### PR TITLE
tests: Bluetooth: ascs: Add Source ASE state transition tests

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -2376,10 +2376,14 @@ static void ase_stop(struct bt_ascs_ase *ase)
 	 * for that ASE by following the Connected Isochronous Stream Terminate
 	 * procedure defined in Volume 3, Part C, Section 9.3.15.
 	 */
-	err = ascs_disconnect_stream(stream);
-	if (err < 0) {
-		LOG_ERR("Failed to disconnect stream %p: %d", stream, err);
-		return;
+	if (ep->iso != NULL &&
+	    ep->iso->chan.state != BT_ISO_STATE_DISCONNECTED &&
+	    ep->iso->chan.state != BT_ISO_STATE_DISCONNECTING) {
+		err = ascs_disconnect_stream(stream);
+		if (err < 0) {
+			LOG_ERR("Failed to disconnect stream %p: %d", stream, err);
+			return;
+		}
 	}
 
 	ascs_ep_set_state(ep, BT_BAP_EP_STATE_QOS_CONFIGURED);

--- a/tests/bluetooth/audio/ascs/include/test_common.h
+++ b/tests/bluetooth/audio/ascs/include/test_common.h
@@ -17,6 +17,10 @@ struct test_ase_chrc_value_hdr {
 	uint8_t params[0];
 } __packed;
 
+void test_mocks_init(void);
+void test_mocks_cleanup(void);
+void test_mocks_reset(void);
+
 /* Initialize connection object for test */
 void test_conn_init(struct bt_conn *conn);
 uint8_t test_ase_get(const struct bt_uuid *uuid, int num_ase, ...);

--- a/tests/bluetooth/audio/ascs/include/test_common.h
+++ b/tests/bluetooth/audio/ascs/include/test_common.h
@@ -35,6 +35,8 @@ void test_ase_control_client_enable(struct bt_conn *conn, uint8_t ase_id);
 void test_ase_control_client_disable(struct bt_conn *conn, uint8_t ase_id);
 void test_ase_control_client_release(struct bt_conn *conn, uint8_t ase_id);
 void test_ase_control_client_update_metadata(struct bt_conn *conn, uint8_t ase_id);
+void test_ase_control_client_receiver_start_ready(struct bt_conn *conn, uint8_t ase_id);
+void test_ase_control_client_receiver_stop_ready(struct bt_conn *conn, uint8_t ase_id);
 
 /* preambles */
 void test_preamble_state_codec_configured(struct bt_conn *conn, uint8_t ase_id,

--- a/tests/bluetooth/audio/ascs/include/test_common.h
+++ b/tests/bluetooth/audio/ascs/include/test_common.h
@@ -35,3 +35,14 @@ void test_ase_control_client_enable(struct bt_conn *conn, uint8_t ase_id);
 void test_ase_control_client_disable(struct bt_conn *conn, uint8_t ase_id);
 void test_ase_control_client_release(struct bt_conn *conn, uint8_t ase_id);
 void test_ase_control_client_update_metadata(struct bt_conn *conn, uint8_t ase_id);
+
+/* preambles */
+void test_preamble_state_codec_configured(struct bt_conn *conn, uint8_t ase_id,
+					  struct bt_bap_stream *stream);
+void test_preamble_state_qos_configured(struct bt_conn *conn, uint8_t ase_id,
+					struct bt_bap_stream *stream);
+void test_preamble_state_enabling(struct bt_conn *conn, uint8_t ase_id,
+				  struct bt_bap_stream *stream);
+void test_preamble_state_streaming(struct bt_conn *conn, uint8_t ase_id,
+				   struct bt_bap_stream *stream, struct bt_iso_chan **chan,
+				   bool source);

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -37,22 +37,12 @@ DEFINE_FFF_GLOBALS;
 
 static void mock_init_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
-	mock_bap_unicast_server_init();
-	mock_bt_iso_init();
-	mock_kernel_init();
-	mock_bt_pacs_init();
-	mock_bap_stream_init();
-	mock_bt_gatt_init();
+	test_mocks_init();
 }
 
 static void mock_destroy_rule_after(const struct ztest_unit_test *test, void *fixture)
 {
-	mock_bap_unicast_server_cleanup();
-	mock_bt_iso_cleanup();
-	mock_kernel_cleanup();
-	mock_bt_pacs_cleanup();
-	mock_bap_stream_cleanup();
-	mock_bt_gatt_cleanup();
+	test_mocks_cleanup();
 }
 
 ZTEST_RULE(mock_rule, mock_init_rule_before, mock_destroy_rule_after);

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -35,37 +35,14 @@
 
 DEFINE_FFF_GLOBALS;
 
-static struct bt_codec lc3_codec =
-	BT_CODEC_LC3(BT_CODEC_LC3_FREQ_ANY, BT_CODEC_LC3_DURATION_10,
-		     BT_CODEC_LC3_CHAN_COUNT_SUPPORT(1), 40u, 120u, 1u,
-		     (BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL | BT_AUDIO_CONTEXT_TYPE_MEDIA));
-
-static void pacs_cap_foreach_custom_fake(enum bt_audio_dir dir, bt_pacs_cap_foreach_func_t func,
-					 void *user_data)
-{
-	static const struct bt_pacs_cap cap[] = {
-		{
-			&lc3_codec,
-		},
-	};
-
-	for (size_t i = 0; i < ARRAY_SIZE(cap); i++) {
-		if (func(&cap[i], user_data) == false) {
-			break;
-		}
-	}
-}
-
 static void mock_init_rule_before(const struct ztest_unit_test *test, void *fixture)
 {
 	mock_bap_unicast_server_init();
 	mock_bt_iso_init();
 	mock_kernel_init();
-	PACS_FFF_FAKES_LIST(RESET_FAKE);
+	mock_bt_pacs_init();
 	mock_bap_stream_init();
 	mock_bt_gatt_init();
-
-	bt_pacs_cap_foreach_fake.custom_fake = pacs_cap_foreach_custom_fake;
 }
 
 static void mock_destroy_rule_after(const struct ztest_unit_test *test, void *fixture)
@@ -73,6 +50,7 @@ static void mock_destroy_rule_after(const struct ztest_unit_test *test, void *fi
 	mock_bap_unicast_server_cleanup();
 	mock_bt_iso_cleanup();
 	mock_kernel_cleanup();
+	mock_bt_pacs_cleanup();
 	mock_bap_stream_cleanup();
 	mock_bt_gatt_cleanup();
 }

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -93,6 +93,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_qos_conf
 
 	/* Preamble */
 	test_ase_control_client_config_codec(conn, ase_id, stream);
+	test_mocks_reset();
 
 	test_ase_control_client_config_qos(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
@@ -110,6 +111,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_enabling)
 	/* Preamble */
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
+	test_mocks_reset();
 
 	test_ase_control_client_enable(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_enable_called_once(stream, EMPTY, EMPTY);
@@ -128,9 +130,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_qos_configured)
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
 	test_ase_control_client_enable(conn, ase_id);
-
-	/* Reset the bap_stream_ops.qos_set callback that is expected to be called again */
-	mock_bap_stream_qos_set_cb_reset();
+	test_mocks_reset();
 
 	test_ase_control_client_disable(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
@@ -148,6 +148,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_releasing)
 	/* Preamble */
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
+	test_mocks_reset();
 
 	test_ase_control_client_release(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
@@ -168,6 +169,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_streaming)
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
 	test_ase_control_client_enable(conn, ase_id);
+	test_mocks_reset();
 
 	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
 	zassert_equal(0, err, "Failed to connect iso: err %d", err);
@@ -189,11 +191,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_codec_co
 
 	/* Preamble */
 	test_ase_control_client_config_codec(conn, ase_id, stream);
-
-	/* Reset the bap_unicast_server_cb.config callback that is not expected to be again */
-	mock_bap_unicast_server_cb_config_reset();
-	/* Reset the bap_stream_ops.configured callback that is expected to be called again */
-	mock_bap_stream_configured_cb_reset();
+	test_mocks_reset();
 
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	expect_bt_bap_unicast_server_cb_config_not_called();
@@ -212,11 +210,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_qos_config
 	/* Preamble */
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
-
-	/* Reset the bap_unicast_server_cb.qos callback that is expected to be called again */
-	mock_bap_unicast_server_cb_qos_reset();
-	/* Reset the bap_stream_ops.qos_set callback that is expected to be called again */
-	mock_bap_stream_qos_set_cb_reset();
+	test_mocks_reset();
 
 	test_ase_control_client_config_qos(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
@@ -234,9 +228,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_codec_conf
 	/* Preamble */
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
-
-	/* Reset the bap_stream_ops.configured callback that is expected to be called again */
-	mock_bap_stream_configured_cb_reset();
+	test_mocks_reset();
 
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SINK, EMPTY);
@@ -253,6 +245,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_releasin
 
 	/* Preamble */
 	test_ase_control_client_config_codec(conn, ase_id, stream);
+	test_mocks_reset();
 
 	test_ase_control_client_release(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
@@ -271,6 +264,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_releasing)
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
 	test_ase_control_client_enable(conn, ase_id);
+	test_mocks_reset();
 
 	test_ase_control_client_release(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
@@ -289,6 +283,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_enabling)
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
 	test_ase_control_client_enable(conn, ase_id);
+	test_mocks_reset();
 
 	test_ase_control_client_update_metadata(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
@@ -309,12 +304,11 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_releasing)
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
 	test_ase_control_client_enable(conn, ase_id);
-
 	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
 	zassert_equal(0, err, "Failed to connect iso: err %d", err);
-
 	err = bt_bap_stream_start(stream);
 	zassert_equal(0, err, "Failed to start stream: err %d", err);
+	test_mocks_reset();
 
 	test_ase_control_client_release(conn, ase_id);
 
@@ -339,12 +333,11 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_streaming)
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
 	test_ase_control_client_enable(conn, ase_id);
-
 	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
 	zassert_equal(0, err, "Failed to connect iso: err %d", err);
-
 	err = bt_bap_stream_start(stream);
 	zassert_equal(0, err, "Failed to start stream: err %d", err);
+	test_mocks_reset();
 
 	test_ase_control_client_update_metadata(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
@@ -365,15 +358,11 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_qos_configured)
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
 	test_ase_control_client_enable(conn, ase_id);
-
 	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
 	zassert_equal(0, err, "Failed to connect iso: err %d", err);
-
 	err = bt_bap_stream_start(stream);
 	zassert_equal(0, err, "Failed to start stream: err %d", err);
-
-	/* Reset the bap_stream_ops.qos_set callback that is expected to be called again */
-	mock_bap_stream_qos_set_cb_reset();
+	test_mocks_reset();
 
 	test_ase_control_client_disable(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -91,9 +91,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_qos_conf
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_mocks_reset();
+	test_preamble_state_codec_configured(conn, ase_id, stream);
 
 	test_ase_control_client_config_qos(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
@@ -108,10 +106,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_enabling)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_ase_control_client_config_qos(conn, ase_id);
-	test_mocks_reset();
+	test_preamble_state_qos_configured(conn, ase_id, stream);
 
 	test_ase_control_client_enable(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_enable_called_once(stream, EMPTY, EMPTY);
@@ -126,11 +121,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_qos_configured)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_ase_control_client_config_qos(conn, ase_id);
-	test_ase_control_client_enable(conn, ase_id);
-	test_mocks_reset();
+	test_preamble_state_enabling(conn, ase_id, stream);
 
 	test_ase_control_client_disable(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
@@ -145,10 +136,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_releasing)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_ase_control_client_config_qos(conn, ase_id);
-	test_mocks_reset();
+	test_preamble_state_qos_configured(conn, ase_id, stream);
 
 	test_ase_control_client_release(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
@@ -165,11 +153,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_streaming)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_ase_control_client_config_qos(conn, ase_id);
-	test_ase_control_client_enable(conn, ase_id);
-	test_mocks_reset();
+	test_preamble_state_enabling(conn, ase_id, stream);
 
 	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
 	zassert_equal(0, err, "Failed to connect iso: err %d", err);
@@ -189,9 +173,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_codec_co
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_mocks_reset();
+	test_preamble_state_codec_configured(conn, ase_id, stream);
 
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	expect_bt_bap_unicast_server_cb_config_not_called();
@@ -207,10 +189,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_qos_config
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_ase_control_client_config_qos(conn, ase_id);
-	test_mocks_reset();
+	test_preamble_state_qos_configured(conn, ase_id, stream);
 
 	test_ase_control_client_config_qos(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
@@ -225,10 +204,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_codec_conf
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_ase_control_client_config_qos(conn, ase_id);
-	test_mocks_reset();
+	test_preamble_state_qos_configured(conn, ase_id, stream);
 
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SINK, EMPTY);
@@ -243,9 +219,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_releasin
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_mocks_reset();
+	test_preamble_state_codec_configured(conn, ase_id, stream);
 
 	test_ase_control_client_release(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
@@ -260,11 +234,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_releasing)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_ase_control_client_config_qos(conn, ase_id);
-	test_ase_control_client_enable(conn, ase_id);
-	test_mocks_reset();
+	test_preamble_state_enabling(conn, ase_id, stream);
 
 	test_ase_control_client_release(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
@@ -279,11 +249,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_enabling)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_ase_control_client_config_qos(conn, ase_id);
-	test_ase_control_client_enable(conn, ase_id);
-	test_mocks_reset();
+	test_preamble_state_enabling(conn, ase_id, stream);
 
 	test_ase_control_client_update_metadata(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
@@ -300,15 +266,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_releasing)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_ase_control_client_config_qos(conn, ase_id);
-	test_ase_control_client_enable(conn, ase_id);
-	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
-	zassert_equal(0, err, "Failed to connect iso: err %d", err);
-	err = bt_bap_stream_start(stream);
-	zassert_equal(0, err, "Failed to start stream: err %d", err);
-	test_mocks_reset();
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, false);
 
 	test_ase_control_client_release(conn, ase_id);
 
@@ -329,15 +287,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_streaming)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_ase_control_client_config_qos(conn, ase_id);
-	test_ase_control_client_enable(conn, ase_id);
-	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
-	zassert_equal(0, err, "Failed to connect iso: err %d", err);
-	err = bt_bap_stream_start(stream);
-	zassert_equal(0, err, "Failed to start stream: err %d", err);
-	test_mocks_reset();
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, false);
 
 	test_ase_control_client_update_metadata(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
@@ -354,15 +304,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_qos_configured)
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
-	/* Preamble */
-	test_ase_control_client_config_codec(conn, ase_id, stream);
-	test_ase_control_client_config_qos(conn, ase_id);
-	test_ase_control_client_enable(conn, ase_id);
-	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
-	zassert_equal(0, err, "Failed to connect iso: err %d", err);
-	err = bt_bap_stream_start(stream);
-	zassert_equal(0, err, "Failed to start stream: err %d", err);
-	test_mocks_reset();
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, false);
 
 	test_ase_control_client_disable(conn, ase_id);
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -25,7 +25,10 @@
 
 #include "test_common.h"
 
-struct test_sink_ase_state_transition_fixture {
+#define test_sink_ase_state_transition_fixture test_ase_state_transition_fixture
+#define test_source_ase_state_transition_fixture test_ase_state_transition_fixture
+
+struct test_ase_state_transition_fixture {
 	struct bt_conn conn;
 	struct bt_bap_stream stream;
 	struct {
@@ -36,7 +39,7 @@ struct test_sink_ase_state_transition_fixture {
 
 static void *test_sink_ase_state_transition_setup(void)
 {
-	struct test_sink_ase_state_transition_fixture *fixture;
+	struct test_ase_state_transition_fixture *fixture;
 
 	fixture = malloc(sizeof(*fixture));
 	zassert_not_null(fixture);
@@ -79,6 +82,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_idle_to_codec_configured)
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
 	test_ase_control_client_config_codec(conn, ase_id, stream);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_config_called_once(conn, EMPTY, BT_AUDIO_DIR_SINK, EMPTY);
 	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
 }
@@ -94,6 +99,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_qos_conf
 	test_preamble_state_codec_configured(conn, ase_id, stream);
 
 	test_ase_control_client_config_qos(conn, ase_id);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
 }
@@ -109,6 +116,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_enabling)
 	test_preamble_state_qos_configured(conn, ase_id, stream);
 
 	test_ase_control_client_enable(conn, ase_id);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_enable_called_once(stream, EMPTY, EMPTY);
 	expect_bt_bap_stream_ops_enabled_called_once(stream);
 }
@@ -124,6 +133,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_qos_configured)
 	test_preamble_state_enabling(conn, ase_id, stream);
 
 	test_ase_control_client_disable(conn, ase_id);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
 }
@@ -139,6 +150,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_releasing)
 	test_preamble_state_qos_configured(conn, ase_id, stream);
 
 	test_ase_control_client_release(conn, ase_id);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_released_called_once(stream);
 }
@@ -161,8 +174,9 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_streaming)
 	err = bt_bap_stream_start(stream);
 	zassert_equal(0, err, "Failed to start stream: err %d", err);
 
-	/* XXX: unicast_server_cb->start is not called for Sink ASE */
+	/* Verification */
 	expect_bt_bap_stream_ops_started_called_once(stream);
+	/* XXX: unicast_server_cb->start is not called for Sink ASE */
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_codec_configured)
@@ -176,6 +190,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_codec_co
 	test_preamble_state_codec_configured(conn, ase_id, stream);
 
 	test_ase_control_client_config_codec(conn, ase_id, stream);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_config_not_called();
 	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SINK, EMPTY);
 	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
@@ -192,6 +208,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_qos_config
 	test_preamble_state_qos_configured(conn, ase_id, stream);
 
 	test_ase_control_client_config_qos(conn, ase_id);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
 }
@@ -207,6 +225,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_codec_conf
 	test_preamble_state_qos_configured(conn, ase_id, stream);
 
 	test_ase_control_client_config_codec(conn, ase_id, stream);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SINK, EMPTY);
 	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
 }
@@ -222,6 +242,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_releasin
 	test_preamble_state_codec_configured(conn, ase_id, stream);
 
 	test_ase_control_client_release(conn, ase_id);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_released_called_once(stream);
 }
@@ -237,6 +259,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_releasing)
 	test_preamble_state_enabling(conn, ase_id, stream);
 
 	test_ase_control_client_release(conn, ase_id);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_released_called_once(stream);
 }
@@ -252,6 +276,8 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_enabling)
 	test_preamble_state_enabling(conn, ase_id, stream);
 
 	test_ase_control_client_update_metadata(conn, ase_id);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
 	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
 }
@@ -262,7 +288,6 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_releasing)
 	struct bt_conn *conn = &fixture->conn;
 	uint8_t ase_id = fixture->ase.id;
 	struct bt_iso_chan *chan;
-	int err;
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
@@ -273,6 +298,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_releasing)
 	/* Client disconnects the ISO */
 	mock_bt_iso_disconnect(chan);
 
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_released_called_once(stream);
 }
@@ -283,13 +309,14 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_streaming)
 	struct bt_conn *conn = &fixture->conn;
 	uint8_t ase_id = fixture->ase.id;
 	struct bt_iso_chan *chan;
-	int err;
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
 	test_preamble_state_streaming(conn, ase_id, stream, &chan, false);
 
 	test_ase_control_client_update_metadata(conn, ase_id);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
 	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
 }
@@ -300,13 +327,338 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_qos_configured)
 	struct bt_conn *conn = &fixture->conn;
 	uint8_t ase_id = fixture->ase.id;
 	struct bt_iso_chan *chan;
-	int err;
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 
 	test_preamble_state_streaming(conn, ase_id, stream, &chan, false);
 
 	test_ase_control_client_disable(conn, ase_id);
+
+	/* Verification */
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
+	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+}
+
+static void *test_source_ase_state_transition_setup(void)
+{
+	struct test_ase_state_transition_fixture *fixture;
+
+	fixture = malloc(sizeof(*fixture));
+	zassert_not_null(fixture);
+
+	memset(fixture, 0, sizeof(*fixture));
+	test_conn_init(&fixture->conn);
+	test_ase_src_get(1, &fixture->ase.attr);
+	if (fixture->ase.attr != NULL) {
+		fixture->ase.id = test_ase_id_get(fixture->ase.attr);
+	}
+
+	return fixture;
+}
+
+ZTEST_SUITE(test_source_ase_state_transition, NULL, test_source_ase_state_transition_setup,
+	    test_ase_state_transition_before, test_ase_state_transition_after,
+	    test_ase_state_transition_teardown);
+
+ZTEST_F(test_source_ase_state_transition, test_client_idle_to_codec_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_ase_control_client_config_codec(conn, ase_id, stream);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_config_called_once(conn, EMPTY, BT_AUDIO_DIR_SOURCE, EMPTY);
+	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_qos_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_codec_configured(conn, ase_id, stream);
+
+	test_ase_control_client_config_qos(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
+	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_enabling)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_qos_configured(conn, ase_id, stream);
+
+	test_ase_control_client_enable(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_enable_called_once(stream, EMPTY, EMPTY);
+	expect_bt_bap_stream_ops_enabled_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_disabling)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	test_ase_control_client_disable(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_qos_configured(conn, ase_id, stream);
+
+	test_ase_control_client_release(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_released_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_streaming)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	struct bt_iso_chan *chan;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
+	zassert_equal(0, err, "Failed to connect iso: err %d", err);
+
+	test_ase_control_client_receiver_start_ready(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_start_called_once(stream);
+	expect_bt_bap_stream_ops_started_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_codec_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_codec_configured(conn, ase_id, stream);
+
+	test_ase_control_client_config_codec(conn, ase_id, stream);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SOURCE, EMPTY);
+	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_qos_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_qos_configured(conn, ase_id, stream);
+
+	test_ase_control_client_config_qos(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_qos_called_once(stream, EMPTY);
+	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_codec_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_qos_configured(conn, ase_id, stream);
+
+	test_ase_control_client_config_codec(conn, ase_id, stream);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SOURCE, EMPTY);
+	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_codec_configured(conn, ase_id, stream);
+
+	test_ase_control_client_release(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_released_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	test_ase_control_client_release(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_released_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_enabling)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	test_ase_control_client_update_metadata(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
+	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	struct bt_iso_chan *chan;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, true);
+
+	test_ase_control_client_release(conn, ase_id);
+	/* Client disconnects the ISO */
+	mock_bt_iso_disconnect(chan);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_stopped_called_once(stream, EMPTY);
+	expect_bt_bap_stream_ops_released_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_streaming)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	struct bt_iso_chan *chan;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, true);
+
+	test_ase_control_client_update_metadata(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
+	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	struct bt_iso_chan *chan;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, true);
+
+	test_ase_control_client_disable(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_disabling_to_qos_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+	test_ase_control_client_disable(conn, ase_id);
+	test_mocks_reset();
+
+	test_ase_control_client_receiver_stop_ready(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_stop_called_once(stream);
+	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling_to_qos_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	struct bt_iso_chan *chan;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, true);
+	test_ase_control_client_disable(conn, ase_id);
+	test_mocks_reset();
+
+	test_ase_control_client_receiver_stop_ready(conn, ase_id);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_stop_called_once(stream);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
 }

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -261,6 +261,34 @@ void test_ase_control_client_update_metadata(struct bt_conn *conn, uint8_t ase_i
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
 }
 
+void test_ase_control_client_receiver_start_ready(struct bt_conn *conn, uint8_t ase_id)
+{
+	const struct bt_gatt_attr *attr = test_ase_control_point_get();
+	const uint8_t buf[] = {
+		0x04,                   /* Opcode = Receiver Start Ready */
+		0x01,                   /* Number_of_ASEs */
+		ase_id,                 /* ASE_ID[0] */
+	};
+	ssize_t ret;
+
+	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+}
+
+void test_ase_control_client_receiver_stop_ready(struct bt_conn *conn, uint8_t ase_id)
+{
+	const struct bt_gatt_attr *attr = test_ase_control_point_get();
+	const uint8_t buf[] = {
+		0x06,                   /* Opcode = Receiver Stop Ready */
+		0x01,                   /* Number_of_ASEs */
+		ase_id,                 /* ASE_ID[0] */
+	};
+	ssize_t ret;
+
+	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
+	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
+}
+
 void test_preamble_state_codec_configured(struct bt_conn *conn, uint8_t ase_id,
 					  struct bt_bap_stream *stream)
 {

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -17,8 +17,38 @@
 #include "bap_stream.h"
 #include "gatt_expects.h"
 #include "conn.h"
+#include "gatt.h"
+#include "iso.h"
+#include "mock_kernel.h"
+#include "pacs.h"
 
 #include "test_common.h"
+
+void test_mocks_init(void)
+{
+	mock_bap_unicast_server_init();
+	mock_bt_iso_init();
+	mock_kernel_init();
+	mock_bt_pacs_init();
+	mock_bap_stream_init();
+	mock_bt_gatt_init();
+}
+
+void test_mocks_cleanup(void)
+{
+	mock_bap_unicast_server_cleanup();
+	mock_bt_iso_cleanup();
+	mock_kernel_cleanup();
+	mock_bt_pacs_cleanup();
+	mock_bap_stream_cleanup();
+	mock_bt_gatt_cleanup();
+}
+
+void test_mocks_reset(void)
+{
+	test_mocks_cleanup();
+	test_mocks_init();
+}
 
 static uint8_t attr_found(const struct bt_gatt_attr *attr, uint16_t handle, void *user_data)
 {

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -260,3 +260,47 @@ void test_ase_control_client_update_metadata(struct bt_conn *conn, uint8_t ase_i
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
 }
+
+void test_preamble_state_codec_configured(struct bt_conn *conn, uint8_t ase_id,
+					  struct bt_bap_stream *stream)
+{
+	test_ase_control_client_config_codec(conn, ase_id, stream);
+	test_mocks_reset();
+}
+
+void test_preamble_state_qos_configured(struct bt_conn *conn, uint8_t ase_id,
+					struct bt_bap_stream *stream)
+{
+	test_ase_control_client_config_codec(conn, ase_id, stream);
+	test_ase_control_client_config_qos(conn, ase_id);
+	test_mocks_reset();
+}
+
+void test_preamble_state_enabling(struct bt_conn *conn, uint8_t ase_id,
+				  struct bt_bap_stream *stream)
+{
+	test_ase_control_client_config_codec(conn, ase_id, stream);
+	test_ase_control_client_config_qos(conn, ase_id);
+	test_ase_control_client_enable(conn, ase_id);
+	test_mocks_reset();
+}
+
+void test_preamble_state_streaming(struct bt_conn *conn, uint8_t ase_id,
+				   struct bt_bap_stream *stream, struct bt_iso_chan **chan,
+				   bool source)
+{
+	int err;
+
+	test_ase_control_client_config_codec(conn, ase_id, stream);
+	test_ase_control_client_config_qos(conn, ase_id);
+	test_ase_control_client_enable(conn, ase_id);
+
+	err = mock_bt_iso_accept(conn, 0x01, 0x01, chan);
+	zassert_equal(0, err, "Failed to connect iso: err %d", err);
+
+	if (source) {
+		test_ase_control_client_receiver_start_ready(conn, ase_id);
+	}
+
+	test_mocks_reset();
+}

--- a/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
@@ -159,18 +159,24 @@ static inline void expect_bt_bap_stream_ops_started_not_called(void)
 		      "'%s()' was called unexpectedly", func_name);
 }
 
-static inline void expect_bt_bap_stream_ops_stopped_called_once(struct bt_bap_stream *stream,
-								uint8_t reason)
-{
-	const char *func_name = "bt_bap_stream_ops.stopped";
-
-	zassert_equal(1, mock_bap_stream_stopped_cb_fake.call_count,
-		      "'%s()' was called %u times, but expected once",
-		      func_name, mock_bap_stream_stopped_cb_fake.call_count);
-
-	zassert_equal_ptr(stream, mock_bap_stream_stopped_cb_fake.arg0_val,
-			  "'%s()' was called with incorrect '%s'", func_name, "stream");
-}
+#define expect_bt_bap_stream_ops_stopped_called_once(_stream, _reason)                             \
+do {                                                                                               \
+	const char *func_name = "bt_bap_stream_ops.stopped";                                       \
+												   \
+	zassert_equal(1, mock_bap_stream_stopped_cb_fake.call_count,                               \
+		      "'%s()' was called %u times, but expected once",                             \
+		      func_name, mock_bap_stream_stopped_cb_fake.call_count);                      \
+												   \
+	IF_NOT_EMPTY(_stream, (                                                                    \
+		     zassert_equal_ptr(_stream, mock_bap_stream_stopped_cb_fake.arg0_val,          \
+				       "'%s()' was called with incorrect '%s' value",              \
+				       func_name, "stream");))                                     \
+												   \
+	IF_NOT_EMPTY(_reason, (                                                                    \
+		     zassert_equal(_reason, mock_bap_stream_stopped_cb_fake.arg1_val,              \
+				   "'%s()' was called with incorrect '%s' value",                  \
+				   func_name, "reason");))                                         \
+} while (0)
 
 static inline void expect_bt_bap_stream_ops_stopped_not_called(void)
 {

--- a/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
@@ -54,7 +54,7 @@ static inline void expect_bt_bap_stream_ops_qos_set_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.qos_set";
 
-	zassert_equal(1, mock_bap_stream_qos_set_cb_fake.call_count,
+	zassert_equal(0, mock_bap_stream_qos_set_cb_fake.call_count,
 		      "'%s()' was called unexpectedly", func_name);
 }
 

--- a/tests/bluetooth/audio/mocks/include/bap_unicast_server_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_unicast_server_expects.h
@@ -170,6 +170,21 @@ do {                                                                            
 				       func_name, "stream");))                                     \
 } while (0)
 
+#define expect_bt_bap_unicast_server_cb_stop_called_once(_stream)                                  \
+do {                                                                                               \
+	const char *func_name = "bt_bap_unicast_server_cb.stop";                                   \
+												   \
+	zassert_true(mock_bap_unicast_server_cb_stop_fake.call_count > 0,                          \
+		     "'%s()' was not called", func_name);                                          \
+	zassert_equal(1, mock_bap_unicast_server_cb_stop_fake.call_count,                          \
+		      "'%s()' was called more than once", func_name);                              \
+												   \
+	IF_NOT_EMPTY(_stream, (                                                                    \
+		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_stop_fake.arg0_val,     \
+				       "'%s()' was called with incorrect '%s' value",              \
+				       func_name, "stream");))                                     \
+} while (0)
+
 static inline void expect_bt_bap_unicast_server_cb_config_not_called(void)
 {
 	const char *func_name = "bt_bap_unicast_server_cb.config";

--- a/tests/bluetooth/audio/mocks/include/bap_unicast_server_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_unicast_server_expects.h
@@ -170,7 +170,7 @@ do {                                                                            
 				       func_name, "stream");))                                     \
 } while (0)
 
-static void expect_bt_bap_unicast_server_cb_config_not_called(void)
+static inline void expect_bt_bap_unicast_server_cb_config_not_called(void)
 {
 	const char *func_name = "bt_bap_unicast_server_cb.config";
 

--- a/tests/bluetooth/audio/mocks/include/pacs.h
+++ b/tests/bluetooth/audio/mocks/include/pacs.h
@@ -10,9 +10,8 @@
 #include <zephyr/fff.h>
 #include <zephyr/bluetooth/audio/pacs.h>
 
-/* List of fakes used by this unit tester */
-#define PACS_FFF_FAKES_LIST(FAKE)                                                                  \
-	FAKE(bt_pacs_cap_foreach)                                                                  \
+void mock_bt_pacs_init(void);
+void mock_bt_pacs_cleanup(void);
 
 DECLARE_FAKE_VOID_FUNC(bt_pacs_cap_foreach, enum bt_audio_dir, bt_pacs_cap_foreach_func_t, void *);
 

--- a/tests/bluetooth/audio/mocks/src/iso.c
+++ b/tests/bluetooth/audio/mocks/src/iso.c
@@ -56,7 +56,7 @@ void mock_bt_iso_init(void)
 
 void mock_bt_iso_cleanup(void)
 {
-	iso_server = NULL;
+
 }
 
 int mock_bt_iso_accept(struct bt_conn *conn, uint8_t cig_id, uint8_t cis_id,

--- a/tests/bluetooth/audio/mocks/src/pacs.c
+++ b/tests/bluetooth/audio/mocks/src/pacs.c
@@ -4,8 +4,45 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/types.h>
 #include <zephyr/bluetooth/audio/pacs.h>
 
 #include "pacs.h"
 
+/* List of fakes used by this unit tester */
+#define PACS_FFF_FAKES_LIST(FAKE)                                                                  \
+	FAKE(bt_pacs_cap_foreach)                                                                  \
+
+static struct bt_codec lc3_codec =
+	BT_CODEC_LC3(BT_CODEC_LC3_FREQ_ANY, BT_CODEC_LC3_DURATION_10,
+		     BT_CODEC_LC3_CHAN_COUNT_SUPPORT(1), 40u, 120u, 1u,
+		     (BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL | BT_AUDIO_CONTEXT_TYPE_MEDIA));
+
 DEFINE_FAKE_VOID_FUNC(bt_pacs_cap_foreach, enum bt_audio_dir, bt_pacs_cap_foreach_func_t, void *);
+
+static void pacs_cap_foreach_custom_fake(enum bt_audio_dir dir, bt_pacs_cap_foreach_func_t func,
+					 void *user_data)
+{
+	static const struct bt_pacs_cap cap[] = {
+		{
+			&lc3_codec,
+		},
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(cap); i++) {
+		if (func(&cap[i], user_data) == false) {
+			break;
+		}
+	}
+}
+
+void mock_bt_pacs_init(void)
+{
+	PACS_FFF_FAKES_LIST(RESET_FAKE);
+	bt_pacs_cap_foreach_fake.custom_fake = pacs_cap_foreach_custom_fake;
+}
+
+void mock_bt_pacs_cleanup(void)
+{
+
+}


### PR DESCRIPTION
This adds source ASE state transition tests and improves the callback call validation.