### PR TITLE
drivers: timer: nrf_rtc_timer: Implement stop function

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -355,6 +355,9 @@ Trusted Firmware-M
 
 * Timer
 
+  * Support added for stopping Nordic nRF RTC system timer, which fixes an
+    issue when booting applications built in prior version of Zephyr.
+
 * USB
 
 * W1

--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -8,6 +8,7 @@ config NRF_RTC_TIMER
 	depends on CLOCK_CONTROL
 	depends on SOC_COMPATIBLE_NRF
 	select TICKLESS_CAPABLE
+	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
 	depends on !$(dt_nodelabel_enabled,rtc1)
 	help
 	  This module implements a kernel device driver for the nRF Real Time


### PR DESCRIPTION
    drivers: timer: nrf_rtc_timer: Implement stop function
    
    Implements functionality to stop the nRF RTC timer clock source.

Fixes #52667