### PR TITLE
boards/arm/efr32xg24_dk2601b: add watchdog support

### DIFF
--- a/boards/arm/efr32xg24_dk2601b/efr32xg24_dk2601b.dts
+++ b/boards/arm/efr32xg24_dk2601b/efr32xg24_dk2601b.dts
@@ -89,6 +89,10 @@
 	status = "okay";
 };
 
+&wdog0 {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -259,6 +259,8 @@ static int wdt_gecko_init(const struct device *dev)
 
 #if defined(_SILICON_LABS_32B_SERIES_2)
 	CMU_ClockSelectSet(config->clock, cmuSelect_ULFRCO);
+	/* Enable Watchdog clock. */
+	CMU_ClockEnable(cmuClock_WDOG0, true);
 #endif
 
 	/* Enable IRQs */


### PR DESCRIPTION
This PR introduces watchdog support to the efr32xg24_dk2601b board.