### PR TITLE
include: adc: Missing input should cause error

### DIFF
--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -218,7 +218,7 @@ struct adc_channel_cfg {
 	.channel_id       = DT_REG_ADDR(node_id), \
 IF_ENABLED(CONFIG_ADC_CONFIGURABLE_INPUTS, \
 	(.differential    = DT_NODE_HAS_PROP(node_id, zephyr_input_negative), \
-	 .input_positive  = DT_PROP_OR(node_id, zephyr_input_positive, 0), \
+	 .input_positive  = DT_PROP(node_id, zephyr_input_positive), \
 	 .input_negative  = DT_PROP_OR(node_id, zephyr_input_negative, 0),)) \
 }
 


### PR DESCRIPTION
Introduce a build error when zephyr,input-positive is not provided in a devicetree specification for a channel when an ADC driver has the ADC configurable inputs Kconfig enabled. Defaulting to a fallback value would cause confusion if a user doesn't realize the driver is using zephyr,input-positive and there is no error.