### PR TITLE
tests: regulator: Update RT685 for LPADC rewrite

### DIFF
--- a/tests/drivers/regulator/voltage/boards/mimxrt685_evk_cm33.overlay
+++ b/tests/drivers/regulator/voltage/boards/mimxrt685_evk_cm33.overlay
@@ -4,6 +4,7 @@
  */
 
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 /* RT685 ADC only supports up to 1.8V,
  * so limit regulator voltage to this range.
@@ -41,7 +42,7 @@
 		 * a voltage within given tolerance
 		 */
 		regulators = <&ldo2 &ldo1>;
-		io-channels = <&lpadc0 0>, <&lpadc0 2>;
+		io-channels = <&lpadc0 0>, <&lpadc0 1>;
 		tolerance-microvolt = <35000>, <35000>;
 		set-read-delay-ms = <20>;
 		adc-avg-count = <10>;
@@ -59,6 +60,7 @@
 		zephyr,vref-mv = <1800>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCUX_LPADC_CH0A>;
 	};
 
 	channel@1 {
@@ -68,14 +70,6 @@
 		zephyr,vref-mv = <1800>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-	};
-
-	channel@2 {
-		reg = <2>;
-		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_EXTERNAL0";
-		zephyr,vref-mv = <1800>;
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
-		zephyr,resolution = <12>;
+		zephyr,input-positive = <MCUX_LPADC_CH2A>;
 	};
 };


### PR DESCRIPTION
Update the RT685 sample overlay for the reagulator/voltage test to work with the recent LPADC driver rewrite, by adding the properties for the configurable inputs to the channel specs.

Unblocks #56538 having CI issues