### PR TITLE
tests: net: websocket: exclude 64 bit platforms

### DIFF
--- a/tests/net/socket/websocket/testcase.yaml
+++ b/tests/net/socket/websocket/testcase.yaml
@@ -1,5 +1,9 @@
 common:
   depends_on: netif
+  # The websocket library uses int for pointers for testing and does not work
+  # reliably on 64 bit architectures.
+  # See: https://github.com/zephyrproject-rtos/zephyr/issues/56542
+  filter: not CONFIG_64BIT
 tests:
   net.socket.websocket:
     min_ram: 21


### PR DESCRIPTION
This used to be excluded and got reenabled in https://github.com/zephyrproject-rtos/zephyr/commit/55ac139aedc5a8517fa72cd7d71ec733260da4da. More details in https://github.com/zephyrproject-rtos/zephyr/issues/56542

---

The websocket library uses int for pointers for testing and does not work reliably on 64 bit architectures.

Exclude the test so it does not block other unrelated PRs.