### PR TITLE
templates: bug: add a note about project forks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,10 +7,18 @@ assignees: ''
 
 ---
 
+**Notes (delete this)**
+Github Discussions (https://github.com/zephyrproject-rtos/zephyr/discussions)
+are available to first verify that the issue is a genuine Zephyr bug and not a
+consequence of Zephyr services misuse.
+
+This issue list is only for bugs in the main Zephyr code base
+(https://github.com/zephyrproject-rtos/zephyr/). If the bug is for a project
+fork (such as NCS) specific feature, please open an issue in the fork project
+instead.
+
 **Describe the bug**
 A clear and concise description of what the bug is.
-(Note that [Github Discussions](https://github.com/zephyrproject-rtos/zephyr/discussions) are available to first verify that the issue
-is a genuine Zephyr bug and not a consequence of Zephyr services misuse.)
 
 Please also mention any information which could help others to understand
 the problem you're facing:


### PR DESCRIPTION
Add a note in the issue template mentioning that bugs in project forks should be reported on the fork issue tracker.