### PR TITLE
drivers: lpadc: Move ADC clocking to SOC level

### DIFF
--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2023 NXP
  * Copyright (c) 2020 Toby Firth
  *
  * Based on adc_mcux_adc16.c and adc_mcux_adc12.c, which are:
@@ -15,14 +16,6 @@
 #include <fsl_lpadc.h>
 
 #include <zephyr/drivers/pinctrl.h>
-
-#if !defined(CONFIG_SOC_SERIES_IMX_RT11XX)
-#include <fsl_power.h>
-#endif
-
-#if defined(CONFIG_SOC_LPC55S36)
-#include <fsl_vref.h>
-#endif
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -43,8 +36,6 @@ LOG_MODULE_REGISTER(nxp_mcux_lpadc);
 
 struct mcux_lpadc_config {
 	ADC_Type *base;
-	uint32_t clock_div;
-	uint32_t clock_source;
 	lpadc_reference_voltage_source_t voltage_ref;
 	uint8_t power_level;
 	uint32_t calibration_average;
@@ -401,49 +392,6 @@ static int mcux_lpadc_init(const struct device *dev)
 		return err;
 	}
 
-#if !defined(CONFIG_SOC_SERIES_IMX_RT11XX)
-#if	defined(CONFIG_SOC_SERIES_IMX_RT6XX)
-
-	SYSCTL0->PDRUNCFG0_CLR = SYSCTL0_PDRUNCFG0_ADC_PD_MASK;
-	SYSCTL0->PDRUNCFG0_CLR = SYSCTL0_PDRUNCFG0_ADC_LP_MASK;
-	RESET_PeripheralReset(kADC0_RST_SHIFT_RSTn);
-	CLOCK_AttachClk(kSFRO_to_ADC_CLK);
-	CLOCK_SetClkDiv(kCLOCK_DivAdcClk, config->clock_div);
-
-#elif	defined(CONFIG_SOC_SERIES_IMX_RT5XX)
-	SYSCTL0->PDRUNCFG0_CLR = SYSCTL0_PDRUNCFG0_ADC_PD_MASK;
-	SYSCTL0->PDRUNCFG0_CLR = SYSCTL0_PDRUNCFG0_ADC_LP_MASK;
-	RESET_PeripheralReset(kADC0_RST_SHIFT_RSTn);
-	CLOCK_AttachClk(kFRO_DIV4_to_ADC_CLK);
-	CLOCK_SetClkDiv(kCLOCK_DivAdcClk, 1);
-
-#elif defined(CONFIG_SOC_LPC55S36)
-	CLOCK_SetClkDiv(kCLOCK_DivAdc0Clk, 2U, true);
-	CLOCK_AttachClk(kFRO_HF_to_ADC0);
-
-	/* Disable VREF power down */
-	POWER_DisablePD(kPDRUNCFG_PD_VREF);
-
-	vref_config_t vrefConfig;
-
-	VREF_GetDefaultConfig(&vrefConfig);
-	vrefConfig.bufferMode                     = kVREF_ModeHighPowerBuffer;
-	vrefConfig.enableInternalVoltageRegulator = true;
-	vrefConfig.enableVrefOut                  = true;
-	adc_config.referenceVoltageSource = kLPADC_ReferenceVoltageAlt3;
-	VREF_Init((VREF_Type *)VREF_BASE, &vrefConfig);
-
-#else
-
-	CLOCK_SetClkDiv(kCLOCK_DivAdcAsyncClk, config->clock_div, true);
-	CLOCK_AttachClk(config->clock_source);
-
-	/* Power up the ADC */
-	POWER_DisablePD(kPDRUNCFG_PD_LDOGPADC);
-
-#endif
-#endif
-
 	LPADC_GetDefaultConfig(&adc_config);
 
 	adc_config.enableAnalogPreliminary = true;
@@ -508,34 +456,12 @@ static const struct adc_driver_api mcux_lpadc_driver_api = {
 };
 
 
-#define ASSERT_LPADC_CLK_SOURCE_VALID(val, str)	\
-	BUILD_ASSERT(val == 0 || val == 1 || val == 2 || val == 7, str)
-
-#define ASSERT_LPADC_CLK_DIV_VALID(val, str) \
-	BUILD_ASSERT(val == 1 || val == 2 || val == 4 || val == 8, str)
-
-#if defined(CONFIG_SOC_SERIES_IMX_RT11XX) || \
-	defined(CONFIG_SOC_SERIES_IMX_RT6XX) || \
-	defined(CONFIG_SOC_SERIES_IMX_RT5XX) || \
-	defined(CONFIG_SOC_LPC55S36)
-#define TO_LPADC_CLOCK_SOURCE(val) 0
-#else
-#define TO_LPADC_CLOCK_SOURCE(val) \
-	MUX_A(CM_ADCASYNCCLKSEL, val)
-#endif
-
 #define LPADC_MCUX_INIT(n)						\
 	static void mcux_lpadc_config_func_##n(const struct device *dev);	\
 									\
-	ASSERT_LPADC_CLK_SOURCE_VALID(DT_INST_PROP(n, clk_source),	\
-			  "Invalid clock source");			\
-	ASSERT_LPADC_CLK_DIV_VALID(DT_INST_PROP(n, clk_divider),	\
-		   "Invalid clock divider");			\
 	PINCTRL_DT_INST_DEFINE(n);						\
 	static const struct mcux_lpadc_config mcux_lpadc_config_##n = {	\
 		.base = (ADC_Type *)DT_INST_REG_ADDR(n),	\
-		.clock_source = TO_LPADC_CLOCK_SOURCE(DT_INST_PROP(n, clk_source)),	\
-		.clock_div = DT_INST_PROP(n, clk_divider),					\
 		.voltage_ref =	DT_INST_PROP(n, voltage_ref),	\
 		.calibration_average = DT_INST_ENUM_IDX_OR(n, calibration_average, 0),	\
 		.power_level = DT_INST_PROP(n, power_level),	\

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -46,6 +46,7 @@ struct mcux_lpadc_config {
 	uint32_t clock_div;
 	uint32_t clock_source;
 	lpadc_reference_voltage_source_t voltage_ref;
+	uint8_t power_level;
 	uint32_t calibration_average;
 	uint32_t offset_a;
 	uint32_t offset_b;
@@ -453,6 +454,8 @@ static int mcux_lpadc_init(const struct device *dev)
 	adc_config.conversionAverageMode = config->calibration_average;
 #endif /* FSL_FEATURE_LPADC_HAS_CTRL_CAL_AVGS */
 
+	adc_config.powerLevelMode = config->power_level;
+
 	LPADC_Init(base, &adc_config);
 
 	/* Do ADC calibration. */
@@ -535,6 +538,7 @@ static const struct adc_driver_api mcux_lpadc_driver_api = {
 		.clock_div = DT_INST_PROP(n, clk_divider),					\
 		.voltage_ref =	DT_INST_PROP(n, voltage_ref),	\
 		.calibration_average = DT_INST_ENUM_IDX_OR(n, calibration_average, 0),	\
+		.power_level = DT_INST_PROP(n, power_level),	\
 		.offset_a = DT_INST_PROP(n, offset_value_a),	\
 		.offset_b = DT_INST_PROP(n, offset_value_b),	\
 		.irq_config_func = mcux_lpadc_config_func_##n,				\

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -382,6 +382,15 @@ static void clock_init(void)
 	/* Reset peripheral module */
 	RESET_PeripheralReset(kFLEXSPI1_RST_SHIFT_RSTn);
 #endif
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpadc0), nxp_lpc_lpadc, okay)
+	SYSCTL0->PDRUNCFG0_CLR = SYSCTL0_PDRUNCFG0_ADC_PD_MASK;
+	SYSCTL0->PDRUNCFG0_CLR = SYSCTL0_PDRUNCFG0_ADC_LP_MASK;
+	RESET_PeripheralReset(kADC0_RST_SHIFT_RSTn);
+	CLOCK_AttachClk(kFRO_DIV4_to_ADC_CLK);
+	CLOCK_SetClkDiv(kCLOCK_DivAdcClk, 1);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 

--- a/soc/arm/nxp_imx/rt6xx/soc.c
+++ b/soc/arm/nxp_imx/rt6xx/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NXP
+ * Copyright 2020-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -302,6 +302,14 @@ static ALWAYS_INLINE void clock_init(void)
 #if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(i3c0), nxp_mcux_i3c, okay))
 	CLOCK_AttachClk(kFFRO_to_I3C_CLK);
 	CLOCK_AttachClk(kLPOSC_to_I3C_TC_CLK);
+#endif
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpadc0), nxp_lpc_lpadc, okay)
+	SYSCTL0->PDRUNCFG0_CLR = SYSCTL0_PDRUNCFG0_ADC_PD_MASK;
+	SYSCTL0->PDRUNCFG0_CLR = SYSCTL0_PDRUNCFG0_ADC_LP_MASK;
+	RESET_PeripheralReset(kADC0_RST_SHIFT_RSTn);
+	CLOCK_AttachClk(kSFRO_to_ADC_CLK);
+	CLOCK_SetClkDiv(kCLOCK_DivAdcClk, DT_PROP(DT_NODELABEL(lpadc0), clk_divider));
 #endif
 
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_XIP

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NXP
+ * Copyright 2017, 2019-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -30,6 +30,9 @@
 #if CONFIG_USB_DC_NXP_LPCIP3511
 #include "usb_phy.h"
 #include "usb.h"
+#endif
+#if defined(CONFIG_SOC_LPC55S36) && defined(CONFIG_ADC_MCUX_LPADC)
+#include <fsl_vref.h>
 #endif
 
 #define CTIMER_CLOCK_SOURCE(node_id) \
@@ -219,6 +222,33 @@ DT_FOREACH_STATUS_OKAY(nxp_lpc_ctimer, CTIMER_CLOCK_SETUP)
 	SYSCON->PWM1SUBCTL |=
 	  (SYSCON_PWM1SUBCTL_CLK0_EN_MASK | SYSCON_PWM1SUBCTL_CLK1_EN_MASK |
 	   SYSCON_PWM1SUBCTL_CLK2_EN_MASK);
+#endif
+
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(adc0), nxp_lpc_lpadc, okay)
+#if defined(CONFIG_SOC_LPC55S36)
+	CLOCK_SetClkDiv(kCLOCK_DivAdc0Clk, 2U, true);
+	CLOCK_AttachClk(kFRO_HF_to_ADC0);
+
+#if defined(CONFIG_ADC_MCUX_LPADC)
+	/* Vref is required for LPADC reference */
+	POWER_DisablePD(kPDRUNCFG_PD_VREF);
+
+	vref_config_t vrefConfig;
+
+	VREF_GetDefaultConfig(&vrefConfig);
+	vrefConfig.bufferMode                     = kVREF_ModeHighPowerBuffer;
+	vrefConfig.enableInternalVoltageRegulator = true;
+	vrefConfig.enableVrefOut                  = true;
+	VREF_Init((VREF_Type *)VREF_BASE, &vrefConfig);
+#endif
+#else
+	CLOCK_SetClkDiv(kCLOCK_DivAdcAsyncClk,
+			DT_PROP(DT_NODELABEL(adc0), clk_divider), true);
+	CLOCK_AttachClk(MUX_A(CM_ADCASYNCCLKSEL, DT_PROP(DT_NODELABEL(adc0), clk_source)));
+
+	/* Power up the ADC */
+	POWER_DisablePD(kPDRUNCFG_PD_LDOGPADC);
+#endif
 #endif
 }
 


### PR DESCRIPTION
To be consistent with the current NXP clocking scheme, move the LPADC clocking code to the SOC files where all of the other peripheral clocking is done.