### PR TITLE
samples: sensors: Remove warp7_m4 from fxas21002 platform_allow list

### DIFF
--- a/samples/sensor/fxas21002/sample.yaml
+++ b/samples/sensor/fxas21002/sample.yaml
@@ -4,6 +4,6 @@ tests:
   sample.sensor.fxas21002:
     harness: sensor
     tags: sensors
-    platform_allow: hexiwear_k64 warp7_m4
+    platform_allow: hexiwear_k64
     integration_platforms:
       - hexiwear_k64


### PR DESCRIPTION
The sample is overflowing flash on this platform

fixes: #56455