### PR TITLE
stm32: entropy: Enhance documentation around domain clock configuration issues

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -233,9 +233,13 @@ static int random_byte_get(void)
 	unsigned int key;
 	RNG_TypeDef *rng = entropy_stm32_rng_data.rng;
 
-	if (IS_ENABLED(CONFIG_ENTROPY_STM32_CLK_CHECK)) {
+	if (IS_ENABLED(CONFIG_ENTROPY_STM32_CLK_CHECK) && !k_is_pre_kernel()) {
+		/* CECS bit signals that a clock configuration issue is detected,
+		 * which may lead to generation of non truly random data.
+		 */
 		__ASSERT(LL_RNG_IsActiveFlag_CECS(rng) == 0,
-			 "Clock configuration error. See reference manual");
+			 "CECS = 1: RNG domain clock is too slow.\n"
+			 "\tSee ref man and update target clock configuration.");
 	}
 
 	key = irq_lock();
@@ -264,6 +268,7 @@ static int random_byte_get(void)
 	}
 
 out:
+
 	irq_unlock(key);
 
 	return retval;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -448,6 +448,9 @@
 			reg = <0x50060800 0x400>;
 			interrupts = <80 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00040000>,
+				/* Following domain clock setting requires MSI
+				 * clock to be enabled with msi-range = <11>;
+				 */
 				 <&rcc STM32_SRC_MSI CLK48_SEL(3)>;
 			status = "disabled";
 		};

--- a/dts/bindings/rng/st,stm32-rng.yaml
+++ b/dts/bindings/rng/st,stm32-rng.yaml
@@ -13,6 +13,13 @@ properties:
 
   clocks:
     required: true
+    description: |
+         Specifies the clock line to be enabled in clock controller as well as
+         the clock domain used, for instance:
+                   <&rcc STM32_SRC_MSI CLK48_SEL(3)> /* RNG clock domain set to MSI */
+         A correctly configured domain clock is required to allow the integrated low
+         sampling clock detection mecanism to behave properly.
+         In provided example, MSI should be configured to provide 48Mhz clock.
 
   nist-config:
     type: int


### PR DESCRIPTION
Enhance mechanism around domain clock configuration issues
Add some more documentation

Should answer issues such as #56494