### PR TITLE
boards: nucleo_f303k8: Fix clock configuration

### DIFF
--- a/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
+++ b/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
@@ -57,7 +57,7 @@
 
 &rcc {
 	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(72)>;
+	clock-frequency = <DT_FREQ_M(36)>;
 	ahb-prescaler = <1>;
 	apb1-prescaler = <2>;
 	apb2-prescaler = <1>;


### PR DESCRIPTION
Using HSI as PLL source, the max sys clock reachable is 36MHz. Use HSE instead.

Fixes #56535