### PR TITLE
dts: drivers: intel_adsp_2.0: Lnl ssp changes

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #define dai_base(dai) dai->plat_data.base
 #define dai_ip_base(dai) dai->plat_data.ip_base
 #define dai_shim_base(dai) dai->plat_data.shim_base
-#define dai_shim2_base(dai) dai->plat_data.shim2_base
+#define dai_hdamlssp_base(dai) dai->plat_data.hdamlssp_base
 
 #define DAI_DIR_PLAYBACK 0
 #define DAI_DIR_CAPTURE 1
@@ -725,11 +725,11 @@ static void dai_ssp_pm_runtime_en_ssp_power(struct dai_intel_ssp *dp, uint32_t i
 					      I2SLCTL_CPA(index), 0,
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
 #elif CONFIG_SOC_INTEL_ACE20_LNL
-	sys_write32(sys_read32(dai_shim2_base(dp) + I2SLCTL_OFFSET) |
+	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) |
 			       I2SLCTL_SPA(index) | I2SLCTL_OFLEN,
-			       dai_shim2_base(dp) + I2SLCTL_OFFSET);
+			       dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
 	/* Check if powered on. */
-	ret = dai_ssp_poll_for_register_delay(dai_shim2_base(dp) + I2SLCTL_OFFSET,
+	ret = dai_ssp_poll_for_register_delay(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET,
 					      I2SLCTL_CPA(index), 0,
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
 #else
@@ -761,11 +761,11 @@ static void dai_ssp_pm_runtime_dis_ssp_power(struct dai_intel_ssp *dp, uint32_t 
 					      I2SLCTL_CPA(index), I2SLCTL_CPA(index),
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
 #elif CONFIG_SOC_INTEL_ACE20_LNL
-	sys_write32(sys_read32(dai_shim2_base(dp) + I2SLCTL_OFFSET) & (~I2SLCTL_SPA(index)) &
-		    (~I2SLCTL_OFLEN), dai_shim2_base(dp) + I2SLCTL_OFFSET);
+	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) & (~I2SLCTL_SPA(index)) &
+		    (~I2SLCTL_OFLEN), dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
 
 	/* Check if powered off. */
-	ret = dai_ssp_poll_for_register_delay(dai_shim2_base(dp) + I2SLCTL_OFFSET,
+	ret = dai_ssp_poll_for_register_delay(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET,
 					      I2SLCTL_CPA(index), I2SLCTL_CPA(index),
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
 #else
@@ -2238,10 +2238,10 @@ static const char irq_name_level5_z[] = "level5";
 		.plat_data = {							\
 			.base =	DT_INST_REG_ADDR_BY_IDX(n, 0),			\
 			IF_ENABLED(DT_NODE_EXISTS(DT_NODELABEL(sspbase)),	\
-			(.ip_base = DT_REG_ADDR_BY_IDX(DT_NODELABEL(sspbase), 0),))	\
+			(.ip_base = DT_REG_ADDR_BY_IDX(DT_NODELABEL(sspbase), 0),))\
 			.shim_base = DT_REG_ADDR_BY_IDX(DT_NODELABEL(shim), 0),	\
-			IF_ENABLED(CONFIG_SOC_INTEL_ACE20_LNL,			\
-				(.shim2_base = DT_INST_PROP_BY_IDX(n, shim2, 0),))\
+			IF_ENABLED(DT_NODE_EXISTS(DT_NODELABEL(hdamlssp)),	\
+				(.hdamlssp_base = DT_REG_ADDR(DT_NODELABEL(hdamlssp)),))\
 			.irq = n,						\
 			.irq_name = irq_name_level5_z,				\
 			.fifo[DAI_DIR_PLAYBACK].offset =			\

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -2261,8 +2261,8 @@ static const char irq_name_level5_z[] = "level5";
 			.shim_base = DT_REG_ADDR_BY_IDX(DT_NODELABEL(shim), 0),	\
 			IF_ENABLED(DT_NODE_EXISTS(DT_NODELABEL(hdamlssp)),	\
 				(.hdamlssp_base = DT_REG_ADDR(DT_NODELABEL(hdamlssp)),))\
-			IF_ENABLED(DT_NODE_EXISTS(DT_NODELABEL(i2svss)),	\
-				(.i2svss_base = DT_REG_ADDR(DT_NODELABEL(i2svss)),))\
+			IF_ENABLED(DT_INST_PROP_HAS_IDX(n, i2svss, 0),	\
+				(.i2svss_base = DT_INST_PROP_BY_IDX(n, i2svss, 0),))\
 			.irq = n,						\
 			.irq_name = irq_name_level5_z,				\
 			.fifo[DAI_DIR_PLAYBACK].offset =			\

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -733,9 +733,6 @@ static void dai_ssp_pm_runtime_en_ssp_power(struct dai_intel_ssp *dp, uint32_t i
 	ret = dai_ssp_poll_for_register_delay(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET,
 					      I2SLCTL_CPA(index), 0,
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
-	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) | I2SLCTL_OFLEN,
-			       dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
-
 #else
 #error need to define SOC
 #endif
@@ -772,10 +769,6 @@ static void dai_ssp_pm_runtime_dis_ssp_power(struct dai_intel_ssp *dp, uint32_t 
 	ret = dai_ssp_poll_for_register_delay(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET,
 					      I2SLCTL_CPA(index), I2SLCTL_CPA(index),
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
-
-	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) & (~I2SLCTL_OFLEN),
-				dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
-
 #else
 #error need to define SOC
 #endif

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -30,6 +30,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #define dai_ip_base(dai) dai->plat_data.ip_base
 #define dai_shim_base(dai) dai->plat_data.shim_base
 #define dai_hdamlssp_base(dai) dai->plat_data.hdamlssp_base
+#define dai_i2svss_base(dai) dai->plat_data.i2svss_base
 
 #define DAI_DIR_PLAYBACK 0
 #define DAI_DIR_CAPTURE 1
@@ -1706,9 +1707,15 @@ static int dai_ssp_parse_aux_data(struct dai_intel_ssp *dp, const void *spec_con
 		case SSP_LINK_CLK_SOURCE:
 			link = (struct ssp_intel_link_ctl *)&aux_tlv->val;
 
+#if CONFIG_SOC_INTEL_ACE15_MTPM
 			sys_write32(sys_read32(dai_ip_base(dp) + I2SLCTL_OFFSET) |
 				    I2CLCTL_MLCS(link->clock_source), dai_ip_base(dp) +
 				    I2SLCTL_OFFSET);
+#elif CONFIG_SOC_INTEL_ACE20_LNL
+			sys_write32(sys_read32(dai_i2svss_base(dp) + I2SLCTL_OFFSET) |
+				    I2CLCTL_MLCS(link->clock_source), dai_i2svss_base(dp) +
+				    I2SLCTL_OFFSET);
+#endif
 			LOG_INF("%s link clock_source %u", __func__, link->clock_source);
 			break;
 #endif
@@ -2254,6 +2261,8 @@ static const char irq_name_level5_z[] = "level5";
 			.shim_base = DT_REG_ADDR_BY_IDX(DT_NODELABEL(shim), 0),	\
 			IF_ENABLED(DT_NODE_EXISTS(DT_NODELABEL(hdamlssp)),	\
 				(.hdamlssp_base = DT_REG_ADDR(DT_NODELABEL(hdamlssp)),))\
+			IF_ENABLED(DT_NODE_EXISTS(DT_NODELABEL(i2svss)),	\
+				(.i2svss_base = DT_REG_ADDR(DT_NODELABEL(i2svss)),))\
 			.irq = n,						\
 			.irq_name = irq_name_level5_z,				\
 			.fifo[DAI_DIR_PLAYBACK].offset =			\

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -726,12 +726,15 @@ static void dai_ssp_pm_runtime_en_ssp_power(struct dai_intel_ssp *dp, uint32_t i
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
 #elif CONFIG_SOC_INTEL_ACE20_LNL
 	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) |
-			       I2SLCTL_SPA(index) | I2SLCTL_OFLEN,
+			       I2SLCTL_SPA(index),
 			       dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
 	/* Check if powered on. */
 	ret = dai_ssp_poll_for_register_delay(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET,
 					      I2SLCTL_CPA(index), 0,
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
+	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) | I2SLCTL_OFLEN,
+			       dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
+
 #else
 #error need to define SOC
 #endif
@@ -761,13 +764,17 @@ static void dai_ssp_pm_runtime_dis_ssp_power(struct dai_intel_ssp *dp, uint32_t 
 					      I2SLCTL_CPA(index), I2SLCTL_CPA(index),
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
 #elif CONFIG_SOC_INTEL_ACE20_LNL
-	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) & (~I2SLCTL_SPA(index)) &
-		    (~I2SLCTL_OFLEN), dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
+	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) & (~I2SLCTL_SPA(index)),
+			dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
 
 	/* Check if powered off. */
 	ret = dai_ssp_poll_for_register_delay(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET,
 					      I2SLCTL_CPA(index), I2SLCTL_CPA(index),
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
+
+	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) & (~I2SLCTL_OFLEN),
+				dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
+
 #else
 #error need to define SOC
 #endif

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -787,6 +787,10 @@ static void dai_ssp_program_channel_map(struct dai_intel_ssp *dp,
 {
 #ifdef CONFIG_SOC_INTEL_ACE20_LNL
 	uint16_t pcmsycm = cfg->link_config;
+	struct dai_intel_ssp_pdata *ssp = dai_get_drvdata(dp);
+
+	/* Set upper slot number from configuration */
+	pcmsycm = pcmsycm | (ssp->params.tdm_slots - 1) << 4;
 
 	if (DAI_INTEL_SSP_IS_BIT_SET(pcmsycm, 15)) {
 		uint32_t reg_add = dai_ip_base(dp) + 0x1000 * index + PCMS0CM_OFFSET;
@@ -2080,14 +2084,15 @@ static int dai_ssp_config_set(const struct device *dev, const struct dai_config 
 			      const void *bespoke_cfg)
 {
 	struct dai_intel_ssp *dp = (struct dai_intel_ssp *)dev->data;
+	int ret;
 
 	if (cfg->type == DAI_INTEL_SSP) {
-		dai_ssp_program_channel_map(dp, cfg, dp->index);
-		return dai_ssp_set_config_tplg(dp, cfg, bespoke_cfg);
+		ret = dai_ssp_set_config_tplg(dp, cfg, bespoke_cfg);
 	} else {
-		dai_ssp_program_channel_map(dp, cfg, dp->index);
-		return dai_ssp_set_config_blob(dp, cfg, bespoke_cfg);
+		ret = dai_ssp_set_config_blob(dp, cfg, bespoke_cfg);
 	}
+	dai_ssp_program_channel_map(dp, cfg, dp->index);
+	return ret;
 }
 
 static const struct dai_properties *dai_ssp_get_properties(const struct device *dev,

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -318,7 +318,7 @@ struct dai_intel_ssp_plat_data {
 	uint32_t ip_base;
 	uint32_t shim_base;
 #ifdef CONFIG_SOC_INTEL_ACE20_LNL
-	uint32_t shim2_base;
+	uint32_t hdamlssp_base;
 #endif
 	int irq;
 	const char *irq_name;

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -221,7 +221,6 @@
 #ifdef CONFIG_SOC_INTEL_ACE15_MTPM
 #define I2SLCTL_SPA(x)		BIT(0 + x)
 #define I2SLCTL_CPA(x)		BIT(8 + x)
-#define I2CLCTL_MLCS(x)		DAI_INTEL_SSP_SET_BITS(30, 27, x)
 #else /* CONFIG_SOC_INTEL_ACE20_LNL */
 #define I2SLCTL_OFLEN		BIT(4)
 #define I2SLCTL_SPA(x)		BIT(16 + x)
@@ -230,6 +229,7 @@
 #define PCMS1CM_OFFSET		0x1A
 #endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
 
+#define I2CLCTL_MLCS(x)		DAI_INTEL_SSP_SET_BITS(30, 27, x)
 #define SHIM_CLKCTL		0x78
 #define SHIM_CLKCTL_I2SFDCGB(x)		BIT(20 + x)
 #define SHIM_CLKCTL_I2SEFDCGB(x)	BIT(18 + x)
@@ -319,6 +319,7 @@ struct dai_intel_ssp_plat_data {
 	uint32_t shim_base;
 #ifdef CONFIG_SOC_INTEL_ACE20_LNL
 	uint32_t hdamlssp_base;
+	uint32_t i2svss_base;
 #endif
 	int irq;
 	const char *irq_name;

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -21,6 +21,7 @@
 	(((x) & (1ULL << (b))) >> (b))
 #define DAI_INTEL_SSP_GET_BITS(b_hi, b_lo, x) \
 	(((x) & MASK(b_hi, b_lo)) >> (b_lo))
+#define DAI_INTEL_SSP_IS_BIT_SET(reg, bit)	(((reg >> bit) & (0x1)) != 0)
 
 /* ssp_freq array constants */
 #define DAI_INTEL_SSP_NUM_FREQ			3
@@ -216,9 +217,18 @@
 #define SSP_CLK_BCLK_ACTIVE	BIT(3)
 
 #define I2SLCTL_OFFSET		0x04
+
+#ifdef CONFIG_SOC_INTEL_ACE15_MTPM
 #define I2SLCTL_SPA(x)		BIT(0 + x)
 #define I2SLCTL_CPA(x)		BIT(8 + x)
 #define I2CLCTL_MLCS(x)		DAI_INTEL_SSP_SET_BITS(30, 27, x)
+#else /* CONFIG_SOC_INTEL_ACE20_LNL */
+#define I2SLCTL_OFLEN		BIT(4)
+#define I2SLCTL_SPA(x)		BIT(16 + x)
+#define I2SLCTL_CPA(x)		BIT(23 + x)
+#define PCMS0CM_OFFSET		0x16
+#define PCMS1CM_OFFSET		0x1A
+#endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
 
 #define SHIM_CLKCTL		0x78
 #define SHIM_CLKCTL_I2SFDCGB(x)		BIT(20 + x)
@@ -307,6 +317,9 @@ struct dai_intel_ssp_plat_data {
 	uint32_t base;
 	uint32_t ip_base;
 	uint32_t shim_base;
+#ifdef CONFIG_SOC_INTEL_ACE20_LNL
+	uint32_t shim2_base;
+#endif
 	int irq;
 	const char *irq_name;
 	uint32_t flags;

--- a/dts/bindings/dma/intel,adsp-hda-ssp-cap.yaml
+++ b/dts/bindings/dma/intel,adsp-hda-ssp-cap.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Intel HDA SSP Capabilities controller
+
+compatible: "intel,adsp-hda-ssp-cap"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+    description: |
+        Intel HD Audio Multiple Links Capability Structure
+        for I2S / PCM Link.

--- a/dts/bindings/i2s/intel,ssp-dai.yaml
+++ b/dts/bindings/i2s/intel,ssp-dai.yaml
@@ -24,3 +24,12 @@ properties:
   dma-names:
     required: true
 
+  shim2:
+    type: array
+    description: |
+      Intel HD Audio Multiple Links Capability Structure
+      for I2S / PCM Link.
+
+  i2svss:
+    type: array
+

--- a/dts/bindings/i2s/intel,ssp-dai.yaml
+++ b/dts/bindings/i2s/intel,ssp-dai.yaml
@@ -24,8 +24,3 @@ properties:
   dma-names:
     required: true
 
-  shim2:
-    type: array
-    description: |
-      Intel HD Audio Multiple Links Capability Structure
-      for I2S / PCM Link.

--- a/dts/bindings/i2s/intel,ssp-dai.yaml
+++ b/dts/bindings/i2s/intel,ssp-dai.yaml
@@ -24,12 +24,5 @@ properties:
   dma-names:
     required: true
 
-  shim2:
-    type: array
-    description: |
-      Intel HD Audio Multiple Links Capability Structure
-      for I2S / PCM Link.
-
   i2svss:
     type: array
-

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -145,6 +145,7 @@
 			#size-cells = <0>;
 			reg = <0x00028100 0x1000
 				   0x00079C00 0x200>;
+			i2svss = <0x00028C00 0x1000>;
 			interrupts = <0x00 0 0>;
 			interrupt-parent = <&ace_intc>;
 			dmas = <&hda_link_out 1
@@ -160,6 +161,7 @@
 			#size-cells = <0>;
 			reg = <0x00029100 0x1000
 				   0x00079C00 0x200>;
+			i2svss = <0x00029C00 0x1000>;
 			interrupts = <0x01 0 0>;
 			interrupt-parent = <&ace_intc>;
 			dmas = <&hda_link_out 2
@@ -175,6 +177,7 @@
 			#size-cells = <0>;
 			reg = <0x0002a100 0x1000
 				   0x00079C00 0x200>;
+			i2svss = <0x0002AC00 0x1000>;
 			interrupts = <0x02 0 0>;
 			interrupt-parent = <&ace_intc>;
 			dmas = <&hda_link_out 3
@@ -190,6 +193,7 @@
 			#size-cells = <0>;
 			reg = <0x0002b100 0x1000
 				   0x00079C00 0x200>;
+			i2svss = <0x0002BC00 0x1000>;
 			interrupts = <0x03 0 0>;
 			interrupt-parent = <&ace_intc>;
 			dmas = <&hda_link_out 4
@@ -205,6 +209,7 @@
 			#size-cells = <0>;
 			reg = <0x0002c100 0x1000
 				   0x00079C00 0x200>;
+			i2svss = <0x0002CC00 0x1000>;
 			interrupts = <0x04 0 0>;
 			interrupt-parent = <&ace_intc>;
 			dmas = <&hda_link_out 5
@@ -220,6 +225,7 @@
 			#size-cells = <0>;
 			reg = <0x0002d100 0x1000
 				   0x00079C00 0x200>;
+			i2svss = <0x0002DC00 0x1000>;
 			interrupts = <0x04 0 0>;
 			interrupt-parent = <&ace_intc>;
 			dmas = <&hda_link_out 6

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -133,13 +133,18 @@
 			reg = <0x28000 0x1000>;
 		};
 
+		hdamlssp: hdamlssp@d00 {
+			compatible = "intel,adsp-hda-ssp-cap";
+			reg = <0xD00 0x40>;
+			status = "okay";
+		};
+
 		ssp0: ssp@28100 {
 			compatible = "intel,ssp-dai";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x00028100 0x1000
 				   0x00079C00 0x200>;
-			shim2 = <0x0D00 0x10>;
 			interrupts = <0x00 0 0>;
 			interrupt-parent = <&ace_intc>;
 			dmas = <&hda_link_out 1
@@ -155,7 +160,6 @@
 			#size-cells = <0>;
 			reg = <0x00029100 0x1000
 				   0x00079C00 0x200>;
-			shim2 = <0x0D00 0x10>;
 			interrupts = <0x01 0 0>;
 			interrupt-parent = <&ace_intc>;
 			dmas = <&hda_link_out 2
@@ -171,7 +175,6 @@
 			#size-cells = <0>;
 			reg = <0x0002a100 0x1000
 				   0x00079C00 0x200>;
-			shim2 = <0x0D00 0x10>;
 			interrupts = <0x02 0 0>;
 			interrupt-parent = <&ace_intc>;
 			dmas = <&hda_link_out 3
@@ -187,7 +190,6 @@
 			#size-cells = <0>;
 			reg = <0x0002b100 0x1000
 				   0x00079C00 0x200>;
-			shim2 = <0x0D00 0x10>;
 			interrupts = <0x03 0 0>;
 			interrupt-parent = <&ace_intc>;
 			dmas = <&hda_link_out 4
@@ -203,7 +205,6 @@
 			#size-cells = <0>;
 			reg = <0x0002c100 0x1000
 				   0x00079C00 0x200>;
-			shim2 = <0x0D00 0x10>;
 			interrupts = <0x04 0 0>;
 			interrupt-parent = <&ace_intc>;
 			dmas = <&hda_link_out 5
@@ -219,7 +220,6 @@
 			#size-cells = <0>;
 			reg = <0x0002d100 0x1000
 				   0x00079C00 0x200>;
-			shim2 = <0x0D00 0x10>;
 			interrupts = <0x04 0 0>;
 			interrupt-parent = <&ace_intc>;
 			dmas = <&hda_link_out 6


### PR DESCRIPTION
Add SSP changes required in driver and DTS to enable ssp on
LNL (ACE 2.0) platform.

Signed-off-by: Jaroslaw Stelter [Jaroslaw.Stelter@intel.com](mailto:Jaroslaw.Stelter@intel.com)