### PR TITLE
net: openthread: Remove duplicate option `TREL` in openthread.

### DIFF
--- a/modules/openthread/Kconfig.thread
+++ b/modules/openthread/Kconfig.thread
@@ -79,9 +79,6 @@ config OPENTHREAD_RADIO_LINK_IEEE_802_15_4_ENABLE
 	bool "Support for IEEE802.15.4 radio link"
 	default y
 
-config OPENTHREAD_RADIO_LINK_TREL_ENABLE
-	bool "Thread Radio Encapsulation Link (TREL)"
-
 config OPENTHREAD_CSL_AUTO_SYNC
 	bool "CSL autosync"
 	default y if OPENTHREAD_CSL_RECEIVER

--- a/modules/openthread/platform/openthread-core-zephyr-config.h
+++ b/modules/openthread/platform/openthread-core-zephyr-config.h
@@ -272,17 +272,6 @@
 #define RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM 0
 
 /**
- * @def OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
- *
- * Set to 1 to enable support for Thread Radio Encapsulation Link (TREL).
- *
- */
-#ifdef CONFIG_OPENTHREAD_RADIO_LINK_TREL_ENABLE
-#define OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE \
-	CONFIG_OPENTHREAD_RADIO_LINK_TREL_ENABLE
-#endif /* CONFIG_OPENTHREAD_RADIO_LINK_TREL_ENABLE */
-
-/**
  * @def OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD
  *
  * For some reasons, CSL receivers wake up a little later than expected. This


### PR DESCRIPTION
Removing duplicated `OPENTHREAD_RADIO_LINK_TREL_ENABLE` from `Kconfig.thread` and `openthread-core-zephyr-config.h`