### PR TITLE
net: wifi_shell: Print firmware version in Wi-Fi status

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -120,6 +120,7 @@ static inline const char *wifi_band_txt(enum wifi_frequency_bands band)
 #define WIFI_SSID_MAX_LEN 32
 #define WIFI_PSK_MAX_LEN 64
 #define WIFI_MAC_ADDR_LEN 6
+#define WIFI_FW_LEN 32
 
 #define WIFI_CHANNEL_MAX 233
 #define WIFI_CHANNEL_ANY 255

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -178,6 +178,7 @@ struct wifi_iface_status {
 	unsigned int ssid_len;
 	char ssid[WIFI_SSID_MAX_LEN];
 	char bssid[WIFI_MAC_ADDR_LEN];
+	char fw_ver[WIFI_FW_LEN];
 	enum wifi_frequency_bands band;
 	unsigned int channel;
 	enum wifi_iface_mode iface_mode;

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -376,6 +376,7 @@ static int cmd_wifi_status(const struct shell *sh, size_t argc, char *argv[])
 		shell_fprintf(sh, SHELL_NORMAL, "RSSI: %d\n", status.rssi);
 		shell_fprintf(sh, SHELL_NORMAL, "Beacon Interval: %d\n", status.beacon_interval);
 		shell_fprintf(sh, SHELL_NORMAL, "DTIM: %d\n", status.dtim_period);
+		shell_fprintf(sh, SHELL_NORMAL, "Firmware Version: %s\n", status.fw_ver);
 	}
 
 	return 0;


### PR DESCRIPTION
Extend Wi-Fi status to include firmware version.