### PR TITLE
stm32h5 supports spi peripheral

### DIFF
--- a/boards/arm/stm32h573i_dk/arduino_r3_connector.dtsi
+++ b/boards/arm/stm32h573i_dk/arduino_r3_connector.dtsi
@@ -34,3 +34,5 @@
 			   <21 0 &gpiob 6 0>;	/* D15 */
 	};
 };
+
+arduino_spi: &spi2 {};

--- a/boards/arm/stm32h573i_dk/doc/index.rst
+++ b/boards/arm/stm32h573i_dk/doc/index.rst
@@ -183,6 +183,8 @@ hardware features:
 +-----------+------------+-------------------------------------+
 | RTC       | on-chip    | Real Time Clock                     |
 +-----------+------------+-------------------------------------+
+| SPI       | on-chip    | spi bus                             |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
@@ -183,3 +183,10 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&spi2 {
+	pinctrl-0 = <&spi2_nss_pa3 &spi2_sck_pi1
+		     &spi2_miso_pi2 &spi2_mosi_pb15>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/arm/stm32h573i_dk/stm32h573i_dk.yaml
+++ b/boards/arm/stm32h573i_dk/stm32h573i_dk.yaml
@@ -17,3 +17,4 @@ supported:
   - dac
   - pwm
   - counter
+  - spi

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -373,6 +373,36 @@
 			};
 		};
 
+		spi1: spi@40013000 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013000 0x400>;
+			interrupts = <55 5>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			status = "disabled";
+		};
+
+		spi2: spi@40003800 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003800 0x400>;
+			interrupts = <56 5>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
+			status = "disabled";
+		};
+
+		spi3: spi@40003c00 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x400>;
+			interrupts = <57 5>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
+			status = "disabled";
+		};
+
 		rng: rng@420c0800 {
 			compatible = "st,stm32-rng";
 			reg = <0x420c0800 0x400>;

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -96,6 +96,36 @@
 			status = "disabled";
 		};
 
+		spi4: spi@40014c00 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40014c00 0x400>;
+			interrupts = <82 5>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00080000>;
+			status = "disabled";
+		};
+
+		spi5: spi@44002000 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x44002000 0x400>;
+			interrupts = <83 5>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000020>;
+			status = "disabled";
+		};
+
+		spi6: spi@40015000 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40015000 0x400>;
+			interrupts = <84 5>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00100000>;
+			status = "disabled";
+		};
+
 		timers4: timers@40000800 {
 			compatible = "st,stm32-timers";
 			reg = <0x40000800 0x400>;

--- a/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&rcc {
+	apb1-prescaler = <2>;
+};
+
+&spi2 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
@@ -9,6 +9,10 @@
 };
 
 &spi2 {
+	dmas = <&gpdma1 0 9 STM32_DMA_PERIPH_TX
+		&gpdma1 1 8 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;
@@ -19,4 +23,12 @@
 		reg = <0>;
 		spi-max-frequency = <10000000>;
 	};
+};
+
+&gpdma1 {
+	status = "okay";
+};
+
+&gpdma2 {
+	status = "okay";
 };

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -28,7 +28,7 @@ tests:
     extra_args: OVERLAY_CONFIG="overlay-stm32-spi-dma.conf"
     filter: CONFIG_SOC_FAMILY_STM32
     platform_allow: nucleo_g474re nucleo_f207zg nucleo_f429zi nucleo_f746zg nucleo_wb55rg
-        nucleo_l152re nucleo_wl55jc nucleo_h743zi
+        nucleo_l152re nucleo_wl55jc nucleo_h743zi stm32h573i_dk
     integration_platforms:
       - nucleo_g474re
   drivers.spi.gd32_spi_interrupt.loopback:


### PR DESCRIPTION
Add the support of the SPI to the stm32H5 serie.

Add SPI nodes 1,2,3  to the stm32h5x family plus SPI 4,5,6 nodes to the stm32h56x/57x devices.
Enable the SPI2  on the stm32h573i_dk board
And test the driver with loop_back test case in interrupt and DMA mode
--> connect D11 to D12 on the stm32h573i_dk (connector CN13) to pass the test.

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)