### PR TITLE
drivers: spi: make SPI dt-spec macros compatible with C++

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -163,6 +163,12 @@ Stable API changes in this release
   automatically migrate existing projects can be found in
   :zephyr_file:`scripts/utils/migrate_sys_init.py`.
 
+* Changed :c:struct:`spi_config` ``cs`` (:c:struct:`spi_cs_control`) from
+  pointer to struct member. This allows using the existing SPI dt-spec macros in
+  C++. SPI controller drivers doing ``NULL`` checks on the ``cs`` field to check
+  if CS is GPIO-based or not, must now use :c:func:`spi_cs_is_gpio` or
+  :c:func:`spi_cs_is_gpio_dt` calls.
+
 New APIs in this release
 ========================
 

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -198,18 +198,18 @@ static bool bt_spi_handle_vendor_evt(uint8_t *rxmsg)
 static int configure_cs(void)
 {
 	/* Configure pin as output and set to active */
-	return gpio_pin_configure_dt(&bus.config.cs->gpio, GPIO_OUTPUT_ACTIVE);
+	return gpio_pin_configure_dt(&bus.config.cs.gpio, GPIO_OUTPUT_ACTIVE);
 }
 
 static void kick_cs(void)
 {
-	gpio_pin_set_dt(&bus.config.cs->gpio, 0);
-	gpio_pin_set_dt(&bus.config.cs->gpio, 1);
+	gpio_pin_set_dt(&bus.config.cs.gpio, 0);
+	gpio_pin_set_dt(&bus.config.cs.gpio, 1);
 }
 
 static void release_cs(void)
 {
-	gpio_pin_set_dt(&bus.config.cs->gpio, 0);
+	gpio_pin_set_dt(&bus.config.cs.gpio, 0);
 }
 
 static bool irq_pin_high(void)

--- a/drivers/fpga/fpga_ice40.c
+++ b/drivers/fpga/fpga_ice40.c
@@ -220,7 +220,7 @@ static int fpga_ice40_load_gpio(const struct device *dev, uint32_t *image_ptr, u
 	const struct fpga_ice40_config *config = dev->config;
 
 	/* prepare masks */
-	cs = BIT(config->bus.config.cs->gpio.pin);
+	cs = BIT(config->bus.config.cs.gpio.pin);
 	clk = BIT(config->clk.pin);
 	pico = BIT(config->pico.pin);
 	creset = BIT(config->creset.pin);
@@ -241,7 +241,7 @@ static int fpga_ice40_load_gpio(const struct device *dev, uint32_t *image_ptr, u
 	LOG_DBG("Initializing GPIO");
 	ret = gpio_pin_configure_dt(&config->cdone, GPIO_INPUT) ||
 	      gpio_pin_configure_dt(&config->creset, GPIO_OUTPUT_HIGH) ||
-	      gpio_pin_configure_dt(&config->bus.config.cs->gpio, GPIO_OUTPUT_HIGH) ||
+	      gpio_pin_configure_dt(&config->bus.config.cs.gpio, GPIO_OUTPUT_HIGH) ||
 	      gpio_pin_configure_dt(&config->clk, GPIO_OUTPUT_HIGH) ||
 	      gpio_pin_configure_dt(&config->pico, GPIO_OUTPUT_HIGH);
 	__ASSERT(ret == 0, "Failed to initialize GPIO: %d", ret);
@@ -297,7 +297,7 @@ static int fpga_ice40_load_gpio(const struct device *dev, uint32_t *image_ptr, u
 
 unlock:
 	(void)gpio_pin_configure_dt(&config->creset, GPIO_OUTPUT_HIGH);
-	(void)gpio_pin_configure_dt(&config->bus.config.cs->gpio, GPIO_OUTPUT_HIGH);
+	(void)gpio_pin_configure_dt(&config->bus.config.cs.gpio, GPIO_OUTPUT_HIGH);
 	(void)gpio_pin_configure_dt(&config->clk, GPIO_DISCONNECTED);
 	(void)gpio_pin_configure_dt(&config->pico, GPIO_DISCONNECTED);
 #ifdef CONFIG_PINCTRL
@@ -339,7 +339,7 @@ static int fpga_ice40_load_spi(const struct device *dev, uint32_t *image_ptr, ui
 	LOG_DBG("Initializing GPIO");
 	ret = gpio_pin_configure_dt(&config->cdone, GPIO_INPUT) ||
 	      gpio_pin_configure_dt(&config->creset, GPIO_OUTPUT_HIGH) ||
-	      gpio_pin_configure_dt(&config->bus.config.cs->gpio, GPIO_OUTPUT_HIGH);
+	      gpio_pin_configure_dt(&config->bus.config.cs.gpio, GPIO_OUTPUT_HIGH);
 	__ASSERT(ret == 0, "Failed to initialize GPIO: %d", ret);
 
 	LOG_DBG("Set CRESET low");
@@ -350,7 +350,7 @@ static int fpga_ice40_load_spi(const struct device *dev, uint32_t *image_ptr, ui
 	}
 
 	LOG_DBG("Set SPI_CS low");
-	ret = gpio_pin_configure_dt(&config->bus.config.cs->gpio, GPIO_OUTPUT_LOW);
+	ret = gpio_pin_configure_dt(&config->bus.config.cs.gpio, GPIO_OUTPUT_LOW);
 	if (ret < 0) {
 		LOG_ERR("failed to set SPI_CS low: %d", ret);
 		goto unlock;
@@ -373,7 +373,7 @@ static int fpga_ice40_load_spi(const struct device *dev, uint32_t *image_ptr, ui
 	k_busy_wait(config->config_delay_us);
 
 	LOG_DBG("Set SPI_CS high");
-	ret = gpio_pin_configure_dt(&config->bus.config.cs->gpio, GPIO_OUTPUT_HIGH);
+	ret = gpio_pin_configure_dt(&config->bus.config.cs.gpio, GPIO_OUTPUT_HIGH);
 	if (ret < 0) {
 		LOG_ERR("failed to set SPI_CS high: %d", ret);
 		goto unlock;
@@ -389,7 +389,7 @@ static int fpga_ice40_load_spi(const struct device *dev, uint32_t *image_ptr, ui
 	}
 
 	LOG_DBG("Set SPI_CS low");
-	ret = gpio_pin_configure_dt(&config->bus.config.cs->gpio, GPIO_OUTPUT_LOW);
+	ret = gpio_pin_configure_dt(&config->bus.config.cs.gpio, GPIO_OUTPUT_LOW);
 	if (ret < 0) {
 		LOG_ERR("failed to set SPI_CS low: %d", ret);
 		goto unlock;
@@ -405,7 +405,7 @@ static int fpga_ice40_load_spi(const struct device *dev, uint32_t *image_ptr, ui
 	}
 
 	LOG_DBG("Set SPI_CS high");
-	ret = gpio_pin_configure_dt(&config->bus.config.cs->gpio, GPIO_OUTPUT_HIGH);
+	ret = gpio_pin_configure_dt(&config->bus.config.cs.gpio, GPIO_OUTPUT_HIGH);
 	if (ret < 0) {
 		LOG_ERR("failed to set SPI_CS high: %d", ret);
 		goto unlock;
@@ -438,7 +438,7 @@ static int fpga_ice40_load_spi(const struct device *dev, uint32_t *image_ptr, ui
 
 unlock:
 	(void)gpio_pin_configure_dt(&config->creset, GPIO_OUTPUT_HIGH);
-	(void)gpio_pin_configure_dt(&config->bus.config.cs->gpio, GPIO_OUTPUT_HIGH);
+	(void)gpio_pin_configure_dt(&config->bus.config.cs.gpio, GPIO_OUTPUT_HIGH);
 #ifdef CONFIG_PINCTRL
 	(void)pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 #endif

--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -74,7 +74,7 @@ static bool spi_b91_config_cs(const struct device *dev,
 	const struct spi_b91_cfg *b91_config = SPI_CFG(dev);
 
 	/* software flow control */
-	if (config->cs.gpio.port != NULL) {
+	if (spi_cs_is_gpio(config)) {
 		/* disable all hardware CS pins */
 		spi_b91_hw_cs_disable(b91_config);
 		return true;
@@ -397,7 +397,7 @@ static int spi_b91_transceive(const struct device *dev,
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
 
 	/* if cs is defined: software cs control, set active true */
-	if (config->cs.gpio.port != NULL) {
+	if (spi_cs_is_gpio(config)) {
 		spi_context_cs_control(&data->ctx, true);
 	}
 
@@ -405,7 +405,7 @@ static int spi_b91_transceive(const struct device *dev,
 	spi_b91_txrx(dev, txrx_len);
 
 	/* if cs is defined: software cs control, set active false */
-	if (config->cs.gpio.port != NULL) {
+	if (spi_cs_is_gpio(config)) {
 		spi_context_cs_control(&data->ctx, false);
 	}
 

--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -74,7 +74,7 @@ static bool spi_b91_config_cs(const struct device *dev,
 	const struct spi_b91_cfg *b91_config = SPI_CFG(dev);
 
 	/* software flow control */
-	if (config->cs) {
+	if (config->cs.gpio.port != NULL) {
 		/* disable all hardware CS pins */
 		spi_b91_hw_cs_disable(b91_config);
 		return true;
@@ -397,7 +397,7 @@ static int spi_b91_transceive(const struct device *dev,
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
 
 	/* if cs is defined: software cs control, set active true */
-	if (config->cs) {
+	if (config->cs.gpio.port != NULL) {
 		spi_context_cs_control(&data->ctx, true);
 	}
 
@@ -405,7 +405,7 @@ static int spi_b91_transceive(const struct device *dev,
 	spi_b91_txrx(dev, txrx_len);
 
 	/* if cs is defined: software cs control, set active false */
-	if (config->cs) {
+	if (config->cs.gpio.port != NULL) {
 		spi_context_cs_control(&data->ctx, false);
 	}
 

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -75,7 +75,7 @@ static int spi_cc13xx_cc26xx_configure(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (config->operation & SPI_CS_ACTIVE_HIGH && config->cs.gpio.port == NULL) {
+	if (config->operation & SPI_CS_ACTIVE_HIGH && !spi_cs_is_gpio(config)) {
 		LOG_ERR("Active high CS requires emulation through a GPIO line.");
 		return -EINVAL;
 	}

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -75,7 +75,7 @@ static int spi_cc13xx_cc26xx_configure(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (config->operation & SPI_CS_ACTIVE_HIGH && !config->cs) {
+	if (config->operation & SPI_CS_ACTIVE_HIGH && config->cs.gpio.port == NULL) {
 		LOG_ERR("Active high CS requires emulation through a GPIO line.");
 		return -EINVAL;
 	}

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -236,18 +236,18 @@ static inline int spi_context_cs_configure_all(struct spi_context *ctx)
 static inline void _spi_context_cs_control(struct spi_context *ctx,
 					   bool on, bool force_off)
 {
-	if (ctx->config && ctx->config->cs && ctx->config->cs->gpio.port) {
+	if (ctx->config && ctx->config->cs.gpio.port) {
 		if (on) {
-			gpio_pin_set_dt(&ctx->config->cs->gpio, 1);
-			k_busy_wait(ctx->config->cs->delay);
+			gpio_pin_set_dt(&ctx->config->cs.gpio, 1);
+			k_busy_wait(ctx->config->cs.delay);
 		} else {
 			if (!force_off &&
 			    ctx->config->operation & SPI_HOLD_ON_CS) {
 				return;
 			}
 
-			k_busy_wait(ctx->config->cs->delay);
-			gpio_pin_set_dt(&ctx->config->cs->gpio, 0);
+			k_busy_wait(ctx->config->cs.delay);
+			gpio_pin_set_dt(&ctx->config->cs.gpio, 0);
 		}
 	}
 }

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -236,7 +236,7 @@ static inline int spi_context_cs_configure_all(struct spi_context *ctx)
 static inline void _spi_context_cs_control(struct spi_context *ctx,
 					   bool on, bool force_off)
 {
-	if (ctx->config && ctx->config->cs.gpio.port) {
+	if (ctx->config && spi_cs_is_gpio(ctx->config)) {
 		if (on) {
 			gpio_pin_set_dt(&ctx->config->cs.gpio, 1);
 			k_busy_wait(ctx->config->cs.delay);

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -147,7 +147,7 @@ static int spi_gd32_configure(const struct device *dev,
 
 	/* Reset to hardware NSS mode. */
 	SPI_CTL0(cfg->reg) &= ~SPI_CTL0_SWNSSEN;
-	if (config->cs.gpio.port != NULL) {
+	if (spi_cs_is_gpio(config)) {
 		SPI_CTL0(cfg->reg) |= SPI_CTL0_SWNSSEN;
 	} else {
 		/*

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -147,7 +147,7 @@ static int spi_gd32_configure(const struct device *dev,
 
 	/* Reset to hardware NSS mode. */
 	SPI_CTL0(cfg->reg) &= ~SPI_CTL0_SWNSSEN;
-	if (config->cs != NULL) {
+	if (config->cs.gpio.port != NULL) {
 		SPI_CTL0(cfg->reg) |= SPI_CTL0_SWNSSEN;
 	} else {
 		/*

--- a/drivers/spi/spi_handlers.c
+++ b/drivers/spi/spi_handlers.c
@@ -104,13 +104,9 @@ static inline int z_vrfy_spi_transceive(const struct device *dev,
 	}
 
 	memcpy(&config_copy, config, sizeof(*config));
-	if (config_copy.cs) {
-		const struct spi_cs_control *cs = config_copy.cs;
-
-		Z_OOPS(Z_SYSCALL_MEMORY_READ(cs, sizeof(*cs)));
-		if (cs->gpio.port) {
-			Z_OOPS(Z_SYSCALL_OBJ(cs->gpio.port, K_OBJ_DRIVER_GPIO));
-		}
+	if (config_copy.cs.gpio.port != NULL) {
+		Z_OOPS(Z_SYSCALL_OBJ(config_copy.cs.gpio.port,
+				     K_OBJ_DRIVER_GPIO));
 	}
 
 	return copy_bufs_and_transceive((const struct device *)dev,

--- a/drivers/spi/spi_handlers.c
+++ b/drivers/spi/spi_handlers.c
@@ -104,7 +104,7 @@ static inline int z_vrfy_spi_transceive(const struct device *dev,
 	}
 
 	memcpy(&config_copy, config, sizeof(*config));
-	if (config_copy.cs.gpio.port != NULL) {
+	if (spi_cs_is_gpio(&config_copy)) {
 		Z_OOPS(Z_SYSCALL_OBJ(config_copy.cs.gpio.port,
 				     K_OBJ_DRIVER_GPIO));
 	}

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -541,7 +541,7 @@ static int spi_stm32_configure(const struct device *dev,
 
 	LL_SPI_DisableCRC(spi);
 
-	if (config->cs || !IS_ENABLED(CONFIG_SPI_STM32_USE_HW_SS)) {
+	if (config->cs.gpio.port != NULL || !IS_ENABLED(CONFIG_SPI_STM32_USE_HW_SS)) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 		if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
 			if (LL_SPI_GetNSSPolarity(spi) == LL_SPI_NSS_POLARITY_LOW)

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -541,7 +541,7 @@ static int spi_stm32_configure(const struct device *dev,
 
 	LL_SPI_DisableCRC(spi);
 
-	if (config->cs.gpio.port != NULL || !IS_ENABLED(CONFIG_SPI_STM32_USE_HW_SS)) {
+	if (spi_cs_is_gpio(config) || !IS_ENABLED(CONFIG_SPI_STM32_USE_HW_SS)) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 		if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
 			if (LL_SPI_GetNSSPolarity(spi) == LL_SPI_NSS_POLARITY_LOW)

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -91,7 +91,7 @@ static int configure(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (spi_cfg->cs) {
+	if (spi_cfg->cs.gpio.port != NULL) {
 		LOG_ERR("CS control via GPIO is not supported");
 		return -EINVAL;
 	}

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -91,7 +91,7 @@ static int configure(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (spi_cfg->cs.gpio.port != NULL) {
+	if (spi_cs_is_gpio(spi_cfg)) {
 		LOG_ERR("CS control via GPIO is not supported");
 		return -EINVAL;
 	}

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -109,7 +109,7 @@ int spi_oc_simple_transceive(const struct device *dev,
 	spi_oc_simple_configure(info, spi, config);
 
 	/* Set chip select */
-	if (config->cs) {
+	if (config->cs.gpio.port != NULL) {
 		spi_context_cs_control(&spi->ctx, true);
 	} else {
 		sys_write8(1 << config->slave, SPI_OC_SIMPLE_SPSS(info));
@@ -147,7 +147,7 @@ int spi_oc_simple_transceive(const struct device *dev,
 	}
 
 	/* Clear chip-select */
-	if (config->cs) {
+	if (config->cs.gpio.port != NULL) {
 		spi_context_cs_control(&spi->ctx, false);
 	} else {
 		sys_write8(0 << config->slave, SPI_OC_SIMPLE_SPSS(info));

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -109,7 +109,7 @@ int spi_oc_simple_transceive(const struct device *dev,
 	spi_oc_simple_configure(info, spi, config);
 
 	/* Set chip select */
-	if (config->cs.gpio.port != NULL) {
+	if (spi_cs_is_gpio(config)) {
 		spi_context_cs_control(&spi->ctx, true);
 	} else {
 		sys_write8(1 << config->slave, SPI_OC_SIMPLE_SPSS(info));
@@ -147,7 +147,7 @@ int spi_oc_simple_transceive(const struct device *dev,
 	}
 
 	/* Clear chip-select */
-	if (config->cs.gpio.port != NULL) {
+	if (spi_cs_is_gpio(config)) {
 		spi_context_cs_control(&spi->ctx, false);
 	} else {
 		sys_write8(0 << config->slave, SPI_OC_SIMPLE_SPSS(info));

--- a/drivers/spi/spi_pw.c
+++ b/drivers/spi/spi_pw.c
@@ -549,7 +549,7 @@ static int spi_pw_configure(const struct device *dev,
 	/* At this point, it's mandatory to set this on the context! */
 	spi->ctx.config = config;
 
-	if (spi->ctx.config->cs.gpio.port == NULL) {
+	if (!spi_cs_is_gpio(spi->ctx.config)) {
 		if (spi->cs_mode == CS_GPIO_MODE) {
 			LOG_DBG("cs gpio is NULL, switch to hw mode");
 			spi->cs_mode = CS_HW_MODE;

--- a/drivers/spi/spi_pw.c
+++ b/drivers/spi/spi_pw.c
@@ -549,7 +549,7 @@ static int spi_pw_configure(const struct device *dev,
 	/* At this point, it's mandatory to set this on the context! */
 	spi->ctx.config = config;
 
-	if (!spi->ctx.config->cs) {
+	if (spi->ctx.config->cs.gpio.port == NULL) {
 		if (spi->cs_mode == CS_GPIO_MODE) {
 			LOG_DBG("cs gpio is NULL, switch to hw mode");
 			spi->cs_mode = CS_HW_MODE;

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -216,7 +216,7 @@ static int spi_sifive_transceive(const struct device *dev,
 	 * If the chip select configuration is not present, we'll ask the
 	 * SPI peripheral itself to control the CS line
 	 */
-	if (config->cs.gpio.port == NULL) {
+	if (!spi_cs_is_gpio(config)) {
 		hw_cs_control = true;
 	}
 

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -216,7 +216,7 @@ static int spi_sifive_transceive(const struct device *dev,
 	 * If the chip select configuration is not present, we'll ask the
 	 * SPI peripheral itself to control the CS line
 	 */
-	if (config->cs == NULL) {
+	if (config->cs.gpio.port == NULL) {
 		hw_cs_control = true;
 	}
 

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -487,6 +487,30 @@ __subsystem struct spi_driver_api {
 };
 
 /**
+ * @brief Check if SPI CS is controlled using a GPIO.
+ *
+ * @param config SPI configuration.
+ * @return true If CS is controlled using a GPIO.
+ * @return false If CS is controlled by hardware or any other means.
+ */
+static inline bool spi_cs_is_gpio(const struct spi_config *config)
+{
+	return config->cs.gpio.port != NULL;
+}
+
+/**
+ * @brief Check if SPI CS in @ref spi_dt_spec is controlled using a GPIO.
+ *
+ * @param spec SPI specification from devicetree.
+ * @return true If CS is controlled using a GPIO.
+ * @return false If CS is controlled by hardware or any other means.
+ */
+static inline bool spi_cs_is_gpio_dt(const struct spi_dt_spec *spec)
+{
+	return spi_cs_is_gpio(&spec->config);
+}
+
+/**
  * @brief Validate that SPI bus is ready.
  *
  * @param spec SPI specification from devicetree
@@ -502,7 +526,7 @@ static inline bool spi_is_ready(const struct spi_dt_spec *spec)
 		return false;
 	}
 	/* Validate CS gpio port is ready, if it is used */
-	if (spec->config.cs.gpio.port != NULL &&
+	if (spi_cs_is_gpio_dt(spec) &&
 	    !device_is_ready(spec->config.cs.gpio.port)) {
 		return false;
 	}
@@ -524,7 +548,7 @@ static inline bool spi_is_ready_dt(const struct spi_dt_spec *spec)
 		return false;
 	}
 	/* Validate CS gpio port is ready, if it is used */
-	if (spec->config.cs.gpio.port != NULL &&
+	if (spi_cs_is_gpio_dt(spec) &&
 	    !device_is_ready(spec->config.cs.gpio.port)) {
 		return false;
 	}

--- a/samples/boards/nrf/nrfx_prs/src/main.c
+++ b/samples/boards/nrf/nrfx_prs/src/main.c
@@ -288,14 +288,13 @@ static bool background_transfer(const struct device *spi_dev)
 {
 	static const uint8_t tx_buffer[] = "Nordic Semiconductor";
 	static uint8_t rx_buffer[sizeof(tx_buffer)];
-	static const struct spi_cs_control spi_dev_cs_ctrl = {
-		.gpio = GPIO_DT_SPEC_GET(SPI_DEV_NODE, cs_gpios),
-	};
 	static const struct spi_config spi_dev_cfg = {
 		.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(8) |
 			     SPI_TRANSFER_MSB,
 		.frequency = 1000000,
-		.cs = &spi_dev_cs_ctrl
+		.cs = {
+			.gpio = GPIO_DT_SPEC_GET(SPI_DEV_NODE, cs_gpios),
+		},
 	};
 	static const struct spi_buf tx_buf = {
 		.buf = (void *)tx_buffer,

--- a/samples/drivers/spi_bitbang/src/main.c
+++ b/samples/drivers/spi_bitbang/src/main.c
@@ -27,7 +27,7 @@ void test_basic_write_9bit_words(const struct device *dev,
 	config.frequency = 125000;
 	config.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(9);
 	config.slave = 0;
-	config.cs = cs;
+	config.cs = *cs;
 
 	uint16_t buff[5] = { 0x0101, 0x00ff, 0x00a5, 0x0000, 0x0102};
 	int len = 5 * sizeof(buff[0]);
@@ -54,7 +54,7 @@ void test_9bit_loopback_partial(const struct device *dev,
 	config.frequency = 125000;
 	config.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(9);
 	config.slave = 0;
-	config.cs = cs;
+	config.cs = *cs;
 
 	enum { datacount = 5 };
 	uint16_t buff[datacount] = { 0x0101, 0x0102, 0x0003, 0x0004, 0x0105};
@@ -93,7 +93,7 @@ void test_8bit_xfer(const struct device *dev, struct spi_cs_control *cs)
 	config.frequency = 1000000;
 	config.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(8);
 	config.slave = 0;
-	config.cs = cs;
+	config.cs = *cs;
 
 	enum { datacount = 5 };
 	uint8_t buff[datacount] = { 0x01, 0x02, 0x03, 0x04, 0x05};

--- a/tests/boards/mec15xxevb_assy6853/qspi/src/main.c
+++ b/tests/boards/mec15xxevb_assy6853/qspi/src/main.c
@@ -42,9 +42,9 @@ uint8_t buffer_tx_2[] = "abcdef\0";
 static uint8_t safbuf[TEST_BUF_SIZE] __aligned(4);
 static uint8_t safbuf2[TEST_BUF_SIZE] __aligned(4);
 static const struct device *const spi_dev = DEVICE_DT_GET(DT_NODELABEL(spi0));
-struct spi_buf_set tx_bufs, rx_bufs;
-struct spi_buf txb[MAX_TX_BUF], rxb;
-struct spi_config spi_cfg_single, spi_cfg_dual, spi_cfg_quad;
+static struct spi_buf_set tx_bufs, rx_bufs;
+static struct spi_buf txb[MAX_TX_BUF], rxb;
+static struct spi_config spi_cfg_single, spi_cfg_dual, spi_cfg_quad;
 
 
 static void spi_single_init(void)
@@ -53,8 +53,6 @@ static void spi_single_init(void)
 	spi_cfg_single.frequency = TEST_FREQ_HZ;
 	spi_cfg_single.operation = SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB
 		| SPI_WORD_SET(8) | SPI_LINES_SINGLE;
-	spi_cfg_single.slave = 0;
-	spi_cfg_single.cs = NULL;
 
 	zassert_true(device_is_ready(spi_dev), "SPI controller device is not ready");
 }
@@ -281,8 +279,6 @@ static void spi_dual_init(void)
 	spi_cfg_dual.frequency = TEST_FREQ_HZ;
 	spi_cfg_dual.operation = SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB
 		| SPI_WORD_SET(8) | SPI_LINES_DUAL;
-	spi_cfg_dual.slave = 0;
-	spi_cfg_dual.cs = NULL;
 
 	zassert_true(device_is_ready(spi_dev), "SPI controller device is not ready");
 }
@@ -479,8 +475,6 @@ static void test_spi_quad_write(void)
 	spi_cfg_quad.frequency = TEST_FREQ_HZ;
 	spi_cfg_quad.operation = SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB
 		| SPI_WORD_SET(8) | SPI_LINES_QUAD;
-	spi_cfg_quad.slave = 0;
-	spi_cfg_quad.cs = NULL;
 
 	/* write data using spi quad mode */
 	/* send quad write opcode and address using single mode */

--- a/tests/drivers/spi/dt_spec/src/main.c
+++ b/tests/drivers/spi/dt_spec/src/main.c
@@ -22,6 +22,7 @@ ZTEST(spi_dt_spec, test_dt_spec)
 	LOG_DBG("spi_cs.config.cs.gpio.pin = %u", spi_cs.config.cs.gpio.pin);
 
 	zassert_equal(spi_cs.bus, DEVICE_DT_GET(DT_NODELABEL(test_spi_cs)), "");
+	zassert_true(spi_cs_is_gpio_dt(&spi_cs), "");
 	zassert_equal(spi_cs.config.cs.gpio.port, DEVICE_DT_GET(DT_NODELABEL(test_gpio)), "");
 	zassert_equal(spi_cs.config.cs.gpio.pin, 0x10, "");
 
@@ -32,7 +33,7 @@ ZTEST(spi_dt_spec, test_dt_spec)
 	LOG_DBG("spi_no_cs.config.cs.gpio.port = %p", spi_no_cs.config.cs.gpio.port);
 
 	zassert_equal(spi_no_cs.bus, DEVICE_DT_GET(DT_NODELABEL(test_spi_no_cs)), "");
-	zassert_is_null(spi_no_cs.config.cs.gpio.port, "");
+	zassert_false(spi_cs_is_gpio_dt(&spi_no_cs), "");
 }
 
 ZTEST_SUITE(spi_dt_spec, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/spi/dt_spec/src/main.c
+++ b/tests/drivers/spi/dt_spec/src/main.c
@@ -18,21 +18,21 @@ ZTEST(spi_dt_spec, test_dt_spec)
 		SPI_DT_SPEC_GET(DT_NODELABEL(test_spi_dev_cs), 0, 0);
 
 	LOG_DBG("spi_cs.bus = %p", spi_cs.bus);
-	LOG_DBG("spi_cs.config.cs->gpio.port = %p", spi_cs.config.cs->gpio.port);
-	LOG_DBG("spi_cs.config.cs->gpio.pin = %u", spi_cs.config.cs->gpio.pin);
+	LOG_DBG("spi_cs.config.cs.gpio.port = %p", spi_cs.config.cs.gpio.port);
+	LOG_DBG("spi_cs.config.cs.gpio.pin = %u", spi_cs.config.cs.gpio.pin);
 
 	zassert_equal(spi_cs.bus, DEVICE_DT_GET(DT_NODELABEL(test_spi_cs)), "");
-	zassert_equal(spi_cs.config.cs->gpio.port, DEVICE_DT_GET(DT_NODELABEL(test_gpio)), "");
-	zassert_equal(spi_cs.config.cs->gpio.pin, 0x10, "");
+	zassert_equal(spi_cs.config.cs.gpio.port, DEVICE_DT_GET(DT_NODELABEL(test_gpio)), "");
+	zassert_equal(spi_cs.config.cs.gpio.pin, 0x10, "");
 
 	const struct spi_dt_spec spi_no_cs =
 		SPI_DT_SPEC_GET(DT_NODELABEL(test_spi_dev_no_cs), 0, 0);
 
 	LOG_DBG("spi_no_cs.bus = %p", spi_no_cs.bus);
-	LOG_DBG("spi_no_cs.config.cs = %p", spi_no_cs.config.cs);
+	LOG_DBG("spi_no_cs.config.cs.gpio.port = %p", spi_no_cs.config.cs.gpio.port);
 
 	zassert_equal(spi_no_cs.bus, DEVICE_DT_GET(DT_NODELABEL(test_spi_no_cs)), "");
-	zassert_is_null(spi_no_cs.config.cs, "");
+	zassert_is_null(spi_no_cs.config.cs.gpio.port, "");
 }
 
 ZTEST_SUITE(spi_dt_spec, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
As of today it is not possible to use SPI dt-spec macros in C++, something known and documented. The main reason is because `cs` property is initialized using a compound literal, something not supported in C++. This PR takes another approach, that is to not make `cs` a pointer but a struct member. This way, we can perform a regular initialization, at the cost of using extra memory for unused delay/pin/flags if `cs` is not used.

Fixes #56572
Closes #57025