### PR TITLE
drivers: intc: mchp_ecia_xec: Ensure correct device init order

### DIFF
--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -43,6 +43,19 @@ config INTC_INIT_PRIORITY
 	help
 	  Interrupt controller device initialization priority.
 
+if MCHP_ECIA_XEC
+
+config XEC_GIRQ_INIT_PRIORITY
+	int "XEX GIRQ Interrupt controller init priority"
+	default 41
+	help
+	  XEC GIRQ Interrupt controller device initialization priority.
+	  The priority value needs to be greater than INTC_INIT_PRIORITY
+	  So that the XEC GIRQ controllers are initialized after the
+	  xec_ecia.
+
+endif
+
 module = INTC
 module-str = intc
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/interrupt_controller/intc_mchp_ecia_xec.c
+++ b/drivers/interrupt_controller/intc_mchp_ecia_xec.c
@@ -574,7 +574,7 @@ static int xec_ecia_init(const struct device *dev)
 									\
 	DEVICE_DT_DEFINE(n, xec_girq_init_##n,				\
 		 NULL, &xec_data_girq_##n, &xec_config_girq_##n,	\
-		 PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY,		\
+		 PRE_KERNEL_1, CONFIG_XEC_GIRQ_INIT_PRIORITY,		\
 		 NULL);							\
 									\
 	static int xec_girq_init_##n(const struct device *dev)		\


### PR DESCRIPTION
We need to ensure that the XEC GIRQs are initialized after the XEC ECIA device.  Right now we depend on the linker ordering things correctly since everything is at INTC_INIT_PRIORITY priority

Set the XEC GIRQs to 41 so the init priority is one more than INTC_INIT_PRIORITY that is used by xec-ecia.