### PR TITLE
gd32: fix some incorrect implement.

### DIFF
--- a/boards/arm/gd32f470i_eval/gd32f470i_eval.dts
+++ b/boards/arm/gd32f470i_eval/gd32f470i_eval.dts
@@ -96,6 +96,10 @@
 	status = "okay";
 };
 
+&gpioi {
+	status = "okay";
+};
+
 &usart0 {
 	status = "okay";
 	current-speed = <115200>;
@@ -139,7 +143,7 @@
 	status = "okay";
 	pinctrl-0 = <&spi5_default>;
 	pinctrl-names = "default";
-	cs-gpios = <&gpiog 9 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpioi 8 GPIO_ACTIVE_LOW>;
 
 	nor_flash: gd25q16@0 {
 		compatible ="jedec,spi-nor";

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -471,17 +471,19 @@ static void spi_gd32_isr(struct device *dev)
 	struct spi_gd32_data *data = dev->data;
 	int err = 0;
 
-	if ((SPI_STAT(cfg->reg) & SPI_GD32_ERR_MASK) != 0) {
-		err = spi_gd32_get_err(cfg);
-	} else {
+	err = spi_gd32_get_err(cfg);
+	if (err) {
+		spi_gd32_complete(dev, err);
+		return;
+	}
+
+	if (spi_gd32_transfer_ongoing(data)) {
 		err = spi_gd32_frame_exchange(dev);
 	}
 
 	if (err || !spi_gd32_transfer_ongoing(data)) {
 		spi_gd32_complete(dev, err);
 	}
-
-	SPI_STAT(cfg->reg) = 0;
 }
 
 #endif /* SPI_GD32_INTERRUPT */


### PR DESCRIPTION
Two fix in this PR:
  1. change an incorrect `cs-gpios` config for gd32f470i_eval board.
  2. Fix [#56575](https://github.com/zephyrproject-rtos/zephyr/issues/56575).  adjust gd32 spi driver `isr` to avoid enter `exchange` function when un-expected `TBE` interrupt triggered.  

gd32f470i_eval spi config:
![Screenshot from 2023-04-05 23-17-26](https://user-images.githubusercontent.com/40390867/230126304-d2de1e7f-2a49-4611-9d69-521314c8080d.png)