### PR TITLE
soc: xtensa: esp32s3: Add FPU support

### DIFF
--- a/soc/xtensa/esp32s3/Kconfig.soc
+++ b/soc/xtensa/esp32s3/Kconfig.soc
@@ -10,6 +10,7 @@ config SOC_ESP32S3
 	select PINCTRL
 	select XIP
 	select HAS_ESPRESSIF_HAL
+	select CPU_HAS_FPU
 
 if SOC_ESP32S3
 

--- a/tests/kernel/fpu_sharing/generic/testcase.yaml
+++ b/tests/kernel/fpu_sharing/generic/testcase.yaml
@@ -70,3 +70,8 @@ tests:
     slow: true
     tags: fpu kernel
     timeout: 600
+  kernel.fpu_sharing.generic.xtensa:
+    filter: CONFIG_CPU_HAS_FPU
+    arch_allow: xtensa
+    tags: fpu kernel
+    timeout: 600


### PR DESCRIPTION
Enable FPU on esp32s3.
Add xtensa arch to FPU test.