### PR TITLE
arch: xtensa: Fix xtensa error handler

### DIFF
--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -48,6 +48,7 @@ extern void xtensa_arch_except(int reason_p);
 
 #define ARCH_EXCEPT(reason_p) do { \
 	xtensa_arch_except(reason_p); \
+	CODE_UNREACHABLE; \
 } while (false)
 
 /* internal routine documented in C file, needed by IRQ_CONNECT() macro */


### PR DESCRIPTION
Force an early return from exception when a stack check failure is detected at interrupt/exception level. This helps to ensure that ARCH_EXCEPT() does not return.