### PR TITLE
boards: arm: <various>: Fix USB Kconfig

### DIFF
--- a/boards/arm/adafruit_itsybitsy_nrf52840/Kconfig.defconfig
+++ b/boards/arm/adafruit_itsybitsy_nrf52840/Kconfig.defconfig
@@ -27,6 +27,10 @@ config USB_DEVICE_INITIALIZE_AT_BOOT
 
 config SHELL_BACKEND_SERIAL_CHECK_DTR
 	default SHELL
+	depends on UART_LINE_CTRL
+
+config UART_LINE_CTRL
+	default SHELL
 
 config USB_DEVICE_REMOTE_WAKEUP
 	default n

--- a/boards/arm/bl654_usb/Kconfig.defconfig
+++ b/boards/arm/bl654_usb/Kconfig.defconfig
@@ -41,6 +41,10 @@ config USB_DEVICE_INITIALIZE_AT_BOOT
 
 config SHELL_BACKEND_SERIAL_CHECK_DTR
 	default SHELL
+	depends on UART_LINE_CTRL
+
+config UART_LINE_CTRL
+	default SHELL
 
 # Logger cannot use itself to log
 config USB_CDC_ACM_LOG_LEVEL

--- a/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
@@ -40,6 +40,10 @@ config USB_DEVICE_INITIALIZE_AT_BOOT
 
 config SHELL_BACKEND_SERIAL_CHECK_DTR
 	default SHELL
+	depends on UART_LINE_CTRL
+
+config UART_LINE_CTRL
+	default SHELL
 
 config USB_DEVICE_REMOTE_WAKEUP
 	default n

--- a/boards/arm/thingy53_nrf5340/Kconfig.defconfig
+++ b/boards/arm/thingy53_nrf5340/Kconfig.defconfig
@@ -107,6 +107,10 @@ config USB_DEVICE_INITIALIZE_AT_BOOT
 
 config SHELL_BACKEND_SERIAL_CHECK_DTR
 	default SHELL
+	depends on UART_LINE_CTRL
+
+config UART_LINE_CTRL
+	default SHELL
 
 config USB_DEVICE_REMOTE_WAKEUP
 	default n


### PR DESCRIPTION
Boards:

- adafruit_itsybitsy_nrf52840
- bl654_usb
- thingy53_nrf5340
- nrf52840dongle_nrf52840

    Fixes an issue whereby a Kconfig dependency was dropped and
    selects UART_LINE_CTRL in addition by default when shell is
    enabled to alleviate an issue with possible garbage data at boot.
