### PR TITLE
samples: bluetooth: hci_spi: use nrf52840dk

### DIFF
--- a/samples/bluetooth/hci_spi/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/bluetooth/hci_spi/boards/nrf52840dk_nrf52840.overlay
@@ -7,10 +7,10 @@
 &pinctrl {
 	spi1_default_alt: spi1_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIS_SCK, 0, 6)>,
-				<NRF_PSEL(SPIS_MOSI, 0, 5)>,
-				<NRF_PSEL(SPIS_MISO, 0, 4)>,
-				<NRF_PSEL(SPIS_CSN, 0, 3)>;
+			psels = <NRF_PSEL(SPIS_SCK, 0, 31)>,
+				<NRF_PSEL(SPIS_MOSI, 0, 30)>,
+				<NRF_PSEL(SPIS_MISO, 1, 8)>,
+				<NRF_PSEL(SPIS_CSN, 1, 1)>;
 		};
 	};
 };
@@ -26,6 +26,6 @@
 	bt-hci@0 {
 		compatible = "zephyr,bt-hci-spi-slave";
 		reg = <0>;
-		irq-gpios = <&gpio0 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+		irq-gpios = <&gpio1 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 	};
 };

--- a/samples/bluetooth/hci_spi/sample.yaml
+++ b/samples/bluetooth/hci_spi/sample.yaml
@@ -5,8 +5,7 @@ sample:
 tests:
   sample.bluetooth.hci_spi:
     harness: bluetooth
-    platform_allow: 96b_carbon_nrf51 nrf51dk_nrf51422
+    platform_allow: nrf52840dk_nrf52840
     integration_platforms:
-      - 96b_carbon_nrf51
-      - nrf51dk_nrf51422
+      - nrf52840dk_nrf52840
     tags: bluetooth spi


### PR DESCRIPTION
It looks like the sample can no longer run on nRF51 SoCs due to RAM overflow. Update the sample to run on nrf52840dk. Pins have been chosen like this: same pins user by master for SCK/MOSI/MISO, CSN/IRQ pins use free pins on the board (same ones used in regulator-fixed tests).