### PR TITLE
[DNM] west.yaml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -181,7 +181,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 143485e35b8da7d234677d8920a28f5ea03f6d09
+      revision: cdf9de094e29f71b11d1fd7ff48ecc51f94dc8d8
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision **cdf9de094e29f71b11d1fd7ff48ecc51f94dc8d8**

Brings following Zephyr relevant fixes:
  - 827118f2 boot: serial_recovery: Add image hash support
  - f5e7753b boot_serial: support fragmentation for outgoing SMP packets
  - 569b1d63 Update to version 1.10.0-rc1
  - 1090d8ff zephyr: Check zephyr,uart-mcumgr as candidate for serial recovery

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.