### PR TITLE
net: ip: Kconfig for TCP packet allocation timeout

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2016 Intel Corporation.
 # Copyright (c) 2021 Nordic Semiconductor
+# Copyright (c) 2023 Arm Limited (or its affiliates). All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 menu "IP stack"
@@ -493,6 +494,17 @@ config NET_TCP_RECV_QUEUE_TIMEOUT
 	  queued (in this order), and then given to application when we receive
 	  SEQ 2. But if we receive SEQs 5,4,3,7 then the SEQ 7 is discarded
 	  because the list would not be sequential as number 6 is be missing.
+
+config NET_TCP_PKT_ALLOC_TIMEOUT
+	int "How long to wait for a TCP packet allocation (in ms)"
+	depends on NET_TCP
+	default 100
+	range 10 1000
+	help
+	  The TCP network stack allocates packets from the buffers and the
+	  allocation can take some time depending on the situation.
+	  This value indicates how long the stack should wait for the packet to
+	  be allocated, before returning an internal error and trying again.
 
 config NET_TCP_WORKQ_STACK_SIZE
 	int "TCP work queue thread stack size"

--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2019 Intel Corporation
+ * Copyright (c) 2023 Arm Limited (or its affiliates). All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -45,7 +46,7 @@
 #define tcp_free(_ptr) k_free(_ptr)
 #endif
 
-#define TCP_PKT_ALLOC_TIMEOUT K_MSEC(100)
+#define TCP_PKT_ALLOC_TIMEOUT K_MSEC(CONFIG_NET_TCP_PKT_ALLOC_TIMEOUT)
 
 #if defined(CONFIG_NET_TEST_PROTOCOL)
 #define tcp_pkt_clone(_pkt) tp_pkt_clone(_pkt, tp_basename(__FILE__), __LINE__)


### PR DESCRIPTION
TCP packet allocation timeout is currently 100ms, but there are cases where it is not enough and as a side effect, the kernel internals are printing some errors on the log before retrying again, create a Kconfig parameter to be able to tune this value.

I'm currently using a model of cortex-r82 and I'm getting this issue for this path when using zperf as tcp client:

zsock_send
zsock_sendto (z_impl_zsock_sendto)
sock_sendto_vmeth
zsock_sendto_ctx
net_context_sendto
context_sendto
net_tcp_queue_data
tcp_send_queued_data
tcp_send_data
->tcp_pkt_alloc (net_pkt_alloc_with_buffer)
+->pkt_alloc_with_buffer
   net_pkt_alloc_buffer
   ->pkt_alloc_buffer (timeout) 
   ->"Data buffer (%zd) allocation failed."
->conn: %p packet allocation failed, len=%d
