### PR TITLE
net: lwm2m: Remove lwm2m_path_to_string

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
@@ -70,6 +70,9 @@ static union cbor_io_fmt_data{
 	struct cbor_out_fmt_data o;
 } fdio;
 
+static int path_to_string(char *buf, size_t buf_size, const struct lwm2m_obj_path *input,
+			 int level_max);
+
 /*
  * SEND is called from a different context than the rest of the LwM2M functionality
  */
@@ -149,7 +152,7 @@ static int put_basename(struct lwm2m_output_context *out, struct lwm2m_obj_path 
 
 	char *basename = GET_CBOR_FD_NAME(fd);
 
-	len = lwm2m_path_to_string(basename, fd->name_sz, path, LWM2M_PATH_LEVEL_OBJECT_INST);
+	len = path_to_string(basename, fd->name_sz, path, LWM2M_PATH_LEVEL_OBJECT_INST);
 
 	if (len < 0) {
 		return len;
@@ -1054,4 +1057,55 @@ int do_send_op_senml_cbor(struct lwm2m_message *msg, sys_slist_t *lwm2m_path_lis
 	clear_out_fmt_data(msg);
 
 	return ret;
+}
+
+static int path_to_string(char *buf, size_t buf_size, const struct lwm2m_obj_path *input,
+			 int level_max)
+{
+	size_t fpl = 0; /* Length of the formed path */
+	int level;
+	int w;
+
+	if (!buf || buf_size < sizeof("/") || !input) {
+		return -EINVAL;
+	}
+
+	memset(buf, '\0', buf_size);
+
+	level = MIN(input->level, level_max);
+
+	/* Write path element at a time and leave space for the terminating NULL */
+	for (int idx = LWM2M_PATH_LEVEL_NONE; idx <= level; idx++) {
+		switch (idx) {
+		case LWM2M_PATH_LEVEL_NONE:
+			w = snprintk(&(buf[fpl]), buf_size - fpl, "/");
+			break;
+		case LWM2M_PATH_LEVEL_OBJECT:
+			w = snprintk(&(buf[fpl]), buf_size - fpl, "%" PRIu16 "/", input->obj_id);
+			break;
+		case LWM2M_PATH_LEVEL_OBJECT_INST:
+			w = snprintk(&(buf[fpl]), buf_size - fpl, "%" PRIu16 "/",
+				     input->obj_inst_id);
+			break;
+		case LWM2M_PATH_LEVEL_RESOURCE:
+			w = snprintk(&(buf[fpl]), buf_size - fpl, "%" PRIu16 "", input->res_id);
+			break;
+		case LWM2M_PATH_LEVEL_RESOURCE_INST:
+			w = snprintk(&(buf[fpl]), buf_size - fpl, "/%" PRIu16 "",
+				     input->res_inst_id);
+			break;
+		default:
+			__ASSERT_NO_MSG(false);
+			return -EINVAL;
+		}
+
+		if (w < 0 || w >= buf_size - fpl) {
+			return -ENOBUFS;
+		}
+
+		/* Next path element, overwrites terminating NULL */
+		fpl += w;
+	}
+
+	return fpl;
 }

--- a/subsys/net/lib/lwm2m/lwm2m_util.c
+++ b/subsys/net/lib/lwm2m/lwm2m_util.c
@@ -424,57 +424,6 @@ int lwm2m_ftoa(double *input, char *out, size_t outlen, int8_t dec_limit)
 			(val1 == 0 && val2 < 0) ? "-" : "", (long long)val1, buf);
 }
 
-int lwm2m_path_to_string(char *buf, size_t buf_size, const struct lwm2m_obj_path *input,
-			 int level_max)
-{
-	size_t fpl = 0; /* Length of the formed path */
-	int level;
-	int w;
-
-	if (!buf || buf_size < sizeof("/") || !input) {
-		return -EINVAL;
-	}
-
-	memset(buf, '\0', buf_size);
-
-	level = MIN(input->level, level_max);
-
-	/* Write path element at a time and leave space for the terminating NULL */
-	for (int idx = LWM2M_PATH_LEVEL_NONE; idx <= level; idx++) {
-		switch (idx) {
-		case LWM2M_PATH_LEVEL_NONE:
-			w = snprintk(&(buf[fpl]), buf_size - fpl, "/");
-			break;
-		case LWM2M_PATH_LEVEL_OBJECT:
-			w = snprintk(&(buf[fpl]), buf_size - fpl, "%" PRIu16 "/", input->obj_id);
-			break;
-		case LWM2M_PATH_LEVEL_OBJECT_INST:
-			w = snprintk(&(buf[fpl]), buf_size - fpl, "%" PRIu16 "/",
-				     input->obj_inst_id);
-			break;
-		case LWM2M_PATH_LEVEL_RESOURCE:
-			w = snprintk(&(buf[fpl]), buf_size - fpl, "%" PRIu16 "", input->res_id);
-			break;
-		case LWM2M_PATH_LEVEL_RESOURCE_INST:
-			w = snprintk(&(buf[fpl]), buf_size - fpl, "/%" PRIu16 "",
-				     input->res_inst_id);
-			break;
-		default:
-			__ASSERT_NO_MSG(false);
-			return -EINVAL;
-		}
-
-		if (w < 0 || w >= buf_size - fpl) {
-			return -ENOBUFS;
-		}
-
-		/* Next path element, overwrites terminating NULL */
-		fpl += w;
-	}
-
-	return fpl;
-}
-
 uint16_t lwm2m_atou16(const uint8_t *buf, uint16_t buflen, uint16_t *len)
 {
 	uint16_t val = 0U;

--- a/subsys/net/lib/lwm2m/lwm2m_util.h
+++ b/subsys/net/lib/lwm2m/lwm2m_util.h
@@ -24,14 +24,6 @@ int lwm2m_ftoa(double *input, char *out, size_t outlen, int8_t dec_limit);
 
 uint16_t lwm2m_atou16(const uint8_t *buf, uint16_t buflen, uint16_t *len);
 
-/* Forms a string from the path given as a structure
- * Level zero seems to mean NONE, not the root path.
- *
- * returns used buffer space with '\0'
- */
-int lwm2m_path_to_string(char *buf, size_t buf_size, const struct lwm2m_obj_path *input,
-			 int level_max);
-
 int lwm2m_string_to_path(const char *pathstr, struct lwm2m_obj_path *path, char delim);
 
 bool lwm2m_obj_path_equal(const struct lwm2m_obj_path *a, const struct lwm2m_obj_path *b);

--- a/tests/net/lib/lwm2m/engine/src/lwm2m_observation.c
+++ b/tests/net/lib/lwm2m/engine/src/lwm2m_observation.c
@@ -54,9 +54,6 @@ static void assert_path_list_order(sys_slist_t *lwm2m_path_list)
 	uint16_t res_id_max;
 	uint16_t res_inst_id_max;
 
-	char next_path_str[LWM2M_MAX_PATH_STR_SIZE];
-	char prev_path_str[LWM2M_MAX_PATH_STR_SIZE];
-
 	if (sys_slist_is_empty(lwm2m_path_list)) {
 		return;
 	}
@@ -64,11 +61,6 @@ static void assert_path_list_order(sys_slist_t *lwm2m_path_list)
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(lwm2m_path_list, entry, tmp, node) {
 		if (prev) {
 			if (entry->path.level > prev->path.level) {
-
-				lwm2m_path_to_string(next_path_str, sizeof(next_path_str),
-							 &entry->path, entry->path.level);
-				lwm2m_path_to_string(prev_path_str, sizeof(prev_path_str),
-							 &prev->path, prev->path.level);
 
 				bool is_after = false;
 
@@ -93,8 +85,8 @@ static void assert_path_list_order(sys_slist_t *lwm2m_path_list)
 						entry->path.res_inst_id >= prev->path.res_inst_id;
 				}
 
-				zassert_true(is_after, "Next element %s must be before previous %s",
-						 next_path_str, prev_path_str);
+				zassert_true(is_after, "Next element %p must be before previous %p",
+						 entry, prev);
 			} else if (entry->path.level == prev->path.level) {
 
 				if (entry->path.level >= LWM2M_PATH_LEVEL_OBJECT) {
@@ -221,21 +213,6 @@ static void assert_path_list_order(sys_slist_t *lwm2m_path_list)
 		prev = entry;
 	}
 }
-static void print_path_list(sys_slist_t *lwm2m_path_list, const char *name)
-{
-	struct lwm2m_obj_path_list *entry, *tmp;
-
-	if (name != NULL) {
-		TEST_VERBOSE_PRINT("Path List %s:\n", name);
-	}
-
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(lwm2m_path_list, entry, tmp, node) {
-		char buf[LWM2M_MAX_PATH_STR_SIZE];
-
-		lwm2m_path_to_string(buf, LWM2M_MAX_PATH_STR_SIZE, &entry->path, entry->path.level);
-		TEST_VERBOSE_PRINT("- %s\n", buf);
-	}
-}
 
 static void run_insertion_test(char const *insert_path_str[], int insertions_count,
 				   char const *expected_path_str[])
@@ -261,13 +238,10 @@ static void run_insertion_test(char const *insert_path_str[], int insertions_cou
 							&insert_path);
 
 		sprintf(name, "Insertion: %d", i);
-		print_path_list(&lwm2m_path_list, name);
 		zassert_true(ret >= 0, "Insertion #%d failed", i);
 		/* THEN: path order is maintained */
 		assert_path_list_order(&lwm2m_path_list);
 	}
-
-	print_path_list(&lwm2m_path_list, "Final");
 
 	/* AND: final list matches expectation */
 	struct lwm2m_obj_path_list *entry, *tmp;


### PR DESCRIPTION
This function had only one use in SenML CBOR formatter and it contained some specific tweaks, so move the function to be a static member of that module.

Fixes #53674