### PR TITLE
net: lwm2m: Default lifetime is also a minimum accepted lifetime

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -158,7 +158,9 @@ config LWM2M_ENGINE_DEFAULT_LIFETIME
 	default 30
 	range 15 4294967295
 	help
-	  Set the default lifetime (in seconds) for the LWM2M library engine
+	  Set the default lifetime (in seconds) for the LWM2M library engine.
+	  This is also a minimum lifetime that client accepts. If server sets lifetime
+	  less than this value, client automatically raises it.
 
 config LWM2M_SECONDS_TO_UPDATE_EARLY
 	int "LWM2M Registration Update transmission time before timeout"

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -616,6 +616,12 @@ static bool sm_update_lifetime(int srv_obj_inst, uint32_t *lifetime)
 		LOG_INF("Using default lifetime: %u", new_lifetime);
 	}
 
+	if (new_lifetime < CONFIG_LWM2M_ENGINE_DEFAULT_LIFETIME) {
+		new_lifetime = CONFIG_LWM2M_ENGINE_DEFAULT_LIFETIME;
+		lwm2m_set_u32(&LWM2M_OBJ(1, srv_obj_inst, 1), new_lifetime);
+		LOG_INF("Overwrite a server lifetime with default");
+	}
+
 	if (new_lifetime != *lifetime) {
 		*lifetime = new_lifetime;
 		return true;

--- a/tests/net/lib/lwm2m/lwm2m_rd_client/src/stubs.c
+++ b/tests/net/lib/lwm2m/lwm2m_rd_client/src/stubs.c
@@ -55,6 +55,7 @@ DEFINE_FAKE_VALUE_FUNC(int, lwm2m_open_socket, struct lwm2m_ctx *);
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_get_u32, const struct lwm2m_obj_path *, uint32_t *);
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_get_u16, const struct lwm2m_obj_path *, uint16_t *);
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_get_bool, const struct lwm2m_obj_path *, bool *);
+DEFINE_FAKE_VALUE_FUNC(int, lwm2m_set_u32, const struct lwm2m_obj_path *, uint32_t);
 int lwm2m_get_bool_fake_default(const struct lwm2m_obj_path *path, bool *value)
 {
 	*value = false;

--- a/tests/net/lib/lwm2m/lwm2m_rd_client/src/stubs.h
+++ b/tests/net/lib/lwm2m/lwm2m_rd_client/src/stubs.h
@@ -44,6 +44,7 @@ DECLARE_FAKE_VALUE_FUNC(int, lwm2m_open_socket, struct lwm2m_ctx *);
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_get_u32, const struct lwm2m_obj_path *, uint32_t *);
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_get_u16, const struct lwm2m_obj_path *, uint16_t *);
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_get_bool, const struct lwm2m_obj_path *, bool *);
+DECLARE_FAKE_VALUE_FUNC(int, lwm2m_set_u32, const struct lwm2m_obj_path *, uint32_t);
 int lwm2m_get_bool_fake_default(const struct lwm2m_obj_path *path, bool *value);
 
 /* subsys/net/lib/lwm2m/lwm2m_engine.h */


### PR DESCRIPTION
If server or bootstrap writes a lifetime value less than configured default lifetime, client will automatically overwrite the value with default one.

This gives better control for the application where client behaviour is fine tuned on the Kconfig, but default values from bootstrap server cannot be fine-tuned.