### PR TITLE
drivers: serial: stm32U5 uart driver do not toggle the DMA Tx request

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1088,9 +1088,19 @@ static inline void uart_stm32_dma_tx_enable(const struct device *dev)
 
 static inline void uart_stm32_dma_tx_disable(const struct device *dev)
 {
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32u5_dma)
+	ARG_UNUSED(dev);
+
+	/*
+	 * Errata Sheet ES0499 : STM32U575xx and STM32U585xx device errata
+	 * USART does not generate DMA requests after setting/clearing DMAT bit
+	 * (also seen on stm32H5 serie)
+	 */
+#else
 	const struct uart_stm32_config *config = dev->config;
 
 	LL_USART_DisableDMAReq_TX(config->usart);
+#endif /* ! st_stm32u5_dma */
 }
 
 static inline void uart_stm32_dma_rx_enable(const struct device *dev)


### PR DESCRIPTION
Errata sheet of the stm32U5 (ES0499) recommends to avoid clearing the DMAT bit with LL_USART_DisableDMAReq_TX to re-start a DMA transfer on the UART Tx block. The function becomes empty.
This is also seen for stm32H5.

The pb is detected with the tests/drivers/uart/uart_async_api/  running on a stm32u5 target board, when the testcase
uart_async_single_read, test_single_read is sending 1 char then 5 char:
```
	static const uint8_t tx_buf[5] = "test";

	uart_tx(uart_dev, tx_buf, 1, 100 * USEC_PER_MSEC);
	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "first TX_DONE timeout");
	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), -EAGAIN,
		      "Extra RX_RDY received");

	uart_tx(uart_dev, tx_buf, sizeof(tx_buf), 100 * USEC_PER_MSEC);
	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "second TX_DONE timeout");
```
The First uart_tx is done but the second uart_tx is never started (no Irq coming) --> "second  TX_DONE timeout" occurs !

Signed-off-by: Francois Ramu <francois.ramu@st.com>