### PR TITLE
tests: Bluetooth: ascs: Add server initiated ASE state transition tests

### DIFF
--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -28,6 +28,10 @@
 #define test_sink_ase_state_transition_fixture test_ase_state_transition_fixture
 #define test_source_ase_state_transition_fixture test_ase_state_transition_fixture
 
+static const struct bt_codec_qos_pref qos_pref = BT_CODEC_QOS_PREF(true, BT_GAP_LE_PHY_2M,
+								   0x02, 10, 40000, 40000,
+								   40000, 40000);
+
 struct test_ase_state_transition_fixture {
 	struct bt_conn conn;
 	struct bt_bap_stream stream;
@@ -154,29 +158,6 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_releasing)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
 	expect_bt_bap_stream_ops_released_called_once(stream);
-}
-
-ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_streaming)
-{
-	struct bt_bap_stream *stream = &fixture->stream;
-	struct bt_conn *conn = &fixture->conn;
-	uint8_t ase_id = fixture->ase.id;
-	struct bt_iso_chan *chan;
-	int err;
-
-	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
-
-	test_preamble_state_enabling(conn, ase_id, stream);
-
-	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
-	zassert_equal(0, err, "Failed to connect iso: err %d", err);
-
-	err = bt_bap_stream_start(stream);
-	zassert_equal(0, err, "Failed to start stream: err %d", err);
-
-	/* Verification */
-	expect_bt_bap_stream_ops_started_called_once(stream);
-	/* XXX: unicast_server_cb->start is not called for Sink ASE */
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_codec_configured)
@@ -337,6 +318,258 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_qos_configured)
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_server_idle_to_codec_configured)
+{
+	struct bt_codec codec = BT_CODEC_LC3_CONFIG_16_2(BT_AUDIO_LOCATION_FRONT_LEFT,
+							 BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	err = bt_bap_unicast_server_config_ase(conn, stream, &codec, &qos_pref);
+	zassert_false(err < 0, "bt_bap_unicast_server_config_ase returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_config_not_called();
+	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_server_codec_configured_to_codec_configured)
+{
+	struct bt_codec codec = BT_CODEC_LC3_CONFIG_16_2(BT_AUDIO_LOCATION_FRONT_LEFT,
+							 BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	test_preamble_state_codec_configured(conn, ase_id, stream);
+
+	err = bt_bap_stream_reconfig(stream, &codec);
+	zassert_false(err < 0, "bt_bap_stream_reconfig returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SINK, EMPTY);
+	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_server_codec_configured_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	test_preamble_state_codec_configured(conn, ase_id, stream);
+
+	err = bt_bap_stream_release(stream);
+	zassert_false(err < 0, "bt_bap_stream_release returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_released_called_once(stream);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_server_qos_configured_to_codec_configured)
+{
+	struct bt_codec codec = BT_CODEC_LC3_CONFIG_16_2(BT_AUDIO_LOCATION_FRONT_LEFT,
+							 BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	test_preamble_state_qos_configured(conn, ase_id, stream);
+
+	err = bt_bap_stream_reconfig(stream, &codec);
+	zassert_false(err < 0, "bt_bap_stream_reconfig returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SINK, EMPTY);
+	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_server_qos_configured_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	test_preamble_state_qos_configured(conn, ase_id, stream);
+
+	err = bt_bap_stream_release(stream);
+	zassert_false(err < 0, "bt_bap_stream_release returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_released_called_once(stream);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	err = bt_bap_stream_release(stream);
+	zassert_false(err < 0, "bt_bap_stream_release returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_released_called_once(stream);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_enabling)
+{
+	struct bt_codec_data meta[] = {
+		BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
+			      (BT_AUDIO_CONTEXT_TYPE_MEDIA & 0xFFU),
+			      ((BT_AUDIO_CONTEXT_TYPE_MEDIA >> 8) & 0xFFU)),
+	};
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	err = bt_bap_stream_metadata(stream, meta, ARRAY_SIZE(meta));
+	zassert_false(err < 0, "bt_bap_stream_metadata returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
+	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_qos_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	err = bt_bap_stream_disable(stream);
+	zassert_false(err < 0, "bt_bap_stream_disable returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
+	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_streaming)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	struct bt_iso_chan *chan;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
+	zassert_equal(0, err, "Failed to connect iso: err %d", err);
+
+	err = bt_bap_stream_start(stream);
+	zassert_false(err < 0, "bt_bap_stream_start returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_stream_ops_started_called_once(stream);
+	/* XXX: unicast_server_cb->start is not called for Sink ASE */
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_streaming)
+{
+	struct bt_codec_data meta[] = {
+		BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
+			      (BT_AUDIO_CONTEXT_TYPE_MEDIA & 0xFFU),
+			      ((BT_AUDIO_CONTEXT_TYPE_MEDIA >> 8) & 0xFFU)),
+	};
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	struct bt_iso_chan *chan;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, false);
+
+	err = bt_bap_stream_metadata(stream, meta, ARRAY_SIZE(meta));
+	zassert_false(err < 0, "bt_bap_stream_metadata returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
+	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_qos_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	struct bt_iso_chan *chan;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, false);
+
+	err = bt_bap_stream_disable(stream);
+	zassert_false(err < 0, "bt_bap_stream_disable returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
+	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+}
+
+ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	struct bt_iso_chan *chan;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, false);
+
+	err = bt_bap_stream_release(stream);
+	zassert_false(err < 0, "bt_bap_stream_release returned err %d", err);
+
+	/* Client disconnects the ISO */
+	mock_bt_iso_disconnect(chan);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_released_called_once(stream);
 }
 
 static void *test_source_ase_state_transition_setup(void)
@@ -661,4 +894,234 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling_to_
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_stop_called_once(stream);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_server_idle_to_codec_configured)
+{
+	struct bt_codec codec = BT_CODEC_LC3_CONFIG_16_2(BT_AUDIO_LOCATION_FRONT_LEFT,
+							 BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	err = bt_bap_unicast_server_config_ase(conn, stream, &codec, &qos_pref);
+	zassert_false(err < 0, "bt_bap_unicast_server_config_ase returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_config_not_called();
+	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_server_codec_configured_to_codec_configured)
+{
+	struct bt_codec codec = BT_CODEC_LC3_CONFIG_16_2(BT_AUDIO_LOCATION_FRONT_LEFT,
+							 BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_codec_configured(conn, ase_id, stream);
+
+	err = bt_bap_stream_reconfig(stream, &codec);
+	zassert_false(err < 0, "bt_bap_stream_reconfig returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SOURCE, EMPTY);
+	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_server_codec_configured_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_codec_configured(conn, ase_id, stream);
+
+	err = bt_bap_stream_release(stream);
+	zassert_false(err < 0, "bt_bap_stream_release returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_released_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_server_qos_configured_to_codec_configured)
+{
+	struct bt_codec codec = BT_CODEC_LC3_CONFIG_16_2(BT_AUDIO_LOCATION_FRONT_LEFT,
+							 BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_qos_configured(conn, ase_id, stream);
+
+	err = bt_bap_stream_reconfig(stream, &codec);
+	zassert_false(err < 0, "bt_bap_stream_reconfig returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_reconfig_called_once(stream, BT_AUDIO_DIR_SOURCE, EMPTY);
+	expect_bt_bap_stream_ops_configured_called_once(stream, EMPTY);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_server_qos_configured_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_qos_configured(conn, ase_id, stream);
+
+	err = bt_bap_stream_release(stream);
+	zassert_false(err < 0, "bt_bap_stream_release returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_released_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	err = bt_bap_stream_release(stream);
+	zassert_false(err < 0, "bt_bap_stream_release returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_released_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_enabling)
+{
+	struct bt_codec_data meta[] = {
+		BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
+			      (BT_AUDIO_CONTEXT_TYPE_MEDIA & 0xFFU),
+			      ((BT_AUDIO_CONTEXT_TYPE_MEDIA >> 8) & 0xFFU)),
+	};
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	err = bt_bap_stream_metadata(stream, meta, ARRAY_SIZE(meta));
+	zassert_false(err < 0, "bt_bap_stream_metadata returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
+	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_server_enabling_to_disabling)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	err = bt_bap_stream_disable(stream);
+	zassert_false(err < 0, "bt_bap_stream_disable returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_streaming)
+{
+	struct bt_codec_data meta[] = {
+		BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
+			      (BT_AUDIO_CONTEXT_TYPE_MEDIA & 0xFFU),
+			      ((BT_AUDIO_CONTEXT_TYPE_MEDIA >> 8) & 0xFFU)),
+	};
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	struct bt_iso_chan *chan;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, true);
+
+	err = bt_bap_stream_metadata(stream, meta, ARRAY_SIZE(meta));
+	zassert_false(err < 0, "bt_bap_stream_metadata returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_metadata_called_once(stream, EMPTY, EMPTY);
+	expect_bt_bap_stream_ops_metadata_updated_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_disabling)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	struct bt_iso_chan *chan;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, true);
+
+	err = bt_bap_stream_disable(stream);
+	zassert_false(err < 0, "bt_bap_stream_disable returned err %d", err);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
+	expect_bt_bap_stream_ops_disabled_called_once(stream);
+}
+
+ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_releasing)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id = fixture->ase.id;
+	struct bt_iso_chan *chan;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, true);
+
+	err = bt_bap_stream_release(stream);
+	zassert_false(err < 0, "bt_bap_stream_release returned err %d", err);
+
+	/* Client disconnects the ISO */
+	mock_bt_iso_disconnect(chan);
+
+	/* Verification */
+	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_stopped_called_once(stream, EMPTY);
+	expect_bt_bap_stream_ops_released_called_once(stream);
 }


### PR DESCRIPTION
This adds tests for server initiated ASE Operations for Sink and Source ASE.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/56527