### PR TITLE
storage: flash_map list partition labels

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -541,6 +541,11 @@ MCUboot
 Storage
 *******
 
+* Added :kconfig:option:`CONFIG_FLASH_MAP_LABELS`, which will enable runtime access to the labels
+  property of fixed partitions. This option is implied if kconfig:option:`CONFIG_FLASH_MAP_SHELL`
+  is enabled. These labels will be displayed in a separate column when using the ``flash_map list``
+  shell command.
+
 Trusted Firmware-M
 ******************
 

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017 Nordic Semiconductor ASA
  * Copyright (c) 2015 Runtime Inc
+ * Copyright (c) 2023 Sensorfy B.V.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -63,6 +64,10 @@ struct flash_area {
 	size_t fa_size;
 	/** Backing flash device */
 	const struct device *fa_dev;
+#if CONFIG_FLASH_MAP_LABELS
+	/** Partition label if defined in DTS. Otherwise nullptr; */
+	const char *fa_label;
+#endif
 };
 
 /**
@@ -238,11 +243,22 @@ int flash_area_has_driver(const struct flash_area *fa);
 /**
  * Get driver for given flash area.
  *
- * @param fa Flash area.
+ * @param[in] fa Flash area.
  *
  * @return device driver.
  */
 const struct device *flash_area_get_device(const struct flash_area *fa);
+
+#if CONFIG_FLASH_MAP_LABELS
+/**
+ * Get the label property from the device tree
+ *
+ * @param[in] fa Flash area.
+ *
+ * @return The label property if it is defined, otherwise NULL
+ */
+const char *flash_area_label(const struct flash_area *fa);
+#endif
 
 /**
  * Get the value expected to be read when accessing any erased

--- a/subsys/storage/flash_map/Kconfig
+++ b/subsys/storage/flash_map/Kconfig
@@ -18,6 +18,7 @@ if FLASH_MAP
 config FLASH_MAP_SHELL
 	bool "Flash map shell interface"
 	depends on SHELL
+	imply FLASH_MAP_LABELS
 	help
 	  This enables shell commands to list and test flash maps.
 
@@ -33,6 +34,13 @@ config FLASH_AREA_CHECK_INTEGRITY
 	help
 	  If enabled, there will be available the backend to check flash
 	  integrity using SHA-256 verification algorithm.
+
+config FLASH_MAP_LABELS
+	bool "Access flash area labels at runtime"
+	help
+	  If enabled the label property of the flash map can be retrieved
+	  at runtime. The available labels will also be displayed in the
+	  flash_map list shell command.
 
 if FLASH_AREA_CHECK_INTEGRITY
 choice FLASH_AREA_CHECK_INTEGRITY_BACKEND

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2015 Runtime Inc
  * Copyright (c) 2017 Linaro Ltd
  * Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2023 Sensorfy B.V.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -99,6 +100,13 @@ const struct device *flash_area_get_device(const struct flash_area *fa)
 {
 	return fa->fa_dev;
 }
+
+#if CONFIG_FLASH_MAP_LABELS
+const char *flash_area_label(const struct flash_area *fa)
+{
+	return fa->fa_label;
+}
+#endif
 
 uint8_t flash_area_erased_val(const struct flash_area *fa)
 {

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017 Nordic Semiconductor ASA
  * Copyright (c) 2015 Runtime Inc
+ * Copyright (c) 2023 Sensorfy B.V.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,11 +12,20 @@
 #include <zephyr/kernel.h>
 #include <zephyr/storage/flash_map.h>
 
+#if CONFIG_FLASH_MAP_LABELS
 #define FLASH_AREA_FOO(part)							\
 	{.fa_id = DT_FIXED_PARTITION_ID(part),					\
 	 .fa_off = DT_REG_ADDR(part),						\
 	 .fa_dev = DEVICE_DT_GET_OR_NULL(DT_MTD_FROM_FIXED_PARTITION(part)),	\
-	 .fa_size = DT_REG_SIZE(part),},
+	 .fa_size = DT_REG_SIZE(part),						\
+	 .fa_label = DT_PROP_OR(part, label, NULL),	},
+#else
+#define FLASH_AREA_FOO(part)							\
+	{.fa_id = DT_FIXED_PARTITION_ID(part),					\
+	 .fa_off = DT_REG_ADDR(part),						\
+	 .fa_dev = DEVICE_DT_GET_OR_NULL(DT_MTD_FROM_FIXED_PARTITION(part)),	\
+	 .fa_size = DT_REG_SIZE(part), },
+#endif
 
 #define FOREACH_PARTITION(n) DT_FOREACH_CHILD(DT_DRV_INST(n), FLASH_AREA_FOO)
 

--- a/subsys/storage/flash_map/flash_map_shell.c
+++ b/subsys/storage/flash_map/flash_map_shell.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Intel Corporation
- *
+ * Copyright (c) 2023 Sensorfy B.V.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,19 +23,35 @@ extern const struct flash_area *flash_map;
 static void fa_cb(const struct flash_area *fa, void *user_data)
 {
 	struct shell *sh = user_data;
+#if CONFIG_FLASH_MAP_LABELS
+	const char *fa_label = flash_area_label(fa);
 
-	shell_print(sh, "%2d   0x%0*"PRIxPTR"   %-26s  0x%-10x 0x%-12x",
-		    (int)fa->fa_id, sizeof(uintptr_t) * 2, (uintptr_t)fa->fa_dev, fa->fa_dev->name,
-		    (uint32_t) fa->fa_off, fa->fa_size);
+	if (fa_label == NULL) {
+		fa_label = "-";
+	}
+	shell_print(sh, "%2d   0x%0*" PRIxPTR "   %-26s  %-24.24s  0x%-10x 0x%-12x", (int)fa->fa_id,
+		    sizeof(uintptr_t) * 2, (uintptr_t)fa->fa_dev, fa->fa_dev->name, fa_label,
+		    (uint32_t)fa->fa_off, fa->fa_size);
+#else
+	shell_print(sh, "%2d   0x%0*" PRIxPTR "   %-26s  0x%-10x 0x%-12x", (int)fa->fa_id,
+		    sizeof(uintptr_t) * 2, (uintptr_t)fa->fa_dev, fa->fa_dev->name,
+		    (uint32_t)fa->fa_off, fa->fa_size);
+#endif
 }
 
-static int cmd_flash_map_list(const struct shell *sh, size_t argc,
-			      char **argv)
+static int cmd_flash_map_list(const struct shell *sh, size_t argc, char **argv)
 {
+#if CONFIG_FLASH_MAP_LABELS
 	shell_print(sh, "ID | Device     | Device Name               "
-		    "|   Offset   |   Size");
+			"| Label                   | Offset     | Size");
+	shell_print(sh, "--------------------------------------------"
+			"-----------------------------------------------");
+#else
+	shell_print(sh, "ID | Device     | Device Name               "
+			"| Offset     | Size");
 	shell_print(sh, "-----------------------------------------"
-		    "------------------------------");
+			"------------------------------");
+#endif
 	flash_area_foreach(fa_cb, (struct shell *)sh);
 	return 0;
 }


### PR DESCRIPTION
Add the partition labels from the device tree fixed flash partitions as a column to the `flash_map list` shell command. If no label is defined, a `-` is used to aid with parsing with regex. 

The use case is runtime identification of partitions, which does not rely on the order. This allows shell users (especially scripts) to interact with specific partitions. 

The new output of `flash_map list` looks like 
```
ID | Device     | Device Name               | Label                   |   Offset   |   Size
-------------------------------------------------------------------------------------------
 0   0x0001654c   flash-controller@4001e000   mcuboot                   0x0          0xc000        
 1   0x0001654c   flash-controller@4001e000   image-0                   0xc000       0x76000       
 2   0x0001654c   flash-controller@4001e000   image-1                   0x82000      0x76000
```     

Signed-off-by: Maurits Fassaert<maurits.fassaert@sensorfy.ai>