### PR TITLE
tests: iterable_sections: Add missing zephyr_iterable_section

### DIFF
--- a/tests/misc/iterable_sections/CMakeLists.txt
+++ b/tests/misc/iterable_sections/CMakeLists.txt
@@ -8,4 +8,9 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
 zephyr_linker_sources(DATA_SECTIONS sections-ram.ld)
+zephyr_iterable_section(NAME test_ram GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
+zephyr_iterable_section(NAME test_ram2 GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
+
 zephyr_linker_sources(SECTIONS sections-rom.ld)
+zephyr_iterable_section(NAME test_rom KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
+zephyr_iterable_section(NAME test_rom2 KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)


### PR DESCRIPTION
As the test is for iterable sections, we need to utilize zephyr_iterable_section for targets that need linker script generation like arm-clang.

So add zephyr_iterable_section() for the RAM & ROM sections that the testcases utilizes.