### PR TITLE
board: teensy: improve on-board SPI flash support

### DIFF
--- a/boards/arm/teensy4/teensy40.dts
+++ b/boards/arm/teensy4/teensy40.dts
@@ -8,6 +8,8 @@
 
 #include <nxp/nxp_rt1060.dtsi>
 #include "teensy4-pinctrl.dtsi"
+#include <freq.h>
+#include <mem.h>
 
 / {
 	model = "PJRC TEENSY 4.0 board";
@@ -18,10 +20,13 @@
 	};
 
 	chosen {
+		zephyr,flash-controller = &w25q16jvuxim;
+		zephyr,flash = &w25q16jvuxim;
 		zephyr,sram = &ocram;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart6; /* Teensy Pins 0(RX1) 1(TX1) */
+		zephyr,shell-uart = &lpuart6;
 		zephyr,canbus = &flexcan1; /* Teensy Pins 23(CRX1) 22(CTX1) */
 	};
 
@@ -35,15 +40,20 @@
 };
 
 &flexspi {
-	reg = <0x402a8000 0x4000>, <0x60000000 0x200000>;
+	status = "okay";
+
+	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(2)>;
 	/* WINBOND flash memory*/
 	w25q16jvuxim: w25q16jvuxim@0 {
-		compatible = "winbond,w25q16jvuxim";
-		size = <16777208>;
+		compatible = "nxp,imx-flexspi-nor";
+		size = <DT_SIZE_M(2 * 8)>;
 		reg = <0>;
-		spi-max-frequency = <133000000>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
 		jedec-id = [ef 40 15];
+
+		erase-block-size = <4096>;
+		write-block-size = <1>;
 	};
 };
 

--- a/boards/arm/teensy4/teensy41.dts
+++ b/boards/arm/teensy4/teensy41.dts
@@ -6,17 +6,31 @@
 
 #include "teensy40.dts"
 
+/ {
+	model = "PJRC TEENSY 4.1 board";
+
+	chosen {
+		zephyr,flash-controller = &w25q64jvxgim;
+		zephyr,flash = &w25q64jvxgim;
+	};
+};
+
 /delete-node/ &w25q16jvuxim;
 &flexspi {
-	reg = < 0x402a8000 0x4000 >, < 0x60000000 0x800000 >;
+	status = "okay";
+
+	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	/* WINBOND flash memory*/
 	w25q64jvxgim: w25q64jvxgim@0 {
-		compatible = "winbond,w25q64jvxgim";
-		size = < 8388607 >;
-		reg = < 0 >;
-		spi-max-frequency = < 133000000 >;
+		compatible = "nxp,imx-flexspi-nor";
+		size = <DT_SIZE_M(8 * 8)>;
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(133)>;
 		status = "okay";
-		jedec-id = [ ef 70 17 ];
+		jedec-id = [ef 70 17];
+
+		erase-block-size = <4096>;
+		write-block-size = <1>;
 	};
 };
 


### PR DESCRIPTION
This PR is a followup to the discussion that happened in #55341

fixes: 29cc07efb - board: teensy: drop spi-nor from the flash nodes

The mentioned commit removed any sort of driver for the on board SPI flash / program region for the teensy4 boards. Due to this builds failed as the available flash size / default program region size would automatically be set to 0B.

With this patch the SPI driver has been updated to follow the mimxrt1060_evk reference implementation.

Additional fixes include:
- changing size from bytes to bits for (teensy41)
- correcting of by one errors in size property
- explicitly stating write and erase block size