### PR TITLE
drivers: regulator: allow non-thread-safe reference counting

### DIFF
--- a/drivers/regulator/Kconfig
+++ b/drivers/regulator/Kconfig
@@ -8,6 +8,13 @@ menuconfig REGULATOR
 
 if REGULATOR
 
+config REGULATOR_THREAD_SAFE_REFCNT
+	bool "Thread-safe reference counting"
+	depends on MULTITHREADING
+	default y
+	help
+	  When enabled, regulator reference counting is thread-safe.
+
 config REGULATOR_SHELL
 	bool "Regulator shell"
 	default y

--- a/drivers/regulator/regulator_common.c
+++ b/drivers/regulator/regulator_common.c
@@ -9,7 +9,9 @@ void regulator_common_data_init(const struct device *dev)
 {
 	struct regulator_common_data *data = dev->data;
 
+#ifdef CONFIG_REGULATOR_THREAD_SAFE_REFCNT
 	(void)k_mutex_init(&data->lock);
+#endif
 	data->refcnt = 0;
 }
 
@@ -88,7 +90,9 @@ int regulator_enable(const struct device *dev)
 		return 0;
 	}
 
+#ifdef CONFIG_REGULATOR_THREAD_SAFE_REFCNT
 	(void)k_mutex_lock(&data->lock, K_FOREVER);
+#endif
 
 	data->refcnt++;
 
@@ -99,7 +103,9 @@ int regulator_enable(const struct device *dev)
 		}
 	}
 
+#ifdef CONFIG_REGULATOR_THREAD_SAFE_REFCNT
 	k_mutex_unlock(&data->lock);
+#endif
 
 	return ret;
 }
@@ -113,9 +119,13 @@ bool regulator_is_enabled(const struct device *dev)
 	if ((config->flags & REGULATOR_ALWAYS_ON) != 0U) {
 		enabled = true;
 	} else {
+#ifdef CONFIG_REGULATOR_THREAD_SAFE_REFCNT
 		(void)k_mutex_lock(&data->lock, K_FOREVER);
+#endif
 		enabled = data->refcnt != 0;
+#ifdef CONFIG_REGULATOR_THREAD_SAFE_REFCNT
 		k_mutex_unlock(&data->lock);
+#endif
 	}
 
 	return enabled;
@@ -138,7 +148,9 @@ int regulator_disable(const struct device *dev)
 		return 0;
 	}
 
+#ifdef CONFIG_REGULATOR_THREAD_SAFE_REFCNT
 	(void)k_mutex_lock(&data->lock, K_FOREVER);
+#endif
 
 	data->refcnt--;
 
@@ -149,7 +161,9 @@ int regulator_disable(const struct device *dev)
 		}
 	}
 
+#ifdef CONFIG_REGULATOR_THREAD_SAFE_REFCNT
 	k_mutex_unlock(&data->lock);
+#endif
 
 	return ret;
 }

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -20,7 +20,9 @@
 
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
+#ifdef CONFIG_REGULATOR_THREAD_SAFE_REFCNT
 #include <zephyr/kernel.h>
+#endif
 #include <zephyr/sys/util_macro.h>
 
 #ifdef __cplusplus
@@ -182,8 +184,10 @@ struct regulator_common_config {
  * This structure **must** be placed first in the driver's data structure.
  */
 struct regulator_common_data {
-	/** Lock */
+#if defined(CONFIG_REGULATOR_THREAD_SAFE_REFCNT) || defined(__DOXYGEN__)
+	/** Lock (only if @kconfig{CONFIG_REGULATOR_THREAD_SAFE_REFCNT}=y) */
 	struct k_mutex lock;
+#endif
 	/** Reference count */
 	int refcnt;
 };

--- a/tests/drivers/regulator/api/testcase.yaml
+++ b/tests/drivers/regulator/api/testcase.yaml
@@ -7,3 +7,10 @@ tests:
     platform_allow: native_posix native_posix_64
     integration_platforms:
       - native_posix
+  drivers.regulator.api.nothreadsaferefcnt:
+    tags: drivers regulator
+    platform_allow: native_posix native_posix_64
+    integration_platforms:
+      - native_posix
+    extra_configs:
+      - CONFIG_REGULATOR_THREAD_SAFE_REFCNT=n


### PR DESCRIPTION
In some cases, it may be desirable to not have thread-safe reference counting. For example, when CONFIG_MULTITHREADING=n.