### PR TITLE
MAINTAINERS: move release notes to release section

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -563,6 +563,8 @@ Documentation:
     - doc/known-warnings.txt
     - doc/templates/sample.tmpl
     - doc/templates/board.tmpl
+  files-exclude:
+    - doc/releases/release-notes-*
   labels:
     - "area: Documentation"
 
@@ -587,6 +589,7 @@ Release Notes:
   status: maintained
   maintainers:
     - nashif
+    - jgl-meta
   files:
     - doc/releases/release-notes-*
   labels:


### PR DESCRIPTION
Move files related to release notes to the release section.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
