### PR TITLE
Bluetooth: logging: don't imply LOG_FUNC_NAME_PREFIX_*

### DIFF
--- a/subsys/bluetooth/Kconfig.logging
+++ b/subsys/bluetooth/Kconfig.logging
@@ -6,10 +6,6 @@
 menuconfig BT_LOG
 	bool "Bluetooth logging"
 	default y if LOG && BT
-	imply LOG_FUNC_NAME_PREFIX_INF
-	imply LOG_FUNC_NAME_PREFIX_WRN
-	imply LOG_FUNC_NAME_PREFIX_ERR
-	imply LOG_FUNC_NAME_PREFIX_DBG
 	select BT_LOG_LEGACY
 
 if BT_LOG


### PR DESCRIPTION
By default there is only `CONFIG_LOG_FUNC_NAME_PREFIX_DBG=y` enabled. When
both Bluetooth (`CONFIG_BT=y`) and logging (`CONFIG_LOG=y`) subsystems are
enabled, then other `CONFIG_LOG_FUNC_NAME_PREFIX_{INF,WRN,ERR}=y` options are
pulled in as well using an `imply` Kconfig command indirectly from
`CONFIG_BT_LOG`. This behavior was introduced recently as part of
commit af01a0f31398 ("Bluetooth: Logging: Move all logging symbols
together") with no explicit reason provided.

Pulling in `LOG_FUNC_NAME_PREFIX_*` options automatically with (`CONFIG_BT=y && CONFIG_LOG=y`)
blows up flash usage. As an example of downstream project
(nRF52840-based, with Bluetooth and WiFi connectivity), it increases flash
usage from 473668 bytes to 487856 bytes. This seems "only" 3% difference,
but this is actually a lot when there is no good reason why this happens.
Downstream users quite often compare flash sizes of subsequent Zephyr
releases and this 3% footprint increase might be a blocker at some point.
Additionally, it is not trivial to find the root cause of footprint
increase for most (non-expert) users.

The reason why there is so much footprint overhead because of
`CONFIG_LOG_FUNC_NAME_PREFIX_*=y` is because each function in the
codebase (be it Zephyr or downstream application) that contains logging
macros (`LOG_{DBG,INF,WRN,ERR}()`) is bloated because the function name has
to be included in the output image.

Remove `imply LOG_FUNC_NAME_PREFIX_*` commands from `menuconfig BT_LOG`
option, so that flash usage does not increase too much. Those logging
options are not enabled by other subsystems, so Bluetooth should not be an
exception here.