### PR TITLE
sys: util: force Zephyr BIT/MIN/MAX/CLAMP definitions

### DIFF
--- a/drivers/counter/counter_esp32_rtc.c
+++ b/drivers/counter/counter_esp32_rtc.c
@@ -6,25 +6,20 @@
 
 #define DT_DRV_COMPAT espressif_esp32_rtc_timer
 
-/*
- * Include esp-idf headers first to avoid
- * redefining BIT() macro
- */
-#include "soc/rtc_cntl_reg.h"
-#include "soc/rtc.h"
-
 #include <zephyr/device.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/kernel.h>
-
 #if defined(CONFIG_SOC_ESP32C3)
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 #else
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #endif
-
 #include <zephyr/logging/log.h>
+
+#include <soc/rtc_cntl_reg.h>
+#include <soc/rtc.h>
+
 LOG_MODULE_REGISTER(esp32_counter_rtc, CONFIG_COUNTER_LOG_LEVEL);
 
 #if defined(CONFIG_SOC_ESP32C3)

--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -6,14 +6,8 @@
 
 #define DT_DRV_COMPAT espressif_esp32_timer
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include <soc/rtc_cntl_reg.h>
-#include <soc/timer_group_reg.h>
-#include <driver/periph_ctrl.h>
-#include <soc/periph_defs.h>
-#include <hal/timer_types.h>
-#include <hal/timer_hal.h>
 #include <string.h>
+
 #include <zephyr/drivers/counter.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/kernel.h>
@@ -24,6 +18,14 @@
 #endif
 #include <zephyr/device.h>
 #include <zephyr/logging/log.h>
+
+#include <driver/periph_ctrl.h>
+#include <hal/timer_types.h>
+#include <hal/timer_hal.h>
+#include <soc/periph_defs.h>
+#include <soc/rtc_cntl_reg.h>
+#include <soc/timer_group_reg.h>
+
 LOG_MODULE_REGISTER(esp32_counter, CONFIG_COUNTER_LOG_LEVEL);
 
 #ifdef CONFIG_SOC_ESP32C3

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -7,16 +7,8 @@
 
 #define DT_DRV_COMPAT espressif_esp32_gpio
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include <soc/gpio_reg.h>
-#include <soc/io_mux_reg.h>
-#include <soc/soc.h>
-#include <hal/gpio_ll.h>
-#include <esp_attr.h>
-#include <hal/rtc_io_hal.h>
-
-#include <soc.h>
 #include <errno.h>
+
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/espressif-esp32-gpio.h>
@@ -27,10 +19,17 @@
 #endif
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
-
 #include <zephyr/drivers/gpio/gpio_utils.h>
-
 #include <zephyr/logging/log.h>
+
+#include <esp_attr.h>
+#include <hal/gpio_ll.h>
+#include <hal/rtc_io_hal.h>
+#include <soc.h>
+#include <soc/gpio_reg.h>
+#include <soc/io_mux_reg.h>
+#include <soc/soc.h>
+
 LOG_MODULE_REGISTER(gpio_esp32, CONFIG_LOG_DEFAULT_LEVEL);
 
 #ifdef CONFIG_SOC_ESP32C3

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -7,24 +7,24 @@
 
 #define DT_DRV_COMPAT espressif_esp32_i2c
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include <esp32/rom/gpio.h>
-#include <soc/gpio_sig_map.h>
-#include <hal/i2c_ll.h>
-#include <hal/i2c_hal.h>
-#include <hal/gpio_hal.h>
-
-#include <soc.h>
 #include <errno.h>
+#include <string.h>
+
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/util.h>
-#include <string.h>
-
 #include <zephyr/logging/log.h>
+
+#include <esp32/rom/gpio.h>
+#include <hal/i2c_ll.h>
+#include <hal/i2c_hal.h>
+#include <hal/gpio_hal.h>
+#include <soc.h>
+#include <soc/gpio_sig_map.h>
+
 LOG_MODULE_REGISTER(i2c_esp32, CONFIG_I2C_LOG_LEVEL);
 
 #include "i2c-priv.h"

--- a/drivers/pinctrl/pinctrl_esp32.c
+++ b/drivers/pinctrl/pinctrl_esp32.c
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include <hal/gpio_ll.h>
-#include <hal/rtc_io_hal.h>
-
-#include <soc.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/pinctrl/pinctrl_esp32_common.h>
+
+#include <soc.h>
+#include <hal/gpio_ll.h>
+#include <hal/rtc_io_hal.h>
 
 #ifdef CONFIG_SOC_ESP32C3
 /* gpio structs in esp32c3 series are different from xtensa ones */

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -7,19 +7,19 @@
 
 #define DT_DRV_COMPAT espressif_esp32_ledc
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include <hal/ledc_hal.h>
-#include <hal/ledc_types.h>
-
-#include <soc.h>
 #include <errno.h>
 #include <string.h>
+
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
-
 #include <zephyr/logging/log.h>
+
+#include <hal/ledc_hal.h>
+#include <hal/ledc_types.h>
+#include <soc.h>
+
 LOG_MODULE_REGISTER(pwm_ledc_esp32, CONFIG_PWM_LOG_LEVEL);
 
 struct pwm_ledc_esp32_data {

--- a/drivers/sensor/pcnt_esp32/pcnt_esp32.c
+++ b/drivers/sensor/pcnt_esp32/pcnt_esp32.c
@@ -6,14 +6,9 @@
 
 #define DT_DRV_COMPAT espressif_esp32_pcnt
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include <hal/pcnt_hal.h>
-#include <hal/pcnt_ll.h>
-#include <hal/pcnt_types.h>
-
-#include <soc.h>
 #include <errno.h>
 #include <string.h>
+
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/pinctrl.h>
@@ -21,8 +16,13 @@
 #ifdef CONFIG_PCNT_ESP32_TRIGGER
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #endif /* CONFIG_PCNT_ESP32_TRIGGER */
-
 #include <zephyr/logging/log.h>
+
+#include <hal/pcnt_hal.h>
+#include <hal/pcnt_ll.h>
+#include <hal/pcnt_types.h>
+#include <soc.h>
+
 LOG_MODULE_REGISTER(pcnt_esp32, CONFIG_SENSOR_LOG_LEVEL);
 
 #define PCNT_INTR_UNIT_0  BIT(0)

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -6,7 +6,25 @@
 
 #define DT_DRV_COMPAT espressif_esp32_uart
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
+#include <errno.h>
+
+#include <zephyr/device.h>
+#ifdef CONFIG_UART_ASYNC_API
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/dma/dma_esp32.h>
+#include <zephyr/dt-bindings/clock/esp32c3_clock.h>
+#endif
+#ifndef CONFIG_SOC_ESP32C3
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+#else
+#include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
+#endif
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
 /* TODO: include w/o prefix */
 #ifdef CONFIG_SOC_ESP32
 #include <esp32/rom/ets_sys.h>
@@ -23,34 +41,17 @@
 #include <esp32c3/rom/ets_sys.h>
 #include <esp32c3/rom/gpio.h>
 #ifdef CONFIG_UART_ASYNC_API
-#include <zephyr/drivers/dma.h>
-#include <zephyr/drivers/dma/dma_esp32.h>
 #include <hal/uhci_ll.h>
-#include <zephyr/dt-bindings/clock/esp32c3_clock.h>
 #endif
 #endif
-#include <soc/uart_struct.h>
+#include <esp_attr.h>
 #include <hal/uart_ll.h>
 #include <hal/uart_hal.h>
 #include <hal/uart_types.h>
-
-#include <zephyr/drivers/pinctrl.h>
-
-#include <soc/uart_reg.h>
-#include <zephyr/device.h>
 #include <soc.h>
-#include <zephyr/drivers/uart.h>
+#include <soc/uart_struct.h>
+#include <soc/uart_reg.h>
 
-#ifndef CONFIG_SOC_ESP32C3
-#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
-#else
-#include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
-#endif
-#include <zephyr/drivers/clock_control.h>
-#include <errno.h>
-#include <zephyr/sys/util.h>
-#include <esp_attr.h>
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uart_esp32, CONFIG_UART_LOG_LEVEL);
 
 #ifdef CONFIG_SOC_ESP32C3

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -6,28 +6,28 @@
 
 #define DT_DRV_COMPAT espressif_esp32_spi
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include <hal/spi_hal.h>
-#include <esp_attr.h>
+#include "spi_context.h"
+#include "spi_esp32_spim.h"
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(esp32_spi, CONFIG_SPI_LOG_LEVEL);
-
-#include <soc.h>
-#include <soc/soc_memory_types.h>
 #include <zephyr/drivers/spi.h>
 #ifndef CONFIG_SOC_ESP32C3
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #else
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 #endif
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/logging/log.h>
+
+#include <esp_attr.h>
 #ifdef SOC_GDMA_SUPPORTED
 #include <hal/gdma_hal.h>
 #include <hal/gdma_ll.h>
 #endif
-#include <zephyr/drivers/clock_control.h>
-#include "spi_context.h"
-#include "spi_esp32_spim.h"
+#include <hal/spi_hal.h>
+#include <soc.h>
+#include <soc/soc_memory_types.h>
+
+LOG_MODULE_REGISTER(esp32_spi, CONFIG_SPI_LOG_LEVEL);
 
 #ifdef CONFIG_SOC_ESP32C3
 #define ISR_HANDLER isr_handler_t

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -6,13 +6,9 @@
 
 #define DT_DRV_COMPAT espressif_esp32_watchdog
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include <soc/rtc_cntl_reg.h>
-#include <soc/timer_group_reg.h>
-#include <hal/mwdt_ll.h>
-#include <hal/wdt_hal.h>
-
 #include <string.h>
+
+#include <zephyr/device.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/drivers/clock_control.h>
 #ifndef CONFIG_SOC_ESP32C3
@@ -20,9 +16,13 @@
 #else
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 #endif
-#include <zephyr/device.h>
-
 #include <zephyr/logging/log.h>
+
+#include <hal/mwdt_ll.h>
+#include <hal/wdt_hal.h>
+#include <soc/rtc_cntl_reg.h>
+#include <soc/timer_group_reg.h>
+
 LOG_MODULE_REGISTER(wdt_esp32, CONFIG_WDT_LOG_LEVEL);
 
 #ifdef CONFIG_SOC_ESP32C3

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -267,7 +267,6 @@ extern "C" {
 #define ceiling_fraction(numerator, divider) __DEPRECATED_MACRO \
 	DIV_ROUND_UP(numerator, divider)
 
-#ifndef MAX
 /**
  * @brief Obtain the maximum of two values.
  *
@@ -280,9 +279,7 @@ extern "C" {
  * @returns Maximum value of @p a and @p b.
  */
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
-#endif
 
-#ifndef MIN
 /**
  * @brief Obtain the minimum of two values.
  *
@@ -295,9 +292,7 @@ extern "C" {
  * @returns Minimum value of @p a and @p b.
  */
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
-#endif
 
-#ifndef CLAMP
 /**
  * @brief Clamp a value to a given range.
  *
@@ -311,7 +306,6 @@ extern "C" {
  * @returns Clamped value.
  */
 #define CLAMP(val, low, high) (((val) <= (low)) ? (low) : MIN(val, high))
-#endif
 
 /**
  * @brief Checks if a value is within range.

--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -33,7 +33,6 @@ extern "C" {
  */
 #include <zephyr/sys/util_internal.h>
 
-#ifndef BIT
 #if defined(_ASMLANGUAGE)
 #define BIT(n)  (1 << (n))
 #else
@@ -42,7 +41,6 @@ extern "C" {
  * assembly language).
  */
 #define BIT(n)  (1UL << (n))
-#endif
 #endif
 
 /** @brief 64-bit unsigned integer with bit position @p _n set. */

--- a/soc/riscv/esp32c3/loader.c
+++ b/soc/riscv/esp32c3/loader.c
@@ -4,16 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <esp32c3/rom/cache.h>
-#include "soc/cache_memory.h"
-#include "soc/extmem_reg.h"
-#include <bootloader_flash_priv.h>
+#include <stdlib.h>
 
 #include <zephyr/kernel.h>
-#include <soc.h>
 #include <zephyr/storage/flash_map.h>
+
+#include <bootloader_flash_priv.h>
+#include <esp32c3/rom/cache.h>
 #include <esp_log.h>
-#include <stdlib.h>
+#include <soc.h>
+#include <soc/cache_memory.h>
+#include <soc/extmem_reg.h>
 
 #ifdef CONFIG_BOOTLOADER_MCUBOOT
 #define HDR_ATTR __attribute__((section(".entry_addr"))) __attribute__((used))

--- a/soc/riscv/esp32c3/soc.c
+++ b/soc/riscv/esp32c3/soc.c
@@ -4,26 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
+#include <string.h>
+
+#include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
+#include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
+
+#include <kernel_internal.h>
+#include <esp_cpu.h>
+#include <esp_timer.h>
+#include <esp_spi_flash.h>
+#include <esp_clk_internal.h>
+#include <hal/soc_ll.h>
+#include <soc.h>
+#include <soc/cache_memory.h>
+#include <soc/gpio_reg.h>
+#include <soc/interrupt_reg.h>
 #include <soc/rtc_cntl_reg.h>
 #include <soc/timer_group_reg.h>
-#include <soc/gpio_reg.h>
 #include <soc/syscon_reg.h>
 #include <soc/system_reg.h>
-#include <soc/cache_memory.h>
-#include "hal/soc_ll.h"
-#include "esp_cpu.h"
-#include "esp_timer.h"
-#include "esp_spi_flash.h"
-#include "esp_clk_internal.h"
-#include <soc/interrupt_reg.h>
-#include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
-
-#include <zephyr/kernel_structs.h>
-#include <kernel_internal.h>
-#include <string.h>
-#include <zephyr/toolchain/gcc.h>
-#include <soc.h>
 
 /*
  * This is written in C rather than assembly since, during the port bring up,

--- a/soc/xtensa/esp32/esp32-mp.c
+++ b/soc/xtensa/esp32/esp32-mp.c
@@ -4,18 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include "soc/dport_reg.h"
-#include "soc/gpio_periph.h"
-#include "soc/rtc_periph.h"
-
-#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
-#include <soc.h>
-#include <ksched.h>
 #include <zephyr/device.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
-#include <zephyr/kernel_structs.h>
+
+#include <soc.h>
+#include <soc/dport_reg.h>
+#include <soc/gpio_periph.h>
+#include <soc/rtc_periph.h>
 
 #define Z_REG(base, off) (*(volatile uint32_t *)((base) + (off)))
 

--- a/soc/xtensa/esp32/soc.c
+++ b/soc/xtensa/esp32/soc.c
@@ -4,35 +4,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include "soc.h"
-#include <soc/rtc_cntl_reg.h>
-#include <soc/timer_group_reg.h>
+#include <string.h>
+
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+#include <zephyr/kernel.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/toolchain.h>
+
+#include <kernel_internal.h>
+#include <esp_private/system_internal.h>
+#include <esp32/rom/cache.h>
+#include <esp_spi_flash.h>
+#include <esp_err.h>
+#include <esp_timer.h>
+#include <esp32/spiram.h>
+#include <esp_app_format.h>
+#ifndef CONFIG_SOC_ESP32_NET
+#include <esp_clk_internal.h>
+#endif
+#include <hal/soc_ll.h>
+#include <soc.h>
+#include <soc/cpu.h>
+#include <soc/gpio_periph.h>
+#include <soc/timer_group_reg.h>
+#include <soc/rtc_cntl_reg.h>
 #include <xtensa/config/core-isa.h>
 #include <xtensa/corebits.h>
-
-#include <zephyr/kernel_structs.h>
-#include <string.h>
-#include <zephyr/toolchain/gcc.h>
-#include <zephyr/types.h>
-#include <zephyr/linker/linker-defs.h>
-#include <kernel_internal.h>
-
-#include "esp_private/system_internal.h"
-#include "esp32/rom/cache.h"
-#include "hal/soc_ll.h"
-#include "soc/cpu.h"
-#include "soc/gpio_periph.h"
-#include "esp_spi_flash.h"
-#include "esp_err.h"
-#include "esp_timer.h"
-#include "esp32/spiram.h"
-#include "esp_app_format.h"
-#ifndef CONFIG_SOC_ESP32_NET
-#include "esp_clk_internal.h"
-#endif
-#include <zephyr/sys/printk.h>
 
 extern void z_cstart(void);
 

--- a/soc/xtensa/esp32_net/soc.c
+++ b/soc/xtensa/esp32_net/soc.c
@@ -4,31 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include "soc.h"
+#include <string.h>
+
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+#include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/sys/printk.h>
+
+#include <kernel_internal.h>
+#include <esp_private/system_internal.h>
+#include <esp32/rom/cache.h>
+#include <esp_spi_flash.h>
+#include <esp_err.h>
+#include <esp32/spiram.h>
+#include <esp_app_format.h>
+#include <hal/soc_ll.h>
+#include <soc.h>
+#include <soc/cpu.h>
+#include <soc/gpio_periph.h>
 #include <soc/rtc_cntl_reg.h>
 #include <soc/timer_group_reg.h>
-#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <xtensa/config/core-isa.h>
 #include <xtensa/corebits.h>
-
-#include <zephyr/kernel_structs.h>
-#include <string.h>
-#include <zephyr/toolchain/gcc.h>
-#include <zephyr/types.h>
-#include <zephyr/linker/linker-defs.h>
-#include <kernel_internal.h>
-
-#include "esp_private/system_internal.h"
-#include "esp32/rom/cache.h"
-#include "hal/soc_ll.h"
-#include "soc/cpu.h"
-#include "soc/gpio_periph.h"
-#include "esp_spi_flash.h"
-#include "esp_err.h"
-#include "esp32/spiram.h"
-#include "esp_app_format.h"
-#include <zephyr/sys/printk.h>
 
 extern void z_cstart(void);
 

--- a/soc/xtensa/esp32s2/soc.c
+++ b/soc/xtensa/esp32s2/soc.c
@@ -4,32 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include "soc.h"
+#include <string.h>
+
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+#include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/sys/printk.h>
+
+#include <kernel_internal.h>
+#include <esp_private/system_internal.h>
+#include <esp32s2/rom/cache.h>
+#include <esp32s2/spiram.h>
+#include <esp_cpu.h>
+#include <esp_err.h>
+#include <esp_spi_flash.h>
+#include <esp_timer.h>
+#include <esp_clk_internal.h>
+#include <hal/cpu_ll.h>
+#include <hal/soc_ll.h>
+#include <soc.h>
+#include <soc/gpio_periph.h>
 #include <soc/rtc_cntl_reg.h>
 #include <soc/timer_group_reg.h>
-#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <xtensa/config/core-isa.h>
 #include <xtensa/corebits.h>
-
-#include <zephyr/kernel_structs.h>
-#include <kernel_internal.h>
-#include <string.h>
-#include <zephyr/toolchain/gcc.h>
-#include <zephyr/types.h>
-
-#include "esp_private/system_internal.h"
-#include "esp32s2/rom/cache.h"
-#include "soc/gpio_periph.h"
-#include "esp_spi_flash.h"
-#include "esp_cpu.h"
-#include "hal/cpu_ll.h"
-#include "hal/soc_ll.h"
-#include "esp_timer.h"
-#include "esp_err.h"
-#include "esp32s2/spiram.h"
-#include "esp_clk_internal.h"
-#include <zephyr/sys/printk.h>
 
 extern void rtc_clk_cpu_freq_set_xtal(void);
 

--- a/soc/xtensa/esp32s3/soc.c
+++ b/soc/xtensa/esp32s3/soc.c
@@ -4,36 +4,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Include esp-idf headers first to avoid redefining BIT() macro */
-#include "soc.h"
-#include <soc/rtc_cntl_reg.h>
-#include <soc/timer_group_reg.h>
-#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
-#include <xtensa/config/core-isa.h>
-#include <xtensa/corebits.h>
-
-#include <zephyr/kernel_structs.h>
 #include <string.h>
-#include <zephyr/toolchain/gcc.h>
-#include <zephyr/types.h>
+#include <stdint.h>
+
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+#include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/linker/linker-defs.h>
-#include <kernel_internal.h>
 #include <zephyr/sys/util.h>
 
-#include "esp_private/system_internal.h"
-#include "esp32s3/rom/cache.h"
-#include "esp32s3/rom/rtc.h"
-#include "soc/syscon_reg.h"
-#include "hal/soc_ll.h"
-#include "hal/wdt_hal.h"
-#include "soc/cpu.h"
-#include "soc/gpio_periph.h"
-#include "esp_spi_flash.h"
-#include "esp_err.h"
-#include "esp_timer.h"
-#include "esp_app_format.h"
-#include "esp_clk_internal.h"
-#include <zephyr/sys/printk.h>
+#include <kernel_internal.h>
+#include <esp32s3/rom/cache.h>
+#include <esp32s3/rom/rtc.h>
+#include <esp_app_format.h>
+#include <esp_clk_internal.h>
+#include <esp_err.h>
+#include <esp_private/system_internal.h>
+#include <esp_spi_flash.h>
+#include <esp_timer.h>
+#include <hal/soc_ll.h>
+#include <hal/wdt_hal.h>
+#include <soc.h>
+#include <soc/cpu.h>
+#include <soc/gpio_periph.h>
+#include <soc/rtc_cntl_reg.h>
+#include <soc/syscon_reg.h>
+#include <soc/timer_group_reg.h>
+#include <xtensa/config/core-isa.h>
+#include <xtensa/corebits.h>
 
 extern void z_cstart(void);
 extern void rom_config_instruction_cache_mode(uint32_t cfg_cache_size,

--- a/west.yml
+++ b/west.yml
@@ -57,7 +57,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: d7576d0da639acbd9a191a3eb7e4f3f3476c9641
+      revision: pull/208/head
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:
@@ -93,7 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: d3c964cd854e53d55d21532431ee337d55348d8c
+      revision: pull/230/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
We've been guarding the definition of BIT/MIN/MAX/CLAMP macros as they are commonly found in other projects. This is dangerous, because depending on the order of includes, Zephyr code could end up using macros defined by other projects (e.g. via HALs).

The current #ifndef _protection_ goes against the recently established guidelines in #51963, so let's remove it.

Ref. https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#rule-a-3-macro-name-collisions