### PR TITLE
i2c: RTIO support with sam twihs

### DIFF
--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -3,6 +3,11 @@
 zephyr_library()
 
 zephyr_library_sources(i2c_common.c)
+
+if(CONFIG_I2C_RTIO)
+zephyr_library_sources(i2c_rtio.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIHS    i2c_sam_twihs_rtio.c)
+else()
 zephyr_library_sources_ifdef(CONFIG_I2C_SHELL		i2c_shell.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_BITBANG		i2c_bitbang.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_TELINK_B91		i2c_b91.c)
@@ -50,10 +55,10 @@ zephyr_library_sources_ifdef(CONFIG_I2C_STM32_V2
 	i2c_ll_stm32_v2.c
 	i2c_ll_stm32.c
 	)
+endif()
 
 zephyr_library_sources_ifdef(CONFIG_I2C_TEST		i2c_test.c)
 
-zephyr_library_sources_ifdef(CONFIG_I2C_RTIO		i2c_rtio.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE		i2c_handlers.c)
 
 add_subdirectory_ifdef(CONFIG_I2C_TARGET target)

--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -22,7 +22,7 @@ zephyr_library_sources_ifdef(CONFIG_I2C_EMUL		i2c_emul.c)
 zephyr_library_sources_ifdef(CONFIG_NRFX_TWI		i2c_nrfx_twi.c)
 zephyr_library_sources_ifdef(CONFIG_NRFX_TWIM		i2c_nrfx_twim.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWI		i2c_sam_twi.c)
-zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIHS	i2c_sam_twihs.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIHS    i2c_sam_twihs.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWIM	i2c_sam4l_twim.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SBCON		i2c_sbcon.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SIFIVE		i2c_sifive.c)
@@ -53,6 +53,7 @@ zephyr_library_sources_ifdef(CONFIG_I2C_STM32_V2
 
 zephyr_library_sources_ifdef(CONFIG_I2C_TEST		i2c_test.c)
 
+zephyr_library_sources_ifdef(CONFIG_I2C_RTIO		i2c_rtio.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE		i2c_handlers.c)
 
 add_subdirectory_ifdef(CONFIG_I2C_TARGET target)

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -40,6 +40,11 @@ config I2C_CALLBACK
 	help
 	  API and implementations of i2c_transfer_cb.
 
+config I2C_RTIO
+	bool "I2C RTIO API"
+	help
+	  API and implementations of I2C for RTIO
+
 # Include these first so that any properties (e.g. defaults) below can be
 # overridden (by defining symbols in multiple locations)
 source "drivers/i2c/Kconfig.b91"
@@ -56,6 +61,7 @@ source "drivers/i2c/Kconfig.sbcon"
 source "drivers/i2c/Kconfig.sifive"
 source "drivers/i2c/Kconfig.stm32"
 source "drivers/i2c/Kconfig.sam0"
+source "drivers/i2c/Kconfig.sam_twihs"
 source "drivers/i2c/Kconfig.litex"
 source "drivers/i2c/Kconfig.lpc11u6x"
 source "drivers/i2c/Kconfig.npcx"
@@ -85,13 +91,6 @@ config I2C_GECKO
 	select SOC_GECKO_I2C
 	help
 	  Enable the SiLabs Gecko I2C bus driver.
-
-config I2C_SAM_TWIHS
-	bool "Atmel SAM (TWIHS) I2C driver"
-	default y
-	depends on DT_HAS_ATMEL_SAM_I2C_TWIHS_ENABLED
-	help
-	  Enable Atmel SAM MCU Family (TWIHS) I2C bus driver.
 
 config I2C_SAM_TWIM
 	bool "Atmel SAM (TWIM) I2C driver"

--- a/drivers/i2c/Kconfig.sam_twihs
+++ b/drivers/i2c/Kconfig.sam_twihs
@@ -1,0 +1,37 @@
+# sam twihs I2C support
+
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig I2C_SAM_TWIHS
+	bool "Atmel SAM (TWIHS) I2C driver"
+	default y
+	depends on DT_HAS_ATMEL_SAM_I2C_TWIHS_ENABLED
+	help
+	  Enable Atmel SAM MCU Family (TWIHS) I2C bus driver.
+
+if I2C_SAM_TWIHS
+if I2C_RTIO
+
+config I2C_SAM_TWIHS_SQ_SIZE
+	int "Submission queue size for blocking calls"
+	default 4
+	help
+	  Blocking i2c calls when I2C_RTIO is enabled are copied into a per driver
+	  submission queue. The queue depth determines the number of possible i2c_msg
+	  structs that may be in the array given to i2c_transfer. A sensible default
+	  is going to be 4 given the device address, register address, and a value
+	  to be read or written.
+
+config I2C_SAM_TWIHS_CQ_SIZE
+	int "Completion queue size for blocking calls"
+	default 4
+	help
+	  Blocking i2c calls when I2C_RTIO is enabled are copied into a per driver
+	  submission queue. The queue depth determines the number of possible i2c_msg
+	  structs that may be in the array given to i2c_transfer. A sensible default
+	  is going to be 4 given the device address, register address, and a value
+	  to be read or written.
+
+endif # I2C_RTIO
+endif # I2C_SAM_TWIHS

--- a/drivers/i2c/i2c_rtio.c
+++ b/drivers/i2c/i2c_rtio.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "zephyr/rtio/rtio.h"
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/rtio/rtio_spsc.h>
+#include <zephyr/sys/__assert.h>
+
+const struct rtio_iodev_api i2c_iodev_api = {
+	.submit = i2c_iodev_submit,
+};
+
+struct rtio_sqe *i2c_rtio_copy(struct rtio *r,
+			       struct rtio_iodev *iodev,
+			       const struct i2c_msg *msgs,
+			       uint8_t num_msgs)
+{
+	__ASSERT(num_msgs > 0, "Expecting at least one message to copy");
+
+	struct rtio_sqe *sqe = NULL;
+
+	for (uint8_t i = 0; i < num_msgs; i++) {
+		sqe = rtio_sqe_acquire(r);
+
+		if (sqe == NULL) {
+			rtio_spsc_drop_all(r->sq);
+			return NULL;
+		}
+
+		if (msgs[i].flags & I2C_MSG_READ) {
+			rtio_sqe_prep_read(sqe, iodev, RTIO_PRIO_NORM,
+					   msgs[i].buf, msgs[i].len, NULL);
+		} else {
+			rtio_sqe_prep_write(sqe, iodev, RTIO_PRIO_NORM,
+					    msgs[i].buf, msgs[i].len, NULL);
+		}
+		sqe->flags |= RTIO_SQE_TRANSACTION;
+		sqe->iodev_flags = ((msgs[i].flags & I2C_MSG_STOP) ? RTIO_IODEV_I2C_STOP : 0) |
+			((msgs[i].flags & I2C_MSG_RESTART) ? RTIO_IODEV_I2C_RESTART : 0) |
+			((msgs[i].flags & I2C_MSG_ADDR_10_BITS) ? RTIO_IODEV_I2C_10_BITS : 0);
+	}
+
+	sqe->flags &= ~RTIO_SQE_TRANSACTION;
+
+	return sqe;
+}

--- a/drivers/i2c/i2c_sam_twihs_rtio.c
+++ b/drivers/i2c/i2c_sam_twihs_rtio.c
@@ -1,0 +1,450 @@
+/*
+ * Copyright (c) 2017 Piotr Mienkowski
+ * Copyright (c) 2023 Gerson Fernando Budke
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "zephyr/spinlock.h"
+#define DT_DRV_COMPAT atmel_sam_i2c_twihs
+
+/** @file
+ * @brief I2C bus (TWIHS) driver for Atmel SAM MCU family.
+ *
+ * Only I2C Controller Mode with 7 bit addressing is currently supported.
+ */
+
+
+#include <errno.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <soc.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/rtio/rtio_executor_simple.h>
+
+#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
+#include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
+LOG_MODULE_REGISTER(i2c_sam_twihs_rtio);
+
+#include "i2c-priv.h"
+
+/** I2C bus speed [Hz] in Standard Mode */
+#define BUS_SPEED_STANDARD_HZ         100000U
+/** I2C bus speed [Hz] in Fast Mode */
+#define BUS_SPEED_FAST_HZ             400000U
+/** I2C bus speed [Hz] in High Speed Mode */
+#define BUS_SPEED_HIGH_HZ            3400000U
+/* Maximum value of Clock Divider (CKDIV) */
+#define CKDIV_MAX                          7
+
+/* Device constant configuration parameters */
+struct i2c_sam_twihs_dev_cfg {
+	Twihs *regs;
+	void (*irq_config)(void);
+	uint32_t bitrate;
+	const struct atmel_sam_pmc_config clock_cfg;
+	const struct pinctrl_dev_config *pcfg;
+	uint8_t irq_id;
+};
+
+/* Device run time data */
+struct i2c_sam_twihs_dev_data {
+	struct k_spinlock lock;
+	struct k_sem block_lock;
+	struct i2c_dt_spec dt_spec;
+	struct rtio_iodev iodev;
+	struct rtio *r;
+	struct rtio_mpsc io_q;
+	struct rtio_iodev_sqe *iodev_sqe;
+	const struct rtio_sqe *sqe;
+	uint32_t buf_idx;
+};
+
+static int i2c_clk_set(Twihs *const twihs, uint32_t speed)
+{
+	uint32_t ck_div = 0U;
+	uint32_t cl_div;
+	bool div_completed = false;
+
+	/*  From the datasheet "TWIHS Clock Waveform Generator Register"
+	 *  T_low = ( ( CLDIV × 2^CKDIV ) + 3 ) × T_MCK
+	 */
+	while (!div_completed) {
+		cl_div =   ((SOC_ATMEL_SAM_MCK_FREQ_HZ / (speed * 2U)) - 3)
+			 / (1 << ck_div);
+
+		if (cl_div <= 255U) {
+			div_completed = true;
+		} else {
+			ck_div++;
+		}
+	}
+
+	if (ck_div > CKDIV_MAX) {
+		LOG_ERR("Failed to configure I2C clock");
+		return -EIO;
+	}
+
+	/* Set I2C bus clock duty cycle to 50% */
+	twihs->TWIHS_CWGR = TWIHS_CWGR_CLDIV(cl_div) | TWIHS_CWGR_CHDIV(cl_div)
+			    | TWIHS_CWGR_CKDIV(ck_div);
+
+	return 0;
+}
+
+static int i2c_sam_twihs_configure(const struct device *dev, uint32_t config)
+{
+	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = dev->config;
+	Twihs *const twihs = dev_cfg->regs;
+	uint32_t bitrate;
+	int ret;
+
+	if (!(config & I2C_MODE_CONTROLLER)) {
+		LOG_ERR("Master Mode is not enabled");
+		return -EIO;
+	}
+
+	if (config & I2C_ADDR_10_BITS) {
+		LOG_ERR("I2C 10-bit addressing is currently not supported");
+		LOG_ERR("Please submit a patch");
+		return -EIO;
+	}
+
+	/* Configure clock */
+	switch (I2C_SPEED_GET(config)) {
+	case I2C_SPEED_STANDARD:
+		bitrate = BUS_SPEED_STANDARD_HZ;
+		break;
+	case I2C_SPEED_FAST:
+		bitrate = BUS_SPEED_FAST_HZ;
+		break;
+	default:
+		LOG_ERR("Unsupported I2C speed value");
+		return -EIO;
+	}
+
+	/* Setup clock waveform */
+	ret = i2c_clk_set(twihs, bitrate);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Disable Target Mode */
+	twihs->TWIHS_CR = TWIHS_CR_SVDIS;
+
+	/* Enable Controller Mode */
+	twihs->TWIHS_CR = TWIHS_CR_MSEN;
+
+	return 0;
+}
+
+static void write_msg_start(Twihs *const twihs, const uint8_t *buf, const uint32_t idx,
+			    const uint8_t daddr)
+{
+	/* Set target address. */
+	twihs->TWIHS_MMR = TWIHS_MMR_DADR(daddr);
+
+	/* Write first data byte on I2C bus */
+	twihs->TWIHS_THR = buf[idx];
+
+	/* Enable Transmit Ready and Transmission Completed interrupts */
+	twihs->TWIHS_IER = TWIHS_IER_TXRDY | TWIHS_IER_TXCOMP | TWIHS_IER_NACK;
+
+}
+
+static void read_msg_start(Twihs *const twihs, const uint32_t len, const uint8_t daddr)
+{
+	uint32_t twihs_cr_stop;
+
+	/* Set target address and number of internal address bytes */
+	twihs->TWIHS_MMR = TWIHS_MMR_MREAD | TWIHS_MMR_DADR(daddr);
+
+	/* In single data byte read the START and STOP must both be set */
+	twihs_cr_stop = (len == 1U) ? TWIHS_CR_STOP : 0;
+
+	/* Enable Receive Ready and Transmission Completed interrupts */
+	twihs->TWIHS_IER = TWIHS_IER_RXRDY | TWIHS_IER_TXCOMP | TWIHS_IER_NACK;
+
+	/* Start the transfer by sending START condition */
+	twihs->TWIHS_CR = TWIHS_CR_START | twihs_cr_stop;
+
+
+}
+
+static void i2c_sam_twihs_complete(const struct device *dev, int status);
+
+static void i2c_sam_twihs_start(const struct device *dev)
+{
+	struct i2c_sam_twihs_dev_data *const dev_data = dev->data;
+	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = dev->config;
+	Twihs *const twihs = dev_cfg->regs;
+	const struct rtio_sqe *const sqe = dev_data->sqe;
+	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
+
+	/* Clear pending interrupts, such as NACK. */
+	(void)twihs->TWIHS_SR;
+
+	/* Set number of internal address bytes to 0, not used. */
+	twihs->TWIHS_IADR = 0;
+
+	/* Set the current index to 0 */
+	dev_data->buf_idx = 0;
+
+	switch (sqe->op) {
+	case RTIO_OP_RX:
+		read_msg_start(twihs, sqe->buf_len, dt_spec->addr);
+		break;
+	case RTIO_OP_TX:
+		dev_data->buf_idx = 1;
+		write_msg_start(twihs, sqe->buf, 0, dt_spec->addr);
+		break;
+	default:
+		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);
+		i2c_sam_twihs_complete(dev, -EINVAL);
+	}
+}
+
+static void i2c_sam_twihs_next(const struct device *dev, bool completion)
+{
+	struct i2c_sam_twihs_dev_data *data = dev->data;
+
+	k_spinlock_key_t key = k_spin_lock(&data->lock);
+
+	if (!completion && data->iodev_sqe != NULL) {
+		k_spin_unlock(&data->lock, key);
+		return;
+	}
+
+	struct rtio_mpsc_node *next = rtio_mpsc_pop(&data->io_q);
+
+	if (next == NULL) {
+		data->iodev_sqe = NULL;
+		data->sqe = NULL;
+		k_spin_unlock(&data->lock, key);
+		return;
+	}
+
+	data->iodev_sqe = CONTAINER_OF(next, struct rtio_iodev_sqe, q);
+	data->sqe = data->iodev_sqe->sqe;
+	k_spin_unlock(&data->lock, key);
+
+	i2c_sam_twihs_start(dev);
+}
+
+static void i2c_sam_twihs_complete(const struct device *dev, int status)
+{
+	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = dev->config;
+	struct i2c_sam_twihs_dev_data *const dev_data = dev->data;
+	Twihs *const twihs = dev_cfg->regs;
+	struct rtio_iodev_sqe *iodev_sqe = dev_data->iodev_sqe;
+
+	/* Disable all enabled interrupts */
+	twihs->TWIHS_IDR = twihs->TWIHS_IMR;
+
+	if (status < 0) {
+		rtio_iodev_sqe_err(iodev_sqe, status);
+		i2c_sam_twihs_next(dev, true);
+		return;
+	}
+
+	if (dev_data->sqe->flags & RTIO_SQE_TRANSACTION) {
+		dev_data->sqe = rtio_spsc_next(iodev_sqe->r->sq, dev_data->sqe);
+		i2c_sam_twihs_start(dev);
+	} else {
+		rtio_iodev_sqe_ok(iodev_sqe, status);
+		i2c_sam_twihs_next(dev, true);
+	}
+}
+
+static void i2c_sam_twihs_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	struct i2c_sam_twihs_dev_data *const dev_data = dev->data;
+
+	rtio_mpsc_push(&dev_data->io_q, &iodev_sqe->q);
+	i2c_sam_twihs_next(dev, false);
+}
+
+static void i2c_sam_twihs_isr(const struct device *dev)
+{
+	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = dev->config;
+	struct i2c_sam_twihs_dev_data *const dev_data = dev->data;
+	Twihs *const twihs = dev_cfg->regs;
+	const struct rtio_sqe *const sqe = dev_data->sqe;
+	uint32_t isr_status;
+
+	/* Retrieve interrupt status */
+	isr_status = twihs->TWIHS_SR & twihs->TWIHS_IMR;
+
+	/* Not Acknowledged */
+	if (isr_status & TWIHS_SR_NACK) {
+		i2c_sam_twihs_complete(dev, -EIO);
+		return;
+	}
+
+	/* Byte received */
+	if (isr_status & TWIHS_SR_RXRDY) {
+		sqe->buf[dev_data->buf_idx] = twihs->TWIHS_RHR;
+		dev_data->buf_idx += 1;
+
+		if (dev_data->buf_idx == sqe->buf_len - 1U) {
+			/* Send STOP condition */
+			twihs->TWIHS_CR = TWIHS_CR_STOP;
+		}
+	}
+
+	/* Byte sent */
+	if (isr_status & TWIHS_SR_TXRDY) {
+		if (dev_data->buf_idx == sqe->buf_len) {
+			if (sqe->iodev_flags & RTIO_IODEV_I2C_STOP) {
+				/* Send STOP condition */
+				twihs->TWIHS_CR = TWIHS_CR_STOP;
+				/* Disable Transmit Ready interrupt */
+				twihs->TWIHS_IDR = TWIHS_IDR_TXRDY;
+			} else {
+				/* Transmission completed */
+				i2c_sam_twihs_complete(dev, 0);
+				return;
+			}
+		} else {
+			twihs->TWIHS_THR = sqe->buf[dev_data->buf_idx++];
+		}
+	}
+
+	/* Transmission completed */
+	if (isr_status & TWIHS_SR_TXCOMP) {
+		i2c_sam_twihs_complete(dev, 0);
+	}
+}
+
+static int i2c_sam_twihs_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
+				  uint16_t addr)
+{
+	struct i2c_sam_twihs_dev_data *const dev_data = dev->data;
+	struct rtio_iodev *iodev = &dev_data->iodev;
+	struct rtio *const r = dev_data->r;
+	struct rtio_sqe *sqe = NULL;
+	struct rtio_cqe *cqe = NULL;
+	int res = 0;
+
+	k_sem_take(&dev_data->block_lock, K_FOREVER);
+
+	dev_data->dt_spec.addr = addr;
+
+	sqe = i2c_rtio_copy(r, iodev, msgs, num_msgs);
+	if (sqe == NULL) {
+		LOG_ERR("Not enough submission queue entries");
+		res = -ENOMEM;
+		goto out;
+	}
+
+	sqe->flags &= ~RTIO_SQE_TRANSACTION;
+
+	rtio_submit(r, 1);
+
+	cqe = rtio_cqe_consume(r);
+	__ASSERT(cqe != NULL, "Expected valid completion");
+	while (cqe != NULL) {
+		res = cqe->result;
+		cqe = rtio_cqe_consume(r);
+	}
+	rtio_cqe_release_all(r);
+
+out:
+	k_sem_give(&dev_data->block_lock);
+	return res;
+}
+
+static int i2c_sam_twihs_initialize(const struct device *dev)
+{
+	const struct i2c_sam_twihs_dev_cfg *const dev_cfg = dev->config;
+	struct i2c_sam_twihs_dev_data *const dev_data = dev->data;
+	Twihs *const twihs = dev_cfg->regs;
+	uint32_t bitrate_cfg;
+	int ret;
+
+	/* Configure interrupts */
+	dev_cfg->irq_config();
+
+	/* Connect pins to the peripheral */
+	ret = pinctrl_apply_state(dev_cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Enable TWIHS clock in PMC */
+	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
+			       (clock_control_subsys_t *)&dev_cfg->clock_cfg);
+
+	/* Reset the module */
+	twihs->TWIHS_CR = TWIHS_CR_SWRST;
+
+	bitrate_cfg = i2c_map_dt_bitrate(dev_cfg->bitrate);
+
+	ret = i2c_sam_twihs_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
+	if (ret < 0) {
+		LOG_ERR("Failed to initialize %s device", dev->name);
+		return ret;
+	}
+
+	k_sem_init(&dev_data->block_lock, 1, 1);
+	dev_data->dt_spec.bus = dev;
+	dev_data->iodev.api = &i2c_iodev_api;
+	dev_data->iodev.data = &dev_data->dt_spec;
+	rtio_mpsc_init(&dev_data->io_q);
+
+	/* Enable module's IRQ */
+	irq_enable(dev_cfg->irq_id);
+
+	LOG_INF("Device %s initialized", dev->name);
+
+	return 0;
+}
+
+static const struct i2c_driver_api i2c_sam_twihs_driver_api = {
+	.configure = i2c_sam_twihs_configure,
+	.transfer = i2c_sam_twihs_transfer,
+	.iodev_submit = i2c_sam_twihs_submit,
+};
+
+#define I2C_TWIHS_SAM_INIT(n)									\
+	PINCTRL_DT_INST_DEFINE(n);								\
+	static void i2c##n##_sam_irq_config(void)						\
+	{											\
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),				\
+			    i2c_sam_twihs_isr,							\
+			    DEVICE_DT_INST_GET(n), 0);						\
+	}											\
+												\
+	RTIO_EXECUTOR_SIMPLE_DEFINE(_i2c##n##_sam_rtio_exec);					\
+	RTIO_DEFINE(_i2c##n##_sam_rtio,								\
+		    (struct rtio_executor *)&_i2c##n##_sam_rtio_exec,				\
+		    CONFIG_I2C_SAM_TWIHS_SQ_SIZE,						\
+		    CONFIG_I2C_SAM_TWIHS_CQ_SIZE);						\
+												\
+	static const struct i2c_sam_twihs_dev_cfg i2c##n##_sam_config = {			\
+		.regs = (Twihs *)DT_INST_REG_ADDR(n),						\
+		.irq_config = i2c##n##_sam_irq_config,						\
+		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(n),					\
+		.irq_id = DT_INST_IRQN(n),							\
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),					\
+		.bitrate = DT_INST_PROP(n, clock_frequency),					\
+	};											\
+												\
+	static struct i2c_sam_twihs_dev_data i2c##n##_sam_data = {				\
+		.r = &_i2c##n##_sam_rtio,							\
+	};											\
+												\
+	I2C_DEVICE_DT_INST_DEFINE(n, i2c_sam_twihs_initialize,					\
+			    NULL,								\
+			    &i2c##n##_sam_data, &i2c##n##_sam_config,				\
+			    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,				\
+			    &i2c_sam_twihs_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(I2C_TWIHS_SAM_INIT)

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -25,6 +25,7 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/slist.h>
+#include <zephyr/rtio/rtio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -229,6 +230,16 @@ typedef int (*i2c_api_transfer_cb_t)(const struct device *dev,
 				 i2c_callback_t cb,
 				 void *userdata);
 #endif /* CONFIG_I2C_CALLBACK */
+#if defined(CONFIG_I2C_RTIO) || defined(DOXYGEN)
+
+/**
+ * @typedef i2c_api_iodev_submit
+ * @brief Callback API for submitting work to a I2C device with RTIO
+ */
+typedef void (*i2c_api_iodev_submit)(const struct device *dev,
+				     struct rtio_iodev_sqe *iodev_sqe);
+#endif /* CONFIG_I2C_RTIO */
+
 typedef int (*i2c_api_recover_bus_t)(const struct device *dev);
 
 __subsystem struct i2c_driver_api {
@@ -239,6 +250,9 @@ __subsystem struct i2c_driver_api {
 	i2c_api_target_unregister_t target_unregister;
 #ifdef CONFIG_I2C_CALLBACK
 	i2c_api_transfer_cb_t transfer_cb;
+#endif
+#ifdef CONFIG_I2C_RTIO
+	i2c_api_iodev_submit iodev_submit;
 #endif
 	i2c_api_recover_bus_t recover_bus;
 };
@@ -899,6 +913,57 @@ static inline int i2c_transfer_signal(const struct device *dev,
 #endif /* CONFIG_POLL */
 
 #endif /* CONFIG_I2C_CALLBACK */
+
+
+#if defined(CONFIG_I2C_RTIO) || defined(DOXYGEN)
+
+/**
+ * @brief Submit request(s) to an I2C device with RTIO
+ *
+ * @param iodev_sqe Prepared submissions queue entry connected to an iodev
+ *                  defined by I2C_DT_IODEV_DEFINE.
+ */
+static inline void i2c_iodev_submit(struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct i2c_dt_spec *dt_spec = iodev_sqe->sqe->iodev->data;
+	const struct device *dev = dt_spec->bus;
+	const struct i2c_driver_api *api = (const struct i2c_driver_api *)dev->api;
+
+	api->iodev_submit(dt_spec->bus, iodev_sqe);
+}
+
+extern const struct rtio_iodev_api i2c_iodev_api;
+
+/**
+ * @brief Define an iodev for a given dt node on the bus
+ *
+ * These do not need to be shared globally but doing so
+ * will save a small amount of memory.
+ *
+ * @param node DT_NODE
+ */
+#define I2C_DT_IODEV_DEFINE(name, node_id)					\
+	const struct i2c_dt_spec _i2c_dt_spec_##name =				\
+		I2C_DT_SPEC_GET(node_id);					\
+	RTIO_IODEV_DEFINE(name, &i2c_iodev_api, (void *)&_i2c_dt_spec_##name)
+
+/**
+ * @brief Copy the i2c_msgs into a set of RTIO requests
+ *
+ * @param r RTIO context
+ * @param iodev RTIO IODev to target for the submissions
+ * @param msgs Array of messages
+ * @param num_msgs Number of i2c msgs in array
+ *
+ * @retval sqe Last submission in the queue added
+ * @retval NULL Not enough memory in the context to copy the requests
+ */
+struct rtio_sqe *i2c_rtio_copy(struct rtio *r,
+			       struct rtio_iodev *iodev,
+			       const struct i2c_msg *msgs,
+			       uint8_t num_msgs);
+
+#endif /* CONFIG_I2C_RTIO */
 
 /**
  * @brief Perform data transfer to another I2C device in controller mode.

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -115,6 +115,26 @@ extern "C" {
  */
 #define RTIO_SQE_TRANSACTION BIT(1)
 
+
+/**
+ * @brief Equivalent to the I2C_MSG_STOP flag
+ */
+#define RTIO_IODEV_I2C_STOP BIT(0)
+
+/**
+ * @brief Equivalent to the I2C_MSG_RESTART flag
+ */
+#define RTIO_IODEV_I2C_RESTART BIT(1)
+
+/**
+ * @brief Equivalent to the I2C_MSG_10_BITS
+ */
+#define RTIO_IODEV_I2C_10_BITS BIT(2)
+
+/**
+ * @brief Equivalent to the I2C_MSG_ADDR_10_BITS
+ */
+
 /**
  * @brief The buffer should be allocated by the RTIO mempool
  *
@@ -191,6 +211,10 @@ struct rtio_sqe {
 	uint8_t prio; /**< Op priority */
 
 	uint16_t flags; /**< Op Flags */
+
+	uint16_t iodev_flags; /**< Op iodev flags */
+
+	uint16_t _resv0;
 
 	const struct rtio_iodev *iodev; /**< Device to operation on */
 


### PR DESCRIPTION
Adds RTIO support to I2C along with a driver implementing the added API for the SAM TWIHS driver using interrupt driven logic. It works well in testing it on the tdk robokit1 with the magn_polling sample

I built it with...

```sh
west build -p always -b tdk_robokit1 samples/sensor/magn_polling -- -DCONFIG_I2C_RTIO=y -DCONFIG_RTIO_SUBMIT_SEM=y
```

Some driver patterns are emerging I think that probably warrant a cleanup pass as a follow up to sort of make the common patterns use common code and reduce code duplication much like spi_context does.