### PR TITLE
twister: Enable armclang on all arm targets

### DIFF
--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -71,6 +71,9 @@ class Platform:
         self.simulation = data.get('simulation', "na")
         self.simulation_exec = data.get('simulation_exec')
         self.supported_toolchains = data.get("toolchain", [])
+        if self.arch == 'arm':
+            if 'armclang' not in self.supported_toolchains:
+                self.supported_toolchains.append('armclang')
         self.env = data.get("env", [])
         self.env_satisfied = True
         for env in self.env:


### PR DESCRIPTION
Rather than having to add 'armclang' to every <BOARD>.yaml, just list it as a generally supported toolchain if the architecture is 'arm'.