### PR TITLE
samples: sensor: Update thermometer sample to use devicetree alias

### DIFF
--- a/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3.overlay
+++ b/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3.overlay
@@ -9,6 +9,7 @@
 		magn0 = &lis2mdl_1e_x_nucleo_iks01a3;
 		accel0 = &lis2dw12_19_x_nucleo_iks01a3;
 		accel1 = &lsm6dso_6b_x_nucleo_iks01a3;
+		ambient-temp0 = &stts751_x_nucleo_iks01a3;
 	};
 };
 

--- a/samples/sensor/thermometer/sample.yaml
+++ b/samples/sensor/thermometer/sample.yaml
@@ -4,5 +4,9 @@ tests:
   sample.sensor.thermometer:
     tags: sensors
     harness: sensor
+    filter: dt_alias_exists("ambient-temp0")
     integration_platforms:
       - frdm_k64f
+    extra_args: SHIELD=x_nucleo_iks01a3
+    depends_on: arduino_i2c arduino_gpio
+    platform_exclude: lpcxpresso55s16 pan1781_evb pan1782_evb

--- a/samples/sensor/thermometer/src/main.c
+++ b/samples/sensor/thermometer/src/main.c
@@ -10,18 +10,17 @@
 
 void main(void)
 {
-	const struct device *temp_dev;
+	const struct device *const temp_dev = DEVICE_DT_GET(DT_ALIAS(ambient_temp0));
 
 	printf("Thermometer Example! %s\n", CONFIG_ARCH);
 
-	temp_dev = device_get_binding("TEMP_0");
-	if (!temp_dev) {
-		printf("error: no temp device\n");
-		return;
-	}
-
 	printf("temp device is %p, name is %s\n",
 	       temp_dev, temp_dev->name);
+
+	if (!device_is_ready(temp_dev)) {
+		printf("temp device not ready.\n");
+		return;
+	}
 
 	while (1) {
 		int r;


### PR DESCRIPTION
Updates the thermometer sample to get the sensor device from a devicetree alias resolved at build time rather than look up the sensor device at runtime with device_get_binding. This also makes the thermometer sample more consistent with other sensor samples (magn_polling, accel_polling, etc).

Tested on frdm_k64f with the x_nucleo_iks01a3 shield.

@asemjonovs this should help address the twister failure in #54947 