### PR TITLE
Rework ST die temp driver to support STM32C0-series

### DIFF
--- a/boards/arm/nucleo_c031c6/doc/index.rst
+++ b/boards/arm/nucleo_c031c6/doc/index.rst
@@ -84,6 +84,8 @@ The Zephyr nucleo_c031c6 board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | ADC Controller                      |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 

--- a/boards/arm/nucleo_c031c6/nucleo_c031c6.dts
+++ b/boards/arm/nucleo_c031c6/nucleo_c031c6.dts
@@ -50,6 +50,7 @@
 		pwm-led0 = &green_pwm_led;
 		sw0 = &user_button;
 		watchdog0 = &iwdg;
+		die-temp0 = &die_temp;
 	};
 };
 
@@ -106,5 +107,9 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1 &adc1_in4_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&die_temp {
 	status = "okay";
 };

--- a/drivers/sensor/stm32_temp/Kconfig
+++ b/drivers/sensor/stm32_temp/Kconfig
@@ -6,7 +6,9 @@
 config STM32_TEMP
 	bool "STM32 Temperature Sensor"
 	default y
-	depends on DT_HAS_ST_STM32_TEMP_ENABLED || DT_HAS_ST_STM32_TEMP_CAL_ENABLED
+	depends on DT_HAS_ST_STM32_TEMP_ENABLED || \
+		   DT_HAS_ST_STM32_TEMP_CAL_ENABLED || \
+		   DT_HAS_ST_STM32C0_TEMP_CAL_ENABLED
 	depends on (ADC && SOC_FAMILY_STM32)
 	help
 	  Enable driver for STM32 temperature sensor.

--- a/drivers/sensor/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/stm32_temp/stm32_temp.c
@@ -15,12 +15,18 @@ LOG_MODULE_REGISTER(stm32_temp, CONFIG_SENSOR_LOG_LEVEL);
 #define CAL_RES 12
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_temp)
 #define DT_DRV_COMPAT st_stm32_temp
-#define HAS_CALIBRATION 0
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_temp_cal)
 #define DT_DRV_COMPAT st_stm32_temp_cal
-#define HAS_CALIBRATION 1
+#define HAS_DUAL_CALIBRATION 1
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32c0_temp_cal)
+#define DT_DRV_COMPAT st_stm32c0_temp_cal
+#define HAS_SINGLE_CALIBRATION 1
 #else
 #error "No compatible devicetree node found"
+#endif
+
+#if defined(HAS_SINGLE_CALIBRATION) || defined(HAS_DUAL_CALIBRATION)
+#define HAS_CALIBRATION 1
 #endif
 
 struct stm32_temp_data {
@@ -35,9 +41,13 @@ struct stm32_temp_data {
 struct stm32_temp_config {
 #if HAS_CALIBRATION
 	uint16_t *cal1_addr;
-	uint16_t *cal2_addr;
 	int cal1_temp;
+#if HAS_DUAL_CALIBRATION
+	uint16_t *cal2_addr;
 	int cal2_temp;
+#else
+	int avgslope;
+#endif
 	int cal_vrefanalog;
 	int ts_cal_shift;
 #else
@@ -90,8 +100,12 @@ static int stm32_temp_channel_get(const struct device *dev, enum sensor_channel 
 #if HAS_CALIBRATION
 	temp = ((float)data->raw * adc_ref_internal(data->adc)) / cfg->cal_vrefanalog;
 	temp -= (*cfg->cal1_addr >> cfg->ts_cal_shift);
+#if HAS_SINGLE_CALIBRATION
+	temp /= (cfg->avgslope * 4096) / (cfg->cal_vrefanalog * 1000);
+#else
 	temp *= (cfg->cal2_temp - cfg->cal1_temp);
 	temp /= ((*cfg->cal2_addr - *cfg->cal1_addr) >> cfg->ts_cal_shift);
+#endif
 	temp += cfg->cal1_temp;
 #else
 	/* Sensor value in millivolts */
@@ -150,9 +164,13 @@ static struct stm32_temp_data stm32_temp_dev_data = {
 static const struct stm32_temp_config stm32_temp_dev_config = {
 #if HAS_CALIBRATION
 	.cal1_addr = (uint16_t *)DT_INST_PROP(0, ts_cal1_addr),
-	.cal2_addr = (uint16_t *)DT_INST_PROP(0, ts_cal2_addr),
 	.cal1_temp = DT_INST_PROP(0, ts_cal1_temp),
+#if HAS_DUAL_CALIBRATION
+	.cal2_addr = (uint16_t *)DT_INST_PROP(0, ts_cal2_addr),
 	.cal2_temp = DT_INST_PROP(0, ts_cal2_temp),
+#else
+	.avgslope = DT_INST_PROP(0, avgslope),
+#endif
 	.ts_cal_shift = (DT_INST_PROP(0, ts_cal_resolution) - CAL_RES),
 	.cal_vrefanalog = DT_INST_PROP(0, ts_cal_vrefanalog),
 #else

--- a/drivers/sensor/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/stm32_temp/stm32_temp.c
@@ -136,35 +136,33 @@ static int stm32_temp_init(const struct device *dev)
 	return 0;
 }
 
+static struct stm32_temp_data stm32_temp_dev_data = {
+	.adc = DEVICE_DT_GET(DT_INST_IO_CHANNELS_CTLR(0)),
+	.adc_cfg = {
+		.gain = ADC_GAIN_1,
+		.reference = ADC_REF_INTERNAL,
+		.acquisition_time = ADC_ACQ_TIME_MAX,
+		.channel_id = DT_INST_IO_CHANNELS_INPUT(0),
+		.differential = 0
+	},
+};
 
-#define STM32_TEMP_DEFINE(inst)									\
-	static struct stm32_temp_data stm32_temp_dev_data_##inst = {				\
-		.adc = DEVICE_DT_GET(DT_INST_IO_CHANNELS_CTLR(inst)),				\
-		.adc_cfg = {									\
-			.gain = ADC_GAIN_1,							\
-			.reference = ADC_REF_INTERNAL,						\
-			.acquisition_time = ADC_ACQ_TIME_MAX,					\
-			.channel_id = DT_INST_IO_CHANNELS_INPUT(inst),				\
-			.differential = 0							\
-		},										\
-	};											\
-												\
-	static const struct stm32_temp_config stm32_temp_dev_config_##inst = {			\
-		COND_CODE_1(HAS_CALIBRATION,							\
-			    (.cal1_addr = (uint16_t *)DT_INST_PROP(inst, ts_cal1_addr),		\
-			     .cal2_addr = (uint16_t *)DT_INST_PROP(inst, ts_cal2_addr),		\
-			     .cal1_temp = DT_INST_PROP(inst, ts_cal1_temp),			\
-			     .cal2_temp = DT_INST_PROP(inst, ts_cal2_temp),			\
-			     .ts_cal_shift = (DT_INST_PROP(inst, ts_cal_resolution) - CAL_RES),	\
-			     .cal_vrefanalog = DT_INST_PROP(inst, ts_cal_vrefanalog),),		\
-			    (.avgslope = DT_INST_PROP(inst, avgslope),				\
-			     .v25_mv = DT_INST_PROP(inst, v25),					\
-			     .is_ntc = DT_INST_PROP(inst, ntc)))				\
-	};											\
-												\
-	SENSOR_DEVICE_DT_INST_DEFINE(inst, stm32_temp_init, NULL,				\
-			      &stm32_temp_dev_data_##inst, &stm32_temp_dev_config_##inst,	\
-			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				\
-			      &stm32_temp_driver_api);						\
+static const struct stm32_temp_config stm32_temp_dev_config = {
+#if HAS_CALIBRATION
+	.cal1_addr = (uint16_t *)DT_INST_PROP(0, ts_cal1_addr),
+	.cal2_addr = (uint16_t *)DT_INST_PROP(0, ts_cal2_addr),
+	.cal1_temp = DT_INST_PROP(0, ts_cal1_temp),
+	.cal2_temp = DT_INST_PROP(0, ts_cal2_temp),
+	.ts_cal_shift = (DT_INST_PROP(0, ts_cal_resolution) - CAL_RES),
+	.cal_vrefanalog = DT_INST_PROP(0, ts_cal_vrefanalog),
+#else
+	.avgslope = DT_INST_PROP(0, avgslope),
+	.v25_mv = DT_INST_PROP(0, v25),
+	.is_ntc = DT_INST_PROP(0, ntc)
+#endif
+};
 
-DT_INST_FOREACH_STATUS_OKAY(STM32_TEMP_DEFINE)
+SENSOR_DEVICE_DT_INST_DEFINE(0, stm32_temp_init, NULL,
+			     &stm32_temp_dev_data, &stm32_temp_dev_config,
+			     POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+			     &stm32_temp_driver_api);

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -282,6 +282,16 @@
 			vref-channel = <10>;
 		};
 	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32c0-temp-cal";
+		ts-cal1-addr = <0x1FFF7568>;
+		ts-cal1-temp = <30>;
+		ts-cal-vrefanalog = <3000>;
+		avgslope = <2530>;
+		io-channels = <&adc1 9>;
+		status = "disabled";
+	};
 };
 
 &nvic {

--- a/dts/bindings/sensor/st,stm32-temp-cal-common.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-cal-common.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2022, Wouter Cappelle
+# SPDX-License-Identifier: Apache-2.0
+
+description: Common fields for STM32 family TEMP production calibrated sensors
+
+include: [base.yaml, "st,stm32-temp-common.yaml"]
+
+properties:
+  ts-cal1-addr:
+    type: int
+    required: true
+    description: address of parameter TS_CAL1
+
+  ts-cal1-temp:
+    type: int
+    required: true
+    description: |
+      temperature at which temperature sensor has been
+      calibrated in production for data into ts-cal1-addr
+
+  ts-cal-vrefanalog:
+    type: int
+    required: true
+    description: |
+      Analog voltage reference (Vref+) voltage with which
+      temperature sensor has been calibrated in production
+
+  ts-cal-resolution:
+    type: int
+    description: |
+      Temperature calibration resolution with which the ts-cal1-temp and
+      ts-cal2-temp are measured.
+      For most stm32 series a native 12-bit ADC is embedded in the device,
+      except for H7 on 16-bit and U5 on 14-bit
+    default: 12
+    enum:
+    - 12
+    - 14
+    - 16

--- a/dts/bindings/sensor/st,stm32-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-cal.yaml
@@ -1,29 +1,19 @@
 # Copyright (c) 2022, Wouter Cappelle
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 family TEMP node for production calibrated sensors like L5/U5
+description: |
+    STM32 family TEMP node for production calibrated sensors like L5/U5
+    with two calibration temperatures.
 
 compatible: "st,stm32-temp-cal"
 
-include: [base.yaml, "st,stm32-temp-common.yaml"]
+include: "st,stm32-temp-cal-common.yaml"
 
 properties:
-  ts-cal1-addr:
-    type: int
-    required: true
-    description: address of parameter TS_CAL1
-
   ts-cal2-addr:
     type: int
     required: true
     description: address of parameter TS_CAL2
-
-  ts-cal1-temp:
-    type: int
-    required: true
-    description: |
-      temperature at which temperature sensor has been
-      calibrated in production for data into ts-cal1-addr
 
   ts-cal2-temp:
     type: int
@@ -31,23 +21,3 @@ properties:
     description: |
       temperature at which temperature sensor has been
       calibrated in production for data into ts-cal2-addr
-
-  ts-cal-vrefanalog:
-    type: int
-    required: true
-    description: |
-      Analog voltage reference (Vref+) voltage with which
-      temperature sensor has been calibrated in production
-
-  ts-cal-resolution:
-    type: int
-    description: |
-      Temperature calibration resolution with which the ts-cal1-temp and
-      ts-cal2-temp are measured.
-      For most stm32 series a native 12-bit ADC is embedded in the device,
-      except for H7 on 16-bit and U5 on 14-bit
-    default: 12
-    enum:
-    - 12
-    - 14
-    - 16

--- a/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2023, Benjamin Björnsson <benjamin.bjornsson@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    STM32 family TEMP node for production calibrated sensors like C0
+    with a single calibration temperature.
+
+compatible: "st,stm32c0-temp-cal"
+
+include: "st,stm32-temp-cal-common.yaml"
+
+properties:
+  avgslope:
+    type: int
+    default: 2530
+    description: |
+      Average slope of T-V chart (in uV/C) according to
+      datasheet "Electrical characteristics/Operating conditions"
+      STM32C0 Table 5.3.16 (min 2400 uV/C, max 2650, typ: 2530)


### PR DESCRIPTION
The STM32C0-series has a single calibration register for die temp which differs from the dual calibration registers in other series.

Tested the driver functionality with Nucleo C031C6 running `samples/sensor/die_temp_polling`.