### PR TITLE
drivers: ethernet: eth_mcux: fix phy_event state diagram sequence

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -556,7 +556,7 @@ static void eth_mcux_phy_event(struct eth_context *context)
 			context->link_up = link_up;
 			context->phy_state = eth_mcux_phy_state_read_duplex;
 			net_eth_carrier_on(context->iface);
-			k_msleep(USEC_PER_MSEC);
+			k_msleep(1);
 #if defined(CONFIG_ETH_MCUX_NO_PHY_SMI)
 			k_work_submit(&context->phy_work);
 #endif


### PR DESCRIPTION
When the phy_event state diagram ends up in the eth_mcux_phy_state_read_status case, the eth carrier is enabled. However, this step only happens when an interface is available in the context. 

Regardless of the state of the iface, the state machine will switch to eth_mcux_phy_state_read_duplex in the next iteration. Thus, the states diagram never returns to the previous state. As a result, the eth carrier will never be enabled in the future.

This problem is fixed by only changing to the next state if the interface is available.

Fixes: #56654