### PR TITLE
boards/arm/efr32xg24_dk2601b: enable semailbox 

### DIFF
--- a/boards/arm/efr32xg24_dk2601b/efr32xg24_dk2601b.dts
+++ b/boards/arm/efr32xg24_dk2601b/efr32xg24_dk2601b.dts
@@ -105,6 +105,10 @@
 	status = "okay";
 };
 
+&se {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/dts/arm/silabs/efr32mg24.dtsi
+++ b/dts/arm/silabs/efr32mg24.dtsi
@@ -13,7 +13,7 @@
 / {
 	chosen {
 		zephyr,flash-controller = &msc;
-		zephyr,entropy = &trng;
+		zephyr,entropy = &se;
 	};
 
 	cpus {
@@ -67,11 +67,12 @@
 			status = "disabled";
 		};
 
-		trng: trng@5c021000 {
-			compatible = "silabs,gecko-trng";
-			reg = < 0x5C021000 0x1000 >;
+		se: semailbox@5c021000 {
+			compatible = "silabs,gecko-semailbox";
+			reg = <0x5c021000 0x1000>;
 			status = "disabled";
-			interrupts = < 0x1 0x0 >;
+			interrupts = <64 3>, <65 3>, <66 3>;
+			interrupt-names = "SETAMPERHOST", "SEMBRX", "SEMBTX";
 		};
 
 		i2c0: i2c@5b000000 {

--- a/soc/arm/silabs_exx32/efr32mg24/Kconfig.series
+++ b/soc/arm/silabs_exx32/efr32mg24/Kconfig.series
@@ -20,5 +20,6 @@ config SOC_SERIES_EFR32MG24
 	select SOC_GECKO_EMU
 	select SOC_GECKO_GPIO
 	select SOC_GECKO_DEV_INIT
+	select SOC_GECKO_SE
 	help
 	  Enable support for EFR32MG24 Mighty Gecko MCU series


### PR DESCRIPTION
This PR enables the Secure Element Mailbox node for the `efr32xg24_dk2601b` and uses it as an entropy source.