### PR TITLE
stm32h5 supports CAN peripheral

### DIFF
--- a/boards/arm/stm32h573i_dk/doc/index.rst
+++ b/boards/arm/stm32h573i_dk/doc/index.rst
@@ -187,6 +187,8 @@ hardware features:
 +-----------+------------+-------------------------------------+
 | OCTOSPI   | on-chip    | octospi                             |
 +-----------+------------+-------------------------------------+
+| CAN       | on-chip    | can bus                             |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,canbus = &can1;
 	};
 
 	leds {
@@ -189,6 +190,16 @@
 	pinctrl-0 = <&spi2_nss_pa3 &spi2_sck_pi1
 		     &spi2_miso_pi2 &spi2_mosi_pb15>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&can1 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>,
+		<&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
+	pinctrl-0 = <&fdcan1_rx_pa11 &fdcan1_tx_pa12>;
+	pinctrl-names = "default";
+	bus-speed = <125000>;
+	bus-speed-data = <1000000>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32h573i_dk/stm32h573i_dk.yaml
+++ b/boards/arm/stm32h573i_dk/stm32h573i_dk.yaml
@@ -19,3 +19,4 @@ supported:
   - counter
   - spi
   - octospi
+  - can

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -403,6 +403,32 @@
 			status = "disabled";
 		};
 
+		can {
+			compatible = "bosch,m_can-base";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			std-filter-elements = <28>;
+			ext-filter-elements = <8>;
+			rx-fifo0-elements = <3>;
+			rx-fifo1-elements = <3>;
+			rx-buffer-elements = <0>;
+			tx-buffer-elements = <3>;
+
+			can1: can@4000a400 {
+				compatible = "st,stm32-fdcan";
+				reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
+				reg-names = "m_can", "message_ram";
+				interrupts = <39 0>, <40 0>;
+				interrupt-names = "LINE_0", "LINE_1";
+				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
+				status = "disabled";
+				sjw = <1>;
+				sample-point = <875>;
+				sjw-data = <1>;
+				sample-point-data = <875>;
+			};
+		};
+
 		rng: rng@420c0800 {
 			compatible = "st,stm32-rng";
 			reg = <0x420c0800 0x400>;

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -243,5 +243,22 @@
 				status = "disabled";
 			};
 		};
+
+		can {
+			can2: can@4000a800 {
+				compatible = "st,stm32-fdcan";
+				reg = <0x4000a800 0x400>, <0x4000af50 0x350>;
+				reg-names = "m_can", "message_ram";
+				interrupts = <109 0>, <110 0>;
+				interrupt-names = "LINE_0", "LINE_1";
+				/* common clock FDCAN 1 & 2 */
+				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
+				status = "disabled";
+				sjw = <1>;
+				sample-point = <875>;
+				sjw-data = <1>;
+				sample-point-data = <875>;
+			};
+		};
 	};
 };


### PR DESCRIPTION
Add the support of the CAN bus to the stm32H5 serie.

There is  one CAN 1 instance of the peripheral on the stm32h50x devices
and another CAN 2 instance on stm32h56x/57x devices.

Enable the CAN1 node on the stm32h573i_dk board with arbitrary pining (just for test purpose).
and select the PLL1_Q as common CAN peripheral clock source.

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)