### PR TITLE
twister: Use pyelf to extract symbol information

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -273,7 +273,7 @@ class TestInstance:
         fns = [x for x in fns if '_pre' not in os.path.split(x)[-1]]
         # EFI elf files
         fns = [x for x in fns if 'zefi' not in os.path.split(x)[-1]]
-        if len(fns) != 1:
+        if len(fns) != 1 and self.platform.type != 'native':
             raise BuildError("Missing/multiple output ELF binary")
         return fns[0]
 

--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -4,7 +4,6 @@
 config ZTEST
 	bool "Zephyr testing framework"
 	select TEST
-	select OUTPUT_SYMBOLS
 	help
 	  Enable the Zephyr testing framework. You should enable this only
 	  if you're writing automated tests.


### PR DESCRIPTION
For ztest twister would parse the symbol information that was generated as part of the build (zephyr.symbols).  However the format of the zephyr.symbols files is highly dependant on the toolchain.

Move to using pyelf to parse the symbol information directly from zephyr.elf instead so that this works regardless of toolchain.