### PR TITLE
tests/sprintf: Skip UB-dependent tests on armclang

### DIFF
--- a/tests/lib/sprintf/src/main.c
+++ b/tests/lib/sprintf/src/main.c
@@ -791,7 +791,7 @@ ZTEST(sprintf, test_fprintf)
 	ret = fprintf(stdout, "");
 	zassert_equal(ret, 0, "fprintf failed!");
 
-#ifndef CONFIG_PICOLIBC	/* this is UB */
+#if !defined(CONFIG_PICOLIBC) && !defined(CONFIG_ARMCLANG_STD_LIBC)	/* this is UB */
 	ret = fprintf(NULL, "%d", i);
 	zassert_equal(ret, EOF, "fprintf failed!");
 #endif
@@ -883,7 +883,7 @@ ZTEST(sprintf, test_put)
 	ret = fputs("This 3\n", stderr);
 	zassert_equal(ret, 0, "fputs \"This 3\" failed");
 
-#ifndef CONFIG_PICOLIBC	/* this is UB */
+#if !defined(CONFIG_PICOLIBC) && !defined(CONFIG_ARMCLANG_STD_LIBC)	/* this is UB */
 	ret = fputs("This 3", NULL);
 	zassert_equal(ret, EOF, "fputs \"This 3\" failed");
 #endif
@@ -894,7 +894,7 @@ ZTEST(sprintf, test_put)
 	ret = fputc('T', stdout);
 	zassert_equal(ret, 84, "fputc \'T\' failed");
 
-#ifndef CONFIG_PICOLIBC	/* this is UB */
+#if !defined(CONFIG_PICOLIBC) && !defined(CONFIG_ARMCLANG_STD_LIBC)	/* this is UB */
 	ret = fputc('T', NULL);
 	zassert_equal(ret, EOF, "fputc \'T\' failed");
 #endif
@@ -902,7 +902,7 @@ ZTEST(sprintf, test_put)
 	ret = putc('T', stdout);
 	zassert_equal(ret, 84, "putc \'T\' failed");
 
-#ifndef CONFIG_PICOLIBC	/* this is UB */
+#if !defined(CONFIG_PICOLIBC) && !defined(CONFIG_ARMCLANG_STD_LIBC)	/* this is UB */
 	ret = putc('T', NULL);
 	zassert_equal(ret, EOF, "putc \'T\' failed");
 #endif


### PR DESCRIPTION
There are several tests with undefined behavior ("UB") this causes compile warnings with armclang.  Skip these tests in this case.