### PR TITLE
emul: Use STRUCT_SECTION macros for emul devices

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -153,8 +153,7 @@ endif()
 zephyr_iterable_section(NAME k_p4wq_initparam KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 
 if(CONFIG_EMUL)
-  zephyr_linker_section(NAME emulators_section GROUP RODATA_REGION ${XIP_ALIGN_WITH_INPUT})
-  zephyr_linker_section_configure(SECTION emulators_section INPUT ".emulators" KEEP SORT NAME)
+  zephyr_iterable_section(NAME emul KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 endif()
 
 if(CONFIG_DNS_SD)

--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -86,13 +86,6 @@ struct emul {
 };
 
 /**
- * Emulators are aggregated into an array at link time, from which emulating
- * devices can find the emulators that they are to use.
- */
-extern const struct emul __emul_list_start[];
-extern const struct emul __emul_list_end[];
-
-/**
  * @brief Use the devicetree node identifier as a unique name.
  *
  * @param node_id A devicetree node identifier
@@ -130,7 +123,7 @@ extern const struct emul __emul_list_end[];
 			.api = bus_api,                                                            \
 			.Z_EMUL_BUS(node_id, addr, chipsel, chipsel) = DT_REG_ADDR(node_id),       \
 	};                                                                                         \
-	const struct emul EMUL_DT_NAME_GET(node_id) __attribute__((__section__(".emulators")))     \
+	const STRUCT_SECTION_ITERABLE(emul, EMUL_DT_NAME_GET(node_id))                             \
 	__used = {                                                                                 \
 		.init = (init_fn),                                                                 \
 		.dev = DEVICE_DT_GET(node_id),                                                     \

--- a/include/zephyr/linker/common-rom/common-rom-misc.ld
+++ b/include/zephyr/linker/common-rom/common-rom-misc.ld
@@ -21,12 +21,7 @@
 #endif
 
 #if defined(CONFIG_EMUL)
-	SECTION_DATA_PROLOGUE(emulators_section,,)
-	{
-		__emul_list_start = .;
-		KEEP(*(SORT_BY_NAME(".emulators")));
-		__emul_list_end = .;
-	} GROUP_LINK_IN(ROMABLE_REGION)
+	ITERABLE_SECTION_ROM(emul, 4)
 #endif /* CONFIG_EMUL */
 
 	SECTION_DATA_PROLOGUE(symbol_to_keep,,)

--- a/subsys/emul/emul.c
+++ b/subsys/emul/emul.c
@@ -15,9 +15,7 @@ LOG_MODULE_REGISTER(emul);
 
 const struct emul *emul_get_binding(const char *name)
 {
-	const struct emul *emul_it;
-
-	for (emul_it = __emul_list_start; emul_it < __emul_list_end; emul_it++) {
+	STRUCT_SECTION_FOREACH(emul, emul_it) {
 		if (strcmp(emul_it->dev->name, name) == 0) {
 			return emul_it;
 		}


### PR DESCRIPTION
Clean up emulator code to utilize macros for handling sections.