### PR TITLE
open-amp: Fix compilation with cache enabled

### DIFF
--- a/lib/open-amp/CMakeLists.txt
+++ b/lib/open-amp/CMakeLists.txt
@@ -6,7 +6,3 @@
 
 zephyr_include_directories_ifdef(CONFIG_OPENAMP_RSC_TABLE .)
 zephyr_sources_ifdef(CONFIG_OPENAMP_RSC_TABLE resource_table.c)
-
-zephyr_compile_definitions_ifdef(CONFIG_OPENAMP_WITH_DCACHE
-				 WITH_DCACHE_VRINGS
-				 WITH_DCACHE_BUFFERS)

--- a/lib/open-amp/Kconfig
+++ b/lib/open-amp/Kconfig
@@ -18,10 +18,3 @@ config OPENAMP_RSC_TABLE_NUM_RPMSG_BUFF
 	help
 	  This option specifies the number of buffer used in a Vring for
 	  interprocessor communication
-
-config OPENAMP_WITH_DCACHE
-	bool "Build OpenAMP with vrings cache operations enabled"
-	default y
-	depends on CACHE_MANAGEMENT
-	help
-	  Build OpenAMP with vrings cache operations enabled.

--- a/modules/Kconfig.open-amp
+++ b/modules/Kconfig.open-amp
@@ -28,4 +28,9 @@ config OPENAMP_SLAVE
 	help
 	  This option enables support for OpenAMP VirtIO Slave
 
+config OPENAMP_WITH_DCACHE
+	bool "Build OpenAMP with vrings cache operations enabled"
+	depends on CACHE_MANAGEMENT
+	help
+	  Build OpenAMP with vrings cache operations enabled.
 endif # OPENAMP

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       revision: 7078310d522664b1612ebac93240b367c4c96299
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
-      revision: aedcc262f93bbb1b0c2f58026911575729b7465c
+      revision: 233fb29c52ffa7733ba132a2b5987a8201ba8ec6
       path: modules/lib/open-amp
     - name: openthread
       revision: 7bdcf8a5d49838ce6e3e227e2780e4f12c461330


### PR DESCRIPTION
In d540cf8877f I tried to optionally enable the cache management functions in Open-AMP introducing a new `CONFIG_OPENAMP_WITH_DCACHE` symbol.

This is not working. Introduce a proper fix to have this actually working correctly as intended.

Fixes: d540cf8877f