### PR TITLE
drivers: sensor: Store sensor trigger as a pointer - batch 3

### DIFF
--- a/drivers/sensor/mcp9808/mcp9808.h
+++ b/drivers/sensor/mcp9808/mcp9808.h
@@ -66,7 +66,7 @@ struct mcp9808_data {
 
 	const struct device *dev;
 
-	struct sensor_trigger trig;
+	const struct sensor_trigger *trig;
 	sensor_trigger_handler_t trigger_handler;
 #endif
 

--- a/drivers/sensor/mcp9808/mcp9808_trigger.c
+++ b/drivers/sensor/mcp9808/mcp9808_trigger.c
@@ -78,7 +78,7 @@ static void process_int(const struct device *dev)
 	struct mcp9808_data *data = dev->data;
 
 	if (data->trigger_handler) {
-		data->trigger_handler(dev, &data->trig);
+		data->trigger_handler(dev, data->trig);
 	}
 
 	if (data->trigger_handler) {
@@ -100,7 +100,7 @@ int mcp9808_trigger_set(const struct device *dev,
 
 	setup_int(dev, false);
 
-	data->trig = *trig;
+	data->trig = trig;
 	data->trigger_handler = handler;
 
 	if (handler != NULL) {

--- a/drivers/sensor/mcux_acmp/mcux_acmp.c
+++ b/drivers/sensor/mcux_acmp/mcux_acmp.c
@@ -63,8 +63,10 @@ struct mcux_acmp_data {
 #endif
 #ifdef CONFIG_MCUX_ACMP_TRIGGER
 	const struct device *dev;
-	sensor_trigger_handler_t rising;
-	sensor_trigger_handler_t falling;
+	sensor_trigger_handler_t rising_handler;
+	const struct sensor_trigger *rising_trigger;
+	sensor_trigger_handler_t falling_handler;
+	const struct sensor_trigger *falling_trigger;
 	struct k_work work;
 	volatile uint32_t status;
 #endif /* CONFIG_MCUX_ACMP_TRIGGER */
@@ -379,10 +381,12 @@ static int mcux_acmp_trigger_set(const struct device *dev,
 
 	switch ((int16_t)trig->type) {
 	case SENSOR_TRIG_MCUX_ACMP_OUTPUT_RISING:
-		data->rising = handler;
+		data->rising_handler = handler;
+		data->rising_trigger = trig;
 		break;
 	case SENSOR_TRIG_MCUX_ACMP_OUTPUT_FALLING:
-		data->falling = handler;
+		data->falling_handler = handler;
+		data->falling_trigger = trig;
 		break;
 	default:
 		return -ENOTSUP;
@@ -393,22 +397,21 @@ static int mcux_acmp_trigger_set(const struct device *dev,
 
 static void mcux_acmp_trigger_work_handler(struct k_work *item)
 {
-	static struct sensor_trigger trigger;
+	const struct sensor_trigger *trigger;
 	struct mcux_acmp_data *data =
 		CONTAINER_OF(item, struct mcux_acmp_data, work);
 	sensor_trigger_handler_t handler = NULL;
 
 	if (data->status & kACMP_OutputRisingEventFlag) {
-		trigger.type = SENSOR_TRIG_MCUX_ACMP_OUTPUT_RISING;
-		handler = data->rising;
+		handler = data->rising_handler;
+		trigger = data->rising_trigger;
 	} else if (data->status & kACMP_OutputFallingEventFlag) {
-		trigger.type = SENSOR_TRIG_MCUX_ACMP_OUTPUT_FALLING;
-		handler = data->falling;
+		handler = data->falling_handler;
+		trigger = data->falling_trigger;
 	}
 
 	if (handler) {
-		trigger.chan = SENSOR_CHAN_MCUX_ACMP_OUTPUT;
-		handler(data->dev, &trigger);
+		handler(data->dev, trigger);
 	}
 }
 

--- a/drivers/sensor/mpu6050/mpu6050.h
+++ b/drivers/sensor/mpu6050/mpu6050.h
@@ -54,7 +54,7 @@ struct mpu6050_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
 
 #if defined(CONFIG_MPU6050_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/mpu6050/mpu6050_trigger.c
+++ b/drivers/sensor/mpu6050/mpu6050_trigger.c
@@ -36,7 +36,7 @@ int mpu6050_trigger_set(const struct device *dev,
 		return 0;
 	}
 
-	drv_data->data_ready_trigger = *trig;
+	drv_data->data_ready_trigger = trig;
 
 	gpio_pin_interrupt_configure_dt(&cfg->int_gpio,
 					GPIO_INT_EDGE_TO_ACTIVE);
@@ -69,7 +69,7 @@ static void mpu6050_thread_cb(const struct device *dev)
 
 	if (drv_data->data_ready_handler != NULL) {
 		drv_data->data_ready_handler(dev,
-					     &drv_data->data_ready_trigger);
+					     drv_data->data_ready_trigger);
 	}
 
 	gpio_pin_interrupt_configure_dt(&cfg->int_gpio,

--- a/drivers/sensor/mpu9250/mpu9250.h
+++ b/drivers/sensor/mpu9250/mpu9250.h
@@ -41,7 +41,7 @@ struct mpu9250_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
 
 #if defined(CONFIG_MPU9250_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/mpu9250/mpu9250_trigger.c
+++ b/drivers/sensor/mpu9250/mpu9250_trigger.c
@@ -39,7 +39,7 @@ int mpu9250_trigger_set(const struct device *dev,
 		return 0;
 	}
 
-	drv_data->data_ready_trigger = *trig;
+	drv_data->data_ready_trigger = trig;
 
 	ret = gpio_pin_interrupt_configure_dt(&cfg->int_pin,
 					      GPIO_INT_EDGE_TO_ACTIVE);
@@ -82,7 +82,7 @@ static void mpu9250_thread_cb(const struct device *dev)
 
 	if (drv_data->data_ready_handler != NULL) {
 		drv_data->data_ready_handler(dev,
-					     &drv_data->data_ready_trigger);
+					     drv_data->data_ready_trigger);
 	}
 
 	ret = gpio_pin_interrupt_configure_dt(&cfg->int_pin,

--- a/drivers/sensor/sht3xd/sht3xd.h
+++ b/drivers/sensor/sht3xd/sht3xd.h
@@ -66,7 +66,7 @@ struct sht3xd_data {
 	uint16_t rh_high;
 
 	sensor_trigger_handler_t handler;
-	struct sensor_trigger trigger;
+	const struct sensor_trigger *trigger;
 
 #if defined(CONFIG_SHT3XD_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_SHT3XD_THREAD_STACK_SIZE);

--- a/drivers/sensor/sht3xd/sht3xd_trigger.c
+++ b/drivers/sensor/sht3xd/sht3xd_trigger.c
@@ -127,7 +127,7 @@ int sht3xd_trigger_set(const struct device *dev,
 		return 0;
 	}
 
-	data->trigger = *trig;
+	data->trigger = trig;
 
 	setup_alert(dev, true);
 
@@ -155,7 +155,7 @@ static void sht3xd_thread_cb(const struct device *dev)
 	struct sht3xd_data *data = dev->data;
 
 	if (data->handler != NULL) {
-		data->handler(dev, &data->trigger);
+		data->handler(dev, data->trigger);
 	}
 
 	setup_alert(dev, true);

--- a/drivers/sensor/sm351lt/sm351lt.c
+++ b/drivers/sensor/sm351lt/sm351lt.c
@@ -30,6 +30,7 @@ static int sm351lt_trigger_set(const struct device *dev,
 
 	if (trig->chan == SENSOR_CHAN_PROX) {
 		data->changed_handler = handler;
+		data->changed_trigger = trig;
 		ret = gpio_pin_interrupt_configure_dt(&config->int_gpio,
 						      (handler ? data->trigger_type
 							       : GPIO_INT_DISABLE));
@@ -67,13 +68,8 @@ static void sm351lt_thread_cb(const struct device *dev)
 {
 	struct sm351lt_data *data = dev->data;
 
-	struct sensor_trigger mag_trigger = {
-		.type = SENSOR_TRIG_NEAR_FAR,
-		.chan = SENSOR_CHAN_PROX,
-	};
-
 	if (likely(data->changed_handler != NULL)) {
-		data->changed_handler(dev, &mag_trigger);
+		data->changed_handler(dev, data->changed_trigger);
 	}
 
 	return;

--- a/drivers/sensor/sm351lt/sm351lt.h
+++ b/drivers/sensor/sm351lt/sm351lt.h
@@ -27,6 +27,7 @@ struct sm351lt_data {
 
 	uint32_t trigger_type;
 	sensor_trigger_handler_t changed_handler;
+	const struct sensor_trigger *changed_trigger;
 
 #if defined(CONFIG_SM351LT_TRIGGER_OWN_THREAD)
 	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_SM351LT_THREAD_STACK_SIZE);

--- a/drivers/sensor/stts751/stts751.h
+++ b/drivers/sensor/stts751/stts751.h
@@ -43,7 +43,7 @@ struct stts751_data {
 #ifdef CONFIG_STTS751_TRIGGER
 	struct gpio_callback gpio_cb;
 
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *thsld_trigger;
 	sensor_trigger_handler_t thsld_handler;
 
 #if defined(CONFIG_STTS751_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/stts751/stts751_trigger.c
+++ b/drivers/sensor/stts751/stts751_trigger.c
@@ -46,6 +46,7 @@ int stts751_trigger_set(const struct device *dev,
 
 	if (trig->chan == SENSOR_CHAN_ALL) {
 		stts751->thsld_handler = handler;
+		stts751->thsld_trigger = trig;
 		if (handler) {
 			return stts751_enable_int(dev, 1);
 		} else {
@@ -64,16 +65,13 @@ static void stts751_handle_interrupt(const struct device *dev)
 {
 	struct stts751_data *stts751 = dev->data;
 	const struct stts751_config *cfg = dev->config;
-	struct sensor_trigger thsld_trigger = {
-		.type = SENSOR_TRIG_THRESHOLD,
-	};
 	stts751_status_t status;
 
 	stts751_status_reg_get(stts751->ctx, &status);
 
 	if (stts751->thsld_handler != NULL &&
 	    (status.t_high || status.t_low)) {
-		stts751->thsld_handler(dev, &thsld_trigger);
+		stts751->thsld_handler(dev, stts751->thsld_trigger);
 	}
 
 	gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);

--- a/drivers/sensor/sx9500/sx9500.h
+++ b/drivers/sensor/sx9500/sx9500.h
@@ -47,8 +47,8 @@ struct sx9500_data {
 
 #ifdef CONFIG_SX9500_TRIGGER
 	const struct device *dev;
-	struct sensor_trigger trigger_drdy;
-	struct sensor_trigger trigger_near_far;
+	const struct sensor_trigger *trigger_drdy;
+	const struct sensor_trigger *trigger_near_far;
 
 	sensor_trigger_handler_t handler_drdy;
 	sensor_trigger_handler_t handler_near_far;

--- a/drivers/sensor/sx9500/sx9500_trigger.c
+++ b/drivers/sensor/sx9500/sx9500_trigger.c
@@ -44,7 +44,7 @@ int sx9500_trigger_set(const struct device *dev,
 			return -EIO;
 		}
 		data->handler_drdy = handler;
-		data->trigger_drdy = *trig;
+		data->trigger_drdy = trig;
 		break;
 
 	case SENSOR_TRIG_NEAR_FAR:
@@ -55,7 +55,7 @@ int sx9500_trigger_set(const struct device *dev,
 			return -EIO;
 		}
 		data->handler_near_far = handler;
-		data->trigger_near_far = *trig;
+		data->trigger_near_far = trig;
 		break;
 
 	default:
@@ -77,11 +77,11 @@ static void sx9500_gpio_thread_cb(const struct device *dev)
 	}
 
 	if ((reg_val & SX9500_CONV_DONE_IRQ) && data->handler_drdy) {
-		data->handler_drdy(dev, &data->trigger_drdy);
+		data->handler_drdy(dev, data->trigger_drdy);
 	}
 
 	if ((reg_val & SX9500_NEAR_FAR_IRQ) && data->handler_near_far) {
-		data->handler_near_far(dev, &data->trigger_near_far);
+		data->handler_near_far(dev, data->trigger_near_far);
 	}
 }
 

--- a/drivers/sensor/tmp007/tmp007.h
+++ b/drivers/sensor/tmp007/tmp007.h
@@ -47,10 +47,10 @@ struct tmp007_data {
 	const struct device *dev;
 
 	sensor_trigger_handler_t drdy_handler;
-	struct sensor_trigger drdy_trigger;
+	const struct sensor_trigger *drdy_trigger;
 
 	sensor_trigger_handler_t th_handler;
-	struct sensor_trigger th_trigger;
+	const struct sensor_trigger *th_trigger;
 
 #if defined(CONFIG_TMP007_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_TMP007_THREAD_STACK_SIZE);

--- a/drivers/sensor/tmp007/tmp007_trigger.c
+++ b/drivers/sensor/tmp007/tmp007_trigger.c
@@ -93,12 +93,12 @@ static void tmp007_thread_cb(const struct device *dev)
 
 	if (status & TMP007_DATA_READY_INT_BIT &&
 	    drv_data->drdy_handler != NULL) {
-		drv_data->drdy_handler(dev, &drv_data->drdy_trigger);
+		drv_data->drdy_handler(dev, drv_data->drdy_trigger);
 	}
 
 	if (status & TMP007_TOBJ_TH_INT_BITS &&
 	    drv_data->th_handler != NULL) {
-		drv_data->th_handler(dev, &drv_data->th_trigger);
+		drv_data->th_handler(dev, drv_data->th_trigger);
 	}
 
 	setup_int(dev, true);
@@ -139,10 +139,10 @@ int tmp007_trigger_set(const struct device *dev,
 
 	if (trig->type == SENSOR_TRIG_DATA_READY) {
 		drv_data->drdy_handler = handler;
-		drv_data->drdy_trigger = *trig;
+		drv_data->drdy_trigger = trig;
 	} else if (trig->type == SENSOR_TRIG_THRESHOLD) {
 		drv_data->th_handler = handler;
-		drv_data->th_trigger = *trig;
+		drv_data->th_trigger = trig;
 	}
 
 	setup_int(dev, true);

--- a/drivers/sensor/tmp108/tmp108.h
+++ b/drivers/sensor/tmp108/tmp108.h
@@ -113,11 +113,11 @@ struct tmp108_data {
 
 	struct k_work_delayable scheduled_work;
 
-	struct sensor_trigger temp_alert_trigger;
+	const struct sensor_trigger *temp_alert_trigger;
 	sensor_trigger_handler_t temp_alert_handler;
 
 	sensor_trigger_handler_t data_ready_handler;
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *data_ready_trigger;
 
 	struct gpio_callback temp_alert_gpio_cb;
 };

--- a/drivers/sensor/tmp108/tmp108_trigger.c
+++ b/drivers/sensor/tmp108/tmp108_trigger.c
@@ -24,11 +24,6 @@ void tmp108_trigger_handle_one_shot(struct k_work *work)
 						    struct tmp108_data,
 						    scheduled_work);
 
-	struct sensor_trigger sensor_trigger_type = {
-		.chan = SENSOR_CHAN_AMBIENT_TEMP,
-		.type = SENSOR_TRIG_DATA_READY
-	};
-
 	uint16_t config = 0;
 	bool shutdown_mode = false;
 
@@ -54,7 +49,7 @@ void tmp108_trigger_handle_one_shot(struct k_work *work)
 	/* Successful read, call set callbacks */
 	if (drv_data->data_ready_handler) {
 		drv_data->data_ready_handler(drv_data->tmp108_dev,
-					     &sensor_trigger_type);
+					     drv_data->data_ready_trigger);
 	}
 }
 
@@ -67,15 +62,10 @@ void tmp108_trigger_handle_alert(const struct device *gpio,
 						    struct tmp108_data,
 						    temp_alert_gpio_cb);
 
-	struct sensor_trigger sensor_trigger_type = {
-		.chan = SENSOR_CHAN_AMBIENT_TEMP,
-		.type = SENSOR_TRIG_THRESHOLD
-	};
-
 	/* Successful read, call set callbacks */
 	if (drv_data->temp_alert_handler) {
 		drv_data->temp_alert_handler(drv_data->tmp108_dev,
-					     &sensor_trigger_type);
+					     drv_data->temp_alert_trigger);
 	}
 }
 
@@ -87,13 +77,13 @@ int tmp_108_trigger_set(const struct device *dev,
 
 	if (trig->type == SENSOR_TRIG_DATA_READY) {
 		drv_data->data_ready_handler = handler;
-		drv_data->data_ready_trigger = *trig;
+		drv_data->data_ready_trigger = trig;
 		return 0;
 	}
 
 	if (trig->type == SENSOR_TRIG_THRESHOLD) {
 		drv_data->temp_alert_handler = handler;
-		drv_data->temp_alert_trigger = *trig;
+		drv_data->temp_alert_trigger = trig;
 		return 0;
 	}
 

--- a/drivers/sensor/vcnl4040/vcnl4040.h
+++ b/drivers/sensor/vcnl4040/vcnl4040.h
@@ -113,7 +113,9 @@ struct vcnl4040_data {
 	struct gpio_callback gpio_cb;
 	enum interrupt_type int_type;
 	sensor_trigger_handler_t proxy_handler;
+	const struct sensor_trigger *proxy_trigger;
 	sensor_trigger_handler_t als_handler;
+	const struct sensor_trigger *als_trigger;
 #endif
 #ifdef CONFIG_VCNL4040_TRIGGER_OWN_THREAD
 	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_VCNL4040_THREAD_STACK_SIZE);

--- a/drivers/sensor/vcnl4040/vcnl4040_trigger.c
+++ b/drivers/sensor/vcnl4040/vcnl4040_trigger.c
@@ -40,13 +40,9 @@ static void vcnl4040_gpio_callback(const struct device *dev,
 static int vcnl4040_handle_proxy_int(const struct device *dev)
 {
 	struct vcnl4040_data *data = dev->data;
-	struct sensor_trigger proxy_trig = {
-		.type = SENSOR_TRIG_THRESHOLD,
-		.chan = SENSOR_CHAN_PROX,
-	};
 
 	if (data->proxy_handler != NULL) {
-		data->proxy_handler(dev, &proxy_trig);
+		data->proxy_handler(dev, data->proxy_trigger);
 	}
 
 	return 0;
@@ -55,13 +51,9 @@ static int vcnl4040_handle_proxy_int(const struct device *dev)
 static int vcnl4040_handle_als_int(const struct device *dev)
 {
 	struct vcnl4040_data *data = dev->data;
-	struct sensor_trigger als_trig = {
-		.type = SENSOR_TRIG_THRESHOLD,
-		.chan = SENSOR_CHAN_LIGHT,
-	};
 
 	if (data->als_handler != NULL) {
-		data->als_handler(dev, &als_trig);
+		data->als_handler(dev, data->als_trigger);
 	}
 
 	return 0;
@@ -213,6 +205,7 @@ int vcnl4040_trigger_set(const struct device *dev,
 			}
 
 			data->proxy_handler = handler;
+			data->proxy_trigger = trig;
 		} else if (trig->chan == SENSOR_CHAN_LIGHT) {
 #ifdef CONFIG_VCNL4040_ENABLE_ALS
 			if (vcnl4040_read(dev, VCNL4040_REG_ALS_CONF, &conf)) {
@@ -229,6 +222,7 @@ int vcnl4040_trigger_set(const struct device *dev,
 			}
 
 			data->als_handler = handler;
+			data->als_trigger = trig;
 #else
 			ret = -ENOTSUP;
 			goto exit;

--- a/drivers/sensor/wsen_hids/wsen_hids.h
+++ b/drivers/sensor/wsen_hids/wsen_hids.h
@@ -36,7 +36,7 @@ struct hids_data {
 	const struct device *dev;
 	struct gpio_callback data_ready_cb;
 
-	struct sensor_trigger data_ready_trigger;
+	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
 
 #if defined(CONFIG_WSEN_HIDS_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/wsen_hids/wsen_hids_trigger.c
+++ b/drivers/sensor/wsen_hids/wsen_hids_trigger.c
@@ -38,7 +38,7 @@ static void hids_process_drdy_interrupt(const struct device *dev)
 	struct hids_data *data = dev->data;
 
 	if (data->data_ready_handler != NULL) {
-		data->data_ready_handler(dev, &data->data_ready_trigger);
+		data->data_ready_handler(dev, data->data_ready_trigger);
 	}
 
 	if (data->data_ready_handler != NULL) {
@@ -64,7 +64,7 @@ int hids_trigger_set(const struct device *dev, const struct sensor_trigger *trig
 		return 0;
 	}
 
-	data->data_ready_trigger = *trig;
+	data->data_ready_trigger = trig;
 
 	hids_setup_drdy_interrupt(dev, true);
 

--- a/drivers/sensor/wsen_itds/itds.h
+++ b/drivers/sensor/wsen_itds/itds.h
@@ -113,6 +113,7 @@ struct itds_device_data {
 
 #ifdef CONFIG_ITDS_TRIGGER
 	sensor_trigger_handler_t handler_drdy;
+	const struct sensor_trigger *trigger_drdy;
 #endif /* CONFIG_ITDS_TRIGGER */
 };
 

--- a/drivers/sensor/wsen_tids/wsen_tids.h
+++ b/drivers/sensor/wsen_tids/wsen_tids.h
@@ -29,7 +29,7 @@ struct tids_data {
 	/* Callback for high/low limit interrupts */
 	struct gpio_callback threshold_cb;
 
-	struct sensor_trigger threshold_trigger;
+	const struct sensor_trigger *threshold_trigger;
 	sensor_trigger_handler_t threshold_handler;
 
 #if defined(CONFIG_WSEN_TIDS_TRIGGER_OWN_THREAD)

--- a/drivers/sensor/wsen_tids/wsen_tids_trigger.c
+++ b/drivers/sensor/wsen_tids/wsen_tids_trigger.c
@@ -65,7 +65,7 @@ static void tids_process_threshold_interrupt(const struct device *dev)
 
 	if (data->threshold_handler != NULL &&
 	    (status.upperLimitExceeded != 0 || status.lowerLimitExceeded != 0)) {
-		data->threshold_handler(dev, &data->threshold_trigger);
+		data->threshold_handler(dev, data->threshold_trigger);
 	}
 
 	if (data->threshold_handler != NULL) {
@@ -92,7 +92,7 @@ int tids_trigger_set(const struct device *dev, const struct sensor_trigger *trig
 		return 0;
 	}
 
-	data->threshold_trigger = *trig;
+	data->threshold_trigger = trig;
 
 	tids_setup_threshold_interrupt(dev, true);
 


### PR DESCRIPTION
Fixes the last batch of sensor drivers to store the user-supplied sensor
trigger as a pointer rather than a copy. This enables the trigger
handler to use CONTAINER_OF to retrieve a context pointer when the
trigger is embedded in a larger struct.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

Fixes #55130 (this is the last batch after #55566 and #56123)

cc: @anthony32086 @huhebo