### PR TITLE
docs/build-flash-debug: expand one-time CMake arguments section

### DIFF
--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -208,10 +208,15 @@ build``, pass them after a ``--`` at the end of the command line.
 .. important::
 
    Passing additional CMake arguments like this forces ``west build`` to re-run
-   CMake, even if a build system has already been generated.
+   the CMake build configuration step, even if a build system has already been
+   generated.  This will make incremental builds slower (but still much faster
+   than building from scratch).
 
    After using ``--`` once to generate the build directory, use ``west build -d
    <build-dir>`` on subsequent runs to do incremental builds.
+
+   Alternatively, make your CMake arguments permanent as described in the next
+   section; it will not slow down incremental builds.
 
 For example, to use the Unix Makefiles CMake generator instead of Ninja (which
 ``west build`` uses by default), run::


### PR DESCRIPTION
- Change "re-run CMake" to "re-run CMake configuration steps" because `west build -v ...` displays `cmake --build ...` every time which can confuse non-experts.

- Explain what is the actual issue with re-configuring: it makes the incremental builds slower. But not much slower:

```
   $ west  build -b qemu_x86 samples/hello_world/ -DCONFIG_OUTPUT_STAT=y
   [133/133] Linking C executable zephyr/zephyr.elf
   $ west  build -b qemu_x86 samples/hello_world/ -DCONFIG_OUTPUT_STAT=y
   [16/16] Linking C executable zephyr/zephyr.elf
```

- Explain that the best solution is to simply skip to the next section

EDIT: this was found in bug
- #56501

It was previously discussed (and misunderstood) in:
- https://github.com/zephyrproject-rtos/zephyr/pull/40431
- https://github.com/zephyrproject-rtos/zephyr/issues/40808