### PR TITLE
drivers: support of 64-bit addresses from Device Tree

### DIFF
--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -22,9 +22,9 @@
 #include <zephyr/irq.h>
 
 #define PLIC_MAX_PRIO	DT_INST_PROP(0, riscv_max_priority)
-#define PLIC_PRIO	DT_INST_REG_ADDR_BY_NAME(0, prio)
-#define PLIC_IRQ_EN	DT_INST_REG_ADDR_BY_NAME(0, irq_en)
-#define PLIC_REG	DT_INST_REG_ADDR_BY_NAME(0, reg)
+#define PLIC_PRIO	DT_INST_REG_ADDR_BY_NAME_U64(0, prio)
+#define PLIC_IRQ_EN	DT_INST_REG_ADDR_BY_NAME_U64(0, irq_en)
+#define PLIC_REG	DT_INST_REG_ADDR_BY_NAME_U64(0, reg)
 
 #define PLIC_IRQS        (CONFIG_NUM_IRQS - CONFIG_2ND_LVL_ISR_TBL_OFFSET)
 #define PLIC_EN_SIZE     ((PLIC_IRQS >> 5) + 1)

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -67,9 +67,9 @@
 #define DT_DRV_COMPAT scr_machine_timer
 #define MTIMER_HAS_DIVIDER
 
-#define MTIMEDIV_REG	(DT_INST_REG_ADDR(0) + 4)
-#define MTIME_REG	(DT_INST_REG_ADDR(0) + 8)
-#define MTIMECMP_REG	(DT_INST_REG_ADDR(0) + 16)
+#define MTIMEDIV_REG	(DT_INST_REG_ADDR_U64(0) + 4)
+#define MTIME_REG	(DT_INST_REG_ADDR_U64(0) + 8)
+#define MTIMECMP_REG	(DT_INST_REG_ADDR_U64(0) + 16)
 #define TIMER_IRQN	DT_INST_IRQN(0)
 #endif
 

--- a/dts/bindings/test/vnd,reg-holder-64.yaml
+++ b/dts/bindings/test/vnd,reg-holder-64.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Syntacore
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test 64-bit register property container
+
+compatible: "vnd,reg-holder-64"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  reg-names:
+    required: true

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -18,6 +18,10 @@
 
 #include <devicetree_generated.h>
 
+#if !defined(_LINKER) && !defined(_ASMLANGUAGE)
+#include <stdint.h>
+#endif
+
 #include <zephyr/sys/util.h>
 
 /**
@@ -2220,6 +2224,18 @@
 #define DT_REG_ADDR(node_id) DT_REG_ADDR_BY_IDX(node_id, 0)
 
 /**
+ * @brief 64-bit version of DT_REG_ADDR()
+ *
+ * This macro version adds the appropriate suffix for 64-bit unsigned
+ * integer literals.
+ * Note that this macro is equivalent to DT_REG_ADDR() in linker/ASM context.
+ *
+ * @param node_id node identifier
+ * @return node's register block address
+ */
+#define DT_REG_ADDR_U64(node_id) DT_U64_C(DT_REG_ADDR(node_id))
+
+/**
  * @brief Get a node's (only) register block size
  *
  * Equivalent to DT_REG_SIZE_BY_IDX(node_id, 0).
@@ -2236,6 +2252,21 @@
  */
 #define DT_REG_ADDR_BY_NAME(node_id, name) \
 	DT_CAT4(node_id, _REG_NAME_, name, _VAL_ADDRESS)
+
+/**
+ * @brief 64-bit version of DT_REG_ADDR_BY_NAME()
+ *
+ * This macro version adds the appropriate suffix for 64-bit unsigned
+ * integer literals.
+ * Note that this macro is equivalent to DT_REG_ADDR_BY_NAME() in
+ * linker/ASM context.
+ *
+ * @param node_id node identifier
+ * @param name lowercase-and-underscores register specifier name
+ * @return address of the register block specified by name
+ */
+#define DT_REG_ADDR_BY_NAME_U64(node_id, name) \
+	DT_U64_C(DT_REG_ADDR_BY_NAME(node_id, name))
 
 /**
  * @brief Get a register block's size by name
@@ -3682,6 +3713,21 @@
 	DT_REG_ADDR_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
+ * @brief 64-bit version of DT_INST_REG_ADDR_BY_NAME()
+ *
+ * This macro version adds the appropriate suffix for 64-bit unsigned
+ * integer literals.
+ * Note that this macro is equivalent to DT_INST_REG_ADDR_BY_NAME() in
+ * linker/ASM context.
+ *
+ * @param inst instance number
+ * @param name lowercase-and-underscores register specifier name
+ * @return address of the register block with the given @p name
+ */
+#define DT_INST_REG_ADDR_BY_NAME_U64(inst, name) \
+	DT_U64_C(DT_INST_REG_ADDR_BY_NAME(inst, name))
+
+/**
  * @brief Get a `DT_DRV_COMPAT`'s register block size by name
  * @param inst instance number
  * @param name lowercase-and-underscores register specifier name
@@ -3696,6 +3742,19 @@
  * @return instance's register block address
  */
 #define DT_INST_REG_ADDR(inst) DT_INST_REG_ADDR_BY_IDX(inst, 0)
+
+/**
+ * @brief 64-bit version of DT_INST_REG_ADDR()
+ *
+ * This macro version adds the appropriate suffix for 64-bit unsigned
+ * integer literals.
+ * Note that this macro is equivalent to DT_INST_REG_ADDR() in
+ * linker/ASM context.
+ *
+ * @param inst instance number
+ * @return instance's register block address
+ */
+#define DT_INST_REG_ADDR_U64(inst) DT_U64_C(DT_INST_REG_ADDR(inst))
 
 /**
  * @brief Get a `DT_DRV_COMPAT`'s (only) register block size
@@ -4171,6 +4230,16 @@
 /** @brief Helper macro to OR multiple has property checks in a loop macro */
 #define DT_INST_NODE_HAS_PROP_AND_OR(inst, prop) \
 	DT_INST_NODE_HAS_PROP(inst, prop) ||
+
+/**
+ * @def DT_U64_C
+ * @brief Macro to add ULL postfix to the devicetree address constants
+ */
+#if defined(_LINKER) || defined(_ASMLANGUAGE)
+#define DT_U64_C(_v) (_v)
+#else
+#define DT_U64_C(_v) UINT64_C(_v)
+#endif
 
 /** @endcond */
 

--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -116,12 +116,12 @@ struct z_device_mmio_rom {
 
 #define Z_DEVICE_MMIO_ROM_INITIALIZER(node_id) \
 	{ \
-		.addr = DT_REG_ADDR(node_id) \
+		.addr = (mm_reg_t)DT_REG_ADDR_U64(node_id) \
 	}
 
 #define Z_DEVICE_MMIO_NAMED_ROM_INITIALIZER(name, node_id) \
 	{ \
-		.addr = DT_REG_ADDR_BY_NAME(node_id, name) \
+		.addr = (mm_reg_t)DT_REG_ADDR_BY_NAME_U64(node_id, name) \
 	}
 
 #endif /* DEVICE_MMIO_IS_IN_RAM */

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -621,4 +621,16 @@
 			val = "XA XPLUS XB", "XC XPLUS XD", "XA XMINUS XB", "XC XMINUS XD";
 		};
 	};
+
+	test_64 {
+		#address-cells = < 2 >;
+		#size-cells = < 0 >;
+
+		test_reg_64: reg-holder-64@ffffffff11223344 {
+			compatible = "vnd,reg-holder-64";
+			reg = < 0xffffffff 0x11223344>;
+			status = "okay";
+			reg-names = "test_name";
+		};
+	};
 };

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -39,6 +39,7 @@
 #define TEST_VENDOR	DT_NODELABEL(test_vendor)
 #define TEST_MODEL	DT_NODELABEL(test_vendor)
 #define TEST_ENUM_0	DT_NODELABEL(test_enum_0)
+#define TEST_64BIT	DT_NODELABEL(test_reg_64)
 
 #define TEST_I2C DT_NODELABEL(test_i2c)
 #define TEST_I2C_DEV DT_PATH(test, i2c_11112222, test_i2c_dev_10)
@@ -546,12 +547,19 @@ ZTEST(devicetree_api, test_reg)
 	/* DT_REG_ADDR */
 	zassert_equal(DT_REG_ADDR(TEST_ABCD1234), 0xabcd1234, "");
 
+	/* DT_REG_ADDR_U64 */
+	zassert_equal(DT_REG_ADDR_U64(TEST_ABCD1234), 0xabcd1234, "");
+
 	/* DT_REG_SIZE */
 	zassert_equal(DT_REG_SIZE(TEST_ABCD1234), 0x500, "");
 
 	/* DT_REG_ADDR_BY_NAME */
 	zassert_equal(DT_REG_ADDR_BY_NAME(TEST_ABCD1234, one), 0xabcd1234, "");
 	zassert_equal(DT_REG_ADDR_BY_NAME(TEST_ABCD1234, two), 0x98765432, "");
+
+	/* DT_REG_ADDR_BY_NAME_U64 */
+	zassert_equal(DT_REG_ADDR_BY_NAME_U64(TEST_ABCD1234, one), 0xabcd1234, "");
+	zassert_equal(DT_REG_ADDR_BY_NAME_U64(TEST_ABCD1234, two), 0x98765432, "");
 
 	/* DT_REG_SIZE_BY_NAME */
 	zassert_equal(DT_REG_SIZE_BY_NAME(TEST_ABCD1234, one), 0x500, "");
@@ -576,6 +584,9 @@ ZTEST(devicetree_api, test_reg)
 	/* DT_INST_REG_ADDR */
 	zassert_equal(DT_INST_REG_ADDR(0), 0x9999aaaa, "");
 
+	/* DT_INST_REG_ADDR_U64 */
+	zassert_equal(DT_INST_REG_ADDR_U64(0), 0x9999aaaa, "");
+
 	/* DT_INST_REG_SIZE */
 	zassert_equal(DT_INST_REG_SIZE(0), 0x1000, "");
 
@@ -583,9 +594,30 @@ ZTEST(devicetree_api, test_reg)
 	zassert_equal(DT_INST_REG_ADDR_BY_NAME(0, first), 0x9999aaaa, "");
 	zassert_equal(DT_INST_REG_ADDR_BY_NAME(0, second), 0xbbbbcccc, "");
 
+	/* DT_INST_REG_ADDR_BY_NAME_U64 */
+	zassert_equal(DT_INST_REG_ADDR_BY_NAME_U64(0, first), 0x9999aaaa, "");
+	zassert_equal(DT_INST_REG_ADDR_BY_NAME_U64(0, second), 0xbbbbcccc, "");
+
 	/* DT_INST_REG_SIZE_BY_NAME */
 	zassert_equal(DT_INST_REG_SIZE_BY_NAME(0, first), 0x1000, "");
 	zassert_equal(DT_INST_REG_SIZE_BY_NAME(0, second), 0x3f, "");
+}
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_reg_holder_64
+ZTEST(devicetree_api, test_reg_64)
+{
+	/* DT_REG_ADDR_U64 */
+	zassert_equal(DT_REG_ADDR_U64(TEST_64BIT), 0xffffffff11223344, "");
+
+	/* DT_REG_ADDR_BY_NAME_U64 */
+	zassert_equal(DT_REG_ADDR_BY_NAME_U64(TEST_64BIT, test_name), 0xffffffff11223344, "");
+
+	/* DT_INST_REG_ADDR_U64 */
+	zassert_equal(DT_INST_REG_ADDR_U64(0), 0xffffffff11223344, "");
+
+	/* DT_INST_REG_ADDR_BY_NAME_U64 */
+	zassert_equal(DT_INST_REG_ADDR_BY_NAME_U64(0, test_name), 0xffffffff11223344, "");
 }
 
 #undef DT_DRV_COMPAT


### PR DESCRIPTION
Usage of 64-bit address constants from Device Tree without a UINT64_C wrapping macro results in the following warning and the cut-off of the address value:

"warning: integer constant is so large that it is unsigned"

This change adds few wrappers over the address constants coming from Device Tree to support such periphery as PLIC, MTIMER and UART for 64-bit RISC-V platforms from Syntacore