### PR TITLE
twister: Alleviate DeviceHandler serial port TOCTOU

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -374,6 +374,12 @@ class DeviceHandler(Handler):
             except OSError:
                 time.sleep(0.001)
                 continue
+            except TypeError:
+                # This exception happens if the serial port was closed and
+                # its file descriptor cleared in between of ser.isOpen()
+                # and ser.in_waiting checks.
+                logger.debug("Serial port is already closed, stop reading.")
+                break
 
             serial_line = None
             try:


### PR DESCRIPTION
The `DeviceHandler` class method `monitor_serial()` has time-of-check to time-of-use (TOCTOU) race condition possible on its serial port which might be closed and its file descriptor cleared in between of `isOpen()` and `is_waiting` status checks.
The issue is alleviated with controlled exception handling.