### PR TITLE
dts: nxp: Mark the USB RAM region as RAM in the MPU

### DIFF
--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -74,6 +74,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x40100000  DT_SIZE_K(16)>;
 		zephyr,memory-region = "USB_SRAM";
+		zephyr,memory-region-mpu = "RAM";
 	};
 };
 

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -88,6 +88,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x40100000  DT_SIZE_K(16)>;
 		zephyr,memory-region = "USB_SRAM";
+		zephyr,memory-region-mpu = "RAM";
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -48,6 +48,7 @@
 		compatible =  "zephyr,memory-region", "mmio-sram";
 		reg = <0x40140000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM1";
+		zephyr,memory-region-mpu = "RAM";
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -47,6 +47,7 @@
 		compatible =  "zephyr,memory-region", "mmio-sram";
 		reg = <0x40140000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM1";
+		zephyr,memory-region-mpu = "RAM";
 	};
 };
 


### PR DESCRIPTION
Without adding a RAM entry for the USB RAM in the MPU, USB RAM is mapped in the Peripheral Memory region
where unaligned memory accesses will cause a fault error. Unaligned access errors were uncovered when we switch to a different Zephyr C library where the memcpy function implementation has unaligned accesses to the USB RAM.