### PR TITLE
boards: stm32h747i_disco: fix gpio_leds definition

### DIFF
--- a/boards/arm/stm32h747i_disco/stm32h747i_disco.dtsi
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco.dtsi
@@ -11,22 +11,22 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1:led_1 {
-			gpios = <&gpioi 12 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioi 12 GPIO_ACTIVE_LOW>;
 			label = "User LD1";
 			status = "disabled";
 		};
 		orange_led_2:led_2 {
-			gpios = <&gpioi 13 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioi 13 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
 			status = "disabled";
 		};
 		red_led_3:led_3 {
-			gpios = <&gpioi 14 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioi 14 GPIO_ACTIVE_LOW>;
 			label = "User LD3";
 			status = "disabled";
 		};
 		blue_led_4:led_4 {
-			gpios = <&gpioi 15 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioi 15 GPIO_ACTIVE_LOW>;
 			label = "User LD4";
 			status = "disabled";
 		};


### PR DESCRIPTION
Fixes #56557
Fix gpio_leds devicetree definition for the STM32H747I-DISCO board. The LEDs were incorrectly marked as GPIO_ACTIVE_HIGH instead of GPIO_ACTIVE_LOW.