### PR TITLE
tests: interrupt: Fix armclang compiler warning

### DIFF
--- a/tests/kernel/interrupt/src/dynamic_isr.c
+++ b/tests/kernel/interrupt/src/dynamic_isr.c
@@ -20,7 +20,7 @@ static void dyn_isr(const void *arg)
 }
 
 #if defined(CONFIG_GEN_SW_ISR_TABLE)
-extern struct _isr_table_entry __sw_isr_table _sw_isr_table[];
+extern struct _isr_table_entry _sw_isr_table[];
 
 /**
  * @brief Test dynamic ISR installation


### PR DESCRIPTION
When building this test with the armclang compiler we get the following warning:

tests/kernel/interrupt/src/dynamic_isr.c
tests/kernel/interrupt/src/dynamic_isr.c:23:32: error: 'used' attribute ignored on a non-definition declaration [-Werror,-Wignored-attributes]

extern struct _isr_table_entry __sw_isr_table _sw_isr_table[];
                               ^
There is no need to add the __sw_isr_table on the extern, so remove it to address the warning.