### PR TITLE
dts: xtensa: espressif: esp32s2: Add TWAI node

### DIFF
--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -288,6 +288,17 @@
 			#io-channel-cells = <1>;
 			status = "disabled";
 		};
+
+		twai: can@3f42b000 {
+			compatible = "espressif,esp32-twai";
+			reg = <0x3f42b000 DT_SIZE_K(4)>;
+			interrupts = <TWAI_INTR_SOURCE>;
+			interrupt-parent = <&intc>;
+			clocks = <&rtc ESP32_TWAI_MODULE>;
+			sjw = <1>;
+			sample-point = <875>;
+			status = "disabled";
+		};
 	};
 
 };


### PR DESCRIPTION
This adds the TWAI node to the ESP32S2 devicetree.