### PR TITLE
input: Add header file to the longpress example

### DIFF
--- a/dts/bindings/input/zephyr,input-longpress.yaml
+++ b/dts/bindings/input/zephyr,input-longpress.yaml
@@ -10,6 +10,8 @@ description: |
   Can be optionally be associated to a specific device to listen for events
   only from that device. Example configuration:
 
+  #include <dt-bindings/input/input-event-codes.h>
+
   longpress {
           input = <&buttons>;
           compatible = "zephyr,input-longpress";


### PR DESCRIPTION
Add the input-event-codes header file to the example. Otherwise, users get 
the following error for the unresolved INPUT_KEY_* values when copy-pasting
the example:

parse error: expected number or parenthesized expression

Signed-off-by: Amit Kucheria <amitk@kernel.org>
Signed-off-by: Amit Kucheria <amit@mbedrock.com>