### PR TITLE
arch: arm: NMI cleanup (NMI_INIT, set_handler)

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -150,7 +150,7 @@ config RUNTIME_NMI
 	  The kernel provides a simple NMI handler that simply hangs in a tight
 	  loop if triggered. This fills the requirement that there must be an
 	  NMI handler installed when the CPU boots. If a custom handler is
-	  needed, enable this option and attach it via _NmiHandlerSet().
+	  needed, enable this option and attach it via z_arm_nmi_set_handler().
 
 config PLATFORM_SPECIFIC_INIT
 	bool "Platform (SOC) specific startup hook"

--- a/arch/arm/core/aarch32/nmi.c
+++ b/arch/arm/core/aarch32/nmi.c
@@ -70,7 +70,7 @@ void z_arm_nmi_init(void)
  *
  */
 
-void z_NmiHandlerSet(void (*pHandler)(void))
+void z_arm_nmi_set_handler(void (*pHandler)(void))
 {
 	handler = pHandler;
 }

--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -12,6 +12,7 @@
 
 #include <errno.h>
 #include <soc.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/reboot.h>
@@ -148,7 +149,6 @@ static const struct wdt_driver_api wdog_cmsdk_apb_api = {
 };
 
 #ifdef CONFIG_RUNTIME_NMI
-extern void z_NmiHandlerSet(void (*pHandler)(void));
 
 static int wdog_cmsdk_apb_has_fired(void)
 {
@@ -189,7 +189,7 @@ static int wdog_cmsdk_apb_init(const struct device *dev)
 
 #ifdef CONFIG_RUNTIME_NMI
 	/* Configure the interrupts */
-	z_NmiHandlerSet(wdog_cmsdk_apb_isr);
+	z_arm_nmi_set_handler(wdog_cmsdk_apb_isr);
 #endif
 
 #ifdef CONFIG_WDOG_CMSDK_APB_START_AT_BOOT

--- a/drivers/watchdog/wdt_smartbond.c
+++ b/drivers/watchdog/wdt_smartbond.c
@@ -5,6 +5,7 @@
  */
 
 #include <soc.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/logging/log.h>
@@ -50,8 +51,6 @@ static int wdg_smartbond_disable(const struct device *dev)
 }
 
 #ifdef CONFIG_WDT_SMARTBOND_NMI
-extern void z_NmiHandlerSet(void (*pHandler)(void));
-
 static void wdog_smartbond_nmi_isr(void)
 {
 	if (wdog_smartbond_dev_data.callback) {
@@ -86,7 +85,7 @@ static int wdg_smartbond_install_timeout(const struct device *dev,
 #if CONFIG_WDT_SMARTBOND_NMI
 	data->callback = config->callback;
 	data->wdog_device = dev;
-	z_NmiHandlerSet(wdog_smartbond_nmi_isr);
+	z_arm_nmi_set_handler(wdog_smartbond_nmi_isr);
 	SYS_WDOG->WATCHDOG_CTRL_REG = 2;
 #else
 	SYS_WDOG->WATCHDOG_CTRL_REG = 2 | SYS_WDOG_WATCHDOG_CTRL_REG_NMI_RST_Msk;

--- a/include/zephyr/arch/arm/aarch32/nmi.h
+++ b/include/zephyr/arch/arm/aarch32/nmi.h
@@ -16,6 +16,7 @@
 #ifndef _ASMLANGUAGE
 #ifdef CONFIG_RUNTIME_NMI
 extern void z_arm_nmi_init(void);
+extern void z_arm_nmi_set_handler(void (*pHandler)(void));
 #define NMI_INIT() z_arm_nmi_init()
 #else
 #define NMI_INIT()

--- a/soc/arm/nordic_nrf/nrf51/soc.c
+++ b/soc/arm/nordic_nrf/nrf51/soc.c
@@ -15,16 +15,10 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <hal/nrf_power.h>
 #include <soc/nrfx_coredep.h>
 #include <zephyr/logging/log.h>
-
-#ifdef CONFIG_RUNTIME_NMI
-extern void z_arm_nmi_init(void);
-#define NMI_INIT() z_arm_nmi_init()
-#else
-#define NMI_INIT()
-#endif
 
 #include <system_nrf51.h>
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -15,16 +15,10 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <hal/nrf_power.h>
 #include <soc/nrfx_coredep.h>
 #include <zephyr/logging/log.h>
-
-#ifdef CONFIG_RUNTIME_NMI
-extern void z_arm_nmi_init(void);
-#define NMI_INIT() z_arm_nmi_init()
-#else
-#define NMI_INIT()
-#endif
 
 #if defined(CONFIG_SOC_NRF52805)
 #include <system_nrf52805.h>

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -15,6 +15,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <soc/nrfx_coredep.h>
 #include <zephyr/logging/log.h>
 #include <nrf_erratas.h>
@@ -36,13 +37,6 @@
 
 #define PIN_XL1 0
 #define PIN_XL2 1
-
-#ifdef CONFIG_RUNTIME_NMI
-extern void z_arm_nmi_init(void);
-#define NMI_INIT() z_arm_nmi_init()
-#else
-#define NMI_INIT()
-#endif
 
 #if defined(CONFIG_SOC_NRF5340_CPUAPP)
 #include <system_nrf5340_application.h>

--- a/soc/arm/nordic_nrf/nrf91/soc.c
+++ b/soc/arm/nordic_nrf/nrf91/soc.c
@@ -15,15 +15,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <soc/nrfx_coredep.h>
 #include <zephyr/logging/log.h>
-
-#ifdef CONFIG_RUNTIME_NMI
-extern void z_arm_nmi_init(void);
-#define NMI_INIT() z_arm_nmi_init()
-#else
-#define NMI_INIT()
-#endif
 
 #if defined(CONFIG_SOC_NRF9160)
 #include <system_nrf9160.h>

--- a/soc/arm/rpi_pico/rp2/soc.c
+++ b/soc/arm/rpi_pico/rp2/soc.c
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
@@ -23,13 +24,6 @@
 #include <hardware/regs/resets.h>
 #include <hardware/clocks.h>
 #include <hardware/resets.h>
-
-#ifdef CONFIG_RUNTIME_NMI
-extern void z_arm_nmi_init(void);
-#define NMI_INIT() z_arm_nmi_init()
-#else
-#define NMI_INIT()
-#endif
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 

--- a/tests/arch/arm/arm_runtime_nmi/src/arm_runtime_nmi.c
+++ b/tests/arch/arm/arm_runtime_nmi/src/arm_runtime_nmi.c
@@ -8,6 +8,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/reboot.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/nmi.h>
 #include <zephyr/ztest.h>
 #include <zephyr/tc_util.h>
 
@@ -15,8 +16,6 @@
 #ifndef SCB_ICSR_NMIPENDSET_Msk
 #define SCB_ICSR_NMIPENDSET_Msk SCB_ICSR_PENDNMISET_Msk
 #endif
-
-extern void z_NmiHandlerSet(void (*pHandler)(void));
 
 static bool nmi_triggered;
 
@@ -38,20 +37,20 @@ static void nmi_test_isr(void)
 /**
  * @brief test the behavior of CONFIG_RUNTIME_NMI at run time
  *
- * @details this test is to validate z_NmiHandlerSet() api.
- * First we configure the NMI isr using z_NmiHandlerSet() api.
+ * @details this test is to validate z_arm_nmi_set_handler() api.
+ * First we configure the NMI isr using z_arm_nmi_set_handler() api.
  * After wait for some time, and set the  Interrupt Control and
  * State Register(ICSR) of System control block (SCB).
  * The registered NMI isr should fire immediately.
  *
- * @see z_NmiHandlerSet()
+ * @see z_arm_nmi_set_handler()
  */
 ZTEST(arm_runtime_nmi_fn, test_arm_runtime_nmi)
 {
 	uint32_t i = 0U;
 
 	/* Configure the NMI isr */
-	z_NmiHandlerSet(nmi_test_isr);
+	z_arm_nmi_set_handler(nmi_test_isr);
 
 	for (i = 0U; i < 10; i++) {
 		printk("Trigger NMI in 10s: %d s\n", i);


### PR DESCRIPTION
- NMI_INIT:
  - nordic_nrf: Remove per soc definitions that are already defined the exact same
    way in include/zephyr/arch/arm/aarch32/nmi.h.
  - rpi_pico: The same as for nordic_nrf
- nmi handler registration
  - rename the function that sets the handler for the nmi.
    It should be namespaced and not camel-case:
    `z_NmiHandlerSet` to `z_arm_nmi_set_handler`