### PR TITLE
Bluetooth: Fix clearing sent_cmd pointer when allocating event buffer

### DIFF
--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -89,9 +89,8 @@ struct net_buf *bt_buf_get_cmd_complete(k_timeout_t timeout)
 {
 	struct net_buf *buf;
 
-	if (bt_dev.sent_cmd) {
-		buf = net_buf_ref(bt_dev.sent_cmd);
-
+	buf = (struct net_buf *)atomic_ptr_clear((atomic_ptr_t *)&bt_dev.sent_cmd);
+	if (buf) {
 		bt_buf_set_type(buf, BT_BUF_EVT);
 		buf->len = 0U;
 		net_buf_reserve(buf, BT_BUF_RESERVE);


### PR DESCRIPTION
We should clear the bt_dev.sent_cmd pointer after using it to allocate a new HCI event buffer in the bt_buf_get_cmd_complete() function. Otherwise, there is a risk of reusing the same stored net_buf for multiple consecutive HCI events in case the controller sents duplicate or invalid event packets.