### PR TITLE
Add support for running SOF on i.MX93's A55 core

### DIFF
--- a/boards/arm64/mimx93_evk/mimx93_evk_a55_sof.dts
+++ b/boards/arm64/mimx93_evk/mimx93_evk_a55_sof.dts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <nxp/nxp_mimx93_a55.dtsi>
+#include "mimx93_evk-pinctrl.dtsi"
+
+/ {
+	model = "NXP i.MX93 A55";
+	compatible = "fsl,mimx93";
+
+	chosen {
+		zephyr,console = &lpuart2;
+		zephyr,shell-uart = &lpuart2;
+		zephyr,sram = &sram0;
+	};
+
+	cpus {
+		cpu@0 {
+			status = "disabled";
+		};
+	};
+
+	/* Inmate memory, reserved through "mem=1248MB" boot argument,
+	 * starts at 0xce000000.
+	 */
+	sram0: memory@ce000000 {
+		reg = <0xce000000 DT_SIZE_M(1)>;
+	};
+
+	/* TODO: all of the nodes below are needed by SOF and should
+	 * be removed once all drivers used by SOF have been moved
+	 * to Zephyr.
+	 *
+	 * They are added in the DTS for the sake of not using hardcoded
+	 * values in mmu_regions.c
+	 */
+	mu2_a: memory@42430000 {
+		reg = <0x42430000 DT_SIZE_K(64)>;
+	};
+
+	sai3: memory@42660000 {
+		reg = <0x42660000 DT_SIZE_K(64)>;
+	};
+
+	edma2_ch0: memory@42010000 {
+		reg = <0x42010000 DT_SIZE_K(32)>;
+	};
+
+	edma2_ch1: memory@42018000 {
+		reg = <0x42018000 DT_SIZE_K(32)>;
+	};
+
+	outbox: memory@ce100000 {
+		reg = <0xce100000 DT_SIZE_K(4)>;
+	};
+
+	inbox: memory@ce101000 {
+		reg = <0xce101000 DT_SIZE_K(4)>;
+	};
+
+	stream: memory@ce102000 {
+		reg = <0xce102000 DT_SIZE_K(4)>;
+	};
+
+	/* TODO: this is extremely bad and it's needed here because of
+	 * the fact that the DMA buffer shared by host and FW is situated
+	 * in this region. For now, it's easier to create a mapping for the
+	 * whole region but in the future a mapping should only be created
+	 * for the physical address of the buffer sent to the FW through an
+	 * IPC.
+	 */
+	host_ram: memory@80000000 {
+		reg = <0x80000000 DT_SIZE_M(1024)>;
+	};
+};
+
+&lpuart2 {
+	status = "okay";
+	current-speed = <115200>;
+	/* clocks = <&ccm IMX_CCM_UART4_CLK 0x6c 24>; */
+	pinctrl-0 = <&uart2_default>;
+	pinctrl-names = "default";
+};

--- a/boards/arm64/mimx93_evk/mimx93_evk_a55_sof.yaml
+++ b/boards/arm64/mimx93_evk/mimx93_evk_a55_sof.yaml
@@ -1,0 +1,12 @@
+identifier: mimx93_evk_a55_sof
+name: NXP i.MX93 Plus EVK A55 for SOF module
+type: mcu
+arch: arm64
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 1024
+testing:
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/arm64/mimx93_evk/mimx93_evk_a55_sof_defconfig
+++ b/boards/arm64/mimx93_evk/mimx93_evk_a55_sof_defconfig
@@ -1,0 +1,44 @@
+#
+# Copyright 2023 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# ARM Options
+CONFIG_AARCH64_IMAGE_HEADER=y
+CONFIG_ARMV8_A_NS=y
+
+# The number of bits used for PAs and VAs
+# from Zephyr needs to match the number of
+# bits used for said address used by Jailhouse.
+CONFIG_ARM64_VA_BITS_40=y
+CONFIG_ARM64_PA_BITS_40=y
+
+# Cache Options
+CONFIG_CACHE_MANAGEMENT=y
+CONFIG_ICACHE_LINE_SIZE_DETECT=y
+# SOF doesn't currently support the usage of
+# run-time data cache line size detection.
+# Because of this, CONFIG_DCACHE_LINE_SIZE_DETECT
+# (which defaults to n) can't be set to 'y'.
+# The size of data cache line will have to be
+# set manually to 64 (value taken from A55 TRM).
+CONFIG_DCACHE_LINE_SIZE=64
+
+# Platform Configuration
+CONFIG_SOC_SERIES_MIMX9_A55=y
+CONFIG_SOC_MIMX93_A55=y
+CONFIG_BOARD_MIMX93_EVK_A55=y
+
+# Serial Drivers
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# Enable Console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+CONFIG_CLOCK_CONTROL=y
+CONFIG_PINCTRL=y
+
+# Enable dynamic interrupts
+CONFIG_DYNAMIC_INTERRUPTS=y

--- a/soc/arm64/nxp_imx/mimx9/linker.ld
+++ b/soc/arm64/nxp_imx/mimx9/linker.ld
@@ -1,8 +1,355 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2023 NXP
+ * Copyright (c) 2013-2014 Wind River Systems, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 
-#include <zephyr/arch/arm64/scripts/linker.ld>
+/* This is mostly a copy of arch/arm64/scripts/linker.ld with
+ * a few SOF-related changes. This is needed in order to avoid
+ * introducing sections based on CONFIG_SOF in the main ARM64
+ * linker script.
+ */
+#include <zephyr/linker/sections.h>
+#include <zephyr/devicetree.h>
+
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/linker/linker-tool.h>
+
+/* physical address of RAM */
+#ifdef CONFIG_XIP
+  #define ROMABLE_REGION FLASH
+#else
+  #define ROMABLE_REGION RAM
+#endif
+#define RAMABLE_REGION RAM
+
+#if !defined(CONFIG_XIP) && (CONFIG_FLASH_SIZE == 0)
+  #define ROM_ADDR RAM_ADDR
+#else
+  #define ROM_ADDR (CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET)
+#endif
+
+#if CONFIG_FLASH_LOAD_SIZE > 0
+  #define ROM_SIZE CONFIG_FLASH_LOAD_SIZE
+#else
+  #define ROM_SIZE (CONFIG_FLASH_SIZE * 1K - CONFIG_FLASH_LOAD_OFFSET)
+#endif
+
+#define RAM_SIZE (CONFIG_SRAM_SIZE * 1K)
+#define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
+
+#if defined(CONFIG_ARM_MMU)
+  _region_min_align = CONFIG_MMU_PAGE_SIZE;
+#elif defined(CONFIG_ARM_MPU)
+  _region_min_align = CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE;
+  #define BSS_ALIGN ALIGN(_region_min_align)
+#else
+  /* If building without MMU support, use default 4-byte alignment. */
+  _region_min_align = 4;
+#endif
+
+#ifndef BSS_ALIGN
+#define BSS_ALIGN
+#endif
+
+#define MMU_ALIGN    . = ALIGN(_region_min_align)
+
+MEMORY
+{
+    FLASH     (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
+    RAM       (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
+    /* Used by and documented in include/linker/intlist.ld */
+    IDT_LIST  (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
+}
+
+ENTRY(CONFIG_KERNEL_ENTRY)
+
+SECTIONS
+{
+
+#include <zephyr/linker/rel-sections.ld>
+
+    /*
+     * .plt and .iplt are here according to 'arm-zephyr-elf-ld --verbose',
+     * before text section.
+     */
+    /DISCARD/ :
+    {
+        *(.plt)
+    }
+
+    /DISCARD/ :
+    {
+        *(.iplt)
+    }
+
+    GROUP_START(ROMABLE_REGION)
+
+    __rom_region_start = ROM_ADDR;
+
+    SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
+    {
+        __text_region_start = .;
+#ifndef CONFIG_XIP
+        z_mapped_start = .;
+#endif
+
+#ifdef CONFIG_AARCH64_IMAGE_HEADER
+        KEEP(*(.image_header))
+        KEEP(*(".image_header.*"))
+#endif
+
+        _vector_start = .;
+        KEEP(*(.exc_vector_table))
+        KEEP(*(".exc_vector_table.*"))
+
+        KEEP(*(.vectors))
+
+        _vector_end = .;
+
+        *(.text)
+        *(".text.*")
+        *(.gnu.linkonce.t.*)
+
+        /*
+         * These are here according to 'arm-zephyr-elf-ld --verbose',
+         * after .gnu.linkonce.t.*
+         */
+        *(.glue_7t) *(.glue_7) *(.vfp11_veneer) *(.v4_bx)
+
+#include <zephyr/linker/kobject-text.ld>
+
+        MMU_ALIGN;
+    } GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+    __text_region_end = .;
+    __text_region_size = __text_region_end - __text_region_start;
+
+#if defined (CONFIG_CPP)
+    SECTION_PROLOGUE(.ARM.extab,,)
+    {
+        /*
+         * .ARM.extab section containing exception unwinding information.
+         */
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#endif
+
+    SECTION_PROLOGUE(.ARM.exidx,,)
+    {
+        /*
+         * This section, related to stack and exception unwinding, is placed
+         * explicitly to prevent it from being shared between multiple regions.
+         * It  must be defined for gcc to support 64-bit math and avoid
+         * section overlap.
+         */
+        __exidx_start = .;
+#if defined (__GCC_LINKER_CMD__)
+        *(.ARM.exidx* gnu.linkonce.armexidx.*)
+#endif
+        __exidx_end = .;
+    } GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+        __rodata_region_start = .;
+
+#include <zephyr/linker/common-rom.ld>
+#include <zephyr/linker/thread-local-storage.ld>
+
+    SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
+    {
+        *(.rodata)
+        *(".rodata.*")
+        *(.gnu.linkonce.r.*)
+
+        /*
+         * The following is a workaround to allow compiling with GCC 12 and
+         * above, which may emit "GOT indirections" for the weak symbol
+         * references (see the GitHub issue zephyrproject-rtos/sdk-ng#547).
+         */
+        *(.got)
+        *(.got.plt)
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-rodata.ld>
+
+#include <zephyr/linker/kobject-rom.ld>
+
+    } GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+#include <zephyr/linker/cplusplus-rom.ld>
+    MMU_ALIGN;
+
+    __rodata_region_end = .;
+    __rodata_region_size = __rodata_region_end - __rodata_region_start;
+    __rom_region_end = .;
+
+    /*
+     * These are here according to 'arm-zephyr-elf-ld --verbose',
+     * before data section.
+     */
+    /DISCARD/ :
+    {
+        *(.igot.plt)
+        *(.igot)
+    }
+
+    GROUP_END(ROMABLE_REGION)
+
+    GROUP_START(RAMABLE_REGION)
+
+    . = RAM_ADDR;
+    /* Align the start of image RAM with the
+     * minimum granularity required by MMU.
+     */
+    . = ALIGN(_region_min_align);
+    _image_ram_start = .;
+#ifdef CONFIG_XIP
+    z_mapped_start = .;
+#endif
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-ram-sections.ld>
+
+#if defined(CONFIG_USERSPACE)
+#define APP_SHARED_ALIGN . = ALIGN(_region_min_align);
+#define SMEM_PARTITION_ALIGN(size) MMU_ALIGN
+
+#if defined(CONFIG_ARM_MPU)
+/*
+ * When _app_smem region is empty, alignment is also needed. If there
+ * is no alignment, the _app_smem_start used by arm mpu can be lower
+ * than __rodata_region_end, and this two regions can overlap.
+ * The Armv8-R aarch64 MPU does not allow overlapped regions.
+ */
+#define EMPTY_APP_SHARED_ALIGN APP_SHARED_ALIGN
+#endif
+
+#include <app_smem.ld>
+
+    _app_smem_size = _app_smem_end - _app_smem_start;
+    _app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
+#endif  /* CONFIG_USERSPACE */
+
+    SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD), BSS_ALIGN)
+    {
+        /*
+         * For performance, BSS section is assumed to be 4 byte aligned and
+         * a multiple of 4 bytes
+         */
+        . = ALIGN(4);
+        __bss_start = .;
+        __kernel_ram_start = .;
+
+        *(.bss)
+        *(".bss.*")
+        *(COMMON)
+        *(".kernel_bss.*")
+
+        /*
+         * As memory is cleared in words only, it is simpler to ensure the BSS
+         * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
+                 */
+        __bss_end = ALIGN(4);
+    } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+
+#if CONFIG_SOF
+    SECTION_PROLOGUE(.static_uuid_entries,,)
+    {
+        *(*.static_uuids)
+    } GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+    SECTION_PROLOGUE(.static_log_entries,,)
+    {
+        *(*.static_log*)
+    } GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#endif /* CONFIG_SOF */
+
+#include <zephyr/linker/common-noinit.ld>
+
+    SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
+    {
+	__data_region_start = .;
+	__data_start = .;
+        *(.data)
+        *(".data.*")
+        *(".kernel.*")
+#if CONFIG_SOF
+	_trace_ctx_start = ABSOLUTE(.);
+	*(.trace_ctx)
+	_trace_ctx_end = ABSOLUTE(.);
+#endif /* CONFIG_SOF */
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-rwdata.ld>
+
+        __data_end = .;
+
+    } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+    __data_size = __data_end - __data_start;
+    __data_load_start = LOADADDR(_DATA_SECTION_NAME);
+
+    __data_region_load_start = LOADADDR(_DATA_SECTION_NAME);
+
+#include <zephyr/linker/common-ram.ld>
+#include <zephyr/linker/kobject-data.ld>
+#include <zephyr/linker/cplusplus-ram.ld>
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
+
+    __data_region_end = .;
+
+
+    /* Define linker symbols */
+
+    MMU_ALIGN;
+    _image_ram_end = .;
+    _end = .; /* end of image */
+    z_mapped_end = .;
+
+    __kernel_ram_end = RAM_ADDR + RAM_SIZE;
+    __kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
+
+    GROUP_END(RAMABLE_REGION)
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-sections.ld>
+
+#include <zephyr/linker/debug-sections.ld>
+
+    SECTION_PROLOGUE(.ARM.attributes, 0,)
+    {
+        KEEP(*(.ARM.attributes))
+        KEEP(*(.gnu.attributes))
+    }
+
+    /DISCARD/ : { *(.note.GNU-stack) }
+
+
+    /* Must be last in romable region */
+    SECTION_PROLOGUE(.last_section,,)
+    {
+#ifdef CONFIG_LINKER_LAST_SECTION_ID
+      /* Fill last section with a word to ensure location counter and actual rom
+       * region data usage match. */
+      LONG(CONFIG_LINKER_LAST_SECTION_ID_PATTERN)
+#endif
+    } GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+    /* To provide the image size as a const expression,
+     * calculate this value here. */
+    _flash_used = LOADADDR(.last_section) + SIZEOF(.last_section) - __rom_region_start;
+
+}

--- a/soc/arm64/nxp_imx/mimx9/mmu_regions.c
+++ b/soc/arm64/nxp_imx/mimx9/mmu_regions.c
@@ -39,6 +39,48 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_ADDR(DT_NODELABEL(iomuxc)),
 			      DT_REG_SIZE(DT_NODELABEL(iomuxc)),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+
+#if CONFIG_SOF
+	MMU_REGION_FLAT_ENTRY("MU2_A",
+			      DT_REG_ADDR(DT_NODELABEL(mu2_a)),
+			      DT_REG_SIZE(DT_NODELABEL(mu2_a)),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+
+	MMU_REGION_FLAT_ENTRY("SAI3",
+			      DT_REG_ADDR(DT_NODELABEL(sai3)),
+			      DT_REG_SIZE(DT_NODELABEL(sai3)),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+
+	MMU_REGION_FLAT_ENTRY("EDMA2_CH0",
+			      DT_REG_ADDR(DT_NODELABEL(edma2_ch0)),
+			      DT_REG_SIZE(DT_NODELABEL(edma2_ch0)),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+
+	MMU_REGION_FLAT_ENTRY("EDMA2_CH1",
+			      DT_REG_ADDR(DT_NODELABEL(edma2_ch1)),
+			      DT_REG_SIZE(DT_NODELABEL(edma2_ch1)),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
+
+	MMU_REGION_FLAT_ENTRY("OUTBOX",
+			      DT_REG_ADDR(DT_NODELABEL(outbox)),
+			      DT_REG_SIZE(DT_NODELABEL(outbox)),
+			      MT_NORMAL | MT_P_RW_U_NA | MT_NS),
+
+	MMU_REGION_FLAT_ENTRY("INBOX",
+			      DT_REG_ADDR(DT_NODELABEL(inbox)),
+			      DT_REG_SIZE(DT_NODELABEL(inbox)),
+			      MT_NORMAL | MT_P_RW_U_NA | MT_NS),
+
+	MMU_REGION_FLAT_ENTRY("STREAM",
+			      DT_REG_ADDR(DT_NODELABEL(stream)),
+			      DT_REG_SIZE(DT_NODELABEL(stream)),
+			      MT_NORMAL | MT_P_RW_U_NA | MT_NS),
+
+	MMU_REGION_FLAT_ENTRY("HOST_RAM",
+			      DT_REG_ADDR(DT_NODELABEL(host_ram)),
+			      DT_REG_SIZE(DT_NODELABEL(host_ram)),
+			      MT_NORMAL | MT_P_RW_U_NA | MT_NS),
+#endif /* CONFIG_SOF */
 };
 
 const struct arm_mmu_config mmu_config = {


### PR DESCRIPTION
This series of patches introduces all the changes required to make SOF using Zephyr run on i.MX93's A55 core.