### PR TITLE
dts: riscv: sifive: fu740: add more cpus

### DIFF
--- a/dts/riscv/sifive/riscv64-fu740.dtsi
+++ b/dts/riscv/sifive/riscv64-fu740.dtsi
@@ -31,7 +31,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu: cpu@0 {
+		cpu0: cpu@0 {
 			compatible = "sifive,s7";
 			device_type = "cpu";
 			reg = <0>;
@@ -41,6 +41,58 @@
 			hlic: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+		cpu1: cpu@1 {
+			compatible = "sifive,u74";
+			device_type = "cpu";
+			mmu-type = "riscv,sv39";
+			reg = <0x1>;
+			riscv,isa = "rv64imafdc";
+
+			cpu1_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+		cpu2: cpu@2 {
+			compatible = "sifive,u74";
+			device_type = "cpu";
+			mmu-type = "riscv,sv39";
+			reg = <0x2>;
+			riscv,isa = "rv64imafdc";
+
+			cpu2_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+		cpu3: cpu@3 {
+			compatible = "sifive,u74";
+			device_type = "cpu";
+			mmu-type = "riscv,sv39";
+			reg = <0x3>;
+			riscv,isa = "rv64imafdc";
+
+			cpu3_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+		cpu4: cpu@4 {
+			compatible = "sifive,u74";
+			device_type = "cpu";
+			mmu-type = "riscv,sv39";
+			reg = <0x4>;
+			riscv,isa = "rv64imafdc";
+
+			cpu4_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
 				#interrupt-cells = <1>;
 				interrupt-controller;
 			};


### PR DESCRIPTION
In the devicetreee for fu740 SoC there is only one cpu described. I am adding a description of lacking CPUs that are also present on that SoC.