### PR TITLE
include: rtio: Remove use of deprecated ceiling_fraction macro

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -1070,7 +1070,7 @@ static inline int rtio_sqe_rx_buf(const struct rtio_iodev_sqe *iodev_sqe, uint32
 		}
 
 		do {
-			size_t num_blks = ceiling_fraction(bytes, blk_size);
+			size_t num_blks = DIV_ROUND_UP(bytes, blk_size);
 			int rc = sys_mem_blocks_alloc_contiguous(pool, num_blks, (void **)buf);
 
 			if (rc == 0) {


### PR DESCRIPTION
Commit 53da110dbfe5f73efa842c4b8560dba26f5a84a9 deprecated ceiling_fraction in favor of DIV_ROUND_UP. Apply this to the rtio header as well.