### PR TITLE
sys/util: extend usage of DIV_ROUND_UP

### DIFF
--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -13,7 +13,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
-
+#include <zephyr/sys/util.h>
 #include <zephyr/audio/codec.h>
 #include "tlv320dac310x.h"
 
@@ -290,7 +290,7 @@ static int codec_configure_clocks(const struct device *dev,
 
 	/* round mix and max values to the required multiple */
 	osr_max = (osr_max / osr_multiple) * osr_multiple;
-	osr_min = (osr_min + osr_multiple - 1) / osr_multiple;
+	osr_min = DIV_ROUND_UP(osr_min, osr_multiple);
 
 	osr = osr_max;
 	while (osr >= osr_min) {
@@ -344,7 +344,7 @@ static int codec_configure_clocks(const struct device *dev,
 	}
 
 	/* calculate MCLK divider to get ~1MHz */
-	mclk_div = (cfg->mclk_freq + 1000000 - 1) / 1000000U;
+	mclk_div = DIV_ROUND_UP(cfg->mclk_freq, 1000000);
 	/* setup timer clock to be MCLK divided */
 	codec_write_reg(dev, TIMER_MCLK_DIV_ADDR,
 			TIMER_MCLK_DIV_EN_EXT | TIMER_MCLK_DIV_VAL(mclk_div));

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -19,7 +19,6 @@
 LOG_MODULE_REGISTER(can_mcan, CONFIG_CAN_LOG_LEVEL);
 
 #define CAN_INIT_TIMEOUT (100)
-#define CAN_DIV_CEIL(val, div) (((val) + (div) - 1) / (div))
 
 static void memcpy32_volatile(volatile void *dst_, const volatile void *src_,
 			      size_t len)

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -341,8 +341,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 		/* Round delay up to next tick boundary */
 		delay += unannounced;
-		delay =
-		 ((delay + CYC_PER_TICK - 1) / CYC_PER_TICK) * CYC_PER_TICK;
+		delay = DIV_ROUND_UP(delay, CYC_PER_TICK) * CYC_PER_TICK;
 
 		delay -= unannounced;
 		delay = MAX(delay, MIN_DELAY);

--- a/drivers/timer/cc13x2_cc26x2_rtc_timer.c
+++ b/drivers/timer/cc13x2_cc26x2_rtc_timer.c
@@ -22,6 +22,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/sys/util.h>
 
 #include <driverlib/interrupt.h>
 #include <driverlib/aon_rtc.h>
@@ -203,8 +204,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		(count - rtc_last);
 
 	/* Round to the nearest tick boundary. */
-	timeout = (timeout + RTC_COUNTS_PER_TICK - 1) / RTC_COUNTS_PER_TICK
-		  * RTC_COUNTS_PER_TICK;
+	timeout = DIV_ROUND_UP(timeout, RTC_COUNTS_PER_TICK) *
+		  RTC_COUNTS_PER_TICK;
 	timeout = MIN(timeout, MAX_CYC);
 	timeout += rtc_last;
 

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -9,6 +9,7 @@
 #include <zephyr/spinlock.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/util.h>
 
 #define COUNTER_MAX 0x00ffffff
 #define TIMER_STOPPED 0xff000000
@@ -198,8 +199,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 		/* Round delay up to next tick boundary */
 		delay += unannounced;
-		delay =
-		 ((delay + CYC_PER_TICK - 1) / CYC_PER_TICK) * CYC_PER_TICK;
+		delay = DIV_ROUND_UP(delay, CYC_PER_TICK) * CYC_PER_TICK;
 		delay -= unannounced;
 		delay = MAX(delay, MIN_DELAY);
 		if (delay > MAX_CYCLES) {

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -23,6 +23,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/util.h>
 
 /* RTC registers. */
 #define RTC0 ((RtcMode0 *) DT_INST_REG_ADDR(0))
@@ -195,8 +196,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	uint32_t timeout = ticks * CYCLES_PER_TICK + count % CYCLES_PER_TICK;
 
 	/* Round to the nearest tick boundary. */
-	timeout = (timeout + CYCLES_PER_TICK - 1) / CYCLES_PER_TICK
-		  * CYCLES_PER_TICK;
+	timeout = DIV_ROUND_UP(timeout, CYCLES_PER_TICK) * CYCLES_PER_TICK;
 
 	if (timeout < TICK_THRESHOLD) {
 		timeout += CYCLES_PER_TICK;

--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -26,6 +26,7 @@
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/util.h>
 LOG_MODULE_REGISTER(usb_dc_dw);
 
 /* Number of SETUP back-to-back packets */
@@ -405,7 +406,7 @@ static int usb_dw_tx(uint8_t ep, const uint8_t *const data,
 		 * pktcnt = N + (short_packet exist ? 1 : 0)
 		 */
 
-		pkt_cnt = (data_len + ep_mps - 1) / ep_mps;
+		pkt_cnt = DIV_ROUND_UP(data_len, ep_mps);
 		if (pkt_cnt > max_pkt_cnt) {
 			LOG_WRN("USB IN EP%d pkt count too big (%d->%d)",
 				ep_idx, pkt_cnt, pkt_cnt);

--- a/include/zephyr/sys/bitarray.h
+++ b/include/zephyr/sys/bitarray.h
@@ -15,6 +15,7 @@ extern "C" {
 #include <stdint.h>
 
 #include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
 
 struct sys_bitarray {
 	/* Number of bits */
@@ -41,13 +42,12 @@ typedef struct sys_bitarray sys_bitarray_t;
  */
 #define _SYS_BITARRAY_DEFINE(name, total_bits, sba_mod)			\
 	sba_mod uint32_t _sys_bitarray_bundles_##name			\
-		[(((total_bits + 8 - 1) / 8) + sizeof(uint32_t) - 1)	\
-		 / sizeof(uint32_t)] = {0};				\
+		[DIV_ROUND_UP(DIV_ROUND_UP(total_bits, 8),		\
+			       sizeof(uint32_t))] = {0};		\
 	sba_mod sys_bitarray_t name = {					\
 		.num_bits = total_bits,					\
-		.num_bundles = (((total_bits + 8 - 1) / 8)		\
-				+ sizeof(uint32_t) - 1)			\
-			       / sizeof(uint32_t),			\
+		.num_bundles = DIV_ROUND_UP(				\
+			DIV_ROUND_UP(total_bits, 8), sizeof(uint32_t)),	\
 		.bundles = _sys_bitarray_bundles_##name,		\
 	}
 

--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -141,8 +141,7 @@ static inline void ring_buf_internal_reset(struct ring_buf *buf, int32_t value)
  *
  * @param expr Expression or type to compute the size of
  */
-#define RING_BUF_ITEM_SIZEOF(expr) \
-	((sizeof(expr) + sizeof(uint32_t) - 1) / sizeof(uint32_t))
+#define RING_BUF_ITEM_SIZEOF(expr) DIV_ROUND_UP(sizeof(expr), sizeof(uint32_t))
 
 /**
  * @brief Initialize a ring buffer for byte data.

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -18,6 +18,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/timing/timing.h>
+#include <zephyr/sys/util.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
@@ -412,7 +413,7 @@ static void flag_ipi(void)
 
 #ifdef CONFIG_TIMESLICING
 
-static int slice_ticks = (CONFIG_TIMESLICE_SIZE * Z_HZ_ticks + Z_HZ_ms - 1) / Z_HZ_ms;
+static int slice_ticks = DIV_ROUND_UP(CONFIG_TIMESLICE_SIZE * Z_HZ_ticks, Z_HZ_ms);
 static int slice_max_prio = CONFIG_TIMESLICE_PRIORITY;
 static struct _timeout slice_timeouts[CONFIG_MP_MAX_NUM_CPUS];
 static bool slice_expired[CONFIG_MP_MAX_NUM_CPUS];

--- a/soc/arm/atmel_sam/sam4l/soc.c
+++ b/soc/arm/atmel_sam/sam4l/soc.c
@@ -16,22 +16,12 @@
 #include <soc.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/util.h>
 
 /** Watchdog control register first write keys */
 #define WDT_FIRST_KEY     0x55ul
 /** Watchdog control register second write keys */
 #define WDT_SECOND_KEY    0xAAul
-
-/**
- * @brief Calculate \f$ \left\lceil \frac{a}{b} \right\rceil \f$ using
- * integer arithmetic.
- *
- * @param a An integer
- * @param b Another integer
- *
- * @return (\a a / \a b) rounded up to the nearest integer.
- */
-#define div_ceil(a, b)	(((a) + (b) - 1) / (b))
 
 /**
  * @brief Sets the WatchDog Timer Control register to the \a ctrl value thanks
@@ -46,7 +36,7 @@ static ALWAYS_INLINE void wdt_set_ctrl(uint32_t ctrl)
 	/** Calculate delay for internal synchronization
 	 *    see 45.1.3 WDT errata
 	 */
-	dly = div_ceil(48000000 * 2, 115000);
+	dly = DIV_ROUND_UP(48000000 * 2, 115000);
 	dly >>= 3; /* ~8 cycles for one while loop */
 	while (dly--) {
 		;

--- a/soc/xtensa/esp32s3/soc.c
+++ b/soc/xtensa/esp32s3/soc.c
@@ -18,6 +18,7 @@
 #include <zephyr/types.h>
 #include <zephyr/linker/linker-defs.h>
 #include <kernel_internal.h>
+#include <zephyr/sys/util.h>
 
 #include "esp_private/system_internal.h"
 #include "esp32s3/rom/cache.h"
@@ -81,8 +82,9 @@ void IRAM_ATTR __esp_platform_start(void)
 	uint32_t rodata_start_align = (uint32_t)&_rodata_reserved_start & ~(MMU_PAGE_SIZE - 1);
 	uint32_t cache_mmu_irom_size = ((rodata_start_align - SOC_DROM_LOW) / MMU_PAGE_SIZE)
 		* sizeof(uint32_t);
-	uint32_t cache_mmu_drom_size = (((uint32_t)&_rodata_reserved_end - rodata_start_align
-		+ MMU_PAGE_SIZE - 1) / MMU_PAGE_SIZE) * sizeof(uint32_t);
+	uint32_t cache_mmu_drom_size = DIV_ROUND_UP(
+			(uint32_t)&_rodata_reserved_end - rodata_start_align,
+			MMU_PAGE_SIZE) * sizeof(uint32_t);
 
 	Cache_Set_IDROM_MMU_Size(cache_mmu_irom_size, CACHE_DROM_MMU_MAX_END - cache_mmu_irom_size);
 	Cache_Set_IDROM_MMU_Info(cache_mmu_irom_size / sizeof(uint32_t),

--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/sys/util.h>
+
 /**
  *  User CPR Interval
  */
@@ -40,10 +42,10 @@ extern bool ull_handle_cpr_anchor_point_move(struct ll_conn *conn, uint16_t *off
 #define DEFER_APM_CHECK(x, y, z) (ull_handle_cpr_anchor_point_move(x, y, z))
 #endif /* CONFIG_BT_CTLR_USER_CPR_ANCHOR_POINT_MOVE */
 /* Macro to convert time in us to connection interval units */
-#define RADIO_CONN_EVENTS(x, y) ((uint16_t)(((x) + (y) - 1) / (y)))
+#define RADIO_CONN_EVENTS(x, y) ((uint16_t)DIV_ROUND_UP(x, y))
 
 /* Macro to convert time in us to periodic advertising interval units */
-#define RADIO_SYNC_EVENTS(x, y) ((uint16_t)(((x) + (y) - 1) / (y)))
+#define RADIO_SYNC_EVENTS(x, y) ((uint16_t)DIV_ROUND_UP(x, y))
 
 static inline uint8_t ull_ref_get(struct ull_hdr *hdr)
 {

--- a/subsys/testsuite/ztest/src/ztest_mock.c
+++ b/subsys/testsuite/ztest/src/ztest_mock.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/ztest.h>
+#include <zephyr/sys/util.h>
 #include <string.h>
 #include <stdio.h>
 
@@ -77,12 +78,12 @@ int snprintk(char *str, size_t size, const char *fmt, ...)
  */
 #define BITS_PER_UL (8 * sizeof(unsigned long int))
 #define DEFINE_BITFIELD(name, bits)                                            \
-	unsigned long int(name)[((bits) + BITS_PER_UL - 1) / BITS_PER_UL]
+	unsigned long int(name)[DIV_ROUND_UP(bits, BITS_PER_UL)]
 
 static inline int sys_bitfield_find_first_clear(const unsigned long *bitmap,
 						const unsigned int bits)
 {
-	const size_t words = (bits + BITS_PER_UL - 1) / BITS_PER_UL;
+	const size_t words = DIV_ROUND_UP(bits, BITS_PER_UL);
 	size_t cnt;
 	unsigned int long neg_bitmap;
 

--- a/subsys/testsuite/ztest/src/ztest_mock.c
+++ b/subsys/testsuite/ztest/src/ztest_mock.c
@@ -78,7 +78,7 @@ int snprintk(char *str, size_t size, const char *fmt, ...)
  */
 #define BITS_PER_UL (8 * sizeof(unsigned long int))
 #define DEFINE_BITFIELD(name, bits)                                            \
-	unsigned long int(name)[DIV_ROUND_UP(bits, BITS_PER_UL)]
+	unsigned long(name)[DIV_ROUND_UP(bits, BITS_PER_UL)]
 
 static inline int sys_bitfield_find_first_clear(const unsigned long *bitmap,
 						const unsigned int bits)

--- a/tests/bluetooth/controller/ctrl_conn_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_conn_update/src/main.c
@@ -2441,7 +2441,7 @@ ZTEST(periph_rem, test_conn_update_periph_rem_accept)
 	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
 		      "Free CTX buffers %d", llcp_ctx_buffers_free());
 }
-#define RADIO_CONN_EVENTS(x, y) ((uint16_t)(((x) + (y) - 1) / (y)))
+#define RADIO_CONN_EVENTS(x, y) ((uint16_t)DIV_ROUND_UP(x, y))
 
 /*
  * Central-initiated Connection Parameters Request procedure - only anchor point move.

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(net_test, LOG_LEVEL_DBG);
 #include <string.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/kernel.h>
-
+#include <zephyr/sys/util.h>
 #include <zephyr/net/coap.h>
 
 #include <zephyr/tc_util.h>
@@ -552,7 +552,7 @@ static void prepare_block1_response(struct coap_packet *rsp,
 	zassert_equal(r, 0, "Unable to append block1 option");
 }
 
-#define ITER_COUNT(len, block_len) (((len) + (block_len) - 1) / (block_len))
+#define ITER_COUNT(len, block_len) DIV_ROUND_UP(len, block_len)
 
 static void verify_block1_request(struct coap_block_context *req_ctx,
 				  uint8_t iter)


### PR DESCRIPTION
Many areas of Zephyr divide and round up without using the DIV_ROUND_UP
macro. Make use of it, so that we utilize a tested system macro and
at the same time, we make code more readable.