### PR TITLE
scripts: dts: disable checks for cyclic dependencies in the devicetree

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -69,6 +69,7 @@ def main():
                          default_prop_types=True,
                          infer_binding_for_paths=["/zephyr,user"],
                          werror=args.edtlib_Werror,
+                         check_cyclic_dependencies=not args.disable_cyclic_dependency_check,
                          vendor_prefixes=vendor_prefixes)
     except edtlib.EDTError as e:
         sys.exit(f"devicetree error: {e}")
@@ -207,6 +208,9 @@ def parse_args():
                         help="if set, edtlib-specific warnings become errors. "
                              "(this does not apply to warnings shared "
                              "with dtc.)")
+    parser.add_argument("--disable-cyclic-dependency-check", action="store_true",
+                        help="disables the check for cyclic dependencies in "
+                             "the devicetree ")
 
     return parser.parse_args()
 
@@ -228,10 +232,8 @@ Node dependency ordering (ordinal and path):
 """
 
     for scc in edt.scc_order:
-        if len(scc) > 1:
-            err("cycle in devicetree involving "
-                + ", ".join(node.path for node in scc))
-        s += f"  {scc[0].dep_ordinal:<3} {scc[0].path}\n"
+        for node in scc:
+            s += f"  {node.dep_ordinal:<3} {node.path}\n"
 
     s += """
 Definitions derived from these nodes in dependency order are next,

--- a/scripts/dts/python-devicetree/src/devicetree/grutils.py
+++ b/scripts/dts/python-devicetree/src/devicetree/grutils.py
@@ -18,8 +18,9 @@ class Graph:
     already be available.
     """
 
-    def __init__(self, root=None):
+    def __init__(self, check_cyclic_dependencies, root=None):
         self.__roots = None
+        self.__check_cyclic_dependencies = check_cyclic_dependencies
         if root is not None:
             self.__roots = {root}
         self.__edge_map = collections.defaultdict(set)
@@ -81,15 +82,17 @@ class Graph:
         for r in roots:
             self._tarjan_root(r)
 
+        # check for cyclic dependencies
+        if self.__check_cyclic_dependencies:
+            for scc in self.__scc_order:
+                if len(scc) > 1:
+                    raise Exception(f'found cyclic dependency in graph including the node {scc[0].name}')
+
         # Assign ordinals for edtlib
         ordinal = 0
         for scc in self.__scc_order:
-            # Zephyr customization: devicetree Node graphs should have
-            # no loops, so all SCCs should be singletons.  That may
-            # change in the future, but for now we only give an
-            # ordinal to singletons.
-            if len(scc) == 1:
-                scc[0].dep_ordinal = ordinal
+            for node in scc:
+                node.dep_ordinal = ordinal
                 ordinal += 1
 
     def _tarjan_root(self, v):

--- a/scripts/dts/python-devicetree/tests/test-cyclic.dts
+++ b/scripts/dts/python-devicetree/tests/test-cyclic.dts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023, SILA Embedded Solutions GmbH
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// Used by testedtlib.py
+
+/dts-v1/;
+
+/ {
+	d1: d1 {
+		compatible = "props";
+		phandle-ref = <&d2>;
+	};
+
+	d2: d2 {
+		compatible = "props";
+		phandle-ref = <&d1>;
+	};
+
+	other: other {
+		compatible = "props";
+		phandle-ref = <&d1>;
+	};
+};

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -627,6 +627,18 @@ def test_wrong_props():
         assert value_str.endswith("but no 'specifier-space' was provided.")
 
 
+def test_cyclic():
+    '''Tests for cyclic dependencies'''
+    with from_here():
+        edt = edtlib.EDT("test-cyclic.dts", ["test-bindings"], check_cyclic_dependencies=False)
+
+    node_d1 = edt.get_node("/d1")
+    node_d2 = edt.get_node("/d2")
+    node_other = edt.get_node("/other")
+    assert node_d1.dep_ordinal == 2
+    assert node_d2.dep_ordinal == 1
+    assert node_other.dep_ordinal == 3
+
 def verify_error(dts, dts_file, expected_err):
     # Verifies that parsing a file 'dts_file' with the contents 'dts'
     # (a string) raises an EDTError with the message 'expected_err'.


### PR DESCRIPTION
Disable the checks for cyclic dependencies in the devicetree, as it is not really necessary to enforce this.

Cycles in the device tree can occur for instance with SPI port expanders, as they by themselves can be used for the chip select of other devices on the same SPI bus.

	&spi1 {
		cs-gpios = <&gpiof 10 GPIO_ACTIVE_LOW>,			
			   <&temp_port_expander 0 GPIO_ACTIVE_LOW>;
		...

		temp_port_expander: temp_port_expander@0 {
			compatible = "microchip,mcp23sxx";
			...
		};

		temp_adc1: temp_adc1@1 {
			compatible = "ti,ads114s08";
			...
		};
	};

With these changes so far only applications are affected, which have a cycle in their devicetree dependency graph.

As far as I can see it the scc_order is only used to determine the device ordinals. I suspect these were originally implicitly used for the device initialization order as well. By now this is defined via initialization levels and priorities, hence it is not necessary anymore to enforce cycle free device tree dependency graphs.

I suspect the device ordinals could also be random (or be given by their first appearance in the devicetree) and the scc_order could be removed completely. But this would of course affect all existing applications, therefore I refrained from changing this.