### PR TITLE
bluetooth: audio: Only build code if BT_CONN is enabled

### DIFF
--- a/subsys/bluetooth/audio/CMakeLists.txt
+++ b/subsys/bluetooth/audio/CMakeLists.txt
@@ -3,9 +3,8 @@
 add_subdirectory_ifdef(CONFIG_BT_SHELL shell)
 
 zephyr_library()
-zephyr_library_sources(
-	audio.c
-)
+
+zephyr_library_sources_ifdef(CONFIG_BT_CONN audio.c)
 
 if (CONFIG_BT_VOCS OR CONFIG_BT_VOCS_CLIENT)
 	zephyr_library_sources(vocs.c)


### PR DESCRIPTION
The audio code utilizes BT_CONN so ensure its enabled in Kconfig. This is to fix a build issue we see with arm-clang for:

sample.bluetooth.broadcast_audio_source

which fails to link since bt_conn_get_info is missing.