### PR TITLE
drivers: spi: sam0: fix DMA initialization for parts with MCLK peripheral

### DIFF
--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -721,7 +721,8 @@ static const struct spi_sam0_config spi_sam0_config_##n = {		\
 	.mclk_mask = BIT(DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, bit)),	\
 	.gclk_core_id = DT_INST_CLOCKS_CELL_BY_NAME(n, gclk, periph_ch),\
 	.pads = SPI_SAM0_SERCOM_PADS(n),				\
-	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n)			\
+	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
+	SPI_SAM0_DMA_CHANNELS(n)					\
 }
 #else
 #define SPI_SAM0_DEFINE_CONFIG(n)					\


### PR DESCRIPTION
The spi-sam0 driver does not initialize DMA parameters when the MCLK peripheral is defined in the microcontroller header file. Fix it by copying the initialization code from the non-MCLK case.