### PR TITLE
boards: riscv32: Fix arch setting in board YAML

### DIFF
--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.yaml
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.yaml
@@ -1,7 +1,7 @@
 identifier: esp32c3_devkitm
 name: ESP32-C3
 type: mcu
-arch: riscv
+arch: riscv32
 toolchain:
   - zephyr
 supported:

--- a/boards/riscv/icev_wireless/icev_wireless.yaml
+++ b/boards/riscv/icev_wireless/icev_wireless.yaml
@@ -1,7 +1,7 @@
 identifier: icev_wireless
 name: ICE-V Wireless
 type: mcu
-arch: riscv
+arch: riscv32
 toolchain:
   - zephyr
 testing:

--- a/boards/riscv/stamp_c3/stamp_c3.yaml
+++ b/boards/riscv/stamp_c3/stamp_c3.yaml
@@ -1,7 +1,7 @@
 identifier: stamp_c3
 name: M5Stack STAMP-C3
 type: mcu
-arch: riscv
+arch: riscv32
 toolchain:
   - zephyr
 supported:

--- a/boards/riscv/xiao_esp32c3/xiao_esp32c3.yaml
+++ b/boards/riscv/xiao_esp32c3/xiao_esp32c3.yaml
@@ -1,7 +1,7 @@
 identifier: xiao_esp32c3
 name: XIAO ESP32C3
 type: mcu
-arch: riscv
+arch: riscv32
 toolchain:
   - zephyr
 supported:


### PR DESCRIPTION
The arch should be riscv32 not riscv.