### PR TITLE
twister: make get_elf_file sysbuild aware

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -422,6 +422,7 @@ class FilterBuilder(CMake):
             domain_path = os.path.join(self.build_dir, "domains.yaml")
             domains = Domains.from_file(domain_path)
             logger.debug("Loaded sysbuild domain data from %s" % (domain_path))
+            self.instance.domains = domains
             domain_build = domains.get_default_domain().build_dir
             cmake_cache_path = os.path.join(domain_build, "CMakeCache.txt")
             defconfig_path = os.path.join(domain_build, "zephyr", ".config")

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -45,6 +45,8 @@ class TestInstance:
         self.run_id = self._get_run_id()
         self.build_dir = os.path.join(outdir, platform.name, testsuite.name)
 
+        self.domains = None
+
         self.run = False
         self.testcases = []
         self.init_cases()
@@ -268,8 +270,14 @@ class TestInstance:
                             generate_warning=generate_warning)
 
     def get_elf_file(self) -> str:
-        fns = glob.glob(os.path.join(self.build_dir, "zephyr", "*.elf"))
-        fns.extend(glob.glob(os.path.join(self.build_dir, "zephyr", "*.exe")))
+
+        if self.testsuite.sysbuild:
+            build_dir = self.domains.get_default_domain().build_dir
+        else:
+            build_dir = self.build_dir
+
+        fns = glob.glob(os.path.join(build_dir, "zephyr", "*.elf"))
+        fns.extend(glob.glob(os.path.join(build_dir, "zephyr", "*.exe")))
         blocklist = [
                 'remapped', # used for xtensa plaforms
                 'zefi', # EFI for Zephyr


### PR DESCRIPTION
If we are doing a sysbuild get_elf_file needs to return the default domain's build_dir.  The standard build_dir will not any ELF builds in it so will error out.