### PR TITLE
drivers: disk: sdmmc_stm32 support for clock divisor

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -689,6 +689,9 @@ static struct stm32_sdmmc_priv stm32_sdmmc_priv_1 = {
 	.hsd = {
 		.Instance = (MMC_TypeDef *)DT_INST_REG_ADDR(0),
 		.Init.BusWide = SDMMC_BUS_WIDTH,
+#if DT_INST_NODE_HAS_PROP(0, clk_div)
+		.Init.ClockDiv = DT_INST_PROP(0, clk_div),
+#endif
 	},
 #if DT_INST_NODE_HAS_PROP(0, cd_gpios)
 	.cd = GPIO_DT_SPEC_INST_GET(0, cd_gpios),

--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -39,6 +39,13 @@ properties:
       - 4
       - 8
 
+  clk-div:
+    type: int
+    default: 0
+    description: |
+        Clock division factor for SDMMC. Typically the clock operates at 25MHz so
+        a division factor of 2 would be 25MHz / 2 = 12.5MHz.
+
   idma:
     type: boolean
     description: |


### PR DESCRIPTION
Adds support for a devicetree property that controls the ClockDiv. This allows you to reduce SDMMC clock speeds without modifying the parent clock.

Closes https://github.com/zephyrproject-rtos/zephyr/issues/56742