### PR TITLE
cfb: correct invert_area implementaion

### DIFF
--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -272,27 +272,34 @@ int cfb_invert_area(const struct device *dev, uint16_t x, uint16_t y,
 					uint8_t m = BIT_MASK((j % 8));
 					uint8_t b = fb->buf[index];
 
-					if (need_reverse) {
-						m = byte_reverse(m);
-						b = byte_reverse(b);
+					/*
+					 * Generate mask for remaining lines in case of
+					 * drawing within 8 lines from the start line
+					 */
+					if (remains < 8) {
+						m |= BIT_MASK((8 - (j % 8) + remains))
+						     << ((j % 8) + remains);
 					}
 
-					fb->buf[index] = ~(b | m) | (b & m);
+					if (need_reverse) {
+						m = byte_reverse(m);
+					}
+
+					fb->buf[index] = (b ^ (~m));
 					j += 7 - (j % 8);
 				} else if (remains >= 8) {
 					/* No mask required if no start or end line is included */
 					fb->buf[index] = ~fb->buf[index];
 					j += 7;
 				} else {
-					uint8_t m = BIT_MASK(remains % 8) << (8 - (remains % 8));
+					uint8_t m = BIT_MASK(8 - remains) << (remains);
 					uint8_t b = fb->buf[index];
 
 					if (need_reverse) {
 						m = byte_reverse(m);
-						b = byte_reverse(b);
 					}
 
-					fb->buf[index] = ~(b | m) | (b & m);
+					fb->buf[index] = (b ^ (~m));
 					j += (remains - 1);
 				}
 			}

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -296,17 +296,9 @@ static int cmd_invert(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (argc == 1) {
-		uint8_t width = cfb_get_display_parameter(dev, CFB_DISPLAY_WIDTH);
-		uint8_t height = cfb_get_display_parameter(dev, CFB_DISPLAY_HEIGH);
-
-		err = cfb_invert_area(dev, 0, 0, width, height);
-		if (err) {
-			shell_error(sh, "Error inverting area");
-			return err;
-		}
-
 		err = cfb_framebuffer_invert(dev);
 		if (err) {
+			shell_error(sh, "Error inverting Framebuffer");
 			return err;
 		}
 	} else if (argc == 5) {
@@ -325,11 +317,6 @@ static int cmd_invert(const struct shell *sh, size_t argc, char *argv[])
 	} else {
 		shell_help(sh);
 		return 0;
-	}
-
-	if (err) {
-		shell_error(sh, "Error inverting Framebuffer");
-		return err;
 	}
 
 	cfb_framebuffer_finalize(dev);


### PR DESCRIPTION
I added cfb_invert_area command to cfb in PR for #53796.
But I found some bugs.

- image inverting calculation is wrong
- The display is strange because cfb_invert_area is called by the invert command of the shell.

This PR correctiong these bugs.

(Because I put it before the improvement of native_posix behavior put in #54957,  It was not possible to confirm the operation with native_posix. I apologize.)