### PR TITLE
drivers: sensor: lsm6dso: round up to the nearest odr

### DIFF
--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -31,7 +31,7 @@ static int lsm6dso_freq_to_odr_val(uint16_t freq)
 	size_t i;
 
 	for (i = 0; i < ARRAY_SIZE(lsm6dso_odr_map); i++) {
-		if (freq == lsm6dso_odr_map[i]) {
+		if (freq <= lsm6dso_odr_map[i]) {
 			return i;
 		}
 	}


### PR DESCRIPTION
It was too strict to require the caller to pass in an accurate odr as a parameter. This patch is to round the odr up to the nearest one, when odr does not match.