### PR TITLE
soc: kconfig: Add config for ESP32 family

### DIFF
--- a/soc/riscv/esp32c3/Kconfig.soc
+++ b/soc/riscv/esp32c3/Kconfig.soc
@@ -17,6 +17,10 @@ config SOC_ESP32C3
 
 if SOC_ESP32C3
 
+config SOC_FAMILY_ESP32
+	bool
+	default y
+
 config IDF_TARGET_ESP32C3
 	bool "ESP32C3 as target board"
 	default y

--- a/soc/xtensa/esp32/Kconfig.soc
+++ b/soc/xtensa/esp32/Kconfig.soc
@@ -15,6 +15,10 @@ config SOC_ESP32
 
 if SOC_ESP32
 
+config SOC_FAMILY_ESP32
+	bool
+	default y
+
 config IDF_TARGET_ESP32
 	bool "ESP32 as target board"
 	default y

--- a/soc/xtensa/esp32_net/Kconfig.soc
+++ b/soc/xtensa/esp32_net/Kconfig.soc
@@ -10,6 +10,10 @@ config SOC_ESP32_NET
 
 if SOC_ESP32_NET
 
+config SOC_FAMILY_ESP32
+	bool
+	default y
+
 config IDF_TARGET_ESP32
 	bool "ESP32 as target board"
 	default y

--- a/soc/xtensa/esp32s2/Kconfig.soc
+++ b/soc/xtensa/esp32s2/Kconfig.soc
@@ -13,6 +13,10 @@ config SOC_ESP32S2
 
 if SOC_ESP32S2
 
+config SOC_FAMILY_ESP32
+	bool
+	default y
+
 config IDF_TARGET_ESP32S2
 	bool "ESP32S2 as target board"
 	default y

--- a/soc/xtensa/esp32s3/Kconfig.soc
+++ b/soc/xtensa/esp32s3/Kconfig.soc
@@ -14,6 +14,10 @@ config SOC_ESP32S3
 
 if SOC_ESP32S3
 
+config SOC_FAMILY_ESP32
+	bool
+	default y
+
 config IDF_TARGET_ESP32S3
 	bool "ESP32S3 as target board"
 	default y


### PR DESCRIPTION
Introduce config for all ESP32 chips which
are using different architectures (Xtensa, RISCV),
but have many common features.
In this particular PR it is needed for
MCUboot port for ESP32 chips.