### PR TITLE
tests: Bluetooth: BAP Uni cli bsim test fix check for g_streams

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -557,10 +557,6 @@ static size_t release_streams(size_t stream_cnt)
 	for (size_t i = 0; i < stream_cnt; i++) {
 		int err;
 
-		if (&g_streams[i] == NULL) {
-			break;
-		}
-
 		UNSET_FLAG(flag_operation_success);
 		UNSET_FLAG(flag_stream_released);
 


### PR DESCRIPTION
There was a check that checked if a stream was NULL, but the value compared to NULL was an address of (&) which can never be NULL. Check is removed.