### PR TITLE
drivers: i2c: ite: use correct I2C init priority

### DIFF
--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -1086,7 +1086,7 @@ static const struct i2c_driver_api i2c_enhance_driver_api = {
 				  &i2c_enhance_data_##inst,                     \
 				  &i2c_enhance_cfg_##inst,                      \
 				  POST_KERNEL,                                  \
-				  CONFIG_KERNEL_INIT_PRIORITY_DEVICE,           \
+				  CONFIG_I2C_INIT_PRIORITY,                     \
 				  &i2c_enhance_driver_api);                     \
 										\
 	static void i2c_enhance_config_func_##inst(void)                        \

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -1279,7 +1279,7 @@ BUILD_ASSERT(((DT_INST_PROP(SMB_CHANNEL_B, fifo_enable) == true) &&
 				  &i2c_it8xxx2_data_##inst,                     \
 				  &i2c_it8xxx2_cfg_##inst,                      \
 				  POST_KERNEL,                                  \
-				  CONFIG_KERNEL_INIT_PRIORITY_DEVICE,           \
+				  CONFIG_I2C_INIT_PRIORITY,                     \
 				  &i2c_it8xxx2_driver_api);                     \
 										\
 	static void i2c_it8xxx2_config_func_##inst(void)                        \


### PR DESCRIPTION
Use `CONFIG_I2C_INIT_PRIORITY` instead of `CONFIG_KERNEL_INIT_PRIORITY_DEVICE` as introduced in c8f9f53322f1faa5a4d13f0dfcee12c596196188.

Looks like the priority was accidentally changed in f2c42663b466c319e0d5feb3f5cc59afe43b6c5a.