### PR TITLE
drivers: eeprom: at2x: initialize after I2C/SPI

### DIFF
--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -18,7 +18,9 @@ config EEPROM_INIT_PRIORITY
 	int "EEPROM init priority"
 	default KERNEL_INIT_PRIORITY_DEVICE
 	help
-	  EEPROM driver device initialization priority.
+	  EEPROM driver device initialization priority. This initialization
+	  priority is used unless the driver implementation has its own
+	  initialization priority.
 
 config EEPROM_SHELL
 	bool "EEPROM shell"
@@ -79,6 +81,16 @@ config EEPROM_AT25
 	select EEPROM_AT2X
 	help
 	  Enable support for Atmel AT25 (and compatible) SPI EEPROMs.
+
+config EEPROM_AT2X_INIT_PRIORITY
+	int "AT2X EEPROM init priority"
+	default 80
+	depends on EEPROM_AT2X
+	help
+	  AT2X EEPROM driver device initialization priority.
+
+	  The EEPROM is connected to I2C or SPI bus an has to be initialized
+	  after I2C/SPI driver.
 
 source "drivers/eeprom/Kconfig.lpc11u6x"
 source "drivers/eeprom/Kconfig.stm32"

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -651,7 +651,7 @@ static const struct eeprom_driver_api eeprom_at2x_api = {
 	DEVICE_DT_DEFINE(INST_DT_AT2X(n, t), &eeprom_at2x_init, \
 			    NULL, &eeprom_at##t##_data_##n, \
 			    &eeprom_at##t##_config_##n, POST_KERNEL, \
-			    CONFIG_EEPROM_INIT_PRIORITY, \
+			    CONFIG_EEPROM_AT2X_INIT_PRIORITY, \
 			    &eeprom_at2x_api)
 
 #define EEPROM_AT24_DEVICE(n) EEPROM_AT2X_DEVICE(n, 24)


### PR DESCRIPTION
Introduce dedicated init priority for AT2X EEPROMs connected via I2C or SPI to ensure they are initialized after I2C/SPI by default.

This approach is similar to other drivers (e.g. flash, DAC) which can be either an internal peripheral of the MCU or connected via I2C or SPI.

Found this issue while trying out #55654 in our custom application. For verification run the following command in the PR branch:

```
$ west build -b native_posix tests/drivers/build_all/eeprom -p -- -DCONFIG_CHECK_INIT_PRIORITIES=y
...
WARNING: /test/spi@33334444/at25@0 POST_KERNEL 50 == /test/spi@33334444 POST_KERNEL 50
WARNING: /test/i2c@11112222/at24@0 POST_KERNEL 50 == /test/i2c@11112222 POST_KERNEL 50
```
