### PR TITLE
Add renode-test integration

### DIFF
--- a/boards/riscv/hifive1/board.cmake
+++ b/boards/riscv/hifive1/board.cmake
@@ -2,6 +2,7 @@
 
 set(SUPPORTED_EMU_PLATFORMS renode qemu)
 set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/hifive1.resc)
+set(RENODE_UART sysbus.uart0)
 
 set(QEMU_binary_suffix riscv32)
 set(QEMU_CPU_TYPE_${ARCH} riscv32)

--- a/boards/riscv/hifive_unleashed/board.cmake
+++ b/boards/riscv/hifive_unleashed/board.cmake
@@ -2,6 +2,7 @@
 
 set(SUPPORTED_EMU_PLATFORMS renode)
 set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/hifive_unleashed.resc)
+set(RENODE_UART sysbus.uart0)
 set(OPENOCD_USE_LOAD_IMAGE NO)
 
 board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_hifive_unleashed.cfg")

--- a/boards/riscv/m2gl025_miv/board.cmake
+++ b/boards/riscv/m2gl025_miv/board.cmake
@@ -2,3 +2,4 @@
 
 set(SUPPORTED_EMU_PLATFORMS renode)
 set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/m2gl025_miv.resc)
+set(RENODE_UART sysbus.uart)

--- a/cmake/emu/renode.cmake
+++ b/cmake/emu/renode.cmake
@@ -27,3 +27,36 @@ add_custom_target(run_renode
   DEPENDS ${logical_target_for_zephyr_elf}
   USES_TERMINAL
   )
+
+find_program(
+  RENODE_TEST
+  renode-test
+  )
+
+set(RENODE_TEST_FLAGS
+  --variable ELF:@${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+  --variable RESC:@${RENODE_SCRIPT}
+  --variable UART:${RENODE_UART}
+  --variable KEYWORDS:${ZEPHYR_BASE}/tests/robot/common.robot
+  --results-dir ${APPLICATION_BINARY_DIR}
+  )
+
+add_custom_target(run_renode_test
+  COMMAND /bin/sh -c "\
+    if [ -z $$ROBOT_FILES ] \;\
+    then\
+        echo ''\;\
+        echo '--- Error: Robot file path is required to run Robot tests in Renode. To provide the path please set the ROBOT_FILES variable.'\;\
+        echo '--- To rerun the test with west execute:'\;\
+        echo '--- ROBOT_FILES=\\<FILES\\> west build -p -b \\<BOARD\\> -s \\<SOURCE_DIR\\> -t run_renode_test'\;\
+        echo ''\;\
+        exit 1\;\
+    fi\;"
+  COMMAND
+  ${RENODE_TEST}
+  ${RENODE_TEST_FLAGS}
+  ${APPLICATION_SOURCE_DIR}/$$ROBOT_FILES
+  WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
+  DEPENDS ${logical_target_for_zephyr_elf}
+  USES_TERMINAL
+  )

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -416,6 +416,7 @@ harness: <string>
     - console
     - pytest
     - gtest
+    - robot
 
     Harnesses ``ztest``, ``gtest`` and ``console`` are based on parsing of the
     output and matching certain phrases. ``ztest`` and ``gtest`` harnesses look
@@ -423,6 +424,8 @@ harness: <string>
     harness if you've already got tests written in the gTest framework and do
     not wish to update them to zTest. The ``console`` harness tells Twister to
     parse a test's text output for a regex defined in the test's YAML file.
+    The ``robot`` harness is used to execute Robot Framework test suites
+    in the Renode simulation framework.
 
     Some widely used harnesses that are not supported yet:
 
@@ -497,6 +500,9 @@ harness_config: <harness configuration options>
     pytest_args: <list of arguments> (default empty)
         Specify a list of additional arguments to pass to ``pytest``.
 
+    robot_test_path: <robot file path> (default empty)
+        Specify a path to a file containing a Robot Framework test suite to be run.
+
     The following is an example yaml file with a few harness_config options.
 
     ::
@@ -529,6 +535,16 @@ harness_config: <harness configuration options>
             harness: pytest
             harness_config:
               pytest_root: [pytest directory name]
+
+    The following is an example yaml file with robot harness_config options.
+
+    ::
+
+        tests:
+          robot.example:
+            harness: robot
+            harness_config:
+              robot_test_path: [robot file path]
 
 filter: <expression>
     Filter whether the testcase should be run by evaluating an expression
@@ -1138,3 +1154,43 @@ dependencies between test cases.  For native_posix platforms, you can provide
 the seed to the random number generator by providing ``-seed=value`` as an
 argument to twister. See :ref:`Shuffling Test Sequence <ztest_shuffle>` for more
 details.
+
+Robot Framework Tests
+*********************
+Zephyr supports `Robot Framework <https://robotframework.org/>`_ as one of solutions for automated testing.
+
+Robot files allow you to express interactive test scenarios in human-readable text format and execute them in simulation or against hardware.
+At this moment Zephyr integration supports running Robot tests in the `Renode <https://renode.io/>`_ simulation framework.
+
+To execute a Robot test suite with twister, run the following command:
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: bash
+
+         $ ./scripts/twister --platform hifive1 --test samples/subsys/shell/shell_module/sample.shell.shell_module.robot
+
+   .. group-tab:: Windows
+
+      .. code-block:: bat
+
+         python .\scripts\twister --platform hifive1 --test samples/subsys/shell/shell_module/sample.shell.shell_module.robot
+
+It's also possible to run it by `west` directly, with:
+
+.. code-block:: bash
+
+   $ ROBOT_FILES=shell_module.robot west build -p -b hifive1 -s samples/subsys/shell/shell_module -t run_renode_test
+
+Writing Robot tests
+===================
+
+For the list of keywords provided by the Robot Framework itself, refer to `the official Robot documentation <https://robotframework.org/robotframework/>`_.
+
+Information on writing and running Robot Framework tests in Renode can be found in `the testing section <https://renode.readthedocs.io/en/latest/introduction/testing.html>`_ of Renode documentation.
+It provides a list of the most commonly used keywords together with links to the source code where those are defined.
+
+It's possible to extend the framework by adding new keywords expressed directly in Robot test suite files, as an external Python library or, like Renode does it, dynamically via XML-RPC.
+For details see the `extending Robot Framework <https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#extending-robot-framework>`_ section in the official Robot documentation.

--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -51,3 +51,7 @@ tests:
     extra_args: CONF_FILE="prj_login.conf"
     integration_platforms:
       - native_posix
+  sample.shell.shell_module.robot:
+    harness: robot
+    harness_config:
+      robot_test_path: shell_module.robot

--- a/samples/subsys/shell/shell_module/shell_module.robot
+++ b/samples/subsys/shell/shell_module/shell_module.robot
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+*** Settings ***
+Resource                      ${KEYWORDS}
+
+*** Test Cases ***
+Should Read Version From Shell
+    # `Prepare Machine` keyword comes from $ZEPHYR_BASE/tests/robot/common.robot file, which is imported as a resource
+    Prepare Machine
+    Start Emulation
+    Wait For Prompt On Uart   uart:~$
+    Write Line To Uart        version
+    Wait For Line On Uart     Zephyr version

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -232,7 +232,11 @@ class BinaryHandler(Handler):
         harness = harness_import.instance
         harness.configure(self.instance)
 
-        if self.call_make_run:
+        robot_test = getattr(harness, "is_robot_test", False)
+
+        if robot_test:
+            command = [self.generator_cmd, "run_renode_test"]
+        elif self.call_make_run:
             command = [self.generator_cmd, "run"]
         elif self.call_west_flash:
             command = ["west", "flash", "--skip-rebuild", "-d", self.build_dir]
@@ -271,6 +275,10 @@ class BinaryHandler(Handler):
         if self.options.enable_ubsan:
             env["UBSAN_OPTIONS"] = "log_path=stdout:halt_on_error=1:" + \
                                   env.get("UBSAN_OPTIONS", "")
+
+        if robot_test:
+            harness.run_robot_test(command, self)
+            return
 
         with subprocess.Popen(command, stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE, cwd=self.build_dir, env=env) as proc:

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -129,7 +129,7 @@ class TestInstance:
     def testsuite_runnable(testsuite, fixtures):
         can_run = False
         # console harness allows us to run the test and capture data.
-        if testsuite.harness in [ 'console', 'ztest', 'pytest', 'test', 'gtest']:
+        if testsuite.harness in [ 'console', 'ztest', 'pytest', 'test', 'gtest', 'robot']:
             can_run = True
             # if we have a fixture that is also being supplied on the
             # command-line, then we need to run the test, not just build it.

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -797,6 +797,10 @@ class TestPlan:
                 if plat.ram < ts.min_ram:
                     instance.add_filter("Not enough RAM", Filters.PLATFORM)
 
+                if ts.harness:
+                    if ts.harness == 'robot' and plat.simulation != 'renode':
+                        instance.add_filter("No robot support for the selected platform", Filters.SKIP)
+
                 if ts.depends_on:
                     dep_intersection = ts.depends_on.intersection(set(plat.supported))
                     if dep_intersection != set(ts.depends_on):

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -107,6 +107,9 @@ mapping:
             required: false
             sequence:
               - type: str
+          "robot_test_path":
+            type: str
+            required: false
           "record":
             type: map
             required: false
@@ -292,6 +295,9 @@ mapping:
                 required: false
                 sequence:
                   - type: str
+              "robot_test_path":
+                type: str
+                required: false
               "record":
                 type: map
                 required: false

--- a/tests/robot/common.robot
+++ b/tests/robot/common.robot
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+*** Keywords ***
+Prepare Machine
+    Execute Command           $bin = ${ELF}
+    Execute Command           include ${RESC}
+    Create Terminal Tester    ${UART}


### PR DESCRIPTION
This PR adds a cmake `run_renode_test` target and integrates it with twister using a new `renode_test` harness.

It allows to express new test cases in Robot Framework syntax and run them in Renode.
As an example we provide a robot file for the `shell` sample and extend the `yaml` file accordingly.

To run a selected robot test in `twister` execute:
```
./scripts/twister --platform hifive1 --test samples/subsys/shell/shell_module/sample.shell.shell_module.robot -v
```

It's also possible to run it outside `twister`, with:
```
ROBOT_FILES=shell_module.robot west build -p -b hifive1 -s samples/subsys/shell/shell_module -t run_renode_test
```

