### PR TITLE
drivers: Fix Modbus DE signal corrupts RS485 signal

### DIFF
--- a/drivers/serial/uart_rpi_pico.c
+++ b/drivers/serial/uart_rpi_pico.c
@@ -290,7 +290,7 @@ static int uart_rpi_irq_tx_complete(const struct device *dev)
 	const struct uart_rpi_config * const config = dev->config;
 	uart_hw_t * const uart_hw = config->uart_regs;
 
-	return !!(uart_hw->fr & UART_UARTFR_TXFE_BITS);
+	return !!(uart_hw->fr & UART_UARTFR_TXFE_BITS) && !(uart_hw->fr & UART_UARTFR_BUSY_BITS);
 }
 
 static int uart_rpi_irq_rx_ready(const struct device *dev)


### PR DESCRIPTION
When use rpi pico with zephyr's Modbus module, the data that's was sent out from RS485 converter circuit was corrupted due to the DE/RE signal was released before all data was sent out include stop bit and parity. To make sure all data was send out we should consider use  UART_UARTFR_BUSY_BITS along with UART_UARTFR_TXFE_BITS to make sure the data in buffer are empty and all bits was sent out.