### PR TITLE
tests: Bluetooth: ascs: Add invalid ASE state transition tests

### DIFF
--- a/tests/bluetooth/audio/ascs/CMakeLists.txt
+++ b/tests/bluetooth/audio/ascs/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(testbinary
   PRIVATE
     src/main.c
     src/test_ase_control_params.c
+    src/test_ase_state_transition_invalid.c
     src/test_ase_state_transition.c
     src/test_common.c
 )

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
@@ -1,0 +1,696 @@
+/* test_ase_state_transition_invalid.c - ASE state transition tests */
+
+/*
+ * Copyright (c) 2023 Codecoup
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdlib.h>
+#include <zephyr/types.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "bap_unicast_server.h"
+#include "bap_unicast_server_expects.h"
+#include "bap_stream.h"
+#include "bap_stream_expects.h"
+#include "conn.h"
+#include "gatt.h"
+#include "gatt_expects.h"
+#include "iso.h"
+
+#include "test_common.h"
+
+struct test_ase_state_transition_invalid_fixture {
+	const struct bt_gatt_attr *ase_cp;
+	const struct bt_gatt_attr *ase_snk;
+	const struct bt_gatt_attr *ase_src;
+	struct bt_bap_stream stream;
+	struct bt_conn conn;
+};
+
+static void *test_ase_state_transition_invalid_setup(void)
+{
+	struct test_ase_state_transition_invalid_fixture *fixture;
+
+	fixture = malloc(sizeof(*fixture));
+	zassert_not_null(fixture);
+
+	memset(fixture, 0, sizeof(*fixture));
+	fixture->ase_cp = test_ase_control_point_get();
+	test_conn_init(&fixture->conn);
+	test_ase_snk_get(1, &fixture->ase_snk);
+	test_ase_src_get(1, &fixture->ase_src);
+
+	return fixture;
+}
+
+static void test_ase_state_transition_invalid_before(void *f)
+{
+	bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
+}
+
+static void test_ase_state_transition_invalid_after(void *f)
+{
+	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
+}
+
+static void test_ase_state_transition_invalid_teardown(void *f)
+{
+	free(f);
+}
+
+ZTEST_SUITE(test_ase_state_transition_invalid, NULL, test_ase_state_transition_invalid_setup,
+	    test_ase_state_transition_invalid_before, test_ase_state_transition_invalid_after,
+	    test_ase_state_transition_invalid_teardown);
+
+static void test_client_config_codec_expect_transition_error(struct bt_conn *conn, uint8_t ase_id,
+							     const struct bt_gatt_attr *ase_cp)
+{
+	const uint8_t expected_error[] = {
+		0x01,           /* Opcode = Config Codec */
+		0x01,           /* Number_of_ASEs */
+		ase_id,         /* ASE_ID[0] */
+		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00,           /* Reason[0] */
+	};
+
+	test_ase_control_client_config_codec(conn, ase_id, NULL);
+	expect_bt_gatt_notify_cb_called_once(conn, BT_UUID_ASCS_ASE_CP, ase_cp, expected_error,
+					     sizeof(expected_error));
+	test_mocks_reset();
+}
+
+static void test_client_config_qos_expect_transition_error(struct bt_conn *conn, uint8_t ase_id,
+							   const struct bt_gatt_attr *ase_cp)
+{
+	const uint8_t expected_error[] = {
+		0x02,           /* Opcode = Config QoS */
+		0x01,           /* Number_of_ASEs */
+		ase_id,         /* ASE_ID[0] */
+		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00,           /* Reason[0] */
+	};
+
+	test_ase_control_client_config_qos(conn, ase_id);
+	expect_bt_gatt_notify_cb_called_once(conn, BT_UUID_ASCS_ASE_CP, ase_cp, expected_error,
+					     sizeof(expected_error));
+	test_mocks_reset();
+}
+
+static void test_client_enable_expect_transition_error(struct bt_conn *conn, uint8_t ase_id,
+						       const struct bt_gatt_attr *ase_cp)
+{
+	const uint8_t expected_error[] = {
+		0x03,           /* Opcode = Enable */
+		0x01,           /* Number_of_ASEs */
+		ase_id,         /* ASE_ID[0] */
+		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00,           /* Reason[0] */
+	};
+
+	test_ase_control_client_enable(conn, ase_id);
+	expect_bt_gatt_notify_cb_called_once(conn, BT_UUID_ASCS_ASE_CP, ase_cp, expected_error,
+					     sizeof(expected_error));
+	test_mocks_reset();
+}
+
+static void test_client_receiver_start_ready_expect_transition_error(
+	struct bt_conn *conn, uint8_t ase_id, const struct bt_gatt_attr *ase_cp)
+{
+	const uint8_t expected_error[] = {
+		0x04,           /* Opcode = Receiver Start Ready */
+		0x01,           /* Number_of_ASEs */
+		ase_id,         /* ASE_ID[0] */
+		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00,           /* Reason[0] */
+	};
+
+	test_ase_control_client_receiver_start_ready(conn, ase_id);
+	expect_bt_gatt_notify_cb_called_once(conn, BT_UUID_ASCS_ASE_CP, ase_cp, expected_error,
+					     sizeof(expected_error));
+	test_mocks_reset();
+}
+
+static void test_client_receiver_start_ready_expect_ase_direction_error(
+	struct bt_conn *conn, uint8_t ase_id, const struct bt_gatt_attr *ase_cp)
+{
+	const uint8_t expected_error[] = {
+		0x04,           /* Opcode = Receiver Start Ready */
+		0x01,           /* Number_of_ASEs */
+		ase_id,         /* ASE_ID[0] */
+		0x05,           /* Response_Code[0] = Invalid ASE direction */
+		0x00,           /* Reason[0] */
+	};
+
+	test_ase_control_client_receiver_start_ready(conn, ase_id);
+	expect_bt_gatt_notify_cb_called_once(conn, BT_UUID_ASCS_ASE_CP, ase_cp, expected_error,
+					     sizeof(expected_error));
+	test_mocks_reset();
+}
+
+static void test_client_disable_expect_transition_error(struct bt_conn *conn, uint8_t ase_id,
+							const struct bt_gatt_attr *ase_cp)
+{
+	const uint8_t expected_error[] = {
+		0x05,           /* Opcode = Disable */
+		0x01,           /* Number_of_ASEs */
+		ase_id,         /* ASE_ID[0] */
+		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00,           /* Reason[0] */
+	};
+
+	test_ase_control_client_disable(conn, ase_id);
+	expect_bt_gatt_notify_cb_called_once(conn, BT_UUID_ASCS_ASE_CP, ase_cp, expected_error,
+					     sizeof(expected_error));
+	test_mocks_reset();
+}
+
+static void test_client_receiver_stop_ready_expect_transition_error(
+	struct bt_conn *conn, uint8_t ase_id, const struct bt_gatt_attr *ase_cp)
+{
+	const uint8_t expected_error[] = {
+		0x06,           /* Opcode = Receiver Stop Ready */
+		0x01,           /* Number_of_ASEs */
+		ase_id,         /* ASE_ID[0] */
+		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00,           /* Reason[0] */
+	};
+
+	test_ase_control_client_receiver_stop_ready(conn, ase_id);
+	expect_bt_gatt_notify_cb_called_once(conn, BT_UUID_ASCS_ASE_CP, ase_cp, expected_error,
+					     sizeof(expected_error));
+	test_mocks_reset();
+}
+
+static void test_client_receiver_stop_ready_expect_ase_direction_error(
+	struct bt_conn *conn, uint8_t ase_id, const struct bt_gatt_attr *ase_cp)
+{
+	const uint8_t expected_error[] = {
+		0x06,           /* Opcode = Receiver Stop Ready */
+		0x01,           /* Number_of_ASEs */
+		ase_id,         /* ASE_ID[0] */
+		0x05,           /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00,           /* Reason[0] */
+	};
+
+	test_ase_control_client_receiver_stop_ready(conn, ase_id);
+	expect_bt_gatt_notify_cb_called_once(conn, BT_UUID_ASCS_ASE_CP, ase_cp, expected_error,
+					     sizeof(expected_error));
+	test_mocks_reset();
+}
+
+static void test_client_update_metadata_expect_transition_error(
+	struct bt_conn *conn, uint8_t ase_id, const struct bt_gatt_attr *ase_cp)
+{
+	const uint8_t expected_error[] = {
+		0x07,           /* Opcode = Update Metadata */
+		0x01,           /* Number_of_ASEs */
+		ase_id,         /* ASE_ID[0] */
+		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00,           /* Reason[0] */
+	};
+
+	test_ase_control_client_update_metadata(conn, ase_id);
+	expect_bt_gatt_notify_cb_called_once(conn, BT_UUID_ASCS_ASE_CP, ase_cp, expected_error,
+					     sizeof(expected_error));
+	test_mocks_reset();
+}
+
+static void test_client_release_expect_transition_error(struct bt_conn *conn, uint8_t ase_id,
+							const struct bt_gatt_attr *ase_cp)
+{
+	const uint8_t expected_error[] = {
+		0x08,           /* Opcode = Release */
+		0x01,           /* Number_of_ASEs */
+		ase_id,         /* ASE_ID[0] */
+		0x04,           /* Response_Code[0] = Invalid ASE State Machine Transition */
+		0x00,           /* Reason[0] */
+	};
+
+	test_ase_control_client_release(conn, ase_id);
+	expect_bt_gatt_notify_cb_called_once(conn, BT_UUID_ASCS_ASE_CP, ase_cp, expected_error,
+					     sizeof(expected_error));
+	test_mocks_reset();
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_client_sink_state_idle)
+{
+	const struct bt_gatt_attr *ase_cp = fixture->ase_cp;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	ase_id = test_ase_id_get(fixture->ase_snk);
+
+	test_client_config_qos_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_enable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_start_ready_expect_ase_direction_error(conn, ase_id, ase_cp);
+	test_client_disable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_stop_ready_expect_ase_direction_error(conn, ase_id, ase_cp);
+	test_client_update_metadata_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_release_expect_transition_error(conn, ase_id, ase_cp);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_client_sink_state_codec_configured)
+{
+	const struct bt_gatt_attr *ase_cp = fixture->ase_cp;
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	ase_id = test_ase_id_get(fixture->ase_snk);
+	test_preamble_state_codec_configured(conn, ase_id, stream);
+
+	test_client_enable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_start_ready_expect_ase_direction_error(conn, ase_id, ase_cp);
+	test_client_disable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_stop_ready_expect_ase_direction_error(conn, ase_id, ase_cp);
+	test_client_update_metadata_expect_transition_error(conn, ase_id, ase_cp);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_client_sink_state_qos_configured)
+{
+	const struct bt_gatt_attr *ase_cp = fixture->ase_cp;
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	ase_id = test_ase_id_get(fixture->ase_snk);
+	test_preamble_state_qos_configured(conn, ase_id, stream);
+
+	test_client_receiver_start_ready_expect_ase_direction_error(conn, ase_id, ase_cp);
+	test_client_disable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_stop_ready_expect_ase_direction_error(conn, ase_id, ase_cp);
+	test_client_update_metadata_expect_transition_error(conn, ase_id, ase_cp);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_client_sink_state_enabling)
+{
+	const struct bt_gatt_attr *ase_cp = fixture->ase_cp;
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	ase_id = test_ase_id_get(fixture->ase_snk);
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	test_client_config_codec_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_config_qos_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_enable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_start_ready_expect_ase_direction_error(conn, ase_id, ase_cp);
+	test_client_receiver_stop_ready_expect_ase_direction_error(conn, ase_id, ase_cp);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_sink_client_state_streaming)
+{
+	const struct bt_gatt_attr *ase_cp = fixture->ase_cp;
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	struct bt_iso_chan *chan;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	ase_id = test_ase_id_get(fixture->ase_snk);
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, false);
+
+	test_client_config_codec_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_config_qos_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_enable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_start_ready_expect_ase_direction_error(conn, ase_id, ase_cp);
+	test_client_receiver_stop_ready_expect_ase_direction_error(conn, ase_id, ase_cp);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_client_source_state_idle)
+{
+	const struct bt_gatt_attr *ase_cp = fixture->ase_cp;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	ase_id = test_ase_id_get(fixture->ase_src);
+
+	test_client_config_qos_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_enable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_start_ready_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_disable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_stop_ready_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_update_metadata_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_release_expect_transition_error(conn, ase_id, ase_cp);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_client_source_state_codec_configured)
+{
+	const struct bt_gatt_attr *ase_cp = fixture->ase_cp;
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	ase_id = test_ase_id_get(fixture->ase_src);
+	test_preamble_state_codec_configured(conn, ase_id, stream);
+
+	test_client_enable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_start_ready_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_disable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_stop_ready_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_update_metadata_expect_transition_error(conn, ase_id, ase_cp);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_client_source_state_qos_configured)
+{
+	const struct bt_gatt_attr *ase_cp = fixture->ase_cp;
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	ase_id = test_ase_id_get(fixture->ase_src);
+	test_preamble_state_qos_configured(conn, ase_id, stream);
+
+	test_client_receiver_start_ready_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_disable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_stop_ready_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_update_metadata_expect_transition_error(conn, ase_id, ase_cp);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_client_source_state_enabling)
+{
+	const struct bt_gatt_attr *ase_cp = fixture->ase_cp;
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	ase_id = test_ase_id_get(fixture->ase_src);
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	test_client_config_codec_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_config_qos_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_enable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_stop_ready_expect_transition_error(conn, ase_id, ase_cp);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_client_source_state_streaming)
+{
+	const struct bt_gatt_attr *ase_cp = fixture->ase_cp;
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	struct bt_iso_chan *chan;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	ase_id = test_ase_id_get(fixture->ase_src);
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, true);
+
+	test_client_config_codec_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_config_qos_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_enable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_start_ready_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_stop_ready_expect_transition_error(conn, ase_id, ase_cp);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_client_source_state_disabling)
+{
+	const struct bt_gatt_attr *ase_cp = fixture->ase_cp;
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	ase_id = test_ase_id_get(fixture->ase_src);
+	test_preamble_state_disabling(conn, ase_id, stream);
+
+	test_client_config_codec_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_config_qos_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_enable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_receiver_start_ready_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_disable_expect_transition_error(conn, ase_id, ase_cp);
+	test_client_update_metadata_expect_transition_error(conn, ase_id, ase_cp);
+}
+
+static void test_server_config_codec_expect_error(struct bt_bap_stream *stream)
+{
+	struct bt_codec codec = BT_CODEC_LC3_CONFIG_16_2(BT_AUDIO_LOCATION_FRONT_LEFT,
+							 BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	int err;
+
+	err = bt_bap_stream_reconfig(stream, &codec);
+	zassert_false(err == 0, "bt_bap_stream_reconfig unexpected success");
+}
+
+static void test_server_receiver_start_ready_expect_error(struct bt_bap_stream *stream)
+{
+	int err;
+
+	err = bt_bap_stream_start(stream);
+	zassert_false(err == 0, "bt_bap_stream_start unexpected success");
+}
+
+static void test_server_disable_expect_error(struct bt_bap_stream *stream)
+{
+	int err;
+
+	err = bt_bap_stream_disable(stream);
+	zassert_false(err == 0, "bt_bap_stream_disable unexpected success");
+}
+
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
+#include "bap_endpoint.h"
+
+static void test_server_config_qos_expect_error(struct bt_bap_stream *stream)
+{
+	struct bt_bap_unicast_group group;
+	int err;
+
+	sys_slist_init(&group.streams);
+	sys_slist_append(&group.streams, &stream->_node);
+
+	err = bt_bap_stream_qos(stream->conn, &group);
+	zassert_false(err == 0, "bt_bap_stream_qos unexpected success");
+}
+
+static void test_server_enable_expect_error(struct bt_bap_stream *stream)
+{
+	struct bt_codec_data meta[] = {
+		BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
+			      (BT_AUDIO_CONTEXT_TYPE_RINGTONE & 0xFFU),
+			      ((BT_AUDIO_CONTEXT_TYPE_RINGTONE >> 8) & 0xFFU)),
+	};
+	int err;
+
+	err = bt_bap_stream_enable(stream, meta, ARRAY_SIZE(meta));
+	zassert_false(err == 0, "bt_bap_stream_enable unexpected success");
+}
+
+static void test_server_receiver_stop_ready_expect_error(struct bt_bap_stream *stream)
+{
+	int err;
+
+	err = bt_bap_stream_stop(stream);
+	zassert_false(err == 0, "bt_bap_stream_stop unexpected success");
+}
+#else
+#define test_server_config_qos_expect_error(...)
+#define test_server_enable_expect_error(...)
+#define test_server_receiver_stop_ready_expect_error(...)
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
+
+static void test_server_update_metadata_expect_error(struct bt_bap_stream *stream)
+{
+	struct bt_codec_data meta[] = {
+		BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
+			      (BT_AUDIO_CONTEXT_TYPE_RINGTONE & 0xFFU),
+			      ((BT_AUDIO_CONTEXT_TYPE_RINGTONE >> 8) & 0xFFU)),
+	};
+	int err;
+
+	err = bt_bap_stream_metadata(stream, meta, ARRAY_SIZE(meta));
+	zassert_false(err == 0, "bt_bap_stream_metadata unexpected success");
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_server_sink_state_codec_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	ase_id = test_ase_id_get(fixture->ase_snk);
+	test_preamble_state_codec_configured(conn, ase_id, stream);
+
+	test_server_config_qos_expect_error(stream);
+	test_server_enable_expect_error(stream);
+	test_server_receiver_start_ready_expect_error(stream);
+	test_server_disable_expect_error(stream);
+	test_server_receiver_stop_ready_expect_error(stream);
+	test_server_update_metadata_expect_error(stream);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_server_sink_state_qos_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	ase_id = test_ase_id_get(fixture->ase_snk);
+	test_preamble_state_qos_configured(conn, ase_id, stream);
+
+	test_server_config_qos_expect_error(stream);
+	test_server_enable_expect_error(stream);
+	test_server_receiver_start_ready_expect_error(stream);
+	test_server_disable_expect_error(stream);
+	test_server_receiver_stop_ready_expect_error(stream);
+	test_server_update_metadata_expect_error(stream);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_server_sink_state_enabling)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	ase_id = test_ase_id_get(fixture->ase_snk);
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	test_server_config_codec_expect_error(stream);
+	test_server_config_qos_expect_error(stream);
+	test_server_enable_expect_error(stream);
+	test_server_receiver_stop_ready_expect_error(stream);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_server_sink_state_streaming)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	struct bt_iso_chan *chan;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
+
+	ase_id = test_ase_id_get(fixture->ase_snk);
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, false);
+
+	test_server_config_codec_expect_error(stream);
+	test_server_config_qos_expect_error(stream);
+	test_server_enable_expect_error(stream);
+	test_server_receiver_start_ready_expect_error(stream);
+	test_server_receiver_stop_ready_expect_error(stream);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_codec_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	ase_id = test_ase_id_get(fixture->ase_src);
+	test_preamble_state_codec_configured(conn, ase_id, stream);
+
+	test_server_config_qos_expect_error(stream);
+	test_server_enable_expect_error(stream);
+	test_server_receiver_start_ready_expect_error(stream);
+	test_server_disable_expect_error(stream);
+	test_server_receiver_stop_ready_expect_error(stream);
+	test_server_update_metadata_expect_error(stream);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_qos_configured)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	ase_id = test_ase_id_get(fixture->ase_src);
+	test_preamble_state_qos_configured(conn, ase_id, stream);
+
+	test_server_config_qos_expect_error(stream);
+	test_server_enable_expect_error(stream);
+	test_server_receiver_start_ready_expect_error(stream);
+	test_server_disable_expect_error(stream);
+	test_server_receiver_stop_ready_expect_error(stream);
+	test_server_update_metadata_expect_error(stream);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_enabling)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	ase_id = test_ase_id_get(fixture->ase_src);
+	test_preamble_state_enabling(conn, ase_id, stream);
+
+	test_server_config_codec_expect_error(stream);
+	test_server_config_qos_expect_error(stream);
+	test_server_enable_expect_error(stream);
+	test_server_receiver_stop_ready_expect_error(stream);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_streaming)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	struct bt_iso_chan *chan;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	ase_id = test_ase_id_get(fixture->ase_src);
+	test_preamble_state_streaming(conn, ase_id, stream, &chan, true);
+
+	test_server_config_codec_expect_error(stream);
+	test_server_config_qos_expect_error(stream);
+	test_server_enable_expect_error(stream);
+	test_server_receiver_start_ready_expect_error(stream);
+	test_server_receiver_stop_ready_expect_error(stream);
+}
+
+ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_disabling)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	uint8_t ase_id;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	ase_id = test_ase_id_get(fixture->ase_src);
+	test_preamble_state_disabling(conn, ase_id, stream);
+
+	test_server_config_codec_expect_error(stream);
+	test_server_config_qos_expect_error(stream);
+	test_server_enable_expect_error(stream);
+	test_server_receiver_start_ready_expect_error(stream);
+	test_server_disable_expect_error(stream);
+	test_server_receiver_stop_ready_expect_error(stream);
+	test_server_update_metadata_expect_error(stream);
+}

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -328,6 +328,9 @@ void test_preamble_state_streaming(struct bt_conn *conn, uint8_t ase_id,
 
 	if (source) {
 		test_ase_control_client_receiver_start_ready(conn, ase_id);
+	} else {
+		err = bt_bap_stream_start(stream);
+		zassert_equal(0, err, "bt_bap_stream_start err %d", err);
 	}
 
 	test_mocks_reset();

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -339,9 +339,18 @@ void test_preamble_state_streaming(struct bt_conn *conn, uint8_t ase_id,
 void test_preamble_state_disabling(struct bt_conn *conn, uint8_t ase_id,
 				   struct bt_bap_stream *stream)
 {
+	struct bt_iso_chan *chan;
+	int err;
+
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
 	test_ase_control_client_enable(conn, ase_id);
+
+	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
+	zassert_equal(0, err, "Failed to connect iso: err %d", err);
+
+	test_ase_control_client_receiver_start_ready(conn, ase_id);
 	test_ase_control_client_disable(conn, ase_id);
+
 	test_mocks_reset();
 }

--- a/tests/bluetooth/audio/ascs/testcase.yaml
+++ b/tests/bluetooth/audio/ascs/testcase.yaml
@@ -1,5 +1,19 @@
 common:
   tags: bluetooth bluetooth_audio
 tests:
-  bluetooth.audio.ascs.test:
+  bluetooth.audio.ascs.test_default:
     type: unit
+  bluetooth.audio.ascs.test_unicast_client_enabled:
+    type: unit
+    extra_configs:
+      - CONFIG_BT_BAP_UNICAST_CLIENT=y
+    testcases:
+      - server_sink_state_codec_configured
+      - server_sink_state_qos_configured
+      - server_sink_state_enabling
+      - server_sink_state_streaming
+      - server_source_state_codec_configured
+      - server_source_state_qos_configured
+      - server_source_state_enabling
+      - server_source_state_streaming
+      - server_source_state_disabling

--- a/tests/bluetooth/audio/ascs/testcase.yaml
+++ b/tests/bluetooth/audio/ascs/testcase.yaml
@@ -3,6 +3,14 @@ common:
 tests:
   bluetooth.audio.ascs.test_default:
     type: unit
+  bluetooth.audio.ascs.test_snk_only:
+    type: unit
+    extra_configs:
+      - CONFIG_BT_ASCS_ASE_SRC_COUNT=0
+  bluetooth.audio.ascs.test_src_only:
+    type: unit
+    extra_configs:
+      - CONFIG_BT_ASCS_ASE_SNK_COUNT=0
   bluetooth.audio.ascs.test_unicast_client_enabled:
     type: unit
     extra_configs:

--- a/tests/bluetooth/audio/mocks/CMakeLists.txt
+++ b/tests/bluetooth/audio/mocks/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_library(mocks STATIC
   src/bap_stream.c
+  src/bap_unicast_client.c
   src/bap_unicast_server.c
   src/conn.c
   src/fatal.c

--- a/tests/bluetooth/audio/mocks/src/bap_unicast_client.c
+++ b/tests/bluetooth/audio/mocks/src/bap_unicast_client.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 Codecoup
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/bluetooth/audio/bap.h>
+
+bool bt_bap_ep_is_unicast_client(const struct bt_bap_ep *ep)
+{
+	return false;
+}
+
+int bt_bap_unicast_client_config(struct bt_bap_stream *stream, const struct bt_codec *codec)
+{
+	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
+	return 0;
+}
+
+int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group)
+{
+	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
+	return 0;
+}
+
+int bt_bap_unicast_client_enable(struct bt_bap_stream *stream, struct bt_codec_data *meta,
+				 size_t meta_count)
+{
+	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
+	return 0;
+}
+
+int bt_bap_unicast_client_metadata(struct bt_bap_stream *stream, struct bt_codec_data *meta,
+				   size_t meta_count)
+{
+	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
+	return 0;
+}
+
+int bt_bap_unicast_client_disable(struct bt_bap_stream *stream)
+{
+	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
+	return 0;
+}
+
+int bt_bap_unicast_client_start(struct bt_bap_stream *stream)
+{
+	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
+	return 0;
+}
+
+int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
+{
+	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
+	return 0;
+}
+
+int bt_bap_unicast_client_release(struct bt_bap_stream *stream)
+{
+	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
+	return 0;
+}


### PR DESCRIPTION
This verifies whether implementation rejects invalid ASE Operation in given state.
Moreover this PR fixes sending proper Response_Code in ASE Control Point
notification in case the client initiates Receiver Start/Stop Ready
operation on Sink ASE.
The response that shall be sent according to the specification is
"Invalid ASE direction", while the implementation sent "Invalid ASE state"
instead.