### PR TITLE
drivers: i2c: remove deprecated I2C_NODE_MASTER

### DIFF
--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -65,9 +65,6 @@ extern "C" {
 /** Peripheral to act as Controller. */
 #define I2C_MODE_CONTROLLER		BIT(4)
 
-/** @deprecated Use I2C_MODE_CONTROLLER instead. */
-#define I2C_MODE_MASTER	__DEPRECATED_MACRO BIT(4)
-
 /**
  * @brief Complete I2C DT information
  *


### PR DESCRIPTION
Remove deprecated I2C_NODE_MASTER definition. It has shipped deprecated 2 releases (3.2, 3.3) so it can be removed now.