### PR TITLE
bluetooth: Fix compiler warning with arm-clang

### DIFF
--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -136,7 +136,7 @@ static void close_link(enum prov_bearer_link_status status);
 
 static void buf_sent(int err, void *user_data)
 {
-	enum prov_bearer_link_status reason = (enum prov_bearer_link_status)user_data;
+	enum prov_bearer_link_status reason = (enum prov_bearer_link_status)(int)user_data;
 
 	if (atomic_test_and_clear_bit(link.flags, ADV_LINK_CLOSING)) {
 		close_link(reason);


### PR DESCRIPTION
Since we enable -fshort-enums for arm-clang we get the following warning:

subsys/bluetooth/mesh/pb_adv.c:139:40: warning: cast to smaller integer type 'enum prov_bearer_link_status' from
 'void *' [-Wvoid-pointer-to-enum-cast]

Fix this by first casting to an int to grow the size of the type.