### PR TITLE
cmake: modules: dts: Fix handling when CMAKE_DTS_PREPROCESSOR is a list

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3525,9 +3525,9 @@ endfunction()
 #
 # WORKING_DIRECTORY <dir>: where to run the preprocessor.
 function(zephyr_dt_preprocess)
-  set(req_single_args "CPP;OUT_FILE")
+  set(req_single_args "OUT_FILE")
   set(single_args "DEPS_FILE;WORKING_DIRECTORY")
-  set(multi_args "SOURCE_FILES;EXTRA_CPPFLAGS;INCLUDE_DIRECTORIES")
+  set(multi_args "CPP;SOURCE_FILES;EXTRA_CPPFLAGS;INCLUDE_DIRECTORIES")
   cmake_parse_arguments(DT_PREPROCESS "" "${req_single_args};${single_args}" "${multi_args}" ${ARGN})
 
   foreach(arg ${req_single_args} SOURCE_FILES)


### PR DESCRIPTION
For arm-clang CMAKE_DTS_PREPROCESSOR gets set to a list so that arguments are also passed to cpp.  This was broken since the args would get dropped.  Change CPP to be treated as a multi_args to fix this.