### PR TITLE
devicetree: bindings: add top-level `interrupt-source` key

### DIFF
--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -491,16 +491,19 @@ def print_binding_page(binding, base_names, vnd_lookup, dup_compats,
           file=string_io)
 
     # Binding description.
-    if binding.bus:
-        bus_help = f'These nodes are "{binding.bus}" bus nodes.'
-    else:
-        bus_help = ''
     print_block(f'''\
     Description
     ***********
 
-    {bus_help}
     ''', string_io)
+    if binding.bus:
+        print(f'These nodes are "{binding.bus}" bus nodes.\n\n',
+              file=string_io)
+    if binding.interrupt_source:
+        print('These nodes are interrupt sources, which means '
+              'they must have either an ``interrupts`` or an '
+              '``interrupts-extended`` property set.\n\n',
+              file=string_io)
     print(to_code_block(binding.description.strip()), file=string_io)
 
     # Properties.

--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -34,6 +34,9 @@ like this:
    # Used to match nodes to this binding:
    compatible: "manufacturer,foo-device"
 
+   # Used to indicate that nodes of this type generate interrupts:
+   interrupt-source: <true | false>
+
    properties:
      # Requirements for and descriptions of the properties that this
      # binding's nodes need to satisfy go here.
@@ -110,6 +113,17 @@ Some bindings apply to a generic class of devices which do not have a specific
 vendor. In these cases, there is no vendor prefix. One example is the
 :dtcompatible:`gpio-leds` compatible which is commonly used to describe board
 LEDs connected to GPIOs.
+
+interrupt-source
+****************
+
+This key is a boolean. It is used to indicate that the hardware represented by
+this compatible generates interrupts. If the binding contains
+``interrupt-source: true``, then any node with this compatible must have either
+an ``interrupts`` or an ``interrupts-extended`` property set.
+
+Refer to the Devicetree Specification v0.3 section 2.4, Interrupts and
+Interrupt Mapping, for more details about these properties.
 
 .. _dt-bindings-properties:
 

--- a/dts/bindings/adc/nordic,nrf-adc.yaml
+++ b/dts/bindings/adc/nordic,nrf-adc.yaml
@@ -5,13 +5,12 @@ description: nRF ADC node
 
 compatible: "nordic,nrf-adc"
 
+interrupt-source: true
+
 include: adc-controller.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   "#io-channel-cells":

--- a/dts/bindings/adc/nordic,nrf-comp.yaml
+++ b/dts/bindings/adc/nordic,nrf-comp.yaml
@@ -5,13 +5,12 @@ description: Nordic nRF family COMP (Comparator)
 
 compatible: "nordic,nrf-comp"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   "#io-channel-cells":

--- a/dts/bindings/adc/nordic,nrf-lpcomp.yaml
+++ b/dts/bindings/adc/nordic,nrf-lpcomp.yaml
@@ -5,13 +5,12 @@ description: Nordic nRF family LPCOMP (Low-power Comparator)
 
 compatible: "nordic,nrf-lpcomp"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   "#io-channel-cells":

--- a/dts/bindings/adc/nordic,nrf-saadc.yaml
+++ b/dts/bindings/adc/nordic,nrf-saadc.yaml
@@ -5,13 +5,12 @@ description: Nordic Semiconductor nRF family SAADC node
 
 compatible: "nordic,nrf-saadc"
 
+interrupt-source: true
+
 include: adc-controller.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   "#io-channel-cells":

--- a/dts/bindings/arm/nordic,nrf-egu.yaml
+++ b/dts/bindings/arm/nordic,nrf-egu.yaml
@@ -5,11 +5,10 @@ description: Nordic EGU (Event Generator Unit)
 
 compatible: "nordic,nrf-egu"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/dts/bindings/arm/nordic,nrf-kmu.yaml
+++ b/dts/bindings/arm/nordic,nrf-kmu.yaml
@@ -5,11 +5,10 @@ description: Nordic KMU (Key Management Unit)
 
 compatible: "nordic,nrf-kmu"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/dts/bindings/arm/nordic,nrf-spu.yaml
+++ b/dts/bindings/arm/nordic,nrf-spu.yaml
@@ -2,11 +2,10 @@ description: Nordic SPU (System Protection Unit)
 
 compatible: "nordic,nrf-spu"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/dts/bindings/arm/nordic,nrf-swi.yaml
+++ b/dts/bindings/arm/nordic,nrf-swi.yaml
@@ -5,11 +5,10 @@ description: Nordic nRF family SWI (Software Interrupt)
 
 compatible: "nordic,nrf-swi"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/dts/bindings/audio/nordic,nrf-pdm.yaml
+++ b/dts/bindings/audio/nordic,nrf-pdm.yaml
@@ -5,13 +5,12 @@ description: Nordic PDM (Pulse Density Modulation interface)
 
 compatible: "nordic,nrf-pdm"
 
+interrupt-source: true
+
 include: [base.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   pinctrl-0:

--- a/dts/bindings/clock/nordic,nrf-clock.yaml
+++ b/dts/bindings/clock/nordic,nrf-clock.yaml
@@ -5,13 +5,12 @@ description: Nordic nRF clock control node
 
 compatible: "nordic,nrf-clock"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   hfclkaudio-frequency:

--- a/dts/bindings/crypto/nordic,nrf-ccm.yaml
+++ b/dts/bindings/crypto/nordic,nrf-ccm.yaml
@@ -5,13 +5,12 @@ description: Nordic nRF family CCM (AES CCM mode encryption)
 
 compatible: "nordic,nrf-ccm"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   length-field-length-8-bits:

--- a/dts/bindings/crypto/nordic,nrf-ecb.yaml
+++ b/dts/bindings/crypto/nordic,nrf-ecb.yaml
@@ -5,11 +5,10 @@ description: Nordic ECB (AES electronic codebook mode encryption)
 
 compatible: "nordic,nrf-ecb"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
@@ -21,6 +21,8 @@ description: |
 
 compatible: "nordic,nrf-qspi"
 
+interrupt-source: true
+
 include: [flash-controller.yaml, pinctrl-device.yaml]
 
 bus: qspi
@@ -33,9 +35,6 @@ properties:
   "#size-cells":
     required: true
     const: 0
-
-  interrupts:
-    required: true
 
   pinctrl-0:
     required: true

--- a/dts/bindings/gpio/nordic,nrf-gpiote.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpiote.yaml
@@ -5,11 +5,10 @@ description: NRF5 GPIOTE node
 
 compatible: "nordic,nrf-gpiote"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -6,11 +6,10 @@
 
 include: [i2c-controller.yaml, pinctrl-device.yaml]
 
+interrupt-source: true
+
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   pinctrl-0:

--- a/dts/bindings/i2s/nordic,nrf-i2s.yaml
+++ b/dts/bindings/i2s/nordic,nrf-i2s.yaml
@@ -5,13 +5,12 @@ description: Nordic I2S (Inter-IC sound interface)
 
 compatible: "nordic,nrf-i2s"
 
+interrupt-source: true
+
 include: [i2s-controller.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   pinctrl-0:

--- a/dts/bindings/ipm/nordic,nrf-ipc.yaml
+++ b/dts/bindings/ipm/nordic,nrf-ipc.yaml
@@ -5,11 +5,10 @@ description: Nordic nRF family IPC (Interprocessor Communication)
 
 compatible: "nordic,nrf-ipc"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/dts/bindings/mbox/nordic,mbox-nrf-ipc.yaml
+++ b/dts/bindings/mbox/nordic,mbox-nrf-ipc.yaml
@@ -5,6 +5,8 @@ description: Nordic nRF family IPC (MBOX Interprocessor Communication)
 
 compatible: "nordic,mbox-nrf-ipc"
 
+interrupt-source: true
+
 include: [base.yaml, mailbox-controller.yaml]
 
 properties:
@@ -17,9 +19,6 @@ properties:
     type: int
     required: true
     description: RX supported channels mask
-
-  interrupts:
-    required: true
 
 mbox-cells:
   - channel

--- a/dts/bindings/net/wireless/nordic,nrf-nfct.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf-nfct.yaml
@@ -5,11 +5,10 @@ description: Nordic nRF family NFCT (Near Field Communication Tag)
 
 compatible: "nordic,nrf-nfct"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/dts/bindings/net/wireless/nordic,nrf-radio.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf-radio.yaml
@@ -108,13 +108,12 @@ description: |
 
 compatible: "nordic,nrf-radio"
 
+interrupt-source: true
+
 include: [base.yaml]
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   fem:

--- a/dts/bindings/power/nordic,nrf-power.yaml
+++ b/dts/bindings/power/nordic,nrf-power.yaml
@@ -5,11 +5,10 @@ description: Nordic nRF power control node
 
 compatible: "nordic,nrf-power"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/dts/bindings/power/nordic,nrf-usbreg.yaml
+++ b/dts/bindings/power/nordic,nrf-usbreg.yaml
@@ -5,11 +5,10 @@ description: Nordic nRF family USBREG (USB Regulator Control)
 
 compatible: "nordic,nrf-usbreg"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/dts/bindings/rng/nordic,nrf-rng.yaml
+++ b/dts/bindings/rng/nordic,nrf-rng.yaml
@@ -5,11 +5,10 @@ description: Nordic nRF family RNG (Random Number Generator)
 
 compatible: "nordic,nrf-rng"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -5,13 +5,12 @@ description: Nordic nRF quadrature decoder (QDEC) node
 
 compatible: "nordic,nrf-qdec"
 
+interrupt-source: true
+
 include: [sensor-device.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   pinctrl-0:

--- a/dts/bindings/sensor/nordic,nrf-temp.yaml
+++ b/dts/bindings/sensor/nordic,nrf-temp.yaml
@@ -5,11 +5,10 @@ description: Nordic nRF family TEMP node
 
 compatible: "nordic,nrf-temp"
 
+interrupt-source: true
+
 include: sensor-device.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/dts/bindings/serial/nordic,nrf-uart-common.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart-common.yaml
@@ -1,10 +1,9 @@
 include: [uart-controller.yaml, pinctrl-device.yaml]
 
+interrupt-source: true
+
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   pinctrl-0:

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -5,11 +5,10 @@
 
 include: [spi-controller.yaml, pinctrl-device.yaml]
 
+interrupt-source: true
+
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   pinctrl-0:

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -5,6 +5,8 @@ description: Nordic nRF timer node
 
 compatible: "nordic,nrf-timer"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
@@ -20,9 +22,6 @@ properties:
     type: int
     required: true
     description: Maximum bit width supported
-
-  interrupts:
-    required: true
 
   prescaler:
     type: int

--- a/dts/bindings/usb/nordic,nrf-usbd.yaml
+++ b/dts/bindings/usb/nordic,nrf-usbd.yaml
@@ -6,13 +6,12 @@ description: |
 
 compatible: "nordic,nrf-usbd"
 
+interrupt-source: true
+
 include: usb-ep.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true
 
   num-isoin-endpoints:

--- a/dts/bindings/watchdog/nordic,nrf-wdt.yaml
+++ b/dts/bindings/watchdog/nordic,nrf-wdt.yaml
@@ -5,11 +5,10 @@ description: Nordic nRF family WDT (Watchdog Timer)
 
 compatible: "nordic,nrf-wdt"
 
+interrupt-source: true
+
 include: base.yaml
 
 properties:
   reg:
-    required: true
-
-  interrupts:
     required: true

--- a/scripts/dts/python-devicetree/tests/test-bindings/interrupt-source.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/interrupt-source.yaml
@@ -1,0 +1,3 @@
+compatible: interrupt-source
+description: Test the 'interrupt-source:' feature
+interrupt-source: true

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -627,18 +627,24 @@ def test_wrong_props():
         assert value_str.endswith("but no 'specifier-space' was provided.")
 
 
-def verify_error(dts, dts_file, expected_err):
+def verify_error(dts, dts_file, expected_err, bindings_dirs=None):
     # Verifies that parsing a file 'dts_file' with the contents 'dts'
     # (a string) raises an EDTError with the message 'expected_err'.
     #
     # The path 'dts_file' is written with the string 'dts' before the
     # test is run.
+    #
+    # You can optionally specify a list of directories containing bindings
+    # to use in 'bindings_dirs'.
 
     with open(dts_file, "w", encoding="utf-8") as f:
         f.write(dts)
         f.flush()  # Can't have unbuffered text IO, so flush() instead
 
+    if bindings_dirs is None:
+        bindings_dirs = []
+
     with pytest.raises(edtlib.EDTError) as e:
-        edtlib.EDT(dts_file, [])
+        edtlib.EDT(dts_file, bindings_dirs)
 
     assert str(e.value) == expected_err

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -78,6 +78,25 @@ def test_interrupts():
     assert str(edt.get_node("/interrupt-map-bitops-test/node@70000000E").interrupts) == \
         f"[<ControllerAndData, controller: <Node /interrupt-map-bitops-test/controller in 'test.dts', binding {filenames[2]}>, data: {{'one': 3, 'two': 2}}>]"
 
+def test_interrupt_source(tmp_path):
+    '''Tests for the 'interrupt-source' feature in bindings.'''
+
+    dts_file = tmp_path / "error.dts"
+
+    with from_here():
+        verify_error("""
+/dts-v1/;
+
+/ {
+        foo {
+                compatible = "interrupt-source";
+        };
+};
+""",
+                     dts_file,
+                     f"Node '/foo' is marked as an interrupt source, but it has neither 'interrupts' nor 'interrupts-extended' properties set",
+                     ["test-bindings"])
+
 def test_ranges():
     '''Tests for the ranges property'''
     with from_here():


### PR DESCRIPTION
--------------------------------------------------------------------------------------

Note: this is prep work for system devicetree ( https://github.com/zephyrproject-rtos/zephyr/issues/51830 ) which is standalone and I believe is mergeable now.

We want to be able to re-use the same binding for the same peripheral IP blocks regardless of whether they appear in a single- or multi-core SoC. Switching to `interrupt-source` in Nordic bindings enables this.

--------------------------------------------------------------------------------------

Zephyr devicetree bindings support either the 'interrupts' or the
'interrupts-extended' method of specifying interrupts. These
properties are standard and defined in the Devicetree Specification.

The 'interrupts' property can be treated as a special case of the
'interrupts-extended' property; you can always write something like
this:

```
  node {
          interrupt-parent = <&parent>;
          interrupts = <1>;
  };
```

as this instead:

```
  node {
          interrupts-extended = <&parent 1>;
  };
```

The 'interrupts-extended' property, however, can be used when the node
in question is hooked up to more than one interrupt controller, and
can contain multiple elements, one per interrupt domain that the node
generates interrupts in.

Therefore, it is sensible semantically to allow an
interrupt-generating devicetree node to use either
'interrupts-extended' or 'interrupts' to specify its generated
interrupts, at the option of the devicetree author, and we can almost
do that today.

The missing piece is that we can't require in the binding that either
'interrupts' or 'interrupts-extended' is set: we can only require
individual properties; we can't say "at least one of these is
required".

You could write some BUILD_ASSERT()s to do this in the driver, but it
would be nicer to have this in the binding so the error messages are
easier to read. The extra effort seems worth it since this is a
special case where the properties are core to the specification
itself.

To enable this, add a top-level 'interrupt-source:' key to the
bindings syntax which, if true, indicates that one of 'interrupts' or
'interrupts-extended' must be set:

```
compatible: foo
interrupt-source: true
[...]
```

