### PR TITLE
xtensa: fix inline assembly of rsil in exception code for XCC

### DIFF
--- a/arch/xtensa/core/xtensa-asm2.c
+++ b/arch/xtensa/core/xtensa-asm2.c
@@ -302,8 +302,8 @@ void *xtensa_excint1_c(int *interrupted_stack)
 		 *    resulting it being zero before switching to another
 		 *    thread.
 		 */
-		__asm__ volatile("rsil %0, " STRINGIFY(XCHAL_NMILEVEL)
-				: "=r" (ignore) : : );
+		__asm__ volatile("rsil %0, %1"
+				: "=r" (ignore) : "i"(XCHAL_NMILEVEL));
 
 		_current_cpu->nested = 1;
 	}


### PR DESCRIPTION
XCC doesn't like the syntax using STRINGIFY. So parameterize the second argument to rsil.