### PR TITLE
twister: logical revert of d8126be55774 to test CI

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -279,7 +279,7 @@ class TestInstance:
         fns = glob.glob(os.path.join(build_dir, "zephyr", "*.elf"))
         fns.extend(glob.glob(os.path.join(build_dir, "zephyr", "*.exe")))
         blocklist = [
-                'remapped', # used for xtensa plaforms
+#                'remapped', # used for xtensa plaforms
                 'zefi', # EFI for Zephyr
                 '_pre' ]
         fns = [x for x in fns if not any(bad in os.path.split(x)[-1] for bad in blocklist)]


### PR DESCRIPTION
Make sure CI catches twister failures.

EDIT: as expected, green failure in `twister (1)` https://github.com/zephyrproject-rtos/zephyr/actions/runs/4683540970/jobs/8298739953