### PR TITLE
init/device: add missing __noasan

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -14,6 +14,7 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/sys/device_mmio.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -912,7 +913,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  */
 #define Z_DEVICE_INIT_ENTRY_DEFINE(dev_id, init_fn_, level, prio)              \
 	static const Z_DECL_ALIGN(struct init_entry)                           \
-		Z_INIT_ENTRY_SECTION(level, prio) __used                       \
+		Z_INIT_ENTRY_SECTION(level, prio) __used __noasan              \
 		Z_INIT_ENTRY_NAME(DEVICE_NAME_GET(dev_id)) = {                 \
 			.init_fn = {.dev = (init_fn_)},                        \
 			.dev = &DEVICE_NAME_GET(dev_id),                       \

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -151,7 +151,7 @@ struct init_entry {
  */
 #define SYS_INIT_NAMED(name, init_fn_, level, prio)                            \
 	static const Z_DECL_ALIGN(struct init_entry)                           \
-		Z_INIT_ENTRY_SECTION(level, prio) __used                       \
+		Z_INIT_ENTRY_SECTION(level, prio) __used __noasan              \
 		Z_INIT_ENTRY_NAME(name) = {                                    \
 			.init_fn = {.sys = (init_fn_)},                        \
 	}


### PR DESCRIPTION
__noasan attribute was accidentally removed by
a5fd0d184a15d0af52599e0f5f5af880f353c6d4. Add it back as it is causing some address sanitizer issues when using the LLVM toolchain.

Details on why this is needed can be found in
74cc5347587624ded3ad9c2cc5266909e864cad9.