### PR TITLE
soc_inf: Refactor native tasks into own header

### DIFF
--- a/boards/posix/native_posix/timer_model.c
+++ b/boards/posix/native_posix/timer_model.c
@@ -29,7 +29,7 @@
 #include <zephyr/arch/posix/posix_trace.h>
 #include <zephyr/sys/util.h>
 #include "cmdline.h"
-#include "soc.h"
+#include "posix_native_task.h"
 
 #define DEBUG_NP_TIMER 0
 

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -21,7 +21,7 @@
 #include <zephyr/kernel.h>
 
 #include "cmdline.h" /* native_posix command line options header */
-#include "soc.h"
+#include "posix_native_task.h"
 
 /*
  * UART driver for POSIX ARCH based boards.

--- a/soc/posix/inf_clock/posix_native_task.h
+++ b/soc/posix/inf_clock/posix_native_task.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017 Oticon A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _POSIX_SOC_INF_CLOCK_POSIX_NATIVE_TASK_H
+#define _POSIX_SOC_INF_CLOCK_POSIX_NATIVE_TASK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * NATIVE_TASK
+ *
+ * For native_posix, register a function to be called at particular moments
+ * during the native_posix execution.
+ *
+ * There is 5 choices for when the function will be called (level):
+ * * PRE_BOOT_1: Will be called before the command line parameters are parsed,
+ *   or the HW models are initialized
+ *
+ * * PRE_BOOT_2: Will be called after the command line parameters are parsed,
+ *   but before the HW models are initialized
+ *
+ * * PRE_BOOT_3: Will be called after the HW models initialization, right before
+ *   the "CPU is booted" and Zephyr is started.
+ *
+ * * FIRST_SLEEP: Will be called the 1st time the CPU is sent to sleep
+ *
+ * * ON_EXIT: Will be called during termination of the native application
+ * execution.
+ *
+ * The function must take no parameters and return nothing.
+ * Note that for the PRE and ON_EXIT levels neither the Zephyr kernel or
+ * any Zephyr thread are running.
+ */
+#define NATIVE_TASK(fn, level, prio)	\
+	static void (* const _CONCAT(__native_task_, fn))() __used __noasan \
+	__attribute__((__section__(".native_" #level STRINGIFY(prio) "_task")))\
+	= fn
+
+
+#define _NATIVE_PRE_BOOT_1_LEVEL	0
+#define _NATIVE_PRE_BOOT_2_LEVEL	1
+#define _NATIVE_PRE_BOOT_3_LEVEL	2
+#define _NATIVE_FIRST_SLEEP_LEVEL	3
+#define _NATIVE_ON_EXIT_LEVEL		4
+
+/**
+ * @brief Run the set of special native tasks corresponding to the given level
+ *
+ * @param level One of _NATIVE_*_LEVEL as defined in soc.h
+ */
+void run_native_tasks(int level);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _POSIX_SOC_INF_CLOCK_POSIX_NATIVE_TASK_H */

--- a/soc/posix/inf_clock/soc.h
+++ b/soc/posix/inf_clock/soc.h
@@ -10,56 +10,13 @@
 #include <zephyr/toolchain.h>
 #include "board_soc.h"
 #include "posix_soc.h"
+#include "posix_native_task.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void posix_soc_clean_up(void);
-
-/**
- * NATIVE_TASK
- *
- * For native_posix, register a function to be called at particular moments
- * during the native_posix execution.
- *
- * There is 5 choices for when the function will be called (level):
- * * PRE_BOOT_1: Will be called before the command line parameters are parsed,
- *   or the HW models are initialized
- *
- * * PRE_BOOT_2: Will be called after the command line parameters are parsed,
- *   but before the HW models are initialized
- *
- * * PRE_BOOT_3: Will be called after the HW models initialization, right before
- *   the "CPU is booted" and Zephyr is started.
- *
- * * FIRST_SLEEP: Will be called the 1st time the CPU is sent to sleep
- *
- * * ON_EXIT: Will be called during termination of the native application
- * execution.
- *
- * The function must take no parameters and return nothing.
- * Note that for the PRE and ON_EXIT levels neither the Zephyr kernel or
- * any Zephyr thread are running.
- */
-#define NATIVE_TASK(fn, level, prio)	\
-	static void (* const _CONCAT(__native_task_, fn))() __used __noasan \
-	__attribute__((__section__(".native_" #level STRINGIFY(prio) "_task")))\
-	= fn
-
-
-#define _NATIVE_PRE_BOOT_1_LEVEL	0
-#define _NATIVE_PRE_BOOT_2_LEVEL	1
-#define _NATIVE_PRE_BOOT_3_LEVEL	2
-#define _NATIVE_FIRST_SLEEP_LEVEL	3
-#define _NATIVE_ON_EXIT_LEVEL		4
-
-/**
- * @brief Run the set of special native tasks corresponding to the given level
- *
- * @param level One of _NATIVE_*_LEVEL as defined in soc.h
- */
-void run_native_tasks(int level);
 
 #ifdef __cplusplus
 }

--- a/tests/bsim/bluetooth/ll/edtt/common/edtt_driver_bsim.c
+++ b/tests/bsim/bluetooth/ll/edtt/common/edtt_driver_bsim.c
@@ -14,7 +14,7 @@
 
 #include "edtt_driver.h"
 #include <zephyr/kernel.h>
-#include "soc.h"
+#include "posix_native_task.h"
 
 #include "bs_tracing.h"
 #include "bs_utils.h"


### PR DESCRIPTION
The native_tasks definition was directly in the soc_inf soc.h header. But soc.h pulls a lot of other headers.
Some of those could cause conflicts, say with application headers, for users who only wanted the be able to register native tasks in a module.

Let's refactor the native tasks definitions into their own header and include that header from soc_inf's soc.h.
In this way users who need only need to register a native tasks can just include posix_native_tasks.h, and all previous users see no change.