### PR TITLE
Add support for STM32F0x0 temperature sensor

### DIFF
--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -40,6 +40,7 @@
 		led0 = &green_led_2;
 		sw0 = &user_button;
 		watchdog0 = &iwdg;
+		die-temp0 = &die_temp;
 	};
 };
 
@@ -105,5 +106,15 @@
 };
 
 &iwdg {
+	status = "okay";
+};
+
+&adc1 {
+	pinctrl-0 = <&adc_in0_pa0>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&die_temp {
 	status = "okay";
 };

--- a/drivers/sensor/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/stm32_temp/stm32_temp.c
@@ -53,8 +53,8 @@ struct stm32_temp_config {
 #else
 	int avgslope;
 	int v25_mv;
-	bool is_ntc;
 #endif
+	bool is_ntc;
 };
 
 static int stm32_temp_sample_fetch(const struct device *dev, enum sensor_channel chan)
@@ -101,6 +101,9 @@ static int stm32_temp_channel_get(const struct device *dev, enum sensor_channel 
 	temp = ((float)data->raw * adc_ref_internal(data->adc)) / cfg->cal_vrefanalog;
 	temp -= (*cfg->cal1_addr >> cfg->ts_cal_shift);
 #if HAS_SINGLE_CALIBRATION
+	if (cfg->is_ntc) {
+		temp = -temp;
+	}
 	temp /= (cfg->avgslope * 4096) / (cfg->cal_vrefanalog * 1000);
 #else
 	temp *= (cfg->cal2_temp - cfg->cal1_temp);
@@ -176,8 +179,8 @@ static const struct stm32_temp_config stm32_temp_dev_config = {
 #else
 	.avgslope = DT_INST_PROP(0, avgslope),
 	.v25_mv = DT_INST_PROP(0, v25),
-	.is_ntc = DT_INST_PROP(0, ntc)
 #endif
+	.is_ntc = DT_INST_PROP_OR(0, ntc, false)
 };
 
 SENSOR_DEVICE_DT_INST_DEFINE(0, stm32_temp_init, NULL,

--- a/dts/arm/st/f0/stm32f030.dtsi
+++ b/dts/arm/st/f0/stm32f030.dtsi
@@ -5,3 +5,15 @@
  */
 
 #include <st/f0/stm32f0.dtsi>
+
+/ {
+	die_temp: dietemp {
+		compatible = "st,stm32c0-temp-cal";
+		ts-cal1-addr = <0x1FFFF7B8>;
+		ts-cal1-temp = <30>;
+		ntc;
+		ts-cal-vrefanalog = <3300>;
+		io-channels = <&adc1 16>;
+		status = "disabled";
+	};
+};

--- a/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
@@ -17,3 +17,7 @@ properties:
       Average slope of T-V chart (in uV/C) according to
       datasheet "Electrical characteristics/Operating conditions"
       STM32C0 Table 5.3.16 (min 2400 uV/C, max 2650, typ: 2530)
+
+  ntc:
+    type: boolean
+    description: Negative Temperature Coefficient. True if STM32F0x0


### PR DESCRIPTION
This PR adds support for the temperature sensor of the STM32F0x0 family. Like STM32C0, it uses single calibration, but with the difference that the temperature coefficient is negative.
Tested on Nucleo F070RB, measured temperature is around 36°C.