### PR TITLE
sysbuild: Fix issue with *_ROOT values not propagating

### DIFF
--- a/cmake/modules/root.cmake
+++ b/cmake/modules/root.cmake
@@ -36,6 +36,13 @@ zephyr_file(APPLICATION_ROOT ARCH_ROOT)
 # Convert paths to absolute, relative from APPLICATION_SOURCE_DIR
 zephyr_file(APPLICATION_ROOT SCA_ROOT)
 
+# Merge in variables from other sources (e.g. sysbuild)
+zephyr_get(MODULE_EXT_ROOT MERGE SYSBUILD GLOBAL)
+zephyr_get(BOARD_ROOT MERGE SYSBUILD GLOBAL)
+zephyr_get(SOC_ROOT MERGE SYSBUILD GLOBAL)
+zephyr_get(ARCH_ROOT MERGE SYSBUILD GLOBAL)
+zephyr_get(SCA_ROOT MERGE SYSBUILD GLOBAL)
+
 if(unittest IN_LIST Zephyr_FIND_COMPONENTS)
   # Zephyr used in unittest mode, use dedicated unittest root.
   set(BOARD_ROOT ${ZEPHYR_BASE}/subsys/testsuite)

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -323,6 +323,15 @@ Build system and infrastructure
   see :ref:`West extending signing <west-extending-signing>` for further
   details.
 
+* Fixed an issue whereby when using ``*_ROOT`` variables with Sysbuild, these
+  were lost for images.
+
+* Enhanced ``zephyr_get`` CMake helper function to optionally support merging
+  of scoped variables into a list.
+
+* Added a new CMake helper function for setting/updating sysbuild CMake cache
+  variables: ``sysbuild_cache_set``.
+
 Drivers and Sensors
 *******************
 


### PR DESCRIPTION
Fixes an issue where variables like BOARD_ROOT would be provided to sysbuild but would then be lost on target images.

Fixes #53780