### PR TITLE
soc/arm/silabs_exx32/common/soc_power: add missing `__weak` symbol

### DIFF
--- a/soc/arm/silabs_exx32/common/soc_power.c
+++ b/soc/arm/silabs_exx32/common/soc_power.c
@@ -134,7 +134,7 @@ static const struct pm_state_info pm_min_residency[] =
 	PM_STATE_INFO_LIST_FROM_DT_CPU(DT_NODELABEL(cpu0));
 struct pm_state_info pm_state_active = {PM_STATE_ACTIVE, 0, 0, 0};
 
-struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
+__weak struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 {
 	int i;
 


### PR DESCRIPTION
This PR adds a missing `__weak` symbol to the `pm_policy_next_state` function.

This is needed for e.g. `tests/kernel/profiling/profiling_api` to build correctly.