### PR TITLE
Bluetooth: CAP: Add missing NULL check for unicast_audio_update

### DIFF
--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1065,6 +1065,18 @@ static bool can_update_metadata(const struct bt_bap_stream *bap_stream)
 int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_update_param params[],
 					  size_t count)
 {
+	CHECKIF(params == NULL) {
+		LOG_DBG("params is NULL");
+
+		return -EINVAL;
+	}
+
+	CHECKIF(count == 0) {
+		LOG_DBG("count is 0");
+
+		return -EINVAL;
+	}
+
 	if (cap_proc_is_active()) {
 		LOG_DBG("A CAP procedure is already in progress");
 


### PR DESCRIPTION
The bt_cap_initiator_unicast_audio_update function was missing NULL and 0 checks for input parameters.