### PR TITLE
Sample: Bluetooth: fix broadcast audio source sink conf file

### DIFF
--- a/samples/bluetooth/broadcast_audio_sink/sample.yaml
+++ b/samples/bluetooth/broadcast_audio_sink/sample.yaml
@@ -15,6 +15,7 @@ tests:
   sample.bluetooth.broadcast_audio_sink.bt_ll_sw_split:
     harness: bluetooth
     platform_allow: >
+      nrf52_bsim
       nrf52833dk_nrf52820
       nrf52833dk_nrf52833
     integration_platforms:

--- a/samples/bluetooth/broadcast_audio_source/sample.yaml
+++ b/samples/bluetooth/broadcast_audio_source/sample.yaml
@@ -15,6 +15,7 @@ tests:
   sample.bluetooth.broadcast_audio_sink.bt_ll_sw_split:
     harness: bluetooth
     platform_allow: >
+      nrf52_bsim
       nrf52833dk_nrf52820
       nrf52833dk_nrf52833
     integration_platforms:


### PR DESCRIPTION
The platform nrf52_bsim was specified as an integration platform, but was missing from the allow list,
causing CI failures
This commit adds this platform to the allow list.

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>
