### PR TITLE
drivers: flash: stm32 ospi: support ospi io ports configuration

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -31,6 +31,11 @@ LOG_MODULE_REGISTER(flash_stm32_ospi, CONFIG_FLASH_LOG_LEVEL);
 
 #define STM32_OSPI_NODE DT_INST_PARENT(0)
 
+#define DT_OSPI_IO_PORT_PROP_OR(prop, default_value)					\
+	COND_CODE_1(DT_NODE_HAS_PROP(STM32_OSPI_NODE, prop),				\
+		    (_CONCAT(HAL_OSPIM_, DT_STRING_TOKEN(STM32_OSPI_NODE, prop))),	\
+		    ((default_value)))
+
 #define STM32_OSPI_RESET_GPIO DT_INST_NODE_HAS_PROP(0, reset_gpios)
 
 #define STM32_OSPI_DLYB_BYPASSED DT_PROP(STM32_OSPI_NODE, dlyb_bypass)
@@ -2069,14 +2074,18 @@ static int flash_stm32_ospi_init(const struct device *dev)
 		ospi_mgr_cfg.ClkPort = 1;
 		ospi_mgr_cfg.DQSPort = 1;
 		ospi_mgr_cfg.NCSPort = 1;
-		ospi_mgr_cfg.IOLowPort = HAL_OSPIM_IOPORT_1_LOW;
-		ospi_mgr_cfg.IOHighPort = HAL_OSPIM_IOPORT_1_HIGH;
+		ospi_mgr_cfg.IOLowPort = DT_OSPI_IO_PORT_PROP_OR(io_low_port,
+								 HAL_OSPIM_IOPORT_1_LOW);
+		ospi_mgr_cfg.IOHighPort = DT_OSPI_IO_PORT_PROP_OR(io_high_port,
+								  HAL_OSPIM_IOPORT_1_HIGH);
 	} else if (dev_data->hospi.Instance == OCTOSPI2) {
 		ospi_mgr_cfg.ClkPort = 2;
 		ospi_mgr_cfg.DQSPort = 2;
 		ospi_mgr_cfg.NCSPort = 2;
-		ospi_mgr_cfg.IOLowPort = HAL_OSPIM_IOPORT_2_LOW;
-		ospi_mgr_cfg.IOHighPort = HAL_OSPIM_IOPORT_2_HIGH;
+		ospi_mgr_cfg.IOLowPort = DT_OSPI_IO_PORT_PROP_OR(io_low_port,
+								 HAL_OSPIM_IOPORT_2_LOW);
+		ospi_mgr_cfg.IOHighPort = DT_OSPI_IO_PORT_PROP_OR(io_high_port,
+								  HAL_OSPIM_IOPORT_2_HIGH);
 	}
 #if defined(OCTOSPIM_CR_MUXEN)
 	ospi_mgr_cfg.Req2AckTime = 1;

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -29,11 +29,13 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(flash_stm32_ospi, CONFIG_FLASH_LOG_LEVEL);
 
+#define STM32_OSPI_NODE DT_INST_PARENT(0)
+
 #define STM32_OSPI_RESET_GPIO DT_INST_NODE_HAS_PROP(0, reset_gpios)
 
-#define STM32_OSPI_DLYB_BYPASSED DT_PROP(DT_PARENT(DT_DRV_INST(0)), dlyb_bypass)
+#define STM32_OSPI_DLYB_BYPASSED DT_PROP(STM32_OSPI_NODE, dlyb_bypass)
 
-#define STM32_OSPI_USE_DMA DT_NODE_HAS_PROP(DT_PARENT(DT_DRV_INST(0)), dmas)
+#define STM32_OSPI_USE_DMA DT_NODE_HAS_PROP(STM32_OSPI_NODE, dmas)
 
 #if STM32_OSPI_USE_DMA
 #include <zephyr/drivers/dma/dma_stm32.h>
@@ -117,8 +119,6 @@ struct stream {
 #endif /* STM32_OSPI_USE_DMA */
 
 typedef void (*irq_config_func_t)(const struct device *dev);
-
-#define STM32_OSPI_NODE DT_INST_PARENT(0)
 
 struct flash_stm32_ospi_config {
 	OCTOSPI_TypeDef *regs;

--- a/dts/bindings/ospi/st,stm32-ospi.yaml
+++ b/dts/bindings/ospi/st,stm32-ospi.yaml
@@ -81,3 +81,41 @@ properties:
       Enables Sample Shifting half-cycle.
 
       It is recommended to be enabled in STR mode and disabled in DTR mode.
+
+  io-low-port:
+    type: string
+    enum:
+      - "IOPORT_NONE"
+      - "IOPORT_1_LOW"
+      - "IOPORT_1_HIGH"
+      - "IOPORT_2_LOW"
+      - "IOPORT_2_HIGH"
+    description: |
+      Specifies which port of the OCTOSPI IO Manager is used for the IO[3:0] pins.
+
+      If absent, then `IOPORT_<n>_LOW` is used where `n` is the OSPI
+      instance number.
+
+      Note: You might need to enable the OCTOSPI I/O manager clock to use the
+            property. Please refer to Reference Manual.
+            The clock can be enabled in the devicetree.
+
+  io-high-port:
+    type: string
+    enum:
+      - "IOPORT_NONE"
+      - "IOPORT_1_LOW"
+      - "IOPORT_1_HIGH"
+      - "IOPORT_2_LOW"
+      - "IOPORT_2_HIGH"
+    description: |
+      Specifies which port of the OCTOSPI IO Manager is used for the IO[7:4] pins.
+
+      If absent, then `IOPORT_<n>_HIGH` is used where `n` is the OSPI
+      instance number.
+
+      Can be set to `IOPORT_NONE` for Single SPI, Dual SPI and Quad SPI.
+
+      Note: You might need to enable the OCTOSPI I/O manager clock to use the
+            property. Please refer to Reference Manual.
+            The clock can be enabled in the devicetree.


### PR DESCRIPTION
Allows to configure used OCTOSPI IO ports for the OSPI via devicetree.

Original values were hardcoded for OCTO mode with `IOLowPort=HAL_OSPIM_IOPORT_<n>_LOW` and
`IOHighPort=HAL_OSPIM_IOPORT_<n>_HIGH` where `<n>` is the OSPI instance. That prevented such configurations
like QUAD mode where `IOLowPort` is required to be `HAL_OSPIM_IOPORT_<n>_HIGH` (_HW layout_) and `IOHighPort` can be disabled.

Usage of OSPIM that deviates from default values requires an extra clock to be enabled.
This PR doesn't enable the required clock.

That can be done by overwriting OSPI clocks in board's devicetree.
For H723/733, H725/735 and H730 the following shall be added to OSPI `clocks`:
> <&rcc STM32_CLOCK_BUS_AHB3 0x00200000>;

Alternative is to add new clock into related `dtsi` files:
```
clock-names = "ospix", "ospi-ker", "ospi-mgr";
clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00004000>,
         <&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>,
         <&rcc STM32_CLOCK_BUS_AHB3 0x00200000>;
```
then enable the clock in the init of the OSPI driver:
```
#define STM32_OSPIM_DEVIATES (DT_NODE_HAS_PROP(DT_OSPI_NODE(0), io_low_port)      \
                              || DT_NODE_HAS_PROP(DT_OSPI_NODE(0), io_high_port))
...
#if defined(OCTOSPIM) && STM32_OSPIM_DEVIATES
#if DT_CLOCKS_HAS_NAME(STM32_OSPI_NODE, ospi_mgr)
	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
			     (clock_control_subsys_t) &dev_cfg->pclken_mgr) != 0) {
		LOG_ERR("Could not enable OSPI Manager clock");
		return -EIO;
	}
#endif
#endif /* OCTOSPIM */
```

However, that clock is required only if OSPIM configuration deviates from default.
Is it worth enabling it for all devices that support OSPIM or shall it be left to the enduser?