### PR TITLE
twister: skip determine_testcases for unit test

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -671,6 +671,9 @@ class ProjectBuilder(FilterBuilder):
         yaml_testsuite_name = self.instance.testsuite.id
         logger.debug(f"Determine test cases for test suite: {yaml_testsuite_name}")
 
+        if self.instance.testsuite.type == "unit":
+            return
+
         elf = ELFFile(open(self.instance.get_elf_file(), "rb"))
 
         logger.debug(f"Test instance {self.instance.name} already has {len(self.instance.testcases)} cases.")


### PR DESCRIPTION
determine_testcases doesn't make sense for unit tests and will fail when it tries to call get_elf_file() as there will not be anything there.  So just return early if we are a unit test.