### PR TITLE
tests: zexpect: Remove CONFIG_LIB_CPLUSPLUS

### DIFF
--- a/tests/ztest/zexpect/testcase.yaml
+++ b/tests/ztest/zexpect/testcase.yaml
@@ -11,7 +11,6 @@ tests:
   testing.ztest.expect_cpp:
     extra_configs:
       - CONFIG_CPLUSPLUS=y
-      - CONFIG_LIB_CPLUSPLUS=y
     integration_platforms:
       - native_posix
   testing.ztest.expect.unit:


### PR DESCRIPTION
Its not needed for this to build and run.  Additionally we've deprecated the CONFIG_LIB_CPLUSPLUS symbol.