### PR TITLE
Bluetooth: Audio: Encrypted BISes cause MPU FAULT

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -41,7 +41,7 @@ config BT_HCI_TX_STACK_SIZE
 	default 512 if BT_H4
 	default 512 if BT_H5
 	default 416 if BT_SPI
-	default 940 if BT_CTLR && BT_LL_SW_SPLIT && NO_OPTIMIZATIONS
+	default 940 if BT_CTLR && BT_LL_SW_SPLIT && (NO_OPTIMIZATIONS || BT_ISO_BROADCAST)
 	default 1024 if BT_CTLR && BT_LL_SW_SPLIT && BT_CENTRAL
 	default 768 if BT_CTLR && BT_LL_SW_SPLIT
 	default 512 if BT_USERCHAN


### PR DESCRIPTION
When enabling BIS encryption by setting create_param.encryption to true, a MPU fault will occur due to an insufficient TX stack size.

Fixes: [#56808](https://github.com/zephyrproject-rtos/zephyr/issues/56808)

Signed-off-by: Theo Gasteiger <gatcode@wdw.one>