### PR TITLE
drivers: lpadc: Make DT props match Reference manual and hardware instead of SDK enum identifiers

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -333,6 +333,10 @@ Drivers and Sensors
    ``zephyr,input-negative`` devicetree properties to select the hardware
    channel(s) to link a software channel configuration to.
 
+ * MCUX LPADC driver ``voltage-ref`` and ``power-level`` devicetree properties
+   were shifted to match the hardware as described in reference manual instead
+   of matching the NXP SDK enum identifers.
+
 * Battery-backed RAM
 
   * Added MCP7940N battery-backed RTC SRAM driver.

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -272,9 +272,9 @@
 		status = "disabled";
 		clk-divider = <8>;
 		clk-source = <0>;
-		voltage-ref= <2>;
+		voltage-ref= <1>;
 		calibration-average = <128>;
-		power-level = <1>;
+		power-level = <0>;
 		offset-value-a = <10>;
 		offset-value-b = <10>;
 		#io-channel-cells = <1>;

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -246,9 +246,9 @@
 		status = "disabled";
 		clk-divider = <8>;
 		clk-source = <0>;
-		voltage-ref= <2>;
+		voltage-ref= <1>;
 		calibration-average = <128>;
-		power-level = <1>;
+		power-level = <0>;
 		offset-value-a = <10>;
 		offset-value-b = <10>;
 		#io-channel-cells = <1>;

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -306,9 +306,9 @@
 		status = "disabled";
 		clk-divider = <8>;
 		clk-source = <0>;
-		voltage-ref= <2>;
+		voltage-ref= <1>;
 		calibration-average = <128>;
-		power-level = <1>;
+		power-level = <0>;
 		offset-value-a = <10>;
 		offset-value-b = <10>;
 		#io-channel-cells = <1>;

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -868,9 +868,9 @@
 			status = "disabled";
 			clk-divider = <8>;
 			clk-source = <0>;
-			voltage-ref= <2>;
+			voltage-ref= <1>;
 			calibration-average = <128>;
-			power-level = <1>;
+			power-level = <0>;
 			offset-value-a = <10>;
 			offset-value-b = <10>;
 			#io-channel-cells = <1>;
@@ -883,7 +883,7 @@
 			status = "disabled";
 			clk-divider = <8>;
 			clk-source = <0>;
-			voltage-ref= <2>;
+			voltage-ref= <1>;
 			calibration-average = <128>;
 			power-level = <1>;
 			offset-value-a = <10>;

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -415,9 +415,9 @@
 		status = "disabled";
 		clk-divider = <1>;
 		clk-source = <0>;
-		voltage-ref= <2>;
+		voltage-ref= <1>;
 		calibration-average = <128>;
-		power-level = <1>;
+		power-level = <0>;
 		offset-value-a = <10>;
 		offset-value-b = <10>;
 		#io-channel-cells = <1>;

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -347,9 +347,9 @@
 		status = "disabled";
 		clk-divider = <1>;
 		clk-source = <0>;
-		voltage-ref= <2>;
+		voltage-ref= <1>;
 		calibration-average = <128>;
-		power-level = <1>;
+		power-level = <0>;
 		offset-value-a = <10>;
 		offset-value-b = <10>;
 		#io-channel-cells = <1>;

--- a/dts/bindings/adc/nxp,lpc-lpadc.yaml
+++ b/dts/bindings/adc/nxp,lpc-lpadc.yaml
@@ -27,17 +27,39 @@ properties:
   voltage-ref:
     type: int
     required: true
-    description: reference voltage source
+    description: |
+      Voltage reference selection. Corresponds to value of
+      register field CFG[REFSEL] (see chip specific manual).
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
 
   calibration-average:
     type: int
-    required: true
     description: conversion average number for auto-calibration
+    enum:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+      - 64
+      - 128
 
   power-level:
     type: int
     required: true
-    description: power level for the ADC
+    description: |
+      Power level selection. Corresponds to the value of
+      register field CFG[PWRSEL] (see chip specific manual).
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
 
   offset-value-a:
     type: int


### PR DESCRIPTION
Change the DT property value meanings for the LPADC power level and voltage reference to match what is documented for the hardware in the SOC reference manual, instead of corresponding to NXP SDK enum names.

Remove all of the build asserts in favor of devicetree enums