### PR TITLE
init: set init_entry.dev to NULL

### DIFF
--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -154,6 +154,7 @@ struct init_entry {
 		Z_INIT_ENTRY_SECTION(level, prio) __used __noasan              \
 		Z_INIT_ENTRY_NAME(name) = {                                    \
 			.init_fn = {.sys = (init_fn_)},                        \
+			.dev = NULL,                                           \
 	}
 
 /** @} */


### PR DESCRIPTION
[PR#51217](https://github.com/zephyrproject-rtos/zephyr/pull/51217) changed the `init_entry` structure, but `Z_INIT_ENTRY_NAME` (called by `SYS_INIT` or `SYS_INIT_NAMED`) does not initialize all of the members of the struct, leading to errors when building with `-Werror=missing-field-initializers`.

Change the macro to initialize the `dev` member to `NULL` so that all members of the struct are initialized.