### PR TITLE
shell: fix MISRA 5.7/21.2 violations

### DIFF
--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -163,7 +163,7 @@ Abstract code for this task would look like this:
 
 .. code-block:: c
 
-	static int gain_cmd_handler(const struct shell *shell,
+	static int gain_cmd_handler(const struct shell *sh,
 				    size_t argc, char **argv, void *data)
 	{
 		int gain;
@@ -172,7 +172,7 @@ Abstract code for this task would look like this:
 		gain = (int)data;
 		adc_set_gain(gain);
 
-		shell_print(shell, "ADC gain set to: %s\n"
+		shell_print(sh, "ADC gain set to: %s\n"
 				   "Value send to ADC driver: %d",
 				   argv[0],
 				   gain);
@@ -332,7 +332,7 @@ Simple command handler implementation:
 
 .. code-block:: c
 
-	static int cmd_handler(const struct shell *shell, size_t argc,
+	static int cmd_handler(const struct shell *sh, size_t argc,
 				char **argv)
 	{
 		ARG_UNUSED(argc);
@@ -340,11 +340,11 @@ Simple command handler implementation:
 
 		shell_fprintf(shell, SHELL_INFO, "Print info message\n");
 
-		shell_print(shell, "Print simple text.");
+		shell_print(sh, "Print simple text.");
 
-		shell_warn(shell, "Print warning text.");
+		shell_warn(sh, "Print warning text.");
 
-		shell_error(shell, "Print error text.");
+		shell_error(sh, "Print error text.");
 
 		return 0;
 	}
@@ -379,7 +379,7 @@ commands or the parent commands, depending on how you index ``argv``.
 
 .. code-block:: c
 
-	static int cmd_handler(const struct shell *shell, size_t argc,
+	static int cmd_handler(const struct shell *sh, size_t argc,
 			       char **argv)
 	{
 		ARG_UNUSED(argc);
@@ -387,14 +387,14 @@ commands or the parent commands, depending on how you index ``argv``.
 		/* If it is a subcommand handler parent command syntax
 		 * can be found using argv[-1].
 		 */
-		shell_print(shell, "This command has a parent command: %s",
+		shell_print(sh, "This command has a parent command: %s",
 			      argv[-1]);
 
 		/* Print this command syntax */
-		shell_print(shell, "This command syntax is: %s", argv[0]);
+		shell_print(sh, "This command syntax is: %s", argv[0]);
 
 		/* Print first argument */
-		shell_print(shell, "%s", argv[1]);
+		shell_print(sh, "%s", argv[1]);
 
 		return 0;
 	}
@@ -665,24 +665,24 @@ The following code shows a simple use case of this library:
 
 	}
 
-	static int cmd_demo_ping(const struct shell *shell, size_t argc,
+	static int cmd_demo_ping(const struct shell *sh, size_t argc,
 				 char **argv)
 	{
 		ARG_UNUSED(argc);
 		ARG_UNUSED(argv);
 
-		shell_print(shell, "pong");
+		shell_print(sh, "pong");
 		return 0;
 	}
 
-	static int cmd_demo_params(const struct shell *shell, size_t argc,
+	static int cmd_demo_params(const struct shell *sh, size_t argc,
 				   char **argv)
 	{
 		int cnt;
 
-		shell_print(shell, "argc = %d", argc);
+		shell_print(sh, "argc = %d", argc);
 		for (cnt = 0; cnt < argc; cnt++) {
-			shell_print(shell, "  argv[%d] = %s", cnt, argv[cnt]);
+			shell_print(sh, "  argv[%d] = %s", cnt, argv[cnt]);
 		}
 		return 0;
 	}

--- a/drivers/adc/adc_shell.c
+++ b/drivers/adc/adc_shell.c
@@ -124,19 +124,19 @@ static struct adc_hdl *get_adc(const char *device_label)
 	return NULL;
 }
 
-static int cmd_adc_ch_id(const struct shell *shell, size_t argc, char **argv)
+static int cmd_adc_ch_id(const struct shell *sh, size_t argc, char **argv)
 {
 	/* -2: index of ADC label name */
 	struct adc_hdl *adc = get_adc(argv[-2]);
 	int retval = 0;
 
 	if (!device_is_ready(adc->dev)) {
-		shell_error(shell, "ADC device not ready");
+		shell_error(sh, "ADC device not ready");
 		return -ENODEV;
 	}
 
 	if (isdigit((unsigned char)argv[1][0]) == 0) {
-		shell_error(shell, "<channel> must be digits");
+		shell_error(sh, "<channel> must be digits");
 		return -EINVAL;
 	}
 
@@ -147,7 +147,7 @@ static int cmd_adc_ch_id(const struct shell *shell, size_t argc, char **argv)
 	return retval;
 }
 
-static int cmd_adc_ch_neg(const struct shell *shell, size_t argc, char **argv)
+static int cmd_adc_ch_neg(const struct shell *sh, size_t argc, char **argv)
 {
 #if CONFIG_ADC_CONFIGURABLE_INPUTS
 	/* -2: index of ADC label name */
@@ -155,12 +155,12 @@ static int cmd_adc_ch_neg(const struct shell *shell, size_t argc, char **argv)
 	int retval = 0;
 
 	if (!device_is_ready(adc->dev)) {
-		shell_error(shell, "ADC device not ready");
+		shell_error(sh, "ADC device not ready");
 		return -ENODEV;
 	}
 
 	if (isdigit((unsigned char)argv[1][0]) == 0) {
-		shell_error(shell, "<negative input> must be digits");
+		shell_error(sh, "<negative input> must be digits");
 		return -EINVAL;
 	}
 
@@ -174,7 +174,7 @@ static int cmd_adc_ch_neg(const struct shell *shell, size_t argc, char **argv)
 #endif
 }
 
-static int cmd_adc_ch_pos(const struct shell *shell, size_t argc, char **argv)
+static int cmd_adc_ch_pos(const struct shell *sh, size_t argc, char **argv)
 {
 #if CONFIG_ADC_CONFIGURABLE_INPUTS
 	/* -2: index of ADC label name */
@@ -182,12 +182,12 @@ static int cmd_adc_ch_pos(const struct shell *shell, size_t argc, char **argv)
 	int retval = 0;
 
 	if (!device_is_ready(adc->dev)) {
-		shell_error(shell, "ADC device not ready");
+		shell_error(sh, "ADC device not ready");
 		return -ENODEV;
 	}
 
 	if (isdigit((unsigned char)argv[1][0]) == 0) {
-		shell_error(shell, "<positive input> must be digits");
+		shell_error(sh, "<positive input> must be digits");
 		return -EINVAL;
 	}
 
@@ -201,7 +201,7 @@ static int cmd_adc_ch_pos(const struct shell *shell, size_t argc, char **argv)
 #endif
 }
 
-static int cmd_adc_gain(const struct shell *shell, size_t argc, char **argv,
+static int cmd_adc_gain(const struct shell *sh, size_t argc, char **argv,
 			void *data)
 {
 	/* -2: index of ADC label name */
@@ -210,7 +210,7 @@ static int cmd_adc_gain(const struct shell *shell, size_t argc, char **argv,
 	int retval = -EINVAL;
 
 	if (!device_is_ready(adc->dev)) {
-		shell_error(shell, "ADC device not ready");
+		shell_error(sh, "ADC device not ready");
 		return -ENODEV;
 	}
 
@@ -225,7 +225,7 @@ static int cmd_adc_gain(const struct shell *shell, size_t argc, char **argv,
 	return retval;
 }
 
-static int cmd_adc_acq(const struct shell *shell, size_t argc, char **argv)
+static int cmd_adc_acq(const struct shell *sh, size_t argc, char **argv)
 {
 	/* -1 index of ADC label name */
 	struct adc_hdl *adc = get_adc(argv[-1]);
@@ -233,12 +233,12 @@ static int cmd_adc_acq(const struct shell *shell, size_t argc, char **argv)
 	int retval;
 
 	if (!device_is_ready(adc->dev)) {
-		shell_error(shell, "ADC device not ready");
+		shell_error(sh, "ADC device not ready");
 		return -ENODEV;
 	}
 
 	if (isdigit((unsigned char)argv[1][0]) == 0) {
-		shell_error(shell, "<time> must be digits");
+		shell_error(sh, "<time> must be digits");
 		return -EINVAL;
 	}
 
@@ -261,19 +261,19 @@ static int cmd_adc_acq(const struct shell *shell, size_t argc, char **argv)
 
 	return retval;
 }
-static int cmd_adc_reso(const struct shell *shell, size_t argc, char **argv)
+static int cmd_adc_reso(const struct shell *sh, size_t argc, char **argv)
 {
 	/* -1 index of ADC label name */
 	struct adc_hdl *adc = get_adc(argv[-1]);
 	int retval;
 
 	if (!device_is_ready(adc->dev)) {
-		shell_error(shell, "ADC device not ready");
+		shell_error(sh, "ADC device not ready");
 		return -ENODEV;
 	}
 
 	if (isdigit((unsigned char)argv[1][0]) == 0) {
-		shell_error(shell, "<resolution> must be digits");
+		shell_error(sh, "<resolution> must be digits");
 		return -EINVAL;
 	}
 
@@ -283,7 +283,7 @@ static int cmd_adc_reso(const struct shell *shell, size_t argc, char **argv)
 	return retval;
 }
 
-static int cmd_adc_ref(const struct shell *shell, size_t argc, char **argv,
+static int cmd_adc_ref(const struct shell *sh, size_t argc, char **argv,
 		       void *data)
 {
 	/* -2 index of ADC label name */
@@ -292,7 +292,7 @@ static int cmd_adc_ref(const struct shell *shell, size_t argc, char **argv,
 	int retval = -EINVAL;
 
 	if (!device_is_ready(adc->dev)) {
-		shell_error(shell, "ADC device not ready");
+		shell_error(sh, "ADC device not ready");
 		return -ENODEV;
 	}
 
@@ -309,7 +309,7 @@ static int cmd_adc_ref(const struct shell *shell, size_t argc, char **argv,
 }
 
 #define BUFFER_SIZE 1
-static int cmd_adc_read(const struct shell *shell, size_t argc, char **argv)
+static int cmd_adc_read(const struct shell *sh, size_t argc, char **argv)
 {
 	uint8_t adc_channel_id = strtol(argv[1], NULL, 10);
 	/* -1 index of adc label name */
@@ -318,7 +318,7 @@ static int cmd_adc_read(const struct shell *shell, size_t argc, char **argv)
 	int retval;
 
 	if (!device_is_ready(adc->dev)) {
-		shell_error(shell, "ADC device not ready");
+		shell_error(sh, "ADC device not ready");
 		return -ENODEV;
 	}
 
@@ -332,18 +332,18 @@ static int cmd_adc_read(const struct shell *shell, size_t argc, char **argv)
 
 	retval = adc_read(adc->dev, &sequence);
 	if (retval >= 0) {
-		shell_print(shell, "read: %i", m_sample_buffer[0]);
+		shell_print(sh, "read: %i", m_sample_buffer[0]);
 	}
 
 	return retval;
 }
 
-static int cmd_adc_print(const struct shell *shell, size_t argc, char **argv)
+static int cmd_adc_print(const struct shell *sh, size_t argc, char **argv)
 {
 	/* -1 index of ADC label name */
 	struct adc_hdl *adc = get_adc(argv[-1]);
 
-	shell_print(shell, "%s:\n"
+	shell_print(sh, "%s:\n"
 			   "Gain: %s\n"
 			   "Reference: %s\n"
 			   "Acquisition Time: %u\n"

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -735,7 +735,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(clock), clk_init, NULL,
 		 PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
 		 &clock_control_api);
 
-static int cmd_status(const struct shell *shell, size_t argc, char **argv)
+static int cmd_status(const struct shell *sh, size_t argc, char **argv)
 {
 	nrf_clock_hfclk_t hfclk_src;
 	bool hf_status;
@@ -757,15 +757,15 @@ static int cmd_status(const struct shell *shell, size_t argc, char **argv)
 	abs_stop = hf_stop_tstamp;
 	irq_unlock(key);
 
-	shell_print(shell, "HF clock:");
-	shell_print(shell, "\t- %srunning (users: %u)",
+	shell_print(sh, "HF clock:");
+	shell_print(sh, "\t- %srunning (users: %u)",
 			hf_status ? "" : "not ", hf_mgr->refs);
-	shell_print(shell, "\t- last start: %u ms (%u ms ago)",
+	shell_print(sh, "\t- last start: %u ms (%u ms ago)",
 			(uint32_t)abs_start, (uint32_t)(now - abs_start));
-	shell_print(shell, "\t- last stop: %u ms (%u ms ago)",
+	shell_print(sh, "\t- last stop: %u ms (%u ms ago)",
 			(uint32_t)abs_stop, (uint32_t)(now - abs_stop));
-	shell_print(shell, "LF clock:");
-	shell_print(shell, "\t- %srunning (users: %u)",
+	shell_print(sh, "LF clock:");
+	shell_print(sh, "\t- %srunning (users: %u)",
 			lf_status ? "" : "not ", lf_mgr->refs);
 
 	return 0;

--- a/drivers/dac/dac_shell.c
+++ b/drivers/dac/dac_shell.c
@@ -27,7 +27,7 @@ static const struct args_index args_indx = {
 	.resolution = 3,
 };
 
-static int cmd_setup(const struct shell *shell, size_t argc, char **argv)
+static int cmd_setup(const struct shell *sh, size_t argc, char **argv)
 {
 	struct dac_channel_cfg cfg;
 	const struct device *dac;
@@ -35,7 +35,7 @@ static int cmd_setup(const struct shell *shell, size_t argc, char **argv)
 
 	dac = device_get_binding(argv[args_indx.device]);
 	if (!dac) {
-		shell_error(shell, "DAC device not found");
+		shell_error(sh, "DAC device not found");
 		return -EINVAL;
 	}
 
@@ -44,14 +44,14 @@ static int cmd_setup(const struct shell *shell, size_t argc, char **argv)
 
 	err = dac_channel_setup(dac, &cfg);
 	if (err) {
-		shell_error(shell, "Failed to setup DAC channel (err %d)", err);
+		shell_error(sh, "Failed to setup DAC channel (err %d)", err);
 		return err;
 	}
 
 	return 0;
 }
 
-static int cmd_write_value(const struct shell *shell, size_t argc, char **argv)
+static int cmd_write_value(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dac;
 	uint8_t channel;
@@ -60,7 +60,7 @@ static int cmd_write_value(const struct shell *shell, size_t argc, char **argv)
 
 	dac = device_get_binding(argv[args_indx.device]);
 	if (!dac) {
-		shell_error(shell, "DAC device not found");
+		shell_error(sh, "DAC device not found");
 		return -EINVAL;
 	}
 
@@ -69,7 +69,7 @@ static int cmd_write_value(const struct shell *shell, size_t argc, char **argv)
 
 	err = dac_write_value(dac, channel, value);
 	if (err) {
-		shell_error(shell, "Failed to write DAC value (err %d)", err);
+		shell_error(sh, "Failed to write DAC value (err %d)", err);
 		return err;
 	}
 

--- a/drivers/edac/shell.c
+++ b/drivers/edac/shell.c
@@ -35,23 +35,23 @@
  * devmem [width [value]]       Physical memory read / write
  */
 
-static void decode_ecc_error(const struct shell *shell, uint64_t ecc_error)
+static void decode_ecc_error(const struct shell *sh, uint64_t ecc_error)
 {
 	uint64_t erradd = ECC_ERROR_ERRADD(ecc_error);
 	unsigned long errsynd = ECC_ERROR_ERRSYND(ecc_error);
 
-	shell_fprintf(shell, SHELL_NORMAL,
+	shell_fprintf(sh, SHELL_NORMAL,
 		      "CMI Error address: 0x%llx\n", erradd);
-	shell_fprintf(shell, SHELL_NORMAL,
+	shell_fprintf(sh, SHELL_NORMAL,
 		      "Error Syndrome: 0x%lx\n", errsynd);
 
 	if (ecc_error & ECC_ERROR_MERRSTS) {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Uncorrectable Error (UE)\n");
 	}
 
 	if (ecc_error & ECC_ERROR_CERRSTS) {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Correctable Error (CE)\n");
 	}
 }
@@ -92,30 +92,30 @@ static int parity_error_show(const struct shell *sh, const struct device *dev)
 	return 0;
 }
 
-static int cmd_edac_info(const struct shell *shell, size_t argc, char **argv)
+static int cmd_edac_info(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	int err;
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "IBECC device not ready");
+		shell_error(sh, "IBECC device not ready");
 		return -ENODEV;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "Show EDAC status\n");
+	shell_fprintf(sh, SHELL_NORMAL, "Show EDAC status\n");
 
-	err = ecc_error_show(shell, dev);
+	err = ecc_error_show(sh, dev);
 	if (err != 0) {
 		return err;
 	}
 
-	err = parity_error_show(shell, dev);
+	err = parity_error_show(sh, dev);
 	if (err != 0) {
 		return err;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL,
+	shell_fprintf(sh, SHELL_NORMAL,
 		      "Errors correctable: %d Errors uncorrectable %d\n",
 		      edac_errors_cor_get(dev), edac_errors_uc_get(dev));
 
@@ -123,20 +123,20 @@ static int cmd_edac_info(const struct shell *shell, size_t argc, char **argv)
 }
 
 #if defined(CONFIG_EDAC_ERROR_INJECT)
-static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
+static int cmd_inject_addr(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	int err;
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "IBECC device not ready");
+		shell_error(sh, "IBECC device not ready");
 		return -ENODEV;
 	}
 
 	if (argc > 2) {
 		/* Usage */
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Usage: edac inject %s [addr]\n", argv[0]);
 		return -ENOTSUP;
 	}
@@ -146,22 +146,22 @@ static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
 
 		err = edac_inject_get_param1(dev, &addr);
 		if (err != 0) {
-			shell_error(shell, "Error getting address (err %d)",
+			shell_error(sh, "Error getting address (err %d)",
 				    err);
 			return err;
 		}
 
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Injection address base: 0x%llx\n", addr);
 	} else {
 		unsigned long value = strtoul(argv[1], NULL, 16);
 
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Set injection address base to: %s\n", argv[1]);
 
 		err = edac_inject_set_param1(dev, value);
 		if (err != 0) {
-			shell_error(shell, "Error setting address (err %d)",
+			shell_error(sh, "Error setting address (err %d)",
 				    err);
 			return err;
 		}
@@ -170,20 +170,20 @@ static int cmd_inject_addr(const struct shell *shell, size_t argc, char **argv)
 	return err;
 }
 
-static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
+static int cmd_inject_mask(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	int err;
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "IBECC device not ready");
+		shell_error(sh, "IBECC device not ready");
 		return -ENODEV;
 	}
 
 	if (argc > 2) {
 		/* Usage */
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Usage: edac inject %s [mask]\n", argv[0]);
 		return -ENOTSUP;
 	}
@@ -193,21 +193,21 @@ static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
 
 		err = edac_inject_get_param2(dev, &mask);
 		if (err != 0) {
-			shell_error(shell, "Error getting mask (err %d)", err);
+			shell_error(sh, "Error getting mask (err %d)", err);
 			return err;
 		}
 
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Injection address mask: 0x%llx\n", mask);
 	} else {
 		uint64_t value = strtoul(argv[1], NULL, 16);
 
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Set injection address mask to %llx\n", value);
 
 		err = edac_inject_set_param2(dev, value);
 		if (err != 0) {
-			shell_error(shell, "Error setting mask (err %d)", err);
+			shell_error(sh, "Error setting mask (err %d)", err);
 			return err;
 		}
 	}
@@ -215,25 +215,25 @@ static int cmd_inject_mask(const struct shell *shell, size_t argc, char **argv)
 	return err;
 }
 
-static int cmd_inject_trigger(const struct shell *shell, size_t argc,
+static int cmd_inject_trigger(const struct shell *sh, size_t argc,
 			      char **argv)
 {
 	const struct device *dev;
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "IBECC device not ready");
+		shell_error(sh, "IBECC device not ready");
 		return -ENODEV;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "Triggering injection\n");
+	shell_fprintf(sh, SHELL_NORMAL, "Triggering injection\n");
 
 	edac_inject_error_trigger(dev);
 
 	return 0;
 }
 
-static int cmd_inject_disable_nmi(const struct shell *shell, size_t argc,
+static int cmd_inject_disable_nmi(const struct shell *sh, size_t argc,
 				  char **argv)
 {
 	sys_out8((sys_in8(0x70) | 0x80), 0x70);
@@ -241,7 +241,7 @@ static int cmd_inject_disable_nmi(const struct shell *shell, size_t argc,
 	return 0;
 }
 
-static int cmd_inject_enable_nmi(const struct shell *shell, size_t argc,
+static int cmd_inject_enable_nmi(const struct shell *sh, size_t argc,
 				 char **argv)
 {
 	sys_out8((sys_in8(0x70) & 0x7F), 0x70);
@@ -261,7 +261,7 @@ static const char *get_error_type(uint32_t type)
 	}
 }
 
-static int cmd_inject_error_type_show(const struct shell *shell, size_t argc,
+static int cmd_inject_error_type_show(const struct shell *sh, size_t argc,
 				      char **argv)
 {
 	const struct device *dev;
@@ -270,57 +270,57 @@ static int cmd_inject_error_type_show(const struct shell *shell, size_t argc,
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "IBECC device not ready");
+		shell_error(sh, "IBECC device not ready");
 		return -ENODEV;
 	}
 
 	err = edac_inject_get_error_type(dev, &error_type);
 	if (err != 0) {
-		shell_error(shell, "Error getting error type (err %d)", err);
+		shell_error(sh, "Error getting error type (err %d)", err);
 		return err;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "Injection error type: %s\n",
+	shell_fprintf(sh, SHELL_NORMAL, "Injection error type: %s\n",
 		      get_error_type(error_type));
 
 	return err;
 }
 
-static int set_error_type(const struct shell *shell, uint32_t error_type)
+static int set_error_type(const struct shell *sh, uint32_t error_type)
 {
 	const struct device *dev;
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "IBECC device not ready");
+		shell_error(sh, "IBECC device not ready");
 		return -ENODEV;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "Set injection error type: %s\n",
+	shell_fprintf(sh, SHELL_NORMAL, "Set injection error type: %s\n",
 		      get_error_type(error_type));
 
 	return edac_inject_set_error_type(dev, error_type);
 }
 
-static int cmd_inject_error_type_cor(const struct shell *shell, size_t argc,
+static int cmd_inject_error_type_cor(const struct shell *sh, size_t argc,
 				     char **argv)
 {
-	return set_error_type(shell, EDAC_ERROR_TYPE_DRAM_COR);
+	return set_error_type(sh, EDAC_ERROR_TYPE_DRAM_COR);
 }
 
-static int cmd_inject_error_type_uc(const struct shell *shell, size_t argc,
+static int cmd_inject_error_type_uc(const struct shell *sh, size_t argc,
 				    char **argv)
 {
-	return set_error_type(shell, EDAC_ERROR_TYPE_DRAM_UC);
+	return set_error_type(sh, EDAC_ERROR_TYPE_DRAM_UC);
 }
 
-static int cmd_inject_test(const struct shell *shell, size_t argc, char **argv)
+static int cmd_inject_test(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "IBECC device not ready");
+		shell_error(sh, "IBECC device not ready");
 		return -ENODEV;
 	}
 
@@ -357,21 +357,21 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_inject_cmds,
 );
 #endif /* CONFIG_EDAC_ERROR_INJECT */
 
-static int cmd_ecc_error_show(const struct shell *shell, size_t argc,
+static int cmd_ecc_error_show(const struct shell *sh, size_t argc,
 			      char **argv)
 {
 	const struct device *dev;
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "IBECC device not ready");
+		shell_error(sh, "IBECC device not ready");
 		return -ENODEV;
 	}
 
-	return ecc_error_show(shell, dev);
+	return ecc_error_show(sh, dev);
 }
 
-static int cmd_ecc_error_clear(const struct shell *shell, size_t argc,
+static int cmd_ecc_error_clear(const struct shell *sh, size_t argc,
 			       char **argv)
 {
 	const struct device *dev;
@@ -379,18 +379,18 @@ static int cmd_ecc_error_clear(const struct shell *shell, size_t argc,
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "IBECC device not ready");
+		shell_error(sh, "IBECC device not ready");
 		return -ENODEV;
 	}
 
 	err = edac_ecc_error_log_clear(dev);
 	if (err != 0) {
-		shell_error(shell, "Error clear ecc error log (err %d)",
+		shell_error(sh, "Error clear ecc error log (err %d)",
 			    err);
 		return err;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "ECC Error Log cleared\n");
+	shell_fprintf(sh, SHELL_NORMAL, "ECC Error Log cleared\n");
 
 	return 0;
 }
@@ -401,21 +401,21 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_ecc_error_cmds,
 	SHELL_SUBCMD_SET_END /* Array terminated */
 );
 
-static int cmd_parity_error_show(const struct shell *shell, size_t argc,
+static int cmd_parity_error_show(const struct shell *sh, size_t argc,
 				 char **argv)
 {
 	const struct device *dev;
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "IBECC device not ready");
+		shell_error(sh, "IBECC device not ready");
 		return -ENODEV;
 	}
 
-	return parity_error_show(shell, dev);
+	return parity_error_show(sh, dev);
 }
 
-static int cmd_parity_error_clear(const struct shell *shell, size_t argc,
+static int cmd_parity_error_clear(const struct shell *sh, size_t argc,
 				  char **argv)
 {
 	const struct device *dev;
@@ -423,18 +423,18 @@ static int cmd_parity_error_clear(const struct shell *shell, size_t argc,
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "IBECC device not ready");
+		shell_error(sh, "IBECC device not ready");
 		return -ENODEV;
 	}
 
 	err = edac_parity_error_log_clear(dev);
 	if (err != 0) {
-		shell_error(shell, "Error clear parity error log (err %d)",
+		shell_error(sh, "Error clear parity error log (err %d)",
 			    err);
 		return err;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "Parity Error Log cleared\n");
+	shell_fprintf(sh, SHELL_NORMAL, "Parity Error Log cleared\n");
 
 	return 0;
 }

--- a/drivers/eeprom/eeprom_shell.c
+++ b/drivers/eeprom/eeprom_shell.c
@@ -30,7 +30,7 @@ static const struct args_index args_indx = {
 	.pattern = 4,
 };
 
-static int cmd_read(const struct shell *shell, size_t argc, char **argv)
+static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *eeprom;
 	size_t addr;
@@ -44,11 +44,11 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 
 	eeprom = device_get_binding(argv[args_indx.device]);
 	if (!eeprom) {
-		shell_error(shell, "EEPROM device not found");
+		shell_error(sh, "EEPROM device not found");
 		return -EINVAL;
 	}
 
-	shell_print(shell, "Reading %zu bytes from EEPROM, offset %zu...", len,
+	shell_print(sh, "Reading %zu bytes from EEPROM, offset %zu...", len,
 		    addr);
 
 	for (upto = 0; upto < len; upto += pending) {
@@ -57,19 +57,19 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 		pending = MIN(len - upto, SHELL_HEXDUMP_BYTES_IN_LINE);
 		err = eeprom_read(eeprom, addr, data, pending);
 		if (err) {
-			shell_error(shell, "EEPROM read failed (err %d)", err);
+			shell_error(sh, "EEPROM read failed (err %d)", err);
 			return err;
 		}
 
-		shell_hexdump_line(shell, addr, data, pending);
+		shell_hexdump_line(sh, addr, data, pending);
 		addr += pending;
 	}
 
-	shell_print(shell, "");
+	shell_print(sh, "");
 	return 0;
 }
 
-static int cmd_write(const struct shell *shell, size_t argc, char **argv)
+static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 {
 	uint8_t wr_buf[CONFIG_EEPROM_SHELL_BUFFER_SIZE];
 	uint8_t rd_buf[CONFIG_EEPROM_SHELL_BUFFER_SIZE];
@@ -84,7 +84,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 	len = argc - args_indx.data;
 
 	if (len > sizeof(wr_buf)) {
-		shell_error(shell, "Write buffer size (%zu bytes) exceeded",
+		shell_error(sh, "Write buffer size (%zu bytes) exceeded",
 			    sizeof(wr_buf));
 		return -EINVAL;
 	}
@@ -92,7 +92,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 	for (i = 0; i < len; i++) {
 		byte = strtoul(argv[args_indx.data + i], NULL, 0);
 		if (byte > UINT8_MAX) {
-			shell_error(shell, "Error parsing data byte %d", i);
+			shell_error(sh, "Error parsing data byte %d", i);
 			return -EINVAL;
 		}
 		wr_buf[i] = byte;
@@ -100,51 +100,51 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 
 	eeprom = device_get_binding(argv[args_indx.device]);
 	if (!eeprom) {
-		shell_error(shell, "EEPROM device not found");
+		shell_error(sh, "EEPROM device not found");
 		return -EINVAL;
 	}
 
-	shell_print(shell, "Writing %zu bytes to EEPROM...", len);
+	shell_print(sh, "Writing %zu bytes to EEPROM...", len);
 
 	err = eeprom_write(eeprom, offset, wr_buf, len);
 	if (err) {
-		shell_error(shell, "EEPROM write failed (err %d)", err);
+		shell_error(sh, "EEPROM write failed (err %d)", err);
 		return err;
 	}
 
-	shell_print(shell, "Verifying...");
+	shell_print(sh, "Verifying...");
 
 	err = eeprom_read(eeprom, offset, rd_buf, len);
 	if (err) {
-		shell_error(shell, "EEPROM read failed (err %d)", err);
+		shell_error(sh, "EEPROM read failed (err %d)", err);
 		return err;
 	}
 
 	if (memcmp(wr_buf, rd_buf, len) != 0) {
-		shell_error(shell, "Verify failed");
+		shell_error(sh, "Verify failed");
 		return -EIO;
 	}
 
-	shell_print(shell, "Verify OK");
+	shell_print(sh, "Verify OK");
 
 	return 0;
 }
 
-static int cmd_size(const struct shell *shell, size_t argc, char **argv)
+static int cmd_size(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *eeprom;
 
 	eeprom = device_get_binding(argv[args_indx.device]);
 	if (!eeprom) {
-		shell_error(shell, "EEPROM device not found");
+		shell_error(sh, "EEPROM device not found");
 		return -EINVAL;
 	}
 
-	shell_print(shell, "%zu bytes", eeprom_get_size(eeprom));
+	shell_print(sh, "%zu bytes", eeprom_get_size(eeprom));
 	return 0;
 }
 
-static int cmd_fill(const struct shell *shell, size_t argc, char **argv)
+static int cmd_fill(const struct shell *sh, size_t argc, char **argv)
 {
 	uint8_t wr_buf[CONFIG_EEPROM_SHELL_BUFFER_SIZE];
 	uint8_t rd_buf[CONFIG_EEPROM_SHELL_BUFFER_SIZE];
@@ -162,18 +162,18 @@ static int cmd_fill(const struct shell *shell, size_t argc, char **argv)
 
 	pattern = strtoul(argv[args_indx.pattern], NULL, 0);
 	if (pattern > UINT8_MAX) {
-		shell_error(shell, "Error parsing pattern byte");
+		shell_error(sh, "Error parsing pattern byte");
 		return -EINVAL;
 	}
 	memset(wr_buf, pattern, MIN(len, CONFIG_EEPROM_SHELL_BUFFER_SIZE));
 
 	eeprom = device_get_binding(argv[args_indx.device]);
 	if (!eeprom) {
-		shell_error(shell, "EEPROM device not found");
+		shell_error(sh, "EEPROM device not found");
 		return -EINVAL;
 	}
 
-	shell_print(shell, "Writing %zu bytes of 0x%02lx to EEPROM...", len,
+	shell_print(sh, "Writing %zu bytes of 0x%02lx to EEPROM...", len,
 		    pattern);
 
 	addr = initial_offset;
@@ -182,7 +182,7 @@ static int cmd_fill(const struct shell *shell, size_t argc, char **argv)
 		pending = MIN(len - upto, CONFIG_EEPROM_SHELL_BUFFER_SIZE);
 		err = eeprom_write(eeprom, addr, wr_buf, pending);
 		if (err) {
-			shell_error(shell, "EEPROM write failed (err %d)", err);
+			shell_error(sh, "EEPROM write failed (err %d)", err);
 			return err;
 		}
 		addr += pending;
@@ -190,25 +190,25 @@ static int cmd_fill(const struct shell *shell, size_t argc, char **argv)
 
 	addr = initial_offset;
 
-	shell_print(shell, "Verifying...");
+	shell_print(sh, "Verifying...");
 
 	for (upto = 0; upto < len; upto += pending) {
 		pending = MIN(len - upto, CONFIG_EEPROM_SHELL_BUFFER_SIZE);
 		err = eeprom_read(eeprom, addr, rd_buf, pending);
 		if (err) {
-			shell_error(shell, "EEPROM read failed (err %d)", err);
+			shell_error(sh, "EEPROM read failed (err %d)", err);
 			return err;
 		}
 
 		if (memcmp(wr_buf, rd_buf, pending) != 0) {
-			shell_error(shell, "Verify failed");
+			shell_error(sh, "Verify failed");
 			return -EIO;
 		}
 
 		addr += pending;
 	}
 
-	shell_print(shell, "Verify OK");
+	shell_print(sh, "Verify OK");
 
 	return 0;
 }

--- a/drivers/led/led_shell.c
+++ b/drivers/led/led_shell.c
@@ -20,21 +20,21 @@ enum {
 	arg_idx_value		= 3,
 };
 
-static int parse_common_args(const struct shell *shell, char **argv,
+static int parse_common_args(const struct shell *sh, char **argv,
 			     const struct device * *dev, uint32_t *led)
 {
 	char *end_ptr;
 
 	*dev = device_get_binding(argv[arg_idx_dev]);
 	if (!*dev) {
-		shell_error(shell,
+		shell_error(sh,
 			    "LED device %s not found", argv[arg_idx_dev]);
 		return -ENODEV;
 	}
 
 	*led = strtoul(argv[arg_idx_led], &end_ptr, 0);
 	if (*end_ptr != '\0') {
-		shell_error(shell, "Invalid LED number parameter %s",
+		shell_error(sh, "Invalid LED number parameter %s",
 			    argv[arg_idx_led]);
 		return -EINVAL;
 	}
@@ -42,49 +42,49 @@ static int parse_common_args(const struct shell *shell, char **argv,
 	return 0;
 }
 
-static int cmd_off(const struct shell *shell, size_t argc, char **argv)
+static int cmd_off(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	uint32_t led;
 	int err;
 
-	err = parse_common_args(shell, argv, &dev, &led);
+	err = parse_common_args(sh, argv, &dev, &led);
 	if (err < 0) {
 		return err;
 	}
 
-	shell_print(shell, "%s: turning off LED %d", dev->name, led);
+	shell_print(sh, "%s: turning off LED %d", dev->name, led);
 
 	err = led_off(dev, led);
 	if (err) {
-		shell_error(shell, "Error: %d", err);
+		shell_error(sh, "Error: %d", err);
 	}
 
 	return err;
 }
 
-static int cmd_on(const struct shell *shell, size_t argc, char **argv)
+static int cmd_on(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	uint32_t led;
 	int err;
 
-	err = parse_common_args(shell, argv, &dev, &led);
+	err = parse_common_args(sh, argv, &dev, &led);
 	if (err < 0) {
 		return err;
 	}
 
-	shell_print(shell, "%s: turning on LED %d", dev->name, led);
+	shell_print(sh, "%s: turning on LED %d", dev->name, led);
 
 	err = led_on(dev, led);
 	if (err) {
-		shell_error(shell, "Error: %d", err);
+		shell_error(sh, "Error: %d", err);
 	}
 
 	return err;
 }
 
-static int cmd_get_info(const struct shell *shell, size_t argc, char **argv)
+static int cmd_get_info(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	uint32_t led;
@@ -92,36 +92,36 @@ static int cmd_get_info(const struct shell *shell, size_t argc, char **argv)
 	const struct led_info *info;
 	int i;
 
-	err = parse_common_args(shell, argv, &dev, &led);
+	err = parse_common_args(sh, argv, &dev, &led);
 	if (err < 0) {
 		return err;
 	}
 
-	shell_print(shell, "%s: getting LED %d information", dev->name, led);
+	shell_print(sh, "%s: getting LED %d information", dev->name, led);
 
 	err = led_get_info(dev, led, &info);
 	if (err) {
-		shell_error(shell, "Error: %d", err);
+		shell_error(sh, "Error: %d", err);
 		return err;
 	}
 
-	shell_print(shell, "Label      : %s", info->label ? : "<NULL>");
-	shell_print(shell, "Index      : %d", info->index);
-	shell_print(shell, "Num colors : %d", info->num_colors);
+	shell_print(sh, "Label      : %s", info->label ? : "<NULL>");
+	shell_print(sh, "Index      : %d", info->index);
+	shell_print(sh, "Num colors : %d", info->num_colors);
 	if (info->color_mapping) {
-		shell_fprintf(shell, SHELL_NORMAL, "Colors     : %d",
+		shell_fprintf(sh, SHELL_NORMAL, "Colors     : %d",
 			      info->color_mapping[0]);
 		for (i = 1; i < info->num_colors; i++) {
-			shell_fprintf(shell, SHELL_NORMAL, ":%d",
+			shell_fprintf(sh, SHELL_NORMAL, ":%d",
 				      info->color_mapping[i]);
 		}
-		shell_fprintf(shell, SHELL_NORMAL, "\n");
+		shell_fprintf(sh, SHELL_NORMAL, "\n");
 	}
 
 	return 0;
 }
 
-static int cmd_set_brightness(const struct shell *shell,
+static int cmd_set_brightness(const struct shell *sh,
 			      size_t argc, char **argv)
 {
 	const struct device *dev;
@@ -130,35 +130,35 @@ static int cmd_set_brightness(const struct shell *shell,
 	char *end_ptr;
 	unsigned long value;
 
-	err = parse_common_args(shell, argv, &dev, &led);
+	err = parse_common_args(sh, argv, &dev, &led);
 	if (err < 0) {
 		return err;
 	}
 
 	value = strtoul(argv[arg_idx_value], &end_ptr, 0);
 	if (*end_ptr != '\0') {
-		shell_error(shell, "Invalid LED brightness parameter %s",
+		shell_error(sh, "Invalid LED brightness parameter %s",
 			     argv[arg_idx_value]);
 		return -EINVAL;
 	}
 	if (value > 100) {
-		shell_error(shell, "Invalid LED brightness value %lu (max 100)",
+		shell_error(sh, "Invalid LED brightness value %lu (max 100)",
 			    value);
 		return -EINVAL;
 	}
 
-	shell_print(shell, "%s: setting LED %d brightness to %lu",
+	shell_print(sh, "%s: setting LED %d brightness to %lu",
 		    dev->name, led, value);
 
 	err = led_set_brightness(dev, led, (uint8_t) value);
 	if (err) {
-		shell_error(shell, "Error: %d", err);
+		shell_error(sh, "Error: %d", err);
 	}
 
 	return err;
 }
 
-static int cmd_set_color(const struct shell *shell, size_t argc, char **argv)
+static int cmd_set_color(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	uint32_t led;
@@ -167,14 +167,14 @@ static int cmd_set_color(const struct shell *shell, size_t argc, char **argv)
 	uint8_t i;
 	uint8_t color[MAX_CHANNEL_ARGS];
 
-	err = parse_common_args(shell, argv, &dev, &led);
+	err = parse_common_args(sh, argv, &dev, &led);
 	if (err < 0) {
 		return err;
 	}
 
 	num_colors = argc - arg_idx_value;
 	if (num_colors > MAX_CHANNEL_ARGS) {
-		shell_error(shell,
+		shell_error(sh,
 			    "Invalid number of colors %d (max %d)",
 			     num_colors, MAX_CHANNEL_ARGS);
 		return -EINVAL;
@@ -186,12 +186,12 @@ static int cmd_set_color(const struct shell *shell, size_t argc, char **argv)
 
 		col = strtoul(argv[arg_idx_value + i], &end_ptr, 0);
 		if (*end_ptr != '\0') {
-			shell_error(shell, "Invalid LED color parameter %s",
+			shell_error(sh, "Invalid LED color parameter %s",
 				    argv[arg_idx_value + i]);
 			return -EINVAL;
 		}
 		if (col > 255) {
-			shell_error(shell,
+			shell_error(sh,
 				    "Invalid LED color value %lu (max 255)",
 				    col);
 			return -EINVAL;
@@ -199,22 +199,22 @@ static int cmd_set_color(const struct shell *shell, size_t argc, char **argv)
 		color[i] = col;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "%s: setting LED %d color to %d",
+	shell_fprintf(sh, SHELL_NORMAL, "%s: setting LED %d color to %d",
 		      dev->name, led, color[0]);
 	for (i = 1; i < num_colors; i++) {
-		shell_fprintf(shell, SHELL_NORMAL, ":%d", color[i]);
+		shell_fprintf(sh, SHELL_NORMAL, ":%d", color[i]);
 	}
-	shell_fprintf(shell, SHELL_NORMAL, "\n");
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
 
 	err = led_set_color(dev, led, num_colors, color);
 	if (err) {
-		shell_error(shell, "Error: %d", err);
+		shell_error(sh, "Error: %d", err);
 	}
 
 	return err;
 }
 
-static int cmd_set_channel(const struct shell *shell, size_t argc, char **argv)
+static int cmd_set_channel(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	uint32_t channel;
@@ -222,36 +222,36 @@ static int cmd_set_channel(const struct shell *shell, size_t argc, char **argv)
 	char *end_ptr;
 	unsigned long value;
 
-	err = parse_common_args(shell, argv, &dev, &channel);
+	err = parse_common_args(sh, argv, &dev, &channel);
 	if (err < 0) {
 		return err;
 	}
 
 	value = strtoul(argv[arg_idx_value], &end_ptr, 0);
 	if (*end_ptr != '\0') {
-		shell_error(shell, "Invalid channel value parameter %s",
+		shell_error(sh, "Invalid channel value parameter %s",
 			     argv[arg_idx_value]);
 		return -EINVAL;
 	}
 	if (value > 255) {
-		shell_error(shell, "Invalid channel value %lu (max 255)",
+		shell_error(sh, "Invalid channel value %lu (max 255)",
 			    value);
 		return -EINVAL;
 	}
 
-	shell_print(shell, "%s: setting channel %d to %lu",
+	shell_print(sh, "%s: setting channel %d to %lu",
 		    dev->name, channel, value);
 
 	err = led_set_channel(dev, channel, (uint8_t) value);
 	if (err) {
-		shell_error(shell, "Error: %d", err);
+		shell_error(sh, "Error: %d", err);
 	}
 
 	return err;
 }
 
 static int
-cmd_write_channels(const struct shell *shell, size_t argc, char **argv)
+cmd_write_channels(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	uint32_t start_channel;
@@ -260,14 +260,14 @@ cmd_write_channels(const struct shell *shell, size_t argc, char **argv)
 	uint8_t i;
 	uint8_t value[MAX_CHANNEL_ARGS];
 
-	err = parse_common_args(shell, argv, &dev, &start_channel);
+	err = parse_common_args(sh, argv, &dev, &start_channel);
 	if (err < 0) {
 		return err;
 	}
 
 	num_channels = argc - arg_idx_value;
 	if (num_channels > MAX_CHANNEL_ARGS) {
-		shell_error(shell,
+		shell_error(sh,
 			    "Can't write %d channels (max %d)",
 			     num_channels, MAX_CHANNEL_ARGS);
 		return -EINVAL;
@@ -279,29 +279,29 @@ cmd_write_channels(const struct shell *shell, size_t argc, char **argv)
 
 		val = strtoul(argv[arg_idx_value + i], &end_ptr, 0);
 		if (*end_ptr != '\0') {
-			shell_error(shell,
+			shell_error(sh,
 				    "Invalid channel value parameter %s",
 				    argv[arg_idx_value + i]);
 			return -EINVAL;
 		}
 		if (val > 255) {
-			shell_error(shell,
+			shell_error(sh,
 				    "Invalid channel value %lu (max 255)", val);
 			return -EINVAL;
 		}
 		value[i] = val;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "%s: writing from channel %d: %d",
+	shell_fprintf(sh, SHELL_NORMAL, "%s: writing from channel %d: %d",
 		      dev->name, start_channel, value[0]);
 	for (i = 1; i < num_channels; i++) {
-		shell_fprintf(shell, SHELL_NORMAL, " %d", value[i]);
+		shell_fprintf(sh, SHELL_NORMAL, " %d", value[i]);
 	}
-	shell_fprintf(shell, SHELL_NORMAL, "\n");
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
 
 	err = led_write_channels(dev, start_channel, num_channels, value);
 	if (err) {
-		shell_error(shell, "Error: %d", err);
+		shell_error(sh, "Error: %d", err);
 	}
 
 	return err;

--- a/drivers/lora/shell.c
+++ b/drivers/lora/shell.c
@@ -31,14 +31,14 @@ static const int bw_table[] = {
 	[BW_500_KHZ] = 500,
 };
 
-static int parse_long(long *out, const struct shell *shell, const char *arg)
+static int parse_long(long *out, const struct shell *sh, const char *arg)
 {
 	char *eptr;
 	long lval;
 
 	lval = strtol(arg, &eptr, 0);
 	if (*eptr != '\0') {
-		shell_error(shell, "'%s' is not an integer", arg);
+		shell_error(sh, "'%s' is not an integer", arg);
 		return -EINVAL;
 	}
 
@@ -46,19 +46,19 @@ static int parse_long(long *out, const struct shell *shell, const char *arg)
 	return 0;
 }
 
-static int parse_long_range(long *out, const struct shell *shell,
+static int parse_long_range(long *out, const struct shell *sh,
 			    const char *arg, const char *name, long min,
 			    long max)
 {
 	int ret;
 
-	ret = parse_long(out, shell, arg);
+	ret = parse_long(out, sh, arg);
 	if (ret < 0) {
 		return ret;
 	}
 
 	if (*out < min || *out > max) {
-		shell_error(shell, "Parameter '%s' is out of range. "
+		shell_error(sh, "Parameter '%s' is out of range. "
 			    "Valid range is %li -- %li.",
 			    name, min, max);
 		return -EINVAL;
@@ -67,20 +67,20 @@ static int parse_long_range(long *out, const struct shell *shell,
 	return 0;
 }
 
-static int parse_freq(uint32_t *out, const struct shell *shell, const char *arg)
+static int parse_freq(uint32_t *out, const struct shell *sh, const char *arg)
 {
 	char *eptr;
 	unsigned long val;
 
 	val = strtoul(arg, &eptr, 0);
 	if (*eptr != '\0') {
-		shell_error(shell, "Invalid frequency, '%s' is not an integer",
+		shell_error(sh, "Invalid frequency, '%s' is not an integer",
 			    arg);
 		return -EINVAL;
 	}
 
 	if (val == ULONG_MAX) {
-		shell_error(shell, "Frequency %s out of range", arg);
+		shell_error(sh, "Frequency %s out of range", arg);
 		return -EINVAL;
 	}
 
@@ -88,79 +88,79 @@ static int parse_freq(uint32_t *out, const struct shell *shell, const char *arg)
 	return 0;
 }
 
-static const struct device *get_modem(const struct shell *shell)
+static const struct device *get_modem(const struct shell *sh)
 {
 	const struct device *dev;
 
 	dev = DEVICE_DT_GET(DEFAULT_RADIO_NODE);
 
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "LORA Radio device not ready");
+		shell_error(sh, "LORA Radio device not ready");
 		return NULL;
 	}
 
 	return dev;
 }
 
-static const struct device *get_configured_modem(const struct shell *shell)
+static const struct device *get_configured_modem(const struct shell *sh)
 {
 	int ret;
 	const struct device *dev;
 
-	dev = get_modem(shell);
+	dev = get_modem(sh);
 	if (!dev) {
 		return NULL;
 	}
 
 	if (modem_config.frequency == 0) {
-		shell_error(shell, "No frequency specified.");
+		shell_error(sh, "No frequency specified.");
 		return NULL;
 	}
 
 	ret = lora_config(dev, &modem_config);
 	if (ret < 0) {
-		shell_error(shell, "LoRa config failed");
+		shell_error(sh, "LoRa config failed");
 		return NULL;
 	}
 
 	return dev;
 }
 
-static int lora_conf_dump(const struct shell *shell)
+static int lora_conf_dump(const struct shell *sh)
 {
-	shell_print(shell, "  Frequency: %" PRIu32 " Hz",
+	shell_print(sh, "  Frequency: %" PRIu32 " Hz",
 		    modem_config.frequency);
-	shell_print(shell, "  TX power: %" PRIi8 " dBm",
+	shell_print(sh, "  TX power: %" PRIi8 " dBm",
 		    modem_config.tx_power);
-	shell_print(shell, "  Bandwidth: %i kHz",
+	shell_print(sh, "  Bandwidth: %i kHz",
 		    bw_table[modem_config.bandwidth]);
-	shell_print(shell, "  Spreading factor: SF%i",
+	shell_print(sh, "  Spreading factor: SF%i",
 		    (int)modem_config.datarate);
-	shell_print(shell, "  Coding rate: 4/%i",
+	shell_print(sh, "  Coding rate: 4/%i",
 		    (int)modem_config.coding_rate + 4);
-	shell_print(shell, "  Preamble length: %" PRIu16,
+	shell_print(sh, "  Preamble length: %" PRIu16,
 		    modem_config.preamble_len);
 
 	return 0;
 }
 
-static int lora_conf_set(const struct shell *shell, const char *param,
+static int lora_conf_set(const struct shell *sh, const char *param,
 			 const char *value)
 {
 	long lval;
 
 	if (!strcmp("freq", param)) {
-		if (parse_freq(&modem_config.frequency, shell, value) < 0) {
+		if (parse_freq(&modem_config.frequency, sh, value) < 0) {
 			return -EINVAL;
 		}
 	} else if (!strcmp("tx-power", param)) {
-		if (parse_long_range(&lval, shell, value,
+		if (parse_long_range(&lval, sh, value,
 				     "tx-power", INT8_MIN, INT8_MAX) < 0) {
 			return -EINVAL;
 		}
 		modem_config.tx_power = lval;
 	} else if (!strcmp("bw", param)) {
-		if (parse_long_range(&lval, shell, value,
+		if (parse_long_range(&lval, sh, value,
 				     "bw", 0, INT8_MAX) < 0) {
 			return -EINVAL;
 		}
@@ -175,50 +175,50 @@ static int lora_conf_set(const struct shell *shell, const char *param,
 			modem_config.bandwidth = BW_500_KHZ;
 			break;
 		default:
-			shell_error(shell, "Invalid bandwidth: %ld", lval);
+			shell_error(sh, "Invalid bandwidth: %ld", lval);
 			return -EINVAL;
 		}
 	} else if (!strcmp("sf", param)) {
-		if (parse_long_range(&lval, shell, value, "sf", 6, 12) < 0) {
+		if (parse_long_range(&lval, sh, value, "sf", 6, 12) < 0) {
 			return -EINVAL;
 		}
 		modem_config.datarate = SF_6 + (unsigned int)lval - 6;
 	} else if (!strcmp("cr", param)) {
-		if (parse_long_range(&lval, shell, value, "cr", 5, 8) < 0) {
+		if (parse_long_range(&lval, sh, value, "cr", 5, 8) < 0) {
 			return -EINVAL;
 		}
 		modem_config.coding_rate = CR_4_5 + (unsigned int)lval - 5;
 	} else if (!strcmp("pre-len", param)) {
-		if (parse_long_range(&lval, shell, value,
+		if (parse_long_range(&lval, sh, value,
 				     "pre-len", 0, UINT16_MAX) < 0) {
 			return -EINVAL;
 		}
 		modem_config.preamble_len = lval;
 	} else {
-		shell_error(shell, "Unknown parameter '%s'", param);
+		shell_error(sh, "Unknown parameter '%s'", param);
 		return -EINVAL;
 	}
 
 	return 0;
 }
 
-static int cmd_lora_conf(const struct shell *shell, size_t argc, char **argv)
+static int cmd_lora_conf(const struct shell *sh, size_t argc, char **argv)
 {
 	int i;
 	int ret;
 
 	if (argc < 2) {
-		return lora_conf_dump(shell);
+		return lora_conf_dump(sh);
 	}
 
 	for (i = 1; i < argc; i += 2) {
 		if (i + 1 >= argc) {
-			shell_error(shell, "'%s' expects an argument",
+			shell_error(sh, "'%s' expects an argument",
 				    argv[i]);
 			return -EINVAL;
 		}
 
-		ret = lora_conf_set(shell, argv[i], argv[i + 1]);
+		ret = lora_conf_set(sh, argv[i], argv[i + 1]);
 		if (ret != 0) {
 			return ret;
 		}
@@ -227,28 +227,28 @@ static int cmd_lora_conf(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-static int cmd_lora_send(const struct shell *shell,
+static int cmd_lora_send(const struct shell *sh,
 			size_t argc, char **argv)
 {
 	int ret;
 	const struct device *dev;
 
 	modem_config.tx = true;
-	dev = get_configured_modem(shell);
+	dev = get_configured_modem(sh);
 	if (!dev) {
 		return -ENODEV;
 	}
 
 	ret = lora_send(dev, argv[1], strlen(argv[1]));
 	if (ret < 0) {
-		shell_error(shell, "LoRa send failed: %i", ret);
+		shell_error(sh, "LoRa send failed: %i", ret);
 		return ret;
 	}
 
 	return 0;
 }
 
-static int cmd_lora_recv(const struct shell *shell, size_t argc, char **argv)
+static int cmd_lora_recv(const struct shell *sh, size_t argc, char **argv)
 {
 	static char buf[0xff];
 	const struct device *dev;
@@ -258,12 +258,12 @@ static int cmd_lora_recv(const struct shell *shell, size_t argc, char **argv)
 	int8_t snr;
 
 	modem_config.tx = false;
-	dev = get_configured_modem(shell);
+	dev = get_configured_modem(sh);
 	if (!dev) {
 		return -ENODEV;
 	}
 
-	if (argc >= 2 && parse_long_range(&timeout, shell, argv[1],
+	if (argc >= 2 && parse_long_range(&timeout, sh, argv[1],
 					  "timeout", 0, INT_MAX) < 0) {
 		return -EINVAL;
 	}
@@ -271,18 +271,18 @@ static int cmd_lora_recv(const struct shell *shell, size_t argc, char **argv)
 	ret = lora_recv(dev, buf, sizeof(buf),
 			timeout ? K_MSEC(timeout) : K_FOREVER, &rssi, &snr);
 	if (ret < 0) {
-		shell_error(shell, "LoRa recv failed: %i", ret);
+		shell_error(sh, "LoRa recv failed: %i", ret);
 		return ret;
 	}
 
-	shell_hexdump(shell, buf, ret);
-	shell_print(shell, "RSSI: %" PRIi16 " dBm, SNR:%" PRIi8 " dBm",
+	shell_hexdump(sh, buf, ret);
+	shell_print(sh, "RSSI: %" PRIi16 " dBm, SNR:%" PRIi8 " dBm",
 		    rssi, snr);
 
 	return 0;
 }
 
-static int cmd_lora_test_cw(const struct shell *shell,
+static int cmd_lora_test_cw(const struct shell *sh,
 			    size_t argc, char **argv)
 {
 	const struct device *dev;
@@ -290,22 +290,22 @@ static int cmd_lora_test_cw(const struct shell *shell,
 	uint32_t freq;
 	long power, duration;
 
-	dev = get_modem(shell);
+	dev = get_modem(sh);
 	if (!dev) {
 		return -ENODEV;
 	}
 
-	if (parse_freq(&freq, shell, argv[1]) < 0 ||
-	    parse_long_range(&power, shell, argv[2],
+	if (parse_freq(&freq, sh, argv[1]) < 0 ||
+	    parse_long_range(&power, sh, argv[2],
 			     "power", INT8_MIN, INT8_MAX) < 0 ||
-	    parse_long_range(&duration, shell, argv[3],
+	    parse_long_range(&duration, sh, argv[3],
 			     "duration", 0, UINT16_MAX) < 0) {
 		return -EINVAL;
 	}
 
 	ret = lora_test_cw(dev, (uint32_t)freq, (int8_t)power, (uint16_t)duration);
 	if (ret < 0) {
-		shell_error(shell, "LoRa test CW failed: %i", ret);
+		shell_error(sh, "LoRa test CW failed: %i", ret);
 		return ret;
 	}
 

--- a/drivers/pwm/pwm_shell.c
+++ b/drivers/pwm/pwm_shell.c
@@ -29,7 +29,7 @@ static const struct args_index args_indx = {
 	.flags = 5,
 };
 
-static int cmd_cycles(const struct shell *shell, size_t argc, char **argv)
+static int cmd_cycles(const struct shell *sh, size_t argc, char **argv)
 {
 	pwm_flags_t flags = 0;
 	const struct device *dev;
@@ -40,7 +40,7 @@ static int cmd_cycles(const struct shell *shell, size_t argc, char **argv)
 
 	dev = device_get_binding(argv[args_indx.device]);
 	if (!dev) {
-		shell_error(shell, "PWM device not found");
+		shell_error(sh, "PWM device not found");
 		return -EINVAL;
 	}
 
@@ -54,7 +54,7 @@ static int cmd_cycles(const struct shell *shell, size_t argc, char **argv)
 
 	err = pwm_set_cycles(dev, channel, period, pulse, flags);
 	if (err) {
-		shell_error(shell, "failed to setup PWM (err %d)",
+		shell_error(sh, "failed to setup PWM (err %d)",
 			    err);
 		return err;
 	}
@@ -62,7 +62,7 @@ static int cmd_cycles(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-static int cmd_usec(const struct shell *shell, size_t argc, char **argv)
+static int cmd_usec(const struct shell *sh, size_t argc, char **argv)
 {
 	pwm_flags_t flags = 0;
 	const struct device *dev;
@@ -73,7 +73,7 @@ static int cmd_usec(const struct shell *shell, size_t argc, char **argv)
 
 	dev = device_get_binding(argv[args_indx.device]);
 	if (!dev) {
-		shell_error(shell, "PWM device not found");
+		shell_error(sh, "PWM device not found");
 		return -EINVAL;
 	}
 
@@ -87,14 +87,14 @@ static int cmd_usec(const struct shell *shell, size_t argc, char **argv)
 
 	err = pwm_set(dev, channel, PWM_USEC(period), PWM_USEC(pulse), flags);
 	if (err) {
-		shell_error(shell, "failed to setup PWM (err %d)", err);
+		shell_error(sh, "failed to setup PWM (err %d)", err);
 		return err;
 	}
 
 	return 0;
 }
 
-static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
+static int cmd_nsec(const struct shell *sh, size_t argc, char **argv)
 {
 	pwm_flags_t flags = 0;
 	const struct device *dev;
@@ -105,7 +105,7 @@ static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
 
 	dev = device_get_binding(argv[args_indx.device]);
 	if (!dev) {
-		shell_error(shell, "PWM device not found");
+		shell_error(sh, "PWM device not found");
 		return -EINVAL;
 	}
 
@@ -119,7 +119,7 @@ static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
 
 	err = pwm_set(dev, channel, period, pulse, flags);
 	if (err) {
-		shell_error(shell, "failed to setup PWM (err %d)", err);
+		shell_error(sh, "failed to setup PWM (err %d)", err);
 		return err;
 	}
 

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -214,34 +214,34 @@ static int handle_channel_by_name(const struct shell *shell_ptr, const struct de
 	return 0;
 }
 
-static int cmd_get_sensor(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_get_sensor(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
 	int err;
 
 	dev = device_get_binding(argv[1]);
 	if (dev == NULL) {
-		shell_error(shell, "Device unknown (%s)", argv[1]);
+		shell_error(sh, "Device unknown (%s)", argv[1]);
 		return -ENODEV;
 	}
 
 	err = sensor_sample_fetch(dev);
 	if (err < 0) {
-		shell_error(shell, "Failed to read sensor: %d", err);
+		shell_error(sh, "Failed to read sensor: %d", err);
 	}
 
 	if (argc == 2) {
 		/* read all channels */
 		for (int i = 0; i < ARRAY_SIZE(sensor_channel_name); i++) {
 			if (sensor_channel_name[i]) {
-				handle_channel_by_name(shell, dev, sensor_channel_name[i]);
+				handle_channel_by_name(sh, dev, sensor_channel_name[i]);
 			}
 		}
 	} else {
 		for (int i = 2; i < argc; i++) {
-			err = handle_channel_by_name(shell, dev, argv[i]);
+			err = handle_channel_by_name(sh, dev, argv[i]);
 			if (err < 0) {
-				shell_error(shell, "Failed to read channel (%s)", argv[i]);
+				shell_error(sh, "Failed to read channel (%s)", argv[i]);
 			}
 		}
 	}

--- a/drivers/sensor/shell_battery.c
+++ b/drivers/sensor/shell_battery.c
@@ -49,7 +49,7 @@ static int get_channels(const struct device *dev, ...)
 }
 
 /* battery */
-static int cmd_battery(const struct shell *shell, size_t argc, char **argv)
+static int cmd_battery(const struct shell *sh, size_t argc, char **argv)
 {
 	struct sensor_value temp, volt, current, i_desired, charge_remain;
 	struct sensor_value charge, v_desired, v_design, cap, nom_cap;
@@ -59,13 +59,13 @@ static int cmd_battery(const struct shell *shell, size_t argc, char **argv)
 	int err;
 
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "Device not ready (%s)", argv[1]);
+		shell_error(sh, "Device not ready (%s)", argv[1]);
 		return -ENODEV;
 	}
 
 	err = sensor_sample_fetch(dev);
 	if (err < 0) {
-		shell_error(shell, "Failed to read sensor: %d", err);
+		shell_error(sh, "Failed to read sensor: %d", err);
 	}
 
 	err = get_channels(dev,
@@ -88,34 +88,34 @@ static int cmd_battery(const struct shell *shell, size_t argc, char **argv)
 		return err;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "Temp:  %.1d.%02d C\n", temp.val1,
+	shell_fprintf(sh, SHELL_NORMAL, "Temp:  %.1d.%02d C\n", temp.val1,
 		      temp.val2 / 10000);
-	shell_fprintf(shell, SHELL_NORMAL, "V: %5d.%02d V\n", volt.val1,
+	shell_fprintf(sh, SHELL_NORMAL, "V: %5d.%02d V\n", volt.val1,
 		      volt.val2 / 10000);
-	shell_fprintf(shell, SHELL_NORMAL, "V-desired: %d.%02d V\n",
+	shell_fprintf(sh, SHELL_NORMAL, "V-desired: %d.%02d V\n",
 		      v_desired.val1, v_desired.val2 / 10000);
-	shell_fprintf(shell, SHELL_NORMAL, "I:    %d mA", current.val1);
+	shell_fprintf(sh, SHELL_NORMAL, "I:    %d mA", current.val1);
 	if (current.val1 > 0) {
-		shell_fprintf(shell, SHELL_NORMAL, " (CHG)");
+		shell_fprintf(sh, SHELL_NORMAL, " (CHG)");
 	} else if (current.val1 < 0) {
-		shell_fprintf(shell, SHELL_NORMAL, " (DISCHG)");
+		shell_fprintf(sh, SHELL_NORMAL, " (DISCHG)");
 	}
-	shell_fprintf(shell, SHELL_NORMAL, "\n");
-	shell_fprintf(shell, SHELL_NORMAL, "I-desired: %5d mA\n",
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
+	shell_fprintf(sh, SHELL_NORMAL, "I-desired: %5d mA\n",
 		      i_desired.val1);
 	allowed = i_desired.val1 && v_desired.val2 && charge.val1 < 100;
-	shell_fprintf(shell, SHELL_NORMAL, "Charging: %sAllowed\n",
+	shell_fprintf(sh, SHELL_NORMAL, "Charging: %sAllowed\n",
 		      allowed ? "" : "Not ");
-	shell_fprintf(shell, SHELL_NORMAL, "Charge: %d %%\n", charge.val1);
-	shell_fprintf(shell, SHELL_NORMAL, "V-design: %d.%02d V\n",
+	shell_fprintf(sh, SHELL_NORMAL, "Charge: %d %%\n", charge.val1);
+	shell_fprintf(sh, SHELL_NORMAL, "V-design: %d.%02d V\n",
 		      v_design.val1, v_design.val2 / 10000);
-	shell_fprintf(shell, SHELL_NORMAL, "Remaining: %d mA\n",
+	shell_fprintf(sh, SHELL_NORMAL, "Remaining: %d mA\n",
 		      charge_remain.val1);
-	shell_fprintf(shell, SHELL_NORMAL, "Cap-full: %d mA\n", cap.val1);
-	shell_fprintf(shell, SHELL_NORMAL, "Design: %d mA\n", nom_cap.val1);
-	shell_fprintf(shell, SHELL_NORMAL, "Time full: %dh:%02d\n",
+	shell_fprintf(sh, SHELL_NORMAL, "Cap-full: %d mA\n", cap.val1);
+	shell_fprintf(sh, SHELL_NORMAL, "Design: %d mA\n", nom_cap.val1);
+	shell_fprintf(sh, SHELL_NORMAL, "Time full: %dh:%02d\n",
 		      full.val1 / 60, full.val1 % 60);
-	shell_fprintf(shell, SHELL_NORMAL, "Time empty: %dh:%02d\n",
+	shell_fprintf(sh, SHELL_NORMAL, "Time empty: %dh:%02d\n",
 		      empty.val1 / 60, empty.val1 % 60);
 
 	return 0;

--- a/drivers/virtualization/virt_ivshmem_shell.c
+++ b/drivers/virtualization/virt_ivshmem_shell.c
@@ -23,7 +23,7 @@ K_THREAD_STACK_DEFINE(doorbell_stack, STACK_SIZE);
 static bool doorbell_started;
 static struct k_thread doorbell_thread;
 
-static void doorbell_notification_thread(const struct shell *shell)
+static void doorbell_notification_thread(const struct shell *sh)
 {
 	while (1) {
 		unsigned int signaled;
@@ -36,7 +36,7 @@ static void doorbell_notification_thread(const struct shell *shell)
 			continue;
 		}
 
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Received a notification on vector %u\n",
 			      (unsigned int)vector);
 
@@ -46,19 +46,19 @@ static void doorbell_notification_thread(const struct shell *shell)
 
 #endif /* CONFIG_IVSHMEM_DOORBELL */
 
-static bool get_ivshmem(const struct shell *shell)
+static bool get_ivshmem(const struct shell *sh)
 {
 	if (ivshmem == NULL) {
 		ivshmem = DEVICE_DT_GET_ONE(qemu_ivshmem);
 		if (!device_is_ready(ivshmem)) {
-			shell_error(shell, "IVshmem device is not ready");
+			shell_error(sh, "IVshmem device is not ready");
 		}
 	}
 
 	return ivshmem != NULL ? true : false;
 }
 
-static int cmd_ivshmem_shmem(const struct shell *shell,
+static int cmd_ivshmem_shmem(const struct shell *sh,
 			     size_t argc, char **argv)
 {
 	uintptr_t mem;
@@ -66,7 +66,7 @@ static int cmd_ivshmem_shmem(const struct shell *shell,
 	uint32_t id;
 	uint16_t vectors;
 
-	if (!get_ivshmem(shell)) {
+	if (!get_ivshmem(sh)) {
 		return 0;
 	}
 
@@ -74,7 +74,7 @@ static int cmd_ivshmem_shmem(const struct shell *shell,
 	id = ivshmem_get_id(ivshmem);
 	vectors = ivshmem_get_vectors(ivshmem);
 
-	shell_fprintf(shell, SHELL_NORMAL,
+	shell_fprintf(sh, SHELL_NORMAL,
 		      "IVshmem up and running: \n"
 		      "\tShared memory: 0x%x of size %u bytes\n"
 		      "\tPeer id: %u\n"
@@ -84,7 +84,7 @@ static int cmd_ivshmem_shmem(const struct shell *shell,
 	return 0;
 }
 
-static int cmd_ivshmem_dump(const struct shell *shell,
+static int cmd_ivshmem_dump(const struct shell *sh,
 			    size_t argc, char **argv)
 {
 	uintptr_t dump_pos;
@@ -92,7 +92,7 @@ static int cmd_ivshmem_dump(const struct shell *shell,
 	uintptr_t mem;
 	size_t size;
 
-	if (!get_ivshmem(shell)) {
+	if (!get_ivshmem(sh)) {
 		return 0;
 	}
 
@@ -102,19 +102,19 @@ static int cmd_ivshmem_dump(const struct shell *shell,
 	size = ivshmem_get_mem(ivshmem, &mem);
 
 	if (dump_size > size) {
-		shell_error(shell, "Size is too big");
+		shell_error(sh, "Size is too big");
 	} else if (dump_pos > size) {
-		shell_error(shell, "Position is out of the shared memory");
+		shell_error(sh, "Position is out of the shared memory");
 	} else if ((mem + dump_pos + dump_size) > (mem + size)) {
-		shell_error(shell, "Position and size overflow");
+		shell_error(sh, "Position and size overflow");
 	} else {
-		shell_hexdump(shell, (const uint8_t *)mem+dump_pos, dump_size);
+		shell_hexdump(sh, (const uint8_t *)mem+dump_pos, dump_size);
 	}
 
 	return 0;
 }
 
-static int cmd_ivshmem_int(const struct shell *shell,
+static int cmd_ivshmem_int(const struct shell *sh,
 			   size_t argc, char **argv)
 {
 	int peer_id;
@@ -122,11 +122,11 @@ static int cmd_ivshmem_int(const struct shell *shell,
 	int ret;
 
 	if (!IS_ENABLED(CONFIG_IVSHMEM_DOORBELL)) {
-		shell_error(shell, "CONFIG_IVSHMEM_DOORBELL is not enabled");
+		shell_error(sh, "CONFIG_IVSHMEM_DOORBELL is not enabled");
 		return 0;
 	}
 
-	if (!get_ivshmem(shell)) {
+	if (!get_ivshmem(sh)) {
 		return 0;
 	}
 
@@ -135,26 +135,26 @@ static int cmd_ivshmem_int(const struct shell *shell,
 
 	ret = ivshmem_int_peer(ivshmem, (uint16_t)peer_id, (uint16_t)vector);
 	if (ret != 0) {
-		shell_error(shell,
+		shell_error(sh,
 			    "Could not notify peer %u on %u. status %d",
 			    peer_id, vector, ret);
 		return -EIO;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL,
+	shell_fprintf(sh, SHELL_NORMAL,
 		      "Notification sent to peer %u on vector %u\n",
 		      peer_id, vector);
 
 	return 0;
 }
 
-static int cmd_ivshmem_get_notified(const struct shell *shell,
+static int cmd_ivshmem_get_notified(const struct shell *sh,
 				    size_t argc, char **argv)
 {
 #ifdef CONFIG_IVSHMEM_DOORBELL
 	int vector;
 
-	if (!get_ivshmem(shell)) {
+	if (!get_ivshmem(sh)) {
 		return 0;
 	}
 
@@ -162,12 +162,12 @@ static int cmd_ivshmem_get_notified(const struct shell *shell,
 
 	if (ivshmem_register_handler(ivshmem, &doorbell_sig,
 				     (uint16_t)vector)) {
-		shell_error(shell, "Could not get notifications on vector %u",
+		shell_error(sh, "Could not get notifications on vector %u",
 			    vector);
 		return -EIO;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL,
+	shell_fprintf(sh, SHELL_NORMAL,
 		      "Notifications enabled for vector %u\n", vector);
 
 	if (!doorbell_started) {
@@ -177,10 +177,10 @@ static int cmd_ivshmem_get_notified(const struct shell *shell,
 			&doorbell_thread,
 			doorbell_stack, STACK_SIZE,
 			(k_thread_entry_t)doorbell_notification_thread,
-			(void *)shell, NULL, NULL,
+			(void *)sh, NULL, NULL,
 			K_PRIO_COOP(2), 0, K_NO_WAIT);
 		if (!tid) {
-			shell_error(shell, "Cannot start notification thread");
+			shell_error(sh, "Cannot start notification thread");
 			return -ENOEXEC;
 		}
 
@@ -191,7 +191,7 @@ static int cmd_ivshmem_get_notified(const struct shell *shell,
 		doorbell_started = true;
 	}
 #else
-	shell_error(shell, "CONFIG_IVSHMEM_DOORBELL is not enabled");
+	shell_error(sh, "CONFIG_IVSHMEM_DOORBELL is not enabled");
 #endif
 	return 0;
 }

--- a/drivers/wifi/eswifi/eswifi_shell.c
+++ b/drivers/wifi/eswifi/eswifi_shell.c
@@ -21,18 +21,18 @@ void eswifi_shell_register(struct eswifi_dev *dev)
 	eswifi = dev;
 }
 
-static int eswifi_shell_atcmd(const struct shell *shell, size_t argc,
+static int eswifi_shell_atcmd(const struct shell *sh, size_t argc,
 			      char **argv)
 {
 	int i;
 
 	if (eswifi == NULL) {
-		shell_print(shell, "no eswifi device registered");
+		shell_print(sh, "no eswifi device registered");
 		return -ENOEXEC;
 	}
 
 	if (argc < 2) {
-		shell_help(shell);
+		shell_help(sh);
 		return -ENOEXEC;
 	}
 
@@ -44,9 +44,9 @@ static int eswifi_shell_atcmd(const struct shell *shell, size_t argc,
 	}
 	strcat(eswifi->buf, "\r");
 
-	shell_print(shell, "> %s", eswifi->buf);
+	shell_print(sh, "> %s", eswifi->buf);
 	eswifi_at_cmd(eswifi, eswifi->buf);
-	shell_print(shell, "< %s", eswifi->buf);
+	shell_print(sh, "< %s", eswifi->buf);
 
 	eswifi_unlock(eswifi);
 

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -127,7 +127,7 @@ const struct device *shell_device_lookup(size_t idx,
 /**
  * @brief Shell command handler prototype.
  *
- * @param shell Shell instance.
+ * @param sh Shell instance.
  * @param argc  Arguments count.
  * @param argv  Arguments.
  *
@@ -136,13 +136,13 @@ const struct device *shell_device_lookup(size_t idx,
  * @retval -EINVAL Argument validation failed.
  * @retval -ENOEXEC Command not executed.
  */
-typedef int (*shell_cmd_handler)(const struct shell *shell,
+typedef int (*shell_cmd_handler)(const struct shell *sh,
 				 size_t argc, char **argv);
 
 /**
  * @brief Shell dictionary command handler prototype.
  *
- * @param shell Shell instance.
+ * @param sh Shell instance.
  * @param argc  Arguments count.
  * @param argv  Arguments.
  * @param data  Pointer to the user data.
@@ -152,7 +152,7 @@ typedef int (*shell_cmd_handler)(const struct shell *shell,
  * @retval -EINVAL Argument validation failed.
  * @retval -ENOEXEC Command not executed.
  */
-typedef int (*shell_dict_cmd_handler)(const struct shell *shell, size_t argc,
+typedef int (*shell_dict_cmd_handler)(const struct shell *sh, size_t argc,
 				      char **argv, void *data);
 
 /* When entries are added to the memory section a padding is applied for
@@ -502,9 +502,9 @@ struct shell_static_entry {
 #define Z_SHELL_CMD_DICT_HANDLER_CREATE(_data, _handler)		\
 static int UTIL_CAT(UTIL_CAT(cmd_dict_, UTIL_CAT(_handler, _)),		\
 			GET_ARG_N(1, __DEBRACKET _data))(		\
-		const struct shell *shell, size_t argc, char **argv)	\
+		const struct shell *sh, size_t argc, char **argv)	\
 {									\
-	return _handler(shell, argc, argv,				\
+	return _handler(sh, argc, argv,					\
 			(void *)GET_ARG_N(2, __DEBRACKET _data));	\
 }
 
@@ -530,12 +530,12 @@ static int UTIL_CAT(UTIL_CAT(cmd_dict_, UTIL_CAT(_handler, _)),		\
  *			passed to the _handler as user data.
  *
  * Example usage:
- *	static int my_handler(const struct shell *shell,
+ *	static int my_handler(const struct shell *sh,
  *			      size_t argc, char **argv, void *data)
  *	{
  *		int val = (int)data;
  *
- *		shell_print(shell, "(syntax, value) : (%s, %d)", argv[0], val);
+ *		shell_print(sh, "(syntax, value) : (%s, %d)", argv[0], val);
  *		return 0;
  *	}
  *
@@ -585,15 +585,15 @@ typedef void (*shell_transport_handler_t)(enum shell_transport_evt evt,
 					  void *context);
 
 
-typedef void (*shell_uninit_cb_t)(const struct shell *shell, int res);
+typedef void (*shell_uninit_cb_t)(const struct shell *sh, int res);
 
 /** @brief Bypass callback.
  *
- * @param shell Shell instance.
+ * @param sh Shell instance.
  * @param data  Raw data from transport.
  * @param len   Data length.
  */
-typedef void (*shell_bypass_cb_t)(const struct shell *shell,
+typedef void (*shell_bypass_cb_t)(const struct shell *sh,
 				  uint8_t *data,
 				  size_t len);
 
@@ -910,7 +910,7 @@ extern void z_shell_print_stream(const void *user_ctx, const char *data,
 /**
  * @brief Function for initializing a transport layer and internal shell state.
  *
- * @param[in] shell		Pointer to shell instance.
+ * @param[in] sh		Pointer to shell instance.
  * @param[in] transport_config	Transport configuration during initialization.
  * @param[in] cfg_flags		Initial backend configuration flags.
  *				Shell will copy this data.
@@ -920,35 +920,35 @@ extern void z_shell_print_stream(const void *user_ctx, const char *data,
  *
  * @return Standard error code.
  */
-int shell_init(const struct shell *shell, const void *transport_config,
+int shell_init(const struct shell *sh, const void *transport_config,
 	       struct shell_backend_config_flags cfg_flags,
 	       bool log_backend, uint32_t init_log_level);
 
 /**
  * @brief Uninitializes the transport layer and the internal shell state.
  *
- * @param shell Pointer to shell instance.
+ * @param sh Pointer to shell instance.
  * @param cb Callback called when uninitialization is completed.
  */
-void shell_uninit(const struct shell *shell, shell_uninit_cb_t cb);
+void shell_uninit(const struct shell *sh, shell_uninit_cb_t cb);
 
 /**
  * @brief Function for starting shell processing.
  *
- * @param shell Pointer to the shell instance.
+ * @param sh Pointer to the shell instance.
  *
  * @return Standard error code.
  */
-int shell_start(const struct shell *shell);
+int shell_start(const struct shell *sh);
 
 /**
  * @brief Function for stopping shell processing.
  *
- * @param shell Pointer to shell instance.
+ * @param sh Pointer to shell instance.
  *
  * @return Standard error code.
  */
-int shell_stop(const struct shell *shell);
+int shell_stop(const struct shell *sh);
 
 /**
  * @brief Terminal default text color for shell_fprintf function.
@@ -981,12 +981,12 @@ int shell_stop(const struct shell *shell);
  * This function can be used from the command handler or from threads, but not
  * from an interrupt context.
  *
- * @param[in] shell	Pointer to the shell instance.
+ * @param[in] sh	Pointer to the shell instance.
  * @param[in] color	Printed text color.
  * @param[in] fmt	Format string.
  * @param[in] ...	List of parameters to print.
  */
-void __printf_like(3, 4) shell_fprintf(const struct shell *shell,
+void __printf_like(3, 4) shell_fprintf(const struct shell *sh,
 				       enum shell_vt100_color color,
 				       const char *fmt, ...);
 
@@ -997,12 +997,12 @@ void __printf_like(3, 4) shell_fprintf(const struct shell *shell,
  * from an interrupt context. It is similar to shell_fprintf() but takes a
  * va_list instead of variable arguments.
  *
- * @param[in] shell	Pointer to the shell instance.
+ * @param[in] sh	Pointer to the shell instance.
  * @param[in] color	Printed text color.
  * @param[in] fmt	Format string.
  * @param[in] args	List of parameters to print.
  */
-void shell_vfprintf(const struct shell *shell, enum shell_vt100_color color,
+void shell_vfprintf(const struct shell *sh, enum shell_vt100_color color,
 		   const char *fmt, va_list args);
 
 /**
@@ -1015,22 +1015,22 @@ void shell_vfprintf(const struct shell *shell, enum shell_vt100_color color,
  * 00008010: 20 25 00 20 2f 48 00 08  80 05 00 20 af 46 00
  *	| %. /H.. ... .F. |
  *
- * @param[in] shell	Pointer to the shell instance.
+ * @param[in] sh	Pointer to the shell instance.
  * @param[in] offset	Offset to show for this line.
  * @param[in] data	Pointer to data.
  * @param[in] len	Length of data.
  */
-void shell_hexdump_line(const struct shell *shell, unsigned int offset,
+void shell_hexdump_line(const struct shell *sh, unsigned int offset,
 			const uint8_t *data, size_t len);
 
 /**
  * @brief Print data in hexadecimal format.
  *
- * @param[in] shell	Pointer to the shell instance.
+ * @param[in] sh	Pointer to the shell instance.
  * @param[in] data	Pointer to data.
  * @param[in] len	Length of data.
  */
-void shell_hexdump(const struct shell *shell, const uint8_t *data, size_t len);
+void shell_hexdump(const struct shell *sh, const uint8_t *data, size_t len);
 
 /**
  * @brief Print info message to the shell.
@@ -1084,20 +1084,20 @@ void shell_hexdump(const struct shell *shell, const uint8_t *data, size_t len);
  * @brief Process function, which should be executed when data is ready in the
  *	  transport interface. To be used if shell thread is disabled.
  *
- * @param[in] shell Pointer to the shell instance.
+ * @param[in] sh Pointer to the shell instance.
  */
-void shell_process(const struct shell *shell);
+void shell_process(const struct shell *sh);
 
 /**
  * @brief Change displayed shell prompt.
  *
- * @param[in] shell	Pointer to the shell instance.
+ * @param[in] sh	Pointer to the shell instance.
  * @param[in] prompt	New shell prompt.
  *
  * @return 0		Success.
  * @return -EINVAL	Pointer to new prompt is not correct.
  */
-int shell_prompt_change(const struct shell *shell, const char *prompt);
+int shell_prompt_change(const struct shell *sh, const char *prompt);
 
 /**
  * @brief Prints the current command help.
@@ -1105,9 +1105,9 @@ int shell_prompt_change(const struct shell *shell, const char *prompt);
  * Function will print a help string with: the currently entered command
  * and subcommands (if they exist).
  *
- * @param[in] shell      Pointer to the shell instance.
+ * @param[in] sh      Pointer to the shell instance.
  */
-void shell_help(const struct shell *shell);
+void shell_help(const struct shell *sh);
 
 /* @brief Command's help has been printed */
 #define SHELL_CMD_HELP_PRINTED	(1)
@@ -1122,14 +1122,14 @@ void shell_help(const struct shell *shell);
  *	 This function must not be called from shell command context!
 
  *
- * @param[in] shell	Pointer to the shell instance.
+ * @param[in] sh	Pointer to the shell instance.
  *			It can be NULL when the
  *			@kconfig{CONFIG_SHELL_BACKEND_DUMMY} option is enabled.
  * @param[in] cmd	Command to be executed.
  *
  * @return		Result of the execution
  */
-int shell_execute_cmd(const struct shell *shell, const char *cmd);
+int shell_execute_cmd(const struct shell *sh, const char *cmd);
 
 /** @brief Set root command for all shell instances.
  *
@@ -1149,10 +1149,10 @@ int shell_set_root_cmd(const char *cmd);
  * Bypass callback is called whenever data is received. Shell is bypassed and
  * data is passed directly to the callback. Use null to disable bypass functionality.
  *
- * @param[in] shell	Pointer to the shell instance.
+ * @param[in] sh	Pointer to the shell instance.
  * @param[in] bypass	Bypass callback or null to disable.
  */
-void shell_set_bypass(const struct shell *shell, shell_bypass_cb_t bypass);
+void shell_set_bypass(const struct shell *sh, shell_bypass_cb_t bypass);
 
 /** @brief Get shell readiness to execute commands.
  *
@@ -1167,26 +1167,26 @@ bool shell_ready(const struct shell *sh);
  * @brief Allow application to control text insert mode.
  * Value is modified atomically and the previous value is returned.
  *
- * @param[in] shell	Pointer to the shell instance.
+ * @param[in] sh	Pointer to the shell instance.
  * @param[in] val	Insert mode.
  *
  * @retval 0 or 1: previous value
  * @retval -EINVAL if shell is NULL.
  */
-int shell_insert_mode_set(const struct shell *shell, bool val);
+int shell_insert_mode_set(const struct shell *sh, bool val);
 
 /**
  * @brief Allow application to control whether terminal output uses colored
  * syntax.
  * Value is modified atomically and the previous value is returned.
  *
- * @param[in] shell	Pointer to the shell instance.
+ * @param[in] sh	Pointer to the shell instance.
  * @param[in] val	Color mode.
  *
  * @retval 0 or 1: previous value
  * @retval -EINVAL if shell is NULL.
  */
-int shell_use_colors_set(const struct shell *shell, bool val);
+int shell_use_colors_set(const struct shell *sh, bool val);
 
 /**
  * @brief Allow application to control whether terminal is using vt100 commands.
@@ -1204,39 +1204,39 @@ int shell_use_vt100_set(const struct shell *sh, bool val);
  * @brief Allow application to control whether user input is echoed back.
  * Value is modified atomically and the previous value is returned.
  *
- * @param[in] shell	Pointer to the shell instance.
+ * @param[in] sh	Pointer to the shell instance.
  * @param[in] val	Echo mode.
  *
  * @retval 0 or 1: previous value
  * @retval -EINVAL if shell is NULL.
  */
-int shell_echo_set(const struct shell *shell, bool val);
+int shell_echo_set(const struct shell *sh, bool val);
 
 /**
  * @brief Allow application to control whether user input is obscured with
  * asterisks -- useful for implementing passwords.
  * Value is modified atomically and the previous value is returned.
  *
- * @param[in] shell	Pointer to the shell instance.
+ * @param[in] sh	Pointer to the shell instance.
  * @param[in] obscure	Obscure mode.
  *
  * @retval 0 or 1: previous value.
  * @retval -EINVAL if shell is NULL.
  */
-int shell_obscure_set(const struct shell *shell, bool obscure);
+int shell_obscure_set(const struct shell *sh, bool obscure);
 
 /**
  * @brief Allow application to control whether the delete key backspaces or
  * deletes.
  * Value is modified atomically and the previous value is returned.
  *
- * @param[in] shell	Pointer to the shell instance.
+ * @param[in] sh	Pointer to the shell instance.
  * @param[in] val	Delete mode.
  *
  * @retval 0 or 1: previous value
  * @retval -EINVAL if shell is NULL.
  */
-int shell_mode_delete_set(const struct shell *shell, bool val);
+int shell_mode_delete_set(const struct shell *sh, bool val);
 
 /**
  * @}

--- a/include/zephyr/shell/shell_dummy.h
+++ b/include/zephyr/shell/shell_dummy.h
@@ -50,19 +50,19 @@ const struct shell *shell_backend_dummy_get_ptr(void);
  *
  * The returned data is always followed by a nul character at position *sizep
  *
- * @param shell	Shell pointer
+ * @param sh	Shell pointer
  * @param sizep	Returns size of data in shell buffer
  * @returns pointer to buffer containing shell output
  */
-const char *shell_backend_dummy_get_output(const struct shell *shell,
+const char *shell_backend_dummy_get_output(const struct shell *sh,
 					   size_t *sizep);
 
 /**
  * @brief Clears the output buffer in the shell backend.
  *
- * @param shell	Shell pointer
+ * @param sh	Shell pointer
  */
-void shell_backend_dummy_clear_output(const struct shell *shell);
+void shell_backend_dummy_clear_output(const struct shell *sh);
 
 #ifdef __cplusplus
 }

--- a/lib/posix/getopt/README
+++ b/lib/posix/getopt/README
@@ -30,7 +30,7 @@ Description:
 
    This module is intended to be used inside the shell command handler
    by the abstraction layer "SHELL_GETOPT". For example:
-   while ((char c = shell_getopt(shell, argc, argv, "abhc:")) != -1) {
+   while ((char c = shell_getopt(sh, argc, argv, "abhc:")) != -1) {
       /* some code */
    }
    ]

--- a/modules/openthread/platform/shell.c
+++ b/modules/openthread/platform/shell.c
@@ -39,7 +39,7 @@ static int ot_console_cb(void *context, const char *format, va_list arg)
 #define SHELL_HELP_OT	"OpenThread subcommands\n" \
 			"Use \"ot help\" to get the list of subcommands"
 
-static int ot_cmd(const struct shell *shell, size_t argc, char *argv[])
+static int ot_cmd(const struct shell *sh, size_t argc, char *argv[])
 {
 	char *buf_ptr = rx_buffer;
 	size_t buf_len = OT_SHELL_BUFFER_SIZE;
@@ -62,7 +62,7 @@ static int ot_cmd(const struct shell *shell, size_t argc, char *argv[])
 		arg_len = snprintk(buf_ptr, buf_len, "%s", argv[i]);
 
 		if (arg_len >= buf_len) {
-			shell_fprintf(shell, SHELL_WARNING,
+			shell_fprintf(sh, SHELL_WARNING,
 				      "OT shell buffer full\n");
 			return -ENOEXEC;
 		}
@@ -72,7 +72,7 @@ static int ot_cmd(const struct shell *shell, size_t argc, char *argv[])
 		buf_len -= arg_len;
 	}
 
-	shell_p = shell;
+	shell_p = sh;
 
 	openthread_api_mutex_lock(openthread_get_default_context());
 	otCliInputLine(rx_buffer);

--- a/samples/arch/mpu/mpu_test/src/main.c
+++ b/samples/arch/mpu/mpu_test/src/main.c
@@ -12,10 +12,10 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/shell/shell.h>
 
-#define PR_SHELL(shell, fmt, ...)				\
-	shell_fprintf(shell, SHELL_NORMAL, fmt, ##__VA_ARGS__)
-#define PR_ERROR(shell, fmt, ...)				\
-	shell_fprintf(shell, SHELL_ERROR, fmt, ##__VA_ARGS__)
+#define PR_SHELL(sh, fmt, ...)				\
+	shell_fprintf(sh, SHELL_NORMAL, fmt, ##__VA_ARGS__)
+#define PR_ERROR(sh, fmt, ...)				\
+	shell_fprintf(sh, SHELL_ERROR, fmt, ##__VA_ARGS__)
 
 /* Assumption: our devices have less than 64MB of memory */
 #define RESERVED_MEM_MAP (CONFIG_SRAM_BASE_ADDRESS + 0x4000000)
@@ -34,7 +34,7 @@
 static const struct device *const flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 #endif
 
-static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_read(const struct shell *sh, size_t argc, char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
@@ -42,13 +42,13 @@ static int cmd_read(const struct shell *shell, size_t argc, char *argv[])
 	uint32_t *p_mem = (uint32_t *) RESERVED_MEM_MAP;
 
 	/* Reads from an address that is reserved in the memory map */
-	PR_SHELL(shell, "The value is: %d\n", *p_mem);
+	PR_SHELL(sh, "The value is: %d\n", *p_mem);
 
 	return 0;
 }
 
 #if defined(CONFIG_SOC_FLASH_MCUX) || defined(CONFIG_SOC_FLASH_LPC)
-static int cmd_write_mcux(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_write_mcux(const struct shell *sh, size_t argc, char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
@@ -61,11 +61,11 @@ static int cmd_write_mcux(const struct shell *shell, size_t argc, char *argv[])
 	value[0] = 0xBADC0DE;
 	value[1] = 0xBADC0DE;
 
-	PR_SHELL(shell, "write address: 0x%x\n", offset);
+	PR_SHELL(sh, "write address: 0x%x\n", offset);
 
 	if (flash_write(flash_dev, offset, value,
 				sizeof(value)) != 0) {
-		PR_ERROR(shell, "Flash write failed!\n");
+		PR_ERROR(sh, "Flash write failed!\n");
 		return 1;
 	}
 
@@ -73,7 +73,7 @@ static int cmd_write_mcux(const struct shell *shell, size_t argc, char *argv[])
 
 }
 #elif defined(CONFIG_SOC_FLASH_STM32)
-static int cmd_write_stm32(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_write_stm32(const struct shell *sh, size_t argc, char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
@@ -82,17 +82,17 @@ static int cmd_write_stm32(const struct shell *shell, size_t argc, char *argv[])
 	uint32_t offset = FLASH_MEM + 0x4000;
 	uint32_t value = 0xBADC0DE;
 
-	PR_SHELL(shell, "write address: 0x%x\n", offset);
+	PR_SHELL(sh, "write address: 0x%x\n", offset);
 
 	if (flash_write(flash_dev, offset, &value, sizeof(value)) != 0) {
-		PR_ERROR(shell, "Flash write failed!\n");
+		PR_ERROR(sh, "Flash write failed!\n");
 		return 1;
 	}
 
 	return 0;
 }
 #else
-static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_write(const struct shell *sh, size_t argc, char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
@@ -100,7 +100,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 	/* 16K reserved to the application */
 	uint32_t *p_mem = (uint32_t *) (FLASH_MEM + 0x4000);
 
-	PR_SHELL(shell, "write address: 0x%x\n", FLASH_MEM + 0x4000);
+	PR_SHELL(sh, "write address: 0x%x\n", FLASH_MEM + 0x4000);
 
 	/* Write in to boot FLASH/ROM */
 	*p_mem = 0xBADC0DE;
@@ -109,7 +109,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char *argv[])
 }
 #endif /* SOC_FLASH_MCUX || SOC_FLASH_LPC */
 
-static int cmd_run(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_run(const struct shell *sh, size_t argc, char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
@@ -122,7 +122,7 @@ static int cmd_run(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
-static int cmd_mtest(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_mtest(const struct shell *sh, size_t argc, char *argv[])
 {
 	uint32_t *mem;
 	uint32_t val;
@@ -131,7 +131,7 @@ static int cmd_mtest(const struct shell *shell, size_t argc, char *argv[])
 	mem = (uint32_t *) val;
 
 	if (argc == 2) {
-		PR_SHELL(shell, "The value is: 0x%x\n", *mem);
+		PR_SHELL(sh, "The value is: 0x%x\n", *mem);
 	} else {
 		*mem = (uint32_t) strtol(argv[2], NULL, 16);
 	}

--- a/samples/net/gsm_modem/src/main.c
+++ b/samples/net/gsm_modem/src/main.c
@@ -24,14 +24,14 @@ static const struct device *const gsm_dev = DEVICE_DT_GET(GSM_MODEM_NODE);
 static struct net_mgmt_event_callback mgmt_cb;
 static bool starting = IS_ENABLED(CONFIG_GSM_PPP_AUTOSTART);
 
-static int cmd_sample_modem_suspend(const struct shell *shell,
+static int cmd_sample_modem_suspend(const struct shell *sh,
 				    size_t argc, char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	if (!starting) {
-		shell_fprintf(shell, SHELL_NORMAL, "Modem is already stopped.\n");
+		shell_fprintf(sh, SHELL_NORMAL, "Modem is already stopped.\n");
 		return -ENOEXEC;
 	}
 
@@ -41,14 +41,14 @@ static int cmd_sample_modem_suspend(const struct shell *shell,
 	return 0;
 }
 
-static int cmd_sample_modem_resume(const struct shell *shell,
+static int cmd_sample_modem_resume(const struct shell *sh,
 				   size_t argc, char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	if (starting) {
-		shell_fprintf(shell, SHELL_NORMAL, "Modem is already started.\n");
+		shell_fprintf(sh, SHELL_NORMAL, "Modem is already started.\n");
 		return -ENOEXEC;
 	}
 

--- a/samples/net/promiscuous_mode/src/main.c
+++ b/samples/net/promiscuous_mode/src/main.c
@@ -152,7 +152,7 @@ static void print_info(struct net_pkt *pkt)
 	}
 }
 
-static int set_promisc_mode(const struct shell *shell,
+static int set_promisc_mode(const struct shell *sh,
 			    size_t argc, char *argv[], bool enable)
 {
 	struct net_if *iface;
@@ -160,7 +160,7 @@ static int set_promisc_mode(const struct shell *shell,
 	int idx, ret;
 
 	if (argc < 2) {
-		shell_fprintf(shell, SHELL_ERROR, "Invalid arguments.\n");
+		shell_fprintf(sh, SHELL_ERROR, "Invalid arguments.\n");
 		return -ENOEXEC;
 	}
 
@@ -168,13 +168,13 @@ static int set_promisc_mode(const struct shell *shell,
 
 	iface = net_if_get_by_index(idx);
 	if (!iface) {
-		shell_fprintf(shell, SHELL_ERROR,
+		shell_fprintf(sh, SHELL_ERROR,
 			      "Cannot find network interface for index %d\n",
 			      idx);
 		return -ENOEXEC;
 	}
 
-	shell_fprintf(shell, SHELL_INFO, "Promiscuous mode %s...\n",
+	shell_fprintf(sh, SHELL_INFO, "Promiscuous mode %s...\n",
 		      enable ? "ON" : "OFF");
 
 	if (enable) {
@@ -185,11 +185,11 @@ static int set_promisc_mode(const struct shell *shell,
 
 	if (ret < 0) {
 		if (ret == -EALREADY) {
-			shell_fprintf(shell, SHELL_INFO,
+			shell_fprintf(sh, SHELL_INFO,
 				      "Promiscuous mode already %s\n",
 				      enable ? "enabled" : "disabled");
 		} else {
-			shell_fprintf(shell, SHELL_ERROR,
+			shell_fprintf(sh, SHELL_ERROR,
 				      "Cannot %s promiscuous mode for "
 				      "interface %p (%d)\n",
 				      enable ? "set" : "unset", iface, ret);
@@ -201,16 +201,16 @@ static int set_promisc_mode(const struct shell *shell,
 	return 0;
 }
 
-static int cmd_promisc_on(const struct shell *shell,
+static int cmd_promisc_on(const struct shell *sh,
 			  size_t argc, char *argv[])
 {
-	return set_promisc_mode(shell, argc, argv, true);
+	return set_promisc_mode(sh, argc, argv, true);
 }
 
-static int cmd_promisc_off(const struct shell *shell,
+static int cmd_promisc_off(const struct shell *sh,
 			   size_t argc, char *argv[])
 {
-	return set_promisc_mode(shell, argc, argv, false);
+	return set_promisc_mode(sh, argc, argv, false);
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(promisc_commands,

--- a/samples/net/sockets/echo_server/src/echo-server.c
+++ b/samples/net/sockets/echo_server/src/echo-server.c
@@ -205,7 +205,7 @@ static void init_app(void)
 	init_usb();
 }
 
-static int cmd_sample_quit(const struct shell *shell,
+static int cmd_sample_quit(const struct shell *sh,
 			  size_t argc, char *argv[])
 {
 	want_to_quit = true;

--- a/samples/net/sockets/txtime/src/main.c
+++ b/samples/net/sockets/txtime/src/main.c
@@ -490,7 +490,7 @@ static void set_qbv_params(struct net_if *iface)
 	}
 }
 
-static int cmd_sample_quit(const struct shell *shell,
+static int cmd_sample_quit(const struct shell *sh,
 			  size_t argc, char *argv[])
 {
 	want_to_quit = true;

--- a/samples/subsys/shell/shell_module/src/dynamic_cmd.c
+++ b/samples/subsys/shell/shell_module/src/dynamic_cmd.c
@@ -26,7 +26,7 @@ static int string_cmp(const void *p_a, const void *p_b)
 	return strcmp((const char *)p_a, (const char *)p_b);
 }
 
-static int cmd_dynamic_add(const struct shell *shell,
+static int cmd_dynamic_add(const struct shell *sh,
 			   size_t argc, char **argv)
 {
 	uint16_t cmd_len;
@@ -35,20 +35,20 @@ static int cmd_dynamic_add(const struct shell *shell,
 	ARG_UNUSED(argc);
 
 	if (dynamic_cmd_cnt >= MAX_CMD_CNT) {
-		shell_error(shell, "command limit reached");
+		shell_error(sh, "command limit reached");
 		return -ENOEXEC;
 	}
 
 	cmd_len = strlen(argv[1]);
 
 	if (cmd_len >= MAX_CMD_LEN) {
-		shell_error(shell, "too long command");
+		shell_error(sh, "too long command");
 		return -ENOEXEC;
 	}
 
 	for (idx = 0U; idx < cmd_len; idx++) {
 		if (isalnum((int)(argv[1][idx])) == 0) {
-			shell_error(shell,
+			shell_error(sh,
 				    "bad command name - please use only"
 				    " alphanumerical characters");
 			return -ENOEXEC;
@@ -57,7 +57,7 @@ static int cmd_dynamic_add(const struct shell *shell,
 
 	for (idx = 0U; idx < MAX_CMD_CNT; idx++) {
 		if (!strcmp(dynamic_cmd_buffer[idx], argv[1])) {
-			shell_error(shell, "duplicated command");
+			shell_error(sh, "duplicated command");
 			return -ENOEXEC;
 		}
 	}
@@ -67,12 +67,12 @@ static int cmd_dynamic_add(const struct shell *shell,
 	qsort(dynamic_cmd_buffer, dynamic_cmd_cnt,
 	      sizeof(dynamic_cmd_buffer[0]), string_cmp);
 
-	shell_print(shell, "command added successfully");
+	shell_print(sh, "command added successfully");
 
 	return 0;
 }
 
-static int cmd_dynamic_execute(const struct shell *shell,
+static int cmd_dynamic_execute(const struct shell *sh,
 			       size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
@@ -80,17 +80,17 @@ static int cmd_dynamic_execute(const struct shell *shell,
 
 	for (uint8_t idx = 0; idx <  dynamic_cmd_cnt; idx++) {
 		if (!strcmp(dynamic_cmd_buffer[idx], argv[1])) {
-			shell_print(shell, "dynamic command: %s", argv[1]);
+			shell_print(sh, "dynamic command: %s", argv[1]);
 			return 0;
 		}
 	}
 
-	shell_error(shell, "%s: unknown parameter: %s", argv[0], argv[1]);
+	shell_error(sh, "%s: unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;
 }
 
-static int cmd_dynamic_remove(const struct shell *shell, size_t argc,
+static int cmd_dynamic_remove(const struct shell *sh, size_t argc,
 			      char **argv)
 {
 	ARG_UNUSED(argc);
@@ -108,30 +108,30 @@ static int cmd_dynamic_remove(const struct shell *shell, size_t argc,
 			}
 
 			--dynamic_cmd_cnt;
-			shell_print(shell, "command removed successfully");
+			shell_print(sh, "command removed successfully");
 			return 0;
 		}
 	}
-	shell_error(shell, "did not find command: %s", argv[1]);
+	shell_error(sh, "did not find command: %s", argv[1]);
 
 	return -ENOEXEC;
 }
 
-static int cmd_dynamic_show(const struct shell *shell,
+static int cmd_dynamic_show(const struct shell *sh,
 			    size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	if (dynamic_cmd_cnt == 0U) {
-		shell_warn(shell, "Please add some commands first.");
+		shell_warn(sh, "Please add some commands first.");
 		return -ENOEXEC;
 	}
 
-	shell_print(shell, "Dynamic command list:");
+	shell_print(sh, "Dynamic command list:");
 
 	for (uint8_t i = 0; i < dynamic_cmd_cnt; i++) {
-		shell_print(shell, "[%3d] %s", i, dynamic_cmd_buffer[i]);
+		shell_print(sh, "[%3d] %s", i, dynamic_cmd_buffer[i]);
 	}
 
 	return 0;

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -33,37 +33,37 @@ void timer_expired_handler(struct k_timer *timer)
 
 K_TIMER_DEFINE(log_timer, timer_expired_handler, NULL);
 
-static int cmd_log_test_start(const struct shell *shell, size_t argc,
+static int cmd_log_test_start(const struct shell *sh, size_t argc,
 			      char **argv, uint32_t period)
 {
 	ARG_UNUSED(argv);
 
 	k_timer_start(&log_timer, K_MSEC(period), K_MSEC(period));
-	shell_print(shell, "Log test started\n");
+	shell_print(sh, "Log test started\n");
 
 	return 0;
 }
 
-static int cmd_log_test_start_demo(const struct shell *shell, size_t argc,
+static int cmd_log_test_start_demo(const struct shell *sh, size_t argc,
 				   char **argv)
 {
-	return cmd_log_test_start(shell, argc, argv, 200);
+	return cmd_log_test_start(sh, argc, argv, 200);
 }
 
-static int cmd_log_test_start_flood(const struct shell *shell, size_t argc,
+static int cmd_log_test_start_flood(const struct shell *sh, size_t argc,
 				    char **argv)
 {
-	return cmd_log_test_start(shell, argc, argv, 10);
+	return cmd_log_test_start(sh, argc, argv, 10);
 }
 
-static int cmd_log_test_stop(const struct shell *shell, size_t argc,
+static int cmd_log_test_stop(const struct shell *sh, size_t argc,
 			     char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	k_timer_stop(&log_timer);
-	shell_print(shell, "Log test stopped");
+	shell_print(sh, "Log test stopped");
 
 	return 0;
 }
@@ -85,12 +85,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_log_test,
 
 SHELL_CMD_REGISTER(log_test, &sub_log_test, "Log test", NULL);
 
-static int cmd_demo_ping(const struct shell *shell, size_t argc, char **argv)
+static int cmd_demo_ping(const struct shell *sh, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(shell, "pong");
+	shell_print(sh, "pong");
 
 	return 0;
 }
@@ -209,33 +209,33 @@ static int cmd_demo_getopt(const struct shell *sh, size_t argc,
 }
 #endif
 
-static int cmd_demo_params(const struct shell *shell, size_t argc, char **argv)
+static int cmd_demo_params(const struct shell *sh, size_t argc, char **argv)
 {
-	shell_print(shell, "argc = %zd", argc);
+	shell_print(sh, "argc = %zd", argc);
 	for (size_t cnt = 0; cnt < argc; cnt++) {
-		shell_print(shell, "  argv[%zd] = %s", cnt, argv[cnt]);
+		shell_print(sh, "  argv[%zd] = %s", cnt, argv[cnt]);
 	}
 
 	return 0;
 }
 
-static int cmd_demo_hexdump(const struct shell *shell, size_t argc, char **argv)
+static int cmd_demo_hexdump(const struct shell *sh, size_t argc, char **argv)
 {
-	shell_print(shell, "argc = %zd", argc);
+	shell_print(sh, "argc = %zd", argc);
 	for (size_t cnt = 0; cnt < argc; cnt++) {
-		shell_print(shell, "argv[%zd]", cnt);
-		shell_hexdump(shell, argv[cnt], strlen(argv[cnt]));
+		shell_print(sh, "argv[%zd]", cnt);
+		shell_hexdump(sh, argv[cnt], strlen(argv[cnt]));
 	}
 
 	return 0;
 }
 
-static int cmd_version(const struct shell *shell, size_t argc, char **argv)
+static int cmd_version(const struct shell *sh, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(shell, "Zephyr version %s", KERNEL_VERSION_STRING);
+	shell_print(sh, "Zephyr version %s", KERNEL_VERSION_STRING);
 
 	return 0;
 }
@@ -256,12 +256,12 @@ static int check_passwd(char *passwd)
 	return strcmp(passwd, DEFAULT_PASSWORD);
 }
 
-static int cmd_login(const struct shell *shell, size_t argc, char **argv)
+static int cmd_login(const struct shell *sh, size_t argc, char **argv)
 {
 	static uint32_t attempts;
 
 	if (check_passwd(argv[1]) != 0) {
-		shell_error(shell, "Incorrect password!");
+		shell_error(sh, "Incorrect password!");
 		attempts++;
 		if (attempts > 3) {
 			k_sleep(K_SECONDS(attempts));
@@ -270,22 +270,22 @@ static int cmd_login(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	/* clear history so password not visible there */
-	z_shell_history_purge(shell->history);
-	shell_obscure_set(shell, false);
+	z_shell_history_purge(sh->history);
+	shell_obscure_set(sh, false);
 	shell_set_root_cmd(NULL);
-	shell_prompt_change(shell, "uart:~$ ");
-	shell_print(shell, "Shell Login Demo\n");
-	shell_print(shell, "Hit tab for help.\n");
+	shell_prompt_change(sh, "uart:~$ ");
+	shell_print(sh, "Shell Login Demo\n");
+	shell_print(sh, "Hit tab for help.\n");
 	attempts = 0;
 	return 0;
 }
 
-static int cmd_logout(const struct shell *shell, size_t argc, char **argv)
+static int cmd_logout(const struct shell *sh, size_t argc, char **argv)
 {
 	shell_set_root_cmd("login");
-	shell_obscure_set(shell, true);
-	shell_prompt_change(shell, "login: ");
-	shell_print(shell, "\n");
+	shell_obscure_set(sh, true);
+	shell_prompt_change(sh, "login: ");
+	shell_print(sh, "\n");
 	return 0;
 }
 
@@ -358,12 +358,12 @@ static int cmd_bypass(const struct shell *sh, size_t argc, char **argv)
 	return set_bypass(sh, bypass_cb);
 }
 
-static int cmd_dict(const struct shell *shell, size_t argc, char **argv,
+static int cmd_dict(const struct shell *sh, size_t argc, char **argv,
 		    void *data)
 {
 	int val = (intptr_t)data;
 
-	shell_print(shell, "(syntax, value) : (%s, %d)", argv[0], val);
+	shell_print(sh, "(syntax, value) : (%s, %d)", argv[0], val);
 
 	return 0;
 }

--- a/samples/subsys/shell/shell_module/src/uart_reinit.c
+++ b/samples/subsys/shell/shell_module/src/uart_reinit.c
@@ -84,7 +84,7 @@ static void uart_poll_timeout(struct k_timer *timer)
 
 K_TIMER_DEFINE(uart_poll_timer, uart_poll_timeout, uart_poll_timer_stopped);
 
-static void shell_uninit_cb(const struct shell *shell, int res)
+static void shell_uninit_cb(const struct shell *sh, int res)
 {
 	__ASSERT_NO_MSG(res >= 0);
 	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
@@ -99,18 +99,18 @@ static void shell_uninit_cb(const struct shell *shell, int res)
 	}
 }
 
-static int cmd_uart_release(const struct shell *shell, size_t argc, char **argv)
+static int cmd_uart_release(const struct shell *sh, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	if (shell != shell_backend_uart_get_ptr()) {
-		shell_error(shell, "Command dedicated for shell over uart");
+	if (sh != shell_backend_uart_get_ptr()) {
+		shell_error(sh, "Command dedicated for shell over uart");
 		return -EINVAL;
 	}
 
-	shell_print(shell, "Uninitializing shell, use 'x' to reinitialize");
-	shell_uninit(shell, shell_uninit_cb);
+	shell_print(sh, "Uninitializing shell, use 'x' to reinitialize");
+	shell_uninit(sh, shell_uninit_cb);
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/shell/utils.h
+++ b/subsys/bluetooth/mesh/shell/utils.h
@@ -36,9 +36,9 @@
 
 bool bt_mesh_shell_mdl_first_get(uint16_t id, struct bt_mesh_model **mod);
 
-int bt_mesh_shell_mdl_instance_set(const struct shell *shell, struct bt_mesh_model **mod,
+int bt_mesh_shell_mdl_instance_set(const struct shell *sh, struct bt_mesh_model **mod,
 			      uint16_t mod_id, uint8_t elem_idx);
 
-int bt_mesh_shell_mdl_print_all(const struct shell *shell, uint16_t mod_id);
+int bt_mesh_shell_mdl_print_all(const struct shell *sh, uint16_t mod_id);
 
-int bt_mesh_shell_mdl_cmds_help(const struct shell *shell, size_t argc, char **argv);
+int bt_mesh_shell_mdl_cmds_help(const struct shell *sh, size_t argc, char **argv);

--- a/subsys/debug/coredump/coredump_backend_flash_partition.c
+++ b/subsys/debug/coredump/coredump_backend_flash_partition.c
@@ -635,21 +635,21 @@ static off_t print_buf_ptr;
 /**
  * @brief Shell command to get backend error.
  *
- * @param shell shell instance
+ * @param sh shell instance
  * @param argc (not used)
  * @param argv (not used)
  * @return 0
  */
-static int cmd_coredump_error_get(const struct shell *shell,
+static int cmd_coredump_error_get(const struct shell *sh,
 				  size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	if (backend_ctx.error == 0) {
-		shell_print(shell, "No error.");
+		shell_print(sh, "No error.");
 	} else {
-		shell_print(shell, "Error: %d", backend_ctx.error);
+		shell_print(sh, "Error: %d", backend_ctx.error);
 	}
 
 	return 0;
@@ -658,17 +658,17 @@ static int cmd_coredump_error_get(const struct shell *shell,
 /**
  * @brief Shell command to clear backend error.
  *
- * @param shell shell instance
+ * @param sh shell instance
  * @param argc (not used)
  * @param argv (not used)
  * @return 0
  */
-static int cmd_coredump_error_clear(const struct shell *shell,
+static int cmd_coredump_error_clear(const struct shell *sh,
 				    size_t argc, char **argv)
 {
 	backend_ctx.error = 0;
 
-	shell_print(shell, "Error cleared.");
+	shell_print(sh, "Error cleared.");
 
 	return 0;
 }
@@ -676,12 +676,12 @@ static int cmd_coredump_error_clear(const struct shell *shell,
 /**
  * @brief Shell command to see if there is a stored coredump in flash.
  *
- * @param shell shell instance
+ * @param sh shell instance
  * @param argc (not used)
  * @param argv (not used)
  * @return 0
  */
-static int cmd_coredump_has_stored_dump(const struct shell *shell,
+static int cmd_coredump_has_stored_dump(const struct shell *sh,
 					size_t argc, char **argv)
 {
 	int ret;
@@ -693,11 +693,11 @@ static int cmd_coredump_has_stored_dump(const struct shell *shell,
 					   NULL);
 
 	if (ret == 1) {
-		shell_print(shell, "Stored coredump found.");
+		shell_print(sh, "Stored coredump found.");
 	} else if (ret == 0) {
-		shell_print(shell, "Stored coredump NOT found.");
+		shell_print(sh, "Stored coredump NOT found.");
 	} else {
-		shell_print(shell, "Failed to perform query: %d", ret);
+		shell_print(sh, "Failed to perform query: %d", ret);
 	}
 
 	return 0;
@@ -706,12 +706,12 @@ static int cmd_coredump_has_stored_dump(const struct shell *shell,
 /**
  * @brief Shell command to verify if the stored coredump is valid.
  *
- * @param shell shell instance
+ * @param sh shell instance
  * @param argc (not used)
  * @param argv (not used)
  * @return 0
  */
-static int cmd_coredump_verify_stored_dump(const struct shell *shell,
+static int cmd_coredump_verify_stored_dump(const struct shell *sh,
 					   size_t argc, char **argv)
 {
 	int ret;
@@ -723,12 +723,12 @@ static int cmd_coredump_verify_stored_dump(const struct shell *shell,
 					 NULL);
 
 	if (ret == 1) {
-		shell_print(shell, "Stored coredump verified.");
+		shell_print(sh, "Stored coredump verified.");
 	} else if (ret == 0) {
-		shell_print(shell, "Stored coredump verification failed "
+		shell_print(sh, "Stored coredump verification failed "
 				   "or there is no stored coredump.");
 	} else {
-		shell_print(shell, "Failed to perform verify command: %d",
+		shell_print(sh, "Failed to perform verify command: %d",
 			    ret);
 	}
 
@@ -740,11 +740,11 @@ static int cmd_coredump_verify_stored_dump(const struct shell *shell,
  *
  * This prints what is in the print buffer to the shell.
  *
- * @param shell shell instance.
+ * @param sh shell instance.
  */
-static void flush_print_buf(const struct shell *shell)
+static void flush_print_buf(const struct shell *sh)
 {
-	shell_print(shell, "%s%s", COREDUMP_PREFIX_STR, print_buf);
+	shell_print(sh, "%s%s", COREDUMP_PREFIX_STR, print_buf);
 	print_buf_ptr = 0;
 	(void)memset(print_buf, 0, sizeof(print_buf));
 }
@@ -765,11 +765,11 @@ static int cb_print_stored_dump(void *arg, uint8_t *buf, size_t len)
 	int ret = 0;
 	size_t i = 0;
 	size_t remaining = len;
-	const struct shell *shell = (const struct shell *)arg;
+	const struct shell *sh = (const struct shell *)arg;
 
 	if (len == 0) {
 		/* Flush print buffer */
-		flush_print_buf(shell);
+		flush_print_buf(sh);
 
 		goto out;
 	}
@@ -794,7 +794,7 @@ static int cb_print_stored_dump(void *arg, uint8_t *buf, size_t len)
 		i++;
 
 		if (print_buf_ptr == PRINT_BUF_SZ) {
-			flush_print_buf(shell);
+			flush_print_buf(sh);
 		}
 	}
 
@@ -805,12 +805,12 @@ out:
 /**
  * @brief Shell command to print stored coredump data to shell
  *
- * @param shell shell instance
+ * @param sh shell instance
  * @param argc (not used)
  * @param argv (not used)
  * @return 0
  */
-static int cmd_coredump_print_stored_dump(const struct shell *shell,
+static int cmd_coredump_print_stored_dump(const struct shell *sh,
 					  size_t argc, char **argv)
 {
 	int ret;
@@ -823,11 +823,11 @@ static int cmd_coredump_print_stored_dump(const struct shell *shell,
 					 NULL);
 
 	if (ret == 0) {
-		shell_print(shell, "Stored coredump verification failed "
+		shell_print(sh, "Stored coredump verification failed "
 				   "or there is no stored coredump.");
 		goto out;
 	} else if (ret != 1) {
-		shell_print(shell, "Failed to perform verify command: %d",
+		shell_print(sh, "Failed to perform verify command: %d",
 			    ret);
 		goto out;
 	}
@@ -836,27 +836,27 @@ static int cmd_coredump_print_stored_dump(const struct shell *shell,
 	print_buf_ptr = 0;
 	(void)memset(print_buf, 0, sizeof(print_buf));
 
-	shell_print(shell, "%s%s", COREDUMP_PREFIX_STR, COREDUMP_BEGIN_STR);
+	shell_print(sh, "%s%s", COREDUMP_PREFIX_STR, COREDUMP_BEGIN_STR);
 
-	ret = process_stored_dump(cb_print_stored_dump, (void *)shell);
+	ret = process_stored_dump(cb_print_stored_dump, (void *)sh);
 	if (print_buf_ptr != 0) {
-		shell_print(shell, "%s%s", COREDUMP_PREFIX_STR, print_buf);
+		shell_print(sh, "%s%s", COREDUMP_PREFIX_STR, print_buf);
 	}
 
 	if (backend_ctx.error != 0) {
-		shell_print(shell, "%s%s", COREDUMP_PREFIX_STR,
+		shell_print(sh, "%s%s", COREDUMP_PREFIX_STR,
 			    COREDUMP_ERROR_STR);
 	}
 
-	shell_print(shell, "%s%s", COREDUMP_PREFIX_STR, COREDUMP_END_STR);
+	shell_print(sh, "%s%s", COREDUMP_PREFIX_STR, COREDUMP_END_STR);
 
 	if (ret == 1) {
-		shell_print(shell, "Stored coredump printed.");
+		shell_print(sh, "Stored coredump printed.");
 	} else if (ret == 0) {
-		shell_print(shell, "Stored coredump verification failed "
+		shell_print(sh, "Stored coredump verification failed "
 				   "or there is no stored coredump.");
 	} else {
-		shell_print(shell, "Failed to print: %d", ret);
+		shell_print(sh, "Failed to print: %d", ret);
 	}
 
 out:
@@ -866,12 +866,12 @@ out:
 /**
  * @brief Shell command to erase stored coredump.
  *
- * @param shell shell instance
+ * @param sh shell instance
  * @param argc (not used)
  * @param argv (not used)
  * @return 0
  */
-static int cmd_coredump_erase_stored_dump(const struct shell *shell,
+static int cmd_coredump_erase_stored_dump(const struct shell *sh,
 					  size_t argc, char **argv)
 {
 	int ret;
@@ -883,9 +883,9 @@ static int cmd_coredump_erase_stored_dump(const struct shell *shell,
 					 NULL);
 
 	if (ret == 0) {
-		shell_print(shell, "Stored coredump erased.");
+		shell_print(sh, "Stored coredump erased.");
 	} else {
-		shell_print(shell, "Failed to perform erase command: %d", ret);
+		shell_print(sh, "Failed to perform erase command: %d", ret);
 	}
 
 	return 0;

--- a/subsys/debug/coredump/coredump_backend_logging.c
+++ b/subsys/debug/coredump/coredump_backend_logging.c
@@ -130,27 +130,27 @@ struct coredump_backend_api coredump_backend_logging = {
 #ifdef CONFIG_DEBUG_COREDUMP_SHELL
 #include <zephyr/shell/shell.h>
 
-static int cmd_coredump_error_get(const struct shell *shell,
+static int cmd_coredump_error_get(const struct shell *sh,
 				  size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	if (error == 0) {
-		shell_print(shell, "No error.");
+		shell_print(sh, "No error.");
 	} else {
-		shell_print(shell, "Error: %d", error);
+		shell_print(sh, "Error: %d", error);
 	}
 
 	return 0;
 }
 
-static int cmd_coredump_error_clear(const struct shell *shell,
+static int cmd_coredump_error_clear(const struct shell *sh,
 				    size_t argc, char **argv)
 {
 	error = 0;
 
-	shell_print(shell, "Error cleared.");
+	shell_print(sh, "Error cleared.");
 
 	return 0;
 }

--- a/subsys/dfu/boot/mcuboot_shell.c
+++ b/subsys/dfu/boot/mcuboot_shell.c
@@ -76,7 +76,7 @@ static const char *swap_state_flag_str(uint8_t flag)
 	return "unknown";
 }
 
-static int cmd_mcuboot_erase(const struct shell *shell, size_t argc,
+static int cmd_mcuboot_erase(const struct shell *sh, size_t argc,
 			     char **argv)
 {
 	unsigned int id;
@@ -86,27 +86,27 @@ static int cmd_mcuboot_erase(const struct shell *shell, size_t argc,
 
 	err = boot_erase_img_bank(id);
 	if (err) {
-		shell_error(shell, "failed to erase bank %u", id);
+		shell_error(sh, "failed to erase bank %u", id);
 		return err;
 	}
 
 	return 0;
 }
 
-static int cmd_mcuboot_confirm(const struct shell *shell, size_t argc,
+static int cmd_mcuboot_confirm(const struct shell *sh, size_t argc,
 			       char **argv)
 {
 	int err;
 
 	err = boot_write_img_confirmed();
 	if (err) {
-		shell_error(shell, "failed to confirm: %d", err);
+		shell_error(sh, "failed to confirm: %d", err);
 	}
 
 	return err;
 }
 
-static int cmd_mcuboot_request_upgrade(const struct shell *shell, size_t argc,
+static int cmd_mcuboot_request_upgrade(const struct shell *sh, size_t argc,
 				       char **argv)
 {
 	int permanent = 0;
@@ -116,20 +116,20 @@ static int cmd_mcuboot_request_upgrade(const struct shell *shell, size_t argc,
 		if (!strcmp(argv[1], "permanent")) {
 			permanent = 1;
 		} else {
-			shell_warn(shell, "invalid argument!");
+			shell_warn(sh, "invalid argument!");
 			return -EINVAL;
 		}
 	}
 
 	err = boot_request_upgrade(permanent);
 	if (err) {
-		shell_error(shell, "failed to request upgrade: %d", err);
+		shell_error(sh, "failed to request upgrade: %d", err);
 	}
 
 	return err;
 }
 
-static int cmd_mcuboot_info_area(const struct shell *shell,
+static int cmd_mcuboot_info_area(const struct shell *sh,
 				 const struct area_desc *area)
 {
 	struct mcuboot_img_header hdr;
@@ -138,54 +138,54 @@ static int cmd_mcuboot_info_area(const struct shell *shell,
 
 	err = boot_read_bank_header(area->id, &hdr, sizeof(hdr));
 	if (err) {
-		shell_error(shell, "failed to read %s area (%u) %s: %d",
+		shell_error(sh, "failed to read %s area (%u) %s: %d",
 			    area->name, area->id, "header", err);
 		return err;
 	}
 
-	shell_print(shell, "%s area (%u):", area->name, area->id);
-	shell_print(shell, "  version: %u.%u.%u+%u",
+	shell_print(sh, "%s area (%u):", area->name, area->id);
+	shell_print(sh, "  version: %u.%u.%u+%u",
 		    (unsigned int) hdr.h.v1.sem_ver.major,
 		    (unsigned int) hdr.h.v1.sem_ver.minor,
 		    (unsigned int) hdr.h.v1.sem_ver.revision,
 		    (unsigned int) hdr.h.v1.sem_ver.build_num);
-	shell_print(shell, "  image size: %u",
+	shell_print(sh, "  image size: %u",
 		    (unsigned int) hdr.h.v1.image_size);
 
 	err = boot_read_swap_state_by_id(area->id, &swap_state);
 	if (err) {
-		shell_error(shell, "failed to read %s area (%u) %s: %d",
+		shell_error(sh, "failed to read %s area (%u) %s: %d",
 			    area->name, area->id, "swap state", err);
 		return err;
 	}
 
-	shell_print(shell, "  magic: %s",
+	shell_print(sh, "  magic: %s",
 		    swap_state_magic_str(swap_state.magic));
 
 	if (IS_ENABLED(CONFIG_MCUBOOT_TRAILER_SWAP_TYPE)) {
-		shell_print(shell, "  swap type: %s",
+		shell_print(sh, "  swap type: %s",
 			    swap_type_str(swap_state.swap_type));
 	}
 
-	shell_print(shell, "  copy done: %s",
+	shell_print(sh, "  copy done: %s",
 		    swap_state_flag_str(swap_state.copy_done));
-	shell_print(shell, "  image ok: %s",
+	shell_print(sh, "  image ok: %s",
 		    swap_state_flag_str(swap_state.image_ok));
 
 	return 0;
 }
 
-static int cmd_mcuboot_info(const struct shell *shell, size_t argc,
+static int cmd_mcuboot_info(const struct shell *sh, size_t argc,
 			    char **argv)
 {
 	int i;
 
-	shell_print(shell, "swap type: %s", swap_type_str(mcuboot_swap_type()));
-	shell_print(shell, "confirmed: %d", boot_is_img_confirmed());
+	shell_print(sh, "swap type: %s", swap_type_str(mcuboot_swap_type()));
+	shell_print(sh, "confirmed: %d", boot_is_img_confirmed());
 
 	for (i = 0; i < ARRAY_SIZE(areas); i++) {
-		shell_print(shell, "");
-		cmd_mcuboot_info_area(shell, &areas[i]);
+		shell_print(sh, "");
+		cmd_mcuboot_info_area(sh, &areas[i]);
 	}
 
 	return 0;

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -25,7 +25,7 @@ static const struct device *const dev =
 static const char * const param_name[] = {
 	"height", "width", "ppt", "rows", "cols"};
 
-static int cmd_clear(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_clear(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
@@ -33,34 +33,34 @@ static int cmd_clear(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
 	err = cfb_framebuffer_clear(dev, true);
 	if (err) {
-		shell_error(shell, "Framebuffer clear error=%d", err);
+		shell_error(sh, "Framebuffer clear error=%d", err);
 		return err;
 	}
 
 	err = cfb_framebuffer_finalize(dev);
 	if (err) {
-		shell_error(shell, "Framebuffer finalize error=%d", err);
+		shell_error(sh, "Framebuffer finalize error=%d", err);
 		return err;
 	}
 
-	shell_print(shell, "Display Cleared");
+	shell_print(sh, "Display Cleared");
 
 	return err;
 }
 
-static int cmd_cfb_print(const struct shell *shell, int col, int row, char *str)
+static int cmd_cfb_print(const struct shell *sh, int col, int row, char *str)
 {
 	int err;
 	uint8_t ppt;
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
@@ -68,20 +68,20 @@ static int cmd_cfb_print(const struct shell *shell, int col, int row, char *str)
 
 	err = cfb_framebuffer_clear(dev, false);
 	if (err) {
-		shell_error(shell, "Framebuffer clear failed error=%d", err);
+		shell_error(sh, "Framebuffer clear failed error=%d", err);
 		return err;
 	}
 
 	err = cfb_print(dev, str, col, row * ppt);
 	if (err) {
-		shell_error(shell, "Failed to print the string %s error=%d",
+		shell_error(sh, "Failed to print the string %s error=%d",
 		      str, err);
 		return err;
 	}
 
 	err = cfb_framebuffer_finalize(dev);
 	if (err) {
-		shell_error(shell,
+		shell_error(sh,
 			    "Failed to finalize the Framebuffer error=%d", err);
 		return err;
 	}
@@ -89,31 +89,31 @@ static int cmd_cfb_print(const struct shell *shell, int col, int row, char *str)
 	return err;
 }
 
-static int cmd_print(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_print(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 	int col, row;
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
 	col = strtol(argv[1], NULL, 10);
 	if (col > cfb_get_display_parameter(dev, CFB_DISPLAY_COLS)) {
-		shell_error(shell, "Invalid col=%d position", col);
+		shell_error(sh, "Invalid col=%d position", col);
 		return -EINVAL;
 	}
 
 	row = strtol(argv[2], NULL, 10);
 	if (row > cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS)) {
-		shell_error(shell, "Invalid row=%d position", row);
+		shell_error(sh, "Invalid row=%d position", row);
 		return -EINVAL;
 	}
 
-	err = cmd_cfb_print(shell, col, row, argv[3]);
+	err = cmd_cfb_print(sh, col, row, argv[3]);
 	if (err) {
-		shell_error(shell, "Failed printing to Framebuffer error=%d",
+		shell_error(sh, "Failed printing to Framebuffer error=%d",
 			    err);
 	}
 
@@ -143,35 +143,35 @@ static int cmd_draw_text(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-static int cmd_scroll_vert(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_scroll_vert(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err = 0;
 	int col, row;
 	int boundary;
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
 	col = strtol(argv[1], NULL, 10);
 	if (col > cfb_get_display_parameter(dev, CFB_DISPLAY_COLS)) {
-		shell_error(shell, "Invalid col=%d position", col);
+		shell_error(sh, "Invalid col=%d position", col);
 		return -EINVAL;
 	}
 
 	row = strtol(argv[2], NULL, 10);
 	if (row > cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS)) {
-		shell_error(shell, "Invalid row=%d position", row);
+		shell_error(sh, "Invalid row=%d position", row);
 		return -EINVAL;
 	}
 
 	boundary = cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS) - row;
 
 	for (int i = 0; i < boundary; i++) {
-		err = cmd_cfb_print(shell, col, row, argv[3]);
+		err = cmd_cfb_print(sh, col, row, argv[3]);
 		if (err) {
-			shell_error(shell,
+			shell_error(sh,
 				    "Failed printing to Framebuffer error=%d",
 				    err);
 			break;
@@ -179,31 +179,31 @@ static int cmd_scroll_vert(const struct shell *shell, size_t argc, char *argv[])
 		row++;
 	}
 
-	cmd_cfb_print(shell, 0, 0, "");
+	cmd_cfb_print(sh, 0, 0, "");
 
 	return err;
 }
 
-static int cmd_scroll_horz(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_scroll_horz(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err = 0;
 	int col, row;
 	int boundary;
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
 	col = strtol(argv[1], NULL, 10);
 	if (col > cfb_get_display_parameter(dev, CFB_DISPLAY_COLS)) {
-		shell_error(shell, "Invalid col=%d position", col);
+		shell_error(sh, "Invalid col=%d position", col);
 		return -EINVAL;
 	}
 
 	row = strtol(argv[2], NULL, 10);
 	if (row > cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS)) {
-		shell_error(shell, "Invalid row=%d position", row);
+		shell_error(sh, "Invalid row=%d position", row);
 		return -EINVAL;
 	}
 
@@ -211,9 +211,9 @@ static int cmd_scroll_horz(const struct shell *shell, size_t argc, char *argv[])
 	boundary = cfb_get_display_parameter(dev, CFB_DISPLAY_COLS) - col;
 
 	for (int i = 0; i < boundary; i++) {
-		err = cmd_cfb_print(shell, col, row, argv[3]);
+		err = cmd_cfb_print(sh, col, row, argv[3]);
 		if (err) {
-			shell_error(shell,
+			shell_error(sh,
 				    "Failed printing to Framebuffer error=%d",
 				    err);
 			break;
@@ -221,12 +221,12 @@ static int cmd_scroll_horz(const struct shell *shell, size_t argc, char *argv[])
 		col++;
 	}
 
-	cmd_cfb_print(shell, 0, 0, "");
+	cmd_cfb_print(sh, 0, 0, "");
 
 	return err;
 }
 
-static int cmd_set_font(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_set_font(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 	int idx;
@@ -234,7 +234,7 @@ static int cmd_set_font(const struct shell *shell, size_t argc, char *argv[])
 	uint8_t width;
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
@@ -242,18 +242,18 @@ static int cmd_set_font(const struct shell *shell, size_t argc, char *argv[])
 
 	err = cfb_get_font_size(dev, idx, &width, &height);
 	if (err) {
-		shell_error(shell, "Invalid font idx=%d err=%d\n", idx, err);
+		shell_error(sh, "Invalid font idx=%d err=%d\n", idx, err);
 		return err;
 	}
 
 	err = cfb_framebuffer_set_font(dev, idx);
 	if (err) {
-		shell_error(shell, "Failed setting font idx=%d err=%d", idx,
+		shell_error(sh, "Failed setting font idx=%d err=%d", idx,
 			    err);
 		return err;
 	}
 
-	shell_print(shell, "Font idx=%d height=%d widht=%d set", idx, height,
+	shell_print(sh, "Font idx=%d height=%d widht=%d set", idx, height,
 		    width);
 
 	return err;
@@ -286,12 +286,12 @@ static int cmd_set_kerning(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
-static int cmd_invert(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_invert(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
@@ -301,7 +301,7 @@ static int cmd_invert(const struct shell *shell, size_t argc, char *argv[])
 
 		err = cfb_invert_area(dev, 0, 0, width, height);
 		if (err) {
-			shell_error(shell, "Error inverting area");
+			shell_error(sh, "Error inverting area");
 			return err;
 		}
 
@@ -319,27 +319,27 @@ static int cmd_invert(const struct shell *shell, size_t argc, char *argv[])
 
 		err = cfb_invert_area(dev, x, y, w, h);
 		if (err) {
-			shell_error(shell, "Error invert area");
+			shell_error(sh, "Error invert area");
 			return err;
 		}
 	} else {
-		shell_help(shell);
+		shell_help(sh);
 		return 0;
 	}
 
 	if (err) {
-		shell_error(shell, "Error inverting Framebuffer");
+		shell_error(sh, "Error inverting Framebuffer");
 		return err;
 	}
 
 	cfb_framebuffer_finalize(dev);
 
-	shell_print(shell, "Framebuffer Inverted");
+	shell_print(sh, "Framebuffer Inverted");
 
 	return err;
 }
 
-static int cmd_get_fonts(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_get_fonts(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err = 0;
 	uint8_t font_height;
@@ -349,7 +349,7 @@ static int cmd_get_fonts(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
@@ -357,14 +357,14 @@ static int cmd_get_fonts(const struct shell *shell, size_t argc, char *argv[])
 		if (cfb_get_font_size(dev, idx, &font_width, &font_height)) {
 			break;
 		}
-		shell_print(shell, "idx=%d height=%d width=%d", idx,
+		shell_print(sh, "idx=%d height=%d width=%d", idx,
 			    font_height, font_width);
 	}
 
 	return err;
 }
 
-static int cmd_get_device(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_get_device(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err = 0;
 
@@ -372,28 +372,28 @@ static int cmd_get_device(const struct shell *shell, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
-	shell_print(shell, "Framebuffer Device: %s", dev->name);
+	shell_print(sh, "Framebuffer Device: %s", dev->name);
 
 	return err;
 }
 
-static int cmd_get_param_all(const struct shell *shell, size_t argc,
+static int cmd_get_param_all(const struct shell *sh, size_t argc,
 			     char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
 	for (unsigned int i = 0; i <= CFB_DISPLAY_COLS; i++) {
-		shell_print(shell, "param: %s=%d", param_name[i],
+		shell_print(sh, "param: %s=%d", param_name[i],
 				cfb_get_display_parameter(dev, i));
 
 	}
@@ -401,97 +401,97 @@ static int cmd_get_param_all(const struct shell *shell, size_t argc,
 	return 0;
 }
 
-static int cmd_get_param_height(const struct shell *shell, size_t argc,
+static int cmd_get_param_height(const struct shell *sh, size_t argc,
 			     char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
-	shell_print(shell, "param: %s=%d", param_name[CFB_DISPLAY_HEIGH],
+	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_HEIGH],
 		    cfb_get_display_parameter(dev, CFB_DISPLAY_HEIGH));
 
 	return 0;
 }
 
-static int cmd_get_param_width(const struct shell *shell, size_t argc,
+static int cmd_get_param_width(const struct shell *sh, size_t argc,
 			     char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
-	shell_print(shell, "param: %s=%d", param_name[CFB_DISPLAY_WIDTH],
+	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_WIDTH],
 		    cfb_get_display_parameter(dev, CFB_DISPLAY_WIDTH));
 
 	return 0;
 }
 
-static int cmd_get_param_ppt(const struct shell *shell, size_t argc,
+static int cmd_get_param_ppt(const struct shell *sh, size_t argc,
 			     char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
-	shell_print(shell, "param: %s=%d", param_name[CFB_DISPLAY_PPT],
+	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_PPT],
 		    cfb_get_display_parameter(dev, CFB_DISPLAY_PPT));
 
 	return 0;
 }
 
-static int cmd_get_param_rows(const struct shell *shell, size_t argc,
+static int cmd_get_param_rows(const struct shell *sh, size_t argc,
 			     char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
-	shell_print(shell, "param: %s=%d", param_name[CFB_DISPLAY_ROWS],
+	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_ROWS],
 		    cfb_get_display_parameter(dev, CFB_DISPLAY_ROWS));
 
 	return 0;
 }
 
-static int cmd_get_param_cols(const struct shell *shell, size_t argc,
+static int cmd_get_param_cols(const struct shell *sh, size_t argc,
 			     char *argv[])
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 	if (!dev) {
-		shell_error(shell, HELP_INIT);
+		shell_error(sh, HELP_INIT);
 		return -ENODEV;
 	}
 
-	shell_print(shell, "param: %s=%d", param_name[CFB_DISPLAY_COLS],
+	shell_print(sh, "param: %s=%d", param_name[CFB_DISPLAY_COLS],
 		    cfb_get_display_parameter(dev, CFB_DISPLAY_COLS));
 
 	return 0;
 }
 
-static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
 	if (!device_is_ready(dev)) {
-		shell_error(shell, "Display device not ready");
+		shell_error(sh, "Display device not ready");
 		return -ENODEV;
 	}
 
@@ -499,25 +499,25 @@ static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
 	if (err) {
 		err = display_set_pixel_format(dev, PIXEL_FORMAT_MONO01);
 		if (err) {
-			shell_error(shell, "Failed to set required pixel format: %d", err);
+			shell_error(sh, "Failed to set required pixel format: %d", err);
 			return err;
 		}
 	}
 
 	err = display_blanking_off(dev);
 	if (err) {
-		shell_error(shell, "Failed to turn off display blanking: %d", err);
+		shell_error(sh, "Failed to turn off display blanking: %d", err);
 		return err;
 	}
 
 	err = cfb_framebuffer_init(dev);
 	if (err) {
-		shell_error(shell, "Framebuffer initialization failed!");
+		shell_error(sh, "Framebuffer initialization failed!");
 		return err;
 	}
 
-	shell_print(shell, "Framebuffer initialized: %s", dev->name);
-	cmd_clear(shell, argc, argv);
+	shell_print(sh, "Framebuffer initialized: %s", dev->name);
+	cmd_clear(sh, argc, argv);
 
 	return err;
 }

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -85,7 +85,7 @@ static void create_abs_path(const char *name, char *path, size_t len)
 	}
 }
 
-static int cmd_cd(const struct shell *shell, size_t argc, char **argv)
+static int cmd_cd(const struct shell *sh, size_t argc, char **argv)
 {
 	char path[MAX_PATH_LEN];
 	struct fs_dirent entry;
@@ -113,12 +113,12 @@ static int cmd_cd(const struct shell *shell, size_t argc, char **argv)
 
 	err = fs_stat(path, &entry);
 	if (err) {
-		shell_error(shell, "%s doesn't exist", path);
+		shell_error(sh, "%s doesn't exist", path);
 		return -ENOEXEC;
 	}
 
 	if (entry.type != FS_DIR_ENTRY_DIR) {
-		shell_error(shell, "%s is not a directory", path);
+		shell_error(sh, "%s is not a directory", path);
 		return -ENOEXEC;
 	}
 
@@ -128,7 +128,7 @@ static int cmd_cd(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-static int cmd_ls(const struct shell *shell, size_t argc, char **argv)
+static int cmd_ls(const struct shell *sh, size_t argc, char **argv)
 {
 	char path[MAX_PATH_LEN];
 	struct fs_dir_t dir;
@@ -145,7 +145,7 @@ static int cmd_ls(const struct shell *shell, size_t argc, char **argv)
 
 	err = fs_opendir(&dir, path);
 	if (err) {
-		shell_error(shell, "Unable to open %s (err %d)", path, err);
+		shell_error(sh, "Unable to open %s (err %d)", path, err);
 		return -ENOEXEC;
 	}
 
@@ -154,7 +154,7 @@ static int cmd_ls(const struct shell *shell, size_t argc, char **argv)
 
 		err = fs_readdir(&dir, &entry);
 		if (err) {
-			shell_error(shell, "Unable to read directory");
+			shell_error(sh, "Unable to read directory");
 			break;
 		}
 
@@ -163,7 +163,7 @@ static int cmd_ls(const struct shell *shell, size_t argc, char **argv)
 			break;
 		}
 
-		shell_print(shell, "%s%s", entry.name,
+		shell_print(sh, "%s%s", entry.name,
 			      (entry.type == FS_DIR_ENTRY_DIR) ? "/" : "");
 	}
 
@@ -172,14 +172,14 @@ static int cmd_ls(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-static int cmd_pwd(const struct shell *shell, size_t argc, char **argv)
+static int cmd_pwd(const struct shell *sh, size_t argc, char **argv)
 {
-	shell_print(shell, "%s", cwd);
+	shell_print(sh, "%s", cwd);
 
 	return 0;
 }
 
-static int cmd_trunc(const struct shell *shell, size_t argc, char **argv)
+static int cmd_trunc(const struct shell *sh, size_t argc, char **argv)
 {
 	char path[MAX_PATH_LEN];
 	struct fs_file_t file;
@@ -197,13 +197,13 @@ static int cmd_trunc(const struct shell *shell, size_t argc, char **argv)
 	fs_file_t_init(&file);
 	err = fs_open(&file, path, FS_O_WRITE);
 	if (err) {
-		shell_error(shell, "Failed to open %s (%d)", path, err);
+		shell_error(sh, "Failed to open %s (%d)", path, err);
 		return -ENOEXEC;;
 	}
 
 	err = fs_truncate(&file, length);
 	if (err) {
-		shell_error(shell, "Failed to truncate %s (%d)", path, err);
+		shell_error(sh, "Failed to truncate %s (%d)", path, err);
 		err = -ENOEXEC;
 	}
 
@@ -212,7 +212,7 @@ static int cmd_trunc(const struct shell *shell, size_t argc, char **argv)
 	return err;
 }
 
-static int cmd_mkdir(const struct shell *shell, size_t argc, char **argv)
+static int cmd_mkdir(const struct shell *sh, size_t argc, char **argv)
 {
 	int err;
 	char path[MAX_PATH_LEN];
@@ -221,14 +221,14 @@ static int cmd_mkdir(const struct shell *shell, size_t argc, char **argv)
 
 	err = fs_mkdir(path);
 	if (err) {
-		shell_error(shell, "Error creating dir[%d]", err);
+		shell_error(sh, "Error creating dir[%d]", err);
 		err = -ENOEXEC;
 	}
 
 	return err;
 }
 
-static int cmd_rm(const struct shell *shell, size_t argc, char **argv)
+static int cmd_rm(const struct shell *sh, size_t argc, char **argv)
 {
 	int err;
 	char path[MAX_PATH_LEN];
@@ -237,14 +237,14 @@ static int cmd_rm(const struct shell *shell, size_t argc, char **argv)
 
 	err = fs_unlink(path);
 	if (err) {
-		shell_error(shell, "Failed to remove %s (%d)", path, err);
+		shell_error(sh, "Failed to remove %s (%d)", path, err);
 		err = -ENOEXEC;
 	}
 
 	return err;
 }
 
-static int cmd_read(const struct shell *shell, size_t argc, char **argv)
+static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 {
 	char path[MAX_PATH_LEN];
 	struct fs_dirent dirent;
@@ -272,29 +272,29 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 
 	err = fs_stat(path, &dirent);
 	if (err) {
-		shell_error(shell, "Failed to obtain file %s (err: %d)",
+		shell_error(sh, "Failed to obtain file %s (err: %d)",
 			    path, err);
 		return -ENOEXEC;
 	}
 
 	if (dirent.type != FS_DIR_ENTRY_FILE) {
-		shell_error(shell, "Not a file %s", path);
+		shell_error(sh, "Not a file %s", path);
 		return -ENOEXEC;
 	}
 
-	shell_print(shell, "File size: %zd", dirent.size);
+	shell_print(sh, "File size: %zd", dirent.size);
 
 	fs_file_t_init(&file);
 	err = fs_open(&file, path, FS_O_READ);
 	if (err) {
-		shell_error(shell, "Failed to open %s (%d)", path, err);
+		shell_error(sh, "Failed to open %s (%d)", path, err);
 		return -ENOEXEC;
 	}
 
 	if (offset > 0) {
 		err = fs_seek(&file, offset, FS_SEEK_SET);
 		if (err) {
-			shell_error(shell, "Failed to seek %s (%d)",
+			shell_error(sh, "Failed to seek %s (%d)",
 				    path, err);
 			fs_close(&file);
 			return -ENOEXEC;
@@ -311,23 +311,23 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 			break;
 		}
 
-		shell_fprintf(shell, SHELL_NORMAL, "%08X  ", (uint32_t)offset);
+		shell_fprintf(sh, SHELL_NORMAL, "%08X  ", (uint32_t)offset);
 
 		for (i = 0; i < read; i++) {
-			shell_fprintf(shell, SHELL_NORMAL, "%02X ", buf[i]);
+			shell_fprintf(sh, SHELL_NORMAL, "%02X ", buf[i]);
 		}
 		for (; i < sizeof(buf); i++) {
-			shell_fprintf(shell, SHELL_NORMAL, "   ");
+			shell_fprintf(sh, SHELL_NORMAL, "   ");
 		}
 		i = sizeof(buf) - i;
-		shell_fprintf(shell, SHELL_NORMAL, "%*c", i*3, ' ');
+		shell_fprintf(sh, SHELL_NORMAL, "%*c", i*3, ' ');
 
 		for (i = 0; i < read; i++) {
-			shell_fprintf(shell, SHELL_NORMAL, "%c", buf[i] < 32 ||
+			shell_fprintf(sh, SHELL_NORMAL, "%c", buf[i] < 32 ||
 				      buf[i] > 127 ? '.' : buf[i]);
 		}
 
-		shell_print(shell, "");
+		shell_print(sh, "");
 
 		offset += read;
 		count -= read;
@@ -338,7 +338,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-static int cmd_cat(const struct shell *shell, size_t argc, char **argv)
+static int cmd_cat(const struct shell *sh, size_t argc, char **argv)
 {
 	char path[MAX_PATH_LEN];
 	uint8_t buf[BUF_CNT];
@@ -354,19 +354,19 @@ static int cmd_cat(const struct shell *shell, size_t argc, char **argv)
 
 		err = fs_stat(path, &dirent);
 		if (err < 0) {
-			shell_error(shell, "Failed to obtain file %s (err: %d)",
+			shell_error(sh, "Failed to obtain file %s (err: %d)",
 					path, err);
 			continue;
 		}
 
 		if (dirent.type != FS_DIR_ENTRY_FILE) {
-			shell_error(shell, "Not a file %s", path);
+			shell_error(sh, "Not a file %s", path);
 			continue;
 		}
 
 		err = fs_open(&file, path, FS_O_READ);
 		if (err < 0) {
-			shell_error(shell, "Failed to open %s (%d)", path, err);
+			shell_error(sh, "Failed to open %s (%d)", path, err);
 			continue;
 		}
 
@@ -377,12 +377,12 @@ static int cmd_cat(const struct shell *shell, size_t argc, char **argv)
 			}
 
 			for (int j = 0; j < read; j++) {
-				shell_fprintf(shell, SHELL_NORMAL, "%c", buf[j]);
+				shell_fprintf(sh, SHELL_NORMAL, "%c", buf[j]);
 			}
 		}
 
 		if (read < 0) {
-			shell_error(shell, "Failed to read from file %s (err: %zd)",
+			shell_error(sh, "Failed to read from file %s (err: %zd)",
 				path, read);
 		}
 
@@ -392,7 +392,7 @@ static int cmd_cat(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-static int cmd_statvfs(const struct shell *shell, size_t argc, char **argv)
+static int cmd_statvfs(const struct shell *sh, size_t argc, char **argv)
 {
 	int err;
 	char path[MAX_PATH_LEN];
@@ -402,18 +402,18 @@ static int cmd_statvfs(const struct shell *shell, size_t argc, char **argv)
 
 	err = fs_statvfs(path, &stat);
 	if (err < 0) {
-		shell_error(shell, "Failed to statvfs %s (%d)", path, err);
+		shell_error(sh, "Failed to statvfs %s (%d)", path, err);
 		return -ENOEXEC;
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL,
+	shell_fprintf(sh, SHELL_NORMAL,
 		      "bsize %lu, frsize %lu, blocks %lu, bfree %lu\n",
 		      stat.f_bsize, stat.f_frsize, stat.f_blocks, stat.f_bfree);
 
 	return 0;
 }
 
-static int cmd_write(const struct shell *shell, size_t argc, char **argv)
+static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 {
 	char path[MAX_PATH_LEN];
 	uint8_t buf[BUF_CNT];
@@ -427,7 +427,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 
 	if (!strcmp(argv[2], "-o")) {
 		if (argc < 4) {
-			shell_error(shell, "Missing argument");
+			shell_error(sh, "Missing argument");
 			return -ENOEXEC;
 		}
 
@@ -441,7 +441,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 	fs_file_t_init(&file);
 	err = fs_open(&file, path, FS_O_CREATE | FS_O_WRITE);
 	if (err) {
-		shell_error(shell, "Failed to open %s (%d)", path, err);
+		shell_error(sh, "Failed to open %s (%d)", path, err);
 		return -ENOEXEC;
 	}
 
@@ -451,7 +451,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 		err = fs_seek(&file, offset, FS_SEEK_SET);
 	}
 	if (err) {
-		shell_error(shell, "Failed to seek %s (%d)", path, err);
+		shell_error(sh, "Failed to seek %s (%d)", path, err);
 		fs_close(&file);
 		return -ENOEXEC;
 	}
@@ -463,7 +463,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 		if ((buf_len == BUF_CNT) || (arg_offset == argc)) {
 			err = fs_write(&file, buf, buf_len);
 			if (err < 0) {
-				shell_error(shell, "Failed to write %s (%d)",
+				shell_error(sh, "Failed to write %s (%d)",
 					      path, err);
 				fs_close(&file);
 				return -ENOEXEC;
@@ -731,14 +731,14 @@ static char *mntpt_prepare(char *mntpt)
 #endif
 
 #if defined(CONFIG_FAT_FILESYSTEM_ELM)
-static int cmd_mount_fat(const struct shell *shell, size_t argc, char **argv)
+static int cmd_mount_fat(const struct shell *sh, size_t argc, char **argv)
 {
 	char *mntpt;
 	int res;
 
 	mntpt = mntpt_prepare(argv[1]);
 	if (!mntpt) {
-		shell_error(shell,
+		shell_error(sh,
 			    "Failed to allocate  buffer for mount point");
 		return -ENOEXEC;
 	}
@@ -746,12 +746,12 @@ static int cmd_mount_fat(const struct shell *shell, size_t argc, char **argv)
 	fatfs_mnt.mnt_point = (const char *)mntpt;
 	res = fs_mount(&fatfs_mnt);
 	if (res != 0) {
-		shell_error(shell,
+		shell_error(sh,
 			"Error mounting FAT fs. Error Code [%d]", res);
 		return -ENOEXEC;
 	}
 
-	shell_print(shell, "Successfully mounted fat fs:%s",
+	shell_print(sh, "Successfully mounted fat fs:%s",
 			fatfs_mnt.mnt_point);
 
 	return 0;
@@ -760,7 +760,7 @@ static int cmd_mount_fat(const struct shell *shell, size_t argc, char **argv)
 
 #if defined(CONFIG_FILE_SYSTEM_LITTLEFS)
 
-static int cmd_mount_littlefs(const struct shell *shell, size_t argc, char **argv)
+static int cmd_mount_littlefs(const struct shell *sh, size_t argc, char **argv)
 {
 	if (littlefs_mnt.mnt_point != NULL) {
 		return -EBUSY;
@@ -769,7 +769,7 @@ static int cmd_mount_littlefs(const struct shell *shell, size_t argc, char **arg
 	char *mntpt = mntpt_prepare(argv[1]);
 
 	if (!mntpt) {
-		shell_error(shell, "Failed to allocate mount point");
+		shell_error(sh, "Failed to allocate mount point");
 		return -ENOEXEC; /* ?!? */
 	}
 
@@ -778,7 +778,7 @@ static int cmd_mount_littlefs(const struct shell *shell, size_t argc, char **arg
 	int rc = fs_mount(&littlefs_mnt);
 
 	if (rc != 0) {
-		shell_error(shell, "Error mounting as littlefs: %d", rc);
+		shell_error(sh, "Error mounting as littlefs: %d", rc);
 		return -ENOEXEC;
 	}
 

--- a/subsys/mgmt/hawkbit/shell.c
+++ b/subsys/mgmt/hawkbit/shell.c
@@ -13,58 +13,58 @@
 #include "hawkbit_firmware.h"
 #include "hawkbit_device.h"
 
-static void cmd_run(const struct shell *shell, size_t argc, char **argv)
+static void cmd_run(const struct shell *sh, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_fprintf(shell, SHELL_INFO, "Starting Hawkbit run...\n");
+	shell_fprintf(sh, SHELL_INFO, "Starting Hawkbit run...\n");
 	switch (hawkbit_probe()) {
 	case HAWKBIT_UNCONFIRMED_IMAGE:
 		shell_fprintf(
-			shell, SHELL_ERROR,
+			sh, SHELL_ERROR,
 			"Image is unconfirmed."
 			"Rebooting to revert back to previous confirmed image\n");
 		sys_reboot(SYS_REBOOT_WARM);
 		break;
 
 	case HAWKBIT_CANCEL_UPDATE:
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "Hawkbit update Cancelled from server\n");
 		break;
 
 	case HAWKBIT_NO_UPDATE:
-		shell_fprintf(shell, SHELL_INFO, "No update found\n");
+		shell_fprintf(sh, SHELL_INFO, "No update found\n");
 		break;
 
 	case HAWKBIT_OK:
-		shell_fprintf(shell, SHELL_INFO, "Image Already updated\n");
+		shell_fprintf(sh, SHELL_INFO, "Image Already updated\n");
 		break;
 
 	case HAWKBIT_UPDATE_INSTALLED:
-		shell_fprintf(shell, SHELL_INFO, "Update Installed\n");
+		shell_fprintf(sh, SHELL_INFO, "Update Installed\n");
 		break;
 
 	case HAWKBIT_DOWNLOAD_ERROR:
-		shell_fprintf(shell, SHELL_INFO, "Download Error\n");
+		shell_fprintf(sh, SHELL_INFO, "Download Error\n");
 		break;
 
 	case HAWKBIT_NETWORKING_ERROR:
-		shell_fprintf(shell, SHELL_INFO, "Networking Error\n");
+		shell_fprintf(sh, SHELL_INFO, "Networking Error\n");
 		break;
 
 	case HAWKBIT_METADATA_ERROR:
-		shell_fprintf(shell, SHELL_INFO, "Metadata Error\n");
+		shell_fprintf(sh, SHELL_INFO, "Metadata Error\n");
 		break;
 
 	default:
-		shell_fprintf(shell, SHELL_ERROR, "Invalid response\n");
+		shell_fprintf(sh, SHELL_ERROR, "Invalid response\n");
 		break;
 	}
 	k_sleep(K_MSEC(1));
 }
 
-static int cmd_info(const struct shell *shell, size_t argc, char *argv)
+static int cmd_info(const struct shell *sh, size_t argc, char *argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
@@ -75,8 +75,8 @@ static int cmd_info(const struct shell *shell, size_t argc, char *argv)
 	hawkbit_get_firmware_version(firmware_version, BOOT_IMG_VER_STRLEN_MAX);
 	hawkbit_get_device_identity(device_id, DEVICE_ID_HEX_MAX_SIZE);
 
-	shell_fprintf(shell, SHELL_NORMAL, "Unique device id: %s\n", device_id);
-	shell_fprintf(shell, SHELL_NORMAL, "Firmware Version: %s\n",
+	shell_fprintf(sh, SHELL_NORMAL, "Unique device id: %s\n", device_id);
+	shell_fprintf(sh, SHELL_NORMAL, "Firmware Version: %s\n",
 		      firmware_version);
 
 	return 0;

--- a/subsys/mgmt/mcumgr/grp/shell_mgmt/src/shell_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/shell_mgmt/src/shell_mgmt.c
@@ -23,10 +23,10 @@ LOG_MODULE_REGISTER(mcumgr_shell_grp, CONFIG_MCUMGR_GRP_SHELL_LOG_LEVEL);
 static int
 shell_exec(const char *line)
 {
-	const struct shell *shell = shell_backend_dummy_get_ptr();
+	const struct shell *sh = shell_backend_dummy_get_ptr();
 
-	shell_backend_dummy_clear_output(shell);
-	return shell_execute_cmd(shell, line);
+	shell_backend_dummy_clear_output(sh);
+	return shell_execute_cmd(sh, line);
 }
 
 const char *

--- a/subsys/mgmt/updatehub/shell.c
+++ b/subsys/mgmt/updatehub/shell.c
@@ -20,12 +20,12 @@ LOG_MODULE_DECLARE(updatehub, CONFIG_UPDATEHUB_LOG_LEVEL);
 #define UPDATEHUB_SERVER "coap.updatehub.io"
 #endif
 
-static int cmd_run(const struct shell *shell, size_t argc,
+static int cmd_run(const struct shell *sh, size_t argc,
 		   char **argv)
 {
 	int ret = -1;
 
-	shell_fprintf(shell, SHELL_INFO, "Starting UpdateHub run...\n");
+	shell_fprintf(sh, SHELL_INFO, "Starting UpdateHub run...\n");
 
 	switch (updatehub_probe()) {
 	case UPDATEHUB_HAS_UPDATE:
@@ -34,25 +34,25 @@ static int cmd_run(const struct shell *shell, size_t argc,
 			ret = 0;
 			break;
 		default:
-			shell_fprintf(shell, SHELL_ERROR, "Error installing update.\n");
+			shell_fprintf(sh, SHELL_ERROR, "Error installing update.\n");
 			break;
 		}
 		break;
 
 	case UPDATEHUB_NO_UPDATE:
-		shell_fprintf(shell, SHELL_INFO, "No update found\n");
+		shell_fprintf(sh, SHELL_INFO, "No update found\n");
 		ret = 0;
 		break;
 
 	default:
-		shell_fprintf(shell, SHELL_ERROR, "Invalid response\n");
+		shell_fprintf(sh, SHELL_ERROR, "Invalid response\n");
 		break;
 	}
 
 	return ret;
 }
 
-static int cmd_info(const struct shell *shell, size_t argc, char **argv)
+static int cmd_info(const struct shell *sh, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
@@ -74,13 +74,13 @@ static int cmd_info(const struct shell *shell, size_t argc, char **argv)
 				       firmware_version,
 				       FIRMWARE_IMG_VER_STRLEN_MAX);
 
-	shell_fprintf(shell, SHELL_NORMAL, "Unique device id: %s\n",
+	shell_fprintf(sh, SHELL_NORMAL, "Unique device id: %s\n",
 		      device_id);
-	shell_fprintf(shell, SHELL_NORMAL, "Firmware Version: %s\n",
+	shell_fprintf(sh, SHELL_NORMAL, "Firmware Version: %s\n",
 		      firmware_version);
-	shell_fprintf(shell, SHELL_NORMAL, "Product uid: %s\n",
+	shell_fprintf(sh, SHELL_NORMAL, "Product uid: %s\n",
 		      CONFIG_UPDATEHUB_PRODUCT_UID);
-	shell_fprintf(shell, SHELL_NORMAL, "UpdateHub Server: %s\n",
+	shell_fprintf(sh, SHELL_NORMAL, "UpdateHub Server: %s\n",
 		      UPDATEHUB_SERVER);
 
 updatehub_shell_error:

--- a/subsys/net/l2/bluetooth/bluetooth_shell.c
+++ b/subsys/net/l2/bluetooth/bluetooth_shell.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(net_bt_shell, CONFIG_NET_L2_BT_LOG_LEVEL);
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 
-static int shell_cmd_connect(const struct shell *shell,
+static int shell_cmd_connect(const struct shell *sh,
 			     size_t argc, char *argv[])
 {
 	int err;
@@ -32,81 +32,81 @@ static int shell_cmd_connect(const struct shell *shell,
 	struct net_if *iface = net_if_get_default();
 
 	if (argc < 3) {
-		shell_help(shell);
+		shell_help(sh);
 		return -ENOEXEC;
 	}
 
 	err = bt_addr_le_from_str(argv[1], argv[2], &addr);
 	if (err) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Invalid peer address (err %d)\n", err);
 		return 0;
 	}
 
 	if (net_mgmt(NET_REQUEST_BT_CONNECT, iface, &addr, sizeof(addr))) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Connection failed\n");
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Connection pending\n");
 	}
 
 	return 0;
 }
 
-static int shell_cmd_scan(const struct shell *shell,
+static int shell_cmd_scan(const struct shell *sh,
 			  size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_default();
 
 	if (argc < 2) {
-		shell_help(shell);
+		shell_help(sh);
 		return -ENOEXEC;
 	}
 
 	if (net_mgmt(NET_REQUEST_BT_SCAN, iface, argv[1], strlen(argv[1]))) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Scan failed\n");
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Scan in progress\n");
 	}
 
 	return 0;
 }
 
-static int shell_cmd_disconnect(const struct shell *shell,
+static int shell_cmd_disconnect(const struct shell *sh,
 				size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_default();
 
 	if (net_mgmt(NET_REQUEST_BT_DISCONNECT, iface, NULL, 0)) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Disconnect failed\n");
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Disconnected\n");
 	}
 
 	return 0;
 }
 
-static int shell_cmd_advertise(const struct shell *shell,
+static int shell_cmd_advertise(const struct shell *sh,
 			       size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_default();
 
 	if (argc < 2) {
-		shell_help(shell);
+		shell_help(sh);
 		return -ENOEXEC;
 	}
 
 	if (net_mgmt(NET_REQUEST_BT_ADVERTISE, iface, argv[1],
 		     strlen(argv[1]))) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Advertise failed\n");
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Advertise in progress\n");
 	}
 

--- a/subsys/net/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/l2/ieee802154/ieee802154_shell.c
@@ -28,7 +28,7 @@ struct ieee802154_req_params params;
 static struct net_mgmt_event_callback scan_cb;
 static const struct shell *cb_shell;
 
-static int cmd_ieee802154_ack(const struct shell *shell,
+static int cmd_ieee802154_ack(const struct shell *sh,
 			      size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
@@ -36,14 +36,14 @@ static int cmd_ieee802154_ack(const struct shell *shell,
 	ARG_UNUSED(argc);
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
 
 	if (!strcmp(argv[1], "set") || !strcmp(argv[1], "1")) {
 		net_mgmt(NET_REQUEST_IEEE802154_SET_ACK, iface, NULL, 0);
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "ACK flag set on outgoing packets\n");
 
 		return 0;
@@ -51,7 +51,7 @@ static int cmd_ieee802154_ack(const struct shell *shell,
 
 	if (!strcmp(argv[1], "unset") || !strcmp(argv[1], "0")) {
 		net_mgmt(NET_REQUEST_IEEE802154_UNSET_ACK, iface, NULL, 0);
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "ACK flag unset on outgoing packets\n");
 
 		return 0;
@@ -72,19 +72,19 @@ static inline void parse_extended_address(char *addr, uint8_t *ext_addr)
 	net_bytes_from_str(ext_addr, IEEE802154_EXT_ADDR_LENGTH, addr);
 }
 
-static int cmd_ieee802154_associate(const struct shell *shell,
+static int cmd_ieee802154_associate(const struct shell *sh,
 				    size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
 	char ext_addr[EXT_ADDR_STR_LEN];
 
 	if (argc < 3) {
-		shell_help(shell);
+		shell_help(sh);
 		return -ENOEXEC;
 	}
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
@@ -102,20 +102,20 @@ static int cmd_ieee802154_associate(const struct shell *shell,
 
 	if (net_mgmt(NET_REQUEST_IEEE802154_ASSOCIATE, iface,
 		     &params, sizeof(struct ieee802154_req_params))) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not associate to %s on PAN ID %u\n",
 			      argv[2], params.pan_id);
 
 		return -ENOEXEC;
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Associated to PAN ID %u\n", params.pan_id);
 	}
 
 	return 0;
 }
 
-static int cmd_ieee802154_disassociate(const struct shell *shell,
+static int cmd_ieee802154_disassociate(const struct shell *sh,
 				       size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
@@ -125,24 +125,24 @@ static int cmd_ieee802154_disassociate(const struct shell *shell,
 	ARG_UNUSED(argv);
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
 
 	ret = net_mgmt(NET_REQUEST_IEEE802154_DISASSOCIATE, iface, NULL, 0);
 	if (ret == -EALREADY) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "Interface is not associated\n");
 
 		return -ENOEXEC;
 	} else if (ret) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not disassociate? (status: %i)\n", ret);
 
 		return -ENOEXEC;
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Interface is now disassociated\n");
 	}
 
@@ -206,7 +206,7 @@ static void scan_result_cb(struct net_mgmt_event_callback *cb,
 		      print_coordinator_address(buf, sizeof(buf)), params.lqi);
 }
 
-static int cmd_ieee802154_scan(const struct shell *shell,
+static int cmd_ieee802154_scan(const struct shell *sh,
 			       size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
@@ -214,12 +214,12 @@ static int cmd_ieee802154_scan(const struct shell *shell,
 	int ret;
 
 	if (argc < 3) {
-		shell_help(shell);
+		shell_help(sh);
 		return -ENOEXEC;
 	}
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
@@ -250,13 +250,13 @@ static int cmd_ieee802154_scan(const struct shell *shell,
 
 	params.duration = atoi(argv[3]);
 
-	shell_fprintf(shell, SHELL_NORMAL,
+	shell_fprintf(sh, SHELL_NORMAL,
 		      "%s Scanning (channel set: 0x%08x, duration %u ms)...\n",
 		      scan_type == NET_REQUEST_IEEE802154_ACTIVE_SCAN ?
 		      "Active" : "Passive", params.channel_set,
 		      params.duration);
 
-	cb_shell = shell;
+	cb_shell = sh;
 
 	if (scan_type == NET_REQUEST_IEEE802154_ACTIVE_SCAN) {
 		ret = net_mgmt(NET_REQUEST_IEEE802154_ACTIVE_SCAN, iface,
@@ -267,31 +267,31 @@ static int cmd_ieee802154_scan(const struct shell *shell,
 	}
 
 	if (ret) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not raise a scan (status: %i)\n", ret);
 
 		return -ENOEXEC;
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Done\n");
 	}
 
 	return 0;
 }
 
-static int cmd_ieee802154_set_chan(const struct shell *shell,
+static int cmd_ieee802154_set_chan(const struct shell *sh,
 				   size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
 	uint16_t channel;
 
 	if (argc < 2) {
-		shell_help(shell);
+		shell_help(sh);
 		return -ENOEXEC;
 	}
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
@@ -300,19 +300,19 @@ static int cmd_ieee802154_set_chan(const struct shell *shell,
 
 	if (net_mgmt(NET_REQUEST_IEEE802154_SET_CHANNEL, iface,
 		     &channel, sizeof(uint16_t))) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not set channel %u\n", channel);
 
 		return -ENOEXEC;
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Channel %u set\n", channel);
 	}
 
 	return 0;
 }
 
-static int cmd_ieee802154_get_chan(const struct shell *shell,
+static int cmd_ieee802154_get_chan(const struct shell *sh,
 				   size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
@@ -322,26 +322,26 @@ static int cmd_ieee802154_get_chan(const struct shell *shell,
 	ARG_UNUSED(argv);
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
 
 	if (net_mgmt(NET_REQUEST_IEEE802154_GET_CHANNEL, iface,
 		     &channel, sizeof(uint16_t))) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not get channel\n");
 
 		return -ENOEXEC;
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Channel %u\n", channel);
 	}
 
 	return 0;
 }
 
-static int cmd_ieee802154_set_pan_id(const struct shell *shell,
+static int cmd_ieee802154_set_pan_id(const struct shell *sh,
 				     size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
@@ -350,12 +350,12 @@ static int cmd_ieee802154_set_pan_id(const struct shell *shell,
 	ARG_UNUSED(argc);
 
 	if (argc < 2) {
-		shell_help(shell);
+		shell_help(sh);
 		return -ENOEXEC;
 	}
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
@@ -364,19 +364,19 @@ static int cmd_ieee802154_set_pan_id(const struct shell *shell,
 
 	if (net_mgmt(NET_REQUEST_IEEE802154_SET_PAN_ID, iface,
 		     &pan_id, sizeof(uint16_t))) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not set PAN ID %u\n", pan_id);
 
 		return -ENOEXEC;
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "PAN ID %u set\n", pan_id);
 	}
 
 	return 0;
 }
 
-static int cmd_ieee802154_get_pan_id(const struct shell *shell,
+static int cmd_ieee802154_get_pan_id(const struct shell *sh,
 				     size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
@@ -386,44 +386,44 @@ static int cmd_ieee802154_get_pan_id(const struct shell *shell,
 	ARG_UNUSED(argv);
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
 
 	if (net_mgmt(NET_REQUEST_IEEE802154_GET_PAN_ID, iface,
 		     &pan_id, sizeof(uint16_t))) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not get PAN ID\n");
 
 		return -ENOEXEC;
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "PAN ID %u (0x%x)\n", pan_id, pan_id);
 	}
 
 	return 0;
 }
 
-static int cmd_ieee802154_set_ext_addr(const struct shell *shell,
+static int cmd_ieee802154_set_ext_addr(const struct shell *sh,
 				       size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
 	uint8_t addr[IEEE802154_EXT_ADDR_LENGTH]; /* in big endian */
 
 	if (argc < 2) {
-		shell_help(shell);
+		shell_help(sh);
 		return -ENOEXEC;
 	}
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
 
 	if (strlen(argv[1]) != EXT_ADDR_STR_LEN) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "%zd characters needed\n", EXT_ADDR_STR_LEN);
 		return -ENOEXEC;
 	}
@@ -432,33 +432,33 @@ static int cmd_ieee802154_set_ext_addr(const struct shell *shell,
 
 	if (net_mgmt(NET_REQUEST_IEEE802154_SET_EXT_ADDR, iface,
 		     addr, IEEE802154_EXT_ADDR_LENGTH)) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not set extended address\n");
 
 		return -ENOEXEC;
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Extended address set\n");
 	}
 
 	return 0;
 }
 
-static int cmd_ieee802154_get_ext_addr(const struct shell *shell,
+static int cmd_ieee802154_get_ext_addr(const struct shell *sh,
 				       size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
 	uint8_t addr[IEEE802154_EXT_ADDR_LENGTH]; /* in big endian */
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
 
 	if (net_mgmt(NET_REQUEST_IEEE802154_GET_EXT_ADDR, iface,
 		     addr, IEEE802154_EXT_ADDR_LENGTH)) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not get extended address\n");
 		return -ENOEXEC;
 	} else {
@@ -473,26 +473,26 @@ static int cmd_ieee802154_get_ext_addr(const struct shell *shell,
 
 		ext_addr[EXT_ADDR_STR_LEN - 1] = '\0';
 
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Extended address: %s\n", ext_addr);
 	}
 
 	return 0;
 }
 
-static int cmd_ieee802154_set_short_addr(const struct shell *shell,
+static int cmd_ieee802154_set_short_addr(const struct shell *sh,
 					 size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
 	uint16_t short_addr; /* in CPU byte order */
 
 	if (argc < 2) {
-		shell_help(shell);
+		shell_help(sh);
 		return -ENOEXEC;
 	}
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
@@ -501,57 +501,57 @@ static int cmd_ieee802154_set_short_addr(const struct shell *shell,
 
 	if (net_mgmt(NET_REQUEST_IEEE802154_SET_SHORT_ADDR, iface,
 		     &short_addr, sizeof(uint16_t))) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not set short address %u\n", short_addr);
 
 		return -ENOEXEC;
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Short address %u set\n", short_addr);
 	}
 
 	return 0;
 }
 
-static int cmd_ieee802154_get_short_addr(const struct shell *shell,
+static int cmd_ieee802154_get_short_addr(const struct shell *sh,
 					 size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
 	uint16_t short_addr; /* in CPU byte order */
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
 
 	if (net_mgmt(NET_REQUEST_IEEE802154_GET_SHORT_ADDR, iface,
 		     &short_addr, sizeof(uint16_t))) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not get short address\n");
 
 		return -ENOEXEC;
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "Short address %u\n", short_addr);
 	}
 
 	return 0;
 }
 
-static int cmd_ieee802154_set_tx_power(const struct shell *shell,
+static int cmd_ieee802154_set_tx_power(const struct shell *sh,
 				       size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
 	int16_t tx_power;
 
 	if (argc < 2) {
-		shell_help(shell);
+		shell_help(sh);
 		return -ENOEXEC;
 	}
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
@@ -560,38 +560,38 @@ static int cmd_ieee802154_set_tx_power(const struct shell *shell,
 
 	if (net_mgmt(NET_REQUEST_IEEE802154_SET_TX_POWER, iface,
 		     &tx_power, sizeof(int16_t))) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not set TX power %d\n", tx_power);
 
 		return -ENOEXEC;
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "TX power %d set\n", tx_power);
 	}
 
 	return 0;
 }
 
-static int cmd_ieee802154_get_tx_power(const struct shell *shell,
+static int cmd_ieee802154_get_tx_power(const struct shell *sh,
 				       size_t argc, char *argv[])
 {
 	struct net_if *iface = net_if_get_ieee802154();
 	int16_t tx_power;
 
 	if (!iface) {
-		shell_fprintf(shell, SHELL_INFO,
+		shell_fprintf(sh, SHELL_INFO,
 			      "No IEEE 802.15.4 interface found.\n");
 		return -ENOEXEC;
 	}
 
 	if (net_mgmt(NET_REQUEST_IEEE802154_GET_TX_POWER, iface,
 		     &tx_power, sizeof(int16_t))) {
-		shell_fprintf(shell, SHELL_WARNING,
+		shell_fprintf(sh, SHELL_WARNING,
 			      "Could not get TX power\n");
 
 		return -ENOEXEC;
 	} else {
-		shell_fprintf(shell, SHELL_NORMAL,
+		shell_fprintf(sh, SHELL_NORMAL,
 			      "TX power (in dbm) %d\n", tx_power);
 	}
 

--- a/subsys/shell/backends/shell_dummy.c
+++ b/subsys/shell/backends/shell_dummy.c
@@ -117,10 +117,10 @@ const struct shell *shell_backend_dummy_get_ptr(void)
 	return &shell_dummy;
 }
 
-const char *shell_backend_dummy_get_output(const struct shell *shell,
+const char *shell_backend_dummy_get_output(const struct shell *sh,
 					   size_t *sizep)
 {
-	struct shell_dummy *sh_dummy = (struct shell_dummy *)shell->iface->ctx;
+	struct shell_dummy *sh_dummy = (struct shell_dummy *)sh->iface->ctx;
 
 	sh_dummy->buf[sh_dummy->len] = '\0';
 	*sizep = sh_dummy->len;
@@ -129,9 +129,9 @@ const char *shell_backend_dummy_get_output(const struct shell *shell,
 	return sh_dummy->buf;
 }
 
-void shell_backend_dummy_clear_output(const struct shell *shell)
+void shell_backend_dummy_clear_output(const struct shell *sh)
 {
-	struct shell_dummy *sh_dummy = (struct shell_dummy *)shell->iface->ctx;
+	struct shell_dummy *sh_dummy = (struct shell_dummy *)sh->iface->ctx;
 
 	sh_dummy->buf[0] = '\0';
 	sh_dummy->len = 0;

--- a/subsys/shell/modules/date_service.c
+++ b/subsys/shell/modules/date_service.c
@@ -14,20 +14,20 @@
 #define HELP_NONE      "[none]"
 #define HELP_DATE_SET  "[Y-m-d] <H:M:S>"
 
-static void date_print(const struct shell *sh, struct tm *tm)
+static void date_print(const struct shell *sh, struct tm *t)
 {
 	shell_print(sh,
 		    "%d-%02u-%02u "
 		    "%02u:%02u:%02u UTC",
-		    tm->tm_year + 1900,
-		    tm->tm_mon + 1,
-		    tm->tm_mday,
-		    tm->tm_hour,
-		    tm->tm_min,
-		    tm->tm_sec);
+		    t->tm_year + 1900,
+		    t->tm_mon + 1,
+		    t->tm_mday,
+		    t->tm_hour,
+		    t->tm_min,
+		    t->tm_sec);
 }
 
-static int get_y_m_d(const struct shell *sh, struct tm *tm, char *date_str)
+static int get_y_m_d(const struct shell *sh, struct tm *t, char *date_str)
 {
 	int year;
 	int month;
@@ -67,9 +67,9 @@ static int get_y_m_d(const struct shell *sh, struct tm *tm, char *date_str)
 		return -EINVAL;
 	}
 
-	tm->tm_year = year - 1900;
-	tm->tm_mon = month - 1;
-	tm->tm_mday = day;
+	t->tm_year = year - 1900;
+	t->tm_mon = month - 1;
+	t->tm_mday = day;
 
 	return 0;
 }
@@ -79,7 +79,7 @@ static int get_y_m_d(const struct shell *sh, struct tm *tm, char *date_str)
  * accept H:M:S, :M:S or ::S where the missing field(s) will be filled in by
  * the previous time state.
  */
-static int get_h_m_s(const struct shell *sh, struct tm *tm, char *time_str)
+static int get_h_m_s(const struct shell *sh, struct tm *t, char *time_str)
 {
 	char *endptr;
 
@@ -87,11 +87,11 @@ static int get_h_m_s(const struct shell *sh, struct tm *tm, char *time_str)
 		time_str++;
 	} else {
 		endptr = NULL;
-		tm->tm_hour = strtol(time_str, &endptr, 10);
+		t->tm_hour = strtol(time_str, &endptr, 10);
 		if (endptr == time_str) {
 			return -EINVAL;
 		} else if (*endptr == ':') {
-			if ((tm->tm_hour < 0) || (tm->tm_hour > 23)) {
+			if ((t->tm_hour < 0) || (t->tm_hour > 23)) {
 				shell_error(sh, "Invalid hour");
 				return -EINVAL;
 			}
@@ -106,11 +106,11 @@ static int get_h_m_s(const struct shell *sh, struct tm *tm, char *time_str)
 		time_str++;
 	} else {
 		endptr = NULL;
-		tm->tm_min = strtol(time_str, &endptr, 10);
+		t->tm_min = strtol(time_str, &endptr, 10);
 		if (endptr == time_str) {
 			return -EINVAL;
 		} else if (*endptr == ':') {
-			if ((tm->tm_min < 0) || (tm->tm_min > 59)) {
+			if ((t->tm_min < 0) || (t->tm_min > 59)) {
 				shell_error(sh, "Invalid minute");
 				return -EINVAL;
 			}
@@ -122,13 +122,13 @@ static int get_h_m_s(const struct shell *sh, struct tm *tm, char *time_str)
 	}
 
 	endptr = NULL;
-	tm->tm_sec = strtol(time_str, &endptr, 10);
+	t->tm_sec = strtol(time_str, &endptr, 10);
 	if ((endptr == time_str) || (*endptr != '\0')) {
 		return -EINVAL;
 	}
 
 	/* Note range allows for a leap second */
-	if ((tm->tm_sec < 0) || (tm->tm_sec > 60)) {
+	if ((t->tm_sec < 0) || (t->tm_sec > 60)) {
 		shell_error(sh, "Invalid second");
 		return -EINVAL;
 	}

--- a/subsys/shell/modules/date_service.c
+++ b/subsys/shell/modules/date_service.c
@@ -14,9 +14,9 @@
 #define HELP_NONE      "[none]"
 #define HELP_DATE_SET  "[Y-m-d] <H:M:S>"
 
-static void date_print(const struct shell *shell, struct tm *tm)
+static void date_print(const struct shell *sh, struct tm *tm)
 {
-	shell_print(shell,
+	shell_print(sh,
 		    "%d-%02u-%02u "
 		    "%02u:%02u:%02u UTC",
 		    tm->tm_year + 1900,
@@ -27,7 +27,7 @@ static void date_print(const struct shell *shell, struct tm *tm)
 		    tm->tm_sec);
 }
 
-static int get_y_m_d(const struct shell *shell, struct tm *tm, char *date_str)
+static int get_y_m_d(const struct shell *sh, struct tm *tm, char *date_str)
 {
 	int year;
 	int month;
@@ -49,7 +49,7 @@ static int get_y_m_d(const struct shell *shell, struct tm *tm, char *date_str)
 	}
 
 	if ((month < 1) || (month > 12)) {
-		shell_error(shell, "Invalid month");
+		shell_error(sh, "Invalid month");
 		return -EINVAL;
 	}
 
@@ -63,7 +63,7 @@ static int get_y_m_d(const struct shell *shell, struct tm *tm, char *date_str)
 
 	/* Check day against maximum month length */
 	if ((day < 1) || (day > 31)) {
-		shell_error(shell, "Invalid day");
+		shell_error(sh, "Invalid day");
 		return -EINVAL;
 	}
 
@@ -79,7 +79,7 @@ static int get_y_m_d(const struct shell *shell, struct tm *tm, char *date_str)
  * accept H:M:S, :M:S or ::S where the missing field(s) will be filled in by
  * the previous time state.
  */
-static int get_h_m_s(const struct shell *shell, struct tm *tm, char *time_str)
+static int get_h_m_s(const struct shell *sh, struct tm *tm, char *time_str)
 {
 	char *endptr;
 
@@ -92,7 +92,7 @@ static int get_h_m_s(const struct shell *shell, struct tm *tm, char *time_str)
 			return -EINVAL;
 		} else if (*endptr == ':') {
 			if ((tm->tm_hour < 0) || (tm->tm_hour > 23)) {
-				shell_error(shell, "Invalid hour");
+				shell_error(sh, "Invalid hour");
 				return -EINVAL;
 			}
 
@@ -111,7 +111,7 @@ static int get_h_m_s(const struct shell *shell, struct tm *tm, char *time_str)
 			return -EINVAL;
 		} else if (*endptr == ':') {
 			if ((tm->tm_min < 0) || (tm->tm_min > 59)) {
-				shell_error(shell, "Invalid minute");
+				shell_error(sh, "Invalid minute");
 				return -EINVAL;
 			}
 
@@ -129,14 +129,14 @@ static int get_h_m_s(const struct shell *shell, struct tm *tm, char *time_str)
 
 	/* Note range allows for a leap second */
 	if ((tm->tm_sec < 0) || (tm->tm_sec > 60)) {
-		shell_error(shell, "Invalid second");
+		shell_error(sh, "Invalid second");
 		return -EINVAL;
 	}
 
 	return 0;
 }
 
-static int cmd_date_set(const struct shell *shell, size_t argc, char **argv)
+static int cmd_date_set(const struct shell *sh, size_t argc, char **argv)
 {
 	struct timespec tp;
 	struct tm tm;
@@ -147,46 +147,46 @@ static int cmd_date_set(const struct shell *shell, size_t argc, char **argv)
 	gmtime_r(&tp.tv_sec, &tm);
 
 	if (argc == 3) {
-		ret = get_y_m_d(shell, &tm, argv[1]);
+		ret = get_y_m_d(sh, &tm, argv[1]);
 		if (ret != 0) {
-			shell_help(shell);
+			shell_help(sh);
 			return -EINVAL;
 		}
-		ret = get_h_m_s(shell, &tm, argv[2]);
+		ret = get_h_m_s(sh, &tm, argv[2]);
 		if (ret != 0) {
-			shell_help(shell);
+			shell_help(sh);
 			return -EINVAL;
 		}
 	} else if (argc == 2) {
-		ret = get_h_m_s(shell, &tm, argv[1]);
+		ret = get_h_m_s(sh, &tm, argv[1]);
 		if (ret != 0) {
-			shell_help(shell);
+			shell_help(sh);
 			return -EINVAL;
 		}
 	} else {
-		shell_help(shell);
+		shell_help(sh);
 		return -EINVAL;
 	}
 
 	tp.tv_sec = timeutil_timegm(&tm);
 	if (tp.tv_sec == -1) {
-		shell_error(shell, "Failed to calculate seconds since Epoch");
+		shell_error(sh, "Failed to calculate seconds since Epoch");
 		return -EINVAL;
 	}
 	tp.tv_nsec = 0;
 
 	ret = clock_settime(CLOCK_REALTIME, &tp);
 	if (ret != 0) {
-		shell_error(shell, "Could not set date %d", ret);
+		shell_error(sh, "Could not set date %d", ret);
 		return -EINVAL;
 	}
 
-	date_print(shell, &tm);
+	date_print(sh, &tm);
 
 	return 0;
 }
 
-static int cmd_date_get(const struct shell *shell, size_t argc, char **argv)
+static int cmd_date_get(const struct shell *sh, size_t argc, char **argv)
 {
 	struct timespec tp;
 	struct tm tm;
@@ -195,7 +195,7 @@ static int cmd_date_get(const struct shell *shell, size_t argc, char **argv)
 
 	gmtime_r(&tp.tv_sec, &tm);
 
-	date_print(shell, &tm);
+	date_print(sh, &tm);
 
 	return 0;
 }

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -131,7 +131,7 @@ static int cmd_device_levels(const struct shell *sh,
 }
 
 struct cmd_device_list_visitor_context {
-	const struct shell *shell;
+	const struct shell *sh;
 	char *buf;
 	size_t buf_size;
 };
@@ -141,7 +141,7 @@ static int cmd_device_list_visitor(const struct device *dev,
 {
 	const struct cmd_device_list_visitor_context *ctx = context;
 
-	shell_fprintf(ctx->shell, SHELL_NORMAL, "  requires: %s\n",
+	shell_fprintf(ctx->sh, SHELL_NORMAL, "  requires: %s\n",
 		      get_device_name(dev, ctx->buf, ctx->buf_size));
 
 	return 0;
@@ -182,7 +182,7 @@ static int cmd_device_list(const struct shell *sh,
 		shell_fprintf(sh, SHELL_NORMAL, " (%s)\n", state);
 		if (!k_is_user_context()) {
 			struct cmd_device_list_visitor_context ctx = {
-				.shell = sh,
+				.sh = sh,
 				.buf = buf,
 				.buf_size = sizeof(buf),
 			};

--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -29,7 +29,7 @@
 #define THREAD_MAX_NAM_LEN 10
 #endif
 
-static int cmd_kernel_version(const struct shell *shell,
+static int cmd_kernel_version(const struct shell *sh,
 			      size_t argc, char **argv)
 {
 	uint32_t version = sys_kernel_version_get();
@@ -37,30 +37,30 @@ static int cmd_kernel_version(const struct shell *shell,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(shell, "Zephyr version %d.%d.%d",
+	shell_print(sh, "Zephyr version %d.%d.%d",
 		      SYS_KERNEL_VER_MAJOR(version),
 		      SYS_KERNEL_VER_MINOR(version),
 		      SYS_KERNEL_VER_PATCHLEVEL(version));
 	return 0;
 }
 
-static int cmd_kernel_uptime(const struct shell *shell,
+static int cmd_kernel_uptime(const struct shell *sh,
 			     size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(shell, "Uptime: %u ms", k_uptime_get_32());
+	shell_print(sh, "Uptime: %u ms", k_uptime_get_32());
 	return 0;
 }
 
-static int cmd_kernel_cycles(const struct shell *shell,
+static int cmd_kernel_cycles(const struct shell *sh,
 			      size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(shell, "cycles: %u hw cycles", k_cycle_get_32());
+	shell_print(sh, "cycles: %u hw cycles", k_cycle_get_32());
 	return 0;
 }
 
@@ -69,7 +69,7 @@ static int cmd_kernel_cycles(const struct shell *shell,
 static void shell_tdata_dump(const struct k_thread *cthread, void *user_data)
 {
 	struct k_thread *thread = (struct k_thread *)cthread;
-	const struct shell *shell = (const struct shell *)user_data;
+	const struct shell *sh = (const struct shell *)user_data;
 	unsigned int pcnt;
 	size_t unused;
 	size_t size = thread->stack_info.size;
@@ -84,16 +84,16 @@ static void shell_tdata_dump(const struct k_thread *cthread, void *user_data)
 
 	tname = k_thread_name_get(thread);
 
-	shell_print(shell, "%s%p %-10s",
+	shell_print(sh, "%s%p %-10s",
 		      (thread == k_current_get()) ? "*" : " ",
 		      thread,
 		      tname ? tname : "NA");
 	/* Cannot use lld as it's less portable. */
-	shell_print(shell, "\toptions: 0x%x, priority: %d timeout: %" PRId64,
+	shell_print(sh, "\toptions: 0x%x, priority: %d timeout: %" PRId64,
 		      thread->base.user_options,
 		      thread->base.prio,
 		      (int64_t)thread->base.timeout.dticks);
-	shell_print(shell, "\tstate: %s, entry: %p",
+	shell_print(sh, "\tstate: %s, entry: %p",
 		    k_thread_state_str(thread, state_str, sizeof(state_str)),
 		    thread->entry.pEntry);
 
@@ -119,58 +119,58 @@ static void shell_tdata_dump(const struct k_thread *cthread, void *user_data)
 		 * so it won't increase RAM/ROM usage too much on 32-bit
 		 * targets.
 		 */
-		shell_print(shell, "\tTotal execution cycles: %u (%u %%)",
+		shell_print(sh, "\tTotal execution cycles: %u (%u %%)",
 			    (uint32_t)rt_stats_thread.execution_cycles,
 			    pcnt);
 #ifdef CONFIG_SCHED_THREAD_USAGE_ANALYSIS
-		shell_print(shell, "\tCurrent execution cycles: %u",
+		shell_print(sh, "\tCurrent execution cycles: %u",
 			    (uint32_t)rt_stats_thread.current_cycles);
-		shell_print(shell, "\tPeak execution cycles: %u",
+		shell_print(sh, "\tPeak execution cycles: %u",
 			    (uint32_t)rt_stats_thread.peak_cycles);
-		shell_print(shell, "\tAverage execution cycles: %u",
+		shell_print(sh, "\tAverage execution cycles: %u",
 			    (uint32_t)rt_stats_thread.average_cycles);
 #endif
 	} else {
-		shell_print(shell, "\tTotal execution cycles: ? (? %%)");
+		shell_print(sh, "\tTotal execution cycles: ? (? %%)");
 #ifdef CONFIG_SCHED_THREAD_USAGE_ANALYSIS
-		shell_print(shell, "\tCurrent execution cycles: ?");
-		shell_print(shell, "\tPeak execution cycles: ?");
-		shell_print(shell, "\tAverage execution cycles: ?");
+		shell_print(sh, "\tCurrent execution cycles: ?");
+		shell_print(sh, "\tPeak execution cycles: ?");
+		shell_print(sh, "\tAverage execution cycles: ?");
 #endif
 	}
 #endif
 
 	ret = k_thread_stack_space_get(thread, &unused);
 	if (ret) {
-		shell_print(shell,
+		shell_print(sh,
 			    "Unable to determine unused stack size (%d)\n",
 			    ret);
 	} else {
 		/* Calculate the real size reserved for the stack */
 		pcnt = ((size - unused) * 100U) / size;
 
-		shell_print(shell,
+		shell_print(sh,
 			    "\tstack size %zu, unused %zu, usage %zu / %zu (%u %%)\n",
 			    size, unused, size - unused, size, pcnt);
 	}
 
 }
 
-static int cmd_kernel_threads(const struct shell *shell,
+static int cmd_kernel_threads(const struct shell *sh,
 			      size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	shell_print(shell, "Scheduler: %u since last call", sys_clock_elapsed());
-	shell_print(shell, "Threads:");
-	k_thread_foreach(shell_tdata_dump, (void *)shell);
+	shell_print(sh, "Scheduler: %u since last call", sys_clock_elapsed());
+	shell_print(sh, "Threads:");
+	k_thread_foreach(shell_tdata_dump, (void *)sh);
 	return 0;
 }
 
 static void shell_stack_dump(const struct k_thread *thread, void *user_data)
 {
-	const struct shell *shell = (const struct shell *)user_data;
+	const struct shell *sh = (const struct shell *)user_data;
 	unsigned int pcnt;
 	size_t unused;
 	size_t size = thread->stack_info.size;
@@ -179,7 +179,7 @@ static void shell_stack_dump(const struct k_thread *thread, void *user_data)
 
 	ret = k_thread_stack_space_get(thread, &unused);
 	if (ret) {
-		shell_print(shell,
+		shell_print(sh,
 			    "Unable to determine unused stack size (%d)\n",
 			    ret);
 		return;
@@ -199,7 +199,7 @@ static void shell_stack_dump(const struct k_thread *thread, void *user_data)
 K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 			     CONFIG_ISR_STACK_SIZE);
 
-static int cmd_kernel_stacks(const struct shell *shell,
+static int cmd_kernel_stacks(const struct shell *sh,
 			     size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
@@ -208,7 +208,7 @@ static int cmd_kernel_stacks(const struct shell *shell,
 
 	memset(pad, ' ', MAX((THREAD_MAX_NAM_LEN - strlen("IRQ 00")), 1));
 
-	k_thread_foreach(shell_stack_dump, (void *)shell);
+	k_thread_foreach(shell_stack_dump, (void *)sh);
 
 	/* Placeholder logic for interrupt stack until we have better
 	 * kernel support, including dumping arch-specific exception-related
@@ -225,7 +225,7 @@ static int cmd_kernel_stacks(const struct shell *shell,
 		(void)err;
 		__ASSERT_NO_MSG(err == 0);
 
-		shell_print(shell,
+		shell_print(sh,
 			    "%p IRQ %02d %s(real size %4zu):\tunused %4zu\tusage %4zu / %4zu (%2zu %%)",
 			    &z_interrupt_stacks[i], i, pad, size, unused, size - unused, size,
 			    ((size - unused) * 100U) / size);
@@ -318,7 +318,7 @@ static int cmd_kernel_log_level_set(const struct shell *sh,
 #endif
 
 #if defined(CONFIG_REBOOT)
-static int cmd_kernel_reboot_warm(const struct shell *shell,
+static int cmd_kernel_reboot_warm(const struct shell *sh,
 				  size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
@@ -330,7 +330,7 @@ static int cmd_kernel_reboot_warm(const struct shell *shell,
 	return 0;
 }
 
-static int cmd_kernel_reboot_cold(const struct shell *shell,
+static int cmd_kernel_reboot_cold(const struct shell *sh,
 				  size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1280,14 +1280,14 @@ static void shell_signal_handle(const struct shell *sh,
 				enum shell_signal sig_idx,
 				shell_signal_handler_t handler)
 {
-	struct k_poll_signal *signal = &sh->ctx->signals[sig_idx];
+	struct k_poll_signal *sig = &sh->ctx->signals[sig_idx];
 	int set;
 	int res;
 
-	k_poll_signal_check(signal, &set, &res);
+	k_poll_signal_check(sig, &set, &res);
 
 	if (set) {
-		k_poll_signal_reset(signal);
+		k_poll_signal_reset(sig);
 		handler(sh);
 	}
 }

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -41,27 +41,27 @@ BUILD_ASSERT(SHELL_THREAD_PRIORITY >=
 		&& SHELL_THREAD_PRIORITY <= K_LOWEST_APPLICATION_THREAD_PRIO,
 		  "Invalid range for thread priority");
 
-static inline void receive_state_change(const struct shell *shell,
+static inline void receive_state_change(const struct shell *sh,
 					enum shell_receive_state state)
 {
-	shell->ctx->receive_state = state;
+	sh->ctx->receive_state = state;
 }
 
-static void cmd_buffer_clear(const struct shell *shell)
+static void cmd_buffer_clear(const struct shell *sh)
 {
-	shell->ctx->cmd_buff[0] = '\0'; /* clear command buffer */
-	shell->ctx->cmd_buff_pos = 0;
-	shell->ctx->cmd_buff_len = 0;
+	sh->ctx->cmd_buff[0] = '\0'; /* clear command buffer */
+	sh->ctx->cmd_buff_pos = 0;
+	sh->ctx->cmd_buff_len = 0;
 }
 
-static void shell_internal_help_print(const struct shell *shell)
+static void shell_internal_help_print(const struct shell *sh)
 {
 	if (!IS_ENABLED(CONFIG_SHELL_HELP)) {
 		return;
 	}
 
-	z_shell_help_cmd_print(shell, &shell->ctx->active_cmd);
-	z_shell_help_subcmd_print(shell, &shell->ctx->active_cmd,
+	z_shell_help_cmd_print(sh, &sh->ctx->active_cmd);
+	z_shell_help_subcmd_print(sh, &sh->ctx->active_cmd,
 				  "Subcommands:\n");
 }
 
@@ -75,16 +75,16 @@ static void shell_internal_help_print(const struct shell *shell)
  * @return 0		  if check passed
  * @return -EINVAL	  if wrong argument count
  */
-static int cmd_precheck(const struct shell *shell,
+static int cmd_precheck(const struct shell *sh,
 			bool arg_cnt_ok)
 {
 	if (!arg_cnt_ok) {
-		z_shell_fprintf(shell, SHELL_ERROR,
+		z_shell_fprintf(sh, SHELL_ERROR,
 				"%s: wrong parameter count\n",
-				shell->ctx->active_cmd.syntax);
+				sh->ctx->active_cmd.syntax);
 
 		if (IS_ENABLED(CONFIG_SHELL_HELP_ON_WRONG_ARGUMENT_COUNT)) {
-			shell_internal_help_print(shell);
+			shell_internal_help_print(sh);
 		}
 
 		return -EINVAL;
@@ -93,38 +93,38 @@ static int cmd_precheck(const struct shell *shell,
 	return 0;
 }
 
-static inline void state_set(const struct shell *shell, enum shell_state state)
+static inline void state_set(const struct shell *sh, enum shell_state state)
 {
-	shell->ctx->state = state;
+	sh->ctx->state = state;
 
-	if (state == SHELL_STATE_ACTIVE && !shell->ctx->bypass) {
-		cmd_buffer_clear(shell);
-		if (z_flag_print_noinit_get(shell)) {
-			z_shell_fprintf(shell, SHELL_WARNING, "%s",
+	if (state == SHELL_STATE_ACTIVE && !sh->ctx->bypass) {
+		cmd_buffer_clear(sh);
+		if (z_flag_print_noinit_get(sh)) {
+			z_shell_fprintf(sh, SHELL_WARNING, "%s",
 					SHELL_MSG_BACKEND_NOT_ACTIVE);
-			z_flag_print_noinit_set(shell, false);
+			z_flag_print_noinit_set(sh, false);
 		}
-		z_shell_print_prompt_and_cmd(shell);
+		z_shell_print_prompt_and_cmd(sh);
 	}
 }
 
-static inline enum shell_state state_get(const struct shell *shell)
+static inline enum shell_state state_get(const struct shell *sh)
 {
-	return shell->ctx->state;
+	return sh->ctx->state;
 }
 
 static inline const struct shell_static_entry *
-selected_cmd_get(const struct shell *shell)
+selected_cmd_get(const struct shell *sh)
 {
 	if (IS_ENABLED(CONFIG_SHELL_CMDS_SELECT)
 	    || (CONFIG_SHELL_CMD_ROOT[0] != 0)) {
-		return shell->ctx->selected_cmd;
+		return sh->ctx->selected_cmd;
 	}
 
 	return NULL;
 }
 
-static void tab_item_print(const struct shell *shell, const char *option,
+static void tab_item_print(const struct shell *sh, const char *option,
 			   uint16_t longest_option)
 {
 	static const char *tab = "  ";
@@ -133,63 +133,63 @@ static void tab_item_print(const struct shell *shell, const char *option,
 
 	/* Function initialization has been requested. */
 	if (option == NULL) {
-		shell->ctx->vt100_ctx.printed_cmd = 0;
+		sh->ctx->vt100_ctx.printed_cmd = 0;
 		return;
 	}
 
 	longest_option += z_shell_strlen(tab);
 
-	columns = (shell->ctx->vt100_ctx.cons.terminal_wid
+	columns = (sh->ctx->vt100_ctx.cons.terminal_wid
 			- z_shell_strlen(tab)) / longest_option;
 	diff = longest_option - z_shell_strlen(option);
 
-	if (shell->ctx->vt100_ctx.printed_cmd++ % columns == 0U) {
-		z_shell_fprintf(shell, SHELL_OPTION, "\n%s%s", tab, option);
+	if (sh->ctx->vt100_ctx.printed_cmd++ % columns == 0U) {
+		z_shell_fprintf(sh, SHELL_OPTION, "\n%s%s", tab, option);
 	} else {
-		z_shell_fprintf(shell, SHELL_OPTION, "%s", option);
+		z_shell_fprintf(sh, SHELL_OPTION, "%s", option);
 	}
 
-	z_shell_op_cursor_horiz_move(shell, diff);
+	z_shell_op_cursor_horiz_move(sh, diff);
 }
 
-static void history_init(const struct shell *shell)
+static void history_init(const struct shell *sh)
 {
 	if (!IS_ENABLED(CONFIG_SHELL_HISTORY)) {
 		return;
 	}
 
-	z_shell_history_init(shell->history);
+	z_shell_history_init(sh->history);
 }
 
-static void history_purge(const struct shell *shell)
+static void history_purge(const struct shell *sh)
 {
 	if (!IS_ENABLED(CONFIG_SHELL_HISTORY)) {
 		return;
 	}
 
-	z_shell_history_purge(shell->history);
+	z_shell_history_purge(sh->history);
 }
 
-static void history_mode_exit(const struct shell *shell)
+static void history_mode_exit(const struct shell *sh)
 {
 	if (!IS_ENABLED(CONFIG_SHELL_HISTORY)) {
 		return;
 	}
 
-	z_flag_history_exit_set(shell, false);
-	z_shell_history_mode_exit(shell->history);
+	z_flag_history_exit_set(sh, false);
+	z_shell_history_mode_exit(sh->history);
 }
 
-static void history_put(const struct shell *shell, uint8_t *line, size_t length)
+static void history_put(const struct shell *sh, uint8_t *line, size_t length)
 {
 	if (!IS_ENABLED(CONFIG_SHELL_HISTORY)) {
 		return;
 	}
 
-	z_shell_history_put(shell->history, line, length);
+	z_shell_history_put(sh->history, line, length);
 }
 
-static void history_handle(const struct shell *shell, bool up)
+static void history_handle(const struct shell *sh, bool up)
 {
 	bool history_mode;
 	uint16_t len;
@@ -200,21 +200,21 @@ static void history_handle(const struct shell *shell, bool up)
 	}
 
 	/* Checking if history process has been stopped */
-	if (z_flag_history_exit_get(shell)) {
-		z_flag_history_exit_set(shell, false);
-		z_shell_history_mode_exit(shell->history);
+	if (z_flag_history_exit_get(sh)) {
+		z_flag_history_exit_set(sh, false);
+		z_shell_history_mode_exit(sh->history);
 	}
 
 	/* Backup command if history is entered */
-	if (!z_shell_history_active(shell->history)) {
+	if (!z_shell_history_active(sh->history)) {
 		if (up) {
-			uint16_t cmd_len = z_shell_strlen(shell->ctx->cmd_buff);
+			uint16_t cmd_len = z_shell_strlen(sh->ctx->cmd_buff);
 
 			if (cmd_len) {
-				strcpy(shell->ctx->temp_buff,
-				       shell->ctx->cmd_buff);
+				strcpy(sh->ctx->temp_buff,
+				       sh->ctx->cmd_buff);
 			} else {
-				shell->ctx->temp_buff[0] = '\0';
+				sh->ctx->temp_buff[0] = '\0';
 			}
 		} else {
 			/* Pressing 'down' not in history mode has no effect. */
@@ -223,38 +223,38 @@ static void history_handle(const struct shell *shell, bool up)
 	}
 
 	/* Start by checking if history is not empty. */
-	history_mode = z_shell_history_get(shell->history, up,
-					   shell->ctx->cmd_buff, &len);
+	history_mode = z_shell_history_get(sh->history, up,
+					   sh->ctx->cmd_buff, &len);
 
 	/* On exiting history mode print backed up command. */
 	if (!history_mode) {
-		strcpy(shell->ctx->cmd_buff, shell->ctx->temp_buff);
-		len = z_shell_strlen(shell->ctx->cmd_buff);
+		strcpy(sh->ctx->cmd_buff, sh->ctx->temp_buff);
+		len = z_shell_strlen(sh->ctx->cmd_buff);
 	}
 
-	z_shell_op_cursor_home_move(shell);
-	z_clear_eos(shell);
-	z_shell_print_cmd(shell);
-	shell->ctx->cmd_buff_pos = len;
-	shell->ctx->cmd_buff_len = len;
-	z_shell_op_cond_next_line(shell);
+	z_shell_op_cursor_home_move(sh);
+	z_clear_eos(sh);
+	z_shell_print_cmd(sh);
+	sh->ctx->cmd_buff_pos = len;
+	sh->ctx->cmd_buff_len = len;
+	z_shell_op_cond_next_line(sh);
 }
 
-static inline uint16_t completion_space_get(const struct shell *shell)
+static inline uint16_t completion_space_get(const struct shell *sh)
 {
 	uint16_t space = (CONFIG_SHELL_CMD_BUFF_SIZE - 1) -
-			shell->ctx->cmd_buff_len;
+			sh->ctx->cmd_buff_len;
 	return space;
 }
 
 /* Prepare arguments and return number of space available for completion. */
-static bool tab_prepare(const struct shell *shell,
+static bool tab_prepare(const struct shell *sh,
 			const struct shell_static_entry **cmd,
 			const char ***argv, size_t *argc,
 			size_t *complete_arg_idx,
 			struct shell_static_entry *d_entry)
 {
-	uint16_t compl_space = completion_space_get(shell);
+	uint16_t compl_space = completion_space_get(sh);
 	size_t search_argc;
 
 	if (compl_space == 0U) {
@@ -262,12 +262,12 @@ static bool tab_prepare(const struct shell *shell,
 	}
 
 	/* Copy command from its beginning to cursor position. */
-	memcpy(shell->ctx->temp_buff, shell->ctx->cmd_buff,
-			shell->ctx->cmd_buff_pos);
-	shell->ctx->temp_buff[shell->ctx->cmd_buff_pos] = '\0';
+	memcpy(sh->ctx->temp_buff, sh->ctx->cmd_buff,
+			sh->ctx->cmd_buff_pos);
+	sh->ctx->temp_buff[sh->ctx->cmd_buff_pos] = '\0';
 
 	/* Create argument list. */
-	(void)z_shell_make_argv(argc, *argv, shell->ctx->temp_buff,
+	(void)z_shell_make_argv(argc, *argv, sh->ctx->temp_buff,
 				CONFIG_SHELL_ARGC_MAX);
 
 	if (*argc > CONFIG_SHELL_ARGC_MAX) {
@@ -280,7 +280,7 @@ static bool tab_prepare(const struct shell *shell,
 	if ((IS_ENABLED(CONFIG_SHELL_CMDS_SELECT) || (CONFIG_SHELL_CMD_ROOT[0] != 0))
 	    && (*argc > 0) &&
 	    (strcmp("select", (*argv)[0]) == 0) &&
-	    !z_shell_in_select_mode(shell)) {
+	    !z_shell_in_select_mode(sh)) {
 		*argv = *argv + 1;
 		*argc = *argc - 1;
 	}
@@ -288,19 +288,19 @@ static bool tab_prepare(const struct shell *shell,
 	/* If last command is not completed (followed by space) it is treated
 	 * as uncompleted one.
 	 */
-	int space = isspace((int)shell->ctx->cmd_buff[
-						shell->ctx->cmd_buff_pos - 1]);
+	int space = isspace((int)sh->ctx->cmd_buff[
+						sh->ctx->cmd_buff_pos - 1]);
 
 	/* root command completion */
 	if ((*argc == 0) || ((space == 0) && (*argc == 1))) {
 		*complete_arg_idx = Z_SHELL_CMD_ROOT_LVL;
-		*cmd = selected_cmd_get(shell);
+		*cmd = selected_cmd_get(sh);
 		return true;
 	}
 
 	search_argc = space ? *argc : *argc - 1;
 
-	*cmd = z_shell_get_last_command(selected_cmd_get(shell), search_argc,
+	*cmd = z_shell_get_last_command(selected_cmd_get(sh), search_argc,
 					*argv, complete_arg_idx,	d_entry,
 					false);
 
@@ -320,7 +320,7 @@ static inline bool is_completion_candidate(const char *candidate,
 	return (strncmp(candidate, str, len) == 0) ? true : false;
 }
 
-static void find_completion_candidates(const struct shell *shell,
+static void find_completion_candidates(const struct shell *sh,
 				       const struct shell_static_entry *cmd,
 				       const char *incompl_cmd,
 				       size_t *first_idx, size_t *cnt,
@@ -351,7 +351,7 @@ static void find_completion_candidates(const struct shell *shell,
 	}
 }
 
-static void autocomplete(const struct shell *shell,
+static void autocomplete(const struct shell *sh,
 			 const struct shell_static_entry *cmd,
 			 const char *arg,
 			 size_t subcmd_idx)
@@ -360,10 +360,10 @@ static void autocomplete(const struct shell *shell,
 	uint16_t cmd_len;
 	uint16_t arg_len = z_shell_strlen(arg);
 
-	/* shell->ctx->active_cmd can be safely used outside of command context
+	/* sh->ctx->active_cmd can be safely used outside of command context
 	 * to save stack
 	 */
-	match = z_shell_cmd_get(cmd, subcmd_idx, &shell->ctx->active_cmd);
+	match = z_shell_cmd_get(cmd, subcmd_idx, &sh->ctx->active_cmd);
 	__ASSERT_NO_MSG(match != NULL);
 	cmd_len = z_shell_strlen(match->syntax);
 
@@ -372,34 +372,34 @@ static void autocomplete(const struct shell *shell,
 		 * complete.
 		 */
 		if (cmd_len == arg_len) {
-			z_shell_op_char_insert(shell, ' ');
+			z_shell_op_char_insert(sh, ' ');
 		}
 		return;
 	}
 
 	/* no exact match found */
 	if (cmd_len != arg_len) {
-		z_shell_op_completion_insert(shell,
+		z_shell_op_completion_insert(sh,
 					     match->syntax + arg_len,
 					     cmd_len - arg_len);
 	}
 
 	/* Next character in the buffer is not 'space'. */
-	if (isspace((int) shell->ctx->cmd_buff[
-					shell->ctx->cmd_buff_pos]) == 0) {
-		if (z_flag_insert_mode_get(shell)) {
-			z_flag_insert_mode_set(shell, false);
-			z_shell_op_char_insert(shell, ' ');
-			z_flag_insert_mode_set(shell, true);
+	if (isspace((int) sh->ctx->cmd_buff[
+					sh->ctx->cmd_buff_pos]) == 0) {
+		if (z_flag_insert_mode_get(sh)) {
+			z_flag_insert_mode_set(sh, false);
+			z_shell_op_char_insert(sh, ' ');
+			z_flag_insert_mode_set(sh, true);
 		} else {
-			z_shell_op_char_insert(shell, ' ');
+			z_shell_op_char_insert(sh, ' ');
 		}
 	} else {
 		/*  case:
 		 * | | -> cursor
 		 * cons_name $: valid_cmd valid_sub_cmd| |argument  <tab>
 		 */
-		z_shell_op_cursor_move(shell, 1);
+		z_shell_op_cursor_move(sh, 1);
 		/* result:
 		 * cons_name $: valid_cmd valid_sub_cmd |a|rgument
 		 */
@@ -420,7 +420,7 @@ static size_t str_common(const char *s1, const char *s2, size_t n)
 	return common;
 }
 
-static void tab_options_print(const struct shell *shell,
+static void tab_options_print(const struct shell *sh,
 			      const struct shell_static_entry *cmd,
 			      const char *str, size_t first, size_t cnt,
 			      uint16_t longest)
@@ -430,13 +430,13 @@ static void tab_options_print(const struct shell *shell,
 	size_t idx = first;
 
 	/* Printing all matching commands (options). */
-	tab_item_print(shell, SHELL_INIT_OPTION_PRINTER, longest);
+	tab_item_print(sh, SHELL_INIT_OPTION_PRINTER, longest);
 
 	while (cnt) {
-		/* shell->ctx->active_cmd can be safely used outside of command
+		/* sh->ctx->active_cmd can be safely used outside of command
 		 * context to save stack
 		 */
-		match = z_shell_cmd_get(cmd, idx, &shell->ctx->active_cmd);
+		match = z_shell_cmd_get(cmd, idx, &sh->ctx->active_cmd);
 		__ASSERT_NO_MSG(match != NULL);
 		idx++;
 		if (str && match->syntax &&
@@ -444,15 +444,15 @@ static void tab_options_print(const struct shell *shell,
 			continue;
 		}
 
-		tab_item_print(shell, match->syntax, longest);
+		tab_item_print(sh, match->syntax, longest);
 		cnt--;
 	}
 
-	z_cursor_next_line_move(shell);
-	z_shell_print_prompt_and_cmd(shell);
+	z_cursor_next_line_move(sh);
+	z_shell_print_prompt_and_cmd(sh);
 }
 
-static uint16_t common_beginning_find(const struct shell *shell,
+static uint16_t common_beginning_find(const struct shell *sh,
 				   const struct shell_static_entry *cmd,
 				   const char **str,
 				   size_t first, size_t cnt, uint16_t arg_len)
@@ -466,8 +466,8 @@ static uint16_t common_beginning_find(const struct shell *shell,
 
 	match = z_shell_cmd_get(cmd, first, &dynamic_entry);
 	__ASSERT_NO_MSG(match);
-	strncpy(shell->ctx->temp_buff, match->syntax,
-			sizeof(shell->ctx->temp_buff) - 1);
+	strncpy(sh->ctx->temp_buff, match->syntax,
+			sizeof(sh->ctx->temp_buff) - 1);
 
 	*str = match->syntax;
 
@@ -481,7 +481,7 @@ static uint16_t common_beginning_find(const struct shell *shell,
 			break;
 		}
 
-		curr_common = str_common(shell->ctx->temp_buff, match2->syntax,
+		curr_common = str_common(sh->ctx->temp_buff, match2->syntax,
 					 UINT16_MAX);
 		if ((arg_len == 0U) || (curr_common >= arg_len)) {
 			--cnt;
@@ -492,14 +492,14 @@ static uint16_t common_beginning_find(const struct shell *shell,
 	return common;
 }
 
-static void partial_autocomplete(const struct shell *shell,
+static void partial_autocomplete(const struct shell *sh,
 				 const struct shell_static_entry *cmd,
 				 const char *arg,
 				 size_t first, size_t cnt)
 {
 	const char *completion;
 	uint16_t arg_len = z_shell_strlen(arg);
-	uint16_t common = common_beginning_find(shell, cmd, &completion, first,
+	uint16_t common = common_beginning_find(sh, cmd, &completion, first,
 					     cnt, arg_len);
 
 	if (!IS_ENABLED(CONFIG_SHELL_TAB_AUTOCOMPLETION)) {
@@ -507,42 +507,42 @@ static void partial_autocomplete(const struct shell *shell,
 	}
 
 	if (common) {
-		z_shell_op_completion_insert(shell, &completion[arg_len],
+		z_shell_op_completion_insert(sh, &completion[arg_len],
 					     common - arg_len);
 	}
 }
 
-static int exec_cmd(const struct shell *shell, size_t argc, const char **argv,
+static int exec_cmd(const struct shell *sh, size_t argc, const char **argv,
 		    const struct shell_static_entry *help_entry)
 {
 	int ret_val = 0;
 
-	if (shell->ctx->active_cmd.handler == NULL) {
+	if (sh->ctx->active_cmd.handler == NULL) {
 		if ((help_entry != NULL) && IS_ENABLED(CONFIG_SHELL_HELP)) {
 			if (help_entry->help == NULL) {
 				return -ENOEXEC;
 			}
-			if (help_entry->help != shell->ctx->active_cmd.help) {
-				shell->ctx->active_cmd = *help_entry;
+			if (help_entry->help != sh->ctx->active_cmd.help) {
+				sh->ctx->active_cmd = *help_entry;
 			}
-			shell_internal_help_print(shell);
+			shell_internal_help_print(sh);
 			return SHELL_CMD_HELP_PRINTED;
 		} else {
-			z_shell_fprintf(shell, SHELL_ERROR,
+			z_shell_fprintf(sh, SHELL_ERROR,
 					SHELL_MSG_SPECIFY_SUBCOMMAND);
 			return -ENOEXEC;
 		}
 	}
 
-	if (shell->ctx->active_cmd.args.mandatory) {
-		uint32_t mand = shell->ctx->active_cmd.args.mandatory;
-		uint8_t opt8 = shell->ctx->active_cmd.args.optional;
+	if (sh->ctx->active_cmd.args.mandatory) {
+		uint32_t mand = sh->ctx->active_cmd.args.mandatory;
+		uint8_t opt8 = sh->ctx->active_cmd.args.optional;
 		uint32_t opt = (opt8 == SHELL_OPT_ARG_CHECK_SKIP) ?
 				UINT16_MAX : opt8;
 		const bool in_range = IN_RANGE(argc, mand, mand + opt);
 
 		/* Check if argc is within allowed range */
-		ret_val = cmd_precheck(shell, in_range);
+		ret_val = cmd_precheck(sh, in_range);
 	}
 
 	if (!ret_val) {
@@ -550,16 +550,16 @@ static int exec_cmd(const struct shell *shell, size_t argc, const char **argv,
 		getopt_init();
 #endif
 
-		z_flag_cmd_ctx_set(shell, true);
+		z_flag_cmd_ctx_set(sh, true);
 		/* Unlock thread mutex in case command would like to borrow
 		 * shell context to other thread to avoid mutex deadlock.
 		 */
-		k_mutex_unlock(&shell->ctx->wr_mtx);
-		ret_val = shell->ctx->active_cmd.handler(shell, argc,
+		k_mutex_unlock(&sh->ctx->wr_mtx);
+		ret_val = sh->ctx->active_cmd.handler(sh, argc,
 							 (char **)argv);
 		/* Bring back mutex to shell thread. */
-		k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
-		z_flag_cmd_ctx_set(shell, false);
+		k_mutex_lock(&sh->ctx->wr_mtx, K_FOREVER);
+		z_flag_cmd_ctx_set(sh, false);
 	}
 
 	return ret_val;
@@ -588,17 +588,17 @@ static void active_cmd_prepare(const struct shell_static_entry *entry,
 	}
 }
 
-static bool wildcard_check_report(const struct shell *shell, bool found,
+static bool wildcard_check_report(const struct shell *sh, bool found,
 				  const struct shell_static_entry *entry)
 {
 	/* An error occurred, fnmatch  argument cannot be followed by argument
 	 * with a handler to avoid multiple function calls.
 	 */
 	if (IS_ENABLED(CONFIG_SHELL_WILDCARD) && found && entry->handler) {
-		z_shell_op_cursor_end_move(shell);
-		z_shell_op_cond_next_line(shell);
+		z_shell_op_cursor_end_move(sh);
+		z_shell_op_cond_next_line(sh);
 
-		z_shell_fprintf(shell, SHELL_ERROR,
+		z_shell_fprintf(sh, SHELL_ERROR,
 			"Error: requested multiple function executions\n");
 		return false;
 	}
@@ -621,11 +621,11 @@ static bool wildcard_check_report(const struct shell *shell, bool found,
  * Because of that feature, command buffer is processed argument by argument and
  * decision on further processing is based on currently processed command.
  */
-static int execute(const struct shell *shell)
+static int execute(const struct shell *sh)
 {
 	struct shell_static_entry dloc; /* Memory for dynamic commands. */
 	const char *argv[CONFIG_SHELL_ARGC_MAX + 1] = {0}; /* +1 reserved for NULL */
-	const struct shell_static_entry *parent = selected_cmd_get(shell);
+	const struct shell_static_entry *parent = selected_cmd_get(sh);
 	const struct shell_static_entry *entry = NULL;
 	struct shell_static_entry help_entry;
 	size_t cmd_lvl = 0;
@@ -634,24 +634,24 @@ static int execute(const struct shell *shell)
 	size_t argc = 0, args_left = SIZE_MAX;
 	char quote;
 	const char **argvp;
-	char *cmd_buf = shell->ctx->cmd_buff;
+	char *cmd_buf = sh->ctx->cmd_buff;
 	bool has_last_handler = false;
 
-	z_shell_op_cursor_end_move(shell);
-	if (!z_shell_cursor_in_empty_line(shell)) {
-		z_cursor_next_line_move(shell);
+	z_shell_op_cursor_end_move(sh);
+	if (!z_shell_cursor_in_empty_line(sh)) {
+		z_cursor_next_line_move(sh);
 	}
 
-	memset(&shell->ctx->active_cmd, 0, sizeof(shell->ctx->active_cmd));
+	memset(&sh->ctx->active_cmd, 0, sizeof(sh->ctx->active_cmd));
 
 	if (IS_ENABLED(CONFIG_SHELL_HISTORY)) {
-		z_shell_cmd_trim(shell);
-		history_put(shell, shell->ctx->cmd_buff,
-			    shell->ctx->cmd_buff_len);
+		z_shell_cmd_trim(sh);
+		history_put(sh, sh->ctx->cmd_buff,
+			    sh->ctx->cmd_buff_len);
 	}
 
 	if (IS_ENABLED(CONFIG_SHELL_WILDCARD)) {
-		z_shell_wildcard_prepare(shell);
+		z_shell_wildcard_prepare(sh);
 	}
 
 	/* Parent present means we are in select mode. */
@@ -659,7 +659,7 @@ static int execute(const struct shell *shell)
 		argv[0] = parent->syntax;
 		argv[1] = cmd_buf;
 		argvp = &argv[1];
-		active_cmd_prepare(parent, &shell->ctx->active_cmd, &help_entry,
+		active_cmd_prepare(parent, &sh->ctx->active_cmd, &help_entry,
 				   &cmd_lvl, &cmd_with_handler_lvl, &args_left);
 		cmd_lvl++;
 	} else {
@@ -676,7 +676,7 @@ static int execute(const struct shell *shell)
 		if (argc == 0) {
 			return -ENOEXEC;
 		} else if ((argc == 1) && (quote != 0)) {
-			z_shell_fprintf(shell, SHELL_ERROR,
+			z_shell_fprintf(sh, SHELL_ERROR,
 					"not terminated: %c\n", quote);
 			return -ENOEXEC;
 		}
@@ -687,12 +687,12 @@ static int execute(const struct shell *shell)
 			 * to search deeper commands.
 			 */
 			if (help_entry.help) {
-				shell->ctx->active_cmd = help_entry;
-				shell_internal_help_print(shell);
+				sh->ctx->active_cmd = help_entry;
+				shell_internal_help_print(sh);
 				return SHELL_CMD_HELP_PRINTED;
 			}
 
-			z_shell_fprintf(shell, SHELL_ERROR,
+			z_shell_fprintf(sh, SHELL_ERROR,
 					SHELL_MSG_SPECIFY_SUBCOMMAND);
 			return -ENOEXEC;
 		}
@@ -700,7 +700,7 @@ static int execute(const struct shell *shell)
 		if (IS_ENABLED(CONFIG_SHELL_WILDCARD) && (cmd_lvl > 0)) {
 			enum shell_wildcard_status status;
 
-			status = z_shell_wildcard_process(shell, entry,
+			status = z_shell_wildcard_process(sh, entry,
 							  argvp[0]);
 			/* Wildcard character found but there is no matching
 			 * command.
@@ -726,20 +726,20 @@ static int execute(const struct shell *shell)
 		argvp++;
 		args_left--;
 		if (entry) {
-			if (wildcard_check_report(shell, wildcard_found, entry)
+			if (wildcard_check_report(sh, wildcard_found, entry)
 				== false) {
 				return -ENOEXEC;
 			}
 
-			active_cmd_prepare(entry, &shell->ctx->active_cmd,
+			active_cmd_prepare(entry, &sh->ctx->active_cmd,
 					  &help_entry, &cmd_lvl,
 					  &cmd_with_handler_lvl, &args_left);
 			parent = entry;
 		} else {
 			if (cmd_lvl == 0 &&
-				(!z_shell_in_select_mode(shell) ||
-				 shell->ctx->selected_cmd->handler == NULL)) {
-				z_shell_fprintf(shell, SHELL_ERROR,
+				(!z_shell_in_select_mode(sh) ||
+				 sh->ctx->selected_cmd->handler == NULL)) {
+				z_shell_fprintf(sh, SHELL_ERROR,
 						"%s%s\n", argv[0],
 						SHELL_MSG_CMD_NOT_FOUND);
 			}
@@ -761,23 +761,23 @@ static int execute(const struct shell *shell)
 		 * there was more characters remaining. It means that number of
 		 * arguments exceeds the limit.
 		 */
-		z_shell_fprintf(shell, SHELL_ERROR, "%s\n",
+		z_shell_fprintf(sh, SHELL_ERROR, "%s\n",
 				SHELL_MSG_TOO_MANY_ARGS);
 		return -ENOEXEC;
 	}
 
 	if (IS_ENABLED(CONFIG_SHELL_WILDCARD) && wildcard_found) {
-		z_shell_wildcard_finalize(shell);
+		z_shell_wildcard_finalize(sh);
 		/* cmd_buffer has been overwritten by function finalize function
 		 * with all expanded commands. Hence shell_make_argv needs to
 		 * be called again.
 		 */
 		(void)z_shell_make_argv(&cmd_lvl,
-					&argv[selected_cmd_get(shell) ? 1 : 0],
-					shell->ctx->cmd_buff,
+					&argv[selected_cmd_get(sh) ? 1 : 0],
+					sh->ctx->cmd_buff,
 					CONFIG_SHELL_ARGC_MAX);
 
-		if (selected_cmd_get(shell)) {
+		if (selected_cmd_get(sh)) {
 			/* Apart from what is in the command buffer, there is
 			 * a selected command.
 			 */
@@ -797,11 +797,11 @@ static int execute(const struct shell *shell)
 	}
 
 	/* Executing the deepest found handler. */
-	return exec_cmd(shell, cmd_lvl - cmd_with_handler_lvl,
+	return exec_cmd(sh, cmd_lvl - cmd_with_handler_lvl,
 			&argv[cmd_with_handler_lvl], &help_entry);
 }
 
-static void tab_handle(const struct shell *shell)
+static void tab_handle(const struct shell *sh)
 {
 	const char *__argv[CONFIG_SHELL_ARGC_MAX + 1];
 	/* d_entry - placeholder for dynamic command */
@@ -814,53 +814,53 @@ static void tab_handle(const struct shell *shell)
 	size_t argc;
 	size_t cnt;
 
-	bool tab_possible = tab_prepare(shell, &cmd, &argv, &argc, &arg_idx,
+	bool tab_possible = tab_prepare(sh, &cmd, &argv, &argc, &arg_idx,
 					&d_entry);
 
 	if (tab_possible == false) {
 		return;
 	}
 
-	find_completion_candidates(shell, cmd, argv[arg_idx], &first, &cnt,
+	find_completion_candidates(sh, cmd, argv[arg_idx], &first, &cnt,
 				   &longest);
 
 	if (cnt == 1) {
 		/* Autocompletion.*/
-		autocomplete(shell, cmd, argv[arg_idx], first);
+		autocomplete(sh, cmd, argv[arg_idx], first);
 	} else if (cnt > 1) {
-		tab_options_print(shell, cmd, argv[arg_idx], first, cnt,
+		tab_options_print(sh, cmd, argv[arg_idx], first, cnt,
 				  longest);
-		partial_autocomplete(shell, cmd, argv[arg_idx], first, cnt);
+		partial_autocomplete(sh, cmd, argv[arg_idx], first, cnt);
 	}
 }
 
-static void alt_metakeys_handle(const struct shell *shell, char data)
+static void alt_metakeys_handle(const struct shell *sh, char data)
 {
 	/* Optional feature */
 	if (!IS_ENABLED(CONFIG_SHELL_METAKEYS)) {
 		return;
 	}
 	if (data == SHELL_VT100_ASCII_ALT_B) {
-		z_shell_op_cursor_word_move(shell, -1);
+		z_shell_op_cursor_word_move(sh, -1);
 	} else if (data == SHELL_VT100_ASCII_ALT_F) {
-		z_shell_op_cursor_word_move(shell, 1);
+		z_shell_op_cursor_word_move(sh, 1);
 	} else if (data == SHELL_VT100_ASCII_ALT_R &&
 		   IS_ENABLED(CONFIG_SHELL_CMDS_SELECT)) {
-		if (selected_cmd_get(shell) != NULL) {
-			z_shell_cmd_line_erase(shell);
-			z_shell_fprintf(shell, SHELL_WARNING,
+		if (selected_cmd_get(sh) != NULL) {
+			z_shell_cmd_line_erase(sh);
+			z_shell_fprintf(sh, SHELL_WARNING,
 					"Restored default root commands\n");
 			if (CONFIG_SHELL_CMD_ROOT[0]) {
-				shell->ctx->selected_cmd = root_cmd_find(CONFIG_SHELL_CMD_ROOT);
+				sh->ctx->selected_cmd = root_cmd_find(CONFIG_SHELL_CMD_ROOT);
 			} else {
-				shell->ctx->selected_cmd = NULL;
+				sh->ctx->selected_cmd = NULL;
 			}
-			z_shell_print_prompt_and_cmd(shell);
+			z_shell_print_prompt_and_cmd(sh);
 		}
 	}
 }
 
-static void ctrl_metakeys_handle(const struct shell *shell, char data)
+static void ctrl_metakeys_handle(const struct shell *sh, char data)
 {
 	/* Optional feature */
 	if (!IS_ENABLED(CONFIG_SHELL_METAKEYS)) {
@@ -869,62 +869,62 @@ static void ctrl_metakeys_handle(const struct shell *shell, char data)
 
 	switch (data) {
 	case SHELL_VT100_ASCII_CTRL_A: /* CTRL + A */
-		z_shell_op_cursor_home_move(shell);
+		z_shell_op_cursor_home_move(sh);
 		break;
 
 	case SHELL_VT100_ASCII_CTRL_B: /* CTRL + B */
-		z_shell_op_left_arrow(shell);
+		z_shell_op_left_arrow(sh);
 		break;
 
 	case SHELL_VT100_ASCII_CTRL_C: /* CTRL + C */
-		z_shell_op_cursor_end_move(shell);
-		if (!z_shell_cursor_in_empty_line(shell)) {
-			z_cursor_next_line_move(shell);
+		z_shell_op_cursor_end_move(sh);
+		if (!z_shell_cursor_in_empty_line(sh)) {
+			z_cursor_next_line_move(sh);
 		}
-		z_flag_history_exit_set(shell, true);
-		state_set(shell, SHELL_STATE_ACTIVE);
+		z_flag_history_exit_set(sh, true);
+		state_set(sh, SHELL_STATE_ACTIVE);
 		break;
 
 	case SHELL_VT100_ASCII_CTRL_D: /* CTRL + D */
-		z_shell_op_char_delete(shell);
+		z_shell_op_char_delete(sh);
 		break;
 
 	case SHELL_VT100_ASCII_CTRL_E: /* CTRL + E */
-		z_shell_op_cursor_end_move(shell);
+		z_shell_op_cursor_end_move(sh);
 		break;
 
 	case SHELL_VT100_ASCII_CTRL_F: /* CTRL + F */
-		z_shell_op_right_arrow(shell);
+		z_shell_op_right_arrow(sh);
 		break;
 
 	case SHELL_VT100_ASCII_CTRL_K: /* CTRL + K */
-		z_shell_op_delete_from_cursor(shell);
+		z_shell_op_delete_from_cursor(sh);
 		break;
 
 	case SHELL_VT100_ASCII_CTRL_L: /* CTRL + L */
-		Z_SHELL_VT100_CMD(shell, SHELL_VT100_CURSORHOME);
-		Z_SHELL_VT100_CMD(shell, SHELL_VT100_CLEARSCREEN);
-		z_shell_print_prompt_and_cmd(shell);
+		Z_SHELL_VT100_CMD(sh, SHELL_VT100_CURSORHOME);
+		Z_SHELL_VT100_CMD(sh, SHELL_VT100_CLEARSCREEN);
+		z_shell_print_prompt_and_cmd(sh);
 		break;
 
 	case SHELL_VT100_ASCII_CTRL_N: /* CTRL + N */
-		history_handle(shell, false);
+		history_handle(sh, false);
 		break;
 
 	case SHELL_VT100_ASCII_CTRL_P: /* CTRL + P */
-		history_handle(shell, true);
+		history_handle(sh, true);
 		break;
 
 	case SHELL_VT100_ASCII_CTRL_U: /* CTRL + U */
-		z_shell_op_cursor_home_move(shell);
-		cmd_buffer_clear(shell);
-		z_flag_history_exit_set(shell, true);
-		z_clear_eos(shell);
+		z_shell_op_cursor_home_move(sh);
+		cmd_buffer_clear(sh);
+		z_flag_history_exit_set(sh, true);
+		z_clear_eos(sh);
 		break;
 
 	case SHELL_VT100_ASCII_CTRL_W: /* CTRL + W */
-		z_shell_op_word_remove(shell);
-		z_flag_history_exit_set(shell, true);
+		z_shell_op_word_remove(sh);
+		z_flag_history_exit_set(sh, true);
 		break;
 
 	default:
@@ -933,16 +933,16 @@ static void ctrl_metakeys_handle(const struct shell *shell, char data)
 }
 
 /* Functions returns true if new line character shall be processed */
-static bool process_nl(const struct shell *shell, uint8_t data)
+static bool process_nl(const struct shell *sh, uint8_t data)
 {
 	if ((data != '\r') && (data != '\n')) {
-		z_flag_last_nl_set(shell, 0);
+		z_flag_last_nl_set(sh, 0);
 		return false;
 	}
 
-	if ((z_flag_last_nl_get(shell) == 0U) ||
-	    (data == z_flag_last_nl_get(shell))) {
-		z_flag_last_nl_set(shell, data);
+	if ((z_flag_last_nl_get(sh) == 0U) ||
+	    (data == z_flag_last_nl_get(sh))) {
+		z_flag_last_nl_set(sh, data);
 		return true;
 	}
 
@@ -955,26 +955,26 @@ static inline int ascii_filter(const char data)
 	return (uint8_t) data > SHELL_ASCII_MAX_CHAR ? -EINVAL : 0;
 }
 
-static void state_collect(const struct shell *shell)
+static void state_collect(const struct shell *sh)
 {
 	size_t count = 0;
 	char data;
 
 	while (true) {
-		shell_bypass_cb_t bypass = shell->ctx->bypass;
+		shell_bypass_cb_t bypass = sh->ctx->bypass;
 
 		if (bypass) {
 			uint8_t buf[16];
 
-			(void)shell->iface->api->read(shell->iface, buf,
+			(void)sh->iface->api->read(sh->iface, buf,
 							sizeof(buf), &count);
 			if (count) {
-				z_flag_cmd_ctx_set(shell, true);
-				bypass(shell, buf, count);
-				z_flag_cmd_ctx_set(shell, false);
+				z_flag_cmd_ctx_set(sh, true);
+				bypass(sh, buf, count);
+				z_flag_cmd_ctx_set(sh, false);
 				/* Check if bypass mode ended. */
-				if (!(volatile shell_bypass_cb_t *)shell->ctx->bypass) {
-					state_set(shell, SHELL_STATE_ACTIVE);
+				if (!(volatile shell_bypass_cb_t *)sh->ctx->bypass) {
+					state_set(sh, SHELL_STATE_ACTIVE);
 				} else {
 					continue;
 				}
@@ -983,7 +983,7 @@ static void state_collect(const struct shell *shell)
 			return;
 		}
 
-		(void)shell->iface->api->read(shell->iface, &data,
+		(void)sh->iface->api->read(sh->iface, &data,
 					      sizeof(data), &count);
 		if (count == 0) {
 			return;
@@ -993,69 +993,69 @@ static void state_collect(const struct shell *shell)
 			continue;
 		}
 
-		switch (shell->ctx->receive_state) {
+		switch (sh->ctx->receive_state) {
 		case SHELL_RECEIVE_DEFAULT:
-			if (process_nl(shell, data)) {
-				if (!shell->ctx->cmd_buff_len) {
-					history_mode_exit(shell);
-					z_cursor_next_line_move(shell);
+			if (process_nl(sh, data)) {
+				if (!sh->ctx->cmd_buff_len) {
+					history_mode_exit(sh);
+					z_cursor_next_line_move(sh);
 				} else {
 					/* Command execution */
-					(void)execute(shell);
+					(void)execute(sh);
 				}
 				/* Function responsible for printing prompt
 				 * on received NL.
 				 */
-				state_set(shell, SHELL_STATE_ACTIVE);
+				state_set(sh, SHELL_STATE_ACTIVE);
 				continue;
 			}
 
 			switch (data) {
 			case SHELL_VT100_ASCII_ESC: /* ESCAPE */
-				receive_state_change(shell, SHELL_RECEIVE_ESC);
+				receive_state_change(sh, SHELL_RECEIVE_ESC);
 				break;
 
 			case '\0':
 				break;
 
 			case '\t': /* TAB */
-				if (z_flag_echo_get(shell) &&
+				if (z_flag_echo_get(sh) &&
 				    IS_ENABLED(CONFIG_SHELL_TAB)) {
 					/* If the Tab key is pressed, "history
 					 * mode" must be terminated because
 					 * tab and history handlers are sharing
 					 * the same array: temp_buff.
 					 */
-					z_flag_history_exit_set(shell, true);
-					tab_handle(shell);
+					z_flag_history_exit_set(sh, true);
+					tab_handle(sh);
 				}
 				break;
 
 			case SHELL_VT100_ASCII_BSPACE: /* BACKSPACE */
-				if (z_flag_echo_get(shell)) {
-					z_flag_history_exit_set(shell, true);
-					z_shell_op_char_backspace(shell);
+				if (z_flag_echo_get(sh)) {
+					z_flag_history_exit_set(sh, true);
+					z_shell_op_char_backspace(sh);
 				}
 				break;
 
 			case SHELL_VT100_ASCII_DEL: /* DELETE */
-				if (z_flag_echo_get(shell)) {
-					z_flag_history_exit_set(shell, true);
-					if (z_flag_mode_delete_get(shell)) {
-						z_shell_op_char_backspace(shell);
+				if (z_flag_echo_get(sh)) {
+					z_flag_history_exit_set(sh, true);
+					if (z_flag_mode_delete_get(sh)) {
+						z_shell_op_char_backspace(sh);
 
 					} else {
-						z_shell_op_char_delete(shell);
+						z_shell_op_char_delete(sh);
 					}
 				}
 				break;
 
 			default:
 				if (isprint((int) data) != 0) {
-					z_flag_history_exit_set(shell, true);
-					z_shell_op_char_insert(shell, data);
-				} else if (z_flag_echo_get(shell)) {
-					ctrl_metakeys_handle(shell, data);
+					z_flag_history_exit_set(sh, true);
+					z_shell_op_char_insert(sh, data);
+				} else if (z_flag_echo_get(sh)) {
+					ctrl_metakeys_handle(sh, data);
 				}
 				break;
 			}
@@ -1063,70 +1063,70 @@ static void state_collect(const struct shell *shell)
 
 		case SHELL_RECEIVE_ESC:
 			if (data == '[') {
-				receive_state_change(shell,
+				receive_state_change(sh,
 						SHELL_RECEIVE_ESC_SEQ);
 				break;
-			} else if (z_flag_echo_get(shell)) {
-				alt_metakeys_handle(shell, data);
+			} else if (z_flag_echo_get(sh)) {
+				alt_metakeys_handle(sh, data);
 			}
-			receive_state_change(shell, SHELL_RECEIVE_DEFAULT);
+			receive_state_change(sh, SHELL_RECEIVE_DEFAULT);
 			break;
 
 		case SHELL_RECEIVE_ESC_SEQ:
-			receive_state_change(shell, SHELL_RECEIVE_DEFAULT);
+			receive_state_change(sh, SHELL_RECEIVE_DEFAULT);
 
-			if (!z_flag_echo_get(shell)) {
+			if (!z_flag_echo_get(sh)) {
 				continue;
 			}
 
 			switch (data) {
 			case 'A': /* UP arrow */
-				history_handle(shell, true);
+				history_handle(sh, true);
 				break;
 
 			case 'B': /* DOWN arrow */
-				history_handle(shell, false);
+				history_handle(sh, false);
 				break;
 
 			case 'C': /* RIGHT arrow */
-				z_shell_op_right_arrow(shell);
+				z_shell_op_right_arrow(sh);
 				break;
 
 			case 'D': /* LEFT arrow */
-				z_shell_op_left_arrow(shell);
+				z_shell_op_left_arrow(sh);
 				break;
 
 			case '4': /* END Button in ESC[n~ mode */
-				receive_state_change(shell,
+				receive_state_change(sh,
 						SHELL_RECEIVE_TILDE_EXP);
 				__fallthrough;
 			case 'F': /* END Button in VT100 mode */
-				z_shell_op_cursor_end_move(shell);
+				z_shell_op_cursor_end_move(sh);
 				break;
 
 			case '1': /* HOME Button in ESC[n~ mode */
-				receive_state_change(shell,
+				receive_state_change(sh,
 						SHELL_RECEIVE_TILDE_EXP);
 				__fallthrough;
 			case 'H': /* HOME Button in VT100 mode */
-				z_shell_op_cursor_home_move(shell);
+				z_shell_op_cursor_home_move(sh);
 				break;
 
 			case '2': /* INSERT Button in ESC[n~ mode */
-				receive_state_change(shell,
+				receive_state_change(sh,
 						SHELL_RECEIVE_TILDE_EXP);
 				__fallthrough;
 			case 'L': {/* INSERT Button in VT100 mode */
-				bool status = z_flag_insert_mode_get(shell);
-				z_flag_insert_mode_set(shell, !status);
+				bool status = z_flag_insert_mode_get(sh);
+				z_flag_insert_mode_set(sh, !status);
 				break;
 			}
 
 			case '3':/* DELETE Button in ESC[n~ mode */
-				receive_state_change(shell,
+				receive_state_change(sh,
 						SHELL_RECEIVE_TILDE_EXP);
-				if (z_flag_echo_get(shell)) {
-					z_shell_op_char_delete(shell);
+				if (z_flag_echo_get(sh)) {
+					z_shell_op_char_delete(sh);
 				}
 				break;
 
@@ -1136,30 +1136,30 @@ static void state_collect(const struct shell *shell)
 			break;
 
 		case SHELL_RECEIVE_TILDE_EXP:
-			receive_state_change(shell, SHELL_RECEIVE_DEFAULT);
+			receive_state_change(sh, SHELL_RECEIVE_DEFAULT);
 			break;
 
 		default:
-			receive_state_change(shell, SHELL_RECEIVE_DEFAULT);
+			receive_state_change(sh, SHELL_RECEIVE_DEFAULT);
 			break;
 		}
 	}
 
-	z_transport_buffer_flush(shell);
+	z_transport_buffer_flush(sh);
 }
 
 static void transport_evt_handler(enum shell_transport_evt evt_type, void *ctx)
 {
-	struct shell *shell = (struct shell *)ctx;
+	struct shell *sh = (struct shell *)ctx;
 	struct k_poll_signal *signal;
 
 	signal = (evt_type == SHELL_TRANSPORT_EVT_RX_RDY) ?
-			&shell->ctx->signals[SHELL_SIGNAL_RXRDY] :
-			&shell->ctx->signals[SHELL_SIGNAL_TXDONE];
+			&sh->ctx->signals[SHELL_SIGNAL_RXRDY] :
+			&sh->ctx->signals[SHELL_SIGNAL_TXDONE];
 	k_poll_signal_raise(signal, 0);
 }
 
-static void shell_log_process(const struct shell *shell)
+static void shell_log_process(const struct shell *sh)
 {
 	bool processed = false;
 	int signaled = 0;
@@ -1167,21 +1167,21 @@ static void shell_log_process(const struct shell *shell)
 
 	do {
 		if (!IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE)) {
-			z_shell_cmd_line_erase(shell);
+			z_shell_cmd_line_erase(sh);
 
 			processed = z_shell_log_backend_process(
-					shell->log_backend);
+					sh->log_backend);
 		}
 
 		struct k_poll_signal *signal =
-			&shell->ctx->signals[SHELL_SIGNAL_RXRDY];
+			&sh->ctx->signals[SHELL_SIGNAL_RXRDY];
 
-		z_shell_print_prompt_and_cmd(shell);
+		z_shell_print_prompt_and_cmd(sh);
 
 		/* Arbitrary delay added to ensure that prompt is
 		 * readable and can be used to enter further commands.
 		 */
-		if (shell->ctx->cmd_buff_len) {
+		if (sh->ctx->cmd_buff_len) {
 			k_sleep(K_MSEC(15));
 		}
 
@@ -1247,40 +1247,40 @@ static int instance_init(const struct shell *sh,
 	return ret;
 }
 
-static int instance_uninit(const struct shell *shell)
+static int instance_uninit(const struct shell *sh)
 {
-	__ASSERT_NO_MSG(shell);
-	__ASSERT_NO_MSG(shell->ctx && shell->iface);
+	__ASSERT_NO_MSG(sh);
+	__ASSERT_NO_MSG(sh->ctx && sh->iface);
 
 	int err;
 
-	if (z_flag_processing_get(shell)) {
+	if (z_flag_processing_get(sh)) {
 		return -EBUSY;
 	}
 
 	if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
 		/* todo purge log queue */
-		z_shell_log_backend_disable(shell->log_backend);
+		z_shell_log_backend_disable(sh->log_backend);
 	}
 
-	err = shell->iface->api->uninit(shell->iface);
+	err = sh->iface->api->uninit(sh->iface);
 	if (err != 0) {
 		return err;
 	}
 
-	history_purge(shell);
-	state_set(shell, SHELL_STATE_UNINITIALIZED);
+	history_purge(sh);
+	state_set(sh, SHELL_STATE_UNINITIALIZED);
 
 	return 0;
 }
 
-typedef void (*shell_signal_handler_t)(const struct shell *shell);
+typedef void (*shell_signal_handler_t)(const struct shell *sh);
 
-static void shell_signal_handle(const struct shell *shell,
+static void shell_signal_handle(const struct shell *sh,
 				enum shell_signal sig_idx,
 				shell_signal_handler_t handler)
 {
-	struct k_poll_signal *signal = &shell->ctx->signals[sig_idx];
+	struct k_poll_signal *signal = &sh->ctx->signals[sig_idx];
 	int set;
 	int res;
 
@@ -1288,44 +1288,44 @@ static void shell_signal_handle(const struct shell *shell,
 
 	if (set) {
 		k_poll_signal_reset(signal);
-		handler(shell);
+		handler(sh);
 	}
 }
 
-static void kill_handler(const struct shell *shell)
+static void kill_handler(const struct shell *sh)
 {
-	int err = instance_uninit(shell);
+	int err = instance_uninit(sh);
 
-	if (shell->ctx->uninit_cb) {
-		shell->ctx->uninit_cb(shell, err);
+	if (sh->ctx->uninit_cb) {
+		sh->ctx->uninit_cb(sh, err);
 	}
 
-	shell->ctx->tid = NULL;
+	sh->ctx->tid = NULL;
 	k_thread_abort(k_current_get());
 }
 
 void shell_thread(void *shell_handle, void *arg_log_backend,
 		  void *arg_log_level)
 {
-	struct shell *shell = shell_handle;
+	struct shell *sh = shell_handle;
 	bool log_backend = (bool)arg_log_backend;
 	uint32_t log_level = POINTER_TO_UINT(arg_log_level);
 	int err;
 
-	err = shell->iface->api->enable(shell->iface, false);
+	err = sh->iface->api->enable(sh->iface, false);
 	if (err != 0) {
 		return;
 	}
 
 	if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND) && log_backend
 	    && !IS_ENABLED(CONFIG_SHELL_START_OBSCURED)) {
-		z_shell_log_backend_enable(shell->log_backend, (void *)shell,
+		z_shell_log_backend_enable(sh->log_backend, (void *)sh,
 					   log_level);
 	}
 
 	if (IS_ENABLED(CONFIG_SHELL_AUTOSTART)) {
 		/* Enable shell and print prompt. */
-		err = shell_start(shell);
+		err = shell_start(sh);
 		if (err != 0) {
 			return;
 		}
@@ -1333,152 +1333,152 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 
 	while (true) {
 		/* waiting for all signals except SHELL_SIGNAL_TXDONE */
-		err = k_poll(shell->ctx->events, SHELL_SIGNAL_TXDONE,
+		err = k_poll(sh->ctx->events, SHELL_SIGNAL_TXDONE,
 			     K_FOREVER);
 
 		if (err != 0) {
-			k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
-			z_shell_fprintf(shell, SHELL_ERROR,
+			k_mutex_lock(&sh->ctx->wr_mtx, K_FOREVER);
+			z_shell_fprintf(sh, SHELL_ERROR,
 					"Shell thread error: %d", err);
-			k_mutex_unlock(&shell->ctx->wr_mtx);
+			k_mutex_unlock(&sh->ctx->wr_mtx);
 			return;
 		}
 
-		k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
+		k_mutex_lock(&sh->ctx->wr_mtx, K_FOREVER);
 
-		shell_signal_handle(shell, SHELL_SIGNAL_KILL, kill_handler);
-		shell_signal_handle(shell, SHELL_SIGNAL_RXRDY, shell_process);
+		shell_signal_handle(sh, SHELL_SIGNAL_KILL, kill_handler);
+		shell_signal_handle(sh, SHELL_SIGNAL_RXRDY, shell_process);
 		if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
-			shell_signal_handle(shell, SHELL_SIGNAL_LOG_MSG,
+			shell_signal_handle(sh, SHELL_SIGNAL_LOG_MSG,
 					    shell_log_process);
 		}
 
-		if (shell->iface->api->update) {
-			shell->iface->api->update(shell->iface);
+		if (sh->iface->api->update) {
+			sh->iface->api->update(sh->iface);
 		}
 
-		k_mutex_unlock(&shell->ctx->wr_mtx);
+		k_mutex_unlock(&sh->ctx->wr_mtx);
 	}
 }
 
-int shell_init(const struct shell *shell, const void *transport_config,
+int shell_init(const struct shell *sh, const void *transport_config,
 	       struct shell_backend_config_flags cfg_flags,
 	       bool log_backend, uint32_t init_log_level)
 {
-	__ASSERT_NO_MSG(shell);
-	__ASSERT_NO_MSG(shell->ctx && shell->iface && shell->default_prompt);
+	__ASSERT_NO_MSG(sh);
+	__ASSERT_NO_MSG(sh->ctx && sh->iface && sh->default_prompt);
 
-	if (shell->ctx->tid) {
+	if (sh->ctx->tid) {
 		return -EALREADY;
 	}
 
-	int err = instance_init(shell, transport_config, cfg_flags);
+	int err = instance_init(sh, transport_config, cfg_flags);
 
 	if (err != 0) {
 		return err;
 	}
 
-	k_tid_t tid = k_thread_create(shell->thread,
-				  shell->stack, CONFIG_SHELL_STACK_SIZE,
-				  shell_thread, (void *)shell, (void *)log_backend,
+	k_tid_t tid = k_thread_create(sh->thread,
+				  sh->stack, CONFIG_SHELL_STACK_SIZE,
+				  shell_thread, (void *)sh, (void *)log_backend,
 				  UINT_TO_POINTER(init_log_level),
 				  SHELL_THREAD_PRIORITY, 0, K_NO_WAIT);
 
-	shell->ctx->tid = tid;
-	k_thread_name_set(tid, shell->thread_name);
+	sh->ctx->tid = tid;
+	k_thread_name_set(tid, sh->thread_name);
 
 	return 0;
 }
 
-void shell_uninit(const struct shell *shell, shell_uninit_cb_t cb)
+void shell_uninit(const struct shell *sh, shell_uninit_cb_t cb)
 {
-	__ASSERT_NO_MSG(shell);
+	__ASSERT_NO_MSG(sh);
 
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		struct k_poll_signal *signal =
-				&shell->ctx->signals[SHELL_SIGNAL_KILL];
+				&sh->ctx->signals[SHELL_SIGNAL_KILL];
 
-		shell->ctx->uninit_cb = cb;
+		sh->ctx->uninit_cb = cb;
 		/* signal kill message */
 		(void)k_poll_signal_raise(signal, 0);
 
 		return;
 	}
 
-	int err = instance_uninit(shell);
+	int err = instance_uninit(sh);
 
 	if (cb) {
-		cb(shell, err);
+		cb(sh, err);
 	} else {
 		__ASSERT_NO_MSG(0);
 	}
 }
 
-int shell_start(const struct shell *shell)
+int shell_start(const struct shell *sh)
 {
-	__ASSERT_NO_MSG(shell);
-	__ASSERT_NO_MSG(shell->ctx && shell->iface && shell->default_prompt);
+	__ASSERT_NO_MSG(sh);
+	__ASSERT_NO_MSG(sh->ctx && sh->iface && sh->default_prompt);
 
-	if (state_get(shell) != SHELL_STATE_INITIALIZED) {
+	if (state_get(sh) != SHELL_STATE_INITIALIZED) {
 		return -ENOTSUP;
 	}
 
-	k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
+	k_mutex_lock(&sh->ctx->wr_mtx, K_FOREVER);
 
 	if (IS_ENABLED(CONFIG_SHELL_VT100_COLORS)) {
-		z_shell_vt100_color_set(shell, SHELL_NORMAL);
+		z_shell_vt100_color_set(sh, SHELL_NORMAL);
 	}
 
-	if (z_shell_strlen(shell->default_prompt) > 0) {
-		z_shell_raw_fprintf(shell->fprintf_ctx, "\n\n");
+	if (z_shell_strlen(sh->default_prompt) > 0) {
+		z_shell_raw_fprintf(sh->fprintf_ctx, "\n\n");
 	}
-	state_set(shell, SHELL_STATE_ACTIVE);
+	state_set(sh, SHELL_STATE_ACTIVE);
 
-	k_mutex_unlock(&shell->ctx->wr_mtx);
+	k_mutex_unlock(&sh->ctx->wr_mtx);
 
 	return 0;
 }
 
-int shell_stop(const struct shell *shell)
+int shell_stop(const struct shell *sh)
 {
-	__ASSERT_NO_MSG(shell);
-	__ASSERT_NO_MSG(shell->ctx);
+	__ASSERT_NO_MSG(sh);
+	__ASSERT_NO_MSG(sh->ctx);
 
-	enum shell_state state = state_get(shell);
+	enum shell_state state = state_get(sh);
 
 	if ((state == SHELL_STATE_INITIALIZED) ||
 	    (state == SHELL_STATE_UNINITIALIZED)) {
 		return -ENOTSUP;
 	}
 
-	state_set(shell, SHELL_STATE_INITIALIZED);
+	state_set(sh, SHELL_STATE_INITIALIZED);
 
 	return 0;
 }
 
-void shell_process(const struct shell *shell)
+void shell_process(const struct shell *sh)
 {
-	__ASSERT_NO_MSG(shell);
-	__ASSERT_NO_MSG(shell->ctx);
+	__ASSERT_NO_MSG(sh);
+	__ASSERT_NO_MSG(sh->ctx);
 
 	/* atomically set the processing flag */
-	z_flag_processing_set(shell, true);
+	z_flag_processing_set(sh, true);
 
-	switch (shell->ctx->state) {
+	switch (sh->ctx->state) {
 	case SHELL_STATE_UNINITIALIZED:
 	case SHELL_STATE_INITIALIZED:
 		/* Console initialized but not started. */
 		break;
 
 	case SHELL_STATE_ACTIVE:
-		state_collect(shell);
+		state_collect(sh);
 		break;
 	default:
 		break;
 	}
 
 	/* atomically clear the processing flag */
-	z_flag_processing_set(shell, false);
+	z_flag_processing_set(sh, false);
 }
 
 /* This function mustn't be used from shell context to avoid deadlock.
@@ -1516,61 +1516,61 @@ void shell_vfprintf(const struct shell *sh, enum shell_vt100_color color,
 /* This function mustn't be used from shell context to avoid deadlock.
  * However it can be used in shell command handlers.
  */
-void shell_fprintf(const struct shell *shell, enum shell_vt100_color color,
+void shell_fprintf(const struct shell *sh, enum shell_vt100_color color,
 		   const char *fmt, ...)
 {
 	va_list args;
 
 	va_start(args, fmt);
-	shell_vfprintf(shell, color, fmt, args);
+	shell_vfprintf(sh, color, fmt, args);
 	va_end(args);
 }
 
-void shell_hexdump_line(const struct shell *shell, unsigned int offset,
+void shell_hexdump_line(const struct shell *sh, unsigned int offset,
 			const uint8_t *data, size_t len)
 {
-	__ASSERT_NO_MSG(shell);
+	__ASSERT_NO_MSG(sh);
 
 	int i;
 
-	shell_fprintf(shell, SHELL_NORMAL, "%08X: ", offset);
+	shell_fprintf(sh, SHELL_NORMAL, "%08X: ", offset);
 
 	for (i = 0; i < SHELL_HEXDUMP_BYTES_IN_LINE; i++) {
 		if (i > 0 && !(i % 8)) {
-			shell_fprintf(shell, SHELL_NORMAL, " ");
+			shell_fprintf(sh, SHELL_NORMAL, " ");
 		}
 
 		if (i < len) {
-			shell_fprintf(shell, SHELL_NORMAL, "%02x ",
+			shell_fprintf(sh, SHELL_NORMAL, "%02x ",
 				      data[i] & 0xFF);
 		} else {
-			shell_fprintf(shell, SHELL_NORMAL, "   ");
+			shell_fprintf(sh, SHELL_NORMAL, "   ");
 		}
 	}
 
-	shell_fprintf(shell, SHELL_NORMAL, "|");
+	shell_fprintf(sh, SHELL_NORMAL, "|");
 
 	for (i = 0; i < SHELL_HEXDUMP_BYTES_IN_LINE; i++) {
 		if (i > 0 && !(i % 8)) {
-			shell_fprintf(shell, SHELL_NORMAL, " ");
+			shell_fprintf(sh, SHELL_NORMAL, " ");
 		}
 
 		if (i < len) {
 			char c = data[i];
 
-			shell_fprintf(shell, SHELL_NORMAL, "%c",
+			shell_fprintf(sh, SHELL_NORMAL, "%c",
 				      isprint((int)c) != 0 ? c : '.');
 		} else {
-			shell_fprintf(shell, SHELL_NORMAL, " ");
+			shell_fprintf(sh, SHELL_NORMAL, " ");
 		}
 	}
 
-	shell_print(shell, "|");
+	shell_print(sh, "|");
 }
 
-void shell_hexdump(const struct shell *shell, const uint8_t *data, size_t len)
+void shell_hexdump(const struct shell *sh, const uint8_t *data, size_t len)
 {
-	__ASSERT_NO_MSG(shell);
+	__ASSERT_NO_MSG(sh);
 
 	const uint8_t *p = data;
 	size_t line_len;
@@ -1578,31 +1578,31 @@ void shell_hexdump(const struct shell *shell, const uint8_t *data, size_t len)
 	while (len) {
 		line_len = MIN(len, SHELL_HEXDUMP_BYTES_IN_LINE);
 
-		shell_hexdump_line(shell, p - data, p, line_len);
+		shell_hexdump_line(sh, p - data, p, line_len);
 
 		len -= line_len;
 		p += line_len;
 	}
 }
 
-int shell_prompt_change(const struct shell *shell, const char *prompt)
+int shell_prompt_change(const struct shell *sh, const char *prompt)
 {
-	__ASSERT_NO_MSG(shell);
+	__ASSERT_NO_MSG(sh);
 
 	if (prompt == NULL) {
 		return -EINVAL;
 	}
-	shell->ctx->prompt = prompt;
-	shell->ctx->vt100_ctx.cons.name_len = z_shell_strlen(prompt);
+	sh->ctx->prompt = prompt;
+	sh->ctx->vt100_ctx.cons.name_len = z_shell_strlen(prompt);
 
 	return 0;
 }
 
-void shell_help(const struct shell *shell)
+void shell_help(const struct shell *sh)
 {
-	k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
-	shell_internal_help_print(shell);
-	k_mutex_unlock(&shell->ctx->wr_mtx);
+	k_mutex_lock(&sh->ctx->wr_mtx, K_FOREVER);
+	shell_internal_help_print(sh);
+	k_mutex_unlock(&sh->ctx->wr_mtx);
 }
 
 int shell_execute_cmd(const struct shell *sh, const char *cmd)
@@ -1642,22 +1642,22 @@ int shell_execute_cmd(const struct shell *sh, const char *cmd)
 	return ret_val;
 }
 
-int shell_insert_mode_set(const struct shell *shell, bool val)
+int shell_insert_mode_set(const struct shell *sh, bool val)
 {
-	if (shell == NULL) {
+	if (sh == NULL) {
 		return -EINVAL;
 	}
 
-	return (int)z_flag_insert_mode_set(shell, val);
+	return (int)z_flag_insert_mode_set(sh, val);
 }
 
-int shell_use_colors_set(const struct shell *shell, bool val)
+int shell_use_colors_set(const struct shell *sh, bool val)
 {
-	if (shell == NULL) {
+	if (sh == NULL) {
 		return -EINVAL;
 	}
 
-	return (int)z_flag_use_colors_set(shell, val);
+	return (int)z_flag_use_colors_set(sh, val);
 }
 
 int shell_use_vt100_set(const struct shell *sh, bool val)
@@ -1669,31 +1669,31 @@ int shell_use_vt100_set(const struct shell *sh, bool val)
 	return (int)z_flag_use_vt100_set(sh, val);
 }
 
-int shell_echo_set(const struct shell *shell, bool val)
+int shell_echo_set(const struct shell *sh, bool val)
 {
-	if (shell == NULL) {
+	if (sh == NULL) {
 		return -EINVAL;
 	}
 
-	return (int)z_flag_echo_set(shell, val);
+	return (int)z_flag_echo_set(sh, val);
 }
 
-int shell_obscure_set(const struct shell *shell, bool val)
+int shell_obscure_set(const struct shell *sh, bool val)
 {
-	if (shell == NULL) {
+	if (sh == NULL) {
 		return -EINVAL;
 	}
 
-	return (int)z_flag_obscure_set(shell, val);
+	return (int)z_flag_obscure_set(sh, val);
 }
 
-int shell_mode_delete_set(const struct shell *shell, bool val)
+int shell_mode_delete_set(const struct shell *sh, bool val)
 {
-	if (shell == NULL) {
+	if (sh == NULL) {
 		return -EINVAL;
 	}
 
-	return (int)z_flag_mode_delete_set(shell, val);
+	return (int)z_flag_mode_delete_set(sh, val);
 }
 
 void shell_set_bypass(const struct shell *sh, shell_bypass_cb_t bypass)
@@ -1714,30 +1714,30 @@ bool shell_ready(const struct shell *sh)
 	return state_get(sh) ==	SHELL_STATE_ACTIVE;
 }
 
-static int cmd_help(const struct shell *shell, size_t argc, char **argv)
+static int cmd_help(const struct shell *sh, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
 #if defined(CONFIG_SHELL_TAB)
-	shell_print(shell, "Please press the <Tab> button to see all available "
+	shell_print(sh, "Please press the <Tab> button to see all available "
 			   "commands.");
 #endif
 
 #if defined(CONFIG_SHELL_TAB_AUTOCOMPLETION)
-	shell_print(shell,
+	shell_print(sh,
 		"You can also use the <Tab> button to prompt or auto-complete"
 		" all commands or its subcommands.");
 #endif
 
 #if defined(CONFIG_SHELL_HELP)
-	shell_print(shell,
+	shell_print(sh,
 		"You can try to call commands with <-h> or <--help> parameter"
 		" for more information.");
 #endif
 
 #if defined(CONFIG_SHELL_METAKEYS)
-	shell_print(shell,
+	shell_print(sh,
 		"\nShell supports following meta-keys:\n"
 		"  Ctrl + (a key from: abcdefklnpuw)\n"
 		"  Alt  + (a key from: bf)\n"
@@ -1746,15 +1746,15 @@ static int cmd_help(const struct shell *shell, size_t argc, char **argv)
 
 	if (IS_ENABLED(CONFIG_SHELL_HELP)) {
 		/* For NULL argument function will print all root commands */
-		z_shell_help_subcmd_print(shell, NULL,
+		z_shell_help_subcmd_print(sh, NULL,
 					 "\nAvailable commands:\n");
 	} else {
 		const struct shell_static_entry *entry;
 		size_t idx = 0;
 
-		shell_print(shell, "\nAvailable commands:");
+		shell_print(sh, "\nAvailable commands:");
 		while ((entry = z_shell_cmd_get(NULL, idx++, NULL)) != NULL) {
-			shell_print(shell, "  %s", entry->syntax);
+			shell_print(sh, "  %s", entry->syntax);
 		}
 	}
 

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1118,6 +1118,7 @@ static void state_collect(const struct shell *sh)
 				__fallthrough;
 			case 'L': {/* INSERT Button in VT100 mode */
 				bool status = z_flag_insert_mode_get(sh);
+
 				z_flag_insert_mode_set(sh, !status);
 				break;
 			}

--- a/subsys/shell/shell_fprintf.c
+++ b/subsys/shell/shell_fprintf.c
@@ -11,12 +11,12 @@
 static int out_func(int c, void *ctx)
 {
 	const struct shell_fprintf *sh_fprintf;
-	const struct shell *shell;
+	const struct shell *sh;
 
 	sh_fprintf = (const struct shell_fprintf *)ctx;
-	shell = (const struct shell *)sh_fprintf->user_ctx;
+	sh = (const struct shell *)sh_fprintf->user_ctx;
 
-	if ((shell->shell_flag == SHELL_FLAG_OLF_CRLF) && (c == '\n')) {
+	if ((sh->shell_flag == SHELL_FLAG_OLF_CRLF) && (c == '\n')) {
 		(void)out_func('\r', ctx);
 	}
 

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -16,7 +16,7 @@
  *   terminal_offset	Requested left margin.
  *   offset_first_line	Add margin to the first printed line.
  */
-static void formatted_text_print(const struct shell *shell, const char *str,
+static void formatted_text_print(const struct shell *sh, const char *str,
 				 size_t terminal_offset, bool offset_first_line)
 {
 	size_t offset = 0;
@@ -27,7 +27,7 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 	}
 
 	if (offset_first_line) {
-		z_shell_op_cursor_horiz_move(shell, terminal_offset);
+		z_shell_op_cursor_horiz_move(sh, terminal_offset);
 	}
 
 
@@ -42,21 +42,21 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 		length = z_shell_strlen(str) - offset;
 
 		if (length <=
-		    shell->ctx->vt100_ctx.cons.terminal_wid - terminal_offset) {
+		    sh->ctx->vt100_ctx.cons.terminal_wid - terminal_offset) {
 			for (idx = 0; idx < length; idx++) {
 				if (*(str + offset + idx) == '\n') {
-					z_transport_buffer_flush(shell);
-					z_shell_write(shell, str + offset, idx);
+					z_transport_buffer_flush(sh);
+					z_shell_write(sh, str + offset, idx);
 					offset += idx + 1;
-					z_cursor_next_line_move(shell);
-					z_shell_op_cursor_horiz_move(shell,
+					z_cursor_next_line_move(sh);
+					z_shell_op_cursor_horiz_move(sh,
 							terminal_offset);
 					break;
 				}
 			}
 
 			/* String will fit in one line. */
-			z_shell_raw_fprintf(shell->fprintf_ctx, str + offset);
+			z_shell_raw_fprintf(sh->fprintf_ctx, str + offset);
 
 			break;
 		}
@@ -64,7 +64,7 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 		/* String is longer than terminal line so text needs to
 		 * divide in the way to not divide words.
 		 */
-		length = shell->ctx->vt100_ctx.cons.terminal_wid
+		length = sh->ctx->vt100_ctx.cons.terminal_wid
 				- terminal_offset;
 
 		while (true) {
@@ -77,7 +77,7 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 			}
 
 			if ((idx + terminal_offset) >=
-			    shell->ctx->vt100_ctx.cons.terminal_wid) {
+			    sh->ctx->vt100_ctx.cons.terminal_wid) {
 				/* End of line reached. */
 				break;
 			}
@@ -88,8 +88,8 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 		/* Writing one line, fprintf IO buffer must be flushed
 		 * before calling shell_write.
 		 */
-		z_transport_buffer_flush(shell);
-		z_shell_write(shell, str + offset, length);
+		z_transport_buffer_flush(sh);
+		z_shell_write(sh, str + offset, length);
 		offset += length;
 
 		/* Calculating text offset to ensure that next line will
@@ -99,14 +99,14 @@ static void formatted_text_print(const struct shell *shell, const char *str,
 			++offset;
 		}
 
-		z_cursor_next_line_move(shell);
-		z_shell_op_cursor_horiz_move(shell, terminal_offset);
+		z_cursor_next_line_move(sh);
+		z_shell_op_cursor_horiz_move(sh, terminal_offset);
 
 	}
-	z_cursor_next_line_move(shell);
+	z_cursor_next_line_move(sh);
 }
 
-static void help_item_print(const struct shell *shell, const char *item_name,
+static void help_item_print(const struct shell *sh, const char *item_name,
 			    uint16_t item_name_width, const char *item_help)
 {
 	static const uint8_t tabulator[] = "  ";
@@ -119,36 +119,36 @@ static void help_item_print(const struct shell *shell, const char *item_name,
 	if (!IS_ENABLED(CONFIG_NEWLIB_LIBC) &&
 	    !IS_ENABLED(CONFIG_ARCH_POSIX)) {
 		/* print option name */
-		z_shell_fprintf(shell, SHELL_NORMAL, "%s%-*s", tabulator,
+		z_shell_fprintf(sh, SHELL_NORMAL, "%s%-*s", tabulator,
 				item_name_width, item_name);
 	} else {
 		uint16_t tmp = item_name_width - strlen(item_name);
 		char space = ' ';
 
-		z_shell_fprintf(shell, SHELL_NORMAL, "%s%s", tabulator,
+		z_shell_fprintf(sh, SHELL_NORMAL, "%s%s", tabulator,
 				item_name);
 
 		if (item_help) {
 			for (uint16_t i = 0; i < tmp; i++) {
-				z_shell_write(shell, &space, 1);
+				z_shell_write(sh, &space, 1);
 			}
 		}
 	}
 
 	if (item_help == NULL) {
-		z_cursor_next_line_move(shell);
+		z_cursor_next_line_move(sh);
 		return;
 	} else {
-		z_shell_fprintf(shell, SHELL_NORMAL, "%s:", tabulator);
+		z_shell_fprintf(sh, SHELL_NORMAL, "%s:", tabulator);
 	}
 	/* print option help */
-	formatted_text_print(shell, item_help, offset, false);
+	formatted_text_print(sh, item_help, offset, false);
 }
 
 /* Function prints all subcommands of the parent command together with their
  * help string
  */
-void z_shell_help_subcmd_print(const struct shell *shell,
+void z_shell_help_subcmd_print(const struct shell *sh,
 			       const struct shell_static_entry *parent,
 			       const char *description)
 {
@@ -168,18 +168,18 @@ void z_shell_help_subcmd_print(const struct shell *shell,
 	}
 
 	if (description != NULL) {
-		z_shell_fprintf(shell, SHELL_NORMAL, description);
+		z_shell_fprintf(sh, SHELL_NORMAL, description);
 	}
 
 	/* Printing subcommands and help string (if exists). */
 	idx = 0;
 
 	while ((entry = z_shell_cmd_get(parent, idx++, &dloc)) != NULL) {
-		help_item_print(shell, entry->syntax, longest, entry->help);
+		help_item_print(sh, entry->syntax, longest, entry->help);
 	}
 }
 
-void z_shell_help_cmd_print(const struct shell *shell,
+void z_shell_help_cmd_print(const struct shell *sh,
 			    const struct shell_static_entry *cmd)
 {
 	static const char cmd_sep[] = " - "; /* commands separator */
@@ -187,9 +187,9 @@ void z_shell_help_cmd_print(const struct shell *shell,
 
 	field_width = z_shell_strlen(cmd->syntax) + z_shell_strlen(cmd_sep);
 
-	z_shell_fprintf(shell, SHELL_NORMAL, "%s%s", cmd->syntax, cmd_sep);
+	z_shell_fprintf(sh, SHELL_NORMAL, "%s%s", cmd->syntax, cmd_sep);
 
-	formatted_text_print(shell, cmd->help, field_width, false);
+	formatted_text_print(sh, cmd->help, field_width, false);
 }
 
 bool z_shell_help_request(const char *str)

--- a/subsys/shell/shell_help.h
+++ b/subsys/shell/shell_help.h
@@ -14,11 +14,11 @@ extern "C" {
 #endif
 
 /* Function is printing command help string. */
-void z_shell_help_cmd_print(const struct shell *shell,
+void z_shell_help_cmd_print(const struct shell *sh,
 			    const struct shell_static_entry *cmd);
 
 /* Function is printing subcommands and help string. */
-void z_shell_help_subcmd_print(const struct shell *shell,
+void z_shell_help_subcmd_print(const struct shell *sh,
 			       const struct shell_static_entry *cmd,
 			       const char *description);
 

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -8,7 +8,7 @@
 #include "shell_ops.h"
 
 #define CMD_CURSOR_LEN 8
-void z_shell_op_cursor_vert_move(const struct shell *shell, int32_t delta)
+void z_shell_op_cursor_vert_move(const struct shell *sh, int32_t delta)
 {
 	char dir = delta > 0 ? 'A' : 'B';
 
@@ -20,10 +20,10 @@ void z_shell_op_cursor_vert_move(const struct shell *shell, int32_t delta)
 		delta = -delta;
 	}
 
-	Z_SHELL_VT100_CMD(shell, "\e[%d%c", delta, dir);
+	Z_SHELL_VT100_CMD(sh, "\e[%d%c", delta, dir);
 }
 
-void z_shell_op_cursor_horiz_move(const struct shell *shell, int32_t delta)
+void z_shell_op_cursor_horiz_move(const struct shell *sh, int32_t delta)
 {
 	char dir = delta > 0 ? 'C' : 'D';
 
@@ -35,83 +35,83 @@ void z_shell_op_cursor_horiz_move(const struct shell *shell, int32_t delta)
 		delta = -delta;
 	}
 
-	Z_SHELL_VT100_CMD(shell, "\e[%d%c", delta, dir);
+	Z_SHELL_VT100_CMD(sh, "\e[%d%c", delta, dir);
 }
 
 /* Function returns true if command length is equal to multiplicity of terminal
  * width.
  */
-static inline bool full_line_cmd(const struct shell *shell)
+static inline bool full_line_cmd(const struct shell *sh)
 {
-	return ((shell->ctx->cmd_buff_len + z_shell_strlen(shell->ctx->prompt))
-			% shell->ctx->vt100_ctx.cons.terminal_wid == 0U);
+	return ((sh->ctx->cmd_buff_len + z_shell_strlen(sh->ctx->prompt))
+			% sh->ctx->vt100_ctx.cons.terminal_wid == 0U);
 }
 
 /* Function returns true if cursor is at beginning of an empty line. */
-bool z_shell_cursor_in_empty_line(const struct shell *shell)
+bool z_shell_cursor_in_empty_line(const struct shell *sh)
 {
-	return (((shell->ctx->cmd_buff_pos * shell->ctx->cfg.flags.echo) +
-		 z_shell_strlen(shell->ctx->prompt)) %
-			shell->ctx->vt100_ctx.cons.terminal_wid ==
+	return (((sh->ctx->cmd_buff_pos * sh->ctx->cfg.flags.echo) +
+		 z_shell_strlen(sh->ctx->prompt)) %
+			sh->ctx->vt100_ctx.cons.terminal_wid ==
 		0U);
 }
 
-void z_shell_op_cond_next_line(const struct shell *shell)
+void z_shell_op_cond_next_line(const struct shell *sh)
 {
-	if (z_shell_cursor_in_empty_line(shell) || full_line_cmd(shell)) {
-		z_cursor_next_line_move(shell);
+	if (z_shell_cursor_in_empty_line(sh) || full_line_cmd(sh)) {
+		z_cursor_next_line_move(sh);
 	}
 }
 
-void z_shell_op_cursor_position_synchronize(const struct shell *shell)
+void z_shell_op_cursor_position_synchronize(const struct shell *sh)
 {
-	struct shell_multiline_cons *cons = &shell->ctx->vt100_ctx.cons;
+	struct shell_multiline_cons *cons = &sh->ctx->vt100_ctx.cons;
 	bool last_line;
 
-	z_shell_multiline_data_calc(cons, shell->ctx->cmd_buff_pos,
-				    shell->ctx->cmd_buff_len);
+	z_shell_multiline_data_calc(cons, sh->ctx->cmd_buff_pos,
+				    sh->ctx->cmd_buff_len);
 	last_line = (cons->cur_y == cons->cur_y_end);
 
 	/* In case cursor reaches the bottom line of a terminal, it will
 	 * be moved to the next line.
 	 */
-	if (full_line_cmd(shell)) {
-		z_cursor_next_line_move(shell);
+	if (full_line_cmd(sh)) {
+		z_cursor_next_line_move(sh);
 	}
 
 	if (last_line) {
-		z_shell_op_cursor_horiz_move(shell, cons->cur_x -
+		z_shell_op_cursor_horiz_move(sh, cons->cur_x -
 							       cons->cur_x_end);
 	} else {
-		z_shell_op_cursor_vert_move(shell, cons->cur_y_end - cons->cur_y);
-		z_shell_op_cursor_horiz_move(shell, cons->cur_x -
+		z_shell_op_cursor_vert_move(sh, cons->cur_y_end - cons->cur_y);
+		z_shell_op_cursor_horiz_move(sh, cons->cur_x -
 							       cons->cur_x_end);
 	}
 }
 
-void z_shell_op_cursor_move(const struct shell *shell, int16_t val)
+void z_shell_op_cursor_move(const struct shell *sh, int16_t val)
 {
-	struct shell_multiline_cons *cons = &shell->ctx->vt100_ctx.cons;
-	uint16_t new_pos = shell->ctx->cmd_buff_pos + val;
+	struct shell_multiline_cons *cons = &sh->ctx->vt100_ctx.cons;
+	uint16_t new_pos = sh->ctx->cmd_buff_pos + val;
 	int32_t row_span;
 	int32_t col_span;
 
-	z_shell_multiline_data_calc(cons, shell->ctx->cmd_buff_pos,
-				    shell->ctx->cmd_buff_len);
+	z_shell_multiline_data_calc(cons, sh->ctx->cmd_buff_pos,
+				    sh->ctx->cmd_buff_len);
 
 	/* Calculate the new cursor. */
 	row_span = z_row_span_with_buffer_offsets_get(
-						&shell->ctx->vt100_ctx.cons,
-						shell->ctx->cmd_buff_pos,
+						&sh->ctx->vt100_ctx.cons,
+						sh->ctx->cmd_buff_pos,
 						new_pos);
 	col_span = z_column_span_with_buffer_offsets_get(
-						&shell->ctx->vt100_ctx.cons,
-						shell->ctx->cmd_buff_pos,
+						&sh->ctx->vt100_ctx.cons,
+						sh->ctx->cmd_buff_pos,
 						new_pos);
 
-	z_shell_op_cursor_vert_move(shell, -row_span);
-	z_shell_op_cursor_horiz_move(shell, col_span);
-	shell->ctx->cmd_buff_pos = new_pos;
+	z_shell_op_cursor_vert_move(sh, -row_span);
+	z_shell_op_cursor_horiz_move(sh, col_span);
+	sh->ctx->cmd_buff_pos = new_pos;
 }
 
 static uint16_t shift_calc(const char *str, uint16_t pos, uint16_t len, int16_t sign)
@@ -139,7 +139,7 @@ static uint16_t shift_calc(const char *str, uint16_t pos, uint16_t len, int16_t 
 	return ret;
 }
 
-void z_shell_op_cursor_word_move(const struct shell *shell, int16_t val)
+void z_shell_op_cursor_word_move(const struct shell *sh, int16_t val)
 {
 	int16_t shift;
 	int16_t sign;
@@ -152,22 +152,22 @@ void z_shell_op_cursor_word_move(const struct shell *shell, int16_t val)
 	}
 
 	while (val--) {
-		shift = shift_calc(shell->ctx->cmd_buff,
-				   shell->ctx->cmd_buff_pos,
-				   shell->ctx->cmd_buff_len, sign);
-		z_shell_op_cursor_move(shell, sign * shift);
+		shift = shift_calc(sh->ctx->cmd_buff,
+				   sh->ctx->cmd_buff_pos,
+				   sh->ctx->cmd_buff_len, sign);
+		z_shell_op_cursor_move(sh, sign * shift);
 	}
 }
 
-void z_shell_op_word_remove(const struct shell *shell)
+void z_shell_op_word_remove(const struct shell *sh)
 {
-	char *str = &shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos - 1];
-	char *str_start = &shell->ctx->cmd_buff[0];
+	char *str = &sh->ctx->cmd_buff[sh->ctx->cmd_buff_pos - 1];
+	char *str_start = &sh->ctx->cmd_buff[0];
 	uint16_t chars_to_delete;
 
 	/* Line must not be empty and cursor must not be at 0 to continue. */
-	if ((shell->ctx->cmd_buff_len == 0) ||
-	    (shell->ctx->cmd_buff_pos == 0)) {
+	if ((sh->ctx->cmd_buff_len == 0) ||
+	    (sh->ctx->cmd_buff_pos == 0)) {
 		return;
 	}
 
@@ -187,44 +187,44 @@ void z_shell_op_word_remove(const struct shell *shell)
 
 	/* Manage the buffer. */
 	memmove(str + 1, str + 1 + chars_to_delete,
-		shell->ctx->cmd_buff_len - chars_to_delete);
-	shell->ctx->cmd_buff_len -= chars_to_delete;
-	shell->ctx->cmd_buff[shell->ctx->cmd_buff_len] = '\0';
+		sh->ctx->cmd_buff_len - chars_to_delete);
+	sh->ctx->cmd_buff_len -= chars_to_delete;
+	sh->ctx->cmd_buff[sh->ctx->cmd_buff_len] = '\0';
 
 	/* Update display. */
-	z_shell_op_cursor_move(shell, -chars_to_delete);
-	z_cursor_save(shell);
-	z_shell_fprintf(shell, SHELL_NORMAL, "%s", str + 1);
-	z_clear_eos(shell);
-	z_cursor_restore(shell);
+	z_shell_op_cursor_move(sh, -chars_to_delete);
+	z_cursor_save(sh);
+	z_shell_fprintf(sh, SHELL_NORMAL, "%s", str + 1);
+	z_clear_eos(sh);
+	z_cursor_restore(sh);
 }
 
-void z_shell_op_cursor_home_move(const struct shell *shell)
+void z_shell_op_cursor_home_move(const struct shell *sh)
 {
-	z_shell_op_cursor_move(shell, -shell->ctx->cmd_buff_pos);
+	z_shell_op_cursor_move(sh, -sh->ctx->cmd_buff_pos);
 }
 
-void z_shell_op_cursor_end_move(const struct shell *shell)
+void z_shell_op_cursor_end_move(const struct shell *sh)
 {
-	z_shell_op_cursor_move(shell, shell->ctx->cmd_buff_len -
-						shell->ctx->cmd_buff_pos);
+	z_shell_op_cursor_move(sh, sh->ctx->cmd_buff_len -
+						sh->ctx->cmd_buff_pos);
 }
 
-void z_shell_op_left_arrow(const struct shell *shell)
+void z_shell_op_left_arrow(const struct shell *sh)
 {
-	if (shell->ctx->cmd_buff_pos > 0) {
-		z_shell_op_cursor_move(shell, -1);
+	if (sh->ctx->cmd_buff_pos > 0) {
+		z_shell_op_cursor_move(sh, -1);
 	}
 }
 
-void z_shell_op_right_arrow(const struct shell *shell)
+void z_shell_op_right_arrow(const struct shell *sh)
 {
-	if (shell->ctx->cmd_buff_pos < shell->ctx->cmd_buff_len) {
-		z_shell_op_cursor_move(shell, 1);
+	if (sh->ctx->cmd_buff_pos < sh->ctx->cmd_buff_len) {
+		z_shell_op_cursor_move(sh, 1);
 	}
 }
 
-static void reprint_from_cursor(const struct shell *shell, uint16_t diff,
+static void reprint_from_cursor(const struct shell *sh, uint16_t diff,
 				bool data_removed)
 {
 	/* Clear eos is needed only when newly printed command is shorter than
@@ -235,181 +235,181 @@ static void reprint_from_cursor(const struct shell *shell, uint16_t diff,
 	 * bytes transmitted between terminal and device.
 	 */
 	if (data_removed) {
-		z_clear_eos(shell);
+		z_clear_eos(sh);
 	}
 
-	if (z_flag_obscure_get(shell)) {
-		int len = strlen(&shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos]);
+	if (z_flag_obscure_get(sh)) {
+		int len = strlen(&sh->ctx->cmd_buff[sh->ctx->cmd_buff_pos]);
 
 		while (len--) {
-			z_shell_raw_fprintf(shell->fprintf_ctx, "*");
+			z_shell_raw_fprintf(sh->fprintf_ctx, "*");
 		}
 	} else {
-		z_shell_fprintf(shell, SHELL_NORMAL, "%s",
-			      &shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos]);
+		z_shell_fprintf(sh, SHELL_NORMAL, "%s",
+			      &sh->ctx->cmd_buff[sh->ctx->cmd_buff_pos]);
 	}
-	shell->ctx->cmd_buff_pos = shell->ctx->cmd_buff_len;
+	sh->ctx->cmd_buff_pos = sh->ctx->cmd_buff_len;
 
-	if (full_line_cmd(shell)) {
+	if (full_line_cmd(sh)) {
 		if (((data_removed) && (diff > 0)) || (!data_removed)) {
-			z_cursor_next_line_move(shell);
+			z_cursor_next_line_move(sh);
 		}
 	}
 
-	z_shell_op_cursor_move(shell, -diff);
+	z_shell_op_cursor_move(sh, -diff);
 }
 
-static void data_insert(const struct shell *shell, const char *data, uint16_t len)
+static void data_insert(const struct shell *sh, const char *data, uint16_t len)
 {
-	uint16_t after = shell->ctx->cmd_buff_len - shell->ctx->cmd_buff_pos;
-	char *curr_pos = &shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos];
+	uint16_t after = sh->ctx->cmd_buff_len - sh->ctx->cmd_buff_pos;
+	char *curr_pos = &sh->ctx->cmd_buff[sh->ctx->cmd_buff_pos];
 
-	if ((shell->ctx->cmd_buff_len + len) >= CONFIG_SHELL_CMD_BUFF_SIZE) {
+	if ((sh->ctx->cmd_buff_len + len) >= CONFIG_SHELL_CMD_BUFF_SIZE) {
 		return;
 	}
 
 	memmove(curr_pos + len, curr_pos, after);
 	memcpy(curr_pos, data, len);
-	shell->ctx->cmd_buff_len += len;
-	shell->ctx->cmd_buff[shell->ctx->cmd_buff_len] = '\0';
+	sh->ctx->cmd_buff_len += len;
+	sh->ctx->cmd_buff[sh->ctx->cmd_buff_len] = '\0';
 
-	if (!z_flag_echo_get(shell)) {
-		shell->ctx->cmd_buff_pos += len;
+	if (!z_flag_echo_get(sh)) {
+		sh->ctx->cmd_buff_pos += len;
 		return;
 	}
 
-	reprint_from_cursor(shell, after, false);
+	reprint_from_cursor(sh, after, false);
 }
 
-static void char_replace(const struct shell *shell, char data)
+static void char_replace(const struct shell *sh, char data)
 {
-	shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos++] = data;
+	sh->ctx->cmd_buff[sh->ctx->cmd_buff_pos++] = data;
 
-	if (!z_flag_echo_get(shell)) {
+	if (!z_flag_echo_get(sh)) {
 		return;
 	}
-	if (z_flag_obscure_get(shell)) {
+	if (z_flag_obscure_get(sh)) {
 		data = '*';
 	}
 
-	z_shell_raw_fprintf(shell->fprintf_ctx, "%c", data);
-	if (z_shell_cursor_in_empty_line(shell)) {
-		z_cursor_next_line_move(shell);
+	z_shell_raw_fprintf(sh->fprintf_ctx, "%c", data);
+	if (z_shell_cursor_in_empty_line(sh)) {
+		z_cursor_next_line_move(sh);
 	}
 }
 
-void z_shell_op_char_insert(const struct shell *shell, char data)
+void z_shell_op_char_insert(const struct shell *sh, char data)
 {
-	if (z_flag_insert_mode_get(shell) &&
-	    (shell->ctx->cmd_buff_len != shell->ctx->cmd_buff_pos)) {
-		char_replace(shell, data);
+	if (z_flag_insert_mode_get(sh) &&
+	    (sh->ctx->cmd_buff_len != sh->ctx->cmd_buff_pos)) {
+		char_replace(sh, data);
 	} else {
-		data_insert(shell, &data, 1);
+		data_insert(sh, &data, 1);
 	}
 }
 
-void z_shell_op_char_backspace(const struct shell *shell)
+void z_shell_op_char_backspace(const struct shell *sh)
 {
-	if ((shell->ctx->cmd_buff_len == 0) ||
-	    (shell->ctx->cmd_buff_pos == 0)) {
+	if ((sh->ctx->cmd_buff_len == 0) ||
+	    (sh->ctx->cmd_buff_pos == 0)) {
 		return;
 	}
 
-	z_shell_op_cursor_move(shell, -1);
-	z_shell_op_char_delete(shell);
+	z_shell_op_cursor_move(sh, -1);
+	z_shell_op_char_delete(sh);
 }
 
-void z_shell_op_char_delete(const struct shell *shell)
+void z_shell_op_char_delete(const struct shell *sh)
 {
-	uint16_t diff = shell->ctx->cmd_buff_len - shell->ctx->cmd_buff_pos;
-	char *str = &shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos];
+	uint16_t diff = sh->ctx->cmd_buff_len - sh->ctx->cmd_buff_pos;
+	char *str = &sh->ctx->cmd_buff[sh->ctx->cmd_buff_pos];
 
 	if (diff == 0U) {
 		return;
 	}
 
 	memmove(str, str + 1, diff);
-	--shell->ctx->cmd_buff_len;
-	reprint_from_cursor(shell, --diff, true);
+	--sh->ctx->cmd_buff_len;
+	reprint_from_cursor(sh, --diff, true);
 }
 
-void z_shell_op_delete_from_cursor(const struct shell *shell)
+void z_shell_op_delete_from_cursor(const struct shell *sh)
 {
-	shell->ctx->cmd_buff_len = shell->ctx->cmd_buff_pos;
-	shell->ctx->cmd_buff[shell->ctx->cmd_buff_pos] = '\0';
+	sh->ctx->cmd_buff_len = sh->ctx->cmd_buff_pos;
+	sh->ctx->cmd_buff[sh->ctx->cmd_buff_pos] = '\0';
 
-	z_clear_eos(shell);
+	z_clear_eos(sh);
 }
 
-void z_shell_op_completion_insert(const struct shell *shell,
+void z_shell_op_completion_insert(const struct shell *sh,
 				  const char *compl,
 				  uint16_t compl_len)
 {
-	data_insert(shell, compl, compl_len);
+	data_insert(sh, compl, compl_len);
 }
 
-void z_shell_cmd_line_erase(const struct shell *shell)
+void z_shell_cmd_line_erase(const struct shell *sh)
 {
-	z_shell_multiline_data_calc(&shell->ctx->vt100_ctx.cons,
-				    shell->ctx->cmd_buff_pos,
-				    shell->ctx->cmd_buff_len);
-	z_shell_op_cursor_horiz_move(shell,
-				   -(shell->ctx->vt100_ctx.cons.cur_x - 1));
-	z_shell_op_cursor_vert_move(shell, shell->ctx->vt100_ctx.cons.cur_y - 1);
+	z_shell_multiline_data_calc(&sh->ctx->vt100_ctx.cons,
+				    sh->ctx->cmd_buff_pos,
+				    sh->ctx->cmd_buff_len);
+	z_shell_op_cursor_horiz_move(sh,
+				   -(sh->ctx->vt100_ctx.cons.cur_x - 1));
+	z_shell_op_cursor_vert_move(sh, sh->ctx->vt100_ctx.cons.cur_y - 1);
 
-	z_clear_eos(shell);
+	z_clear_eos(sh);
 }
 
-static void print_prompt(const struct shell *shell)
+static void print_prompt(const struct shell *sh)
 {
-	z_shell_fprintf(shell, SHELL_INFO, "%s", shell->ctx->prompt);
+	z_shell_fprintf(sh, SHELL_INFO, "%s", sh->ctx->prompt);
 }
 
-void z_shell_print_cmd(const struct shell *shell)
+void z_shell_print_cmd(const struct shell *sh)
 {
-	z_shell_raw_fprintf(shell->fprintf_ctx, "%s", shell->ctx->cmd_buff);
+	z_shell_raw_fprintf(sh->fprintf_ctx, "%s", sh->ctx->cmd_buff);
 }
 
-void z_shell_print_prompt_and_cmd(const struct shell *shell)
+void z_shell_print_prompt_and_cmd(const struct shell *sh)
 {
-	print_prompt(shell);
+	print_prompt(sh);
 
-	if (z_flag_echo_get(shell)) {
-		z_shell_print_cmd(shell);
-		z_shell_op_cursor_position_synchronize(shell);
+	if (z_flag_echo_get(sh)) {
+		z_shell_print_cmd(sh);
+		z_shell_op_cursor_position_synchronize(sh);
 	}
 }
 
-static void shell_pend_on_txdone(const struct shell *shell)
+static void shell_pend_on_txdone(const struct shell *sh)
 {
 	if (IS_ENABLED(CONFIG_MULTITHREADING) &&
-	    (shell->ctx->state < SHELL_STATE_PANIC_MODE_ACTIVE)) {
+	    (sh->ctx->state < SHELL_STATE_PANIC_MODE_ACTIVE)) {
 		struct k_poll_event event;
 
 		k_poll_event_init(&event,
 				  K_POLL_TYPE_SIGNAL,
 				  K_POLL_MODE_NOTIFY_ONLY,
-				  &shell->ctx->signals[SHELL_SIGNAL_TXDONE]);
+				  &sh->ctx->signals[SHELL_SIGNAL_TXDONE]);
 		k_poll(&event, 1, K_FOREVER);
-		k_poll_signal_reset(&shell->ctx->signals[SHELL_SIGNAL_TXDONE]);
+		k_poll_signal_reset(&sh->ctx->signals[SHELL_SIGNAL_TXDONE]);
 	} else {
 		/* Blocking wait in case of bare metal. */
-		while (!z_flag_tx_rdy_get(shell)) {
+		while (!z_flag_tx_rdy_get(sh)) {
 		}
-		z_flag_tx_rdy_set(shell, false);
+		z_flag_tx_rdy_set(sh, false);
 	}
 }
 
-void z_shell_write(const struct shell *shell, const void *data,
+void z_shell_write(const struct shell *sh, const void *data,
 		 size_t length)
 {
-	__ASSERT_NO_MSG(shell && data);
+	__ASSERT_NO_MSG(sh && data);
 
 	size_t offset = 0;
 	size_t tmp_cnt;
 
 	while (length) {
-		int err = shell->iface->api->write(shell->iface,
+		int err = sh->iface->api->write(sh->iface,
 				&((const uint8_t *) data)[offset], length,
 				&tmp_cnt);
 		(void)err;
@@ -418,8 +418,8 @@ void z_shell_write(const struct shell *shell, const void *data,
 		offset += tmp_cnt;
 		length -= tmp_cnt;
 		if (tmp_cnt == 0 &&
-		    (shell->ctx->state != SHELL_STATE_PANIC_MODE_ACTIVE)) {
-			shell_pend_on_txdone(shell);
+		    (sh->ctx->state != SHELL_STATE_PANIC_MODE_ACTIVE)) {
+			shell_pend_on_txdone(sh);
 		}
 	}
 }
@@ -430,7 +430,7 @@ void z_shell_print_stream(const void *user_ctx, const char *data, size_t len)
 	z_shell_write((const struct shell *) user_ctx, data, len);
 }
 
-static void vt100_bgcolor_set(const struct shell *shell,
+static void vt100_bgcolor_set(const struct shell *sh,
 			      enum shell_vt100_color bgcolor)
 {
 	if (!IS_ENABLED(CONFIG_SHELL_VT100_COLORS)) {
@@ -442,15 +442,15 @@ static void vt100_bgcolor_set(const struct shell *shell,
 	}
 
 	if ((bgcolor == SHELL_NORMAL) ||
-	    (shell->ctx->vt100_ctx.col.bgcol == bgcolor)) {
+	    (sh->ctx->vt100_ctx.col.bgcol == bgcolor)) {
 		return;
 	}
 
-	shell->ctx->vt100_ctx.col.bgcol = bgcolor;
-	Z_SHELL_VT100_CMD(shell, "\e[403%dm", bgcolor);
+	sh->ctx->vt100_ctx.col.bgcol = bgcolor;
+	Z_SHELL_VT100_CMD(sh, "\e[403%dm", bgcolor);
 }
 
-void z_shell_vt100_color_set(const struct shell *shell,
+void z_shell_vt100_color_set(const struct shell *sh,
 			     enum shell_vt100_color color)
 {
 	if (!IS_ENABLED(CONFIG_SHELL_VT100_COLORS)) {
@@ -461,46 +461,46 @@ void z_shell_vt100_color_set(const struct shell *shell,
 		return;
 	}
 
-	if (shell->ctx->vt100_ctx.col.col == color) {
+	if (sh->ctx->vt100_ctx.col.col == color) {
 		return;
 	}
 
-	shell->ctx->vt100_ctx.col.col = color;
+	sh->ctx->vt100_ctx.col.col = color;
 
 	if (color != SHELL_NORMAL) {
-		Z_SHELL_VT100_CMD(shell, "\e[1;3%dm", color);
+		Z_SHELL_VT100_CMD(sh, "\e[1;3%dm", color);
 	} else {
-		Z_SHELL_VT100_CMD(shell, SHELL_VT100_MODESOFF);
+		Z_SHELL_VT100_CMD(sh, SHELL_VT100_MODESOFF);
 	}
 }
 
-void z_shell_vt100_colors_restore(const struct shell *shell,
+void z_shell_vt100_colors_restore(const struct shell *sh,
 				  const struct shell_vt100_colors *color)
 {
 	if (!IS_ENABLED(CONFIG_SHELL_VT100_COLORS)) {
 		return;
 	}
 
-	z_shell_vt100_color_set(shell, color->col);
-	vt100_bgcolor_set(shell, color->bgcol);
+	z_shell_vt100_color_set(sh, color->col);
+	vt100_bgcolor_set(sh, color->bgcol);
 }
 
-void z_shell_vfprintf(const struct shell *shell, enum shell_vt100_color color,
+void z_shell_vfprintf(const struct shell *sh, enum shell_vt100_color color,
 		      const char *fmt, va_list args)
 {
 	if (IS_ENABLED(CONFIG_SHELL_VT100_COLORS) &&
-	    z_flag_use_colors_get(shell)	  &&
-	    (color != shell->ctx->vt100_ctx.col.col)) {
+	    z_flag_use_colors_get(sh)	  &&
+	    (color != sh->ctx->vt100_ctx.col.col)) {
 		struct shell_vt100_colors col;
 
-		z_shell_vt100_colors_store(shell, &col);
-		z_shell_vt100_color_set(shell, color);
+		z_shell_vt100_colors_store(sh, &col);
+		z_shell_vt100_color_set(sh, color);
 
-		z_shell_fprintf_fmt(shell->fprintf_ctx, fmt, args);
+		z_shell_fprintf_fmt(sh->fprintf_ctx, fmt, args);
 
-		z_shell_vt100_colors_restore(shell, &col);
+		z_shell_vt100_colors_restore(sh, &col);
 	} else {
-		z_shell_fprintf_fmt(shell->fprintf_ctx, fmt, args);
+		z_shell_fprintf_fmt(sh->fprintf_ctx, fmt, args);
 	}
 }
 

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -301,14 +301,14 @@ void z_shell_cmd_line_erase(const struct shell *sh);
 /**
  * @brief Print command buffer.
  *
- * @param shell Shell instance.
+ * @param sh Shell instance.
  */
 void z_shell_print_cmd(const struct shell *sh);
 
 /**
  * @brief Print prompt followed by command buffer.
  *
- * @param shell Shell instance.
+ * @param sh Shell instance.
  */
 void z_shell_print_prompt_and_cmd(const struct shell *sh);
 

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -488,10 +488,10 @@ static void buffer_trim(char *buff, uint16_t *buff_len)
 	}
 }
 
-void z_shell_cmd_trim(const struct shell *shell)
+void z_shell_cmd_trim(const struct shell *sh)
 {
-	buffer_trim(shell->ctx->cmd_buff, &shell->ctx->cmd_buff_len);
-	shell->ctx->cmd_buff_pos = shell->ctx->cmd_buff_len;
+	buffer_trim(sh->ctx->cmd_buff, &sh->ctx->cmd_buff_len);
+	sh->ctx->cmd_buff_pos = sh->ctx->cmd_buff_len;
 }
 
 const struct device *shell_device_lookup(size_t idx,

--- a/subsys/shell/shell_utils.h
+++ b/subsys/shell/shell_utils.h
@@ -61,7 +61,7 @@ const struct shell_static_entry *z_shell_find_cmd(
 /* @internal @brief Function returns pointer to a shell's subcommands array
  * for a level given by argc and matching command patter provided in argv.
  *
- * @param shell		Entry. NULL for root entry.
+ * @param sh		Entry. NULL for root entry.
  * @param argc		Number of arguments.
  * @param argv		Pointer to an array with arguments.
  * @param match_arg	Subcommand level of last matching argument.
@@ -79,18 +79,18 @@ const struct shell_static_entry *z_shell_get_last_command(
 					bool only_static);
 
 void z_shell_spaces_trim(char *str);
-void z_shell_cmd_trim(const struct shell *shell);
+void z_shell_cmd_trim(const struct shell *sh);
 
 const struct shell_static_entry *root_cmd_find(const char *syntax);
 
-static inline void z_transport_buffer_flush(const struct shell *shell)
+static inline void z_transport_buffer_flush(const struct shell *sh)
 {
-	z_shell_fprintf_buffer_flush(shell->fprintf_ctx);
+	z_shell_fprintf_buffer_flush(sh->fprintf_ctx);
 }
 
-static inline bool z_shell_in_select_mode(const struct shell *shell)
+static inline bool z_shell_in_select_mode(const struct shell *sh)
 {
-	return shell->ctx->selected_cmd == NULL ? false : true;
+	return sh->ctx->selected_cmd == NULL ? false : true;
 }
 
 #ifdef __cplusplus

--- a/subsys/shell/shell_wildcard.c
+++ b/subsys/shell/shell_wildcard.c
@@ -66,7 +66,7 @@ static enum shell_wildcard_status command_add(char *buff, uint16_t *buff_len,
  *					     is too small.
  * @retval WILDCARD_CMD_NO_MATCH_FOUND No matching command found.
  */
-static enum shell_wildcard_status commands_expand(const struct shell *shell,
+static enum shell_wildcard_status commands_expand(const struct shell *sh,
 					const struct shell_static_entry *cmd,
 					const char *pattern)
 {
@@ -79,11 +79,11 @@ static enum shell_wildcard_status commands_expand(const struct shell *shell,
 	while ((entry = z_shell_cmd_get(cmd, cmd_idx++, &dloc)) != NULL) {
 
 		if (fnmatch(pattern, entry->syntax, 0) == 0) {
-			ret_val = command_add(shell->ctx->temp_buff,
-					      &shell->ctx->cmd_tmp_buff_len,
+			ret_val = command_add(sh->ctx->temp_buff,
+					      &sh->ctx->cmd_tmp_buff_len,
 					      entry->syntax, pattern);
 			if (ret_val == SHELL_WILDCARD_CMD_MISSING_SPACE) {
-				z_shell_fprintf(shell, SHELL_WARNING,
+				z_shell_fprintf(sh, SHELL_WARNING,
 					"Command buffer is too short to"
 					" expand all commands matching"
 					" wildcard pattern: %s\n", pattern);
@@ -96,8 +96,8 @@ static enum shell_wildcard_status commands_expand(const struct shell *shell,
 	}
 
 	if (cnt > 0) {
-		z_shell_pattern_remove(shell->ctx->temp_buff,
-				       &shell->ctx->cmd_tmp_buff_len, pattern);
+		z_shell_pattern_remove(sh->ctx->temp_buff,
+				       &sh->ctx->cmd_tmp_buff_len, pattern);
 	}
 
 	return ret_val;
@@ -116,7 +116,7 @@ bool z_shell_has_wildcard(const char *str)
 	return false;
 }
 
-void z_shell_wildcard_prepare(const struct shell *shell)
+void z_shell_wildcard_prepare(const struct shell *sh)
 {
 	/* Wildcard can be correctly handled under following conditions:
 	 * - wildcard command does not have a handler
@@ -140,23 +140,23 @@ void z_shell_wildcard_prepare(const struct shell *shell)
 	 *    including expanded commands, are passed as arguments.
 	 */
 
-	memset(shell->ctx->temp_buff, 0, sizeof(shell->ctx->temp_buff));
-	memcpy(shell->ctx->temp_buff,
-			shell->ctx->cmd_buff,
-			shell->ctx->cmd_buff_len);
+	memset(sh->ctx->temp_buff, 0, sizeof(sh->ctx->temp_buff));
+	memcpy(sh->ctx->temp_buff,
+			sh->ctx->cmd_buff,
+			sh->ctx->cmd_buff_len);
 
 	/* Function shell_spaces_trim must be used instead of shell_make_argv.
 	 * At this point it is important to keep temp_buff as one string.
 	 * It will allow to find wildcard commands easily with strstr function.
 	 */
-	z_shell_spaces_trim(shell->ctx->temp_buff);
+	z_shell_spaces_trim(sh->ctx->temp_buff);
 
 	/* +1 for EOS*/
-	shell->ctx->cmd_tmp_buff_len = z_shell_strlen(shell->ctx->temp_buff) + 1;
+	sh->ctx->cmd_tmp_buff_len = z_shell_strlen(sh->ctx->temp_buff) + 1;
 }
 
 
-enum shell_wildcard_status z_shell_wildcard_process(const struct shell *shell,
+enum shell_wildcard_status z_shell_wildcard_process(const struct shell *sh,
 					const struct shell_static_entry *cmd,
 					const char *pattern)
 {
@@ -177,15 +177,15 @@ enum shell_wildcard_status z_shell_wildcard_process(const struct shell *shell,
 	 * possible. Next it will continue to search for next wildcard pattern
 	 * and it will try to add matching commands.
 	 */
-	ret_val = commands_expand(shell, cmd, pattern);
+	ret_val = commands_expand(sh, cmd, pattern);
 
 	return ret_val;
 }
 
-void z_shell_wildcard_finalize(const struct shell *shell)
+void z_shell_wildcard_finalize(const struct shell *sh)
 {
-	memcpy(shell->ctx->cmd_buff,
-	       shell->ctx->temp_buff,
-	       shell->ctx->cmd_tmp_buff_len);
-	shell->ctx->cmd_buff_len = shell->ctx->cmd_tmp_buff_len;
+	memcpy(sh->ctx->cmd_buff,
+	       sh->ctx->temp_buff,
+	       sh->ctx->cmd_tmp_buff_len);
+	sh->ctx->cmd_buff_len = sh->ctx->cmd_tmp_buff_len;
 }

--- a/subsys/shell/shell_wildcard.h
+++ b/subsys/shell/shell_wildcard.h
@@ -20,7 +20,7 @@ enum shell_wildcard_status {
  *
  * @param[in] shell	Pointer to the shell instance.
  */
-void z_shell_wildcard_prepare(const struct shell *shell);
+void z_shell_wildcard_prepare(const struct shell *sh);
 
 /* Function returns true if string contains wildcard character: '?' or '*'
  *
@@ -44,7 +44,7 @@ bool z_shell_has_wildcard(const char *str);
  * @param[in] cmd	Pointer to command which will be processed.
  * @param[in] pattern	Pointer to wildcard pattern.
  */
-enum shell_wildcard_status z_shell_wildcard_process(const struct shell *shell,
+enum shell_wildcard_status z_shell_wildcard_process(const struct shell *sh,
 					const struct shell_static_entry *cmd,
 					const char *pattern);
 
@@ -52,7 +52,7 @@ enum shell_wildcard_status z_shell_wildcard_process(const struct shell *shell,
  *
  * @param[in] shell	Pointer to the shell instance.
  */
-void z_shell_wildcard_finalize(const struct shell *shell);
+void z_shell_wildcard_finalize(const struct shell *sh);
 
 
 #endif /* SHELL_SHELL_WILDCARDS_H__ */

--- a/subsys/storage/flash_map/flash_map_shell.c
+++ b/subsys/storage/flash_map/flash_map_shell.c
@@ -24,17 +24,17 @@ static void fa_cb(const struct flash_area *fa, void *user_data)
 {
 	struct shell *shell = user_data;
 
-	shell_print(shell, "%2d   0x%0*"PRIxPTR"   %-26s  0x%-10x 0x%-12x",
+	shell_print(sh, "%2d   0x%0*"PRIxPTR"   %-26s  0x%-10x 0x%-12x",
 		    (int)fa->fa_id, sizeof(uintptr_t) * 2, (uintptr_t)fa->fa_dev, fa->fa_dev->name,
 		    (uint32_t) fa->fa_off, fa->fa_size);
 }
 
-static int cmd_flash_map_list(const struct shell *shell, size_t argc,
+static int cmd_flash_map_list(const struct shell *sh, size_t argc,
 			      char **argv)
 {
-	shell_print(shell, "ID | Device     | Device Name               "
+	shell_print(sh, "ID | Device     | Device Name               "
 		    "|   Offset   |   Size");
-	shell_print(shell, "-----------------------------------------"
+	shell_print(sh, "-----------------------------------------"
 		    "------------------------------");
 	flash_area_foreach(fa_cb, (struct shell *)shell);
 	return 0;

--- a/subsys/testsuite/include/zephyr/tc_util.h
+++ b/subsys/testsuite/include/zephyr/tc_util.h
@@ -241,7 +241,7 @@ static inline void print_nothing(const char *fmt, ...)
 
 #if defined(CONFIG_SHELL)
 #define TC_CMD_DEFINE(name)						\
-	static int cmd_##name(const struct shell *shell, size_t argc,	\
+	static int cmd_##name(const struct shell *sh, size_t argc,	\
 			      char **argv) \
 	{								\
 		TC_START(__func__);					\

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -43,7 +43,7 @@ static const struct bt_data ad[] = {
 		      BT_UUID_16_ENCODE(BT_UUID_DIS_VAL)),
 };
 
-static int cmd_hrs_simulate(const struct shell *shell,
+static int cmd_hrs_simulate(const struct shell *sh,
 			    size_t argc, char *argv[])
 {
 	static bool hrs_registered;
@@ -51,12 +51,12 @@ static int cmd_hrs_simulate(const struct shell *shell,
 
 	if (!strcmp(argv[1], "on")) {
 		if (!hrs_registered && IS_ENABLED(CONFIG_BT_BROADCASTER)) {
-			shell_print(shell, "Registering HRS Service");
+			shell_print(sh, "Registering HRS Service");
 			hrs_registered = true;
 			err = bt_le_adv_start(BT_LE_ADV_CONN_NAME, ad,
 					      ARRAY_SIZE(ad), NULL, 0);
 			if (err) {
-				shell_error(shell, "Advertising failed to start"
+				shell_error(sh, "Advertising failed to start"
 					    " (err %d)\n", err);
 				return -ENOEXEC;
 			}
@@ -64,10 +64,10 @@ static int cmd_hrs_simulate(const struct shell *shell,
 			printk("Advertising successfully started\n");
 		}
 
-		shell_print(shell, "Start HRS simulation");
+		shell_print(sh, "Start HRS simulation");
 		hrs_simulate = true;
 	} else if (!strcmp(argv[1], "off")) {
-		shell_print(shell, "Stop HRS simulation");
+		shell_print(sh, "Stop HRS simulation");
 
 		if (hrs_registered && IS_ENABLED(CONFIG_BT_BROADCASTER)) {
 			bt_le_adv_stop();
@@ -75,8 +75,8 @@ static int cmd_hrs_simulate(const struct shell *shell,
 
 		hrs_simulate = false;
 	} else {
-		shell_print(shell, "Incorrect value: %s", argv[1]);
-		shell_help(shell);
+		shell_print(sh, "Incorrect value: %s", argv[1]);
+		shell_help(sh);
 		return -ENOEXEC;
 	}
 
@@ -96,9 +96,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(hrs_cmds,
 	SHELL_SUBCMD_SET_END
 );
 
-static int cmd_hrs(const struct shell *shell, size_t argc, char **argv)
+static int cmd_hrs(const struct shell *sh, size_t argc, char **argv)
 {
-	shell_error(shell, "%s unknown parameter: %s", argv[0], argv[1]);
+	shell_error(sh, "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;
 }

--- a/tests/subsys/shell/shell/src/main.c
+++ b/tests/subsys/shell/shell/src/main.c
@@ -43,7 +43,7 @@ ZTEST(shell_1cpu, test_cmd_help)
 	test_shell_execute_cmd("help dummy dummy", -EINVAL);
 }
 
-ZTEST(shell, test_cmd_clear)
+ZTEST(sh, test_cmd_clear)
 {
 	test_shell_execute_cmd("clear", 0);
 	test_shell_execute_cmd("clear -h", 1);
@@ -52,7 +52,7 @@ ZTEST(shell, test_cmd_clear)
 	test_shell_execute_cmd("clear dummy dummy", -EINVAL);
 }
 
-ZTEST(shell, test_cmd_shell)
+ZTEST(sh, test_cmd_shell)
 {
 	test_shell_execute_cmd("shell -h", 1);
 	test_shell_execute_cmd("shell --help", 1);
@@ -135,7 +135,7 @@ ZTEST(shell, test_cmd_shell)
 	test_shell_execute_cmd("shell stats show dummy dummy", -EINVAL);
 }
 
-ZTEST(shell, test_cmd_history)
+ZTEST(sh, test_cmd_history)
 {
 	test_shell_execute_cmd("history", 0);
 	test_shell_execute_cmd("history -h", 1);
@@ -144,7 +144,7 @@ ZTEST(shell, test_cmd_history)
 	test_shell_execute_cmd("history dummy dummy", -EINVAL);
 }
 
-ZTEST(shell, test_cmd_resize)
+ZTEST(sh, test_cmd_resize)
 {
 	test_shell_execute_cmd("resize -h", 1);
 	test_shell_execute_cmd("resize --help", 1);
@@ -159,7 +159,7 @@ ZTEST(shell, test_cmd_resize)
 	test_shell_execute_cmd("resize default dummy dummy", -EINVAL);
 }
 
-ZTEST(shell, test_shell_module)
+ZTEST(sh, test_shell_module)
 {
 	test_shell_execute_cmd("test_shell_cmd", 0);
 	test_shell_execute_cmd("test_shell_cmd -h", 1);
@@ -172,7 +172,7 @@ ZTEST(shell, test_shell_module)
 }
 
 /* test wildcard and static subcommands */
-ZTEST(shell, test_shell_wildcards_static)
+ZTEST(sh, test_shell_wildcards_static)
 {
 	test_shell_execute_cmd("test_wildcard", 0);
 	test_shell_execute_cmd("test_wildcard argument_1", 1);
@@ -186,7 +186,7 @@ ZTEST(shell, test_shell_wildcards_static)
 }
 
 /* test wildcard and dynamic subcommands */
-ZTEST(shell, test_shell_wildcards_dynamic)
+ZTEST(sh, test_shell_wildcards_dynamic)
 {
 	test_shell_execute_cmd("test_dynamic", 0);
 	test_shell_execute_cmd("test_dynamic d*", 1);
@@ -195,7 +195,7 @@ ZTEST(shell, test_shell_wildcards_dynamic)
 }
 
 
-static int cmd_test_module(const struct shell *shell, size_t argc, char **argv)
+static int cmd_test_module(const struct shell *sh, size_t argc, char **argv)
 {
 	ARG_UNUSED(argv);
 	ARG_UNUSED(argc);
@@ -205,7 +205,7 @@ static int cmd_test_module(const struct shell *shell, size_t argc, char **argv)
 SHELL_CMD_ARG_REGISTER(test_shell_cmd, NULL, "help", cmd_test_module, 1, 0);
 
 
-static int cmd_wildcard(const struct shell *shell, size_t argc, char **argv)
+static int cmd_wildcard(const struct shell *sh, size_t argc, char **argv)
 {
 	int valid_arguments = 0;
 	for (size_t i = 1; i < argc; i++) {
@@ -234,7 +234,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_test_shell_cmdl,
 SHELL_CMD_REGISTER(test_wildcard, &m_sub_test_shell_cmdl, NULL, cmd_wildcard);
 
 
-static int cmd_dynamic(const struct shell *shell, size_t argc, char **argv)
+static int cmd_dynamic(const struct shell *sh, size_t argc, char **argv)
 {
 	int valid_arguments = 0;
 
@@ -276,12 +276,12 @@ SHELL_CMD_REGISTER(test_dynamic, &m_sub_test_dynamic, NULL, cmd_dynamic);
 static void unselect_cmd(void)
 {
 	/* Unselecting command <shell color> */
-	const struct shell *shell = shell_backend_dummy_get_ptr();
+	const struct shell *sh = shell_backend_dummy_get_ptr();
 
-	shell->ctx->selected_cmd = NULL;
+	sh->ctx->selected_cmd = NULL;
 }
 
-ZTEST(shell, test_cmd_select)
+ZTEST(sh, test_cmd_select)
 {
 	unselect_cmd();
 	test_shell_execute_cmd("select -h", 1);
@@ -296,7 +296,7 @@ ZTEST(shell, test_cmd_select)
 	test_shell_execute_cmd("on", -ENOEXEC);
 }
 
-ZTEST(shell, test_set_root_cmd)
+ZTEST(sh, test_set_root_cmd)
 {
 	int err;
 
@@ -317,22 +317,22 @@ ZTEST(shell, test_set_root_cmd)
 	test_shell_execute_cmd("shell colors on", 0);
 }
 
-ZTEST(shell, test_shell_fprintf)
+ZTEST(sh, test_shell_fprintf)
 {
 	static const char expect[] = "testing 1 2 3";
-	const struct shell *shell;
+	const struct shell *sh;
 	const char *buf;
 	size_t size;
 
-	shell = shell_backend_dummy_get_ptr();
-	zassert_not_null(shell, "Failed to get shell");
+	sh = shell_backend_dummy_get_ptr();
+	zassert_not_null(sh, "Failed to get shell");
 
 	/* Clear the output buffer */
-	shell_backend_dummy_clear_output(shell);
+	shell_backend_dummy_clear_output(sh);
 
-	shell_fprintf(shell, SHELL_VT100_COLOR_DEFAULT, "testing %d %s %c",
+	shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, "testing %d %s %c",
 		      1, "2", '3');
-	buf = shell_backend_dummy_get_output(shell, &size);
+	buf = shell_backend_dummy_get_output(sh, &size);
 	zassert_true(size >= sizeof(expect), "Expected size > %u, got %d",
 		     sizeof(expect), size);
 
@@ -366,7 +366,7 @@ static int cmd_mand_1_opt_raw_handler(const struct shell *sh, size_t argc, char 
 SHELL_CMD_ARG_REGISTER(CMD_MAND_1_OPT_RAW_NAME, NULL, NULL, cmd_mand_1_opt_raw_handler, 1,
 		       SHELL_OPT_ARG_RAW);
 
-ZTEST(shell, test_cmd_mand_1_opt_raw)
+ZTEST(sh, test_cmd_mand_1_opt_raw)
 {
 	test_shell_execute_cmd("cmd_mand_1_opt_raw aaa \"\" bbb", 0);
 	test_shell_execute_cmd("cmd_mand_1_opt_raw", 0);
@@ -401,7 +401,7 @@ static int cmd_mand_2_opt_raw_handler(const struct shell *sh, size_t argc, char 
 SHELL_CMD_ARG_REGISTER(CMD_MAND_2_OPT_RAW_NAME, NULL, NULL, cmd_mand_2_opt_raw_handler, 2,
 		       SHELL_OPT_ARG_RAW);
 
-ZTEST(shell, test_mand_2_opt_raw)
+ZTEST(sh, test_mand_2_opt_raw)
 {
 	test_shell_execute_cmd("cmd_mand_2_opt_raw", -EINVAL);
 	test_shell_execute_cmd("cmd_mand_2_opt_raw mandatory", 0);
@@ -413,14 +413,14 @@ ZTEST(shell, test_mand_2_opt_raw)
 	shell_set_root_cmd(NULL);
 }
 
-static int cmd_dummy(const struct shell *shell, size_t argc, char **argv)
+static int cmd_dummy(const struct shell *sh, size_t argc, char **argv)
 {
 	return 0;
 }
 
 SHELL_CMD_REGISTER(dummy, NULL, NULL, cmd_dummy);
 
-ZTEST(shell, test_max_argc)
+ZTEST(sh, test_max_argc)
 {
 	BUILD_ASSERT(CONFIG_SHELL_ARGC_MAX == 20,
 		     "Unexpected test configuration.");
@@ -451,7 +451,7 @@ SHELL_SUBCMD_DICT_SET_CREATE(dict2, cmd_handler_dict_2, (one, 1, "one"), (two, 2
 SHELL_CMD_REGISTER(dict1, &dict1, NULL, NULL);
 SHELL_CMD_REGISTER(dict2, &dict2, NULL, NULL);
 
-ZTEST(shell, test_cmd_dict)
+ZTEST(sh, test_cmd_dict)
 {
 	test_shell_execute_cmd("dict1 one", 1);
 	test_shell_execute_cmd("dict1 two", 2);
@@ -480,7 +480,7 @@ SHELL_SUBCMD_ADD((section_cmd), cmd1, &sub_section_cmd1, "help for cmd1", cmd1_h
 SHELL_CMD_REGISTER(section_cmd, &sub_section_cmd,
 		   "Demo command using section for subcommand registration", NULL);
 
-ZTEST(shell, test_section_cmd)
+ZTEST(sh, test_section_cmd)
 {
 	test_shell_execute_cmd("section_cmd", SHELL_CMD_HELP_PRINTED);
 	test_shell_execute_cmd("section_cmd cmd1", 10);
@@ -503,4 +503,4 @@ static void *shell_setup(void)
 ZTEST_SUITE(shell_1cpu, NULL, shell_setup, ztest_simple_1cpu_before,
 			ztest_simple_1cpu_after, NULL);
 
-ZTEST_SUITE(shell, NULL, shell_setup, NULL, NULL, NULL);
+ZTEST_SUITE(sh, NULL, shell_setup, NULL, NULL, NULL);

--- a/tests/subsys/shell/shell_flash/src/shell_flash_test.c
+++ b/tests/subsys/shell/shell_flash/src/shell_flash_test.c
@@ -34,7 +34,7 @@ ZTEST(shell_flash, test_flash_read)
 		"00000010: 51 52 53 54 55 56 57 58  59 5a 5b 5c 5d 5e 5f 60 |QRSTUVWX YZ[\\]^_`|",
 		"00000020: 61 62 63                                         |abc              |",
 	};
-	const struct shell *shell = shell_backend_dummy_get_ptr();
+	const struct shell *sh = shell_backend_dummy_get_ptr();
 	const struct device *const flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 	const char *buf;
 	const int test_base = FLASH_SIMULATOR_BASE_OFFSET;
@@ -57,7 +57,7 @@ ZTEST(shell_flash, test_flash_read)
 	ret = shell_execute_cmd(NULL, "flash read 0 23");
 	zassert_equal(0, ret, "flash read failed: %d", ret);
 
-	buf = shell_backend_dummy_get_output(shell, &size);
+	buf = shell_backend_dummy_get_output(sh, &size);
 	for (i = 0; i < ARRAY_SIZE(lines); i++) {
 		/* buf contains all the bytes that goes through the shell
 		 * backend interface including escape codes, NL and CR.


### PR DESCRIPTION
MISRA Rule 5.7 requires uniqueness of tag identifiers. Shell is frequently problematic because many code uses `const struct shell *shell`. This causes CI noise every time one of these shell files is edited, so let's update all of them with `const struct shell *sh` instead.