### PR TITLE
usb: device: Revert "Do not call callback when transfer is cancelled"

### DIFF
--- a/include/zephyr/usb/usb_device.h
+++ b/include/zephyr/usb/usb_device.h
@@ -390,6 +390,8 @@ int usb_transfer(uint8_t ep, uint8_t *data, size_t dlen, unsigned int flags,
  *
  * Synchronous version of usb_transfer, wait for transfer completion before
  * returning.
+ * A return value of zero can also mean that transfer was cancelled or that the
+ * endpoint is not ready. This is due to the design of transfers and usb_dc API.
  *
  * @param[in]  ep           Endpoint address corresponding to the one
  *                          listed in the device configuration table

--- a/subsys/usb/device/usb_transfer.c
+++ b/subsys/usb/device/usb_transfer.c
@@ -14,8 +14,6 @@
 
 LOG_MODULE_REGISTER(usb_transfer, CONFIG_USB_DEVICE_LOG_LEVEL);
 
-#define USB_TRANSFER_SYNC_TIMEOUT 100
-
 struct usb_transfer_sync_priv {
 	int tsize;
 	struct k_sem sem;
@@ -318,23 +316,8 @@ int usb_transfer_sync(uint8_t ep, uint8_t *data, size_t dlen, unsigned int flags
 		return ret;
 	}
 
-	/* Semaphore will be released by the transfer completion callback
-	 * which might not be called when transfer was cancelled
-	 */
-	while (1) {
-		struct usb_transfer_data *trans;
-
-		ret = k_sem_take(&pdata.sem, K_MSEC(USB_TRANSFER_SYNC_TIMEOUT));
-		if (ret == 0) {
-			break;
-		}
-
-		trans = usb_ep_get_transfer(ep);
-		if (!trans || trans->status != -EBUSY) {
-			LOG_WRN("Sync transfer cancelled, ep 0x%02x", ep);
-			return -ECANCELED;
-		}
-	}
+	/* Semaphore will be released by the transfer completion callback */
+	k_sem_take(&pdata.sem, K_FOREVER);
 
 	return pdata.tsize;
 }

--- a/subsys/usb/device/usb_transfer.c
+++ b/subsys/usb/device/usb_transfer.c
@@ -151,9 +151,7 @@ done:
 		k_sem_give(&trans->sem);
 
 		/* Transfer completion callback */
-		if (trans->status != -ECANCELED) {
-			cb(ep, tsize, priv);
-		}
+		cb(ep, tsize, priv);
 	}
 }
 


### PR DESCRIPTION
This reverts commit f206170c655c433f25691728a22d675e15ad6d78 introduced as workaround for nRF USBD device controller in PR https://github.com/zephyrproject-rtos/zephyr/pull/16193.

This commit may be reverted due to changes made in commit e326c5839938
("usb: device: Do not cancel transfers on suspend").

Cherry-picked from https://github.com/zephyrproject-rtos/zephyr/pull/53540 and fixed commit message.