### PR TITLE
twister: Include unit test `testbinary` in ELF search space

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -278,11 +278,12 @@ class TestInstance:
 
         fns = glob.glob(os.path.join(build_dir, "zephyr", "*.elf"))
         fns.extend(glob.glob(os.path.join(build_dir, "zephyr", "*.exe")))
+        fns.extend(glob.glob(os.path.join(build_dir, "testbinary")))
         blocklist = [
                 'remapped', # used for xtensa plaforms
                 'zefi', # EFI for Zephyr
                 '_pre' ]
-        fns = [x for x in fns if not any(bad in os.path.split(x)[-1] for bad in blocklist)]
+        fns = [x for x in fns if not any(bad in os.path.basename(x) for bad in blocklist)]
         if len(fns) != 1 and self.platform.type != 'native':
             raise BuildError("Missing/multiple output ELF binary")
         return fns[0]


### PR DESCRIPTION
`TestInstance.get_elf_file()` does not include the binary name used for unit testing (`testbinary`) in its search, causing unit tests to not complete successfully. This does not cause tests to fail and thus goes unnoticed.

Update the glob expressions used in `get_elf_file()` to also look for files called `testbinary`

