### PR TITLE
lora: Add support for fine-grained STM32WL power amplifier configuration

### DIFF
--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -165,10 +165,18 @@
 	status = "okay";
 	lora: radio@0 {
 		status = "okay";
-		tx-enable-gpios = <&gpioc 4 GPIO_ACTIVE_LOW>;
-		rx-enable-gpios = <&gpioc 5 GPIO_ACTIVE_LOW>;
+		tx-enable-gpios = <&gpioc 4 GPIO_ACTIVE_LOW>; /* FE_CTRL1 */
+		rx-enable-gpios = <&gpioc 5 GPIO_ACTIVE_LOW>; /* FE_CTRL2 */
 		dio3-tcxo-voltage = <SX126X_DIO3_TCXO_1V7>;
 		tcxo-power-startup-delay-ms = <5>;
+		/* High-power output is selected as a consequence of using
+		 * tx/rx-enable-gpio to control FE_CTRL1 and FE_CTRL2. Low-power
+		 * output would require both FE_CTRL1 and FE_CTRL2 to be high,
+		 * which is not currently supported by the driver.
+		 */
+		power-amplifier-output = "rfo-hp";
+		rfo-lp-max-power = <15>;
+		rfo-hp-max-power = <22>;
 	};
 };
 

--- a/drivers/lora/sx126x.c
+++ b/drivers/lora/sx126x.c
@@ -359,7 +359,7 @@ void SX126xReset(void)
 void SX126xSetRfTxPower(int8_t power)
 {
 	LOG_DBG("power: %" PRIi8, power);
-	SX126xSetTxParams(power, RADIO_RAMP_40_US);
+	sx126x_set_tx_params(power, RADIO_RAMP_40_US);
 }
 
 void SX126xWaitOnBusy(void)

--- a/drivers/lora/sx126x_common.h
+++ b/drivers/lora/sx126x_common.h
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/spi.h>
 
 #include <sx126x/sx126x.h>
+#include <sx126x-board.h>
 
 #if DT_HAS_COMPAT_STATUS_OKAY(semtech_sx1261)
 #define DT_DRV_COMPAT semtech_sx1261
@@ -63,6 +64,8 @@ uint32_t sx126x_get_dio1_pin_state(struct sx126x_data *dev_data);
 void sx126x_dio1_irq_enable(struct sx126x_data *dev_data);
 
 void sx126x_dio1_irq_disable(struct sx126x_data *dev_data);
+
+void sx126x_set_tx_params(int8_t power, RadioRampTimes_t ramp_time);
 
 int sx126x_variant_init(const struct device *dev);
 

--- a/drivers/lora/sx126x_standalone.c
+++ b/drivers/lora/sx126x_standalone.c
@@ -61,6 +61,11 @@ static void sx126x_dio1_irq_callback(const struct device *dev,
 	}
 }
 
+void sx126x_set_tx_params(int8_t power, RadioRampTimes_t ramp_time)
+{
+	SX126xSetTxParams(power, ramp_time);
+}
+
 int sx126x_variant_init(const struct device *dev)
 {
 	struct sx126x_data *dev_data = dev->data;

--- a/drivers/lora/sx126x_stm32wl.c
+++ b/drivers/lora/sx126x_stm32wl.c
@@ -16,6 +16,11 @@
 #include <zephyr/irq.h>
 LOG_MODULE_DECLARE(sx126x, CONFIG_LORA_LOG_LEVEL);
 
+static const enum {
+	RFO_LP,
+	RFO_HP,
+} pa_output = DT_INST_STRING_UPPER_TOKEN(0, power_amplifier_output);
+
 void sx126x_reset(struct sx126x_data *dev_data)
 {
 	LL_RCC_RF_EnableReset();
@@ -43,6 +48,71 @@ void sx126x_dio1_irq_enable(struct sx126x_data *dev_data)
 void sx126x_dio1_irq_disable(struct sx126x_data *dev_data)
 {
 	irq_disable(DT_INST_IRQN(0));
+}
+
+void sx126x_set_tx_params(int8_t power, RadioRampTimes_t ramp_time)
+{
+	uint8_t buf[2];
+
+	if (pa_output == RFO_LP) {
+		const int8_t max_power = DT_INST_PROP(0, rfo_lp_max_power);
+
+		if (power > max_power) {
+			power = max_power;
+		}
+		if (max_power == 15) {
+			SX126xSetPaConfig(0x07, 0x00, 0x01, 0x01);
+			power = 14 - (max_power - power);
+		} else if (max_power == 10) {
+			SX126xSetPaConfig(0x01, 0x00, 0x01, 0x01);
+			power = 13 - (max_power - power);
+		} else { /* default +14 dBm */
+			SX126xSetPaConfig(0x04, 0x00, 0x01, 0x01);
+			power = 14 - (max_power - power);
+		}
+		if (power < -17) {
+			power = -17;
+		}
+
+		/* PA overcurrent protection limit 60 mA */
+		SX126xWriteRegister(REG_OCP, 0x18);
+	} else { /* RFO_HP */
+		/* Better Resistance of the RFO High Power Tx to Antenna
+		 * Mismatch, see STM32WL Erratasheet
+		 */
+		SX126xWriteRegister(REG_TX_CLAMP_CFG,
+				    SX126xReadRegister(REG_TX_CLAMP_CFG)
+					| (0x0F << 1));
+
+		const int8_t max_power = DT_INST_PROP(0, rfo_hp_max_power);
+
+		if (power > max_power) {
+			power = max_power;
+		}
+		if (max_power == 20) {
+			SX126xSetPaConfig(0x03, 0x05, 0x00, 0x01);
+			power = 22 - (max_power - power);
+		} else if (max_power == 17) {
+			SX126xSetPaConfig(0x02, 0x03, 0x00, 0x01);
+			power = 22 - (max_power - power);
+		} else if (max_power == 14) {
+			SX126xSetPaConfig(0x02, 0x02, 0x00, 0x01);
+			power = 14 - (max_power - power);
+		} else { /* default +22 dBm */
+			SX126xSetPaConfig(0x04, 0x07, 0x00, 0x01);
+			power = 22 - (max_power - power);
+		}
+		if (power < -9) {
+			power = -9;
+		}
+
+		/* PA overcurrent protection limit 140 mA */
+		SX126xWriteRegister(REG_OCP, 0x38);
+	}
+
+	buf[0] = power;
+	buf[1] = (uint8_t)ramp_time;
+	SX126xWriteCommand(RADIO_SET_TXPARAMS, buf, 2);
 }
 
 static void radio_isr(const struct device *dev)

--- a/dts/arm/olimex/bb-stm32wl.dtsi
+++ b/dts/arm/olimex/bb-stm32wl.dtsi
@@ -21,5 +21,7 @@
 		status = "okay";
 		tx-enable-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>; /* FE_CTRL1 */
 		rx-enable-gpios = <&gpiob 8 GPIO_ACTIVE_LOW>;  /* FE_CTRL2 */
+		power-amplifier-output = "rfo-lp";
+		rfo-lp-max-power = <14>;
 	};
 };

--- a/dts/arm/seeed/lora-e5.dtsi
+++ b/dts/arm/seeed/lora-e5.dtsi
@@ -24,5 +24,7 @@
 		rx-enable-gpios = <&gpioa 5 GPIO_ACTIVE_LOW>;
 		dio3-tcxo-voltage = <SX126X_DIO3_TCXO_1V7>;
 		tcxo-power-startup-delay-ms = <5>;
+		power-amplifier-output = "rfo-hp";
+		rfo-hp-max-power = <22>;
 	};
 };

--- a/dts/bindings/lora/st,stm32wl-subghz-radio.yaml
+++ b/dts/bindings/lora/st,stm32wl-subghz-radio.yaml
@@ -12,3 +12,45 @@ properties:
     required: true
     description: |
       Position of the "Radio IRQ, Busy" interrupt line.
+
+  power-amplifier-output:
+    type: string
+    required: true
+    description: |
+      Selects between the low- and high-power power amplifier output pin.
+    enum:
+      - "rfo-lp"
+      - "rfo-hp"
+
+  rfo-lp-max-power:
+    type: int
+    default: 14
+    description: |
+      Maximum design power for the board's RFO_LP output matching network.
+
+      The default setting of +14 dBm is a prevalent board configuration;
+      however, for optimal performance, it is advisable to align the value with
+      the board's RF design.
+
+      See ST application note AN5457, chapter 5.1.2 for more information.
+    enum:
+      - 10
+      - 14
+      - 15
+
+  rfo-hp-max-power:
+    type: int
+    default: 22
+    description: |
+      Maximum design power for the board's RFO_HP output matching network.
+
+      The default setting of +22 dBm is a prevalent board configuration;
+      however, for optimal performance, it is advisable to align the value with
+      the board's RF design.
+
+      See ST application note AN5457, chapter 5.1.2 for more information.
+    enum:
+      - 14
+      - 17
+      - 20
+      - 22


### PR DESCRIPTION
### Summary

This PR adds the ability to select between the low-power `RFO_LP` and high-power `RFO_HP` LoRa radio power amplifier output, as well as setting the maximum design Tx output via a new devicetree properties on STM32WL-based boards.
This allows better matching of the power amplifier output with boards' RF impedance matching network.

Previously only the high-power `RFO_HP` output was supported in the highest design power output (+22 dBm), as the same PA config register is used to differentiate between the discrete SX1261 and SX1262 chips in LoRaMac-node.

I've locally tested this change on a Olimex STM32WL Devkit.

Closes #48511

### Change Description

Add STM32WL-specific `sx126x_set_tx_params` function based on the STM32CubeWL modifications to LoRaMac-node.

~~Add `tx-power-low` devicetree binding to `st,stm32wl-subghz-radio` for toggling the `RFO_LP` output functionality provided in this commit.~~
**Add the `power-amplifier-output` devicetree property to `st,stm32wl-subghz-radio` for selecting between the RFO_LP and RFO_HP output configurations provided by the above mentioned function.**

Also add the `rfo-lp-max-power` and `rfo-hp-max-power` DT properties for defining the maximum design power of the respective outputs' matching networks.

~~Set `RFO_LP` output as default for the BB-STM32WL module.~~
**Set the appropriate output and max-power values for all affected boards and modules.**
### Impact and future work

I consider this method of least impact for adding this feature and aligning the behavior of the Zephyr LoRa driver for the STM32WL family with that provided by the STM32CubeWL driver. (Versus the alternative of adding the STM32CubeWL LoRaMac-node modifications as its own Zephyr module with accompanying glue code in `sx126x.c`)

This PR may improve `RFO_LP` Tx performance, as it uses the higher duty cycle configured in the STM32CubeWL driver for the +15 dBm output mode. It should also guarantee better device longevity by additionally enforcing overcurrent protection for the power amplifier.

This PR also paves the way for more advanced PA output selection. A `tx-power-gpios` property might later be added for defining GPIOs to control an RF switch to toggle `RFO_LP` and `RFO_HP` on hardware supporting this such as the Nucleo WL55JC.

There are still some differences in hardware configuration to STM32CubeWL that the Zephyr LoRa driver is lacking, such as not setting the highest Rx gain possible in `SX126xSetRxBoosted`, and the LoRaMac-node code assuming a default antenna gain of 2.15 dBi, but I will address these in separate PR(s).

@martinjaeger I'm not sure how you've worked around this issue on your hardware, but if you've re-soldered the 0R resistor to enable the `RFO_HP` output path, you'll need to delete the newly added property in your overlay(s). Just a friendly heads up :smiley:

### References

See chapter RM0461 chapter 4.8.4., Set_PaConfig() command, and AN5457 chapter 5.1.2.

1. [RM0461 Reference manual - STM32WLEx advanced Arm-based 32-bit MCUs with sub-GHz radio solution](https://www.st.com/resource/en/reference_manual/rm0461-stm32wlex-advanced-armbased-32bit-mcus-with-subghz-radio-solution-stmicroelectronics.pdf)
2. [AN5457 Application note - RF matching network design guide for STM32WL Series](https://www.st.com/resource/en/application_note/an5457-rf-matching-network-design-guide-for-stm32wl-series-stmicroelectronics.pdf)
3. [STM32CubeWL SubGHz_PHY driver](https://github.com/STMicroelectronics/STM32CubeWL/blob/main/Middlewares/Third_Party/SubGHz_Phy/stm32_radio_driver/radio_driver.c#L620-L692)