### PR TITLE
manifest: Update MCUboot revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -181,7 +181,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 143485e35b8da7d234677d8920a28f5ea03f6d09
+      revision: 6902abba270c0fbcbe8ee3bb56fe39bc9acc2774
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Updates MCUboot to commit 6902abb from upstream which includes:

6902abb zephyr: Create common boot serial enter function 35941fe boot: zephyr: Add pin reset serial recovery entrance method fd79db3 zephyr: boot: serial_recovery: Add no application entrace
        method
b3e3ce3 boot: zephyr: serial_recovery: Add boot mode enter ability e5c57dd boot_serial: Only have build number if non-zero 8a3b32c bootutil: Refactor signature verification
4e07d8f docs: add release note snippet for dumpinfo ca56135 imgtool: Add 'dumpinfo' command
c050573 docs: Add release note for p224 removal
75c7c31 sim: Remove P224 curve references
3d92a6c imgtool: Remove P224 curve references
206b914 bootutil: Remove P224 curve
a97f009 Update readme for next dev version
23d2883 Update to version 1.10.0
cdf9de0 doc/readme-zephyr: document the serial recovery 4e9d86a doc: Added serial recovery documentation
827118f boot: serial_recovery: Add image hash support f5e7753 boot_serial: support fragmentation for outgoing SMP packets 569b1d6 Update to version 1.10.0-rc1
d2dfa1b docs: Create release notes for 1.10.0 release 4337fee docs: Describe the release note snippet requirement d4184eb docs: Setup template for release note process 1090d8f zephyr: Check zephyr,uart-mcumgr as candidate for serial
        recovery