### PR TITLE
Mix fixes following main() type change

### DIFF
--- a/arch/posix/include/posix_cheats.h
+++ b/arch/posix/include/posix_cheats.h
@@ -47,7 +47,7 @@
 #if defined(__cplusplus) && defined(CONFIG_CPP_MAIN)
 /* To be able to define main() in C++ code we need to have its prototype
  * defined somewhere visibly. Otherwise name mangling will prevent the linker
- * from finding it. Zephyr assumes a void main(void) prototype and therefore
+ * from finding it. Zephyr assumes an int main(void) prototype and therefore
  * this will be the prototype after renaming:
  */
 extern "C" int _posix_zephyr_main(void);

--- a/samples/bluetooth/broadcast_audio_sink/src/main.c
+++ b/samples/bluetooth/broadcast_audio_sink/src/main.c
@@ -599,7 +599,7 @@ int main(void)
 		if (err != 0) {
 			printk("Resetting failed: %d - Aborting\n", err);
 
-			return;
+			return 0;
 		}
 
 		if (IS_ENABLED(CONFIG_SCAN_OFFLOAD)) {
@@ -609,7 +609,7 @@ int main(void)
 				printk("Unable to start advertising connectable: %d\n",
 				       err);
 
-				return;
+				return 0;
 			}
 
 			printk("Waiting for Broadcast Assistant\n");
@@ -622,7 +622,7 @@ int main(void)
 					printk("Unable to stop advertising: %d\n",
 					       err);
 
-					return;
+					return 0;
 				}
 			} else {
 				/* Wait for the PA request to determine if we


### PR DESCRIPTION
samples/bluetooth/broadcast_audio_sink: Fix return to int  <-- hotfix, CI breaks without this.

Main now has an int return type.
Fix return values, so this sample can be compiled.

----------

arch posix: posix_cheats.h main() type changed in comment

Align the comment with the new int main(void) convention used in Zephyr.

---------

Fixes following https://github.com/zephyrproject-rtos/zephyr/pull/54628 