### PR TITLE
drivers: usb: Make EP0 max packet size configurable

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -91,6 +91,18 @@ config USB_DC_SAM_USBHS
 	help
 	  SAM family USB HS device controller Driver.
 
+config USB_DC_EP0_MPS
+	int "Maximum packet size of endpoint 0"
+	default 64
+	help
+	  Maximum packet size of endpoint 0. This value goes to
+	  device descriptor and is used for EP0 configuration.
+	  It is bMaxPacketSize0 field (byte 7 of the device descriptor).
+	  Valid values for:
+	  - low speed devices: 8
+	  - full speed devices: 8, 16, 32, 64
+	  - high speed device: 64
+
 config USB_NRFX
 	bool "Nordic Semiconductor USB Device Controller Driver"
 	default y

--- a/include/zephyr/usb/usb_device.h
+++ b/include/zephyr/usb/usb_device.h
@@ -79,10 +79,10 @@ extern "C" {
  *  USB configuration
  **************************************************************************/
 
-#define USB_MAX_CTRL_MPS	64   /**< maximum packet size (MPS) for EP 0 */
-#define USB_MAX_FS_BULK_MPS	64   /**< full speed MPS for bulk EP */
-#define USB_MAX_FS_INT_MPS	64   /**< full speed MPS for interrupt EP */
-#define USB_MAX_FS_ISO_MPS	1023 /**< full speed MPS for isochronous EP */
+#define USB_MAX_CTRL_MPS	CONFIG_USB_DC_EP0_MPS   /**< maximum packet size (MPS) for EP 0 */
+#define USB_MAX_FS_BULK_MPS	64                      /**< full speed MPS for bulk EP */
+#define USB_MAX_FS_INT_MPS	64                      /**< full speed MPS for interrupt EP */
+#define USB_MAX_FS_ISO_MPS	1023                    /**< full speed MPS for isochronous EP */
 
 /*************************************************************************
  *  USB application interface


### PR DESCRIPTION
MPS for EP0 is a fixed value now and states under USB_MAX_CTRL_MPS define. Since this value could have another values like 8, 16, 32 or fixed 64 and it depends on a device, that sometimes could not support such high values, then reasonable seems to be make it configurable by the end user.