### PR TITLE
Bluetooth: Controller: Fix connection update window offset data type

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2088,7 +2088,7 @@ static void ull_conn_update_ticker(struct ll_conn *conn,
 }
 
 void ull_conn_update_parameters(struct ll_conn *conn, uint8_t is_cu_proc, uint8_t win_size,
-				uint16_t win_offset_us, uint16_t interval, uint16_t latency,
+				uint32_t win_offset_us, uint16_t interval, uint16_t latency,
 				uint16_t timeout, uint16_t instant)
 {
 	struct lll_conn *lll;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -79,7 +79,7 @@ static inline void cpr_active_reset(void)
 uint16_t ull_conn_event_counter(struct ll_conn *conn);
 
 void ull_conn_update_parameters(struct ll_conn *conn, uint8_t is_cu_proc,
-				uint8_t win_size, uint16_t win_offset_us,
+				uint8_t win_size, uint32_t win_offset_us,
 				uint16_t interval, uint16_t latency,
 				uint16_t timeout, uint16_t instant);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -209,13 +209,13 @@ struct proc_ctx {
 			uint8_t error;
 			uint8_t rejected_opcode;
 			uint8_t params_changed;
-			uint16_t instant;
 			uint8_t win_size;
-			uint16_t win_offset_us;
+			uint16_t instant;
 			uint16_t interval_min;
 			uint16_t interval_max;
 			uint16_t latency;
 			uint16_t timeout;
+			uint32_t win_offset_us;
 #if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
 			uint8_t  preferred_periodicity;
 			uint16_t reference_conn_event_count;


### PR DESCRIPTION
Fix regression in refactored LLCP using uint16_t instead of uint32_t in storing the win_offset_us value. This caused connection update to fail with incorrect window offset being used to schedule the connection radio events.

Regression since commit e1c2c36f569a ("Bluetooth: controller:
llcp: set refactored as default").

Fixes #56197.