### PR TITLE
Bluetooth: controller: removing (invalid) ASSERT on invalid PDU

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1745,15 +1745,18 @@ void ull_cp_rx(struct ll_conn *conn, struct node_rx_pdu *rx)
 					 pdu_is_unknown(pdu, ctx_r) ||
 					 pdu_is_reject_ext(pdu, ctx_r));
 
-			if (unexpected_l && unexpected_r) {
-				/* Local active procedure
-				 * Unexpected local procedure PDU
-				 * Remote active procedure
-				 * Unexpected remote procedure PDU
+			if (unexpected_l == unexpected_r) {
+				/* Both Local and Remote procedure active
+				 * and PDU is either
+				 * unexpected by both
+				 * or
+				 * expected by both
+				 *
+				 * Both situations is a result of invalid behaviour
 				 */
-
-				/* Invalid Behaviour */
-				conn->llcp_terminate.reason_final = BT_HCI_ERR_LOCALHOST_TERM_CONN;
+				conn->llcp_terminate.reason_final =
+					unexpected_r ? BT_HCI_ERR_LMP_PDU_NOT_ALLOWED :
+						       BT_HCI_ERR_UNSPECIFIED;
 			} else if (unexpected_l) {
 				/* Local active procedure
 				 * Unexpected local procedure PDU
@@ -1772,16 +1775,10 @@ void ull_cp_rx(struct ll_conn *conn, struct node_rx_pdu *rx)
 
 				/* Process PDU in local procedure */
 				llcp_lr_rx(conn, ctx_l, rx);
-			} else {
-				/* Local active procedure
-				 * Expected local procedure PDU
-				 * Remote active procedure
-				 * Expected remote procedure PDU
-				 */
-
-				/* This cannot happen */
-				LL_ASSERT(0);
 			}
+			/* no else clause as this cannot occur with the logic above:
+			 * if they are not identical then one must be true
+			 */
 		} else {
 			/* Local active procedure
 			 * No remote active procedure

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -602,6 +602,14 @@ static void rr_st_idle(struct ll_conn *conn, uint8_t evt, void *param)
 				 *
 				 * Local periph procedure completes with error.
 				 */
+				/* Local procedure */
+				ctx_local = llcp_lr_peek(conn);
+				if (ctx_local) {
+					/* Make sure local procedure stops expecting PDUs except
+					 * implicit UNKNOWN_RSP and REJECTs
+					 */
+					ctx_local->rx_opcode = PDU_DATA_LLCTRL_TYPE_UNUSED;
+				}
 
 				/* Run remote procedure */
 				rr_act_run(conn);


### PR DESCRIPTION
A case of an invalid PDU was seen leading to a hit on this ASSERT, ie this COULD happen. Refactoring of the state handling re. expectedness in remote vs local request machines combined with ensuring the local request machine ceases to expect PDUs when remote procedure 'takes over'