### PR TITLE
[RFC] soc: xtensa: intel_adsp: do power off only with custom pm policy

### DIFF
--- a/soc/xtensa/intel_adsp/cavs/power.c
+++ b/soc/xtensa/intel_adsp/cavs/power.c
@@ -32,7 +32,7 @@ LOG_MODULE_REGISTER(soc);
 # define SHIM_GPDMA_CLKCTL(x)     (SHIM_GPDMA_BASE(x) + 0x4)
 # define SHIM_CLKCTL_LPGPDMAFDCGB BIT(0)
 
-#ifdef CONFIG_PM
+#ifdef CONFIG_PM_POLICY_CUSTOM
 #define SRAM_ALIAS_BASE		0x9E000000
 #define SRAM_ALIAS_MASK		0xFF000000
 #define EBB_BANKS_IN_SEGMENT	32
@@ -108,7 +108,7 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 		__ASSERT(false, "invalid argument - unsupported power state");
 	}
 }
-#endif
+#endif /* CONFIG_PM_POLICY_CUSTOM */
 
 __imr void power_init(void)
 {


### PR DESCRIPTION
The power off sequence in cavs is meant to be used only by custom pm policy handler thus guard it with proper ifdefs.