### PR TITLE
drivers: flash: stm32 ospi: fix jedec id read for non OPI mode

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -351,7 +351,6 @@ static int stm32_ospi_read_jedec_id(const struct device *dev)
 	OSPI_RegularCmdTypeDef cmd = ospi_prepare_cmd(OSPI_SPI_MODE, OSPI_STR_TRANSFER);
 
 	cmd.Instruction = JESD216_CMD_READ_ID;
-	cmd.DummyCycles = 8U;
 	cmd.AddressSize = HAL_OSPI_ADDRESS_NONE;
 	cmd.NbData = JESD216_READ_ID_LEN; /* 3 bytes in the READ ID */
 


### PR DESCRIPTION
Flash not in OPI mode doesn't require extra dummy cycles.