### PR TITLE
devicetree: edtlib: support deepcopy and add type annotations

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -817,7 +817,7 @@ class DT:
 
     def has_node(self, path: str) -> bool:
         """
-        Returns True if the path or alias 'path' exists. See Node.get_node().
+        Returns True if the path or alias 'path' exists. See DT.get_node().
         """
         try:
             self.get_node(path)

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -781,6 +781,49 @@ class Range:
         return "<Range, {}>".format(", ".join(fields))
 
 
+class ControllerAndData:
+    """
+    Represents an entry in an 'interrupts' or 'type: phandle-array' property
+    value, e.g. <&ctrl-1 4 0> in
+
+        cs-gpios = <&ctrl-1 4 0 &ctrl-2 3 4>;
+
+    These attributes are available on ControllerAndData objects:
+
+    node:
+      The Node instance the property appears on
+
+    controller:
+      The Node instance for the controller (e.g. the controller the interrupt
+      gets sent to for interrupts)
+
+    data:
+      A dictionary that maps names from the *-cells key in the binding for the
+      controller to data values, e.g. {"pin": 4, "flags": 0} for the example
+      above.
+
+      'interrupts = <1 2>' might give {"irq": 1, "level": 2}.
+
+    name:
+      The name of the entry as given in
+      'interrupt-names'/'gpio-names'/'pwm-names'/etc., or None if there is no
+      *-names property
+
+    basename:
+      Basename for the controller when supporting named cells
+    """
+    def __repr__(self):
+        fields = []
+
+        if self.name is not None:
+            fields.append("name: " + self.name)
+
+        fields.append(f"controller: {self.controller}")
+        fields.append(f"data: {self.data}")
+
+        return "<ControllerAndData, {}>".format(", ".join(fields))
+
+
 class EDT:
     """
     Represents a devicetree augmented with information from bindings.
@@ -2168,49 +2211,6 @@ class Node:
                  f"instead of {len(data_list)}")
 
         return dict(zip(cell_names, data_list))
-
-
-class ControllerAndData:
-    """
-    Represents an entry in an 'interrupts' or 'type: phandle-array' property
-    value, e.g. <&ctrl-1 4 0> in
-
-        cs-gpios = <&ctrl-1 4 0 &ctrl-2 3 4>;
-
-    These attributes are available on ControllerAndData objects:
-
-    node:
-      The Node instance the property appears on
-
-    controller:
-      The Node instance for the controller (e.g. the controller the interrupt
-      gets sent to for interrupts)
-
-    data:
-      A dictionary that maps names from the *-cells key in the binding for the
-      controller to data values, e.g. {"pin": 4, "flags": 0} for the example
-      above.
-
-      'interrupts = <1 2>' might give {"irq": 1, "level": 2}.
-
-    name:
-      The name of the entry as given in
-      'interrupt-names'/'gpio-names'/'pwm-names'/etc., or None if there is no
-      *-names property
-
-    basename:
-      Basename for the controller when supporting named cells
-    """
-    def __repr__(self):
-        fields = []
-
-        if self.name is not None:
-            fields.append("name: " + self.name)
-
-        fields.append(f"controller: {self.controller}")
-        fields.append(f"data: {self.data}")
-
-        return "<ControllerAndData, {}>".format(", ".join(fields))
 
 
 class PinCtrl:

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -3173,7 +3173,7 @@ _BindingLoader.add_constructor("!include", _binding_include)
 # include/devicetree.h.
 #
 
-_DEFAULT_PROP_TYPES = {
+_DEFAULT_PROP_TYPES: Dict[str, str] = {
     "compatible": "string-array",
     "status": "string",
     "reg": "array",
@@ -3185,10 +3185,12 @@ _DEFAULT_PROP_TYPES = {
     "interrupt-controller": "boolean",
 }
 
-_STATUS_ENUM = "ok okay disabled reserved fail fail-sss".split()
+_STATUS_ENUM: List[str] = "ok okay disabled reserved fail fail-sss".split()
 
-def _raw_default_property_for(name):
-    ret = {
+def _raw_default_property_for(
+        name: str
+) -> Dict[str, Union[str, bool, List[str]]]:
+    ret: Dict[str, Union[str, bool, List[str]]] = {
         'type': _DEFAULT_PROP_TYPES[name],
         'required': False,
     }
@@ -3196,7 +3198,7 @@ def _raw_default_property_for(name):
         ret['enum'] = _STATUS_ENUM
     return ret
 
-_DEFAULT_PROP_BINDING = Binding(
+_DEFAULT_PROP_BINDING: Binding = Binding(
     None, {},
     raw={
         'properties': {
@@ -3207,14 +3209,14 @@ _DEFAULT_PROP_BINDING = Binding(
     require_compatible=False, require_description=False,
 )
 
-_DEFAULT_PROP_SPECS = {
+_DEFAULT_PROP_SPECS: Dict[str, PropertySpec] = {
     name: PropertySpec(name, _DEFAULT_PROP_BINDING)
     for name in _DEFAULT_PROP_TYPES
 }
 
 # A set of vendor prefixes which are grandfathered in by Linux,
 # and therefore by us as well.
-_VENDOR_PREFIX_ALLOWED = set([
+_VENDOR_PREFIX_ALLOWED: Set[str] = set([
     "at25", "bm", "devbus", "dmacap", "dsa",
     "exynos", "fsia", "fsib", "gpio-fan", "gpio-key", "gpio", "gpmc",
     "hdmi", "i2c-gpio", "keypad", "m25p", "max8952", "max8997",

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -598,6 +598,106 @@ class PropertySpec:
         return self._raw.get("specifier-space")
 
 
+class Property:
+    """
+    Represents a property on a Node, as set in its DT node and with
+    additional info from the 'properties:' section of the binding.
+
+    Only properties mentioned in 'properties:' get created. Properties of type
+    'compound' currently do not get Property instances, as it's not clear
+    what to generate for them.
+
+    These attributes are available on Property objects. Several are
+    just convenience accessors for attributes on the PropertySpec object
+    accessible via the 'spec' attribute.
+
+    These attributes are available on Property objects:
+
+    node:
+      The Node instance the property is on
+
+    spec:
+      The PropertySpec object which specifies this property.
+
+    name:
+      Convenience for spec.name.
+
+    description:
+      Convenience for spec.description with leading and trailing whitespace
+      (including newlines) removed. May be None.
+
+    type:
+      Convenience for spec.type.
+
+    val:
+      The value of the property, with the format determined by spec.type,
+      which comes from the 'type:' string in the binding.
+
+        - For 'type: int/array/string/string-array', 'val' is what you'd expect
+          (a Python integer or string, or a list of them)
+
+        - For 'type: phandle' and 'type: path', 'val' is the pointed-to Node
+          instance
+
+        - For 'type: phandles', 'val' is a list of the pointed-to Node
+          instances
+
+        - For 'type: phandle-array', 'val' is a list of ControllerAndData
+          instances. See the documentation for that class.
+
+    val_as_token:
+      The value of the property as a token, i.e. with non-alphanumeric
+      characters replaced with underscores. This is only safe to access
+      if self.enum_tokenizable returns True.
+
+    enum_index:
+      The index of 'val' in 'spec.enum' (which comes from the 'enum:' list
+      in the binding), or None if spec.enum is None.
+    """
+
+    def __init__(self, spec, val, node):
+        self.val = val
+        self.spec = spec
+        self.node = node
+
+    @property
+    def name(self):
+        "See the class docstring"
+        return self.spec.name
+
+    @property
+    def description(self):
+        "See the class docstring"
+        return self.spec.description.strip() if self.spec.description else None
+
+    @property
+    def type(self):
+        "See the class docstring"
+        return self.spec.type
+
+    @property
+    def val_as_token(self):
+        "See the class docstring"
+        return str_as_token(self.val)
+
+    @property
+    def enum_index(self):
+        "See the class docstring"
+        enum = self.spec.enum
+        return enum.index(self.val) if enum else None
+
+    def __repr__(self):
+        fields = ["name: " + self.name,
+                  # repr() to deal with lists
+                  "type: " + self.type,
+                  "value: " + repr(self.val)]
+
+        if self.enum_index is not None:
+            fields.append(f"enum index: {self.enum_index}")
+
+        return "<Property, {}>".format(", ".join(fields))
+
+
 class EDT:
     """
     Represents a devicetree augmented with information from bindings.
@@ -2150,106 +2250,6 @@ class PinCtrl:
         fields.append("configuration nodes: " + str(self.conf_nodes))
 
         return "<PinCtrl, {}>".format(", ".join(fields))
-
-
-class Property:
-    """
-    Represents a property on a Node, as set in its DT node and with
-    additional info from the 'properties:' section of the binding.
-
-    Only properties mentioned in 'properties:' get created. Properties of type
-    'compound' currently do not get Property instances, as it's not clear
-    what to generate for them.
-
-    These attributes are available on Property objects. Several are
-    just convenience accessors for attributes on the PropertySpec object
-    accessible via the 'spec' attribute.
-
-    These attributes are available on Property objects:
-
-    node:
-      The Node instance the property is on
-
-    spec:
-      The PropertySpec object which specifies this property.
-
-    name:
-      Convenience for spec.name.
-
-    description:
-      Convenience for spec.description with leading and trailing whitespace
-      (including newlines) removed. May be None.
-
-    type:
-      Convenience for spec.type.
-
-    val:
-      The value of the property, with the format determined by spec.type,
-      which comes from the 'type:' string in the binding.
-
-        - For 'type: int/array/string/string-array', 'val' is what you'd expect
-          (a Python integer or string, or a list of them)
-
-        - For 'type: phandle' and 'type: path', 'val' is the pointed-to Node
-          instance
-
-        - For 'type: phandles', 'val' is a list of the pointed-to Node
-          instances
-
-        - For 'type: phandle-array', 'val' is a list of ControllerAndData
-          instances. See the documentation for that class.
-
-    val_as_token:
-      The value of the property as a token, i.e. with non-alphanumeric
-      characters replaced with underscores. This is only safe to access
-      if self.enum_tokenizable returns True.
-
-    enum_index:
-      The index of 'val' in 'spec.enum' (which comes from the 'enum:' list
-      in the binding), or None if spec.enum is None.
-    """
-
-    def __init__(self, spec, val, node):
-        self.val = val
-        self.spec = spec
-        self.node = node
-
-    @property
-    def name(self):
-        "See the class docstring"
-        return self.spec.name
-
-    @property
-    def description(self):
-        "See the class docstring"
-        return self.spec.description.strip() if self.spec.description else None
-
-    @property
-    def type(self):
-        "See the class docstring"
-        return self.spec.type
-
-    @property
-    def val_as_token(self):
-        "See the class docstring"
-        return str_as_token(self.val)
-
-    @property
-    def enum_index(self):
-        "See the class docstring"
-        enum = self.spec.enum
-        return enum.index(self.val) if enum else None
-
-    def __repr__(self):
-        fields = ["name: " + self.name,
-                  # repr() to deal with lists
-                  "type: " + self.type,
-                  "value: " + repr(self.val)]
-
-        if self.enum_index is not None:
-            fields.append(f"enum index: {self.enum_index}")
-
-        return "<Property, {}>".format(", ".join(fields))
 
 
 def bindings_from_paths(yaml_paths, ignore_errors=False):

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -522,36 +522,36 @@ class PropertySpec:
       The specifier space for the property as given in the binding, or None.
     """
 
-    def __init__(self, name, binding):
-        self.binding = binding
-        self.name = name
-        self._raw = self.binding.raw["properties"][name]
+    def __init__(self, name: str, binding: Binding):
+        self.binding: Binding = binding
+        self.name: str = name
+        self._raw: Dict[str, Any] = self.binding.raw["properties"][name]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<PropertySpec {self.name} type '{self.type}'>"
 
     @property
-    def path(self):
+    def path(self) -> Optional[str]:
         "See the class docstring"
         return self.binding.path
 
     @property
-    def type(self):
+    def type(self) -> str:
         "See the class docstring"
         return self._raw["type"]
 
     @property
-    def description(self):
+    def description(self) -> Optional[str]:
         "See the class docstring"
         return self._raw.get("description")
 
     @property
-    def enum(self):
+    def enum(self) -> Optional[list]:
         "See the class docstring"
         return self._raw.get("enum")
 
     @property
-    def enum_tokenizable(self):
+    def enum_tokenizable(self) -> bool:
         "See the class docstring"
         if not hasattr(self, '_enum_tokenizable'):
             if self.type != 'string' or self.enum is None:
@@ -568,7 +568,7 @@ class PropertySpec:
         return self._enum_tokenizable
 
     @property
-    def enum_upper_tokenizable(self):
+    def enum_upper_tokenizable(self) -> bool:
         "See the class docstring"
         if not hasattr(self, '_enum_upper_tokenizable'):
             if not self.enum_tokenizable:
@@ -580,27 +580,27 @@ class PropertySpec:
         return self._enum_upper_tokenizable
 
     @property
-    def const(self):
+    def const(self) -> Union[None, int, List[int], str, List[str]]:
         "See the class docstring"
         return self._raw.get("const")
 
     @property
-    def default(self):
+    def default(self) -> Union[None, int, List[int], str, List[str]]:
         "See the class docstring"
         return self._raw.get("default")
 
     @property
-    def required(self):
+    def required(self) -> bool:
         "See the class docstring"
         return self._raw.get("required", False)
 
     @property
-    def deprecated(self):
+    def deprecated(self) -> bool:
         "See the class docstring"
         return self._raw.get("deprecated", False)
 
     @property
-    def specifier_space(self):
+    def specifier_space(self) -> Optional[str]:
         "See the class docstring"
         return self._raw.get("specifier-space")
 
@@ -2558,6 +2558,8 @@ def _check_prop_by_type(prop_name: str,
                  f"has type 'phandle-array' and its name does not end in 's', "
                  f"but no 'specifier-space' was provided.")
 
+    # If you change const_types, be sure to update the type annotation
+    # for PropertySpec.const.
     const_types = {"int", "array", "uint8-array", "string", "string-array"}
     if const and prop_type not in const_types:
         _err(f"const in {binding_path} for property '{prop_name}' "
@@ -2576,7 +2578,9 @@ def _check_prop_by_type(prop_name: str,
              f"'properties:' in {binding_path}")
 
     def ok_default() -> bool:
-        # Returns True if 'default' is an okay default for the property's type
+        # Returns True if 'default' is an okay default for the property's type.
+        # If you change this, be sure to update the type annotation for
+        # PropertySpec.default.
 
         if prop_type == "int" and isinstance(default, int) or \
            prop_type == "string" and isinstance(default, str):

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -810,6 +810,7 @@ class ControllerAndData:
     basename: Optional[str]
 
 
+@dataclass
 class PinCtrl:
     """
     Represents a pin control configuration for a set of pins on a device,
@@ -834,20 +835,14 @@ class PinCtrl:
           pinctrl-0 = <&state_1 &state_2>;
     """
 
+    node: 'Node'
+    name: Optional[str]
+    conf_nodes: List['Node']
+
     @property
     def name_as_token(self):
         "See the class docstring"
         return str_as_token(self.name) if self.name is not None else None
-
-    def __repr__(self):
-        fields = []
-
-        if self.name is not None:
-            fields.append("name: " + self.name)
-
-        fields.append("configuration nodes: " + str(self.conf_nodes))
-
-        return "<PinCtrl, {}>".format(", ".join(fields))
 
 
 class Node:
@@ -1625,12 +1620,12 @@ class Node:
 
         self.pinctrls = []
         for prop in pinctrl_props:
-            pinctrl = PinCtrl()
-            pinctrl.node = self
-            pinctrl.conf_nodes = [
-                self.edt._node2enode[node] for node in prop.to_nodes()
-            ]
-            self.pinctrls.append(pinctrl)
+            # We'll fix up the names below.
+            self.pinctrls.append(PinCtrl(
+                node=self,
+                name=None,
+                conf_nodes=[self.edt._node2enode[node]
+                            for node in prop.to_nodes()]))
 
         _add_names(node, "pinctrl", self.pinctrls)
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -740,26 +740,26 @@ class Range:
       The Node instance this range is from
 
     child_bus_cells:
-      Is the number of cells (4-bytes wide words) describing the child bus address.
+      The number of cells used to describe a child bus address.
 
     child_bus_addr:
-      Is a physical address within the child bus address space, or None if the
-      child address-cells is equal 0.
+      A physical address within the child bus address space, or None if the
+      child's #address-cells equals 0.
 
     parent_bus_cells:
-      Is the number of cells (4-bytes wide words) describing the parent bus address.
+      The number of cells used to describe a parent bus address.
 
     parent_bus_addr:
-      Is a physical address within the parent bus address space, or None if the
-      parent address-cells is equal 0.
+      A physical address within the parent bus address space, or None if the
+      parent's #address-cells equals 0.
 
     length_cells:
-      Is the number of cells (4-bytes wide words) describing the size of range in
-      the child address space.
+      The number of cells used to describe the size of range in
+      the child's address space.
 
     length:
-      Specifies the size of the range in the child address space, or None if the
-      child size-cells is equal 0.
+      The size of the range in the child address space, or None if the
+      child's #size-cells equals 0.
     """
     def __repr__(self):
         fields = []

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -698,6 +698,39 @@ class Property:
         return "<Property, {}>".format(", ".join(fields))
 
 
+class Register:
+    """
+    Represents a register on a node.
+
+    These attributes are available on Register objects:
+
+    node:
+      The Node instance this register is from
+
+    name:
+      The name of the register as given in the 'reg-names' property, or None if
+      there is no 'reg-names' property
+
+    addr:
+      The starting address of the register, in the parent address space, or None
+      if #address-cells is zero. Any 'ranges' properties are taken into account.
+
+    size:
+      The length of the register in bytes
+    """
+    def __repr__(self):
+        fields = []
+
+        if self.name is not None:
+            fields.append("name: " + self.name)
+        if self.addr is not None:
+            fields.append("addr: " + hex(self.addr))
+        if self.size is not None:
+            fields.append("size: " + hex(self.size))
+
+        return "<Register, {}>".format(", ".join(fields))
+
+
 class EDT:
     """
     Represents a devicetree augmented with information from bindings.
@@ -2135,38 +2168,6 @@ class Range:
             fields.append("length " + hex(self.length))
 
         return "<Range, {}>".format(", ".join(fields))
-
-class Register:
-    """
-    Represents a register on a node.
-
-    These attributes are available on Register objects:
-
-    node:
-      The Node instance this register is from
-
-    name:
-      The name of the register as given in the 'reg-names' property, or None if
-      there is no 'reg-names' property
-
-    addr:
-      The starting address of the register, in the parent address space, or None
-      if #address-cells is zero. Any 'ranges' properties are taken into account.
-
-    size:
-      The length of the register in bytes
-    """
-    def __repr__(self):
-        fields = []
-
-        if self.name is not None:
-            fields.append("name: " + self.name)
-        if self.addr is not None:
-            fields.append("addr: " + hex(self.addr))
-        if self.size is not None:
-            fields.append("size: " + hex(self.size))
-
-        return "<Register, {}>".format(", ".join(fields))
 
 
 class ControllerAndData:

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -731,6 +731,56 @@ class Register:
         return "<Register, {}>".format(", ".join(fields))
 
 
+class Range:
+    """
+    Represents a translation range on a node as described by the 'ranges' property.
+
+    These attributes are available on Range objects:
+
+    node:
+      The Node instance this range is from
+
+    child_bus_cells:
+      Is the number of cells (4-bytes wide words) describing the child bus address.
+
+    child_bus_addr:
+      Is a physical address within the child bus address space, or None if the
+      child address-cells is equal 0.
+
+    parent_bus_cells:
+      Is the number of cells (4-bytes wide words) describing the parent bus address.
+
+    parent_bus_addr:
+      Is a physical address within the parent bus address space, or None if the
+      parent address-cells is equal 0.
+
+    length_cells:
+      Is the number of cells (4-bytes wide words) describing the size of range in
+      the child address space.
+
+    length:
+      Specifies the size of the range in the child address space, or None if the
+      child size-cells is equal 0.
+    """
+    def __repr__(self):
+        fields = []
+
+        if self.child_bus_cells is not None:
+            fields.append("child-bus-cells: " + hex(self.child_bus_cells))
+        if self.child_bus_addr is not None:
+            fields.append("child-bus-addr: " + hex(self.child_bus_addr))
+        if self.parent_bus_cells is not None:
+            fields.append("parent-bus-cells: " + hex(self.parent_bus_cells))
+        if self.parent_bus_addr is not None:
+            fields.append("parent-bus-addr: " + hex(self.parent_bus_addr))
+        if self.length_cells is not None:
+            fields.append("length-cells " + hex(self.length_cells))
+        if self.length is not None:
+            fields.append("length " + hex(self.length))
+
+        return "<Range, {}>".format(", ".join(fields))
+
+
 class EDT:
     """
     Represents a devicetree augmented with information from bindings.
@@ -2118,56 +2168,6 @@ class Node:
                  f"instead of {len(data_list)}")
 
         return dict(zip(cell_names, data_list))
-
-
-class Range:
-    """
-    Represents a translation range on a node as described by the 'ranges' property.
-
-    These attributes are available on Range objects:
-
-    node:
-      The Node instance this range is from
-
-    child_bus_cells:
-      Is the number of cells (4-bytes wide words) describing the child bus address.
-
-    child_bus_addr:
-      Is a physical address within the child bus address space, or None if the
-      child address-cells is equal 0.
-
-    parent_bus_cells:
-      Is the number of cells (4-bytes wide words) describing the parent bus address.
-
-    parent_bus_addr:
-      Is a physical address within the parent bus address space, or None if the
-      parent address-cells is equal 0.
-
-    length_cells:
-      Is the number of cells (4-bytes wide words) describing the size of range in
-      the child address space.
-
-    length:
-      Specifies the size of the range in the child address space, or None if the
-      child size-cells is equal 0.
-    """
-    def __repr__(self):
-        fields = []
-
-        if self.child_bus_cells is not None:
-            fields.append("child-bus-cells: " + hex(self.child_bus_cells))
-        if self.child_bus_addr is not None:
-            fields.append("child-bus-addr: " + hex(self.child_bus_addr))
-        if self.parent_bus_cells is not None:
-            fields.append("parent-bus-cells: " + hex(self.parent_bus_cells))
-        if self.parent_bus_addr is not None:
-            fields.append("parent-bus-addr: " + hex(self.parent_bus_addr))
-        if self.length_cells is not None:
-            fields.append("length-cells " + hex(self.length_cells))
-        if self.length is not None:
-            fields.append("length " + hex(self.length))
-
-        return "<Range, {}>".format(", ".join(fields))
 
 
 class ControllerAndData:

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -824,6 +824,46 @@ class ControllerAndData:
         return "<ControllerAndData, {}>".format(", ".join(fields))
 
 
+class PinCtrl:
+    """
+    Represents a pin control configuration for a set of pins on a device,
+    e.g. pinctrl-0 or pinctrl-1.
+
+    These attributes are available on PinCtrl objects:
+
+    node:
+      The Node instance the pinctrl-* property is on
+
+    name:
+      The name of the configuration, as given in pinctrl-names, or None if
+      there is no pinctrl-names property
+
+    name_as_token:
+      Like 'name', but with non-alphanumeric characters converted to underscores.
+
+    conf_nodes:
+      A list of Node instances for the pin configuration nodes, e.g.
+      the nodes pointed at by &state_1 and &state_2 in
+
+          pinctrl-0 = <&state_1 &state_2>;
+    """
+
+    @property
+    def name_as_token(self):
+        "See the class docstring"
+        return str_as_token(self.name) if self.name is not None else None
+
+    def __repr__(self):
+        fields = []
+
+        if self.name is not None:
+            fields.append("name: " + self.name)
+
+        fields.append("configuration nodes: " + str(self.conf_nodes))
+
+        return "<PinCtrl, {}>".format(", ".join(fields))
+
+
 class EDT:
     """
     Represents a devicetree augmented with information from bindings.
@@ -2211,46 +2251,6 @@ class Node:
                  f"instead of {len(data_list)}")
 
         return dict(zip(cell_names, data_list))
-
-
-class PinCtrl:
-    """
-    Represents a pin control configuration for a set of pins on a device,
-    e.g. pinctrl-0 or pinctrl-1.
-
-    These attributes are available on PinCtrl objects:
-
-    node:
-      The Node instance the pinctrl-* property is on
-
-    name:
-      The name of the configuration, as given in pinctrl-names, or None if
-      there is no pinctrl-names property
-
-    name_as_token:
-      Like 'name', but with non-alphanumeric characters converted to underscores.
-
-    conf_nodes:
-      A list of Node instances for the pin configuration nodes, e.g.
-      the nodes pointed at by &state_1 and &state_2 in
-
-          pinctrl-0 = <&state_1 &state_2>;
-    """
-
-    @property
-    def name_as_token(self):
-        "See the class docstring"
-        return str_as_token(self.name) if self.name is not None else None
-
-    def __repr__(self):
-        fields = []
-
-        if self.name is not None:
-            fields.append("name: " + self.name)
-
-        fields.append("configuration nodes: " + str(self.conf_nodes))
-
-        return "<PinCtrl, {}>".format(", ".join(fields))
 
 
 def bindings_from_paths(yaml_paths, ignore_errors=False):

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -190,6 +190,8 @@ class Binding:
         self._fname2path = fname2path
 
         if raw is None:
+            if path is None:
+                _err("you must provide either a 'path' or a 'raw' argument")
             with open(path, encoding="utf-8") as f:
                 raw = yaml.load(f, Loader=_BindingLoader)
 
@@ -340,6 +342,8 @@ class Binding:
 
         with open(path, encoding="utf-8") as f:
             contents = yaml.load(f, Loader=_BindingLoader)
+            if not isinstance(contents, dict):
+                _err(f'{path}: invalid contents, expected a mapping')
 
         return self._merge_includes(contents, path)
 

--- a/scripts/dts/python-devicetree/tests/test-multidir.dts
+++ b/scripts/dts/python-devicetree/tests/test-multidir.dts
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-// Used by testedtlib.py. Dedicated file for testing having multiple binding
-// directories.
+/*
+ * Used by test_edtlib.py. Dedicated file for testing having multiple binding
+ * directories.
+ */
 
 /dts-v1/;
 

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -237,6 +237,7 @@
 
 		node {
 			reg = <1 2>;
+			reg-names = "foo", "bar";
 		};
 	};
 	reg-zero-size-cells {

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -121,17 +121,34 @@ def test_reg():
     with from_here():
         edt = edtlib.EDT("test.dts", ["test-bindings"])
 
-    assert str(edt.get_node("/reg-zero-address-cells/node").regs) == \
-        "[<Register, size: 0x1>, <Register, size: 0x2>]"
+    def verify_regs(node, expected_tuples):
+        regs = node.regs
+        assert len(regs) == len(expected_tuples)
+        for reg, expected_tuple in zip(regs, expected_tuples):
+            name, addr, size = expected_tuple
+            assert reg.node is node
+            assert reg.name == name
+            assert reg.addr == addr
+            assert reg.size == size
 
-    assert str(edt.get_node("/reg-zero-size-cells/node").regs) == \
-        "[<Register, addr: 0x1>, <Register, addr: 0x2>]"
+    verify_regs(edt.get_node("/reg-zero-address-cells/node"),
+                [('foo', None, 0x1),
+                 ('bar', None, 0x2)])
 
-    assert str(edt.get_node("/reg-ranges/parent/node").regs) == \
-        "[<Register, addr: 0x5, size: 0x1>, <Register, addr: 0xe0000000f, size: 0x1>, <Register, addr: 0xc0000000e, size: 0x1>, <Register, addr: 0xc0000000d, size: 0x1>, <Register, addr: 0xa0000000b, size: 0x1>, <Register, addr: 0x0, size: 0x1>]"
+    verify_regs(edt.get_node("/reg-zero-size-cells/node"),
+                [(None, 0x1, None),
+                 (None, 0x2, None)])
 
-    assert str(edt.get_node("/reg-nested-ranges/grandparent/parent/node").regs) == \
-        "[<Register, addr: 0x30000000200000001, size: 0x1>]"
+    verify_regs(edt.get_node("/reg-ranges/parent/node"),
+                [(None, 0x5, 0x1),
+                 (None, 0xe0000000f, 0x1),
+                 (None, 0xc0000000e, 0x1),
+                 (None, 0xc0000000d, 0x1),
+                 (None, 0xa0000000b, 0x1),
+                 (None, 0x0, 0x1)])
+
+    verify_regs(edt.get_node("/reg-nested-ranges/grandparent/parent/node"),
+                [(None, 0x30000000200000001, 0x1)])
 
 def test_pinctrl():
     '''Test 'pinctrl-<index>'.'''

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -84,37 +84,73 @@ def test_ranges():
     with from_here():
         edt = edtlib.EDT("test.dts", ["test-bindings"])
 
-    assert str(edt.get_node("/reg-ranges/parent").ranges) == \
-        "[<Range, child-bus-cells: 0x1, child-bus-addr: 0x1, parent-bus-cells: 0x2, parent-bus-addr: 0xa0000000b, length-cells 0x1, length 0x1>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x2, parent-bus-cells: 0x2, parent-bus-addr: 0xc0000000d, length-cells 0x1, length 0x2>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x4, parent-bus-cells: 0x2, parent-bus-addr: 0xe0000000f, length-cells 0x1, length 0x1>]"
+    node = edt.get_node("/reg-ranges/parent")
+    assert node.ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x1, parent_bus_cells=0x2, parent_bus_addr=0xa0000000b, length_cells=0x1, length=0x1),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x2, parent_bus_cells=0x2, parent_bus_addr=0xc0000000d, length_cells=0x1, length=0x2),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x4, parent_bus_cells=0x2, parent_bus_addr=0xe0000000f, length_cells=0x1, length=0x1)
+    ]
 
-    assert str(edt.get_node("/reg-nested-ranges/grandparent").ranges) == \
-        "[<Range, child-bus-cells: 0x2, child-bus-addr: 0x0, parent-bus-cells: 0x3, parent-bus-addr: 0x30000000000000000, length-cells 0x2, length 0x200000002>]"
+    node = edt.get_node("/reg-nested-ranges/grandparent")
+    assert node.ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0x0, parent_bus_cells=0x3, parent_bus_addr=0x30000000000000000, length_cells=0x2, length=0x200000002)
+    ]
 
-    assert str(edt.get_node("/reg-nested-ranges/grandparent/parent").ranges) == \
-        "[<Range, child-bus-cells: 0x1, child-bus-addr: 0x0, parent-bus-cells: 0x2, parent-bus-addr: 0x200000000, length-cells 0x1, length 0x2>]"
+    node = edt.get_node("/reg-nested-ranges/grandparent/parent")
+    assert node.ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x0, parent_bus_cells=0x2, parent_bus_addr=0x200000000, length_cells=0x1, length=0x2)
+    ]
 
-    assert str(edt.get_node("/ranges-zero-cells/node").ranges) == "[]"
+    assert edt.get_node("/ranges-zero-cells/node").ranges == []
 
-    assert str(edt.get_node("/ranges-zero-parent-cells/node").ranges) == \
-        "[<Range, child-bus-cells: 0x1, child-bus-addr: 0xa, parent-bus-cells: 0x0, length-cells 0x0>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x1a, parent-bus-cells: 0x0, length-cells 0x0>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x2a, parent-bus-cells: 0x0, length-cells 0x0>]"
+    node = edt.get_node("/ranges-zero-parent-cells/node")
+    assert node.ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0xa, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x0, length=None),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x1a, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x0, length=None),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x2a, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x0, length=None)
+    ]
 
-    assert str(edt.get_node("/ranges-one-address-cells/node").ranges) == \
-        "[<Range, child-bus-cells: 0x1, child-bus-addr: 0xa, parent-bus-cells: 0x0, length-cells 0x1, length 0xb>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x1a, parent-bus-cells: 0x0, length-cells 0x1, length 0x1b>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x2a, parent-bus-cells: 0x0, length-cells 0x1, length 0x2b>]"
+    node = edt.get_node("/ranges-one-address-cells/node")
+    assert node.ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0xa, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x1, length=0xb),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x1a, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x1, length=0x1b),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x2a, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x1, length=0x2b)
+    ]
 
-    assert str(edt.get_node("/ranges-one-address-two-size-cells/node").ranges) == \
-        "[<Range, child-bus-cells: 0x1, child-bus-addr: 0xa, parent-bus-cells: 0x0, length-cells 0x2, length 0xb0000000c>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x1a, parent-bus-cells: 0x0, length-cells 0x2, length 0x1b0000001c>, <Range, child-bus-cells: 0x1, child-bus-addr: 0x2a, parent-bus-cells: 0x0, length-cells 0x2, length 0x2b0000002c>]"
+    node = edt.get_node("/ranges-one-address-two-size-cells/node")
+    assert node.ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0xa, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x2, length=0xb0000000c),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x1a, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x2, length=0x1b0000001c),
+        edtlib.Range(node=node, child_bus_cells=0x1, child_bus_addr=0x2a, parent_bus_cells=0x0, parent_bus_addr=None, length_cells=0x2, length=0x2b0000002c)
+    ]
 
-    assert str(edt.get_node("/ranges-two-address-cells/node@1").ranges) == \
-        "[<Range, child-bus-cells: 0x2, child-bus-addr: 0xa0000000b, parent-bus-cells: 0x1, parent-bus-addr: 0xc, length-cells 0x1, length 0xd>, <Range, child-bus-cells: 0x2, child-bus-addr: 0x1a0000001b, parent-bus-cells: 0x1, parent-bus-addr: 0x1c, length-cells 0x1, length 0x1d>, <Range, child-bus-cells: 0x2, child-bus-addr: 0x2a0000002b, parent-bus-cells: 0x1, parent-bus-addr: 0x2c, length-cells 0x1, length 0x2d>]"
+    node = edt.get_node("/ranges-two-address-cells/node@1")
+    assert node.ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0xa0000000b, parent_bus_cells=0x1, parent_bus_addr=0xc, length_cells=0x1, length=0xd),
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0x1a0000001b, parent_bus_cells=0x1, parent_bus_addr=0x1c, length_cells=0x1, length=0x1d),
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0x2a0000002b, parent_bus_cells=0x1, parent_bus_addr=0x2c, length_cells=0x1, length=0x2d)
+    ]
 
-    assert str(edt.get_node("/ranges-two-address-two-size-cells/node@1").ranges) == \
-        "[<Range, child-bus-cells: 0x2, child-bus-addr: 0xa0000000b, parent-bus-cells: 0x1, parent-bus-addr: 0xc, length-cells 0x2, length 0xd0000000e>, <Range, child-bus-cells: 0x2, child-bus-addr: 0x1a0000001b, parent-bus-cells: 0x1, parent-bus-addr: 0x1c, length-cells 0x2, length 0x1d0000001e>, <Range, child-bus-cells: 0x2, child-bus-addr: 0x2a0000002b, parent-bus-cells: 0x1, parent-bus-addr: 0x2c, length-cells 0x2, length 0x2d0000001d>]"
+    node = edt.get_node("/ranges-two-address-two-size-cells/node@1")
+    assert node.ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0xa0000000b, parent_bus_cells=0x1, parent_bus_addr=0xc, length_cells=0x2, length=0xd0000000e),
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0x1a0000001b, parent_bus_cells=0x1, parent_bus_addr=0x1c, length_cells=0x2, length=0x1d0000001e),
+        edtlib.Range(node=node, child_bus_cells=0x2, child_bus_addr=0x2a0000002b, parent_bus_cells=0x1, parent_bus_addr=0x2c, length_cells=0x2, length=0x2d0000001d)
+    ]
 
-    assert str(edt.get_node("/ranges-three-address-cells/node@1").ranges) == \
-        "[<Range, child-bus-cells: 0x3, child-bus-addr: 0xa0000000b0000000c, parent-bus-cells: 0x2, parent-bus-addr: 0xd0000000e, length-cells 0x1, length 0xf>, <Range, child-bus-cells: 0x3, child-bus-addr: 0x1a0000001b0000001c, parent-bus-cells: 0x2, parent-bus-addr: 0x1d0000001e, length-cells 0x1, length 0x1f>, <Range, child-bus-cells: 0x3, child-bus-addr: 0x2a0000002b0000002c, parent-bus-cells: 0x2, parent-bus-addr: 0x2d0000002e, length-cells 0x1, length 0x2f>]"
+    node = edt.get_node("/ranges-three-address-cells/node@1")
+    assert node.ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0xa0000000b0000000c, parent_bus_cells=0x2, parent_bus_addr=0xd0000000e, length_cells=0x1, length=0xf),
+        edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0x1a0000001b0000001c, parent_bus_cells=0x2, parent_bus_addr=0x1d0000001e, length_cells=0x1, length=0x1f),
+        edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0x2a0000002b0000002c, parent_bus_cells=0x2, parent_bus_addr=0x2d0000002e, length_cells=0x1, length=0x2f)
+    ]
 
-    assert str(edt.get_node("/ranges-three-address-two-size-cells/node@1").ranges) == \
-        "[<Range, child-bus-cells: 0x3, child-bus-addr: 0xa0000000b0000000c, parent-bus-cells: 0x2, parent-bus-addr: 0xd0000000e, length-cells 0x2, length 0xf00000010>, <Range, child-bus-cells: 0x3, child-bus-addr: 0x1a0000001b0000001c, parent-bus-cells: 0x2, parent-bus-addr: 0x1d0000001e, length-cells 0x2, length 0x1f00000110>, <Range, child-bus-cells: 0x3, child-bus-addr: 0x2a0000002b0000002c, parent-bus-cells: 0x2, parent-bus-addr: 0x2d0000002e, length-cells 0x2, length 0x2f00000210>]"
+    node = edt.get_node("/ranges-three-address-two-size-cells/node@1")
+    assert node.ranges == [
+        edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0xa0000000b0000000c, parent_bus_cells=0x2, parent_bus_addr=0xd0000000e, length_cells=0x2, length=0xf00000010),
+        edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0x1a0000001b0000001c, parent_bus_cells=0x2, parent_bus_addr=0x1d0000001e, length_cells=0x2, length=0x1f00000110),
+        edtlib.Range(node=node, child_bus_cells=0x3, child_bus_addr=0x2a0000002b0000002c, parent_bus_cells=0x2, parent_bus_addr=0x2d0000002e, length_cells=0x2, length=0x2f00000210)
+    ]
 
 def test_reg():
     '''Tests for the regs property'''

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -61,23 +61,46 @@ def test_interrupts():
     '''Tests for the interrupts property.'''
     with from_here():
         edt = edtlib.EDT("test.dts", ["test-bindings"])
-    filenames = {i: hpath(f'test-bindings/interrupt-{i}-cell.yaml')
-                 for i in range(1, 4)}
 
-    assert str(edt.get_node("/interrupt-parent-test/node").interrupts) == \
-        f"[<ControllerAndData, name: foo, controller: <Node /interrupt-parent-test/controller in 'test.dts', binding {filenames[3]}>, data: {{'one': 1, 'two': 2, 'three': 3}}>, <ControllerAndData, name: bar, controller: <Node /interrupt-parent-test/controller in 'test.dts', binding {filenames[3]}>, data: {{'one': 4, 'two': 5, 'three': 6}}>]"
+    node = edt.get_node("/interrupt-parent-test/node")
+    controller = edt.get_node('/interrupt-parent-test/controller')
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=controller, data={'one': 1, 'two': 2, 'three': 3}, name='foo', basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller, data={'one': 4, 'two': 5, 'three': 6}, name='bar', basename=None)
+    ]
 
-    assert str(edt.get_node("/interrupts-extended-test/node").interrupts) == \
-        f"[<ControllerAndData, controller: <Node /interrupts-extended-test/controller-0 in 'test.dts', binding {filenames[1]}>, data: {{'one': 1}}>, <ControllerAndData, controller: <Node /interrupts-extended-test/controller-1 in 'test.dts', binding {filenames[2]}>, data: {{'one': 2, 'two': 3}}>, <ControllerAndData, controller: <Node /interrupts-extended-test/controller-2 in 'test.dts', binding {filenames[3]}>, data: {{'one': 4, 'two': 5, 'three': 6}}>]"
+    node = edt.get_node("/interrupts-extended-test/node")
+    controller_0 = edt.get_node('/interrupts-extended-test/controller-0')
+    controller_1 = edt.get_node('/interrupts-extended-test/controller-1')
+    controller_2 = edt.get_node('/interrupts-extended-test/controller-2')
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=controller_0, data={'one': 1}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_1, data={'one': 2, 'two': 3}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 4, 'two': 5, 'three': 6}, name=None, basename=None)
+    ]
 
-    assert str(edt.get_node("/interrupt-map-test/node@0").interrupts) == \
-        f"[<ControllerAndData, controller: <Node /interrupt-map-test/controller-0 in 'test.dts', binding {filenames[1]}>, data: {{'one': 0}}>, <ControllerAndData, controller: <Node /interrupt-map-test/controller-1 in 'test.dts', binding {filenames[2]}>, data: {{'one': 0, 'two': 1}}>, <ControllerAndData, controller: <Node /interrupt-map-test/controller-2 in 'test.dts', binding {filenames[3]}>, data: {{'one': 0, 'two': 0, 'three': 2}}>]"
+    node = edt.get_node("/interrupt-map-test/node@0")
+    controller_0 = edt.get_node('/interrupt-map-test/controller-0')
+    controller_1 = edt.get_node('/interrupt-map-test/controller-1')
+    controller_2 = edt.get_node('/interrupt-map-test/controller-2')
 
-    assert str(edt.get_node("/interrupt-map-test/node@1").interrupts) == \
-        f"[<ControllerAndData, controller: <Node /interrupt-map-test/controller-0 in 'test.dts', binding {filenames[1]}>, data: {{'one': 3}}>, <ControllerAndData, controller: <Node /interrupt-map-test/controller-1 in 'test.dts', binding {filenames[2]}>, data: {{'one': 0, 'two': 4}}>, <ControllerAndData, controller: <Node /interrupt-map-test/controller-2 in 'test.dts', binding {filenames[3]}>, data: {{'one': 0, 'two': 0, 'three': 5}}>]"
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=controller_0, data={'one': 0}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_1, data={'one': 0, 'two': 1}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 2}, name=None, basename=None)
+    ]
 
-    assert str(edt.get_node("/interrupt-map-bitops-test/node@70000000E").interrupts) == \
-        f"[<ControllerAndData, controller: <Node /interrupt-map-bitops-test/controller in 'test.dts', binding {filenames[2]}>, data: {{'one': 3, 'two': 2}}>]"
+    node = edt.get_node("/interrupt-map-test/node@1")
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=controller_0, data={'one': 3}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_1, data={'one': 0, 'two': 4}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 5}, name=None, basename=None)
+    ]
+
+    node = edt.get_node("/interrupt-map-bitops-test/node@70000000E")
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=edt.get_node('/interrupt-map-bitops-test/controller'), data={'one': 3, 'two': 2}, name=None, basename=None)
+    ]
 
 def test_ranges():
     '''Tests for the ranges property'''
@@ -432,8 +455,6 @@ def test_props():
     '''Test Node.props (derived from DT and 'properties:' in the binding)'''
     with from_here():
         edt = edtlib.EDT("test.dts", ["test-bindings"])
-    filenames = {i: hpath(f'test-bindings/phandle-array-controller-{i}.yaml')
-                 for i in range(0, 4)}
 
     props_node = edt.get_node('/props')
     ctrl_1, ctrl_2 = [edt.get_node(path) for path in ['/ctrl-1', '/ctrl-2']]

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -214,8 +214,14 @@ def test_pinctrl():
     with from_here():
         edt = edtlib.EDT("test.dts", ["test-bindings"])
 
-    assert str(edt.get_node("/pinctrl/dev").pinctrls) == \
-        "[<PinCtrl, name: zero, configuration nodes: []>, <PinCtrl, name: one, configuration nodes: [<Node /pinctrl/pincontroller/state-1 in 'test.dts', no binding>]>, <PinCtrl, name: two, configuration nodes: [<Node /pinctrl/pincontroller/state-1 in 'test.dts', no binding>, <Node /pinctrl/pincontroller/state-2 in 'test.dts', no binding>]>]"
+    node = edt.get_node("/pinctrl/dev")
+    state_1 = edt.get_node('/pinctrl/pincontroller/state-1')
+    state_2 = edt.get_node('/pinctrl/pincontroller/state-2')
+    assert node.pinctrls == [
+        edtlib.PinCtrl(node=node, name='zero', conf_nodes=[]),
+        edtlib.PinCtrl(node=node, name='one', conf_nodes=[state_1]),
+        edtlib.PinCtrl(node=node, name='two', conf_nodes=[state_1, state_2])
+    ]
 
 def test_hierarchy():
     '''Test Node.parent and Node.children'''


### PR DESCRIPTION
This is a standalone PR that will be needed to add system devicetree support.

After prototyping in https://github.com/zephyrproject-rtos/zephyr/pull/52272, it became clear that it makes sense to implement the sysdtlib.SysDT class we will use to implement system DT support as a subclass of edtlib.EDT. This is a change from making it a subclass of dtlib.DT as originally proposed.

Using edtlib instead means that we can have type-safe access to some properties in sysdtlib by writing bindings for system DT specific compatibles. It also helps when implementing requirements like accessing the proper number of cells in `reg` properties, which edtlib knows, but dtlib doesn't. (We need address/size cell counts in order to be able to decode the `address-map` properties in CPU cluster nodes.)

This PR does two things that we need to be able to safely do this subclassing:

1. Adds `EDT.__deepcopy__()` support, so that I can make a copy of the system devicetree, mutate it into a regular devicetree, and emit the mutated copy
2. Adds type annotations for all the public classes in edtlib, so that sysdtlib can be implemented in a type-safe way

There are a couple of cleanup commits at the beginning that I found along the way.