### PR TITLE
tests bsim net echo_test: Minor fixes

### DIFF
--- a/tests/bsim/net/sockets/echo_test/src/echo_test.c
+++ b/tests/bsim/net/sockets/echo_test/src/echo_test.c
@@ -7,6 +7,7 @@
 
 #include "bs_types.h"
 #include "bs_tracing.h"
+#include "bs_utils.h"
 #include "time_machine.h"
 #include "bstests.h"
 
@@ -75,8 +76,8 @@ static const struct bst_test_instance test_echo_client[] = {
 		.test_id = "echo_client",
 		.test_descr = "Test based on the echo client sample. "
 			      "It expects to be connected to a compatible echo server, "
-			      "waits for 20 seconds, and checks how many packets have been "
-			      "exchanged correctly",
+			      "waits for " STR(WAIT_TIME) " seconds, and checks how "
+			      "many packets have been exchanged correctly",
 		.test_post_init_f = test_echo_client_init,
 		.test_tick_f = test_echo_client_tick,
 	},

--- a/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_802154.sh
+++ b/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_802154.sh
@@ -25,6 +25,6 @@ Execute ./bs_${BOARD}_samples_net_sockets_echo_server_prj_conf_overlay-802154_co
   -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=1 \
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=2 -sim_length=60e6 -argschannel -at=40 $@
+  -D=2 -sim_length=21e6 -argschannel -at=40 -argsmain $@
 
 wait_for_background_jobs #Wait for all programs in background and return != 0 if any fails

--- a/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_ot.sh
+++ b/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_ot.sh
@@ -25,6 +25,6 @@ Execute ./bs_${BOARD}_samples_net_sockets_echo_server_prj_conf_overlay-ot_conf\
   -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=1 \
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=2 -sim_length=60e6 -argschannel -at=40 $@
+  -D=2 -sim_length=26e6 -argschannel -at=40 -argsmain $@
 
 wait_for_background_jobs #Wait for all programs in background and return != 0 if any fails


### PR DESCRIPTION
Two minor fixes:
* The wait time mention in the description was wrong.
* The possible argument passed to the scripts is meant to target the phy itself, but it was sent to the channel library.
And
* Shorten a bit the simulation length, as the tests have already passed or failed at 20 or 25 seconds.