### PR TITLE
net: if: Rework interface locking 

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -140,6 +140,14 @@ Changes in this release
   using picolibc, only applications using picolibc will be affected by this
   change at this time.
 
+* The following network interface APIs now take additional,
+  ``struct net_if * iface`` parameter:
+
+  * :c:func:`net_if_ipv4_maddr_join`
+  * :c:func:`net_if_ipv4_maddr_leave`
+  * :c:func:`net_if_ipv6_maddr_join`
+  * :c:func:`net_if_ipv6_maddr_leave`
+
 Removed APIs in this release
 ============================
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1259,9 +1259,11 @@ void net_if_mcast_monitor(struct net_if *iface, const struct net_addr *addr,
 /**
  * @brief Mark a given multicast address to be joined.
  *
+ * @param iface Network interface the address belongs to
  * @param addr IPv6 multicast address
  */
-void net_if_ipv6_maddr_join(struct net_if_mcast_addr *addr);
+void net_if_ipv6_maddr_join(struct net_if *iface,
+			    struct net_if_mcast_addr *addr);
 
 /**
  * @brief Check if given multicast address is joined or not.
@@ -1280,9 +1282,11 @@ static inline bool net_if_ipv6_maddr_is_joined(struct net_if_mcast_addr *addr)
 /**
  * @brief Mark a given multicast address to be left.
  *
+ * @param iface Network interface the address belongs to
  * @param addr IPv6 multicast address
  */
-void net_if_ipv6_maddr_leave(struct net_if_mcast_addr *addr);
+void net_if_ipv6_maddr_leave(struct net_if *iface,
+			     struct net_if_mcast_addr *addr);
 
 /**
  * @brief Return prefix that corresponds to this IPv6 address.
@@ -1813,9 +1817,11 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_lookup(const struct in_addr *addr,
 /**
  * @brief Mark a given multicast address to be joined.
  *
+ * @param iface Network interface the address belongs to
  * @param addr IPv4 multicast address
  */
-void net_if_ipv4_maddr_join(struct net_if_mcast_addr *addr);
+void net_if_ipv4_maddr_join(struct net_if *iface,
+			    struct net_if_mcast_addr *addr);
 
 /**
  * @brief Check if given multicast address is joined or not.
@@ -1834,9 +1840,11 @@ static inline bool net_if_ipv4_maddr_is_joined(struct net_if_mcast_addr *addr)
 /**
  * @brief Mark a given multicast address to be left.
  *
+ * @param iface Network interface the address belongs to
  * @param addr IPv4 multicast address
  */
-void net_if_ipv4_maddr_leave(struct net_if_mcast_addr *addr);
+void net_if_ipv4_maddr_leave(struct net_if *iface,
+			     struct net_if_mcast_addr *addr);
 
 /**
  * @brief Get the IPv4 address of the given router

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -526,7 +526,23 @@ struct net_if {
 	 */
 	int tx_pending;
 #endif
+
+	struct k_mutex lock;
 };
+
+static inline void net_if_lock(struct net_if *iface)
+{
+	NET_ASSERT(iface);
+
+	(void)k_mutex_lock(&iface->lock, K_FOREVER);
+}
+
+static inline void net_if_unlock(struct net_if *iface)
+{
+	NET_ASSERT(iface);
+
+	k_mutex_unlock(&iface->lock);
+}
 
 /**
  * @brief Set a value in network interface flags

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -317,8 +317,10 @@ static inline void net_pkt_set_iface(struct net_pkt *pkt, struct net_if *iface)
 	 * that the address type is properly set and is not forgotten.
 	 */
 	if (iface) {
-		pkt->lladdr_src.type = net_if_get_link_addr(iface)->type;
-		pkt->lladdr_dst.type = net_if_get_link_addr(iface)->type;
+		enum net_link_type type = net_if_get_link_addr(iface)->type;
+
+		pkt->lladdr_src.type = type;
+		pkt->lladdr_dst.type = type;
 	}
 }
 

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -304,7 +304,7 @@ int net_ipv4_igmp_join(struct net_if *iface, const struct in_addr *addr)
 		return ret;
 	}
 
-	net_if_ipv4_maddr_join(maddr);
+	net_if_ipv4_maddr_join(iface, maddr);
 
 	net_if_mcast_monitor(iface, &maddr->address, true);
 
@@ -333,7 +333,7 @@ int net_ipv4_igmp_leave(struct net_if *iface, const struct in_addr *addr)
 		return ret;
 	}
 
-	net_if_ipv4_maddr_leave(maddr);
+	net_if_ipv4_maddr_leave(iface, maddr);
 
 	net_if_mcast_monitor(iface, &maddr->address, false);
 
@@ -374,7 +374,7 @@ void net_ipv4_igmp_init(struct net_if *iface)
 		}
 	}
 
-	net_if_ipv4_maddr_join(maddr);
+	net_if_ipv4_maddr_join(iface, maddr);
 
 	net_if_mcast_monitor(iface, &maddr->address, true);
 }

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -203,7 +203,7 @@ int net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr)
 		return ret;
 	}
 
-	net_if_ipv6_maddr_join(maddr);
+	net_if_ipv6_maddr_join(iface, maddr);
 
 	net_if_mcast_monitor(iface, &maddr->address, true);
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -755,10 +755,13 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			ll_addr->sll_ifindex;
 		net_sll_ptr(&context->local)->sll_protocol =
 			ll_addr->sll_protocol;
+
+		net_if_lock(iface);
 		net_sll_ptr(&context->local)->sll_addr =
 			net_if_get_link_addr(iface)->addr;
 		net_sll_ptr(&context->local)->sll_halen =
 			net_if_get_link_addr(iface)->len;
+		net_if_unlock(iface);
 
 		NET_DBG("Context %p bind to type 0x%04x iface[%d] %p addr %s",
 			context, htons(net_context_get_proto(context)),

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -383,7 +383,9 @@ void net_if_stats_reset(struct net_if *iface)
 #if defined(CONFIG_NET_STATISTICS_PER_INTERFACE)
 	STRUCT_SECTION_FOREACH(net_if, tmp) {
 		if (iface == tmp) {
+			net_if_lock(iface);
 			memset(&iface->stats, 0, sizeof(iface->stats));
+			net_if_unlock(iface);
 			return;
 		}
 	}
@@ -395,13 +397,11 @@ void net_if_stats_reset(struct net_if *iface)
 void net_if_stats_reset_all(void)
 {
 #if defined(CONFIG_NET_STATISTICS_PER_INTERFACE)
-	k_mutex_lock(&lock, K_FOREVER);
-
 	STRUCT_SECTION_FOREACH(net_if, iface) {
+		net_if_lock(iface);
 		memset(&iface->stats, 0, sizeof(iface->stats));
+		net_if_unlock(iface);
 	}
-
-	k_mutex_unlock(&lock);
 #endif
 }
 
@@ -434,6 +434,8 @@ static inline void init_iface(struct net_if *iface)
 	z_object_init(iface);
 #endif
 
+	k_mutex_init(&iface->lock);
+
 	api->init(iface);
 }
 
@@ -444,7 +446,7 @@ enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)
 	enum net_verdict verdict = NET_OK;
 	int status = -EIO;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!net_if_flag_is_set(iface, NET_IF_LOWER_UP) ||
 	    net_if_flag_is_set(iface, NET_IF_SUSPENDED)) {
@@ -528,7 +530,7 @@ done:
 		net_if_queue_tx(iface, pkt);
 	}
 
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return verdict;
 }
@@ -539,11 +541,11 @@ int net_if_set_link_addr_locked(struct net_if *iface,
 {
 	int ret;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ret = net_if_set_link_addr_unlocked(iface, addr, len, type);
 
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -551,10 +553,13 @@ int net_if_set_link_addr_locked(struct net_if *iface,
 struct net_if *net_if_get_by_link_addr(struct net_linkaddr *ll_addr)
 {
 	STRUCT_SECTION_FOREACH(net_if, iface) {
+		net_if_lock(iface);
 		if (!memcmp(net_if_get_link_addr(iface)->addr, ll_addr->addr,
 			    ll_addr->len)) {
+			net_if_unlock(iface);
 			return iface;
 		}
+		net_if_unlock(iface);
 	}
 
 	return NULL;
@@ -1012,7 +1017,7 @@ int net_if_config_ipv6_get(struct net_if *iface, struct net_if_ipv6 **ipv6)
 	int ret = 0;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!net_if_flag_is_set(iface, NET_IF_IPV6)) {
 		ret = -ENOTSUP;
@@ -1027,6 +1032,8 @@ int net_if_config_ipv6_get(struct net_if *iface, struct net_if_ipv6 **ipv6)
 		goto out;
 	}
 
+	k_mutex_lock(&lock, K_FOREVER);
+
 	for (i = 0; i < ARRAY_SIZE(ipv6_addresses); i++) {
 		if (ipv6_addresses[i].iface) {
 			continue;
@@ -1039,12 +1046,15 @@ int net_if_config_ipv6_get(struct net_if *iface, struct net_if_ipv6 **ipv6)
 			*ipv6 = &ipv6_addresses[i].ipv6;
 		}
 
+		k_mutex_unlock(&lock);
 		goto out;
 	}
 
+	k_mutex_unlock(&lock);
+
 	ret = -ESRCH;
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -1054,7 +1064,7 @@ int net_if_config_ipv6_put(struct net_if *iface)
 	int ret = 0;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!net_if_flag_is_set(iface, NET_IF_IPV6)) {
 		ret = -ENOTSUP;
@@ -1066,6 +1076,8 @@ int net_if_config_ipv6_put(struct net_if *iface)
 		goto out;
 	}
 
+	k_mutex_lock(&lock, K_FOREVER);
+
 	for (i = 0; i < ARRAY_SIZE(ipv6_addresses); i++) {
 		if (ipv6_addresses[i].iface != iface) {
 			continue;
@@ -1074,12 +1086,15 @@ int net_if_config_ipv6_put(struct net_if *iface)
 		iface->config.ip.ipv6 = NULL;
 		ipv6_addresses[i].iface = NULL;
 
+		k_mutex_unlock(&lock);
 		goto out;
 	}
 
+	k_mutex_unlock(&lock);
+
 	ret = -ESRCH;
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -1162,16 +1177,16 @@ static void dad_timeout(struct k_work *work)
 	uint32_t current_time = k_uptime_get_32();
 	struct net_if_addr *ifaddr, *next;
 	int32_t delay = -1;
+	sys_slist_t expired_list;
 
 	ARG_UNUSED(work);
+
+	sys_slist_init(&expired_list);
 
 	k_mutex_lock(&lock, K_FOREVER);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&active_dad_timers,
 					  ifaddr, next, dad_node) {
-		struct net_if_addr *tmp;
-		struct net_if *iface;
-
 		/* DAD entries are ordered by construction.  Stop when
 		 * we find one that hasn't expired.
 		 */
@@ -1183,6 +1198,20 @@ static void dad_timeout(struct k_work *work)
 
 		/* Removing the ifaddr from active_dad_timers list */
 		sys_slist_remove(&active_dad_timers, NULL, &ifaddr->dad_node);
+		sys_slist_append(&expired_list, &ifaddr->dad_node);
+
+		ifaddr = NULL;
+	}
+
+	if ((ifaddr != NULL) && (delay > 0)) {
+		k_work_reschedule(&dad_timer, K_MSEC((uint32_t)delay));
+	}
+
+	k_mutex_unlock(&lock);
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&expired_list, ifaddr, dad_node) {
+		struct net_if_addr *tmp;
+		struct net_if *iface;
 
 		NET_DBG("DAD succeeded for %s",
 			net_sprint_ipv6_addr(&ifaddr->address.in6_addr));
@@ -1206,15 +1235,7 @@ static void dad_timeout(struct k_work *work)
 			 */
 			net_ipv6_nbr_rm(iface, &ifaddr->address.in6_addr);
 		}
-
-		ifaddr = NULL;
 	}
-
-	if ((ifaddr != NULL) && (delay > 0)) {
-		k_work_reschedule(&dad_timer, K_MSEC((uint32_t)delay));
-	}
-
-	k_mutex_unlock(&lock);
 }
 
 static void net_if_ipv6_start_dad(struct net_if *iface,
@@ -1234,7 +1255,10 @@ static void net_if_ipv6_start_dad(struct net_if *iface,
 
 		if (!net_ipv6_start_dad(iface, ifaddr)) {
 			ifaddr->dad_start = k_uptime_get_32();
+
+			k_mutex_lock(&lock, K_FOREVER);
 			sys_slist_append(&active_dad_timers, &ifaddr->dad_node);
+			k_mutex_unlock(&lock);
 
 			/* FUTURE: use schedule, not reschedule. */
 			if (!k_work_delayable_remaining_get(&dad_timer)) {
@@ -1256,7 +1280,7 @@ void net_if_start_dad(struct net_if *iface)
 	struct in6_addr addr = { };
 	int ret, i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	NET_DBG("Starting DAD for iface %p", iface);
 
@@ -1297,14 +1321,14 @@ void net_if_start_dad(struct net_if *iface)
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 }
 
 void net_if_ipv6_dad_failed(struct net_if *iface, const struct in6_addr *addr)
 {
 	struct net_if_addr *ifaddr;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ifaddr = net_if_ipv6_addr_lookup(addr, &iface);
 	if (!ifaddr) {
@@ -1313,7 +1337,10 @@ void net_if_ipv6_dad_failed(struct net_if *iface, const struct in6_addr *addr)
 		goto out;
 	}
 
+
+	k_mutex_lock(&lock, K_FOREVER);
 	sys_slist_find_and_remove(&active_dad_timers, &ifaddr->dad_node);
+	k_mutex_unlock(&lock);
 
 	net_mgmt_event_notify_with_info(NET_EVENT_IPV6_DAD_FAILED, iface,
 					&ifaddr->address.in6_addr,
@@ -1322,7 +1349,7 @@ void net_if_ipv6_dad_failed(struct net_if *iface, const struct in6_addr *addr)
 	net_if_ipv6_addr_rm(iface, addr);
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 }
 
 static inline void iface_ipv6_dad_init(void)
@@ -1350,15 +1377,16 @@ static void rs_timeout(struct k_work *work)
 	uint32_t current_time = k_uptime_get_32();
 	struct net_if_ipv6 *ipv6, *next;
 	int32_t delay = -1;
+	sys_slist_t expired_list;
 
 	ARG_UNUSED(work);
+
+	sys_slist_init(&expired_list);
 
 	k_mutex_lock(&lock, K_FOREVER);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&active_rs_timers,
 					  ipv6, next, rs_node) {
-		struct net_if *iface = NULL;
-
 		/* RS entries are ordered by construction.  Stop when
 		 * we find one that hasn't expired.
 		 */
@@ -1369,6 +1397,20 @@ static void rs_timeout(struct k_work *work)
 
 		/* Removing the ipv6 from active_rs_timers list */
 		sys_slist_remove(&active_rs_timers, NULL, &ipv6->rs_node);
+		sys_slist_append(&expired_list, &ipv6->rs_node);
+
+		ipv6 = NULL;
+	}
+
+	if ((ipv6 != NULL) && (delay > 0)) {
+		k_work_reschedule(&rs_timer, K_MSEC(ipv6->rs_start +
+						    RS_TIMEOUT - current_time));
+	}
+
+	k_mutex_unlock(&lock);
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&expired_list, ipv6, rs_node) {
+		struct net_if *iface = NULL;
 
 		/* Did not receive RA yet. */
 		ipv6->rs_count++;
@@ -1389,23 +1431,14 @@ static void rs_timeout(struct k_work *work)
 		} else {
 			NET_DBG("Interface IPv6 config %p not found", ipv6);
 		}
-
-		ipv6 = NULL;
 	}
-
-	if ((ipv6 != NULL) && (delay > 0)) {
-		k_work_reschedule(&rs_timer, K_MSEC(ipv6->rs_start +
-						    RS_TIMEOUT - current_time));
-	}
-
-	k_mutex_unlock(&lock);
 }
 
 void net_if_start_rs(struct net_if *iface)
 {
 	struct net_if_ipv6 *ipv6;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ipv6 = iface->config.ip.ipv6;
 	if (!ipv6) {
@@ -1416,7 +1449,10 @@ void net_if_start_rs(struct net_if *iface)
 
 	if (!net_ipv6_start_rs(iface)) {
 		ipv6->rs_start = k_uptime_get_32();
+
+		k_mutex_lock(&lock, K_FOREVER);
 		sys_slist_append(&active_rs_timers, &ipv6->rs_node);
+		k_mutex_unlock(&lock);
 
 		/* FUTURE: use schedule, not reschedule. */
 		if (!k_work_delayable_remaining_get(&rs_timer)) {
@@ -1425,14 +1461,14 @@ void net_if_start_rs(struct net_if *iface)
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 }
 
 void net_if_stop_rs(struct net_if *iface)
 {
 	struct net_if_ipv6 *ipv6;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ipv6 = iface->config.ip.ipv6;
 	if (!ipv6) {
@@ -1441,10 +1477,12 @@ void net_if_stop_rs(struct net_if *iface)
 
 	NET_DBG("Stopping ND/RS for iface %p", iface);
 
+	k_mutex_lock(&lock, K_FOREVER);
 	sys_slist_find_and_remove(&active_rs_timers, &ipv6->rs_node);
+	k_mutex_unlock(&lock);
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 }
 
 static inline void iface_ipv6_nd_init(void)
@@ -1464,13 +1502,15 @@ struct net_if_addr *net_if_ipv6_addr_lookup(const struct in6_addr *addr,
 {
 	struct net_if_addr *ifaddr = NULL;
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	STRUCT_SECTION_FOREACH(net_if, iface) {
-		struct net_if_ipv6 *ipv6 = iface->config.ip.ipv6;
+		struct net_if_ipv6 *ipv6;
 		int i;
 
+		net_if_lock(iface);
+
+		ipv6 = iface->config.ip.ipv6;
 		if (!ipv6) {
+			net_if_unlock(iface);
 			continue;
 		}
 
@@ -1490,14 +1530,15 @@ struct net_if_addr *net_if_ipv6_addr_lookup(const struct in6_addr *addr,
 				}
 
 				ifaddr = &ipv6->unicast[i];
+				net_if_unlock(iface);
 				goto out;
 			}
 		}
+
+		net_if_unlock(iface);
 	}
 
 out:
-	k_mutex_unlock(&lock);
-
 	return ifaddr;
 }
 
@@ -1508,7 +1549,7 @@ struct net_if_addr *net_if_ipv6_addr_lookup_by_iface(struct net_if *iface,
 	struct net_if_ipv6 *ipv6;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ipv6 = iface->config.ip.ipv6;
 	if (!ipv6) {
@@ -1531,7 +1572,7 @@ struct net_if_addr *net_if_ipv6_addr_lookup_by_iface(struct net_if *iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ifaddr;
 }
@@ -1701,7 +1742,7 @@ struct net_if_addr *net_if_ipv6_addr_add(struct net_if *iface,
 	struct net_if_ipv6 *ipv6;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (net_if_config_ipv6_get(iface, &ipv6) < 0) {
 		goto out;
@@ -1757,7 +1798,7 @@ struct net_if_addr *net_if_ipv6_addr_add(struct net_if *iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ifaddr;
 }
@@ -1770,7 +1811,7 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 
 	NET_ASSERT(addr);
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ipv6 = iface->config.ip.ipv6;
 	if (!ipv6) {
@@ -1790,6 +1831,8 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 		}
 
 		if (!ipv6->unicast[i].is_infinite) {
+			k_mutex_lock(&lock, K_FOREVER);
+
 			sys_slist_find_and_remove(
 				&active_address_lifetime_timers,
 				&ipv6->unicast[i].lifetime.node);
@@ -1799,6 +1842,8 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 				k_work_cancel_delayable(
 					&address_lifetime_timer);
 			}
+
+			k_mutex_unlock(&lock);
 		}
 
 		ipv6->unicast[i].is_used = false;
@@ -1826,7 +1871,7 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -1912,7 +1957,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 	struct net_if_ipv6 *ipv6;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (net_if_config_ipv6_get(iface, &ipv6) < 0) {
 		goto out;
@@ -1952,7 +1997,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ifmaddr;
 }
@@ -1963,7 +2008,7 @@ bool net_if_ipv6_maddr_rm(struct net_if *iface, const struct in6_addr *addr)
 	struct net_if_ipv6 *ipv6;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ipv6 = iface->config.ip.ipv6;
 	if (!ipv6) {
@@ -1995,7 +2040,7 @@ bool net_if_ipv6_maddr_rm(struct net_if *iface, const struct in6_addr *addr)
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -2005,17 +2050,19 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_lookup(const struct in6_addr *maddr,
 {
 	struct net_if_mcast_addr *ifmaddr = NULL;
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	STRUCT_SECTION_FOREACH(net_if, iface) {
-		struct net_if_ipv6 *ipv6 = iface->config.ip.ipv6;
+		struct net_if_ipv6 *ipv6;
 		int i;
 
 		if (ret && *ret && iface != *ret) {
 			continue;
 		}
 
+		net_if_lock(iface);
+
+		ipv6 = iface->config.ip.ipv6;
 		if (!ipv6) {
+			net_if_unlock(iface);
 			continue;
 		}
 
@@ -2034,14 +2081,15 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_lookup(const struct in6_addr *maddr,
 				}
 
 				ifmaddr = &ipv6->mcast[i];
+				net_if_unlock(iface);
 				goto out;
 			}
 		}
+
+		net_if_unlock(iface);
 	}
 
 out:
-	k_mutex_unlock(&lock);
-
 	return ifmaddr;
 }
 
@@ -2049,22 +2097,14 @@ void net_if_ipv6_maddr_leave(struct net_if_mcast_addr *addr)
 {
 	NET_ASSERT(addr);
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	addr->is_joined = false;
-
-	k_mutex_unlock(&lock);
 }
 
 void net_if_ipv6_maddr_join(struct net_if_mcast_addr *addr)
 {
 	NET_ASSERT(addr);
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	addr->is_joined = true;
-
-	k_mutex_unlock(&lock);
 }
 
 static void remove_prefix_addresses(struct net_if *iface,
@@ -2095,6 +2135,8 @@ static void prefix_lifetime_expired(struct net_if_ipv6_prefix *ifprefix)
 {
 	struct net_if_ipv6 *ipv6;
 
+	net_if_lock(ifprefix->iface);
+
 	NET_DBG("Prefix %s/%d expired",
 		net_sprint_ipv6_addr(&ifprefix->prefix),
 		ifprefix->len);
@@ -2113,6 +2155,8 @@ static void prefix_lifetime_expired(struct net_if_ipv6_prefix *ifprefix)
 	net_mgmt_event_notify_with_info(
 		NET_EVENT_IPV6_PREFIX_DEL, ifprefix->iface,
 		&ifprefix->prefix, sizeof(struct in6_addr));
+
+	net_if_unlock(ifprefix->iface);
 }
 
 static void prefix_timer_remove(struct net_if_ipv6_prefix *ifprefix)
@@ -2136,8 +2180,11 @@ static void prefix_lifetime_timeout(struct k_work *work)
 	uint32_t next_update = UINT32_MAX;
 	uint32_t current_time = k_uptime_get_32();
 	struct net_if_ipv6_prefix *current, *next;
+	sys_slist_t expired_list;
 
 	ARG_UNUSED(work);
+
+	sys_slist_init(&expired_list);
 
 	k_mutex_lock(&lock, K_FOREVER);
 
@@ -2148,7 +2195,11 @@ static void prefix_lifetime_timeout(struct k_work *work)
 							    current_time);
 
 		if (this_update == 0U) {
-			prefix_lifetime_expired(current);
+			sys_slist_find_and_remove(
+				&active_prefix_lifetime_timers,
+				&current->lifetime.node);
+			sys_slist_append(&expired_list,
+					 &current->lifetime.node);
 			continue;
 		}
 
@@ -2166,6 +2217,10 @@ static void prefix_lifetime_timeout(struct k_work *work)
 	}
 
 	k_mutex_unlock(&lock);
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&expired_list, current, lifetime.node) {
+		prefix_lifetime_expired(current);
+	}
 }
 
 static void prefix_start_timer(struct net_if_ipv6_prefix *ifprefix,
@@ -2235,7 +2290,7 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_add(struct net_if *iface,
 	struct net_if_ipv6 *ipv6;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (net_if_config_ipv6_get(iface, &ipv6) < 0) {
 		goto out;
@@ -2270,7 +2325,7 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_add(struct net_if *iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ifprefix;
 }
@@ -2282,7 +2337,7 @@ bool net_if_ipv6_prefix_rm(struct net_if *iface, struct in6_addr *addr,
 	struct net_if_ipv6 *ipv6;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ipv6 = iface->config.ip.ipv6;
 	if (!ipv6) {
@@ -2317,7 +2372,7 @@ bool net_if_ipv6_prefix_rm(struct net_if *iface, struct in6_addr *addr,
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -2329,11 +2384,11 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_get(struct net_if *iface,
 	struct net_if_ipv6 *ipv6;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	if (!iface) {
 		iface = net_if_get_default();
 	}
+
+	net_if_lock(iface);
 
 	ipv6 = iface->config.ip.ipv6;
 	if (!ipv6) {
@@ -2355,7 +2410,7 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_get(struct net_if *iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return prefix;
 }
@@ -2368,7 +2423,7 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_lookup(struct net_if *iface,
 	struct net_if_ipv6 *ipv6;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ipv6 = iface->config.ip.ipv6;
 	if (!ipv6) {
@@ -2388,7 +2443,7 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_lookup(struct net_if *iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return prefix;
 }
@@ -2397,17 +2452,19 @@ bool net_if_ipv6_addr_onlink(struct net_if **iface, struct in6_addr *addr)
 {
 	bool ret = false;
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	STRUCT_SECTION_FOREACH(net_if, tmp) {
-		struct net_if_ipv6 *ipv6 = tmp->config.ip.ipv6;
+		struct net_if_ipv6 *ipv6;
 		int i;
 
 		if (iface && *iface && *iface != tmp) {
 			continue;
 		}
 
+		net_if_lock(tmp);
+
+		ipv6 = tmp->config.ip.ipv6;
 		if (!ipv6) {
+			net_if_unlock(tmp);
 			continue;
 		}
 
@@ -2421,14 +2478,15 @@ bool net_if_ipv6_addr_onlink(struct net_if **iface, struct in6_addr *addr)
 				}
 
 				ret = true;
+				net_if_unlock(tmp);
 				goto out;
 			}
 		}
+
+		net_if_unlock(tmp);
 	}
 
 out:
-	k_mutex_unlock(&lock);
-
 	return ret;
 }
 
@@ -2496,7 +2554,7 @@ uint8_t net_if_ipv6_get_hop_limit(struct net_if *iface)
 #if defined(CONFIG_NET_NATIVE_IPV6)
 	int ret = 0;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!iface->config.ip.ipv6) {
 		goto out;
@@ -2504,7 +2562,7 @@ uint8_t net_if_ipv6_get_hop_limit(struct net_if *iface)
 
 	ret = iface->config.ip.ipv6->hop_limit;
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 #else
@@ -2517,7 +2575,7 @@ out:
 void net_ipv6_set_hop_limit(struct net_if *iface, uint8_t hop_limit)
 {
 #if defined(CONFIG_NET_NATIVE_IPV6)
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!iface->config.ip.ipv6) {
 		goto out;
@@ -2525,7 +2583,7 @@ void net_ipv6_set_hop_limit(struct net_if *iface, uint8_t hop_limit)
 
 	iface->config.ip.ipv6->hop_limit = hop_limit;
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 #else
 	ARG_UNUSED(iface);
 	ARG_UNUSED(hop_limit);
@@ -2539,7 +2597,7 @@ struct in6_addr *net_if_ipv6_get_ll(struct net_if *iface,
 	struct net_if_ipv6 *ipv6;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ipv6 = iface->config.ip.ipv6;
 	if (!ipv6) {
@@ -2561,7 +2619,7 @@ struct in6_addr *net_if_ipv6_get_ll(struct net_if *iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return addr;
 }
@@ -2571,22 +2629,23 @@ struct in6_addr *net_if_ipv6_get_ll_addr(enum net_addr_state state,
 {
 	struct in6_addr *addr = NULL;
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	STRUCT_SECTION_FOREACH(net_if, tmp) {
+		net_if_lock(tmp);
+
 		addr = net_if_ipv6_get_ll(tmp, state);
 		if (addr) {
 			if (iface) {
 				*iface = tmp;
 			}
 
+			net_if_unlock(tmp);
 			goto out;
 		}
+
+		net_if_unlock(tmp);
 	}
 
 out:
-	k_mutex_unlock(&lock);
-
 	return addr;
 }
 
@@ -2620,25 +2679,26 @@ struct in6_addr *net_if_ipv6_get_global_addr(enum net_addr_state state,
 {
 	struct in6_addr *addr = NULL;
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	STRUCT_SECTION_FOREACH(net_if, tmp) {
 		if (iface && *iface && tmp != *iface) {
 			continue;
 		}
 
+		net_if_lock(tmp);
 		addr = check_global_addr(tmp, state);
 		if (addr) {
 			if (iface) {
 				*iface = tmp;
 			}
 
+			net_if_unlock(tmp);
 			goto out;
 		}
+
+		net_if_unlock(tmp);
 	}
 
 out:
-	k_mutex_unlock(&lock);
 
 	return addr;
 }
@@ -2664,13 +2724,16 @@ static struct in6_addr *net_if_ipv6_get_best_match(struct net_if *iface,
 						   const struct in6_addr *dst,
 						   uint8_t *best_so_far)
 {
-	struct net_if_ipv6 *ipv6 = iface->config.ip.ipv6;
+	struct net_if_ipv6 *ipv6;
 	struct in6_addr *src = NULL;
 	uint8_t len;
 	int i;
 
+	net_if_lock(iface);
+
+	ipv6 = iface->config.ip.ipv6;
 	if (!ipv6) {
-		return NULL;
+		goto out;
 	}
 
 	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
@@ -2693,6 +2756,9 @@ static struct in6_addr *net_if_ipv6_get_best_match(struct net_if *iface,
 		}
 	}
 
+out:
+	net_if_unlock(iface);
+
 	return src;
 }
 
@@ -2701,8 +2767,6 @@ const struct in6_addr *net_if_ipv6_select_src_addr(struct net_if *dst_iface,
 {
 	const struct in6_addr *src = NULL;
 	uint8_t best_match = 0U;
-
-	k_mutex_lock(&lock, K_FOREVER);
 
 	if (!net_ipv6_is_ll_addr(dst) && !net_ipv6_is_addr_mcast_link(dst)) {
 		/* If caller has supplied interface, then use that */
@@ -2744,8 +2808,6 @@ const struct in6_addr *net_if_ipv6_select_src_addr(struct net_if *dst_iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
-
 	return src;
 }
 
@@ -2753,8 +2815,6 @@ struct net_if *net_if_ipv6_select_src_iface(const struct in6_addr *dst)
 {
 	struct net_if *iface = NULL;
 	const struct in6_addr *src;
-
-	k_mutex_lock(&lock, K_FOREVER);
 
 	src = net_if_ipv6_select_src_addr(NULL, dst);
 	if (src != net_ipv6_unspecified_address()) {
@@ -2765,8 +2825,6 @@ struct net_if *net_if_ipv6_select_src_iface(const struct in6_addr *dst)
 		iface = net_if_get_default();
 	}
 
-	k_mutex_unlock(&lock);
-
 	return iface;
 }
 
@@ -2774,14 +2832,10 @@ uint32_t net_if_ipv6_calc_reachable_time(struct net_if_ipv6 *ipv6)
 {
 	uint32_t min_reachable, max_reachable;
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	min_reachable = (MIN_RANDOM_NUMER * ipv6->base_reachable_time)
 			/ MIN_RANDOM_DENOM;
 	max_reachable = (MAX_RANDOM_NUMER * ipv6->base_reachable_time)
 			/ MAX_RANDOM_DENOM;
-
-	k_mutex_unlock(&lock);
 
 	NET_DBG("min_reachable:%u max_reachable:%u", min_reachable,
 		max_reachable);
@@ -2877,7 +2931,7 @@ int net_if_config_ipv4_get(struct net_if *iface, struct net_if_ipv4 **ipv4)
 	int ret = 0;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!net_if_flag_is_set(iface, NET_IF_IPV4)) {
 		ret = -ENOTSUP;
@@ -2892,6 +2946,8 @@ int net_if_config_ipv4_get(struct net_if *iface, struct net_if_ipv4 **ipv4)
 		goto out;
 	}
 
+	k_mutex_lock(&lock, K_FOREVER);
+
 	for (i = 0; i < ARRAY_SIZE(ipv4_addresses); i++) {
 		if (ipv4_addresses[i].iface) {
 			continue;
@@ -2904,12 +2960,15 @@ int net_if_config_ipv4_get(struct net_if *iface, struct net_if_ipv4 **ipv4)
 			*ipv4 = &ipv4_addresses[i].ipv4;
 		}
 
+		k_mutex_unlock(&lock);
 		goto out;
 	}
 
+	k_mutex_unlock(&lock);
+
 	ret = -ESRCH;
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -2919,7 +2978,7 @@ int net_if_config_ipv4_put(struct net_if *iface)
 	int ret = 0;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!net_if_flag_is_set(iface, NET_IF_IPV4)) {
 		ret = -ENOTSUP;
@@ -2931,6 +2990,8 @@ int net_if_config_ipv4_put(struct net_if *iface)
 		goto out;
 	}
 
+	k_mutex_lock(&lock, K_FOREVER);
+
 	for (i = 0; i < ARRAY_SIZE(ipv4_addresses); i++) {
 		if (ipv4_addresses[i].iface != iface) {
 			continue;
@@ -2939,12 +3000,15 @@ int net_if_config_ipv4_put(struct net_if *iface)
 		iface->config.ip.ipv4 = NULL;
 		ipv4_addresses[i].iface = NULL;
 
+		k_mutex_unlock(&lock);
 		goto out;
 	}
 
+	k_mutex_unlock(&lock);
+
 	ret = -ESRCH;
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -2954,7 +3018,7 @@ uint8_t net_if_ipv4_get_ttl(struct net_if *iface)
 #if defined(CONFIG_NET_NATIVE_IPV4)
 	int ret = 0;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!iface->config.ip.ipv4) {
 		goto out;
@@ -2962,7 +3026,7 @@ uint8_t net_if_ipv4_get_ttl(struct net_if *iface)
 
 	ret = iface->config.ip.ipv4->ttl;
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 #else
@@ -2975,7 +3039,7 @@ out:
 void net_if_ipv4_set_ttl(struct net_if *iface, uint8_t ttl)
 {
 #if defined(CONFIG_NET_NATIVE_IPV4)
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!iface->config.ip.ipv4) {
 		goto out;
@@ -2983,7 +3047,7 @@ void net_if_ipv4_set_ttl(struct net_if *iface, uint8_t ttl)
 
 	iface->config.ip.ipv4->ttl = ttl;
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 #else
 	ARG_UNUSED(iface);
 	ARG_UNUSED(ttl);
@@ -3023,7 +3087,7 @@ bool net_if_ipv4_addr_mask_cmp(struct net_if *iface,
 	uint32_t subnet;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ipv4 = iface->config.ip.ipv4;
 	if (!ipv4) {
@@ -3046,7 +3110,7 @@ bool net_if_ipv4_addr_mask_cmp(struct net_if *iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -3054,30 +3118,37 @@ out:
 static bool ipv4_is_broadcast_address(struct net_if *iface,
 				      const struct in_addr *addr)
 {
-	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
+	struct net_if_ipv4 *ipv4;
+	bool ret = false;
 
+	net_if_lock(iface);
+
+	ipv4 = iface->config.ip.ipv4;
 	if (!ipv4) {
-		return false;
+		ret = false;
+		goto out;
 	}
 
 	if (!net_if_ipv4_addr_mask_cmp(iface, addr)) {
-		return false;
+		ret = false;
+		goto out;
 	}
 
 	if ((UNALIGNED_GET(&addr->s_addr) & ~ipv4->netmask.s_addr) ==
 	    ~ipv4->netmask.s_addr) {
-		return true;
+		ret = true;
+		goto out;
 	}
 
-	return false;
+out:
+	net_if_unlock(iface);
+	return ret;
 }
 
 bool net_if_ipv4_is_addr_bcast(struct net_if *iface,
 			       const struct in_addr *addr)
 {
 	bool ret = false;
-
-	k_mutex_lock(&lock, K_FOREVER);
 
 	if (iface) {
 		ret = ipv4_is_broadcast_address(iface, addr);
@@ -3092,16 +3163,12 @@ bool net_if_ipv4_is_addr_bcast(struct net_if *iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
-
 	return ret;
 }
 
 struct net_if *net_if_ipv4_select_src_iface(const struct in_addr *dst)
 {
 	struct net_if *selected = NULL;
-
-	k_mutex_lock(&lock, K_FOREVER);
 
 	STRUCT_SECTION_FOREACH(net_if, iface) {
 		bool ret;
@@ -3118,8 +3185,6 @@ struct net_if *net_if_ipv4_select_src_iface(const struct in_addr *dst)
 	}
 
 out:
-	k_mutex_unlock(&lock);
-
 	return selected;
 }
 
@@ -3144,13 +3209,16 @@ static struct in_addr *net_if_ipv4_get_best_match(struct net_if *iface,
 						  const struct in_addr *dst,
 						  uint8_t *best_so_far)
 {
-	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
+	struct net_if_ipv4 *ipv4;
 	struct in_addr *src = NULL;
 	uint8_t len;
 	int i;
 
+	net_if_lock(iface);
+
+	ipv4 = iface->config.ip.ipv4;
 	if (!ipv4) {
-		return NULL;
+		goto out;
 	}
 
 	for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
@@ -3165,6 +3233,9 @@ static struct in_addr *net_if_ipv4_get_best_match(struct net_if *iface,
 		}
 	}
 
+out:
+	net_if_unlock(iface);
+
 	return src;
 }
 
@@ -3175,7 +3246,7 @@ static struct in_addr *if_ipv4_get_addr(struct net_if *iface,
 	struct net_if_ipv4 *ipv4;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!iface) {
 		goto out;
@@ -3209,7 +3280,7 @@ static struct in_addr *if_ipv4_get_addr(struct net_if *iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return addr;
 }
@@ -3231,8 +3302,6 @@ const struct in_addr *net_if_ipv4_select_src_addr(struct net_if *dst_iface,
 {
 	const struct in_addr *src = NULL;
 	uint8_t best_match = 0U;
-
-	k_mutex_lock(&lock, K_FOREVER);
 
 	if (!net_ipv4_is_ll_addr(dst)) {
 
@@ -3288,8 +3357,6 @@ const struct in_addr *net_if_ipv4_select_src_addr(struct net_if *dst_iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
-
 	return src;
 }
 
@@ -3298,13 +3365,15 @@ struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
 {
 	struct net_if_addr *ifaddr = NULL;
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	STRUCT_SECTION_FOREACH(net_if, iface) {
-		struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
+		struct net_if_ipv4 *ipv4;
 		int i;
 
+		net_if_lock(iface);
+
+		ipv4 = iface->config.ip.ipv4;
 		if (!ipv4) {
+			net_if_unlock(iface);
 			continue;
 		}
 
@@ -3322,14 +3391,15 @@ struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
 				}
 
 				ifaddr = &ipv4->unicast[i];
+				net_if_unlock(iface);
 				goto out;
 			}
 		}
+
+		net_if_unlock(iface);
 	}
 
 out:
-	k_mutex_unlock(&lock);
-
 	return ifaddr;
 }
 
@@ -3362,7 +3432,7 @@ static inline int z_vrfy_net_if_ipv4_addr_lookup_by_index(
 void net_if_ipv4_set_netmask(struct net_if *iface,
 			     const struct in_addr *netmask)
 {
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (net_if_config_ipv4_get(iface, NULL) < 0) {
 		goto out;
@@ -3374,7 +3444,7 @@ void net_if_ipv4_set_netmask(struct net_if *iface,
 
 	net_ipaddr_copy(&iface->config.ip.ipv4->netmask, netmask);
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 }
 
 bool z_impl_net_if_ipv4_set_netmask_by_index(int index,
@@ -3415,7 +3485,7 @@ bool z_vrfy_net_if_ipv4_set_netmask_by_index(int index,
 
 void net_if_ipv4_set_gw(struct net_if *iface, const struct in_addr *gw)
 {
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (net_if_config_ipv4_get(iface, NULL) < 0) {
 		goto out;
@@ -3427,7 +3497,7 @@ void net_if_ipv4_set_gw(struct net_if *iface, const struct in_addr *gw)
 
 	net_ipaddr_copy(&iface->config.ip.ipv4->gw, gw);
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 }
 
 bool z_impl_net_if_ipv4_set_gw_by_index(int index,
@@ -3494,7 +3564,7 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 	struct net_if_ipv4 *ipv4;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (net_if_config_ipv4_get(iface, &ipv4) < 0) {
 		goto out;
@@ -3552,7 +3622,7 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ifaddr;
 }
@@ -3563,7 +3633,7 @@ bool net_if_ipv4_addr_rm(struct net_if *iface, const struct in_addr *addr)
 	bool ret = false;
 	int i;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ipv4 = iface->config.ip.ipv4;
 	if (!ipv4) {
@@ -3595,7 +3665,7 @@ bool net_if_ipv4_addr_rm(struct net_if *iface, const struct in_addr *addr)
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -3709,7 +3779,7 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_add(struct net_if *iface,
 {
 	struct net_if_mcast_addr *maddr = NULL;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (net_if_config_ipv4_get(iface, NULL) < 0) {
 		goto out;
@@ -3737,7 +3807,7 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_add(struct net_if *iface,
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return maddr;
 }
@@ -3747,7 +3817,7 @@ bool net_if_ipv4_maddr_rm(struct net_if *iface, const struct in_addr *addr)
 	struct net_if_mcast_addr *maddr;
 	bool ret = false;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	maddr = ipv4_maddr_find(iface, true, addr);
 	if (maddr) {
@@ -3764,7 +3834,7 @@ bool net_if_ipv4_maddr_rm(struct net_if *iface, const struct in_addr *addr)
 		ret = true;
 	}
 
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -3774,12 +3844,12 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_lookup(const struct in_addr *maddr,
 {
 	struct net_if_mcast_addr *addr = NULL;
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	STRUCT_SECTION_FOREACH(net_if, iface) {
 		if (ret && *ret && iface != *ret) {
 			continue;
 		}
+
+		net_if_lock(iface);
 
 		addr = ipv4_maddr_find(iface, true, maddr);
 		if (addr) {
@@ -3787,13 +3857,14 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_lookup(const struct in_addr *maddr,
 				*ret = iface;
 			}
 
+			net_if_unlock(iface);
 			goto out;
 		}
+
+		net_if_unlock(iface);
 	}
 
 out:
-	k_mutex_unlock(&lock);
-
 	return addr;
 }
 
@@ -3801,22 +3872,14 @@ void net_if_ipv4_maddr_leave(struct net_if_mcast_addr *addr)
 {
 	NET_ASSERT(addr);
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	addr->is_joined = false;
-
-	k_mutex_unlock(&lock);
 }
 
 void net_if_ipv4_maddr_join(struct net_if_mcast_addr *addr)
 {
 	NET_ASSERT(addr);
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	addr->is_joined = true;
-
-	k_mutex_unlock(&lock);
 }
 
 static void iface_ipv4_init(int if_count)
@@ -3895,8 +3958,6 @@ struct net_if *net_if_select_src_iface(const struct sockaddr *dst)
 		goto out;
 	}
 
-	k_mutex_lock(&lock, K_FOREVER);
-
 	if (IS_ENABLED(CONFIG_NET_IPV6) && dst->sa_family == AF_INET6) {
 		iface = net_if_ipv6_select_src_iface(&net_sin6(dst)->sin6_addr);
 		goto out;
@@ -3908,8 +3969,6 @@ struct net_if *net_if_select_src_iface(const struct sockaddr *dst)
 	}
 
 out:
-	k_mutex_unlock(&lock);
-
 	if (iface == NULL) {
 		iface = net_if_get_default();
 	}
@@ -4195,7 +4254,7 @@ int net_if_up(struct net_if *iface)
 
 	NET_DBG("iface %p", iface);
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (net_if_flag_is_set(iface, NET_IF_UP)) {
 		status = -EALREADY;
@@ -4221,7 +4280,7 @@ done:
 	update_operational_state(iface);
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return status;
 }
@@ -4232,7 +4291,7 @@ int net_if_down(struct net_if *iface)
 
 	NET_DBG("iface %p", iface);
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!net_if_flag_is_set(iface, NET_IF_UP)) {
 		status = -EALREADY;
@@ -4259,7 +4318,7 @@ done:
 	update_operational_state(iface);
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return status;
 }
@@ -4268,52 +4327,52 @@ void net_if_carrier_on(struct net_if *iface)
 {
 	NET_ASSERT(iface);
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!net_if_flag_test_and_set(iface, NET_IF_LOWER_UP)) {
 		update_operational_state(iface);
 	}
 
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 }
 
 void net_if_carrier_off(struct net_if *iface)
 {
 	NET_ASSERT(iface);
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (net_if_flag_test_and_clear(iface, NET_IF_LOWER_UP)) {
 		update_operational_state(iface);
 	}
 
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 }
 
 void net_if_dormant_on(struct net_if *iface)
 {
 	NET_ASSERT(iface);
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!net_if_flag_test_and_set(iface, NET_IF_DORMANT)) {
 		update_operational_state(iface);
 	}
 
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 }
 
 void net_if_dormant_off(struct net_if *iface)
 {
 	NET_ASSERT(iface);
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (net_if_flag_test_and_clear(iface, NET_IF_DORMANT)) {
 		update_operational_state(iface);
 	}
 
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 }
 
 static int promisc_mode_set(struct net_if *iface, bool enable)
@@ -4348,7 +4407,7 @@ int net_if_set_promisc(struct net_if *iface)
 {
 	int ret;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ret = promisc_mode_set(iface, true);
 	if (ret < 0) {
@@ -4362,7 +4421,7 @@ int net_if_set_promisc(struct net_if *iface)
 	}
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -4371,7 +4430,7 @@ void net_if_unset_promisc(struct net_if *iface)
 {
 	int ret;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	ret = promisc_mode_set(iface, false);
 	if (ret < 0) {
@@ -4381,7 +4440,7 @@ void net_if_unset_promisc(struct net_if *iface)
 	net_if_flag_clear(iface, NET_IF_PROMISC);
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 }
 
 bool net_if_is_promisc(struct net_if *iface)
@@ -4397,7 +4456,7 @@ int net_if_suspend(struct net_if *iface)
 {
 	int ret = 0;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (net_if_are_pending_tx_packets(iface)) {
 		ret = -EBUSY;
@@ -4412,7 +4471,7 @@ int net_if_suspend(struct net_if *iface)
 	net_stats_add_suspend_start_time(iface, k_cycle_get_32());
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }
@@ -4421,7 +4480,7 @@ int net_if_resume(struct net_if *iface)
 {
 	int ret = 0;
 
-	k_mutex_lock(&lock, K_FOREVER);
+	net_if_lock(iface);
 
 	if (!net_if_flag_is_set(iface, NET_IF_SUSPENDED)) {
 		ret = -EALREADY;
@@ -4433,7 +4492,7 @@ int net_if_resume(struct net_if *iface)
 	net_stats_add_suspend_end_time(iface, k_cycle_get_32());
 
 out:
-	k_mutex_unlock(&lock);
+	net_if_unlock(iface);
 
 	return ret;
 }

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2093,18 +2093,24 @@ out:
 	return ifmaddr;
 }
 
-void net_if_ipv6_maddr_leave(struct net_if_mcast_addr *addr)
+void net_if_ipv6_maddr_leave(struct net_if *iface, struct net_if_mcast_addr *addr)
 {
+	NET_ASSERT(iface);
 	NET_ASSERT(addr);
 
+	net_if_lock(iface);
 	addr->is_joined = false;
+	net_if_unlock(iface);
 }
 
-void net_if_ipv6_maddr_join(struct net_if_mcast_addr *addr)
+void net_if_ipv6_maddr_join(struct net_if *iface, struct net_if_mcast_addr *addr)
 {
+	NET_ASSERT(iface);
 	NET_ASSERT(addr);
 
+	net_if_lock(iface);
 	addr->is_joined = true;
+	net_if_unlock(iface);
 }
 
 static void remove_prefix_addresses(struct net_if *iface,
@@ -3868,18 +3874,24 @@ out:
 	return addr;
 }
 
-void net_if_ipv4_maddr_leave(struct net_if_mcast_addr *addr)
+void net_if_ipv4_maddr_leave(struct net_if *iface, struct net_if_mcast_addr *addr)
 {
+	NET_ASSERT(iface);
 	NET_ASSERT(addr);
 
+	net_if_lock(iface);
 	addr->is_joined = false;
+	net_if_unlock(iface);
 }
 
-void net_if_ipv4_maddr_join(struct net_if_mcast_addr *addr)
+void net_if_ipv4_maddr_join(struct net_if *iface, struct net_if_mcast_addr *addr)
 {
+	NET_ASSERT(iface);
 	NET_ASSERT(addr);
 
+	net_if_lock(iface);
 	addr->is_joined = true;
+	net_if_unlock(iface);
 }
 
 static void iface_ipv4_init(int if_count)

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -430,12 +430,14 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	}
 #endif /* CONFIG_NET_L2_VIRTUAL */
 
+	net_if_lock(iface);
 	if (net_if_get_link_addr(iface) &&
 	    net_if_get_link_addr(iface)->addr) {
 		PR("Link addr : %s\n",
 		   net_sprint_ll_addr(net_if_get_link_addr(iface)->addr,
 				      net_if_get_link_addr(iface)->len));
 	}
+	net_if_unlock(iface);
 
 	PR("MTU       : %d\n", net_if_get_mtu(iface));
 	PR("Flags     : %s\n", iface_flags2str(iface));

--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -273,7 +273,7 @@ void add_ipv6_maddr_to_zephyr(struct openthread_context *context)
 		      net_ipv6_is_addr_mcast_link_all_nodes(
 				(struct in6_addr *)(&maddress->mAddress)))) {
 
-			net_if_ipv6_maddr_join(zmaddr);
+			net_if_ipv6_maddr_join(context->iface, zmaddr);
 		}
 	}
 }


### PR DESCRIPTION
Instead of having a single global mutex, covering, in most cases
unrelated, access to all network interfaces, introduce a separate mutex
for each network interface. Details in the commit messages.

Fixes #50875