### PR TITLE
drivers: temp_nrf5: Fix warning in ISR prototype

### DIFF
--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -95,7 +95,7 @@ static int temp_nrf5_channel_get(const struct device *dev,
 	return 0;
 }
 
-static void temp_nrf5_isr(void *arg)
+static void temp_nrf5_isr(const void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	struct temp_nrf5_data *data = dev->data;


### PR DESCRIPTION
The ISR prototype was changed some time ago
(6df8b3995e05d6348f8de9601379475a5455fedd)
to (const void*) => Fix the isr function definition
to avoid a compile warning.