### PR TITLE
nrf52_bsim: Use HW models with temperature sensor

### DIFF
--- a/boards/posix/nrf52_bsim/Kconfig.defconfig
+++ b/boards/posix/nrf52_bsim/Kconfig.defconfig
@@ -25,13 +25,6 @@ config BT_CTLR
 	default y
 	depends on BT
 
-# The simulated nRF52 HW models do not include yet the TEMP peripheral
-# So we disable its default usage by the 15.4 driver
-# Otherwise it would be set by default, and NRF_802154_SL_OPENSOURCE
-# would require TEMP_NRF5, which requires the missing HW model
-config NRF_802154_TEMPERATURE_UPDATE
-	default n
-
 # The 15.4 driver Tx encryption is currently not functional with this
 # simulated board => we disable it by default. With this Openthread will normally
 # default to encrypt packets on its own.

--- a/boards/posix/nrf52_bsim/nrf52_bsim.dts
+++ b/boards/posix/nrf52_bsim/nrf52_bsim.dts
@@ -57,7 +57,6 @@
 		/delete-node/ spi@40004000;
 		/delete-node/ spi@40023000;
 		/delete-node/ spi@4002f000;
-		/delete-node/ temp@4000c000;
 		/delete-node/ watchdog@40010000;
 		/delete-node/ acl@4001e000;
 		/delete-node/ usbd@40027000;

--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -95,7 +95,7 @@ static int temp_nrf5_channel_get(const struct device *dev,
 	return 0;
 }
 
-static void temp_nrf5_isr(void *arg)
+static void temp_nrf5_isr(const void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	struct temp_nrf5_data *data = dev->data;

--- a/west.yml
+++ b/west.yml
@@ -197,7 +197,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 7078310d522664b1612ebac93240b367c4c96299
+      revision: bad9877e997b2c2a78dd74eec8978181f4655d14
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: aedcc262f93bbb1b0c2f58026911575729b7465c


### PR DESCRIPTION
    nrf52_bsim: Stop disabling temperature sensor
    
    The HW models now include the temperature sensor,
    let's stop excluding it.
    
--------

    manifest: nrf hw models: Update to latest w TEMP HW
    
    Update to the latest HW models which include models
    of the TEMP peripheral
    
--------

    drivers: temp_nrf5: Fix warning in ISR prototype
    
    The ISR prototype was changed some time ago
    (6df8b3995e05d6348f8de9601379475a5455fedd)
    to (const void*) => fix isr function definition
    to avoid a compile warning.
