### PR TITLE
samples: drivers: adc: Update console output specification

### DIFF
--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -16,5 +16,5 @@ tests:
     harness_config:
       type: multi_line
       regex:
-        - "ADC reading:"
+        - "ADC reading\\[\\d+\\]:"
         - "- .+, channel \\d+: -?\\d+"


### PR DESCRIPTION
This is a follow-up to commit 9fa35bc9a05cbf5c524255a24107e4b554ab2409.

Align specification of the expected console output with the changes done to the sample in the above commit.

Fixes #56750.