### PR TITLE
drivers: i2c: nrfx: add multithreading dependency

### DIFF
--- a/drivers/i2c/Kconfig.nrfx
+++ b/drivers/i2c/Kconfig.nrfx
@@ -7,6 +7,7 @@ menuconfig I2C_NRFX
 	bool "nRF TWI nrfx drivers"
 	default y
 	depends on SOC_FAMILY_NRF
+	depends on MULTITHREADING
 	help
 	  Enable support for nrfx TWI drivers for nRF MCU series.
 


### PR DESCRIPTION
This patch adds MULTITHREADING as a dependency to the nrfx i2c driver. The driver uses semaphores internally and can result in linker errors if MULTITHREADING is not enabled.