### PR TITLE
drivers: flash: stm32 ospi: support alternate bytes in STR mode

### DIFF
--- a/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
@@ -105,3 +105,20 @@ properties:
       * 2READ 1-2-2 (0xBB) -> 2READ 1-2-2 4B (0xBC)
       * QREAD 1-1-4 (0x6B) -> QREAD 1-1-4 4B (0x6C)
       * 4READ 1-4-4 (0xEB) -> 4READ 1-4-4 4B (0xEC)
+  use-alternate-bytes:
+    type: boolean
+    description: |
+      If enabled, the OSPI transmits 1 byte equal to 0xFF
+      before the dummy clocks (wait states) on all data lines
+      based on spi_bus_width.
+
+      Done only when JESD216 BFP query reports
+      mode clocks value higher than 0 for the read mode it will use.
+
+      For example, the W25Q80BV recommends transmitting
+      0xFX (where X doesn't matter) for the mode clocks phase
+      for 0xEB read opcode (Fast Read Quad I/O).
+
+      If not enabled, then mode clocks are added to dummy clocks.
+
+      Uses STM32 Alternate Bytes functionality.


### PR DESCRIPTION
Uses STM32 Alternate Bytes to insert "mode clocks" before "wait states" (_dummy clocks_).

While OSPI output(s) are tri-state for dummy cycles, they are driven either low or high for alternate bytes (mode clocks).

It doesn't look like many chips support/require that mode. Therefore, enabling is guarded by bindings. No footprint impact when it is not enabled.

The current implementation is very limited. It is covering the [Winbond W25](https://www.winbond.com/hq/support/documentation/levelOne.jsp?__locale=en&DocNo=DA00-W25Q64JV) case where they recommend transmitting `0xFX` (_where `X` doesn't matter_) before dummy cycles during the "Fast Read Quad I/O" operation in STR mode. In DTR mode it is used for "Continuous Read Mode" (_mostly used in XIP, not supported in this PR_).

If enabled, it transmits a single byte (`0xFF`) over data lines based on `spi_bus_width` when the read operation requires mode clocks. Supports only STR mode. That covers the recommendation note for the Flash (_at least for Quad STR mode_).

If disabled, then mode cycles are appended to the dummy cycles. Same way as it used to work.