### PR TITLE
dts: riscv: gd32vf103: Add UART3 and UART4 configuration

### DIFF
--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -116,6 +116,24 @@
 			status = "disabled";
 		};
 
+		uart3: serial@40004c00 {
+			compatible = "gd,gd32-usart";
+			reg = <0x40004c00 0x400>;
+			interrupts = <71 0>;
+			clocks = <&cctl GD32_CLOCK_UART3>;
+			resets = <&rctl GD32_RESET_UART3>;
+			status = "disabled";
+		};
+
+		uart4: serial@40005000 {
+			compatible = "gd,gd32-usart";
+			reg = <0x40005000 0x400>;
+			interrupts = <72 0>;
+			clocks = <&cctl GD32_CLOCK_UART4>;
+			resets = <&rctl GD32_RESET_UART4>;
+			status = "disabled";
+		};
+
 		adc0: adc@40012400 {
 			compatible = "gd,gd32-adc";
 			reg = <0x40012400 0x400>;


### PR DESCRIPTION
These UART peripherals are present on higher pin count devices.

Verified working using an RV-STAR board. Support for that board will come in another PR.