### PR TITLE
net: socket: fix hanging net contexts

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -588,7 +588,7 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 			sock_set_eof(ctx);
 			z_free_fd(fd);
 			zsock_flush_queue(ctx);
-			net_context_unref(ctx);
+			net_context_put(ctx);
 			errno = ECONNABORTED;
 			return -1;
 		}
@@ -598,7 +598,7 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 		errno = ECONNABORTED;
 		z_free_fd(fd);
 		zsock_flush_queue(ctx);
-		net_context_unref(ctx);
+		net_context_put(ctx);
 		return -1;
 	}
 
@@ -620,7 +620,7 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 			z_free_fd(fd);
 			errno = ENOTSUP;
 			zsock_flush_queue(ctx);
-			net_context_unref(ctx);
+			net_context_put(ctx);
 			return -1;
 		}
 	}


### PR DESCRIPTION
Calls put instead of unref on net contexts
in the socket accept function.
Mere unref didn't subtract the reference
count of net context which leaves
it in used state. This situation happens
in case of accepting already
closed connection.