### PR TITLE
twister: Check for early termination of BinaryHandler

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -192,6 +192,8 @@ class BinaryHandler(Handler):
             timeout_extended = False
             timeout_time = time.time() + self.timeout
             while True:
+                if proc.poll():
+                    break
                 this_timeout = timeout_time - time.time()
                 if this_timeout < 0:
                     break


### PR DESCRIPTION
BinaryHandlers might terminate because of a test failure (e.g. native_posix tests will exit on an assert) but twister will currently keep polling the dead process for output until the timeout elapses.

This change makes it faster to tell if a test failed, so developers working on broken tests do not need to wait for the full timeout.