### PR TITLE
devicetree: add `DT_ENUM_HAS_VALUE`

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -39,6 +39,7 @@
  * are missing from this list, please add them. It should be complete.
  *
  * _ENUM_IDX: property's value as an index into bindings enum
+ * _ENUM_VAL_<val>_EXISTS property's value as a token exists
  * _ENUM_TOKEN: property's value as a token into bindings enum (string
  *              enum values are identifiers) [deprecated, use _STRING_TOKEN]
  * _ENUM_UPPER_TOKEN: like _ENUM_TOKEN, but uppercased [deprecated, use
@@ -826,6 +827,17 @@
 #define DT_ENUM_IDX_OR(node_id, prop, default_idx_value) \
 	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
 		    (DT_ENUM_IDX(node_id, prop)), (default_idx_value))
+
+/**
+ * @brief Does a node enumeration property have a given value?
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param value lowercase-and-underscores enumeration value
+ * @return 1 if the node property has the value @a value, 0 otherwise.
+ */
+#define DT_ENUM_HAS_VALUE(node_id, prop, value) \
+	IS_ENABLED(DT_CAT6(node_id, _P_, prop, _ENUM_VAL_, value, _EXISTS))
 
 /**
  * @brief Get a string property's value as a token.
@@ -3335,6 +3347,17 @@
  */
 #define DT_INST_ENUM_IDX_OR(inst, prop, default_idx_value) \
 	DT_ENUM_IDX_OR(DT_DRV_INST(inst), prop, default_idx_value)
+
+/**
+ * @brief Does a `DT_DRV_COMPAT` enumeration property have a given value?
+ *
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param value lowercase-and-underscores enumeration value
+ * @return 1 if the node property has the value @a value, 0 otherwise.
+ */
+#define DT_INST_ENUM_HAS_VALUE(inst, prop, value) \
+	DT_ENUM_HAS_VALUE(DT_DRV_INST(inst), prop, value)
 
 /**
  * @brief Get a `DT_DRV_COMPAT` instance property

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -657,12 +657,17 @@ def write_vanilla_props(node):
             if spec.enum_tokenizable:
                 as_token = prop.val_as_token
 
+                # DT_N_<node-id>_P_<prop-id>_ENUM_VAL_<val>_EXISTS 1
+                macro2val[macro + f"_ENUM_VAL_{as_token}_EXISTS"] = 1
                 # DT_N_<node-id>_P_<prop-id>_ENUM_TOKEN
                 macro2val[macro + "_ENUM_TOKEN"] = as_token
 
                 if spec.enum_upper_tokenizable:
                     # DT_N_<node-id>_P_<prop-id>_ENUM_UPPER_TOKEN
                     macro2val[macro + "_ENUM_UPPER_TOKEN"] = as_token.upper()
+            else:
+                # DT_N_<node-id>_P_<prop-id>_ENUM_VAL_<val>_EXISTS 1
+                macro2val[macro + f"_ENUM_VAL_{prop.val}_EXISTS"] = 1
 
         if "phandle" in prop.type:
             macro2val.update(phandle_macros(prop, macro))

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1659,7 +1659,17 @@ ZTEST(devicetree_api, test_enums)
 		MY_ENUM_ZERO = 0xaa,
 	};
 
+	/* DT_ENUM_IDX and DT_ENUM_HAS_VALUE on string enum */
 	zassert_equal(DT_ENUM_IDX(TEST_ENUM_0, val), 0, "0");
+	zassert_true(DT_ENUM_HAS_VALUE(TEST_ENUM_0, val, zero), "");
+	zassert_false(DT_ENUM_HAS_VALUE(TEST_ENUM_0, val, one), "");
+	zassert_false(DT_ENUM_HAS_VALUE(TEST_ENUM_0, val, two), "");
+
+	/* DT_ENUM_IDX and DT_ENUM_HAS_VALUE on int enum */
+	zassert_equal(DT_ENUM_IDX(DT_NODELABEL(test_enum_int_default_0), val), 0, "0");
+	zassert_true(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_default_0), val, 5), "");
+	zassert_false(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_default_0), val, 6), "");
+	zassert_false(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_default_0), val, 7), "");
 }
 #undef TO_MY_ENUM
 #undef TO_MY_ENUM_2
@@ -1686,10 +1696,16 @@ ZTEST(devicetree_api, test_inst_enums)
 #define DT_DRV_COMPAT vnd_enum_holder_inst
 	zassert_equal(DT_INST_ENUM_IDX(0, val), 0, "");
 	zassert_equal(DT_INST_ENUM_IDX_OR(0, val, 2), 0, "");
+	zassert_true(DT_INST_ENUM_HAS_VALUE(0, val, zero), "");
+	zassert_false(DT_INST_ENUM_HAS_VALUE(0, val, one), "");
+	zassert_false(DT_INST_ENUM_HAS_VALUE(0, val, two), "");
 
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_enum_required_false_holder_inst
 	zassert_equal(DT_INST_ENUM_IDX_OR(0, val, 2), 2, "");
+	zassert_false(DT_INST_ENUM_HAS_VALUE(0, val, zero), "");
+	zassert_false(DT_INST_ENUM_HAS_VALUE(0, val, one), "");
+	zassert_false(DT_INST_ENUM_HAS_VALUE(0, val, two), "");
 }
 
 #undef DT_DRV_COMPAT


### PR DESCRIPTION
Add a macro for checking if an enumeration matches a given value.
This enables code to directly check whether a string enumeration is a
specific value, without needing to construct an intermediate variable,
and without checking against a index value which may change.

```
/* Enables this */
if (DT_INST_ENUM_HAS_VALUE(0, power_amplifier_output, rfo_hp)) {}
/* Instead of this */
if (DT_INST_ENUM_IDX(0, power_amplifier_output) == 0) {}
```

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>