### PR TITLE
ci: backport: Update backport action to v2.0.3-3

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,11 +9,23 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-22.04
     name: Backport
+    runs-on: ubuntu-22.04
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged &&
+      (
+        github.event.action == 'closed' ||
+        (
+          github.event.action == 'labeled' &&
+          contains(github.event.label.name, 'backport')
+        )
+      )
     steps:
       - name: Backport
-        uses: zephyrproject-rtos/action-backport@v1.1.1-3
+        uses: zephyrproject-rtos/action-backport@v2.0.3-3
         with:
           github_token: ${{ secrets.ZB_GITHUB_TOKEN }}
-          issue_labels: backport
+          issue_labels: Backport
+          labels_template: '["Backport"]'


### PR DESCRIPTION
This commit updates the backport action to v2.0.3-3, which is based on node.js 16 and @actions/core 1.10.0, in preparation for the upcoming removal of the deprecated GitHub features.

---

Tested in https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/4706234949/jobs/8347327054
Partially fixes https://github.com/zephyrproject-rtos/zephyr/issues/56613