### PR TITLE
[v2.7-branch] ci: labeler: Use actions/labeler@v4

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,5 +8,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v2.1.1
-        with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
This commit updates the labeler workflow to use the labeler action v4, which is based on node.js 16 and @actions/core 1.10.0, in preparation for the upcoming removal of the deprecated GitHub features.

---

Partially fixes https://github.com/zephyrproject-rtos/zephyr/issues/56613