### PR TITLE
cmake: change ZephyrBuildConfiguration behavior

### DIFF
--- a/cmake/modules/zephyr_default.cmake
+++ b/cmake/modules/zephyr_default.cmake
@@ -24,10 +24,13 @@ message(STATUS "Application: ${APPLICATION_SOURCE_DIR}")
 # to CMake 3.20; this produces different binaries.
 message(STATUS "CMake version: ${CMAKE_VERSION}")
 
+if (NOT ZephyrBuildConfiguration_ROOT)
+  set(ZephyrBuildConfiguration_ROOT "${ZEPHYR_BASE}/../*")
+endif()
+
 find_package(ZephyrBuildConfiguration
   QUIET NO_POLICY_SCOPE
   NAMES ZephyrBuild
-  PATHS ${ZEPHYR_BASE}/../*
   NO_CMAKE_PATH
   NO_CMAKE_ENVIRONMENT_PATH
   NO_SYSTEM_ENVIRONMENT_PATH


### PR DESCRIPTION
See #56200 for initial motivation.

This PR changes the `ZephyrBuildConfiguration` search mechanism to ignore the default search path if `ZephyrBuildConfiguration_ROOT` is set. This prevents the arbitrary detection of unrelated `ZephyrBuildConfig.cmake` files in case the user explicitly specified a `ZephyrBuildConfiguration_ROOT` and there was no `ZephyrBuildConfig.cmake` file found there.

This should probably not be merged with only one commit. It's a change in behavior and should be documented at least somewhat, even though the actual behavior in this case is currently not explicitly specified in the documentation [Zephyr Build Configuration CMake package](https://docs.zephyrproject.org/latest/build/zephyr_cmake_package.html#zephyr-build-configuration-cmake-package).

Happy to hear feedback.

Fixes #56200 