### PR TITLE
sys: lists: Add list functions to compute list length

### DIFF
--- a/include/zephyr/sys/dlist.h
+++ b/include/zephyr/sys/dlist.h
@@ -525,6 +525,24 @@ static inline sys_dnode_t *sys_dlist_get(sys_dlist_t *list)
 	return node;
 }
 
+/**
+ * @brief Compute the size of the given list in O(n) time
+ *
+ * @param list A pointer on the list
+ *
+ * @return an integer equal to the size of the list, or 0 if empty
+ */
+static inline size_t sys_dlist_len(sys_dlist_t *list)
+{
+	size_t len = 0;
+	sys_dnode_t *node = NULL;
+
+	SYS_DLIST_FOR_EACH_NODE(list, node) {
+		len++;
+	}
+	return len;
+}
+
 /** @} */
 
 #ifdef __cplusplus

--- a/include/zephyr/sys/list_gen.h
+++ b/include/zephyr/sys/list_gen.h
@@ -234,4 +234,15 @@
 		return false;						 \
 	}
 
+#define Z_GENLIST_LEN(__lname, __nname)                                                            \
+	static inline size_t sys_##__lname##_len(sys_##__lname##_t * list)                         \
+	{                                                                                          \
+		size_t len = 0;                                                                    \
+		static sys_##__nname##_t * node;                                                   \
+		Z_GENLIST_FOR_EACH_NODE(__lname, list, node) {                                     \
+			len++;                                                                     \
+		}                                                                                  \
+		return len;                                                                        \
+	}
+
 #endif /* ZEPHYR_INCLUDE_SYS_LIST_GEN_H_ */

--- a/include/zephyr/sys/sflist.h
+++ b/include/zephyr/sys/sflist.h
@@ -477,6 +477,17 @@ static inline bool sys_sflist_find_and_remove(sys_sflist_t *list,
 
 Z_GENLIST_FIND_AND_REMOVE(sflist, sfnode)
 
+/**
+ * @brief Compute the size of the given list in O(n) time
+ *
+ * @param list A pointer on the list
+ *
+ * @return an integer equal to the size of the list, or 0 if empty
+ */
+static inline size_t sys_sflist_len(sys_sflist_t *list);
+
+Z_GENLIST_LEN(sflist, sfnode)
+
 /** @} */
 
 #ifdef __cplusplus

--- a/include/zephyr/sys/slist.h
+++ b/include/zephyr/sys/slist.h
@@ -413,6 +413,17 @@ Z_GENLIST_REMOVE(slist, snode)
 static inline bool sys_slist_find_and_remove(sys_slist_t *list,
 					     sys_snode_t *node);
 
+/**
+ * @brief Compute the size of the given list in O(n) time
+ *
+ * @param list A pointer on the list
+ *
+ * @return an integer equal to the size of the list, or 0 if empty
+ */
+static inline size_t sys_slist_len(sys_slist_t *list);
+
+Z_GENLIST_LEN(slist, snode)
+
 /** @} */
 Z_GENLIST_FIND_AND_REMOVE(slist, snode)
 

--- a/tests/unit/list/dlist.c
+++ b/tests/unit/list/dlist.c
@@ -39,6 +39,10 @@ static inline bool verify_emptyness(sys_dlist_t *list)
 		return false;
 	}
 
+	if (sys_dlist_len(list) != 0) {
+		return false;
+	}
+
 	count = 0;
 	SYS_DLIST_FOR_EACH_NODE(list, node) {
 		count++;
@@ -94,6 +98,10 @@ static inline bool verify_content_amount(sys_dlist_t *list, int amount)
 	}
 
 	if (!sys_dlist_peek_tail(list)) {
+		return false;
+	}
+
+	if (sys_dlist_len(list) != amount) {
 		return false;
 	}
 

--- a/tests/unit/list/sflist.c
+++ b/tests/unit/list/sflist.c
@@ -40,6 +40,10 @@ static inline bool verify_emptyness(sys_sflist_t *list)
 		return false;
 	}
 
+	if (sys_sflist_len(list) != 0) {
+		return false;
+	}
+
 	count = 0;
 	SYS_SFLIST_FOR_EACH_NODE(list, node) {
 		count++;
@@ -95,6 +99,10 @@ static inline bool verify_content_amount(sys_sflist_t *list, int amount)
 	}
 
 	if (!sys_sflist_peek_tail(list)) {
+		return false;
+	}
+
+	if (sys_sflist_len(list) != amount) {
 		return false;
 	}
 

--- a/tests/unit/list/slist.c
+++ b/tests/unit/list/slist.c
@@ -40,6 +40,10 @@ static inline bool verify_emptyness(sys_slist_t *list)
 		return false;
 	}
 
+	if (sys_slist_len(list) != 0) {
+		return false;
+	}
+
 	count = 0;
 	SYS_SLIST_FOR_EACH_NODE(list, node) {
 		count++;
@@ -95,6 +99,10 @@ static inline bool verify_content_amount(sys_slist_t *list, int amount)
 	}
 
 	if (!sys_slist_peek_tail(list)) {
+		return false;
+	}
+
+	if (sys_slist_len(list) != amount) {
 		return false;
 	}
 


### PR DESCRIPTION
Many parts of zephyr regularly need to compute the length of various lists, as indicated in #42775
This commit adds functions to slist, sflist, and dlist to return the length of provided lists, which will allow future commits to refactor code that implements this manually. The commit also adds tests for these APIs to the corresponding test cases. It is noted that the test functions calculate equivalent values manually using several different internal list functions. This has been left unmodified to ensure that each of the various ways to traverse the list compute the same value as the new list_len() functions.

The new functions all take a reference to any node in the list and compute the length of the entire list. If the list is empty, they return 0.