### PR TITLE
ci: Use EnricoMi/publish-unit-test-result-action@v2

### DIFF
--- a/.github/workflows/bsim-tests-publish.yaml
+++ b/.github/workflows/bsim-tests-publish.yaml
@@ -18,7 +18,7 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
 
       - name: Publish BabbleSim Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           check_name: BabbleSim Test Results
           comment_mode: off

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -152,10 +152,9 @@ jobs:
             junit-clang.html
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           check_name: Unit Test Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           files: "**/twister.xml"
           comment_mode: off

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -322,9 +322,8 @@ jobs:
             junit.html
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           check_name: Unit Test Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           files: "**/twister.xml"
           comment_mode: off


### PR DESCRIPTION
This commit updates the CI workflows to use the
publish-unit-test-result-action v2, which uses the up-to-date GitHub commands, in preparation for the upcoming removal of the deprecated GitHub features.

---

Partially fixes https://github.com/zephyrproject-rtos/zephyr/issues/56613

NOTE: These patches have been submitted as separate PRs to make it easier to automatically backport them.