### PR TITLE
ci: stale_issue: Use actions/stale@v8

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -9,9 +9,8 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v8
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This pull request has been marked as stale because it has been open (more
           than) 60 days with no activity. Remove the stale label or add a comment saying that you
           would like to have the label removed otherwise this pull request will automatically be


### PR DESCRIPTION
This commit updates the stale issue workflow to use the stale action v8, which is based on node.js 16 and @actions/core 1.10.0, in preparation for the upcoming removal of the deprecated GitHub features.

---

Partially fixes https://github.com/zephyrproject-rtos/zephyr/issues/56613

NOTE: These patches have been submitted as separate PRs to make it easier to automatically backport them.