### PR TITLE
ci: Use aws-actions/configure-aws-credentials@v2

### DIFF
--- a/.github/workflows/bug_snapshot.yaml
+++ b/.github/workflows/bug_snapshot.yaml
@@ -42,7 +42,7 @@ jobs:
         echo "BUGS_PICKLE_PATH=${BUGS_PICKLE_PATH}" >> ${GITHUB_ENV}
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.AWS_BUILDS_ZEPHYR_BUG_SNAPSHOT_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_BUILDS_ZEPHYR_BUG_SNAPSHOT_SECRET_ACCESS_KEY }}

--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TESTING }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TESTING }}

--- a/.github/workflows/doc-publish-pr.yml
+++ b/.github/workflows/doc-publish-pr.yml
@@ -48,7 +48,7 @@ jobs:
         tar xf html-output/html-output.tar.xz -C html-output
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.AWS_BUILDS_ZEPHYR_PR_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_BUILDS_ZEPHYR_PR_SECRET_ACCESS_KEY }}

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -34,7 +34,7 @@ jobs:
         tar xf html-output/html-output.tar.xz -C html-output
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -58,7 +58,7 @@ jobs:
           west update 2>&1 1> west.update.log || west update 2>&1 1> west.update2.log
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.FOOTPRINT_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.FOOTPRINT_AWS_ACCESS_KEY }}

--- a/.github/workflows/issue_count.yml
+++ b/.github/workflows/issue_count.yml
@@ -42,7 +42,7 @@ jobs:
         path: ${{ env.OUTPUT_FILE_NAME }}
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TESTING }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TESTING }}


### PR DESCRIPTION
This commit updates the CI workflows to use the AWS configure-aws-credentials action v2, which is based on node.js 16 and @actions/core 1.10.0, in preparation for the upcoming removal of the deprecated GitHub features.

---

Partially fixes https://github.com/zephyrproject-rtos/zephyr/issues/56613

NOTE: These patches have been submitted as separate PRs to make it easier to automatically backport them.