### PR TITLE
ci: Use carpentries/actions/check-valid-pr@v0.14.0

### DIFF
--- a/.github/workflows/doc-publish-pr.yml
+++ b/.github/workflows/doc-publish-pr.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Check PR number
       id: check-pr
-      uses: carpentries/actions/check-valid-pr@v0.8
+      uses: carpentries/actions/check-valid-pr@v0.14.0
       with:
         pr: ${{ env.PR_NUM }}
         sha: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
This commit updates the CI workflows to use the check-valid-pr action v0.14.0, which uses the up-to-date GitHub commands, in preparation for the upcoming removal of the deprecated GitHub features.

---

Partially fixes https://github.com/zephyrproject-rtos/zephyr/issues/56613

NOTE: These patches have been submitted as separate PRs to make it easier to automatically backport them.