### PR TITLE
ci: codecov: Use codecov/codecov-action@v3

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           directory: ./coverage/reports
           env_vars: OS,PYTHON


### PR DESCRIPTION
This commit updates the CI workflows to use the codecov-action v3, which is based on node.js 16 and @actions/core 1.10.0, in preparation for the upcoming removal of the deprecated GitHub features.

---

Partially fixes https://github.com/zephyrproject-rtos/zephyr/issues/56613

NOTE: These patches have been submitted as separate PRs to make it easier to automatically backport them.