### PR TITLE
drivers: sensor: qdec_nrfx: Typo fix from trigger work.

### DIFF
--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -140,7 +140,7 @@ static int qdec_nrfx_trigger_set(const struct device *dev,
 static void qdec_nrfx_event_handler(nrfx_qdec_event_t event)
 {
 	sensor_trigger_handler_t handler;
-	const struct sensor_trigger *trig,
+	const struct sensor_trigger *trig;
 	unsigned int key;
 
 	switch (event.type) {


### PR DESCRIPTION
Fix a typo introduced during move to store pointer to the user supplied trigger.

Minor fix for https://github.com/zephyrproject-rtos/zephyr/commit/6836d03dc097b3bcb0ea3d9171a7224e09ffec1b