### PR TITLE
docs: emulator: expands documentation

### DIFF
--- a/doc/hardware/emulator/adc_emul.rst
+++ b/doc/hardware/emulator/adc_emul.rst
@@ -1,0 +1,26 @@
+.. _adc_emul_api:
+
+
+ADC Emulator
+###################################
+
+Overview
+********
+The Analog-to-Digital Converter (ADC) emulator provides the ability to
+programmatically set the value reported by the ADC driver to assist in
+testing without access to the real hardware.
+
+Configuration Options
+*********************
+
+Related configuration options:
+
+* :kconfig:option:`CONFIG_ADC`
+* :kconfig:option:`CONFIG_ADC_EMUL`
+* :kconfig:option:`CONFIG_ADC_EMUL_ACQUISITION_THREAD_PRIO`
+* :kconfig:option:`CONFIG_ADC_EMUL_ACQUISITION_THREAD_STACK_SIZE`
+
+API Reference
+*************
+
+.. doxygengroup:: adc_emul_interface

--- a/doc/hardware/emulator/can_emul.rst
+++ b/doc/hardware/emulator/can_emul.rst
@@ -1,0 +1,19 @@
+.. _can_emul_api:
+
+
+CAN Loopback Driver
+###################################
+
+Overview
+********
+The Controller Area Network (CAN) loopback driver provides the ability to
+receive to previously sent messages to assist in testing without access to the
+real hardware.
+
+Configuration Options
+*********************
+
+Related configuration options:
+
+* :kconfig:option:`CONFIG_CAN`
+* :kconfig:option:`CONFIG_CAN_LOOPBACK`

--- a/doc/hardware/emulator/eeprom_emul.rst
+++ b/doc/hardware/emulator/eeprom_emul.rst
@@ -1,0 +1,19 @@
+.. _eeprom_emul_api:
+
+
+EEPROM Emulator
+###################################
+
+Overview
+********
+The EEPROM emulator provides the ability to simulate non-volatile ROM by storing
+the EEPROM content in a file that can be queried to assist in testing without
+access to the real hardware.
+
+Configuration Options
+*********************
+
+Related configuration options:
+
+* :kconfig:option:`CONFIG_EEPROM`
+* :kconfig:option:`CONFIG_EEPROM_EMULATOR`

--- a/doc/hardware/emulator/espi_emul.rst
+++ b/doc/hardware/emulator/espi_emul.rst
@@ -1,0 +1,24 @@
+.. _espi_emul_api:
+
+
+eSPI Emulator
+###################################
+
+Overview
+********
+The eSPI emulator provides the ability to pose as an eSPI device allowing the
+creation of mocks and simulators to assist in testing without access to the
+real hardware.
+
+Configuration Options
+*********************
+
+Related configuration options:
+
+* :kconfig:option:`CONFIG_ESPI`
+* :kconfig:option:`CONFIG_ESPI_EMUL`
+
+API Reference
+*************
+
+.. doxygengroup:: espi_emul_interface

--- a/doc/hardware/emulator/flash_emul.rst
+++ b/doc/hardware/emulator/flash_emul.rst
@@ -1,0 +1,24 @@
+.. _flash_emul_api:
+
+
+Flash Simulator
+###################################
+
+Overview
+********
+The Flash simulator provides the ability to simulate flash storage by creating
+a mock software flash that can be queried to assist in testing without access
+to the real hardware.
+
+Configuration Options
+*********************
+
+Related configuration options:
+
+* :kconfig:option:`CONFIG_FLASH`
+* :kconfig:option:`CONFIG_FLASH_SIMULATOR`
+
+API Reference
+*************
+
+.. doxygengroup:: flash_emul_interface

--- a/doc/hardware/emulator/gpio_emul.rst
+++ b/doc/hardware/emulator/gpio_emul.rst
@@ -1,0 +1,27 @@
+.. _gpio_emul_api:
+
+
+GPIO Emulator
+###################################
+
+Overview
+********
+The General-Purpose Input/Output (GPIO) emulator provides the ability to
+programmatically set the value reported by the GPIO driver to assist in
+testing without access to the real hardware. This includes triggering
+interrupts tied to a GIPO pin or port.
+
+
+Configuration Options
+*********************
+
+Related configuration options:
+
+* :kconfig:option:`CONFIG_GPIO`
+* :kconfig:option:`CONFIG_GPIO_EMUL`
+* :kconfig:option:`CONFIG_GPIO_EMUL_SDL`
+
+API Reference
+*************
+
+.. doxygengroup:: gpio_emul_interface

--- a/doc/hardware/emulator/i2c_emul.rst
+++ b/doc/hardware/emulator/i2c_emul.rst
@@ -1,0 +1,24 @@
+.. _i2c_emul_api:
+
+
+I2C Emulator
+###################################
+
+Overview
+********
+The I2C emulator provides the ability to pose as an I2C device allowing the
+creation of mocks and simulators to assist in testing without access to the
+real hardware.
+
+Configuration Options
+*********************
+
+Related configuration options:
+
+* :kconfig:option:`CONFIG_I2C`
+* :kconfig:option:`CONFIG_I2C_EMUL`
+
+API Reference
+*************
+
+.. doxygengroup:: i2c_emul_interface

--- a/doc/hardware/emulator/index.rst
+++ b/doc/hardware/emulator/index.rst
@@ -141,19 +141,18 @@ Available Emulators
 
 Zephyr includes the following emulators:
 
-* EEPROM, which uses a file as the EEPROM contents
+.. toctree::
+   :maxdepth: 1
 
-* I2C emulator driver, allowing drivers to be connected to an emulator so that
-  tests can be performed without access to the real hardware
-
-* SPI emulator driver, which does the same for SPI
-
-* eSPI emulator driver, which does the same for eSPI. The emulator is being
-  developed to support more functionalities.
-
-* CAN loopback driver
-
-A GPIO emulator is planned but is not yet complete.
+   adc_emul.rst
+   can_emul.rst
+   eeprom_emul.rst
+   espi_emul.rst
+   flash_emul.rst
+   gpio_emul.rst
+   i2c_emul.rst
+   spi_emul.rst
+   uart_emul.rst
 
 Samples
 =======

--- a/doc/hardware/emulator/spi_emul.rst
+++ b/doc/hardware/emulator/spi_emul.rst
@@ -1,0 +1,24 @@
+.. _spi_emul_api:
+
+
+SPI Emulator
+###################################
+
+Overview
+********
+The SPI emulator provides the ability to pose as an SPI device allowing the
+creation of mocks and simulators to assist in testing without access to the
+real hardware.
+
+Configuration Options
+*********************
+
+Related configuration options:
+
+* :kconfig:option:`CONFIG_SPI`
+* :kconfig:option:`CONFIG_SPI_EMUL`
+
+API Reference
+*************
+
+.. doxygengroup:: spi_emul_interface

--- a/doc/hardware/emulator/uart_emul.rst
+++ b/doc/hardware/emulator/uart_emul.rst
@@ -1,0 +1,24 @@
+.. _uart_emul_api:
+
+
+UART Emulator
+###################################
+
+Overview
+********
+The UART emulator provides the ability to programmatically set both RX and TX
+data of an UART device to assist in testing without access to the real
+hardware.
+
+Configuration Options
+*********************
+
+Related configuration options:
+
+* :kconfig:option:`CONFIG_UART`
+* :kconfig:option:`CONFIG_UART_EMUL`
+
+API Reference
+*************
+
+.. doxygengroup:: uart_emul_interface

--- a/include/zephyr/drivers/adc/adc_emul.h
+++ b/include/zephyr/drivers/adc/adc_emul.h
@@ -21,7 +21,7 @@ extern "C" {
 
 /**
  * @brief Emulated ADC backend API
- * @defgroup adc_emul Emulated ADC
+ * @defgroup adc_emul_interface Emulated ADC Interface
  * @ingroup adc_interface
  * @{
  *

--- a/include/zephyr/drivers/flash/flash_simulator.h
+++ b/include/zephyr/drivers/flash/flash_simulator.h
@@ -6,15 +6,22 @@
 #ifndef __ZEPHYR_INCLUDE_DRIVERS__FLASH_SIMULATOR_H__
 #define __ZEPHYR_INCLUDE_DRIVERS__FLASH_SIMULATOR_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * @file
  * @brief Flash simulator specific API.
  *
  * Extension for flash simulator.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Flash Emulation Interface
+ * @defgroup flash_emul_interface flash Emulation Interface
+ * @ingroup io_interfaces
+ * @{
  */
 
 /**
@@ -30,6 +37,12 @@ extern "C" {
  */
 __syscall void *flash_simulator_get_memory(const struct device *dev,
 					   size_t *mock_size);
+
+
+/**
+ * @}
+ */
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/drivers/gpio/gpio_emul.h
+++ b/include/zephyr/drivers/gpio/gpio_emul.h
@@ -21,7 +21,7 @@ extern "C" {
 
 /**
  * @brief Emulated GPIO backend API
- * @defgroup gpio_emul Emulated GPIO
+ * @defgroup gpio_emul_interface Emulated GPIO Interface
  * @ingroup gpio_interface
  * @{
  *

--- a/include/zephyr/drivers/serial/uart_emul.h
+++ b/include/zephyr/drivers/serial/uart_emul.h
@@ -19,6 +19,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief UART Emulation Interface
+ * @defgroup uart_emul_interface UART Emulation Interface
+ * @ingroup io_interfaces
+ * @{
+ */
+
+/**
  * @brief Define the application callback function signature for
  * uart_emul_callback_tx_data_ready_set() function.
  *
@@ -81,6 +88,10 @@ uint32_t uart_emul_flush_rx_data(const struct device *dev);
  * @return Number of cleared bytes
  */
 uint32_t uart_emul_flush_tx_data(const struct device *dev);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The emulators are a bit hidden so this change makes them more visible.

- Adds docs for each emulator, displaying their API if they have one.
- Modifies header files of some the emulators to enforce consistent doxygen grouping names.
- Updates the index.rst to include the new emulator files docs.

If there is interest in this change, I would happily add more information to each emulator file.
