### PR TITLE
boards: 96b_carbon: fix gpio for Bluetooth LED

### DIFF
--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -32,7 +32,7 @@
 			label = "USR2 LED";
 		};
 		bt_blue_led: led_3 {
-			gpios = <&gpioa 15 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
 			label = "BT LED";
 		};
 	};


### PR DESCRIPTION
According to the schematic, the Bluetooth LED should be on GPIOB 5:
https://github.com/96boards/documentation/blob/master/iot/carbon/hardware-docs/Carbon_Schematics.pdf

Tested by modifying the blinky sample to use that LED.