### PR TITLE
Move adc dt bindings include

### DIFF
--- a/boards/arm/tdk_robokit1/tdk_robokit1-common.dtsi
+++ b/boards/arm/tdk_robokit1/tdk_robokit1-common.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include "tdk_robokit1-pinctrl.dtsi"
 #include "tdk_robokit1-thermistor.dtsi"
 

--- a/boards/posix/native_posix/native_posix.dts
+++ b/boards/posix/native_posix/native_posix.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <posix/posix.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
@@ -209,5 +210,12 @@
 		status = "okay";
 		compatible = "zephyr,rtc-emul";
 		alarms-count = <2>;
+	};
+
+	adc0: adc {
+		compatible = "zephyr,adc-emul";
+		nchannels = <2>;
+		#io-channel-cells = <1>;
+		status = "okay";
 	};
 };

--- a/drivers/adc/adc_emul.c
+++ b/drivers/adc/adc_emul.c
@@ -574,6 +574,6 @@ static int adc_emul_init(const struct device *dev)
 			      &adc_emul_data_##_num,			\
 			      &adc_emul_config_##_num, POST_KERNEL,	\
 			      CONFIG_ADC_INIT_PRIORITY,			\
-			      &adc_emul_api_##_num)
+			      &adc_emul_api_##_num);
 
-DT_INST_FOREACH_STATUS_OKAY(ADC_EMUL_INIT);
+DT_INST_FOREACH_STATUS_OKAY(ADC_EMUL_INIT)

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/clock/atmel_sam_pmc.h>

--- a/dts/arm/atmel/samc2x.dtsi
+++ b/dts/arm/atmel/samc2x.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <arm/armv6-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>

--- a/dts/arm/atmel/samd2x.dtsi
+++ b/dts/arm/atmel/samd2x.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <arm/armv6-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -6,6 +6,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>

--- a/dts/arm/atmel/saml2x.dtsi
+++ b/dts/arm/atmel/saml2x.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <arm/armv6-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>

--- a/dts/arm/gigadevice/gd32a50x/gd32a50x.dtsi
+++ b/dts/arm/gigadevice/gd32a50x/gd32a50x.dtsi
@@ -6,6 +6,7 @@
 
 #include <freq.h>
 #include <arm/armv8-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>

--- a/dts/arm/gigadevice/gd32f3x0/gd32f3x0.dtsi
+++ b/dts/arm/gigadevice/gd32f3x0/gd32f3x0.dtsi
@@ -6,6 +6,7 @@
 
 #include <freq.h>
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/adc/gd32f3x0.h>
 #include <zephyr/dt-bindings/clock/gd32f3x0-clocks.h>

--- a/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
+++ b/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
@@ -7,6 +7,7 @@
 
 #include <freq.h>
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/clock/gd32f403-clocks.h>

--- a/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>

--- a/dts/arm/gigadevice/gd32l23x/gd32l23x.dtsi
+++ b/dts/arm/gigadevice/gd32l23x/gd32l23x.dtsi
@@ -6,6 +6,7 @@
 
 #include <freq.h>
 #include <arm/armv8-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/clock/gd32l23x-clocks.h>
 #include <zephyr/dt-bindings/reset/gd32l23x.h>

--- a/dts/arm/infineon/xmc4xxx.dtsi
+++ b/dts/arm/infineon/xmc4xxx.dtsi
@@ -6,6 +6,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/gpio/infineon-xmc4xxx-gpio.h>
 

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/mchp_xec_pcr.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/mchp_xec_pcr.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/gpio/microchip-xec-gpio.h>

--- a/dts/arm/nuvoton/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx.dtsi
@@ -7,6 +7,7 @@
 #include <arm/armv7-m.dtsi>
 
 /* Macros for device tree declarations of npcx soc family */
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/npcx_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <zephyr/dt-bindings/clock/kinetis_mcg.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -2,6 +2,7 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <zephyr/dt-bindings/clock/kinetis_mcg.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_mcg.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_pcc.h>
 #include <zephyr/dt-bindings/clock/kinetis_scg.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -2,6 +2,7 @@
 
 #include <mem.h>
 #include "armv6-m.dtsi"
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <zephyr/dt-bindings/clock/kinetis_mcg.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <zephyr/dt-bindings/clock/kinetis_mcg.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -2,6 +2,7 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <zephyr/dt-bindings/clock/kinetis_mcg.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -2,6 +2,7 @@
 
 #include <mem.h>
 #include "armv6-m.dtsi"
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <zephyr/dt-bindings/clock/kinetis_mcg.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <arm/armv6-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/kinetis_sim.h>
 #include <zephyr/dt-bindings/clock/kinetis_mcg.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv8-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv8-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <mem.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/imx_ccm.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <arm/armv8-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -6,6 +6,7 @@
 
 #include <mem.h>
 #include <arm/armv8-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv6-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/regulator/rpi_pico.h>

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv6-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/stm32c0_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -7,6 +7,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/stm32f4_clock.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -6,6 +6,7 @@
 
 
 #include <arm/armv8-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/clock/stm32h5_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/reset/stm32h5_reset.h>

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -7,6 +7,7 @@
 
 
 #include <arm/armv8-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/clock/stm32u5_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>

--- a/dts/arm/ti/cc13x2_cc26x2.dtsi
+++ b/dts/arm/ti/cc13x2_cc26x2.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 

--- a/dts/arm/ti/cc32xx.dtsi
+++ b/dts/arm/ti/cc32xx.dtsi
@@ -2,6 +2,7 @@
 
 #include <arm/armv7-m.dtsi>
 
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <mem.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/interrupt-controller/esp-esp32c3-intmux.h>

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <freq.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/timer/nuclei-systimer.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -7,6 +7,7 @@
 
 #include <mem.h>
 #include <zephyr/dt-bindings/dt-util.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/interrupt-controller/ite-intc.h>
 #include <zephyr/dt-bindings/interrupt-controller/it8xxx2-wuc.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -5,6 +5,7 @@
  */
 #include <mem.h>
 #include <xtensa/xtensa.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/esp32_clock.h>

--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -5,6 +5,7 @@
  */
 #include <mem.h>
 #include <xtensa/xtensa.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/clock/esp32s2_clock.h>

--- a/samples/drivers/adc/boards/atsamc21n_xpro.overlay
+++ b/samples/drivers/adc/boards/atsamc21n_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 Argentum Systems Ltd.
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* EXT-1, pin 3 ADC(+) */

--- a/samples/drivers/adc/boards/atsamd21_xpro.overlay
+++ b/samples/drivers/adc/boards/atsamd21_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 Argentum Systems Ltd.
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* EXT-1, pin 3 ADC(+) */

--- a/samples/drivers/adc/boards/atsame54_xpro.overlay
+++ b/samples/drivers/adc/boards/atsame54_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 Gerson Fernando Budke <nandojve@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* EXT-1 ADC(+) */

--- a/samples/drivers/adc/boards/atsaml21_xpro.overlay
+++ b/samples/drivers/adc/boards/atsaml21_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 Argentum Systems Ltd.
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* EXT-1, pin 3 ADC(+) */

--- a/samples/drivers/adc/boards/atsamr21_xpro.overlay
+++ b/samples/drivers/adc/boards/atsamr21_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 Gerson Fernando Budke <nandojve@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* EXT-1 ADC(+) */

--- a/samples/drivers/adc/boards/atsamr34_xpro.overlay
+++ b/samples/drivers/adc/boards/atsamr34_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 Argentum Systems Ltd.
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* EXT-1, pin 3 ADC(+) */

--- a/samples/drivers/adc/boards/cc1352r1_launchxl.overlay
+++ b/samples/drivers/adc/boards/cc1352r1_launchxl.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* 0x5 is ADC_COMPB_IN_VDDS (power supply measurement) */

--- a/samples/drivers/adc/boards/cc1352r_sensortag.overlay
+++ b/samples/drivers/adc/boards/cc1352r_sensortag.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* 0x5 is ADC_COMPB_IN_VDDS (power supply measurement) */

--- a/samples/drivers/adc/boards/cc26x2r1_launchxl.overlay
+++ b/samples/drivers/adc/boards/cc26x2r1_launchxl.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* 0x5 is ADC_COMPB_IN_VDDS (power supply measurement) */

--- a/samples/drivers/adc/boards/cc3220sf_launchxl.overlay
+++ b/samples/drivers/adc/boards/cc3220sf_launchxl.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 Pavlo Hamov <pasha.gamov@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/cc3235sf_launchxl.overlay
+++ b/samples/drivers/adc/boards/cc3235sf_launchxl.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 Pavlo Hamov <pasha.gamov@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/disco_l475_iot1.overlay
+++ b/samples/drivers/adc/boards/disco_l475_iot1.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2020 Linaro Limited
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/esp32.overlay
+++ b/samples/drivers/adc/boards/esp32.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels =

--- a/samples/drivers/adc/boards/esp32c3_devkitm.overlay
+++ b/samples/drivers/adc/boards/esp32c3_devkitm.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels =

--- a/samples/drivers/adc/boards/esp32s2_saola.overlay
+++ b/samples/drivers/adc/boards/esp32s2_saola.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels =

--- a/samples/drivers/adc/boards/frdm_k64f.overlay
+++ b/samples/drivers/adc/boards/frdm_k64f.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2022 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/gd32a503v_eval.overlay
+++ b/samples/drivers/adc/boards/gd32a503v_eval.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 YuLong Yao <feilongphone@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/gd32f350r_eval.overlay
+++ b/samples/drivers/adc/boards/gd32f350r_eval.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2022 BrainCo Inc.
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
  / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/gd32f403z_eval.overlay
+++ b/samples/drivers/adc/boards/gd32f403z_eval.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2022 BrainCo Inc.
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/gd32f450i_eval.overlay
+++ b/samples/drivers/adc/boards/gd32f450i_eval.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2022 BrainCo Inc.
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/gd32l233r_eval.overlay
+++ b/samples/drivers/adc/boards/gd32l233r_eval.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2022 BrainCo Inc.
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
  / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/gd32vf103v_eval.overlay
+++ b/samples/drivers/adc/boards/gd32vf103v_eval.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2022 BrainCo Inc.
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
  / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/lpcxpresso55s36.overlay
+++ b/samples/drivers/adc/boards/lpcxpresso55s36.overlay
@@ -4,7 +4,6 @@
  * Copyright 2023 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/samples/drivers/adc/boards/lpcxpresso55s69_cpu0.overlay
+++ b/samples/drivers/adc/boards/lpcxpresso55s69_cpu0.overlay
@@ -4,7 +4,6 @@
  * Copyright 2022-2023 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/samples/drivers/adc/boards/mimxrt1010_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1010_evk.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/mimxrt1015_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1015_evk.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/mimxrt1020_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1020_evk.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/mimxrt1024_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1024_evk.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/mimxrt1050_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1050_evk.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2020 Linaro Limited
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/mimxrt1060_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1060_evk.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/mimxrt1064_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1064_evk.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/mimxrt1160_evk_cm7.overlay
+++ b/samples/drivers/adc/boards/mimxrt1160_evk_cm7.overlay
@@ -4,7 +4,6 @@
  * Copyright 2021,2023 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/samples/drivers/adc/boards/mimxrt1170_evk_cm7.overlay
+++ b/samples/drivers/adc/boards/mimxrt1170_evk_cm7.overlay
@@ -5,7 +5,6 @@
  * Copyright 2023 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/samples/drivers/adc/boards/mimxrt595_evk_cm33.overlay
+++ b/samples/drivers/adc/boards/mimxrt595_evk_cm33.overlay
@@ -5,7 +5,6 @@
  * Copyright 2023 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/samples/drivers/adc/boards/mimxrt685_evk_cm33.overlay
+++ b/samples/drivers/adc/boards/mimxrt685_evk_cm33.overlay
@@ -5,7 +5,6 @@
  * Copyright 2023 NXP
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/samples/drivers/adc/boards/nucleo_c031c6.overlay
+++ b/samples/drivers/adc/boards/nucleo_c031c6.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
  / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/nucleo_h7a3zi_q.overlay
+++ b/samples/drivers/adc/boards/nucleo_h7a3zi_q.overlay
@@ -1,8 +1,6 @@
 /* Copyright (c) 2021 STMicroelectronics
    SPDX-License-Identifier: Apache-2.0 */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
  / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/nucleo_l073rz.overlay
+++ b/samples/drivers/adc/boards/nucleo_l073rz.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2020 Libre Solar Technologies GmbH
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/nucleo_l552ze_q.overlay
+++ b/samples/drivers/adc/boards/nucleo_l552ze_q.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 STMicroelectronics
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/nucleo_u575zi_q.overlay
+++ b/samples/drivers/adc/boards/nucleo_u575zi_q.overlay
@@ -1,8 +1,6 @@
 /* Copyright (c) 2022 STMicroelectronics
    SPDX-License-Identifier: Apache-2.0 */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
  / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/nucleo_wl55jc.overlay
+++ b/samples/drivers/adc/boards/nucleo_wl55jc.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2022 QRTECH
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/rpi_pico.overlay
+++ b/samples/drivers/adc/boards/rpi_pico.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc 0>;

--- a/samples/drivers/adc/boards/sam4e_xpro.overlay
+++ b/samples/drivers/adc/boards/sam4e_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023, Gerson Fernando Budke
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/sam4s_xplained.overlay
+++ b/samples/drivers/adc/boards/sam4s_xplained.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2022, Basalte bv
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/sam_e70_xplained.overlay
+++ b/samples/drivers/adc/boards/sam_e70_xplained.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2022, Gerson Fernando Budke
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/sam_v71_xult.overlay
+++ b/samples/drivers/adc/boards/sam_v71_xult.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2022, Gerson Fernando Budke
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/stm32h573i_dk.overlay
+++ b/samples/drivers/adc/boards/stm32h573i_dk.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
  / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/stm32h735g_disco.overlay
+++ b/samples/drivers/adc/boards/stm32h735g_disco.overlay
@@ -1,8 +1,6 @@
 /* Copyright (c) 2021 STMicroelectronics
    SPDX-License-Identifier: Apache-2.0 */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
  / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/stm32l496g_disco.overlay
+++ b/samples/drivers/adc/boards/stm32l496g_disco.overlay
@@ -1,8 +1,6 @@
 /* Copyright (c) 2021 STMicroelectronics
    SPDX-License-Identifier: Apache-2.0 */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
  / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/stm32l562e_dk.overlay
+++ b/samples/drivers/adc/boards/stm32l562e_dk.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2021 STMicroelectronics
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/samples/drivers/adc/boards/tdk_robokit1.overlay
+++ b/samples/drivers/adc/boards/tdk_robokit1.overlay
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/spi/spi.h>
 
 / {

--- a/samples/drivers/adc/boards/xmc45_relax_kit.overlay
+++ b/samples/drivers/adc/boards/xmc45_relax_kit.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2022 Andriy Gelman <andriy.gelman@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>; /* P14.0 */

--- a/tests/drivers/adc/adc_api/boards/96b_aerocore2.overlay
+++ b/tests/drivers/adc/adc_api/boards/96b_aerocore2.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/adafruit_kb2040.overlay
+++ b/tests/drivers/adc/adc_api/boards/adafruit_kb2040.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc 0>, <&adc 1>;

--- a/tests/drivers/adc/adc_api/boards/adafruit_trinket_m0.overlay
+++ b/tests/drivers/adc/adc_api/boards/adafruit_trinket_m0.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1BU
 
 / {

--- a/tests/drivers/adc/adc_api/boards/arduino_mkrzero.overlay
+++ b/tests/drivers/adc/adc_api/boards/arduino_mkrzero.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1BU
 
 / {

--- a/tests/drivers/adc/adc_api/boards/arduino_nano_33_iot.overlay
+++ b/tests/drivers/adc/adc_api/boards/arduino_nano_33_iot.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1BU
 
 / {

--- a/tests/drivers/adc/adc_api/boards/arduino_zero.overlay
+++ b/tests/drivers/adc/adc_api/boards/arduino_zero.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1BU
 
 / {

--- a/tests/drivers/adc/adc_api/boards/atsamc21n_xpro.overlay
+++ b/tests/drivers/adc/adc_api/boards/atsamc21n_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1BU
 
 / {

--- a/tests/drivers/adc/adc_api/boards/atsamd21_xpro.overlay
+++ b/tests/drivers/adc/adc_api/boards/atsamd21_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1BU
 
 / {

--- a/tests/drivers/adc/adc_api/boards/atsame54_xpro.overlay
+++ b/tests/drivers/adc/adc_api/boards/atsame54_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1AU
 
 / {

--- a/tests/drivers/adc/adc_api/boards/atsaml21_xpro.overlay
+++ b/tests/drivers/adc/adc_api/boards/atsaml21_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1BU
 
 / {

--- a/tests/drivers/adc/adc_api/boards/atsamr21_xpro.overlay
+++ b/tests/drivers/adc/adc_api/boards/atsamr21_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1BU
 
 / {

--- a/tests/drivers/adc/adc_api/boards/atsamr34_xpro.overlay
+++ b/tests/drivers/adc/adc_api/boards/atsamr34_xpro.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1BU
 
 / {

--- a/tests/drivers/adc/adc_api/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/adc/adc_api/boards/b_u585i_iot02a.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/blackpill_f401cc.overlay
+++ b/tests/drivers/adc/adc_api/boards/blackpill_f401cc.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/blackpill_f401ce.overlay
+++ b/tests/drivers/adc/adc_api/boards/blackpill_f401ce.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/blackpill_f411ce.overlay
+++ b/tests/drivers/adc/adc_api/boards/blackpill_f411ce.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/cc1352r1_launchxl.overlay
+++ b/tests/drivers/adc/adc_api/boards/cc1352r1_launchxl.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/cc1352r_sensortag.overlay
+++ b/tests/drivers/adc/adc_api/boards/cc1352r_sensortag.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/cc26x2r1_launchxl.overlay
+++ b/tests/drivers/adc/adc_api/boards/cc26x2r1_launchxl.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/cc3220sf_launchxl.overlay
+++ b/tests/drivers/adc/adc_api/boards/cc3220sf_launchxl.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/cc3235sf_launchxl.overlay
+++ b/tests/drivers/adc/adc_api/boards/cc3235sf_launchxl.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/esp32.overlay
+++ b/tests/drivers/adc/adc_api/boards/esp32.overlay
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/esp32c3_devkitm.overlay
+++ b/tests/drivers/adc/adc_api/boards/esp32c3_devkitm.overlay
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/esp32s2_saola.overlay
+++ b/tests/drivers/adc/adc_api/boards/esp32s2_saola.overlay
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/frdm_k22f.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_k22f.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 14>;

--- a/tests/drivers/adc/adc_api/boards/frdm_k64f.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_k64f.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 14>;

--- a/tests/drivers/adc/adc_api/boards/frdm_k82f.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_k82f.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 15>;

--- a/tests/drivers/adc/adc_api/boards/frdm_kl25z.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_kl25z.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 12>;

--- a/tests/drivers/adc/adc_api/boards/frdm_kw41z.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_kw41z.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 3>;

--- a/tests/drivers/adc/adc_api/boards/gd32a503v_eval.overlay
+++ b/tests/drivers/adc/adc_api/boards/gd32a503v_eval.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/hexiwear_k64.overlay
+++ b/tests/drivers/adc/adc_api/boards/hexiwear_k64.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 16>;

--- a/tests/drivers/adc/adc_api/boards/hexiwear_kw40z.overlay
+++ b/tests/drivers/adc/adc_api/boards/hexiwear_kw40z.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 1>;

--- a/tests/drivers/adc/adc_api/boards/it8xxx2_evb.overlay
+++ b/tests/drivers/adc/adc_api/boards/it8xxx2_evb.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>, <&adc0 1>;

--- a/tests/drivers/adc/adc_api/boards/lpcxpresso55s28.overlay
+++ b/tests/drivers/adc/adc_api/boards/lpcxpresso55s28.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/lpcxpresso55s69_cpu0.overlay
+++ b/tests/drivers/adc/adc_api/boards/lpcxpresso55s69_cpu0.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/lpcxpresso55s69_ns.overlay
+++ b/tests/drivers/adc/adc_api/boards/lpcxpresso55s69_ns.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/mec1501modular_assy6885.overlay
+++ b/tests/drivers/adc/adc_api/boards/mec1501modular_assy6885.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 4>, <&adc0 5>;

--- a/tests/drivers/adc/adc_api/boards/mec15xxevb_assy6853.overlay
+++ b/tests/drivers/adc/adc_api/boards/mec15xxevb_assy6853.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 4>, <&adc0 5>;

--- a/tests/drivers/adc/adc_api/boards/mec172xevb_assy6906.overlay
+++ b/tests/drivers/adc/adc_api/boards/mec172xevb_assy6906.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 4>, <&adc0 5>;

--- a/tests/drivers/adc/adc_api/boards/mikroe_clicker_2.overlay
+++ b/tests/drivers/adc/adc_api/boards/mikroe_clicker_2.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/mimxrt1010_evk.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1010_evk.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/mimxrt1015_evk.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1015_evk.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/mimxrt1020_evk.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1020_evk.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/mimxrt1024_evk.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1024_evk.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/mimxrt1050_evk.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1050_evk.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/mimxrt1050_evk_qspi.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1050_evk_qspi.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/mimxrt1060_evk.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1060_evk.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/mimxrt1060_evkb.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1060_evkb.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/mimxrt1064_evk.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1064_evk.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/mimxrt1170_evk_cm7.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1170_evk_cm7.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/mimxrt595_evk_cm33.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt595_evk_cm33.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/mimxrt685_evk_cm33.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt685_evk_cm33.overlay
@@ -4,7 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 / {

--- a/tests/drivers/adc/adc_api/boards/native_posix.overlay
+++ b/tests/drivers/adc/adc_api/boards/native_posix.overlay
@@ -8,18 +8,11 @@
 	zephyr,user {
 		io-channels = <&adc0 0>, <&adc0 1>;
 	};
-
-	adc0: adc {
-		compatible = "zephyr,adc-emul";
-		nchannels = <2>;
-		ref-internal-mv = <3300>;
-		ref-external1-mv = <5000>;
-		#io-channel-cells = <1>;
-		status = "okay";
-	};
 };
 
 &adc0 {
+	ref-internal-mv = <3300>;
+	ref-external1-mv = <5000>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 

--- a/tests/drivers/adc/adc_api/boards/native_posix.overlay
+++ b/tests/drivers/adc/adc_api/boards/native_posix.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>, <&adc0 1>;

--- a/tests/drivers/adc/adc_api/boards/npcx7m6fb_evb.overlay
+++ b/tests/drivers/adc/adc_api/boards/npcx7m6fb_evb.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>, <&adc0 2>;

--- a/tests/drivers/adc/adc_api/boards/npcx9m6f_evb.overlay
+++ b/tests/drivers/adc/adc_api/boards/npcx9m6f_evb.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>, <&adc0 2>;

--- a/tests/drivers/adc/adc_api/boards/nucleo_f401re.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f401re.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f429zi.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/nucleo_h563zi.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_h563zi.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/rpi_pico.overlay
+++ b/tests/drivers/adc/adc_api/boards/rpi_pico.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc 0>, <&adc 1>;

--- a/tests/drivers/adc/adc_api/boards/sam4s_xplained.overlay
+++ b/tests/drivers/adc/adc_api/boards/sam4s_xplained.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 15>;

--- a/tests/drivers/adc/adc_api/boards/sam_e70_xplained.overlay
+++ b/tests/drivers/adc/adc_api/boards/sam_e70_xplained.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&afec0 0>;

--- a/tests/drivers/adc/adc_api/boards/sam_e70b_xplained.overlay
+++ b/tests/drivers/adc/adc_api/boards/sam_e70b_xplained.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&afec0 0>;

--- a/tests/drivers/adc/adc_api/boards/sam_v71_xult.overlay
+++ b/tests/drivers/adc/adc_api/boards/sam_v71_xult.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&afec0 0>;

--- a/tests/drivers/adc/adc_api/boards/sam_v71b_xult.overlay
+++ b/tests/drivers/adc/adc_api/boards/sam_v71b_xult.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&afec0 0>;

--- a/tests/drivers/adc/adc_api/boards/serpente.overlay
+++ b/tests/drivers/adc/adc_api/boards/serpente.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1BU
 
 / {

--- a/tests/drivers/adc/adc_api/boards/sparkfun_pro_micro_rp2040.overlay
+++ b/tests/drivers/adc/adc_api/boards/sparkfun_pro_micro_rp2040.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc 0>, <&adc 1>;

--- a/tests/drivers/adc/adc_api/boards/stm32f401_mini.overlay
+++ b/tests/drivers/adc/adc_api/boards/stm32f401_mini.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/adc/adc_api/boards/stm32h573i_dk.overlay
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_api/boards/twr_ke18f.overlay
+++ b/tests/drivers/adc/adc_api/boards/twr_ke18f.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		io-channels = <&adc0 0>, <&adc0 1>;

--- a/tests/drivers/adc/adc_api/boards/wio_terminal.overlay
+++ b/tests/drivers/adc/adc_api/boards/wio_terminal.overlay
@@ -4,8 +4,6 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 #define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1AU
 
 / {

--- a/tests/drivers/adc/adc_api/boards/xmc45_relax_kit.overlay
+++ b/tests/drivers/adc/adc_api/boards/xmc45_relax_kit.overlay
@@ -1,5 +1,3 @@
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */

--- a/tests/drivers/adc/adc_emul/app.overlay
+++ b/tests/drivers/adc/adc_emul/app.overlay
@@ -4,13 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/ {
-	adc_emulator_test_dev {
-		compatible = "zephyr,adc-emul";
-		nchannels = <2>;
-		ref-internal-mv = <3300>;
-		ref-external1-mv = <5000>;
-		#io-channel-cells = <1>;
-		status = "okay";
-	};
+&adc0 {
+	ref-internal-mv = <3300>;
+	ref-external1-mv = <5000>;
 };

--- a/tests/drivers/build_all/sensor/adc.dtsi
+++ b/tests/drivers/build_all/sensor/adc.dtsi
@@ -14,7 +14,7 @@ test_adc_mcp9700a: mcp9700a {
 	io-channels = <&test_adc 0>;
 };
 
-adc0: adc {
+test_adc_emul: adc {
 	compatible = "zephyr,adc-emul";
 	nchannels = <2>;
 	ref-internal-mv = <3300>;

--- a/tests/drivers/build_all/sensor/adc.dtsi
+++ b/tests/drivers/build_all/sensor/adc.dtsi
@@ -7,8 +7,6 @@
  * Application overlay for ADC devices
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 test_adc_mcp9700a: mcp9700a {
 	status = "okay";
 	compatible = "microchip,mcp970x";

--- a/tests/drivers/build_all/sensor/app.overlay
+++ b/tests/drivers/build_all/sensor/app.overlay
@@ -10,8 +10,6 @@
  * (and be extended to test) real hardware.
  */
 
- #include <zephyr/dt-bindings/adc/adc.h>
-
 / {
 	test {
 		#address-cells = <1>;

--- a/tests/drivers/regulator/voltage/boards/mimxrt685_evk_cm33.overlay
+++ b/tests/drivers/regulator/voltage/boards/mimxrt685_evk_cm33.overlay
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 
 /* RT685 ADC only supports up to 1.8V,

--- a/tests/drivers/regulator/voltage/boards/rpi_pico.overlay
+++ b/tests/drivers/regulator/voltage/boards/rpi_pico.overlay
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/adc/adc.h>
-
 / {
         /* NOTE: It is necessary to connect VREG_OUT to the ADC to perform the test.
 	 * But the rpi_pico board and most boards that use the rp2040, VREG_OUT and


### PR DESCRIPTION
Cleanup of adc dt-bindings includes that were previously distributed among samples and tests.