### PR TITLE
net: fix UDP raw sockets

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1366,11 +1366,7 @@ static int context_setup_udp_packet(struct net_context *context,
 	}
 
 	ret = context_write_data(pkt, buf, len, msg);
-	if (ret) {
-		return ret;
-	}
-
-	return 0;
+	return ret;
 }
 
 static void context_finalize_packet(struct net_context *context,

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1357,15 +1357,17 @@ static int context_setup_udp_packet(struct net_context *context,
 		return ret;
 	}
 
-	ret = net_udp_create(pkt,
-			     net_sin((struct sockaddr *)
-				     &context->local)->sin_port,
-			     dst_port);
-	if (ret) {
-		return ret;
+	if (net_context_get_type(context) != SOCK_RAW) {
+		ret = net_udp_create(pkt,
+				     net_sin((struct sockaddr *)
+					     &context->local)->sin_port,
+				     dst_port);
 	}
 
-	ret = context_write_data(pkt, buf, len, msg);
+	if (ret == 0) {
+		ret = context_write_data(pkt, buf, len, msg);
+	}
+
 	return ret;
 }
 


### PR DESCRIPTION
With `AF_INET`, `SOCK_RAW`, `IPPROTO_UDP`, the network stack should not insert its own UDP header; see `raw(7)`.

I'm not sure if this is the best way to fix this, but it solves my specific problem.