### PR TITLE
samples: stm32: backup_sram: Fix main function return statement

### DIFF
--- a/samples/boards/stm32/backup_sram/src/main.c
+++ b/samples/boards/stm32/backup_sram/src/main.c
@@ -21,7 +21,7 @@ int main(void)
 
 	if (!device_is_ready(dev)) {
 		printk("ERROR: BackUp SRAM device is not ready\n");
-		return;
+		return 0;
 	}
 
 	printk("Current value in backup SRAM (%p): %d\n", &backup_value, backup_value);


### PR DESCRIPTION
The `main` function now returns `int` instead of `void` and therefore any return statements inside it must return a value.

Note that any return values other than 0 are currently reserved.

---

Fixes the `samples/boards/stm32/backup_sram/sample.boards.stm32.backup_sram` build failures seen in the [bi-weekly build](https://github.com/zephyrproject-rtos/zephyr/runs/12768209603).