### PR TITLE
samples/bluetooth/central: fix error code reporting

### DIFF
--- a/samples/bluetooth/central/src/main.c
+++ b/samples/bluetooth/central/src/main.c
@@ -54,7 +54,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN,
 				BT_LE_CONN_PARAM_DEFAULT, &default_conn);
 	if (err) {
-		printk("Create conn to %s failed (%u)\n", addr_str, err);
+		printk("Create conn to %s failed (%d)\n", addr_str, err);
 		start_scan();
 	}
 }


### PR DESCRIPTION
`bt_conn_le_create` returns a signed value. Error message format string expects an unsigned value.

This PR changes the expected value in the format string to a signed one, to match what `bt_conn_le_create` returns.