### PR TITLE
Tests: Bluetooth: Mesh: Add persistent storage test for SAR TX/RX

### DIFF
--- a/tests/bsim/bluetooth/mesh/CMakeLists.txt
+++ b/tests/bsim/bluetooth/mesh/CMakeLists.txt
@@ -36,6 +36,7 @@ if(CONFIG_SETTINGS)
   target_sources(app PRIVATE
    src/test_dfu.c
    src/test_blob.c
+   src/test_sar.c
  )
  endif()
 

--- a/tests/bsim/bluetooth/mesh/src/main.c
+++ b/tests/bsim/bluetooth/mesh/src/main.c
@@ -14,6 +14,7 @@ extern struct bst_test_list *test_provision_pst_install(struct bst_test_list *te
 #if defined(CONFIG_BT_MESH_V1d1)
 extern struct bst_test_list *test_dfu_install(struct bst_test_list *test);
 extern struct bst_test_list *test_blob_pst_install(struct bst_test_list *test);
+extern struct bst_test_list *test_sar_pst_install(struct bst_test_list *test);
 #endif /* defined(CONFIG_BT_MESH_V1d1) */
 #elif defined(CONFIG_BT_MESH_GATT_PROXY)
 extern struct bst_test_list *test_adv_install(struct bst_test_list *test);
@@ -46,6 +47,7 @@ bst_test_install_t test_installers[] = {
 	test_provision_pst_install,
 	test_dfu_install,
 	test_blob_pst_install,
+	test_sar_pst_install,
 #endif /* defined(CONFIG_BT_MESH_V1d1) */
 #elif defined(CONFIG_BT_MESH_GATT_PROXY)
 	test_adv_install,

--- a/tests/bsim/bluetooth/mesh/tests_scripts/sar/sar_cfg_persistent_storage.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/sar/sar_cfg_persistent_storage.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Note:
+# Tests must be added in sequence.
+# First test sets SAR TX/RX configuration.
+# Second test restores it from flash and checks if configuration persisted.
+conf=prj_mesh1d1_conf
+overlay=overlay_pst_conf
+RunTest sar_persistence sar_srv_cfg_store
+RunTest sar_persistence sar_srv_cfg_restore


### PR DESCRIPTION
This tests if SAR RX/TX configuaration is saved in and loaded from persistent storage correctly.