### PR TITLE
samples: drivers: spi_flash_at45: Add missing return statement

### DIFF
--- a/samples/drivers/spi_flash_at45/src/main.c
+++ b/samples/drivers/spi_flash_at45/src/main.c
@@ -159,4 +159,5 @@ int main(void)
 #endif
 
 	k_sleep(K_FOREVER);
+	return 0;
 }


### PR DESCRIPTION
The `main` function now returns `int` instead of `void` and therefore must return a value.