### PR TITLE
drivers: hwinfo: esp32xx: implements get_reset_cause

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -117,7 +117,7 @@ config HWINFO_SAM0
 config HWINFO_ESP32
 	bool "ESP32 device ID"
 	default y
-	depends on SOC_ESP32 || SOC_ESP32C3
+	depends on SOC_FAMILY_ESP32
 	help
 	  Enable ESP32 hwinfo driver.
 

--- a/drivers/hwinfo/hwinfo_esp32.c
+++ b/drivers/hwinfo/hwinfo_esp32.c
@@ -6,13 +6,16 @@
  */
 
 #include <soc/efuse_reg.h>
+#include <soc/reset_reasons.h>
+#include "esp_system.h"
+#include "rtc.h"
 
 #include <zephyr/drivers/hwinfo.h>
 #include <string.h>
 
 ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
-#ifdef CONFIG_SOC_ESP32C3
+#ifndef CONFIG_SOC_ESP32
 	uint32_t rdata1 = sys_read32(EFUSE_RD_MAC_SPI_SYS_0_REG);
 	uint32_t rdata2 = sys_read32(EFUSE_RD_MAC_SPI_SYS_1_REG);
 #else
@@ -40,4 +43,52 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 	memcpy(buffer, id, length);
 
 	return length;
+}
+
+int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
+{
+	*supported = (RESET_POR
+		      | RESET_PIN
+		      | RESET_SOFTWARE
+		      | RESET_WATCHDOG
+		      | RESET_LOW_POWER_WAKE
+		      | RESET_CPU_LOCKUP
+		      | RESET_BROWNOUT);
+
+	return 0;
+}
+
+int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
+{
+	uint32_t reason = esp_reset_reason();
+
+	switch (reason) {
+	case ESP_RST_POWERON:
+		*cause = RESET_POR;
+		break;
+	case ESP_RST_EXT:
+		*cause = RESET_PIN;
+		break;
+	case ESP_RST_SW:
+		*cause = RESET_SOFTWARE;
+		break;
+	case ESP_RST_INT_WDT:
+	case ESP_RST_TASK_WDT:
+	case ESP_RST_WDT:
+		*cause = RESET_WATCHDOG;
+		break;
+	case ESP_RST_DEEPSLEEP:
+		*cause = RESET_LOW_POWER_WAKE;
+		break;
+	case ESP_RST_PANIC:
+		*cause = RESET_CPU_LOCKUP;
+	case ESP_RST_BROWNOUT:
+		*cause = RESET_BROWNOUT;
+		break;
+	default:
+		*cause = 0;
+		break;
+	}
+
+	return 0;
 }


### PR DESCRIPTION
Add support for all esp32xx boards and implements
get_reset_cause.