### PR TITLE
logging: Fix LOG_RAW failing when logging is disabled

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -403,6 +403,9 @@ extern struct log_source_const_data __log_const_end[];
  * @param ...		Format string with arguments.
  */
 #define Z_LOG_PRINTK(_is_raw, ...) do { \
+	if (!IS_ENABLED(CONFIG_LOG)) { \
+		break; \
+	} \
 	if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL)) { \
 		z_log_minimal_printk(__VA_ARGS__); \
 		break; \


### PR DESCRIPTION
Macro was not taking into account case when logging was disabled and it was failing to link in that case.