### PR TITLE
shell: Convert to using iterable sections

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -173,6 +173,12 @@ zephyr_linker_section_configure(SECTION log_const INPUT ".log_const_*" KEEP SORT
 
 zephyr_iterable_section(NAME shell KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 
+zephyr_iterable_section(NAME shell_root_cmds KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
+
+zephyr_iterable_section(NAME shell_subcmds KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
+
+zephyr_iterable_section(NAME shell_dynamic_subcmds KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
+
 zephyr_linker_section(NAME shell_root_cmds KVMA RAM_REGION GROUP RODATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT})
 zephyr_linker_section_configure(SECTION shell_root_cmds INPUT ".shell_root_cmd_*" KEEP SORT NAME)
 

--- a/include/zephyr/linker/common-rom/common-rom-misc.ld
+++ b/include/zephyr/linker/common-rom/common-rom-misc.ld
@@ -33,26 +33,11 @@
 
 	ITERABLE_SECTION_ROM(shell, 4)
 
-	SECTION_DATA_PROLOGUE(shell_root_cmds_sections,,)
-	{
-		__shell_root_cmds_start = .;
-		KEEP(*(SORT(.shell_root_cmd_*)));
-		__shell_root_cmds_end = .;
-	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	ITERABLE_SECTION_ROM(shell_root_cmds, 4)
 
-	SECTION_DATA_PROLOGUE(shell_subcmds_sections,,)
-	{
-		__shell_subcmds_start = .;
-		KEEP(*(SORT(.shell_subcmd_*)));
-		__shell_subcmds_end = .;
-	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	ITERABLE_SECTION_ROM(shell_subcmds, 4)
 
-	SECTION_DATA_PROLOGUE(shell_dynamic_subcmds_sections,,)
-	{
-		__shell_dynamic_subcmds_start = .;
-		KEEP(*(SORT(.shell_dynamic_subcmd_*)));
-		__shell_dynamic_subcmds_end = .;
-	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	ITERABLE_SECTION_ROM(shell_dynamic_subcmds, 4)
 
 	SECTION_DATA_PROLOGUE(font_entry_sections,,)
 	{

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -9,29 +9,28 @@
 #include "shell_utils.h"
 #include "shell_wildcard.h"
 
-extern const union shell_cmd_entry __shell_root_cmds_start[];
-extern const union shell_cmd_entry __shell_root_cmds_end[];
+TYPE_SECTION_START_EXTERN(union shell_cmd_entry, shell_dynamic_subcmds);
+TYPE_SECTION_END_EXTERN(union shell_cmd_entry, shell_dynamic_subcmds);
 
-extern const union shell_cmd_entry __shell_dynamic_subcmds_start[];
-extern const union shell_cmd_entry __shell_dynamic_subcmds_end[];
-
-extern const union shell_cmd_entry __shell_subcmds_start[];
-extern const union shell_cmd_entry __shell_subcmds_end[];
+TYPE_SECTION_START_EXTERN(union shell_cmd_entry, shell_subcmds);
+TYPE_SECTION_END_EXTERN(union shell_cmd_entry, shell_subcmds);
 
 /* Macro creates empty entry at the bottom of the memory section with subcommands
  * it is used to detect end of subcommand set that is located before this marker.
  */
 #define Z_SHELL_SUBCMD_END_MARKER_CREATE()				\
-	static const struct shell_static_entry z_shell_subcmd_end_marker\
-	__attribute__ ((section("."					\
-			STRINGIFY(Z_SHELL_SUBCMD_NAME(999)))))		\
-	__attribute__((used))
+	static const TYPE_SECTION_ITERABLE(struct shell_static_entry, \
+			z_shell_subcmd_end_marker, shell_subcmds, Z_SHELL_UNDERSCORE(999))
 
 Z_SHELL_SUBCMD_END_MARKER_CREATE();
 
 static inline const union shell_cmd_entry *shell_root_cmd_get(uint32_t id)
 {
-	return &__shell_root_cmds_start[id];
+	const union shell_cmd_entry *cmd;
+
+	TYPE_SECTION_GET(union shell_cmd_entry, shell_root_cmds, id, &cmd);
+
+	return cmd;
 }
 
 /* Determine if entry is a dynamic command by checking if address is within
@@ -39,8 +38,8 @@ static inline const union shell_cmd_entry *shell_root_cmd_get(uint32_t id)
  */
 static inline bool is_dynamic_cmd(const union shell_cmd_entry *entry)
 {
-	return (entry >= __shell_dynamic_subcmds_start) &&
-		(entry < __shell_dynamic_subcmds_end);
+	return (entry >= TYPE_SECTION_START(shell_dynamic_subcmds)) &&
+		(entry < TYPE_SECTION_END(shell_dynamic_subcmds));
 }
 
 /* Determine if entry is a section command by checking if address is within
@@ -48,8 +47,8 @@ static inline bool is_dynamic_cmd(const union shell_cmd_entry *entry)
  */
 static inline bool is_section_cmd(const union shell_cmd_entry *entry)
 {
-	return (entry >= __shell_subcmds_start) &&
-		(entry < __shell_subcmds_end);
+	return (entry >= TYPE_SECTION_START(shell_subcmds)) &&
+		(entry < TYPE_SECTION_END(shell_subcmds));
 }
 
 /* Calculates relative line number of given position in buffer */
@@ -259,9 +258,11 @@ void z_shell_pattern_remove(char *buff, uint16_t *buff_len, const char *pattern)
 
 static inline uint32_t shell_root_cmd_count(void)
 {
-	return ((uint8_t *)__shell_root_cmds_end -
-			(uint8_t *)__shell_root_cmds_start)/
-				sizeof(union shell_cmd_entry);
+	size_t len;
+
+	TYPE_SECTION_COUNT(union shell_cmd_entry, shell_root_cmds, &len);
+
+	return len;
 }
 
 /* Function returning pointer to parent command matching requested syntax. */


### PR DESCRIPTION
Convert handling of shell_root_cmds, shell_subcmds, and shell_dynamic_subcmds to use iterable section macros.