### PR TITLE
dts: bindings: serial: altera uart: remove redundent properties

### DIFF
--- a/dts/bindings/serial/altr,uart.yaml
+++ b/dts/bindings/serial/altr,uart.yaml
@@ -17,26 +17,3 @@ properties:
     type: boolean
     description: |
       Baud rate cannot be changed by software (Divisor register is not writable)
-
-  data-bits:
-    type: string
-    description: |
-      Determines the widths of the txdata, rxdata, and endofpacket registers.
-      Driver default is DATA_BITS_8
-    enum:
-      - "NOT_SUPPORTED_5"
-      - "NOT_SUPPORTED_6"
-      - "DATA_BITS_7"
-      - "DATA_BITS_8"
-      - "DATA_BITS_9"
-
-  stop-bits:
-    type: string
-    description: |
-      Determines the widths of the txdata, rxdata, and endofpacket registers.
-      Driver default is STOP_BITS_1
-    enum:
-      - "NOT_SUPPORTED_0_5"
-      - "STOP_BITS_1"
-      - "NOT_SUPPORTED_1_5"
-      - "STOP_BITS_2"


### PR DESCRIPTION
A recent change added the stop-bits and data-bits to the base uart-controller binding, meaning it's no longer required to be added in the Altera specific binding.

This requires no further changes because its only use is in uart_altera.c where only the index of the enum is used, which remains the same between the new implementation and how it was previously implemented in the altera specific binding.

Relevant commit: 0234f12