### PR TITLE
samples: boards: stm32 main function return type from void to int

### DIFF
--- a/samples/boards/stm32/backup_sram/src/main.c
+++ b/samples/boards/stm32/backup_sram/src/main.c
@@ -21,7 +21,7 @@ int main(void)
 
 	if (!device_is_ready(dev)) {
 		printk("ERROR: BackUp SRAM device is not ready\n");
-		return;
+		return 0;
 	}
 
 	printk("Current value in backup SRAM (%p): %d\n", &backup_value, backup_value);


### PR DESCRIPTION
Return 0 on samples/boards/stm32/backup_sram/src/main.c to match the int type.

Regression due to commit  0b90fd5adf1f01625412efadba4331b5041fb828  (PR #54628)
causing compilation warning 
```
./samples/boards/stm32/backup_sram/src/main.c: In function 'main':
./boards/stm32/backup_sram/src/main.c:24:17: warning: 'return' with no value, in function returning non-void [-Wreturn-type]
   24 |                 return;
      |                 ^~~~~~
./samples/boards/stm32/backup_sram/src/main.c:18:5: note: declared here
   18 | int main(void)
      |     ^~~~

```

Signed-off-by: Francois Ramu <francois.ramu@st.com>