### PR TITLE
samples: settings: Fix typo in comment

### DIFF
--- a/samples/subsys/settings/src/main.c
+++ b/samples/subsys/settings/src/main.c
@@ -560,7 +560,7 @@ int main(void)
 		example_direct_load_subtree();
 
 		/*-------------------------
-		 * delete certain kay-value
+		 * delete certain key-value
 		 */
 		example_delete();
 


### PR DESCRIPTION
This commit fixes the typo: 'kay-value' to 'key-value'

Signed-off-by: Ivan Herrera Olivares <ivan.herreraolivares@gmail.com>