### PR TITLE
dts: microchip: Remove deleted property

### DIFF
--- a/dts/arm/microchip/mec1727nsz.dtsi
+++ b/dts/arm/microchip/mec1727nsz.dtsi
@@ -25,7 +25,6 @@
 	status = "okay";
 	clock-frequency = <12000000>;
 	lines = <2>;
-	port-sel = <2>;
 	chip-select = <0>;
 	pinctrl-0 = < &gpspi_cs_n_gpio116
 		      &gpspi_clk_gpio117

--- a/samples/drivers/espi/boards/mec172xevb_assy6906.overlay
+++ b/samples/drivers/espi/boards/mec172xevb_assy6906.overlay
@@ -46,7 +46,6 @@
 &spi0 {
 	status = "okay";
 	clock-frequency = <24000000>;
-	port-sel = <0>;
 	chip-select = <0>;
 	lines = <4>;
 };


### PR DESCRIPTION
PR https://github.com/zephyrproject-rtos/zephyr/pull/55129 deleted the "port-sel" property.  Delete this property from remaining Microchip SoC variants and boards.

Test: west build -b mec172xevb_assy6906 samples/drivers/espi/