### PR TITLE
drivers: intel: ssp: Fix checked expression in WAIT_FOR()

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -666,7 +666,7 @@ static void dai_ssp_mn_reset_bclk_divider(struct dai_intel_ssp *dp, uint32_t dai
 static int dai_ssp_poll_for_register_delay(uint32_t reg, uint32_t mask,
 					   uint32_t val, uint64_t us)
 {
-	if (!WAIT_FOR((sys_read32(reg) & mask) != val, us, k_busy_wait(1))) {
+	if (!WAIT_FOR((sys_read32(reg) & mask) == val, us, k_busy_wait(1))) {
 		LOG_ERR("%s poll timeout reg %u mask %u val %u us %u",
 			__func__, reg, mask, val, (uint32_t)us);
 		return -EIO;


### PR DESCRIPTION
The function dai_ssp_poll_for_register_delay() is meant to poll the register until the value of the mask bits is equal to the "val" argument or until poll timeout has occured. WAIT_FOR() returns the value of the checked expression, so the check should be modified accordingly. This should prevent the errors seen during every SSP trigger as below:

<err> dai_intel_ssp: dai_ssp_poll_for_register_delay poll timeout reg 487432 mask 4 val 4 us 125
<err> dai_intel_ssp: dai_ssp_poll_for_register_delay poll timeout reg 487496 mask 63 val 0 us 937