### PR TITLE
canbus: isotp: tx state machine restructure and add event handler

### DIFF
--- a/include/zephyr/canbus/isotp.h
+++ b/include/zephyr/canbus/isotp.h
@@ -391,7 +391,6 @@ struct isotp_send_ctx {
 	struct isotp_fc_opts opts;
 	uint8_t state;
 	uint8_t tx_backlog;
-	struct k_sem tx_sem;
 	struct isotp_msg_id rx_addr;
 	struct isotp_msg_id tx_addr;
 	uint8_t wft;

--- a/subsys/canbus/isotp/Kconfig
+++ b/subsys/canbus/isotp/Kconfig
@@ -64,6 +64,14 @@ config ISOTP_ENABLE_TX_PADDING
 	  Add padding bytes 0xCC (as recommended by Bosch) if the PDU payload
 	  does not fit exactly into the CAN frame.
 
+config ISOTP_REQUIRE_FC_PADDING
+	bool "Force send process FC padding detection"
+	default y
+	depends on ISOTP_ENABLE_TX_PADDING
+	help
+	  Force FC padding dections. If enabled, the FC packet must always
+	  have a DLC of 8 bytes. Set default to false to get better compliant.
+
 config ISOTP_RX_BUF_COUNT
 	int "Number of data buffers for receiving data"
 	default 4

--- a/subsys/canbus/isotp/isotp_internal.h
+++ b/subsys/canbus/isotp/isotp_internal.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Alexander Wachter
+ * Copyright (c) 2023 Jiapeng Li
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -107,9 +108,15 @@ enum isotp_tx_state {
 	ISOTP_TX_WAIT_FC,
 	ISOTP_TX_SEND_CF,
 	ISOTP_TX_WAIT_ST,
-	ISOTP_TX_WAIT_BACKLOG,
 	ISOTP_TX_WAIT_FIN,
 	ISOTP_TX_ERR
+};
+
+enum isotp_event {
+	ISOTP_EVENT_TIMEOUT = -2,
+	ISOTP_EVENT_ERROR = -1,
+	ISOTP_EVENT_SEND_FRAME_DONE = 0,
+	ISOTP_EVENT_RECV_FRAME_DONE = 1
 };
 
 struct isotp_global_ctx {


### PR DESCRIPTION
  - split ISOTP_REQUIRE_FC_PADDING from ISOTP_ENABLE_TX_PADDING, it can improve sender compatibility if enabled (loose lenght checking)
  - use a dedicated event handler to drive the state machine, this can  improve isotp driver's robustness, and make source code more easier to read
  - added timeout feature for can packet sending, restart can controller if timeout happenps, this avoid blocks application thread if there is no valid receiver on can bus, when timeout the application layer will get chance to change baud rate
  - fix potential bugs of isotp FF/CF sending (similar with #56747)
  - remove tx_sem. tx_sem can block sys_work_queue for a long time if can controller can't send packet out (e.g. no receiver on bus)