### PR TITLE
modules: openthread: fix handling tx done when sleep to tx is supported

### DIFF
--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -526,7 +526,8 @@ void platformRadioProcess(otInstance *aInstance)
 	if (is_pending_event_set(PENDING_EVENT_TX_DONE)) {
 		reset_pending_event(PENDING_EVENT_TX_DONE);
 
-		if (sState == OT_RADIO_STATE_TRANSMIT) {
+		if (sState == OT_RADIO_STATE_TRANSMIT ||
+		    radio_api->get_capabilities(radio_dev) & IEEE802154_HW_SLEEP_TO_TX) {
 			sState = OT_RADIO_STATE_RECEIVE;
 			handle_tx_done(aInstance);
 		}


### PR DESCRIPTION
After `otPlatRadioSleep` was fixed to properly set radio state to sleep, radios supporting `IEEE802154_HW_SLEEP_TO_TX` capability would not be able to handle `PENDING_EVENT_TX_DONE` while in sleep state.

This commit fixes such case.