### PR TITLE
toolchain: gcc: Fix separator between directives on same line

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -312,7 +312,7 @@ do {                                                                    \
 
 #else
 
-#define FUNC_CODE() .code 32
+#define FUNC_CODE() .code 32;
 #define FUNC_INSTR(a)
 
 #endif /* CONFIG_ASSEMBLER_ISA_THUMB2 */


### PR DESCRIPTION
The Arm assembler in binutils 2.40 contains a change [1] which affects how multiple directives on the same line are parsed.

Previously, the following combination of directives parsed successfully:

    .code 32 .balign 4

With binutils 2.40, the following error is now seen:

    Error: junk at end of line, first unrecognised character is `.'

To fix, insert a semicolon after '.code 32', as there already is after '.thumb'.

[1] https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=a37854f9162fac592b669eda53f465fc190c9341