### PR TITLE
device: allow NULL init function 

### DIFF
--- a/drivers/adc/adc_test.c
+++ b/drivers/adc/adc_test.c
@@ -45,14 +45,9 @@ static const struct adc_driver_api vnd_adc_api = {
 #endif
 };
 
-static int vnd_adc_init(const struct device *dev)
-{
-	return 0;
-}
-
 #define VND_ADC_INIT(n)						  \
-	DEVICE_DT_INST_DEFINE(n, &vnd_adc_init, NULL,		  \
-			      NULL, NULL, POST_KERNEL,		  \
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, NULL,	  \
+			      POST_KERNEL,			  \
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 			      &vnd_adc_api);
 

--- a/drivers/bbram/bbram_emul.c
+++ b/drivers/bbram/bbram_emul.c
@@ -128,11 +128,6 @@ static const struct bbram_driver_api bbram_emul_driver_api = {
 	.write = bbram_emul_write,
 };
 
-static int bbram_emul_init(const struct device *dev)
-{
-	return 0;
-}
-
 #define BBRAM_INIT(inst)                                                                           \
 	static uint8_t bbram_emul_mem_##inst[DT_INST_PROP(inst, size)];                            \
 	static struct bbram_emul_data bbram_emul_data_##inst = {                                   \
@@ -141,7 +136,7 @@ static int bbram_emul_init(const struct device *dev)
 	static struct bbram_emul_config bbram_emul_config_##inst = {                               \
 		.size = DT_INST_PROP(inst, size),                                                  \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, &bbram_emul_init, NULL, &bbram_emul_data_##inst,               \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &bbram_emul_data_##inst,                           \
 			      &bbram_emul_config_##inst, PRE_KERNEL_1, CONFIG_BBRAM_INIT_PRIORITY, \
 			      &bbram_emul_driver_api);
 

--- a/drivers/bbram/bbram_npcx.c
+++ b/drivers/bbram/bbram_npcx.c
@@ -99,13 +99,6 @@ static const struct bbram_driver_api bbram_npcx_driver_api = {
 	.write = bbram_npcx_write,
 };
 
-static int bbram_npcx_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 #define BBRAM_INIT(inst)                                                                           \
 	static struct {                                                                            \
 	} bbram_data_##inst;                                                                       \
@@ -114,7 +107,7 @@ static int bbram_npcx_init(const struct device *dev)
 		.size = DT_INST_REG_SIZE_BY_NAME(inst, memory),                                    \
 		.status_reg_addr = DT_INST_REG_ADDR_BY_NAME(inst, status),                         \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, bbram_npcx_init, NULL, &bbram_data_##inst, &bbram_cfg_##inst,  \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &bbram_data_##inst, &bbram_cfg_##inst,             \
 			      PRE_KERNEL_1, CONFIG_BBRAM_INIT_PRIORITY, &bbram_npcx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(BBRAM_INIT);

--- a/drivers/bbram/bbram_xec.c
+++ b/drivers/bbram/bbram_xec.c
@@ -79,20 +79,12 @@ static const struct bbram_driver_api bbram_xec_driver_api = {
 	.write = bbram_xec_write,
 };
 
-static int bbram_xec_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 #define BBRAM_INIT(inst)						\
 	static const struct bbram_xec_config bbram_cfg_##inst = {	\
 		.base = (uint8_t *)(DT_INST_REG_ADDR(inst)),		\
 		.size = DT_INST_REG_SIZE(inst),				\
 	};								\
-	DEVICE_DT_INST_DEFINE(inst, bbram_xec_init, NULL, NULL,		\
-			      &bbram_cfg_##inst,			\
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, &bbram_cfg_##inst,\
 			      PRE_KERNEL_1, CONFIG_BBRAM_INIT_PRIORITY,	\
 			      &bbram_xec_driver_api);
 

--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -138,16 +138,9 @@ static const struct can_driver_api fake_can_driver_api = {
 #endif /* CONFIG_CAN_FD_MODE */
 };
 
-static int fake_can_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 #define FAKE_CAN_INIT(inst)						\
-	DEVICE_DT_INST_DEFINE(inst, &fake_can_init, NULL, NULL, NULL,	\
-			      POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,	\
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, NULL, POST_KERNEL,\
+			      CONFIG_CAN_INIT_PRIORITY,			\
 			      &fake_can_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(FAKE_CAN_INIT)

--- a/drivers/clock_control/clock_agilex.c
+++ b/drivers/clock_control/clock_agilex.c
@@ -8,16 +8,6 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/clock_agilex_ll.h>
 #include <zephyr/dt-bindings/clock/intel_socfpga_clock.h>
-#include <zephyr/logging/log.h>
-
-LOG_MODULE_REGISTER(clock_control, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
-
-static int clk_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	LOG_INF("Intel Clock driver initialized");
-	return 0;
-}
 
 static int clk_get_rate(const struct device *dev,
 			clock_control_subsys_t sub_system,
@@ -49,6 +39,6 @@ static const struct clock_control_driver_api clk_api = {
 	.get_rate = clk_get_rate
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(clock), clk_init, NULL, NULL, NULL,
+DEVICE_DT_DEFINE(DT_NODELABEL(clock), NULL, NULL, NULL, NULL,
 		 PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
 		 &clk_api);

--- a/drivers/clock_control/clock_control_ast10x0.c
+++ b/drivers/clock_control/clock_control_ast10x0.c
@@ -146,12 +146,6 @@ static int aspeed_clock_control_get_rate(const struct device *dev,
 	return 0;
 }
 
-static int aspeed_clock_control_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 0;
-}
-
 static const struct clock_control_driver_api aspeed_clk_api = {
 	.on = aspeed_clock_control_on,
 	.off = aspeed_clock_control_off,
@@ -162,7 +156,7 @@ static const struct clock_control_driver_api aspeed_clk_api = {
 	static const struct clock_aspeed_config clock_aspeed_cfg_##n = {                           \
 		.syscon = DEVICE_DT_GET(DT_NODELABEL(syscon)),                                     \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(n, &aspeed_clock_control_init, NULL, NULL, &clock_aspeed_cfg_##n,    \
-			      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &aspeed_clk_api);
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, &clock_aspeed_cfg_##n, PRE_KERNEL_1,            \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &aspeed_clk_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ASPEED_CLOCK_INIT)

--- a/drivers/clock_control/clock_control_gd32.c
+++ b/drivers/clock_control/clock_control_gd32.c
@@ -203,17 +203,10 @@ static struct clock_control_driver_api clock_control_gd32_api = {
 	.get_status = clock_control_gd32_get_status,
 };
 
-static int clock_control_gd32_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static const struct clock_control_gd32_config config = {
 	.base = DT_REG_ADDR(DT_INST_PARENT(0)),
 };
 
-DEVICE_DT_INST_DEFINE(0, clock_control_gd32_init, NULL, NULL, &config,
-		      PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, &config, PRE_KERNEL_1,
+		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
 		      &clock_control_gd32_api);

--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -263,20 +263,12 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 	return 0;
 }
 
-static int mcux_ccm_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct clock_control_driver_api mcux_ccm_driver_api = {
 	.on = mcux_ccm_on,
 	.off = mcux_ccm_off,
 	.get_rate = mcux_ccm_get_subsys_rate,
 };
 
-DEVICE_DT_INST_DEFINE(0,
-		    &mcux_ccm_init,
-		    NULL,
-		    NULL, NULL,
-		    PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
-		    &mcux_ccm_driver_api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL,
+		      PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
+		      &mcux_ccm_driver_api);

--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -111,20 +111,12 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 	return 0;
 }
 
-static int mcux_ccm_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct clock_control_driver_api mcux_ccm_driver_api = {
 	.on = mcux_ccm_on,
 	.off = mcux_ccm_off,
 	.get_rate = mcux_ccm_get_subsys_rate,
 };
 
-DEVICE_DT_INST_DEFINE(0,
-		    &mcux_ccm_init,
-		    NULL,
-		    NULL, NULL,
-		    PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
-		    &mcux_ccm_driver_api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, PRE_KERNEL_1,
+		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
+		      &mcux_ccm_driver_api);

--- a/drivers/clock_control/clock_control_mcux_mcg.c
+++ b/drivers/clock_control/clock_control_mcux_mcg.c
@@ -55,20 +55,12 @@ static int mcux_mcg_get_rate(const struct device *dev,
 	return 0;
 }
 
-static int mcux_mcg_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct clock_control_driver_api mcux_mcg_driver_api = {
 	.on = mcux_mcg_on,
 	.off = mcux_mcg_off,
 	.get_rate = mcux_mcg_get_rate,
 };
 
-DEVICE_DT_INST_DEFINE(0,
-		    &mcux_mcg_init,
-		    NULL,
-		    NULL, NULL,
-		    PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
-		    &mcux_mcg_driver_api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, PRE_KERNEL_1,
+		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
+		      &mcux_mcg_driver_api);

--- a/drivers/clock_control/clock_control_mcux_pcc.c
+++ b/drivers/clock_control/clock_control_mcux_pcc.c
@@ -57,11 +57,6 @@ static int mcux_pcc_get_rate(const struct device *dev,
 	return 0;
 }
 
-static int mcux_pcc_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct clock_control_driver_api mcux_pcc_api = {
 	.on = mcux_pcc_on,
 	.off = mcux_pcc_off,
@@ -74,7 +69,7 @@ static const struct clock_control_driver_api mcux_pcc_api = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
-			    &mcux_pcc_init,				\
+			    NULL,					\
 			    NULL,					\
 			    NULL, &mcux_pcc##inst##_config,		\
 			    PRE_KERNEL_1,				\

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -171,11 +171,6 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(
 	return 0;
 }
 
-static int mcux_lpc_syscon_clock_control_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct clock_control_driver_api mcux_lpc_syscon_api = {
 	.on = mcux_lpc_syscon_clock_control_on,
 	.off = mcux_lpc_syscon_clock_control_off,
@@ -185,7 +180,7 @@ static const struct clock_control_driver_api mcux_lpc_syscon_api = {
 #define LPC_CLOCK_INIT(n) \
 	\
 DEVICE_DT_INST_DEFINE(n, \
-		    &mcux_lpc_syscon_clock_control_init, \
+		    NULL, \
 		    NULL, \
 		    NULL, NULL, \
 		    PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY, \

--- a/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
@@ -134,12 +134,6 @@ static int r8a7795_cpg_get_rate(const struct device *dev,
 	return ret;
 }
 
-static int r8a7795_cpg_mssr_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 0;
-}
-
 static const struct clock_control_driver_api r8a7795_cpg_mssr_api = {
 	.on = r8a7795_cpg_mssr_start,
 	.off = r8a7795_cpg_mssr_stop,
@@ -152,7 +146,7 @@ static const struct clock_control_driver_api r8a7795_cpg_mssr_api = {
 	};									  \
 										  \
 	DEVICE_DT_INST_DEFINE(inst,						  \
-			      &r8a7795_cpg_mssr_init,				  \
+			      NULL,						  \
 			      NULL,						  \
 			      NULL, &r8a7795_cpg_mssr##inst##_config,		  \
 			      PRE_KERNEL_1,					  \

--- a/drivers/clock_control/clock_control_rv32m1_pcc.c
+++ b/drivers/clock_control/clock_control_rv32m1_pcc.c
@@ -51,11 +51,6 @@ static int rv32m1_pcc_get_rate(const struct device *dev,
 	return 0;
 }
 
-static int rv32m1_pcc_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct clock_control_driver_api rv32m1_pcc_api = {
 	.on = rv32m1_pcc_on,
 	.off = rv32m1_pcc_off,
@@ -68,7 +63,7 @@ static const struct clock_control_driver_api rv32m1_pcc_api = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
-			    &rv32m1_pcc_init,				\
+			    NULL,					\
 			    NULL,					\
 			    NULL, &rv32m1_pcc##inst##_config,		\
 			    PRE_KERNEL_1,				\

--- a/drivers/clock_control/clock_control_sam_pmc.c
+++ b/drivers/clock_control/clock_control_sam_pmc.c
@@ -135,16 +135,6 @@ static struct clock_control_driver_api atmel_sam_clock_control_api = {
 	.get_status = atmel_sam_clock_control_get_status,
 };
 
-static int atmel_sam_clock_control_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
-DEVICE_DT_INST_DEFINE(0, atmel_sam_clock_control_init,
-		      NULL,
-		      NULL,
-		      NULL,
-		      PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, PRE_KERNEL_1,
+		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
 		      &atmel_sam_clock_control_api);

--- a/drivers/counter/counter_ace_v1x_art.c
+++ b/drivers/counter/counter_ace_v1x_art.c
@@ -102,17 +102,10 @@ int counter_ace_v1x_art_get_value(const struct device *dev, uint64_t *value)
 	return 0;
 }
 
-int counter_ace_v1x_art_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static const struct counter_driver_api ace_v1x_art_counter_apis = {
 	.get_value_64 = counter_ace_v1x_art_get_value
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(ace_art_counter), counter_ace_v1x_art_init, NULL, NULL, NULL,
+DEVICE_DT_DEFINE(DT_NODELABEL(ace_art_counter), NULL, NULL, NULL, NULL,
 		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		 &ace_v1x_art_counter_apis);

--- a/drivers/counter/counter_cmos.c
+++ b/drivers/counter/counter_cmos.c
@@ -194,13 +194,6 @@ int get_value(const struct device *dev, uint32_t *ticks)
 	return 0;
 }
 
-static int init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static const struct counter_config_info info = {
 	.max_top_value = UINT_MAX,
 	.freq = 1
@@ -210,5 +203,5 @@ static const struct counter_driver_api api = {
 	.get_value = get_value
 };
 
-DEVICE_DT_INST_DEFINE(0, &init, NULL, NULL, &info,
-		      POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY, &api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, &info, POST_KERNEL,
+		      CONFIG_COUNTER_INIT_PRIORITY, &api);

--- a/drivers/crypto/crypto_intel_sha.c
+++ b/drivers/crypto/crypto_intel_sha.c
@@ -320,11 +320,6 @@ static int intel_sha_device_free(const struct device *dev, struct hash_ctx *ctx)
 	return 0;
 }
 
-static int intel_sha_device_init(const struct device *dev)
-{
-	return 0;
-}
-
 static int intel_sha_device_hw_caps(const struct device *dev)
 {
 	return (CAP_SEPARATE_IO_BUFS | CAP_SYNC_OPS);
@@ -341,7 +336,7 @@ static struct crypto_driver_api hash_enc_funcs = {
 static struct sha_container sha_data_##inst  = {                                  \
 	.dfsha = (volatile struct sha_hw_regs *)DT_INST_REG_ADDR_BY_IDX(inst, 0)  \
 };                                                                                \
-DEVICE_DT_INST_DEFINE(inst, intel_sha_device_init, NULL, &sha_data_##inst, NULL,  \
+DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &sha_data_##inst, NULL,                   \
 	POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY, (void *)&hash_enc_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(INTEL_SHA_DEVICE_INIT)

--- a/drivers/crypto/crypto_mtls_shim.c
+++ b/drivers/crypto/crypto_mtls_shim.c
@@ -599,11 +599,6 @@ static int mtls_query_caps(const struct device *dev)
 	return MTLS_SUPPORT;
 }
 
-static int mtls_shim_init(const struct device *dev)
-{
-	return 0;
-}
-
 static struct crypto_driver_api mtls_crypto_funcs = {
 	.cipher_begin_session = mtls_session_setup,
 	.cipher_free_session = mtls_session_free,
@@ -614,6 +609,5 @@ static struct crypto_driver_api mtls_crypto_funcs = {
 };
 
 DEVICE_DEFINE(crypto_mtls, CONFIG_CRYPTO_MBEDTLS_SHIM_DRV_NAME,
-		    &mtls_shim_init, NULL, NULL, NULL,
-		    POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY,
-		    (void *)&mtls_crypto_funcs);
+	      NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY,
+	      (void *)&mtls_crypto_funcs);

--- a/drivers/crypto/crypto_npcx_sha.c
+++ b/drivers/crypto/crypto_npcx_sha.c
@@ -204,18 +204,13 @@ static int npcx_query_caps(const struct device *dev)
 	return NPCX_HASH_CAPS_SUPPORT;
 }
 
-static int sha_npcx_init(const struct device *dev)
-{
-	return 0;
-}
-
 static struct crypto_driver_api npcx_crypto_api = {
 	.hash_begin_session = npcx_hash_session_setup,
 	.hash_free_session = npcx_hash_session_free,
 	.query_hw_caps = npcx_query_caps,
 };
 
-DEVICE_DT_INST_DEFINE(0, &sha_npcx_init, NULL, NULL, NULL, POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY,
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY,
 		      &npcx_crypto_api);
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "only one 'nuvoton,npcx-sha' compatible node can be supported");

--- a/drivers/dac/dac_mcux_dac.c
+++ b/drivers/dac/dac_mcux_dac.c
@@ -82,11 +82,6 @@ static int mcux_dac_write_value(const struct device *dev, uint8_t channel,
 	return 0;
 }
 
-static int mcux_dac_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct dac_driver_api mcux_dac_driver_api = {
 	.channel_setup = mcux_dac_channel_setup,
 	.write_value = mcux_dac_write_value,
@@ -105,7 +100,7 @@ static const struct dac_driver_api mcux_dac_driver_api = {
 		.low_power = DT_INST_PROP(n, low_power_mode),		\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, mcux_dac_init, NULL,			\
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL,				\
 			&mcux_dac_data_##n,				\
 			&mcux_dac_config_##n,				\
 			POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,		\

--- a/drivers/dai/intel/alh/alh.c
+++ b/drivers/dai/intel/alh/alh.c
@@ -182,11 +182,6 @@ static int dai_alh_remove(const struct device *dev)
 	return 0;
 }
 
-static int alh_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct dai_driver_api dai_intel_alh_api_funcs = {
 	.probe			= dai_alh_probe,
 	.remove			= dai_alh_remove,
@@ -213,7 +208,7 @@ static const struct dai_driver_api dai_intel_alh_api_funcs = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
-			alh_init, NULL,					\
+			NULL, NULL,					\
 			&dai_intel_alh_data_##n,			\
 			&dai_intel_alh_config_##n,			\
 			POST_KERNEL, 32,				\

--- a/drivers/dai/intel/hda/hda.c
+++ b/drivers/dai/intel/hda/hda.c
@@ -99,11 +99,6 @@ static int dai_hda_remove(const struct device *dev)
 	return 0;
 }
 
-static int hda_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct dai_driver_api dai_intel_hda_api_funcs = {
 	.probe			= dai_hda_probe,
 	.remove			= dai_hda_remove,
@@ -124,7 +119,7 @@ static const struct dai_driver_api dai_intel_hda_api_funcs = {
 	};							\
 								\
 	DEVICE_DT_INST_DEFINE(n,				\
-			hda_init, NULL,				\
+			NULL, NULL,				\
 			&dai_intel_hda_data_##n,		\
 			&dai_intel_hda_config_##n,		\
 			POST_KERNEL, 32,			\

--- a/drivers/eeprom/eeprom_lpc11u6x.c
+++ b/drivers/eeprom/eeprom_lpc11u6x.c
@@ -101,11 +101,6 @@ static size_t eeprom_lpc11u6x_size(const struct device *dev)
 	return config->size;
 }
 
-static int eeprom_lpc11u6x_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct eeprom_driver_api eeprom_lpc11u6x_api = {
 	.read = eeprom_lpc11u6x_read,
 	.write = eeprom_lpc11u6x_write,
@@ -116,6 +111,5 @@ static const struct eeprom_lpc11u6x_config eeprom_config = {
 	.size = DT_INST_PROP(0, size),
 };
 
-DEVICE_DT_INST_DEFINE(0, &eeprom_lpc11u6x_init, NULL, NULL,
-		    &eeprom_config, POST_KERNEL,
-		    CONFIG_EEPROM_INIT_PRIORITY, &eeprom_lpc11u6x_api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, &eeprom_config, POST_KERNEL,
+		      CONFIG_EEPROM_INIT_PRIORITY, &eeprom_lpc11u6x_api);

--- a/drivers/eeprom/eeprom_stm32.c
+++ b/drivers/eeprom/eeprom_stm32.c
@@ -107,11 +107,6 @@ static size_t eeprom_stm32_size(const struct device *dev)
 	return config->size;
 }
 
-static int eeprom_stm32_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct eeprom_driver_api eeprom_stm32_api = {
 	.read = eeprom_stm32_read,
 	.write = eeprom_stm32_write,
@@ -123,6 +118,5 @@ static const struct eeprom_stm32_config eeprom_config = {
 	.size = DT_INST_REG_SIZE(0),
 };
 
-DEVICE_DT_INST_DEFINE(0, &eeprom_stm32_init, NULL, NULL,
-		    &eeprom_config, POST_KERNEL,
-		    CONFIG_EEPROM_INIT_PRIORITY, &eeprom_stm32_api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, &eeprom_config, POST_KERNEL,
+		      CONFIG_EEPROM_INIT_PRIORITY, &eeprom_stm32_api);

--- a/drivers/entropy/entropy_litex.c
+++ b/drivers/entropy/entropy_litex.c
@@ -34,16 +34,9 @@ static int entropy_prbs_get_entropy(const struct device *dev, uint8_t *buffer,
 	return 0;
 }
 
-static int entropy_prbs_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct entropy_driver_api entropy_prbs_api = {
 	.get_entropy = entropy_prbs_get_entropy
 };
 
-DEVICE_DT_INST_DEFINE(0,
-		    entropy_prbs_init, NULL, NULL, NULL,
-		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
-		    &entropy_prbs_api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, PRE_KERNEL_1,
+		      CONFIG_ENTROPY_INIT_PRIORITY, &entropy_prbs_api);

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -201,12 +201,6 @@ static int eth_send(const struct device *dev, struct net_pkt *pkt)
 	return ret < 0 ? ret : 0;
 }
 
-static int eth_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 0;
-}
-
 static struct net_linkaddr *eth_get_mac(struct eth_context *ctx)
 {
 	ctx->ll_addr.addr = ctx->mac_addr;
@@ -639,9 +633,7 @@ LISTIFY(CONFIG_ETH_NATIVE_POSIX_INTERFACE_COUNT, DEFINE_ETH_DEV_DATA, (;), _);
 #define DEFINE_ETH_DEVICE(x, _)						\
 	ETH_NET_DEVICE_INIT(eth_native_posix_##x,			\
 			    CONFIG_ETH_NATIVE_POSIX_DRV_NAME #x,	\
-			    eth_init, NULL,				\
-			    &eth_context_data_##x,			\
-			    NULL,					\
+			    NULL, NULL,	&eth_context_data_##x, NULL,	\
 			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 			    &eth_if_api,				\
 			    NET_ETH_MTU)

--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -835,22 +835,9 @@ static const struct mdio_driver_api mdio_smsc_api = {
 	.write = mdio_smsc_write,
 };
 
-static int mdio_smsc_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	/*
-	 * It doesn't need to initialize anything because smsc_init has
-	 * already done it.
-	 */
-	return 0;
-}
-
 const struct mdio_smsc_config mdio_smsc_config_0 = {
 	.eth_dev = DEVICE_DT_GET(DT_INST_PARENT(0)),
 };
 
-DEVICE_DT_INST_DEFINE(0,
-	&mdio_smsc_init, NULL, NULL,
-	&mdio_smsc_config_0, POST_KERNEL,
-	CONFIG_MDIO_INIT_PRIORITY, &mdio_smsc_api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, &mdio_smsc_config_0, POST_KERNEL,
+		      CONFIG_MDIO_INIT_PRIORITY, &mdio_smsc_api);

--- a/drivers/flash/flash_rpi_pico.c
+++ b/drivers/flash/flash_rpi_pico.c
@@ -298,13 +298,6 @@ void flash_rpi_page_layout(const struct device *dev, const struct flash_pages_la
 
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-static int flash_rpi_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static const struct flash_driver_api flash_rpi_driver_api = {
 	.read = flash_rpi_read,
 	.write = flash_rpi_write,
@@ -315,6 +308,5 @@ static const struct flash_driver_api flash_rpi_driver_api = {
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 };
 
-DEVICE_DT_INST_DEFINE(0, flash_rpi_init, NULL,
-		      NULL, NULL, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL,
 		      CONFIG_FLASH_INIT_PRIORITY, &flash_rpi_driver_api);

--- a/drivers/flash/flash_smartbond.c
+++ b/drivers/flash/flash_smartbond.c
@@ -270,13 +270,6 @@ void flash_smartbond_page_layout(const struct device *dev,
 }
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-static int flash_smartbond_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static const struct flash_driver_api flash_smartbond_driver_api = {
 	.read = flash_smartbond_read,
 	.write = flash_smartbond_write,
@@ -291,5 +284,5 @@ static const struct flash_smartbond_config flash_smartbond_0_config = {
 	.qspif_base_address = DT_REG_ADDR(QSPIF_NODE),
 };
 
-DEVICE_DT_INST_DEFINE(0, flash_smartbond_init, NULL, NULL, &flash_smartbond_0_config,
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, &flash_smartbond_0_config,
 		      POST_KERNEL, CONFIG_FLASH_INIT_PRIORITY, &flash_smartbond_driver_api);

--- a/drivers/gpio/gpio_creg_gpio.c
+++ b/drivers/gpio/gpio_creg_gpio.c
@@ -156,17 +156,6 @@ static int pin_config(const struct device *dev,
 	return -ENOTSUP;
 }
 
-/**
- * @brief Initialization function of creg_gpio
- *
- * @param dev Device struct
- * @return 0 if successful, failed otherwise.
- */
-static int creg_gpio_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct gpio_driver_api api_table = {
 	.pin_configure = pin_config,
 	.port_get_raw = port_get,
@@ -191,7 +180,6 @@ static struct creg_gpio_drv_data creg_gpio_drvdata = {
 	.base_addr = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_DT_INST_DEFINE(0, creg_gpio_init, NULL,
-		      &creg_gpio_drvdata, &creg_gpio_cfg,
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, &creg_gpio_drvdata, &creg_gpio_cfg,
 		      POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,
 		      &api_table);

--- a/drivers/gpio/gpio_ifx_cat1.c
+++ b/drivers/gpio/gpio_ifx_cat1.c
@@ -283,12 +283,6 @@ static const struct gpio_driver_api gpio_cat1_api = {
 	.get_pending_int = gpio_cat1_get_pending_int,
 };
 
-static int gpio_cat1_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 0;
-}
-
 #define GPIO_CAT1_INIT(n)							     \
 										     \
 	cyhal_gpio_callback_data_t						     \
@@ -306,8 +300,7 @@ static int gpio_cat1_init(const struct device *dev)
 										     \
 	static struct gpio_cat1_data _cat1_gpio##n##_data;			     \
 										     \
-	DEVICE_DT_INST_DEFINE(n, gpio_cat1_init, NULL,				     \
-			      &_cat1_gpio##n##_data,				     \
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, &_cat1_gpio##n##_data,		     \
 			      &_cat1_gpio##n##_config, POST_KERNEL,		     \
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		     \
 			      &gpio_cat1_api);

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -684,11 +684,6 @@ static const struct gpio_driver_api gpio_ite_driver_api = {
 	.manage_callback = gpio_ite_manage_callback,
 };
 
-static int gpio_ite_init(const struct device *dev)
-{
-	return 0;
-}
-
 #define GPIO_ITE_DEV_CFG_DATA(inst)                                \
 static struct gpio_ite_data gpio_ite_data_##inst;                  \
 static const struct gpio_ite_cfg gpio_ite_cfg_##inst = {           \
@@ -712,7 +707,7 @@ static const struct gpio_ite_cfg gpio_ite_cfg_##inst = {           \
 	.gpio_irq[7] = DT_INST_IRQ_BY_IDX(inst, 7, irq),           \
 	};                                                         \
 DEVICE_DT_INST_DEFINE(inst,                                        \
-		gpio_ite_init,                                     \
+		NULL,                                              \
 		NULL,                                              \
 		&gpio_ite_data_##inst,                             \
 		&gpio_ite_cfg_##inst,                              \

--- a/drivers/gpio/gpio_kscan_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_kscan_ite_it8xxx2.c
@@ -200,11 +200,6 @@ static int gpio_kscan_it8xxx2_port_toggle_bits(const struct device *dev,
 	return 0;
 }
 
-static int gpio_kscan_it8xxx2_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct gpio_driver_api gpio_kscan_it8xxx2_driver_api = {
 	.pin_configure = gpio_kscan_it8xxx2_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
@@ -233,7 +228,7 @@ static const struct gpio_kscan_cfg gpio_kscan_it8xxx2_cfg_##inst = {           \
 static struct gpio_kscan_data gpio_kscan_it8xxx2_data_##inst;                  \
 									       \
 DEVICE_DT_INST_DEFINE(inst,                                                    \
-		      gpio_kscan_it8xxx2_init,                                 \
+		      NULL,                                                    \
 		      NULL,                                                    \
 		      &gpio_kscan_it8xxx2_data_##inst,                         \
 		      &gpio_kscan_it8xxx2_cfg_##inst,                          \

--- a/drivers/gpio/gpio_test.c
+++ b/drivers/gpio/gpio_test.c
@@ -95,11 +95,6 @@ static const struct gpio_driver_api vnd_gpio_api = {
 	.get_pending_int = vnd_gpio_get_pending_int
 };
 
-static int vnd_gpio_init(const struct device *dev)
-{
-	return 0;
-}
-
 #define VND_GPIO_INIT(n)						\
 	static const struct vnd_gpio_config vnd_gpio_config_##n = {	\
 		.common = {						\
@@ -109,9 +104,8 @@ static int vnd_gpio_init(const struct device *dev)
 									\
 	static struct vnd_gpio_data vnd_gpio_data_##n;			\
 									\
-	DEVICE_DT_INST_DEFINE(n, &vnd_gpio_init, NULL,			\
-			      &vnd_gpio_data_##n, &vnd_gpio_config_##n,	\
-			      POST_KERNEL,				\
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, &vnd_gpio_data_##n,	\
+			      &vnd_gpio_config_##n, POST_KERNEL,	\
 			      CONFIG_GPIO_INIT_PRIORITY,		\
 			      &vnd_gpio_api);
 

--- a/drivers/i2c/i2c_test.c
+++ b/drivers/i2c/i2c_test.c
@@ -32,15 +32,8 @@ static const struct i2c_driver_api vnd_i2c_api = {
 	.transfer  = vnd_i2c_transfer,
 };
 
-static int vnd_i2c_init(const struct device *dev)
-{
-	return 0;
-}
-
-#define VND_I2C_INIT(n)						\
-	I2C_DEVICE_DT_INST_DEFINE(n, vnd_i2c_init, NULL,			\
-			      NULL, NULL, POST_KERNEL,			\
-			      CONFIG_I2C_INIT_PRIORITY,	\
-			      &vnd_i2c_api);
+#define VND_I2C_INIT(n)							       \
+	I2C_DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, NULL, POST_KERNEL,      \
+				  CONFIG_I2C_INIT_PRIORITY, &vnd_i2c_api);
 
 DT_INST_FOREACH_STATUS_OKAY(VND_I2C_INIT)

--- a/drivers/interrupt_controller/wuc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/wuc_ite_it8xxx2.c
@@ -99,11 +99,6 @@ void it8xxx2_wuc_set_polarity(const struct device *dev, uint8_t mask, uint32_t f
 	}
 }
 
-static int it8xxx2_wuc_init(const struct device *dev)
-{
-	return 0;
-}
-
 #define IT8XXX2_WUC_INIT(inst)						       \
 									       \
 	static const struct it8xxx2_wuc_cfg it8xxx2_wuc_cfg_##inst = {	       \
@@ -114,7 +109,7 @@ static int it8xxx2_wuc_init(const struct device *dev)
 	};								       \
 									       \
 	DEVICE_DT_INST_DEFINE(inst,					       \
-			      &it8xxx2_wuc_init,			       \
+			      NULL,					       \
 			      NULL,					       \
 			      NULL,					       \
 			      &it8xxx2_wuc_cfg_##inst,			       \

--- a/drivers/pwm/pwm_test.c
+++ b/drivers/pwm/pwm_test.c
@@ -58,15 +58,8 @@ static const struct pwm_driver_api vnd_pwm_api = {
 	.get_cycles_per_sec = vnd_pwm_get_cycles_per_sec,
 };
 
-static int vnd_pwm_init(const struct device *dev)
-{
-	return 0;
-}
-
-#define VND_PWM_INIT(n)						  \
-	DEVICE_DT_INST_DEFINE(n, &vnd_pwm_init, NULL,		  \
-			      NULL, NULL, POST_KERNEL,		  \
-			      CONFIG_PWM_INIT_PRIORITY,		  \
-			      &vnd_pwm_api);
+#define VND_PWM_INIT(n)							       \
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, NULL, POST_KERNEL,	       \
+			      CONFIG_PWM_INIT_PRIORITY, &vnd_pwm_api);
 
 DT_INST_FOREACH_STATUS_OKAY(VND_PWM_INIT)

--- a/drivers/pwm/pwm_xlnx_axi_timer.c
+++ b/drivers/pwm/pwm_xlnx_axi_timer.c
@@ -172,11 +172,6 @@ static int xlnx_axi_timer_get_cycles_per_sec(const struct device *dev,
 	return 0;
 }
 
-static int xlnx_axi_timer_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct pwm_driver_api xlnx_axi_timer_driver_api = {
 	.set_cycles = xlnx_axi_timer_set_cycles,
 	.get_cycles_per_sec = xlnx_axi_timer_get_cycles_per_sec,
@@ -200,8 +195,7 @@ static const struct pwm_driver_api xlnx_axi_timer_driver_api = {
 			GENMASK(DT_INST_PROP(n, xlnx_count_width) - 1, 0), \
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, &xlnx_axi_timer_init,			\
-			    NULL, NULL,					\
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL,			\
 			    &xlnx_axi_timer_config_##n,			\
 			    POST_KERNEL,				\
 			    CONFIG_PWM_INIT_PRIORITY,			\

--- a/drivers/regulator/regulator_fake.c
+++ b/drivers/regulator/regulator_fake.c
@@ -72,13 +72,6 @@ static struct regulator_parent_driver_api parent_api = {
 	.dvs_state_set = regulator_parent_fake_dvs_state_set,
 };
 
-static int regulator_fake_common_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 #define FAKE_DATA_NAME(node_id) _CONCAT(data_, DT_DEP_ORD(node_id))
 #define FAKE_CONF_NAME(node_id) _CONCAT(config_, DT_DEP_ORD(node_id))
 
@@ -95,8 +88,7 @@ static int regulator_fake_common_init(const struct device *dev)
 			 &api);
 
 #define REGULATOR_FAKE_DEFINE_ALL(inst)                                        \
-	DEVICE_DT_INST_DEFINE(inst, regulator_fake_common_init, NULL, NULL,    \
-			      NULL, POST_KERNEL,                               \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, NULL, POST_KERNEL,       \
 			      CONFIG_REGULATOR_FAKE_COMMON_INIT_PRIORITY,      \
 			      &parent_api);                                    \
                                                                                \

--- a/drivers/reset/reset_ast10x0.c
+++ b/drivers/reset/reset_ast10x0.c
@@ -91,12 +91,6 @@ static int aspeed_reset_line_toggle(const struct device *dev, uint32_t id)
 	return ret;
 }
 
-static int aspeed_reset_control_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 0;
-}
-
 static const struct reset_driver_api aspeed_reset_api = {
 	.status = aspeed_reset_status,
 	.line_assert = aspeed_reset_line_assert,
@@ -108,7 +102,7 @@ static const struct reset_driver_api aspeed_reset_api = {
 	static const struct reset_aspeed_config reset_aspeed_cfg_##n = {                           \
 		.syscon = DEVICE_DT_GET(DT_NODELABEL(syscon)),                                     \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(n, &aspeed_reset_control_init, NULL, NULL, &reset_aspeed_cfg_##n,    \
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, &reset_aspeed_cfg_##n,                          \
 			      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                    \
 			      &aspeed_reset_api);
 

--- a/drivers/reset/reset_gd32.c
+++ b/drivers/reset/reset_gd32.c
@@ -66,14 +66,9 @@ static const struct reset_driver_api reset_gd32_driver_api = {
 	.line_toggle = reset_gd32_line_toggle,
 };
 
-static int reset_gd32_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct reset_gd32_config config = {
 	.base = DT_REG_ADDR(DT_INST_PARENT(0)),
 };
 
-DEVICE_DT_INST_DEFINE(0, reset_gd32_init, NULL, NULL, &config, PRE_KERNEL_1,
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, &config, PRE_KERNEL_1,
 		      CONFIG_RESET_INIT_PRIORITY, &reset_gd32_driver_api);

--- a/drivers/reset/reset_stm32.c
+++ b/drivers/reset/reset_stm32.c
@@ -63,11 +63,6 @@ static int reset_stm32_line_toggle(const struct device *dev, uint32_t id)
 	return 0;
 }
 
-static int reset_stm32_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct reset_driver_api reset_stm32_driver_api = {
 	.status = reset_stm32_status,
 	.line_assert = reset_stm32_line_assert,
@@ -79,6 +74,5 @@ static const struct reset_stm32_config reset_stm32_config = {
 	.base = DT_REG_ADDR(DT_INST_PARENT(0)),
 };
 
-DEVICE_DT_INST_DEFINE(0, reset_stm32_init, NULL, NULL, &reset_stm32_config,
-		      PRE_KERNEL_1, CONFIG_RESET_INIT_PRIORITY,
-		      &reset_stm32_driver_api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, &reset_stm32_config, PRE_KERNEL_1,
+		      CONFIG_RESET_INIT_PRIORITY, &reset_stm32_driver_api);

--- a/drivers/serial/serial_test.c
+++ b/drivers/serial/serial_test.c
@@ -140,11 +140,6 @@ static const struct uart_driver_api serial_vnd_api = {
 #endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 };
 
-static int serial_vnd_init(const struct device *dev)
-{
-	return 0;
-}
-
 #define VND_SERIAL_DATA_BUFFER(n)                                                                  \
 	RING_BUF_DECLARE(written_data_##n, DT_INST_PROP(n, buffer_size));                          \
 	RING_BUF_DECLARE(read_queue_##n, DT_INST_PROP(n, buffer_size));                            \
@@ -156,7 +151,7 @@ static int serial_vnd_init(const struct device *dev)
 #define VND_SERIAL_INIT(n)                                                                         \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, buffer_size), (VND_SERIAL_DATA_BUFFER(n)),            \
 		    (VND_SERIAL_DATA(n)))                                                          \
-	DEVICE_DT_INST_DEFINE(n, &serial_vnd_init, NULL, &serial_vnd_data_##n, NULL, POST_KERNEL,  \
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, &serial_vnd_data_##n, NULL, POST_KERNEL,              \
 			      CONFIG_SERIAL_INIT_PRIORITY, &serial_vnd_api);
 
 DT_INST_FOREACH_STATUS_OKAY(VND_SERIAL_INIT)

--- a/drivers/serial/uart_emul.c
+++ b/drivers/serial/uart_emul.c
@@ -164,11 +164,6 @@ uint32_t uart_emul_flush_tx_data(const struct device *dev)
 	return count;
 }
 
-static int uart_emul_init(const struct device *dev)
-{
-	return 0;
-}
-
 #define UART_EMUL_RX_FIFO_SIZE(inst) (DT_INST_PROP(inst, rx_fifo_size))
 #define UART_EMUL_TX_FIFO_SIZE(inst) (DT_INST_PROP(inst, tx_fifo_size))
 
@@ -185,8 +180,7 @@ static int uart_emul_init(const struct device *dev)
 		.tx_rb = &uart_emul_##inst##_tx_rb,                                                \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, uart_emul_init, NULL, &uart_emul_data_##inst,                  \
-			      &uart_emul_cfg_##inst, PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,    \
-			      &uart_emul_api);
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &uart_emul_data_##inst, &uart_emul_cfg_##inst,     \
+			      PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY, &uart_emul_api);
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_UART_EMUL)

--- a/drivers/serial/uart_hostlink.c
+++ b/drivers/serial/uart_hostlink.c
@@ -365,13 +365,6 @@ static inline int32_t hl_write_char(int fd, const char c)
 	return ret;
 }
 
-static int uart_hostlink_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 /**
  * @brief Poll the device for input.
  *
@@ -406,5 +399,5 @@ static const struct uart_driver_api uart_hostlink_driver_api = {
 	.poll_out = uart_hostlink_poll_out,
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(hostlink), uart_hostlink_init, NULL, NULL, NULL, PRE_KERNEL_1,
+DEVICE_DT_DEFINE(DT_NODELABEL(hostlink), NULL, NULL, NULL, NULL, PRE_KERNEL_1,
 		 CONFIG_SERIAL_INIT_PRIORITY, &uart_hostlink_driver_api);

--- a/drivers/serial/uart_ql_usbserialport_s3b.c
+++ b/drivers/serial/uart_ql_usbserialport_s3b.c
@@ -80,13 +80,6 @@ static const struct uart_driver_api uart_usbserial_driver_api = {
 	.poll_out		= uart_usbserial_poll_out,
 };
 
-static int uart_usbserial_init(const struct device *dev)
-{
-	return 0;
-}
-
-DEVICE_DT_INST_DEFINE(0,
-		uart_usbserial_init,
-		NULL, NULL, NULL,
-		PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,
-		(void *)&uart_usbserial_driver_api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, PRE_KERNEL_1,
+		      CONFIG_SERIAL_INIT_PRIORITY,
+		      (void *)&uart_usbserial_driver_api);

--- a/drivers/spi/spi_litespi.c
+++ b/drivers/spi/spi_litespi.c
@@ -126,11 +126,6 @@ static void spi_litespi_xfer(const struct device *dev,
 
 /* API Functions */
 
-static int spi_litespi_init(const struct device *dev)
-{
-	return 0;
-}
-
 static int spi_litespi_transceive(const struct device *dev,
 				  const struct spi_config *config,
 				  const struct spi_buf_set *tx_bufs,
@@ -182,7 +177,7 @@ static struct spi_driver_api spi_litespi_api = {
 		.base = DT_INST_REG_ADDR_BY_NAME(n, control), \
 	}; \
 	DEVICE_DT_INST_DEFINE(n, \
-			spi_litespi_init, \
+			NULL, \
 			NULL, \
 			&spi_litespi_data_##n, \
 			&spi_litespi_cfg_##n, \

--- a/drivers/spi/spi_test.c
+++ b/drivers/spi/spi_test.c
@@ -48,14 +48,8 @@ static const struct spi_driver_api vnd_spi_api = {
 	.release = vnd_spi_release,
 };
 
-static int vnd_spi_init(const struct device *dev)
-{
-	return 0;
-}
-
-#define VND_SPI_INIT(n)						\
-	DEVICE_DT_INST_DEFINE(n, &vnd_spi_init, NULL,			\
-			      NULL, NULL, POST_KERNEL,			\
+#define VND_SPI_INIT(n)							\
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, NULL, POST_KERNEL,	\
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
 			      &vnd_spi_api);
 

--- a/drivers/w1/w1_test.c
+++ b/drivers/w1/w1_test.c
@@ -62,17 +62,12 @@ static const struct w1_driver_api w1_vnd_api = {
 	.configure = w1_vnd_configure,
 };
 
-static int w1_vnd_init(const struct device *dev)
-{
-	return 0;
-}
-
 #define W1_VND_INIT(n)							\
 static const struct w1_vnd_config w1_vnd_cfg_##inst = {			\
 	.master_config.slave_count = W1_INST_SLAVE_COUNT(inst)		\
 };									\
 static struct w1_vnd_data w1_vnd_data_##inst = {};			\
-DEVICE_DT_INST_DEFINE(n, &w1_vnd_init, NULL, &w1_vnd_data_##inst,	\
+DEVICE_DT_INST_DEFINE(n, NULL, NULL, &w1_vnd_data_##inst,		\
 		      &w1_vnd_cfg_##inst, POST_KERNEL,			\
 		      CONFIG_W1_INIT_PRIORITY, &w1_vnd_api);
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -109,7 +109,7 @@ typedef int16_t device_handle_t;
  * device_get_binding(). This must be less than Z_DEVICE_MAX_NAME_LEN characters
  * (including terminating `NULL`) in order to be looked up from user mode.
  * @param init_fn Pointer to the device's initialization function, which will be
- * run by the kernel during system initialization.
+ * run by the kernel during system initialization. Can be `NULL`.
  * @param pm Pointer to the device's power management resources, a
  * @ref pm_device, which will be stored in @ref device.pm field. Use `NULL` if
  * the device does not use PM.
@@ -160,7 +160,7 @@ typedef int16_t device_handle_t;
  *
  * @param node_id The devicetree node identifier.
  * @param init_fn Pointer to the device's initialization function, which will be
- * run by the kernel during system initialization.
+ * run by the kernel during system initialization. Can be `NULL`.
  * @param pm Pointer to the device's power management resources, a
  * @ref pm_device, which will be stored in @ref device.pm. Use `NULL` if the
  * device does not use PM.

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -618,7 +618,11 @@ struct can_device_state {
 		stats_init(&state->stats.s_hdr, STATS_SIZE_32, 7,	\
 			   STATS_NAME_INIT_PARMS(can));			\
 		stats_register(dev->name, &(state->stats.s_hdr));	\
-		return init_fn(dev);					\
+		if (init_fn != NULL) {					\
+			return init_fn(dev);				\
+		}							\
+									\
+		return 0;						\
 	}
 
 /** @endcond */

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -539,7 +539,11 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 		stats_init(&state->stats.s_hdr, STATS_SIZE_32, 4,	\
 			   STATS_NAME_INIT_PARMS(i2c));			\
 		stats_register(dev->name, &(state->stats.s_hdr));	\
-		return init_fn(dev);					\
+		if (init_fn != NULL) {					\
+			return init_fn(dev);				\
+		}							\
+									\
+		return 0;						\
 	}
 
 /** @endcond */
@@ -553,7 +557,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  *
  * @param node_id The devicetree node identifier.
  *
- * @param init_fn Name of the init function of the driver.
+ * @param init_fn Name of the init function of the driver. Can be `NULL`.
  *
  * @param pm PM device resources reference (NULL if device does not use PM).
  *
@@ -594,7 +598,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 
 #define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
 			     prio, api, ...)				\
-	DEVICE_DT_DEFINE(node_id, &init_fn, pm, data, config, level,	\
+	DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
 			 prio, api, __VA_ARGS__)
 
 #endif /* CONFIG_I2C_STATS */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -252,20 +252,26 @@ static void z_sys_init_run_level(enum init_level level)
 		const struct device *dev = entry->dev;
 
 		if (dev != NULL) {
-			int rc = entry->init_fn.dev(dev);
-			/* Mark device initialized.  If initialization
-			 * failed, record the error condition.
-			 */
-			if (rc != 0) {
-				if (rc < 0) {
-					rc = -rc;
+			int rc = 0;
+
+			if (entry->init_fn.dev != NULL) {
+				rc = entry->init_fn.dev(dev);
+				/* Mark device initialized. If initialization
+				 * failed, record the error condition.
+				 */
+				if (rc != 0) {
+					if (rc < 0) {
+						rc = -rc;
+					}
+					if (rc > UINT8_MAX) {
+						rc = UINT8_MAX;
+					}
+					dev->state->init_res = rc;
 				}
-				if (rc > UINT8_MAX) {
-					rc = UINT8_MAX;
-				}
-				dev->state->init_res = rc;
 			}
+
 			dev->state->initialized = true;
+
 			if (rc == 0) {
 				/* Run automatic device runtime enablement */
 				(void)pm_device_runtime_auto_enable(dev);

--- a/samples/net/virtual/src/main.c
+++ b/samples/net/virtual/src/main.c
@@ -71,13 +71,6 @@ static struct virtual_test_context virtual_test_context_data2 = {
 static struct virtual_test_context virtual_test_context_data3 = {
 };
 
-static int virtual_test_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static enum virtual_interface_caps
 virtual_test_get_capabilities(struct net_if *iface)
 {
@@ -170,24 +163,21 @@ static const struct virtual_interface_api virtual_test_iface_api = {
 	.attach = virtual_test_interface_attach,
 };
 
-NET_VIRTUAL_INTERFACE_INIT(virtual_test1, VIRTUAL_TEST,
-			   virtual_test_init, NULL,
+NET_VIRTUAL_INTERFACE_INIT(virtual_test1, VIRTUAL_TEST, NULL, NULL,
 			   &virtual_test_context_data1,
 			   NULL,
 			   CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 			   &virtual_test_iface_api,
 			   VIRTUAL_TEST_MTU);
 
-NET_VIRTUAL_INTERFACE_INIT(virtual_test2, VIRTUAL_TEST2,
-			   virtual_test_init, NULL,
+NET_VIRTUAL_INTERFACE_INIT(virtual_test2, VIRTUAL_TEST2, NULL, NULL,
 			   &virtual_test_context_data2,
 			   NULL,
 			   CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 			   &virtual_test_iface_api,
 			   VIRTUAL_TEST_MTU);
 
-NET_VIRTUAL_INTERFACE_INIT(virtual_test3, VIRTUAL_TEST3,
-			   virtual_test_init, NULL,
+NET_VIRTUAL_INTERFACE_INIT(virtual_test3, VIRTUAL_TEST3, NULL, NULL,
 			   &virtual_test_context_data3,
 			   NULL,
 			   CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,

--- a/subsys/net/l2/virtual/ipip/ipip.c
+++ b/subsys/net/l2/virtual/ipip/ipip.c
@@ -49,13 +49,6 @@ struct ipip_context {
 	bool init_done;
 };
 
-static int ipip_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static void iface_init(struct net_if *iface)
 {
 	struct ipip_context *ctx = net_if_get_device(iface)->data;
@@ -559,7 +552,7 @@ static const struct virtual_interface_api ipip_iface_api = {
 	}
 
 #define NET_IPIP_INTERFACE_INIT(x, _)					\
-	NET_VIRTUAL_INTERFACE_INIT(ipip##x, "IP_TUNNEL" #x, ipip_init,	\
+	NET_VIRTUAL_INTERFACE_INIT(ipip##x, "IP_TUNNEL" #x, NULL,	\
 				   NULL, &ipip_context_data_##x, NULL,	\
 				   CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 				   &ipip_iface_api, IPIPV4_MTU)

--- a/tests/benchmarks/footprints/src/pm_device.c
+++ b/tests/benchmarks/footprints/src/pm_device.c
@@ -16,11 +16,6 @@
 #define DUMMY_PM_DRIVER_NAME	"dummy_pm_driver"
 #define DUMMY_DRIVER_NAME	"dummy_driver"
 
-static int dummy_init(const struct device *dev)
-{
-	return 0;
-}
-
 static int dummy_device_pm_action(const struct device *dev,
 				  enum pm_device_action action)
 {
@@ -30,13 +25,12 @@ static int dummy_device_pm_action(const struct device *dev,
 /* Define a driver with and without power management enabled */
 PM_DEVICE_DEFINE(dummy_pm_driver, dummy_device_pm_action);
 
-DEVICE_DEFINE(dummy_pm_driver, DUMMY_PM_DRIVER_NAME, &dummy_init,
-		    PM_DEVICE_GET(dummy_pm_driver), NULL, NULL, APPLICATION,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+DEVICE_DEFINE(dummy_pm_driver, DUMMY_PM_DRIVER_NAME, NULL,
+	      PM_DEVICE_GET(dummy_pm_driver), NULL, NULL, APPLICATION,
+	      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
-DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,
-		    NULL, NULL, NULL, APPLICATION,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, NULL, NULL, NULL, NULL,
+	      APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 void run_pm_device(void)
 {

--- a/tests/drivers/clock_control/nrf_clock_calibration/src/mock_temp_nrf5.c
+++ b/tests/drivers/clock_control/nrf_clock_calibration/src/mock_temp_nrf5.c
@@ -19,11 +19,6 @@ void mock_temp_nrf5_value_set(struct sensor_value *val)
 	value = *val;
 }
 
-static int mock_temp_nrf5_init(const struct device *dev)
-{
-	return 0;
-}
-
 static int mock_temp_nrf5_sample_fetch(const struct device *dev,
 					enum sensor_channel chan)
 {
@@ -45,7 +40,7 @@ static const struct sensor_driver_api mock_temp_nrf5_driver_api = {
 };
 
 DEVICE_DT_DEFINE(DT_INST(0, nordic_nrf_temp),
-		    mock_temp_nrf5_init,
+		    NULL,
 		    NULL,
 		    NULL,
 		    NULL,

--- a/tests/drivers/ipm/src/ipm_dummy.c
+++ b/tests/drivers/ipm/src/ipm_dummy.c
@@ -120,12 +120,3 @@ struct ipm_driver_api ipm_dummy_api = {
 	.max_id_val_get = ipm_dummy_max_id_val_get,
 	.set_enabled = ipm_dummy_set_enabled
 };
-
-/* Dummy IPM driver initialization, will be bound at runtime
- * to high-level drivers under test
- */
-
-int ipm_dummy_init(const struct device *d)
-{
-	return 0;
-}

--- a/tests/drivers/ipm/src/ipm_dummy.h
+++ b/tests/drivers/ipm/src/ipm_dummy.h
@@ -27,6 +27,4 @@ struct ipm_dummy_driver_data {
 	void *cb_context;
 	volatile struct ipm_dummy_regs regs;
 };
-
-int ipm_dummy_init(const struct device *d);
 #endif

--- a/tests/drivers/ipm/src/main.c
+++ b/tests/drivers/ipm/src/main.c
@@ -30,7 +30,7 @@ extern struct ipm_driver_api ipm_dummy_api;
 
 /* Set up the dummy IPM driver */
 struct ipm_dummy_driver_data ipm_dummy0_driver_data;
-DEVICE_DEFINE(ipm_dummy0, "ipm_dummy0", ipm_dummy_init,
+DEVICE_DEFINE(ipm_dummy0, "ipm_dummy0", NULL,
 		NULL, &ipm_dummy0_driver_data, NULL,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&ipm_dummy_api);

--- a/tests/drivers/kscan/kscan_input/src/main.c
+++ b/tests/drivers/kscan/kscan_input/src/main.c
@@ -15,12 +15,7 @@ static const struct device *kscan_dev = DEVICE_DT_GET(
 static const struct device *input_dev = DEVICE_DT_GET(
 		DT_NODELABEL(fake_input_device));
 
-static int device_init(const struct device *dev)
-{
-	return 0;
-}
-
-DEVICE_DT_DEFINE(DT_INST(0, vnd_input_device), device_init, NULL, NULL, NULL,
+DEVICE_DT_DEFINE(DT_INST(0, vnd_input_device), NULL, NULL, NULL, NULL,
 		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
 
 static struct {

--- a/tests/drivers/pinctrl/common/test_device.c
+++ b/tests/drivers/pinctrl/common/test_device.c
@@ -11,18 +11,10 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/pinctrl.h>
 
-int test_device_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 #define PINCTRL_DEVICE_INIT(inst)					\
 	PINCTRL_DT_INST_DEFINE(inst);					\
 									\
-	DEVICE_DT_INST_DEFINE(inst, test_device_init, NULL, NULL, NULL,	\
-			      POST_KERNEL,				\
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, NULL, POST_KERNEL,\
 			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(PINCTRL_DEVICE_INIT)

--- a/tests/drivers/w1/w1_api/src/w1_dummy_slave.c
+++ b/tests/drivers/w1/w1_api/src/w1_dummy_slave.c
@@ -14,13 +14,8 @@ struct w1_dummy_slave_api {
 
 static const struct w1_dummy_slave_api w1_dummy_slave_api1 = {};
 
-static int w1_dummy_slave_init(const struct device *dev)
-{
-	return 0;
-}
-
 #define TEST_W1_DUMMY_SLAVE_DEFINE(inst)                                                           \
-	DEVICE_DT_INST_DEFINE(inst, w1_dummy_slave_init, NULL, NULL, NULL, POST_KERNEL,            \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, NULL, POST_KERNEL,                           \
 			      CONFIG_W1_INIT_PRIORITY, &w1_dummy_slave_api1);
 
 DT_INST_FOREACH_STATUS_OKAY(TEST_W1_DUMMY_SLAVE_DEFINE)

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -15,10 +15,15 @@
 
 #define DUMMY_PORT_1    "dummy"
 #define DUMMY_PORT_2    "dummy_driver"
+#define DUMMY_NOINIT    "dummy_noinit"
 #define BAD_DRIVER	"bad_driver"
 
 #define MY_DRIVER_A     "my_driver_A"
 #define MY_DRIVER_B     "my_driver_B"
+
+/* A device without init call */
+DEVICE_DEFINE(dummy_noinit, DUMMY_NOINIT, NULL, NULL, NULL, NULL,
+	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 /**
  * @brief Test cases to verify device objects
@@ -58,6 +63,10 @@ ZTEST(device, test_dummy_device)
 
 	/* Validates device binding for an existing device object */
 	dev = device_get_binding(DUMMY_PORT_2);
+	zassert_not_null(dev);
+
+	/* Validates device binding for an existing device object */
+	dev = device_get_binding(DUMMY_NOINIT);
 	zassert_not_null(dev);
 
 	/* device_get_binding() returns false for device object

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2467,17 +2467,10 @@ ZTEST(devicetree_api, test_pinctrl)
 	zassert_equal(DT_INST_PINCTRL_HAS_NAME(0, f_o_o2), 0, "");
 }
 
-static int test_mbox_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
-DEVICE_DT_DEFINE(DT_NODELABEL(test_mbox), test_mbox_init, NULL,
-		 NULL, NULL, POST_KERNEL, 90, NULL);
-DEVICE_DT_DEFINE(DT_NODELABEL(test_mbox_zero_cell), test_mbox_init, NULL,
-		 NULL, NULL, POST_KERNEL, 90, NULL);
+DEVICE_DT_DEFINE(DT_NODELABEL(test_mbox), NULL, NULL, NULL, NULL, POST_KERNEL,
+		 90, NULL);
+DEVICE_DT_DEFINE(DT_NODELABEL(test_mbox_zero_cell), NULL, NULL, NULL, NULL,
+		 POST_KERNEL, 90, NULL);
 
 ZTEST(devicetree_api, test_mbox)
 {

--- a/tests/net/conn_mgr_conn/src/test_ifaces.c
+++ b/tests/net/conn_mgr_conn/src/test_ifaces.c
@@ -24,12 +24,6 @@ static void test_iface_init(struct net_if *iface)
 	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 }
 
-/* Mandatory stub for NET_DEVICE_INIT */
-static int test_iface_netdev_init(const struct device *dev)
-{
-	return 0;
-}
-
 static struct dummy_api test_iface_api = {
 	.iface_api.init = test_iface_init,
 };
@@ -40,7 +34,7 @@ static struct dummy_api test_iface_api = {
  */
 NET_DEVICE_INIT(test_iface_a1,
 		"test_iface_a1",
-		test_iface_netdev_init,
+		NULL,
 		NULL,
 		NULL,
 		NULL,
@@ -51,7 +45,7 @@ NET_DEVICE_INIT(test_iface_a1,
 		127);
 NET_DEVICE_INIT(test_iface_a2,
 		"test_iface_a2",
-		test_iface_netdev_init,
+		NULL,
 		NULL,
 		NULL,
 		NULL,
@@ -62,7 +56,7 @@ NET_DEVICE_INIT(test_iface_a2,
 		127);
 NET_DEVICE_INIT(test_iface_b,
 		"test_iface_b",
-		test_iface_netdev_init,
+		NULL,
 		NULL,
 		NULL,
 		NULL,
@@ -75,7 +69,7 @@ NET_DEVICE_INIT(test_iface_b,
 /* Create an ifaces with NULL implementation, NULL init, and no connectivity at all */
 NET_DEVICE_INIT(test_iface_null,
 		"test_iface_null",
-		test_iface_netdev_init,
+		NULL,
 		NULL,
 		NULL,
 		NULL,
@@ -86,7 +80,7 @@ NET_DEVICE_INIT(test_iface_null,
 		127);
 NET_DEVICE_INIT(test_iface_ni,
 		"test_iface_ni",
-		test_iface_netdev_init,
+		NULL,
 		NULL,
 		NULL,
 		NULL,
@@ -97,7 +91,7 @@ NET_DEVICE_INIT(test_iface_ni,
 		127);
 NET_DEVICE_INIT(test_iface_none,
 		"test_iface_none",
-		test_iface_netdev_init,
+		NULL,
 		NULL,
 		NULL,
 		NULL,

--- a/tests/net/hostname/src/main.c
+++ b/tests/net/hostname/src/main.c
@@ -62,11 +62,6 @@ struct net_if_test {
 	struct net_linkaddr ll_addr;
 };
 
-static int net_iface_dev_init(const struct device *dev)
-{
-	return 0;
-}
-
 static uint8_t *net_iface_get_mac(const struct device *dev)
 {
 	struct net_if_test *data = dev->data;
@@ -120,7 +115,7 @@ static struct ethernet_api net_iface_api = {
 NET_DEVICE_INIT_INSTANCE(net_iface1_test,
 			 "iface1",
 			 iface1,
-			 net_iface_dev_init,
+			 NULL,
 			 NULL,
 			 &net_iface1_data,
 			 NULL,

--- a/tests/net/ieee802154/custom_l2/src/main.c
+++ b/tests/net/ieee802154/custom_l2/src/main.c
@@ -58,17 +58,11 @@ static void dummy_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, mac, 8, NET_LINK_IEEE802154);
 }
 
-static int dummy_init(const struct device *dev)
-{
-	return 0;
-}
-
 static struct ieee802154_radio_api dummy_radio_api = {
 	.iface_api.init	= dummy_iface_init,
 };
 
-NET_DEVICE_INIT(dummy, "dummy_ieee802154",
-		dummy_init, NULL, NULL, NULL,
+NET_DEVICE_INIT(dummy, "dummy_ieee802154", NULL, NULL, NULL, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&dummy_radio_api, CUSTOM_IEEE802154_L2,
 		NET_L2_GET_CTX_TYPE(CUSTOM_IEEE802154_L2),

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -75,11 +75,6 @@ struct net_if_test {
 	struct net_linkaddr ll_addr;
 };
 
-static int net_iface_dev_init(const struct device *dev)
-{
-	return 0;
-}
-
 static uint8_t *net_iface_get_mac(const struct device *dev)
 {
 	struct net_if_test *data = dev->data;
@@ -149,7 +144,7 @@ static struct dummy_api net_iface_api = {
 NET_DEVICE_INIT_INSTANCE(net_iface1_test,
 			 "iface1",
 			 iface1,
-			 net_iface_dev_init,
+			 NULL,
 			 NULL,
 			 &net_iface1_data,
 			 NULL,
@@ -162,7 +157,7 @@ NET_DEVICE_INIT_INSTANCE(net_iface1_test,
 NET_DEVICE_INIT_INSTANCE(net_iface2_test,
 			 "iface2",
 			 iface2,
-			 net_iface_dev_init,
+			 NULL,
 			 NULL,
 			 &net_iface2_data,
 			 NULL,
@@ -175,7 +170,7 @@ NET_DEVICE_INIT_INSTANCE(net_iface2_test,
 NET_DEVICE_INIT_INSTANCE(net_iface3_test,
 			 "iface3",
 			 iface3,
-			 net_iface_dev_init,
+			 NULL,
 			 NULL,
 			 &net_iface3_data,
 			 NULL,

--- a/tests/net/ipv4_fragment/src/main.c
+++ b/tests/net/ipv4_fragment/src/main.c
@@ -150,7 +150,6 @@ static uint16_t upper_layer_total_size;
 static uint8_t tmp_buf[256];
 static uint8_t net_iface_dummy_data;
 
-static int net_iface_dev_init(const struct device *dev);
 static void net_iface_init(struct net_if *iface);
 static int sender_iface(const struct device *dev, struct net_pkt *pkt);
 
@@ -162,7 +161,7 @@ static struct dummy_api net_iface_api = {
 NET_DEVICE_INIT_INSTANCE(net_iface1_test,
 			 "iface1",
 			 iface1,
-			 net_iface_dev_init,
+			 NULL,
 			 NULL,
 			 &net_iface_dummy_data,
 			 NULL,
@@ -172,11 +171,6 @@ NET_DEVICE_INIT_INSTANCE(net_iface1_test,
 			 NET_L2_GET_CTX_TYPE(DUMMY_L2),
 			 NET_IPV4_MTU);
 
-
-static int net_iface_dev_init(const struct device *dev)
-{
-	return 0;
-}
 
 static void net_iface_init(struct net_if *iface)
 {

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -927,11 +927,6 @@ enum net_test_type {
 
 static enum net_test_type test_type = NO_TEST_TYPE;
 
-static int net_iface_dev_init(const struct device *dev)
-{
-	return 0;
-}
-
 static uint8_t *net_iface_get_mac(const struct device *dev)
 {
 	struct net_if_test *data = dev->data;
@@ -1591,7 +1586,7 @@ static struct dummy_api net_iface_api = {
 NET_DEVICE_INIT_INSTANCE(net_iface1_test,
 			 "iface1",
 			 iface1,
-			 net_iface_dev_init,
+			 NULL,
 			 NULL,
 			 &net_iface1_data,
 			 NULL,

--- a/tests/net/lib/dns_addremove/src/main.c
+++ b/tests/net/lib/dns_addremove/src/main.c
@@ -80,11 +80,6 @@ struct net_if_test {
 	uint8_t mac_addr[sizeof(struct net_eth_addr)];
 };
 
-static int net_iface_dev_init(const struct device *dev)
-{
-	return 0;
-}
-
 static uint8_t *net_iface_get_mac(const struct device *dev)
 {
 	struct net_if_test *data = dev->data;
@@ -133,7 +128,7 @@ static struct dummy_api net_iface_api = {
 NET_DEVICE_INIT_INSTANCE(net_iface1_test,
 			 "iface1",
 			 iface1,
-			 net_iface_dev_init,
+			 NULL,
 			 NULL,
 			 &net_iface1_data,
 			 NULL,

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -78,11 +78,6 @@ struct net_if_test {
 	struct net_linkaddr ll_addr;
 };
 
-static int net_iface_dev_init(const struct device *dev)
-{
-	return 0;
-}
-
 static uint8_t *net_iface_get_mac(const struct device *dev)
 {
 	struct net_if_test *data = dev->data;
@@ -187,7 +182,7 @@ static struct dummy_api net_iface_api = {
 NET_DEVICE_INIT_INSTANCE(net_iface1_test,
 			 "iface1",
 			 iface1,
-			 net_iface_dev_init,
+			 NULL,
 			 NULL,
 			 &net_iface1_data,
 			 NULL,

--- a/tests/net/npf/src/main.c
+++ b/tests/net/npf/src/main.c
@@ -76,17 +76,10 @@ static struct net_pkt *build_test_pkt(int type, int size, struct net_if *iface)
  * Declare some fake interfaces and test their filter conditions.
  */
 
-static int eth_fake_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
-ETH_NET_DEVICE_INIT(dummy_iface_a, "dummy_a", eth_fake_init, NULL,
+ETH_NET_DEVICE_INIT(dummy_iface_a, "dummy_a", NULL, NULL,
 		    NULL, NULL, CONFIG_ETH_INIT_PRIORITY,
 		    NULL, NET_ETH_MTU);
-ETH_NET_DEVICE_INIT(dummy_iface_b, "dummy_b", eth_fake_init, NULL,
+ETH_NET_DEVICE_INIT(dummy_iface_b, "dummy_b", NULL, NULL,
 		    NULL, NULL, CONFIG_ETH_INIT_PRIORITY,
 		    NULL, NET_ETH_MTU);
 #define dummy_iface_a NET_IF_GET_NAME(dummy_iface_a, 0)[0]

--- a/tests/net/offloaded_netdev/src/main.c
+++ b/tests/net/offloaded_netdev/src/main.c
@@ -19,14 +19,6 @@
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_l2.h>
 
-/* Offloaded L2 initializer, mandatory for offloaded L2s */
-static int offload_l2_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 /* Dummy socket creator for socket-offloaded ifaces */
 int offload_socket(int family, int type, int proto)
 {
@@ -100,27 +92,23 @@ static struct offloaded_if_api net_offloaded_no_impl_api = {
 
 /* Socket-offloaded netdevs, with and without .enable */
 NET_DEVICE_OFFLOAD_INIT(sock_offload_test_impl, "sock_offload_test_impl",
-			offload_l2_init, NULL,
-			NULL, NULL,
+			NULL, NULL, NULL, NULL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 			&sock_offloaded_impl_api, 0);
 
 NET_DEVICE_OFFLOAD_INIT(sock_offload_test_no_impl, "sock_offload_test_no_impl",
-			offload_l2_init, NULL,
-			NULL, NULL,
+			NULL, NULL, NULL, NULL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 			&sock_offloaded_no_impl_api, 0);
 
 /* Net-offloaded netdevs, with and without .enable */
 NET_DEVICE_OFFLOAD_INIT(net_offload_test_impl, "net_offload_test_impl",
-			offload_l2_init, NULL,
-			NULL, NULL,
+			NULL, NULL, NULL, NULL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 			&net_offloaded_impl_api, 0);
 
 NET_DEVICE_OFFLOAD_INIT(net_offload_test_no_impl, "net_offload_test_no_impl",
-			offload_l2_init, NULL,
-			NULL, NULL,
+			NULL, NULL, NULL, NULL,
 			CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 			&net_offloaded_no_impl_api, 0);
 

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -83,13 +83,6 @@ static void fake_dev_iface_init(struct net_if *iface)
 	ctx->iface = iface;
 }
 
-int fake_dev_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 struct fake_dev_context fake_dev_context_data;
 
 static struct dummy_api fake_dev_if_api = {
@@ -103,7 +96,7 @@ static struct dummy_api fake_dev_if_api = {
 PM_DEVICE_DEFINE(fake_dev, fake_dev_pm_action);
 
 NET_DEVICE_INIT(fake_dev, "fake_dev",
-		fake_dev_init, PM_DEVICE_GET(fake_dev),
+		NULL, PM_DEVICE_GET(fake_dev),
 		&fake_dev_context_data, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 		&fake_dev_if_api, _ETH_L2_LAYER, _ETH_L2_CTX_TYPE, 127);

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -95,20 +95,11 @@ static struct ethernet_api eth_fake_api_funcs = {
 	.send = eth_fake_send,
 };
 
-static int eth_fake_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
-ETH_NET_DEVICE_INIT(eth_fake1, "eth_fake1", eth_fake_init,
-		    NULL, &eth_fake_data1, NULL,
+ETH_NET_DEVICE_INIT(eth_fake1, "eth_fake1", NULL, NULL, &eth_fake_data1, NULL,
 		    CONFIG_ETH_INIT_PRIORITY, &eth_fake_api_funcs,
 		    NET_ETH_MTU);
 
-ETH_NET_DEVICE_INIT(eth_fake2, "eth_fake2", eth_fake_init,
-		    NULL, &eth_fake_data2, NULL,
+ETH_NET_DEVICE_INIT(eth_fake2, "eth_fake2", NULL, NULL, &eth_fake_data2, NULL,
 		    CONFIG_ETH_INIT_PRIORITY, &eth_fake_api_funcs,
 		    NET_ETH_MTU);
 

--- a/tests/net/socket/misc/src/main.c
+++ b/tests/net/socket/misc/src/main.c
@@ -143,24 +143,15 @@ static struct dummy_api dummy_api_funcs = {
 	.send = dummy_send,
 };
 
-static int dummy_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 #define DEV1_NAME "dummy_1"
 #define DEV2_NAME "dummy_2"
 
-NET_DEVICE_INIT(dummy_1, DEV1_NAME, dummy_init,
-		NULL, &dummy_data1, NULL,
+NET_DEVICE_INIT(dummy_1, DEV1_NAME, NULL, NULL, &dummy_data1, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &dummy_api_funcs,
 		DUMMY_L2, NET_L2_GET_CTX_TYPE(DUMMY_L2), 127);
 
 
-NET_DEVICE_INIT(dummy_2, DEV2_NAME, dummy_init,
-		NULL, &dummy_data2, NULL,
+NET_DEVICE_INIT(dummy_2, DEV2_NAME, NULL, NULL, &dummy_data2, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &dummy_api_funcs,
 		DUMMY_L2, NET_L2_GET_CTX_TYPE(DUMMY_L2), 127);
 

--- a/tests/net/socket/offload_dispatcher/src/main.c
+++ b/tests/net/socket/offload_dispatcher/src/main.c
@@ -294,14 +294,6 @@ static bool offload_1_is_supported(int family, int type, int proto)
 NET_SOCKET_OFFLOAD_REGISTER(offloaded_1, SOCKET_OFFLOAD_PRIO_HIGH, AF_UNSPEC,
 			    offload_1_is_supported, offload_1_socket);
 
-
-static int offloaded_1_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static void offloaded_1_iface_init(struct net_if *iface)
 {
 	net_if_socket_offload_set(iface, offload_1_socket);
@@ -311,7 +303,7 @@ static struct offloaded_if_api offloaded_1_if_api = {
 	.iface_api.init = offloaded_1_iface_init,
 };
 
-NET_DEVICE_OFFLOAD_INIT(offloaded_1, "offloaded_1", offloaded_1_init, NULL,
+NET_DEVICE_OFFLOAD_INIT(offloaded_1, "offloaded_1", NULL, NULL,
 			NULL, NULL, 0, &offloaded_1_if_api, 1500);
 
 /* Offloaded interface 2 - low priority */
@@ -364,14 +356,6 @@ static bool offload_2_is_supported(int family, int type, int proto)
 NET_SOCKET_OFFLOAD_REGISTER(offloaded_2, SOCKET_OFFLOAD_PRIO_HIGH, AF_UNSPEC,
 			    offload_2_is_supported, offload_2_socket);
 
-
-static int offloaded_2_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static void offloaded_2_iface_init(struct net_if *iface)
 {
 	net_if_socket_offload_set(iface, offload_2_socket);
@@ -381,7 +365,7 @@ static struct offloaded_if_api offloaded_2_if_api = {
 	.iface_api.init = offloaded_2_iface_init,
 };
 
-NET_DEVICE_OFFLOAD_INIT(offloaded_2, "offloaded_2", offloaded_2_init, NULL,
+NET_DEVICE_OFFLOAD_INIT(offloaded_2, "offloaded_2", NULL, NULL,
 			NULL, NULL, 0, &offloaded_2_if_api, 1500);
 
 
@@ -407,19 +391,12 @@ static int dummy_native_dev_send(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-int dummy_native_dev_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static const struct dummy_api dummy_native_dev_api = {
 	.iface_api.init = dummy_native_iface_init,
 	.send = dummy_native_dev_send,
 };
 
-NET_DEVICE_INIT(dummy_native, "dummy_native", dummy_native_dev_init, NULL, NULL,
+NET_DEVICE_INIT(dummy_native, "dummy_native", NULL, NULL, NULL,
 		NULL, 0, &dummy_native_dev_api, DUMMY_L2,
 		NET_L2_GET_CTX_TYPE(DUMMY_L2), 1500);
 

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -984,16 +984,8 @@ static struct ethernet_api eth_fake_api_funcs = {
 	.send = eth_fake_send,
 };
 
-static int eth_fake_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
-ETH_NET_DEVICE_INIT(eth_fake, "eth_fake", eth_fake_init, NULL,
-		    &eth_fake_data, NULL, CONFIG_ETH_INIT_PRIORITY,
-		    &eth_fake_api_funcs, NET_ETH_MTU);
+ETH_NET_DEVICE_INIT(eth_fake, "eth_fake", NULL, NULL, &eth_fake_data, NULL,
+		    CONFIG_ETH_INIT_PRIORITY, &eth_fake_api_funcs, NET_ETH_MTU);
 
 static void iface_cb(struct net_if *iface, void *user_data)
 {

--- a/tests/net/virtual/src/main.c
+++ b/tests/net/virtual/src/main.c
@@ -198,11 +198,6 @@ struct net_if_test {
 	struct net_linkaddr ll_addr;
 };
 
-static int net_iface_dev_init(const struct device *dev)
-{
-	return 0;
-}
-
 static uint8_t *net_iface_get_mac(const struct device *dev)
 {
 	struct net_if_test *data = dev->data;
@@ -250,7 +245,7 @@ static struct dummy_api net_iface_api = {
 NET_DEVICE_INIT_INSTANCE(eth_test_dummy1,
 			 "iface1",
 			 iface1,
-			 net_iface_dev_init,
+			 NULL,
 			 NULL,
 			 &net_iface1_data,
 			 NULL,
@@ -263,7 +258,7 @@ NET_DEVICE_INIT_INSTANCE(eth_test_dummy1,
 NET_DEVICE_INIT_INSTANCE(eth_test_dummy2,
 			 "iface2",
 			 iface2,
-			 net_iface_dev_init,
+			 NULL,
 			 NULL,
 			 &net_iface2_data,
 			 NULL,

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -200,11 +200,6 @@ struct net_if_test {
 	struct net_linkaddr ll_addr;
 };
 
-static int net_iface_dev_init(const struct device *dev)
-{
-	return 0;
-}
-
 static uint8_t *net_iface_get_mac(const struct device *dev)
 {
 	struct net_if_test *data = dev->data;
@@ -252,7 +247,7 @@ static struct dummy_api net_iface_api = {
 NET_DEVICE_INIT_INSTANCE(net_iface1_test,
 			 "iface1",
 			 iface1,
-			 net_iface_dev_init,
+			 NULL,
 			 NULL,
 			 &net_iface1_data,
 			 NULL,
@@ -265,7 +260,7 @@ NET_DEVICE_INIT_INSTANCE(net_iface1_test,
 NET_DEVICE_INIT_INSTANCE(net_iface2_test,
 			 "iface2",
 			 iface2,
-			 net_iface_dev_init,
+			 NULL,
 			 NULL,
 			 &net_iface2_data,
 			 NULL,

--- a/tests/subsys/edac/ibecc/src/dummy.c
+++ b/tests/subsys/edac/ibecc/src/dummy.c
@@ -14,14 +14,9 @@
  * EDAC dummy is used for coverage tests for -ENOSYS returns
  */
 
-int edac_dummy_init(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct edac_driver_api edac_dummy_api = { 0 };
 
-DEVICE_DEFINE(dummy_edac, "dummy_edac", edac_dummy_init, NULL,
+DEVICE_DEFINE(dummy_edac, "dummy_edac", NULL, NULL,
 	      NULL, NULL,
 	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
 	      &edac_dummy_api);

--- a/tests/subsys/fs/multi-fs/src/test_ram_backend.c
+++ b/tests/subsys/fs/multi-fs/src/test_ram_backend.c
@@ -18,11 +18,6 @@
 
 static uint8_t rambuf[TEST_PARTITION_SIZE];
 
-static int test_ram_flash_init(const struct device *dev)
-{
-	return 0;
-}
-
 static int test_flash_ram_erase(const struct device *dev, off_t offset,
 				size_t len)
 {
@@ -89,6 +84,5 @@ static const struct flash_driver_api flash_ram_api = {
 	.page_layout = test_flash_ram_pages_layout,
 };
 
-DEVICE_DEFINE(flash_ram_test, "ram_flash_test_drv", test_ram_flash_init,
-		NULL, NULL, NULL, POST_KERNEL,
-		CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_ram_api);
+DEVICE_DEFINE(flash_ram_test, "ram_flash_test_drv", NULL, NULL, NULL, NULL,
+	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &flash_ram_api);

--- a/tests/subsys/input/input_longpress/src/main.c
+++ b/tests/subsys/input/input_longpress/src/main.c
@@ -14,12 +14,7 @@ static const struct device *const fake_dev = DEVICE_DT_GET(
 static const struct device *const longpress_dev = DEVICE_DT_GET(
 		DT_NODELABEL(longpress));
 
-static int device_init(const struct device *dev)
-{
-	return 0;
-}
-
-DEVICE_DT_DEFINE(DT_INST(0, vnd_input_device), device_init, NULL, NULL, NULL,
+DEVICE_DT_DEFINE(DT_INST(0, vnd_input_device), NULL, NULL, NULL, NULL,
 		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
 
 static int event_count;

--- a/tests/subsys/ipc/ipc_service/src/backend.c
+++ b/tests/subsys/ipc/ipc_service/src/backend.c
@@ -68,15 +68,6 @@ const static struct ipc_service_backend backend_ops = {
 	.deregister_endpoint = deregister_ept,
 };
 
-static int backend_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	/* Nothing to do */
-
-	return 0;
-}
-
 #define DEFINE_BACKEND_DEVICE(i)					\
 	static struct backend_config_t backend_config_##i = {		\
 		.offset = DT_INST_PROP(i, offset),			\
@@ -85,7 +76,7 @@ static int backend_init(const struct device *dev)
 	static struct backend_data_t backend_data_##i;			\
 									\
 	DEVICE_DT_INST_DEFINE(i,					\
-			 &backend_init,					\
+			 NULL,						\
 			 NULL,						\
 			 &backend_data_##i,				\
 			 &backend_config_##i,				\

--- a/tests/subsys/openthread/radio_test.c
+++ b/tests/subsys/openthread/radio_test.c
@@ -73,15 +73,8 @@ static struct ieee802154_radio_api rapi = {.get_capabilities = get_capabilities,
 #endif /* CONFIG_NET_L2_IEEE802154_SUB_GHZ */
 					   .ed_scan = scan_mock};
 
-static int init_mock(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 #define DT_DRV_COMPAT vnd_ieee802154
-DEVICE_DT_INST_DEFINE(0, init_mock, NULL, NULL, NULL, POST_KERNEL, 0, &rapi);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, 0, &rapi);
 
 static const struct device *const radio = DEVICE_DT_INST_GET(0);
 

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -217,13 +217,8 @@ ZTEST(device_runtime_api, test_api)
 	zassert_equal(ret, 0);
 }
 
-static int pm_unsupported_init(const struct device *dev)
-{
-	return 0;
-}
-
-DEVICE_DEFINE(pm_unsupported_device, "PM Unsupported", pm_unsupported_init,
-	      NULL, NULL, NULL, APPLICATION, 0, NULL);
+DEVICE_DEFINE(pm_unsupported_device, "PM Unsupported", NULL, NULL, NULL, NULL,
+	      APPLICATION, 0, NULL);
 
 ZTEST(device_runtime_api, test_unsupported)
 {
@@ -236,11 +231,6 @@ ZTEST(device_runtime_api, test_unsupported)
 	zassert_equal(pm_device_runtime_put(dev), 0, "");
 }
 
-static int dev_init(const struct device *dev)
-{
-	return 0;
-}
-
 int dev_pm_control(const struct device *dev, enum pm_device_action action)
 {
 	ARG_UNUSED(dev);
@@ -250,7 +240,7 @@ int dev_pm_control(const struct device *dev, enum pm_device_action action)
 }
 
 PM_DEVICE_DT_DEFINE(DT_NODELABEL(test_dev), dev_pm_control);
-DEVICE_DT_DEFINE(DT_NODELABEL(test_dev), dev_init, PM_DEVICE_DT_GET(DT_NODELABEL(test_dev)),
+DEVICE_DT_DEFINE(DT_NODELABEL(test_dev), NULL, PM_DEVICE_DT_GET(DT_NODELABEL(test_dev)),
 		 NULL, NULL, POST_KERNEL, 80, NULL);
 
 ZTEST(device_runtime_api, test_pm_device_runtime_auto)

--- a/tests/subsys/pm/power_domain/src/main.c
+++ b/tests/subsys/pm/power_domain/src/main.c
@@ -21,13 +21,6 @@ static const struct device *devc;
 static int testing_domain_on_notitication;
 static int testing_domain_off_notitication;
 
-static int dev_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static int domain_pm_action(const struct device *dev,
 	enum pm_device_action action)
 {
@@ -99,19 +92,19 @@ static int devb_pm_action(const struct device *dev,
 
 
 PM_DEVICE_DT_DEFINE(TEST_DOMAIN, domain_pm_action);
-DEVICE_DT_DEFINE(TEST_DOMAIN, dev_init, PM_DEVICE_DT_GET(TEST_DOMAIN),
+DEVICE_DT_DEFINE(TEST_DOMAIN, NULL, PM_DEVICE_DT_GET(TEST_DOMAIN),
 		 NULL, NULL, POST_KERNEL, 10, NULL);
 
 PM_DEVICE_DT_DEFINE(TEST_DEVA, deva_pm_action);
-DEVICE_DT_DEFINE(TEST_DEVA, dev_init, PM_DEVICE_DT_GET(TEST_DEVA),
+DEVICE_DT_DEFINE(TEST_DEVA, NULL, PM_DEVICE_DT_GET(TEST_DEVA),
 		 NULL, NULL, POST_KERNEL, 20, NULL);
 
 PM_DEVICE_DT_DEFINE(TEST_DEVB, devb_pm_action);
-DEVICE_DT_DEFINE(TEST_DEVB, dev_init, PM_DEVICE_DT_GET(TEST_DEVB),
+DEVICE_DT_DEFINE(TEST_DEVB, NULL, PM_DEVICE_DT_GET(TEST_DEVB),
 		 NULL, NULL, POST_KERNEL, 30, NULL);
 
 PM_DEVICE_DEFINE(devc, deva_pm_action);
-DEVICE_DEFINE(devc, "devc", dev_init, PM_DEVICE_GET(devc),
+DEVICE_DEFINE(devc, "devc", NULL, PM_DEVICE_GET(devc),
 	      NULL, NULL,
 	      APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
 
@@ -234,11 +227,11 @@ ZTEST(power_domain_1cpu, test_power_domain_device_runtime)
 #define TEST_DEV_BALANCED DT_NODELABEL(test_dev_balanced)
 
 PM_DEVICE_DT_DEFINE(TEST_DOMAIN_BALANCED, domain_pm_action);
-DEVICE_DT_DEFINE(TEST_DOMAIN_BALANCED, dev_init, PM_DEVICE_DT_GET(TEST_DOMAIN_BALANCED),
+DEVICE_DT_DEFINE(TEST_DOMAIN_BALANCED, NULL, PM_DEVICE_DT_GET(TEST_DOMAIN_BALANCED),
 		 NULL, NULL, POST_KERNEL, 10, NULL);
 
 PM_DEVICE_DT_DEFINE(TEST_DEV_BALANCED, deva_pm_action);
-DEVICE_DT_DEFINE(TEST_DEV_BALANCED, dev_init, PM_DEVICE_DT_GET(TEST_DEV_BALANCED),
+DEVICE_DT_DEFINE(TEST_DEV_BALANCED, NULL, PM_DEVICE_DT_GET(TEST_DEV_BALANCED),
 		 NULL, NULL, POST_KERNEL, 20, NULL);
 
 /**

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -53,15 +53,6 @@ static const struct device *const device_c =
  * when suspending / resuming device B.
  */
 
-
-/* Common init function for devices A,B and C */
-static int device_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
 static int device_a_pm_action(const struct device *dev,
 		enum pm_device_action pm_action)
 {
@@ -73,7 +64,7 @@ static int device_a_pm_action(const struct device *dev,
 
 PM_DEVICE_DT_DEFINE(DT_INST(0, test_device_pm), device_a_pm_action);
 
-DEVICE_DT_DEFINE(DT_INST(0, test_device_pm), device_init,
+DEVICE_DT_DEFINE(DT_INST(0, test_device_pm), NULL,
 		PM_DEVICE_DT_GET(DT_INST(0, test_device_pm)), NULL, NULL,
 		PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);
@@ -118,7 +109,7 @@ static int device_b_pm_action(const struct device *dev,
 
 PM_DEVICE_DT_DEFINE(DT_INST(1, test_device_pm), device_b_pm_action);
 
-DEVICE_DT_DEFINE(DT_INST(1, test_device_pm), device_init,
+DEVICE_DT_DEFINE(DT_INST(1, test_device_pm), NULL,
 		PM_DEVICE_DT_GET(DT_INST(1, test_device_pm)), NULL, NULL,
 		PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);
@@ -134,7 +125,7 @@ static int device_c_pm_action(const struct device *dev,
 
 PM_DEVICE_DT_DEFINE(DT_INST(2, test_device_pm), device_c_pm_action);
 
-DEVICE_DT_DEFINE(DT_INST(2, test_device_pm), device_init,
+DEVICE_DT_DEFINE(DT_INST(2, test_device_pm), NULL,
 		PM_DEVICE_DT_GET(DT_INST(2, test_device_pm)), NULL, NULL,
 		POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		NULL);


### PR DESCRIPTION
Some devices do not need to perform any initialization, so allow the
init function to be NULL. In this case, the initialization code will
just mark the device as initialized, i.e. ready.

Removed all redundant init functions I found throughout the tree (2nd commit).