### PR TITLE
net: lib: dns: mdns_responder: Simplify query handling

### DIFF
--- a/include/zephyr/net/dns_sd.h
+++ b/include/zephyr/net/dns_sd.h
@@ -86,36 +86,36 @@ extern "C" {
  * @brief Register a service for DNS Service Discovery
  *
  * This macro should be used for advanced use cases. Two simple use cases are
- * when a custom @p domain or a custom (non-standard) @p proto is required.
+ * when a custom @p _domain or a custom (non-standard) @p _proto is required.
  *
  * Another use case is when the port number is not preassigned. That could
  * be for a number of reasons, but the most common use case would be for
  * ephemeral port usage - i.e. when the service is bound using port number 0.
  * In that case, Zephyr (like other OS's) will simply choose an unused port.
- * When using ephemeral ports, it can be helpful to assign @p port to the
+ * When using ephemeral ports, it can be helpful to assign @p _port to the
  * @ref sockaddr_in.sin_port field of an IPv4 @ref sockaddr_in, or to the
  * @ref sockaddr_in6.sin6_port field of an IPv6 @ref sockaddr_in6.
  *
- * The service can be referenced using the @p id variable.
+ * The service can be referenced using the @p _id variable.
  *
- * @param id variable name for the DNS-SD service record
- * @param instance name of the service instance such as "My HTTP Server"
- * @param service name of the service, such as "_http"
- * @param proto protocol used by the service - either "_tcp" or "_udp"
- * @param domain the domain of the service, such as "local"
- * @param text information for the DNS TXT record
- * @param port a pointer to the port number that this service will use
+ * @param _id variable name for the DNS-SD service record
+ * @param _instance name of the service instance such as "My HTTP Server"
+ * @param _service name of the service, such as "_http"
+ * @param _proto protocol used by the service - either "_tcp" or "_udp"
+ * @param _domain the domain of the service, such as "local"
+ * @param _text information for the DNS TXT record
+ * @param _port a pointer to the port number that this service will use
  */
-#define DNS_SD_REGISTER_SERVICE(id, instance, service, proto, domain, \
-				text, port)			      \
-	static const STRUCT_SECTION_ITERABLE(dns_sd_rec, id) = {      \
-		instance,					      \
-		service,					      \
-		proto,						      \
-		domain,						      \
-		(const char *)text,				      \
-		sizeof(text) - 1,				      \
-		port						      \
+#define DNS_SD_REGISTER_SERVICE(_id, _instance, _service, _proto,	\
+				_domain, _text, _port)			\
+	static const STRUCT_SECTION_ITERABLE(dns_sd_rec, _id) = {	\
+		.instance = _instance,					\
+		.service = _service,					\
+		.proto = _proto,					\
+		.domain = _domain,					\
+		.text = (const char *)_text,				\
+		.text_size = sizeof(_text) - 1,				\
+		.port = _port,						\
 	}
 
 /**

--- a/subsys/net/lib/dns/dns_sd.c
+++ b/subsys/net/lib/dns/dns_sd.c
@@ -103,6 +103,7 @@ bool label_is_valid(const char *label, size_t label_size)
 	size_t i;
 
 	if (label == NULL) {
+		NET_DBG("label is NULL");
 		return false;
 	}
 
@@ -113,6 +114,10 @@ bool label_is_valid(const char *label, size_t label_size)
 
 	if (label_size < DNS_LABEL_MIN_SIZE ||
 	    label_size > DNS_LABEL_MAX_SIZE) {
+		NET_DBG("label invalid size (%zu, min: %u, max: %u)",
+			 label_size,
+			 DNS_LABEL_MIN_SIZE,
+			 DNS_LABEL_MAX_SIZE);
 		return false;
 	}
 
@@ -131,6 +136,7 @@ bool label_is_valid(const char *label, size_t label_size)
 			}
 		}
 
+		NET_DBG("label '%s' contains illegal byte 0x%02x", label, label[i]);
 		return false;
 	}
 
@@ -143,20 +149,20 @@ static bool instance_is_valid(const char *instance)
 	size_t instance_size;
 
 	if (instance == NULL) {
-		NET_DBG("label is NULL");
+		NET_DBG("instance is NULL");
 		return false;
 	}
 
 	instance_size = strlen(instance);
 	if (instance_size < DNS_SD_INSTANCE_MIN_SIZE) {
-		NET_DBG("label '%s' is too small (%zu, min: %u)",
+		NET_DBG("instance '%s' is too small (%zu, min: %u)",
 			instance, instance_size,
 			DNS_SD_INSTANCE_MIN_SIZE);
 		return false;
 	}
 
 	if (instance_size > DNS_SD_INSTANCE_MAX_SIZE) {
-		NET_DBG("label '%s' is too big (%zu, max: %u)",
+		NET_DBG("instance '%s' is too big (%zu, max: %u)",
 			instance, instance_size,
 			DNS_SD_INSTANCE_MAX_SIZE);
 		return false;
@@ -181,19 +187,19 @@ static bool service_is_valid(const char *service)
 	size_t service_size;
 
 	if (service == NULL) {
-		NET_DBG("label is NULL");
+		NET_DBG("service is NULL");
 		return false;
 	}
 
 	service_size = strlen(service);
 	if (service_size < DNS_SD_SERVICE_MIN_SIZE) {
-		NET_DBG("label '%s' is too small (%zu, min: %u)",
+		NET_DBG("service '%s' is too small (%zu, min: %u)",
 			service, service_size, DNS_SD_SERVICE_MIN_SIZE);
 		return false;
 	}
 
 	if (service_size > DNS_SD_SERVICE_MAX_SIZE) {
-		NET_DBG("label '%s' is too big (%zu, max: %u)",
+		NET_DBG("service '%s' is too big (%zu, max: %u)",
 			service, service_size, DNS_SD_SERVICE_MAX_SIZE);
 		return false;
 	}
@@ -218,13 +224,13 @@ static bool proto_is_valid(const char *proto)
 	size_t proto_size;
 
 	if (proto == NULL) {
-		NET_DBG("label is NULL");
+		NET_DBG("proto is NULL");
 		return false;
 	}
 
 	proto_size = strlen(proto);
 	if (proto_size != DNS_SD_PROTO_SIZE) {
-		NET_DBG("label '%s' wrong size (%zu, exp: %u)",
+		NET_DBG("proto '%s' wrong size (%zu, exp: %u)",
 			proto, proto_size, DNS_SD_PROTO_SIZE);
 		return false;
 	}
@@ -245,19 +251,19 @@ static bool domain_is_valid(const char *domain)
 	size_t domain_size;
 
 	if (domain == NULL) {
-		NET_DBG("label is NULL");
+		NET_DBG("domain is NULL");
 		return false;
 	}
 
 	domain_size = strlen(domain);
 	if (domain_size < DNS_SD_DOMAIN_MIN_SIZE) {
-		NET_DBG("label '%s' is too small (%zu, min: %u)",
+		NET_DBG("domain '%s' is too small (%zu, min: %u)",
 			domain, domain_size, DNS_SD_DOMAIN_MIN_SIZE);
 		return false;
 	}
 
 	if (domain_size > DNS_SD_DOMAIN_MAX_SIZE) {
-		NET_DBG("label '%s' is too big (%zu, max: %u)",
+		NET_DBG("domain '%s' is too big (%zu, max: %u)",
 			domain, domain_size, DNS_SD_DOMAIN_MAX_SIZE);
 		return false;
 	}
@@ -926,7 +932,7 @@ bool dns_sd_rec_match(const struct dns_sd_rec *record,
 	};
 
 	if (!rec_is_valid(record)) {
-		LOG_WRN("DNS SD record at %p is invalid", record);
+		LOG_DBG("DNS SD record at %p is invalid", record);
 		return false;
 	}
 

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -251,8 +251,9 @@ static int create_answer(struct net_context *ctx,
 }
 
 static int send_response(struct net_context *ctx,
-			 struct net_pkt *pkt,
-			 union net_ip_header *ip_hdr,
+			 struct net_if *iface,
+			 sa_family_t family,
+			 const void *src_addr,
 			 struct net_buf *query,
 			 enum dns_rr_type qtype)
 {
@@ -260,7 +261,7 @@ static int send_response(struct net_context *ctx,
 	socklen_t dst_len;
 	int ret;
 
-	ret = setup_dst_addr(ctx, net_pkt_family(pkt), &dst, &dst_len);
+	ret = setup_dst_addr(ctx, family, &dst, &dst_len);
 	if (ret < 0) {
 		NET_DBG("unable to set up the response address");
 		return ret;
@@ -269,22 +270,20 @@ static int send_response(struct net_context *ctx,
 	if (IS_ENABLED(CONFIG_NET_IPV4) && qtype == DNS_RR_TYPE_A) {
 		const struct in_addr *addr;
 
-		addr = net_if_ipv4_select_src_addr(net_pkt_iface(pkt),
-						   (struct in_addr *)ip_hdr->ipv4->src);
+		addr = net_if_ipv4_select_src_addr(iface,
+			family == AF_INET ? (struct in_addr *)src_addr : NULL);
 
-		ret = create_answer(ctx, query, qtype,
-				      sizeof(struct in_addr), (uint8_t *)addr);
+		ret = create_answer(ctx, query, qtype, sizeof(struct in_addr), (uint8_t *)addr);
 		if (ret != 0) {
 			return ret;
 		}
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) && qtype == DNS_RR_TYPE_AAAA) {
 		const struct in6_addr *addr;
 
-		addr = net_if_ipv6_select_src_addr(net_pkt_iface(pkt),
-						   (struct in6_addr *)ip_hdr->ipv6->src);
+		addr = net_if_ipv6_select_src_addr(iface,
+			family == AF_INET6 ? (struct in6_addr *)src_addr : NULL);
 
-		ret = create_answer(ctx, query, qtype,
-				      sizeof(struct in6_addr), (uint8_t *)addr);
+		ret = create_answer(ctx, query, qtype, sizeof(struct in6_addr), (uint8_t *)addr);
 		if (ret != 0) {
 			return -ENOMEM;
 		}
@@ -316,8 +315,11 @@ static const char *qtype_to_string(int qtype)
 }
 
 static void send_sd_response(struct net_context *ctx,
-		 struct net_pkt *pkt, union net_ip_header *ip_hdr,
-		 struct dns_msg_t *dns_msg, struct net_buf *result)
+			     struct net_if *iface,
+			     sa_family_t family,
+			     const void *src_addr,
+			     struct dns_msg_t *dns_msg,
+			     struct net_buf *result)
 {
 	int ret;
 	const struct dns_sd_rec *record;
@@ -355,7 +357,7 @@ static void send_sd_response(struct net_context *ctx,
 	/* This actually is used but the compiler doesn't see that */
 	ARG_UNUSED(record);
 
-	ret = setup_dst_addr(ctx, net_pkt_family(pkt), &dst, &dst_len);
+	ret = setup_dst_addr(ctx, family, &dst, &dst_len);
 	if (ret < 0) {
 		NET_DBG("unable to set up the response address");
 		return;
@@ -363,14 +365,14 @@ static void send_sd_response(struct net_context *ctx,
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		/* Look up the local IPv4 address */
-		addr4 = net_if_ipv4_select_src_addr(net_pkt_iface(pkt),
-						    (struct in_addr *)ip_hdr->ipv4->src);
+		addr4 = net_if_ipv4_select_src_addr(iface,
+			family == AF_INET ? (struct in_addr *)src_addr : NULL);
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
 		/* Look up the local IPv6 address */
-		addr6 = net_if_ipv6_select_src_addr(net_pkt_iface(pkt),
-						    (struct in6_addr *)ip_hdr->ipv6->src);
+		addr6 = net_if_ipv6_select_src_addr(iface,
+			family == AF_INET6 ? (struct in6_addr *)src_addr : NULL);
 	}
 
 	ret = dns_sd_query_extract(dns_msg->msg,
@@ -437,7 +439,6 @@ static void send_sd_response(struct net_context *ctx,
 
 static int dns_read(struct net_context *ctx,
 		    struct net_pkt *pkt,
-		    union net_ip_header *ip_hdr,
 		    struct net_buf *dns_data,
 		    struct dns_addrinfo *info)
 {
@@ -446,6 +447,7 @@ static int dns_read(struct net_context *ctx,
 	int hostname_len = strlen(hostname);
 	struct net_buf *result;
 	struct dns_msg_t dns_msg;
+	const void *src_addr;
 	int data_len;
 	int queries;
 	int ret;
@@ -479,11 +481,12 @@ static int dns_read(struct net_context *ctx,
 
 	queries = ret;
 
+	src_addr = net_pkt_family(pkt) == AF_INET
+		 ? (const void *)&NET_IPV4_HDR(pkt)->src : (const void *)&NET_IPV6_HDR(pkt)->src;
+
 	NET_DBG("Received %d %s from %s", queries,
 		queries > 1 ? "queries" : "query",
-		net_pkt_family(pkt) == AF_INET ?
-		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src) :
-		net_sprint_ipv6_addr(&NET_IPV6_HDR(pkt)->src));
+		net_sprint_addr(net_pkt_family(pkt), src_addr));
 
 	do {
 		enum dns_rr_type qtype;
@@ -517,10 +520,12 @@ static int dns_read(struct net_context *ctx,
 		    &(result->data + 1)[hostname_len] == lquery) {
 			NET_DBG("mDNS query to our hostname %s.local",
 				hostname);
-			send_response(ctx, pkt, ip_hdr, result, qtype);
+			send_response(ctx, net_pkt_iface(pkt), net_pkt_family(pkt), src_addr,
+				      result, qtype);
 		} else if (IS_ENABLED(CONFIG_MDNS_RESPONDER_DNS_SD)
 			&& qtype == DNS_RR_TYPE_PTR) {
-			send_sd_response(ctx, pkt, ip_hdr, &dns_msg, result);
+			send_sd_response(ctx, net_pkt_iface(pkt), net_pkt_family(pkt), src_addr,
+					 &dns_msg, result);
 		}
 
 	} while (--queries);
@@ -548,6 +553,8 @@ static void recv_cb(struct net_context *net_ctx,
 	int ret;
 
 	ARG_UNUSED(net_ctx);
+	ARG_UNUSED(ip_hdr);
+	ARG_UNUSED(proto_hdr);
 	NET_ASSERT(ctx == net_ctx);
 
 	if (!pkt) {
@@ -563,7 +570,7 @@ static void recv_cb(struct net_context *net_ctx,
 		goto quit;
 	}
 
-	ret = dns_read(ctx, pkt, ip_hdr, dns_data, &info);
+	ret = dns_read(ctx, pkt, dns_data, &info);
 	if (ret < 0 && ret != -EINVAL) {
 		NET_DBG("mDNS read failed (%d)", ret);
 	}


### PR DESCRIPTION
This PR updates some trivial logging, and fixes an issue with IPv4/IPv6 handling in `send_sd_response` if both `CONFIG_NET_IPV4` and `CONFIG_NET_IPV6` are enabled.