### PR TITLE
dts: binding: Added input and output enable

### DIFF
--- a/dts/bindings/pinctrl/renesas,smartbond-pinctrl.yaml
+++ b/dts/bindings/pinctrl/renesas,smartbond-pinctrl.yaml
@@ -83,6 +83,8 @@ child-binding:
         property-allowlist:
           - bias-pull-down
           - bias-pull-up
+          - output-enable
+          - input-enable
 
     properties:
       pinmux:


### PR DESCRIPTION
Udpate the device tree bindings to allow setting the pins into
input or output mode
