### PR TITLE
Bluetooth: BAP: Shell: Scan Delegator prefer past by default

### DIFF
--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -33,7 +33,7 @@ struct sync_state {
 	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
 } sync_states[CONFIG_BT_BAP_SCAN_DELEGATOR_RECV_STATE_COUNT];
 
-static bool past_preference;
+static bool past_preference = true;
 
 static struct sync_state *sync_state_get(const struct bt_bap_scan_delegator_recv_state *recv_state)
 {


### PR DESCRIPTION
Change the default value of past_preference to true, to prefer PAST by default when using the scan delegator.