### PR TITLE
Bluetooth:controller: disallow enc start/pause when CIS established

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -60,6 +60,7 @@
 #include "ll_sw/isoal.h"
 #include "ll_sw/ull_iso_types.h"
 #include "ll_sw/ull_conn_iso_types.h"
+#include "ll_sw/ull_conn_iso_internal.h"
 
 #include "ll_sw/ull_llcp.h"
 
@@ -554,6 +555,14 @@ uint8_t ll_enc_req_send(uint16_t handle, uint8_t const *const rand_num,
 	if (!conn) {
 		return BT_HCI_ERR_UNKNOWN_CONN_ID;
 	}
+
+#if defined(CONFIG_BT_CTLR_CENTRAL_ISO)
+	struct ll_conn_iso_stream *cis = ll_conn_iso_stream_get_by_acl(conn, NULL);
+
+	if (cis || ull_lp_cc_is_enqueued(conn)) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
+#endif /* CONFIG_BT_CTLR_CENTRAL_ISO */
 
 	if (!conn->lll.enc_tx && !conn->lll.enc_rx) {
 		/* Encryption is fully disabled */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1349,6 +1349,15 @@ bool ull_lp_cc_is_active(struct ll_conn *conn)
 	}
 	return false;
 }
+
+bool ull_lp_cc_is_enqueued(struct ll_conn *conn)
+{
+	struct proc_ctx *ctx;
+
+	ctx = llcp_lr_peek_proc(conn, PROC_CIS_CREATE);
+
+	return (ctx != NULL);
+}
 #endif /* defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_CTLR_CENTRAL_ISO) */
 
 static bool pdu_is_expected(struct pdu_data *pdu, struct proc_ctx *ctx)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -223,6 +223,11 @@ void ull_cp_cc_established(struct ll_conn *conn, uint8_t error_code);
 bool ull_lp_cc_is_active(struct ll_conn *conn);
 
 /**
+ * @brief CIS creation ongoing or enqueued.
+ */
+bool ull_lp_cc_is_enqueued(struct ll_conn *conn);
+
+/**
  * @brief Initiate a Channel Map Update Procedure.
  */
 uint8_t ull_cp_chan_map_update(struct ll_conn *conn, const uint8_t chm[5]);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -511,6 +511,7 @@ void llcp_pdu_decode_terminate_ind(struct proc_ctx *ctx, struct pdu_data *pdu);
  * LLCP Local Request
  */
 struct proc_ctx *llcp_lr_peek(struct ll_conn *conn);
+struct proc_ctx *llcp_lr_peek_proc(struct ll_conn *conn, uint8_t proc);
 bool llcp_lr_ispaused(struct ll_conn *conn);
 void llcp_lr_pause(struct ll_conn *conn);
 void llcp_lr_resume(struct ll_conn *conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -169,6 +169,27 @@ struct proc_ctx *llcp_lr_peek(struct ll_conn *conn)
 	return ctx;
 }
 
+struct proc_ctx *llcp_lr_peek_proc(struct ll_conn *conn, uint8_t proc)
+{
+	/* This function is called from both Thread and Mayfly (ISR),
+	 * make sure only a single context have access at a time.
+	 */
+
+	struct proc_ctx *ctx, *tmp;
+
+	bool key = shared_data_access_lock();
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn->llcp.local.pend_proc_list, ctx, tmp, node) {
+		if (ctx->proc == proc) {
+			break;
+		}
+	}
+
+	shared_data_access_unlock(key);
+
+	return ctx;
+}
+
 bool llcp_lr_ispaused(struct ll_conn *conn)
 {
 	return conn->llcp.local.pause == 1U;

--- a/tests/bluetooth/controller/ctrl_api/src/main.c
+++ b/tests/bluetooth/controller/ctrl_api/src/main.c
@@ -334,6 +334,23 @@ ZTEST(public, test_int_pause_resume_data_path)
 	zassert_equal_ptr(node, NULL, "");
 }
 
+ZTEST(public, test_check_peek_proc)
+{
+	struct proc_ctx *ctx1, *ctx2;
+
+	ctx1 = llcp_create_local_procedure(PROC_CHAN_MAP_UPDATE);
+	llcp_lr_enqueue(&conn, ctx1);
+
+	zassert_is_null(llcp_lr_peek_proc(&conn, PROC_CIS_CREATE), "CTX is not null");
+	zassert_equal(llcp_lr_peek_proc(&conn, PROC_CHAN_MAP_UPDATE), ctx1, "CTX is not correct");
+
+	ctx2 = llcp_create_local_procedure(PROC_CIS_CREATE);
+	llcp_lr_enqueue(&conn, ctx2);
+
+	zassert_equal(llcp_lr_peek_proc(&conn, PROC_CHAN_MAP_UPDATE), ctx1, "CTX is not correct");
+	zassert_equal(llcp_lr_peek_proc(&conn, PROC_CIS_CREATE), ctx2, "CTX is not correct");
+	zassert_is_null(llcp_lr_peek_proc(&conn, PROC_CIS_TERMINATE), "CTX is not null");
+}
 
 ZTEST(internal, test_int_mem_proc_ctx)
 {
@@ -540,7 +557,6 @@ ZTEST(internal, test_int_remote_pending_requests)
 	dequeue_ctx = llcp_rr_dequeue(&conn);
 	zassert_is_null(dequeue_ctx, NULL);
 }
-
 
 ZTEST_SUITE(public, NULL, NULL, NULL, NULL, NULL);
 ZTEST_SUITE(internal, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Start/pause encryption should not be initiated on ACL with CIS established (BT Core Spec 5.4, Vol 6, Part B, Sect. 5.1.3)