### PR TITLE
clang-format: UseTab use ForContinuationAndIndentation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -82,7 +82,7 @@ IndentWidth: 8
 InsertBraces: true
 SpaceBeforeParens: ControlStatementsExceptControlMacros
 SortIncludes: Never
-UseTab: Always
+UseTab: ForContinuationAndIndentation
 WhitespaceSensitiveMacros:
   - STRINGIFY
   - Z_STRINGIFY


### PR DESCRIPTION
Modify UseTab to use ForContinuationAndIndentation instead of always. This will only use tabs for indentation, and then spaces for alignment, which is the most commonly used approach in Zephyr.

See https://clang.llvm.org/docs/ClangFormatStyleOptions.html#usetab for more