### PR TITLE
arc: boards: openocd: replace obsolete syntax

### DIFF
--- a/boards/arc/em_starterkit/support/openocd.cfg
+++ b/boards/arc/em_starterkit/support/openocd.cfg
@@ -1,11 +1,11 @@
 # Configure JTAG cable
 # EM Starter Kit has built-in FT2232 chip, which is similar to Digilent HS-1.
 adapter driver ftdi
-ftdi_vid_pid 0x0403 0x6010
+ftdi vid_pid 0x0403 0x6010
 # channel 1 does not have any functionality
-ftdi_channel 0
+ftdi channel 0
 # just TCK TDI TDO TMS, no reset
-ftdi_layout_init 0x0088 0x008b
+ftdi layout_init 0x0088 0x008b
 reset_config none
 
 # Only specify FTDI serial number if it is specified via

--- a/boards/arc/emsdp/support/openocd.cfg
+++ b/boards/arc/emsdp/support/openocd.cfg
@@ -16,9 +16,9 @@ if { [info exists _ZEPHYR_BOARD_SERIAL] } {
        ftdi_serial $_ZEPHYR_BOARD_SERIAL
 }
 
-ftdi_vid_pid 0x0403 0x6010
-ftdi_layout_init 0x0088 0x008b
-ftdi_channel 0
+ftdi vid_pid 0x0403 0x6010
+ftdi layout_init 0x0088 0x008b
+ftdi channel 0
 
 
 # EM11D requires 10 MHz.
@@ -36,7 +36,7 @@ set _TARGETNAME $_CHIPNAME.cpu
 jtag newtap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -expected-id 0x200044b1
 
 set _coreid 0
-set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+set _dbgbase [expr {0x00000000 | ($_coreid << 13)}]
 
 target create $_TARGETNAME arcv2 -chain-position $_TARGETNAME \
   -coreid 0 -dbgbase $_dbgbase -endian little

--- a/boards/arc/iotdk/support/openocd.cfg
+++ b/boards/arc/iotdk/support/openocd.cfg
@@ -16,9 +16,9 @@ if { [info exists _ZEPHYR_BOARD_SERIAL] } {
 	ftdi_serial $_ZEPHYR_BOARD_SERIAL
 }
 
-ftdi_vid_pid 0x0403 0x6010
-ftdi_layout_init 0x0088 0x008b
-ftdi_channel 1
+ftdi vid_pid 0x0403 0x6010
+ftdi layout_init 0x0088 0x008b
+ftdi channel 1
 
 
 # EM9D requires 8 MHz.
@@ -36,7 +36,7 @@ set _TARGETNAME $_CHIPNAME.cpu
 jtag newtap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -expected-id 0x200444b1
 
 set _coreid 0
-set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+set _dbgbase [expr {0x00000000 | ($_coreid << 13)}]
 
 target create $_TARGETNAME arcv2 -chain-position $_TARGETNAME \
   -coreid 0 -dbgbase $_dbgbase -endian little


### PR DESCRIPTION
Reaplace obsolete syntax in OpenOCD configuration scripts