### PR TITLE
tests: rtio: fix compile warning with arm-clang

### DIFF
--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -433,7 +433,7 @@ void test_rtio_transaction_(struct rtio *r)
 		}
 		uintptr_t idx = *(uintptr_t *)cqe->userdata;
 
-		TC_PRINT("userdata is %p, value %lu\n", cqe->userdata, idx);
+		TC_PRINT("userdata is %p, value %" PRIuPTR "\n", cqe->userdata, idx);
 		zassert(idx == 0 || idx == 1, "idx should be 0 or 1");
 		seen[idx] = true;
 		rtio_spsc_release(r->cq);


### PR DESCRIPTION
When building the rtio_api tests with arm-clang we get the following compiler warning:

rtio_api/src/test_rtio_api.c:436:58: warning: format specifies type 'unsigned long' but the argument has type 'uintptr_t' (aka 'unsigned int') [-Wformat]

        TC_PRINT("userdata is %p, value %lu\n", cqe->userdata, idx);
                                        ~~~                    ^~~
                                        %u

Use PRIuPTR to fix the issue.