### PR TITLE
rtio: Remove unused linker section

### DIFF
--- a/include/zephyr/linker/common-ram.ld
+++ b/include/zephyr/linker/common-ram.ld
@@ -148,14 +148,6 @@
 
 
 #if defined(CONFIG_RTIO)
-	SECTION_DATA_PROLOGUE(rtio,,SUBALIGN(4))
-	{
-		__rtio_start = .;
-		*(".rtio.*")
-		KEEP(*(SORT_BY_NAME(".rtio.*")))
-		__rtio_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
 	ITERABLE_SECTION_RAM(rtio, 4)
 	ITERABLE_SECTION_RAM(rtio_iodev, 4)
 #endif /* CONFIG_RTIO */


### PR DESCRIPTION
rtio is utilizing iterable sections so the explicit linker code does not need to exist so we can remove it.