### PR TITLE
logging: Use TYPE_SECTION macros for log strings

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -165,8 +165,7 @@ if(CONFIG_PCIE)
   zephyr_linker_section_configure(SECTION irq_alloc INPUT ".irq_alloc*" KEEP SORT NAME)
 endif()
 
-zephyr_linker_section(NAME log_strings KVMA RAM_REGION GROUP RODATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT})
-zephyr_linker_section_configure(SECTION log_strings INPUT ".log_strings*" KEEP SORT NAME)
+zephyr_iterable_section(NAME log_strings KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 
 zephyr_linker_section(NAME log_const KVMA RAM_REGION GROUP RODATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT})
 zephyr_linker_section_configure(SECTION log_const INPUT ".log_const_*" KEEP SORT NAME)

--- a/include/zephyr/linker/common-rom/common-rom-logging.ld
+++ b/include/zephyr/linker/common-rom/common-rom-logging.ld
@@ -1,11 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-	SECTION_DATA_PROLOGUE(log_strings_sections,,)
-	{
-		__log_strings_start = .;
-		KEEP(*(SORT(.log_strings*)));
-		__log_strings_end = .;
-	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	ITERABLE_SECTION_ROM(log_strings, 4)
 
 	SECTION_DATA_PROLOGUE(log_const_sections,,)
 	{

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -341,8 +341,7 @@ do { \
 #define Z_LOG_MSG_STR_VAR_IN_SECTION(_name, ...) \
 	COND_CODE_0(NUM_VA_ARGS_LESS_1(_, ##__VA_ARGS__), \
 		    (/* No args provided, no variable */), \
-		    (static const char _name[] \
-			__attribute__((__section__(".log_strings"))) = \
+		    (static const TYPE_SECTION_ITERABLE(char *, _name, log_strings, _name) = \
 			GET_ARG_N(1, __VA_ARGS__);))
 
 /** @brief Create variable in the dedicated memory section (if enabled).

--- a/subsys/logging/log_output_syst.c
+++ b/subsys/logging/log_output_syst.c
@@ -629,11 +629,11 @@ static int mipi_vprintf_formatter(cbprintf_cb out, void *ctx,
 
 static inline bool is_in_log_strings_section(const void *addr)
 {
-	extern const char __log_strings_start[];
-	extern const char __log_strings_end[];
+	TYPE_SECTION_START_EXTERN(const char *, log_strings);
+	TYPE_SECTION_END_EXTERN(const char *, log_strings);
 
-	if (((const char *)addr >= (const char *)__log_strings_start) &&
-	    ((const char *)addr < (const char *)__log_strings_end)) {
+	if (((const char *)addr >= (const char *)TYPE_SECTION_START(log_strings)) &&
+	    ((const char *)addr < (const char *)TYPE_SECTION_END(log_strings))) {
 		return true;
 	}
 


### PR DESCRIPTION
Clean up log_strings to utilize macros for handling sections.