### PR TITLE
Revert "adc: harness regex string not capturing sample app"

### DIFF
--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -16,5 +16,5 @@ tests:
     harness_config:
       type: multi_line
       regex:
-        - "ADC reading\\[\\d+\\]"
+        - "ADC reading\\[\\d+\\]:"
         - "- .+, channel \\d+: -?\\d+"


### PR DESCRIPTION
Reverts zephyrproject-rtos/zephyr#56992