### PR TITLE
logging: Use TYPE_SECTION macros

### DIFF
--- a/cmake/linker_script/common/common-ram.cmake
+++ b/cmake/linker_script/common/common-ram.cmake
@@ -21,8 +21,7 @@ if(CONFIG_PM_DEVICE)
   zephyr_iterable_section(NAME pm_device_slots GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
 endif()
 
-zephyr_linker_section(NAME log_dynamic GROUP DATA_REGION NOINPUT)
-zephyr_linker_section_configure(SECTION log_dynamic KEEP INPUT ".log_dynamic_*")
+zephyr_iterable_section(NAME log_dynamic GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
 
 if(CONFIG_USERSPACE)
   # All kernel objects within are assumed to be either completely

--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -167,8 +167,7 @@ endif()
 zephyr_linker_section(NAME log_strings KVMA RAM_REGION GROUP RODATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT})
 zephyr_linker_section_configure(SECTION log_strings INPUT ".log_strings*" KEEP SORT NAME)
 
-zephyr_linker_section(NAME log_const KVMA RAM_REGION GROUP RODATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT})
-zephyr_linker_section_configure(SECTION log_const INPUT ".log_const_*" KEEP SORT NAME)
+zephyr_iterable_section(NAME log_const KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 
 zephyr_iterable_section(NAME shell KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 

--- a/include/zephyr/linker/common-ram.ld
+++ b/include/zephyr/linker/common-ram.ld
@@ -49,13 +49,7 @@
 
 	ITERABLE_SECTION_RAM_GC_ALLOWED(log_mpsc_pbuf, 4)
 	ITERABLE_SECTION_RAM(log_msg_ptr, 4)
-
-	SECTION_DATA_PROLOGUE(log_dynamic_sections,,)
-	{
-		__log_dynamic_start = .;
-		KEEP(*(SORT(.log_dynamic_*)));
-		__log_dynamic_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	ITERABLE_SECTION_RAM(log_dynamic, 4)
 
 #ifdef CONFIG_USERSPACE
 	/* All kernel objects within are assumed to be either completely

--- a/include/zephyr/linker/common-rom/common-rom-logging.ld
+++ b/include/zephyr/linker/common-rom/common-rom-logging.ld
@@ -7,12 +7,7 @@
 		__log_strings_end = .;
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-	SECTION_DATA_PROLOGUE(log_const_sections,,)
-	{
-		__log_const_start = .;
-		KEEP(*(SORT(.log_const_*)));
-		__log_const_end = .;
-	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	ITERABLE_SECTION_ROM(log_const, 4)
 
 	ITERABLE_SECTION_ROM(log_backend, 4)
 

--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -298,9 +298,10 @@ void z_log_vprintk(const char *fmt, va_list ap);
 
 #define _LOG_MODULE_CONST_DATA_CREATE(_name, _level)			       \
 	IF_ENABLED(LOG_IN_CPLUSPLUS, (extern))				       \
-	const struct log_source_const_data Z_LOG_ITEM_CONST_DATA(_name)	       \
-	__attribute__ ((section("." STRINGIFY(Z_LOG_ITEM_CONST_DATA(_name))))) \
-	__attribute__((used)) = {					       \
+	const STRUCT_SECTION_ITERABLE_ALTERNATE(log_const,		       \
+		log_source_const_data,					       \
+		Z_LOG_ITEM_CONST_DATA(_name)) =				       \
+	{								       \
 		.name = STRINGIFY(_name),				       \
 		.level = _level						       \
 	}

--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -306,12 +306,9 @@ void z_log_vprintk(const char *fmt, va_list ap);
 		.level = _level						       \
 	}
 
-#define _LOG_MODULE_DYNAMIC_DATA_CREATE(_name)				\
-	struct log_source_dynamic_data LOG_ITEM_DYNAMIC_DATA(_name)	\
-	__attribute__ ((section("." STRINGIFY(				\
-				     LOG_ITEM_DYNAMIC_DATA(_name))))	\
-				     )					\
-	__attribute__((used))
+#define _LOG_MODULE_DYNAMIC_DATA_CREATE(_name)					\
+	STRUCT_SECTION_ITERABLE_ALTERNATE(log_dynamic, log_source_dynamic_data, \
+			LOG_ITEM_DYNAMIC_DATA(_name))
 
 #define _LOG_MODULE_DYNAMIC_DATA_COND_CREATE(_name)		\
 	IF_ENABLED(CONFIG_LOG_RUNTIME_FILTERING,		\

--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -389,8 +389,8 @@ static inline char z_log_minimal_level_to_char(int level)
  */
 #define LOG_LEVEL_INTERNAL_RAW_STRING LOG_LEVEL_NONE
 
-extern struct log_source_const_data __log_const_start[];
-extern struct log_source_const_data __log_const_end[];
+TYPE_SECTION_START_EXTERN(struct log_source_const_data, log_const);
+TYPE_SECTION_END_EXTERN(struct log_source_const_data, log_const);
 
 /** @brief Create message for logging printk-like string or a raw string.
  *
@@ -429,7 +429,7 @@ extern struct log_source_const_data __log_const_end[];
 static inline uint32_t log_const_source_id(
 				const struct log_source_const_data *data)
 {
-	return ((const uint8_t *)data - (uint8_t *)__log_const_start)/
+	return ((const uint8_t *)data - (uint8_t *)TYPE_SECTION_START(log_const))/
 			sizeof(struct log_source_const_data);
 }
 

--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -433,8 +433,8 @@ static inline uint32_t log_const_source_id(
 			sizeof(struct log_source_const_data);
 }
 
-extern struct log_source_dynamic_data __log_dynamic_start[];
-extern struct log_source_dynamic_data __log_dynamic_end[];
+TYPE_SECTION_START_EXTERN(struct log_source_dynamic_data, log_dynamic);
+TYPE_SECTION_END_EXTERN(struct log_source_dynamic_data, log_dynamic);
 
 /** @brief Creates name of variable and section for runtime log data.
  *
@@ -454,7 +454,7 @@ extern struct log_source_dynamic_data __log_dynamic_end[];
  */
 static inline uint32_t log_dynamic_source_id(struct log_source_dynamic_data *data)
 {
-	return ((uint8_t *)data - (uint8_t *)__log_dynamic_start)/
+	return ((uint8_t *)data - (uint8_t *)TYPE_SECTION_START(log_dynamic))/
 			sizeof(struct log_source_dynamic_data);
 }
 

--- a/include/zephyr/logging/log_instance.h
+++ b/include/zephyr/logging/log_instance.h
@@ -61,9 +61,10 @@ struct log_source_dynamic_data {
  * @param _level Messages up to this level are compiled in.
  */
 #define Z_LOG_CONST_ITEM_REGISTER(_name, _str_name, _level)		       \
-	const struct log_source_const_data Z_LOG_ITEM_CONST_DATA(_name)	       \
-	__attribute__ ((section("." STRINGIFY(Z_LOG_ITEM_CONST_DATA(_name))))) \
-	__attribute__((used)) = {					       \
+	const STRUCT_SECTION_ITERABLE_ALTERNATE(log_const,		       \
+		log_source_const_data,					       \
+		Z_LOG_ITEM_CONST_DATA(_name)) =				       \
+	{								       \
 		.name = _str_name,					       \
 		.level  = (_level),					       \
 	}

--- a/include/zephyr/logging/log_instance.h
+++ b/include/zephyr/logging/log_instance.h
@@ -143,11 +143,8 @@ struct log_source_dynamic_data {
 	IF_ENABLED(CONFIG_LOG, (Z_LOG_INSTANCE_STRUCT * _name))
 
 #define Z_LOG_RUNTIME_INSTANCE_REGISTER(_module_name, _inst_name) \
-	struct log_source_dynamic_data LOG_INSTANCE_DYNAMIC_DATA(_module_name, _inst_name) \
-		__attribute__ ((section("." STRINGIFY( \
-				LOG_INSTANCE_DYNAMIC_DATA(_module_name, _inst_name) \
-				) \
-		))) __attribute__((used))
+	STRUCT_SECTION_ITERABLE_ALTERNATE(log_dynamic, log_source_dynamic_data, \
+			LOG_INSTANCE_DYNAMIC_DATA(_module_name, _inst_name))
 
 #define Z_LOG_INSTANCE_REGISTER(_module_name, _inst_name, _level) \
 	Z_LOG_CONST_ITEM_REGISTER( \

--- a/include/zephyr/logging/log_internal.h
+++ b/include/zephyr/logging/log_internal.h
@@ -86,7 +86,7 @@ void z_log_notify_backend_enabled(void);
  */
 static inline uint32_t *z_log_dynamic_filters_get(uint32_t source_id)
 {
-	return &__log_dynamic_start[source_id].filters;
+	return &TYPE_SECTION_START(log_dynamic)[source_id].filters;
 }
 
 /** @brief Get number of registered sources. */

--- a/include/zephyr/logging/log_internal.h
+++ b/include/zephyr/logging/log_internal.h
@@ -92,7 +92,7 @@ static inline uint32_t *z_log_dynamic_filters_get(uint32_t source_id)
 /** @brief Get number of registered sources. */
 static inline uint32_t z_log_sources_count(void)
 {
-	return log_const_source_id(__log_const_end);
+	return log_const_source_id(TYPE_SECTION_END(log_const));
 }
 
 /** @brief Return number of external domains.

--- a/scripts/logging/dictionary/database_gen.py
+++ b/scripts/logging/dictionary/database_gen.py
@@ -167,7 +167,7 @@ def find_log_const_symbols(elf):
     return ret_list
 
 
-def parse_log_const_symbols(database, log_const_section, log_const_symbols, string_mappings):
+def parse_log_const_symbols(database, log_const_area, log_const_symbols, string_mappings):
     """Find the log instances and map source IDs to names"""
     if database.is_tgt_little_endian():
         formatter = "<"
@@ -192,17 +192,17 @@ def parse_log_const_symbols(database, log_const_section, log_const_symbols, stri
         if sym.entry['st_value'] < first_offset:
             first_offset = sym.entry['st_value']
 
-    first_offset -= log_const_section['start']
+    first_offset -= log_const_area['start']
 
     # find all log_const_*
     for sym in log_const_symbols:
-        # Find data offset in log_const_section for this symbol
-        offset = sym.entry['st_value'] - log_const_section['start']
+        # Find data offset in log_const_area for this symbol
+        offset = sym.entry['st_value'] - log_const_area['start']
 
         idx_s = offset
         idx_e = offset + datum_size
 
-        datum = log_const_section['data'][idx_s:idx_e]
+        datum = log_const_area['data'][idx_s:idx_e]
 
         if len(datum) != datum_size:
             # Not enough data to unpack
@@ -266,13 +266,13 @@ def extract_logging_subsys_information(elf, database, string_mappings):
     mapping from source ID to name.
     """
     # Extract log constant section for module names
-    section_log_const = find_elf_sections(elf, "log_const_sections")
+    section_log_const = find_elf_sections(elf, "log_const_area")
     if section_log_const is None:
-        # ESP32 puts "log_const_*" info log_static_section instead of log_const_sections
+        # ESP32 puts "log_const_*" info log_static_section instead of log_const_areas
         section_log_const = find_elf_sections(elf, "log_static_section")
 
     if section_log_const is None:
-        logger.error("Cannot find section 'log_const_sections' in ELF file, exiting...")
+        logger.error("Cannot find section 'log_const_areas' in ELF file, exiting...")
         sys.exit(1)
 
     # Find all "log_const_*" symbols and parse them

--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -196,7 +196,7 @@ static uint16_t link_source_count(uint8_t domain_id)
 uint32_t log_src_cnt_get(uint32_t domain_id)
 {
 	if (z_log_is_local_domain(domain_id)) {
-		return log_const_source_id(__log_const_end);
+		return z_log_sources_count();
 	}
 
 	return link_source_count(domain_id);
@@ -242,7 +242,7 @@ const char *log_source_name_get(uint32_t domain_id, uint32_t source_id)
 {
 	if (z_log_is_local_domain(domain_id)) {
 		if (source_id < log_src_cnt_get(domain_id)) {
-			return __log_const_start[source_id].name;
+			return TYPE_SECTION_START(log_const)[source_id].name;
 		} else {
 			return NULL;
 		}
@@ -308,7 +308,7 @@ uint8_t log_compiled_level_get(uint8_t domain_id, uint32_t source_id)
 {
 	if (z_log_is_local_domain(domain_id)) {
 		if (source_id < log_src_cnt_get(domain_id)) {
-			return __log_const_start[source_id].level;
+			return TYPE_SECTION_START(log_const)[source_id].level;
 		} else {
 			return LOG_LEVEL_NONE;
 		}

--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -330,7 +330,7 @@ int z_log_link_set_runtime_level(uint8_t domain_id, uint16_t source_id, uint8_t 
 static uint32_t *get_dynamic_filter(uint8_t domain_id, uint32_t source_id)
 {
 	if (z_log_is_local_domain(domain_id)) {
-		return &__log_dynamic_start[source_id].filters;
+		return &TYPE_SECTION_START(log_dynamic)[source_id].filters;
 	}
 
 	return z_log_link_get_dynamic_filter(domain_id, source_id);

--- a/tests/subsys/logging/log_links/src/main.c
+++ b/tests/subsys/logging/log_links/src/main.c
@@ -131,7 +131,7 @@ ZTEST(log_links, test_log_domain_count)
 ZTEST(log_links, test_log_source_count)
 {
 	uint8_t exp_source_cnt[] = {
-		log_const_source_id(__log_const_end),
+		log_const_source_id(TYPE_SECTION_END(log_const)),
 		/*link1*/
 		domains_a[0]->source_cnt,
 		domains_a[1]->source_cnt,


### PR DESCRIPTION
Clean up log_const to utilize macros for handling sections.

Update database_gen.py to match naming convention change.