### PR TITLE
cmake: sparse: fix handling of (deprecated) -DSPARSE=garbage

### DIFF
--- a/cmake/modules/FindDeprecated.cmake
+++ b/cmake/modules/FindDeprecated.cmake
@@ -88,10 +88,12 @@ if("SPARSE" IN_LIST Deprecated_FIND_COMPONENTS)
   # This code was deprecated after Zephyr v3.2.0
   if(SPARSE)
     message(DEPRECATION
-        "Setting SPARSE=${SPARSE} is deprecated. "
+        "Setting SPARSE='${SPARSE}' is deprecated. "
         "Please set ZEPHYR_SCA_VARIANT to 'sparse'"
     )
-    set_ifndef(ZEPHYR_SCA_VARIANT sparse)
+    if("${SPARSE}" STREQUAL "y")
+      set_ifndef(ZEPHYR_SCA_VARIANT sparse)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
Due to many layers of indirections (Github Actions, Docker scripts, SOF
build scripts, etc.), https://github.com/thesofproject/sof/pull/7452's first attempt to
turn off VLAs ended up setting `-DSPARSE=gar bage`:
```
  west build ...  -- '-DSPARSE=y -DCONFIG_LOG_USE_VLA=n'
```
Quoting issues are typical when trying to pass parameters through too many layers of indirections. In this case, the mistake set the $SPARSE variable to the 'y -DCONFIG_LOG_USE_VLA=n' garbage which printed this confusing and time-consuming error message:
```
    Setting SPARSE=y -DCONFIG_LOG_USE_VLA=n is deprecated.
```
Worse: this enabled sparse (!) while silently ignoring the garbage trailing after "y".

1. Enable sparse only when $SPARSE is equal to "y" and nothing else. This stops enabling sparse when `-DSPARSE=gar bage` which draws more attention to the warning and gives a little more incentive to leave the deprecated option behind. Don't make any difference between the "n" and "gar bage" values because $SPARSE is deprecated so not worth that much CMake code.

2. Add quotes in the deprecation message to make garbage values more obvious, now:
```
    Setting SPARSE='y -DCONFIG_LOG_USE_VLA=n' is deprecated.
```
Fixes: 60196ca1126a ("cmake: sparse: deprecate old sparse support")