### PR TITLE
Revert "dts: adsp: ace: Changed used watchdog device"

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -510,6 +510,32 @@
 			interrupt-parent = <&ace_intc>;
 		};
 
+		watchdog0: watchdog@78300 {
+			compatible = "snps,designware-watchdog";
+			reg = <0x78300 0x100>;
+			interrupts = <8 0 0>;
+			interrupt-parent = <&core_intc>;
+			clock-frequency = <32768>;
+			reset-pulse-length = <2>;
+			status = "okay";
+		};
+
+		watchdog1: watchdog@78400 {
+			compatible = "snps,designware-watchdog";
+			reg = <0x78400 0x100>;
+			clock-frequency = <32768>;
+			reset-pulse-length = <2>;
+			status = "okay";
+		};
+
+		watchdog2: watchdog@78500 {
+			compatible = "snps,designware-watchdog";
+			reg = <0x78500 0x100>;
+			clock-frequency = <32768>;
+			reset-pulse-length = <2>;
+			status = "okay";
+		};
+
 		/* This is actually an array of per-core designware
 		 * controllers, but the special setup and extra
 		 * masking layer makes it easier for MTL to handle
@@ -561,21 +587,6 @@
 			dma-buf-size-alignment = <4>;
 			dma-copy-alignment = <4>;
 			power-domain = <&io0_domain>;
-			status = "okay";
-		};
-
-		/* This is actually an array of per-core designware
-		 * watchdogs, but the special setup and extra
-		 * masking layer makes it easier for MTL to handle
-		 * this internally.
-		 */
-		adsp_watchdog: adsp_watchdog@178D40 {
-			compatible = "intel,adsp-watchdog";
-			reg = <0x178D40 0x60>;
-			interrupts = <8 0 0>;
-			interrupt-parent = <&core_intc>;
-			clock-frequency = <32768>;
-			reset-pulse-length = <2>;
 			status = "okay";
 		};
 


### PR DESCRIPTION
This reverts commit c558fd532317408855400b23d510567287367a6d.

This change results in boot failures on ace15 platform.

Link: https://github.com/thesofproject/sof/issues/7433