### PR TITLE
shell: remove dead linker section for shell

### DIFF
--- a/cmake/linker_script/common/common-ram.cmake
+++ b/cmake/linker_script/common/common-ram.cmake
@@ -22,16 +22,6 @@ if(CONFIG_PM_DEVICE)
   zephyr_linker_section_configure(SECTION pm_device_slots KEEP INPUT ".z_pm_device_slots")
 endif()
 
-zephyr_linker_section(NAME initshell GROUP DATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT})
-zephyr_linker_section_configure(SECTION initshell
-  KEEP INPUT ".shell_module_*"
-  SYMBOLS __shell_module_start __shell_module_end
-)
-zephyr_linker_section_configure(SECTION initshell
-  KEEP INPUT ".shell_cmd_*"
-  SYMBOLS __shell_cmd_start __shell_end_end
-)
-
 zephyr_linker_section(NAME log_dynamic GROUP DATA_REGION NOINPUT)
 zephyr_linker_section_configure(SECTION log_dynamic KEEP INPUT ".log_dynamic_*")
 

--- a/include/zephyr/linker/common-ram.ld
+++ b/include/zephyr/linker/common-ram.ld
@@ -52,20 +52,6 @@
 	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif 	/* CONFIG_HAS_DYNAMIC_DEVICE_HANDLES */
 
-	SECTION_DATA_PROLOGUE(initshell,,)
-	{
-		/* link in shell initialization objects for all modules that
-		 * use shell and their shell commands are automatically
-		 * initialized by the kernel.
-		 */
-		__shell_module_start = .;
-		KEEP(*(".shell_module_*"));
-		__shell_module_end = .;
-		__shell_cmd_start = .;
-		KEEP(*(".shell_cmd_*"));
-		__shell_cmd_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
 	ITERABLE_SECTION_RAM_GC_ALLOWED(log_mpsc_pbuf, 4)
 	ITERABLE_SECTION_RAM(log_msg_ptr, 4)
 

--- a/scripts/pylib/twister/twisterlib/size_calc.py
+++ b/scripts/pylib/twister/twisterlib/size_calc.py
@@ -29,7 +29,6 @@ class SizeCalculator:
         "datas",
         "initlevel",
         "exceptions",
-        "initshell",
         "_static_thread_data_area",
         "k_timer_area",
         "k_mem_slab_area",


### PR DESCRIPTION
The initshell sections in the linker scripts where associated with theo old shell code.  The old shell code has been removed for some time so remove references to initshell in the linker scripts and size_calc.py