### PR TITLE
twister: size_calc: Fix compliance warning in script

### DIFF
--- a/scripts/pylib/twister/twisterlib/size_calc.py
+++ b/scripts/pylib/twister/twisterlib/size_calc.py
@@ -220,7 +220,7 @@ class SizeCalculator:
             print(str(e))
             sys.exit(2)
 
-        self.is_xip = (len(is_xip_output) != 0)
+        self.is_xip = len(is_xip_output) != 0
 
     def _get_info_elf_sections(self) -> None:
         """Calculate RAM and ROM usage and information about issues by section"""


### PR DESCRIPTION
compliance script runs pylink on size_calc.py and reports:

C0325:Unnecessary parens after '=' keyword (superfluous-parens)

Fix warning by remove unnecessary parens.