### PR TITLE
drivers: pcie: Use TYPE_SECTION macros for irq_alloc

### DIFF
--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -187,11 +187,7 @@ static ATOMIC_DEFINE(irq_reserved, CONFIG_MAX_IRQ_LINES);
 
 static void irq_init(void)
 {
-	extern uint8_t __irq_alloc_start[];
-	extern uint8_t __irq_alloc_end[];
-	const uint8_t *irq;
-
-	for (irq = __irq_alloc_start; irq < __irq_alloc_end; irq++) {
+	TYPE_SECTION_FOREACH(const uint8_t, irq_alloc, irq) {
 		__ASSERT_NO_MSG(*irq < CONFIG_MAX_IRQ_LINES);
 		atomic_set_bit(irq_reserved, *irq);
 	}

--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -161,8 +161,7 @@ if(CONFIG_DNS_SD)
 endif()
 
 if(CONFIG_PCIE)
-  zephyr_linker_section(NAME irq_alloc GROUP RODATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT})
-  zephyr_linker_section_configure(SECTION irq_alloc INPUT ".irq_alloc*" KEEP SORT NAME)
+  zephyr_iterable_section(NAME irq_alloc KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 endif()
 
 zephyr_linker_section(NAME log_strings KVMA RAM_REGION GROUP RODATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT})

--- a/include/zephyr/arch/x86/intel64/arch.h
+++ b/include/zephyr/arch/x86/intel64/arch.h
@@ -117,8 +117,7 @@ struct x86_ssf {
 
 #ifdef CONFIG_PCIE
 #define X86_RESERVE_IRQ(irq_p, name) \
-	static Z_DECL_ALIGN(uint8_t) name \
-	__in_section(_irq_alloc, static, name) __used = irq_p
+	static TYPE_SECTION_ITERABLE(uint8_t, name, irq_alloc, name) = irq_p
 #else
 #define X86_RESERVE_IRQ(irq_p, name)
 #endif

--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -73,12 +73,7 @@
 	ITERABLE_SECTION_ROM(_static_thread_data, 4)
 
 #if defined(CONFIG_PCIE)
-	SECTION_DATA_PROLOGUE(irq_alloc,,)
-	{
-		__irq_alloc_start = .;
-		KEEP(*(SORT_BY_NAME("._irq_alloc*")));
-		__irq_alloc_end = .;
-	} GROUP_LINK_IN(ROMABLE_REGION)
+	ITERABLE_SECTION_ROM(irq_alloc, 4)
 #endif /* CONFIG_PCIE */
 
 #if !defined(CONFIG_HAS_DYNAMIC_DEVICE_HANDLES)


### PR DESCRIPTION
Clean up irq_alloc to utilize TYPE_SECTION macros for handling sections.