### PR TITLE
fb: cfb: Use TYPE_SECTION macros for cfb_fonts

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -179,8 +179,7 @@ zephyr_iterable_section(NAME shell_subcmds KVMA RAM_REGION GROUP RODATA_REGION S
 
 zephyr_iterable_section(NAME shell_dynamic_subcmds KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 
-zephyr_linker_section(NAME font_entry KVMA RAM_REGION GROUP RODATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT})
-zephyr_linker_section_configure(SECTION font_entry INPUT "._cfb_font.*" KEEP SORT NAME)
+zephyr_iterable_section(NAME cfb_font KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 
 zephyr_iterable_section(NAME tracing_backend KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 

--- a/include/zephyr/linker/common-rom/common-rom-misc.ld
+++ b/include/zephyr/linker/common-rom/common-rom-misc.ld
@@ -39,9 +39,4 @@
 
 	ITERABLE_SECTION_ROM(shell_dynamic_subcmds, 4)
 
-	SECTION_DATA_PROLOGUE(font_entry_sections,,)
-	{
-		__font_entry_start = .;
-		KEEP(*(SORT_BY_NAME("._cfb_font.*")))
-		__font_entry_end = .;
-	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	ITERABLE_SECTION_ROM(cfb_font, 4)

--- a/scripts/pylib/twister/twisterlib/size_calc.py
+++ b/scripts/pylib/twister/twisterlib/size_calc.py
@@ -64,7 +64,6 @@ class SizeCalculator:
         "app_smem",
         'shell_root_cmds_sections',
         'log_const_sections',
-        "font_entry_sections",
         "priv_stacks_noinit",
         "_GCOV_BSS_SECTION_NAME",
         "gcov",

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -12,8 +12,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(cfb);
 
-extern const struct cfb_font __font_entry_start[];
-extern const struct cfb_font __font_entry_end[];
+STRUCT_SECTION_START_EXTERN(cfb_font);
+STRUCT_SECTION_END_EXTERN(cfb_font);
 
 static inline uint8_t byte_reverse(uint8_t b)
 {
@@ -425,11 +425,11 @@ int cfb_get_font_size(const struct device *dev, uint8_t idx, uint8_t *width,
 	}
 
 	if (width) {
-		*width = __font_entry_start[idx].width;
+		*width = TYPE_SECTION_START(cfb_font)[idx].width;
 	}
 
 	if (height) {
-		*height = __font_entry_start[idx].height;
+		*height = TYPE_SECTION_START(cfb_font)[idx].height;
 	}
 
 	return 0;
@@ -457,7 +457,8 @@ int cfb_framebuffer_init(const struct device *dev)
 
 	api->get_capabilities(dev, &cfg);
 
-	fb->numof_fonts = __font_entry_end - __font_entry_start;
+	STRUCT_SECTION_COUNT(cfb_font, &fb->numof_fonts);
+
 	LOG_DBG("number of fonts %d", fb->numof_fonts);
 	if (!fb->numof_fonts) {
 		return -ENODEV;
@@ -472,7 +473,7 @@ int cfb_framebuffer_init(const struct device *dev)
 	fb->kerning = 0;
 	fb->inverted = false;
 
-	fb->fonts = __font_entry_start;
+	fb->fonts = TYPE_SECTION_START(cfb_font);
 	fb->font_idx = 0U;
 
 	fb->size = fb->x_res * fb->y_res / fb->ppt;


### PR DESCRIPTION
Clean up cfb_fonts to utilize TYPE_SECTION macros for handling sections.