### PR TITLE
xtensa: add some structs for interrupt stack frames

### DIFF
--- a/arch/xtensa/core/debug_helpers_asm.S
+++ b/arch/xtensa/core/debug_helpers_asm.S
@@ -10,6 +10,8 @@
 #include <xtensa/hal.h>
 #include <xtensa-asm2-context.h>
 
+#include <offsets.h>
+
 	.section    .iram1, "ax"
 	.align      4
 	.global     z_xtensa_backtrace_get_start
@@ -24,15 +26,15 @@ z_xtensa_backtrace_get_start:
 	/* Load address for interrupted stack */
 	l32i    a6, a5, 0
 	/* Load i PC in a7 */
-	l32i    a7, a6, BSA_PC_OFF
+	l32i    a7, a6, ___xtensa_irq_bsa_t_pc_OFFSET
 	/* Store value of i PC in a2 */
 	s32i    a7, a2, 0
 	/* Load value for (i-1) PC, which return address of i into a7 */
-	l32i    a7, a6, BSA_A0_OFF
+	l32i    a7, a6, ___xtensa_irq_bsa_t_a0_OFFSET
 	/* Store value of (i-1) PC in a4 */
 	s32i    a7, a4, 0
-	/* Add BASE_SAVE_AREA_SIZE in interrupted stack to get i SP */
-	addi    a6, a6, BASE_SAVE_AREA_SIZE
+	/* Add base stack frame size in interrupted stack to get i SP */
+	addi    a6, a6, ___xtensa_irq_bsa_t_SIZEOF
 	/* Store i SP in a3 */
 	s32i    a6, a3, 0
 	retw

--- a/arch/xtensa/core/gdbstub.c
+++ b/arch/xtensa/core/gdbstub.c
@@ -518,7 +518,7 @@ static void restore_from_ctx(struct gdb_ctx *ctx, const z_arch_esf_t *stack)
 	struct xtensa_register *reg;
 	int idx, num_laddr_regs;
 
-	uint32_t *bsa = *(int **)stack;
+	_xtensa_irq_bsa_t *bsa = (void *)*(int **)stack;
 
 	if ((int *)bsa - stack > 4) {
 		num_laddr_regs = 8;
@@ -577,7 +577,7 @@ static void restore_from_ctx(struct gdb_ctx *ctx, const z_arch_esf_t *stack)
 		 * which raises debug interrupt, and we will be
 		 * stuck in an infinite loop.
 		 */
-		bsa[BSA_PC_OFF / 4] += 2;
+		bsa->pc += 2;
 		not_first_break = true;
 	}
 }

--- a/arch/xtensa/core/offsets/offsets.c
+++ b/arch/xtensa/core/offsets/offsets.c
@@ -6,9 +6,58 @@
 #include <gen_offset.h>
 #include <kernel_offsets.h>
 
-/* No offsets required in Xtensa, but this file must be present for
- * the build.  Usage is the same as other architectures if you want to
- * add some.
- */
+#include <xtensa-asm2-context.h>
+
+GEN_ABSOLUTE_SYM(___xtensa_irq_bsa_t_SIZEOF, sizeof(_xtensa_irq_bsa_t));
+GEN_ABSOLUTE_SYM(___xtensa_irq_stack_frame_raw_t_SIZEOF, sizeof(_xtensa_irq_stack_frame_raw_t));
+GEN_ABSOLUTE_SYM(___xtensa_irq_stack_frame_a15_t_SIZEOF, sizeof(_xtensa_irq_stack_frame_a15_t));
+GEN_ABSOLUTE_SYM(___xtensa_irq_stack_frame_a11_t_SIZEOF, sizeof(_xtensa_irq_stack_frame_a11_t));
+GEN_ABSOLUTE_SYM(___xtensa_irq_stack_frame_a7_t_SIZEOF, sizeof(_xtensa_irq_stack_frame_a7_t));
+GEN_ABSOLUTE_SYM(___xtensa_irq_stack_frame_a3_t_SIZEOF, sizeof(_xtensa_irq_stack_frame_a3_t));
+
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, a0);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, scratch);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, a2);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, a3);
+
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, exccause);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, pc);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, ps);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, sar);
+
+#if XCHAL_HAVE_LOOPS
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, lcount);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, lbeg);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, lend);
+#endif
+
+#if XCHAL_HAVE_S32C1I
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, scompare1);
+#endif
+
+#if XCHAL_HAVE_THREADPTR
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, threadptr);
+#endif
+
+#if XCHAL_HAVE_FP && defined(CONFIG_CPU_HAS_FPU) && defined(CONFIG_FPU_SHARING)
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fcr);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fsr);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu0);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu1);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu2);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu3);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu4);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu5);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu6);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu7);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu8);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu9);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu10);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu11);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu12);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu13);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu14);
+GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu15);
+#endif
 
 GEN_ABS_SYM_END

--- a/arch/xtensa/core/xtensa-asm2-util.S
+++ b/arch/xtensa/core/xtensa-asm2-util.S
@@ -151,39 +151,39 @@ _high_restore_done:
 _restore_context:
 	call0 xtensa_restore_high_regs
 
-	l32i a0, a1, BSA_PC_OFF
+	l32i a0, a1, ___xtensa_irq_bsa_t_pc_OFFSET
 	wsr a0, ZSR_EPC
-	l32i a0, a1, BSA_PS_OFF
+	l32i a0, a1, ___xtensa_irq_bsa_t_ps_OFFSET
 	wsr a0, ZSR_EPS
 
 #if XCHAL_HAVE_FP && defined(CONFIG_CPU_HAS_FPU) && defined(CONFIG_FPU_SHARING)
 	FPU_REG_RESTORE
 #endif
 
-	l32i a0, a1, BSA_SAR_OFF
+	l32i a0, a1, ___xtensa_irq_bsa_t_sar_OFFSET
 	wsr a0, SAR
 #if XCHAL_HAVE_LOOPS
-	l32i a0, a1, BSA_LBEG_OFF
+	l32i a0, a1, ___xtensa_irq_bsa_t_lbeg_OFFSET
 	wsr a0, LBEG
-	l32i a0, a1, BSA_LEND_OFF
+	l32i a0, a1, ___xtensa_irq_bsa_t_lend_OFFSET
 	wsr a0, LEND
-	l32i a0, a1, BSA_LCOUNT_OFF
+	l32i a0, a1, ___xtensa_irq_bsa_t_lcount_OFFSET
 	wsr a0, LCOUNT
 #endif
 #if XCHAL_HAVE_S32C1I
-	l32i a0, a1, BSA_SCOMPARE1_OFF
+	l32i a0, a1, ___xtensa_irq_bsa_t_scompare1_OFFSET
 	wsr a0, SCOMPARE1
 #endif
 #if XCHAL_HAVE_THREADPTR && defined(CONFIG_THREAD_LOCAL_STORAGE)
-	l32i a0, a1, BSA_THREADPTR_OFF
+	l32i a0, a1, ___xtensa_irq_bsa_t_threadptr_OFFSET
 	wur a0, THREADPTR
 #endif
 	rsync
 
-	l32i a0, a1, BSA_A0_OFF
-	l32i a2, a1, BSA_A2_OFF
-	l32i a3, a1, BSA_A3_OFF
-	addi a1, a1, BASE_SAVE_AREA_SIZE
+	l32i a0, a1, ___xtensa_irq_bsa_t_a0_OFFSET
+	l32i a2, a1, ___xtensa_irq_bsa_t_a2_OFFSET
+	l32i a3, a1, ___xtensa_irq_bsa_t_a3_OFFSET
+	addi a1, a1, ___xtensa_irq_bsa_t_SIZEOF
 
 	rfi ZSR_RFI_LEVEL
 
@@ -214,7 +214,7 @@ xtensa_arch_except_epc:
 xtensa_switch:
 	entry a1, 16
 	SPILL_ALL_WINDOWS
-	addi a1, a1, -BASE_SAVE_AREA_SIZE
+	addi a1, a1, -___xtensa_irq_bsa_t_SIZEOF
 
 	/* Stash our A0/2/3 and the shift/loop registers into the base
 	 * save area so they get restored as they are now.  A2/A3
@@ -222,16 +222,16 @@ xtensa_switch:
 	 * stashed across the xtensa_save_high_regs call and this is a
 	 * convenient place.
 	 */
-	s32i a0, a1, BSA_A0_OFF
-	s32i a2, a1, BSA_A2_OFF
-	s32i a3, a1, BSA_A3_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_a0_OFFSET
+	s32i a2, a1, ___xtensa_irq_bsa_t_a2_OFFSET
+	s32i a3, a1, ___xtensa_irq_bsa_t_a3_OFFSET
 	ODD_REG_SAVE
 
 	/* Stash our PS register contents and a "restore" PC. */
 	rsr a0, PS
-	s32i a0, a1, BSA_PS_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_ps_OFFSET
 	movi a0, _switch_restore_pc
-	s32i a0, a1, BSA_PC_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_pc_OFFSET
 
 	/* Now the high registers */
 	call0 xtensa_save_high_regs
@@ -255,7 +255,7 @@ noflush:
 	 * stack to the "new" context out of the A2 spill slot.
 	 */
 	l32i a2, a1, 0
-	l32i a3, a2, BSA_A3_OFF
+	l32i a3, a2, ___xtensa_irq_bsa_t_a3_OFFSET
 	s32i a1, a3, 0
 
 	/* Switch stack pointer and restore.  The jump to
@@ -263,7 +263,7 @@ noflush:
 	 * for the restored "next" address to be immediately after for
 	 * sanity.
 	 */
-	l32i a1, a2, BSA_A2_OFF
+	 l32i a1, a2, ___xtensa_irq_bsa_t_a2_OFFSET
 
 #ifdef CONFIG_INSTRUMENT_THREAD_SWITCHING
 	call4 z_thread_mark_switched_in

--- a/arch/xtensa/include/xtensa-asm2-s.h
+++ b/arch/xtensa/include/xtensa-asm2-s.h
@@ -9,6 +9,8 @@
 
 #include "xtensa-asm2-context.h"
 
+#include <offsets.h>
+
 /* Assembler header!  This file contains macros designed to be included
  * only by the assembler.
  */
@@ -100,48 +102,48 @@
  */
 .macro FPU_REG_SAVE
 	rur.fcr	a0
-	s32i	a0, a1, BSA_FPU_OFF
+	s32i	a0, a1, ___xtensa_irq_bsa_t_fcr_OFFSET
 	rur.fsr	a0
-	s32i	a0, a1, 4+BSA_FPU_OFF
-	ssi	f0, a1, 8+BSA_FPU_OFF
-	ssi	f1, a1, 12+BSA_FPU_OFF
-	ssi	f2, a1, 16+BSA_FPU_OFF
-	ssi	f3, a1, 20+BSA_FPU_OFF
-	ssi	f4, a1, 24+BSA_FPU_OFF
-	ssi	f5, a1, 28+BSA_FPU_OFF
-	ssi	f6, a1, 32+BSA_FPU_OFF
-	ssi	f7, a1, 36+BSA_FPU_OFF
-	ssi	f8, a1, 40+BSA_FPU_OFF
-	ssi	f9, a1, 44+BSA_FPU_OFF
-	ssi	f10, a1, 48+BSA_FPU_OFF
-	ssi	f11, a1, 52+BSA_FPU_OFF
-	ssi	f12, a1, 56+BSA_FPU_OFF
-	ssi	f13, a1, 60+BSA_FPU_OFF
-	ssi	f14, a1, 64+BSA_FPU_OFF
-	ssi	f15, a1, 68+BSA_FPU_OFF
+	s32i	a0, a1, ___xtensa_irq_bsa_t_fsr_OFFSET
+	ssi	f0, a1, ___xtensa_irq_bsa_t_fpu0_OFFSET
+	ssi	f1, a1, ___xtensa_irq_bsa_t_fpu1_OFFSET
+	ssi	f2, a1, ___xtensa_irq_bsa_t_fpu2_OFFSET
+	ssi	f3, a1, ___xtensa_irq_bsa_t_fpu3_OFFSET
+	ssi	f4, a1, ___xtensa_irq_bsa_t_fpu4_OFFSET
+	ssi	f5, a1, ___xtensa_irq_bsa_t_fpu5_OFFSET
+	ssi	f6, a1, ___xtensa_irq_bsa_t_fpu6_OFFSET
+	ssi	f7, a1, ___xtensa_irq_bsa_t_fpu7_OFFSET
+	ssi	f8, a1, ___xtensa_irq_bsa_t_fpu8_OFFSET
+	ssi	f9, a1, ___xtensa_irq_bsa_t_fpu9_OFFSET
+	ssi	f10, a1, ___xtensa_irq_bsa_t_fpu10_OFFSET
+	ssi	f11, a1, ___xtensa_irq_bsa_t_fpu11_OFFSET
+	ssi	f12, a1, ___xtensa_irq_bsa_t_fpu12_OFFSET
+	ssi	f13, a1, ___xtensa_irq_bsa_t_fpu13_OFFSET
+	ssi	f14, a1, ___xtensa_irq_bsa_t_fpu14_OFFSET
+	ssi	f15, a1, ___xtensa_irq_bsa_t_fpu15_OFFSET
 .endm
 
 .macro FPU_REG_RESTORE
-	l32i.n	a0, a1, BSA_FPU_OFF
+	l32i.n	a0, a1, ___xtensa_irq_bsa_t_fcr_OFFSET
 	wur.fcr	a0
-	l32i.n	a0, a1, 4+BSA_FPU_OFF
+	l32i.n	a0, a1, ___xtensa_irq_bsa_t_fsr_OFFSET
 	wur.fsr	a0
-	lsi	f0, a1, 8+BSA_FPU_OFF
-	lsi	f1, a1, 12+BSA_FPU_OFF
-	lsi	f2, a1, 16+BSA_FPU_OFF
-	lsi	f3, a1, 20+BSA_FPU_OFF
-	lsi	f4, a1, 24+BSA_FPU_OFF
-	lsi	f5, a1, 28+BSA_FPU_OFF
-	lsi	f6, a1, 32+BSA_FPU_OFF
-	lsi	f7, a1, 36+BSA_FPU_OFF
-	lsi	f8, a1, 40+BSA_FPU_OFF
-	lsi	f9, a1, 44+BSA_FPU_OFF
-	lsi	f10, a1, 48+BSA_FPU_OFF
-	lsi	f11, a1, 52+BSA_FPU_OFF
-	lsi	f12, a1, 56+BSA_FPU_OFF
-	lsi	f13, a1, 60+BSA_FPU_OFF
-	lsi	f14, a1, 64+BSA_FPU_OFF
-	lsi	f15, a1, 68+BSA_FPU_OFF
+	lsi	f0, a1, ___xtensa_irq_bsa_t_fpu0_OFFSET
+	lsi	f1, a1, ___xtensa_irq_bsa_t_fpu1_OFFSET
+	lsi	f2, a1, ___xtensa_irq_bsa_t_fpu2_OFFSET
+	lsi	f3, a1, ___xtensa_irq_bsa_t_fpu3_OFFSET
+	lsi	f4, a1, ___xtensa_irq_bsa_t_fpu4_OFFSET
+	lsi	f5, a1, ___xtensa_irq_bsa_t_fpu5_OFFSET
+	lsi	f6, a1, ___xtensa_irq_bsa_t_fpu6_OFFSET
+	lsi	f7, a1, ___xtensa_irq_bsa_t_fpu7_OFFSET
+	lsi	f8, a1, ___xtensa_irq_bsa_t_fpu8_OFFSET
+	lsi	f9, a1, ___xtensa_irq_bsa_t_fpu9_OFFSET
+	lsi	f10, a1, ___xtensa_irq_bsa_t_fpu10_OFFSET
+	lsi	f11, a1, ___xtensa_irq_bsa_t_fpu11_OFFSET
+	lsi	f12, a1, ___xtensa_irq_bsa_t_fpu12_OFFSET
+	lsi	f13, a1, ___xtensa_irq_bsa_t_fpu13_OFFSET
+	lsi	f14, a1, ___xtensa_irq_bsa_t_fpu14_OFFSET
+	lsi	f15, a1, ___xtensa_irq_bsa_t_fpu15_OFFSET
 .endm
 #endif
 
@@ -158,24 +160,24 @@
  */
 .macro ODD_REG_SAVE
 	rsr.SAR a0
-	s32i a0, a1, BSA_SAR_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_sar_OFFSET
 #if XCHAL_HAVE_LOOPS
 	rsr.LBEG a0
-	s32i a0, a1, BSA_LBEG_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_lbeg_OFFSET
 	rsr.LEND a0
-	s32i a0, a1, BSA_LEND_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_lend_OFFSET
 	rsr.LCOUNT a0
-	s32i a0, a1, BSA_LCOUNT_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_lcount_OFFSET
 #endif
 	rsr.exccause a0
-	s32i a0, a1, BSA_EXCCAUSE_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_exccause_OFFSET
 #if XCHAL_HAVE_S32C1I
 	rsr.SCOMPARE1 a0
-	s32i a0, a1, BSA_SCOMPARE1_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_scompare1_OFFSET
 #endif
 #if XCHAL_HAVE_THREADPTR && defined(CONFIG_THREAD_LOCAL_STORAGE)
 	rur.THREADPTR a0
-	s32i a0, a1, BSA_THREADPTR_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_threadptr_OFFSET
 #endif
 #if XCHAL_HAVE_FP && defined(CONFIG_CPU_HAS_FPU) && defined(CONFIG_FPU_SHARING)
 	FPU_REG_SAVE
@@ -254,8 +256,8 @@
 
 	/* Recover the interrupted SP from the BSA */
 	l32i a1, a1, 0
-	l32i a0, a1, BSA_A0_OFF
-	addi a1, a1, BASE_SAVE_AREA_SIZE
+	l32i a0, a1, ___xtensa_irq_bsa_t_a0_OFFSET
+	addi a1, a1, ___xtensa_irq_bsa_t_SIZEOF
 
 	call4 _xstack_call0_\@
 	mov a1, a3		/* restore original SP */
@@ -298,13 +300,13 @@ _xstack_returned_\@:
 	 * by the save.  Stash it into the unused "a1" slot in the
 	 * BSA and recover it immediately after.  Kind of a hack.
 	 */
-	s32i a2, a1, BSA_SCRATCH_OFF
+	s32i a2, a1, ___xtensa_irq_bsa_t_scratch_OFFSET
 
 	ODD_REG_SAVE
 	call0 xtensa_save_high_regs
 
 	l32i a2, a1, 0
-	l32i a2, a2, BSA_SCRATCH_OFF
+	l32i a2, a2, ___xtensa_irq_bsa_t_scratch_OFFSET
 
 	/* There's a gotcha with level 1 handlers: the INTLEVEL field
 	 * gets left at zero and not set like high priority interrupts
@@ -384,8 +386,8 @@ _do_call_\@:
 	 */
 	beq a6, a1, _restore_\@
 	l32i a1, a1, 0
-	l32i a0, a1, BSA_A0_OFF
-	addi a1, a1, BASE_SAVE_AREA_SIZE
+	l32i a0, a1, ___xtensa_irq_bsa_t_a0_OFFSET
+	addi a1, a1, ___xtensa_irq_bsa_t_SIZEOF
 #ifndef CONFIG_KERNEL_COHERENCE
 	/* When using coherence, the registers of the interrupted
 	 * context got spilled upstream in arch_cohere_stacks()
@@ -433,10 +435,10 @@ _Level\LVL\()VectorHelper :
 .global _Level\LVL\()Vector
 _Level\LVL\()Vector:
 #endif
-	addi a1, a1, -BASE_SAVE_AREA_SIZE
-	s32i a0, a1, BSA_A0_OFF
-	s32i a2, a1, BSA_A2_OFF
-	s32i a3, a1, BSA_A3_OFF
+	addi a1, a1, -___xtensa_irq_bsa_t_SIZEOF
+	s32i a0, a1, ___xtensa_irq_bsa_t_a0_OFFSET
+	s32i a2, a1, ___xtensa_irq_bsa_t_a2_OFFSET
+	s32i a3, a1, ___xtensa_irq_bsa_t_a3_OFFSET
 
 	/* Level "1" is the exception handler, which uses a different
 	 * calling convention.  No special register holds the
@@ -447,14 +449,14 @@ _Level\LVL\()Vector:
 	rsr.PS a0
 	movi a2, ~(PS_EXCM_MASK | PS_INTLEVEL_MASK)
 	and a0, a0, a2
-	s32i a0, a1, BSA_PS_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_ps_OFFSET
 .else
 	rsr.EPS\LVL a0
-	s32i a0, a1, BSA_PS_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_ps_OFFSET
 .endif
 
 	rsr.EPC\LVL a0
-	s32i a0, a1, BSA_PC_OFF
+	s32i a0, a1, ___xtensa_irq_bsa_t_pc_OFFSET
 
 	/* What's happening with this jump is that the L32R
 	 * instruction to load a full 32 bit immediate must use an

--- a/soc/xtensa/esp32/gdbstub.c
+++ b/soc/xtensa/esp32/gdbstub.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <xtensa-asm2-context.h>
 #include <zephyr/debug/gdbstub.h>
+#include <offsets.h>
 
 /*
  * Address Mappings From ESP32 Technical Reference Manual Version 4.5
@@ -111,7 +112,7 @@ static struct xtensa_register gdb_reg_list[] = {
 		.regno = 0x0020,
 		.byte_size = 4,
 		.gpkt_offset = 0,
-		.stack_offset = BSA_PC_OFF,
+		.stack_offset = ___xtensa_irq_bsa_t_pc_OFFSET,
 	},
 	{
 		/* AR0 */
@@ -567,7 +568,7 @@ static struct xtensa_register gdb_reg_list[] = {
 		.regno = 0x0200,
 		.byte_size = 4,
 		.gpkt_offset = 260,
-		.stack_offset = BSA_LBEG_OFF,
+		.stack_offset = ___xtensa_irq_bsa_t_lbeg_OFFSET,
 	},
 	{
 		/* LEND */
@@ -575,7 +576,7 @@ static struct xtensa_register gdb_reg_list[] = {
 		.regno = 0x0201,
 		.byte_size = 4,
 		.gpkt_offset = 264,
-		.stack_offset = BSA_LBEG_OFF,
+		.stack_offset = ___xtensa_irq_bsa_t_lend_OFFSET,
 	},
 	{
 		/* LCOUNT */
@@ -583,7 +584,7 @@ static struct xtensa_register gdb_reg_list[] = {
 		.regno = 0x0202,
 		.byte_size = 4,
 		.gpkt_offset = 268,
-		.stack_offset = BSA_LBEG_OFF,
+		.stack_offset = ___xtensa_irq_bsa_t_lcount_OFFSET,
 	},
 	{
 		/* SAR */
@@ -591,7 +592,7 @@ static struct xtensa_register gdb_reg_list[] = {
 		.regno = 0x0203,
 		.byte_size = 4,
 		.gpkt_offset = 272,
-		.stack_offset = BSA_SAR_OFF,
+		.stack_offset = ___xtensa_irq_bsa_t_sar_OFFSET,
 	},
 	{
 		/* WINDOWBASE */
@@ -615,7 +616,7 @@ static struct xtensa_register gdb_reg_list[] = {
 		.regno = 0x02E6,
 		.byte_size = 4,
 		.gpkt_offset = 292,
-		.stack_offset = BSA_PS_OFF,
+		.stack_offset = ___xtensa_irq_bsa_t_ps_OFFSET,
 	},
 	{
 		/* THREADPTR */
@@ -625,7 +626,7 @@ static struct xtensa_register gdb_reg_list[] = {
 		.gpkt_offset = 296,
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 		/* Only saved in stack if TLS is enabled */
-		.stack_offset = BSA_THREADPTR_OFF,
+		.stack_offset = ___xtensa_irq_bsa_t_threadptr_OFFSET,
 #endif
 	},
 	{
@@ -634,7 +635,7 @@ static struct xtensa_register gdb_reg_list[] = {
 		.regno = 0x020C,
 		.byte_size = 4,
 		.gpkt_offset = 304,
-		.stack_offset = BSA_SCOMPARE1_OFF,
+		.stack_offset = ___xtensa_irq_bsa_t_scompare1_OFFSET,
 	},
 	{
 		/* EXCCAUSE */
@@ -642,7 +643,7 @@ static struct xtensa_register gdb_reg_list[] = {
 		.regno = 0x02E8,
 		.byte_size = 4,
 		.gpkt_offset = 572,
-		.stack_offset = BSA_EXCCAUSE_OFF,
+		.stack_offset = ___xtensa_irq_bsa_t_exccause_OFFSET,
 	},
 	{
 		/* DEBUGCAUSE */
@@ -664,7 +665,7 @@ static struct xtensa_register gdb_reg_list[] = {
 		.regno = 0x0000,
 		.byte_size = 4,
 		.gpkt_offset = 628,
-		.stack_offset = BSA_A0_OFF,
+		.stack_offset = ___xtensa_irq_bsa_t_a0_OFFSET,
 	},
 	{
 		/* A1 */
@@ -679,7 +680,7 @@ static struct xtensa_register gdb_reg_list[] = {
 		.regno = 0x0002,
 		.byte_size = 4,
 		.gpkt_offset = 636,
-		.stack_offset = BSA_A2_OFF,
+		.stack_offset = ___xtensa_irq_bsa_t_a2_OFFSET,
 	},
 	{
 		/* A3 */
@@ -687,7 +688,7 @@ static struct xtensa_register gdb_reg_list[] = {
 		.regno = 0x0003,
 		.byte_size = 4,
 		.gpkt_offset = 640,
-		.stack_offset = BSA_A3_OFF,
+		.stack_offset = ___xtensa_irq_bsa_t_a3_OFFSET,
 	},
 	{
 		/* A4 */


### PR DESCRIPTION
This adds some structs for interrupt stack frames to make it easier to access individual elements, and ultimately getting rid of magic array element numbers in the code. Hopefully, this would aid in debugging where you can view the whole struct in debugger.