### PR TITLE
drivers: clock_control: stm32: LSE fix

### DIFF
--- a/drivers/clock_control/clock_stm32f1.c
+++ b/drivers/clock_control/clock_stm32f1.c
@@ -158,5 +158,9 @@ void config_pll2(void)
  */
 void config_enable_default_clocks(void)
 {
-	/* Nothing for now */
+	if (IS_ENABLED(STM32_LSE_ENABLED)) {
+		/* Set the PWREN and BKPEN bits in the RCC_APB1ENR register */
+		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_BKP);
+	}
 }


### PR DESCRIPTION
Power supply and clock need to be enabled before operating BKP
Fixes #57011