### PR TITLE
fs: change fatFS initialization to match littleFS.

### DIFF
--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -527,4 +527,4 @@ static int fatfs_init(void)
 	return fs_register(FS_FATFS, &fatfs_fs);
 }
 
-SYS_INIT(fatfs_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(fatfs_init, POST_KERNEL, 99);


### PR DESCRIPTION
# Bug Description
In C++, I defined a global object and mounted a disk in the global object constructor. When i mounted the disk with FS_LITTLEFS, it was successful. However, when i mounted the disk with FS_FATFS, i got an error message "requested file system type not registered!!".

# Solution description
The level and priority of the FATFS initialization function should be set to match the littleFS initialization function.

# To Reviewers
C++ is not recommended to be used in system initialization code. However, since FAT and LITTLEFS are both file systems, i thought that their level and priority settings should be the same. It is unclear to me what problems may arise from this change. If there are any differences between Fat and LITTLEFS,  Please provide any additional information.

# TEST
After the modification, the fatFS can be mounted normally. However, it is unknown if there will be any issues elsewhere in the system.
