### PR TITLE
modules: openthread: align received frame timestamp to SFD

### DIFF
--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -95,7 +95,10 @@ struct net_pkt {
 #endif
 
 #if defined(CONFIG_NET_PKT_TIMESTAMP)
-	/** Timestamp if available. */
+	/**
+	 * Timestamp if available.
+	 * For IEEE 802.15.4 packets this refers to the first symbol of the MAC Header.
+	 */
 	struct net_ptp_time timestamp;
 #endif
 

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -38,7 +38,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 
 #define SHORT_ADDRESS_SIZE 2
 
-#define FCS_SIZE 2
+#define FCS_SIZE     2
+#define PHR_DURATION 32
 #if defined(CONFIG_IEEE802154_2015)
 #define ACK_PKT_LENGTH 127
 #else
@@ -185,8 +186,9 @@ enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface,
 #if defined(CONFIG_NET_PKT_TIMESTAMP)
 	struct net_ptp_time *pkt_time = net_pkt_timestamp(pkt);
 
-	ack_frame.mInfo.mRxInfo.mTimestamp =
-		pkt_time->second * USEC_PER_SEC + pkt_time->nanosecond / NSEC_PER_USEC;
+	/* OpenThread expects the timestamp to point to the end of SFD */
+	ack_frame.mInfo.mRxInfo.mTimestamp = pkt_time->second * USEC_PER_SEC +
+					     pkt_time->nanosecond / NSEC_PER_USEC - PHR_DURATION;
 #endif
 
 	return NET_OK;
@@ -394,8 +396,9 @@ static void openthread_handle_received_frame(otInstance *instance,
 #if defined(CONFIG_NET_PKT_TIMESTAMP)
 	struct net_ptp_time *pkt_time = net_pkt_timestamp(pkt);
 
-	recv_frame.mInfo.mRxInfo.mTimestamp =
-		pkt_time->second * USEC_PER_SEC + pkt_time->nanosecond / NSEC_PER_USEC;
+	/* OpenThread expects the timestamp to point to the end of SFD */
+	recv_frame.mInfo.mRxInfo.mTimestamp = pkt_time->second * USEC_PER_SEC +
+					      pkt_time->nanosecond / NSEC_PER_USEC - PHR_DURATION;
 #endif
 
 #if defined(CONFIG_IEEE802154_2015)


### PR DESCRIPTION
OpenThread requires that the `mTimestamp` parameter from the `mRxInfo` struct points to the end of SFD, i.e. beggining of PHR.

Relates to: https://github.com/openthread/openthread/pull/8894/