### PR TITLE
json: add json_calc_encoded_arr_len function

### DIFF
--- a/include/zephyr/data/json.h
+++ b/include/zephyr/data/json.h
@@ -696,6 +696,18 @@ ssize_t json_calc_encoded_len(const struct json_obj_descr *descr,
 			      size_t descr_len, const void *val);
 
 /**
+ * @brief Calculates the string length to fully encode an array
+ *
+ * @param descr Pointer to the descriptor array
+ * @param val Struct holding the values
+ *
+ * @return Number of bytes necessary to encode the values if >0,
+ * an error code is returned.
+ */
+ssize_t json_calc_encoded_arr_len(const struct json_obj_descr *descr,
+				  const void *val);
+
+/**
  * @brief Encodes an object in a contiguous memory location
  *
  * @param descr Pointer to the descriptor array

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -1096,3 +1096,17 @@ ssize_t json_calc_encoded_len(const struct json_obj_descr *descr,
 
 	return total;
 }
+
+ssize_t json_calc_encoded_arr_len(const struct json_obj_descr *descr,
+				  const void *val)
+{
+	ssize_t total = 0;
+	int ret;
+
+	ret = json_arr_encode(descr, val, measure_bytes, &total);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return total;
+}

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -393,6 +393,10 @@ ZTEST(lib_json_test, test_json_arr_obj_encoding)
 		"]";
 	char buffer[sizeof(encoded)];
 	int ret;
+	ssize_t len;
+
+	len = json_calc_encoded_arr_len(obj_array_descr, &oa);
+	zassert_equal(len, strlen(encoded), "encoded size mismatch");
 
 	ret = json_arr_encode_buf(obj_array_descr, &oa, buffer, sizeof(buffer));
 	zassert_equal(ret, 0, "Encoding array of object returned error %d", ret);


### PR DESCRIPTION
Analog to json_obj_encode vs. json_calc_encoded_len which calculates the object len using json_obj_encode, introduce json_calc_encoded_arr_len which calculates the length using json_arr_encode. That is needed when the object to be encoded is array on the root level.