### PR TITLE
lib: bitarray: Remove redundant code

### DIFF
--- a/lib/os/bitarray.c
+++ b/lib/os/bitarray.c
@@ -427,7 +427,6 @@ int sys_bitarray_alloc(sys_bitarray_t *bitarray, size_t num_bits,
 			bit_idx += off_start;
 		}
 
-		ret = idx < INT_MAX ? (int)idx : INT_MAX;
 		break;
 	}
 


### PR DESCRIPTION
Remove statement probably left after rebase. ret should be 0 or error codes, described in docs, and it is rewritten 4 lines below.