### PR TITLE
lib/common: relax common libc property

### DIFF
--- a/lib/libc/common/CMakeLists.txt
+++ b/lib/libc/common/CMakeLists.txt
@@ -2,3 +2,4 @@
 
 zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_TIME source/time/time.c)
+zephyr_library_property(ALLOW_EMPTY TRUE)


### PR DESCRIPTION
In case CONFIG_MINIMAL_LIBC_TIME is not set the build may throw warnings about missing sources. It seems to be okay not to have time related functions built in so less strict rules should apply.