### PR TITLE
drivers: counter: mcux_qtmr: fix SYS_INIT call signature

### DIFF
--- a/drivers/counter/counter_mcux_qtmr.c
+++ b/drivers/counter/counter_mcux_qtmr.c
@@ -105,7 +105,7 @@ static void mcux_qtmr_isr(const struct device *timers[])
 	static const struct device *const timers_##n[4] = {				\
 		DT_FOREACH_CHILD_STATUS_OKAY(DT_DRV_INST(n), INIT_TIMER)		\
 	};										\
-	static int init_irq_##n(const struct device *dev)				\
+	static int init_irq_##n(void)							\
 	{										\
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), mcux_qtmr_isr,	\
 				timers_##n, 0);						\


### PR DESCRIPTION
Use the new int f(void) SYS_INIT call signature.