### PR TITLE
pm: Use TYPE_SECTION macros for pm_device_slots

### DIFF
--- a/cmake/linker_script/common/common-ram.cmake
+++ b/cmake/linker_script/common/common-ram.cmake
@@ -18,8 +18,7 @@ zephyr_linker_section_configure(SECTION device_states
 )
 
 if(CONFIG_PM_DEVICE)
-  zephyr_linker_section(NAME pm_device_slots GROUP DATA_REGION TYPE NOLOAD NOINPUT ${XIP_ALIGN_WITH_INPUT})
-  zephyr_linker_section_configure(SECTION pm_device_slots KEEP INPUT ".z_pm_device_slots")
+  zephyr_iterable_section(NAME pm_device_slots GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
 endif()
 
 zephyr_linker_section(NAME initshell GROUP DATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT})

--- a/include/zephyr/linker/common-ram.ld
+++ b/include/zephyr/linker/common-ram.ld
@@ -37,12 +37,7 @@
         } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 #if CONFIG_PM_DEVICE
-	SECTION_DATA_PROLOGUE(pm_device_slots, (NOLOAD),)
-	{
-		__pm_device_slots_start = .;
-		KEEP(*(".z_pm_device_slots"));
-		__pm_device_slots_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	ITERABLE_SECTION_RAM(pm_device_slots, 4)
 #endif
 
 #if defined(CONFIG_HAS_DYNAMIC_DEVICE_HANDLES)

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -210,7 +210,7 @@ struct pm_device {
 /**
  * @brief Define device PM slot.
  *
- * This macro defines a pointer to a device in the z_pm_device_slots region.
+ * This macro defines a pointer to a device in the pm_device_slots region.
  * When invoked for each device with PM, it will effectively result in a device
  * pointer array with the same size of the actual devices with PM enabled. This
  * is used internally by the PM subsystem to keep track of suspended devices
@@ -219,9 +219,8 @@ struct pm_device {
  * @param dev_id Device id.
  */
 #define Z_PM_DEVICE_DEFINE_SLOT(dev_id)					\
-	static const Z_DECL_ALIGN(struct device *)			\
-	_CONCAT(__pm_slot_, dev_id) __used				\
-	__attribute__((__section__(".z_pm_device_slots")))
+	static const STRUCT_SECTION_ITERABLE_ALTERNATE(pm_device_slots, device, \
+			_CONCAT(__pm_slot_, dev_id))
 
 #ifdef CONFIG_PM_DEVICE
 /**

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -51,7 +51,7 @@ static struct k_spinlock pm_notifier_lock;
 
 
 #ifdef CONFIG_PM_DEVICE
-extern const struct device *__pm_device_slots_start[];
+TYPE_SECTION_START_EXTERN(const struct device *, pm_device_slots);
 
 #if !defined(CONFIG_PM_DEVICE_RUNTIME_EXCLUSIVE)
 /* Number of devices successfully suspended. */
@@ -92,7 +92,7 @@ static int pm_suspend_devices(void)
 			return ret;
 		}
 
-		__pm_device_slots_start[num_susp] = dev;
+		TYPE_SECTION_START(pm_device_slots)[num_susp] = dev;
 		num_susp++;
 	}
 
@@ -102,7 +102,7 @@ static int pm_suspend_devices(void)
 static void pm_resume_devices(void)
 {
 	for (int i = (num_susp - 1); i >= 0; i--) {
-		pm_device_action_run(__pm_device_slots_start[i],
+		pm_device_action_run(TYPE_SECTION_START(pm_device_slots)[i],
 				    PM_DEVICE_ACTION_RESUME);
 	}
 


### PR DESCRIPTION
Clean up pm_device_slots to utilize TYPE_SECTION macros for handling sections.