### PR TITLE
linker: cleanup net_buf_pool to use iterable section macros

### DIFF
--- a/cmake/linker_script/common/common-ram.cmake
+++ b/cmake/linker_script/common/common-ram.cmake
@@ -57,11 +57,7 @@ zephyr_iterable_section(NAME k_queue GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} S
 zephyr_iterable_section(NAME k_condvar GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
 zephyr_iterable_section(NAME k_event GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
 
-zephyr_linker_section(NAME _net_buf_pool_area GROUP DATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
-zephyr_linker_section_configure(SECTION _net_buf_pool_area
-  KEEP SORT NAME INPUT "._net_buf_pool.static.*"
-  SYMBOLS _net_buf_pool_list
-)
+zephyr_iterable_section(NAME net_buf_pool GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
 
 if(CONFIG_NETWORKING)
   zephyr_iterable_section(NAME net_if     GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)

--- a/include/zephyr/linker/common-ram.ld
+++ b/include/zephyr/linker/common-ram.ld
@@ -100,11 +100,7 @@
 	ITERABLE_SECTION_RAM_GC_ALLOWED(k_queue, 4)
 	ITERABLE_SECTION_RAM_GC_ALLOWED(k_condvar, 4)
 
-	SECTION_DATA_PROLOGUE(_net_buf_pool_area,,SUBALIGN(4))
-	{
-		_net_buf_pool_list = .;
-		KEEP(*(SORT_BY_NAME("._net_buf_pool.static.*")))
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	ITERABLE_SECTION_RAM(net_buf_pool, 4)
 
 #if defined(CONFIG_NETWORKING)
 	NETWORK_RAM_SECTIONS

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -43,16 +43,20 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #endif
 
 /* Linker-defined symbol bound to the static pool structs */
-extern struct net_buf_pool _net_buf_pool_list[];
+STRUCT_SECTION_START_EXTERN(net_buf_pool);
 
 struct net_buf_pool *net_buf_pool_get(int id)
 {
-	return &_net_buf_pool_list[id];
+	struct net_buf_pool *pool;
+
+	STRUCT_SECTION_GET(net_buf_pool, id, &pool);
+
+	return pool;
 }
 
 static int pool_id(struct net_buf_pool *pool)
 {
-	return pool - _net_buf_pool_list;
+	return pool - TYPE_SECTION_START(net_buf_pool);
 }
 
 int net_buf_id(struct net_buf *buf)


### PR DESCRIPTION
Cleanup linker scripts for net_buf_pool section to use the linker script related iterable section macros.