### PR TITLE
Bluetooth: ASCS: Log missing fields of qos_pref

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -460,10 +460,10 @@ static void ascs_ep_get_status_config(struct bt_bap_ep *ep, struct net_buf_simpl
 	cfg->codec.vid = sys_cpu_to_le16(ep->codec.vid);
 
 	LOG_DBG("dir %s unframed_supported 0x%02x phy 0x%02x rtn %u "
-	       "latency %u pd_min %u pd_max %u codec 0x%02x",
-	       bt_audio_dir_str(ep->dir), pref->unframed_supported, pref->phy,
-	       pref->rtn, pref->latency, pref->pd_min, pref->pd_max,
-	       ep->stream->codec->id);
+		"latency %u pd_min %u pd_max %u pref_pd_min %u pref_pd_max %u codec 0x%02x",
+		bt_audio_dir_str(ep->dir), pref->unframed_supported, pref->phy, pref->rtn,
+		pref->latency, pref->pd_min, pref->pd_max, pref->pref_pd_min, pref->pref_pd_max,
+		ep->stream->codec->id);
 
 	cfg->cc_len = buf->len;
 	ascs_codec_data_add(buf, "data", ep->codec.data_count, ep->codec.data);


### PR DESCRIPTION
Added logging of the pref_pd_min and pref_pd_max field.