### PR TITLE
mgmt/mcumg: Provide zcbor_map_decode_bulk_reset utility function

### DIFF
--- a/subsys/mgmt/mcumgr/util/include/mgmt/mcumgr/util/zcbor_bulk.h
+++ b/subsys/mgmt/mcumgr/util/include/mgmt/mcumgr/util/zcbor_bulk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -40,6 +40,7 @@ struct zcbor_map_decode_key_val {
 		},						\
 		.decoder = (zcbor_decoder_t *)dec,		\
 		.value_ptr = vp,				\
+		.found = false,					\
 	}
 
 /** @brief Define single key-value decode mapping

--- a/subsys/mgmt/mcumgr/util/include/mgmt/mcumgr/util/zcbor_bulk.h
+++ b/subsys/mgmt/mcumgr/util/include/mgmt/mcumgr/util/zcbor_bulk.h
@@ -114,6 +114,19 @@ int zcbor_map_decode_bulk(zcbor_state_t *zsd, struct zcbor_map_decode_key_val *m
 bool zcbor_map_decode_bulk_key_found(struct zcbor_map_decode_key_val *map,
 	size_t map_size, const char *key);
 
+/** @brief Reset decoding state of key-value
+ *
+ * The function takes @p map and resets internal fields that mark decoding state
+ * of the map. Function needs to be used on @p map after the map has been already
+ * used for decoding other buffer, otherwise decoding may fail.
+ *
+ * @param map		key-decoder mapping list;
+ * @param map_size	size of maps, both maps have to have the same size.
+ *
+ * @return Nothing.
+ */
+void zcbor_map_decode_bulk_reset(struct zcbor_map_decode_key_val *map, size_t map_size);
+
 /** @endcond */
 
 #ifdef __cplusplus

--- a/subsys/mgmt/mcumgr/util/src/zcbor_bulk.c
+++ b/subsys/mgmt/mcumgr/util/src/zcbor_bulk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -100,4 +100,11 @@ bool zcbor_map_decode_bulk_key_found(struct zcbor_map_decode_key_val *map, size_
 	}
 
 	return false;
+}
+
+void zcbor_map_decode_bulk_reset(struct zcbor_map_decode_key_val *map, size_t map_size)
+{
+	for (size_t map_index = 0; map_index < map_size; ++map_index) {
+		map[map_index].found = false;
+	}
 }


### PR DESCRIPTION
PR adds `zcbor_map_decode_bulk_reset` function and fixes missing initialization of `zcbor_map_decode_key_val.found`.

Three commits:
1) Fix for missing initialization of `zcbor_map_decode_key_val.found`;
2) zcbor_map_decode_bulk_reset;
3) zcbor_map_decode_bulk_reset  tests.