### PR TITLE
mgmt/mcumgr: Add zcbor_map_decode_bulk_key_found utility function

### DIFF
--- a/subsys/mgmt/mcumgr/util/include/mgmt/mcumgr/util/zcbor_bulk.h
+++ b/subsys/mgmt/mcumgr/util/include/mgmt/mcumgr/util/zcbor_bulk.h
@@ -101,6 +101,18 @@ struct zcbor_map_decode_key_val {
 int zcbor_map_decode_bulk(zcbor_state_t *zsd, struct zcbor_map_decode_key_val *map,
 	size_t map_size, size_t *matched);
 
+/** @brief Check whether key has been found by zcbor_map_decode_bulk
+ *
+ * @param map		key-decoder mapping list;
+ * @param map_size	size of maps, both maps have to have the same size;
+ * @param key		string representing key to check with map.
+ *
+ * @return		true if key has been found during decoding, false otherwise.
+ *
+ */
+bool zcbor_map_decode_bulk_key_found(struct zcbor_map_decode_key_val *map,
+	size_t map_size, const char *key);
+
 /** @endcond */
 
 #ifdef __cplusplus

--- a/subsys/mgmt/mcumgr/util/src/zcbor_bulk.c
+++ b/subsys/mgmt/mcumgr/util/src/zcbor_bulk.c
@@ -70,3 +70,34 @@ int zcbor_map_decode_bulk(zcbor_state_t *zsd, struct zcbor_map_decode_key_val *m
 
 	return zcbor_map_end_decode(zsd) ? 0 : -EBADMSG;
 }
+
+bool zcbor_map_decode_bulk_key_found(struct zcbor_map_decode_key_val *map, size_t map_size,
+	const char *key)
+{
+	size_t key_len;
+	struct zcbor_map_decode_key_val *dptr = map;
+
+	/* Lazy run, comparing pointers only assuming that compiler will be able to store
+	 * read-only string of the same value as single instance.
+	 */
+	while (dptr < (map + map_size)) {
+		if (dptr->key.value == (const uint8_t *)key) {
+			return dptr->found;
+		}
+		++dptr;
+	}
+
+	/* Lazy run failed so need to do real comprison */
+	key_len = strlen(key);
+	dptr = map;
+
+	while (dptr < (map + map_size)) {
+		if (dptr->key.len == key_len &&
+		    memcmp(key, dptr->key.value, key_len) == 0) {
+			return dptr->found;
+		}
+		++dptr;
+	}
+
+	return false;
+}


### PR DESCRIPTION
PR adds `zcbor_map_decode_bulk_key_found` function that can be run over map used with `zcbor_map_decode_bulk` to decode zcbor stream, to figure out whether given key has been found in stream.

Two commits:
 1) Addition of zcbor_map_decode_bulk_key_found;
 2) addition of tests for zcbor_map_decode_bulk_key_found.