### PR TITLE
drivers: remove redundant CONFIG_PINCTRL #ifdef guards

### DIFF
--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -14,9 +14,7 @@
 #include <zephyr/drivers/adc.h>
 #include <fsl_lpadc.h>
 
-#if CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 
 #if !defined(CONFIG_SOC_SERIES_IMX_RT11XX)
 #include <fsl_power.h>
@@ -58,9 +56,7 @@ struct mcux_lpadc_config {
 	uint32_t offset_a;
 	uint32_t offset_b;
 	void (*irq_config_func)(const struct device *dev);
-#if CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
-#endif
 };
 
 struct mcux_lpadc_data {
@@ -403,14 +399,12 @@ static int mcux_lpadc_init(const struct device *dev)
 	struct mcux_lpadc_data *data = dev->data;
 	ADC_Type *base = config->base;
 	lpadc_config_t adc_config;
-#ifdef CONFIG_PINCTRL
 	int err;
 
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {
 		return err;
 	}
-#endif
 
 #if !defined(CONFIG_SOC_SERIES_IMX_RT11XX)
 #if	defined(CONFIG_SOC_SERIES_IMX_RT6XX)
@@ -556,14 +550,6 @@ static const struct adc_driver_api mcux_lpadc_driver_api = {
 #define TO_LPADC_POWER_LEVEL(val) \
 	_DO_CONCAT(kLPADC_PowerLevelAlt, val)
 
-#if CONFIG_PINCTRL
-#define PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n);
-#define PINCTRL_INIT(n) .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
-#else
-#define PINCTRL_DEFINE(n)
-#define PINCTRL_INIT(n)
-#endif /* CONFIG_PINCTRL */
-
 #define LPADC_MCUX_INIT(n)						\
 	static void mcux_lpadc_config_func_##n(const struct device *dev);	\
 									\
@@ -578,7 +564,7 @@ static const struct adc_driver_api mcux_lpadc_driver_api = {
 		"Invalid conversion average number for auto-calibration time");	\
 	ASSERT_WITHIN_RANGE(DT_INST_PROP(n, power_level), 1, 4,		\
 		"Invalid power level");					\
-	PINCTRL_DEFINE(n)						\
+	PINCTRL_DT_INST_DEFINE(n);					\
 	static const struct mcux_lpadc_config mcux_lpadc_config_##n = {	\
 		.base = (ADC_Type *)DT_INST_REG_ADDR(n),	\
 		.clock_source = TO_LPADC_CLOCK_SOURCE(DT_INST_PROP(n, clk_source)),	\
@@ -591,7 +577,7 @@ static const struct adc_driver_api mcux_lpadc_driver_api = {
 		.offset_a = DT_INST_PROP(n, offset_value_a),	\
 		.offset_b = DT_INST_PROP(n, offset_value_b),	\
 		.irq_config_func = mcux_lpadc_config_func_##n,				\
-		PINCTRL_INIT(n)					\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
 	};									\
 										\
 	static struct mcux_lpadc_data mcux_lpadc_data_##n = {	\

--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -8,6 +8,7 @@ config CAN_MCUX_FLEXCAN
 	default y
 	depends on DT_HAS_NXP_FLEXCAN_ENABLED
 	depends on CLOCK_CONTROL
+	select PINCTRL
 	help
 	  Enable support for the NXP FlexCAN driver.
 
@@ -37,5 +38,6 @@ config CAN_MCUX_MCAN
 	depends on DT_HAS_NXP_LPC_MCAN_ENABLED
 	depends on CLOCK_CONTROL
 	select CAN_MCAN
+	select PINCTRL
 	help
 	  Enable support for mcux mcan driver.

--- a/drivers/eeprom/Kconfig.xec
+++ b/drivers/eeprom/Kconfig.xec
@@ -7,5 +7,6 @@ config EEPROM_XEC
 	bool "MCHP XEC EEPROM driver"
 	default y
 	depends on DT_HAS_MICROCHIP_XEC_EEPROM_ENABLED
+	select PINCTRL
 	help
 	  Enable support for Microchip XEC EEPROM driver.

--- a/drivers/eeprom/eeprom_mchp_xec.c
+++ b/drivers/eeprom/eeprom_mchp_xec.c
@@ -11,9 +11,7 @@
 #include <zephyr/kernel.h>
 #include <soc.h>
 
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(eeprom_xec, CONFIG_EEPROM_LOG_LEVEL);
@@ -64,9 +62,7 @@ struct eeprom_xec_regs {
 struct eeprom_xec_config {
 	struct eeprom_xec_regs * const regs;
 	size_t size;
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pcfg;
-#endif
 };
 
 struct eeprom_xec_data {
@@ -307,14 +303,12 @@ static int eeprom_xec_init(const struct device *dev)
 
 	k_mutex_init(&data->lock_mtx);
 
-#ifdef CONFIG_PINCTRL
 	int ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 
 	if (ret != 0) {
 		LOG_ERR("XEC EEPROM pinctrl init failed (%d)", ret);
 		return ret;
 	}
-#endif
 
 	regs->mode |= XEC_EEPROM_MODE_ACTIVATE;
 
@@ -327,16 +321,12 @@ static const struct eeprom_driver_api eeprom_xec_api = {
 	.size = eeprom_xec_size,
 };
 
-#ifdef CONFIG_PINCTRL
 PINCTRL_DT_INST_DEFINE(0);
-#endif
 
 static const struct eeprom_xec_config eeprom_config = {
 	.regs = (struct eeprom_xec_regs * const)DT_INST_REG_ADDR(0),
 	.size = DT_INST_REG_SIZE(0),
-#ifdef CONFIG_PINCTRL
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
-#endif
 };
 
 static struct eeprom_xec_data eeprom_data;

--- a/drivers/gpio/Kconfig.imx
+++ b/drivers/gpio/Kconfig.imx
@@ -8,5 +8,6 @@ config GPIO_IMX
 	default y
 	depends on HAS_IMX_GPIO
 	depends on DT_HAS_NXP_IMX_GPIO_ENABLED
+	select PINCTRL
 	help
 	  Enable the IMX GPIO driver.

--- a/drivers/gpio/Kconfig.mcux_igpio
+++ b/drivers/gpio/Kconfig.mcux_igpio
@@ -8,5 +8,6 @@ config GPIO_MCUX_IGPIO
 	default y
 	depends on HAS_MCUX_IGPIO
 	depends on DT_HAS_NXP_IMX_GPIO_ENABLED
+	select PINCTRL
 	help
 	  Enable the MCUX IGPIO driver.

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -120,6 +120,7 @@ config I2C_MCUX_FLEXCOMM
 	bool "MCUX FLEXCOMM I2C driver"
 	default y
 	depends on DT_HAS_NXP_LPC_I2C_ENABLED
+	select PINCTRL
 	help
 	  Enable the mcux flexcomm i2c driver.
 
@@ -128,6 +129,7 @@ config I2C_MCUX_LPI2C
 	default y
 	depends on DT_HAS_NXP_IMX_LPI2C_ENABLED
 	depends on CLOCK_CONTROL
+	select PINCTRL
 	help
 	  Enable the mcux LPI2C driver.
 

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -171,6 +171,7 @@ config I2C_RV32M1_LPI2C
 	default y
 	depends on DT_HAS_OPENISA_RV32M1_LPI2C_ENABLED
 	depends on CLOCK_CONTROL
+	select PINCTRL
 	help
 	  Enable the RV32M1 LPI2C driver.
 

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -15,9 +15,7 @@
 #include <zephyr/irq.h>
 #include <fsl_lpi2c.h>
 
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif /* CONFIG_PINCTRL */
 
 #ifdef CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY
 #include "i2c_bitbang.h"
@@ -41,9 +39,7 @@ struct mcux_lpi2c_config {
 	void (*irq_config_func)(const struct device *dev);
 	uint32_t bitrate;
 	uint32_t bus_idle_timeout_ns;
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
-#endif /* CONFIG_PINCTRL */
 #ifdef CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY
 	struct gpio_dt_spec scl;
 	struct gpio_dt_spec sda;
@@ -517,12 +513,10 @@ static int mcux_lpi2c_init(const struct device *dev)
 		return error;
 	}
 
-#ifdef CONFIG_PINCTRL
 	error = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (error) {
 		return error;
 	}
-#endif /* CONFIG_PINCTRL */
 
 	config->irq_config_func(dev);
 
@@ -541,14 +535,6 @@ static const struct i2c_driver_api mcux_lpi2c_driver_api = {
 #endif /* CONFIG_I2C_TARGET */
 };
 
-#ifdef CONFIG_PINCTRL
-#define I2C_MCUX_LPI2C_PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n);
-#define I2C_MCUX_LPI2C_PINCTRL_INIT(n) .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
-#else
-#define I2C_MCUX_LPI2C_PINCTRL_DEFINE(n)
-#define I2C_MCUX_LPI2C_PINCTRL_INIT(n)
-#endif /* CONFIG_PINCTRL */
-
 #if CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY
 #define I2C_MCUX_LPI2C_SCL_INIT(n) .scl = GPIO_DT_SPEC_INST_GET_OR(n, scl_gpios, {0}),
 #define I2C_MCUX_LPI2C_SDA_INIT(n) .sda = GPIO_DT_SPEC_INST_GET_OR(n, sda_gpios, {0}),
@@ -558,7 +544,7 @@ static const struct i2c_driver_api mcux_lpi2c_driver_api = {
 #endif /* CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY */
 
 #define I2C_MCUX_LPI2C_INIT(n)						\
-	I2C_MCUX_LPI2C_PINCTRL_DEFINE(n)				\
+	PINCTRL_DT_INST_DEFINE(n);					\
 									\
 	static void mcux_lpi2c_config_func_##n(const struct device *dev); \
 									\
@@ -569,7 +555,7 @@ static const struct i2c_driver_api mcux_lpi2c_driver_api = {
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
 		.irq_config_func = mcux_lpi2c_config_func_##n,		\
 		.bitrate = DT_INST_PROP(n, clock_frequency),		\
-		I2C_MCUX_LPI2C_PINCTRL_INIT(n)				\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
 		I2C_MCUX_LPI2C_SCL_INIT(n)				\
 		I2C_MCUX_LPI2C_SDA_INIT(n)				\
 		.bus_idle_timeout_ns =					\

--- a/drivers/i2s/Kconfig.mcux
+++ b/drivers/i2s/Kconfig.mcux
@@ -8,6 +8,7 @@ menuconfig I2S_MCUX_SAI
 	default y
 	depends on DT_HAS_NXP_MCUX_I2S_ENABLED
 	select DMA
+	select PINCTRL
 	help
 	  Enable I2S support on the I.MX family of processors.
 

--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -18,9 +18,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/i3c.h>
 
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 
 /*
  * This is from NXP HAL which contains register bits macros
@@ -78,10 +76,8 @@ struct mcux_i3c_config {
 	/** Clock control subsys related struct. */
 	clock_control_subsys_t clock_subsys;
 
-#ifdef CONFIG_PINCTRL
 	/** Pointer to pin control device. */
 	const struct pinctrl_dev_config *pincfg;
-#endif
 
 	/** Interrupt configuration function. */
 	void (*irq_config_func)(const struct device *dev);
@@ -2006,12 +2002,10 @@ static int mcux_i3c_init(const struct device *dev)
 	CLOCK_SetClkDiv(kCLOCK_DivI3cSlowClk, data->clocks.clk_div_od);
 	CLOCK_SetClkDiv(kCLOCK_DivI3cTcClk, data->clocks.clk_div_tc);
 
-#ifdef CONFIG_PINCTRL
 	ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (ret != 0) {
 		goto err_out;
 	}
-#endif
 
 	k_sem_init(&data->lock, 1, 1);
 	k_sem_init(&data->ibi_lock, 1, 1);
@@ -2120,16 +2114,8 @@ static const struct i3c_driver_api mcux_i3c_driver_api = {
 #endif
 };
 
-#ifdef CONFIG_PINCTRL
-#define I3C_MCUX_PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n);
-#define I3C_MCUX_PINCTRL_INIT(n) .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
-#else
-#define I3C_MCUX_PINCTRL_DEFINE(n)
-#define I3C_MCUX_PINCTRL_INIT(n)
-#endif
-
 #define I3C_MCUX_DEVICE(id)							\
-	I3C_MCUX_PINCTRL_DEFINE(id)						\
+	PINCTRL_DT_INST_DEFINE(n);						\
 	static void mcux_i3c_config_func_##id(const struct device *dev);	\
 	static struct i3c_device_desc mcux_i3c_device_array_##id[] =			\
 		I3C_DEVICE_ARRAY_DT_INST(id);					\
@@ -2145,7 +2131,7 @@ static const struct i3c_driver_api mcux_i3c_driver_api = {
 		.common.dev_list.num_i3c = ARRAY_SIZE(mcux_i3c_device_array_##id),	\
 		.common.dev_list.i2c = mcux_i3c_i2c_device_array_##id,			\
 		.common.dev_list.num_i2c = ARRAY_SIZE(mcux_i3c_i2c_device_array_##id),	\
-		I3C_MCUX_PINCTRL_INIT(id)					\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
 	};									\
 	static struct mcux_i3c_data mcux_i3c_data_##id = {			\
 		.clocks.i3c_od_scl_hz = DT_INST_PROP_OR(id, i3c_od_scl_hz, 0),	\

--- a/drivers/kscan/Kconfig.xec
+++ b/drivers/kscan/Kconfig.xec
@@ -8,6 +8,7 @@ menuconfig KSCAN_XEC
 	default y
 	depends on DT_HAS_MICROCHIP_XEC_KSCAN_ENABLED
 	select MULTITHREADING
+	select PINCTRL
 	help
 	  Enable the Microchip XEC Kscan IO driver.
 

--- a/drivers/kscan/kscan_mchp_xec.c
+++ b/drivers/kscan/kscan_mchp_xec.c
@@ -14,9 +14,7 @@
 #include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>
 #endif
 #include <zephyr/drivers/kscan.h>
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 #include <zephyr/kernel.h>
 #include <soc.h>
 #include <zephyr/sys/atomic.h>
@@ -50,9 +48,7 @@ struct kscan_xec_config {
 	uint8_t pcr_idx;
 	uint8_t pcr_pos;
 	uint8_t rsvd[3];
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pcfg;
-#endif
 };
 
 struct kscan_xec_data {
@@ -465,14 +461,12 @@ static int kscan_xec_init(const struct device *dev)
 	struct kscan_xec_data *const data = dev->data;
 	struct kscan_regs *regs = cfg->regs;
 
-#ifdef CONFIG_PINCTRL
 	int ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 
 	if (ret != 0) {
 		LOG_ERR("XEC KSCAN pinctrl init failed (%d)", ret);
 		return ret;
 	}
-#endif
 
 	kscan_clr_slp_en(dev);
 
@@ -509,9 +503,7 @@ static int kscan_xec_init(const struct device *dev)
 
 static struct kscan_xec_data kbd_data;
 
-#ifdef CONFIG_PINCTRL
 PINCTRL_DT_INST_DEFINE(0);
-#endif
 
 static struct kscan_xec_config kscan_xec_cfg_0 = {
 	.regs = (struct kscan_regs *)(DT_INST_REG_ADDR(0)),
@@ -519,9 +511,7 @@ static struct kscan_xec_config kscan_xec_cfg_0 = {
 	.girq_pos = (uint8_t)(DT_INST_PROP_BY_IDX(0, girqs, 1)),
 	.pcr_idx = (uint8_t)(DT_INST_PROP_BY_IDX(0, pcrs, 0)),
 	.pcr_pos = (uint8_t)(DT_INST_PROP_BY_IDX(0, pcrs, 1)),
-#ifdef CONFIG_PINCTRL
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
-#endif
 };
 
 DEVICE_DT_INST_DEFINE(0, kscan_xec_init,

--- a/drivers/memc/Kconfig.mcux
+++ b/drivers/memc/Kconfig.mcux
@@ -18,5 +18,6 @@ config MEMC_MCUX_FLEXSPI_APS6408L
 
 config MEMC_MCUX_FLEXSPI
 	bool
+	select PINCTRL
 
 endif

--- a/drivers/peci/Kconfig.xec
+++ b/drivers/peci/Kconfig.xec
@@ -7,5 +7,6 @@ config PECI_XEC
 	bool "XEC Microchip PECI driver"
 	default y
 	depends on DT_HAS_MICROCHIP_XEC_PECI_ENABLED
+	select PINCTRL
 	help
 	  Enable the Microchip XEC PECI IO driver.

--- a/drivers/peci/peci_mchp_xec.c
+++ b/drivers/peci/peci_mchp_xec.c
@@ -14,9 +14,7 @@
 #include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>
 #endif
 #include <zephyr/drivers/peci.h>
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
 #include <soc.h>
@@ -52,9 +50,7 @@ struct peci_xec_config {
 	uint8_t girq_pos;
 	uint8_t pcr_idx;
 	uint8_t pcr_pos;
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pcfg;
-#endif
 };
 
 enum peci_pm_policy_state_flag {
@@ -525,14 +521,12 @@ static int peci_xec_init(const struct device *dev)
 	struct peci_regs * const regs = cfg->regs;
 	struct ecs_regs * const ecs_regs = (struct ecs_regs *)(DT_REG_ADDR(DT_NODELABEL(ecs)));
 
-#ifdef CONFIG_PINCTRL
 	int ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 
 	if (ret != 0) {
 		LOG_ERR("XEC PECI pinctrl init failed (%d)", ret);
 		return ret;
 	}
-#endif
 
 #ifdef CONFIG_PECI_INTERRUPT_DRIVEN
 	k_sem_init(&data->tx_lock, 0, 1);
@@ -568,9 +562,7 @@ static int peci_xec_init(const struct device *dev)
 
 static struct peci_xec_data peci_data;
 
-#ifdef CONFIG_PINCTRL
 PINCTRL_DT_INST_DEFINE(0);
-#endif
 
 static const struct peci_xec_config peci_xec_config = {
 	.regs = (struct peci_regs * const)(DT_INST_REG_ADDR(0)),
@@ -579,9 +571,7 @@ static const struct peci_xec_config peci_xec_config = {
 	.girq_pos = DT_INST_PROP_BY_IDX(0, girqs, 1),
 	.pcr_idx = DT_INST_PROP_BY_IDX(0, pcrs, 0),
 	.pcr_pos = DT_INST_PROP_BY_IDX(0, pcrs, 1),
-#ifdef CONFIG_PINCTRL
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
-#endif
 };
 
 PM_DEVICE_DT_INST_DEFINE(0, peci_xec_pm_action);

--- a/drivers/ps2/Kconfig.xec
+++ b/drivers/ps2/Kconfig.xec
@@ -6,6 +6,7 @@
 config PS2_XEC
 	bool "XEC Microchip PS2 driver"
 	depends on SOC_FAMILY_MEC && ESPI_PERIPHERAL_8042_KBC
+	select PINCTRL
 	help
 	  Enable the Microchip XEC PS2 IO driver. The driver also
 	  depends on the KBC 8042 keyboard controller. Note, MEC15xx

--- a/drivers/ps2/ps2_mchp_xec.c
+++ b/drivers/ps2/ps2_mchp_xec.c
@@ -15,9 +15,7 @@
 #include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
 #include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>
 #endif
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 #include <zephyr/drivers/ps2.h>
 #include <soc.h>
 #include <zephyr/logging/log.h>
@@ -37,9 +35,7 @@ struct ps2_xec_config {
 	uint8_t pcr_idx;
 	uint8_t pcr_pos;
 	void (*irq_config_func)(void);
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pcfg;
-#endif
 };
 
 struct ps2_xec_data {
@@ -261,14 +257,12 @@ static int ps2_xec_init(const struct device *dev)
 	const struct ps2_xec_config * const cfg = dev->config;
 	struct ps2_xec_data * const data = dev->data;
 
-#ifdef CONFIG_PINCTRL
 	int ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 
 	if (ret != 0) {
 		LOG_ERR("XEC PS2 pinctrl init failed (%d)", ret);
 		return ret;
 	}
-#endif
 
 	ps2_xec_slp_en_clr(dev);
 
@@ -279,8 +273,6 @@ static int ps2_xec_init(const struct device *dev)
 	return 0;
 }
 
-#ifdef CONFIG_PINCTRL
-#define XEC_PS2_PINCTRL_CFG(inst) PINCTRL_DT_INST_DEFINE(inst)
 #define XEC_PS2_CONFIG(inst)							\
 	static const struct ps2_xec_config ps2_xec_config_##inst = {		\
 		.regs = (struct ps2_regs * const)(DT_INST_REG_ADDR(inst)),	\
@@ -292,19 +284,6 @@ static int ps2_xec_init(const struct device *dev)
 		.irq_config_func = ps2_xec_irq_config_func_##inst,		\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),			\
 	}
-#else
-#define XEC_PS2_PINCTRL_CFG(inst)
-#define XEC_PS2_CONFIG(inst)							\
-	static const struct ps2_xec_config ps2_xec_config_##inst = {		\
-		.regs = (struct ps2_regs * const)(DT_INST_REG_ADDR(inst)),	\
-		.isr_nvic = DT_INST_IRQN(inst),					\
-		.girq_id = (uint8_t)(DT_INST_PROP_BY_IDX(inst, girqs, 0)),	\
-		.girq_bit = (uint8_t)(DT_INST_PROP_BY_IDX(inst, girqs, 1)),	\
-		.pcr_idx = (uint8_t)(DT_INST_PROP_BY_IDX(inst, pcrs, 0)),	\
-		.pcr_pos = (uint8_t)(DT_INST_PROP_BY_IDX(inst, pcrs, 1)),	\
-		.irq_config_func = ps2_xec_irq_config_func_##inst,		\
-	}
-#endif
 
 #define PS2_XEC_DEVICE(i)						\
 									\
@@ -319,7 +298,7 @@ static int ps2_xec_init(const struct device *dev)
 									\
 	static struct ps2_xec_data ps2_xec_port_data_##i;		\
 									\
-	XEC_PS2_PINCTRL_CFG(i);						\
+	PINCTRL_DT_INST_DEFINE(i);					\
 									\
 	XEC_PS2_CONFIG(i);						\
 									\

--- a/drivers/pwm/Kconfig.mcux_sctimer
+++ b/drivers/pwm/Kconfig.mcux_sctimer
@@ -5,5 +5,6 @@ config PWM_MCUX_SCTIMER
 	bool "MCUX SCTimer PWM driver"
 	default y
 	depends on DT_HAS_NXP_SCTIMER_PWM_ENABLED
+	select PINCTRL
 	help
 	  Enable sctimer based pwm driver.

--- a/drivers/pwm/Kconfig.rv32m1_tpm
+++ b/drivers/pwm/Kconfig.rv32m1_tpm
@@ -8,5 +8,6 @@ config PWM_RV32M1_TPM
 	default y
 	depends on DT_HAS_OPENISA_RV32M1_TPM_ENABLED
 	depends on CLOCK_CONTROL
+	select PINCTRL
 	help
 	  Enable the RV32M1 TPM PWM driver.

--- a/drivers/pwm/Kconfig.xec
+++ b/drivers/pwm/Kconfig.xec
@@ -7,6 +7,7 @@ config PWM_XEC
 	bool "Microchip XEC PWM"
 	default y
 	depends on DT_HAS_MICROCHIP_XEC_PWM_ENABLED
+	select PINCTRL
 	help
 	  Enable driver to utilize PWM on the Microchip XEC IP block.
 
@@ -14,6 +15,7 @@ config PWM_BBLED_XEC
 	bool "Microchip XEC PWM-BBLED"
 	default y
 	depends on DT_HAS_MICROCHIP_XEC_PWMBBLED_ENABLED
+	select PINCTRL
 	help
 	  Enable driver to utilize the Microchip XEC Breathing-Blinking LED
 	  as a PWM

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -17,9 +17,7 @@
 #include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
 #include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>
 #endif
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
@@ -55,9 +53,7 @@ struct pwm_xec_config {
 	struct pwm_regs * const regs;
 	uint8_t pcr_idx;
 	uint8_t pcr_pos;
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pcfg;
-#endif
 };
 
 struct xec_params {
@@ -379,7 +375,6 @@ static const struct pwm_driver_api pwm_xec_driver_api = {
 
 static int pwm_xec_init(const struct device *dev)
 {
-#ifdef CONFIG_PINCTRL
 	const struct pwm_xec_config * const cfg = dev->config;
 	int ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 
@@ -387,15 +382,10 @@ static int pwm_xec_init(const struct device *dev)
 		LOG_ERR("XEC PWM pinctrl init failed (%d)", ret);
 		return ret;
 	}
-#else
-	ARG_UNUSED(dev);
-#endif
 
 	return 0;
 }
 
-#ifdef CONFIG_PINCTRL
-#define XEC_PWM_PINCTRL_DEF(inst) PINCTRL_DT_INST_DEFINE(inst)
 #define XEC_PWM_CONFIG(inst)							\
 	static struct pwm_xec_config pwm_xec_config_##inst = {			\
 		.regs = (struct pwm_regs * const)DT_INST_REG_ADDR(inst),	\
@@ -404,19 +394,9 @@ static int pwm_xec_init(const struct device *dev)
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),			\
 	};
 
-#else
-#define XEC_PWM_PINCTRL_DEF(inst)
-#define XEC_PWM_CONFIG(inst)							\
-	static struct pwm_xec_config pwm_xec_config_##inst = {			\
-		.regs = (struct pwm_regs * const)DT_INST_REG_ADDR(inst),	\
-		.pcr_idx = (uint8_t)DT_INST_PROP_BY_IDX(inst, pcrs, 0),		\
-		.pcr_pos = (uint8_t)DT_INST_PROP_BY_IDX(inst, pcrs, 1),		\
-	};
-#endif
-
 #define XEC_PWM_DEVICE_INIT(index)					\
 									\
-	XEC_PWM_PINCTRL_DEF(index);					\
+	PINCTRL_DT_INST_DEFINE(index);					\
 									\
 	XEC_PWM_CONFIG(index);						\
 									\

--- a/drivers/pwm/pwm_mchp_xec_bbled.c
+++ b/drivers/pwm/pwm_mchp_xec_bbled.c
@@ -123,9 +123,7 @@ struct pwm_bbled_xec_config {
 	uint8_t pcr_idx;
 	uint8_t pcr_pos;
 	uint8_t clk_sel;
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pcfg;
-#endif
 };
 
 /* Compute BBLED PWM delay factor to produce requested frequency.
@@ -346,8 +344,6 @@ static int pwm_bbled_xec_init(const struct device *dev)
 	return 0;
 }
 
-#define XEC_PWM_BBLED_PINCTRL_DEF(inst) PINCTRL_DT_INST_DEFINE(inst)
-
 #define XEC_PWM_BBLED_CLKSEL(n)							\
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clock_select),			\
 		    (DT_INST_ENUM_IDX(n, clock_select)), (0))
@@ -365,7 +361,7 @@ static int pwm_bbled_xec_init(const struct device *dev)
 
 #define XEC_PWM_BBLED_DEVICE_INIT(index)				\
 									\
-	XEC_PWM_BBLED_PINCTRL_DEF(index);				\
+	PINCTRL_DT_INST_DEFINE(index);					\
 									\
 	XEC_PWM_BBLED_CONFIG(index);					\
 									\

--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -11,9 +11,7 @@
 #include <zephyr/drivers/pwm.h>
 #include <fsl_sctimer.h>
 #include <fsl_clock.h>
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 
 #include <zephyr/logging/log.h>
 
@@ -24,9 +22,7 @@ LOG_MODULE_REGISTER(pwm_mcux_sctimer, CONFIG_PWM_LOG_LEVEL);
 struct pwm_mcux_sctimer_config {
 	SCT_Type *base;
 	uint32_t prescale;
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
-#endif
 };
 
 struct pwm_mcux_sctimer_data {
@@ -134,14 +130,12 @@ static int mcux_sctimer_pwm_init(const struct device *dev)
 	sctimer_config_t pwm_config;
 	status_t status;
 	int i;
-#ifdef CONFIG_PINCTRL
 	int err;
 
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {
 		return err;
 	}
-#endif
 
 	SCTIMER_GetDefaultConfig(&pwm_config);
 	/* Divide the SCT clock by 8 */
@@ -168,22 +162,14 @@ static const struct pwm_driver_api pwm_mcux_sctimer_driver_api = {
 	.get_cycles_per_sec = mcux_sctimer_pwm_get_cycles_per_sec,
 };
 
-#ifdef CONFIG_PINCTRL
-#define PWM_MCUX_SCTIMER_PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n);
-#define PWM_MCUX_SCTIMER_PINCTRL_INIT(n) .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
-#else
-#define PWM_MCUX_SCTIMER_PINCTRL_DEFINE(n)
-#define PWM_MCUX_SCTIMER_PINCTRL_INIT(n)
-#endif
-
 #define PWM_MCUX_SCTIMER_DEVICE_INIT_MCUX(n)						\
-	PWM_MCUX_SCTIMER_PINCTRL_DEFINE(n)						\
+	PINCTRL_DT_INST_DEFINE(n);							\
 	static struct pwm_mcux_sctimer_data pwm_mcux_sctimer_data_##n;			\
 											\
 	static const struct pwm_mcux_sctimer_config pwm_mcux_sctimer_config_##n = {	\
 		.base = (SCT_Type *)DT_INST_REG_ADDR(n),				\
 		.prescale = DT_INST_PROP(n, prescaler),					\
-		PWM_MCUX_SCTIMER_PINCTRL_INIT(n)					\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\
 	};										\
 											\
 	DEVICE_DT_INST_DEFINE(n,							\

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -15,9 +15,7 @@
 #include <soc.h>
 #include <fsl_tpm.h>
 #include <fsl_clock.h>
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 
 #include <zephyr/logging/log.h>
 
@@ -33,9 +31,7 @@ struct rv32m1_tpm_config {
 	tpm_clock_prescale_t prescale;
 	uint8_t channel_count;
 	tpm_pwm_mode_t mode;
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
-#endif
 };
 
 struct rv32m1_tpm_data {
@@ -137,9 +133,7 @@ static int rv32m1_tpm_init(const struct device *dev)
 	struct rv32m1_tpm_data *data = dev->data;
 	tpm_chnl_pwm_signal_param_t *channel = data->channel;
 	tpm_config_t tpm_config;
-#ifdef CONFIG_PINCTRL
 	int err;
-#endif
 	int i;
 
 	if (config->channel_count > ARRAY_SIZE(data->channel)) {
@@ -171,12 +165,10 @@ static int rv32m1_tpm_init(const struct device *dev)
 		channel++;
 	}
 
-#ifdef CONFIG_PINCTRL
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {
 		return err;
 	}
-#endif
 
 	TPM_GetDefaultConfig(&tpm_config);
 	tpm_config.prescale = config->prescale;
@@ -191,16 +183,8 @@ static const struct pwm_driver_api rv32m1_tpm_driver_api = {
 	.get_cycles_per_sec = rv32m1_tpm_get_cycles_per_sec,
 };
 
-#ifdef CONFIG_PINCTRL
-#define PINCTRL_INIT(n) .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
-#define PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n);
-#else
-#define PINCTRL_DEFINE(n)
-#define PINCTRL_INIT(n)
-#endif
-
 #define TPM_DEVICE(n) \
-	PINCTRL_DEFINE(n) \
+	PINCTRL_DT_INST_DEFINE(n); \
 	static const struct rv32m1_tpm_config rv32m1_tpm_config_##n = { \
 		.base =	(TPM_Type *) \
 			DT_INST_REG_ADDR(n), \
@@ -212,7 +196,7 @@ static const struct pwm_driver_api rv32m1_tpm_driver_api = {
 		.channel_count = FSL_FEATURE_TPM_CHANNEL_COUNTn((TPM_Type *) \
 			DT_INST_REG_ADDR(n)), \
 		.mode = kTPM_EdgeAlignedPwm, \
-		PINCTRL_INIT(n) \
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n), \
 	}; \
 	static struct rv32m1_tpm_data rv32m1_tpm_data_##n; \
 	DEVICE_DT_INST_DEFINE(n, &rv32m1_tpm_init, NULL, \

--- a/drivers/sdhc/Kconfig.imx
+++ b/drivers/sdhc/Kconfig.imx
@@ -7,6 +7,7 @@ config IMX_USDHC
 	depends on DT_HAS_NXP_IMX_USDHC_ENABLED
 	select SDHC_SUPPORTS_UHS
 	select SDHC_SUPPORTS_NATIVE_MODE
+	select PINCTRL
 	help
 	  Enable the NXP IMX SD Host controller driver
 

--- a/drivers/sdhc/Kconfig.mcux_sdif
+++ b/drivers/sdhc/Kconfig.mcux_sdif
@@ -6,6 +6,7 @@ config MCUX_SDIF
 	default y
 	depends on DT_HAS_NXP_LPC_SDIF_ENABLED
 	select SDHC_SUPPORTS_NATIVE_MODE
+	select PINCTRL
 	help
 	  Enable the NXP SDIF Host controller driver
 

--- a/drivers/sensor/mchp_tach_xec/Kconfig
+++ b/drivers/sensor/mchp_tach_xec/Kconfig
@@ -8,6 +8,7 @@ config TACH_XEC
 	default y
 	depends on DT_HAS_MICROCHIP_XEC_TACH_ENABLED
 	depends on SOC_FAMILY_MEC
+	select PINCTRL
 	help
 	  Enable the Microchip XEC tachometer sensor.
 

--- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
+++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
@@ -15,9 +15,7 @@
 #include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
 #include <zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h>
 #endif
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 #include <zephyr/drivers/sensor.h>
 #include <soc.h>
 #include <zephyr/sys/sys_io.h>
@@ -31,9 +29,7 @@ struct tach_xec_config {
 	uint8_t girq_pos;
 	uint8_t pcr_idx;
 	uint8_t pcr_pos;
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pcfg;
-#endif
 };
 
 struct tach_xec_data {
@@ -126,14 +122,12 @@ static int tach_xec_init(const struct device *dev)
 	const struct tach_xec_config * const cfg = dev->config;
 	struct tach_regs * const tach = cfg->regs;
 
-#ifdef CONFIG_PINCTRL
 	int ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
 
 	if (ret != 0) {
 		LOG_ERR("XEC TACH pinctrl init failed (%d)", ret);
 		return ret;
 	}
-#endif
 
 	tach_xec_sleep_clr(dev);
 
@@ -150,8 +144,6 @@ static const struct sensor_driver_api tach_xec_driver_api = {
 	.channel_get = tach_xec_channel_get,
 };
 
-#ifdef CONFIG_PINCTRL
-#define XEC_TACH_PINCTRL_DEF(inst) PINCTRL_DT_INST_DEFINE(inst)
 #define XEC_TACH_CONFIG(inst)						\
 	static const struct tach_xec_config tach_xec_config_##inst = {	\
 		.regs = (struct tach_regs * const)DT_INST_REG_ADDR(inst),	\
@@ -161,22 +153,11 @@ static const struct sensor_driver_api tach_xec_driver_api = {
 		.pcr_pos = DT_INST_PROP_BY_IDX(inst, pcrs, 1),		\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),		\
 	}
-#else
-#define XEC_TACH_PINCTRL_DEF(inst)
-#define XEC_TACH_CONFIG(inst)						\
-	static const struct tach_xec_config tach_xec_config_##inst = {	\
-		.regs = (struct tach_regs * const)DT_INST_REG_ADDR(inst),	\
-		.girq = DT_INST_PROP_BY_IDX(inst, girqs, 0),		\
-		.girq_pos = DT_INST_PROP_BY_IDX(inst, girqs, 1),	\
-		.pcr_idx = DT_INST_PROP_BY_IDX(inst, pcrs, 0),		\
-		.pcr_pos = DT_INST_PROP_BY_IDX(inst, pcrs, 1),		\
-	}
-#endif
 
 #define TACH_XEC_DEVICE(id)						\
 	static struct tach_xec_data tach_xec_data_##id;			\
 									\
-	XEC_TACH_PINCTRL_DEF(id);					\
+	PINCTRL_DT_INST_DEFINE(id);					\
 									\
 	XEC_TACH_CONFIG(id);						\
 									\

--- a/drivers/sensor/qdec_mcux/Kconfig
+++ b/drivers/sensor/qdec_mcux/Kconfig
@@ -6,5 +6,6 @@ config QDEC_MCUX
 	default y
 	depends on DT_HAS_NXP_MCUX_QDEC_ENABLED
 	select MCUX_XBARA
+	select PINCTRL
 	help
 	  Enable support for NXP MCUX Quadrature Encoder driver.

--- a/drivers/serial/Kconfig.mcux
+++ b/drivers/serial/Kconfig.mcux
@@ -11,5 +11,6 @@ config UART_MCUX
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	select SERIAL_SUPPORT_ASYNC
+	select PINCTRL
 	help
 	  Enable the MCUX uart driver.

--- a/drivers/serial/Kconfig.mcux_flexcomm
+++ b/drivers/serial/Kconfig.mcux_flexcomm
@@ -9,5 +9,6 @@ config UART_MCUX_FLEXCOMM
 	depends on DT_HAS_NXP_LPC_USART_ENABLED
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	select PINCTRL
 	help
 	  Enable the MCUX USART driver.

--- a/drivers/serial/Kconfig.mcux_lpuart
+++ b/drivers/serial/Kconfig.mcux_lpuart
@@ -12,6 +12,7 @@ config UART_MCUX_LPUART
 	select SERIAL_SUPPORT_INTERRUPT
 	select SERIAL_SUPPORT_ASYNC
 	select DMA if UART_ASYNC_API
+	select PINCTRL
 	help
 	  Enable the MCUX LPUART driver.
 

--- a/drivers/serial/Kconfig.rv32m1_lpuart
+++ b/drivers/serial/Kconfig.rv32m1_lpuart
@@ -10,5 +10,6 @@ config UART_RV32M1_LPUART
 	depends on CLOCK_CONTROL
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	select PINCTRL
 	help
 	  Enable the RV32M1 LPUART driver.

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -15,9 +15,7 @@
 #include <fsl_uart.h>
 #include <soc.h>
 #include <zephyr/pm/device.h>
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 
 struct uart_mcux_config {
 	UART_Type *base;
@@ -26,9 +24,7 @@ struct uart_mcux_config {
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	void (*irq_config_func)(const struct device *dev);
 #endif
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
-#endif
 };
 
 struct uart_mcux_data {
@@ -327,9 +323,7 @@ static void uart_mcux_isr(const struct device *dev)
 
 static int uart_mcux_init(const struct device *dev)
 {
-#if defined(CONFIG_PINCTRL) || defined(CONFIG_UART_INTERRUPT_DRIVEN)
 	const struct uart_mcux_config *config = dev->config;
-#endif
 	struct uart_mcux_data *data = dev->data;
 	int err;
 
@@ -338,12 +332,10 @@ static int uart_mcux_init(const struct device *dev)
 		return err;
 	}
 
-#ifdef CONFIG_PINCTRL
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err != 0) {
 		return err;
 	}
-#endif
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	config->irq_config_func(dev);
@@ -401,20 +393,12 @@ static const struct uart_driver_api uart_mcux_driver_api = {
 #endif
 };
 
-#ifdef CONFIG_PINCTRL
-#define PINCTRL_INIT(n) .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
-#define PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n);
-#else
-#define PINCTRL_DEFINE(n)
-#define PINCTRL_INIT(n)
-#endif
-
 #define UART_MCUX_DECLARE_CFG(n, IRQ_FUNC_INIT)				\
 static const struct uart_mcux_config uart_mcux_##n##_config = {		\
 	.base = (UART_Type *)DT_INST_REG_ADDR(n),			\
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
 	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
-	PINCTRL_INIT(n)							\
+	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
 	IRQ_FUNC_INIT							\
 }
 
@@ -446,7 +430,7 @@ static const struct uart_mcux_config uart_mcux_##n##_config = {		\
 #endif
 
 #define UART_MCUX_INIT(n)						\
-	PINCTRL_DEFINE(n)						\
+	PINCTRL_DT_INST_DEFINE(n);					\
 									\
 	static struct uart_mcux_data uart_mcux_##n##_data = {		\
 		.uart_cfg = {						\

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -14,9 +14,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/policy.h>
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 #ifdef CONFIG_UART_ASYNC_API
 #include <zephyr/drivers/dma.h>
 #endif
@@ -37,9 +35,7 @@ struct lpuart_dma_config {
 struct mcux_lpuart_config {
 	LPUART_Type *base;
 	const struct device *clock_dev;
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
-#endif
 	clock_control_subsys_t clock_subsys;
 	uint32_t baud_rate;
 	uint8_t flow_ctrl;
@@ -1044,9 +1040,7 @@ static int mcux_lpuart_init(const struct device *dev)
 	const struct mcux_lpuart_config *config = dev->config;
 	struct mcux_lpuart_data *data = dev->data;
 	struct uart_config *uart_api_config = &data->uart_config;
-#ifdef CONFIG_PINCTRL
 	int err;
-#endif
 
 	uart_api_config->baudrate = config->baud_rate;
 	uart_api_config->parity = config->parity;
@@ -1056,12 +1050,10 @@ static int mcux_lpuart_init(const struct device *dev)
 
 	/* set initial configuration */
 	mcux_lpuart_configure_init(dev, uart_api_config);
-#ifdef CONFIG_PINCTRL
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err < 0) {
 		return err;
 	}
-#endif
 
 #ifdef CONFIG_UART_MCUX_LPUART_ISR_SUPPORT
 	config->irq_config_func(dev);
@@ -1186,14 +1178,6 @@ static const struct uart_driver_api mcux_lpuart_driver_api = {
 #define TX_DMA_CONFIG(n)
 #endif /* CONFIG_UART_ASYNC_API */
 
-#if CONFIG_PINCTRL
-#define PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n);
-#define PINCTRL_INIT(n) .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
-#else
-#define PINCTRL_DEFINE(n)
-#define PINCTRL_INIT(n)
-#endif /* CONFIG_PINCTRL */
-
 #define FLOW_CONTROL(n) \
 	DT_INST_PROP(n, hw_flow_control)   \
 		? UART_CFG_FLOW_CTRL_RTS_CTS     \
@@ -1211,7 +1195,7 @@ static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {     \
 	.parity = DT_INST_ENUM_IDX_OR(n, parity, UART_CFG_PARITY_NONE),       \
 	.rs485_de_active_low = DT_INST_PROP(n, nxp_rs485_de_active_low),      \
 	.loopback_en = DT_INST_PROP(n, nxp_loopback),                         \
-	PINCTRL_INIT(n)         \
+	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                          \
 	MCUX_LPUART_IRQ_INIT(n) \
 	RX_DMA_CONFIG(n)        \
 	TX_DMA_CONFIG(n)        \
@@ -1221,7 +1205,7 @@ static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {     \
 									\
 	static struct mcux_lpuart_data mcux_lpuart_##n##_data;		\
 									\
-	PINCTRL_DEFINE(n)						\
+	PINCTRL_DT_INST_DEFINE(n);					\
 	MCUX_LPUART_IRQ_DEFINE(n)					\
 									\
 	LPUART_MCUX_DECLARE_CFG(n)					\

--- a/drivers/spi/Kconfig.mcux_flexcomm
+++ b/drivers/spi/Kconfig.mcux_flexcomm
@@ -6,6 +6,7 @@ config SPI_MCUX_FLEXCOMM
 	bool "MCUX FLEXCOMM SPI driver"
 	default y
 	depends on DT_HAS_NXP_LPC_SPI_ENABLED
+	select PINCTRL
 	help
 	  Enable support for mcux flexcomm spi driver.
 

--- a/drivers/spi/Kconfig.mcux_lpspi
+++ b/drivers/spi/Kconfig.mcux_lpspi
@@ -8,6 +8,7 @@ config SPI_MCUX_LPSPI
 	default y
 	depends on DT_HAS_NXP_IMX_LPSPI_ENABLED
 	depends on CLOCK_CONTROL
+	select PINCTRL
 	help
 	  Enable support for mcux spi driver.
 

--- a/drivers/spi/Kconfig.rv32m1_lpspi
+++ b/drivers/spi/Kconfig.rv32m1_lpspi
@@ -8,5 +8,6 @@ config SPI_RV32M1_LPSPI
 	default y
 	depends on DT_HAS_OPENISA_RV32M1_LPSPI_ENABLED
 	depends on CLOCK_CONTROL
+	select PINCTRL
 	help
 	  Enable the RV32M1 LPSPI driver.

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -15,9 +15,7 @@
 #ifdef CONFIG_SPI_MCUX_FLEXCOMM_DMA
 #include <zephyr/drivers/dma.h>
 #endif
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif
 #include <zephyr/sys_clock.h>
 #include <zephyr/irq.h>
 
@@ -38,9 +36,7 @@ struct spi_mcux_config {
 	uint32_t frame_delay;
 	uint32_t transfer_delay;
 	uint32_t def_char;
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
-#endif
 };
 
 #ifdef CONFIG_SPI_MCUX_FLEXCOMM_DMA
@@ -736,12 +732,10 @@ static int spi_mcux_init(const struct device *dev)
 
 	data->dev = dev;
 
-#ifdef CONFIG_PINCTRL
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {
 		return err;
 	}
-#endif
 
 #ifdef CONFIG_SPI_MCUX_FLEXCOMM_DMA
 	if (!device_is_ready(data->dma_tx.dma_dev)) {
@@ -788,14 +782,6 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 	irq_enable(DT_INST_IRQN(id));				\
 }
 
-#ifdef CONFIG_PINCTRL
-#define SPI_MCUX_FLEXCOMM_PINCTRL_DEFINE(id) PINCTRL_DT_INST_DEFINE(id);
-#define SPI_MCUX_FLEXCOMM_PINCTRL_INIT(id) .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),
-#else
-#define SPI_MCUX_FLEXCOMM_PINCTRL_DEFINE(id)
-#define SPI_MCUX_FLEXCOMM_PINCTRL_INIT(id)
-#endif
-
 #ifndef CONFIG_SPI_MCUX_FLEXCOMM_DMA
 #define SPI_DMA_CHANNELS(id)
 #else
@@ -827,7 +813,7 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 
 #define SPI_MCUX_FLEXCOMM_DEVICE(id)					\
 	SPI_MCUX_FLEXCOMM_IRQ_HANDLER_DECL(id);			\
-	SPI_MCUX_FLEXCOMM_PINCTRL_DEFINE(id)				\
+	PINCTRL_DT_INST_DEFINE(id);					\
 	static const struct spi_mcux_config spi_mcux_config_##id = {	\
 		.base =							\
 		(SPI_Type *)DT_INST_REG_ADDR(id),			\
@@ -840,7 +826,7 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 		.frame_delay = DT_INST_PROP_OR(id, frame_delay, 0),		\
 		.transfer_delay = DT_INST_PROP_OR(id, transfer_delay, 0),		\
 		.def_char = DT_INST_PROP_OR(id, def_char, 0),		\
-		SPI_MCUX_FLEXCOMM_PINCTRL_INIT(id)			\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),		\
 	};								\
 	static struct spi_mcux_data spi_mcux_data_##id = {		\
 		SPI_CONTEXT_INIT_LOCK(spi_mcux_data_##id, ctx),		\

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -15,9 +15,7 @@
 #ifdef CONFIG_SPI_MCUX_LPSPI_DMA
 #include <zephyr/drivers/dma.h>
 #endif
-#ifdef CONFIG_PINCTRL
 #include <zephyr/drivers/pinctrl.h>
-#endif /* CONFIG_PINCTRL */
 
 LOG_MODULE_REGISTER(spi_mcux_lpspi, CONFIG_SPI_LOG_LEVEL);
 
@@ -34,9 +32,7 @@ struct spi_mcux_config {
 	uint32_t pcs_sck_delay;
 	uint32_t sck_pcs_delay;
 	uint32_t transfer_delay;
-#ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
-#endif /* CONFIG_PINCTRL */
 };
 
 #ifdef CONFIG_SPI_MCUX_LPSPI_DMA
@@ -568,12 +564,10 @@ static int spi_mcux_init(const struct device *dev)
 	}
 #endif /* CONFIG_SPI_MCUX_LPSPI_DMA */
 
-#ifdef CONFIG_PINCTRL
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {
 		return err;
 	}
-#endif /* CONFIG_PINCTRL */
 
 	spi_context_unlock_unconditionally(&data->ctx);
 
@@ -620,17 +614,8 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 #define SPI_DMA_CHANNELS(n)
 #endif /* CONFIG_SPI_MCUX_LPSPI_DMA */
 
-#ifdef CONFIG_PINCTRL
-#define SPI_MCUX_LPSPI_PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n);
-#define SPI_MCUX_LPSPI_PINCTRL_INIT(n) .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
-#else
-#define SPI_MCUX_LPSPI_PINCTRL_DEFINE(n)
-#define SPI_MCUX_LPSPI_PINCTRL_INIT(n)
-#endif /* CONFIG_PINCTRL */
-
-
 #define SPI_MCUX_LPSPI_INIT(n)						\
-	SPI_MCUX_LPSPI_PINCTRL_DEFINE(n)				\
+	PINCTRL_DT_INST_DEFINE(n);					\
 									\
 	static void spi_mcux_config_func_##n(const struct device *dev);	\
 									\
@@ -649,7 +634,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		.transfer_delay = UTIL_AND(				\
 			DT_INST_NODE_HAS_PROP(n, transfer_delay),	\
 			DT_INST_PROP(n, transfer_delay)),		\
-		SPI_MCUX_LPSPI_PINCTRL_INIT(n)				\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
 	};								\
 									\
 	static struct spi_mcux_data spi_mcux_data_##n = {		\


### PR DESCRIPTION
Pre-pinctrl era is now gone, so there's no need for macrology or extra guarding around CONFIG_PINCTRL. This PR cleans most drivers (left gecko ones, as they are more convoluted).