### PR TITLE
board: tdk_robokit1: chip select fixes

### DIFF
--- a/boards/arm/tdk_robokit1/tdk_robokit1-common.dtsi
+++ b/boards/arm/tdk_robokit1/tdk_robokit1-common.dtsi
@@ -67,12 +67,6 @@
 	status = "okay";
 };
 
-&afec1 {
-	pinctrl-0 = <&afec1_default>;
-	pinctrl-names = "default";
-	status = "okay";
-};
-
 &dacc {
 	status = "okay";
 };

--- a/boards/arm/tdk_robokit1/tdk_robokit1-pinctrl.dtsi
+++ b/boards/arm/tdk_robokit1/tdk_robokit1-pinctrl.dtsi
@@ -14,12 +14,6 @@
 		};
 	};
 
-	afec1_default: afec1_default {	/* ADCH - J504 */
-		group1 {
-			pinmux = <PC31X_AFE1_AD6>;
-		};
-	};
-
 	can0_default: can0_default {
 		group1 {
 			pinmux = <PB3A_CAN0_RX>,


### PR DESCRIPTION
Disables AFEC1 on the tdk robokit1 as the PC31 pin is used a chip select for the on board spi connected ADC.

Sets the register used by the spi connected adc to register 0 (implying hardware chip select peripheral 0) so that the software (gpio) chip select works.