### PR TITLE
nrf52_bsim: Do not load Tsymbols from main

### DIFF
--- a/boards/posix/nrf52_bsim/main.c
+++ b/boards/posix/nrf52_bsim/main.c
@@ -8,7 +8,6 @@
 #include "NRF_HW_model_top.h"
 #include "NRF_HWLowL.h"
 #include "bs_tracing.h"
-#include "bs_symbols.h"
 #include "bs_types.h"
 #include "bs_utils.h"
 #include "bs_rand_main.h"
@@ -37,7 +36,6 @@ uint8_t inner_main_clean_up(int exit_code)
 	bs_dump_files_close_all();
 
 	bs_clean_back_channels();
-	bs_clear_Tsymbols();
 
 	uint8_t bst_result = bst_delete();
 
@@ -81,8 +79,6 @@ int main(int argc, char *argv[])
 
 	args = nrfbsim_argsparse(argc, argv);
 	global_device_nbr = args->global_device_nbr;
-
-	bs_read_function_names_from_Tsymbols(argv[0]);
 
 	run_native_tasks(_NATIVE_PRE_BOOT_2_LEVEL);
 


### PR DESCRIPTION
We do not use them for anything yet, but they do
use a lot of heap, specially for the networking apps with openthread.
If we need them later we can always add it again.

Moreover, there is an issue is this bsim component detected by ASAN when loading symbols with too long names, the issue is fixed in the master branch, but better if users do not need to update for a component which is not used.

Note: This is a feature which loads all symbols names into memory so we can (programatically) resolve them from their addresses for runtime "debug" features. But it is not used by anything in this board.