### PR TITLE
console: uart_mux: Use TYPE_SECTION macros for uart_mux

### DIFF
--- a/cmake/linker_script/common/common-ram.cmake
+++ b/cmake/linker_script/common/common-ram.cmake
@@ -60,10 +60,7 @@ if(CONFIG_NETWORKING)
 endif()
 
 if(CONFIG_UART_MUX)
-  zephyr_linker_section(NAME uart_mux GROUP DATA_REGION NOINPUT ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
-  zephyr_linker_section_configure(SECTION uart_mux
-    KEEP SORT NAME INPUT ".uart_mux.*"
-  )
+  zephyr_iterable_section(NAME uart_mux GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
 endif()
 
 if(CONFIG_USB_DEVICE_STACK)

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -66,15 +66,14 @@ struct uart_mux {
 #define DEFINE_UART_MUX(x, _)						\
 	RING_BUF_DECLARE(uart_rx_ringbuf_##x,				\
 			 CONFIG_UART_MUX_RINGBUF_SIZE);			\
-	static struct uart_mux uart_mux_##x __used			\
-		__attribute__((__section__(".uart_mux.data"))) = {	\
+	STRUCT_SECTION_ITERABLE(uart_mux, uart_mux_##x)	= {		\
 			.rx_ringbuf = &uart_rx_ringbuf_##x,		\
 	}
 
 LISTIFY(CONFIG_UART_MUX_REAL_DEVICE_COUNT, DEFINE_UART_MUX, (;), _);
 
-extern struct uart_mux __uart_mux_start[];
-extern struct uart_mux __uart_mux_end[];
+STRUCT_SECTION_START_EXTERN(uart_mux);
+STRUCT_SECTION_END_EXTERN(uart_mux);
 
 /* UART Mux Driver Status Codes */
 enum uart_mux_status_code {
@@ -342,7 +341,8 @@ static int init_real_uart(const struct device *mux, const struct device *uart,
 	bool found = false;
 	struct uart_mux *real_uart;
 
-	for (real_uart = __uart_mux_start; real_uart != __uart_mux_end;
+	for (real_uart = TYPE_SECTION_START(uart_mux);
+	     real_uart != TYPE_SECTION_END(uart_mux);
 	     real_uart++) {
 		if (real_uart->uart == uart) {
 			found = true;
@@ -351,7 +351,8 @@ static int init_real_uart(const struct device *mux, const struct device *uart,
 	}
 
 	if (found == false) {
-		for (real_uart = __uart_mux_start; real_uart != __uart_mux_end;
+		for (real_uart = TYPE_SECTION_START(uart_mux);
+		     real_uart != TYPE_SECTION_END(uart_mux);
 		     real_uart++) {
 			if (real_uart->uart == NULL) {
 				real_uart->uart = uart;

--- a/include/zephyr/linker/common-ram.ld
+++ b/include/zephyr/linker/common-ram.ld
@@ -96,13 +96,7 @@
 #endif /* PCIE */
 
 #if defined(CONFIG_UART_MUX)
-	SECTION_DATA_PROLOGUE(uart_mux,,SUBALIGN(4))
-	{
-		__uart_mux_start = .;
-		*(".uart_mux.*")
-		KEEP(*(SORT_BY_NAME(".uart_mux.*")))
-		__uart_mux_end = .;
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	ITERABLE_SECTION_RAM(uart_mux, 4)
 #endif
 
 #if defined(CONFIG_USB_DEVICE_STACK)


### PR DESCRIPTION
Clean up uart_mux to utilize TYPE_SECTION macros for handling sections.