### PR TITLE
xtensa: fatal: no backtrace if no stack is passed in

### DIFF
--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -108,13 +108,15 @@ void z_xtensa_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 
 		coredump(reason, esf, IS_ENABLED(CONFIG_MULTITHREADING) ? k_current_get() : NULL);
 
-		arch_irq_unlock(key);
-	}
 #if defined(CONFIG_XTENSA_ENABLE_BACKTRACE)
 #if XCHAL_HAVE_WINDOWED
-	z_xtensa_backtrace_print(100, (int *)esf);
+		z_xtensa_backtrace_print(100, (int *)esf);
 #endif
 #endif
+
+		arch_irq_unlock(key);
+	}
+
 	z_fatal_error(reason, esf);
 }
 


### PR DESCRIPTION
The backtrace requires a valid stack pointer to start printing backtraces. So if there is no stack pointer being passed in, skip printing backtraces.