### PR TITLE
soc: arm64: nxp_imx: Add common directory

### DIFF
--- a/soc/arm64/nxp_imx/CMakeLists.txt
+++ b/soc/arm64/nxp_imx/CMakeLists.txt
@@ -5,3 +5,4 @@
 #
 
 add_subdirectory(${SOC_SERIES})
+add_subdirectory(common)

--- a/soc/arm64/nxp_imx/common/CMakeLists.txt
+++ b/soc/arm64/nxp_imx/common/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright 2023 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_interface_library_named(NXP_IMX_COMMON)
+
+zephyr_library_named(nxp_imx_common)
+zephyr_library_include_directories(include)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+
+zephyr_library_link_libraries(NXP_IMX_COMMON)
+
+target_include_directories(NXP_IMX_COMMON INTERFACE include)
+target_link_libraries(NXP_IMX_COMMON INTERFACE nxp_imx_common)

--- a/soc/arm64/nxp_imx/common/include/soc.h
+++ b/soc/arm64/nxp_imx/common/include/soc.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_SOC_NXP_IMX_COMMON_SOC_H_
+#define ZEPHYR_SOC_NXP_IMX_COMMON_SOC_H_
+
+/* TODO: populate me when need be */
+
+
+#endif /* ZEPHYR_SOC_NXP_IMX_COMMON_SOC_H_ */


### PR DESCRIPTION
This commit introduces the common/ directory which should contain all definitions required by NXP's arm64-based SoC's. This is required mostly for the soc.h header without which the build process of Zephyr's SOF module fails for i.MX93.