### PR TITLE
drivers: wdt_tco: Change init level from PRE_KERNEL_1 to POST_KERNEL

### DIFF
--- a/drivers/watchdog/wdt_tco.c
+++ b/drivers/watchdog/wdt_tco.c
@@ -271,5 +271,5 @@ static const struct tco_config wdt_config = {
 };
 
 DEVICE_DT_DEFINE(TCO_WDT_NODE, wdt_init, NULL, &wdt_data, &wdt_config,
-		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
 		 &tco_driver_api);


### PR DESCRIPTION
All other watchdog drivers also use POST_KERNEL, and it seems on some platforms where the TCO watchdog is used not all dependencies are yet set up by the PRE_KERNEL_1 level.