### PR TITLE
Flash simulator enhancements

### DIFF
--- a/boards/posix/nrf52_bsim/nrf52_bsim.dts
+++ b/boards/posix/nrf52_bsim/nrf52_bsim.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 
+#include <mem.h>
 #include <arm/nordic/nrf52833.dtsi>
 
 / {


### PR DESCRIPTION
For the POSIX architecture, add options to:
* Clear the flash content at boot
* To delete the file on exit
* To just keep the flash in RAM instead of a file in disk

It is normal for users to want to do this things, let's just provide them command line options, so they don't need to delete the files by hand before/after running their test.
