### PR TITLE
doc: doxygen: Remove kernel tests

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -926,8 +926,7 @@ INPUT                  = @ZEPHYR_BASE@/doc/_doxygen/mainpage.md \
                          @ZEPHYR_BASE@/include/ \
                          @ZEPHYR_BASE@/lib/libc/minimal/include/ \
                          @ZEPHYR_BASE@/subsys/testsuite/include/ \
-                         @ZEPHYR_BASE@/subsys/testsuite/ztest/include/ \
-                         @ZEPHYR_BASE@/tests/kernel/
+                         @ZEPHYR_BASE@/subsys/testsuite/ztest/include/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Remove kernel tests from Doxygen INPUT as they end up unnecessarily included in the generated API documentation, where they can cause confusion as to what is/isn't API and generally make it harder to find information.

![image](https://user-images.githubusercontent.com/128251/233356582-1393133c-439f-48cd-b49f-6a25ce1c3fd6.png)
