### PR TITLE
boards/arm/mm_{feather,swiftio}: declare missing `zephyr,flash` chosen

### DIFF
--- a/boards/arm/mm_feather/mm_feather.dts
+++ b/boards/arm/mm_feather/mm_feather.dts
@@ -26,6 +26,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
+		zephyr,flash = &is25wp064;
 	};
 
 	sdram0: memory@80000000 {

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -26,6 +26,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
+		zephyr,flash = &is25wp064;
 	};
 
 	sdram0: memory@80000000 {


### PR DESCRIPTION
This PR declares the missing `zephyr,flash` chosen field. Without this, any Zephyr app is unable to compile properly for these boards.

This appeared after 48214e86b08116d9029eca598ba521d67d2772f2.