### PR TITLE
smbus: Change init priority from DEVICE to DEFAULT

### DIFF
--- a/drivers/smbus/Kconfig
+++ b/drivers/smbus/Kconfig
@@ -25,7 +25,7 @@ config SMBUS_STATS
 
 config SMBUS_INIT_PRIORITY
 	int "Init priority"
-	default KERNEL_INIT_PRIORITY_DEVICE
+	default KERNEL_INIT_PRIORITY_DEFAULT
 	help
 	  SMBus device driver initialization priority.
 


### PR DESCRIPTION
Change init priority for SMBus from KERNEL_INIT_PRIORITY_DEVICE (50) to KERNEL_INIT_PRIORITY_DEFAULT (40) since other devices which depend on SMBus (like EEPROM) have the same priority.