### PR TITLE
nrf52_bsim: Use the flash simulator by default

### DIFF
--- a/boards/posix/nrf52_bsim/nrf52_bsim.dts
+++ b/boards/posix/nrf52_bsim/nrf52_bsim.dts
@@ -34,11 +34,6 @@
 		/delete-property/ qdec-0;
 	};
 
-	chosen {
-		/delete-property/ zephyr,flash-controller;
-		zephyr,ieee802154 = &ieee802154;
-	};
-
 	soc {
 		/delete-node/ flash-controller@4001e000;
 		/delete-node/ memory@20000000;
@@ -64,6 +59,46 @@
 	};
 
 	/delete-node/ sw-pwm;
+
+	chosen {
+		/delete-property/ zephyr,flash-controller;
+		zephyr,ieee802154 = &ieee802154;
+	};
+
+	/* Let's use the flash simulator while the HW models do not have a FLASH peripheral model */
+	flashcontroller0: flash-controller@0 {
+		compatible = "zephyr,sim-flash";
+		reg = <0x00000000 DT_SIZE_K(2048)>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+		erase-value = <0xff>;
+
+		flash0: flash@0 {
+			status = "okay";
+			compatible = "soc-nv-flash";
+			erase-block-size = <4096>;
+			write-block-size = <1>;
+			reg = <0x00000000 DT_SIZE_K(256)>;
+
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				storage_partition: partition@00000 {
+					label = "storage";
+					reg = <0x0000000 DT_SIZE_K(256)>;
+				};
+			};
+		};
+	};
+
+	chosen {
+		zephyr,flash = &flash0;
+		zephyr,flash-controller = &flashcontroller0;
+	};
+
 };
 
 &radio {

--- a/samples/net/sockets/echo_client/boards/nrf52_bsim.conf
+++ b/samples/net/sockets/echo_client/boards/nrf52_bsim.conf
@@ -1,4 +1,0 @@
-# The nrf52 HW models do not have a flash model yet. Even though it is possible to use different
-# replacements, the easiest one is to disable the flash, so when configured with openthread
-# it will use the OPENTHREAD_SETTINGS_RAM
-CONFIG_FLASH=n

--- a/samples/net/sockets/echo_server/boards/nrf52_bsim.conf
+++ b/samples/net/sockets/echo_server/boards/nrf52_bsim.conf
@@ -1,4 +1,0 @@
-# The nrf52 HW models do not have a flash model yet. Even though it is possible to use different
-# replacements, the easiest one is to disable the flash, so when configured with openthread
-# it will use the OPENTHREAD_SETTINGS_RAM
-CONFIG_FLASH=n

--- a/tests/bsim/net/sockets/echo_test/boards/nrf52_bsim.conf
+++ b/tests/bsim/net/sockets/echo_test/boards/nrf52_bsim.conf
@@ -1,4 +1,0 @@
-# The nrf52 HW models do not have a flash model yet. Even though it is possible to use different
-# replacements, the easiest one is to disable the flash, so when configured with openthread
-# it will use the OPENTHREAD_SETTINGS_RAM
-CONFIG_FLASH=n

--- a/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_ot.sh
+++ b/tests/bsim/net/sockets/echo_test/tests_scripts/echo_test_ot.sh
@@ -19,10 +19,10 @@ cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD}_tests_bsim_net_sockets_echo_test_prj_conf_overlay-ot_conf \
   -v=${verbosity_level} -s=${simulation_id} -d=0 -RealEncryption=1 \
-  -testid=echo_client
+  -testid=echo_client -flash_in_ram
 
 Execute ./bs_${BOARD}_samples_net_sockets_echo_server_prj_conf_overlay-ot_conf\
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=1 \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -RealEncryption=1 -flash_in_ram
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=26e6 -argschannel -at=40 -argsmain $@


### PR DESCRIPTION
Today there is no "FLASH" peripheral in the nrf52_bsim, so the real nrf flash driver cannot be used.
But the flash simulator can be used with the nrf52_bsim just like with any other board (it does not even require the POSIX arch, even though, for this arch, it is even nicer, as it allows you to keep the flash content in a file in disk).

Today users need to add a DT overlay to their app if they want to use the flash simulator with this board, which is a bit cumbersome.

This PR provides a good default dts configuration for most use cases for this board, which makes it much easier for users to enable the flash simulator in their apps/tests.

------
    nrf52_bsim: dts: Enable the flash simulator
    
    So when applications try to use CONFIG_FLASH it will
    work and default to the simulator without the need for
    any overlay.
------
    tests/net: For nrf52_bsim use FLASH simulator in RAM
    
    Instead of falling back to the openthread RAM settings backend
Note that for these tests we keep the flash just in RAM because we do not want to persist anything between runs in this case.
