### PR TITLE
NPM1300 GPIO updated for new silicon revision

### DIFF
--- a/boards/shields/npm1300_ek/npm1300_ek.overlay
+++ b/boards/shields/npm1300_ek/npm1300_ek.overlay
@@ -58,5 +58,13 @@
 			thermistor-beta = <3380>;
 			charging-enable;
 		};
+
+		npm1300_ek_buttons: buttons {
+			compatible = "gpio-keys";
+			pmic_button0: pmic_button_0 {
+				gpios = < &npm1300_ek_gpio 0 GPIO_ACTIVE_HIGH>;
+				label = "Pmic button switch 0";
+			};
+		};
 	};
 };


### PR DESCRIPTION
Status readback has been added in the latest silicon revision on the NPM1300. 

The GPIO driver has been updated to add support for port_get_raw and port_toggle_bits,
and an associated button has been added to the shield overlay.