### PR TITLE
tests: rtc: fix test identifier

### DIFF
--- a/tests/drivers/rtc/rtc_api_helpers/src/test_rtc_time_to_tm.c
+++ b/tests/drivers/rtc/rtc_api_helpers/src/test_rtc_time_to_tm.c
@@ -8,7 +8,7 @@
 #include <zephyr/drivers/rtc.h>
 #include <time.h>
 
-ZTEST(rtc_api_helpers, validate_rtc_time_compat_with_tm)
+ZTEST(rtc_api_helpers, test_validate_rtc_time_compat_with_tm)
 {
 	zassert(offsetof(struct rtc_time, tm_sec) == offsetof(struct tm, tm_sec),
 		"Offset of tm_sec in struct rtc_time does not match struct tm");
@@ -38,7 +38,7 @@ ZTEST(rtc_api_helpers, validate_rtc_time_compat_with_tm)
 		"Offset of tm_isdts in struct rtc_time does not match struct tm");
 }
 
-ZTEST(rtc_api_helpers, validate_rtc_time_to_tm)
+ZTEST(rtc_api_helpers, test_validate_rtc_time_to_tm)
 {
 	struct rtc_time rtc_datetime;
 	struct tm *datetime = NULL;


### PR DESCRIPTION
Tests need to be prefixed with test_.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
