### PR TITLE
Support SPI ASYNC mode in the NXP Flexcomm driver when DMA is enabled

### DIFF
--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -713,6 +713,10 @@ static int spi_mcux_transceive_async(const struct device *dev,
 				     spi_callback_t cb,
 				     void *userdata)
 {
+#ifdef CONFIG_SPI_MCUX_FLEXCOMM_DMA
+	return transceive_dma(dev, spi_cfg, tx_bufs, rx_bufs, true, cb, userdata);
+#endif
+
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, cb, userdata);
 }
 #endif /* CONFIG_SPI_ASYNC */

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt595_evk_cm33.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt595_evk_cm33.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_FLEXCOMM_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt685_evk_cm33.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt685_evk_cm33.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_FLEXCOMM_DMA=y
-CONFIG_SPI_ASYNC=n


### PR DESCRIPTION
Support SPI ASYNC mode in the NXP Flexcomm driver when DMA is enabled.