### PR TITLE
logging: Change Z_LOG_MSG_STACK_CREATE() variable

### DIFF
--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -226,12 +226,12 @@ enum z_log_msg_mode {
 #define Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, _dlen, ...) \
 do { \
 	int _plen; \
-	uint32_t flags = Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt) | \
-			 CBPRINTF_PACKAGE_ADD_RW_STR_POS; \
+	uint32_t _options = Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt) | \
+			  CBPRINTF_PACKAGE_ADD_RW_STR_POS; \
 	if (GET_ARG_N(1, __VA_ARGS__) == NULL) { \
 		_plen = 0; \
 	} else { \
-		CBPRINTF_STATIC_PACKAGE(NULL, 0, _plen, Z_LOG_MSG_ALIGN_OFFSET, flags, \
+		CBPRINTF_STATIC_PACKAGE(NULL, 0, _plen, Z_LOG_MSG_ALIGN_OFFSET, _options, \
 					__VA_ARGS__); \
 	} \
 	struct log_msg *_msg; \
@@ -239,7 +239,7 @@ do { \
 	Z_LOG_ARM64_VLA_PROTECT(); \
 	if (_plen != 0) { \
 		CBPRINTF_STATIC_PACKAGE(_msg->data, _plen, \
-					_plen, Z_LOG_MSG_ALIGN_OFFSET, flags, \
+					_plen, Z_LOG_MSG_ALIGN_OFFSET, _options, \
 					__VA_ARGS__);\
 	} \
 	struct log_msg_desc _desc = \


### PR DESCRIPTION
"flags" is a common variable name and is more likely to be passed to LOG_DBG() or LOG_ERR() as a parameter. Changing the name of the local variable created in Z_LOG_MSG_STACK_CREATE() from "flags" to "_options" make it less likely that someone will pass a parameter of that name to LOG_DBG() or LOG_ERR() and have that passed value occluded by the variable created in Z_LOG_MSG_STACK_CREATE.

Fixes #57089