### PR TITLE
Revert "adc: harness regex string not capturing sample app"

### DIFF
--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -16,5 +16,5 @@ tests:
     harness_config:
       type: multi_line
       regex:
-        - "ADC reading\\[\\d+\\]"
+        - "ADC reading\\[\\d+\\]:"
         - "- .+, channel \\d+: -?\\d+"


### PR DESCRIPTION
This reverts commit aef973d65b4836aa5153a1e145239227f97545fc.