### PR TITLE
Make minimal libc "work" without -ffreestanding

### DIFF
--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -7,6 +7,8 @@ zephyr_library()
 set(GEN_DIR ${ZEPHYR_BINARY_DIR}/include/generated)
 set(STRERROR_TABLE_H ${GEN_DIR}/libc/minimal/strerror_table.h)
 
+zephyr_library_cc_option(-fno-builtin)
+
 zephyr_library_sources(
   source/stdlib/abort.c
   source/stdlib/atoi.c

--- a/lib/libc/minimal/include/stdio.h
+++ b/lib/libc/minimal/include/stdio.h
@@ -60,14 +60,8 @@ int fputc(int c, FILE *stream);
 int fputs(const char *ZRESTRICT s, FILE *ZRESTRICT stream);
 size_t fwrite(const void *ZRESTRICT ptr, size_t size, size_t nitems,
 	      FILE *ZRESTRICT stream);
-static inline int putc(int c, FILE *stream)
-{
-	return fputc(c, stream);
-}
-static inline int putchar(int c)
-{
-	return putc(c, stdout);
-}
+#define putc(c, stream) fputc(c, stream)
+#define putchar(c) putc(c, stdout)
 
 #ifdef __cplusplus
 }

--- a/lib/libc/minimal/source/stdlib/abort.c
+++ b/lib/libc/minimal/source/stdlib/abort.c
@@ -11,4 +11,5 @@ void abort(void)
 {
 	printk("abort()\n");
 	k_panic();
+	CODE_UNREACHABLE;
 }

--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -53,6 +53,18 @@ int fputs(const char *ZRESTRICT s, FILE *ZRESTRICT stream)
 	return len == ret ? 0 : EOF;
 }
 
+#undef putc
+int putc(int c, FILE *stream)
+{
+	return zephyr_fputc(c, stream);
+}
+
+#undef putchar
+int putchar(int c)
+{
+	return zephyr_fputc(c, stdout);
+}
+
 size_t z_impl_zephyr_fwrite(const void *ZRESTRICT ptr, size_t size,
 			    size_t nitems, FILE *ZRESTRICT stream)
 {

--- a/tests/lib/sprintf/src/main.c
+++ b/tests/lib/sprintf/src/main.c
@@ -791,10 +791,6 @@ ZTEST(sprintf, test_fprintf)
 	ret = fprintf(stdout, "");
 	zassert_equal(ret, 0, "fprintf failed!");
 
-#if !defined(CONFIG_PICOLIBC) && !defined(CONFIG_ARMCLANG_STD_LIBC)	/* this is UB */
-	ret = fprintf(NULL, "%d", i);
-	zassert_equal(ret, EOF, "fprintf failed!");
-#endif
 }
 
 
@@ -823,10 +819,6 @@ ZTEST(sprintf, test_vfprintf)
 	ret = WriteFrmtd_vf(stdout,  "11\n");
 	zassert_equal(ret, 3, "vfprintf \"11\" failed");
 
-#ifndef CONFIG_PICOLIBC	/* this is UB */
-	ret = WriteFrmtd_vf(NULL,  "This %d", 3);
-	zassert_equal(ret, EOF, "vfprintf \"This 3\" failed");
-#endif
 }
 
 /**
@@ -883,29 +875,14 @@ ZTEST(sprintf, test_put)
 	ret = fputs("This 3\n", stderr);
 	zassert_equal(ret, 0, "fputs \"This 3\" failed");
 
-#if !defined(CONFIG_PICOLIBC) && !defined(CONFIG_ARMCLANG_STD_LIBC)	/* this is UB */
-	ret = fputs("This 3", NULL);
-	zassert_equal(ret, EOF, "fputs \"This 3\" failed");
-#endif
-
 	ret = puts("This 3");
 	zassert_equal(ret, 0, "puts \"This 3\" failed");
 
 	ret = fputc('T', stdout);
 	zassert_equal(ret, 84, "fputc \'T\' failed");
 
-#if !defined(CONFIG_PICOLIBC) && !defined(CONFIG_ARMCLANG_STD_LIBC)	/* this is UB */
-	ret = fputc('T', NULL);
-	zassert_equal(ret, EOF, "fputc \'T\' failed");
-#endif
-
 	ret = putc('T', stdout);
 	zassert_equal(ret, 84, "putc \'T\' failed");
-
-#if !defined(CONFIG_PICOLIBC) && !defined(CONFIG_ARMCLANG_STD_LIBC)	/* this is UB */
-	ret = putc('T', NULL);
-	zassert_equal(ret, EOF, "putc \'T\' failed");
-#endif
 
 	ret = fputc('T', stderr);
 	zassert_equal(ret, 84, "fputc \'T\' failed");


### PR DESCRIPTION
When the minimal C library is selected, `-ffreestanding` will be normally be added to the compiler flags. However, it is possible to disable that by setting `CONFIG_COMPILER_FREESTANDING=n`. In that mode, there are a few minor issues caught by the test suite which can be resolved by making modest changes to the minimal C library code.

With these changes, `twister -xCONFIG_COMPILER_FREESTANDING=n` passes.