### PR TITLE
IPC: rpmsg: Changed checking endpoints on close

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -465,6 +465,10 @@ Libraries / Subsystems
     called with ``FS_MOUNT_FLAG_NO_FORMAT`` and the designated LittleFS area could not be
     mounted because it has not yet been mounted or it required reformatting.
 
+* IPC
+
+  * :c:func:`ipc_service_close_instance` now only acts on bounded endpoints.
+
 * Management
 
   * Added optional input expiration to shell MCUmgr transport, this allows

--- a/include/zephyr/ipc/ipc_service.h
+++ b/include/zephyr/ipc/ipc_service.h
@@ -220,7 +220,7 @@ int ipc_service_open_instance(const struct device *instance);
 
 /** @brief Close an instance
  *
- *  Function to be used to close an instance. All endpoints must be
+ *  Function to be used to close an instance. All bounded endpoints must be
  *  deregistered using ipc_service_deregister_endpoint before this
  *  is called.
  *

--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -95,7 +95,7 @@ static bool check_endpoints_freed(struct ipc_rpmsg_instance *rpmsg_inst)
 	for (size_t i = 0; i < NUM_ENDPOINTS; i++) {
 		rpmsg_ept = &rpmsg_inst->endpoint[i];
 
-		if (strcmp("", rpmsg_ept->name) != 0) {
+		if (rpmsg_ept->bound == true) {
 			return false;
 		}
 	}


### PR DESCRIPTION
Initially this change was part of #56113 and there discussion about that started.
This change is due to situation I have got in project - network core creates two endpoints and app core creates only one. In that situation there are two endpoints, both of them have names and one of them is bounded - unused one has name.
So checking bounded by name returned false result in case of unused endpoint.