### PR TITLE
dai: intel: dmic: simplify the probe

### DIFF
--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -302,7 +302,7 @@ static inline void dai_dmic_en_power(const struct dai_intel_dmic *dmic)
 
 #ifdef CONFIG_SOC_INTEL_ACE20_LNL /* Ace 2.0 */
 	while (!(sys_read32(base + DMICLCTL_OFFSET) & DMICLCTL_CPA)) {
-		k_sleep(K_USEC(100));
+		k_sleep(K_USEC(10));
 	}
 #endif
 }
@@ -313,6 +313,12 @@ static inline void dai_dmic_dis_power(const struct dai_intel_dmic *dmic)
 	/* Disable DMIC power */
 	sys_write32((sys_read32(base + DMICLCTL_OFFSET) & (~DMICLCTL_SPA)),
 		     base + DMICLCTL_OFFSET);
+
+#ifdef CONFIG_SOC_INTEL_ACE20_LNL /* Ace 2.0 */
+	while ((sys_read32(base + DMICLCTL_OFFSET) & DMICLCTL_CPA)) {
+		k_sleep(K_USEC(10));
+	}
+#endif
 }
 
 static int dai_dmic_probe(struct dai_intel_dmic *dmic)

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -347,6 +347,9 @@ static int dai_dmic_probe(struct dai_intel_dmic *dmic)
 	/* Set state, note there is no playback direction support */
 	dmic->state = DAI_STATE_NOT_READY;
 
+	/* DMIC Owner Select to DSP */
+	dai_dmic_claim_ownership(dmic);
+
 	/* Enable DMIC power */
 	dai_dmic_en_power(dmic);
 
@@ -355,9 +358,6 @@ static int dai_dmic_probe(struct dai_intel_dmic *dmic)
 
 	/* DMIC Change sync period */
 	dai_dmic_set_sync_period(CONFIG_DAI_DMIC_PLATFORM_SYNC_PERIOD, dmic);
-
-	/* DMIC Owner Select to DSP */
-	dai_dmic_claim_ownership(dmic);
 
 	irq_enable(dmic->irq);
 


### PR DESCRIPTION
After checking with hardware architects, we can simplify the DMIC probe quite a bit.

ownership change, power-up/down, clock-gating and period handling seem to be mixed case of misunderstandings, logical inversions and workarounds maintained since 2018.

Time for a Spring 2023 clean-up aligned with hardware-recommended programming sequences.

Setting as draft for now since it's my first PR against Zephyr main.

@jxstelter @kv2019i @singalsu @juimonen @ranj063 comments welcome.