### PR TITLE
doc: add ARMv6 expected outputs to mpu_test README

### DIFF
--- a/samples/arch/mpu/mpu_test/README.rst
+++ b/samples/arch/mpu/mpu_test/README.rst
@@ -43,6 +43,9 @@ proper configs.
 Sample Output
 =============
 
+When running the above on an ARMv7 or ARMv8 CPU, the output of each command may look
+like the following.
+
 .. code-block:: console
 
   uart:~$ mpu read
@@ -86,3 +89,50 @@ Sample Output
   <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
   <err> os: Current thread: 0x20000708 (shell_uart)
   <err> os: Halting system
+
+
+When running this test on an ARMv6 CPU (specifically on a Cortex-M0+), the output will
+look different, as ARMv6 handles MPU faults as generic hard faults. Moreover, when
+running the ``mpu run`` command, Zephyr's hard fault handler for AArch32 tries to
+dereference the program counter from the exception stack frame, causing a second fault
+and silently placing the processor into a lockup state.
+
+To verify that the ``mpu run`` test in particular is running correctly, one can
+
+* start the MPU test under gdb with ``west debug``
+* execute ``mpu run`` over UART
+* then interrupt gdb with Ctrl-C and show the program counter by running ``l`` in gdb.
+
+The program counter should display as ``0xfffffffe``, indicating a lockup state.
+
+
+.. code-block:: console
+
+  uart:~$ mpu read
+  <err> os: ***** HARD FAULT *****
+  <err> os: r0/a1:  0x0800a54c  r1/a2:  0x00000008  r2/a3:  0x08003
+  <err> os: r3/a4:  0x24000000 r12/ip:  0x00000040 r14/lr:  0x0800d
+  <err> os:  xpsr:  0x01000000
+  <err> os: Faulting instruction address (r15/pc): 0x08000486
+  <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
+  <err> os: Current thread: 0x200006a8 (shell_uart)
+  <err> os: Halting system
+
+
+.. code-block:: console
+
+  uart:~$ mpu write
+  <err> os: ***** HARD FAULT *****
+  <err> os: r0/a1:  0x00000000  r1/a2:  0x0000000e  r2/a3:  0x0000e
+  <err> os: r3/a4:  0x0badc0de r12/ip:  0x00000000 r14/lr:  0x08009
+  <err> os:  xpsr:  0x61000000
+  <err> os: Faulting instruction address (r15/pc): 0x0800046a
+  <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
+  <err> os: Current thread: 0x200006a8 (shell_uart)
+  <err> os: Halting system
+
+
+.. code-block:: console
+
+  uart~$ mpu run
+  <no output>


### PR DESCRIPTION
Add expected output for ARMv6 CPUs in the `mpu_test` README, as this differs from that for other AArch32 CPUs due to differences in how ARMv6 handles faults.

This change in the README for the MPU test notes the true expected output for ARMv6 CPUs (taken from my tests with a Nucleo G071RB board) and explains the rationale for why these indicate correct functionality.

In particular, the output for ARMv6 differs from that currently in the README, because

* ARMv6 lacks a specific MPU fault, so it emits hard faults whenever a MPU fault occurs (changing the output for `mpu read` and `mpu write`)
* The Zephyr hard fault handler for AArch32 dereferences the ESF PC, which for the `mpu run` test triggers a second fault, putting the CPU into lockup and resulting in no output over UART.