### PR TITLE
drivers/bluetooth/hci/slz_hci: remove unused `const struct device`

### DIFF
--- a/drivers/bluetooth/hci/slz_hci.c
+++ b/drivers/bluetooth/hci/slz_hci.c
@@ -168,10 +168,8 @@ static const struct bt_hci_driver drv = {
 	.quirks         = BT_QUIRK_NO_RESET
 };
 
-static int slz_bt_init(const struct device *unused)
+static int slz_bt_init(void)
 {
-	ARG_UNUSED(unused);
-
 	int ret;
 
 	ret = bt_hci_driver_register(&drv);


### PR DESCRIPTION
This PR removes the unused argument form the `slz_bt_init` function, and makes it consistent with what `SYS_INIT` expects - `int (*)(void)`.