### PR TITLE
libc: add strchrnul implementation

### DIFF
--- a/lib/libc/minimal/include/string.h
+++ b/lib/libc/minimal/include/string.h
@@ -23,6 +23,7 @@ extern char  *strncpy(char *ZRESTRICT d, const char *ZRESTRICT s,
 		      size_t n);
 extern char  *strchr(const char *s, int c);
 extern char  *strrchr(const char *s, int c);
+extern char  *strchrnul(const char *s, int c);
 extern size_t strlen(const char *s);
 extern size_t strnlen(const char *s, size_t maxlen);
 extern int    strcmp(const char *s1, const char *s2);

--- a/lib/libc/minimal/source/string/string.c
+++ b/lib/libc/minimal/source/string/string.c
@@ -63,10 +63,10 @@ char *strncpy(char *ZRESTRICT d, const char *ZRESTRICT s, size_t n)
  *
  * @brief String scanning operation
  *
- * @return pointer to 1st instance of found byte, or NULL if not found
+ * @return pointer to 1st instance of found byte, or to end of word
  */
 
-char *strchr(const char *s, int c)
+char *strchrnul(const char *s, int c)
 {
 	char tmp = (char) c;
 
@@ -74,7 +74,22 @@ char *strchr(const char *s, int c)
 		s++;
 	}
 
-	return (*s == tmp) ? (char *) s : NULL;
+	return (char *) s;
+}
+
+/**
+ *
+ * @brief String scanning operation
+ *
+ * @return pointer to 1st instance of found byte, or NULL if not found
+ */
+
+char *strchr(const char *s, int c)
+{
+	char tmp = (char) c;
+	char *r = strchrnul(s, c);
+
+	return (*r == tmp) ? r : NULL;
 }
 
 /**


### PR DESCRIPTION
Add implementation of `strchrnul` function to libc. Because `strchr` is a special case of `strchrnul` (where we return NULL instead of position of string end) I have updated implementation of `strchr` to use `strchrnul`.