### PR TITLE
devicetree: introduce DT_ANY_INST_HAS_PROP_STATUS_OKAY

### DIFF
--- a/drivers/sensor/lm77/lm77.c
+++ b/drivers/sensor/lm77/lm77.c
@@ -20,9 +20,8 @@ LOG_MODULE_REGISTER(lm77, CONFIG_SENSOR_LOG_LEVEL);
  * Only compile in trigger support if enabled in Kconfig and at least one
  * enabled lm77 devicetree node has the int-gpios property.
  */
-#define LM77_TRIGGER_SUPPORT_INST(inst) DT_INST_NODE_HAS_PROP(inst, int_gpios) ||
 #define LM77_TRIGGER_SUPPORT \
-	(CONFIG_LM77_TRIGGER && (DT_INST_FOREACH_STATUS_OKAY(LM77_TRIGGER_SUPPORT_INST) 0))
+	(CONFIG_LM77_TRIGGER && DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios))
 
 /* LM77 registers */
 #define LM77_REG_TEMP   0x00U

--- a/dts/bindings/test/vnd,device-with-props.yaml
+++ b/dts/bindings/test/vnd,device-with-props.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test device with random properties
+
+compatible: "vnd,device-with-props"
+
+properties:
+  foo:
+    type: int
+
+  bar:
+    type: int
+
+  baz:
+    type: int

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -3791,6 +3791,53 @@
 	DT_COMPAT_ON_BUS_INTERNAL(DT_DRV_COMPAT, bus)
 
 /**
+ * @brief Check if any `DT_DRV_COMPAT` node with status `okay` has a given
+ *        property.
+ *
+ * @param prop lowercase-and-underscores property name
+ *
+ * Example devicetree overlay:
+ *
+ * @code{.dts}
+ *     &i2c0 {
+ *         sensor0: sensor@0 {
+ *             compatible = "vnd,some-sensor";
+ *             status = "okay";
+ *             reg = <0>;
+ *             foo = <1>;
+ *             bar = <2>;
+ *         };
+ *
+ *         sensor1: sensor@1 {
+ *             compatible = "vnd,some-sensor";
+ *             status = "okay";
+ *             reg = <1>;
+ *             foo = <2>;
+ *         };
+ *
+ *         sensor2: sensor@2 {
+ *             compatible = "vnd,some-sensor";
+ *             status = "disabled";
+ *             reg = <2>;
+ *             baz = <1>;
+ *         };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     #define DT_DRV_COMPAT vnd_some_sensor
+ *
+ *     DT_ANY_INST_HAS_PROP_STATUS_OKAY(foo) // 1
+ *     DT_ANY_INST_HAS_PROP_STATUS_OKAY(bar) // 1
+ *     DT_ANY_INST_HAS_PROP_STATUS_OKAY(baz) // 0
+ * @endcode
+ */
+#define DT_ANY_INST_HAS_PROP_STATUS_OKAY(prop) \
+	(DT_INST_FOREACH_STATUS_OKAY_VARGS(DT_INST_NODE_HAS_PROP_AND_OR, prop) 0)
+
+/**
  * @brief Call @p fn on all nodes with compatible `DT_DRV_COMPAT`
  *        and status `okay`
  *
@@ -4076,6 +4123,10 @@
 /** @brief Helper for test cases and DT_ANY_INST_ON_BUS_STATUS_OKAY() */
 #define DT_COMPAT_ON_BUS_INTERNAL(compat, bus) \
 	IS_ENABLED(UTIL_CAT(DT_CAT(DT_COMPAT_, compat), _BUS_##bus))
+
+/** @brief Helper macro to OR multiple has property checks in a loop macro */
+#define DT_INST_NODE_HAS_PROP_AND_OR(inst, prop) \
+	DT_INST_NODE_HAS_PROP(inst, prop) ||
 
 /** @endcond */
 

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -537,6 +537,25 @@
 			};
 		};
 
+		device-with-props-0 {
+			compatible = "vnd,device-with-props";
+			status = "okay";
+			foo = <1>;
+			bar = <2>;
+		};
+
+		device-with-props-1 {
+			compatible = "vnd,device-with-props";
+			status = "okay";
+			foo = <2>;
+		};
+
+		device-with-props-2 {
+			compatible = "vnd,device-with-props";
+			status = "disabled";
+			baz = <1>;
+		};
+
 		test_string_token_0: string-token-0 {
 			compatible = "vnd,string-token";
 			val = "token_zero";

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -180,6 +180,16 @@ ZTEST(devicetree_api, test_inst_props)
 			      strlen(label_startswith)), "");
 }
 
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_device_with_props
+ZTEST(devicetree_api, test_any_inst_prop)
+{
+	zassert_equal(DT_ANY_INST_HAS_PROP_STATUS_OKAY(foo), 1, "");
+	zassert_equal(DT_ANY_INST_HAS_PROP_STATUS_OKAY(bar), 1, "");
+	zassert_equal(DT_ANY_INST_HAS_PROP_STATUS_OKAY(baz), 0, "");
+	zassert_equal(DT_ANY_INST_HAS_PROP_STATUS_OKAY(does_not_exist), 0, "");
+}
+
 ZTEST(devicetree_api, test_default_prop_access)
 {
 	/*


### PR DESCRIPTION
Add a new macro, DT_ANY_INST_HAS_PROP_STATUS_OKAY that given a property
name, evaluates to 1 if any enabled instance of `DT_DRV_COMPAT` has the
property or to zero if it hasn't.

This macro can be useful in the context of drivers to optimize
resources.