### PR TITLE
doc: flash_map: fix code snippet and docstring

### DIFF
--- a/doc/services/storage/flash_map/flash_map.rst
+++ b/doc/services/storage/flash_map/flash_map.rst
@@ -95,7 +95,7 @@ using :c:func:`flash_area_open` and DTS node label:
 
 .. code-block:: c
 
-   struct flash_area *my_area;
+   const struct flash_area *my_area;
    int err = flash_area_open(FIXED_PARITION_ID(slot0_partition), &my_area);
 
    if (err != 0) {

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -156,7 +156,7 @@ int flash_area_read(const struct flash_area *fa, off_t off, void *dst,
  * as wrapped flash driver.
  *
  * @param[in]  fa  Flash area
- * @param[in]  off Offset relative from beginning of flash area to read
+ * @param[in]  off Offset relative from beginning of flash area to write
  * @param[out] src Buffer with data to be written
  * @param[in]  len Number of bytes to write
  *


### PR DESCRIPTION
Small corrections to documentation related to flash map

- flash_area_open() uses an argument of type 'const struct flash_area **' while the code snippet suggested 'struct flash_area **' Updated code snippet so it can be copied without causing warnings.
- Fix typo in docstring of `flash_area_write`: `off` is used as write offset, and not read offset.