### PR TITLE
mailmap: fixed (all?) author names inconsistencies

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,121 +1,121 @@
-Dirk Brandewie <dirk.j.brandewie@intel.com> <dirk.j.brandewie@intel.com>
-Mike Hirst <michael.hirst@windriver.com> <michael.hirst@windriver.com>
-Johan Kruger <johan.kruger@windriver.com> <johan.kruger@windriver.com>
-Leona Cook <leonax.cook@intel.com> <lsc@hackeress.com>
-Leona Cook <leonax.cook@intel.com> <leonax.cook@intel.com>
-Thomas Heeley <thomas.heeley@intel.com> <thomas.heeley@intel.com>
-Shuang He <shuang.he@intel.com> <shuang.he@intel.com>
-Chuck Jordan <cjordan@synopsys.com> <cjordan@synopsys.com>
-Jeremie Garcia <jeremie.garcia@intel.com> <jeremie.garcia@intel.com>
-Bit Pathe <bitpathe@gmail.com> <bitpathe@gmail.com>
-Carles Cufi <carles.cufi@nordicsemi.no> <carles.cufi@nordicsemi.no>
-Kuo-Lang Tseng <kuo-lang.tseng@intel.com> <kuo-lang.tseng@intel.com>
-Gerardo Aceves <gerardo.aceves@intel.com> <gerardo.aceves@intel.com>
-Evan Couzens <evanx.couzens@intel.com> <evanx.couzens@intel.com>
-Lei Liu <lei.a.liu@intel.com> <lei.a.liu@intel.com>
-Douglas Su <d0u9.su@outlook.com> <d0u9.su@outlook.com>
-Keren Siman-Tov <keren.siman-tov@intel.com> <keren.siman-tov@intel.com>
-Naga Raja Rao Tulasi <tulasi.r@tcs.com> <tulasi.r@tcs.com>
-Felipe Neves <ryukokki.felipe@gmail.com> <ryukokki.felipe@gmail.com>
+Alexandr Kolosov <rikorsev@gmail.com>
+Alexandre d'Alton <alexandre.dalton@intel.com>
 Amir Kaplan <amir.kaplan@intel.com> <amir.kaplan@intel.com>
 Anas Nashif <anas.nashif@intel.com> <anas.nashif@intel.com>
-Ruud Derwig <Ruud.Derwig@synopsys.com> <Ruud.Derwig@synopsys.com>
-Flavio Arieta Netto <flavio@exati.com.br>
-Nishikant Nayak <nishikantax.nayak@intel.com>
-Justin Watson <jwatson5@gmail.com>
-Johann Fischer <j.fischer@phytec.de>
-Jun Li <jun.r.li@intel.com>
-Xiaorui Hu <xiaorui.hu@linaro.org>
-Yannis Damigos <giannis.damigos@gmail.com> <ydamigos@iccs.gr>
-Vinayak Kariappa Chettimada <vinayak.kariappa.chettimada@nordicsemi.no> <vinayak.kariappa.chettimada@nordicsemi.no> <vich@nordicsemi.no> <vinayak.kariappa@gmail.com>
-Sean Nyekjaer <sean@geanix.com> <sean.nyekjaer@prevas.dk>
-Sean Nyekjaer <sean@geanix.com> <sean@nyekjaer.dk>
-Marc Herbert <marc.herbert@intel.com> <46978960+marc-hb@users.noreply.github.com>
-Martin Jäger <martin@libre.solar>  <17674105+martinjaeger@users.noreply.github.com>
+Andrzej Kuroś <andrzej.kuros@nordicsemi.no>
+Anthony Smigielski <thebasti0ncode@gmail.com>
 Armand Ciejak <armand@riedonetworks.com>  <armandciejak@users.noreply.github.com>
-Chunlin Han <chunlin.han@linaro.org> <chunlin.han@acer.com>
+Aska Wu <aska.wu@linaro.org>
+Bit Pathe <bitpathe@gmail.com> <bitpathe@gmail.com>
+Bjarki Arge Andreasen <baa@trackunit.com>
+Carles Cufi <carles.cufi@nordicsemi.no> <carles.cufi@nordicsemi.no>
 chao an <anchao@xiaomi.com>
+Charles E. Youse <charles.youse@intel.com>
+Chen Xingyu <hi@xingrz.me>
+Christoph Schnetzler <christoph.schnetzler@husqvarnagroup.com>
+Christoph Schramm <schramm@makaio.com>
+Christopher Friedt <cfriedt@meta.com>
+Christopher Friedt <cfriedt@meta.com> <cfriedt@fb.com>
+Chuck Jordan <cjordan@synopsys.com> <cjordan@synopsys.com>
+Chunlin Han <chunlin.han@linaro.org> <chunlin.han@acer.com>
+David B. Kinder <david.b.kinder@intel.com>
+David Komel <a8961713@gmail.com>
+David Leach <david.leach@nxp.com>
+Dirk Brandewie <dirk.j.brandewie@intel.com> <dirk.j.brandewie@intel.com>
+Douglas Su <d0u9.su@outlook.com> <d0u9.su@outlook.com>
+Enjia Mai <enjia.mai@intel.com>
+Enjia Mai <enjia.mai@intel.com> <enjiax.mai@intel.com>
+Evan Couzens <evanx.couzens@intel.com> <evanx.couzens@intel.com>
+Evgeniy Paltsev <PaltsevEvgeniy@gmail.com>
+Evgeniy Paltsev <PaltsevEvgeniy@gmail.com> <Eugeniy.Paltsev@synopsys.com>
+Felipe Neves <ryukokki.felipe@gmail.com> <ryukokki.felipe@gmail.com>
+Findlay Feng <i@fengch.me>
+Flavio Arieta Netto <flavio@exati.com.br>
+Francois Ramu <francois.ramu@st.com>
+Gerardo Aceves <gerardo.aceves@intel.com> <gerardo.aceves@intel.com>
+Gregory Shue <gregory.shue@legrand.com>
+Gregory Shue <gregory.shue@legrand.com> <gregory.shue@legrand.us>
+HaiLong Yang <cameledyang@pm.me>
+James Johnson <james.johnson672@t-mobile.com>
+Jarno Lämsä <jarno.lamsa@nordicsemi.no>
+Jędrzej Ciupis <jedrzej.ciupis@nordicsemi.no>
+Jeremie Garcia <jeremie.garcia@intel.com> <jeremie.garcia@intel.com>
+Jim Benjamin Luther <jilu@oticon.com>
+Johan Kruger <johan.kruger@windriver.com> <johan.kruger@windriver.com>
+Johann Fischer <j.fischer@phytec.de>
+Jørgen Kvalvaag <jorgen.kvalvaag@nordicsemi.no>
+Juan Manuel Cruz Alcaraz <juan.m.cruz.alcaraz@intel.com>
+Juan Solano <juanx.solano.menacho@intel.com>
+Julien D'Ascenzio <julien.dascenzio@paratronic.fr>
+Jun Li <jun.r.li@intel.com>
+Justin Watson <jwatson5@gmail.com>
+Kamil Sroka <kamil.sroka@nordicsemi.no>
+Katarzyna Giądła <katarzyna.giadla@nordicsemi.no>
+Keren Siman-Tov <keren.siman-tov@intel.com> <keren.siman-tov@intel.com>
+Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>
+Kuo-Lang Tseng <kuo-lang.tseng@intel.com> <kuo-lang.tseng@intel.com>
+Lei Liu <lei.a.liu@intel.com> <lei.a.liu@intel.com>
+Leona Cook <leonax.cook@intel.com> <leonax.cook@intel.com>
+Leona Cook <leonax.cook@intel.com> <lsc@hackeress.com>
+Lixin Guo <lixinx.guo@intel.com>
+Łukasz Mazur <lukasz.mazur@hidglobal.com>
+Manuel Argüelles <manuel.arguelles@nxp.com>
+Manuel Argüelles <manuel.arguelles@nxp.com> <manuel.arguelles@coredumplabs.com>
+Marc Herbert <marc.herbert@intel.com> <46978960+marc-hb@users.noreply.github.com>
+Marin Jurjević <marin.jurjevic@hotmail.com>
+Mariusz Ryndzionek <mariusz.ryndzionek@firmwave.com>
+Mariusz Skamra <mariusz.skamra@codecoup.pl>
+Mariusz Skamra <mariusz.skamra@codecoup.pl> <mariusz.skamra@tieto.com>
 Martí Bolívar <marti.bolivar@nordicsemi.no>
 Martí Bolívar <marti.bolivar@nordicsemi.no> <marti.bolivar@linaro.org>
 Martí Bolívar <marti.bolivar@nordicsemi.no> <marti.f.bolivar@gmail.com>
 Martí Bolívar <marti.bolivar@nordicsemi.no> <marti@foundries.io>
 Martí Bolívar <marti.bolivar@nordicsemi.no> <marti@opensourcefoundries.com>
-Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>
-Francois Ramu <francois.ramu@st.com>
-David Leach <david.leach@nxp.com>
-Raja D. Singh <rdsingh@iotwizards.com>
-Scott Worley <scott.worley@microchip.com>
-Łukasz Mazur <lukasz.mazur@hidglobal.com>
-Julien D'Ascenzio <julien.dascenzio@paratronic.fr>
-Jørgen Kvalvaag <jorgen.kvalvaag@nordicsemi.no>
-Stine Åkredalen <stine.akredalen@nordicsemi.no>
-Mohan Kumar Kumar <mohankm@fb.com>
-Gregory Shue <gregory.shue@legrand.com>
-Gregory Shue <gregory.shue@legrand.com> <gregory.shue@legrand.us>
-Alexandre d'Alton <alexandre.dalton@intel.com>
-Jarno Lämsä <jarno.lamsa@nordicsemi.no>
-Andrzej Kuroś <andrzej.kuros@nordicsemi.no>
-Katarzyna Giądła <katarzyna.giadla@nordicsemi.no>
-Manuel Argüelles <manuel.arguelles@nxp.com>
-Manuel Argüelles <manuel.arguelles@nxp.com> <manuel.arguelles@coredumplabs.com>
-Paweł Czarnecki <pczarnecki@antmicro.com>
-Pavel Král <pavel.kral@omsquare.com>
-Enjia Mai <enjia.mai@intel.com>
-Enjia Mai <enjia.mai@intel.com> <enjiax.mai@intel.com>
-Stéphane D'Alu <sdalu@sdalu.com>
-Paweł Kwiek <pawel.kwiek@nordicsemi.no>
-Navin Sankar Velliangiri <navin@linumiz.com>
+Martin Jäger <martin@libre.solar>  <17674105+martinjaeger@users.noreply.github.com>
 Mateusz Hołenko <mholenko@antmicro.com>
-Marin Jurjević <marin.jurjevic@hotmail.com>
+Michael Rosen <michael.r.rosen@intel.com>
+Michal Narajowski <michal.narajowski@codecoup.pl>
+Mike Hirst <michael.hirst@windriver.com> <michael.hirst@windriver.com>
+Ming Shao <ming.shao@intel.com>
+Mohan Kumar Kumar <mohankm@fb.com>
+Naga Raja Rao Tulasi <tulasi.r@tcs.com> <tulasi.r@tcs.com>
+Navin Sankar Velliangiri <navin@linumiz.com>
 NingX Zhao <ningx.zhao@intel.com>
+Nishikant Nayak <nishikantax.nayak@intel.com>
+Ole Sæther <ole.saether@nordicsemi.no>
+Pavel Král <pavel.kral@omsquare.com>
+Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>
+Paweł Czarnecki <pczarnecki@antmicro.com>
 Paweł Czarnecki <pczarnecki@antmicro.com>
 Paweł Czarnecki <pczarnecki@antmicro.com> <pczarnecki@internships.antmicro.com>
-Radosław Koppel <radoslaw.koppel@nordicsemi.no>
-Radosław Koppel <radoslaw.koppel@nordicsemi.no> <r.koppel@k-el.com>
-Aska Wu <aska.wu@linaro.org>
-Peter Johanson <peter@peterjohanson.com>
-Evgeniy Paltsev <PaltsevEvgeniy@gmail.com>
-Evgeniy Paltsev <PaltsevEvgeniy@gmail.com> <Eugeniy.Paltsev@synopsys.com>
-Ricardo Salveti <ricardo@opensourcefoundries.com>
-Ricardo Salveti <ricardo@opensourcefoundries.com> <ricardo.salveti@linaro.org>
-Jędrzej Ciupis <jedrzej.ciupis@nordicsemi.no>
-Michal Narajowski <michal.narajowski@codecoup.pl>
-Ole Sæther <ole.saether@nordicsemi.no>
-Christoph Schnetzler <christoph.schnetzler@husqvarnagroup.com>
-David B. Kinder <david.b.kinder@intel.com>
+Paweł Kwiek <pawel.kwiek@nordicsemi.no>
+Peng Chen <peng1.chen@intel.com>
 Peter Bigot <peter.bigot@nordicsemi.no>
 Peter Bigot <peter.bigot@nordicsemi.no> <pab@pabigot.com>
-Sigvart Hovland <sigvart.hovland@nordicsemi.no>
-Charles E. Youse <charles.youse@intel.com>
-Mariusz Skamra <mariusz.skamra@codecoup.pl>
-Mariusz Skamra <mariusz.skamra@codecoup.pl> <mariusz.skamra@tieto.com>
-Michael Rosen <michael.r.rosen@intel.com>
-David Komel <a8961713@gmail.com>
-Bjarki Arge Andreasen <baa@trackunit.com>
-Christopher Friedt <cfriedt@meta.com>
-Christopher Friedt <cfriedt@meta.com> <cfriedt@fb.com>
-James Johnson <james.johnson672@t-mobile.com>
-Alexandr Kolosov <rikorsev@gmail.com>
-Saku Rautio <saku.rautio@nordicsemi.no>
-Sharron Liu <sharron.liu@intel.com>
-Anthony Smigielski <thebasti0ncode@gmail.com>
-YouhuaX Zhu <youhuax.zhu@intel.com>
-Mariusz Ryndzionek <mariusz.ryndzionek@firmwave.com>
-Ming Shao <ming.shao@intel.com>
-Juan Manuel Cruz Alcaraz <juan.m.cruz.alcaraz@intel.com>
+Peter Johanson <peter@peterjohanson.com>
 Piyush Itankar <piyush.t.itankar@intel.com>
-Kamil Sroka <kamil.sroka@nordicsemi.no>
-Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>
-Jim Benjamin Luther <jilu@oticon.com>
-HaiLong Yang <cameledyang@pm.me>
-Christoph Schramm <schramm@makaio.com>
-Lixin Guo <lixinx.guo@intel.com>
-Juan Solano <juanx.solano.menacho@intel.com>
+Radosław Koppel <radoslaw.koppel@nordicsemi.no>
+Radosław Koppel <radoslaw.koppel@nordicsemi.no> <r.koppel@k-el.com>
+Raja D. Singh <rdsingh@iotwizards.com>
+Ricardo Salveti <ricardo@opensourcefoundries.com>
+Ricardo Salveti <ricardo@opensourcefoundries.com> <ricardo.salveti@linaro.org>
+Ruud Derwig <Ruud.Derwig@synopsys.com> <Ruud.Derwig@synopsys.com>
+Saku Rautio <saku.rautio@nordicsemi.no>
+Scott Worley <scott.worley@microchip.com>
+Sean Nyekjaer <sean@geanix.com> <sean.nyekjaer@prevas.dk>
+Sean Nyekjaer <sean@geanix.com> <sean@nyekjaer.dk>
+Sharron Liu <sharron.liu@intel.com>
 Shilpashree L C <shilpashree.lc@intel.com>
-Yonattan Louise <yonattan.a.louise.mendoza@intel.com>
-Yonattan Louise <yonattan.a.louise.mendoza@intel.com> <yonattan.a.louise.mendoza@linux.intel.com>
-Findlay Feng <i@fengch.me>
-Peng Chen <peng1.chen@intel.com>
-Chen Xingyu <hi@xingrz.me>
+Shuang He <shuang.he@intel.com> <shuang.he@intel.com>
+Sigvart Hovland <sigvart.hovland@nordicsemi.no>
+Stéphane D'Alu <sdalu@sdalu.com>
+Stine Åkredalen <stine.akredalen@nordicsemi.no>
+Thomas Heeley <thomas.heeley@intel.com> <thomas.heeley@intel.com>
 Tim Sørensen <tims@demant.com>
 Tim Sørensen <tims@demant.com> <tims@oticon.com>
+Vinayak Kariappa Chettimada <vinayak.kariappa.chettimada@nordicsemi.no> <vinayak.kariappa.chettimada@nordicsemi.no> <vich@nordicsemi.no> <vinayak.kariappa@gmail.com>
+Xiaorui Hu <xiaorui.hu@linaro.org>
+Yannis Damigos <giannis.damigos@gmail.com> <ydamigos@iccs.gr>
+Yonattan Louise <yonattan.a.louise.mendoza@intel.com>
+Yonattan Louise <yonattan.a.louise.mendoza@intel.com> <yonattan.a.louise.mendoza@linux.intel.com>
+YouhuaX Zhu <youhuax.zhu@intel.com>

--- a/.mailmap
+++ b/.mailmap
@@ -35,3 +35,87 @@ Martin Jäger <martin@libre.solar>  <17674105+martinjaeger@users.noreply.github.
 Armand Ciejak <armand@riedonetworks.com>  <armandciejak@users.noreply.github.com>
 Chunlin Han <chunlin.han@linaro.org> <chunlin.han@acer.com>
 chao an <anchao@xiaomi.com>
+Martí Bolívar <marti.bolivar@nordicsemi.no>
+Martí Bolívar <marti.bolivar@nordicsemi.no> <marti.bolivar@linaro.org>
+Martí Bolívar <marti.bolivar@nordicsemi.no> <marti.f.bolivar@gmail.com>
+Martí Bolívar <marti.bolivar@nordicsemi.no> <marti@foundries.io>
+Martí Bolívar <marti.bolivar@nordicsemi.no> <marti@opensourcefoundries.com>
+Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>
+Francois Ramu <francois.ramu@st.com>
+David Leach <david.leach@nxp.com>
+Raja D. Singh <rdsingh@iotwizards.com>
+Scott Worley <scott.worley@microchip.com>
+Łukasz Mazur <lukasz.mazur@hidglobal.com>
+Julien D'Ascenzio <julien.dascenzio@paratronic.fr>
+Jørgen Kvalvaag <jorgen.kvalvaag@nordicsemi.no>
+Stine Åkredalen <stine.akredalen@nordicsemi.no>
+Mohan Kumar Kumar <mohankm@fb.com>
+Gregory Shue <gregory.shue@legrand.com>
+Gregory Shue <gregory.shue@legrand.com> <gregory.shue@legrand.us>
+Alexandre d'Alton <alexandre.dalton@intel.com>
+Jarno Lämsä <jarno.lamsa@nordicsemi.no>
+Andrzej Kuroś <andrzej.kuros@nordicsemi.no>
+Katarzyna Giądła <katarzyna.giadla@nordicsemi.no>
+Manuel Argüelles <manuel.arguelles@nxp.com>
+Manuel Argüelles <manuel.arguelles@nxp.com> <manuel.arguelles@coredumplabs.com>
+Paweł Czarnecki <pczarnecki@antmicro.com>
+Pavel Král <pavel.kral@omsquare.com>
+Enjia Mai <enjia.mai@intel.com>
+Enjia Mai <enjia.mai@intel.com> <enjiax.mai@intel.com>
+Stéphane D'Alu <sdalu@sdalu.com>
+Paweł Kwiek <pawel.kwiek@nordicsemi.no>
+Navin Sankar Velliangiri <navin@linumiz.com>
+Mateusz Hołenko <mholenko@antmicro.com>
+Marin Jurjević <marin.jurjevic@hotmail.com>
+NingX Zhao <ningx.zhao@intel.com>
+Paweł Czarnecki <pczarnecki@antmicro.com>
+Paweł Czarnecki <pczarnecki@antmicro.com> <pczarnecki@internships.antmicro.com>
+Radosław Koppel <radoslaw.koppel@nordicsemi.no>
+Radosław Koppel <radoslaw.koppel@nordicsemi.no> <r.koppel@k-el.com>
+Aska Wu <aska.wu@linaro.org>
+Peter Johanson <peter@peterjohanson.com>
+Evgeniy Paltsev <PaltsevEvgeniy@gmail.com>
+Evgeniy Paltsev <PaltsevEvgeniy@gmail.com> <Eugeniy.Paltsev@synopsys.com>
+Ricardo Salveti <ricardo@opensourcefoundries.com>
+Ricardo Salveti <ricardo@opensourcefoundries.com> <ricardo.salveti@linaro.org>
+Jędrzej Ciupis <jedrzej.ciupis@nordicsemi.no>
+Michal Narajowski <michal.narajowski@codecoup.pl>
+Ole Sæther <ole.saether@nordicsemi.no>
+Christoph Schnetzler <christoph.schnetzler@husqvarnagroup.com>
+David B. Kinder <david.b.kinder@intel.com>
+Peter Bigot <peter.bigot@nordicsemi.no>
+Peter Bigot <peter.bigot@nordicsemi.no> <pab@pabigot.com>
+Sigvart Hovland <sigvart.hovland@nordicsemi.no>
+Charles E. Youse <charles.youse@intel.com>
+Mariusz Skamra <mariusz.skamra@codecoup.pl>
+Mariusz Skamra <mariusz.skamra@codecoup.pl> <mariusz.skamra@tieto.com>
+Michael Rosen <michael.r.rosen@intel.com>
+David Komel <a8961713@gmail.com>
+Bjarki Arge Andreasen <baa@trackunit.com>
+Christopher Friedt <cfriedt@meta.com>
+Christopher Friedt <cfriedt@meta.com> <cfriedt@fb.com>
+James Johnson <james.johnson672@t-mobile.com>
+Alexandr Kolosov <rikorsev@gmail.com>
+Saku Rautio <saku.rautio@nordicsemi.no>
+Sharron Liu <sharron.liu@intel.com>
+Anthony Smigielski <thebasti0ncode@gmail.com>
+YouhuaX Zhu <youhuax.zhu@intel.com>
+Mariusz Ryndzionek <mariusz.ryndzionek@firmwave.com>
+Ming Shao <ming.shao@intel.com>
+Juan Manuel Cruz Alcaraz <juan.m.cruz.alcaraz@intel.com>
+Piyush Itankar <piyush.t.itankar@intel.com>
+Kamil Sroka <kamil.sroka@nordicsemi.no>
+Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>
+Jim Benjamin Luther <jilu@oticon.com>
+HaiLong Yang <cameledyang@pm.me>
+Christoph Schramm <schramm@makaio.com>
+Lixin Guo <lixinx.guo@intel.com>
+Juan Solano <juanx.solano.menacho@intel.com>
+Shilpashree L C <shilpashree.lc@intel.com>
+Yonattan Louise <yonattan.a.louise.mendoza@intel.com>
+Yonattan Louise <yonattan.a.louise.mendoza@intel.com> <yonattan.a.louise.mendoza@linux.intel.com>
+Findlay Feng <i@fengch.me>
+Peng Chen <peng1.chen@intel.com>
+Chen Xingyu <hi@xingrz.me>
+Tim Sørensen <tims@demant.com>
+Tim Sørensen <tims@demant.com> <tims@oticon.com>


### PR DESCRIPTION
Ran Levensthein diff on all author names to spot and fix inconsistencies. Used authors' most recently used name and emails as canonical.

This effectively removes 40+ phantom authors, like such as the infamous Marti Bolivar, Martí Bolívar's infamous doppelgänger. @mbolivar 