### PR TITLE
 nrf52_bsim: Find simulator thru west as fallback

### DIFF
--- a/boards/posix/nrf52_bsim/CMakeLists.txt
+++ b/boards/posix/nrf52_bsim/CMakeLists.txt
@@ -1,17 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This board requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-if (NOT DEFINED ENV{BSIM_OUT_PATH})
-	message(FATAL_ERROR "This board requires the BabbleSim simulator. Please set\
- the environment variable BSIM_OUT_PATH to point to the folder where the\
- simulator is compiled to. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
+find_package(BabbleSim)
 
 zephyr_library()
 zephyr_library_compile_definitions(NO_POSIX_CHEATS)
@@ -37,9 +26,9 @@ zephyr_include_directories(soc)
 zephyr_include_directories(cmsis)
 
 zephyr_library_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libRandv2/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libRandv2/src/
   ${ZEPHYR_BASE}/kernel/include
   ${ZEPHYR_BASE}/arch/posix/include
 )
@@ -48,7 +37,7 @@ zephyr_ld_options(
   -lm
 )
 
-set(libpath $ENV{BSIM_OUT_PATH}/lib)
+set(libpath ${BSIM_OUT_PATH}/lib)
 zephyr_library_import(bsim_libUtilv1      ${libpath}/libUtilv1.32.a)
 zephyr_library_import(bsim_libPhyComv1    ${libpath}/libPhyComv1.32.a)
 zephyr_library_import(bsim_lib2G4PhyComv1 ${libpath}/lib2G4PhyComv1.32.a)

--- a/cmake/modules/FindBabbleSim.cmake
+++ b/cmake/modules/FindBabbleSim.cmake
@@ -1,0 +1,62 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# FindBabbleSim module for locating BabbleSim
+#
+# The module defines the following variables:
+#
+# 'BSIM_COMPONENTS_PATH'
+# Path to the BabbleSim components source folder
+#
+# 'BSIM_OUT_PATH'
+# Path to the BabbleSim build output root path (under which libraries and binaries) are kept
+#
+# We first try to find it via the environment variables BSIM_OUT_PATH and BSIM_COMPONENTS_PATH.
+# If these are not set, as a fallback we attempt to find it through west, in case the user
+# fetched babblesim using the manifest.
+# Note that what we find through the environment variables is meant to have precedence.
+#
+# If BabbleSim cannot be found we error right away with a message trying to guide users
+
+zephyr_get(BSIM_COMPONENTS_PATH)
+zephyr_get(BSIM_OUT_PATH)
+
+if ((DEFINED WEST) AND (NOT DEFINED BSIM_COMPONENTS_PATH) AND (NOT DEFINED BSIM_OUT_PATH))
+  # Let's ask west for the bsim_project existence and its path
+  execute_process(COMMAND ${WEST}
+    status babblesim_base
+    OUTPUT_QUIET
+    ERROR_QUIET
+    RESULT_VARIABLE ret_val1)
+  execute_process(COMMAND ${WEST}
+    list babblesim_base -f {posixpath}
+    OUTPUT_VARIABLE BSIM_BASE_PATH
+    ERROR_QUIET
+    RESULT_VARIABLE ret_val2)
+  if (NOT (${ret_val1} OR ${ret_val2}))
+    string(STRIP ${BSIM_BASE_PATH} BSIM_COMPONENTS_PATH)
+    get_filename_component(BSIM_OUT_PATH ${BSIM_COMPONENTS_PATH}/.. ABSOLUTE)
+  endif()
+endif()
+
+message(STATUS "Using BSIM from BSIM_COMPONENTS_PATH=${BSIM_COMPONENTS_PATH}\
+ BSIM_OUT_PATH=${BSIM_OUT_PATH}")
+
+if ((NOT DEFINED BSIM_COMPONENTS_PATH) OR (NOT DEFINED BSIM_OUT_PATH))
+  message(FATAL_ERROR "This board requires the BabbleSim simulator. Please either\n\
+  a) Enable the west babblesim group with\n\
+     west config manifest.group-filter +babblesim && west update\n\
+     and build it with\n\
+     cd ${ZEPHYR_BASE}/../tools/bsim\n\
+      make everything -j 8\n\
+     OR\n\
+  b) set the environment variable BSIM_COMPONENTS_PATH to point to your own bsim installation\n\
+     `components/` folder, *and* BSIM_OUT_PATH to point to the folder where the simulator\n\
+     is compiled to.\n\
+     More information can be found in https://babblesim.github.io/folder_structure_and_env.html"
+  )
+endif()
+
+#Many apps cmake files (in and out of tree) expect these environment variables. Lets provide them:
+set(ENV{BSIM_COMPONENTS_PATH} ${BSIM_COMPONENTS_PATH})
+set(ENV{BSIM_OUT_PATH} ${BSIM_OUT_PATH})

--- a/tests/bsim/bluetooth/audio/CMakeLists.txt
+++ b/tests/bsim/bluetooth/audio/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_audio)
 

--- a/tests/bsim/bluetooth/host/adv/chain/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/adv/chain/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set  \
-          the  environment variable BSIM_COMPONENTS_PATH to point to its       \
-          components folder. More information can be found in                  \
-          https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_adv_chain)
 

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if(NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-        message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set  \
-          the  environment variable BSIM_COMPONENTS_PATH to point to its       \
-          components folder. More information can be found in                  \
-          https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_ead_css_sample_data)
 

--- a/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set  \
-          the  environment variable BSIM_COMPONENTS_PATH to point to its       \
-          components folder. More information can be found in                  \
-          https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_ead_sample)
 

--- a/tests/bsim/bluetooth/host/adv/periodic/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/adv/periodic/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_audio)
 

--- a/tests/bsim/bluetooth/host/adv/resume/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/adv/resume/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_adv_resume)
 

--- a/tests/bsim/bluetooth/host/att/eatt/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/att/eatt/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_host)
 

--- a/tests/bsim/bluetooth/host/att/eatt_notif/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_eatt_notif)
 

--- a/tests/bsim/bluetooth/host/att/mtu_update/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/att/mtu_update/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set  \
-          the  environment variable BSIM_COMPONENTS_PATH to point to its       \
-          components folder. More information can be found in                  \
-          https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_mtu_update)
 

--- a/tests/bsim/bluetooth/host/gatt/caching/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/gatt/caching/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_gatt)
 

--- a/tests/bsim/bluetooth/host/gatt/general/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/gatt/general/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_gatt)
 

--- a/tests/bsim/bluetooth/host/gatt/notify/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/gatt/notify/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_gatt)
 

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_gatt)
 

--- a/tests/bsim/bluetooth/host/gatt/settings/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/gatt/settings/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_gatt_settings)
 

--- a/tests/bsim/bluetooth/host/l2cap/general/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/l2cap/general/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_l2cap)
 

--- a/tests/bsim/bluetooth/host/l2cap/stress/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/l2cap/stress/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_l2cap_stress)
 

--- a/tests/bsim/bluetooth/host/l2cap/userdata/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_l2cap_userdata)
 

--- a/tests/bsim/bluetooth/host/misc/disable/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/misc/disable/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_disable)
 

--- a/tests/bsim/bluetooth/host/privacy/central/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/privacy/central/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_rpa_central)
 

--- a/tests/bsim/bluetooth/host/privacy/device/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/privacy/device/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set  \
-          the  environment variable BSIM_COMPONENTS_PATH to point to its       \
-          components folder. More information can be found in                  \
-          https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_privacy)
 

--- a/tests/bsim/bluetooth/host/privacy/peripheral/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_rpa_peripheral)
 

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_multi_id_bond_overwrite_deny)
 

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_multi_id_bond_overwrite_deny)
 

--- a/tests/bsim/bluetooth/ll/advx/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/advx/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_advx)
 

--- a/tests/bsim/bluetooth/ll/conn/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/conn/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_app)
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/CMakeLists.txt
@@ -3,13 +3,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(peripheral_test)
 

--- a/tests/bsim/bluetooth/ll/edtt/hci_test_app/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/edtt/hci_test_app/CMakeLists.txt
@@ -3,13 +3,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(hci_test_app)
 

--- a/tests/bsim/bluetooth/ll/iso/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/iso/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_iso)
 

--- a/tests/bsim/bluetooth/ll/multiple_id/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/multiple_id/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set  \
-          the  environment variable BSIM_COMPONENTS_PATH to point to its       \
-          components folder. More information can be found in                  \
-          https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_multiple)
 

--- a/tests/bsim/bluetooth/ll/throughput/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/throughput/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set  \
-          the  environment variable BSIM_COMPONENTS_PATH to point to its       \
-          components folder. More information can be found in                  \
-          https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_gatt_write)
 

--- a/tests/bsim/bluetooth/mesh/CMakeLists.txt
+++ b/tests/bsim/bluetooth/mesh/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_mesh)
 


### PR DESCRIPTION
```
nrf52_bsim: Find simulator thru west as fallback
    
For developers ease, let's try to find the simulator
thru west if the environment variables that tell where
the simulator is are not set.
```

---------

```
tests bsim: Do not check for the simulator in apps cmake files
    
Let the board check for it instead, as it now does it
smarter and can try to find it using west if it was
fetched with the Zephyr manifest.
```

-----

Note: These changes do not break anything for users or current apps. The benefit is:
a) More descriptive errors when the simulator is not found
b) cmake trying to find the simulator thru west as fallback
c) Less boilerplate in the apps cmake files.

The idea is to follow it up later with a check for the need to rebuild the simulator if it is too old after a zephyr update.
