### PR TITLE
drivers: dai: fix regressions on Intel platforms

### DIFF
--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -325,10 +325,11 @@ static inline void dai_dmic_en_power(const struct dai_intel_dmic *dmic)
 	sys_write32((sys_read32(base + DMICLCTL_OFFSET) | DMICLCTL_SPA),
 			base + DMICLCTL_OFFSET);
 
+#ifdef CONFIG_SOC_INTEL_ACE20_LNL /* Ace 2.0 */
 	while (!(sys_read32(base + DMICLCTL_OFFSET) & DMICLCTL_CPA)) {
 		k_sleep(K_USEC(100));
 	}
-
+#endif
 }
 
 static inline void dai_dmic_dis_power(const struct dai_intel_dmic *dmic)

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -218,16 +218,18 @@
 
 #define I2SLCTL_OFFSET		0x04
 
-#ifdef CONFIG_SOC_INTEL_ACE15_MTPM
+#if defined(CONFIG_SOC_INTEL_ACE15_MTPM) || defined(CONFIG_SOC_SERIES_INTEL_ADSP_CAVS)
 #define I2SLCTL_SPA(x)		BIT(0 + x)
 #define I2SLCTL_CPA(x)		BIT(8 + x)
-#else /* CONFIG_SOC_INTEL_ACE20_LNL */
+#elif defined(CONFIG_SOC_INTEL_ACE20_LNL)
 #define I2SLCTL_OFLEN		BIT(4)
 #define I2SLCTL_SPA(x)		BIT(16 + x)
 #define I2SLCTL_CPA(x)		BIT(23 + x)
 #define PCMS0CM_OFFSET		0x16
 #define PCMS1CM_OFFSET		0x1A
-#endif /* CONFIG_SOC_INTEL_ACE15_MTPM */
+#else
+#error "Missing ssp definitions"
+#endif
 
 #define I2CLCTL_MLCS(x)		DAI_INTEL_SSP_SET_BITS(30, 27, x)
 #define SHIM_CLKCTL		0x78


### PR DESCRIPTION
Fix two separate regressions found while trying to uprev Zephyr to SOF in
https://github.com/thesofproject/sof/pull/6480

Failing tests
    https://sof-ci.01.org/sofpr/PR6480/build6216/devicetest/index.html
    https://sof-ci.01.org/sofpr/PR6480/build6217/devicetest/index.html
