### PR TITLE
Handle duplicates in test names

### DIFF
--- a/samples/bluetooth/broadcast_audio_source/sample.yaml
+++ b/samples/bluetooth/broadcast_audio_source/sample.yaml
@@ -12,7 +12,7 @@ tests:
       - qemu_x86
       - nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
-  sample.bluetooth.broadcast_audio_sink.bt_ll_sw_split:
+  sample.bluetooth.broadcast_audio_source.bt_ll_sw_split:
     harness: bluetooth
     platform_allow:
       - nrf52_bsim

--- a/samples/bluetooth/periodic_adv_conn/sample.yaml
+++ b/samples/bluetooth/periodic_adv_conn/sample.yaml
@@ -1,7 +1,7 @@
 sample:
-  name: Bluetooth Periodic Advertising with Responses Advertiser
+  name: Bluetooth Periodic Advertising Connection Procedure
 tests:
-  sample.bluetooth.periodic_adv:
+  sample.bluetooth.periodic_adv_conn:
     harness: bluetooth
     platform_allow:
       - qemu_cortex_m3

--- a/samples/bluetooth/periodic_adv_rsp/sample.yaml
+++ b/samples/bluetooth/periodic_adv_rsp/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Bluetooth Periodic Advertising with Responses Advertiser
 tests:
-  sample.bluetooth.periodic_adv:
+  sample.bluetooth.periodic_adv_rsp:
     harness: bluetooth
     platform_allow:
       - qemu_cortex_m3

--- a/samples/bluetooth/periodic_sync_conn/sample.yaml
+++ b/samples/bluetooth/periodic_sync_conn/sample.yaml
@@ -1,7 +1,7 @@
 sample:
-  name: Bluetooth Periodic Advertising with Responses Synchronization
+  name: Bluetooth Periodic Advertising Connection Procedure
 tests:
-  sample.bluetooth.periodic_sync:
+  sample.bluetooth.periodic_sync_conn:
     harness: bluetooth
     platform_allow:
       - qemu_cortex_m3

--- a/samples/bluetooth/periodic_sync_rsp/sample.yaml
+++ b/samples/bluetooth/periodic_sync_rsp/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: Bluetooth Periodic Advertising with Responses Synchronization
 tests:
-  sample.bluetooth.periodic_sync:
+  sample.bluetooth.periodic_sync_rsp:
     harness: bluetooth
     platform_allow:
       - qemu_cortex_m3

--- a/samples/modules/thrift/hello/client/sample.yaml
+++ b/samples/modules/thrift/hello/client/sample.yaml
@@ -14,9 +14,9 @@ common:
     - qemu_x86_64
   filter: CONFIG_FULL_LIBCPP_SUPPORTED
 tests:
-  sample.thrift.hello.server.binaryProtocol: {}
-  sample.thrift.hello.server.compactProtocol:
+  sample.thrift.hello.client.binaryProtocol: {}
+  sample.thrift.hello.client.compactProtocol:
     extra_configs:
       - CONFIG_THRIFT_COMPACT_PROTOCOL=y
-  sample.thrift.hello.server.tlsTransport:
+  sample.thrift.hello.client.tlsTransport:
     extra_args: OVERLAY_CONFIG="../overlay-tls.conf"

--- a/samples/subsys/usb_c/source/sample.yaml
+++ b/samples/subsys/usb_c/source/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: USB-C SOURCE
 tests:
-  sample.usbc.sink:
+  sample.usbc.source:
     depends_on: tcpc
     tags: usbc
     platform_allow: stm32g081b_eval

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -113,10 +113,6 @@ Artificially long but functional example:
         and net.socket.fd_set belong to different directories.
         """)
 
-    case_select.add_argument("--list-test-duplicates", action="store_true",
-                             help="""List tests with duplicate identifiers.
-        """)
-
     case_select.add_argument("--test-tree", action="store_true",
                              help="""Output the test plan in a tree form""")
 

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -176,6 +176,8 @@ class TestPlan:
         for _, ts in self.testsuites.items():
             self.scenarios.append(ts.id)
 
+        self.report_duplicates()
+
         self.parse_configuration(config_file=self.env.test_config)
         self.add_configurations()
 
@@ -301,10 +303,7 @@ class TestPlan:
 
 
     def report(self):
-        if self.options.list_test_duplicates:
-            self.report_duplicates()
-            return 0
-        elif self.options.test_tree:
+        if self.options.test_tree:
             self.report_test_tree()
             return 0
         elif self.options.list_tests:
@@ -319,13 +318,14 @@ class TestPlan:
     def report_duplicates(self):
         dupes = [item for item, count in collections.Counter(self.scenarios).items() if count > 1]
         if dupes:
-            print("Tests with duplicate identifiers:")
+            msg = "Duplicated test scenarios found:\n"
             for dupe in dupes:
-                print("- {}".format(dupe))
+                msg += ("- {} found in:\n".format(dupe))
                 for dc in self.get_testsuite(dupe):
-                    print("  - {}".format(dc.name))
+                    msg += ("  - {}\n".format(dc.yamlfile))
+            raise TwisterRuntimeError(msg)
         else:
-            print("No duplicates found.")
+            logger.debug("No duplicates found.")
 
     def report_tag_list(self):
         tags = set()

--- a/tests/bluetooth/host/id/bt_id_init/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_init/testcase.yaml
@@ -10,7 +10,7 @@ tests:
     extra_configs:
       - CONFIG_SETTINGS=y
       - CONFIG_BT_SETTINGS=y
-  bluetooth.host.bt_id_create.bt_privacy_enabled:
+  bluetooth.host.bt_id_init.bt_privacy_enabled:
     type: unit
     extra_configs:
       - CONFIG_BT_SMP=y

--- a/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/testcase.yaml
@@ -5,7 +5,7 @@ common:
 tests:
   bluetooth.host.bt_le_ext_adv_oob_get_local.default:
     type: unit
-  bluetooth.host.bt_le_oob_get_local.bt_privacy_enabled:
+  bluetooth.host.bt_le_ext_adv_oob_get_local.bt_privacy_enabled:
     type: unit
     extra_configs:
       - CONFIG_BT_SMP=y

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/testcase.yaml
@@ -3,32 +3,32 @@ common:
     - bluetooth
     - host
 tests:
-  bluetooth.host.bt_id_create.default:
+  bluetooth.host.bt_random_idcreate.default:
     type: unit
     extra_configs:
       - CONFIG_BT_ID_MAX=1
-  bluetooth.host.bt_id_create.multiple_identities:
+  bluetooth.host.bt_random_idcreate.multiple_identities:
     type: unit
     extra_configs:
       - CONFIG_BT_ID_MAX=4
-  bluetooth.host.bt_id_create.hci_vs_ext_detect:
+  bluetooth.host.bt_random_idcreate.hci_vs_ext_detect:
     type: unit
     extra_configs:
       - CONFIG_BT_ID_MAX=1
       - CONFIG_BT_HCI_VS_EXT_DETECT=y
-  bluetooth.host.bt_id_create.multiple_identities_hci_vs_ext_detect:
+  bluetooth.host.bt_random_idcreate.multiple_identities_hci_vs_ext_detect:
     type: unit
     extra_configs:
       - CONFIG_BT_ID_MAX=4
       - CONFIG_BT_HCI_VS_EXT_DETECT=y
-  bluetooth.host.bt_id_create.multiple_identities_hci_vs_ext_detect_privacy_enabled:
+  bluetooth.host.bt_random_idcreate.multiple_identities_hci_vs_ext_detect_privacy_enabled:
     type: unit
     extra_configs:
       - CONFIG_BT_ID_MAX=4
       - CONFIG_BT_HCI_VS_EXT_DETECT=y
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
-  bluetooth.host.bt_id_create.multiple_identities_hci_vs_ext_detect_privacy_settings_enabled:
+  bluetooth.host.bt_random_idcreate.multiple_identities_hci_vs_ext_detect_privacy_settings_enabled:
     type: unit
     extra_configs:
       - CONFIG_BT_ID_MAX=4

--- a/tests/drivers/rtc/rtc_api_helpers/testcase.yaml
+++ b/tests/drivers/rtc/rtc_api_helpers/testcase.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 tests:
-  drivers.rtc.rtc_api:
+  drivers.rtc.rtc_api_helpers:
     tags:
       - drivers
       - rtc

--- a/tests/subsys/mgmt/ec_host_cmd/simulator/testcase.yaml
+++ b/tests/subsys/mgmt/ec_host_cmd/simulator/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  mgmt.ec_host_cmd.core:
+  mgmt.ec_host_cmd.simulator.core:
     platform_allow: native_posix
     tags: ec_host_cmd

--- a/tests/subsys/mgmt/ec_host_cmd/uart/testcase.yaml
+++ b/tests/subsys/mgmt/ec_host_cmd/uart/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
-  mgmt.ec_host_cmd.core:
+  mgmt.ec_host_cmd.uart.core:
     platform_allow: native_posix
     tags: ec_host_cmd


### PR DESCRIPTION
Several duplicates of test names where found in zephyr tree. This is problematic since tests with the same name will be overwritten in the result report 
This PR consist of 2 commits:
- resolving found duplicates
- by default, twister will raise an error whenever duplicates are found
