### PR TITLE
west: support flashing using SiLabs Commander for EFR32BG27

### DIFF
--- a/boards/arm/efr32_thunderboard/board.cmake
+++ b/boards/arm/efr32_thunderboard/board.cmake
@@ -2,6 +2,10 @@
 
 if(CONFIG_BOARD_EFR32BG22_BRD4184A)
 board_runner_args(jlink "--device=EFR32BG22C224F512IM40" "--reset-after-load")
-endif() # CONFIG_BOARD_EFR32BG22_BRD4184A
-
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+
+elseif(CONFIG_BOARD_EFR32BG27_BRD2602A)
+board_runner_args(silabs_commander "--device=EFR32BG27C140F768IM40")
+include(${ZEPHYR_BASE}/boards/common/silabs_commander.board.cmake)
+
+endif()

--- a/boards/arm/efr32_thunderboard/doc/brd2602.rst
+++ b/boards/arm/efr32_thunderboard/doc/brd2602.rst
@@ -47,6 +47,50 @@ The efr32bg27_brd2602 board configuration supports the following hardware featur
 | UART      | on-chip    | serial                              |
 +-----------+------------+-------------------------------------+
 
+Flashing
+========
+
+The EFR32BG27-BRD2602A includes an embedded `J-Link`_ adapter built around
+EFM32GG12 microcontroller (not user-programmable).
+The adapter provides:
+
+- SWD interface to EFR32BG27 for flashing and debugging.
+- SWO trace interface to EFR32BG27 for tracing.
+- UART interface to EFR32BG27 for console access.
+- A USB connection to the host computer, which exposes CDC-ACM Serial Port
+  endpoints for access to the console UART interface and proprietary J-Link
+  endpoints for access to the SWD and SWO interfaces.
+
+UART functionality of the adapter is accessible via standard CDC-ACM USB driver
+present in most desktop operating systems and any standard serial port terminal
+program e.g. `picocom`_.
+
+SWD and SWO functionality is accessible via `Simplicity Commander`_.
+
+The simplest way to flash the board is by using West, which runs Simplicity
+Commander in unattended mode and passes all the necessary arguments to it.
+
+- If Simplicity Commander is installed in the system and the directory in
+  which `commander` executable is located is present in the `PATH` environment
+  variable:
+
+  .. code-block:: console
+
+   west flash
+
+- Otherwise, one should specify full path to the `commander` executable:
+
+  .. code-block:: console
+
+   west flash --commander <path_to_commander_directory>/commander
+
+- In case several J-Link adapters are connected, you must specify serial number
+  of the adapter which should be used for flashing:
+
+  .. code-block:: console
+
+   west flash --dev-id <J-Link serial number>
+
 Programming and Debugging
 =========================
 
@@ -55,24 +99,11 @@ Build the Zephyr kernel and application:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: efr32bg_brd4184a
+   :board: efr32bg27_brd2602a
    :goals: build
 
 Connect your device to your host computer using the USB port and you
 should see a USB connection. Use `west`'s flash command
-
-Unlike older Silicon Labs devices, this device can't be flashed using regular
-SEGGER J-Link software at the moment. Instead
-`Silicon Labs' Simplicity Commander`_ is required in order to upload any
-software to this device.
-
-Open Simplicity Commander and go to "Flash" tab. Enter the path to `zephyr.hex` or
-`zephyr.bin` file in text field labeled "Binary file". Click "Flash" to upload the
-software to your device.
-
-.. note::
-   If you get an "unspecified error during flashing", you may need to use the
-   memory erase option first.
 
 Open a serial terminal (minicom, putty, etc.) with the following settings:
 
@@ -88,5 +119,11 @@ the following message:
 
    Hello World! efr32bg27_brd2602a
 
-.. _Silicon Labs' Simplicity Commander:
+.. _picocom:
+   https://github.com/npat-efault/picocom
+
+.. _J-Link:
+   https://www.segger.com/jlink-debug-probes.html
+
+.. _Simplicity Commander:
    https://www.silabs.com/developers/mcu-programming-options

--- a/boards/common/silabs_commander.board.cmake
+++ b/boards/common/silabs_commander.board.cmake
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(silabs_commander)
+board_finalize_runner_args(silabs_commander)

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -46,6 +46,7 @@ _names = [
     'openocd',
     'pyocd',
     'qemu',
+    'silabs_commander',
     'spi_burn',
     'stm32cubeprogrammer',
     'stm32flash',

--- a/scripts/west_commands/runners/silabs_commander.py
+++ b/scripts/west_commands/runners/silabs_commander.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2023, Antmicro <www.antmicro.com>
+#
+# Based on J-Link runner
+# Copyright (c) 2017 Linaro Limited.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Runner that implements flashing with SiLabs Simplicity Commander binary tool.
+See SiLabs UG162: "Simplicity Commander Reference Guide" for more info.
+"""
+
+import os
+import shlex
+from runners.core import ZephyrBinaryRunner, RunnerCaps, FileType
+
+
+DEFAULT_APP = 'commander'
+
+
+class SiLabsCommanderBinaryRunner(ZephyrBinaryRunner):
+    def __init__(self, cfg, device, dev_id, commander, dt_flash, erase, speed, tool_opt):
+        super().__init__(cfg)
+        self.file = cfg.file
+        self.file_type = cfg.file_type
+        self.hex_name = cfg.hex_file
+        self.bin_name = cfg.bin_file
+        self.elf_name = cfg.elf_file
+        self.device = device
+        self.dev_id = dev_id
+        self.commander = commander
+        self.dt_flash = dt_flash
+        self.erase = erase
+        self.speed = speed
+
+        self.tool_opt = []
+        for opts in [shlex.split(opt) for opt in tool_opt]:
+            self.tool_opt += opts
+
+    @classmethod
+    def name(cls):
+        return 'silabs_commander'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash'},
+                          dev_id=True, flash_addr=True, erase=True,
+                          tool_opt=True, file=True)
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        return '''Device identifier. Use it to select the J-Link Serial Number
+                  of the device connected over USB.'''
+
+    @classmethod
+    def tool_opt_help(cls) -> str:
+        return "Additional options for Simplicity Commander, e.g. '--noreset'"
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        # Required:
+        parser.add_argument('--device', required=True,
+                            help='device part number')
+
+        # Optional:
+        parser.add_argument('--commander', default=DEFAULT_APP,
+                            help='path to Simplicity Commander executable')
+        parser.add_argument('--speed', default=None,
+                            help='JTAG/SWD speed to use')
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        return SiLabsCommanderBinaryRunner(
+                cfg, args.device,
+                dev_id=args.dev_id,
+                commander=args.commander,
+                dt_flash=args.dt_flash,
+                erase=args.erase,
+                speed=args.speed,
+                tool_opt=args.tool_opt)
+
+    def do_run(self, command, **kwargs):
+        self.require(self.commander)
+
+        opts = ['--device', self.device]
+        if self.erase:
+            opts.append('--masserase')
+        if self.dev_id:
+            opts.extend(['--serialno', self.dev_id])
+        if self.speed is not None:
+            opts.extend(['--speed', self.speed])
+
+        # Get the build artifact to flash
+
+        if self.dt_flash:
+            flash_addr = self.flash_address_from_build_conf(self.build_conf)
+        else:
+            flash_addr = 0
+
+        if self.file is not None:
+            # use file provided by the user
+            if not os.path.isfile(self.file):
+                raise ValueError(f'Cannot flash; file ({self.file}) not found')
+
+            flash_file = self.file
+
+            if self.file_type == FileType.HEX:
+                flash_args = [flash_file]
+            elif self.file_type == FileType.BIN:
+                flash_args = ['--binary', '--address', f'0x{flash_addr:x}', flash_file]
+            else:
+                raise ValueError('Cannot flash; this runner only supports hex and bin files')
+
+        else:
+            # use hex or bin file provided by the buildsystem, preferring .hex over .bin
+            if self.hex_name is not None and os.path.isfile(self.hex_name):
+                flash_file = self.hex_name
+                flash_args = [flash_file]
+            elif self.bin_name is not None and os.path.isfile(self.bin_name):
+                flash_file = self.bin_name
+                flash_args = ['--binary', '--address', f'0x{flash_addr:x}', flash_file]
+            else:
+                raise ValueError(f'Cannot flash; no hex ({self.hex_name}) or bin ({self.bin_name}) files found.')
+
+        args = [self.commander, 'flash'] + opts + self.tool_opt + flash_args
+
+        self.logger.info('Flashing file: {}'.format(flash_file))
+        self.check_call(args)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -36,6 +36,7 @@ def test_runner_imports():
                     'openocd',
                     'pyocd',
                     'qemu',
+                    'silabs_commander',
                     'spi_burn',
                     'stm32cubeprogrammer',
                     'stm32flash',


### PR DESCRIPTION
SiLabs EFR32BG27 evaluation board comes with a built-in J-Link adapter. However, stock J-Link software does not (yet) provide support for flashing BG27 chips, so SiLabs Simplicity Commander tool must be used for that today.

This PR adds a new West _Runner_ for Simplicity Commander and uses it to flash _efr32bg27_brd2602a_ board.