### PR TITLE
drivers: counter: Add support for rpi_pico timer

### DIFF
--- a/boards/arm/rpi_pico/rpi_pico-common.dtsi
+++ b/boards/arm/rpi_pico/rpi_pico-common.dtsi
@@ -119,6 +119,10 @@
 	pinctrl-names = "default";
 };
 
+&timer {
+	status = "okay";
+};
+
 &wdt0 {
 	status = "okay";
 };

--- a/boards/arm/rpi_pico/rpi_pico.yaml
+++ b/boards/arm/rpi_pico/rpi_pico.yaml
@@ -19,3 +19,4 @@ supported:
   - pwm
   - flash
   - dma
+  - counter

--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -47,3 +47,4 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_NXP_S32_SYS_TIMER   counter_nxp_s32_
 zephyr_library_sources_ifdef(CONFIG_COUNTER_TIMER_GD32		counter_gd32_timer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_SNPS_DW             counter_dw_timer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_SHELL               counter_timer_shell.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_TIMER_RPI_PICO	counter_rpi_pico_timer.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -92,4 +92,6 @@ source "drivers/counter/Kconfig.gd32"
 
 source "drivers/counter/Kconfig.dw"
 
+source "drivers/counter/Kconfig.rpi_pico"
+
 endif # COUNTER

--- a/drivers/counter/Kconfig.rpi_pico
+++ b/drivers/counter/Kconfig.rpi_pico
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+config COUNTER_TIMER_RPI_PICO
+	def_bool y
+	select PICOSDK_USE_TIMER
+	select PICOSDK_USE_CLAIM
+	depends on DT_HAS_RASPBERRYPI_PICO_TIMER_ENABLED

--- a/drivers/counter/counter_rpi_pico_timer.c
+++ b/drivers/counter/counter_rpi_pico_timer.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2023 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <hardware/timer.h>
+
+#include <zephyr/drivers/counter.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/irq.h>
+#include <cmsis_core.h>
+
+#define LOG_LEVEL CONFIG_COUNTER_LOG_LEVEL
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(counter_rpi_pico_timer, LOG_LEVEL);
+
+#define DT_DRV_COMPAT raspberrypi_pico_timer
+
+struct counter_rpi_pico_timer_ch_data {
+	counter_alarm_callback_t callback;
+	void *user_data;
+};
+
+struct counter_rpi_pico_timer_data {
+	struct counter_rpi_pico_timer_ch_data *ch_data;
+	uint32_t guard_period;
+};
+
+struct counter_rpi_pico_timer_config {
+	struct counter_config_info info;
+	timer_hw_t *timer;
+	void (*irq_config)();
+};
+
+static int counter_rpi_pico_timer_start(const struct device *dev)
+{
+	const struct counter_rpi_pico_timer_config *config = dev->config;
+
+	config->timer->pause = 0;
+
+	return 0;
+}
+
+static int counter_rpi_pico_timer_stop(const struct device *dev)
+{
+	const struct counter_rpi_pico_timer_config *config = dev->config;
+
+	config->timer->pause = 1u;
+	config->timer->timelw = 0;
+	config->timer->timehw = 0;
+
+	return 0;
+}
+
+static uint32_t counter_rpi_pico_timer_get_top_value(const struct device *dev)
+{
+	const struct counter_rpi_pico_timer_config *config = dev->config;
+
+	return config->info.max_top_value;
+}
+
+static int counter_rpi_pico_timer_get_value(const struct device *dev, uint32_t *ticks)
+{
+	*ticks = time_us_32();
+	return 0;
+}
+
+static int counter_rpi_pico_timer_set_alarm(const struct device *dev, uint8_t id,
+					    const struct counter_alarm_cfg *alarm_cfg)
+{
+	const struct counter_rpi_pico_timer_config *config = dev->config;
+	struct counter_rpi_pico_timer_data *data = dev->data;
+	struct counter_rpi_pico_timer_ch_data *chdata = &data->ch_data[id];
+	uint64_t target = (alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) ? 0 : alarm_cfg->ticks;
+	absolute_time_t alarm_at;
+	bool missed;
+
+	update_us_since_boot(&alarm_at, config->timer->timerawl + target);
+
+	if (alarm_cfg->ticks > counter_rpi_pico_timer_get_top_value(dev)) {
+		return -EINVAL;
+	}
+
+	if (chdata->callback) {
+		return -EBUSY;
+	}
+
+	chdata->callback = alarm_cfg->callback;
+	chdata->user_data = alarm_cfg->user_data;
+
+	missed = hardware_alarm_set_target(id, alarm_at);
+
+	if (missed) {
+		if (alarm_cfg->flags & COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE) {
+			hardware_alarm_force_irq(id);
+		}
+		chdata->callback = NULL;
+		chdata->user_data = NULL;
+		return -ETIME;
+	}
+
+	return 0;
+}
+
+static int counter_rpi_pico_timer_cancel_alarm(const struct device *dev, uint8_t id)
+{
+	hardware_alarm_cancel(id);
+
+	return 0;
+}
+
+static int counter_rpi_pico_timer_set_top_value(const struct device *dev,
+						const struct counter_top_cfg *cfg)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cfg);
+
+	return -ENOTSUP;
+}
+
+static uint32_t counter_rpi_pico_timer_get_pending_int(const struct device *dev)
+{
+	return 0;
+}
+
+static uint32_t counter_rpi_pico_timer_get_guard_period(const struct device *dev, uint32_t flags)
+{
+	struct counter_rpi_pico_timer_data *data = dev->data;
+
+	return data->guard_period;
+}
+
+static int counter_rpi_pico_timer_set_guard_period(const struct device *dev, uint32_t guard,
+						   uint32_t flags)
+{
+	struct counter_rpi_pico_timer_data *data = dev->data;
+
+	__ASSERT_NO_MSG(guard < counter_rpi_pico_timer_get_top_value(dev));
+
+	data->guard_period = guard;
+
+	return 0;
+}
+
+static void counter_rpi_pico_irq_handle(uint32_t ch, void *arg)
+{
+	struct device *dev = arg;
+	struct counter_rpi_pico_timer_data *data = dev->data;
+	counter_alarm_callback_t cb = data->ch_data[ch].callback;
+	void *user_data = data->ch_data[ch].user_data;
+
+	if (cb) {
+		data->ch_data[ch].callback = NULL;
+		data->ch_data[ch].user_data = NULL;
+		cb(dev, ch, time_us_32(), user_data);
+	}
+}
+
+static int counter_rpi_pico_timer_init(const struct device *dev)
+{
+	const struct counter_rpi_pico_timer_config *config = dev->config;
+
+	config->irq_config();
+
+	return 0;
+}
+
+static const struct counter_driver_api counter_rpi_pico_driver_api = {
+	.start = counter_rpi_pico_timer_start,
+	.stop = counter_rpi_pico_timer_stop,
+	.get_value = counter_rpi_pico_timer_get_value,
+	.set_alarm = counter_rpi_pico_timer_set_alarm,
+	.cancel_alarm = counter_rpi_pico_timer_cancel_alarm,
+	.set_top_value = counter_rpi_pico_timer_set_top_value,
+	.get_pending_int = counter_rpi_pico_timer_get_pending_int,
+	.get_top_value = counter_rpi_pico_timer_get_top_value,
+	.get_guard_period = counter_rpi_pico_timer_get_guard_period,
+	.set_guard_period = counter_rpi_pico_timer_set_guard_period,
+};
+
+#define RPI_PICO_TIMER_IRQ_ENABLE(node_id, name, idx)                                              \
+	do {                                                                                       \
+		hardware_alarm_set_callback(idx, counter_rpi_pico_irq_handle);                     \
+		IRQ_CONNECT((DT_IRQ_BY_IDX(node_id, idx, irq)),                                    \
+			    (DT_IRQ_BY_IDX(node_id, idx, priority)), hardware_alarm_irq_handler,   \
+			    (DEVICE_DT_GET(node_id)), 0);                                          \
+		irq_enable((DT_IRQ_BY_IDX(node_id, idx, irq)));                                    \
+	} while (false);
+
+#define COUNTER_RPI_PICO_TIMER(inst)                                                               \
+	static void counter_irq_config##inst(void)                                                 \
+	{                                                                                          \
+		DT_INST_FOREACH_PROP_ELEM(inst, interrupt_names, RPI_PICO_TIMER_IRQ_ENABLE);       \
+	}                                                                                          \
+	static struct counter_rpi_pico_timer_ch_data                                               \
+		ch_data##inst[DT_NUM_IRQS(DT_DRV_INST(inst))];                                     \
+	static struct counter_rpi_pico_timer_data counter_##inst##_data = {                        \
+		.ch_data = ch_data##inst,                                                          \
+	};                                                                                         \
+	static const struct counter_rpi_pico_timer_config counter_##inst##_config = {              \
+		.timer = (timer_hw_t *)DT_INST_REG_ADDR(inst),                                     \
+		.irq_config = counter_irq_config##inst,                                            \
+		.info =                                                                            \
+			{                                                                          \
+				.max_top_value = UINT32_MAX,                                       \
+				.freq = 1000000,                                                   \
+				.flags = COUNTER_CONFIG_INFO_COUNT_UP,                             \
+				.channels = ARRAY_SIZE(ch_data##inst),                             \
+			},                                                                         \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, counter_rpi_pico_timer_init, NULL, &counter_##inst##_data,     \
+			      &counter_##inst##_config, PRE_KERNEL_1,                              \
+			      CONFIG_COUNTER_INIT_PRIORITY, &counter_rpi_pico_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(COUNTER_RPI_PICO_TIMER)

--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -187,6 +187,22 @@
 			#pwm-cells = <3>;
 		};
 
+		timer: timer@40054000 {
+			compatible = "raspberrypi,pico-timer";
+			reg = <0x40054000 DT_SIZE_K(4)>;
+			resets = <&reset RPI_PICO_RESETS_RESET_TIMER>;
+			clocks = <&xtal_clk>;
+			interrupts = <0 RPI_PICO_DEFAULT_IRQ_PRIORITY>,
+				     <1 RPI_PICO_DEFAULT_IRQ_PRIORITY>,
+				     <2 RPI_PICO_DEFAULT_IRQ_PRIORITY>,
+				     <3 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
+			interrupt-names = "TIMER_IRQ_0",
+					  "TIMER_IRQ_1",
+					  "TIMER_IRQ_2",
+					  "TIMER_IRQ_3";
+			status = "disabled";
+		};
+
 		dma: dma@50000000 {
 			compatible = "raspberrypi,pico-dma";
 			reg = <0x50000000 DT_SIZE_K(64)>;

--- a/dts/bindings/timer/raspberrypi,pico-timer.yaml
+++ b/dts/bindings/timer/raspberrypi,pico-timer.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+description: RaspberryPi Pico timer
+
+compatible: "raspberrypi,pico-timer"
+
+include: [base.yaml, reset-device.yaml]

--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -105,6 +105,11 @@ if(CONFIG_HAS_RPI_PICO)
   zephyr_include_directories_ifdef(CONFIG_PICOSDK_USE_DMA
           ${rp2_common_dir}/hardware_dma/include)
 
+  zephyr_library_sources_ifdef(CONFIG_PICOSDK_USE_TIMER
+          ${rp2_common_dir}/hardware_timer/timer.c)
+  zephyr_include_directories_ifdef(CONFIG_PICOSDK_USE_TIMER
+          ${rp2_common_dir}/hardware_timer/include)
+
   zephyr_library_sources_ifdef(CONFIG_PICOSDK_USE_CLAIM
           ${rp2_common_dir}/hardware_claim/claim.c)
   zephyr_include_directories_ifdef(CONFIG_PICOSDK_USE_CLAIM

--- a/modules/hal_rpi_pico/Kconfig
+++ b/modules/hal_rpi_pico/Kconfig
@@ -44,3 +44,8 @@ config PICOSDK_USE_CLAIM
 	bool
 	help
 	  Use the "claim" driver from pico-sdk
+
+config PICOSDK_USE_TIMER
+	bool
+	help
+	  Use the TIMER driver from pico-sdk

--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -25,6 +25,7 @@ tests:
       - gd32f470i_eval
       - stm32h735g_disco
       - stm32h573i_dk
+      - rpi_pico
     integration_platforms:
       - nucleo_f746zg
     harness_config:

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -51,6 +51,8 @@ struct counter_alarm_cfg alarm_cfg;
 #define TIMER DT_NODELABEL(counter0)
 #elif defined(CONFIG_COUNTER_SNPS_DW)
 #define TIMER DT_NODELABEL(timer0)
+#elif defined(CONFIG_COUNTER_TIMER_RPI_PICO)
+#define TIMER DT_NODELABEL(timer)
 #endif
 
 static void test_counter_interrupt_fn(const struct device *counter_dev,

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -93,6 +93,9 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_TIMER_GD32
 	DEVS_FOR_DT_COMPAT(gd_gd32_timer)
 #endif
+#ifdef CONFIG_COUNTER_TIMER_RPI_PICO
+	DEVS_FOR_DT_COMPAT(raspberrypi_pico_timer)
+#endif
 };
 
 static const struct device *const period_devs[] = {

--- a/west.yml
+++ b/west.yml
@@ -215,7 +215,7 @@ manifest:
         - hal
     - name: hal_rpi_pico
       path: modules/hal/rpi_pico
-      revision: b7801e4db6a62ea2d37bbef7880c3d056530c9bf
+      revision: fba7162cc7bee06d0149622bbcaac4e41062d368
       groups:
         - hal
     - name: hal_silabs


### PR DESCRIPTION
Adds support for rpi_pico timer
    
Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@gmail.com>

---

This PR need to modify HAL changes https://github.com/zephyrproject-rtos/hal_rpi_pico/pull/5.
