### PR TITLE
dts/arm/silabs: ADC support for EFR32BG27

### DIFF
--- a/dts/arm/silabs/efr32bg27.dtsi
+++ b/dts/arm/silabs/efr32bg27.dtsi
@@ -81,3 +81,7 @@
 &stimer0 {
 	interrupts = <15 0>;
 };
+
+&adc0 {
+	interrupts = <54 0>;
+};

--- a/tests/drivers/adc/adc_api/boards/efr32bg27_brd2602a.overlay
+++ b/tests/drivers/adc/adc_api/boards/efr32bg27_brd2602a.overlay
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Antmicro <www.antmicro.com>
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <0x11>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <0x01>;
+	};
+};


### PR DESCRIPTION
Enable ADC peripheral for EFR32BG27 and add support for _efr32bg27_brd2602a_ board to _tests/drivers/adc_api_ test.