### PR TITLE
runners: stm32cubeprogrammer: fix program files path for win x64

### DIFF
--- a/scripts/west_commands/runners/stm32cubeprogrammer.py
+++ b/scripts/west_commands/runners/stm32cubeprogrammer.py
@@ -89,7 +89,7 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
             if x86_path.exists():
                 return x86_path
 
-            return Path(os.environ["PROGRAMFILES"]) / cli
+            return Path(os.environ["PROGRAMW6432"]) / cli
 
         if platform.system() == "Darwin":
             return (


### PR DESCRIPTION
I started to fiddle with Twister on Windows to run some tests on the HW but got a problem with
the stm32cubeprogrammer runner.

The '%ProgramFiles%' is not guaranteed to be 'C:\Program Files' on Windows x64.
The value will be 'C:\Program Files (x86)' if the west is executed by 32-bit Python.

To correct the issue '%ProgramW6432%' must be used.