### PR TITLE
cmake: snippets: Store DTC_OVERLAY_FILE and OVERLAY_CONFIG to cache

### DIFF
--- a/cmake/modules/snippets.cmake
+++ b/cmake/modules/snippets.cmake
@@ -94,8 +94,8 @@ function(zephyr_process_snippets)
   include(${snippets_generated})
 
   # Propagate include()d build system settings to the caller.
-  set(DTC_OVERLAY_FILE ${DTC_OVERLAY_FILE} PARENT_SCOPE)
-  set(OVERLAY_CONFIG ${OVERLAY_CONFIG} PARENT_SCOPE)
+  set(DTC_OVERLAY_FILE ${DTC_OVERLAY_FILE} CACHE STRING "DTC overlay" FORCE)
+  set(OVERLAY_CONFIG ${OVERLAY_CONFIG} CACHE STRING "Kconfig overlay" FORCE)
 
   # Create the 'snippets' target. Each snippet is printed in a
   # separate command because build system files are not fond of


### PR DESCRIPTION
This commit updates the snippets module to store the content of the local `DTC_OVERLAY_FILE` and `OVERLAY_CONFIG` variables in the cache to ensure that the future `zephyr_get` operations on these variables do not end up overwriting the local changes made by the snippets module.

Note that these variables are initially set to the cache content (e.g. when `-DDTC_OVERLAY_FILE=...` or `-DOVERLAY_CONFIG=...` is passed to the CMake command line) at the time of module entry and appended with the snippet overlay file list during the module execution.

---

Fixes #57139 