### PR TITLE
drivers/entropy/entropy_gecko_trng: support EFR32BG27

### DIFF
--- a/drivers/entropy/Kconfig.gecko
+++ b/drivers/entropy/Kconfig.gecko
@@ -10,6 +10,7 @@ config ENTROPY_GECKO_TRNG
 	depends on DT_HAS_SILABS_GECKO_TRNG_ENABLED
 	select ENTROPY_HAS_DRIVER
 	select CRYPTO_ACC_GECKO_TRNG if SOC_SERIES_EFR32BG22
+	select CRYPTO_ACC_GECKO_TRNG if SOC_SERIES_EFR32BG27
 	help
 	  This option enables the true random number generator
 	  driver based on the TRNG.


### PR DESCRIPTION
Add TRNG support for BG27, which has slightly different register definitions in HAL, compared to BG22.