### PR TITLE
soc: mps3: add pmu defines for cmsis

### DIFF
--- a/soc/arm/arm/mps3/soc.h
+++ b/soc/arm/arm/mps3/soc.h
@@ -17,6 +17,8 @@
 #define __MVE_FP                  1U        /* MVE floating point present */
 #define __ICACHE_PRESENT          1U        /* ICACHE present */
 #define __DCACHE_PRESENT          1U        /* DCACHE present */
+#define __PMU_PRESENT             1U        /* PMU present */
+#define __PMU_NUM_EVENTCNT        8U        /* PMU Event Counters */
 #endif
 
 


### PR DESCRIPTION
The mps3 soc is missing PMU defines required for CMSIS. This adds the defines __PMU_PRESENT and __PMU_NUM_EVENTCNT enabling the api for the PMU.