### PR TITLE
drivers: sensor: bh1749: adding support for bh1749 color sensor

### DIFF
--- a/drivers/sensor/CMakeLists.txt
+++ b/drivers/sensor/CMakeLists.txt
@@ -122,7 +122,7 @@ add_subdirectory_ifdef(CONFIG_PCNT_ESP32	pcnt_esp32)
 add_subdirectory_ifdef(CONFIG_ESP32_TEMP	esp32_temp)
 add_subdirectory_ifdef(CONFIG_RPI_PICO_TEMP	rpi_pico_temp)
 add_subdirectory_ifdef(CONFIG_XMC4XXX_TEMP	xmc4xxx_temp)
-
+add_subdirectory_ifdef(CONFIG_BH1749        bh1749)
 if(CONFIG_USERSPACE OR CONFIG_SENSOR_SHELL OR CONFIG_SENSOR_SHELL_BATTERY)
 # The above if() is needed or else CMake would complain about
 # empty library.

--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -283,4 +283,7 @@ source "drivers/sensor/rpi_pico_temp/Kconfig"
 
 source "drivers/sensor/xmc4xxx_temp/Kconfig"
 
+source "drivers/sensor/bh1749/Kconfig"
+
+
 endif # SENSOR

--- a/drivers/sensor/bh1749/CMakeLists.txt
+++ b/drivers/sensor/bh1749/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(bh1749.c)

--- a/drivers/sensor/bh1749/Kconfig
+++ b/drivers/sensor/bh1749/Kconfig
@@ -1,0 +1,10 @@
+
+
+config BH1749
+    bool "BH1749 with i2c interface"
+    default y
+    depends on GPIO
+    select I2C
+    help
+        Enable the color sensor bh1749
+

--- a/drivers/sensor/bh1749/bh1749.c
+++ b/drivers/sensor/bh1749/bh1749.c
@@ -1,0 +1,173 @@
+
+
+#define DT_DRV_COMPAT rohm_bh1749
+
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/drivers/sensor.h>
+
+
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/printk.h>
+#include <stdio.h>
+
+#include "bh1749.h"
+
+
+LOG_MODULE_REGISTER(BH1749, CONFIG_SENSOR_LOG_LEVEL);
+
+
+static int bh1749_sample_fetch(const struct device *dev, enum sensor_channel chan)
+
+{    
+    struct bh1749_data *data = dev->data;
+    const struct bh1749_config *cfg = dev->config;
+
+    uint16_t buf[3];
+    uint16_t buff[2];
+
+    uint16_t th[2];
+
+    if(i2c_burst_read_dt(&cfg->i2c, RED_DATAL, (uint8_t *)buf, 6) < 0){
+        LOG_ERR("Failed to read data sample");
+        return -EIO;
+     }
+
+    data->red = sys_be16_to_cpu(buf[0]);
+    data->green = sys_be16_to_cpu(buf[1]);
+    data->blue = sys_be16_to_cpu(buf[2]);  
+
+    if(i2c_burst_read_dt(&cfg->i2c, IR_DATAL, (uint8_t *)buff, 4) < 0){
+        LOG_ERR("Failed to read data sample");
+        return -EIO;
+    }
+
+    if(i2c_burst_read_dt(&cfg->i2c, TH_HIGHL, (uint8_t *)th, 4) < 0){
+        LOG_ERR("Failed to read data sample");
+        return -EIO;
+    }
+
+
+    data->ir = sys_be16_to_cpu(buff[0]);
+    data->green2 = sys_be16_to_cpu(buff[1]);
+
+    data->th_high = sys_be16_to_cpu(th[0]);
+    data->th_low = sys_be16_to_cpu(th[1]);
+
+    return 0;
+}
+
+static int bh1749_channel_get(const struct device *dev, enum sensor_channel chan, struct sensor_value *val)
+{
+    struct bh1749_data *data = dev->data;
+    
+    switch(chan) {
+    
+    case SENSOR_CHAN_RED: 
+        val->val1 = (int)data->red * 0.0125;
+        val->val2 = (int)data->red % 80;        
+        break;
+        
+    case SENSOR_CHAN_BLUE:
+        val->val1 = (int)data->blue * 0.0125;
+        val->val2 = (int)data->blue % 80;
+        break;
+
+    case SENSOR_CHAN_GREEN:
+        val->val1 = (int)data->green * 0.0125;
+        val->val2 = (int)data->green % 80;
+        break;
+
+    case SENSOR_CHAN_IR:
+        val->val1 = (int)data->ir * 0.0125;
+        val->val2 = (int)data->ir % 80;
+        break;
+    default:
+        break;
+    }
+    return 0;
+}
+
+static const struct sensor_driver_api bh1749_driver_api = {
+
+    .sample_fetch = bh1749_sample_fetch,
+    .channel_get = bh1749_channel_get,
+
+};
+
+
+uint8_t bh1749_read_chip_id(const struct device *dev){
+
+    const struct bh1749_config *cfg = dev->config;
+    //struct bh1749_data *data = dev->data;
+    uint8_t chip_id;
+
+    if(i2c_reg_read_byte_dt(&cfg->i2c, CHIP_ID_VAL, &chip_id) < 0){
+        LOG_ERR("Wrong chip detected");
+        
+        return -EIO;
+    }
+    return chip_id;
+}
+
+
+int bh1749_init(const struct device *dev){
+
+    const struct bh1749_config *cfg = dev->config;
+    //struct bh1749_data *data = dev->data;
+    uint8_t id;
+
+    if(!device_is_ready(cfg->i2c.bus)){
+        LOG_ERR("Device is not ready!");
+        return -ENODEV;
+    }
+    /*check the chip-id */
+    if(i2c_reg_read_byte_dt(&cfg->i2c, CHIP_ID_VAL, &id) < 0){
+        LOG_ERR("Wrong chip detected");       
+        return -EIO;
+    }
+    
+    if(i2c_reg_write_byte_dt(&cfg->i2c, SYS_CONTROL, 0x0D) < 0){
+        LOG_ERR("Error writing SYS control");       
+        return -EIO;
+    }
+    /*keep sensor in highest gain and measurement time*/
+    if(i2c_reg_write_byte_dt(&cfg->i2c, MODE_CNTL1, 0x2A) < 0){
+        LOG_ERR("Error wtinting control reg1");       
+        return -EIO;
+    }
+
+    if(i2c_reg_write_byte_dt(&cfg->i2c, MODE_CTRL2, 0x10) < 0){
+        LOG_ERR("Error wtinting control reg2");       
+        return -EIO;
+    }
+    
+    if(i2c_reg_write_byte_dt(&cfg->i2c, INTERRUPT, 0x00) < 0){
+        LOG_ERR("Error wtinting control Interrupt reg");       
+        return -EIO;
+    }
+
+    if(i2c_reg_write_byte_dt(&cfg->i2c, PERSISTANCE, 0x01) < 0){
+        LOG_ERR("Error wtinting Persistance reg");       
+        return -EIO;
+    }
+
+    /*   Write thresold values  */
+
+    return 0;
+}
+
+#define BH1749_DEFINE(inst)									\
+	static struct bh1749_data bh1749_data_##inst;						\
+												\
+	static const struct bh1749_config bh1749_config_##inst = {				\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
+		};											\
+												\
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, bh1749_init, NULL,					\
+			      &bh1749_data_##inst, &bh1749_config_##inst,			\
+			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				\
+			      &bh1749_driver_api);						\
+
+DT_INST_FOREACH_STATUS_OKAY(BH1749_DEFINE)

--- a/drivers/sensor/bh1749/bh1749.h
+++ b/drivers/sensor/bh1749/bh1749.h
@@ -1,0 +1,67 @@
+
+
+#ifndef _BH1749_H__
+#define _BH1749_H__
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/types.h>
+
+#define I2C_ADDRESS         0x38
+
+#define SYS_CONTROL         0x40
+
+#define MODE_CNTL1          0x41
+#define MODE_CTRL2          0x42
+
+#define RED_DATAL           0x50
+#define RED_DATAH           0x51
+
+#define GREEN_DATAL         0x52
+#define GREEN_DATAH         0x53
+
+#define BLUE_DATAL          0x54
+#define BLUE_DATAH          0x55
+
+#define IR_DATAL            0x58
+#define IR_DATAH            0x59
+
+#define GREEN2_DATAL        0x5A
+#define GREEN2_DATAH        0x5B
+
+#define INTERRUPT            0x60
+#define PERSISTANCE         0x61
+
+
+#define TH_HIGHL            0x62
+#define TH_HIGHH            0x63
+
+#define TH_LOWL             0x64
+#define TH_LOWH             0x65
+
+#define CHIP_ID_VAL         0x92
+
+
+struct bh1749_config {
+    struct i2c_dt_spec i2c;
+
+};
+struct bh1749_data {
+
+    uint16_t red;
+    uint16_t green;
+    uint16_t blue;
+
+    uint16_t ir;
+
+    uint16_t green2;
+
+    uint16_t th_high;
+    uint16_t th_low;
+
+};
+
+#endif

--- a/dts/bindings/sensor/rohm,bh1749.yaml
+++ b/dts/bindings/sensor/rohm,bh1749.yaml
@@ -1,0 +1,8 @@
+description: Roah semiconductor BH1749 color sensor
+
+compatible: "rohm,bh1749"
+
+include: [sensor-device.yaml, i2c-device.yaml]
+
+
+


### PR DESCRIPTION
The rohm semiconductor bh1749 color sensor is digital color sensor IC with I2C bus interface. This IC senses
 Red, Green, Blue (RGB) and Infrared and converts them
to digital values. The high sensitivity, wide dynamic range and excellent Ircut characteristics make it possible for this IC to obtain the accurate illuminance and color temperature of ambient light. It is ideal for adjusting LCD backlight of TV, mobile phone and tablet PC.