### PR TITLE
docs(build): fix typo of in CONFIG_GEN_ISR_TABLES description

### DIFF
--- a/doc/build/cmake/index.rst
+++ b/doc/build/cmake/index.rst
@@ -257,7 +257,7 @@ Device dependencies
     :width: 80%
 
 When :kconfig:option:`CONFIG_GEN_ISR_TABLES` is enabled:
-   The *gen_isr_tables.py* script scant the fixed size binary and creates
+   The *gen_isr_tables.py* script scans the fixed size binary and creates
    an isr_tables.c source file with a hardware vector table and/or software
    IRQ table.
 


### PR DESCRIPTION
Fixes misspelling of `scans` in the description of `CONFIG_GEN_ISR_TABLES` in the build system documentation.