### PR TITLE
cmake: compiler: add double promotion warning

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -33,6 +33,9 @@ set_compiler_property(PROPERTY warning_base
                       -Wno-typedef-redefinition
 )
 
+# C implicit promotion rules will want to make floats into doubles very easily
+check_set_compiler_property(APPEND PROPERTY warning_base -Wdouble-promotion)
+
 check_set_compiler_property(APPEND PROPERTY warning_base -Wno-pointer-sign)
 
 # Prohibit void pointer arithmetic. Illegal in C99

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -45,6 +45,9 @@ check_set_compiler_property(PROPERTY warning_base
                             -Wno-deprecated-non-prototype
 )
 
+# C implicit promotion rules will want to make floats into doubles very easily
+check_set_compiler_property(APPEND PROPERTY warning_base -Wdouble-promotion)
+
 check_set_compiler_property(APPEND PROPERTY warning_base -Wno-pointer-sign)
 
 # Prohibit void pointer arithmetic. Illegal in C99

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -32,6 +32,9 @@ check_set_compiler_property(PROPERTY warning_base
     "SHELL:-Wformat -Wno-format-zero-length"
 )
 
+# C implicit promotion rules will want to make floats into doubles very easily
+check_set_compiler_property(APPEND PROPERTY warning_base -Wdouble-promotion)
+
 check_set_compiler_property(APPEND PROPERTY warning_base -Wno-pointer-sign)
 
 # Prohibit void pointer arithmetic. Illegal in C99


### PR DESCRIPTION
Too many times, code is pushed that includes floats that really becomes doubles and C implicit promotion rules will want to make floats into doubles very easily. As Zephyr primarily targets low-end processors that may not have a double precision floating point unit, enable this flag globally for now.

__DEPENDS ON__
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/38651
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/40448
- [x] https://github.com/picolibc/picolibc/pull/364
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/58479
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/57265
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/57266
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/56957
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/57303
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/57304
- [x] https://github.com/zephyrproject-rtos/hal_st/pull/15
- [x] https://github.com/NordicSemiconductor/zcbor/pull/326
- [x] https://github.com/WurthElektronik/Sensors-SDK_STM32/pull/3
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/60378
- [x] https://github.com/zephyrproject-rtos/hal_espressif/pull/224
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/60403
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/60593
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/60594
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/60595
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/60596
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/60598
- [x] https://github.com/zephyrproject-rtos/hal_openisa/pull/8
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/60602
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/60605
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/61771
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/61772
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/61807
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/66241
- [x] https://github.com/zephyrproject-rtos/zscilib/pull/56
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/66354
_and likely others to come as the CI finds it all_

west.yml also needed to be updated to include the fixes above with the fixes merged in to their "Zephyr forks"
- [x] hal_openisa - https://github.com/zephyrproject-rtos/zephyr/pull/66470
- [x] hal_wurthelektronik - https://github.com/zephyrproject-rtos/zephyr/pull/66471
- [x] zcbor - https://github.com/zephyrproject-rtos/zephyr/pull/67418
- [x] zscilib - https://github.com/zephyrproject-rtos/zephyr/pull/66504