### PR TITLE
boards: arm: nucleo_f030r8: add die-temp0 alias

### DIFF
--- a/boards/arm/nucleo_f030r8/doc/index.rst
+++ b/boards/arm/nucleo_f030r8/doc/index.rst
@@ -93,6 +93,8 @@ The Zephyr nucleo_f030r8 board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c controller                      |
 +-----------+------------+-------------------------------------+
+| ADC       | on-chip    | ADC controller                      |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 
@@ -124,6 +126,7 @@ Default Zephyr Peripheral Mapping:
 - SPI2 NSS/SCK/MISO/MOSI : PB12/PB13/PB14/PB15
 - USER_PB : PC13
 - LD1 : PA5
+- ADC : PA0
 
 
 For mode details please refer to `STM32 Nucleo-64 board User Manual`_.

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -110,6 +110,12 @@
 	status = "okay";
 };
 
+&adc1 {
+	pinctrl-0 = <&adc_in0_pa0>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &iwdg {
 	status = "okay";
 };

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -40,6 +40,7 @@
 		led0 = &green_led_2;
 		sw0 = &user_button;
 		watchdog0 = &iwdg;
+		die-temp0 = &die_temp;
 	};
 };
 
@@ -117,5 +118,9 @@
 };
 
 &iwdg {
+	status = "okay";
+};
+
+&die_temp {
 	status = "okay";
 };

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.yaml
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.yaml
@@ -16,6 +16,7 @@ supported:
   - spi
   - gpio
   - watchdog
+  - adc
 testing:
   ignore_tags:
     - net

--- a/tests/drivers/adc/adc_api/boards/nucleo_f030r8.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f030r8.overlay
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 TOKITA Hiroshi
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 0>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};


### PR DESCRIPTION
Add die-temp0 alias to die_temp node.
The `die_temp_polling` sample uses this alias.

And prior to that, I added a node for adc1 and enabled the ADC.
Die-temp sensor depends on ADC.
