### PR TITLE
drivers: spi: Make spi_context.h usable for CONFIG_MULTITHREADING=n

### DIFF
--- a/drivers/spi/spi_andes_atcspi200.c
+++ b/drivers/spi/spi_andes_atcspi200.c
@@ -400,8 +400,7 @@ static void spi_atcspi200_irq_handler(void *arg)
 
 #define SPI_INIT(n)								\
 	static struct spi_atcspi200_data spi_atcspi200_dev_data_##n = {		\
-		SPI_CONTEXT_INIT_LOCK(spi_atcspi200_dev_data_##n, ctx),		\
-		SPI_CONTEXT_INIT_SYNC(spi_atcspi200_dev_data_##n, ctx),		\
+		SPI_CONTEXT_BASE_INIT(spi_atcspi200_dev_data_##n, ctx),		\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)		\
 		SPI_IF_NO_CMD(n)						\
 		SPI_BUSY_INIT							\

--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -466,8 +466,7 @@ static struct spi_driver_api spi_b91_api = {
 	PINCTRL_DT_INST_DEFINE(inst);					  \
 									  \
 	static struct spi_b91_data spi_b91_data_##inst = {		  \
-		SPI_CONTEXT_INIT_LOCK(spi_b91_data_##inst, ctx),	  \
-		SPI_CONTEXT_INIT_SYNC(spi_b91_data_##inst, ctx),	  \
+		SPI_CONTEXT_BASE_INIT(spi_b91_data_##inst, ctx),	  \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(inst), ctx)	  \
 	};								  \
 									  \

--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -315,8 +315,7 @@ int spi_bitbang_init(const struct device *dev)
 	};								\
 									\
 	static struct spi_bitbang_data spi_bitbang_data_##inst = {	\
-		SPI_CONTEXT_INIT_LOCK(spi_bitbang_data_##inst, ctx),	\
-		SPI_CONTEXT_INIT_SYNC(spi_bitbang_data_##inst, ctx),	\
+		SPI_CONTEXT_BASE_INIT(spi_bitbang_data_##inst, ctx),	\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(inst), ctx)	\
 	};								\
 									\

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -323,8 +323,7 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 									\
 	static struct spi_cc13xx_cc26xx_data				\
 		spi_cc13xx_cc26xx_data_##n = {				\
-		SPI_CONTEXT_INIT_LOCK(spi_cc13xx_cc26xx_data_##n, ctx),	\
-		SPI_CONTEXT_INIT_SYNC(spi_cc13xx_cc26xx_data_##n, ctx),	\
+		SPI_CONTEXT_BASE_INIT(spi_cc13xx_cc26xx_data_##n, ctx),	\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
 									\

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -552,8 +552,7 @@ int spi_dw_init(const struct device *dev)
 void spi_config_0_irq(void);
 
 struct spi_dw_data spi_dw_data_port_0 = {
-	SPI_CONTEXT_INIT_LOCK(spi_dw_data_port_0, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_dw_data_port_0, ctx),
+	SPI_CONTEXT_BASE_INIT(spi_dw_data_port_0, ctx),
 	SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(0), ctx)
 };
 
@@ -616,8 +615,7 @@ void spi_config_0_irq(void)
 void spi_config_1_irq(void);
 
 struct spi_dw_data spi_dw_data_port_1 = {
-	SPI_CONTEXT_INIT_LOCK(spi_dw_data_port_1, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_dw_data_port_1, ctx),
+	SPI_CONTEXT_BASE_INIT(spi_dw_data_port_1, ctx),
 	SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(1), ctx)
 };
 
@@ -680,8 +678,7 @@ void spi_config_1_irq(void)
 void spi_config_2_irq(void);
 
 struct spi_dw_data spi_dw_data_port_2 = {
-	SPI_CONTEXT_INIT_LOCK(spi_dw_data_port_2, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_dw_data_port_2, ctx),
+	SPI_CONTEXT_BASE_INIT(spi_dw_data_port_2, ctx),
 	SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(2), ctx)
 };
 
@@ -744,8 +741,7 @@ void spi_config_2_irq(void)
 void spi_config_3_irq(void);
 
 struct spi_dw_data spi_dw_data_port_3 = {
-	SPI_CONTEXT_INIT_LOCK(spi_dw_data_port_3, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_dw_data_port_3, ctx),
+	SPI_CONTEXT_BASE_INIT(spi_dw_data_port_3, ctx),
 	SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(3), ctx)
 };
 

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -463,8 +463,7 @@ static const struct spi_driver_api spi_api = {
 	PINCTRL_DT_INST_DEFINE(idx);	\
 										\
 	static struct spi_esp32_data spi_data_##idx = {	\
-		SPI_CONTEXT_INIT_LOCK(spi_data_##idx, ctx),	\
-		SPI_CONTEXT_INIT_SYNC(spi_data_##idx, ctx),	\
+		SPI_CONTEXT_BASE_INIT(spi_data_##idx, ctx),	\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(idx), ctx)	\
 		.hal = {	\
 			.hw = (spi_dev_t *)DT_INST_REG_ADDR(idx),	\

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -666,8 +666,7 @@ int spi_gd32_init(const struct device *dev)
 	PINCTRL_DT_INST_DEFINE(idx);					       \
 	IF_ENABLED(CONFIG_SPI_GD32_INTERRUPT, (GD32_IRQ_CONFIGURE(idx)));      \
 	static struct spi_gd32_data spi_gd32_data_##idx = {		       \
-		SPI_CONTEXT_INIT_LOCK(spi_gd32_data_##idx, ctx),	       \
-		SPI_CONTEXT_INIT_SYNC(spi_gd32_data_##idx, ctx),	       \
+		SPI_CONTEXT_BASE_INIT(spi_gd32_data_##idx, ctx),	       \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(idx), ctx) };      \
 	static struct spi_gd32_config spi_gd32_config_##idx = {		       \
 		.reg = DT_INST_REG_ADDR(idx),				       \

--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -369,8 +369,7 @@ static struct spi_driver_api spi_gecko_api = {
 #define SPI_INIT(n)				    \
 	PINCTRL_DT_INST_DEFINE(n);			    \
 	static struct spi_gecko_data spi_gecko_data_##n = { \
-		SPI_CONTEXT_INIT_LOCK(spi_gecko_data_##n, ctx), \
-		SPI_CONTEXT_INIT_SYNC(spi_gecko_data_##n, ctx), \
+		SPI_CONTEXT_BASE_INIT(spi_gecko_data_##n, ctx), \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	}; \
 	static struct spi_gecko_config spi_gecko_cfg_##n = { \
@@ -390,8 +389,7 @@ static struct spi_driver_api spi_gecko_api = {
 #else
 #define SPI_INIT(n)				    \
 	static struct spi_gecko_data spi_gecko_data_##n = { \
-		SPI_CONTEXT_INIT_LOCK(spi_gecko_data_##n, ctx), \
-		SPI_CONTEXT_INIT_SYNC(spi_gecko_data_##n, ctx), \
+		SPI_CONTEXT_BASE_INIT(spi_gecko_data_##n, ctx), \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	}; \
 	static struct spi_gecko_config spi_gecko_cfg_##n = { \

--- a/drivers/spi/spi_litespi.c
+++ b/drivers/spi/spi_litespi.c
@@ -170,8 +170,7 @@ static struct spi_driver_api spi_litespi_api = {
 
 #define SPI_INIT(n)	\
 	static struct spi_litespi_data spi_litespi_data_##n = { \
-		SPI_CONTEXT_INIT_LOCK(spi_litespi_data_##n, ctx), \
-		SPI_CONTEXT_INIT_SYNC(spi_litespi_data_##n, ctx), \
+		SPI_CONTEXT_BASE_INIT(spi_litespi_data_##n, ctx), \
 	}; \
 	static struct spi_litespi_cfg spi_litespi_cfg_##n = { \
 		.base = DT_INST_REG_ADDR_BY_NAME(n, control), \

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -1025,8 +1025,7 @@ static const struct spi_stm32_config spi_stm32_cfg_##id = {		\
 };									\
 									\
 static struct spi_stm32_data spi_stm32_dev_data_##id = {		\
-	SPI_CONTEXT_INIT_LOCK(spi_stm32_dev_data_##id, ctx),		\
-	SPI_CONTEXT_INIT_SYNC(spi_stm32_dev_data_##id, ctx),		\
+	SPI_CONTEXT_BASE_INIT(spi_stm32_dev_data_##id, ctx),		\
 	SPI_DMA_CHANNEL(id, rx, RX, PERIPHERAL, MEMORY)			\
 	SPI_DMA_CHANNEL(id, tx, TX, MEMORY, PERIPHERAL)			\
 	SPI_DMA_STATUS_SEM(id)						\

--- a/drivers/spi/spi_mchp_mss_qspi.c
+++ b/drivers/spi/spi_mchp_mss_qspi.c
@@ -586,8 +586,7 @@ static const struct spi_driver_api mss_qspi_driver_api = {
 	};								\
 									\
 	static struct mss_qspi_data mss_qspi_data_##n = {	\
-		SPI_CONTEXT_INIT_LOCK(mss_qspi_data_##n, ctx),	\
-		SPI_CONTEXT_INIT_SYNC(mss_qspi_data_##n, ctx),	\
+		SPI_CONTEXT_BASE_INIT(mss_qspi_data_##n, ctx),	\
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n, &mss_qspi_init,			\

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -881,8 +881,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	TX_BUFFER(id);							\
 	RX_BUFFER(id);							\
 	static struct spi_mcux_data spi_mcux_data_##id = {		\
-		SPI_CONTEXT_INIT_LOCK(spi_mcux_data_##id, ctx),		\
-		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##id, ctx),		\
+		SPI_CONTEXT_BASE_INIT(spi_mcux_data_##id, ctx),		\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(id), ctx)	\
 		TX_DMA_CONFIG(id) RX_DMA_CONFIG(id)			\
 	};								\

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -834,8 +834,7 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),		\
 	};								\
 	static struct spi_mcux_data spi_mcux_data_##id = {		\
-		SPI_CONTEXT_INIT_LOCK(spi_mcux_data_##id, ctx),		\
-		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##id, ctx),		\
+		SPI_CONTEXT_BASE_INIT(spi_mcux_data_##id, ctx),		\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(id), ctx)	\
 		SPI_DMA_CHANNELS(id)		\
 	};								\

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -638,8 +638,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	};								\
 									\
 	static struct spi_mcux_data spi_mcux_data_##n = {		\
-		SPI_CONTEXT_INIT_LOCK(spi_mcux_data_##n, ctx),		\
-		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##n, ctx),		\
+		SPI_CONTEXT_BASE_INIT(spi_mcux_data_##n, ctx),		\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 		SPI_DMA_CHANNELS(n)					\
 	};								\

--- a/drivers/spi/spi_npcx_fiu.c
+++ b/drivers/spi/spi_npcx_fiu.c
@@ -175,7 +175,7 @@ static const struct npcx_spi_fiu_config npcx_spi_fiu_config = {
 };
 
 static struct npcx_spi_fiu_data npcx_spi_fiu_data = {
-	SPI_CONTEXT_INIT_LOCK(npcx_spi_fiu_data, ctx),
+	SPI_CONTEXT_BASE_INIT(npcx_spi_fiu_data, ctx),
 };
 
 DEVICE_DT_INST_DEFINE(0, &spi_npcx_fiu_init, NULL, &npcx_spi_fiu_data,

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -393,8 +393,7 @@ static int spi_nrfx_init(const struct device *dev)
 			    nrfx_isr, nrfx_spi_##idx##_irq_handler, 0);	       \
 	}								       \
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
-		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \
-		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
+		SPI_CONTEXT_BASE_INIT(spi_##idx##_data, ctx),		       \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(SPI(idx), ctx)		       \
 		.dev  = DEVICE_DT_GET(SPI(idx)),			       \
 		.busy = false,						       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -576,8 +576,7 @@ static int spi_nrfx_init(const struct device *dev)
 			[CONFIG_SPI_NRFX_RAM_BUFFER_SIZE]		       \
 			SPIM_MEMORY_SECTION(idx);))			       \
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
-		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \
-		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
+		SPI_CONTEXT_BASE_INIT(spi_##idx##_data, ctx),		       \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(SPIM(idx), ctx)		       \
 		IF_ENABLED(SPI_BUFFER_IN_RAM,				       \
 			(.buffer = spim_##idx##_buffer,))		       \

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -271,8 +271,7 @@ static int spi_nrfx_init(const struct device *dev)
 			    nrfx_isr, nrfx_spis_##idx##_irq_handler, 0);       \
 	}								       \
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
-		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \
-		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
+		SPI_CONTEXT_BASE_INIT(spi_##idx##_data, ctx),		       \
 	};								       \
 	PINCTRL_DT_DEFINE(SPIS(idx));					       \
 	static const struct spi_nrfx_config spi_##idx##z_config = {	       \

--- a/drivers/spi/spi_nxp_s32.c
+++ b/drivers/spi/spi_nxp_s32.c
@@ -665,8 +665,7 @@ static const struct spi_driver_api spi_nxp_s32_driver_api = {
 	};										\
 	static struct spi_nxp_s32_data spi_nxp_s32_data_##n = {				\
 		SPI_NXP_S32_TRANSFER_CONFIG(n),						\
-		SPI_CONTEXT_INIT_LOCK(spi_nxp_s32_data_##n, ctx),			\
-		SPI_CONTEXT_INIT_SYNC(spi_nxp_s32_data_##n, ctx),			\
+		SPI_CONTEXT_BASE_INIT(spi_nxp_s32_data_##n, ctx),			\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(SPI_NXP_S32_NODE(n), ctx)		\
 	};										\
 	DEVICE_DT_DEFINE(SPI_NXP_S32_NODE(n),						\

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -221,8 +221,7 @@ int spi_oc_simple_init(const struct device *dev)
 	};								\
 									\
 	static struct spi_oc_simple_data spi_oc_simple_data_##inst = {	\
-		SPI_CONTEXT_INIT_LOCK(spi_oc_simple_data_##inst, ctx),	\
-		SPI_CONTEXT_INIT_SYNC(spi_oc_simple_data_##inst, ctx),	\
+		SPI_CONTEXT_BASE_INIT(spi_oc_simple_data_##inst, ctx),	\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(inst), ctx) \
 	};								\
 									\

--- a/drivers/spi/spi_pl022.c
+++ b/drivers/spi/spi_pl022.c
@@ -962,8 +962,7 @@ static int spi_pl022_init(const struct device *dev)
 			   irq_enable(DT_INST_IRQN(idx));                                          \
 		    }))                                                                            \
 	static struct spi_pl022_data spi_pl022_data_##idx = {                                      \
-		SPI_CONTEXT_INIT_LOCK(spi_pl022_data_##idx, ctx),                                  \
-		SPI_CONTEXT_INIT_SYNC(spi_pl022_data_##idx, ctx),                                  \
+		SPI_CONTEXT_BASE_INIT(spi_pl022_data_##idx, ctx),                                  \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(idx), ctx)};                           \
 	static struct spi_pl022_cfg spi_pl022_cfg_##idx = {                                        \
 		.reg = DT_INST_REG_ADDR(idx),                                                      \

--- a/drivers/spi/spi_psoc6.c
+++ b/drivers/spi/spi_psoc6.c
@@ -417,8 +417,7 @@ static const struct spi_driver_api spi_psoc6_driver_api = {
 		.irq_config_func = spi_psoc6_spi##n##_irq_cfg,		\
 	};								\
 	static struct spi_psoc6_data spi_psoc6_dev_data_##n = {		\
-		SPI_CONTEXT_INIT_LOCK(spi_psoc6_dev_data_##n, ctx),	\
-		SPI_CONTEXT_INIT_SYNC(spi_psoc6_dev_data_##n, ctx),	\
+		SPI_CONTEXT_BASE_INIT(spi_psoc6_dev_data_##n, ctx),	\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
 	DEVICE_DT_INST_DEFINE(n, &spi_psoc6_init, NULL,			\

--- a/drivers/spi/spi_pw.c
+++ b/drivers/spi/spi_pw.c
@@ -853,8 +853,7 @@ static int spi_pw_init(const struct device *dev)
 
 #define SPI_PW_DEV_INIT(n)					     \
 	static struct spi_pw_data spi_##n##_data = {		     \
-		SPI_CONTEXT_INIT_LOCK(spi_##n##_data, ctx),	     \
-		SPI_CONTEXT_INIT_SYNC(spi_##n##_data, ctx),	     \
+		SPI_CONTEXT_BASE_INIT(spi_##n##_data, ctx),	     \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx) \
 		.cs_mode = DT_INST_PROP(n, pw_cs_mode),		     \
 		.cs_output = DT_INST_PROP(n, pw_cs_output),	     \
@@ -875,8 +874,7 @@ static int spi_pw_init(const struct device *dev)
 
 #define SPI_PW_DEV_INIT(n)					     \
 	static struct spi_pw_data spi_##n##_data = {		     \
-		SPI_CONTEXT_INIT_LOCK(spi_##n##_data, ctx),	     \
-		SPI_CONTEXT_INIT_SYNC(spi_##n##_data, ctx),	     \
+		SPI_CONTEXT_BASE_INIT(spi_##n##_data, ctx),	     \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx) \
 		.cs_mode = DT_INST_PROP(n, pw_cs_mode),		     \
 		.cs_output = DT_INST_PROP(n, pw_cs_output),	     \

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -319,8 +319,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	};								\
 									\
 	static struct spi_mcux_data spi_mcux_data_##n = {		\
-		SPI_CONTEXT_INIT_LOCK(spi_mcux_data_##n, ctx),		\
-		SPI_CONTEXT_INIT_SYNC(spi_mcux_data_##n, ctx),		\
+		SPI_CONTEXT_BASE_INIT(spi_mcux_data_##n, ctx),		\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
 									\

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -914,8 +914,7 @@ static const struct spi_driver_api spi_sam_driver_api = {
 	SPI_SAM_DEFINE_CONFIG(n);								\
 	COND_CODE_1(CONFIG_SPI_RTIO, (SPI_SAM_RTIO_DEFINE(n)), ());				\
 	static struct spi_sam_data spi_sam_dev_data_##n = {					\
-		SPI_CONTEXT_INIT_LOCK(spi_sam_dev_data_##n, ctx),				\
-		SPI_CONTEXT_INIT_SYNC(spi_sam_dev_data_##n, ctx),				\
+		SPI_CONTEXT_BASE_INIT(spi_sam_dev_data_##n, ctx),				\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)				\
 		IF_ENABLED(CONFIG_SPI_RTIO, (.r = &spi_sam_rtio_##n))				\
 	};											\

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -740,8 +740,7 @@ static const struct spi_sam0_config spi_sam0_config_##n = {		\
 	PINCTRL_DT_INST_DEFINE(n);					\
 	SPI_SAM0_DEFINE_CONFIG(n);					\
 	static struct spi_sam0_data spi_sam0_dev_data_##n = {		\
-		SPI_CONTEXT_INIT_LOCK(spi_sam0_dev_data_##n, ctx),	\
-		SPI_CONTEXT_INIT_SYNC(spi_sam0_dev_data_##n, ctx),	\
+		SPI_CONTEXT_BASE_INIT(spi_sam0_dev_data_##n, ctx),	\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
 	DEVICE_DT_INST_DEFINE(n, &spi_sam0_init, NULL,			\

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -280,8 +280,7 @@ static struct spi_driver_api spi_sifive_api = {
 #define SPI_INIT(n)	\
 	PINCTRL_DT_INST_DEFINE(n); \
 	static struct spi_sifive_data spi_sifive_data_##n = { \
-		SPI_CONTEXT_INIT_LOCK(spi_sifive_data_##n, ctx), \
-		SPI_CONTEXT_INIT_SYNC(spi_sifive_data_##n, ctx), \
+		SPI_CONTEXT_BASE_INIT(spi_sifive_data_##n, ctx), \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	}; \
 	static struct spi_sifive_cfg spi_sifive_cfg_##n = { \

--- a/drivers/spi/spi_smartbond.c
+++ b/drivers/spi/spi_smartbond.c
@@ -281,8 +281,7 @@ static int spi_smartbond_init(const struct device *dev)
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),                                        \
 	};                                                                                         \
 	static struct spi_smartbond_data spi_smartbond_##id##_data = {                             \
-		SPI_CONTEXT_INIT_LOCK(spi_smartbond_##id##_data, ctx),                             \
-		SPI_CONTEXT_INIT_SYNC(spi_smartbond_##id##_data, ctx),                             \
+		SPI_CONTEXT_BASE_INIT(spi_smartbond_##id##_data, ctx),                             \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(id), ctx)};                            \
 	DEVICE_DT_INST_DEFINE(id, spi_smartbond_init, NULL, &spi_smartbond_##id##_data,            \
 			      &spi_smartbond_##id##_cfg, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,    \

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -694,8 +694,7 @@ static const struct spi_qmspi_config spi_qmspi_0_config = {
 };
 
 static struct spi_qmspi_data spi_qmspi_0_dev_data = {
-	SPI_CONTEXT_INIT_LOCK(spi_qmspi_0_dev_data, ctx),
-	SPI_CONTEXT_INIT_SYNC(spi_qmspi_0_dev_data, ctx),
+	SPI_CONTEXT_BASE_INIT(spi_qmspi_0_dev_data, ctx),
 	SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(0), ctx)
 };
 

--- a/drivers/spi/spi_xec_qmspi_ldma.c
+++ b/drivers/spi/spi_xec_qmspi_ldma.c
@@ -1048,8 +1048,7 @@ static const struct spi_driver_api spi_qmspi_xec_driver_api = {
 	}								\
 									\
 	static struct spi_qmspi_data qmspi_xec_data_##i = {		\
-		SPI_CONTEXT_INIT_LOCK(qmspi_xec_data_##i, ctx),		\
-		SPI_CONTEXT_INIT_SYNC(qmspi_xec_data_##i, ctx),		\
+		SPI_CONTEXT_BASE_INIT(qmspi_xec_data_##i, ctx),		\
 	};								\
 	static const struct spi_qmspi_config qmspi_xec_config_##i = {	\
 		.regs = (struct qmspi_regs *) DT_INST_REG_ADDR(i),	\

--- a/drivers/spi/spi_xlnx_axi_quadspi.c
+++ b/drivers/spi/spi_xlnx_axi_quadspi.c
@@ -484,8 +484,7 @@ static const struct spi_driver_api xlnx_quadspi_driver_api = {
 	};								\
 									\
 	static struct xlnx_quadspi_data xlnx_quadspi_data_##n = {	\
-		SPI_CONTEXT_INIT_LOCK(xlnx_quadspi_data_##n, ctx),	\
-		SPI_CONTEXT_INIT_SYNC(xlnx_quadspi_data_##n, ctx),	\
+		SPI_CONTEXT_BASE_INIT(xlnx_quadspi_data_##n, ctx),	\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
 									\

--- a/drivers/spi/spi_xmc4xxx.c
+++ b/drivers/spi/spi_xmc4xxx.c
@@ -667,8 +667,7 @@ static const struct spi_driver_api spi_xmc4xxx_driver_api = {
 	XMC4XXX_IRQ_HANDLER_INIT(index)                                                            \
 	static struct spi_xmc4xxx_data xmc4xxx_data_##index = {                                    \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(index), ctx)                           \
-			SPI_CONTEXT_INIT_LOCK(xmc4xxx_data_##index, ctx),                          \
-		SPI_CONTEXT_INIT_SYNC(xmc4xxx_data_##index, ctx),                                  \
+		SPI_CONTEXT_BASE_INIT(xmc4xxx_data_##index, ctx),                                  \
 		SPI_DMA_CHANNEL(index, tx, MEMORY_TO_PERIPHERAL, 8, 1)                             \
 		SPI_DMA_CHANNEL(index, rx, PERIPHERAL_TO_MEMORY, 1, 8)};                           \
                                                                                                    \


### PR DESCRIPTION
`drivers/flash/spi_nor.c` supports `CONFIG_MULTITHREADING=n` however spi drivers using `spi_context.h` can't.

This commit makes `spi_context.h` usable for single threaded applications by removing `k_sem lock` and `k_sem sync` for `CONFIG_MULTITHREADING=n`, and introduces a new macro `SPI_CONTEXT_BASE_INIT()` for both `CONFIG_MULTITHREADING=y` and `n`.

This reduces about 3KB.

With CONFIG_MULTITHREADING=n

    Memory region         Used Size  Region Size  %age Used
               FLASH:          0 GB         0 GB
                 RAM:       12260 B       128 KB      9.35%
            IDT_LIST:          0 GB         2 KB      0.00%

With CONFIG_MULTITHREADING=y

    Memory region         Used Size  Region Size  %age Used
               FLASH:          0 GB         0 GB
                 RAM:       15556 B       128 KB     11.87%
            IDT_LIST:          0 GB         2 KB      0.00%

`spi_context_cs_configure_all()`, `_spi_context_cs_control()`, and `spi_context_cs_control()` are move above `#ifndef CONFIG_MULTITHREADING` in order to group the related functions under one `#ifdef`.