### PR TITLE
posix: sched: ensure min and max priority are schedulable

### DIFF
--- a/include/zephyr/posix/sched.h
+++ b/include/zephyr/posix/sched.h
@@ -6,9 +6,18 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SCHED_H_
 #define ZEPHYR_INCLUDE_POSIX_SCHED_H_
 
+#include <zephyr/kernel.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/*
+ * Other mandatory scheduling policy. Must be numerically distinct. May
+ * execute identically to SCHED_RR or SCHED_FIFO. For Zephyr this is a
+ * pseudonym for SCHED_RR.
+ */
+#define SCHED_OTHER 0
 
 /* Cooperative scheduling policy */
 #define SCHED_FIFO 1

--- a/lib/posix/posix_internal.h
+++ b/lib/posix/posix_internal.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_LIB_POSIX_POSIX_INTERNAL_H_
 #define ZEPHYR_LIB_POSIX_POSIX_INTERNAL_H_
 
+#include <zephyr/kernel.h>
+
 /*
  * Bit used to mark a pthread object as initialized. Initialization status is
  * verified (against internal status) in lock / unlock / destroy functions.

--- a/lib/posix/pthread_sched.c
+++ b/lib/posix/pthread_sched.c
@@ -4,13 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "pthread_sched.h"
+
 #include <zephyr/kernel.h>
 #include <zephyr/posix/sched.h>
-
-static inline bool valid_posix_policy(int policy)
-{
-	return policy == SCHED_FIFO || policy == SCHED_RR;
-}
 
 /**
  * @brief Get minimum priority value for a given policy
@@ -36,7 +33,8 @@ int sched_get_priority_max(int policy)
 {
 	if (IS_ENABLED(CONFIG_COOP_ENABLED) && policy == SCHED_FIFO) {
 		return CONFIG_NUM_COOP_PRIORITIES - 1;
-	} else if (IS_ENABLED(CONFIG_PREEMPT_ENABLED) && policy == SCHED_RR) {
+	} else if (IS_ENABLED(CONFIG_PREEMPT_ENABLED) &&
+		   (policy == SCHED_RR || policy == SCHED_OTHER)) {
 		return CONFIG_NUM_PREEMPT_PRIORITIES - 1;
 	}
 

--- a/lib/posix/pthread_sched.h
+++ b/lib/posix/pthread_sched.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_POSIX_POSIX_PTHREAD_SCHED_H_
+#define ZEPHYR_LIB_POSIX_POSIX_PTHREAD_SCHED_H_
+
+#include <stdbool.h>
+
+#include <zephyr/posix/sched.h>
+
+static inline bool valid_posix_policy(int policy)
+{
+	return policy == SCHED_FIFO || policy == SCHED_RR || policy == SCHED_OTHER;
+}
+
+#endif

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -618,26 +618,31 @@ ZTEST(posix_apis, test_sched_policy)
 	static const int policies[] = {
 		SCHED_FIFO,
 		SCHED_RR,
+		SCHED_OTHER,
 		SCHED_INVALID,
 	};
 	static const char *const policy_names[] = {
 		"SCHED_FIFO",
 		"SCHED_RR",
+		"SCHED_OTHER",
 		"SCHED_INVALID",
 	};
 	static const bool policy_enabled[] = {
 		IS_ENABLED(CONFIG_COOP_ENABLED),
+		IS_ENABLED(CONFIG_PREEMPT_ENABLED),
 		IS_ENABLED(CONFIG_PREEMPT_ENABLED),
 		false,
 	};
 	static int nprio[] = {
 		CONFIG_NUM_COOP_PRIORITIES,
 		CONFIG_NUM_PREEMPT_PRIORITIES,
+		CONFIG_NUM_PREEMPT_PRIORITIES,
 		42,
 	};
 	const char *const prios[] = {"pmin", "pmax"};
 
-	BUILD_ASSERT(!(SCHED_INVALID == SCHED_FIFO || SCHED_INVALID == SCHED_RR),
+	BUILD_ASSERT(!(SCHED_INVALID == SCHED_FIFO || SCHED_INVALID == SCHED_RR ||
+		       SCHED_INVALID == SCHED_OTHER),
 		     "SCHED_INVALID is itself invalid");
 
 	for (int policy = 0; policy < ARRAY_SIZE(policies); ++policy) {

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -598,3 +598,132 @@ ZTEST(posix_apis, test_pthread_descriptor_leak)
 		zassert_ok(pthread_join(pthread1, &unused), "unable to join thread %zu", i);
 	}
 }
+
+ZTEST(posix_apis, test_sched_policy)
+{
+	/*
+	 * TODO:
+	 * 1. assert that _POSIX_PRIORITY_SCHEDULING is defined
+	 * 2. if _POSIX_SPORADIC_SERVER or _POSIX_THREAD_SPORADIC_SERVER are defined,
+	 *    also check SCHED_SPORADIC
+	 * 3. SCHED_OTHER is mandatory (but may be equivalent to SCHED_FIFO or SCHED_RR,
+	 *    and is implementation defined)
+	 */
+
+	int pmin;
+	int pmax;
+	pthread_t th;
+	pthread_attr_t attr;
+	struct sched_param param;
+	static const int policies[] = {
+		SCHED_FIFO,
+		SCHED_RR,
+		SCHED_INVALID,
+	};
+	static const char *const policy_names[] = {
+		"SCHED_FIFO",
+		"SCHED_RR",
+		"SCHED_INVALID",
+	};
+	static const bool policy_enabled[] = {
+		IS_ENABLED(CONFIG_COOP_ENABLED),
+		IS_ENABLED(CONFIG_PREEMPT_ENABLED),
+		false,
+	};
+	static int nprio[] = {
+		CONFIG_NUM_COOP_PRIORITIES,
+		CONFIG_NUM_PREEMPT_PRIORITIES,
+		42,
+	};
+	const char *const prios[] = {"pmin", "pmax"};
+
+	BUILD_ASSERT(!(SCHED_INVALID == SCHED_FIFO || SCHED_INVALID == SCHED_RR),
+		     "SCHED_INVALID is itself invalid");
+
+	for (int policy = 0; policy < ARRAY_SIZE(policies); ++policy) {
+		if (!policy_enabled[policy]) {
+			/* test degenerate cases */
+			errno = 0;
+			zassert_equal(-1, sched_get_priority_min(policies[policy]),
+				      "expected sched_get_priority_min(%s) to fail",
+				      policy_names[policy]);
+			zassert_equal(EINVAL, errno, "sched_get_priority_min(%s) did not set errno",
+				      policy_names[policy]);
+
+			errno = 0;
+			zassert_equal(-1, sched_get_priority_max(policies[policy]),
+				      "expected sched_get_priority_max(%s) to fail",
+				      policy_names[policy]);
+			zassert_equal(EINVAL, errno, "sched_get_priority_max(%s) did not set errno",
+				      policy_names[policy]);
+			continue;
+		}
+
+		/* get pmin and pmax for policies[policy] */
+		for (int i = 0; i < 2; ++i) {
+			errno = 0;
+			if (i == 0) {
+				pmin = sched_get_priority_min(policies[policy]);
+				param.sched_priority = pmin;
+			} else {
+				pmax = sched_get_priority_max(policies[policy]);
+				param.sched_priority = pmax;
+			}
+
+			zassert_not_equal(-1, param.sched_priority,
+					  "sched_get_priority_%s(%s) failed: %d",
+					  i == 0 ? "min" : "max", policy_names[policy], errno);
+			zassert_ok(errno, "sched_get_priority_%s(%s) set errno to %s",
+				   i == 0 ? "min" : "max", policy_names[policy], errno);
+		}
+
+		/*
+		 * IEEE 1003.1-2008 Section 2.8.4
+		 * conforming implementations should provide a range of at least 32 priorities
+		 *
+		 * Note: we relax this requirement
+		 */
+		zassert_true(pmax > pmin, "pmax (%d) <= pmin (%d)", pmax, pmin,
+			     "%s min/max inconsistency: pmin: %d pmax: %d", policy_names[policy],
+			     pmin, pmax);
+
+		/*
+		 * Getting into the weeds a bit (i.e. whitebox testing), Zephyr
+		 * cooperative threads use [-CONFIG_NUM_COOP_PRIORITIES,-1] and
+		 * preemptive threads use [0, CONFIG_NUM_PREEMPT_PRIORITIES - 1],
+		 * where the more negative thread has the higher priority. Since we
+		 * cannot map those directly (a return value of -1 indicates error),
+		 * we simply map those to the positive space.
+		 */
+		zassert_equal(pmin, 0, "unexpected pmin for %s", policy_names[policy]);
+		zassert_equal(pmax, nprio[policy] - 1, "unexpected pmax for %s",
+			      policy_names[policy]); /* test happy paths */
+
+		for (int i = 0; i < 2; ++i) {
+			/* create threads with min and max priority levels */
+			zassert_ok(pthread_attr_init(&attr),
+				   "pthread_attr_init() failed for %s (%d) of %s", prios[i],
+				   param.sched_priority, policy_names[policy]);
+
+			zassert_ok(pthread_attr_setschedpolicy(&attr, policies[policy]),
+				   "pthread_attr_setschedpolicy() failed for %s (%d) of %s",
+				   prios[i], param.sched_priority, policy_names[policy]);
+
+			zassert_ok(pthread_attr_setschedparam(&attr, &param),
+				   "pthread_attr_setschedparam() failed for %s (%d) of %s",
+				   prios[i], param.sched_priority, policy_names[policy]);
+
+			zassert_ok(pthread_attr_setstack(&attr, &stack_e[0][0], STACKS),
+				   "pthread_attr_setstack() failed for %s (%d) of %s", prios[i],
+				   param.sched_priority, policy_names[policy]);
+
+			zassert_ok(pthread_create(&th, &attr, create_thread1, NULL),
+				   "pthread_create() failed for %s (%d) of %s", prios[i],
+				   param.sched_priority, policy_names[policy]);
+
+			zassert_ok(pthread_join(th, NULL),
+				   "pthread_join() failed for %s (%d) of %s", prios[i],
+				   param.sched_priority, policy_names[policy]);
+		}
+	}
+}


### PR DESCRIPTION
Previously, with preemptive scheduling, minimum priority threads were not schedulable. The linked issue appears to highlight an off-by-one error as well, which I believe should be fixed here.

Also add `SCHED_OTHER` support, which is mandatory (separate commits)

Fixes #56729