### PR TITLE
Bluetooth: Mesh: Add callback for received beacons

### DIFF
--- a/include/zephyr/bluetooth/mesh/main.h
+++ b/include/zephyr/bluetooth/mesh/main.h
@@ -762,6 +762,73 @@ struct bt_mesh_friend_cb {
 	static const STRUCT_SECTION_ITERABLE(bt_mesh_friend_cb,          \
 					     _CONCAT(bt_mesh_friend_cb_, \
 						     _name))
+#if defined(CONFIG_BT_TESTING)
+struct bt_mesh_snb {
+	/** Flags */
+	uint8_t flags;
+
+	/** Network ID */
+	uint64_t net_id;
+
+	/** IV Index */
+	uint32_t iv_idx;
+
+	/** Authentication Value */
+	uint64_t auth_val;
+};
+
+#if defined(CONFIG_BT_MESH_V1d1)
+struct bt_mesh_prb {
+	/** Random */
+	uint8_t random[13];
+
+	/** Flags */
+	uint8_t flags;
+
+	/** IV Index */
+	uint32_t iv_idx;
+
+	/** Authentication tag */
+	uint64_t auth_tag;
+};
+#endif
+
+/** Beacon callback functions. */
+struct bt_mesh_beacon_cb {
+	/** @brief Secure Network Beacon received.
+	 *
+	 *  This callback notifies the application that Secure Network Beacon
+	 *  was received.
+	 *
+	 *  @param snb  Structure describing received Secure Network Beacon
+	 */
+	void (*snb_received)(const struct bt_mesh_snb *snb);
+
+#if defined(CONFIG_BT_MESH_V1d1)
+	/** @brief Private Beacon received.
+	 *
+	 *  This callback notifies the application that Private Beacon
+	 *  was received and successfully decrypted.
+	 *
+	 *  @param prb  Structure describing received Private Beacon
+	 */
+	void (*priv_received)(const struct bt_mesh_prb *prb);
+#endif
+};
+
+/**
+ *  @brief Register a callback structure for beacon events.
+ *
+ *  Registers a callback structure that will be called whenever beacon advertisement
+ *  is received.
+ *
+ *  @param _name Name of callback structure.
+ */
+#define BT_MESH_BEACON_CB_DEFINE(_name)                                  \
+	static const STRUCT_SECTION_ITERABLE(bt_mesh_beacon_cb,          \
+					     _CONCAT(bt_mesh_beacon_cb_, \
+						     _name))
+#endif
 
 /** @brief Terminate Friendship.
  *

--- a/include/zephyr/linker/common-rom/common-rom-bt.ld
+++ b/include/zephyr/linker/common-rom/common-rom-bt.ld
@@ -17,6 +17,10 @@
 	ITERABLE_SECTION_ROM(bt_mesh_app_key_cb, 4)
 
 	ITERABLE_SECTION_ROM(bt_mesh_hb_cb, 4)
+
+#if defined(CONFIG_BT_TESTING)
+	ITERABLE_SECTION_ROM(bt_mesh_beacon_cb, 4)
+#endif
 #endif
 
 #if defined(CONFIG_BT_MESH_FRIEND)


### PR DESCRIPTION
This adds callbacks for Secure and Private Network Beacons. SNB callbacks are called after `secure_beacon_authenticate` ends with success, and Private Beacon callback after Private Beacon payload is decrypted succsessfully.