### PR TITLE
Bluetooth: BAP: Fix guards for specific build configurations

### DIFF
--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -160,11 +160,13 @@ enum bt_bap_ascs_reason bt_audio_verify_qos(const struct bt_codec_qos *qos)
 		return BT_BAP_ASCS_REASON_SDU;
 	}
 
+#if defined(CONFIG_BT_BAP_BROADCAST_SOURCE) || defined(CONFIG_BT_BAP_UNICAST)
 	if (qos->latency < BT_ISO_LATENCY_MIN ||
 	    qos->latency > BT_ISO_LATENCY_MAX) {
 		LOG_DBG("Invalid Latency %u", qos->latency);
 		return BT_BAP_ASCS_REASON_LATENCY;
 	}
+#endif /* CONFIG_BT_BAP_BROADCAST_SOURCE || CONFIG_BT_BAP_UNICAST */
 
 	if (qos->pd > BT_AUDIO_PD_MAX) {
 		LOG_DBG("Invalid presentation delay %u", qos->pd);

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -134,7 +134,6 @@ int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info)
 	return 0;
 }
 
-#if defined(CONFIG_BT_AUDIO_TX)
 enum bt_bap_ascs_reason bt_audio_verify_qos(const struct bt_codec_qos *qos)
 {
 	if (qos->interval < BT_ISO_SDU_INTERVAL_MIN ||
@@ -226,6 +225,7 @@ bool bt_audio_valid_codec(const struct bt_codec *codec)
 	return true;
 }
 
+#if defined(CONFIG_BT_AUDIO_TX)
 int bt_bap_stream_send(struct bt_bap_stream *stream, struct net_buf *buf,
 			 uint16_t seq_num, uint32_t ts)
 {

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -237,6 +237,22 @@ tests:
     platform_allow: native_posix
     extra_configs:
       - CONFIG_BT_BAP_BROADCAST_SINK=n
+  bluetooth.audio_shell.no_audio_tx:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_BT_BAP_BROADCAST_SOURCE=n
+      - CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT=0
+      - CONFIG_BT_ASCS_ASE_SRC_COUNT=0
+  bluetooth.audio_shell.no_audio_rx:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_BT_BAP_BROADCAST_SINK=n
+      - CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT=0
+      - CONFIG_BT_ASCS_ASE_SNK_COUNT=0
   bluetooth.audio_shell.no_has:
     extra_args: CONF_FILE="audio.conf"
     build_only: true


### PR DESCRIPTION
Move the BT_AUDIO_TX guard so that it does not cover the verification functions for valid_codec and qos, as they are also relevant for receivers to verify what remote devices send.