### PR TITLE
Bluetooth: Controller: Fix endianness handling for DID/SID struct

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5938,7 +5938,7 @@ static void dup_periodic_adv_reset(uint8_t addr_type, const uint8_t *addr,
 			struct dup_ext_adv_set *adv_set;
 
 			adv_set = &dup_mode->set[set_idx];
-			if (adv_set->adi.sid != sid) {
+			if (PDU_ADV_ADI_SID_GET(&adv_set->adi) != sid) {
 				continue;
 			}
 
@@ -5985,13 +5985,14 @@ static inline bool is_dup_or_update(struct dup_entry *dup, uint8_t adv_type,
 			struct dup_ext_adv_set *adv_set;
 
 			adv_set = &dup_mode->set[j];
-			if (adv_set->adi.sid != adi->sid) {
+			if (PDU_ADV_ADI_SID_GET(&adv_set->adi) != PDU_ADV_ADI_SID_GET(adi)) {
 				continue;
 			}
 
-			if (adv_set->adi.did != adi->did) {
+			if (PDU_ADV_ADI_DID_GET(&adv_set->adi) != PDU_ADV_ADI_DID_GET(adi)) {
 				/* report different DID */
-				adv_set->adi.did = adi->did;
+				adv_set->adi.did_sid_packed[0] = adi->did_sid_packed[0];
+				adv_set->adi.did_sid_packed[1] = adi->did_sid_packed[1];
 				/* set new data status */
 				if (data_status == BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_COMPLETE) {
 					adv_set->data_cmplt = 1U;
@@ -6586,7 +6587,7 @@ static void ext_adv_info_fill(uint8_t evt_type, uint8_t phy, uint8_t sec_phy,
 
 	adv_info->prim_phy = find_lsb_set(phy);
 	adv_info->sec_phy = sec_phy;
-	adv_info->sid = (adi) ? adi->sid : BT_HCI_LE_EXT_ADV_SID_INVALID;
+	adv_info->sid = (adi) ? PDU_ADV_ADI_SID_GET(adi) : BT_HCI_LE_EXT_ADV_SID_INVALID;
 	adv_info->tx_power = tx_pwr;
 	adv_info->rssi = rssi;
 	adv_info->interval = interval_le16;
@@ -6856,8 +6857,8 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 
 			ptr += sizeof(*adi);
 
-			LOG_DBG("    AdvDataInfo DID = 0x%x, SID = 0x%x", adi_curr->did,
-				adi_curr->sid);
+			LOG_DBG("    AdvDataInfo DID = 0x%x, SID = 0x%x",
+				PDU_ADV_ADI_DID_GET(adi_curr), PDU_ADV_ADI_SID_GET(adi_curr));
 		}
 
 		if (h->aux_ptr) {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -607,7 +607,7 @@ uint8_t ll_adv_params_set(uint16_t interval, uint8_t adv_type,
 				sizeof(struct pdu_adv_adi));
 
 			adi = (void *)pri_dptr;
-			adi->sid = sid;
+			PDU_ADV_ADI_SID_SET(adi, sid);
 		}
 		adv->sid = sid;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -1892,19 +1892,17 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	pri_adi = (void *)pri_dptr;
 	sec_adi = (void *)sec_dptr;
 
-	pri_adi->sid = adv->sid;
-	sec_adi->sid = adv->sid;
-
 	if (!adi) {
 		/* The DID for a specific SID shall be unique.
 		 */
 		did = ull_adv_aux_did_next_unique_get(adv->sid);
 	} else {
-		did = adi->did;
+		did = PDU_ADV_ADI_DID_GET(adi);
 	}
 
-	pri_adi->did = sys_cpu_to_le16(did);
-	sec_adi->did = sys_cpu_to_le16(did);
+	did = sys_cpu_to_le16(did);
+	PDU_ADV_ADI_DID_SID_SET(pri_adi, did, adv->sid);
+	PDU_ADV_ADI_DID_SID_SET(sec_adi, did, adv->sid);
 
 	/* No CTEInfo field in primary channel PDU */
 
@@ -2335,16 +2333,14 @@ uint8_t ull_adv_aux_pdu_set_clear(struct ll_adv_set *adv,
 		adi_pdu = (void *)dptr;
 
 		if (!adi) {
-			adi_pdu->sid = adv->sid;
-
 			/* The DID for a specific SID shall be unique.
 			 */
 			const uint16_t did =
-				ull_adv_aux_did_next_unique_get(adv->sid);
-			adi_pdu->did = sys_cpu_to_le16(did);
+				sys_cpu_to_le16(ull_adv_aux_did_next_unique_get(adv->sid));
+			PDU_ADV_ADI_DID_SID_SET(adi_pdu, did, adv->sid);
 		} else {
-			adi_pdu->sid = adi->sid;
-			adi_pdu->did = adi->did;
+			adi_pdu->did_sid_packed[0] = adi->did_sid_packed[0];
+			adi_pdu->did_sid_packed[1] = adi->did_sid_packed[1];
 		}
 	}
 
@@ -2840,10 +2836,11 @@ void ull_adv_aux_chain_pdu_duplicate(struct pdu_adv *pdu_prev,
 		if (hdr_chain->adi) {
 			struct pdu_adv_adi *adi;
 
-			/* update DID to superior PDU DID */
+			/* update ADI to superior PDU ADI */
 			adi = (void *)dptr_chain;
 			if (adi_parent) {
-				adi->did = adi_parent->did;
+				adi->did_sid_packed[0] = adi_parent->did_sid_packed[0];
+				adi->did_sid_packed[1] = adi_parent->did_sid_packed[1];
 			}
 
 			dptr_chain += sizeof(struct pdu_adv_adi);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -1834,16 +1834,14 @@ uint8_t ull_adv_sync_pdu_set_clear(struct lll_adv_sync *lll_sync,
 
 			adv = HDR_LLL2ULL(lll_sync->adv);
 
-			adi_pdu->sid = adv->sid;
-
 			/* The DID for a specific SID shall be unique.
 			 */
 			const uint16_t did =
-				ull_adv_aux_did_next_unique_get(adv->sid);
-			adi_pdu->did = sys_cpu_to_le16(did);
+				sys_cpu_to_le16(ull_adv_aux_did_next_unique_get(adv->sid));
+			PDU_ADV_ADI_DID_SID_SET(adi_pdu, did, adv->sid);
 		} else {
-			adi_pdu->sid = adi->sid;
-			adi_pdu->did = adi->did;
+			adi_pdu->did_sid_packed[0] = adi->did_sid_packed[0];
+			adi_pdu->did_sid_packed[1] = adi->did_sid_packed[1];
 		}
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -412,7 +412,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		 * Periodic Advertiser List or with the explicitly supplied.
 		 */
 		if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && sync && adi &&
-		    ull_sync_setup_sid_match(scan, adi->sid)) {
+		    ull_sync_setup_sid_match(scan, PDU_ADV_ADI_SID_GET(adi))) {
 			ull_sync_setup(scan, aux, rx, si);
 		}
 	}


### PR DESCRIPTION
Bitsets across byte boundaries does not work properly for big-endian; Converted to use two uint8's instead