### PR TITLE
tests: Bluetooth: CAP: Fix CAP initiator guard that should be source

### DIFF
--- a/tests/bsim/bluetooth/audio/src/cap_initiator_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_test.c
@@ -329,7 +329,7 @@ static void init(void)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SINK)) {
+	if (IS_ENABLED(CONFIG_BT_BAP_BROADCAST_SOURCE)) {
 		(void)memset(broadcast_source_streams, 0,
 			     sizeof(broadcast_source_streams));
 


### PR DESCRIPTION
Fixed a guard that should have been BROADCAST_SOURCE instead of BROADCAST_SINK.