### PR TITLE
ITE: drivers/i2c: Disable pre-detect on IT82xx2 family

### DIFF
--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -1091,13 +1091,6 @@ static int i2c_it8xxx2_init(const struct device *dev)
 	uint32_t bitrate_cfg;
 	int error, status;
 
-	/*
-	 * This register is a pre-define hardware slave A and can
-	 * be accessed through I2C0. It is not currently used, so
-	 * it can be disabled to avoid illegal access.
-	 */
-	IT8XXX2_SMB_SFFCTL &= ~IT8XXX2_SMB_HSAPE;
-
 	/* Initialize mutex and semaphore */
 	k_mutex_init(&data->mutex);
 	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -895,6 +895,7 @@ enum chip_pll_mode {
  *
  */
 #define IT8XXX2_SMB_BASE            0x00F01C00
+#ifdef CONFIG_SOC_IT8XXX2_REG_SET_V1
 #define IT8XXX2_SMB_4P7USL          ECREG(IT8XXX2_SMB_BASE + 0x00)
 #define IT8XXX2_SMB_4P0USL          ECREG(IT8XXX2_SMB_BASE + 0x01)
 #define IT8XXX2_SMB_300NS           ECREG(IT8XXX2_SMB_BASE + 0x02)
@@ -925,6 +926,20 @@ enum chip_pll_mode {
 #define IT8XXX2_SMB_PECERC(base)    ECREG(base + 0x07)
 #define IT8XXX2_SMB_SMBPCTL(base)   ECREG(base + 0x0A)
 #define IT8XXX2_SMB_HOCTL2(base)    ECREG(base + 0x10)
+#elif CONFIG_SOC_IT8XXX2_REG_SET_V2
+#define IT8XXX2_SMB_SLVISEL         ECREG(IT8XXX2_SMB_BASE + 0x08)
+#define IT8XXX2_SMB_SMB01CHS        ECREG(IT8XXX2_SMB_BASE + 0x09)
+#define IT8XXX2_SMB_SMB23CHS        ECREG(IT8XXX2_SMB_BASE + 0x0A)
+#define IT8XXX2_SMB_SMB4CHS         ECREG(IT8XXX2_SMB_BASE + 0x0B)
+#define IT8XXX2_SMB_SCLKTS_BRGS     ECREG(IT8XXX2_SMB_BASE + 0x80)
+#define IT8XXX2_SMB_SCLKTS_BRGM     ECREG(IT8XXX2_SMB_BASE + 0x81)
+#define IT8XXX2_SMB_CHSBRG          ECREG(IT8XXX2_SMB_BASE + 0x82)
+#define IT8XXX2_SMB_CHSMOT          ECREG(IT8XXX2_SMB_BASE + 0x83)
+
+/* SMBus register fields */
+/* 0x80: SMCLK Timing Setting Register Bridge Slave */
+#define IT8XXX2_SMB_PREDEN            BIT(7)
+#endif
 
 /**
  * Enhanced SMBus/I2C Interface

--- a/soc/riscv/riscv-ite/it8xxx2/soc.c
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.c
@@ -278,6 +278,17 @@ static int ite_it8xxx2_init(void)
 	 */
 	gctrl_regs->GCTRL_WMCR |= BIT(7);
 
+	/*
+	 * Disable this feature that can detect pre-define hardware
+	 * target A through I2C0. This is for debugging use, so it
+	 * can be disabled to avoid illegal access.
+	 */
+#ifdef CONFIG_SOC_IT8XXX2_REG_SET_V1
+	IT8XXX2_SMB_SFFCTL &= ~IT8XXX2_SMB_HSAPE;
+#elif CONFIG_SOC_IT8XXX2_REG_SET_V2
+	IT8XXX2_SMB_SCLKTS_BRGS &= ~IT8XXX2_SMB_PREDEN;
+#endif
+
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart1), okay)
 	/* UART1 board init */
 	/* bit2: clocks to UART1 modules are not gated. */


### PR DESCRIPTION
Disable the hardware I2C target detection on the IT82xx2 SoC family.

Note: The register setting of I2C target detection is different in
IT81XX2 and IT82XX2 SOC.