### PR TITLE
drivers: ethernet: stm32: Set API V2 as default

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -17,11 +17,22 @@ menuconfig ETH_STM32_HAL
 
 if ETH_STM32_HAL
 
+choice ETH_STM32_HAL_API_VERSION
+	prompt "STM32Cube HAL Ethernet version"
+
 config ETH_STM32_HAL_API_V2
 	bool "Use new HAL driver"
 	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
 	help
 	  Use the new HAL driver instead of the legacy one.
+
+config ETH_STM32_HAL_API_V1
+	bool "Use new HAL driver"
+	select DEPRECATED if SOC_SERIES_STM32H7X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
+	help
+	  Driver version based on legacy HAL version. Deprecated unless using STM32F2 series.
+
+endchoice
 
 config ETH_STM32_HAL_RX_THREAD_STACK_SIZE
 	int "RX thread stack size"


### PR DESCRIPTION
Set STM32CubeHAL ethernet version in use as V2 by default, on series supporting it (H7, F7, F4). Not yet available on F2 series.

Add a choice symbol to explicit V1 version as deprecated.