### PR TITLE
drivers: stm32_temp stm32h5 device must disable icache to access cal

### DIFF
--- a/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
@@ -55,6 +55,7 @@
 		sw0 = &user_button;
 		watchdog0 = &iwdg;
 		spi-flash0 = &mx25lm51245;
+		die-temp0 = &die_temp;
 	};
 };
 
@@ -235,4 +236,8 @@
 			   };
 		};
 	};
+};
+
+&die_temp {
+	status = "okay";
 };

--- a/drivers/sensor/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/stm32_temp/stm32_temp.c
@@ -10,6 +10,9 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/adc.h>
 #include <zephyr/logging/log.h>
+#if defined(CONFIG_SOC_SERIES_STM32H5X)
+#include <stm32_ll_icache.h>
+#endif /* CONFIG_SOC_SERIES_STM32H5X */
 
 LOG_MODULE_REGISTER(stm32_temp, CONFIG_SENSOR_LOG_LEVEL);
 #define CAL_RES 12
@@ -98,6 +101,11 @@ static int stm32_temp_channel_get(const struct device *dev, enum sensor_channel 
 	}
 
 #if HAS_CALIBRATION
+
+#if defined(CONFIG_SOC_SERIES_STM32H5X)
+	LL_ICACHE_Disable();
+#endif /* CONFIG_SOC_SERIES_STM32H5X */
+
 	temp = ((float)data->raw * adc_ref_internal(data->adc)) / cfg->cal_vrefanalog;
 	temp -= (*cfg->cal1_addr >> cfg->ts_cal_shift);
 #if HAS_SINGLE_CALIBRATION
@@ -110,6 +118,11 @@ static int stm32_temp_channel_get(const struct device *dev, enum sensor_channel 
 	temp /= ((*cfg->cal2_addr - *cfg->cal1_addr) >> cfg->ts_cal_shift);
 #endif
 	temp += cfg->cal1_temp;
+
+#if defined(CONFIG_SOC_SERIES_STM32H5X)
+	LL_ICACHE_Enable();
+#endif /* CONFIG_SOC_SERIES_STM32H5X */
+
 #else
 	/* Sensor value in millivolts */
 	int32_t mv = data->raw * adc_ref_internal(data->adc) / 0x0FFF;

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -464,6 +464,18 @@
 			status = "disabled";
 		};
 	};
+
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x08fff814>;
+		ts-cal2-addr = <0x08fff818>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <130>;
+		ts-cal-vrefanalog = <3300>;
+		ts-cal-resolution = <12>;
+		io-channels = <&adc1 16>;
+		status = "disabled";
+	};
 };
 
 &nvic {


### PR DESCRIPTION
Reading the temperature calibration data requires disabling the icache of the stm32h5x mcu.
Else a bus fault error occurs reading Address: 0x8fff814-0x8fff818.
Enable afterwards.