### PR TITLE
boards/arm/efr32xg24_dk2601b: add BLE support

### DIFF
--- a/boards/arm/efr32xg24_dk2601b/Kconfig.defconfig
+++ b/boards/arm/efr32xg24_dk2601b/Kconfig.defconfig
@@ -18,4 +18,21 @@ config FLASH_BASE_ADDRESS
 	hex
 	default 0x08000000
 
+if BT
+
+config FPU
+	default y
+
+config MINIMAL_LIBC_MALLOC_ARENA_SIZE
+	default 8192
+
+config MAIN_STACK_SIZE
+	default 2304
+
+choice BT_HCI_BUS_TYPE
+	default BT_SILABS_HCI
+endchoice
+
+endif # BT
+
 endif # BOARD_EFR32XG24_DK2601B

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -58,7 +58,7 @@ config BT_STM32_IPM
 
 config BT_SILABS_HCI
 	bool "Silicon Labs Bluetooth interface"
-	depends on SOC_SERIES_EFR32BG22
+	depends on SOC_SERIES_EFR32BG22 || SOC_SERIES_EFR32MG24
 	select ENTROPY_GENERATOR
 	select MBEDTLS
 	select MBEDTLS_PSA_CRYPTO_C

--- a/drivers/bluetooth/hci/slz_hci.c
+++ b/drivers/bluetooth/hci/slz_hci.c
@@ -26,7 +26,11 @@ static struct k_thread slz_ll_thread;
 
 void rail_isr_installer(void)
 {
+#ifdef CONFIG_SOC_SERIES_EFR32MG24
+	IRQ_CONNECT(SYNTH_IRQn, 0, SYNTH_IRQHandler, NULL, 0);
+#else
 	IRQ_CONNECT(RDMAILBOX_IRQn, 0, RDMAILBOX_IRQHandler, NULL, 0);
+#endif
 	IRQ_CONNECT(RAC_SEQ_IRQn, 0, RAC_SEQ_IRQHandler, NULL, 0);
 	IRQ_CONNECT(RAC_RSM_IRQn, 0, RAC_RSM_IRQHandler, NULL, 0);
 	IRQ_CONNECT(PROTIMER_IRQn, 0, PROTIMER_IRQHandler, NULL, 0);

--- a/west.yml
+++ b/west.yml
@@ -126,7 +126,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 249c08f16f5ee9663c8b225b68faf8ec54a21e8e
+      revision: cee0e7704ece414924734cb422a6f346e13e71e5
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
This PR adds BLE support to the `efr32xg24_dk2601b` board. It also modifies the SiLabs BT HCI driver to accomodate the EFR32xG24 SoC series.