### PR TITLE
soc/arm/silabs/bg2x: support DFU

### DIFF
--- a/boards/arm/efr32_thunderboard/efr32bg22_brd4184a.dts
+++ b/boards/arm/efr32_thunderboard/efr32bg22_brd4184a.dts
@@ -21,6 +21,9 @@
 		spi-flash0 = &mx25r80;
 		spi0 = &usart0;
 		watchdog0 = &wdog0;
+		/* If enabled, MCUboot uses this for recovery mode entrance */
+		mcuboot-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 
 	chosen {

--- a/boards/arm/efr32_thunderboard/efr32bg22_brd4184a.dts
+++ b/boards/arm/efr32_thunderboard/efr32bg22_brd4184a.dts
@@ -22,39 +22,37 @@
 		spi0 = &usart0;
 		watchdog0 = &wdog0;
 	};
+
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
 };
 
 &flash0 {
 	partitions {
-		/* Reserve 32 kB for the bootloader */
+		/* Reserve 48 KiB for the bootloader */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x0 0x00008000>;
+			reg = <0x00000000 0x0000c000>;
 			read-only;
 		};
 
-		/* Reserve 220 kB for the application in slot 0 */
-		slot0_partition: partition@8000 {
+		/* Reserve 224 KiB for the application in slot 0 */
+		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0008000 0x00037000>;
+			reg = <0x0000c000 0x00038000>;
 		};
 
-		/* Reserve 220 kB for the application in slot 1 */
-		slot1_partition: partition@3f000 {
+		/* Reserve 224 KiB for the application in slot 1 */
+		slot1_partition: partition@44000 {
 			label = "image-1";
-			reg = <0x0003f000 0x00037000>;
+			reg = <0x00044000 0x00038000>;
 		};
 
-		/* Reserve 32 kB for the scratch partition */
-		scratch_partition: partition@76000 {
-			label = "image-scratch";
-			reg = <0x00076000 0x00008000>;
-		};
-
-		/* Set 8Kb of storage at the end of the 512KB of flash */
-		storage_partition: partition@7e000 {
+		/* Set 16 KiB of storage at the end of the 512 KiB of flash */
+		storage_partition: partition@7c000 {
 			label = "storage";
-			reg = <0x0007e000 0x00002000>;
+			reg = <0x0007c000 0x00004000>;
 		};
 	};
 };

--- a/boards/arm/efr32_thunderboard/efr32bg27_brd2602a.dts
+++ b/boards/arm/efr32_thunderboard/efr32bg27_brd2602a.dts
@@ -21,6 +21,9 @@
 		spi-flash0 = &mx25r80;
 		spi0 = &usart0;
 		watchdog0 = &wdog0;
+		/* If enabled, MCUboot uses this for recovery mode entrance */
+		mcuboot-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 
 	chosen {

--- a/boards/arm/efr32_thunderboard/efr32bg27_brd2602a.dts
+++ b/boards/arm/efr32_thunderboard/efr32bg27_brd2602a.dts
@@ -22,6 +22,39 @@
 		spi0 = &usart0;
 		watchdog0 = &wdog0;
 	};
+
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
+};
+
+&flash0 {
+	partitions {
+		/* Reserve 48 KiB for the bootloader */
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x0000c000>;
+			read-only;
+		};
+
+		/* Reserve 328 KiB for the application in slot 0 */
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0x0000c000 0x00052000>;
+		};
+
+		/* Reserve 328 KiB for the application in slot 1 */
+		slot1_partition: partition@5e000 {
+			label = "image-1";
+			reg = <0x0005e000 0x00052000>;
+		};
+
+		/* Set 64 KiB of storage at the end of the 768 KiB of flash */
+		storage_partition: partition@b0000 {
+			label = "storage";
+			reg = <0x000b0000 0x00010000>;
+		};
+	};
 };
 
 &led0 {

--- a/dts/arm/silabs/efr32bg22.dtsi
+++ b/dts/arm/silabs/efr32bg22.dtsi
@@ -13,39 +13,6 @@
 		write-block-size = <4>;
 		erase-block-size = <8192>;
 		reg = <0x0 DT_SIZE_K(512)>;
-
-		partitions {
-			/* Reserve 32 kB for the bootloader */
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x0 0x00008000>;
-				read-only;
-			};
-
-			/* Reserve 220 kB for the application in slot 0 */
-			slot0_partition: partition@8000 {
-				label = "image-0";
-				reg = <0x0008000 0x00037000>;
-			};
-
-			/* Reserve 220 kB for the application in slot 1 */
-			slot1_partition: partition@3f000 {
-				label = "image-1";
-				reg = <0x0003f000 0x00037000>;
-			};
-
-			/* Reserve 32 kB for the scratch partition */
-			scratch_partition: partition@76000 {
-				label = "image-scratch";
-				reg = <0x00076000 0x00008000>;
-			};
-
-			/* Set 8Kb of storage at the end of the 512KB of flash */
-			storage_partition: partition@7e000 {
-				label = "storage";
-				reg = <0x0007e000 0x00002000>;
-			};
-		};
 	};
 };
 

--- a/dts/arm/silabs/efr32bg27.dtsi
+++ b/dts/arm/silabs/efr32bg27.dtsi
@@ -13,40 +13,6 @@
 		write-block-size = <4>;
 		erase-block-size = <8192>;
 		reg = <0x08000000 DT_SIZE_K(768)>;
-
-		partitions {
-			/* Reserve 32 kB for the bootloader */
-			boot_partition: partition@0 {
-				label = "mcuboot";
-				reg = <0x0 0x00008000>;
-				read-only;
-			};
-
-			/* Reserve 320 kB for the application in slot 0 */
-			slot0_partition: partition@8000 {
-				label = "image-0";
-				reg = <0x00008000 0x00050000>;
-			};
-
-			/* Reserve 320 kB for the application in slot 1 */
-			slot1_partition: partition@58000 {
-				label = "image-1";
-				reg = <0x00058000 0x00050000>;
-			};
-
-			/* Reserve 32 kB for the scratch partition */
-			scratch_partition: partition@a8000 {
-				label = "image-scratch";
-				reg = <0x000a8000 0x00008000>;
-			};
-
-			/* Set 64Kb of storage at the end of the 768KB of flash */
-			storage_partition: partition@b0000 {
-				label = "storage";
-				reg = <0x000b0000 0x00010000>;
-			};
-
-		};
 	};
 };
 

--- a/soc/arm/silabs_exx32/efr32bg22/Kconfig.defconfig.efr32bg22
+++ b/soc/arm/silabs_exx32/efr32bg22/Kconfig.defconfig.efr32bg22
@@ -5,6 +5,3 @@
 
 config GPIO_GECKO
 	default y
-
-config SOC_FLASH_GECKO
-	default n

--- a/soc/arm/silabs_exx32/efr32bg27/Kconfig.defconfig.efr32bg27
+++ b/soc/arm/silabs_exx32/efr32bg27/Kconfig.defconfig.efr32bg27
@@ -5,6 +5,3 @@
 
 config GPIO_GECKO
 	default y
-
-config SOC_FLASH_GECKO
-	default n


### PR DESCRIPTION
This PR contains contains following changes:
1. Enables flash driver for SiLabs EFR32BG22 and BG27 that was disabled by default.
2. Updates partition tables for Thunderboard EVB for those SoCs (removes scratch partition, increases size of MCUboot partition to 48K to fit recent MCUboot builds that are ~40KB), sets `zephyr,code-partition` in DTS.
3. Partition tables are moved from SoC DTS files to board DTS files, and this layout is aligned between BG22 and BG27.

With these changes, MCUboot & mcumgr can perform a DFU over UART.