### PR TITLE
modules/fatfst: Add support for default ffconf.h FF_VOLUME_STRS override

### DIFF
--- a/modules/fatfs/zephyr_fatfs_config.h
+++ b/modules/fatfs/zephyr_fatfs_config.h
@@ -108,3 +108,14 @@
 #else
 #define FS_FATFS_WINDOW_ALIGNMENT	1
 #endif /* defined(CONFIG_FS_FATFS_WINDOW_ALIGNMENT) */
+
+/* CONFIG_FF_VOLUME_STRS_OVERRIDE is used to override hard-coded ffconf.h
+ * FF_VOLUMES_STRS content and, instead, provide one from the Kconfig option
+ * CONFIG_FF_VOLUME_STRS which - at runtime - will require parsing once.
+ */
+#if defined(CONFIG_FF_VOLUME_STRS_OVERRIDE)
+#undef FF_VOLUME_STRS
+#define FF_VOLUME_STRS CONFIG_FF_VOLUME_STRS
+#undef FF_VOLUMES
+#define FF_VOLUMES CONFIG_FF_VOLUMES
+#endif

--- a/modules/fatfs/zfs_diskio.c
+++ b/modules/fatfs/zfs_diskio.c
@@ -14,7 +14,12 @@
 #include <diskio.h>	/* FatFs lower layer API */
 #include <zephyr/storage/disk_access.h>
 
+#if defined(CONFIG_FF_VOLUME_STRS_OVERRIDE)
+extern char *VolumeStr[FF_VOLUMES];
+#define pdrv_str VolumeStr
+#else
 static const char * const pdrv_str[] = {FF_VOLUME_STRS};
+#endif
 
 /* Get Drive Status */
 DSTATUS disk_status(BYTE pdrv)

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -229,6 +229,28 @@ config FS_FATFS_REENTRANT
 	  access for each volume. Will create a zephyr mutex object for each
 	  FatFs volume and a FatFs system mutex.
 
+config FF_VOLUME_STRS_OVERRIDE
+	bool "Override ffconf.h FF_VOLUME_STRS"
+	help
+	  Overrides hardcoded volume strings found in ffconf.h
+
+if FF_VOLUME_STRS_OVERRIDE
+
+config FF_VOLUMES
+	int "Number of volume names"
+	default 8
+	help
+	  Number of volumes found in CONFIG_FF_VOLUME_STRS
+
+config FF_VOLUME_STRS
+	string "Volume names (ended by a ';')"
+	default "RAM;NAND;CF;SD;SD2;USB;USB2;USB3;"
+	help
+	  Volume strings overriding defaults found in ffconf.h.
+	  A ';' must always be put at the end of each volume names.
+
+endif # FF_VOLUME_STRS_OVERRIDE
+
 endmenu
 
 endif # FAT_FILESYSTEM_ELM


### PR DESCRIPTION
FatFS is pretty unflexible when it comes to volume names where all are hardcoded and fixed.

So let's patch Zephyr to expose a Kconfig based volumes string which will be parsed by fatfs to fill up it's volumes list.

see fatfs's related PR https://github.com/zephyrproject-rtos/fatfs/pull/17