### PR TITLE
Bluetooth: controller: fixup HCI LE Create CIS 'parameter' checks

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -530,6 +530,11 @@ uint8_t ll_cis_create_check(uint16_t cis_handle, uint16_t acl_handle)
 	if (conn) {
 		struct ll_conn_iso_stream *cis;
 
+		/* Verify conn refers to a device acting as central */
+		if (conn->lll.role != BT_HCI_ROLE_CENTRAL) {
+			return BT_HCI_ERR_CMD_DISALLOWED;
+		}
+
 		/* Verify handle validity and association */
 		cis = ll_conn_iso_stream_get(cis_handle);
 		if (cis->lll.handle == cis_handle) {
@@ -537,7 +542,7 @@ uint8_t ll_cis_create_check(uint16_t cis_handle, uint16_t acl_handle)
 		}
 	}
 
-	return BT_HCI_ERR_CMD_DISALLOWED;
+	return BT_HCI_ERR_UNKNOWN_CONN_ID;
 }
 
 void ll_cis_create(uint16_t cis_handle, uint16_t acl_handle)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -447,7 +447,7 @@ uint8_t ll_feature_req_send(uint16_t handle)
 
 	uint8_t err;
 
-	err = ull_cp_feature_exchange(conn);
+	err = ull_cp_feature_exchange(conn, 1U);
 	if (err) {
 		return err;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -876,8 +876,11 @@ uint8_t ull_cp_cis_create(struct ll_conn *conn, struct ll_conn_iso_stream *cis)
 	struct ll_conn_iso_group *cig;
 	struct proc_ctx *ctx;
 
-	if (conn->lll.handle != cis->lll.acl_handle) {
-		return BT_HCI_ERR_CMD_DISALLOWED;
+	if (!conn->llcp.fex.valid) {
+		/* No feature exchange was performed so initiate before CIS Create */
+		if (ull_cp_feature_exchange(conn, 0U) != BT_HCI_ERR_SUCCESS) {
+			return BT_HCI_ERR_CMD_DISALLOWED;
+		}
 	}
 
 	ctx = llcp_create_local_procedure(PROC_CIS_CREATE);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -701,7 +701,7 @@ uint8_t ull_cp_le_ping(struct ll_conn *conn)
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
 #if defined(CONFIG_BT_CENTRAL) || defined(CONFIG_BT_CTLR_PER_INIT_FEAT_XCHG)
-uint8_t ull_cp_feature_exchange(struct ll_conn *conn)
+uint8_t ull_cp_feature_exchange(struct ll_conn *conn, uint8_t host_initiated)
 {
 	struct proc_ctx *ctx;
 
@@ -709,6 +709,8 @@ uint8_t ull_cp_feature_exchange(struct ll_conn *conn)
 	if (!ctx) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
+
+	ctx->data.fex.host_initiated = host_initiated;
 
 	llcp_lr_enqueue(conn, ctx);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -85,7 +85,7 @@ uint8_t ull_cp_version_exchange(struct ll_conn *conn);
 /**
  * @brief Initiate a Feature Exchange Procedure.
  */
-uint8_t ull_cp_feature_exchange(struct ll_conn *conn);
+uint8_t ull_cp_feature_exchange(struct ll_conn *conn, uint8_t host_initiated);
 
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
 /**

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -167,6 +167,10 @@ struct proc_ctx {
 
 	/* Procedure data */
 	union {
+		/* Feature Exchange Procedure */
+		struct {
+			uint8_t host_initiated:1;
+		} fex;
 		/* Used by Minimum Used Channels Procedure */
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
 		struct {

--- a/tests/bluetooth/controller/ctrl_feature_exchange/src/main.c
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/src/main.c
@@ -110,7 +110,7 @@ ZTEST(fex_central, test_feat_exchange_central_loc)
 		ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 		/* Initiate a Feature Exchange Procedure */
-		err = ull_cp_feature_exchange(&conn);
+		err = ull_cp_feature_exchange(&conn, 1U);
 		zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 		event_prepare(&conn);
@@ -140,7 +140,7 @@ ZTEST(fex_central, test_feat_exchange_central_loc)
 
 	sys_put_le64(set_featureset[0], local_feature_req.features);
 	/* Initiate a Feature Exchange Procedure */
-	err = ull_cp_feature_exchange(&conn);
+	err = ull_cp_feature_exchange(&conn, 1U);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
@@ -209,7 +209,7 @@ ZTEST(fex_central, test_feat_exchange_central_loc_invalid_rsp)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	/* Initiate a Feature Exchange Procedure */
-	err = ull_cp_feature_exchange(&conn);
+	err = ull_cp_feature_exchange(&conn, 1U);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
@@ -243,7 +243,7 @@ ZTEST(fex_central, test_feat_exchange_central_loc_invalid_rsp)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	/* Initiate another Feature Exchange Procedure */
-	err = ull_cp_feature_exchange(&conn);
+	err = ull_cp_feature_exchange(&conn, 1U);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
@@ -277,10 +277,10 @@ ZTEST(fex_central, test_feat_exchange_central_loc_2)
 	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
-	err = ull_cp_feature_exchange(&conn);
+	err = ull_cp_feature_exchange(&conn, 1U);
 	for (int i = 0U; i < CONFIG_BT_CTLR_LLCP_LOCAL_PROC_CTX_BUF_NUM; i++) {
 		zassert_equal(err, BT_HCI_ERR_SUCCESS);
-		err = ull_cp_feature_exchange(&conn);
+		err = ull_cp_feature_exchange(&conn, 1U);
 	}
 
 	zassert_not_equal(err, BT_HCI_ERR_SUCCESS, NULL);
@@ -405,7 +405,7 @@ ZTEST(fex_central, test_feat_exchange_central_rem_2)
 		sys_put_le64(ut_featureset[feat_count], ut_feature_req.features);
 		sys_put_le64(ut_exp_featureset[feat_count], ut_feature_rsp.features);
 
-		err = ull_cp_feature_exchange(&conn);
+		err = ull_cp_feature_exchange(&conn, 1U);
 		zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 		event_prepare(&conn);
@@ -468,7 +468,7 @@ ZTEST(fex_periph, test_peripheral_feat_exchange_periph_loc)
 	}
 
 	/* Initiate a Feature Exchange Procedure */
-	err = ull_cp_feature_exchange(&conn);
+	err = ull_cp_feature_exchange(&conn, 1U);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
@@ -529,7 +529,7 @@ ZTEST(fex_periph, test_feat_exchange_periph_loc_unknown_rsp)
 	/* Initiate a Feature Exchange Procedure */
 
 	event_prepare(&conn);
-	err = ull_cp_feature_exchange(&conn);
+	err = ull_cp_feature_exchange(&conn, 1U);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 	event_done(&conn);
 


### PR DESCRIPTION
A couple of minor updates to condition checks for HCE LE Create CIS:
* BT Core Spec states that feature exchange should be initiated if not already performed.
* Also confirm that the 'requesting connection' is acting as central