### PR TITLE
doc: Add small section about UBSan

### DIFF
--- a/boards/posix/native_posix/doc/index.rst
+++ b/boards/posix/native_posix/doc/index.rst
@@ -105,7 +105,7 @@ To ease debugging you may want to compile your code without optimizations
 Address Sanitizer (ASan)
 ========================
 
-You can also build Zephyr with `Address Sanitizer`_. To do this, set
+You can also build Zephyr with the `Address Sanitizer`_. To do this, set
 :kconfig:option:`CONFIG_ASAN`, for example, in the application project file, or in the
 ``west build`` or ``cmake`` command line invocation.
 
@@ -114,6 +114,16 @@ In Debian/Ubuntu this is ``libasan1``.
 
 .. _Address Sanitizer:
    https://github.com/google/sanitizers/wiki/AddressSanitizer
+
+Undefined Behavior Sanitizer (UBSan)
+====================================
+
+You can also build Zephyr with the `Undefined Behavior Sanitizer`_. To do this, set
+:kconfig:option:`CONFIG_UBSAN`, for example, in the application project file, or in the
+``west build`` or ``cmake`` command line invocation.
+
+.. _Undefined Behavior Sanitizer:
+   https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
 
 Coverage reports
 ================

--- a/boards/posix/nrf52_bsim/doc/index.rst
+++ b/boards/posix/nrf52_bsim/doc/index.rst
@@ -161,7 +161,7 @@ The same
 :ref:`code coverage analysis means from the POSIX arch<coverage_posix>`
 are inherited in this board.
 Similarly, the
-:ref:`address sanitizers can be used as in native_posix<native_posix_asan>`.
+:ref:`address and undefined behavior sanitizers can be used as in native_posix<native_posix_asan>`.
 
 
 Note that BabbleSim will run fine if one or several of its components are


### PR DESCRIPTION
Add a mention of the undefined behavior sanitizer
and which kconfig option toggles it, as users
may not be aware of it, but could benefit from it.