### PR TITLE
drivers: cache: Fix circular dependency between cache API header files

### DIFF
--- a/include/zephyr/drivers/cache.h
+++ b/include/zephyr/drivers/cache.h
@@ -12,14 +12,14 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CACHE_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CACHE_H_
 
+#include <stddef.h>
+
 /**
  * @brief External Cache Controller Interface
  * @defgroup cache_external_interface External Cache Controller Interface
  * @ingroup io_interfaces
  * @{
  */
-
-#include <zephyr/cache.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
When `CONFIG_EXTERNAL_CACHE=y`, the `zephyr/cache.h` header file includes `zephyr/drivers/cache.h`, which then includes `zephyr/cache.h` again.

This commit fixes the above circular dependency by removing the unneeded `zephyr/cache.h` inclusion from the `zephyr/drivers/cache.h`.