### PR TITLE
Bluetooth: audio: ascs: Make ascs_ep_set_state function static

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -201,7 +201,7 @@ static int ascs_disconnect_stream(struct bt_bap_stream *stream)
 				 K_MSEC(CONFIG_BT_ASCS_ISO_DISCONNECT_DELAY));
 }
 
-void ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state)
+static void ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state)
 {
 	struct bt_bap_stream *stream;
 	bool state_changed;
@@ -1413,7 +1413,7 @@ static int ase_config(struct bt_ascs *ascs, struct bt_ascs_ase *ase,
 	return 0;
 }
 
-int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_codec *codec,
+int bt_ascs_ase_config(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_codec *codec,
 		       const struct bt_codec_qos_pref *qos_pref)
 {
 	int err;
@@ -2888,4 +2888,145 @@ void bt_ascs_cleanup(void)
 		unicast_server_cb = NULL;
 	}
 }
+
+int bt_ascs_ase_reconfig(struct bt_bap_stream *stream, const struct bt_codec *codec)
+{
+	struct bt_bap_ep *ep;
+	struct bt_bap_ascs_rsp rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS,
+						     BT_BAP_ASCS_REASON_NONE);
+	int err;
+
+	ep = stream->ep;
+
+	if (unicast_server_cb != NULL &&
+		unicast_server_cb->reconfig != NULL) {
+		err = unicast_server_cb->reconfig(stream, ep->dir, codec,
+						  &ep->qos_pref, &rsp);
+	} else {
+		err = -ENOTSUP;
+	}
+
+	if (err != 0) {
+		return err;
+	}
+
+	(void)memcpy(&ep->codec, &codec, sizeof(codec));
+
+	ascs_ep_set_state(ep, BT_BAP_EP_STATE_CODEC_CONFIGURED);
+
+	return 0;
+}
+
+int bt_ascs_ase_start(struct bt_bap_stream *stream)
+{
+	struct bt_bap_ep *ep = stream->ep;
+
+	if (ep->dir != BT_AUDIO_DIR_SINK) {
+		LOG_DBG("Invalid operation for stream %p with dir %u",
+			stream, ep->dir);
+
+		return -EINVAL;
+	}
+
+	/* If ISO is connected to go streaming state,
+	 * else wait for ISO to be connected
+	 */
+	if (ep->iso->chan.state == BT_ISO_STATE_CONNECTED) {
+		ascs_ep_set_state(ep, BT_BAP_EP_STATE_STREAMING);
+	} else {
+		ep->receiver_ready = true;
+	}
+
+	return 0;
+}
+
+int bt_ascs_ase_metadata(struct bt_bap_stream *stream, struct bt_codec_data meta[],
+			 size_t meta_count)
+{
+	struct bt_bap_ep *ep;
+	struct bt_bap_ascs_rsp rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS,
+						     BT_BAP_ASCS_REASON_NONE);
+	int err;
+
+
+	if (unicast_server_cb != NULL && unicast_server_cb->metadata != NULL) {
+		err = unicast_server_cb->metadata(stream, meta, meta_count, &rsp);
+	} else {
+		err = -ENOTSUP;
+	}
+
+	ep = stream->ep;
+	for (size_t i = 0U; i < meta_count; i++) {
+		(void)memcpy(&ep->codec.meta[i], &meta[i],
+			     sizeof(ep->codec.meta[i]));
+	}
+
+	if (err) {
+		LOG_ERR("Metadata failed: err %d, code %u, reason %u", err, rsp.code, rsp.reason);
+		return err;
+	}
+
+	/* Set the state to the same state to trigger the notifications */
+	ascs_ep_set_state(ep, ep->status.state);
+
+	return 0;
+}
+
+int bt_ascs_ase_disable(struct bt_bap_stream *stream)
+{
+	struct bt_bap_ep *ep;
+	struct bt_bap_ascs_rsp rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS,
+						     BT_BAP_ASCS_REASON_NONE);
+	int err;
+
+	if (unicast_server_cb != NULL && unicast_server_cb->disable != NULL) {
+		err = unicast_server_cb->disable(stream, &rsp);
+	} else {
+		err = -ENOTSUP;
+	}
+
+	if (err != 0) {
+		LOG_ERR("Disable failed: err %d, code %u, reason %u", err, rsp.code, rsp.reason);
+		return err;
+	}
+
+	ep = stream->ep;
+
+	/* The ASE state machine goes into different states from this operation
+	 * based on whether it is a source or a sink ASE.
+	 */
+	if (ep->dir == BT_AUDIO_DIR_SOURCE) {
+		ascs_ep_set_state(ep, BT_BAP_EP_STATE_DISABLING);
+	} else {
+		ascs_ep_set_state(ep, BT_BAP_EP_STATE_QOS_CONFIGURED);
+	}
+
+	return 0;
+}
+
+int bt_ascs_ase_release(struct bt_bap_stream *stream)
+{
+	struct bt_bap_ascs_rsp rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS,
+						     BT_BAP_ASCS_REASON_NONE);
+	int err;
+
+	if (unicast_server_cb != NULL && unicast_server_cb->release != NULL) {
+		err = unicast_server_cb->release(stream, &rsp);
+	} else {
+		err = -ENOTSUP;
+	}
+
+	if (err != 0) {
+		LOG_ERR("Release failed: err %d, code %u, reason %u", err, rsp.code, rsp.reason);
+		return err;
+	}
+
+	/* ase_process will set the state to IDLE after sending the
+	 * notification, finalizing the release
+	 */
+	ascs_ep_set_state(stream->ep, BT_BAP_EP_STATE_RELEASING);
+
+	return 0;
+}
+
 #endif /* BT_BAP_UNICAST_SERVER */

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -335,9 +335,13 @@ static inline const char *bt_ascs_reason_str(uint8_t reason)
 int bt_ascs_init(const struct bt_bap_unicast_server_cb *cb);
 void bt_ascs_cleanup(void);
 
-void ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state);
-
-int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_codec *codec,
+int bt_ascs_ase_config(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_codec *codec,
 		       const struct bt_codec_qos_pref *qos_pref);
+int bt_ascs_ase_reconfig(struct bt_bap_stream *stream, const struct bt_codec *codec);
+int bt_ascs_ase_start(struct bt_bap_stream *stream);
+int bt_ascs_ase_metadata(struct bt_bap_stream *stream, struct bt_codec_data meta[],
+			 size_t meta_count);
+int bt_ascs_ase_disable(struct bt_bap_stream *stream);
+int bt_ascs_ase_release(struct bt_bap_stream *stream);
 
 void bt_ascs_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func, void *user_data);

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -65,149 +65,35 @@ int bt_bap_unicast_server_unregister_cb(const struct bt_bap_unicast_server_cb *c
 
 int bt_bap_unicast_server_reconfig(struct bt_bap_stream *stream, const struct bt_codec *codec)
 {
-	struct bt_bap_ep *ep;
-	struct bt_bap_ascs_rsp rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS,
-						     BT_BAP_ASCS_REASON_NONE);
-	int err;
-
-	ep = stream->ep;
-
-	if (unicast_server_cb != NULL &&
-		unicast_server_cb->reconfig != NULL) {
-		err = unicast_server_cb->reconfig(stream, ep->dir, codec,
-						  &ep->qos_pref, &rsp);
-	} else {
-		err = -ENOTSUP;
-	}
-
-	if (err != 0) {
-		return err;
-	}
-
-	(void)memcpy(&ep->codec, &codec, sizeof(codec));
-
-	ascs_ep_set_state(ep, BT_BAP_EP_STATE_CODEC_CONFIGURED);
-
-	return 0;
+	return bt_ascs_ase_reconfig(stream, codec);
 }
 
 int bt_bap_unicast_server_start(struct bt_bap_stream *stream)
 {
-	struct bt_bap_ep *ep = stream->ep;
-
-	if (ep->dir != BT_AUDIO_DIR_SINK) {
-		LOG_DBG("Invalid operation for stream %p with dir %u",
-			stream, ep->dir);
-
-		return -EINVAL;
-	}
-
-	/* If ISO is connected to go streaming state,
-	 * else wait for ISO to be connected
-	 */
-	if (ep->iso->chan.state == BT_ISO_STATE_CONNECTED) {
-		ascs_ep_set_state(ep, BT_BAP_EP_STATE_STREAMING);
-	} else {
-		ep->receiver_ready = true;
-	}
-
-	return 0;
+	return bt_ascs_ase_start(stream);
 }
 
 int bt_bap_unicast_server_metadata(struct bt_bap_stream *stream, struct bt_codec_data meta[],
 				   size_t meta_count)
 {
-	struct bt_bap_ep *ep;
-	struct bt_bap_ascs_rsp rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS,
-						     BT_BAP_ASCS_REASON_NONE);
-	int err;
-
-
-	if (unicast_server_cb != NULL && unicast_server_cb->metadata != NULL) {
-		err = unicast_server_cb->metadata(stream, meta, meta_count, &rsp);
-	} else {
-		err = -ENOTSUP;
-	}
-
-	ep = stream->ep;
-	for (size_t i = 0U; i < meta_count; i++) {
-		(void)memcpy(&ep->codec.meta[i], &meta[i],
-			     sizeof(ep->codec.meta[i]));
-	}
-
-	if (err) {
-		LOG_ERR("Metadata failed: err %d, code %u, reason %u", err, rsp.code, rsp.reason);
-		return err;
-	}
-
-	/* Set the state to the same state to trigger the notifications */
-	ascs_ep_set_state(ep, ep->status.state);
-
-	return 0;
+	return bt_ascs_ase_metadata(stream, meta, meta_count);
 }
 
 int bt_bap_unicast_server_disable(struct bt_bap_stream *stream)
 {
-	struct bt_bap_ep *ep;
-	struct bt_bap_ascs_rsp rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS,
-						     BT_BAP_ASCS_REASON_NONE);
-	int err;
-
-	if (unicast_server_cb != NULL && unicast_server_cb->disable != NULL) {
-		err = unicast_server_cb->disable(stream, &rsp);
-	} else {
-		err = -ENOTSUP;
-	}
-
-	if (err != 0) {
-		LOG_ERR("Disable failed: err %d, code %u, reason %u", err, rsp.code, rsp.reason);
-		return err;
-	}
-
-	ep = stream->ep;
-
-	/* The ASE state machine goes into different states from this operation
-	 * based on whether it is a source or a sink ASE.
-	 */
-	if (ep->dir == BT_AUDIO_DIR_SOURCE) {
-		ascs_ep_set_state(ep, BT_BAP_EP_STATE_DISABLING);
-	} else {
-		ascs_ep_set_state(ep, BT_BAP_EP_STATE_QOS_CONFIGURED);
-	}
-
-	return 0;
+	return bt_ascs_ase_disable(stream);
 }
 
 int bt_bap_unicast_server_release(struct bt_bap_stream *stream)
 {
-	struct bt_bap_ascs_rsp rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS,
-						     BT_BAP_ASCS_REASON_NONE);
-	int err;
-
-	if (unicast_server_cb != NULL && unicast_server_cb->release != NULL) {
-		err = unicast_server_cb->release(stream, &rsp);
-	} else {
-		err = -ENOTSUP;
-	}
-
-	if (err != 0) {
-		LOG_ERR("Release failed: err %d, code %u, reason %u", err, rsp.code, rsp.reason);
-		return err;
-	}
-
-	/* ase_process will set the state to IDLE after sending the
-	 * notification, finalizing the release
-	 */
-	ascs_ep_set_state(stream->ep, BT_BAP_EP_STATE_RELEASING);
-
-	return 0;
+	return bt_ascs_ase_release(stream);
 }
 
 int bt_bap_unicast_server_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 				     struct bt_codec *codec,
 				     const struct bt_codec_qos_pref *qos_pref)
 {
-	return bt_ascs_config_ase(conn, stream, codec, qos_pref);
+	return bt_ascs_ase_config(conn, stream, codec, qos_pref);
 }
 
 void bt_bap_unicast_server_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func, void *user_data)


### PR DESCRIPTION
The ASCS shall be the only module that allows to explicitly change the ASE state. This moves the EP state management out of unicast_server.c that seem to do more job than it should.