### PR TITLE
doc: Update FIFO and LIFO documentation

### DIFF
--- a/doc/kernel/services/data_passing/fifos.rst
+++ b/doc/kernel/services/data_passing/fifos.rst
@@ -32,6 +32,12 @@ reserved space requirements for data items if they are added with
 :c:func:`k_fifo_alloc_put`, instead additional memory is temporarily
 allocated from the calling thread's resource pool.
 
+.. note::
+    FIFO data items are restricted to single active instance across all FIFO
+    data queues. Any attempt to re-add a FIFO data item to a queue before
+    it has been removed from the queue to which it was previously added will
+    result in undefined behavior.
+
 A data item may be **added** to a FIFO by a thread or an ISR.
 The item is given directly to a waiting thread, if one exists;
 otherwise the item is added to the FIFO's queue.

--- a/doc/kernel/services/data_passing/lifos.rst
+++ b/doc/kernel/services/data_passing/lifos.rst
@@ -32,6 +32,12 @@ space requirements for data items if they are added with
 :c:func:`k_lifo_alloc_put`, instead additional memory is temporarily
 allocated from the calling thread's resource pool.
 
+.. note::
+    LIFO data items are restricted to single active instance across all LIFO
+    data queues. Any attempt to re-add a LIFO data item to a queue before
+    it has been removed from the queue to which it was previously added will
+    result in undefined behavior.
+
 A data item may be **added** to a LIFO by a thread or an ISR.
 The item is given directly to a waiting thread, if one exists;
 otherwise the item is added to the LIFO's queue.


### PR DESCRIPTION
Updates the FIFO and LIFO documentation to clarify behavior surrounding re-adding data items to queues.

Fixes #56336