### PR TITLE
net: ip: only define socklen_t if not already defined

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -164,7 +164,10 @@ struct in_addr {
 typedef unsigned short int sa_family_t;
 
 /** Length of a socket address */
+#ifndef __socklen_t_defined
 typedef size_t socklen_t;
+#define __socklen_t_defined
+#endif
 
 /*
  * Note that the sin_port and sin6_port are in network byte order


### PR DESCRIPTION
There is a chance that a previous declaration exists of socklen_t through the unistd.h header. Luckily that header defines a macro when it defines the type. This commit therefore uses that define to know if the type has already been declared or not, similar to what unistd.h does.

Closes #57195