### PR TITLE
drivers: ethernet: sam0: Fix receive buffer initialization

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1220,6 +1220,10 @@ static int nonpriority_queue_init(Gmac *gmac, struct gmac_queue *queue)
 	gmac->GMAC_DCFGR =
 		/* Receive Buffer Size (defined in multiples of 64 bytes) */
 		GMAC_DCFGR_DRBS(CONFIG_NET_BUF_DATA_SIZE >> 6) |
+#if defined(GMAC_DCFGR_RXBMS)
+		/* Use full receive buffer size on parts where this is selectable */
+		GMAC_DCFGR_RXBMS(3) |
+#endif
 		/* Attempt to use INCR4 AHB bursts (Default) */
 		GMAC_DCFGR_FBLDO_INCR4 |
 		/* DMA Queue Flags */


### PR DESCRIPTION
The SAM GMAC driver is not utilizing the entire receive buffer, causing large packets to be dropped. Fix it by setting Receiver Packet Buffer Memory Size Select to Full (RXBMS = 3) in the GMAC_DCFGR register.

Fixes #55701