### PR TITLE
net: ZWP timeout explicit type on bit shift calculation

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1402,14 +1402,14 @@ static void tcp_send_zwp(struct k_work *work)
 	tcp_derive_rto(conn);
 
 	if (conn->send_win == 0) {
-		uint64_t timeout;
+		uint64_t timeout = TCP_RTO_MS;
 
 		/* Make sure the retry counter does not overflow. */
 		if (conn->zwp_retries < UINT8_MAX) {
 			conn->zwp_retries++;
 		}
 
-		timeout = TCP_RTO_MS << conn->zwp_retries;
+		timeout <<= conn->zwp_retries;
 		if (timeout == 0 || timeout > ZWP_MAX_DELAY_MS) {
 			timeout = ZWP_MAX_DELAY_MS;
 		}


### PR DESCRIPTION
Fix tcp_send_zwp() retransmission timeout calculation to avoid sign extension on bit shift operation:
the uint16_t value was implicitly promoted to 32-bit signed type with sign extension to uint64_t.