### PR TITLE
scripts: gen_handles: silence "should it be static?" warnings

### DIFF
--- a/scripts/build/gen_handles.py
+++ b/scripts/build/gen_handles.py
@@ -103,8 +103,13 @@ def c_handle_array(dev, handles, extra_support_handles=0):
         *(extra_support_handles * ['DEVICE_HANDLE_NULL']),
         'DEVICE_HANDLE_ENDS',
     ]
+    ctype = 'const Z_DECL_ALIGN(device_handle_t) __attribute__((__section__(".__device_handles_pass2")))'
     return [
-        'const Z_DECL_ALIGN(device_handle_t) __attribute__((__section__(".__device_handles_pass2")))',
+        # The `extern` line pretends this was first declared in some .h
+        # file to silence "should it be static?" warnings in some
+        # compilers and static analyzers.
+        'extern {:s} {:s}[{:d}];'.format(ctype, dev.ordinals.sym.name, len(handles)),
+        ctype,
         '{:s}[] = {{ {:s} }};'.format(dev.ordinals.sym.name, ', '.join(handles)),
     ]
 


### PR DESCRIPTION
Some compilers and static analyzers warn when non-static (globals) are not declared in some .h file. Tweak the generated code and add an `extern` declaration before each device handle definition to make it look it was declared in a (non-existent) .h file.

This makes the code a bit longer but it is already generated and very repetitive anyway.

In the typical SOF configuration this silences about 150 sparse warnings; as many as device handles.