### PR TITLE
kernel: idle: fix build error on arm-clang

### DIFF
--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -27,7 +27,9 @@ void z_pm_save_idle_exit(void)
 	 */
 	pm_system_resume();
 #endif	/* CONFIG_PM */
+#ifdef CONFIG_SYS_CLOCK_EXISTS
 	sys_clock_idle_exit();
+#endif
 }
 
 void idle(void *unused1, void *unused2, void *unused3)


### PR DESCRIPTION
When building sample.minimal.mt-no-preempt-no-timers.arm on arm-clang we get a link error as z_pm_save_idle_exit expects sys_clock_idle_exit to be defined.

However the sample sets CONFIG_SYS_CLOCK_EXISTS=n so sys_clock_idle_exit() will not be defined by any driver.  So add proper ifdef protection in z_pm_save_idle_exit to fix this.