### PR TITLE
modem: hl7800: Fix build issue with arm-clang

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -1348,7 +1348,7 @@ uint32_t mdm_hl7800_log_filter_set(uint32_t level)
 {
 	uint32_t new_log_level = 0;
 
-#ifdef CONFIG_LOG
+#ifdef CONFIG_LOG_RUNTIME_FILTERING
 	new_log_level =
 		log_filter_set(NULL, Z_LOG_LOCAL_DOMAIN_ID,
 			       log_source_id_get(STRINGIFY(LOG_MODULE_NAME)),


### PR DESCRIPTION
When building drivers.modem.build we get a link error since log_source_id_get() is not defined when CONFIG_LOG_MODE_MINIMAL is defined.

Change ifdef protection to be CONFIG_LOG_RUNTIME_FILTERING instead of CONFIG_LOG in the code to handle this case.