### PR TITLE
armstdc: add limits.h header

### DIFF
--- a/lib/libc/armstdc/include/limits.h
+++ b/lib/libc/armstdc/include/limits.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Intel
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_ARMSTDC_INCLUDE_LIMITS_H_
+#define ZEPHYR_LIB_LIBC_ARMSTDC_INCLUDE_LIMITS_H_
+
+#include_next <limits.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PATH_MAX 256
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* ZEPHYR_LIB_LIBC_ARMSTDC_INCLUDE_LIMITS_H_ */


### PR DESCRIPTION
Add limits.h header that defines PATH_MAX as this is not defined by the toolchain headers.