### PR TITLE
tests: http_server: Add missing zephyr_iterable_section

### DIFF
--- a/tests/net/lib/http_server/common/CMakeLists.txt
+++ b/tests/net/lib/http_server/common/CMakeLists.txt
@@ -8,3 +8,5 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
 zephyr_linker_sources(SECTIONS sections-rom.ld)
+zephyr_iterable_section(NAME http_resource_desc_service_A KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
+zephyr_iterable_section(NAME http_resource_desc_service_B KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)


### PR DESCRIPTION
As the test uses iterable sections, we need to utilize zephyr_iterable_section for targets that need linker script generation like arm-clang.

So add zephyr_iterable_section() for the ROM sections that the testcases utilizes.