### PR TITLE
ARC: tweak _st32_huge_offset macro to have same behaviour with GNU & MWDT

### DIFF
--- a/arch/arc/include/swap_macros.h
+++ b/arch/arc/include/swap_macros.h
@@ -553,19 +553,18 @@ fpu_skip_load :
  * instruction. So we can use _st32_huge_offset macro instead
  */
 .macro _st32_huge_offset, d, s, offset, temp
-	off = MACRO_ARG(offset)
-	u9_max_shifted = __arc_u9_max << __arc_ldst32_as_shift
-
-	.if off <= __arc_u9_max && off >= __arc_u9_min
-		st MACRO_ARG(d), [MACRO_ARG(s), off]
+	.if MACRO_ARG(offset) <= __arc_u9_max && MACRO_ARG(offset) >= __arc_u9_min
+		st MACRO_ARG(d), [MACRO_ARG(s), MACRO_ARG(offset)]
 	/* Technically we can optimize with .as both big positive and negative offsets here, but
 	 * as we use only positive offsets in hand-written assembly code we keep only
 	 * positive offset case here for simplicity.
 	 */
-	.elseif !(off % (1 << __arc_ldst32_as_shift)) && off <= u9_max_shifted && off >= 0
-		st.as MACRO_ARG(d), [MACRO_ARG(s), off >> __arc_ldst32_as_shift]
+	.elseif !(MACRO_ARG(offset) % (1 << __arc_ldst32_as_shift)) &&                             \
+		MACRO_ARG(offset) <= (__arc_u9_max << __arc_ldst32_as_shift) &&                    \
+		MACRO_ARG(offset) >= 0
+		st.as MACRO_ARG(d), [MACRO_ARG(s), MACRO_ARG(offset) >> __arc_ldst32_as_shift]
 	.else
-		ADDR MACRO_ARG(temp), MACRO_ARG(s), off
+		ADDR MACRO_ARG(temp), MACRO_ARG(s), MACRO_ARG(offset)
 		st MACRO_ARG(d), [MACRO_ARG(temp)]
 	.endif
 .endm


### PR DESCRIPTION
Local variables in ASM macro works differently for GNU and MWDT toolchains. In case of GNU toolchain they are local per each macro instance, but in case of MWDT they are local per file where macro is used.

To avoid issues when macro is used multiple times in one file let's align _st32_huge_offset to have same behaviour with GNU & MWDT toolchains.