### PR TITLE
lib/cpp: Allow REQUIRES_FULL_LIBCPP to be selected by applications

### DIFF
--- a/lib/cpp/Kconfig
+++ b/lib/cpp/Kconfig
@@ -57,14 +57,12 @@ config STD_CPP2B
 endchoice
 
 config REQUIRES_FULL_LIBCPP
-	bool
+	bool "Require complete C++ standard library"
 	select REQUIRES_FULL_LIBC
 	help
-	  Helper symbol to indicate that a full C++ standard library
-	  implementation is required.
-
-	  Select this from a symbol that enables a feature requiring a full
-	  C++ standard library implementation.
+	  Indicates that a full C++ standard library is required, either by
+	  a subsystem or an application. This will also include a full C
+	  library implementation.
 
 choice LIBCPP_IMPLEMENTATION
 	prompt "C++ Standard Library Implementation"


### PR DESCRIPTION
Add a prompt to the Kconfig symbol so that applications can select this in to guide C++ standard library selection towards configurations which provide a complete implementation.

This can be used to address #57097 in a cleaner fashion.