### PR TITLE
Bluetooth: Mesh: Make elements as const

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/blob_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/blob_cli.rst
@@ -23,7 +23,7 @@ The BLOB Transfer Client is instantiated on an element with a set of event handl
          .cb = &blob_cb,
    };
 
-   static struct bt_mesh_model models[] = {
+   static const struct bt_mesh_model models[] = {
          BT_MESH_MODEL_BLOB_CLI(&blob_cli),
    };
 

--- a/doc/connectivity/bluetooth/api/mesh/blob_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/blob_srv.rst
@@ -27,7 +27,7 @@ The BLOB Transfer Server is instantiated on an element with a set of event handl
        .cb = &blob_cb,
    };
 
-   static struct bt_mesh_model models[] = {
+   static const struct bt_mesh_model models[] = {
        BT_MESH_MODEL_BLOB_SRV(&blob_srv),
    };
 

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -140,6 +140,9 @@ Changes in this release
   using picolibc, only applications using picolibc will be affected by this
   change at this time.
 
+* The Bluetooth Mesh ``element`` and ``model`` declaration has been changed to add prefix ``const``,
+  The ``elem->addr`` has been removed. The new API :c:func:`bt_mesh_elem_addr_get` has been added instead.
+
 Removed APIs in this release
 ============================
 

--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -108,9 +108,6 @@ extern "C" {
 
 /** Abstraction that describes a Mesh Element */
 struct bt_mesh_elem {
-	/** Unicast Address. Set at runtime during provisioning. */
-	uint16_t addr;
-
 	/** Location Descriptor (GATT Bluetooth Namespace Descriptors) */
 	const uint16_t loc;
 	/** The number of SIG models in this element */
@@ -801,7 +798,7 @@ static inline bool bt_mesh_model_pub_is_retransmission(const struct bt_mesh_mode
  *
  *  @return Pointer to the element that the given model belongs to.
  */
-struct bt_mesh_elem *bt_mesh_model_elem(struct bt_mesh_model *mod);
+const struct bt_mesh_elem *bt_mesh_model_elem(struct bt_mesh_model *mod);
 
 /** @brief Find a SIG model.
  *
@@ -836,6 +833,15 @@ static inline bool bt_mesh_model_in_primary(const struct bt_mesh_model *mod)
 {
 	return (mod->elem_idx == 0);
 }
+
+/** @brief Get the address of the element.
+ *
+ *  @param elem Element to get address of.
+ *
+ *  @return The address of the element if the device is provisioned,
+ *          @ref BT_MESH_ADDR_UNASSIGNED otherwise.
+ */
+uint16_t bt_mesh_elem_addr_get(const struct bt_mesh_elem *elem);
 
 /** @brief Immediately store the model's user data in persistent storage.
  *
@@ -943,7 +949,7 @@ struct bt_mesh_comp {
 	uint16_t vid; /**< Version ID */
 
 	size_t elem_count; /**< The number of elements in this device. */
-	struct bt_mesh_elem *elem; /**< List of elements. */
+	const struct bt_mesh_elem *elem; /**< List of elements. */
 };
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/mesh/blob_cli.h
+++ b/include/zephyr/bluetooth/mesh/blob_cli.h
@@ -292,7 +292,7 @@ struct bt_mesh_blob_cli {
 	const struct bt_mesh_blob_cli_cb *cb;
 
 	/* Runtime state */
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 
 	struct {
 		struct bt_mesh_blob_target *target;

--- a/include/zephyr/bluetooth/mesh/blob_srv.h
+++ b/include/zephyr/bluetooth/mesh/blob_srv.h
@@ -137,7 +137,7 @@ struct bt_mesh_blob_srv {
 	const struct bt_mesh_blob_io *io;
 	struct k_work_delayable rx_timeout;
 	struct bt_mesh_blob_block block;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	enum bt_mesh_blob_xfer_phase phase;
 
 	struct bt_mesh_blob_srv_state {

--- a/include/zephyr/bluetooth/mesh/cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/cfg_cli.h
@@ -190,7 +190,7 @@ struct bt_mesh_cfg_cli_cb {
 /** Mesh Configuration Client Model Context */
 struct bt_mesh_cfg_cli {
 	/** Composition data model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/** Optional callback for Mesh Configuration Client Status messages. */
 	const struct bt_mesh_cfg_cli_cb *cb;

--- a/include/zephyr/bluetooth/mesh/dfd_srv.h
+++ b/include/zephyr/bluetooth/mesh/dfd_srv.h
@@ -116,7 +116,7 @@ struct bt_mesh_dfd_srv_cb {
 /** Firmware Distribution Server instance. */
 struct bt_mesh_dfd_srv {
 	const struct bt_mesh_dfd_srv_cb *cb;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_dfu_cli dfu;
 	struct bt_mesh_dfu_target targets[CONFIG_BT_MESH_DFD_SRV_TARGETS_MAX];
 	struct bt_mesh_blob_target_pull pull_ctxs[CONFIG_BT_MESH_DFD_SRV_TARGETS_MAX];

--- a/include/zephyr/bluetooth/mesh/dfu_cli.h
+++ b/include/zephyr/bluetooth/mesh/dfu_cli.h
@@ -190,7 +190,7 @@ struct bt_mesh_dfu_cli {
 	/* runtime state */
 
 	uint32_t op;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 
 	struct {
 		const struct bt_mesh_dfu_slot *slot;

--- a/include/zephyr/bluetooth/mesh/dfu_srv.h
+++ b/include/zephyr/bluetooth/mesh/dfu_srv.h
@@ -184,7 +184,7 @@ struct bt_mesh_dfu_srv {
 	size_t img_count;
 
 	/* Runtime state */
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct {
 		/* Effect of transfer, @see bt_mesh_dfu_effect. */
 		uint8_t effect;

--- a/include/zephyr/bluetooth/mesh/health_cli.h
+++ b/include/zephyr/bluetooth/mesh/health_cli.h
@@ -26,7 +26,7 @@ extern "C" {
 /** Health Client Model Context */
 struct bt_mesh_health_cli {
 	/** Composition data model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/** Publication structure instance */
 	struct bt_mesh_model_pub pub;

--- a/include/zephyr/bluetooth/mesh/health_srv.h
+++ b/include/zephyr/bluetooth/mesh/health_srv.h
@@ -53,7 +53,7 @@ struct bt_mesh_health_srv_cb {
 	 *
 	 *  @return 0 on success, or (negative) error code otherwise.
 	 */
-	int (*fault_get_cur)(struct bt_mesh_model *model, uint8_t *test_id,
+	int (*fault_get_cur)(const struct bt_mesh_model *model, uint8_t *test_id,
 			     uint16_t *company_id, uint8_t *faults,
 			     uint8_t *fault_count);
 
@@ -79,7 +79,7 @@ struct bt_mesh_health_srv_cb {
 	 *
 	 *  @return 0 on success, or (negative) error code otherwise.
 	 */
-	int (*fault_get_reg)(struct bt_mesh_model *model, uint16_t company_id,
+	int (*fault_get_reg)(const struct bt_mesh_model *model, uint16_t company_id,
 			     uint8_t *test_id, uint8_t *faults,
 			     uint8_t *fault_count);
 
@@ -91,7 +91,7 @@ struct bt_mesh_health_srv_cb {
 	 *
 	 *  @return 0 on success, or (negative) error code otherwise.
 	 */
-	int (*fault_clear)(struct bt_mesh_model *model, uint16_t company_id);
+	int (*fault_clear)(const struct bt_mesh_model *model, uint16_t company_id);
 
 	/** @brief Run a self-test.
 	 *
@@ -108,7 +108,7 @@ struct bt_mesh_health_srv_cb {
 	 * (negative) error code otherwise. Note that the fault array will not
 	 * be reported back to the client if the test execution didn't start.
 	 */
-	int (*fault_test)(struct bt_mesh_model *model, uint8_t test_id,
+	int (*fault_test)(const struct bt_mesh_model *model, uint8_t test_id,
 			  uint16_t company_id);
 
 	/** @brief Start calling attention to the device.
@@ -125,7 +125,7 @@ struct bt_mesh_health_srv_cb {
 	 *
 	 *  @param model Health Server model to start the attention state of.
 	 */
-	void (*attn_on)(struct bt_mesh_model *model);
+	void (*attn_on)(const struct bt_mesh_model *model);
 
 	/** @brief Stop the attention state.
 	 *
@@ -134,7 +134,7 @@ struct bt_mesh_health_srv_cb {
 	 *
 	 *  @param model
 	 */
-	void (*attn_off)(struct bt_mesh_model *model);
+	void (*attn_off)(const struct bt_mesh_model *model);
 };
 
 /**
@@ -149,7 +149,7 @@ struct bt_mesh_health_srv_cb {
 /** Mesh Health Server Model Context */
 struct bt_mesh_health_srv {
 	/** Composition data model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/** Optional callback struct */
 	const struct bt_mesh_health_srv_cb *cb;

--- a/include/zephyr/bluetooth/mesh/health_srv.h
+++ b/include/zephyr/bluetooth/mesh/health_srv.h
@@ -219,7 +219,7 @@ struct bt_mesh_health_srv {
  *
  *  @return 0 on success, or (negative) error code otherwise.
  */
-int bt_mesh_health_srv_fault_update(struct bt_mesh_elem *elem);
+int bt_mesh_health_srv_fault_update(const struct bt_mesh_elem *elem);
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op bt_mesh_health_srv_op[];

--- a/include/zephyr/bluetooth/mesh/large_comp_data_cli.h
+++ b/include/zephyr/bluetooth/mesh/large_comp_data_cli.h
@@ -69,7 +69,7 @@ struct bt_mesh_large_comp_data_cli_cb {
 /** Large Composition Data Client model context */
 struct bt_mesh_large_comp_data_cli {
 	/** Model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/** Internal parameters for tracking message responses. */
 	struct bt_mesh_msg_ack_ctx ack_ctx;

--- a/include/zephyr/bluetooth/mesh/od_priv_proxy_cli.h
+++ b/include/zephyr/bluetooth/mesh/od_priv_proxy_cli.h
@@ -23,7 +23,7 @@ extern "C" {
 /** On-Demand Private Proxy Client Model Context */
 struct bt_mesh_od_priv_proxy_cli {
 	/** Solicitation PDU RPL model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/* Internal parameters for tracking message responses. */
 	struct bt_mesh_msg_ack_ctx ack_ctx;

--- a/include/zephyr/bluetooth/mesh/priv_beacon_cli.h
+++ b/include/zephyr/bluetooth/mesh/priv_beacon_cli.h
@@ -91,7 +91,7 @@ struct bt_mesh_priv_beacon_cli_cb {
 
 /** Mesh Private Beacon Client model */
 struct bt_mesh_priv_beacon_cli {
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/* Internal parameters for tracking message responses. */
 	struct bt_mesh_msg_ack_ctx ack_ctx;

--- a/include/zephyr/bluetooth/mesh/rpr_cli.h
+++ b/include/zephyr/bluetooth/mesh/rpr_cli.h
@@ -95,7 +95,7 @@ struct bt_mesh_rpr_cli {
 		enum bt_mesh_rpr_link_state state;
 	} link;
 
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 };
 
 /** @brief Get scanning capabilities of Remote Provisioning Server.

--- a/include/zephyr/bluetooth/mesh/sar_cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/sar_cfg_cli.h
@@ -27,7 +27,7 @@ extern "C" {
 /** Mesh SAR Configuration Client Model Context */
 struct bt_mesh_sar_cfg_cli {
 	/** Access model pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/* Publication structure instance */
 	struct bt_mesh_model_pub pub;

--- a/include/zephyr/bluetooth/mesh/sol_pdu_rpl_cli.h
+++ b/include/zephyr/bluetooth/mesh/sol_pdu_rpl_cli.h
@@ -23,7 +23,7 @@ extern "C" {
 /** Solicitation PDU RPL Client Model Context */
 struct bt_mesh_sol_pdu_rpl_cli {
 	/** Solicitation PDU RPL model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/* Internal parameters for tracking message responses. */
 	struct bt_mesh_msg_ack_ctx ack_ctx;

--- a/include/zephyr/bluetooth/testing.h
+++ b/include/zephyr/bluetooth/testing.h
@@ -39,9 +39,9 @@ struct bt_test_cb {
 			      const void *payload, size_t payload_len);
 	void (*mesh_model_recv)(uint16_t src, uint16_t dst, const void *payload,
 				size_t payload_len);
-	void (*mesh_model_bound)(uint16_t addr, struct bt_mesh_model *model,
+	void (*mesh_model_bound)(uint16_t addr, const struct bt_mesh_model *model,
 				 uint16_t key_idx);
-	void (*mesh_model_unbound)(uint16_t addr, struct bt_mesh_model *model,
+	void (*mesh_model_unbound)(uint16_t addr, const struct bt_mesh_model *model,
 				   uint16_t key_idx);
 	void (*mesh_prov_invalid_bearer)(uint8_t opcode);
 	void (*mesh_trans_incomp_timer_exp)(void);

--- a/samples/bluetooth/mesh/src/main.c
+++ b/samples/bluetooth/mesh/src/main.c
@@ -257,7 +257,7 @@ static struct bt_mesh_model models[] = {
 		      NULL),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, models, BT_MESH_MODEL_NONE),
 };
 

--- a/samples/bluetooth/mesh/src/main.c
+++ b/samples/bluetooth/mesh/src/main.c
@@ -25,12 +25,12 @@
 #define OP_ONOFF_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x03)
 #define OP_ONOFF_STATUS    BT_MESH_MODEL_OP_2(0x82, 0x04)
 
-static void attention_on(struct bt_mesh_model *mod)
+static void attention_on(const struct bt_mesh_model *mod)
 {
 	board_led_set(true);
 }
 
-static void attention_off(struct bt_mesh_model *mod)
+static void attention_off(const struct bt_mesh_model *mod)
 {
 	board_led_set(false);
 }
@@ -102,7 +102,7 @@ static inline uint8_t model_time_encode(int32_t ms)
 	return 0x3f;
 }
 
-static int onoff_status_send(struct bt_mesh_model *model,
+static int onoff_status_send(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx)
 {
 	uint32_t remaining;
@@ -151,7 +151,7 @@ static void onoff_timeout(struct k_work *work)
 
 /* Generic OnOff Server message handlers */
 
-static int gen_onoff_get(struct bt_mesh_model *model,
+static int gen_onoff_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -159,7 +159,7 @@ static int gen_onoff_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set_unack(struct bt_mesh_model *model,
+static int gen_onoff_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -202,7 +202,7 @@ static int gen_onoff_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set(struct bt_mesh_model *model,
+static int gen_onoff_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -221,7 +221,7 @@ static const struct bt_mesh_model_op gen_onoff_srv_op[] = {
 
 /* Generic OnOff Client */
 
-static int gen_onoff_status(struct bt_mesh_model *model,
+static int gen_onoff_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -248,7 +248,7 @@ static const struct bt_mesh_model_op gen_onoff_cli_op[] = {
 };
 
 /* This application only needs one element to contain its models */
-static struct bt_mesh_model models[] = {
+static const struct bt_mesh_model models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_srv_op, NULL,

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -50,14 +50,14 @@ static void heartbeat(const struct bt_mesh_hb_sub *sub, uint8_t hops,
 static struct bt_mesh_cfg_cli cfg_cli = {
 };
 
-static void attention_on(struct bt_mesh_model *model)
+static void attention_on(const struct bt_mesh_model *model)
 {
 	printk("attention_on()\n");
 	board_attention(true);
 	board_play("100H100C100H100C100H100C");
 }
 
-static void attention_off(struct bt_mesh_model *model)
+static void attention_off(const struct bt_mesh_model *model)
 {
 	printk("attention_off()\n");
 	board_attention(false);
@@ -74,19 +74,19 @@ static struct bt_mesh_health_srv health_srv = {
 
 BT_MESH_HEALTH_PUB_DEFINE(health_pub, 0);
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
 };
 
-static int vnd_button_pressed(struct bt_mesh_model *model,
+static int vnd_button_pressed(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
 	printk("src 0x%04x\n", ctx->addr);
 
-	if (ctx->addr == bt_mesh_model_elem(model)->addr) {
+	if (ctx->addr == bt_mesh_elem_addr_get(bt_mesh_model_elem(model))) {
 		return 0;
 	}
 
@@ -101,7 +101,7 @@ static const struct bt_mesh_model_op vnd_ops[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static struct bt_mesh_model vnd_models[] = {
+static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, MOD_LF, vnd_ops, NULL, NULL),
 };
 

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -105,7 +105,7 @@ static struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, MOD_LF, vnd_ops, NULL, NULL),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, vnd_models),
 };
 

--- a/samples/bluetooth/mesh_provisioner/src/main.c
+++ b/samples/bluetooth/mesh_provisioner/src/main.c
@@ -53,7 +53,7 @@ static struct bt_mesh_health_cli health_cli = {
 	.current_status = health_current_status,
 };
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_CLI(&health_cli),

--- a/samples/bluetooth/mesh_provisioner/src/main.c
+++ b/samples/bluetooth/mesh_provisioner/src/main.c
@@ -59,7 +59,7 @@ static struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_HEALTH_CLI(&health_cli),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, BT_MESH_MODEL_NONE),
 };
 

--- a/samples/boards/nrf/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff-app/src/main.c
@@ -54,19 +54,19 @@
 #define BT_MESH_MODEL_OP_GEN_ONOFF_SET_UNACK	BT_MESH_MODEL_OP_2(0x82, 0x03)
 #define BT_MESH_MODEL_OP_GEN_ONOFF_STATUS	BT_MESH_MODEL_OP_2(0x82, 0x04)
 
-static int gen_onoff_set(struct bt_mesh_model *model,
+static int gen_onoff_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf);
 
-static int gen_onoff_set_unack(struct bt_mesh_model *model,
+static int gen_onoff_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf);
 
-static int gen_onoff_get(struct bt_mesh_model *model,
+static int gen_onoff_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf);
 
-static int gen_onoff_status(struct bt_mesh_model *model,
+static int gen_onoff_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf);
 
@@ -167,7 +167,7 @@ static struct onoff_state onoff_state[] = {
  * Element 0 Root Models
  */
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
@@ -181,7 +181,7 @@ static struct bt_mesh_model root_models[] = {
  * Element 1 Models
  */
 
-static struct bt_mesh_model secondary_0_models[] = {
+static const struct bt_mesh_model secondary_0_models[] = {
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_srv_op,
 		      &gen_onoff_pub_srv_s_0, &onoff_state[1]),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, gen_onoff_cli_op,
@@ -192,7 +192,7 @@ static struct bt_mesh_model secondary_0_models[] = {
  * Element 2 Models
  */
 
-static struct bt_mesh_model secondary_1_models[] = {
+static const struct bt_mesh_model secondary_1_models[] = {
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_srv_op,
 		      &gen_onoff_pub_srv_s_1, &onoff_state[2]),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, gen_onoff_cli_op,
@@ -203,7 +203,7 @@ static struct bt_mesh_model secondary_1_models[] = {
  * Element 3 Models
  */
 
-static struct bt_mesh_model secondary_2_models[] = {
+static const struct bt_mesh_model secondary_2_models[] = {
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_srv_op,
 		      &gen_onoff_pub_srv_s_2, &onoff_state[3]),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, gen_onoff_cli_op,
@@ -214,7 +214,7 @@ static struct bt_mesh_model secondary_2_models[] = {
  * Button to Client Model Assignments
  */
 
-struct bt_mesh_model *mod_cli_sw[] = {
+const struct bt_mesh_model *mod_cli_sw[] = {
 		&root_models[4],
 		&secondary_0_models[1],
 		&secondary_1_models[1],
@@ -225,7 +225,7 @@ struct bt_mesh_model *mod_cli_sw[] = {
  * LED to Server Model Assignments
  */
 
-struct bt_mesh_model *mod_srv_sw[] = {
+const struct bt_mesh_model *mod_srv_sw[] = {
 		&root_models[3],
 		&secondary_0_models[0],
 		&secondary_1_models[0],
@@ -281,7 +281,7 @@ static uint16_t primary_net_idx;
  *
  */
 
-static int gen_onoff_get(struct bt_mesh_model *model,
+static int gen_onoff_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -289,7 +289,7 @@ static int gen_onoff_get(struct bt_mesh_model *model,
 	struct onoff_state *onoff_state = model->user_data;
 
 	printk("addr 0x%04x onoff 0x%02x\n",
-	       bt_mesh_model_elem(model)->addr, onoff_state->current);
+	       bt_mesh_elem_addr_get(bt_mesh_model_elem(model)), onoff_state->current);
 	bt_mesh_model_msg_init(&msg, BT_MESH_MODEL_OP_GEN_ONOFF_STATUS);
 	net_buf_simple_add_u8(&msg, onoff_state->current);
 
@@ -300,7 +300,7 @@ static int gen_onoff_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set_unack(struct bt_mesh_model *model,
+static int gen_onoff_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -310,7 +310,7 @@ static int gen_onoff_set_unack(struct bt_mesh_model *model,
 
 	onoff_state->current = net_buf_simple_pull_u8(buf);
 	printk("addr 0x%02x state 0x%02x\n",
-	       bt_mesh_model_elem(model)->addr, onoff_state->current);
+	       bt_mesh_elem_addr_get(bt_mesh_model_elem(model)), onoff_state->current);
 
 	gpio_pin_set_dt(&onoff_state->led_device, onoff_state->current);
 
@@ -340,7 +340,7 @@ static int gen_onoff_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set(struct bt_mesh_model *model,
+static int gen_onoff_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -352,7 +352,7 @@ static int gen_onoff_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_status(struct bt_mesh_model *model,
+static int gen_onoff_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -361,7 +361,7 @@ static int gen_onoff_status(struct bt_mesh_model *model,
 	state = net_buf_simple_pull_u8(buf);
 
 	printk("Node 0x%04x OnOff status from 0x%04x with state 0x%02x\n",
-	       bt_mesh_model_elem(model)->addr, ctx->addr, state);
+	       bt_mesh_elem_addr_get(bt_mesh_model_elem(model)), ctx->addr, state);
 
 	return 0;
 }
@@ -465,7 +465,7 @@ static void button_cnt_timer(struct k_timer *work)
 
 static void button_pressed_worker(struct k_work *work)
 {
-	struct bt_mesh_model *mod_cli, *mod_srv;
+	const struct bt_mesh_model *mod_cli, *mod_srv;
 	struct bt_mesh_model_pub *pub_cli, *pub_srv;
 	struct sw *sw = CONTAINER_OF(work, struct sw, button_work);
 	int err;

--- a/samples/boards/nrf/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff-app/src/main.c
@@ -236,7 +236,7 @@ struct bt_mesh_model *mod_srv_sw[] = {
  * Root and Secondary Element Declarations
  */
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, BT_MESH_MODEL_NONE),
 	BT_MESH_ELEM(0, secondary_0_models, BT_MESH_MODEL_NONE),
 	BT_MESH_ELEM(0, secondary_1_models, BT_MESH_MODEL_NONE),

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -68,7 +68,7 @@ static const struct bt_mesh_elem elements[];
 /* message handlers (Start) */
 
 /* Generic OnOff Server message handlers */
-static int gen_onoff_get(struct bt_mesh_model *model,
+static int gen_onoff_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -95,7 +95,7 @@ send:
 	return 0;
 }
 
-void gen_onoff_publish(struct bt_mesh_model *model)
+void gen_onoff_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -119,7 +119,7 @@ void gen_onoff_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int gen_onoff_set_unack(struct bt_mesh_model *model,
+static int gen_onoff_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -188,7 +188,7 @@ static int gen_onoff_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set(struct bt_mesh_model *model,
+static int gen_onoff_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -261,7 +261,7 @@ static int gen_onoff_set(struct bt_mesh_model *model,
 }
 
 /* Generic OnOff Client message handlers */
-static int gen_onoff_status(struct bt_mesh_model *model,
+static int gen_onoff_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -277,7 +277,7 @@ static int gen_onoff_status(struct bt_mesh_model *model,
 }
 
 /* Generic Level (LIGHTNESS) Server message handlers */
-static int gen_level_get(struct bt_mesh_model *model,
+static int gen_level_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -304,7 +304,7 @@ send:
 	return 0;
 }
 
-void gen_level_publish(struct bt_mesh_model *model)
+void gen_level_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -328,7 +328,7 @@ void gen_level_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int gen_level_set_unack(struct bt_mesh_model *model,
+static int gen_level_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -394,7 +394,7 @@ static int gen_level_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_level_set(struct bt_mesh_model *model,
+static int gen_level_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -463,7 +463,7 @@ static int gen_level_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_delta_set_unack(struct bt_mesh_model *model,
+static int gen_delta_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -545,7 +545,7 @@ static int gen_delta_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_delta_set(struct bt_mesh_model *model,
+static int gen_delta_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -630,7 +630,7 @@ static int gen_delta_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_move_set_unack(struct bt_mesh_model *model,
+static int gen_move_set_unack(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -705,7 +705,7 @@ static int gen_move_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_move_set(struct bt_mesh_model *model,
+static int gen_move_set(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
@@ -783,7 +783,7 @@ static int gen_move_set(struct bt_mesh_model *model,
 }
 
 /* Generic Level Client message handlers */
-static int gen_level_status(struct bt_mesh_model *model,
+static int gen_level_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -799,7 +799,7 @@ static int gen_level_status(struct bt_mesh_model *model,
 }
 
 /* Generic Default Transition Time Server message handlers */
-static int gen_def_trans_time_get(struct bt_mesh_model *model,
+static int gen_def_trans_time_get(const struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
@@ -815,7 +815,7 @@ static int gen_def_trans_time_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static void gen_def_trans_time_publish(struct bt_mesh_model *model)
+static void gen_def_trans_time_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -833,7 +833,7 @@ static void gen_def_trans_time_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int gen_def_trans_time_set_unack(struct bt_mesh_model *model,
+static int gen_def_trans_time_set_unack(const struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
@@ -855,7 +855,7 @@ static int gen_def_trans_time_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_def_trans_time_set(struct bt_mesh_model *model,
+static int gen_def_trans_time_set(const struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
@@ -881,7 +881,7 @@ static int gen_def_trans_time_set(struct bt_mesh_model *model,
 }
 
 /* Generic Default Transition Time Client message handlers */
-static int gen_def_trans_time_status(struct bt_mesh_model *model,
+static int gen_def_trans_time_status(const struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
@@ -892,7 +892,7 @@ static int gen_def_trans_time_status(struct bt_mesh_model *model,
 }
 
 /* Generic Power OnOff Server message handlers */
-static int gen_onpowerup_get(struct bt_mesh_model *model,
+static int gen_onpowerup_get(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -909,7 +909,7 @@ static int gen_onpowerup_get(struct bt_mesh_model *model,
 }
 
 /* Generic Power OnOff Client message handlers */
-static int gen_onpowerup_status(struct bt_mesh_model *model,
+static int gen_onpowerup_status(const struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
@@ -921,7 +921,7 @@ static int gen_onpowerup_status(struct bt_mesh_model *model,
 
 /* Generic Power OnOff Setup Server message handlers */
 
-static void gen_onpowerup_publish(struct bt_mesh_model *model)
+static void gen_onpowerup_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -939,7 +939,7 @@ static void gen_onpowerup_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int gen_onpowerup_set_unack(struct bt_mesh_model *model,
+static int gen_onpowerup_set_unack(const struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
@@ -961,7 +961,7 @@ static int gen_onpowerup_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onpowerup_set(struct bt_mesh_model *model,
+static int gen_onpowerup_set(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -987,7 +987,7 @@ static int gen_onpowerup_set(struct bt_mesh_model *model,
 }
 
 /* Vendor Model message handlers*/
-static int vnd_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int vnd_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		   struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(3 + 6 + 4);
@@ -1007,7 +1007,7 @@ static int vnd_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int vnd_set_unack(struct bt_mesh_model *model,
+static int vnd_set_unack(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -1040,7 +1040,7 @@ static int vnd_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int vnd_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int vnd_set(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		   struct net_buf_simple *buf)
 {
 	(void)vnd_set_unack(model, ctx, buf);
@@ -1049,7 +1049,7 @@ static int vnd_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int vnd_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int vnd_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
 	printk("Acknowledgement from Vendor\n");
@@ -1060,7 +1060,7 @@ static int vnd_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 }
 
 /* Light Lightness Server message handlers */
-static int light_lightness_get(struct bt_mesh_model *model,
+static int light_lightness_get(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -1087,7 +1087,7 @@ send:
 	return 0;
 }
 
-void light_lightness_publish(struct bt_mesh_model *model)
+void light_lightness_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -1111,7 +1111,7 @@ void light_lightness_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_lightness_set_unack(struct bt_mesh_model *model,
+static int light_lightness_set_unack(const struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
@@ -1177,7 +1177,7 @@ static int light_lightness_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_set(struct bt_mesh_model *model,
+static int light_lightness_set(const struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
@@ -1246,7 +1246,7 @@ static int light_lightness_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_linear_get(struct bt_mesh_model *model,
+static int light_lightness_linear_get(const struct bt_mesh_model *model,
 				      struct bt_mesh_msg_ctx *ctx,
 				      struct net_buf_simple *buf)
 {
@@ -1274,7 +1274,7 @@ send:
 	return 0;
 }
 
-void light_lightness_linear_publish(struct bt_mesh_model *model)
+void light_lightness_linear_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -1299,7 +1299,7 @@ void light_lightness_linear_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_lightness_linear_set_unack(struct bt_mesh_model *model,
+static int light_lightness_linear_set_unack(const struct bt_mesh_model *model,
 					    struct bt_mesh_msg_ctx *ctx,
 					    struct net_buf_simple *buf)
 {
@@ -1365,7 +1365,7 @@ static int light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_linear_set(struct bt_mesh_model *model,
+static int light_lightness_linear_set(const struct bt_mesh_model *model,
 				      struct bt_mesh_msg_ctx *ctx,
 				      struct net_buf_simple *buf)
 {
@@ -1434,7 +1434,7 @@ static int light_lightness_linear_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_last_get(struct bt_mesh_model *model,
+static int light_lightness_last_get(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -1450,7 +1450,7 @@ static int light_lightness_last_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_default_get(struct bt_mesh_model *model,
+static int light_lightness_default_get(const struct bt_mesh_model *model,
 				       struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
@@ -1467,7 +1467,7 @@ static int light_lightness_default_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_range_get(struct bt_mesh_model *model,
+static int light_lightness_range_get(const struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
@@ -1489,7 +1489,7 @@ static int light_lightness_range_get(struct bt_mesh_model *model,
 
 /* Light Lightness Setup Server message handlers */
 
-static void light_lightness_default_publish(struct bt_mesh_model *model)
+static void light_lightness_default_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -1508,7 +1508,7 @@ static void light_lightness_default_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_lightness_default_set_unack(struct bt_mesh_model *model,
+static int light_lightness_default_set_unack(const struct bt_mesh_model *model,
 					     struct bt_mesh_msg_ctx *ctx,
 					     struct net_buf_simple *buf)
 {
@@ -1527,7 +1527,7 @@ static int light_lightness_default_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_default_set(struct bt_mesh_model *model,
+static int light_lightness_default_set(const struct bt_mesh_model *model,
 				       struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
@@ -1549,7 +1549,7 @@ static int light_lightness_default_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static void light_lightness_range_publish(struct bt_mesh_model *model)
+static void light_lightness_range_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -1569,7 +1569,7 @@ static void light_lightness_range_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_lightness_range_set_unack(struct bt_mesh_model *model,
+static int light_lightness_range_set_unack(const struct bt_mesh_model *model,
 					   struct bt_mesh_msg_ctx *ctx,
 					   struct net_buf_simple *buf)
 {
@@ -1603,7 +1603,7 @@ static int light_lightness_range_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_range_set(struct bt_mesh_model *model,
+static int light_lightness_range_set(const struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
@@ -1641,7 +1641,7 @@ static int light_lightness_range_set(struct bt_mesh_model *model,
 }
 
 /* Light Lightness Client message handlers */
-static int light_lightness_status(struct bt_mesh_model *model,
+static int light_lightness_status(const struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
@@ -1657,7 +1657,7 @@ static int light_lightness_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_linear_status(struct bt_mesh_model *model,
+static int light_lightness_linear_status(const struct bt_mesh_model *model,
 					 struct bt_mesh_msg_ctx *ctx,
 					 struct net_buf_simple *buf)
 {
@@ -1673,7 +1673,7 @@ static int light_lightness_linear_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_last_status(struct bt_mesh_model *model,
+static int light_lightness_last_status(const struct bt_mesh_model *model,
 				       struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
@@ -1683,7 +1683,7 @@ static int light_lightness_last_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_default_status(struct bt_mesh_model *model,
+static int light_lightness_default_status(const struct bt_mesh_model *model,
 					  struct bt_mesh_msg_ctx *ctx,
 					  struct net_buf_simple *buf)
 {
@@ -1693,7 +1693,7 @@ static int light_lightness_default_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_range_status(struct bt_mesh_model *model,
+static int light_lightness_range_status(const struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
@@ -1706,7 +1706,7 @@ static int light_lightness_range_status(struct bt_mesh_model *model,
 }
 
 /* Light CTL Server message handlers */
-static int light_ctl_get(struct bt_mesh_model *model,
+static int light_ctl_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -1736,7 +1736,7 @@ send:
 	return 0;
 }
 
-void light_ctl_publish(struct bt_mesh_model *model)
+void light_ctl_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -1766,7 +1766,7 @@ void light_ctl_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_ctl_set_unack(struct bt_mesh_model *model,
+static int light_ctl_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -1845,7 +1845,7 @@ static int light_ctl_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_set(struct bt_mesh_model *model,
+static int light_ctl_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -1927,7 +1927,7 @@ static int light_ctl_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_temp_range_get(struct bt_mesh_model *model,
+static int light_ctl_temp_range_get(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -1947,7 +1947,7 @@ static int light_ctl_temp_range_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_default_get(struct bt_mesh_model *model,
+static int light_ctl_default_get(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -1967,7 +1967,7 @@ static int light_ctl_default_get(struct bt_mesh_model *model,
 
 /* Light CTL Setup Server message handlers */
 
-static void light_ctl_default_publish(struct bt_mesh_model *model)
+static void light_ctl_default_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -1987,7 +1987,7 @@ static void light_ctl_default_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_ctl_default_set_unack(struct bt_mesh_model *model,
+static int light_ctl_default_set_unack(const struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
@@ -2018,7 +2018,7 @@ static int light_ctl_default_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_default_set(struct bt_mesh_model *model,
+static int light_ctl_default_set(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -2052,7 +2052,7 @@ static int light_ctl_default_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static void light_ctl_temp_range_publish(struct bt_mesh_model *model)
+static void light_ctl_temp_range_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -2072,7 +2072,7 @@ static void light_ctl_temp_range_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_ctl_temp_range_set_unack(struct bt_mesh_model *model,
+static int light_ctl_temp_range_set_unack(const struct bt_mesh_model *model,
 					  struct bt_mesh_msg_ctx *ctx,
 					  struct net_buf_simple *buf)
 {
@@ -2108,7 +2108,7 @@ static int light_ctl_temp_range_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_temp_range_set(struct bt_mesh_model *model,
+static int light_ctl_temp_range_set(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -2148,7 +2148,7 @@ static int light_ctl_temp_range_set(struct bt_mesh_model *model,
 }
 
 /* Light CTL Client message handlers */
-static int light_ctl_status(struct bt_mesh_model *model,
+static int light_ctl_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -2168,7 +2168,7 @@ static int light_ctl_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_temp_range_status(struct bt_mesh_model *model,
+static int light_ctl_temp_range_status(const struct bt_mesh_model *model,
 				       struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
@@ -2180,7 +2180,7 @@ static int light_ctl_temp_range_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_temp_status(struct bt_mesh_model *model,
+static int light_ctl_temp_status(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -2201,7 +2201,7 @@ static int light_ctl_temp_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_default_status(struct bt_mesh_model *model,
+static int light_ctl_default_status(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -2214,7 +2214,7 @@ static int light_ctl_default_status(struct bt_mesh_model *model,
 }
 
 /* Light CTL Temp. Server message handlers */
-static int light_ctl_temp_get(struct bt_mesh_model *model,
+static int light_ctl_temp_get(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2244,7 +2244,7 @@ send:
 	return 0;
 }
 
-void light_ctl_temp_publish(struct bt_mesh_model *model)
+void light_ctl_temp_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -2270,7 +2270,7 @@ void light_ctl_temp_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_ctl_temp_set_unack(struct bt_mesh_model *model,
+static int light_ctl_temp_set_unack(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -2345,7 +2345,7 @@ static int light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_temp_set(struct bt_mesh_model *model,
+static int light_ctl_temp_set(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2424,7 +2424,7 @@ static int light_ctl_temp_set(struct bt_mesh_model *model,
 }
 
 /* Generic Level (TEMPERATURE) Server message handlers */
-static int gen_level_get_temp(struct bt_mesh_model *model,
+static int gen_level_get_temp(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2451,7 +2451,7 @@ send:
 	return 0;
 }
 
-void gen_level_publish_temp(struct bt_mesh_model *model)
+void gen_level_publish_temp(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -2475,7 +2475,7 @@ void gen_level_publish_temp(struct bt_mesh_model *model)
 	}
 }
 
-static int gen_level_set_unack_temp(struct bt_mesh_model *model,
+static int gen_level_set_unack_temp(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -2541,7 +2541,7 @@ static int gen_level_set_unack_temp(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_level_set_temp(struct bt_mesh_model *model,
+static int gen_level_set_temp(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2610,7 +2610,7 @@ static int gen_level_set_temp(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_delta_set_unack_temp(struct bt_mesh_model *model,
+static int gen_delta_set_unack_temp(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -2692,7 +2692,7 @@ static int gen_delta_set_unack_temp(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_delta_set_temp(struct bt_mesh_model *model,
+static int gen_delta_set_temp(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2777,7 +2777,7 @@ static int gen_delta_set_temp(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_move_set_unack_temp(struct bt_mesh_model *model,
+static int gen_move_set_unack_temp(const struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
@@ -2852,7 +2852,7 @@ static int gen_move_set_unack_temp(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_move_set_temp(struct bt_mesh_model *model,
+static int gen_move_set_temp(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -2931,7 +2931,7 @@ static int gen_move_set_temp(struct bt_mesh_model *model,
 }
 
 /* Generic Level (TEMPERATURE) Client message handlers */
-static int gen_level_status_temp(struct bt_mesh_model *model,
+static int gen_level_status_temp(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -63,7 +63,7 @@ struct vendor_state vnd_user_data;
 
 /* Definitions of models user data (End) */
 
-static struct bt_mesh_elem elements[];
+static const struct bt_mesh_elem elements[];
 
 /* message handlers (Start) */
 
@@ -3190,7 +3190,7 @@ struct bt_mesh_model s0_models[] = {
 		      NULL),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, vnd_models),
 	BT_MESH_ELEM(0, s0_models, BT_MESH_MODEL_NONE),
 };

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
@@ -99,12 +99,12 @@ extern struct bt_mesh_model s0_models[];
 
 extern const struct bt_mesh_comp comp;
 
-void gen_onoff_publish(struct bt_mesh_model *model);
-void gen_level_publish(struct bt_mesh_model *model);
-void light_lightness_publish(struct bt_mesh_model *model);
-void light_lightness_linear_publish(struct bt_mesh_model *model);
-void light_ctl_publish(struct bt_mesh_model *model);
-void light_ctl_temp_publish(struct bt_mesh_model *model);
-void gen_level_publish_temp(struct bt_mesh_model *model);
+void gen_onoff_publish(const struct bt_mesh_model *model);
+void gen_level_publish(const struct bt_mesh_model *model);
+void light_lightness_publish(const struct bt_mesh_model *model);
+void light_lightness_linear_publish(const struct bt_mesh_model *model);
+void light_ctl_publish(const struct bt_mesh_model *model);
+void light_ctl_temp_publish(const struct bt_mesh_model *model);
+void gen_level_publish_temp(const struct bt_mesh_model *model);
 
 #endif

--- a/samples/boards/reel_board/mesh_badge/src/mesh.c
+++ b/samples/boards/reel_board/mesh_badge/src/mesh.c
@@ -159,12 +159,12 @@ static struct bt_mesh_cfg_cli cfg_cli = {
 	.cb = &cfg_cli_cb,
 };
 
-static void attention_on(struct bt_mesh_model *model)
+static void attention_on(const struct bt_mesh_model *model)
 {
 	board_show_text("Attention!", false, K_SECONDS(2));
 }
 
-static void attention_off(struct bt_mesh_model *model)
+static void attention_off(const struct bt_mesh_model *model)
 {
 	board_refresh_display();
 }
@@ -179,7 +179,7 @@ static struct bt_mesh_health_srv health_srv = {
 };
 
 /* Generic OnOff Server message handlers */
-static int gen_onoff_get(struct bt_mesh_model *model,
+static int gen_onoff_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -187,7 +187,7 @@ static int gen_onoff_get(struct bt_mesh_model *model,
 	struct led_onoff_state *state = model->user_data;
 
 	printk("addr 0x%04x onoff 0x%02x\n",
-	       bt_mesh_model_elem(model)->addr, state->current);
+	       bt_mesh_elem_addr_get(bt_mesh_model_elem(model)), state->current);
 	bt_mesh_model_msg_init(&msg, BT_MESH_MODEL_OP_GEN_ONOFF_STATUS);
 	net_buf_simple_add_u8(&msg, state->current);
 
@@ -198,7 +198,7 @@ static int gen_onoff_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set_unack(struct bt_mesh_model *model,
+static int gen_onoff_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -229,7 +229,7 @@ static int gen_onoff_set_unack(struct bt_mesh_model *model,
 	state->last_msg_timestamp = now;
 
 	printk("addr 0x%02x state 0x%02x\n",
-	       bt_mesh_model_elem(model)->addr, state->current);
+	       bt_mesh_elem_addr_get(bt_mesh_model_elem(model)), state->current);
 
 	if (set_led_state(state->dev_id, onoff)) {
 		printk("Failed to set led state\n");
@@ -263,7 +263,7 @@ static int gen_onoff_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set(struct bt_mesh_model *model,
+static int gen_onoff_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -273,7 +273,7 @@ static int gen_onoff_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int sensor_desc_get(struct bt_mesh_model *model,
+static int sensor_desc_get(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -333,7 +333,7 @@ static void sensor_create_status(uint16_t id, struct net_buf_simple *msg)
 	}
 }
 
-static int sensor_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int sensor_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, 1 + MAX_SENS_STATUS_LEN + 4);
@@ -349,7 +349,7 @@ static int sensor_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int sensor_col_get(struct bt_mesh_model *model,
+static int sensor_col_get(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -357,7 +357,7 @@ static int sensor_col_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int sensor_series_get(struct bt_mesh_model *model,
+static int sensor_series_get(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -385,7 +385,7 @@ static const struct bt_mesh_model_op sensor_srv_op[] = {
 	{ BT_MESH_MODEL_OP_SENS_SERIES_GET, BT_MESH_LEN_EXACT(2), sensor_series_get },
 };
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
@@ -396,7 +396,7 @@ static struct bt_mesh_model root_models[] = {
 		      sensor_srv_op, NULL, NULL),
 };
 
-static int vnd_hello(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int vnd_hello(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		     struct net_buf_simple *buf)
 {
 	char str[32];
@@ -404,7 +404,7 @@ static int vnd_hello(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 
 	printk("Hello message from 0x%04x\n", ctx->addr);
 
-	if (ctx->addr == bt_mesh_model_elem(model)->addr) {
+	if (ctx->addr == bt_mesh_elem_addr_get(bt_mesh_model_elem(model))) {
 		printk("Ignoring message from self\n");
 		return 0;
 	}
@@ -423,7 +423,7 @@ static int vnd_hello(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int vnd_baduser(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int vnd_baduser(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	char str[32];
@@ -431,7 +431,7 @@ static int vnd_baduser(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 
 	printk("\"Bad user\" message from 0x%04x\n", ctx->addr);
 
-	if (ctx->addr == bt_mesh_model_elem(model)->addr) {
+	if (ctx->addr == bt_mesh_elem_addr_get(bt_mesh_model_elem(model))) {
 		printk("Ignoring message from self\n");
 		return 0;
 	}
@@ -448,14 +448,14 @@ static int vnd_baduser(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int vnd_heartbeat(struct bt_mesh_model *model,
+static int vnd_heartbeat(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
 	uint8_t init_ttl, hops;
 
 	/* Ignore messages from self */
-	if (ctx->addr == bt_mesh_model_elem(model)->addr) {
+	if (ctx->addr == bt_mesh_elem_addr_get(bt_mesh_model_elem(model))) {
 		return 0;
 	}
 
@@ -477,7 +477,7 @@ static const struct bt_mesh_model_op vnd_ops[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int pub_update(struct bt_mesh_model *mod)
+static int pub_update(const struct bt_mesh_model *mod)
 {
 	struct net_buf_simple *msg = mod->pub->msg;
 
@@ -491,7 +491,7 @@ static int pub_update(struct bt_mesh_model *mod)
 
 BT_MESH_MODEL_PUB_DEFINE(vnd_pub, pub_update, 3 + 1);
 
-static struct bt_mesh_model vnd_models[] = {
+static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, MOD_LF, vnd_ops, &vnd_pub, NULL),
 };
 
@@ -638,12 +638,12 @@ void mesh_start(void)
 
 bool mesh_is_initialized(void)
 {
-	return elements[0].addr != BT_MESH_ADDR_UNASSIGNED;
+	return bt_mesh_elem_addr_get(&elements[0]) != BT_MESH_ADDR_UNASSIGNED;
 }
 
 uint16_t mesh_get_addr(void)
 {
-	return elements[0].addr;
+	return bt_mesh_elem_addr_get(&elements[0]);
 }
 
 int mesh_init(void)

--- a/samples/boards/reel_board/mesh_badge/src/mesh.c
+++ b/samples/boards/reel_board/mesh_badge/src/mesh.c
@@ -495,7 +495,7 @@ static struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, MOD_LF, vnd_ops, &vnd_pub, NULL),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, vnd_models),
 };
 

--- a/subsys/bluetooth/host/testing.c
+++ b/subsys/bluetooth/host/testing.c
@@ -56,7 +56,7 @@ void bt_test_mesh_model_recv(uint16_t src, uint16_t dst, const void *payload,
 	}
 }
 
-void bt_test_mesh_model_bound(uint16_t addr, struct bt_mesh_model *model,
+void bt_test_mesh_model_bound(uint16_t addr, const struct bt_mesh_model *model,
 			      uint16_t key_idx)
 {
 	struct bt_test_cb *cb;
@@ -68,7 +68,7 @@ void bt_test_mesh_model_bound(uint16_t addr, struct bt_mesh_model *model,
 	}
 }
 
-void bt_test_mesh_model_unbound(uint16_t addr, struct bt_mesh_model *model,
+void bt_test_mesh_model_unbound(uint16_t addr, const struct bt_mesh_model *model,
 				uint16_t key_idx)
 {
 	struct bt_test_cb *cb;

--- a/subsys/bluetooth/host/testing.h
+++ b/subsys/bluetooth/host/testing.h
@@ -14,9 +14,9 @@ void bt_test_mesh_net_recv(uint8_t ttl, uint8_t ctl, uint16_t src, uint16_t dst,
 			   const void *payload, size_t payload_len);
 void bt_test_mesh_model_recv(uint16_t src, uint16_t dst, const void *payload,
 			     size_t payload_len);
-void bt_test_mesh_model_bound(uint16_t addr, struct bt_mesh_model *model,
+void bt_test_mesh_model_bound(uint16_t addr, const struct bt_mesh_model *model,
 			      uint16_t key_idx);
-void bt_test_mesh_model_unbound(uint16_t addr, struct bt_mesh_model *model,
+void bt_test_mesh_model_unbound(uint16_t addr, const struct bt_mesh_model *model,
 				uint16_t key_idx);
 void bt_test_mesh_prov_invalid_bearer(uint8_t opcode);
 void bt_test_mesh_trans_incomp_timer_exp(void);

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -87,20 +87,20 @@ static struct mod_relation mod_rel_list[MOD_REL_LIST_SIZE];
 		 (idx)++)
 
 #define IS_MOD_BASE(mod, idx) \
-	(mod_rel_list[(idx)].elem_base == (mod)->elem_idx && \
-	 mod_rel_list[(idx)].idx_base == (mod)->mod_idx &&   \
-	 !(mod_rel_list[(idx)].elem_ext != (mod)->elem_idx && \
-	   mod_rel_list[(idx)].idx_ext != (mod)->mod_idx))
+	(mod_rel_list[(idx)].elem_base == (mod)->ctx->elem_idx && \
+	 mod_rel_list[(idx)].idx_base == (mod)->ctx->mod_idx &&   \
+	 !(mod_rel_list[(idx)].elem_ext != (mod)->ctx->elem_idx && \
+	   mod_rel_list[(idx)].idx_ext != (mod)->ctx->mod_idx))
 
 #define IS_MOD_EXTENSION(mod, idx) \
-	 (mod_rel_list[(idx)].elem_ext == (mod)->elem_idx && \
-	  mod_rel_list[(idx)].idx_ext == (mod)->mod_idx &&   \
-	  !(mod_rel_list[(idx)].elem_base != (mod)->elem_idx && \
-	    mod_rel_list[(idx)].idx_base != (mod)->mod_idx))
+	 (mod_rel_list[(idx)].elem_ext == (mod)->ctx->elem_idx && \
+	  mod_rel_list[(idx)].idx_ext == (mod)->ctx->mod_idx &&   \
+	  !(mod_rel_list[(idx)].elem_base != (mod)->ctx->elem_idx && \
+	    mod_rel_list[(idx)].idx_base != (mod)->ctx->mod_idx))
 
 #define RELATION_TYPE_EXT 0xFF
 
-void bt_mesh_model_foreach(void (*func)(struct bt_mesh_model *mod,
+void bt_mesh_model_foreach(void (*func)(const struct bt_mesh_model *mod,
 					const struct bt_mesh_elem *elem,
 					bool vnd, bool primary,
 					void *user_data),
@@ -112,13 +112,13 @@ void bt_mesh_model_foreach(void (*func)(struct bt_mesh_model *mod,
 		const struct bt_mesh_elem *elem = &dev_comp->elem[i];
 
 		for (j = 0; j < elem->model_count; j++) {
-			struct bt_mesh_model *model = &elem->models[j];
+			const struct bt_mesh_model *model = &elem->models[j];
 
 			func(model, elem, false, i == 0, user_data);
 		}
 
 		for (j = 0; j < elem->vnd_model_count; j++) {
-			struct bt_mesh_model *model = &elem->vnd_models[j];
+			const struct bt_mesh_model *model = &elem->vnd_models[j];
 
 			func(model, elem, true, i == 0, user_data);
 		}
@@ -155,7 +155,7 @@ static void data_buf_add_le16_offset(struct net_buf_simple *buf,
 	}
 }
 
-static void comp_add_model(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
+static void comp_add_model(const struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 			   bool vnd, void *user_data)
 {
 	struct comp_foreach_model_arg *arg = user_data;
@@ -184,7 +184,7 @@ static void data_buf_add_mem_offset(struct net_buf_simple *buf,
 	}
 }
 
-static size_t metadata_model_size(struct bt_mesh_model *mod,
+static size_t metadata_model_size(const struct bt_mesh_model *mod,
 				  const struct bt_mesh_elem *elem, bool vnd)
 {
 	const struct bt_mesh_models_metadata_entry *entry;
@@ -225,13 +225,13 @@ size_t bt_mesh_metadata_page_0_size(void)
 			sizeof(elem->vnd_model_count);
 
 		for (j = 0; j < elem->model_count; j++) {
-			struct bt_mesh_model *model = &elem->models[j];
+			const struct bt_mesh_model *model = &elem->models[j];
 
 			size += metadata_model_size(model, elem, false);
 		}
 
 		for (j = 0; j < elem->vnd_model_count; j++) {
-			struct bt_mesh_model *model = &elem->vnd_models[j];
+			const struct bt_mesh_model *model = &elem->vnd_models[j];
 
 			size += metadata_model_size(model, elem, true);
 		}
@@ -240,7 +240,7 @@ size_t bt_mesh_metadata_page_0_size(void)
 	return size;
 }
 
-static int metadata_add_model(struct bt_mesh_model *mod,
+static int metadata_add_model(const struct bt_mesh_model *mod,
 			      const struct bt_mesh_elem *elem, bool vnd,
 			      void *user_data)
 {
@@ -310,7 +310,7 @@ int bt_mesh_metadata_get_page_0(struct net_buf_simple *buf, size_t offset)
 		vnd_count_ptr = data_buf_add_u8_offset(buf, 0, &offset);
 
 		for (j = 0; j < elem->model_count; j++) {
-			struct bt_mesh_model *model = &elem->models[j];
+			const struct bt_mesh_model *model = &elem->models[j];
 
 			if (!model->metadata) {
 				continue;
@@ -327,7 +327,7 @@ int bt_mesh_metadata_get_page_0(struct net_buf_simple *buf, size_t offset)
 		}
 
 		for (j = 0; j < elem->vnd_model_count; j++) {
-			struct bt_mesh_model *model = &elem->vnd_models[j];
+			const struct bt_mesh_model *model = &elem->vnd_models[j];
 
 			if (!model->metadata) {
 				continue;
@@ -417,13 +417,13 @@ static int comp_add_elem(struct net_buf_simple *buf, const struct bt_mesh_elem *
 	data_buf_add_u8_offset(buf, elem->vnd_model_count, offset);
 
 	for (i = 0; i < elem->model_count; i++) {
-		struct bt_mesh_model *model = &elem->models[i];
+		const struct bt_mesh_model *model = &elem->models[i];
 
 		comp_add_model(model, elem, false, &arg);
 	}
 
 	for (i = 0; i < elem->vnd_model_count; i++) {
-		struct bt_mesh_model *model = &elem->vnd_models[i];
+		const struct bt_mesh_model *model = &elem->vnd_models[i];
 
 		comp_add_model(model, elem, true, &arg);
 	}
@@ -473,7 +473,7 @@ int bt_mesh_comp_data_get_page_0(struct net_buf_simple *buf, size_t offset)
 	return 0;
 }
 
-static uint8_t count_mod_ext(struct bt_mesh_model *mod, uint8_t *max_offset)
+static uint8_t count_mod_ext(const struct bt_mesh_model *mod, uint8_t *max_offset)
 {
 	int i;
 	uint8_t extensions = 0;
@@ -494,7 +494,7 @@ static uint8_t count_mod_ext(struct bt_mesh_model *mod, uint8_t *max_offset)
 	return extensions;
 }
 
-static bool is_cor_present(struct bt_mesh_model *mod, uint8_t *cor_id)
+static bool is_cor_present(const struct bt_mesh_model *mod, uint8_t *cor_id)
 {
 	int i;
 
@@ -509,7 +509,7 @@ static bool is_cor_present(struct bt_mesh_model *mod, uint8_t *cor_id)
 	return false;
 }
 
-static void prep_model_item_header(struct bt_mesh_model *mod, uint8_t *cor_id,
+static void prep_model_item_header(const struct bt_mesh_model *mod, uint8_t *cor_id,
 			    uint8_t *mod_cnt, struct net_buf_simple *buf)
 {
 	uint8_t ext_mod_cnt;
@@ -537,7 +537,7 @@ static void prep_model_item_header(struct bt_mesh_model *mod, uint8_t *cor_id,
 	memset(mod_cnt, ext_mod_cnt, sizeof(uint8_t));
 }
 
-static void add_items_to_page(struct net_buf_simple *buf, struct bt_mesh_model *mod,
+static void add_items_to_page(struct net_buf_simple *buf, const struct bt_mesh_model *mod,
 		       uint8_t ext_mod_cnt)
 {
 	int i, offset;
@@ -545,7 +545,7 @@ static void add_items_to_page(struct net_buf_simple *buf, struct bt_mesh_model *
 
 	MOD_REL_LIST_FOR_EACH(i) {
 		if (IS_MOD_EXTENSION(mod, i)) {
-			offset = mod->elem_idx - mod_rel_list[i].elem_base;
+			offset = mod->ctx->elem_idx - mod_rel_list[i].elem_base;
 			mod_idx = mod_rel_list[i].idx_base;
 			if (ext_mod_cnt < 32 &&
 				offset < 4 &&
@@ -604,7 +604,7 @@ int bt_mesh_comp_data_get_page_1(struct net_buf_simple *buf)
 	return 0;
 }
 
-int32_t bt_mesh_model_pub_period_get(struct bt_mesh_model *mod)
+int32_t bt_mesh_model_pub_period_get(const struct bt_mesh_model *mod)
 {
 	int32_t period;
 
@@ -644,7 +644,7 @@ int32_t bt_mesh_model_pub_period_get(struct bt_mesh_model *mod)
 	}
 }
 
-static int32_t next_period(struct bt_mesh_model *mod)
+static int32_t next_period(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_model_pub *pub = mod->pub;
 	uint32_t period = 0;
@@ -685,7 +685,7 @@ static int32_t next_period(struct bt_mesh_model *mod)
 
 static void publish_sent(int err, void *user_data)
 {
-	struct bt_mesh_model *mod = user_data;
+	const struct bt_mesh_model *mod = user_data;
 	int32_t delay;
 
 	LOG_DBG("err %d, time %u", err, k_uptime_get_32());
@@ -715,7 +715,7 @@ static const struct bt_mesh_send_cb pub_sent_cb = {
 	.end = publish_sent,
 };
 
-static int publish_transmit(struct bt_mesh_model *mod)
+static int publish_transmit(const struct bt_mesh_model *mod)
 {
 	NET_BUF_SIMPLE_DEFINE(sdu, BT_MESH_TX_SDU_MAX);
 	struct bt_mesh_model_pub *pub = mod->pub;
@@ -728,7 +728,7 @@ static int publish_transmit(struct bt_mesh_model *mod)
 
 	net_buf_simple_add_mem(&sdu, pub->msg->data, pub->msg->len);
 
-	return bt_mesh_trans_send(&tx, &sdu, &pub_sent_cb, mod);
+	return bt_mesh_trans_send(&tx, &sdu, &pub_sent_cb, (void *)mod);
 }
 
 static int pub_period_start(struct bt_mesh_model_pub *pub)
@@ -749,7 +749,7 @@ static int pub_period_start(struct bt_mesh_model_pub *pub)
 		/* Skip this publish attempt. */
 		LOG_DBG("Update failed, skipping publish (err: %d)", err);
 		pub->count = 0;
-		publish_sent(err, pub->mod);
+		publish_sent(err, (void *)pub->mod);
 		return err;
 	}
 
@@ -781,7 +781,7 @@ static void mod_publish(struct k_work *work)
 		    bt_mesh_model_pub_is_retransmission(pub->mod)) {
 			err = pub->update(pub->mod);
 			if (err) {
-				publish_sent(err, pub->mod);
+				publish_sent(err, (void *)pub->mod);
 				return;
 			}
 		}
@@ -796,16 +796,16 @@ static void mod_publish(struct k_work *work)
 	err = publish_transmit(pub->mod);
 	if (err) {
 		LOG_ERR("Failed to publish (err %d)", err);
-		publish_sent(err, pub->mod);
+		publish_sent(err, (void *)pub->mod);
 	}
 }
 
-const struct bt_mesh_elem *bt_mesh_model_elem(struct bt_mesh_model *mod)
+const struct bt_mesh_elem *bt_mesh_model_elem(const struct bt_mesh_model *mod)
 {
-	return &dev_comp->elem[mod->elem_idx];
+	return &dev_comp->elem[mod->ctx->elem_idx];
 }
 
-struct bt_mesh_model *bt_mesh_model_get(bool vnd, uint8_t elem_idx, uint8_t mod_idx)
+const struct bt_mesh_model *bt_mesh_model_get(bool vnd, uint8_t elem_idx, uint8_t mod_idx)
 {
 	const struct bt_mesh_elem *elem;
 
@@ -834,7 +834,7 @@ struct bt_mesh_model *bt_mesh_model_get(bool vnd, uint8_t elem_idx, uint8_t mod_
 }
 
 #if defined(CONFIG_BT_MESH_MODEL_VND_MSG_CID_FORCE)
-static int bt_mesh_vnd_mod_msg_cid_check(struct bt_mesh_model *mod)
+static int bt_mesh_vnd_mod_msg_cid_check(const struct bt_mesh_model *mod)
 {
 	uint16_t cid;
 	const struct bt_mesh_model_op *op;
@@ -857,7 +857,7 @@ static int bt_mesh_vnd_mod_msg_cid_check(struct bt_mesh_model *mod)
 }
 #endif
 
-static void mod_init(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
+static void mod_init(const struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 		     bool vnd, bool primary, void *user_data)
 {
 	int i;
@@ -876,9 +876,9 @@ static void mod_init(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 		mod->keys[i] = BT_MESH_KEY_UNUSED;
 	}
 
-	mod->elem_idx = elem - dev_comp->elem;
+	mod->ctx->elem_idx = elem - dev_comp->elem;
 	if (vnd) {
-		mod->mod_idx = mod - elem->vnd_models;
+		mod->ctx->mod_idx = mod - elem->vnd_models;
 
 		if (IS_ENABLED(CONFIG_BT_MESH_MODEL_VND_MSG_CID_FORCE)) {
 			*err = bt_mesh_vnd_mod_msg_cid_check(mod);
@@ -888,7 +888,7 @@ static void mod_init(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 		}
 
 	} else {
-		mod->mod_idx = mod - elem->models;
+		mod->ctx->mod_idx = mod - elem->models;
 	}
 
 	if (mod->cb && mod->cb->init) {
@@ -966,7 +966,7 @@ uint16_t bt_mesh_primary_addr(void)
 	return dev_primary_addr;
 }
 
-static uint16_t *model_group_get(struct bt_mesh_model *mod, uint16_t addr)
+static uint16_t *model_group_get(const struct bt_mesh_model *mod, uint16_t addr)
 {
 	int i;
 
@@ -981,15 +981,15 @@ static uint16_t *model_group_get(struct bt_mesh_model *mod, uint16_t addr)
 
 struct find_group_visitor_ctx {
 	uint16_t *entry;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	uint16_t addr;
 };
 
-static enum bt_mesh_walk find_group_mod_visitor(struct bt_mesh_model *mod, void *user_data)
+static enum bt_mesh_walk find_group_mod_visitor(const struct bt_mesh_model *mod, void *user_data)
 {
 	struct find_group_visitor_ctx *ctx = user_data;
 
-	if (mod->elem_idx != ctx->mod->elem_idx) {
+	if (mod->ctx->elem_idx != ctx->mod->ctx->elem_idx) {
 		return BT_MESH_WALK_CONTINUE;
 	}
 
@@ -1002,7 +1002,7 @@ static enum bt_mesh_walk find_group_mod_visitor(struct bt_mesh_model *mod, void 
 	return BT_MESH_WALK_CONTINUE;
 }
 
-uint16_t *bt_mesh_model_find_group(struct bt_mesh_model **mod, uint16_t addr)
+uint16_t *bt_mesh_model_find_group(const struct bt_mesh_model **mod, uint16_t addr)
 {
 	struct find_group_visitor_ctx ctx = {
 		.mod = *mod,
@@ -1016,10 +1016,10 @@ uint16_t *bt_mesh_model_find_group(struct bt_mesh_model **mod, uint16_t addr)
 	return ctx.entry;
 }
 
-static struct bt_mesh_model *bt_mesh_elem_find_group(const struct bt_mesh_elem *elem,
+static const struct bt_mesh_model *bt_mesh_elem_find_group(const struct bt_mesh_elem *elem,
 						     uint16_t group_addr)
 {
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 	uint16_t *match;
 	int i;
 
@@ -1116,7 +1116,7 @@ uint8_t bt_mesh_elem_count(void)
 	return dev_comp->elem_count;
 }
 
-bool bt_mesh_model_has_key(struct bt_mesh_model *mod, uint16_t key)
+bool bt_mesh_model_has_key(const struct bt_mesh_model *mod, uint16_t key)
 {
 	int i;
 
@@ -1131,12 +1131,12 @@ bool bt_mesh_model_has_key(struct bt_mesh_model *mod, uint16_t key)
 	return false;
 }
 
-static bool model_has_dst(struct bt_mesh_model *mod, uint16_t dst)
+static bool model_has_dst(const struct bt_mesh_model *mod, uint16_t dst)
 {
 	if (BT_MESH_ADDR_IS_UNICAST(dst)) {
-		return (bt_mesh_elem_addr_get(&dev_comp->elem[mod->elem_idx]) == dst);
+		return (bt_mesh_elem_addr_get(&dev_comp->elem[mod->ctx->elem_idx]) == dst);
 	} else if (BT_MESH_ADDR_IS_GROUP(dst) || BT_MESH_ADDR_IS_VIRTUAL(dst) ||
-		  (BT_MESH_ADDR_IS_FIXED_GROUP(dst) &&  mod->elem_idx != 0)) {
+		  (BT_MESH_ADDR_IS_FIXED_GROUP(dst) &&  mod->ctx->elem_idx != 0)) {
 		return !!bt_mesh_model_find_group(&mod, dst);
 	}
 
@@ -1144,17 +1144,17 @@ static bool model_has_dst(struct bt_mesh_model *mod, uint16_t dst)
 	 * the lower layers have already confirmed that we are subscribing to
 	 * it. All models on the primary element should receive the message.
 	 */
-	return mod->elem_idx == 0;
+	return mod->ctx->elem_idx == 0;
 }
 
 static const struct bt_mesh_model_op *find_op(const struct bt_mesh_elem *elem,
-					      uint32_t opcode, struct bt_mesh_model **model)
+					      uint32_t opcode, const struct bt_mesh_model **model)
 {
 	uint8_t i;
 	uint8_t count;
 	/* This value shall not be used in shipping end products. */
 	uint32_t cid = UINT32_MAX;
-	struct bt_mesh_model *models;
+	const struct bt_mesh_model *models;
 
 	/* SIG models cannot contain 3-byte (vendor) OpCodes, and
 	 * vendor models cannot contain SIG (1- or 2-byte) OpCodes, so
@@ -1236,7 +1236,7 @@ static int element_model_recv(struct bt_mesh_msg_ctx *ctx,
 			      const struct bt_mesh_elem *elem, uint32_t opcode)
 {
 	const struct bt_mesh_model_op *op;
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 	struct net_buf_simple_state state;
 	int err;
 
@@ -1322,7 +1322,7 @@ int bt_mesh_model_recv(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
 	return err;
 }
 
-int bt_mesh_model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_model_send(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *msg,
 		       const struct bt_mesh_send_cb *cb, void *cb_data)
 {
@@ -1339,7 +1339,7 @@ int bt_mesh_model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				   cb, cb_data);
 }
 
-int bt_mesh_model_publish(struct bt_mesh_model *model)
+int bt_mesh_model_publish(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_model_pub *pub = model->pub;
 
@@ -1379,8 +1379,8 @@ int bt_mesh_model_publish(struct bt_mesh_model *model)
 	return 0;
 }
 
-struct bt_mesh_model *bt_mesh_model_find_vnd(const struct bt_mesh_elem *elem,
-					     uint16_t company, uint16_t id)
+const struct bt_mesh_model *bt_mesh_model_find_vnd(const struct bt_mesh_elem *elem,
+						   uint16_t company, uint16_t id)
 {
 	uint8_t i;
 
@@ -1394,8 +1394,8 @@ struct bt_mesh_model *bt_mesh_model_find_vnd(const struct bt_mesh_elem *elem,
 	return NULL;
 }
 
-struct bt_mesh_model *bt_mesh_model_find(const struct bt_mesh_elem *elem,
-					 uint16_t id)
+const struct bt_mesh_model *bt_mesh_model_find(const struct bt_mesh_elem *elem,
+					       uint16_t id)
 {
 	uint8_t i;
 
@@ -1413,8 +1413,8 @@ const struct bt_mesh_comp *bt_mesh_comp_get(void)
 	return dev_comp;
 }
 
-void bt_mesh_model_extensions_walk(struct bt_mesh_model *model,
-				   enum bt_mesh_walk (*cb)(struct bt_mesh_model *mod,
+void bt_mesh_model_extensions_walk(const struct bt_mesh_model *model,
+				   enum bt_mesh_walk (*cb)(const struct bt_mesh_model *mod,
 							   void *user_data),
 				   void *user_data)
 {
@@ -1422,14 +1422,14 @@ void bt_mesh_model_extensions_walk(struct bt_mesh_model *model,
 	(void)cb(model, user_data);
 	return;
 #else
-	struct bt_mesh_model *it;
+	const struct bt_mesh_model *it;
 
-	if (cb(model, user_data) == BT_MESH_WALK_STOP || !model->next) {
+	if (cb(model, user_data) == BT_MESH_WALK_STOP || !model->ctx->next) {
 		return;
 	}
 
 	/* List is circular. Step through all models until we reach the start: */
-	for (it = model->next; it != model; it = it->next) {
+	for (it = model->ctx->next; it != model; it = it->ctx->next) {
 		if (cb(it, user_data) == BT_MESH_WALK_STOP) {
 			return;
 		}
@@ -1438,16 +1438,16 @@ void bt_mesh_model_extensions_walk(struct bt_mesh_model *model,
 }
 
 #ifdef CONFIG_BT_MESH_MODEL_EXTENSIONS
-static int mod_rel_register(struct bt_mesh_model *base,
-				 struct bt_mesh_model *ext,
-				 uint8_t type)
+static int mod_rel_register(const struct bt_mesh_model *base,
+			    const struct bt_mesh_model *ext,
+			    uint8_t type)
 {
 	LOG_DBG("");
 	struct mod_relation extension = {
-		base->elem_idx,
-		base->mod_idx,
-		ext->elem_idx,
-		ext->mod_idx,
+		base->ctx->elem_idx,
+		base->ctx->mod_idx,
+		ext->ctx->elem_idx,
+		ext->ctx->mod_idx,
 		type,
 	};
 	int i;
@@ -1466,22 +1466,23 @@ static int mod_rel_register(struct bt_mesh_model *base,
 	return -ENOMEM;
 }
 
-int bt_mesh_model_extend(struct bt_mesh_model *extending_mod, struct bt_mesh_model *base_mod)
+int bt_mesh_model_extend(const struct bt_mesh_model *extending_mod,
+			 const struct bt_mesh_model *base_mod)
 {
-	struct bt_mesh_model *a = extending_mod;
-	struct bt_mesh_model *b = base_mod;
-	struct bt_mesh_model *a_next = a->next;
-	struct bt_mesh_model *b_next = b->next;
-	struct bt_mesh_model *it;
+	const struct bt_mesh_model *a = extending_mod;
+	const struct bt_mesh_model *b = base_mod;
+	const struct bt_mesh_model *a_next = a->ctx->next;
+	const struct bt_mesh_model *b_next = b->ctx->next;
+	const struct bt_mesh_model *it;
 
-	base_mod->flags |= BT_MESH_MOD_EXTENDED;
+	base_mod->ctx->flags |= BT_MESH_MOD_EXTENDED;
 
 	if (a == b) {
 		return 0;
 	}
 
 	/* Check if a's list contains b */
-	for (it = a; (it != NULL) && (it->next != a); it = it->next) {
+	for (it = a; (it != NULL) && (it->ctx->next != a); it = it->ctx->next) {
 		if (it == b) {
 			return 0;
 		}
@@ -1489,15 +1490,15 @@ int bt_mesh_model_extend(struct bt_mesh_model *extending_mod, struct bt_mesh_mod
 
 	/* Merge lists */
 	if (a_next) {
-		b->next = a_next;
+		b->ctx->next = a_next;
 	} else {
-		b->next = a;
+		b->ctx->next = a;
 	}
 
 	if (b_next) {
-		a->next = b_next;
+		a->ctx->next = b_next;
 	} else {
-		a->next = b;
+		a->ctx->next = b;
 	}
 
 
@@ -1508,8 +1509,8 @@ int bt_mesh_model_extend(struct bt_mesh_model *extending_mod, struct bt_mesh_mod
 	return 0;
 }
 
-int bt_mesh_model_correspond(struct bt_mesh_model *corresponding_mod,
-			     struct bt_mesh_model *base_mod)
+int bt_mesh_model_correspond(const struct bt_mesh_model *corresponding_mod,
+			     const struct bt_mesh_model *base_mod)
 {
 	int i, err;
 	uint8_t cor_id = 0;
@@ -1540,12 +1541,12 @@ int bt_mesh_model_correspond(struct bt_mesh_model *corresponding_mod,
 }
 #endif /* CONFIG_BT_MESH_MODEL_EXTENSIONS */
 
-bool bt_mesh_model_is_extended(struct bt_mesh_model *model)
+bool bt_mesh_model_is_extended(const struct bt_mesh_model *model)
 {
-	return model->flags & BT_MESH_MOD_EXTENDED;
+	return model->ctx->flags & BT_MESH_MOD_EXTENDED;
 }
 
-static int mod_set_bind(struct bt_mesh_model *mod, size_t len_rd,
+static int mod_set_bind(const struct bt_mesh_model *mod, size_t len_rd,
 			settings_read_cb read_cb, void *cb_arg)
 {
 	ssize_t len;
@@ -1573,7 +1574,7 @@ static int mod_set_bind(struct bt_mesh_model *mod, size_t len_rd,
 	return 0;
 }
 
-static int mod_set_sub(struct bt_mesh_model *mod, size_t len_rd,
+static int mod_set_sub(const struct bt_mesh_model *mod, size_t len_rd,
 		       settings_read_cb read_cb, void *cb_arg)
 {
 	size_t size = mod->groups_cnt * sizeof(mod->groups[0]);
@@ -1599,7 +1600,7 @@ static int mod_set_sub(struct bt_mesh_model *mod, size_t len_rd,
 	return 0;
 }
 
-static int mod_set_pub(struct bt_mesh_model *mod, size_t len_rd,
+static int mod_set_pub(const struct bt_mesh_model *mod, size_t len_rd,
 		       settings_read_cb read_cb, void *cb_arg)
 {
 	struct mod_pub_val pub;
@@ -1647,7 +1648,7 @@ static int mod_set_pub(struct bt_mesh_model *mod, size_t len_rd,
 	return 0;
 }
 
-static int mod_data_set(struct bt_mesh_model *mod,
+static int mod_data_set(const struct bt_mesh_model *mod,
 			const char *name, size_t len_rd,
 			settings_read_cb read_cb, void *cb_arg)
 {
@@ -1666,7 +1667,7 @@ static int mod_data_set(struct bt_mesh_model *mod,
 static int mod_set(bool vnd, const char *name, size_t len_rd,
 		   settings_read_cb read_cb, void *cb_arg)
 {
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	uint8_t elem_idx, mod_idx;
 	uint16_t mod_key;
 	int len;
@@ -1746,10 +1747,10 @@ static int comp_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 }
 BT_MESH_SETTINGS_DEFINE(comp, "cmp", comp_set);
 
-static void encode_mod_path(struct bt_mesh_model *mod, bool vnd,
+static void encode_mod_path(const struct bt_mesh_model *mod, bool vnd,
 			    const char *key, char *path, size_t path_len)
 {
-	uint16_t mod_key = (((uint16_t)mod->elem_idx << 8) | mod->mod_idx);
+	uint16_t mod_key = (((uint16_t)mod->ctx->elem_idx << 8) | mod->ctx->mod_idx);
 
 	if (vnd) {
 		snprintk(path, path_len, "bt/mesh/v/%x/%s", mod_key, key);
@@ -1758,7 +1759,7 @@ static void encode_mod_path(struct bt_mesh_model *mod, bool vnd,
 	}
 }
 
-static void store_pending_mod_bind(struct bt_mesh_model *mod, bool vnd)
+static void store_pending_mod_bind(const struct bt_mesh_model *mod, bool vnd)
 {
 	uint16_t keys[CONFIG_BT_MESH_MODEL_KEY_COUNT];
 	char path[20];
@@ -1786,7 +1787,7 @@ static void store_pending_mod_bind(struct bt_mesh_model *mod, bool vnd)
 	}
 }
 
-static void store_pending_mod_sub(struct bt_mesh_model *mod, bool vnd)
+static void store_pending_mod_sub(const struct bt_mesh_model *mod, bool vnd)
 {
 	uint16_t groups[CONFIG_BT_MESH_MODEL_GROUP_COUNT];
 	char path[20];
@@ -1814,7 +1815,7 @@ static void store_pending_mod_sub(struct bt_mesh_model *mod, bool vnd)
 	}
 }
 
-static void store_pending_mod_pub(struct bt_mesh_model *mod, bool vnd)
+static void store_pending_mod_pub(const struct bt_mesh_model *mod, bool vnd)
 {
 	struct mod_pub_val pub = {0};
 	char path[20];
@@ -1843,31 +1844,31 @@ static void store_pending_mod_pub(struct bt_mesh_model *mod, bool vnd)
 	}
 }
 
-static void store_pending_mod(struct bt_mesh_model *mod,
+static void store_pending_mod(const struct bt_mesh_model *mod,
 			      const struct bt_mesh_elem *elem, bool vnd,
 			      bool primary, void *user_data)
 {
-	if (!mod->flags) {
+	if (!mod->ctx->flags) {
 		return;
 	}
 
-	if (mod->flags & BT_MESH_MOD_BIND_PENDING) {
-		mod->flags &= ~BT_MESH_MOD_BIND_PENDING;
+	if (mod->ctx->flags & BT_MESH_MOD_BIND_PENDING) {
+		mod->ctx->flags &= ~BT_MESH_MOD_BIND_PENDING;
 		store_pending_mod_bind(mod, vnd);
 	}
 
-	if (mod->flags & BT_MESH_MOD_SUB_PENDING) {
-		mod->flags &= ~BT_MESH_MOD_SUB_PENDING;
+	if (mod->ctx->flags & BT_MESH_MOD_SUB_PENDING) {
+		mod->ctx->flags &= ~BT_MESH_MOD_SUB_PENDING;
 		store_pending_mod_sub(mod, vnd);
 	}
 
-	if (mod->flags & BT_MESH_MOD_PUB_PENDING) {
-		mod->flags &= ~BT_MESH_MOD_PUB_PENDING;
+	if (mod->ctx->flags & BT_MESH_MOD_PUB_PENDING) {
+		mod->ctx->flags &= ~BT_MESH_MOD_PUB_PENDING;
 		store_pending_mod_pub(mod, vnd);
 	}
 
-	if (mod->flags & BT_MESH_MOD_DATA_PENDING) {
-		mod->flags &= ~BT_MESH_MOD_DATA_PENDING;
+	if (mod->ctx->flags & BT_MESH_MOD_DATA_PENDING) {
+		mod->ctx->flags &= ~BT_MESH_MOD_DATA_PENDING;
 		mod->cb->pending_store(mod);
 	}
 }
@@ -1877,21 +1878,21 @@ void bt_mesh_model_pending_store(void)
 	bt_mesh_model_foreach(store_pending_mod, NULL);
 }
 
-void bt_mesh_model_bind_store(struct bt_mesh_model *mod)
+void bt_mesh_model_bind_store(const struct bt_mesh_model *mod)
 {
-	mod->flags |= BT_MESH_MOD_BIND_PENDING;
+	mod->ctx->flags |= BT_MESH_MOD_BIND_PENDING;
 	bt_mesh_settings_store_schedule(BT_MESH_SETTINGS_MOD_PENDING);
 }
 
-void bt_mesh_model_sub_store(struct bt_mesh_model *mod)
+void bt_mesh_model_sub_store(const struct bt_mesh_model *mod)
 {
-	mod->flags |= BT_MESH_MOD_SUB_PENDING;
+	mod->ctx->flags |= BT_MESH_MOD_SUB_PENDING;
 	bt_mesh_settings_store_schedule(BT_MESH_SETTINGS_MOD_PENDING);
 }
 
-void bt_mesh_model_pub_store(struct bt_mesh_model *mod)
+void bt_mesh_model_pub_store(const struct bt_mesh_model *mod)
 {
-	mod->flags |= BT_MESH_MOD_PUB_PENDING;
+	mod->ctx->flags |= BT_MESH_MOD_PUB_PENDING;
 	bt_mesh_settings_store_schedule(BT_MESH_SETTINGS_MOD_PENDING);
 }
 
@@ -1978,7 +1979,7 @@ int bt_mesh_comp_read(struct net_buf_simple *buf)
 	return 0;
 }
 
-int bt_mesh_model_data_store(struct bt_mesh_model *mod, bool vnd,
+int bt_mesh_model_data_store(const struct bt_mesh_model *mod, bool vnd,
 			     const char *name, const void *data,
 			     size_t data_len)
 {
@@ -2126,7 +2127,7 @@ int bt_mesh_models_metadata_change_prepare(void)
 	return bt_mesh_models_metadata_store();
 }
 
-static void commit_mod(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
+static void commit_mod(const struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 		       bool vnd, bool primary, void *user_data)
 {
 	if (mod->pub && mod->pub->update &&
@@ -2155,8 +2156,8 @@ void bt_mesh_model_settings_commit(void)
 	bt_mesh_model_foreach(commit_mod, NULL);
 }
 
-void bt_mesh_model_data_store_schedule(struct bt_mesh_model *mod)
+void bt_mesh_model_data_store_schedule(const struct bt_mesh_model *mod)
 {
-	mod->flags |= BT_MESH_MOD_DATA_PENDING;
+	mod->ctx->flags |= BT_MESH_MOD_DATA_PENDING;
 	bt_mesh_settings_store_schedule(BT_MESH_SETTINGS_MOD_PENDING);
 }

--- a/subsys/bluetooth/mesh/access.h
+++ b/subsys/bluetooth/mesh/access.h
@@ -33,32 +33,31 @@ int bt_mesh_comp_data_get_page_1(struct net_buf_simple *buf);
 const struct bt_mesh_elem *bt_mesh_elem_find(uint16_t addr);
 
 bool bt_mesh_has_addr(uint16_t addr);
-bool bt_mesh_model_has_key(struct bt_mesh_model *mod, uint16_t key);
+bool bt_mesh_model_has_key(const struct bt_mesh_model *mod, uint16_t key);
 
-void bt_mesh_model_extensions_walk(struct bt_mesh_model *root,
-				   enum bt_mesh_walk (*cb)(struct bt_mesh_model *mod,
+void bt_mesh_model_extensions_walk(const struct bt_mesh_model *root,
+				   enum bt_mesh_walk (*cb)(const struct bt_mesh_model *mod,
 							   void *user_data),
 				   void *user_data);
 
-uint16_t *bt_mesh_model_find_group(struct bt_mesh_model **mod, uint16_t addr);
+uint16_t *bt_mesh_model_find_group(const struct bt_mesh_model **mod, uint16_t addr);
 
-void bt_mesh_model_foreach(void (*func)(struct bt_mesh_model *mod,
+void bt_mesh_model_foreach(void (*func)(const struct bt_mesh_model *mod,
 					const struct bt_mesh_elem *elem,
 					bool vnd, bool primary,
 					void *user_data),
 			   void *user_data);
 
-int32_t bt_mesh_model_pub_period_get(struct bt_mesh_model *mod);
+int32_t bt_mesh_model_pub_period_get(const struct bt_mesh_model *mod);
 
 void bt_mesh_comp_provision(uint16_t addr);
 void bt_mesh_comp_unprovision(void);
 
 uint16_t bt_mesh_primary_addr(void);
-uint16_t bt_mesh_elem_addr_get(const struct bt_mesh_elem *elem);
 
 const struct bt_mesh_comp *bt_mesh_comp_get(void);
 
-struct bt_mesh_model *bt_mesh_model_get(bool vnd, uint8_t elem_idx, uint8_t mod_idx);
+const struct bt_mesh_model *bt_mesh_model_get(bool vnd, uint8_t elem_idx, uint8_t mod_idx);
 
 int bt_mesh_model_recv(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf);
 
@@ -73,9 +72,9 @@ void bt_mesh_comp_data_pending_clear(void);
 void bt_mesh_comp_data_clear(void);
 
 void bt_mesh_model_pending_store(void);
-void bt_mesh_model_bind_store(struct bt_mesh_model *mod);
-void bt_mesh_model_sub_store(struct bt_mesh_model *mod);
-void bt_mesh_model_pub_store(struct bt_mesh_model *mod);
+void bt_mesh_model_bind_store(const struct bt_mesh_model *mod);
+void bt_mesh_model_sub_store(const struct bt_mesh_model *mod);
+void bt_mesh_model_pub_store(const struct bt_mesh_model *mod);
 void bt_mesh_model_settings_commit(void);
 
 /** @brief Register a callback function hook for mesh model messages.

--- a/subsys/bluetooth/mesh/access.h
+++ b/subsys/bluetooth/mesh/access.h
@@ -20,7 +20,7 @@ enum {
 	BT_MESH_MOD_DATA_PENDING = BIT(5),
 };
 
-void bt_mesh_elem_register(struct bt_mesh_elem *elem, uint8_t count);
+void bt_mesh_elem_register(const struct bt_mesh_elem *elem, uint8_t count);
 
 uint8_t bt_mesh_elem_count(void);
 size_t bt_mesh_comp_page_0_size(void);
@@ -30,7 +30,7 @@ int bt_mesh_metadata_get_page_0(struct net_buf_simple *buf, size_t offset);
 int bt_mesh_comp_data_get_page_1(struct net_buf_simple *buf);
 
 /* Find local element based on unicast address */
-struct bt_mesh_elem *bt_mesh_elem_find(uint16_t addr);
+const struct bt_mesh_elem *bt_mesh_elem_find(uint16_t addr);
 
 bool bt_mesh_has_addr(uint16_t addr);
 bool bt_mesh_model_has_key(struct bt_mesh_model *mod, uint16_t key);
@@ -43,7 +43,7 @@ void bt_mesh_model_extensions_walk(struct bt_mesh_model *root,
 uint16_t *bt_mesh_model_find_group(struct bt_mesh_model **mod, uint16_t addr);
 
 void bt_mesh_model_foreach(void (*func)(struct bt_mesh_model *mod,
-					struct bt_mesh_elem *elem,
+					const struct bt_mesh_elem *elem,
 					bool vnd, bool primary,
 					void *user_data),
 			   void *user_data);
@@ -54,6 +54,7 @@ void bt_mesh_comp_provision(uint16_t addr);
 void bt_mesh_comp_unprovision(void);
 
 uint16_t bt_mesh_primary_addr(void);
+uint16_t bt_mesh_elem_addr_get(const struct bt_mesh_elem *elem);
 
 const struct bt_mesh_comp *bt_mesh_comp_get(void);
 

--- a/subsys/bluetooth/mesh/blob_cli.c
+++ b/subsys/bluetooth/mesh/blob_cli.c
@@ -1204,7 +1204,7 @@ static void rx_block_status(struct bt_mesh_blob_cli *cli,
 	blob_cli_broadcast_rsp(cli, target);
 }
 
-static int handle_xfer_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_xfer_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_cli *cli = mod->user_data;
@@ -1276,7 +1276,7 @@ static int handle_xfer_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 	return 0;
 }
 
-static int handle_block_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_block_report(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_cli *cli = mod->user_data;
@@ -1330,7 +1330,7 @@ static int handle_block_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx
 	return 0;
 }
 
-static int handle_block_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_block_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_cli *cli = mod->user_data;
@@ -1401,7 +1401,7 @@ static int handle_block_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx
 	return 0;
 }
 
-static int handle_info_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_info_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_cli *cli = mod->user_data;
@@ -1458,7 +1458,7 @@ const struct bt_mesh_model_op _bt_mesh_blob_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int blob_cli_init(struct bt_mesh_model *mod)
+static int blob_cli_init(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_blob_cli *cli = mod->user_data;
 
@@ -1471,7 +1471,7 @@ static int blob_cli_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void blob_cli_reset(struct bt_mesh_model *mod)
+static void blob_cli_reset(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_blob_cli *cli = mod->user_data;
 

--- a/subsys/bluetooth/mesh/blob_srv.c
+++ b/subsys/bluetooth/mesh/blob_srv.c
@@ -382,7 +382,7 @@ static void block_status_rsp(struct bt_mesh_blob_srv *srv,
 	bt_mesh_model_send(srv->mod, ctx, &buf, NULL, NULL);
 }
 
-static int handle_xfer_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_xfer_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
@@ -393,7 +393,7 @@ static int handle_xfer_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ct
 	return 0;
 }
 
-static int handle_xfer_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_xfer_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
@@ -524,7 +524,7 @@ rsp:
 	return 0;
 }
 
-static int handle_xfer_cancel(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_xfer_cancel(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	enum bt_mesh_blob_status status = BT_MESH_BLOB_SUCCESS;
@@ -552,7 +552,7 @@ rsp:
 	return 0;
 }
 
-static int handle_block_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_block_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
 	enum bt_mesh_blob_status status;
@@ -583,7 +583,7 @@ static int handle_block_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *c
 	return 0;
 }
 
-static int handle_block_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_block_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
@@ -678,7 +678,7 @@ rsp:
 	return 0;
 }
 
-static int handle_chunk(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_chunk(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
@@ -768,7 +768,7 @@ static int handle_chunk(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int handle_info_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_info_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
@@ -805,7 +805,7 @@ const struct bt_mesh_model_op _bt_mesh_blob_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int blob_srv_init(struct bt_mesh_model *mod)
+static int blob_srv_init(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
 
@@ -819,7 +819,7 @@ static int blob_srv_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static int blob_srv_settings_set(struct bt_mesh_model *mod, const char *name,
+static int blob_srv_settings_set(const struct bt_mesh_model *mod, const char *name,
 				 size_t len_rd, settings_read_cb read_cb,
 				 void *cb_arg)
 {
@@ -861,7 +861,7 @@ static int blob_srv_settings_set(struct bt_mesh_model *mod, const char *name,
 	return 0;
 }
 
-static int blob_srv_start(struct bt_mesh_model *mod)
+static int blob_srv_start(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
 	int err = -ENOTSUP;
@@ -889,7 +889,7 @@ static int blob_srv_start(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void blob_srv_reset(struct bt_mesh_model *mod)
+static void blob_srv_reset(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
 

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -48,7 +48,7 @@ static int32_t msg_timeout;
 
 static struct bt_mesh_cfg_cli *cli;
 
-static int comp_data_status(struct bt_mesh_model *model,
+static int comp_data_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -77,7 +77,7 @@ static int comp_data_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static uint8_t state_status_u8(struct bt_mesh_model *model,
+static uint8_t state_status_u8(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf,
 			   uint32_t expect_status)
@@ -103,7 +103,7 @@ static uint8_t state_status_u8(struct bt_mesh_model *model,
 	return status;
 }
 
-static int beacon_status(struct bt_mesh_model *model,
+static int beacon_status(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -118,7 +118,7 @@ static int beacon_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int ttl_status(struct bt_mesh_model *model,
+static int ttl_status(const struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
@@ -133,7 +133,7 @@ static int ttl_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int friend_status(struct bt_mesh_model *model,
+static int friend_status(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -148,7 +148,7 @@ static int friend_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gatt_proxy_status(struct bt_mesh_model *model,
+static int gatt_proxy_status(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -170,7 +170,7 @@ struct krp_param {
 	uint8_t *phase;
 };
 
-static int krp_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int krp_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	struct krp_param *param;
@@ -208,7 +208,7 @@ struct relay_param {
 	uint8_t *transmit;
 };
 
-static int relay_status(struct bt_mesh_model *model,
+static int relay_status(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
@@ -242,7 +242,7 @@ static int relay_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int net_transmit_status(struct bt_mesh_model *model,
+static int net_transmit_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -262,7 +262,7 @@ struct net_key_param {
 	uint16_t net_idx;
 };
 
-static int net_key_status(struct bt_mesh_model *model,
+static int net_key_status(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -308,7 +308,7 @@ struct net_key_list_param {
 	size_t *key_cnt;
 };
 
-static int net_key_list(struct bt_mesh_model *model,
+static int net_key_list(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
@@ -348,7 +348,7 @@ static int net_key_list(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int node_reset_status(struct bt_mesh_model *model,
+static int node_reset_status(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -379,7 +379,7 @@ struct app_key_param {
 	uint16_t app_idx;
 };
 
-static int app_key_status(struct bt_mesh_model *model,
+static int app_key_status(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -428,7 +428,7 @@ struct app_key_list_param {
 	size_t *key_cnt;
 };
 
-static int app_key_list(struct bt_mesh_model *model,
+static int app_key_list(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
@@ -488,7 +488,7 @@ struct mod_app_param {
 	uint16_t cid;
 };
 
-static int mod_app_status(struct bt_mesh_model *model,
+static int mod_app_status(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -609,7 +609,7 @@ static int mod_member_list_handle(struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int mod_app_list(struct bt_mesh_model *model,
+static int mod_app_list(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
 {
 	LOG_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s", ctx->net_idx, ctx->app_idx,
@@ -618,7 +618,7 @@ static int mod_app_list(struct bt_mesh_model *model,
 	return mod_member_list_handle(ctx, buf, OP_SIG_MOD_APP_LIST, false);
 }
 
-static int mod_app_list_vnd(struct bt_mesh_model *model,
+static int mod_app_list_vnd(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -636,7 +636,7 @@ struct mod_pub_param {
 	struct bt_mesh_cfg_cli_mod_pub *pub;
 };
 
-static int mod_pub_status(struct bt_mesh_model *model,
+static int mod_pub_status(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -712,7 +712,7 @@ struct mod_sub_param {
 	uint16_t cid;
 };
 
-static int mod_sub_status(struct bt_mesh_model *model,
+static int mod_sub_status(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -771,7 +771,7 @@ done:
 	return err;
 }
 
-static int mod_sub_list(struct bt_mesh_model *model,
+static int mod_sub_list(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
 {
 	LOG_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s", ctx->net_idx, ctx->app_idx,
@@ -780,7 +780,7 @@ static int mod_sub_list(struct bt_mesh_model *model,
 	return mod_member_list_handle(ctx, buf, OP_MOD_SUB_LIST, false);
 }
 
-static int mod_sub_list_vnd(struct bt_mesh_model *model,
+static int mod_sub_list_vnd(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -795,7 +795,7 @@ struct hb_sub_param {
 	struct bt_mesh_cfg_cli_hb_sub *sub;
 };
 
-static int hb_sub_status(struct bt_mesh_model *model,
+static int hb_sub_status(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -834,7 +834,7 @@ struct hb_pub_param {
 	struct bt_mesh_cfg_cli_hb_pub *pub;
 };
 
-static int hb_pub_status(struct bt_mesh_model *model,
+static int hb_pub_status(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -874,7 +874,7 @@ struct node_idt_param {
 	uint8_t *identity;
 };
 
-static int node_identity_status(struct bt_mesh_model *model,
+static int node_identity_status(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -915,7 +915,7 @@ struct lpn_timeout_param {
 	int32_t *polltimeout;
 };
 
-static int lpn_timeout_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int lpn_timeout_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct lpn_timeout_param *param;
@@ -982,7 +982,7 @@ const struct bt_mesh_model_op bt_mesh_cfg_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int cfg_cli_init(struct bt_mesh_model *model)
+static int cfg_cli_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Configuration Client only allowed in primary element");
@@ -1003,7 +1003,7 @@ static int cfg_cli_init(struct bt_mesh_model *model)
 	 * and remote keys are allowed to access this model.
 	 */
 	model->keys[0] = BT_MESH_KEY_DEV_ANY;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	bt_mesh_msg_ack_ctx_init(&cli->ack_ctx);
 

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -103,7 +103,7 @@ static int dev_comp_data_get(struct bt_mesh_model *model,
 	return err;
 }
 
-static struct bt_mesh_model *get_model(struct bt_mesh_elem *elem,
+static struct bt_mesh_model *get_model(const struct bt_mesh_elem *elem,
 				       struct net_buf_simple *buf, bool *vnd)
 {
 	if (buf->len < 4) {
@@ -111,7 +111,7 @@ static struct bt_mesh_model *get_model(struct bt_mesh_elem *elem,
 
 		id = net_buf_simple_pull_le16(buf);
 
-		LOG_DBG("ID 0x%04x addr 0x%04x", id, elem->addr);
+		LOG_DBG("ID 0x%04x addr 0x%04x", id, bt_mesh_elem_addr_get(elem));
 
 		*vnd = false;
 
@@ -122,7 +122,7 @@ static struct bt_mesh_model *get_model(struct bt_mesh_elem *elem,
 		company = net_buf_simple_pull_le16(buf);
 		id = net_buf_simple_pull_le16(buf);
 
-		LOG_DBG("Company 0x%04x ID 0x%04x addr 0x%04x", company, id, elem->addr);
+		LOG_DBG("Company 0x%04x ID 0x%04x addr 0x%04x", company, id, bt_mesh_elem_addr_get(elem));
 
 		*vnd = true;
 
@@ -333,7 +333,7 @@ static int app_key_update(struct bt_mesh_model *model,
 }
 
 static void mod_app_key_del(struct bt_mesh_model *mod,
-			    struct bt_mesh_elem *elem, bool vnd, bool primary,
+			    const struct bt_mesh_elem *elem, bool vnd, bool primary,
 			    void *user_data)
 {
 	uint16_t *app_idx = user_data;
@@ -700,7 +700,7 @@ static int mod_pub_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 {
 	uint16_t elem_addr, pub_addr = 0U;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	bool vnd;
 
@@ -753,7 +753,7 @@ static int mod_pub_set(struct bt_mesh_model *model,
 	uint8_t retransmit, status, pub_ttl, pub_period, cred_flag;
 	uint16_t elem_addr, pub_addr, pub_app_idx;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	bool vnd;
 
@@ -850,7 +850,7 @@ static int mod_pub_va_set(struct bt_mesh_model *model,
 	uint8_t retransmit, status, pub_ttl, pub_period, cred_flag;
 	uint16_t elem_addr, pub_addr, pub_app_idx;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *label_uuid;
 	uint8_t *mod_id;
 	bool vnd;
@@ -952,7 +952,7 @@ static int mod_sub_add(struct bt_mesh_model *model,
 {
 	uint16_t elem_addr, sub_addr;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	uint8_t status;
 	uint16_t *entry;
@@ -1030,7 +1030,7 @@ static int mod_sub_del(struct bt_mesh_model *model,
 {
 	uint16_t elem_addr, sub_addr;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	uint16_t *match;
 	uint8_t status;
@@ -1112,7 +1112,7 @@ static int mod_sub_overwrite(struct bt_mesh_model *model,
 {
 	uint16_t elem_addr, sub_addr;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	uint8_t status;
 	bool vnd;
@@ -1182,7 +1182,7 @@ static int mod_sub_del_all(struct bt_mesh_model *model,
 			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint16_t elem_addr;
 	uint8_t *mod_id;
 	uint8_t status;
@@ -1272,7 +1272,7 @@ static int mod_sub_get(struct bt_mesh_model *model,
 	NET_BUF_SIMPLE_DEFINE(msg, BT_MESH_TX_SDU_MAX);
 	struct mod_sub_list_ctx visit_ctx;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint16_t addr, id;
 
 	addr = net_buf_simple_pull_le16(buf);
@@ -1327,7 +1327,7 @@ static int mod_sub_get_vnd(struct bt_mesh_model *model,
 	NET_BUF_SIMPLE_DEFINE(msg, BT_MESH_TX_SDU_MAX);
 	struct mod_sub_list_ctx visit_ctx;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint16_t company, addr, id;
 
 	addr = net_buf_simple_pull_le16(buf);
@@ -1385,7 +1385,7 @@ static int mod_sub_va_add(struct bt_mesh_model *model,
 {
 	uint16_t elem_addr, sub_addr;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *label_uuid;
 	uint8_t *mod_id;
 	uint16_t *entry;
@@ -1467,7 +1467,7 @@ static int mod_sub_va_del(struct bt_mesh_model *model,
 {
 	uint16_t elem_addr, sub_addr;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *label_uuid;
 	uint8_t *mod_id;
 	uint16_t *match;
@@ -1540,7 +1540,7 @@ static int mod_sub_va_overwrite(struct bt_mesh_model *model,
 {
 	uint16_t elem_addr, sub_addr = BT_MESH_ADDR_UNASSIGNED;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *label_uuid;
 	uint8_t *mod_id;
 	uint8_t status;
@@ -1819,7 +1819,7 @@ static int mod_app_bind(struct bt_mesh_model *model,
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_STATUS, 9);
 	uint16_t elem_addr, key_app_idx;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	bool vnd;
 
@@ -1883,7 +1883,7 @@ static int mod_app_unbind(struct bt_mesh_model *model,
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_STATUS, 9);
 	uint16_t elem_addr, key_app_idx;
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	bool vnd;
 
@@ -1945,7 +1945,7 @@ static int mod_app_get(struct bt_mesh_model *model,
 				  BT_MESH_MODEL_BUF_LEN(OP_SIG_MOD_APP_LIST,
 							9 + KEY_LIST_LEN)));
 	struct bt_mesh_model *mod;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	uint16_t elem_addr;
 	bool vnd;
@@ -2502,7 +2502,7 @@ const struct bt_mesh_model_cb bt_mesh_cfg_srv_cb = {
 	.init = cfg_srv_init,
 };
 
-static void mod_reset(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void mod_reset(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 		      bool vnd, bool primary, void *user_data)
 {
 	size_t clear_count;

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -47,7 +47,7 @@ static void node_reset_pending_handler(struct k_work *work)
 
 static K_WORK_DEFINE(node_reset_pending, node_reset_pending_handler);
 
-static int dev_comp_data_get(struct bt_mesh_model *model,
+static int dev_comp_data_get(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -103,7 +103,7 @@ static int dev_comp_data_get(struct bt_mesh_model *model,
 	return err;
 }
 
-static struct bt_mesh_model *get_model(const struct bt_mesh_elem *elem,
+static const struct bt_mesh_model *get_model(const struct bt_mesh_elem *elem,
 				       struct net_buf_simple *buf, bool *vnd)
 {
 	if (buf->len < 4) {
@@ -122,7 +122,8 @@ static struct bt_mesh_model *get_model(const struct bt_mesh_elem *elem,
 		company = net_buf_simple_pull_le16(buf);
 		id = net_buf_simple_pull_le16(buf);
 
-		LOG_DBG("Company 0x%04x ID 0x%04x addr 0x%04x", company, id, bt_mesh_elem_addr_get(elem));
+		LOG_DBG("Company 0x%04x ID 0x%04x addr 0x%04x", company, id,
+			 bt_mesh_elem_addr_get(elem));
 
 		*vnd = true;
 
@@ -130,7 +131,7 @@ static struct bt_mesh_model *get_model(const struct bt_mesh_elem *elem,
 	}
 }
 
-static uint8_t _mod_pub_set(struct bt_mesh_model *model, uint16_t pub_addr,
+static uint8_t _mod_pub_set(const struct bt_mesh_model *model, uint16_t pub_addr,
 			 uint16_t app_idx, uint8_t cred_flag, uint8_t ttl, uint8_t period,
 			 uint8_t retransmit, bool store)
 {
@@ -218,7 +219,7 @@ static uint8_t _mod_pub_set(struct bt_mesh_model *model, uint16_t pub_addr,
 	return STATUS_SUCCESS;
 }
 
-static uint8_t mod_bind(struct bt_mesh_model *model, uint16_t key_idx)
+static uint8_t mod_bind(const struct bt_mesh_model *model, uint16_t key_idx)
 {
 	int i;
 
@@ -251,7 +252,7 @@ static uint8_t mod_bind(struct bt_mesh_model *model, uint16_t key_idx)
 	return STATUS_INSUFF_RESOURCES;
 }
 
-static uint8_t mod_unbind(struct bt_mesh_model *model, uint16_t key_idx, bool store)
+static uint8_t mod_unbind(const struct bt_mesh_model *model, uint16_t key_idx, bool store)
 {
 	int i;
 
@@ -281,7 +282,7 @@ static uint8_t mod_unbind(struct bt_mesh_model *model, uint16_t key_idx, bool st
 	return STATUS_SUCCESS;
 }
 
-static int send_app_key_status(struct bt_mesh_model *model,
+static int send_app_key_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       uint8_t status,
 			       uint16_t app_idx, uint16_t net_idx)
@@ -299,7 +300,7 @@ static int send_app_key_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int app_key_add(struct bt_mesh_model *model,
+static int app_key_add(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
@@ -315,7 +316,7 @@ static int app_key_add(struct bt_mesh_model *model,
 	return send_app_key_status(model, ctx, status, key_app_idx, key_net_idx);
 }
 
-static int app_key_update(struct bt_mesh_model *model,
+static int app_key_update(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -332,7 +333,7 @@ static int app_key_update(struct bt_mesh_model *model,
 	return send_app_key_status(model, ctx, status, key_app_idx, key_net_idx);
 }
 
-static void mod_app_key_del(struct bt_mesh_model *mod,
+static void mod_app_key_del(const struct bt_mesh_model *mod,
 			    const struct bt_mesh_elem *elem, bool vnd, bool primary,
 			    void *user_data)
 {
@@ -351,7 +352,7 @@ static void app_key_evt(uint16_t app_idx, uint16_t net_idx,
 
 BT_MESH_APP_KEY_CB_DEFINE(app_key_evt);
 
-static int app_key_del(struct bt_mesh_model *model,
+static int app_key_del(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
@@ -370,7 +371,7 @@ static int app_key_del(struct bt_mesh_model *model,
 /* Index list length: 3 bytes for every pair and 2 bytes for an odd idx */
 #define IDX_LEN(num) (((num) / 2) * 3 + ((num) % 2) * 2)
 
-static int app_key_get(struct bt_mesh_model *model,
+static int app_key_get(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
@@ -426,7 +427,7 @@ send_status:
 	return 0;
 }
 
-static int beacon_get(struct bt_mesh_model *model,
+static int beacon_get(const struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
@@ -445,7 +446,7 @@ static int beacon_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int beacon_set(struct bt_mesh_model *model,
+static int beacon_set(const struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
@@ -471,7 +472,7 @@ static int beacon_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int default_ttl_get(struct bt_mesh_model *model,
+static int default_ttl_get(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -490,7 +491,7 @@ static int default_ttl_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int default_ttl_set(struct bt_mesh_model *model,
+static int default_ttl_set(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -516,7 +517,7 @@ static int default_ttl_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int send_gatt_proxy_status(struct bt_mesh_model *model,
+static int send_gatt_proxy_status(const struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_GATT_PROXY_STATUS, 1);
@@ -531,7 +532,7 @@ static int send_gatt_proxy_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gatt_proxy_get(struct bt_mesh_model *model,
+static int gatt_proxy_get(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -541,7 +542,7 @@ static int gatt_proxy_get(struct bt_mesh_model *model,
 	return send_gatt_proxy_status(model, ctx);
 }
 
-static int gatt_proxy_set(struct bt_mesh_model *model,
+static int gatt_proxy_set(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -565,7 +566,7 @@ static int gatt_proxy_set(struct bt_mesh_model *model,
 	return send_gatt_proxy_status(model, ctx);
 }
 
-static int net_transmit_get(struct bt_mesh_model *model,
+static int net_transmit_get(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -584,7 +585,7 @@ static int net_transmit_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int net_transmit_set(struct bt_mesh_model *model,
+static int net_transmit_set(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -608,7 +609,7 @@ static int net_transmit_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int relay_get(struct bt_mesh_model *model,
+static int relay_get(const struct bt_mesh_model *model,
 		     struct bt_mesh_msg_ctx *ctx,
 		     struct net_buf_simple *buf)
 {
@@ -628,7 +629,7 @@ static int relay_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int relay_set(struct bt_mesh_model *model,
+static int relay_set(const struct bt_mesh_model *model,
 		     struct bt_mesh_msg_ctx *ctx,
 		     struct net_buf_simple *buf)
 {
@@ -655,10 +656,10 @@ static int relay_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int send_mod_pub_status(struct bt_mesh_model *cfg_mod,
+static int send_mod_pub_status(const struct bt_mesh_model *cfg_mod,
 			       struct bt_mesh_msg_ctx *ctx, uint16_t elem_addr,
 			       uint16_t pub_addr, bool vnd,
-			       struct bt_mesh_model *mod, uint8_t status,
+			       const struct bt_mesh_model *mod, uint8_t status,
 			       uint8_t *mod_id)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_PUB_STATUS, 14);
@@ -695,11 +696,11 @@ static int send_mod_pub_status(struct bt_mesh_model *cfg_mod,
 	return 0;
 }
 
-static int mod_pub_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mod_pub_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, pub_addr = 0U;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	bool vnd;
@@ -746,13 +747,13 @@ send_status:
 				   status, mod_id);
 }
 
-static int mod_pub_set(struct bt_mesh_model *model,
+static int mod_pub_set(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	uint8_t retransmit, status, pub_ttl, pub_period, cred_flag;
 	uint16_t elem_addr, pub_addr, pub_app_idx;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	bool vnd;
@@ -811,7 +812,7 @@ send_status:
 				   status, mod_id);
 }
 
-static size_t mod_sub_list_clear(struct bt_mesh_model *mod)
+static size_t mod_sub_list_clear(const struct bt_mesh_model *mod)
 {
 	uint8_t *label_uuid;
 	size_t clear_count;
@@ -843,13 +844,13 @@ static size_t mod_sub_list_clear(struct bt_mesh_model *mod)
 	return clear_count;
 }
 
-static int mod_pub_va_set(struct bt_mesh_model *model,
+static int mod_pub_va_set(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
 	uint8_t retransmit, status, pub_ttl, pub_period, cred_flag;
 	uint16_t elem_addr, pub_addr, pub_app_idx;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint8_t *label_uuid;
 	uint8_t *mod_id;
@@ -918,7 +919,7 @@ send_status:
 				   status, mod_id);
 }
 
-static int send_mod_sub_status(struct bt_mesh_model *model,
+static int send_mod_sub_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx, uint8_t status,
 			       uint16_t elem_addr, uint16_t sub_addr, uint8_t *mod_id,
 			       bool vnd)
@@ -946,12 +947,12 @@ static int send_mod_sub_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int mod_sub_add(struct bt_mesh_model *model,
+static int mod_sub_add(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	uint8_t status;
@@ -1024,12 +1025,12 @@ send_status:
 				   mod_id, vnd);
 }
 
-static int mod_sub_del(struct bt_mesh_model *model,
+static int mod_sub_del(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	uint16_t *match;
@@ -1095,7 +1096,7 @@ send_status:
 				   mod_id, vnd);
 }
 
-static enum bt_mesh_walk mod_sub_clear_visitor(struct bt_mesh_model *mod, void *user_data)
+static enum bt_mesh_walk mod_sub_clear_visitor(const struct bt_mesh_model *mod, void *user_data)
 {
 	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {
 		bt_mesh_lpn_group_del(mod->groups, mod->groups_cnt);
@@ -1106,12 +1107,12 @@ static enum bt_mesh_walk mod_sub_clear_visitor(struct bt_mesh_model *mod, void *
 	return BT_MESH_WALK_CONTINUE;
 }
 
-static int mod_sub_overwrite(struct bt_mesh_model *model,
+static int mod_sub_overwrite(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	uint8_t status;
@@ -1177,11 +1178,11 @@ send_status:
 				   mod_id, vnd);
 }
 
-static int mod_sub_del_all(struct bt_mesh_model *model,
+static int mod_sub_del_all(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint16_t elem_addr;
 	uint8_t *mod_id;
@@ -1235,13 +1236,13 @@ struct mod_sub_list_ctx {
 	struct net_buf_simple *msg;
 };
 
-static enum bt_mesh_walk mod_sub_list_visitor(struct bt_mesh_model *mod, void *ctx)
+static enum bt_mesh_walk mod_sub_list_visitor(const struct bt_mesh_model *mod, void *ctx)
 {
 	struct mod_sub_list_ctx *visit = ctx;
 	int count = 0;
 	int i;
 
-	if (mod->elem_idx != visit->elem_idx) {
+	if (mod->ctx->elem_idx != visit->elem_idx) {
 		return BT_MESH_WALK_CONTINUE;
 	}
 
@@ -1260,18 +1261,18 @@ static enum bt_mesh_walk mod_sub_list_visitor(struct bt_mesh_model *mod, void *c
 		count++;
 	}
 
-	LOG_DBG("sublist: model %u:%x: %u groups", mod->elem_idx, mod->id, count);
+	LOG_DBG("sublist: model %u:%x: %u groups", mod->ctx->elem_idx, mod->id, count);
 
 	return BT_MESH_WALK_CONTINUE;
 }
 
-static int mod_sub_get(struct bt_mesh_model *model,
+static int mod_sub_get(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, BT_MESH_TX_SDU_MAX);
 	struct mod_sub_list_ctx visit_ctx;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint16_t addr, id;
 
@@ -1309,7 +1310,7 @@ static int mod_sub_get(struct bt_mesh_model *model,
 	net_buf_simple_add_le16(&msg, id);
 
 	visit_ctx.msg = &msg;
-	visit_ctx.elem_idx = mod->elem_idx;
+	visit_ctx.elem_idx = mod->ctx->elem_idx;
 	bt_mesh_model_extensions_walk(mod, mod_sub_list_visitor, &visit_ctx);
 
 send_list:
@@ -1320,13 +1321,13 @@ send_list:
 	return 0;
 }
 
-static int mod_sub_get_vnd(struct bt_mesh_model *model,
+static int mod_sub_get_vnd(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, BT_MESH_TX_SDU_MAX);
 	struct mod_sub_list_ctx visit_ctx;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint16_t company, addr, id;
 
@@ -1368,7 +1369,7 @@ static int mod_sub_get_vnd(struct bt_mesh_model *model,
 	net_buf_simple_add_le16(&msg, id);
 
 	visit_ctx.msg = &msg;
-	visit_ctx.elem_idx = mod->elem_idx;
+	visit_ctx.elem_idx = mod->ctx->elem_idx;
 	bt_mesh_model_extensions_walk(mod, mod_sub_list_visitor, &visit_ctx);
 
 send_list:
@@ -1379,12 +1380,12 @@ send_list:
 	return 0;
 }
 
-static int mod_sub_va_add(struct bt_mesh_model *model,
+static int mod_sub_va_add(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint8_t *label_uuid;
 	uint8_t *mod_id;
@@ -1461,12 +1462,12 @@ send_status:
 				   mod_id, vnd);
 }
 
-static int mod_sub_va_del(struct bt_mesh_model *model,
+static int mod_sub_va_del(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint8_t *label_uuid;
 	uint8_t *mod_id;
@@ -1534,12 +1535,12 @@ send_status:
 				   mod_id, vnd);
 }
 
-static int mod_sub_va_overwrite(struct bt_mesh_model *model,
+static int mod_sub_va_overwrite(const struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr = BT_MESH_ADDR_UNASSIGNED;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint8_t *label_uuid;
 	uint8_t *mod_id;
@@ -1602,7 +1603,7 @@ send_status:
 				   mod_id, vnd);
 }
 
-static int send_net_key_status(struct bt_mesh_model *model,
+static int send_net_key_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx, uint16_t idx,
 			       uint8_t status)
 {
@@ -1620,7 +1621,7 @@ static int send_net_key_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int net_key_add(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int net_key_add(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	uint8_t status;
@@ -1639,7 +1640,7 @@ static int net_key_add(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return send_net_key_status(model, ctx, idx, status);
 }
 
-static int net_key_update(struct bt_mesh_model *model,
+static int net_key_update(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -1657,7 +1658,7 @@ static int net_key_update(struct bt_mesh_model *model,
 	return send_net_key_status(model, ctx, idx, status);
 }
 
-static int net_key_del(struct bt_mesh_model *model,
+static int net_key_del(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
@@ -1684,7 +1685,7 @@ static int net_key_del(struct bt_mesh_model *model,
 	return send_net_key_status(model, ctx, del_idx, STATUS_SUCCESS);
 }
 
-static int net_key_get(struct bt_mesh_model *model,
+static int net_key_get(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
@@ -1716,7 +1717,7 @@ static int net_key_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int send_node_id_status(struct bt_mesh_model *model,
+static int send_node_id_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       uint8_t status,
 			       uint16_t net_idx, uint8_t node_id)
@@ -1735,7 +1736,7 @@ static int send_node_id_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int node_identity_get(struct bt_mesh_model *model,
+static int node_identity_get(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -1757,7 +1758,7 @@ static int node_identity_get(struct bt_mesh_model *model,
 	return send_node_id_status(model, ctx, status, idx, node_id);
 }
 
-static int node_identity_set(struct bt_mesh_model *model,
+static int node_identity_set(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -1795,7 +1796,7 @@ static int node_identity_set(struct bt_mesh_model *model,
 }
 
 static void create_mod_app_status(struct net_buf_simple *msg,
-				  struct bt_mesh_model *mod, bool vnd,
+				  const struct bt_mesh_model *mod, bool vnd,
 				  uint16_t elem_addr, uint16_t app_idx,
 				  uint8_t status, uint8_t *mod_id)
 {
@@ -1812,13 +1813,13 @@ static void create_mod_app_status(struct net_buf_simple *msg,
 	}
 }
 
-static int mod_app_bind(struct bt_mesh_model *model,
+static int mod_app_bind(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_STATUS, 9);
 	uint16_t elem_addr, key_app_idx;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	bool vnd;
@@ -1852,7 +1853,7 @@ static int mod_app_bind(struct bt_mesh_model *model,
 	}
 
 	/* Some models only allow device key based access */
-	if (mod->flags & BT_MESH_MOD_DEVKEY_ONLY) {
+	if (mod->ctx->flags & BT_MESH_MOD_DEVKEY_ONLY) {
 		LOG_ERR("Client tried to bind AppKey to DevKey based model");
 		status = STATUS_CANNOT_BIND;
 		goto send_status;
@@ -1876,13 +1877,13 @@ send_status:
 	return 0;
 }
 
-static int mod_app_unbind(struct bt_mesh_model *model,
+static int mod_app_unbind(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_STATUS, 9);
 	uint16_t elem_addr, key_app_idx;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	bool vnd;
@@ -1935,7 +1936,7 @@ send_status:
 
 #define KEY_LIST_LEN (CONFIG_BT_MESH_MODEL_KEY_COUNT * 2)
 
-static int mod_app_get(struct bt_mesh_model *model,
+static int mod_app_get(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
@@ -1944,7 +1945,7 @@ static int mod_app_get(struct bt_mesh_model *model,
 							9 + KEY_LIST_LEN),
 				  BT_MESH_MODEL_BUF_LEN(OP_SIG_MOD_APP_LIST,
 							9 + KEY_LIST_LEN)));
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	uint16_t elem_addr;
@@ -2027,7 +2028,7 @@ static void reset_send_end(int err, void *cb_data)
 	k_work_submit(&node_reset_pending);
 }
 
-static int node_reset(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int node_reset(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
 	static const struct bt_mesh_send_cb reset_cb = {
@@ -2049,7 +2050,7 @@ static int node_reset(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int send_friend_status(struct bt_mesh_model *model,
+static int send_friend_status(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_FRIEND_STATUS, 1);
@@ -2064,7 +2065,7 @@ static int send_friend_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int friend_get(struct bt_mesh_model *model,
+static int friend_get(const struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
@@ -2074,7 +2075,7 @@ static int friend_get(struct bt_mesh_model *model,
 	return send_friend_status(model, ctx);
 }
 
-static int friend_set(struct bt_mesh_model *model,
+static int friend_set(const struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
@@ -2091,7 +2092,7 @@ static int friend_set(struct bt_mesh_model *model,
 	return send_friend_status(model, ctx);
 }
 
-static int lpn_timeout_get(struct bt_mesh_model *model,
+static int lpn_timeout_get(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -2137,7 +2138,7 @@ send_rsp:
 	return 0;
 }
 
-static int send_krp_status(struct bt_mesh_model *model,
+static int send_krp_status(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx, uint16_t idx,
 			   uint8_t phase, uint8_t status)
 {
@@ -2156,7 +2157,7 @@ static int send_krp_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int krp_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int krp_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		    struct net_buf_simple *buf)
 {
 	uint8_t kr_phase, status;
@@ -2175,7 +2176,7 @@ static int krp_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return send_krp_status(model, ctx, idx, kr_phase, status);
 }
 
-static int krp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int krp_set(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		   struct net_buf_simple *buf)
 {
 	uint8_t phase, status;
@@ -2231,7 +2232,7 @@ struct hb_pub_param {
 	uint16_t net_idx;
 } __packed;
 
-static int hb_pub_send_status(struct bt_mesh_model *model,
+static int hb_pub_send_status(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx, uint8_t status,
 			      const struct bt_mesh_hb_pub *pub)
 {
@@ -2257,7 +2258,7 @@ static int hb_pub_send_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int heartbeat_pub_get(struct bt_mesh_model *model,
+static int heartbeat_pub_get(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2270,7 +2271,7 @@ static int heartbeat_pub_get(struct bt_mesh_model *model,
 	return hb_pub_send_status(model, ctx, STATUS_SUCCESS, &pub);
 }
 
-static int heartbeat_pub_set(struct bt_mesh_model *model,
+static int heartbeat_pub_set(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -2330,7 +2331,7 @@ rsp:
 	return hb_pub_send_status(model, ctx, status, &pub);
 }
 
-static int hb_sub_send_status(struct bt_mesh_model *model,
+static int hb_sub_send_status(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      const struct bt_mesh_hb_sub *sub)
 {
@@ -2355,7 +2356,7 @@ static int hb_sub_send_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int heartbeat_sub_get(struct bt_mesh_model *model,
+static int heartbeat_sub_get(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2368,7 +2369,7 @@ static int heartbeat_sub_get(struct bt_mesh_model *model,
 	return hb_sub_send_status(model, ctx, &sub);
 }
 
-static int heartbeat_sub_set(struct bt_mesh_model *model,
+static int heartbeat_sub_set(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -2481,7 +2482,7 @@ const struct bt_mesh_model_op bt_mesh_cfg_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int cfg_srv_init(struct bt_mesh_model *model)
+static int cfg_srv_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Configuration Server only allowed in primary element");
@@ -2493,7 +2494,7 @@ static int cfg_srv_init(struct bt_mesh_model *model)
 	 * device-key is allowed to access this model.
 	 */
 	model->keys[0] = BT_MESH_KEY_DEV_LOCAL;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	return 0;
 }
@@ -2502,7 +2503,7 @@ const struct bt_mesh_model_cb bt_mesh_cfg_srv_cb = {
 	.init = cfg_srv_init,
 };
 
-static void mod_reset(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
+static void mod_reset(const struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 		      bool vnd, bool primary, void *user_data)
 {
 	size_t clear_count;

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -112,7 +112,7 @@ static void receivers_status_rsp(struct bt_mesh_dfd_srv *srv,
 	bt_mesh_model_send(srv->mod, ctx, &buf, NULL, NULL);
 }
 
-static int handle_receivers_add(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_receivers_add(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	enum bt_mesh_dfd_status status = BT_MESH_DFD_SUCCESS;
@@ -143,7 +143,7 @@ static int handle_receivers_add(struct bt_mesh_model *mod, struct bt_mesh_msg_ct
 	return 0;
 }
 
-static int handle_receivers_delete_all(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_receivers_delete_all(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -153,7 +153,7 @@ static int handle_receivers_delete_all(struct bt_mesh_model *mod, struct bt_mesh
 	return 0;
 }
 
-static int handle_receivers_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_receivers_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -206,7 +206,7 @@ static enum bt_mesh_dfu_iter slot_space_cb(const struct bt_mesh_dfu_slot *slot,
 	return BT_MESH_DFU_ITER_CONTINUE;
 }
 
-static int handle_capabilities_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_capabilities_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
 	size_t size = 0;
@@ -256,7 +256,7 @@ static void status_rsp(struct bt_mesh_dfd_srv *srv, struct bt_mesh_msg_ctx *ctx,
 	bt_mesh_model_send(srv->mod, ctx, &rsp, NULL, NULL);
 }
 
-static int handle_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -266,7 +266,7 @@ static int handle_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int handle_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -298,7 +298,7 @@ static int handle_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int handle_suspend(struct bt_mesh_model *mod,
+static int handle_suspend(const struct bt_mesh_model *mod,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -309,7 +309,7 @@ static int handle_suspend(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_cancel(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_cancel(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -319,7 +319,7 @@ static int handle_cancel(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int handle_apply(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_apply(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -354,7 +354,7 @@ static void upload_status_rsp(struct bt_mesh_dfd_srv *srv,
 	bt_mesh_model_send(srv->mod, ctx, &rsp, NULL, NULL);
 }
 
-static int handle_upload_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_upload_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -364,7 +364,7 @@ static int handle_upload_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *
 	return 0;
 }
 
-static int handle_upload_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_upload_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -474,7 +474,7 @@ static int handle_upload_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx
 	return 0;
 }
 
-static int handle_upload_start_oob(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_upload_start_oob(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -486,7 +486,7 @@ static int handle_upload_start_oob(struct bt_mesh_model *mod, struct bt_mesh_msg
 	return 0;
 }
 
-static int handle_upload_cancel(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_upload_cancel(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -518,7 +518,7 @@ static void fw_status_rsp(struct bt_mesh_dfd_srv *srv,
 	bt_mesh_model_send(srv->mod, ctx, &rsp, NULL, NULL);
 }
 
-static int handle_fw_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_fw_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -542,7 +542,7 @@ static int handle_fw_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int handle_fw_get_by_index(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_fw_get_by_index(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -563,7 +563,7 @@ static int handle_fw_get_by_index(struct bt_mesh_model *mod, struct bt_mesh_msg_
 	return 0;
 }
 
-static int handle_fw_delete(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_fw_delete(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -592,7 +592,7 @@ static enum bt_mesh_dfu_iter slot_del_cb(const struct bt_mesh_dfu_slot *slot,
 	return BT_MESH_DFU_ITER_CONTINUE;
 }
 
-static int handle_fw_delete_all(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_fw_delete_all(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -752,7 +752,7 @@ const struct bt_mesh_blob_srv_cb _bt_mesh_dfd_srv_blob_cb = {
 	.suspended = upload_timeout,
 };
 
-static int dfd_srv_init(struct bt_mesh_model *mod)
+static int dfd_srv_init(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
 
@@ -765,7 +765,7 @@ static int dfd_srv_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void dfd_srv_reset(struct bt_mesh_model *mod)
+static void dfd_srv_reset(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
 

--- a/subsys/bluetooth/mesh/dfu_cli.c
+++ b/subsys/bluetooth/mesh/dfu_cli.c
@@ -681,7 +681,7 @@ static void cancelled(struct bt_mesh_blob_cli *b)
  * Message handlers
  ******************************************************************************/
 
-static int handle_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_cli *cli = mod->user_data;
@@ -807,7 +807,7 @@ static int handle_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int handle_info_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_info_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_cli *cli = mod->user_data;
@@ -906,7 +906,7 @@ static int handle_info_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 	return 0;
 }
 
-static int handle_metadata_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_metadata_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_cli *cli = mod->user_data;
@@ -943,11 +943,11 @@ const struct bt_mesh_model_op _bt_mesh_dfu_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int dfu_cli_init(struct bt_mesh_model *mod)
+static int dfu_cli_init(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_dfu_cli *cli = mod->user_data;
 
-	if (mod->elem_idx != 0) {
+	if (mod->ctx->elem_idx != 0) {
 		LOG_ERR("DFU update client must be instantiated on first elem");
 		return -EINVAL;
 	}
@@ -963,7 +963,7 @@ static int dfu_cli_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void dfu_cli_reset(struct bt_mesh_model *mod)
+static void dfu_cli_reset(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_dfu_cli *cli = mod->user_data;
 

--- a/subsys/bluetooth/mesh/dfu_srv.c
+++ b/subsys/bluetooth/mesh/dfu_srv.c
@@ -125,7 +125,7 @@ static void verify(struct bt_mesh_dfu_srv *srv)
 	}
 }
 
-static int handle_info_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_info_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
@@ -187,7 +187,7 @@ static int handle_info_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ct
 	return 0;
 }
 
-static int handle_metadata_check(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_metadata_check(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
@@ -239,7 +239,7 @@ static void update_status_rsp(struct bt_mesh_dfu_srv *srv,
 	bt_mesh_model_send(srv->mod, ctx, &buf, send_cb, srv);
 }
 
-static int handle_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
@@ -262,7 +262,7 @@ static inline bool is_active_update(struct bt_mesh_dfu_srv *srv, uint8_t idx,
 		srv->update.meta != meta_checksum);
 }
 
-static int handle_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
@@ -371,7 +371,7 @@ rsp:
 	return 0;
 }
 
-static int handle_cancel(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_cancel(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
@@ -392,7 +392,7 @@ rsp:
 	return 0;
 }
 
-static int handle_apply(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_apply(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
@@ -435,7 +435,7 @@ const struct bt_mesh_model_op _bt_mesh_dfu_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int dfu_srv_init(struct bt_mesh_model *mod)
+static int dfu_srv_init(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
 
@@ -455,7 +455,7 @@ static int dfu_srv_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static int dfu_srv_settings_set(struct bt_mesh_model *mod, const char *name,
+static int dfu_srv_settings_set(const struct bt_mesh_model *mod, const char *name,
 				size_t len_rd, settings_read_cb read_cb,
 				void *cb_arg)
 {
@@ -484,7 +484,7 @@ static int dfu_srv_settings_set(struct bt_mesh_model *mod, const char *name,
 	return 0;
 }
 
-static void dfu_srv_reset(struct bt_mesh_model *mod)
+static void dfu_srv_reset(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
 

--- a/subsys/bluetooth/mesh/foundation.h
+++ b/subsys/bluetooth/mesh/foundation.h
@@ -150,7 +150,7 @@
 
 void bt_mesh_model_reset(void);
 
-void bt_mesh_attention(struct bt_mesh_model *model, uint8_t time);
+void bt_mesh_attention(const struct bt_mesh_model *model, uint8_t time);
 
 #include <zephyr/sys/byteorder.h>
 

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -36,7 +36,7 @@ struct health_fault_param {
 	size_t *fault_count;
 };
 
-static int health_fault_status(struct bt_mesh_model *model,
+static int health_fault_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -89,7 +89,7 @@ done:
 	return 0;
 }
 
-static int health_current_status(struct bt_mesh_model *model,
+static int health_current_status(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -117,7 +117,7 @@ struct health_period_param {
 	uint8_t *divisor;
 };
 
-static int health_period_status(struct bt_mesh_model *model,
+static int health_period_status(const struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
@@ -151,7 +151,7 @@ struct health_attention_param {
 	uint8_t *attention;
 };
 
-static int health_attention_status(struct bt_mesh_model *model,
+static int health_attention_status(const struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
@@ -402,7 +402,7 @@ void bt_mesh_health_cli_timeout_set(int32_t timeout)
 	msg_timeout = timeout;
 }
 
-static int health_cli_init(struct bt_mesh_model *model)
+static int health_cli_init(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_health_cli *cli = model->user_data;
 
@@ -423,7 +423,7 @@ static int health_cli_init(struct bt_mesh_model *model)
 	return 0;
 }
 
-static void health_cli_reset(struct bt_mesh_model *model)
+static void health_cli_reset(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_health_cli *cli = model->user_data;
 

--- a/subsys/bluetooth/mesh/health_srv.c
+++ b/subsys/bluetooth/mesh/health_srv.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(bt_mesh_health_srv);
 /* Health Server context of the primary element */
 struct bt_mesh_health_srv *health_srv;
 
-static void health_get_registered(struct bt_mesh_model *mod,
+static void health_get_registered(const struct bt_mesh_model *mod,
 				  uint16_t company_id,
 				  struct net_buf_simple *msg)
 {
@@ -64,7 +64,7 @@ static void health_get_registered(struct bt_mesh_model *mod,
 	}
 }
 
-static size_t health_get_current(struct bt_mesh_model *mod,
+static size_t health_get_current(const struct bt_mesh_model *mod,
 				 struct net_buf_simple *msg)
 {
 	struct bt_mesh_health_srv *srv = mod->user_data;
@@ -105,7 +105,7 @@ static size_t health_get_current(struct bt_mesh_model *mod,
 	return fault_count;
 }
 
-static int health_fault_get(struct bt_mesh_model *model,
+static int health_fault_get(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -125,7 +125,7 @@ static int health_fault_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int health_fault_clear_unrel(struct bt_mesh_model *model,
+static int health_fault_clear_unrel(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -143,7 +143,7 @@ static int health_fault_clear_unrel(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int health_fault_clear(struct bt_mesh_model *model,
+static int health_fault_clear(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -173,7 +173,7 @@ static int health_fault_clear(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int health_fault_test_unrel(struct bt_mesh_model *model,
+static int health_fault_test_unrel(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -193,7 +193,7 @@ static int health_fault_test_unrel(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int health_fault_test(struct bt_mesh_model *model,
+static int health_fault_test(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -228,7 +228,7 @@ static int health_fault_test(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int send_attention_status(struct bt_mesh_model *model,
+static int send_attention_status(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
@@ -251,7 +251,7 @@ static int send_attention_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int attention_get(struct bt_mesh_model *model,
+static int attention_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -260,7 +260,7 @@ static int attention_get(struct bt_mesh_model *model,
 	return send_attention_status(model, ctx);
 }
 
-static int attention_set_unrel(struct bt_mesh_model *model,
+static int attention_set_unrel(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -275,7 +275,7 @@ static int attention_set_unrel(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int attention_set(struct bt_mesh_model *model,
+static int attention_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -291,7 +291,7 @@ static int attention_set(struct bt_mesh_model *model,
 	return send_attention_status(model, ctx);
 }
 
-static int send_health_period_status(struct bt_mesh_model *model,
+static int send_health_period_status(const struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
@@ -308,7 +308,7 @@ static int send_health_period_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int health_period_get(struct bt_mesh_model *model,
+static int health_period_get(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -317,7 +317,7 @@ static int health_period_get(struct bt_mesh_model *model,
 	return send_health_period_status(model, ctx);
 }
 
-static int health_period_set_unrel(struct bt_mesh_model *model,
+static int health_period_set_unrel(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -336,7 +336,7 @@ static int health_period_set_unrel(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int health_period_set(struct bt_mesh_model *model,
+static int health_period_set(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -367,7 +367,7 @@ const struct bt_mesh_model_op bt_mesh_health_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int health_pub_update(struct bt_mesh_model *mod)
+static int health_pub_update(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_model_pub *pub = mod->pub;
 	size_t count;
@@ -386,7 +386,7 @@ static int health_pub_update(struct bt_mesh_model *mod)
 
 int bt_mesh_health_srv_fault_update(const struct bt_mesh_elem *elem)
 {
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 
 	mod = bt_mesh_model_find(elem, BT_MESH_MODEL_ID_HEALTH_SRV);
 	if (!mod) {
@@ -418,7 +418,7 @@ static void attention_off(struct k_work *work)
 	}
 }
 
-static int health_srv_init(struct bt_mesh_model *model)
+static int health_srv_init(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_health_srv *srv = model->user_data;
 
@@ -449,7 +449,7 @@ const struct bt_mesh_model_cb bt_mesh_health_srv_cb = {
 	.init = health_srv_init,
 };
 
-void bt_mesh_attention(struct bt_mesh_model *model, uint8_t time)
+void bt_mesh_attention(const struct bt_mesh_model *model, uint8_t time)
 {
 	struct bt_mesh_health_srv *srv;
 

--- a/subsys/bluetooth/mesh/health_srv.c
+++ b/subsys/bluetooth/mesh/health_srv.c
@@ -384,7 +384,7 @@ static int health_pub_update(struct bt_mesh_model *mod)
 	return 0;
 }
 
-int bt_mesh_health_srv_fault_update(struct bt_mesh_elem *elem)
+int bt_mesh_health_srv_fault_update(const struct bt_mesh_elem *elem)
 {
 	struct bt_mesh_model *mod;
 

--- a/subsys/bluetooth/mesh/large_comp_data_cli.c
+++ b/subsys/bluetooth/mesh/large_comp_data_cli.c
@@ -33,7 +33,7 @@ LOG_MODULE_REGISTER(bt_mesh_large_comp_data_cli);
 static struct bt_mesh_large_comp_data_cli *cli;
 static int32_t msg_timeout;
 
-static int data_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int data_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf, uint32_t op,
 		       void (*cb)(struct bt_mesh_large_comp_data_cli *cli, uint16_t addr,
 				  struct bt_mesh_large_comp_data_rsp *rsp))
@@ -78,7 +78,7 @@ static int data_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int large_comp_data_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int large_comp_data_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
 	return data_status(model, ctx, buf, OP_LARGE_COMP_DATA_STATUS,
@@ -86,7 +86,7 @@ static int large_comp_data_status(struct bt_mesh_model *model, struct bt_mesh_ms
 			    cli->cb->large_comp_data_status : NULL));
 }
 
-static int models_metadata_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int models_metadata_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
 	return data_status(model, ctx, buf, OP_MODELS_METADATA_STATUS,
@@ -100,7 +100,7 @@ const struct bt_mesh_model_op _bt_mesh_large_comp_data_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int large_comp_data_cli_init(struct bt_mesh_model *model)
+static int large_comp_data_cli_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Large Comp Data Client only allowed in primary element");
@@ -108,7 +108,7 @@ static int large_comp_data_cli_init(struct bt_mesh_model *model)
 	}
 
 	model->keys[0] = BT_MESH_KEY_DEV_ANY;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	cli = model->user_data;
 	cli->model = model;

--- a/subsys/bluetooth/mesh/large_comp_data_srv.c
+++ b/subsys/bluetooth/mesh/large_comp_data_srv.c
@@ -37,10 +37,11 @@ LOG_MODULE_REGISTER(bt_mesh_large_comp_data_srv);
 /** Mesh Large Composition Data Server Model Context */
 static struct bt_mesh_large_comp_data_srv {
 	/** Composition data model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 } srv;
 
-static int handle_large_comp_data_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int handle_large_comp_data_get(const struct bt_mesh_model *model,
+				      struct bt_mesh_msg_ctx *ctx,
 				      struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(rsp, OP_LARGE_COMP_DATA_STATUS,
@@ -86,7 +87,8 @@ static int handle_large_comp_data_get(struct bt_mesh_model *model, struct bt_mes
 	return 0;
 }
 
-static int handle_models_metadata_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int handle_models_metadata_get(const struct bt_mesh_model *model,
+				      struct bt_mesh_msg_ctx *ctx,
 				      struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(rsp, OP_MODELS_METADATA_STATUS,
@@ -151,7 +153,7 @@ const struct bt_mesh_model_op _bt_mesh_large_comp_data_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int large_comp_data_srv_init(struct bt_mesh_model *model)
+static int large_comp_data_srv_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Large Composition Data Server only allowed in primary element");
@@ -160,7 +162,7 @@ static int large_comp_data_srv_init(struct bt_mesh_model *model)
 
 	/* Large Composition Data Server model shall use the device key */
 	model->keys[0] = BT_MESH_KEY_DEV;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	srv.model = model;
 

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -363,7 +363,7 @@ bool bt_mesh_is_provisioned(void)
 	return atomic_test_bit(bt_mesh.flags, BT_MESH_VALID);
 }
 
-static void model_suspend(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
+static void model_suspend(const struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 			  bool vnd, bool primary, void *user_data)
 {
 	if (mod->pub && mod->pub->update) {
@@ -407,7 +407,7 @@ int bt_mesh_suspend(void)
 	return 0;
 }
 
-static void model_resume(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
+static void model_resume(const struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 			  bool vnd, bool primary, void *user_data)
 {
 	if (mod->pub && mod->pub->update) {
@@ -496,7 +496,7 @@ int bt_mesh_init(const struct bt_mesh_prov *prov,
 	return 0;
 }
 
-static void model_start(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
+static void model_start(const struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 			bool vnd, bool primary, void *user_data)
 {
 	if (mod->cb && mod->cb->start) {

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -363,7 +363,7 @@ bool bt_mesh_is_provisioned(void)
 	return atomic_test_bit(bt_mesh.flags, BT_MESH_VALID);
 }
 
-static void model_suspend(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void model_suspend(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 			  bool vnd, bool primary, void *user_data)
 {
 	if (mod->pub && mod->pub->update) {
@@ -407,7 +407,7 @@ int bt_mesh_suspend(void)
 	return 0;
 }
 
-static void model_resume(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void model_resume(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 			  bool vnd, bool primary, void *user_data)
 {
 	if (mod->pub && mod->pub->update) {
@@ -496,7 +496,7 @@ int bt_mesh_init(const struct bt_mesh_prov *prov,
 	return 0;
 }
 
-static void model_start(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void model_start(struct bt_mesh_model *mod, const struct bt_mesh_elem *elem,
 			bool vnd, bool primary, void *user_data)
 {
 	if (mod->cb && mod->cb->start) {

--- a/subsys/bluetooth/mesh/msg.c
+++ b/subsys/bluetooth/mesh/msg.c
@@ -87,7 +87,7 @@ bool bt_mesh_msg_ack_ctx_match(const struct bt_mesh_msg_ack_ctx *ack,
 	return true;
 }
 
-int bt_mesh_msg_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_msg_send(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		     struct net_buf_simple *buf)
 {
 	if (!ctx && !model->pub) {
@@ -104,7 +104,7 @@ int bt_mesh_msg_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return bt_mesh_model_publish(model);
 }
 
-int bt_mesh_msg_ackd_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_msg_ackd_send(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf, const struct bt_mesh_msg_rsp_ctx *rsp)
 {
 	int err;

--- a/subsys/bluetooth/mesh/msg.h
+++ b/subsys/bluetooth/mesh/msg.h
@@ -18,7 +18,7 @@
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is not configured.
  * @retval -EAGAIN The device has not been provisioned.
  */
-int bt_mesh_msg_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_msg_send(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		     struct net_buf_simple *buf);
 
 /**
@@ -51,5 +51,5 @@ struct bt_mesh_msg_rsp_ctx {
  * @retval -EAGAIN The device has not been provisioned.
  * @retval -ETIMEDOUT The request timed out without a response.
  */
-int bt_mesh_msg_ackd_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_msg_ackd_send(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf, const struct bt_mesh_msg_rsp_ctx *rsp);

--- a/subsys/bluetooth/mesh/od_priv_proxy_cli.c
+++ b/subsys/bluetooth/mesh/od_priv_proxy_cli.c
@@ -20,7 +20,7 @@ static struct bt_mesh_od_priv_proxy_cli *cli;
 
 static int32_t msg_timeout;
 
-static int handle_proxy_status(struct bt_mesh_model *mod,
+static int handle_proxy_status(const struct bt_mesh_model *mod,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -91,7 +91,7 @@ void bt_mesh_od_priv_proxy_cli_timeout_set(int32_t timeout)
 	msg_timeout = timeout;
 }
 
-static int on_demand_proxy_cli_init(struct bt_mesh_model *mod)
+static int on_demand_proxy_cli_init(const struct bt_mesh_model *mod)
 {
 	if (!bt_mesh_model_in_primary(mod)) {
 		LOG_ERR("On-Demand Private Proxy client not in primary element");
@@ -101,7 +101,7 @@ static int on_demand_proxy_cli_init(struct bt_mesh_model *mod)
 	cli = mod->user_data;
 	cli->model = mod;
 	mod->keys[0] = BT_MESH_KEY_DEV_ANY;
-	mod->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	mod->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 	msg_timeout = CONFIG_BT_MESH_OD_PRIV_PROXY_CLI_TIMEOUT;
 
 	bt_mesh_msg_ack_ctx_init(&cli->ack_ctx);

--- a/subsys/bluetooth/mesh/od_priv_proxy_srv.c
+++ b/subsys/bluetooth/mesh/od_priv_proxy_srv.c
@@ -14,7 +14,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_od_priv_proxy_srv);
 
-static int proxy_status_rsp(struct bt_mesh_model *mod,
+static int proxy_status_rsp(const struct bt_mesh_model *mod,
 			    struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(buf, OP_OD_PRIV_PROXY_STATUS, 1);
@@ -27,7 +27,7 @@ static int proxy_status_rsp(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_proxy_get(struct bt_mesh_model *mod,
+static int handle_proxy_get(const struct bt_mesh_model *mod,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -38,7 +38,7 @@ static int handle_proxy_get(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_proxy_set(struct bt_mesh_model *mod,
+static int handle_proxy_set(const struct bt_mesh_model *mod,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -62,11 +62,11 @@ const struct bt_mesh_model_op _bt_mesh_od_priv_proxy_srv_op[] = {
 	BT_MESH_MODEL_OP_END
 };
 
-static int od_priv_proxy_srv_init(struct bt_mesh_model *mod)
+static int od_priv_proxy_srv_init(const struct bt_mesh_model *mod)
 {
-	struct bt_mesh_model *priv_beacon_srv = bt_mesh_model_find(
+	const struct bt_mesh_model *priv_beacon_srv = bt_mesh_model_find(
 		bt_mesh_model_elem(mod), BT_MESH_MODEL_ID_PRIV_BEACON_SRV);
-	struct bt_mesh_model *sol_pdu_rpl_srv = bt_mesh_model_find(
+	const struct bt_mesh_model *sol_pdu_rpl_srv = bt_mesh_model_find(
 		bt_mesh_model_elem(mod), BT_MESH_MODEL_ID_SOL_PDU_RPL_SRV);
 
 	if (priv_beacon_srv == NULL) {
@@ -79,7 +79,7 @@ static int od_priv_proxy_srv_init(struct bt_mesh_model *mod)
 	}
 
 	mod->keys[0] = BT_MESH_KEY_DEV_LOCAL;
-	mod->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	mod->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
 		bt_mesh_model_extend(mod, priv_beacon_srv);

--- a/subsys/bluetooth/mesh/op_agg.c
+++ b/subsys/bluetooth/mesh/op_agg.c
@@ -54,7 +54,7 @@ void bt_mesh_op_agg_ctx_reinit(void)
 	agg_ctx.initialized = true;
 }
 
-int bt_mesh_op_agg_send(struct bt_mesh_model *model,
+int bt_mesh_op_agg_send(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *msg,
 			const struct bt_mesh_send_cb *cb)
 {
@@ -67,7 +67,7 @@ int bt_mesh_op_agg_send(struct bt_mesh_model *model,
 	/* Store source address so that Opcodes Aggregator Client can match
 	 * response with source model
 	 */
-	src = bt_mesh_model_elem(model)->addr;
+	src = bt_mesh_elem_addr_get(bt_mesh_model_elem(model));
 
 	if (net_buf_simple_tailroom(&srcs) < 2) {
 		return -ENOMEM;

--- a/subsys/bluetooth/mesh/op_agg.h
+++ b/subsys/bluetooth/mesh/op_agg.h
@@ -46,6 +46,6 @@ int bt_mesh_op_agg_decode_msg(struct net_buf_simple *msg,
 
 int bt_mesh_op_agg_accept(struct bt_mesh_msg_ctx *ctx);
 
-int bt_mesh_op_agg_send(struct bt_mesh_model *model,
+int bt_mesh_op_agg_send(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *msg,
 			const struct bt_mesh_send_cb *cb);

--- a/subsys/bluetooth/mesh/op_agg_cli.c
+++ b/subsys/bluetooth/mesh/op_agg_cli.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(bt_mesh_op_agg_cli);
 /** Mesh Opcodes Aggregator Client Model Context */
 static struct bt_mesh_op_agg_cli {
 	/** Composition data model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/* Internal parameters for tracking message responses. */
 	struct bt_mesh_msg_ack_ctx ack_ctx;
@@ -29,7 +29,7 @@ static struct bt_mesh_op_agg_cli {
 
 static int32_t msg_timeout;
 
-static int handle_status(struct bt_mesh_model *model,
+static int handle_status(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -93,7 +93,7 @@ const struct bt_mesh_model_op _bt_mesh_op_agg_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int op_agg_cli_init(struct bt_mesh_model *model)
+static int op_agg_cli_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Opcodes Aggregator Client only allowed in primary element");

--- a/subsys/bluetooth/mesh/op_agg_srv.c
+++ b/subsys/bluetooth/mesh/op_agg_srv.c
@@ -20,10 +20,10 @@ LOG_MODULE_REGISTER(bt_mesh_op_agg_srv);
 /** Mesh Opcodes Aggragator Server Model Context */
 static struct bt_mesh_op_agg_srv {
 	/** Composition data model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 } srv;
 
-static int handle_sequence(struct bt_mesh_model *model,
+static int handle_sequence(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -105,7 +105,7 @@ const struct bt_mesh_model_op _bt_mesh_op_agg_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int op_agg_srv_init(struct bt_mesh_model *model)
+static int op_agg_srv_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Opcodes Aggregator Server only allowed in primary element");

--- a/subsys/bluetooth/mesh/priv_beacon_cli.c
+++ b/subsys/bluetooth/mesh/priv_beacon_cli.c
@@ -18,7 +18,7 @@ static struct bt_mesh_priv_beacon_cli *cli;
 
 static int32_t msg_timeout;
 
-static int handle_beacon_status(struct bt_mesh_model *model,
+static int handle_beacon_status(const struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
@@ -56,7 +56,7 @@ static int handle_beacon_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int handle_gatt_proxy_status(struct bt_mesh_model *model,
+static int handle_gatt_proxy_status(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -86,7 +86,7 @@ static int handle_gatt_proxy_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int handle_node_id_status(struct bt_mesh_model *model,
+static int handle_node_id_status(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -134,7 +134,7 @@ const struct bt_mesh_model_op bt_mesh_priv_beacon_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int priv_beacon_cli_init(struct bt_mesh_model *model)
+static int priv_beacon_cli_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Private Beacon Client only allowed in primary element");
@@ -145,7 +145,7 @@ static int priv_beacon_cli_init(struct bt_mesh_model *model)
 	cli->model = model;
 	msg_timeout = 2 * MSEC_PER_SEC;
 	model->keys[0] = BT_MESH_KEY_DEV_ANY;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	bt_mesh_msg_ack_ctx_init(&cli->ack_ctx);
 

--- a/subsys/bluetooth/mesh/priv_beacon_srv.c
+++ b/subsys/bluetooth/mesh/priv_beacon_srv.c
@@ -16,7 +16,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_priv_beacon_srv);
 
-static int beacon_status_rsp(struct bt_mesh_model *mod,
+static int beacon_status_rsp(const struct bt_mesh_model *mod,
 			      struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(buf, OP_PRIV_BEACON_STATUS, 2);
@@ -30,7 +30,7 @@ static int beacon_status_rsp(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_beacon_get(struct bt_mesh_model *mod,
+static int handle_beacon_get(const struct bt_mesh_model *mod,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -41,7 +41,7 @@ static int handle_beacon_get(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_beacon_set(struct bt_mesh_model *mod,
+static int handle_beacon_set(const struct bt_mesh_model *mod,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -68,7 +68,7 @@ static int handle_beacon_set(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static void gatt_proxy_status_rsp(struct bt_mesh_model *mod,
+static void gatt_proxy_status_rsp(const struct bt_mesh_model *mod,
 				  struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(buf, OP_PRIV_GATT_PROXY_STATUS, 1);
@@ -79,7 +79,7 @@ static void gatt_proxy_status_rsp(struct bt_mesh_model *mod,
 	bt_mesh_model_send(mod, ctx, &buf, NULL, NULL);
 }
 
-static int handle_gatt_proxy_get(struct bt_mesh_model *mod,
+static int handle_gatt_proxy_get(const struct bt_mesh_model *mod,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -90,7 +90,7 @@ static int handle_gatt_proxy_get(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_gatt_proxy_set(struct bt_mesh_model *mod,
+static int handle_gatt_proxy_set(const struct bt_mesh_model *mod,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -112,7 +112,7 @@ static int handle_gatt_proxy_set(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static void node_id_status_rsp(struct bt_mesh_model *mod,
+static void node_id_status_rsp(const struct bt_mesh_model *mod,
 			       struct bt_mesh_msg_ctx *ctx, uint8_t status,
 			       uint16_t net_idx, uint8_t node_id)
 {
@@ -126,7 +126,7 @@ static void node_id_status_rsp(struct bt_mesh_model *mod,
 	bt_mesh_model_send(mod, ctx, &buf, NULL, NULL);
 }
 
-static int handle_node_id_get(struct bt_mesh_model *mod,
+static int handle_node_id_get(const struct bt_mesh_model *mod,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -141,7 +141,7 @@ static int handle_node_id_get(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_node_id_set(struct bt_mesh_model *mod,
+static int handle_node_id_set(const struct bt_mesh_model *mod,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -172,7 +172,7 @@ const struct bt_mesh_model_op bt_mesh_priv_beacon_srv_op[] = {
 	BT_MESH_MODEL_OP_END
 };
 
-static int priv_beacon_srv_init(struct bt_mesh_model *mod)
+static int priv_beacon_srv_init(const struct bt_mesh_model *mod)
 {
 	if (!bt_mesh_model_in_primary(mod)) {
 		LOG_ERR("Priv beacon server not in primary element");

--- a/subsys/bluetooth/mesh/rpr_cli.c
+++ b/subsys/bluetooth/mesh/rpr_cli.c
@@ -90,7 +90,7 @@ static void tx_complete(struct bt_mesh_rpr_cli *cli, int err, void *cb_data)
 	}
 }
 
-static int handle_extended_scan_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_extended_scan_report(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_node srv = RPR_NODE(ctx);
@@ -123,7 +123,7 @@ static int handle_extended_scan_report(struct bt_mesh_model *mod, struct bt_mesh
 	return 0;
 }
 
-static int handle_link_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_link_report(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_node srv = RPR_NODE(ctx);
@@ -161,7 +161,7 @@ static int handle_link_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 	return 0;
 }
 
-static int handle_link_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_link_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_cli *cli = mod->user_data;
@@ -195,7 +195,7 @@ static int handle_link_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 	return 0;
 }
 
-static int handle_pdu_outbound_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_pdu_outbound_report(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				      struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_cli *cli = mod->user_data;
@@ -226,7 +226,7 @@ static int handle_pdu_outbound_report(struct bt_mesh_model *mod, struct bt_mesh_
 	return 0;
 }
 
-static int handle_pdu_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_pdu_report(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_cli *cli = mod->user_data;
@@ -257,7 +257,7 @@ static int handle_pdu_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *
 	return 0;
 }
 
-static int handle_scan_caps_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_caps_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_cli *cli = mod->user_data;
@@ -281,7 +281,7 @@ static int handle_scan_caps_status(struct bt_mesh_model *mod, struct bt_mesh_msg
 	return 0;
 }
 
-static int handle_scan_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_report(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_cli *cli = mod->user_data;
@@ -313,7 +313,7 @@ static int handle_scan_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 	return 0;
 }
 
-static int handle_scan_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_cli *cli = mod->user_data;
@@ -361,9 +361,9 @@ static void link_timeout(struct k_work *work)
 	}
 }
 
-static int rpr_cli_init(struct bt_mesh_model *mod)
+static int rpr_cli_init(const struct bt_mesh_model *mod)
 {
-	if (mod->elem_idx) {
+	if (mod->ctx->elem_idx) {
 		LOG_ERR("Remote provisioning client must be initialized "
 			"on first element");
 		return -EINVAL;
@@ -378,7 +378,7 @@ static int rpr_cli_init(struct bt_mesh_model *mod)
 	bt_mesh_msg_ack_ctx_init(&cli->prov_ack_ctx);
 	k_work_init_delayable(&cli->link.timeout, link_timeout);
 	mod->keys[0] = BT_MESH_KEY_DEV_ANY;
-	mod->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	mod->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/rpr_srv.c
+++ b/subsys/bluetooth/mesh/rpr_srv.c
@@ -46,7 +46,7 @@ enum {
 
 /** Remote provisioning server instance. */
 static struct {
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 
 	ATOMIC_DEFINE(flags, RPR_SRV_NUM_FLAGS);
 
@@ -533,7 +533,7 @@ static const struct prov_bearer_cb prov_bearer_cb = {
  * Message handlers
  ******************************************************************************/
 
-static int handle_scan_caps_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_caps_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(rsp, RPR_OP_SCAN_CAPS_STATUS, 2);
@@ -546,7 +546,7 @@ static int handle_scan_caps_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ct
 	return 0;
 }
 
-static int handle_scan_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	scan_status_send(ctx, BT_MESH_RPR_SUCCESS);
@@ -554,7 +554,7 @@ static int handle_scan_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ct
 	return 0;
 }
 
-static int handle_scan_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_node cli = RPR_NODE(ctx);
@@ -618,7 +618,7 @@ rsp:
 	return 0;
 }
 
-static int handle_extended_scan_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_extended_scan_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				      struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(rsp, RPR_OP_EXTENDED_SCAN_REPORT,
@@ -781,7 +781,7 @@ rsp:
 	return 0;
 }
 
-static int handle_scan_stop(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_stop(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
 	if (atomic_test_bit(srv.flags, SCANNING)) {
@@ -794,7 +794,7 @@ static int handle_scan_stop(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *c
 	return 0;
 }
 
-static int handle_link_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_link_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	LOG_DBG("");
@@ -804,7 +804,7 @@ static int handle_link_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ct
 	return 0;
 }
 
-static int handle_link_open(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_link_open(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
 	bool is_refresh_procedure = (buf->len == 1);
@@ -935,7 +935,7 @@ rsp:
 	return 0;
 }
 
-static int handle_link_close(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_link_close(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_node cli = RPR_NODE(ctx);
@@ -972,7 +972,7 @@ static int handle_link_close(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *
 	return 0;
 }
 
-static int handle_pdu_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_pdu_send(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_node cli = RPR_NODE(ctx);
@@ -1300,9 +1300,9 @@ static struct bt_le_scan_cb scan_cb = {
 	.recv = scan_packet_recv,
 };
 
-static int rpr_srv_init(struct bt_mesh_model *mod)
+static int rpr_srv_init(const struct bt_mesh_model *mod)
 {
-	if (mod->elem_idx || srv.mod) {
+	if (mod->ctx->elem_idx || srv.mod) {
 		LOG_ERR("Remote provisioning server must be initialized "
 			"on first element");
 		return -EINVAL;
@@ -1317,12 +1317,12 @@ static int rpr_srv_init(struct bt_mesh_model *mod)
 	k_work_init(&srv.link.report, link_report_send_and_clear);
 	bt_le_scan_cb_register(&scan_cb);
 	mod->keys[0] = BT_MESH_KEY_DEV_LOCAL;
-	mod->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	mod->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	return 0;
 }
 
-static void rpr_srv_reset(struct bt_mesh_model *mod)
+static void rpr_srv_reset(const struct bt_mesh_model *mod)
 {
 	cli_link_clear();
 	cli_scan_clear();

--- a/subsys/bluetooth/mesh/sar_cfg_cli.c
+++ b/subsys/bluetooth/mesh/sar_cfg_cli.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(bt_mesh_sar_cfg_cli);
 
 static struct bt_mesh_sar_cfg_cli *cli;
 
-static int transmitter_status(struct bt_mesh_model *model,
+static int transmitter_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -45,7 +45,7 @@ static int transmitter_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int receiver_status(struct bt_mesh_model *model,
+static int receiver_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -87,7 +87,7 @@ void bt_mesh_sar_cfg_cli_timeout_set(int32_t timeout)
 	cli->timeout = timeout;
 }
 
-static int bt_mesh_sar_cfg_cli_init(struct bt_mesh_model *model)
+static int bt_mesh_sar_cfg_cli_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("SAR Configuration Client only allowed in primary element");
@@ -104,14 +104,14 @@ static int bt_mesh_sar_cfg_cli_init(struct bt_mesh_model *model)
 	cli->timeout = 2 * MSEC_PER_SEC;
 
 	model->keys[0] = BT_MESH_KEY_DEV_ANY;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	bt_mesh_msg_ack_ctx_init(&cli->ack_ctx);
 
 	return 0;
 }
 
-static void bt_mesh_sar_cfg_cli_reset(struct bt_mesh_model *model)
+static void bt_mesh_sar_cfg_cli_reset(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_sar_cfg_cli *cli;
 

--- a/subsys/bluetooth/mesh/sar_cfg_srv.c
+++ b/subsys/bluetooth/mesh/sar_cfg_srv.c
@@ -27,7 +27,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_sar_cfg_srv);
 
-static int sar_rx_store(struct bt_mesh_model *model, bool delete)
+static int sar_rx_store(const struct bt_mesh_model *model, bool delete)
 {
 	const void *data = delete ? NULL : &bt_mesh.sar_rx;
 	size_t len = delete ? 0 : sizeof(struct bt_mesh_sar_rx);
@@ -35,7 +35,7 @@ static int sar_rx_store(struct bt_mesh_model *model, bool delete)
 	return bt_mesh_model_data_store(model, false, "sar_rx", data, len);
 }
 
-static int sar_tx_store(struct bt_mesh_model *model, bool delete)
+static int sar_tx_store(const struct bt_mesh_model *model, bool delete)
 {
 	const void *data = delete ? NULL : &bt_mesh.sar_tx;
 	size_t len = delete ? 0 : sizeof(struct bt_mesh_sar_tx);
@@ -43,7 +43,7 @@ static int sar_tx_store(struct bt_mesh_model *model, bool delete)
 	return bt_mesh_model_data_store(model, false, "sar_tx", data, len);
 }
 
-static void transmitter_status(struct bt_mesh_model *model,
+static void transmitter_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_SAR_CFG_TX_STATUS, BT_MESH_SAR_TX_LEN);
@@ -63,7 +63,7 @@ static void transmitter_status(struct bt_mesh_model *model,
 	}
 }
 
-static void receiver_status(struct bt_mesh_model *model,
+static void receiver_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_SAR_CFG_RX_STATUS, BT_MESH_SAR_RX_LEN);
@@ -81,7 +81,7 @@ static void receiver_status(struct bt_mesh_model *model,
 	}
 }
 
-static int transmitter_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int transmitter_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	LOG_DBG("src 0x%04x", ctx->addr);
@@ -91,7 +91,7 @@ static int transmitter_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *
 	return 0;
 }
 
-static int transmitter_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int transmitter_set(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_sar_tx *tx = &bt_mesh.sar_tx;
@@ -108,7 +108,7 @@ static int transmitter_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *
 	return 0;
 }
 
-static int receiver_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int receiver_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	LOG_DBG("src 0x%04x", ctx->addr);
@@ -118,7 +118,7 @@ static int receiver_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx
 	return 0;
 }
 
-static int receiver_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int receiver_set(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_sar_rx *rx = &bt_mesh.sar_rx;
@@ -143,7 +143,7 @@ const struct bt_mesh_model_op bt_mesh_sar_cfg_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int sar_cfg_srv_init(struct bt_mesh_model *model)
+static int sar_cfg_srv_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Configuration Server only allowed in primary element");
@@ -155,12 +155,12 @@ static int sar_cfg_srv_init(struct bt_mesh_model *model)
 	 * device-key is allowed to access this model.
 	 */
 	model->keys[0] = BT_MESH_KEY_DEV_LOCAL;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	return 0;
 }
 
-static void sar_cfg_srv_reset(struct bt_mesh_model *model)
+static void sar_cfg_srv_reset(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_sar_tx sar_tx = BT_MESH_SAR_TX_INIT;
 	struct bt_mesh_sar_rx sar_rx = BT_MESH_SAR_RX_INIT;
@@ -175,8 +175,9 @@ static void sar_cfg_srv_reset(struct bt_mesh_model *model)
 }
 
 #ifdef CONFIG_BT_SETTINGS
-static int sar_cfg_srv_settings_set(struct bt_mesh_model *model, const char *name, size_t len_rd,
-				    settings_read_cb read_cb, void *cb_data)
+static int sar_cfg_srv_settings_set(const struct bt_mesh_model *model, const char *name,
+				    size_t len_rd, settings_read_cb read_cb,
+				    void *cb_data)
 {
 	if (!strncmp(name, "sar_rx", 5)) {
 		return bt_mesh_settings_set(read_cb, cb_data, &bt_mesh.sar_rx,

--- a/subsys/bluetooth/mesh/shell/blob.c
+++ b/subsys/bluetooth/mesh/shell/blob.c
@@ -271,7 +271,7 @@ static int cmd_flash_stream_unset(const struct shell *sh, size_t argc, char *arg
 
 #if defined(CONFIG_BT_MESH_SHELL_BLOB_CLI)
 
-static struct bt_mesh_model *mod_cli;
+static const struct bt_mesh_model *mod_cli;
 
 static void blob_cli_inputs_prepare(uint16_t group)
 {
@@ -503,7 +503,7 @@ static int cmd_tx_resume(const struct shell *sh, size_t argc, char *argv[])
 
 #if defined(CONFIG_BT_MESH_SHELL_BLOB_SRV)
 
-static struct bt_mesh_model *mod_srv;
+static const struct bt_mesh_model *mod_srv;
 
 static int cmd_rx(const struct shell *sh, size_t argc, char *argv[])
 {

--- a/subsys/bluetooth/mesh/shell/dfd.c
+++ b/subsys/bluetooth/mesh/shell/dfd.c
@@ -14,7 +14,7 @@
 #include "../dfd_srv_internal.h"
 #include "../access.h"
 
-static struct bt_mesh_model *mod;
+static const struct bt_mesh_model *mod;
 
 static void print_receivers_status(const struct shell *sh, struct bt_mesh_dfd_srv *srv,
 				   enum bt_mesh_dfd_status status)

--- a/subsys/bluetooth/mesh/shell/dfu.c
+++ b/subsys/bluetooth/mesh/shell/dfu.c
@@ -516,7 +516,7 @@ static int cmd_dfu_slot_get(const struct shell *sh, size_t argc, char *argv[])
 
 #if defined(CONFIG_BT_MESH_SHELL_DFU_CLI)
 
-static struct bt_mesh_model *mod_cli;
+static const struct bt_mesh_model *mod_cli;
 
 static struct {
 	struct bt_mesh_dfu_target targets[32];
@@ -907,7 +907,7 @@ static int cmd_dfu_tx_progress(const struct shell *sh, size_t argc, char *argv[]
 
 #if defined(CONFIG_BT_MESH_SHELL_DFU_SRV)
 
-static struct bt_mesh_model *mod_srv;
+static const struct bt_mesh_model *mod_srv;
 
 static int cmd_dfu_applied(const struct shell *sh, size_t argc, char *argv[])
 {

--- a/subsys/bluetooth/mesh/shell/health.c
+++ b/subsys/bluetooth/mesh/shell/health.c
@@ -13,7 +13,7 @@
 #include "utils.h"
 #include <zephyr/bluetooth/mesh/shell.h>
 
-static struct bt_mesh_model *mod;
+static const struct bt_mesh_model *mod;
 
 static void show_faults(const struct shell *sh, uint8_t test_id, uint16_t cid, uint8_t *faults,
 			size_t fault_count)

--- a/subsys/bluetooth/mesh/shell/rpr.c
+++ b/subsys/bluetooth/mesh/shell/rpr.c
@@ -11,7 +11,7 @@
 
 #include "utils.h"
 
-static struct bt_mesh_model *mod;
+static const struct bt_mesh_model *mod;
 
 /***************************************************************************************************
  * Implementation of the model's instance

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -1058,7 +1058,7 @@ static int cmd_rpl_clear(const struct shell *sh, size_t argc, char *argv[])
 }
 
 #if defined(CONFIG_BT_MESH_SHELL_HEALTH_SRV_INSTANCE)
-static struct bt_mesh_elem *primary_element(void)
+static const struct bt_mesh_elem *primary_element(void)
 {
 	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
 
@@ -1073,7 +1073,7 @@ static int cmd_add_fault(const struct shell *sh, size_t argc, char *argv[])
 {
 	uint8_t fault_id;
 	uint8_t i;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	int err = 0;
 
 	elem = primary_element();
@@ -1126,7 +1126,7 @@ static int cmd_del_fault(const struct shell *sh, size_t argc, char *argv[])
 {
 	uint8_t fault_id;
 	uint8_t i;
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	int err = 0;
 
 	elem = primary_element();

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -68,7 +68,7 @@ static void get_faults(uint8_t *faults, uint8_t faults_size, uint8_t *dst, uint8
 	}
 }
 
-static int fault_get_cur(struct bt_mesh_model *model, uint8_t *test_id,
+static int fault_get_cur(const struct bt_mesh_model *model, uint8_t *test_id,
 			 uint16_t *company_id, uint8_t *faults, uint8_t *fault_count)
 {
 	shell_print_ctx("Sending current faults");
@@ -81,7 +81,7 @@ static int fault_get_cur(struct bt_mesh_model *model, uint8_t *test_id,
 	return 0;
 }
 
-static int fault_get_reg(struct bt_mesh_model *model, uint16_t cid,
+static int fault_get_reg(const struct bt_mesh_model *model, uint16_t cid,
 			 uint8_t *test_id, uint8_t *faults, uint8_t *fault_count)
 {
 	if (cid != CONFIG_BT_COMPANY_ID) {
@@ -99,7 +99,7 @@ static int fault_get_reg(struct bt_mesh_model *model, uint16_t cid,
 	return 0;
 }
 
-static int fault_clear(struct bt_mesh_model *model, uint16_t cid)
+static int fault_clear(const struct bt_mesh_model *model, uint16_t cid)
 {
 	if (cid != CONFIG_BT_COMPANY_ID) {
 		return -EINVAL;
@@ -110,7 +110,7 @@ static int fault_clear(struct bt_mesh_model *model, uint16_t cid)
 	return 0;
 }
 
-static int fault_test(struct bt_mesh_model *model, uint8_t test_id,
+static int fault_test(const struct bt_mesh_model *model, uint8_t test_id,
 		      uint16_t cid)
 {
 	if (cid != CONFIG_BT_COMPANY_ID) {
@@ -124,12 +124,12 @@ static int fault_test(struct bt_mesh_model *model, uint8_t test_id,
 	return 0;
 }
 
-static void attention_on(struct bt_mesh_model *model)
+static void attention_on(const struct bt_mesh_model *model)
 {
 	shell_print_ctx("Attention On");
 }
 
-static void attention_off(struct bt_mesh_model *model)
+static void attention_off(const struct bt_mesh_model *model)
 {
 	shell_print_ctx("Attention Off");
 }

--- a/subsys/bluetooth/mesh/shell/utils.c
+++ b/subsys/bluetooth/mesh/shell/utils.c
@@ -21,7 +21,7 @@ struct shell_model_instance {
 static void model_instances_get(uint16_t id, struct shell_model_instance *arr, uint8_t len)
 {
 	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
-	struct bt_mesh_elem *elem;
+	const struct bt_mesh_elem *elem;
 	struct bt_mesh_model *mod;
 
 	for (int i = 0; i < len; i++) {

--- a/subsys/bluetooth/mesh/shell/utils.c
+++ b/subsys/bluetooth/mesh/shell/utils.c
@@ -22,19 +22,19 @@ static void model_instances_get(uint16_t id, struct shell_model_instance *arr, u
 {
 	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
 	const struct bt_mesh_elem *elem;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 
 	for (int i = 0; i < len; i++) {
-		elem = bt_mesh_elem_find(comp->elem[i].addr);
+		elem = bt_mesh_elem_find(bt_mesh_elem_addr_get(&comp->elem[i]));
 		mod = bt_mesh_model_find(elem, id);
 		if (mod) {
-			arr[i].addr = comp->elem[i].addr;
-			arr[i].elem_idx = mod->elem_idx;
+			arr[i].addr = bt_mesh_elem_addr_get(&comp->elem[i]);
+			arr[i].elem_idx = mod->ctx->elem_idx;
 		}
 	}
 }
 
-bool bt_mesh_shell_mdl_first_get(uint16_t id, struct bt_mesh_model **mod)
+bool bt_mesh_shell_mdl_first_get(uint16_t id, const struct bt_mesh_model **mod)
 {
 	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
 
@@ -48,10 +48,10 @@ bool bt_mesh_shell_mdl_first_get(uint16_t id, struct bt_mesh_model **mod)
 	return false;
 }
 
-int bt_mesh_shell_mdl_instance_set(const struct shell *sh, struct bt_mesh_model **mod,
+int bt_mesh_shell_mdl_instance_set(const struct shell *sh, const struct bt_mesh_model **mod,
 				 uint16_t mod_id, uint8_t elem_idx)
 {
-	struct bt_mesh_model *mod_temp;
+	const struct bt_mesh_model *mod_temp;
 	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
 
 	if (elem_idx >= comp->elem_count) {

--- a/subsys/bluetooth/mesh/shell/utils.h
+++ b/subsys/bluetooth/mesh/shell/utils.h
@@ -34,9 +34,9 @@
 					     0), \
 			       SHELL_SUBCMD_SET_END);
 
-bool bt_mesh_shell_mdl_first_get(uint16_t id, struct bt_mesh_model **mod);
+bool bt_mesh_shell_mdl_first_get(uint16_t id, const struct bt_mesh_model **mod);
 
-int bt_mesh_shell_mdl_instance_set(const struct shell *sh, struct bt_mesh_model **mod,
+int bt_mesh_shell_mdl_instance_set(const struct shell *sh, const struct bt_mesh_model **mod,
 			      uint16_t mod_id, uint8_t elem_idx);
 
 int bt_mesh_shell_mdl_print_all(const struct shell *sh, uint16_t mod_id);

--- a/subsys/bluetooth/mesh/sol_pdu_rpl_cli.c
+++ b/subsys/bluetooth/mesh/sol_pdu_rpl_cli.c
@@ -22,7 +22,7 @@ struct sol_rpl_param {
 	uint8_t *len;
 };
 
-static int handle_status(struct bt_mesh_model *mod,
+static int handle_status(const struct bt_mesh_model *mod,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -160,7 +160,7 @@ void bt_mesh_sol_pdu_rpl_cli_timeout_set(int32_t timeout)
 	msg_timeout = timeout;
 }
 
-static int sol_pdu_rpl_cli_init(struct bt_mesh_model *mod)
+static int sol_pdu_rpl_cli_init(const struct bt_mesh_model *mod)
 {
 	if (!bt_mesh_model_in_primary(mod)) {
 		LOG_ERR("Solicitation PDU RPL Configuration client not in primary element");

--- a/subsys/bluetooth/mesh/sol_pdu_rpl_srv.c
+++ b/subsys/bluetooth/mesh/sol_pdu_rpl_srv.c
@@ -14,7 +14,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_sol_pdu_rpl_srv);
 
-static void sol_rpl_status_rsp(struct bt_mesh_model *mod,
+static void sol_rpl_status_rsp(const struct bt_mesh_model *mod,
 			       struct bt_mesh_msg_ctx *ctx,
 			       uint16_t range,
 			       uint8_t len)
@@ -32,7 +32,7 @@ static void sol_rpl_status_rsp(struct bt_mesh_model *mod,
 	bt_mesh_model_send(mod, ctx, &buf, NULL, NULL);
 }
 
-static int item_clear(struct bt_mesh_model *mod,
+static int item_clear(const struct bt_mesh_model *mod,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf,
 		      bool acked)
@@ -78,14 +78,14 @@ static int item_clear(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_item_clear(struct bt_mesh_model *mod,
+static int handle_item_clear(const struct bt_mesh_model *mod,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
 	return item_clear(mod, ctx, buf, true);
 }
 
-static int handle_item_clear_unacked(struct bt_mesh_model *mod,
+static int handle_item_clear_unacked(const struct bt_mesh_model *mod,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
@@ -99,7 +99,7 @@ const struct bt_mesh_model_op _bt_mesh_sol_pdu_rpl_srv_op[] = {
 	BT_MESH_MODEL_OP_END
 };
 
-static int sol_pdu_rpl_srv_init(struct bt_mesh_model *mod)
+static int sol_pdu_rpl_srv_init(const struct bt_mesh_model *mod)
 {
 	if (!bt_mesh_model_in_primary(mod)) {
 		LOG_ERR("Solicitation PDU RPL Configuration server not in primary element");

--- a/tests/bluetooth/mesh/basic/src/main.c
+++ b/tests/bluetooth/mesh/basic/src/main.c
@@ -15,7 +15,7 @@
 
 static bool has_reg_fault = true;
 
-static int fault_get_cur(struct bt_mesh_model *model, uint8_t *test_id,
+static int fault_get_cur(const struct bt_mesh_model *model, uint8_t *test_id,
 			 uint16_t *company_id, uint8_t *faults, uint8_t *fault_count)
 {
 	uint8_t reg_faults[MAX_FAULT] = { [0 ... (MAX_FAULT - 1)] = 0xff };
@@ -30,7 +30,7 @@ static int fault_get_cur(struct bt_mesh_model *model, uint8_t *test_id,
 	return 0;
 }
 
-static int fault_get_reg(struct bt_mesh_model *model, uint16_t company_id,
+static int fault_get_reg(const struct bt_mesh_model *model, uint16_t company_id,
 			 uint8_t *test_id, uint8_t *faults, uint8_t *fault_count)
 {
 	if (company_id != BT_COMP_ID_LF) {
@@ -53,7 +53,7 @@ static int fault_get_reg(struct bt_mesh_model *model, uint16_t company_id,
 	return 0;
 }
 
-static int fault_clear(struct bt_mesh_model *model, uint16_t company_id)
+static int fault_clear(const struct bt_mesh_model *model, uint16_t company_id)
 {
 	if (company_id != BT_COMP_ID_LF) {
 		return -EINVAL;
@@ -64,7 +64,7 @@ static int fault_clear(struct bt_mesh_model *model, uint16_t company_id)
 	return 0;
 }
 
-static int fault_test(struct bt_mesh_model *model, uint8_t test_id,
+static int fault_test(const struct bt_mesh_model *model, uint8_t test_id,
 		      uint16_t company_id)
 {
 	if (company_id != BT_COMP_ID_LF) {
@@ -90,12 +90,12 @@ static struct bt_mesh_health_srv health_srv = {
 
 BT_MESH_HEALTH_PUB_DEFINE(health_pub, MAX_FAULT);
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
 };
 
-static int vnd_publish(struct bt_mesh_model *mod)
+static int vnd_publish(const struct bt_mesh_model *mod)
 {
 	printk("Vendor publish\n");
 	return 0;
@@ -109,7 +109,7 @@ static const struct bt_mesh_model_op vnd_ops[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static struct bt_mesh_model vnd_models[] = {
+static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, 0x1234, vnd_ops, &vnd_pub, NULL),
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, 0x4321, vnd_ops, &vnd_pub2, NULL),
 };

--- a/tests/bluetooth/mesh/basic/src/main.c
+++ b/tests/bluetooth/mesh/basic/src/main.c
@@ -114,7 +114,7 @@ static struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, 0x4321, vnd_ops, &vnd_pub2, NULL),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, vnd_models),
 };
 

--- a/tests/bluetooth/mesh_shell/src/main.c
+++ b/tests/bluetooth/mesh_shell/src/main.c
@@ -43,7 +43,7 @@ struct bt_mesh_large_comp_data_cli large_comp_data_cli;
 
 BT_MESH_SHELL_HEALTH_PUB_DEFINE(health_pub);
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_SRV(&bt_mesh_shell_health_srv, &health_pub),

--- a/tests/bluetooth/mesh_shell/src/main.c
+++ b/tests/bluetooth/mesh_shell/src/main.c
@@ -107,7 +107,7 @@ static struct bt_mesh_model root_models[] = {
 #endif
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, BT_MESH_MODEL_NONE),
 };
 

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -58,7 +58,7 @@ static uint16_t vnd_app_key_idx = 0x000f;
 #define AUTH_METHOD_INPUT 0x03
 
 static struct model_data {
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 	uint16_t addr;
 	uint16_t appkey_idx;
 } model_bound[MODEL_BOUNDS_MAX];
@@ -190,7 +190,7 @@ static void get_faults(uint8_t *faults, uint8_t faults_size, uint8_t *dst, uint8
 	}
 }
 
-static int fault_get_cur(struct bt_mesh_model *model, uint8_t *test_id,
+static int fault_get_cur(const struct bt_mesh_model *model, uint8_t *test_id,
 			 uint16_t *company_id, uint8_t *faults, uint8_t *fault_count)
 {
 	LOG_DBG("");
@@ -203,7 +203,7 @@ static int fault_get_cur(struct bt_mesh_model *model, uint8_t *test_id,
 	return 0;
 }
 
-static int fault_get_reg(struct bt_mesh_model *model, uint16_t company_id,
+static int fault_get_reg(const struct bt_mesh_model *model, uint16_t company_id,
 			 uint8_t *test_id, uint8_t *faults, uint8_t *fault_count)
 {
 	LOG_DBG("company_id 0x%04x", company_id);
@@ -219,7 +219,7 @@ static int fault_get_reg(struct bt_mesh_model *model, uint16_t company_id,
 	return 0;
 }
 
-static int fault_clear(struct bt_mesh_model *model, uint16_t company_id)
+static int fault_clear(const struct bt_mesh_model *model, uint16_t company_id)
 {
 	LOG_DBG("company_id 0x%04x", company_id);
 
@@ -232,7 +232,7 @@ static int fault_clear(struct bt_mesh_model *model, uint16_t company_id)
 	return 0;
 }
 
-static int fault_test(struct bt_mesh_model *model, uint8_t test_id,
+static int fault_test(const struct bt_mesh_model *model, uint8_t test_id,
 		      uint16_t company_id)
 {
 	LOG_DBG("test_id 0x%02x company_id 0x%04x", test_id, company_id);
@@ -290,14 +290,14 @@ static struct bt_mesh_health_cli health_cli = {
 	.current_status = health_current_status,
 };
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
 	BT_MESH_MODEL_HEALTH_CLI(&health_cli),
 };
 
-static struct bt_mesh_model vnd_models[] = {
+static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(CID_LOCAL, VND_MODEL_ID_1, BT_MESH_MODEL_NO_OPS, NULL,
 			  NULL),
 };
@@ -799,7 +799,7 @@ static uint8_t model_send(const void *cmd, uint16_t cmd_len,
 {
 	const struct btp_mesh_model_send_cmd *cp = cmd;
 	NET_BUF_SIMPLE_DEFINE(msg, UINT8_MAX);
-	struct bt_mesh_model *model = NULL;
+	const struct bt_mesh_model *model = NULL;
 	uint16_t src;
 	int err;
 
@@ -2876,7 +2876,7 @@ void net_recv_ev(uint8_t ttl, uint8_t ctl, uint16_t src, uint16_t dst, const voi
 	tester_event(BTP_SERVICE_ID_MESH, BTP_MESH_EV_NET_RECV, buf.data, buf.len);
 }
 
-static void model_bound_cb(uint16_t addr, struct bt_mesh_model *model,
+static void model_bound_cb(uint16_t addr, const struct bt_mesh_model *model,
 			   uint16_t key_idx)
 {
 	int i;
@@ -2897,7 +2897,7 @@ static void model_bound_cb(uint16_t addr, struct bt_mesh_model *model,
 	LOG_ERR("model_bound is full");
 }
 
-static void model_unbound_cb(uint16_t addr, struct bt_mesh_model *model,
+static void model_unbound_cb(uint16_t addr, const struct bt_mesh_model *model,
 			     uint16_t key_idx)
 {
 	int i;

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -302,7 +302,7 @@ static struct bt_mesh_model vnd_models[] = {
 			  NULL),
 };
 
-static struct bt_mesh_elem elements[] = {
+static const struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, vnd_models),
 };
 

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -24,7 +24,7 @@ struct bt_mesh_test_stats test_stats;
 struct bt_mesh_msg_ctx test_send_ctx;
 static void (*ra_cb)(uint8_t *, size_t);
 
-static int msg_rx(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int msg_rx(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		   struct net_buf_simple *buf)
 {
 	size_t len = buf->len + BT_MESH_MODEL_OP_LEN(TEST_MSG_OP_1);
@@ -72,7 +72,7 @@ static int msg_rx(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int ra_rx(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int ra_rx(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		 struct net_buf_simple *buf)
 {
 	LOG_INF("\tlen: %d bytes", buf->len);
@@ -94,19 +94,19 @@ static const struct bt_mesh_model_op model_op[] = {
 	BT_MESH_MODEL_OP_END
 };
 
-int __weak test_model_pub_update(struct bt_mesh_model *mod)
+int __weak test_model_pub_update(const struct bt_mesh_model *mod)
 {
 	return -1;
 }
 
-int __weak test_model_settings_set(struct bt_mesh_model *model,
+int __weak test_model_settings_set(const struct bt_mesh_model *model,
 				   const char *name, size_t len_rd,
 				   settings_read_cb read_cb, void *cb_arg)
 {
 	return -1;
 }
 
-void __weak test_model_reset(struct bt_mesh_model *model)
+void __weak test_model_reset(const struct bt_mesh_model *model)
 {
 	/* No-op. */
 }
@@ -125,19 +125,19 @@ static const struct bt_mesh_model_op vnd_model_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-int __weak test_vnd_model_pub_update(struct bt_mesh_model *mod)
+int __weak test_vnd_model_pub_update(const struct bt_mesh_model *mod)
 {
 	return -1;
 }
 
-int __weak test_vnd_model_settings_set(struct bt_mesh_model *model,
+int __weak test_vnd_model_settings_set(const struct bt_mesh_model *model,
 				       const char *name, size_t len_rd,
 				       settings_read_cb read_cb, void *cb_arg)
 {
 	return -1;
 }
 
-void __weak test_vnd_model_reset(struct bt_mesh_model *model)
+void __weak test_vnd_model_reset(const struct bt_mesh_model *model)
 {
 	/* No-op. */
 }
@@ -163,7 +163,7 @@ static struct bt_mesh_model_pub health_pub = {
 static struct bt_mesh_sar_cfg_cli sar_cfg_cli;
 #endif
 
-static struct bt_mesh_model models[] = {
+static const struct bt_mesh_model models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_CB(TEST_MOD_ID, model_op, &pub, NULL, &test_model_cb),
@@ -174,14 +174,14 @@ static struct bt_mesh_model models[] = {
 #endif
 };
 
-struct bt_mesh_model *test_model = &models[2];
+const struct bt_mesh_model *test_model = &models[2];
 
-static struct bt_mesh_model vnd_models[] = {
+static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND_CB(TEST_VND_COMPANY_ID, TEST_VND_MOD_ID, vnd_model_op, &vnd_pub,
 			     NULL, &test_vnd_model_cb),
 };
 
-struct bt_mesh_model *test_vnd_model = &vnd_models[0];
+const struct bt_mesh_model *test_vnd_model = &vnd_models[0];
 
 static const struct bt_mesh_elem elems[] = {
 	BT_MESH_ELEM(0, models, vnd_models),

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -183,7 +183,7 @@ static struct bt_mesh_model vnd_models[] = {
 
 struct bt_mesh_model *test_vnd_model = &vnd_models[0];
 
-static struct bt_mesh_elem elems[] = {
+static const struct bt_mesh_elem elems[] = {
 	BT_MESH_ELEM(0, models, vnd_models),
 };
 

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.h
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.h
@@ -127,8 +127,8 @@ struct bt_mesh_test_sync_ctx {
 
 extern enum bst_result_t bst_result;
 extern const struct bt_mesh_test_cfg *cfg;
-extern struct bt_mesh_model *test_model;
-extern struct bt_mesh_model *test_vnd_model;
+extern const struct bt_mesh_model *test_model;
+extern const struct bt_mesh_model *test_vnd_model;
 extern const uint8_t test_net_key[16];
 extern const uint8_t test_app_key[16];
 extern const uint8_t test_va_uuid[16];

--- a/tests/bsim/bluetooth/mesh/src/test_access.c
+++ b/tests/bsim/bluetooth/mesh/src/test_access.c
@@ -35,15 +35,15 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL_INF);
 #define RX_JITTER_MAX (10 + CONFIG_BT_MESH_NETWORK_TRANSMIT_COUNT * \
 		       (CONFIG_BT_MESH_NETWORK_TRANSMIT_INTERVAL + 10))
 
-static int model1_init(struct bt_mesh_model *model);
-static int model2_init(struct bt_mesh_model *model);
-static int model3_init(struct bt_mesh_model *model);
-static int model4_init(struct bt_mesh_model *model);
-static int model5_init(struct bt_mesh_model *model);
-static int test_msg_handler(struct bt_mesh_model *model,
+static int model1_init(const struct bt_mesh_model *model);
+static int model2_init(const struct bt_mesh_model *model);
+static int model3_init(const struct bt_mesh_model *model);
+static int model4_init(const struct bt_mesh_model *model);
+static int model5_init(const struct bt_mesh_model *model);
+static int test_msg_handler(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf);
-static int test_msg_ne_handler(struct bt_mesh_model *model,
+static int test_msg_ne_handler(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf);
 
@@ -99,7 +99,7 @@ static const struct {
 static struct k_sem publish_sem;
 static bool publish_allow;
 
-static int model1_update(struct bt_mesh_model *model)
+static int model1_update(const struct bt_mesh_model *model)
 {
 	model->pub->msg->data[1]++;
 
@@ -108,7 +108,7 @@ static int model1_update(struct bt_mesh_model *model)
 	return publish_allow ? k_sem_give(&publish_sem), 0 : -1;
 }
 
-static int test_msgf_handler(struct bt_mesh_model *model,
+static int test_msgf_handler(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -204,7 +204,7 @@ static const struct bt_mesh_model_op model_ne_op5[] = {
 static struct bt_mesh_cfg_cli cfg_cli;
 
 /* do not change model sequence. it will break pointer arithmetic. */
-static struct bt_mesh_model models[] = {
+static const struct bt_mesh_model models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_CB(TEST_MODEL_ID_1, model_op1, &model_pub1, NULL, &test_model1_cb),
@@ -215,7 +215,7 @@ static struct bt_mesh_model models[] = {
 };
 
 /* do not change model sequence. it will break pointer arithmetic. */
-static struct bt_mesh_model models_ne[] = {
+static const struct bt_mesh_model models_ne[] = {
 	BT_MESH_MODEL_CB(TEST_MODEL_ID_1, model_ne_op1, NULL, NULL, &test_model1_cb),
 	BT_MESH_MODEL_CB(TEST_MODEL_ID_2, model_ne_op2, NULL, NULL, &test_model2_cb),
 	BT_MESH_MODEL_CB(TEST_MODEL_ID_3, model_ne_op3, NULL, NULL, &test_model3_cb),
@@ -223,7 +223,7 @@ static struct bt_mesh_model models_ne[] = {
 	BT_MESH_MODEL_CB(TEST_MODEL_ID_5, model_ne_op5, NULL, NULL, &test_model5_cb),
 };
 
-static struct bt_mesh_model vnd_models[] = {};
+static const struct bt_mesh_model vnd_models[] = {};
 
 static const struct bt_mesh_elem elems[] = {
 	BT_MESH_ELEM(0, models, vnd_models),
@@ -246,43 +246,43 @@ const struct bt_mesh_comp local_comp = {
  *            m4        mne4
  */
 
-static int model1_init(struct bt_mesh_model *model)
+static int model1_init(const struct bt_mesh_model *model)
 {
 	return 0;
 }
 
-static int model2_init(struct bt_mesh_model *model)
+static int model2_init(const struct bt_mesh_model *model)
 {
 	return 0;
 }
 
-static int model3_init(struct bt_mesh_model *model)
+static int model3_init(const struct bt_mesh_model *model)
 {
 	ASSERT_OK(bt_mesh_model_extend(model, model - 2));
 	ASSERT_OK(bt_mesh_model_extend(model, model - 1));
 
-	if (model->elem_idx == 0) {
+	if (model->ctx->elem_idx == 0) {
 		ASSERT_OK(bt_mesh_model_extend(&models_ne[2], model));
 	}
 
 	return 0;
 }
 
-static int model4_init(struct bt_mesh_model *model)
+static int model4_init(const struct bt_mesh_model *model)
 {
 	ASSERT_OK(bt_mesh_model_extend(model, model - 1));
 
 	return 0;
 }
 
-static int model5_init(struct bt_mesh_model *model)
+static int model5_init(const struct bt_mesh_model *model)
 {
 	ASSERT_OK(bt_mesh_model_extend(model, model - 4));
 
 	return 0;
 }
 
-static int test_msg_handler(struct bt_mesh_model *model,
+static int test_msg_handler(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
@@ -292,7 +292,7 @@ static int test_msg_handler(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int test_msg_ne_handler(struct bt_mesh_model *model,
+static int test_msg_ne_handler(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
@@ -515,7 +515,7 @@ static void pub_param_set(uint8_t period, uint8_t transmit)
 
 static void msgf_publish(void)
 {
-	struct bt_mesh_model *model = &models[2];
+	const struct bt_mesh_model *model = &models[2];
 
 	bt_mesh_model_msg_init(model->pub->msg, TEST_MESSAGE_OP_F);
 	net_buf_simple_add_u8(model->pub->msg, 1);
@@ -591,7 +591,7 @@ static void recv_jitter_check(int32_t interval, uint8_t count)
  */
 static void test_tx_period(void)
 {
-	struct bt_mesh_model *model = &models[2];
+	const struct bt_mesh_model *model = &models[2];
 
 	bt_mesh_test_cfg_set(NULL, 60);
 	bt_mesh_device_setup(&prov, &local_comp);
@@ -647,7 +647,7 @@ static void test_rx_period(void)
  */
 static void test_tx_transmit(void)
 {
-	struct bt_mesh_model *model = &models[2];
+	const struct bt_mesh_model *model = &models[2];
 	uint8_t status;
 	int err;
 
@@ -719,7 +719,7 @@ static void test_rx_transmit(void)
  */
 static void test_tx_cancel(void)
 {
-	struct bt_mesh_model *model = &models[2];
+	const struct bt_mesh_model *model = &models[2];
 	int err;
 
 	bt_mesh_test_cfg_set(NULL, 20);

--- a/tests/bsim/bluetooth/mesh/src/test_access.c
+++ b/tests/bsim/bluetooth/mesh/src/test_access.c
@@ -225,7 +225,7 @@ static struct bt_mesh_model models_ne[] = {
 
 static struct bt_mesh_model vnd_models[] = {};
 
-static struct bt_mesh_elem elems[] = {
+static const struct bt_mesh_elem elems[] = {
 	BT_MESH_ELEM(0, models, vnd_models),
 	BT_MESH_ELEM(1, models_ne, vnd_models),
 };

--- a/tests/bsim/bluetooth/mesh/src/test_blob.c
+++ b/tests/bsim/bluetooth/mesh/src/test_blob.c
@@ -270,7 +270,7 @@ static const struct bt_mesh_comp cli_comp = {
 
 static struct k_sem info_get_sem;
 
-static int mock_handle_info_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mock_handle_info_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	k_sem_give(&info_get_sem);
@@ -1319,7 +1319,7 @@ static void test_srv_fail_on_block_get(void)
 	PASS();
 }
 
-static int dummy_xfer_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int dummy_xfer_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	return 0;

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -1265,7 +1265,7 @@ static void test_cli_stop(void)
 
 static struct k_sem caps_get_sem;
 
-static int mock_handle_caps_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mock_handle_caps_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	LOG_WRN("Rejecting BLOB Information Get message");
@@ -1296,7 +1296,7 @@ static const struct bt_mesh_comp srv_caps_broken_comp = {
 	.elem_count = 1,
 };
 
-static int mock_handle_chunks(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mock_handle_chunks(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	LOG_WRN("Skipping receiving block");
@@ -1329,7 +1329,7 @@ static const struct bt_mesh_comp broken_target_comp = {
 
 static struct k_sem update_get_sem;
 
-static int mock_handle_update_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mock_handle_update_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
 	LOG_WRN("Rejecting Firmware Update Get message");
@@ -1362,7 +1362,7 @@ static const struct bt_mesh_comp srv_update_get_broken_comp = {
 
 static struct k_sem update_apply_sem;
 
-static int mock_handle_update_apply(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mock_handle_update_apply(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
 	LOG_WRN("Rejecting Firmware Update Apply message");

--- a/tests/bsim/bluetooth/mesh/src/test_lcd.c
+++ b/tests/bsim/bluetooth/mesh/src/test_lcd.c
@@ -71,7 +71,7 @@ static struct bt_mesh_cfg_cli cfg_cli;
 static struct bt_mesh_large_comp_data_cli lcd_cli;
 
 /* Creates enough composition data to send a max SDU comp status message + 1 byte */
-static struct bt_mesh_elem elements_1[] = {
+static const struct bt_mesh_elem elements_1[] = {
 	BT_MESH_ELEM(1,
 		     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 				BT_MESH_MODEL_CFG_CLI(&cfg_cli),
@@ -82,7 +82,7 @@ static struct bt_mesh_elem elements_1[] = {
 };
 
 /* Creates enough metadata to send a max SDU metadata status message + 1 byte */
-static struct bt_mesh_elem elements_2[] = {
+static const struct bt_mesh_elem elements_2[] = {
 	BT_MESH_ELEM(1,
 		     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 				BT_MESH_MODEL_CFG_CLI(&cfg_cli),

--- a/tests/bsim/bluetooth/mesh/src/test_lcd.c
+++ b/tests/bsim/bluetooth/mesh/src/test_lcd.c
@@ -41,7 +41,8 @@ LOG_MODULE_REGISTER(test_lcd, LOG_LEVEL_INF);
 	.op = _dummy_op,                            \
 	.cb = NULL,                                 \
 	.user_data = NULL,                          \
-	.metadata = _metadata,                      \
+	.metadata = _metadata,			    \
+	.ctx = &(struct bt_mesh_model_ctx){ 0 },    \
 }
 
 const struct bt_mesh_model_op dummy_op[] = {

--- a/tests/bsim/bluetooth/mesh/src/test_op_agg.c
+++ b/tests/bsim/bluetooth/mesh/src/test_op_agg.c
@@ -127,18 +127,7 @@ const struct bt_mesh_model_op _dummy_vnd_mod_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-<<<<<<< HEAD
 static struct bt_mesh_elem elements[] = {BT_MESH_ELEM(
-=======
-static const struct bt_mesh_model dummy_vnd_model = {
-	.op = _dummy_vnd_mod_op,
-	.vnd.id = TEST_VND_MOD_ID,
-	.vnd.company = TEST_VND_COMPANY_ID,
-	.ctx = &(struct bt_mesh_model_ctx){ 0 },
-};
-
-static const struct bt_mesh_elem elements[] = {BT_MESH_ELEM(
->>>>>>> Bluetooth: Mesh: Make bt_mesh_model as rodata
 	0,
 	MODEL_LIST(BT_MESH_MODEL_CFG_SRV, BT_MESH_MODEL_CFG_CLI(&cfg_cli), BT_MESH_MODEL_OP_AGG_SRV,
 		   BT_MESH_MODEL_OP_AGG_CLI),

--- a/tests/bsim/bluetooth/mesh/src/test_op_agg.c
+++ b/tests/bsim/bluetooth/mesh/src/test_op_agg.c
@@ -61,7 +61,7 @@ static struct bt_mesh_msg_ctx test_ctx = {
 static struct bt_mesh_prov prov;
 static struct bt_mesh_cfg_cli cfg_cli;
 
-static int get_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int get_handler(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	uint8_t seq = net_buf_simple_pull_u8(buf);
@@ -85,7 +85,7 @@ static int get_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return bt_mesh_model_send(model, ctx, &msg, NULL, NULL);
 }
 
-static int status_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int status_handler(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
 	uint8_t seq = net_buf_simple_pull_u8(buf);
@@ -100,7 +100,9 @@ static int status_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *c
 	return 0;
 }
 
-static int dummy_vnd_mod_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx, uint8_t seq)
+static int dummy_vnd_mod_get(const struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     uint8_t seq)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_DUMMY_VND_MOD_GET_OP,
 				 BT_MESH_DUMMY_VND_MOD_MSG_MAXLEN);
@@ -125,7 +127,18 @@ const struct bt_mesh_model_op _dummy_vnd_mod_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
+<<<<<<< HEAD
 static struct bt_mesh_elem elements[] = {BT_MESH_ELEM(
+=======
+static const struct bt_mesh_model dummy_vnd_model = {
+	.op = _dummy_vnd_mod_op,
+	.vnd.id = TEST_VND_MOD_ID,
+	.vnd.company = TEST_VND_COMPANY_ID,
+	.ctx = &(struct bt_mesh_model_ctx){ 0 },
+};
+
+static const struct bt_mesh_elem elements[] = {BT_MESH_ELEM(
+>>>>>>> Bluetooth: Mesh: Make bt_mesh_model as rodata
 	0,
 	MODEL_LIST(BT_MESH_MODEL_CFG_SRV, BT_MESH_MODEL_CFG_CLI(&cfg_cli), BT_MESH_MODEL_OP_AGG_SRV,
 		   BT_MESH_MODEL_OP_AGG_CLI),
@@ -170,7 +183,7 @@ static void op_agg_test_prov_and_conf(uint16_t addr)
 
 static void test_cli_max_len_sequence_msg_send(void)
 {
-	struct bt_mesh_model *dummy_vnd_model = &elements[0].vnd_models[0];
+	const struct bt_mesh_model *dummy_vnd_model = &elements[0].vnd_models[0];
 	uint8_t seq;
 
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);

--- a/tests/bsim/bluetooth/mesh/src/test_persistence.c
+++ b/tests/bsim/bluetooth/mesh/src/test_persistence.c
@@ -299,7 +299,7 @@ static void check_mod_pub_params(const struct bt_mesh_cfg_cli_mod_pub *expected,
 	ASSERT_EQUAL(expected->transmit, got->transmit);
 }
 
-int test_model_settings_set(struct bt_mesh_model *model,
+int test_model_settings_set(const struct bt_mesh_model *model,
 			    const char *name, size_t len_rd,
 			    settings_read_cb read_cb, void *cb_arg)
 {
@@ -325,12 +325,12 @@ int test_model_settings_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-void test_model_reset(struct bt_mesh_model *model)
+void test_model_reset(const struct bt_mesh_model *model)
 {
 	ASSERT_OK(bt_mesh_model_data_store(test_model, false, TEST_MOD_DATA_NAME, NULL, 0));
 }
 
-int test_vnd_model_settings_set(struct bt_mesh_model *model,
+int test_vnd_model_settings_set(const struct bt_mesh_model *model,
 				const char *name, size_t len_rd,
 				settings_read_cb read_cb, void *cb_arg)
 {
@@ -356,7 +356,7 @@ int test_vnd_model_settings_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-void test_vnd_model_reset(struct bt_mesh_model *model)
+void test_vnd_model_reset(const struct bt_mesh_model *model)
 {
 	ASSERT_OK(bt_mesh_model_data_store(test_vnd_model, true, TEST_VND_MOD_DATA_NAME, NULL, 0));
 }

--- a/tests/bsim/bluetooth/mesh/src/test_sar.c
+++ b/tests/bsim/bluetooth/mesh/src/test_sar.c
@@ -136,31 +136,14 @@ static const struct bt_mesh_model_op _dummy_vnd_mod_op[] = {
 
 uint16_t dummy_keys[CONFIG_BT_MESH_MODEL_KEY_COUNT] = { 0 };
 
-<<<<<<< HEAD
 static struct bt_mesh_elem elements[] = {BT_MESH_ELEM(
-=======
-static const struct bt_mesh_model dummy_vnd_mod = {
-	.op = _dummy_vnd_mod_op,
-	.keys = dummy_keys,
-	.keys_cnt = CONFIG_BT_MESH_MODEL_KEY_COUNT,
-	.vnd.id = TEST_VND_MOD_ID,
-	.vnd.company = TEST_VND_COMPANY_ID,
-	.ctx = &(struct bt_mesh_model_ctx){ 0 },
-};
-
-static const struct bt_mesh_elem elements[] = {BT_MESH_ELEM(
->>>>>>> Bluetooth: Mesh: Make bt_mesh_model as rodata
 	0,
 	MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 		   BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 		   BT_MESH_MODEL_SAR_CFG_CLI(&sar_cli),
 		   BT_MESH_MODEL_SAR_CFG_SRV),
 	MODEL_LIST(BT_MESH_MODEL_VND_CB(TEST_VND_COMPANY_ID, TEST_VND_MOD_ID, _dummy_vnd_mod_op,
-<<<<<<< HEAD
 					NULL, NULL, NULL)))};
-=======
-					NULL, (void *)&dummy_vnd_mod, NULL)))};
->>>>>>> Bluetooth: Mesh: Make bt_mesh_model as rodata
 
 static const struct bt_mesh_comp comp = {
 	.cid = TEST_VND_COMPANY_ID,

--- a/tests/bsim/bluetooth/mesh/src/test_sar.c
+++ b/tests/bsim/bluetooth/mesh/src/test_sar.c
@@ -96,7 +96,7 @@ static void data_integrity_check(struct net_buf_simple *buf)
 	net_buf_simple_restore(buf, &state);
 }
 
-static int get_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int get_handler(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	data_integrity_check(buf);
@@ -109,7 +109,7 @@ static int get_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return bt_mesh_model_send(model, ctx, &msg, NULL, NULL);
 }
 
-static int status_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int status_handler(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
 	data_integrity_check(buf);
@@ -117,7 +117,7 @@ static int status_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *c
 	return 0;
 }
 
-static int dummy_vnd_mod_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int dummy_vnd_mod_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			     uint8_t msg[])
 {
 	BT_MESH_MODEL_BUF_DEFINE(buf, DUMMY_VND_MOD_GET_OP, MAX_SDU_MSG_LEN);
@@ -136,14 +136,31 @@ static const struct bt_mesh_model_op _dummy_vnd_mod_op[] = {
 
 uint16_t dummy_keys[CONFIG_BT_MESH_MODEL_KEY_COUNT] = { 0 };
 
+<<<<<<< HEAD
 static struct bt_mesh_elem elements[] = {BT_MESH_ELEM(
+=======
+static const struct bt_mesh_model dummy_vnd_mod = {
+	.op = _dummy_vnd_mod_op,
+	.keys = dummy_keys,
+	.keys_cnt = CONFIG_BT_MESH_MODEL_KEY_COUNT,
+	.vnd.id = TEST_VND_MOD_ID,
+	.vnd.company = TEST_VND_COMPANY_ID,
+	.ctx = &(struct bt_mesh_model_ctx){ 0 },
+};
+
+static const struct bt_mesh_elem elements[] = {BT_MESH_ELEM(
+>>>>>>> Bluetooth: Mesh: Make bt_mesh_model as rodata
 	0,
 	MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 		   BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 		   BT_MESH_MODEL_SAR_CFG_CLI(&sar_cli),
 		   BT_MESH_MODEL_SAR_CFG_SRV),
 	MODEL_LIST(BT_MESH_MODEL_VND_CB(TEST_VND_COMPANY_ID, TEST_VND_MOD_ID, _dummy_vnd_mod_op,
+<<<<<<< HEAD
 					NULL, NULL, NULL)))};
+=======
+					NULL, (void *)&dummy_vnd_mod, NULL)))};
+>>>>>>> Bluetooth: Mesh: Make bt_mesh_model as rodata
 
 static const struct bt_mesh_comp comp = {
 	.cid = TEST_VND_COMPANY_ID,
@@ -190,7 +207,7 @@ static void array_random_fill(uint8_t array[], uint16_t len, int seed)
 static void cli_max_len_sdu_send(struct bt_mesh_sar_rx *sar_rx_config,
 				 struct bt_mesh_sar_tx *sar_tx_config)
 {
-	struct bt_mesh_model *dummy_vnd_mod = &elements[0].vnd_models[0];
+	const struct bt_mesh_model *dummy_vnd_mod = &elements[0].vnd_models[0];
 
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
 	bt_mesh_device_setup(&prov, &comp);


### PR DESCRIPTION
Since, elements and models define do not change in whole mesh network, so prefix `const` may more suitable.

Also, elem->addr will replace with funtion `bt_mesh_elem_addr_get`.