### PR TITLE
kernel: event modification functions return previous value

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2257,6 +2257,19 @@ __syscall uint32_t k_event_wait_all(struct k_event *event, uint32_t events,
 				    bool reset, k_timeout_t timeout);
 
 /**
+ * @brief Test the events currently tracked in the event object
+ *
+ * @param event Address of the event object
+ * @param events_mask Set of desired events to test
+ *
+ * @retval Current value of events in @a events_mask
+ */
+static inline uint32_t k_event_test(struct k_event *event, uint32_t events_mask)
+{
+	return k_event_wait(event, events_mask, false, K_NO_WAIT);
+}
+
+/**
  * @brief Statically define and initialize an event object
  *
  * The event can be accessed outside the module where it is defined using:

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2157,8 +2157,10 @@ __syscall void k_event_init(struct k_event *event);
  *
  * @param event Address of the event object
  * @param events Set of events to post to @a event
+ *
+ * @retval Previous value of the events in @a event
  */
-__syscall void k_event_post(struct k_event *event, uint32_t events);
+__syscall uint32_t k_event_post(struct k_event *event, uint32_t events);
 
 /**
  * @brief Set the events in an event object
@@ -2172,8 +2174,10 @@ __syscall void k_event_post(struct k_event *event, uint32_t events);
  *
  * @param event Address of the event object
  * @param events Set of events to set in @a event
+ *
+ * @retval Previous value of the events in @a event
  */
-__syscall void k_event_set(struct k_event *event, uint32_t events);
+__syscall uint32_t k_event_set(struct k_event *event, uint32_t events);
 
 /**
  * @brief Set or clear the events in an event object
@@ -2186,8 +2190,10 @@ __syscall void k_event_set(struct k_event *event, uint32_t events);
  * @param event Address of the event object
  * @param events Set of events to set/clear in @a event
  * @param events_mask Mask to be applied to @a events
+ *
+ * @retval Previous value of the events in @a events_mask
  */
-__syscall void k_event_set_masked(struct k_event *event, uint32_t events,
+__syscall uint32_t k_event_set_masked(struct k_event *event, uint32_t events,
 				  uint32_t events_mask);
 
 /**
@@ -2197,8 +2203,10 @@ __syscall void k_event_set_masked(struct k_event *event, uint32_t events,
  *
  * @param event Address of the event object
  * @param events Set of events to clear in @a event
+ *
+ * @retval Previous value of the events in @a event
  */
-__syscall void k_event_clear(struct k_event *event, uint32_t events);
+__syscall uint32_t k_event_clear(struct k_event *event, uint32_t events);
 
 /**
  * @brief Wait for any of the specified events

--- a/tests/kernel/events/event_api/src/main.c
+++ b/tests/kernel/events/event_api/src/main.c
@@ -15,6 +15,7 @@
  *   -# k_event_set
  *   -# k_event_wait
  *   -# k_event_wait_all
+ *   -# k_event_test
  *
  * @defgroup kernel_event_tests events
  * @ingroup all_tests

--- a/tests/kernel/events/event_api/src/test_event_apis.c
+++ b/tests/kernel/events/event_api/src/test_event_apis.c
@@ -341,10 +341,11 @@ ZTEST(events_api, test_event_deliver)
 	static struct k_event  event;
 	uint32_t  events;
 	uint32_t  events_mask;
+	uint32_t  previous;
 
 	k_event_init(&event);
 
-	zassert_true(event.events == 0);
+	zassert_equal(k_event_test(&event, ~0), 0);
 
 	/*
 	 * Verify k_event_post()  and k_event_set() update the
@@ -352,43 +353,49 @@ ZTEST(events_api, test_event_deliver)
 	 */
 
 	events = 0xAAAA;
-	k_event_post(&event, events);
-	zassert_true(event.events == events);
+	previous = k_event_post(&event, events);
+	zassert_equal(previous, 0x0000);
+	zassert_equal(k_event_test(&event, ~0), events);
 
 	events |= 0x55555ABC;
-	k_event_post(&event, events);
-	zassert_true(event.events == events);
+	previous = k_event_post(&event, events);
+	zassert_equal(previous, events & 0xAAAA);
+	zassert_equal(k_event_test(&event, ~0), events);
 
 	events = 0xAAAA0000;
-	k_event_set(&event, events);
-	zassert_true(event.events == events);
+	previous = k_event_set(&event, events);
+	zassert_equal(previous, 0xAAAA | 0x55555ABC);
+	zassert_equal(k_event_test(&event, ~0), events);
 
 	/*
 	 * Verify k_event_set_masked() update the events
 	 * stored in the event object as expected
 	 */
 	events = 0x33333333;
-	k_event_set(&event, events);
-	zassert_true(event.events == events);
+	(void)k_event_set(&event, events);
+	zassert_equal(k_event_test(&event, ~0), events);
 
 	events_mask = 0x11111111;
-	k_event_set_masked(&event, 0, events_mask);
-	zassert_true(event.events == 0x22222222);
+	previous = k_event_set_masked(&event, 0, events_mask);
+	zassert_equal(previous, 0x11111111);
+	zassert_equal(k_event_test(&event, ~0), 0x22222222);
 
 	events_mask = 0x22222222;
-	k_event_set_masked(&event, 0, events_mask);
-	zassert_true(event.events == 0);
+	previous = k_event_set_masked(&event, 0, events_mask);
+	zassert_equal(previous, 0x22222222);
+	zassert_equal(k_event_test(&event, ~0), 0);
 
 	events = 0x22222222;
 	events_mask = 0x22222222;
-	k_event_set_masked(&event, events, events_mask);
-	zassert_true(event.events == events);
+	previous = k_event_set_masked(&event, events, events_mask);
+	zassert_equal(previous, 0x00000000);
+	zassert_equal(k_event_test(&event, ~0), events);
 
 	events = 0x11111111;
 	events_mask = 0x33333333;
-	k_event_set_masked(&event, events, events_mask);
-	zassert_true(event.events == events);
-
+	previous = k_event_set_masked(&event, events, events_mask);
+	zassert_equal(previous, 0x22222222);
+	zassert_equal(k_event_test(&event, ~0), events);
 }
 
 /**


### PR DESCRIPTION
Update the return value of functions that modify the internal event
state from `void` to `uint32_t`, so that calling code can determine
whether the event was already in a given state, or if the call modified
it.

This simplifies the usage of `struct k_event` as an alternative to
`atomic_t` that users can block on.

Implements https://github.com/zephyrproject-rtos/zephyr/issues/57216

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>