### PR TITLE
net: lwm2m: use path as block context retrieval

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -436,12 +436,8 @@ struct lwm2m_block_context {
 	struct lwm2m_opaque_context opaque;
 	int64_t timestamp;
 	uint32_t expected;
-	uint8_t token[8];
-	uint8_t tkl;
 	bool last_block : 1;
-	uint8_t  level;  /* 3/4 (4 = resource instance) */
-	uint16_t res_id;
-	uint16_t res_inst_id;
+	struct lwm2m_obj_path path;
 };
 
 struct lwm2m_output_context {

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
@@ -952,11 +952,11 @@ int do_write_op_senml_cbor(struct lwm2m_message *msg)
 	 * go directly to the message processing
 	 */
 	if (msg->in.block_ctx != NULL && msg->in.block_ctx->ctx.current > 0) {
-		msg->path.res_id = msg->in.block_ctx->res_id;
-		msg->path.level = msg->in.block_ctx->level;
+		msg->path.res_id = msg->in.block_ctx->path.res_id;
+		msg->path.level = msg->in.block_ctx->path.level;
 
 		if (msg->path.level == LWM2M_PATH_LEVEL_RESOURCE_INST) {
-			msg->path.res_inst_id = msg->in.block_ctx->res_inst_id;
+			msg->path.res_inst_id = msg->in.block_ctx->path.res_inst_id;
 		}
 
 		return do_write_op_item(msg, NULL);


### PR DESCRIPTION
Block-wise context retrieval based on lwm2m path instead of token
Fix issue #57165