### PR TITLE
net: lwm2m: use path as block context retrieval

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -106,15 +106,20 @@ void lwm2m_clear_block_contexts(void)
 	(void)memset(block1_contexts, 0, sizeof(block1_contexts));
 }
 
-static int init_block_ctx(const uint8_t *token, uint8_t tkl, struct lwm2m_block_context **ctx)
+static int init_block_ctx(const struct lwm2m_obj_path *path, struct lwm2m_block_context **ctx)
 {
 	int i;
 	int64_t timestamp;
 
+	if (!path) {
+		LOG_ERR("Null block ctx path");
+		return -EFAULT;
+	}
+
 	*ctx = NULL;
 	timestamp = k_uptime_get();
 	for (i = 0; i < NUM_BLOCK1_CONTEXT; i++) {
-		if (block1_contexts[i].tkl == 0U) {
+		if (block1_contexts[i].path.level == 0U) {
 			*ctx = &block1_contexts[i];
 			break;
 		}
@@ -134,8 +139,7 @@ static int init_block_ctx(const uint8_t *token, uint8_t tkl, struct lwm2m_block_
 		return -ENOMEM;
 	}
 
-	(*ctx)->tkl = tkl;
-	memcpy((*ctx)->token, token, tkl);
+	memcpy(&(*ctx)->path, path, sizeof(struct lwm2m_obj_path));
 	coap_block_transfer_init(&(*ctx)->ctx, lwm2m_default_block_size(), 0);
 	(*ctx)->timestamp = timestamp;
 	(*ctx)->expected = 0;
@@ -145,15 +149,20 @@ static int init_block_ctx(const uint8_t *token, uint8_t tkl, struct lwm2m_block_
 	return 0;
 }
 
-static int get_block_ctx(const uint8_t *token, uint8_t tkl, struct lwm2m_block_context **ctx)
+static int get_block_ctx(const struct lwm2m_obj_path *path, struct lwm2m_block_context **ctx)
 {
 	int i;
+
+	if (!path) {
+		LOG_ERR("Null block ctx path");
+		return -EFAULT;
+	}
 
 	*ctx = NULL;
 
 	for (i = 0; i < NUM_BLOCK1_CONTEXT; i++) {
-		if (block1_contexts[i].tkl == tkl &&
-		    memcmp(token, block1_contexts[i].token, tkl) == 0) {
+		if (memcmp(path, &block1_contexts[i].path,
+			  sizeof(struct lwm2m_obj_path)) == 0) {
 			*ctx = &block1_contexts[i];
 			/* refresh timestamp */
 			(*ctx)->timestamp = k_uptime_get();
@@ -174,7 +183,7 @@ static void free_block_ctx(struct lwm2m_block_context *ctx)
 		return;
 	}
 
-	ctx->tkl = 0U;
+	memset(&ctx->path, 0, sizeof(struct lwm2m_obj_path));
 }
 
 void lwm2m_engine_context_close(struct lwm2m_ctx *client_ctx)
@@ -2008,9 +2017,9 @@ int handle_request(struct coap_packet *request, struct lwm2m_message *msg)
 		/* Try to retrieve existing block context. If one not exists,
 		 * and we've received first block, allocate new context.
 		 */
-		r = get_block_ctx(token, tkl, &block_ctx);
+		r = get_block_ctx(&msg->path, &block_ctx);
 		if (r < 0 && block_num == 0) {
-			r = init_block_ctx(token, tkl, &block_ctx);
+			r = init_block_ctx(&msg->path, &block_ctx);
 		}
 
 		if (r < 0) {

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -436,12 +436,8 @@ struct lwm2m_block_context {
 	struct lwm2m_opaque_context opaque;
 	int64_t timestamp;
 	uint32_t expected;
-	uint8_t token[8];
-	uint8_t tkl;
 	bool last_block : 1;
-	uint8_t  level;  /* 3/4 (4 = resource instance) */
-	uint16_t res_id;
-	uint16_t res_inst_id;
+	struct lwm2m_obj_path path;
 };
 
 struct lwm2m_output_context {

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -885,7 +885,7 @@ static int write_tlv_resource(struct lwm2m_message *msg, struct oma_tlv *tlv)
 	int ret;
 
 	if (msg->in.block_ctx) {
-		msg->in.block_ctx->res_id = tlv->id;
+		msg->in.block_ctx->path.res_id = tlv->id;
 	}
 
 	msg->path.res_id = tlv->id;
@@ -916,7 +916,7 @@ static int lwm2m_multi_resource_tlv_parse(struct lwm2m_message *msg,
 	int ret;
 
 	if (msg->in.block_ctx) {
-		msg->in.block_ctx->res_id = multi_resource_tlv->id;
+		msg->in.block_ctx->path.res_id = multi_resource_tlv->id;
 	}
 
 	if (multi_resource_tlv->length == 0U) {
@@ -964,7 +964,7 @@ int do_write_op_tlv(struct lwm2m_message *msg)
 	 * header.
 	 */
 	if (msg->in.block_ctx != NULL && msg->in.block_ctx->ctx.current > 0) {
-		msg->path.res_id = msg->in.block_ctx->res_id;
+		msg->path.res_id = msg->in.block_ctx->path.res_id;
 		msg->path.level = 3U;
 		ret = do_write_op_tlv_item(msg);
 		if (ret < 0) {

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
@@ -952,11 +952,11 @@ int do_write_op_senml_cbor(struct lwm2m_message *msg)
 	 * go directly to the message processing
 	 */
 	if (msg->in.block_ctx != NULL && msg->in.block_ctx->ctx.current > 0) {
-		msg->path.res_id = msg->in.block_ctx->res_id;
-		msg->path.level = msg->in.block_ctx->level;
+		msg->path.res_id = msg->in.block_ctx->path.res_id;
+		msg->path.level = msg->in.block_ctx->path.level;
 
 		if (msg->path.level == LWM2M_PATH_LEVEL_RESOURCE_INST) {
-			msg->path.res_inst_id = msg->in.block_ctx->res_inst_id;
+			msg->path.res_inst_id = msg->in.block_ctx->path.res_inst_id;
 		}
 
 		return do_write_op_item(msg, NULL);


### PR DESCRIPTION
Replace block context retrieval using object path instead of token. Changing token between each block is a correct behavior and restore a functional link with Leshan/Californium

Fix issue #57165