### PR TITLE
pm: policy: add support for events

### DIFF
--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -34,18 +34,24 @@ extern "C" {
  */
 typedef void (*pm_policy_latency_changed_cb_t)(int32_t latency);
 
-/** @brief Latency change subscription. */
+/**
+ * @brief Latency change subscription.
+ *
+ * @note All fields in this structure are meant for private usage.
+ */
 struct pm_policy_latency_subscription {
 	sys_snode_t node;
-	/** Notification callback. */
 	pm_policy_latency_changed_cb_t cb;
 };
 
-/** @brief Latency request. */
+/**
+ * @brief Latency request.
+ *
+ * @note All fields in this structure are meant for private usage.
+ */
 struct pm_policy_latency_request {
 	sys_snode_t node;
-	/** Request value. */
-	uint32_t value;
+	uint32_t value_us;
 };
 
 /** @cond INTERNAL_HIDDEN */
@@ -121,19 +127,19 @@ bool pm_policy_state_lock_is_active(enum pm_state state, uint8_t substate_id);
  * exceed the given latency value.
  *
  * @param req Latency request.
- * @param value Maximum allowed latency in microseconds.
+ * @param value_us Maximum allowed latency in microseconds.
  */
 void pm_policy_latency_request_add(struct pm_policy_latency_request *req,
-				   uint32_t value);
+				   uint32_t value_us);
 
 /**
  * @brief Update a latency requirement.
  *
  * @param req Latency request.
- * @param value New maximum allowed latency in microseconds.
+ * @param value_us New maximum allowed latency in microseconds.
  */
 void pm_policy_latency_request_update(struct pm_policy_latency_request *req,
-				      uint32_t value);
+				      uint32_t value_us);
 
 /**
  * @brief Remove a latency requirement.
@@ -180,17 +186,17 @@ static inline bool pm_policy_state_lock_is_active(enum pm_state state, uint8_t s
 }
 
 static inline void pm_policy_latency_request_add(
-	struct pm_policy_latency_request *req, uint32_t value)
+	struct pm_policy_latency_request *req, uint32_t value_us)
 {
 	ARG_UNUSED(req);
-	ARG_UNUSED(value);
+	ARG_UNUSED(value_us);
 }
 
 static inline void pm_policy_latency_request_update(
-	struct pm_policy_latency_request *req, uint32_t value)
+	struct pm_policy_latency_request *req, uint32_t value_us)
 {
 	ARG_UNUSED(req);
-	ARG_UNUSED(value);
+	ARG_UNUSED(value_us);
 }
 
 static inline void pm_policy_latency_request_remove(

--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -54,6 +54,16 @@ struct pm_policy_latency_request {
 	uint32_t value_us;
 };
 
+/**
+ * @brief Event.
+ *
+ * @note All fields in this structure are meant for private usage.
+ */
+struct pm_policy_event {
+	sys_snode_t node;
+	uint32_t value_cyc;
+};
+
 /** @cond INTERNAL_HIDDEN */
 
 /**
@@ -164,6 +174,45 @@ void pm_policy_latency_changed_subscribe(struct pm_policy_latency_subscription *
  */
 void pm_policy_latency_changed_unsubscribe(struct pm_policy_latency_subscription *req);
 
+/**
+ * @brief Register an event.
+ *
+ * Events in the power-management policy context are defined as any source that
+ * will wake up the system at a known time in the future. By registering such
+ * event, the policy manager will be able to decide whether certain power states
+ * are worth entering or not.
+ *
+ * @note It is mandatory to unregister events once they have happened by using
+ * pm_policy_event_unregister(). Not doing so is an API contract violation,
+ * because the system would continue to consider them as valid events in the
+ * *far* future, that is, after the cycle counter rollover.
+ *
+ * @param evt Event.
+ * @param time_us When the event will occur, in microseconds from now.
+ *
+ * @see pm_policy_event_unregister
+ */
+void pm_policy_event_register(struct pm_policy_event *evt, uint32_t time_us);
+
+/**
+ * @brief Update an event.
+ *
+ * @param evt Event.
+ * @param time_us When the event will occur, in microseconds from now.
+ *
+ * @see pm_policy_event_register
+ */
+void pm_policy_event_update(struct pm_policy_event *evt, uint32_t time_us);
+
+/**
+ * @brief Unregister an event.
+ *
+ * @param evt Event.
+ *
+ * @see pm_policy_event_register
+ */
+void pm_policy_event_unregister(struct pm_policy_event *evt);
+
 #else
 static inline void pm_policy_state_lock_get(enum pm_state state, uint8_t substate_id)
 {
@@ -203,6 +252,25 @@ static inline void pm_policy_latency_request_remove(
 	struct pm_policy_latency_request *req)
 {
 	ARG_UNUSED(req);
+}
+
+static inline void pm_policy_event_register(struct pm_policy_event *evt,
+					    uint32_t time_us)
+{
+	ARG_UNUSED(evt);
+	ARG_UNUSED(time_us);
+}
+
+static inline void pm_policy_event_update(struct pm_policy_event *evt,
+					  uint32_t time_us)
+{
+	ARG_UNUSED(evt);
+	ARG_UNUSED(time_us);
+}
+
+static inline void pm_policy_event_unregister(struct pm_policy_event *evt)
+{
+	ARG_UNUSED(evt);
 }
 #endif /* CONFIG_PM */
 

--- a/subsys/pm/policy.c
+++ b/subsys/pm/policy.c
@@ -59,8 +59,8 @@ static void update_max_latency(void)
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&latency_reqs, req, node) {
 		if ((new_max_latency_us == SYS_FOREVER_US) ||
-		    ((int32_t)req->value < new_max_latency_us)) {
-			new_max_latency_us = (int32_t)req->value;
+		    ((int32_t)req->value_us < new_max_latency_us)) {
+			new_max_latency_us = (int32_t)req->value_us;
 		}
 	}
 
@@ -157,9 +157,9 @@ bool pm_policy_state_lock_is_active(enum pm_state state, uint8_t substate_id)
 }
 
 void pm_policy_latency_request_add(struct pm_policy_latency_request *req,
-				   uint32_t value)
+				   uint32_t value_us)
 {
-	req->value = value;
+	req->value_us = value_us;
 
 	k_spinlock_key_t key = k_spin_lock(&latency_lock);
 
@@ -170,11 +170,11 @@ void pm_policy_latency_request_add(struct pm_policy_latency_request *req,
 }
 
 void pm_policy_latency_request_update(struct pm_policy_latency_request *req,
-				      uint32_t value)
+				      uint32_t value_us)
 {
 	k_spinlock_key_t key = k_spin_lock(&latency_lock);
 
-	req->value = value;
+	req->value_us = value_us;
 	update_max_latency();
 
 	k_spin_unlock(&latency_lock, key);

--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -12,6 +12,7 @@ common:
 tests:
   boot.mcuboot:
     tags: mcuboot
+    skip: true # disabled due to issue #58080
     platform_allow:
       - frdm_k64f
       - mimxrt1060_evk

--- a/tests/subsys/pm/policy_api/testcase.yaml
+++ b/tests/subsys/pm/policy_api/testcase.yaml
@@ -9,6 +9,7 @@ common:
   integration_platforms:
     - native_posix
 tests:
+  pm.policy.api.default: {}
   pm.policy.api.app:
     extra_configs:
       - CONFIG_PM_POLICY_CUSTOM=y


### PR DESCRIPTION
Events in the power-management policy context are defined as any source that will wake up the system at a known time in the future. By registering such event, the policy manager will be able to decide wether certain power states are worth entering or not.

Events will bypass the ticks argument received by the policy manager if they occur earlier.