### PR TITLE
scripts: utils: migrate_sys_init: handle empty line after ARG_UNUSED

### DIFF
--- a/scripts/utils/migrate_sys_init.py
+++ b/scripts/utils/migrate_sys_init.py
@@ -45,6 +45,7 @@ def update_sys_init(project, dry_run):
         arg = None
         content = ""
         update = False
+        unused = False
         for line in lines:
             m = re.match(
                 r"(.*)int ("
@@ -60,8 +61,14 @@ def update_sys_init(project, dry_run):
                 m = re.match(r"^\s?ARG_UNUSED\(" + arg + r"\);.*$", line)
                 if m:
                     arg = None
+                    unused = True
                 else:
                     content += line
+            elif unused:
+                m = re.match(r"^\s?\n$", line)
+                if not m:
+                    content += line
+                unused = False
             else:
                 content += line
 

--- a/scripts/utils/migrate_sys_init.py
+++ b/scripts/utils/migrate_sys_init.py
@@ -19,9 +19,6 @@ from pathlib import Path
 import re
 
 
-ZEPHYR_BASE = Path(__file__).parents[2]
-
-
 def update_sys_init(project, dry_run):
     for p in project.glob("**/*"):
         if not p.is_file() or not p.suffix or p.suffix[1:] not in ("c", "cpp"):


### PR DESCRIPTION
The script left empty lines below ARG_UNUSED. After this patch,

```c
static int f(const struct device *dev)
{
	ARG_UNUSED(dev);

	/* code */
	...
}
```

will become:

```c
static int f(void)
{
	/* code */
	...
}
```

instead of:

```c
static int f(void)
{

	/* code */
	...
}
```

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/56954