### PR TITLE
scripts: Fixes set_assignees.py by adding /

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2140,7 +2140,7 @@ Raspberry Pi Pico Platforms:
     - boards/arm/sparkfun_pro_micro_rp2040/
     - dts/arm/rpi_pico/
     - dts/bindings/*/raspberrypi,pico*
-    - drivers/*/*rpi_pico
+    - drivers/*/*rpi_pico/
     - drivers/*/*rpi_pico*/
     - drivers/*/*rpi_pico*.c
     - soc/arm/rpi_pico/


### PR DESCRIPTION
It looks like there is a missing / in the MAINTAINERS.yml file causing set_assignees.py to fail