### PR TITLE
MAINTAINERS: Fix file path rule in Raspberry Pi

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2140,7 +2140,7 @@ Raspberry Pi Pico Platforms:
     - boards/arm/sparkfun_pro_micro_rp2040/
     - dts/arm/rpi_pico/
     - dts/bindings/*/raspberrypi,pico*
-    - drivers/*/*rpi_pico
+    - drivers/*/Kconfig.rpi_pico
     - drivers/*/*rpi_pico*/
     - drivers/*/*rpi_pico*.c
     - soc/arm/rpi_pico/


### PR DESCRIPTION
It looks like the only match for this will be the Kconfigs inside of the various directories ending in rpi_pico and that this shouldn't pick up entire directories since that would be redundant of the rule following the rule that is breaking. Hopefully someone can double check me to ensure that is in fact the case. Essentially, what this does is explicitly name the Kconfigs instead of allowing wild card syntax match on anything including directories, which is an error since the rule doesn't include /. Furthermore, note that simply adding / to the failing rule or adding ** to the center part of the rule does also not seem to fix the issue. 