### PR TITLE
tests: cpp: libcxx: Add host standard C++ library testcase

### DIFF
--- a/tests/lib/cpp/libcxx/testcase.yaml
+++ b/tests/lib/cpp/libcxx/testcase.yaml
@@ -41,3 +41,12 @@ tests:
     extra_configs:
       - CONFIG_ARCMWDT_LIBC=y
       - CONFIG_ARCMWDT_LIBCPP=y
+  cpp.libcxx.host:
+    arch_allow: posix
+    tags: cpp
+    extra_configs:
+      - CONFIG_EXTERNAL_LIBCPP=y
+      - CONFIG_CPP_EXCEPTIONS=y
+    integration_platforms:
+      - native_posix
+      - native_posix_64


### PR DESCRIPTION
This commit adds a new libcxx testcase that tests the host standard C++ library.