### PR TITLE
drivers: stm32: SPI: cannot send several buffers if frame size=16bits

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -270,12 +270,13 @@ static inline void spi_context_unlock_unconditionally(struct spi_context *ctx)
 
 static inline void *spi_context_get_next_buf(const struct spi_buf **current,
 					     size_t *count,
-					     size_t *buf_len)
+					     size_t *buf_len,
+					     uint8_t dfs)
 {
 	/* This loop skips zero-length buffers in the set, if any. */
 	while (*count) {
-		if (((*current)->len) != 0) {
-			*buf_len = (*current)->len;
+		if (((*current)->len / dfs) != 0) {
+			*buf_len = (*current)->len / dfs;
 			return (*current)->buf;
 		}
 		++(*current);
@@ -298,13 +299,13 @@ void spi_context_buffers_setup(struct spi_context *ctx,
 	ctx->tx_count = ctx->current_tx ? tx_bufs->count : 0;
 	ctx->tx_buf = (const uint8_t *)
 		spi_context_get_next_buf(&ctx->current_tx, &ctx->tx_count,
-					 &ctx->tx_len);
+					 &ctx->tx_len, dfs);
 
 	ctx->current_rx = rx_bufs ? rx_bufs->buffers : NULL;
 	ctx->rx_count = ctx->current_rx ? rx_bufs->count : 0;
 	ctx->rx_buf = (uint8_t *)
 		spi_context_get_next_buf(&ctx->current_rx, &ctx->rx_count,
-					 &ctx->rx_len);
+					 &ctx->rx_len, dfs);
 
 	ctx->sync_status = 0;
 
@@ -340,7 +341,7 @@ void spi_context_update_tx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 		ctx->tx_buf = (const uint8_t *)
 			spi_context_get_next_buf(&ctx->current_tx,
 						 &ctx->tx_count,
-						 &ctx->tx_len);
+						 &ctx->tx_len, dfs);
 	} else if (ctx->tx_buf) {
 		ctx->tx_buf += dfs * len;
 	}
@@ -387,7 +388,7 @@ void spi_context_update_rx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 		ctx->rx_buf = (uint8_t *)
 			spi_context_get_next_buf(&ctx->current_rx,
 						 &ctx->rx_count,
-						 &ctx->rx_len);
+						 &ctx->rx_len, dfs);
 	} else if (ctx->rx_buf) {
 		ctx->rx_buf += dfs * len;
 	}

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -270,13 +270,12 @@ static inline void spi_context_unlock_unconditionally(struct spi_context *ctx)
 
 static inline void *spi_context_get_next_buf(const struct spi_buf **current,
 					     size_t *count,
-					     size_t *buf_len,
-					     uint8_t dfs)
+					     size_t *buf_len)
 {
 	/* This loop skips zero-length buffers in the set, if any. */
 	while (*count) {
-		if (((*current)->len / dfs) != 0) {
-			*buf_len = (*current)->len / dfs;
+		if (((*current)->len) != 0) {
+			*buf_len = (*current)->len;
 			return (*current)->buf;
 		}
 		++(*current);
@@ -299,13 +298,13 @@ void spi_context_buffers_setup(struct spi_context *ctx,
 	ctx->tx_count = ctx->current_tx ? tx_bufs->count : 0;
 	ctx->tx_buf = (const uint8_t *)
 		spi_context_get_next_buf(&ctx->current_tx, &ctx->tx_count,
-					 &ctx->tx_len, dfs);
+					 &ctx->tx_len);
 
 	ctx->current_rx = rx_bufs ? rx_bufs->buffers : NULL;
 	ctx->rx_count = ctx->current_rx ? rx_bufs->count : 0;
 	ctx->rx_buf = (uint8_t *)
 		spi_context_get_next_buf(&ctx->current_rx, &ctx->rx_count,
-					 &ctx->rx_len, dfs);
+					 &ctx->rx_len);
 
 	ctx->sync_status = 0;
 
@@ -341,7 +340,7 @@ void spi_context_update_tx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 		ctx->tx_buf = (const uint8_t *)
 			spi_context_get_next_buf(&ctx->current_tx,
 						 &ctx->tx_count,
-						 &ctx->tx_len, dfs);
+						 &ctx->tx_len);
 	} else if (ctx->tx_buf) {
 		ctx->tx_buf += dfs * len;
 	}
@@ -388,7 +387,7 @@ void spi_context_update_rx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 		ctx->rx_buf = (uint8_t *)
 			spi_context_get_next_buf(&ctx->current_rx,
 						 &ctx->rx_count,
-						 &ctx->rx_len, dfs);
+						 &ctx->rx_len);
 	} else if (ctx->rx_buf) {
 		ctx->rx_buf += dfs * len;
 	}

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -628,7 +628,11 @@ static int transceive(const struct device *dev,
 	}
 
 	/* Set buffers info */
-	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
+	if (SPI_WORD_SIZE_GET(config->operation) == 8) {
+		spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
+	} else {
+		spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 2);
+	}
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo)
 	/* Flush RX buffer */
@@ -729,7 +733,11 @@ static int transceive_dma(const struct device *dev,
 	}
 
 	/* Set buffers info */
-	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
+	if (SPI_WORD_SIZE_GET(config->operation) == 8) {
+		spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
+	} else {
+		spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 2);
+	}
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	/* set request before enabling (else SPI CFG1 reg is write protected) */


### PR DESCRIPTION
The stm32 SPI driver does not work if one tries to send several buffers with a frame size of 16 bits.

If the SPI's transaction's frame size is set to 16 bits and more than one buffer wants to be sent, the data sent is wrong. This is caused by a function dividing the length of the 'next buffer' by a parameter `dfs`, which should not happen.

More details in #57247 

The following proposal assumes that the `struct spi_buf`'s `len` field is expected to be units of frame size, not bytes. This, as far as I understand, matches the logic of `spi_context_update_tx`.

After removing the division by `dfs`, the result is:

![after-fix](https://user-images.githubusercontent.com/127399215/234312352-0d7e65c7-e3a2-4827-a03e-6697deda9f24.png)

Fixes #57247 
Closes #57247 
