### PR TITLE
scripts: get_maintainer: Fix glob pattern directory match error logic

### DIFF
--- a/scripts/get_maintainer.py
+++ b/scripts/get_maintainer.py
@@ -524,10 +524,9 @@ def _check_maintainers(maints_path, yaml):
                              "match any files".format(glob_pattern, files_key,
                                                       area_name))
                     if not glob_pattern.endswith("/"):
-                        for path in paths:
-                            if path.is_dir():
-                                ferr("glob pattern '{}' in '{}' in area '{}' "
-                                     "matches a directory, but has no "
+                        if all(path.is_dir() for path in paths):
+                            ferr("glob pattern '{}' in '{}' in area '{}' "
+                                     "matches only directories, but has no "
                                      "trailing '/'"
                                      .format(glob_pattern, files_key,
                                              area_name))


### PR DESCRIPTION
The `get_maintainer` script currently generates an error when a non- slash-suffixed glob pattern matches any directories -- this is incorrect because the glob pattern may be used to match files.

This commit updates the script to only generate an error when a non-slash suffixed _only_ matches directories.

---

Fixes the following error seen in the CI:

> get_maintainer.MaintainersError: MAINTAINERS.yml: glob pattern 'drivers/*/*rpi_pico' in 'files' in area 'Raspberry Pi Pico Platforms' matches a directory, but has no trailing '/'

**Note that the pull request assigner workflow fails here because it runs on the `pull_request_target` event (i.e. in the context of the `main` branch and not the PR branch)**