### PR TITLE
scripts: gen_isr_tables: fix pylint issues

### DIFF
--- a/scripts/build/gen_isr_tables.py
+++ b/scripts/build/gen_isr_tables.py
@@ -13,7 +13,7 @@ import os
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 
-ISR_FLAG_DIRECT = (1 << 0)
+ISR_FLAG_DIRECT = 1 << 0
 
 # The below few hardware independent magic numbers represent various
 # levels of interrupts in a multi-level interrupt system.
@@ -313,7 +313,7 @@ def main():
                 debug('IRQ = ' + hex(irq))
                 irq3 = (irq & THIRD_LVL_INTERRUPTS) >> 16
                 irq2 = (irq & SECND_LVL_INTERRUPTS) >> 8
-                irq1 = (irq & FIRST_LVL_INTERRUPTS)
+                irq1 = irq & FIRST_LVL_INTERRUPTS
 
                 if irq3:
                     irq_parent = irq2


### PR DESCRIPTION
pylint reports the following issues on the
scripts/build/gen_isr_tables.py:

 C0325:Unnecessary parens after '=' keyword (superfluous-parens)
File:scripts/build/gen_isr_tables.py
Line:16
Column:0
 C0325:Unnecessary parens after '=' keyword (superfluous-parens)
File:scripts/build/gen_isr_tables.py
Line:316
Column:0

Fix that so that unrelated PR touching the same file have a chance to pass the compliance checks.