### PR TITLE
xec: spi: Remove `.cs = NULL` in spi_config initializer

### DIFF
--- a/drivers/spi/spi_xec_qmspi_ldma.c
+++ b/drivers/spi/spi_xec_qmspi_ldma.c
@@ -970,7 +970,6 @@ static int qmspi_xec_init(const struct device *dev)
 	const struct spi_config spi_cfg = {
 		.frequency = cfg->clock_freq,
 		.operation = SPI_LINES_SINGLE | SPI_WORD_SET(8),
-		.cs = NULL,
 	};
 
 	ret = qmspi_configure(dev, &spi_cfg);


### PR DESCRIPTION
Following #56576, the `cs` field in `struct spi_config` is of type `struct spi_cs_control` instead of a pointer to the same type. `spi_xec_qmspi_ldma.c:qmspi_xec_init` tries assigning `NULL` to the `.cs` field through a designated initializer, which causes a compilation error.

This PR simply removes the `.cs = NULL` line. The designated initializer will automatically zeroize the underlying GPIO pin info, which should have the same effect that setting the pointer to NULL did previously.