### PR TITLE
drivers: ieee 802.15.4:: fix double-promotions warnings

### DIFF
--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -486,30 +486,30 @@ static int rf2xx_set_txpower(const struct device *dev, int16_t dbm)
 
 	min = conf->tx_pwr_min[1];
 	if (conf->tx_pwr_min[0] == 0x01) {
-		min *= -1.0;
+		min *= -1.0f;
 	}
 
 	max = conf->tx_pwr_max[1];
 	if (conf->tx_pwr_max[0] == 0x01) {
-		min *= -1.0;
+		min *= -1.0f;
 	}
 
-	step = (max - min) / ((float)conf->tx_pwr_table_size - 1.0);
+	step = (max - min) / ((float)conf->tx_pwr_table_size - 1.0f);
 
-	if (step == 0.0) {
-		step = 1.0;
+	if (step == 0.0f) {
+		step = 1.0f;
 	}
 
 	LOG_DBG("Tx-power values: min %f, max %f, step %f, entries %d",
-		min, max, step, conf->tx_pwr_table_size);
+		(double)min, (double)max, (double)step, conf->tx_pwr_table_size);
 
 	if (dbm < min) {
 		LOG_INF("TX-power %d dBm below min of %f dBm, using %f dBm",
-			dbm, min, max);
+			dbm, (double)min, (double)max);
 		dbm = min;
 	} else if (dbm > max) {
 		LOG_INF("TX-power %d dBm above max of %f dBm, using %f dBm",
-			dbm, min, max);
+			dbm, (double)min, (double)max);
 		dbm = max;
 	}
 


### PR DESCRIPTION
title