### PR TITLE
debug: Make stack sentinel incompatible with MPU stack guard

### DIFF
--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -178,6 +178,7 @@ config STACK_SENTINEL
 	select THREAD_STACK_INFO
 	depends on MULTITHREADING
 	depends on !USERSPACE
+	depends on !MPU_STACK_GUARD
 	help
 	  Store a magic value at the lowest addresses of a thread's stack.
 	  Periodically check that this value is still present and kill the


### PR DESCRIPTION
The MPU stack guard can move the start address of a thread stack.
Don't allow both options to be enabled at the same time.