### PR TITLE
ci: Run greeting workflow on pull_request_target

### DIFF
--- a/.github/workflows/greet_first_time_contributor.yml
+++ b/.github/workflows/greet_first_time_contributor.yml
@@ -3,7 +3,7 @@ name: Greet first time contributor
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened, closed]
 
 jobs:


### PR DESCRIPTION
In order to be able to comment on PR, the workflow requires a GITHUB_TOKEN with appropriate write permissions, which are only provided when running in the context of the base of the pull request.

@stephanosio 