### PR TITLE
ITE: it8xxx2: Fix chip setting for IT8xxx2

### DIFF
--- a/boards/riscv/it82xx2_evb/it82xx2_evb.dts
+++ b/boards/riscv/it82xx2_evb/it82xx2_evb.dts
@@ -126,8 +126,8 @@
 
 &ite_uart2_wrapper {
 	status = "okay";
-	pinctrl-0 = <&uart2_rx_gph1_default
-		     &uart2_tx_gph2_default>;
+	pinctrl-0 = <&uart2_rx_gpf0_default
+		     &uart2_tx_gpf1_default>;
 	pinctrl-names = "default";
 };
 

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -39,7 +39,7 @@
 		standby: standby {
 			compatible = "zephyr,power-state";
 			power-state-name = "standby";
-			min-residency-us = <240000>;
+			min-residency-us = <500>;
 		};
 	};
 


### PR DESCRIPTION
This PR includes two changes, one is to reduce the min-residency-us,
and the other is to correct the setting of pinctrl.