### PR TITLE
drivers: pwm: pwm_mcux: Round up PWM frequency to prevent overflow

### DIFF
--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -88,7 +88,7 @@ static int mcux_pwm_set_cycles(const struct device *dev, uint32_t channel,
 			return -EINVAL;
 		}
 
-		pwm_freq = (clock_freq >> config->prescale) / period_cycles;
+		pwm_freq = DIV_ROUND_UP(clock_freq >> config->prescale, period_cycles);
 
 		if (pwm_freq == 0) {
 			LOG_ERR("Could not set up pwm_freq=%d", pwm_freq);


### PR DESCRIPTION
The HAL function PWM_SetupPwm does the inverse division to get the number of pulses from the frequency.
In the case of a prescaler of 1 and a period of UINT16_MAX cycles this would result in an uint16_t overflow.