### PR TITLE
west.yaml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 6902abba270c0fbcbe8ee3bb56fe39bc9acc2774
+      revision: 1558e7ab0aadb4eac11f03befb5ccd3fa3f0aafe
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:  1558e7ab0aadb4eac11f03befb5ccd3fa3f0aafe

Brings following Zephyr relevant fixes:
 - 1558e7ab boot: zephyr: remove stm32 watchdog defines
  - 4420bb66 boot: zephyr: setup watchdog
  - 393af79e boot_serial: Update zcbor files from zcbor 0.7.0
  - a95a41b3 boot: bootutil: loader: Let image version comparison use           build number
  - f7d8660e boot_serial: Fix include paths for zephyr builds
  - c7835371 bootutil: Add FIH for ED25519 sig verification
  - 186ac885 bootutil: Fix FIH return type for EC256
  - 5397c13d zephyr: serial_recovery: Fix broken CDC device selection
  - 918da26a bootutil: Provide boot_set_next function
 
Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.