### PR TITLE
drivers: can: mcan: various clean-ups

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1074,14 +1074,14 @@ int can_mcan_init(const struct device *dev)
 	can_mcan_set_timing_data(dev, &timing_data);
 #endif /* CONFIG_CAN_FD_MODE */
 
-	can->ie = CAN_MCAN_IE_BO | CAN_MCAN_IE_EW | CAN_MCAN_IE_EP | CAN_MCAN_IE_MRAF |
-		  CAN_MCAN_IE_TEFL | CAN_MCAN_IE_TEFN | CAN_MCAN_IE_RF0N | CAN_MCAN_IE_RF1N |
-		  CAN_MCAN_IE_RF0L | CAN_MCAN_IE_RF1L;
+	can->ie = CAN_MCAN_IE_BOE | CAN_MCAN_IE_EWE | CAN_MCAN_IE_EPE | CAN_MCAN_IE_MRAFE |
+		  CAN_MCAN_IE_TEFLE | CAN_MCAN_IE_TEFNE | CAN_MCAN_IE_RF0NE | CAN_MCAN_IE_RF1NE |
+		  CAN_MCAN_IE_RF0LE | CAN_MCAN_IE_RF1LE;
 
 #ifdef CONFIG_CAN_STM32FD
 	can->ils = CAN_MCAN_ILS_RXFIFO0 | CAN_MCAN_ILS_RXFIFO1;
 #else  /* CONFIG_CAN_STM32FD */
-	can->ils = CAN_MCAN_ILS_RF0N | CAN_MCAN_ILS_RF1N;
+	can->ils = CAN_MCAN_ILS_RF0NL | CAN_MCAN_ILS_RF1NL;
 #endif /* !CONFIG_CAN_STM32FD */
 	can->ile = CAN_MCAN_ILE_EINT0 | CAN_MCAN_ILE_EINT1;
 	/* Interrupt on every TX fifo element*/

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -5,13 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/sys/util.h>
-#include <string.h>
 #include <zephyr/cache.h>
-#include <zephyr/kernel.h>
 #include <zephyr/drivers/can.h>
 #include <zephyr/drivers/can/transceiver.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
 
 #include "can_mcan.h"
 #include "can_mcan_priv.h"

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -47,7 +47,7 @@ static void memset32_volatile(volatile void *dst_, uint32_t val, size_t len)
 	}
 }
 
-static int can_exit_sleep_mode(const struct device *dev)
+static int can_mcan_exit_sleep_mode(const struct device *dev)
 {
 	const struct can_mcan_config *cfg = dev->config;
 	struct can_mcan_reg *can = cfg->can;
@@ -66,7 +66,7 @@ static int can_exit_sleep_mode(const struct device *dev)
 	return 0;
 }
 
-static int can_enter_init_mode(const struct device *dev, k_timeout_t timeout)
+static int can_mcan_enter_init_mode(const struct device *dev, k_timeout_t timeout)
 {
 	const struct can_mcan_config *cfg = dev->config;
 	struct can_mcan_reg *can = cfg->can;
@@ -85,7 +85,7 @@ static int can_enter_init_mode(const struct device *dev, k_timeout_t timeout)
 	return 0;
 }
 
-static int can_leave_init_mode(const struct device *dev, k_timeout_t timeout)
+static int can_mcan_leave_init_mode(const struct device *dev, k_timeout_t timeout)
 {
 	const struct can_mcan_config *cfg = dev->config;
 	struct can_mcan_reg *can = cfg->can;
@@ -219,7 +219,7 @@ int can_mcan_start(const struct device *dev)
 		}
 	}
 
-	ret = can_leave_init_mode(dev, K_MSEC(CAN_INIT_TIMEOUT));
+	ret = can_mcan_leave_init_mode(dev, K_MSEC(CAN_INIT_TIMEOUT));
 	if (ret) {
 		LOG_ERR("failed to leave init mode");
 
@@ -249,7 +249,7 @@ int can_mcan_stop(const struct device *dev)
 	}
 
 	/* CAN transmissions are automatically stopped when entering init mode */
-	ret = can_enter_init_mode(dev, K_MSEC(CAN_INIT_TIMEOUT));
+	ret = can_mcan_enter_init_mode(dev, K_MSEC(CAN_INIT_TIMEOUT));
 	if (ret != 0) {
 		LOG_ERR("Failed to enter init mode");
 		return -EIO;
@@ -351,13 +351,13 @@ int can_mcan_init(const struct device *dev)
 		}
 	}
 
-	ret = can_exit_sleep_mode(dev);
+	ret = can_mcan_exit_sleep_mode(dev);
 	if (ret) {
 		LOG_ERR("Failed to exit sleep mode");
 		return -EIO;
 	}
 
-	ret = can_enter_init_mode(dev, K_MSEC(CAN_INIT_TIMEOUT));
+	ret = can_mcan_enter_init_mode(dev, K_MSEC(CAN_INIT_TIMEOUT));
 	if (ret) {
 		LOG_ERR("Failed to enter init mode");
 		return -EIO;
@@ -753,7 +753,7 @@ int can_mcan_recover(const struct device *dev, k_timeout_t timeout)
 		return -ENETDOWN;
 	}
 
-	return can_leave_init_mode(dev, timeout);
+	return can_mcan_leave_init_mode(dev, timeout);
 }
 #endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -20,8 +20,7 @@ LOG_MODULE_REGISTER(can_mcan, CONFIG_CAN_LOG_LEVEL);
 
 #define CAN_INIT_TIMEOUT (100)
 
-static void memcpy32_volatile(volatile void *dst_, const volatile void *src_,
-			      size_t len)
+static void memcpy32_volatile(volatile void *dst_, const volatile void *src_, size_t len)
 {
 	volatile uint32_t *dst = dst_;
 	const volatile uint32_t *src = src_;
@@ -56,8 +55,7 @@ static int can_exit_sleep_mode(struct can_mcan_reg *can)
 	start_time = k_cycle_get_32();
 
 	while ((can->cccr & CAN_MCAN_CCCR_CSA) == CAN_MCAN_CCCR_CSA) {
-		if (k_cycle_get_32() - start_time >
-			k_ms_to_cyc_ceil32(CAN_INIT_TIMEOUT)) {
+		if (k_cycle_get_32() - start_time > k_ms_to_cyc_ceil32(CAN_INIT_TIMEOUT)) {
 			can->cccr |= CAN_MCAN_CCCR_CSR;
 			return -EAGAIN;
 		}
@@ -99,35 +97,29 @@ static int can_leave_init_mode(struct can_mcan_reg *can, k_timeout_t timeout)
 	return 0;
 }
 
-void can_mcan_configure_timing(struct can_mcan_reg *can,
-			       const struct can_timing *timing,
+void can_mcan_configure_timing(struct can_mcan_reg *can, const struct can_timing *timing,
 			       const struct can_timing *timing_data)
 {
 	if (timing) {
 		uint32_t nbtp_sjw = can->nbtp & CAN_MCAN_NBTP_NSJW_MSK;
 
 		__ASSERT_NO_MSG(timing->prop_seg == 0);
-		__ASSERT_NO_MSG(timing->phase_seg1 <= 0x100 &&
-				timing->phase_seg1 > 0);
-		__ASSERT_NO_MSG(timing->phase_seg2 <= 0x80 &&
-				timing->phase_seg2 > 0);
-		__ASSERT_NO_MSG(timing->prescaler <= 0x200 &&
-				timing->prescaler > 0);
+		__ASSERT_NO_MSG(timing->phase_seg1 <= 0x100 && timing->phase_seg1 > 0);
+		__ASSERT_NO_MSG(timing->phase_seg2 <= 0x80 && timing->phase_seg2 > 0);
+		__ASSERT_NO_MSG(timing->prescaler <= 0x200 && timing->prescaler > 0);
 		__ASSERT_NO_MSG(timing->sjw == CAN_SJW_NO_CHANGE ||
 				(timing->sjw <= 0x80 && timing->sjw > 0));
 
-		can->nbtp = (((uint32_t)timing->phase_seg1 - 1UL) & 0xFF) <<
-				CAN_MCAN_NBTP_NTSEG1_POS |
-			    (((uint32_t)timing->phase_seg2 - 1UL) & 0x7F) <<
-				CAN_MCAN_NBTP_NTSEG2_POS |
-			    (((uint32_t)timing->prescaler  - 1UL) & 0x1FF) <<
-				CAN_MCAN_NBTP_NBRP_POS;
+		can->nbtp =
+			(((uint32_t)timing->phase_seg1 - 1UL) & 0xFF) << CAN_MCAN_NBTP_NTSEG1_POS |
+			(((uint32_t)timing->phase_seg2 - 1UL) & 0x7F) << CAN_MCAN_NBTP_NTSEG2_POS |
+			(((uint32_t)timing->prescaler - 1UL) & 0x1FF) << CAN_MCAN_NBTP_NBRP_POS;
 
 		if (timing->sjw == CAN_SJW_NO_CHANGE) {
 			can->nbtp |= nbtp_sjw;
 		} else {
-			can->nbtp |= (((uint32_t)timing->sjw - 1UL) & 0x7F) <<
-				     CAN_MCAN_NBTP_NSJW_POS;
+			can->nbtp |= (((uint32_t)timing->sjw - 1UL) & 0x7F)
+				     << CAN_MCAN_NBTP_NSJW_POS;
 		}
 	}
 
@@ -136,34 +128,30 @@ void can_mcan_configure_timing(struct can_mcan_reg *can,
 		uint32_t dbtp_sjw = can->dbtp & CAN_MCAN_DBTP_DSJW_MSK;
 
 		__ASSERT_NO_MSG(timing_data->prop_seg == 0);
-		__ASSERT_NO_MSG(timing_data->phase_seg1 <= 0x20 &&
-				timing_data->phase_seg1 > 0);
-		__ASSERT_NO_MSG(timing_data->phase_seg2 <= 0x10 &&
-				timing_data->phase_seg2 > 0);
-		__ASSERT_NO_MSG(timing_data->prescaler <= 0x20 &&
-				timing_data->prescaler > 0);
+		__ASSERT_NO_MSG(timing_data->phase_seg1 <= 0x20 && timing_data->phase_seg1 > 0);
+		__ASSERT_NO_MSG(timing_data->phase_seg2 <= 0x10 && timing_data->phase_seg2 > 0);
+		__ASSERT_NO_MSG(timing_data->prescaler <= 0x20 && timing_data->prescaler > 0);
 		__ASSERT_NO_MSG(timing_data->sjw == CAN_SJW_NO_CHANGE ||
 				(timing_data->sjw <= 0x80 && timing_data->sjw > 0));
 
-		can->dbtp = (((uint32_t)timing_data->phase_seg1 - 1UL) & 0x1F) <<
-				CAN_MCAN_DBTP_DTSEG1_POS |
-			    (((uint32_t)timing_data->phase_seg2 - 1UL) & 0x0F) <<
-				CAN_MCAN_DBTP_DTSEG2_POS |
-			    (((uint32_t)timing_data->prescaler  - 1UL) & 0x1F) <<
-				CAN_MCAN_DBTP_DBRP_POS;
+		can->dbtp = (((uint32_t)timing_data->phase_seg1 - 1UL) & 0x1F)
+				    << CAN_MCAN_DBTP_DTSEG1_POS |
+			    (((uint32_t)timing_data->phase_seg2 - 1UL) & 0x0F)
+				    << CAN_MCAN_DBTP_DTSEG2_POS |
+			    (((uint32_t)timing_data->prescaler - 1UL) & 0x1F)
+				    << CAN_MCAN_DBTP_DBRP_POS;
 
 		if (timing_data->sjw == CAN_SJW_NO_CHANGE) {
 			can->dbtp |= dbtp_sjw;
 		} else {
-			can->dbtp |= (((uint32_t)timing_data->sjw - 1UL) & 0x0F) <<
-				     CAN_MCAN_DBTP_DSJW_POS;
+			can->dbtp |= (((uint32_t)timing_data->sjw - 1UL) & 0x0F)
+				     << CAN_MCAN_DBTP_DSJW_POS;
 		}
 	}
 #endif
 }
 
-int can_mcan_set_timing(const struct device *dev,
-			const struct can_timing *timing)
+int can_mcan_set_timing(const struct device *dev, const struct can_timing *timing)
 {
 	const struct can_mcan_config *cfg = dev->config;
 	struct can_mcan_data *data = dev->data;
@@ -179,8 +167,7 @@ int can_mcan_set_timing(const struct device *dev,
 }
 
 #ifdef CONFIG_CAN_FD_MODE
-int can_mcan_set_timing_data(const struct device *dev,
-			const struct can_timing *timing_data)
+int can_mcan_set_timing_data(const struct device *dev, const struct can_timing *timing_data)
 {
 	const struct can_mcan_config *cfg = dev->config;
 	struct can_mcan_data *data = dev->data;
@@ -378,8 +365,7 @@ int can_mcan_init(const struct device *dev)
 	LOG_DBG("IP rel: %lu.%lu.%lu %02lu.%lu.%lu",
 		(can->crel & CAN_MCAN_CREL_REL) >> CAN_MCAN_CREL_REL_POS,
 		(can->crel & CAN_MCAN_CREL_STEP) >> CAN_MCAN_CREL_STEP_POS,
-		(can->crel & CAN_MCAN_CREL_SUBSTEP) >>
-			     CAN_MCAN_CREL_SUBSTEP_POS,
+		(can->crel & CAN_MCAN_CREL_SUBSTEP) >> CAN_MCAN_CREL_SUBSTEP_POS,
 		(can->crel & CAN_MCAN_CREL_YEAR) >> CAN_MCAN_CREL_YEAR_POS,
 		(can->crel & CAN_MCAN_CREL_MON) >> CAN_MCAN_CREL_MON_POS,
 		(can->crel & CAN_MCAN_CREL_DAY) >> CAN_MCAN_CREL_DAY_POS);
@@ -394,19 +380,18 @@ int can_mcan_init(const struct device *dev)
 	can->mrba = mrba;
 #endif
 	can->sidfc = (((uint32_t)msg_ram->std_filt - mrba) & CAN_MCAN_SIDFC_FLSSA_MSK) |
-		(ARRAY_SIZE(msg_ram->std_filt) << CAN_MCAN_SIDFC_LSS_POS);
+		     (ARRAY_SIZE(msg_ram->std_filt) << CAN_MCAN_SIDFC_LSS_POS);
 	can->xidfc = (((uint32_t)msg_ram->ext_filt - mrba) & CAN_MCAN_XIDFC_FLESA_MSK) |
-		(ARRAY_SIZE(msg_ram->ext_filt) << CAN_MCAN_XIDFC_LSS_POS);
+		     (ARRAY_SIZE(msg_ram->ext_filt) << CAN_MCAN_XIDFC_LSS_POS);
 	can->rxf0c = (((uint32_t)msg_ram->rx_fifo0 - mrba) & CAN_MCAN_RXF0C_F0SA) |
-		(ARRAY_SIZE(msg_ram->rx_fifo0) << CAN_MCAN_RXF0C_F0S_POS);
+		     (ARRAY_SIZE(msg_ram->rx_fifo0) << CAN_MCAN_RXF0C_F0S_POS);
 	can->rxf1c = (((uint32_t)msg_ram->rx_fifo1 - mrba) & CAN_MCAN_RXF1C_F1SA) |
-		(ARRAY_SIZE(msg_ram->rx_fifo1) << CAN_MCAN_RXF1C_F1S_POS);
+		     (ARRAY_SIZE(msg_ram->rx_fifo1) << CAN_MCAN_RXF1C_F1S_POS);
 	can->rxbc = (((uint32_t)msg_ram->rx_buffer - mrba) & CAN_MCAN_RXBC_RBSA);
 	can->txefc = (((uint32_t)msg_ram->tx_event_fifo - mrba) & CAN_MCAN_TXEFC_EFSA_MSK) |
-		(ARRAY_SIZE(msg_ram->tx_event_fifo) << CAN_MCAN_TXEFC_EFS_POS);
+		     (ARRAY_SIZE(msg_ram->tx_event_fifo) << CAN_MCAN_TXEFC_EFS_POS);
 	can->txbc = (((uint32_t)msg_ram->tx_buffer - mrba) & CAN_MCAN_TXBC_TBSA) |
-		(ARRAY_SIZE(msg_ram->tx_buffer) << CAN_MCAN_TXBC_TFQS_POS) |
-		CAN_MCAN_TXBC_TFQM;
+		    (ARRAY_SIZE(msg_ram->tx_buffer) << CAN_MCAN_TXBC_TFQS_POS) | CAN_MCAN_TXBC_TFQM;
 
 	if (sizeof(msg_ram->tx_buffer[0].data) <= 24) {
 		can->txesc = (sizeof(msg_ram->tx_buffer[0].data) - 8) / 4;
@@ -415,51 +400,45 @@ int can_mcan_init(const struct device *dev)
 	}
 
 	if (sizeof(msg_ram->rx_fifo0[0].data) <= 24) {
-		can->rxesc = (((sizeof(msg_ram->rx_fifo0[0].data) - 8) / 4) <<
-				CAN_MCAN_RXESC_F0DS_POS) |
-			     (((sizeof(msg_ram->rx_fifo1[0].data) - 8) / 4) <<
-				CAN_MCAN_RXESC_F1DS_POS) |
-			     (((sizeof(msg_ram->rx_buffer[0].data) - 8) / 4) <<
-				CAN_MCAN_RXESC_RBDS_POS);
+		can->rxesc =
+			(((sizeof(msg_ram->rx_fifo0[0].data) - 8) / 4) << CAN_MCAN_RXESC_F0DS_POS) |
+			(((sizeof(msg_ram->rx_fifo1[0].data) - 8) / 4) << CAN_MCAN_RXESC_F1DS_POS) |
+			(((sizeof(msg_ram->rx_buffer[0].data) - 8) / 4) << CAN_MCAN_RXESC_RBDS_POS);
 	} else {
-		can->rxesc = (((sizeof(msg_ram->rx_fifo0[0].data) - 32)
-				/ 16 + 5) << CAN_MCAN_RXESC_F0DS_POS) |
-			     (((sizeof(msg_ram->rx_fifo1[0].data) - 32)
-				/ 16 + 5) << CAN_MCAN_RXESC_F1DS_POS) |
-			     (((sizeof(msg_ram->rx_buffer[0].data) - 32)
-				/ 16 + 5) << CAN_MCAN_RXESC_RBDS_POS);
+		can->rxesc = (((sizeof(msg_ram->rx_fifo0[0].data) - 32) / 16 + 5)
+			      << CAN_MCAN_RXESC_F0DS_POS) |
+			     (((sizeof(msg_ram->rx_fifo1[0].data) - 32) / 16 + 5)
+			      << CAN_MCAN_RXESC_F1DS_POS) |
+			     (((sizeof(msg_ram->rx_buffer[0].data) - 32) / 16 + 5)
+			      << CAN_MCAN_RXESC_RBDS_POS);
 	}
 #endif
-	can->cccr &= ~(CAN_MCAN_CCCR_FDOE | CAN_MCAN_CCCR_BRSE |
-		       CAN_MCAN_CCCR_TEST | CAN_MCAN_CCCR_MON |
-		       CAN_MCAN_CCCR_ASM);
+	can->cccr &= ~(CAN_MCAN_CCCR_FDOE | CAN_MCAN_CCCR_BRSE | CAN_MCAN_CCCR_TEST |
+		       CAN_MCAN_CCCR_MON | CAN_MCAN_CCCR_ASM);
 	can->test &= ~(CAN_MCAN_TEST_LBCK);
 
 #if defined(CONFIG_CAN_DELAY_COMP) && defined(CONFIG_CAN_FD_MODE)
 	can->dbtp |= CAN_MCAN_DBTP_TDC;
-	can->tdcr |=  cfg->tx_delay_comp_offset << CAN_MCAN_TDCR_TDCO_POS;
+	can->tdcr |= cfg->tx_delay_comp_offset << CAN_MCAN_TDCR_TDCO_POS;
 
 #endif
 
 #ifdef CONFIG_CAN_STM32FD
 	can->rxgfc |= (CONFIG_CAN_MAX_STD_ID_FILTER << CAN_MCAN_RXGFC_LSS_POS) |
 		      (CONFIG_CAN_MAX_EXT_ID_FILTER << CAN_MCAN_RXGFC_LSE_POS) |
-		      (0x2 << CAN_MCAN_RXGFC_ANFS_POS) |
-		      (0x2 << CAN_MCAN_RXGFC_ANFE_POS);
+		      (0x2 << CAN_MCAN_RXGFC_ANFS_POS) | (0x2 << CAN_MCAN_RXGFC_ANFE_POS);
 #else
-	can->gfc |= (0x2 << CAN_MCAN_GFC_ANFE_POS) |
-		    (0x2 << CAN_MCAN_GFC_ANFS_POS);
+	can->gfc |= (0x2 << CAN_MCAN_GFC_ANFE_POS) | (0x2 << CAN_MCAN_GFC_ANFS_POS);
 #endif /* CONFIG_CAN_STM32FD */
 
 	if (cfg->sample_point) {
-		ret = can_calc_timing(dev, &timing, cfg->bus_speed,
-				      cfg->sample_point);
+		ret = can_calc_timing(dev, &timing, cfg->bus_speed, cfg->sample_point);
 		if (ret == -EINVAL) {
 			LOG_ERR("Can't find timing for given param");
 			return -EIO;
 		}
-		LOG_DBG("Presc: %d, TS1: %d, TS2: %d",
-			timing.prescaler, timing.phase_seg1, timing.phase_seg2);
+		LOG_DBG("Presc: %d, TS1: %d, TS2: %d", timing.prescaler, timing.phase_seg1,
+			timing.phase_seg2);
 		LOG_DBG("Sample-point err : %d", ret);
 	} else if (cfg->prop_ts1) {
 		timing.prop_seg = 0;
@@ -472,8 +451,7 @@ int can_mcan_init(const struct device *dev)
 	}
 #ifdef CONFIG_CAN_FD_MODE
 	if (cfg->sample_point_data) {
-		ret = can_calc_timing_data(dev, &timing_data,
-					   cfg->bus_speed_data,
+		ret = can_calc_timing_data(dev, &timing_data, cfg->bus_speed_data,
 					   cfg->sample_point_data);
 		if (ret == -EINVAL) {
 			LOG_ERR("Can't find timing for given dataphase param");
@@ -485,8 +463,7 @@ int can_mcan_init(const struct device *dev)
 		timing_data.prop_seg = 0;
 		timing_data.phase_seg1 = cfg->prop_ts1_data;
 		timing_data.phase_seg2 = cfg->ts2_data;
-		ret = can_calc_prescaler(dev, &timing_data,
-					 cfg->bus_speed_data);
+		ret = can_calc_prescaler(dev, &timing_data, cfg->bus_speed_data);
 		if (ret) {
 			LOG_WRN("Dataphase bitrate error: %d", ret);
 		}
@@ -501,10 +478,9 @@ int can_mcan_init(const struct device *dev)
 	can_mcan_configure_timing(can, &timing, NULL);
 #endif
 
-	can->ie = CAN_MCAN_IE_BO | CAN_MCAN_IE_EW | CAN_MCAN_IE_EP |
-		  CAN_MCAN_IE_MRAF | CAN_MCAN_IE_TEFL | CAN_MCAN_IE_TEFN |
-		  CAN_MCAN_IE_RF0N | CAN_MCAN_IE_RF1N | CAN_MCAN_IE_RF0L |
-		  CAN_MCAN_IE_RF1L;
+	can->ie = CAN_MCAN_IE_BO | CAN_MCAN_IE_EW | CAN_MCAN_IE_EP | CAN_MCAN_IE_MRAF |
+		  CAN_MCAN_IE_TEFL | CAN_MCAN_IE_TEFN | CAN_MCAN_IE_RF0N | CAN_MCAN_IE_RF1N |
+		  CAN_MCAN_IE_RF0L | CAN_MCAN_IE_RF1L;
 
 #ifdef CONFIG_CAN_STM32FD
 	can->ils = CAN_MCAN_ILS_RXFIFO0 | CAN_MCAN_ILS_RXFIFO1;
@@ -547,8 +523,7 @@ static void can_mcan_tc_event_handler(const struct device *dev)
 	uint32_t event_idx, tx_idx;
 
 	while (can->txefs & CAN_MCAN_TXEFS_EFFL) {
-		event_idx = (can->txefs & CAN_MCAN_TXEFS_EFGI) >>
-			    CAN_MCAN_TXEFS_EFGI_POS;
+		event_idx = (can->txefs & CAN_MCAN_TXEFS_EFGI) >> CAN_MCAN_TXEFS_EFGI_POS;
 		sys_cache_data_invd_range((void *)&msg_ram->tx_event_fifo[event_idx],
 					  sizeof(struct can_mcan_tx_event_fifo));
 		tx_event = &msg_ram->tx_event_fifo[event_idx];
@@ -571,10 +546,8 @@ void can_mcan_line_0_isr(const struct device *dev)
 	struct can_mcan_reg *can = cfg->can;
 
 	do {
-		if (can->ir & (CAN_MCAN_IR_BO | CAN_MCAN_IR_EP |
-			       CAN_MCAN_IR_EW)) {
-			can->ir = CAN_MCAN_IR_BO | CAN_MCAN_IR_EP |
-				  CAN_MCAN_IR_EW;
+		if (can->ir & (CAN_MCAN_IR_BO | CAN_MCAN_IR_EP | CAN_MCAN_IR_EW)) {
+			can->ir = CAN_MCAN_IR_BO | CAN_MCAN_IR_EP | CAN_MCAN_IR_EW;
 			can_mcan_state_change_handler(dev);
 		}
 		/* TX event FIFO new entry */
@@ -590,21 +563,20 @@ void can_mcan_line_0_isr(const struct device *dev)
 		}
 
 		if (can->ir & CAN_MCAN_IR_ARA) {
-			can->ir  = CAN_MCAN_IR_ARA;
+			can->ir = CAN_MCAN_IR_ARA;
 			LOG_ERR("Access to reserved address");
 		}
 
 		if (can->ir & CAN_MCAN_IR_MRAF) {
-			can->ir  = CAN_MCAN_IR_MRAF;
+			can->ir = CAN_MCAN_IR_MRAF;
 			LOG_ERR("Message RAM access failure");
 		}
 
-	} while (can->ir & (CAN_MCAN_IR_BO | CAN_MCAN_IR_EW | CAN_MCAN_IR_EP |
-			    CAN_MCAN_IR_TEFL | CAN_MCAN_IR_TEFN));
+	} while (can->ir & (CAN_MCAN_IR_BO | CAN_MCAN_IR_EW | CAN_MCAN_IR_EP | CAN_MCAN_IR_TEFL |
+			    CAN_MCAN_IR_TEFN));
 }
 
-static void can_mcan_get_message(const struct device *dev,
-				 volatile struct can_mcan_rx_fifo *fifo,
+static void can_mcan_get_message(const struct device *dev, volatile struct can_mcan_rx_fifo *fifo,
 				 volatile uint32_t *fifo_status_reg,
 				 volatile uint32_t *fifo_ack_reg)
 {
@@ -620,13 +592,11 @@ static void can_mcan_get_message(const struct device *dev,
 	bool fd_frame_filter;
 
 	while ((*fifo_status_reg & CAN_MCAN_RXF0S_F0FL)) {
-		get_idx = (*fifo_status_reg & CAN_MCAN_RXF0S_F0GI) >>
-			   CAN_MCAN_RXF0S_F0GI_POS;
+		get_idx = (*fifo_status_reg & CAN_MCAN_RXF0S_F0GI) >> CAN_MCAN_RXF0S_F0GI_POS;
 
 		sys_cache_data_invd_range((void *)&fifo[get_idx].hdr,
 					  sizeof(struct can_mcan_rx_fifo_hdr));
-		memcpy32_volatile(&hdr, &fifo[get_idx].hdr,
-				  sizeof(struct can_mcan_rx_fifo_hdr));
+		memcpy32_volatile(&hdr, &fifo[get_idx].hdr, sizeof(struct can_mcan_rx_fifo_hdr));
 
 		frame.dlc = hdr.dlc;
 
@@ -685,13 +655,11 @@ static void can_mcan_get_message(const struct device *dev,
 
 			if ((frame.flags & CAN_FRAME_IDE) != 0) {
 				LOG_DBG("Frame on filter %d, ID: 0x%x",
-					filt_idx + NUM_STD_FILTER_DATA,
-					frame.id);
+					filt_idx + NUM_STD_FILTER_DATA, frame.id);
 				cb = data->rx_cb_ext[filt_idx];
 				cb_arg = data->cb_arg_ext[filt_idx];
 			} else {
-				LOG_DBG("Frame on filter %d, ID: 0x%x",
-					filt_idx, frame.id);
+				LOG_DBG("Frame on filter %d, ID: 0x%x", filt_idx, frame.id);
 				cb = data->rx_cb_std[filt_idx];
 				cb_arg = data->cb_arg_std[filt_idx];
 			}
@@ -718,31 +686,29 @@ void can_mcan_line_1_isr(const struct device *dev)
 
 	do {
 		if (can->ir & CAN_MCAN_IR_RF0N) {
-			can->ir  = CAN_MCAN_IR_RF0N;
+			can->ir = CAN_MCAN_IR_RF0N;
 			LOG_DBG("RX FIFO0 INT");
-			can_mcan_get_message(dev, msg_ram->rx_fifo0,
-					     &can->rxf0s, &can->rxf0a);
+			can_mcan_get_message(dev, msg_ram->rx_fifo0, &can->rxf0s, &can->rxf0a);
 		}
 
 		if (can->ir & CAN_MCAN_IR_RF1N) {
-			can->ir  = CAN_MCAN_IR_RF1N;
+			can->ir = CAN_MCAN_IR_RF1N;
 			LOG_DBG("RX FIFO1 INT");
-			can_mcan_get_message(dev, msg_ram->rx_fifo1,
-					     &can->rxf1s, &can->rxf1a);
+			can_mcan_get_message(dev, msg_ram->rx_fifo1, &can->rxf1s, &can->rxf1a);
 		}
 
 		if (can->ir & CAN_MCAN_IR_RF0L) {
-			can->ir  = CAN_MCAN_IR_RF0L;
+			can->ir = CAN_MCAN_IR_RF0L;
 			LOG_ERR("Message lost on FIFO0");
 		}
 
 		if (can->ir & CAN_MCAN_IR_RF1L) {
-			can->ir  = CAN_MCAN_IR_RF1L;
+			can->ir = CAN_MCAN_IR_RF1L;
 			LOG_ERR("Message lost on FIFO1");
 		}
 
-	} while (can->ir & (CAN_MCAN_IR_RF0N | CAN_MCAN_IR_RF1N |
-			    CAN_MCAN_IR_RF0L | CAN_MCAN_IR_RF1L));
+	} while (can->ir &
+		 (CAN_MCAN_IR_RF0N | CAN_MCAN_IR_RF1N | CAN_MCAN_IR_RF0L | CAN_MCAN_IR_RF1L));
 }
 
 int can_mcan_get_state(const struct device *dev, enum can_state *state,
@@ -767,11 +733,9 @@ int can_mcan_get_state(const struct device *dev, enum can_state *state,
 	}
 
 	if (err_cnt != NULL) {
-		err_cnt->tx_err_cnt = (can->ecr & CAN_MCAN_ECR_TEC_MSK) <<
-				      CAN_MCAN_ECR_TEC_POS;
+		err_cnt->tx_err_cnt = (can->ecr & CAN_MCAN_ECR_TEC_MSK) << CAN_MCAN_ECR_TEC_POS;
 
-		err_cnt->rx_err_cnt = (can->ecr & CAN_MCAN_ECR_REC_MSK) <<
-				      CAN_MCAN_ECR_REC_POS;
+		err_cnt->rx_err_cnt = (can->ecr & CAN_MCAN_ECR_REC_MSK) << CAN_MCAN_ECR_REC_POS;
 	}
 
 	return 0;
@@ -792,10 +756,7 @@ int can_mcan_recover(const struct device *dev, k_timeout_t timeout)
 }
 #endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 
-
-int can_mcan_send(const struct device *dev,
-		  const struct can_frame *frame,
-		  k_timeout_t timeout,
+int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_timeout_t timeout,
 		  can_tx_callback_t callback, void *user_data)
 {
 	const struct can_mcan_config *cfg = dev->config;
@@ -811,7 +772,7 @@ int can_mcan_send(const struct device *dev,
 #ifdef CONFIG_CAN_FD_MODE
 		.fdf = (frame->flags & CAN_FRAME_FDF) != 0 ? 1U : 0U,
 		.brs = (frame->flags & CAN_FRAME_BRS) != 0 ? 1U : 0U,
-#else /* CONFIG_CAN_FD_MODE */
+#else  /* CONFIG_CAN_FD_MODE */
 		.fdf = 0U,
 		.brs = 0U,
 #endif /* !CONFIG_CAN_FD_MODE */
@@ -821,8 +782,7 @@ int can_mcan_send(const struct device *dev,
 	int ret;
 	struct can_mcan_mm mm;
 
-	LOG_DBG("Sending %d bytes. Id: 0x%x, ID type: %s %s %s %s",
-		data_length, frame->id,
+	LOG_DBG("Sending %d bytes. Id: 0x%x, ID type: %s %s %s %s", data_length, frame->id,
 		(frame->flags & CAN_FRAME_IDE) != 0 ? "extended" : "standard",
 		(frame->flags & CAN_FRAME_RTR) != 0 ? "RTR" : "",
 		(frame->flags & CAN_FRAME_FDF) != 0 ? "FD frame" : "",
@@ -831,8 +791,8 @@ int can_mcan_send(const struct device *dev,
 	__ASSERT_NO_MSG(callback != NULL);
 
 #ifdef CONFIG_CAN_FD_MODE
-	if ((frame->flags & ~(CAN_FRAME_IDE | CAN_FRAME_RTR |
-		CAN_FRAME_FDF | CAN_FRAME_BRS)) != 0) {
+	if ((frame->flags & ~(CAN_FRAME_IDE | CAN_FRAME_RTR | CAN_FRAME_FDF | CAN_FRAME_BRS)) !=
+	    0) {
 		LOG_ERR("unsupported CAN frame flags 0x%02x", frame->flags);
 		return -ENOTSUP;
 	}
@@ -846,7 +806,7 @@ int can_mcan_send(const struct device *dev,
 		LOG_ERR("CAN-FD BRS not supported in non-FD mode");
 		return -ENOTSUP;
 	}
-#else /* CONFIG_CAN_FD_MODE */
+#else  /* CONFIG_CAN_FD_MODE */
 	if ((frame->flags & ~(CAN_FRAME_IDE | CAN_FRAME_RTR)) != 0) {
 		LOG_ERR("unsupported CAN frame flags 0x%02x", frame->flags);
 		return -ENOTSUP;
@@ -854,8 +814,8 @@ int can_mcan_send(const struct device *dev,
 #endif /* !CONFIG_CAN_FD_MODE */
 
 	if (data_length > sizeof(frame->data)) {
-		LOG_ERR("data length (%zu) > max frame data length (%zu)",
-			data_length, sizeof(frame->data));
+		LOG_ERR("data length (%zu) > max frame data length (%zu)", data_length,
+			sizeof(frame->data));
 		return -EINVAL;
 	}
 
@@ -884,13 +844,11 @@ int can_mcan_send(const struct device *dev,
 		return -EAGAIN;
 	}
 
-	__ASSERT_NO_MSG((can->txfqs & CAN_MCAN_TXFQS_TFQF) !=
-			CAN_MCAN_TXFQS_TFQF);
+	__ASSERT_NO_MSG((can->txfqs & CAN_MCAN_TXFQS_TFQF) != CAN_MCAN_TXFQS_TFQF);
 
 	k_mutex_lock(&data->tx_mtx, K_FOREVER);
 
-	put_idx = ((can->txfqs & CAN_MCAN_TXFQS_TFQPI) >>
-		   CAN_MCAN_TXFQS_TFQPI_POS);
+	put_idx = ((can->txfqs & CAN_MCAN_TXFQS_TFQPI) >> CAN_MCAN_TXFQS_TFQPI_POS);
 
 	mm.idx = put_idx;
 	mm.cnt = data->mm.cnt++;
@@ -946,17 +904,13 @@ int can_mcan_get_max_filters(const struct device *dev, bool ide)
  * Dual mode gets tricky, because we can only activate both filters.
  * If one of the IDs is not used anymore, we would need to mark it as unused.
  */
-int can_mcan_add_rx_filter_std(const struct device *dev,
-			       can_rx_callback_t callback, void *user_data,
-			       const struct can_filter *filter)
+int can_mcan_add_rx_filter_std(const struct device *dev, can_rx_callback_t callback,
+			       void *user_data, const struct can_filter *filter)
 {
 	struct can_mcan_data *data = dev->data;
 	struct can_mcan_msg_sram *msg_ram = data->msg_ram;
 	struct can_mcan_std_filter filter_element = {
-		.id1 = filter->id,
-		.id2 = filter->mask,
-		.sft = CAN_MCAN_SFT_MASKED
-	};
+		.id1 = filter->id, .id2 = filter->mask, .sft = CAN_MCAN_SFT_MASKED};
 	int filter_id;
 
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
@@ -968,11 +922,10 @@ int can_mcan_add_rx_filter_std(const struct device *dev,
 	}
 
 	/* TODO proper fifo balancing */
-	filter_element.sfce = filter_id & 0x01 ? CAN_MCAN_FCE_FIFO1 :
-						 CAN_MCAN_FCE_FIFO0;
+	filter_element.sfce = filter_id & 0x01 ? CAN_MCAN_FCE_FIFO1 : CAN_MCAN_FCE_FIFO0;
 
 	memcpy32_volatile(&msg_ram->std_filt[filter_id], &filter_element,
-			 sizeof(struct can_mcan_std_filter));
+			  sizeof(struct can_mcan_std_filter));
 	sys_cache_data_flush_range((void *)&msg_ram->std_filt[filter_id],
 				   sizeof(struct can_mcan_std_filter));
 
@@ -987,7 +940,7 @@ int can_mcan_add_rx_filter_std(const struct device *dev,
 	}
 
 	if ((filter->flags & (CAN_FILTER_DATA | CAN_FILTER_RTR)) !=
-		(CAN_FILTER_DATA | CAN_FILTER_RTR)) {
+	    (CAN_FILTER_DATA | CAN_FILTER_RTR)) {
 		data->std_filt_rtr_mask |= (1U << filter_id);
 	} else {
 		data->std_filt_rtr_mask &= ~(1U << filter_id);
@@ -1016,17 +969,13 @@ static int can_mcan_get_free_ext(volatile struct can_mcan_ext_filter *filters)
 	return -ENOSPC;
 }
 
-static int can_mcan_add_rx_filter_ext(const struct device *dev,
-				      can_rx_callback_t callback, void *user_data,
-				      const struct can_filter *filter)
+static int can_mcan_add_rx_filter_ext(const struct device *dev, can_rx_callback_t callback,
+				      void *user_data, const struct can_filter *filter)
 {
 	struct can_mcan_data *data = dev->data;
 	struct can_mcan_msg_sram *msg_ram = data->msg_ram;
 	struct can_mcan_ext_filter filter_element = {
-		.id2 = filter->mask,
-		.id1 = filter->id,
-		.eft = CAN_MCAN_EFT_MASKED
-	};
+		.id2 = filter->mask, .id1 = filter->id, .eft = CAN_MCAN_EFT_MASKED};
 	int filter_id;
 
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
@@ -1038,8 +987,7 @@ static int can_mcan_add_rx_filter_ext(const struct device *dev,
 	}
 
 	/* TODO proper fifo balancing */
-	filter_element.efce = filter_id & 0x01 ? CAN_MCAN_FCE_FIFO1 :
-						 CAN_MCAN_FCE_FIFO0;
+	filter_element.efce = filter_id & 0x01 ? CAN_MCAN_FCE_FIFO1 : CAN_MCAN_FCE_FIFO0;
 
 	memcpy32_volatile(&msg_ram->ext_filt[filter_id], &filter_element,
 			  sizeof(struct can_mcan_ext_filter));
@@ -1057,7 +1005,7 @@ static int can_mcan_add_rx_filter_ext(const struct device *dev,
 	}
 
 	if ((filter->flags & (CAN_FILTER_DATA | CAN_FILTER_RTR)) !=
-		(CAN_FILTER_DATA | CAN_FILTER_RTR)) {
+	    (CAN_FILTER_DATA | CAN_FILTER_RTR)) {
 		data->ext_filt_rtr_mask |= (1U << filter_id);
 	} else {
 		data->ext_filt_rtr_mask &= ~(1U << filter_id);
@@ -1075,8 +1023,7 @@ static int can_mcan_add_rx_filter_ext(const struct device *dev,
 	return filter_id;
 }
 
-int can_mcan_add_rx_filter(const struct device *dev,
-			   can_rx_callback_t callback, void *user_data,
+int can_mcan_add_rx_filter(const struct device *dev, can_rx_callback_t callback, void *user_data,
 			   const struct can_filter *filter)
 {
 	int filter_id;
@@ -1085,10 +1032,9 @@ int can_mcan_add_rx_filter(const struct device *dev,
 		return -EINVAL;
 	}
 
-
 #ifdef CONFIG_CAN_FD_MODE
-	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA |
-							CAN_FILTER_RTR | CAN_FILTER_FDF)) != 0) {
+	if ((filter->flags &
+	     ~(CAN_FILTER_IDE | CAN_FILTER_DATA | CAN_FILTER_RTR | CAN_FILTER_FDF)) != 0) {
 #else
 	if ((filter->flags & ~(CAN_FILTER_IDE | CAN_FILTER_DATA | CAN_FILTER_RTR)) != 0) {
 #endif
@@ -1136,8 +1082,7 @@ void can_mcan_remove_rx_filter(const struct device *dev, int filter_id)
 }
 
 void can_mcan_set_state_change_callback(const struct device *dev,
-					can_state_change_callback_t callback,
-					void *user_data)
+					can_state_change_callback_t callback, void *user_data)
 {
 	struct can_mcan_data *data = dev->data;
 

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -961,29 +961,29 @@ int can_mcan_init(const struct device *dev)
 		FIELD_GET(CAN_MCAN_CREL_DAY, can->crel));
 
 #ifndef CONFIG_CAN_STM32FD
-	uint32_t mrba = 0;
+	uintptr_t mrba = 0;
 
 #ifdef CONFIG_CAN_STM32H7
-	mrba = (uint32_t)msg_ram;
+	mrba = POINTER_TO_UINT(msg_ram);
 #endif /* CONFIG_CAN_STM32H7 */
 
 #ifdef CONFIG_CAN_MCUX_MCAN
-	mrba = (uint32_t)msg_ram & CAN_MCAN_MRBA_BA;
+	mrba = POINTER_TO_UINT(msg_ram) & CAN_MCAN_MRBA_BA;
 	can->mrba = mrba;
 #endif /* CONFIG_CAN_MCUX_MCAN */
 
-	can->sidfc = (((uint32_t)msg_ram->std_filt - mrba) & CAN_MCAN_SIDFC_FLSSA) |
+	can->sidfc = ((POINTER_TO_UINT(msg_ram->std_filt) - mrba) & CAN_MCAN_SIDFC_FLSSA) |
 		     FIELD_PREP(CAN_MCAN_SIDFC_LSS, ARRAY_SIZE(msg_ram->std_filt));
-	can->xidfc = (((uint32_t)msg_ram->ext_filt - mrba) & CAN_MCAN_XIDFC_FLESA) |
+	can->xidfc = ((POINTER_TO_UINT(msg_ram->ext_filt) - mrba) & CAN_MCAN_XIDFC_FLESA) |
 		     FIELD_PREP(CAN_MCAN_XIDFC_LSS, ARRAY_SIZE(msg_ram->ext_filt));
-	can->rxf0c = (((uint32_t)msg_ram->rx_fifo0 - mrba) & CAN_MCAN_RXF0C_F0SA) |
+	can->rxf0c = ((POINTER_TO_UINT(msg_ram->rx_fifo0) - mrba) & CAN_MCAN_RXF0C_F0SA) |
 		     FIELD_PREP(CAN_MCAN_RXF0C_F0S, ARRAY_SIZE(msg_ram->rx_fifo0));
-	can->rxf1c = (((uint32_t)msg_ram->rx_fifo1 - mrba) & CAN_MCAN_RXF1C_F1SA) |
+	can->rxf1c = ((POINTER_TO_UINT(msg_ram->rx_fifo1) - mrba) & CAN_MCAN_RXF1C_F1SA) |
 		     FIELD_PREP(CAN_MCAN_RXF1C_F1S, ARRAY_SIZE(msg_ram->rx_fifo1));
-	can->rxbc = (((uint32_t)msg_ram->rx_buffer - mrba) & CAN_MCAN_RXBC_RBSA);
-	can->txefc = (((uint32_t)msg_ram->tx_event_fifo - mrba) & CAN_MCAN_TXEFC_EFSA) |
+	can->rxbc = ((POINTER_TO_UINT(msg_ram->rx_buffer) - mrba) & CAN_MCAN_RXBC_RBSA);
+	can->txefc = ((POINTER_TO_UINT(msg_ram->tx_event_fifo) - mrba) & CAN_MCAN_TXEFC_EFSA) |
 		     FIELD_PREP(CAN_MCAN_TXEFC_EFS, ARRAY_SIZE(msg_ram->tx_event_fifo));
-	can->txbc = (((uint32_t)msg_ram->tx_buffer - mrba) & CAN_MCAN_TXBC_TBSA) |
+	can->txbc = ((POINTER_TO_UINT(msg_ram->tx_buffer) - mrba) & CAN_MCAN_TXBC_TBSA) |
 		    FIELD_PREP(CAN_MCAN_TXBC_TFQS, ARRAY_SIZE(msg_ram->tx_buffer)) |
 		    CAN_MCAN_TXBC_TFQM;
 

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -49,8 +49,8 @@ static void memset32_volatile(volatile void *dst_, uint32_t val, size_t len)
 
 static int can_mcan_exit_sleep_mode(const struct device *dev)
 {
-	const struct can_mcan_config *cfg = dev->config;
-	struct can_mcan_reg *can = cfg->can;
+	const struct can_mcan_config *config = dev->config;
+	struct can_mcan_reg *can = config->can;
 	uint32_t start_time;
 
 	can->cccr &= ~CAN_MCAN_CCCR_CSR;
@@ -68,8 +68,8 @@ static int can_mcan_exit_sleep_mode(const struct device *dev)
 
 static int can_mcan_enter_init_mode(const struct device *dev, k_timeout_t timeout)
 {
-	const struct can_mcan_config *cfg = dev->config;
-	struct can_mcan_reg *can = cfg->can;
+	const struct can_mcan_config *config = dev->config;
+	struct can_mcan_reg *can = config->can;
 	int64_t start_time;
 
 	can->cccr |= CAN_MCAN_CCCR_INIT;
@@ -87,8 +87,8 @@ static int can_mcan_enter_init_mode(const struct device *dev, k_timeout_t timeou
 
 static int can_mcan_leave_init_mode(const struct device *dev, k_timeout_t timeout)
 {
-	const struct can_mcan_config *cfg = dev->config;
-	struct can_mcan_reg *can = cfg->can;
+	const struct can_mcan_config *config = dev->config;
+	struct can_mcan_reg *can = config->can;
 	int64_t start_time;
 
 	can->cccr &= ~CAN_MCAN_CCCR_INIT;
@@ -105,9 +105,9 @@ static int can_mcan_leave_init_mode(const struct device *dev, k_timeout_t timeou
 
 int can_mcan_set_timing(const struct device *dev, const struct can_timing *timing)
 {
-	const struct can_mcan_config *cfg = dev->config;
+	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
-	struct can_mcan_reg *can = cfg->can;
+	struct can_mcan_reg *can = config->can;
 	uint32_t nbtp_sjw = can->nbtp & CAN_MCAN_NBTP_NSJW_MSK;
 
 	if (data->started) {
@@ -137,9 +137,9 @@ int can_mcan_set_timing(const struct device *dev, const struct can_timing *timin
 #ifdef CONFIG_CAN_FD_MODE
 int can_mcan_set_timing_data(const struct device *dev, const struct can_timing *timing_data)
 {
-	const struct can_mcan_config *cfg = dev->config;
+	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
-	struct can_mcan_reg *can = cfg->can;
+	struct can_mcan_reg *can = config->can;
 	uint32_t dbtp_sjw = can->dbtp & CAN_MCAN_DBTP_DSJW_MSK;
 
 	if (data->started) {
@@ -182,7 +182,7 @@ int can_mcan_get_capabilities(const struct device *dev, can_mode_t *cap)
 
 int can_mcan_start(const struct device *dev)
 {
-	const struct can_mcan_config *cfg = dev->config;
+	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
 	int ret;
 
@@ -190,8 +190,8 @@ int can_mcan_start(const struct device *dev)
 		return -EALREADY;
 	}
 
-	if (cfg->phy != NULL) {
-		ret = can_transceiver_enable(cfg->phy);
+	if (config->phy != NULL) {
+		ret = can_transceiver_enable(config->phy);
 		if (ret != 0) {
 			LOG_ERR("failed to enable CAN transceiver (err %d)", ret);
 			return ret;
@@ -202,9 +202,9 @@ int can_mcan_start(const struct device *dev)
 	if (ret) {
 		LOG_ERR("failed to leave init mode");
 
-		if (cfg->phy != NULL) {
+		if (config->phy != NULL) {
 			/* Attempt to disable the CAN transceiver in case of error */
-			(void)can_transceiver_disable(cfg->phy);
+			(void)can_transceiver_disable(config->phy);
 		}
 
 		return -EIO;
@@ -217,7 +217,7 @@ int can_mcan_start(const struct device *dev)
 
 int can_mcan_stop(const struct device *dev)
 {
-	const struct can_mcan_config *cfg = dev->config;
+	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
 	can_tx_callback_t tx_cb;
 	uint32_t tx_idx;
@@ -234,8 +234,8 @@ int can_mcan_stop(const struct device *dev)
 		return -EIO;
 	}
 
-	if (cfg->phy != NULL) {
-		ret = can_transceiver_disable(cfg->phy);
+	if (config->phy != NULL) {
+		ret = can_transceiver_disable(config->phy);
 		if (ret != 0) {
 			LOG_ERR("failed to disable CAN transceiver (err %d)", ret);
 			return ret;
@@ -261,9 +261,9 @@ int can_mcan_stop(const struct device *dev)
 
 int can_mcan_set_mode(const struct device *dev, can_mode_t mode)
 {
-	const struct can_mcan_config *cfg = dev->config;
+	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
-	struct can_mcan_reg *can = cfg->can;
+	struct can_mcan_reg *can = config->can;
 
 #ifdef CONFIG_CAN_FD_MODE
 	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY | CAN_MODE_FD)) != 0) {
@@ -324,9 +324,9 @@ static void can_mcan_state_change_handler(const struct device *dev)
 
 static void can_mcan_tc_event_handler(const struct device *dev)
 {
-	const struct can_mcan_config *cfg = dev->config;
+	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
-	struct can_mcan_reg *can = cfg->can;
+	struct can_mcan_reg *can = config->can;
 	struct can_mcan_msg_sram *msg_ram = data->msg_ram;
 	volatile struct can_mcan_tx_event_fifo *tx_event;
 	can_tx_callback_t tx_cb;
@@ -351,9 +351,9 @@ static void can_mcan_tc_event_handler(const struct device *dev)
 
 void can_mcan_line_0_isr(const struct device *dev)
 {
-	const struct can_mcan_config *cfg = dev->config;
+	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
-	struct can_mcan_reg *can = cfg->can;
+	struct can_mcan_reg *can = config->can;
 
 	do {
 		if (can->ir & (CAN_MCAN_IR_BO | CAN_MCAN_IR_EP | CAN_MCAN_IR_EW)) {
@@ -489,9 +489,9 @@ static void can_mcan_get_message(const struct device *dev, volatile struct can_m
 
 void can_mcan_line_1_isr(const struct device *dev)
 {
-	const struct can_mcan_config *cfg = dev->config;
+	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
-	struct can_mcan_reg *can = cfg->can;
+	struct can_mcan_reg *can = config->can;
 	struct can_mcan_msg_sram *msg_ram = data->msg_ram;
 
 	do {
@@ -524,9 +524,9 @@ void can_mcan_line_1_isr(const struct device *dev)
 int can_mcan_get_state(const struct device *dev, enum can_state *state,
 		       struct can_bus_err_cnt *err_cnt)
 {
-	const struct can_mcan_config *cfg = dev->config;
+	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
-	struct can_mcan_reg *can = cfg->can;
+	struct can_mcan_reg *can = config->can;
 
 	if (state != NULL) {
 		if (!data->started) {
@@ -567,9 +567,9 @@ int can_mcan_recover(const struct device *dev, k_timeout_t timeout)
 int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_timeout_t timeout,
 		  can_tx_callback_t callback, void *user_data)
 {
-	const struct can_mcan_config *cfg = dev->config;
+	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
-	struct can_mcan_reg *can = cfg->can;
+	struct can_mcan_reg *can = config->can;
 	struct can_mcan_msg_sram *msg_ram = data->msg_ram;
 	size_t data_length = can_dlc_to_bytes(frame->dlc);
 	struct can_mcan_tx_buffer_hdr tx_hdr = {
@@ -900,9 +900,9 @@ void can_mcan_set_state_change_callback(const struct device *dev,
 
 int can_mcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
-	const struct can_mcan_config *cfg = dev->config;
+	const struct can_mcan_config *config = dev->config;
 
-	*max_bitrate = cfg->max_bitrate;
+	*max_bitrate = config->max_bitrate;
 
 	return 0;
 }
@@ -913,17 +913,17 @@ int can_mcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
  */
 void can_mcan_enable_configuration_change(const struct device *dev)
 {
-	const struct can_mcan_config *cfg = dev->config;
-	struct can_mcan_reg *can = cfg->can;
+	const struct can_mcan_config *config = dev->config;
+	struct can_mcan_reg *can = config->can;
 
 	can->cccr |= CAN_MCAN_CCCR_CCE;
 }
 
 int can_mcan_init(const struct device *dev)
 {
-	const struct can_mcan_config *cfg = dev->config;
+	const struct can_mcan_config *config = dev->config;
 	struct can_mcan_data *data = dev->data;
-	struct can_mcan_reg *can = cfg->can;
+	struct can_mcan_reg *can = config->can;
 	struct can_mcan_msg_sram *msg_ram = data->msg_ram;
 	struct can_timing timing;
 #ifdef CONFIG_CAN_FD_MODE
@@ -935,8 +935,8 @@ int can_mcan_init(const struct device *dev)
 	k_mutex_init(&data->tx_mtx);
 	k_sem_init(&data->tx_sem, NUM_TX_BUF_ELEMENTS, NUM_TX_BUF_ELEMENTS);
 
-	if (cfg->phy != NULL) {
-		if (!device_is_ready(cfg->phy)) {
+	if (config->phy != NULL) {
+		if (!device_is_ready(config->phy)) {
 			LOG_ERR("CAN transceiver not ready");
 			return -ENODEV;
 		}
@@ -1013,7 +1013,7 @@ int can_mcan_init(const struct device *dev)
 
 #if defined(CONFIG_CAN_DELAY_COMP) && defined(CONFIG_CAN_FD_MODE)
 	can->dbtp |= CAN_MCAN_DBTP_TDC;
-	can->tdcr |= cfg->tx_delay_comp_offset << CAN_MCAN_TDCR_TDCO_POS;
+	can->tdcr |= config->tx_delay_comp_offset << CAN_MCAN_TDCR_TDCO_POS;
 
 #endif
 
@@ -1025,8 +1025,8 @@ int can_mcan_init(const struct device *dev)
 	can->gfc |= (0x2 << CAN_MCAN_GFC_ANFE_POS) | (0x2 << CAN_MCAN_GFC_ANFS_POS);
 #endif /* CONFIG_CAN_STM32FD */
 
-	if (cfg->sample_point) {
-		ret = can_calc_timing(dev, &timing, cfg->bus_speed, cfg->sample_point);
+	if (config->sample_point) {
+		ret = can_calc_timing(dev, &timing, config->bus_speed, config->sample_point);
 		if (ret == -EINVAL) {
 			LOG_ERR("Can't find timing for given param");
 			return -EIO;
@@ -1034,41 +1034,41 @@ int can_mcan_init(const struct device *dev)
 		LOG_DBG("Presc: %d, TS1: %d, TS2: %d", timing.prescaler, timing.phase_seg1,
 			timing.phase_seg2);
 		LOG_DBG("Sample-point err : %d", ret);
-	} else if (cfg->prop_ts1) {
+	} else if (config->prop_ts1) {
 		timing.prop_seg = 0;
-		timing.phase_seg1 = cfg->prop_ts1;
-		timing.phase_seg2 = cfg->ts2;
-		ret = can_calc_prescaler(dev, &timing, cfg->bus_speed);
+		timing.phase_seg1 = config->prop_ts1;
+		timing.phase_seg2 = config->ts2;
+		ret = can_calc_prescaler(dev, &timing, config->bus_speed);
 		if (ret) {
 			LOG_WRN("Bitrate error: %d", ret);
 		}
 	}
 #ifdef CONFIG_CAN_FD_MODE
-	if (cfg->sample_point_data) {
-		ret = can_calc_timing_data(dev, &timing_data, cfg->bus_speed_data,
-					   cfg->sample_point_data);
+	if (config->sample_point_data) {
+		ret = can_calc_timing_data(dev, &timing_data, config->bus_speed_data,
+					   config->sample_point_data);
 		if (ret == -EINVAL) {
 			LOG_ERR("Can't find timing for given dataphase param");
 			return -EIO;
 		}
 
 		LOG_DBG("Sample-point err data phase: %d", ret);
-	} else if (cfg->prop_ts1_data) {
+	} else if (config->prop_ts1_data) {
 		timing_data.prop_seg = 0;
-		timing_data.phase_seg1 = cfg->prop_ts1_data;
-		timing_data.phase_seg2 = cfg->ts2_data;
-		ret = can_calc_prescaler(dev, &timing_data, cfg->bus_speed_data);
+		timing_data.phase_seg1 = config->prop_ts1_data;
+		timing_data.phase_seg2 = config->ts2_data;
+		ret = can_calc_prescaler(dev, &timing_data, config->bus_speed_data);
 		if (ret) {
 			LOG_WRN("Dataphase bitrate error: %d", ret);
 		}
 	}
 #endif
 
-	timing.sjw = cfg->sjw;
+	timing.sjw = config->sjw;
 	can_mcan_set_timing(dev, &timing);
 
 #ifdef CONFIG_CAN_FD_MODE
-	timing_data.sjw = cfg->sjw_data;
+	timing_data.sjw = config->sjw_data;
 	can_mcan_set_timing_data(dev, &timing_data);
 #endif
 

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -103,72 +103,33 @@ static int can_mcan_leave_init_mode(const struct device *dev, k_timeout_t timeou
 	return 0;
 }
 
-void can_mcan_configure_timing(const struct device *dev, const struct can_timing *timing,
-			       const struct can_timing *timing_data)
-{
-	const struct can_mcan_config *cfg = dev->config;
-	struct can_mcan_reg *can = cfg->can;
-
-	if (timing) {
-		uint32_t nbtp_sjw = can->nbtp & CAN_MCAN_NBTP_NSJW_MSK;
-
-		__ASSERT_NO_MSG(timing->prop_seg == 0);
-		__ASSERT_NO_MSG(timing->phase_seg1 <= 0x100 && timing->phase_seg1 > 0);
-		__ASSERT_NO_MSG(timing->phase_seg2 <= 0x80 && timing->phase_seg2 > 0);
-		__ASSERT_NO_MSG(timing->prescaler <= 0x200 && timing->prescaler > 0);
-		__ASSERT_NO_MSG(timing->sjw == CAN_SJW_NO_CHANGE ||
-				(timing->sjw <= 0x80 && timing->sjw > 0));
-
-		can->nbtp =
-			(((uint32_t)timing->phase_seg1 - 1UL) & 0xFF) << CAN_MCAN_NBTP_NTSEG1_POS |
-			(((uint32_t)timing->phase_seg2 - 1UL) & 0x7F) << CAN_MCAN_NBTP_NTSEG2_POS |
-			(((uint32_t)timing->prescaler - 1UL) & 0x1FF) << CAN_MCAN_NBTP_NBRP_POS;
-
-		if (timing->sjw == CAN_SJW_NO_CHANGE) {
-			can->nbtp |= nbtp_sjw;
-		} else {
-			can->nbtp |= (((uint32_t)timing->sjw - 1UL) & 0x7F)
-				     << CAN_MCAN_NBTP_NSJW_POS;
-		}
-	}
-
-#ifdef CONFIG_CAN_FD_MODE
-	if (timing_data) {
-		uint32_t dbtp_sjw = can->dbtp & CAN_MCAN_DBTP_DSJW_MSK;
-
-		__ASSERT_NO_MSG(timing_data->prop_seg == 0);
-		__ASSERT_NO_MSG(timing_data->phase_seg1 <= 0x20 && timing_data->phase_seg1 > 0);
-		__ASSERT_NO_MSG(timing_data->phase_seg2 <= 0x10 && timing_data->phase_seg2 > 0);
-		__ASSERT_NO_MSG(timing_data->prescaler <= 0x20 && timing_data->prescaler > 0);
-		__ASSERT_NO_MSG(timing_data->sjw == CAN_SJW_NO_CHANGE ||
-				(timing_data->sjw <= 0x80 && timing_data->sjw > 0));
-
-		can->dbtp = (((uint32_t)timing_data->phase_seg1 - 1UL) & 0x1F)
-				    << CAN_MCAN_DBTP_DTSEG1_POS |
-			    (((uint32_t)timing_data->phase_seg2 - 1UL) & 0x0F)
-				    << CAN_MCAN_DBTP_DTSEG2_POS |
-			    (((uint32_t)timing_data->prescaler - 1UL) & 0x1F)
-				    << CAN_MCAN_DBTP_DBRP_POS;
-
-		if (timing_data->sjw == CAN_SJW_NO_CHANGE) {
-			can->dbtp |= dbtp_sjw;
-		} else {
-			can->dbtp |= (((uint32_t)timing_data->sjw - 1UL) & 0x0F)
-				     << CAN_MCAN_DBTP_DSJW_POS;
-		}
-	}
-#endif
-}
-
 int can_mcan_set_timing(const struct device *dev, const struct can_timing *timing)
 {
+	const struct can_mcan_config *cfg = dev->config;
 	struct can_mcan_data *data = dev->data;
+	struct can_mcan_reg *can = cfg->can;
+	uint32_t nbtp_sjw = can->nbtp & CAN_MCAN_NBTP_NSJW_MSK;
 
 	if (data->started) {
 		return -EBUSY;
 	}
 
-	can_mcan_configure_timing(dev, timing, NULL);
+	__ASSERT_NO_MSG(timing->prop_seg == 0);
+	__ASSERT_NO_MSG(timing->phase_seg1 <= 0x100 && timing->phase_seg1 > 0);
+	__ASSERT_NO_MSG(timing->phase_seg2 <= 0x80 && timing->phase_seg2 > 0);
+	__ASSERT_NO_MSG(timing->prescaler <= 0x200 && timing->prescaler > 0);
+	__ASSERT_NO_MSG(timing->sjw == CAN_SJW_NO_CHANGE ||
+			(timing->sjw <= 0x80 && timing->sjw > 0));
+
+	can->nbtp = (((uint32_t)timing->phase_seg1 - 1UL) & 0xFF) << CAN_MCAN_NBTP_NTSEG1_POS |
+		    (((uint32_t)timing->phase_seg2 - 1UL) & 0x7F) << CAN_MCAN_NBTP_NTSEG2_POS |
+		    (((uint32_t)timing->prescaler - 1UL) & 0x1FF) << CAN_MCAN_NBTP_NBRP_POS;
+
+	if (timing->sjw == CAN_SJW_NO_CHANGE) {
+		can->nbtp |= nbtp_sjw;
+	} else {
+		can->nbtp |= (((uint32_t)timing->sjw - 1UL) & 0x7F) << CAN_MCAN_NBTP_NSJW_POS;
+	}
 
 	return 0;
 }
@@ -176,13 +137,31 @@ int can_mcan_set_timing(const struct device *dev, const struct can_timing *timin
 #ifdef CONFIG_CAN_FD_MODE
 int can_mcan_set_timing_data(const struct device *dev, const struct can_timing *timing_data)
 {
+	const struct can_mcan_config *cfg = dev->config;
 	struct can_mcan_data *data = dev->data;
+	struct can_mcan_reg *can = cfg->can;
+	uint32_t dbtp_sjw = can->dbtp & CAN_MCAN_DBTP_DSJW_MSK;
 
 	if (data->started) {
 		return -EBUSY;
 	}
 
-	can_mcan_configure_timing(dev, NULL, timing_data);
+	__ASSERT_NO_MSG(timing_data->prop_seg == 0);
+	__ASSERT_NO_MSG(timing_data->phase_seg1 <= 0x20 && timing_data->phase_seg1 > 0);
+	__ASSERT_NO_MSG(timing_data->phase_seg2 <= 0x10 && timing_data->phase_seg2 > 0);
+	__ASSERT_NO_MSG(timing_data->prescaler <= 0x20 && timing_data->prescaler > 0);
+	__ASSERT_NO_MSG(timing_data->sjw == CAN_SJW_NO_CHANGE ||
+			(timing_data->sjw <= 0x80 && timing_data->sjw > 0));
+
+	can->dbtp = (((uint32_t)timing_data->phase_seg1 - 1UL) & 0x1F) << CAN_MCAN_DBTP_DTSEG1_POS |
+		    (((uint32_t)timing_data->phase_seg2 - 1UL) & 0x0F) << CAN_MCAN_DBTP_DTSEG2_POS |
+		    (((uint32_t)timing_data->prescaler - 1UL) & 0x1F) << CAN_MCAN_DBTP_DBRP_POS;
+
+	if (timing_data->sjw == CAN_SJW_NO_CHANGE) {
+		can->dbtp |= dbtp_sjw;
+	} else {
+		can->dbtp |= (((uint32_t)timing_data->sjw - 1UL) & 0x0F) << CAN_MCAN_DBTP_DSJW_POS;
+	}
 
 	return 0;
 }
@@ -1086,11 +1065,11 @@ int can_mcan_init(const struct device *dev)
 #endif
 
 	timing.sjw = cfg->sjw;
+	can_mcan_set_timing(dev, &timing);
+
 #ifdef CONFIG_CAN_FD_MODE
 	timing_data.sjw = cfg->sjw_data;
-	can_mcan_configure_timing(dev, &timing, &timing_data);
-#else
-	can_mcan_configure_timing(dev, &timing, NULL);
+	can_mcan_set_timing_data(dev, &timing_data);
 #endif
 
 	can->ie = CAN_MCAN_IE_BO | CAN_MCAN_IE_EW | CAN_MCAN_IE_EP | CAN_MCAN_IE_MRAF |

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -8,12 +8,9 @@
 #ifndef ZEPHYR_DRIVERS_CAN_MCAN_H_
 #define ZEPHYR_DRIVERS_CAN_MCAN_H_
 
-#include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/can.h>
-
-#include <zephyr/toolchain.h>
-#include <stdint.h>
+#include <zephyr/kernel.h>
 
 #ifdef CONFIG_CAN_MCUX_MCAN
 #define MCAN_DT_PATH DT_NODELABEL(can0)

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -23,10 +23,10 @@
 
 #define NUM_STD_FILTER_ELEMENTS DT_PROP(MCAN_DT_PATH, std_filter_elements)
 #define NUM_EXT_FILTER_ELEMENTS DT_PROP(MCAN_DT_PATH, ext_filter_elements)
-#define NUM_RX_FIFO0_ELEMENTS   DT_PROP(MCAN_DT_PATH, rx_fifo0_elements)
-#define NUM_RX_FIFO1_ELEMENTS   DT_PROP(MCAN_DT_PATH, rx_fifo0_elements)
-#define NUM_RX_BUF_ELEMENTS     DT_PROP(MCAN_DT_PATH, rx_buffer_elements)
-#define NUM_TX_BUF_ELEMENTS     DT_PROP(MCAN_DT_PATH, tx_buffer_elements)
+#define NUM_RX_FIFO0_ELEMENTS	DT_PROP(MCAN_DT_PATH, rx_fifo0_elements)
+#define NUM_RX_FIFO1_ELEMENTS	DT_PROP(MCAN_DT_PATH, rx_fifo0_elements)
+#define NUM_RX_BUF_ELEMENTS	DT_PROP(MCAN_DT_PATH, rx_buffer_elements)
+#define NUM_TX_BUF_ELEMENTS	DT_PROP(MCAN_DT_PATH, tx_buffer_elements)
 
 #ifdef CONFIG_CAN_STM32FD
 #define NUM_STD_FILTER_DATA CONFIG_CAN_MAX_STD_ID_FILTER
@@ -39,120 +39,120 @@
 struct can_mcan_rx_fifo_hdr {
 	union {
 		struct {
-			volatile uint32_t ext_id : 29; /* Extended Identifier */
-			volatile uint32_t rtr    :  1; /* Remote Transmission Request*/
-			volatile uint32_t xtd    :  1; /* Extended identifier */
-			volatile uint32_t esi    :  1; /* Error state indicator */
+			volatile uint32_t ext_id: 29; /* Extended Identifier */
+			volatile uint32_t rtr: 1;     /* Remote Transmission Request*/
+			volatile uint32_t xtd: 1;     /* Extended identifier */
+			volatile uint32_t esi: 1;     /* Error state indicator */
 		};
 		struct {
-			volatile uint32_t pad1   : 18;
-			volatile uint32_t std_id : 11; /* Standard Identifier */
-			volatile uint32_t pad2   : 3;
+			volatile uint32_t pad1: 18;
+			volatile uint32_t std_id: 11; /* Standard Identifier */
+			volatile uint32_t pad2: 3;
 		};
 	};
 
-	volatile uint32_t rxts : 16; /* Rx timestamp */
-	volatile uint32_t dlc  :  4; /* Data Length Code */
-	volatile uint32_t brs  :  1; /* Bit Rate Switch */
-	volatile uint32_t fdf  :  1; /* FD Format */
-	volatile uint32_t res  :  2; /* Reserved */
-	volatile uint32_t fidx :  7; /* Filter Index */
-	volatile uint32_t anmf :  1; /* Accepted non-matching frame */
+	volatile uint32_t rxts: 16; /* Rx timestamp */
+	volatile uint32_t dlc: 4;   /* Data Length Code */
+	volatile uint32_t brs: 1;   /* Bit Rate Switch */
+	volatile uint32_t fdf: 1;   /* FD Format */
+	volatile uint32_t res: 2;   /* Reserved */
+	volatile uint32_t fidx: 7;  /* Filter Index */
+	volatile uint32_t anmf: 1;  /* Accepted non-matching frame */
 } __packed __aligned(4);
 
 struct can_mcan_rx_fifo {
 	struct can_mcan_rx_fifo_hdr hdr;
 	union {
-		volatile uint8_t  data[64];
+		volatile uint8_t data[64];
 		volatile uint32_t data_32[16];
 	};
 } __packed __aligned(4);
 
 struct can_mcan_mm {
-	volatile uint8_t idx : 5;
-	volatile uint8_t cnt : 3;
+	volatile uint8_t idx: 5;
+	volatile uint8_t cnt: 3;
 } __packed;
 
 struct can_mcan_tx_buffer_hdr {
 	union {
 		struct {
-			volatile uint32_t ext_id : 29; /* Identifier */
-			volatile uint32_t rtr    :  1; /* Remote Transmission Request*/
-			volatile uint32_t xtd    :  1; /* Extended identifier */
-			volatile uint32_t esi    :  1; /* Error state indicator */
+			volatile uint32_t ext_id: 29; /* Identifier */
+			volatile uint32_t rtr: 1;     /* Remote Transmission Request*/
+			volatile uint32_t xtd: 1;     /* Extended identifier */
+			volatile uint32_t esi: 1;     /* Error state indicator */
 		};
 		struct {
-			volatile uint32_t pad1   : 18;
-			volatile uint32_t std_id : 11; /* Identifier */
-			volatile uint32_t pad2   :  3;
+			volatile uint32_t pad1: 18;
+			volatile uint32_t std_id: 11; /* Identifier */
+			volatile uint32_t pad2: 3;
 		};
 	};
-	volatile uint16_t res1;      /* Reserved */
-	volatile uint8_t dlc  :  4; /* Data Length Code */
-	volatile uint8_t brs  :  1; /* Bit Rate Switch */
-	volatile uint8_t fdf  :  1; /* FD Format */
-	volatile uint8_t res2 :  1; /* Reserved */
-	volatile uint8_t efc  :  1; /* Event FIFO control (Store Tx events) */
-	struct can_mcan_mm mm; /* Message marker */
+	volatile uint16_t res1;	  /* Reserved */
+	volatile uint8_t dlc: 4;  /* Data Length Code */
+	volatile uint8_t brs: 1;  /* Bit Rate Switch */
+	volatile uint8_t fdf: 1;  /* FD Format */
+	volatile uint8_t res2: 1; /* Reserved */
+	volatile uint8_t efc: 1;  /* Event FIFO control (Store Tx events) */
+	struct can_mcan_mm mm;	  /* Message marker */
 } __packed __aligned(4);
 
 struct can_mcan_tx_buffer {
 	struct can_mcan_tx_buffer_hdr hdr;
 	union {
-		volatile uint8_t  data[64];
+		volatile uint8_t data[64];
 		volatile uint32_t data_32[16];
 	};
 } __packed __aligned(4);
 
-#define CAN_MCAN_TE_TX    0x1 /* TX event */
-#define CAN_MCAN_TE_TXC   0x2 /* TX event in spite of cancellation */
+#define CAN_MCAN_TE_TX	0x1 /* TX event */
+#define CAN_MCAN_TE_TXC 0x2 /* TX event in spite of cancellation */
 
 struct can_mcan_tx_event_fifo {
-	volatile uint32_t id   : 29; /* Identifier */
-	volatile uint32_t rtr  :  1; /* Remote Transmission Request*/
-	volatile uint32_t xtd  :  1; /* Extended identifier */
-	volatile uint32_t esi  :  1; /* Error state indicator */
+	volatile uint32_t id: 29; /* Identifier */
+	volatile uint32_t rtr: 1; /* Remote Transmission Request*/
+	volatile uint32_t xtd: 1; /* Extended identifier */
+	volatile uint32_t esi: 1; /* Error state indicator */
 
-	volatile uint16_t txts;      /* TX Timestamp */
-	volatile uint8_t dlc   :  4; /* Data Length Code */
-	volatile uint8_t brs   :  1; /* Bit Rate Switch */
-	volatile uint8_t fdf   :  1; /* FD Format */
-	volatile uint8_t et    :  2; /* Event type */
-	struct can_mcan_mm mm; /* Message marker */
+	volatile uint16_t txts;	 /* TX Timestamp */
+	volatile uint8_t dlc: 4; /* Data Length Code */
+	volatile uint8_t brs: 1; /* Bit Rate Switch */
+	volatile uint8_t fdf: 1; /* FD Format */
+	volatile uint8_t et: 2;	 /* Event type */
+	struct can_mcan_mm mm;	 /* Message marker */
 } __packed __aligned(4);
 
-#define CAN_MCAN_FCE_DISABLE    0x0
-#define CAN_MCAN_FCE_FIFO0      0x1
-#define CAN_MCAN_FCE_FIFO1      0x2
-#define CAN_MCAN_FCE_REJECT     0x3
-#define CAN_MCAN_FCE_PRIO       0x4
+#define CAN_MCAN_FCE_DISABLE	0x0
+#define CAN_MCAN_FCE_FIFO0	0x1
+#define CAN_MCAN_FCE_FIFO1	0x2
+#define CAN_MCAN_FCE_REJECT	0x3
+#define CAN_MCAN_FCE_PRIO	0x4
 #define CAN_MCAN_FCE_PRIO_FIFO0 0x5
 #define CAN_MCAN_FCE_PRIO_FIFO1 0x7
 
-#define CAN_MCAN_SFT_RANGE       0x0
-#define CAN_MCAN_SFT_DUAL        0x1
-#define CAN_MCAN_SFT_MASKED      0x2
-#define CAN_MCAN_SFT_DISABLED    0x3
+#define CAN_MCAN_SFT_RANGE    0x0
+#define CAN_MCAN_SFT_DUAL     0x1
+#define CAN_MCAN_SFT_MASKED   0x2
+#define CAN_MCAN_SFT_DISABLED 0x3
 
 struct can_mcan_std_filter {
-	volatile uint32_t id2  : 11; /* ID2 for dual or range, mask otherwise */
-	volatile uint32_t res  :  5;
-	volatile uint32_t id1  : 11;
-	volatile uint32_t sfce :  3; /* Filter config */
-	volatile uint32_t sft  :  2; /* Filter type */
+	volatile uint32_t id2: 11; /* ID2 for dual or range, mask otherwise */
+	volatile uint32_t res: 5;
+	volatile uint32_t id1: 11;
+	volatile uint32_t sfce: 3; /* Filter config */
+	volatile uint32_t sft: 2;  /* Filter type */
 } __packed __aligned(4);
 
 #define CAN_MCAN_EFT_RANGE_XIDAM 0x0
-#define CAN_MCAN_EFT_DUAL        0x1
-#define CAN_MCAN_EFT_MASKED      0x2
-#define CAN_MCAN_EFT_RANGE       0x3
+#define CAN_MCAN_EFT_DUAL	 0x1
+#define CAN_MCAN_EFT_MASKED	 0x2
+#define CAN_MCAN_EFT_RANGE	 0x3
 
 struct can_mcan_ext_filter {
-	volatile uint32_t id1  : 29;
-	volatile uint32_t efce :  3; /* Filter config */
-	volatile uint32_t id2  : 29; /* ID2 for dual or range, mask otherwise */
-	volatile uint32_t res  :  1;
-	volatile uint32_t eft   : 2; /* Filter type */
+	volatile uint32_t id1: 29;
+	volatile uint32_t efce: 3; /* Filter config */
+	volatile uint32_t id2: 29; /* ID2 for dual or range, mask otherwise */
+	volatile uint32_t res: 1;
+	volatile uint32_t eft: 2; /* Filter type */
 } __packed __aligned(4);
 
 struct can_mcan_msg_sram {
@@ -190,7 +190,7 @@ struct can_mcan_data {
 } __aligned(4);
 
 struct can_mcan_config {
-	struct can_mcan_reg *can;   /*!< CAN Registers*/
+	struct can_mcan_reg *can; /*!< CAN Registers*/
 	uint32_t bus_speed;
 	uint32_t bus_speed_data;
 	uint16_t sjw;
@@ -212,51 +212,44 @@ struct can_mcan_config {
 struct can_mcan_reg;
 
 #ifdef CONFIG_CAN_FD_MODE
-#define CAN_MCAN_DT_CONFIG_GET(node_id, _custom_config)				\
-	{									\
-		.can = (struct can_mcan_reg *)DT_REG_ADDR_BY_NAME(node_id, m_can), \
-		.bus_speed = DT_PROP(node_id, bus_speed),			\
-		.sjw = DT_PROP(node_id, sjw),					\
-		.sample_point = DT_PROP_OR(node_id, sample_point, 0),		\
-		.prop_ts1 = DT_PROP_OR(node_id, prop_seg, 0) +			\
-			DT_PROP_OR(node_id, phase_seg1, 0),			\
-		.ts2 = DT_PROP_OR(node_id, phase_seg2, 0),			\
-		.bus_speed_data = DT_PROP(node_id, bus_speed_data),		\
-		.sjw_data = DT_PROP(node_id, sjw_data),				\
-		.sample_point_data =						\
-			DT_PROP_OR(node_id, sample_point_data, 0),		\
-		.prop_ts1_data = DT_PROP_OR(node_id, prop_seg_data, 0) +	\
-			DT_PROP_OR(node_id, phase_seg1_data, 0),		\
-		.ts2_data = DT_PROP_OR(node_id, phase_seg2_data, 0),		\
-		.tx_delay_comp_offset =						\
-			DT_PROP(node_id, tx_delay_comp_offset),			\
-		.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, phys)),	\
-		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, 8000000),\
-		.custom = _custom_config,					\
+#define CAN_MCAN_DT_CONFIG_GET(node_id, _custom_config)                                            \
+	{                                                                                          \
+		.can = (struct can_mcan_reg *)DT_REG_ADDR_BY_NAME(node_id, m_can),                 \
+		.bus_speed = DT_PROP(node_id, bus_speed), .sjw = DT_PROP(node_id, sjw),            \
+		.sample_point = DT_PROP_OR(node_id, sample_point, 0),                              \
+		.prop_ts1 = DT_PROP_OR(node_id, prop_seg, 0) + DT_PROP_OR(node_id, phase_seg1, 0), \
+		.ts2 = DT_PROP_OR(node_id, phase_seg2, 0),                                         \
+		.bus_speed_data = DT_PROP(node_id, bus_speed_data),                                \
+		.sjw_data = DT_PROP(node_id, sjw_data),                                            \
+		.sample_point_data = DT_PROP_OR(node_id, sample_point_data, 0),                    \
+		.prop_ts1_data = DT_PROP_OR(node_id, prop_seg_data, 0) +                           \
+				 DT_PROP_OR(node_id, phase_seg1_data, 0),                          \
+		.ts2_data = DT_PROP_OR(node_id, phase_seg2_data, 0),                               \
+		.tx_delay_comp_offset = DT_PROP(node_id, tx_delay_comp_offset),                    \
+		.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, phys)),                           \
+		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, 8000000),                   \
+		.custom = _custom_config,                                                          \
 	}
 #else /* CONFIG_CAN_FD_MODE */
-#define CAN_MCAN_DT_CONFIG_GET(node_id, _custom_config)				\
-	{									\
-		.can = (struct can_mcan_reg *)DT_REG_ADDR_BY_NAME(node_id, m_can), \
-		.bus_speed = DT_PROP(node_id, bus_speed),			\
-		.sjw = DT_PROP(node_id, sjw),					\
-		.sample_point = DT_PROP_OR(node_id, sample_point, 0),		\
-		.prop_ts1 = DT_PROP_OR(node_id, prop_seg, 0) +			\
-			DT_PROP_OR(node_id, phase_seg1, 0),			\
-		.ts2 = DT_PROP_OR(node_id, phase_seg2, 0),			\
-		.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, phys)),	\
-		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, 1000000),\
-		.custom = _custom_config,					\
+#define CAN_MCAN_DT_CONFIG_GET(node_id, _custom_config)                                            \
+	{                                                                                          \
+		.can = (struct can_mcan_reg *)DT_REG_ADDR_BY_NAME(node_id, m_can),                 \
+		.bus_speed = DT_PROP(node_id, bus_speed), .sjw = DT_PROP(node_id, sjw),            \
+		.sample_point = DT_PROP_OR(node_id, sample_point, 0),                              \
+		.prop_ts1 = DT_PROP_OR(node_id, prop_seg, 0) + DT_PROP_OR(node_id, phase_seg1, 0), \
+		.ts2 = DT_PROP_OR(node_id, phase_seg2, 0),                                         \
+		.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, phys)),                           \
+		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, 1000000),                   \
+		.custom = _custom_config,                                                          \
 	}
 #endif /* !CONFIG_CAN_FD_MODE */
 
-#define CAN_MCAN_DT_CONFIG_INST_GET(inst, _custom_config)		\
+#define CAN_MCAN_DT_CONFIG_INST_GET(inst, _custom_config)                                          \
 	CAN_MCAN_DT_CONFIG_GET(DT_DRV_INST(inst), _custom_config)
 
-#define CAN_MCAN_DATA_INITIALIZER(_msg_ram, _custom_data)		\
-	{								\
-		.msg_ram = _msg_ram,					\
-		.custom = _custom_data,					\
+#define CAN_MCAN_DATA_INITIALIZER(_msg_ram, _custom_data)                                          \
+	{                                                                                          \
+		.msg_ram = _msg_ram, .custom = _custom_data,                                       \
 	}
 
 int can_mcan_get_capabilities(const struct device *dev, can_mode_t *cap);
@@ -267,11 +260,9 @@ int can_mcan_stop(const struct device *dev);
 
 int can_mcan_set_mode(const struct device *dev, can_mode_t mode);
 
-int can_mcan_set_timing(const struct device *dev,
-			const struct can_timing *timing);
+int can_mcan_set_timing(const struct device *dev, const struct can_timing *timing);
 
-int can_mcan_set_timing_data(const struct device *dev,
-			     const struct can_timing *timing_data);
+int can_mcan_set_timing_data(const struct device *dev, const struct can_timing *timing_data);
 
 int can_mcan_init(const struct device *dev);
 
@@ -281,14 +272,12 @@ void can_mcan_line_1_isr(const struct device *dev);
 
 int can_mcan_recover(const struct device *dev, k_timeout_t timeout);
 
-int can_mcan_send(const struct device *dev, const struct can_frame *frame,
-		  k_timeout_t timeout, can_tx_callback_t callback,
-		  void *user_data);
+int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_timeout_t timeout,
+		  can_tx_callback_t callback, void *user_data);
 
 int can_mcan_get_max_filters(const struct device *dev, bool ide);
 
-int can_mcan_add_rx_filter(const struct device *dev,
-			   can_rx_callback_t callback, void *user_data,
+int can_mcan_add_rx_filter(const struct device *dev, can_rx_callback_t callback, void *user_data,
 			   const struct can_filter *filter);
 
 void can_mcan_remove_rx_filter(const struct device *dev, int filter_id);
@@ -297,8 +286,7 @@ int can_mcan_get_state(const struct device *dev, enum can_state *state,
 		       struct can_bus_err_cnt *err_cnt);
 
 void can_mcan_set_state_change_callback(const struct device *dev,
-					can_state_change_callback_t callback,
-					void *user_data);
+					can_state_change_callback_t callback, void *user_data);
 
 int can_mcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate);
 

--- a/drivers/can/can_mcan_priv.h
+++ b/drivers/can/can_mcan_priv.h
@@ -8,8 +8,6 @@
 #ifndef ZEPHYR_DRIVERS_CAN_CAN_MCAN_PRIV_H_
 #define ZEPHYR_DRIVERS_CAN_CAN_MCAN_PRIV_H_
 
-#include <zephyr/drivers/can.h>
-
 /*
  * Register Masks are taken from the stm32cube library and extended for
  * full M_CAN IPs

--- a/drivers/can/can_mcan_priv.h
+++ b/drivers/can/can_mcan_priv.h
@@ -17,1537 +17,1537 @@
  */
 /****************  Bit definition for CAN_MCAN_CREL register  *****************/
 /* Timestamp Day */
-#define CAN_MCAN_CREL_DAY_POS        (0U)
-#define CAN_MCAN_CREL_DAY_MSK        (0xFFUL << CAN_MCAN_CREL_DAY_POS)
-#define CAN_MCAN_CREL_DAY            CAN_MCAN_CREL_DAY_MSK
+#define CAN_MCAN_CREL_DAY_POS	  (0U)
+#define CAN_MCAN_CREL_DAY_MSK	  (0xFFUL << CAN_MCAN_CREL_DAY_POS)
+#define CAN_MCAN_CREL_DAY	  CAN_MCAN_CREL_DAY_MSK
 /* Timestamp Month */
-#define CAN_MCAN_CREL_MON_POS        (8U)
-#define CAN_MCAN_CREL_MON_MSK        (0xFFUL << CAN_MCAN_CREL_MON_POS)
-#define CAN_MCAN_CREL_MON            CAN_MCAN_CREL_MON_MSK
+#define CAN_MCAN_CREL_MON_POS	  (8U)
+#define CAN_MCAN_CREL_MON_MSK	  (0xFFUL << CAN_MCAN_CREL_MON_POS)
+#define CAN_MCAN_CREL_MON	  CAN_MCAN_CREL_MON_MSK
 /* Timestamp Year */
-#define CAN_MCAN_CREL_YEAR_POS       (16U)
-#define CAN_MCAN_CREL_YEAR_MSK       (0xFUL << CAN_MCAN_CREL_YEAR_POS)
-#define CAN_MCAN_CREL_YEAR           CAN_MCAN_CREL_YEAR_MSK
+#define CAN_MCAN_CREL_YEAR_POS	  (16U)
+#define CAN_MCAN_CREL_YEAR_MSK	  (0xFUL << CAN_MCAN_CREL_YEAR_POS)
+#define CAN_MCAN_CREL_YEAR	  CAN_MCAN_CREL_YEAR_MSK
 /* Substep of Core release */
-#define CAN_MCAN_CREL_SUBSTEP_POS    (20U)
-#define CAN_MCAN_CREL_SUBSTEP_MSK    (0xFUL << CAN_MCAN_CREL_SUBSTEP_POS)
-#define CAN_MCAN_CREL_SUBSTEP        CAN_MCAN_CREL_SUBSTEP_MSK
+#define CAN_MCAN_CREL_SUBSTEP_POS (20U)
+#define CAN_MCAN_CREL_SUBSTEP_MSK (0xFUL << CAN_MCAN_CREL_SUBSTEP_POS)
+#define CAN_MCAN_CREL_SUBSTEP	  CAN_MCAN_CREL_SUBSTEP_MSK
 /* Step of Core release */
-#define CAN_MCAN_CREL_STEP_POS       (24U)
-#define CAN_MCAN_CREL_STEP_MSK       (0xFUL << CAN_MCAN_CREL_STEP_POS)
-#define CAN_MCAN_CREL_STEP           CAN_MCAN_CREL_STEP_MSK
+#define CAN_MCAN_CREL_STEP_POS	  (24U)
+#define CAN_MCAN_CREL_STEP_MSK	  (0xFUL << CAN_MCAN_CREL_STEP_POS)
+#define CAN_MCAN_CREL_STEP	  CAN_MCAN_CREL_STEP_MSK
 /* Core release */
-#define CAN_MCAN_CREL_REL_POS        (28U)
-#define CAN_MCAN_CREL_REL_MSK        (0xFUL << CAN_MCAN_CREL_REL_POS)
-#define CAN_MCAN_CREL_REL            CAN_MCAN_CREL_REL_MSK
+#define CAN_MCAN_CREL_REL_POS	  (28U)
+#define CAN_MCAN_CREL_REL_MSK	  (0xFUL << CAN_MCAN_CREL_REL_POS)
+#define CAN_MCAN_CREL_REL	  CAN_MCAN_CREL_REL_MSK
 
 /****************  Bit definition for CAN_MCAN_ENDN register  *****************/
 /* Endianness Test Value */
-#define CAN_MCAN_ENDN_ETV_POS        (0U)
-#define CAN_MCAN_ENDN_ETV_MSK        (0xFFFFFFFFUL << CAN_MCAN_ENDN_ETV_POS)
-#define CAN_MCAN_ENDN_ETV            CAN_MCAN_ENDN_ETV_MSK
+#define CAN_MCAN_ENDN_ETV_POS (0U)
+#define CAN_MCAN_ENDN_ETV_MSK (0xFFFFFFFFUL << CAN_MCAN_ENDN_ETV_POS)
+#define CAN_MCAN_ENDN_ETV     CAN_MCAN_ENDN_ETV_MSK
 
 /***************  Bit definition for CAN_MCAN_DBTP register  ******************/
 /* Synchronization Jump Width */
-#define CAN_MCAN_DBTP_DSJW_POS       (0U)
-#define CAN_MCAN_DBTP_DSJW_MSK       (0xFUL << CAN_MCAN_DBTP_DSJW_POS)
-#define CAN_MCAN_DBTP_DSJW           CAN_MCAN_DBTP_DSJW_MSK
+#define CAN_MCAN_DBTP_DSJW_POS	 (0U)
+#define CAN_MCAN_DBTP_DSJW_MSK	 (0xFUL << CAN_MCAN_DBTP_DSJW_POS)
+#define CAN_MCAN_DBTP_DSJW	 CAN_MCAN_DBTP_DSJW_MSK
 /* Data time segment after sample point */
-#define CAN_MCAN_DBTP_DTSEG2_POS     (4U)
-#define CAN_MCAN_DBTP_DTSEG2_MSK     (0xFUL << CAN_MCAN_DBTP_DTSEG2_POS)
-#define CAN_MCAN_DBTP_DTSEG2         CAN_MCAN_DBTP_DTSEG2_MSK
+#define CAN_MCAN_DBTP_DTSEG2_POS (4U)
+#define CAN_MCAN_DBTP_DTSEG2_MSK (0xFUL << CAN_MCAN_DBTP_DTSEG2_POS)
+#define CAN_MCAN_DBTP_DTSEG2	 CAN_MCAN_DBTP_DTSEG2_MSK
 /* Data time segment before sample point */
-#define CAN_MCAN_DBTP_DTSEG1_POS     (8U)
-#define CAN_MCAN_DBTP_DTSEG1_MSK     (0x1FUL << CAN_MCAN_DBTP_DTSEG1_POS)
-#define CAN_MCAN_DBTP_DTSEG1         CAN_MCAN_DBTP_DTSEG1_MSK
+#define CAN_MCAN_DBTP_DTSEG1_POS (8U)
+#define CAN_MCAN_DBTP_DTSEG1_MSK (0x1FUL << CAN_MCAN_DBTP_DTSEG1_POS)
+#define CAN_MCAN_DBTP_DTSEG1	 CAN_MCAN_DBTP_DTSEG1_MSK
 /* Data BIt Rate Prescaler */
-#define CAN_MCAN_DBTP_DBRP_POS       (16U)
-#define CAN_MCAN_DBTP_DBRP_MSK       (0x1FUL << CAN_MCAN_DBTP_DBRP_POS)
-#define CAN_MCAN_DBTP_DBRP           CAN_MCAN_DBTP_DBRP_MSK
+#define CAN_MCAN_DBTP_DBRP_POS	 (16U)
+#define CAN_MCAN_DBTP_DBRP_MSK	 (0x1FUL << CAN_MCAN_DBTP_DBRP_POS)
+#define CAN_MCAN_DBTP_DBRP	 CAN_MCAN_DBTP_DBRP_MSK
 /* Transceiver Delay Compensation */
-#define CAN_MCAN_DBTP_TDC_POS        (23U)
-#define CAN_MCAN_DBTP_TDC_MSK        (0x1UL << CAN_MCAN_DBTP_TDC_POS)
-#define CAN_MCAN_DBTP_TDC            CAN_MCAN_DBTP_TDC_MSK
+#define CAN_MCAN_DBTP_TDC_POS	 (23U)
+#define CAN_MCAN_DBTP_TDC_MSK	 (0x1UL << CAN_MCAN_DBTP_TDC_POS)
+#define CAN_MCAN_DBTP_TDC	 CAN_MCAN_DBTP_TDC_MSK
 
 /***************  Bit definition for CAN_MCAN_TEST register  *****************/
 /* Loop Back mode */
-#define CAN_MCAN_TEST_LBCK_POS       (4U)
-#define CAN_MCAN_TEST_LBCK_MSK       (0x1UL << CAN_MCAN_TEST_LBCK_POS)
-#define CAN_MCAN_TEST_LBCK           CAN_MCAN_TEST_LBCK_MSK
+#define CAN_MCAN_TEST_LBCK_POS	(4U)
+#define CAN_MCAN_TEST_LBCK_MSK	(0x1UL << CAN_MCAN_TEST_LBCK_POS)
+#define CAN_MCAN_TEST_LBCK	CAN_MCAN_TEST_LBCK_MSK
 /* Control of Transmit Pin */
-#define CAN_MCAN_TEST_TX_POS         (5U)
-#define CAN_MCAN_TEST_TX_MSK         (0x3UL << CAN_MCAN_TEST_TX_POS)
-#define CAN_MCAN_TEST_TX             CAN_MCAN_TEST_TX_MSK
+#define CAN_MCAN_TEST_TX_POS	(5U)
+#define CAN_MCAN_TEST_TX_MSK	(0x3UL << CAN_MCAN_TEST_TX_POS)
+#define CAN_MCAN_TEST_TX	CAN_MCAN_TEST_TX_MSK
 /* Receive Pin */
-#define CAN_MCAN_TEST_RX_POS         (7U)
-#define CAN_MCAN_TEST_RX_MSK         (0x1UL << CAN_MCAN_TEST_RX_POS)
-#define CAN_MCAN_TEST_RX             CAN_MCAN_TEST_RX_MSK
+#define CAN_MCAN_TEST_RX_POS	(7U)
+#define CAN_MCAN_TEST_RX_MSK	(0x1UL << CAN_MCAN_TEST_RX_POS)
+#define CAN_MCAN_TEST_RX	CAN_MCAN_TEST_RX_MSK
 /* Does not exist on STM32 begin */
 /* Tx Buffer Number Prepared */
-#define CAN_MCAN_TEST_TXBNP_POS      (8U)
-#define CAN_MCAN_TEST_TXBNP_MSK      (0x1FUL << CAN_MCAN_TEST_TXBNP_POS)
-#define CAN_MCAN_TEST_TXBNP          CAN_MCAN_TEST_RX_MSK
+#define CAN_MCAN_TEST_TXBNP_POS (8U)
+#define CAN_MCAN_TEST_TXBNP_MSK (0x1FUL << CAN_MCAN_TEST_TXBNP_POS)
+#define CAN_MCAN_TEST_TXBNP	CAN_MCAN_TEST_RX_MSK
 /* Prepared Valid */
-#define CAN_MCAN_TEST_PVAL_POS       (13U)
-#define CAN_MCAN_TEST_PVAL_MSK       (0x1UL << CAN_MCAN_TEST_PVAL_POS)
-#define CAN_MCAN_TEST_PVAL           CAN_MCAN_TEST_RX_MSK
+#define CAN_MCAN_TEST_PVAL_POS	(13U)
+#define CAN_MCAN_TEST_PVAL_MSK	(0x1UL << CAN_MCAN_TEST_PVAL_POS)
+#define CAN_MCAN_TEST_PVAL	CAN_MCAN_TEST_RX_MSK
 /* Tx Buffer Number Started */
-#define CAN_MCAN_TEST_TXBNS_POS      (16U)
-#define CAN_MCAN_TEST_TXBNS_MSK      (0x1FUL << CAN_MCAN_TEST_TXBNS_POS)
-#define CAN_MCAN_TEST_TXBNS          CAN_MCAN_TEST_RX_MSK
+#define CAN_MCAN_TEST_TXBNS_POS (16U)
+#define CAN_MCAN_TEST_TXBNS_MSK (0x1FUL << CAN_MCAN_TEST_TXBNS_POS)
+#define CAN_MCAN_TEST_TXBNS	CAN_MCAN_TEST_RX_MSK
 /* Started Valid */
-#define CAN_MCAN_TEST_SVAL_POS       (12U)
-#define CAN_MCAN_TEST_SVAL_MSK       (0x1UL << CAN_MCAN_TEST_SVAL_POS)
-#define CAN_MCAN_TEST_SVAL           CAN_MCAN_TEST_RX_MSK
+#define CAN_MCAN_TEST_SVAL_POS	(12U)
+#define CAN_MCAN_TEST_SVAL_MSK	(0x1UL << CAN_MCAN_TEST_SVAL_POS)
+#define CAN_MCAN_TEST_SVAL	CAN_MCAN_TEST_RX_MSK
 /* Does not exist on STM32 end */
 
 /***************  Bit definition for CAN_MCAN_RWD register  ******************/
 /* Watchdog configuration */
-#define CAN_MCAN_RWD_WDC_POS         (0U)
-#define CAN_MCAN_RWD_WDC_MSK         (0xFFUL << CAN_MCAN_RWD_WDC_POS)
-#define CAN_MCAN_RWD_WDC             CAN_MCAN_RWD_WDC_MSK
+#define CAN_MCAN_RWD_WDC_POS (0U)
+#define CAN_MCAN_RWD_WDC_MSK (0xFFUL << CAN_MCAN_RWD_WDC_POS)
+#define CAN_MCAN_RWD_WDC     CAN_MCAN_RWD_WDC_MSK
 /* Watchdog value */
-#define CAN_MCAN_RWD_WDV_POS         (8U)
-#define CAN_MCAN_RWD_WDV_MSK         (0xFFUL << CAN_MCAN_RWD_WDV_POS)
-#define CAN_MCAN_RWD_WDV             CAN_MCAN_RWD_WDV_MSK
+#define CAN_MCAN_RWD_WDV_POS (8U)
+#define CAN_MCAN_RWD_WDV_MSK (0xFFUL << CAN_MCAN_RWD_WDV_POS)
+#define CAN_MCAN_RWD_WDV     CAN_MCAN_RWD_WDV_MSK
 
 /***************  Bit definition for CAN_MCAN_CCCR register  ******************/
 /* Initialization */
-#define CAN_MCAN_CCCR_INIT_POS       (0U)
-#define CAN_MCAN_CCCR_INIT_MSK       (0x1UL << CAN_MCAN_CCCR_INIT_POS)
-#define CAN_MCAN_CCCR_INIT           CAN_MCAN_CCCR_INIT_MSK
+#define CAN_MCAN_CCCR_INIT_POS (0U)
+#define CAN_MCAN_CCCR_INIT_MSK (0x1UL << CAN_MCAN_CCCR_INIT_POS)
+#define CAN_MCAN_CCCR_INIT     CAN_MCAN_CCCR_INIT_MSK
 /* Configuration Change Enable */
-#define CAN_MCAN_CCCR_CCE_POS        (1U)
-#define CAN_MCAN_CCCR_CCE_MSK        (0x1UL << CAN_MCAN_CCCR_CCE_POS)
-#define CAN_MCAN_CCCR_CCE            CAN_MCAN_CCCR_CCE_MSK
+#define CAN_MCAN_CCCR_CCE_POS  (1U)
+#define CAN_MCAN_CCCR_CCE_MSK  (0x1UL << CAN_MCAN_CCCR_CCE_POS)
+#define CAN_MCAN_CCCR_CCE      CAN_MCAN_CCCR_CCE_MSK
 /* ASM Restricted Operation Mode */
-#define CAN_MCAN_CCCR_ASM_POS        (2U)
-#define CAN_MCAN_CCCR_ASM_MSK        (0x1UL << CAN_MCAN_CCCR_ASM_POS)
-#define CAN_MCAN_CCCR_ASM            CAN_MCAN_CCCR_ASM_MSK
+#define CAN_MCAN_CCCR_ASM_POS  (2U)
+#define CAN_MCAN_CCCR_ASM_MSK  (0x1UL << CAN_MCAN_CCCR_ASM_POS)
+#define CAN_MCAN_CCCR_ASM      CAN_MCAN_CCCR_ASM_MSK
 /* Clock Stop Acknowledge */
-#define CAN_MCAN_CCCR_CSA_POS        (3U)
-#define CAN_MCAN_CCCR_CSA_MSK        (0x1UL << CAN_MCAN_CCCR_CSA_POS)
-#define CAN_MCAN_CCCR_CSA            CAN_MCAN_CCCR_CSA_MSK
+#define CAN_MCAN_CCCR_CSA_POS  (3U)
+#define CAN_MCAN_CCCR_CSA_MSK  (0x1UL << CAN_MCAN_CCCR_CSA_POS)
+#define CAN_MCAN_CCCR_CSA      CAN_MCAN_CCCR_CSA_MSK
 /* Clock Stop Request */
-#define CAN_MCAN_CCCR_CSR_POS        (4U)
-#define CAN_MCAN_CCCR_CSR_MSK        (0x1UL << CAN_MCAN_CCCR_CSR_POS)
-#define CAN_MCAN_CCCR_CSR            CAN_MCAN_CCCR_CSR_MSK
+#define CAN_MCAN_CCCR_CSR_POS  (4U)
+#define CAN_MCAN_CCCR_CSR_MSK  (0x1UL << CAN_MCAN_CCCR_CSR_POS)
+#define CAN_MCAN_CCCR_CSR      CAN_MCAN_CCCR_CSR_MSK
 /* Bus Monitoring Mode */
-#define CAN_MCAN_CCCR_MON_POS        (5U)
-#define CAN_MCAN_CCCR_MON_MSK        (0x1UL << CAN_MCAN_CCCR_MON_POS)
-#define CAN_MCAN_CCCR_MON            CAN_MCAN_CCCR_MON_MSK
+#define CAN_MCAN_CCCR_MON_POS  (5U)
+#define CAN_MCAN_CCCR_MON_MSK  (0x1UL << CAN_MCAN_CCCR_MON_POS)
+#define CAN_MCAN_CCCR_MON      CAN_MCAN_CCCR_MON_MSK
 /* Disable Automatic Retransmission */
-#define CAN_MCAN_CCCR_DAR_POS        (6U)
-#define CAN_MCAN_CCCR_DAR_MSK        (0x1UL << CAN_MCAN_CCCR_DAR_POS)
-#define CAN_MCAN_CCCR_DAR            CAN_MCAN_CCCR_DAR_MSK
+#define CAN_MCAN_CCCR_DAR_POS  (6U)
+#define CAN_MCAN_CCCR_DAR_MSK  (0x1UL << CAN_MCAN_CCCR_DAR_POS)
+#define CAN_MCAN_CCCR_DAR      CAN_MCAN_CCCR_DAR_MSK
 /* Test Mode Enable */
-#define CAN_MCAN_CCCR_TEST_POS       (7U)
-#define CAN_MCAN_CCCR_TEST_MSK       (0x1UL << CAN_MCAN_CCCR_TEST_POS)
-#define CAN_MCAN_CCCR_TEST           CAN_MCAN_CCCR_TEST_MSK
+#define CAN_MCAN_CCCR_TEST_POS (7U)
+#define CAN_MCAN_CCCR_TEST_MSK (0x1UL << CAN_MCAN_CCCR_TEST_POS)
+#define CAN_MCAN_CCCR_TEST     CAN_MCAN_CCCR_TEST_MSK
 /* FD Operation Enable */
-#define CAN_MCAN_CCCR_FDOE_POS       (8U)
-#define CAN_MCAN_CCCR_FDOE_MSK       (0x1UL << CAN_MCAN_CCCR_FDOE_POS)
-#define CAN_MCAN_CCCR_FDOE           CAN_MCAN_CCCR_FDOE_MSK
+#define CAN_MCAN_CCCR_FDOE_POS (8U)
+#define CAN_MCAN_CCCR_FDOE_MSK (0x1UL << CAN_MCAN_CCCR_FDOE_POS)
+#define CAN_MCAN_CCCR_FDOE     CAN_MCAN_CCCR_FDOE_MSK
 /* FDCAN Bit Rate Switching */
-#define CAN_MCAN_CCCR_BRSE_POS       (9U)
-#define CAN_MCAN_CCCR_BRSE_MSK       (0x1UL << CAN_MCAN_CCCR_BRSE_POS)
-#define CAN_MCAN_CCCR_BRSE           CAN_MCAN_CCCR_BRSE_MSK
+#define CAN_MCAN_CCCR_BRSE_POS (9U)
+#define CAN_MCAN_CCCR_BRSE_MSK (0x1UL << CAN_MCAN_CCCR_BRSE_POS)
+#define CAN_MCAN_CCCR_BRSE     CAN_MCAN_CCCR_BRSE_MSK
 /* does not exist on stm32 begin*/
 /* Use Timestamping Uni */
-#define CAN_MCAN_CCCR_UTSU_POS       (10U)
-#define CAN_MCAN_CCCR_UTSU_MSK       (0x1UL << CAN_MCAN_CCCR_UTSU_POS)
-#define CAN_MCAN_CCCR_UTSU           CAN_MCAN_CCCR_UTSU_MSK
+#define CAN_MCAN_CCCR_UTSU_POS (10U)
+#define CAN_MCAN_CCCR_UTSU_MSK (0x1UL << CAN_MCAN_CCCR_UTSU_POS)
+#define CAN_MCAN_CCCR_UTSU     CAN_MCAN_CCCR_UTSU_MSK
 /* FDCAN Wide Message Marker */
-#define CAN_MCAN_CCCR_WMM_POS       (11U)
-#define CAN_MCAN_CCCR_WMM_MSK       (0x1UL << CAN_MCAN_CCCR_WMM_POS)
-#define CAN_MCAN_CCCR_WMM           CAN_MCAN_CCCR_WMM_MSK
+#define CAN_MCAN_CCCR_WMM_POS  (11U)
+#define CAN_MCAN_CCCR_WMM_MSK  (0x1UL << CAN_MCAN_CCCR_WMM_POS)
+#define CAN_MCAN_CCCR_WMM      CAN_MCAN_CCCR_WMM_MSK
 /* end */
 /* Protocol Exception Handling Disable */
-#define CAN_MCAN_CCCR_PXHD_POS       (12U)
-#define CAN_MCAN_CCCR_PXHD_MSK       (0x1UL << CAN_MCAN_CCCR_PXHD_POS)
-#define CAN_MCAN_CCCR_PXHD           CAN_MCAN_CCCR_PXHD_MSK
+#define CAN_MCAN_CCCR_PXHD_POS (12U)
+#define CAN_MCAN_CCCR_PXHD_MSK (0x1UL << CAN_MCAN_CCCR_PXHD_POS)
+#define CAN_MCAN_CCCR_PXHD     CAN_MCAN_CCCR_PXHD_MSK
 /* Edge Filtering during Bus Integration */
-#define CAN_MCAN_CCCR_EFBI_POS       (13U)
-#define CAN_MCAN_CCCR_EFBI_MSK       (0x1UL << CAN_MCAN_CCCR_EFBI_POS)
-#define CAN_MCAN_CCCR_EFBI           CAN_MCAN_CCCR_EFBI_MSK
+#define CAN_MCAN_CCCR_EFBI_POS (13U)
+#define CAN_MCAN_CCCR_EFBI_MSK (0x1UL << CAN_MCAN_CCCR_EFBI_POS)
+#define CAN_MCAN_CCCR_EFBI     CAN_MCAN_CCCR_EFBI_MSK
 /* Two CAN bit times Pause */
-#define CAN_MCAN_CCCR_TXP_POS        (14U)
-#define CAN_MCAN_CCCR_TXP_MSK        (0x1UL << CAN_MCAN_CCCR_TXP_POS)
-#define CAN_MCAN_CCCR_TXP            CAN_MCAN_CCCR_TXP_MSK
+#define CAN_MCAN_CCCR_TXP_POS  (14U)
+#define CAN_MCAN_CCCR_TXP_MSK  (0x1UL << CAN_MCAN_CCCR_TXP_POS)
+#define CAN_MCAN_CCCR_TXP      CAN_MCAN_CCCR_TXP_MSK
 /* Non ISO Operation */
-#define CAN_MCAN_CCCR_NISO_POS       (15U)
-#define CAN_MCAN_CCCR_NISO_MSK       (0x1UL << CAN_MCAN_CCCR_NISO_POS)
-#define CAN_MCAN_CCCR_NISO           CAN_MCAN_CCCR_NISO_MSK
+#define CAN_MCAN_CCCR_NISO_POS (15U)
+#define CAN_MCAN_CCCR_NISO_MSK (0x1UL << CAN_MCAN_CCCR_NISO_POS)
+#define CAN_MCAN_CCCR_NISO     CAN_MCAN_CCCR_NISO_MSK
 
 /***************  Bit definition for CAN_MCAN_NBTP register  ******************/
 /* Nominal Time segment after sample point */
-#define CAN_MCAN_NBTP_NTSEG2_POS     (0U)
-#define CAN_MCAN_NBTP_NTSEG2_MSK     (0x7FUL << CAN_MCAN_NBTP_NTSEG2_POS)
-#define CAN_MCAN_NBTP_NTSEG2         CAN_MCAN_NBTP_NTSEG2_MSK
+#define CAN_MCAN_NBTP_NTSEG2_POS (0U)
+#define CAN_MCAN_NBTP_NTSEG2_MSK (0x7FUL << CAN_MCAN_NBTP_NTSEG2_POS)
+#define CAN_MCAN_NBTP_NTSEG2	 CAN_MCAN_NBTP_NTSEG2_MSK
 /* Nominal Time segment before sample point */
-#define CAN_MCAN_NBTP_NTSEG1_POS     (8U)
-#define CAN_MCAN_NBTP_NTSEG1_MSK     (0xFFUL << CAN_MCAN_NBTP_NTSEG1_POS)
-#define CAN_MCAN_NBTP_NTSEG1         CAN_MCAN_NBTP_NTSEG1_MSK
+#define CAN_MCAN_NBTP_NTSEG1_POS (8U)
+#define CAN_MCAN_NBTP_NTSEG1_MSK (0xFFUL << CAN_MCAN_NBTP_NTSEG1_POS)
+#define CAN_MCAN_NBTP_NTSEG1	 CAN_MCAN_NBTP_NTSEG1_MSK
 /* Bit Rate Prescaler */
-#define CAN_MCAN_NBTP_NBRP_POS       (16U)
-#define CAN_MCAN_NBTP_NBRP_MSK       (0x1FFUL << CAN_MCAN_NBTP_NBRP_POS)
-#define CAN_MCAN_NBTP_NBRP           CAN_MCAN_NBTP_NBRP_MSK
+#define CAN_MCAN_NBTP_NBRP_POS	 (16U)
+#define CAN_MCAN_NBTP_NBRP_MSK	 (0x1FFUL << CAN_MCAN_NBTP_NBRP_POS)
+#define CAN_MCAN_NBTP_NBRP	 CAN_MCAN_NBTP_NBRP_MSK
 /* Nominal (Re)Synchronization Jump Width */
-#define CAN_MCAN_NBTP_NSJW_POS       (25U)
-#define CAN_MCAN_NBTP_NSJW_MSK       (0x7FUL << CAN_MCAN_NBTP_NSJW_POS)
-#define CAN_MCAN_NBTP_NSJW           CAN_MCAN_NBTP_NSJW_MSK
+#define CAN_MCAN_NBTP_NSJW_POS	 (25U)
+#define CAN_MCAN_NBTP_NSJW_MSK	 (0x7FUL << CAN_MCAN_NBTP_NSJW_POS)
+#define CAN_MCAN_NBTP_NSJW	 CAN_MCAN_NBTP_NSJW_MSK
 
 /***************  Bit definition for CAN_MCAN_TSCC register  ******************/
 /* Timestamp Select */
-#define CAN_MCAN_TSCC_TSS_POS        (0U)
-#define CAN_MCAN_TSCC_TSS_MSK        (0x3UL << CAN_MCAN_TSCC_TSS_POS)
-#define CAN_MCAN_TSCC_TSS            CAN_MCAN_TSCC_TSS_MSK
+#define CAN_MCAN_TSCC_TSS_POS (0U)
+#define CAN_MCAN_TSCC_TSS_MSK (0x3UL << CAN_MCAN_TSCC_TSS_POS)
+#define CAN_MCAN_TSCC_TSS     CAN_MCAN_TSCC_TSS_MSK
 /* Timestamp Counter Prescaler */
-#define CAN_MCAN_TSCC_TCP_POS        (16U)
-#define CAN_MCAN_TSCC_TCP_MSK        (0xFUL << CAN_MCAN_TSCC_TCP_POS)
-#define CAN_MCAN_TSCC_TCP            CAN_MCAN_TSCC_TCP_MSK
+#define CAN_MCAN_TSCC_TCP_POS (16U)
+#define CAN_MCAN_TSCC_TCP_MSK (0xFUL << CAN_MCAN_TSCC_TCP_POS)
+#define CAN_MCAN_TSCC_TCP     CAN_MCAN_TSCC_TCP_MSK
 /***************  Bit definition for CAN_MCAN_TSCV register  ******************/
 /* Timestamp Counter */
-#define CAN_MCAN_TSCV_TSC_POS        (0U)
-#define CAN_MCAN_TSCV_TSC_MSK        (0xFFFFUL << CAN_MCAN_TSCV_TSC_POS)
-#define CAN_MCAN_TSCV_TSC            CAN_MCAN_TSCV_TSC_MSK
+#define CAN_MCAN_TSCV_TSC_POS (0U)
+#define CAN_MCAN_TSCV_TSC_MSK (0xFFFFUL << CAN_MCAN_TSCV_TSC_POS)
+#define CAN_MCAN_TSCV_TSC     CAN_MCAN_TSCV_TSC_MSK
 
 /***************  Bit definition for CAN_MCAN_TOCC register  ******************/
 /* Enable Timeout Counter */
-#define CAN_MCAN_TOCC_ETOC_POS       (0U)
-#define CAN_MCAN_TOCC_ETOC_MSK       (0x1UL << CAN_MCAN_TOCC_ETOC_POS)
-#define CAN_MCAN_TOCC_ETOC           CAN_MCAN_TOCC_ETOC_MSK
+#define CAN_MCAN_TOCC_ETOC_POS (0U)
+#define CAN_MCAN_TOCC_ETOC_MSK (0x1UL << CAN_MCAN_TOCC_ETOC_POS)
+#define CAN_MCAN_TOCC_ETOC     CAN_MCAN_TOCC_ETOC_MSK
 /* Timeout Select */
-#define CAN_MCAN_TOCC_TOS_POS        (1U)
-#define CAN_MCAN_TOCC_TOS_MSK        (0x3UL << CAN_MCAN_TOCC_TOS_POS)
-#define CAN_MCAN_TOCC_TOS            CAN_MCAN_TOCC_TOS_MSK
+#define CAN_MCAN_TOCC_TOS_POS  (1U)
+#define CAN_MCAN_TOCC_TOS_MSK  (0x3UL << CAN_MCAN_TOCC_TOS_POS)
+#define CAN_MCAN_TOCC_TOS      CAN_MCAN_TOCC_TOS_MSK
 /* Timeout Period */
-#define CAN_MCAN_TOCC_TOP_POS        (16U)
-#define CAN_MCAN_TOCC_TOP_MSK        (0xFFFFUL << CAN_MCAN_TOCC_TOP_POS)
-#define CAN_MCAN_TOCC_TOP            CAN_MCAN_TOCC_TOP_MSK
+#define CAN_MCAN_TOCC_TOP_POS  (16U)
+#define CAN_MCAN_TOCC_TOP_MSK  (0xFFFFUL << CAN_MCAN_TOCC_TOP_POS)
+#define CAN_MCAN_TOCC_TOP      CAN_MCAN_TOCC_TOP_MSK
 
 /***************  Bit definition for CAN_MCAN_TOCV register  ******************/
 /* Timeout Counter */
-#define CAN_MCAN_TOCV_TOC_POS        (0U)
-#define CAN_MCAN_TOCV_TOC_MSK        (0xFFFFUL << CAN_MCAN_TOCV_TOC_POS)
-#define CAN_MCAN_TOCV_TOC            CAN_MCAN_TOCV_TOC_MSK
+#define CAN_MCAN_TOCV_TOC_POS (0U)
+#define CAN_MCAN_TOCV_TOC_MSK (0xFFFFUL << CAN_MCAN_TOCV_TOC_POS)
+#define CAN_MCAN_TOCV_TOC     CAN_MCAN_TOCV_TOC_MSK
 
 /***************  Bit definition for CAN_MCAN_ECR register  *******************/
 /* Transmit Error Counter */
-#define CAN_MCAN_ECR_TEC_POS         (0U)
-#define CAN_MCAN_ECR_TEC_MSK         (0xFFUL << CAN_MCAN_ECR_TEC_POS)
-#define CAN_MCAN_ECR_TEC             CAN_MCAN_ECR_TEC_MSK
+#define CAN_MCAN_ECR_TEC_POS (0U)
+#define CAN_MCAN_ECR_TEC_MSK (0xFFUL << CAN_MCAN_ECR_TEC_POS)
+#define CAN_MCAN_ECR_TEC     CAN_MCAN_ECR_TEC_MSK
 /* Receive Error Counter */
-#define CAN_MCAN_ECR_REC_POS         (8U)
-#define CAN_MCAN_ECR_REC_MSK         (0x7FUL << CAN_MCAN_ECR_REC_POS)
-#define CAN_MCAN_ECR_REC             CAN_MCAN_ECR_REC_MSK
+#define CAN_MCAN_ECR_REC_POS (8U)
+#define CAN_MCAN_ECR_REC_MSK (0x7FUL << CAN_MCAN_ECR_REC_POS)
+#define CAN_MCAN_ECR_REC     CAN_MCAN_ECR_REC_MSK
 /* Receive Error Passive */
-#define CAN_MCAN_ECR_RP_POS          (15U)
-#define CAN_MCAN_ECR_RP_MSK          (0x1UL << CAN_MCAN_ECR_RP_POS)
-#define CAN_MCAN_ECR_RP              CAN_MCAN_ECR_RP_MSK
+#define CAN_MCAN_ECR_RP_POS  (15U)
+#define CAN_MCAN_ECR_RP_MSK  (0x1UL << CAN_MCAN_ECR_RP_POS)
+#define CAN_MCAN_ECR_RP	     CAN_MCAN_ECR_RP_MSK
 /* CAN Error Logging */
-#define CAN_MCAN_ECR_CEL_POS         (16U)
-#define CAN_MCAN_ECR_CEL_MSK         (0xFFUL << CAN_MCAN_ECR_CEL_POS)
-#define CAN_MCAN_ECR_CEL             CAN_MCAN_ECR_CEL_MSK
+#define CAN_MCAN_ECR_CEL_POS (16U)
+#define CAN_MCAN_ECR_CEL_MSK (0xFFUL << CAN_MCAN_ECR_CEL_POS)
+#define CAN_MCAN_ECR_CEL     CAN_MCAN_ECR_CEL_MSK
 
 /***************  Bit definition for CAN_MCAN_PSR register  *******************/
 /* Last Error Code */
-#define CAN_MCAN_PSR_LEC_POS         (0U)
-#define CAN_MCAN_PSR_LEC_MSK         (0x7UL << CAN_MCAN_PSR_LEC_POS)
-#define CAN_MCAN_PSR_LEC             CAN_MCAN_PSR_LEC_MSK
+#define CAN_MCAN_PSR_LEC_POS  (0U)
+#define CAN_MCAN_PSR_LEC_MSK  (0x7UL << CAN_MCAN_PSR_LEC_POS)
+#define CAN_MCAN_PSR_LEC      CAN_MCAN_PSR_LEC_MSK
 /* Activity */
-#define CAN_MCAN_PSR_ACT_POS         (3U)
-#define CAN_MCAN_PSR_ACT_MSK         (0x3UL << CAN_MCAN_PSR_ACT_POS)
-#define CAN_MCAN_PSR_ACT             CAN_MCAN_PSR_ACT_MSK
+#define CAN_MCAN_PSR_ACT_POS  (3U)
+#define CAN_MCAN_PSR_ACT_MSK  (0x3UL << CAN_MCAN_PSR_ACT_POS)
+#define CAN_MCAN_PSR_ACT      CAN_MCAN_PSR_ACT_MSK
 /* Error Passive */
-#define CAN_MCAN_PSR_EP_POS          (5U)
-#define CAN_MCAN_PSR_EP_MSK          (0x1UL << CAN_MCAN_PSR_EP_POS)
-#define CAN_MCAN_PSR_EP              CAN_MCAN_PSR_EP_MSK
+#define CAN_MCAN_PSR_EP_POS   (5U)
+#define CAN_MCAN_PSR_EP_MSK   (0x1UL << CAN_MCAN_PSR_EP_POS)
+#define CAN_MCAN_PSR_EP	      CAN_MCAN_PSR_EP_MSK
 /* Warning Status */
-#define CAN_MCAN_PSR_EW_POS          (6U)
-#define CAN_MCAN_PSR_EW_MSK          (0x1UL << CAN_MCAN_PSR_EW_POS)
-#define CAN_MCAN_PSR_EW              CAN_MCAN_PSR_EW_MSK
+#define CAN_MCAN_PSR_EW_POS   (6U)
+#define CAN_MCAN_PSR_EW_MSK   (0x1UL << CAN_MCAN_PSR_EW_POS)
+#define CAN_MCAN_PSR_EW	      CAN_MCAN_PSR_EW_MSK
 /* Bus_Off Status */
-#define CAN_MCAN_PSR_BO_POS          (7U)
-#define CAN_MCAN_PSR_BO_MSK          (0x1UL << CAN_MCAN_PSR_BO_POS)
-#define CAN_MCAN_PSR_BO              CAN_MCAN_PSR_BO_MSK
+#define CAN_MCAN_PSR_BO_POS   (7U)
+#define CAN_MCAN_PSR_BO_MSK   (0x1UL << CAN_MCAN_PSR_BO_POS)
+#define CAN_MCAN_PSR_BO	      CAN_MCAN_PSR_BO_MSK
 /* Data Last Error Code */
-#define CAN_MCAN_PSR_DLEC_POS        (8U)
-#define CAN_MCAN_PSR_DLEC_MSK        (0x7UL << CAN_MCAN_PSR_DLEC_POS)
-#define CAN_MCAN_PSR_DLEC            CAN_MCAN_PSR_DLEC_MSK
+#define CAN_MCAN_PSR_DLEC_POS (8U)
+#define CAN_MCAN_PSR_DLEC_MSK (0x7UL << CAN_MCAN_PSR_DLEC_POS)
+#define CAN_MCAN_PSR_DLEC     CAN_MCAN_PSR_DLEC_MSK
 /* ESI flag of last received FDCAN Message */
-#define CAN_MCAN_PSR_RESI_POS        (11U)
-#define CAN_MCAN_PSR_RESI_MSK        (0x1UL << CAN_MCAN_PSR_RESI_POS)
-#define CAN_MCAN_PSR_RESI            CAN_MCAN_PSR_RESI_MSK
+#define CAN_MCAN_PSR_RESI_POS (11U)
+#define CAN_MCAN_PSR_RESI_MSK (0x1UL << CAN_MCAN_PSR_RESI_POS)
+#define CAN_MCAN_PSR_RESI     CAN_MCAN_PSR_RESI_MSK
 /* BRS flag of last received FDCAN Message */
-#define CAN_MCAN_PSR_RBRS_POS        (12U)
-#define CAN_MCAN_PSR_RBRS_MSK        (0x1UL << CAN_MCAN_PSR_RBRS_POS)
-#define CAN_MCAN_PSR_RBRS            CAN_MCAN_PSR_RBRS_MSK
+#define CAN_MCAN_PSR_RBRS_POS (12U)
+#define CAN_MCAN_PSR_RBRS_MSK (0x1UL << CAN_MCAN_PSR_RBRS_POS)
+#define CAN_MCAN_PSR_RBRS     CAN_MCAN_PSR_RBRS_MSK
 /* Received FDCAN Message */
-#define CAN_MCAN_PSR_REDL_POS        (13U)
-#define CAN_MCAN_PSR_REDL_MSK        (0x1UL << CAN_MCAN_PSR_REDL_POS)
-#define CAN_MCAN_PSR_REDL            CAN_MCAN_PSR_REDL_MSK
+#define CAN_MCAN_PSR_REDL_POS (13U)
+#define CAN_MCAN_PSR_REDL_MSK (0x1UL << CAN_MCAN_PSR_REDL_POS)
+#define CAN_MCAN_PSR_REDL     CAN_MCAN_PSR_REDL_MSK
 /* Protocol Exception Event */
-#define CAN_MCAN_PSR_PXE_POS         (14U)
-#define CAN_MCAN_PSR_PXE_MSK         (0x1UL << CAN_MCAN_PSR_PXE_POS)
-#define CAN_MCAN_PSR_PXE             CAN_MCAN_PSR_PXE_MSK
- /* Transmitter Delay Compensation Value */
-#define CAN_MCAN_PSR_TDCV_POS        (16U)
-#define CAN_MCAN_PSR_TDCV_MSK        (0x7FUL << CAN_MCAN_PSR_TDCV_POS)
-#define CAN_MCAN_PSR_TDCV            CAN_MCAN_PSR_TDCV_MSK
+#define CAN_MCAN_PSR_PXE_POS  (14U)
+#define CAN_MCAN_PSR_PXE_MSK  (0x1UL << CAN_MCAN_PSR_PXE_POS)
+#define CAN_MCAN_PSR_PXE      CAN_MCAN_PSR_PXE_MSK
+/* Transmitter Delay Compensation Value */
+#define CAN_MCAN_PSR_TDCV_POS (16U)
+#define CAN_MCAN_PSR_TDCV_MSK (0x7FUL << CAN_MCAN_PSR_TDCV_POS)
+#define CAN_MCAN_PSR_TDCV     CAN_MCAN_PSR_TDCV_MSK
 
 /***************  Bit definition for CAN_MCAN_TDCR register  ******************/
 /* Transmitter Delay Compensation Filter */
-#define CAN_MCAN_TDCR_TDCF_POS       (0U)
-#define CAN_MCAN_TDCR_TDCF_MSK       (0x7FUL << CAN_MCAN_TDCR_TDCF_POS)
-#define CAN_MCAN_TDCR_TDCF           CAN_MCAN_TDCR_TDCF_MSK
+#define CAN_MCAN_TDCR_TDCF_POS (0U)
+#define CAN_MCAN_TDCR_TDCF_MSK (0x7FUL << CAN_MCAN_TDCR_TDCF_POS)
+#define CAN_MCAN_TDCR_TDCF     CAN_MCAN_TDCR_TDCF_MSK
 /* Transmitter Delay Compensation Offset */
-#define CAN_MCAN_TDCR_TDCO_POS       (8U)
-#define CAN_MCAN_TDCR_TDCO_MSK       (0x7FUL << CAN_MCAN_TDCR_TDCO_POS)
-#define CAN_MCAN_TDCR_TDCO           CAN_MCAN_TDCR_TDCO_MSK
+#define CAN_MCAN_TDCR_TDCO_POS (8U)
+#define CAN_MCAN_TDCR_TDCO_MSK (0x7FUL << CAN_MCAN_TDCR_TDCO_POS)
+#define CAN_MCAN_TDCR_TDCO     CAN_MCAN_TDCR_TDCO_MSK
 
 /***************  Bit definition for CAN_MCAN_IR register  ********************/
 #ifdef CONFIG_CAN_STM32FD
 /* Rx FIFO 0 New Message */
-#define CAN_MCAN_IR_RF0N_POS         (0U)
-#define CAN_MCAN_IR_RF0N_MSK         (0x1UL << CAN_MCAN_IR_RF0N_POS)
-#define CAN_MCAN_IR_RF0N             CAN_MCAN_IR_RF0N_MSK
+#define CAN_MCAN_IR_RF0N_POS (0U)
+#define CAN_MCAN_IR_RF0N_MSK (0x1UL << CAN_MCAN_IR_RF0N_POS)
+#define CAN_MCAN_IR_RF0N     CAN_MCAN_IR_RF0N_MSK
 /* Rx FIFO 0 Full */
-#define CAN_MCAN_IR_RF0F_POS         (1U)
-#define CAN_MCAN_IR_RF0F_MSK         (0x1UL << CAN_MCAN_IR_RF0F_POS)
-#define CAN_MCAN_IR_RF0F             CAN_MCAN_IR_RF0F_MSK
+#define CAN_MCAN_IR_RF0F_POS (1U)
+#define CAN_MCAN_IR_RF0F_MSK (0x1UL << CAN_MCAN_IR_RF0F_POS)
+#define CAN_MCAN_IR_RF0F     CAN_MCAN_IR_RF0F_MSK
 /* Rx FIFO 0 Message Lost */
-#define CAN_MCAN_IR_RF0L_POS         (2U)
-#define CAN_MCAN_IR_RF0L_MSK         (0x1UL << CAN_MCAN_IR_RF0L_POS)
-#define CAN_MCAN_IR_RF0L             CAN_MCAN_IR_RF0L_MSK
+#define CAN_MCAN_IR_RF0L_POS (2U)
+#define CAN_MCAN_IR_RF0L_MSK (0x1UL << CAN_MCAN_IR_RF0L_POS)
+#define CAN_MCAN_IR_RF0L     CAN_MCAN_IR_RF0L_MSK
 /* Rx FIFO 1 New Message */
-#define CAN_MCAN_IR_RF1N_POS         (3U)
-#define CAN_MCAN_IR_RF1N_MSK         (0x1UL << CAN_MCAN_IR_RF1N_POS)
-#define CAN_MCAN_IR_RF1N             CAN_MCAN_IR_RF1N_MSK
+#define CAN_MCAN_IR_RF1N_POS (3U)
+#define CAN_MCAN_IR_RF1N_MSK (0x1UL << CAN_MCAN_IR_RF1N_POS)
+#define CAN_MCAN_IR_RF1N     CAN_MCAN_IR_RF1N_MSK
 /* Rx FIFO 1 Full */
-#define CAN_MCAN_IR_RF1F_POS         (4U)
-#define CAN_MCAN_IR_RF1F_MSK         (0x1UL << CAN_MCAN_IR_RF1F_POS)
-#define CAN_MCAN_IR_RF1F             CAN_MCAN_IR_RF1F_MSK
+#define CAN_MCAN_IR_RF1F_POS (4U)
+#define CAN_MCAN_IR_RF1F_MSK (0x1UL << CAN_MCAN_IR_RF1F_POS)
+#define CAN_MCAN_IR_RF1F     CAN_MCAN_IR_RF1F_MSK
 /* Rx FIFO 1 Message Lost */
-#define CAN_MCAN_IR_RF1L_POS         (5U)
-#define CAN_MCAN_IR_RF1L_MSK         (0x1UL << CAN_MCAN_IR_RF1L_POS)
-#define CAN_MCAN_IR_RF1L             CAN_MCAN_IR_RF1L_MSK
+#define CAN_MCAN_IR_RF1L_POS (5U)
+#define CAN_MCAN_IR_RF1L_MSK (0x1UL << CAN_MCAN_IR_RF1L_POS)
+#define CAN_MCAN_IR_RF1L     CAN_MCAN_IR_RF1L_MSK
 /* High Priority Message */
-#define CAN_MCAN_IR_HPM_POS          (6U)
-#define CAN_MCAN_IR_HPM_MSK          (0x1UL << CAN_MCAN_IR_HPM_POS)
-#define CAN_MCAN_IR_HPM              CAN_MCAN_IR_HPM_MSK
+#define CAN_MCAN_IR_HPM_POS  (6U)
+#define CAN_MCAN_IR_HPM_MSK  (0x1UL << CAN_MCAN_IR_HPM_POS)
+#define CAN_MCAN_IR_HPM	     CAN_MCAN_IR_HPM_MSK
 /* Transmission Completed     */
-#define CAN_MCAN_IR_TC_POS           (7U)
-#define CAN_MCAN_IR_TC_MSK           (0x1UL << CAN_MCAN_IR_TC_POS)
-#define CAN_MCAN_IR_TC               CAN_MCAN_IR_TC_MSK
+#define CAN_MCAN_IR_TC_POS   (7U)
+#define CAN_MCAN_IR_TC_MSK   (0x1UL << CAN_MCAN_IR_TC_POS)
+#define CAN_MCAN_IR_TC	     CAN_MCAN_IR_TC_MSK
 /* Transmission Cancellation Finished */
-#define CAN_MCAN_IR_TCF_POS          (8U)
-#define CAN_MCAN_IR_TCF_MSK          (0x1UL << CAN_MCAN_IR_TCF_POS)
-#define CAN_MCAN_IR_TCF              CAN_MCAN_IR_TCF_MSK
+#define CAN_MCAN_IR_TCF_POS  (8U)
+#define CAN_MCAN_IR_TCF_MSK  (0x1UL << CAN_MCAN_IR_TCF_POS)
+#define CAN_MCAN_IR_TCF	     CAN_MCAN_IR_TCF_MSK
 /* Tx FIFO Empty */
-#define CAN_MCAN_IR_TFE_POS          (9U)
-#define CAN_MCAN_IR_TFE_MSK          (0x1UL << CAN_MCAN_IR_TFE_POS)
-#define CAN_MCAN_IR_TFE              CAN_MCAN_IR_TFE_MSK
+#define CAN_MCAN_IR_TFE_POS  (9U)
+#define CAN_MCAN_IR_TFE_MSK  (0x1UL << CAN_MCAN_IR_TFE_POS)
+#define CAN_MCAN_IR_TFE	     CAN_MCAN_IR_TFE_MSK
 /* Tx Event FIFO New Entry */
-#define CAN_MCAN_IR_TEFN_POS         (10U)
-#define CAN_MCAN_IR_TEFN_MSK         (0x1UL << CAN_MCAN_IR_TEFN_POS)
-#define CAN_MCAN_IR_TEFN             CAN_MCAN_IR_TEFN_MSK
+#define CAN_MCAN_IR_TEFN_POS (10U)
+#define CAN_MCAN_IR_TEFN_MSK (0x1UL << CAN_MCAN_IR_TEFN_POS)
+#define CAN_MCAN_IR_TEFN     CAN_MCAN_IR_TEFN_MSK
 /* Tx Event FIFO Full */
-#define CAN_MCAN_IR_TEFF_POS         (11U)
-#define CAN_MCAN_IR_TEFF_MSK         (0x1UL << CAN_MCAN_IR_TEFF_POS)
-#define CAN_MCAN_IR_TEFF             CAN_MCAN_IR_TEFF_MSK
+#define CAN_MCAN_IR_TEFF_POS (11U)
+#define CAN_MCAN_IR_TEFF_MSK (0x1UL << CAN_MCAN_IR_TEFF_POS)
+#define CAN_MCAN_IR_TEFF     CAN_MCAN_IR_TEFF_MSK
 /* Tx Event FIFO Element Lost */
-#define CAN_MCAN_IR_TEFL_POS         (12U)
-#define CAN_MCAN_IR_TEFL_MSK         (0x1UL << CAN_MCAN_IR_TEFL_POS)
-#define CAN_MCAN_IR_TEFL             CAN_MCAN_IR_TEFL_MSK
+#define CAN_MCAN_IR_TEFL_POS (12U)
+#define CAN_MCAN_IR_TEFL_MSK (0x1UL << CAN_MCAN_IR_TEFL_POS)
+#define CAN_MCAN_IR_TEFL     CAN_MCAN_IR_TEFL_MSK
 /* Timestamp Wraparound */
-#define CAN_MCAN_IR_TSW_POS          (13U)
-#define CAN_MCAN_IR_TSW_MSK          (0x1UL << CAN_MCAN_IR_TSW_POS)
-#define CAN_MCAN_IR_TSW              CAN_MCAN_IR_TSW_MSK
+#define CAN_MCAN_IR_TSW_POS  (13U)
+#define CAN_MCAN_IR_TSW_MSK  (0x1UL << CAN_MCAN_IR_TSW_POS)
+#define CAN_MCAN_IR_TSW	     CAN_MCAN_IR_TSW_MSK
 /* Message RAM Access Failure */
-#define CAN_MCAN_IR_MRAF_POS         (14U)
-#define CAN_MCAN_IR_MRAF_MSK         (0x1UL << CAN_MCAN_IR_MRAF_POS)
-#define CAN_MCAN_IR_MRAF             CAN_MCAN_IR_MRAF_MSK
+#define CAN_MCAN_IR_MRAF_POS (14U)
+#define CAN_MCAN_IR_MRAF_MSK (0x1UL << CAN_MCAN_IR_MRAF_POS)
+#define CAN_MCAN_IR_MRAF     CAN_MCAN_IR_MRAF_MSK
 /* Timeout Occurred */
-#define CAN_MCAN_IR_TOO_POS          (15U)
-#define CAN_MCAN_IR_TOO_MSK          (0x1UL << CAN_MCAN_IR_TOO_POS)
-#define CAN_MCAN_IR_TOO              CAN_MCAN_IR_TOO_MSK
+#define CAN_MCAN_IR_TOO_POS  (15U)
+#define CAN_MCAN_IR_TOO_MSK  (0x1UL << CAN_MCAN_IR_TOO_POS)
+#define CAN_MCAN_IR_TOO	     CAN_MCAN_IR_TOO_MSK
 /* Error Logging Overflow */
-#define CAN_MCAN_IR_ELO_POS          (16U)
-#define CAN_MCAN_IR_ELO_MSK          (0x1UL << CAN_MCAN_IR_ELO_POS)
-#define CAN_MCAN_IR_ELO              CAN_MCAN_IR_ELO_MSK
+#define CAN_MCAN_IR_ELO_POS  (16U)
+#define CAN_MCAN_IR_ELO_MSK  (0x1UL << CAN_MCAN_IR_ELO_POS)
+#define CAN_MCAN_IR_ELO	     CAN_MCAN_IR_ELO_MSK
 /* Error Passive */
-#define CAN_MCAN_IR_EP_POS           (17U)
-#define CAN_MCAN_IR_EP_MSK           (0x1UL << CAN_MCAN_IR_EP_POS)
-#define CAN_MCAN_IR_EP               CAN_MCAN_IR_EP_MSK
+#define CAN_MCAN_IR_EP_POS   (17U)
+#define CAN_MCAN_IR_EP_MSK   (0x1UL << CAN_MCAN_IR_EP_POS)
+#define CAN_MCAN_IR_EP	     CAN_MCAN_IR_EP_MSK
 /* Warning Status */
-#define CAN_MCAN_IR_EW_POS           (18U)
-#define CAN_MCAN_IR_EW_MSK           (0x1UL << CAN_MCAN_IR_EW_POS)
-#define CAN_MCAN_IR_EW               CAN_MCAN_IR_EW_MSK
+#define CAN_MCAN_IR_EW_POS   (18U)
+#define CAN_MCAN_IR_EW_MSK   (0x1UL << CAN_MCAN_IR_EW_POS)
+#define CAN_MCAN_IR_EW	     CAN_MCAN_IR_EW_MSK
 /* Bus_Off Status */
-#define CAN_MCAN_IR_BO_POS           (19U)
-#define CAN_MCAN_IR_BO_MSK           (0x1UL << CAN_MCAN_IR_BO_POS)
-#define CAN_MCAN_IR_BO                CAN_MCAN_IR_BO_MSK
+#define CAN_MCAN_IR_BO_POS   (19U)
+#define CAN_MCAN_IR_BO_MSK   (0x1UL << CAN_MCAN_IR_BO_POS)
+#define CAN_MCAN_IR_BO	     CAN_MCAN_IR_BO_MSK
 /* Watchdog Interrupt */
-#define CAN_MCAN_IR_WDI_POS          (20U)
-#define CAN_MCAN_IR_WDI_MSK          (0x1UL << CAN_MCAN_IR_WDI_POS)
-#define CAN_MCAN_IR_WDI              CAN_MCAN_IR_WDI_MSK
+#define CAN_MCAN_IR_WDI_POS  (20U)
+#define CAN_MCAN_IR_WDI_MSK  (0x1UL << CAN_MCAN_IR_WDI_POS)
+#define CAN_MCAN_IR_WDI	     CAN_MCAN_IR_WDI_MSK
 /* Protocol Error in Arbitration Phase */
-#define CAN_MCAN_IR_PEA_POS          (21U)
-#define CAN_MCAN_IR_PEA_MSK          (0x1UL << CAN_MCAN_IR_PEA_POS)
-#define CAN_MCAN_IR_PEA              CAN_MCAN_IR_PEA_MSK
+#define CAN_MCAN_IR_PEA_POS  (21U)
+#define CAN_MCAN_IR_PEA_MSK  (0x1UL << CAN_MCAN_IR_PEA_POS)
+#define CAN_MCAN_IR_PEA	     CAN_MCAN_IR_PEA_MSK
 /* Protocol Error in Data Phase */
-#define CAN_MCAN_IR_PED_POS          (22U)
-#define CAN_MCAN_IR_PED_MSK          (0x1UL << CAN_MCAN_IR_PED_POS)
-#define CAN_MCAN_IR_PED              CAN_MCAN_IR_PED_MSK
- /* Access to Reserved Address */
-#define CAN_MCAN_IR_ARA_POS          (23U)
-#define CAN_MCAN_IR_ARA_MSK          (0x1UL << CAN_MCAN_IR_ARA_POS)
-#define CAN_MCAN_IR_ARA              CAN_MCAN_IR_ARA_MSK
+#define CAN_MCAN_IR_PED_POS  (22U)
+#define CAN_MCAN_IR_PED_MSK  (0x1UL << CAN_MCAN_IR_PED_POS)
+#define CAN_MCAN_IR_PED	     CAN_MCAN_IR_PED_MSK
+/* Access to Reserved Address */
+#define CAN_MCAN_IR_ARA_POS  (23U)
+#define CAN_MCAN_IR_ARA_MSK  (0x1UL << CAN_MCAN_IR_ARA_POS)
+#define CAN_MCAN_IR_ARA	     CAN_MCAN_IR_ARA_MSK
 
 #else /* CONFIG_CAN_STM32FD */
 
 /* Rx FIFO 0 New Message */
-#define CAN_MCAN_IR_RF0N_POS         (0U)
-#define CAN_MCAN_IR_RF0N_MSK         (0x1UL << CAN_MCAN_IR_RF0N_POS)
-#define CAN_MCAN_IR_RF0N             CAN_MCAN_IR_RF0N_MSK
+#define CAN_MCAN_IR_RF0N_POS (0U)
+#define CAN_MCAN_IR_RF0N_MSK (0x1UL << CAN_MCAN_IR_RF0N_POS)
+#define CAN_MCAN_IR_RF0N     CAN_MCAN_IR_RF0N_MSK
 /* Rx FIFO 0 Watermark Reached*/
-#define CAN_MCAN_IR_RF0W_POS         (1U)
-#define CAN_MCAN_IR_RF0W_MSK         (0x1UL << CAN_MCAN_IR_RF0W_POS)
-#define CAN_MCAN_IR_RF0W             CAN_MCAN_IR_RF0W_MSK
+#define CAN_MCAN_IR_RF0W_POS (1U)
+#define CAN_MCAN_IR_RF0W_MSK (0x1UL << CAN_MCAN_IR_RF0W_POS)
+#define CAN_MCAN_IR_RF0W     CAN_MCAN_IR_RF0W_MSK
 /* Rx FIFO 0 Full */
-#define CAN_MCAN_IR_RF0F_POS         (2U)
-#define CAN_MCAN_IR_RF0F_MSK         (0x1UL << CAN_MCAN_IR_RF0F_POS)
-#define CAN_MCAN_IR_RF0F             CAN_MCAN_IR_RF0F_MSK
+#define CAN_MCAN_IR_RF0F_POS (2U)
+#define CAN_MCAN_IR_RF0F_MSK (0x1UL << CAN_MCAN_IR_RF0F_POS)
+#define CAN_MCAN_IR_RF0F     CAN_MCAN_IR_RF0F_MSK
 /* Rx FIFO 0 Message Lost */
-#define CAN_MCAN_IR_RF0L_POS         (3U)
-#define CAN_MCAN_IR_RF0L_MSK         (0x1UL << CAN_MCAN_IR_RF0L_POS)
-#define CAN_MCAN_IR_RF0L             CAN_MCAN_IR_RF0L_MSK
+#define CAN_MCAN_IR_RF0L_POS (3U)
+#define CAN_MCAN_IR_RF0L_MSK (0x1UL << CAN_MCAN_IR_RF0L_POS)
+#define CAN_MCAN_IR_RF0L     CAN_MCAN_IR_RF0L_MSK
 /* Rx FIFO 1 New Message */
-#define CAN_MCAN_IR_RF1N_POS         (4U)
-#define CAN_MCAN_IR_RF1N_MSK         (0x1UL << CAN_MCAN_IR_RF1N_POS)
-#define CAN_MCAN_IR_RF1N             CAN_MCAN_IR_RF1N_MSK
+#define CAN_MCAN_IR_RF1N_POS (4U)
+#define CAN_MCAN_IR_RF1N_MSK (0x1UL << CAN_MCAN_IR_RF1N_POS)
+#define CAN_MCAN_IR_RF1N     CAN_MCAN_IR_RF1N_MSK
 /* Rx FIFO 1 Watermark Reached*/
-#define CAN_MCAN_IR_RF1W_POS         (5U)
-#define CAN_MCAN_IR_RF1W_MSK         (0x1UL << CAN_MCAN_IR_RF1W_POS)
-#define CAN_MCAN_IR_RF1W             CAN_MCAN_IR_RF1W_MSK
+#define CAN_MCAN_IR_RF1W_POS (5U)
+#define CAN_MCAN_IR_RF1W_MSK (0x1UL << CAN_MCAN_IR_RF1W_POS)
+#define CAN_MCAN_IR_RF1W     CAN_MCAN_IR_RF1W_MSK
 /* Rx FIFO 1 Full */
-#define CAN_MCAN_IR_RF1F_POS         (6U)
-#define CAN_MCAN_IR_RF1F_MSK         (0x1UL << CAN_MCAN_IR_RF1F_POS)
-#define CAN_MCAN_IR_RF1F             CAN_MCAN_IR_RF1F_MSK
+#define CAN_MCAN_IR_RF1F_POS (6U)
+#define CAN_MCAN_IR_RF1F_MSK (0x1UL << CAN_MCAN_IR_RF1F_POS)
+#define CAN_MCAN_IR_RF1F     CAN_MCAN_IR_RF1F_MSK
 /* Rx FIFO 1 Message Lost */
-#define CAN_MCAN_IR_RF1L_POS         (7U)
-#define CAN_MCAN_IR_RF1L_MSK         (0x1UL << CAN_MCAN_IR_RF1L_POS)
-#define CAN_MCAN_IR_RF1L             CAN_MCAN_IR_RF1L_MSK
+#define CAN_MCAN_IR_RF1L_POS (7U)
+#define CAN_MCAN_IR_RF1L_MSK (0x1UL << CAN_MCAN_IR_RF1L_POS)
+#define CAN_MCAN_IR_RF1L     CAN_MCAN_IR_RF1L_MSK
 /* High Priority Message */
-#define CAN_MCAN_IR_HPM_POS          (8U)
-#define CAN_MCAN_IR_HPM_MSK          (0x1UL << CAN_MCAN_IR_HPM_POS)
-#define CAN_MCAN_IR_HPM              CAN_MCAN_IR_HPM_MSK
+#define CAN_MCAN_IR_HPM_POS  (8U)
+#define CAN_MCAN_IR_HPM_MSK  (0x1UL << CAN_MCAN_IR_HPM_POS)
+#define CAN_MCAN_IR_HPM	     CAN_MCAN_IR_HPM_MSK
 /* Transmission Completed */
-#define CAN_MCAN_IR_TC_POS           (9U)
-#define CAN_MCAN_IR_TC_MSK           (0x1UL << CAN_MCAN_IR_TC_POS)
-#define CAN_MCAN_IR_TC               CAN_MCAN_IR_TC_MSK
+#define CAN_MCAN_IR_TC_POS   (9U)
+#define CAN_MCAN_IR_TC_MSK   (0x1UL << CAN_MCAN_IR_TC_POS)
+#define CAN_MCAN_IR_TC	     CAN_MCAN_IR_TC_MSK
 /* Transmission Cancellation Finished */
-#define CAN_MCAN_IR_TCF_POS          (10U)
-#define CAN_MCAN_IR_TCF_MSK          (0x1UL << CAN_MCAN_IR_TCF_POS)
-#define CAN_MCAN_IR_TCF              CAN_MCAN_IR_TCF_MSK
+#define CAN_MCAN_IR_TCF_POS  (10U)
+#define CAN_MCAN_IR_TCF_MSK  (0x1UL << CAN_MCAN_IR_TCF_POS)
+#define CAN_MCAN_IR_TCF	     CAN_MCAN_IR_TCF_MSK
 /* Tx FIFO Empty */
-#define CAN_MCAN_IR_TFE_POS          (11U)
-#define CAN_MCAN_IR_TFE_MSK          (0x1UL << CAN_MCAN_IR_TFE_POS)
-#define CAN_MCAN_IR_TFE              CAN_MCAN_IR_TFE_MSK
+#define CAN_MCAN_IR_TFE_POS  (11U)
+#define CAN_MCAN_IR_TFE_MSK  (0x1UL << CAN_MCAN_IR_TFE_POS)
+#define CAN_MCAN_IR_TFE	     CAN_MCAN_IR_TFE_MSK
 /* Tx Event FIFO New Entry */
-#define CAN_MCAN_IR_TEFN_POS         (12U)
-#define CAN_MCAN_IR_TEFN_MSK         (0x1UL << CAN_MCAN_IR_TEFN_POS)
-#define CAN_MCAN_IR_TEFN             CAN_MCAN_IR_TEFN_MSK
+#define CAN_MCAN_IR_TEFN_POS (12U)
+#define CAN_MCAN_IR_TEFN_MSK (0x1UL << CAN_MCAN_IR_TEFN_POS)
+#define CAN_MCAN_IR_TEFN     CAN_MCAN_IR_TEFN_MSK
 /* Tx Event FIFO Watermark */
-#define CAN_MCAN_IR_TEFW_POS         (13U)
-#define CAN_MCAN_IR_TEFW_MSK         (0x1UL << CAN_MCAN_IR_TEFW_POS)
-#define CAN_MCAN_IR_TEFW             CAN_MCAN_IR_TEFW_MSK
+#define CAN_MCAN_IR_TEFW_POS (13U)
+#define CAN_MCAN_IR_TEFW_MSK (0x1UL << CAN_MCAN_IR_TEFW_POS)
+#define CAN_MCAN_IR_TEFW     CAN_MCAN_IR_TEFW_MSK
 /* Tx Event FIFO Full */
-#define CAN_MCAN_IR_TEFF_POS         (14U)
-#define CAN_MCAN_IR_TEFF_MSK         (0x1UL << CAN_MCAN_IR_TEFF_POS)
-#define CAN_MCAN_IR_TEFF             CAN_MCAN_IR_TEFF_MSK
+#define CAN_MCAN_IR_TEFF_POS (14U)
+#define CAN_MCAN_IR_TEFF_MSK (0x1UL << CAN_MCAN_IR_TEFF_POS)
+#define CAN_MCAN_IR_TEFF     CAN_MCAN_IR_TEFF_MSK
 /* Tx Event FIFO Element Lost */
-#define CAN_MCAN_IR_TEFL_POS         (15U)
-#define CAN_MCAN_IR_TEFL_MSK         (0x1UL << CAN_MCAN_IR_TEFL_POS)
-#define CAN_MCAN_IR_TEFL             CAN_MCAN_IR_TEFL_MSK
+#define CAN_MCAN_IR_TEFL_POS (15U)
+#define CAN_MCAN_IR_TEFL_MSK (0x1UL << CAN_MCAN_IR_TEFL_POS)
+#define CAN_MCAN_IR_TEFL     CAN_MCAN_IR_TEFL_MSK
 /* Timestamp Wraparound */
-#define CAN_MCAN_IR_TSW_POS          (16U)
-#define CAN_MCAN_IR_TSW_MSK          (0x1UL << CAN_MCAN_IR_TSW_POS)
-#define CAN_MCAN_IR_TSW              CAN_MCAN_IR_TSW_MSK
+#define CAN_MCAN_IR_TSW_POS  (16U)
+#define CAN_MCAN_IR_TSW_MSK  (0x1UL << CAN_MCAN_IR_TSW_POS)
+#define CAN_MCAN_IR_TSW	     CAN_MCAN_IR_TSW_MSK
 /* Message RAM Access Failure */
-#define CAN_MCAN_IR_MRAF_POS         (17U)
-#define CAN_MCAN_IR_MRAF_MSK         (0x1UL << CAN_MCAN_IR_MRAF_POS)
-#define CAN_MCAN_IR_MRAF             CAN_MCAN_IR_MRAF_MSK
+#define CAN_MCAN_IR_MRAF_POS (17U)
+#define CAN_MCAN_IR_MRAF_MSK (0x1UL << CAN_MCAN_IR_MRAF_POS)
+#define CAN_MCAN_IR_MRAF     CAN_MCAN_IR_MRAF_MSK
 /* Timeout Occurred */
-#define CAN_MCAN_IR_TOO_POS          (18U)
-#define CAN_MCAN_IR_TOO_MSK          (0x1UL << CAN_MCAN_IR_TOO_POS)
-#define CAN_MCAN_IR_TOO              CAN_MCAN_IR_TOO_MSK
+#define CAN_MCAN_IR_TOO_POS  (18U)
+#define CAN_MCAN_IR_TOO_MSK  (0x1UL << CAN_MCAN_IR_TOO_POS)
+#define CAN_MCAN_IR_TOO	     CAN_MCAN_IR_TOO_MSK
 /* Message stored to Dedicated Rx Buffer */
-#define CAN_MCAN_IR_DRX_POS          (19U)
-#define CAN_MCAN_IR_DRX_MSK          (0x1UL << CAN_MCAN_IR_DRX_POS)
-#define CAN_MCAN_IR_DRX              CAN_MCAN_IR_DRX_MSK
+#define CAN_MCAN_IR_DRX_POS  (19U)
+#define CAN_MCAN_IR_DRX_MSK  (0x1UL << CAN_MCAN_IR_DRX_POS)
+#define CAN_MCAN_IR_DRX	     CAN_MCAN_IR_DRX_MSK
 /* Bit Error Corrected */
-#define CAN_MCAN_IR_BEC_POS          (20U)
-#define CAN_MCAN_IR_BEC_MSK          (0x1UL << CAN_MCAN_IR_BEC_POS)
-#define CAN_MCAN_IR_BEC              CAN_MCAN_IR_BEC_MSK
+#define CAN_MCAN_IR_BEC_POS  (20U)
+#define CAN_MCAN_IR_BEC_MSK  (0x1UL << CAN_MCAN_IR_BEC_POS)
+#define CAN_MCAN_IR_BEC	     CAN_MCAN_IR_BEC_MSK
 /* Bit Error Uncorrected */
-#define CAN_MCAN_IR_BEU_POS          (21U)
-#define CAN_MCAN_IR_BEU_MSK          (0x1UL << CAN_MCAN_IR_BEU_POS)
-#define CAN_MCAN_IR_BEU              CAN_MCAN_IR_BEU_MSK
+#define CAN_MCAN_IR_BEU_POS  (21U)
+#define CAN_MCAN_IR_BEU_MSK  (0x1UL << CAN_MCAN_IR_BEU_POS)
+#define CAN_MCAN_IR_BEU	     CAN_MCAN_IR_BEU_MSK
 /* Error Logging Overflow */
-#define CAN_MCAN_IR_ELO_POS          (22U)
-#define CAN_MCAN_IR_ELO_MSK          (0x1UL << CAN_MCAN_IR_ELO_POS)
-#define CAN_MCAN_IR_ELO              CAN_MCAN_IR_ELO_MSK
+#define CAN_MCAN_IR_ELO_POS  (22U)
+#define CAN_MCAN_IR_ELO_MSK  (0x1UL << CAN_MCAN_IR_ELO_POS)
+#define CAN_MCAN_IR_ELO	     CAN_MCAN_IR_ELO_MSK
 /* Error Passive*/
-#define CAN_MCAN_IR_EP_POS           (23U)
-#define CAN_MCAN_IR_EP_MSK           (0x1UL << CAN_MCAN_IR_EP_POS)
-#define CAN_MCAN_IR_EP               CAN_MCAN_IR_EP_MSK
+#define CAN_MCAN_IR_EP_POS   (23U)
+#define CAN_MCAN_IR_EP_MSK   (0x1UL << CAN_MCAN_IR_EP_POS)
+#define CAN_MCAN_IR_EP	     CAN_MCAN_IR_EP_MSK
 /* Warning Status*/
-#define CAN_MCAN_IR_EW_POS           (24U)
-#define CAN_MCAN_IR_EW_MSK           (0x1UL << CAN_MCAN_IR_EW_POS)
-#define CAN_MCAN_IR_EW               CAN_MCAN_IR_EW_MSK
+#define CAN_MCAN_IR_EW_POS   (24U)
+#define CAN_MCAN_IR_EW_MSK   (0x1UL << CAN_MCAN_IR_EW_POS)
+#define CAN_MCAN_IR_EW	     CAN_MCAN_IR_EW_MSK
 /* Bus_Off Status*/
-#define CAN_MCAN_IR_BO_POS           (25U)
-#define CAN_MCAN_IR_BO_MSK           (0x1UL << CAN_MCAN_IR_BO_POS)
-#define CAN_MCAN_IR_BO               CAN_MCAN_IR_BO_MSK
+#define CAN_MCAN_IR_BO_POS   (25U)
+#define CAN_MCAN_IR_BO_MSK   (0x1UL << CAN_MCAN_IR_BO_POS)
+#define CAN_MCAN_IR_BO	     CAN_MCAN_IR_BO_MSK
 /* Watchdog Interrupt */
-#define CAN_MCAN_IR_WDI_POS          (26U)
-#define CAN_MCAN_IR_WDI_MSK          (0x1UL << CAN_MCAN_IR_WDI_POS)
-#define CAN_MCAN_IR_WDI              CAN_MCAN_IR_WDI_MSK
+#define CAN_MCAN_IR_WDI_POS  (26U)
+#define CAN_MCAN_IR_WDI_MSK  (0x1UL << CAN_MCAN_IR_WDI_POS)
+#define CAN_MCAN_IR_WDI	     CAN_MCAN_IR_WDI_MSK
 /* Protocol Error in Arbitration Phase */
-#define CAN_MCAN_IR_PEA_POS          (27U)
-#define CAN_MCAN_IR_PEA_MSK          (0x1UL << CAN_MCAN_IR_PEA_POS)
-#define CAN_MCAN_IR_PEA              CAN_MCAN_IR_PEA_MSK
+#define CAN_MCAN_IR_PEA_POS  (27U)
+#define CAN_MCAN_IR_PEA_MSK  (0x1UL << CAN_MCAN_IR_PEA_POS)
+#define CAN_MCAN_IR_PEA	     CAN_MCAN_IR_PEA_MSK
 /* Protocol Error in Data Phase */
-#define CAN_MCAN_IR_PED_POS          (28U)
-#define CAN_MCAN_IR_PED_MSK          (0x1UL << CAN_MCAN_IR_PED_POS)
-#define CAN_MCAN_IR_PED              CAN_MCAN_IR_PED_MSK
+#define CAN_MCAN_IR_PED_POS  (28U)
+#define CAN_MCAN_IR_PED_MSK  (0x1UL << CAN_MCAN_IR_PED_POS)
+#define CAN_MCAN_IR_PED	     CAN_MCAN_IR_PED_MSK
 /* Access to Reserved Address */
-#define CAN_MCAN_IR_ARA_POS          (29U)
-#define CAN_MCAN_IR_ARA_MSK          (0x1UL << CAN_MCAN_IR_ARA_POS)
-#define CAN_MCAN_IR_ARA              CAN_MCAN_IR_ARA_MSK
+#define CAN_MCAN_IR_ARA_POS  (29U)
+#define CAN_MCAN_IR_ARA_MSK  (0x1UL << CAN_MCAN_IR_ARA_POS)
+#define CAN_MCAN_IR_ARA	     CAN_MCAN_IR_ARA_MSK
 
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_IE register  ********************/
 #ifdef CONFIG_CAN_STM32FD
 /* Rx FIFO 0 New Message Enable */
-#define CAN_MCAN_IE_RF0N_POS        (0U)
-#define CAN_MCAN_IE_RF0N_MSK        (0x1UL << CAN_MCAN_IE_RF0N_POS)
-#define CAN_MCAN_IE_RF0N            CAN_MCAN_IE_RF0N_MSK
+#define CAN_MCAN_IE_RF0N_POS (0U)
+#define CAN_MCAN_IE_RF0N_MSK (0x1UL << CAN_MCAN_IE_RF0N_POS)
+#define CAN_MCAN_IE_RF0N     CAN_MCAN_IE_RF0N_MSK
 /* Rx FIFO 0 Full Enable */
-#define CAN_MCAN_IE_RF0F_POS        (1U)
-#define CAN_MCAN_IE_RF0F_MSK        (0x1UL << CAN_MCAN_IE_RF0F_POS)
-#define CAN_MCAN_IE_RF0F            CAN_MCAN_IE_RF0F_MSK
+#define CAN_MCAN_IE_RF0F_POS (1U)
+#define CAN_MCAN_IE_RF0F_MSK (0x1UL << CAN_MCAN_IE_RF0F_POS)
+#define CAN_MCAN_IE_RF0F     CAN_MCAN_IE_RF0F_MSK
 /* Rx FIFO 0 Message Lost Enable */
-#define CAN_MCAN_IE_RF0L_POS        (2U)
-#define CAN_MCAN_IE_RF0L_MSK        (0x1UL << CAN_MCAN_IE_RF0L_POS)
-#define CAN_MCAN_IE_RF0L            CAN_MCAN_IE_RF0L_MSK
+#define CAN_MCAN_IE_RF0L_POS (2U)
+#define CAN_MCAN_IE_RF0L_MSK (0x1UL << CAN_MCAN_IE_RF0L_POS)
+#define CAN_MCAN_IE_RF0L     CAN_MCAN_IE_RF0L_MSK
 /* Rx FIFO 1 New Message Enable */
-#define CAN_MCAN_IE_RF1N_POS        (3U)
-#define CAN_MCAN_IE_RF1N_MSK        (0x1UL << CAN_MCAN_IE_RF1N_POS)
-#define CAN_MCAN_IE_RF1N            CAN_MCAN_IE_RF1N_MSK
+#define CAN_MCAN_IE_RF1N_POS (3U)
+#define CAN_MCAN_IE_RF1N_MSK (0x1UL << CAN_MCAN_IE_RF1N_POS)
+#define CAN_MCAN_IE_RF1N     CAN_MCAN_IE_RF1N_MSK
 /* Rx FIFO 1 Full Enable */
-#define CAN_MCAN_IE_RF1F_POS        (4U)
-#define CAN_MCAN_IE_RF1F_MSK        (0x1UL << CAN_MCAN_IE_RF1F_POS)
-#define CAN_MCAN_IE_RF1F            CAN_MCAN_IE_RF1F_MSK
+#define CAN_MCAN_IE_RF1F_POS (4U)
+#define CAN_MCAN_IE_RF1F_MSK (0x1UL << CAN_MCAN_IE_RF1F_POS)
+#define CAN_MCAN_IE_RF1F     CAN_MCAN_IE_RF1F_MSK
 /* Rx FIFO 1 Message Lost Enable */
-#define CAN_MCAN_IE_RF1L_POS        (5U)
-#define CAN_MCAN_IE_RF1L_MSK        (0x1UL << CAN_MCAN_IE_RF1L_POS)
-#define CAN_MCAN_IE_RF1L            CAN_MCAN_IE_RF1L_MSK
+#define CAN_MCAN_IE_RF1L_POS (5U)
+#define CAN_MCAN_IE_RF1L_MSK (0x1UL << CAN_MCAN_IE_RF1L_POS)
+#define CAN_MCAN_IE_RF1L     CAN_MCAN_IE_RF1L_MSK
 /* High Priority Message Enable */
-#define CAN_MCAN_IE_HPM_POS         (6U)
-#define CAN_MCAN_IE_HPM_MSK         (0x1UL << CAN_MCAN_IE_HPM_POS)
-#define CAN_MCAN_IE_HPM             CAN_MCAN_IE_HPM_MSK
+#define CAN_MCAN_IE_HPM_POS  (6U)
+#define CAN_MCAN_IE_HPM_MSK  (0x1UL << CAN_MCAN_IE_HPM_POS)
+#define CAN_MCAN_IE_HPM	     CAN_MCAN_IE_HPM_MSK
 /* Transmission Completed Enable */
-#define CAN_MCAN_IE_TC_POS          (7U)
-#define CAN_MCAN_IE_TC_MSK          (0x1UL << CAN_MCAN_IE_TC_POS)
-#define CAN_MCAN_IE_TC              CAN_MCAN_IE_TC_MSK
+#define CAN_MCAN_IE_TC_POS   (7U)
+#define CAN_MCAN_IE_TC_MSK   (0x1UL << CAN_MCAN_IE_TC_POS)
+#define CAN_MCAN_IE_TC	     CAN_MCAN_IE_TC_MSK
 /* Transmission Cancellation Finished Enable*/
-#define CAN_MCAN_IE_TCF_POS         (8U)
-#define CAN_MCAN_IE_TCF_MSK         (0x1UL << CAN_MCAN_IE_TCF_POS)
-#define CAN_MCAN_IE_TCF             CAN_MCAN_IE_TCF_MSK
+#define CAN_MCAN_IE_TCF_POS  (8U)
+#define CAN_MCAN_IE_TCF_MSK  (0x1UL << CAN_MCAN_IE_TCF_POS)
+#define CAN_MCAN_IE_TCF	     CAN_MCAN_IE_TCF_MSK
 /* Tx FIFO Empty Enable */
-#define CAN_MCAN_IE_TFE_POS         (9U)
-#define CAN_MCAN_IE_TFE_MSK         (0x1UL << CAN_MCAN_IE_TFE_POS)
-#define CAN_MCAN_IE_TFE             CAN_MCAN_IE_TFE_MSK
+#define CAN_MCAN_IE_TFE_POS  (9U)
+#define CAN_MCAN_IE_TFE_MSK  (0x1UL << CAN_MCAN_IE_TFE_POS)
+#define CAN_MCAN_IE_TFE	     CAN_MCAN_IE_TFE_MSK
 /* Tx Event FIFO New Entry Enable */
-#define CAN_MCAN_IE_TEFN_POS        (10U)
-#define CAN_MCAN_IE_TEFN_MSK        (0x1UL << CAN_MCAN_IE_TEFN_POS)
-#define CAN_MCAN_IE_TEFN            CAN_MCAN_IE_TEFN_MSK
+#define CAN_MCAN_IE_TEFN_POS (10U)
+#define CAN_MCAN_IE_TEFN_MSK (0x1UL << CAN_MCAN_IE_TEFN_POS)
+#define CAN_MCAN_IE_TEFN     CAN_MCAN_IE_TEFN_MSK
 /* Tx Event FIFO Full Enable */
-#define CAN_MCAN_IE_TEFF_POS        (11U)
-#define CAN_MCAN_IE_TEFF_MSK        (0x1UL << CAN_MCAN_IE_TEFF_POS)
-#define CAN_MCAN_IE_TEFF            CAN_MCAN_IE_TEFF_MSK
+#define CAN_MCAN_IE_TEFF_POS (11U)
+#define CAN_MCAN_IE_TEFF_MSK (0x1UL << CAN_MCAN_IE_TEFF_POS)
+#define CAN_MCAN_IE_TEFF     CAN_MCAN_IE_TEFF_MSK
 /* Tx Event FIFO Element Lost Enable */
-#define CAN_MCAN_IE_TEFL_POS        (12U)
-#define CAN_MCAN_IE_TEFL_MSK        (0x1UL << CAN_MCAN_IE_TEFL_POS)
-#define CAN_MCAN_IE_TEFL            CAN_MCAN_IE_TEFL_MSK
- /* Timestamp Wraparound Enable */
-#define CAN_MCAN_IE_TSW_POS         (13U)
-#define CAN_MCAN_IE_TSW_MSK         (0x1UL << CAN_MCAN_IE_TSW_POS)
-#define CAN_MCAN_IE_TSW             CAN_MCAN_IE_TSW_MSK
+#define CAN_MCAN_IE_TEFL_POS (12U)
+#define CAN_MCAN_IE_TEFL_MSK (0x1UL << CAN_MCAN_IE_TEFL_POS)
+#define CAN_MCAN_IE_TEFL     CAN_MCAN_IE_TEFL_MSK
+/* Timestamp Wraparound Enable */
+#define CAN_MCAN_IE_TSW_POS  (13U)
+#define CAN_MCAN_IE_TSW_MSK  (0x1UL << CAN_MCAN_IE_TSW_POS)
+#define CAN_MCAN_IE_TSW	     CAN_MCAN_IE_TSW_MSK
 /* Message RAM Access Failure Enable */
-#define CAN_MCAN_IE_MRAF_POS        (14U)
-#define CAN_MCAN_IE_MRAF_MSK        (0x1UL << CAN_MCAN_IE_MRAF_POS)
-#define CAN_MCAN_IE_MRAF            CAN_MCAN_IE_MRAF_MSK
+#define CAN_MCAN_IE_MRAF_POS (14U)
+#define CAN_MCAN_IE_MRAF_MSK (0x1UL << CAN_MCAN_IE_MRAF_POS)
+#define CAN_MCAN_IE_MRAF     CAN_MCAN_IE_MRAF_MSK
 /* Timeout Occurred Enable */
-#define CAN_MCAN_IE_TOO_POS         (15U)
-#define CAN_MCAN_IE_TOO_MSK         (0x1UL << CAN_MCAN_IE_TOO_POS)
-#define CAN_MCAN_IE_TOO             CAN_MCAN_IE_TOO_MSK
+#define CAN_MCAN_IE_TOO_POS  (15U)
+#define CAN_MCAN_IE_TOO_MSK  (0x1UL << CAN_MCAN_IE_TOO_POS)
+#define CAN_MCAN_IE_TOO	     CAN_MCAN_IE_TOO_MSK
 /* Error Logging Overflow Enable */
-#define CAN_MCAN_IE_ELO_POS         (16U)
-#define CAN_MCAN_IE_ELO_MSK         (0x1UL << CAN_MCAN_IE_ELO_POS)
-#define CAN_MCAN_IE_ELO             CAN_MCAN_IE_ELO_MSK
+#define CAN_MCAN_IE_ELO_POS  (16U)
+#define CAN_MCAN_IE_ELO_MSK  (0x1UL << CAN_MCAN_IE_ELO_POS)
+#define CAN_MCAN_IE_ELO	     CAN_MCAN_IE_ELO_MSK
 /* Error Passive Enable */
-#define CAN_MCAN_IE_EP_POS          (17U)
-#define CAN_MCAN_IE_EP_MSK          (0x1UL << CAN_MCAN_IE_EP_POS)
-#define CAN_MCAN_IE_EP              CAN_MCAN_IE_EP_MSK
+#define CAN_MCAN_IE_EP_POS   (17U)
+#define CAN_MCAN_IE_EP_MSK   (0x1UL << CAN_MCAN_IE_EP_POS)
+#define CAN_MCAN_IE_EP	     CAN_MCAN_IE_EP_MSK
 /* Warning Status Enable */
-#define CAN_MCAN_IE_EW_POS          (18U)
-#define CAN_MCAN_IE_EW_MSK          (0x1UL << CAN_MCAN_IE_EW_POS)
-#define CAN_MCAN_IE_EW              CAN_MCAN_IE_EW_MSK
+#define CAN_MCAN_IE_EW_POS   (18U)
+#define CAN_MCAN_IE_EW_MSK   (0x1UL << CAN_MCAN_IE_EW_POS)
+#define CAN_MCAN_IE_EW	     CAN_MCAN_IE_EW_MSK
 /* Bus_Off Status Enable */
-#define CAN_MCAN_IE_BO_POS          (19U)
-#define CAN_MCAN_IE_BO_MSK          (0x1UL << CAN_MCAN_IE_BO_POS)
-#define CAN_MCAN_IE_BO              CAN_MCAN_IE_BO_MSK
+#define CAN_MCAN_IE_BO_POS   (19U)
+#define CAN_MCAN_IE_BO_MSK   (0x1UL << CAN_MCAN_IE_BO_POS)
+#define CAN_MCAN_IE_BO	     CAN_MCAN_IE_BO_MSK
 /* Watchdog Interrupt Enable  */
-#define CAN_MCAN_IE_WDI_POS         (20U)
-#define CAN_MCAN_IE_WDI_MSK         (0x1UL << CAN_MCAN_IE_WDI_POS)
-#define CAN_MCAN_IE_WDI             CAN_MCAN_IE_WDIE_MSK
+#define CAN_MCAN_IE_WDI_POS  (20U)
+#define CAN_MCAN_IE_WDI_MSK  (0x1UL << CAN_MCAN_IE_WDI_POS)
+#define CAN_MCAN_IE_WDI	     CAN_MCAN_IE_WDIE_MSK
 /* Protocol Error in Arbitration Phase Enable */
-#define CAN_MCAN_IE_PEA_POS         (21U)
-#define CAN_MCAN_IE_PEA_MSK         (0x1UL << CAN_MCAN_IE_PEA_POS)
-#define CAN_MCAN_IE_PEA             CAN_MCAN_IE_PEA_MSK
+#define CAN_MCAN_IE_PEA_POS  (21U)
+#define CAN_MCAN_IE_PEA_MSK  (0x1UL << CAN_MCAN_IE_PEA_POS)
+#define CAN_MCAN_IE_PEA	     CAN_MCAN_IE_PEA_MSK
 /* Protocol Error in Data Phase Enable */
-#define CAN_MCAN_IE_PED_POS         (22U)
-#define CAN_MCAN_IE_PED_MSK         (0x1UL << CAN_MCAN_IE_PED_POS)
-#define CAN_MCAN_IE_PED             CAN_MCAN_IE_PED_MSK
+#define CAN_MCAN_IE_PED_POS  (22U)
+#define CAN_MCAN_IE_PED_MSK  (0x1UL << CAN_MCAN_IE_PED_POS)
+#define CAN_MCAN_IE_PED	     CAN_MCAN_IE_PED_MSK
 /* Access to Reserved Address Enable */
-#define CAN_MCAN_IE_ARA_POS         (23U)
-#define CAN_MCAN_IE_ARA_MSK         (0x1UL << CAN_MCAN_IE_ARA_POS)
-#define CAN_MCAN_IE_ARA             CAN_MCAN_IE_ARA_MSK
+#define CAN_MCAN_IE_ARA_POS  (23U)
+#define CAN_MCAN_IE_ARA_MSK  (0x1UL << CAN_MCAN_IE_ARA_POS)
+#define CAN_MCAN_IE_ARA	     CAN_MCAN_IE_ARA_MSK
 
 #else /* CONFIG_CAN_STM32FD */
 
 /* Rx FIFO 0 New Message */
-#define CAN_MCAN_IE_RF0N_POS         (0U)
-#define CAN_MCAN_IE_RF0N_MSK         (0x1UL << CAN_MCAN_IE_RF0N_POS)
-#define CAN_MCAN_IE_RF0N             CAN_MCAN_IE_RF0N_MSK
+#define CAN_MCAN_IE_RF0N_POS (0U)
+#define CAN_MCAN_IE_RF0N_MSK (0x1UL << CAN_MCAN_IE_RF0N_POS)
+#define CAN_MCAN_IE_RF0N     CAN_MCAN_IE_RF0N_MSK
 /* Rx FIFO 0 Watermark Reached*/
-#define CAN_MCAN_IE_RF0W_POS         (1U)
-#define CAN_MCAN_IE_RF0W_MSK         (0x1UL << CAN_MCAN_IE_RF0W_POS)
-#define CAN_MCAN_IE_RF0W             CAN_MCAN_IE_RF0W_MSK
+#define CAN_MCAN_IE_RF0W_POS (1U)
+#define CAN_MCAN_IE_RF0W_MSK (0x1UL << CAN_MCAN_IE_RF0W_POS)
+#define CAN_MCAN_IE_RF0W     CAN_MCAN_IE_RF0W_MSK
 /* Rx FIFO 0 Full */
-#define CAN_MCAN_IE_RF0F_POS         (2U)
-#define CAN_MCAN_IE_RF0F_MSK         (0x1UL << CAN_MCAN_IE_RF0F_POS)
-#define CAN_MCAN_IE_RF0F             CAN_MCAN_IE_RF0F_MSK
+#define CAN_MCAN_IE_RF0F_POS (2U)
+#define CAN_MCAN_IE_RF0F_MSK (0x1UL << CAN_MCAN_IE_RF0F_POS)
+#define CAN_MCAN_IE_RF0F     CAN_MCAN_IE_RF0F_MSK
 /* Rx FIFO 0 Message Lost */
-#define CAN_MCAN_IE_RF0L_POS         (3U)
-#define CAN_MCAN_IE_RF0L_MSK         (0x1UL << CAN_MCAN_IE_RF0L_POS)
-#define CAN_MCAN_IE_RF0L             CAN_MCAN_IE_RF0L_MSK
+#define CAN_MCAN_IE_RF0L_POS (3U)
+#define CAN_MCAN_IE_RF0L_MSK (0x1UL << CAN_MCAN_IE_RF0L_POS)
+#define CAN_MCAN_IE_RF0L     CAN_MCAN_IE_RF0L_MSK
 /* Rx FIFO 1 New Message */
-#define CAN_MCAN_IE_RF1N_POS         (4U)
-#define CAN_MCAN_IE_RF1N_MSK         (0x1UL << CAN_MCAN_IE_RF1N_POS)
-#define CAN_MCAN_IE_RF1N             CAN_MCAN_IE_RF1N_MSK
+#define CAN_MCAN_IE_RF1N_POS (4U)
+#define CAN_MCAN_IE_RF1N_MSK (0x1UL << CAN_MCAN_IE_RF1N_POS)
+#define CAN_MCAN_IE_RF1N     CAN_MCAN_IE_RF1N_MSK
 /* Rx FIFO 1 Watermark Reached*/
-#define CAN_MCAN_IE_RF1W_POS         (5U)
-#define CAN_MCAN_IE_RF1W_MSK         (0x1UL << CAN_MCAN_IE_RF1W_POS)
-#define CAN_MCAN_IE_RF1W             CAN_MCAN_IE_RF1W_MSK
+#define CAN_MCAN_IE_RF1W_POS (5U)
+#define CAN_MCAN_IE_RF1W_MSK (0x1UL << CAN_MCAN_IE_RF1W_POS)
+#define CAN_MCAN_IE_RF1W     CAN_MCAN_IE_RF1W_MSK
 /* Rx FIFO 1 Full */
-#define CAN_MCAN_IE_RF1F_POS         (6U)
-#define CAN_MCAN_IE_RF1F_MSK         (0x1UL << CAN_MCAN_IE_RF1F_POS)
-#define CAN_MCAN_IE_RF1F             CAN_MCAN_IE_RF1F_MSK
+#define CAN_MCAN_IE_RF1F_POS (6U)
+#define CAN_MCAN_IE_RF1F_MSK (0x1UL << CAN_MCAN_IE_RF1F_POS)
+#define CAN_MCAN_IE_RF1F     CAN_MCAN_IE_RF1F_MSK
 /* Rx FIFO 1 Message Lost */
-#define CAN_MCAN_IE_RF1L_POS         (7U)
-#define CAN_MCAN_IE_RF1L_MSK         (0x1UL << CAN_MCAN_IE_RF1L_POS)
-#define CAN_MCAN_IE_RF1L             CAN_MCAN_IE_RF1L_MSK
+#define CAN_MCAN_IE_RF1L_POS (7U)
+#define CAN_MCAN_IE_RF1L_MSK (0x1UL << CAN_MCAN_IE_RF1L_POS)
+#define CAN_MCAN_IE_RF1L     CAN_MCAN_IE_RF1L_MSK
 /* High Priority Message */
-#define CAN_MCAN_IE_HPM_POS          (8U)
-#define CAN_MCAN_IE_HPM_MSK          (0x1UL << CAN_MCAN_IE_HPM_POS)
-#define CAN_MCAN_IE_HPM              CAN_MCAN_IE_HPM_MSK
+#define CAN_MCAN_IE_HPM_POS  (8U)
+#define CAN_MCAN_IE_HPM_MSK  (0x1UL << CAN_MCAN_IE_HPM_POS)
+#define CAN_MCAN_IE_HPM	     CAN_MCAN_IE_HPM_MSK
 /* Transmission Completed */
-#define CAN_MCAN_IE_TC_POS           (9U)
-#define CAN_MCAN_IE_TC_MSK           (0x1UL << CAN_MCAN_IE_TC_POS)
-#define CAN_MCAN_IE_TC               CAN_MCAN_IE_TC_MSK
+#define CAN_MCAN_IE_TC_POS   (9U)
+#define CAN_MCAN_IE_TC_MSK   (0x1UL << CAN_MCAN_IE_TC_POS)
+#define CAN_MCAN_IE_TC	     CAN_MCAN_IE_TC_MSK
 /* Transmission Cancellation Finished */
-#define CAN_MCAN_IE_TCF_POS          (10U)
-#define CAN_MCAN_IE_TCF_MSK          (0x1UL << CAN_MCAN_IE_TCF_POS)
-#define CAN_MCAN_IE_TCF              CAN_MCAN_IE_TCF_MSK
+#define CAN_MCAN_IE_TCF_POS  (10U)
+#define CAN_MCAN_IE_TCF_MSK  (0x1UL << CAN_MCAN_IE_TCF_POS)
+#define CAN_MCAN_IE_TCF	     CAN_MCAN_IE_TCF_MSK
 /* Tx FIFO Empty */
-#define CAN_MCAN_IE_TFE_POS          (11U)
-#define CAN_MCAN_IE_TFE_MSK          (0x1UL << CAN_MCAN_IE_TFE_POS)
-#define CAN_MCAN_IE_TFE              CAN_MCAN_IE_TFE_MSK
+#define CAN_MCAN_IE_TFE_POS  (11U)
+#define CAN_MCAN_IE_TFE_MSK  (0x1UL << CAN_MCAN_IE_TFE_POS)
+#define CAN_MCAN_IE_TFE	     CAN_MCAN_IE_TFE_MSK
 /* Tx Event FIFO New Entry */
-#define CAN_MCAN_IE_TEFN_POS         (12U)
-#define CAN_MCAN_IE_TEFN_MSK         (0x1UL << CAN_MCAN_IE_TEFN_POS)
-#define CAN_MCAN_IE_TEFN             CAN_MCAN_IE_TEFN_MSK
+#define CAN_MCAN_IE_TEFN_POS (12U)
+#define CAN_MCAN_IE_TEFN_MSK (0x1UL << CAN_MCAN_IE_TEFN_POS)
+#define CAN_MCAN_IE_TEFN     CAN_MCAN_IE_TEFN_MSK
 /* Tx Event FIFO Watermark */
-#define CAN_MCAN_IE_TEFW_POS         (13U)
-#define CAN_MCAN_IE_TEFW_MSK         (0x1UL << CAN_MCAN_IE_TEFW_POS)
-#define CAN_MCAN_IE_TEFW             CAN_MCAN_IE_TEFW_MSK
+#define CAN_MCAN_IE_TEFW_POS (13U)
+#define CAN_MCAN_IE_TEFW_MSK (0x1UL << CAN_MCAN_IE_TEFW_POS)
+#define CAN_MCAN_IE_TEFW     CAN_MCAN_IE_TEFW_MSK
 /* Tx Event FIFO Full */
-#define CAN_MCAN_IE_TEFF_POS         (14U)
-#define CAN_MCAN_IE_TEFF_MSK         (0x1UL << CAN_MCAN_IE_TEFF_POS)
-#define CAN_MCAN_IE_TEFF             CAN_MCAN_IE_TEFF_MSK
+#define CAN_MCAN_IE_TEFF_POS (14U)
+#define CAN_MCAN_IE_TEFF_MSK (0x1UL << CAN_MCAN_IE_TEFF_POS)
+#define CAN_MCAN_IE_TEFF     CAN_MCAN_IE_TEFF_MSK
 /* Tx Event FIFO Element Lost */
-#define CAN_MCAN_IE_TEFL_POS         (15U)
-#define CAN_MCAN_IE_TEFL_MSK         (0x1UL << CAN_MCAN_IE_TEFL_POS)
-#define CAN_MCAN_IE_TEFL             CAN_MCAN_IE_TEFL_MSK
+#define CAN_MCAN_IE_TEFL_POS (15U)
+#define CAN_MCAN_IE_TEFL_MSK (0x1UL << CAN_MCAN_IE_TEFL_POS)
+#define CAN_MCAN_IE_TEFL     CAN_MCAN_IE_TEFL_MSK
 /* Timestamp Wraparound */
-#define CAN_MCAN_IE_TSW_POS          (16U)
-#define CAN_MCAN_IE_TSW_MSK          (0x1UL << CAN_MCAN_IE_TSW_POS)
-#define CAN_MCAN_IE_TSW              CAN_MCAN_IE_TSW_MSK
+#define CAN_MCAN_IE_TSW_POS  (16U)
+#define CAN_MCAN_IE_TSW_MSK  (0x1UL << CAN_MCAN_IE_TSW_POS)
+#define CAN_MCAN_IE_TSW	     CAN_MCAN_IE_TSW_MSK
 /* Message RAM Access Failure */
-#define CAN_MCAN_IE_MRAF_POS         (17U)
-#define CAN_MCAN_IE_MRAF_MSK         (0x1UL << CAN_MCAN_IE_MRAF_POS)
-#define CAN_MCAN_IE_MRAF             CAN_MCAN_IE_MRAF_MSK
+#define CAN_MCAN_IE_MRAF_POS (17U)
+#define CAN_MCAN_IE_MRAF_MSK (0x1UL << CAN_MCAN_IE_MRAF_POS)
+#define CAN_MCAN_IE_MRAF     CAN_MCAN_IE_MRAF_MSK
 /* Timeout Occurred */
-#define CAN_MCAN_IE_TOO_POS          (18U)
-#define CAN_MCAN_IE_TOO_MSK          (0x1UL << CAN_MCAN_IE_TOO_POS)
-#define CAN_MCAN_IE_TOO              CAN_MCAN_IE_TOO_MSK
+#define CAN_MCAN_IE_TOO_POS  (18U)
+#define CAN_MCAN_IE_TOO_MSK  (0x1UL << CAN_MCAN_IE_TOO_POS)
+#define CAN_MCAN_IE_TOO	     CAN_MCAN_IE_TOO_MSK
 /* Message stored to Dedicated Rx Buffer */
-#define CAN_MCAN_IE_DRX_POS          (19U)
-#define CAN_MCAN_IE_DRX_MSK          (0x1UL << CAN_MCAN_IE_DRX_POS)
-#define CAN_MCAN_IE_DRX              CAN_MCAN_IE_DRX_MSK
+#define CAN_MCAN_IE_DRX_POS  (19U)
+#define CAN_MCAN_IE_DRX_MSK  (0x1UL << CAN_MCAN_IE_DRX_POS)
+#define CAN_MCAN_IE_DRX	     CAN_MCAN_IE_DRX_MSK
 /* Bit Error Corrected */
-#define CAN_MCAN_IE_BEC_POS          (20U)
-#define CAN_MCAN_IE_BEC_MSK          (0x1UL << CAN_MCAN_IE_BEC_POS)
-#define CAN_MCAN_IE_BEC              CAN_MCAN_IE_BEC_MSK
+#define CAN_MCAN_IE_BEC_POS  (20U)
+#define CAN_MCAN_IE_BEC_MSK  (0x1UL << CAN_MCAN_IE_BEC_POS)
+#define CAN_MCAN_IE_BEC	     CAN_MCAN_IE_BEC_MSK
 /* Bit Error Uncorrected */
-#define CAN_MCAN_IE_BEU_POS          (21U)
-#define CAN_MCAN_IE_BEU_MSK          (0x1UL << CAN_MCAN_IE_BEU_POS)
-#define CAN_MCAN_IE_BEU              CAN_MCAN_IE_BEU_MSK
+#define CAN_MCAN_IE_BEU_POS  (21U)
+#define CAN_MCAN_IE_BEU_MSK  (0x1UL << CAN_MCAN_IE_BEU_POS)
+#define CAN_MCAN_IE_BEU	     CAN_MCAN_IE_BEU_MSK
 /* Error Logging Overflow */
-#define CAN_MCAN_IE_ELO_POS          (22U)
-#define CAN_MCAN_IE_ELO_MSK          (0x1UL << CAN_MCAN_IE_ELO_POS)
-#define CAN_MCAN_IE_ELO              CAN_MCAN_IE_ELO_MSK
+#define CAN_MCAN_IE_ELO_POS  (22U)
+#define CAN_MCAN_IE_ELO_MSK  (0x1UL << CAN_MCAN_IE_ELO_POS)
+#define CAN_MCAN_IE_ELO	     CAN_MCAN_IE_ELO_MSK
 /* Error Passive*/
-#define CAN_MCAN_IE_EP_POS           (23U)
-#define CAN_MCAN_IE_EP_MSK           (0x1UL << CAN_MCAN_IE_EP_POS)
-#define CAN_MCAN_IE_EP               CAN_MCAN_IE_EP_MSK
+#define CAN_MCAN_IE_EP_POS   (23U)
+#define CAN_MCAN_IE_EP_MSK   (0x1UL << CAN_MCAN_IE_EP_POS)
+#define CAN_MCAN_IE_EP	     CAN_MCAN_IE_EP_MSK
 /* Warning Status*/
-#define CAN_MCAN_IE_EW_POS           (24U)
-#define CAN_MCAN_IE_EW_MSK           (0x1UL << CAN_MCAN_IE_EW_POS)
-#define CAN_MCAN_IE_EW               CAN_MCAN_IE_EW_MSK
+#define CAN_MCAN_IE_EW_POS   (24U)
+#define CAN_MCAN_IE_EW_MSK   (0x1UL << CAN_MCAN_IE_EW_POS)
+#define CAN_MCAN_IE_EW	     CAN_MCAN_IE_EW_MSK
 /* Bus_Off Status*/
-#define CAN_MCAN_IE_BO_POS           (25U)
-#define CAN_MCAN_IE_BO_MSK           (0x1UL << CAN_MCAN_IE_BO_POS)
-#define CAN_MCAN_IE_BO               CAN_MCAN_IE_BO_MSK
+#define CAN_MCAN_IE_BO_POS   (25U)
+#define CAN_MCAN_IE_BO_MSK   (0x1UL << CAN_MCAN_IE_BO_POS)
+#define CAN_MCAN_IE_BO	     CAN_MCAN_IE_BO_MSK
 /* Watchdog Interrupt */
-#define CAN_MCAN_IE_WDI_POS          (26U)
-#define CAN_MCAN_IE_WDI_MSK          (0x1UL << CAN_MCAN_IE_WDI_POS)
-#define CAN_MCAN_IE_WDI              CAN_MCAN_IE_WDI_MSK
+#define CAN_MCAN_IE_WDI_POS  (26U)
+#define CAN_MCAN_IE_WDI_MSK  (0x1UL << CAN_MCAN_IE_WDI_POS)
+#define CAN_MCAN_IE_WDI	     CAN_MCAN_IE_WDI_MSK
 /* Protocol Error in Arbitration Phase */
-#define CAN_MCAN_IE_PEA_POS          (27U)
-#define CAN_MCAN_IE_PEA_MSK          (0x1UL << CAN_MCAN_IE_PEA_POS)
-#define CAN_MCAN_IE_PEA              CAN_MCAN_IE_PEA_MSK
+#define CAN_MCAN_IE_PEA_POS  (27U)
+#define CAN_MCAN_IE_PEA_MSK  (0x1UL << CAN_MCAN_IE_PEA_POS)
+#define CAN_MCAN_IE_PEA	     CAN_MCAN_IE_PEA_MSK
 /* Protocol Error in Data Phase */
-#define CAN_MCAN_IE_PED_POS          (28U)
-#define CAN_MCAN_IE_PED_MSK          (0x1UL << CAN_MCAN_IE_PED_POS)
-#define CAN_MCAN_IE_PED              CAN_MCAN_IE_PED_MSK
+#define CAN_MCAN_IE_PED_POS  (28U)
+#define CAN_MCAN_IE_PED_MSK  (0x1UL << CAN_MCAN_IE_PED_POS)
+#define CAN_MCAN_IE_PED	     CAN_MCAN_IE_PED_MSK
 /* Access to Reserved Address */
-#define CAN_MCAN_IE_ARA_POS          (29U)
-#define CAN_MCAN_IE_ARA_MSK          (0x1UL << CAN_MCAN_IE_ARA_POS)
-#define CAN_MCAN_IE_ARA              CAN_MCAN_IE_ARA_MSK
+#define CAN_MCAN_IE_ARA_POS  (29U)
+#define CAN_MCAN_IE_ARA_MSK  (0x1UL << CAN_MCAN_IE_ARA_POS)
+#define CAN_MCAN_IE_ARA	     CAN_MCAN_IE_ARA_MSK
 
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_ILS register  *******************/
 #ifdef CONFIG_CAN_STM32FD
 /* Rx FIFO 0 */
-#define CAN_MCAN_ILS_RXFIFO0_POS     (0U)
-#define CAN_MCAN_ILS_RXFIFO0_MSK     (0x1UL << CAN_MCAN_ILS_RXFIFO0_POS)
-#define CAN_MCAN_ILS_RXFIFO0         CAN_MCAN_ILS_RXFIFO0_MSK
+#define CAN_MCAN_ILS_RXFIFO0_POS (0U)
+#define CAN_MCAN_ILS_RXFIFO0_MSK (0x1UL << CAN_MCAN_ILS_RXFIFO0_POS)
+#define CAN_MCAN_ILS_RXFIFO0	 CAN_MCAN_ILS_RXFIFO0_MSK
 /* Rx FIFO 1 */
-#define CAN_MCAN_ILS_RXFIFO1_POS     (1U)
-#define CAN_MCAN_ILS_RXFIFO1_MSK     (0x1UL << CAN_MCAN_ILS_RXFIFO1_POS)
-#define CAN_MCAN_ILS_RXFIFO1         CAN_MCAN_ILS_RXFIFO1_MSK
+#define CAN_MCAN_ILS_RXFIFO1_POS (1U)
+#define CAN_MCAN_ILS_RXFIFO1_MSK (0x1UL << CAN_MCAN_ILS_RXFIFO1_POS)
+#define CAN_MCAN_ILS_RXFIFO1	 CAN_MCAN_ILS_RXFIFO1_MSK
 /* Transmission Cancellation Finished */
-#define CAN_MCAN_ILS_SMSG_POS        (2U)
-#define CAN_MCAN_ILS_SMSG_MSK        (0x1UL << CAN_MCAN_ILS_SMSG_POS)
-#define CAN_MCAN_ILS_SMSG            CAN_MCAN_ILS_SMSG_MSK
+#define CAN_MCAN_ILS_SMSG_POS	 (2U)
+#define CAN_MCAN_ILS_SMSG_MSK	 (0x1UL << CAN_MCAN_ILS_SMSG_POS)
+#define CAN_MCAN_ILS_SMSG	 CAN_MCAN_ILS_SMSG_MSK
 /* Tx Event FIFO Element Lost */
-#define CAN_MCAN_ILS_TFERR_POS       (3U)
-#define CAN_MCAN_ILS_TFERR_MSK       (0x1UL << CAN_MCAN_ILS_TFERR_POS)
-#define CAN_MCAN_ILS_TFERR           CAN_MCAN_ILS_TFERR_MSK
+#define CAN_MCAN_ILS_TFERR_POS	 (3U)
+#define CAN_MCAN_ILS_TFERR_MSK	 (0x1UL << CAN_MCAN_ILS_TFERR_POS)
+#define CAN_MCAN_ILS_TFERR	 CAN_MCAN_ILS_TFERR_MSK
 /* Timeout Occurred */
-#define CAN_MCAN_ILS_MISC_POS        (4U)
-#define CAN_MCAN_ILS_MISC_MSK        (0x1UL << CAN_MCAN_ILS_MISC_POS)
-#define CAN_MCAN_ILS_MISC            CAN_MCAN_ILS_MISC_MSK
+#define CAN_MCAN_ILS_MISC_POS	 (4U)
+#define CAN_MCAN_ILS_MISC_MSK	 (0x1UL << CAN_MCAN_ILS_MISC_POS)
+#define CAN_MCAN_ILS_MISC	 CAN_MCAN_ILS_MISC_MSK
 /* Error Passive Error Logging Overflow */
-#define CAN_MCAN_ILS_BERR_POS        (5U)
-#define CAN_MCAN_ILS_BERR_MSK        (0x1UL << CAN_MCAN_ILS_BERR_POS)
-#define CAN_MCAN_ILS_BERR            CAN_MCAN_ILS_BERR_MSK
+#define CAN_MCAN_ILS_BERR_POS	 (5U)
+#define CAN_MCAN_ILS_BERR_MSK	 (0x1UL << CAN_MCAN_ILS_BERR_POS)
+#define CAN_MCAN_ILS_BERR	 CAN_MCAN_ILS_BERR_MSK
 /* Access to Reserved Address Line */
-#define CAN_MCAN_ILS_PERR_POS        (6U)
-#define CAN_MCAN_ILS_PERR_MSK        (0x1UL << CAN_MCAN_ILS_PERR_POS)
-#define CAN_MCAN_ILS_PERR            CAN_MCAN_ILS_PERR_MSK
+#define CAN_MCAN_ILS_PERR_POS	 (6U)
+#define CAN_MCAN_ILS_PERR_MSK	 (0x1UL << CAN_MCAN_ILS_PERR_POS)
+#define CAN_MCAN_ILS_PERR	 CAN_MCAN_ILS_PERR_MSK
 
-#else/* CONFIG_CAN_STM32FD */
+#else /* CONFIG_CAN_STM32FD */
 /* Rx FIFO 0 New Message */
-#define CAN_MCAN_ILS_RF0N_POS         (0U)
-#define CAN_MCAN_ILS_RF0N_MSK         (0x1UL << CAN_MCAN_ILS_RF0N_POS)
-#define CAN_MCAN_ILS_RF0N             CAN_MCAN_ILS_RF0N_MSK
+#define CAN_MCAN_ILS_RF0N_POS (0U)
+#define CAN_MCAN_ILS_RF0N_MSK (0x1UL << CAN_MCAN_ILS_RF0N_POS)
+#define CAN_MCAN_ILS_RF0N     CAN_MCAN_ILS_RF0N_MSK
 /* Rx FIFO 0 Watermark Reached*/
-#define CAN_MCAN_ILS_RF0W_POS         (1U)
-#define CAN_MCAN_ILS_RF0W_MSK         (0x1UL << CAN_MCAN_ILS_RF0W_POS)
-#define CAN_MCAN_ILS_RF0W             CAN_MCAN_ILS_RF0W_MSK
+#define CAN_MCAN_ILS_RF0W_POS (1U)
+#define CAN_MCAN_ILS_RF0W_MSK (0x1UL << CAN_MCAN_ILS_RF0W_POS)
+#define CAN_MCAN_ILS_RF0W     CAN_MCAN_ILS_RF0W_MSK
 /* Rx FIFO 0 Full */
-#define CAN_MCAN_ILS_RF0F_POS         (2U)
-#define CAN_MCAN_ILS_RF0F_MSK         (0x1UL << CAN_MCAN_ILS_RF0F_POS)
-#define CAN_MCAN_ILS_RF0F             CAN_MCAN_ILS_RF0F_MSK
+#define CAN_MCAN_ILS_RF0F_POS (2U)
+#define CAN_MCAN_ILS_RF0F_MSK (0x1UL << CAN_MCAN_ILS_RF0F_POS)
+#define CAN_MCAN_ILS_RF0F     CAN_MCAN_ILS_RF0F_MSK
 /* Rx FIFO 0 Message Lost */
-#define CAN_MCAN_ILS_RF0L_POS         (3U)
-#define CAN_MCAN_ILS_RF0L_MSK         (0x1UL << CAN_MCAN_ILS_RF0L_POS)
-#define CAN_MCAN_ILS_RF0L             CAN_MCAN_ILS_RF0L_MSK
+#define CAN_MCAN_ILS_RF0L_POS (3U)
+#define CAN_MCAN_ILS_RF0L_MSK (0x1UL << CAN_MCAN_ILS_RF0L_POS)
+#define CAN_MCAN_ILS_RF0L     CAN_MCAN_ILS_RF0L_MSK
 /* Rx FIFO 1 New Message */
-#define CAN_MCAN_ILS_RF1N_POS         (4U)
-#define CAN_MCAN_ILS_RF1N_MSK         (0x1UL << CAN_MCAN_ILS_RF1N_POS)
-#define CAN_MCAN_ILS_RF1N             CAN_MCAN_ILS_RF1N_MSK
+#define CAN_MCAN_ILS_RF1N_POS (4U)
+#define CAN_MCAN_ILS_RF1N_MSK (0x1UL << CAN_MCAN_ILS_RF1N_POS)
+#define CAN_MCAN_ILS_RF1N     CAN_MCAN_ILS_RF1N_MSK
 /* Rx FIFO 1 Watermark Reached*/
-#define CAN_MCAN_ILS_RF1W_POS         (5U)
-#define CAN_MCAN_ILS_RF1W_MSK         (0x1UL << CAN_MCAN_ILS_RF1W_POS)
-#define CAN_MCAN_ILS_RF1W             CAN_MCAN_ILS_RF1W_MSK
+#define CAN_MCAN_ILS_RF1W_POS (5U)
+#define CAN_MCAN_ILS_RF1W_MSK (0x1UL << CAN_MCAN_ILS_RF1W_POS)
+#define CAN_MCAN_ILS_RF1W     CAN_MCAN_ILS_RF1W_MSK
 /* Rx FIFO 1 Full */
-#define CAN_MCAN_ILS_RF1F_POS         (6U)
-#define CAN_MCAN_ILS_RF1F_MSK         (0x1UL << CAN_MCAN_ILS_RF1F_POS)
-#define CAN_MCAN_ILS_RF1F             CAN_MCAN_ILS_RF1F_MSK
+#define CAN_MCAN_ILS_RF1F_POS (6U)
+#define CAN_MCAN_ILS_RF1F_MSK (0x1UL << CAN_MCAN_ILS_RF1F_POS)
+#define CAN_MCAN_ILS_RF1F     CAN_MCAN_ILS_RF1F_MSK
 /* Rx FIFO 1 Message Lost */
-#define CAN_MCAN_ILS_RF1L_POS         (7U)
-#define CAN_MCAN_ILS_RF1L_MSK         (0x1UL << CAN_MCAN_ILS_RF1L_POS)
-#define CAN_MCAN_ILS_RF1L             CAN_MCAN_ILS_RF1L_MSK
+#define CAN_MCAN_ILS_RF1L_POS (7U)
+#define CAN_MCAN_ILS_RF1L_MSK (0x1UL << CAN_MCAN_ILS_RF1L_POS)
+#define CAN_MCAN_ILS_RF1L     CAN_MCAN_ILS_RF1L_MSK
 /* High Priority Message */
-#define CAN_MCAN_ILS_HPM_POS          (8U)
-#define CAN_MCAN_ILS_HPM_MSK          (0x1UL << CAN_MCAN_ILS_HPM_POS)
-#define CAN_MCAN_ILS_HPM              CAN_MCAN_ILS_HPM_MSK
+#define CAN_MCAN_ILS_HPM_POS  (8U)
+#define CAN_MCAN_ILS_HPM_MSK  (0x1UL << CAN_MCAN_ILS_HPM_POS)
+#define CAN_MCAN_ILS_HPM      CAN_MCAN_ILS_HPM_MSK
 /* Transmission Completed */
-#define CAN_MCAN_ILS_TC_POS           (9U)
-#define CAN_MCAN_ILS_TC_MSK           (0x1UL << CAN_MCAN_ILS_TC_POS)
-#define CAN_MCAN_ILS_TC               CAN_MCAN_ILS_TC_MSK
+#define CAN_MCAN_ILS_TC_POS   (9U)
+#define CAN_MCAN_ILS_TC_MSK   (0x1UL << CAN_MCAN_ILS_TC_POS)
+#define CAN_MCAN_ILS_TC	      CAN_MCAN_ILS_TC_MSK
 /* Transmission Cancellation Finished */
-#define CAN_MCAN_ILS_TCF_POS          (10U)
-#define CAN_MCAN_ILS_TCF_MSK          (0x1UL << CAN_MCAN_ILS_TCF_POS)
-#define CAN_MCAN_ILS_TCF              CAN_MCAN_ILS_TCF_MSK
+#define CAN_MCAN_ILS_TCF_POS  (10U)
+#define CAN_MCAN_ILS_TCF_MSK  (0x1UL << CAN_MCAN_ILS_TCF_POS)
+#define CAN_MCAN_ILS_TCF      CAN_MCAN_ILS_TCF_MSK
 /* Tx FIFO Empty */
-#define CAN_MCAN_ILS_TFE_POS          (11U)
-#define CAN_MCAN_ILS_TFE_MSK          (0x1UL << CAN_MCAN_ILS_TFE_POS)
-#define CAN_MCAN_ILS_TFE              CAN_MCAN_ILS_TFE_MSK
+#define CAN_MCAN_ILS_TFE_POS  (11U)
+#define CAN_MCAN_ILS_TFE_MSK  (0x1UL << CAN_MCAN_ILS_TFE_POS)
+#define CAN_MCAN_ILS_TFE      CAN_MCAN_ILS_TFE_MSK
 /* Tx Event FIFO New Entry */
-#define CAN_MCAN_ILS_TEFN_POS         (12U)
-#define CAN_MCAN_ILS_TEFN_MSK         (0x1UL << CAN_MCAN_ILS_TEFN_POS)
-#define CAN_MCAN_ILS_TEFN             CAN_MCAN_ILS_TEFN_MSK
+#define CAN_MCAN_ILS_TEFN_POS (12U)
+#define CAN_MCAN_ILS_TEFN_MSK (0x1UL << CAN_MCAN_ILS_TEFN_POS)
+#define CAN_MCAN_ILS_TEFN     CAN_MCAN_ILS_TEFN_MSK
 /* Tx Event FIFO Watermark */
-#define CAN_MCAN_ILS_TEFW_POS         (13U)
-#define CAN_MCAN_ILS_TEFW_MSK         (0x1UL << CAN_MCAN_ILS_TEFW_POS)
-#define CAN_MCAN_ILS_TEFW             CAN_MCAN_ILS_TEFW_MSK
+#define CAN_MCAN_ILS_TEFW_POS (13U)
+#define CAN_MCAN_ILS_TEFW_MSK (0x1UL << CAN_MCAN_ILS_TEFW_POS)
+#define CAN_MCAN_ILS_TEFW     CAN_MCAN_ILS_TEFW_MSK
 /* Tx Event FIFO Full */
-#define CAN_MCAN_ILS_TEFF_POS         (14U)
-#define CAN_MCAN_ILS_TEFF_MSK         (0x1UL << CAN_MCAN_ILS_TEFF_POS)
-#define CAN_MCAN_ILS_TEFF             CAN_MCAN_ILS_TEFF_MSK
+#define CAN_MCAN_ILS_TEFF_POS (14U)
+#define CAN_MCAN_ILS_TEFF_MSK (0x1UL << CAN_MCAN_ILS_TEFF_POS)
+#define CAN_MCAN_ILS_TEFF     CAN_MCAN_ILS_TEFF_MSK
 /* Tx Event FIFO Element Lost */
-#define CAN_MCAN_ILS_TEFL_POS         (15U)
-#define CAN_MCAN_ILS_TEFL_MSK         (0x1UL << CAN_MCAN_ILS_TEFL_POS)
-#define CAN_MCAN_ILS_TEFL             CAN_MCAN_ILS_TEFL_MSK
+#define CAN_MCAN_ILS_TEFL_POS (15U)
+#define CAN_MCAN_ILS_TEFL_MSK (0x1UL << CAN_MCAN_ILS_TEFL_POS)
+#define CAN_MCAN_ILS_TEFL     CAN_MCAN_ILS_TEFL_MSK
 /* Timestamp Wraparound */
-#define CAN_MCAN_ILS_TSW_POS          (16U)
-#define CAN_MCAN_ILS_TSW_MSK          (0x1UL << CAN_MCAN_ILS_TSW_POS)
-#define CAN_MCAN_ILS_TSW              CAN_MCAN_ILS_TSW_MSK
+#define CAN_MCAN_ILS_TSW_POS  (16U)
+#define CAN_MCAN_ILS_TSW_MSK  (0x1UL << CAN_MCAN_ILS_TSW_POS)
+#define CAN_MCAN_ILS_TSW      CAN_MCAN_ILS_TSW_MSK
 /* Message RAM Access Failure */
-#define CAN_MCAN_ILS_MRAF_POS         (17U)
-#define CAN_MCAN_ILS_MRAF_MSK         (0x1UL << CAN_MCAN_ILS_MRAF_POS)
-#define CAN_MCAN_ILS_MRAF             CAN_MCAN_ILS_MRAF_MSK
+#define CAN_MCAN_ILS_MRAF_POS (17U)
+#define CAN_MCAN_ILS_MRAF_MSK (0x1UL << CAN_MCAN_ILS_MRAF_POS)
+#define CAN_MCAN_ILS_MRAF     CAN_MCAN_ILS_MRAF_MSK
 /* Timeout Occurred */
-#define CAN_MCAN_ILS_TOO_POS          (18U)
-#define CAN_MCAN_ILS_TOO_MSK          (0x1UL << CAN_MCAN_ILS_TOO_POS)
-#define CAN_MCAN_ILS_TOO              CAN_MCAN_ILS_TOO_MSK
+#define CAN_MCAN_ILS_TOO_POS  (18U)
+#define CAN_MCAN_ILS_TOO_MSK  (0x1UL << CAN_MCAN_ILS_TOO_POS)
+#define CAN_MCAN_ILS_TOO      CAN_MCAN_ILS_TOO_MSK
 /* Message stored to Dedicated Rx Buffer */
-#define CAN_MCAN_ILS_DRX_POS          (19U)
-#define CAN_MCAN_ILS_DRX_MSK          (0x1UL << CAN_MCAN_ILS_DRX_POS)
-#define CAN_MCAN_ILS_DRX              CAN_MCAN_ILS_DRX_MSK
+#define CAN_MCAN_ILS_DRX_POS  (19U)
+#define CAN_MCAN_ILS_DRX_MSK  (0x1UL << CAN_MCAN_ILS_DRX_POS)
+#define CAN_MCAN_ILS_DRX      CAN_MCAN_ILS_DRX_MSK
 /* Bit Error Corrected */
-#define CAN_MCAN_ILS_BEC_POS          (20U)
-#define CAN_MCAN_ILS_BEC_MSK          (0x1UL << CAN_MCAN_ILS_BEC_POS)
-#define CAN_MCAN_ILS_BEC              CAN_MCAN_ILS_BEC_MSK
+#define CAN_MCAN_ILS_BEC_POS  (20U)
+#define CAN_MCAN_ILS_BEC_MSK  (0x1UL << CAN_MCAN_ILS_BEC_POS)
+#define CAN_MCAN_ILS_BEC      CAN_MCAN_ILS_BEC_MSK
 /* Bit Error Uncorrected */
-#define CAN_MCAN_ILS_BEU_POS          (21U)
-#define CAN_MCAN_ILS_BEU_MSK          (0x1UL << CAN_MCAN_ILS_BEU_POS)
-#define CAN_MCAN_ILS_BEU              CAN_MCAN_ILS_BEU_MSK
+#define CAN_MCAN_ILS_BEU_POS  (21U)
+#define CAN_MCAN_ILS_BEU_MSK  (0x1UL << CAN_MCAN_ILS_BEU_POS)
+#define CAN_MCAN_ILS_BEU      CAN_MCAN_ILS_BEU_MSK
 /* Error Logging Overflow */
-#define CAN_MCAN_ILS_ELO_POS          (22U)
-#define CAN_MCAN_ILS_ELO_MSK          (0x1UL << CAN_MCAN_ILS_ELO_POS)
-#define CAN_MCAN_ILS_ELO              CAN_MCAN_ILS_ELO_MSK
+#define CAN_MCAN_ILS_ELO_POS  (22U)
+#define CAN_MCAN_ILS_ELO_MSK  (0x1UL << CAN_MCAN_ILS_ELO_POS)
+#define CAN_MCAN_ILS_ELO      CAN_MCAN_ILS_ELO_MSK
 /* Error Passive*/
-#define CAN_MCAN_ILS_EP_POS           (23U)
-#define CAN_MCAN_ILS_EP_MSK           (0x1UL << CAN_MCAN_ILS_EP_POS)
-#define CAN_MCAN_ILS_EP               CAN_MCAN_ILS_EP_MSK
+#define CAN_MCAN_ILS_EP_POS   (23U)
+#define CAN_MCAN_ILS_EP_MSK   (0x1UL << CAN_MCAN_ILS_EP_POS)
+#define CAN_MCAN_ILS_EP	      CAN_MCAN_ILS_EP_MSK
 /* Warning Status*/
-#define CAN_MCAN_ILS_EW_POS           (24U)
-#define CAN_MCAN_ILS_EW_MSK           (0x1UL << CAN_MCAN_ILS_EW_POS)
-#define CAN_MCAN_ILS_EW               CAN_MCAN_ILS_EW_MSK
+#define CAN_MCAN_ILS_EW_POS   (24U)
+#define CAN_MCAN_ILS_EW_MSK   (0x1UL << CAN_MCAN_ILS_EW_POS)
+#define CAN_MCAN_ILS_EW	      CAN_MCAN_ILS_EW_MSK
 /* Bus_Off Status*/
-#define CAN_MCAN_ILS_BO_POS           (25U)
-#define CAN_MCAN_ILS_BO_MSK           (0x1UL << CAN_MCAN_ILS_BO_POS)
-#define CAN_MCAN_ILS_BO               CAN_MCAN_ILS_BO_MSK
+#define CAN_MCAN_ILS_BO_POS   (25U)
+#define CAN_MCAN_ILS_BO_MSK   (0x1UL << CAN_MCAN_ILS_BO_POS)
+#define CAN_MCAN_ILS_BO	      CAN_MCAN_ILS_BO_MSK
 /* Watchdog Interrupt */
-#define CAN_MCAN_ILS_WDI_POS          (26U)
-#define CAN_MCAN_ILS_WDI_MSK          (0x1UL << CAN_MCAN_ILS_WDI_POS)
-#define CAN_MCAN_ILS_WDI              CAN_MCAN_ILS_WDI_MSK
+#define CAN_MCAN_ILS_WDI_POS  (26U)
+#define CAN_MCAN_ILS_WDI_MSK  (0x1UL << CAN_MCAN_ILS_WDI_POS)
+#define CAN_MCAN_ILS_WDI      CAN_MCAN_ILS_WDI_MSK
 /* Protocol Error in Arbitration Phase */
-#define CAN_MCAN_ILS_PEA_POS          (27U)
-#define CAN_MCAN_ILS_PEA_MSK          (0x1UL << CAN_MCAN_ILS_PEA_POS)
-#define CAN_MCAN_ILS_PEA              CAN_MCAN_ILS_PEA_MSK
+#define CAN_MCAN_ILS_PEA_POS  (27U)
+#define CAN_MCAN_ILS_PEA_MSK  (0x1UL << CAN_MCAN_ILS_PEA_POS)
+#define CAN_MCAN_ILS_PEA      CAN_MCAN_ILS_PEA_MSK
 /* Protocol Error in Data Phase */
-#define CAN_MCAN_ILS_PED_POS          (28U)
-#define CAN_MCAN_ILS_PED_MSK          (0x1UL << CAN_MCAN_ILS_PED_POS)
-#define CAN_MCAN_ILS_PED              CAN_MCAN_ILS_PED_MSK
+#define CAN_MCAN_ILS_PED_POS  (28U)
+#define CAN_MCAN_ILS_PED_MSK  (0x1UL << CAN_MCAN_ILS_PED_POS)
+#define CAN_MCAN_ILS_PED      CAN_MCAN_ILS_PED_MSK
 /* Access to Reserved Address */
-#define CAN_MCAN_ILS_ARA_POS          (29U)
-#define CAN_MCAN_ILS_ARA_MSK          (0x1UL << CAN_MCAN_ILS_ARA_POS)
-#define CAN_MCAN_ILS_ARA              CAN_MCAN_IL_ARA_MSK
+#define CAN_MCAN_ILS_ARA_POS  (29U)
+#define CAN_MCAN_ILS_ARA_MSK  (0x1UL << CAN_MCAN_ILS_ARA_POS)
+#define CAN_MCAN_ILS_ARA      CAN_MCAN_IL_ARA_MSK
 
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_ILE register  *******************/
 /* Enable Interrupt Line 0 */
-#define CAN_MCAN_ILE_EINT0_POS       (0U)
-#define CAN_MCAN_ILE_EINT0_MSK       (0x1UL << CAN_MCAN_ILE_EINT0_POS)
-#define CAN_MCAN_ILE_EINT0           CAN_MCAN_ILE_EINT0_MSK
+#define CAN_MCAN_ILE_EINT0_POS (0U)
+#define CAN_MCAN_ILE_EINT0_MSK (0x1UL << CAN_MCAN_ILE_EINT0_POS)
+#define CAN_MCAN_ILE_EINT0     CAN_MCAN_ILE_EINT0_MSK
 /* Enable Interrupt Line 1 */
-#define CAN_MCAN_ILE_EINT1_POS       (1U)
-#define CAN_MCAN_ILE_EINT1_MSK       (0x1UL << CAN_MCAN_ILE_EINT1_POS)
-#define CAN_MCAN_ILE_EINT1           CAN_MCAN_ILE_EINT1_MSK
+#define CAN_MCAN_ILE_EINT1_POS (1U)
+#define CAN_MCAN_ILE_EINT1_MSK (0x1UL << CAN_MCAN_ILE_EINT1_POS)
+#define CAN_MCAN_ILE_EINT1     CAN_MCAN_ILE_EINT1_MSK
 
 /***************  Bit definition for CAN_MCAN_RXGFC register  *****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Reject Remote Frames Extended */
-#define CAN_MCAN_RXGFC_RRFE_POS      (0U)
-#define CAN_MCAN_RXGFC_RRFE_MSK      (0x1UL << CAN_MCAN_RXGFC_RRFE_POS)
-#define CAN_MCAN_RXGFC_RRFE          CAN_MCAN_RXGFC_RRFE_MSK
+#define CAN_MCAN_RXGFC_RRFE_POS (0U)
+#define CAN_MCAN_RXGFC_RRFE_MSK (0x1UL << CAN_MCAN_RXGFC_RRFE_POS)
+#define CAN_MCAN_RXGFC_RRFE	CAN_MCAN_RXGFC_RRFE_MSK
 /* Reject Remote Frames Standard */
-#define CAN_MCAN_RXGFC_RRFS_POS      (1U)
-#define CAN_MCAN_RXGFC_RRFS_MSK      (0x1UL << CAN_MCAN_RXGFC_RRFS_POS)
-#define CAN_MCAN_RXGFC_RRFS          CAN_MCAN_RXGFC_RRFS_MSK
+#define CAN_MCAN_RXGFC_RRFS_POS (1U)
+#define CAN_MCAN_RXGFC_RRFS_MSK (0x1UL << CAN_MCAN_RXGFC_RRFS_POS)
+#define CAN_MCAN_RXGFC_RRFS	CAN_MCAN_RXGFC_RRFS_MSK
 /* Accept Non-matching Frames Extended */
-#define CAN_MCAN_RXGFC_ANFE_POS      (2U)
-#define CAN_MCAN_RXGFC_ANFE_MSK      (0x3UL << CAN_MCAN_RXGFC_ANFE_POS)
-#define CAN_MCAN_RXGFC_ANFE          CAN_MCAN_RXGFC_ANFE_MSK
+#define CAN_MCAN_RXGFC_ANFE_POS (2U)
+#define CAN_MCAN_RXGFC_ANFE_MSK (0x3UL << CAN_MCAN_RXGFC_ANFE_POS)
+#define CAN_MCAN_RXGFC_ANFE	CAN_MCAN_RXGFC_ANFE_MSK
 /* Accept Non-matching Frames Standard */
-#define CAN_MCAN_RXGFC_ANFS_POS      (4U)
-#define CAN_MCAN_RXGFC_ANFS_MSK      (0x3UL << CAN_MCAN_RXGFC_ANFS_POS)
-#define CAN_MCAN_RXGFC_ANFS          CAN_MCAN_RXGFC_ANFS_MSK
+#define CAN_MCAN_RXGFC_ANFS_POS (4U)
+#define CAN_MCAN_RXGFC_ANFS_MSK (0x3UL << CAN_MCAN_RXGFC_ANFS_POS)
+#define CAN_MCAN_RXGFC_ANFS	CAN_MCAN_RXGFC_ANFS_MSK
 /* FIFO 1 operation mode */
-#define CAN_MCAN_RXGFC_F1OM_POS      (8U)
-#define CAN_MCAN_RXGFC_F1OM_MSK      (0x1UL << CAN_MCAN_RXGFC_F1OM_POS)
-#define CAN_MCAN_RXGFC_F1OM          CAN_MCAN_RXGFC_F1OM_MSK
+#define CAN_MCAN_RXGFC_F1OM_POS (8U)
+#define CAN_MCAN_RXGFC_F1OM_MSK (0x1UL << CAN_MCAN_RXGFC_F1OM_POS)
+#define CAN_MCAN_RXGFC_F1OM	CAN_MCAN_RXGFC_F1OM_MSK
 /* FIFO 0 operation mode */
-#define CAN_MCAN_RXGFC_F0OM_POS      (9U)
-#define CAN_MCAN_RXGFC_F0OM_MSK      (0x1UL << CAN_MCAN_RXGFC_F0OM_POS)
-#define CAN_MCAN_RXGFC_F0OM          CAN_MCAN_RXGFC_F0OM_MSK
+#define CAN_MCAN_RXGFC_F0OM_POS (9U)
+#define CAN_MCAN_RXGFC_F0OM_MSK (0x1UL << CAN_MCAN_RXGFC_F0OM_POS)
+#define CAN_MCAN_RXGFC_F0OM	CAN_MCAN_RXGFC_F0OM_MSK
 /* List Size Standard */
-#define CAN_MCAN_RXGFC_LSS_POS       (16U)
-#define CAN_MCAN_RXGFC_LSS_MSK       (0x1FUL << CAN_MCAN_RXGFC_LSS_POS)
-#define CAN_MCAN_RXGFC_LSS           CAN_MCAN_RXGFC_LSS_MSK
+#define CAN_MCAN_RXGFC_LSS_POS	(16U)
+#define CAN_MCAN_RXGFC_LSS_MSK	(0x1FUL << CAN_MCAN_RXGFC_LSS_POS)
+#define CAN_MCAN_RXGFC_LSS	CAN_MCAN_RXGFC_LSS_MSK
 /* List Size Extended */
-#define CAN_MCAN_RXGFC_LSE_POS       (24U)
-#define CAN_MCAN_RXGFC_LSE_MSK       (0xFUL << CAN_MCAN_RXGFC_LSE_POS)
-#define CAN_MCAN_RXGFC_LSE           CAN_MCAN_RXGFC_LSE_MSK
+#define CAN_MCAN_RXGFC_LSE_POS	(24U)
+#define CAN_MCAN_RXGFC_LSE_MSK	(0xFUL << CAN_MCAN_RXGFC_LSE_POS)
+#define CAN_MCAN_RXGFC_LSE	CAN_MCAN_RXGFC_LSE_MSK
 
 #else /* CONFIG_CAN_STM32FD */
 
 /* Reject Remote Frames Extended */
-#define CAN_MCAN_GFC_RRFE_POS      (0U)
-#define CAN_MCAN_GFC_RRFE_MSK      (0x1UL << CAN_MCAN_GFC_RRFE_POS)
-#define CAN_MCAN_GFC_RRFE          CAN_MCAN_GFC_RRFE_MSK
+#define CAN_MCAN_GFC_RRFE_POS	 (0U)
+#define CAN_MCAN_GFC_RRFE_MSK	 (0x1UL << CAN_MCAN_GFC_RRFE_POS)
+#define CAN_MCAN_GFC_RRFE	 CAN_MCAN_GFC_RRFE_MSK
 /* Reject Remote Frames Standard */
-#define CAN_MCAN_GFC_RRFS_POS      (1U)
-#define CAN_MCAN_GFC_RRFS_MSK      (0x1UL << CAN_MCAN_GFC_RRFS_POS)
-#define CAN_MCAN_GFC_RRFS          CAN_MCAN_GFC_RRFS_MSK
+#define CAN_MCAN_GFC_RRFS_POS	 (1U)
+#define CAN_MCAN_GFC_RRFS_MSK	 (0x1UL << CAN_MCAN_GFC_RRFS_POS)
+#define CAN_MCAN_GFC_RRFS	 CAN_MCAN_GFC_RRFS_MSK
 /* Accept Non-matching Frames Extended */
-#define CAN_MCAN_GFC_ANFE_POS      (2U)
-#define CAN_MCAN_GFC_ANFE_MSK      (0x3UL << CAN_MCAN_GFC_ANFE_POS)
-#define CAN_MCAN_GFC_ANFE          CAN_MCAN_GFC_ANFE_MSK
+#define CAN_MCAN_GFC_ANFE_POS	 (2U)
+#define CAN_MCAN_GFC_ANFE_MSK	 (0x3UL << CAN_MCAN_GFC_ANFE_POS)
+#define CAN_MCAN_GFC_ANFE	 CAN_MCAN_GFC_ANFE_MSK
 /* Accept Non-matching Frames Standard */
-#define CAN_MCAN_GFC_ANFS_POS      (4U)
-#define CAN_MCAN_GFC_ANFS_MSK      (0x3UL << CAN_MCAN_GFC_ANFS_POS)
-#define CAN_MCAN_GFC_ANFS          CAN_MCAN_GFC_ANFS_MSK
+#define CAN_MCAN_GFC_ANFS_POS	 (4U)
+#define CAN_MCAN_GFC_ANFS_MSK	 (0x3UL << CAN_MCAN_GFC_ANFS_POS)
+#define CAN_MCAN_GFC_ANFS	 CAN_MCAN_GFC_ANFS_MSK
 
 /*  Filter List Standard Start Address */
-#define CAN_MCAN_SIDFC_FLSSA_POS      (2U)
-#define CAN_MCAN_SIDFC_FLSSA_MSK      (0x3FFFUL << CAN_MCAN_SIDFC_FLSSA_POS)
-#define CAN_MCAN_SIDFC_FLSSA           CAN_MCAN_SIDFC_FLSSA_MSK
+#define CAN_MCAN_SIDFC_FLSSA_POS (2U)
+#define CAN_MCAN_SIDFC_FLSSA_MSK (0x3FFFUL << CAN_MCAN_SIDFC_FLSSA_POS)
+#define CAN_MCAN_SIDFC_FLSSA	 CAN_MCAN_SIDFC_FLSSA_MSK
 /* List Size Standard */
-#define CAN_MCAN_SIDFC_LSS_POS      (16U)
-#define CAN_MCAN_SIDFC_LSS_MSK      (0xFFUL << CAN_MCAN_SIDFC_LSS_POS)
-#define CAN_MCAN_SIDFC_LSS          CAN_MCAN_SIDFC_LSS_MSK
+#define CAN_MCAN_SIDFC_LSS_POS	 (16U)
+#define CAN_MCAN_SIDFC_LSS_MSK	 (0xFFUL << CAN_MCAN_SIDFC_LSS_POS)
+#define CAN_MCAN_SIDFC_LSS	 CAN_MCAN_SIDFC_LSS_MSK
 
 /*  Filter List Extended Start Address */
-#define CAN_MCAN_XIDFC_FLESA_POS      (2U)
-#define CAN_MCAN_XIDFC_FLESA_MSK      (0x3FFFUL << CAN_MCAN_XIDFC_FLESA_POS)
-#define CAN_MCAN_XIDFC_FLESA          CAN_MCAN_XIDFC_FLESA_MSK
+#define CAN_MCAN_XIDFC_FLESA_POS (2U)
+#define CAN_MCAN_XIDFC_FLESA_MSK (0x3FFFUL << CAN_MCAN_XIDFC_FLESA_POS)
+#define CAN_MCAN_XIDFC_FLESA	 CAN_MCAN_XIDFC_FLESA_MSK
 /* List Size Extended */
-#define CAN_MCAN_XIDFC_LSS_POS      (16U)
-#define CAN_MCAN_XIDFC_LSS_MSK      (0x7FUL << CAN_MCAN_XIDFC_LSS_POS)
-#define CAN_MCAN_XIDFC_LSS          CAN_MCAN_XIDFC_LSS_MSK
+#define CAN_MCAN_XIDFC_LSS_POS	 (16U)
+#define CAN_MCAN_XIDFC_LSS_MSK	 (0x7FUL << CAN_MCAN_XIDFC_LSS_POS)
+#define CAN_MCAN_XIDFC_LSS	 CAN_MCAN_XIDFC_LSS_MSK
 
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_XIDAM register  *****************/
 /* Extended ID Mask */
-#define CAN_MCAN_XIDAM_EIDM_POS      (0U)
-#define CAN_MCAN_XIDAM_EIDM_MSK      (0x1FFFFFFFUL << CAN_MCAN_XIDAM_EIDM_POS)
-#define CAN_MCAN_XIDAM_EIDM          CAN_MCAN_XIDAM_EIDM_MSK
+#define CAN_MCAN_XIDAM_EIDM_POS (0U)
+#define CAN_MCAN_XIDAM_EIDM_MSK (0x1FFFFFFFUL << CAN_MCAN_XIDAM_EIDM_POS)
+#define CAN_MCAN_XIDAM_EIDM	CAN_MCAN_XIDAM_EIDM_MSK
 
 /***************  Bit definition for CAN_MCAN_HPMS register  ******************/
 #ifdef CONFIG_CAN_STM32FD
 /* Buffer Index */
-#define CAN_MCAN_HPMS_BIDX_POS       (0U)
-#define CAN_MCAN_HPMS_BIDX_MSK       (0x7UL << CAN_MCAN_HPMS_BIDX_POS)
-#define CAN_MCAN_HPMS_BIDX           CAN_MCAN_HPMS_BIDX_MSK
+#define CAN_MCAN_HPMS_BIDX_POS (0U)
+#define CAN_MCAN_HPMS_BIDX_MSK (0x7UL << CAN_MCAN_HPMS_BIDX_POS)
+#define CAN_MCAN_HPMS_BIDX     CAN_MCAN_HPMS_BIDX_MSK
 /* Message Storage Indicator */
-#define CAN_MCAN_HPMS_MSI_POS        (6U)
-#define CAN_MCAN_HPMS_MSI_MSK        (0x3UL << CAN_MCAN_HPMS_MSI_POS)
-#define CAN_MCAN_HPMS_MSI            CAN_MCAN_HPMS_MSI_MSK
+#define CAN_MCAN_HPMS_MSI_POS  (6U)
+#define CAN_MCAN_HPMS_MSI_MSK  (0x3UL << CAN_MCAN_HPMS_MSI_POS)
+#define CAN_MCAN_HPMS_MSI      CAN_MCAN_HPMS_MSI_MSK
 /* Filter Index */
-#define CAN_MCAN_HPMS_FIDX_POS       (8U)
-#define CAN_MCAN_HPMS_FIDX_MSK       (0x1FUL << CAN_MCAN_HPMS_FIDX_POS)
-#define CAN_MCAN_HPMS_FIDX           CAN_MCAN_HPMS_FIDX_MSK
+#define CAN_MCAN_HPMS_FIDX_POS (8U)
+#define CAN_MCAN_HPMS_FIDX_MSK (0x1FUL << CAN_MCAN_HPMS_FIDX_POS)
+#define CAN_MCAN_HPMS_FIDX     CAN_MCAN_HPMS_FIDX_MSK
 /* Filter List  */
-#define CAN_MCAN_HPMS_FLST_POS       (15U)
-#define CAN_MCAN_HPMS_FLST_MSK       (0x1UL << CAN_MCAN_HPMS_FLST_POS)
-#define CAN_MCAN_HPMS_FLST           CAN_MCAN_HPMS_FLST_MSK
+#define CAN_MCAN_HPMS_FLST_POS (15U)
+#define CAN_MCAN_HPMS_FLST_MSK (0x1UL << CAN_MCAN_HPMS_FLST_POS)
+#define CAN_MCAN_HPMS_FLST     CAN_MCAN_HPMS_FLST_MSK
 
 #else /* CONFIG_CAN_STM32FD */
 
 /* Buffer Index */
-#define CAN_MCAN_HPMS_BIDX_POS       (0U)
-#define CAN_MCAN_HPMS_BIDX_MSK       (0x3FUL << CAN_MCAN_HPMS_BIDX_POS)
-#define CAN_MCAN_HPMS_BIDX           CAN_MCAN_HPMS_BIDX_MSK
+#define CAN_MCAN_HPMS_BIDX_POS (0U)
+#define CAN_MCAN_HPMS_BIDX_MSK (0x3FUL << CAN_MCAN_HPMS_BIDX_POS)
+#define CAN_MCAN_HPMS_BIDX     CAN_MCAN_HPMS_BIDX_MSK
 /* Message Storage Indicator */
-#define CAN_MCAN_HPMS_MSI_POS        (6U)
-#define CAN_MCAN_HPMS_MSI_MSK        (0x3UL << CAN_MCAN_HPMS_MSI_POS)
-#define CAN_MCAN_HPMS_MSI            CAN_MCAN_HPMS_MSI_MSK
+#define CAN_MCAN_HPMS_MSI_POS  (6U)
+#define CAN_MCAN_HPMS_MSI_MSK  (0x3UL << CAN_MCAN_HPMS_MSI_POS)
+#define CAN_MCAN_HPMS_MSI      CAN_MCAN_HPMS_MSI_MSK
 /* Filter Index */
-#define CAN_MCAN_HPMS_FIDX_POS       (8U)
-#define CAN_MCAN_HPMS_FIDX_MSK       (0x7FUL << CAN_MCAN_HPMS_FIDX_POS)
-#define CAN_MCAN_HPMS_FIDX           CAN_MCAN_HPMS_FIDX_MSK
+#define CAN_MCAN_HPMS_FIDX_POS (8U)
+#define CAN_MCAN_HPMS_FIDX_MSK (0x7FUL << CAN_MCAN_HPMS_FIDX_POS)
+#define CAN_MCAN_HPMS_FIDX     CAN_MCAN_HPMS_FIDX_MSK
 /* Filter List  */
-#define CAN_MCAN_HPMS_FLST_POS       (15U)
-#define CAN_MCAN_HPMS_FLST_MSK       (0x1UL << CAN_MCAN_HPMS_FLST_POS)
-#define CAN_MCAN_HPMS_FLST           CAN_MCAN_HPMS_FLST_MSK
+#define CAN_MCAN_HPMS_FLST_POS (15U)
+#define CAN_MCAN_HPMS_FLST_MSK (0x1UL << CAN_MCAN_HPMS_FLST_POS)
+#define CAN_MCAN_HPMS_FLST     CAN_MCAN_HPMS_FLST_MSK
 
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_RXF0C register  *****************/
 /* Rx FIFO 0 Start Address */
-#define CAN_MCAN_RXF0C_F0SA_POS      (2U)
-#define CAN_MCAN_RXF0C_F0SA_MSK      (0x3FFFUL << CAN_MCAN_RXF0C_F0SA_POS)
-#define CAN_MCAN_RXF0C_F0SA          CAN_MCAN_RXF0C_F0SA_MSK
+#define CAN_MCAN_RXF0C_F0SA_POS (2U)
+#define CAN_MCAN_RXF0C_F0SA_MSK (0x3FFFUL << CAN_MCAN_RXF0C_F0SA_POS)
+#define CAN_MCAN_RXF0C_F0SA	CAN_MCAN_RXF0C_F0SA_MSK
 /* Rx FIFO 0 Size */
-#define CAN_MCAN_RXF0C_F0S_POS       (16U)
-#define CAN_MCAN_RXF0C_F0S_MSK       (0x7FUL << CAN_MCAN_RXF0C_F0S_POS)
-#define CAN_MCAN_RXF0C_F0S           CAN_MCAN_RXF0C_F0S_MSK
+#define CAN_MCAN_RXF0C_F0S_POS	(16U)
+#define CAN_MCAN_RXF0C_F0S_MSK	(0x7FUL << CAN_MCAN_RXF0C_F0S_POS)
+#define CAN_MCAN_RXF0C_F0S	CAN_MCAN_RXF0C_F0S_MSK
 /* Rx FIFO 0 Watermark */
-#define CAN_MCAN_RXF0C_F0WM_POS      (24)
-#define CAN_MCAN_RXF0C_F0WM_MSK      (0x7FUL << CAN_MCAN_RXF0C_F0WM_POS)
-#define CAN_MCAN_RXF0C_F0WM           CAN_MCAN_RXF0C_F0WM_MSK
+#define CAN_MCAN_RXF0C_F0WM_POS (24)
+#define CAN_MCAN_RXF0C_F0WM_MSK (0x7FUL << CAN_MCAN_RXF0C_F0WM_POS)
+#define CAN_MCAN_RXF0C_F0WM	CAN_MCAN_RXF0C_F0WM_MSK
 /* FIFO 0 Operation Mode */
-#define CAN_MCAN_RXF0C_F0OM_POS      (31)
-#define CAN_MCAN_RXF0C_F0OM_MSK      (0x1UL << CAN_MCAN_RXF0C_F0OM_POS)
-#define CAN_MCAN_RXF0C_F0OM           CAN_MCAN_RXF0C_F0OM_MSK
+#define CAN_MCAN_RXF0C_F0OM_POS (31)
+#define CAN_MCAN_RXF0C_F0OM_MSK (0x1UL << CAN_MCAN_RXF0C_F0OM_POS)
+#define CAN_MCAN_RXF0C_F0OM	CAN_MCAN_RXF0C_F0OM_MSK
 
 /***************  Bit definition for CAN_MCAN_RXF0S register  *****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Rx FIFO 0 Fill Level */
-#define CAN_MCAN_RXF0S_F0FL_POS      (0U)
-#define CAN_MCAN_RXF0S_F0FL_MSK      (0xFUL << CAN_MCAN_RXF0S_F0FL_POS)
-#define CAN_MCAN_RXF0S_F0FL          CAN_MCAN_RXF0S_F0FL_MSK
+#define CAN_MCAN_RXF0S_F0FL_POS (0U)
+#define CAN_MCAN_RXF0S_F0FL_MSK (0xFUL << CAN_MCAN_RXF0S_F0FL_POS)
+#define CAN_MCAN_RXF0S_F0FL	CAN_MCAN_RXF0S_F0FL_MSK
 /* Rx FIFO 0 Get Index */
-#define CAN_MCAN_RXF0S_F0GI_POS      (8U)
-#define CAN_MCAN_RXF0S_F0GI_MSK      (0x3UL << CAN_MCAN_RXF0S_F0GI_POS)
-#define CAN_MCAN_RXF0S_F0GI          CAN_MCAN_RXF0S_F0GI_MSK
+#define CAN_MCAN_RXF0S_F0GI_POS (8U)
+#define CAN_MCAN_RXF0S_F0GI_MSK (0x3UL << CAN_MCAN_RXF0S_F0GI_POS)
+#define CAN_MCAN_RXF0S_F0GI	CAN_MCAN_RXF0S_F0GI_MSK
 /* Rx FIFO 0 Put Index */
-#define CAN_MCAN_RXF0S_F0PI_POS      (16U)
-#define CAN_MCAN_RXF0S_F0PI_MSK      (0x3UL << CAN_MCAN_RXF0S_F0PI_POS)
-#define CAN_MCAN_RXF0S_F0PI          CAN_MCAN_RXF0S_F0PI_MSK
+#define CAN_MCAN_RXF0S_F0PI_POS (16U)
+#define CAN_MCAN_RXF0S_F0PI_MSK (0x3UL << CAN_MCAN_RXF0S_F0PI_POS)
+#define CAN_MCAN_RXF0S_F0PI	CAN_MCAN_RXF0S_F0PI_MSK
 /* Rx FIFO 0 Full */
-#define CAN_MCAN_RXF0S_F0F_POS       (24U)
-#define CAN_MCAN_RXF0S_F0F_MSK       (0x1UL << CAN_MCAN_RXF0S_F0F_POS)
-#define CAN_MCAN_RXF0S_F0F           CAN_MCAN_RXF0S_F0F_MSK
+#define CAN_MCAN_RXF0S_F0F_POS	(24U)
+#define CAN_MCAN_RXF0S_F0F_MSK	(0x1UL << CAN_MCAN_RXF0S_F0F_POS)
+#define CAN_MCAN_RXF0S_F0F	CAN_MCAN_RXF0S_F0F_MSK
 /* Rx FIFO 0 Message Lost */
-#define CAN_MCAN_RXF0S_RF0L_POS      (25U)
-#define CAN_MCAN_RXF0S_RF0L_MSK      (0x1UL << CAN_MCAN_RXF0S_RF0L_POS)
-#define CAN_MCAN_RXF0S_RF0L          CAN_MCAN_RXF0S_RF0L_MSK
+#define CAN_MCAN_RXF0S_RF0L_POS (25U)
+#define CAN_MCAN_RXF0S_RF0L_MSK (0x1UL << CAN_MCAN_RXF0S_RF0L_POS)
+#define CAN_MCAN_RXF0S_RF0L	CAN_MCAN_RXF0S_RF0L_MSK
 
 #else /* CONFIG_CAN_STM32FD */
 
 /* Rx FIFO 0 Fill Level */
-#define CAN_MCAN_RXF0S_F0FL_POS      (0U)
-#define CAN_MCAN_RXF0S_F0FL_MSK      (0x7FUL << CAN_MCAN_RXF0S_F0FL_POS)
-#define CAN_MCAN_RXF0S_F0FL          CAN_MCAN_RXF0S_F0FL_MSK
+#define CAN_MCAN_RXF0S_F0FL_POS (0U)
+#define CAN_MCAN_RXF0S_F0FL_MSK (0x7FUL << CAN_MCAN_RXF0S_F0FL_POS)
+#define CAN_MCAN_RXF0S_F0FL	CAN_MCAN_RXF0S_F0FL_MSK
 /* Rx FIFO 0 Get Index */
-#define CAN_MCAN_RXF0S_F0GI_POS      (8U)
-#define CAN_MCAN_RXF0S_F0GI_MSK      (0x3FUL << CAN_MCAN_RXF0S_F0GI_POS)
-#define CAN_MCAN_RXF0S_F0GI          CAN_MCAN_RXF0S_F0GI_MSK
+#define CAN_MCAN_RXF0S_F0GI_POS (8U)
+#define CAN_MCAN_RXF0S_F0GI_MSK (0x3FUL << CAN_MCAN_RXF0S_F0GI_POS)
+#define CAN_MCAN_RXF0S_F0GI	CAN_MCAN_RXF0S_F0GI_MSK
 /* Rx FIFO 0 Put Index */
-#define CAN_MCAN_RXF0S_F0PI_POS      (16U)
-#define CAN_MCAN_RXF0S_F0PI_MSK      (0x3FUL << CAN_MCAN_RXF0S_F0PI_POS)
-#define CAN_MCAN_RXF0S_F0PI          CAN_MCAN_RXF0S_F0PI_MSK
+#define CAN_MCAN_RXF0S_F0PI_POS (16U)
+#define CAN_MCAN_RXF0S_F0PI_MSK (0x3FUL << CAN_MCAN_RXF0S_F0PI_POS)
+#define CAN_MCAN_RXF0S_F0PI	CAN_MCAN_RXF0S_F0PI_MSK
 /* Rx FIFO 0 Full */
-#define CAN_MCAN_RXF0S_F0F_POS       (24U)
-#define CAN_MCAN_RXF0S_F0F_MSK       (0x1UL << CAN_MCAN_RXF0S_F0F_POS)
-#define CAN_MCAN_RXF0S_F0F           CAN_MCAN_RXF0S_F0F_MSK
+#define CAN_MCAN_RXF0S_F0F_POS	(24U)
+#define CAN_MCAN_RXF0S_F0F_MSK	(0x1UL << CAN_MCAN_RXF0S_F0F_POS)
+#define CAN_MCAN_RXF0S_F0F	CAN_MCAN_RXF0S_F0F_MSK
 /* Rx FIFO 0 Message Lost */
-#define CAN_MCAN_RXF0S_RF0L_POS      (25U)
-#define CAN_MCAN_RXF0S_RF0L_MSK      (0x1UL << CAN_MCAN_RXF0S_RF0L_POS)
-#define CAN_MCAN_RXF0S_RF0L          CAN_MCAN_RXF0S_RF0L_MSK
+#define CAN_MCAN_RXF0S_RF0L_POS (25U)
+#define CAN_MCAN_RXF0S_RF0L_MSK (0x1UL << CAN_MCAN_RXF0S_RF0L_POS)
+#define CAN_MCAN_RXF0S_RF0L	CAN_MCAN_RXF0S_RF0L_MSK
 #endif
 
 /***************  Bit definition for CAN_MCAN_RXF0A register  *****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Rx FIFO 0 Acknowledge Index */
-#define CAN_MCAN_RXF0A_F0AI_POS      (0U)
-#define CAN_MCAN_RXF0A_F0AI_MSK      (0x7UL << CAN_MCAN_RXF0A_F0AI_POS)
-#define CAN_MCAN_RXF0A_F0AI          CAN_MCAN_RXF0A_F0AI_MSK
+#define CAN_MCAN_RXF0A_F0AI_POS (0U)
+#define CAN_MCAN_RXF0A_F0AI_MSK (0x7UL << CAN_MCAN_RXF0A_F0AI_POS)
+#define CAN_MCAN_RXF0A_F0AI	CAN_MCAN_RXF0A_F0AI_MSK
 #else
 /* Rx FIFO 0 Acknowledge Index */
-#define CAN_MCAN_RXF0A_F0AI_POS      (0U)
-#define CAN_MCAN_RXF0A_F0AI_MSK      (0x3FUL << CAN_MCAN_RXF0A_F0AI_POS)
-#define CAN_MCAN_RXF0A_F0AI          CAN_MCAN_RXF0A_F0AI_MSK
+#define CAN_MCAN_RXF0A_F0AI_POS (0U)
+#define CAN_MCAN_RXF0A_F0AI_MSK (0x3FUL << CAN_MCAN_RXF0A_F0AI_POS)
+#define CAN_MCAN_RXF0A_F0AI	CAN_MCAN_RXF0A_F0AI_MSK
 
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_RXBC register  ******************/
 /*  Rx Buffer Start Address */
-#define CAN_MCAN_RXBC_RBSA_POS      (2U)
-#define CAN_MCAN_RXBC_RBSA_MSK      (0x3FFFUL << CAN_MCAN_RXBC_RBSA_POS)
-#define CAN_MCAN_RXBC_RBSA          CAN_MCAN_RXBC_RBSA_MSK
+#define CAN_MCAN_RXBC_RBSA_POS (2U)
+#define CAN_MCAN_RXBC_RBSA_MSK (0x3FFFUL << CAN_MCAN_RXBC_RBSA_POS)
+#define CAN_MCAN_RXBC_RBSA     CAN_MCAN_RXBC_RBSA_MSK
 
 /***************  Bit definition for CAN_MCAN_RXF1C register  *****************/
 /* Rx FIFO 0 Start Address */
-#define CAN_MCAN_RXF1C_F1SA_POS      (2U)
-#define CAN_MCAN_RXF1C_F1SA_MSK      (0x3FFFUL << CAN_MCAN_RXF1C_F1SA_POS)
-#define CAN_MCAN_RXF1C_F1SA          CAN_MCAN_RXF1C_F1SA_MSK
+#define CAN_MCAN_RXF1C_F1SA_POS (2U)
+#define CAN_MCAN_RXF1C_F1SA_MSK (0x3FFFUL << CAN_MCAN_RXF1C_F1SA_POS)
+#define CAN_MCAN_RXF1C_F1SA	CAN_MCAN_RXF1C_F1SA_MSK
 /* Rx FIFO 0 Size */
-#define CAN_MCAN_RXF1C_F1S_POS       (16U)
-#define CAN_MCAN_RXF1C_F1S_MSK       (0x7FUL << CAN_MCAN_RXF1C_F1S_POS)
-#define CAN_MCAN_RXF1C_F1S           CAN_MCAN_RXF1C_F1S_MSK
+#define CAN_MCAN_RXF1C_F1S_POS	(16U)
+#define CAN_MCAN_RXF1C_F1S_MSK	(0x7FUL << CAN_MCAN_RXF1C_F1S_POS)
+#define CAN_MCAN_RXF1C_F1S	CAN_MCAN_RXF1C_F1S_MSK
 /* Rx FIFO 0 Watermark */
-#define CAN_MCAN_RXF1C_F1WM_POS      (24)
-#define CAN_MCAN_RXF1C_F1WM_MSK      (0x7FUL << CAN_MCAN_RXF1C_F1WM_POS)
-#define CAN_MCAN_RXF1C_F1WM           CAN_MCAN_RXF1C_F1WM_MSK
+#define CAN_MCAN_RXF1C_F1WM_POS (24)
+#define CAN_MCAN_RXF1C_F1WM_MSK (0x7FUL << CAN_MCAN_RXF1C_F1WM_POS)
+#define CAN_MCAN_RXF1C_F1WM	CAN_MCAN_RXF1C_F1WM_MSK
 /* FIFO 0 Operation Mode */
-#define CAN_MCAN_RXF1C_F1OM_POS      (31)
-#define CAN_MCAN_RXF1C_F1OM_MSK      (0x1UL << CAN_MCAN_RXF1C_F1OM_POS)
-#define CAN_MCAN_RXF1C_F1OM           CAN_MCAN_RXF1C_F1OM_MSK
+#define CAN_MCAN_RXF1C_F1OM_POS (31)
+#define CAN_MCAN_RXF1C_F1OM_MSK (0x1UL << CAN_MCAN_RXF1C_F1OM_POS)
+#define CAN_MCAN_RXF1C_F1OM	CAN_MCAN_RXF1C_F1OM_MSK
 
 /***************  Bit definition for CAN_MCAN_RXF1S register  *****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Rx FIFO 1 Fill Level */
-#define CAN_MCAN_RXF1S_F1FL_POS      (0U)
-#define CAN_MCAN_RXF1S_F1FL_MSK      (0xFUL << CAN_MCAN_RXF1S_F1FL_POS)
-#define CAN_MCAN_RXF1S_F1FL          CAN_MCAN_RXF1S_F1FL_MSK
+#define CAN_MCAN_RXF1S_F1FL_POS (0U)
+#define CAN_MCAN_RXF1S_F1FL_MSK (0xFUL << CAN_MCAN_RXF1S_F1FL_POS)
+#define CAN_MCAN_RXF1S_F1FL	CAN_MCAN_RXF1S_F1FL_MSK
 /* Rx FIFO 1 Get Index */
-#define CAN_MCAN_RXF1S_F1GI_POS      (8U)
-#define CAN_MCAN_RXF1S_F1GI_MSK      (0x3UL << CAN_MCAN_RXF1S_F1GI_POS)
-#define CAN_MCAN_RXF1S_F1GI          CAN_MCAN_RXF1S_F1GI_MSK
+#define CAN_MCAN_RXF1S_F1GI_POS (8U)
+#define CAN_MCAN_RXF1S_F1GI_MSK (0x3UL << CAN_MCAN_RXF1S_F1GI_POS)
+#define CAN_MCAN_RXF1S_F1GI	CAN_MCAN_RXF1S_F1GI_MSK
 /* Rx FIFO 1 Put Index */
-#define CAN_MCAN_RXF1S_F1PI_POS      (16U)
-#define CAN_MCAN_RXF1S_F1PI_MSK      (0x3UL << CAN_MCAN_RXF1S_F1PI_POS)
-#define CAN_MCAN_RXF1S_F1PI          CAN_MCAN_RXF1S_F1PI_MSK
+#define CAN_MCAN_RXF1S_F1PI_POS (16U)
+#define CAN_MCAN_RXF1S_F1PI_MSK (0x3UL << CAN_MCAN_RXF1S_F1PI_POS)
+#define CAN_MCAN_RXF1S_F1PI	CAN_MCAN_RXF1S_F1PI_MSK
 /* Rx FIFO 1 Full */
-#define CAN_MCAN_RXF1S_F1F_POS       (24U)
-#define CAN_MCAN_RXF1S_F1F_MSK       (0x1UL << CAN_MCAN_RXF1S_F1F_POS)
-#define CAN_MCAN_RXF1S_F1F           CAN_MCAN_RXF1S_F1F_MSK
+#define CAN_MCAN_RXF1S_F1F_POS	(24U)
+#define CAN_MCAN_RXF1S_F1F_MSK	(0x1UL << CAN_MCAN_RXF1S_F1F_POS)
+#define CAN_MCAN_RXF1S_F1F	CAN_MCAN_RXF1S_F1F_MSK
 /* Rx FIFO 1 Message Lost */
-#define CAN_MCAN_RXF1S_RF1L_POS      (25U)
-#define CAN_MCAN_RXF1S_RF1L_MSK      (0x1UL << CAN_MCAN_RXF1S_RF1L_POS)
-#define CAN_MCAN_RXF1S_RF1L          CAN_MCAN_RXF1S_RF1L_MSK
+#define CAN_MCAN_RXF1S_RF1L_POS (25U)
+#define CAN_MCAN_RXF1S_RF1L_MSK (0x1UL << CAN_MCAN_RXF1S_RF1L_POS)
+#define CAN_MCAN_RXF1S_RF1L	CAN_MCAN_RXF1S_RF1L_MSK
 
 #else /* CONFIG_CAN_STM32FD */
 
 /* Rx FIFO 1 Fill Level */
-#define CAN_MCAN_RXF1S_F1FL_POS      (0U)
-#define CAN_MCAN_RXF1S_F1FL_MSK      (0x7FUL << CAN_MCAN_RXF1S_F1FL_POS)
-#define CAN_MCAN_RXF1S_F1FL          CAN_MCAN_RXF1S_F1FL_MSK
+#define CAN_MCAN_RXF1S_F1FL_POS (0U)
+#define CAN_MCAN_RXF1S_F1FL_MSK (0x7FUL << CAN_MCAN_RXF1S_F1FL_POS)
+#define CAN_MCAN_RXF1S_F1FL	CAN_MCAN_RXF1S_F1FL_MSK
 /* Rx FIFO 1 Get Index */
-#define CAN_MCAN_RXF1S_F1GI_POS      (8U)
-#define CAN_MCAN_RXF1S_F1GI_MSK      (0x3FUL << CAN_MCAN_RXF1S_F1GI_POS)
-#define CAN_MCAN_RXF1S_F1GI          CAN_MCAN_RXF1S_F1GI_MSK
+#define CAN_MCAN_RXF1S_F1GI_POS (8U)
+#define CAN_MCAN_RXF1S_F1GI_MSK (0x3FUL << CAN_MCAN_RXF1S_F1GI_POS)
+#define CAN_MCAN_RXF1S_F1GI	CAN_MCAN_RXF1S_F1GI_MSK
 /* Rx FIFO 1 Put Index */
-#define CAN_MCAN_RXF1S_F1PI_POS      (16U)
-#define CAN_MCAN_RXF1S_F1PI_MSK      (0x3FUL << CAN_MCAN_RXF1S_F1PI_POS)
-#define CAN_MCAN_RXF1S_F1PI          CAN_MCAN_RXF1S_F1PI_MSK
+#define CAN_MCAN_RXF1S_F1PI_POS (16U)
+#define CAN_MCAN_RXF1S_F1PI_MSK (0x3FUL << CAN_MCAN_RXF1S_F1PI_POS)
+#define CAN_MCAN_RXF1S_F1PI	CAN_MCAN_RXF1S_F1PI_MSK
 /* Rx FIFO 1 Full */
-#define CAN_MCAN_RXF1S_F1F_POS       (24U)
-#define CAN_MCAN_RXF1S_F1F_MSK       (0x1UL << CAN_MCAN_RXF1S_F1F_POS)
-#define CAN_MCAN_RXF1S_F1F           CAN_MCAN_RXF1S_F1F_MSK
+#define CAN_MCAN_RXF1S_F1F_POS	(24U)
+#define CAN_MCAN_RXF1S_F1F_MSK	(0x1UL << CAN_MCAN_RXF1S_F1F_POS)
+#define CAN_MCAN_RXF1S_F1F	CAN_MCAN_RXF1S_F1F_MSK
 /* Rx FIFO 1 Message Lost */
-#define CAN_MCAN_RXF1S_RF1L_POS      (25U)
-#define CAN_MCAN_RXF1S_RF1L_MSK      (0x1UL << CAN_MCAN_RXF1S_RF1L_POS)
-#define CAN_MCAN_RXF1S_RF1L          CAN_MCAN_RXF1S_RF1L_MSK
+#define CAN_MCAN_RXF1S_RF1L_POS (25U)
+#define CAN_MCAN_RXF1S_RF1L_MSK (0x1UL << CAN_MCAN_RXF1S_RF1L_POS)
+#define CAN_MCAN_RXF1S_RF1L	CAN_MCAN_RXF1S_RF1L_MSK
 
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_RXF1A register  *****************/
 /* Rx FIFO 1 Acknowledge Index */
 #ifdef CONFIG_CAN_STM32FD
-#define CAN_MCAN_RXF1A_F1AI_POS      (0U)
-#define CAN_MCAN_RXF1A_F1AI_MSK      (0x7UL << CAN_MCAN_RXF1A_F1AI_POS)
-#define CAN_MCAN_RXF1A_F1AI          CAN_MCAN_RXF1A_F1AI_MSK
+#define CAN_MCAN_RXF1A_F1AI_POS (0U)
+#define CAN_MCAN_RXF1A_F1AI_MSK (0x7UL << CAN_MCAN_RXF1A_F1AI_POS)
+#define CAN_MCAN_RXF1A_F1AI	CAN_MCAN_RXF1A_F1AI_MSK
 #else
-#define CAN_MCAN_RXF1A_F1AI_POS      (0U)
-#define CAN_MCAN_RXF1A_F1AI_MSK      (0x3FUL << CAN_MCAN_RXF1A_F1AI_POS)
-#define CAN_MCAN_RXF1A_F1AI          CAN_MCAN_RXF1A_F1AI_MSK
+#define CAN_MCAN_RXF1A_F1AI_POS (0U)
+#define CAN_MCAN_RXF1A_F1AI_MSK (0x3FUL << CAN_MCAN_RXF1A_F1AI_POS)
+#define CAN_MCAN_RXF1A_F1AI	CAN_MCAN_RXF1A_F1AI_MSK
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_RXESC register  *****************/
 /* Rx FIFO 0 Data Field Size */
-#define CAN_MCAN_RXESC_F0DS_POS      (0U)
-#define CAN_MCAN_RXESC_F0DS_MSK      (0x7UL << CAN_MCAN_RXESC_F0DS_POS)
-#define CAN_MCAN_RXESC_F0DS          CAN_MCAN_RXESC_F0DS_MSK
+#define CAN_MCAN_RXESC_F0DS_POS (0U)
+#define CAN_MCAN_RXESC_F0DS_MSK (0x7UL << CAN_MCAN_RXESC_F0DS_POS)
+#define CAN_MCAN_RXESC_F0DS	CAN_MCAN_RXESC_F0DS_MSK
 /* Rx FIFO 1 Data Field Size */
-#define CAN_MCAN_RXESC_F1DS_POS      (4U)
-#define CAN_MCAN_RXESC_F1DS_MSK      (0x7UL << CAN_MCAN_RXESC_F1DS_POS)
-#define CAN_MCAN_RXESC_F1DS          CAN_MCAN_RXESC_F1DS_MSK
+#define CAN_MCAN_RXESC_F1DS_POS (4U)
+#define CAN_MCAN_RXESC_F1DS_MSK (0x7UL << CAN_MCAN_RXESC_F1DS_POS)
+#define CAN_MCAN_RXESC_F1DS	CAN_MCAN_RXESC_F1DS_MSK
 /* Receive Buffer Data Field Size */
-#define CAN_MCAN_RXESC_RBDS_POS      (8U)
-#define CAN_MCAN_RXESC_RBDS_MSK      (0x7UL << CAN_MCAN_RXESC_RBDS_POS)
-#define CAN_MCAN_RXESC_RBDS          CAN_MCAN_RXESC_RBDS_MSK
+#define CAN_MCAN_RXESC_RBDS_POS (8U)
+#define CAN_MCAN_RXESC_RBDS_MSK (0x7UL << CAN_MCAN_RXESC_RBDS_POS)
+#define CAN_MCAN_RXESC_RBDS	CAN_MCAN_RXESC_RBDS_MSK
 
 /***************  Bit definition for CAN_MCAN_TXBC register  ******************/
 #ifdef CONFIG_CAN_STM32FD
 /* Tx FIFO/Queue Mode */
-#define CAN_MCAN_TXBC_TFQM_POS       (24U)
-#define CAN_MCAN_TXBC_TFQM_MSK       (0x1UL << CAN_MCAN_TXBC_TFQM_POS)
-#define CAN_MCAN_TXBC_TFQM           CAN_MCAN_TXBC_TFQM_MSK
+#define CAN_MCAN_TXBC_TFQM_POS (24U)
+#define CAN_MCAN_TXBC_TFQM_MSK (0x1UL << CAN_MCAN_TXBC_TFQM_POS)
+#define CAN_MCAN_TXBC_TFQM     CAN_MCAN_TXBC_TFQM_MSK
 #else
 /* Tx Buffers Start Address */
-#define CAN_MCAN_TXBC_TBSA_POS       (2U)
-#define CAN_MCAN_TXBC_TBSA_MSK       (0x3FFFUL << CAN_MCAN_TXBC_TBSA_POS)
-#define CAN_MCAN_TXBC_TBSA           CAN_MCAN_TXBC_TBSA_MSK
+#define CAN_MCAN_TXBC_TBSA_POS (2U)
+#define CAN_MCAN_TXBC_TBSA_MSK (0x3FFFUL << CAN_MCAN_TXBC_TBSA_POS)
+#define CAN_MCAN_TXBC_TBSA     CAN_MCAN_TXBC_TBSA_MSK
 /* Number of Dedicated Transmit Buffers */
-#define CAN_MCAN_TXBC_NDTB_POS       (16U)
-#define CAN_MCAN_TXBC_NDTB_MSK       (0x3FUL << CAN_MCAN_TXBC_NDTB_POS)
-#define CAN_MCAN_TXBC_NDTB           CAN_MCAN_TXBC_NDTB_MSK
+#define CAN_MCAN_TXBC_NDTB_POS (16U)
+#define CAN_MCAN_TXBC_NDTB_MSK (0x3FUL << CAN_MCAN_TXBC_NDTB_POS)
+#define CAN_MCAN_TXBC_NDTB     CAN_MCAN_TXBC_NDTB_MSK
 /* Transmit FIFO/Queue Size */
-#define CAN_MCAN_TXBC_TFQS_POS       (24U)
-#define CAN_MCAN_TXBC_TFQS_MSK       (0x3FUL << CAN_MCAN_TXBC_TFQS_POS)
-#define CAN_MCAN_TXBC_TFQS           CAN_MCAN_TXBC_TFQS_MSK
+#define CAN_MCAN_TXBC_TFQS_POS (24U)
+#define CAN_MCAN_TXBC_TFQS_MSK (0x3FUL << CAN_MCAN_TXBC_TFQS_POS)
+#define CAN_MCAN_TXBC_TFQS     CAN_MCAN_TXBC_TFQS_MSK
 /* Tx FIFO/Queue Mode */
-#define CAN_MCAN_TXBC_TFQM_POS       (30U)
-#define CAN_MCAN_TXBC_TFQM_MSK       (0x3FUL << CAN_MCAN_TXBC_TFQM_POS)
-#define CAN_MCAN_TXBC_TFQM           CAN_MCAN_TXBC_TFQM_MSK
+#define CAN_MCAN_TXBC_TFQM_POS (30U)
+#define CAN_MCAN_TXBC_TFQM_MSK (0x3FUL << CAN_MCAN_TXBC_TFQM_POS)
+#define CAN_MCAN_TXBC_TFQM     CAN_MCAN_TXBC_TFQM_MSK
 
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_TXFQS register  *****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Tx FIFO Free Level */
-#define CAN_MCAN_TXFQS_TFFL_POS      (0U)
-#define CAN_MCAN_TXFQS_TFFL_MSK      (0x7UL << CAN_MCAN_TXFQS_TFFL_POS)
-#define CAN_MCAN_TXFQS_TFFL          CAN_MCAN_TXFQS_TFFL_MSK
+#define CAN_MCAN_TXFQS_TFFL_POS	 (0U)
+#define CAN_MCAN_TXFQS_TFFL_MSK	 (0x7UL << CAN_MCAN_TXFQS_TFFL_POS)
+#define CAN_MCAN_TXFQS_TFFL	 CAN_MCAN_TXFQS_TFFL_MSK
 /* Tx FIFO Get Index */
-#define CAN_MCAN_TXFQS_TFGI_POS      (8U)
-#define CAN_MCAN_TXFQS_TFGI_MSK      (0x3UL << CAN_MCAN_TXFQS_TFGI_POS)
-#define CAN_MCAN_TXFQS_TFGI          CAN_MCAN_TXFQS_TFGI_MSK
+#define CAN_MCAN_TXFQS_TFGI_POS	 (8U)
+#define CAN_MCAN_TXFQS_TFGI_MSK	 (0x3UL << CAN_MCAN_TXFQS_TFGI_POS)
+#define CAN_MCAN_TXFQS_TFGI	 CAN_MCAN_TXFQS_TFGI_MSK
 /* Tx FIFO/Queue Put Index */
-#define CAN_MCAN_TXFQS_TFQPI_POS     (16U)
-#define CAN_MCAN_TXFQS_TFQPI_MSK     (0x3UL << CAN_MCAN_TXFQS_TFQPI_POS)
-#define CAN_MCAN_TXFQS_TFQPI         CAN_MCAN_TXFQS_TFQPI_MSK
+#define CAN_MCAN_TXFQS_TFQPI_POS (16U)
+#define CAN_MCAN_TXFQS_TFQPI_MSK (0x3UL << CAN_MCAN_TXFQS_TFQPI_POS)
+#define CAN_MCAN_TXFQS_TFQPI	 CAN_MCAN_TXFQS_TFQPI_MSK
 /* Tx FIFO/Queue Full */
-#define CAN_MCAN_TXFQS_TFQF_POS      (21U)
-#define CAN_MCAN_TXFQS_TFQF_MSK      (0x1UL << CAN_MCAN_TXFQS_TFQF_POS)
-#define CAN_MCAN_TXFQS_TFQF          CAN_MCAN_TXFQS_TFQF_MSK
+#define CAN_MCAN_TXFQS_TFQF_POS	 (21U)
+#define CAN_MCAN_TXFQS_TFQF_MSK	 (0x1UL << CAN_MCAN_TXFQS_TFQF_POS)
+#define CAN_MCAN_TXFQS_TFQF	 CAN_MCAN_TXFQS_TFQF_MSK
 
 #else /* CONFIG_CAN_STM32FD */
 
 /* Tx FIFO Free Level */
-#define CAN_MCAN_TXFQS_TFFL_POS      (0U)
-#define CAN_MCAN_TXFQS_TFFL_MSK      (0x3FUL << CAN_MCAN_TXFQS_TFFL_POS)
-#define CAN_MCAN_TXFQS_TFFL          CAN_MCAN_TXFQS_TFFL_MSK
+#define CAN_MCAN_TXFQS_TFFL_POS	 (0U)
+#define CAN_MCAN_TXFQS_TFFL_MSK	 (0x3FUL << CAN_MCAN_TXFQS_TFFL_POS)
+#define CAN_MCAN_TXFQS_TFFL	 CAN_MCAN_TXFQS_TFFL_MSK
 /* Tx FIFO Get Index */
-#define CAN_MCAN_TXFQS_TFGI_POS      (8U)
-#define CAN_MCAN_TXFQS_TFGI_MSK      (0x1FUL << CAN_MCAN_TXFQS_TFGI_POS)
-#define CAN_MCAN_TXFQS_TFGI          CAN_MCAN_TXFQS_TFGI_MSK
+#define CAN_MCAN_TXFQS_TFGI_POS	 (8U)
+#define CAN_MCAN_TXFQS_TFGI_MSK	 (0x1FUL << CAN_MCAN_TXFQS_TFGI_POS)
+#define CAN_MCAN_TXFQS_TFGI	 CAN_MCAN_TXFQS_TFGI_MSK
 /* Tx FIFO/Queue Put Index */
-#define CAN_MCAN_TXFQS_TFQPI_POS     (16U)
-#define CAN_MCAN_TXFQS_TFQPI_MSK     (0x1FUL << CAN_MCAN_TXFQS_TFQPI_POS)
-#define CAN_MCAN_TXFQS_TFQPI         CAN_MCAN_TXFQS_TFQPI_MSK
+#define CAN_MCAN_TXFQS_TFQPI_POS (16U)
+#define CAN_MCAN_TXFQS_TFQPI_MSK (0x1FUL << CAN_MCAN_TXFQS_TFQPI_POS)
+#define CAN_MCAN_TXFQS_TFQPI	 CAN_MCAN_TXFQS_TFQPI_MSK
 /* Tx FIFO/Queue Full */
-#define CAN_MCAN_TXFQS_TFQF_POS      (21U)
-#define CAN_MCAN_TXFQS_TFQF_MSK      (0x1UL << CAN_MCAN_TXFQS_TFQF_POS)
-#define CAN_MCAN_TXFQS_TFQF          CAN_MCAN_TXFQS_TFQF_MSK
+#define CAN_MCAN_TXFQS_TFQF_POS	 (21U)
+#define CAN_MCAN_TXFQS_TFQF_MSK	 (0x1UL << CAN_MCAN_TXFQS_TFQF_POS)
+#define CAN_MCAN_TXFQS_TFQF	 CAN_MCAN_TXFQS_TFQF_MSK
 
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_TXESC register  *****************/
 /* Tx Buffer Data Field Size */
-#define CAN_MCAN_TXESC_TBDS_POS      (0U)
-#define CAN_MCAN_TXESC_TBDS_MSK      (0x7UL << CAN_MCAN_TXESC_TBDS_POS)
-#define CAN_MCAN_TXESC_TBDS          CAN_MCAN_TXESC_TBDS_MSK
+#define CAN_MCAN_TXESC_TBDS_POS (0U)
+#define CAN_MCAN_TXESC_TBDS_MSK (0x7UL << CAN_MCAN_TXESC_TBDS_POS)
+#define CAN_MCAN_TXESC_TBDS	CAN_MCAN_TXESC_TBDS_MSK
 
 /***************  Bit definition for CAN_MCAN_TXBRP register  *****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Transmission Request Pending */
-#define CAN_MCAN_TXBRP_TRP_POS       (0U)
-#define CAN_MCAN_TXBRP_TRP_MSK       (0x7UL << CAN_MCAN_TXBRP_TRP_POS)
-#define CAN_MCAN_TXBRP_TRP           CAN_MCAN_TXBRP_TRP_MSK
+#define CAN_MCAN_TXBRP_TRP_POS (0U)
+#define CAN_MCAN_TXBRP_TRP_MSK (0x7UL << CAN_MCAN_TXBRP_TRP_POS)
+#define CAN_MCAN_TXBRP_TRP     CAN_MCAN_TXBRP_TRP_MSK
 #else
 /* Transmission Request Pending */
-#define CAN_MCAN_TXBRP_TRP_POS       (0U)
-#define CAN_MCAN_TXBRP_TRP_MSK       (0xFFFFFFFFUL << CAN_MCAN_TXBRP_TRP_POS)
-#define CAN_MCAN_TXBRP_TRP           CAN_MCAN_TXBRP_TRP_MSK
+#define CAN_MCAN_TXBRP_TRP_POS (0U)
+#define CAN_MCAN_TXBRP_TRP_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBRP_TRP_POS)
+#define CAN_MCAN_TXBRP_TRP     CAN_MCAN_TXBRP_TRP_MSK
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_TXBAR register  *****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Add Request */
-#define CAN_MCAN_TXBAR_AR_POS        (0U)
-#define CAN_MCAN_TXBAR_AR_MSK        (0x7UL << CAN_MCAN_TXBAR_AR_POS)
-#define CAN_MCAN_TXBAR_AR            CAN_MCAN_TXBAR_AR_MSK
+#define CAN_MCAN_TXBAR_AR_POS (0U)
+#define CAN_MCAN_TXBAR_AR_MSK (0x7UL << CAN_MCAN_TXBAR_AR_POS)
+#define CAN_MCAN_TXBAR_AR     CAN_MCAN_TXBAR_AR_MSK
 #else
 /* Add Request */
-#define CAN_MCAN_TXBAR_AR_POS        (0U)
-#define CAN_MCAN_TXBAR_AR_MSK        (0xFFFFFFFFUL << CAN_MCAN_TXBAR_AR_POS)
-#define CAN_MCAN_TXBAR_AR            CAN_MCAN_TXBAR_AR_MSK
+#define CAN_MCAN_TXBAR_AR_POS (0U)
+#define CAN_MCAN_TXBAR_AR_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBAR_AR_POS)
+#define CAN_MCAN_TXBAR_AR     CAN_MCAN_TXBAR_AR_MSK
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_TXBCR register  *****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Cancellation Request */
-#define CAN_MCAN_TXBCR_CR_POS        (0U)
-#define CAN_MCAN_TXBCR_CR_MSK        (0x7UL << CAN_MCAN_TXBCR_CR_POS)
-#define CAN_MCAN_TXBCR_CR            CAN_MCAN_TXBCR_CR_MSK
+#define CAN_MCAN_TXBCR_CR_POS (0U)
+#define CAN_MCAN_TXBCR_CR_MSK (0x7UL << CAN_MCAN_TXBCR_CR_POS)
+#define CAN_MCAN_TXBCR_CR     CAN_MCAN_TXBCR_CR_MSK
 #else
 /* Cancellation Request */
-#define CAN_MCAN_TXBCR_CR_POS        (0U)
-#define CAN_MCAN_TXBCR_CR_MSK        (0xFFFFFFFFUL << CAN_MCAN_TXBCR_CR_POS)
-#define CAN_MCAN_TXBCR_CR            CAN_MCAN_TXBCR_CR_MSK
+#define CAN_MCAN_TXBCR_CR_POS (0U)
+#define CAN_MCAN_TXBCR_CR_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBCR_CR_POS)
+#define CAN_MCAN_TXBCR_CR     CAN_MCAN_TXBCR_CR_MSK
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_TXBTO register  *****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Transmission Occurred */
-#define CAN_MCAN_TXBTO_TO_POS        (0U)
-#define CAN_MCAN_TXBTO_TO_MSK        (0x7UL << CAN_MCAN_TXBTO_TO_POS)
-#define CAN_MCAN_TXBTO_TO            CAN_MCAN_TXBTO_TO_MSK
+#define CAN_MCAN_TXBTO_TO_POS (0U)
+#define CAN_MCAN_TXBTO_TO_MSK (0x7UL << CAN_MCAN_TXBTO_TO_POS)
+#define CAN_MCAN_TXBTO_TO     CAN_MCAN_TXBTO_TO_MSK
 #else
 /* Transmission Occurred */
-#define CAN_MCAN_TXBTO_TO_POS        (0U)
-#define CAN_MCAN_TXBTO_TO_MSK        (0xFFFFFFFFUL << CAN_MCAN_TXBTO_TO_POS)
-#define CAN_MCAN_TXBTO_TO            CAN_MCAN_TXBTO_TO_MSK
+#define CAN_MCAN_TXBTO_TO_POS (0U)
+#define CAN_MCAN_TXBTO_TO_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBTO_TO_POS)
+#define CAN_MCAN_TXBTO_TO     CAN_MCAN_TXBTO_TO_MSK
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_TXBCF register  *****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Cancellation Finished */
-#define CAN_MCAN_TXBCF_CF_POS        (0U)
-#define CAN_MCAN_TXBCF_CF_MSK        (0x7UL << CAN_MCAN_TXBCF_CF_POS)
-#define CAN_MCAN_TXBCF_CF            CAN_MCAN_TXBCF_CF_MSK
+#define CAN_MCAN_TXBCF_CF_POS (0U)
+#define CAN_MCAN_TXBCF_CF_MSK (0x7UL << CAN_MCAN_TXBCF_CF_POS)
+#define CAN_MCAN_TXBCF_CF     CAN_MCAN_TXBCF_CF_MSK
 #else
 /* Cancellation Finished */
-#define CAN_MCAN_TXBCF_CF_POS        (0U)
-#define CAN_MCAN_TXBCF_CF_MSK        (0xFFFFFFFFUL << CAN_MCAN_TXBCF_CF_POS)
-#define CAN_MCAN_TXBCF_CF            CAN_MCAN_TXBCF_CF_MSK
+#define CAN_MCAN_TXBCF_CF_POS (0U)
+#define CAN_MCAN_TXBCF_CF_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBCF_CF_POS)
+#define CAN_MCAN_TXBCF_CF     CAN_MCAN_TXBCF_CF_MSK
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_TXBTIE register  ****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Transmission Interrupt Enable */
-#define CAN_MCAN_TXBTIE_TIE_POS      (0U)
-#define CAN_MCAN_TXBTIE_TIE_MSK      (0x7UL << CAN_MCAN_TXBTIE_TIE_POS)
-#define CAN_MCAN_TXBTIE_TIE          CAN_MCAN_TXBTIE_TIE_MSK
+#define CAN_MCAN_TXBTIE_TIE_POS (0U)
+#define CAN_MCAN_TXBTIE_TIE_MSK (0x7UL << CAN_MCAN_TXBTIE_TIE_POS)
+#define CAN_MCAN_TXBTIE_TIE	CAN_MCAN_TXBTIE_TIE_MSK
 #else
 /* Transmission Interrupt Enable */
-#define CAN_MCAN_TXBTIE_TIE_POS      (0U)
-#define CAN_MCAN_TXBTIE_TIE_MSK      (0xFFFFFFFFUL << CAN_MCAN_TXBTIE_TIE_POS)
-#define CAN_MCAN_TXBTIE_TIE          CAN_MCAN_TXBTIE_TIE_MSK
+#define CAN_MCAN_TXBTIE_TIE_POS (0U)
+#define CAN_MCAN_TXBTIE_TIE_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBTIE_TIE_POS)
+#define CAN_MCAN_TXBTIE_TIE	CAN_MCAN_TXBTIE_TIE_MSK
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_ TXBCIE register  ***************/
 #ifdef CONFIG_CAN_STM32FD
 /* Cancellation Finished Interrupt Enable */
-#define CAN_MCAN_TXBCIE_CFIE_POS     (0U)
-#define CAN_MCAN_TXBCIE_CFIE_MSK     (0x7UL << CAN_MCAN_TXBCIE_CFIE_POS)
-#define CAN_MCAN_TXBCIE_CFIE         CAN_MCAN_TXBCIE_CFIE_MSK
+#define CAN_MCAN_TXBCIE_CFIE_POS (0U)
+#define CAN_MCAN_TXBCIE_CFIE_MSK (0x7UL << CAN_MCAN_TXBCIE_CFIE_POS)
+#define CAN_MCAN_TXBCIE_CFIE	 CAN_MCAN_TXBCIE_CFIE_MSK
 #else
 /* Cancellation Finished Interrupt Enable */
-#define CAN_MCAN_TXBCIE_CFIE_POS     (0U)
-#define CAN_MCAN_TXBCIE_CFIE_MSK     (0xFFFFFFFFUL << CAN_MCAN_TXBCIE_CFIE_POS)
-#define CAN_MCAN_TXBCIE_CFIE         CAN_MCAN_TXBCIE_CFIE_MSK
+#define CAN_MCAN_TXBCIE_CFIE_POS (0U)
+#define CAN_MCAN_TXBCIE_CFIE_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBCIE_CFIE_POS)
+#define CAN_MCAN_TXBCIE_CFIE	 CAN_MCAN_TXBCIE_CFIE_MSK
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_TXEFC register  *****************/
 /* Event FIFO Watermark */
-#define CAN_MCAN_TXEFC_EFSA_POS      (2U)
-#define CAN_MCAN_TXEFC_EFSA_MSK      (0x3FFFUL << CAN_MCAN_TXEFC_EFSA_POS)
-#define CAN_MCAN_TXEFC_EFSA          CAN_MCAN_TXEFC_EFSA_MSK
+#define CAN_MCAN_TXEFC_EFSA_POS (2U)
+#define CAN_MCAN_TXEFC_EFSA_MSK (0x3FFFUL << CAN_MCAN_TXEFC_EFSA_POS)
+#define CAN_MCAN_TXEFC_EFSA	CAN_MCAN_TXEFC_EFSA_MSK
 /* Event FIFO Size */
-#define CAN_MCAN_TXEFC_EFS_POS      (16U)
-#define CAN_MCAN_TXEFC_EFS_MSK      (0x3FUL << CAN_MCAN_TXEFC_EFS_POS)
-#define CAN_MCAN_TXEFC_EFS          CAN_MCAN_TXEFC_EFS_MSK
+#define CAN_MCAN_TXEFC_EFS_POS	(16U)
+#define CAN_MCAN_TXEFC_EFS_MSK	(0x3FUL << CAN_MCAN_TXEFC_EFS_POS)
+#define CAN_MCAN_TXEFC_EFS	CAN_MCAN_TXEFC_EFS_MSK
 /* Event FIFO Start Address */
-#define CAN_MCAN_TXEFC_EFWM_POS     (24U)
-#define CAN_MCAN_TXEFC_EFWM_MSK     (0x3FUL << CAN_MCAN_TXEFC_EFWM_POS)
-#define CAN_MCAN_TXEFC_EFWM         CAN_MCAN_TXEFC_EFWM_POS
+#define CAN_MCAN_TXEFC_EFWM_POS (24U)
+#define CAN_MCAN_TXEFC_EFWM_MSK (0x3FUL << CAN_MCAN_TXEFC_EFWM_POS)
+#define CAN_MCAN_TXEFC_EFWM	CAN_MCAN_TXEFC_EFWM_POS
 
 /***************  Bit definition for CAN_MCAN_TXEFS register  *****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Event FIFO Fill Level */
-#define CAN_MCAN_TXEFS_EFFL_POS      (0U)
-#define CAN_MCAN_TXEFS_EFFL_MSK      (0x7UL << CAN_MCAN_TXEFS_EFFL_POS)
-#define CAN_MCAN_TXEFS_EFFL          CAN_MCAN_TXEFS_EFFL_MSK
+#define CAN_MCAN_TXEFS_EFFL_POS (0U)
+#define CAN_MCAN_TXEFS_EFFL_MSK (0x7UL << CAN_MCAN_TXEFS_EFFL_POS)
+#define CAN_MCAN_TXEFS_EFFL	CAN_MCAN_TXEFS_EFFL_MSK
 /* Event FIFO Get Index */
-#define CAN_MCAN_TXEFS_EFGI_POS      (8U)
-#define CAN_MCAN_TXEFS_EFGI_MSK      (0x3UL << CAN_MCAN_TXEFS_EFGI_POS)
-#define CAN_MCAN_TXEFS_EFGI          CAN_MCAN_TXEFS_EFGI_MSK
+#define CAN_MCAN_TXEFS_EFGI_POS (8U)
+#define CAN_MCAN_TXEFS_EFGI_MSK (0x3UL << CAN_MCAN_TXEFS_EFGI_POS)
+#define CAN_MCAN_TXEFS_EFGI	CAN_MCAN_TXEFS_EFGI_MSK
 /* Event FIFO Put Index */
-#define CAN_MCAN_TXEFS_EFPI_POS      (16U)
-#define CAN_MCAN_TXEFS_EFPI_MSK      (0x3UL << CAN_MCAN_TXEFS_EFPI_POS)
-#define CAN_MCAN_TXEFS_EFPI          CAN_MCAN_TXEFS_EFPI_MSK
+#define CAN_MCAN_TXEFS_EFPI_POS (16U)
+#define CAN_MCAN_TXEFS_EFPI_MSK (0x3UL << CAN_MCAN_TXEFS_EFPI_POS)
+#define CAN_MCAN_TXEFS_EFPI	CAN_MCAN_TXEFS_EFPI_MSK
 /* Event FIFO Full */
-#define CAN_MCAN_TXEFS_EFF_POS       (24U)
-#define CAN_MCAN_TXEFS_EFF_MSK       (0x1UL << CAN_MCAN_TXEFS_EFF_POS)
-#define CAN_MCAN_TXEFS_EFF           CAN_MCAN_TXEFS_EFF_MSK
+#define CAN_MCAN_TXEFS_EFF_POS	(24U)
+#define CAN_MCAN_TXEFS_EFF_MSK	(0x1UL << CAN_MCAN_TXEFS_EFF_POS)
+#define CAN_MCAN_TXEFS_EFF	CAN_MCAN_TXEFS_EFF_MSK
 /* Tx Event FIFO Element Lost */
-#define CAN_MCAN_TXEFS_TEFL_POS      (25U)
-#define CAN_MCAN_TXEFS_TEFL_MSK      (0x1UL << CAN_MCAN_TXEFS_TEFL_POS)
-#define CAN_MCAN_TXEFS_TEFL          CAN_MCAN_TXEFS_TEFL_MSK
+#define CAN_MCAN_TXEFS_TEFL_POS (25U)
+#define CAN_MCAN_TXEFS_TEFL_MSK (0x1UL << CAN_MCAN_TXEFS_TEFL_POS)
+#define CAN_MCAN_TXEFS_TEFL	CAN_MCAN_TXEFS_TEFL_MSK
 
 #else /* CONFIG_CAN_STM32FD */
 /* Event FIFO Fill Level */
-#define CAN_MCAN_TXEFS_EFFL_POS      (0U)
-#define CAN_MCAN_TXEFS_EFFL_MSK      (0x3FUL << CAN_MCAN_TXEFS_EFFL_POS)
-#define CAN_MCAN_TXEFS_EFFL          CAN_MCAN_TXEFS_EFFL_MSK
+#define CAN_MCAN_TXEFS_EFFL_POS (0U)
+#define CAN_MCAN_TXEFS_EFFL_MSK (0x3FUL << CAN_MCAN_TXEFS_EFFL_POS)
+#define CAN_MCAN_TXEFS_EFFL	CAN_MCAN_TXEFS_EFFL_MSK
 /* Event FIFO Get Index */
-#define CAN_MCAN_TXEFS_EFGI_POS      (8U)
-#define CAN_MCAN_TXEFS_EFGI_MSK      (0x1FUL << CAN_MCAN_TXEFS_EFGI_POS)
-#define CAN_MCAN_TXEFS_EFGI          CAN_MCAN_TXEFS_EFGI_MSK
-#define CAN_MCAN_TXEFS_EFPI_POS      (16U)
+#define CAN_MCAN_TXEFS_EFGI_POS (8U)
+#define CAN_MCAN_TXEFS_EFGI_MSK (0x1FUL << CAN_MCAN_TXEFS_EFGI_POS)
+#define CAN_MCAN_TXEFS_EFGI	CAN_MCAN_TXEFS_EFGI_MSK
+#define CAN_MCAN_TXEFS_EFPI_POS (16U)
 /* Event FIFO Put Index */
-#define CAN_MCAN_TXEFS_EFPI_MSK      (0x1FUL << CAN_MCAN_TXEFS_EFPI_POS)
-#define CAN_MCAN_TXEFS_EFPI          CAN_MCAN_TXEFS_EFPI_MSK
+#define CAN_MCAN_TXEFS_EFPI_MSK (0x1FUL << CAN_MCAN_TXEFS_EFPI_POS)
+#define CAN_MCAN_TXEFS_EFPI	CAN_MCAN_TXEFS_EFPI_MSK
 /* Event FIFO Full */
-#define CAN_MCAN_TXEFS_EFF_POS       (24U)
-#define CAN_MCAN_TXEFS_EFF_MSK       (0x1UL << CAN_MCAN_TXEFS_EFF_POS)
-#define CAN_MCAN_TXEFS_EFF           CAN_MCAN_TXEFS_EFF_MSK
+#define CAN_MCAN_TXEFS_EFF_POS	(24U)
+#define CAN_MCAN_TXEFS_EFF_MSK	(0x1UL << CAN_MCAN_TXEFS_EFF_POS)
+#define CAN_MCAN_TXEFS_EFF	CAN_MCAN_TXEFS_EFF_MSK
 /* Tx Event FIFO Element Lost */
-#define CAN_MCAN_TXEFS_TEFL_POS      (25U)
-#define CAN_MCAN_TXEFS_TEFL_MSK      (0x1UL << CAN_MCAN_TXEFS_TEFL_POS)
-#define CAN_MCAN_TXEFS_TEFL          CAN_MCAN_TXEFS_TEFL_MSK
+#define CAN_MCAN_TXEFS_TEFL_POS (25U)
+#define CAN_MCAN_TXEFS_TEFL_MSK (0x1UL << CAN_MCAN_TXEFS_TEFL_POS)
+#define CAN_MCAN_TXEFS_TEFL	CAN_MCAN_TXEFS_TEFL_MSK
 
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_TXEFA register  *****************/
 #ifdef CONFIG_CAN_STM32FD
 /* Event FIFO Acknowledge Index */
-#define CAN_MCAN_TXEFA_EFAI_POS      (0U)
-#define CAN_MCAN_TXEFA_EFAI_MSK      (0x3UL << CAN_MCAN_TXEFA_EFAI_POS)
-#define CAN_MCAN_TXEFA_EFAI          CAN_MCAN_TXEFA_EFAI_MSK
+#define CAN_MCAN_TXEFA_EFAI_POS (0U)
+#define CAN_MCAN_TXEFA_EFAI_MSK (0x3UL << CAN_MCAN_TXEFA_EFAI_POS)
+#define CAN_MCAN_TXEFA_EFAI	CAN_MCAN_TXEFA_EFAI_MSK
 #else
 /* Event FIFO Acknowledge Index */
-#define CAN_MCAN_TXEFA_EFAI_POS      (0U)
-#define CAN_MCAN_TXEFA_EFAI_MSK      (0x1FUL << CAN_MCAN_TXEFA_EFAI_POS)
-#define CAN_MCAN_TXEFA_EFAI          CAN_MCAN_TXEFA_EFAI_MSK
+#define CAN_MCAN_TXEFA_EFAI_POS (0U)
+#define CAN_MCAN_TXEFA_EFAI_MSK (0x1FUL << CAN_MCAN_TXEFA_EFAI_POS)
+#define CAN_MCAN_TXEFA_EFAI	CAN_MCAN_TXEFA_EFAI_MSK
 #endif /* CONFIG_CAN_STM32FD */
 
 /***************  Bit definition for CAN_MCAN_MRBA register  *****************/
 #ifdef CONFIG_CAN_MCUX_MCAN
 /* Event FIFO Acknowledge Index */
-#define CAN_MCAN_MRBA_BA_POS         (16U)
-#define CAN_MCAN_MRBA_BA_MSK         (0xFFFFUL << CAN_MCAN_MRBA_BA_POS)
-#define CAN_MCAN_MRBA_BA             CAN_MCAN_MRBA_BA_MSK
+#define CAN_MCAN_MRBA_BA_POS (16U)
+#define CAN_MCAN_MRBA_BA_MSK (0xFFFFUL << CAN_MCAN_MRBA_BA_POS)
+#define CAN_MCAN_MRBA_BA     CAN_MCAN_MRBA_BA_MSK
 #endif /* CONFIG_CAN_MCUX_MCAN */
 
 #ifdef CONFIG_CAN_STM32FD
 struct can_mcan_reg {
-	volatile uint32_t crel;     /* Core Release Register */
-	volatile uint32_t endn;     /* Endian Register */
-	volatile uint32_t cust;     /* Customer Register */
-	volatile uint32_t dbtp;     /* Data Bit Timing & Prescaler Register */
-	volatile uint32_t test;     /* Test Register */
-	volatile uint32_t rwd;      /* RAM Watchdog */
-	volatile uint32_t cccr;     /* CC Control Register */
-	volatile uint32_t nbtp;     /* Nominal Bit Timing & Prescaler Register */
-	volatile uint32_t tscc;     /* Timestamp Counter Configuration */
-	volatile uint32_t tscv;     /* Timestamp Counter Value */
-	volatile uint32_t tocc;     /* Timeout Counter Configuration */
-	volatile uint32_t tocv;     /* Timeout Counter Value */
-	uint32_t res1[4];           /* Reserved (4) */
-	volatile uint32_t ecr;      /* Error Counter Register */
-	volatile uint32_t psr;      /* Protocol Status Register */
-	volatile uint32_t tdcr;     /* Transmitter Delay Compensation */
-	uint32_t res2;              /* Reserved (1) */
-	volatile uint32_t ir;       /* Interrupt Register */
-	volatile uint32_t ie;       /* Interrupt Enable */
-	volatile uint32_t ils;      /* Interrupt Line Select */
-	volatile uint32_t ile;      /* Interrupt Line Enable */
-	uint32_t res3[8];           /* Reserved (8) */
-	volatile uint32_t rxgfc;    /* Global Filter Configuration */
-	volatile uint32_t xidam;    /* Extended ID AND Mask */
-	volatile uint32_t hpms;     /* High Priority Message Status */
-	uint32_t res4;              /* Reserved (1) */
-	volatile uint32_t rxf0s;    /* Rx FIFO 0 Status */
-	volatile uint32_t rxf0a;    /* Rx FIFO 0 Acknowledge */
-	volatile uint32_t rxf1s;    /* Rx FIFO 1 Status */
-	volatile uint32_t rxf1a;    /* Rx FIFO 1 Acknowledge */
-	uint32_t res5[8];           /* Reserved (8) */
-	volatile uint32_t txbc;     /* Tx Buffer Configuration */
-	volatile uint32_t txfqs;    /* Tx FIFO/Queue Status */
-	volatile uint32_t txbrp;    /* Tx Buffer Request Pending */
-	volatile uint32_t txbar;    /* Tx Buffer Add Request */
-	volatile uint32_t txbcr;    /* Tx Buffer Cancellation */
-	volatile uint32_t txbto;    /* Tx Buffer Transmission */
-	volatile uint32_t txbcf;    /* Tx Buffer Cancellation Finished */
-	volatile uint32_t txbtie;   /* Tx Buffer Transmission Interrupt Enable */
-	volatile uint32_t txcbie;   /* Tx Buffer Cancellation Fi.Interrupt En. */
-	volatile uint32_t txefs;    /* Tx Event FIFO Status */
-	volatile uint32_t txefa;    /* Tx Event FIFO Acknowledge */
+	volatile uint32_t crel;	  /* Core Release Register */
+	volatile uint32_t endn;	  /* Endian Register */
+	volatile uint32_t cust;	  /* Customer Register */
+	volatile uint32_t dbtp;	  /* Data Bit Timing & Prescaler Register */
+	volatile uint32_t test;	  /* Test Register */
+	volatile uint32_t rwd;	  /* RAM Watchdog */
+	volatile uint32_t cccr;	  /* CC Control Register */
+	volatile uint32_t nbtp;	  /* Nominal Bit Timing & Prescaler Register */
+	volatile uint32_t tscc;	  /* Timestamp Counter Configuration */
+	volatile uint32_t tscv;	  /* Timestamp Counter Value */
+	volatile uint32_t tocc;	  /* Timeout Counter Configuration */
+	volatile uint32_t tocv;	  /* Timeout Counter Value */
+	uint32_t res1[4];	  /* Reserved (4) */
+	volatile uint32_t ecr;	  /* Error Counter Register */
+	volatile uint32_t psr;	  /* Protocol Status Register */
+	volatile uint32_t tdcr;	  /* Transmitter Delay Compensation */
+	uint32_t res2;		  /* Reserved (1) */
+	volatile uint32_t ir;	  /* Interrupt Register */
+	volatile uint32_t ie;	  /* Interrupt Enable */
+	volatile uint32_t ils;	  /* Interrupt Line Select */
+	volatile uint32_t ile;	  /* Interrupt Line Enable */
+	uint32_t res3[8];	  /* Reserved (8) */
+	volatile uint32_t rxgfc;  /* Global Filter Configuration */
+	volatile uint32_t xidam;  /* Extended ID AND Mask */
+	volatile uint32_t hpms;	  /* High Priority Message Status */
+	uint32_t res4;		  /* Reserved (1) */
+	volatile uint32_t rxf0s;  /* Rx FIFO 0 Status */
+	volatile uint32_t rxf0a;  /* Rx FIFO 0 Acknowledge */
+	volatile uint32_t rxf1s;  /* Rx FIFO 1 Status */
+	volatile uint32_t rxf1a;  /* Rx FIFO 1 Acknowledge */
+	uint32_t res5[8];	  /* Reserved (8) */
+	volatile uint32_t txbc;	  /* Tx Buffer Configuration */
+	volatile uint32_t txfqs;  /* Tx FIFO/Queue Status */
+	volatile uint32_t txbrp;  /* Tx Buffer Request Pending */
+	volatile uint32_t txbar;  /* Tx Buffer Add Request */
+	volatile uint32_t txbcr;  /* Tx Buffer Cancellation */
+	volatile uint32_t txbto;  /* Tx Buffer Transmission */
+	volatile uint32_t txbcf;  /* Tx Buffer Cancellation Finished */
+	volatile uint32_t txbtie; /* Tx Buffer Transmission Interrupt Enable */
+	volatile uint32_t txcbie; /* Tx Buffer Cancellation Fi.Interrupt En. */
+	volatile uint32_t txefs;  /* Tx Event FIFO Status */
+	volatile uint32_t txefa;  /* Tx Event FIFO Acknowledge */
 };
 #else /* CONFIG_CAN_STM32FD */
 
 struct can_mcan_reg {
-	volatile uint32_t crel;     /* Core Release Register */
-	volatile uint32_t endn;     /* Endian Register */
-	volatile uint32_t cust;     /* Customer Register */
-	volatile uint32_t dbtp;     /* Data Bit Timing & Prescaler Register */
-	volatile uint32_t test;     /* Test Register */
-	volatile uint32_t rwd;      /* RAM Watchdog */
-	volatile uint32_t cccr;     /* CC Control Register */
-	volatile uint32_t nbtp;     /* Nominal Bit Timing & Prescaler Register */
-	volatile uint32_t tscc;     /* Timestamp Counter Configuration */
-	volatile uint32_t tscv;     /* Timestamp Counter Value */
-	volatile uint32_t tocc;     /* Timeout Counter Configuration */
-	volatile uint32_t tocv;     /* Timeout Counter Value */
-	uint32_t res1[4];           /* Reserved (4) */
-	volatile uint32_t ecr;      /* Error Counter Register */
-	volatile uint32_t psr;      /* Protocol Status Register */
-	volatile uint32_t tdcr;     /* Transmitter Delay Compensation */
-	uint32_t res2;              /* Reserved (1) */
-	volatile uint32_t ir;       /* Interrupt Register */
-	volatile uint32_t ie;       /* Interrupt Enable */
-	volatile uint32_t ils;      /* Interrupt Line Select */
-	volatile uint32_t ile;      /* Interrupt Line Enable */
-	uint32_t res3[8];           /* Reserved (8) */
-	volatile uint32_t gfc;      /* Global Filter Configuration */
+	volatile uint32_t crel;	    /* Core Release Register */
+	volatile uint32_t endn;	    /* Endian Register */
+	volatile uint32_t cust;	    /* Customer Register */
+	volatile uint32_t dbtp;	    /* Data Bit Timing & Prescaler Register */
+	volatile uint32_t test;	    /* Test Register */
+	volatile uint32_t rwd;	    /* RAM Watchdog */
+	volatile uint32_t cccr;	    /* CC Control Register */
+	volatile uint32_t nbtp;	    /* Nominal Bit Timing & Prescaler Register */
+	volatile uint32_t tscc;	    /* Timestamp Counter Configuration */
+	volatile uint32_t tscv;	    /* Timestamp Counter Value */
+	volatile uint32_t tocc;	    /* Timeout Counter Configuration */
+	volatile uint32_t tocv;	    /* Timeout Counter Value */
+	uint32_t res1[4];	    /* Reserved (4) */
+	volatile uint32_t ecr;	    /* Error Counter Register */
+	volatile uint32_t psr;	    /* Protocol Status Register */
+	volatile uint32_t tdcr;	    /* Transmitter Delay Compensation */
+	uint32_t res2;		    /* Reserved (1) */
+	volatile uint32_t ir;	    /* Interrupt Register */
+	volatile uint32_t ie;	    /* Interrupt Enable */
+	volatile uint32_t ils;	    /* Interrupt Line Select */
+	volatile uint32_t ile;	    /* Interrupt Line Enable */
+	uint32_t res3[8];	    /* Reserved (8) */
+	volatile uint32_t gfc;	    /* Global Filter Configuration */
 	volatile uint32_t sidfc;    /* Standard ID Filter Configuration */
 	volatile uint32_t xidfc;    /* Extended ID Filter Configuration */
-	volatile uint32_t res4;     /* Reserved (1) */
+	volatile uint32_t res4;	    /* Reserved (1) */
 	volatile uint32_t xidam;    /* Extended ID AND Mask */
-	volatile uint32_t hpms;     /* High Priority Message Status */
+	volatile uint32_t hpms;	    /* High Priority Message Status */
 	volatile uint32_t ndata1;   /* New Data 1 */
 	volatile uint32_t ndata2;   /* New Data 2 */
 	volatile uint32_t rxf0c;    /* Rx FIFO 0 Configuration */
 	volatile uint32_t rxf0s;    /* Rx FIFO 0 Status */
 	volatile uint32_t rxf0a;    /* FIFO 0 Acknowledge */
-	volatile uint32_t rxbc;     /* Rx Buffer Configuration */
+	volatile uint32_t rxbc;	    /* Rx Buffer Configuration */
 	volatile uint32_t rxf1c;    /* Rx FIFO 1 Configuration */
 	volatile uint32_t rxf1s;    /* Rx FIFO 1 Status */
 	volatile uint32_t rxf1a;    /* Rx FIFO 1 Acknowledge*/
 	volatile uint32_t rxesc;    /* Rx Buffer / FIFO Element Size Config */
-	volatile uint32_t txbc;     /* Buffer Configuration */
+	volatile uint32_t txbc;	    /* Buffer Configuration */
 	volatile uint32_t txfqs;    /* FIFO/Queue Status */
 	volatile uint32_t txesc;    /* Tx Buffer Element Size Configuration */
 	volatile uint32_t txbrp;    /* Buffer Request Pending */
@@ -1563,7 +1563,7 @@ struct can_mcan_reg {
 	volatile uint32_t txefa;    /* Tx Event FIFO Acknowledge */
 #ifdef CONFIG_CAN_MCUX_MCAN
 	volatile uint32_t res6[65]; /* Reserved (65) */
-	volatile uint32_t mrba;     /* Message RAM Base Address */
+	volatile uint32_t mrba;	    /* Message RAM Base Address */
 #endif /* CONFIG_CAN_MCUX_MCAN */
 };
 

--- a/drivers/can/can_mcan_priv.h
+++ b/drivers/can/can_mcan_priv.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Vestas Wind Systems A/S
  * Copyright (c) 2020 Alexander Wachter
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -8,1455 +9,510 @@
 #ifndef ZEPHYR_DRIVERS_CAN_CAN_MCAN_PRIV_H_
 #define ZEPHYR_DRIVERS_CAN_CAN_MCAN_PRIV_H_
 
+#include <zephyr/sys/util.h>
+
 /*
- * Register Masks are taken from the stm32cube library and extended for
- * full M_CAN IPs
- * Copyright (c) 2019 STMicroelectronics.
+ * The Bosch M_CAN register definitions correspond to those found in the Bosch M_CAN Controller Area
+ * Network User's Manual, Revision 3.3.0.
+ *
+ * The STMicroelectronics STM32 FDCAN definitions correspond to those found in the
+ * STMicroelectronics STM32G4 Series Reference manual (RM0440), Rev 7.
  */
-/****************  Bit definition for CAN_MCAN_CREL register  *****************/
-/* Timestamp Day */
-#define CAN_MCAN_CREL_DAY_POS	  (0U)
-#define CAN_MCAN_CREL_DAY_MSK	  (0xFFUL << CAN_MCAN_CREL_DAY_POS)
-#define CAN_MCAN_CREL_DAY	  CAN_MCAN_CREL_DAY_MSK
-/* Timestamp Month */
-#define CAN_MCAN_CREL_MON_POS	  (8U)
-#define CAN_MCAN_CREL_MON_MSK	  (0xFFUL << CAN_MCAN_CREL_MON_POS)
-#define CAN_MCAN_CREL_MON	  CAN_MCAN_CREL_MON_MSK
-/* Timestamp Year */
-#define CAN_MCAN_CREL_YEAR_POS	  (16U)
-#define CAN_MCAN_CREL_YEAR_MSK	  (0xFUL << CAN_MCAN_CREL_YEAR_POS)
-#define CAN_MCAN_CREL_YEAR	  CAN_MCAN_CREL_YEAR_MSK
-/* Substep of Core release */
-#define CAN_MCAN_CREL_SUBSTEP_POS (20U)
-#define CAN_MCAN_CREL_SUBSTEP_MSK (0xFUL << CAN_MCAN_CREL_SUBSTEP_POS)
-#define CAN_MCAN_CREL_SUBSTEP	  CAN_MCAN_CREL_SUBSTEP_MSK
-/* Step of Core release */
-#define CAN_MCAN_CREL_STEP_POS	  (24U)
-#define CAN_MCAN_CREL_STEP_MSK	  (0xFUL << CAN_MCAN_CREL_STEP_POS)
-#define CAN_MCAN_CREL_STEP	  CAN_MCAN_CREL_STEP_MSK
-/* Core release */
-#define CAN_MCAN_CREL_REL_POS	  (28U)
-#define CAN_MCAN_CREL_REL_MSK	  (0xFUL << CAN_MCAN_CREL_REL_POS)
-#define CAN_MCAN_CREL_REL	  CAN_MCAN_CREL_REL_MSK
 
-/****************  Bit definition for CAN_MCAN_ENDN register  *****************/
-/* Endianness Test Value */
-#define CAN_MCAN_ENDN_ETV_POS (0U)
-#define CAN_MCAN_ENDN_ETV_MSK (0xFFFFFFFFUL << CAN_MCAN_ENDN_ETV_POS)
-#define CAN_MCAN_ENDN_ETV     CAN_MCAN_ENDN_ETV_MSK
+/* Core Release register */
+#define CAN_MCAN_CREL_REL     GENMASK(31, 28)
+#define CAN_MCAN_CREL_STEP    GENMASK(27, 24)
+#define CAN_MCAN_CREL_SUBSTEP GENMASK(23, 20)
+#define CAN_MCAN_CREL_YEAR    GENMASK(19, 16)
+#define CAN_MCAN_CREL_MON     GENMASK(15, 8)
+#define CAN_MCAN_CREL_DAY     GENMASK(7, 0)
 
-/***************  Bit definition for CAN_MCAN_DBTP register  ******************/
-/* Synchronization Jump Width */
-#define CAN_MCAN_DBTP_DSJW_POS	 (0U)
-#define CAN_MCAN_DBTP_DSJW_MSK	 (0xFUL << CAN_MCAN_DBTP_DSJW_POS)
-#define CAN_MCAN_DBTP_DSJW	 CAN_MCAN_DBTP_DSJW_MSK
-/* Data time segment after sample point */
-#define CAN_MCAN_DBTP_DTSEG2_POS (4U)
-#define CAN_MCAN_DBTP_DTSEG2_MSK (0xFUL << CAN_MCAN_DBTP_DTSEG2_POS)
-#define CAN_MCAN_DBTP_DTSEG2	 CAN_MCAN_DBTP_DTSEG2_MSK
-/* Data time segment before sample point */
-#define CAN_MCAN_DBTP_DTSEG1_POS (8U)
-#define CAN_MCAN_DBTP_DTSEG1_MSK (0x1FUL << CAN_MCAN_DBTP_DTSEG1_POS)
-#define CAN_MCAN_DBTP_DTSEG1	 CAN_MCAN_DBTP_DTSEG1_MSK
-/* Data BIt Rate Prescaler */
-#define CAN_MCAN_DBTP_DBRP_POS	 (16U)
-#define CAN_MCAN_DBTP_DBRP_MSK	 (0x1FUL << CAN_MCAN_DBTP_DBRP_POS)
-#define CAN_MCAN_DBTP_DBRP	 CAN_MCAN_DBTP_DBRP_MSK
-/* Transceiver Delay Compensation */
-#define CAN_MCAN_DBTP_TDC_POS	 (23U)
-#define CAN_MCAN_DBTP_TDC_MSK	 (0x1UL << CAN_MCAN_DBTP_TDC_POS)
-#define CAN_MCAN_DBTP_TDC	 CAN_MCAN_DBTP_TDC_MSK
+/* Endian register */
+#define CAN_MCAN_ENDN_ETV GENMASK(31, 0)
 
-/***************  Bit definition for CAN_MCAN_TEST register  *****************/
-/* Loop Back mode */
-#define CAN_MCAN_TEST_LBCK_POS	(4U)
-#define CAN_MCAN_TEST_LBCK_MSK	(0x1UL << CAN_MCAN_TEST_LBCK_POS)
-#define CAN_MCAN_TEST_LBCK	CAN_MCAN_TEST_LBCK_MSK
-/* Control of Transmit Pin */
-#define CAN_MCAN_TEST_TX_POS	(5U)
-#define CAN_MCAN_TEST_TX_MSK	(0x3UL << CAN_MCAN_TEST_TX_POS)
-#define CAN_MCAN_TEST_TX	CAN_MCAN_TEST_TX_MSK
-/* Receive Pin */
-#define CAN_MCAN_TEST_RX_POS	(7U)
-#define CAN_MCAN_TEST_RX_MSK	(0x1UL << CAN_MCAN_TEST_RX_POS)
-#define CAN_MCAN_TEST_RX	CAN_MCAN_TEST_RX_MSK
-/* Does not exist on STM32 begin */
-/* Tx Buffer Number Prepared */
-#define CAN_MCAN_TEST_TXBNP_POS (8U)
-#define CAN_MCAN_TEST_TXBNP_MSK (0x1FUL << CAN_MCAN_TEST_TXBNP_POS)
-#define CAN_MCAN_TEST_TXBNP	CAN_MCAN_TEST_RX_MSK
-/* Prepared Valid */
-#define CAN_MCAN_TEST_PVAL_POS	(13U)
-#define CAN_MCAN_TEST_PVAL_MSK	(0x1UL << CAN_MCAN_TEST_PVAL_POS)
-#define CAN_MCAN_TEST_PVAL	CAN_MCAN_TEST_RX_MSK
-/* Tx Buffer Number Started */
-#define CAN_MCAN_TEST_TXBNS_POS (16U)
-#define CAN_MCAN_TEST_TXBNS_MSK (0x1FUL << CAN_MCAN_TEST_TXBNS_POS)
-#define CAN_MCAN_TEST_TXBNS	CAN_MCAN_TEST_RX_MSK
-/* Started Valid */
-#define CAN_MCAN_TEST_SVAL_POS	(12U)
-#define CAN_MCAN_TEST_SVAL_MSK	(0x1UL << CAN_MCAN_TEST_SVAL_POS)
-#define CAN_MCAN_TEST_SVAL	CAN_MCAN_TEST_RX_MSK
-/* Does not exist on STM32 end */
+/* Customer register */
+#define CAN_MCAN_CUST_CUST GENMASK(31, 0)
 
-/***************  Bit definition for CAN_MCAN_RWD register  ******************/
-/* Watchdog configuration */
-#define CAN_MCAN_RWD_WDC_POS (0U)
-#define CAN_MCAN_RWD_WDC_MSK (0xFFUL << CAN_MCAN_RWD_WDC_POS)
-#define CAN_MCAN_RWD_WDC     CAN_MCAN_RWD_WDC_MSK
-/* Watchdog value */
-#define CAN_MCAN_RWD_WDV_POS (8U)
-#define CAN_MCAN_RWD_WDV_MSK (0xFFUL << CAN_MCAN_RWD_WDV_POS)
-#define CAN_MCAN_RWD_WDV     CAN_MCAN_RWD_WDV_MSK
+/* Data Bit Timing & Prescaler register */
+#define CAN_MCAN_DBTP_TDC    BIT(23)
+#define CAN_MCAN_DBTP_DBRP   GENMASK(20, 16)
+#define CAN_MCAN_DBTP_DTSEG1 GENMASK(12, 8)
+#define CAN_MCAN_DBTP_DTSEG2 GENMASK(7, 4)
+#define CAN_MCAN_DBTP_DSJW   GENMASK(3, 0)
 
-/***************  Bit definition for CAN_MCAN_CCCR register  ******************/
-/* Initialization */
-#define CAN_MCAN_CCCR_INIT_POS (0U)
-#define CAN_MCAN_CCCR_INIT_MSK (0x1UL << CAN_MCAN_CCCR_INIT_POS)
-#define CAN_MCAN_CCCR_INIT     CAN_MCAN_CCCR_INIT_MSK
-/* Configuration Change Enable */
-#define CAN_MCAN_CCCR_CCE_POS  (1U)
-#define CAN_MCAN_CCCR_CCE_MSK  (0x1UL << CAN_MCAN_CCCR_CCE_POS)
-#define CAN_MCAN_CCCR_CCE      CAN_MCAN_CCCR_CCE_MSK
-/* ASM Restricted Operation Mode */
-#define CAN_MCAN_CCCR_ASM_POS  (2U)
-#define CAN_MCAN_CCCR_ASM_MSK  (0x1UL << CAN_MCAN_CCCR_ASM_POS)
-#define CAN_MCAN_CCCR_ASM      CAN_MCAN_CCCR_ASM_MSK
-/* Clock Stop Acknowledge */
-#define CAN_MCAN_CCCR_CSA_POS  (3U)
-#define CAN_MCAN_CCCR_CSA_MSK  (0x1UL << CAN_MCAN_CCCR_CSA_POS)
-#define CAN_MCAN_CCCR_CSA      CAN_MCAN_CCCR_CSA_MSK
-/* Clock Stop Request */
-#define CAN_MCAN_CCCR_CSR_POS  (4U)
-#define CAN_MCAN_CCCR_CSR_MSK  (0x1UL << CAN_MCAN_CCCR_CSR_POS)
-#define CAN_MCAN_CCCR_CSR      CAN_MCAN_CCCR_CSR_MSK
-/* Bus Monitoring Mode */
-#define CAN_MCAN_CCCR_MON_POS  (5U)
-#define CAN_MCAN_CCCR_MON_MSK  (0x1UL << CAN_MCAN_CCCR_MON_POS)
-#define CAN_MCAN_CCCR_MON      CAN_MCAN_CCCR_MON_MSK
-/* Disable Automatic Retransmission */
-#define CAN_MCAN_CCCR_DAR_POS  (6U)
-#define CAN_MCAN_CCCR_DAR_MSK  (0x1UL << CAN_MCAN_CCCR_DAR_POS)
-#define CAN_MCAN_CCCR_DAR      CAN_MCAN_CCCR_DAR_MSK
-/* Test Mode Enable */
-#define CAN_MCAN_CCCR_TEST_POS (7U)
-#define CAN_MCAN_CCCR_TEST_MSK (0x1UL << CAN_MCAN_CCCR_TEST_POS)
-#define CAN_MCAN_CCCR_TEST     CAN_MCAN_CCCR_TEST_MSK
-/* FD Operation Enable */
-#define CAN_MCAN_CCCR_FDOE_POS (8U)
-#define CAN_MCAN_CCCR_FDOE_MSK (0x1UL << CAN_MCAN_CCCR_FDOE_POS)
-#define CAN_MCAN_CCCR_FDOE     CAN_MCAN_CCCR_FDOE_MSK
-/* FDCAN Bit Rate Switching */
-#define CAN_MCAN_CCCR_BRSE_POS (9U)
-#define CAN_MCAN_CCCR_BRSE_MSK (0x1UL << CAN_MCAN_CCCR_BRSE_POS)
-#define CAN_MCAN_CCCR_BRSE     CAN_MCAN_CCCR_BRSE_MSK
-/* does not exist on stm32 begin*/
-/* Use Timestamping Uni */
-#define CAN_MCAN_CCCR_UTSU_POS (10U)
-#define CAN_MCAN_CCCR_UTSU_MSK (0x1UL << CAN_MCAN_CCCR_UTSU_POS)
-#define CAN_MCAN_CCCR_UTSU     CAN_MCAN_CCCR_UTSU_MSK
-/* FDCAN Wide Message Marker */
-#define CAN_MCAN_CCCR_WMM_POS  (11U)
-#define CAN_MCAN_CCCR_WMM_MSK  (0x1UL << CAN_MCAN_CCCR_WMM_POS)
-#define CAN_MCAN_CCCR_WMM      CAN_MCAN_CCCR_WMM_MSK
-/* end */
-/* Protocol Exception Handling Disable */
-#define CAN_MCAN_CCCR_PXHD_POS (12U)
-#define CAN_MCAN_CCCR_PXHD_MSK (0x1UL << CAN_MCAN_CCCR_PXHD_POS)
-#define CAN_MCAN_CCCR_PXHD     CAN_MCAN_CCCR_PXHD_MSK
-/* Edge Filtering during Bus Integration */
-#define CAN_MCAN_CCCR_EFBI_POS (13U)
-#define CAN_MCAN_CCCR_EFBI_MSK (0x1UL << CAN_MCAN_CCCR_EFBI_POS)
-#define CAN_MCAN_CCCR_EFBI     CAN_MCAN_CCCR_EFBI_MSK
-/* Two CAN bit times Pause */
-#define CAN_MCAN_CCCR_TXP_POS  (14U)
-#define CAN_MCAN_CCCR_TXP_MSK  (0x1UL << CAN_MCAN_CCCR_TXP_POS)
-#define CAN_MCAN_CCCR_TXP      CAN_MCAN_CCCR_TXP_MSK
-/* Non ISO Operation */
-#define CAN_MCAN_CCCR_NISO_POS (15U)
-#define CAN_MCAN_CCCR_NISO_MSK (0x1UL << CAN_MCAN_CCCR_NISO_POS)
-#define CAN_MCAN_CCCR_NISO     CAN_MCAN_CCCR_NISO_MSK
+/* Test register */
+#ifndef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TEST_SVAL  BIT(21)
+#define CAN_MCAN_TEST_TXBNS GENMASK(20, 16)
+#define CAN_MCAN_TEST_PVAL  BIT(13)
+#define CAN_MCAN_TEST_TXBNP GENMASK(12, 8)
+#endif /* !CONFIG_CAN_STM32FD */
+#define CAN_MCAN_TEST_RX   BIT(7)
+#define CAN_MCAN_TEST_TX   GENMASK(6, 5)
+#define CAN_MCAN_TEST_LBCK BIT(4)
 
-/***************  Bit definition for CAN_MCAN_NBTP register  ******************/
-/* Nominal Time segment after sample point */
-#define CAN_MCAN_NBTP_NTSEG2_POS (0U)
-#define CAN_MCAN_NBTP_NTSEG2_MSK (0x7FUL << CAN_MCAN_NBTP_NTSEG2_POS)
-#define CAN_MCAN_NBTP_NTSEG2	 CAN_MCAN_NBTP_NTSEG2_MSK
-/* Nominal Time segment before sample point */
-#define CAN_MCAN_NBTP_NTSEG1_POS (8U)
-#define CAN_MCAN_NBTP_NTSEG1_MSK (0xFFUL << CAN_MCAN_NBTP_NTSEG1_POS)
-#define CAN_MCAN_NBTP_NTSEG1	 CAN_MCAN_NBTP_NTSEG1_MSK
-/* Bit Rate Prescaler */
-#define CAN_MCAN_NBTP_NBRP_POS	 (16U)
-#define CAN_MCAN_NBTP_NBRP_MSK	 (0x1FFUL << CAN_MCAN_NBTP_NBRP_POS)
-#define CAN_MCAN_NBTP_NBRP	 CAN_MCAN_NBTP_NBRP_MSK
-/* Nominal (Re)Synchronization Jump Width */
-#define CAN_MCAN_NBTP_NSJW_POS	 (25U)
-#define CAN_MCAN_NBTP_NSJW_MSK	 (0x7FUL << CAN_MCAN_NBTP_NSJW_POS)
-#define CAN_MCAN_NBTP_NSJW	 CAN_MCAN_NBTP_NSJW_MSK
+/* RAM Watchdog register */
+#define CAN_MCAN_RWD_WDV GENMASK(15, 8)
+#define CAN_MCAN_RWD_WDC GENMASK(7, 0)
 
-/***************  Bit definition for CAN_MCAN_TSCC register  ******************/
-/* Timestamp Select */
-#define CAN_MCAN_TSCC_TSS_POS (0U)
-#define CAN_MCAN_TSCC_TSS_MSK (0x3UL << CAN_MCAN_TSCC_TSS_POS)
-#define CAN_MCAN_TSCC_TSS     CAN_MCAN_TSCC_TSS_MSK
-/* Timestamp Counter Prescaler */
-#define CAN_MCAN_TSCC_TCP_POS (16U)
-#define CAN_MCAN_TSCC_TCP_MSK (0xFUL << CAN_MCAN_TSCC_TCP_POS)
-#define CAN_MCAN_TSCC_TCP     CAN_MCAN_TSCC_TCP_MSK
-/***************  Bit definition for CAN_MCAN_TSCV register  ******************/
-/* Timestamp Counter */
-#define CAN_MCAN_TSCV_TSC_POS (0U)
-#define CAN_MCAN_TSCV_TSC_MSK (0xFFFFUL << CAN_MCAN_TSCV_TSC_POS)
-#define CAN_MCAN_TSCV_TSC     CAN_MCAN_TSCV_TSC_MSK
+/* CC Control register */
+#define CAN_MCAN_CCCR_NISO BIT(15)
+#define CAN_MCAN_CCCR_TXP  BIT(14)
+#define CAN_MCAN_CCCR_EFBI BIT(13)
+#define CAN_MCAN_CCCR_PXHD BIT(12)
+#ifndef CONFIG_CAN_STM32FD
+#define CAN_MCAN_CCCR_WMM  BIT(11)
+#define CAN_MCAN_CCCR_UTSU BIT(10)
+#endif /* !CONFIG_CAN_STM32FD */
+#define CAN_MCAN_CCCR_BRSE BIT(9)
+#define CAN_MCAN_CCCR_FDOE BIT(8)
+#define CAN_MCAN_CCCR_TEST BIT(7)
+#define CAN_MCAN_CCCR_DAR  BIT(6)
+#define CAN_MCAN_CCCR_MON  BIT(5)
+#define CAN_MCAN_CCCR_CSR  BIT(4)
+#define CAN_MCAN_CCCR_CSA  BIT(3)
+#define CAN_MCAN_CCCR_ASM  BIT(2)
+#define CAN_MCAN_CCCR_CCE  BIT(1)
+#define CAN_MCAN_CCCR_INIT BIT(0)
 
-/***************  Bit definition for CAN_MCAN_TOCC register  ******************/
-/* Enable Timeout Counter */
-#define CAN_MCAN_TOCC_ETOC_POS (0U)
-#define CAN_MCAN_TOCC_ETOC_MSK (0x1UL << CAN_MCAN_TOCC_ETOC_POS)
-#define CAN_MCAN_TOCC_ETOC     CAN_MCAN_TOCC_ETOC_MSK
-/* Timeout Select */
-#define CAN_MCAN_TOCC_TOS_POS  (1U)
-#define CAN_MCAN_TOCC_TOS_MSK  (0x3UL << CAN_MCAN_TOCC_TOS_POS)
-#define CAN_MCAN_TOCC_TOS      CAN_MCAN_TOCC_TOS_MSK
-/* Timeout Period */
-#define CAN_MCAN_TOCC_TOP_POS  (16U)
-#define CAN_MCAN_TOCC_TOP_MSK  (0xFFFFUL << CAN_MCAN_TOCC_TOP_POS)
-#define CAN_MCAN_TOCC_TOP      CAN_MCAN_TOCC_TOP_MSK
+/* Nominal Bit Timing & Prescaler register */
+#define CAN_MCAN_NBTP_NSJW   GENMASK(31, 25)
+#define CAN_MCAN_NBTP_NBRP   GENMASK(24, 16)
+#define CAN_MCAN_NBTP_NTSEG1 GENMASK(15, 8)
+#define CAN_MCAN_NBTP_NTSEG2 GENMASK(6, 0)
 
-/***************  Bit definition for CAN_MCAN_TOCV register  ******************/
-/* Timeout Counter */
-#define CAN_MCAN_TOCV_TOC_POS (0U)
-#define CAN_MCAN_TOCV_TOC_MSK (0xFFFFUL << CAN_MCAN_TOCV_TOC_POS)
-#define CAN_MCAN_TOCV_TOC     CAN_MCAN_TOCV_TOC_MSK
+/* Timestamp Counter Configuration register */
+#define CAN_MCAN_TSCC_TCP GENMASK(19, 16)
+#define CAN_MCAN_TSCC_TSS GENMASK(1, 0)
 
-/***************  Bit definition for CAN_MCAN_ECR register  *******************/
-/* Transmit Error Counter */
-#define CAN_MCAN_ECR_TEC_POS (0U)
-#define CAN_MCAN_ECR_TEC_MSK (0xFFUL << CAN_MCAN_ECR_TEC_POS)
-#define CAN_MCAN_ECR_TEC     CAN_MCAN_ECR_TEC_MSK
-/* Receive Error Counter */
-#define CAN_MCAN_ECR_REC_POS (8U)
-#define CAN_MCAN_ECR_REC_MSK (0x7FUL << CAN_MCAN_ECR_REC_POS)
-#define CAN_MCAN_ECR_REC     CAN_MCAN_ECR_REC_MSK
-/* Receive Error Passive */
-#define CAN_MCAN_ECR_RP_POS  (15U)
-#define CAN_MCAN_ECR_RP_MSK  (0x1UL << CAN_MCAN_ECR_RP_POS)
-#define CAN_MCAN_ECR_RP	     CAN_MCAN_ECR_RP_MSK
-/* CAN Error Logging */
-#define CAN_MCAN_ECR_CEL_POS (16U)
-#define CAN_MCAN_ECR_CEL_MSK (0xFFUL << CAN_MCAN_ECR_CEL_POS)
-#define CAN_MCAN_ECR_CEL     CAN_MCAN_ECR_CEL_MSK
+/* Timestamp Counter Value register */
+#define CAN_MCAN_TSCV_TSC GENMASK(15, 0)
 
-/***************  Bit definition for CAN_MCAN_PSR register  *******************/
-/* Last Error Code */
-#define CAN_MCAN_PSR_LEC_POS  (0U)
-#define CAN_MCAN_PSR_LEC_MSK  (0x7UL << CAN_MCAN_PSR_LEC_POS)
-#define CAN_MCAN_PSR_LEC      CAN_MCAN_PSR_LEC_MSK
-/* Activity */
-#define CAN_MCAN_PSR_ACT_POS  (3U)
-#define CAN_MCAN_PSR_ACT_MSK  (0x3UL << CAN_MCAN_PSR_ACT_POS)
-#define CAN_MCAN_PSR_ACT      CAN_MCAN_PSR_ACT_MSK
-/* Error Passive */
-#define CAN_MCAN_PSR_EP_POS   (5U)
-#define CAN_MCAN_PSR_EP_MSK   (0x1UL << CAN_MCAN_PSR_EP_POS)
-#define CAN_MCAN_PSR_EP	      CAN_MCAN_PSR_EP_MSK
-/* Warning Status */
-#define CAN_MCAN_PSR_EW_POS   (6U)
-#define CAN_MCAN_PSR_EW_MSK   (0x1UL << CAN_MCAN_PSR_EW_POS)
-#define CAN_MCAN_PSR_EW	      CAN_MCAN_PSR_EW_MSK
-/* Bus_Off Status */
-#define CAN_MCAN_PSR_BO_POS   (7U)
-#define CAN_MCAN_PSR_BO_MSK   (0x1UL << CAN_MCAN_PSR_BO_POS)
-#define CAN_MCAN_PSR_BO	      CAN_MCAN_PSR_BO_MSK
-/* Data Last Error Code */
-#define CAN_MCAN_PSR_DLEC_POS (8U)
-#define CAN_MCAN_PSR_DLEC_MSK (0x7UL << CAN_MCAN_PSR_DLEC_POS)
-#define CAN_MCAN_PSR_DLEC     CAN_MCAN_PSR_DLEC_MSK
-/* ESI flag of last received FDCAN Message */
-#define CAN_MCAN_PSR_RESI_POS (11U)
-#define CAN_MCAN_PSR_RESI_MSK (0x1UL << CAN_MCAN_PSR_RESI_POS)
-#define CAN_MCAN_PSR_RESI     CAN_MCAN_PSR_RESI_MSK
-/* BRS flag of last received FDCAN Message */
-#define CAN_MCAN_PSR_RBRS_POS (12U)
-#define CAN_MCAN_PSR_RBRS_MSK (0x1UL << CAN_MCAN_PSR_RBRS_POS)
-#define CAN_MCAN_PSR_RBRS     CAN_MCAN_PSR_RBRS_MSK
-/* Received FDCAN Message */
-#define CAN_MCAN_PSR_REDL_POS (13U)
-#define CAN_MCAN_PSR_REDL_MSK (0x1UL << CAN_MCAN_PSR_REDL_POS)
-#define CAN_MCAN_PSR_REDL     CAN_MCAN_PSR_REDL_MSK
-/* Protocol Exception Event */
-#define CAN_MCAN_PSR_PXE_POS  (14U)
-#define CAN_MCAN_PSR_PXE_MSK  (0x1UL << CAN_MCAN_PSR_PXE_POS)
-#define CAN_MCAN_PSR_PXE      CAN_MCAN_PSR_PXE_MSK
-/* Transmitter Delay Compensation Value */
-#define CAN_MCAN_PSR_TDCV_POS (16U)
-#define CAN_MCAN_PSR_TDCV_MSK (0x7FUL << CAN_MCAN_PSR_TDCV_POS)
-#define CAN_MCAN_PSR_TDCV     CAN_MCAN_PSR_TDCV_MSK
+/* Timeout Counter Configuration register */
+#define CAN_MCAN_TOCC_TOP  GENMASK(31, 16)
+#define CAN_MCAN_TOCC_TOS  GENMASK(2, 1)
+#define CAN_MCAN_TOCC_ETOC BIT(1)
 
-/***************  Bit definition for CAN_MCAN_TDCR register  ******************/
-/* Transmitter Delay Compensation Filter */
-#define CAN_MCAN_TDCR_TDCF_POS (0U)
-#define CAN_MCAN_TDCR_TDCF_MSK (0x7FUL << CAN_MCAN_TDCR_TDCF_POS)
-#define CAN_MCAN_TDCR_TDCF     CAN_MCAN_TDCR_TDCF_MSK
-/* Transmitter Delay Compensation Offset */
-#define CAN_MCAN_TDCR_TDCO_POS (8U)
-#define CAN_MCAN_TDCR_TDCO_MSK (0x7FUL << CAN_MCAN_TDCR_TDCO_POS)
-#define CAN_MCAN_TDCR_TDCO     CAN_MCAN_TDCR_TDCO_MSK
+/* Timeout Counter Value register */
+#define CAN_MCAN_TOCV_TOC GENMASK(15, 0)
 
-/***************  Bit definition for CAN_MCAN_IR register  ********************/
+/* Error Counter register */
+#define CAN_MCAN_ECR_CEL GENMASK(23, 16)
+#define CAN_MCAN_ECR_RP	 BIT(15)
+#define CAN_MCAN_ECR_REC GENMASK(14, 8)
+#define CAN_MCAN_ECR_TEC GENMASK(7, 0)
+
+/* Protocol Status register */
+#define CAN_MCAN_PSR_TDCV GENMASK(22, 16)
+#define CAN_MCAN_PSR_PXE  BIT(14)
+#define CAN_MCAN_PSR_RFDF BIT(13)
+#define CAN_MCAN_PSR_RBRS BIT(12)
+#define CAN_MCAN_PSR_RESI BIT(11)
+#define CAN_MCAN_PSR_DLEC GENMASK(10, 8)
+#define CAN_MCAN_PSR_BO	  BIT(7)
+#define CAN_MCAN_PSR_EW	  BIT(6)
+#define CAN_MCAN_PSR_EP	  BIT(5)
+#define CAN_MCAN_PSR_ACT  GENMASK(4, 3)
+#define CAN_MCAN_PSR_LEC  GENMASK(2, 0)
+
+/* Transmitter Delay Compensation register */
+#define CAN_MCAN_TDCR_TDCO GENMASK(14, 8)
+#define CAN_MCAN_TDCR_TDCF GENMASK(6, 0)
+
+/* Interrupt register */
 #ifdef CONFIG_CAN_STM32FD
-/* Rx FIFO 0 New Message */
-#define CAN_MCAN_IR_RF0N_POS (0U)
-#define CAN_MCAN_IR_RF0N_MSK (0x1UL << CAN_MCAN_IR_RF0N_POS)
-#define CAN_MCAN_IR_RF0N     CAN_MCAN_IR_RF0N_MSK
-/* Rx FIFO 0 Full */
-#define CAN_MCAN_IR_RF0F_POS (1U)
-#define CAN_MCAN_IR_RF0F_MSK (0x1UL << CAN_MCAN_IR_RF0F_POS)
-#define CAN_MCAN_IR_RF0F     CAN_MCAN_IR_RF0F_MSK
-/* Rx FIFO 0 Message Lost */
-#define CAN_MCAN_IR_RF0L_POS (2U)
-#define CAN_MCAN_IR_RF0L_MSK (0x1UL << CAN_MCAN_IR_RF0L_POS)
-#define CAN_MCAN_IR_RF0L     CAN_MCAN_IR_RF0L_MSK
-/* Rx FIFO 1 New Message */
-#define CAN_MCAN_IR_RF1N_POS (3U)
-#define CAN_MCAN_IR_RF1N_MSK (0x1UL << CAN_MCAN_IR_RF1N_POS)
-#define CAN_MCAN_IR_RF1N     CAN_MCAN_IR_RF1N_MSK
-/* Rx FIFO 1 Full */
-#define CAN_MCAN_IR_RF1F_POS (4U)
-#define CAN_MCAN_IR_RF1F_MSK (0x1UL << CAN_MCAN_IR_RF1F_POS)
-#define CAN_MCAN_IR_RF1F     CAN_MCAN_IR_RF1F_MSK
-/* Rx FIFO 1 Message Lost */
-#define CAN_MCAN_IR_RF1L_POS (5U)
-#define CAN_MCAN_IR_RF1L_MSK (0x1UL << CAN_MCAN_IR_RF1L_POS)
-#define CAN_MCAN_IR_RF1L     CAN_MCAN_IR_RF1L_MSK
-/* High Priority Message */
-#define CAN_MCAN_IR_HPM_POS  (6U)
-#define CAN_MCAN_IR_HPM_MSK  (0x1UL << CAN_MCAN_IR_HPM_POS)
-#define CAN_MCAN_IR_HPM	     CAN_MCAN_IR_HPM_MSK
-/* Transmission Completed     */
-#define CAN_MCAN_IR_TC_POS   (7U)
-#define CAN_MCAN_IR_TC_MSK   (0x1UL << CAN_MCAN_IR_TC_POS)
-#define CAN_MCAN_IR_TC	     CAN_MCAN_IR_TC_MSK
-/* Transmission Cancellation Finished */
-#define CAN_MCAN_IR_TCF_POS  (8U)
-#define CAN_MCAN_IR_TCF_MSK  (0x1UL << CAN_MCAN_IR_TCF_POS)
-#define CAN_MCAN_IR_TCF	     CAN_MCAN_IR_TCF_MSK
-/* Tx FIFO Empty */
-#define CAN_MCAN_IR_TFE_POS  (9U)
-#define CAN_MCAN_IR_TFE_MSK  (0x1UL << CAN_MCAN_IR_TFE_POS)
-#define CAN_MCAN_IR_TFE	     CAN_MCAN_IR_TFE_MSK
-/* Tx Event FIFO New Entry */
-#define CAN_MCAN_IR_TEFN_POS (10U)
-#define CAN_MCAN_IR_TEFN_MSK (0x1UL << CAN_MCAN_IR_TEFN_POS)
-#define CAN_MCAN_IR_TEFN     CAN_MCAN_IR_TEFN_MSK
-/* Tx Event FIFO Full */
-#define CAN_MCAN_IR_TEFF_POS (11U)
-#define CAN_MCAN_IR_TEFF_MSK (0x1UL << CAN_MCAN_IR_TEFF_POS)
-#define CAN_MCAN_IR_TEFF     CAN_MCAN_IR_TEFF_MSK
-/* Tx Event FIFO Element Lost */
-#define CAN_MCAN_IR_TEFL_POS (12U)
-#define CAN_MCAN_IR_TEFL_MSK (0x1UL << CAN_MCAN_IR_TEFL_POS)
-#define CAN_MCAN_IR_TEFL     CAN_MCAN_IR_TEFL_MSK
-/* Timestamp Wraparound */
-#define CAN_MCAN_IR_TSW_POS  (13U)
-#define CAN_MCAN_IR_TSW_MSK  (0x1UL << CAN_MCAN_IR_TSW_POS)
-#define CAN_MCAN_IR_TSW	     CAN_MCAN_IR_TSW_MSK
-/* Message RAM Access Failure */
-#define CAN_MCAN_IR_MRAF_POS (14U)
-#define CAN_MCAN_IR_MRAF_MSK (0x1UL << CAN_MCAN_IR_MRAF_POS)
-#define CAN_MCAN_IR_MRAF     CAN_MCAN_IR_MRAF_MSK
-/* Timeout Occurred */
-#define CAN_MCAN_IR_TOO_POS  (15U)
-#define CAN_MCAN_IR_TOO_MSK  (0x1UL << CAN_MCAN_IR_TOO_POS)
-#define CAN_MCAN_IR_TOO	     CAN_MCAN_IR_TOO_MSK
-/* Error Logging Overflow */
-#define CAN_MCAN_IR_ELO_POS  (16U)
-#define CAN_MCAN_IR_ELO_MSK  (0x1UL << CAN_MCAN_IR_ELO_POS)
-#define CAN_MCAN_IR_ELO	     CAN_MCAN_IR_ELO_MSK
-/* Error Passive */
-#define CAN_MCAN_IR_EP_POS   (17U)
-#define CAN_MCAN_IR_EP_MSK   (0x1UL << CAN_MCAN_IR_EP_POS)
-#define CAN_MCAN_IR_EP	     CAN_MCAN_IR_EP_MSK
-/* Warning Status */
-#define CAN_MCAN_IR_EW_POS   (18U)
-#define CAN_MCAN_IR_EW_MSK   (0x1UL << CAN_MCAN_IR_EW_POS)
-#define CAN_MCAN_IR_EW	     CAN_MCAN_IR_EW_MSK
-/* Bus_Off Status */
-#define CAN_MCAN_IR_BO_POS   (19U)
-#define CAN_MCAN_IR_BO_MSK   (0x1UL << CAN_MCAN_IR_BO_POS)
-#define CAN_MCAN_IR_BO	     CAN_MCAN_IR_BO_MSK
-/* Watchdog Interrupt */
-#define CAN_MCAN_IR_WDI_POS  (20U)
-#define CAN_MCAN_IR_WDI_MSK  (0x1UL << CAN_MCAN_IR_WDI_POS)
-#define CAN_MCAN_IR_WDI	     CAN_MCAN_IR_WDI_MSK
-/* Protocol Error in Arbitration Phase */
-#define CAN_MCAN_IR_PEA_POS  (21U)
-#define CAN_MCAN_IR_PEA_MSK  (0x1UL << CAN_MCAN_IR_PEA_POS)
-#define CAN_MCAN_IR_PEA	     CAN_MCAN_IR_PEA_MSK
-/* Protocol Error in Data Phase */
-#define CAN_MCAN_IR_PED_POS  (22U)
-#define CAN_MCAN_IR_PED_MSK  (0x1UL << CAN_MCAN_IR_PED_POS)
-#define CAN_MCAN_IR_PED	     CAN_MCAN_IR_PED_MSK
-/* Access to Reserved Address */
-#define CAN_MCAN_IR_ARA_POS  (23U)
-#define CAN_MCAN_IR_ARA_MSK  (0x1UL << CAN_MCAN_IR_ARA_POS)
-#define CAN_MCAN_IR_ARA	     CAN_MCAN_IR_ARA_MSK
-
+#define CAN_MCAN_IR_ARA	 BIT(23)
+#define CAN_MCAN_IR_PED	 BIT(22)
+#define CAN_MCAN_IR_PEA	 BIT(21)
+#define CAN_MCAN_IR_WDI	 BIT(20)
+#define CAN_MCAN_IR_BO	 BIT(19)
+#define CAN_MCAN_IR_EW	 BIT(18)
+#define CAN_MCAN_IR_EP	 BIT(17)
+#define CAN_MCAN_IR_ELO	 BIT(16)
+#define CAN_MCAN_IR_TOO	 BIT(15)
+#define CAN_MCAN_IR_MRAF BIT(14)
+#define CAN_MCAN_IR_TSW	 BIT(13)
+#define CAN_MCAN_IR_TEFL BIT(12)
+#define CAN_MCAN_IR_TEFF BIT(11)
+#define CAN_MCAN_IR_TEFN BIT(10)
+#define CAN_MCAN_IR_TFE	 BIT(9)
+#define CAN_MCAN_IR_TCF	 BIT(8)
+#define CAN_MCAN_IR_TC	 BIT(7)
+#define CAN_MCAN_IR_HPM	 BIT(6)
+#define CAN_MCAN_IR_RF1L BIT(5)
+#define CAN_MCAN_IR_RF1F BIT(4)
+#define CAN_MCAN_IR_RF1N BIT(3)
+#define CAN_MCAN_IR_RF0L BIT(2)
+#define CAN_MCAN_IR_RF0F BIT(1)
+#define CAN_MCAN_IR_RF0N BIT(0)
 #else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_IR_ARA	 BIT(29)
+#define CAN_MCAN_IR_PED	 BIT(28)
+#define CAN_MCAN_IR_PEA	 BIT(27)
+#define CAN_MCAN_IR_WDI	 BIT(26)
+#define CAN_MCAN_IR_BO	 BIT(25)
+#define CAN_MCAN_IR_EW	 BIT(24)
+#define CAN_MCAN_IR_EP	 BIT(23)
+#define CAN_MCAN_IR_ELO	 BIT(22)
+#define CAN_MCAN_IR_BEU	 BIT(21)
+#define CAN_MCAN_IR_BEC	 BIT(20)
+#define CAN_MCAN_IR_DRX	 BIT(19)
+#define CAN_MCAN_IR_TOO	 BIT(18)
+#define CAN_MCAN_IR_MRAF BIT(17)
+#define CAN_MCAN_IR_TSW	 BIT(16)
+#define CAN_MCAN_IR_TEFL BIT(15)
+#define CAN_MCAN_IR_TEFF BIT(14)
+#define CAN_MCAN_IR_TEFW BIT(13)
+#define CAN_MCAN_IR_TEFN BIT(12)
+#define CAN_MCAN_IR_TFE	 BIT(11)
+#define CAN_MCAN_IR_TCF	 BIT(10)
+#define CAN_MCAN_IR_TC	 BIT(9)
+#define CAN_MCAN_IR_HPM	 BIT(8)
+#define CAN_MCAN_IR_RF1L BIT(7)
+#define CAN_MCAN_IR_RF1F BIT(6)
+#define CAN_MCAN_IR_RF1W BIT(5)
+#define CAN_MCAN_IR_RF1N BIT(4)
+#define CAN_MCAN_IR_RF0L BIT(3)
+#define CAN_MCAN_IR_RF0F BIT(2)
+#define CAN_MCAN_IR_RF0W BIT(1)
+#define CAN_MCAN_IR_RF0N BIT(0)
+#endif /* !CONFIG_CAN_STM32FD */
 
-/* Rx FIFO 0 New Message */
-#define CAN_MCAN_IR_RF0N_POS (0U)
-#define CAN_MCAN_IR_RF0N_MSK (0x1UL << CAN_MCAN_IR_RF0N_POS)
-#define CAN_MCAN_IR_RF0N     CAN_MCAN_IR_RF0N_MSK
-/* Rx FIFO 0 Watermark Reached*/
-#define CAN_MCAN_IR_RF0W_POS (1U)
-#define CAN_MCAN_IR_RF0W_MSK (0x1UL << CAN_MCAN_IR_RF0W_POS)
-#define CAN_MCAN_IR_RF0W     CAN_MCAN_IR_RF0W_MSK
-/* Rx FIFO 0 Full */
-#define CAN_MCAN_IR_RF0F_POS (2U)
-#define CAN_MCAN_IR_RF0F_MSK (0x1UL << CAN_MCAN_IR_RF0F_POS)
-#define CAN_MCAN_IR_RF0F     CAN_MCAN_IR_RF0F_MSK
-/* Rx FIFO 0 Message Lost */
-#define CAN_MCAN_IR_RF0L_POS (3U)
-#define CAN_MCAN_IR_RF0L_MSK (0x1UL << CAN_MCAN_IR_RF0L_POS)
-#define CAN_MCAN_IR_RF0L     CAN_MCAN_IR_RF0L_MSK
-/* Rx FIFO 1 New Message */
-#define CAN_MCAN_IR_RF1N_POS (4U)
-#define CAN_MCAN_IR_RF1N_MSK (0x1UL << CAN_MCAN_IR_RF1N_POS)
-#define CAN_MCAN_IR_RF1N     CAN_MCAN_IR_RF1N_MSK
-/* Rx FIFO 1 Watermark Reached*/
-#define CAN_MCAN_IR_RF1W_POS (5U)
-#define CAN_MCAN_IR_RF1W_MSK (0x1UL << CAN_MCAN_IR_RF1W_POS)
-#define CAN_MCAN_IR_RF1W     CAN_MCAN_IR_RF1W_MSK
-/* Rx FIFO 1 Full */
-#define CAN_MCAN_IR_RF1F_POS (6U)
-#define CAN_MCAN_IR_RF1F_MSK (0x1UL << CAN_MCAN_IR_RF1F_POS)
-#define CAN_MCAN_IR_RF1F     CAN_MCAN_IR_RF1F_MSK
-/* Rx FIFO 1 Message Lost */
-#define CAN_MCAN_IR_RF1L_POS (7U)
-#define CAN_MCAN_IR_RF1L_MSK (0x1UL << CAN_MCAN_IR_RF1L_POS)
-#define CAN_MCAN_IR_RF1L     CAN_MCAN_IR_RF1L_MSK
-/* High Priority Message */
-#define CAN_MCAN_IR_HPM_POS  (8U)
-#define CAN_MCAN_IR_HPM_MSK  (0x1UL << CAN_MCAN_IR_HPM_POS)
-#define CAN_MCAN_IR_HPM	     CAN_MCAN_IR_HPM_MSK
-/* Transmission Completed */
-#define CAN_MCAN_IR_TC_POS   (9U)
-#define CAN_MCAN_IR_TC_MSK   (0x1UL << CAN_MCAN_IR_TC_POS)
-#define CAN_MCAN_IR_TC	     CAN_MCAN_IR_TC_MSK
-/* Transmission Cancellation Finished */
-#define CAN_MCAN_IR_TCF_POS  (10U)
-#define CAN_MCAN_IR_TCF_MSK  (0x1UL << CAN_MCAN_IR_TCF_POS)
-#define CAN_MCAN_IR_TCF	     CAN_MCAN_IR_TCF_MSK
-/* Tx FIFO Empty */
-#define CAN_MCAN_IR_TFE_POS  (11U)
-#define CAN_MCAN_IR_TFE_MSK  (0x1UL << CAN_MCAN_IR_TFE_POS)
-#define CAN_MCAN_IR_TFE	     CAN_MCAN_IR_TFE_MSK
-/* Tx Event FIFO New Entry */
-#define CAN_MCAN_IR_TEFN_POS (12U)
-#define CAN_MCAN_IR_TEFN_MSK (0x1UL << CAN_MCAN_IR_TEFN_POS)
-#define CAN_MCAN_IR_TEFN     CAN_MCAN_IR_TEFN_MSK
-/* Tx Event FIFO Watermark */
-#define CAN_MCAN_IR_TEFW_POS (13U)
-#define CAN_MCAN_IR_TEFW_MSK (0x1UL << CAN_MCAN_IR_TEFW_POS)
-#define CAN_MCAN_IR_TEFW     CAN_MCAN_IR_TEFW_MSK
-/* Tx Event FIFO Full */
-#define CAN_MCAN_IR_TEFF_POS (14U)
-#define CAN_MCAN_IR_TEFF_MSK (0x1UL << CAN_MCAN_IR_TEFF_POS)
-#define CAN_MCAN_IR_TEFF     CAN_MCAN_IR_TEFF_MSK
-/* Tx Event FIFO Element Lost */
-#define CAN_MCAN_IR_TEFL_POS (15U)
-#define CAN_MCAN_IR_TEFL_MSK (0x1UL << CAN_MCAN_IR_TEFL_POS)
-#define CAN_MCAN_IR_TEFL     CAN_MCAN_IR_TEFL_MSK
-/* Timestamp Wraparound */
-#define CAN_MCAN_IR_TSW_POS  (16U)
-#define CAN_MCAN_IR_TSW_MSK  (0x1UL << CAN_MCAN_IR_TSW_POS)
-#define CAN_MCAN_IR_TSW	     CAN_MCAN_IR_TSW_MSK
-/* Message RAM Access Failure */
-#define CAN_MCAN_IR_MRAF_POS (17U)
-#define CAN_MCAN_IR_MRAF_MSK (0x1UL << CAN_MCAN_IR_MRAF_POS)
-#define CAN_MCAN_IR_MRAF     CAN_MCAN_IR_MRAF_MSK
-/* Timeout Occurred */
-#define CAN_MCAN_IR_TOO_POS  (18U)
-#define CAN_MCAN_IR_TOO_MSK  (0x1UL << CAN_MCAN_IR_TOO_POS)
-#define CAN_MCAN_IR_TOO	     CAN_MCAN_IR_TOO_MSK
-/* Message stored to Dedicated Rx Buffer */
-#define CAN_MCAN_IR_DRX_POS  (19U)
-#define CAN_MCAN_IR_DRX_MSK  (0x1UL << CAN_MCAN_IR_DRX_POS)
-#define CAN_MCAN_IR_DRX	     CAN_MCAN_IR_DRX_MSK
-/* Bit Error Corrected */
-#define CAN_MCAN_IR_BEC_POS  (20U)
-#define CAN_MCAN_IR_BEC_MSK  (0x1UL << CAN_MCAN_IR_BEC_POS)
-#define CAN_MCAN_IR_BEC	     CAN_MCAN_IR_BEC_MSK
-/* Bit Error Uncorrected */
-#define CAN_MCAN_IR_BEU_POS  (21U)
-#define CAN_MCAN_IR_BEU_MSK  (0x1UL << CAN_MCAN_IR_BEU_POS)
-#define CAN_MCAN_IR_BEU	     CAN_MCAN_IR_BEU_MSK
-/* Error Logging Overflow */
-#define CAN_MCAN_IR_ELO_POS  (22U)
-#define CAN_MCAN_IR_ELO_MSK  (0x1UL << CAN_MCAN_IR_ELO_POS)
-#define CAN_MCAN_IR_ELO	     CAN_MCAN_IR_ELO_MSK
-/* Error Passive*/
-#define CAN_MCAN_IR_EP_POS   (23U)
-#define CAN_MCAN_IR_EP_MSK   (0x1UL << CAN_MCAN_IR_EP_POS)
-#define CAN_MCAN_IR_EP	     CAN_MCAN_IR_EP_MSK
-/* Warning Status*/
-#define CAN_MCAN_IR_EW_POS   (24U)
-#define CAN_MCAN_IR_EW_MSK   (0x1UL << CAN_MCAN_IR_EW_POS)
-#define CAN_MCAN_IR_EW	     CAN_MCAN_IR_EW_MSK
-/* Bus_Off Status*/
-#define CAN_MCAN_IR_BO_POS   (25U)
-#define CAN_MCAN_IR_BO_MSK   (0x1UL << CAN_MCAN_IR_BO_POS)
-#define CAN_MCAN_IR_BO	     CAN_MCAN_IR_BO_MSK
-/* Watchdog Interrupt */
-#define CAN_MCAN_IR_WDI_POS  (26U)
-#define CAN_MCAN_IR_WDI_MSK  (0x1UL << CAN_MCAN_IR_WDI_POS)
-#define CAN_MCAN_IR_WDI	     CAN_MCAN_IR_WDI_MSK
-/* Protocol Error in Arbitration Phase */
-#define CAN_MCAN_IR_PEA_POS  (27U)
-#define CAN_MCAN_IR_PEA_MSK  (0x1UL << CAN_MCAN_IR_PEA_POS)
-#define CAN_MCAN_IR_PEA	     CAN_MCAN_IR_PEA_MSK
-/* Protocol Error in Data Phase */
-#define CAN_MCAN_IR_PED_POS  (28U)
-#define CAN_MCAN_IR_PED_MSK  (0x1UL << CAN_MCAN_IR_PED_POS)
-#define CAN_MCAN_IR_PED	     CAN_MCAN_IR_PED_MSK
-/* Access to Reserved Address */
-#define CAN_MCAN_IR_ARA_POS  (29U)
-#define CAN_MCAN_IR_ARA_MSK  (0x1UL << CAN_MCAN_IR_ARA_POS)
-#define CAN_MCAN_IR_ARA	     CAN_MCAN_IR_ARA_MSK
-
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_IE register  ********************/
+/* Interrupt Enable register */
 #ifdef CONFIG_CAN_STM32FD
-/* Rx FIFO 0 New Message Enable */
-#define CAN_MCAN_IE_RF0N_POS (0U)
-#define CAN_MCAN_IE_RF0N_MSK (0x1UL << CAN_MCAN_IE_RF0N_POS)
-#define CAN_MCAN_IE_RF0N     CAN_MCAN_IE_RF0N_MSK
-/* Rx FIFO 0 Full Enable */
-#define CAN_MCAN_IE_RF0F_POS (1U)
-#define CAN_MCAN_IE_RF0F_MSK (0x1UL << CAN_MCAN_IE_RF0F_POS)
-#define CAN_MCAN_IE_RF0F     CAN_MCAN_IE_RF0F_MSK
-/* Rx FIFO 0 Message Lost Enable */
-#define CAN_MCAN_IE_RF0L_POS (2U)
-#define CAN_MCAN_IE_RF0L_MSK (0x1UL << CAN_MCAN_IE_RF0L_POS)
-#define CAN_MCAN_IE_RF0L     CAN_MCAN_IE_RF0L_MSK
-/* Rx FIFO 1 New Message Enable */
-#define CAN_MCAN_IE_RF1N_POS (3U)
-#define CAN_MCAN_IE_RF1N_MSK (0x1UL << CAN_MCAN_IE_RF1N_POS)
-#define CAN_MCAN_IE_RF1N     CAN_MCAN_IE_RF1N_MSK
-/* Rx FIFO 1 Full Enable */
-#define CAN_MCAN_IE_RF1F_POS (4U)
-#define CAN_MCAN_IE_RF1F_MSK (0x1UL << CAN_MCAN_IE_RF1F_POS)
-#define CAN_MCAN_IE_RF1F     CAN_MCAN_IE_RF1F_MSK
-/* Rx FIFO 1 Message Lost Enable */
-#define CAN_MCAN_IE_RF1L_POS (5U)
-#define CAN_MCAN_IE_RF1L_MSK (0x1UL << CAN_MCAN_IE_RF1L_POS)
-#define CAN_MCAN_IE_RF1L     CAN_MCAN_IE_RF1L_MSK
-/* High Priority Message Enable */
-#define CAN_MCAN_IE_HPM_POS  (6U)
-#define CAN_MCAN_IE_HPM_MSK  (0x1UL << CAN_MCAN_IE_HPM_POS)
-#define CAN_MCAN_IE_HPM	     CAN_MCAN_IE_HPM_MSK
-/* Transmission Completed Enable */
-#define CAN_MCAN_IE_TC_POS   (7U)
-#define CAN_MCAN_IE_TC_MSK   (0x1UL << CAN_MCAN_IE_TC_POS)
-#define CAN_MCAN_IE_TC	     CAN_MCAN_IE_TC_MSK
-/* Transmission Cancellation Finished Enable*/
-#define CAN_MCAN_IE_TCF_POS  (8U)
-#define CAN_MCAN_IE_TCF_MSK  (0x1UL << CAN_MCAN_IE_TCF_POS)
-#define CAN_MCAN_IE_TCF	     CAN_MCAN_IE_TCF_MSK
-/* Tx FIFO Empty Enable */
-#define CAN_MCAN_IE_TFE_POS  (9U)
-#define CAN_MCAN_IE_TFE_MSK  (0x1UL << CAN_MCAN_IE_TFE_POS)
-#define CAN_MCAN_IE_TFE	     CAN_MCAN_IE_TFE_MSK
-/* Tx Event FIFO New Entry Enable */
-#define CAN_MCAN_IE_TEFN_POS (10U)
-#define CAN_MCAN_IE_TEFN_MSK (0x1UL << CAN_MCAN_IE_TEFN_POS)
-#define CAN_MCAN_IE_TEFN     CAN_MCAN_IE_TEFN_MSK
-/* Tx Event FIFO Full Enable */
-#define CAN_MCAN_IE_TEFF_POS (11U)
-#define CAN_MCAN_IE_TEFF_MSK (0x1UL << CAN_MCAN_IE_TEFF_POS)
-#define CAN_MCAN_IE_TEFF     CAN_MCAN_IE_TEFF_MSK
-/* Tx Event FIFO Element Lost Enable */
-#define CAN_MCAN_IE_TEFL_POS (12U)
-#define CAN_MCAN_IE_TEFL_MSK (0x1UL << CAN_MCAN_IE_TEFL_POS)
-#define CAN_MCAN_IE_TEFL     CAN_MCAN_IE_TEFL_MSK
-/* Timestamp Wraparound Enable */
-#define CAN_MCAN_IE_TSW_POS  (13U)
-#define CAN_MCAN_IE_TSW_MSK  (0x1UL << CAN_MCAN_IE_TSW_POS)
-#define CAN_MCAN_IE_TSW	     CAN_MCAN_IE_TSW_MSK
-/* Message RAM Access Failure Enable */
-#define CAN_MCAN_IE_MRAF_POS (14U)
-#define CAN_MCAN_IE_MRAF_MSK (0x1UL << CAN_MCAN_IE_MRAF_POS)
-#define CAN_MCAN_IE_MRAF     CAN_MCAN_IE_MRAF_MSK
-/* Timeout Occurred Enable */
-#define CAN_MCAN_IE_TOO_POS  (15U)
-#define CAN_MCAN_IE_TOO_MSK  (0x1UL << CAN_MCAN_IE_TOO_POS)
-#define CAN_MCAN_IE_TOO	     CAN_MCAN_IE_TOO_MSK
-/* Error Logging Overflow Enable */
-#define CAN_MCAN_IE_ELO_POS  (16U)
-#define CAN_MCAN_IE_ELO_MSK  (0x1UL << CAN_MCAN_IE_ELO_POS)
-#define CAN_MCAN_IE_ELO	     CAN_MCAN_IE_ELO_MSK
-/* Error Passive Enable */
-#define CAN_MCAN_IE_EP_POS   (17U)
-#define CAN_MCAN_IE_EP_MSK   (0x1UL << CAN_MCAN_IE_EP_POS)
-#define CAN_MCAN_IE_EP	     CAN_MCAN_IE_EP_MSK
-/* Warning Status Enable */
-#define CAN_MCAN_IE_EW_POS   (18U)
-#define CAN_MCAN_IE_EW_MSK   (0x1UL << CAN_MCAN_IE_EW_POS)
-#define CAN_MCAN_IE_EW	     CAN_MCAN_IE_EW_MSK
-/* Bus_Off Status Enable */
-#define CAN_MCAN_IE_BO_POS   (19U)
-#define CAN_MCAN_IE_BO_MSK   (0x1UL << CAN_MCAN_IE_BO_POS)
-#define CAN_MCAN_IE_BO	     CAN_MCAN_IE_BO_MSK
-/* Watchdog Interrupt Enable  */
-#define CAN_MCAN_IE_WDI_POS  (20U)
-#define CAN_MCAN_IE_WDI_MSK  (0x1UL << CAN_MCAN_IE_WDI_POS)
-#define CAN_MCAN_IE_WDI	     CAN_MCAN_IE_WDIE_MSK
-/* Protocol Error in Arbitration Phase Enable */
-#define CAN_MCAN_IE_PEA_POS  (21U)
-#define CAN_MCAN_IE_PEA_MSK  (0x1UL << CAN_MCAN_IE_PEA_POS)
-#define CAN_MCAN_IE_PEA	     CAN_MCAN_IE_PEA_MSK
-/* Protocol Error in Data Phase Enable */
-#define CAN_MCAN_IE_PED_POS  (22U)
-#define CAN_MCAN_IE_PED_MSK  (0x1UL << CAN_MCAN_IE_PED_POS)
-#define CAN_MCAN_IE_PED	     CAN_MCAN_IE_PED_MSK
-/* Access to Reserved Address Enable */
-#define CAN_MCAN_IE_ARA_POS  (23U)
-#define CAN_MCAN_IE_ARA_MSK  (0x1UL << CAN_MCAN_IE_ARA_POS)
-#define CAN_MCAN_IE_ARA	     CAN_MCAN_IE_ARA_MSK
-
+#define CAN_MCAN_IE_ARAE  BIT(23)
+#define CAN_MCAN_IE_PEDE  BIT(22)
+#define CAN_MCAN_IE_PEAE  BIT(21)
+#define CAN_MCAN_IE_WDIE  BIT(20)
+#define CAN_MCAN_IE_BOE	  BIT(19)
+#define CAN_MCAN_IE_EWE	  BIT(18)
+#define CAN_MCAN_IE_EPE	  BIT(17)
+#define CAN_MCAN_IE_ELOE  BIT(16)
+#define CAN_MCAN_IE_TOOE  BIT(15)
+#define CAN_MCAN_IE_MRAFE BIT(14)
+#define CAN_MCAN_IE_TSWE  BIT(13)
+#define CAN_MCAN_IE_TEFLE BIT(12)
+#define CAN_MCAN_IE_TEFFE BIT(11)
+#define CAN_MCAN_IE_TEFNE BIT(10)
+#define CAN_MCAN_IE_TFEE  BIT(9)
+#define CAN_MCAN_IE_TCFE  BIT(8)
+#define CAN_MCAN_IE_TCE	  BIT(7)
+#define CAN_MCAN_IE_HPME  BIT(6)
+#define CAN_MCAN_IE_RF1LE BIT(5)
+#define CAN_MCAN_IE_RF1FE BIT(4)
+#define CAN_MCAN_IE_RF1NE BIT(3)
+#define CAN_MCAN_IE_RF0LE BIT(2)
+#define CAN_MCAN_IE_RF0FE BIT(1)
+#define CAN_MCAN_IE_RF0NE BIT(0)
 #else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_IE_ARAE  BIT(29)
+#define CAN_MCAN_IE_PEDE  BIT(28)
+#define CAN_MCAN_IE_PEAE  BIT(27)
+#define CAN_MCAN_IE_WDIE  BIT(26)
+#define CAN_MCAN_IE_BOE	  BIT(25)
+#define CAN_MCAN_IE_EWE	  BIT(24)
+#define CAN_MCAN_IE_EPE	  BIT(23)
+#define CAN_MCAN_IE_ELOE  BIT(22)
+#define CAN_MCAN_IE_BEUE  BIT(21)
+#define CAN_MCAN_IE_BECE  BIT(20)
+#define CAN_MCAN_IE_DRXE  BIT(19)
+#define CAN_MCAN_IE_TOOE  BIT(18)
+#define CAN_MCAN_IE_MRAFE BIT(17)
+#define CAN_MCAN_IE_TSWE  BIT(16)
+#define CAN_MCAN_IE_TEFLE BIT(15)
+#define CAN_MCAN_IE_TEFFE BIT(14)
+#define CAN_MCAN_IE_TEFWE BIT(13)
+#define CAN_MCAN_IE_TEFNE BIT(12)
+#define CAN_MCAN_IE_TFEE  BIT(11)
+#define CAN_MCAN_IE_TCFE  BIT(10)
+#define CAN_MCAN_IE_TCE	  BIT(9)
+#define CAN_MCAN_IE_HPME  BIT(8)
+#define CAN_MCAN_IE_RF1LE BIT(7)
+#define CAN_MCAN_IE_RF1FE BIT(6)
+#define CAN_MCAN_IE_RF1WE BIT(5)
+#define CAN_MCAN_IE_RF1NE BIT(4)
+#define CAN_MCAN_IE_RF0LE BIT(3)
+#define CAN_MCAN_IE_RF0FE BIT(2)
+#define CAN_MCAN_IE_RF0WE BIT(1)
+#define CAN_MCAN_IE_RF0NE BIT(0)
+#endif /* !CONFIG_CAN_STM32FD */
 
-/* Rx FIFO 0 New Message */
-#define CAN_MCAN_IE_RF0N_POS (0U)
-#define CAN_MCAN_IE_RF0N_MSK (0x1UL << CAN_MCAN_IE_RF0N_POS)
-#define CAN_MCAN_IE_RF0N     CAN_MCAN_IE_RF0N_MSK
-/* Rx FIFO 0 Watermark Reached*/
-#define CAN_MCAN_IE_RF0W_POS (1U)
-#define CAN_MCAN_IE_RF0W_MSK (0x1UL << CAN_MCAN_IE_RF0W_POS)
-#define CAN_MCAN_IE_RF0W     CAN_MCAN_IE_RF0W_MSK
-/* Rx FIFO 0 Full */
-#define CAN_MCAN_IE_RF0F_POS (2U)
-#define CAN_MCAN_IE_RF0F_MSK (0x1UL << CAN_MCAN_IE_RF0F_POS)
-#define CAN_MCAN_IE_RF0F     CAN_MCAN_IE_RF0F_MSK
-/* Rx FIFO 0 Message Lost */
-#define CAN_MCAN_IE_RF0L_POS (3U)
-#define CAN_MCAN_IE_RF0L_MSK (0x1UL << CAN_MCAN_IE_RF0L_POS)
-#define CAN_MCAN_IE_RF0L     CAN_MCAN_IE_RF0L_MSK
-/* Rx FIFO 1 New Message */
-#define CAN_MCAN_IE_RF1N_POS (4U)
-#define CAN_MCAN_IE_RF1N_MSK (0x1UL << CAN_MCAN_IE_RF1N_POS)
-#define CAN_MCAN_IE_RF1N     CAN_MCAN_IE_RF1N_MSK
-/* Rx FIFO 1 Watermark Reached*/
-#define CAN_MCAN_IE_RF1W_POS (5U)
-#define CAN_MCAN_IE_RF1W_MSK (0x1UL << CAN_MCAN_IE_RF1W_POS)
-#define CAN_MCAN_IE_RF1W     CAN_MCAN_IE_RF1W_MSK
-/* Rx FIFO 1 Full */
-#define CAN_MCAN_IE_RF1F_POS (6U)
-#define CAN_MCAN_IE_RF1F_MSK (0x1UL << CAN_MCAN_IE_RF1F_POS)
-#define CAN_MCAN_IE_RF1F     CAN_MCAN_IE_RF1F_MSK
-/* Rx FIFO 1 Message Lost */
-#define CAN_MCAN_IE_RF1L_POS (7U)
-#define CAN_MCAN_IE_RF1L_MSK (0x1UL << CAN_MCAN_IE_RF1L_POS)
-#define CAN_MCAN_IE_RF1L     CAN_MCAN_IE_RF1L_MSK
-/* High Priority Message */
-#define CAN_MCAN_IE_HPM_POS  (8U)
-#define CAN_MCAN_IE_HPM_MSK  (0x1UL << CAN_MCAN_IE_HPM_POS)
-#define CAN_MCAN_IE_HPM	     CAN_MCAN_IE_HPM_MSK
-/* Transmission Completed */
-#define CAN_MCAN_IE_TC_POS   (9U)
-#define CAN_MCAN_IE_TC_MSK   (0x1UL << CAN_MCAN_IE_TC_POS)
-#define CAN_MCAN_IE_TC	     CAN_MCAN_IE_TC_MSK
-/* Transmission Cancellation Finished */
-#define CAN_MCAN_IE_TCF_POS  (10U)
-#define CAN_MCAN_IE_TCF_MSK  (0x1UL << CAN_MCAN_IE_TCF_POS)
-#define CAN_MCAN_IE_TCF	     CAN_MCAN_IE_TCF_MSK
-/* Tx FIFO Empty */
-#define CAN_MCAN_IE_TFE_POS  (11U)
-#define CAN_MCAN_IE_TFE_MSK  (0x1UL << CAN_MCAN_IE_TFE_POS)
-#define CAN_MCAN_IE_TFE	     CAN_MCAN_IE_TFE_MSK
-/* Tx Event FIFO New Entry */
-#define CAN_MCAN_IE_TEFN_POS (12U)
-#define CAN_MCAN_IE_TEFN_MSK (0x1UL << CAN_MCAN_IE_TEFN_POS)
-#define CAN_MCAN_IE_TEFN     CAN_MCAN_IE_TEFN_MSK
-/* Tx Event FIFO Watermark */
-#define CAN_MCAN_IE_TEFW_POS (13U)
-#define CAN_MCAN_IE_TEFW_MSK (0x1UL << CAN_MCAN_IE_TEFW_POS)
-#define CAN_MCAN_IE_TEFW     CAN_MCAN_IE_TEFW_MSK
-/* Tx Event FIFO Full */
-#define CAN_MCAN_IE_TEFF_POS (14U)
-#define CAN_MCAN_IE_TEFF_MSK (0x1UL << CAN_MCAN_IE_TEFF_POS)
-#define CAN_MCAN_IE_TEFF     CAN_MCAN_IE_TEFF_MSK
-/* Tx Event FIFO Element Lost */
-#define CAN_MCAN_IE_TEFL_POS (15U)
-#define CAN_MCAN_IE_TEFL_MSK (0x1UL << CAN_MCAN_IE_TEFL_POS)
-#define CAN_MCAN_IE_TEFL     CAN_MCAN_IE_TEFL_MSK
-/* Timestamp Wraparound */
-#define CAN_MCAN_IE_TSW_POS  (16U)
-#define CAN_MCAN_IE_TSW_MSK  (0x1UL << CAN_MCAN_IE_TSW_POS)
-#define CAN_MCAN_IE_TSW	     CAN_MCAN_IE_TSW_MSK
-/* Message RAM Access Failure */
-#define CAN_MCAN_IE_MRAF_POS (17U)
-#define CAN_MCAN_IE_MRAF_MSK (0x1UL << CAN_MCAN_IE_MRAF_POS)
-#define CAN_MCAN_IE_MRAF     CAN_MCAN_IE_MRAF_MSK
-/* Timeout Occurred */
-#define CAN_MCAN_IE_TOO_POS  (18U)
-#define CAN_MCAN_IE_TOO_MSK  (0x1UL << CAN_MCAN_IE_TOO_POS)
-#define CAN_MCAN_IE_TOO	     CAN_MCAN_IE_TOO_MSK
-/* Message stored to Dedicated Rx Buffer */
-#define CAN_MCAN_IE_DRX_POS  (19U)
-#define CAN_MCAN_IE_DRX_MSK  (0x1UL << CAN_MCAN_IE_DRX_POS)
-#define CAN_MCAN_IE_DRX	     CAN_MCAN_IE_DRX_MSK
-/* Bit Error Corrected */
-#define CAN_MCAN_IE_BEC_POS  (20U)
-#define CAN_MCAN_IE_BEC_MSK  (0x1UL << CAN_MCAN_IE_BEC_POS)
-#define CAN_MCAN_IE_BEC	     CAN_MCAN_IE_BEC_MSK
-/* Bit Error Uncorrected */
-#define CAN_MCAN_IE_BEU_POS  (21U)
-#define CAN_MCAN_IE_BEU_MSK  (0x1UL << CAN_MCAN_IE_BEU_POS)
-#define CAN_MCAN_IE_BEU	     CAN_MCAN_IE_BEU_MSK
-/* Error Logging Overflow */
-#define CAN_MCAN_IE_ELO_POS  (22U)
-#define CAN_MCAN_IE_ELO_MSK  (0x1UL << CAN_MCAN_IE_ELO_POS)
-#define CAN_MCAN_IE_ELO	     CAN_MCAN_IE_ELO_MSK
-/* Error Passive*/
-#define CAN_MCAN_IE_EP_POS   (23U)
-#define CAN_MCAN_IE_EP_MSK   (0x1UL << CAN_MCAN_IE_EP_POS)
-#define CAN_MCAN_IE_EP	     CAN_MCAN_IE_EP_MSK
-/* Warning Status*/
-#define CAN_MCAN_IE_EW_POS   (24U)
-#define CAN_MCAN_IE_EW_MSK   (0x1UL << CAN_MCAN_IE_EW_POS)
-#define CAN_MCAN_IE_EW	     CAN_MCAN_IE_EW_MSK
-/* Bus_Off Status*/
-#define CAN_MCAN_IE_BO_POS   (25U)
-#define CAN_MCAN_IE_BO_MSK   (0x1UL << CAN_MCAN_IE_BO_POS)
-#define CAN_MCAN_IE_BO	     CAN_MCAN_IE_BO_MSK
-/* Watchdog Interrupt */
-#define CAN_MCAN_IE_WDI_POS  (26U)
-#define CAN_MCAN_IE_WDI_MSK  (0x1UL << CAN_MCAN_IE_WDI_POS)
-#define CAN_MCAN_IE_WDI	     CAN_MCAN_IE_WDI_MSK
-/* Protocol Error in Arbitration Phase */
-#define CAN_MCAN_IE_PEA_POS  (27U)
-#define CAN_MCAN_IE_PEA_MSK  (0x1UL << CAN_MCAN_IE_PEA_POS)
-#define CAN_MCAN_IE_PEA	     CAN_MCAN_IE_PEA_MSK
-/* Protocol Error in Data Phase */
-#define CAN_MCAN_IE_PED_POS  (28U)
-#define CAN_MCAN_IE_PED_MSK  (0x1UL << CAN_MCAN_IE_PED_POS)
-#define CAN_MCAN_IE_PED	     CAN_MCAN_IE_PED_MSK
-/* Access to Reserved Address */
-#define CAN_MCAN_IE_ARA_POS  (29U)
-#define CAN_MCAN_IE_ARA_MSK  (0x1UL << CAN_MCAN_IE_ARA_POS)
-#define CAN_MCAN_IE_ARA	     CAN_MCAN_IE_ARA_MSK
-
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_ILS register  *******************/
+/* Interrupt Line Select register */
 #ifdef CONFIG_CAN_STM32FD
-/* Rx FIFO 0 */
-#define CAN_MCAN_ILS_RXFIFO0_POS (0U)
-#define CAN_MCAN_ILS_RXFIFO0_MSK (0x1UL << CAN_MCAN_ILS_RXFIFO0_POS)
-#define CAN_MCAN_ILS_RXFIFO0	 CAN_MCAN_ILS_RXFIFO0_MSK
-/* Rx FIFO 1 */
-#define CAN_MCAN_ILS_RXFIFO1_POS (1U)
-#define CAN_MCAN_ILS_RXFIFO1_MSK (0x1UL << CAN_MCAN_ILS_RXFIFO1_POS)
-#define CAN_MCAN_ILS_RXFIFO1	 CAN_MCAN_ILS_RXFIFO1_MSK
-/* Transmission Cancellation Finished */
-#define CAN_MCAN_ILS_SMSG_POS	 (2U)
-#define CAN_MCAN_ILS_SMSG_MSK	 (0x1UL << CAN_MCAN_ILS_SMSG_POS)
-#define CAN_MCAN_ILS_SMSG	 CAN_MCAN_ILS_SMSG_MSK
-/* Tx Event FIFO Element Lost */
-#define CAN_MCAN_ILS_TFERR_POS	 (3U)
-#define CAN_MCAN_ILS_TFERR_MSK	 (0x1UL << CAN_MCAN_ILS_TFERR_POS)
-#define CAN_MCAN_ILS_TFERR	 CAN_MCAN_ILS_TFERR_MSK
-/* Timeout Occurred */
-#define CAN_MCAN_ILS_MISC_POS	 (4U)
-#define CAN_MCAN_ILS_MISC_MSK	 (0x1UL << CAN_MCAN_ILS_MISC_POS)
-#define CAN_MCAN_ILS_MISC	 CAN_MCAN_ILS_MISC_MSK
-/* Error Passive Error Logging Overflow */
-#define CAN_MCAN_ILS_BERR_POS	 (5U)
-#define CAN_MCAN_ILS_BERR_MSK	 (0x1UL << CAN_MCAN_ILS_BERR_POS)
-#define CAN_MCAN_ILS_BERR	 CAN_MCAN_ILS_BERR_MSK
-/* Access to Reserved Address Line */
-#define CAN_MCAN_ILS_PERR_POS	 (6U)
-#define CAN_MCAN_ILS_PERR_MSK	 (0x1UL << CAN_MCAN_ILS_PERR_POS)
-#define CAN_MCAN_ILS_PERR	 CAN_MCAN_ILS_PERR_MSK
-
+#define CAN_MCAN_ILS_PERR    BIT(6)
+#define CAN_MCAN_ILS_BERR    BIT(5)
+#define CAN_MCAN_ILS_MISC    BIT(4)
+#define CAN_MCAN_ILS_TFERR   BIT(3)
+#define CAN_MCAN_ILS_SMSG    BIT(2)
+#define CAN_MCAN_ILS_RXFIFO1 BIT(1)
+#define CAN_MCAN_ILS_RXFIFO0 BIT(0)
 #else /* CONFIG_CAN_STM32FD */
-/* Rx FIFO 0 New Message */
-#define CAN_MCAN_ILS_RF0N_POS (0U)
-#define CAN_MCAN_ILS_RF0N_MSK (0x1UL << CAN_MCAN_ILS_RF0N_POS)
-#define CAN_MCAN_ILS_RF0N     CAN_MCAN_ILS_RF0N_MSK
-/* Rx FIFO 0 Watermark Reached*/
-#define CAN_MCAN_ILS_RF0W_POS (1U)
-#define CAN_MCAN_ILS_RF0W_MSK (0x1UL << CAN_MCAN_ILS_RF0W_POS)
-#define CAN_MCAN_ILS_RF0W     CAN_MCAN_ILS_RF0W_MSK
-/* Rx FIFO 0 Full */
-#define CAN_MCAN_ILS_RF0F_POS (2U)
-#define CAN_MCAN_ILS_RF0F_MSK (0x1UL << CAN_MCAN_ILS_RF0F_POS)
-#define CAN_MCAN_ILS_RF0F     CAN_MCAN_ILS_RF0F_MSK
-/* Rx FIFO 0 Message Lost */
-#define CAN_MCAN_ILS_RF0L_POS (3U)
-#define CAN_MCAN_ILS_RF0L_MSK (0x1UL << CAN_MCAN_ILS_RF0L_POS)
-#define CAN_MCAN_ILS_RF0L     CAN_MCAN_ILS_RF0L_MSK
-/* Rx FIFO 1 New Message */
-#define CAN_MCAN_ILS_RF1N_POS (4U)
-#define CAN_MCAN_ILS_RF1N_MSK (0x1UL << CAN_MCAN_ILS_RF1N_POS)
-#define CAN_MCAN_ILS_RF1N     CAN_MCAN_ILS_RF1N_MSK
-/* Rx FIFO 1 Watermark Reached*/
-#define CAN_MCAN_ILS_RF1W_POS (5U)
-#define CAN_MCAN_ILS_RF1W_MSK (0x1UL << CAN_MCAN_ILS_RF1W_POS)
-#define CAN_MCAN_ILS_RF1W     CAN_MCAN_ILS_RF1W_MSK
-/* Rx FIFO 1 Full */
-#define CAN_MCAN_ILS_RF1F_POS (6U)
-#define CAN_MCAN_ILS_RF1F_MSK (0x1UL << CAN_MCAN_ILS_RF1F_POS)
-#define CAN_MCAN_ILS_RF1F     CAN_MCAN_ILS_RF1F_MSK
-/* Rx FIFO 1 Message Lost */
-#define CAN_MCAN_ILS_RF1L_POS (7U)
-#define CAN_MCAN_ILS_RF1L_MSK (0x1UL << CAN_MCAN_ILS_RF1L_POS)
-#define CAN_MCAN_ILS_RF1L     CAN_MCAN_ILS_RF1L_MSK
-/* High Priority Message */
-#define CAN_MCAN_ILS_HPM_POS  (8U)
-#define CAN_MCAN_ILS_HPM_MSK  (0x1UL << CAN_MCAN_ILS_HPM_POS)
-#define CAN_MCAN_ILS_HPM      CAN_MCAN_ILS_HPM_MSK
-/* Transmission Completed */
-#define CAN_MCAN_ILS_TC_POS   (9U)
-#define CAN_MCAN_ILS_TC_MSK   (0x1UL << CAN_MCAN_ILS_TC_POS)
-#define CAN_MCAN_ILS_TC	      CAN_MCAN_ILS_TC_MSK
-/* Transmission Cancellation Finished */
-#define CAN_MCAN_ILS_TCF_POS  (10U)
-#define CAN_MCAN_ILS_TCF_MSK  (0x1UL << CAN_MCAN_ILS_TCF_POS)
-#define CAN_MCAN_ILS_TCF      CAN_MCAN_ILS_TCF_MSK
-/* Tx FIFO Empty */
-#define CAN_MCAN_ILS_TFE_POS  (11U)
-#define CAN_MCAN_ILS_TFE_MSK  (0x1UL << CAN_MCAN_ILS_TFE_POS)
-#define CAN_MCAN_ILS_TFE      CAN_MCAN_ILS_TFE_MSK
-/* Tx Event FIFO New Entry */
-#define CAN_MCAN_ILS_TEFN_POS (12U)
-#define CAN_MCAN_ILS_TEFN_MSK (0x1UL << CAN_MCAN_ILS_TEFN_POS)
-#define CAN_MCAN_ILS_TEFN     CAN_MCAN_ILS_TEFN_MSK
-/* Tx Event FIFO Watermark */
-#define CAN_MCAN_ILS_TEFW_POS (13U)
-#define CAN_MCAN_ILS_TEFW_MSK (0x1UL << CAN_MCAN_ILS_TEFW_POS)
-#define CAN_MCAN_ILS_TEFW     CAN_MCAN_ILS_TEFW_MSK
-/* Tx Event FIFO Full */
-#define CAN_MCAN_ILS_TEFF_POS (14U)
-#define CAN_MCAN_ILS_TEFF_MSK (0x1UL << CAN_MCAN_ILS_TEFF_POS)
-#define CAN_MCAN_ILS_TEFF     CAN_MCAN_ILS_TEFF_MSK
-/* Tx Event FIFO Element Lost */
-#define CAN_MCAN_ILS_TEFL_POS (15U)
-#define CAN_MCAN_ILS_TEFL_MSK (0x1UL << CAN_MCAN_ILS_TEFL_POS)
-#define CAN_MCAN_ILS_TEFL     CAN_MCAN_ILS_TEFL_MSK
-/* Timestamp Wraparound */
-#define CAN_MCAN_ILS_TSW_POS  (16U)
-#define CAN_MCAN_ILS_TSW_MSK  (0x1UL << CAN_MCAN_ILS_TSW_POS)
-#define CAN_MCAN_ILS_TSW      CAN_MCAN_ILS_TSW_MSK
-/* Message RAM Access Failure */
-#define CAN_MCAN_ILS_MRAF_POS (17U)
-#define CAN_MCAN_ILS_MRAF_MSK (0x1UL << CAN_MCAN_ILS_MRAF_POS)
-#define CAN_MCAN_ILS_MRAF     CAN_MCAN_ILS_MRAF_MSK
-/* Timeout Occurred */
-#define CAN_MCAN_ILS_TOO_POS  (18U)
-#define CAN_MCAN_ILS_TOO_MSK  (0x1UL << CAN_MCAN_ILS_TOO_POS)
-#define CAN_MCAN_ILS_TOO      CAN_MCAN_ILS_TOO_MSK
-/* Message stored to Dedicated Rx Buffer */
-#define CAN_MCAN_ILS_DRX_POS  (19U)
-#define CAN_MCAN_ILS_DRX_MSK  (0x1UL << CAN_MCAN_ILS_DRX_POS)
-#define CAN_MCAN_ILS_DRX      CAN_MCAN_ILS_DRX_MSK
-/* Bit Error Corrected */
-#define CAN_MCAN_ILS_BEC_POS  (20U)
-#define CAN_MCAN_ILS_BEC_MSK  (0x1UL << CAN_MCAN_ILS_BEC_POS)
-#define CAN_MCAN_ILS_BEC      CAN_MCAN_ILS_BEC_MSK
-/* Bit Error Uncorrected */
-#define CAN_MCAN_ILS_BEU_POS  (21U)
-#define CAN_MCAN_ILS_BEU_MSK  (0x1UL << CAN_MCAN_ILS_BEU_POS)
-#define CAN_MCAN_ILS_BEU      CAN_MCAN_ILS_BEU_MSK
-/* Error Logging Overflow */
-#define CAN_MCAN_ILS_ELO_POS  (22U)
-#define CAN_MCAN_ILS_ELO_MSK  (0x1UL << CAN_MCAN_ILS_ELO_POS)
-#define CAN_MCAN_ILS_ELO      CAN_MCAN_ILS_ELO_MSK
-/* Error Passive*/
-#define CAN_MCAN_ILS_EP_POS   (23U)
-#define CAN_MCAN_ILS_EP_MSK   (0x1UL << CAN_MCAN_ILS_EP_POS)
-#define CAN_MCAN_ILS_EP	      CAN_MCAN_ILS_EP_MSK
-/* Warning Status*/
-#define CAN_MCAN_ILS_EW_POS   (24U)
-#define CAN_MCAN_ILS_EW_MSK   (0x1UL << CAN_MCAN_ILS_EW_POS)
-#define CAN_MCAN_ILS_EW	      CAN_MCAN_ILS_EW_MSK
-/* Bus_Off Status*/
-#define CAN_MCAN_ILS_BO_POS   (25U)
-#define CAN_MCAN_ILS_BO_MSK   (0x1UL << CAN_MCAN_ILS_BO_POS)
-#define CAN_MCAN_ILS_BO	      CAN_MCAN_ILS_BO_MSK
-/* Watchdog Interrupt */
-#define CAN_MCAN_ILS_WDI_POS  (26U)
-#define CAN_MCAN_ILS_WDI_MSK  (0x1UL << CAN_MCAN_ILS_WDI_POS)
-#define CAN_MCAN_ILS_WDI      CAN_MCAN_ILS_WDI_MSK
-/* Protocol Error in Arbitration Phase */
-#define CAN_MCAN_ILS_PEA_POS  (27U)
-#define CAN_MCAN_ILS_PEA_MSK  (0x1UL << CAN_MCAN_ILS_PEA_POS)
-#define CAN_MCAN_ILS_PEA      CAN_MCAN_ILS_PEA_MSK
-/* Protocol Error in Data Phase */
-#define CAN_MCAN_ILS_PED_POS  (28U)
-#define CAN_MCAN_ILS_PED_MSK  (0x1UL << CAN_MCAN_ILS_PED_POS)
-#define CAN_MCAN_ILS_PED      CAN_MCAN_ILS_PED_MSK
-/* Access to Reserved Address */
-#define CAN_MCAN_ILS_ARA_POS  (29U)
-#define CAN_MCAN_ILS_ARA_MSK  (0x1UL << CAN_MCAN_ILS_ARA_POS)
-#define CAN_MCAN_ILS_ARA      CAN_MCAN_IL_ARA_MSK
+#define CAN_MCAN_ILS_ARAL  BIT(29)
+#define CAN_MCAN_ILS_PEDL  BIT(28)
+#define CAN_MCAN_ILS_PEAL  BIT(27)
+#define CAN_MCAN_ILS_WDIL  BIT(26)
+#define CAN_MCAN_ILS_BOL   BIT(25)
+#define CAN_MCAN_ILS_EWL   BIT(24)
+#define CAN_MCAN_ILS_EPL   BIT(23)
+#define CAN_MCAN_ILS_ELOL  BIT(22)
+#define CAN_MCAN_ILS_BEUL  BIT(21)
+#define CAN_MCAN_ILS_BECL  BIT(20)
+#define CAN_MCAN_ILS_DRXL  BIT(19)
+#define CAN_MCAN_ILS_TOOL  BIT(18)
+#define CAN_MCAN_ILS_MRAFL BIT(17)
+#define CAN_MCAN_ILS_TSWL  BIT(16)
+#define CAN_MCAN_ILS_TEFLL BIT(15)
+#define CAN_MCAN_ILS_TEFFL BIT(14)
+#define CAN_MCAN_ILS_TEFWL BIT(13)
+#define CAN_MCAN_ILS_TEFNL BIT(12)
+#define CAN_MCAN_ILS_TFEL  BIT(11)
+#define CAN_MCAN_ILS_TCFL  BIT(10)
+#define CAN_MCAN_ILS_TCL   BIT(9)
+#define CAN_MCAN_ILS_HPML  BIT(8)
+#define CAN_MCAN_ILS_RF1LL BIT(7)
+#define CAN_MCAN_ILS_RF1FL BIT(6)
+#define CAN_MCAN_ILS_RF1WL BIT(5)
+#define CAN_MCAN_ILS_RF1NL BIT(4)
+#define CAN_MCAN_ILS_RF0LL BIT(3)
+#define CAN_MCAN_ILS_RF0FL BIT(2)
+#define CAN_MCAN_ILS_RF0WL BIT(1)
+#define CAN_MCAN_ILS_RF0NL BIT(0)
+#endif /* !CONFIG_CAN_STM32FD */
 
-#endif /* CONFIG_CAN_STM32FD */
+/* Interrupt Line Enable register */
+#define CAN_MCAN_ILE_EINT1 BIT(1)
+#define CAN_MCAN_ILE_EINT0 BIT(0)
 
-/***************  Bit definition for CAN_MCAN_ILE register  *******************/
-/* Enable Interrupt Line 0 */
-#define CAN_MCAN_ILE_EINT0_POS (0U)
-#define CAN_MCAN_ILE_EINT0_MSK (0x1UL << CAN_MCAN_ILE_EINT0_POS)
-#define CAN_MCAN_ILE_EINT0     CAN_MCAN_ILE_EINT0_MSK
-/* Enable Interrupt Line 1 */
-#define CAN_MCAN_ILE_EINT1_POS (1U)
-#define CAN_MCAN_ILE_EINT1_MSK (0x1UL << CAN_MCAN_ILE_EINT1_POS)
-#define CAN_MCAN_ILE_EINT1     CAN_MCAN_ILE_EINT1_MSK
-
-/***************  Bit definition for CAN_MCAN_RXGFC register  *****************/
+/* Global filter configuration register */
 #ifdef CONFIG_CAN_STM32FD
-/* Reject Remote Frames Extended */
-#define CAN_MCAN_RXGFC_RRFE_POS (0U)
-#define CAN_MCAN_RXGFC_RRFE_MSK (0x1UL << CAN_MCAN_RXGFC_RRFE_POS)
-#define CAN_MCAN_RXGFC_RRFE	CAN_MCAN_RXGFC_RRFE_MSK
-/* Reject Remote Frames Standard */
-#define CAN_MCAN_RXGFC_RRFS_POS (1U)
-#define CAN_MCAN_RXGFC_RRFS_MSK (0x1UL << CAN_MCAN_RXGFC_RRFS_POS)
-#define CAN_MCAN_RXGFC_RRFS	CAN_MCAN_RXGFC_RRFS_MSK
-/* Accept Non-matching Frames Extended */
-#define CAN_MCAN_RXGFC_ANFE_POS (2U)
-#define CAN_MCAN_RXGFC_ANFE_MSK (0x3UL << CAN_MCAN_RXGFC_ANFE_POS)
-#define CAN_MCAN_RXGFC_ANFE	CAN_MCAN_RXGFC_ANFE_MSK
-/* Accept Non-matching Frames Standard */
-#define CAN_MCAN_RXGFC_ANFS_POS (4U)
-#define CAN_MCAN_RXGFC_ANFS_MSK (0x3UL << CAN_MCAN_RXGFC_ANFS_POS)
-#define CAN_MCAN_RXGFC_ANFS	CAN_MCAN_RXGFC_ANFS_MSK
-/* FIFO 1 operation mode */
-#define CAN_MCAN_RXGFC_F1OM_POS (8U)
-#define CAN_MCAN_RXGFC_F1OM_MSK (0x1UL << CAN_MCAN_RXGFC_F1OM_POS)
-#define CAN_MCAN_RXGFC_F1OM	CAN_MCAN_RXGFC_F1OM_MSK
-/* FIFO 0 operation mode */
-#define CAN_MCAN_RXGFC_F0OM_POS (9U)
-#define CAN_MCAN_RXGFC_F0OM_MSK (0x1UL << CAN_MCAN_RXGFC_F0OM_POS)
-#define CAN_MCAN_RXGFC_F0OM	CAN_MCAN_RXGFC_F0OM_MSK
-/* List Size Standard */
-#define CAN_MCAN_RXGFC_LSS_POS	(16U)
-#define CAN_MCAN_RXGFC_LSS_MSK	(0x1FUL << CAN_MCAN_RXGFC_LSS_POS)
-#define CAN_MCAN_RXGFC_LSS	CAN_MCAN_RXGFC_LSS_MSK
-/* List Size Extended */
-#define CAN_MCAN_RXGFC_LSE_POS	(24U)
-#define CAN_MCAN_RXGFC_LSE_MSK	(0xFUL << CAN_MCAN_RXGFC_LSE_POS)
-#define CAN_MCAN_RXGFC_LSE	CAN_MCAN_RXGFC_LSE_MSK
-
+#define CAN_MCAN_RXGFC_LSE  GENMASK(27, 24)
+#define CAN_MCAN_RXGFC_LSS  GENMASK(20, 16)
+#define CAN_MCAN_RXGFC_F0OM BIT(9)
+#define CAN_MCAN_RXGFC_F1OM BIT(8)
+#define CAN_MCAN_RXGFC_ANFS GENMASK(5, 4)
+#define CAN_MCAN_RXGFC_ANFE GENMASK(3, 2)
+#define CAN_MCAN_RXGFC_RRFS BIT(1)
+#define CAN_MCAN_RXGFC_RRFE BIT(0)
 #else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_GFC_ANFS GENMASK(5, 4)
+#define CAN_MCAN_GFC_ANFE GENMASK(3, 2)
+#define CAN_MCAN_GFC_RRFS BIT(1)
+#define CAN_MCAN_GFC_RRFE BIT(0)
+#endif /* !CONFIG_CAN_STM32FD */
 
-/* Reject Remote Frames Extended */
-#define CAN_MCAN_GFC_RRFE_POS	 (0U)
-#define CAN_MCAN_GFC_RRFE_MSK	 (0x1UL << CAN_MCAN_GFC_RRFE_POS)
-#define CAN_MCAN_GFC_RRFE	 CAN_MCAN_GFC_RRFE_MSK
-/* Reject Remote Frames Standard */
-#define CAN_MCAN_GFC_RRFS_POS	 (1U)
-#define CAN_MCAN_GFC_RRFS_MSK	 (0x1UL << CAN_MCAN_GFC_RRFS_POS)
-#define CAN_MCAN_GFC_RRFS	 CAN_MCAN_GFC_RRFS_MSK
-/* Accept Non-matching Frames Extended */
-#define CAN_MCAN_GFC_ANFE_POS	 (2U)
-#define CAN_MCAN_GFC_ANFE_MSK	 (0x3UL << CAN_MCAN_GFC_ANFE_POS)
-#define CAN_MCAN_GFC_ANFE	 CAN_MCAN_GFC_ANFE_MSK
-/* Accept Non-matching Frames Standard */
-#define CAN_MCAN_GFC_ANFS_POS	 (4U)
-#define CAN_MCAN_GFC_ANFS_MSK	 (0x3UL << CAN_MCAN_GFC_ANFS_POS)
-#define CAN_MCAN_GFC_ANFS	 CAN_MCAN_GFC_ANFS_MSK
+/* Standard ID Filter Configuration register */
+#ifndef CONFIG_CAN_STM32FD
+#define CAN_MCAN_SIDFC_LSS   GENMASK(23, 16)
+#define CAN_MCAN_SIDFC_FLSSA GENMASK(15, 2)
+#endif /* !CONFIG_CAN_STM32FD */
 
-/*  Filter List Standard Start Address */
-#define CAN_MCAN_SIDFC_FLSSA_POS (2U)
-#define CAN_MCAN_SIDFC_FLSSA_MSK (0x3FFFUL << CAN_MCAN_SIDFC_FLSSA_POS)
-#define CAN_MCAN_SIDFC_FLSSA	 CAN_MCAN_SIDFC_FLSSA_MSK
-/* List Size Standard */
-#define CAN_MCAN_SIDFC_LSS_POS	 (16U)
-#define CAN_MCAN_SIDFC_LSS_MSK	 (0xFFUL << CAN_MCAN_SIDFC_LSS_POS)
-#define CAN_MCAN_SIDFC_LSS	 CAN_MCAN_SIDFC_LSS_MSK
+/* Extended ID Filter Configuration register */
+#ifndef CONFIG_CAN_STM32FD
+#define CAN_MCAN_XIDFC_LSS   GENMASK(22, 16)
+#define CAN_MCAN_XIDFC_FLESA GENMASK(15, 2)
+#endif /* !CONFIG_CAN_STM32FD */
 
-/*  Filter List Extended Start Address */
-#define CAN_MCAN_XIDFC_FLESA_POS (2U)
-#define CAN_MCAN_XIDFC_FLESA_MSK (0x3FFFUL << CAN_MCAN_XIDFC_FLESA_POS)
-#define CAN_MCAN_XIDFC_FLESA	 CAN_MCAN_XIDFC_FLESA_MSK
-/* List Size Extended */
-#define CAN_MCAN_XIDFC_LSS_POS	 (16U)
-#define CAN_MCAN_XIDFC_LSS_MSK	 (0x7FUL << CAN_MCAN_XIDFC_LSS_POS)
-#define CAN_MCAN_XIDFC_LSS	 CAN_MCAN_XIDFC_LSS_MSK
+/* Extended ID AND Mask register */
+#define CAN_MCAN_XIDAM_EIDM GENMASK(28, 0)
 
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_XIDAM register  *****************/
-/* Extended ID Mask */
-#define CAN_MCAN_XIDAM_EIDM_POS (0U)
-#define CAN_MCAN_XIDAM_EIDM_MSK (0x1FFFFFFFUL << CAN_MCAN_XIDAM_EIDM_POS)
-#define CAN_MCAN_XIDAM_EIDM	CAN_MCAN_XIDAM_EIDM_MSK
-
-/***************  Bit definition for CAN_MCAN_HPMS register  ******************/
+/* HPMS register */
+#define CAN_MCAN_HPMS_FLST BIT(15)
 #ifdef CONFIG_CAN_STM32FD
-/* Buffer Index */
-#define CAN_MCAN_HPMS_BIDX_POS (0U)
-#define CAN_MCAN_HPMS_BIDX_MSK (0x7UL << CAN_MCAN_HPMS_BIDX_POS)
-#define CAN_MCAN_HPMS_BIDX     CAN_MCAN_HPMS_BIDX_MSK
-/* Message Storage Indicator */
-#define CAN_MCAN_HPMS_MSI_POS  (6U)
-#define CAN_MCAN_HPMS_MSI_MSK  (0x3UL << CAN_MCAN_HPMS_MSI_POS)
-#define CAN_MCAN_HPMS_MSI      CAN_MCAN_HPMS_MSI_MSK
-/* Filter Index */
-#define CAN_MCAN_HPMS_FIDX_POS (8U)
-#define CAN_MCAN_HPMS_FIDX_MSK (0x1FUL << CAN_MCAN_HPMS_FIDX_POS)
-#define CAN_MCAN_HPMS_FIDX     CAN_MCAN_HPMS_FIDX_MSK
-/* Filter List  */
-#define CAN_MCAN_HPMS_FLST_POS (15U)
-#define CAN_MCAN_HPMS_FLST_MSK (0x1UL << CAN_MCAN_HPMS_FLST_POS)
-#define CAN_MCAN_HPMS_FLST     CAN_MCAN_HPMS_FLST_MSK
-
+#define CAN_MCAN_HPMS_FIDX GENMASK(12, 8)
 #else /* CONFIG_CAN_STM32FD */
-
-/* Buffer Index */
-#define CAN_MCAN_HPMS_BIDX_POS (0U)
-#define CAN_MCAN_HPMS_BIDX_MSK (0x3FUL << CAN_MCAN_HPMS_BIDX_POS)
-#define CAN_MCAN_HPMS_BIDX     CAN_MCAN_HPMS_BIDX_MSK
-/* Message Storage Indicator */
-#define CAN_MCAN_HPMS_MSI_POS  (6U)
-#define CAN_MCAN_HPMS_MSI_MSK  (0x3UL << CAN_MCAN_HPMS_MSI_POS)
-#define CAN_MCAN_HPMS_MSI      CAN_MCAN_HPMS_MSI_MSK
-/* Filter Index */
-#define CAN_MCAN_HPMS_FIDX_POS (8U)
-#define CAN_MCAN_HPMS_FIDX_MSK (0x7FUL << CAN_MCAN_HPMS_FIDX_POS)
-#define CAN_MCAN_HPMS_FIDX     CAN_MCAN_HPMS_FIDX_MSK
-/* Filter List  */
-#define CAN_MCAN_HPMS_FLST_POS (15U)
-#define CAN_MCAN_HPMS_FLST_MSK (0x1UL << CAN_MCAN_HPMS_FLST_POS)
-#define CAN_MCAN_HPMS_FLST     CAN_MCAN_HPMS_FLST_MSK
-
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_RXF0C register  *****************/
-/* Rx FIFO 0 Start Address */
-#define CAN_MCAN_RXF0C_F0SA_POS (2U)
-#define CAN_MCAN_RXF0C_F0SA_MSK (0x3FFFUL << CAN_MCAN_RXF0C_F0SA_POS)
-#define CAN_MCAN_RXF0C_F0SA	CAN_MCAN_RXF0C_F0SA_MSK
-/* Rx FIFO 0 Size */
-#define CAN_MCAN_RXF0C_F0S_POS	(16U)
-#define CAN_MCAN_RXF0C_F0S_MSK	(0x7FUL << CAN_MCAN_RXF0C_F0S_POS)
-#define CAN_MCAN_RXF0C_F0S	CAN_MCAN_RXF0C_F0S_MSK
-/* Rx FIFO 0 Watermark */
-#define CAN_MCAN_RXF0C_F0WM_POS (24)
-#define CAN_MCAN_RXF0C_F0WM_MSK (0x7FUL << CAN_MCAN_RXF0C_F0WM_POS)
-#define CAN_MCAN_RXF0C_F0WM	CAN_MCAN_RXF0C_F0WM_MSK
-/* FIFO 0 Operation Mode */
-#define CAN_MCAN_RXF0C_F0OM_POS (31)
-#define CAN_MCAN_RXF0C_F0OM_MSK (0x1UL << CAN_MCAN_RXF0C_F0OM_POS)
-#define CAN_MCAN_RXF0C_F0OM	CAN_MCAN_RXF0C_F0OM_MSK
-
-/***************  Bit definition for CAN_MCAN_RXF0S register  *****************/
+#define CAN_MCAN_HPMS_FIDX GENMASK(14, 8)
+#endif /* !CONFIG_CAN_STM32FD */
+#define CAN_MCAN_HPMS_MSI GENMASK(7, 6)
 #ifdef CONFIG_CAN_STM32FD
-/* Rx FIFO 0 Fill Level */
-#define CAN_MCAN_RXF0S_F0FL_POS (0U)
-#define CAN_MCAN_RXF0S_F0FL_MSK (0xFUL << CAN_MCAN_RXF0S_F0FL_POS)
-#define CAN_MCAN_RXF0S_F0FL	CAN_MCAN_RXF0S_F0FL_MSK
-/* Rx FIFO 0 Get Index */
-#define CAN_MCAN_RXF0S_F0GI_POS (8U)
-#define CAN_MCAN_RXF0S_F0GI_MSK (0x3UL << CAN_MCAN_RXF0S_F0GI_POS)
-#define CAN_MCAN_RXF0S_F0GI	CAN_MCAN_RXF0S_F0GI_MSK
-/* Rx FIFO 0 Put Index */
-#define CAN_MCAN_RXF0S_F0PI_POS (16U)
-#define CAN_MCAN_RXF0S_F0PI_MSK (0x3UL << CAN_MCAN_RXF0S_F0PI_POS)
-#define CAN_MCAN_RXF0S_F0PI	CAN_MCAN_RXF0S_F0PI_MSK
-/* Rx FIFO 0 Full */
-#define CAN_MCAN_RXF0S_F0F_POS	(24U)
-#define CAN_MCAN_RXF0S_F0F_MSK	(0x1UL << CAN_MCAN_RXF0S_F0F_POS)
-#define CAN_MCAN_RXF0S_F0F	CAN_MCAN_RXF0S_F0F_MSK
-/* Rx FIFO 0 Message Lost */
-#define CAN_MCAN_RXF0S_RF0L_POS (25U)
-#define CAN_MCAN_RXF0S_RF0L_MSK (0x1UL << CAN_MCAN_RXF0S_RF0L_POS)
-#define CAN_MCAN_RXF0S_RF0L	CAN_MCAN_RXF0S_RF0L_MSK
-
+#define CAN_MCAN_HPMS_BIDX GENMASK(2, 0)
 #else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_HPMS_BIDX GENMASK(5, 0)
+#endif /* !CONFIG_CAN_STM32FD */
 
-/* Rx FIFO 0 Fill Level */
-#define CAN_MCAN_RXF0S_F0FL_POS (0U)
-#define CAN_MCAN_RXF0S_F0FL_MSK (0x7FUL << CAN_MCAN_RXF0S_F0FL_POS)
-#define CAN_MCAN_RXF0S_F0FL	CAN_MCAN_RXF0S_F0FL_MSK
-/* Rx FIFO 0 Get Index */
-#define CAN_MCAN_RXF0S_F0GI_POS (8U)
-#define CAN_MCAN_RXF0S_F0GI_MSK (0x3FUL << CAN_MCAN_RXF0S_F0GI_POS)
-#define CAN_MCAN_RXF0S_F0GI	CAN_MCAN_RXF0S_F0GI_MSK
-/* Rx FIFO 0 Put Index */
-#define CAN_MCAN_RXF0S_F0PI_POS (16U)
-#define CAN_MCAN_RXF0S_F0PI_MSK (0x3FUL << CAN_MCAN_RXF0S_F0PI_POS)
-#define CAN_MCAN_RXF0S_F0PI	CAN_MCAN_RXF0S_F0PI_MSK
-/* Rx FIFO 0 Full */
-#define CAN_MCAN_RXF0S_F0F_POS	(24U)
-#define CAN_MCAN_RXF0S_F0F_MSK	(0x1UL << CAN_MCAN_RXF0S_F0F_POS)
-#define CAN_MCAN_RXF0S_F0F	CAN_MCAN_RXF0S_F0F_MSK
-/* Rx FIFO 0 Message Lost */
-#define CAN_MCAN_RXF0S_RF0L_POS (25U)
-#define CAN_MCAN_RXF0S_RF0L_MSK (0x1UL << CAN_MCAN_RXF0S_RF0L_POS)
-#define CAN_MCAN_RXF0S_RF0L	CAN_MCAN_RXF0S_RF0L_MSK
-#endif
+/* New Data 1 register */
+#ifndef CONFIG_CAN_STM32FD
+#define CAN_MCAN_NDAT1_ND GENMASK(31, 0)
+#endif /* !CONFIG_CAN_STM32FD */
 
-/***************  Bit definition for CAN_MCAN_RXF0A register  *****************/
+/* New Data 2 register */
+#ifndef CONFIG_CAN_STM32FD
+#define CAN_MCAN_NDAT2_ND GENMASK(31, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Rx FIFO 0 Configuration register */
+#ifndef CONFIG_CAN_STM32FD
+#define CAN_MCAN_RXF0C_F0OM BIT(31)
+#define CAN_MCAN_RXF0C_F0WM GENMASK(30, 24)
+#define CAN_MCAN_RXF0C_F0S  GENMASK(22, 16)
+#define CAN_MCAN_RXF0C_F0SA GENMASK(15, 2)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Rx FIFO 0 Status register */
+#define CAN_MCAN_RXF0S_RF0L BIT(25)
+#define CAN_MCAN_RXF0S_F0F  BIT(24)
 #ifdef CONFIG_CAN_STM32FD
-/* Rx FIFO 0 Acknowledge Index */
-#define CAN_MCAN_RXF0A_F0AI_POS (0U)
-#define CAN_MCAN_RXF0A_F0AI_MSK (0x7UL << CAN_MCAN_RXF0A_F0AI_POS)
-#define CAN_MCAN_RXF0A_F0AI	CAN_MCAN_RXF0A_F0AI_MSK
-#else
-/* Rx FIFO 0 Acknowledge Index */
-#define CAN_MCAN_RXF0A_F0AI_POS (0U)
-#define CAN_MCAN_RXF0A_F0AI_MSK (0x3FUL << CAN_MCAN_RXF0A_F0AI_POS)
-#define CAN_MCAN_RXF0A_F0AI	CAN_MCAN_RXF0A_F0AI_MSK
-
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_RXBC register  ******************/
-/*  Rx Buffer Start Address */
-#define CAN_MCAN_RXBC_RBSA_POS (2U)
-#define CAN_MCAN_RXBC_RBSA_MSK (0x3FFFUL << CAN_MCAN_RXBC_RBSA_POS)
-#define CAN_MCAN_RXBC_RBSA     CAN_MCAN_RXBC_RBSA_MSK
-
-/***************  Bit definition for CAN_MCAN_RXF1C register  *****************/
-/* Rx FIFO 0 Start Address */
-#define CAN_MCAN_RXF1C_F1SA_POS (2U)
-#define CAN_MCAN_RXF1C_F1SA_MSK (0x3FFFUL << CAN_MCAN_RXF1C_F1SA_POS)
-#define CAN_MCAN_RXF1C_F1SA	CAN_MCAN_RXF1C_F1SA_MSK
-/* Rx FIFO 0 Size */
-#define CAN_MCAN_RXF1C_F1S_POS	(16U)
-#define CAN_MCAN_RXF1C_F1S_MSK	(0x7FUL << CAN_MCAN_RXF1C_F1S_POS)
-#define CAN_MCAN_RXF1C_F1S	CAN_MCAN_RXF1C_F1S_MSK
-/* Rx FIFO 0 Watermark */
-#define CAN_MCAN_RXF1C_F1WM_POS (24)
-#define CAN_MCAN_RXF1C_F1WM_MSK (0x7FUL << CAN_MCAN_RXF1C_F1WM_POS)
-#define CAN_MCAN_RXF1C_F1WM	CAN_MCAN_RXF1C_F1WM_MSK
-/* FIFO 0 Operation Mode */
-#define CAN_MCAN_RXF1C_F1OM_POS (31)
-#define CAN_MCAN_RXF1C_F1OM_MSK (0x1UL << CAN_MCAN_RXF1C_F1OM_POS)
-#define CAN_MCAN_RXF1C_F1OM	CAN_MCAN_RXF1C_F1OM_MSK
-
-/***************  Bit definition for CAN_MCAN_RXF1S register  *****************/
-#ifdef CONFIG_CAN_STM32FD
-/* Rx FIFO 1 Fill Level */
-#define CAN_MCAN_RXF1S_F1FL_POS (0U)
-#define CAN_MCAN_RXF1S_F1FL_MSK (0xFUL << CAN_MCAN_RXF1S_F1FL_POS)
-#define CAN_MCAN_RXF1S_F1FL	CAN_MCAN_RXF1S_F1FL_MSK
-/* Rx FIFO 1 Get Index */
-#define CAN_MCAN_RXF1S_F1GI_POS (8U)
-#define CAN_MCAN_RXF1S_F1GI_MSK (0x3UL << CAN_MCAN_RXF1S_F1GI_POS)
-#define CAN_MCAN_RXF1S_F1GI	CAN_MCAN_RXF1S_F1GI_MSK
-/* Rx FIFO 1 Put Index */
-#define CAN_MCAN_RXF1S_F1PI_POS (16U)
-#define CAN_MCAN_RXF1S_F1PI_MSK (0x3UL << CAN_MCAN_RXF1S_F1PI_POS)
-#define CAN_MCAN_RXF1S_F1PI	CAN_MCAN_RXF1S_F1PI_MSK
-/* Rx FIFO 1 Full */
-#define CAN_MCAN_RXF1S_F1F_POS	(24U)
-#define CAN_MCAN_RXF1S_F1F_MSK	(0x1UL << CAN_MCAN_RXF1S_F1F_POS)
-#define CAN_MCAN_RXF1S_F1F	CAN_MCAN_RXF1S_F1F_MSK
-/* Rx FIFO 1 Message Lost */
-#define CAN_MCAN_RXF1S_RF1L_POS (25U)
-#define CAN_MCAN_RXF1S_RF1L_MSK (0x1UL << CAN_MCAN_RXF1S_RF1L_POS)
-#define CAN_MCAN_RXF1S_RF1L	CAN_MCAN_RXF1S_RF1L_MSK
-
+#define CAN_MCAN_RXF0S_F0PI GENMASK(17, 16)
+#define CAN_MCAN_RXF0S_F0GI GENMASK(9, 8)
+#define CAN_MCAN_RXF0S_F0FL GENMASK(3, 0)
 #else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_RXF0S_F0PI GENMASK(21, 16)
+#define CAN_MCAN_RXF0S_F0GI GENMASK(13, 8)
+#define CAN_MCAN_RXF0S_F0FL GENMASK(6, 0)
+#endif /* !CONFIG_CAN_STM32FD */
 
-/* Rx FIFO 1 Fill Level */
-#define CAN_MCAN_RXF1S_F1FL_POS (0U)
-#define CAN_MCAN_RXF1S_F1FL_MSK (0x7FUL << CAN_MCAN_RXF1S_F1FL_POS)
-#define CAN_MCAN_RXF1S_F1FL	CAN_MCAN_RXF1S_F1FL_MSK
-/* Rx FIFO 1 Get Index */
-#define CAN_MCAN_RXF1S_F1GI_POS (8U)
-#define CAN_MCAN_RXF1S_F1GI_MSK (0x3FUL << CAN_MCAN_RXF1S_F1GI_POS)
-#define CAN_MCAN_RXF1S_F1GI	CAN_MCAN_RXF1S_F1GI_MSK
-/* Rx FIFO 1 Put Index */
-#define CAN_MCAN_RXF1S_F1PI_POS (16U)
-#define CAN_MCAN_RXF1S_F1PI_MSK (0x3FUL << CAN_MCAN_RXF1S_F1PI_POS)
-#define CAN_MCAN_RXF1S_F1PI	CAN_MCAN_RXF1S_F1PI_MSK
-/* Rx FIFO 1 Full */
-#define CAN_MCAN_RXF1S_F1F_POS	(24U)
-#define CAN_MCAN_RXF1S_F1F_MSK	(0x1UL << CAN_MCAN_RXF1S_F1F_POS)
-#define CAN_MCAN_RXF1S_F1F	CAN_MCAN_RXF1S_F1F_MSK
-/* Rx FIFO 1 Message Lost */
-#define CAN_MCAN_RXF1S_RF1L_POS (25U)
-#define CAN_MCAN_RXF1S_RF1L_MSK (0x1UL << CAN_MCAN_RXF1S_RF1L_POS)
-#define CAN_MCAN_RXF1S_RF1L	CAN_MCAN_RXF1S_RF1L_MSK
-
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_RXF1A register  *****************/
-/* Rx FIFO 1 Acknowledge Index */
+/* Rx FIFO 0 Acknowledge register */
 #ifdef CONFIG_CAN_STM32FD
-#define CAN_MCAN_RXF1A_F1AI_POS (0U)
-#define CAN_MCAN_RXF1A_F1AI_MSK (0x7UL << CAN_MCAN_RXF1A_F1AI_POS)
-#define CAN_MCAN_RXF1A_F1AI	CAN_MCAN_RXF1A_F1AI_MSK
-#else
-#define CAN_MCAN_RXF1A_F1AI_POS (0U)
-#define CAN_MCAN_RXF1A_F1AI_MSK (0x3FUL << CAN_MCAN_RXF1A_F1AI_POS)
-#define CAN_MCAN_RXF1A_F1AI	CAN_MCAN_RXF1A_F1AI_MSK
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_RXESC register  *****************/
-/* Rx FIFO 0 Data Field Size */
-#define CAN_MCAN_RXESC_F0DS_POS (0U)
-#define CAN_MCAN_RXESC_F0DS_MSK (0x7UL << CAN_MCAN_RXESC_F0DS_POS)
-#define CAN_MCAN_RXESC_F0DS	CAN_MCAN_RXESC_F0DS_MSK
-/* Rx FIFO 1 Data Field Size */
-#define CAN_MCAN_RXESC_F1DS_POS (4U)
-#define CAN_MCAN_RXESC_F1DS_MSK (0x7UL << CAN_MCAN_RXESC_F1DS_POS)
-#define CAN_MCAN_RXESC_F1DS	CAN_MCAN_RXESC_F1DS_MSK
-/* Receive Buffer Data Field Size */
-#define CAN_MCAN_RXESC_RBDS_POS (8U)
-#define CAN_MCAN_RXESC_RBDS_MSK (0x7UL << CAN_MCAN_RXESC_RBDS_POS)
-#define CAN_MCAN_RXESC_RBDS	CAN_MCAN_RXESC_RBDS_MSK
-
-/***************  Bit definition for CAN_MCAN_TXBC register  ******************/
-#ifdef CONFIG_CAN_STM32FD
-/* Tx FIFO/Queue Mode */
-#define CAN_MCAN_TXBC_TFQM_POS (24U)
-#define CAN_MCAN_TXBC_TFQM_MSK (0x1UL << CAN_MCAN_TXBC_TFQM_POS)
-#define CAN_MCAN_TXBC_TFQM     CAN_MCAN_TXBC_TFQM_MSK
-#else
-/* Tx Buffers Start Address */
-#define CAN_MCAN_TXBC_TBSA_POS (2U)
-#define CAN_MCAN_TXBC_TBSA_MSK (0x3FFFUL << CAN_MCAN_TXBC_TBSA_POS)
-#define CAN_MCAN_TXBC_TBSA     CAN_MCAN_TXBC_TBSA_MSK
-/* Number of Dedicated Transmit Buffers */
-#define CAN_MCAN_TXBC_NDTB_POS (16U)
-#define CAN_MCAN_TXBC_NDTB_MSK (0x3FUL << CAN_MCAN_TXBC_NDTB_POS)
-#define CAN_MCAN_TXBC_NDTB     CAN_MCAN_TXBC_NDTB_MSK
-/* Transmit FIFO/Queue Size */
-#define CAN_MCAN_TXBC_TFQS_POS (24U)
-#define CAN_MCAN_TXBC_TFQS_MSK (0x3FUL << CAN_MCAN_TXBC_TFQS_POS)
-#define CAN_MCAN_TXBC_TFQS     CAN_MCAN_TXBC_TFQS_MSK
-/* Tx FIFO/Queue Mode */
-#define CAN_MCAN_TXBC_TFQM_POS (30U)
-#define CAN_MCAN_TXBC_TFQM_MSK (0x3FUL << CAN_MCAN_TXBC_TFQM_POS)
-#define CAN_MCAN_TXBC_TFQM     CAN_MCAN_TXBC_TFQM_MSK
-
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_TXFQS register  *****************/
-#ifdef CONFIG_CAN_STM32FD
-/* Tx FIFO Free Level */
-#define CAN_MCAN_TXFQS_TFFL_POS	 (0U)
-#define CAN_MCAN_TXFQS_TFFL_MSK	 (0x7UL << CAN_MCAN_TXFQS_TFFL_POS)
-#define CAN_MCAN_TXFQS_TFFL	 CAN_MCAN_TXFQS_TFFL_MSK
-/* Tx FIFO Get Index */
-#define CAN_MCAN_TXFQS_TFGI_POS	 (8U)
-#define CAN_MCAN_TXFQS_TFGI_MSK	 (0x3UL << CAN_MCAN_TXFQS_TFGI_POS)
-#define CAN_MCAN_TXFQS_TFGI	 CAN_MCAN_TXFQS_TFGI_MSK
-/* Tx FIFO/Queue Put Index */
-#define CAN_MCAN_TXFQS_TFQPI_POS (16U)
-#define CAN_MCAN_TXFQS_TFQPI_MSK (0x3UL << CAN_MCAN_TXFQS_TFQPI_POS)
-#define CAN_MCAN_TXFQS_TFQPI	 CAN_MCAN_TXFQS_TFQPI_MSK
-/* Tx FIFO/Queue Full */
-#define CAN_MCAN_TXFQS_TFQF_POS	 (21U)
-#define CAN_MCAN_TXFQS_TFQF_MSK	 (0x1UL << CAN_MCAN_TXFQS_TFQF_POS)
-#define CAN_MCAN_TXFQS_TFQF	 CAN_MCAN_TXFQS_TFQF_MSK
-
+#define CAN_MCAN_RXF0A_F0AI GENMASK(2, 0)
 #else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_RXF0A_F0AI GENMASK(5, 0)
+#endif /* !CONFIG_CAN_STM32FD */
 
-/* Tx FIFO Free Level */
-#define CAN_MCAN_TXFQS_TFFL_POS	 (0U)
-#define CAN_MCAN_TXFQS_TFFL_MSK	 (0x3FUL << CAN_MCAN_TXFQS_TFFL_POS)
-#define CAN_MCAN_TXFQS_TFFL	 CAN_MCAN_TXFQS_TFFL_MSK
-/* Tx FIFO Get Index */
-#define CAN_MCAN_TXFQS_TFGI_POS	 (8U)
-#define CAN_MCAN_TXFQS_TFGI_MSK	 (0x1FUL << CAN_MCAN_TXFQS_TFGI_POS)
-#define CAN_MCAN_TXFQS_TFGI	 CAN_MCAN_TXFQS_TFGI_MSK
-/* Tx FIFO/Queue Put Index */
-#define CAN_MCAN_TXFQS_TFQPI_POS (16U)
-#define CAN_MCAN_TXFQS_TFQPI_MSK (0x1FUL << CAN_MCAN_TXFQS_TFQPI_POS)
-#define CAN_MCAN_TXFQS_TFQPI	 CAN_MCAN_TXFQS_TFQPI_MSK
-/* Tx FIFO/Queue Full */
-#define CAN_MCAN_TXFQS_TFQF_POS	 (21U)
-#define CAN_MCAN_TXFQS_TFQF_MSK	 (0x1UL << CAN_MCAN_TXFQS_TFQF_POS)
-#define CAN_MCAN_TXFQS_TFQF	 CAN_MCAN_TXFQS_TFQF_MSK
+/* Rx Buffer Configuration register */
+#ifndef CONFIG_CAN_STM32FD
+#define CAN_MCAN_RXBC_RBSA GENMASK(15, 2)
+#endif /* !CONFIG_CAN_STM32FD */
 
-#endif /* CONFIG_CAN_STM32FD */
+/* Rx FIFO 1 Configuration register */
+#ifndef CONFIG_CAN_STM32FD
+#define CAN_MCAN_RXF1C_F1OM BIT(31)
+#define CAN_MCAN_RXF1C_F1WM GENMASK(30, 24)
+#define CAN_MCAN_RXF1C_F1S  GENMASK(22, 16)
+#define CAN_MCAN_RXF1C_F1SA GENMASK(15, 2)
+#endif /* !CONFIG_CAN_STM32FD */
 
-/***************  Bit definition for CAN_MCAN_TXESC register  *****************/
-/* Tx Buffer Data Field Size */
-#define CAN_MCAN_TXESC_TBDS_POS (0U)
-#define CAN_MCAN_TXESC_TBDS_MSK (0x7UL << CAN_MCAN_TXESC_TBDS_POS)
-#define CAN_MCAN_TXESC_TBDS	CAN_MCAN_TXESC_TBDS_MSK
-
-/***************  Bit definition for CAN_MCAN_TXBRP register  *****************/
+/* Rx FIFO 1 Status register */
+#define CAN_MCAN_RXF1S_RF1L BIT(25)
+#define CAN_MCAN_RXF1S_F1F  BIT(24)
 #ifdef CONFIG_CAN_STM32FD
-/* Transmission Request Pending */
-#define CAN_MCAN_TXBRP_TRP_POS (0U)
-#define CAN_MCAN_TXBRP_TRP_MSK (0x7UL << CAN_MCAN_TXBRP_TRP_POS)
-#define CAN_MCAN_TXBRP_TRP     CAN_MCAN_TXBRP_TRP_MSK
-#else
-/* Transmission Request Pending */
-#define CAN_MCAN_TXBRP_TRP_POS (0U)
-#define CAN_MCAN_TXBRP_TRP_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBRP_TRP_POS)
-#define CAN_MCAN_TXBRP_TRP     CAN_MCAN_TXBRP_TRP_MSK
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_TXBAR register  *****************/
-#ifdef CONFIG_CAN_STM32FD
-/* Add Request */
-#define CAN_MCAN_TXBAR_AR_POS (0U)
-#define CAN_MCAN_TXBAR_AR_MSK (0x7UL << CAN_MCAN_TXBAR_AR_POS)
-#define CAN_MCAN_TXBAR_AR     CAN_MCAN_TXBAR_AR_MSK
-#else
-/* Add Request */
-#define CAN_MCAN_TXBAR_AR_POS (0U)
-#define CAN_MCAN_TXBAR_AR_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBAR_AR_POS)
-#define CAN_MCAN_TXBAR_AR     CAN_MCAN_TXBAR_AR_MSK
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_TXBCR register  *****************/
-#ifdef CONFIG_CAN_STM32FD
-/* Cancellation Request */
-#define CAN_MCAN_TXBCR_CR_POS (0U)
-#define CAN_MCAN_TXBCR_CR_MSK (0x7UL << CAN_MCAN_TXBCR_CR_POS)
-#define CAN_MCAN_TXBCR_CR     CAN_MCAN_TXBCR_CR_MSK
-#else
-/* Cancellation Request */
-#define CAN_MCAN_TXBCR_CR_POS (0U)
-#define CAN_MCAN_TXBCR_CR_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBCR_CR_POS)
-#define CAN_MCAN_TXBCR_CR     CAN_MCAN_TXBCR_CR_MSK
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_TXBTO register  *****************/
-#ifdef CONFIG_CAN_STM32FD
-/* Transmission Occurred */
-#define CAN_MCAN_TXBTO_TO_POS (0U)
-#define CAN_MCAN_TXBTO_TO_MSK (0x7UL << CAN_MCAN_TXBTO_TO_POS)
-#define CAN_MCAN_TXBTO_TO     CAN_MCAN_TXBTO_TO_MSK
-#else
-/* Transmission Occurred */
-#define CAN_MCAN_TXBTO_TO_POS (0U)
-#define CAN_MCAN_TXBTO_TO_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBTO_TO_POS)
-#define CAN_MCAN_TXBTO_TO     CAN_MCAN_TXBTO_TO_MSK
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_TXBCF register  *****************/
-#ifdef CONFIG_CAN_STM32FD
-/* Cancellation Finished */
-#define CAN_MCAN_TXBCF_CF_POS (0U)
-#define CAN_MCAN_TXBCF_CF_MSK (0x7UL << CAN_MCAN_TXBCF_CF_POS)
-#define CAN_MCAN_TXBCF_CF     CAN_MCAN_TXBCF_CF_MSK
-#else
-/* Cancellation Finished */
-#define CAN_MCAN_TXBCF_CF_POS (0U)
-#define CAN_MCAN_TXBCF_CF_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBCF_CF_POS)
-#define CAN_MCAN_TXBCF_CF     CAN_MCAN_TXBCF_CF_MSK
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_TXBTIE register  ****************/
-#ifdef CONFIG_CAN_STM32FD
-/* Transmission Interrupt Enable */
-#define CAN_MCAN_TXBTIE_TIE_POS (0U)
-#define CAN_MCAN_TXBTIE_TIE_MSK (0x7UL << CAN_MCAN_TXBTIE_TIE_POS)
-#define CAN_MCAN_TXBTIE_TIE	CAN_MCAN_TXBTIE_TIE_MSK
-#else
-/* Transmission Interrupt Enable */
-#define CAN_MCAN_TXBTIE_TIE_POS (0U)
-#define CAN_MCAN_TXBTIE_TIE_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBTIE_TIE_POS)
-#define CAN_MCAN_TXBTIE_TIE	CAN_MCAN_TXBTIE_TIE_MSK
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_ TXBCIE register  ***************/
-#ifdef CONFIG_CAN_STM32FD
-/* Cancellation Finished Interrupt Enable */
-#define CAN_MCAN_TXBCIE_CFIE_POS (0U)
-#define CAN_MCAN_TXBCIE_CFIE_MSK (0x7UL << CAN_MCAN_TXBCIE_CFIE_POS)
-#define CAN_MCAN_TXBCIE_CFIE	 CAN_MCAN_TXBCIE_CFIE_MSK
-#else
-/* Cancellation Finished Interrupt Enable */
-#define CAN_MCAN_TXBCIE_CFIE_POS (0U)
-#define CAN_MCAN_TXBCIE_CFIE_MSK (0xFFFFFFFFUL << CAN_MCAN_TXBCIE_CFIE_POS)
-#define CAN_MCAN_TXBCIE_CFIE	 CAN_MCAN_TXBCIE_CFIE_MSK
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_TXEFC register  *****************/
-/* Event FIFO Watermark */
-#define CAN_MCAN_TXEFC_EFSA_POS (2U)
-#define CAN_MCAN_TXEFC_EFSA_MSK (0x3FFFUL << CAN_MCAN_TXEFC_EFSA_POS)
-#define CAN_MCAN_TXEFC_EFSA	CAN_MCAN_TXEFC_EFSA_MSK
-/* Event FIFO Size */
-#define CAN_MCAN_TXEFC_EFS_POS	(16U)
-#define CAN_MCAN_TXEFC_EFS_MSK	(0x3FUL << CAN_MCAN_TXEFC_EFS_POS)
-#define CAN_MCAN_TXEFC_EFS	CAN_MCAN_TXEFC_EFS_MSK
-/* Event FIFO Start Address */
-#define CAN_MCAN_TXEFC_EFWM_POS (24U)
-#define CAN_MCAN_TXEFC_EFWM_MSK (0x3FUL << CAN_MCAN_TXEFC_EFWM_POS)
-#define CAN_MCAN_TXEFC_EFWM	CAN_MCAN_TXEFC_EFWM_POS
-
-/***************  Bit definition for CAN_MCAN_TXEFS register  *****************/
-#ifdef CONFIG_CAN_STM32FD
-/* Event FIFO Fill Level */
-#define CAN_MCAN_TXEFS_EFFL_POS (0U)
-#define CAN_MCAN_TXEFS_EFFL_MSK (0x7UL << CAN_MCAN_TXEFS_EFFL_POS)
-#define CAN_MCAN_TXEFS_EFFL	CAN_MCAN_TXEFS_EFFL_MSK
-/* Event FIFO Get Index */
-#define CAN_MCAN_TXEFS_EFGI_POS (8U)
-#define CAN_MCAN_TXEFS_EFGI_MSK (0x3UL << CAN_MCAN_TXEFS_EFGI_POS)
-#define CAN_MCAN_TXEFS_EFGI	CAN_MCAN_TXEFS_EFGI_MSK
-/* Event FIFO Put Index */
-#define CAN_MCAN_TXEFS_EFPI_POS (16U)
-#define CAN_MCAN_TXEFS_EFPI_MSK (0x3UL << CAN_MCAN_TXEFS_EFPI_POS)
-#define CAN_MCAN_TXEFS_EFPI	CAN_MCAN_TXEFS_EFPI_MSK
-/* Event FIFO Full */
-#define CAN_MCAN_TXEFS_EFF_POS	(24U)
-#define CAN_MCAN_TXEFS_EFF_MSK	(0x1UL << CAN_MCAN_TXEFS_EFF_POS)
-#define CAN_MCAN_TXEFS_EFF	CAN_MCAN_TXEFS_EFF_MSK
-/* Tx Event FIFO Element Lost */
-#define CAN_MCAN_TXEFS_TEFL_POS (25U)
-#define CAN_MCAN_TXEFS_TEFL_MSK (0x1UL << CAN_MCAN_TXEFS_TEFL_POS)
-#define CAN_MCAN_TXEFS_TEFL	CAN_MCAN_TXEFS_TEFL_MSK
-
+#define CAN_MCAN_RXF1S_F1PI GENMASK(17, 16)
+#define CAN_MCAN_RXF1S_F1GI GENMASK(9, 8)
+#define CAN_MCAN_RXF1S_F1FL GENMASK(3, 0)
 #else /* CONFIG_CAN_STM32FD */
-/* Event FIFO Fill Level */
-#define CAN_MCAN_TXEFS_EFFL_POS (0U)
-#define CAN_MCAN_TXEFS_EFFL_MSK (0x3FUL << CAN_MCAN_TXEFS_EFFL_POS)
-#define CAN_MCAN_TXEFS_EFFL	CAN_MCAN_TXEFS_EFFL_MSK
-/* Event FIFO Get Index */
-#define CAN_MCAN_TXEFS_EFGI_POS (8U)
-#define CAN_MCAN_TXEFS_EFGI_MSK (0x1FUL << CAN_MCAN_TXEFS_EFGI_POS)
-#define CAN_MCAN_TXEFS_EFGI	CAN_MCAN_TXEFS_EFGI_MSK
-#define CAN_MCAN_TXEFS_EFPI_POS (16U)
-/* Event FIFO Put Index */
-#define CAN_MCAN_TXEFS_EFPI_MSK (0x1FUL << CAN_MCAN_TXEFS_EFPI_POS)
-#define CAN_MCAN_TXEFS_EFPI	CAN_MCAN_TXEFS_EFPI_MSK
-/* Event FIFO Full */
-#define CAN_MCAN_TXEFS_EFF_POS	(24U)
-#define CAN_MCAN_TXEFS_EFF_MSK	(0x1UL << CAN_MCAN_TXEFS_EFF_POS)
-#define CAN_MCAN_TXEFS_EFF	CAN_MCAN_TXEFS_EFF_MSK
-/* Tx Event FIFO Element Lost */
-#define CAN_MCAN_TXEFS_TEFL_POS (25U)
-#define CAN_MCAN_TXEFS_TEFL_MSK (0x1UL << CAN_MCAN_TXEFS_TEFL_POS)
-#define CAN_MCAN_TXEFS_TEFL	CAN_MCAN_TXEFS_TEFL_MSK
+#define CAN_MCAN_RXF1S_F1PI GENMASK(21, 16)
+#define CAN_MCAN_RXF1S_F1GI GENMASK(13, 8)
+#define CAN_MCAN_RXF1S_F1FL GENMASK(6, 0)
+#endif /* !CONFIG_CAN_STM32FD */
 
-#endif /* CONFIG_CAN_STM32FD */
-
-/***************  Bit definition for CAN_MCAN_TXEFA register  *****************/
+/* Rx FIFO 1 Acknowledge register */
 #ifdef CONFIG_CAN_STM32FD
-/* Event FIFO Acknowledge Index */
-#define CAN_MCAN_TXEFA_EFAI_POS (0U)
-#define CAN_MCAN_TXEFA_EFAI_MSK (0x3UL << CAN_MCAN_TXEFA_EFAI_POS)
-#define CAN_MCAN_TXEFA_EFAI	CAN_MCAN_TXEFA_EFAI_MSK
-#else
-/* Event FIFO Acknowledge Index */
-#define CAN_MCAN_TXEFA_EFAI_POS (0U)
-#define CAN_MCAN_TXEFA_EFAI_MSK (0x1FUL << CAN_MCAN_TXEFA_EFAI_POS)
-#define CAN_MCAN_TXEFA_EFAI	CAN_MCAN_TXEFA_EFAI_MSK
-#endif /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_RXF1A_F1AI GENMASK(2, 0)
+#else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_RXF1A_F1AI GENMASK(5, 0)
+#endif /* !CONFIG_CAN_STM32FD */
 
-/***************  Bit definition for CAN_MCAN_MRBA register  *****************/
+/* Rx Buffer/FIFO Element Size Configuration register */
+#ifndef CONFIG_CAN_STM32FD
+#define CAN_MCAN_RXESC_RBDS GENMASK(10, 8)
+#define CAN_MCAN_RXESC_F1DS GENMASK(6, 4)
+#define CAN_MCAN_RXESC_F0DS GENMASK(2, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx Buffer Configuration register */
+#ifdef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXBC_TFQM BIT(24)
+#else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_TXBC_TFQM BIT(30)
+#define CAN_MCAN_TXBC_TFQS GENMASK(29, 24)
+#define CAN_MCAN_TXBC_NDTB GENMASK(21, 16)
+#define CAN_MCAN_TXBC_TBSA GENMASK(15, 2)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx FIFO/Queue Status register */
+#define CAN_MCAN_TXFQS_TFQF BIT(21)
+#ifdef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXFQS_TFQPI GENMASK(17, 16)
+#define CAN_MCAN_TXFQS_TFGI  GENMASK(9, 8)
+#define CAN_MCAN_TXFQS_TFFL  GENMASK(2, 0)
+#else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_TXFQS_TFQPI GENMASK(20, 16)
+#define CAN_MCAN_TXFQS_TFGI  GENMASK(12, 8)
+#define CAN_MCAN_TXFQS_TFFL  GENMASK(5, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx Buffer Element Size Configuration register */
+#ifndef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXESC_TBDS GENMASK(2, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx Buffer Request Pending register */
+#ifdef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXBRP_TRP GENMASK(2, 0)
+#else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_TXBRP_TRP GENMASK(31, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx Buffer Add Request register */
+#ifdef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXBAR_AR GENMASK(2, 0)
+#else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_TXBAR_AR GENMASK(31, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx Buffer Cancellation Request register */
+#ifdef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXBCR_CR GENMASK(2, 0)
+#else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_TXBCR_CR GENMASK(31, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx Buffer Transmission Occurred register */
+#ifdef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXBTO_TO GENMASK(2, 0)
+#else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_TXBTO_TO GENMASK(31, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx Buffer Cancellation Finished register */
+#ifdef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXBCF_CF GENMASK(2, 0)
+#else /* CONFIG_CAN_STM32FD*/
+#define CAN_MCAN_TXBCF_CF GENMASK(31, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx Buffer Transmission Interrupt Enable register */
+#ifdef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXBTIE_TIE GENMASK(2, 0)
+#else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_TXBTIE_TIE GENMASK(31, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx Buffer Cancellation Finished Interrupt Enable register */
+#ifdef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXBCIE_CFIE GENMASK(2, 0)
+#else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_TXBCIE_CFIE GENMASK(31, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx Event FIFO Configuration register */
+#ifndef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXEFC_EFWM GENMASK(29, 24)
+#define CAN_MCAN_TXEFC_EFS  GENMASK(21, 16)
+#define CAN_MCAN_TXEFC_EFSA GENMASK(15, 2)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx Event FIFO Status register */
+#define CAN_MCAN_TXEFS_TEFL BIT(25)
+#define CAN_MCAN_TXEFS_EFF  BIT(24)
+#ifdef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXEFS_EFPI GENMASK(17, 16)
+#define CAN_MCAN_TXEFS_EFGI GENMASK(9, 8)
+#define CAN_MCAN_TXEFS_EFFL GENMASK(2, 0)
+#else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_TXEFS_EFPI GENMASK(20, 16)
+#define CAN_MCAN_TXEFS_EFGI GENMASK(12, 8)
+#define CAN_MCAN_TXEFS_EFFL GENMASK(5, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Tx Event FIFO Acknowledge register */
+#ifdef CONFIG_CAN_STM32FD
+#define CAN_MCAN_TXEFA_EFAI GENMASK(1, 0)
+#else /* CONFIG_CAN_STM32FD */
+#define CAN_MCAN_TXEFA_EFAI GENMASK(4, 0)
+#endif /* !CONFIG_CAN_STM32FD */
+
+/* Message RAM Base Address register */
 #ifdef CONFIG_CAN_MCUX_MCAN
-/* Event FIFO Acknowledge Index */
-#define CAN_MCAN_MRBA_BA_POS (16U)
-#define CAN_MCAN_MRBA_BA_MSK (0xFFFFUL << CAN_MCAN_MRBA_BA_POS)
-#define CAN_MCAN_MRBA_BA     CAN_MCAN_MRBA_BA_MSK
+#define CAN_MCAN_MRBA_BA     GENMASK(31, 16)
 #endif /* CONFIG_CAN_MCUX_MCAN */
 
 #ifdef CONFIG_CAN_STM32FD


### PR DESCRIPTION
This PR includes a number of clean-ups to the existing Bosch M_CAN driver backend code. The rationale is making the code more readable and easier maintainable along with preparing it for further refactoring:
- Reformat source files using clang-format prior to refactoring the driver code.
- Pass a pointer to the struct device for internal driver functions instead of passing around a pointer to the register struct.
- Use the `can_mcan_*` namespace for all driver-internal functions to improve code readability.
- Move the driver initialization function to the bottom of the file to be consistent with Zephyr conventions.
- Get rid of the `can_mcan_configure_timing()` helper function as it provides no benefit to just having the implementation split in `can_mcan_set_timing()` and `can_mcan_set_timing_data()`.
- Rename the local `const struct can_mcan_config *` variables from `cfg` to `config` to be consistent with Zephyr conventions.
- Use consistent comments for `#ifdef ... #else ... #endif` statements to improve code readability.
- Remove unused includes and sort the remaining includes alphabetically.
- Use the `FIELD_PREP()` and `FIELD_GET()` macros instead of manual bitshifts and masking.
- Be consistent in the use of register field definition macros.
- Use `uintptr_t` for doing pointer mathematics.
- Regenerate/rewrite the Bosch M_CAN register field definitions using the `GENMASK()` and `BIT()` macros.

The changes are best reviewed commit-by-commit. No functional changes should be introduced in any of these commits. 

The changes were verified on the following boards:
- `lpcxpresso55s16`
- `lpcxpresso55s36`
- `nucleo_g474re`

The above covers the following driver front-ends:
- `drivers/can/can_mcux_mcan.c`
- `drivers/can/can_stm32fd.c`

The following driver front-ends were only compile-tested:
- `drivers/can/can_sam.c`
- `drivers/can/can_stm32h7.c`
