### PR TITLE
drivers: spi_flash_at45: Fix erasing of first two sectors

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -394,6 +394,8 @@ Drivers and Sensors
   * flash_simulator: A memory region can now be used as the storage area for the
     flash simulator. Using the memory region allows the flash simulator to keep
     its contents over a device reboot.
+  * spi_flash_at45: Fixed erase procedure to properly handle chips that have
+    their initial sector split into two parts (usually marked as 0a and 0b).
 
 * FPGA
 

--- a/dts/bindings/mtd/atmel,at45.yaml
+++ b/dts/bindings/mtd/atmel,at45.yaml
@@ -23,6 +23,18 @@ properties:
     required: true
     description: Flash sector size in bytes.
 
+  sector-0a-pages:
+    type: int
+    default: 8
+    description: |
+      Most available AT45 flash chips have their first two sectors shorter
+      than the consecutive ones. Usually, the first sector is marked as 0a
+      and has its size equal to eight pages (one block) and the second one
+      (usually 0b) is the complement to the size of a regular sector.
+      This property allows specifying the size (in pages) of that first sector
+      and defaults to the commonly used value of eight pages.
+      Value of zero means that the flash chip has all sectors of equal size.
+
   block-size:
     type: int
     required: true
@@ -32,6 +44,16 @@ properties:
     type: int
     required: true
     description: Flash page size in bytes.
+
+  no-chip-erase:
+    type: boolean
+    description: |
+      If set, indicates that the chip does not support the chip erase command.
+
+  no-sector-erase:
+    type: boolean
+    description: |
+      If set, indicates that the chip does not support the sector erase command.
 
   use-udpd:
     type: boolean


### PR DESCRIPTION
Most available AT45 flash chips have their first two sectors shorter than the consecutive ones. Usually, the first sector is marked as 0a and has its size equal to eight pages (one block) and the second one (usually 0b) is the complement to the size of a regular sector. This commits modifies the driver so that erasing of these first two sectors is performed correctly. This modified behavior is configurable with a new DT property so that it is still possible to also use legacy AT45 chips that do not feature such sector split. Such legacy chips usually also do not support the chip erase and sector erase commands, so two more DT properties are introduced to cover that.

Fixes #56416.