### PR TITLE
Bluetooth: BAP: Shell: Fix NULL pointer dereference

### DIFF
--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -493,7 +493,7 @@ static int cmd_bap_scan_delegator_term_pa(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	err = pa_sync_term(NULL);
+	err = pa_sync_term(state);
 	if (err != 0) {
 		shell_error(ctx_shell, "Failed to terminate PA sync: %d", err);
 


### PR DESCRIPTION
Make sure 'state' is valid.