### PR TITLE
net: add openthread config for mbedtls debug

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -157,6 +157,12 @@ config MBEDTLS_PROMPTLESS
 	bool
 	default y if !CUSTOM_OPENTHREAD_SECURITY
 
+config OPENTHREAD_MBEDTLS_DEBUG
+	bool "Enable mbedtls logs"
+	select MBEDTLS
+	select MBEDTLS_DEBUG
+	select MBEDTLS_DEBUG_C
+
 choice OPENTHREAD_SECURITY
 	prompt "OpenThread security"
 	default OPENTHREAD_MBEDTLS_CHOICE


### PR DESCRIPTION
Adds config that makes it possible to enable mbedtls debug configs with openthread.
Currently it's impossible to select MBEDTLS_DEBUG if not using CUSTOM_OPENTHREAD_SECURITY.