### PR TITLE
drivers: timer: use PRE_KERNEL_1

### DIFF
--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -32,12 +32,12 @@ config SYSTEM_CLOCK_SLOPPY_IDLE
 
 config SYSTEM_CLOCK_INIT_PRIORITY
 	int "System clock driver initialization priority"
-	default 0
+	default 99
 	help
 	  This options can be used to set a specific initialization priority
 	  value for the system clock driver. As driver initialization  might need
 	  the clock to be running already, you should let the default value as it
-	  is (0).
+	  is.
 
 # Hidden option to be selected by individual SoC.
 config TICKLESS_CAPABLE

--- a/drivers/timer/altera_avalon_timer_hal.c
+++ b/drivers/timer/altera_avalon_timer_hal.c
@@ -90,5 +90,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -245,5 +245,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -203,5 +203,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -446,5 +446,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -216,5 +216,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/cc13x2_cc26x2_rtc_timer.c
+++ b/drivers/timer/cc13x2_cc26x2_rtc_timer.c
@@ -251,5 +251,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -281,5 +281,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/esp32c3_sys_timer.c
+++ b/drivers/timer/esp32c3_sys_timer.c
@@ -155,5 +155,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/gecko_burtc_timer.c
+++ b/drivers/timer/gecko_burtc_timer.c
@@ -233,5 +233,5 @@ static int burtc_init(void)
 	return 0;
 }
 
-SYS_INIT(burtc_init, PRE_KERNEL_2,
+SYS_INIT(burtc_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -463,5 +463,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -225,5 +225,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -454,5 +454,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -129,5 +129,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/litex_timer.c
+++ b/drivers/timer/litex_timer.c
@@ -95,5 +95,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -444,5 +444,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mcux_gpt_timer.c
+++ b/drivers/timer/mcux_gpt_timer.c
@@ -246,5 +246,5 @@ int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -124,5 +124,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -138,5 +138,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -129,5 +129,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -137,5 +137,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -388,5 +388,5 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -728,5 +728,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/rcar_cmt_timer.c
+++ b/drivers/timer/rcar_cmt_timer.c
@@ -157,5 +157,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -241,5 +241,5 @@ void smp_timer_init(void)
 }
 #endif
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/rv32m1_lptmr_timer.c
+++ b/drivers/timer/rv32m1_lptmr_timer.c
@@ -148,5 +148,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -328,5 +328,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -468,5 +468,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -202,5 +202,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -129,5 +129,5 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
 	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);


### PR DESCRIPTION
Move all timer drivers to PRE_KERNEL_1, and set init level to 99, which is roughly equivalent to PRE_KERNEL_2 + 0 (to keep existing behavior).

According to the docs,

> `PRE_KERNEL_2`: Used for devices that rely on the initialization of
  devices initialized as part of the `PRE_KERNEL_1` level.

Which is not the case for timer drivers, unless I missed a particular case.