### PR TITLE
soc: xtensa: intel_adsp: fix build error for cavs

### DIFF
--- a/soc/xtensa/intel_adsp/cavs/power.c
+++ b/soc/xtensa/intel_adsp/cavs/power.c
@@ -12,6 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/pm/pm.h>
 #include <zephyr/device.h>
+#include <zephyr/cache.h>
 #include <cpu_init.h>
 
 #include <adsp_shim.h>


### PR DESCRIPTION
Build of Intel cAVS2.5 platforms fails due to undefined reference sys_cache_data_flush_and_invd_all(). Fix this by adding missing header include to bring in the inline definition for this function.

Fixes: 6388f5f106ac ("xtensa: use sys_cache API instead of custom interfaces")