### PR TITLE
scripts: runners: nrf: Fix the formatting of the old --nrf-family

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -31,6 +31,8 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
                  tool_opt=[], force=False, recover=False):
         super().__init__(cfg)
         self.hex_ = cfg.hex_file
+        if family and not family.endswith('_FAMILY'):
+            family = f'{family}_FAMILY'
         self.family = family
         self.softreset = softreset
         self.dev_id = dev_id


### PR DESCRIPTION
The now legacy --nrf-family parameter takes the "raw" family name as nrfjprog accepts it. But now we use an intermediate representation with {FAMILY}_FAMILY as the format, so covert to it as required.