### PR TITLE
drivers: ethernet: eth_mcux: fix double-promotion warnings

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1737,20 +1737,20 @@ static int ptp_clock_mcux_rate_adjust(const struct device *dev, double ratio)
 	ratio *= context->clk_ratio;
 
 	/* Limit possible ratio. */
-	if ((ratio > 1.0f + 1.0f/(2 * hw_inc)) ||
-			(ratio < 1.0f - 1.0f/(2 * hw_inc))) {
+	if ((ratio > 1.0 + 1.0/(2 * hw_inc)) ||
+			(ratio < 1.0 - 1.0/(2 * hw_inc))) {
 		return -EINVAL;
 	}
 
 	/* Save new ratio. */
 	context->clk_ratio = ratio;
 
-	if (ratio < 1.0f) {
+	if (ratio < 1.0) {
 		corr = hw_inc - 1;
-		val = 1.0f / (hw_inc * (1.0f - ratio));
-	} else if (ratio > 1.0f) {
+		val = 1.0 / (hw_inc * (1.0 - ratio));
+	} else if (ratio > 1.0) {
 		corr = hw_inc + 1;
-		val = 1.0f / (hw_inc * (ratio - 1.0f));
+		val = 1.0 / (hw_inc * (ratio - 1.0));
 	} else {
 		val = 0;
 		corr = hw_inc;


### PR DESCRIPTION
Some single-precision float constants were being compared against double-precision floats. Make the constants doubles.