### PR TITLE
drivers: pcie_ep: iproc: enable based on device tree specs

### DIFF
--- a/drivers/pcie/endpoint/pcie_ep_iproc.c
+++ b/drivers/pcie/endpoint/pcie_ep_iproc.c
@@ -469,7 +469,7 @@ err_out:
 
 static struct iproc_pcie_ep_ctx iproc_pcie_ep_ctx_0;
 
-static struct iproc_pcie_ep_config iproc_pcie_ep_config_0 = {
+static const struct iproc_pcie_ep_config iproc_pcie_ep_config_0 = {
 	.id = 0,
 	.base = (struct iproc_pcie_reg *)DT_INST_REG_ADDR(0),
 	.reg_size = DT_INST_REG_SIZE(0),
@@ -484,7 +484,7 @@ static struct iproc_pcie_ep_config iproc_pcie_ep_config_0 = {
 #endif
 };
 
-static struct pcie_ep_driver_api iproc_pcie_ep_api = {
+static const struct pcie_ep_driver_api iproc_pcie_ep_api = {
 	.conf_read = iproc_pcie_conf_read,
 	.conf_write = iproc_pcie_conf_write,
 	.map_addr = iproc_pcie_map_addr,

--- a/drivers/pcie/endpoint/pcie_ep_iproc.c
+++ b/drivers/pcie/endpoint/pcie_ep_iproc.c
@@ -477,9 +477,11 @@ static struct iproc_pcie_ep_config iproc_pcie_ep_config_0 = {
 	.map_low_size = DT_INST_REG_SIZE_BY_NAME(0, map_lowmem),
 	.map_high_base = DT_INST_REG_ADDR_BY_NAME(0, map_highmem),
 	.map_high_size = DT_INST_REG_SIZE_BY_NAME(0, map_highmem),
+#if DT_INST_NODE_HAS_PROP(0, dmas)
 	.pl330_dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_IDX(0, 0)),
 	.pl330_tx_chan_id = DT_INST_DMAS_CELL_BY_NAME(0, txdma, channel),
 	.pl330_rx_chan_id = DT_INST_DMAS_CELL_BY_NAME(0, rxdma, channel),
+#endif
 };
 
 static struct pcie_ep_driver_api iproc_pcie_ep_api = {
@@ -489,7 +491,9 @@ static struct pcie_ep_driver_api iproc_pcie_ep_api = {
 	.unmap_addr = iproc_pcie_unmap_addr,
 	.raise_irq = iproc_pcie_raise_irq,
 	.register_reset_cb = iproc_pcie_register_reset_cb,
+#if DT_INST_NODE_HAS_PROP(0, dmas)
 	.dma_xfer = iproc_pcie_pl330_dma_xfer,
+#endif
 };
 
 DEVICE_DT_INST_DEFINE(0, &iproc_pcie_ep_init, NULL,


### PR DESCRIPTION
There are use cases for the pcie_ep driver where we don't necessarily need the dma functionality. Added ifdef's around the dma functionality so that it's only available if we specify the dma engines in the device tree similar to
```
dmas = <&pl330 0>, <&pl330 1>;
dma-names = "txdma", "rxdma";
```

Also 
* ensure `config` and `api` structures are `const`

Fixes #57210
cc @tarun292