### PR TITLE
boards: arm: atsame54_xpro: Add I2C MAC chip

### DIFF
--- a/boards/arm/atsame54_xpro/Kconfig.defconfig
+++ b/boards/arm/atsame54_xpro/Kconfig.defconfig
@@ -8,6 +8,22 @@ if BOARD_ATSAME54_XPRO
 config BOARD
 	default "atsame54_xpro"
 
+if ETH_SAM_GMAC
+
+# Read MAC address from AT24MAC402 EEPROM
+
+config ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS
+	default 0x9A
+
+config ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS_SIZE
+	default 1
+
+config ETH_SAM_GMAC_MAC_I2C_EEPROM
+	default y
+	select I2C
+
+endif # ETH_SAM_GMAC
+
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -96,6 +96,11 @@
 
 	pinctrl-0 = <&sercom7_i2c_default>;
 	pinctrl-names = "default";
+
+	eeprom: eeprom@5e {
+		compatible = "atmel,24mac402";
+		reg = <0x5e>;
+	};
 };
 
 &adc0 {
@@ -111,10 +116,11 @@ zephyr_udc0: &usb0 {
 
 &gmac {
 	status = "okay";
-	zephyr,random-mac-address;
 
 	pinctrl-0 = <&gmac_rmii>;
 	pinctrl-names = "default";
+
+	mac-eeprom = <&eeprom>;
 
 	phy: phy {
 		compatible = "ethernet-phy";


### PR DESCRIPTION
The atsame54_xpro has an AT24MAC402 MAC chip on SERCOM7 at I2C address 0x5E, but it is not used by default. Fix this by copying from the sam_e70_xplained and changing the I2C address to match the strapping pins on the atsame54_xpro. Tested with the dhcpv4_client sample project to confirm that the MAC address is no longer randomly generated.