### PR TITLE
drivers: regulator: fixed: refactor init code

### DIFF
--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -224,6 +224,21 @@ void regulator_common_data_init(const struct device *dev);
  */
 int regulator_common_init(const struct device *dev, bool is_enabled);
 
+/**
+ * @brief Check if regulator is expected to be enabled at init time.
+ *
+ * @param dev Regulator device instance
+ * @return true If regulator needs to be enabled at init time.
+ * @return false If regulator does not need to be enabled at init time.
+ */
+static inline bool regulator_common_is_init_enabled(const struct device *dev)
+{
+	const struct regulator_common_config *config =
+		(const struct regulator_common_config *)dev->config;
+
+	return (config->flags & REGULATOR_INIT_ENABLED) != 0U;
+}
+
 /** @endcond */
 
 /**

--- a/tests/drivers/regulator/api/src/main.c
+++ b/tests/drivers/regulator/api/src/main.c
@@ -93,6 +93,14 @@ ZTEST(regulator_api, test_common_config)
 	zassert_equal(config->allowed_modes_cnt, 2U);
 }
 
+ZTEST(regulator_api, test_common_is_init_enabled)
+{
+	zassert_false(regulator_common_is_init_enabled(reg0));
+	zassert_true(regulator_common_is_init_enabled(reg1));
+	zassert_true(regulator_common_is_init_enabled(reg2));
+	zassert_false(regulator_common_is_init_enabled(reg3));
+}
+
 ZTEST(regulator_api, test_enable_disable)
 {
 	RESET_FAKE(regulator_fake_enable);


### PR DESCRIPTION
In some cases, the enable pin may be already enabled by a previous stage, e.g. bootloader. Therefore, it is not desirable to disable the pin, as it could cause malfunctioning of the device. Refactor init procedure so that we pick the right GPIO flags during the first configuration stage.

Fixes #57312