### PR TITLE
coredump: memory window backend

### DIFF
--- a/subsys/debug/coredump/CMakeLists.txt
+++ b/subsys/debug/coredump/CMakeLists.txt
@@ -23,6 +23,11 @@ zephyr_library_sources_ifdef(
   coredump_backend_flash_partition.c
   )
 
+zephyr_library_sources_ifdef(
+  CONFIG_DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW
+  coredump_backend_intel_adsp_mem_window.c
+  )
+
   # @Intent: Set XTENSA_TOOLCHAIN_VARIANT macro required for Xtensa coredump
 if(CONFIG_XTENSA)
   if(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "zephyr")

--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -28,6 +28,13 @@ config DEBUG_COREDUMP_BACKEND_FLASH_PARTITION
 	  Core dump is saved to a flash partition with DTS alias
 	  "coredump-partition".
 
+config DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW
+	bool "Use memory window for coredump on Intel ADSP"
+	help
+	  Core dump is done via memory window slot[1].
+	  It is Intel ADSP memory region shared with xtensa DSP.
+	  Window 2 slot [1] is reserved for debuging information.
+
 config DEBUG_COREDUMP_BACKEND_OTHER
 	bool "Backend subsystem for coredump defined out of tree"
 	help

--- a/subsys/debug/coredump/coredump_backend_intel_adsp_mem_window.c
+++ b/subsys/debug/coredump/coredump_backend_intel_adsp_mem_window.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <zephyr/sys/util.h>
+
+#include <zephyr/debug/coredump.h>
+#include "coredump_internal.h"
+
+#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <adsp_memory.h>
+#include <adsp_debug_window.h>
+LOG_MODULE_REGISTER(coredump_error, CONFIG_KERNEL_LOG_LEVEL);
+
+static int error;
+
+static void coredump_mem_window_backend_start(void)
+{
+	/* Reset error */
+	error = 0;
+	ADSP_DW->descs[1].type = ADSP_DW_SLOT_TELEMETRY;
+
+	while (LOG_PROCESS()) {
+		;
+	}
+
+	LOG_PANIC();
+	LOG_ERR(COREDUMP_PREFIX_STR COREDUMP_BEGIN_STR);
+}
+
+static void coredump_mem_window_backend_end(void)
+{
+	if (error != 0) {
+		LOG_ERR(COREDUMP_PREFIX_STR COREDUMP_ERROR_STR);
+	}
+
+	LOG_ERR(COREDUMP_PREFIX_STR COREDUMP_END_STR);
+}
+
+static void coredump_mem_window_backend_buffer_output(uint8_t *buf, size_t buflen)
+{
+	uint32_t *mem_window_separator = (uint32_t *)(ADSP_DW->slots[1]);
+	uint8_t *mem_window_sink = (uint8_t *)(ADSP_DW->slots[1]) + 4;
+	uint8_t *coredump_data = buf;
+	size_t data_left;
+	/* Default place for telemetry dump is in memory window. Each data is easily find using
+	 * separator. For telemetry that separator is 0x0DEC0DEB.
+	 */
+	*mem_window_separator = 0x0DEC0DEB;
+
+	if (buf) {
+		for (data_left = buflen; data_left > 0; data_left--) {
+			*mem_window_sink = *coredump_data;
+			mem_window_sink++;
+			coredump_data++;
+		}
+	} else {
+		error = -EINVAL;
+	}
+}
+
+static int coredump_mem_window_backend_query(enum coredump_query_id query_id,
+					     void *arg)
+{
+	int ret;
+
+	switch (query_id) {
+	case COREDUMP_QUERY_GET_ERROR:
+		ret = error;
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
+	}
+
+	return ret;
+}
+
+static int coredump_mem_window_backend_cmd(enum coredump_cmd_id cmd_id,
+					   void *arg)
+{
+	int ret;
+
+	switch (cmd_id) {
+	case COREDUMP_CMD_CLEAR_ERROR:
+		ret = 0;
+		error = 0;
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
+	}
+
+	return ret;
+}
+
+struct coredump_backend_api coredump_backend_intel_adsp_mem_window = {
+	.start = coredump_mem_window_backend_start,
+	.end = coredump_mem_window_backend_end,
+	.buffer_output = coredump_mem_window_backend_buffer_output,
+	.query = coredump_mem_window_backend_query,
+	.cmd = coredump_mem_window_backend_cmd,
+};

--- a/subsys/debug/coredump/coredump_core.c
+++ b/subsys/debug/coredump/coredump_core.c
@@ -12,7 +12,6 @@
 #include <zephyr/sys/util.h>
 
 #include "coredump_internal.h"
-
 #if defined(CONFIG_DEBUG_COREDUMP_BACKEND_LOGGING)
 extern struct coredump_backend_api coredump_backend_logging;
 static struct coredump_backend_api
@@ -21,6 +20,10 @@ static struct coredump_backend_api
 extern struct coredump_backend_api coredump_backend_flash_partition;
 static struct coredump_backend_api
 	*backend_api = &coredump_backend_flash_partition;
+#elif defined(CONFIG_DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW)
+extern struct coredump_backend_api coredump_backend_intel_adsp_mem_window;
+static struct coredump_backend_api
+	*backend_api = &coredump_backend_intel_adsp_mem_window;
 #elif defined(CONFIG_DEBUG_COREDUMP_BACKEND_OTHER)
 extern struct coredump_backend_api coredump_backend_other;
 static struct coredump_backend_api


### PR DESCRIPTION
For debug usage is added backend to memory window. Coredump is being dumped in raw data. It needs to be converted to ACSI for later analysis. Data is located in memory window slot[1] but in future is required to move it to last position of telemetry.