### PR TITLE
tests: tickless_concept: Fix failures seen on NXP RT595 & RT685

### DIFF
--- a/tests/kernel/tickless/tickless_concept/boards/mimxrt595_evk_cm33.conf
+++ b/tests/kernel/tickless/tickless_concept/boards/mimxrt595_evk_cm33.conf
@@ -1,0 +1,10 @@
+#
+# Copyright 2022, NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Turn on Device Level Power Management as we wish
+# to reconfigure the FlexSPI pins for power savings
+# when transitioning the SoC to Deep Low Power modes.
+CONFIG_PM_DEVICE=y

--- a/tests/kernel/tickless/tickless_concept/boards/mimxrt595_evk_cm33.overlay
+++ b/tests/kernel/tickless/tickless_concept/boards/mimxrt595_evk_cm33.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2022, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&os_timer {
+	status = "okay";
+	wakeup-source;
+};


### PR DESCRIPTION
Add the os_timer as a wakeup source so we can exit deep-sleep modes.
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/57037