### PR TITLE
sensor: thermistor: improve temperature calculation

### DIFF
--- a/drivers/sensor/ntc_thermistor/ntc_thermistor.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor.c
@@ -119,11 +119,13 @@ static int ntc_thermistor_init(const struct device *dev)
 				.pullup_ohm = DT_INST_PROP(inst, pullup_ohm),                      \
 				.pulldown_ohm = DT_INST_PROP(inst, pulldown_ohm),                  \
 				.connected_positive = DT_INST_PROP(inst, connected_positive),      \
-				.type = {                                                          \
-					.comp = (const struct ntc_compensation *)comp_table,       \
-					.n_comp = ARRAY_SIZE(comp_table),                          \
-					.ohm_cmp = compare_ohm_##id##inst,                         \
-				},                                                                 \
+				.type =                                                            \
+					{                                                          \
+						.comp = (const struct ntc_compensation *)          \
+							comp_table,                                \
+						.n_comp = ARRAY_SIZE(comp_table) / 2,              \
+						.ohm_cmp = compare_ohm_##id##inst,                 \
+					},                                                         \
 			},                                                                         \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/sensor/ntc_thermistor/ntc_thermistor.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor.c
@@ -61,17 +61,17 @@ static int ntc_thermistor_channel_get(const struct device *dev, enum sensor_chan
 {
 	struct ntc_thermistor_data *data = dev->data;
 	const struct ntc_thermistor_config *cfg = dev->config;
-	uint32_t ohm, max_adc;
+	uint32_t ohm;
 	int32_t temp;
 
 	switch (chan) {
 	case SENSOR_CHAN_AMBIENT_TEMP:
-		max_adc = (1 << (cfg->adc_channel.resolution - 1)) - 1;
-		ohm = ntc_get_ohm_of_thermistor(&cfg->ntc_cfg, max_adc, data->raw);
+		ohm = ntc_get_ohm_of_thermistor(&cfg->ntc_cfg, data->sample_mv);
 		temp = ntc_get_temp_mc(&cfg->ntc_cfg.type, ohm);
 		val->val1 = temp / 1000;
 		val->val2 = (temp % 1000) * 1000;
-		LOG_INF("ntc temp says %u", val->val1);
+		LOG_DBG("vin=%u vout=%u ohms=%u temp=%d", cfg->ntc_cfg.pullup_uv / 1000,
+			data->sample_mv, ohm, temp);
 		break;
 	default:
 		return -ENOTSUP;

--- a/drivers/sensor/ntc_thermistor/ntc_thermistor.h
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor.h
@@ -56,11 +56,10 @@ int32_t ntc_get_temp_mc(const struct ntc_type *type, uint32_t ohm);
  * @brief Calculate the resistance read from NTC Thermistor
  *
  * @param cfg: NTC Thermistor configuration
- * @param max_adc: Max ADC value
- * @param raw_adc: Raw ADC value read
+ * @param vout: Measured voltage divider output voltage in millivolts
  *
- * @return resistance from raw ADC value
+ * @return thermistor resistance in Ohms
  */
-uint32_t ntc_get_ohm_of_thermistor(const struct ntc_config *cfg, uint32_t max_adc, int16_t raw_adc);
+uint32_t ntc_get_ohm_of_thermistor(const struct ntc_config *cfg, uint32_t vout);
 
 #endif /* NTC_THERMISTOR_H */

--- a/drivers/sensor/ntc_thermistor/ntc_thermistor.h
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor.h
@@ -16,7 +16,7 @@ struct ntc_compensation {
 
 struct ntc_type {
 	const struct ntc_compensation *comp;
-	int n_comp;
+	unsigned int n_comp;
 	int (*ohm_cmp)(const void *key, const void *element);
 };
 
@@ -50,7 +50,7 @@ int ntc_compensation_compare_ohm(const struct ntc_type *type, const void *key, c
  *
  * @return temperature in milli centigrade
  */
-int32_t ntc_get_temp_mc(const struct ntc_type *type, unsigned int ohm);
+int32_t ntc_get_temp_mc(const struct ntc_type *type, uint32_t ohm);
 
 /**
  * @brief Calculate the resistance read from NTC Thermistor

--- a/drivers/sensor/ntc_thermistor/ntc_thermistor_calc.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor_calc.c
@@ -56,12 +56,11 @@ int ntc_compensation_compare_ohm(const struct ntc_type *type, const void *key, c
 		}
 	} else if (ntc_key->ohm == element_val->ohm) {
 		sgn = 0;
-	} else if (ntc_key->ohm < element_val->ohm) {
+	} else {
 		if (element_idx == (type->n_comp / 2) - 1) {
 			sgn = 0;
 		} else {
-			if (element_idx != (type->n_comp / 2) - 1 &&
-			    ntc_key->ohm > type->comp[element_idx + 1].ohm) {
+			if (ntc_key->ohm > type->comp[element_idx + 1].ohm) {
 				sgn = 0;
 			} else {
 				sgn = 1;

--- a/drivers/sensor/ntc_thermistor/ntc_thermistor_calc.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor_calc.c
@@ -6,6 +6,7 @@
 
 #include <stdlib.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
 #include "ntc_thermistor.h"
 
 /**
@@ -117,6 +118,8 @@ uint32_t ntc_get_ohm_of_thermistor(const struct ntc_config *cfg, uint32_t max_ad
 
 int32_t ntc_get_temp_mc(const struct ntc_type *type, uint32_t ohm)
 {
+	const int32_t min_temp = type->comp[0].temp_c * 1000;
+	const int32_t max_temp = type->comp[type->n_comp - 1].temp_c * 1000;
 	unsigned int low, high;
 	int32_t temp;
 
@@ -129,5 +132,6 @@ int32_t ntc_get_temp_mc(const struct ntc_type *type, uint32_t ohm)
 	temp = ntc_fixp_linear_interpolate(type->comp[low].ohm, type->comp[low].temp_c * 1000,
 					   type->comp[high].ohm, type->comp[high].temp_c * 1000,
 					   ohm);
-	return temp;
+
+	return CLAMP(temp, min_temp, max_temp);
 }

--- a/drivers/sensor/ntc_thermistor/ntc_thermistor_calc.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor_calc.c
@@ -61,7 +61,7 @@ int ntc_compensation_compare_ohm(const struct ntc_type *type, const void *key, c
 	} else if (ntc_key->ohm == element_val->ohm) {
 		sgn = 0;
 	} else {
-		if (element_idx == (type->n_comp / 2) - 1) {
+		if (element_idx == type->n_comp - 1) {
 			sgn = 0;
 		} else {
 			if (ntc_key->ohm > type->comp[element_idx + 1].ohm) {

--- a/drivers/sensor/ntc_thermistor/ntc_thermistor_calc.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor_calc.c
@@ -87,13 +87,13 @@ static void ntc_lookup_comp(const struct ntc_type *type, uint32_t ohm, unsigned 
 
 	ptr = bsearch(&search_ohm_key, type->comp, type->n_comp, sizeof(type->comp[0]),
 		      type->ohm_cmp);
-	if (ptr) {
-		*i_low = (unsigned int)(ptr - type->comp);
-		*i_high = *i_low + 1;
-	} else {
-		*i_low = 0;
-		*i_high = 0;
+	__ASSERT_NO_MSG(ptr != NULL);
+
+	*i_low = (unsigned int)(ptr - type->comp);
+	if (*i_low == type->n_comp - 1) {
+		--*i_low;
 	}
+	*i_high = *i_low + 1;
 }
 
 /**


### PR DESCRIPTION
Tested with STM32F303C8 and Murata NXFT15XH103FA2B060.

Would especially appreciate comments about DTS changes.
In summary: I don't think I've ever seen such a configuration where the thermistor is sandwiched between two fixed value resistors. Is there really a need to require the user to provide two resistance values? Such configuration seems really exotic and is not supported by the driver anyways.

If only the classical scenario should be supported, then it's enough to only require the one fixed resistance value and the rest can be deduced from `connection-type`.