### PR TITLE
STM32 ADC driver: Rework sampling time

### DIFF
--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -286,6 +286,8 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 4 8 13 20 40 80 161>;
+			num-sampling-time-common-channels = <2>;
 		};
 	};
 

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -337,6 +337,8 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 8 14 29 42 56 72 240>;
+			num-sampling-time-common-channels = <1>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -342,6 +342,7 @@
 			temp-channel = <16>;
 			vref-channel = <17>;
 			resolutions = <STM32F1_ADC_RES(12)>;
+			sampling-times = <2 8 14 29 42 56 72 240>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -372,6 +372,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 15 28 58 84 112 144 480>;
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -113,6 +113,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 3 5 8 20 62 182 602>;
 		};
 	};
 };

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -152,6 +152,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 3 5 8 20 62 182 602>;
 		};
 	};
 };

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -37,6 +37,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 3 5 8 20 62 182 602>;
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -182,6 +182,7 @@
 			status = "disabled";
 			#io-channel-cells = <1>;
 			resolutions = <STM32F1_ADC_RES(12)>;
+			sampling-times = <2 8 14 29 42 56 72 240>;
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -519,6 +519,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 15 28 56 84 112 144 480>;
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -740,6 +740,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 15 28 56 84 112 144 480>;
 		};
 
 		adc2: adc@40012100 {
@@ -753,6 +754,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 15 28 56 84 112 144 480>;
 		};
 
 		adc3: adc@40012200 {
@@ -766,6 +768,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 15 28 56 84 112 144 480>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -402,6 +402,14 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			/* Errata ES0418: For sampling time set to 1.5 or 3.5
+			 * cycles, the sampling in a single ADC conversion or in
+			 * the first conversion of a sequence takes one extra
+			 * cycle.
+			 * So instead of 2 4, we set 3 5.
+			 */
+			sampling-times = <3 5 8 13 20 40 80 161>;
+			num-sampling-time-common-channels = <2>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -113,6 +113,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
 		};
 
 		adc2: adc@50000100 {
@@ -126,6 +127,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
 		};
 
 		dac1: dac@50000800 {

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -268,6 +268,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
 		};
 
 		rtc: rtc@44007800 {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -814,6 +814,7 @@
 				       STM32_ADC_RES(12, 0x06)
 				       STM32_ADC_RES(10, 0x03)
 				       STM32_ADC_RES(8, 0x07)>;
+			sampling-times = <2 3 9 17 33 65 388 811>;
 		};
 
 		adc2: adc@40022100 {
@@ -828,6 +829,7 @@
 				       STM32_ADC_RES(12, 0x06)
 				       STM32_ADC_RES(10, 0x03)
 				       STM32_ADC_RES(8, 0x07)>;
+			sampling-times = <2 3 9 17 33 65 388 811>;
 		};
 
 		/* dual mode: adc1 and adc2 coupled */
@@ -843,6 +845,7 @@
 				       STM32_ADC_RES(12, 0x06)
 				       STM32_ADC_RES(10, 0x03)
 				       STM32_ADC_RES(8, 0x07)>;
+			sampling-times = <2 3 9 17 33 65 388 811>;
 		};
 
 		adc3: adc@58026000 {
@@ -857,6 +860,7 @@
 				       STM32_ADC_RES(12, 0x06)
 				       STM32_ADC_RES(10, 0x03)
 				       STM32_ADC_RES(8, 0x07)>;
+			sampling-times = <2 3 9 17 33 65 388 811>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -51,6 +51,7 @@
 				       STM32H72X_ADC3_RES(10, 0x01)
 				       STM32H72X_ADC3_RES(8, 0x02)
 				       STM32H72X_ADC3_RES(6, 0x03)>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
 		};
 
 		dmamux1: dmamux@40020800 {

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -304,6 +304,8 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 4 8 13 20 40 80 161>;
+			num-sampling-time-common-channels = <1>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -222,6 +222,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <4 9 16 24 48 96 192 384>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -395,6 +395,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
 		};
 
 		adc2: adc@50040100 {
@@ -408,6 +409,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -664,6 +664,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
 		};
 
 		adc2: adc@42028100 {
@@ -677,6 +678,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
 		};
 
 		usb: usb@4000d400 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -749,6 +749,7 @@
 				       STM32_ADC_RES(12, 0x01)
 				       STM32_ADC_RES(10, 0x02)
 				       STM32_ADC_RES(8, 0x03)>;
+			sampling-times = <5 6 12 20 36 68 391 814>;
 		};
 
 		adc4: adc@46021000 {
@@ -765,6 +766,8 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 4 8 13 20 40 80 815>;
+			num-sampling-time-common-channels = <2>;
 		};
 
 		can {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -416,6 +416,7 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
 		};
 
 		iwdg: watchdog@40003000 {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -337,6 +337,8 @@
 				       STM32_ADC_RES(10, 0x01)
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 4 8 13 20 40 80 161>;
+			num-sampling-time-common-channels = <2>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -58,5 +58,18 @@ properties:
       By design, these macros also contains all register information (address,
       field offset and field mask) necessary to properly set the resolution.
 
+  sampling-times:
+    type: array
+    required: true
+    description: |
+      List all the sampling times supported by the ADC instance.
+      Rounded up if needed. Order is important: their index matches their binary
+      value in the register.
+
+  num-sampling-time-common-channels:
+    type: int
+    description: |
+      Number of sampling time common channels for this ADC instance, if any.
+
 io-channel-cells:
   - input


### PR DESCRIPTION
This is a new PR in the "trying to remove the crust from the STM32 ADC driver" series.
This PR moves the ADC sampling time in the dtsi instead of in the driver itself. This allows to get rid of many arrays using macro concatenation, and to define the sampling time per ADC instead of per MCU (STM32U5 or STM32H723 have different types of ADC that use different sampling times). This should also make it easier to add new series in the future.

Sampling time is either configured individually per ADC channel, or using one or two common fields for all ADC channels (in the case of two common fields, only one is used for the moment, no change from previous implementation).