### PR TITLE
nrf52_bsim: Enable real flash peripheral

### DIFF
--- a/boards/posix/nrf52_bsim/board_soc.h
+++ b/boards/posix/nrf52_bsim/board_soc.h
@@ -32,6 +32,9 @@
 
 #define OFFLOAD_SW_IRQ SWI0_EGU0_IRQn
 
+#define FLASH_PAGE_ERASE_MAX_TIME_US	89700UL
+#define FLASH_PAGE_MAX_CNT		256UL
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/boards/posix/nrf52_bsim/doc/index.rst
+++ b/boards/posix/nrf52_bsim/doc/index.rst
@@ -27,6 +27,8 @@ This board models some of the NRF52 SOC peripherals:
 * PPI (Programmable Peripheral Interconnect)
 * EGU (Event Generator Unit)
 * TEMP (Temperature sensor)
+* UICR (User information configuration registers)
+* NVMC (Non-volatile memory controller)
 
 The nrf52_bsim board definition uses the POSIX architecture to
 run applications natively on the development system, this has the benefit of

--- a/boards/posix/nrf52_bsim/nrf52_bsim.dts
+++ b/boards/posix/nrf52_bsim/nrf52_bsim.dts
@@ -35,12 +35,11 @@
 	};
 
 	chosen {
-		/delete-property/ zephyr,flash-controller;
 		zephyr,ieee802154 = &ieee802154;
+		zephyr,flash = &flash0;
 	};
 
 	soc {
-		/delete-node/ flash-controller@4001e000;
 		/delete-node/ memory@20000000;
 		/delete-node/ adc@40007000;
 		/delete-node/ uart@40002000;
@@ -81,4 +80,18 @@
 	 * modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_gpiote_zephyr.c
 	 */
 	status = "okay";
+};
+
+&flash0 {
+	reg = <0x00000000 DT_SIZE_K(512)>;
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		storage_partition: partition@0 {
+			label = "storage";
+			reg = <0x00000000 DT_SIZE_K(512)>;
+		};
+	};
 };

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -137,7 +137,7 @@ static int flash_nrf_read(const struct device *dev, off_t addr,
 		return 0;
 	}
 
-	memcpy(data, (void *)addr, len);
+	nrf_nvmc_buffer_read(data, (uint32_t)addr, len);
 
 	return 0;
 }

--- a/samples/net/sockets/echo_client/boards/nrf52_bsim.conf
+++ b/samples/net/sockets/echo_client/boards/nrf52_bsim.conf
@@ -1,4 +1,0 @@
-# The nrf52 HW models do not have a flash model yet. Even though it is possible to use different
-# replacements, the easiest one is to disable the flash, so when configured with openthread
-# it will use the OPENTHREAD_SETTINGS_RAM
-CONFIG_FLASH=n

--- a/samples/net/sockets/echo_server/boards/nrf52_bsim.conf
+++ b/samples/net/sockets/echo_server/boards/nrf52_bsim.conf
@@ -1,4 +1,0 @@
-# The nrf52 HW models do not have a flash model yet. Even though it is possible to use different
-# replacements, the easiest one is to disable the flash, so when configured with openthread
-# it will use the OPENTHREAD_SETTINGS_RAM
-CONFIG_FLASH=n

--- a/tests/bsim/net/sockets/echo_test/boards/nrf52_bsim.conf
+++ b/tests/bsim/net/sockets/echo_test/boards/nrf52_bsim.conf
@@ -1,4 +1,0 @@
-# The nrf52 HW models do not have a flash model yet. Even though it is possible to use different
-# replacements, the easiest one is to disable the flash, so when configured with openthread
-# it will use the OPENTHREAD_SETTINGS_RAM
-CONFIG_FLASH=n

--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -78,7 +78,7 @@ static void *flash_driver_setup(void)
 	}
 
 	/* Check if tested region fits in flash */
-	zassert_true((TEST_AREA_OFFSET + EXPECTED_SIZE) < TEST_AREA_MAX,
+	zassert_true((TEST_AREA_OFFSET + EXPECTED_SIZE) <= TEST_AREA_MAX,
 		     "Test area exceeds flash size");
 
 	/* Check if flash is cleared */

--- a/west.yml
+++ b/west.yml
@@ -204,7 +204,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: bad9877e997b2c2a78dd74eec8978181f4655d14
+      revision: c8d2ecd25d6976d2d77eccf66878420fdb8ef5a1
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 233fb29c52ffa7733ba132a2b5987a8201ba8ec6


### PR DESCRIPTION
    nrf52_bsim: Enable real flash(nvmc) peripheral
    
    The HW models include now the real flash peripheral.
    Enable it.
    
---------

    manifest: nrf hw models: Use latest w flash
    
    Update to the latest NRF HW models which include
    models of the NVMC and UICR peripherals,
    as well as some other (very) minor fixes.
    
---------

    drivers: nrf5 flash: Fix for simulation
    
    Use new nrfx hal function to memcpy from flash
    instead of accessing the array directly.
    That function is inlining a memcpy for real targets,
    so there is no practical difference for those.
    
---------

    manifest: nordic hal: Update to latest
    
    Which includes some new APIs and minor changes needed
    to enable the simulated flash.

-------

   tests/net: For nrf52_bsim use flash model
    
    Now that the nrf52 HW models support it,
    let's use their flash model instead of falling back
    to the openthread RAM settings backend.
    
    Note that the flash model defaults to just keeping the
    flash content in the Linux process heap.

------

    tests/flash: Fix max test size check
    
    The condition just needs to be <=, as it is ok
    to write say 128KB in a 128KB storage partition.
    
------
