### PR TITLE
net: Make net_mgmt queue timeout configurable

### DIFF
--- a/subsys/net/ip/Kconfig.mgmt
+++ b/subsys/net/ip/Kconfig.mgmt
@@ -38,6 +38,14 @@ config NET_MGMT_EVENT_QUEUE_SIZE
 	  notification. Thus the size of this queue has to be tweaked depending
 	  on the load of the system, planned for the usage.
 
+config NET_MGMT_EVENT_QUEUE_TIMEOUT
+	int "Timeout for event queue"
+	default 10
+	range 1 10000
+	help
+	  Timeout in milliseconds for the event queue. This timeout is used to
+	  wait for the queue to be available.
+
 config NET_MGMT_EVENT_INFO
 	bool "Passing information along with an event"
 	help

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -79,9 +79,11 @@ static inline void mgmt_push_event(uint32_t mgmt_event, struct net_if *iface,
 	new_event.event = mgmt_event;
 	new_event.iface = iface;
 
-	if (k_msgq_put(&event_msgq, &new_event, K_MSEC(10)) != 0) {
+	if (k_msgq_put(&event_msgq, &new_event,
+		K_MSEC(CONFIG_NET_MGMT_EVENT_QUEUE_TIMEOUT)) != 0) {
 		NET_WARN("Failure to push event (%u), "
-			 "try increasing the 'CONFIG_NET_MGMT_EVENT_QUEUE_SIZE'",
+			 "try increasing the 'CONFIG_NET_MGMT_EVENT_QUEUE_SIZE' "
+			 "or 'CONFIG_NET_MGMT_EVENT_QUEUE_TIMEOUT' options.",
 			 mgmt_event);
 	}
 


### PR DESCRIPTION
This helps us work with low queue depth of network management queue in case the we have high rate events.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/56595 .