### PR TITLE
dts: arm: nxp: Fix PINT base address for LPC51xxx and 54xxxx

### DIFF
--- a/dts/arm/nxp/nxp_lpc51u68.dtsi
+++ b/dts/arm/nxp/nxp_lpc51u68.dtsi
@@ -72,9 +72,9 @@
 			port = <1>;
 		};
 
-		pint: pint@4000 {
+		pint: pint@40004000 {
 			compatible = "nxp,pint";
-			reg = <0x4000 0x1000>;
+			reg = <0x40004000 0x1000>;
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			#address-cells = <0>;

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -127,9 +127,9 @@
 			port = <1>;
 		};
 
-		pint: pint@4000 {
+		pint: pint@40004000 {
 			compatible = "nxp,pint";
-			reg = <0x4000 0x1000>;
+			reg = <0x40004000 0x1000>;
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			#address-cells = <0>;


### PR DESCRIPTION
Fix PINT base address for LPC51xxx and 54xxx. These addresses were incorrectly copied from the LPC55S69, which utilizes trustzone. Add the relevant base address offset to the addresses.

Fixes #57334