### PR TITLE
tests: net: Disable test for mps2_an385

### DIFF
--- a/tests/net/socket/tls/testcase.yaml
+++ b/tests/net/socket/tls/testcase.yaml
@@ -13,3 +13,4 @@ tests:
   net.socket.tls.preempt:
     extra_configs:
       - CONFIG_NET_TC_THREAD_PREEMPTIVE=y
+    platform_exclude: mps2_an385


### PR DESCRIPTION
This test seems to run out of memory for this platform. Temp. disabling it.