### PR TITLE
manifest: bsim: Do not import explicitly but keep copy in submanifests/

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -116,7 +116,7 @@ jobs:
           || steps.check-networking-files.outputs.any_changed == 'true'
           || steps.check-common-files.outputs.any_changed == 'true'
         run: |
-          export BSIM_VERSION=$( west list bsim -f {sha} )
+          export BSIM_VERSION=$( west list bsim -f {revision} )
           echo "Manifest points to bsim sha $BSIM_VERSION"
           cd /opt/bsim_west/bsim
           git fetch -n origin ${BSIM_VERSION}

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -69,7 +69,6 @@ jobs:
     - name: west setup
       run: |
         west init -l .
-        west update bsim
 
     - name: build-docs
       run: |
@@ -155,7 +154,6 @@ jobs:
     - name: west setup
       run: |
         west init -l .
-        west update bsim
 
     - name: build-docs
       run: |

--- a/submanifests/README.txt
+++ b/submanifests/README.txt
@@ -1,6 +1,6 @@
 This directory can contain additional west manifest files. Any files
-in this directory will be included in the main west.yml file sorted by
-filename.
+in this directory (but not subdirectorries) will be included in the main
+west.yml file sorted by filename.
 
 See example.yaml.sample for an example.
 

--- a/submanifests/bsim/notes.txt
+++ b/submanifests/bsim/notes.txt
@@ -1,0 +1,28 @@
+This folder holds an exact copy of the Babblesim manifest,
+as pointed by the top level manifest bsim project.
+
+This is a provisional solution until some new features in west enable a more
+automatic integration.
+
+Background:
+**********
+
+Due to a limitation in the west import feature
+https://github.com/zephyrproject-rtos/west/issues/543
+a project cannot both have an import and be part of a group.
+
+Moreover, when a project has an import and is not filtered out, it is required
+for that project to be present for most west commands to work.
+
+To work around this issue, we do not do an import in the bsim project, that is,
+we do not have west automatically find the babblesim manifest inside the bsim
+project, but instead import the manifest from this local replica.
+
+This manifest is kept in a subfolder of the submanifests folder, so the placing
+of its projects can be individually controlled with the west import path-prefix
+property.
+
+The bsim project as included in the top level manifest has two purposes:
+ * It provides a skeleton and some glue for the BabbleSim installation, if the user
+   enables the babblesim group.
+ * It is the bsim manifest revision Zephyr's CI will use.

--- a/submanifests/bsim/west.yml
+++ b/submanifests/bsim/west.yml
@@ -1,0 +1,86 @@
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+#
+# west manifest file for BabbleSim
+#
+# Check https://babblesim.github.io/fetching.html for more information
+#
+
+manifest:
+  defaults:
+    remote: upstream
+
+  remotes:
+    - name: upstream
+      url-base: https://github.com/BabbleSim
+
+  self:
+    path: bsim
+
+  projects:
+    - name: babblesim_base
+      repo-path: base.git
+      path: bsim/components
+      revision: 02838ca04c4562e68dc876196828d8121679e537
+      groups:
+        - babblesim
+    - name: babblesim_ext_2G4_libPhyComv1
+      repo-path: ext_2G4_libPhyComv1.git
+      path: bsim/components/ext_2G4_libPhyComv1
+      revision: 9018113a362fa6c9e8f4b9cab9e5a8f12cc46b94
+      groups:
+        - babblesim
+    - name: babblesim_ext_2G4_phy_v1
+      repo-path: ext_2G4_phy_v1.git
+      path: bsim/components/ext_2G4_phy_v1
+      revision: cf2d86e736efac4f12fad5093ed2da2c5b406156
+      groups:
+        - babblesim
+    - name: babblesim_ext_2G4_channel_NtNcable
+      repo-path: ext_2G4_channel_NtNcable.git
+      path: bsim/components/ext_2G4_channel_NtNcable
+      revision: 20a38c997f507b0aa53817aab3d73a462fff7af1
+      groups:
+        - babblesim
+    - name: babblesim_ext_2G4_channel_multiatt
+      repo-path: ext_2G4_channel_multiatt.git
+      path: bsim/components/ext_2G4_channel_multiatt
+      revision: e09bc2d14b1975f969ad19c6ed23eb20e5dc3d09
+      groups:
+        - babblesim
+    - name: babblesim_ext_2G4_modem_magic
+      repo-path: ext_2G4_modem_magic.git
+      path: bsim/components/ext_2G4_modem_magic
+      revision: cb70771794f0bf6f262aa474848611c68ae8f1ed
+      groups:
+        - babblesim
+    - name: babblesim_ext_2G4_modem_BLE_simple
+      repo-path: ext_2G4_modem_BLE_simple.git
+      path: bsim/components/ext_2G4_modem_BLE_simple
+      revision: ce975a3259fd0dd761d371b60435242d54794bad
+      groups:
+        - babblesim
+    - name: babblesim_ext_2G4_device_burst_interferer
+      repo-path: ext_2G4_device_burst_interferer.git
+      path: bsim/components/ext_2G4_device_burst_interferer
+      revision: 5b5339351d6e6a2368c686c734dc8b2fc65698fc
+      groups:
+        - babblesim
+    - name: babblesim_ext_2G4_device_WLAN_actmod
+      repo-path: ext_2G4_device_WLAN_actmod.git
+      path: bsim/components/ext_2G4_device_WLAN_actmod
+      revision: 9cb6d8e72695f6b785e57443f0629a18069d6ce4
+      groups:
+        - babblesim
+    - name: babblesim_ext_2G4_device_playback
+      repo-path: ext_2G4_device_playback.git
+      path: bsim/components/ext_2G4_device_playback
+      revision: 85c645929cf1ce995d8537107d9dcbd12ed64036
+      groups:
+        - babblesim
+    - name: babblesim_ext_libCryptov1
+      repo-path: ext_libCryptov1.git
+      path: bsim/components/ext_libCryptov1
+      revision: eed6d7038e839153e340bd333bc43541cb90ba64
+      groups:
+        - babblesim

--- a/west.yml
+++ b/west.yml
@@ -30,8 +30,9 @@ manifest:
     - name: bsim
       repo-path: babblesim-manifest
       revision: 908ffde6298a937c6549dbfa843a62caab26bfc5
-      import:
-        path-prefix: tools
+      path: tools/bsim
+      groups:
+        - babblesim
     - name: canopennode
       revision: dec12fa3f0d790cafa8414a4c2930ea71ab72ffd
       path: modules/lib/canopennode
@@ -273,4 +274,7 @@ manifest:
   self:
     path: zephyr
     west-commands: scripts/west-commands.yml
-    import: submanifests
+    import:
+      - file: submanifests
+      - file: submanifests/bsim/west.yml
+        path-prefix: tools


### PR DESCRIPTION
Due to a limitation in the west import feature,
    a project cannot both have an import and be part of a group.
    Moreover, when a project has an import and is not filtered
    out, it is required for that project to be present
    for most west commands to work.
    
As the bsim project is not filtered by default,
    it causes trouble for users who never run a
    west update but try to use west further.
    
To work around this issue, let's disable the import
    in the bsim project, and instead copy its manifest
    into the submanifests/ folder.
    
Having a replica of the babblesim manifes in the submanifest
    folder is likely to cause some confusion in users,
    wrt to which version of components they are using.
    So whenever west supports both imports and groups, or another
    simple and nicer way of working around this, it should be used.

Fixes #57198