### PR TITLE
boards: arm: nrf52840dongle_nrf52840: Fix boot partition address

### DIFF
--- a/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
@@ -18,11 +18,12 @@ config BOARD
 
 # When building MCUBoot, MCUBoot itself will select USE_DT_CODE_PARTITION
 # which will make it link into the correct partition specified in DTS file,
-# so no override is necessary.
+# the offset is applied here so that the full partition size can be used when
+# the bootloader Kconfig option has been disabled.
 
 config FLASH_LOAD_OFFSET
 	default 0x1000
-	depends on BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
+	depends on BOARD_HAS_NRF5_BOOTLOADER && (MCUBOOT || !USE_DT_CODE_PARTITION)
 
 if BOARD_SERIAL_BACKEND_CDC_ACM
 

--- a/boards/arm/nrf52840dongle_nrf52840/fstab-stock.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/fstab-stock.dts
@@ -12,13 +12,14 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* MCUboot placed after Nordic MBR.
-		 * The size of this partition ensures that MCUBoot
-		 * can be built with CDC ACM support and w/o optimizations.
+		/* MCUboot placed after Nordic MBR (this is set with the FLASH_LOAD_OFFSET
+		 * Kconfig value when BOARD_HAS_NRF5_BOOTLOADER is enabled), otherwise MCUboot
+		 * will be placed at 0x0. The size of this partition ensures that MCUBoot can
+		 * be built with CDC ACM support and w/o optimizations.
 		 */
-		boot_partition: partition@1000 {
+		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00001000 0x0000f000>;
+			reg = <0x00000000 0x00010000>;
 		};
 
 		slot0_partition: partition@10000 {


### PR DESCRIPTION
Fixes an issue when mcuboot is built for this board with the nRF5x SDK bootloader Kconfig disabled to allow it to be placed at 0x0 instead of 0x1000 whereby it would not boot.

Fixes #57345