### PR TITLE
intel_adsp: power: add missing header

### DIFF
--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -9,6 +9,7 @@
 #include <zephyr/debug/sparse.h>
 #include <zephyr/cache.h>
 #include <cpu_init.h>
+#include <soc_util.h>
 
 #include <adsp_boot.h>
 #include <adsp_power.h>


### PR DESCRIPTION
After commit e195739565 function bmemcpy require soc_util include.