### PR TITLE
net: if: Add new flags to disable ND/MLD per interface

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -203,6 +203,9 @@ enum net_if_flag {
 	/** Driver signals dormant. */
 	NET_IF_DORMANT,
 
+	/** IPv6 Neighbor Discovery disabled. */
+	NET_IF_IPV6_NO_ND,
+
 /** @cond INTERNAL_HIDDEN */
 	/* Total number of flags - must be at the end of the enum */
 	NET_IF_NUM_FLAGS

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -206,6 +206,9 @@ enum net_if_flag {
 	/** IPv6 Neighbor Discovery disabled. */
 	NET_IF_IPV6_NO_ND,
 
+	/** IPv6 Multicast Listener Discovery disabled. */
+	NET_IF_IPV6_NO_MLD,
+
 /** @cond INTERNAL_HIDDEN */
 	/* Total number of flags - must be at the end of the enum */
 	NET_IF_NUM_FLAGS

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -194,6 +194,10 @@ int net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr)
 		}
 	}
 
+	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_MLD)) {
+		return 0;
+	}
+
 	if (!net_if_is_up(iface)) {
 		return -ENETDOWN;
 	}
@@ -226,6 +230,10 @@ int net_ipv6_mld_leave(struct net_if *iface, const struct in6_addr *addr)
 
 	if (!net_if_ipv6_maddr_rm(iface, addr)) {
 		return -EINVAL;
+	}
+
+	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_MLD)) {
+		return 0;
 	}
 
 	ret = mld_send_generic(iface, addr, NET_IPV6_MLDv2_MODE_IS_INCLUDE);

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -846,8 +846,8 @@ ignore_frag_error:
 	    /* Workaround Linux bug, see:
 	     * https://github.com/zephyrproject-rtos/zephyr/issues/3111
 	     */
-	    net_if_flag_is_set(net_pkt_iface(pkt),
-			       NET_IF_POINTOPOINT)) {
+	    net_if_flag_is_set(net_pkt_iface(pkt), NET_IF_POINTOPOINT) ||
+	    net_if_flag_is_set(net_pkt_iface(pkt), NET_IF_IPV6_NO_ND)) {
 		return NET_OK;
 	}
 
@@ -1161,6 +1161,10 @@ static enum net_verdict handle_ns_input(struct net_pkt *pkt,
 	struct net_linkaddr src_lladdr;
 
 	src_lladdr.len = 0;
+
+	if (net_if_flag_is_set(net_pkt_iface(pkt), NET_IF_IPV6_NO_ND)) {
+		goto drop;
+	}
 
 	ns_hdr = (struct net_icmpv6_ns_hdr *)net_pkt_get_data(pkt, &ns_access);
 	if (!ns_hdr) {
@@ -1730,6 +1734,10 @@ static enum net_verdict handle_na_input(struct net_pkt *pkt,
 	struct net_icmpv6_nd_opt_hdr *nd_opt_hdr;
 	struct net_icmpv6_na_hdr *na_hdr;
 	struct net_if_addr *ifaddr;
+
+	if (net_if_flag_is_set(net_pkt_iface(pkt), NET_IF_IPV6_NO_ND)) {
+		goto drop;
+	}
 
 	na_hdr = (struct net_icmpv6_na_hdr *)net_pkt_get_data(pkt, &na_access);
 	if (!na_hdr) {
@@ -2399,6 +2407,10 @@ static enum net_verdict handle_ra_input(struct net_pkt *pkt,
 	struct net_if_router *router;
 	uint32_t mtu, reachable_time, retrans_timer;
 	uint16_t router_lifetime;
+
+	if (net_if_flag_is_set(net_pkt_iface(pkt), NET_IF_IPV6_NO_ND)) {
+		goto drop;
+	}
 
 	ra_hdr = (struct net_icmpv6_ra_hdr *)net_pkt_get_data(pkt, &ra_access);
 	if (!ra_hdr) {

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1407,6 +1407,10 @@ void net_if_start_rs(struct net_if *iface)
 
 	k_mutex_lock(&lock, K_FOREVER);
 
+	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
+		goto out;
+	}
+
 	ipv6 = iface->config.ip.ipv6;
 	if (!ipv6) {
 		goto out;
@@ -1725,7 +1729,8 @@ struct net_if_addr *net_if_ipv6_addr_add(struct net_if *iface,
 			net_addr_type2str(addr_type));
 
 		if (!(l2_flags_get(iface) & NET_L2_POINT_TO_POINT) &&
-		    !net_ipv6_is_addr_loopback(addr)) {
+		    !net_ipv6_is_addr_loopback(addr) &&
+		    !net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
 			/* RFC 4862 5.4.2
 			 * Before sending a Neighbor Solicitation, an interface
 			 * MUST join the all-nodes multicast address and the
@@ -2792,7 +2797,8 @@ uint32_t net_if_ipv6_calc_reachable_time(struct net_if_ipv6 *ipv6)
 
 static void iface_ipv6_start(struct net_if *iface)
 {
-	if (!net_if_flag_is_set(iface, NET_IF_IPV6)) {
+	if (!net_if_flag_is_set(iface, NET_IF_IPV6) ||
+	    net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
 		return;
 	}
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -291,7 +291,7 @@ static const char *iface_flags2str(struct net_if *iface)
 	static char str[sizeof("POINTOPOINT") + sizeof("PROMISC") +
 			sizeof("NO_AUTO_START") + sizeof("SUSPENDED") +
 			sizeof("MCAST_FORWARD") + sizeof("IPv4") +
-			sizeof("IPv6")];
+			sizeof("IPv6") + sizeof("NO_ND") + sizeof("NO_MLD")];
 	int pos = 0;
 
 	if (net_if_flag_is_set(iface, NET_IF_POINTOPOINT)) {
@@ -325,6 +325,16 @@ static const char *iface_flags2str(struct net_if *iface)
 	if (net_if_flag_is_set(iface, NET_IF_IPV6)) {
 		pos += snprintk(str + pos, sizeof(str) - pos,
 				"IPv6,");
+	}
+
+	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
+		pos += snprintk(str + pos, sizeof(str) - pos,
+				"NO_ND,");
+	}
+
+	if (net_if_flag_is_set(iface, NET_IF_IPV6_NO_MLD)) {
+		pos += snprintk(str + pos, sizeof(str) - pos,
+				"NO_MLD,");
 	}
 
 	/* get rid of last ',' character */

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -567,6 +567,9 @@ void ieee802154_init(struct net_if *iface)
 		net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 	}
 
+	net_if_flag_set(iface, NET_IF_IPV6_NO_ND);
+	net_if_flag_set(iface, NET_IF_IPV6_NO_MLD);
+
 	openthread_init(iface);
 }
 

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -283,9 +283,10 @@ static void setup_ipv6(struct net_if *iface, uint32_t flags)
 
 exit:
 
-#if !defined(CONFIG_NET_IPV6_DAD)
-	services_notify_ready(NET_CONFIG_NEED_IPV6);
-#endif
+	if (!IS_ENABLED(CONFIG_NET_IPV6_DAD) ||
+	    net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
+		services_notify_ready(NET_CONFIG_NEED_IPV6);
+	}
 
 	return;
 }


### PR DESCRIPTION
Add new network interface flags, which allows to disable ND/MLD protocolS from being used on the interface. This allows to interfaces that do not support ND/MLD (like OpenThread) to coexist with other IPv6 interfaces.

