### PR TITLE
enable tests/drivers/adc/adc_dma on board for nucleo_h743zi

### DIFF
--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.yaml
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.yaml
@@ -24,3 +24,4 @@ supported:
   - usb_device
   - can
   - dac
+  - dma

--- a/tests/drivers/adc/adc_dma/testcase.yaml
+++ b/tests/drivers/adc/adc_dma/testcase.yaml
@@ -11,5 +11,6 @@ tests:
     platform_allow:
       - frdm_k82f
       - frdm_k64f
+      - nucleo_h743zi
     integration_platforms:
       - frdm_k82f


### PR DESCRIPTION
   
 the twister test is now enable for tests/drivers/adc/adc_dma on board
 nucleo_h743zi.   
 add platform_allow nucleo_h743zi.
 used on driver st_stm32_adc with CONFIG_ADC_STM32_DMA=y.
     
 Signed-off-by: Marc Desvaux <marc.desvaux-ext@st.com>