### PR TITLE
flash_simulator: add ability to use memory region

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -382,6 +382,9 @@ Drivers and Sensors
     with ``nrf_qspi_nor_xip_enable`` which apart from forcing the clock divider
     prevents the driver from deactivating the QSPI peripheral so that the XIP
     operation is actually possible.
+  * flash_simulator: A memory region can now be used as the storage area for the
+    flash simulator. Using the memory region allows the flash simulator to keep
+    its contents over a device reboot.
 
 * FPGA
 

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -10,3 +10,8 @@ properties:
   erase-value:
     type: int
     description: Value of erased flash cell
+  memory-region:
+    type: phandle
+    description: |
+      Memory region used by the simulated flash memory. If this option is used
+      the memory that is used by the simulated flash memory is not erased.

--- a/tests/drivers/flash_simulator/boards/nucleo_f411re.overlay
+++ b/tests/drivers/flash_simulator/boards/nucleo_f411re.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+        sram_2001C000:sram@2001C000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x2001C000 0x4000>;
+		zephyr,memory-region = "FlashSim";
+		status = "okay";
+        };
+
+        soc {
+                sim_flash_controller: sim-flash-controller@0 {
+	                compatible = "zephyr,sim-flash";
+                        reg = <0x0 0x1>;
+
+			#address-cells = <1>;
+		        #size-cells = <1>;
+		        erase-value = <0xff>;
+                        memory-region = <&sram_2001C000>;
+
+			flash_sim0: flash_sim@0 {
+			        status = "okay";
+			        compatible = "soc-nv-flash";
+			        erase-block-size = <512>;
+				/* the flash_simulator test uses a write block
+				 * size of 4 for alignment test, so set it to 4.
+				 */
+			        write-block-size = <4>;
+			        reg = <0x00000000 DT_SIZE_K(16)>;
+                        };
+                };
+        };
+};
+
+&flash_sim0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		lfsram_partition: partition@0 {
+			label = "lfsram";
+			reg = <0x00000000 DT_SIZE_K(16)>;
+		};
+	};
+};

--- a/tests/drivers/flash_simulator/src/main.c
+++ b/tests/drivers/flash_simulator/src/main.c
@@ -32,7 +32,11 @@
 		(((((((0xff & pat) << 8) | (0xff & pat)) << 8) | \
 		   (0xff & pat)) << 8) | (0xff & pat))
 
+#if (defined(CONFIG_ARCH_POSIX) || defined(CONFIG_BOARD_QEMU_X86))
 static const struct device *const flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+#else
+static const struct device *const flash_dev = DEVICE_DT_GET(DT_NODELABEL(sim_flash_controller));
+#endif
 static uint8_t test_read_buf[TEST_SIM_FLASH_SIZE];
 
 static uint32_t p32_inc;

--- a/tests/drivers/flash_simulator/testcase.yaml
+++ b/tests/drivers/flash_simulator/testcase.yaml
@@ -2,7 +2,7 @@ common:
   tags: drivers flash
 tests:
   drivers.flash.flash_simulator:
-    platform_allow: qemu_x86 native_posix native_posix_64
+    platform_allow: qemu_x86 native_posix native_posix_64 nucleo_f411re
     integration_platforms:
       - qemu_x86
   drivers.flash.flash_simulator.qemu_erase_value_0x00:


### PR DESCRIPTION
Add the ability for the flash simulator to store its contents in a memory region. 

This allows filesystems on the flash simulator to survive a reboot. And allows subsystems (e.g. coredump) to store their info on ram while using the (existing) flash partition backend.

Add a example (for nucleo_f411re) that shows how to configure the flash simulator for hardware (cfg discussion #54166).