### PR TITLE
dts/sparc/gaisler: add SoC and board compatible strings

### DIFF
--- a/boards/sparc/generic_leon3/generic_leon3.dts
+++ b/boards/sparc/generic_leon3/generic_leon3.dts
@@ -9,6 +9,8 @@
 #include <gaisler/leon3soc.dtsi>
 
 / {
+	model = "Generic LEON3 system";
+	compatible = "gaisler,generic-leon3";
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;

--- a/boards/sparc/gr716a_mini/gr716a_mini.dts
+++ b/boards/sparc/gr716a_mini/gr716a_mini.dts
@@ -9,6 +9,8 @@
 #include <gaisler/gr716a.dtsi>
 
 / {
+	model = "GR716-MINI Development Board";
+	compatible = "gaisler,gr716a-mini";
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;

--- a/dts/sparc/gaisler/gr716a.dtsi
+++ b/dts/sparc/gaisler/gr716a.dtsi
@@ -30,7 +30,7 @@
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
-		compatible = "simple-bus";
+		compatible = "gaisler,gr716-soc", "simple-bus";
 		ranges;
 		interrupt-parent = <&irqmp>;
 

--- a/dts/sparc/gaisler/leon3soc.dtsi
+++ b/dts/sparc/gaisler/leon3soc.dtsi
@@ -25,7 +25,7 @@
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
-		compatible = "simple-bus";
+		compatible = "gaisler,leon3-soc", "simple-bus";
 		ranges;
 		interrupt-parent = <&irqmp>;
 


### PR DESCRIPTION
This PR adds compatible strings to Gaisler SoCs and boards in devicetree files. This is especially useful for effort relying on structured data such us [Renodepedia](https://zephyr-dashboard.renode.io/renodepedia/).