### PR TITLE
Bluetooth: BAP: Add specific error code for stopping stopped sink

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -1674,8 +1674,8 @@ int bt_bap_broadcast_sink_stop(struct bt_bap_broadcast_sink *sink)
 	}
 
 	if (sys_slist_is_empty(&sink->streams)) {
-		LOG_DBG("Source does not have any streams");
-		return -EINVAL;
+		LOG_DBG("Source does not have any streams (already stopped)");
+		return -EALREADY;
 	}
 
 	head_node = sys_slist_peek_head(&sink->streams);


### PR DESCRIPTION
If the broadcast sink is already stopped (i.e. the streams have all been disconnected), then we can return a more useful error code than EINVAL.