### PR TITLE
bsim: cmake: Remove unnecessary references to environment

### DIFF
--- a/drivers/console/CMakeLists.txt
+++ b/drivers/console/CMakeLists.txt
@@ -4,7 +4,7 @@ zephyr_library()
 
 if (${CONFIG_BSIM_CONSOLE})
   zephyr_library_sources(bsim_console.c)
-  zephyr_library_include_directories($ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/)
+  zephyr_library_include_directories(${BSIM_COMPONENTS_PATH}/libUtilv1/src/)
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_GSM_MUX gsm_mux.c)

--- a/tests/bsim/bluetooth/audio/CMakeLists.txt
+++ b/tests/bsim/bluetooth/audio/CMakeLists.txt
@@ -9,7 +9,7 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources} )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   ${ZEPHYR_BASE}/subsys/bluetooth/host/audio/
 )

--- a/tests/bsim/bluetooth/host/adv/chain/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/adv/chain/CMakeLists.txt
@@ -12,6 +12,6 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
 )

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/CMakeLists.txt
@@ -13,6 +13,6 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-        $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-        $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+        ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+        ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
 )

--- a/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/CMakeLists.txt
@@ -12,8 +12,8 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
 
   ${ZEPHYR_BASE}/samples/bluetooth/encrypted_advertising/peripheral/src/
   ${ZEPHYR_BASE}/samples/bluetooth/encrypted_advertising/include/

--- a/tests/bsim/bluetooth/host/adv/periodic/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/adv/periodic/CMakeLists.txt
@@ -13,7 +13,7 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   ${ZEPHYR_BASE}/subsys/bluetooth/host/audio/
 )

--- a/tests/bsim/bluetooth/host/adv/resume/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/adv/resume/CMakeLists.txt
@@ -13,6 +13,6 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/att/eatt/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/att/eatt/CMakeLists.txt
@@ -16,6 +16,6 @@ target_sources(app PRIVATE
 
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/att/eatt_notif/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/CMakeLists.txt
@@ -9,6 +9,6 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources} )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/att/mtu_update/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/att/mtu_update/CMakeLists.txt
@@ -12,6 +12,6 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
 )

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/client/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/client/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if(NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(app)
 
@@ -22,6 +15,6 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
 )

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/server/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/server/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if(NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(app)
 
@@ -19,6 +12,6 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
 )

--- a/tests/bsim/bluetooth/host/gatt/caching/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/gatt/caching/CMakeLists.txt
@@ -9,6 +9,6 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources} )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/gatt/general/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/gatt/general/CMakeLists.txt
@@ -9,6 +9,6 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources} )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/gatt/notify/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/gatt/notify/CMakeLists.txt
@@ -9,6 +9,6 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources} )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/CMakeLists.txt
@@ -9,6 +9,6 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources} )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/gatt/settings/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/gatt/settings/CMakeLists.txt
@@ -15,6 +15,6 @@ target_sources(app PRIVATE
   )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/l2cap/credits/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/l2cap/credits/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-	message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_l2cap_credits)
 
@@ -16,6 +9,6 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources} )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/l2cap/general/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/l2cap/general/CMakeLists.txt
@@ -9,6 +9,6 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources} )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/l2cap/split/dut/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/l2cap/split/dut/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_l2cap_split_dut)
 
@@ -18,6 +11,6 @@ target_sources(app PRIVATE
 
 zephyr_include_directories(
   ../common/
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/l2cap/split/tester/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/l2cap/split/tester/CMakeLists.txt
@@ -2,13 +2,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
-  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set\
- the  environment variable BSIM_COMPONENTS_PATH to point to its components \
- folder. More information can be found in\
- https://babblesim.github.io/folder_structure_and_env.html")
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_l2cap_split_tester)
 
@@ -17,6 +10,6 @@ target_sources(app PRIVATE src/main.c)
 zephyr_include_directories(
   ../common/
   ${ZEPHYR_BASE}/subsys/bluetooth/common/
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/l2cap/stress/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/l2cap/stress/CMakeLists.txt
@@ -9,6 +9,6 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources} )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/l2cap/userdata/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/CMakeLists.txt
@@ -9,6 +9,6 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources} )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/misc/disable/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/misc/disable/CMakeLists.txt
@@ -9,6 +9,6 @@ FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources} )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/privacy/central/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/privacy/central/CMakeLists.txt
@@ -13,6 +13,6 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/privacy/device/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/privacy/device/CMakeLists.txt
@@ -12,7 +12,7 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   ${ZEPHYR_BASE}/subsys/bluetooth/host/
 )

--- a/tests/bsim/bluetooth/host/privacy/peripheral/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/CMakeLists.txt
@@ -13,6 +13,6 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/CMakeLists.txt
@@ -13,6 +13,6 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/CMakeLists.txt
@@ -13,6 +13,6 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )

--- a/tests/bsim/bluetooth/ll/advx/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/advx/CMakeLists.txt
@@ -8,7 +8,7 @@ project(bsim_test_advx)
 target_sources(app PRIVATE src/main.c)
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   ${ZEPHYR_BASE}/subsys/bluetooth/controller/include
   )

--- a/tests/bsim/bluetooth/ll/conn/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/conn/CMakeLists.txt
@@ -13,7 +13,7 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   ${ZEPHYR_BASE}/samples/bluetooth
 )

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/CMakeLists.txt
@@ -17,6 +17,6 @@ target_sources(app PRIVATE
 zephyr_library_include_directories(${ZEPHYR_BASE}/samples/bluetooth
   ../common/
   src/
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
 )

--- a/tests/bsim/bluetooth/ll/edtt/hci_test_app/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/edtt/hci_test_app/CMakeLists.txt
@@ -15,6 +15,6 @@ zephyr_library_include_directories(
   ${ZEPHYR_BASE}/samples/bluetooth
   ${ZEPHYR_BASE}/subsys/bluetooth
   ../common/
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
 )

--- a/tests/bsim/bluetooth/ll/iso/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/iso/CMakeLists.txt
@@ -9,7 +9,7 @@ target_sources(app PRIVATE src/main.c)
 
 zephyr_include_directories(
   ${ZEPHYR_BASE}
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   ${ZEPHYR_BASE}/subsys/bluetooth/controller/include
   )

--- a/tests/bsim/bluetooth/ll/multiple_id/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/multiple_id/CMakeLists.txt
@@ -12,6 +12,6 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
 )

--- a/tests/bsim/bluetooth/ll/throughput/CMakeLists.txt
+++ b/tests/bsim/bluetooth/ll/throughput/CMakeLists.txt
@@ -13,6 +13,6 @@ target_sources(app PRIVATE
 )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
 )

--- a/tests/bsim/bluetooth/mesh/CMakeLists.txt
+++ b/tests/bsim/bluetooth/mesh/CMakeLists.txt
@@ -73,6 +73,6 @@ else()
 endif()
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
 )

--- a/tests/bsim/net/sockets/echo_test/CMakeLists.txt
+++ b/tests/bsim/net/sockets/echo_test/CMakeLists.txt
@@ -42,6 +42,6 @@ generate_inc_file_for_target(
     )
 
 zephyr_include_directories(
-  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
-  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
   )


### PR DESCRIPTION
These variables are now provided by the FindBabbleSim cmake module, which finds them in the environment or thru west.