### PR TITLE
samples, tests: cleanup void main usage.

### DIFF
--- a/samples/bluetooth/periodic_adv_conn/src/main.c
+++ b/samples/bluetooth/periodic_adv_conn/src/main.c
@@ -160,7 +160,7 @@ static void init_bufs(void)
 	}
 }
 
-void main(void)
+int main(void)
 {
 	int err;
 	struct bt_le_ext_adv *pawr_adv;
@@ -173,38 +173,40 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Create a non-connectable non-scannable advertising set */
 	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN_NAME, &adv_cb, &pawr_adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Set periodic advertising parameters */
 	err = bt_le_per_adv_set_param(pawr_adv, &per_adv_params);
 	if (err) {
 		printk("Failed to set periodic advertising parameters (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Enable Periodic Advertising */
 	err = bt_le_per_adv_start(pawr_adv);
 	if (err) {
 		printk("Failed to enable periodic advertising (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Start Periodic Advertising\n");
 	err = bt_le_ext_adv_start(pawr_adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (err) {
 		printk("Failed to start extended advertising (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	while (true) {
 		k_sleep(K_SECONDS(1));
 	}
+
+	return 0;
 }

--- a/samples/bluetooth/periodic_adv_rsp/src/main.c
+++ b/samples/bluetooth/periodic_adv_rsp/src/main.c
@@ -247,7 +247,7 @@ struct pawr_timing {
 
 static uint8_t num_synced;
 
-void main(void)
+int main(void)
 {
 	int err;
 	struct bt_le_ext_adv *pawr_adv;
@@ -263,42 +263,42 @@ void main(void)
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Create a non-connectable non-scannable advertising set */
 	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_NCONN, &adv_cb, &pawr_adv);
 	if (err) {
 		printk("Failed to create advertising set (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Set periodic advertising parameters */
 	err = bt_le_per_adv_set_param(pawr_adv, &per_adv_params);
 	if (err) {
 		printk("Failed to set periodic advertising parameters (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	/* Enable Periodic Advertising */
 	err = bt_le_per_adv_start(pawr_adv);
 	if (err) {
 		printk("Failed to enable periodic advertising (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	printk("Start Periodic Advertising\n");
 	err = bt_le_ext_adv_start(pawr_adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (err) {
 		printk("Failed to start extended advertising (err %d)\n", err);
-		return;
+		return 0;
 	}
 
 	while (num_synced < MAX_SYNCS) {
 		err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, device_found);
 		if (err) {
 			printk("Scanning failed to start (err %d)\n", err);
-			return;
+			return 0;
 		}
 
 		printk("Scanning successfully started\n");
@@ -368,7 +368,7 @@ void main(void)
 disconnect:
 		err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 		if (err) {
-			return;
+			return 0;
 		}
 
 		k_sem_take(&sem_disconnected, K_FOREVER);
@@ -379,4 +379,6 @@ disconnect:
 	while (true) {
 		k_sleep(K_SECONDS(1));
 	}
+
+	return 0;
 }

--- a/samples/bluetooth/periodic_sync_rsp/src/main.c
+++ b/samples/bluetooth/periodic_sync_rsp/src/main.c
@@ -195,7 +195,7 @@ BT_CONN_CB_DEFINE(conn_cb) = {
 	.disconnected = disconnected,
 };
 
-void main(void)
+int main(void)
 {
 	struct bt_le_per_adv_sync_transfer_param past_param;
 	int err;
@@ -206,7 +206,7 @@ void main(void)
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 
-		return;
+		return 0;
 	}
 
 	bt_le_per_adv_sync_cb_register(&sync_callbacks);
@@ -218,7 +218,7 @@ void main(void)
 	if (err) {
 		printk("PAST subscribe failed (err %d)\n", err);
 
-		return;
+		return 0;
 	}
 
 	do {
@@ -231,7 +231,7 @@ void main(void)
 		if (err && err != -EALREADY) {
 			printk("Advertising failed to start (err %d)\n", err);
 
-			return;
+			return 0;
 		}
 
 		printk("Waiting for periodic sync...\n");
@@ -248,9 +248,11 @@ void main(void)
 		if (err) {
 			printk("failed (err %d)\n", err);
 
-			return;
+			return 0;
 		}
 
 		printk("Periodic sync lost.\n");
 	} while (true);
+
+	return 0;
 }

--- a/samples/boards/rpi_pico/uart_pio/src/main.c
+++ b/samples/boards/rpi_pico/uart_pio/src/main.c
@@ -8,18 +8,18 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 
-void main(void)
+int main(void)
 {
 	char data;
 	const struct device *uart0 = DEVICE_DT_GET(DT_NODELABEL(pio1_uart0));
 	const struct device *uart1 = DEVICE_DT_GET(DT_NODELABEL(pio1_uart1));
 
 	if (!device_is_ready(uart0)) {
-		return;
+		return 0;
 	}
 
 	if (!device_is_ready(uart1)) {
-		return;
+		return 0;
 	}
 
 	while (1) {
@@ -31,4 +31,6 @@ void main(void)
 			uart_poll_out(uart1, data);
 		}
 	}
+
+	return 0;
 }

--- a/samples/subsys/usb_c/source/src/main.c
+++ b/samples/subsys/usb_c/source/src/main.c
@@ -313,7 +313,7 @@ bool port1_policy_check(const struct device *dev,
 }
 /* usbc.rst check end */
 
-void main(void)
+int main(void)
 {
 	const struct device *usbc_port1;
 
@@ -321,7 +321,7 @@ void main(void)
 	usbc_port1 = DEVICE_DT_GET(PORT1_NODE);
 	if (!device_is_ready(usbc_port1)) {
 		LOG_ERR("PORT1 device not ready");
-		return;
+		return 0;
 	}
 
 	/* usbc.rst register start */
@@ -389,4 +389,6 @@ void main(void)
 		/* Arbitrary delay */
 		k_msleep(10);
 	}
+
+	return 0;
 }

--- a/tests/boot/mcuboot_recovery_retention/src/main.c
+++ b/tests/boot/mcuboot_recovery_retention/src/main.c
@@ -10,7 +10,7 @@
 #include <zephyr/kernel.h>
 #include <stdio.h>
 
-void main(void)
+int main(void)
 {
 	printf("Waiting...\n");
 	k_sleep(K_SECONDS(1));
@@ -22,4 +22,6 @@ void main(void)
 	} else {
 		printf("Error, failed to set boot mode: %d\n", rc);
 	}
+
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/testlib/bs_main.c
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/testlib/bs_main.c
@@ -45,7 +45,9 @@ static struct bst_test_list *install(struct bst_test_list *tests)
 
 bst_test_install_t test_installers[] = {install, NULL};
 
-void main(void)
+int main(void)
 {
 	bst_main();
+
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
@@ -421,7 +421,9 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-void main(void)
+int main(void)
 {
 	bst_main();
+
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/l2cap/split/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/split/dut/src/main.c
@@ -280,7 +280,9 @@ static struct bst_test_list *install(struct bst_test_list *tests)
 
 bst_test_install_t test_installers[] = {install, NULL};
 
-void main(void)
+int main(void)
 {
 	bst_main();
+
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/l2cap/split/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/split/tester/src/main.c
@@ -673,7 +673,9 @@ static struct bst_test_list *install(struct bst_test_list *tests)
 bst_test_install_t test_installers[] = {install, NULL};
 
 
-void main(void)
+int main(void)
 {
 	bst_main();
+
+	return 0;
 }


### PR DESCRIPTION
Some samples, tests got missed in the switch from void main() to int main().  Cleanup those samples/tests to use int main().