### PR TITLE
west.yml: hal_espressif: use common shared source

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -64,7 +64,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 0b5aa325aead1f36e104615f966e171cf4d36538
+      revision: 075894ed22caa5c2d1686a1e33953edd6aa41333
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This fixes an issue related to SPIRAM and DRAM_1 region access. It is possible that the application crashes due to invalid pointer value.