### PR TITLE
rtio: Various bug fixes for RTIO

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -1095,35 +1095,19 @@ static inline int rtio_sqe_rx_buf(const struct rtio_iodev_sqe *iodev_sqe, uint32
  *
  * @param r RTIO context
  * @param buff Pointer to the buffer to be released.
+ * @param buff_len Number of bytes to free (will be rounded up to nearest memory block).
  */
-__syscall void rtio_release_buffer(struct rtio *r, void *buff);
+__syscall void rtio_release_buffer(struct rtio *r, void *buff, uint32_t buff_len);
 
-static inline void z_impl_rtio_release_buffer(struct rtio *r, void *buff)
+static inline void z_impl_rtio_release_buffer(struct rtio *r, void *buff, uint32_t buff_len)
 {
 #ifdef CONFIG_RTIO_SYS_MEM_BLOCKS
-	if (r == NULL || buff == NULL || r->mempool == NULL) {
+	if (r == NULL || buff == NULL || r->mempool == NULL || buff_len == 0) {
 		return;
 	}
 
-	int rc = sys_mem_blocks_free(r->mempool, 1, &buff);
-
-	if (rc != 0) {
-		return;
-	}
-
-	uint16_t blk_index = __rtio_compute_mempool_block_index(r, buff);
-
-	if (blk_index == UINT16_MAX) {
-		return;
-	}
-	for (unsigned long i = 0; i < r->sq->_spsc.mask + 1; ++i) {
-		struct rtio_mempool_map_entry *entry = &r->mempool_map[i];
-
-		if (entry->block_idx == blk_index) {
-			entry->state = RTIO_MEMPOOL_ENTRY_STATE_FREE;
-			break;
-		}
-	}
+	sys_mem_blocks_free_contiguous(r->mempool, buff,
+				       DIV_ROUND_UP(buff_len, r->mempool_blk_size));
 #endif
 }
 

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -145,21 +145,34 @@ extern "C" {
  */
 #define RTIO_CQE_FLAG_MEMPOOL_BUFFER BIT(0)
 
-/**
- * @brief Get the value portion of the CQE flags
- *
- * @param flags The CQE flags value
- * @return The value portion of the flags field.
- */
-#define RTIO_CQE_FLAG_GET_VALUE(flags) FIELD_GET(GENMASK(31, 16), (flags))
+#define RTIO_CQE_FLAG_GET(flags) FIELD_GET(GENMASK(7, 0), (flags))
 
 /**
- * @brief Prepare a value to be added to the CQE flags field.
+ * @brief Get the block index of a mempool flags
  *
- * @param value The value to prepare
+ * @param flags The CQE flags value
+ * @return The block index portion of the flags field.
+ */
+#define RTIO_CQE_FLAG_MEMPOOL_GET_BLK_IDX(flags) FIELD_GET(GENMASK(19, 8), (flags))
+
+/**
+ * @brief Get the block count of a mempool flags
+ *
+ * @param flags The CQE flags value
+ * @return The block count portion of the flags field.
+ */
+#define RTIO_CQE_FLAG_MEMPOOL_GET_BLK_CNT(flags) FIELD_GET(GENMASK(31, 20), (flags))
+
+/**
+ * @brief Prepare CQE flags for a mempool read.
+ *
+ * @param blk_idx The mempool block index
+ * @param blk_cnt The mempool block count
  * @return A shifted and masked value that can be added to the flags field with an OR operator.
  */
-#define RTIO_CQE_FLAG_PREP_VALUE(value) FIELD_PREP(GENMASK(31, 16), (value))
+#define RTIO_CQE_FLAG_PREP_MEMPOOL(blk_idx, blk_cnt)                                               \
+	(FIELD_PREP(GENMASK(7, 0), RTIO_CQE_FLAG_MEMPOOL_BUFFER) |                                 \
+	 FIELD_PREP(GENMASK(19, 8), blk_idx) | FIELD_PREP(GENMASK(31, 20), blk_cnt))
 
 /**
  * @}
@@ -334,18 +347,6 @@ enum rtio_mempool_entry_state {
 BUILD_ASSERT(RTIO_MEMPOOL_ENTRY_STATE_COUNT < 4);
 
 /**
- * @brief An entry mapping a mempool entry to its sqe.
- */
-struct rtio_mempool_map_entry {
-	/** The state of the sqe map entry */
-	enum rtio_mempool_entry_state state : 2;
-	/** The starting block index into the mempool buffer */
-	uint16_t block_idx : 15;
-	/** Number of blocks after the block_idx */
-	uint16_t block_count : 15;
-};
-
-/**
  * @brief An RTIO queue pair that both the kernel and application work with
  *
  * The kernel is the consumer of the submission queue, and producer of the completion queue.
@@ -395,8 +396,6 @@ struct rtio {
 	struct sys_mem_blocks *mempool;
 	/* The size (in bytes) of a single block in the mempool */
 	uint32_t mempool_blk_size;
-	/* Map of allocated starting blocks */
-	struct rtio_mempool_map_entry *mempool_map;
 #endif /* CONFIG_RTIO_SYS_MEM_BLOCKS */
 };
 
@@ -722,11 +721,9 @@ static inline void rtio_sqe_prep_transceive(struct rtio_sqe *sqe,
 		_mempool_buf_##name[num_blks*WB_UP(blk_size)];	                                   \
 	_SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(_mempool_##name, WB_UP(blk_size), num_blks,		   \
 					    _mempool_buf_##name, RTIO_DMEM);                       \
-	RTIO_BMEM struct rtio_mempool_map_entry _mempool_map_##name[sq_sz];                        \
 	_RTIO_DEFINE(name, exec, sq_sz, cq_sz)                                                     \
 		.mempool = &_mempool_##name,                                                       \
 		.mempool_blk_size = WB_UP(blk_size),                                               \
-		.mempool_map = _mempool_map_##name,                                                \
 	}
 /* clang-format on */
 
@@ -887,17 +884,10 @@ static inline uint32_t rtio_cqe_compute_flags(struct rtio_iodev_sqe *iodev_sqe)
 #ifdef CONFIG_RTIO_SYS_MEM_BLOCKS
 	if (iodev_sqe->sqe->op == RTIO_OP_RX && iodev_sqe->sqe->flags & RTIO_SQE_MEMPOOL_BUFFER) {
 		struct rtio *r = iodev_sqe->r;
-		int sqe_index = iodev_sqe->sqe - r->sq->buffer;
-		struct rtio_mempool_map_entry *map_entry = &r->mempool_map[sqe_index];
+		int blk_index = (iodev_sqe->sqe->buf - r->mempool->buffer) / r->mempool_blk_size;
+		int blk_count = iodev_sqe->sqe->buf_len / r->mempool_blk_size;
 
-		if (map_entry->state != RTIO_MEMPOOL_ENTRY_STATE_ALLOCATED) {
-			/* Not allocated to this sqe */
-			return flags;
-		}
-
-		flags |= RTIO_CQE_FLAG_MEMPOOL_BUFFER;
-		flags |= RTIO_CQE_FLAG_PREP_VALUE(sqe_index);
-		map_entry->state = RTIO_MEMPOOL_ENTRY_STATE_ZOMBIE;
+		flags = RTIO_CQE_FLAG_PREP_MEMPOOL(blk_index, blk_count);
 	}
 #endif
 
@@ -926,15 +916,12 @@ static inline int z_impl_rtio_cqe_get_mempool_buffer(const struct rtio *r, struc
 						     uint8_t **buff, uint32_t *buff_len)
 {
 #ifdef CONFIG_RTIO_SYS_MEM_BLOCKS
-	if (cqe->flags & RTIO_CQE_FLAG_MEMPOOL_BUFFER) {
-		int map_idx = RTIO_CQE_FLAG_GET_VALUE(cqe->flags);
-		struct rtio_mempool_map_entry *entry = &r->mempool_map[map_idx];
+	if (RTIO_CQE_FLAG_GET(cqe->flags) == RTIO_CQE_FLAG_MEMPOOL_BUFFER) {
+		int blk_idx = RTIO_CQE_FLAG_MEMPOOL_GET_BLK_IDX(cqe->flags);
+		int blk_count = RTIO_CQE_FLAG_MEMPOOL_GET_BLK_CNT(cqe->flags);
 
-		if (entry->state != RTIO_MEMPOOL_ENTRY_STATE_ZOMBIE) {
-			return -EINVAL;
-		}
-		*buff = r->mempool->buffer + entry->block_idx * r->mempool_blk_size;
-		*buff_len = entry->block_count * r->mempool_blk_size;
+		*buff = r->mempool->buffer + blk_idx * r->mempool_blk_size;
+		*buff_len = blk_count * r->mempool_blk_size;
 		__ASSERT_NO_MSG(*buff >= r->mempool->buffer);
 		__ASSERT_NO_MSG(*buff <
 				r->mempool->buffer + r->mempool_blk_size * r->mempool->num_blocks);
@@ -1058,14 +1045,14 @@ static inline int rtio_sqe_rx_buf(const struct rtio_iodev_sqe *iodev_sqe, uint32
 		struct sys_mem_blocks *pool = r->mempool;
 		uint32_t bytes = max_buf_len;
 		int sqe_index = sqe - r->sq->buffer;
-		struct rtio_mempool_map_entry *map_entry = &r->mempool_map[sqe_index];
+		struct rtio_sqe *mutable_sqe = &r->sq->buffer[sqe_index];
 
-		if (map_entry->state == RTIO_MEMPOOL_ENTRY_STATE_ALLOCATED) {
-			if (map_entry->block_count * blk_size < min_buf_len) {
+		if (sqe->buf != NULL) {
+			if (sqe->buf_len < min_buf_len) {
 				return -ENOMEM;
 			}
-			*buf = &r->mempool->buffer[map_entry->block_count * blk_size];
-			*buf_len = map_entry->block_count * blk_size;
+			*buf = sqe->buf;
+			*buf_len = sqe->buf_len;
 			return 0;
 		}
 
@@ -1075,9 +1062,8 @@ static inline int rtio_sqe_rx_buf(const struct rtio_iodev_sqe *iodev_sqe, uint32
 
 			if (rc == 0) {
 				*buf_len = num_blks * blk_size;
-				map_entry->state = RTIO_MEMPOOL_ENTRY_STATE_ALLOCATED;
-				map_entry->block_idx = __rtio_compute_mempool_block_index(r, *buf);
-				map_entry->block_count = num_blks;
+				mutable_sqe->buf = *buf;
+				mutable_sqe->buf_len = *buf_len;
 				return 0;
 			}
 			if (bytes == min_buf_len) {

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -32,14 +32,16 @@
 #ifndef ZEPHYR_INCLUDE_RTIO_RTIO_H_
 #define ZEPHYR_INCLUDE_RTIO_RTIO_H_
 
-#include <zephyr/rtio/rtio_spsc.h>
+#include <string.h>
+
+#include <zephyr/app_memory/app_memdomain.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
 #include <zephyr/rtio/rtio_mpsc.h>
+#include <zephyr/rtio/rtio_spsc.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/mem_blocks.h>
-#include <zephyr/device.h>
-#include <zephyr/kernel.h>
-#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -659,7 +659,7 @@ static inline void rtio_sqe_prep_transceive(struct rtio_sqe *sqe,
 	RTIO_SQ_DEFINE(_sq_##name, sq_sz);                                                         \
 	RTIO_CQ_DEFINE(_cq_##name, cq_sz);                                                         \
 	STRUCT_SECTION_ITERABLE(rtio, name) = {                                                    \
-		.executor = (exec),                                                                \
+		.executor = (struct rtio_executor *)(exec),                                        \
 		IF_ENABLED(CONFIG_RTIO_SUBMIT_SEM, (.submit_sem = &_submit_sem_##name,))           \
 		IF_ENABLED(CONFIG_RTIO_SUBMIT_SEM, (.submit_count = 0,))                           \
 		IF_ENABLED(CONFIG_RTIO_CONSUME_SEM, (.consume_sem = &_consume_sem_##name,))        \

--- a/samples/subsys/rtio/sensor_batch_processing/src/main.c
+++ b/samples/subsys/rtio/sensor_batch_processing/src/main.c
@@ -90,7 +90,7 @@ int main(void)
 		for (m = 0; m < M; m++) {
 			struct rtio_sqe *sqe = rtio_spsc_acquire(ez_io.sq);
 
-			rtio_release_buffer(&ez_io, userdata[m]);
+			rtio_release_buffer(&ez_io, userdata[m], data_len[m]);
 			rtio_sqe_prep_read_with_pool(sqe, iodev, RTIO_PRIO_HIGH, NULL);
 			rtio_spsc_produce(ez_io.sq);
 		}

--- a/subsys/rtio/rtio_handlers.c
+++ b/subsys/rtio/rtio_handlers.c
@@ -51,10 +51,10 @@ static inline bool rtio_vrfy_sqe(struct rtio_sqe *sqe)
 	return valid_sqe;
 }
 
-static inline void z_vrfy_rtio_release_buffer(struct rtio *r, void *buff)
+static inline void z_vrfy_rtio_release_buffer(struct rtio *r, void *buff, uint32_t buff_len)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(r, K_OBJ_RTIO));
-	z_impl_rtio_release_buffer(r, buff);
+	z_impl_rtio_release_buffer(r, buff, buff_len);
 }
 #include <syscalls/rtio_release_buffer_mrsh.c>
 

--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -29,12 +29,17 @@
 #define MEM_BLK_ALIGN 4
 
 RTIO_EXECUTOR_SIMPLE_DEFINE(simple_exec_simp);
+/*
+ * Purposefully double the block count and half the block size. This leaves the same size mempool,
+ * but ensures that allocation is done in larger blocks because the tests assume a larger block
+ * size.
+ */
 RTIO_DEFINE_WITH_MEMPOOL(r_simple_simp, (struct rtio_executor *)&simple_exec_simp, 4, 4,
-			 MEM_BLK_COUNT, MEM_BLK_SIZE, MEM_BLK_ALIGN);
+			 MEM_BLK_COUNT * 2, MEM_BLK_SIZE / 2, MEM_BLK_ALIGN);
 
 RTIO_EXECUTOR_CONCURRENT_DEFINE(simple_exec_con, 1);
 RTIO_DEFINE_WITH_MEMPOOL(r_simple_con, (struct rtio_executor *)&simple_exec_con, 4, 4,
-			 MEM_BLK_COUNT, MEM_BLK_SIZE, MEM_BLK_ALIGN);
+			 MEM_BLK_COUNT * 2, MEM_BLK_SIZE / 2, MEM_BLK_ALIGN);
 
 RTIO_IODEV_TEST_DEFINE(iodev_test_simple);
 
@@ -325,7 +330,7 @@ static void test_rtio_simple_mempool_(struct rtio *r, int run_count)
 	zassert_equal(buffer_len, MEM_BLK_SIZE);
 	zassert_mem_equal(buffer, mempool_data, MEM_BLK_SIZE, "Data expected to be the same");
 	TC_PRINT("Calling rtio_cqe_get_mempool_buffer\n");
-	rtio_release_buffer(r, buffer);
+	rtio_release_buffer(r, buffer, buffer_len);
 }
 
 static void rtio_simple_mempool_test(void *a, void *b, void *c)


### PR DESCRIPTION
- Rework RTIO mempool (existing implementation had issues when sqes and cqes went out of alignment.
- Make it easier to create the RTIO by avoiding the cast of the executor.
- Fix bug when releasing mempool memory
- Add missing header