### PR TITLE
Update nucleo_f303re.dts to match board labels

### DIFF
--- a/boards/arm/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/arm/nucleo_f303re/nucleo_f303re.dts
@@ -96,7 +96,7 @@
 };
 
 &i2c1 {
-	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb9>;
+	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	status = "okay";
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;


### PR DESCRIPTION
Updated i2c1 to match labeling on board and standard Arduino header pinout Fixes #57394