### PR TITLE
tests: sensor SBS EMUL_CONFIG to testcase.yaml

### DIFF
--- a/tests/drivers/sensor/sbs_gauge/boards/native_posix.conf
+++ b/tests/drivers/sensor/sbs_gauge/boards/native_posix.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2022 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_EMUL=y

--- a/tests/drivers/sensor/sbs_gauge/boards/qemu_arc_hs.conf
+++ b/tests/drivers/sensor/sbs_gauge/boards/qemu_arc_hs.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2023 Google LLC
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_EMUL=y

--- a/tests/drivers/sensor/sbs_gauge/boards/qemu_cortex_a9.conf
+++ b/tests/drivers/sensor/sbs_gauge/boards/qemu_cortex_a9.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2022 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_EMUL=y

--- a/tests/drivers/sensor/sbs_gauge/testcase.yaml
+++ b/tests/drivers/sensor/sbs_gauge/testcase.yaml
@@ -3,7 +3,8 @@ tests:
   drivers.sensors.sbs_gauge:
     build_only: true
     tags: drivers sensors
-    filter: dt_compat_enabled("sbs,sbs-gauge")
+    filter:
+      dt_compat_enabled("sbs,sbs-gauge") and not dt_compat_enabled("zephyr,i2c-emul-controller")
     integration_platforms:
       - nucleo_f070rb
   drivers.sensors.sbs_gauge.emulated:
@@ -12,3 +13,5 @@ tests:
     platform_allow: native_posix qemu_cortex_a9 qemu_arc_hs
     integration_platforms:
       - native_posix
+    extra_configs:
+      - CONFIG_EMUL=y


### PR DESCRIPTION
NOTE: This currently fails because CONFIG_EMUL isn't being applied for some reason. I've found this to work with other tests and I'm not sure where to go next on debugging this so I'm pushing this WIP PR for folks to examine, namely @galak .

There exists several <board>.conf files in the boards directory of the sbs_gauge tests. All these confs do is enable CONFIG_EMUL. We can remove these board confs in favor of a single extra_configs entry in the sensor sbs gauge testcase.yaml file.

Remove the sensor test_bs_gauge test's board conf files in favor of enabling CONFIG_EMUL in the testcase.yaml file.