### PR TITLE
tests: posix: pthread: init pthread_attr_t on each iteration

### DIFF
--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -584,7 +584,6 @@ ZTEST(posix_apis, test_posix_pthread_create_negative)
 
 ZTEST(posix_apis, test_pthread_descriptor_leak)
 {
-	void *unused;
 	pthread_t pthread1;
 	pthread_attr_t attr;
 
@@ -594,6 +593,6 @@ ZTEST(posix_apis, test_pthread_descriptor_leak)
 		zassert_ok(pthread_attr_setstack(&attr, &stack_e[0][0], STACKS));
 		zassert_ok(pthread_create(&pthread1, &attr, create_thread1, NULL),
 			   "unable to create thread %zu", i);
-		zassert_ok(pthread_join(pthread1, &unused), "unable to join thread %zu", i);
+		zassert_ok(pthread_join(pthread1, NULL), "unable to join thread %zu", i);
 	}
 }

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -588,11 +588,10 @@ ZTEST(posix_apis, test_pthread_descriptor_leak)
 	pthread_t pthread1;
 	pthread_attr_t attr;
 
-	zassert_ok(pthread_attr_init(&attr));
-	zassert_ok(pthread_attr_setstack(&attr, &stack_e[0][0], STACKS));
-
 	/* If we are leaking descriptors, then this loop will never complete */
 	for (size_t i = 0; i < CONFIG_MAX_PTHREAD_COUNT * 2; ++i) {
+		zassert_ok(pthread_attr_init(&attr));
+		zassert_ok(pthread_attr_setstack(&attr, &stack_e[0][0], STACKS));
 		zassert_ok(pthread_create(&pthread1, &attr, create_thread1, NULL),
 			   "unable to create thread %zu", i);
 		zassert_ok(pthread_join(pthread1, &unused), "unable to join thread %zu", i);


### PR DESCRIPTION
The `test_pthread_descriptor_leak` test was causing a kernel panic on some platforms. Initially, it was not clear why.

The usual cases were examined - race conditions, stack sizes, etc. Still no luck.

As it turns out, recycling a thread stack (or at least the `pthread_attr_t`) in-place does not work on some platforms, and we need to reinitialize the `pthread_attr_t` and set set the stack property again prior to calling `pthread_create()`.

Fixes #56163

Tested with:
```shell
west build -p always -b qemu_cortex_r5 -t run tests/posix/common \
    --   -DCONFIG_TICKLESS_KERNEL=n -DCONFIG_NEWLIB_LIBC=y
```