### PR TITLE
samples: net: dhcpv4_client: Make DHCP requests on all ipv4 interfaces

### DIFF
--- a/samples/net/dhcpv4_client/README.rst
+++ b/samples/net/dhcpv4_client/README.rst
@@ -179,8 +179,9 @@ are shown like this:
     [00:00:00.170,000] <inf> eth_smsc91x: MAC 00:02:f7:ef:37:16
     *** Booting Zephyr OS build zephyr-v3.2.0-4300-g3e6505dba29e ***
     [00:00:00.170,000] <inf> net_dhcpv4_client_sample: Run dhcpv4 client
+    [00:00:00.180,000] <inf> net_dhcpv4_client_sample: Start on ethernet@9a000000: index=1
     [00:00:07.180,000] <inf> net_dhcpv4: Received: 172.20.51.1
-    [00:00:07.180,000] <inf> net_dhcpv4_client_sample: Your address: 172.20.51.1
-    [00:00:07.180,000] <inf> net_dhcpv4_client_sample: Lease time: 86400 seconds
-    [00:00:07.180,000] <inf> net_dhcpv4_client_sample: Subnet: 255.255.255.0
-    [00:00:07.180,000] <inf> net_dhcpv4_client_sample: Router: 172.20.51.254
+    [00:00:07.180,000] <inf> net_dhcpv4_client_sample:    Address[1]: 172.20.51.1
+    [00:00:07.180,000] <inf> net_dhcpv4_client_sample:     Subnet[1]: 255.255.255.0
+    [00:00:07.180,000] <inf> net_dhcpv4_client_sample:     Router[1]: 172.20.51.254
+    [00:00:07.180,000] <inf> net_dhcpv4_client_sample: Lease time[1]: 86400 seconds

--- a/samples/net/dhcpv4_client/src/main.c
+++ b/samples/net/dhcpv4_client/src/main.c
@@ -28,6 +28,15 @@ static struct net_mgmt_event_callback mgmt_cb;
 
 static struct net_dhcpv4_option_callback dhcp_cb;
 
+static void start_dhcpv4_client(struct net_if *iface, void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	LOG_INF("Start on %s: index=%d", net_if_get_device(iface)->name,
+		net_if_get_by_iface(iface));
+	net_dhcpv4_start(iface);
+}
+
 static void handler(struct net_mgmt_event_callback *cb,
 		    uint32_t mgmt_event,
 		    struct net_if *iface)
@@ -46,20 +55,20 @@ static void handler(struct net_mgmt_event_callback *cb,
 			continue;
 		}
 
-		LOG_INF("Your address: %s",
+		LOG_INF("   Address[%d]: %s", net_if_get_by_iface(iface),
 			net_addr_ntop(AF_INET,
 			    &iface->config.ip.ipv4->unicast[i].address.in_addr,
 						  buf, sizeof(buf)));
-		LOG_INF("Lease time: %u seconds",
-			 iface->config.dhcpv4.lease_time);
-		LOG_INF("Subnet: %s",
+		LOG_INF("    Subnet[%d]: %s", net_if_get_by_iface(iface),
 			net_addr_ntop(AF_INET,
 				       &iface->config.ip.ipv4->netmask,
 				       buf, sizeof(buf)));
-		LOG_INF("Router: %s",
+		LOG_INF("    Router[%d]: %s", net_if_get_by_iface(iface),
 			net_addr_ntop(AF_INET,
 						 &iface->config.ip.ipv4->gw,
 						 buf, sizeof(buf)));
+		LOG_INF("Lease time[%d]: %u seconds", net_if_get_by_iface(iface),
+			iface->config.dhcpv4.lease_time);
 	}
 }
 
@@ -92,6 +101,6 @@ int main(void)
 
 	net_dhcpv4_add_option_callback(&dhcp_cb);
 
-	net_dhcpv4_start(iface);
+	net_if_foreach(start_dhcpv4_client, NULL);
 	return 0;
 }


### PR DESCRIPTION
Send DHCPv4 requests on all available ipv4 interfaces.

I changed the message to make the log display easier to read when running
the DHCPv4 client on multiple interfaces.

So I reflect it to the sample log exemplified in the document.