### PR TITLE
[Backport v2.7] tests: posix: pthread: init pthread_attr_t on each iteration

### DIFF
--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -563,7 +563,6 @@ void test_posix_pthread_create_negative(void)
 
 void test_pthread_descriptor_leak(void)
 {
-	void *unused;
 	pthread_t pthread1;
 	pthread_attr_t attr;
 

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -567,13 +567,12 @@ void test_pthread_descriptor_leak(void)
 	pthread_t pthread1;
 	pthread_attr_t attr;
 
-	zassert_ok(pthread_attr_init(&attr), NULL);
-	zassert_ok(pthread_attr_setstack(&attr, &stack_e[0][0], STACKS), NULL);
-
 	/* If we are leaking descriptors, then this loop will never complete */
 	for (size_t i = 0; i < CONFIG_MAX_PTHREAD_COUNT * 2; ++i) {
-		zassert_ok(pthread_create(&pthread1, &attr, create_thread1, NULL),
+		zassert_equal(0, pthread_attr_init(&attr), NULL);
+		zassert_equal(0, pthread_attr_setstack(&attr, &stack_e[0][0], STACKS), NULL);
+		zassert_equal(0, pthread_create(&pthread1, &attr, create_thread1, NULL),
 			   "unable to create thread %zu", i);
-		zassert_ok(pthread_join(pthread1, &unused), "unable to join thread %zu", i);
+		zassert_equal(0, pthread_join(pthread1, NULL), "unable to join thread %zu", i);
 	}
 }


### PR DESCRIPTION
Backport 7c17bda3c23ed1ea33aa65df2732ac9a586640a4..12ed08a2fb02515b2469f3e7d0f91ae4b03ea83e from https://github.com/zephyrproject-rtos/zephyr/pull/57403

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/56163