### PR TITLE
test: dma: mitigate warnings and provide 64 bit dma support

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -77,8 +77,13 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 	TC_PRINT("Starting the transfer\n");
 	(void)memset(rx_data, 0, sizeof(rx_data));
 	dma_block_cfg.block_size = sizeof(tx_data);
+#ifdef CONFIG_DMA_64BIT
+	dma_block_cfg.source_address = (uint64_t)tx_data;
+	dma_block_cfg.dest_address = (uint64_t)rx_data;
+#else
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data;
+#endif
 
 	if (dma_config(dma, chan_id, &dma_cfg)) {
 		TC_PRINT("ERROR: transfer\n");

--- a/tests/drivers/dma/chan_blen_transfer/testcase.yaml
+++ b/tests/drivers/dma/chan_blen_transfer/testcase.yaml
@@ -3,4 +3,4 @@ tests:
     min_ram: 16
     depends_on: dma
     tags: drivers dma
-    filter: dt_nodelabel_enabled("test_dma")
+    filter: dt_nodelabel_enabled("test_dma0")

--- a/tests/drivers/dma/chan_link_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_link_transfer/src/test_dma.c
@@ -86,8 +86,13 @@ static int test_task(int minor, int major)
 	(void)memset(rx_data2, 0, sizeof(rx_data2));
 
 	dma_block_cfg.block_size = sizeof(tx_data);
+#ifdef CONFIG_DMA_64BIT
+	dma_block_cfg.source_address = (uint64_t)tx_data;
+	dma_block_cfg.dest_address = (uint64_t)rx_data2;
+#else
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data2;
+#endif
 
 	if (dma_config(dma, TEST_DMA_CHANNEL_1, &dma_cfg)) {
 		TC_PRINT("ERROR: transfer\n");
@@ -103,8 +108,13 @@ static int test_task(int minor, int major)
 	dma_cfg.linked_channel = TEST_DMA_CHANNEL_1;
 
 	dma_block_cfg.block_size = sizeof(tx_data);
+#ifdef CONFIG_DMA_64BIT
+	dma_block_cfg.source_address = (uint64_t)tx_data;
+	dma_block_cfg.dest_address = (uint64_t)rx_data;
+#else
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data;
+#endif
 
 	if (dma_config(dma, TEST_DMA_CHANNEL_0, &dma_cfg)) {
 		TC_PRINT("ERROR: transfer\n");

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -80,8 +80,13 @@ static void test_transfer(const struct device *dev, uint32_t id)
 	transfer_count++;
 	if (transfer_count < TRANSFER_LOOPS) {
 		dma_block_cfg.block_size = strlen(tx_data);
+#ifdef CONFIG_DMA_64BIT
+		dma_block_cfg.source_address = (uint64_t)tx_data;
+		dma_block_cfg.dest_address = (uint64_t)rx_data[transfer_count];
+#else
 		dma_block_cfg.source_address = (uint32_t)tx_data;
 		dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];
+#endif
 
 		zassert_false(dma_config(dev, id, &dma_cfg),
 					"Not able to config transfer %d",
@@ -160,8 +165,13 @@ static int test_loop(const struct device *dma)
 	done = 0;
 	TC_PRINT("Starting the transfer on channel %d and waiting for 1 second\n", chan_id);
 	dma_block_cfg.block_size = strlen(tx_data);
+#ifdef CONFIG_DMA_64BIT
+	dma_block_cfg.source_address = (uint64_t)tx_data;
+	dma_block_cfg.dest_address = (uint64_t)rx_data[transfer_count];
+#else
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];
+#endif
 
 	if (dma_config(dma, chan_id, &dma_cfg)) {
 		TC_PRINT("ERROR: transfer config (%d)\n", chan_id);
@@ -245,8 +255,13 @@ static int test_loop_suspend_resume(const struct device *dma)
 	done = 0;
 	TC_PRINT("Starting the transfer on channel %d and waiting for 1 second\n", chan_id);
 	dma_block_cfg.block_size = strlen(tx_data);
+#ifdef CONFIG_DMA_64BIT
+	dma_block_cfg.source_address = (uint64_t)tx_data;
+	dma_block_cfg.dest_address = (uint64_t)rx_data[transfer_count];
+#else
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];
+#endif
 
 	unsigned int irq_key;
 
@@ -421,8 +436,13 @@ static int test_loop_repeated_start_stop(const struct device *dma)
 	done = 0;
 	TC_PRINT("Starting the transfer on channel %d and waiting for 1 second\n", chan_id);
 	dma_block_cfg.block_size = strlen(tx_data);
+#ifdef CONFIG_DMA_64BIT
+	dma_block_cfg.source_address = (uint64_t)tx_data;
+	dma_block_cfg.dest_address = (uint64_t)rx_data[transfer_count];
+#else
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];
+#endif
 
 	if (dma_config(dma, chan_id, &dma_cfg)) {
 		TC_PRINT("ERROR: transfer config (%d)\n", chan_id);

--- a/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
+++ b/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
@@ -102,11 +102,19 @@ static int test_sg(void)
 	for (int i = 0; i < XFERS; i++) {
 		dma_block_cfgs[i].source_gather_en = 1U;
 		dma_block_cfgs[i].block_size = XFER_SIZE;
+#ifdef CONFIG_DMA_64BIT
+		dma_block_cfgs[i].source_address = (uint64_t)(tx_data);
+		dma_block_cfgs[i].dest_address = (uint64_t)(rx_data[i]);
+		TC_PRINT("dma block %d block_size %d, source addr %" PRIx64 ", dest addr %"
+		     PRIx64 "\n", i, XFER_SIZE, dma_block_cfgs[i].source_address,
+			 dma_block_cfgs[i].dest_address);
+#else
 		dma_block_cfgs[i].source_address = (uint32_t)(tx_data);
 		dma_block_cfgs[i].dest_address = (uint32_t)(rx_data[i]);
 		TC_PRINT("dma block %d block_size %d, source addr %x, dest addr %x\n",
 			 i, XFER_SIZE, dma_block_cfgs[i].source_address,
 			 dma_block_cfgs[i].dest_address);
+#endif
 		if (i < XFERS - 1) {
 			dma_block_cfgs[i].next_block = &dma_block_cfgs[i+1];
 			TC_PRINT("set next block pointer to %p\n", dma_block_cfgs[i].next_block);


### PR DESCRIPTION
5 commits - please see each commit message for details.

* tests: drivers: dma: chan_blen: support 64-bit dma
* tests: drivers: dma: chan_link: support 64-bit dma
* tests: drivers: dma: loop: support 64-bit dma
* tests: drivers: dma: sg: support 64-bit dma
* tests: drivers: dma: chan_blen: correct nodelabel filter

Fixes #57419