### PR TITLE
LCDIF and DCNANO performance improvements for LVGL

### DIFF
--- a/boards/arm/mimxrt1060_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1060_evk/Kconfig.defconfig
@@ -1,6 +1,6 @@
 # MIMXRT1060-EVK board
 
-# Copyright (c) 2018, NXP
+# Copyright 2018,2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_MIMXRT1060_EVK || BOARD_MIMXRT1060_EVK_HYPERFLASH || BOARD_MIMXRT1060_EVKB
@@ -56,11 +56,29 @@ if LVGL
 config LV_Z_POINTER_KSCAN
 	default y
 
+# LVGL should allocate buffers equal to size of display
 config LV_Z_VDB_SIZE
-	default 16
+	default 100
+
+# Enable double buffering
+config LV_Z_DOUBLE_VDB
+	default y
+
+# Force full refresh. This prevents memory copy associated with partial
+# display refreshes, which is not necessary for the eLCDIF driver
+config LV_Z_FULL_REFRESH
+	default y
 
 config LV_Z_DPI
 	default 128
+
+config LV_Z_BITS_PER_PIXEL
+	default 16
+
+# Force display buffers to be aligned to cache line size (32 bytes)
+config LV_Z_VDB_ALIGN
+	default 32
+
 
 choice LV_COLOR_DEPTH
 	default LV_COLOR_DEPTH_16

--- a/boards/arm/mimxrt1170_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1170_evk/Kconfig.defconfig
@@ -1,6 +1,6 @@
 # MIMXRT1170-EVK board
 
-# Copyright (c) 2021, NXP
+# Copyright 2021,2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_MIMXRT1170_EVK_CM7 || BOARD_MIMXRT1170_EVK_CM4
@@ -81,7 +81,20 @@ if LVGL
 config LV_Z_POINTER_KSCAN
 	default y
 
+# LVGL should allocate buffers equal to size of display
 config LV_Z_VDB_SIZE
+	default 100
+
+# Enable double buffering
+config LV_Z_DOUBLE_VDB
+	default y
+
+# Force full refresh. This prevents memory copy associated with partial
+# display refreshes, which is not necessary for the eLCDIF driver
+config LV_Z_FULL_REFRESH
+	default y
+
+config LV_Z_BITS_PER_PIXEL
 	default 16
 
 config LV_Z_DPI

--- a/boards/arm/mimxrt595_evk/CMakeLists.txt
+++ b/boards/arm/mimxrt595_evk/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -23,3 +23,7 @@ if(CONFIG_NXP_IMX_RT5XX_BOOT_HEADER)
   zephyr_library_sources(${RT595_BOARD_DIR}/flash_config/flash_config.c)
   zephyr_library_include_directories(${RT595_BOARD_DIR}/flash_config)
 endif()
+
+# Add custom linker section to relocate framebuffers to PSRAM
+zephyr_linker_sources_ifdef(CONFIG_LV_Z_VBD_CUSTOM_SECTION
+  SECTIONS dc_ram.ld)

--- a/boards/arm/mimxrt595_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt595_evk/Kconfig.defconfig
@@ -41,6 +41,8 @@ config MCUX_DCNANO_LCDIF_EXTERNAL_FB_MEM
 	default y
 # Use FlexSPI2 base address for framebuffer (pSRAM is present on this bus)
 config MCUX_DCNANO_LCDIF_EXTERNAL_FB_ADDR
+	# Move DCNANO framebuffer if LVGL framebuffers are also in PSRAM
+	default 0x38400000 if LV_Z_VBD_CUSTOM_SECTION
 	default 0x38000000
 # M33 core and LCDIF both access FlexSPI2 through the same cache,
 # so coherency does not need to be managed.
@@ -53,6 +55,34 @@ config KSCAN
 	default y if LVGL
 
 if LVGL
+
+# LVGL should allocate buffers equal to size of display
+config LV_Z_VDB_SIZE
+	default 100
+
+# Enable double buffering
+config LV_Z_DOUBLE_VDB
+	default y
+
+# Force full refresh. This prevents memory copy associated with partial
+# display refreshes, which is not necessary for the eLCDIF driver
+config LV_Z_FULL_REFRESH
+	default y
+
+config LV_Z_DPI
+	default 128
+
+config LV_Z_BITS_PER_PIXEL
+	default 16
+
+# Force display buffers to be aligned for DCNANO LCDIF (128 byte alignment)
+config LV_Z_VDB_ALIGN
+	default 128
+
+# LVGL display buffers will be too large for internal SRAM, locate in
+# custom section within PSRAM
+config LV_Z_VBD_CUSTOM_SECTION
+	default y
 
 config LV_Z_POINTER_KSCAN
 	default y

--- a/boards/arm/mimxrt595_evk/board.c
+++ b/boards/arm/mimxrt595_evk/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022,  NXP
+ * Copyright 2022-2023 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -98,9 +98,33 @@ static int mimxrt595_evk_init(void)
 	return 0;
 }
 
+
+#ifdef CONFIG_LV_Z_VBD_CUSTOM_SECTION
+extern char __flexspi2_start[];
+extern char __flexspi2_end[];
+
+static int init_psram_framebufs(void)
+{
+	/*
+	 * Framebuffers will be stored in PSRAM, within FlexSPI2 linker
+	 * section. Zero out BSS section.
+	 */
+	memset(__flexspi2_start, 0, __flexspi2_end - __flexspi2_start);
+	return 0;
+}
+
+#endif /* CONFIG_LV_Z_VBD_CUSTOM_SECTION */
+
 #if CONFIG_REGULATOR
 /* PMIC setup is dependent on the regulator API */
 SYS_INIT(board_config_pmic, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
+#endif
+
+#ifdef CONFIG_LV_Z_VBD_CUSTOM_SECTION
+/* Framebuffers should be setup after PSRAM is initialized but before
+ * Graphics framework init
+ */
+SYS_INIT(init_psram_framebufs, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
 #endif
 
 SYS_INIT(mimxrt595_evk_init, PRE_KERNEL_1, CONFIG_BOARD_INIT_PRIORITY);

--- a/boards/arm/mimxrt595_evk/dc_ram.ld
+++ b/boards/arm/mimxrt595_evk/dc_ram.ld
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/linker/linker-tool.h>
+
+
+GROUP_START(FLEXSPI2)
+	SECTION_PROLOGUE(.flexspi2_bss,(NOLOAD),SUBALIGN(4))
+	{
+		__flexspi2_start = .;
+		*(.lvgl_buf);
+		__flexspi2_end = .;
+	} GROUP_LINK_IN(FLEXSPI2)

--- a/drivers/display/Kconfig.mcux_dcnano_lcdif
+++ b/drivers/display/Kconfig.mcux_dcnano_lcdif
@@ -12,14 +12,19 @@ menuconfig DISPLAY_MCUX_DCNANO_LCDIF
 
 if DISPLAY_MCUX_DCNANO_LCDIF
 
-config MCUX_DCNANO_LCDIF_DOUBLE_FRAMEBUFFER
-	bool "Double framebuffer"
+config MCUX_DCNANO_LCDIF_FB_NUM
+	int "Framebuffers to allocate in driver"
+	default 1
+	range 0 2
 	help
-	  Enable dual framebuffer for LCDIF peripheral. Two framebuffers
-	  will be allocated, and switched between for each frame.
-	  Note that for partial display updates, the prior framebuffer must
-	  be copied into the next one. This can have significant performance
-	  impact.
+	  Number of framebuffers to allocate in DCNANO driver. Driver allocated
+	  framebuffers are required to support partial display updates.
+	  The driver has been validated to support 0 through 2 framebuffers.
+	  Note that hardware will likely perform best if zero driver
+	  framebuffers are allocated by the driver, and the application
+	  implements double framebuffering by always calling display_write with
+	  a buffer equal in size to the connected panel.
+
 
 config MCUX_DCNANO_LCDIF_MAINTAIN_CACHE
 	bool "Maintain cache coherency"

--- a/drivers/display/Kconfig.mcux_elcdif
+++ b/drivers/display/Kconfig.mcux_elcdif
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NXP
+# Copyright 2019,2023 NXP
 # Copyright (c) 2022, Basalte bv
 # SPDX-License-Identifier: Apache-2.0
 
@@ -12,10 +12,24 @@ menuconfig DISPLAY_MCUX_ELCDIF
 
 if DISPLAY_MCUX_ELCDIF
 
-config MCUX_ELCDIF_DOUBLE_FRAMEBUFFER
-	bool "Double framebuffer"
-	default y
+config MCUX_ELCDIF_FB_NUM
+	int "Framebuffers to allocate in driver"
+	default 2
+	range 0 2
 	help
-	  Optionally use two framebuffers and alternate between them.
+	  Number of framebuffers to allocate in ELCDIF driver. Driver allocated
+	  framebuffers are required to support partial display updates.
+	  The driver has been validated to support 0 through 2 framebuffers.
+	  Note that hardware will likely perform best if zero driver
+	  framebuffers are allocated by the driver, and the application
+	  implements double framebuffering by always calling display_write with
+	  a buffer equal in size to the connected panel.
+
+	  NOTE: when no framebuffers are allocated, the ELCDIF will be
+	  set to display an empty buffer during initialization. This means
+	  the display will show what is effectively a dump of
+	  system RAM until a new framebuffer is written. If the security
+	  implications of this concern you, leave at least one driver
+	  framebuffer enabled.
 
 endif # DISPLAY_MCUX_ELCDIF

--- a/drivers/display/display_mcux_dcnano_lcdif.c
+++ b/drivers/display/display_mcux_dcnano_lcdif.c
@@ -20,12 +20,6 @@
 
 LOG_MODULE_REGISTER(display_mcux_dcnano_lcdif, CONFIG_DISPLAY_LOG_LEVEL);
 
-#ifdef CONFIG_MCUX_DCNANO_LCDIF_DOUBLE_FRAMEBUFFER
-#define MCUX_DCNANO_LCDIF_FB_NUM 2
-#else
-#define MCUX_DCNANO_LCDIF_FB_NUM 1
-#endif
-
 struct mcux_dcnano_lcdif_config {
 	LCDIF_Type *base;
 	void (*irq_config_func)(const struct device *dev);
@@ -38,11 +32,14 @@ struct mcux_dcnano_lcdif_config {
 };
 
 struct mcux_dcnano_lcdif_data {
-	uint8_t *fb[MCUX_DCNANO_LCDIF_FB_NUM];
-	uint8_t fb_idx;
+	/* Pointer to active framebuffer */
+	const uint8_t *active_fb;
+	uint8_t *fb[CONFIG_MCUX_DCNANO_LCDIF_FB_NUM];
 	lcdif_fb_config_t fb_config;
 	uint8_t pixel_bytes;
 	struct k_sem sem;
+	/* Tracks index of next active driver framebuffer */
+	uint8_t next_idx;
 };
 
 static int mcux_dcnano_lcdif_write(const struct device *dev, const uint16_t x,
@@ -52,7 +49,6 @@ static int mcux_dcnano_lcdif_write(const struct device *dev, const uint16_t x,
 {
 	const struct mcux_dcnano_lcdif_config *config = dev->config;
 	struct mcux_dcnano_lcdif_data *data = dev->data;
-	uint8_t next_fb_idx = (data->fb_idx + 1) % MCUX_DCNANO_LCDIF_FB_NUM;
 	uint32_t h_idx;
 	const uint8_t *src;
 	uint8_t *dst;
@@ -62,49 +58,64 @@ static int mcux_dcnano_lcdif_write(const struct device *dev, const uint16_t x,
 
 	LOG_DBG("W=%d, H=%d @%d,%d", desc->width, desc->height, x, y);
 
-#ifdef CONFIG_MCUX_DCNANO_LCDIF_DOUBLE_FRAMEBUFFER
-	/* If display write is partial, copy current framebuffer to
-	 * queued one. Note- this has a significant performance
-	 * impact, especially when using external RAM.
-	 */
-	if ((x != 0) ||
-		(y != 0) ||
-		(desc->height != config->dpi_config.panelHeight) ||
-		(desc->width != config->dpi_config.panelWidth)) {
-		memcpy(data->fb[next_fb_idx], data->fb[data->fb_idx],
-			config->fb_bytes);
-	}
-#endif
+	if ((x == 0) && (y == 0) &&
+		(desc->width == config->dpi_config.panelWidth) &&
+		(desc->height == config->dpi_config.panelHeight) &&
+		(desc->pitch == desc->width)) {
+		/* We can use the display buffer directly, without copying */
+		LOG_DBG("Setting FB from %p->%p",
+			(void *)data->active_fb, (void *)buf);
+		data->active_fb = buf;
+	} else {
+		/* We must use partial framebuffer copy */
+		if (CONFIG_MCUX_DCNANO_LCDIF_FB_NUM == 0)  {
+			LOG_ERR("Partial display refresh requires driver framebuffers");
+			return -ENOTSUP;
+		} else if (data->active_fb != data->fb[data->next_idx]) {
+			/*
+			 * Copy the entirety of the current framebuffer to new
+			 * buffer, since we are changing the active buffer address
+			 */
+			src = data->active_fb;
+			dst = data->fb[data->next_idx];
+			memcpy(dst, src, config->fb_bytes);
+		}
+		/* Write the display update to the active framebuffer */
+		src = buf;
+		dst = data->fb[data->next_idx];
+		dst += data->pixel_bytes * (y * config->dpi_config.panelWidth + x);
 
-
-	src = buf;
-	dst = data->fb[next_fb_idx];
-	dst += data->pixel_bytes * ((y * config->dpi_config.panelWidth) + x);
-
-	for (h_idx = 0; h_idx < desc->height; h_idx++) {
-		memcpy(dst, src, data->pixel_bytes * desc->width);
-		src += data->pixel_bytes * desc->pitch;
-		dst += data->pixel_bytes * config->dpi_config.panelWidth;
+		for (h_idx = 0; h_idx < desc->height; h_idx++) {
+			memcpy(dst, src, data->pixel_bytes * desc->width);
+			src += data->pixel_bytes * desc->pitch;
+			dst += data->pixel_bytes * config->dpi_config.panelWidth;
+		}
+		LOG_DBG("Setting FB from %p->%p", (void *) data->active_fb,
+			(void *) data->fb[data->next_idx]);
+		/* Set new active framebuffer */
+		data->active_fb = data->fb[data->next_idx];
 	}
 
 #if defined(CONFIG_HAS_MCUX_CACHE) && defined(CONFIG_MCUX_DCNANO_LCDIF_MAINTAIN_CACHE)
-	CACHE64_InvalidateCacheByRange((uint32_t) data->fb[next_fb_idx],
+	CACHE64_CleanCacheByRange((uint32_t) data->active_fb,
 					config->fb_bytes);
 #endif
 
-
-	/* Wait for framebuffer completion before writing */
-	k_sem_take(&data->sem, K_FOREVER);
+	k_sem_reset(&data->sem);
 
 	/* Set new framebuffer */
 	LCDIF_SetFrameBufferStride(config->base, 0,
 		config->dpi_config.panelWidth * data->pixel_bytes);
 	LCDIF_SetFrameBufferAddr(config->base, 0,
-		(uint32_t)data->fb[next_fb_idx]);
+		(uint32_t)data->active_fb);
 	LCDIF_SetFrameBufferConfig(config->base, 0, &data->fb_config);
 
-	/* Update current framebuffer IDX */
-	data->fb_idx = next_fb_idx;
+#if CONFIG_MCUX_DCNANO_LCDIF_FB_NUM != 0
+	/* Update index of active framebuffer */
+	data->next_idx = (data->next_idx + 1) % CONFIG_MCUX_DCNANO_LCDIF_FB_NUM;
+#endif
+	/* Wait for frame to complete */
+	k_sem_take(&data->sem, K_FOREVER);
 
 	return 0;
 }
@@ -139,13 +150,9 @@ static void mcux_dcnano_lcdif_get_capabilities(const struct device *dev,
 
 static void *mcux_dcnano_lcdif_get_framebuffer(const struct device *dev)
 {
-	const struct mcux_dcnano_lcdif_config *config = dev->config;
+	struct mcux_dcnano_lcdif_data *data = dev->data;
 
-	if (IS_ENABLED(CONFIG_MCUX_DCNANO_LCDIF_DOUBLE_FRAMEBUFFER)) {
-		return NULL; /* Direct framebuffer access not supported */
-	} else {
-		return config->fb_ptr;
-	}
+	return (void *)data->active_fb;
 }
 
 static int mcux_dcnano_lcdif_display_blanking_off(const struct device *dev)
@@ -218,16 +225,17 @@ static int mcux_dcnano_lcdif_init(const struct device *dev)
 	LCDIF_EnableInterrupts(config->base, kLCDIF_Display0FrameDoneInterrupt);
 	config->irq_config_func(dev);
 
-	data->fb[0] = config->fb_ptr;
-#ifdef CONFIG_MCUX_DCNANO_LCDIF_DOUBLE_FRAMEBUFFER
-	data->fb[1] = config->fb_ptr + config->fb_bytes;
-#endif
+	for (int i = 0; i < CONFIG_MCUX_DCNANO_LCDIF_FB_NUM; i++) {
+		/* Record pointers to each driver framebuffer */
+		data->fb[i] = config->fb_ptr + (config->fb_bytes * i);
+	}
+	data->active_fb = config->fb_ptr;
 
 	k_sem_init(&data->sem, 1, 1);
 
 #ifdef CONFIG_MCUX_DCNANO_LCDIF_EXTERNAL_FB_MEM
 	/* Clear external memory, as it is uninitialized */
-	memset(config->fb_ptr, 0, config->fb_bytes * MCUX_DCNANO_LCDIF_FB_NUM);
+	memset(config->fb_ptr, 0, config->fb_bytes * CONFIG_MCUX_DCNANO_LCDIF_FB_NUM);
 #endif
 
 	return 0;
@@ -263,9 +271,9 @@ static const struct display_driver_api mcux_dcnano_lcdif_api = {
 		mcux_dcnano_lcdif_frame_buffer_##n[DT_INST_PROP(n, width) *	\
 					 DT_INST_PROP(n, height) *		\
 					 MCUX_DCNANO_LCDIF_PIXEL_BYTES(n) *	\
-					 MCUX_DCNANO_LCDIF_FB_NUM]
+					 CONFIG_MCUX_DCNANO_LCDIF_FB_NUM]
 #define MCUX_DCNANO_LCDIF_FB_SIZE(n)						\
-	sizeof(mcux_dcnano_lcdif_frame_buffer_##n) / MCUX_DCNANO_LCDIF_FB_NUM
+	sizeof(mcux_dcnano_lcdif_frame_buffer_##n) / CONFIG_MCUX_DCNANO_LCDIF_FB_NUM
 #define MCUX_DCNANO_LCDIF_FRAMEBUFFER(n) mcux_dcnano_lcdif_frame_buffer_##n
 #endif
 
@@ -286,6 +294,7 @@ static const struct display_driver_api mcux_dcnano_lcdif_api = {
 			.enableGamma = false,					\
 			.format = DT_INST_ENUM_IDX(n, pixel_format),		\
 		},								\
+		.next_idx = 0,							\
 		.pixel_bytes = MCUX_DCNANO_LCDIF_PIXEL_BYTES(n),		\
 	};									\
 	struct mcux_dcnano_lcdif_config mcux_dcnano_lcdif_config_##n = {	\

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-22, NXP
+ * Copyright 2019-23, NXP
  * Copyright (c) 2022, Basalte bv
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -22,12 +22,6 @@
 
 LOG_MODULE_REGISTER(display_mcux_elcdif, CONFIG_DISPLAY_LOG_LEVEL);
 
-#ifdef CONFIG_MCUX_ELCDIF_DOUBLE_FRAMEBUFFER
-#define MCUX_ELCDIF_FB_NUM 2
-#else
-#define MCUX_ELCDIF_FB_NUM 1
-#endif
-
 struct mcux_elcdif_config {
 	LCDIF_Type *base;
 	void (*irq_config_func)(const struct device *dev);
@@ -37,13 +31,17 @@ struct mcux_elcdif_config {
 	size_t fb_bytes;
 	const struct pinctrl_dev_config *pincfg;
 	const struct gpio_dt_spec backlight_gpio;
+	uint8_t *fb_ptr;
 };
 
 struct mcux_elcdif_data {
-	uint8_t *fb_ptr;
-	uint8_t *fb[MCUX_ELCDIF_FB_NUM];
+	/* Pointer to active framebuffer */
+	const uint8_t *active_fb;
+	/* Pointers to driver allocated framebuffers */
+	uint8_t *fb[CONFIG_MCUX_ELCDIF_FB_NUM];
 	struct k_sem sem;
-	uint8_t write_idx;
+	/* Tracks index of next active driver framebuffer */
+	uint8_t next_idx;
 };
 
 static int mcux_elcdif_write(const struct device *dev, const uint16_t x,
@@ -53,9 +51,6 @@ static int mcux_elcdif_write(const struct device *dev, const uint16_t x,
 {
 	const struct mcux_elcdif_config *config = dev->config;
 	struct mcux_elcdif_data *dev_data = dev->data;
-
-	uint8_t write_idx = (dev_data->write_idx + 1) % MCUX_ELCDIF_FB_NUM;
-
 	int h_idx;
 	const uint8_t *src;
 	uint8_t *dst;
@@ -65,39 +60,65 @@ static int mcux_elcdif_write(const struct device *dev, const uint16_t x,
 
 	LOG_DBG("W=%d, H=%d, @%d,%d", desc->width, desc->height, x, y);
 
-#ifdef CONFIG_MCUX_ELCDIF_DOUBLE_FRAMEBUFFER
-	k_sem_take(&dev_data->sem, K_FOREVER);
 
-	memcpy(dev_data->fb[write_idx], dev_data->fb[dev_data->write_idx],
-	       config->fb_bytes);
-#else
-	/* wait for the next frame done */
-	k_sem_reset(&dev_data->sem);
-	k_sem_take(&dev_data->sem, K_FOREVER);
-#endif
+	if ((x == 0) && (y == 0) &&
+	    (desc->width == config->rgb_mode.panelWidth) &&
+	    (desc->height == config->rgb_mode.panelHeight) &&
+	    (desc->pitch == desc->width)) {
+		/* We can use the display buffer directly, no need to copy it */
+		LOG_DBG("Setting FB from %p->%p",
+			(void *) dev_data->active_fb, (void *) buf);
+		dev_data->active_fb = buf;
+	} else {
+		/* We must use partial framebuffer copy */
+		if (CONFIG_MCUX_ELCDIF_FB_NUM == 0) {
+			LOG_ERR("Partial display refresh requires driver framebuffers");
+			return -ENOTSUP;
+		} else if (dev_data->active_fb != dev_data->fb[dev_data->next_idx]) {
+			/*
+			 * We must copy the entire current framebuffer to new
+			 * buffer, since we wil change the active buffer
+			 * address
+			 */
+			src = dev_data->active_fb;
+			dst = dev_data->fb[dev_data->next_idx];
+			memcpy(dst, src, config->fb_bytes);
+		}
+		/* Now, write the display update into active framebuffer */
+		src = buf;
+		dst = dev_data->fb[dev_data->next_idx];
+		dst += config->pixel_bytes * (y * config->rgb_mode.panelWidth + x);
 
-	src = buf;
-	dst = dev_data->fb[write_idx];
-	dst += config->pixel_bytes * (y * config->rgb_mode.panelWidth + x);
+		for (h_idx = 0; h_idx < desc->height; h_idx++) {
+			memcpy(dst, src, config->pixel_bytes * desc->width);
+			src += config->pixel_bytes * desc->pitch;
+			dst += config->pixel_bytes * config->rgb_mode.panelWidth;
+		}
 
-	for (h_idx = 0; h_idx < desc->height; h_idx++) {
-		memcpy(dst, src, config->pixel_bytes * desc->width);
-		src += config->pixel_bytes * desc->pitch;
-		dst += config->pixel_bytes * config->rgb_mode.panelWidth;
+		LOG_DBG("Setting FB from %p->%p", (void *) dev_data->active_fb,
+			(void *) dev_data->fb[dev_data->next_idx]);
+		/* Set new active framebuffer */
+		dev_data->active_fb = dev_data->fb[dev_data->next_idx];
 	}
 
+
 #ifdef CONFIG_HAS_MCUX_CACHE
-	DCACHE_CleanByRange((uint32_t) dev_data->fb[write_idx],
-			    config->fb_bytes);
+	DCACHE_CleanByRange((uint32_t) dev_data->active_fb, config->fb_bytes);
 #endif
 
-#ifdef CONFIG_MCUX_ELCDIF_DOUBLE_FRAMEBUFFER
-	ELCDIF_SetNextBufferAddr(config->base,
-				 (uint32_t) dev_data->fb[write_idx]);
+	/* Queue next framebuffer */
+	ELCDIF_SetNextBufferAddr(config->base, (uint32_t)dev_data->active_fb);
+
+#if CONFIG_MCUX_ELCDIF_FB_NUM != 0
+		/* Update index of active framebuffer */
+		dev_data->next_idx =
+			(dev_data->next_idx + 1) % CONFIG_MCUX_ELCDIF_FB_NUM;
 #endif
-
-	dev_data->write_idx = write_idx;
-
+	/* Enable frame buffer completion interrupt */
+	ELCDIF_EnableInterrupts(config->base,
+				kELCDIF_CurFrameDoneInterruptEnable);
+	/* Wait for frame send to complete */
+	k_sem_take(&dev_data->sem, K_FOREVER);
 	return 0;
 }
 
@@ -112,14 +133,14 @@ static int mcux_elcdif_read(const struct device *dev, const uint16_t x,
 
 static void *mcux_elcdif_get_framebuffer(const struct device *dev)
 {
-#ifdef CONFIG_MCUX_ELCDIF_DOUBLE_FRAMEBUFFER
+	/*
+	 * Direct FB access is not available. If the user wants to set
+	 * the framebuffer directly, they must provide a buffer to
+	 * `display_write` equal in size to the connected display,
+	 * with coordinates [0,0]
+	 */
 	LOG_ERR("Direct framebuffer access not available");
 	return NULL;
-#else
-	struct mcux_elcdif_data *dev_data = dev->data;
-
-	return dev_data->fb_ptr;
-#endif
 }
 
 static int mcux_elcdif_display_blanking_off(const struct device *dev)
@@ -194,8 +215,14 @@ static void mcux_elcdif_isr(const struct device *dev)
 
 	status = ELCDIF_GetInterruptStatus(config->base);
 	ELCDIF_ClearInterruptStatus(config->base, status);
-
-	k_sem_give(&dev_data->sem);
+	if (config->base->CUR_BUF == ((uint32_t)dev_data->active_fb)) {
+		/* Disable frame completion interrupt, post to
+		 * sem to notify that frame send is complete.
+		 */
+		ELCDIF_DisableInterrupts(config->base,
+					kELCDIF_CurFrameDoneInterruptEnable);
+		k_sem_give(&dev_data->sem);
+	}
 }
 
 static int mcux_elcdif_init(const struct device *dev)
@@ -226,20 +253,19 @@ static int mcux_elcdif_init(const struct device *dev)
 		rgb_mode.pixelFormat = kELCDIF_PixelFormatRGB888;
 	}
 
-	dev_data->fb[0] = dev_data->fb_ptr;
-#ifdef CONFIG_MCUX_ELCDIF_DOUBLE_FRAMEBUFFER
-	dev_data->fb[1] = dev_data->fb_ptr + config->fb_bytes;
-#endif
+	for (int i = 0; i < CONFIG_MCUX_ELCDIF_FB_NUM; i++) {
+		/* Record pointers to each driver framebuffer */
+		dev_data->fb[i] = config->fb_ptr + (config->fb_bytes * i);
+	}
 
-	rgb_mode.bufferAddr = (uint32_t) dev_data->fb_ptr;
+	rgb_mode.bufferAddr = (uint32_t) config->fb_ptr;
+	dev_data->active_fb = config->fb_ptr;
 
-	k_sem_init(&dev_data->sem, 1, 1);
+	k_sem_init(&dev_data->sem, 0, 1);
 
 	config->irq_config_func(dev);
 
 	ELCDIF_RgbModeInit(config->base, &rgb_mode);
-	ELCDIF_EnableInterrupts(config->base,
-				kELCDIF_CurFrameDoneInterruptEnable);
 	ELCDIF_RgbModeStart(config->base);
 
 	return 0;
@@ -264,6 +290,10 @@ static const struct display_driver_api mcux_elcdif_api = {
 #define MCUX_ELCDIF_DEVICE_INIT(id)						\
 	PINCTRL_DT_INST_DEFINE(id);						\
 	static void mcux_elcdif_config_func_##id(const struct device *dev);	\
+	static uint8_t __aligned(64) frame_buffer_##id[CONFIG_MCUX_ELCDIF_FB_NUM\
+			* DT_INST_PROP(id, width)				\
+			* DT_INST_PROP(id, height)				\
+			* MCUX_ELCDIF_PIXEL_BYTES(id)];				\
 	static const struct mcux_elcdif_config mcux_elcdif_config_##id = {	\
 		.base = (LCDIF_Type *) DT_INST_REG_ADDR(id),			\
 		.irq_config_func = mcux_elcdif_config_func_##id,		\
@@ -288,13 +318,10 @@ static const struct display_driver_api mcux_elcdif_api = {
 			* MCUX_ELCDIF_PIXEL_BYTES(id),				\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),			\
 		.backlight_gpio = GPIO_DT_SPEC_INST_GET(id, backlight_gpios),	\
-	};									\
-	static uint8_t __aligned(64) frame_buffer_##id[MCUX_ELCDIF_FB_NUM	\
-			* DT_INST_PROP(id, width)				\
-			* DT_INST_PROP(id, height)				\
-			* MCUX_ELCDIF_PIXEL_BYTES(id)];				\
-	static struct mcux_elcdif_data mcux_elcdif_data_##id = {		\
 		.fb_ptr = frame_buffer_##id,					\
+	};									\
+	static struct mcux_elcdif_data mcux_elcdif_data_##id = {		\
+		.next_idx = 0,							\
 	};									\
 	DEVICE_DT_INST_DEFINE(id,						\
 			    &mcux_elcdif_init,					\

--- a/soc/arm/nxp_imx/rt5xx/linker.ld
+++ b/soc/arm/nxp_imx/rt5xx/linker.ld
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NXP
+ * Copyright 2021,2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,4 +9,16 @@
  *
  * This is the linker script for both standard images and XIP images.
  */
+
+#include <zephyr/devicetree.h>
+
+ MEMORY
+     {
+#if (DT_REG_SIZE_BY_IDX(DT_NODELABEL(flexspi1), 1) > 0)
+        FLEXSPI1  (wx) : ORIGIN = DT_REG_ADDR_BY_IDX(DT_NODELABEL(flexspi1), 1), LENGTH = DT_REG_SIZE_BY_IDX(DT_NODELABEL(flexspi1), 1)
+#endif
+#if (DT_REG_SIZE_BY_IDX(DT_NODELABEL(flexspi2), 1) > 0)
+        FLEXSPI2  (wx) : ORIGIN = DT_REG_ADDR_BY_IDX(DT_NODELABEL(flexspi2), 1), LENGTH = DT_REG_SIZE_BY_IDX(DT_NODELABEL(flexspi2), 1)
+#endif
+     }
 #include <zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/west.yml
+++ b/west.yml
@@ -177,7 +177,7 @@ manifest:
       revision: ce57712f3e426bbbb13acaec97b45369f716f43a
       path: modules/lib/loramac-node
     - name: lvgl
-      revision: 1557cb3e4d5c8dc7bb2e8610b686b5acb157903c
+      revision: 7102083f626cda09e5792420ea60af0525cce9ae
       path: modules/lib/gui/lvgl
     - name: lz4
       revision: 8e303c264fc21c2116dc612658003a22e933124d


### PR DESCRIPTION
This PR includes the following updates:

- Updates Zephyr's revision of LVGL to include performance tuning options for the following settings:
    - Enable forcing LVGL to perform a full display refresh on every update
    - Enable custom alignment and linker section location of LVGL framebuffers.
- Updates MCUX ECLDIF and DCNANO drivers to pass the framebuffer in the `display_write` call directly to hardware when possible (ie when the buffer is the same size as the display). This enables the calling application to avoid the expensive memory copies associated with partial display updates by always calling `display_write` with a buffer the same size as the connected display
- Updates LVGL configuration for the RT595, RT1060, and RT1170 EVK with the following settings:
    - Allocate dual LVGL rendering buffers equal in size to the connected display
    - Always refresh the entire display (so that the hardware can use the LVGL rendering buffer directly)
    - For the RT595 EVK, relocate the LVGL rendering buffers to external PSRAM since they will not fit in internal RAM


This results in the following performance improvements in the weighted FPS of the LVGL benchmark sample:

RT595:
3 FPS -> 7 FPS

RT1170:
3 FPS -> 34 FPS

RT1060:
18 FPS -> 65 FPS