### PR TITLE
drivers: ethernet: enc28j60: Prevent infinate loop on driver init

### DIFF
--- a/drivers/ethernet/Kconfig.enc28j60
+++ b/drivers/ethernet/Kconfig.enc28j60
@@ -28,6 +28,16 @@ config ETH_ENC28J60_RX_THREAD_PRIO
 	  Priority level for internal thread which is ran for incoming
 	  packet processing.
 
+config ETH_ENC28J60_CLKRDY_INIT_WAIT_MS
+	int "Time to wait for the CLKRDY bit on driver init"
+	depends on ETH_ENC28J60
+	default 2
+	help
+	  Timeout in milliseconds. Maximum time the initialisation
+	  of the driver will wait for the OST to expire, indicated
+	  by the CLKRDY bit set. If timeout driver init will fail
+	  with -ETIMEDOUT.
+
 config ETH_ENC28J60_TIMEOUT
 	int "IP buffer timeout"
 	depends on ETH_ENC28J60


### PR DESCRIPTION
In the case that there is a situation where the controller oscillator start-up timer doesn't expire, or the SPI can't read the CLKRDY bit the driver would hang during init. The config option ETH_ENC28J60_CLKRDY_INIT_WAIT_MS sets the time that the driver will wait for OST before returning an ETIMEDOUT error.