### PR TITLE
drivers: spi: esp32xx: Fix word size limiting transaction

### DIFF
--- a/drivers/spi/spi_esp32_spim.h
+++ b/drivers/spi/spi_esp32_spim.h
@@ -52,7 +52,6 @@ struct spi_esp32_data {
 	int irq_line;
 	lldesc_t dma_desc_tx;
 	lldesc_t dma_desc_rx;
-	uint8_t word_size;
 };
 
 #endif /* ZEPHYR_DRIVERS_SPI_ESP32_SPIM_H_ */


### PR DESCRIPTION
Word size setting limited any SPI transaction to the frame size. In addition to making the SPI inefficient this broke drivers that set the word size. It appears that most drivers use a one byte (8) size for this setting.
This change respects what I think is the intended use of the word size setting. That is to set the length of each element in a tx/rx buffer struct.

In my use case this change made the driver for the ENC28J60 SPI ethernet controller hang on initialisation.