### PR TITLE
nrf52_bsim: twister yaml: Reduce filtering & fix nrf_rtc_timer driver test for it

### DIFF
--- a/boards/posix/nrf52_bsim/nrf52_bsim.yaml
+++ b/boards/posix/nrf52_bsim/nrf52_bsim.yaml
@@ -9,4 +9,6 @@ toolchain:
   - zephyr
 testing:
   ignore_tags:
-    - drivers
+    - gpio
+    - modem
+    - uart

--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -35,7 +35,7 @@ NET_BUF_POOL_DEFINE(mdm_recv_pool, MDM_RECV_MAX_BUF, MDM_RECV_BUF_SIZE, 0, NULL)
 static const struct gpio_dt_spec power_gpio = GPIO_DT_SPEC_INST_GET(0, mdm_power_gpios);
 
 static void socket_close(struct modem_socket *sock);
-const struct socket_dns_offload offload_dns_ops;
+static const struct socket_dns_offload offload_dns_ops;
 
 static inline uint32_t hash32(char *str, int len)
 {
@@ -756,7 +756,7 @@ static void offload_freeaddrinfo(struct zsock_addrinfo *res)
 /*
  * DNS vtable.
  */
-const struct socket_dns_offload offload_dns_ops = {
+static const struct socket_dns_offload offload_dns_ops = {
 	.getaddrinfo = offload_getaddrinfo,
 	.freeaddrinfo = offload_freeaddrinfo,
 };

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(modem_ublox_sara_r4, CONFIG_MODEM_LOG_LEVEL);
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_offload.h>

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -2034,7 +2034,7 @@ static void offload_freeaddrinfo(struct zsock_addrinfo *res)
 	res = NULL;
 }
 
-const struct socket_dns_offload offload_dns_ops = {
+static const struct socket_dns_offload offload_dns_ops = {
 	.getaddrinfo = offload_getaddrinfo,
 	.freeaddrinfo = offload_freeaddrinfo,
 };

--- a/tests/drivers/build_all/modem/testcase.yaml
+++ b/tests/drivers/build_all/modem/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   build_only: true
-  tags: drivers net
+  tags: drivers net modem
 tests:
   drivers.modem.build:
     extra_args: CONF_FILE=modem.conf

--- a/tests/drivers/timer/nrf_rtc_timer/src/main.c
+++ b/tests/drivers/timer/nrf_rtc_timer/src/main.c
@@ -469,6 +469,7 @@ ZTEST(nrf_rtc_timer, test_next_cycle_timeouts)
 		if ((k_cycle_get_32() - start) > CYCLES_TO_WAIT) {
 			break;
 		}
+		Z_SPIN_DELAY(10);
 	}
 
 	zassert_equal(0, timeouts_left,
@@ -530,6 +531,7 @@ ZTEST(nrf_rtc_timer, test_tight_rescheduling)
 			while (!expired &&
 				(z_nrf_rtc_timer_read() - start) <
 					CYCLE_DIFF + 10) {
+				Z_SPIN_DELAY(10);
 			}
 			zassert_true(expired,
 				"Timeout expiration missed (d: %u us, i: %u)",


### PR DESCRIPTION
    nrf52_bsim: twister yaml: Reduce filtering
    
    Two parts:
    
    1)
    The nrf52_bsim has had an overall driver filter since
    the begining.
    But nowadays it supports most of the nrf drivers, so
    it can be used to run these drives' tests.
    It is actually the only platform which allows running
    these drivers in CI without HW (for ex. upstream).
    
    Instead of filtering all drivers, filter only the
    drivers which cannot yet be used in this board.
    
    2)
    This platform is not a good target to test the
    modem drivers, as will not be able to run those until
    somebody would want to include models of their respective HW,
    for which there is currently no intention.
    Build only tests are better suited in native_posix.
    
    Moreover, most of those will fail to build due to their
    use of either a GPIO or UART which are not yet supported
    in this board.

----------

    tests/drivers modem: Add tag modem to ease filtering
    
    Add the "modem" tag, which is already used in other
    tests/samples using modems drivers, to ease filtering
    of the modem drivers tests if somebody so desires.

-------------

    tests/drivers/nrf_rtc_timer: Fix for nrf52_bsim
    
    Break two busy wait loops with a Z_SPIN_DELAY
    (busy_wait() conditionally compiled for the posix arch)
    so this test can also be run in the nrf52_bsim.
    
--------
--------

& 2 bugs' fixes for bugs in main this CI run uncovered:

    drivers/modem sim7080 & ublox-sara: Fix link error
    
    Fix link error when both modems' drivers are enabled
    as they both define the same structure but did not
    make it static.
    
    This fixes the CI build failure of
    tests/drivers/build_all/modem/drivers.modem.simcom_sim7080.build
    on particle_boron
    
  -----------

    drivers/modem/ublox-sara: Fix build warning
    
    Fix the following build warning:
    include <fcntl.h> without CONFIG_POSIX_API
    is deprecated. Please use CONFIG_POSIX_API
    or #include <zephyr/posix/fcntl.h>

Fixes #57435