### PR TITLE
ci: bsim workflow: Update bsim to version pointed by manifest

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -110,6 +110,21 @@ jobs:
             drivers/ieee802154/**
             include/zephyr/net/ieee802154*
 
+      - name: Update BabbleSim to manifest revision
+        if: >
+          steps.check-bluetooth-files.outputs.any_changed == 'true'
+          || steps.check-networking-files.outputs.any_changed == 'true'
+          || steps.check-common-files.outputs.any_changed == 'true'
+        run: |
+          export BSIM_VERSION=$( west list bsim -f {sha} )
+          echo "Manifest points to bsim sha $BSIM_VERSION"
+          cd /opt/bsim_west/bsim
+          git fetch -n origin ${BSIM_VERSION}
+          git config --global advice.detachedHead false
+          git checkout ${BSIM_VERSION}
+          west update
+          make everything -s -j 8
+
       - name: Run Bluetooth Tests with BSIM
         if: steps.check-bluetooth-files.outputs.any_changed == 'true' || steps.check-common-files.outputs.any_changed == 'true'
         run: |


### PR DESCRIPTION
To ensure a reproducible enviroment while not needing to update the docker images too often,
let's update on the fly the docker bsim installation to whatever the Zephyr manifest points to.
Note that the update and rebuild is incremental,
so if the docker image already has the right version the operation is very fast.