### PR TITLE
boards: arm: scobc_module1: Replace obsolete OpenOCD syntax

### DIFF
--- a/boards/arm/scobc_module1/support/akizuki-m-02990.cfg
+++ b/boards/arm/scobc_module1/support/akizuki-m-02990.cfg
@@ -5,8 +5,8 @@
 #
 
 adapter driver ftdi
-ftdi_device_desc "Dual RS232"
-ftdi_vid_pid 0x0403 0x6010
+ftdi device_desc "Dual RS232"
+ftdi vid_pid 0x0403 0x6010
 
 # Every pin set as high impedance except TCK, TDI, TDO and TMS
-ftdi_layout_init 0x0008 0x000b
+ftdi layout_init 0x0008 0x000b


### PR DESCRIPTION
Replace obsolete 'ftdi_' syntax in OpenOCD configuration scripts.