### PR TITLE
Improvements for NXP MIMXRT1060-EVK(B)

### DIFF
--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -172,7 +172,7 @@ arduino_serial: &lpuart3 {
 	};
 };
 
-&lpi2c1 {
+arduino_i2c: &lpi2c1 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpi2c1>;
 	pinctrl-names = "default";

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -256,7 +256,7 @@ zephyr_udc0: &usb1 {
 	status = "okay";
 };
 
-&lpspi1 {
+arduino_spi: &lpspi1 {
 	status = "okay";
 	/* DMA channels 0 and 1, muxed to LPSPI1 RX and TX */
 	dmas = <&edma0 0 13>, <&edma0 1 14>;

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
@@ -18,6 +18,7 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_serial
+  - arduino_spi
   - counter
   - display
   - dma

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.yaml
@@ -16,6 +16,7 @@ ram: 32768
 flash: 8192
 supported:
   - arduino_gpio
+  - arduino_i2c
   - arduino_serial
   - counter
   - display

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
@@ -16,6 +16,7 @@ ram: 32768
 flash: 65536
 supported:
   - arduino_gpio
+  - arduino_i2c
   - arduino_serial
   - counter
   - display

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.yaml
@@ -18,6 +18,7 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_serial
+  - arduino_spi
   - counter
   - display
   - dma
@@ -25,5 +26,6 @@ supported:
   - i2c
   - netif:eth
   - sdhc
+  - spi
   - usb_device
   - watchdog

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evkb.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evkb.yaml
@@ -18,6 +18,7 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_serial
+  - arduino_spi
   - counter
   - display
   - gpio

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evkb.yaml
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evkb.yaml
@@ -16,6 +16,7 @@ ram: 32768
 flash: 8192
 supported:
   - arduino_gpio
+  - arduino_i2c
   - arduino_serial
   - counter
   - display


### PR DESCRIPTION
- Arduino UNO R3 header: add I2C label
- Arduino UNO R3 header: add SPI label