### PR TITLE
Introducing a new barriers API

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -34,6 +34,7 @@ config ARM
 	# is really only necessary for Cortex-M with ARM MPU!
 	select GEN_PRIV_STACKS
 	select ARCH_HAS_THREAD_LOCAL_STORAGE if CPU_AARCH32_CORTEX_R || CPU_CORTEX_M || CPU_AARCH32_CORTEX_A
+	select BARRIER_OPERATIONS_ARCH
 	help
 	  ARM architecture
 

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -48,6 +48,7 @@ config ARM64
 	select USE_SWITCH
 	select USE_SWITCH_SUPPORTED
 	select IRQ_OFFLOAD_NESTED if IRQ_OFFLOAD
+	select BARRIER_OPERATIONS_ARCH
 	help
 	  ARM64 (AArch64) architecture
 

--- a/arch/arm/core/aarch32/cortex_a_r/cache.c
+++ b/arch/arm/core/aarch32/cortex_a_r/cache.c
@@ -15,6 +15,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/cache.h>
 #include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
+#include <zephyr/sys/barrier.h>
 
 /* Cache Type Register */
 #define	CTR_DMINLINE_SHIFT	16
@@ -51,7 +52,7 @@ void arch_dcache_enable(void)
 
 	val = __get_SCTLR();
 	val |= SCTLR_C_Msk;
-	__DSB();
+	barrier_dsync_fence_full();
 	__set_SCTLR(val);
 	__ISB();
 }
@@ -62,7 +63,7 @@ void arch_dcache_disable(void)
 
 	val = __get_SCTLR();
 	val &= ~SCTLR_C_Msk;
-	__DSB();
+	barrier_dsync_fence_full();
 	__set_SCTLR(val);
 	__ISB();
 

--- a/arch/arm/core/aarch32/cortex_a_r/cache.c
+++ b/arch/arm/core/aarch32/cortex_a_r/cache.c
@@ -54,7 +54,7 @@ void arch_dcache_enable(void)
 	val |= SCTLR_C_Msk;
 	barrier_dsync_fence_full();
 	__set_SCTLR(val);
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 void arch_dcache_disable(void)
@@ -65,7 +65,7 @@ void arch_dcache_disable(void)
 	val &= ~SCTLR_C_Msk;
 	barrier_dsync_fence_full();
 	__set_SCTLR(val);
-	__ISB();
+	barrier_isync_fence_full();
 
 	arch_dcache_flush_and_invd_all();
 }
@@ -169,13 +169,13 @@ void arch_icache_enable(void)
 {
 	arch_icache_invd_all();
 	__set_SCTLR(__get_SCTLR() | SCTLR_I_Msk);
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 void arch_icache_disable(void)
 {
 	__set_SCTLR(__get_SCTLR() & ~SCTLR_I_Msk);
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 int arch_icache_flush_all(void)

--- a/arch/arm/core/aarch32/cortex_m/fault.c
+++ b/arch/arm/core/aarch32/cortex_m/fault.c
@@ -17,6 +17,7 @@
 #include <inttypes.h>
 #include <zephyr/exc_handle.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/barrier.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #if defined(CONFIG_PRINTK) || defined(CONFIG_LOG)
@@ -710,13 +711,13 @@ static inline bool z_arm_is_synchronous_svc(z_arch_esf_t *esf)
 	uint16_t fault_insn = *(ret_addr - 1);
 #else
 	SCB->CCR |= SCB_CCR_BFHFNMIGN_Msk;
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	uint16_t fault_insn = *(ret_addr - 1);
 
 	SCB->CCR &= ~SCB_CCR_BFHFNMIGN_Msk;
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 #endif /* ARMV6_M_ARMV8_M_BASELINE && !ARMV8_M_BASELINE */
 

--- a/arch/arm/core/aarch32/cortex_m/fault.c
+++ b/arch/arm/core/aarch32/cortex_m/fault.c
@@ -712,13 +712,13 @@ static inline bool z_arm_is_synchronous_svc(z_arch_esf_t *esf)
 #else
 	SCB->CCR |= SCB_CCR_BFHFNMIGN_Msk;
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	uint16_t fault_insn = *(ret_addr - 1);
 
 	SCB->CCR &= ~SCB_CCR_BFHFNMIGN_Msk;
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 #endif /* ARMV6_M_ARMV8_M_BASELINE && !ARMV8_M_BASELINE */
 
 	if (((fault_insn & 0xff00) == _SVC_OPCODE) &&

--- a/arch/arm/core/aarch32/cortex_m/scb.c
+++ b/arch/arm/core/aarch32/cortex_m/scb.c
@@ -17,6 +17,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/barrier.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/cache.h>
@@ -132,7 +133,7 @@ void z_arm_init_arch_hw_at_boot(void)
 	/* Restore Interrupts */
 	__enable_irq();
 
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 }
 #endif /* CONFIG_INIT_ARCH_HW_AT_BOOT */

--- a/arch/arm/core/aarch32/cortex_m/scb.c
+++ b/arch/arm/core/aarch32/cortex_m/scb.c
@@ -134,6 +134,6 @@ void z_arm_init_arch_hw_at_boot(void)
 	__enable_irq();
 
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 }
 #endif /* CONFIG_INIT_ARCH_HW_AT_BOOT */

--- a/arch/arm/core/aarch32/irq_manage.c
+++ b/arch/arm/core/aarch32/irq_manage.c
@@ -283,7 +283,7 @@ void irq_target_state_set_all_non_secure(void)
 	}
 
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* Set all NVIC interrupt lines to target Non-Secure */
 	for (i = 0; i < sizeof(NVIC->ITNS) / sizeof(NVIC->ITNS[0]); i++) {

--- a/arch/arm/core/aarch32/irq_manage.c
+++ b/arch/arm/core/aarch32/irq_manage.c
@@ -23,6 +23,7 @@
 #include <zephyr/drivers/interrupt_controller/gic.h>
 #endif
 #include <zephyr/sys/__assert.h>
+#include <zephyr/sys/barrier.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/sw_isr_table.h>
@@ -281,7 +282,7 @@ void irq_target_state_set_all_non_secure(void)
 		NVIC->ICER[i] = 0xFFFFFFFF;
 	}
 
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	/* Set all NVIC interrupt lines to target Non-Secure */

--- a/arch/arm/core/aarch32/mmu/arm_mmu.c
+++ b/arch/arm/core/aarch32/mmu/arm_mmu.c
@@ -27,6 +27,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/mem_manage.h>
+#include <zephyr/sys/barrier.h>
 
 #include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
 
@@ -115,7 +116,7 @@ static void arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
 static void invalidate_tlb_all(void)
 {
 	__set_TLBIALL(0); /* 0 = opc2 = invalidate entire TLB */
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 }
 

--- a/arch/arm/core/aarch32/mmu/arm_mmu.c
+++ b/arch/arm/core/aarch32/mmu/arm_mmu.c
@@ -117,7 +117,7 @@ static void invalidate_tlb_all(void)
 {
 	__set_TLBIALL(0); /* 0 = opc2 = invalidate entire TLB */
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 /**

--- a/arch/arm/core/aarch32/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_mpu.c
@@ -152,7 +152,7 @@ void arm_core_mpu_enable(void)
 	__set_SCTLR(val);
 
 	/* Make sure that all the registers are set before proceeding */
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 }
 
@@ -164,14 +164,14 @@ void arm_core_mpu_disable(void)
 	uint32_t val;
 
 	/* Force any outstanding transfers to complete before disabling MPU */
-	__DSB();
+	barrier_dsync_fence_full();
 
 	val = __get_SCTLR();
 	val &= ~SCTLR_MPU_ENABLE;
 	__set_SCTLR(val);
 
 	/* Make sure that all the registers are set before proceeding */
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 }
 #else
@@ -190,7 +190,7 @@ void arm_core_mpu_enable(void)
 #endif
 
 	/* Make sure that all the registers are set before proceeding */
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 }
 

--- a/arch/arm/core/aarch32/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_mpu.c
@@ -153,7 +153,7 @@ void arm_core_mpu_enable(void)
 
 	/* Make sure that all the registers are set before proceeding */
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 /**
@@ -172,7 +172,7 @@ void arm_core_mpu_disable(void)
 
 	/* Make sure that all the registers are set before proceeding */
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 }
 #else
 /**
@@ -191,7 +191,7 @@ void arm_core_mpu_enable(void)
 
 	/* Make sure that all the registers are set before proceeding */
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 /**

--- a/arch/arm/core/aarch32/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_mpu.c
@@ -7,6 +7,7 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/barrier.h>
 #include "arm_core_mpu_dev.h"
 #include <zephyr/linker/linker-defs.h>
 #include <kernel_arch_data.h>
@@ -199,7 +200,7 @@ void arm_core_mpu_enable(void)
 void arm_core_mpu_disable(void)
 {
 	/* Force any outstanding transfers to complete before disabling MPU */
-	__DMB();
+	barrier_dmem_fence_full();
 
 	/* Disable MPU */
 	MPU->CTRL = 0;

--- a/arch/arm/core/aarch32/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/aarch32/mpu/arm_mpu_v8_internal.h
@@ -81,7 +81,7 @@ static inline void mpu_set_mair0(uint32_t mair0)
 {
 	write_mair0(mair0);
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 static inline void mpu_set_rnr(uint32_t rnr)
@@ -94,7 +94,7 @@ static inline void mpu_set_rbar(uint32_t rbar)
 {
 	write_prbar(rbar);
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 static inline uint32_t mpu_get_rbar(void)
@@ -106,7 +106,7 @@ static inline void mpu_set_rlar(uint32_t rlar)
 {
 	write_prlar(rlar);
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 static inline uint32_t mpu_get_rlar(void)

--- a/arch/arm/core/aarch32/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/aarch32/mpu/arm_mpu_v8_internal.h
@@ -12,6 +12,7 @@
 #define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/barrier.h>
 
 /**
  * @brief internal structure holding information of
@@ -79,20 +80,20 @@ static inline void mpu_clear_region(uint32_t rnr)
 static inline void mpu_set_mair0(uint32_t mair0)
 {
 	write_mair0(mair0);
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 }
 
 static inline void mpu_set_rnr(uint32_t rnr)
 {
 	write_prselr(rnr);
-	__DSB();
+	barrier_dsync_fence_full();
 }
 
 static inline void mpu_set_rbar(uint32_t rbar)
 {
 	write_prbar(rbar);
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 }
 
@@ -104,7 +105,7 @@ static inline uint32_t mpu_get_rbar(void)
 static inline void mpu_set_rlar(uint32_t rlar)
 {
 	write_prlar(rlar);
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 }
 

--- a/arch/arm/core/aarch32/mpu/nxp_mpu.c
+++ b/arch/arm/core/aarch32/mpu/nxp_mpu.c
@@ -399,7 +399,7 @@ void arm_core_mpu_enable(void)
 	SYSMPU->CESR |= SYSMPU_CESR_VLD_MASK;
 
 	/* Make sure that all the registers are set before proceeding */
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 }
 

--- a/arch/arm/core/aarch32/mpu/nxp_mpu.c
+++ b/arch/arm/core/aarch32/mpu/nxp_mpu.c
@@ -11,6 +11,7 @@
 #include "arm_core_mpu_dev.h"
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/barrier.h>
 #include <zephyr/linker/linker-defs.h>
 
 #define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
@@ -408,7 +409,7 @@ void arm_core_mpu_enable(void)
 void arm_core_mpu_disable(void)
 {
 	/* Force any outstanding transfers to complete before disabling MPU */
-	__DMB();
+	barrier_dmem_fence_full();
 
 	/* Disable MPU */
 	SYSMPU->CESR &= ~SYSMPU_CESR_VLD_MASK;

--- a/arch/arm/core/aarch32/mpu/nxp_mpu.c
+++ b/arch/arm/core/aarch32/mpu/nxp_mpu.c
@@ -400,7 +400,7 @@ void arm_core_mpu_enable(void)
 
 	/* Make sure that all the registers are set before proceeding */
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 /**

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -19,6 +19,7 @@
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <zephyr/linker/linker-defs.h>
+#include <zephyr/sys/barrier.h>
 
 #if !defined(CONFIG_CPU_CORTEX_M)
 #include <zephyr/arch/arm/aarch32/cortex_a_r/lib_helpers.h>
@@ -53,7 +54,7 @@ void *_vector_table_pointer;
 static inline void relocate_vector_table(void)
 {
 	SCB->VTOR = VECTOR_ADDRESS & SCB_VTOR_TBLOFF_Msk;
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 }
 
@@ -149,7 +150,7 @@ static inline void z_arm_floating_point_init(void)
 	/* Make the side-effects of modifying the FPCCR be realized
 	 * immediately.
 	 */
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	/* Initialize the Floating Point Status and Control Register. */

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -55,7 +55,7 @@ static inline void relocate_vector_table(void)
 {
 	SCB->VTOR = VECTOR_ADDRESS & SCB_VTOR_TBLOFF_Msk;
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 #elif defined(CONFIG_AARCH32_ARMV8_R)
@@ -66,7 +66,7 @@ static inline void relocate_vector_table(void)
 {
 	write_sctlr(read_sctlr() & ~HIVECS);
 	write_vbar(VECTOR_ADDRESS & VBAR_MASK);
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 #else
@@ -151,7 +151,7 @@ static inline void z_arm_floating_point_init(void)
 	 * immediately.
 	 */
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* Initialize the Floating Point Status and Control Register. */
 #if defined(CONFIG_ARMV8_1_M_MAINLINE)
@@ -215,7 +215,7 @@ static inline void z_arm_floating_point_init(void)
 	/* Enable PL1 access to CP10, CP11 */
 	reg_val |= (CPACR_CP10(CPACR_FA) | CPACR_CP11(CPACR_FA));
 	__set_CPACR(reg_val);
-	__ISB();
+	barrier_isync_fence_full();
 
 #if !defined(CONFIG_FPU_SHARING)
 	/*

--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -15,6 +15,7 @@
 #include <zephyr/kernel.h>
 #include <ksched.h>
 #include <zephyr/wait_q.h>
+#include <zephyr/sys/barrier.h>
 
 #if (MPU_GUARD_ALIGN_AND_SIZE_FLOAT > MPU_GUARD_ALIGN_AND_SIZE)
 #define FP_GUARD_EXTRA_SIZE	(MPU_GUARD_ALIGN_AND_SIZE_FLOAT - \
@@ -522,7 +523,7 @@ static void z_arm_prepare_switch_to_main(void)
 #if defined(CONFIG_CPU_CORTEX_M) && defined(CONFIG_FPU_SHARING)
 	/* In Sharing mode clearing FPSCR may set the CONTROL.FPCA flag. */
 	__set_CONTROL(__get_CONTROL() & (~(CONTROL_FPCA_Msk)));
-	__ISB();
+	barrier_isync_fence_full();
 #endif /* CONFIG_FPU_SHARING */
 #endif /* CONFIG_FPU */
 }

--- a/arch/arm64/core/cortex_r/arm_mpu.c
+++ b/arch/arm64/core/cortex_r/arm_mpu.c
@@ -76,7 +76,7 @@ void arm_core_mpu_enable(void)
 	val = read_sctlr_el1();
 	val |= SCTLR_M_BIT;
 	write_sctlr_el1(val);
-	dsb();
+	barrier_dsync_fence_full();
 	isb();
 }
 
@@ -93,7 +93,7 @@ void arm_core_mpu_disable(void)
 	val = read_sctlr_el1();
 	val &= ~SCTLR_M_BIT;
 	write_sctlr_el1(val);
-	dsb();
+	barrier_dsync_fence_full();
 	isb();
 }
 
@@ -112,7 +112,7 @@ static void mpu_init(void)
 	uint64_t mair = MPU_MAIR_ATTRS;
 
 	write_mair_el1(mair);
-	dsb();
+	barrier_dsync_fence_full();
 	isb();
 }
 
@@ -120,10 +120,10 @@ static inline void mpu_set_region(uint32_t rnr, uint64_t rbar,
 				  uint64_t rlar)
 {
 	write_prselr_el1(rnr);
-	dsb();
+	barrier_dsync_fence_full();
 	write_prbar_el1(rbar);
 	write_prlar_el1(rlar);
-	dsb();
+	barrier_dsync_fence_full();
 	isb();
 }
 

--- a/arch/arm64/core/cortex_r/arm_mpu.c
+++ b/arch/arm64/core/cortex_r/arm_mpu.c
@@ -13,6 +13,7 @@
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/check.h>
+#include <zephyr/sys/barrier.h>
 
 LOG_MODULE_REGISTER(mpu, CONFIG_MPU_LOG_LEVEL);
 
@@ -87,7 +88,7 @@ void arm_core_mpu_disable(void)
 	uint64_t val;
 
 	/* Force any outstanding transfers to complete before disabling MPU */
-	dmb();
+	barrier_dmem_fence_full();
 
 	val = read_sctlr_el1();
 	val &= ~SCTLR_M_BIT;

--- a/arch/arm64/core/cortex_r/arm_mpu.c
+++ b/arch/arm64/core/cortex_r/arm_mpu.c
@@ -77,7 +77,7 @@ void arm_core_mpu_enable(void)
 	val |= SCTLR_M_BIT;
 	write_sctlr_el1(val);
 	barrier_dsync_fence_full();
-	isb();
+	barrier_isync_fence_full();
 }
 
 /**
@@ -94,7 +94,7 @@ void arm_core_mpu_disable(void)
 	val &= ~SCTLR_M_BIT;
 	write_sctlr_el1(val);
 	barrier_dsync_fence_full();
-	isb();
+	barrier_isync_fence_full();
 }
 
 /* ARM MPU Driver Initial Setup
@@ -113,7 +113,7 @@ static void mpu_init(void)
 
 	write_mair_el1(mair);
 	barrier_dsync_fence_full();
-	isb();
+	barrier_isync_fence_full();
 }
 
 static inline void mpu_set_region(uint32_t rnr, uint64_t rbar,
@@ -124,7 +124,7 @@ static inline void mpu_set_region(uint32_t rnr, uint64_t rbar,
 	write_prbar_el1(rbar);
 	write_prlar_el1(rlar);
 	barrier_dsync_fence_full();
-	isb();
+	barrier_isync_fence_full();
 }
 
 /* This internal functions performs MPU region initialization. */

--- a/arch/arm64/core/fpu.c
+++ b/arch/arm64/core/fpu.c
@@ -74,7 +74,7 @@ void z_arm64_flush_local_fpu(void)
 
 		/* turn on FPU access */
 		write_cpacr_el1(cpacr | CPACR_EL1_FPEN_NOTRAP);
-		isb();
+		barrier_isync_fence_full();
 
 		/* save current owner's content */
 		z_arm64_fpu_save(&owner->arch.saved_fp_context);
@@ -141,7 +141,7 @@ void z_arm64_fpu_enter_exc(void)
 
 	/* always deny FPU access whenever an exception is entered */
 	write_cpacr_el1(read_cpacr_el1() & ~CPACR_EL1_FPEN_NOTRAP);
-	isb();
+	barrier_isync_fence_full();
 }
 
 /*
@@ -230,7 +230,7 @@ void z_arm64_fpu_trap(z_arch_esf_t *esf)
 
 	/* turn on FPU access */
 	write_cpacr_el1(read_cpacr_el1() | CPACR_EL1_FPEN_NOTRAP);
-	isb();
+	barrier_isync_fence_full();
 
 	/* save current owner's content  if any */
 	struct k_thread *owner = _current_cpu->arch.fpu_owner;

--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -813,7 +813,7 @@ static void enable_mmu_el1(struct arm_mmu_ptables *ptables, unsigned int flags)
 	write_ttbr0_el1((uint64_t)ptables->base_xlat_table);
 
 	/* Ensure these changes are seen before MMU is enabled */
-	isb();
+	barrier_isync_fence_full();
 
 	/* Invalidate all data caches before enable them */
 	sys_cache_data_invd_all();
@@ -823,7 +823,7 @@ static void enable_mmu_el1(struct arm_mmu_ptables *ptables, unsigned int flags)
 	write_sctlr_el1(val | SCTLR_M_BIT | SCTLR_C_BIT);
 
 	/* Ensure the MMU enable takes effect immediately */
-	isb();
+	barrier_isync_fence_full();
 
 	MMU_DEBUG("MMU enabled with dcache\n");
 }
@@ -979,7 +979,7 @@ int arch_page_phys_get(void *virt, uintptr_t *phys)
 
 	key = arch_irq_lock();
 	__asm__ volatile ("at S1E1R, %0" : : "r" (virt));
-	isb();
+	barrier_isync_fence_full();
 	par = read_par_el1();
 	arch_irq_unlock(key);
 

--- a/arch/arm64/core/reset.c
+++ b/arch/arm64/core/reset.c
@@ -5,6 +5,7 @@
  */
 
 #include <kernel_internal.h>
+#include <zephyr/sys/barrier.h>
 #include "boot.h"
 
 void z_arm64_el2_init(void);
@@ -37,7 +38,7 @@ void z_arm64_el_highest_init(void)
 
 	z_arm64_el_highest_plat_init();
 
-	isb();
+	barrier_isync_fence_full();
 }
 
 enum el3_next_el {
@@ -68,7 +69,7 @@ void z_arm64_el3_init(void)
 
 	/* Setup vector table */
 	write_vbar_el3((uint64_t)_vector_table);
-	isb();
+	barrier_isync_fence_full();
 
 	reg = 0U;			/* Mostly RES0 */
 	reg &= ~(CPTR_TTA_BIT |		/* Do not trap sysreg accesses */
@@ -98,7 +99,7 @@ void z_arm64_el3_init(void)
 
 	z_arm64_el3_plat_init();
 
-	isb();
+	barrier_isync_fence_full();
 
 	if (el3_get_next_el() == EL3_TO_EL1_SKIP_EL2) {
 		/*
@@ -149,7 +150,7 @@ void z_arm64_el2_init(void)
 
 	z_arm64_el2_plat_init();
 
-	isb();
+	barrier_isync_fence_full();
 }
 
 void z_arm64_el1_init(void)
@@ -158,7 +159,7 @@ void z_arm64_el1_init(void)
 
 	/* Setup vector table */
 	write_vbar_el1((uint64_t)_vector_table);
-	isb();
+	barrier_isync_fence_full();
 
 	reg = 0U;			/* RES0 */
 	reg |= CPACR_EL1_FPEN_NOTRAP;	/* Do not trap NEON/SIMD/FP initially */
@@ -180,7 +181,7 @@ void z_arm64_el1_init(void)
 
 	z_arm64_el1_plat_init();
 
-	isb();
+	barrier_isync_fence_full();
 }
 
 void z_arm64_el3_get_next_el(uint64_t switch_addr)

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -22,6 +22,7 @@
 #include <zephyr/drivers/interrupt_controller/gic.h>
 #include <zephyr/drivers/pm_cpu_ops.h>
 #include <zephyr/sys/arch_interface.h>
+#include <zephyr/sys/barrier.h>
 #include <zephyr/irq.h>
 #include "boot.h"
 
@@ -87,7 +88,7 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	arm64_cpu_boot_params.arg = arg;
 	arm64_cpu_boot_params.cpu_num = cpu_num;
 
-	dsb();
+	barrier_dsync_fence_full();
 
 	/* store mpid last as this is our synchronization point */
 	arm64_cpu_boot_params.mpid = cpu_mpid;
@@ -139,7 +140,7 @@ void z_arm64_secondary_start(void)
 
 	fn = arm64_cpu_boot_params.fn;
 	arg = arm64_cpu_boot_params.arg;
-	dsb();
+	barrier_dsync_fence_full();
 
 	/*
 	 * Secondary core clears .fn to announce its presence.
@@ -147,7 +148,7 @@ void z_arm64_secondary_start(void)
 	 * arm64_cpu_boot_params afterwards.
 	 */
 	arm64_cpu_boot_params.fn = NULL;
-	dsb();
+	barrier_dsync_fence_full();
 	sev();
 
 	fn(arg);

--- a/drivers/cache/cache_aspeed.c
+++ b/drivers/cache/cache_aspeed.c
@@ -207,10 +207,10 @@ int cache_instr_invd_all(void)
 
 	ctrl &= ~ICACHE_CLEAN;
 	syscon_write_reg(dev, CACHE_FUNC_CTRL_REG, ctrl);
-	__ISB();
+	barrier_isync_fence_full();
 	ctrl |= ICACHE_CLEAN;
 	syscon_write_reg(dev, CACHE_FUNC_CTRL_REG, ctrl);
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* exit critical section */
 	if (!k_is_in_isr()) {

--- a/drivers/cache/cache_aspeed.c
+++ b/drivers/cache/cache_aspeed.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/drivers/syscon.h>
+#include <zephyr/sys/barrier.h>
 
 /*
  * cache area control: each bit controls 32KB cache area
@@ -145,10 +146,10 @@ int cache_data_invd_all(void)
 	ctrl &= ~DCACHE_CLEAN;
 	syscon_write_reg(dev, CACHE_FUNC_CTRL_REG, ctrl);
 
-	__DSB();
+	barrier_dsync_fence_full();
 	ctrl |= DCACHE_CLEAN;
 	syscon_write_reg(dev, CACHE_FUNC_CTRL_REG, ctrl);
-	__DSB();
+	barrier_dsync_fence_full();
 
 	/* exit critical section */
 	if (!k_is_in_isr()) {
@@ -181,7 +182,7 @@ int cache_data_invd_range(void *addr, size_t size)
 		syscon_write_reg(dev, CACHE_INVALID_REG, DCACHE_INVALID(aligned_addr));
 		aligned_addr += CACHE_LINE_SIZE;
 	}
-	__DSB();
+	barrier_dsync_fence_full();
 
 	/* exit critical section */
 	if (!k_is_in_isr()) {
@@ -242,7 +243,7 @@ int cache_instr_invd_range(void *addr, size_t size)
 		syscon_write_reg(dev, CACHE_INVALID_REG, ICACHE_INVALID(aligned_addr));
 		aligned_addr += CACHE_LINE_SIZE;
 	}
-	__DSB();
+	barrier_dsync_fence_full();
 
 	/* exit critical section */
 	if (!k_is_in_isr()) {

--- a/drivers/clock_control/clock_control_mchp_xec.c
+++ b/drivers/clock_control/clock_control_mchp_xec.c
@@ -15,6 +15,7 @@
 #include <zephyr/dt-bindings/clock/mchp_xec_pcr.h>
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/barrier.h>
 LOG_MODULE_REGISTER(clock_control_xec, LOG_LEVEL_ERR);
 
 #define CLK32K_SIL_OSC_DELAY		256
@@ -765,7 +766,7 @@ static void xec_clock_control_core_clock_divider_set(uint8_t clkdiv)
 	arch_nop();
 	arch_nop();
 	arch_nop();
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 }
 

--- a/drivers/clock_control/clock_control_mchp_xec.c
+++ b/drivers/clock_control/clock_control_mchp_xec.c
@@ -767,7 +767,7 @@ static void xec_clock_control_core_clock_divider_set(uint8_t clkdiv)
 	arch_nop();
 	arch_nop();
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 /*

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -11,6 +11,7 @@
 #include <zephyr/irq.h>
 #include <fsl_gpt.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/barrier.h>
 
 LOG_MODULE_REGISTER(mcux_gpt, CONFIG_COUNTER_LOG_LEVEL);
 
@@ -114,7 +115,7 @@ void mcux_gpt_isr(const struct device *dev)
 	status =  GPT_GetStatusFlags(config->base, kGPT_OutputCompare1Flag |
 				     kGPT_RollOverFlag);
 	GPT_ClearStatusFlags(config->base, status);
-	__DSB();
+	barrier_dsync_fence_full();
 
 	if ((status & kGPT_OutputCompare1Flag) && data->alarm_callback) {
 		GPT_DisableInterrupts(config->base,

--- a/drivers/counter/counter_mcux_qtmr.c
+++ b/drivers/counter/counter_mcux_qtmr.c
@@ -18,6 +18,7 @@
 #include <zephyr/irq.h>
 #include <fsl_qtmr.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/barrier.h>
 
 LOG_MODULE_REGISTER(mcux_qtmr, CONFIG_COUNTER_LOG_LEVEL);
 
@@ -57,7 +58,7 @@ void mcux_qtmr_timer_handler(const struct device *dev, uint32_t status)
 	uint32_t current = QTMR_GetCurrentTimerCount(config->base, config->channel);
 
 	QTMR_ClearStatusFlags(config->base, config->channel, status);
-	__DSB();
+	barrier_dsync_fence_full();
 
 	if ((status & kQTMR_Compare1Flag) && data->alarm_callback) {
 		QTMR_DisableInterrupts(config->base, config->channel,

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -17,6 +17,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/pm/device.h>
+#include <zephyr/sys/barrier.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(display_stm32_ltdc, CONFIG_DISPLAY_LOG_LEVEL);
@@ -61,7 +62,7 @@ LOG_MODULE_REGISTER(display_stm32_ltdc, CONFIG_DISPLAY_LOG_LEVEL);
 #define CACHE_CLEAN(addr, size)		SCB_CleanDCache_by_Addr((addr), (size))
 #else
 #define CACHE_INVALIDATE(addr, size)
-#define CACHE_CLEAN(addr, size)		__DSB()
+#define CACHE_CLEAN(addr, size)		barrier_dsync_fence_full();
 #endif /* __DCACHE_PRESENT == 1 */
 
 #else

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -17,6 +17,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/sys/barrier.h>
 
 #include "dma_mcux_edma.h"
 
@@ -147,7 +148,7 @@ static void dma_mcux_edma_irq_handler(const struct device *dev)
 			EDMA_HandleIRQ(DEV_EDMA_HANDLE(dev, i));
 			LOG_DBG("IRQ DONE");
 #if defined __CORTEX_M && (__CORTEX_M == 4U)
-			__DSB();
+			barrier_dsync_fence_full();
 #endif
 		}
 	}
@@ -170,7 +171,7 @@ static void dma_mcux_edma_error_irq_handler(const struct device *dev)
 	}
 
 #if defined __CORTEX_M && (__CORTEX_M == 4U)
-	__DSB();
+	barrier_dsync_fence_full();
 #endif
 }
 

--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -15,6 +15,7 @@
 #include <fsl_inputmux.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/barrier.h>
 
 #define DT_DRV_COMPAT nxp_lpc_dma
 
@@ -85,7 +86,7 @@ static void dma_mcux_lpc_irq_handler(const struct device *dev)
  * to incorrect interrupt
  */
 #if defined __CORTEX_M && (__CORTEX_M == 4U)
-	__DSB();
+	barrier_dsync_fence_full();
 #endif
 }
 

--- a/drivers/entropy/entropy_smartbond.c
+++ b/drivers/entropy/entropy_smartbond.c
@@ -8,6 +8,7 @@
 #include <zephyr/kernel.h>
 #include <soc.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/barrier.h>
 #include <DA1469xAB.h>
 
 #define DT_DRV_COMPAT renesas_smartbond_trng
@@ -309,7 +310,7 @@ static int entropy_smartbond_get_entropy_isr(const struct device *dev, uint8_t *
 				 * DSB is recommended by spec before WFE (to
 				 * guarantee completion of memory transactions)
 				 */
-				__DSB();
+				barrier_dsync_fence_full();
 				__WFE();
 				__SEV();
 				__WFE();

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -27,6 +27,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/barrier.h>
 #include "stm32_hsem.h"
 
 #define IRQN		DT_INST_IRQN(0)
@@ -313,7 +314,7 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 			 * DSB is recommended by spec before WFE (to
 			 * guarantee completion of memory transactions)
 			 */
-			__DSB();
+			barrier_dsync_fence_full();
 			__WFE();
 			__SEV();
 			__WFE();

--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/kernel.h>
 #include <zephyr/cache.h>
 #include <zephyr/net/ethernet.h>
+#include <zephyr/sys/barrier.h>
 #include <ethernet/eth_stats.h>
 
 #include "eth_dwmac_priv.h"
@@ -188,7 +189,7 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 	} while (frag);
 
 	/* make sure all the above made it to memory */
-	__DMB();
+	barrier_dmem_fence_full();
 
 	/* update the descriptor index head */
 	p->tx_desc_head = d_idx;
@@ -380,7 +381,7 @@ static void dwmac_rx_refill_thread(void *arg1, void *unused1, void *unused2)
 		d->des3 = RDES3_BUF1V | RDES3_IOC | RDES3_OWN;
 
 		/* commit the above to memory */
-		__DMB();
+		barrier_dmem_fence_full();
 
 		/* advance to the next descriptor */
 		p->rx_desc_head = INC_WRAP(d_idx, NB_RX_DESCS);

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -34,6 +34,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/sys/barrier.h>
 #include <zephyr/sys/util.h>
 #include <errno.h>
 #include <stdbool.h>
@@ -1338,7 +1339,7 @@ static struct net_pkt *frame_get(struct gmac_queue *queue)
 		/* Guarantee that status word is written before the address
 		 * word to avoid race condition.
 		 */
-		__DMB();  /* data memory barrier */
+		barrier_dmem_fence_full();
 		/* Update buffer descriptor address word */
 		wrap = (tail == rx_desc_list->len-1U ? GMAC_RXW0_WRAP : 0);
 		rx_desc->w0 = ((uint32_t)frag->data & GMAC_RXW0_ADDR) | wrap;
@@ -1583,7 +1584,7 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	/* Guarantee that all the fragments have been written before removing
 	 * the used bit to avoid race condition.
 	 */
-	__DMB();  /* data memory barrier */
+	barrier_dmem_fence_full();
 
 	/* Remove the used bit of the first fragment to allow the controller
 	 * to process it and the following fragments.
@@ -1605,7 +1606,7 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	/* Guarantee that the first fragment got its bit removed before starting
 	 * sending packets to avoid packets getting stuck.
 	 */
-	__DMB();  /* data memory barrier */
+	barrier_dmem_fence_full();
 
 	/* Start transmission */
 	gmac->GMAC_NCR |= GMAC_NCR_TSTART;

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/barrier.h>
 #include <soc.h>
 #include <string.h>
 
@@ -150,14 +151,14 @@ static int flash_sam_write_page(const struct device *dev, off_t offset,
 	for (; len > 0; len -= sizeof(*src)) {
 		*dst++ = *src++;
 		/* Assure data are written to the latch buffer consecutively */
-		__DSB();
+		barrier_dsync_fence_full();
 	}
 
 	/* Trigger the flash write */
 	efc->EEFC_FCR = EEFC_FCR_FKEY_PASSWD |
 			EEFC_FCR_FARG(flash_sam_get_page(offset)) |
 			EEFC_FCR_FCMD_WP;
-	__DSB();
+	barrier_dsync_fence_full();
 
 	/* Wait for the flash write to finish */
 	return flash_sam_wait_ready(dev);
@@ -256,7 +257,7 @@ static int flash_sam_erase_block(const struct device *dev, off_t offset)
 	efc->EEFC_FCR = EEFC_FCR_FKEY_PASSWD |
 			EEFC_FCR_FARG(flash_sam_get_page(offset) | 2) |
 			EEFC_FCR_FCMD_EPA;
-	__DSB();
+	barrier_dsync_fence_full();
 
 	return flash_sam_wait_ready(dev);
 }

--- a/drivers/flash/flash_stm32f4x.c
+++ b/drivers/flash/flash_stm32f4x.c
@@ -12,6 +12,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/barrier.h>
 
 #include <soc.h>
 
@@ -232,7 +233,7 @@ static __unused int write_optb(const struct device *dev, uint32_t mask,
 	regs->OPTCR |= FLASH_OPTCR_OPTSTRT;
 
 	/* Make sure previous write is completed. */
-	__DSB();
+	barrier_dsync_fence_full();
 
 	rc = flash_stm32_wait_flash_idle(dev);
 	if (rc < 0) {

--- a/drivers/flash/flash_stm32f7x.c
+++ b/drivers/flash/flash_stm32f7x.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/init.h>
+#include <zephyr/sys/barrier.h>
 #include <soc.h>
 
 #include "flash_stm32.h"
@@ -56,12 +57,12 @@ static int write_byte(const struct device *dev, off_t offset, uint8_t val)
 	regs->CR = (regs->CR & CR_PSIZE_MASK) |
 		   FLASH_PSIZE_BYTE | FLASH_CR_PG;
 	/* flush the register write */
-	__DSB();
+	barrier_dsync_fence_full();
 
 	/* write the data */
 	*((uint8_t *) offset + CONFIG_FLASH_BASE_ADDRESS) = val;
 	/* flush the register write */
-	__DSB();
+	barrier_dsync_fence_full();
 
 	rc = flash_stm32_wait_flash_idle(dev);
 	regs->CR &= (~FLASH_CR_PG);
@@ -105,7 +106,7 @@ static int erase_sector(const struct device *dev, uint32_t sector)
 		   (sector << FLASH_CR_SNB_Pos) |
 		   FLASH_CR_STRT;
 	/* flush the register write */
-	__DSB();
+	barrier_dsync_fence_full();
 
 	rc = flash_stm32_wait_flash_idle(dev);
 	regs->CR &= ~(FLASH_CR_SER | FLASH_CR_SNB);

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -571,14 +571,14 @@ static int flash_stm32h7_read(const struct device *dev, off_t offset,
 	__set_FAULTMASK(1);
 	SCB->CCR |= SCB_CCR_BFHFNMIGN_Msk;
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	memcpy(data, (uint8_t *) CONFIG_FLASH_BASE_ADDRESS + offset, len);
 
 	__set_FAULTMASK(0);
 	SCB->CCR &= ~SCB_CCR_BFHFNMIGN_Msk;
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 	irq_unlock(irq_lock_key);
 
 	return flash_stm32_check_status(dev);

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/init.h>
+#include <zephyr/sys/barrier.h>
 #include <soc.h>
 #include <stm32h7xx_ll_bus.h>
 #include <stm32h7xx_ll_utils.h>
@@ -262,7 +263,7 @@ static int erase_sector(const struct device *dev, int offset)
 		| ((sector.sector_index << FLASH_CR_SNB_Pos) & FLASH_CR_SNB));
 	*(sector.cr) |= FLASH_CR_START;
 	/* flush the register write */
-	__DSB();
+	barrier_dsync_fence_full();
 
 	rc = flash_stm32_wait_flash_idle(dev);
 	*(sector.cr) &= ~(FLASH_CR_SER | FLASH_CR_SNB);
@@ -338,14 +339,14 @@ static int write_ndwords(const struct device *dev,
 	*(sector.cr) |= FLASH_CR_PG;
 
 	/* Flush the register write */
-	__DSB();
+	barrier_dsync_fence_full();
 
 	/* Perform the data write operation at the desired memory address */
 	for (i = 0; i < n; ++i) {
 		flash[i] = data[i];
 
 		/* Flush the data write */
-		__DSB();
+		barrier_dsync_fence_full();
 
 		wait_write_queue(&sector);
 	}
@@ -569,14 +570,14 @@ static int flash_stm32h7_read(const struct device *dev, off_t offset,
 
 	__set_FAULTMASK(1);
 	SCB->CCR |= SCB_CCR_BFHFNMIGN_Msk;
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	memcpy(data, (uint8_t *) CONFIG_FLASH_BASE_ADDRESS + offset, len);
 
 	__set_FAULTMASK(0);
 	SCB->CCR &= ~SCB_CCR_BFHFNMIGN_Msk;
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 	irq_unlock(irq_lock_key);
 

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <zephyr/init.h>
 #include <soc.h>
+#include <zephyr/sys/barrier.h>
 #include "flash_priv.h"
 
 #include "fsl_common.h"
@@ -68,7 +69,7 @@ static uint32_t get_cmd_status(uint32_t cmd, uint32_t addr, size_t len)
 	p_fmc->STARTA = (addr>>4) & 0x3FFFF;
 	p_fmc->STOPA = ((addr+len-1)>>4) & 0x3FFFF;
 	p_fmc->CMD = cmd;
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	/* wait for command to be done */

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -70,7 +70,7 @@ static uint32_t get_cmd_status(uint32_t cmd, uint32_t addr, size_t len)
 	p_fmc->STOPA = ((addr+len-1)>>4) & 0x3FFFF;
 	p_fmc->CMD = cmd;
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* wait for command to be done */
 	while (!(p_fmc->INT_STATUS & FMC_STATUS_DONE))

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -20,6 +20,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/imx_ccm.h>
+#include <zephyr/sys/barrier.h>
 #include <soc.h>
 
 #include "i2s_mcux_sai.h"
@@ -1114,7 +1115,7 @@ static void i2s_mcux_isr(void *arg)
 	 *  might vector to incorrect interrupt
 	 */
 #if defined __CORTEX_M && (__CORTEX_M == 4U)
-	__DSB();
+	barrier_dsync_fence_full();
 #endif
 }
 

--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -15,6 +15,7 @@
 #include <zephyr/sw_isr_table.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/drivers/interrupt_controller/gic.h>
+#include <zephyr/sys/barrier.h>
 
 static const uint64_t cpu_mpid_list[] = {
 	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))
@@ -96,7 +97,7 @@ void arm_gic_eoi(unsigned int irq)
 	 * and the barrier is the best core can do by which execution of further
 	 * instructions waits till the barrier is alive.
 	 */
-	__DSB();
+	barrier_dsync_fence_full();
 
 	/* set to inactive */
 	sys_write32(irq, GICC_EOIR);
@@ -113,7 +114,7 @@ void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
 		GICD_SGIR_CPULIST(target_list & GICD_SGIR_CPULIST_MASK) |
 		sgi_id;
 
-	__DSB();
+	barrier_dsync_fence_full();
 	sys_write32(sgi_val, GICD_SGIR);
 	__ISB();
 }

--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -116,7 +116,7 @@ void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
 
 	barrier_dsync_fence_full();
 	sys_write32(sgi_val, GICD_SGIR);
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 static void gic_dist_init(void)

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -10,6 +10,7 @@
 #include <zephyr/sw_isr_table.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/drivers/interrupt_controller/gic.h>
+#include <zephyr/sys/barrier.h>
 #include "intc_gic_common_priv.h"
 #include "intc_gicv3_priv.h"
 
@@ -80,7 +81,7 @@ static void arm_gic_lpi_setup(unsigned int intid, bool enable)
 		*cfg &= ~BIT(0);
 	}
 
-	dsb();
+	barrier_dsync_fence_full();
 
 	its_rdist_invall();
 }
@@ -92,7 +93,7 @@ static void arm_gic_lpi_set_priority(unsigned int intid, unsigned int prio)
 	*cfg &= 0xfc;
 	*cfg |= prio & 0xfc;
 
-	dsb();
+	barrier_dsync_fence_full();
 
 	its_rdist_invall();
 }
@@ -235,7 +236,7 @@ void arm_gic_eoi(unsigned int intid)
 	 * The dsb will also ensure *completion* of previous writes with
 	 * DEVICE nGnRnE attribute.
 	 */
-	__DSB();
+	barrier_dsync_fence_full();
 
 	/* (AP -> Pending) Or (Active -> Inactive) or (AP to AP) nested case */
 	write_sysreg(intid, ICC_EOIR1_EL1);
@@ -261,7 +262,7 @@ void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
 	sgi_val = GICV3_SGIR_VALUE(aff3, aff2, aff1, sgi_id,
 				   SGIR_IRM_TO_AFF, target_list);
 
-	__DSB();
+	barrier_dsync_fence_full();
 	write_sysreg(sgi_val, ICC_SGI1R);
 	__ISB();
 }
@@ -332,7 +333,7 @@ static void gicv3_rdist_setup_lpis(mem_addr_t rdist)
 	ctlr |= GICR_CTLR_ENABLE_LPIS;
 	sys_write32(ctlr, rdist + GICR_CTLR);
 
-	dsb();
+	barrier_dsync_fence_full();
 }
 #endif
 

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -264,7 +264,7 @@ void gic_raise_sgi(unsigned int sgi_id, uint64_t target_aff,
 
 	barrier_dsync_fence_full();
 	write_sysreg(sgi_val, ICC_SGI1R);
-	__ISB();
+	barrier_isync_fence_full();
 }
 
 /*

--- a/drivers/interrupt_controller/intc_gicv3_its.c
+++ b/drivers/interrupt_controller/intc_gicv3_its.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(intc_gicv3_its, LOG_LEVEL_ERR);
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/interrupt_controller/gicv3_its.h>
+#include <zephyr/sys/barrier.h>
 
 #include "intc_gic_common_priv.h"
 #include "intc_gicv3_priv.h"
@@ -302,7 +303,7 @@ static int its_post_command(struct gicv3_its_data *data, struct its_cmd_block *c
 	wr_idx = (data->cmd_write - data->cmd_base) * sizeof(*cmd);
 	rd_idx = sys_read32(data->base + GITS_CREADR);
 
-	dsb();
+	barrier_dsync_fence_full();
 
 	sys_write32(wr_idx, data->base + GITS_CWRITER);
 
@@ -531,7 +532,7 @@ static int gicv3_its_init_device_id(const struct device *dev, uint32_t device_id
 			data->indirect_dev_lvl1_table[offset] = (uintptr_t)alloc_addr |
 								MASK_SET(1, GITS_BASER_VALID);
 
-			dsb();
+			barrier_dsync_fence_full();
 		}
 	}
 

--- a/drivers/ipm/ipm_imx.c
+++ b/drivers/ipm/ipm_imx.c
@@ -11,6 +11,7 @@
 #include <soc.h>
 #include <zephyr/drivers/ipm.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/barrier.h>
 #if defined(CONFIG_IPM_IMX_REV2)
 #define DT_DRV_COMPAT nxp_imx_mu_rev2
 #include "fsl_mu.h"
@@ -155,7 +156,7 @@ static void imx_mu_isr(const struct device *dev)
 	 * with errata 838869.
 	 */
 #if (defined __CORTEX_M) && ((__CORTEX_M == 4U) || (__CORTEX_M == 7U))
-	__DSB();
+	barrier_dsync_fence_full();
 #endif
 }
 

--- a/drivers/ipm/ipm_mcux.c
+++ b/drivers/ipm/ipm_mcux.c
@@ -13,6 +13,7 @@
 #include <fsl_clock.h>
 #include <soc.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/barrier.h>
 
 #define MCUX_IPM_DATA_REGS 1
 #define MCUX_IPM_MAX_ID_VAL 0
@@ -69,7 +70,7 @@ static void mcux_mailbox_isr(const struct device *dev)
 	 * might vector to incorrect interrupt
 	 */
 #if defined __CORTEX_M && (__CORTEX_M == 4U)
-	__DSB();
+	barrier_dsync_fence_full();
 #endif
 }
 

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -14,6 +14,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/sys/device_mmio.h>
+#include <zephyr/sys/barrier.h>
 #include <zephyr/irq.h>
 #if defined(CONFIG_PINCTRL)
 #include <zephyr/drivers/pinctrl.h>
@@ -212,7 +213,7 @@ static int pl011_set_baudrate(const struct device *dev,
 	get_uart(dev)->ibrd = bauddiv >> PL011_FBRD_WIDTH;
 	get_uart(dev)->fbrd = bauddiv & ((1u << PL011_FBRD_WIDTH) - 1u);
 
-	__DMB();
+	barrier_dmem_fence_full();
 
 	/* In order to internally update the contents of ibrd or fbrd, a
 	 * lcr_h write must always be performed at the end

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -458,10 +458,10 @@ static int pl011_init(const struct device *dev)
 
 	if (!data->sbsa) {
 		get_uart(dev)->dmacr = 0U;
-		__ISB();
+		barrier_isync_fence_full();
 		get_uart(dev)->cr &= ~(BIT(14) | BIT(15) | BIT(1));
 		get_uart(dev)->cr |= PL011_CR_RXE | PL011_CR_TXE;
-		__ISB();
+		barrier_isync_fence_full();
 	}
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	config->irq_config_func(dev);

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/timer/nrf_rtc_timer.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/sys/barrier.h>
 #include <hal/nrf_rtc.h>
 #include <zephyr/irq.h>
 
@@ -152,7 +153,7 @@ static bool compare_int_lock(int32_t chan)
 
 	nrf_rtc_int_disable(RTC, NRF_RTC_CHANNEL_INT_MASK(chan));
 
-	__DMB();
+	barrier_dmem_fence_full();
 	__ISB();
 
 	return prev & BIT(chan);
@@ -387,7 +388,7 @@ uint64_t z_nrf_rtc_timer_read(void)
 {
 	uint64_t val = ((uint64_t)overflow_cnt) << COUNTER_BIT_WIDTH;
 
-	__DMB();
+	barrier_dmem_fence_full();
 
 	uint32_t cntr = counter();
 

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -154,7 +154,7 @@ static bool compare_int_lock(int32_t chan)
 	nrf_rtc_int_disable(RTC, NRF_RTC_CHANNEL_INT_MASK(chan));
 
 	barrier_dmem_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	return prev & BIT(chan);
 }

--- a/drivers/usb/device/usb_dc_sam_usbc.c
+++ b/drivers/usb/device/usb_dc_sam_usbc.c
@@ -1187,7 +1187,7 @@ static int usb_dc_ep_write_stp(uint8_t ep_bank, const uint8_t *data,
 		if (data) {
 			memcpy(dev_desc[ep_bank].ep_pipe_addr,
 			       data, packet_len);
-			__DSB();
+			barrier_dsync_fence_full();
 		}
 		dev_desc[ep_bank].sizes = packet_len;
 
@@ -1269,7 +1269,7 @@ int usb_dc_ep_write(uint8_t ep, const uint8_t *data,
 	} else {
 		if (data && packet_len > 0) {
 			memcpy(dev_desc[ep_bank].ep_pipe_addr, data, packet_len);
-			__DSB();
+			barrier_dsync_fence_full();
 		}
 		dev_desc[ep_bank].sizes = packet_len;
 
@@ -1385,7 +1385,7 @@ int usb_dc_ep_read_ex(uint8_t ep, uint8_t *data, uint32_t max_data_len,
 		       (uint8_t *) dev_desc[ep_bank].ep_pipe_addr +
 		       dev_data.ep_data[ep_idx].out_at,
 		       take);
-		__DSB();
+		barrier_dsync_fence_full();
 	}
 
 	if (read_bytes) {

--- a/drivers/usb/device/usb_dc_sam_usbc.c
+++ b/drivers/usb/device/usb_dc_sam_usbc.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(usb_dc_sam_usbc, CONFIG_USB_DRIVER_LOG_LEVEL);
 #include <soc.h>
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/barrier.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 
@@ -654,7 +655,7 @@ static void usb_dc_sam_usbc_isr(void)
 	}
 
 usb_dc_sam_usbc_isr_barrier:
-	__DMB();
+	barrier_dmem_fence_full();
 }
 
 int usb_dc_attach(void)

--- a/drivers/xen/events.c
+++ b/drivers/xen/events.c
@@ -9,6 +9,7 @@
 #include <zephyr/xen/public/xen.h>
 #include <zephyr/xen/public/event_channel.h>
 #include <zephyr/xen/events.h>
+#include <zephyr/sys/barrier.h>
 
 #include <errno.h>
 #include <zephyr/kernel.h>
@@ -219,7 +220,7 @@ static void events_isr(void *data)
 	 */
 	vcpu->evtchn_upcall_pending = 0;
 
-	dmb();
+	barrier_dmem_fence_full();
 
 	/* Can not use system atomic_t/atomic_set() due to 32-bit casting */
 	pos_selector = __atomic_exchange_n(&vcpu->evtchn_pending_sel,

--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -23,6 +23,7 @@
 #include <zephyr/xen/public/grant_table.h>
 #include <zephyr/xen/public/memory.h>
 #include <zephyr/xen/public/xen.h>
+#include <zephyr/sys/barrier.h>
 
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
@@ -86,7 +87,7 @@ static void gnttab_grant_permit_access(grant_ref_t gref, domid_t domid,
 	gnttab.table[gref].frame = gfn;
 	gnttab.table[gref].domid = domid;
 	/* Need to be sure that gfn and domid will be set before flags */
-	__DMB();
+	barrier_dmem_fence_full();
 
 	gnttab.table[gref].flags = flags;
 }

--- a/include/zephyr/arch/arm/aarch32/barrier.h
+++ b/include/zephyr/arch/arm/aarch32/barrier.h
@@ -25,6 +25,11 @@ static ALWAYS_INLINE void z_barrier_dmem_fence_full(void)
 	__DMB();
 }
 
+static ALWAYS_INLINE void z_barrier_dsync_fence_full(void)
+{
+	__DSB();
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/arch/arm/aarch32/barrier.h
+++ b/include/zephyr/arch/arm/aarch32/barrier.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2023 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_BARRIER_ARM_H_
+#define ZEPHYR_INCLUDE_BARRIER_ARM_H_
+
+#ifndef ZEPHYR_INCLUDE_SYS_BARRIER_H_
+#error Please include <zephyr/sys/barrier.h>
+#endif
+
+#if defined(CONFIG_CPU_CORTEX_M)
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#else
+#include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static ALWAYS_INLINE void z_barrier_dmem_fence_full(void)
+{
+	__DMB();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_BARRIER_ARM_H_ */

--- a/include/zephyr/arch/arm/aarch32/barrier.h
+++ b/include/zephyr/arch/arm/aarch32/barrier.h
@@ -30,6 +30,11 @@ static ALWAYS_INLINE void z_barrier_dsync_fence_full(void)
 	__DSB();
 }
 
+static ALWAYS_INLINE void z_barrier_isync_fence_full(void)
+{
+	__ISB();
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/sys_io.h
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/sys_io.h
@@ -17,6 +17,7 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
+#include <zephyr/sys/barrier.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,13 +31,13 @@ static ALWAYS_INLINE uint8_t sys_read8(mem_addr_t addr)
 
 	__asm__ volatile("ldrb %0, [%1]" : "=r" (val) : "r" (addr));
 
-	__DMB();
+	barrier_dmem_fence_full();
 	return val;
 }
 
 static ALWAYS_INLINE void sys_write8(uint8_t data, mem_addr_t addr)
 {
-	__DMB();
+	barrier_dmem_fence_full();
 	__asm__ volatile("strb %0, [%1]" : : "r" (data), "r" (addr));
 }
 
@@ -46,13 +47,13 @@ static ALWAYS_INLINE uint16_t sys_read16(mem_addr_t addr)
 
 	__asm__ volatile("ldrh %0, [%1]" : "=r" (val) : "r" (addr));
 
-	__DMB();
+	barrier_dmem_fence_full();
 	return val;
 }
 
 static ALWAYS_INLINE void sys_write16(uint16_t data, mem_addr_t addr)
 {
-	__DMB();
+	barrier_dmem_fence_full();
 	__asm__ volatile("strh %0, [%1]" : : "r" (data), "r" (addr));
 }
 
@@ -62,13 +63,13 @@ static ALWAYS_INLINE uint32_t sys_read32(mem_addr_t addr)
 
 	__asm__ volatile("ldr %0, [%1]" : "=r" (val) : "r" (addr));
 
-	__DMB();
+	barrier_dmem_fence_full();
 	return val;
 }
 
 static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 {
-	__DMB();
+	barrier_dmem_fence_full();
 	__asm__ volatile("str %0, [%1]" : : "r" (data), "r" (addr));
 }
 
@@ -78,7 +79,7 @@ static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
 
 	__asm__ volatile("ldrd %Q0, %R0, [%1]" : "=r" (val) : "r" (addr));
 
-	__DMB();
+	barrier_dmem_fence_full();
 	return val;
 }
 

--- a/include/zephyr/arch/arm64/barrier.h
+++ b/include/zephyr/arch/arm64/barrier.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2023 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_BARRIER_ARM64_H_
+#define ZEPHYR_INCLUDE_BARRIER_ARM64_H_
+
+#ifndef ZEPHYR_INCLUDE_SYS_BARRIER_H_
+#error Please include <zephyr/sys/barrier.h>
+#endif
+
+#include <zephyr/toolchain.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static ALWAYS_INLINE void z_barrier_dmem_fence_full(void)
+{
+	__asm__ volatile ("dmb sy" ::: "memory");
+}
+
+static ALWAYS_INLINE void z_barrier_dsync_fence_full(void)
+{
+	__asm__ volatile ("dsb sy" ::: "memory");
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_BARRIER_ARM64_H_ */

--- a/include/zephyr/arch/arm64/barrier.h
+++ b/include/zephyr/arch/arm64/barrier.h
@@ -26,6 +26,11 @@ static ALWAYS_INLINE void z_barrier_dsync_fence_full(void)
 	__asm__ volatile ("dsb sy" ::: "memory");
 }
 
+static ALWAYS_INLINE void z_barrier_isync_fence_full(void)
+{
+	__asm__ volatile ("isb" ::: "memory");
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/arch/arm64/cache.h
+++ b/include/zephyr/arch/arm64/cache.h
@@ -10,6 +10,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/barrier.h>
 #include <zephyr/arch/cpu.h>
 #include <errno.h>
 
@@ -133,7 +134,7 @@ static ALWAYS_INLINE int arm64_dcache_range(void *addr, size_t size, int op)
 	}
 
 done:
-	dsb();
+	barrier_dsync_fence_full();
 
 	return 0;
 }
@@ -155,7 +156,7 @@ static ALWAYS_INLINE int arm64_dcache_all(int op)
 	}
 
 	/* Data barrier before start */
-	dsb();
+	barrier_dsync_fence_full();
 
 	clidr_el1 = read_clidr_el1();
 
@@ -209,7 +210,7 @@ static ALWAYS_INLINE int arm64_dcache_all(int op)
 
 	/* Restore csselr_el1 to level 0 */
 	write_csselr_el1(0);
-	dsb();
+	barrier_dsync_fence_full();
 	isb();
 
 	return 0;

--- a/include/zephyr/arch/arm64/cache.h
+++ b/include/zephyr/arch/arm64/cache.h
@@ -176,7 +176,7 @@ static ALWAYS_INLINE int arm64_dcache_all(int op)
 		/* select cache level */
 		csselr_el1 = cache_level << 1;
 		write_csselr_el1(csselr_el1);
-		isb();
+		barrier_isync_fence_full();
 
 		ccsidr_el1 = read_ccsidr_el1();
 		line_size = (ccsidr_el1 >> CCSIDR_EL1_LN_SZ_SHIFT
@@ -211,7 +211,7 @@ static ALWAYS_INLINE int arm64_dcache_all(int op)
 	/* Restore csselr_el1 to level 0 */
 	write_csselr_el1(0);
 	barrier_dsync_fence_full();
-	isb();
+	barrier_isync_fence_full();
 
 	return 0;
 }

--- a/include/zephyr/arch/arm64/lib_helpers.h
+++ b/include/zephyr/arch/arm64/lib_helpers.h
@@ -154,11 +154,6 @@ static ALWAYS_INLINE void disable_fiq(void)
 #define wfe()	__asm__ volatile("wfe" : : : "memory")
 #define wfi()	__asm__ volatile("wfi" : : : "memory")
 
-#define isb()	__asm__ volatile ("isb" ::: "memory")
-
-/* Zephyr needs these as well */
-#define __ISB() isb()
-
 static inline bool is_el_implemented(unsigned int el)
 {
 	unsigned int shift;

--- a/include/zephyr/arch/arm64/lib_helpers.h
+++ b/include/zephyr/arch/arm64/lib_helpers.h
@@ -154,12 +154,10 @@ static ALWAYS_INLINE void disable_fiq(void)
 #define wfe()	__asm__ volatile("wfe" : : : "memory")
 #define wfi()	__asm__ volatile("wfi" : : : "memory")
 
-#define dsb()	__asm__ volatile ("dsb sy" ::: "memory")
 #define isb()	__asm__ volatile ("isb" ::: "memory")
 
 /* Zephyr needs these as well */
 #define __ISB() isb()
-#define __DSB() dsb()
 
 static inline bool is_el_implemented(unsigned int el)
 {

--- a/include/zephyr/arch/arm64/lib_helpers.h
+++ b/include/zephyr/arch/arm64/lib_helpers.h
@@ -155,12 +155,10 @@ static ALWAYS_INLINE void disable_fiq(void)
 #define wfi()	__asm__ volatile("wfi" : : : "memory")
 
 #define dsb()	__asm__ volatile ("dsb sy" ::: "memory")
-#define dmb()	__asm__ volatile ("dmb sy" ::: "memory")
 #define isb()	__asm__ volatile ("isb" ::: "memory")
 
 /* Zephyr needs these as well */
 #define __ISB() isb()
-#define __DMB() dmb()
 #define __DSB() dsb()
 
 static inline bool is_el_implemented(unsigned int el)

--- a/include/zephyr/arch/arm64/sys_io.h
+++ b/include/zephyr/arch/arm64/sys_io.h
@@ -16,6 +16,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/barrier.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,13 +40,13 @@ static ALWAYS_INLINE uint8_t sys_read8(mem_addr_t addr)
 
 	__asm__ volatile("ldrb %w0, [%1]" : "=r" (val) : "r" (addr));
 
-	__DMB();
+	barrier_dmem_fence_full();
 	return val;
 }
 
 static ALWAYS_INLINE void sys_write8(uint8_t data, mem_addr_t addr)
 {
-	__DMB();
+	barrier_dmem_fence_full();
 	__asm__ volatile("strb %w0, [%1]" : : "r" (data), "r" (addr));
 }
 
@@ -55,13 +56,13 @@ static ALWAYS_INLINE uint16_t sys_read16(mem_addr_t addr)
 
 	__asm__ volatile("ldrh %w0, [%1]" : "=r" (val) : "r" (addr));
 
-	__DMB();
+	barrier_dmem_fence_full();
 	return val;
 }
 
 static ALWAYS_INLINE void sys_write16(uint16_t data, mem_addr_t addr)
 {
-	__DMB();
+	barrier_dmem_fence_full();
 	__asm__ volatile("strh %w0, [%1]" : : "r" (data), "r" (addr));
 }
 
@@ -71,13 +72,13 @@ static ALWAYS_INLINE uint32_t sys_read32(mem_addr_t addr)
 
 	__asm__ volatile("ldr %w0, [%1]" : "=r" (val) : "r" (addr));
 
-	__DMB();
+	barrier_dmem_fence_full();
 	return val;
 }
 
 static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 {
-	__DMB();
+	barrier_dmem_fence_full();
 	__asm__ volatile("str %w0, [%1]" : : "r" (data), "r" (addr));
 }
 
@@ -87,13 +88,13 @@ static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
 
 	__asm__ volatile("ldr %x0, [%1]" : "=r" (val) : "r" (addr));
 
-	__DMB();
+	barrier_dmem_fence_full();
 	return val;
 }
 
 static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
 {
-	__DMB();
+	barrier_dmem_fence_full();
 	__asm__ volatile("str %x0, [%1]" : : "r" (data), "r" (addr));
 }
 

--- a/include/zephyr/sys/barrier.h
+++ b/include/zephyr/sys/barrier.h
@@ -40,6 +40,26 @@ static ALWAYS_INLINE void barrier_dmem_fence_full(void)
 #endif
 }
 
+/**
+ * @brief Full/sequentially-consistent data synchronization barrier.
+ *
+ * This routine acts as a synchronization fence between threads and prevents
+ * re-ordering of data accesses instructions across the barrier instruction
+ * like @ref barrier_dmem_fence_full(), but has the additional effect of
+ * blocking execution of any further instructions, not just loads or stores, or
+ * both, until synchronization is complete.
+ *
+ * @note When not supported by hardware or architecture, this instruction falls
+ * back to a full/sequentially-consistent data memory barrier.
+ */
+static ALWAYS_INLINE void barrier_dsync_fence_full(void)
+{
+#if defined(CONFIG_BARRIER_OPERATIONS_ARCH) || defined(CONFIG_BARRIER_OPERATIONS_BUILTIN)
+	z_barrier_dsync_fence_full();
+#endif
+}
+
+
 /** @} */
 
 #ifdef __cplusplus

--- a/include/zephyr/sys/barrier.h
+++ b/include/zephyr/sys/barrier.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_BARRIER_H_
+#define ZEPHYR_INCLUDE_SYS_BARRIER_H_
+
+#include <zephyr/toolchain.h>
+
+#if defined(CONFIG_BARRIER_OPERATIONS_ARCH)
+/* Empty */
+#elif defined(CONFIG_BARRIER_OPERATIONS_BUILTIN)
+#include <zephyr/sys/barrier_builtin.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup barrier_apis Barrier Services APIs
+ * @ingroup kernel_apis
+ * @{
+ */
+
+/**
+ * @brief Full/sequentially-consistent data memory barrier.
+ *
+ * This routine acts as a synchronization fence between threads and prevents
+ * re-ordering of data accesses instructions across the barrier instruction.
+ */
+static ALWAYS_INLINE void barrier_dmem_fence_full(void)
+{
+#if defined(CONFIG_BARRIER_OPERATIONS_ARCH) || defined(CONFIG_BARRIER_OPERATIONS_BUILTIN)
+	z_barrier_dmem_fence_full();
+#endif
+}
+
+/** @} */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* ZEPHYR_INCLUDE_SYS_ATOMIC_H_ */

--- a/include/zephyr/sys/barrier.h
+++ b/include/zephyr/sys/barrier.h
@@ -10,7 +10,9 @@
 #include <zephyr/toolchain.h>
 
 #if defined(CONFIG_BARRIER_OPERATIONS_ARCH)
-/* Empty */
+# if defined(CONFIG_ARM)
+# include <zephyr/arch/arm/aarch32/barrier.h>
+# endif
 #elif defined(CONFIG_BARRIER_OPERATIONS_BUILTIN)
 #include <zephyr/sys/barrier_builtin.h>
 #endif

--- a/include/zephyr/sys/barrier.h
+++ b/include/zephyr/sys/barrier.h
@@ -61,6 +61,24 @@ static ALWAYS_INLINE void barrier_dsync_fence_full(void)
 #endif
 }
 
+/**
+ * @brief Full/sequentially-consistent instruction synchronization barrier.
+ *
+ * This routine is used to guarantee that any subsequent instructions are
+ * fetched and to ensure any previously executed context-changing operations,
+ * such as writes to system control registers, have completed by the time the
+ * routine completes. In hardware terms, this might mean that the instruction
+ * pipeline is flushed, for example.
+ *
+ * @note When not supported by hardware or architecture, this instruction falls
+ * back to a compiler barrier.
+ */
+static ALWAYS_INLINE void barrier_isync_fence_full(void)
+{
+#if defined(CONFIG_BARRIER_OPERATIONS_ARCH) || defined(CONFIG_BARRIER_OPERATIONS_BUILTIN)
+	z_barrier_isync_fence_full();
+#endif
+}
 
 /** @} */
 

--- a/include/zephyr/sys/barrier.h
+++ b/include/zephyr/sys/barrier.h
@@ -12,6 +12,8 @@
 #if defined(CONFIG_BARRIER_OPERATIONS_ARCH)
 # if defined(CONFIG_ARM)
 # include <zephyr/arch/arm/aarch32/barrier.h>
+# elif defined(CONFIG_ARM64)
+# include <zephyr/arch/arm64/barrier.h>
 # endif
 #elif defined(CONFIG_BARRIER_OPERATIONS_BUILTIN)
 #include <zephyr/sys/barrier_builtin.h>

--- a/include/zephyr/sys/barrier_builtin.h
+++ b/include/zephyr/sys/barrier_builtin.h
@@ -19,12 +19,22 @@ extern "C" {
 
 static ALWAYS_INLINE void z_barrier_dmem_fence_full(void)
 {
+#if defined(__GNUC__)
+	/* GCC-ism */
 	__atomic_thread_fence(__ATOMIC_SEQ_CST);
+#else
+	atomic_thread_fence(memory_order_seq_cst);
+#endif
 }
 
 static ALWAYS_INLINE void z_barrier_dsync_fence_full(void)
 {
+#if defined(__GNUC__)
+	/* GCC-ism */
 	__atomic_thread_fence(__ATOMIC_SEQ_CST);
+#else
+	atomic_thread_fence(memory_order_seq_cst);
+#endif
 }
 
 static ALWAYS_INLINE void z_barrier_isync_fence_full(void)

--- a/include/zephyr/sys/barrier_builtin.h
+++ b/include/zephyr/sys/barrier_builtin.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_BARRIER_BUILTIN_H_
+#define ZEPHYR_INCLUDE_SYS_BARRIER_BUILTIN_H_
+
+#ifndef ZEPHYR_INCLUDE_SYS_BARRIER_H_
+#error Please include <zephyr/sys/barrier.h>
+#endif
+
+#include <zephyr/toolchain.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static ALWAYS_INLINE void z_barrier_dmem_fence_full(void)
+{
+	__atomic_thread_fence(__ATOMIC_SEQ_CST);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_SYS_BARRIER_BUILTIN_H_ */

--- a/include/zephyr/sys/barrier_builtin.h
+++ b/include/zephyr/sys/barrier_builtin.h
@@ -22,6 +22,11 @@ static ALWAYS_INLINE void z_barrier_dmem_fence_full(void)
 	__atomic_thread_fence(__ATOMIC_SEQ_CST);
 }
 
+static ALWAYS_INLINE void z_barrier_dsync_fence_full(void)
+{
+	__atomic_thread_fence(__ATOMIC_SEQ_CST);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/sys/barrier_builtin.h
+++ b/include/zephyr/sys/barrier_builtin.h
@@ -27,6 +27,11 @@ static ALWAYS_INLINE void z_barrier_dsync_fence_full(void)
 	__atomic_thread_fence(__ATOMIC_SEQ_CST);
 }
 
+static ALWAYS_INLINE void z_barrier_isync_fence_full(void)
+{
+	__asm__ volatile("" : : : "memory");
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -452,6 +452,21 @@ config SYSTEM_WORKQUEUE_NO_YIELD
 
 endmenu
 
+menu "Barrier Operations"
+config BARRIER_OPERATIONS_BUILTIN
+	bool
+	help
+	  Use the compiler builtin functions for barrier operations. This is
+	  the preferred method. However, support for all arches in GCC is
+	  incomplete.
+
+config BARRIER_OPERATIONS_ARCH
+	bool
+	help
+	  Use when there isn't support for compiler built-ins, but you have
+	  written optimized assembly code under arch/ which implements these.
+endmenu
+
 menu "Atomic Operations"
 config ATOMIC_OPERATIONS_BUILTIN
 	bool

--- a/soc/arm/arm/fvp_aemv8r_aarch32/soc.c
+++ b/soc/arm/arm/fvp_aemv8r_aarch32/soc.c
@@ -14,7 +14,7 @@ void z_arm_platform_init(void)
 		if (!(__get_SCTLR() & SCTLR_I_Msk)) {
 			L1C_InvalidateICacheAll();
 			__set_SCTLR(__get_SCTLR() | SCTLR_I_Msk);
-			__ISB();
+			barrier_isync_fence_full();
 		}
 	}
 

--- a/soc/arm/arm/fvp_aemv8r_aarch32/soc.c
+++ b/soc/arm/arm/fvp_aemv8r_aarch32/soc.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
+#include <zephyr/sys/barrier.h>
 
 void z_arm_platform_init(void)
 {
@@ -21,7 +22,7 @@ void z_arm_platform_init(void)
 		if (!(__get_SCTLR() & SCTLR_C_Msk)) {
 			L1C_InvalidateDCacheAll();
 			__set_SCTLR(__get_SCTLR() | SCTLR_C_Msk);
-			__DSB();
+			barrier_dsync_fence_full();
 		}
 	}
 }

--- a/soc/arm/microchip_mec/mec1501/power.c
+++ b/soc/arm/microchip_mec/mec1501/power.c
@@ -134,7 +134,7 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	case PM_STATE_SUSPEND_TO_IDLE:
 	case PM_STATE_SUSPEND_TO_RAM:
 		__set_PRIMASK(0);
-		__ISB();
+		barrier_isync_fence_full();
 		break;
 
 	default:

--- a/soc/arm/microchip_mec/mec1501/power.c
+++ b/soc/arm/microchip_mec/mec1501/power.c
@@ -8,6 +8,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/sys/barrier.h>
 #include <zephyr/pm/pm.h>
 #include <soc.h>
 #include "device_power.h"
@@ -53,7 +54,7 @@ static void z_power_soc_deep_sleep(void)
 	 * prevent entering an ISR after unmasking in BASEPRI.
 	 */
 	__set_BASEPRI(0);
-	__DSB();
+	barrier_dsync_fence_full();
 	__WFI();	/* triggers sleep hardware */
 	__NOP();
 	__NOP();
@@ -90,7 +91,7 @@ static void z_power_soc_sleep(void)
 	soc_lite_sleep_enable();
 
 	__set_BASEPRI(0); /* Make sure wake interrupts are not masked! */
-	__DSB();
+	barrier_dsync_fence_full();
 	__WFI();	/* triggers sleep hardware */
 	__NOP();
 	__NOP();

--- a/soc/arm/nxp_imx/mcimx6x_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx6x_m4/soc.c
@@ -164,7 +164,7 @@ static void SOC_CacheInit(void)
 		;
 	/* Enable system bus cache, enable write buffer */
 	LMEM_PSCCR = (LMEM_PSCCR_ENWRBUF_MASK | LMEM_PSCCR_ENCACHE_MASK);
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* Enable Code Bus Cache */
 	/* set command to invalidate all ways and write GO bit
@@ -177,7 +177,7 @@ static void SOC_CacheInit(void)
 		;
 	/* Enable code bus cache, enable write buffer */
 	LMEM_PCCCR = (LMEM_PCCCR_ENWRBUF_MASK | LMEM_PCCCR_ENCACHE_MASK);
-	__ISB();
+	barrier_isync_fence_full();
 	barrier_dsync_fence_full();
 }
 

--- a/soc/arm/nxp_imx/mcimx6x_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx6x_m4/soc.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/barrier.h>
 #include <soc.h>
 #include <zephyr/dt-bindings/rdc/imx_rdc.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
@@ -177,7 +178,7 @@ static void SOC_CacheInit(void)
 	/* Enable code bus cache, enable write buffer */
 	LMEM_PCCCR = (LMEM_PCCCR_ENWRBUF_MASK | LMEM_PCCCR_ENCACHE_MASK);
 	__ISB();
-	__DSB();
+	barrier_dsync_fence_full();
 }
 
 /* Initialize clock. */

--- a/soc/arm/nxp_imx/rt/power_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/power_rt10xx.c
@@ -14,6 +14,7 @@
 #include <fsl_gpc.h>
 #include <fsl_clock.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/barrier.h>
 
 #include "power_rt10xx.h"
 
@@ -97,7 +98,7 @@ static void lpm_enter_sleep_mode(clock_mode_t mode)
 	__disable_irq();
 	/* Set BASEPRI to 0 */
 	irq_unlock(0);
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	if (mode == kCLOCK_ModeWait) {

--- a/soc/arm/nxp_imx/rt/power_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/power_rt10xx.c
@@ -99,7 +99,7 @@ static void lpm_enter_sleep_mode(clock_mode_t mode)
 	/* Set BASEPRI to 0 */
 	irq_unlock(0);
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	if (mode == kCLOCK_ModeWait) {
 		/* Clear the SLEEPDEEP bit to go into sleep mode (WAIT) */

--- a/soc/arm/nxp_s32/s32ze/soc.c
+++ b/soc/arm/nxp_s32/s32ze/soc.c
@@ -24,13 +24,13 @@ void z_arm_platform_init(void)
 	__asm__ volatile("orr r0, #1\n");
 	__asm__ volatile("mcr p15, 0, r0, c15, c0, 0\n");
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	if (IS_ENABLED(CONFIG_ICACHE)) {
 		if (!(__get_SCTLR() & SCTLR_I_Msk)) {
 			L1C_InvalidateICacheAll();
 			__set_SCTLR(__get_SCTLR() | SCTLR_I_Msk);
-			__ISB();
+			barrier_isync_fence_full();
 		}
 	}
 

--- a/soc/arm/nxp_s32/s32ze/soc.c
+++ b/soc/arm/nxp_s32/s32ze/soc.c
@@ -8,6 +8,7 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
+#include <zephyr/sys/barrier.h>
 
 #include <OsIf.h>
 
@@ -22,7 +23,7 @@ void z_arm_platform_init(void)
 	__asm__ volatile("mrc p15, 0, r0, c15, c0, 0\n");
 	__asm__ volatile("orr r0, #1\n");
 	__asm__ volatile("mcr p15, 0, r0, c15, c0, 0\n");
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	if (IS_ENABLED(CONFIG_ICACHE)) {
@@ -37,7 +38,7 @@ void z_arm_platform_init(void)
 		if (!(__get_SCTLR() & SCTLR_C_Msk)) {
 			L1C_InvalidateDCacheAll();
 			__set_SCTLR(__get_SCTLR() | SCTLR_C_Msk);
-			__DSB();
+			barrier_dsync_fence_full();
 		}
 	}
 }

--- a/soc/arm/renesas_rcar/gen3/soc.c
+++ b/soc/arm/renesas_rcar/gen3/soc.c
@@ -35,7 +35,7 @@ void z_arm_platform_init(void)
 	/* Invalidate instruction cache and flush branch target cache */
 	__set_ICIALLU(0);
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	L1C_EnableCaches();
 	L1C_EnableBTAC();

--- a/soc/arm/renesas_rcar/gen3/soc.c
+++ b/soc/arm/renesas_rcar/gen3/soc.c
@@ -8,6 +8,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/sys/barrier.h>
 
 /**
  *
@@ -33,7 +34,7 @@ void z_arm_platform_init(void)
 
 	/* Invalidate instruction cache and flush branch target cache */
 	__set_ICIALLU(0);
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	L1C_EnableCaches();

--- a/soc/arm64/bcm_vk/viper/plat_core.c
+++ b/soc/arm64/bcm_vk/viper/plat_core.c
@@ -49,5 +49,5 @@ void z_arm64_el3_plat_init(void)
 	write_sysreg(reg, CORTEX_A72_L2CTLR_EL1);
 
 	barrier_dsync_fence_full();
-	isb();
+	barrier_isync_fence_full();
 }

--- a/soc/arm64/bcm_vk/viper/plat_core.c
+++ b/soc/arm64/bcm_vk/viper/plat_core.c
@@ -7,6 +7,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/arch/cpu.h>
+#include <zephyr/sys/barrier.h>
 
 void z_arm64_el3_plat_init(void)
 {
@@ -47,6 +48,6 @@ void z_arm64_el3_plat_init(void)
 
 	write_sysreg(reg, CORTEX_A72_L2CTLR_EL1);
 
-	dsb();
+	barrier_dsync_fence_full();
 	isb();
 }

--- a/subsys/testsuite/include/zephyr/test_asm_inline_gcc.h
+++ b/subsys/testsuite/include/zephyr/test_asm_inline_gcc.h
@@ -9,6 +9,8 @@
 #ifndef _TEST_ASM_INLINE_GCC_H
 #define _TEST_ASM_INLINE_GCC_H
 
+#include <zephyr/sys/barrier.h>
+
 #if !defined(__GNUC__)
 #error test_asm_inline_gcc.h goes only with GCC
 #endif
@@ -23,24 +25,14 @@ static inline void timestamp_serialize(void)
 	:
 	: "%eax", "%ebx", "%ecx", "%edx");
 }
-#elif defined(CONFIG_CPU_CORTEX_M)
-#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#elif defined(CONFIG_CPU_CORTEX_M) || \
+	defined(CONFIG_CPU_AARCH32_CORTEX_R) || \
+	defined(CONFIG_CPU_AARCH32_CORTEX_A) || \
+	defined(CONFIG_CPU_CORTEX_A) || \
+	defined(CONFIG_CPU_AARCH64_CORTEX_R)
 static inline void timestamp_serialize(void)
 {
-	/* isb is available in all Cortex-M  */
-	__ISB();
-}
-#elif defined(CONFIG_CPU_AARCH32_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
-#include <zephyr/arch/arm/aarch32/cortex_a_r/cpu.h>
-static inline void timestamp_serialize(void)
-{
-	__ISB();
-}
-#elif defined(CONFIG_CPU_CORTEX_A) || defined(CONFIG_CPU_AARCH64_CORTEX_R)
-#include <zephyr/arch/arm64/cpu.h>
-static inline void timestamp_serialize(void)
-{
-	__ISB();
+	barrier_isync_fence_full();
 }
 #elif defined(CONFIG_ARC)
 #define timestamp_serialize()

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -7,6 +7,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/sys/barrier.h>
 
 static volatile int test_flag;
 static volatile int expected_reason = -1;
@@ -292,7 +293,7 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 	NVIC_ClearPendingIRQ(i);
 	NVIC_EnableIRQ(i);
 	NVIC_SetPendingIRQ(i);
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	/* Verify that the spurious ISR has led to the fault and the
@@ -320,7 +321,7 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 		 * Instruction barriers to make sure the NVIC IRQ is
 		 * set to pending state before 'test_flag' is checked.
 		 */
-		__DSB();
+		barrier_dsync_fence_full();
 		__ISB();
 
 		/* Returning here implies the thread was not aborted. */
@@ -367,7 +368,7 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 #endif
 
 	__enable_irq();
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	/* No stack variable access below this point.

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -294,7 +294,7 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 	NVIC_EnableIRQ(i);
 	NVIC_SetPendingIRQ(i);
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* Verify that the spurious ISR has led to the fault and the
 	 * expected reason variable is reset.
@@ -322,7 +322,7 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 		 * set to pending state before 'test_flag' is checked.
 		 */
 		barrier_dsync_fence_full();
-		__ISB();
+		barrier_isync_fence_full();
 
 		/* Returning here implies the thread was not aborted. */
 
@@ -369,7 +369,7 @@ ZTEST(arm_interrupt, test_arm_interrupt)
 
 	__enable_irq();
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* No stack variable access below this point.
 	 * The IRQ will handle the verification.

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
@@ -7,6 +7,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/sys/barrier.h>
 
 /* Offset for the Direct interrupt used in this test. */
 #define DIRECT_ISR_OFFSET (CONFIG_NUM_IRQS - 1)
@@ -53,7 +54,7 @@ ZTEST(arm_irq_advanced_features, test_arm_dynamic_direct_interrupts)
 	 * Instruction barriers to make sure the NVIC IRQ is
 	 * set to pending state before 'test_flag' is checked.
 	 */
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	/* Confirm test flag is set by the dynamic direct ISR handler. */
@@ -77,7 +78,7 @@ ZTEST(arm_irq_advanced_features, test_arm_dynamic_direct_interrupts)
 	 * Instruction barriers to make sure the NVIC IRQ is
 	 * set to pending state before 'test_flag' is checked.
 	 */
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	/* Confirm test flag is set by the dynamic direct ISR handler. */

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
@@ -55,7 +55,7 @@ ZTEST(arm_irq_advanced_features, test_arm_dynamic_direct_interrupts)
 	 * set to pending state before 'test_flag' is checked.
 	 */
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* Confirm test flag is set by the dynamic direct ISR handler. */
 	post_flag = test_flag;
@@ -79,7 +79,7 @@ ZTEST(arm_irq_advanced_features, test_arm_dynamic_direct_interrupts)
 	 * set to pending state before 'test_flag' is checked.
 	 */
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* Confirm test flag is set by the dynamic direct ISR handler. */
 	post_flag = test_flag;

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
@@ -96,7 +96,7 @@ ZTEST(arm_irq_advanced_features, test_arm_zero_latency_irqs)
 	 * set to pending state before 'test_flag' is checked.
 	 */
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* Confirm test flag is set by the zero-latency ISR handler. */
 	post_flag = test_flag;

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
@@ -7,6 +7,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/sys/barrier.h>
 
 static volatile int test_flag;
 
@@ -94,7 +95,7 @@ ZTEST(arm_irq_advanced_features, test_arm_zero_latency_irqs)
 	 * Instruction barriers to make sure the NVIC IRQ is
 	 * set to pending state before 'test_flag' is checked.
 	 */
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	/* Confirm test flag is set by the zero-latency ISR handler. */

--- a/tests/arch/arm/arm_irq_zero_latency_levels/src/main.c
+++ b/tests/arch/arm/arm_irq_zero_latency_levels/src/main.c
@@ -88,7 +88,7 @@ void isr_a_handler(const void *args)
 	/* Set higher prior irq b pending */
 	NVIC_SetPendingIRQ(irq_b);
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	execution_trace_add(STEP_ISR_A_END);
 }
@@ -184,7 +184,7 @@ ZTEST(arm_irq_zero_latency_levels, test_arm_zero_latency_levels)
 	/* Trigger irq_a */
 	NVIC_SetPendingIRQ(irq_a);
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	execution_trace_add(STEP_MAIN_END);
 

--- a/tests/arch/arm/arm_irq_zero_latency_levels/src/main.c
+++ b/tests/arch/arm/arm_irq_zero_latency_levels/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/sys/barrier.h>
 
 
 #define EXECUTION_TRACE_LENGTH 6
@@ -86,7 +87,7 @@ void isr_a_handler(const void *args)
 
 	/* Set higher prior irq b pending */
 	NVIC_SetPendingIRQ(irq_b);
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	execution_trace_add(STEP_ISR_A_END);
@@ -182,7 +183,7 @@ ZTEST(arm_irq_zero_latency_levels, test_arm_zero_latency_levels)
 
 	/* Trigger irq_a */
 	NVIC_SetPendingIRQ(irq_a);
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	execution_trace_add(STEP_MAIN_END);

--- a/tests/arch/arm/arm_no_multithreading/src/main.c
+++ b/tests/arch/arm/arm_no_multithreading/src/main.c
@@ -8,6 +8,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/sys/barrier.h>
 
 #if !defined(CONFIG_CPU_CORTEX_M)
   #error test can only run on Cortex-M MCUs
@@ -89,7 +90,7 @@ void test_main(void)
 	/* Verify activating the PendSV IRQ triggers a K_ERR_SPURIOUS_IRQ */
 	expected_reason = K_ERR_CPU_EXCEPTION;
 	SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	/* Determine an NVIC IRQ line that is not currently in use. */
@@ -142,7 +143,7 @@ void test_main(void)
 
 		NVIC_EnableIRQ(i);
 
-		__DSB();
+		barrier_dsync_fence_full();
 		__ISB();
 
 		flag = test_flag;

--- a/tests/arch/arm/arm_no_multithreading/src/main.c
+++ b/tests/arch/arm/arm_no_multithreading/src/main.c
@@ -91,7 +91,7 @@ void test_main(void)
 	expected_reason = K_ERR_CPU_EXCEPTION;
 	SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* Determine an NVIC IRQ line that is not currently in use. */
 	int i, flag = test_flag;
@@ -144,7 +144,7 @@ void test_main(void)
 		NVIC_EnableIRQ(i);
 
 		barrier_dsync_fence_full();
-		__ISB();
+		barrier_isync_fence_full();
 
 		flag = test_flag;
 

--- a/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
@@ -140,7 +140,7 @@ static void user_thread_entry(uint32_t irq_line)
 
 	NVIC->STIR = irq_line;
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* ISR is set to cause thread to context-switch -out and -in again.
 	 * We inspect for a second time, to verlfy the status, after
@@ -148,7 +148,7 @@ static void user_thread_entry(uint32_t irq_line)
 	 */
 	NVIC->STIR = irq_line;
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 #endif
 }
 

--- a/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
@@ -8,6 +8,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/kernel_structs.h>
+#include <zephyr/sys/barrier.h>
 #include <offsets_short_arch.h>
 #include <ksched.h>
 
@@ -138,7 +139,7 @@ static void user_thread_entry(uint32_t irq_line)
 	TC_PRINT("USR Thread: IRQ Line: %u\n", (uint32_t)irq_line);
 
 	NVIC->STIR = irq_line;
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	/* ISR is set to cause thread to context-switch -out and -in again.
@@ -146,7 +147,7 @@ static void user_thread_entry(uint32_t irq_line)
 	 * the user thread is switch back in.
 	 */
 	NVIC->STIR = irq_line;
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 #endif
 }

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -92,7 +92,7 @@ static void load_callee_saved_regs(const _callee_saved_t *regs)
 		: "memory", "r1"
 	);
 #endif
-	__DSB();
+	barrier_dsync_fence_full();
 }
 
 static void verify_callee_saved(const _callee_saved_t *src,
@@ -154,7 +154,7 @@ static void load_fp_callee_saved_regs(
 		: "r" (regs)
 		: "memory"
 		);
-	__DSB();
+	barrier_dsync_fence_full();
 }
 
 static void verify_fp_callee_saved(const struct _preempt_float *src,

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -8,6 +8,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/kernel_structs.h>
+#include <zephyr/sys/barrier.h>
 #include <offsets_short_arch.h>
 #include <ksched.h>
 
@@ -392,7 +393,7 @@ static void alt_thread_entry(void)
 	/* Manually trigger a context-switch, to swap-out
 	 * the alternative test thread.
 	 */
-	__DMB();
+	barrier_dmem_fence_full();
 	SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
 	irq_unlock(0);
 
@@ -593,7 +594,7 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 	/* Manually trigger a context-switch to swap-out the current thread.
 	 * Request a return to a different interrupt lock state.
 	 */
-	__DMB();
+	barrier_dmem_fence_full();
 
 #if defined(CONFIG_NO_OPTIMIZATIONS)
 	SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;

--- a/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
+++ b/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/ztest.h>
+#include <zephyr/sys/barrier.h>
 
 #define STACKSIZE 1024
 
@@ -226,7 +227,7 @@ static void sup_fp_thread_entry(void)
 	 * Instruction barriers to make sure the NVIC IRQ is
 	 * set to pending state before program proceeds.
 	 */
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 
 	/* Verify K_FP_REGS flag is still set */

--- a/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
+++ b/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
@@ -228,7 +228,7 @@ static void sup_fp_thread_entry(void)
 	 * set to pending state before program proceeds.
 	 */
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 
 	/* Verify K_FP_REGS flag is still set */
 	if ((sup_fp_thread.base.user_options & K_FP_REGS) == 0) {

--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -161,7 +161,7 @@ int test_irq(int offset)
 	trigger_irq(IRQ_LINE(offset));
 #ifdef CONFIG_CPU_CORTEX_M
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 #endif
 	if (trigger_check[offset] != 1) {
 		TC_PRINT("interrupt %d didn't run once, ran %d times\n",

--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -10,6 +10,7 @@
 #include <zephyr/tc_util.h>
 #include <zephyr/sw_isr_table.h>
 #include <zephyr/interrupt_util.h>
+#include <zephyr/sys/barrier.h>
 
 extern uint32_t _irq_vector_table[];
 
@@ -159,7 +160,7 @@ int test_irq(int offset)
 	TC_PRINT("triggering irq %d\n", IRQ_LINE(offset));
 	trigger_irq(IRQ_LINE(offset));
 #ifdef CONFIG_CPU_CORTEX_M
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 #endif
 	if (trigger_check[offset] != 1) {

--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -10,6 +10,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <zephyr/kernel_structs.h>
+#include <zephyr/sys/barrier.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -40,7 +41,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 /* Must set LSB of function address to call in Thumb mode. */
 #define PTR_TO_FUNC(x) (int (*)(int))((uintptr_t)(x) | 0x1)
 /* Flush preceding data writes and instruction fetches. */
-#define DO_BARRIERS() do { __DSB(); __ISB(); } while (0)
+#define DO_BARRIERS() do { barrier_dsync_fence_full(); __ISB(); } while (0)
 #else
 #define FUNC_TO_PTR(x) (void *)(x)
 #define PTR_TO_FUNC(x) (int (*)(int))(x)

--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -41,7 +41,9 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 /* Must set LSB of function address to call in Thumb mode. */
 #define PTR_TO_FUNC(x) (int (*)(int))((uintptr_t)(x) | 0x1)
 /* Flush preceding data writes and instruction fetches. */
-#define DO_BARRIERS() do { barrier_dsync_fence_full(); __ISB(); } while (0)
+#define DO_BARRIERS() do { barrier_dsync_fence_full(); \
+			   barrier_isync_fence_full(); \
+			} while (0)
 #else
 #define FUNC_TO_PTR(x) (void *)(x)
 #define PTR_TO_FUNC(x) (int (*)(int))(x)

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -147,7 +147,7 @@ ZTEST_USER(userspace, test_write_control)
 	msr_value &= ~(CONTROL_nPRIV_Msk);
 	__set_CONTROL(msr_value);
 	barrier_dsync_fence_full();
-	__ISB();
+	barrier_isync_fence_full();
 	msr_value = __get_CONTROL();
 	zassert_true((msr_value & (CONTROL_nPRIV_Msk)),
 		     "Write to control register was successful");

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <zephyr/app_memory/app_memdomain.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/barrier.h>
 #include <zephyr/debug/stack.h>
 #include <zephyr/syscall_handler.h>
 #include "test_syscall.h"
@@ -145,7 +146,7 @@ ZTEST_USER(userspace, test_write_control)
 	msr_value = __get_CONTROL();
 	msr_value &= ~(CONTROL_nPRIV_Msk);
 	__set_CONTROL(msr_value);
-	__DSB();
+	barrier_dsync_fence_full();
 	__ISB();
 	msr_value = __get_CONTROL();
 	zassert_true((msr_value & (CONTROL_nPRIV_Msk)),


### PR DESCRIPTION
Zephyr is missing a proper API for data memory barriers.

We currently have some kind of ARM-centric arch-specific macros scattered around called (mostly) `__DMB()` or `__DSB()`.

In general the situation is confusing because:
- There is no a standard nomenclature for the macros. Sometimes they are called `__DMB()`, sometimes `dmb()`, sometimes `cpu_dmb()`, sometimes something arch-specific entirely, etc...
- Each architecture is doing something different. On ARM those are falling back to CMSIS, on ARM64 those are implemented in assembly, on several architecture they do not have an implementation at all, etc... See for example:
 https://github.com/zephyrproject-rtos/zephyr/blob/9ad78eb60cfa629c1caf7217dbbf7adc5d747011/subsys/testsuite/include/zephyr/test_asm_inline_gcc.h#L26-L44
- Since each architecture is doing something different we are starting to see something like this https://github.com/zephyrproject-rtos/zephyr/pull/57363#discussion_r1180049262 and https://github.com/zephyrproject-rtos/zephyr/pull/57363/commits/8d3718e4ac2795be13ee3b5b16ddd851d009369c where the drivers compiled for different architectures needs to carry boilerplate code to deal with this confusion
- Core code is missing this in SMP code, for example: https://github.com/zephyrproject-rtos/zephyr/blob/ca6c08f960d83265497af261c5eda2e782c47b26/kernel/include/kswap.h#L38-L41

This patch is meant to cleanup a bit the situation, introducing a proper API like it was done for the atomic API already in place. When possible we try to leverage the compiler and the built-in functions for memory model aware atomic operations like it was suggested already in #42625

We use arch-specific implementation only on ARM and ARM64 and use the built-in implementation on all the others.