### PR TITLE
[Backport v2.7] test: dma: mitigate warnings and provide 64 bit dma support

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -79,8 +79,13 @@ static int test_task(uint32_t chan_id, uint32_t blen)
 	TC_PRINT("Starting the transfer\n");
 	(void)memset(rx_data, 0, sizeof(rx_data));
 	dma_block_cfg.block_size = sizeof(tx_data);
+#ifdef CONFIG_DMA_64BIT
+	dma_block_cfg.source_address = (uint64_t)tx_data;
+	dma_block_cfg.dest_address = (uint64_t)rx_data;
+#else
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data;
+#endif
 
 	if (dma_config(dma, chan_id, &dma_cfg)) {
 		TC_PRINT("ERROR: transfer\n");

--- a/tests/drivers/dma/chan_link_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_link_transfer/src/test_dma.c
@@ -87,8 +87,13 @@ static int test_task(int minor, int major)
 	(void)memset(rx_data2, 0, sizeof(rx_data2));
 
 	dma_block_cfg.block_size = sizeof(tx_data);
+#ifdef CONFIG_DMA_64BIT
+	dma_block_cfg.source_address = (uint64_t)tx_data;
+	dma_block_cfg.dest_address = (uint64_t)rx_data2;
+#else
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data2;
+#endif
 
 	if (dma_config(dma, TEST_DMA_CHANNEL_1, &dma_cfg)) {
 		TC_PRINT("ERROR: transfer\n");
@@ -104,8 +109,13 @@ static int test_task(int minor, int major)
 	dma_cfg.linked_channel = TEST_DMA_CHANNEL_1;
 
 	dma_block_cfg.block_size = sizeof(tx_data);
+#ifdef CONFIG_DMA_64BIT
+	dma_block_cfg.source_address = (uint64_t)tx_data;
+	dma_block_cfg.dest_address = (uint64_t)rx_data;
+#else
 	dma_block_cfg.source_address = (uint32_t)tx_data;
 	dma_block_cfg.dest_address = (uint32_t)rx_data;
+#endif
 
 	if (dma_config(dma, TEST_DMA_CHANNEL_0, &dma_cfg)) {
 		TC_PRINT("ERROR: transfer\n");

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -57,8 +57,13 @@ static void test_transfer(const struct device *dev, uint32_t id)
 	transfer_count++;
 	if (transfer_count < TRANSFER_LOOPS) {
 		dma_block_cfg.block_size = strlen(tx_data);
+#ifdef CONFIG_DMA_64BIT
+		dma_block_cfg.source_address = (uint64_t)tx_data;
+		dma_block_cfg.dest_address = (uint64_t)rx_data[transfer_count];
+#else
 		dma_block_cfg.source_address = (uint32_t)tx_data;
 		dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];
+#endif
 
 		zassert_false(dma_config(dev, id, &dma_cfg),
 					"Not able to config transfer %d",


### PR DESCRIPTION
Backport 5afcac5e1433456adadae579c1fab17b36c99494..bacc8d929321437621798f1c4afb31f3d2d98d80 from https://github.com/zephyrproject-rtos/zephyr/pull/57420

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/57419