### PR TITLE
drivers: sbs_gauge: Add support for Alarm properties

### DIFF
--- a/drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c
@@ -26,6 +26,8 @@ LOG_MODULE_REGISTER(sbs_sbs_gauge);
 /** Run-time data used by the emulator */
 struct sbs_gauge_emul_data {
 	uint16_t mfr_acc;
+	uint16_t remaining_capacity_alarm;
+	uint16_t remaining_time_alarm;
 	uint16_t mode;
 	int16_t at_rate;
 };
@@ -44,6 +46,12 @@ static int emul_sbs_gauge_reg_write(const struct emul *target, int reg, int val)
 	switch (reg) {
 	case SBS_GAUGE_CMD_MANUFACTURER_ACCESS:
 		data->mfr_acc = val;
+		break;
+	case SBS_GAUGE_CMD_REM_CAPACITY_ALARM:
+		data->remaining_capacity_alarm = val;
+		break;
+	case SBS_GAUGE_CMD_REM_TIME_ALARM:
+		data->remaining_time_alarm = val;
 		break;
 	case SBS_GAUGE_CMD_BATTERY_MODE:
 		data->mode = val;
@@ -67,6 +75,18 @@ static int emul_sbs_gauge_reg_read(const struct emul *target, int reg, int *val)
 	case SBS_GAUGE_CMD_MANUFACTURER_ACCESS:
 		*val = data->mfr_acc;
 		break;
+	case SBS_GAUGE_CMD_REM_CAPACITY_ALARM:
+		*val = data->remaining_capacity_alarm;
+		break;
+	case SBS_GAUGE_CMD_REM_TIME_ALARM:
+		*val = data->remaining_time_alarm;
+		break;
+	case SBS_GAUGE_CMD_BATTERY_MODE:
+		*val = data->mode;
+		break;
+	case SBS_GAUGE_CMD_AR:
+		*val = data->at_rate;
+		break;
 	case SBS_GAUGE_CMD_VOLTAGE:
 	case SBS_GAUGE_CMD_AVG_CURRENT:
 	case SBS_GAUGE_CMD_TEMP:
@@ -80,11 +100,9 @@ static int emul_sbs_gauge_reg_read(const struct emul *target, int reg, int *val)
 	case SBS_GAUGE_CMD_CYCLE_COUNT:
 	case SBS_GAUGE_CMD_DESIGN_VOLTAGE:
 	case SBS_GAUGE_CMD_CURRENT:
-	case SBS_GAUGE_CMD_BATTERY_MODE:
 	case SBS_GAUGE_CMD_CHG_CURRENT:
 	case SBS_GAUGE_CMD_CHG_VOLTAGE:
 	case SBS_GAUGE_CMD_FLAGS:
-	case SBS_GAUGE_CMD_AR:
 	case SBS_GAUGE_CMD_ARTTF:
 	case SBS_GAUGE_CMD_ARTTE:
 	case SBS_GAUGE_CMD_AROK:

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -135,7 +135,14 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AROK, &val);
 		prop->value.sbs_at_rate_ok = val;
 		break;
-
+	case FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM:
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_CAPACITY_ALARM, &val);
+		prop->value.sbs_remaining_capacity_alarm = val;
+		break;
+	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM:
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_TIME_ALARM, &val);
+		prop->value.sbs_remaining_time_alarm = val;
+		break;
 	default:
 		rc = -ENOTSUP;
 	}
@@ -156,6 +163,16 @@ static int sbs_gauge_set_prop(const struct device *dev, struct fuel_gauge_set_pr
 		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_MANUFACTURER_ACCESS,
 				       prop->value.sbs_mfr_access_word);
 		prop->value.sbs_mfr_access_word = val;
+		break;
+	case FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM:
+		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_REM_CAPACITY_ALARM,
+				       prop->value.sbs_remaining_capacity_alarm);
+		prop->value.sbs_remaining_capacity_alarm = val;
+		break;
+	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM:
+		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_REM_TIME_ALARM,
+				       prop->value.sbs_remaining_time_alarm);
+		prop->value.sbs_remaining_time_alarm = val;
 		break;
 	case FUEL_GAUGE_SBS_MODE:
 		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_BATTERY_MODE, prop->value.sbs_mode);

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -256,6 +256,7 @@ static const struct fuel_gauge_driver_api sbs_gauge_driver_api = {
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(index, &sbs_gauge_init, NULL, NULL, &sbs_gauge_config_##index,       \
-			      POST_KERNEL, CONFIG_FUEL_GAUGE_INIT_PRIORITY, &sbs_gauge_driver_api);
+			      POST_KERNEL, CONFIG_FUEL_GAUGE_INIT_PRIORITY,                        \
+			      &sbs_gauge_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SBS_GAUGE_INIT)

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -37,57 +37,57 @@ extern "C" {
 #define FUEL_GAUGE_AVG_CURRENT 0
 
 /** Battery current (uA); negative=discharging */
-#define FUEL_GAUGE_CURRENT		    FUEL_GAUGE_AVG_CURRENT + 1
+#define FUEL_GAUGE_CURRENT			FUEL_GAUGE_AVG_CURRENT + 1
 /** Whether the battery underlying the fuel-gauge is cut off from charge */
-#define FUEL_GAUGE_CHARGE_CUTOFF	    FUEL_GAUGE_CURRENT + 1
+#define FUEL_GAUGE_CHARGE_CUTOFF		FUEL_GAUGE_CURRENT + 1
 /** Cycle count in 1/100ths (number of charge/discharge cycles) */
-#define FUEL_GAUGE_CYCLE_COUNT		    FUEL_GAUGE_CHARGE_CUTOFF + 1
+#define FUEL_GAUGE_CYCLE_COUNT			FUEL_GAUGE_CHARGE_CUTOFF + 1
 /** Connect state of battery */
-#define FUEL_GAUGE_CONNECT_STATE	    FUEL_GAUGE_CYCLE_COUNT + 1
+#define FUEL_GAUGE_CONNECT_STATE		FUEL_GAUGE_CYCLE_COUNT + 1
 /** General Error/Runtime Flags */
-#define FUEL_GAUGE_FLAGS		    FUEL_GAUGE_CONNECT_STATE + 1
+#define FUEL_GAUGE_FLAGS			FUEL_GAUGE_CONNECT_STATE + 1
 /** Full Charge Capacity in uAh (might change in some implementations to determine wear) */
-#define FUEL_GAUGE_FULL_CHARGE_CAPACITY	    FUEL_GAUGE_FLAGS + 1
+#define FUEL_GAUGE_FULL_CHARGE_CAPACITY		FUEL_GAUGE_FLAGS + 1
 /** Is the battery physically present */
-#define FUEL_GAUGE_PRESENT_STATE	    FUEL_GAUGE_FULL_CHARGE_CAPACITY + 1
+#define FUEL_GAUGE_PRESENT_STATE		FUEL_GAUGE_FULL_CHARGE_CAPACITY + 1
 /** Remaining capacity in uAh */
-#define FUEL_GAUGE_REMAINING_CAPACITY	    FUEL_GAUGE_PRESENT_STATE + 1
+#define FUEL_GAUGE_REMAINING_CAPACITY		FUEL_GAUGE_PRESENT_STATE + 1
 /** Remaining battery life time in minutes */
-#define FUEL_GAUGE_RUNTIME_TO_EMPTY	    FUEL_GAUGE_REMAINING_CAPACITY + 1
+#define FUEL_GAUGE_RUNTIME_TO_EMPTY		FUEL_GAUGE_REMAINING_CAPACITY + 1
 /** Remaining time in minutes until battery reaches full charge */
-#define FUEL_GAUGE_RUNTIME_TO_FULL	    FUEL_GAUGE_RUNTIME_TO_EMPTY + 1
+#define FUEL_GAUGE_RUNTIME_TO_FULL		FUEL_GAUGE_RUNTIME_TO_EMPTY + 1
 /** Retrieve word from SBS1.1 ManufactuerAccess */
-#define FUEL_GAUGE_SBS_MFR_ACCESS	    FUEL_GAUGE_RUNTIME_TO_FULL + 1
+#define FUEL_GAUGE_SBS_MFR_ACCESS		FUEL_GAUGE_RUNTIME_TO_FULL + 1
 /** Absolute state of charge (percent, 0-100) - expressed as % of design capacity */
-#define FUEL_GAUGE_STATE_OF_CHARGE	    FUEL_GAUGE_SBS_MFR_ACCESS + 1
+#define FUEL_GAUGE_STATE_OF_CHARGE		FUEL_GAUGE_SBS_MFR_ACCESS + 1
 /** Temperature in 0.1 K */
-#define FUEL_GAUGE_TEMPERATURE		    FUEL_GAUGE_STATE_OF_CHARGE + 1
+#define FUEL_GAUGE_TEMPERATURE			FUEL_GAUGE_STATE_OF_CHARGE + 1
 /** Battery voltage (uV) */
-#define FUEL_GAUGE_VOLTAGE		    FUEL_GAUGE_TEMPERATURE + 1
+#define FUEL_GAUGE_VOLTAGE			FUEL_GAUGE_TEMPERATURE + 1
 /** Battery Mode (flags) */
-#define FUEL_GAUGE_SBS_MODE		    FUEL_GAUGE_VOLTAGE + 1
+#define FUEL_GAUGE_SBS_MODE			FUEL_GAUGE_VOLTAGE + 1
 /** Battery desired Max Charging Current (mA) */
-#define FUEL_GAUGE_CHARGE_CURRENT	    FUEL_GAUGE_SBS_MODE + 1
+#define FUEL_GAUGE_CHARGE_CURRENT		FUEL_GAUGE_SBS_MODE + 1
 /** Battery desired Max Charging Voltage (mV) */
-#define FUEL_GAUGE_CHARGE_VOLTAGE	    FUEL_GAUGE_CHARGE_CURRENT + 1
+#define FUEL_GAUGE_CHARGE_VOLTAGE		FUEL_GAUGE_CHARGE_CURRENT + 1
 /** Alarm, Status and Error codes (flags) */
-#define FUEL_GAUGE_STATUS		    FUEL_GAUGE_CHARGE_VOLTAGE + 1
+#define FUEL_GAUGE_STATUS			FUEL_GAUGE_CHARGE_VOLTAGE + 1
 /** Design Capacity (mAh or 10mWh) */
-#define FUEL_GAUGE_DESIGN_CAPACITY	    FUEL_GAUGE_STATUS + 1
+#define FUEL_GAUGE_DESIGN_CAPACITY		FUEL_GAUGE_STATUS + 1
 /** Design Voltage (mV) */
-#define FUEL_GAUGE_DESIGN_VOLTAGE	    FUEL_GAUGE_DESIGN_CAPACITY + 1
+#define FUEL_GAUGE_DESIGN_VOLTAGE		FUEL_GAUGE_DESIGN_CAPACITY + 1
 /** AtRate (mA or 10 mW) */
-#define FUEL_GAUGE_SBS_ATRATE		    FUEL_GAUGE_DESIGN_VOLTAGE + 1
+#define FUEL_GAUGE_SBS_ATRATE			FUEL_GAUGE_DESIGN_VOLTAGE + 1
 /** AtRateTimeToFull (minutes) */
-#define FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL  FUEL_GAUGE_SBS_ATRATE + 1
+#define FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL	FUEL_GAUGE_SBS_ATRATE + 1
 /** AtRateTimeToEmpty (minutes) */
-#define FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL + 1
+#define FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY	FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL + 1
 /** AtRateOK (boolean) */
-#define FUEL_GAUGE_SBS_ATRATE_OK	    FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY + 1
+#define FUEL_GAUGE_SBS_ATRATE_OK		FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY + 1
 /** Remaining Capacity Alarm (mAh or 10mWh) */
 #define FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM FUEL_GAUGE_SBS_ATRATE_OK + 1
 /** Remaining Time Alarm (minutes) */
-#define FUEL_GAUGE_SBS_REMAINING_TIME_ALARM	    FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM + 1
+#define FUEL_GAUGE_SBS_REMAINING_TIME_ALARM	FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM + 1
 
 /** Reserved to demark end of common fuel gauge properties */
 #define FUEL_GAUGE_COMMON_COUNT FUEL_GAUGE_DESIGN_VOLTAGE + 1

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -84,6 +84,10 @@ extern "C" {
 #define FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL + 1
 /** AtRateOK (boolean) */
 #define FUEL_GAUGE_SBS_ATRATE_OK	    FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY + 1
+/** Remaining Capacity Alarm (mAh or 10mWh) */
+#define FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM FUEL_GAUGE_SBS_ATRATE_OK + 1
+/** Remaining Time Alarm (minutes) */
+#define FUEL_GAUGE_SBS_REMAINING_TIME_ALARM	    FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM + 1
 
 /** Reserved to demark end of common fuel gauge properties */
 #define FUEL_GAUGE_COMMON_COUNT FUEL_GAUGE_DESIGN_VOLTAGE + 1
@@ -156,6 +160,10 @@ struct fuel_gauge_get_property {
 		uint16_t sbs_at_rate_time_to_empty;
 		/** FUEL_GAUGE_SBS_ATRATE_OK */
 		bool sbs_at_rate_ok;
+		/** FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM */
+		uint16_t sbs_remaining_capacity_alarm;
+		/** FUEL_GAUGE_SBS_REMAINING_TIME_ALARM */
+		uint16_t sbs_remaining_time_alarm;
 	} value;
 };
 
@@ -175,6 +183,10 @@ struct fuel_gauge_set_property {
 		/* Writable Dynamic Battery Info */
 		/** FUEL_GAUGE_SBS_MFR_ACCESS */
 		uint16_t sbs_mfr_access_word;
+		/** FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM */
+		uint16_t sbs_remaining_capacity_alarm;
+		/** FUEL_GAUGE_SBS_REMAINING_TIME_ALARM */
+		uint16_t sbs_remaining_time_alarm;
 		/** FUEL_GAUGE_SBS_MODE */
 		uint16_t sbs_mode;
 		/** FUEL_GAUGE_SBS_ATRATE */

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -134,23 +134,66 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_some_props_failed_returns_failed_prop_c
 ZTEST_USER_F(sbs_gauge_new_api, test_set_prop_can_be_get)
 {
 	uint16_t word = BIT(15) | BIT(0);
-	struct fuel_gauge_set_property set_prop = {
-		/* Valid property */
-		.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
-		/* Set Manufacturer's Access to 16 bit word*/
-		.value.sbs_mfr_access_word = word,
+	struct fuel_gauge_set_property set_props[] = {
+		{
+			/* Valid property */
+			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
+			/* Set Manufacturer's Access to 16 bit word */
+			.value.sbs_mfr_access_word = word,
+		},
+		{
+			.property_type = FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
+			.value.sbs_remaining_capacity_alarm = word,
+		},
+		{
+			.property_type = FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
+			.value.sbs_remaining_time_alarm = word,
+		},
+		{
+			.property_type = FUEL_GAUGE_SBS_MODE,
+			.value.sbs_mode = word,
+		},
+		{
+			.property_type = FUEL_GAUGE_SBS_ATRATE,
+			.value.sbs_at_rate = (int16_t)word,
+		},
 	};
 
-	zassert_ok(fuel_gauge_set_prop(fixture->dev, &set_prop, 1));
-	zassert_ok(set_prop.status);
-
-	struct fuel_gauge_get_property get_prop = {
-		.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
+	struct fuel_gauge_get_property get_props[] = {
+		{
+			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
+		},
+		{
+			.property_type = FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
+		},
+		{
+			.property_type = FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
+		},
+		{
+			.property_type = FUEL_GAUGE_SBS_MODE,
+		},
+		{
+			.property_type = FUEL_GAUGE_SBS_ATRATE,
+		},
 	};
 
-	zassert_ok(fuel_gauge_get_prop(fixture->dev, &get_prop, 1));
-	zassert_ok(get_prop.status);
-	zassert_equal(get_prop.value.sbs_mfr_access_word, word);
+	zassert_ok(fuel_gauge_set_prop(fixture->dev, set_props, ARRAY_SIZE(set_props)));
+	for (int i = 0; i < ARRAY_SIZE(set_props); i++) {
+		zassert_ok(set_props[i].status, "Property %d writing %d has a bad status.", i,
+			   set_props[i].property_type);
+	}
+
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, get_props, ARRAY_SIZE(get_props)));
+	for (int i = 0; i < ARRAY_SIZE(get_props); i++) {
+		zassert_ok(get_props[i].status, "Property %d getting %d has a bad status.", i,
+			   get_props[i].property_type);
+	}
+
+	zassert_equal(get_props[0].value.sbs_mfr_access_word, word);
+	zassert_equal(get_props[1].value.sbs_remaining_capacity_alarm, word);
+	zassert_equal(get_props[2].value.sbs_remaining_time_alarm, word);
+	zassert_equal(get_props[3].value.sbs_mode, word);
+	zassert_equal(get_props[4].value.sbs_at_rate, (int16_t)word);
 }
 
 ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)
@@ -221,6 +264,12 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)
 		{
 			.property_type = FUEL_GAUGE_SBS_ATRATE_OK,
 		},
+		{
+			.property_type = FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
+		},
+		{
+			.property_type = FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
+		},
 	};
 
 	int ret = fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props));
@@ -240,6 +289,12 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_props__returns_ok)
 	struct fuel_gauge_set_property props[] = {
 		{
 			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
+		},
+		{
+			.property_type = FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
+		},
+		{
+			.property_type = FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
 		},
 		{
 			.property_type = FUEL_GAUGE_SBS_MODE,


### PR DESCRIPTION
RemainingCapacityAlarm(r/w) and RemainingTimeAlarm(r/w)