### PR TITLE
twister: Fix suite-name-check bypass on flash error

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -660,8 +660,7 @@ class DeviceHandler(Handler):
         if self.instance.status in ["error", "failed"]:
             self.instance.add_missing_case_status("blocked", self.instance.reason)
 
-        if not flash_error:
-            self._final_handle_actions(harness, handler_time)
+        self._final_handle_actions(harness, handler_time)
 
         if post_script:
             self.run_custom_script(post_script, 30)

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -146,7 +146,8 @@ class Handler:
         harness_class_name = type(harness).__name__
         if self.suite_name_check and harness_class_name == "Test":
             self._verify_ztest_suite_name(harness.state, harness.detected_suite_names, handler_time)
-
+            if self.instance.status == 'failed':
+                return
             if not harness.matched_run_id and harness.run_id_exists:
                 self.instance.status = "failed"
                 self.instance.execution_time = handler_time

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -116,6 +116,8 @@ class Handler:
         (and not in reverse).
         """
         expected_suite_names = self.instance.testsuite.ztest_suite_names
+        logger.debug(f"Expected suite names:{expected_suite_names}")
+        logger.debug(f"Detected suite names:{detected_suite_names}")
         if not expected_suite_names or \
                 not harness_state == "passed":
             return


### PR DESCRIPTION
Fix suite-name-check bypassed at DeviceHandler on flash errors.

If the flash timeout is smaller than needed, but test images are actually flashed successfully and appropriate tests executed, then results from the previous test case were taken because the flash error status makes the suite-name-check bypassed.

Don't override a test case name check failed result by the following RunID check failed result to report clearly about test case mismatch situation as well as more specifically when the same test case appears with unexpected RunID.

Log expected and detected test case names for the test suite name check debug.