### PR TITLE
board: tdk robokit1 fixes

### DIFF
--- a/boards/arm/tdk_robokit1/tdk_robokit1-common.dtsi
+++ b/boards/arm/tdk_robokit1/tdk_robokit1-common.dtsi
@@ -117,7 +117,7 @@
 		#io-channel-cells = <1>;
 		#address-cells = <1>;
 		#size-cells = <0>;
-		spi-max-frequency = <12000000>;
+		spi-max-frequency = <24000000>;
 		channel@0 {
 			reg = <0>;
 			zephyr,gain = "ADC_GAIN_1";

--- a/drivers/adc/adc_ads7052.c
+++ b/drivers/adc/adc_ads7052.c
@@ -288,7 +288,8 @@ static const struct adc_driver_api ads7052_api = {
 #endif
 };
 
-#define ADC_ADS7052_SPI_CFG SPI_OP_MODE_MASTER | SPI_MODE_CPHA | SPI_WORD_SET(8)
+#define ADC_ADS7052_SPI_CFG \
+	SPI_OP_MODE_MASTER | SPI_MODE_CPOL | SPI_MODE_CPHA | SPI_WORD_SET(8) | SPI_TRANSFER_MSB
 
 #define ADC_ADS7052_INIT(n)                                                                        \
                                                                                                    \

--- a/drivers/sensor/icm42688/icm42688_common.c
+++ b/drivers/sensor/icm42688/icm42688_common.c
@@ -182,8 +182,8 @@ int icm42688_configure(const struct device *dev, struct icm42688_cfg *cfg)
 
 	uint8_t int_config1 = 0;
 
-	if (cfg->fifo_en && (cfg->accel_odr <= ICM42688_ACCEL_ODR_4000 ||
-			     cfg->gyro_odr <= ICM42688_GYRO_ODR_4000)) {
+	if ((cfg->accel_odr <= ICM42688_ACCEL_ODR_4000 ||
+	     cfg->gyro_odr <= ICM42688_GYRO_ODR_4000)) {
 		int_config1 = FIELD_PREP(BIT_INT_TPULSE_DURATION, 1) |
 			      FIELD_PREP(BIT_INT_TDEASSERT_DISABLE, 1);
 	}


### PR DESCRIPTION
Fixes a few things with respect to the tdk robokit1 board

Sadly only one spi clock can be used with the software controlled gpio, so use the faster 24MHz (25MHz from the SAM) clock which works just fine.