### PR TITLE
drivers: uart_mcux: Do not select async support

### DIFF
--- a/drivers/serial/Kconfig.mcux
+++ b/drivers/serial/Kconfig.mcux
@@ -10,7 +10,6 @@ config UART_MCUX
 	depends on CLOCK_CONTROL
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
-	select SERIAL_SUPPORT_ASYNC
 	select PINCTRL
 	help
 	  Enable the MCUX uart driver.


### PR DESCRIPTION
Commit f1b0b458b03 mistakenly selected the SERIAL_SUPPORT_ASYNC kconfig for the kinetis uart driver when enabling the lpuart driver. Revert this, because the kinetis uart driver does not currently support async api.