### PR TITLE
logging: change log_output_timestamp_to_us() to take log_timestamp_t

### DIFF
--- a/include/zephyr/logging/log_output.h
+++ b/include/zephyr/logging/log_output.h
@@ -221,7 +221,7 @@ void log_output_timestamp_freq_set(uint32_t freq);
  *
  * @return Timestamp value in us.
  */
-uint64_t log_output_timestamp_to_us(uint32_t timestamp);
+uint64_t log_output_timestamp_to_us(log_timestamp_t timestamp);
 
 /**
  * @}

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -596,7 +596,7 @@ void log_output_timestamp_freq_set(uint32_t frequency)
 	freq = frequency;
 }
 
-uint64_t log_output_timestamp_to_us(uint32_t timestamp)
+uint64_t log_output_timestamp_to_us(log_timestamp_t timestamp)
 {
 	timestamp /= timestamp_div;
 


### PR DESCRIPTION
If CONFIG_LOG_TIMESTAMP_64BIT is enabled, the timestamp will be 64-bit