### PR TITLE
stm32f7, stm32h7: Avoid speculative reads from QSPI

### DIFF
--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -43,6 +43,13 @@
 		};
 	};
 
+	quadspi_memory: memory@90000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x90000000 DT_SIZE_M(256)>;
+		zephyr,memory-region = "QSPI";
+		zephyr,memory-region-mpu = "EXTMEM";
+	};
+
 	clocks {
 		clk_hse: clk-hse {
 			#clock-cells = <0>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -44,6 +44,13 @@
 		};
 	};
 
+	quadspi_memory: memory@90000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x90000000 DT_SIZE_M(256)>;
+		zephyr,memory-region = "QSPI";
+		zephyr,memory-region-mpu = "EXTMEM";
+	};
+
 	clocks {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/dts/bindings/base/zephyr,memory-region.yaml
+++ b/dts/bindings/base/zephyr,memory-region.yaml
@@ -25,6 +25,7 @@ properties:
       - "FLASH"
       - "PPB"
       - "IO"
+      - "EXTMEM"
     description: |
       Signify that this node should result in a dedicated MPU region. The
       region address and size are taken from the <reg> property, while the MPU

--- a/include/zephyr/arch/arm/aarch32/mpu/arm_mpu_v7m.h
+++ b/include/zephyr/arch/arm/aarch32/mpu/arm_mpu_v7m.h
@@ -137,6 +137,8 @@
 #define REGION_PPB_ATTR(size) { (STRONGLY_ORDERED_SHAREABLE | size | \
 		P_RW_U_NA_Msk) }
 #define REGION_IO_ATTR(size) { (DEVICE_NON_SHAREABLE | size | P_RW_U_NA_Msk) }
+#define REGION_EXTMEM_ATTR(size) { (STRONGLY_ORDERED_SHAREABLE | size | \
+		NO_ACCESS_Msk) }
 
 struct arm_mpu_region_attr {
 	/* Attributes belonging to RASR (including the encoded region size) */


### PR DESCRIPTION
As recommended in [AN4760](https://www.st.com/resource/en/reference_manual/dm00176879-stm32h745755-and-stm32h747757-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) the memory region where the QSPI flash can be memory mapped should be configured to be Strongly ordered memory. This works around an issue where a speculative read from the CPU may cause later problems with using the QSPI bus.

This avoids #57466.

I made this change in the standard Cortex-M arm_mpu_regions.c, even though it's applicable to only STM's Cortex-M7 chips, since we can use the device tree to make sure it's enabled only on devices where it's relevant. It also seems this perhaps should be done through the device tree now, but it was not clear to me how that could be done, especially not to set custom values to the regions. 

Note that the change has only tested on STM32F7, but it seems from ST's docs that it should be done on both F7 and H7, so I'm including the equivalent changes for both. 