### PR TITLE
boards: st: add ST Morpho nexus node

### DIFF
--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
@@ -8,6 +8,7 @@
 #include <st/f3/stm32f302X8.dtsi>
 #include <st/f3/stm32f302r(6-8)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F302R8-NUCLEO board";

--- a/boards/arm/nucleo_f302r8/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_f302r8/st_morpho_connector.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Teslabs Engineering S.L.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpiof 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpiof 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -8,6 +8,7 @@
 #include <st/g4/stm32g431Xb.dtsi>
 #include <st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32G431RB-NUCLEO board";

--- a/boards/arm/nucleo_g431rb/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_g431rb/st_morpho_connector.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Teslabs Engineering S.L.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpiof 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpiof 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/dts/bindings/gpio/st-morpho-header.yaml
+++ b/dts/bindings/gpio/st-morpho-header.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2023 Teslabs Engineering S.L.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  GPIO pins exposed on ST Morpho connector.
+
+  The ST morpho connector consists in male pin headers (CN7 and CN10) accessible
+  on both sides of any Nucleo board. They can be used to connect shields. All
+  signals and power pins of the STM32 are available on the ST morpho connector.
+
+compatible: "st-morpho-header"
+
+include: [gpio-nexus.yaml, base.yaml]

--- a/include/zephyr/dt-bindings/gpio/gpio.h
+++ b/include/zephyr/dt-bindings/gpio/gpio.h
@@ -14,6 +14,9 @@
  * @{
  */
 
+/** Mask for DT GPIO flags. */
+#define GPIO_DT_FLAGS_MASK 0x3F
+
 /**
  * @name GPIO pin active level flags
  * @{

--- a/include/zephyr/dt-bindings/gpio/st-morpho-header.h
+++ b/include/zephyr/dt-bindings/gpio/st-morpho-header.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Teslabs Engineering S.L.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef INCLUDE_ZEPHYR_DT_BINDINGS_GPIO_ST_MORPHO_HEADER_H_
+#define INCLUDE_ZEPHYR_DT_BINDINGS_GPIO_ST_MORPHO_HEADER_H_
+
+/** ST Morpho pin mask (0...75). */
+#define ST_MORPHO_PIN_MASK 0x7F
+
+/**
+ * @name ST Morpho pin identifiers
+ * @{
+ */
+#define ST_MORPHO_CN7_1	  0
+#define ST_MORPHO_CN7_2	  1
+#define ST_MORPHO_CN7_3	  2
+#define ST_MORPHO_CN7_4	  3
+#define ST_MORPHO_CN7_5	  4
+#define ST_MORPHO_CN7_6	  5
+#define ST_MORPHO_CN7_7	  6
+#define ST_MORPHO_CN7_8	  7
+#define ST_MORPHO_CN7_9	  8
+#define ST_MORPHO_CN7_10  9
+#define ST_MORPHO_CN7_11  10
+#define ST_MORPHO_CN7_12  11
+#define ST_MORPHO_CN7_13  12
+#define ST_MORPHO_CN7_14  13
+#define ST_MORPHO_CN7_15  14
+#define ST_MORPHO_CN7_16  15
+#define ST_MORPHO_CN7_17  16
+#define ST_MORPHO_CN7_18  17
+#define ST_MORPHO_CN7_19  18
+#define ST_MORPHO_CN7_20  19
+#define ST_MORPHO_CN7_21  20
+#define ST_MORPHO_CN7_22  21
+#define ST_MORPHO_CN7_23  22
+#define ST_MORPHO_CN7_24  23
+#define ST_MORPHO_CN7_25  24
+#define ST_MORPHO_CN7_26  25
+#define ST_MORPHO_CN7_27  26
+#define ST_MORPHO_CN7_28  27
+#define ST_MORPHO_CN7_29  28
+#define ST_MORPHO_CN7_30  29
+#define ST_MORPHO_CN7_31  30
+#define ST_MORPHO_CN7_32  31
+#define ST_MORPHO_CN7_33  32
+#define ST_MORPHO_CN7_34  33
+#define ST_MORPHO_CN7_35  34
+#define ST_MORPHO_CN7_36  35
+#define ST_MORPHO_CN7_37  36
+#define ST_MORPHO_CN7_38  37
+#define ST_MORPHO_CN10_1  38
+#define ST_MORPHO_CN10_2  39
+#define ST_MORPHO_CN10_3  40
+#define ST_MORPHO_CN10_4  41
+#define ST_MORPHO_CN10_5  42
+#define ST_MORPHO_CN10_6  43
+#define ST_MORPHO_CN10_7  44
+#define ST_MORPHO_CN10_8  45
+#define ST_MORPHO_CN10_9  46
+#define ST_MORPHO_CN10_10 47
+#define ST_MORPHO_CN10_11 48
+#define ST_MORPHO_CN10_12 49
+#define ST_MORPHO_CN10_13 50
+#define ST_MORPHO_CN10_14 51
+#define ST_MORPHO_CN10_15 52
+#define ST_MORPHO_CN10_16 53
+#define ST_MORPHO_CN10_17 54
+#define ST_MORPHO_CN10_18 55
+#define ST_MORPHO_CN10_19 56
+#define ST_MORPHO_CN10_20 57
+#define ST_MORPHO_CN10_21 58
+#define ST_MORPHO_CN10_22 59
+#define ST_MORPHO_CN10_23 60
+#define ST_MORPHO_CN10_24 61
+#define ST_MORPHO_CN10_25 62
+#define ST_MORPHO_CN10_26 63
+#define ST_MORPHO_CN10_27 64
+#define ST_MORPHO_CN10_28 65
+#define ST_MORPHO_CN10_29 66
+#define ST_MORPHO_CN10_30 67
+#define ST_MORPHO_CN10_31 68
+#define ST_MORPHO_CN10_32 69
+#define ST_MORPHO_CN10_33 70
+#define ST_MORPHO_CN10_34 71
+#define ST_MORPHO_CN10_35 72
+#define ST_MORPHO_CN10_36 73
+#define ST_MORPHO_CN10_37 74
+#define ST_MORPHO_CN10_38 75
+
+/** @} */
+
+#endif /* INCLUDE_ZEPHYR_DT_BINDINGS_GPIO_ST_MORPHO_HEADER_H_ */


### PR DESCRIPTION
This PR introduces the ST Morpho nexus node present in Nucleo boards. It has been added to a couple of boards, f302r8 and g431rb.