### PR TITLE
Bluetooth: Host: Fix sync subevent cmd length

### DIFF
--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1092,7 +1092,12 @@ int bt_le_per_adv_sync_subevent(struct bt_le_per_adv_sync *per_adv_sync,
 	struct bt_hci_cp_le_set_pawr_sync_subevent *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PER_ADV_SYNC_SUBEVENT, sizeof(*cp));
+	if (params->num_subevents > BT_HCI_PAWR_SUBEVENT_MAX) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PER_ADV_SYNC_SUBEVENT,
+				sizeof(*cp) + params->num_subevents);
 
 	if (!buf) {
 		return -ENOBUFS;


### PR DESCRIPTION
The subevents were not considered in the length of the command.

---

Found when running on nrf53 because hci_rpmsg has stricter checks on the commands than the softdevice controller driver has.