### PR TITLE
drivers: timer: stm32u5 lptimer wait for ready only once

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -447,11 +447,6 @@ static int sys_clock_driver_init(void)
 	/* ARROK bit validates the write operation to ARR register */
 	LL_LPTIM_EnableIT_ARROK(LPTIM);
 	stm32_lptim_wait_ready();
-#ifdef CONFIG_SOC_SERIES_STM32U5X
-	while (LL_LPTIM_IsActiveFlag_DIEROK(LPTIM) == 0) {
-	}
-	LL_LPTIM_ClearFlag_DIEROK(LPTIM);
-#endif
 	LL_LPTIM_ClearFlag_ARROK(LPTIM);
 
 	accumulated_lptim_cnt = 0;


### PR DESCRIPTION
The stm32_lptim_wait_ready() is waiting for the DIEROK flag with a while loop. 
It should not be repeated.

Following the https://github.com/zephyrproject-rtos/zephyr/pull/54501  one extra while loop remained on the LL_LPTIM_IsActiveFlag_DIEROK.
Removed to avoid infinite loop.

Signed-off-by: Francois Ramu <francois.ramu@st.com>