### PR TITLE
tests: Bluetooth: Mesh: run bsim mesh tests from non-preemptible thread

### DIFF
--- a/tests/bsim/bluetooth/mesh/src/main.c
+++ b/tests/bsim/bluetooth/mesh/src/main.c
@@ -74,8 +74,20 @@ bst_test_install_t test_installers[] = {
 	NULL
 };
 
-int main(void)
+static struct k_thread bsim_mesh_thread;
+static K_KERNEL_STACK_DEFINE(bsim_mesh_thread_stack, 4096);
+
+static void bsim_mesh_entry_point(void *, void *, void *)
 {
 	bst_main();
+}
+
+int main(void)
+{
+	k_thread_create(&bsim_mesh_thread, bsim_mesh_thread_stack,
+			K_KERNEL_STACK_SIZEOF(bsim_mesh_thread_stack), bsim_mesh_entry_point, NULL,
+			NULL, NULL, K_PRIO_COOP(1), 0, K_NO_WAIT);
+	k_thread_name_set(&bsim_mesh_thread, "BabbleSim BLE Mesh tests");
+
 	return 0;
 }

--- a/tests/bsim/bluetooth/mesh/src/test_blob.c
+++ b/tests/bsim/bluetooth/mesh/src/test_blob.c
@@ -717,7 +717,7 @@ static void test_cli_broadcast_trans(void)
 		FAIL("Broadcast did not trigger send CB");
 	}
 
-	if (k_sem_take(&blob_broad_next_sem, K_NO_WAIT)) {
+	if (k_sem_take(&blob_broad_next_sem, K_SECONDS(1))) {
 		FAIL("Broadcast did not trigger next CB");
 	}
 

--- a/tests/bsim/bluetooth/mesh/src/test_friendship.c
+++ b/tests/bsim/bluetooth/mesh/src/test_friendship.c
@@ -477,11 +477,6 @@ static void test_lpn_msg_mesh(void)
 	/* Receive an unsegmented message back */
 	ASSERT_OK(bt_mesh_test_recv(5, cfg->addr, K_FOREVER));
 
-	/* Workaround while bug #57043 has not been fixed.
-	 * For details: https://github.com/zephyrproject-rtos/zephyr/issues/57043
-	 */
-	k_sleep(K_SECONDS(1));
-
 	/* Send a segmented message to the mesh node. */
 	ASSERT_OK_MSG(bt_mesh_test_send(other_cfg.addr, 15, 0, K_FOREVER),
 		      "Send to other failed");

--- a/tests/bsim/bluetooth/mesh/src/test_transport.c
+++ b/tests/bsim/bluetooth/mesh/src/test_transport.c
@@ -179,11 +179,10 @@ static void test_tx_loopback(void)
 	bt_mesh_test_setup();
 
 	for (int i = 0; i < ARRAY_SIZE(test_vector); i++) {
-		bt_mesh_test_recv(test_vector[i].len, cfg->addr, K_NO_WAIT);
-		err = bt_mesh_test_send(cfg->addr, test_vector[i].len,
-					test_vector[i].flags,
-					K_SECONDS(20));
+		err = bt_mesh_test_send(cfg->addr, test_vector[i].len, test_vector[i].flags,
+					K_NO_WAIT);
 		ASSERT_OK_MSG(err, "Failed sending vector %d", i);
+		bt_mesh_test_recv(test_vector[i].len, cfg->addr, K_SECONDS(1));
 
 		if (test_stats.received != i + 1) {
 			FAIL("Didn't receive message %d", i);


### PR DESCRIPTION
BLE Mesh stack has been designed to work in non-preemtible environment. The PR fixes running bsim mesh test from main thread that is preemptible. Running mesh tests causes reentering in the same mesh functionality twice and rewriting ongoing data.