### PR TITLE
Add OpenTitan watchdog support

### DIFF
--- a/boards/riscv/opentitan_earlgrey/doc/index.rst
+++ b/boards/riscv/opentitan_earlgrey/doc/index.rst
@@ -43,6 +43,8 @@ the Earl Grey chip simulated in Verilator, a cycle-accurate HDL simulation tool.
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | SPI host                            |
 +-----------+------------+-------------------------------------+
+| WDT       | on-chip    | Always-On Timer (Watchdog)          |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 
@@ -89,8 +91,8 @@ References
 
 .. target-notes::
 
-.. _OpenTitan Earl Grey Chip Datasheet: https://docs.opentitan.org/hw/top_earlgrey/doc/
+.. _OpenTitan Earl Grey Chip Datasheet: https://opentitan.org/book/hw/top_earlgrey/doc/specification.html
 
 .. _OpenTitan GitHub: https://github.com/lowRISC/opentitan
 
-.. _OpenTitan Verilator Setup: https://docs.opentitan.org/doc/getting_started/setup_verilator/
+.. _OpenTitan Verilator Setup: https://opentitan.org/guides/getting_started/setup_verilator.html

--- a/boards/riscv/opentitan_earlgrey/opentitan_earlgrey.yaml
+++ b/boards/riscv/opentitan_earlgrey/opentitan_earlgrey.yaml
@@ -9,3 +9,5 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+supported:
+  - watchdog

--- a/drivers/watchdog/CMakeLists.txt
+++ b/drivers/watchdog/CMakeLists.txt
@@ -34,6 +34,7 @@ zephyr_library_sources_ifdef(CONFIG_WDT_SMARTBOND wdt_smartbond.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_TI_TPS382X wdt_ti_tps382x.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_XILINX_AXI wdt_xilinx_axi.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_INFINEON_CAT1 wdt_ifx_cat1.c)
+zephyr_library_sources_ifdef(CONFIG_WDT_OPENTITAN wdt_opentitan.c)
 
 zephyr_library_sources_ifdef(CONFIG_WDT_DW wdt_dw.c wdt_dw_common.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_INTEL_ADSP wdt_intel_adsp.c wdt_dw_common.c)

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -108,4 +108,6 @@ source "drivers/watchdog/Kconfig.xlnx"
 
 source "drivers/watchdog/Kconfig.ifx_cat1"
 
+source "drivers/watchdog/Kconfig.opentitan"
+
 endif # WATCHDOG

--- a/drivers/watchdog/Kconfig.opentitan
+++ b/drivers/watchdog/Kconfig.opentitan
@@ -1,0 +1,13 @@
+# OpenTitan Always-On Timer support
+
+# Copyright (c) 2023, Rivos Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config WDT_OPENTITAN
+	bool "OpenTitan Always-On (AON) Timer"
+	depends on DT_HAS_LOWRISC_OPENTITAN_AONTIMER_ENABLED
+	default y
+	select HAS_WDT_MULTISTAGE
+	help
+	  This option enables support for the watchdog portion of the OpenTitan AON
+	  timer.

--- a/drivers/watchdog/wdt_opentitan.c
+++ b/drivers/watchdog/wdt_opentitan.c
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2023 by Rivos Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT lowrisc_opentitan_aontimer
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/drivers/watchdog.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(wdt_opentitan, CONFIG_WDT_LOG_LEVEL);
+
+#define OT_REG_WDOG_REGWEN_OFFSET 0x10
+#define OT_REG_WDOG_CTRL_OFFSET 0x14
+#define OT_REG_WDOG_BARK_THOLD_OFFSET 0x18
+#define OT_REG_WDOG_BITE_THOLD_OFFSET 0x1C
+#define OT_REG_WDOG_COUNT_OFFSET 0x20
+#define OT_REG_INTR_STATE_OFFSET 0x24
+
+struct wdt_ot_aontimer_cfg {
+	uintptr_t regs;
+	uint32_t clk_freq;
+	bool wdog_lock;
+};
+
+struct wdt_ot_aontimer_data {
+	wdt_callback_t bark;
+};
+
+static int ot_aontimer_setup(const struct device *dev, uint8_t options)
+{
+	const struct wdt_ot_aontimer_cfg *const cfg = dev->config;
+	volatile uintptr_t regs = cfg->regs;
+
+	sys_write32(0, regs + OT_REG_WDOG_COUNT_OFFSET);
+	sys_write32(1, regs + OT_REG_WDOG_CTRL_OFFSET);
+	if (cfg->wdog_lock) {
+		/* Force a read to ensure the timer was enabled. */
+		(void) sys_read32(regs + OT_REG_WDOG_CTRL_OFFSET);
+		sys_write32(0, regs + OT_REG_WDOG_REGWEN_OFFSET);
+	}
+	return 0;
+}
+
+static int ot_aontimer_disable(const struct device *dev)
+{
+	const struct wdt_ot_aontimer_cfg *const cfg = dev->config;
+	volatile uintptr_t regs = cfg->regs;
+
+	if (!sys_read32(regs + OT_REG_WDOG_REGWEN_OFFSET)) {
+		LOG_ERR("Cannot disable - watchdog settings locked.");
+		return -EPERM;
+	}
+
+	uint32_t ctrl_val = sys_read32(regs + OT_REG_WDOG_CTRL_OFFSET);
+
+	if (!(ctrl_val & BIT(0))) {
+		return -EFAULT;
+	}
+	sys_write32(ctrl_val & ~BIT(0), regs + OT_REG_WDOG_CTRL_OFFSET);
+
+	return 0;
+}
+
+/*
+ * The OpenTitan AON Timer includes a multi-level watchdog timer.
+ * While the first stage supports an interrupt callback, the second does not.
+ * The second stage is mandatory to adjust the "bite" time window.
+ *
+ * Some boundaries are enforced to prevent behavior that is technically correct
+ * but is not likely intended.
+ * Bark:
+ * Minimum must be 0. Maximum must be > min.
+ * The bark interrupt occurs at max (or if the timeout is too long to be
+ * supported, the value x s.t. min < x < max and x is the largest valid timeout)
+ * Bite:
+ * Minimum must be >= bark.min, and maximum >= bark.max. If the timeout is too
+ * long to fit, it tries to find the value x s.t. min < x < max where x is the
+ * largest valid timeout.
+ * The bite action occurs max.
+ */
+static int ot_aontimer_install_timeout(const struct device *dev,
+					const struct wdt_timeout_cfg *cfg)
+{
+	struct wdt_ot_aontimer_data *data = dev->data;
+	const struct wdt_ot_aontimer_cfg *const dev_cfg = dev->config;
+	volatile uintptr_t reg_base = dev_cfg->regs;
+	const uint64_t max_window = (uint64_t) UINT32_MAX * 1000 / dev_cfg->clk_freq;
+	uint64_t bite_thold;
+#ifdef CONFIG_WDT_MULTISTAGE
+	/* When multistage is selected, add an intermediate bark stage */
+	uint64_t bark_thold;
+	struct wdt_timeout_cfg *bite = cfg->next;
+
+	if (bite == NULL || bite->window.max < cfg->window.max ||
+			(uint64_t) bite->window.min > max_window) {
+		return -EINVAL;
+	}
+	/*
+	 * Flag must be clear for stage 1, and reset SOC for stage 2.
+	 * CPU not supported
+	 */
+	if (cfg->flags != WDT_FLAG_RESET_NONE || bite->flags != WDT_FLAG_RESET_SOC) {
+		return -ENOTSUP;
+	}
+#endif
+
+	if (cfg->window.min > cfg->window.max || (uint64_t) cfg->window.min > max_window) {
+		return -EINVAL;
+	}
+
+	if (!sys_read32(reg_base + OT_REG_WDOG_REGWEN_OFFSET)) {
+		LOG_ERR("Cannot install timeout - watchdog settings locked.");
+		return -ENOMEM;
+	}
+
+	/* Watchdog is already enabled! */
+	if (sys_read32(reg_base + OT_REG_WDOG_CTRL_OFFSET) & BIT(0)) {
+		return -EBUSY;
+	}
+
+#ifdef CONFIG_WDT_MULTISTAGE
+	/* Force 64-bit ops to ensure thresholds fits in the timer reg. */
+	bark_thold = ((uint64_t) cfg->window.max * dev_cfg->clk_freq / 1000);
+	bite_thold = ((uint64_t) bite->window.max * dev_cfg->clk_freq / 1000);
+	/* Saturate these config values; min is verified to be < max_window */
+	if (bark_thold > UINT32_MAX) {
+		bark_thold = UINT32_MAX;
+	}
+	if (bite_thold > UINT32_MAX) {
+		bite_thold = UINT32_MAX;
+	}
+	data->bark = cfg->callback;
+	sys_write32((uint32_t) bark_thold, reg_base + OT_REG_WDOG_BARK_THOLD_OFFSET);
+	sys_write32((uint32_t) bite_thold, reg_base + OT_REG_WDOG_BITE_THOLD_OFFSET);
+#else
+	bite_thold = ((uint64_t) cfg->window.max * dev_cfg->clk_freq / 1000);
+	/* Saturate this config value; min is verified to be < max_window */
+	if (bite_thold > UINT32_MAX) {
+		bite_thold = UINT32_MAX;
+	}
+	if (cfg->flags == WDT_FLAG_RESET_NONE) {
+		/* Set bite -> bark, so we generate an interrupt instead of resetting */
+		sys_write32((uint32_t) bite_thold, reg_base + OT_REG_WDOG_BARK_THOLD_OFFSET);
+		/* Disable bite by writing it to max. Edge case is the bark = max. */
+		sys_write32(UINT32_MAX, reg_base + OT_REG_WDOG_BITE_THOLD_OFFSET);
+		data->bark = cfg->callback;
+	} else {
+		data->bark = NULL;
+		/* Effectively disable bark by setting it to max */
+		sys_write32(UINT32_MAX, reg_base + OT_REG_WDOG_BARK_THOLD_OFFSET);
+		sys_write32((uint32_t) bite_thold, reg_base + OT_REG_WDOG_BITE_THOLD_OFFSET);
+	}
+#endif
+
+	return 0;
+}
+
+static int ot_aontimer_feed(const struct device *dev, int channel_id)
+{
+	ARG_UNUSED(channel_id);
+	const struct wdt_ot_aontimer_cfg *const cfg = dev->config;
+	volatile uintptr_t regs = cfg->regs;
+
+	sys_write32(0, regs + OT_REG_WDOG_COUNT_OFFSET);
+
+	/* Deassert the interrupt line */
+	sys_write32(BIT(1), regs + OT_REG_INTR_STATE_OFFSET);
+	return 0;
+}
+
+static void wdt_ot_isr(const struct device *dev)
+{
+	const struct wdt_ot_aontimer_cfg *const cfg = dev->config;
+	struct wdt_ot_aontimer_data *data = dev->data;
+	volatile uintptr_t regs = cfg->regs;
+
+	if (data->bark != NULL) {
+		data->bark(dev, 0);
+	}
+
+	/* Deassert the interrupt line */
+	sys_write32(BIT(1), regs + OT_REG_INTR_STATE_OFFSET);
+}
+
+static int ot_aontimer_init(const struct device *dev)
+{
+	IRQ_CONNECT(
+		DT_INST_IRQ_BY_IDX(0, 0, irq),
+		DT_INST_IRQ_BY_IDX(0, 0, priority), wdt_ot_isr,
+		DEVICE_DT_INST_GET(0), 0);
+	irq_enable(DT_INST_IRQ_BY_IDX(0, 0, irq));
+
+	return 0;
+}
+
+static struct wdt_ot_aontimer_data ot_aontimer_data;
+
+static struct wdt_ot_aontimer_cfg ot_aontimer_cfg = {
+	.regs = (volatile uintptr_t) DT_INST_REG_ADDR(0),
+	.clk_freq = DT_INST_PROP(0, clock_frequency),
+	.wdog_lock = DT_INST_PROP(0, wdog_lock),
+};
+
+static const struct wdt_driver_api ot_aontimer_api = {
+	.setup = ot_aontimer_setup,
+	.disable = ot_aontimer_disable,
+	.install_timeout = ot_aontimer_install_timeout,
+	.feed = ot_aontimer_feed,
+};
+
+DEVICE_DT_INST_DEFINE(0, ot_aontimer_init, NULL,
+	&ot_aontimer_data, &ot_aontimer_cfg, PRE_KERNEL_1,
+	CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+	&ot_aontimer_api);

--- a/dts/bindings/power/lowrisc,opentitan-pwrmgr.yaml
+++ b/dts/bindings/power/lowrisc,opentitan-pwrmgr.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Rivos
+# SPDX-License-Identifier: Apache-2.0
+
+description: OpenTitan power management
+
+compatible: "lowrisc,opentitan-pwrmgr"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/bindings/watchdog/lowrisc,opentitan-aontimer.yaml
+++ b/dts/bindings/watchdog/lowrisc,opentitan-aontimer.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2023 Rivos Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: OpenTitan Always-On Timer driver
+
+compatible: "lowrisc,opentitan-aontimer"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  clock-frequency:
+    type: int
+    description: AON-Timer frequency
+    required: true
+
+  wdog-lock:
+    type: boolean
+    description: |
+      When set, lock watchdog configration after setup until the next
+      reset.

--- a/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
+++ b/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
@@ -63,6 +63,12 @@
 			status = "disabled";
 		};
 
+		pwrmgr: pwrmgr@40400000 {
+			compatible = "lowrisc,opentitan-pwrmgr";
+			reg = <0x40400000 0x80>;
+			status = "okay";
+		};
+
 		plic: interrupt-controller@48000000 {
 			compatible = "sifive,plic-1.0.0";
 			#address-cells = <0>;

--- a/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
+++ b/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
@@ -53,18 +53,29 @@
 			status = "disabled";
 		};
 
+		aontimer: aontimer@40470000 {
+			compatible = "lowrisc,opentitan-aontimer";
+			reg = <0x40470000 0x1000>;
+			interrupts = <156 1>;
+			interrupt-names = "wdog_bark";
+			interrupt-parent = <&plic>;
+			clock-frequency = <200000>;
+			status = "disabled";
+		};
+
 		plic: interrupt-controller@48000000 {
 			compatible = "sifive,plic-1.0.0";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = <0x48000000 0x00002000
-			       0x48002000 0x001fe000
-			       0x48000000 0x03e00000>;
+			reg = <0x48000000 0x00001000
+			       0x48002000 0x00001000
+			       0x48200000 0x00000008>;
 			reg-names = "prio", "irq_en", "reg";
 			riscv,max-priority = <7>;
 			riscv,ndev = <184>;
+			status = "okay";
 		};
 
 		uart0: serial@40000000{

--- a/samples/drivers/watchdog/boards/opentitan_earlgrey.overlay
+++ b/samples/drivers/watchdog/boards/opentitan_earlgrey.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023 Rivos Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &aontimer;
+	};
+};
+
+&aontimer {
+	status = "okay";
+};

--- a/soc/riscv/riscv-privilege/opentitan/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/opentitan/Kconfig.defconfig.series
@@ -24,7 +24,10 @@ config RISCV_GP
 config 2ND_LVL_ISR_TBL_OFFSET
 	default 32
 
+config 2ND_LVL_INTR_00_OFFSET
+	default 11
+
 config NUM_IRQS
-	default 216
+	default 217
 
 endif # SOC_SERIES_RISCV_OPENTITAN

--- a/soc/riscv/riscv-privilege/opentitan/soc.c
+++ b/soc/riscv/riscv-privilege/opentitan/soc.c
@@ -8,10 +8,18 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 
+#define PWRMGR_BASE (DT_REG_ADDR(DT_NODELABEL(pwrmgr)))
 #define RV_TIMER_BASE (DT_REG_ADDR(DT_NODELABEL(mtimer)))
 
 static int soc_opentitan_init(void)
 {
+	/* Enable the watchdog reset (bit 1). */
+	sys_write32(2u, PWRMGR_BASE + PWRMGR_RESET_EN_REG_OFFSET);
+	/* Write CFG_CDC_SYNC to commit change. */
+	sys_write32(1u, PWRMGR_BASE + PWRMGR_CFG_CDC_SYNC_REG_OFFSET);
+	/* Poll CFG_CDC_SYNC register until it reads 0. */
+	while (sys_read32(PWRMGR_BASE + PWRMGR_CFG_CDC_SYNC_REG_OFFSET)) {
+	}
 
 	/* Initialize the Machine Timer, so it behaves as a regular one. */
 	sys_write32(1u, RV_TIMER_BASE + RV_TIMER_CTRL_REG_OFFSET);

--- a/soc/riscv/riscv-privilege/opentitan/soc.h
+++ b/soc/riscv/riscv-privilege/opentitan/soc.h
@@ -10,6 +10,11 @@
 #include <soc_common.h>
 #include <zephyr/devicetree.h>
 
+/* OpenTitan power management regs. */
+#define PWRMGR_CFG_CDC_SYNC_REG_OFFSET  0x018
+#define PWRMGR_RESET_EN_REG_OFFSET      0x02c
+#define PWRMGR_RESET_EN_WDOG_SRC_MASK   0x002
+
 /* Ibex timer registers. */
 #define RV_TIMER_CTRL_REG_OFFSET        0x004
 #define RV_TIMER_INTR_ENABLE_REG_OFFSET 0x100

--- a/tests/drivers/watchdog/wdt_basic_api/boards/opentitan_earlgrey.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/opentitan_earlgrey.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023 Rivos Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &aontimer;
+	};
+};
+
+&aontimer {
+	status = "okay";
+};


### PR DESCRIPTION
The OpenTitan contains a HWIP called the Always-On (AON) Timer, which has two features - a wakeup timer and a watchdog timer. This patch series is concerned solely with the watchdog feature and does the following:
* Adds the OpenTitan watchdog dts binding
* Adds a driver for the watchdog
* Adds the watchdog for the OpenTitan Earlgrey "board".

More details in the commits.

The AON Timer spec can be found here:
https://opentitan.org/book/hw/ip/aon_timer/index.html

To make the watchdog interrupt work with OpenTitan Earlgrey, some changes were needed to be made to the PLIC configuration.