### PR TITLE
samples: espi: microchip: espi sample compile fix

### DIFF
--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -239,7 +239,10 @@ int spi_saf_init(void)
 	 */
 	jedec_id = 0U;
 	spi_cfg.slave = 0;
-	spi_cfg.cs = NULL;
+	spi_cfg.cs.delay = 0;
+	spi_cfg.cs.gpio.pin = 0;
+	spi_cfg.cs.gpio.dt_flags = 0;
+	spi_cfg.cs.gpio.port = NULL;
 
 	txb.buf = &safbuf;
 	txb.len = 1U;


### PR DESCRIPTION
Part of #56576 PR structure definition for "cs" changed from pointer to structure member.
It impacted mchp "espi" sample application during compilation, it uses "cs" as pointer to initialize. 
Updating the "cs" initialization as a structure member instead of pointer.