### PR TITLE
cmake: Rework snippet overlay processing scheme

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -158,6 +158,11 @@ if(DTC_OVERLAY_FILE)
     )
 endif()
 
+list(APPEND
+  dts_files
+  ${snippet_dts_files}
+  )
+
 set(i 0)
 foreach(dts_file ${dts_files})
   if(i EQUAL 0)

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -248,6 +248,7 @@ set(
   ${CONF_FILE_AS_LIST}
   ${shield_conf_files}
   ${OVERLAY_CONFIG_AS_LIST}
+  ${snippet_conf_files}
   ${EXTRA_KCONFIG_OPTIONS_FILE}
   ${config_files}
 )

--- a/cmake/modules/snippets.cmake
+++ b/cmake/modules/snippets.cmake
@@ -15,14 +15,12 @@
 # Outcome:
 # The following variables will be defined when this module completes:
 #
+# - snippet_conf_files: List of snippet-specific Kconfig fragments
+# - snippet_dts_files: List of snippet-specific devicetree files
 # - SNIPPET_AS_LIST: CMake list of snippet names, created from the
 #   SNIPPET variable
 # - SNIPPET_ROOT: CMake list of snippet roots, deduplicated and with
 #   ZEPHYR_BASE appended at the end
-#
-# The following variables may be updated when this module completes:
-# - DTC_OVERLAY_FILE
-# - OVERLAY_CONFIG
 #
 # The following targets will be defined when this CMake module completes:
 # - snippets: when invoked, a list of valid snippets will be printed
@@ -94,8 +92,8 @@ function(zephyr_process_snippets)
   include(${snippets_generated})
 
   # Propagate include()d build system settings to the caller.
-  set(DTC_OVERLAY_FILE ${DTC_OVERLAY_FILE} PARENT_SCOPE)
-  set(OVERLAY_CONFIG ${OVERLAY_CONFIG} PARENT_SCOPE)
+  set(snippet_conf_files ${snippet_conf_files} PARENT_SCOPE)
+  set(snippet_dts_files ${snippet_dts_files} PARENT_SCOPE)
 
   # Create the 'snippets' target. Each snippet is printed in a
   # separate command because build system files are not fond of

--- a/scripts/snippets.py
+++ b/scripts/snippets.py
@@ -39,6 +39,14 @@ def _new_append():
 def _new_board2appends():
     return defaultdict(_new_append)
 
+def append_var_to_cmake_var(name):
+    if name == "DTC_OVERLAY_FILE":
+        return "snippet_dts_files"
+    elif name == "OVERLAY_CONFIG":
+        return "snippet_conf_files"
+    else:
+        _err(f"unknown append variable: {name}")
+
 @dataclass
 class Snippet:
     '''Class for keeping track of all the settings discovered for an
@@ -167,8 +175,9 @@ if("${{BOARD}}" STREQUAL "{board}")''')
     def print_appends(self, appends: Appends, indent: int):
         space = '  ' * indent
         for name, values in appends.items():
+            cmake_var = append_var_to_cmake_var(name)
             for value in values:
-                self.print(f'{space}list(APPEND {name} {value})')
+                self.print(f'{space}list(APPEND {cmake_var} {value})')
 
     def print(self, *args, **kwargs):
         kwargs['file'] = self.out_file


### PR DESCRIPTION
This commit reworks the snippet implementation such that:

1. Snippet Kconfig and devicetree overlay lists are stored in the snippet-specific variables, `snippet_conf_files` and `snippet_dts_files`, instead of the global `OVERLAY_CONFIG` and `DTC_OVERLAY_FILE` variables, in order to avoid any conflicts when these variables are set in the cache.

2. Snippet Kconfig overlays in `snippet_conf_files` are processed after the overlays specified in the `OVERLAY_CONFIG` variable (e.g. application `prj.conf`).

3. Snippet devicetree overlays in `snippet_dts_files` are processed after the overlays specified in the `DTC_OVERLAY_FILE` variable (e.g. application `app.overlay`).

The snippet Kconfig and devicetree overlays are processed after the overlays specified in the `OVERLAY_CONFIG` and `DTC_OVERLAY_FILE` variables in order to ensure that the snippet configurations take precedence over the application default configurations -- this is necessary because snippets can be used to further customise and override the application default configurations.

---

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/57139