### PR TITLE
Change lsm6dso sensor hub names

### DIFF
--- a/drivers/sensor/lsm6dso/lsm6dso.h
+++ b/drivers/sensor/lsm6dso/lsm6dso.h
@@ -66,14 +66,7 @@ struct lsm6dso_config {
 #endif /* CONFIG_LSM6DSO_TRIGGER */
 };
 
-union samples {
-	uint8_t raw[6];
-	struct {
-		int16_t axis[3];
-	};
-} __aligned(2);
-
-#define LSM6DSO_SHUB_MAX_NUM_SLVS			2
+#define LSM6DSO_SHUB_MAX_NUM_TARGETS			3
 
 struct lsm6dso_data {
 	const struct device *dev;
@@ -85,7 +78,7 @@ struct lsm6dso_data {
 	int16_t temp_sample;
 #endif
 #if defined(CONFIG_LSM6DSO_SENSORHUB)
-	uint8_t ext_data[2][6];
+	uint8_t ext_data[LSM6DSO_SHUB_MAX_NUM_TARGETS][6];
 	uint16_t magn_gain;
 
 	struct hts221_data {
@@ -96,7 +89,7 @@ struct lsm6dso_data {
 	} hts221;
 	bool shub_inited;
 	uint8_t num_ext_dev;
-	uint8_t shub_ext[LSM6DSO_SHUB_MAX_NUM_SLVS];
+	uint8_t shub_ext[LSM6DSO_SHUB_MAX_NUM_TARGETS];
 #endif /* CONFIG_LSM6DSO_SENSORHUB */
 
 	uint16_t accel_freq;

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
@@ -23,28 +23,12 @@ static void lis2dw12_trigger_handler(const struct device *dev,
 
 #ifdef CONFIG_LSM6DSO_TRIGGER
 static int lsm6dso_acc_trig_cnt;
-static int lsm6dso_gyr_trig_cnt;
-static int lsm6dso_temp_trig_cnt;
 
 static void lsm6dso_acc_trig_handler(const struct device *dev,
 				     const struct sensor_trigger *trig)
 {
-	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
+	sensor_sample_fetch(dev);
 	lsm6dso_acc_trig_cnt++;
-}
-
-static void lsm6dso_gyr_trig_handler(const struct device *dev,
-				     const struct sensor_trigger *trig)
-{
-	sensor_sample_fetch_chan(dev, SENSOR_CHAN_GYRO_XYZ);
-	lsm6dso_gyr_trig_cnt++;
-}
-
-static void lsm6dso_temp_trig_handler(const struct device *dev,
-				      const struct sensor_trigger *trig)
-{
-	sensor_sample_fetch_chan(dev, SENSOR_CHAN_DIE_TEMP);
-	lsm6dso_temp_trig_cnt++;
 }
 #endif
 
@@ -154,14 +138,6 @@ static void lsm6dso_config(const struct device *lsm6dso)
 	trig.type = SENSOR_TRIG_DATA_READY;
 	trig.chan = SENSOR_CHAN_ACCEL_XYZ;
 	sensor_trigger_set(lsm6dso, &trig, lsm6dso_acc_trig_handler);
-
-	trig.type = SENSOR_TRIG_DATA_READY;
-	trig.chan = SENSOR_CHAN_GYRO_XYZ;
-	sensor_trigger_set(lsm6dso, &trig, lsm6dso_gyr_trig_handler);
-
-	trig.type = SENSOR_TRIG_DATA_READY;
-	trig.chan = SENSOR_CHAN_DIE_TEMP;
-	sensor_trigger_set(lsm6dso, &trig, lsm6dso_temp_trig_handler);
 #endif
 }
 
@@ -284,9 +260,6 @@ int main(void)
 
 #ifdef CONFIG_LSM6DSO_TRIGGER
 		printk("%d:: lsm6dso acc trig %d\n", cnt, lsm6dso_acc_trig_cnt);
-		printk("%d:: lsm6dso gyr trig %d\n", cnt, lsm6dso_gyr_trig_cnt);
-		printk("%d:: lsm6dso temp trig %d\n", cnt,
-			lsm6dso_temp_trig_cnt);
 #endif
 
 		cnt++;


### PR DESCRIPTION
lsm6dso sensor driver:    

1. Fix sensorhub names using the zephyr A.2 rule (use inclusive language).
    The only exception is names within STMEMSC API and h/w register names.
    
2. Extend the STMEMSC API usage. It is always better to not code again
    already available software functionalities.    
    
Tested using x_nucleo_iks01a3 shield
