### PR TITLE
net: pkt: Fix possible NULL dereference at net_pkt_cursor_operate()

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1623,7 +1623,7 @@ static int net_pkt_cursor_operate(struct net_pkt *pkt,
 			len = d_len;
 		}
 
-		if (copy) {
+		if (copy && data) {
 			memcpy(write ? c_op->pos : data,
 			       write ? data : c_op->pos,
 			       len);


### PR DESCRIPTION
Fix possible NULL dereference at net_pkt_cursor_operate() and resolve 'Dereference after null check' warnings from the Coverity static code analysis.