### PR TITLE
samples: modules: can opennode runs on stm32h573i_dk

### DIFF
--- a/samples/modules/canopennode/boards/stm32h573i_dk.overlay
+++ b/samples/modules/canopennode/boards/stm32h573i_dk.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* do not use the NOR octoflash for nvs can storage */
+&mx25lm51245 {
+	status = "disabled";
+};


### PR DESCRIPTION
Add an overlay to avoid running the samples/modules/canopennode on the external octo NOR flash of the stm32h573i disco kit.



Signed-off-by: Francois Ramu <francois.ramu@st.com>