### PR TITLE
drivers: serial: stm32 uart implements driver enable

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1695,6 +1695,23 @@ static int uart_stm32_init(const struct device *dev)
 	}
 #endif
 
+#ifdef USART_CR3_DEM
+	if (config->de_enable) {
+		if (!IS_UART_DRIVER_ENABLE_INSTANCE(config->usart)) {
+			LOG_ERR("%s does not support driver enable", dev->name);
+			return -EINVAL;
+		}
+
+		LL_USART_EnableDEMode(config->usart);
+		LL_USART_SetDEAssertionTime(config->usart, config->de_assert_time);
+		LL_USART_SetDEDeassertionTime(config->usart, config->de_deassert_time);
+
+		if (config->de_invert) {
+			LL_USART_SetDESignalPolarity(config->usart, LL_USART_DE_POLARITY_LOW);
+		}
+	}
+#endif
+
 	LL_USART_Enable(config->usart);
 
 #ifdef USART_ISR_TEACK
@@ -1908,6 +1925,10 @@ static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 	.tx_rx_swap = DT_INST_PROP_OR(index, tx_rx_swap, false),	\
 	.rx_invert = DT_INST_PROP(index, rx_invert),			\
 	.tx_invert = DT_INST_PROP(index, tx_invert),			\
+	.de_enable = DT_INST_PROP(index, de_enable),			\
+	.de_assert_time = DT_INST_PROP(index, de_assert_time),		\
+	.de_deassert_time = DT_INST_PROP(index, de_deassert_time),	\
+	.de_invert = DT_INST_PROP(index, de_invert),			\
 	STM32_UART_IRQ_HANDLER_FUNC(index)				\
 	STM32_UART_PM_WAKEUP(index)					\
 };									\

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -36,6 +36,14 @@ struct uart_stm32_config {
 	bool rx_invert;
 	/* enable tx pin inversion */
 	bool tx_invert;
+	/* enable de signal */
+	bool de_enable;
+	/* de signal assertion time in 1/16 of a bit */
+	uint8_t de_assert_time;
+	/* de signal deassertion time in 1/16 of a bit */
+	uint8_t de_deassert_time;
+	/* enable de pin inversion */
+	bool de_invert;
 	const struct pinctrl_dev_config *pcfg;
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) || \
 	defined(CONFIG_PM)

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -58,3 +58,31 @@ properties:
       configured masked at boot (sm32wl55 for instance), preventing the device to wakeup
       the core from stop mode(s).
       Valid range: 0 - 31
+
+  de-enable:
+    type: boolean
+    description: |
+      Enable activating an external transeiver through the DE pin which must also be configured
+      using pinctrl.
+
+  de-assert-time:
+    type: int
+    default: 0
+    description: |
+      Defines the time between the activation of the DE signal and the beginning of the start bit.
+      It is expressed in 16th of a bit time.
+      Valid range: 0 - 31
+
+  de-deassert-time:
+    type: int
+    default: 0
+    description: |
+      Defines the time between the activation of the DE signal and the beginning of the start bit.
+      It is expressed in 16th of a bit time.
+      Valid range: 0 - 31
+
+  de-invert:
+    type: boolean
+    description: |
+      Invert the binary logic of the de pin. When enabled, physical logic levels are inverted and
+      we use 1=Low, 0=High instead of 1=High, 0=Low.


### PR DESCRIPTION
Enables the use of the hardware DE pin provided by an stm32 UART using device tree flags.

There are only two items that I would like input on before making this an official pull request:

I was unsure on how to handle the assert/deassert times. The value written to the register must be between 0 and 31, but is in either 1/8 or 1/16 bit time depending on the oversampling. The simplest method would be to just limit the devicetree values to 0 through 31, but it wouldn't be clear what this was measuring. The cleanest would probably be to explicitly say that the values are in 1/16 bit times, and then scaling them depending on the oversampling. But I wasn't 100% sure what the driver was doing.

The second is about the `de-enable` property. I'm wondering if an enum with `none`, `high`, `low` would make more sense than separate `de-enable` and `de-invert` flags. I was just trying to match the nomenclature of the other flags initially, but I'll throw this out there for consideration.

Working waveforms with a DE assert time of 16, deassert time of 8, and both non-inverted and inverted DE:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/4633731/235977894-bc50f5c3-6d60-4a76-a2ab-c25b7aa19d41.png">
<img width="378" alt="image" src="https://user-images.githubusercontent.com/4633731/235978868-f6aec075-b10f-453b-84f5-7849e458456d.png">
