### PR TITLE
soc: arm: nxp: ensure code cache is enabled at boot for RT11xx

### DIFF
--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -659,6 +659,11 @@ static int imxrt_init(void)
 #ifndef CONFIG_IMXRT1XXX_CODE_CACHE
 	/* SystemInit enables code cache, disable it here */
 	SCB_DisableICache();
+#else
+	/* z_arm_init_arch_hw_at_boot() disables code cache if CONFIG_ARCH_CACHE is enabled,
+	 * enable it here.
+	 */
+	SCB_EnableICache();
 #endif
 
 	if (IS_ENABLED(CONFIG_IMXRT1XXX_DATA_CACHE)) {


### PR DESCRIPTION
Ensure code cache is enabled at boot for RT11xx. CMSIS SystemInit should enable the code cache, but if CONFIG_INIT_ARCH_HW_AT_BOOT=y and CONFIG_CACHE_MANAGEMENT=y, then the cache will be disabled after SystemInit is called. Since calling SCB_EnableICache will not change hardware settings if the ICACHE is already enabled, just call it unconditionally during init.

This fixes the same issue as described in #57349, as it also exists on the RT11xx series.