### PR TITLE
logging: trigger log process once reach threshold

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -167,7 +167,7 @@ static void z_log_msg_post_finalize(void)
 				      K_MSEC(CONFIG_LOG_PROCESS_THREAD_SLEEP_MS),
 				      K_NO_WAIT);
 		} else if (CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD &&
-			   cnt == CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD) {
+			   (cnt + 1) == CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD) {
 			k_timer_stop(&log_process_thread_timer);
 			k_sem_give(&log_process_thread_sem);
 		} else {


### PR DESCRIPTION
atomic_inc(&buffered_cnt) return previous count of log messages, should use current count to compare with threshold config value.