### PR TITLE
arch: x86: ia32: don't create FP context for NULL thread

### DIFF
--- a/arch/x86/core/ia32/float.c
+++ b/arch/x86/core/ia32/float.c
@@ -169,6 +169,10 @@ void z_float_enable(struct k_thread *thread, unsigned int options)
 	unsigned int imask;
 	struct k_thread *fp_owner;
 
+	if (!thread) {
+		return;
+	}
+
 	/* Ensure a preemptive context switch does not occur */
 
 	imask = irq_lock();
@@ -176,7 +180,6 @@ void z_float_enable(struct k_thread *thread, unsigned int options)
 	/* Indicate thread requires floating point context saving */
 
 	thread->base.user_options |= (uint8_t)options;
-
 	/*
 	 * The current thread might not allow FP instructions, so clear CR0[TS]
 	 * so we can use them. (CR0[TS] gets restored later on, if necessary.)


### PR DESCRIPTION
Enhance for cases when call z_float_enable() with NULL thread.