### PR TITLE
lib: getopt: Fix compiler warning.

### DIFF
--- a/lib/posix/getopt/getopt_long.c
+++ b/lib/posix/getopt/getopt_long.c
@@ -172,7 +172,7 @@ parse_long_options(struct getopt_state *state, char * const *nargv,
 {
 	char *current_argv, *has_equal;
 #ifdef GNU_COMPATIBLE
-	char *current_dash;
+	char *current_dash = "";
 #endif
 	size_t current_argv_len;
 	int i, match, exact_match, second_partial_match;
@@ -191,7 +191,6 @@ parse_long_options(struct getopt_state *state, char * const *nargv,
 			current_dash = "-W ";
 			break;
 		default:
-			current_dash = "";
 			break;
 		}
 	}

--- a/tests/posix/getopt/testcase.yaml
+++ b/tests/posix/getopt/testcase.yaml
@@ -16,3 +16,9 @@ tests:
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_PICOLIBC=y
+  portability.posix.getopt.logger:
+    integration_platforms:
+      - qemu_x86
+    extra_configs:
+      - CONFIG_LOG=y
+    build_only: true


### PR DESCRIPTION
current_dash may be used uninitialized

Fixes #57520