### PR TITLE
Bluetooth: Audio: Shell: Move audio defines to audio.h

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -23,4 +23,48 @@ ssize_t audio_pa_data_add(struct bt_data *data_array, const size_t data_array_si
 ssize_t csis_ad_data_add(struct bt_data *data, const size_t data_size, const bool discoverable);
 size_t cap_acceptor_ad_data_add(struct bt_data data[], size_t data_size, bool discoverable);
 
+#if defined(CONFIG_BT_AUDIO)
+/* Must guard before including audio.h as audio.h uses Kconfigs guarded by
+ * CONFIG_BT_AUDIO
+ */
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/bap_lc3_preset.h>
+#include <zephyr/bluetooth/audio/cap.h>
+
+struct named_lc3_preset {
+	const char *name;
+	struct bt_bap_lc3_preset preset;
+};
+
+#if defined(CONFIG_BT_BAP_UNICAST)
+
+#define UNICAST_SERVER_STREAM_COUNT                                                                \
+	COND_CODE_1(CONFIG_BT_ASCS, (CONFIG_BT_ASCS_ASE_SNK_COUNT + CONFIG_BT_ASCS_ASE_SRC_COUNT), \
+		    (0))
+#define UNICAST_CLIENT_STREAM_COUNT                                                                \
+	COND_CODE_1(CONFIG_BT_BAP_UNICAST_CLIENT,                                                  \
+		    (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT +                                  \
+		     CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT),                                  \
+		    (0))
+
+struct unicast_stream {
+	struct bt_cap_stream stream;
+	struct bt_codec codec;
+	struct bt_codec_qos qos;
+};
+
+extern struct unicast_stream unicast_streams[CONFIG_BT_MAX_CONN * (UNICAST_SERVER_STREAM_COUNT +
+								   UNICAST_CLIENT_STREAM_COUNT)];
+
+#if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
+
+extern struct bt_bap_unicast_group *default_unicast_group;
+extern struct bt_bap_ep *snks[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
+extern struct bt_bap_ep *srcs[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
+extern const struct named_lc3_preset *default_sink_preset;
+extern const struct named_lc3_preset *default_source_preset;
+#endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
+#endif /* CONFIG_BT_BAP_UNICAST */
+#endif /* CONFIG_BT_AUDIO */
+
 #endif /* __AUDIO_H */

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -16,6 +16,7 @@
 #include <zephyr/bluetooth/audio/cap.h>
 
 #include "shell/bt.h"
+#include "audio.h"
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 #define CAP_UNICAST_CLIENT_STREAM_COUNT ARRAY_SIZE(unicast_streams)

--- a/subsys/bluetooth/shell/bt.h
+++ b/subsys/bluetooth/shell/bt.h
@@ -31,50 +31,6 @@ extern struct bt_le_per_adv_sync *per_adv_syncs[CONFIG_BT_PER_ADV_SYNC_MAX];
 #endif /* CONFIG_BT_PER_ADV_SYNC */
 #endif /* CONFIG_BT_EXT_ADV */
 
-#if defined(CONFIG_BT_AUDIO)
-/* Must guard before including audio.h as audio.h uses Kconfigs guarded by
- * CONFIG_BT_AUDIO
- */
-#include <zephyr/bluetooth/audio/audio.h>
-#include <zephyr/bluetooth/audio/bap_lc3_preset.h>
-#include <zephyr/bluetooth/audio/cap.h>
-
-struct named_lc3_preset {
-	const char *name;
-	struct bt_bap_lc3_preset preset;
-};
-
-#if defined(CONFIG_BT_BAP_UNICAST)
-
-#define UNICAST_SERVER_STREAM_COUNT                                                                \
-	COND_CODE_1(CONFIG_BT_ASCS, (CONFIG_BT_ASCS_ASE_SNK_COUNT + CONFIG_BT_ASCS_ASE_SRC_COUNT), \
-		    (0))
-#define UNICAST_CLIENT_STREAM_COUNT                                                                \
-	COND_CODE_1(CONFIG_BT_BAP_UNICAST_CLIENT,                                                \
-		    (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT +                                \
-		     CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT),                                \
-		    (0))
-
-struct unicast_stream {
-	struct bt_cap_stream stream;
-	struct bt_codec codec;
-	struct bt_codec_qos qos;
-};
-
-extern struct unicast_stream unicast_streams[CONFIG_BT_MAX_CONN * (UNICAST_SERVER_STREAM_COUNT +
-								   UNICAST_CLIENT_STREAM_COUNT)];
-
-#if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
-
-extern struct bt_bap_unicast_group *default_unicast_group;
-extern struct bt_bap_ep *snks[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT];
-extern struct bt_bap_ep *srcs[CONFIG_BT_MAX_CONN][CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
-extern const struct named_lc3_preset *default_sink_preset;
-extern const struct named_lc3_preset *default_source_preset;
-#endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
-#endif /* CONFIG_BT_BAP_UNICAST */
-#endif /* CONFIG_BT_AUDIO */
-
 void conn_addr_str(struct bt_conn *conn, char *addr, size_t len);
 
 #endif /* __BT_H */


### PR DESCRIPTION
The generic BT shell header, bt.h, contained quite a few things related to audio, which should be put in the audio.h shell header file.