### PR TITLE
Bluetooth: Audio: Fix enum mismatch for codec get chan alloc

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -555,7 +555,8 @@ int bt_codec_cfg_get_frame_duration_us(const struct bt_codec *codec);
  *  @return BT_AUDIO_CODEC_PARSE_SUCCESS if value is found and stored in the pointer provided
  *          else a negative value of type @ref bt_audio_codec_parse_err.
  */
-int bt_codec_cfg_get_chan_allocation_val(const struct bt_codec *codec, uint32_t *chan_allocation);
+int bt_codec_cfg_get_chan_allocation_val(const struct bt_codec *codec,
+					 enum bt_audio_location *chan_allocation);
 
 /** @brief Extract frame size in octets from BT codec config
  *

--- a/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
+++ b/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
@@ -77,7 +77,7 @@ static void print_codec(const struct bt_codec *codec)
 	if (codec->id == BT_CODEC_LC3_ID) {
 		/* LC3 uses the generic LTV format - other codecs might do as well */
 
-		uint32_t chan_allocation;
+		enum bt_audio_location chan_allocation;
 
 		printk("  Frequency: %d Hz\n", bt_codec_cfg_get_freq(codec));
 		printk("  Frame Duration: %d us\n", bt_codec_cfg_get_frame_duration_us(codec));

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -123,7 +123,7 @@ static void print_codec(const struct bt_codec *codec)
 	if (codec->id == BT_CODEC_LC3_ID) {
 		/* LC3 uses the generic LTV format - other codecs might do as well */
 
-		uint32_t chan_allocation;
+		enum bt_audio_location chan_allocation;
 
 		printk("  Frequency: %d Hz\n", bt_codec_cfg_get_freq(codec));
 		printk("  Frame Duration: %d us\n", bt_codec_cfg_get_frame_duration_us(codec));

--- a/tests/bluetooth/tester/src/btp_bap.c
+++ b/tests/bluetooth/tester/src/btp_bap.c
@@ -91,7 +91,7 @@ static void print_codec(const struct bt_codec *codec)
 	if (codec->id == BT_CODEC_LC3_ID) {
 		/* LC3 uses the generic LTV format - other codecs might do as well */
 
-		uint32_t chan_allocation;
+		enum bt_audio_location chan_allocation;
 
 		LOG_DBG("  Frequency: %d Hz", bt_codec_cfg_get_freq(codec));
 		LOG_DBG("  Frame Duration: %d us", bt_codec_cfg_get_frame_duration_us(codec));


### PR DESCRIPTION
The function bt_codec_cfg_get_chan_allocation_val takes a pointer to an enum, rather than an uint32_t, but was wrongly defined in the header files and incorrectly used a few places.