### PR TITLE
introduce the STM32 system wakeup pins to exit low power modes

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
@@ -64,3 +64,10 @@
 &gpdma1 {
 	status = "okay";
 };
+
+&pwr_wkup {
+	status = "okay";
+	wkpins = <&wakeup7_pe8 STM32_PWR_WAKEUP_RISING>,
+		<&wakeup4_pa2 STM32_PWR_WAKEUP_RISING>,
+		<&wakeup6_pa5 STM32_PWR_WAKEUP_FALLING>;
+};

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -173,3 +173,8 @@
 		pinctrl-names = "default";
 	};
 };
+
+&pwr_wkup {
+	status = "okay";
+	wkpins = <&wakeup1_pa0>;
+};

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -213,3 +213,10 @@
 	bus-speed-data = <1000000>;
 	status = "okay";
 };
+
+&pwr_wkup {
+	status = "okay";
+	/* WARNING: wakeup4_pa2 is conflicting with lpuart1_tx_pa2 */
+	wkpins = <&wakeup2_pc13 STM32_PWR_WAKEUP_RISING>,
+		<&wakeup1_pa0 STM32_PWR_WAKEUP_FALLING>;
+};

--- a/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
@@ -178,3 +178,10 @@ zephyr_udc0: &usbotg_hs {
 &rng {
 	status = "okay";
 };
+
+&pwr_wkup {
+	status = "okay";
+	/* WARNING: wakeup2_pa2 is conflicting with lpuart1_tx_pa2 */
+	wkpins = <&wakeup4_pc13 STM32_PWR_WAKEUP_RISING STM32_PWR_WAKEUP_PULLUP>,
+		<&wakeup1_pa0 STM32_PWR_WAKEUP_FALLING STM32_PWR_WAKEUP_PULLDOWN>;
+};

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32c0_reset.h>
+#include <zephyr/dt-bindings/power/stm32_power.h>
 #include <freq.h>
 
 / {
@@ -296,6 +297,40 @@
 		ts-cal-vrefanalog = <3000>;
 		avgslope = <2530>;
 		io-channels = <&adc1 9>;
+		status = "disabled";
+	};
+	wakeup1_pa0: wakeup1_pa0 {
+		compatible = "st,stm32-wkup-pin1";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <1>;
+	};
+	wakeup2_pc13: wakeup2_pc13 {
+		compatible = "st,stm32-wkup-pin1";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <2>;
+	};
+	wakeup3_pe6: wakeup3_pe6 {
+		compatible = "st,stm32-wkup-pin1";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <3>;
+	};
+	wakeup4_pa2: wakeup4_pa2 {
+		compatible = "st,stm32-wkup-pin1";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <4>;
+	};
+	wakeup6_pb5: wakeup6_pb5 {
+		compatible = "st,stm32-wkup-pin1";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <6>;
+	};
+
+	pwr_wkup: pwr@40007000 {
+		compatible = "st,stm32-pwr";
+		reg = <0x40007000 0x400>; /* PWR register bank */
+		clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>;
+		pin-nb = <5>; /* 5 system WakeUp pins */
+		pin-pol;
 		status = "disabled";
 	};
 };

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -15,6 +15,7 @@
 #include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32f0_1_3_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/power/stm32_power.h>
 #include <freq.h>
 
 / {
@@ -347,6 +348,25 @@
 			interrupts = <9 0 10 0 10 0 11 0 11 0>;
 			status = "disabled";
 		};
+	};
+
+	wakeup1_pa0: wakeup1_pa0 {
+		compatible = "st,stm32-wkup-pin0";
+		#wkpin-cells = <0>;
+		syswakeup-pin = <1>;
+	};
+	wakeup2_pc13: wakeup2_pc13 {
+		compatible = "st,stm32-wkup-pin0";
+		#wkpin-cells = <0>;
+		syswakeup-pin = <2>;
+	};
+
+	pwr_wkup: pwr@40007000 {
+		compatible = "st,stm32-pwr";
+		reg = <0x40007000 0x400>; /* PWR register bank */
+		clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>;
+		pin-nb = <2>; /* 2 system WakeUp pins */
+		status = "disabled";
 	};
 };
 

--- a/dts/arm/st/f0/stm32f030Xc.dtsi
+++ b/dts/arm/st/f0/stm32f030Xc.dtsi
@@ -72,5 +72,30 @@
 			st,prescaler = <0>;
 			status = "disabled";
 		};
+
+		wakeup4_pa2: wakeup4_pa2 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <4>;
+		};
+		wakeup5_pc5: wakeup5_pc5 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <5>;
+		};
+		wakeup6_pb5: wakeup6_pb5 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <6>;
+		};
+		wakeup7_pb15: wakeup5_pb15 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <7>;
+		};
 	};
+};
+
+&pwr_wkup {
+	pin-nb = <6>; /* 6 system WakeUp pins */
 };

--- a/dts/arm/st/f0/stm32f042X6.dtsi
+++ b/dts/arm/st/f0/stm32f042X6.dtsi
@@ -18,5 +18,25 @@
 				reg = <0x08000000 DT_SIZE_K(32)>;
 			};
 		};
+
+		wakeup4_pa2: wakeup4_pa2 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <4>;
+		};
+		wakeup6_pb5: wakeup6_pb5 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <6>;
+		};
+		wakeup7_pb15: wakeup5_pb15 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <7>;
+		};
 	};
+};
+
+&pwr_wkup {
+	pin-nb = <5>; /* 5 system WakeUp pins */
 };

--- a/dts/arm/st/f0/stm32f070Xb.dtsi
+++ b/dts/arm/st/f0/stm32f070Xb.dtsi
@@ -86,5 +86,30 @@
 			st,prescaler = <0>;
 			status = "disabled";
 		};
+
+		wakeup4_pa2: wakeup4_pa2 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <4>;
+		};
+		wakeup5_pc5: wakeup5_pc5 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <5>;
+		};
+		wakeup6_pb5: wakeup6_pb5 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <6>;
+		};
+		wakeup7_pb15: wakeup5_pb15 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <7>;
+		};
 	};
+};
+
+&pwr_wkup {
+	pin-nb = <6>; /* 6 system WakeUp pins */
 };

--- a/dts/arm/st/f0/stm32f071Xb.dtsi
+++ b/dts/arm/st/f0/stm32f071Xb.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <mem.h>
-#include <st/f0/stm32f072.dtsi>
+#include <st/f0/stm32f071.dtsi>
 
 / {
 	sram0: memory@20000000 {

--- a/dts/arm/st/f0/stm32f091Xc.dtsi
+++ b/dts/arm/st/f0/stm32f091Xc.dtsi
@@ -17,5 +17,40 @@
 				reg = <0x08000000 DT_SIZE_K(256)>;
 			};
 		};
+
+		wakeup3_pe6: wakeup3_pe6 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <3>;
+		};
+		wakeup4_pa2: wakeup4_pa2 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <4>;
+		};
+		wakeup5_pc5: wakeup5_pc5 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <5>;
+		};
+		wakeup6_pb5: wakeup6_pb5 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <6>;
+		};
+		wakeup7_pb15: wakeup5_pb15 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <7>;
+		};
+		wakeup8_pf2: wakeup8_pf2 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <8>;
+		};
 	};
+};
+
+&pwr_wkup {
+	pin-nb = <8>; /* 8 system WakeUp pins */
 };

--- a/dts/arm/st/f0/stm32f098Xc.dtsi
+++ b/dts/arm/st/f0/stm32f098Xc.dtsi
@@ -17,5 +17,40 @@
 				reg = <0x08000000 DT_SIZE_K(256)>;
 			};
 		};
+
+		wakeup3_pe6: wakeup3_pe6 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <3>;
+		};
+		wakeup4_pa2: wakeup4_pa2 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <4>;
+		};
+		wakeup5_pc5: wakeup5_pc5 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <5>;
+		};
+		wakeup6_pb5: wakeup6_pb5 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <6>;
+		};
+		wakeup7_pb15: wakeup5_pb15 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <7>;
+		};
+		wakeup8_pf2: wakeup8_pf2 {
+			compatible = "st,stm32-wkup-pin0";
+			#wkpin-cells = <0>;
+			syswakeup-pin = <8>;
+		};
 	};
+};
+
+&pwr_wkup {
+	pin-nb = <8>; /* 8 system WakeUp pins */
 };

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -16,6 +16,8 @@
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32g4_l4_5_reset.h>
+#include <zephyr/dt-bindings/power/stm32_power.h>
+
 #include <freq.h>
 
 / {
@@ -684,6 +686,41 @@
 	usb_fs_phy: usbphy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;
+	};
+	wakeup1_pa0: wakeup1_pa0 {
+		compatible = "st,stm32-wkup-pin1";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <1>;
+	};
+	wakeup2_pc13: wakeup2_pc13 {
+		compatible = "st,stm32-wkup-pin1";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <2>;
+	};
+	wakeup3_pe6: wakeup3_pe6 {
+		compatible = "st,stm32-wkup-pin1";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <3>;
+	};
+	wakeup4_pa2: wakeup4_pa2 {
+		compatible = "st,stm32-wkup-pin1";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <4>;
+	};
+	wakeup5_pc5: wakeup5_pc5 {
+		compatible = "st,stm32-wkup-pin1";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <5>;
+	};
+
+	/* pwr register bank @40007000 */
+	pwr_wkup: pwr@40007000 {
+		compatible = "st,stm32-pwr";
+		reg = <0x40007000 0x400>; /* PWR register bank */
+		clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>;
+		pin-nb = <5>; /* 5 system WakeUp pins */
+		pin-pol;
+		status = "disabled";
 	};
 };
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -17,6 +17,7 @@
 #include <zephyr/dt-bindings/reset/stm32h7_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
+#include <zephyr/dt-bindings/power/stm32_power.h>
 #include <freq.h>
 
 / {
@@ -1019,6 +1020,37 @@
 		ts-cal-vrefanalog = <3300>;
 		ts-cal-resolution = <16>;
 		io-channels = <&adc3 18>;
+		status = "disabled";
+	};
+
+	wakeup1_pa0: wakeup1_pa0 {
+		compatible = "st,stm32-wkup-pin2";
+		#wkpin-cells = <2>;
+		syswakeup-pin = <1>;
+	};
+	wakeup2_pa2: wakeup2_pa2 {
+		compatible = "st,stm32-wkup-pin2";
+		#wkpin-cells = <2>;
+		syswakeup-pin = <2>;
+	};
+	wakeup4_pc13: wakeup1_pc13 {
+		compatible = "st,stm32-wkup-pin2";
+		#wkpin-cells = <2>;
+		syswakeup-pin = <4>;
+	};
+	wakeup6_pc1: wakeup2_pc1 {
+		compatible = "st,stm32-wkup-pin2";
+		#wkpin-cells = <2>;
+		syswakeup-pin = <6>;
+	};
+
+	pwr_wkup: pwr@40007000 {
+		compatible = "st,stm32-pwr";
+		reg = <0x58024800 0x400>; /* PWR register bank */
+		clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>;
+		pin-nb = <4>; /* 4 system WakeUp pins */
+		pin-pol;
+		pin-pupd;
 		status = "disabled";
 	};
 };

--- a/dts/arm/st/h7/stm32h742.dtsi
+++ b/dts/arm/st/h7/stm32h742.dtsi
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 Teslabs Engineering S.L.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/h7/stm32h7.dtsi>
+
+/ {
+	soc {
+		wakeup3_pi8: wakeup3_pi8 {
+			compatible = "st,stm32-wkup-pin2";
+			#wkpin-cells = <2>;
+			syswakeup-pin = <3>;
+		};
+		wakeup5_pi11: wakeup1_pi11 {
+			compatible = "st,stm32-wkup-pin2";
+			#wkpin-cells = <2>;
+			syswakeup-pin = <5>;
+		};
+	};
+};
+
+&pwr_wkup {
+	pin-nb = <6>; /* 6 system WakeUp pins */
+};

--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/h7/stm32h7.dtsi>
+#include <st/h7/stm32h742.dtsi>
 #include <zephyr/dt-bindings/display/stm32_ltdc.h>
 
 / {

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -128,4 +128,19 @@
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;
 	};
+
+	wakeup3_pi8: wakeup3_pi8 {
+		compatible = "st,stm32-wkup-pin2";
+		#wkpin-cells = <2>;
+		syswakeup-pin = <3>;
+	};
+	wakeup5_pi11: wakeup1_pi11 {
+		compatible = "st,stm32-wkup-pin2";
+		#wkpin-cells = <2>;
+		syswakeup-pin = <5>;
+	};
+};
+
+&pwr_wkup {
+	pin-nb = <6>; /* 6 system WakeUp pins */
 };

--- a/dts/arm/st/h7/stm32h750.dtsi
+++ b/dts/arm/st/h7/stm32h750.dtsi
@@ -89,4 +89,20 @@
 		reg = <0x20000000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "DTCM";
 	};
+
+	wakeup3_pi8: wakeup3_pi8 {
+		compatible = "st,stm32-wkup-pin2";
+		#wkpin-cells = <2>;
+		syswakeup-pin = <3>;
+	};
+	wakeup5_pi11: wakeup1_pi11 {
+		compatible = "st,stm32-wkup-pin2";
+		#wkpin-cells = <2>;
+		syswakeup-pin = <5>;
+	};
+
+};
+
+&pwr_wkup {
+	pin-nb = <6>; /* 6 system WakeUp pins */
 };

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -151,4 +151,19 @@
 		io-channels = <&adc2 18>;
 		ts-cal2-temp = <130>;
 	};
+
+	wakeup3_pi8: wakeup3_pi8 {
+		compatible = "st,stm32-wkup-pin2";
+		#wkpin-cells = <2>;
+		syswakeup-pin = <3>;
+	};
+	wakeup5_pi11: wakeup1_pi11 {
+		compatible = "st,stm32-wkup-pin2";
+		#wkpin-cells = <2>;
+		syswakeup-pin = <5>;
+	};
+};
+
+&pwr_wkup {
+	pin-nb = <6>; /* 6 system WakeUp pins */
 };

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -18,6 +18,7 @@
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-nor-psram.h>
 #include <zephyr/dt-bindings/adc/stm32u5_adc.h>
+#include <zephyr/dt-bindings/power/stm32_power.h>
 #include <freq.h>
 
 / {
@@ -838,6 +839,159 @@
 		ts-cal-vrefanalog = <3000>;
 		ts-cal-resolution = <14>;
 		io-channels = <&adc1 19>;
+		status = "disabled";
+	};
+
+	wakeup1_pa0: wakeup1_pa0 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <1>;
+		syswakeup-sel = <0>;
+	};
+	wakeup1_pb2: wakeup1_pb2 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <1>;
+		syswakeup-sel = <1>;
+	};
+	wakeup1_pe4: wakeup1_pe4 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <1>;
+		syswakeup-sel = <2>;
+	};
+	wakeup2_pa4: wakeup2_pa4 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <2>;
+		syswakeup-sel = <0>;
+	};
+	wakeup2_pc13: wakeup2_pc13 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <2>;
+		syswakeup-sel = <1>;
+	};
+	wakeup2_pe5: wakeup2_pe5 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <2>;
+		syswakeup-sel = <2>;
+	};
+	wakeup3_pe6: wakeup3_pe6 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <3>;
+		syswakeup-sel = <0>;
+	};
+	wakeup3_pa1: wakeup3_pa1 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <3>;
+		syswakeup-sel = <1>;
+	};
+	wakeup3_pb6: wakeup3_pb6 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <3>;
+		syswakeup-sel = <2>;
+	};
+	wakeup4_pa2: wakeup4_pa2 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <4>;
+		syswakeup-sel = <0>;
+	};
+	wakeup4_pb1: wakeup4_pb1 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <4>;
+		syswakeup-sel = <1>;
+	};
+	wakeup4_pb7: wakeup4_pb7 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <4>;
+		syswakeup-sel = <2>;
+	};
+	wakeup5_pc5: wakeup5_pc5 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <5>;
+		syswakeup-sel = <0>;
+	};
+	wakeup5_pa3: wakeup5_pa3 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <5>;
+		syswakeup-sel = <1>;
+	};
+	wakeup5_pb8: wakeup5_pb8 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <5>;
+		syswakeup-sel = <2>;
+	};
+	wakeup6_pb5: wakeup6_pb5 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <6>;
+		syswakeup-sel = <0>;
+	};
+	wakeup6_pa5: wakeup6_pa5 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <6>;
+		syswakeup-sel = <1>;
+	};
+	wakeup6_pe7: wakeup6_pe7 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <6>;
+		syswakeup-sel = <2>;
+	};
+	wakeup7_pb15: wakeup7_pb15 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <7>;
+		syswakeup-sel = <0>;
+	};
+	wakeup7_pa6: wakeup7_pa6 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <7>;
+		syswakeup-sel = <1>;
+	};
+	wakeup7_pe8: wakeup7_pe8 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <7>;
+		syswakeup-sel = <2>;
+	};
+	wakeup8_pf2: wakeup8_pf2 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <8>;
+		syswakeup-sel = <0>;
+	};
+	wakeup8_pa7: wakeup8_pa7 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <8>;
+		syswakeup-sel = <1>;
+	};
+	wakeup8_pb10: wakeup8_pb10 {
+		compatible = "st,stm32-wkup-pin-sel";
+		#wkpin-cells = <1>;
+		syswakeup-pin = <8>;
+		syswakeup-sel = <2>;
+	};
+
+	pwr_wkup: pwr@40007000 {
+		compatible = "st,stm32-pwr";
+		reg = <0x46020800 0x400>; /* PWR register bank */
+		clocks = <&rcc STM32_CLOCK_BUS_APB1 0x10000000>;
+		pin-nb = <8>; /* 8 system WakeUp pins */
 		status = "disabled";
 	};
 };

--- a/dts/bindings/power/st,stm32-pwr.yaml
+++ b/dts/bindings/power/st,stm32-pwr.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2023 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32 PWR controller for the WakeUp pins.
+
+compatible: "st,stm32-pwr"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  clocks:
+    required: true
+
+  pin-nb:
+    type: int
+    description: |
+      Max nb of system wakeUp pins. For example pin-nb = <4>; on the stm32g474re
+
+  pin-pol:
+    type: boolean
+    description: |
+      True if a wakeUp pin has polarity config Rising or Falling
+
+  pin-pupd:
+    type: boolean
+    description: |
+      True if a wakeUp pin has pull-up/down config
+
+  wkpins:
+    type: phandle-array
+    description: |
+      system wakeup pins and the polarity/pull config to trig the wakeup event.
+      For example <&wakeup2_pc13 STM32_PWR_WAKEUP_RISING>

--- a/dts/bindings/power/st,stm32-wkup-pin-sel.yaml
+++ b/dts/bindings/power/st,stm32-wkup-pin-sel.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2023 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+
+description: |
+  STM32 system wakeup Node for stm32U5
+  where each pin is multiplexed and
+  when polarity and pull-up/down are configurable for each pin.
+
+compatible: "st,stm32-wkup-pin-sel"
+
+properties:
+  syswakeup-pin:
+    type: int
+    description: |
+      nb (index) of the sys wakeup pin associated with the GPIO
+      For example PC13 is associated with wakeup pin nb <2> on the stm32u5
+
+  syswakeup-sel:
+    type: int
+    enum:
+      - 0
+      - 1
+      - 2
+    description: |
+      signal selection [0,1,2] of the sys wakeup pin associated with the GPIO
+      For example PC13 is associated with wakeup signal 1
+
+  "#wkpin-cells":
+    type: int
+    const: 1
+    description: |
+      reference to the system wakeup pin
+      with its polarity config to trig the wakeup event.
+
+# Parameter syntax of stm32 follows the st,stm32-pwr dts syntax
+
+wkpin-cells:
+  - polarity

--- a/dts/bindings/power/st,stm32-wkup-pin0.yaml
+++ b/dts/bindings/power/st,stm32-wkup-pin0.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32 system wakeup Node w/o polarity configuration
+
+compatible: "st,stm32-wkup-pin0"
+
+properties:
+  syswakeup-pin:
+    type: int
+    description: |
+      nb (index) of the sys wakeup pin associated with the GPIO
+      Ex. pin PC13 is associated with wakeup pin nb <2> on the stm32f0x
+
+  "#wkpin-cells":
+    type: int
+    const: 0
+    description: |
+      reference to the system wakeup pin and its polarity to trig the wakeup event.

--- a/dts/bindings/power/st,stm32-wkup-pin1.yaml
+++ b/dts/bindings/power/st,stm32-wkup-pin1.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2023 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32 system wakeup Node with polarity configuration
+
+compatible: "st,stm32-wkup-pin1"
+
+properties:
+  syswakeup-pin:
+    type: int
+    description: |
+      nb (index) of the sys wakeup pin associated with the GPIO
+      For example PC13 is associated with wakeup pin nb <2> on the stm32g474
+
+  "#wkpin-cells":
+    type: int
+    const: 1
+    description: |
+      reference to the system wakeup pin and its polarity to trig the wakeup event.
+
+# Parameter syntax of stm32 follows the st,stm32-pwr dts syntax
+
+wkpin-cells:
+  - polarity

--- a/dts/bindings/power/st,stm32-wkup-pin2.yaml
+++ b/dts/bindings/power/st,stm32-wkup-pin2.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2023 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+
+description: |
+  STM32 system wakeup Node for stm32H5, stm32H7 and stm32MP1
+  when polarity and pull-up/down are configurable for each pin.
+
+compatible: "st,stm32-wkup-pin2"
+
+properties:
+  syswakeup-pin:
+    type: int
+    description: |
+      nb (index) of the sys wakeup pin associated with the GPIO
+      For example PC13 is associated with wakeup pin nb <2> on the stm32h575
+
+  "#wkpin-cells":
+    type: int
+    const: 2
+    description: |
+      reference to the system wakeup pin and its polarity
+      plus its pull-up/down config to trig the wakeup event.
+
+# Parameter syntax of stm32 follows the st,stm32-pwr dts syntax
+
+wkpin-cells:
+  - polarity
+  - pupd

--- a/dts/bindings/power/st,stm32h5-wkup-pin.yaml
+++ b/dts/bindings/power/st,stm32h5-wkup-pin.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2023 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32 system wakeup Node for stm32H5, stm32H7 and stm32MP1
+
+compatible: "st,stm32h5-wkup-pin"
+
+properties:
+  syswakeup-pin:
+    type: int
+    description: |
+      nb (index) of the sys wakeup pin associated with the GPIO
+      For example PC13 is associated with wakeup pin nb <2> on the stm32g474
+
+  "#wkpin-cells":
+    type: int
+    const: 2
+    description: |
+      reference to the system wakeup pin and its polarity
+      plus its pull-up/down config to trig the wakeup event.
+
+# Parameter syntax of stm32 follows the dma client dts syntax
+
+wkpin-cells:
+  - polarity
+  - pupd

--- a/include/zephyr/dt-bindings/power/stm32_power.h
+++ b/include/zephyr/dt-bindings/power/stm32_power.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_STM32_POWER_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_STM32_POWER_H_
+
+/**
+ * @name custom detection polarity for system WakeUp pins
+ * @{
+ */
+/** POWER Wake Up polarity */
+#define STM32_PWR_WAKEUP_RISING	0
+#define STM32_PWR_WAKEUP_FALLING	1
+
+/** POWER Pull-Up/Down configuration */
+#define STM32_PWR_WAKEUP_NOPULL	0
+#define STM32_PWR_WAKEUP_PULLUP	1
+#define STM32_PWR_WAKEUP_PULLDOWN	2
+
+/* Some stm32 devices do not have all the LL_PWR_WAKEUP_PINx */
+#define LL_PWR_WAKEUP_PIN0 0
+#ifndef LL_PWR_WAKEUP_PIN3
+#define LL_PWR_WAKEUP_PIN3 0
+#endif /* LL_PWR_WAKEUP_PIN3 */
+#ifndef LL_PWR_WAKEUP_PIN5
+#define LL_PWR_WAKEUP_PIN5 0
+#endif /* LL_PWR_WAKEUP_PIN5 */
+#ifndef LL_PWR_WAKEUP_PIN6
+#define LL_PWR_WAKEUP_PIN6 0
+#endif /* LL_PWR_WAKEUP_PIN6 */
+#ifndef LL_PWR_WAKEUP_PIN7
+#define LL_PWR_WAKEUP_PIN7 0
+#endif /* LL_PWR_WAKEUP_PIN7 */
+#ifndef LL_PWR_WAKEUP_PIN8
+#define LL_PWR_WAKEUP_PIN8 0
+#endif /* LL_PWR_WAKEUP_PIN8 */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_STM32_POWER_H_ */

--- a/include/zephyr/dt-bindings/power/stm32_power.h
+++ b/include/zephyr/dt-bindings/power/stm32_power.h
@@ -19,6 +19,12 @@
 #define STM32_PWR_WAKEUP_PULLUP	1
 #define STM32_PWR_WAKEUP_PULLDOWN	2
 
+/** POWER stm32U5 pin Muxing selection */
+#define STM32_PWR_WAKEUP_SEL_0	0
+#define STM32_PWR_WAKEUP_SEL_1	1
+#define STM32_PWR_WAKEUP_SEL_2	2
+#define STM32_PWR_WAKEUP_SEL_3	3
+
 /* Some stm32 devices do not have all the LL_PWR_WAKEUP_PINx */
 #define LL_PWR_WAKEUP_PIN0 0
 #ifndef LL_PWR_WAKEUP_PIN3

--- a/soc/arm/st_stm32/common/CMakeLists.txt
+++ b/soc/arm/st_stm32/common/CMakeLists.txt
@@ -8,3 +8,8 @@ zephyr_sources_ifdef(CONFIG_STM32_BACKUP_SRAM stm32_backup_sram.c)
 zephyr_linker_sources_ifdef(CONFIG_STM32_BACKUP_SRAM SECTIONS stm32_backup_sram.ld)
 
 zephyr_sources(soc_config.c)
+if(CONFIG_PM)
+	zephyr_sources_ifdef(CONFIG_DT_HAS_ST_STM32_PWR_ENABLED
+		soc_pwr_config.c
+	)
+endif()

--- a/soc/arm/st_stm32/common/soc_pwr_config.c
+++ b/soc/arm/st_stm32/common/soc_pwr_config.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file
+ * @brief System module to configure the power system WakeUp pins
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/types.h>
+#include <soc.h>
+#include <zephyr/arch/cpu.h>
+#include <stm32_ll_system.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_pwr.h>
+
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/dt-bindings/power/stm32_power.h>
+
+#define DT_DRV_COMPAT st_stm32_pwr
+
+#define PWR_STM32_WAKEUP DT_NODELABEL(pwr_wkup)
+
+/* Give one more entry to ease the indexing */
+#define PWR_STM32_MAX_NB_WAKEUP_PINS	DT_INST_PROP(0, pin_nb)
+
+#define PWR_STM32_WAKEUP_PINS_POL	DT_INST_PROP(0, pin_pol)
+
+#define PWR_STM32_WAKEUP_PINS_PUPD	DT_INST_PROP(0, pin_pupd)
+
+/* Configure the polarity is possible of not */
+#define PWR_STM32_WAKEUP_PINS_TYPE0(i, _)	\
+	DT_NODE_HAS_COMPAT(DT_PHANDLE_BY_IDX(PWR_STM32_WAKEUP, wkpins, i), st_stm32_wkup_pin0)
+
+#define PWR_STM32_WAKEUP_PINS_TYPE1(i, _)	\
+	DT_NODE_HAS_COMPAT(DT_PHANDLE_BY_IDX(PWR_STM32_WAKEUP, wkpins, i), st_stm32_wkup_pin1)
+
+#define PWR_STM32_WAKEUP_PINS_TYPE2(i, _)	\
+	DT_NODE_HAS_COMPAT(DT_PHANDLE_BY_IDX(PWR_STM32_WAKEUP, wkpins, i), st_stm32_wkup_pin2)
+
+#define PWR_STM32_WAKEUP_PIN_DEF(i, _)	LL_PWR_WAKEUP_PIN##i
+#define PWR_STM32_WAKEUP_PIN(i)		LL_PWR_WAKEUP_PIN##i
+
+/*
+ * LookUp Table to store the LL_PWR_WAKEUP_PINx for each pin.
+ * Add one more to the list to have table_wakeup_pins[5] =  LL_PWR_WAKEUP_PIN5
+ */
+static const uint32_t table_wakeup_pins[PWR_STM32_MAX_NB_WAKEUP_PINS + 1] = {
+		LISTIFY(PWR_STM32_MAX_NB_WAKEUP_PINS, PWR_STM32_WAKEUP_PIN_DEF, (,)),
+		FOR_EACH(PWR_STM32_WAKEUP_PIN, (,), PWR_STM32_MAX_NB_WAKEUP_PINS)
+	};
+
+/* Nb of wakeup pin used for this &pwr_wkup node */
+#define PWR_STM32_WAKEUP_PINS	DT_PROP_LEN(PWR_STM32_WAKEUP, wkpins)
+
+#define PWR_STM32_WAKEUP_POS(i, _)	\
+	DT_PROP_BY_PHANDLE_IDX(PWR_STM32_WAKEUP, wkpins, i, syswakeup_pin)
+
+#define PWR_STM32_WAKEUP_POL(i, _) \
+	COND_CODE_1(PWR_STM32_WAKEUP_PINS_POL, \
+		(.polarity = DT_PHA_BY_IDX(PWR_STM32_WAKEUP, wkpins, i, polarity),), \
+		())
+
+#define PWR_STM32_WAKEUP_PUPD(i, _) \
+	COND_CODE_1(PWR_STM32_WAKEUP_PINS_PUPD, \
+		(.pupd =  DT_PHA_BY_IDX(PWR_STM32_WAKEUP, wkpins, i, pupd),), \
+		())
+
+/* Only one node_id = DT_NODELABEL(pwr_wkup) */
+#define PWR_STM32_WAKEUP_PIN_ENTRY(node_id, prop, index)	\
+	{ 							\
+		.position = PWR_STM32_WAKEUP_POS(index, _),	\
+		PWR_STM32_WAKEUP_POL(index, _)		\
+		PWR_STM32_WAKEUP_PUPD(index, _)		\
+	},
+
+/* Structure of each system WakeUp Pin */
+struct pwr_stm32_wakeup_pin {
+	uint8_t position;	/* The <syswakeup_pin> property of the phandle */
+#if PWR_STM32_WAKEUP_PINS_POL
+	bool polarity;		/* True if detection on the low level : FALLING edge */
+#endif /* PWR_STM32_WAKEUP_PINS_POL */
+#if PWR_STM32_WAKEUP_PINS_PUPD
+	uint8_t pupd;		/* The pull-up/pull-down of the phandle */
+#endif /* PWR_STM32_WAKEUP_PINS_PUPD */
+};
+
+/* Structure of the pwr driver configuration */
+struct pwr_stm32_cfg {
+	struct stm32_pclken pclken;
+	PWR_TypeDef *Instance;
+	const struct pwr_stm32_wakeup_pin *wakeup_pins;
+};
+
+static const struct pwr_stm32_wakeup_pin wakeup_pins_list[] = {
+	DT_FOREACH_PROP_ELEM(PWR_STM32_WAKEUP, wkpins, PWR_STM32_WAKEUP_PIN_ENTRY)
+};
+
+/* One instanciation of the pwr device */
+static const struct pwr_stm32_cfg pwr_stm32_dev_cfg = {
+	.pclken = {
+		.enr = DT_INST_CLOCKS_CELL(0, bits),
+		.bus = DT_INST_CLOCKS_CELL(0, bus),
+	},
+	.Instance = (PWR_TypeDef *)DT_INST_REG_ADDR(0),
+	.wakeup_pins = wakeup_pins_list,
+};
+
+/**
+ * @brief Perform SoC configuration at boot.
+ *
+ * This should be run early during the boot process but after basic hardware
+ * initialization is done.
+ *
+ * @return 0
+ */
+static int stm32_pwr_init(void)
+{
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	uint32_t table_index;
+
+	if (!device_is_ready(clk)) {
+		/* clock control device not ready */
+		return -ENODEV;
+	}
+
+	/* enable Power clock */
+	if (clock_control_on(clk,
+		(clock_control_subsys_t) &pwr_stm32_dev_cfg.pclken) != 0) {
+		return -EIO;
+	}
+
+	/* Get the nb of len_syswkup_pins in the phandle-array */
+	uint32_t len_syswkup_pins = PWR_STM32_WAKEUP_PINS;
+
+	if (len_syswkup_pins > PWR_STM32_MAX_NB_WAKEUP_PINS) {
+		/*% selected pins exceeds PWR_STM32_MAX_NB_WAKEUP_PINS */
+		return -ENODEV;
+	}
+
+	/* Get each element at index in the phandle array  */
+	for (int index = 0; index < len_syswkup_pins; index++) {
+		/*
+		 * Get the syswakeup-pin property of this phandle index,
+		 * this is the entry in the table_wakeup_pins
+		 */
+		table_index = pwr_stm32_dev_cfg.wakeup_pins[index].position;
+
+		LL_PWR_EnableWakeUpPin(table_wakeup_pins[table_index]);
+#if PWR_STM32_WAKEUP_PINS_POL
+		/* Set the polarity at this index */
+		if (pwr_stm32_dev_cfg.wakeup_pins[index].polarity == STM32_PWR_WAKEUP_RISING) {
+			LL_PWR_SetWakeUpPinPolarityHigh(table_wakeup_pins[table_index]);
+		} else {
+			LL_PWR_SetWakeUpPinPolarityLow(table_wakeup_pins[table_index]);
+		}
+#endif /* PWR_STM32_WAKEUP_PINS_POL */
+
+#if PWR_STM32_WAKEUP_PINS_PUPD
+		/* Set the pull-up/down at this index */
+		if (pwr_stm32_dev_cfg.wakeup_pins[index].pupd == STM32_PWR_WAKEUP_PULLUP) {
+			LL_PWR_SetWakeUpPinPullUp(table_wakeup_pins[table_index]);
+		} else if (pwr_stm32_dev_cfg.wakeup_pins[index].pupd == STM32_PWR_WAKEUP_PULLDOWN) {
+			LL_PWR_SetWakeUpPinPullDown(table_wakeup_pins[table_index]);
+		} else {
+			LL_PWR_SetWakeUpPinPullNone(table_wakeup_pins[table_index]);
+		}
+#endif /* PWR_STM32_WAKEUP_PINS_PUPD */
+	}
+
+	return 0;
+}
+
+/* Only one instance of st_stm32_pwr */
+
+SYS_INIT(stm32_pwr_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
implementation of the https://github.com/zephyrproject-rtos/zephyr/issues/57323
for the stm32C0, stm32F0, stm32H7, stm32G4

For each stm32 serie, for example the stm32g4, the dts/arm/st/g4/stm32g4.dtsi contains the definition of each wakeUp pin with the related compatible = "st,stm32-wkup-pinx"; 
```
	wakeup1_pa0: wakeup1_pa0 {
		compatible = "st,stm32-wkup-pin1";
		#wkpin-cells = <1>;
		syswakeup-pin = <1>;
	};
```

Signed-off-by: Francois Ramu <francois.ramu@st.com>