### PR TITLE
west.yaml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 1558e7ab0aadb4eac11f03befb5ccd3fa3f0aafe
+      revision: 2878eb4e32fabc14bc391c3221cbf285064d9db4
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  2878eb4e32fabc14bc391c3221cbf285064d9db4

Brings following Zephyr relevant fixes:
 - ec2ac82c boot/zephyr: switch main return type to 'int'
 - 67693442 boot: zephyr: esp32: zephyr port
 - 0a1ef372 bootutil/crypto: Move BOOTUTIL_CRYPTO_ECDSA_P256_HASH_SIZE into common
 - 10529d30 bootutil/crypto: Have a single ECDSA verification module
 - 966ac818 bootutil/crypto: Extend ECDSA to support P384 curve
 - 25390ad5 bootutil/crypto: Have a single ECDSA abstraction file
 - cf36d670 bootutil/crypto: Add license disclaimer to ecdsa_p256.h
 - 557451d2 bootutil/crypto: Add a generic signature validation module for ECDSA
 - c725cee1 docs: Add release note snippet for ECDSA TLV
 - 30978516 sim: Remove curve specific ECDSA TLVs
 - 6205c10f sim: Add generic ECDSA TLV support
 - 5704174c imgtool: Add generic ECDSA TLV support
 - b08e77e0 bootutil: Create new generic ECDSA TLV

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.