### PR TITLE
Tests filter fixes for POSIX arch

### DIFF
--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -27,7 +27,7 @@ tests:
   sample.shell.shell_module.getopt:
     integration_platforms:
       - qemu_x86
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart") and not CONFIG_NEWLIB_LIBC
     tags: shell
     harness: keyboard

--- a/samples/subsys/usb/audio/headphones_microphone/sample.yaml
+++ b/samples/subsys/usb/audio/headphones_microphone/sample.yaml
@@ -4,7 +4,7 @@ tests:
   sample.usb.audio.headphones_microphone:
     depends_on: usb_device
     tags: usb
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp

--- a/samples/subsys/usb/audio/headset/sample.yaml
+++ b/samples/subsys/usb/audio/headset/sample.yaml
@@ -4,7 +4,7 @@ tests:
   sample.usb.audio.headset:
     depends_on: usb_device
     tags: usb
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp

--- a/samples/subsys/usb/cdc_acm/sample.yaml
+++ b/samples/subsys/usb/cdc_acm/sample.yaml
@@ -4,7 +4,7 @@ tests:
   sample.usb.cdc-acm:
     depends_on: usb_device
     tags: usb
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     harness: console
     harness_config:
       type: one_line
@@ -23,7 +23,7 @@ tests:
   sample.usb.cdc-acm.comp:
     depends_on: usb_device
     tags: usb
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     extra_args: OVERLAY_CONFIG=overlay-composite-cdc-msc.conf
     harness: console
     harness_config:
@@ -33,7 +33,7 @@ tests:
   sample.usb.cdc-acm.buildonly:
     depends_on: usb_device
     tags: usb
-    platform_allow: native_posix native_posix_64
+    arch_allow: posix
     build_only: true
     integration_platforms:
       - native_posix

--- a/samples/subsys/usb/cdc_acm_composite/sample.yaml
+++ b/samples/subsys/usb/cdc_acm_composite/sample.yaml
@@ -4,7 +4,7 @@ tests:
   sample.usb.cdc-acm-composite:
     depends_on: usb_device
     tags: usb
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     harness: console
     harness_config:
       type: one_line

--- a/samples/subsys/usb/dfu/sample.yaml
+++ b/samples/subsys/usb/dfu/sample.yaml
@@ -3,7 +3,8 @@ sample:
 
 common:
   build_only: true
-  platform_exclude: native_posix native_posix_64 mimxrt1010_evk
+  arch_exclude: posix
+  platform_exclude: mimxrt1010_evk
     mimxrt1050_evk_qspi mimxrt1020_evk mimxrt1015_evk mimxrt1060_evk sam4l_ek
     mimxrt1050_evk mimxrt1060_evk_hyperflash nucleo_f207zg teensy40 teensy41
     b_u585i_iot02a frdm_kl25z lpcxpresso55s69_cpu0 stm32l562e_dk_ns

--- a/samples/subsys/usb/hid/sample.yaml
+++ b/samples/subsys/usb/hid/sample.yaml
@@ -4,7 +4,7 @@ tests:
   sample.usb.hid:
     depends_on: usb_device
     tags: usb
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     harness: console
     harness_config:
       type: multi_line
@@ -16,7 +16,7 @@ tests:
     extra_configs:
       - CONFIG_USB_COMPOSITE_DEVICE=y
     tags: usb
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     harness: console
     harness_config:
       type: multi_line

--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -4,7 +4,7 @@ tests:
   sample.usb.mass_ram_none:
     min_ram: 64
     depends_on: usb_device
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     extra_configs:
       - CONFIG_LOG_DEFAULT_LEVEL=3
     tags: msd usb
@@ -33,7 +33,7 @@ tests:
   sample.usb.mass_ram_fat:
     min_ram: 128
     depends_on: usb_device
-    platform_exclude: native_posix native_posix_64
+    arch_exclude: posix
     extra_configs:
       - CONFIG_LOG_DEFAULT_LEVEL=3
       - CONFIG_APP_MSC_STORAGE_RAM=y

--- a/tests/kernel/timer/cycle64/testcase.yaml
+++ b/tests/kernel/timer/cycle64/testcase.yaml
@@ -13,10 +13,10 @@ tests:
   kernel.timer.cycle64:
     tags: kernel timer
     filter: CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
-    platform_exclude: native_posix
+    arch_exclude: posix
     timeout: 140
     slow: true
   kernel.timer.cycle64.fast:
     tags: kernel timer
     filter: CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
-    platform_allow: native_posix
+    arch_allow: posix

--- a/tests/lib/c_lib/testcase.yaml
+++ b/tests/lib/c_lib/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   tags: clib
-  platform_exclude: native_posix native_posix_64 nrf52_bsim
+  arch_exclude: posix
 tests:
   libraries.libc:
     ignore_faults: true

--- a/tests/lib/cbprintf_fp/testcase.yaml
+++ b/tests/lib/cbprintf_fp/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   harness: console
-  platform_exclude: native_posix native_posix_64 nrf52_bsim
+  arch_exclude: posix
   tags: cbprintf
   integration_platforms:
     - qemu_x86

--- a/tests/lib/sprintf/testcase.yaml
+++ b/tests/lib/sprintf/testcase.yaml
@@ -4,7 +4,7 @@ tests:
     filter: not CONFIG_SOC_MCIMX7_M4 and CONFIG_STDOUT_CONSOLE
     integration_platforms:
     - qemu_x86
-    platform_exclude: native_posix native_posix_64 nrf52_bsim
+    arch_exclude: posix
     tags: libc
     ignore_faults: true
     testcases:
@@ -23,7 +23,7 @@ tests:
     - snprintf
   libraries.libc.sprintf_new:
     extra_args: CONF_FILE=prj_new.conf
-    platform_exclude: native_posix native_posix_64 nrf52_bsim
+    arch_exclude: posix
     tags: libc
     testcases:
     - EOF


### PR DESCRIPTION
    tests: Use posix arch exclude where appropriate
    
    Some tests were filtering by explicitly listing
    all posix arch boards.
    Filter by the arch instead.

-------------

    samples: shell: Fix filtering for POSIX arch
    
    One of these samples was filtering all POSIX arch
    boards out by explictly listing them by name
    (and for the nrf52_bsim by lack of UART).
    
    Instead filter by the architecture.
    
    There is no functional difference in tree with this change.
    
---------------

    samples/usb: Fix filtering for POSIX arch
    
    Some of these samples were filtering all POSIX arch
    boards out by explictly listing them by name
    (and for the nrf52_bsim by lack of usb_device).
    
    Instead filter by the architecture.
    
    There is no functional difference in tree with this change.
    
-----------

    tests: timer cycle64: Fix filtering for POSIX arch
    
    This test was excluding and including only
    the native_posix board, while it should have instead
    excluded/allowed anything in the architecture.
    => Change the filtering accordingly.