### PR TITLE
Twister config names

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -80,6 +80,7 @@ class TestPlan:
 
     SAMPLE_FILENAME = 'sample.yaml'
     TESTSUITE_FILENAME = 'testcase.yaml'
+    TWISTER_FILENAME = 'twister.yaml'
 
     def __init__(self, env=None):
 
@@ -497,6 +498,8 @@ class TestPlan:
                     filename = self.SAMPLE_FILENAME
                 elif self.TESTSUITE_FILENAME in filenames:
                     filename = self.TESTSUITE_FILENAME
+                elif self.TWISTER_FILENAME in filenames:
+                    filename = self.TWISTER_FILENAME
                 else:
                     continue
 

--- a/scripts/utils/twister_to_list.py
+++ b/scripts/utils/twister_to_list.py
@@ -51,7 +51,7 @@ def twister_to_list(project, dry_run):
     yaml.preserve_quotes = True
 
     for p in project.glob("**/*"):
-        if p.name not in ("testcase.yaml", "sample.yaml"):
+        if p.name not in ("testcase.yaml", "sample.yaml", "twister.yaml"):
             continue
 
         conf = yaml.load(p)

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -260,7 +260,7 @@ class Build(Forceable):
 
     def _parse_test_item(self, test_item):
         found_test_metadata = False
-        for yp in ['sample.yaml', 'testcase.yaml']:
+        for yp in ['sample.yaml', 'testcase.yaml', 'twister.yaml']:
             yf = os.path.join(self.args.source_dir, yp)
             if not os.path.exists(yf):
                 continue


### PR DESCRIPTION
In some scenarios, like applications, we may want to use twister to
build multiple configurations. The "sample" or "testcase" file names may
not specify the purpose of it, so allow "twister" name as well. It is a
name that clearly identifies the file with Twister, without any
particular purpose.