### PR TITLE
west.yml: Update NXP HAL to get fixed SDK drivers

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -100,7 +100,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 69d57af9ae499c07dd2348e9d4cf4c9f781486c9
+      revision: 6053bdcb5889cb2b1dd720ece03127db4d897292
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Some SDK driver changes were overwritten by the recent update to SDK 2.13