### PR TITLE
Make ESPI/I2C_EMUL depend on EMUL

### DIFF
--- a/drivers/espi/Kconfig.espi_emul
+++ b/drivers/espi/Kconfig.espi_emul
@@ -5,6 +5,7 @@ config ESPI_EMUL
 	bool "eSPI emulator"
 	default y
 	depends on DT_HAS_ZEPHYR_ESPI_EMUL_CONTROLLER_ENABLED
+	depends on EMUL
 	help
 	  Enable the eSPI emulator driver. This is a fake driver,
 	  it does not talk to real hardware. Instead it talks to emulation

--- a/drivers/i2c/Kconfig.i2c_emul
+++ b/drivers/i2c/Kconfig.i2c_emul
@@ -5,6 +5,7 @@ config I2C_EMUL
 	bool "I2C emulator"
 	default y
 	depends on DT_HAS_ZEPHYR_I2C_EMUL_CONTROLLER_ENABLED
+	depends on EMUL
 	help
 	  Enable the I2C emulator driver. This is a fake driver in that it
 	  does not talk to real hardware. Instead it talks to emulation


### PR DESCRIPTION
~~Throughout our emulated off-chip peripheral tests we require the explicit setting of CONFIG_EMUL=y while also requiring an emulated bus in the overlay. This is a bit redundant and may cause confusing linking errors if an emulated bus controler such as zephyr,i2c-emul-controller is enabled without CONFIG_EMUL also being enabled.~~

~~Have EMUL be selected in the emulated bus controller kconfigs so that EMUL is implicitly enabled by having an emulated bus controller in the DT overlay.~~

Make ESPI/I2C_EMUL depend on EMUL because it shows a clear Kconfig dependency on config EMUL but also it produces easier to understand linker errors if someone forgets to enable CONFIG_EMUL.