### PR TITLE
drivers: spi: esp32xx: Add chip select setup and hold time

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -338,6 +338,13 @@ static int IRAM_ATTR spi_esp32_configure(const struct device *dev,
 		hal_dev->mode |= BIT(1);
 	}
 
+	/* Chip select setup and hold times */
+	/* GPIO CS have their own delay parameter*/
+	if (!spi_cs_is_gpio(spi_cfg)) {
+		hal_dev->cs_hold = cfg->cs_hold;
+		hal_dev->cs_setup = cfg->cs_setup;
+	}
+
 	spi_hal_setup_device(hal, hal_dev);
 
 	/*
@@ -496,6 +503,8 @@ static const struct spi_driver_api spi_api = {
 		.dma_enabled = DT_INST_PROP(idx, dma_enabled),	\
 		.dma_clk_src = DT_INST_PROP(idx, dma_clk),	\
 		.dma_host = DT_INST_PROP(idx, dma_host),	\
+		.cs_setup = DT_INST_PROP_OR(idx, cs_setup_time, 0), \
+		.cs_hold = DT_INST_PROP_OR(idx, cs_hold_time, 0), \
 	};	\
 		\
 	DEVICE_DT_INST_DEFINE(idx, &spi_esp32_init,	\

--- a/drivers/spi/spi_esp32_spim.h
+++ b/drivers/spi/spi_esp32_spim.h
@@ -36,6 +36,8 @@ struct spi_esp32_config {
 	bool dma_enabled;
 	int dma_clk_src;
 	int dma_host;
+	int cs_setup;
+	int cs_hold;
 };
 
 struct spi_esp32_data {

--- a/dts/bindings/spi/espressif,esp32-spi.yaml
+++ b/dts/bindings/spi/espressif,esp32-spi.yaml
@@ -64,3 +64,15 @@ properties:
 
       Refer to SoC's Technical Reference Manual to check which pins are
       allowed to use this routing path.
+
+  cs-setup-time:
+    type: int
+    description: |
+      Chip select setup time setting, see TRF for SOC for details of
+      timing applied.
+
+  cs-hold-time:
+    type: int
+    description: |
+      Chip select hold time setting, see TRF for SOC for details of
+      timing applied.


### PR DESCRIPTION
Added device tree bindings and implementation for setting the spi controllers chip select setup and hold time settings.

Sometimes an SPI peripheral requires a specific CS timing. This PR implements setting the chip select setup and hold times for the ESP32 hardware spi controller.
Examples with 20MHz SCLK on ESP32C3 SPI mode 0,0

![image](https://user-images.githubusercontent.com/119280044/236358354-d34dc516-447b-409a-b6ab-7a06ebb8a57e.png)
![image](https://user-images.githubusercontent.com/119280044/236358397-7872ad61-efbb-49ae-9288-f655cecb2062.png)
![image](https://user-images.githubusercontent.com/119280044/236358426-d9e5d9f7-ec3a-439d-8d44-e1ac9a547d4a.png)
