### PR TITLE
arch: x86: make sys_arch_reboot as weak function

### DIFF
--- a/arch/x86/core/reboot_rst_cnt.c
+++ b/arch/x86/core/reboot_rst_cnt.c
@@ -27,7 +27,7 @@ static inline void cold_reboot(void)
 	sys_out8(reset_value, X86_RST_CNT_REG);
 }
 
-void sys_arch_reboot(int type)
+void __weak sys_arch_reboot(int type)
 {
 	switch (type) {
 	case SYS_REBOOT_COLD:


### PR DESCRIPTION
Intel ISH SoC can't reboot via RST_CNT register, so make sys_arch_reboot as weak function to allow implement different arch reboot in SoC layer.
