### PR TITLE
arch: x86: assign unique name for TSS ISR stub

### DIFF
--- a/include/zephyr/arch/x86/ia32/arch.h
+++ b/include/zephyr/arch/x86/ia32/arch.h
@@ -144,7 +144,7 @@ typedef struct s_isrList {
  */
 #define _X86_IDT_TSS_REGISTER(tss_p, irq_p, priority_p, vec_p, dpl_p) \
 	static ISR_LIST __attribute__((section(".intList"))) \
-			__attribute__((used)) MK_ISR_NAME(r) = \
+			__attribute__((used)) MK_ISR_NAME(vec_p) = \
 			{ \
 				.fnc = NULL, \
 				.irq = (irq_p), \


### PR DESCRIPTION
To avoid name conflict when register multi TSS IDT, now only double fault use task gate, and Intel ISH need to use additional TSS IDT for page fault.