### PR TITLE
arch: x86: fix SSE init issue when enable paging

### DIFF
--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -176,7 +176,7 @@ __csSet:
 	andl	$~0x400, %eax		/* CR4[OSXMMEXCPT] = 0 */
 	movl	%eax, %cr4		/* move EAX to CR4 */
 
-	ldmxcsr _sse_mxcsr_default_value   /* initialize SSE control/status reg */
+	ldmxcsr Z_MEM_PHYS_ADDR(_sse_mxcsr_default_value)   /* initialize SSE control/status reg */
 
   #endif /* CONFIG_X86_SSE */
 


### PR DESCRIPTION
With paging config, need to use physical address as paging is not enabled here.