### PR TITLE
arch: x86: pin boot arg before paging is up

### DIFF
--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -15,7 +15,7 @@ extern FUNC_NORETURN void z_cstart(void);
 extern void x86_64_irq_init(void);
 
 #if !defined(CONFIG_X86_64)
-x86_boot_arg_t x86_cpu_boot_arg;
+__pinned_data x86_boot_arg_t x86_cpu_boot_arg;
 #endif
 
 /* Early global initialization functions, C domain. This runs only on the first


### PR DESCRIPTION
x86_cpu_boot_arg is accessed in boot code before enable paging.