### PR TITLE
cmake: extensions: Do not clear variable in zephyr_get MERGE mode

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -2508,7 +2508,9 @@ function(zephyr_get variable)
   endif()
 
   if(GET_VAR_MERGE)
-    # Clear variable before appending items in MERGE mode
+    # Clear variable before appending items in MERGE mode but keep a backup for
+    # local appending later
+    set(local_var_backup ${${variable}})
     set(${variable})
   endif()
 
@@ -2574,6 +2576,7 @@ function(zephyr_get variable)
   endif()
 
   if(GET_VAR_MERGE)
+    list(APPEND ${variable} ${local_var_backup})
     list(REMOVE_DUPLICATES ${variable})
     set(${variable} ${${variable}} PARENT_SCOPE)
   endif()


### PR DESCRIPTION
Fixes a regression whereby the variable would be cleared prior to being used in MERGE mode.

Fixes #57566

CC @ElectricalPaul @heinwessels 