### PR TITLE
compiler: add CONFIG_COMPILER_TRACK_MACRO_EXPANSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,11 @@ if(CONFIG_COMPILER_SAVE_TEMPS)
   zephyr_compile_options($<TARGET_PROPERTY:compiler,save_temps>)
 endif()
 
+if(NOT CONFIG_COMPILER_TRACK_MACRO_EXPANSION)
+  # @Intent: Set compiler specific flags to not track macro expansion
+  zephyr_compile_options($<TARGET_PROPERTY:compiler,no_track_macro_expansion>)
+endif()
+
 if(CONFIG_COMPILER_COLOR_DIAGNOSTICS)
 # @Intent: Set compiler specific flag for diagnostic messages
 zephyr_compile_options($<TARGET_PROPERTY:compiler,diagnostic>)

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -378,6 +378,14 @@ config COMPILER_SAVE_TEMPS
 	  Instruct the compiler to save the temporary intermediate files
 	  permanently. These can be useful for troubleshooting build issues.
 
+config COMPILER_TRACK_MACRO_EXPANSION
+	bool "Track macro expansion"
+	default y
+	help
+	  When enabled, locations of tokens across macro expansions will be
+	  tracked. Disabling this option may be useful to debug long macro
+	  expansion chains.
+
 config COMPILER_COLOR_DIAGNOSTICS
 	bool "Colored diagnostics"
 	default y

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -182,6 +182,9 @@ set_compiler_property(PROPERTY debug -g)
 # Flags to save temporary object files
 set_compiler_property(PROPERTY save_temps -save-temps=obj)
 
+# Flags to not track macro expansion
+set_compiler_property(PROPERTY no_track_macro_expansion -ftrack-macro-expansion=0)
+
 # GCC 11 by default emits DWARF version 5 which cannot be parsed by
 # pyelftools. Can be removed once pyelftools supports v5.
 check_set_compiler_property(APPEND PROPERTY debug -gdwarf-4)

--- a/doc/build/dts/troubleshooting.rst
+++ b/doc/build/dts/troubleshooting.rst
@@ -289,6 +289,21 @@ them. For example, to use ``clang-format`` to reformat the file in place:
 You can then open the file in your favorite editor to view the final C results
 after preprocessing.
 
+Do not track macro expansion
+****************************
+
+The compiler error message chain can quickly grow when making a mistake and
+using devicetree macros. In some situations, the number of compiler error
+messages can be overwhelming, specially because many not relevant internals are
+exposed. This happens because of long macro expansion chains. You may disable
+the :kconfig:option:`CONFIG_COMPILER_TRACK_MACRO_EXPANSION` option to skip macro
+expansion, typically reducing the error messages to one line. For example, to
+build :ref:`hello_world` with west and this option set, use:
+
+.. code-block:: sh
+
+   west build -b BOARD samples/hello_world -- -DCONFIG_COMPILER_TRACK_MACRO_EXPANSION=n
+
 Validate properties
 *******************
 


### PR DESCRIPTION
Add a new compiler option to control tracking locations of tokens across macro
expansions. While the compiler diagnostics will be reduced when disabled, it can be
useful in situations where the expansion chain is long enough to _hide_
useful error messages.

Updated DT guide: when debugging devicetree related issues, it may be useful to turn macro
expansion tracking off. Let's document this in the troubleshooting
section.

Example:

```diff
diff --git a/drivers/regulator/regulator_npm6001.c b/drivers/regulator/regulator_npm6001.c
index 32e8c3192e..e9881608d6 100644
--- a/drivers/regulator/regulator_npm6001.c
+++ b/drivers/regulator/regulator_npm6001.c
@@ -714,7 +714,7 @@ static const struct regulator_driver_api api = {
                          NPM6001_BUCKMODEPADCONF_BUCKMODE1PULLD_ENABLED) |    \
                         (DT_INST_PROP(inst, nordic_buck_mode2_pull_down) *    \
                          NPM6001_BUCKMODEPADCONF_BUCKMODE2PULLD_ENABLED)),    \
-               .pad_val = ((DT_INST_PROP(inst, nordic_ready_high_drive) *     \
+               .pad_val = ((DT_INST_PROP(inst, nordic_ready_high_driv) *     \
                             NPM6001_PADDRIVESTRENGTH_READY_HIGH) |            \
                            (DT_INST_PROP(inst, nordic_nint_high_drive) *      \
                             NPM6001_PADDRIVESTRENGTH_NINT_HIGH) |             \
```

default setup:
```
west build -b nrf52840dk_nrf52840 samples/shields/npm6001_ek -p

...

FAILED: zephyr/drivers/regulator/CMakeFiles/drivers__regulator.dir/regulator_npm6001.c.obj 
ccache /home/gmarull/zephyr-sdk-0.16.0/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc -DKERNEL -DNRF52840_XXAA -D__PROGRAM_START -D__ZEPHYR_SUPERVISOR__ -D__ZEPHYR__=1 -I/home/gmarull/ws/nordic/zephyrproject/zephyr/include -I/home/gmarull/ws/nordic/zephyrproject/zephyr/build/zephyr/include/generated -I/home/gmarull/ws/nordic/zephyrproject/zephyr/s
oc/arm/nordic_nrf/nrf52 -I/home/gmarull/ws/nordic/zephyrproject/zephyr/lib/posix/getopt/. -I/home/gmarull/ws/nordic/zephyrproject/zephyr/soc/arm/nordic_nrf/common/. -I/home/gmarull/ws/nordic/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include -I/home/gmarull/ws/nordic/zephyrproject/modules/hal/nordic/nrfx -I/home/gmarull/ws/nordic/zephyrproj
ect/modules/hal/nordic/nrfx/drivers/include -I/home/gmarull/ws/nordic/zephyrproject/modules/hal/nordic/nrfx/mdk -I/home/gmarull/ws/nordic/zephyrproject/zephyr/modules/hal_nordic/nrfx/. -I/home/gmarull/ws/nordic/zephyrproject/modules/debug/segger/SEGGER -I/home/gmarull/ws/nordic/zephyrproject/modules/debug/segger/Config -I/home/gmarull/ws/no
rdic/zephyrproject/zephyr/modules/segger/. -isystem /home/gmarull/ws/nordic/zephyrproject/zephyr/lib/libc/minimal/include -isystem /home/gmarull/zephyr-sdk-0.16.0/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/include -isystem /home/gmarull/zephyr-sdk-0.16.0/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/include-fixed -fno-str
ict-aliasing -Os -imacros /home/gmarull/ws/nordic/zephyrproject/zephyr/build/zephyr/include/generated/autoconf.h -ffreestanding -fno-common -g -gdwarf-4 -fdiagnostics-color=always -mcpu=cortex-m4 -mthumb -mabi=aapcs --sysroot=/home/gmarull/zephyr-sdk-0.16.0/arm-zephyr-eabi/arm-zephyr-eabi -imacros /home/gmarull/ws/nordic/zephyrproject/zephy
r/include/zephyr/toolchain/zephyr_stdint.h -Wall -Wformat -Wformat-security -Wno-format-zero-length -Wno-pointer-sign -Wpointer-arith -Wexpansion-to-defined -Wno-unused-but-set-variable -Werror=implicit-int -fno-pic -fno-pie -fno-asynchronous-unwind-tables -fno-reorder-functions --param=min-pagesize=0 -fno-defer-pop -fmacro-prefix-map=/home
/gmarull/ws/nordic/zephyrproject/zephyr/samples/shields/npm6001_ek=CMAKE_SOURCE_DIR -fmacro-prefix-map=/home/gmarull/ws/nordic/zephyrproject/zephyr=ZEPHYR_BASE -fmacro-prefix-map=/home/gmarull/ws/nordic/zephyrproject=WEST_TOPDIR -ffunction-sections -fdata-sections -D_POSIX_THREADS -std=c99 -nostdinc -MD -MT zephyr/drivers/regulator/CMakeFil
es/drivers__regulator.dir/regulator_npm6001.c.obj -MF zephyr/drivers/regulator/CMakeFiles/drivers__regulator.dir/regulator_npm6001.c.obj.d -o zephyr/drivers/regulator/CMakeFiles/drivers__regulator.dir/regulator_npm6001.c.obj -c /home/gmarull/ws/nordic/zephyrproject/zephyr/drivers/regulator/regulator_npm6001.c
In file included from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_macro.h:34,
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util.h:17,                                                                                                                                                                                                                                                      
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/devicetree.h:21,
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/device.h:12,                      
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/drivers/i2c.h:25,                                                                                                                                                                                                                                                   
                 from /home/gmarull/ws/nordic/zephyrproject/zephyr/drivers/regulator/regulator_npm6001.c:10:
/home/gmarull/ws/nordic/zephyrproject/zephyr/build/zephyr/include/generated/devicetree_generated.h:15321:46: error: 'DT_N_S_soc_S_i2c_40003000_S_pmic_70_S_regulators_P_nordic_ready_high_driv' undeclared here (not in a function); did you mean 'DT_N_S_soc_S_i2c_40003000_S_pmic_70_S_regulators_P_nordic_ready_high_drive'?
15321 | #define DT_N_INST_0_nordic_npm6001_regulator DT_N_S_soc_S_i2c_40003000_S_pmic_70_S_regulators
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_internal.h:72:26: note: in definition of macro '__DEBRACKET'
   72 | #define __DEBRACKET(...) __VA_ARGS__
      |                          ^~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_internal.h:64:9: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   64 |         __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |         ^~~~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_internal.h:59:9: note: in expansion of macro '__COND_CODE'
   59 |         __COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_macro.h:180:9: note: in expansion of macro 'Z_COND_CODE_1'
  180 |         Z_COND_CODE_1(_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/devicetree.h:3906:9: note: in expansion of macro 'COND_CODE_1'
 3906 |         COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT),   \
      |         ^~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/devicetree.h:609:32: note: in expansion of macro 'DT_CAT3'
  609 | #define DT_PROP(node_id, prop) DT_CAT3(node_id, _P_, prop)
      |                                ^~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/devicetree.h:3345:34: note: in expansion of macro 'DT_PROP'
 3345 | #define DT_INST_PROP(inst, prop) DT_PROP(DT_DRV_INST(inst), prop)
      |                                  ^~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_internal.h:105:36: note: in expansion of macro 'DT_N_INST_0_nordic_npm6001_regulator'
  105 | #define UTIL_PRIMITIVE_CAT(a, ...) a##__VA_ARGS__
      |                                    ^
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_internal.h:104:26: note: in expansion of macro 'UTIL_PRIMITIVE_CAT'
  104 | #define UTIL_CAT(a, ...) UTIL_PRIMITIVE_CAT(a, __VA_ARGS__)
      |                          ^~~~~~~~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/devicetree.h:328:31: note: in expansion of macro 'UTIL_CAT'
  328 | #define DT_INST(inst, compat) UTIL_CAT(DT_N_INST, DT_DASH(inst, compat))
      |                               ^~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/devicetree.h:3154:27: note: in expansion of macro 'DT_INST'
 3154 | #define DT_DRV_INST(inst) DT_INST(inst, DT_DRV_COMPAT)
      |                           ^~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/devicetree.h:3345:42: note: in expansion of macro 'DT_DRV_INST'
 3345 | #define DT_INST_PROP(inst, prop) DT_PROP(DT_DRV_INST(inst), prop)
      |                                          ^~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/drivers/regulator/regulator_npm6001.c:717:30: note: in expansion of macro 'DT_INST_PROP'
  717 |                 .pad_val = ((DT_INST_PROP(inst, nordic_ready_high_driv) *     \
      |                              ^~~~~~~~~~~~
/home/gmarull/ws/nordic/zephyrproject/zephyr/build/zephyr/include/generated/devicetree_generated.h:17631:59: note: in expansion of macro 'REGULATOR_NPM6001_DEFINE_ALL'
17631 | #define DT_FOREACH_OKAY_INST_nordic_npm6001_regulator(fn) fn(0)
      |                                                           ^~
/home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/sys/util_internal.h:105:36: note: in expansion of macro 'DT_FOREACH_OKAY_INST_nordic_npm6001_regulator'
  105 | #define UTIL_PRIMITIVE_CAT(a, ...) a##__VA_ARGS__
      |                                    ^
/home/gmarull/ws/nordic/zephyrproject/zephyr/drivers/regulator/regulator_npm6001.c:743:1: note: in expansion of macro 'DT_INST_FOREACH_STATUS_OKAY'
  743 | DT_INST_FOREACH_STATUS_OKAY(REGULATOR_NPM6001_DEFINE_ALL)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
[148/197] Building C object modules/hal_nordic/nrfx/CMakeFiles/modules__hal_nordic__nrfx.dir/home/gmarull/ws/nordic/zephyrproject/modules/hal/nordic/nrfx/drivers/src/nrfx_twi.c.obj
ninja: build stopped: subcommand failed.

```

without macro expansion tracking:
```
west build -b nrf52840dk_nrf52840 samples/shields/npm6001_ek -p -- -DCONFIG_COMPILER_NO_TRACK_MACRO_EXPANSION=y

...

FAILED: zephyr/drivers/regulator/CMakeFiles/drivers__regulator.dir/regulator_npm6001.c.obj 
ccache /home/gmarull/zephyr-sdk-0.16.0/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc -DKERNEL -DNRF52840_XXAA -D__PROGRAM_START -D__ZEPHYR_SUPERVISOR__ -D__ZEPHYR__=1 -I/home/gmarull/ws/nordic/zephyrproject/zephyr/include -I/home/gmarull/ws/nordic/zephyrproject/zephyr/build/zephyr/include/generated -I/home/gmarull/ws/nordic/zephyrproject/zephyr/soc/arm/nordic_nrf/nrf52 -I/home/gmarull/ws/nordic/zephyrproject/zephyr/lib/posix/getopt/. -I/home/gmarull/ws/nordic/zephyrproject/zephyr/soc/arm/nordic_nrf/common/. -I/home/gmarull/ws/nordic/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include -I/home/gmarull/ws/nordic/zephyrproject/modules/hal/nordic/nrfx -I/home/gmarull/ws/nordic/zephyrproject/modules/hal/nordic/nrfx/drivers/include -I/home/gmarull/ws/nordic/zephyrproject/modules/hal/nordic/nrfx/mdk -I/home/gmarull/ws/nordic/zephyrproject/zephyr/modules/hal_nordic/nrfx/. -I/home/gmarull/ws/nordic/zephyrproject/modules/debug/segger/SEGGER -I/home/gmarull/ws/nordic/zephyrproject/modules/debug/segger/Config -I/home/gmarull/ws/nordic/zephyrproject/zephyr/modules/segger/. -isystem /home/gmarull/ws/nordic/zephyrproject/zephyr/lib/libc/minimal/include -isystem /home/gmarull/zephyr-sdk-0.16.0/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/include -isystem /home/gmarull/zephyr-sdk-0.16.0/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/include-fixed -fno-strict-aliasing -Os -imacros /home/gmarull/ws/nordic/zephyrproject/zephyr/build/zephyr/include/generated/autoconf.h -ffreestanding -fno-common -g -gdwarf-4 -ftrack-macro-expansion=0 -fdiagnostics-color=always -mcpu=cortex-m4 -mthumb -mabi=aapcs --sysroot=/home/gmarull/zephyr-sdk-0.16.0/arm-zephyr-eabi/arm-zephyr-eabi -imacros /home/gmarull/ws/nordic/zephyrproject/zephyr/include/zephyr/toolchain/zephyr_stdint.h -Wall -Wformat -Wformat-security -Wno-format-zero-length -Wno-pointer-sign -Wpointer-arith -Wexpansion-to-defined -Wno-unused-but-set-variable -Werror=implicit-int -fno-pic -fno-pie -fno-asynchronous-unwind-tables -fno-reorder-functions --param=min-pagesize=0 -fno-defer-pop -fmacro-prefix-map=/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/shields/npm6001_ek=CMAKE_SOURCE_DIR -fmacro-prefix-map=/home/gmarull/ws/nordic/zephyrproject/zephyr=ZEPHYR_BASE -fmacro-prefix-map=/home/gmarull/ws/nordic/zephyrproject=WEST_TOPDIR -ffunction-sections -fdata-sections -D_POSIX_THREADS -std=c99 -nostdinc -MD -MT zephyr/drivers/regulator/CMakeFiles/drivers__regulator.dir/regulator_npm6001.c.obj -MF zephyr/drivers/regulator/CMakeFiles/drivers__regulator.dir/regulator_npm6001.c.obj.d -o zephyr/drivers/regulator/CMakeFiles/drivers__regulator.dir/regulator_npm6001.c.obj -c /home/gmarull/ws/nordic/zephyrproject/zephyr/drivers/regulator/regulator_npm6001.c
/home/gmarull/ws/nordic/zephyrproject/zephyr/drivers/regulator/regulator_npm6001.c:743:1: error: 'DT_N_S_soc_S_i2c_40003000_S_pmic_70_S_regulators_P_nordic_ready_high_driv' undeclared here (not in a function); did you mean 'DT_N_S_soc_S_i2c_40003000_S_pmic_70_S_regulators_P_nordic_ready_high_drive'?
  743 | DT_INST_FOREACH_STATUS_OKAY(REGULATOR_NPM6001_DEFINE_ALL)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      | DT_N_S_soc_S_i2c_40003000_S_pmic_70_S_regulators_P_nordic_ready_high_drive
[178/197] Building C object zephyr/kernel/CMakeFiles/kernel.dir/sched.c.obj
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/bin/cmake --build /home/gmarull/ws/nordic/zephyrproject/zephyr/build
```