### PR TITLE
Bluetooth: Audio: Shell: Make broadcast source generic

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -34,6 +34,7 @@ size_t cap_acceptor_ad_data_add(struct bt_data data[], size_t data_size, bool di
  * CONFIG_BT_AUDIO
  */
 #include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/cap.h>
 
@@ -55,6 +56,20 @@ struct named_lc3_preset {
 
 struct unicast_stream {
 	struct bt_cap_stream stream;
+	struct bt_codec codec;
+	struct bt_codec_qos qos;
+};
+
+struct broadcast_stream {
+	struct bt_cap_stream stream;
+	struct bt_codec_data data;
+};
+
+struct broadcast_source {
+	union {
+		struct bt_bap_broadcast_source *bap_source;
+		struct bt_cap_broadcast_source *cap_source;
+	};
 	struct bt_codec codec;
 	struct bt_codec_qos qos;
 };
@@ -109,6 +124,11 @@ static inline void print_codec(const struct shell *sh, const struct bt_codec *co
 	}
 #endif /* CONFIG_BT_CODEC_MAX_METADATA_COUNT > 0 */
 }
+
+#if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
+extern struct broadcast_stream broadcast_source_streams[CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT];
+extern struct broadcast_source default_source;
+#endif /* CONFIG_BT_BAP_BROADCAST_SOURCE */
 
 #if BROADCAST_SNK_SUBGROUP_CNT > 0
 static inline void print_base(const struct shell *sh, const struct bt_bap_base *base)
@@ -165,7 +185,6 @@ static inline void print_base(const struct shell *sh, const struct bt_bap_base *
 	shell_print(sh, "Possible indexes: %s", bis_indexes_str);
 }
 #endif /* BROADCAST_SNK_SUBGROUP_CNT > 0 */
-
 #endif /* CONFIG_BT_AUDIO */
 
 #endif /* __AUDIO_H */

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -128,27 +128,6 @@ static void populate_connected_conns(struct bt_conn *conn, void *data)
 	}
 }
 
-static void cap_copy_preset(struct unicast_stream *uni_stream,
-			    const struct named_lc3_preset *name_preset)
-{
-	memcpy(&uni_stream->qos, &name_preset->preset.qos, sizeof(uni_stream->qos));
-	memcpy(&uni_stream->codec, &name_preset->preset.codec,
-	       sizeof(uni_stream->codec));
-
-	/* Need to update the `bt_data.data` pointer to the new value after copying the codec */
-	for (size_t i = 0U; i < ARRAY_SIZE(uni_stream->codec.data); i++) {
-		struct bt_codec_data *data = &uni_stream->codec.data[i];
-
-		data->data.data = data->value;
-	}
-
-	for (size_t i = 0U; i < ARRAY_SIZE(uni_stream->codec.meta); i++) {
-		struct bt_codec_data *data = &uni_stream->codec.meta[i];
-
-		data->data.data = data->value;
-	}
-}
-
 static int cmd_cap_initiator_unicast_start(const struct shell *sh, size_t argc,
 					   char *argv[])
 {
@@ -264,7 +243,7 @@ static int cmd_cap_initiator_unicast_start(const struct shell *sh, size_t argc,
 			stream_param[start_param.count].member.member = conn;
 			stream_param[start_param.count].stream = stream;
 			stream_param[start_param.count].ep = snk_ep;
-			cap_copy_preset(uni_stream, default_sink_preset);
+			copy_unicast_stream_preset(uni_stream, default_sink_preset);
 			stream_param[start_param.count].codec = &uni_stream->codec;
 			stream_param[start_param.count].qos = &uni_stream->qos;
 
@@ -298,7 +277,7 @@ static int cmd_cap_initiator_unicast_start(const struct shell *sh, size_t argc,
 			stream_param[start_param.count].member.member = conn;
 			stream_param[start_param.count].stream = stream;
 			stream_param[start_param.count].ep = src_ep;
-			cap_copy_preset(uni_stream, default_source_preset);
+			copy_unicast_stream_preset(uni_stream, default_source_preset);
 			stream_param[start_param.count].codec = &uni_stream->codec;
 			stream_param[start_param.count].qos = &uni_stream->qos;
 
@@ -399,9 +378,9 @@ static int cmd_cap_initiator_unicast_update(const struct shell *sh, size_t argc,
 
 
 			if (ep_info.dir == BT_AUDIO_DIR_SINK) {
-				cap_copy_preset(uni_stream, default_sink_preset);
+				copy_unicast_stream_preset(uni_stream, default_sink_preset);
 			} else {
-				cap_copy_preset(uni_stream, default_source_preset);
+				copy_unicast_stream_preset(uni_stream, default_source_preset);
 			}
 
 			params[count].meta = uni_stream->codec.meta;
@@ -441,9 +420,9 @@ static int cmd_cap_initiator_unicast_update(const struct shell *sh, size_t argc,
 			params[count].stream = stream;
 
 			if (ep_info.dir == BT_AUDIO_DIR_SINK) {
-				cap_copy_preset(uni_stream, default_sink_preset);
+				copy_unicast_stream_preset(uni_stream, default_sink_preset);
 			} else {
-				cap_copy_preset(uni_stream, default_source_preset);
+				copy_unicast_stream_preset(uni_stream, default_source_preset);
 			}
 
 			params[count].meta = uni_stream->codec.meta;


### PR DESCRIPTION
Implement profile-agnostic broadcast source and broadcast stream structs, similar to the unicast stream struct.

The purpose of these are to be able to use the same structs for multiple profiles such as BAP, CAP and TMAP.

Since only the BAP shell implements broadcast support at this moment, the changes are minimal, but makes it easier to implement broadcast support for other profile shells.