### PR TITLE
drivers: usb_dc_nrfx: Enable SOF interrupts only when needed

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -686,7 +686,7 @@ static inline void usbd_work_process_pwr_events(struct usbd_pwr_event *pwr_evt)
 
 	case USBD_POWERED:
 		usbd_enable_endpoints(ctx);
-		nrfx_usbd_start(true);
+		nrfx_usbd_start(IS_ENABLED(CONFIG_USB_DEVICE_SOF));
 		ctx->ready = true;
 
 		LOG_DBG("USB Powered");


### PR DESCRIPTION
Do not enable SOF event interrupt when the USB device driver is going to discard the event anyway. This prevents completely unnecessary interrupt handler from executing 1000 times a second when device is connected.