### PR TITLE
Documentation Fixes for Hawkbit sample and ZTest

### DIFF
--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -559,7 +559,8 @@ and adding a file :file:`tc_util_user_override.h` with your overrides.
 Add the line ``zephyr_include_directories(my_folder)`` to
 your project's :file:`CMakeLists.txt` to let Zephyr find your header file during builds.
 
-See the file :zephyr_file:`subsys/testsuite/include/tc_util.h` to see which macros and/or defines can be overridden.
+See the file :zephyr_file:`subsys/testsuite/include/zephyr/tc_util.h` to see
+which macros and/or defines can be overridden.
 These will be surrounded by blocks such as:
 
 .. code-block:: C

--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -574,14 +574,15 @@ These will be surrounded by blocks such as:
 Shuffling Test Sequence
 ***********************
 By default the tests are sorted and ran in alphanumerical order.  Test cases may
-be dependent on this sequence. Enable `ZTEST_SHUFFLE` to randomize the order. The
-output from the test will display the seed for failed tests.  For native posix
-builds you can provide the seed as an argument to twister with `--seed`
+be dependent on this sequence. Enable :kconfig:option:`CONFIG_ZTEST_SHUFFLE` to
+randomize the order. The output from the test will display the seed for failed
+tests.  For native posix builds you can provide the seed as an argument to
+twister with `--seed`
 
 Static configuration of ZTEST_SHUFFLE contains:
 
- - :c:macro:`ZTEST_SHUFFLE_SUITE_REPEAT_COUNT` - Number of iterations the test suite will run.
- - :c:macro:`ZTEST_SHUFFLE_TEST_REPEAT_COUNT` - Number of iterations the test will run.
+ - :kconfig:option:`CONFIG_ZTEST_SHUFFLE_SUITE_REPEAT_COUNT` - Number of iterations the test suite will run.
+ - :kconfig:option:`CONFIG_ZTEST_SHUFFLE_TEST_REPEAT_COUNT` - Number of iterations the test will run.
 
 
 Test Selection

--- a/samples/subsys/mgmt/hawkbit/README.rst
+++ b/samples/subsys/mgmt/hawkbit/README.rst
@@ -80,7 +80,7 @@ Step 4: Build Hawkbit
 ``Hawkbit`` can be built for the frdm_k64f as follows:
 
 .. zephyr-app-commands::
-    :zephyr-app: samples/net/hawkbit
+    :zephyr-app: samples/subsys/mgmt/hawkbit
     :board: frdm_k64f
     :conf: "prj.conf"
     :goals: build
@@ -286,7 +286,7 @@ Step 11: Build Hawkbit HTTPS
 ``Hawkbit https`` can be built for the frdm_k64f as follows:
 
 .. zephyr-app-commands::
-    :zephyr-app: samples/net/hawkbit
+    :zephyr-app: samples/subsys/mgmt/hawkbit
     :board: frdm_k64f
     :conf: "prj.conf overlay-tls.conf"
     :goals: build


### PR DESCRIPTION
The build command for the hawkbit sample was not correct.

https://docs.zephyrproject.org/latest/samples/subsys/mgmt/hawkbit/README.html#step-4-build-hawkbit

Also here some documentation fixes for ZTest:
* #55450: Fix broken links
* Use RST `kconfig` directive vor ZTEST_SHUFFLE