### PR TITLE
twister: Bring back scope selection rule using platform_allow

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -685,10 +685,8 @@ class TestPlan:
                 b = set(filter(lambda item: item.name in ts.platform_allow, self.platforms))
                 c = a.intersection(b)
                 if not c:
-                    _platform_scope = list(filter(lambda item: item.name in ts.platform_allow, \
+                    platform_scope = list(filter(lambda item: item.name in ts.platform_allow, \
                                              self.platforms))
-                    if len(_platform_scope) > 0:
-                        platform_scope = _platform_scope[:1]
 
 
             # list of instances per testsuite, aka configurations.


### PR DESCRIPTION
A change to the scope selection rules was introduced by #52715 but it doesn't comply with the description in the code. What's more, the change introduces major issues i.e. non deterministic scope selection, especially in a CI environment. More context at #57595