### PR TITLE
linker: align CREATE_OBJ_LEVEL and zephyr_linker_section_obj_level

### DIFF
--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -145,8 +145,8 @@
  */
 #define CREATE_OBJ_LEVEL(object, level)				\
 		__##object##_##level##_start = .;		\
-		KEEP(*(SORT(.z_##object##_##level[0-9]_*)));		\
-		KEEP(*(SORT(.z_##object##_##level[1-9][0-9]_*)));
+		KEEP(*(SORT(.z_##object##_##level?_)));		\
+		KEEP(*(SORT(.z_##object##_##level??_)));
 
 /*
  * link in shell initialization objects for all modules that use shell and


### PR DESCRIPTION
Use the same wildcard pattern for sorting. Note that the range wildcard, e.g. [0-9], can't be used as not all linkers support it.