### PR TITLE
Add coding guidelines on C standard library function usage

### DIFF
--- a/doc/contribute/coding_guidelines/index.rst
+++ b/doc/contribute/coding_guidelines/index.rst
@@ -1297,6 +1297,134 @@ macros. Given that Zephyr uses a fork of the corresponding upstream for each
 module, it is always possible to patch the macro implementation in each module
 to avoid collisions.
 
+Rule A.4: C Standard Library Usage Restrictions in Zephyr Kernel
+================================================================
+
+Severity
+--------
+
+Required
+
+Description
+-----------
+
+The use of the C standard library functions and macros in the Zephyr kernel
+shall be limited to the following functions and macros from the ISO/IEC
+9899:2011 standard, also known as C11, and their extensions:
+
+.. csv-table:: List of allowed libc functions and macros in the Zephyr kernel
+   :header: Function,Source
+   :widths: auto
+
+   abort(),ISO/IEC 9899:2011
+   abs(),ISO/IEC 9899:2011
+   aligned_alloc(),ISO/IEC 9899:2011
+   assert(),ISO/IEC 9899:2011
+   atoi(),ISO/IEC 9899:2011
+   bsearch(),ISO/IEC 9899:2011
+   calloc(),ISO/IEC 9899:2011
+   exit(),ISO/IEC 9899:2011
+   fprintf(),ISO/IEC 9899:2011
+   fputc(),ISO/IEC 9899:2011
+   fputs(),ISO/IEC 9899:2011
+   free(),ISO/IEC 9899:2011
+   fwrite(),ISO/IEC 9899:2011
+   gmtime(),ISO/IEC 9899:2011
+   isalnum(),ISO/IEC 9899:2011
+   isalpha(),ISO/IEC 9899:2011
+   iscntrl(),ISO/IEC 9899:2011
+   isdigit(),ISO/IEC 9899:2011
+   isgraph(),ISO/IEC 9899:2011
+   isprint(),ISO/IEC 9899:2011
+   isspace(),ISO/IEC 9899:2011
+   isupper(),ISO/IEC 9899:2011
+   isxdigit(),ISO/IEC 9899:2011
+   labs(),ISO/IEC 9899:2011
+   llabs(),ISO/IEC 9899:2011
+   malloc(),ISO/IEC 9899:2011
+   memchr(),ISO/IEC 9899:2011
+   memcmp(),ISO/IEC 9899:2011
+   memcpy(),ISO/IEC 9899:2011
+   memmove(),ISO/IEC 9899:2011
+   memset(),ISO/IEC 9899:2011
+   perror(),ISO/IEC 9899:2011
+   printf(),ISO/IEC 9899:2011
+   putc(),ISO/IEC 9899:2011
+   putchar(),ISO/IEC 9899:2011
+   puts(),ISO/IEC 9899:2011
+   qsort(),ISO/IEC 9899:2011
+   rand(),ISO/IEC 9899:2011
+   realloc(),ISO/IEC 9899:2011
+   snprintf(),ISO/IEC 9899:2011
+   sprintf(),ISO/IEC 9899:2011
+   sqrt(),ISO/IEC 9899:2011
+   sqrtf(),ISO/IEC 9899:2011
+   srand(),ISO/IEC 9899:2011
+   strcat(),ISO/IEC 9899:2011
+   strchr(),ISO/IEC 9899:2011
+   strcmp(),ISO/IEC 9899:2011
+   strcpy(),ISO/IEC 9899:2011
+   strcspn(),ISO/IEC 9899:2011
+   strerror(),ISO/IEC 9899:2011
+   strlen(),ISO/IEC 9899:2011
+   strncat(),ISO/IEC 9899:2011
+   strncmp(),ISO/IEC 9899:2011
+   strncpy(),ISO/IEC 9899:2011
+   `strnlen()`_,POSIX.1-2008
+   strrchr(),ISO/IEC 9899:2011
+   strspn(),ISO/IEC 9899:2011
+   strstr(),ISO/IEC 9899:2011
+   strtol(),ISO/IEC 9899:2011
+   strtoll(),ISO/IEC 9899:2011
+   strtoul(),ISO/IEC 9899:2011
+   strtoull(),ISO/IEC 9899:2011
+   time(),ISO/IEC 9899:2011
+   tolower(),ISO/IEC 9899:2011
+   toupper(),ISO/IEC 9899:2011
+   vfprintf(),ISO/IEC 9899:2011
+   vprintf(),ISO/IEC 9899:2011
+   vsnprintf(),ISO/IEC 9899:2011
+   vsprintf(),ISO/IEC 9899:2011
+
+All of the functions listed above must be implemented by the
+:ref:`minimal libc <c_library_minimal>` to ensure that the Zephyr kernel can
+build with the minimal libc.
+
+In addition, any functions from the above list that are not part of the
+ISO/IEC 9899:2011 standard must be implemented by the
+:ref:`common libc <c_library_common>` to ensure their availability across
+multiple C standard libraries.
+
+Introducing new C standard library functions to the Zephyr kernel is allowed
+with justification given that the above requirements are satisfied.
+
+Note that the use of the functions listed above are subject to secure and safe
+coding practices and it should not be assumed that their use in the Zephyr
+kernel is unconditionally permitted by being listed in this rule.
+
+The "Zephyr kernel" in this context consists of the following components:
+
+* Kernel (:file:`kernel`)
+* OS Library (:file:`lib/os`)
+* Architecture Port (:file:`arch`)
+* Logging Subsystem (:file:`subsys/logging`)
+
+.. _strnlen(): https://pubs.opengroup.org/onlinepubs/9699919799/functions/strlen.html
+
+Rationale
+---------
+
+Zephyr kernel must be able to build with the
+:ref:`minimal libc <c_library_minimal>`, a limited C standard library
+implementation that is part of the Zephyr RTOS and maintained by the Zephyr
+Project, to allow self-contained testing and verification of the kernel and
+core OS services.
+
+In order to ensure that the Zephyr kernel can build with the minimal libc, it
+is necessary to restrict the use of the C standard library functions and macros
+in the Zephyr kernel to the functions and macros that are available as part of
+the minimal libc.
+
 Parasoft Codescan Tool
 **********************
 

--- a/doc/contribute/coding_guidelines/index.rst
+++ b/doc/contribute/coding_guidelines/index.rst
@@ -1297,6 +1297,8 @@ macros. Given that Zephyr uses a fork of the corresponding upstream for each
 module, it is always possible to patch the macro implementation in each module
 to avoid collisions.
 
+.. _coding_guideline_libc_usage_restrictions_in_zephyr_kernel:
+
 Rule A.4: C Standard Library Usage Restrictions in Zephyr Kernel
 ================================================================
 
@@ -1409,8 +1411,6 @@ The "Zephyr kernel" in this context consists of the following components:
 * Architecture Port (:file:`arch`)
 * Logging Subsystem (:file:`subsys/logging`)
 
-.. _strnlen(): https://pubs.opengroup.org/onlinepubs/9699919799/functions/strlen.html
-
 Rationale
 ---------
 
@@ -1424,6 +1424,63 @@ In order to ensure that the Zephyr kernel can build with the minimal libc, it
 is necessary to restrict the use of the C standard library functions and macros
 in the Zephyr kernel to the functions and macros that are available as part of
 the minimal libc.
+
+Rule A.5: C Standard Library Usage Restrictions in Zephyr Codebase
+==================================================================
+
+Severity
+--------
+
+Required
+
+Description
+-----------
+
+The use of the C standard library functions and macros in the Zephyr codebase
+shall be limited to the functions, excluding the Annex K "Bounds-checking
+interfaces", from the ISO/IEC 9899:2011 standard, also known as C11, unless
+exempted by this rule.
+
+The "Zephyr codebase" in this context refers to all source code files committed
+to the `main Zephyr repository`_, except the Zephyr kernel as defined by the
+:ref:`coding_guideline_libc_usage_restrictions_in_zephyr_kernel`.
+
+The following non-ISO 9899:2011, hereinafter referred to as non-standard,
+functions and macros are exempt from this rule and allowed to be used in the
+Zephyr codebase:
+
+.. csv-table:: List of allowed non-standard libc functions
+   :header: Function,Source
+   :widths: auto
+
+   `strnlen()`_,POSIX.1-2008
+   `strtok_r()`_,POSIX.1-2001
+
+All non-standard functions and macros listed above must be implemented by the
+:ref:`common libc <c_library_common>` in order to make sure that these
+functions can be made available when using a C standard library that does not
+implement these functions.
+
+Adding a new non-standard function from common C standard libraries to the
+above list is allowed with justification, given that the above requirement is
+satisfied. However, when there exists a standard function that is functionally
+equivalent, the standard function shall be used.
+
+Rationale
+---------
+
+Some C standard libraries, such as Newlib and Picolibc, include additional
+functions and macros that are defined by the standards and de-facto standards
+that extend the ISO C standard (e.g. POSIX, Linux).
+
+The ISO/IEC 9899:2011 standard does not require C compiler toolchains to
+include the support for these non-standard functions, and therefore using
+these functions can lead to compatibility issues with the third-party
+toolchains that come with their own C standard libraries.
+
+.. _main Zephyr repository: https://github.com/zephyrproject-rtos/zephyr
+.. _strnlen(): https://pubs.opengroup.org/onlinepubs/9699919799/functions/strlen.html
+.. _strtok_r(): https://pubs.opengroup.org/onlinepubs/9699919799/functions/strtok.html
 
 Parasoft Codescan Tool
 **********************

--- a/doc/develop/languages/c/minimal_libc.rst
+++ b/doc/develop/languages/c/minimal_libc.rst
@@ -15,6 +15,14 @@ with a number of different toolchains.
 The minimal libc implementation can be found in :file:`lib/libc/minimal` in the
 main Zephyr tree.
 
+Functions
+*********
+
+The minimal libc implements the minimal subset of the ISO/IEC 9899:2011
+standard C library functions required to meet the needs of the Zephyr kernel,
+as defined by the :ref:`Coding Guidelines Rule A.4
+<coding_guideline_libc_usage_restrictions_in_zephyr_kernel>`.
+
 Formatted Output
 ****************
 


### PR DESCRIPTION
This series adds the coding guidelines rules on the usage of C standard library functions in the Zephyr codebase, in preparation for making Picolibc the default libc.

It adds two new rules:

* Rule A.4: C Standard Library Usage Restrictions in Zephyr Kernel
    * Ensures that the Zephyr kernel can still build with the minimal libc even after making Picolibc the default.
* Rule A.5: C Standard Library Usage Restrictions in Zephyr Codebase
    * Prohibit the use of non-standard (non-ISO) functions from Picolibc (or any other LIBCs for that matter) in the Zephyr codebase

Once these rules are accepted, additional testcases and CI checks will be implemented to enforce them.

Preview: https://builds.zephyrproject.io/zephyr/pr/57598/docs/index.html

Part of https://github.com/zephyrproject-rtos/zephyr/issues/49922