### PR TITLE
mcumgr: img_mgmt: Fix check for upgrade-only

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -646,7 +646,7 @@ img_mgmt_upload_inspect(const struct img_mgmt_upload_req *req,
 
 
 		if (req->upgrade) {
-			/* User specified upgrade-only.  Make sure new image version is
+			/* User specified upgrade-only. Make sure new image version is
 			 * greater than that of the currently running image.
 			 */
 			rc = img_mgmt_my_version(&cur_ver);
@@ -654,7 +654,7 @@ img_mgmt_upload_inspect(const struct img_mgmt_upload_req *req,
 				return MGMT_ERR_EUNKNOWN;
 			}
 
-			if (img_mgmt_vercmp(&cur_ver, &hdr->ih_ver) > 0) {
+			if (img_mgmt_vercmp(&cur_ver, &hdr->ih_ver) >= 0) {
 				IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action,
 					img_mgmt_err_str_downgrade);
 				return MGMT_ERR_EBADSTATE;


### PR DESCRIPTION
Change fixes check for upgrade-only to ensure that the the new image version is greater than version of the currently running image.