### PR TITLE
mcumgr: img_mgmt: Let image version comparison use build number

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -88,6 +88,13 @@ config MCUMGR_GRP_IMG_FRUGAL_LIST
 	  a device but requires support in client software, which has to default omitted values.
 	  Works correctly with mcumgr-cli.
 
+config MCUMGR_GRP_IMG_VERSION_CMP_USE_BUILD_NUMBER
+	bool "Use build number while comparing image version"
+	help
+	  By default, the image version comparison relies only on version major,
+	  minor and revision. Enable this option to take into account the build
+	  number as well.
+
 config MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK
 	bool "Upload check hook"
 	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -278,7 +278,13 @@ img_mgmt_vercmp(const struct image_version *a, const struct image_version *b)
 		return 1;
 	}
 
-	/* Note: For semver compatibility, don't compare the 32-bit build num. */
+#if defined(CONFIG_MCUMGR_GRP_IMG_VERSION_CMP_USE_BUILD_NUMBER)
+	if (a->iv_build_num < b->iv_build_num) {
+		return -1;
+	} else if (a->iv_build_num > b->iv_build_num) {
+		return 1;
+	}
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Change allows using build number in image version comparison.