### PR TITLE
manifest: hal_nordic: Pull fix for CCM at nRF51 SoCs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -90,7 +90,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: a1a8a83771361fe932673119a073fd4af3943a77
+      revision: a1c3e0fbaafda091139b8744becd4853ada2f747
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
KSGEN and CRYPT tasks and corresponding events weren't compiled for boards with nRF51 SoCs due to change in HAL.