### PR TITLE
tests: c_lib: test exit not _exit

### DIFF
--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -1211,12 +1211,12 @@ ZTEST(test_c_lib, test_abort)
 
 /**
  *
- * @brief test _exit functions
+ * @brief test exit functions
  *
  */
 static void exit_program(void *p1, void *p2, void *p3)
 {
-	_exit(1);
+	exit(1);
 }
 
 ZTEST(test_c_lib, test_exit)


### PR DESCRIPTION
Tweak test to test exit and not _exit, as _exit is not a standard libc function.