### PR TITLE
Fix i3c_mcux build breakage and get it working on RT595EVK

### DIFF
--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33-pinctrl.dtsi
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33-pinctrl.dtsi
@@ -220,4 +220,21 @@
 			drive-strength = "normal";
 		};
 	};
+
+	pinmux_i3c: pinmux_i3c {
+		group0 {
+			pinmux = <I3C0_SCL_PIO2_29>,
+				<I3C0_SDA_PIO2_30>;
+			input-enable;
+			slew-rate = "slow";
+			drive-strength = "high";
+		};
+
+		group1 {
+			pinmux = <I3C0_PUR_PIO2_31>;
+			slew-rate = "normal";
+			drive-strength = "normal";
+		};
+	};
+
 };

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -528,3 +528,10 @@ zephyr_udc0: &usbhs {
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&i3c0 {
+	pinctrl-0 = <&pinmux_i3c>;
+	pinctrl-names = "default";
+
+	status = "okay";
+};

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -495,6 +495,19 @@
 		clock-names = "dphy", "esc", "pixel";
 		status = "disabled";
 	};
+
+	i3c0: i3c@36000 {
+		compatible = "nxp,mcux-i3c";
+		reg = <0x36000 0x1000>;
+		interrupts = <49 0>;
+		clocks = <&clkctl1 MCUX_I3C_CLK>;
+		clk-divider = <2>;
+		clk-divider-slow = <1>;
+		clk-divider-tc = <1>;
+		status = "disabled";
+		#address-cells = <3>;
+		#size-cells = <0>;
+	};
 };
 
 &flexspi {

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -302,6 +302,11 @@ static void clock_init(void)
 	/* Switch FLEXCOMM4 to FRO_DIV4 */
 	CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM4);
 #endif
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(i3c0), nxp_mcux_i3c, okay)
+	/* Attach main clock to I3C, divider will be set in i3c_mcux.c */
+	CLOCK_AttachClk(kMAIN_CLK_to_I3C_CLK);
+	CLOCK_AttachClk(kLPOSC_to_I3C_TC_CLK);
+#endif
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(hs_spi1), nxp_lpc_spi, okay)
 	CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM16);
 #endif


### PR DESCRIPTION
Fix a recent regression which broke build of i3c_mcux.c for RT685EVK.

Add I3C to RT595EVK

Make it work when there are only i2c devices on the i3c bus, as is the case in the RT595EVK.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/57560