### PR TITLE
xtensa: limit speical exit() to XT_SIMULATOR

### DIFF
--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -120,9 +120,9 @@ void z_xtensa_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	z_fatal_error(reason, esf);
 }
 
+#ifdef XT_SIMULATOR
 void exit(int return_code)
 {
-#ifdef XT_SIMULATOR
 	__asm__ (
 	    "mov a3, %[code]\n\t"
 	    "movi a2, %[call]\n\t"
@@ -130,12 +130,8 @@ void exit(int return_code)
 	    :
 	    : [code] "r" (return_code), [call] "i" (SYS_exit)
 	    : "a3", "a2");
-#else
-	LOG_ERR("exit(%d)", return_code);
-	k_panic();
-#endif
-	CODE_UNREACHABLE;
 }
+#endif
 
 #ifdef XT_SIMULATOR
 FUNC_NORETURN void z_system_halt(unsigned int reason)


### PR DESCRIPTION
Use the common exit() provided by libc so we get standard behavior across all architectures.  So only implement a special exit when XT_SIMULATOR is defined.