### PR TITLE
NXP RT595: enablement of i2s

### DIFF
--- a/boards/arm/mimxrt595_evk/board.c
+++ b/boards/arm/mimxrt595_evk/board.c
@@ -95,6 +95,35 @@ static int mimxrt595_evk_init(void)
 	/* Do not enter deep low power modes until the PMIC modes have been initialized */
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
 
+#ifdef CONFIG_I2S
+
+	/* Set shared signal set 0 SCK, WS from Transmit I2S - Flexcomm3 */
+	SYSCTL1->SHAREDCTRLSET[0] = SYSCTL1_SHAREDCTRLSET_SHAREDSCKSEL(3) |
+				SYSCTL1_SHAREDCTRLSET_SHAREDWSSEL(3);
+
+#ifdef CONFIG_I2S_TEST_SEPARATE_DEVICES
+	/* Select Data in from Transmit I2S - Flexcomm 3 */
+	SYSCTL1->SHAREDCTRLSET[0] |= SYSCTL1_SHAREDCTRLSET_SHAREDDATASEL(3);
+	/* Enable Transmit I2S - Flexcomm 3 for Shared Data Out */
+	SYSCTL1->SHAREDCTRLSET[0] |= SYSCTL1_SHAREDCTRLSET_FC3DATAOUTEN(1);
+#endif
+
+	/* Set Receive I2S - Flexcomm 1 SCK, WS from shared signal set 0 */
+	SYSCTL1->FCCTRLSEL[1] = SYSCTL1_FCCTRLSEL_SCKINSEL(1) |
+				SYSCTL1_FCCTRLSEL_WSINSEL(1);
+
+	/* Set Transmit I2S - Flexcomm 3 SCK, WS from shared signal set 0 */
+	SYSCTL1->FCCTRLSEL[3] = SYSCTL1_FCCTRLSEL_SCKINSEL(1) |
+				SYSCTL1_FCCTRLSEL_WSINSEL(1);
+
+#ifdef CONFIG_I2S_TEST_SEPARATE_DEVICES
+	/* Select Receive I2S - Flexcomm 1 Data in from shared signal set 0 */
+	SYSCTL1->FCCTRLSEL[1] |= SYSCTL1_FCCTRLSEL_DATAINSEL(1);
+	/* Select Transmit I2S - Flexcomm 3 Data out to shared signal set 0 */
+	SYSCTL1->FCCTRLSEL[3] |= SYSCTL1_FCCTRLSEL_DATAOUTSEL(1);
+#endif
+
+#endif
 	return 0;
 }
 

--- a/boards/arm/mimxrt595_evk/doc/index.rst
+++ b/boards/arm/mimxrt595_evk/doc/index.rst
@@ -105,6 +105,8 @@ already supported, which can also be re-used on this mimxrt595_evk board:
 +-----------+------------+-------------------------------------+
 | SDHC      | on-chip    | disk access (works with eMMC & SD)  |
 +-----------+------------+-------------------------------------+
+| I2S       | on-chip    | i2s                                 |
++-----------+------------+-------------------------------------+
 | DISPLAY   | on-chip    | LCDIF; MIPI-DSI. Tested with RM68200|
 |           |            | based MIPI display                  |
 |           |            | (`RK055HDMIPI4M`_)                  |

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33-pinctrl.dtsi
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33-pinctrl.dtsi
@@ -24,6 +24,28 @@
 		};
 	};
 
+	/* RX */
+	pinmux_flexcomm1_i2s: pinmux_flexcomm1_i2s {
+		group0 {
+			pinmux = <FC1_RXD_SDA_MOSI_DATA_PIO0_9>,
+				<FC1_TXD_SCL_MISO_WS_PIO0_8>,
+				<FC1_SCK_PIO0_7>;
+			slew-rate = "normal";
+			input-enable;
+			drive-strength = "high";
+		};
+	};
+
+	/* TX */
+	pinmux_flexcomm3_i2s: pinmux_flexcomm3_i2s {
+		group0 {
+			pinmux = <FC3_RXD_SDA_MOSI_DATA_PIO0_23>;
+			input-enable;
+			slew-rate = "normal";
+			drive-strength = "high";
+		};
+	};
+
 	pinmux_flexcomm4_i2c: pinmux_flexcomm4_i2c {
 		group0 {
 			pinmux = <FC4_TXD_SCL_MISO_WS_PIO0_29>,

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -233,6 +233,30 @@ hs_spi1: &hs_lspi1 {
 	status = "okay";
 };
 
+/* I2S RX */
+i2s0: &flexcomm1 {
+	compatible = "nxp,lpc-i2s";
+	pinctrl-0 = <&pinmux_flexcomm1_i2s>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	dmas = <&dma0 2>;
+	dma-names = "rx";
+	status = "disabled";
+};
+
+/* I2S TX */
+i2s1: &flexcomm3 {
+	compatible = "nxp,lpc-i2s";
+	pinctrl-0 = <&pinmux_flexcomm3_i2s>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	dmas = <&dma0 7>;
+	dma-names = "tx";
+	status = "disabled";
+};
+
 arduino_serial: &flexcomm12 {
 	compatible = "nxp,lpc-usart";
 	status = "okay";

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.yaml
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.yaml
@@ -27,3 +27,4 @@ supported:
   - watchdog
   - sdhc
   - pwm
+  - i2s

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -288,6 +288,16 @@ static void clock_init(void)
 #if CONFIG_USB_DC_NXP_LPCIP3511
 	usb_device_clock_init();
 #endif
+
+#if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm1), nxp_lpc_i2s, okay) && CONFIG_I2S)
+	/* attach AUDIO PLL clock to FLEXCOMM1 (I2S1) */
+	CLOCK_AttachClk(kAUDIO_PLL_to_FLEXCOMM1);
+#endif
+#if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm3), nxp_lpc_i2s, okay) && CONFIG_I2S)
+	/* attach AUDIO PLL clock to FLEXCOMM3 (I2S3) */
+	CLOCK_AttachClk(kAUDIO_PLL_to_FLEXCOMM3);
+#endif
+
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm4), nxp_lpc_i2c, okay)
 	/* Switch FLEXCOMM4 to FRO_DIV4 */
 	CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM4);

--- a/tests/drivers/i2s/i2s_speed/boards/mimxrt595_evk_cm33.conf
+++ b/tests/drivers/i2s/i2s_speed/boards/mimxrt595_evk_cm33.conf
@@ -1,0 +1,7 @@
+#
+# Copyright 2023 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_I2S_TEST_SEPARATE_DEVICES=y

--- a/tests/drivers/i2s/i2s_speed/boards/mimxrt595_evk_cm33.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/mimxrt595_evk_cm33.overlay
@@ -1,0 +1,20 @@
+/* i2s_speed with CONFIG_I2S_TEST_SEPARATE_DEVICES=y uses two I2S peripherals:
+ * i2s-node0 is the receiver
+ * i2s-node1 is the transmitter
+ */
+
+/ {
+	aliases {
+		i2s-node0 = &i2s0;
+		i2s-node1 = &i2s1;
+	};
+
+};
+
+&i2s0 {
+    status = "okay";
+};
+
+&i2s1 {
+    status = "okay";
+};


### PR DESCRIPTION
This PR enables i2s on rt595:

 - device tree nodes,
 - clock enablement
 - set up code for loopback requirements (i2s speed test)