### PR TITLE
include/device.h: Add device class sorting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,11 +83,13 @@ endif()
 set(ZEPHYR_FINAL_EXECUTABLE zephyr_final)
 
 # Set some phony targets to collect dependencies
-set(OFFSETS_H_TARGET           offsets_h)
-set(SYSCALL_LIST_H_TARGET      syscall_list_h_target)
-set(DRIVER_VALIDATION_H_TARGET driver_validation_h_target)
-set(KOBJ_TYPES_H_TARGET        kobj_types_h_target)
-set(PARSE_SYSCALLS_TARGET      parse_syscalls_target)
+set(OFFSETS_H_TARGET               offsets_h)
+set(SYSCALL_LIST_H_TARGET          syscall_list_h_target)
+set(DRIVER_VALIDATION_H_TARGET     driver_validation_h_target)
+set(KOBJ_TYPES_H_TARGET            kobj_types_h_target)
+set(PARSE_SYSCALLS_TARGET          parse_syscalls_target)
+set(KERNEL_DEVICE_SUBSYS_LD_TARGET kernel_device_subsys_ld_target)
+set(KERNEL_DEVICE_CLASS_H_TARGET   kernel_device_class_h_target)
 
 define_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT BRIEF_DOCS " " FULL_DOCS " ")
 set_property(   GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-little${ARCH}) # BFD format
@@ -781,6 +783,54 @@ add_custom_target(${DRIVER_VALIDATION_H_TARGET} DEPENDS ${DRV_VALIDATION})
 include(${ZEPHYR_BASE}/cmake/kobj.cmake)
 gen_kobj(KOBJ_INCLUDE_PATH)
 
+# Generate sections for kernel device subsystems
+
+set(
+  KERNEL_DEVICE_SUBSYS_SECTIONS
+  ${CMAKE_CURRENT_BINARY_DIR}/include/generated/kernel-device-subsys-sections.ld
+  )
+
+add_custom_command(
+  OUTPUT ${KERNEL_DEVICE_SUBSYS_SECTIONS}
+  COMMAND ${PYTHON_EXECUTABLE}
+  ${ZEPHYR_BASE}/scripts/build/gen_iter_sections.py
+  -i ${struct_tags_json}
+  -t __subsystem
+  -o ${KERNEL_DEVICE_SUBSYS_SECTIONS}
+  DEPENDS
+  ${ZEPHYR_BASE}/scripts/build/gen_iter_sections.py
+  ${struct_tags_json}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+
+# Generate macros for device classes
+
+add_custom_target(${KERNEL_DEVICE_SUBSYS_LD_TARGET} DEPENDS ${KERNEL_DEVICE_SUBSYS_SECTIONS})
+
+set(
+  KERNEL_DEVICE_CLASS_HEADER
+  ${CMAKE_CURRENT_BINARY_DIR}/include/generated/device_class_generated.h
+  )
+
+add_custom_command(
+  OUTPUT ${KERNEL_DEVICE_CLASS_HEADER}
+  COMMAND ${PYTHON_EXECUTABLE}
+  ${ZEPHYR_BASE}/scripts/build/gen_device_class.py
+  -k $<TARGET_FILE:${ZEPHYR_LINK_STAGE_EXECUTABLE}>
+  -o ${KERNEL_DEVICE_CLASS_HEADER}
+  -z ${ZEPHYR_BASE}
+  -s "$<TARGET_PROPERTY:linker,devices_start_symbol>"
+  VERBATIM
+  DEPENDS
+  ${ZEPHYR_BASE}/scripts/build/gen_device_class.py
+  ${ZEPHYR_LINK_STAGE_EXECUTABLE}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+
+set_property(GLOBAL APPEND PROPERTY GENERATED_DEVICE_CLASS_HEADER ${KERNEL_DEVICE_CLASS_HEADER})
+
+add_custom_target(${KERNEL_DEVICE_CLASS_H_TARGET} DEPENDS ${KERNEL_DEVICE_CLASS_HEADER})
+
 # Add a pseudo-target that is up-to-date when all generated headers
 # are up-to-date.
 
@@ -807,6 +857,7 @@ add_dependencies(zephyr_interface
   ${SYSCALL_LIST_H_TARGET}
   ${DRIVER_VALIDATION_H_TARGET}
   ${KOBJ_TYPES_H_TARGET}
+  ${KERNEL_DEVICE_SUBSYS_LD_TARGET}
   )
 
 add_custom_command(
@@ -1366,12 +1417,13 @@ set_property(TARGET
   )
 
 # Read global variables into local variables
+get_property(GDCH GLOBAL PROPERTY GENERATED_DEVICE_CLASS_HEADER)
 get_property(GASF GLOBAL PROPERTY GENERATED_APP_SOURCE_FILES)
 get_property(GKOF GLOBAL PROPERTY GENERATED_KERNEL_OBJECT_FILES)
 get_property(GKSF GLOBAL PROPERTY GENERATED_KERNEL_SOURCE_FILES)
 
 # FIXME: Is there any way to get rid of empty_file.c?
-add_executable(       ${ZEPHYR_LINK_STAGE_EXECUTABLE} misc/empty_file.c ${GASF})
+add_executable(       ${ZEPHYR_LINK_STAGE_EXECUTABLE} misc/empty_file.c ${GASF} ${GDCH})
 toolchain_ld_link_elf(
   TARGET_ELF            ${ZEPHYR_LINK_STAGE_EXECUTABLE}
   OUTPUT_MAP            ${PROJECT_BINARY_DIR}/${ZEPHYR_LINK_STAGE_EXECUTABLE}.map

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -738,6 +738,24 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 }
 
 /**
+ * @brief Define device class API
+ *
+ * @details Places device API implementation in appropriate
+ * section in ROM.
+ *
+ * @example
+ *
+ * DEVICE_CLASS_API(rtc, rtc_emul_driver_api) = {
+ *         get_time = rtc_emul_get_time;
+ * };
+ *
+ * @param _class Device class [rtc, i2c, ...]
+ * @param _varname Variable name
+ */
+#define DEVICE_CLASS_API(_class, _varname) \
+	const STRUCT_SECTION_ITERABLE(_class##_driver_api, _varname)
+
+/**
  * @}
  */
 

--- a/include/zephyr/device_class.h
+++ b/include/zephyr/device_class.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DEVICE_CLASS_H_
+#define ZEPHYR_INCLUDE_DEVICE_CLASS_H_
+
+#include <zephyr/sys/util.h>
+
+#include <device_class_generated.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Get the enumeration of a device from device class and index
+ *
+ * @example
+ *
+ * DEVICE_CLASS_ENUM(rtc, 0)
+ *
+ * expands to
+ *
+ * DC_E_rtc_0
+ */
+#define DEVICE_CLASS_ENUM(device_class, index) \
+	_CONCAT(DC_E_, _CONCAT(_class, _CONCAT(_, _index)))
+
+/**
+ * @brief Get pointer to device by class and index
+ *
+ * @example
+ *
+ * to get a struct device by enumeration
+ *
+ * const struct device *rtc = DEVICE_CLASS_GET_DEVICE(DEVICE_CLASS_ENUM(rtc, 0));
+ *
+ * or to get a struct device from devicetree
+ *
+ * const struct device *rtc =
+ *         DEVICE_CLASS_GET_DEVICE(DEVICE_CLASS_ENUM_FROM_DT(DT_ALIAS(console)));
+ */
+#define DEVICE_CLASS_GET_DEVICE(device_enum) \
+	(&_CONCAT(device_enum, _SYM))
+
+/**
+ * @brief Get the number of devices which belong to specific device class
+ * @example size_t number_of_rtc_devices = DEVICE_CLASS_NUM(rtc);
+ */
+#define DEVICE_CLASS_COUNT(device_class) \
+	_CONCAT(DC_CNT_, device_class)
+
+/**
+ * @brief Get the device enumeration from a devicetree node identifier
+ *
+ * @example
+ *
+ * DEVICE_CLASS_ENUM_FROM_DT(DT_ALIAS(console))
+ *
+ * could expand to
+ *
+ * DEVICE_CLASS_E_uart_0
+ *
+ * given the device exists and belongs to the UART class
+ */
+#define DEVICE_CLASS_ENUM_FROM_DT(node_id) \
+	_CONCAT(DC_E_DT_RL_, node_id)
+
+/**
+ * @brief Get the device enumeration from a devicetree node identifier
+ *
+ * @example
+ *
+ * DEVICE_CLASS_DT_NODE_FROM_ENUM(DEVICE_CLASS_ENUM(uart, 0))
+ *
+ * could expand to
+ *
+ * DT_N_S_soc_S_serial_40004800
+ *
+ * given the device exists and belongs to the UART class
+ */
+#define DEVICE_CLASS_DT_NODE_FROM_ENUM(device_enum) \
+	_CONCAT(device_enum, _DT_NODE)
+
+/**
+ * @brief Get the class of a device  from device enumeration
+ *
+ * @example
+ *
+ * DEVICE_CLASS_ENUM_GET_CLASS(DEVICE_CLASS_ENUM(uart, 0))
+ *
+ * expands to
+ *
+ * uart
+ *
+ * given the device exists and belongs to the UART class
+ */
+#define DEVICE_CLASS_ENUM_GET_CLASS(device_enum) \
+	_CONCAT(device_enum, _CLASS)
+
+/**
+ * @brief Get the index of a device within its class from its enumeration
+ *
+ * @example
+ *
+ * DEVICE_CLASS_ENUM_GET_INDEX(DEVICE_CLASS_ENUM(uart, 0))
+ *
+ * expands to
+ *
+ * 0
+ *
+ * given the device exists and belongs to the UART class
+ */
+#define DEVICE_CLASS_ENUM_GET_INDEX(device_enum) \
+	_CONCAT(device_enum, _INDEX)
+
+/**
+ * @brief Iterate through all devices of a specified class
+ *
+ * @example
+ *
+ * #define SOME_UART_FN(device_enum)
+ *
+ * DEVICE_CLASS_FOREACH_DEVICE_OF_CLASS(uart, SOME_UART_FN)
+ */
+#define DEVICE_CLASS_FOREACH_DEVICE_OF_CLASS(device_class, fn) \
+	_CONCAT(DC_E_FOREACH_, device_class)(fn)
+
+/**
+ * @brief Iterate through all devices regardless of class
+ *
+ * @example
+ *
+ * #define SOME_DEVICE_FN(device_enum)
+ *
+ * DEVICE_CLASS_FOREACH_DEVICE(SOME_DEVICE_FN)
+ */
+#define DEVICE_CLASS_FOREACH_DEVICE(fn) \
+	DC_E_FOREACH(fn)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DEVICE_CLASS_H_ */

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -97,7 +97,7 @@ typedef int (*clock_control_configure_fn)(const struct device *dev,
 					  clock_control_subsys_t sys,
 					  void *data);
 
-struct clock_control_driver_api {
+__subsystem struct clock_control_driver_api {
 	clock_control			on;
 	clock_control			off;
 	clock_control_async_on_fn	async_on;

--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -82,3 +82,5 @@
 #include <zephyr/linker/device-handles.ld>
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif /* !CONFIG_HAS_DYNAMIC_DEVICE_HANDLES */
+
+#include <kernel-device-subsys-sections.ld>

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -959,6 +959,9 @@ config HAS_DYNAMIC_DEVICE_HANDLES
 	  Hidden option that makes possible to manipulate device handles at
 	  runtime.
 
+config DEVICE_VALIDATE_CLASS
+	bool "Validate class"
+
 endmenu
 
 rsource "Kconfig.vm"

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -76,6 +76,9 @@ GEN_ABSOLUTE_SYM(__z_interrupt_stack_SIZEOF, sizeof(z_interrupt_stacks[0]));
 GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_HANDLES_OFFSET,
 		 offsetof(struct device, handles));
 
+GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_API_OFFSET,
+		 offsetof(struct device, api));
+
 #ifdef CONFIG_PM_DEVICE
 GEN_ABSOLUTE_SYM(_DEVICE_STRUCT_PM_OFFSET,
 		 offsetof(struct device, pm));

--- a/scripts/build/elf_parser.py
+++ b/scripts/build/elf_parser.py
@@ -81,6 +81,7 @@ class Device(_Symbol):
     Represents information about a device object and its references to other objects.
     """
     required_ld_consts = [
+        "_DEVICE_STRUCT_API_OFFSET",
         "_DEVICE_STRUCT_HANDLES_OFFSET",
         "_DEVICE_STRUCT_PM_OFFSET"
     ]
@@ -91,6 +92,11 @@ class Device(_Symbol):
         self.handle = None
         self.ordinals = None
         self.pm = None
+        self.api = None
+
+        # Pointer to device API
+        api_offset = self.elf.ld_consts['_DEVICE_STRUCT_API_OFFSET']
+        self.api = self._data_native_read(api_offset)
 
         # Devicetree dependencies, injected dependencies, supported devices
         self.devs_depends_on = set()
@@ -156,6 +162,14 @@ class ZephyrElf:
             if (start <= addr) and (addr + len) <= end:
                 offset = addr - section['sh_addr']
                 return bytes(section.data()[offset:offset + len])
+
+    def find_section_by_address(self, address):
+        for section in self.elf.iter_sections():
+            start = section['sh_addr']
+            end = start + section['sh_size']
+            if start <= address < end:
+                return section
+        return None
 
     def _symbols_find_value(self, names):
         symbols = {}

--- a/scripts/build/gen_device_class.py
+++ b/scripts/build/gen_device_class.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2023 Bjarki Arge Andreasen
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''
+Script to generate a header file containing kernel struct devices and
+their properties.
+
+This script uses an early build of the kernel, which builds all device
+drivers, to find built struct devices and their properties from sections
+in the elf file and properties from the devicetree, with the help of the
+elf_parser.py script.
+
+The output is then used by the application and subsystems to get pointers
+to and information about the existing struct devices at compile time.
+
+struct devices are sorted by their class, and then sorted within their
+class by either their unit address They are then given an index based on
+their position within their class. This results in consistent indexes of struct
+devices for a board across builds.
+
+Note that applications and subsystems should not rely on the index of the
+struct devices.
+'''
+
+import sys
+import argparse
+import os
+import pickle
+import textwrap
+
+from elf_parser import ZephyrElf
+
+# This is needed to load edt.pickle files.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..',
+                                'dts', 'python-devicetree', 'src'))
+
+DEVICE_CLASS_PREFIX = 'DC'
+
+def parse_args():
+    global args
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
+
+    parser.add_argument('-k', '--kernel', required=True,
+                        help='Input zephyr ELF binary')
+    parser.add_argument('-o', '--output-header', required=True,
+                        help='Output header file')
+    parser.add_argument('-z', '--zephyr-base',
+                        help='Path to current Zephyr base. If this argument \
+                        is not provided the environment will be checked for \
+                        the ZEPHYR_BASE environment variable.')
+    parser.add_argument('-s', '--start-symbol', required=True,
+                        help='Symbol name of the section which contains the \
+                        devices. The symbol name must point to the first \
+                        device in that section.')
+
+    args = parser.parse_args()
+
+    ZEPHYR_BASE = args.zephyr_base or os.getenv('ZEPHYR_BASE')
+
+    if ZEPHYR_BASE is None:
+        sys.exit('-z / --zephyr-base not provided. Please provide '
+                 '--zephyr-base or set ZEPHYR_BASE in environment')
+
+    sys.path.insert(0, os.path.join(ZEPHYR_BASE, 'scripts/dts'))
+
+def devices_from_parsed_elf(parsed_elf):
+    devices = []
+
+    for device in parsed_elf.devices:
+        if not device.api:
+            continue
+
+        api_section = parsed_elf.find_section_by_address(device.api)
+
+        if not api_section or not api_section.name.endswith('_driver_api_area'):
+            print(f'struct device {device.sym.name} could not be classified')
+            continue
+
+        parsed_device = {
+            'symbol name': device.sym.name,
+            'class': api_section.name[:-16],
+            'node id': 'DT_' + device.edt_node.z_path_id if device.edt_node else None,
+            'node unit address': device.edt_node.unit_addr if device.edt_node else None,
+        }
+
+        devices.append(parsed_device)
+
+    return devices
+
+def sort_devices_by_class(devices):
+    devices_by_class = {}
+
+    for device in devices:
+        if device['class'] not in devices_by_class:
+            devices_by_class[device['class']] = [device]
+        else:
+            devices_by_class[device['class']].append(device)
+
+    devices_by_class = dict(sorted(devices_by_class.items()))
+
+    def sort_key(d):
+        return d['node unit address'] if d['node unit address'] is not None else 0xFFFFFFFF
+
+    for key in devices_by_class:
+        devices_by_class[key] = sorted(devices_by_class[key], key=sort_key)
+
+    sorted_devices = [item for sublist in devices_by_class.values() for item in sublist]
+
+    return sorted_devices, devices_by_class
+
+def enumerate_devices_by_class(devices_by_class):
+    global DEVICE_CLASS_PREFIX
+
+    for device_class in devices_by_class.values():
+        for i, device in enumerate(device_class):
+            device['index'] = i
+            device['device enum'] = '_'.join([DEVICE_CLASS_PREFIX, 'E', device['class'], str(device['index'])])
+
+def write_devices_by_class(f, devices_by_class: dict):
+    for device_class, devices in devices_by_class.items():
+        f.write(textwrap.dedent(f'''
+            /*
+             * {device_class.capitalize()} devices
+             */
+        '''))
+
+        for device in devices:
+            f.write(textwrap.dedent(f'''
+                /* {device["class"]}_{device["index"]} */
+                #define {device["device enum"]}_SYM {device["symbol name"]}
+                #define {device["device enum"]}_CLASS {device["class"]}
+                #define {device["device enum"]}_INDEX {device["index"]}
+                #define {device["device enum"]}_DT_NODE {device["node id"]}
+            '''))
+
+def write_edt_reverse_links(f, devices: dict):
+    global DEVICE_CLASS_PREFIX
+
+    f.write(textwrap.dedent(f'''
+        /*
+         * Links from devicetree nodes to device enumerations
+         */
+    '''))
+
+    for device in devices:
+        if 'node id' not in device:
+            continue
+
+        f.write(f'#define {DEVICE_CLASS_PREFIX}_E_DT_RL_{device["node id"]} {device["device enum"]}\n')
+
+def write_number_of_devices_by_class(f, devices_by_class: dict):
+    global DEVICE_CLASS_PREFIX
+
+    f.write(textwrap.dedent(f'''
+        /*
+         * Length of device enumerations by class
+         */
+    '''))
+
+    for device_class, devices in devices_by_class.items():
+        f.write(f'#define {DEVICE_CLASS_PREFIX}_E_CNT_{device_class} {len(devices)}\n')
+
+def write_foreach_device_by_class(f, devices_by_class: dict):
+    global DEVICE_CLASS_PREFIX
+
+    f.write(textwrap.dedent(f'''
+        /*
+         * For each device within specified device class
+         */
+    '''))
+
+    for device_class, devices in devices_by_class.items():
+        fns = " ".join([f"fn({d['device enum']})" for d in devices])
+        f.write(f'#define {DEVICE_CLASS_PREFIX}_E_FOREACH_{device_class}(fn) {fns}\n')
+
+def write_foreach_device(f, sorted_devices: list):
+    global DEVICE_CLASS_PREFIX
+
+    f.write(textwrap.dedent(f'''
+        /*
+         * For each device regardless of device class
+         */
+    '''))
+
+    fns = " ".join([f"fn({d['device enum']})" for d in sorted_devices])
+    f.write(f'#define {DEVICE_CLASS_PREFIX}_E_FOREACH(fn) {fns}\n')
+
+def main():
+    parse_args()
+
+    edtser = os.path.join(os.path.split(args.kernel)[0], "edt.pickle")
+
+    with open(edtser, 'rb') as f:
+        edt = pickle.load(f)
+
+    parsed_elf = ZephyrElf(args.kernel, edt, args.start_symbol)
+
+    devices = devices_from_parsed_elf(parsed_elf)
+
+    sorted_devices, devices_by_class = sort_devices_by_class(devices)
+
+    enumerate_devices_by_class(devices_by_class)
+
+    with open(args.output_header, 'w') as f:
+        write_devices_by_class(f, devices_by_class)
+
+        write_edt_reverse_links(f, sorted_devices)
+
+        write_number_of_devices_by_class(f, devices_by_class)
+
+        write_foreach_device_by_class(f, devices_by_class)
+
+        write_foreach_device(f, sorted_devices)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/build/gen_iter_sections.py
+++ b/scripts/build/gen_iter_sections.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2023 Bjarki Arge Andreasen
+#
+# SPDX-License-Identifier: Apache-2.0
+'''
+Script to generate iterable sections from JSON encoded dictionary containing lists of items.
+'''
+
+import argparse
+import json
+
+def get_tagged_items(filepath: str, tag: str) -> list:
+    with open(filepath, 'r') as fp:
+        return json.load(fp)[tag]
+
+def gen_ld(filepath: str, items: list, tag):
+    with open(filepath, 'w') as fp:
+        fp.write('\n'.join([f'\tITERABLE_SECTION_ROM({i}, 4)' for i in items]))
+        fp.write('\n')
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__,
+            formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
+
+    parser.add_argument('-i', '--input', required=True,
+                        help='Path to input list of tags')
+
+    parser.add_argument('-t', '--tag', required=True,
+                    help='Tag to generate iterable sections for')
+
+    parser.add_argument('-o', '--output', required=True,
+                        help='Path to output linker file')
+
+    return parser.parse_args()
+
+def main():
+    args = parse_args()
+
+    items = get_tagged_items(args.input, args.tag)
+
+    gen_ld(args.output, items, args.tag)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Introduction

### TL;DR

Adds macro which places struct device API structure in sections based on class, which is then made available to the elf parser, allowing it to determine the class of a struct device without dwarf info or other device meta data. This can be used for sorting through devices by class instead of by node/name using macros

### Disclaimer

This is a working prototype, thats is currently being worked on

### What is the problem?

Right now, we use devicetree aliases to identify hardware using the name only. This ties all struct devices to the node they belong to, and does not ensure that the device driver is of any particular class, or exists at all. From the application, to get the RTC, we currently do this:

```
const struct device *rtc = DEVICE_DT_GET(DT_ALIAS(rtc));
```

This can result in unpredictable behavior, if the device driver is not actually using the RTC API, but the counter API, which we can not protect against outside of userspace currently.

### What will the solution look like?

Knowing all devices that exist by global variable name, and what API they implement (their class), we can do this instead:

`#define DEVICE_CLASS_GET(_class, _index)`

```
const struct device *rtc = DEVICE_CLASS_GET(rtc, 0);
```

Which will return the first instance of any RTC on the system, regardless of where in the devicetree it exists. This macro would ensure that the struct device actually implements the RTC API, and we can even extend the API wrappers to perform an additional validation on the struct device API ptr for an extra layer of protection.

We can additionally check how many instances of some device class there is at compile time, and iterate through them with macros.

`#define DEVICE_CLASS_COUNT(_class)`
`#define DEVICE_CLASS_FOREACH(_class, _fn)`

```
BUILD_ASSERT(DEVICE_CLASS_COUNT(counter) >= 3, "This sample requires at least 3 HW counters");
```

We may become entirely independent from the devicetree nodes the from application (above drivers, kernel and subsystems) using this solution.

### What will change?

A new macro has been added which will be used to define device API implementations within device drivers:

From

```
const struct rtc_driver_api rtc_emul_driver_api = {
        .set_time = rtc_emul_set_time,
        .get_time = rtc_emul_get_time
};
```

To

```
DEVICE_CLASS_API(rtc, rtc_emul_driver_api) = {
        .set_time = rtc_emul_set_time,
        .get_time = rtc_emul_get_time
        ...
};
```

This places the struct device api implementation in the correct section in ROM to be identified and recognized by the elf parser. The following steps are used to determine the class of a device:
1. Build pre linker stage elf file
2. Run elf_parser.py to get list of devices and their properties, including the value of the struct device api pointer
3. Run kernel_device_class.py which uses the API pointer to check which section it points to [rtc_driver_api_area, ...]
4. We now have name and class of all struct devices, DT or none DT
5. FUTURE: create macros to sort through devices by class, like a static version of Linux sysfs
