### PR TITLE
soc: esp32s3: add usb serial dts interface

### DIFF
--- a/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.dts
+++ b/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm.dts
@@ -46,6 +46,10 @@
 	clock-frequency = <ESP32_CLK_CPU_240M>;
 };
 
+&usb_serial {
+	status = "okay";
+};
+
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;

--- a/dts/xtensa/espressif/esp32s3.dtsi
+++ b/dts/xtensa/espressif/esp32s3.dtsi
@@ -201,6 +201,15 @@
 			status = "disabled";
 		};
 
+		usb_serial: uart@60038000 {
+			compatible = "espressif,esp32-usb-serial";
+			reg = <0x60038000 DT_SIZE_K(4)>;
+			status = "disabled";
+			interrupts = <USB_SERIAL_JTAG_INTR_SOURCE>;
+			interrupt-parent = <&intc>;
+			clocks = <&rtc ESP32_USB_MODULE>;
+		};
+
 		timer0: counter@6001f000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x6001f000 DT_SIZE_K(4)>;


### PR DESCRIPTION
Enable ESP32-S3 usb-serial interface.