### PR TITLE
devicetree: expand use cases for some main macros

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -724,16 +724,28 @@
  * It might help to read the argument order as being similar to
  * `node->property[index]`.
  *
- * When the property's binding has type array, string-array,
- * uint8-array, or phandles, this expands to the idx-th array element
- * as an integer, string literal, or node identifier respectively.
+ * The return value depends on the property's type:
+ *
+ * - for types array, string-array, uint8-array, and phandles,
+ *   this expands to the idx-th array element as an
+ *   integer, string literal, integer, and node identifier
+ *   respectively
+ *
+ * - for type phandle, idx must be 0 and the expansion is a node
+ *   identifier (this treats phandle like a phandles of length 1)
+ *
+ * - for type string, idx must be 0 and the expansion is the the
+ *   entire string (this treats string like string-array of length 1)
  *
  * These properties are handled as special cases:
  *
- * - `reg` property: use DT_REG_ADDR_BY_IDX() or DT_REG_SIZE_BY_IDX() instead
- * - `interrupts` property: use DT_IRQ_BY_IDX() instead
+ * - `reg`: use DT_REG_ADDR_BY_IDX() or DT_REG_SIZE_BY_IDX() instead
+ * - `interrupts`: use DT_IRQ_BY_IDX()
+ * - `ranges`: use DT_NUM_RANGES()
+ * - `dma-ranges`: it is an error to use this property with
+ *   DT_PROP_BY_IDX()
  *
- * For non-array properties, behavior is undefined.
+ * For properties of other types, behavior is undefined.
  *
  * @param node_id node identifier
  * @param prop lowercase-and-underscores property name
@@ -2641,6 +2653,9 @@
  * DT_FOREACH_PROP_ELEM(), and @p idx is the current index into the array.
  * The @p idx values are integer literals starting from 0.
  *
+ * The @p prop argument must refer to a property that can be passed to
+ * DT_PROP_LEN().
+ *
  * Example devicetree fragment:
  *
  * @code{.dts}
@@ -2675,13 +2690,10 @@
  * where `n` is the number of elements in @p prop, as it would be
  * returned by `DT_PROP_LEN(node_id, prop)`.
  *
- * The @p prop argument must refer to a property with type `string`,
- * `array`, `uint8-array`, `string-array`, `phandles`, or `phandle-array`. It
- * is an error to use this macro with properties of other types.
- *
  * @param node_id node identifier
  * @param prop lowercase-and-underscores property name
  * @param fn macro to invoke
+ * @see DT_PROP_LEN
  */
 #define DT_FOREACH_PROP_ELEM(node_id, prop, fn)		\
 	DT_CAT4(node_id, _P_, prop, _FOREACH_PROP_ELEM)(fn)
@@ -2718,9 +2730,8 @@
  *     };
  * @endcode
  *
- * The "prop" argument must refer to a property with type string,
- * array, uint8-array, string-array, phandles, or phandle-array. It is
- * an error to use this macro with properties of other types.
+ * The @p prop parameter has the same restrictions as the same parameter
+ * given to DT_FOREACH_PROP_ELEM().
  *
  * @param node_id node identifier
  * @param prop lowercase-and-underscores property name
@@ -2743,6 +2754,9 @@
  * the array. The @p idx values are integer literals starting from 0. The
  * remaining arguments are passed-in by the caller.
  *
+ * The @p prop parameter has the same restrictions as the same parameter
+ * given to DT_FOREACH_PROP_ELEM().
+ *
  * @param node_id node identifier
  * @param prop lowercase-and-underscores property name
  * @param fn macro to invoke
@@ -2756,6 +2770,9 @@
 /**
  * @brief Invokes @p fn for each element in the value of property @p prop with
  * multiple arguments and a separator.
+ *
+ * The @p prop parameter has the same restrictions as the same parameter
+ * given to DT_FOREACH_PROP_ELEM().
  *
  * @param node_id node identifier
  * @param prop lowercase-and-underscores property name

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -621,6 +621,10 @@
  * - for type phandles, this expands to the number of phandles
  * - for type phandle-array, this expands to the number of
  *   phandle and specifier blocks in the property
+ * - for type phandle, this expands to 1 (so that a phandle
+ *   can be treated as a degenerate case of phandles with length 1)
+ * - for type string, this expands to 1 (so that a string can be
+ *   treated as a degenerate case of string-array with length 1)
  *
  * These properties are handled as special cases:
  *

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -645,8 +645,11 @@ def write_vanilla_props(node):
             macro2val[macro] = val
 
         if prop.spec.type == 'string':
+            # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UNQUOTED
             macro2val[macro + "_STRING_UNQUOTED"] = prop.val
+            # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_TOKEN
             macro2val[macro + "_STRING_TOKEN"] = prop.val_as_token
+            # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UPPER_TOKEN
             macro2val[macro + "_STRING_UPPER_TOKEN"] = prop.val_as_token.upper()
 
         if prop.enum_index is not None:
@@ -667,14 +670,18 @@ def write_vanilla_props(node):
         if "phandle" in prop.type:
             macro2val.update(phandle_macros(prop, macro))
         elif "array" in prop.type:
-            # DT_N_<node-id>_P_<prop-id>_IDX_<i>
-            # DT_N_<node-id>_P_<prop-id>_IDX_<i>_EXISTS
             for i, subval in enumerate(prop.val):
+                # DT_N_<node-id>_P_<prop-id>_IDX_<i>
+                # DT_N_<node-id>_P_<prop-id>_IDX_<i>_EXISTS
+
                 if isinstance(subval, str):
                     macro2val[macro + f"_IDX_{i}"] = quote_str(subval)
                     subval_as_token = edtlib.str_as_token(subval)
+                    # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UNQUOTED
                     macro2val[macro + f"_IDX_{i}_STRING_UNQUOTED"] = subval
+                    # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_TOKEN
                     macro2val[macro + f"_IDX_{i}_STRING_TOKEN"] = subval_as_token
+                    # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UPPER_TOKEN
                     macro2val[macro + f"_IDX_{i}_STRING_UPPER_TOKEN"] = subval_as_token.upper()
                 else:
                     macro2val[macro + f"_IDX_{i}"] = subval
@@ -687,16 +694,19 @@ def write_vanilla_props(node):
                     f'fn(DT_{node.z_path_id}, {prop_id}, {i})'
                     for i in range(len(prop.val)))
 
+            # DT_N_<node-id>_P_<prop-id>_FOREACH_PROP_ELEM_SEP
             macro2val[f"{macro}_FOREACH_PROP_ELEM_SEP(fn, sep)"] = \
                 ' DT_DEBRACKET_INTERNAL sep \\\n\t'.join(
                     f'fn(DT_{node.z_path_id}, {prop_id}, {i})'
                     for i in range(len(prop.val)))
 
+            # DT_N_<node-id>_P_<prop-id>_FOREACH_PROP_ELEM_VARGS
             macro2val[f"{macro}_FOREACH_PROP_ELEM_VARGS(fn, ...)"] = \
                 ' \\\n\t'.join(
                     f'fn(DT_{node.z_path_id}, {prop_id}, {i}, __VA_ARGS__)'
                     for i in range(len(prop.val)))
 
+            # DT_N_<node-id>_P_<prop-id>_FOREACH_PROP_ELEM_SEP_VARGS
             macro2val[f"{macro}_FOREACH_PROP_ELEM_SEP_VARGS(fn, sep, ...)"] = \
                 ' DT_DEBRACKET_INTERNAL sep \\\n\t'.join(
                     f'fn(DT_{node.z_path_id}, {prop_id}, {i}, __VA_ARGS__)'
@@ -707,6 +717,7 @@ def write_vanilla_props(node):
             # DT_N_<node-id>_P_<prop-id>_LEN
             macro2val[macro + "_LEN"] = plen
 
+        # DT_N_<node-id>_P_<prop-id>_EXISTS
         macro2val[f"{macro}_EXISTS"] = 1
 
     if macro2val:

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -32,12 +32,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'python-devicetree',
 
 from devicetree import edtlib
 
-# The set of binding types whose values can be iterated over with
-# DT_FOREACH_PROP_ELEM(). If you change this, make sure to update the
-# doxygen string for that macro.
-FOREACH_PROP_ELEM_TYPES = set(['string', 'array', 'uint8-array', 'string-array',
-                               'phandles', 'phandle-array'])
-
 class LogFormatter(logging.Formatter):
     '''A log formatter that prints the level name in lower case,
     for compatibility with earlier versions of edtlib.'''
@@ -651,6 +645,12 @@ def write_vanilla_props(node):
             macro2val[macro + "_STRING_TOKEN"] = prop.val_as_token
             # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UPPER_TOKEN
             macro2val[macro + "_STRING_UPPER_TOKEN"] = prop.val_as_token.upper()
+            # DT_N_<node-id>_P_<prop-id>_IDX_0:
+            # DT_N_<node-id>_P_<prop-id>_IDX_0_EXISTS:
+            # Allows treating the string like a degenerate case of a
+            # string-array of length 1.
+            macro2val[macro + "_IDX_0"] = quote_str(prop.val)
+            macro2val[macro + "_IDX_0_EXISTS"] = 1
 
         if prop.enum_index is not None:
             # DT_N_<node-id>_P_<prop-id>_ENUM_IDX
@@ -687,33 +687,32 @@ def write_vanilla_props(node):
                     macro2val[macro + f"_IDX_{i}"] = subval
                 macro2val[macro + f"_IDX_{i}_EXISTS"] = 1
 
-        if prop.type in FOREACH_PROP_ELEM_TYPES:
+        plen = prop_len(prop)
+        if plen is not None:
             # DT_N_<node-id>_P_<prop-id>_FOREACH_PROP_ELEM
             macro2val[f"{macro}_FOREACH_PROP_ELEM(fn)"] = \
                 ' \\\n\t'.join(
                     f'fn(DT_{node.z_path_id}, {prop_id}, {i})'
-                    for i in range(len(prop.val)))
+                    for i in range(plen))
 
             # DT_N_<node-id>_P_<prop-id>_FOREACH_PROP_ELEM_SEP
             macro2val[f"{macro}_FOREACH_PROP_ELEM_SEP(fn, sep)"] = \
                 ' DT_DEBRACKET_INTERNAL sep \\\n\t'.join(
                     f'fn(DT_{node.z_path_id}, {prop_id}, {i})'
-                    for i in range(len(prop.val)))
+                    for i in range(plen))
 
             # DT_N_<node-id>_P_<prop-id>_FOREACH_PROP_ELEM_VARGS
             macro2val[f"{macro}_FOREACH_PROP_ELEM_VARGS(fn, ...)"] = \
                 ' \\\n\t'.join(
                     f'fn(DT_{node.z_path_id}, {prop_id}, {i}, __VA_ARGS__)'
-                    for i in range(len(prop.val)))
+                    for i in range(plen))
 
             # DT_N_<node-id>_P_<prop-id>_FOREACH_PROP_ELEM_SEP_VARGS
             macro2val[f"{macro}_FOREACH_PROP_ELEM_SEP_VARGS(fn, sep, ...)"] = \
                 ' DT_DEBRACKET_INTERNAL sep \\\n\t'.join(
                     f'fn(DT_{node.z_path_id}, {prop_id}, {i}, __VA_ARGS__)'
-                    for i in range(len(prop.val)))
+                    for i in range(plen))
 
-        plen = prop_len(prop)
-        if plen is not None:
             # DT_N_<node-id>_P_<prop-id>_LEN
             macro2val[macro + "_LEN"] = plen
 
@@ -780,6 +779,11 @@ def prop2value(prop):
 def prop_len(prop):
     # Returns the property's length if and only if we should generate
     # a _LEN macro for the property. Otherwise, returns None.
+    #
+    # The set of types handled here coincides with the allowable types
+    # that can be used with DT_PROP_LEN(). If you change this set,
+    # make sure to update the doxygen string for that macro, and make
+    # sure that DT_FOREACH_PROP_ELEM() works for the new types too.
     #
     # This deliberately excludes ranges, dma-ranges, reg and interrupts.
     # While they have array type, their lengths as arrays are

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -794,7 +794,9 @@ def prop_len(prop):
     # with a build error. This forces users to switch to the right
     # macros.
 
-    if prop.type == "phandle":
+    if prop.type in ["phandle", "string"]:
+        # phandle is treated as a phandles of length 1.
+        # string is treated as a string-array of length 1.
         return 1
 
     if (prop.type in ["array", "uint8-array", "string-array",

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -19,6 +19,11 @@
 		ztest,gpio = &test_nodelabel;
 	};
 
+	zephyr,user {
+		ph = <&test_gpio_1>;
+		string = "foo";
+	};
+
 	test {
 		#address-cells = < 0x1 >;
 		#size-cells = < 0x1 >;

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -87,6 +87,8 @@
 #define TEST_RANGES_PCIE  DT_NODELABEL(test_ranges_pcie)
 #define TEST_RANGES_OTHER DT_NODELABEL(test_ranges_other)
 
+#define ZEPHYR_USER DT_PATH(zephyr_user)
+
 #define TA_HAS_COMPAT(compat) DT_NODE_HAS_COMPAT(TEST_ARRAYS, compat)
 
 #define TO_STRING(x) TO_STRING_(x)
@@ -1457,15 +1459,91 @@ ZTEST(devicetree_api, test_foreach_prop_elem)
 {
 #define TIMES_TWO(node_id, prop, idx) \
 	(2 * DT_PROP_BY_IDX(node_id, prop, idx)),
+#define BY_IDX_COMMA(node_id, prop, idx) DT_PROP_BY_IDX(node_id, prop, idx),
 
-	int array[] = {
+	int array_a[] = {
 		DT_FOREACH_PROP_ELEM(TEST_ARRAYS, a, TIMES_TWO)
 	};
 
-	zassert_equal(ARRAY_SIZE(array), 3, "");
-	zassert_equal(array[0], 2000, "");
-	zassert_equal(array[1], 4000, "");
-	zassert_equal(array[2], 6000, "");
+	zassert_equal(ARRAY_SIZE(array_a), 3, "");
+	zassert_equal(array_a[0], 2000, "");
+	zassert_equal(array_a[1], 4000, "");
+	zassert_equal(array_a[2], 6000, "");
+
+	int array_b[] = {
+		DT_FOREACH_PROP_ELEM(TEST_ARRAYS, b, TIMES_TWO)
+	};
+
+	zassert_equal(ARRAY_SIZE(array_b), 4, "");
+	zassert_equal(array_b[0], 2 * 0xAA, "");
+	zassert_equal(array_b[1], 2 * 0xBB, "");
+	zassert_equal(array_b[2], 2 * 0xCC, "");
+	zassert_equal(array_b[3], 2 * 0xDD, "");
+
+	static const char * const array_c[] = {
+		DT_FOREACH_PROP_ELEM(TEST_ARRAYS, c, BY_IDX_COMMA)
+	};
+
+	zassert_equal(ARRAY_SIZE(array_c), 2, "");
+	zassert_true(!strcmp(array_c[0], "bar"), "");
+	zassert_true(!strcmp(array_c[1], "baz"), "");
+
+	static const char * const array_val[] = {
+		DT_FOREACH_PROP_ELEM(TEST_ENUM_0, val, BY_IDX_COMMA)
+	};
+
+	zassert_equal(ARRAY_SIZE(array_val), 1, "");
+	zassert_true(!strcmp(array_val[0], "zero"), "");
+
+	static const char * const string_zephyr_user[] = {
+		DT_FOREACH_PROP_ELEM(ZEPHYR_USER, string, BY_IDX_COMMA)
+	};
+
+	zassert_equal(ARRAY_SIZE(string_zephyr_user), 1, "");
+	zassert_true(!strcmp(string_zephyr_user[0], "foo"), "");
+
+#undef BY_IDX_COMMA
+
+#define PATH_COMMA(node_id, prop, idx) \
+	DT_NODE_PATH(DT_PROP_BY_IDX(node_id, prop, idx)),
+
+	static const char * const array_ph[] = {
+		DT_FOREACH_PROP_ELEM(TEST_PH, ph, PATH_COMMA)
+	};
+
+	zassert_equal(ARRAY_SIZE(array_ph), 1, "");
+	zassert_true(!strcmp(array_ph[0], DT_NODE_PATH(TEST_GPIO_1)), "");
+
+	static const char * const array_zephyr_user_ph[] = {
+		DT_FOREACH_PROP_ELEM(ZEPHYR_USER, ph, PATH_COMMA)
+	};
+
+	zassert_equal(ARRAY_SIZE(array_zephyr_user_ph), 1, "");
+	zassert_true(!strcmp(array_zephyr_user_ph[0],
+			     DT_NODE_PATH(TEST_GPIO_1)), "");
+
+	static const char * const array_phs[] = {
+		DT_FOREACH_PROP_ELEM(TEST_PH, phs, PATH_COMMA)
+	};
+
+	zassert_equal(ARRAY_SIZE(array_phs), 3, "");
+	zassert_true(!strcmp(array_phs[0], DT_NODE_PATH(TEST_GPIO_1)), "");
+	zassert_true(!strcmp(array_phs[1], DT_NODE_PATH(TEST_GPIO_2)), "");
+	zassert_true(!strcmp(array_phs[2], DT_NODE_PATH(TEST_I2C)), "");
+
+#undef PATH_COMMA
+
+#define PIN_COMMA(node_id, prop, idx) DT_GPIO_PIN_BY_IDX(node_id, prop, idx),
+
+	int array_gpios[] = {
+		DT_FOREACH_PROP_ELEM(TEST_PH, gpios, PIN_COMMA)
+	};
+
+	zassert_equal(ARRAY_SIZE(array_gpios), 2, "");
+	zassert_equal(array_gpios[0], 10, "");
+	zassert_equal(array_gpios[1], 30, "");
+
+#undef PATH_COMMA
 
 	int array_sep[] = {
 		DT_FOREACH_PROP_ELEM_SEP(TEST_ARRAYS, a, DT_PROP_BY_IDX, (,))
@@ -1483,10 +1561,10 @@ ZTEST(devicetree_api, test_foreach_prop_elem)
 		DT_INST_FOREACH_PROP_ELEM(0, a, TIMES_TWO)
 	};
 
-	zassert_equal(ARRAY_SIZE(inst_array), ARRAY_SIZE(array), "");
-	zassert_equal(inst_array[0], array[0], "");
-	zassert_equal(inst_array[1], array[1], "");
-	zassert_equal(inst_array[2], array[2], "");
+	zassert_equal(ARRAY_SIZE(inst_array), ARRAY_SIZE(array_a), "");
+	zassert_equal(inst_array[0], array_a[0], "");
+	zassert_equal(inst_array[1], array_a[1], "");
+	zassert_equal(inst_array[2], array_a[2], "");
 
 	int inst_array_sep[] = {
 		DT_INST_FOREACH_PROP_ELEM_SEP(0, a, DT_PROP_BY_IDX, (,))

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -145,6 +145,7 @@ ZTEST(devicetree_api, test_nodelabel_props)
 	zassert_equal(DT_PROP_LEN(TEST_NODELABEL, compatible), 1, "");
 	zassert_true(!strcmp(DT_PROP_BY_IDX(TEST_NODELABEL, compatible, 0),
 			     "vnd,gpio-device"), "");
+	zassert_equal(DT_PROP_LEN(TEST_ENUM_0, val), 1, "");
 }
 
 #undef DT_DRV_COMPAT
@@ -740,6 +741,7 @@ ZTEST(devicetree_api, test_phandles)
 	zassert_true(DT_NODE_HAS_PROP(TEST_PH, ph), "");
 	zassert_true(DT_SAME_NODE(DT_PROP(TEST_PH, ph),
 				  DT_NODELABEL(test_gpio_1)), "");
+	zassert_equal(DT_PROP_LEN(TEST_PH, ph), 1, "");
 	zassert_true(DT_SAME_NODE(DT_PROP_BY_IDX(TEST_PH, ph, 0),
 				  DT_NODELABEL(test_gpio_1)), "");
 	/* DT_PROP_BY_PHANDLE */


### PR DESCRIPTION
Allow using `DT_PROP_LEN()` and `DT_PROP_BY_IDX()` with properties of type `phandle` and `string`. This also allows using `DT_FOREACH_PROP_ELEM()` with both types, which this PR verifies is possible in the test cases.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55115
