### PR TITLE
scripts: size_report: Add sorting key and depth as cmake arguments

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -3,7 +3,11 @@
 set(flag_for_ram_report ram)
 set(flag_for_rom_report rom)
 set(flag_for_footprint all -q)
-set(report_depth 99)
+
+set(report_depth 99 CACHE STRING "Depth of tree to display")
+set(sort_key "name" CACHE STRING "Sort key for results display (name or size)")
+set_property(CACHE sort_key PROPERTY STRINGS "name" "size")
+
 
 if(DEFINED ZEPHYR_WORKSPACE)
   set(workspace_arg "--workspace=${ZEPHYR_WORKSPACE}")
@@ -40,6 +44,7 @@ if (CONFIG_BUILD_WITH_TFM)
       -o ${CMAKE_BINARY_DIR}
       ${workspace_arg}
       -d ${report_depth}
+      -s ${sort_key}
       ${flag_for_${report}}
       DEPENDS tfm
       USES_TERMINAL

--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -25,6 +25,7 @@ foreach(report ram_report rom_report footprint)
     -o ${CMAKE_BINARY_DIR}
     ${workspace_arg}
     -d ${report_depth}
+    -s ${sort_key}
     ${flag_for_${report}}
     DEPENDS ${logical_target_for_zephyr_elf}
             $<TARGET_PROPERTY:zephyr_property_target,${report}_DEPENDENCIES>
@@ -64,6 +65,7 @@ if (CONFIG_TFM_BL2)
     -o ${CMAKE_BINARY_DIR}
     ${workspace_arg}
     -d ${report_depth}
+    -s ${sort_key}
     ${flag_for_${report}}
     DEPENDS tfm
     USES_TERMINAL

--- a/doc/develop/optimizations/tools.rst
+++ b/doc/develop/optimizations/tools.rst
@@ -157,6 +157,17 @@ which will generate something similar to the output below::
     ...
 
 
+The depth of the report and the sort key (alphabetical or by size) can be
+configured. Arguments can also be passed to the report as shown below:
+
+.. zephyr-app-commands::
+    :tool: all
+    :app: samples/hello_world
+    :board: reel_board
+    :goals: rom_report
+    :gen-args: -Dreport_depth=4 -Dsort_key=size
+
+
 Data Structures
 ****************
 

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -670,7 +670,10 @@ def node_sort(items):
     """
     Node sorting used with RenderTree.
     """
-    return sorted(items, key=lambda item: item.name)
+    if args.sortkey == 'name':
+        return sorted(items, key=lambda item: item.name)
+    elif args.sortkey == 'size':
+        return sorted(items, key=lambda item: item.size, reverse=True)
 
 
 def print_any_tree(root, total_size, depth):
@@ -722,6 +725,9 @@ def parse_args():
                         type=int, default=None,
                         help="How deep should we go into the tree",
                         metavar="DEPTH")
+    parser.add_argument("-s", '--sortkey', choices=['name', 'size'],
+                        dest='sortkey', type=str, default="name",
+                        help="Key for display sorting")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print extra debugging information")
     parser.add_argument("--json", help="store results in a JSON file.")


### PR DESCRIPTION
This change brings the ability to specify the sort key (by name or by size) and report depth as arguments to cmake/west. They can be given like:

`west build -t rom_report -- -Dreport_depth=4 -Dsort_key=size`

Addresses #57569