### PR TITLE
drivers: ethernet: stm32: Disable HW checksum by default

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1203,7 +1203,8 @@ static int eth_initialize(const struct device *dev)
 	memset(&tx_config, 0, sizeof(ETH_TxPacketConfig));
 	tx_config.Attributes = ETH_TX_PACKETS_FEATURES_CSUM |
 				ETH_TX_PACKETS_FEATURES_CRCPAD;
-	tx_config.ChecksumCtrl = ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC;
+	tx_config.ChecksumCtrl = IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ?
+			ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC : ETH_CHECKSUM_DISABLE;
 	tx_config.CRCPadCtrl = ETH_CRC_PAD_INSERT;
 #endif /* CONFIG_SOC_SERIES_STM32H7X || CONFIG_ETH_STM32_HAL_API_V2 */
 


### PR DESCRIPTION
This change disables hardware checksums by default for V2 of the HAL Ethernet driver and for STM32H7, to be equivalent to the default configuration on V1 of the driver.

Hardware checksums can be enabled with CONFIG_ETH_STM32_HW_CHECKSUM Kconfig, but note that at least on some boards, enabling this will lead to invalid checksums (e.g. all 0) in outgoing packets, and hence loss of network communication. On such boards, this change makes networking functional by default, even with the V2 driver enabled. This therefore fixes #57629.