### PR TITLE
tests: bsim: CIS: Increase timeouts

### DIFF
--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
+EXECUTE_TIMEOUT=200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_first.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso_acl_first"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
+EXECUTE_TIMEOUT=200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_group.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_group.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso_acl_group"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
+EXECUTE_TIMEOUT=200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_group_acl_first.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_acl_group_acl_first.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso_acl_group_acl_first"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
+EXECUTE_TIMEOUT=200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso_legacy_adv"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
+EXECUTE_TIMEOUT=200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv_acl_first.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_legacy_adv_acl_first.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # 1 CIS each to 9 Peripherals (9 CIS in a CIG)
 simulation_id="connected_iso_legacy_adv_acl_first"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
+EXECUTE_TIMEOUT=200
 
 cd ${BSIM_OUT_PATH}/bin
 

--- a/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_peripheral_cis.sh
+++ b/tests/bsim/bluetooth/ll/cis/tests_scripts/connected_iso_peripheral_cis.sh
@@ -7,7 +7,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Basic Connected ISO test: multiple peripheral CIS establishment
 simulation_id="connected_iso_peripheral_cis"
 verbosity_level=2
-EXECUTE_TIMEOUT=30
+EXECUTE_TIMEOUT=100
 
 cd ${BSIM_OUT_PATH}/bin
 


### PR DESCRIPTION
These tests take relatively long to run.
The runtime timeout (CI safety timeout) is too short.
Increase it so it does not fail at random in CI.

The only penalty of increasing this timeout, is that
if one of these tests actually hangs, we will not detect it
until the timeout expires, wasting a bit of CI time.

---

One failure due to this timeout in CI here:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/4896346415/jobs/8743045813?pr=57346#step:12:26015