### PR TITLE
Fix USER_CACHE_DIR path generation

### DIFF
--- a/cmake/modules/user_cache.cmake
+++ b/cmake/modules/user_cache.cmake
@@ -59,7 +59,7 @@ function(find_appropriate_cache_directory dir)
     if(DEFINED ENV{${env_var}})
       set(env_dir $ENV{${env_var}})
 
-      set(test_user_dir ${env_dir}/${env_suffix_${env_var}})
+      string(JOIN "/" test_user_dir ${env_dir} ${env_suffix_${env_var}})
 
       execute_process(COMMAND ${PYTHON_EXECUTABLE}
         ${ZEPHYR_BASE}/scripts/build/dir_is_writeable.py ${test_user_dir}


### PR DESCRIPTION
When the optional env_suffix_${env_var} was not set, USER_CACHE_DIR was slightly malformed and had double slashes, e.g. /home/user/.cache//zephyr.

To fix it [`string(JOIN ...)`](https://cmake.org/cmake/help/v3.20/command/string.html#join) is used, which only sets slashes when necessary.