### PR TITLE
tests/bsim: On timeout print info to stderr

### DIFF
--- a/tests/bsim/sh_common.source
+++ b/tests/bsim/sh_common.source
@@ -43,6 +43,6 @@ function Execute() {
   EXECUTE_TIMEOUT="${EXECUTE_TIMEOUT:-30}"
 
   check_program_exists $1
-  run_in_background timeout ${EXECUTE_TIMEOUT} $@
+  run_in_background timeout -v ${EXECUTE_TIMEOUT} $@
 }
 


### PR DESCRIPTION
To ease diagnosing why a test fails in CI when the CI safety timeout triggers, have the timeout command print to stderr a message in which it indicates it has just killed the underlaying process.