### PR TITLE
boards: arm: thingy: Add GPIO support for Thingy platforms

### DIFF
--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.yaml
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.yaml
@@ -9,5 +9,6 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - gpio
   - i2c
   - hts221

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp_ns.yaml
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 192
 flash: 192
 supported:
+  - gpio
   - i2c
   - pwm
   - watchdog

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.yaml
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.yaml
@@ -9,4 +9,5 @@ toolchain:
 ram: 64
 flash: 256
 supported:
+  - gpio
   - watchdog


### PR DESCRIPTION
Add information about support GPIO for Nordic-supported Thingy platforms.