### PR TITLE
maintainers: make gmarull the maintainer of the device driver model area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -472,8 +472,9 @@ Debug:
 Device Driver Model:
   status: maintained
   maintainers:
-    - tbursztyka
+    - gmarull
   collaborators:
+    - tbursztyka
     - dcpleung
     - nashif
   files:


### PR DESCRIPTION
Since I've been working on device.h for a while, I propose to become the maintainer of the device driver model in Zephyr.