### PR TITLE
drivers: ethernet: eth_stm32_hal: Configurable speed and duplex

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1234,8 +1234,10 @@ static int eth_initialize(const struct device *dev)
 	ETH_MACConfigTypeDef mac_config;
 
 	HAL_ETH_GetMACConfig(heth, &mac_config);
-	mac_config.DuplexMode = ETH_FULLDUPLEX_MODE;
-	mac_config.Speed = ETH_SPEED_100M;
+	mac_config.DuplexMode = IS_ENABLED(CONFIG_ETH_STM32_MODE_HALFDUPLEX) ?
+				      ETH_HALFDUPLEX_MODE : ETH_FULLDUPLEX_MODE;
+	mac_config.Speed = IS_ENABLED(CONFIG_ETH_STM32_SPEED_10M) ?
+				 ETH_SPEED_10M : ETH_SPEED_100M;
 	hal_ret = HAL_ETH_SetMACConfig(heth, &mac_config);
 	if (hal_ret != HAL_OK) {
 		LOG_ERR("HAL_ETH_SetMACConfig: failed: %d", hal_ret);


### PR DESCRIPTION
Make it possible to be able to change speed and duplex for the STM32H7xx and API_V2 from the configuration settings.

This exists for the non-STM32H7x already today, so this is basically copying the code for the other STM32's.

Please note that ST has a series incompability. For F1 and F2, the duplex settings are named ETH_MODE_FULLDUPLEX respective ETH_MODE_HALFDUPLEX. For F4, H7 and F7 the duplex settings are named ETH_FULLDUPLEX_MODE respective ETG_HALFDUPLEX_MODE.

This should really be queried from the PHY (as previous programmer have written in the code). But while waiting for a proper PHY solution, this is intended as a stop-gap solution.