### PR TITLE
boards: arm: disable external flash by default on nrf9160DK and nRF9161DK

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common_0_14_0.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common_0_14_0.dtsi
@@ -42,6 +42,7 @@
 		   <&gpio0 25 GPIO_ACTIVE_LOW>;
 	mx25r64: mx25r6435f@1 {
 		compatible = "jedec,spi-nor";
+		status = "disabled";
 		reg = <1>;
 		spi-max-frequency = <8000000>;
 		label = "MX25R64";

--- a/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_common.dtsi
+++ b/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_common.dtsi
@@ -192,6 +192,7 @@ arduino_spi: &spi3 {
 
 	gd25lb256: gd25lb256e3ir@1 {
 		compatible = "jedec,spi-nor";
+		status = "disabled";
 		reg = <1>;
 		spi-max-frequency = <60000000>;
 		jedec-id = [c8 67 19];

--- a/drivers/spi/Kconfig.nrfx
+++ b/drivers/spi/Kconfig.nrfx
@@ -5,6 +5,7 @@ menuconfig SPI_NRFX
 	bool "nRF SPI nrfx drivers"
 	default y
 	depends on SOC_FAMILY_NRF
+	depends on MULTITHREADING
 	help
 	  Enable support for nrfx SPI drivers for nRF MCU series.
 


### PR DESCRIPTION
* Disable external flash by default on the nRF9160DK (rev 0.14.0 and newer) and nRF9161DK. When enabled, it will require the
SPI driver to be enabled, which in turn require multithreading support.
This adds a lot of overhead to applications not needing the external
flash.

* The nrfx SPI driver depends on semaphores, which require multithreading
support to be enabled.