### PR TITLE
Bluetooth: Controller: Fix incorrect use of rx buffer in Tx ISR

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -760,7 +760,7 @@ static void isr_rx(void *param)
 		    ull_iso_pdu_rx_alloc_peek(2U)) {
 			struct node_rx_iso_meta *iso_meta;
 
-			/* Increment next expected serial number */
+			/* Increment next expected sequence number */
 			cis_lll->nesn++;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -715,33 +715,6 @@ static void isr_rx(void *param)
 			/* Increment sequence number */
 			cis_lll->sn++;
 
-#if defined(CONFIG_BT_CTLR_LE_ENC)
-			if (!cis_lll->npi) {
-				/* Get reference to PDU Tx */
-				struct node_tx_iso *node_tx;
-				struct pdu_cis *pdu_tx;
-				uint8_t payload_index;
-				memq_link_t *link;
-
-				payload_index = bn_tx - 1U;
-				link = memq_peek_n(cis_lll->memq_tx.head,
-						   cis_lll->memq_tx.tail,
-						   payload_index,
-						   (void **)&node_tx);
-				pdu_tx = (void *)node_tx->pdu;
-				if (pdu_tx->len) {
-					/* Get reference to ACL context */
-					const struct lll_conn *conn_lll =
-						ull_conn_lll_get(cis_lll->acl_handle);
-
-					/* if encrypted increment tx counter */
-					if (conn_lll->enc_tx) {
-						cis_lll->tx.ccm.counter++;
-					}
-				}
-			}
-#endif /* CONFIG_BT_CTLR_LE_ENC */
-
 			/* Increment burst number */
 			if (bn_tx <= cis_lll->tx.bn) {
 				bn_tx++;
@@ -781,9 +754,6 @@ static void isr_rx(void *param)
 
 					goto isr_rx_done;
 				}
-
-				/* Increment counter */
-				cis_lll->rx.ccm.counter++;
 
 				/* Record MIC valid */
 				mic_state = LLL_CONN_MIC_PASS;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -510,29 +510,6 @@ static void isr_rx(void *param)
 			/* Increment sequence number */
 			cis_lll->sn++;
 
-#if defined(CONFIG_BT_CTLR_LE_ENC)
-			if (!cis_lll->npi) {
-				/* Get reference to PDU Tx */
-				struct node_tx_iso *node_tx;
-				struct pdu_cis *pdu_tx;
-				uint8_t payload_index;
-				memq_link_t *link;
-
-				payload_index = bn_tx - 1U;
-				link = memq_peek_n(cis_lll->memq_tx.head,
-						   cis_lll->memq_tx.tail,
-						   payload_index,
-						   (void **)&node_tx);
-				pdu_tx = (void *)node_tx->pdu;
-				if (pdu_tx->len) {
-					/* if encrypted increment tx counter */
-					if (conn_lll->enc_tx) {
-						cis_lll->tx.ccm.counter++;
-					}
-				}
-			}
-#endif /* CONFIG_BT_CTLR_LE_ENC */
-
 			/* Increment burst number */
 			if (bn_tx <= cis_lll->tx.bn) {
 				bn_tx++;
@@ -571,9 +548,6 @@ static void isr_rx(void *param)
 
 					return;
 				}
-
-				/* Increment counter */
-				cis_lll->rx.ccm.counter++;
 
 				/* Record MIC valid */
 				mic_state = LLL_CONN_MIC_PASS;


### PR DESCRIPTION
Do not enqueue node rx buffers for generating invalid ISO
data from Tx ISR while supplying the node rx buffer to
Radio. This causes node rx pool corruption and also MIC
failures in the central ISO LLL.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>