### PR TITLE
getopt: extend ztests scope

### DIFF
--- a/tests/posix/getopt/testcase.yaml
+++ b/tests/posix/getopt/testcase.yaml
@@ -16,3 +16,9 @@ tests:
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_PICOLIBC=y
+  portability.posix.getopt.logger:
+    integration_platforms:
+      - qemu_x86
+    extra_configs:
+      - CONFIG_LOG=y
+    build_only: true


### PR DESCRIPTION
Adding a test to detect problems in the cooperation of the getopt and logger modules. It would detect issue: #57520