### PR TITLE
Bluetooth: BAP: Add return error for sink cb register

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1633,7 +1633,7 @@ struct bt_bap_broadcast_sink_cb {
  * *
  *  @param cb  Broadcast sink callback structure.
  */
-void bt_bap_broadcast_sink_register_cb(struct bt_bap_broadcast_sink_cb *cb);
+int bt_bap_broadcast_sink_register_cb(struct bt_bap_broadcast_sink_cb *cb);
 
 /** @brief Start scan for broadcast sources.
  *

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -990,9 +990,16 @@ static void broadcast_scan_timeout(void)
 	}
 }
 
-void bt_bap_broadcast_sink_register_cb(struct bt_bap_broadcast_sink_cb *cb)
+int bt_bap_broadcast_sink_register_cb(struct bt_bap_broadcast_sink_cb *cb)
 {
+	CHECKIF(cb == NULL) {
+		LOG_DBG("cb is NULL");
+		return -EINVAL;
+	}
+
 	sys_slist_append(&sink_cbs, &cb->_node);
+
+	return 0;
 }
 
 int bt_bap_broadcast_sink_scan_start(const struct bt_le_scan_param *param)


### PR DESCRIPTION
Since the provided callback can be NULL which would break things, add a check and a return value.