### PR TITLE
drivers: serial: uart_miv: Disable SERIAL_SUPPORT_INTERRUPT

### DIFF
--- a/drivers/serial/Kconfig.miv
+++ b/drivers/serial/Kconfig.miv
@@ -8,6 +8,5 @@ config UART_MIV
 	default y
 	depends on DT_HAS_MICROCHIP_COREUART_ENABLED
 	select SERIAL_HAS_DRIVER
-	select SERIAL_SUPPORT_INTERRUPT
 	help
 	  This option enables the Mi-V serial driver.


### PR DESCRIPTION
In the real MiV platform, UART does not have any interrupts routed to the interrupt controller.
Up to this stage, the driver implemented a separate thread to simulate interrupt operation to enable shell samples.
This is not required anymore, as Zephyr can run shell on interrupt-less UARTs.