### PR TITLE
riscv: Microchip Mi-V should use built-in atomic operations

### DIFF
--- a/soc/riscv/riscv-privilege/miv/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/miv/Kconfig.soc
@@ -9,7 +9,7 @@ choice
 
 config SOC_RISCV32_MIV
 	bool "Microchip Mi-V system implementation"
-	select ATOMIC_OPERATIONS_C
+	select ATOMIC_OPERATIONS_BUILTIN
 	select INCLUDE_RESET_VECTOR
 	select RISCV_ISA_RV32I
 	select RISCV_ISA_EXT_M


### PR DESCRIPTION
The Mi-V implements the A extension therefore it shouldn't use the C
version. The built-in version generates code with proper machine
opcodes.

