### PR TITLE
Kconfig: experimental: Fix some experimental options

### DIFF
--- a/modules/openthread/Kconfig.features
+++ b/modules/openthread/Kconfig.features
@@ -185,6 +185,7 @@ config OPENTHREAD_MESSAGE_USE_HEAP
 
 config OPENTHREAD_MLE_LONG_ROUTES
 	bool "MLE long routes extension (experimental)"
+	select EXPERIMENTAL
 	help
 	  Enable MLE long routes extension (experimental, breaks Thread conformance)
 

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -545,6 +545,7 @@ config LWM2M_LOCATION_OBJ_SUPPORT
 
 config LWM2M_GATEWAY_OBJ_SUPPORT
 	bool "LwM2M Gateway Object (25) [EXPERIMENTAL]"
+	select EXPERIMENTAL
 
 config LWM2M_EVENT_LOG_OBJ_SUPPORT
 	bool "LwM2M Event Log Object (20)"

--- a/subsys/usb/device/class/audio/Kconfig
+++ b/subsys/usb/device/class/audio/Kconfig
@@ -5,6 +5,7 @@
 
 config USB_DEVICE_AUDIO
 	bool "USB Audio Device Class Driver"
+	select EXPERIMENTAL
 	help
 	  USB Audio Device Class driver.
 	  Zephyr USB Audio Class is considered experimental


### PR DESCRIPTION
Select EXPERIMENTAL symbol for options that explicitly says that are experimental. 