### PR TITLE
requirements: Update pyOCD requirement to 0.35.0

### DIFF
--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -3,7 +3,7 @@
 # things used by twister or related in run time testing
 
 # used to flash & debug various boards
-pyocd>=0.29.0
+pyocd>=0.35.0
 
 # used by twister for board/hardware map
 tabulate


### PR DESCRIPTION
Updates the pyOCD requirement to 0.35.0 to support a new flasher option of flashing and preventing reset of the device.

Fixes #53651