### PR TITLE
Bluetooth: Host: Fix warning from the logging subsystem

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3449,7 +3449,7 @@ static struct bt_smp *smp_find(int flag)
 
 static void bt_smp_dhkey_ready(const uint8_t *dhkey)
 {
-	LOG_DBG("%p", dhkey);
+	LOG_DBG("%p", (void *)dhkey);
 	int err;
 
 	struct bt_smp *smp = smp_find(SMP_FLAG_DHKEY_GEN);


### PR DESCRIPTION
Cast `dhkey` to `void*` to avoid a warning from the logging subsystem:
```
<wrn> cbprintf_package: (unsigned) char * used for %p argument.
It's recommended to cast it to void * because it may cause misbehavior
in certain configurations
```