### PR TITLE
Bluetooth: Controller: Use strict cis_offset_min when CIG is active

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1233,13 +1233,15 @@ void ull_cp_cte_req_set_disable(struct ll_conn *conn)
 }
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_REQ */
 
-void ull_cp_cc_offset_calc_reply(struct ll_conn *conn, uint32_t cis_offset_min)
+void ull_cp_cc_offset_calc_reply(struct ll_conn *conn, uint32_t cis_offset_min,
+				 uint32_t cis_offset_max)
 {
 	struct proc_ctx *ctx;
 
 	ctx = llcp_lr_peek(conn);
 	if (ctx && ctx->proc == PROC_CIS_CREATE) {
 		ctx->data.cis_create.cis_offset_min = cis_offset_min;
+		ctx->data.cis_create.cis_offset_max = cis_offset_max;
 
 		llcp_lp_cc_offset_calc_reply(conn, ctx);
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -189,7 +189,8 @@ uint8_t ull_cp_cis_create(struct ll_conn *conn, struct ll_conn_iso_stream *cis);
 /**
  * @brief Resume CIS create after CIS offset calculation.
  */
-void ull_cp_cc_offset_calc_reply(struct ll_conn *conn, uint32_t cis_offset_min);
+void ull_cp_cc_offset_calc_reply(struct ll_conn *conn, uint32_t cis_offset_min,
+				 uint32_t cis_offset_max);
 
 /**
  * @brief Is ongoing create cis procedure expecting a reply?


### PR DESCRIPTION
When there is an active CIG for a new CIS create, then use strict cis_offset_min/cis_offset_max so that the new CIS is scheduled inside the active CIG event.