### PR TITLE
Smartbond: Add code to boot MCUboot images

### DIFF
--- a/boards/arm/da1469x_dk_pro/da1469x_dk_pro.dts
+++ b/boards/arm/da1469x_dk_pro/da1469x_dk_pro.dts
@@ -78,25 +78,26 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		/*
+		 * Flash area from 0x0000 to 0x2400 is reserved
+		 * for product header added by flasher.
+		 */
+
 		boot_partition: partition@2400 {
 			label = "mcuboot";
-			reg = <0x000002400 0x00005c00>;
+			reg = <0x000002400 0x00009c00>;
 		};
-		slot0_partition: partition@8000 {
+		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x00008000 0x00060000>;
+			reg = <0x0000c000 0x00076000>;
 		};
-		slot1_partition: partition@68000 {
+		slot1_partition: partition@80000 {
 			label = "image-1";
-			reg = <0x00068000 0x00060000>;
+			reg = <0x00082000 0x00076000>;
 		};
-		scratch_partition: partition@c8000 {
-			label = "image-scratch";
-			reg = <0x000c8000 0x00010000>;
-		};
-		storage_partition: partition@dc000 {
+		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x000dc000 0x00004000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/da1469x_dk_pro/da1469x_dk_pro.dts
+++ b/boards/arm/da1469x_dk_pro/da1469x_dk_pro.dts
@@ -71,7 +71,7 @@
 };
 
 &flash0 {
-	reg = <0 DT_SIZE_M(1)>;
+	reg = <0x16000000 DT_SIZE_M(1)>;
 
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/arm/da1469x_dk_pro/da1469x_dk_pro.dts
+++ b/boards/arm/da1469x_dk_pro/da1469x_dk_pro.dts
@@ -18,6 +18,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart;
 		zephyr,shell-uart = &uart;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {

--- a/dts/arm/renesas/smartbond/da1469x.dtsi
+++ b/dts/arm/renesas/smartbond/da1469x.dtsi
@@ -13,6 +13,7 @@
 / {
 	chosen {
 		zephyr,entropy = &trng;
+		zephyr,flash-controller = &flash_controller;
 	};
 
 	cpus: cpus {

--- a/dts/arm/renesas/smartbond/da1469x.dtsi
+++ b/dts/arm/renesas/smartbond/da1469x.dtsi
@@ -103,7 +103,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			flash0: flash@0 {
+			flash0: flash@16000000 {
 				compatible = "soc-nv-flash";
 				erase-block-size = <4096>;
 				write-block-size = <1>;

--- a/soc/arm/renesas_smartbond/da1469x/Kconfig.defconfig.series
+++ b/soc/arm/renesas_smartbond/da1469x/Kconfig.defconfig.series
@@ -17,8 +17,14 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SRAM_VECTOR_TABLE
 	default y
 
+config USE_DT_CODE_PARTITION
+	default y if MCUBOOT
+
 config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
+
+config FLASH_LOAD_OFFSET
+	default 0x2400 if !USE_DT_CODE_PARTITION
 
 config PLATFORM_SPECIFIC_INIT
 	default y

--- a/soc/arm/renesas_smartbond/da1469x/Kconfig.defconfig.series
+++ b/soc/arm/renesas_smartbond/da1469x/Kconfig.defconfig.series
@@ -20,4 +20,7 @@ config SRAM_VECTOR_TABLE
 config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
+config PLATFORM_SPECIFIC_INIT
+	default y
+
 endif # SOC_SERIES_DA1469X

--- a/soc/arm/renesas_smartbond/da1469x/Kconfig.defconfig.series
+++ b/soc/arm/renesas_smartbond/da1469x/Kconfig.defconfig.series
@@ -17,4 +17,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SRAM_VECTOR_TABLE
 	default y
 
+config FLASH_BASE_ADDRESS
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
+
 endif # SOC_SERIES_DA1469X

--- a/soc/arm/renesas_smartbond/da1469x/soc.c
+++ b/soc/arm/renesas_smartbond/da1469x/soc.c
@@ -7,12 +7,105 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/arch/arm/aarch32/nmi.h>
+#include <zephyr/linker/linker-defs.h>
+#include <string.h>
+
+#define REMAP_ADR0_QSPI           0x2
+
+#define FLASH_REGION_SIZE_32M     0
+#define FLASH_REGION_SIZE_16M     1
+#define FLASH_REGION_SIZE_8M      2
+#define FLASH_REGION_SIZE_4M      3
+#define FLASH_REGION_SIZE_2M      4
+#define FLASH_REGION_SIZE_1M      5
+#define FLASH_REGION_SIZE_05M     6
+#define FLASH_REGION_SIZE_025M    7
+
+#if defined(CONFIG_BOOTLOADER_MCUBOOT)
+#define MAGIC 0xaabbccdd
+static uint32_t z_renesas_cache_configured;
+#endif
 
 void sys_arch_reboot(int type)
 {
 	ARG_UNUSED(type);
 
 	NVIC_SystemReset();
+}
+
+#if defined(CONFIG_BOOTLOADER_MCUBOOT)
+static void z_renesas_configure_cache(void)
+{
+	uint32_t cache_start;
+	uint32_t region_size;
+	uint32_t reg_region_size;
+	uint32_t reg_cache_len;
+
+	if (z_renesas_cache_configured == MAGIC) {
+		return;
+	}
+
+	cache_start = (uint32_t)&_vector_start;
+	region_size = (uint32_t)&__rom_region_end - cache_start;
+
+	/* Disable cache before configuring it */
+	CACHE->CACHE_CTRL2_REG = 0;
+	CRG_TOP->SYS_CTRL_REG &= ~CRG_TOP_SYS_CTRL_REG_CACHERAM_MUX_Msk;
+
+	/* Disable MRM unit */
+	CACHE->CACHE_MRM_CTRL_REG = 0;
+	CACHE->CACHE_MRM_TINT_REG = 0;
+	CACHE->CACHE_MRM_MISSES_THRES_REG = 0;
+
+	if (region_size > MB(16)) {
+		reg_region_size = FLASH_REGION_SIZE_32M;
+	} else if (region_size > MB(8)) {
+		reg_region_size = FLASH_REGION_SIZE_16M;
+	} else if (region_size > MB(4)) {
+		reg_region_size = FLASH_REGION_SIZE_8M;
+	} else if (region_size > MB(2)) {
+		reg_region_size = FLASH_REGION_SIZE_4M;
+	} else if (region_size > MB(1)) {
+		reg_region_size = FLASH_REGION_SIZE_2M;
+	} else if (region_size > KB(512)) {
+		reg_region_size = FLASH_REGION_SIZE_1M;
+	} else if (region_size > KB(256)) {
+		reg_region_size = FLASH_REGION_SIZE_05M;
+	} else {
+		reg_region_size = FLASH_REGION_SIZE_025M;
+	}
+	CACHE->CACHE_FLASH_REG =
+		(cache_start >> 16) << CACHE_CACHE_FLASH_REG_FLASH_REGION_BASE_Pos |
+		((cache_start & 0xffff) >> 2) << CACHE_CACHE_FLASH_REG_FLASH_REGION_OFFSET_Pos |
+		reg_region_size << CACHE_CACHE_FLASH_REG_FLASH_REGION_SIZE_Pos;
+
+	reg_cache_len = CLAMP(reg_region_size / KB(64), 0, 0x1ff);
+	CACHE->CACHE_CTRL2_REG = (CACHE->CACHE_FLASH_REG & ~CACHE_CACHE_CTRL2_REG_CACHE_LEN_Msk) |
+				 reg_cache_len;
+
+	/* Copy IVT from flash to start of RAM.
+	 * It will be remapped at 0x0 so it can be used after SW Reset
+	 */
+	memcpy(&_image_ram_start, &_vector_start, 0x200);
+
+	/* Configure remapping */
+	CRG_TOP->SYS_CTRL_REG = (CRG_TOP->SYS_CTRL_REG & ~CRG_TOP_SYS_CTRL_REG_REMAP_ADR0_Msk) |
+				CRG_TOP_SYS_CTRL_REG_CACHERAM_MUX_Msk |
+				CRG_TOP_SYS_CTRL_REG_REMAP_INTVECT_Msk |
+				REMAP_ADR0_QSPI;
+
+	z_renesas_cache_configured = MAGIC;
+
+	/* Trigger SW Reset to apply cache configuration */
+	CRG_TOP->SYS_CTRL_REG |= CRG_TOP_SYS_CTRL_REG_SW_RESET_Msk;
+}
+#endif /* CONFIG_HAS_FLASH_LOAD_OFFSET */
+
+void z_arm_platform_init(void)
+{
+#if defined(CONFIG_BOOTLOADER_MCUBOOT)
+	z_renesas_configure_cache();
+#endif
 }
 
 static int renesas_da14699_init(void)


### PR DESCRIPTION
Smartbond: add code to boot MCUboot images

Changes include: updating the cache controller settings on boot in soc.c and updating the EZflashCLI runner to support putting the image in the correct slot

Co-authored-by: Andrzej Kaczmarek <andrzej.kaczmarek@codecoup.pl>

Signed-off-by: Niek Ilmer <niek.ilmer.aj@renesas.com>