### PR TITLE
bluetooth: hci: spi: warn about l2cap MTU values

### DIFF
--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -58,6 +58,17 @@ LOG_MODULE_REGISTER(bt_driver);
 
 #define DATA_DELAY_US DT_INST_PROP(0, controller_data_delay_us)
 
+/* Single byte header denoting the buffer type */
+#define H4_HDR_SIZE 1
+
+/* Maximum L2CAP MTU that can fit in a single packet */
+#define MAX_MTU (SPI_MAX_MSG_LEN - H4_HDR_SIZE - BT_L2CAP_HDR_SIZE - BT_HCI_ACL_HDR_SIZE)
+
+#if CONFIG_BT_L2CAP_TX_MTU > MAX_MTU
+#warning CONFIG_BT_L2CAP_TX_MTU is too large and can result in packets that cannot \
+	be transmitted across this HCI link
+#endif /* CONFIG_BT_L2CAP_TX_MTU > MAX_MTU */
+
 static uint8_t rxmsg[SPI_MAX_MSG_LEN];
 static uint8_t txmsg[SPI_MAX_MSG_LEN];
 
@@ -428,7 +439,7 @@ static int bt_spi_send(struct net_buf *buf)
 
 	/* Buffer needs an additional byte for type */
 	if (buf->len >= SPI_MAX_MSG_LEN) {
-		LOG_ERR("Message too long");
+		LOG_ERR("Message too long (%d)", buf->len);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
`CONFIG_BT_L2CAP_TX_MTU` drives the maximum supported MTU on a Bluetooth connection, but the SPI backend also imposes its own hidden limits.

Display a warning if a value is chosen that can result in failures to send. This is done here instead of as a range on `BT_L2CAP_TX_MTU` as ranges on that symbol are already defined in terms of software features, which would conflict with this check.

Regarding the choice of 246:
* 247 is the maximum size without splitting across multiple LL packets
* Using 247 resulted in packets of size `SPI_MAX_MSG_LEN` when attempting to perform an OTA update via mcumgr
* `SPI_MAX_MSG_LEN` is too large to fit across the link (1 byte is reserved for a type)
* mcumgr backend attempts to split data based on the connection MTU
* Dropping `BT_L2CAP_TX_MTU` to 246 resulting in the OTA update succeeding.

I don't know where the extra 8 bytes in the payload are coming from, and whether this restriction is sufficient to work in all circumstances. If anyone has a better metric that can be used in the check, I would love to use something of the form
`#if CONFIG_BT_L2CAP_TX_MTU > (SPI_MAX_MSG_LEN - sizeof(some struct))` instead. 