### PR TITLE
Bluetooth: BAP: Broadcast source validate subgroup count in create

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -523,8 +523,8 @@ static bool valid_create_param(const struct bt_bap_broadcast_source_create_param
 		return false;
 	}
 
-	CHECKIF(param->params_count == 0U) {
-		LOG_DBG("param->params_count is 0");
+	CHECKIF(!IN_RANGE(param->params_count, 1U, CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT)) {
+		LOG_DBG("param->params_count %zu is invalid", param->params_count);
 		return false;
 	}
 


### PR DESCRIPTION
Add proper validation check for the number of subgroups attempted to be added to the broadcast source.