### PR TITLE
Share MCUboot mode to app and use it in MCUmgr for basic DirectXIP support

### DIFF
--- a/Kconfig.mcuboot
+++ b/Kconfig.mcuboot
@@ -1,0 +1,130 @@
+# General configuration options
+
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Intel Corporation
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config MCUBOOT
+	bool
+	help
+	  Hidden option used to indicate that the current image is MCUBoot
+
+config BOOTLOADER_MCUBOOT
+	bool "MCUboot bootloader support"
+	select USE_DT_CODE_PARTITION
+	imply INIT_ARCH_HW_AT_BOOT if ARCH_SUPPORTS_ARCH_HW_INIT
+	depends on !MCUBOOT
+	help
+	  This option signifies that the target uses MCUboot as a bootloader,
+	  or in other words that the image is to be chain-loaded by MCUboot.
+	  This sets several required build system and Device Tree options in
+	  order for the image generated to be bootable using the MCUboot open
+	  source bootloader. Currently this includes:
+
+	    * Setting ROM_START_OFFSET to a default value that allows space
+	      for the MCUboot image header
+	    * Activating SW_VECTOR_RELAY_CLIENT on Cortex-M0
+	      (or Armv8-M baseline) targets with no built-in vector relocation
+	      mechanisms
+
+	  By default, this option instructs Zephyr to initialize the core
+	  architecture HW registers during boot, when this is supported by
+	  the application. This removes the need by MCUboot to reset
+	  the core registers' state itself.
+
+if BOOTLOADER_MCUBOOT
+
+config MCUBOOT_CMAKE_WEST_SIGN_PARAMS
+	string "Extra parameters to west sign"
+	default "--quiet"
+	help
+	  Parameters that are passed by cmake to west sign, just after
+	  the command, before all other parameters needed for image
+	  signing.
+	  By default this is set to "--quiet" to prevent extra, non-error,
+	  diagnostic messages from west sign. This does not affect signing
+	  tool for which extra parameters are passed with
+	  MCUBOOT_EXTRA_IMGTOOL_ARGS.
+
+config MCUBOOT_SIGNATURE_KEY_FILE
+	string "Path to the mcuboot signing key file"
+	default ""
+	depends on !MCUBOOT_GENERATE_UNSIGNED_IMAGE
+	help
+	  The file contains a key pair whose public half is verified
+	  by your target's MCUboot image. The file is in PEM format.
+
+	  If set to a non-empty value, the build system tries to
+	  sign the final binaries using a 'west sign -t imgtool' command.
+	  The signed binaries are placed in the build directory
+	  at zephyr/zephyr.signed.bin and zephyr/zephyr.signed.hex.
+
+	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
+	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
+	  and CONFIG_BUILD_OUTPUT_HEX.
+
+	  This option should contain a path to the same file as the
+	  BOOT_SIGNATURE_KEY_FILE option in your MCUboot .config. The path
+	  may be absolute or relative to the west workspace topdir. (The MCUboot
+	  config option is used for the MCUboot bootloader image; this option is
+	  for your application which is to be loaded by MCUboot. The MCUboot
+	  config option can be a relative path from the MCUboot repository
+	  root.)
+
+	  If left empty, you must sign the Zephyr binaries manually.
+
+config MCUBOOT_ENCRYPTION_KEY_FILE
+	string "Path to the mcuboot encryption key file"
+	default ""
+	depends on MCUBOOT_SIGNATURE_KEY_FILE != ""
+	help
+	  The file contains the public key that is used to encrypt the
+	  ephemeral key that encrypts the image. The corresponding
+	  private key is hard coded in the MCUboot source code and is
+	  used to decrypt the ephemeral key that is embedded in the
+	  image. The file is in PEM format.
+
+	  If set to a non-empty value, the build system tries to
+	  sign and encrypt the final binaries using a 'west sign -t imgtool'
+	  command. The binaries are placed in the build directory at
+	  zephyr/zephyr.signed.encrypted.bin and
+	  zephyr/zephyr.signed.encrypted.hex.
+
+	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
+	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
+	  and CONFIG_BUILD_OUTPUT_HEX.
+
+	  This option should either be an absolute path or a path relative to
+	  the west workspace topdir.
+	  Example: './bootloader/mcuboot/enc-rsa2048-pub.pem'
+
+	  If left empty, you must encrypt the Zephyr binaries manually.
+
+config MCUBOOT_EXTRA_IMGTOOL_ARGS
+	string "Extra arguments to pass to imgtool when signing"
+	default ""
+	help
+	  When signing (CONFIG_MCUBOOT_SIGNATURE_KEY_FILE is a non-empty
+	  string) you can use this option to pass extra options to
+	  imgtool.  For example, you could set this to "--version 1.2".
+
+config MCUBOOT_GENERATE_UNSIGNED_IMAGE
+	bool "Generate unsigned binary image bootable with MCUboot"
+	help
+	  Enabling this configuration allows automatic unsigned binary image
+	  generation when MCUboot signing key is not provided,
+	  i.e., MCUBOOT_SIGNATURE_KEY_FILE is left empty.
+
+config MCUBOOT_GENERATE_CONFIRMED_IMAGE
+	bool "Also generate a padded, confirmed image"
+	help
+	  The signed, padded, and confirmed binaries are placed in the build
+	  directory at zephyr/zephyr.signed.confirmed.bin and
+	  zephyr/zephyr.signed.confirmed.hex.
+
+	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
+	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
+	  and CONFIG_BUILD_OUTPUT_HEX.
+
+endif # BOOTLOADER_MCUBOOT

--- a/Kconfig.mcuboot
+++ b/Kconfig.mcuboot
@@ -127,4 +127,46 @@ config MCUBOOT_GENERATE_CONFIRMED_IMAGE
 	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
 	  and CONFIG_BUILD_OUTPUT_HEX.
 
+choice MCUBOOT_BOOTLOADER_MODE
+	prompt "Application assumed MCUboot mode of operation"
+	default MCUBOOT_BOOTLOADER_MODE_SWAP_WITHOUT_SCRATCH # MCUBOOT_BOOTLOADER_MODE
+	help
+	  Informs application build on assumed MCUboot mode of operation.
+	  This is important for validataing application against DT configuration,
+	  which is done by west sign.
+
+config MCUBOOT_BOOTLOADER_MODE_SINGLE_APP
+	bool "MCUboot has been configured for single slot execution"
+	help
+	  MCUboot will only boot slot0_partition placed application and does
+	  not care about other slots. In this mode application is not able
+	  to DFU its own update to secondary slot and all updates need to
+	  be performed using MCUboot serial recovery.
+
+config MCUBOOT_BOOTLOADER_MODE_SWAP_WITHOUT_SCRATCH
+	bool "MCUboot has been configured for swap without scratch operation"
+	help
+	  MCUboot expects slot0_partition and slot1_partition to be present
+	  in DT and application will boot from slot0_partition.
+
+config MCUBOOT_BOOTLOADER_MODE_SWAP_SCRATCH
+	bool "MCUboot has been configured for swap using scratch operation"
+	help
+	  MCUboot expects slot0_partition, slot1_partition and scratch_partition
+	  to be present in DT, and application will boot from slot0_partition.
+	  In this mode scratch_partition is used as temporary storage when
+	  MCUboot swaps application from the secondary slot to the primary
+	  slot.
+
+config MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
+	bool "MCUboot has been configured for DirectXIP operation"
+	help
+	  MCUboot expects slot0_partition and slot1_partition to exist in DT.
+	  In this mode MCUboot can boot from either partition and will
+	  select one with higher application image version, which usually
+	  means major.minor.patch triple, unless BOOT_VERSION_CMP_USE_BUILD_NUMBER
+	  is also selected that enables comparison of build number.
+
+endchoice # MCUBOOT_BOOTLOADER_MODE
+
 endif # BOOTLOADER_MCUBOOT

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2014-2015 Wind River Systems, Inc.
 # Copyright (c) 2016 Intel Corporation
+# Copyright (c) 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -793,129 +794,7 @@ config BOOTLOADER_SRAM_SIZE
 	  - Zephyr is a !XIP image, which implicitly assumes existence of a
 	  bootloader that loads the Zephyr !XIP image onto SRAM.
 
-config MCUBOOT
-	bool
-	help
-	  Hidden option used to indicate that the current image is MCUBoot
-
-config BOOTLOADER_MCUBOOT
-	bool "MCUboot bootloader support"
-	select USE_DT_CODE_PARTITION
-	imply INIT_ARCH_HW_AT_BOOT if ARCH_SUPPORTS_ARCH_HW_INIT
-	depends on !MCUBOOT
-	help
-	  This option signifies that the target uses MCUboot as a bootloader,
-	  or in other words that the image is to be chain-loaded by MCUboot.
-	  This sets several required build system and Device Tree options in
-	  order for the image generated to be bootable using the MCUboot open
-	  source bootloader. Currently this includes:
-
-	    * Setting ROM_START_OFFSET to a default value that allows space
-	      for the MCUboot image header
-	    * Activating SW_VECTOR_RELAY_CLIENT on Cortex-M0
-	      (or Armv8-M baseline) targets with no built-in vector relocation
-	      mechanisms
-
-	  By default, this option instructs Zephyr to initialize the core
-	  architecture HW registers during boot, when this is supported by
-	  the application. This removes the need by MCUboot to reset
-	  the core registers' state itself.
-
-if BOOTLOADER_MCUBOOT
-
-config MCUBOOT_CMAKE_WEST_SIGN_PARAMS
-	string "Extra parameters to west sign"
-	default "--quiet"
-	help
-	  Parameters that are passed by cmake to west sign, just after
-	  the command, before all other parameters needed for image
-	  signing.
-	  By default this is set to "--quiet" to prevent extra, non-error,
-	  diagnostic messages from west sign. This does not affect signing
-	  tool for which extra parameters are passed with
-	  MCUBOOT_EXTRA_IMGTOOL_ARGS.
-
-config MCUBOOT_SIGNATURE_KEY_FILE
-	string "Path to the mcuboot signing key file"
-	default ""
-	depends on !MCUBOOT_GENERATE_UNSIGNED_IMAGE
-	help
-	  The file contains a key pair whose public half is verified
-	  by your target's MCUboot image. The file is in PEM format.
-
-	  If set to a non-empty value, the build system tries to
-	  sign the final binaries using a 'west sign -t imgtool' command.
-	  The signed binaries are placed in the build directory
-	  at zephyr/zephyr.signed.bin and zephyr/zephyr.signed.hex.
-
-	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
-	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
-	  and CONFIG_BUILD_OUTPUT_HEX.
-
-	  This option should contain a path to the same file as the
-	  BOOT_SIGNATURE_KEY_FILE option in your MCUboot .config. The path
-	  may be absolute or relative to the west workspace topdir. (The MCUboot
-	  config option is used for the MCUboot bootloader image; this option is
-	  for your application which is to be loaded by MCUboot. The MCUboot
-	  config option can be a relative path from the MCUboot repository
-	  root.)
-
-	  If left empty, you must sign the Zephyr binaries manually.
-
-config MCUBOOT_ENCRYPTION_KEY_FILE
-	string "Path to the mcuboot encryption key file"
-	default ""
-	depends on MCUBOOT_SIGNATURE_KEY_FILE != ""
-	help
-	  The file contains the public key that is used to encrypt the
-	  ephemeral key that encrypts the image. The corresponding
-	  private key is hard coded in the MCUboot source code and is
-	  used to decrypt the ephemeral key that is embedded in the
-	  image. The file is in PEM format.
-
-	  If set to a non-empty value, the build system tries to
-	  sign and encrypt the final binaries using a 'west sign -t imgtool'
-	  command. The binaries are placed in the build directory at
-	  zephyr/zephyr.signed.encrypted.bin and
-	  zephyr/zephyr.signed.encrypted.hex.
-
-	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
-	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
-	  and CONFIG_BUILD_OUTPUT_HEX.
-
-	  This option should either be an absolute path or a path relative to
-	  the west workspace topdir.
-	  Example: './bootloader/mcuboot/enc-rsa2048-pub.pem'
-
-	  If left empty, you must encrypt the Zephyr binaries manually.
-
-config MCUBOOT_EXTRA_IMGTOOL_ARGS
-	string "Extra arguments to pass to imgtool when signing"
-	default ""
-	help
-	  When signing (CONFIG_MCUBOOT_SIGNATURE_KEY_FILE is a non-empty
-	  string) you can use this option to pass extra options to
-	  imgtool.  For example, you could set this to "--version 1.2".
-
-config MCUBOOT_GENERATE_UNSIGNED_IMAGE
-	bool "Generate unsigned binary image bootable with MCUboot"
-	help
-	  Enabling this configuration allows automatic unsigned binary image
-	  generation when MCUboot signing key is not provided,
-	  i.e., MCUBOOT_SIGNATURE_KEY_FILE is left empty.
-
-config MCUBOOT_GENERATE_CONFIRMED_IMAGE
-	bool "Also generate a padded, confirmed image"
-	help
-	  The signed, padded, and confirmed binaries are placed in the build
-	  directory at zephyr/zephyr.signed.confirmed.bin and
-	  zephyr/zephyr.signed.confirmed.hex.
-
-	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
-	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
-	  and CONFIG_BUILD_OUTPUT_HEX.
-
-endif # BOOTLOADER_MCUBOOT
+source "Kconfig.mcuboot"
 
 config BOOTLOADER_ESP_IDF
 	bool "ESP-IDF bootloader support"

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -142,6 +142,24 @@ int img_mgmt_my_version(struct image_version *ver);
  * @return Non-negative on success, negative value on error.
  */
 int img_mgmt_ver_str(const struct image_version *ver, char *dst);
+
+/**
+ * @brief Get active, running application slot number for an image
+ *
+ * @param image		image number to get active slot for.
+ *
+ * @return Non-negative slot number
+ */
+int img_mgmt_active_slot(int image);
+
+/**
+ * @brief Get active image number
+ *
+ * Gets 0 based number for running application.
+ *
+ * @return Non-negative image number.
+ */
+int img_mgmt_active_image(void);
 
 /**
  * @brief Check if the image slot is in use.

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -16,6 +16,7 @@ menuconfig MCUMGR_GRP_IMG
 	bool "Mcumgr handlers for image management"
 	depends on FLASH
 	depends on IMG_MANAGER
+	depends on !MCUBOOT_BOOTLOADER_MODE_SINGLE_APP
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
 	help

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/include/mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/include/mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -141,6 +141,7 @@ int img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver);
 int img_mgmt_find_by_ver(struct image_version *find, uint8_t *hash);
 int img_mgmt_state_read(struct smp_streamer *ctxt);
 int img_mgmt_state_write(struct smp_streamer *njb);
+int img_mgmt_flash_area_id(int slot);
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -669,7 +669,11 @@ img_mgmt_my_version(struct image_version *ver)
 static const struct mgmt_handler img_mgmt_handlers[] = {
 	[IMG_MGMT_ID_STATE] = {
 		.mh_read = img_mgmt_state_read,
+#ifdef CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
+		.mh_write = NULL
+#else
 		.mh_write = img_mgmt_state_write,
+#endif
 	},
 	[IMG_MGMT_ID_UPLOAD] = {
 		.mh_read = NULL,

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/storage/flash_map.h>
 
 #include <zcbor_common.h>
 #include <zcbor_decode.h>
@@ -23,7 +24,6 @@
 #include <zephyr/mgmt/mcumgr/grp/img_mgmt/image.h>
 
 #include <mgmt/mcumgr/util/zcbor_bulk.h>
-#include <mgmt/mcumgr/grp/img_mgmt/img_mgmt_config.h>
 #include <mgmt/mcumgr/grp/img_mgmt/img_mgmt_impl.h>
 #include <mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h>
 
@@ -33,6 +33,21 @@
 
 #ifdef CONFIG_MCUMGR_MGMT_NOTIFICATION_HOOKS
 #include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
+#endif
+
+#ifndef CONFIG_FLASH_LOAD_OFFSET
+#error MCUmgr requires application to be built with CONFIG_FLASH_LOAD_OFFSET set \
+	to be able to figure out application running slot.
+#endif
+
+#define FIXED_PARTITION_IS_RUNNING_APP_PARTITION(label)	\
+	(FIXED_PARTITION_OFFSET(label) == CONFIG_FLASH_LOAD_OFFSET)
+
+#if !(FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot0_partition) ||	\
+	FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot0_ns_partition) ||	\
+	FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot1_partition) ||	\
+	FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot2_partition))
+#error "Unsupported chosen zephyr,code-partition for boot application."
 #endif
 
 LOG_MODULE_REGISTER(mcumgr_img_grp, CONFIG_MCUMGR_GRP_IMG_LOG_LEVEL);
@@ -78,6 +93,31 @@ img_mgmt_find_tlvs(int slot, size_t *start_off, size_t *end_off,
 	return 0;
 }
 
+int img_mgmt_active_slot(int image)
+{
+#if CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER == 2
+	if (image == 1) {
+		return 2;
+	}
+#endif
+	/* Image 0 */
+	if (FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot1_partition)) {
+		return 1;
+	}
+	return 0;
+}
+
+int img_mgmt_active_image(void)
+{
+#if CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER == 2
+	if (!(FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot0_partition) ||
+	      FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot0_ns_partition) ||
+	      FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot1_partition))) {
+		return 1;
+	}
+#endif
+	return 0;
+}
 /*
  * Reads the version and build hash from the specified image slot.
  */
@@ -234,6 +274,24 @@ void img_mgmt_reset_upload(void)
 	g_img_mgmt_state.area_id = -1;
 }
 
+static int
+img_mgmt_get_other_slot(void)
+{
+	int slot = img_mgmt_active_slot(img_mgmt_active_image());
+
+	switch (slot) {
+	case 1:
+		return 0;
+#if CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER
+	case 2:
+		return 3;
+	case 3:
+		return 2;
+	}
+#endif
+	return 1;
+}
+
 /**
  * Command handler: image erase
  */
@@ -244,7 +302,7 @@ img_mgmt_erase(struct smp_streamer *ctxt)
 	int rc;
 	zcbor_state_t *zsd = ctxt->reader->zs;
 	bool ok;
-	uint32_t slot = 1;
+	uint32_t slot = img_mgmt_get_other_slot();
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val image_erase_decode[] = {
@@ -604,7 +662,8 @@ end:
 int
 img_mgmt_my_version(struct image_version *ver)
 {
-	return img_mgmt_read_info(IMG_MGMT_BOOT_CURR_SLOT, ver, NULL, NULL);
+	return img_mgmt_read_info(img_mgmt_active_slot(img_mgmt_active_image()),
+				  ver, NULL, NULL);
 }
 
 static const struct mgmt_handler img_mgmt_handlers[] = {

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -124,13 +124,18 @@ img_mgmt_state_any_pending(void)
 int
 img_mgmt_slot_in_use(int slot)
 {
-	uint8_t state_flags;
 	int active_slot = img_mgmt_active_slot(img_mgmt_active_image());
 
-	state_flags = img_mgmt_state_flags(slot);
-	return slot == active_slot				||
-		   state_flags & IMG_MGMT_STATE_F_CONFIRMED	||
-		   state_flags & IMG_MGMT_STATE_F_PENDING;
+#ifndef CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
+	uint8_t state_flags = img_mgmt_state_flags(slot);
+
+	if (state_flags & IMG_MGMT_STATE_F_CONFIRMED ||
+	    state_flags & IMG_MGMT_STATE_F_PENDING) {
+		return 1;
+	}
+#endif
+
+	return (active_slot == slot);
 }
 
 /**

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -152,7 +152,7 @@ static int img_mgmt_flash_check_empty(uint8_t fa_id)
  * image_2 and so on. The function treats slot numbers as absolute
  * slot number starting at 0.
  */
-static int
+int
 img_mgmt_flash_area_id(int slot)
 {
 	uint8_t fa_id;


### PR DESCRIPTION
~~Three~~ Four commits:
 0) Separated MCUboot related Kconfigs from Kconfig.zephyr to Kconfig.mcuboot.
 1) introducing Kconfig options that allow to inform application regarding MCUboot mode the application will be boot with;
 2) disabling MCUmgr image management when MCUboot has been configured for single application mode;
 3) disabling setting of image state, to confirm or test, when MCUboot has been configured for DirectXIP


** Update 2023-05-10 **
The PR kinda depends on https://github.com/zephyrproject-rtos/zephyr/pull/56725, because the https://github.com/zephyrproject-rtos/zephyr/pull/56725 actually makes DirectXIP work, even though it does not depend on Kconfigs added with this PR.
