### PR TITLE
i2c: Fix write byte count stats

### DIFF
--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -507,8 +507,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 	for (uint8_t i = 0U; i < num_msgs; i++) {
 		if (msgs[i].flags & I2C_MSG_READ) {
 			bytes_read += msgs[i].len;
-		}
-		if (msgs[i].flags & I2C_MSG_WRITE) {
+		} else {
 			bytes_written += msgs[i].len;
 		}
 	}


### PR DESCRIPTION
The I2C_MSG_WRITE flag wasn't being checked for correctly as its not actually a bit that is set.