### PR TITLE
net: openthread: allow to configure OPENTHREAD_CSL_TIMEOUT

### DIFF
--- a/modules/openthread/Kconfig.thread
+++ b/modules/openthread/Kconfig.thread
@@ -100,6 +100,12 @@ config OPENTHREAD_PLATFORM_CSL_UNCERT
 	help
 	  The fixed uncertainty of the Device for scheduling CSL Transmissions in units of 10 microseconds.
 
+config OPENTHREAD_CSL_TIMEOUT
+	int "CSL timeout in seconds"
+	default 100
+	help
+	  The default CSL timeout in seconds.
+
 config OPENTHREAD_MAC_SOFTWARE_TX_SECURITY_ENABLE
 	bool "Software transmission security logic"
 	default y if !OPENTHREAD_THREAD_VERSION_1_1

--- a/modules/openthread/platform/openthread-core-zephyr-config.h
+++ b/modules/openthread/platform/openthread-core-zephyr-config.h
@@ -295,6 +295,16 @@
 #endif /* CONFIG_OPENTHREAD_CSL_MIN_RECEIVE_ON */
 
 /**
+ * @def OPENTHREAD_CONFIG_CSL_TIMEOUT
+ *
+ * The default CSL timeout in seconds.
+ *
+ */
+#ifdef CONFIG_OPENTHREAD_CSL_TIMEOUT
+#define OPENTHREAD_CONFIG_CSL_TIMEOUT CONFIG_OPENTHREAD_CSL_TIMEOUT
+#endif /* CONFIG_OPENTHREAD_CSL_TIMEOUT */
+
+/**
  * @def OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_SECURITY_ENABLE
  *
  * Set to 1 to enable software transmission security logic.


### PR DESCRIPTION
Added the possibility to set the default OpenThread CSL timeout using Kconfig.