### PR TITLE
intel_adsp: linker: Rename text area variables

### DIFF
--- a/soc/xtensa/intel_adsp/ace/ace-link.ld
+++ b/soc/xtensa/intel_adsp/ace/ace-link.ld
@@ -234,7 +234,7 @@ SECTIONS {
   } >vector_double_text
 
   .text : {
-    _text_start = .;
+    __text_region_start = .;
     *(.iram1 .iram1.*)
     *(.entry.text)
     *(.init.literal)
@@ -245,7 +245,7 @@ SECTIONS {
     *(.fini.literal)
     KEEP(*(.fini))
     *(.gnu.version)
-    _text_end = .;
+    __text_region_end = .;
   } >ram
 
   .rodata : ALIGN(4096)

--- a/soc/xtensa/intel_adsp/cavs/include/xtensa-cavs-linker.ld
+++ b/soc/xtensa/intel_adsp/cavs/include/xtensa-cavs-linker.ld
@@ -260,7 +260,7 @@ SECTIONS {
 #endif
 
   .text : {
-    _text_start = .;
+    __text_region_start = .;
     *(.iram1 .iram1.*)
     *(.entry.text)
     *(.init.literal)
@@ -271,7 +271,7 @@ SECTIONS {
     *(.fini.literal)
     KEEP(*(.fini))
     *(.gnu.version)
-    _text_end = .;
+    __text_region_end = .;
   } >RAM
 
   .rodata : ALIGN(4096)

--- a/soc/xtensa/intel_adsp/common/include/debug_helpers.h
+++ b/soc/xtensa/intel_adsp/common/include/debug_helpers.h
@@ -7,9 +7,8 @@
 #define ZEPHYR_SOC_INTEL_ADSP_DEBUG_HELPERS_H_
 
 #include <adsp_memory.h>
+#include <zephyr/linker/linker-defs.h>
 
-extern char _text_start[];
-extern char _text_end[];
 extern char _imr_start[];
 extern char _imr_end[];
 extern char _end[];
@@ -19,7 +18,7 @@ extern char _cached_end[];
 
 static inline bool intel_adsp_ptr_executable(const void *p)
 {
-	return (p >= (void *)_text_start && p <= (void *)_text_end) ||
+	return (p >= (void *)__text_region_start && p <= (void *)__text_region_end) ||
 		(p >= (void *)_imr_start && p <= (void *)_imr_end);
 }
 


### PR DESCRIPTION
Use Zephyr's convention for text region start and end.