### PR TITLE
arch: x86: add irq runtime statistics

### DIFF
--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -185,4 +185,11 @@ config X86_MFENCE_INSTRUCTION_SUPPORTED
 	  Set n to disable the use of MFENCE instruction in arch_dcache_flush()
 	  for X86 CPUs have CLFLUSH instruction but no MFENCE
 
+config X86_RUNTIME_IRQ_STATS
+	bool
+	help
+	  Add irq runtime statistics to allow runtime profiling irq performance
+	  data with Host tools, enable this and implement platform dependent API
+	  runtime_irq_stats().
+
 endif # !X86_64

--- a/arch/x86/core/ia32/intstub.S
+++ b/arch/x86/core/ia32/intstub.S
@@ -180,6 +180,16 @@ alreadyOnIntStack:
 	popl	%eax
 #endif
 
+#if defined(CONFIG_X86_RUNTIME_IRQ_STATS)
+	/*
+	 *  The runtime_irq_stats() function should be implemented
+	 *  by platform with this config.
+	 */
+	pushl	%eax
+	call	runtime_irq_stats
+	popl	%eax
+#endif
+
 	xorl	%eax, %eax
 #if defined(CONFIG_X2APIC)
 	xorl	%edx, %edx


### PR DESCRIPTION
Unlike tracing module mainly for debug usage, this is to allow runtime profiling IRQ performance data, and
target to enable it in product release since platform can choose to make it work with low weight protocol.

Enable this option and implement runtime_irq_stats() in platform code, such as Intel ISH platform implement
with SHMI protocol to allow host profiling irq stats.