### PR TITLE
Fix linker scripts to define _end correctly

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86_tiny.ld
+++ b/boards/x86/qemu_x86/qemu_x86_tiny.ld
@@ -788,14 +788,9 @@ SECTIONS
 	__kernel_ram_end = KERNEL_BASE_ADDR + KERNEL_RAM_SIZE;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
-	_image_ram_end = .;
 	_image_ram_all = (KERNEL_BASE_ADDR + KERNEL_RAM_SIZE) - _image_ram_start;
 
-	z_mapped_end = .;
 	z_mapped_size = z_mapped_end - z_mapped_start;
-	_end = .; /* end of image */
-
-	GROUP_END(RAMABLE_REGION)
 
 #ifndef LINKER_ZEPHYR_FINAL
 	/* static interrupts */
@@ -822,6 +817,12 @@ SECTIONS
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-sections.ld>
+
+#define LAST_RAM_ALIGN MMU_PAGE_ALIGN
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -135,6 +135,8 @@ if(NOT CONFIG_USERSPACE)
   zephyr_linker_section_configure(SECTION .noinit INPUT ".kernel_noinit.*")
 endif()
 
+include(${COMMON_ZEPHYR_LINKER_DIR}/ram-end.cmake)
+
 zephyr_linker_symbol(OBJECT REGION_RAM SYMBOL __kernel_ram_start EXPR "(@__bss_start@)")
 zephyr_linker_symbol(OBJECT REGION_RAM SYMBOL __kernel_ram_end  EXPR "(${RAM_ADDR} + ${RAM_SIZE})")
 zephyr_linker_symbol(OBJECT REGION_RAM SYMBOL __kernel_ram_size EXPR "(@__kernel_ram_end@ - @__bss_start@)")

--- a/cmake/linker_script/common/ram-end.cmake
+++ b/cmake/linker_script/common/ram-end.cmake
@@ -1,0 +1,7 @@
+zephyr_linker_section(NAME .last_ram_section VMA RAM LMA RAM_REGION TYPE BSS)
+zephyr_linker_section_configure(
+  SECTION .last_ram_section
+  INPUT ""
+  SYMBOLS _end z_mapped_end
+  KEEP
+  )

--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -246,8 +246,6 @@ SECTIONS {
 
 	MPU_MIN_SIZE_ALIGN
 	/* Define linker symbols */
-	_image_ram_end = .;
-	_end = .; /* end of image */
 
 	__kernel_ram_end = .;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
@@ -278,12 +276,14 @@ SECTIONS {
 	} GROUP_DATA_LINK_IN(YCCM, RAMABLE_REGION)
 #endif
 
-	GROUP_END(RAMABLE_REGION)
-
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-sections.ld>
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -332,15 +332,8 @@ SECTIONS
 
     /* Define linker symbols */
 
-    . = ALIGN(_region_min_align);
-    _image_ram_end = .;
-    _end = .; /* end of image */
-    z_mapped_end = .;
-
     __kernel_ram_end = RAM_ADDR + RAM_SIZE;
     __kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
-
-    GROUP_END(RAMABLE_REGION)
 
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_ocm), okay)
 GROUP_START(OCM)
@@ -372,6 +365,12 @@ GROUP_END(OCM)
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-sections.ld>
+
+#define LAST_RAM_ALIGN . = ALIGN(_region_min_align);
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -361,13 +361,8 @@ SECTIONS
 
     /* Define linker symbols */
 
-    _image_ram_end = .;
-    _end = .; /* end of image */
-
     __kernel_ram_end = RAM_ADDR + RAM_SIZE;
     __kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
-
-    GROUP_END(RAMABLE_REGION)
 
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_itcm), okay)
 GROUP_START(ITCM)
@@ -425,6 +420,10 @@ GROUP_END(DTCM)
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-sections.ld>
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -295,20 +295,20 @@ SECTIONS
 
     /* Define linker symbols */
 
-    MMU_ALIGN;
-    _image_ram_end = .;
-    _end = .; /* end of image */
-    z_mapped_end = .;
-
     __kernel_ram_end = RAM_ADDR + RAM_SIZE;
     __kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
-    GROUP_END(RAMABLE_REGION)
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-sections.ld>
+
+#define LAST_RAM_ALIGN MMU_ALIGN;
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/include/zephyr/arch/mips/linker.ld
+++ b/include/zephyr/arch/mips/linker.ld
@@ -181,13 +181,14 @@ SECTIONS
 
 #include <zephyr/linker/cplusplus-ram.ld>
 
-     _image_ram_end = .;
-     _end = .; /* end of image */
-
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-sections.ld>
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/include/zephyr/arch/nios2/linker.ld
+++ b/include/zephyr/arch/nios2/linker.ld
@@ -259,16 +259,14 @@ SECTIONS
 
 #include <zephyr/linker/common-noinit.ld>
 
-    /* Define linker symbols */
-    _image_ram_end = .;
-    _end = .; /* end of image */
-
-    GROUP_END(RAMABLE_REGION)
-
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-sections.ld>
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -305,11 +305,6 @@ SECTIONS
 
     __data_region_end = .;
 
-    MPU_MIN_SIZE_ALIGN
-
-     _image_ram_end = .;
-     _end = .; /* end of image */
-
 	__kernel_ram_end = .;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
@@ -370,7 +365,11 @@ GROUP_END(DTCM)
  */
 #include <snippets-sections.ld>
 
-     GROUP_END(RAMABLE_REGION)
+#define LAST_RAM_ALIGN MPU_MIN_SIZE_ALIGN
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/include/zephyr/arch/sparc/linker.ld
+++ b/include/zephyr/arch/sparc/linker.ld
@@ -154,13 +154,14 @@ SECTIONS
 
 #include <zephyr/linker/cplusplus-ram.ld>
 
-     _image_ram_end = .;
-     _end = .; /* end of image */
-
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-sections.ld>
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/include/zephyr/arch/x86/ia32/linker.ld
+++ b/include/zephyr/arch/x86/ia32/linker.ld
@@ -503,14 +503,10 @@ SECTIONS
 	__kernel_ram_end = KERNEL_BASE_ADDR + KERNEL_RAM_SIZE;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
-	_image_ram_end = .;
 	_image_ram_all = (KERNEL_BASE_ADDR + KERNEL_RAM_SIZE) - _image_ram_start;
 
 	z_mapped_end = .;
 	z_mapped_size = z_mapped_end - z_mapped_start;
-	_end = .; /* end of image */
-
-	GROUP_END(RAMABLE_REGION)
 
 #ifndef LINKER_ZEPHYR_FINAL
 	/* static interrupts */
@@ -537,6 +533,10 @@ SECTIONS
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-sections.ld>
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/include/zephyr/arch/x86/intel64/linker.ld
+++ b/include/zephyr/arch/x86/intel64/linker.ld
@@ -192,10 +192,12 @@ SECTIONS
 
 /* Must be last in RAM */
 #include <zephyr/linker/kobject-data.ld>
-	MMU_PAGE_ALIGN
-	_image_ram_end = .;
-	z_mapped_end = .;
-	_end = .;
+
+#define LAST_RAM_ALIGN MMU_PAGE_ALIGN
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 	/* All unused memory also owned by the kernel for heaps */
 	__kernel_ram_end = KERNEL_BASE_ADDR + KERNEL_RAM_SIZE;

--- a/include/zephyr/linker/ram-end.ld
+++ b/include/zephyr/linker/ram-end.ld
@@ -1,0 +1,14 @@
+/*
+ * Added after the very last allocation that might land in RAM to define the various
+ * end-of-used-memory symbols
+ */
+
+    SECTION_PROLOGUE(.last_ram_section,,)
+    {
+#ifdef LAST_RAM_ALIGN
+	LAST_RAM_ALIGN
+#endif
+	_image_ram_end = .;
+	_end = .; /* end of image */
+	z_mapped_end = .;
+    } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)

--- a/soc/arm64/nxp_imx/mimx9/linker.ld
+++ b/soc/arm64/nxp_imx/mimx9/linker.ld
@@ -312,20 +312,19 @@ SECTIONS
 
     /* Define linker symbols */
 
-    MMU_ALIGN;
-    _image_ram_end = .;
-    _end = .; /* end of image */
-    z_mapped_end = .;
-
-    __kernel_ram_end = RAM_ADDR + RAM_SIZE;
-    __kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
-
-    GROUP_END(RAMABLE_REGION)
-
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-sections.ld>
+
+#define LAST_RAM_ALIGN MMU_ALIGN;
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
+
+    __kernel_ram_end = RAM_ADDR + RAM_SIZE;
+    __kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -233,15 +233,14 @@ SECTIONS
  */
 #include <snippets-ram-sections.ld>
 
-     _image_ram_end = .;
-     _end = .; /* end of image */
-
-     GROUP_END(RAM)
-
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-sections.ld>
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #ifdef CONFIG_GEN_ISR_TABLES
 /* Bogus section, post-processed during the build to initialize interrupts. */

--- a/soc/riscv/riscv-ite/it8xxx2/linker.ld
+++ b/soc/riscv/riscv-ite/it8xxx2/linker.ld
@@ -356,11 +356,6 @@ SECTIONS
 
     __data_region_end = .;
 
-    MPU_MIN_SIZE_ALIGN
-
-     _image_ram_end = .;
-     _end = .; /* end of image */
-
 	__kernel_ram_end = .;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
@@ -369,7 +364,11 @@ SECTIONS
  */
 #include <snippets-sections.ld>
 
-     GROUP_END(RAMABLE_REGION)
+#define LAST_RAM_ALIGN MPU_MIN_SIZE_ALIGN
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/soc/riscv/riscv-privileged/andes_v5/ae350/linker.ld
+++ b/soc/riscv/riscv-privileged/andes_v5/ae350/linker.ld
@@ -274,11 +274,6 @@ SECTIONS
 
     __data_region_end = .;
 
-    MPU_MIN_SIZE_ALIGN
-
-     _image_ram_end = .;
-     _end = .; /* end of image */
-
 	__kernel_ram_end = .;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
@@ -339,7 +334,11 @@ GROUP_END(DTCM)
  */
 #include <snippets-sections.ld>
 
-     GROUP_END(RAMABLE_REGION)
+#define LAST_RAM_ALIGN MPU_MIN_SIZE_ALIGN
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/soc/xtensa/intel_adsp/ace/ace-link.ld
+++ b/soc/xtensa/intel_adsp/ace/ace-link.ld
@@ -403,6 +403,8 @@ SECTIONS {
     _unused_ram_start_marker = .;
     *(.unused_ram_start_marker)
     *(.unused_ram_start_marker.*)
+    _end = .;
+    z_mapped_end = .;
   } >ram
 
   . = L2_SRAM_BASE + L2_SRAM_SIZE;


### PR DESCRIPTION
_end must point past the last address of statically allocated RAM in the application. Adjust the linker scripts to use a new fragment which does this. Adjust the cmake linker script generator to do the same.