### PR TITLE
Make output buffer for STM32 DAC configurable

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -156,6 +156,12 @@ Changes in this release
   registration function now returns a value which is 0 for success or a
   negative error code if an error occurred.
 
+* Added a new flag :c:struct:`dac_channel_cfg` ``buffered`` for DAC channels in
+  :c:struct:`dac_channel_cfg` to allow the configuration of the output buffer.
+  The actual interpretation of this depends on the hardware and is so far only
+  implemented for the STM32 DAC driver. Implicitly for this driver this changes
+  the default from being buffered to unbuffered.
+
 Removed APIs in this release
 ============================
 

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -84,6 +84,7 @@ static int dac_stm32_channel_setup(const struct device *dev,
 {
 	struct dac_stm32_data *data = dev->data;
 	const struct dac_stm32_cfg *cfg = dev->config;
+	uint32_t output_buffer;
 
 	if ((channel_cfg->channel_id - STM32_FIRST_CHANNEL >=
 			data->channel_count) ||
@@ -100,10 +101,15 @@ static int dac_stm32_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	/* enable output buffer by default */
+	if (channel_cfg->buffered) {
+		output_buffer = LL_DAC_OUTPUT_BUFFER_ENABLE;
+	} else {
+		output_buffer = LL_DAC_OUTPUT_BUFFER_DISABLE;
+	}
+
 	LL_DAC_SetOutputBuffer(cfg->base,
 		table_channels[channel_cfg->channel_id - STM32_FIRST_CHANNEL],
-		LL_DAC_OUTPUT_BUFFER_ENABLE);
+		output_buffer);
 
 	LL_DAC_Enable(cfg->base,
 		table_channels[channel_cfg->channel_id - STM32_FIRST_CHANNEL]);

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -32,10 +32,14 @@ extern "C" {
  * @param channel_id Channel identifier of the DAC that should be configured.
  * @param resolution Desired resolution of the DAC (depends on device
  *                   capabilities).
+ * @param buffered Enable output buffer for this channel. This is relevant for instance
+ *                 if the output is directly connected to the load, without an amplifier
+ *                 in between. The actual details on this are hardware dependent.
  */
 struct dac_channel_cfg {
 	uint8_t channel_id;
 	uint8_t resolution;
+	bool buffered;
 };
 
 /**


### PR DESCRIPTION
If an operational amplifier is used on the DAC output it is preferrable to disable the DAC output buffer.