### PR TITLE
MAINTAINERS: Add more coding guidelines-related files

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -447,6 +447,8 @@ Coding Guidelines:
     - scripts/gitlint/
     - scripts/pylint/
     - scripts/spelling.txt
+  labels:
+    - "area: Coding Guidelines"
 
 Common Architecture Interface:
   status: odd fixes

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -430,8 +430,23 @@ Coding Guidelines:
     - carlescufi
     - jfischer-no
   files:
+    - .checkpatch.conf
     - .clang-format
+    - .editorconfig
+    - .gitlint
+    - .yamllint
     - doc/contribute/guidelines.rst
+    - doc/contribute/coding_guidelines/
+    - scripts/checkpatch.pl
+    - scripts/checkpatch/
+    - scripts/ci/check_compliance.py
+    - scripts/ci/guideline_check.py
+    - scripts/ci/pylintrc
+    - scripts/coccicheck
+    - scripts/coccinelle/
+    - scripts/gitlint/
+    - scripts/pylint/
+    - scripts/spelling.txt
 
 Common Architecture Interface:
   status: odd fixes


### PR DESCRIPTION
This commit adds more coding guidelines and code style-related files to
the "Coding Guidelines" area; most importantly, it adds the coding
guidelines document itself (`doc/contribute/coding_guidelines/`) to the
area.