### PR TITLE
nrf52_bsim: Add command line option to control re-sync offset

### DIFF
--- a/boards/posix/nrf52_bsim/argparse.c
+++ b/boards/posix/nrf52_bsim/argparse.c
@@ -17,6 +17,7 @@
 #include "bs_dynargs.h"
 #include "bs_cmd_line_typical.h"
 #include "NRF_HWLowL.h"
+#include "time_machine.h"
 
 static bs_args_struct_t *args_struct;
 char executable_name[] = "bs_nrf52_bsim_..";
@@ -71,6 +72,11 @@ static void cmd_no_sync_preinit_found(char *argv, int offset)
 static void cmd_no_sync_preboot_found(char *argv, int offset)
 {
 	arg.sync_preboot = false;
+}
+
+static void cmd_max_resync_offset_found(char *argv, int offset)
+{
+	tm_set_phy_max_resync_offset(arg.max_resync_offset);
 }
 
 static void save_test_arg(struct NRF_bsim_args_t *args, char *argv)
@@ -158,6 +164,13 @@ void nrfbsim_register_args(void)
 		"no_delay_init", "", 'b',
 		NULL, cmd_no_delay_init_found,
 		"Clear delay_init. Note that by default delay_init is not set"},
+		{ false, false, false,
+		"mro", "max_resync_offset", 'd',
+		(void *)&arg.max_resync_offset, cmd_max_resync_offset_found,
+		"Set the max Phy synchronization offset, that is, how far the device time can be "
+		"from the Phy time before it resynchronizes with the Phy again "
+		"(by default 1e6, 1s). Note that this value may be changed programmatically by "
+		"tests"},
 		BS_DUMP_FILES_ARGS,
 		{false, false, false,
 		"testid", "testid", 's',

--- a/boards/posix/nrf52_bsim/argparse.h
+++ b/boards/posix/nrf52_bsim/argparse.h
@@ -24,6 +24,7 @@ struct NRF_bsim_args_t {
 	bool delay_init;
 	bool sync_preinit;
 	bool sync_preboot;
+	double max_resync_offset;
 	nrf_hw_sub_args_t nrf_hw;
 };
 


### PR DESCRIPTION
Some users use this simulated board interactively
(even though it is not recomended).
In that case, they may want to perceive a relatively smooth time flow.
By default the maximum resynchronization offset is set at 1 second.
When running with a simulation speed close to real time, this results in the simulated board jerking and pausing in time 1 second at a time when there is no radio activity. With this new option, users can set a resynchronization offset of, for ex., 10 ms, which would give the illusion of time progressing smoothly.