### PR TITLE
Remove tickless idle from Power Management in introduction

### DIFF
--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -60,8 +60,9 @@ Zephyr offers a large and ever growing number of features including:
    * *Inter-thread Data Passing Services* for basic message queues, enhanced
      message queues, and byte streams.
 
-   * *Power Management Services* such as tickless idle and an advanced idling
-     infrastructure.
+   * *Power Management Services* such as overarching, application or
+     policy-defined, System Power Management and fine-grained, driver-defined,
+     Device Power Management.
 
 **Multiple Scheduling Algorithms**
    Zephyr provides a comprehensive set of thread scheduling choices:


### PR DESCRIPTION
Tickless idle has been replaced by the tickless kernel and also power management has become much more advanced.

See also: https://github.com/zephyrproject-rtos/zephyr/pull/33302