### PR TITLE
linker: restore CREATE_OBJ_LEVEL wildcard pattern

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -4247,13 +4247,13 @@ function(zephyr_linker_section_obj_level)
 
   zephyr_linker_section_configure(
     SECTION ${OBJ_SECTION}
-    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}?_"
+    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}?_*"
     SYMBOLS __${OBJ_SECTION}_${OBJ_LEVEL}_start
     KEEP SORT NAME
   )
   zephyr_linker_section_configure(
     SECTION ${OBJ_SECTION}
-    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}??_"
+    INPUT ".z_${OBJ_SECTION}_${OBJ_LEVEL}??_*"
     KEEP SORT NAME
   )
 endfunction()

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -145,8 +145,8 @@
  */
 #define CREATE_OBJ_LEVEL(object, level)				\
 		__##object##_##level##_start = .;		\
-		KEEP(*(SORT(.z_##object##_##level?_)));		\
-		KEEP(*(SORT(.z_##object##_##level??_)));
+		KEEP(*(SORT(.z_##object##_##level?_*)));	\
+		KEEP(*(SORT(.z_##object##_##level??_*)));
 
 /*
  * link in shell initialization objects for all modules that use shell and


### PR DESCRIPTION
The 2c98a001a42743168e0280afa17ccf772816f0c3 (#57597) cause regression with ARC MWDT toolchain.

Restore CREATE_OBJ_LEVEL wildcard pattern to have syntax suitable for both GNU and MWDT toolchains. We return asterisk symbol which was dropped in 2c98a001a42743168e0280afa17ccf772816f0c3 (but keep rest of the changes to wildcard pattern).