### PR TITLE
modules: kconfig: Fix dependencies 

### DIFF
--- a/modules/Kconfig
+++ b/modules/Kconfig
@@ -12,8 +12,6 @@ comment "Available modules."
 
 osource "$(KCONFIG_BINARY_DIR)/Kconfig.modules"
 
-comment "Optional modules. Make sure they're installed, via the project manifest."
-
 source "modules/Kconfig.altera"
 source "modules/Kconfig.atmel"
 source "modules/Kconfig.chre"

--- a/modules/Kconfig.libmetal
+++ b/modules/Kconfig.libmetal
@@ -1,8 +1,12 @@
 # Copyright (c) 2018 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
+config ZEPHYR_LIBMETAL_MODULE
+	bool
+
 menuconfig LIBMETAL
 	bool "libmetal Support"
+	depends on ZEPHYR_LIBMETAL_MODULE
 	help
 	  This option enables the libmetal HAL abstraction layer
 

--- a/modules/Kconfig.open-amp
+++ b/modules/Kconfig.open-amp
@@ -1,8 +1,12 @@
 # Copyright (c) 2018 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
+config ZEPHYR_OPEN_AMP_MODULE
+	bool
+
 config OPENAMP
 	bool "OpenAMP Support"
+	depends on ZEPHYR_OPEN_AMP_MODULE
 	select LIBMETAL
 	help
 	  This option enables the OpenAMP IPC library

--- a/modules/Kconfig.sof
+++ b/modules/Kconfig.sof
@@ -1,7 +1,11 @@
 # Copyright (c) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+config ZEPHYR_SOF_MODULE
+	bool
+
 config SOF
 	bool "Sound Open Firmware (SOF)"
+	depends on ZEPHYR_SOF_MODULE
 	help
 	  Build Sound Open Firmware (SOF) support.

--- a/modules/Kconfig.tinycrypt
+++ b/modules/Kconfig.tinycrypt
@@ -3,8 +3,12 @@
 # Copyright (c) 2015 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+config ZEPHYR_TINYCRYPT_MODULE
+	bool
+
 config TINYCRYPT
 	bool "TinyCrypt Support"
+	depends on ZEPHYR_TINYCRYPT_MODULE
 	help
 	  This option enables the TinyCrypt cryptography library.
 

--- a/modules/zcbor/Kconfig
+++ b/modules/zcbor/Kconfig
@@ -6,6 +6,7 @@ config ZEPHYR_ZCBOR_MODULE
 
 config ZCBOR
 	bool "zcbor CBOR library"
+	depends on ZEPHYR_ZCBOR_MODULE
 	help
 	  zcbor CBOR encoder/decoder library
 

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -350,7 +350,10 @@ def process_kconfig(module, meta):
         return kconfig_snippet(meta, module_path, Path(kconfig_file),
                                blobs=taint_blobs)
     else:
-        return ""
+        name_sanitized = meta['name-sanitized']
+        return (f'config ZEPHYR_{name_sanitized.upper()}_MODULE\n'
+                f'   bool\n'
+                f'   default y\n')
 
 
 def process_sysbuildkconfig(module, meta):


### PR DESCRIPTION
- Generate ZEPHYR_{MODULE_NAME}_MODULE for all available modules
  - Right now only "kconfig-ext" modules have this symbol defined / set
 
- Add the module dependency for the module options to avoid menu options for modules not available
  - Modules that are explicitly sourced have their menu options visible even when they are not available


** To consider

It is not clear what is exactly "optional" modules
```
comment "Optional modules. Make sure they're installed, via the project manifest."

source "modules/Kconfig.altera"
source "modules/Kconfig.atmel"
...
source "modules/Kconfig.xtensa"
```

why these module are listed as "optional" and others like "hal_nxp" and "hal_nordic" are not ? It seems that this a legacy thing. Also these "optional" modules end up with duplicated menu entry. Probably the best thing would be changing all modules to be `kconfig-ext` and use `osource` instead of explicitly source their Kconfig but that requires changing many submodules.
