### PR TITLE
Bluetooth: Controller: Fix Peripheral CIS supervision timeout

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -1231,7 +1231,6 @@ static void isr_done(void *param)
 
 	e->type = EVENT_DONE_EXTRA_TYPE_CIS;
 	e->trx_performed_bitmask = trx_performed_bitmask;
-	e->crc_valid = 1U;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	e->mic_state = mic_state;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -292,10 +292,18 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_tmr_aa_save(0U);
 	radio_tmr_aa_capture();
 
+	/* Header Complete Timeout, use additional EVENT_TICKER_RES_MARGIN_US to
+	 * compensate for possible shift in ACL peripheral's anchor point at
+	 * the instant the CIS is to be established.
+	 *
+	 * FIXME: use a one time value in a window member variable to avoid
+	 *        using this additional EVENT_TICKER_RES_MARGIN_US window in
+	 *        subsequent events once CIS is established.
+	 */
 	hcto = start_us +
 	       ((EVENT_JITTER_US + EVENT_TICKER_RES_MARGIN_US +
 		 EVENT_US_FRAC_TO_US(cig_lll->window_widening_event_us_frac)) <<
-		1U);
+		1U) + EVENT_TICKER_RES_MARGIN_US;
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	hcto += radio_rx_ready_delay_get(cis_lll->rx.phy, PHY_FLAGS_S8);


### PR DESCRIPTION
Fix premature Peripheral CIS supervision timeout due to corrupted trx_performed_bitmask value.

There was a bug in peripheral LLL that caused to have an undefined drift causing the supervision timeout.

Also I discovered that the Central was lacking precise timing with respect to cig_offset_us from the ACL anchor point.

What is still unresolved is, the peripheral receive window sometimes is not able to sync with central iso anchor point. I suspect that the peripheral ACL event at instant was at the edge of its receive window and undergoes drift compensation. Whereas the first peripheral CIS event is schedule at the offset calculated from the peripheral ACL event at instant that has not been drift compensated. Hence, I have added EVENT_TICKER_RES_MARGIN_US as the additional window widening to catch the anchor point.