### PR TITLE
drivers: uart: esp32: fix baudrate return value

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -160,7 +160,7 @@ static int uart_esp32_config_get(const struct device *dev, struct uart_config *c
 	uart_word_length_t data_bit;
 	uart_hw_flowcontrol_t hw_flow;
 
-	cfg->baudrate = data->uart_config.baudrate;
+	uart_hal_get_baudrate(&data->hal, &cfg->baudrate);
 
 	uart_hal_get_parity(&data->hal, &parity);
 	switch (parity) {


### PR DESCRIPTION
Baudrate value was not updated properly when requested.

Fixes #57746