### PR TITLE
pinctrl: esp32: fix byte garbage before banner

### DIFF
--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm-pinctrl.dtsi
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm-pinctrl.dtsi
@@ -13,6 +13,7 @@
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <UART0_TX_GPIO21>;
+			output-high;
 		};
 		group2 {
 			pinmux = <UART0_RX_GPIO20>;

--- a/boards/riscv/icev_wireless/icev_wireless-pinctrl.dtsi
+++ b/boards/riscv/icev_wireless/icev_wireless-pinctrl.dtsi
@@ -13,6 +13,7 @@
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <UART0_TX_GPIO21>;
+			output-high;
 		};
 		group2 {
 			pinmux = <UART0_RX_GPIO20>;

--- a/boards/riscv/stamp_c3/stamp_c3-pinctrl.dtsi
+++ b/boards/riscv/stamp_c3/stamp_c3-pinctrl.dtsi
@@ -13,6 +13,7 @@
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <UART0_TX_GPIO21>;
+			output-high;
 		};
 		group2 {
 			pinmux = <UART0_RX_GPIO20>;

--- a/boards/riscv/xiao_esp32c3/xiao_esp32c3-pinctrl.dtsi
+++ b/boards/riscv/xiao_esp32c3/xiao_esp32c3-pinctrl.dtsi
@@ -12,6 +12,7 @@
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <UART0_TX_GPIO21>;
+			output-high;
 		};
 		group2 {
 			pinmux = <UART0_RX_GPIO20>;

--- a/boards/xtensa/esp32/esp32-pinctrl.dtsi
+++ b/boards/xtensa/esp32/esp32-pinctrl.dtsi
@@ -13,6 +13,7 @@
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <UART0_TX_GPIO1>;
+			output-high;
 		};
 		group2 {
 			pinmux = <UART0_RX_GPIO3>;

--- a/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit-pinctrl.dtsi
+++ b/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit-pinctrl.dtsi
@@ -13,6 +13,7 @@
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <UART0_TX_GPIO1>;
+			output-high;
 		};
 		group2 {
 			pinmux = <UART0_RX_GPIO3>;

--- a/boards/xtensa/esp32s2_franzininho/esp32s2_franzininho-pinctrl.dtsi
+++ b/boards/xtensa/esp32s2_franzininho/esp32s2_franzininho-pinctrl.dtsi
@@ -13,6 +13,7 @@
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <UART0_TX_GPIO43>;
+			output-high;
 		};
 		group2 {
 			pinmux = <UART0_RX_GPIO44>;

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola-pinctrl.dtsi
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola-pinctrl.dtsi
@@ -13,6 +13,7 @@
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <UART0_TX_GPIO43>;
+			output-high;
 		};
 		group2 {
 			pinmux = <UART0_RX_GPIO44>;

--- a/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm-pinctrl.dtsi
+++ b/boards/xtensa/esp32s3_devkitm/esp32s3_devkitm-pinctrl.dtsi
@@ -12,6 +12,7 @@
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <UART0_TX_GPIO43>;
+			output-high;
 		};
 		group2 {
 			pinmux = <UART0_RX_GPIO44>;

--- a/boards/xtensa/esp_wrover_kit/esp_wrover_kit-pinctrl.dtsi
+++ b/boards/xtensa/esp_wrover_kit/esp_wrover_kit-pinctrl.dtsi
@@ -13,6 +13,7 @@
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <UART0_TX_GPIO1>;
+			output-high;
 		};
 		group2 {
 			pinmux = <UART0_RX_GPIO3>;

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2-pinctrl.dtsi
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2-pinctrl.dtsi
@@ -13,6 +13,7 @@
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <UART0_TX_GPIO1>;
+			output-high;
 		};
 		group2 {
 			pinmux = <UART0_RX_GPIO3>;

--- a/boards/xtensa/m5stickc_plus/m5stickc_plus-pinctrl.dtsi
+++ b/boards/xtensa/m5stickc_plus/m5stickc_plus-pinctrl.dtsi
@@ -12,6 +12,7 @@
 
 	uart0_tx_gpio1: uart0_tx_gpio1 {
 		pinmux = <UART0_TX_GPIO1>;
+		output-high;
 	};
 
 	uart0_rx_gpio3: uart0_rx_gpio3 {

--- a/boards/xtensa/odroid_go/odroid_go-pinctrl.dtsi
+++ b/boards/xtensa/odroid_go/odroid_go-pinctrl.dtsi
@@ -13,6 +13,7 @@
 	uart0_default: uart0_default {
 		group1 {
 			pinmux = <UART0_TX_GPIO1>;
+			output-high;
 		};
 		group2 {
 			pinmux = <UART0_RX_GPIO3>;

--- a/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb-pinctrl.dtsi
+++ b/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb-pinctrl.dtsi
@@ -11,8 +11,11 @@
 &pinctrl {
 	uart0_default: uart0_default {
 		group1 {
-			pinmux = <UART0_TX_GPIO1>,
-				 <UART0_RX_GPIO3>;
+			pinmux = <UART0_TX_GPIO1>;
+			output-high;
+		};
+		group2 {
+			pinmux = <UART0_RX_GPIO3>;
 		};
 	};
 


### PR DESCRIPTION
All ESP32 boards shows a garbage char before Zephyr banner. This happens during uart TX pin configuration that current lacks setting as output high.