### PR TITLE
kernel: device: add new driver define interface for abstract platform complexity from device drivers

### DIFF
--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -86,10 +86,6 @@ typedef void (*i2c_isr_cb_t)(const struct device *port);
 
 
 struct i2c_dw_rom_config {
-	DEVICE_MMIO_ROM;
-	i2c_isr_cb_t	config_func;
-	uint32_t		bitrate;
-
 #if defined(CONFIG_PINCTRL)
 	const struct pinctrl_dev_config *pcfg;
 #endif
@@ -100,7 +96,6 @@ struct i2c_dw_rom_config {
 };
 
 struct i2c_dw_dev_config {
-	DEVICE_MMIO_RAM;
 	struct k_sem		device_sync_sem;
 	struct k_mutex		bus_mutex;
 	uint32_t app_config;

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -27,6 +27,10 @@ properties:
     type: string-array
     description: name of each register space
 
+  io-mapped:
+    type: boolean
+    description: specify registers are IO mapped or memory mapped
+
   interrupts:
     type: array
     description: interrupts for device

--- a/dts/bindings/root/root.yaml
+++ b/dts/bindings/root/root.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for acpi bus driver
+
+description: Root node
+
+compatible: "root"
+
+include: base.yaml

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -18,6 +18,3 @@ properties:
     type: int
     description: divisor latch fraction (DLF, if supported)
 
-  io-mapped:
-    type: boolean
-    description: specify registers are IO mapped or memory mapped

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -9,6 +9,7 @@
 
 #include <stddef.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/device.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
@@ -51,6 +52,42 @@ typedef uint32_t pcie_id_t;
 struct pcie_dev {
 	pcie_bdf_t bdf;
 	pcie_id_t  id;
+};
+
+struct pcie_device_config {
+	/* Hardware id for uniqully identify a device. */
+	struct pcie_dev *pcie;
+	/**
+	 * Config function for the device.
+	 *
+	 * @param dev Device pointer.
+	 *
+	 * @retval 0 if success else system error code.
+	 */
+	int (*conf)(const struct device *dev);
+	/**
+	 * Isr function for the device.
+	 *
+	 * @param arg Device pointer, or any custom argu or can be NULL.
+	 *
+	 * @retval NIL
+	 */
+	void (*isr)(const void *arg);
+};
+
+struct pci_platform_conf {
+	pcie_id_t pci_id;
+	uint8_t io_mapped:1;
+	uint8_t bus_master:1;
+	int irq_num;
+	int irq_prio;
+	int irq_flag;
+};
+
+struct pcie_dev_id {
+	/* Hardware id for uniqully identify a device. */
+	pcie_id_t id;
+	struct device *dev_obj;
 };
 
 #define Z_DEVICE_PCIE_NAME(node_id) _CONCAT(pcie_dev_, DT_DEP_ORD(node_id))

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -1654,6 +1654,48 @@ static inline int z_impl_uart_drv_cmd(const struct device *dev, uint32_t cmd,
 #endif
 }
 
+#ifdef CONFIG_PLATFORM_ABST_SUPPORT
+
+#define DEV_DATA_FLOW_CTRL0 UART_CFG_FLOW_CTRL_NONE
+#define DEV_DATA_FLOW_CTRL1 UART_CFG_FLOW_CTRL_RTS_CTS
+#define DEV_DATA_FLOW_CTRL(n) \
+	_CONCAT(DEV_DATA_FLOW_CTRL, DT_INST_PROP_OR(n, hw_flow_control, 0))
+
+#define UART_DEFAULT_CONF_GET(dev)\
+			(struct uart_config *)dev->default_cfg
+
+/**
+ * @brief Like PLATFORM_DEV_DT_DEFINE() with UART specifics.
+ *
+ * @details Defines a device which implements the UART API.
+ *
+ * @param node_id The devicetree node identifier.
+ * @param flag describe type of Device object and requried boot priority.
+ * @param init_fn Pointer to the device's initialization function, which will be
+ * run by the kernel during system initialization.
+ * @param pm Pointer to the device's power management resources, a
+ * @ref pm_device, which will be stored in @ref device.pm. Use `NULL` if the
+ * device does not use PM.
+ * @param data Pointer to the device's private mutable data, which will be
+ * stored in @ref device.data.
+ * @param config Pointer to the device's private constant data, which will be
+ * stored in @ref device.config field.
+ * @param api Pointer to the device's API structure. Can be `NULL`.
+ * @param isr Pointer to the device's ISR function. Can be `NULL`.
+ */
+#define UART_PLATFORM_DEV_DT_DEFINE(node_id, flag, init_fn, pm, data,\
+				config, api, isr, ...)				\
+		static const struct uart_config __default_cfg##node_id = {\
+		.baudrate = DT_INST_PROP_OR(n, current_speed, 0),        \
+		.parity = DT_INST_PROP_OR(n, parity, UART_CFG_PARITY_NONE),                          \
+		.stop_bits = DT_INST_PROP_OR(n, stop_bits, UART_CFG_STOP_BITS_1),                       \
+		.data_bits = DT_INST_PROP_OR(n, data_bits, UART_CFG_DATA_BITS_8),                       \
+		.flow_ctrl = DEV_DATA_FLOW_CTRL(n),                      \
+		};\
+		PLATFORM_DEV_DT_DEFINE(DT_DRV_INST(node_id), flag,\
+			&__default_cfg##node_id, init_fn, pm, data, config, api, isr, __VA_ARGS__)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -16,6 +16,19 @@
 extern "C" {
 #endif
 
+#ifdef CONFIG_PLATFORM_ABST_SUPPORT
+enum notify_boot_level {
+	NOTIFY_LEVEL_PRE_KERNEL,
+	NOTIFY_LEVEL_POST_KERNEL,
+	NOTIFY_LEVEL_APPLICATION,
+	NOTIFY_LEVEL_MAX,
+};
+
+typedef void (*boot_notify_cb)(enum notify_boot_level type);
+
+enum notify_boot_level current_boot_stage_get(void);
+#endif
+
 /**
  * @defgroup sys_init System Initialization
  *
@@ -156,6 +169,10 @@ struct init_entry {
 			.init_fn = {.sys = (init_fn_)},                        \
 			.dev = NULL,                                           \
 	}
+
+#ifdef CONFIG_PLATFORM_ABST_SUPPORT
+int device_boot_notify_register(enum notify_boot_level type, boot_notify_cb cb);
+#endif
 
 /** @} */
 

--- a/include/zephyr/platform.h
+++ b/include/zephyr/platform.h
@@ -1,0 +1,697 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_PLATFORM_H_
+#define ZEPHYR_INCLUDE_PLATFORM_H_
+
+#include <stdint.h>
+
+#include <zephyr/devicetree.h>
+#include <zephyr/init.h>
+#include <zephyr/device.h>
+#include <zephyr/irq.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/sys/util.h>
+#if defined(CONFIG_PLATFORM_ABST_SUPPORT)
+#include <zephyr/sys/slist.h>
+#endif
+#if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
+BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "DT need CONFIG_PCIE");
+#include <zephyr/drivers/pcie/pcie.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Flags describe type of Device object and requried boot priority.
+ *
+ * These are various flag which describe boot priority requriements and type
+ * of device object such as Root/sys devices or PCI device etc.
+ */
+#define BOOT_LEVEL_MASK	 (0x7) /* Mask for various boot option. */
+#define BOOT_PRE_KERNEL	 (1 << 0) /* Device init will call before kernel init. */
+#define BOOT_POST_KERNEL (1 << 1) /* Device init will call after kernel init. */
+#define BOOT_APPLICATION (1 << 2) /* Device init will call after main thread invoked. */
+#define BOOT_DTS_DEVICE (1 << 3) /* Root/sys device type which is not on any bus node.*/
+#define BOOT_PCI_DEVICE	 (1 << 4) /* Device which is on PCI bus node.*/
+#define DEV_FLAG_IOMAPPED (1 << 5) /*Device who's register address are IO mapped.*/
+#define DEV_FLAG_BUS_ADD (1 << 6) /*Device who's address are bus specifc such as I2C devices*/
+
+/**
+ * @brief Get device boot priorty level.
+ *
+ * This will return device boot priorty level (notify_boot_level) based on device
+ * object boot priorty flag.
+ *
+ * @param dev pointer to device object
+ * @return notify_boot_level type
+ */
+#define BOOT_FLAG_LEVEL(dev)   ((dev->flag & BOOT_LEVEL_MASK) >> 1)
+
+/**
+ * @brief Check whether the device is defined using PLATFORM_DEV_DT_DEFINE or not.
+ *
+ * This macro will return true if device is new device object type
+ *
+ * @param dev pointer to device object
+ * @return true if new device object type else false
+ */
+#define IS_PLATFORM_DEVICE(dev) (dev->flag & (BOOT_DTS_DEVICE | BOOT_PCI_DEVICE))
+
+/**
+ * @brief Check whether the device is IO mapped or or not.
+ *
+ * This macro will return true if device is IO mapped
+ *
+ * @param dev pointer to device object
+ * @return true if IO mapped device else false
+ */
+#define IS_DEV_IOMAPPED(dev) ((dev->flag & DEV_FLAG_IOMAPPED) == DEV_FLAG_IOMAPPED)
+
+/**
+ * @brief Get memory mapped register based address.
+ *
+ * This will return mmio address of device's register base address.
+ * If MMU enabled then this macro will return the virtual address else
+ * will return physical address.
+ *
+ * @param dev pointer to device object
+ * @return MMIO address of register base address
+ */
+#define PLATFORM_MMIO_GET(dev) dev->mmio->mem
+
+/**
+ * @brief Get IO mapped register based address.
+ *
+ * This will return IO/port address of device's register base address.
+ *
+ * @param dev pointer to device object
+ * @return IO/port address of register base address
+ */
+#define PLATFORM_PORT_GET(dev) dev->mmio->port
+
+/**
+ * @brief Device's platform config info structure (in ROM) per driver instance
+ */
+struct platform_config {
+	/* Hardware id for uniquely identify a device. */
+	const char *hid;
+	/* Instance id for uniquely identify a device instance. */
+	uint8_t inst;
+	/**
+	 * Config function for the device.
+	 *
+	 * @param dev Device pointer.
+	 *
+	 * @retval 0 if success else system error code.
+	 */
+	int (*conf)(const struct device *dev);
+	/**
+	 * Isr function for the device.
+	 *
+	 * @param arg Device pointer, or any custom argu or can be NULL.
+	 *
+	 * @retval NIL
+	 */
+	void (*isr)(const void *arg);
+};
+
+/**
+ * @brief device resource info
+ *
+ * Structure for passing down temp platform information from bus or dts to
+ * various device and platform init functions.
+ */
+struct platform_resource {
+	/* Hardware id for uniquely identify a device. */
+	char *hw_id;
+	/* Instance id for uniquely identify a device instance. */
+	uint8_t inst;
+	/* MMIO or port address. */
+	uint32_t reg_size;
+	union {
+		uintptr_t reg_base_phy;
+		uint32_t port;
+	};
+	/* io mapped vs memory mapped. */
+	uint16_t io_mapped : 1;
+	/* device IRQ number. */
+	uint16_t irq_num : 8;
+	/* device IRQ priority. */
+	uint16_t irq_prio : 7;
+	/* device IRQ flags. */
+	uint32_t irq_flag;
+};
+
+/**
+ * @brief Utility function internally used by framework for initialize device nodes.
+ *
+ * @param dev child node's device object.
+ * @return NIL.
+ */
+void platform_node_init(const struct init_entry *entry);
+
+/**
+ * @brief Write 8bit value to a register
+ *
+ * @param dev the device object.
+ * @param reg register offset.
+ * @param val register value.
+ * @return NIL.
+ */
+static inline void platform_write_reg_8(const struct device *dev, uint32_t reg, uint8_t val)
+{
+	if (IS_DEV_IOMAPPED(dev)) {
+		sys_out8(val, PLATFORM_PORT_GET(dev) + reg);
+	} else {
+		sys_write8(val, PLATFORM_MMIO_GET(dev) + reg);
+	}
+}
+
+/**
+ * @brief Write 16bit value to a register
+ *
+ * @param dev the device object.
+ * @param reg register offset.
+ * @param val register value.
+ * @return NIL.
+ */
+static inline void platform_write_reg_16(const struct device *dev, uint32_t reg, uint16_t val)
+{
+	if (IS_DEV_IOMAPPED(dev)) {
+		sys_out16(val, PLATFORM_PORT_GET(dev) + reg);
+	} else {
+		sys_write16(val, PLATFORM_MMIO_GET(dev) + reg);
+	}
+}
+
+/**
+ * @brief Write 32bit value to a register
+ *
+ * @param dev the device object.
+ * @param reg register offset.
+ * @param val register value.
+ * @return NIL.
+ */
+static inline void platform_write_reg_32(const struct device *dev, uint32_t reg, uint32_t val)
+{
+	if (IS_DEV_IOMAPPED(dev)) {
+		sys_out32(val, PLATFORM_PORT_GET(dev) + reg);
+	} else {
+		sys_write32(val, PLATFORM_MMIO_GET(dev) + reg);
+	}
+}
+
+/**
+ * @brief Read 8bit value from a register
+ *
+ * @param dev the device object.
+ * @param reg register offset.
+ * @return register value.
+ */
+static inline uint8_t platform_read_reg_8(const struct device *dev, uint32_t reg)
+{
+	uint8_t val;
+
+	if (IS_DEV_IOMAPPED(dev)) {
+		val = sys_in8(PLATFORM_PORT_GET(dev) + reg);
+	} else {
+		val = sys_read8(PLATFORM_MMIO_GET(dev) + reg);
+	}
+	return val;
+}
+
+/**
+ * @brief Read 16bit value from a register
+ *
+ * @param dev the device object.
+ * @param reg register offset.
+ * @return register value.
+ */
+static inline uint16_t platform_read_reg_16(const struct device *dev, uint32_t reg)
+{
+	uint16_t val;
+
+	if (IS_DEV_IOMAPPED(dev)) {
+		val = sys_in16(PLATFORM_PORT_GET(dev) + reg);
+	} else {
+		val = sys_read16(PLATFORM_MMIO_GET(dev) + reg);
+	}
+	return val;
+}
+
+/**
+ * @brief Read 32bit value from a register
+ *
+ * @param dev the device object.
+ * @param reg register offset.
+ * @return register value.
+ */
+static inline uint32_t platform_read_reg_32(const struct device *dev, uint32_t reg)
+{
+	uint32_t val;
+
+	if (IS_DEV_IOMAPPED(dev)) {
+		val = sys_in32(PLATFORM_PORT_GET(dev) + reg);
+	} else {
+		val = sys_read32(PLATFORM_MMIO_GET(dev) + reg);
+	}
+
+	return val;
+}
+
+int platform_specific_dev_config(const struct device *dev, struct platform_resource *res);
+int platform_specific_dev_update(const struct device *dev, struct platform_resource *res, int status);
+
+#ifndef PLATFORM_LOG_DBG
+#define PLATFORM_LOG_DBG(...)
+#endif
+
+#define DEV_FLAG_IOMAPPED_0   0
+#define DEV_FLAG_IOMAPPED_1   DEV_FLAG_IOMAPPED
+#define DEV_FLAG_IOMAP_GET(n) _CONCAT(DEV_FLAG_IOMAPPED_, DT_PROP_OR(n, io_mapped, 0))
+
+#define DEV_FLAG_PCIE_0	     BOOT_DTS_DEVICE
+#define DEV_FLAG_PCIE_1	     BOOT_PCI_DEVICE
+#define DEV_FLAG_PCIE_GET(n) _CONCAT(DEV_FLAG_PCIE_, DT_ON_BUS(n, pcie))
+
+/**
+ * @brief Retrive info such as pci device, IO mapped etc.
+ *
+ */
+#define DEV_FLAG(n) (DEV_FLAG_PCIE_GET(n) | DEV_FLAG_IOMAP_GET(n))
+
+#define IRQ_FLAGS_SENSE0(n) 0
+#define IRQ_FLAGS_SENSE1(n) DT_IRQ(n, sense)
+#define IRQ_FLAGS_GET(n)    _CONCAT(IRQ_FLAGS_SENSE, DT_IRQ_HAS_CELL(n, sense))(n)
+
+#define INIT_IRQ_INFO0(n)
+#define INIT_IRQ_INFO1(n)                                                                          \
+	.irq_num = DT_IRQ(n, irq), .irq_prio = DT_IRQ(n, priority), .irq_flag = IRQ_FLAGS_GET(n),
+
+/**
+ * @brief Retrive IRQ info such as irq number, priortiy and interrupt flags.
+ *
+ */
+#define DEV_IRQ_INIT(n) _CONCAT(INIT_IRQ_INFO, DT_PROP_HAS_IDX(n, interrupts, 0))(n)
+
+#define IRQ_REGISTER0(n)
+#define IRQ_REGISTER1(n)                                                                           \
+	IRQ_CONNECT(DT_IRQN(n), DT_IRQ(n, priority), platform_cfg->isr, DEVICE_DT_GET(n),               \
+		    IRQ_FLAGS_GET(n));
+
+/**
+ * @brief Register ISR with platform's interrupt subsystem.
+ *
+ */
+#define DEV_IRQ_REGISTER(n) _CONCAT(IRQ_REGISTER, DT_PROP_HAS_IDX(n, interrupts, 0))(n)
+
+#define IRQ_ENABLE_0(n)
+#define IRQ_ENABLE_1(n)                                                                           \
+	irq_enable(DT_IRQN(n))
+
+/**
+ * @brief Enable device interrupt.
+ *
+ */
+#define DEV_IRQ_ENABLE(n) _CONCAT(IRQ_ENABLE_, DT_PROP_HAS_IDX(n, interrupts, 0))(n)
+
+
+#define DT_GET_REG_SIZE0(n) 0
+#define DT_GET_REG_SIZE1(n) DT_REG_SIZE(n)
+
+#define DT_REG_HAS_SIZE(node_id, idx) \
+	IS_ENABLED(DT_CAT4(node_id, _REG_IDX_, idx, _VAL_SIZE))
+
+#define GET_REG_SIZE_OR(n) _CONCAT(DT_GET_REG_SIZE, DT_REG_HAS_SIZE(n, 0))(n)
+
+#define DT_GET_REG_ADDR0(n) 0
+#define DT_GET_REG_ADDR1(n) .reg_base_phy = DT_REG_ADDR(n), .reg_size = GET_REG_SIZE_OR(n)
+
+#define GET_REG_ADD_OR(n) _CONCAT(DT_GET_REG_ADDR, DT_PROP_HAS_IDX(n, reg, 0))(n)
+
+#define DT_GET_MMIO_ADDR0(n) GET_REG_ADD_OR(n)
+#define DT_GET_MMIO_ADDR1(n) .port = DT_REG_ADDR(n), .reg_size = GET_REG_SIZE_OR(n)
+
+/**
+ * @brief Retrive MMIO address.
+ *
+ */
+#define GET_MMIO_ADD_OR(n) _CONCAT(DT_GET_MMIO_ADDR, DT_PROP_HAS_IDX(n, io_mapped, 0))(n)
+
+/**
+ * @brief Retrive platform specific information from DTS (Internal use only).
+ *
+ */
+#define PLATFORM_GENERIC_CONFIG_DECLARE(n, isr_)                                                   \
+	static const struct platform_config platform_cfg_##n = {                                          \
+		.conf = platform_config_fn_##n,                                                      \
+		.hid = DT_PROP_OR(n, hardware_id, 0),                                              \
+		.isr = isr_,                                                                       \
+	}
+
+
+/**
+ * @brief Retrive platform specific information from DTS for PCIe devices (Internal use only).
+ *
+ */
+#define PLATFORM_PCIE_CONFIG_DECLARE(n, isr_)                                                      \
+	DEVICE_PCIE_DECLARE(n);                                                                    \
+	static const struct pcie_device_config platform_cfg_##n = {                                     \
+		.conf = platform_config_fn_##n,                                                      \
+		DEVICE_PCIE_INIT(n, pcie),                                                         \
+		.isr = isr_,                                                                       \
+	}
+
+/**
+ * @brief Platform specific configurations (Internal use only).
+ *
+ */
+#define PLATFORM_SPECIFIC_DEV_CONFIG(n)                                                            \
+	static int platform_config_fn_##n(const struct device *dev)                                  \
+	{                                                                                          \
+		struct platform_resource res = {                                                          \
+			GET_MMIO_ADD_OR(n), .hw_id = DT_PROP_OR(n, hardware_id, 0),                \
+			.io_mapped = DT_PROP_OR(n, io_mapped, 0), DEV_IRQ_INIT(n)};                \
+		return platform_specific_dev_config(dev, &res);                                    \
+	}
+
+/**
+ * @brief Platform specific configuration update (Internal use only).
+ *
+ */
+#define PLATFORM_SPECIFIC_DEV_UPDATE(n)                                                            \
+	static int platform_update_device_##n(const struct device *dev, int status)                    \
+	{                                                                                          \
+		struct platform_resource res = {                                                          \
+			GET_MMIO_ADD_OR(n), .hw_id = DT_PROP_OR(n, hardware_id, 0),                \
+			.io_mapped = DT_PROP_OR(n, io_mapped, 0), DEV_IRQ_INIT(n)};                \
+                                                                                                   \
+		return platform_specific_dev_update(dev, &res, status);                            \
+	}
+
+/**
+ * @brief PCIe specific configuration update (Internal use only).
+ *
+ */
+#define PLATFORM_PCIE_DEV_UPDATE(n)                                                                \
+	int pcie_dev_update(const struct device *dev,\
+				struct pci_platform_conf *pci_cfg, int status);\
+	static int platform_update_device_##n(const struct device *dev, int status)                    \
+	{                                                                                          \
+		struct pci_platform_conf pci_cfg = {                                                 \
+			.pci_id = PCIE_DT_ID(n),                                                   \
+			.io_mapped = DT_PROP_OR(n, io_mapped, 0),                                  \
+			.bus_master = DT_PROP_OR(n, bus_master, 1),                                \
+			.irq_num = DT_IRQN(n),                                                     \
+			.irq_prio = DT_IRQ(n, priority),                                           \
+			.irq_flag = IRQ_FLAGS_GET(n),                                              \
+		};                                                                                 \
+		return pcie_dev_update(dev, &pci_cfg, status);                                     \
+	}
+
+/**
+ * @brief PCIe specific configurations (Internal use only).
+ *
+ */
+#define PLATFORM_PCIE_DEV_CONFIG(n)                                                                \
+	int pcie_dev_config(const struct device *dev, struct pci_platform_conf *pci_cfg);            \
+	static int platform_config_fn_##n(const struct device *dev)                                  \
+	{                                                                                          \
+		PLATFORM_LOG_DBG("%s\n", __func__);                                                \
+		struct pci_platform_conf pci_cfg = {                                                 \
+			.pci_id = PCIE_DT_ID(n),                                                   \
+			.io_mapped = DT_PROP_OR(n, io_mapped, 0),                                  \
+			.bus_master = DT_PROP_OR(n, bus_master, 1),                                \
+			.irq_num = DT_IRQN(n),                                                     \
+			.irq_prio = DT_IRQ(n, priority),                                           \
+			.irq_flag = IRQ_FLAGS_GET(n),                                              \
+		};                                                                                 \
+		return pcie_dev_config(dev, &pci_cfg);                                             \
+	}
+
+/**
+ * @brief Platform general configurations (Internal use only).
+ *
+ */
+#define PLATFORM_GENERIC_DEV_CONFIG(n)                                                             \
+	static int platform_config_fn_##n(const struct device *dev)                                  \
+	{                                                                                          \
+		const struct platform_config *platform_cfg = dev->platform_cfg;                                \
+                                                                                                   \
+		PLATFORM_LOG_DBG("%s\n", __func__);                                                \
+                                                                                                   \
+		if (DT_PROP_OR(n, io_mapped, 0)) {                                                 \
+			dev->mmio->port = DT_REG_ADDR(n);                                          \
+			PLATFORM_LOG_DBG("IO Mapped:%x\n", dev->mmio->port);                       \
+		} else {                                                                           \
+			dev->mmio->mem = DT_REG_ADDR(n);                                           \
+			PLATFORM_LOG_DBG("memory mapped: %p\n", (void *)dev->mmio->mem);                   \
+		}                                                                                  \
+                                                                                                   \
+		if (platform_cfg->isr) {                                                                \
+			DEV_IRQ_REGISTER(n);                                                       \
+		}                                                                                  \
+		return 0;                                                                          \
+	}
+
+/**
+ * @brief Platform general update (Internal use only).
+ *
+ */
+#define PLATFORM_GENERIC_DEV_UPDATE(n)                                                             \
+	static int platform_update_device_##n(const struct device *dev, int status)                    \
+	{                                                                                          \
+		const struct platform_config *platform_cfg = dev->platform_cfg;                                \
+		if (status != 0) {\
+			if (status < 0) {\
+				status = -status;\
+			} \
+			if (status > UINT8_MAX) {\
+				status = UINT8_MAX;\
+			} \
+			dev->state->init_res = status;\
+		} else if (platform_cfg->isr) {\
+			PLATFORM_LOG_DBG("enable irq\n");\
+			DEV_IRQ_ENABLE(n);\
+		} \
+			\
+		dev->state->initialized = true;\
+		return 0;\
+	}
+
+#define PLATFORM_DEV_CONFIG_DECLARE_1(n, _isr) PLATFORM_PCIE_CONFIG_DECLARE(n, _isr)
+#define PLATFORM_DEV_CONFIG_DECLARE_0(n, _isr) PLATFORM_GENERIC_CONFIG_DECLARE(n, _isr)
+
+#define PLATFORM_DEV_CONFIG_DECLARE(n, _isr)                                                       \
+	_CONCAT(PLATFORM_DEV_CONFIG_DECLARE_, DT_ON_BUS(n, pcie))(n, _isr)
+
+#ifdef CONFIG_PLATFORM_SPECIFIC_DEV_INIT
+#define PLATFORM_DEV_CONFIG_0(n) PLATFORM_SPECIFIC_DEV_CONFIG(n)
+#define PLATFORM_DEV_UPDATE_0(n) PLATFORM_SPECIFIC_DEV_UPDATE(n)
+#else
+#define PLATFORM_DEV_CONFIG_0(n) PLATFORM_GENERIC_DEV_CONFIG(n)
+#define PLATFORM_DEV_UPDATE_0(n) PLATFORM_GENERIC_DEV_UPDATE(n)
+#endif
+
+#define PLATFORM_DEV_CONFIG_1(n) PLATFORM_PCIE_DEV_CONFIG(n)
+#define PLATFORM_DEV_UPDATE_1(n) PLATFORM_PCIE_DEV_UPDATE(n)
+
+/**
+ * @brief Platform Configuration macro (Internal use only).
+ *
+ */
+#define PLATFORM_DEV_CONFIG(n) _CONCAT(PLATFORM_DEV_CONFIG_, DT_ON_BUS(n, pcie))(n)
+
+/**
+ * @brief Platform update macro (Internal use only).
+ *
+ */
+#define PLATFORM_DEV_UPDATE(n) _CONCAT(PLATFORM_DEV_UPDATE_, DT_ON_BUS(n, pcie))(n)
+
+/**
+ * @brief Platform generic init function (Internal use only).
+ *
+ */
+#define PLATFORM_GENERIC_DEV_INIT(n, init)                                                            \
+	static int platform_dev_init_##n(const struct device *dev)                                     \
+	{                                                                                          \
+		int status;                                                                        \
+		const struct platform_config *platform_cfg = dev->platform_cfg;                                \
+                                                                                                   \
+		PLATFORM_LOG_DBG("%s\n", __func__);                                      \
+		status = platform_cfg->conf(dev);                                                       \
+		if (status) {                                                                      \
+			PLATFORM_LOG_DBG("device config failed:%s\n", platform_cfg->hid);               \
+			goto exit;                                                                 \
+		}                                                                                  \
+			status = init(dev);                                                                \
+exit:                                                                                      \
+		platform_update_device_##n(dev, status);                                               \
+		return status;                                                                     \
+	}
+
+/**
+ * @brief PCIe specific init function (Internal use only).
+ *
+ */
+#define PLATFORM_PCI_DEV_INIT(n, init)                                                                \
+	static int platform_dev_init_##n(const struct device *dev)                                     \
+	{                                                                                          \
+		int status;                                                                        \
+		const struct pcie_device_config *platform_cfg = dev->platform_cfg;                           \
+                                                                                                   \
+		PLATFORM_LOG_DBG("%x\n", platform_cfg->pcie->id);                    \
+		status = platform_cfg->conf(dev);                                                       \
+		if (status) {                                                                      \
+			PLATFORM_LOG_DBG("device config failed:%x\n", platform_cfg->pcie->id);          \
+			goto exit;                                                                 \
+		}                                                                                  \
+			status = init(dev);                                                                \
+exit:                                                                                      \
+		platform_update_device_##n(dev, status);                                               \
+		return status;                                                                     \
+	}
+
+#define PLATFORM_DEV_INIT_0(n, init) PLATFORM_GENERIC_DEV_INIT(n, init)
+#define PLATFORM_DEV_INIT_1(n, init) PLATFORM_PCI_DEV_INIT(n, init)
+
+#define PLATFORM_DEV_INIT(n, init) _CONCAT(PLATFORM_DEV_INIT_, DT_ON_BUS(n, pcie))(n, init)
+
+#define DECL_DEV_NODE(n)                                                                           \
+	struct platform_resource res_##n = {GET_MMIO_ADD_OR(n),\
+					.hw_id = DT_PROP_OR(n, hardware_id, 0),   \
+				    .io_mapped = DT_PROP_OR(n, io_mapped, 0), DEV_IRQ_INIT(n)};
+
+
+#define PROB_CHILD_NODE(n) platform_node_init(DEVICE_INIT_DT_GET(n))
+
+/**
+ * @brief Enumerate child devices for the given node
+ *
+ * Each device is placed in a custom section and Root/sys or any bus driver can
+ * enumerate all their child node using this macro during boot time.
+ *
+ * @node_id node lable of bus driver or "root/sys" label if it is in the Root/sys node.
+ *
+ */
+#define DEVICE_PROB_CHILD_NODE(node_id)                                               \
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_NODELABEL(node_id), PROB_CHILD_NODE, (;))
+
+/**
+ * @brief Like PLATFORM_DEV_DT_DEFINE(), but uses an instance of a `DT_DRV_COMPAT`
+ * compatible instead of a node identifier.
+ *
+ * @param inst Instance number. The `node_id` argument to PLATFORM_DEV_DT_DEFINE() is
+ * set to `DT_DRV_INST(inst)`.
+ * @param ... Other parameters as expected by PLATFORM_DEV_DT_DEFINE().
+ */
+#define PLATFORM_DEV_DT_INST_DEFINE(inst, ...)                                                     \
+	PLATFORM_DEV_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
+
+/**
+ * @brief Create a device object from a devicetree node identifier and set it up
+ * for boot time initialization.
+ *
+ * This macro defines a @ref device that is automatically configured by the
+ * kernel during system initialization. The global device object's name as a C
+ * identifier is derived from the node's dependency ordinal. @ref device.name is
+ * set to `DEVICE_DT_NAME(node_id)`.
+ *
+ * The device is declared with extern visibility, so a pointer to a global
+ * device object can be obtained with `DEVICE_DT_GET(node_id)` from any source
+ * file that includes `<zephyr/device.h>`. Before using the pointer, the
+ * referenced object should be checked using device_is_ready().
+ *
+ * @param node_id The devicetree node identifier.
+ * @param flag describe type of Device object and requried boot priority.
+ * @param defaut_cfg The default device conifg such as baud rate, clk freq etc.
+ * @param init_fn Pointer to the device's initialization function, which will be
+ * run by the kernel during system initialization.
+ * @param pm Pointer to the device's power management resources, a
+ * @ref pm_device, which will be stored in @ref device.pm. Use `NULL` if the
+ * device does not use PM.
+ * @param data Pointer to the device's private mutable data, which will be
+ * stored in @ref device.data.
+ * @param config Pointer to the device's private constant data, which will be
+ * stored in @ref device.config field.
+ * @param api Pointer to the device's API structure. Can be `NULL`.
+ * @param isr Pointer to the device's ISR function. Can be `NULL`.
+ */
+#define PLATFORM_DEV_DT_DEFINE(node_id, flag, defaut_cfg, init_fn, pm, data, config, api, isr,     \
+			       ...)                                                                \
+	Z_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_ID(node_id));                                        \
+	Z_PLATFORM_DEV_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id), DEVICE_DT_NAME(node_id),       \
+			      init_fn, pm, data, config, api, flag, defaut_cfg, isr,               \
+			      &Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)), __VA_ARGS__)
+
+/**
+ * @brief Initializer (V2) for @ref device.
+ *
+ * @param name_ Name of the device.
+ * @param pm_ Reference to @ref pm_device (optional).
+ * @param data_ Reference to device data.
+ * @param config_ Reference to device config.
+ * @param api_ Reference to device API ops.
+ * @param state_ Reference to device state.
+ * @param handles_ Reference to device handles.
+ * @param res_ Device resource such as mmio address.
+ * @param platform_cfg_ platform specific configuration info.
+ * @param default_cfg_ The default device conifg such as baud rate, clk freq etc.
+ * @param flag_ Flags describe type of Device object and requried boot priority.
+ */
+#define Z_PLATFORM_INIT(name_, pm_, data_, config_, api_, state_, handles_, res_, platform_cfg_,       \
+			 default_cfg_, flag_)                                                      \
+	{                                                                                          \
+		.name = name_, .data = (data_), .default_cfg = default_cfg_, .config = (config_),  \
+		.api = (api_), .state = (state_), .handles = (handles_),                           \
+		IF_ENABLED(CONFIG_PM_DEVICE, (.pm = (pm_),)).mmio = res_, .platform_cfg = platform_cfg_,    \
+		.flag = flag_,                                                                     \
+	}
+
+/**
+ * @brief Define a @ref device
+ *
+ * @param node_id Devicetree node id for the device (DT_INVALID_NODE if a
+ * software device).
+ * @param dev_id Device identifier (used to name the defined @ref device).
+ * @param name Name of the device.
+ * @param pm Reference to @ref pm_device associated with the device.
+ * (optional).
+ * @param data Reference to device data.
+ * @param config Reference to device config.
+ * @param level Initialization level.
+ * @param prio Initialization priority.
+ * @param api Reference to device API.
+ * @param ... Optional dependencies, manually specified.
+ */
+
+#define Z_PLATFORM_DEV_DEFINE(node_id, dev_id, name, init_fn, pm, data, config, api, flag,         \
+			      default_cfg, isr_, state, ...)                                       \
+	Z_DEVICE_NAME_CHECK(name);                                                                 \
+	static union mmio_info dev_mmio_##node_id;                                                \
+                                                                                                   \
+	PLATFORM_DEV_CONFIG(node_id);                                                              \
+	PLATFORM_DEV_CONFIG_DECLARE(node_id, isr_);                                                \
+	PLATFORM_DEV_UPDATE(node_id);                                                              \
+	PLATFORM_DEV_INIT(node_id, init_fn);                                                       \
+                                                                                                   \
+	Z_DEVICE_HANDLES_DEFINE(node_id, dev_id, __VA_ARGS__);                                     \
+                                                                                                   \
+	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))                                         \
+	const Z_DECL_ALIGN(struct device) DEVICE_NAME_GET(dev_id)                                  \
+		Z_DEVICE_SECTION(PRE_KERNEL_2, 0) __used =                                    \
+			Z_PLATFORM_INIT(name, pm, data, config, api, state,                       \
+					 Z_DEVICE_HANDLES_NAME(dev_id), &dev_mmio_##node_id,       \
+					 &platform_cfg_##node_id, default_cfg,                          \
+					 flag | DEV_FLAG(node_id));                                \
+                                                                                                   \
+	Z_DEVICE_INIT_ENTRY_DEFINE(dev_id, platform_dev_init_##node_id, PRE_KERNEL_2, 0)
+
+#endif

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND kernel_files
   main_weak.c
   banner.c
   device.c
+  platform.c
   errno.c
   fatal.c
   init.c

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -718,7 +718,6 @@ config APPLICATION_INIT_PRIORITY
 	  This priority level is for end-user drivers such as sensors and display
 	  which have no inward dependencies.
 
-
 endmenu
 
 menu "Security Options"
@@ -962,3 +961,5 @@ config HAS_DYNAMIC_DEVICE_HANDLES
 endmenu
 
 rsource "Kconfig.vm"
+
+rsource "Kconfig.platform"

--- a/kernel/Kconfig.platform
+++ b/kernel/Kconfig.platform
@@ -1,0 +1,23 @@
+# Copyright (c) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+menu "Platform Abstract Support"
+
+config PLATFORM_ABST_SUPPORT
+	bool "enable Platform Abstract Support"
+	default n
+	help
+	  Option to enable Platform Abstract Support.
+
+if PLATFORM_ABST_SUPPORT
+
+config PLATFORM_SPECIFIC_DEV_INIT
+	bool "Enable platform specifc initialize Support"
+	default n
+	help
+	  Option to enable platform specifc initialize Support.
+
+endif # PLATFORM_ABST_SUPPORT
+
+endmenu # Platform Abstract Support

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -12,7 +12,9 @@
 
 extern const struct device __device_start[];
 extern const struct device __device_end[];
+extern const struct init_entry __init_end[];
 
+/* sys_slist_t pend_dev_list; */
 
 /**
  * @brief Initialize state for all static devices.
@@ -29,6 +31,7 @@ void z_device_state_init(void)
 		++dev;
 	}
 }
+
 
 const struct device *z_impl_device_get_binding(const char *name)
 {

--- a/kernel/platform.c
+++ b/kernel/platform.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2015-2016 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT root
+
+#include <zephyr/platform.h>
+
+
+#define LOG_LEVEL CONFIG_PLATFORM_ABST_SUPPORT_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(platform_abst);
+
+#if defined(CONFIG_PLATFORM_ABST_SUPPORT)
+__attribute__((weak)) int platform_specific_dev_config(const struct device *dev,
+		struct platform_resource *res)
+{
+	const struct platform_config  *platform_cfg = dev->platform_cfg;
+
+	LOG_DBG("");
+
+	if (!res->io_mapped) {
+#if defined(CONFIG_MMU)
+		if (dev->flag & DEV_FLAG_BUS_ADD) {
+			dev->mmio->mem = res->reg_base_phy;
+		} else if (res->reg_base_phy) {
+			device_map(&dev->mmio->mem, res->reg_base_phy,
+			   res->reg_size, K_MEM_CACHE_NONE);
+		}
+#else
+		dev->mmio->mem = res->reg_base_phy;
+#endif
+		LOG_DBG("memory mapped: %p\n", (void *)dev->mmio->mem);
+	} else {
+		dev->mmio->port =  res->port;
+		LOG_DBG("IO Mapped:%x\n", dev->mmio->port);
+	}
+	if (platform_cfg->isr) {
+		LOG_DBG("irq:%d, prio:%x, flag:%x\n", res->irq_num, res->irq_prio, res->irq_flag);
+		irq_connect_dynamic(res->irq_num, res->irq_prio,
+			    platform_cfg->isr, dev, res->irq_flag);
+		irq_enable(res->irq_num);
+	}
+
+	return 0;
+}
+
+__attribute__((weak)) int platform_specific_dev_update(const struct device *dev,
+			struct platform_resource *res,  int status)
+{
+	LOG_DBG("");
+
+	if (status != 0) {
+		if (status < 0) {
+			status = -status;
+		}
+		if (status > UINT8_MAX) {
+			status = UINT8_MAX;
+		}
+		dev->state->init_res = status;
+	}
+
+	dev->state->initialized = true;
+
+	return 0;
+}
+
+void platform_node_init(const struct init_entry *entry)
+{
+	const struct device *dev;
+ 
+	if (!entry || !entry->dev || !entry->init_fn.dev) {
+		return;
+	}
+
+	dev = entry->dev;
+
+	if (((dev->flag & BOOT_DTS_DEVICE) != BOOT_DTS_DEVICE) ||
+		(dev->state->initialized == true) ||
+		(BOOT_FLAG_LEVEL(dev) > current_boot_stage_get())) {
+		return;
+	}
+
+	entry->init_fn.dev(dev);
+}
+
+static void prob_child_device(void)
+{
+	DEVICE_PROB_CHILD_NODE(root);
+}
+
+static void platform_boot_notfy(enum notify_boot_level)
+{
+	prob_child_device();
+}
+
+static int platform_init(const struct device *dev)
+{
+	device_boot_notify_register(NOTIFY_LEVEL_POST_KERNEL, platform_boot_notfy);
+	device_boot_notify_register(NOTIFY_LEVEL_APPLICATION, platform_boot_notfy);
+
+	prob_child_device();
+
+	return 0;
+}
+
+/* we need to define device object for root node as well. */
+DEVICE_DT_INST_DEFINE(0, platform_init, NULL, NULL, NULL, POST_KERNEL, 0, NULL);
+
+#endif


### PR DESCRIPTION
add new driver define interface for abstract platform complexity from device drivers.

**Issue/problem Statement.**
======================================

Zephyr RTOS introduced many features, spatially on driver framework which make it much more capable from other counter part RTOS in case of scalability, configurability, modularity and re-usability. Generic APIs for IO drivers, device tree, power management, user mode, PCI bus driver etc. which make it capable for supporting in numerous use case from very tiny low foot print MCU to Application processor based platforms with complex sub subsystems. But as OS become more capable it become more complex as well. Following are some of the limitations of existing Zephyr driver interface:

- Developers have to understand and implement various platform and OS specific interface code such PCI bus, DTS, interrupt configuration/management etc. in each drivers they newly write or even modify an existing driver for porting into their platform. 
- The porting will be more complex when device is sitting on some of the bus such as PCI or ACPI
- These OS/Bus/platform interface might change with platforms as well as newer Zephyr versions and hence we need to maintain/modify every driver source code for migrate to new platform/OS version.
- Less re-usable: These bus/platform adoption code almost have similar logic for resource enumeration, interrupt configuration etc. and so other drivers can easily re-use them once developed for one IO device. But with current model developers have to add these code into every drivers they develop/port.

If we can enhance existing driver interface in such a way that most of these platform complexities can be abstracted behind interface, then driver developers can focus only on device/ip specific implementation code for their driver. 

> **Note**
Please note that the PR is only a draft version and currently given for analyze purpose. 

**How to enhance interface for IO drivers - Draft Proposal**
======================================
Following section brief on the new proposal for enhance device driver interface. The proposal is only able to capture base requirements, but might need continue improvement by review and adopt suggestion from community and domain experts. 

**Analyze on Architecture Changes on Existing driver Interface**
------------------------------------------------------------------
As shown in the below block diagram, the proposed model have abstract interface for platform specific implementation and other bus specific complexity and provide a unified interface to driver developers. It also propose interface for IO subsystem such as i2c driver, spi driver etc. The sensor bus interface can further abstract sensor drivers from underlying bus interface such as i2c, spi etc.

![image](https://github.com/zephyrproject-rtos/zephyr/assets/42460060/b571a89f-3e23-4129-a46f-228d5c003743)

**Platform Abstract Interface**
-------------------------------

In the proposed model, Zephyr provide a new driver define interface for drivers called "PLATFORM_DEV_DT_INST_DEFINE".

> **Note**
In order to make backsword compatible with existing drivers, the new interface by default will be disabled and can be enabled only if developers have to use this new interface for their drivers. Also the new interface will co-exist with existing DEVICE_DT_DEFINE interface. 

Following code snippet depicts how this new interface can be used for driver development .

```diff
static void my_dev_isr(const void *arg)
{
	const struct device *dev = arg;
	
+	platform_write_reg_32(dev, MY_REG_OFFSET_2, MY_INTR_CFG_1);

	...

}

static int my_dev_config(const struct device *dev,
			struct my_config *config_param)
{
	const struct my_device_config * config = dev->config;
	struct my_device_data * data = dev->data;
	
+	platform_write_reg_32(dev, MY_REG_OFFSET_1, config_param->my_cfg1);

	...

}

static int my_dev_initialize(const struct device *dev)
{
	const struct my_device_config * config = dev->config;
	struct my_config *default_cfg = config->my_default_config;
	
+	platform_write_reg_32(dev, MY_REG_OFFSET_1, default_cfg->my_cfg1);

	...
	
}

struct my_device_api my_dev_api = {
	.my_config = my_dev_config,
	...
};

#define MY_DEVICE_INIT(n) \
	static const struct my_device_config my_dev_config_##n = {           \
		.my_default_config = DT_INST_PROP(n, my_some_config),                  \
	};                                                                    \
	static struct my_device_data my_dev_data_##n;                    \
+	PLATFORM_DEV_DT_INST_DEFINE(n, BOOT_POST_KERNEL, NULL, my_dev_initialize,\
+		NULL, &my_dev_data_##n, &my_dev_config_##n, &my_dev_api, my_dev_isr);   \

DT_INST_FOREACH_STATUS_OKAY(MY_DEVICE_INIT)
```
Here the new PLATFORM_DEV_DT_INST_DEFINE interface is almost similar to existing DEVICE_DT_INST_DEFINE interface, except following changes:
- Boot priority limited to pre-kernel, post-kernel or application level which are based on the specific driver implementation ( example: if driver have to use some kernel APIs during init then it should be post kernel etc.) and use case (example: UART driver might required to be pre-kernel for enable early logging). These flags expected to be remain same for a specific driver and will not change from platform to platform. Device boot priority will be also depend on bus/parent driver boot priority as well apart  from these boot flag. All other inter driver dependency and boot priority will be take care by platform abstraction layer based on your device position in the device tree such as order of device node, parent node up on which the child node located etc. The framework will ensure the parent node init will be invoked before the child node init call. Similarly device init will be called in the ascending order of nodes in the device tree. This will help a platform integrator to configure the driver boot order dependency based on his platform boot order requirement, bus upon which the device node placed etc. Following diagram depict the parent child hierarchy and the device boot order. Please note that below diagram assume all driver have same boot priority say pre-kernel and if it it have different boot flag then all pre-kernel device will get instantiated first followed by post-kernel and finally application level.
 
![image](https://github.com/zephyrproject-rtos/zephyr/assets/42460060/04ebf348-0de7-4b77-94da-57de3733b620)

- defaut_cfg (optional) which can be used for sub system interface such as i2c or spi to keep the default device configuration such as clock frequency, baud rate etc.  [Please refer I2C PR](https://github.com/zephyrproject-rtos/zephyr/pull/57765/commits/c01c80d867971bb9735bb6a51e29bc85367def31) and  [UART PR](https://github.com/zephyrproject-rtos/zephyr/pull/57765/commits/c01c80d867971bb9735bb6a51e29bc85367def31)  for more detail on changes required for i2c  and UART drivers with new interface. 

- isr (optional) can be provided to the platform abstraction layer and it will take care of how to register ISR with platform or bus driver (such as PCI etc.) based on DTS, PCI information etc.

Additionally platform abstract layer will provide device register access API where driver developers need to provide only register offset. Based on SOC/platform HW, the register will be re-directed as memory mapped access or IO access. Platform abstract layer will retrieve MMIO address from either DTS or from bus such as PCI depend on the node position in the device tree and also map the MMIO address into virtual address if MMU enabled in the platform.

**Bus/Parent device**

For drivers such as SPI, I2C etc. where child device/node (sensors) can use platform abstract macro such as DEVICE_PROBE_CHILD_NODE_POST_KERNEL() to enumerate its child devices. This should be part of SPI/i2C common layer(i2c.h or spi.h) and should be abstract from device drivers.

**Platform Abstract Layer Configuration Details**

There are three type of device configuration supported:

- Generic device configuration where default configuration will be used such as IRQ registration using IRQ_CONNECT(), retrieve  MMIO address using DT_REG_ADDR etc. This can be used for MCUs where there is no constrain in ISR name/location and no MMU support etc. [Please refer PLATFORM_GENERIC_DEV_CONFIG macro in platform.h ](https://github.com/zephyrproject-rtos/zephyr/pull/57765/commits/319b3c53422d019683cc5eaddecf94f78a75a40d) for more details on generic configuration implementation.

- Platform specific configuration (PLATFORM_SPECIFIC_DEV_INIT) can be use if generic device configuration cannot be used in such case where device ISR/MMIO interface will be specific to platform. In this case there is a default week function implementation of platform_specific_dev_config() which can be used if your constrain is only dynamic IRQ allocations and MMU support . If platform require more specific implementation then SOC/platform vendor can implement their own impletion of platform_specific_dev_config() function which override the default implementation.  [Please refer platform.c ](https://github.com/zephyrproject-rtos/zephyr/pull/57765/commits/319b3c53422d019683cc5eaddecf94f78a75a40d) for more details on Platform specific week implementation.

- Bus specific configuration is for device sitting on PCI or ACPI node. In this case, device resource allocation will be taken care by underlying bus driver.  [Please refer pcie.h ](https://github.com/zephyrproject-rtos/zephyr/pull/57765/commits/ecf2b9dfe1d309c85d228cc15b6666c4624c0b8b) for more details on PCI specific implementation.

**IO Abstract Interface**
------------------------

In the proposed model, Zephyr provide a set of new driver define interface for IO drivers such as  I2C_PLATFORM_DEV_DT_DEFINE(), UART_PLATFORM_DEV_DT_DEFINE() etc.  These interface will internally use PLATFORM_DEV_DT_INST_DEFINE() to abstract underlying platform and bus interface complexity and also will fetch additional device configuration from DTS such as clock speed, baud rate etc. and provide those information through simplified interface such as I2C_SPEED_GET(), UART_DEFAULT_CONF_GET() etc.

It also do device enumeration if the DTS node have additional child node such as sensor devices and enable them for ready to use.

Following code snippet show how the new I2C_PLATFORM_DEV_DT_DEFINE() i2c interface can be used to write/port i2c device driver. The interface is almost similar to PLATFORM_DEV_DT_INST_DEFINE(). Driver can use default i2c bus configuration such as clock frequency using I2C_SPEED_GET() macro. Also you could notice a lot of code is not required in drivers since it is taken care by the interface layer.

```diff

...

+     clk_freq = I2C_SPEED_GET(dev);
+	platform_write_reg_32(dev, DW_CFG_REG, clk_freq);

...

- #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
-	if (rom->pcie) {
-		struct pcie_bar mbar;
-
-		if (rom->pcie->bdf == PCIE_BDF_NONE) {
-			return -EINVAL;
-		}
-
-		pcie_probe_mbar(rom->pcie->bdf, 0, &mbar);
-		pcie_set_cmd(rom->pcie->bdf, PCIE_CONF_CMDSTAT_MEM, true);
-
-		device_map(DEVICE_MMIO_RAM_PTR(dev), mbar.phys_addr,
-			   mbar.size, K_MEM_CACHE_NONE);
-	} else
- #endif
-	{
-		DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
-	}

...

- #define I2C_DW_INIT_PCIE0(n)
- #define I2C_DW_INIT_PCIE1(n) DEVICE_PCIE_INST_INIT(n, pcie),
- #define I2C_DW_INIT_PCIE(n) \
-	_CONCAT(I2C_DW_INIT_PCIE, DT_INST_ON_BUS(n, pcie))(n)
-
- #define I2C_DEFINE_PCIE0(n)
- #define I2C_DEFINE_PCIE1(n) DEVICE_PCIE_INST_DECLARE(n)
- #define I2C_PCIE_DEFINE(n) \
-	_CONCAT(I2C_DEFINE_PCIE, DT_INST_ON_BUS(n, pcie))(n)
-
- #define I2C_DW_IRQ_FLAGS_SENSE0(n) 0
- #define I2C_DW_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
- #define I2C_DW_IRQ_FLAGS(n) \
-	_CONCAT(I2C_DW_IRQ_FLAGS_SENSE, DT_INST_IRQ_HAS_CELL(n, sense))(n)
-
- /* not PCI(e) */
- #define I2C_DW_IRQ_CONFIG_PCIE0(n)                                            \
-	static void i2c_config_##n(const struct device *port)                 \
-	{                                                                     \
-		ARG_UNUSED(port);                                             \
-		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	      \
-			    i2c_dw_isr, DEVICE_DT_INST_GET(n),                \
-			    I2C_DW_IRQ_FLAGS(n));                             \
-		irq_enable(DT_INST_IRQN(n));                                  \
-	}
-
- /* PCI(e) with auto IRQ detection */
- #define I2C_DW_IRQ_CONFIG_PCIE1(n)                                            \
-	static void i2c_config_##n(const struct device *port)                 \
-	{                                                                     \
-		BUILD_ASSERT(DT_INST_IRQN(n) == PCIE_IRQ_DETECT,              \
-			     "Only runtime IRQ configuration is supported");  \
-		BUILD_ASSERT(IS_ENABLED(CONFIG_DYNAMIC_INTERRUPTS),           \
-			     "DW I2C PCI needs CONFIG_DYNAMIC_INTERRUPTS");   \
-		const struct i2c_dw_rom_config * const dev_cfg = port->config;\
-		unsigned int irq = pcie_alloc_irq(dev_cfg->pcie->bdf);        \
-		if (irq == PCIE_CONF_INTR_IRQ_NONE) {                         \
-			return;                                               \
-		}                                                             \
-		pcie_connect_dynamic_irq(dev_cfg->pcie->bdf, irq,	      \
-				     DT_INST_IRQ(n, priority),		      \
-				    (void (*)(const void *))i2c_dw_isr,       \
-				    DEVICE_DT_INST_GET(n),                    \
-				    I2C_DW_IRQ_FLAGS(n));                     \
-		pcie_irq_enable(dev_cfg->pcie->bdf, irq);                     \
-	}
-
- #define I2C_DW_IRQ_CONFIG(n) \
-	_CONCAT(I2C_DW_IRQ_CONFIG_PCIE, DT_INST_ON_BUS(n, pcie))(n)
-
- #define I2C_CONFIG_REG_INIT_PCIE0(n) DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),
- #define I2C_CONFIG_REG_INIT_PCIE1(n)
- #define I2C_CONFIG_REG_INIT(n) \
-	_CONCAT(I2C_CONFIG_REG_INIT_PCIE, DT_INST_ON_BUS(n, pcie))(n)
-
 #define I2C_DEVICE_INIT_DW(n)                                                 \
	PINCTRL_DW_DEFINE(n);                                                 \
-	I2C_PCIE_DEFINE(n);                                                   \
-	static void i2c_config_##n(const struct device *port);                \
-	static const struct i2c_dw_rom_config i2c_config_dw_##n = {           \
-		I2C_CONFIG_REG_INIT(n)                                        \
-		.config_func = i2c_config_##n,                                \
-		.bitrate = DT_INST_PROP(n, clock_frequency),                  \
		PINCTRL_DW_CONFIG(n)                                          \
-		I2C_DW_INIT_PCIE(n)                                           \
-	};                                                                    \
	static struct i2c_dw_dev_config i2c_##n##_runtime;                    \
-	I2C_DEVICE_DT_INST_DEFINE(n, i2c_dw_initialize, NULL,                 \
-			      &i2c_##n##_runtime, &i2c_config_dw_##n,         \
			      POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,          \
-			      &funcs);                                        \
-	I2C_DW_IRQ_CONFIG(n)
-
...

+	I2C_PLATFORM_DEV_DT_DEFINE(n, BOOT_POST_KERNEL, \
                i2c_dw_initialize,\
		NULL, &i2c_##n##_runtime, &i2c_config_dw_##n, &funcs,\
+             i2c_dw_isr);   \

...

```
**Sensor Bus Abstract Interface**
-----------------------------
TODO


