### PR TITLE
drivers: spi: add SPI device statistics

### DIFF
--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -55,6 +55,12 @@ config SPI_COMPLETION_TIMEOUT_TOLERANCE
 	help
 	  The tolerance value in ms for the SPI completion timeout logic.
 
+config SPI_STATS
+	bool "SPI device statistics"
+	depends on STATS
+	help
+	  Enable SPI device statistics.
+
 module = SPI
 module-str = spi
 source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
Enable below statistics for SPI by follow Zephyr STATS subsystem,
    rx_bytes, tx_bytes, transfer_error.

and add SPI_DEVICE_DT_DEFINE helper macro to define SPI device.