### PR TITLE
libc: minimal: strtoll: Remove typo in SPDX-License-Identifier

### DIFF
--- a/lib/libc/minimal/source/stdlib/strtoll.c
+++ b/lib/libc/minimal/source/stdlib/strtoll.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3-Clause-UC */
+/* SPDX-License-Identifier: BSD-3-Clause */
 
 /*-
  * Copyright (c) 1990 The Regents of the University of California.


### PR DESCRIPTION
BSD-3-Clause-UC is not a valid license name and spdx validator generates a Warning! when detected. Most probably a typo from old version of strtoll.c licenced as BSD-4-Clause-UC.

see commit: 570ed08