### PR TITLE
boards: arm: adafruit_kb2040: Support flashing with UF2 runner

### DIFF
--- a/boards/arm/adafruit_kb2040/board.cmake
+++ b/boards/arm/adafruit_kb2040/board.cmake
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 TOKITA Hiroshi
+
+board_runner_args(uf2 "--board-id=RPI-RP2")
+
+include(${ZEPHYR_BASE}/boards/common/uf2.board.cmake)


### PR DESCRIPTION
Add support UF2 runner to use `west flash`.