### PR TITLE
MAINTAINERS: Make nordicjm maintainer for MCUmgr subsystem

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -651,7 +651,7 @@
 /include/zephyr/logging/                         @nordic-krch
 /include/zephyr/lorawan/lorawan.h                @Mani-Sadhasivam
 /include/zephyr/mgmt/osdp.h                      @sidcha
-/include/zephyr/mgmt/mcumgr/                     @de-nordic
+/include/zephyr/mgmt/mcumgr/                     @nordicjm
 /include/zephyr/net/                             @rlubos @tbursztyka
 /include/zephyr/net/buf.h                        @jhedberg @tbursztyka @rlubos
 /include/zephyr/net/coap*.h                      @rlubos

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1699,9 +1699,9 @@ Mbed TLS:
 MCU Manager:
   status: maintained
   maintainers:
-    - de-nordic
-  collaborators:
     - nordicjm
+  collaborators:
+    - de-nordic
   files:
     - subsys/mgmt/mcumgr/
     - include/zephyr/mgmt/mcumgr/


### PR DESCRIPTION
With significant contribution to MCUmgr that brought increased upload speeds and various other improvements in RAM and CPU usage, general improvements in MCUmgr architecture and documentation, Jamie has shown his vision for the subsystem and therefore lets welcome him as a new MCUmgr subsystem maintainer.