### PR TITLE
tests/cmsis_rtos_v2: increase main thread sleep time

### DIFF
--- a/tests/subsys/portability/cmsis_rtos_v2/src/mutex.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/mutex.c
@@ -8,7 +8,8 @@
 #include <zephyr/kernel.h>
 #include <cmsis_os2.h>
 
-#define TIMEOUT_TICKS   10
+#define WAIT_TICKS      5
+#define TIMEOUT_TICKS   (10 + WAIT_TICKS)
 #define STACKSZ         CONFIG_CMSIS_V2_THREAD_MAX_STACK_SIZE
 
 int max_mtx_cnt = CONFIG_CMSIS_V2_MUTEX_MAX_COUNT;
@@ -117,7 +118,7 @@ void tThread_entry_lock_timeout(void *arg)
 	status = osMutexAcquire((osMutexId_t)arg, 0);
 	zassert_true(status == osErrorResource);
 
-	status = osMutexAcquire((osMutexId_t)arg, TIMEOUT_TICKS - 5);
+	status = osMutexAcquire((osMutexId_t)arg, WAIT_TICKS);
 	zassert_true(status == osErrorTimeout);
 
 	status = osMutexRelease((osMutexId_t)arg);

--- a/tests/subsys/portability/cmsis_rtos_v2/src/semaphore.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/semaphore.c
@@ -8,7 +8,8 @@
 #include <zephyr/kernel.h>
 #include <cmsis_os2.h>
 
-#define TIMEOUT_TICKS   10
+#define WAIT_TICKS      5
+#define TIMEOUT_TICKS   (10 + WAIT_TICKS)
 #define STACKSZ         CONFIG_CMSIS_V2_THREAD_MAX_STACK_SIZE
 
 void thread_sema(void *arg)
@@ -21,7 +22,7 @@ void thread_sema(void *arg)
 		     "Semaphore acquired unexpectedly!");
 
 	/* Try taking semaphore after a TIMEOUT, but before release */
-	status = osSemaphoreAcquire((osSemaphoreId_t)arg, TIMEOUT_TICKS - 5);
+	status = osSemaphoreAcquire((osSemaphoreId_t)arg, WAIT_TICKS);
 	zassert_true(status == osErrorTimeout,
 		     "Semaphore acquired unexpectedly!");
 


### PR DESCRIPTION
In the mutex and semaphore tests, main thread will sleep for 10 ticks to wait for test thread to finish its work. And test thread will wait 5 ticks for timeout test. This means that test thread has 5 ticks to finish its job.
On platform where idle thread has low power mode enabled (e.g. it8xxx2_evb), latency in waking up from low power mode will cause main thread to wake up early before test thread has finished its work. This symptom will break next test (osThreadGetCount() not equal to 2). This change makes the test threads have a full 10 ticks to finish its job.

fixes: #57557