### PR TITLE
soc: stm32wl: Adding logging support to stm32wl soc

### DIFF
--- a/soc/arm/st_stm32/stm32wl/soc.c
+++ b/soc/arm/st_stm32/stm32wl/soc.c
@@ -18,6 +18,12 @@
 
 #include <stm32wlxx_ll_system.h>
 
+#include <zephyr/logging/log.h>
+
+#define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
+LOG_MODULE_REGISTER(soc);
+
+
 /**
  * @brief Perform basic hardware initialization at boot.
  *


### PR DESCRIPTION
As described in issue [#57655](https://github.com/zephyrproject-rtos/zephyr/issues/57655), the `STM32WL` SOC functions in `soc/arm/st_stm32/stm32wl` are missing a call to register the module with the logging module, which are needed by the power state specific code in `power.c` when logging is at the `DEBUG` level. Attempting to compile an application built for this SOC with `CONFIG_LOG_DEFAULT_LEVEL=4` will result in a compile-time error.

This commit adds a call to `LOG_MODULE_REGISTER` to the `soc.c` file which resolves the error.