### PR TITLE
Lnl change core count

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -42,6 +42,13 @@
 			cpu-power-states = <&d0i3 &d3>;
 		};
 
+		cpu4: cpu@4 {
+			device_type = "cpu";
+			compatible = "cdns,tensilica-xtensa-lx7";
+			reg = <4>;
+			cpu-power-states = <&d0i3 &d3>;
+		};
+
 	};
 
 	power-states {

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -17,6 +17,8 @@
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <0>;
 			cpu-power-states = <&d0i3 &d3>;
+			i-cache-line-size = <64>;
+			d-cache-line-size = <64>;
 		};
 
 		cpu1: cpu@1 {

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -874,7 +874,7 @@ config SMP_BOOT_DELAY
 config MP_NUM_CPUS
 	int "Number of CPUs/cores"
 	default MP_MAX_NUM_CPUS
-	range 1 4
+	range 1 5
 	help
 	  Number of multiprocessing-capable cores available to the
 	  multicpu API and SMP features.
@@ -882,7 +882,7 @@ config MP_NUM_CPUS
 config MP_MAX_NUM_CPUS
 	int "Maximum number of CPUs/cores"
 	default 1
-	range 1 4
+	range 1 5
 	help
 	  Maximum number of multiprocessing-capable cores available to the
 	  multicpu API and SMP features.

--- a/soc/xtensa/intel_adsp/ace/Kconfig.defconfig.ace20_lnl
+++ b/soc/xtensa/intel_adsp/ace/Kconfig.defconfig.ace20_lnl
@@ -9,6 +9,6 @@ config SOC
 	default "intel_ace20_lnl"
 
 config MP_MAX_NUM_CPUS
-	default 4
+	default 5
 
 endif


### PR DESCRIPTION
The ACE 2.0 LNL platform has 5 HIFI4 cores. Change number
of cores to enable 5th core on the platform.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>