### PR TITLE
ci: Fix footprint tracking workflow

### DIFF
--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -44,8 +44,11 @@ jobs:
       - name: Update PATH for west
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - name: Install pip packages
+
+      - name: Install packages
         run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-venv
           sudo pip3 install -U setuptools wheel pip gitpython
 
       - name: checkout
@@ -73,4 +76,10 @@ jobs:
         run: |
           export ZEPHYR_BASE=${PWD}
           ./scripts/footprint/track.py  -p scripts/footprint/plan.txt
+
+      - name: Upload footprint data
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip3 install awscli
           aws s3 sync  --quiet footprint_data/ s3://testing.zephyrproject.org/footprint_data/

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'VERSION'
       - '.github/workflows/footprint-tracking.yml'
+    branches:
+      - main
+      - v*-branch
     tags:
       # only publish v* tags, do not care about zephyr-v* which point to the
       # same commit

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   footprint-tracking:
     runs-on: ubuntu-22.04
-    if: github.repository == 'zephyrproject-rtos/zephyr'
+    if: github.repository_owner == 'zephyrproject-rtos'
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.26.2
       options: '--entrypoint /bin/bash'


### PR DESCRIPTION
This series fixes the CI footprint workflow, which is currently broken due to the `awscli` Python package being removed from the CI Docker image.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/57772