### PR TITLE
boards: xtensa: nxp_adsp_imx8m: include pinctrl dtsi in overlay

### DIFF
--- a/boards/xtensa/nxp_adsp_imx8m/nxp_adsp_imx8m.dts
+++ b/boards/xtensa/nxp_adsp_imx8m/nxp_adsp_imx8m.dts
@@ -7,7 +7,6 @@
 /dts-v1/;
 
 #include <nxp/nxp_imx8m.dtsi>
-#include <nxp/nxp_imx/mimx8ml8dvnlz-pinctrl.dtsi>
 
 / {
 	model = "nxp_adsp_imx8m";
@@ -15,17 +14,5 @@
 
 	chosen {
 		zephyr,sram = &sram0;
-	};
-};
-
-&pinctrl {
-	/omit-if-no-ref/ uart4_default: uart4_default {
-		group0 {
-			pinmux = <&iomuxc_uart4_rxd_uart_rx_uart4_rx>,
-				<&iomuxc_uart4_txd_uart_tx_uart4_tx>;
-			bias-pull-up;
-			slew-rate = "slow";
-			drive-strength = "x1";
-		};
 	};
 };

--- a/boards/xtensa/nxp_adsp_imx8m/nxp_adsp_imx8m_uart.overlay
+++ b/boards/xtensa/nxp_adsp_imx8m/nxp_adsp_imx8m_uart.overlay
@@ -4,10 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <nxp/nxp_imx/mimx8ml8dvnlz-pinctrl.dtsi>
+
 / {
 	chosen {
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
+	};
+};
+
+&pinctrl {
+	/omit-if-no-ref/ uart4_default: uart4_default {
+		group0 {
+			pinmux = <&iomuxc_uart4_rxd_uart_rx_uart4_rx>,
+				<&iomuxc_uart4_txd_uart_tx_uart4_tx>;
+			bias-pull-up;
+			slew-rate = "slow";
+			drive-strength = "x1";
+		};
 	};
 };
 


### PR DESCRIPTION
Move the pinctrl dtsi (mimx8ml8dvnlz-pinctrl.dtsi) from board dts to _uart overlay since, now, for nxp_adsp_imx8m, this is used only with uart support for certain samples.

This also fixes a build error on SOF, where we don't take the nxp_hal and the dtsi cannot be found.