### PR TITLE
net: openthread: allow to configure CSL debugging

### DIFF
--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -92,6 +92,12 @@ config IEEE802154_CSL_ENDPOINT
 	  Make this device a CSL (coordinated sampled listening) endpoint with delayed
 	  reception handling and CSL IE injection.
 
+config IEEE802154_CSL_DEBUG
+	bool "Support for CSL debugging"
+	depends on IEEE802154_CSL_ENDPOINT
+	help
+	  Enable support for CSL debugging by avoiding sleep state in favor of receive state.
+
 config IEEE802154_SELECTIVE_TXPOWER
 	bool "Support selective TX power setting"
 	help

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -1019,7 +1019,15 @@ void nrf_802154_receive_failed(nrf_802154_rx_error_t error, uint32_t id)
 #if defined(CONFIG_IEEE802154_CSL_ENDPOINT)
 	if (id == DRX_SLOT_RX) {
 		__ASSERT_NO_MSG(nrf5_data.event_handler);
+#if !defined(CONFIG_IEEE802154_CSL_DEBUG)
+		/* When CSL debug option is used we intentionally avoid notifying the higher layer
+		 * about the finalization of a DRX slot, so that the radio stays in receive state
+		 * for receiving "out of slot" frames.
+		 * As a side effect, regular failure notifications would be reported with the
+		 * incorrect ID.
+		 */
 		nrf5_data.event_handler(dev, IEEE802154_EVENT_SLEEP, NULL);
+#endif
 		if (error == NRF_802154_RX_ERROR_DELAYED_TIMEOUT) {
 			return;
 		}


### PR DESCRIPTION
Add new `IEEE802154_CSL_DEBUG` Kconfig option that, when enabled, prevents the radio to sleep after a delayed reception is finished.

This allows to debug CSL timing issues due to accuracy drifts in communications between receiver and transmitter.