### PR TITLE
mcumgr: Bootloader info request definition

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -393,6 +393,11 @@ MCUboot
     with downgrade  prevention enabled. This option is automatically selected for
     DirectXIP mode and is available for both swap modes.
 
+  * Added :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY`
+    that allows to inform application that the on-board MCUboot will overwrite
+    the primary slot with secondary slot contents, without saving the original
+    image in primary slot.
+
 Storage
 *******
 

--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
@@ -24,6 +24,7 @@ extern "C" {
 #define OS_MGMT_ID_RESET		5
 #define OS_MGMT_ID_MCUMGR_PARAMS	6
 #define OS_MGMT_ID_INFO			7
+#define OS_MGMT_ID_BOOTLOADER_INFO	8
 
 /**
  * Command result codes for OS management group.
@@ -37,6 +38,9 @@ enum os_mgmt_err_code_t {
 
 	/** The provided format value is not valid. */
 	OS_MGMT_ERR_INVALID_FORMAT,
+
+	/** Query was not recognized. */
+	OS_MGMT_ERR_QUERY_YIELDS_NO_ANSWER,
 };
 
 /* Bitmask values used by the os info command handler. Note that the width of this variable is

--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -175,6 +175,18 @@ config MCUBOOT_BOOTLOADER_MODE_SWAP_SCRATCH
 	  MCUBOOT_BOOTLOADER_NO_DOWNGRADE should also be selected
 	  if MCUboot has been built with MCUBOOT_DOWNGRADE_PREVENTION.
 
+config MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY
+	bool "MCUboot has been configured to just overwrite primary slot"
+	select MCUBOOT_BOOTLOADER_MODE_HAS_NO_DOWNGRADE
+	help
+	  MCUboot will take contents of secondary slot of an image and will
+	  overwrite primary slot with it.
+	  In this mode it is not possible to revert back to previous version
+	  as it is not stored in the secondary slot.
+	  This mode supports MCUBOOT_BOOTLOADER_NO_DOWNGRADE which means
+	  that the overwrite will not happen unless the version of secondary
+	  slot is higher than the version in primary slot.
+
 config MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
 	bool "MCUboot has been configured for DirectXIP operation"
 	select MCUBOOT_BOOTLOADER_MODE_HAS_NO_DOWNGRADE

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2018-2021 mcumgr authors
-# Copyright (c) 2022 Nordic Semiconductor ASA
+# Copyright (c) 2022-2023 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -11,6 +11,12 @@ zephyr_library(mgmt_mcumgr_grp_os)
 zephyr_library_sources(src/os_mgmt.c)
 
 zephyr_library_include_directories(include)
+
+if (CONFIG_MCUMGR_GRP_OS_BOOTLOADER_INFO)
+    zephyr_include_directories(
+        ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/bootutil/include
+    )
+endif()
 
 if(DEFINED CONFIG_MCUMGR_GRP_OS_INFO_BUILD_DATE_TIME)
   set(MCUMGR_GRP_OS_INFO_BUILD_DATE_TIME_DIR ${PROJECT_BINARY_DIR}/os_mgmt_auto)

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
@@ -173,6 +173,16 @@ config MCUMGR_GRP_OS_INFO_BUILD_DATE_TIME
 
 endif
 
+if BOOTLOADER_MCUBOOT
+
+config MCUMGR_GRP_OS_BOOTLOADER_INFO
+	bool "Bootloader information"
+	help
+	  Allows to query MCUmgr about bootloader used by device and various bootloader
+	  parameters.
+
+endif # BOOTLOADER_MCUBOOT
+
 module = MCUMGR_GRP_OS
 module-str = mcumgr_grp_os
 source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
Specification for MCUmgr OS group command allowing to query for bootloader information.

On top of https://github.com/zephyrproject-rtos/zephyr/pull/63053 that adds downgrade prevention Kconfig.