### PR TITLE
 input: convert the nuvoton npcx keyboard scan driver to input

### DIFF
--- a/boards/arm/npcx7m6fb_evb/Kconfig.defconfig
+++ b/boards/arm/npcx7m6fb_evb/Kconfig.defconfig
@@ -10,3 +10,6 @@ endif # BOARD_NPCX7M6FB_EVB
 
 config SYS_CLOCK_TICKS_PER_SEC
 	default 1000
+
+config INPUT
+	default y if KSCAN

--- a/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
+++ b/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
@@ -16,7 +16,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart1;
 		zephyr,flash = &flash0;
-		zephyr,keyboard-scan = &kscan0;
+		zephyr,keyboard-scan = &kscan_input;
 	};
 
 	aliases {
@@ -31,7 +31,7 @@
 		/* For samples/drivers/spi_flash */
 		spi-flash0 = &int_flash;
 		/* For kscan test suites */
-		kscan0 = &kscan0;
+		kscan0 = &kscan_input;
 	};
 
 	pwmleds {
@@ -118,7 +118,7 @@
 	pinctrl-names = "default";
 };
 
-&kscan0 {
+&kbd {
 	/* Demonstrate a 6 x 8 keyboard matrix on evb */
 	pinctrl-0 = <&ksi0_gp31 /* KSI0 PIN31 */
 		     &ksi1_gp30 /* KSI1 PIN30 */
@@ -139,4 +139,8 @@
 	row-size = <8>;
 	col-size = <6>;
 	status = "okay";
+
+	kscan_input: kscan-input {
+		compatible = "zephyr,kscan-input";
+	};
 };

--- a/boards/arm/npcx9m6f_evb/Kconfig.defconfig
+++ b/boards/arm/npcx9m6f_evb/Kconfig.defconfig
@@ -10,3 +10,6 @@ endif # BOARD_NPCX9M6F_EVB
 
 config SYS_CLOCK_TICKS_PER_SEC
 	default 1000
+
+config INPUT
+	default y if KSCAN

--- a/boards/arm/npcx9m6f_evb/npcx9m6f_evb.dts
+++ b/boards/arm/npcx9m6f_evb/npcx9m6f_evb.dts
@@ -16,7 +16,7 @@
 		zephyr,sram = &sram0;
 		zephyr,console = &uart1;
 		zephyr,flash = &flash0;
-		zephyr,keyboard-scan = &kscan0;
+		zephyr,keyboard-scan = &kscan_input;
 	};
 
 	aliases {
@@ -34,7 +34,7 @@
 		/* For samples/drivers/spi_flash */
 		spi-flash0 = &int_flash;
 		/* For kscan test suites */
-		kscan0 = &kscan0;
+		kscan0 = &kscan_input;
 	};
 
 	leds-pwm {
@@ -130,7 +130,7 @@
 	pinctrl-names = "default";
 };
 
-&kscan0 {
+&kbd {
 	/* Demonstrate a 13 x 8 keyboard matrix on evb */
 	pinctrl-0 = <&ksi0_gp31 /* KSI0 PIN31 */
 		     &ksi1_gp30 /* KSI1 PIN30 */
@@ -158,4 +158,8 @@
 	row-size = <8>;
 	col-size = <13>;
 	status = "okay";
+
+	kscan_input: kscan-input {
+		compatible = "zephyr,kscan-input";
+	};
 };

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -126,6 +126,9 @@ Changes in this release
     option from ``KSCAN_SDL`` to :kconfig:option:`CONFIG_INPUT_SDL_TOUCH` and the
     compatible from ``zephyr,sdl-kscan`` to
     :dtcompatible:`zephyr,input-sdl-touch`.
+  * ``nuvoton,npcx-kscan`` moved to :ref:`input`, renamed the Kconfig option
+    names from ``KSCAN_NPCX_...`` to ``INPUT_NPCX_KBD...`` and the compatible
+    from ``nuvoton,npcx-kscan`` to :dtcompatible:`nuvoton,npcx-kbd`.
   * Touchscreen drivers converted to use the input APIs can use the
     :dtcompatible:`zephyr,kscan-input` driver to maintain Kscan compatilibity.
 

--- a/drivers/input/CMakeLists.txt
+++ b/drivers/input/CMakeLists.txt
@@ -5,4 +5,5 @@ zephyr_library_property(ALLOW_EMPTY TRUE)
 
 zephyr_library_sources_ifdef(CONFIG_INPUT_FT5336 input_ft5336.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_GPIO_KEYS input_gpio_keys.c)
+zephyr_library_sources_ifdef(CONFIG_INPUT_NPCX_KBD input_npcx_kbd.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_SDL_TOUCH input_sdl_touch.c)

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -7,6 +7,7 @@ menu "Input drivers"
 
 source "drivers/input/Kconfig.ft5336"
 source "drivers/input/Kconfig.gpio_keys"
+source "drivers/input/Kconfig.npcx"
 source "drivers/input/Kconfig.sdl"
 
 endmenu # Input Drivers

--- a/drivers/input/Kconfig.npcx
+++ b/drivers/input/Kconfig.npcx
@@ -1,43 +1,43 @@
-# NPCX Keyboard Scan driver configuration options
+# NPCX Keyboard scan driver configuration options
 
 # Copyright (c) 2022 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig KSCAN_NPCX
-	bool "Nuvoton NPCX embedded controller (EC) Keyboard Scan (KSCAN) driver"
+menuconfig INPUT_NPCX_KBD
+	bool "Nuvoton NPCX embedded controller (EC) keyboard scan driver"
 	default y
-	depends on DT_HAS_NUVOTON_NPCX_KSCAN_ENABLED
+	depends on DT_HAS_NUVOTON_NPCX_KBD_ENABLED
 	select MULTITHREADING
 	help
-	  This option enables the KSCAN driver for NPCX family of
+	  This option enables the keyboard scan driver for NPCX family of
 	  processors.
 
-if  KSCAN_NPCX
+if  INPUT_NPCX_KBD
 
-config KSCAN_NPCX_POLL_PERIOD_MS
+config INPUT_NPCX_KBD_POLL_PERIOD_MS
 	int "Keyscan NPCX Poll Period"
 	default 5
 	help
 	  Defines the poll period in msecs between between matrix scans.
 
-config KSCAN_NPCX_KSO_HIGH_DRIVE
+config INPUT_NPCX_KBD_KSO_HIGH_DRIVE
 	bool "Select quasi-bidirectional buffers for KSO pins"
 	default y
 	help
 	  Select quasi-bidirectional buffers for KSO pins to reduce the
 	  low-to-high transition time.
 
-config KSCAN_NPCX_POLL_COL_OUTPUT_SETTLE_TIME_US
+config INPUT_NPCX_KBD_POLL_COL_OUTPUT_SETTLE_TIME_US
 	int "keyboard matrix poll column output settle time"
 	default 50
 	help
 	  Delay (us) between setting column output and waiting for it
 	  to settle
 
-config KSCAN_NPCX_THREAD_STACK_SIZE
+config INPUT_NPCX_KBD_THREAD_STACK_SIZE
 	int "Stack size for the kscan thread"
 	default 1024
 	help
 	  Size of the stack used for the kscan thread.
 
-endif # KSCAN_NPCX
+endif # INPUT_NPCX_KBD

--- a/drivers/input/input_npcx_kbd.c
+++ b/drivers/input/input_npcx_kbd.c
@@ -478,6 +478,8 @@ static int input_npcx_kbd_init(const struct device *dev)
 			(k_thread_entry_t)kbd_matrix_polling_thread, (void *)dev, NULL, NULL,
 			K_PRIO_COOP(4), 0, K_NO_WAIT);
 
+	k_thread_name_set(&data->thread, "npcx-kbd");
+
 	return 0;
 }
 

--- a/drivers/input/input_npcx_kbd.c
+++ b/drivers/input/input_npcx_kbd.c
@@ -5,19 +5,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nuvoton_npcx_kscan
+#define DT_DRV_COMPAT nuvoton_npcx_kbd
 
 #include "soc_miwu.h"
 
 #include <zephyr/drivers/clock_control.h>
-#include <zephyr/drivers/kscan.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/input/input.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
-#define LOG_LEVEL CONFIG_KSCAN_LOG_LEVEL
-LOG_MODULE_REGISTER(kscan_npcx);
+#define LOG_LEVEL CONFIG_INPUT_LOG_LEVEL
+LOG_MODULE_REGISTER(input_npcx_kbd);
 
 #define KEYBOARD_COLUMN_DRIVE_ALL  -2
 #define KEYBOARD_COLUMN_DRIVE_NONE -1
@@ -30,7 +30,7 @@ LOG_MODULE_REGISTER(kscan_npcx);
 #define HAS_GHOSTING_ENABLED !DT_INST_PROP(0, no_ghostkey_check)
 
 /* Driver config */
-struct kscan_npcx_config {
+struct input_npcx_kbd_config {
 	/* keyboard scan controller base address */
 	struct kbs_reg *base;
 	/* clock configuration */
@@ -49,7 +49,7 @@ struct kscan_npcx_config {
 	struct npcx_wui wui_maps[];
 };
 
-struct kscan_npcx_data {
+struct input_npcx_kbd_data {
 	/* variables in usec units */
 	int64_t poll_timeout;
 	uint32_t poll_period;
@@ -66,25 +66,23 @@ struct kscan_npcx_data {
 	uint8_t scan_clk_cycle[SCAN_OCURRENCES];
 	struct k_sem poll_lock;
 	uint8_t scan_cycles_idx;
-	kscan_callback_t callback;
 	struct k_thread thread;
-	atomic_t enable_scan;
 
-	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_KSCAN_NPCX_THREAD_STACK_SIZE);
+	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_INPUT_NPCX_KBD_THREAD_STACK_SIZE);
 };
 
 /* Keyboard Scan local functions */
-static void kscan_npcx_ksi_isr(const struct device *dev, struct npcx_wui *wui)
+static void input_npcx_kbd_ksi_isr(const struct device *dev, struct npcx_wui *wui)
 {
 	ARG_UNUSED(wui);
-	struct kscan_npcx_data *const data = dev->data;
+	struct input_npcx_kbd_data *const data = dev->data;
 
 	k_sem_give(&data->poll_lock);
 }
 
-static int kscan_npcx_resume_detection(const struct device *dev, bool resume)
+static int input_npcx_kbd_resume_detection(const struct device *dev, bool resume)
 {
-	const struct kscan_npcx_config *const config = dev->config;
+	const struct input_npcx_kbd_config *const config = dev->config;
 
 	if (resume) {
 		irq_enable(config->irq);
@@ -95,9 +93,9 @@ static int kscan_npcx_resume_detection(const struct device *dev, bool resume)
 	return 0;
 }
 
-static int kscan_npcx_drive_column(const struct device *dev, int col)
+static int input_npcx_kbd_drive_column(const struct device *dev, int col)
 {
-	const struct kscan_npcx_config *config = dev->config;
+	const struct input_npcx_kbd_config *config = dev->config;
 	struct kbs_reg *const inst = config->base;
 	uint32_t mask;
 
@@ -128,9 +126,9 @@ static int kscan_npcx_drive_column(const struct device *dev, int col)
 	return 0;
 }
 
-static int kscan_npcx_read_row(const struct device *dev)
+static int input_npcx_kbd_read_row(const struct device *dev)
 {
-	const struct kscan_npcx_config *config = dev->config;
+	const struct input_npcx_kbd_config *config = dev->config;
 	struct kbs_reg *const inst = config->base;
 	int val;
 
@@ -144,7 +142,7 @@ static int kscan_npcx_read_row(const struct device *dev)
 
 static bool is_matrix_ghosting(const struct device *dev, const uint8_t *state)
 {
-	const struct kscan_npcx_config *const config = dev->config;
+	const struct input_npcx_kbd_config *const config = dev->config;
 
 	/*
 	 * matrix keyboard designs are suceptible to ghosting.
@@ -189,30 +187,30 @@ static bool is_matrix_ghosting(const struct device *dev, const uint8_t *state)
 
 static bool read_keyboard_matrix(const struct device *dev, uint8_t *new_state)
 {
-	const struct kscan_npcx_config *const config = dev->config;
+	const struct input_npcx_kbd_config *const config = dev->config;
 	int row;
 	uint8_t key_event = 0U;
 
 	for (int col = 0; col < config->col_size; col++) {
-		kscan_npcx_drive_column(dev, col);
+		input_npcx_kbd_drive_column(dev, col);
 
 		/* Allow the matrix to stabilize before reading it */
-		k_busy_wait(CONFIG_KSCAN_NPCX_POLL_COL_OUTPUT_SETTLE_TIME_US);
+		k_busy_wait(CONFIG_INPUT_NPCX_KBD_POLL_COL_OUTPUT_SETTLE_TIME_US);
 
-		row = kscan_npcx_read_row(dev);
+		row = input_npcx_kbd_read_row(dev);
 		new_state[col] = row & 0xFF;
 		key_event |= row;
 	}
 
-	kscan_npcx_drive_column(dev, KEYBOARD_COLUMN_DRIVE_NONE);
+	input_npcx_kbd_drive_column(dev, KEYBOARD_COLUMN_DRIVE_NONE);
 
 	return key_event != 0U;
 }
 
 static void update_matrix_state(const struct device *dev, uint8_t *matrix_new_state)
 {
-	const struct kscan_npcx_config *const config = dev->config;
-	struct kscan_npcx_data *const data = dev->data;
+	const struct input_npcx_kbd_config *const config = dev->config;
+	struct input_npcx_kbd_data *const data = dev->data;
 	uint32_t cycles_now = k_cycle_get_32();
 	uint8_t row_changed = 0U;
 	uint8_t deb_col;
@@ -289,17 +287,18 @@ static void update_matrix_state(const struct device *dev, uint8_t *matrix_new_st
 			 * application about the keys pressed.
 			 */
 			data->matrix_stable_state[c] ^= mask;
-			if (data->callback) {
-				data->callback(dev, r, c, row_bit ? true : false);
-			}
+
+			input_report_abs(dev, INPUT_ABS_X, c, false, K_FOREVER);
+			input_report_abs(dev, INPUT_ABS_Y, r, false, K_FOREVER);
+			input_report_key(dev, INPUT_BTN_TOUCH, row_bit, true, K_FOREVER);
 		}
 	}
 }
 
 static bool check_key_events(const struct device *dev)
 {
-	const struct kscan_npcx_config *const config = dev->config;
-	struct kscan_npcx_data *const data = dev->data;
+	const struct input_npcx_kbd_config *const config = dev->config;
+	struct input_npcx_kbd_data *const data = dev->data;
 	uint8_t *matrix_new_state = data->matrix_new_state;
 	bool key_pressed = false;
 
@@ -325,15 +324,15 @@ static bool check_key_events(const struct device *dev)
 	return key_pressed;
 }
 
-static void ksan_matrix_poll(const struct device *dev)
+static void kbd_matrix_poll(const struct device *dev)
 {
-	struct kscan_npcx_data *const data = dev->data;
+	struct input_npcx_kbd_data *const data = dev->data;
 	uint64_t poll_time_end = sys_clock_timeout_end_calc(K_USEC(data->poll_timeout));
 	uint32_t current_cycles;
 	uint32_t cycles_diff;
 	uint32_t wait_period;
 
-	while (atomic_get(&data->enable_scan) == 1U) {
+	while (true) {
 		uint32_t start_period_cycles = k_cycle_get_32();
 
 		if (check_key_events(dev)) {
@@ -370,32 +369,32 @@ static void ksan_matrix_poll(const struct device *dev)
 	}
 }
 
-static void kscan_matrix_polling_thread(const struct device *dev, void *dummy2, void *dummy3)
+static void kbd_matrix_polling_thread(const struct device *dev, void *dummy2, void *dummy3)
 {
-	struct kscan_npcx_data *const data = dev->data;
+	struct input_npcx_kbd_data *const data = dev->data;
 
 	ARG_UNUSED(dummy2);
 	ARG_UNUSED(dummy3);
 
 	while (true) {
 		/* Enable interrupt of KSI pins */
-		kscan_npcx_resume_detection(dev, true);
+		input_npcx_kbd_resume_detection(dev, true);
 
-		kscan_npcx_drive_column(dev, KEYBOARD_COLUMN_DRIVE_ALL);
+		input_npcx_kbd_drive_column(dev, KEYBOARD_COLUMN_DRIVE_ALL);
 		k_sem_take(&data->poll_lock, K_FOREVER);
 		LOG_DBG("Start KB scan!!");
 
 		/* Disable interrupt of KSI pins and start polling */
-		kscan_npcx_resume_detection(dev, false);
+		input_npcx_kbd_resume_detection(dev, false);
 
-		ksan_matrix_poll(dev);
+		kbd_matrix_poll(dev);
 	}
 }
 
-static void kscan_npcx_init_ksi_wui_callback(const struct device *dev,
-					     struct miwu_callback *callback,
-					     const struct npcx_wui *wui,
-					     miwu_dev_callback_handler_t handler)
+static void input_npcx_kbd_init_ksi_wui_callback(const struct device *dev,
+						 struct miwu_callback *callback,
+						 const struct npcx_wui *wui,
+						 miwu_dev_callback_handler_t handler)
 {
 	/* KSI signal which has no wake-up input source */
 	if (wui->table == NPCX_MIWU_TABLE_NONE) {
@@ -411,11 +410,11 @@ static void kscan_npcx_init_ksi_wui_callback(const struct device *dev,
 	npcx_miwu_irq_enable(wui);
 }
 
-static int kscan_npcx_init(const struct device *dev)
+static int input_npcx_kbd_init(const struct device *dev)
 {
 	const struct device *clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
-	const struct kscan_npcx_config *const config = dev->config;
-	struct kscan_npcx_data *const data = dev->data;
+	const struct input_npcx_kbd_config *const config = dev->config;
+	struct input_npcx_kbd_data *const data = dev->data;
 	struct kbs_reg *const inst = config->base;
 	int ret;
 
@@ -448,76 +447,44 @@ static int kscan_npcx_init(const struct device *dev)
 	 * Select quasi-bidirectional buffers for KSO pins. It reduces the
 	 * low-to-high transition time. This feature only supports in npcx7.
 	 */
-	if (IS_ENABLED(CONFIG_KSCAN_NPCX_KSO_HIGH_DRIVE)) {
+	if (IS_ENABLED(CONFIG_INPUT_NPCX_KBD_KSO_HIGH_DRIVE)) {
 		SET_FIELD(inst->KBSCTL, NPCX_KBSCTL_KBHDRV_FIELD, 0x01);
 	}
 
 	/* Drive all column lines to low for detection any key press */
-	kscan_npcx_drive_column(dev, KEYBOARD_COLUMN_DRIVE_NONE);
+	input_npcx_kbd_drive_column(dev, KEYBOARD_COLUMN_DRIVE_NONE);
 
 	/* Configure wake-up input and callback for keyboard input signal */
 	for (int i = 0; i < config->row_size; i++)
-		kscan_npcx_init_ksi_wui_callback(dev, &data->ksi_callback[i], &config->wui_maps[i],
-						 kscan_npcx_ksi_isr);
+		input_npcx_kbd_init_ksi_wui_callback(
+				dev, &data->ksi_callback[i], &config->wui_maps[i],
+				input_npcx_kbd_ksi_isr);
 
-	/* Configure pin-mux for kscan device */
+	/* Configure pin-mux for keyboard scan device */
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
-		LOG_ERR("kscan pinctrl setup failed (%d)", ret);
+		LOG_ERR("keyboard scan pinctrl setup failed (%d)", ret);
 		return ret;
 	}
 
-	/* Initialize semaphore usbed by kscan task and driver */
+	/* Initialize semaphore usbed by keyboard scan task and driver */
 	k_sem_init(&data->poll_lock, 0, 1);
 
 	/* Time figures are transformed from msec to usec */
-	data->poll_period = (uint32_t)(CONFIG_KSCAN_NPCX_POLL_PERIOD_MS * USEC_PER_MSEC);
+	data->poll_period = (uint32_t)(CONFIG_INPUT_NPCX_KBD_POLL_PERIOD_MS * USEC_PER_MSEC);
 	data->poll_timeout = 100 * USEC_PER_MSEC;
 
-	k_thread_create(&data->thread, data->thread_stack, CONFIG_KSCAN_NPCX_THREAD_STACK_SIZE,
-			(void (*)(void *, void *, void *))kscan_matrix_polling_thread, (void *)dev,
+	k_thread_create(&data->thread, data->thread_stack,
+			CONFIG_INPUT_NPCX_KBD_THREAD_STACK_SIZE,
+			(void (*)(void *, void *, void *))kbd_matrix_polling_thread, (void *)dev,
 			NULL, NULL, K_PRIO_COOP(4), 0, K_NO_WAIT);
 
 	return 0;
 }
 
-static int kscan_npcx_configure(const struct device *dev, kscan_callback_t callback)
-{
-	struct kscan_npcx_data *const data = dev->data;
-
-	if (!callback) {
-		return -EINVAL;
-	}
-	data->callback = callback;
-
-	return 0;
-}
-
-static int kscan_npcx_enable_interface(const struct device *dev)
-{
-	struct kscan_npcx_data *const data = dev->data;
-
-	atomic_set(&data->enable_scan, 1);
-
-	return 0;
-}
-
-static int kscan_npcx_disable_interface(const struct device *dev)
-{
-	struct kscan_npcx_data *const data = dev->data;
-
-	atomic_set(&data->enable_scan, 0);
-
-	return 0;
-}
-static const struct kscan_driver_api kscan_npcx_driver_api = {
-	.config = kscan_npcx_configure,
-	.enable_callback = kscan_npcx_enable_interface,
-	.disable_callback = kscan_npcx_disable_interface,
-};
-
 PINCTRL_DT_INST_DEFINE(0);
-static const struct kscan_npcx_config kscan_cfg_0 = {
+
+static const struct input_npcx_kbd_config npcx_kbd_cfg = {
 	.base = (struct kbs_reg *)DT_INST_REG_ADDR(0),
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 	.clk_cfg = NPCX_DT_CLK_CFG_ITEM(0),
@@ -530,10 +497,10 @@ static const struct kscan_npcx_config kscan_cfg_0 = {
 	.deb_time_rel = DT_INST_PROP(0, debounce_up_ms),
 };
 
-static struct kscan_npcx_data kscan_data_0;
+static struct input_npcx_kbd_data npcx_kbd_data;
 
-DEVICE_DT_INST_DEFINE(0, kscan_npcx_init, NULL, &kscan_data_0, &kscan_cfg_0, POST_KERNEL,
-		      CONFIG_KSCAN_INIT_PRIORITY, &kscan_npcx_driver_api);
+DEVICE_DT_INST_DEFINE(0, input_npcx_kbd_init, NULL, &npcx_kbd_data, &npcx_kbd_cfg, POST_KERNEL,
+		      CONFIG_INPUT_INIT_PRIORITY, NULL);
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
-	     "only one 'nuvoton_npcx_kscan' compatible node can be supported");
+	     "only one nuvoton,npcx-kbd compatible node can be supported");

--- a/drivers/kscan/CMakeLists.txt
+++ b/drivers/kscan/CMakeLists.txt
@@ -8,7 +8,6 @@ zephyr_library_sources_ifdef(CONFIG_KSCAN_XEC		kscan_mchp_xec.c)
 zephyr_library_sources_ifdef(CONFIG_KSCAN_HT16K33	kscan_ht16k33.c)
 zephyr_library_sources_ifdef(CONFIG_KSCAN_CST816S	kscan_cst816s.c)
 zephyr_library_sources_ifdef(CONFIG_KSCAN_CAP1203	kscan_cap1203.c)
-zephyr_library_sources_ifdef(CONFIG_KSCAN_NPCX		kscan_npcx.c)
 zephyr_library_sources_ifdef(CONFIG_KSCAN_XPT2046	kscan_xpt2046.c)
 zephyr_library_sources_ifdef(CONFIG_KSCAN_INPUT		kscan_input.c)
 

--- a/drivers/kscan/Kconfig
+++ b/drivers/kscan/Kconfig
@@ -16,7 +16,6 @@ source "drivers/kscan/Kconfig.xec"
 source "drivers/kscan/Kconfig.ht16k33"
 source "drivers/kscan/Kconfig.cst816s"
 source "drivers/kscan/Kconfig.cap1203"
-source "drivers/kscan/Kconfig.npcx"
 source "drivers/kscan/Kconfig.xpt2046"
 source "drivers/kscan/Kconfig.input"
 

--- a/dts/arm/nuvoton/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx.dtsi
@@ -527,8 +527,8 @@
 			status = "disabled";
 		};
 
-		kscan0: kscan@400a3000 {
-			compatible = "nuvoton,npcx-kscan";
+		kbd: kbd@400a3000 {
+			compatible = "nuvoton,npcx-kbd";
 			reg = <0x400a3000 0x2000>;
 			interrupts = <49 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB1 NPCX_PWDWN_CTL1 0>;

--- a/dts/bindings/input/nuvoton,npcx-kbd.yaml
+++ b/dts/bindings/input/nuvoton,npcx-kbd.yaml
@@ -1,11 +1,11 @@
 # Copyright (c) 2022 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Nuvoton, NPCX keyboard scan controller
+description: Nuvoton NPCX keyboard scan controller
 
-compatible: "nuvoton,npcx-kscan"
+compatible: "nuvoton,npcx-kbd"
 
-include: [kscan.yaml, pinctrl-device.yaml]
+include: [base.yaml, pinctrl-device.yaml]
 
 properties:
   reg:


### PR DESCRIPTION
Convert the Nuvoton NPCX keyboard scan driver to the input subsystem.

This specific driver implements a scanning thread, debouncing and ghosting detection. Some of these functionalities are duplicated in other keyboard scanning drivers, some are unique to this.

The idea is to followup by decoupling the common functionalities in common code so it can be reused by other drivers, implementation would follow the `I2C_BITBANG` example, then we could convert the other keyboard scan driver as well and hopefully come up with something that could be reused by ZMK as well.

Previous effort on this front were https://github.com/zephyrproject-rtos/zephyr/issues/52355 and https://github.com/zephyrproject-rtos/zephyr/pull/42923, may file a new RFC down the road but for now I'm just sending this to change the driver API and fix some coding style nits I bumped into.

Tested on a custom board against the current kscan and input dump samples.