### PR TITLE
profiling: Fix missing gmon.out file when running with C++

### DIFF
--- a/boards/posix/native_posix/main.c
+++ b/boards/posix/native_posix/main.c
@@ -39,6 +39,11 @@ void posix_exit(int exit_code)
 {
 	static int max_exit_code;
 
+#if defined(CONFIG_GPROF) && defined(CONFIG_CPP)
+	extern void _mcleanup(void);
+	_mcleanup();
+#endif
+
 	max_exit_code = MAX(exit_code, max_exit_code);
 	/*
 	 * posix_soc_clean_up may not return if this is called from a SW thread,


### PR DESCRIPTION
I'm not sure why the atexit() hook wasn't being called when C++ is enabled, but adding a direct call to _mcleanup() which is a part of gprof fixes the issue. Note this will not work if the application calls exit() which means it's only a halfway fix.

- [x] Generates gmon.out on posix_exit() call
- [x] Generates gmon.out on Ctrl-C
- [ ] Generates gmon.out on exit() call

Reference #57763