### PR TITLE
Bluetooth: id: Fix uninitialized RPA

### DIFF
--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -382,7 +382,7 @@ struct bt_dev {
 	uint8_t			irk[CONFIG_BT_ID_MAX][16];
 
 	/* Only 1 RPA per identity */
-	bt_addr_le_t		rpa[CONFIG_BT_ID_MAX];
+	bt_addr_t		rpa[CONFIG_BT_ID_MAX];
 
 	/* Work used for RPA rotation */
 	struct k_work_delayable rpa_update;

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -208,7 +208,7 @@ static void adv_rpa_expired(struct bt_le_ext_adv *adv)
 	    adv->cb && adv->cb->rpa_expired) {
 		rpa_invalid = adv->cb->rpa_expired(adv);
 		if (rpa_invalid) {
-			bt_addr_le_copy(&bt_dev.rpa[adv->id], BT_ADDR_LE_NONE);
+			bt_addr_copy(&bt_dev.rpa[adv->id], BT_ADDR_NONE);
 		}
 	}
 #endif
@@ -363,14 +363,14 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 		return 0;
 	}
 
-	if (bt_addr_le_eq(&bt_dev.rpa[adv->id], BT_ADDR_LE_NONE)) {
-		err = bt_rpa_create(bt_dev.irk[adv->id], &bt_dev.rpa[adv->id].a);
+	if (bt_addr_eq(&bt_dev.rpa[adv->id], BT_ADDR_NONE)) {
+		err = bt_rpa_create(bt_dev.irk[adv->id], &bt_dev.rpa[adv->id]);
 		if (err) {
 			return err;
 		}
 	}
 
-	err = bt_id_set_adv_random_addr(adv, &bt_dev.rpa[adv->id].a);
+	err = bt_id_set_adv_random_addr(adv, &bt_dev.rpa[adv->id]);
 	if (!err) {
 		atomic_set_bit(adv->flags, BT_ADV_RPA_VALID);
 	}
@@ -384,7 +384,7 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_LOG_SNIFFER_INFO)) {
-		LOG_INF("RPA: %s", bt_addr_str(&bt_dev.rpa[adv->id].a));
+		LOG_INF("RPA: %s", bt_addr_str(&bt_dev.rpa[adv->id]));
 	}
 
 	return 0;
@@ -1220,7 +1220,7 @@ static int id_create(uint8_t id, bt_addr_le_t *addr, uint8_t *irk)
 				memcpy(irk, &bt_dev.irk[id], 16);
 			}
 		}
-		bt_addr_le_copy(&bt_dev.rpa[id], BT_ADDR_LE_NONE);
+		bt_addr_copy(&bt_dev.rpa[id], BT_ADDR_NONE);
 	}
 #endif
 	/* Only store if stack was already initialized. Before initialization
@@ -2036,7 +2036,7 @@ int bt_id_init(void)
 	int err;
 
 #if defined(CONFIG_BT_PRIVACY)
-	bt_addr_le_copy(&bt_dev.rpa[BT_ID_DEFAULT], BT_ADDR_LE_NONE);
+	bt_addr_copy(&bt_dev.rpa[BT_ID_DEFAULT], BT_ADDR_NONE);
 	k_work_init_delayable(&bt_dev.rpa_update, rpa_timeout);
 #endif
 

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -2035,6 +2035,11 @@ int bt_id_init(void)
 {
 	int err;
 
+#if defined(CONFIG_BT_PRIVACY)
+	bt_addr_le_copy(&bt_dev.rpa[BT_ID_DEFAULT], BT_ADDR_LE_NONE);
+	k_work_init_delayable(&bt_dev.rpa_update, rpa_timeout);
+#endif
+
 	if (!IS_ENABLED(CONFIG_BT_SETTINGS) && !bt_dev.id_count) {
 		LOG_DBG("No user identity. Trying to set public.");
 
@@ -2065,10 +2070,6 @@ int bt_id_init(void)
 			return err;
 		}
 	}
-
-#if defined(CONFIG_BT_PRIVACY)
-	k_work_init_delayable(&bt_dev.rpa_update, rpa_timeout);
-#endif
 
 	return 0;
 }

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/main.c
@@ -25,7 +25,7 @@ static void fff_reset_rule_before(const struct ztest_unit_test *test, void *fixt
 	memset(&bt_dev, 0x00, sizeof(struct bt_dev));
 	bt_addr_le_copy(&bt_dev.random_addr, &bt_addr_le_none);
 #if defined(CONFIG_BT_PRIVACY)
-	bt_addr_le_copy(&bt_dev.rpa[BT_ID_DEFAULT], BT_ADDR_LE_NONE);
+	bt_addr_copy(&bt_dev.rpa[BT_ID_DEFAULT], BT_ADDR_NONE);
 #endif
 
 	RPA_FFF_FAKES_LIST(RESET_FAKE);


### PR DESCRIPTION
This fixes uninitialized RPA value for BT_ID_DEFAULT.
The regression has been introduced in
https://github.com/zephyrproject-rtos/zephyr/commit/8d6b206064c915316245616a718ae29eb157a717.
As the result, the private address was not created and the advertising
was started with 00:00:00:00:00:00 address.
In case of the other advertising ID's, those are initialized
from id_create context.