### PR TITLE
twister: allow loading external configuration

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -664,6 +664,13 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
     parser.add_argument("extra_test_args", nargs=argparse.REMAINDER,
         help="Additional args following a '--' are passed to the test binary")
 
+    parser.add_argument("--alt-config-root", action="append", default=[],
+        help="Alternative test configuration root/s. When a test is found, "
+             "Twister will check if a test configuration file exist in any of "
+             "the alternative test configuration root folders. For example, "
+             "given $test_root/tests/foo/testcase.yaml, Twister will use "
+             "$alt_config_root/tests/foo/testcase.yaml if it exists")
+
     return parser
 
 
@@ -798,6 +805,8 @@ class TwisterEnv:
         self.hwm = None
 
         self.test_config = options.test_config
+
+        self.alt_config_root = options.alt_config_root
 
     def discover(self):
         self.check_zephyr_version()

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -505,6 +505,16 @@ class TestPlan:
                 suite_yaml_path = os.path.join(dirpath, filename)
                 suite_path = os.path.dirname(suite_yaml_path)
 
+                for alt_config_root in self.env.alt_config_root:
+                    alt_config = os.path.join(os.path.abspath(alt_config_root),
+                                              os.path.relpath(suite_path, root),
+                                              filename)
+                    if os.path.exists(alt_config):
+                        logger.info("Using alternative configuration from %s" %
+                                    os.path.normpath(alt_config))
+                        suite_yaml_path = alt_config
+                        break
+
                 try:
                     parsed_data = TwisterConfigParser(suite_yaml_path, self.suite_schema)
                     parsed_data.load()


### PR DESCRIPTION
Add a new option to Twister that allows to load alternative configuration files, `--alt-config-root`. This new option takes an arbitrary number of root folders where alternative configuration files can be stored. Twister will check if a test configuration file exists in any of the alternative test configuration folders. For example, given `$test_root/tests/foo/testcase.yaml`, Twister will use `$alt_config_root/tests/foo/testcase.yaml` if it exists.

Main usecase:
This feature can be useful if an out-of-tree project needs to run upstream tests in different configurations, potentially not available upstream (e.g. an out-of-tree board, or Kconfig setting).
For example, an out-of-tree board and SoC can be tested using the standard set of Zephyr tests by using this option to point to a separate, out-of-tree root that contains the same layout of the in-tree one but only has .yaml twister configuration files. This helps avoid keeping patches in a Zephyr fork that only modify those twister .yaml files.

Note that overlaying has been discarded because we can't easily delete fields from the original configuration file, something that in certain cases could be required. Current approach may lead to some dupplication, but guarantees full control of the test configuration.