### PR TITLE
ci: Use organisation-level AWS secrets

### DIFF
--- a/.github/workflows/bug_snapshot.yaml
+++ b/.github/workflows/bug_snapshot.yaml
@@ -44,7 +44,7 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        aws-access-key-id: ${{ secrets.AWS_BUILDS_ZEPHYR_BUG_SNAPSHOT_ACCESS_KEY_ID }}
+        aws-access-key-id: ${{ vars.AWS_BUILDS_ZEPHYR_BUG_SNAPSHOT_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_BUILDS_ZEPHYR_BUG_SNAPSHOT_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
 

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -88,8 +88,8 @@ jobs:
           key: ${{ steps.ccache_cache_timestamp.outputs.repo }}-${{ github.ref_name }}-clang-${{ matrix.platform }}-ccache
           path: /github/home/.ccache
           aws-s3-bucket: ccache.zephyrproject.org
-          aws-access-key-id: ${{ secrets.CCACHE_S3_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CCACHE_S3_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ vars.AWS_CCACHE_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_CCACHE_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
 
       - name: ccache stats initial

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -72,8 +72,8 @@ jobs:
           key: ${{ steps.ccache_cache_prop.outputs.repo }}-${{github.event_name}}-${{matrix.platform}}-codecov-ccache
           path: /github/home/.ccache
           aws-s3-bucket: ccache.zephyrproject.org
-          aws-access-key-id: ${{ secrets.CCACHE_S3_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CCACHE_S3_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ vars.AWS_CCACHE_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_CCACHE_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
 
       - name: ccache stats initial

--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TESTING }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TESTING }}
+        aws-access-key-id: ${{ vars.AWS_TESTING_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TESTING_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
 
     - name: install-pip

--- a/.github/workflows/doc-publish-pr.yml
+++ b/.github/workflows/doc-publish-pr.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        aws-access-key-id: ${{ secrets.AWS_BUILDS_ZEPHYR_PR_ACCESS_KEY_ID }}
+        aws-access-key-id: ${{ vars.AWS_BUILDS_ZEPHYR_PR_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_BUILDS_ZEPHYR_PR_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
 

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -36,8 +36,8 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ vars.AWS_DOCS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_DOCS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
 
     - name: Upload to AWS S3

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.FOOTPRINT_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.FOOTPRINT_AWS_ACCESS_KEY }}
+          aws-access-key-id: ${{ vars.AWS_TESTING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TESTING_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       - name: Record Footprint

--- a/.github/workflows/issue_count.yml
+++ b/.github/workflows/issue_count.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TESTING }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TESTING }}
+        aws-access-key-id: ${{ vars.AWS_TESTING_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TESTING_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
 
     - name: Post Results

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -202,8 +202,8 @@ jobs:
           key: ${{ steps.ccache_cache_timestamp.outputs.repo }}-${{ github.ref_name }}-${{github.event_name}}-${{ matrix.subset }}-ccache
           path: /github/home/.ccache
           aws-s3-bucket: ccache.zephyrproject.org
-          aws-access-key-id: ${{ secrets.CCACHE_S3_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CCACHE_S3_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ vars.AWS_CCACHE_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_CCACHE_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
 
       - name: ccache stats initial


### PR DESCRIPTION
This commit updates the CI workflows to use the `zephyrproject-rtos` organisation-level AWS secrets instead of the repository-level secrets.

Using organisation-level secrets allows more centralised management of the access keys used throughout the GitHub Actions CI infrastructure.

Note that the `AWS_*_ACCESS_KEY_ID` is now stored in plaintext as a variable instead of a secret because it is equivalent to username and needs to be identifiable for management and audit purposes.

---

Partially fixes https://github.com/zephyrproject-rtos/infrastructure-private/issues/137