### PR TITLE
This is a fix for RT1024 EVK Ethernet issue. Resolves #57808

### DIFF
--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -95,8 +95,8 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
-	int-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
-	reset-gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+	int-gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+	reset-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
 	ptp {
 		status = "okay";
 		pinctrl-0 = <&pinmux_ptp>;


### PR DESCRIPTION
In this fix, the PHY reset and interrupt GPIO pins were reversed for the NXP RT1024 EVK

Fixes #57808 