### PR TITLE
linker: Fix __stackmem section with CONFIG_KERNEL_COHERENCE

### DIFF
--- a/include/zephyr/linker/section_tags.h
+++ b/include/zephyr/linker/section_tags.h
@@ -51,8 +51,12 @@
 
 #if defined(CONFIG_KERNEL_COHERENCE)
 #define __incoherent __in_section_unique(cached)
+#if defined(CONFIG_USERSPACE)
+#define __stackmem Z_GENERIC_SECTION(.user_stacks)
+#else
 #define __stackmem __incoherent
-#define __kstackmem __stackmem
+#endif /* CONFIG_USERSPACE */
+#define __kstackmem __incoherent
 #else
 #define __incoherent
 #define __stackmem Z_GENERIC_SECTION(.user_stacks)


### PR DESCRIPTION
When building whith CONFIG_KERNEL_COHERENCE enabled, __stackmem was not being put in the user_stack section making impossible to gen_kobject script find user capable stacks.

It is responsability of the platform to put user_stacks section in the appropriated region.