### PR TITLE
arch: xtensa: Lock vecbase API 

### DIFF
--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -94,11 +94,6 @@ static ALWAYS_INLINE void xtensa_vecbase_lock(void)
 	__asm__ volatile("wsr.vecbase %0; rsync" : : "r" (vecbase | 1));
 }
 
-#ifdef __cplusplus
-}
-#endif
-
-
 #if defined(CONFIG_XTENSA_RPO_CACHE)
 #if defined(CONFIG_ARCH_HAS_COHERENCE)
 static inline bool arch_mem_coherent(void *ptr)
@@ -232,6 +227,10 @@ static inline void *arch_xtensa_uncached_ptr(void __sparse_cache *ptr)
 	FOR_EACH(_SET_ONE_TLB, (;), 0, 1, 2, 3, 4, 5, 6, 7);	\
 } while (0)
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* !defined(_ASMLANGUAGE) && !defined(__ASSEMBLER__)  */

--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -81,6 +81,19 @@ static ALWAYS_INLINE void arch_nop(void)
 	__asm__ volatile("nop");
 }
 
+static ALWAYS_INLINE void xtensa_vecbase_lock(void)
+{
+	int vecbase;
+
+	__asm__ volatile("rsr.vecbase %0" : "=r" (vecbase));
+
+	/* In some targets the bit 0 of VECBASE works as lock bit.
+	 * When this bit set, VECBASE can't be changed until it is cleared by
+	 * reset. When the target does not have it, it is hardwired to 0.
+	 **/
+	__asm__ volatile("wsr.vecbase %0; rsync" : : "r" (vecbase | 1));
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/soc/xtensa/intel_adsp/common/boot.c
+++ b/soc/xtensa/intel_adsp/common/boot.c
@@ -154,6 +154,8 @@ __imr void boot_core0(void)
 	parse_manifest();
 	sys_cache_data_flush_all();
 
+	xtensa_vecbase_lock();
+
 	/* Zephyr! */
 	extern FUNC_NORETURN void z_cstart(void);
 	z_cstart();


### PR DESCRIPTION
- arch API to lock vecbase
-  Fix cpluplus guard
- lock vecbase on Intel ADSP