### PR TITLE
west: sign: rimage: drop default -c option when the user provides one

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -529,10 +529,13 @@ class RimageSigner(Signer):
             cmake_default_key = cache.get('RIMAGE_SIGN_KEY')
             extra_ri_args += [ '-k', str(sof_src_dir / 'keys' / cmake_default_key) ]
 
+        if '-c' not in sign_config_extra_args + args.tool_args:
+            extra_ri_args += conf_path_cmd
+
         # Warning: while not officially supported (yet?), the rimage --option that is last
         # on the command line currently wins in case of duplicate options. So pay
         # attention to the _args order below.
-        sign_base += (['-o', out_bin] + sign_config_extra_args + conf_path_cmd +
+        sign_base += (['-o', out_bin] + sign_config_extra_args +
                       extra_ri_args + args.tool_args + components)
 
         if not args.quiet:


### PR DESCRIPTION
sign.py has an internal and indirect way to compute a default -c signing schema option and pass it to rimage. It is built by appending `$platform.toml` to whatever `rimage/config/` location was found. Defaults are very convenient but in this case this computed -c option can conflict with an explicit -c option spelled out by the user.

Scan for any explicit -c coming directly from the user. If any found, ignore the default we computed. This is what is already being done for -k.

The precedence across rimage parameters coming from different places is too complicated. Not passing multiple -c options simplifies the logic a little bit.