### PR TITLE
drivers: sensor: lsm6dsl: Fix lsm6dsl gyroscope full range setting

### DIFF
--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -143,14 +143,14 @@ static int lsm6dsl_gyro_set_fs_raw(const struct device *dev, uint8_t fs)
 	if (fs == GYRO_FULLSCALE_125) {
 		if (data->hw_tf->update_reg(dev,
 					LSM6DSL_REG_CTRL2_G,
-					LSM6DSL_MASK_CTRL2_FS125,
+					LSM6DSL_MASK_CTRL2_FS125 | LSM6DSL_MASK_CTRL2_G_FS_G,
 					1 << LSM6DSL_SHIFT_CTRL2_FS125) < 0) {
 			return -EIO;
 		}
 	} else {
 		if (data->hw_tf->update_reg(dev,
 					LSM6DSL_REG_CTRL2_G,
-					LSM6DSL_MASK_CTRL2_G_FS_G,
+					LSM6DSL_MASK_CTRL2_FS125 | LSM6DSL_MASK_CTRL2_G_FS_G,
 					fs << LSM6DSL_SHIFT_CTRL2_G_FS_G) < 0) {
 			return -EIO;
 		}
@@ -560,7 +560,7 @@ static int lsm6dsl_gyro_channel_get(enum sensor_channel chan,
 				    struct lsm6dsl_data *data)
 {
 	return lsm6dsl_gyro_get_channel(chan, val, data,
-					LSM6DSL_DEFAULT_GYRO_SENSITIVITY);
+					data->gyro_sensitivity);
 }
 
 #if defined(CONFIG_LSM6DSL_ENABLE_TEMP)


### PR DESCRIPTION
Bug 1: Fix lsm6dsl_gyro_set_fs_raw does not clear FS125 to register when setting the full range to be other values.

Bug 2: Fix lsm6dsl_gyro_channel_get does not use the current gyro_sensitivity when getting data from the gyroscope.


This has been tested with an STM32H7 dev board connected to LSM6DSL via SPI.

We tried the following code:
```
        struct sensor_value g_full_scale_attr;

	const int32_t g_full_scale_target_degree = 2000;

	sensor_degrees_to_rad(g_full_scale_target_degree, &g_full_scale_attr);

	if (sensor_attr_set(accel_dev, SENSOR_CHAN_GYRO_XYZ, SENSOR_ATTR_FULL_SCALE,
			    &g_full_scale_attr) < 0) {
		printk("Cannot set full scale for gyro.\n");
		return 0;
	}
```

Before the fix, the output gyroscope value is still clearly capped at ~2.2 rad/s or 125 dps, and after the fix, the value can go above the limit.

Also, thanks to Tyler Chen <tyler@skywalk.dev> for his contribution.

