### PR TITLE
rtio: Add support for canceling and multishot

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -447,6 +447,7 @@ static inline void rtio_sqe_prep_nop(struct rtio_sqe *sqe,
 				const struct rtio_iodev *iodev,
 				void *userdata)
 {
+	memset(sqe, 0, sizeof(struct rtio_sqe));
 	sqe->op = RTIO_OP_NOP;
 	sqe->iodev = iodev;
 	sqe->userdata = userdata;
@@ -462,6 +463,7 @@ static inline void rtio_sqe_prep_read(struct rtio_sqe *sqe,
 				      uint32_t len,
 				      void *userdata)
 {
+	memset(sqe, 0, sizeof(struct rtio_sqe));
 	sqe->op = RTIO_OP_RX;
 	sqe->prio = prio;
 	sqe->iodev = iodev;
@@ -493,6 +495,7 @@ static inline void rtio_sqe_prep_write(struct rtio_sqe *sqe,
 				       uint32_t len,
 				       void *userdata)
 {
+	memset(sqe, 0, sizeof(struct rtio_sqe));
 	sqe->op = RTIO_OP_TX;
 	sqe->prio = prio;
 	sqe->iodev = iodev;
@@ -520,6 +523,7 @@ static inline void rtio_sqe_prep_tiny_write(struct rtio_sqe *sqe,
 {
 	__ASSERT_NO_MSG(tiny_write_len <= sizeof(sqe->tiny_buf));
 
+	memset(sqe, 0, sizeof(struct rtio_sqe));
 	sqe->op = RTIO_OP_TINY_TX;
 	sqe->prio = prio;
 	sqe->iodev = iodev;
@@ -541,6 +545,7 @@ static inline void rtio_sqe_prep_callback(struct rtio_sqe *sqe,
 					  void *arg0,
 					  void *userdata)
 {
+	memset(sqe, 0, sizeof(struct rtio_sqe));
 	sqe->op = RTIO_OP_CALLBACK;
 	sqe->prio = 0;
 	sqe->iodev = NULL;
@@ -560,6 +565,7 @@ static inline void rtio_sqe_prep_transceive(struct rtio_sqe *sqe,
 					    uint32_t buf_len,
 					    void *userdata)
 {
+	memset(sqe, 0, sizeof(struct rtio_sqe));
 	sqe->op = RTIO_OP_TXRX;
 	sqe->prio = prio;
 	sqe->iodev = iodev;
@@ -578,8 +584,6 @@ static inline struct rtio_iodev_sqe *rtio_sqe_pool_alloc(struct rtio_sqe_pool *p
 	}
 
 	struct rtio_iodev_sqe *iodev_sqe = CONTAINER_OF(node, struct rtio_iodev_sqe, q);
-
-	memset(iodev_sqe, 0, sizeof(struct rtio_iodev_sqe));
 
 	pool->pool_free--;
 

--- a/subsys/rtio/rtio_handlers.c
+++ b/subsys/rtio/rtio_handlers.c
@@ -70,9 +70,14 @@ static inline int z_vrfy_rtio_cqe_get_mempool_buffer(const struct rtio *r, struc
 }
 #include <syscalls/rtio_cqe_get_mempool_buffer_mrsh.c>
 
-static inline int z_vrfy_rtio_sqe_copy_in(struct rtio *r,
-					  const struct rtio_sqe *sqes,
-					  size_t sqe_count)
+static inline int z_vrfy_rtio_sqe_cancel(struct rtio_sqe *sqe)
+{
+	return z_impl_rtio_sqe_cancel(sqe);
+}
+#include <syscalls/rtio_sqe_cancel_mrsh.c>
+
+static inline int z_vrfy_rtio_sqe_copy_in_get_handles(struct rtio *r, const struct rtio_sqe *sqes,
+						      struct rtio_sqe **handle, size_t sqe_count)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(r, K_OBJ_RTIO));
 
@@ -84,9 +89,13 @@ static inline int z_vrfy_rtio_sqe_copy_in(struct rtio *r,
 		return -ENOMEM;
 	}
 
+
 	for (int i = 0; i < sqe_count; i++) {
 		sqe = rtio_sqe_acquire(r);
 		__ASSERT_NO_MSG(sqe != NULL);
+		if (handle != NULL && i == 0) {
+			*handle = sqe;
+		}
 		*sqe = sqes[i];
 
 		if (!rtio_vrfy_sqe(sqe)) {
@@ -96,9 +105,9 @@ static inline int z_vrfy_rtio_sqe_copy_in(struct rtio *r,
 	}
 
 	/* Already copied *and* verified, no need to redo */
-	return z_impl_rtio_sqe_copy_in(r, NULL, 0);
+	return z_impl_rtio_sqe_copy_in_get_handles(r, NULL, NULL, 0);
 }
-#include <syscalls/rtio_sqe_copy_in_mrsh.c>
+#include <syscalls/rtio_sqe_copy_in_get_handles_mrsh.c>
 
 static inline int z_vrfy_rtio_cqe_copy_out(struct rtio *r,
 					   struct rtio_cqe *cqes,

--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -503,6 +503,85 @@ ZTEST(rtio_api, test_rtio_transaction_cancel)
 #endif
 }
 
+static inline void test_rtio_simple_multishot_(struct rtio *r, int idx)
+{
+	int res;
+	struct rtio_sqe sqe;
+	struct rtio_cqe cqe;
+	struct rtio_sqe *handle;
+
+	for (int i = 0; i < MEM_BLK_SIZE; ++i) {
+		mempool_data[i] = i + idx;
+	}
+
+	TC_PRINT("setting up single mempool read\n");
+	rtio_sqe_prep_read_multishot(&sqe, (struct rtio_iodev *)&iodev_test_simple, 0,
+				     mempool_data);
+	TC_PRINT("Calling rtio_sqe_copy_in()\n");
+	res = rtio_sqe_copy_in_get_handles(r, &sqe, &handle, 1);
+	zassert_ok(res);
+
+	TC_PRINT("submit with wait, handle=%p\n", handle);
+	res = rtio_submit(r, 1);
+	zassert_ok(res, "Should return ok from rtio_execute");
+
+	TC_PRINT("Calling rtio_cqe_copy_out\n");
+	zassert_equal(1, rtio_cqe_copy_out(r, &cqe, 1, K_FOREVER));
+	zassert_ok(cqe.result, "Result should be ok but got %d", cqe.result);
+	zassert_equal_ptr(cqe.userdata, mempool_data, "Expected userdata back");
+
+	uint8_t *buffer = NULL;
+	uint32_t buffer_len = 0;
+
+	TC_PRINT("Calling rtio_cqe_get_mempool_buffer\n");
+	zassert_ok(rtio_cqe_get_mempool_buffer(r, &cqe, &buffer, &buffer_len));
+
+	zassert_not_null(buffer, "Expected an allocated mempool buffer");
+	zassert_equal(buffer_len, MEM_BLK_SIZE);
+	zassert_mem_equal(buffer, mempool_data, MEM_BLK_SIZE, "Data expected to be the same");
+	TC_PRINT("Calling rtio_release_buffer\n");
+	rtio_release_buffer(r, buffer, buffer_len);
+
+	TC_PRINT("Waiting for next cqe\n");
+	zassert_equal(1, rtio_cqe_copy_out(r, &cqe, 1, K_FOREVER));
+	zassert_equal(1, cqe.result, "Result should be ok but got %d", cqe.result);
+	zassert_equal_ptr(cqe.userdata, mempool_data, "Expected userdata back");
+	rtio_cqe_get_mempool_buffer(r, &cqe, &buffer, &buffer_len);
+	rtio_release_buffer(r, buffer, buffer_len);
+
+	TC_PRINT("Canceling %p\n", handle);
+	rtio_sqe_cancel(handle);
+	/* Flush any pending CQEs */
+	while (rtio_cqe_copy_out(r, &cqe, 1, K_MSEC(15)) != 0) {
+		rtio_cqe_get_mempool_buffer(r, &cqe, &buffer, &buffer_len);
+		rtio_release_buffer(r, buffer, buffer_len);
+	}
+}
+
+static void rtio_simple_multishot_test(void *a, void *b, void *c)
+{
+	ARG_UNUSED(a);
+	ARG_UNUSED(b);
+	ARG_UNUSED(c);
+
+	for (int i = 0; i < TEST_REPEATS; i++) {
+		test_rtio_simple_multishot_(&r_simple, i);
+	}
+}
+
+ZTEST(rtio_api, test_rtio_multishot)
+{
+	rtio_iodev_test_init(&iodev_test_simple);
+#ifdef CONFIG_USERSPACE
+	k_mem_domain_add_thread(&rtio_domain, k_current_get());
+	rtio_access_grant(&r_simple, k_current_get());
+	k_object_access_grant(&iodev_test_simple, k_current_get());
+	k_thread_user_mode_enter(rtio_simple_multishot_test, NULL, NULL, NULL);
+#else
+	rtio_simple_multishot_test(NULL, NULL, NULL);
+#endif
+}
+
 
 ZTEST(rtio_api, test_rtio_syscalls)
 {


### PR DESCRIPTION
- Add support for canceling an sqe by use of a pointer (new API was added to copy_in which returns the generated sqes)
- Add support for sqes that do not clear once complete until canceled.