### PR TITLE
drivers: fuel_gauge: Add support for RSOC and ASOC

### DIFF
--- a/drivers/fuel_gauge/max17048/max17048.c
+++ b/drivers/fuel_gauge/max17048/max17048.c
@@ -187,8 +187,8 @@ static int max17048_get_prop(const struct device *dev, struct fuel_gauge_get_pro
 	case FUEL_GAUGE_RUNTIME_TO_FULL:
 		prop->value.runtime_to_full = data->time_to_full;
 		break;
-	case FUEL_GAUGE_STATE_OF_CHARGE:
-		prop->value.state_of_charge = data->charge;
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
+		prop->value.relative_state_of_charge = data->charge;
 		break;
 	case FUEL_GAUGE_VOLTAGE:
 		prop->value.voltage = data->voltage;

--- a/drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c
@@ -91,6 +91,7 @@ static int emul_sbs_gauge_reg_read(const struct emul *target, int reg, int *val)
 	case SBS_GAUGE_CMD_AVG_CURRENT:
 	case SBS_GAUGE_CMD_TEMP:
 	case SBS_GAUGE_CMD_ASOC:
+	case SBS_GAUGE_CMD_RSOC:
 	case SBS_GAUGE_CMD_FULL_CAPACITY:
 	case SBS_GAUGE_CMD_REM_CAPACITY:
 	case SBS_GAUGE_CMD_NOM_CAPACITY:

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -83,9 +83,13 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_MANUFACTURER_ACCESS, &val);
 		prop->value.sbs_mfr_access_word = val;
 		break;
-	case FUEL_GAUGE_STATE_OF_CHARGE:
+	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ASOC, &val);
-		prop->value.state_of_charge = val;
+		prop->value.absolute_state_of_charge = val;
+		break;
+	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_RSOC, &val);
+		prop->value.relative_state_of_charge = val;
 		break;
 	case FUEL_GAUGE_TEMPERATURE:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_TEMP, &val);

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -59,9 +59,11 @@ extern "C" {
 /** Retrieve word from SBS1.1 ManufactuerAccess */
 #define FUEL_GAUGE_SBS_MFR_ACCESS		FUEL_GAUGE_RUNTIME_TO_FULL + 1
 /** Absolute state of charge (percent, 0-100) - expressed as % of design capacity */
-#define FUEL_GAUGE_STATE_OF_CHARGE		FUEL_GAUGE_SBS_MFR_ACCESS + 1
+#define FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE	    FUEL_GAUGE_SBS_MFR_ACCESS + 1
+/** Relative state of charge (percent, 0-100) - expressed as % of full charge capacity */
+#define FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE		FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE + 1
 /** Temperature in 0.1 K */
-#define FUEL_GAUGE_TEMPERATURE			FUEL_GAUGE_STATE_OF_CHARGE + 1
+#define FUEL_GAUGE_TEMPERATURE		    FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE + 1
 /** Battery voltage (uV) */
 #define FUEL_GAUGE_VOLTAGE			FUEL_GAUGE_TEMPERATURE + 1
 /** Battery Mode (flags) */
@@ -134,8 +136,10 @@ struct fuel_gauge_get_property {
 		uint32_t runtime_to_full;
 		/** FUEL_GAUGE_SBS_MFR_ACCESS */
 		uint16_t sbs_mfr_access_word;
-		/** FUEL_GAUGE_STATE_OF_CHARGE */
-		uint8_t state_of_charge;
+		/** FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE */
+		uint8_t absolute_state_of_charge;
+		/** FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE */
+		uint8_t relative_state_of_charge;
 		/** FUEL_GAUGE_TEMPERATURE */
 		uint16_t temperature;
 		/** FUEL_GAUGE_VOLTAGE */

--- a/samples/fuel_gauge/max17048/src/main.c
+++ b/samples/fuel_gauge/max17048/src/main.c
@@ -46,7 +46,7 @@ int main(void)
 				.property_type = FUEL_GAUGE_RUNTIME_TO_FULL,
 			},
 			{
-				.property_type = FUEL_GAUGE_STATE_OF_CHARGE,
+				.property_type = FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
 			},
 			{
 				.property_type = FUEL_GAUGE_VOLTAGE,
@@ -80,7 +80,7 @@ int main(void)
 			}
 
 			if (props[2].status == 0) {
-				printk("Charge %d%%\n", props[2].value.state_of_charge);
+				printk("Charge %d%%\n", props[2].value.relative_state_of_charge);
 			} else {
 				printk(
 				"Property FUEL_GAUGE_STATE_OF_CHARGE failed with error %d\n",

--- a/tests/drivers/fuel_gauge/max17048/src/test_max17048.c
+++ b/tests/drivers/fuel_gauge/max17048/src/test_max17048.c
@@ -93,7 +93,7 @@ ZTEST_USER_F(max17048, test_get_props__returns_ok)
 			.property_type = FUEL_GAUGE_RUNTIME_TO_FULL,
 		},
 		{
-			.property_type = FUEL_GAUGE_STATE_OF_CHARGE,
+			.property_type = FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
 		},
 		{
 			.property_type = FUEL_GAUGE_VOLTAGE,

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -214,7 +214,10 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)
 			.property_type = FUEL_GAUGE_TEMPERATURE,
 		},
 		{
-			.property_type = FUEL_GAUGE_STATE_OF_CHARGE,
+			.property_type = FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE,
+		},
+		{
+			.property_type = FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
 		},
 		{
 			.property_type = FUEL_GAUGE_RUNTIME_TO_FULL,


### PR DESCRIPTION
Current driver only allows state-of-charge.  Adding relative-state- of-charge and absolute-state-of-charge to differentiate between the different types.  Updated sbs and max drivers to support new enum. Discussed in issue #57523