### PR TITLE
include: posix: signal: add sig_atomic_t type

### DIFF
--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -24,6 +24,8 @@ extern "C" {
 #define SIGEV_THREAD 3
 #endif
 
+typedef int	sig_atomic_t;		/* Atomic entity type (ANSI) */
+
 typedef union sigval {
 	int sival_int;
 	void *sival_ptr;


### PR DESCRIPTION
This commit adds the definition of sig_atomic_t to the posix/signal.h file. The definition was copied from the file
modules/lib/picolibc/newlib/libc/include/signal.h. The problem of the missing definition arose when I tried to compile a lua module for the 3.3.0 version of zephyr. Adding this definition solves the problem.