### PR TITLE
drivers: can: stm32h7: remove unused std/ext filter size Kconfig options

### DIFF
--- a/drivers/can/Kconfig.stm32h7
+++ b/drivers/can/Kconfig.stm32h7
@@ -9,23 +9,3 @@ config CAN_STM32H7
 	depends on DT_HAS_ST_STM32H7_FDCAN_ENABLED
 	select CAN_MCAN
 	select USE_STM32_LL_RCC
-
-if CAN_STM32H7
-
-config CAN_MAX_STD_ID_FILTER
-	int "Maximum number of std ID filters"
-	default 28
-	range 0 28
-	help
-	  Defines the maximum number of filters with standard ID (11-bit)
-	  that can be attached.
-
-config CAN_MAX_EXT_ID_FILTER
-	int "Maximum number of ext ID filters"
-	default 8
-	range 0 8
-	help
-	  Defines the maximum number of filters with extended ID (29-bit)
-	  that can be attached.
-
-endif #CAN_STM32H7


### PR DESCRIPTION
Remove the STM32H7 specific Kconfig overrides for setting the maximum number of standard and extended CAN RX filters as they are unused.

The number of available standard and extended filter elements for Bosch M_CAN can be configured via the devicetree.