### PR TITLE
Bluetooth: audio: ascs: Fix repeated ops->released callback call

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -989,7 +989,6 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(ase_pool); i++) {
 		struct bt_ascs_ase *ase = &ase_pool[i];
-		struct bt_bap_stream *stream = ase->ep.stream;
 
 		if (ase->conn != conn) {
 			continue;
@@ -998,11 +997,6 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		if (ase->ep.status.state != BT_BAP_EP_STATE_IDLE) {
 			ase_release(ase);
 			/* At this point, `ase` object have been free'd */
-		}
-
-		if (stream != NULL && stream->conn != NULL) {
-			bt_conn_unref(stream->conn);
-			stream->conn = NULL;
 		}
 	}
 }

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -998,18 +998,6 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		if (ase->ep.status.state != BT_BAP_EP_STATE_IDLE) {
 			ase_release(ase);
 			/* At this point, `ase` object have been free'd */
-
-			if (stream != NULL) {
-				const struct bt_bap_stream_ops *ops;
-
-				/* Notify upper layer */
-				ops = stream->ops;
-				if (ops != NULL && ops->released != NULL) {
-					ops->released(stream);
-				} else {
-					LOG_WRN("No callback for released set");
-				}
-			}
 		}
 
 		if (stream != NULL && stream->conn != NULL) {

--- a/tests/bluetooth/audio/ascs/testcase.yaml
+++ b/tests/bluetooth/audio/ascs/testcase.yaml
@@ -27,3 +27,10 @@ tests:
       - server_source_state_enabling
       - server_source_state_streaming
       - server_source_state_disabling
+  bluetooth.audio.ascs.test_stream_pair:
+    type: unit
+    extra_configs:
+      - CONFIG_BT_ASCS_MAX_ACTIVE_ASES=2
+    testcases:
+      - test_release_stream_pair_on_acl_disconnection_client_terminates_cis
+      - test_release_stream_pair_on_acl_disconnection_server_terminates_cis

--- a/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
@@ -129,6 +129,26 @@ static inline void expect_bt_bap_stream_ops_disabled_not_called(void)
 		      "'%s()' was called unexpectedly", func_name);
 }
 
+static inline void expect_bt_bap_stream_ops_released_called_twice(
+	const struct bt_bap_stream *streams[2])
+{
+	const char *func_name = "bt_bap_stream_ops.released";
+
+	zexpect_equal(2, mock_bap_stream_released_cb_fake.call_count,
+		      "'%s()' was called %u times, but expected once",
+		      func_name, mock_bap_stream_released_cb_fake.call_count);
+
+	if (mock_bap_stream_released_cb_fake.call_count > 0) {
+		zexpect_equal_ptr(streams[0], mock_bap_stream_released_cb_fake.arg0_history[0],
+				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	}
+
+	if (mock_bap_stream_released_cb_fake.call_count > 1) {
+		zexpect_equal_ptr(streams[1], mock_bap_stream_released_cb_fake.arg0_history[1],
+				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	}
+}
+
 static inline void expect_bt_bap_stream_ops_released_called_once(struct bt_bap_stream *stream)
 {
 	const char *func_name = "bt_bap_stream_ops.released";

--- a/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
@@ -16,9 +16,7 @@
 do {                                                                                               \
 	const char *func_name = "bt_bap_stream_ops.configured";                                    \
 												   \
-	zexpect_equal(1, mock_bap_stream_configured_cb_fake.call_count,                            \
-		      "'%s()' was called %u times, but expected once",                             \
-		      func_name, mock_bap_stream_configured_cb_fake.call_count);                   \
+	zexpect_call_count(func_name, 1, mock_bap_stream_configured_cb_fake.call_count);           \
 												   \
 	if (mock_bap_stream_configured_cb_fake.call_count > 0) {                                   \
 		IF_NOT_EMPTY(_stream, (                                                            \
@@ -36,17 +34,14 @@ static inline void expect_bt_bap_stream_ops_configured_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.configured";
 
-	zexpect_equal(0, mock_bap_stream_configured_cb_fake.call_count,
-		      "'%s()' was called unexpectedly", func_name);
+	zexpect_call_count(func_name, 0, mock_bap_stream_configured_cb_fake.call_count);
 }
 
 static inline void expect_bt_bap_stream_ops_qos_set_called_once(struct bt_bap_stream *stream)
 {
 	const char *func_name = "bt_bap_stream_ops.qos_set";
 
-	zexpect_equal(1, mock_bap_stream_qos_set_cb_fake.call_count,
-		      "'%s()' was called %u times, but expected once",
-		      func_name, mock_bap_stream_qos_set_cb_fake.call_count);
+	zexpect_call_count(func_name, 1, mock_bap_stream_qos_set_cb_fake.call_count);
 
 	if (mock_bap_stream_qos_set_cb_fake.call_count > 0) {
 		zexpect_equal_ptr(stream, mock_bap_stream_qos_set_cb_fake.arg0_val,
@@ -58,17 +53,14 @@ static inline void expect_bt_bap_stream_ops_qos_set_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.qos_set";
 
-	zexpect_equal(0, mock_bap_stream_qos_set_cb_fake.call_count,
-		      "'%s()' was called unexpectedly", func_name);
+	zexpect_call_count(func_name, 0, mock_bap_stream_qos_set_cb_fake.call_count);
 }
 
 static inline void expect_bt_bap_stream_ops_enabled_called_once(struct bt_bap_stream *stream)
 {
 	const char *func_name = "bt_bap_stream_ops.enabled";
 
-	zexpect_equal(1, mock_bap_stream_enabled_cb_fake.call_count,
-		      "'%s()' was called %u times, but expected once",
-		      func_name, mock_bap_stream_enabled_cb_fake.call_count);
+	zexpect_call_count(func_name, 1, mock_bap_stream_enabled_cb_fake.call_count);
 
 	if (mock_bap_stream_enabled_cb_fake.call_count > 0) {
 		zexpect_equal_ptr(stream, mock_bap_stream_enabled_cb_fake.arg0_val,
@@ -80,8 +72,7 @@ static inline void expect_bt_bap_stream_ops_enabled_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.enabled";
 
-	zexpect_equal(0, mock_bap_stream_enabled_cb_fake.call_count,
-		      "'%s()' was called unexpectedly", func_name);
+	zexpect_call_count(func_name, 0, mock_bap_stream_enabled_cb_fake.call_count);
 }
 
 static inline void expect_bt_bap_stream_ops_metadata_updated_called_once(
@@ -89,9 +80,7 @@ static inline void expect_bt_bap_stream_ops_metadata_updated_called_once(
 {
 	const char *func_name = "bt_bap_stream_ops.metadata_updated";
 
-	zexpect_equal(1, mock_bap_stream_metadata_updated_cb_fake.call_count,
-		      "'%s()' was called %u times, but expected once",
-		      func_name, mock_bap_stream_metadata_updated_cb_fake.call_count);
+	zexpect_call_count(func_name, 1, mock_bap_stream_metadata_updated_cb_fake.call_count);
 
 	if (mock_bap_stream_metadata_updated_cb_fake.call_count > 0) {
 		zexpect_equal_ptr(stream, mock_bap_stream_metadata_updated_cb_fake.arg0_val,
@@ -103,17 +92,14 @@ static inline void expect_bt_bap_stream_ops_metadata_updated_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.metadata_updated";
 
-	zexpect_equal(0, mock_bap_stream_metadata_updated_cb_fake.call_count,
-		      "'%s()' was called unexpectedly", func_name);
+	zexpect_call_count(func_name, 0, mock_bap_stream_metadata_updated_cb_fake.call_count);
 }
 
 static inline void expect_bt_bap_stream_ops_disabled_called_once(struct bt_bap_stream *stream)
 {
 	const char *func_name = "bt_bap_stream_ops.disabled";
 
-	zexpect_equal(1, mock_bap_stream_disabled_cb_fake.call_count,
-		      "'%s()' was called %u times, but expected once",
-		      func_name, mock_bap_stream_disabled_cb_fake.call_count);
+	zexpect_call_count(func_name, 1, mock_bap_stream_disabled_cb_fake.call_count);
 
 	if (mock_bap_stream_disabled_cb_fake.call_count > 0) {
 		zexpect_equal_ptr(stream, mock_bap_stream_disabled_cb_fake.arg0_val,
@@ -125,8 +111,7 @@ static inline void expect_bt_bap_stream_ops_disabled_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.disabled";
 
-	zexpect_equal(0, mock_bap_stream_disabled_cb_fake.call_count,
-		      "'%s()' was called unexpectedly", func_name);
+	zexpect_call_count(func_name, 0, mock_bap_stream_disabled_cb_fake.call_count);
 }
 
 static inline void expect_bt_bap_stream_ops_released_called_twice(
@@ -134,9 +119,7 @@ static inline void expect_bt_bap_stream_ops_released_called_twice(
 {
 	const char *func_name = "bt_bap_stream_ops.released";
 
-	zexpect_equal(2, mock_bap_stream_released_cb_fake.call_count,
-		      "'%s()' was called %u times, but expected once",
-		      func_name, mock_bap_stream_released_cb_fake.call_count);
+	zexpect_call_count(func_name, 2, mock_bap_stream_released_cb_fake.call_count);
 
 	if (mock_bap_stream_released_cb_fake.call_count > 0) {
 		zexpect_equal_ptr(streams[0], mock_bap_stream_released_cb_fake.arg0_history[0],
@@ -153,9 +136,7 @@ static inline void expect_bt_bap_stream_ops_released_called_once(struct bt_bap_s
 {
 	const char *func_name = "bt_bap_stream_ops.released";
 
-	zexpect_equal(1, mock_bap_stream_released_cb_fake.call_count,
-		      "'%s()' was called %u times, but expected once",
-		      func_name, mock_bap_stream_released_cb_fake.call_count);
+	zexpect_call_count(func_name, 1, mock_bap_stream_released_cb_fake.call_count);
 
 	if (mock_bap_stream_released_cb_fake.call_count > 0) {
 		zexpect_equal_ptr(stream, mock_bap_stream_released_cb_fake.arg0_val,
@@ -175,9 +156,7 @@ static inline void expect_bt_bap_stream_ops_started_called_once(struct bt_bap_st
 {
 	const char *func_name = "bt_bap_stream_ops.started";
 
-	zexpect_equal(1, mock_bap_stream_started_cb_fake.call_count,
-		      "'%s()' was called %u times, but expected once",
-		      func_name, mock_bap_stream_started_cb_fake.call_count);
+	zexpect_call_count(func_name, 1, mock_bap_stream_started_cb_fake.call_count);
 
 	if (mock_bap_stream_started_cb_fake.call_count > 0) {
 		zexpect_equal_ptr(stream, mock_bap_stream_started_cb_fake.arg0_val,
@@ -189,17 +168,14 @@ static inline void expect_bt_bap_stream_ops_started_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.started";
 
-	zexpect_equal(0, mock_bap_stream_started_cb_fake.call_count,
-		      "'%s()' was called unexpectedly", func_name);
+	zexpect_call_count(func_name, 0, mock_bap_stream_started_cb_fake.call_count);
 }
 
 #define expect_bt_bap_stream_ops_stopped_called_once(_stream, _reason)                             \
 do {                                                                                               \
 	const char *func_name = "bt_bap_stream_ops.stopped";                                       \
 												   \
-	zexpect_equal(1, mock_bap_stream_stopped_cb_fake.call_count,                               \
-		      "'%s()' was called %u times, but expected once",                             \
-		      func_name, mock_bap_stream_stopped_cb_fake.call_count);                      \
+	zexpect_call_count(func_name, 1, mock_bap_stream_stopped_cb_fake.call_count);              \
 												   \
 	if (mock_bap_stream_stopped_cb_fake.call_count > 0) {                                      \
 		IF_NOT_EMPTY(_stream, (                                                            \
@@ -218,8 +194,7 @@ static inline void expect_bt_bap_stream_ops_stopped_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.stopped";
 
-	zexpect_equal(0, mock_bap_stream_stopped_cb_fake.call_count,
-		      "'%s()' was called unexpectedly", func_name);
+	zexpect_call_count(func_name, 0, mock_bap_stream_stopped_cb_fake.call_count);
 }
 
 static inline void expect_bt_bap_stream_ops_recv_called_once(struct bt_bap_stream *stream,
@@ -228,9 +203,7 @@ static inline void expect_bt_bap_stream_ops_recv_called_once(struct bt_bap_strea
 {
 	const char *func_name = "bt_bap_stream_ops.recv";
 
-	zexpect_equal(1, mock_bap_stream_recv_cb_fake.call_count,
-		      "'%s()' was called %u times, but expected once",
-		      func_name, mock_bap_stream_recv_cb_fake.call_count);
+	zexpect_call_count(func_name, 1, mock_bap_stream_recv_cb_fake.call_count);
 
 	if (mock_bap_stream_recv_cb_fake.call_count > 0) {
 		zexpect_equal_ptr(stream, mock_bap_stream_recv_cb_fake.arg0_val,
@@ -244,17 +217,14 @@ static inline void expect_bt_bap_stream_ops_recv_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.recv";
 
-	zexpect_equal(0, mock_bap_stream_recv_cb_fake.call_count,
-		      "'%s()' was called unexpectedly", func_name);
+	zexpect_call_count(func_name, 0, mock_bap_stream_recv_cb_fake.call_count);
 }
 
 static inline void expect_bt_bap_stream_ops_sent_called_once(struct bt_bap_stream *stream)
 {
 	const char *func_name = "bt_bap_stream_ops.sent";
 
-	zexpect_equal(1, mock_bap_stream_sent_cb_fake.call_count,
-		      "'%s()' was called %u times, but expected once",
-		      func_name, mock_bap_stream_sent_cb_fake.call_count);
+	zexpect_call_count(func_name, 1, mock_bap_stream_sent_cb_fake.call_count);
 
 	if (mock_bap_stream_sent_cb_fake.call_count > 0) {
 		zexpect_equal_ptr(stream, mock_bap_stream_sent_cb_fake.arg0_val,
@@ -266,8 +236,7 @@ static inline void expect_bt_bap_stream_ops_sent_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.sent";
 
-	zexpect_equal(0, mock_bap_stream_sent_cb_fake.call_count,
-		      "'%s()' was called unexpectedly", func_name);
+	zexpect_call_count(func_name, 0, mock_bap_stream_sent_cb_fake.call_count);
 }
 
 #endif /* MOCKS_BAP_STREAM_EXPECTS_H_ */

--- a/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
@@ -16,25 +16,27 @@
 do {                                                                                               \
 	const char *func_name = "bt_bap_stream_ops.configured";                                    \
 												   \
-	zassert_equal(1, mock_bap_stream_configured_cb_fake.call_count,                            \
+	zexpect_equal(1, mock_bap_stream_configured_cb_fake.call_count,                            \
 		      "'%s()' was called %u times, but expected once",                             \
 		      func_name, mock_bap_stream_configured_cb_fake.call_count);                   \
 												   \
-	IF_NOT_EMPTY(_stream, (                                                                    \
-		     zassert_equal_ptr(_stream, mock_bap_stream_configured_cb_fake.arg0_val,       \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "stream");))                                     \
+	if (mock_bap_stream_configured_cb_fake.call_count > 0) {                                   \
+		IF_NOT_EMPTY(_stream, (                                                            \
+			zexpect_equal_ptr(_stream, mock_bap_stream_configured_cb_fake.arg0_val,    \
+					  "'%s()' was called with incorrect '%s' value",           \
+					  func_name, "stream");))                                  \
 												   \
-	IF_NOT_EMPTY(_pref, (                                                                      \
-		     /* TODO */                                                                    \
-		     zassert_unreachable("Not implemented");))                                     \
+		IF_NOT_EMPTY(_pref, (                                                              \
+			/* TODO */                                                                 \
+			zassert_unreachable("Not implemented");))                                  \
+	}                                                                                          \
 } while (0)
 
 static inline void expect_bt_bap_stream_ops_configured_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.configured";
 
-	zassert_equal(0, mock_bap_stream_configured_cb_fake.call_count,
+	zexpect_equal(0, mock_bap_stream_configured_cb_fake.call_count,
 		      "'%s()' was called unexpectedly", func_name);
 }
 
@@ -42,19 +44,21 @@ static inline void expect_bt_bap_stream_ops_qos_set_called_once(struct bt_bap_st
 {
 	const char *func_name = "bt_bap_stream_ops.qos_set";
 
-	zassert_equal(1, mock_bap_stream_qos_set_cb_fake.call_count,
+	zexpect_equal(1, mock_bap_stream_qos_set_cb_fake.call_count,
 		      "'%s()' was called %u times, but expected once",
 		      func_name, mock_bap_stream_qos_set_cb_fake.call_count);
 
-	zassert_equal_ptr(stream, mock_bap_stream_qos_set_cb_fake.arg0_val,
-			  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	if (mock_bap_stream_qos_set_cb_fake.call_count > 0) {
+		zexpect_equal_ptr(stream, mock_bap_stream_qos_set_cb_fake.arg0_val,
+				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	}
 }
 
 static inline void expect_bt_bap_stream_ops_qos_set_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.qos_set";
 
-	zassert_equal(0, mock_bap_stream_qos_set_cb_fake.call_count,
+	zexpect_equal(0, mock_bap_stream_qos_set_cb_fake.call_count,
 		      "'%s()' was called unexpectedly", func_name);
 }
 
@@ -62,19 +66,21 @@ static inline void expect_bt_bap_stream_ops_enabled_called_once(struct bt_bap_st
 {
 	const char *func_name = "bt_bap_stream_ops.enabled";
 
-	zassert_equal(1, mock_bap_stream_enabled_cb_fake.call_count,
+	zexpect_equal(1, mock_bap_stream_enabled_cb_fake.call_count,
 		      "'%s()' was called %u times, but expected once",
 		      func_name, mock_bap_stream_enabled_cb_fake.call_count);
 
-	zassert_equal_ptr(stream, mock_bap_stream_enabled_cb_fake.arg0_val,
-			  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	if (mock_bap_stream_enabled_cb_fake.call_count > 0) {
+		zexpect_equal_ptr(stream, mock_bap_stream_enabled_cb_fake.arg0_val,
+				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	}
 }
 
 static inline void expect_bt_bap_stream_ops_enabled_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.enabled";
 
-	zassert_equal(0, mock_bap_stream_enabled_cb_fake.call_count,
+	zexpect_equal(0, mock_bap_stream_enabled_cb_fake.call_count,
 		      "'%s()' was called unexpectedly", func_name);
 }
 
@@ -83,19 +89,21 @@ static inline void expect_bt_bap_stream_ops_metadata_updated_called_once(
 {
 	const char *func_name = "bt_bap_stream_ops.metadata_updated";
 
-	zassert_equal(1, mock_bap_stream_metadata_updated_cb_fake.call_count,
+	zexpect_equal(1, mock_bap_stream_metadata_updated_cb_fake.call_count,
 		      "'%s()' was called %u times, but expected once",
 		      func_name, mock_bap_stream_metadata_updated_cb_fake.call_count);
 
-	zassert_equal_ptr(stream, mock_bap_stream_metadata_updated_cb_fake.arg0_val,
-			  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	if (mock_bap_stream_metadata_updated_cb_fake.call_count > 0) {
+		zexpect_equal_ptr(stream, mock_bap_stream_metadata_updated_cb_fake.arg0_val,
+				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	}
 }
 
 static inline void expect_bt_bap_stream_ops_metadata_updated_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.metadata_updated";
 
-	zassert_equal(0, mock_bap_stream_metadata_updated_cb_fake.call_count,
+	zexpect_equal(0, mock_bap_stream_metadata_updated_cb_fake.call_count,
 		      "'%s()' was called unexpectedly", func_name);
 }
 
@@ -103,19 +111,21 @@ static inline void expect_bt_bap_stream_ops_disabled_called_once(struct bt_bap_s
 {
 	const char *func_name = "bt_bap_stream_ops.disabled";
 
-	zassert_equal(1, mock_bap_stream_disabled_cb_fake.call_count,
+	zexpect_equal(1, mock_bap_stream_disabled_cb_fake.call_count,
 		      "'%s()' was called %u times, but expected once",
 		      func_name, mock_bap_stream_disabled_cb_fake.call_count);
 
-	zassert_equal_ptr(stream, mock_bap_stream_disabled_cb_fake.arg0_val,
-			  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	if (mock_bap_stream_disabled_cb_fake.call_count > 0) {
+		zexpect_equal_ptr(stream, mock_bap_stream_disabled_cb_fake.arg0_val,
+				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	}
 }
 
 static inline void expect_bt_bap_stream_ops_disabled_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.disabled";
 
-	zassert_equal(0, mock_bap_stream_disabled_cb_fake.call_count,
+	zexpect_equal(0, mock_bap_stream_disabled_cb_fake.call_count,
 		      "'%s()' was called unexpectedly", func_name);
 }
 
@@ -123,19 +133,21 @@ static inline void expect_bt_bap_stream_ops_released_called_once(struct bt_bap_s
 {
 	const char *func_name = "bt_bap_stream_ops.released";
 
-	zassert_equal(1, mock_bap_stream_released_cb_fake.call_count,
+	zexpect_equal(1, mock_bap_stream_released_cb_fake.call_count,
 		      "'%s()' was called %u times, but expected once",
 		      func_name, mock_bap_stream_released_cb_fake.call_count);
 
-	zassert_equal_ptr(stream, mock_bap_stream_released_cb_fake.arg0_val,
-			  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	if (mock_bap_stream_released_cb_fake.call_count > 0) {
+		zexpect_equal_ptr(stream, mock_bap_stream_released_cb_fake.arg0_val,
+				   "'%s()' was called with incorrect '%s'", func_name, "stream");
+	}
 }
 
 static inline void expect_bt_bap_stream_ops_released_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.released";
 
-	zassert_equal(0, mock_bap_stream_released_cb_fake.call_count,
+	zexpect_equal(0, mock_bap_stream_released_cb_fake.call_count,
 		      "'%s()' was called unexpectedly", func_name);
 }
 
@@ -143,19 +155,21 @@ static inline void expect_bt_bap_stream_ops_started_called_once(struct bt_bap_st
 {
 	const char *func_name = "bt_bap_stream_ops.started";
 
-	zassert_equal(1, mock_bap_stream_started_cb_fake.call_count,
+	zexpect_equal(1, mock_bap_stream_started_cb_fake.call_count,
 		      "'%s()' was called %u times, but expected once",
 		      func_name, mock_bap_stream_started_cb_fake.call_count);
 
-	zassert_equal_ptr(stream, mock_bap_stream_started_cb_fake.arg0_val,
-			  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	if (mock_bap_stream_started_cb_fake.call_count > 0) {
+		zexpect_equal_ptr(stream, mock_bap_stream_started_cb_fake.arg0_val,
+				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	}
 }
 
 static inline void expect_bt_bap_stream_ops_started_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.started";
 
-	zassert_equal(0, mock_bap_stream_started_cb_fake.call_count,
+	zexpect_equal(0, mock_bap_stream_started_cb_fake.call_count,
 		      "'%s()' was called unexpectedly", func_name);
 }
 
@@ -163,26 +177,28 @@ static inline void expect_bt_bap_stream_ops_started_not_called(void)
 do {                                                                                               \
 	const char *func_name = "bt_bap_stream_ops.stopped";                                       \
 												   \
-	zassert_equal(1, mock_bap_stream_stopped_cb_fake.call_count,                               \
+	zexpect_equal(1, mock_bap_stream_stopped_cb_fake.call_count,                               \
 		      "'%s()' was called %u times, but expected once",                             \
 		      func_name, mock_bap_stream_stopped_cb_fake.call_count);                      \
 												   \
-	IF_NOT_EMPTY(_stream, (                                                                    \
-		     zassert_equal_ptr(_stream, mock_bap_stream_stopped_cb_fake.arg0_val,          \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "stream");))                                     \
+	if (mock_bap_stream_stopped_cb_fake.call_count > 0) {                                      \
+		IF_NOT_EMPTY(_stream, (                                                            \
+			zexpect_equal_ptr(_stream, mock_bap_stream_stopped_cb_fake.arg0_val,       \
+					  "'%s()' was called with incorrect '%s' value",           \
+					  func_name, "stream");))                                  \
 												   \
-	IF_NOT_EMPTY(_reason, (                                                                    \
-		     zassert_equal(_reason, mock_bap_stream_stopped_cb_fake.arg1_val,              \
-				   "'%s()' was called with incorrect '%s' value",                  \
-				   func_name, "reason");))                                         \
+		IF_NOT_EMPTY(_reason, (                                                            \
+			zexpect_equal(_reason, mock_bap_stream_stopped_cb_fake.arg1_val,           \
+				      "'%s()' was called with incorrect '%s' value",               \
+				      func_name, "reason");))                                      \
+	}                                                                                          \
 } while (0)
 
 static inline void expect_bt_bap_stream_ops_stopped_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.stopped";
 
-	zassert_equal(0, mock_bap_stream_stopped_cb_fake.call_count,
+	zexpect_equal(0, mock_bap_stream_stopped_cb_fake.call_count,
 		      "'%s()' was called unexpectedly", func_name);
 }
 
@@ -192,12 +208,15 @@ static inline void expect_bt_bap_stream_ops_recv_called_once(struct bt_bap_strea
 {
 	const char *func_name = "bt_bap_stream_ops.recv";
 
-	zassert_equal(1, mock_bap_stream_recv_cb_fake.call_count,
+	zexpect_equal(1, mock_bap_stream_recv_cb_fake.call_count,
 		      "'%s()' was called %u times, but expected once",
 		      func_name, mock_bap_stream_recv_cb_fake.call_count);
 
-	zassert_equal_ptr(stream, mock_bap_stream_recv_cb_fake.arg0_val,
-			  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	if (mock_bap_stream_recv_cb_fake.call_count > 0) {
+		zexpect_equal_ptr(stream, mock_bap_stream_recv_cb_fake.arg0_val,
+				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	}
+
 	/* TODO: validate info && buf */
 }
 
@@ -205,7 +224,7 @@ static inline void expect_bt_bap_stream_ops_recv_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.recv";
 
-	zassert_equal(0, mock_bap_stream_recv_cb_fake.call_count,
+	zexpect_equal(0, mock_bap_stream_recv_cb_fake.call_count,
 		      "'%s()' was called unexpectedly", func_name);
 }
 
@@ -213,19 +232,21 @@ static inline void expect_bt_bap_stream_ops_sent_called_once(struct bt_bap_strea
 {
 	const char *func_name = "bt_bap_stream_ops.sent";
 
-	zassert_equal(1, mock_bap_stream_sent_cb_fake.call_count,
+	zexpect_equal(1, mock_bap_stream_sent_cb_fake.call_count,
 		      "'%s()' was called %u times, but expected once",
 		      func_name, mock_bap_stream_sent_cb_fake.call_count);
 
-	zassert_equal_ptr(stream, mock_bap_stream_sent_cb_fake.arg0_val,
-			  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	if (mock_bap_stream_sent_cb_fake.call_count > 0) {
+		zexpect_equal_ptr(stream, mock_bap_stream_sent_cb_fake.arg0_val,
+				  "'%s()' was called with incorrect '%s'", func_name, "stream");
+	}
 }
 
 static inline void expect_bt_bap_stream_ops_sent_not_called(void)
 {
 	const char *func_name = "bt_bap_stream_ops.sent";
 
-	zassert_equal(0, mock_bap_stream_sent_cb_fake.call_count,
+	zexpect_equal(0, mock_bap_stream_sent_cb_fake.call_count,
 		      "'%s()' was called unexpectedly", func_name);
 }
 

--- a/tests/bluetooth/audio/mocks/include/bap_unicast_server_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_unicast_server_expects.h
@@ -155,6 +155,26 @@ do {                                                                            
 				       func_name, "stream");))                                     \
 } while (0)
 
+#define expect_bt_bap_unicast_server_cb_release_called_twice(_streams)                             \
+do {                                                                                               \
+	const char *func_name = "bt_bap_unicast_server_cb.release";                                \
+												   \
+	zassert_equal(2, mock_bap_unicast_server_cb_release_fake.call_count,                       \
+		      "'%s()' was called %u times, but expected once",                             \
+		      func_name, mock_bap_unicast_server_cb_release_fake.call_count);              \
+												   \
+	IF_NOT_EMPTY(_stream[0], (                                                                 \
+		     zassert_equal_ptr(_streams[0],                                                \
+				       mock_bap_unicast_server_cb_release_fake.arg0_history[0],    \
+				       "'%s()' was called with incorrect '%s' value",              \
+				       func_name, "stream[0]");))                                  \
+	IF_NOT_EMPTY(_stream[1], (                                                                 \
+		     zassert_equal_ptr(_streams[1],                                                \
+				       mock_bap_unicast_server_cb_release_fake.arg0_history[1],    \
+				       "'%s()' was called with incorrect '%s' value",              \
+				       func_name, "stream[1]");))                                  \
+} while (0)
+
 #define expect_bt_bap_unicast_server_cb_start_called_once(_stream)                                 \
 do {                                                                                               \
 	const char *func_name = "bt_bap_unicast_server_cb.start";                                  \

--- a/tests/bluetooth/audio/mocks/include/bap_unicast_server_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_unicast_server_expects.h
@@ -16,9 +16,7 @@
 do {                                                                                               \
 	const char *func_name = "bt_bap_unicast_server_cb.config";                                 \
 												   \
-	zassert_equal(1, mock_bap_unicast_server_cb_config_fake.call_count,                        \
-		      "'%s()' was called %u times, but expected once",                             \
-		      func_name, mock_bap_unicast_server_cb_config_fake.call_count);               \
+	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_config_fake.call_count);       \
 												   \
 	IF_NOT_EMPTY(_conn, (                                                                      \
 		     zassert_equal_ptr(_conn, mock_bap_unicast_server_cb_config_fake.arg0_val,     \
@@ -44,10 +42,7 @@ do {                                                                            
 do {                                                                                               \
 	const char *func_name = "bt_bap_unicast_server_cb.reconfig";                               \
 												   \
-	zassert_true(mock_bap_unicast_server_cb_reconfig_fake.call_count > 0,                      \
-		     "'%s()' was not called", func_name);                                          \
-	zassert_equal(1, mock_bap_unicast_server_cb_reconfig_fake.call_count,                      \
-		      "'%s()' was called more than once", func_name);                              \
+	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_reconfig_fake.call_count);     \
 												   \
 	IF_NOT_EMPTY(_stream, (                                                                    \
 		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_reconfig_fake.arg0_val, \
@@ -68,9 +63,7 @@ do {                                                                            
 do {                                                                                               \
 	const char *func_name = "bt_bap_unicast_server_cb.qos";                                    \
 												   \
-	zassert_equal(1, mock_bap_unicast_server_cb_qos_fake.call_count,                           \
-		      "'%s()' was called %u times, but expected once",                             \
-		      func_name, mock_bap_unicast_server_cb_qos_fake.call_count);                  \
+	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_qos_fake.call_count);          \
 												   \
 	IF_NOT_EMPTY(_stream, (                                                                    \
 		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_qos_fake.arg0_val,      \
@@ -86,9 +79,7 @@ do {                                                                            
 do {                                                                                               \
 	const char *func_name = "bt_bap_unicast_server_cb.enable";                                 \
 												   \
-	zassert_equal(1, mock_bap_unicast_server_cb_enable_fake.call_count,                        \
-		      "'%s()' was called %u times, but expected once",                             \
-		      func_name, mock_bap_unicast_server_cb_enable_fake.call_count);               \
+	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_enable_fake.call_count);       \
 												   \
 	IF_NOT_EMPTY(_stream, (                                                                    \
 		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_enable_fake.arg0_val,   \
@@ -108,10 +99,7 @@ do {                                                                            
 do {                                                                                               \
 	const char *func_name = "bt_bap_unicast_server_cb.enable";                                 \
 												   \
-	zassert_true(mock_bap_unicast_server_cb_metadata_fake.call_count > 0,                      \
-		     "'%s()' was not called", func_name);                                          \
-	zassert_equal(1, mock_bap_unicast_server_cb_metadata_fake.call_count,                      \
-		      "'%s()' was called more than once", func_name);                              \
+	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_metadata_fake.call_count);     \
 												   \
 	IF_NOT_EMPTY(_stream, (                                                                    \
 		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_metadata_fake.arg0_val, \
@@ -131,9 +119,7 @@ do {                                                                            
 do {                                                                                               \
 	const char *func_name = "bt_bap_unicast_server_cb.disable";                                \
 												   \
-	zassert_equal(1, mock_bap_unicast_server_cb_disable_fake.call_count,                       \
-		      "'%s()' was called %u times, but expected once",                             \
-		      func_name, mock_bap_unicast_server_cb_disable_fake.call_count);              \
+	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_disable_fake.call_count);      \
 												   \
 	IF_NOT_EMPTY(_stream, (                                                                    \
 		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_disable_fake.arg0_val,  \
@@ -145,9 +131,7 @@ do {                                                                            
 do {                                                                                               \
 	const char *func_name = "bt_bap_unicast_server_cb.release";                                \
 												   \
-	zassert_equal(1, mock_bap_unicast_server_cb_release_fake.call_count,                       \
-		      "'%s()' was called %u times, but expected once",                             \
-		      func_name, mock_bap_unicast_server_cb_release_fake.call_count);              \
+	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_release_fake.call_count);      \
 												   \
 	IF_NOT_EMPTY(_stream, (                                                                    \
 		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_release_fake.arg0_val,  \
@@ -159,9 +143,7 @@ do {                                                                            
 do {                                                                                               \
 	const char *func_name = "bt_bap_unicast_server_cb.release";                                \
 												   \
-	zassert_equal(2, mock_bap_unicast_server_cb_release_fake.call_count,                       \
-		      "'%s()' was called %u times, but expected once",                             \
-		      func_name, mock_bap_unicast_server_cb_release_fake.call_count);              \
+	zexpect_call_count(func_name, 2, mock_bap_unicast_server_cb_release_fake.call_count);      \
 												   \
 	IF_NOT_EMPTY(_stream[0], (                                                                 \
 		     zassert_equal_ptr(_streams[0],                                                \
@@ -179,10 +161,7 @@ do {                                                                            
 do {                                                                                               \
 	const char *func_name = "bt_bap_unicast_server_cb.start";                                  \
 												   \
-	zassert_true(mock_bap_unicast_server_cb_start_fake.call_count > 0,                         \
-		     "'%s()' was not called", func_name);                                          \
-	zassert_equal(1, mock_bap_unicast_server_cb_start_fake.call_count,                         \
-		      "'%s()' was called more than once", func_name);                              \
+	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_start_fake.call_count);        \
 												   \
 	IF_NOT_EMPTY(_stream, (                                                                    \
 		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_start_fake.arg0_val,    \
@@ -194,10 +173,7 @@ do {                                                                            
 do {                                                                                               \
 	const char *func_name = "bt_bap_unicast_server_cb.stop";                                   \
 												   \
-	zassert_true(mock_bap_unicast_server_cb_stop_fake.call_count > 0,                          \
-		     "'%s()' was not called", func_name);                                          \
-	zassert_equal(1, mock_bap_unicast_server_cb_stop_fake.call_count,                          \
-		      "'%s()' was called more than once", func_name);                              \
+	zexpect_call_count(func_name, 1, mock_bap_unicast_server_cb_stop_fake.call_count);         \
 												   \
 	IF_NOT_EMPTY(_stream, (                                                                    \
 		     zassert_equal_ptr(_stream, mock_bap_unicast_server_cb_stop_fake.arg0_val,     \
@@ -209,8 +185,7 @@ static inline void expect_bt_bap_unicast_server_cb_config_not_called(void)
 {
 	const char *func_name = "bt_bap_unicast_server_cb.config";
 
-	zassert_equal(0, mock_bap_unicast_server_cb_config_fake.call_count,
-		      "'%s()' was called unexpectedly", func_name);
+	zexpect_call_count(func_name, 0, mock_bap_unicast_server_cb_config_fake.call_count);
 }
 
 #endif /* MOCKS_BAP_UNICAST_SERVER_EXPECTS_H_ */

--- a/tests/bluetooth/audio/mocks/include/conn.h
+++ b/tests/bluetooth/audio/mocks/include/conn.h
@@ -14,4 +14,6 @@ struct bt_conn {
 	struct bt_conn_info info;
 };
 
+void mock_bt_conn_disconnected(struct bt_conn *conn, uint8_t err);
+
 #endif /* MOCKS_CONN_H_ */

--- a/tests/bluetooth/audio/mocks/include/expects_util.h
+++ b/tests/bluetooth/audio/mocks/include/expects_util.h
@@ -9,6 +9,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/ztest.h>
 
 #define CHECK_EMPTY(_x) UTIL_BOOL(IS_EMPTY(_x))
 #define COND_CODE_EMPTY(_x, _if_any_code, _else_code)                                              \
@@ -18,6 +19,10 @@
 
 #define expect_data(_func_name, _arg_name, _exp_data, _data, _len)                                 \
 	IF_NOT_EMPTY(_exp_data, (expect_data_equal(_func_name, _arg_name, _exp_data, _data, _len);))
+
+#define zexpect_call_count(_func_name, _expected, _actual)                                         \
+	zexpect_equal(_expected, _actual, "'%s()' was called %u times, expected %u times",         \
+		      _func_name, _actual, _expected)
 
 static inline void expect_data_equal(const char *func_name, const char *arg_name,
 				     const uint8_t *expect, const uint8_t *data, size_t len)

--- a/tests/bluetooth/audio/mocks/src/conn.c
+++ b/tests/bluetooth/audio/mocks/src/conn.c
@@ -29,3 +29,12 @@ void bt_conn_unref(struct bt_conn *conn)
 {
 
 }
+
+void mock_bt_conn_disconnected(struct bt_conn *conn, uint8_t err)
+{
+	STRUCT_SECTION_FOREACH(bt_conn_cb, cb) {
+		if (cb->disconnected) {
+			cb->disconnected(conn, err);
+		}
+	}
+}

--- a/tests/bluetooth/audio/mocks/src/kernel.c
+++ b/tests/bluetooth/audio/mocks/src/kernel.c
@@ -38,10 +38,12 @@ int k_work_reschedule(struct k_work_delayable *dwork, k_timeout_t delay)
 	/* Determine whether the work item is queued already. */
 	SYS_SLIST_FOR_EACH_CONTAINER(&work_pending, work, node) {
 		if (work == &dwork->work) {
+			dwork->timeout.dticks = delay.ticks;
 			return 0;
 		}
 	}
 
+	dwork->timeout.dticks = delay.ticks;
 	sys_slist_append(&work_pending, &dwork->work.node);
 
 	return 0;
@@ -50,6 +52,27 @@ int k_work_reschedule(struct k_work_delayable *dwork, k_timeout_t delay)
 int k_work_cancel_delayable(struct k_work_delayable *dwork)
 {
 	(void)sys_slist_find_and_remove(&work_pending, &dwork->work.node);
+
+	return 0;
+}
+
+int32_t k_sleep(k_timeout_t timeout)
+{
+	struct k_work *work;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&work_pending, work, node) {
+		if (work->flags & K_WORK_DELAYED) {
+			struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+
+			if (dwork->timeout.dticks > timeout.ticks) {
+				dwork->timeout.dticks -= timeout.ticks;
+				continue;
+			}
+		}
+
+		(void)sys_slist_remove(&work_pending, NULL, &work->node);
+		work->handler(work);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Once the ACL disconnects, the implementation releases the related
endpoints. The ops->released callback is called once ASE enters IDLE
state, thus there is no need to call it explicitly.
This fixes repeated ops->released callback call.