### PR TITLE
dts: stm32h5: Add support for adc2

### DIFF
--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -139,6 +139,21 @@
 			status = "disabled";
 		};
 
+		adc2: adc@42028100 {
+			compatible = "st,stm32-adc";
+			reg = <0x42028100 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000400>;
+			interrupts = <69 0>;
+			status = "disabled";
+			vref-mv = <3300>;
+			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+					STM32_ADC_RES(10, 0x01)
+					STM32_ADC_RES(8, 0x02)
+					STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <3 7 13 25 48 93 248 641>;
+		};
+
 		timers4: timers@40000800 {
 			compatible = "st,stm32-timers";
 			reg = <0x40000800 0x400>;


### PR DESCRIPTION
Add support for ADC2 on the stm32h5 devices that supports this