### PR TITLE
dts/arm/st: add SoC compatible strings

### DIFF
--- a/dts/arm/st/c0/stm32c031.dtsi
+++ b/dts/arm/st/c0/stm32c031.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32c031", "st,stm32c0", "simple-bus";
+
 		pinctrl: pin-controller@50000000 {
 			gpiod: gpio@50000c00 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/f0/stm32f030.dtsi
+++ b/dts/arm/st/f0/stm32f030.dtsi
@@ -7,6 +7,10 @@
 #include <st/f0/stm32f0.dtsi>
 
 / {
+	soc {
+		compatible = "st,stm32f030", "st,stm32f0", "simple-bus";
+	};
+
 	die_temp: dietemp {
 		compatible = "st,stm32c0-temp-cal";
 		ts-cal1-addr = <0x1FFFF7B8>;

--- a/dts/arm/st/f0/stm32f031.dtsi
+++ b/dts/arm/st/f0/stm32f031.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f031", "st,stm32f0", "simple-bus";
+
 		timers2: timers@40000000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40000000 0x400>;

--- a/dts/arm/st/f0/stm32f042.dtsi
+++ b/dts/arm/st/f0/stm32f042.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f042", "st,stm32f0", "simple-bus";
+
 		clocks {
 			clk_hsi48: clk-hsi48 {
 				#clock-cells = <0>;

--- a/dts/arm/st/f0/stm32f051.dtsi
+++ b/dts/arm/st/f0/stm32f051.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f051", "st,stm32f0", "simple-bus";
+
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;

--- a/dts/arm/st/f0/stm32f070.dtsi
+++ b/dts/arm/st/f0/stm32f070.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f070", "st,stm32f0", "simple-bus";
+
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;

--- a/dts/arm/st/f0/stm32f071.dtsi
+++ b/dts/arm/st/f0/stm32f071.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f071", "st,stm32f0", "simple-bus";
+
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
 				erase-block-size = <2048>;

--- a/dts/arm/st/f0/stm32f072.dtsi
+++ b/dts/arm/st/f0/stm32f072.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f072", "st,stm32f0", "simple-bus";
+
 		can1: can@40006400 {
 			compatible = "st,stm32-can";
 			reg = <0x40006400 0x400>;

--- a/dts/arm/st/f0/stm32f091.dtsi
+++ b/dts/arm/st/f0/stm32f091.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f091", "st,stm32f0", "simple-bus";
+
 		/*
 		 * USARTs 3-8 share the same IRQ on stm32f091xx devices. This
 		 * configuration is not currently supported, so at most one of

--- a/dts/arm/st/f1/stm32f100Xb.dtsi
+++ b/dts/arm/st/f1/stm32f100Xb.dtsi
@@ -25,6 +25,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32f100", "st,stm32f1", "simple-bus";
+
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
 				reg = <0x08000000 DT_SIZE_K(128)>;

--- a/dts/arm/st/f1/stm32f103X8.dtsi
+++ b/dts/arm/st/f1/stm32f103X8.dtsi
@@ -13,6 +13,7 @@
 	};
 
 	soc {
+		compatible = "st,stm32f103", "st,stm32f1", "simple-bus";
 
 		flash-controller@40022000 {
 			flash0: flash@8000000 {

--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -25,6 +25,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32f105", "st,stm32f1", "simple-bus";
+
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
 				erase-block-size = <DT_SIZE_K(2)>;

--- a/dts/arm/st/f1/stm32f107.dtsi
+++ b/dts/arm/st/f1/stm32f107.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f107", "st,stm32f1", "simple-bus";
+
 		dma2: dma@40020400 {
 			compatible = "st,stm32-dma-v2bis";
 			#dma-cells = <2>;

--- a/dts/arm/st/f2/stm32f207.dtsi
+++ b/dts/arm/st/f2/stm32f207.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f207", "st,stm32f2", "simple-bus";
+
 		mac: ethernet@40028000 {
 			compatible = "st,stm32-ethernet";
 			reg = <0x40028000 0x8000>;

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f302", "st,stm32f3", "simple-bus";
+
 		usb: usb@40005c00 {
 			/* Remap USB_LP IRQ to enable use with CAN_1 */
 			interrupts = <75 0>;

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f303", "st,stm32f3", "simple-bus";
+
 		usb: usb@40005c00 {
 			/* Remap USB_LP IRQ to enable use with CAN_1 */
 			interrupts = <75 0>;

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f334", "st,stm32f3", "simple-bus";
+
 		timers1: timers@40012c00 {
 			compatible = "st,stm32-timers";
 			reg = <0x40012c00 0x400>;

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f373", "st,stm32f3", "simple-bus";
+
 		pinctrl: pin-controller@48000000 {
 			gpioe: gpio@48001000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/f4/stm32f401.dtsi
+++ b/dts/arm/st/f4/stm32f401.dtsi
@@ -16,6 +16,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32f401", "st,stm32f4", "simple-bus";
+
 		spi2: spi@40003800 {
 			compatible = "st,stm32-spi";
 			#address-cells = <1>;

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -13,6 +13,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32f405", "st,stm32f4", "simple-bus";
+
 		pinctrl: pin-controller@40020000 {
 			reg = <0x40020000 0x2400>;
 

--- a/dts/arm/st/f4/stm32f407.dtsi
+++ b/dts/arm/st/f4/stm32f407.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f407", "st,stm32f4", "simple-bus";
+
 		mac: ethernet@40028000 {
 			compatible = "st,stm32-ethernet";
 			reg = <0x40028000 0x8000>;

--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -13,6 +13,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32f410", "st,stm32f4", "simple-bus";
+
 		spi2: spi@40003800 {
 			compatible = "st,stm32-spi";
 			#address-cells = <1>;

--- a/dts/arm/st/f4/stm32f411.dtsi
+++ b/dts/arm/st/f4/stm32f411.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f411", "st,stm32f4", "simple-bus";
+
 		spi5: spi@40015000 {
 			compatible = "st,stm32-spi";
 			#address-cells = <1>;

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -19,6 +19,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32f412", "st,stm32f4", "simple-bus";
+
 		pinctrl: pin-controller@40020000 {
 			reg = <0x40020000 0x1c00>;
 

--- a/dts/arm/st/f4/stm32f413.dtsi
+++ b/dts/arm/st/f4/stm32f413.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f413", "st,stm32f4", "simple-bus";
+
 		uart4: serial@40004c00 {
 			compatible ="st,stm32-uart";
 			reg = <0x40004c00 0x400>;

--- a/dts/arm/st/f4/stm32f415.dtsi
+++ b/dts/arm/st/f4/stm32f415.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f415", "st,stm32f4", "simple-bus";
+
 		cryp: cryp@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;

--- a/dts/arm/st/f4/stm32f417.dtsi
+++ b/dts/arm/st/f4/stm32f417.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f417", "st,stm32f4", "simple-bus";
+
 		cryp: cryp@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;

--- a/dts/arm/st/f4/stm32f423.dtsi
+++ b/dts/arm/st/f4/stm32f423.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f423", "st,stm32f4", "simple-bus";
+
 		aes: aes@50060000 {
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -10,6 +10,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f427", "st,stm32f4", "simple-bus";
+
 		pinctrl: pin-controller@40020000 {
 			reg = <0x40020000 0x2C00>;
 

--- a/dts/arm/st/f4/stm32f429.dtsi
+++ b/dts/arm/st/f4/stm32f429.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f429", "st,stm32f4", "simple-bus";
+
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f437", "st,stm32f4", "simple-bus";
+
 		cryp: cryp@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -16,6 +16,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32f446", "st,stm32f4", "simple-bus";
+
 		i2s1: i2s@40013000 {
 			compatible = "st,stm32-i2s";
 			#address-cells = <1>;

--- a/dts/arm/st/f4/stm32f469.dtsi
+++ b/dts/arm/st/f4/stm32f469.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f469", "st,stm32f4", "simple-bus";
+
 		sdmmc1: sdmmc@40012c00 {
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>,
 				 <&rcc STM32_SRC_SYSCLK SDMMC_SEL(1)>;

--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -27,6 +27,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32f723", "st,stm32f7", "simple-bus";
+
 		usbphyc: usbphyc@40017c00 {
 			compatible = "st,stm32-usbphyc";
 			reg = <0x40017c00 0x400>;

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -21,6 +21,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32f745", "st,stm32f7", "simple-bus";
+
 		pinctrl: pin-controller@40020000 {
 			reg = <0x40020000 0x2C00>;
 

--- a/dts/arm/st/f7/stm32f746.dtsi
+++ b/dts/arm/st/f7/stm32f746.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32f746", "st,stm32f7", "simple-bus";
+
 		ltdc: display-controller@40016800 {
 			compatible = "st,stm32-ltdc";
 			reg = <0x40016800 0x200>;

--- a/dts/arm/st/f7/stm32f750.dtsi
+++ b/dts/arm/st/f7/stm32f750.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/f7/stm32f746.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32f750", "st,stm32f7", "simple-bus";
+	};
+};

--- a/dts/arm/st/f7/stm32f756.dtsi
+++ b/dts/arm/st/f7/stm32f756.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/f7/stm32f746.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32f756", "st,stm32f7", "simple-bus";
+	};
+};

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -24,6 +24,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32f767", "st,stm32f7", "simple-bus";
+
 		pinctrl: pin-controller@40020000 {
 			reg = <0x40020000 0x2C00>;
 

--- a/dts/arm/st/f7/stm32f769.dtsi
+++ b/dts/arm/st/f7/stm32f769.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/f7/stm32f767.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32f769", "st,stm32f7", "simple-bus";
+	};
+};

--- a/dts/arm/st/g0/stm32g030.dtsi
+++ b/dts/arm/st/g0/stm32g030.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/g0/stm32g0.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32g030", "st,stm32g0", "simple-bus";
+	};
+};

--- a/dts/arm/st/g0/stm32g031.dtsi
+++ b/dts/arm/st/g0/stm32g031.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32g031", "st,stm32g0", "simple-bus";
+
 		lpuart1: serial@40008000 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;

--- a/dts/arm/st/g0/stm32g041.dtsi
+++ b/dts/arm/st/g0/stm32g041.dtsi
@@ -6,3 +6,9 @@
 
 #include <st/g0/stm32g031.dtsi>
 #include <st/g0/stm32g0_crypt.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32g041", "st,stm32g0", "simple-bus";
+	};
+};

--- a/dts/arm/st/g0/stm32g050.dtsi
+++ b/dts/arm/st/g0/stm32g050.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32g050", "st,stm32g0", "simple-bus";
+
 		timers6: timers@40001000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40001000 0x400>;

--- a/dts/arm/st/g0/stm32g051.dtsi
+++ b/dts/arm/st/g0/stm32g051.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32g051", "st,stm32g0", "simple-bus";
+
 		timers6: timers@40001000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40001000 0x400>;

--- a/dts/arm/st/g0/stm32g061.dtsi
+++ b/dts/arm/st/g0/stm32g061.dtsi
@@ -6,3 +6,9 @@
 
 #include <st/g0/stm32g051.dtsi>
 #include <st/g0/stm32g0_crypt.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32g061", "st,stm32g0", "simple-bus";
+	};
+};

--- a/dts/arm/st/g0/stm32g070.dtsi
+++ b/dts/arm/st/g0/stm32g070.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32g070", "st,stm32g0", "simple-bus";
+
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;

--- a/dts/arm/st/g0/stm32g071.dtsi
+++ b/dts/arm/st/g0/stm32g071.dtsi
@@ -10,6 +10,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32g071", "st,stm32g0", "simple-bus";
+
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;

--- a/dts/arm/st/g0/stm32g081.dtsi
+++ b/dts/arm/st/g0/stm32g081.dtsi
@@ -6,3 +6,9 @@
 
 #include <st/g0/stm32g071.dtsi>
 #include <st/g0/stm32g0_crypt.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32g081", "st,stm32g0", "simple-bus";
+	};
+};

--- a/dts/arm/st/g0/stm32g0b0.dtsi
+++ b/dts/arm/st/g0/stm32g0b0.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32g0b0", "st,stm32g0", "simple-bus";
+
 		pinctrl: pin-controller@50000000 {
 			gpioe: gpio@50001000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32g0b1", "st,stm32g0", "simple-bus";
+
 		clocks {
 			clk_hsi48: clk-hsi48 {
 				#clock-cells = <0>;

--- a/dts/arm/st/g0/stm32g0c1.dtsi
+++ b/dts/arm/st/g0/stm32g0c1.dtsi
@@ -6,3 +6,9 @@
 
 #include <st/g0/stm32g0b1.dtsi>
 #include <st/g0/stm32g0_crypt.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32g0c1", "st,stm32g0", "simple-bus";
+	};
+};

--- a/dts/arm/st/g4/stm32g431.dtsi
+++ b/dts/arm/st/g4/stm32g431.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32g431", "st,stm32g4", "simple-bus";
+
 		dma1: dma@40020000 {
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0>;
 			dma-requests = <6>;

--- a/dts/arm/st/g4/stm32g441.dtsi
+++ b/dts/arm/st/g4/stm32g441.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/g4/stm32g431.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32g441", "st,stm32g4", "simple-bus";
+	};
+};

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32g473", "st,stm32g4", "simple-bus";
+
 		timers5: timers@40000c00 {
 			compatible = "st,stm32-timers";
 			reg = <0x40000c00 0x400>;

--- a/dts/arm/st/g4/stm32g474.dtsi
+++ b/dts/arm/st/g4/stm32g474.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/g4/stm32g473.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32g474", "st,stm32g4", "simple-bus";
+	};
+};

--- a/dts/arm/st/g4/stm32g483.dtsi
+++ b/dts/arm/st/g4/stm32g483.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/g4/stm32g473.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32g483", "st,stm32g4", "simple-bus";
+	};
+};

--- a/dts/arm/st/g4/stm32g484.dtsi
+++ b/dts/arm/st/g4/stm32g484.dtsi
@@ -6,3 +6,8 @@
 
 #include <st/g4/stm32g474.dtsi>
 
+/ {
+	soc {
+		compatible = "st,stm32g484", "st,stm32g4", "simple-bus";
+	};
+};

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32g491", "st,stm32g4", "simple-bus";
+
 		can {
 			can2: can@40006800 {
 				compatible = "st,stm32-fdcan";

--- a/dts/arm/st/g4/stm32g4a1.dtsi
+++ b/dts/arm/st/g4/stm32g4a1.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/g4/stm32g491.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32g4a1", "st,stm32g4", "simple-bus";
+	};
+};

--- a/dts/arm/st/h5/stm32h503.dtsi
+++ b/dts/arm/st/h5/stm32h503.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/h5/stm32h5.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32h503", "st,stm32h5", "simple-bus";
+	};
+};

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -18,6 +18,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32h562", "st,stm32h5", "simple-bus";
+
 		pinctrl: pin-controller@42020000 {
 			gpioe: gpio@42021000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/h5/stm32h562.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32h563", "st,stm32h5", "simple-bus";
+	};
+};

--- a/dts/arm/st/h5/stm32h573.dtsi
+++ b/dts/arm/st/h5/stm32h573.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/h5/stm32h563.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32h573", "st,stm32h5", "simple-bus";
+	};
+};

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -12,6 +12,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32h723", "st,stm32h7", "simple-bus";
+
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
 				compatible = "st,stm32-nv-flash", "soc-nv-flash";

--- a/dts/arm/st/h7/stm32h725.dtsi
+++ b/dts/arm/st/h7/stm32h725.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/h7/stm32h723.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32h725", "st,stm32h7", "simple-bus";
+	};
+};

--- a/dts/arm/st/h7/stm32h730.dtsi
+++ b/dts/arm/st/h7/stm32h730.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32h730", "st,stm32h7", "simple-bus";
+
 		cryp: cryp@48021000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;

--- a/dts/arm/st/h7/stm32h735.dtsi
+++ b/dts/arm/st/h7/stm32h735.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/h7/stm32h730.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32h735", "st,stm32h7", "simple-bus";
+	};
+};

--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32h743", "st,stm32h7", "simple-bus";
+
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
 				compatible = "st,stm32-nv-flash", "soc-nv-flash";

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32h745", "st,stm32h7", "simple-bus";
+
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
 				compatible = "st,stm32-nv-flash", "soc-nv-flash";

--- a/dts/arm/st/h7/stm32h747.dtsi
+++ b/dts/arm/st/h7/stm32h747.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32h747", "st,stm32h7", "simple-bus";
+
 		mipi_dsi: dsihost@50000000 {
 			compatible = "st,stm32-mipi-dsi";
 			#address-cells = <1>;

--- a/dts/arm/st/h7/stm32h750.dtsi
+++ b/dts/arm/st/h7/stm32h750.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32h750", "st,stm32h7", "simple-bus";
+
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
 				compatible = "st,stm32-nv-flash", "soc-nv-flash";

--- a/dts/arm/st/h7/stm32h753.dtsi
+++ b/dts/arm/st/h7/stm32h753.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/h7/stm32h743.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32h753", "st,stm32h7", "simple-bus";
+	};
+};

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -10,6 +10,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32h7a3", "st,stm32h7", "simple-bus";
+
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
 				compatible = "st,stm32-nv-flash", "soc-nv-flash";

--- a/dts/arm/st/h7/stm32h7b3.dtsi
+++ b/dts/arm/st/h7/stm32h7b3.dtsi
@@ -13,6 +13,8 @@
  */
 / {
 	soc {
+		compatible = "st,stm32h7b3", "st,stm32h7", "simple-bus";
+
 		cryp: cryp@48021000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;

--- a/dts/arm/st/l0/stm32l010.dtsi
+++ b/dts/arm/st/l0/stm32l010.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l010", "st,stm32l0", "simple-bus";
+
 		eeprom: eeprom@8080000{
 			reg = <0x08080000 512>;
 		};

--- a/dts/arm/st/l0/stm32l031.dtsi
+++ b/dts/arm/st/l0/stm32l031.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l031", "st,stm32l0", "simple-bus";
+
 		timers22: timers@40011400 {
 			compatible = "st,stm32-timers";
 			reg = <0x40011400 0x400>;

--- a/dts/arm/st/l0/stm32l051.dtsi
+++ b/dts/arm/st/l0/stm32l051.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l051", "st,stm32l0", "simple-bus";
+
 		i2c2: i2c@40005800 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;

--- a/dts/arm/st/l0/stm32l053.dtsi
+++ b/dts/arm/st/l0/stm32l053.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l053", "st,stm32l0", "simple-bus";
+
 		clocks {
 			clk_hsi48: clk-hsi48 {
 				#clock-cells = <0>;

--- a/dts/arm/st/l0/stm32l071.dtsi
+++ b/dts/arm/st/l0/stm32l071.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l071", "st,stm32l0", "simple-bus";
+
 		pinctrl: pin-controller@50000000 {
 			gpioe: gpio@50001000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/l0/stm32l072.dtsi
+++ b/dts/arm/st/l0/stm32l072.dtsi
@@ -12,6 +12,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32l072", "st,stm32l0", "simple-bus";
+
 		clocks {
 			clk_hsi48: clk-hsi48 {
 				#clock-cells = <0>;

--- a/dts/arm/st/l0/stm32l073.dtsi
+++ b/dts/arm/st/l0/stm32l073.dtsi
@@ -6,3 +6,9 @@
  */
 
 #include <st/l0/stm32l072.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32l073", "st,stm32l0", "simple-bus";
+	};
+};

--- a/dts/arm/st/l1/stm32l151.dtsi
+++ b/dts/arm/st/l1/stm32l151.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/l1/stm32l1.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32l151", "st,stm32l1", "simple-bus";
+	};
+};

--- a/dts/arm/st/l1/stm32l152.dtsi
+++ b/dts/arm/st/l1/stm32l152.dtsi
@@ -9,3 +9,9 @@
  * the STM32L152 features an LCD controller.
  */
 #include <st/l1/stm32l151.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32l152", "st,stm32l1", "simple-bus";
+	};
+};

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l412", "st,stm32l4", "simple-bus";
+
 		clocks {
 			clk_hsi48: clk-hsi48 {
 				#clock-cells = <0>;

--- a/dts/arm/st/l4/stm32l422.dtsi
+++ b/dts/arm/st/l4/stm32l422.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l422", "st,stm32l4", "simple-bus";
+
 		aes: aes@50060000 {
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l431", "st,stm32l4", "simple-bus";
+
 		clocks {
 			clk_hsi48: clk-hsi48 {
 				#clock-cells = <0>;

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l432", "st,stm32l4", "simple-bus";
+
 		clocks {
 			clk_hsi48: clk-hsi48 {
 				#clock-cells = <0>;

--- a/dts/arm/st/l4/stm32l433.dtsi
+++ b/dts/arm/st/l4/stm32l433.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l433", "st,stm32l4", "simple-bus";
+
 		pinctrl: pin-controller@48000000 {
 			gpiod: gpio@48000c00 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/l4/stm32l452.dtsi
+++ b/dts/arm/st/l4/stm32l452.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l452", "st,stm32l4", "simple-bus";
+
 		clocks {
 			clk_hsi48: clk-hsi48 {
 				#clock-cells = <0>;

--- a/dts/arm/st/l4/stm32l462.dtsi
+++ b/dts/arm/st/l4/stm32l462.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l462", "st,stm32l4", "simple-bus";
+
 		aes: aes@50060000 {
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l471", "st,stm32l4", "simple-bus";
+
 		pinctrl: pin-controller@48000000 {
 
 			gpiod: gpio@48000c00 {

--- a/dts/arm/st/l4/stm32l475.dtsi
+++ b/dts/arm/st/l4/stm32l475.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l475", "st,stm32l4", "simple-bus";
+
 		usbotg_fs: otgfs@50000000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x50000000 0x40000>;

--- a/dts/arm/st/l4/stm32l476.dtsi
+++ b/dts/arm/st/l4/stm32l476.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/l4/stm32l475.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32l476", "st,stm32l4", "simple-bus";
+	};
+};

--- a/dts/arm/st/l4/stm32l486.dtsi
+++ b/dts/arm/st/l4/stm32l486.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/l4/stm32l476.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32l486", "st,stm32l4", "simple-bus";
+	};
+};

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l496", "st,stm32l4", "simple-bus";
+
 		clocks {
 			clk_hsi48: clk-hsi48 {
 				#clock-cells = <0>;

--- a/dts/arm/st/l4/stm32l4a6.dtsi
+++ b/dts/arm/st/l4/stm32l4a6.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/l4/stm32l496.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32l4a6", "st,stm32l4", "simple-bus";
+	};
+};

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -16,6 +16,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32l4p5", "st,stm32l4", "simple-bus";
+
 		clocks {
 			clk_hsi48: clk-hsi48 {
 				#clock-cells = <0>;

--- a/dts/arm/st/l4/stm32l4q5.dtsi
+++ b/dts/arm/st/l4/stm32l4q5.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/l4/stm32l4p5.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32l4q5", "st,stm32l4", "simple-bus";
+	};
+};

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -15,6 +15,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32l4r5", "st,stm32l4", "simple-bus";
+
 		rtc@40002800 {
 			bbram: backup_regs {
 				compatible = "st,stm32-bbram";

--- a/dts/arm/st/l4/stm32l4r9.dtsi
+++ b/dts/arm/st/l4/stm32l4r9.dtsi
@@ -10,6 +10,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l4r9", "st,stm32l4", "simple-bus";
+
 		ltdc: display-controller@40016800 {
 			compatible = "st,stm32-ltdc";
 			reg = <0x40016800 0x200>;

--- a/dts/arm/st/l4/stm32l4s5.dtsi
+++ b/dts/arm/st/l4/stm32l4s5.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/l4/stm32l4r5.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32l4s5", "st,stm32l4", "simple-bus";
+	};
+};

--- a/dts/arm/st/l5/stm32l552.dtsi
+++ b/dts/arm/st/l5/stm32l552.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/l5/stm32l5.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32l552", "st,stm32l5", "simple-bus";
+	};
+};

--- a/dts/arm/st/l5/stm32l562.dtsi
+++ b/dts/arm/st/l5/stm32l562.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32l562", "st,stm32l5", "simple-bus";
+
 		aes: aes@420c0000 {
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;

--- a/dts/arm/st/u5/stm32u575.dtsi
+++ b/dts/arm/st/u5/stm32u575.dtsi
@@ -9,6 +9,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32u575", "st,stm32u5", "simple-bus";
+
 		usbotg_fs: otgfs@42040000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x42040000 0x80000>;

--- a/dts/arm/st/u5/stm32u585.dtsi
+++ b/dts/arm/st/u5/stm32u585.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/u5/stm32u575.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32u585", "st,stm32u5", "simple-bus";
+	};
+};

--- a/dts/arm/st/wb/stm32wb55.dtsi
+++ b/dts/arm/st/wb/stm32wb55.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	soc {
+		compatible = "st,stm32wb55", "st,stm32wb", "simple-bus";
+
 		adc1: adc@50040000 {
 			temp-channel = <17>;
 		};

--- a/dts/arm/st/wl/stm32wl55.dtsi
+++ b/dts/arm/st/wl/stm32wl55.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/wl/stm32wl.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32wl55", "st,stm32wl", "simple-bus";
+	};
+};

--- a/dts/arm/st/wl/stm32wle5.dtsi
+++ b/dts/arm/st/wl/stm32wle5.dtsi
@@ -5,3 +5,9 @@
  */
 
 #include <st/wl/stm32wl.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32wle5", "st,stm32wl", "simple-bus";
+	};
+};


### PR DESCRIPTION
This PR adds compatible strings to the SoC nodes from the ST SoCs in Zephyr. This is especially useful for efforts relying on structured data such us [Renodepedia](https://zephyr-dashboard.renode.io/renodepedia/).