### PR TITLE
ci: bump zephyrproject-rtos/action-first-interaction version

### DIFF
--- a/.github/workflows/greet_first_time_contributor.yml
+++ b/.github/workflows/greet_first_time_contributor.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: zephyrproject-rtos/action-first-interaction@v1.1.1-zephyr-1
+      - uses: zephyrproject-rtos/action-first-interaction@v1.1.1-zephyr-3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Bump to v1.1.1-zephyr-3 version of the first-interaction GH action.

This fixes several issues:
- some contributors being improperly flagged as first-time contributors
- retry/throttling handling to address secondary API rate limit causing
action to sometimes fail
- first time contributor not being notified on their first merged PR

Fixes #57644 