### PR TITLE
drivers: uart: Allow early release of an RX buffer

### DIFF
--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -177,9 +177,10 @@ typedef void (*uart_irq_config_func_t)(const struct device *dev);
  *    generated. It can happen multiples times for the same buffer. RX timeout
  *    is counted from last byte received i.e. if no data was received, there
  *    won't be any timeout event.
- * 4. After buffer is filled #UART_RX_RDY will be generated, immediately
- *    followed by #UART_RX_BUF_RELEASED indicating that current buffer
- *    is no longer used.
+ * 4. #UART_RX_BUF_RELEASED event will be generated when the current buffer is
+ *    no longer used by the driver. It will immediately follow #UART_RX_RDY event.
+ *    Depending on the implementation buffer may be released when it is completely
+ *    or partially filled.
  * 5. If there was second buffer provided, it will become current buffer and
  *    we start again at point 2.
  *    If no second buffer was specified receiving is stopped and


### PR DESCRIPTION
I would like to clarify the expected behavior of the UART device in asynchronous API. So far it stated that

```
After buffer is filled #UART_RX_RDY will be generated, immediately followed by #UART_RX_BUF_RELEASED
indicating that current buffer is no longer used.
```

It does not say if it is completely filled or partially and in the test it is assumed that it is completely filed. However, for some implementations (i have one in the pipeline) it may be much more convenient to release buffer after buffer is partially filled (on timeout) if for example timeout event triggers switch of DMA buffers. Rest of the API specifies only that `UART_RX_BUF_RELEASED` event is triggered when buffer is no longer used so no change is needed.

PR is adding clarification in the API and modifies the test to handle buffer release event without assumption that it only happens after buffer is completely filled.