### PR TITLE
When building for board mimxrt1050_evk_qspi make sure to set pyocd ar…

### DIFF
--- a/boards/arm/mimxrt1050_evk/board.cmake
+++ b/boards/arm/mimxrt1050_evk/board.cmake
@@ -3,12 +3,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-
-board_runner_args(pyocd "--target=mimxrt1050_hyperflash")
 board_runner_args(jlink "--device=MCIMXRT1052")
 
 if(${CONFIG_BOARD_MIMXRT1050_EVK_QSPI})
     board_runner_args(jlink "--loader=BankAddr=0x60000000&Loader=QSPI")
+    board_runner_args(pyocd "--target=mimxrt1050_quadspi")
+else()
+    board_runner_args(pyocd "--target=mimxrt1050_hyperflash")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
build: board mimxrt1050_evk_qspi: fix pyocd target arg

When building for mimxrt1050_evk_qspi board, runners.yaml needs to have the pyocd arg target set to mimxrt1050_quadspi so that west knows to access Quad SPI instead of hyperflash.