### PR TITLE
drivers: clock_control: stm32f3: Enable PWR clock to access BDCR

### DIFF
--- a/drivers/clock_control/clock_stm32f0_f3.c
+++ b/drivers/clock_control/clock_stm32f0_f3.c
@@ -144,15 +144,15 @@ uint32_t get_pllout_frequency(void)
  */
 void config_enable_default_clocks(void)
 {
+	/* Enable PWR clock, required to access BDCR and PWR_CR */
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+
 #ifndef CONFIG_SOC_SERIES_STM32F3X
 #if defined(CONFIG_EXTI_STM32) || defined(CONFIG_USB_DC_STM32)
 	/* Enable System Configuration Controller clock. */
 	LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_SYSCFG);
 #endif
 #else
-	/* Enable PWR clock, required to access BDCR */
-	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
-
 #if defined(CONFIG_USB_DC_STM32) && defined(SYSCFG_CFGR1_USB_IT_RMP)
 	/* Enable System Configuration Controller clock. */
 	/* SYSCFG is required to remap IRQ to avoid conflicts with CAN */


### PR DESCRIPTION
BDCR and PWR_CR could be required for LSE or RTC for instance. Enable it here as for now, no sophisticated PM handling is available on F0 and F3 series.

Fixes #56449
Fixup for #56505