### PR TITLE
manifest: update NXP HAL to fix i2c slave report bug

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -100,7 +100,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: a45b6bcee7824e42d9950c8324b3d783a2521a84
+      revision: 904830e8f684a9fd573751a1cdecde877ec49242
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
NXP HAL patch to address a but with improper slave reporting.

Fixes #57858