### PR TITLE
Bluetooth: Controller: Fix peer ISO feature support check

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -2796,7 +2796,7 @@ static inline int rx_demux_rx(memq_link_t *link, struct node_rx_hdr *rx)
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 #endif /* CONFIG_BT_OBSERVER */
 
-#if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
+#if defined(CONFIG_BT_CTLR_CONN_ISO)
 	case NODE_RX_TYPE_CIS_ESTABLISHED:
 	{
 		struct ll_conn *conn;
@@ -2812,7 +2812,7 @@ static inline int rx_demux_rx(memq_link_t *link, struct node_rx_hdr *rx)
 		ll_rx_put_sched(link, rx);
 	}
 	break;
-#endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
+#endif /* CONFIG_BT_CTLR_CONN_ISO */
 
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX) || defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX) || \
 	defined(CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_features.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_features.h
@@ -161,7 +161,7 @@ static inline bool feature_peer_smi_tx(struct ll_conn *conn)
 
 static inline bool feature_peer_iso_central(struct ll_conn *conn)
 {
-	return (conn->llcp.fex.features_peer & LL_FEAT_BIT_CIS_CENTRAL) != 0;
+	return (conn->llcp.fex.features_peer & BIT64(BT_LE_FEAT_BIT_CIS_CENTRAL)) != 0;
 }
 
 static inline bool feature_iso_central(struct ll_conn *conn)
@@ -171,7 +171,7 @@ static inline bool feature_iso_central(struct ll_conn *conn)
 
 static inline bool feature_peer_iso_peripheral(struct ll_conn *conn)
 {
-	return (conn->llcp.fex.features_peer & LL_FEAT_BIT_CIS_PERIPHERAL) != 0;
+	return (conn->llcp.fex.features_peer & BIT64(BT_LE_FEAT_BIT_CIS_PERIPHERAL)) != 0;
 }
 
 static inline bool feature_iso_peripheral(struct ll_conn *conn)


### PR DESCRIPTION
Fix peer ISO feature support check, by using feature support bit instead of whether locally supported bit value.