### PR TITLE
boards: qemu_x86_tiny: Place Newlib-nano into pinned sections

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86_tiny.ld
+++ b/boards/x86/qemu_x86/qemu_x86_tiny.ld
@@ -394,8 +394,8 @@ SECTIONS
 		*(.text.*.constprop.*)
 
 #if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_PICOLIBC)
-		*libc.a:(.text)
-		*libc.a:(.text.*)
+		*libc*.a:(.text)
+		*libc*.a:(.text.*)
 #endif
 
 #ifdef CONFIG_COVERAGE
@@ -438,8 +438,8 @@ SECTIONS
 		*(.rodata.*.str*.*)
 
 #if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_PICOLIBC)
-		*libc.a:(.rodata)
-		*libc.a:(.rodata.*)
+		*libc*.a:(.rodata)
+		*libc*.a:(.rodata.*)
 #endif
 
 #include <snippets-rodata.ld>


### PR DESCRIPTION
This commit updates the qemu_x86_tiny linker script to place the Newlib-nano text and rodata sections into the corresponding pinned sections so that they are accessible.

---

This fixes the `qemu_x86_tiny` boot failure when using Newlib-nano, which is enabled for x86 as well since the SDK 0.16.1 release.