### PR TITLE
drivers: i3c: Fix Build failure on MCUX I3C

### DIFF
--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -832,7 +832,7 @@ struct i3c_device_desc *mcux_i3c_device_find(const struct device *dev,
 static struct i3c_i2c_device_desc *
 mcux_i3c_i2c_device_find(const struct device *dev, uint16_t addr)
 {
-	struct cdns_i3c_data *data = dev->data;
+	struct mcux_i3c_data *data = dev->data;
 
 	return i3c_dev_list_i2c_addr_find(&data->common.attached_dev, addr);
 }
@@ -2115,7 +2115,7 @@ static const struct i3c_driver_api mcux_i3c_driver_api = {
 };
 
 #define I3C_MCUX_DEVICE(id)							\
-	PINCTRL_DT_INST_DEFINE(n);						\
+	PINCTRL_DT_INST_DEFINE(id);						\
 	static void mcux_i3c_config_func_##id(const struct device *dev);	\
 	static struct i3c_device_desc mcux_i3c_device_array_##id[] =			\
 		I3C_DEVICE_ARRAY_DT_INST(id);					\
@@ -2131,7 +2131,7 @@ static const struct i3c_driver_api mcux_i3c_driver_api = {
 		.common.dev_list.num_i3c = ARRAY_SIZE(mcux_i3c_device_array_##id),	\
 		.common.dev_list.i2c = mcux_i3c_i2c_device_array_##id,			\
 		.common.dev_list.num_i2c = ARRAY_SIZE(mcux_i3c_i2c_device_array_##id),	\
-		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),			\
 	};									\
 	static struct mcux_i3c_data mcux_i3c_data_##id = {			\
 		.clocks.i3c_od_scl_hz = DT_INST_PROP_OR(id, i3c_od_scl_hz, 0),	\


### PR DESCRIPTION
Fix build failure introduced by commits
989d103d5355c57d4533b78aa32a3033d33b142e and
62f22f8d3b2dc99276b692eb26200305c9b088d5.

CI failures were seen when building PR https://github.com/zephyrproject-rtos/zephyr/pull/57860