### PR TITLE
arch: x86: use TSS for page fault exception

### DIFF
--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -84,6 +84,25 @@ config X86_USERSPACE
 	  supporting user-level threads that are protected from each other and
 	  from crashing the kernel.
 
+config X86_PF_USE_TSS
+	bool "Use TSS for page fault exception"
+	select SET_GDT
+	select GDT_DYNAMIC
+	select X86_ENABLE_TSS
+	help
+	  This option enables TSS for page fault exception, without TSS, page
+	  fault exception go through common exception handling, then require
+	  to pin stack memory of all threads when enable paging, or will lead
+	  to fatal errors. This TSS option will use dedicate stack to make it
+	  works with memory critical system.
+
+config X86_PF_TSS_STACK_SIZE
+	int
+	default 2048
+	depends on X86_PF_USE_TSS
+	help
+	  Stack size for page fault exception handling.
+
 config X86_PAE
 	bool "Use PAE page tables"
 	default y

--- a/include/zephyr/arch/x86/ia32/arch.h
+++ b/include/zephyr/arch/x86/ia32/arch.h
@@ -51,6 +51,12 @@
 #define GS_TLS_SEG	(0x18 | 0x03)
 #endif
 
+#if CONFIG_THREAD_LOCAL_STORAGE
+#define PF_TSS		((GS_TLS_SEG & 0xF8) + 8)
+#else
+#define PF_TSS		(GS_TLS_SEG & 0xF8)
+#endif /*CONFIG_THREAD_LOCAL_STORAGE*/
+
 /**
  * Macro used internally by NANO_CPU_INT_REGISTER and NANO_CPU_INT_REGISTER_ASM.
  * Not meant to be used explicitly by platform, driver or application code.

--- a/include/zephyr/arch/x86/ia32/scripts/shared_kernel_pages.ld
+++ b/include/zephyr/arch/x86/ia32/scripts/shared_kernel_pages.ld
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Intel Corporation
+ * Copyright (c) 2021-2023 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -46,7 +46,14 @@
 #else
     #define GDT_NUM_ENTRIES 3
 #endif /* CONFIG_X86_USERSPACE */
-	. += (GDT_NUM_ENTRIES + GDT_NUM_TLS_ENTRIES) * 8;
+
+#ifdef CONFIG_X86_PF_USE_TSS
+#define GDT_NUM_PF_TSS_ENTRIES 1
+#else
+#define GDT_NUM_PF_TSS_ENTRIES 0
+#endif
+
+	. += (GDT_NUM_ENTRIES + GDT_NUM_TLS_ENTRIES + GDT_NUM_PF_TSS_ENTRIES) * 8;
 	. += CONFIG_GDT_RESERVED_NUM_ENTRIES * 8;
 #endif /* LINKER_ZEPHYR_FINAL */
 #endif /* CONFIG_GDT_DYNAMIC */


### PR DESCRIPTION
Page fault exception will go through x86 common exception handling, use excepted thread's stack to save context and handle page fault, this require to reserve enough stack memory for all threads, and those memory must be pinned.

It's not acceptable for some memory critical system, so provide this option to use TSS to handle page fault exception, since it is more applicable to use one fixed stack than to customize current exception handling.

Similar to Double fault exception, will define one new tss, statically allocate one entry in GDT, configure tss with dedicate stack and wrapper pf_handler which will call common z_x86_page_fault_handler.