### PR TITLE
kernel: pin _kernel variable in case of paging

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -42,6 +42,7 @@ BUILD_ASSERT(CONFIG_MP_NUM_CPUS == CONFIG_MP_MAX_NUM_CPUS,
 	     "CONFIG_MP_NUM_CPUS and CONFIG_MP_MAX_NUM_CPUS need to be set the same");
 
 /* the only struct z_kernel instance */
+__pinned_bss
 struct z_kernel _kernel;
 
 /* init/main and idle threads */


### PR DESCRIPTION
Exception handler(arch/x86/core/ia32/excstub.S) may access _kernel variable, it will lead to failure when enabled paging, so make this critical variable pinned.