### PR TITLE
boards: arm: xiao_ble: increase regulator startup to 3ms

### DIFF
--- a/boards/arm/xiao_ble/xiao_ble_sense.dts
+++ b/boards/arm/xiao_ble/xiao_ble_sense.dts
@@ -18,7 +18,7 @@
 		enable-gpios = <&gpio1 8 (NRF_GPIO_DRIVE_S0H1 | GPIO_ACTIVE_HIGH)>;
 		regulator-name = "LSM6DS3TR_C_EN";
 		regulator-boot-on;
-		startup-delay-us = <900>;
+		startup-delay-us = <3000>;
 	};
 };
 


### PR DESCRIPTION
900us regulator startup time was chosen based on tests with single board,
when used directly after 'jlink' flash runner.

It seems that this is not enough when board is reset using RESET button.
Additionally some boards require even more startup time in order to
successfully communicate with LSM6DS3TR-C IMU.

Increase regulator startup time from 900us to 3ms, which seems to be good
enough.