### PR TITLE
fixes #57825: add missing ILPS22QS in Kconfig.st

### DIFF
--- a/modules/Kconfig.st
+++ b/modules/Kconfig.st
@@ -55,6 +55,9 @@ config USE_STDC_IIS3DHHC
 config USE_STDC_IIS3DWB
 	bool
 
+config USE_STDC_ILPS22QS
+	bool
+
 config USE_STDC_ISM303DAC
 	bool
 


### PR DESCRIPTION
To use the `ILPS22QS`  driver, it should be select-able in kcofig (i.e. `west build -t menuconfig`). This PR adds the missing menu item in `Kconfig.st` (fixes: #57825).