### PR TITLE
Bluetooth: Controller: Fix CIS offset_min for dissimilar interval

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -53,6 +53,8 @@ struct lll_conn_iso_stream {
 	memq_link_t *link_tx_free;
 };
 
+#define LLL_CONN_ISO_EVENT_COUNT_MAX BIT64_MASK(39)
+
 struct lll_conn_iso_group {
 	struct lll_hdr hdr;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -179,9 +179,19 @@ static int prepare_cb(struct lll_prepare_param *p)
 	cig_lll->latency_prepare = 0U;
 
 	/* Adjust the SN and NESN for skipped CIG events */
-	/* sn and nesn are 1-bit, only Least Significant bit is needed */
-	cis_lll->sn += cis_lll->tx.bn * lazy;
-	cis_lll->nesn += cis_lll->rx.bn * lazy;
+	if (cis_lll->event_count) {
+		uint16_t cis_lazy;
+
+		if (lazy > cis_lll->event_count) {
+			cis_lazy = lazy - cis_lll->event_count;
+		} else {
+			cis_lazy = lazy;
+		}
+
+		/* sn and nesn are 1-bit, only Least Significant bit is needed */
+		cis_lll->sn += cis_lll->tx.bn * cis_lazy;
+		cis_lll->nesn += cis_lll->rx.bn * cis_lazy;
+	}
 
 	se_curr = 1U;
 	bn_tx = 1U;
@@ -368,9 +378,19 @@ static int prepare_cb(struct lll_prepare_param *p)
 	do {
 		cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll, &cis_handle);
 		if (cis_lll && cis_lll->active) {
-			/* sn and nesn are 1-bit, only Least Significant bit is needed */
-			cis_lll->sn += cis_lll->tx.bn * lazy;
-			cis_lll->nesn += cis_lll->rx.bn * lazy;
+			if (cis_lll->event_count) {
+				uint16_t cis_lazy;
+
+				if (lazy > cis_lll->event_count) {
+					cis_lazy = lazy - cis_lll->event_count;
+				} else {
+					cis_lazy = lazy;
+				}
+
+				/* sn and nesn are 1-bit, only Least Significant bit is needed */
+				cis_lll->sn += cis_lll->tx.bn * cis_lazy;
+				cis_lll->nesn += cis_lll->rx.bn * cis_lazy;
+			}
 		}
 	} while (cis_lll);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -403,6 +403,21 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 
 		cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll, NULL);
 
+		/* FIXME: Consider Flush Timeout when resetting current burst number */
+		if (!has_tx) {
+			has_tx = 1U;
+
+			/* Adjust nesn when flushing Tx */
+			/* FIXME: When Flush Timeout is implemented */
+			if (bn_tx <= cis_lll->tx.bn) {
+				/* sn and nesn are 1-bit, only Least Significant bit is needed */
+				cis_lll->sn += cis_lll->tx.bn + 1U - bn_tx;
+			}
+
+			/* Set to last burst number in previous event */
+			bn_tx = cis_lll->tx.bn;
+		}
+
 		/* Perform event abort here.
 		 * After event has been cleanly aborted, clean up resources
 		 * and dispatch event done.
@@ -462,8 +477,8 @@ static void isr_rx(void *param)
 				cis_lll->sn += cis_lll->tx.bn + 1U - bn_tx;
 			}
 
-			/* Start transmitting new burst */
-			bn_tx = 1U;
+			/* Set to last burst number in previous event */
+			bn_tx = cis_lll->tx.bn;
 		}
 
 		if (se_curr < cis_lll->nse) {

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -351,6 +351,7 @@
 						    ((enc) ? \
 						     (PDU_MIC_SIZE) : 0), \
 						    (phy))
+#define PDU_CIS_OFFSET_MIN_US 500U
 
 struct pdu_adv_adv_ind {
 	uint8_t addr[BDADDR_SIZE];

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -563,7 +563,7 @@ void ll_cis_create(uint16_t cis_handle, uint16_t acl_handle)
 	/* Initialize stream states */
 	cis->established = 0;
 	cis->teardown = 0;
-	cis->lll.event_count = 0;
+	cis->lll.event_count = LLL_CONN_ISO_EVENT_COUNT_MAX;
 	cis->lll.sn = 0;
 	cis->lll.nesn = 0;
 	cis->lll.cie = 0;
@@ -732,7 +732,6 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 #endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
 
 	cis->central.instant = instant;
-	cis->lll.event_count = -1;
 	cis->lll.next_subevent = 0U;
 	cis->lll.sn = 0U;
 	cis->lll.nesn = 0U;
@@ -863,10 +862,13 @@ static void cis_offset_get(struct ll_conn_iso_stream *cis)
 
 static void mfy_cis_offset_get(void *param)
 {
+	uint32_t elapsed_acl_us, elapsed_cig_us;
+	uint16_t latency_acl, latency_cig;
 	struct ll_conn_iso_stream *cis;
 	struct ll_conn_iso_group *cig;
 	uint32_t cig_remainder_us;
 	uint32_t acl_remainder_us;
+	uint32_t cig_interval_us;
 	uint32_t ticks_to_expire;
 	uint32_t ticks_current;
 	uint32_t offset_min_us;
@@ -952,6 +954,32 @@ static void mfy_cis_offset_get(void *param)
 	offset_min_us = HAL_TICKER_TICKS_TO_US(ticks_to_expire) +
 			cig_remainder_us + cig->sync_delay -
 			acl_remainder_us - cis->sync_delay;
+
+	/* Calculate instant latency */
+	/* 32-bits are sufficient as maximum connection interval is 4 seconds,
+	 * and latency counts (typically 3) is low enough to avoid 32-bit
+	 * overflow. Refer to ull_central_iso_cis_offset_get().
+	 */
+	latency_acl = cis->central.instant - ull_conn_event_counter(conn);
+	elapsed_acl_us = latency_acl * conn->lll.interval * CONN_INT_UNIT_US;
+
+	/* Calculate elapsed CIG intervals until the instant */
+	cig_interval_us = cig->iso_interval * ISO_INT_UNIT_US;
+	latency_cig = DIV_ROUND_UP(elapsed_acl_us, cig_interval_us);
+	elapsed_cig_us = latency_cig * cig_interval_us;
+
+	/* Compensate for the difference between ACL elapsed vs CIG elapsed */
+	offset_min_us += elapsed_cig_us - elapsed_acl_us;
+	while (offset_min_us > (cig_interval_us + PDU_CIS_OFFSET_MIN_US)) {
+		offset_min_us -= cig_interval_us;
+	}
+
+	/* Decrement event_count to compensate for offset_min_us greater than
+	 * CIG interval due to offset being atleast PDU_CIS_OFFSET_MIN_US.
+	 */
+	if (offset_min_us > cig_interval_us) {
+		cis->lll.event_count--;
+	}
 
 	ull_cp_cc_offset_calc_reply(conn, offset_min_us, offset_min_us);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -319,7 +319,7 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 	cis->sync_delay = sys_get_le24(ind->cis_sync_delay);
 	cis->offset = cis_offset;
 	memcpy(cis->lll.access_addr, ind->aa, sizeof(ind->aa));
-	cis->lll.event_count = -1;
+	cis->lll.event_count = LLL_CONN_ISO_EVENT_COUNT_MAX;
 	cis->lll.next_subevent = 0U;
 	cis->lll.sn = 0U;
 	cis->lll.nesn = 0U;


### PR DESCRIPTION
Fix CIS offset_min calculation to consider that ACL connection
interval and ISO intervals can be dissimilar and the offset
value has to be compensated for the latency until the
instant at which the offset is used.

Fix Central CIS SN and NESN for skipped events during CIS
setup. It is possible that CIG event may overlap the ACL or
other events at the CIS create instant, and hence have non
zero lazy value during the CIS setup events until CIS is
established.

Fix SN value on Peripheral CIS event abort. Adjust the SN
value based on the burst number such that the ISO data where
transmitted as normal.