### PR TITLE
logging: Fix user space crash when runtime filtering is on

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -229,10 +229,8 @@ static inline char z_log_minimal_level_to_char(int level)
 	} \
 	\
 	bool is_user_context = k_is_user_context(); \
-	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-						(_dsource)->filters : 0;\
 	if (!IS_ENABLED(CONFIG_LOG_FRONTEND) && IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && \
-	    !is_user_context && _level > Z_LOG_RUNTIME_FILTER(filters)) { \
+	    !is_user_context && _level > Z_LOG_RUNTIME_FILTER((_dsource)->filters)) { \
 		break; \
 	} \
 	int _mode; \


### PR DESCRIPTION
Logging module data (including filters) are not accessible by the user space. Macro for creating logs where creating local variable with filters before checking is we are in the user context. It was not used in that case but creating variable was violating access writes that resulted in failure.

Removing variable creation and using filters directly in the if clause but after checking condition that it is not the user context. With this approach data is accessed only in the kernel mode.

Fixes #55323.