### PR TITLE
bluetooth: mesh: fix iterable section issues

### DIFF
--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -369,6 +369,17 @@
 	TYPE_SECTION_ITERABLE(struct struct_type, varname, secname, varname)
 
 /**
+ * @brief Defines an array of elements of alternate data type for an iterable
+ * section.
+ *
+ * @see STRUCT_SECTION_ITERABLE_ALTERNATE
+ */
+#define STRUCT_SECTION_ITERABLE_ARRAY_ALTERNATE(secname, struct_type, varname, \
+						size)                          \
+	TYPE_SECTION_ITERABLE(struct struct_type, varname[size], secname,      \
+			      varname)
+
+/**
  * @brief Defines a new element for an iterable section.
  *
  * @details
@@ -384,6 +395,15 @@
  */
 #define STRUCT_SECTION_ITERABLE(struct_type, varname) \
 	STRUCT_SECTION_ITERABLE_ALTERNATE(struct_type, struct_type, varname)
+
+/**
+ * @brief Defines an array of elements for an iterable section.
+ *
+ * @see STRUCT_SECTION_ITERABLE
+ */
+#define STRUCT_SECTION_ITERABLE_ARRAY(struct_type, varname, size)              \
+	STRUCT_SECTION_ITERABLE_ARRAY_ALTERNATE(struct_type, struct_type,      \
+						varname, size)
 
 /**
  * @brief Defines a new element for an iterable section with a custom name.

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -84,7 +84,7 @@ static STRUCT_SECTION_ITERABLE(bt_mesh_ext_adv, adv_main) = {
 };
 
 #if CONFIG_BT_MESH_RELAY_ADV_SETS
-static STRUCT_SECTION_ITERABLE(bt_mesh_ext_adv, adv_relay[CONFIG_BT_MESH_RELAY_ADV_SETS]) = {
+static STRUCT_SECTION_ITERABLE_ARRAY(bt_mesh_ext_adv, adv_relay, CONFIG_BT_MESH_RELAY_ADV_SETS) = {
 	[0 ... CONFIG_BT_MESH_RELAY_ADV_SETS - 1] = {
 		.tag = BT_MESH_RELAY_ADV,
 		.work = Z_WORK_DELAYABLE_INITIALIZER(send_pending_adv),


### PR DESCRIPTION
STRUCT_SECTION_ITERABLE cannot be used with arrays, because of preprocessor tokenization issues. Introduced STRUCT_SECTION_ITERABLE_ARRAY to fix the problem.