### PR TITLE
soc: intel_adsp: ipc: check for pending ack

### DIFF
--- a/soc/xtensa/intel_adsp/common/ipc.c
+++ b/soc/xtensa/intel_adsp/common/ipc.c
@@ -119,8 +119,10 @@ void intel_adsp_ipc_complete(const struct device *dev)
 bool intel_adsp_ipc_is_complete(const struct device *dev)
 {
 	const struct intel_adsp_ipc_config *config = dev->config;
+	const struct intel_adsp_ipc_data *devdata = dev->data;
+	bool not_busy = (config->regs->idr & INTEL_ADSP_IPC_BUSY) == 0;
 
-	return (config->regs->idr & INTEL_ADSP_IPC_BUSY) == 0;
+	return not_busy && !devdata->tx_ack_pending;
 }
 
 bool intel_adsp_ipc_send_message(const struct device *dev,


### PR DESCRIPTION
This patch extends the driver API with a function to check if we are waiting for an ACK from the host.

This change will allow to solve the problem that occurs during the power state transitions. Occasionally, the Application decides to enter the power gating state after sending an IPC message, before receiving an ACK from the HOST. This results in broken IPC communication when coming back to Idle state.