### PR TITLE
drivers/bluetooth/hci/slz_hci: bump blobs and enable BG27

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -58,7 +58,7 @@ config BT_STM32_IPM
 
 config BT_SILABS_HCI
 	bool "Silicon Labs Bluetooth interface"
-	depends on SOC_SERIES_EFR32BG22 || SOC_SERIES_EFR32MG24
+	depends on SOC_SERIES_EFR32BG22 || SOC_SERIES_EFR32MG24 || SOC_SERIES_EFR32BG27
 	depends on !PM || SOC_GECKO_PM_BACKEND_PMGR
 	select ENTROPY_GENERATOR
 	select MBEDTLS

--- a/drivers/bluetooth/hci/slz_hci.c
+++ b/drivers/bluetooth/hci/slz_hci.c
@@ -140,12 +140,11 @@ static int slz_bt_open(void)
 		goto deinit;
 	}
 
-	sl_btctrl_init_scan();
 	sl_btctrl_init_adv();
+	sl_btctrl_init_scan();
 	sl_btctrl_init_conn();
-
-	sl_btctrl_hci_parser_init_adv();
-	sl_btctrl_hci_parser_init_conn();
+	sl_btctrl_init_adv_ext();
+	sl_btctrl_init_scan_ext();
 
 	ret = sl_btctrl_init_basic(SL_BT_CONFIG_MAX_CONNECTIONS,
 			SL_BT_CONFIG_USER_ADVERTISERS,
@@ -156,6 +155,10 @@ static int slz_bt_open(void)
 	}
 
 	sl_bthci_init_upper();
+	sl_btctrl_hci_parser_init_default();
+	sl_btctrl_hci_parser_init_conn();
+	sl_btctrl_hci_parser_init_adv();
+	sl_btctrl_hci_parser_init_phy();
 
 #ifdef CONFIG_PM
 	{

--- a/soc/arm/silabs_exx32/efr32bg27/Kconfig.series
+++ b/soc/arm/silabs_exx32/efr32bg27/Kconfig.series
@@ -19,5 +19,6 @@ config SOC_SERIES_EFR32BG27
 	select SOC_GECKO_CMU
 	select SOC_GECKO_CORE
 	select SOC_GECKO_DEV_INIT
+	select SOC_GECKO_SE
 	help
 	  Enable support for EFR32BG27 Blue Gecko MCU series

--- a/west.yml
+++ b/west.yml
@@ -126,7 +126,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: cee0e7704ece414924734cb422a6f346e13e71e5
+      revision: a143f03e846eb1b7b3135f3c8192820ce1b6d9c4
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
This PR:
* bumps BT-related binary blobs from version 4.0 to version 4.1 and makes requried changes in the HCI driver
* enabled slz_hci on EFR32BG27 series SoCs