### PR TITLE
boards: sparkfun_thing_plus_nrf9160: Always enable GPIO

### DIFF
--- a/boards/arm/sparkfun_thing_plus_nrf9160/Kconfig.board
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/Kconfig.board
@@ -8,8 +8,16 @@ if SOC_NRF9160_SICA
 
 config BOARD_SPARKFUN_THING_PLUS_NRF9160
 	bool "Sparkfun nRF9160 Thing Plus"
+	# The GPIO driver is required by this board's initialization code
+	# (board.c), so it is forced here to be enabled always, not only
+	# enabled by default (in defconfig).
+	select GPIO
 
 config BOARD_SPARKFUN_THING_PLUS_NRF9160_NS
 	bool "Sparkfun nRF9160 Thing Plus non-secure"
+	# The GPIO driver is required by this board's initialization code
+	# (board.c), so it is forced here to be enabled always, not only
+	# enabled by default (in defconfig).
+	select GPIO
 
 endif # SOC_NRF9160_SICA

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_defconfig
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_defconfig
@@ -13,9 +13,6 @@ CONFIG_ARM_TRUSTZONE_M=y
 # Hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
 
-# enable GPIO
-CONFIG_GPIO=y
-
 # Enable uart driver
 CONFIG_SERIAL=y
 

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_ns_defconfig
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_ns_defconfig
@@ -16,9 +16,6 @@ CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 # Hardware stack protection
 CONFIG_HW_STACK_PROTECTION=y
 
-# enable GPIO
-CONFIG_GPIO=y
-
 # Enable uart driver
 CONFIG_SERIAL=y
 


### PR DESCRIPTION
The GPIO driver is required by this board's initialization code (board.c), so it is forced to be enabled always for the board Kconfig, not only enabled by default (in defconfig).

Fixes: #57890