### PR TITLE
drivers: dma: intel_lpss: Added intel LPSS DMA interface to use LPSS internal DMA.

### DIFF
--- a/drivers/dma/CMakeLists.txt
+++ b/drivers/dma/CMakeLists.txt
@@ -23,6 +23,7 @@ zephyr_library_sources_ifdef(CONFIG_DMA_INTEL_ADSP_HDA_HOST_OUT dma_intel_adsp_h
 zephyr_library_sources_ifdef(CONFIG_DMA_INTEL_ADSP_HDA_LINK_IN dma_intel_adsp_hda_link_in.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_INTEL_ADSP_HDA_LINK_OUT dma_intel_adsp_hda_link_out.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_INTEL_ADSP_GPDMA	dma_intel_adsp_gpdma.c dma_dw_common.c)
+zephyr_library_sources_ifdef(CONFIG_DMA_INTEL_LPSS      dma_intel_lpss.c dma_dw_common.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_GD32		dma_gd32.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_ESP32		dma_esp32_gdma.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_MCHP_XEC	dma_mchp_xec.c)

--- a/drivers/dma/Kconfig
+++ b/drivers/dma/Kconfig
@@ -58,4 +58,5 @@ source "drivers/dma/Kconfig.xmc4xxx"
 
 source "drivers/dma/Kconfig.rpi_pico"
 
+source "drivers/dma/Kconfig.intel_lpss"
 endif # DMA

--- a/drivers/dma/Kconfig.dw_common
+++ b/drivers/dma/Kconfig.dw_common
@@ -38,3 +38,9 @@ config DMA_DW_HOST_MASK
 	help
 	  Some instances of the DesignWare DMAC require a mask applied to source/destination
 	  addresses to signifiy the memory space the address is in.
+
+config DMA_DW_CHANNEL_COUNT
+	int "dw max channel count"
+	default 8
+	help
+	  Channel count for designware DMA instances.

--- a/drivers/dma/Kconfig.intel_lpss
+++ b/drivers/dma/Kconfig.intel_lpss
@@ -1,0 +1,17 @@
+# LPSS DMA configuration options
+
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config DMA_INTEL_LPSS
+	bool "INTEL LPSS DMA driver"
+	default n
+	depends on DT_HAS_INTEL_LPSS_ENABLED
+	help
+	  INTEL LPSS DMA driver.
+
+if DMA_INTEL_LPSS
+
+source "drivers/dma/Kconfig.dw_common"
+
+endif # DMA_INTEL_LPSS

--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -206,6 +206,7 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 		case 1:
 			/* byte at a time transfer */
 			lli_desc->ctrl_lo |= DW_CTLL_SRC_WIDTH(0);
+			break;
 		case 2:
 			/* non peripheral copies are optimal using words */
 			switch (cfg->channel_direction) {
@@ -236,7 +237,8 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 		switch (cfg->dest_data_size) {
 		case 1:
 			/* byte at a time transfer */
-			lli_desc->ctrl_lo |= DW_CTLL_SRC_WIDTH(0);
+			lli_desc->ctrl_lo |= DW_CTLL_DST_WIDTH(0);
+			break;
 		case 2:
 			/* non peripheral copies are optimal using words */
 			switch (cfg->channel_direction) {

--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -362,7 +362,7 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 		chan_data->ptr_data.buffer_bytes += block_cfg->block_size;
 
 		/* set next descriptor in list */
-		lli_desc->llp = (uint32_t)(lli_desc + 1);
+		lli_desc->llp = (uintptr_t)(lli_desc + 1);
 
 		LOG_DBG("lli_desc llp %x", lli_desc->llp);
 
@@ -378,7 +378,7 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 
 	/* end of list or cyclic buffer */
 	if (cfg->cyclic) {
-		lli_desc_tail->llp = (uint32_t)lli_desc_head;
+		lli_desc_tail->llp = (uintptr_t)lli_desc_head;
 	} else {
 		lli_desc_tail->llp = 0;
 #if CONFIG_DMA_DW_HW_LLI
@@ -491,8 +491,15 @@ int dw_dma_start(const struct device *dev, uint32_t channel)
 #endif /* CONFIG_DMA_DW_HW_LLI */
 
 	/* channel needs to start from scratch, so write SAR and DAR */
+#ifdef CONFIG_DMA_64BIT
+	dw_write(dev_cfg->base, DW_SAR(channel), (uint32_t)(lli->sar & BIT_MASK(32)));
+	dw_write(dev_cfg->base, DW_SAR_HI(channel), (uint32_t)(lli->sar >> 32));
+	dw_write(dev_cfg->base, DW_DAR(channel), (uint32_t)(lli->dar & BIT_MASK(32)));
+	dw_write(dev_cfg->base, DW_DAR_HI(channel), (uint32_t)(lli->dar >> 32));
+#else
 	dw_write(dev_cfg->base, DW_SAR(channel), lli->sar);
 	dw_write(dev_cfg->base, DW_DAR(channel), lli->dar);
+#endif /* CONFIG_DMA_64BIT */
 
 	/* program CTL_LO and CTL_HI */
 	dw_write(dev_cfg->base, DW_CTRL_LOW(channel), lli->ctrl_lo);
@@ -502,10 +509,17 @@ int dw_dma_start(const struct device *dev, uint32_t channel)
 	dw_write(dev_cfg->base, DW_CFG_LOW(channel), chan_data->cfg_lo);
 	dw_write(dev_cfg->base, DW_CFG_HIGH(channel), chan_data->cfg_hi);
 
+#ifdef CONFIG_DMA_64BIT
+	LOG_DBG("start: sar %llx, dar %llx, ctrl_lo %x, ctrl_hi %x, cfg_lo %x, cfg_hi %x, llp %x",
+		lli->sar, lli->dar, lli->ctrl_lo, lli->ctrl_hi, chan_data->cfg_lo,
+		chan_data->cfg_hi, dw_read(dev_cfg->base, DW_LLP(channel))
+		);
+#else
 	LOG_DBG("start: sar %x, dar %x, ctrl_lo %x, ctrl_hi %x, cfg_lo %x, cfg_hi %x, llp %x",
 		lli->sar, lli->dar, lli->ctrl_lo, lli->ctrl_hi, chan_data->cfg_lo,
 		chan_data->cfg_hi, dw_read(dev_cfg->base, DW_LLP(channel))
 		);
+#endif /* CONFIG_DMA_64BIT */
 
 #ifdef CONFIG_DMA_DW_HW_LLI
 	if (lli->ctrl_lo & DW_CTLL_D_SCAT_EN) {

--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -132,7 +132,7 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 	uint32_t msize = 3;/* default msize, 8 bytes */
 	int ret = 0;
 
-	if (channel >= DW_MAX_CHAN) {
+	if (channel >= DW_CHAN_COUNT) {
 		LOG_ERR("%s: invalid dma channel %d", __func__, channel);
 		ret = -EINVAL;
 		goto out;
@@ -444,7 +444,7 @@ int dw_dma_start(const struct device *dev, uint32_t channel)
 	int ret = 0;
 
 	/* validate channel */
-	if (channel >= DW_MAX_CHAN) {
+	if (channel >= DW_CHAN_COUNT) {
 		ret = -EINVAL;
 		goto out;
 	}
@@ -492,10 +492,10 @@ int dw_dma_start(const struct device *dev, uint32_t channel)
 
 	/* channel needs to start from scratch, so write SAR and DAR */
 #ifdef CONFIG_DMA_64BIT
-	dw_write(dev_cfg->base, DW_SAR(channel), (uint32_t)(lli->sar & BIT_MASK(32)));
-	dw_write(dev_cfg->base, DW_SAR_HI(channel), (uint32_t)(lli->sar >> 32));
-	dw_write(dev_cfg->base, DW_DAR(channel), (uint32_t)(lli->dar & BIT_MASK(32)));
-	dw_write(dev_cfg->base, DW_DAR_HI(channel), (uint32_t)(lli->dar >> 32));
+	dw_write(dev_cfg->base, DW_SAR(channel), (uint32_t)(lli->sar & DW_ADDR_MASK_32));
+	dw_write(dev_cfg->base, DW_SAR_HI(channel), (uint32_t)(lli->sar >> DW_ADDR_RIGHT_SHIFT));
+	dw_write(dev_cfg->base, DW_DAR(channel), (uint32_t)(lli->dar & DW_ADDR_MASK_32));
+	dw_write(dev_cfg->base, DW_DAR_HI(channel), (uint32_t)(lli->dar >> DW_ADDR_RIGHT_SHIFT));
 #else
 	dw_write(dev_cfg->base, DW_SAR(channel), lli->sar);
 	dw_write(dev_cfg->base, DW_DAR(channel), lli->dar);
@@ -548,7 +548,7 @@ int dw_dma_stop(const struct device *dev, uint32_t channel)
 	struct dw_dma_chan_data *chan_data = &dev_data->chan[channel];
 	int ret = 0;
 
-	if (channel >= DW_MAX_CHAN) {
+	if (channel >= DW_CHAN_COUNT) {
 		ret = -EINVAL;
 		goto out;
 	}
@@ -617,7 +617,7 @@ int dw_dma_resume(const struct device *dev, uint32_t channel)
 	int ret = 0;
 
 	/* Validate channel index */
-	if (channel >= DW_MAX_CHAN) {
+	if (channel >= DW_CHAN_COUNT) {
 		ret = -EINVAL;
 		goto out;
 	}
@@ -649,7 +649,7 @@ int dw_dma_suspend(const struct device *dev, uint32_t channel)
 	int ret = 0;
 
 	/* Validate channel index */
-	if (channel >= DW_MAX_CHAN) {
+	if (channel >= DW_CHAN_COUNT) {
 		ret = -EINVAL;
 		goto out;
 	}
@@ -704,7 +704,7 @@ int dw_dma_setup(const struct device *dev)
 
 	LOG_DBG("%s: dma %s", __func__, dev->name);
 
-	for (i = 0; i <  DW_MAX_CHAN; i++) {
+	for (i = 0; i <  DW_CHAN_COUNT; i++) {
 		dw_read(dev_cfg->base, DW_DMA_CHAN_EN);
 	}
 

--- a/drivers/dma/dma_dw_common.h
+++ b/drivers/dma/dma_dw_common.h
@@ -41,6 +41,13 @@ extern "C" {
 #define DW_DSR(chan) \
 	(0x0050 + DW_CHAN_OFFSET(chan))
 
+#ifdef CONFIG_DMA_64BIT
+#define DW_SAR_HI(chan) \
+	(0x0004 + DW_CHAN_OFFSET(chan))
+#define DW_DAR_HI(chan) \
+	(0x000C + DW_CHAN_OFFSET(chan))
+#endif
+
 /* registers */
 #define DW_RAW_TFR		0x02C0
 #define DW_RAW_BLOCK		0x02C8
@@ -174,6 +181,10 @@ struct dw_drv_plat_data {
 
 /* DMA descriptor used by HW */
 struct dw_lli {
+#ifdef CONFIG_DMA_64BIT
+	uint64_t sar;
+	uint64_t dar;
+#else
 	uint32_t sar;
 	uint32_t dar;
 	uint32_t llp;
@@ -239,16 +250,16 @@ struct dw_dma_dev_data {
 
 /* Device constant configuration parameters */
 struct dw_dma_dev_cfg {
-	uint32_t base;
+	uintptr_t base;
 	void (*irq_config)(void);
 };
 
-static ALWAYS_INLINE void dw_write(uint32_t dma_base, uint32_t reg, uint32_t value)
+static ALWAYS_INLINE void dw_write(uintptr_t dma_base, uint32_t reg, uint32_t value)
 {
 	*((volatile uint32_t *)(dma_base + reg)) = value;
 }
 
-static ALWAYS_INLINE uint32_t dw_read(uint32_t dma_base, uint32_t reg)
+static ALWAYS_INLINE uint32_t dw_read(uintptr_t dma_base, uint32_t reg)
 {
 	return *((volatile uint32_t *)(dma_base + reg));
 }

--- a/drivers/dma/dma_dw_common.h
+++ b/drivers/dma/dma_dw_common.h
@@ -21,8 +21,11 @@ extern "C" {
 	(((x) & ((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL)) << (b_lo))
 
 #define DW_MAX_CHAN		8
+#define DW_CHAN_COUNT		CONFIG_DMA_DW_CHANNEL_COUNT
 #define DW_CH_SIZE		0x58
 #define DW_CHAN_OFFSET(chan)	(DW_CH_SIZE * chan)
+#define DW_ADDR_MASK_32		BIT_MASK(32)
+#define DW_ADDR_RIGHT_SHIFT	32
 
 #define DW_SAR(chan)	\
 	(0x0000 + DW_CHAN_OFFSET(chan))
@@ -176,7 +179,7 @@ struct dw_chan_arbit_data {
 };
 
 struct dw_drv_plat_data {
-	struct dw_chan_arbit_data chan[DW_MAX_CHAN];
+	struct dw_chan_arbit_data chan[DW_CHAN_COUNT];
 };
 
 /* DMA descriptor used by HW */
@@ -187,6 +190,7 @@ struct dw_lli {
 #else
 	uint32_t sar;
 	uint32_t dar;
+#endif
 	uint32_t llp;
 	uint32_t ctrl_lo;
 	uint32_t ctrl_hi;
@@ -242,10 +246,10 @@ static const uint32_t burst_elems[] = {1, 2, 4, 8};
 struct dw_dma_dev_data {
 	struct dma_context dma_ctx;
 	struct dw_drv_plat_data *channel_data;
-	struct dw_dma_chan_data chan[DW_MAX_CHAN];
-	struct dw_lli lli_pool[DW_MAX_CHAN][CONFIG_DMA_DW_LLI_POOL_SIZE] __aligned(64);
+	struct dw_dma_chan_data chan[DW_CHAN_COUNT];
+	struct dw_lli lli_pool[DW_CHAN_COUNT][CONFIG_DMA_DW_LLI_POOL_SIZE] __aligned(64);
 
-	ATOMIC_DEFINE(channels_atomic, DW_MAX_CHAN);
+	ATOMIC_DEFINE(channels_atomic, DW_CHAN_COUNT);
 };
 
 /* Device constant configuration parameters */

--- a/drivers/dma/dma_intel_lpss.c
+++ b/drivers/dma/dma_intel_lpss.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT intel_lpss
+
+#include <errno.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/dma/dma_intel_lpss.h>
+#include "dma_dw_common.h"
+#include <soc.h>
+
+#include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
+LOG_MODULE_REGISTER(dma_intel_lpss, CONFIG_DMA_LOG_LEVEL);
+
+struct dma_intel_lpss_cfg {
+	struct dw_dma_dev_cfg dw_cfg;
+	const struct device *parent;
+};
+
+static int dma_intel_lpss_init(const struct device *dev)
+{
+	struct dma_intel_lpss_cfg *dev_cfg = (struct dma_intel_lpss_cfg *)dev->config;
+	uint32_t base;
+	int ret;
+
+	if (!device_is_ready(dev_cfg->parent)) {
+		LOG_ERR("LPSS DMA parent not ready");
+		ret = -ENODEV;
+		goto out;
+	}
+
+	base = DEVICE_MMIO_GET(dev_cfg->parent) + DMA_INTEL_LPSS_OFFSET;
+	dev_cfg->dw_cfg.base = base;
+
+	ret = dw_dma_setup(dev);
+
+	if (ret != 0) {
+		LOG_ERR("failed to initialize LPSS DMA %s", dev->name);
+		goto out;
+	}
+	ret = 0;
+out:
+	return ret;
+}
+
+void dma_intel_lpss_isr(const struct device *dev)
+{
+	dw_dma_isr(dev);
+}
+
+static const struct dma_driver_api dma_intel_lpss_driver_api = {
+	.config = dw_dma_config,
+	.start = dw_dma_start,
+	.stop = dw_dma_stop,
+};
+
+#define DMA_INTEL_LPSS_INIT(n)						\
+									\
+	static struct dw_drv_plat_data dma_intel_lpss##n = {		\
+		.chan[0] = {						\
+			.class  = 6,					\
+			.weight = 0,					\
+		},							\
+		.chan[1] = {						\
+			.class  = 6,					\
+			.weight = 0,					\
+		},							\
+	};								\
+									\
+									\
+	static struct dma_intel_lpss_cfg dma_intel_lpss##n##_config = {	\
+		.dw_cfg = {						\
+			.base = 0,					\
+		},							\
+		.parent = DEVICE_DT_GET(DT_INST_PARENT(n)),		\
+	};								\
+									\
+	static struct dw_dma_dev_data dma_intel_lpss##n##_data = {	\
+		.channel_data = &dma_intel_lpss##n,			\
+	};								\
+									\
+	DEVICE_DT_INST_DEFINE(n,					\
+			    &dma_intel_lpss_init,			\
+			    NULL,					\
+			    &dma_intel_lpss##n##_data,			\
+			    &dma_intel_lpss##n##_config, POST_KERNEL,	\
+			    DMA_INTEL_LPSS_INIT_PRIORITY,		\
+			    &dma_intel_lpss_driver_api);		\
+
+DT_INST_FOREACH_STATUS_OKAY(DMA_INTEL_LPSS_INIT)

--- a/dts/bindings/dma/intel,lpss.yaml
+++ b/dts/bindings/dma/intel,lpss.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2019 Intel Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+description: LPSS DMA Controller node
+
+compatible: "intel,lpss"
+
+include: dma-controller.yaml
+
+properties:
+  "#dma-cells":
+    const: 1
+
+dma-cells:
+  - channel

--- a/include/zephyr/drivers/dma/dma_intel_lpss.h
+++ b/include/zephyr/drivers/dma/dma_intel_lpss.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_DMA_INTEL_LPSS_H_
+#define ZEPHYR_INCLUDE_DRIVERS_DMA_INTEL_LPSS_H_
+
+#define DMA_INTEL_LPSS_INIT_PRIORITY	80
+#define DMA_INTEL_LPSS_OFFSET		0x800
+#define DMA_INTEL_LPSS_REMAP_LOW	0x240
+#define DMA_INTEL_LPSS_REMAP_HI		0x244
+#define DMA_INTEL_LPSS_TX_CHAN		0
+#define DMA_INTEL_LPSS_RX_CHAN		1
+#define DMA_INTEL_LPSS_ADDR_RIGHT_SHIFT	32
+
+void dma_intel_lpss_isr(const struct device *dev);
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_DMA_INTEL_LPSS_H_ */


### PR DESCRIPTION
Added intel LPSS DMA interface using dw common to support
usage of internal DMA in LPSS UART, SPI and I2C to transfer and
receive data.

Added changes to dw common to support 64bit address
transactions. 

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>