### PR TITLE
soc: xtensa: Lower HW_STATE_CHECK_DELAY

### DIFF
--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_power.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_power.h
@@ -9,7 +9,7 @@
 #define ZEPHYR_SOC_INTEL_ADSP_POWER_H_
 
 /* Value used as delay when waiting for hw register state change. */
-#define HW_STATE_CHECK_DELAY 256
+#define HW_STATE_CHECK_DELAY 64
 
 /* Power Control register - controls the power domain operations. */
 struct ace_pwrctl {

--- a/soc/xtensa/intel_adsp/ace/include/intel_ace20_lnl/adsp_power.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace20_lnl/adsp_power.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_SOC_INTEL_ADSP_POWER_H_
 
 /* Value used as delay when waiting for hw register state change. */
-#define HW_STATE_CHECK_DELAY 256
+#define HW_STATE_CHECK_DELAY  64
 
 
 struct ace_pwrctl {

--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -18,7 +18,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/cache.h>
 
-#define CORE_POWER_CHECK_NUM 32
+#define CORE_POWER_CHECK_NUM 128
 #define ACE_INTC_IRQ DT_IRQN(DT_NODELABEL(ace_intc))
 
 static void ipc_isr(void *arg)


### PR DESCRIPTION
The macro HW_STATE_CHECK_DELAY represents the number of usec to busy-wait when waiting for a h/w register state change. This value has been lowered by 75% to correct a couple of issues related to Power Management (PM).

1. This resolves a kernel.timer.tickless test failure (see tests/kernel/timer/timer_api) on the LNL simulator where the test was taking too long to wake after sleeping for 50 ticks. This was tracked down to the xtensa SOC power management code where it was performing a busy wait of 256 usec, which was equivalent to 2.56 ticks.

2. Furthermore, this delay of 256 usec contradicted the information in the DTSI (see power-states for d0i3) which states that the "exit-latency-us" is 100 usec. Reducing this value to 64 helps to keep that in line.