### PR TITLE
drivers console native_posix: Do not set buffering mode anymore

### DIFF
--- a/drivers/console/native_posix_console.c
+++ b/drivers/console/native_posix_console.c
@@ -31,14 +31,6 @@
  */
 static void native_posix_stdout_init(void)
 {
-	/* Let's ensure that even if we are redirecting to a file, we get stdout
-	 * and stderr line buffered (default for console). Note that glibc
-	 * ignores size. But just in case we set a reasonable number in case
-	 * somebody tries to compile against a different library
-	 */
-	setvbuf(stdout, NULL, _IOLBF, 512);
-	setvbuf(stderr, NULL, _IOLBF, 512);
-
 #ifdef CONFIG_PRINTK
 	extern void __printk_hook_install(int (*fn)(int));
 	__printk_hook_install(putchar);


### PR DESCRIPTION
Since aadca692b3f1c53aad97f11febc1657ce695bd4b
the board code already sets the stdout/err buffering, even if there is no console driver;
So there is no need to set it also in the console driver.