### PR TITLE
boards: intel_adsp_ace20_lnl: build with Zephyr SDK

### DIFF
--- a/boards/xtensa/intel_adsp_ace20_lnl/intel_adsp_ace20_lnl.yaml
+++ b/boards/xtensa/intel_adsp_ace20_lnl/intel_adsp_ace20_lnl.yaml
@@ -5,6 +5,7 @@ arch: xtensa
 toolchain:
   - xcc
   - xt-clang
+  - zephyr
 supported:
   - dma
 testing:


### PR DESCRIPTION
intel_adsp_ace20_lnl can also build with intel_adsp_ace15_mtpm toolchain in Zephyr SDK as the SoC is quite similar. This allows twister to build in CI to avoid any breakage.