### PR TITLE
boards: actinius_icarus: CONFIG_BUILD_WITH_TFM=y if _NS

### DIFF
--- a/boards/arm/actinius_icarus/Kconfig.defconfig
+++ b/boards/arm/actinius_icarus/Kconfig.defconfig
@@ -8,6 +8,21 @@ if BOARD_ACTINIUS_ICARUS || BOARD_ACTINIUS_ICARUS_NS
 config BOARD
 	default "actinius_icarus"
 
+# By default, if we build for a Non-Secure version of the board,
+# enable building with TF-M as the Secure Execution Environment.
+config BUILD_WITH_TFM
+	default y if BOARD_ACTINIUS_ICARUS_NS
+
+if BUILD_WITH_TFM
+
+# By default, if we build with TF-M, instruct build system to
+# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
+config TFM_FLASH_MERGED_BINARY
+	bool
+	default y
+
+endif # BUILD_WITH_TFM
+
 source "boards/common/actinius/Kconfig"
 
 # For the secure version of the board the firmware is linked at the beginning


### PR DESCRIPTION
This config is copied from nrf9160dk, it allows usage of cellular modem when using the _ns board variant

https://github.com/zephyrproject-rtos/zephyr/blob/7058f3722e14d1af194fb38dbe7236a3160643b8/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig#L11-L24