### PR TITLE
xtensa: mmu: Implement support for xtensa mmu version 3

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -114,11 +114,29 @@ config XTENSA_MMU
 
 if XTENSA_MMU
 
-	config XTENSA_MMU_PTEVADDR
-		hex "PageTable virtual adddress"
-		default 0x20000000
+	choice
+		prompt "PageTable virtual adddress"
+		default XTENSA_MMU_PTEVADDR_20000000
 		help
 		  The virtual address for Xtensa page table (PTEVADDR).
+
+	config XTENSA_MMU_PTEVADDR_20000000
+		bool "0x20000000"
+
+	endchoice
+
+	config XTENSA_MMU_PTEVADDR
+		hex
+		default 0x20000000 if XTENSA_MMU_PTEVADDR_20000000
+		help
+		  The virtual address for Xtensa page table (PTEVADDR).
+
+	config XTENSA_MMU_PTEVADDR_SHIFT
+		int
+		default 29 if XTENSA_MMU_PTEVADDR_20000000
+		help
+		  The bit shift number for the virtual address for Xtensa
+		  page table (PTEVADDR).
 
 	config XTENSA_MMU_NUM_L2_TABLES
 		int "Number of L2 page tables"

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -103,4 +103,31 @@ config XTENSA_CCOUNT_HZ
 	  Rate in HZ of the Xtensa core as measured by the value of
 	  the CCOUNT register.
 
+if CPU_HAS_MMU
+
+config XTENSA_MMU
+	bool "Xtensa MMU Support"
+	default n
+	select MMU
+	help
+	  Enable support for Xtensa Memory Management Unit.
+
+if XTENSA_MMU
+
+	config XTENSA_MMU_PTEVADDR
+		hex "PageTable virtual adddress"
+		default 0x20000000
+		help
+		  The virtual address for Xtensa page table (PTEVADDR).
+
+	config XTENSA_MMU_NUM_L2_TABLES
+		int "Number of L2 page tables"
+		default 10
+		help
+		  Each table can address up to 4MB memory address.
+
+endif # XTENSA_MMU
+
+endif # CPU_HAS_MMU
+
 endmenu

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -109,6 +109,7 @@ config XTENSA_MMU
 	bool "Xtensa MMU Support"
 	default n
 	select MMU
+	select XTENSA_SMALL_VECTOR_TABLE_ENTRY
 	help
 	  Enable support for Xtensa Memory Management Unit.
 

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -126,6 +126,13 @@ if XTENSA_MMU
 		help
 		  Each table can address up to 4MB memory address.
 
+	config XTENSA_MMU_DOUBLE_MAP
+		bool "Map memory in cached and uncached region"
+		default n
+		help
+			This option specifies that the memory is mapped in two
+			distinct region, cached and uncached.
+
 endif # XTENSA_MMU
 
 endif # CPU_HAS_MMU

--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -21,6 +21,7 @@ zephyr_library_sources_ifdef(CONFIG_XTENSA_ENABLE_BACKTRACE debug_helpers_asm.S)
 zephyr_library_sources_ifdef(CONFIG_DEBUG_COREDUMP coredump.c)
 zephyr_library_sources_ifdef(CONFIG_TIMING_FUNCTIONS timing.c)
 zephyr_library_sources_ifdef(CONFIG_GDBSTUB gdbstub.c)
+zephyr_library_sources_ifdef(CONFIG_XTENSA_MMU xtensa_mmu.c)
 
 if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "xcc")
   zephyr_library_sources(xcc_stubs.c)

--- a/arch/xtensa/core/gen_zsr.py
+++ b/arch/xtensa/core/gen_zsr.py
@@ -65,6 +65,7 @@ with open(outfile, "w") as f:
     # Emit any remaining registers as generics
     for i in range(len(NEEDED), len(regs)):
         f.write(f"# define ZSR_EXTRA{i - len(NEEDED)} {regs[i]}\n")
+        f.write(f"# define ZSR_EXTRA{i - len(NEEDED)}_STR \"{regs[i]}\"\n")
 
     # Also, our highest level EPC/EPS registers
     f.write(f"# define ZSR_RFI_LEVEL {maxint}\n")

--- a/arch/xtensa/core/include/xtensa_mmu_priv.h
+++ b/arch/xtensa/core/include/xtensa_mmu_priv.h
@@ -1,0 +1,358 @@
+/*
+ * Xtensa MMU support
+ *
+ * Private data declarations
+ *
+ * Copyright (c) 2022 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_ARCH_XTENSA_XTENSA_MMU_PRIV_H_
+#define ZEPHYR_ARCH_XTENSA_XTENSA_MMU_PRIV_H_
+
+#include <stdint.h>
+#include <xtensa/config/core-isa.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/sys/util_macro.h>
+
+#define Z_XTENSA_PTE_VPN_MASK 0xFFFFF000U
+#define Z_XTENSA_PTE_PPN_MASK 0xFFFFF000U
+#define Z_XTENSA_PTE_ATTR_MASK 0x0000000FU
+#define Z_XTENSA_L1_MASK 0x3FF00000U
+#define Z_XTENSA_L2_MASK 0x3FFFFFU
+
+#define Z_XTENSA_PPN_SHIFT 12U
+
+#define Z_XTENSA_PTE_RING_MASK 0x00000030U
+
+#define Z_XTENSA_PTE(paddr, ring, attr) \
+	(((paddr) & Z_XTENSA_PTE_PPN_MASK) | \
+	(((ring) << 4) & Z_XTENSA_PTE_RING_MASK) | \
+	((attr) & Z_XTENSA_PTE_ATTR_MASK))
+
+#define Z_XTENSA_TLB_ENTRY(vaddr, way) \
+	(((vaddr) & Z_XTENSA_PTE_PPN_MASK) | (way))
+
+#define Z_XTENSA_AUTOFILL_TLB_ENTRY(vaddr) \
+	(((vaddr) & Z_XTENSA_PTE_PPN_MASK) | \
+	 (((vaddr) >> Z_XTENSA_PPN_SHIFT) & 0x03U))
+
+#define Z_XTENSA_L2_POS(vaddr) \
+	(((vaddr) & Z_XTENSA_L2_MASK) >> Z_XTENSA_PPN_SHIFT)
+
+
+/* Number of data TLB ways [0-9] */
+#define Z_XTENSA_DTLB_WAYS 10
+
+/* Number of instruction TLB ways [0-6] */
+#define Z_XTENSA_ITLB_WAYS 7
+
+/* Number of auto-refill ways */
+#define Z_XTENSA_TLB_AUTOREFILL_WAYS 4
+
+
+/* PITLB HIT bit. For more information see
+ * Xtensa Instruction Set Architecture (ISA) Reference Manual
+ * 4.6.5.7 Formats for Probing MMU Option TLB Entries
+ */
+#define Z_XTENSA_PITLB_HIT BIT(3)
+
+/* PDTLB HIT bit. For more information see
+ * Xtensa Instruction Set Architecture (ISA) Reference Manual
+ * 4.6.5.7 Formats for Probing MMU Option TLB Entries
+ */
+#define Z_XTENSA_PDTLB_HIT BIT(4)
+
+/*
+ * Virtual address where the page table is mapped
+ */
+#define Z_XTENSA_PTEVADDR CONFIG_XTENSA_MMU_PTEVADDR
+
+/*
+ * Find the pte entry address of a given vaddr.
+ *
+ * For example, assuming PTEVADDR in 0xE0000000,
+ * the page spans from 0xE0000000 - 0xE03FFFFF
+
+ *
+ * address 0x00 is in 0xE0000000
+ * address 0x1000 is in 0xE0000004
+ * .....
+ * address 0xE0000000 (where the page is) is in 0xE0380000
+ *
+ * Generalizing it, any PTE virtual address can be calculated this way:
+ *
+ * PTE_ENTRY_ADDRESS = PTEVADDR + ((VADDR / 4096) * 4)
+ */
+#define Z_XTENSA_PTE_ENTRY_VADDR(vaddr) \
+	(Z_XTENSA_PTEVADDR + (((vaddr) / KB(4)) * 4))
+
+/*
+ * The address of the top level page where the page
+ * is located in the virtual address.
+ */
+#define Z_XTENSA_PAGE_TABLE_VADDR \
+	Z_XTENSA_PTE_ENTRY_VADDR(Z_XTENSA_PTEVADDR)
+
+static ALWAYS_INLINE void xtensa_rasid_set(uint32_t rasid)
+{
+	__asm__ volatile("wsr %0, rasid\n\t"
+			"isync\n" : : "a"(rasid));
+}
+
+static ALWAYS_INLINE uint32_t xtensa_rasid_get(void)
+{
+	uint32_t rasid;
+
+	__asm__ volatile("rsr %0, rasid" : "=a"(rasid));
+	return rasid;
+}
+
+static ALWAYS_INLINE void xtensa_itlb_entry_invalidate(uint32_t entry)
+{
+	__asm__ volatile("iitlb %0\n\t"
+			: : "a" (entry));
+}
+
+static ALWAYS_INLINE void xtensa_itlb_entry_invalidate_sync(uint32_t entry)
+{
+	__asm__ volatile("iitlb %0\n\t"
+			"isync\n\t"
+			: : "a" (entry));
+}
+
+static ALWAYS_INLINE void xtensa_dtlb_entry_invalidate_sync(uint32_t entry)
+{
+	__asm__ volatile("idtlb %0\n\t"
+			"dsync\n\t"
+			: : "a" (entry));
+}
+
+static ALWAYS_INLINE void xtensa_dtlb_entry_invalidate(uint32_t entry)
+{
+	__asm__ volatile("idtlb %0\n\t"
+			: : "a" (entry));
+}
+
+static ALWAYS_INLINE void xtensa_dtlb_entry_write_sync(uint32_t pte, uint32_t entry)
+{
+	__asm__ volatile("wdtlb %0, %1\n\t"
+			"dsync\n\t"
+			: : "a" (pte), "a"(entry));
+}
+
+static ALWAYS_INLINE void xtensa_dtlb_entry_write(uint32_t pte, uint32_t entry)
+{
+	__asm__ volatile("wdtlb %0, %1\n\t"
+			: : "a" (pte), "a"(entry));
+}
+
+static ALWAYS_INLINE void xtensa_itlb_entry_write(uint32_t pte, uint32_t entry)
+{
+	__asm__ volatile("witlb %0, %1\n\t"
+			: : "a" (pte), "a"(entry));
+}
+
+static ALWAYS_INLINE void xtensa_itlb_entry_write_sync(uint32_t pte, uint32_t entry)
+{
+	__asm__ volatile("witlb %0, %1\n\t"
+			"isync\n\t"
+			: : "a" (pte), "a"(entry));
+}
+
+/**
+ * @brief Invalidate all ITLB entries.
+ *
+ * This should be used carefully since all entries in the instruction TLB
+ * will be erased and the only way to find lookup a physical address will be
+ * through the page tables.
+ */
+static inline void xtensa_itlb_invalidate_sync(void)
+{
+	uint8_t way, i;
+
+	for (way = 0; way < Z_XTENSA_ITLB_WAYS; way++) {
+		for (i = 0; i < (1 << XCHAL_ITLB_ARF_ENTRIES_LOG2); i++) {
+			uint32_t entry = way + (i << Z_XTENSA_PPN_SHIFT);
+
+			xtensa_itlb_entry_invalidate(entry);
+		}
+	}
+	__asm__ volatile("isync");
+}
+
+/**
+ * @brief Invalidate all DTLB entries.
+ *
+ * This should be used carefully since all entries in the data TLB will be
+ * erased and the only way to find lookup a physical address will be through
+ * the page tables.
+ */
+static inline void xtensa_dtlb_invalidate_sync(void)
+{
+	uint8_t way, i;
+
+	for (way = 0; way < Z_XTENSA_DTLB_WAYS; way++) {
+		for (i = 0; i < (1 << XCHAL_DTLB_ARF_ENTRIES_LOG2); i++) {
+			uint32_t entry = way + (i << Z_XTENSA_PPN_SHIFT);
+
+			xtensa_dtlb_entry_invalidate(entry);
+		}
+	}
+	__asm__ volatile("isync");
+}
+
+/**
+ * @brief Invalidates an autorefill DTLB entry.
+ *
+ * Invalidates the page table enrty that maps a given virtual address.
+ */
+static inline void xtensa_dtlb_autorefill_invalidate_sync(void *vaddr)
+{
+	uint8_t way;
+
+	for (way = 0; way < Z_XTENSA_TLB_AUTOREFILL_WAYS; way++) {
+		xtensa_dtlb_entry_invalidate(Z_XTENSA_TLB_ENTRY((uint32_t)vaddr, way));
+	}
+	__asm__ volatile("dsync");
+}
+
+/**
+ * @brief Invalidates an autorefill ITLB entry.
+ *
+ * Invalidates the page table enrty that maps a given virtual address.
+ */
+static inline void xtensa_itlb_autorefill_invalidate_sync(void *vaddr)
+{
+	uint8_t way;
+
+	for (way = 0; way < Z_XTENSA_TLB_AUTOREFILL_WAYS; way++) {
+		xtensa_itlb_entry_invalidate(Z_XTENSA_TLB_ENTRY((uint32_t)vaddr, way));
+	}
+	__asm__ volatile("isync");
+}
+/**
+ * @brief Invalidate all autorefill ITLB entries.
+ *
+ * This should be used carefully since all entries in the instruction TLB
+ * will be erased and the only way to find lookup a physical address will be
+ * through the page tables.
+ */
+static inline void xtensa_itlb_autorefill_invalidate_all_sync(void)
+{
+	uint8_t way, i;
+
+	for (way = 0; way < Z_XTENSA_TLB_AUTOREFILL_WAYS; way++) {
+		for (i = 0; i < (1 << XCHAL_ITLB_ARF_ENTRIES_LOG2); i++) {
+			uint32_t entry = way + (i << Z_XTENSA_PPN_SHIFT);
+
+			xtensa_itlb_entry_invalidate(entry);
+		}
+	}
+	__asm__ volatile("isync");
+}
+
+/**
+ * @brief Invalidate all autorefill DTLB entries.
+ *
+ * This should be used carefully since all entries in the data TLB will be
+ * erased and the only way to find lookup a physical address will be through
+ * the page tables.
+ */
+static inline void xtensa_dtlb_autorefill_invalidate_all_sync(void)
+{
+	uint8_t way, i;
+
+	for (way = 0; way < Z_XTENSA_TLB_AUTOREFILL_WAYS; way++) {
+		for (i = 0; i < (1 << XCHAL_DTLB_ARF_ENTRIES_LOG2); i++) {
+			uint32_t entry = way + (i << Z_XTENSA_PPN_SHIFT);
+
+			xtensa_dtlb_entry_invalidate(entry);
+		}
+	}
+	__asm__ volatile("isync");
+}
+
+
+/**
+ * @brief Set the page tables.
+ *
+ * The page tables is set writing ptevaddr address.
+ *
+ * @param ptables The page tables address (virtual address)
+ */
+static ALWAYS_INLINE void xtensa_ptevaddr_set(void *ptables)
+{
+	__asm__ volatile("wsr.ptevaddr %0" : : "a"((uint32_t)ptables));
+}
+
+/*
+ * The following functions are helpful when debugging.
+ */
+static ALWAYS_INLINE void *xtensa_dtlb_vaddr_read(uint32_t entry)
+{
+	uint32_t vaddr;
+
+	__asm__ volatile("rdtlb0  %0, %1\n\t" : "=a" (vaddr) : "a" (entry));
+	return (void *)(vaddr & Z_XTENSA_PTE_VPN_MASK);
+}
+
+static ALWAYS_INLINE uint32_t xtensa_dtlb_paddr_read(uint32_t entry)
+{
+	uint32_t paddr;
+
+	__asm__ volatile("rdtlb1  %0, %1\n\t" : "=a" (paddr) : "a" (entry));
+	return (paddr & Z_XTENSA_PTE_PPN_MASK);
+}
+
+static ALWAYS_INLINE void *xtensa_itlb_vaddr_read(uint32_t entry)
+{
+	uint32_t vaddr;
+
+	__asm__ volatile("ritlb0  %0, %1\n\t" : "=a" (vaddr), "+a" (entry));
+	return (void *)(vaddr & Z_XTENSA_PTE_VPN_MASK);
+}
+
+static ALWAYS_INLINE uint32_t xtensa_itlb_paddr_read(uint32_t entry)
+{
+	uint32_t paddr;
+
+	__asm__ volatile("ritlb1  %0, %1\n\t" : "=a" (paddr), "+a" (entry));
+	return (paddr & Z_XTENSA_PTE_PPN_MASK);
+}
+
+static ALWAYS_INLINE uint32_t xtensa_itlb_probe(void *vaddr)
+{
+	uint32_t ret;
+
+	__asm__ __volatile__("pitlb  %0, %1\n\t" : "=a" (ret) : "a" ((uint32_t)vaddr));
+	return ret;
+}
+
+static ALWAYS_INLINE uint32_t xtensa_dtlb_probe(void *vaddr)
+{
+	uint32_t ret;
+
+	__asm__ __volatile__("pdtlb  %0, %1\n\t" : "=a" (ret) : "a" ((uint32_t)vaddr));
+	return ret;
+}
+
+static inline void xtensa_itlb_vaddr_invalidate(void *vaddr)
+{
+	uint32_t entry = xtensa_itlb_probe(vaddr);
+
+	if (entry & Z_XTENSA_PITLB_HIT) {
+		xtensa_itlb_entry_invalidate_sync(entry);
+	}
+}
+
+static inline void xtensa_dtlb_vaddr_invalidate(void *vaddr)
+{
+	uint32_t entry = xtensa_dtlb_probe(vaddr);
+
+	if (entry & Z_XTENSA_PDTLB_HIT) {
+		xtensa_dtlb_entry_invalidate_sync(entry);
+	}
+}
+
+#endif /* ZEPHYR_ARCH_XTENSA_XTENSA_MMU_PRIV_H_ */

--- a/arch/xtensa/core/xtensa-asm2-util.S
+++ b/arch/xtensa/core/xtensa-asm2-util.S
@@ -278,7 +278,7 @@ _switch_restore_pc:
  */
 .align 4
 _handle_excint:
-	EXCINT_HANDLER ZSR_CPU, ___cpu_t_nested_OFFSET, ___cpu_t_irq_stack_OFFSET
+	EXCINT_HANDLER ___cpu_t_nested_OFFSET, ___cpu_t_irq_stack_OFFSET
 
 /* Define the actual vectors for the hardware-defined levels with
  * DEF_EXCINT.  These load a C handler address and jump to our handler
@@ -344,39 +344,12 @@ DEF_EXCINT XCHAL_DEBUGLEVEL, _handle_excint, xtensa_debugint_c
 _Level1RealVector:
 	wsr a0, ZSR_ALLOCA
 	rsr.exccause a0
-#ifdef CONFIG_XTENSA_MMU
-	beqi a0, EXCCAUSE_ITLB_MISS, _handle_miss
-	addi a0, a0, -EXCCAUSE_DTLB_MISS
-	beqz a0, _handle_miss
-	rsr.exccause a0
-#endif /* CONFIG_XTENSA_MMU */
 	bnei a0, EXCCAUSE_ALLOCA, _not_alloca
 
 	j _xt_alloca_exc
 _not_alloca:
 	rsr a0, ZSR_ALLOCA
 	j _Level1Vector
-#ifdef CONFIG_XTENSA_MMU
-_handle_miss:
-/**
- * That is a temporary way to load a page for a tlb miss.
- * The way it works is, when we try to access an address that is not
- * mapped, we will have a miss. The HW then will try to get the correspondent
- * memory in the page table. As the page table is not mapped in memory we
- * will have a second miss, which will trigger an exception. In the exception
- * (here) what we do is to exploit this hardware capability just trying to load
- * the page table (not mapped address), which will cause a miss, but then the
- * hardware will automatically map it again from the page table. This time it will
- * work since the page necessary to map the page table itself are wired map.
- *
- * This solution is temporary because we don't gracefully handle a second level
- * miss. We are just assuming that the requested memory is available.
- */
-	rsr.ptevaddr a0
-	l32i a0, a0, 0
-	rsr a0, ZSR_ALLOCA
-	rfe
-#endif /* CONFIG_XTENSA_MMU */
 .popsection
 
 /* In theory you can have levels up to 15, but known hardware only uses 7. */
@@ -390,13 +363,47 @@ _handle_miss:
 .pushsection .KernelExceptionVector.text, "ax"
 .global _KernelExceptionVector
 _KernelExceptionVector:
+#ifdef CONFIG_XTENSA_MMU
+	wsr a0, ZSR_ALLOCA
+	rsr.exccause a0
+	beqi a0, EXCCAUSE_ITLB_MISS, _handle_tlb_miss_kernel
+	addi a0, a0, -EXCCAUSE_DTLB_MISS
+	beqz a0, _handle_tlb_miss_kernel
+	rsr a0, ZSR_ALLOCA
+#endif
 	j _Level1Vector
+#ifdef CONFIG_XTENSA_MMU
+_handle_tlb_miss_kernel:
+	/* The TLB miss handling is used only during z_xtensa_mmu_init()
+	 * where vecbase is at a different address, as the offset used
+	 * in the jump ('j') instruction will not jump to correct
+	 * address (... remember the vecbase is moved).
+	 * So we handle TLB misses in a very simple way here until
+	 * we move back to using UserExceptionVector above.
+	 */
+	rsr.ptevaddr a0
+	l32i a0, a0, 0
+	rsr a0, ZSR_ALLOCA
+	rfe
+#endif
 .popsection
 
 #ifdef XCHAL_DOUBLEEXC_VECTOR_VADDR
 .pushsection .DoubleExceptionVector.text, "ax"
 .global _DoubleExceptionVector
 _DoubleExceptionVector:
+#ifdef CONFIG_XTENSA_MMU
+	wsr a0, ZSR_ALLOCA
+	wsr a1, ZSR_EXTRA0
+
+	rsr.exccause a0
+	addi a0, a0, -EXCCAUSE_DTLB_MISS
+	beqz a0, _handle_tlb_miss_dblexc
+
+_not_handle_tlb_miss_dblexc:
+	rsr a1, ZSR_EXTRA0
+	rsr a0, ZSR_ALLOCA
+#endif
 #if defined(CONFIG_SIMULATOR_XTENSA) || defined(XT_SIMULATOR)
 1:
 /* Tell simulator to stop executing here, instead of trying to do
@@ -414,5 +421,57 @@ _DoubleExceptionVector:
 1:
 #endif
 	j	1b
+
+#ifdef CONFIG_XTENSA_MMU
+_handle_tlb_miss_dblexc:
+	/* The tiny space reserved for each vector is not enough
+	 * to accommodate code below, and beqz cannot jump too far.
+	 * So we have this here as a trampoline.
+	 */
+	j _handle_tlb_miss_dblexc_helper
+#endif
 .popsection
+
+#ifdef CONFIG_XTENSA_MMU
+.pushsection .iram.text, "ax"
+_handle_tlb_miss_dblexc_helper:
+	/* It is possible that VECBASE is not mapped in TLB
+	 * so TLB misses would be raised. We will need to
+	 * map it and return so it can continue handling
+	 * the original exception.
+	 */
+
+	/* Find the address of mapped region of this PTE page.
+	 * Since each PTE page maps 1024 of 4K pages, we simply
+	 * need to multiply by 1024 (shift left by 10).
+	 */
+	rsr.ptevaddr a0
+	slli a0, a0, 10
+
+	/* Get the beginning address of the 4K page mapped for
+	 * VECBASE. Shift 12 bits right and left as a way to zero
+	 * the lower 11 bits.
+	 */
+	rsr.vecbase a1
+	srli a1, a1, 12
+	slli a1, a1, 12
+
+	/* If it is VECBASE causing TLB miss, we load the PTE page
+	 * and continue.
+	 */
+	beq a0, a1, _dblexc_load_pte
+
+	/* Ignore TLB miss is not on VECBASE page. */
+	j _not_handle_tlb_miss_dblexc
+
+_dblexc_load_pte:
+	rsr.ptevaddr a0
+	l32i a0, a0, 0
+
+	rsr a1, ZSR_EXTRA0
+	rsr a0, ZSR_ALLOCA
+	rfde
+.popsection
+#endif
+
 #endif

--- a/arch/xtensa/core/xtensa-asm2-util.S
+++ b/arch/xtensa/core/xtensa-asm2-util.S
@@ -344,11 +344,39 @@ DEF_EXCINT XCHAL_DEBUGLEVEL, _handle_excint, xtensa_debugint_c
 _Level1RealVector:
 	wsr a0, ZSR_ALLOCA
 	rsr.exccause a0
+#ifdef CONFIG_XTENSA_MMU
+	beqi a0, EXCCAUSE_ITLB_MISS, _handle_miss
+	addi a0, a0, -EXCCAUSE_DTLB_MISS
+	beqz a0, _handle_miss
+	rsr.exccause a0
+#endif /* CONFIG_XTENSA_MMU */
 	bnei a0, EXCCAUSE_ALLOCA, _not_alloca
+
 	j _xt_alloca_exc
 _not_alloca:
 	rsr a0, ZSR_ALLOCA
 	j _Level1Vector
+#ifdef CONFIG_XTENSA_MMU
+_handle_miss:
+/**
+ * That is a temporary way to load a page for a tlb miss.
+ * The way it works is, when we try to access an address that is not
+ * mapped, we will have a miss. The HW then will try to get the correspondent
+ * memory in the page table. As the page table is not mapped in memory we
+ * will have a second miss, which will trigger an exception. In the exception
+ * (here) what we do is to exploit this hardware capability just trying to load
+ * the page table (not mapped address), which will cause a miss, but then the
+ * hardware will automatically map it again from the page table. This time it will
+ * work since the page necessary to map the page table itself are wired map.
+ *
+ * This solution is temporary because we don't gracefully handle a second level
+ * miss. We are just assuming that the requested memory is available.
+ */
+	rsr.ptevaddr a0
+	l32i a0, a0, 0
+	rsr a0, ZSR_ALLOCA
+	rfe
+#endif /* CONFIG_XTENSA_MMU */
 .popsection
 
 /* In theory you can have levels up to 15, but known hardware only uses 7. */

--- a/arch/xtensa/core/xtensa_mmu.c
+++ b/arch/xtensa/core/xtensa_mmu.c
@@ -19,6 +19,9 @@
 /* Fixed data TLB way to map the page table */
 #define MMU_PTE_WAY 7
 
+/* Fixed data TLB way to map VECBASE */
+#define MMU_VECBASE_WAY 8
+
 /* Level 1 contains page table entries
  * necessary to map the page table itself.
  */
@@ -283,6 +286,12 @@ static void xtensa_mmu_init(bool is_core0)
 				:: [idx] "a"((entry << 29) | 6));
 	}
 
+	/* Map VECBASE to a fixed data TLB */
+	xtensa_dtlb_entry_write(
+			Z_XTENSA_PTE((uint32_t)vecbase,
+				     MMU_KERNEL_RING, Z_XTENSA_MMU_CACHED_WB),
+			Z_XTENSA_TLB_ENTRY((uint32_t)vecbase, MMU_VECBASE_WAY));
+
 	/* To finish, just restore vecbase and invalidate TLB entries
 	 * used to map the relocated vecbase.
 	 */
@@ -305,10 +314,6 @@ static void xtensa_mmu_init(bool is_core0)
 	 * TLB misses.
 	 */
 	xtensa_itlb_entry_write_sync(
-		Z_XTENSA_PTE(vecbase, MMU_KERNEL_RING,
-			Z_XTENSA_MMU_X | Z_XTENSA_MMU_CACHED_WT),
-		Z_XTENSA_AUTOFILL_TLB_ENTRY(vecbase));
-	xtensa_dtlb_entry_write_sync(
 		Z_XTENSA_PTE(vecbase, MMU_KERNEL_RING,
 			Z_XTENSA_MMU_X | Z_XTENSA_MMU_CACHED_WT),
 		Z_XTENSA_AUTOFILL_TLB_ENTRY(vecbase));

--- a/arch/xtensa/core/xtensa_mmu.c
+++ b/arch/xtensa/core/xtensa_mmu.c
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/cache.h>
+#include <zephyr/arch/xtensa/xtensa_mmu.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/mem_manage.h>
+#include <xtensa_mmu_priv.h>
+
+/* Kernel specific ASID. Ring field in the PTE */
+#define MMU_KERNEL_RING 0
+
+/* Fixed data TLB way to map the page table */
+#define MMU_PTE_WAY 7
+
+/* Level 1 contains page table entries
+ * necessary to map the page table itself.
+ */
+#define XTENSA_L1_PAGE_TABLE_ENTRIES 1024U
+
+/* Level 2 contains page table entries
+ * necessary to map the page table itself.
+ */
+#define XTENSA_L2_PAGE_TABLE_ENTRIES 1024U
+
+LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
+
+BUILD_ASSERT(CONFIG_MMU_PAGE_SIZE == 0x1000,
+	     "MMU_PAGE_SIZE value is invalid, only 4 kB pages are supported\n");
+
+/*
+ * Level 1 page table has to be 4Kb to fit into one of the wired entries.
+ * All entries are initialized as INVALID, so an attempt to read an unmapped
+ * area will cause a double exception.
+ */
+uint32_t l1_page_table[XTENSA_L1_PAGE_TABLE_ENTRIES] __aligned(KB(4));
+
+/*
+ * Each table in the level 2 maps a 4Mb memory range. It consists of 1024 entries each one
+ * covering a 4Kb page.
+ */
+static uint32_t l2_page_tables[CONFIG_XTENSA_MMU_NUM_L2_TABLES][XTENSA_L2_PAGE_TABLE_ENTRIES]
+				__aligned(KB(4));
+
+/*
+ * This additional variable tracks which l2 tables are in use. This is kept separated from
+ * the tables to keep alignment easier.
+ */
+static ATOMIC_DEFINE(l2_page_tables_track, CONFIG_XTENSA_MMU_NUM_L2_TABLES);
+
+extern char _heap_end[];
+extern char _heap_start[];
+extern char __data_start[];
+extern char __data_end[];
+extern char _bss_start[];
+extern char _bss_end[];
+
+/*
+ * Static definition of all code & data memory regions of the
+ * current Zephyr image. This information must be available &
+ * processed upon MMU initialization.
+ */
+
+static const struct xtensa_mmu_range mmu_zephyr_ranges[] = {
+	/*
+	 * Mark the zephyr execution regions (data, bss, noinit, etc.)
+	 * cacheable, read / write and non-executable
+	 */
+	{
+		.start = (uint32_t)__data_start,
+		.end   = (uint32_t)__data_end,
+		.attrs = Z_XTENSA_MMU_W,
+		.name = "data",
+	},
+	{
+		.start = (uint32_t)_bss_start,
+		.end   = (uint32_t)_bss_end,
+		.attrs = Z_XTENSA_MMU_W,
+		.name = "bss",
+	},
+	/* System heap memory */
+	{
+		.start = (uint32_t)_heap_start,
+		.end   = (uint32_t)_heap_end,
+		.attrs = Z_XTENSA_MMU_W,
+		.name = "heap",
+	},
+	/* Mark text segment cacheable, read only and executable */
+	{
+		.start = (uint32_t)__text_region_start,
+		.end   = (uint32_t)__text_region_end,
+		.attrs = Z_XTENSA_MMU_X | Z_XTENSA_MMU_CACHED_WB,
+		.name = "text",
+	},
+	/* Mark rodata segment cacheable, read only and non-executable */
+	{
+		.start = (uint32_t)__rodata_region_start,
+		.end   = (uint32_t)__rodata_region_end,
+		.attrs = Z_XTENSA_MMU_CACHED_WB,
+		.name = "rodata",
+	},
+};
+
+static inline uint32_t *alloc_l2_table(void)
+{
+	uint16_t idx;
+
+	for (idx = 0; idx < CONFIG_XTENSA_MMU_NUM_L2_TABLES; idx++) {
+		if (!atomic_test_and_set_bit(l2_page_tables_track, idx)) {
+			return (uint32_t *)&l2_page_tables[idx];
+		}
+	}
+
+	return NULL;
+}
+
+static void map_memory_range(const struct xtensa_mmu_range *range)
+{
+	uint32_t page, *table;
+
+	for (page = range->start; page < range->end; page += CONFIG_MMU_PAGE_SIZE) {
+		uint32_t pte = Z_XTENSA_PTE(page, MMU_KERNEL_RING, range->attrs);
+		uint32_t l2_pos = Z_XTENSA_L2_POS(page);
+		uint32_t l1_pos = page >> 22;
+
+		if (l1_page_table[l1_pos] == Z_XTENSA_MMU_ILLEGAL) {
+			table  = alloc_l2_table();
+
+			__ASSERT(table != NULL, "There is no l2 page table available to "
+				"map 0x%08x\n", page);
+
+			l1_page_table[l1_pos] =
+				Z_XTENSA_PTE((uint32_t)table, MMU_KERNEL_RING,
+						Z_XTENSA_MMU_CACHED_WT);
+		}
+
+		table = (uint32_t *)(l1_page_table[l1_pos] & Z_XTENSA_PTE_PPN_MASK);
+		table[l2_pos] = pte;
+	}
+}
+
+static void xtensa_init_page_tables(void)
+{
+	volatile uint8_t entry;
+	uint32_t page;
+
+	for (page = 0; page < XTENSA_L1_PAGE_TABLE_ENTRIES; page++) {
+		l1_page_table[page] = Z_XTENSA_MMU_ILLEGAL;
+	}
+
+	for (entry = 0; entry < ARRAY_SIZE(mmu_zephyr_ranges); entry++) {
+		map_memory_range(&mmu_zephyr_ranges[entry]);
+	}
+
+/**
+ * GCC complains about usage of the SoC MMU range ARRAY_SIZE
+ * (xtensa_soc_mmu_ranges) as the default weak declaration is
+ * an empty array, and any access to its element is considered
+ * out of bound access. However, we have a number of element
+ * variable to guard against this (... if done correctly).
+ * Besides, this will almost be overridden by the SoC layer.
+ * So tell GCC to ignore this.
+ */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+	for (entry = 0; entry < xtensa_soc_mmu_ranges_num; entry++) {
+		map_memory_range(&xtensa_soc_mmu_ranges[entry]);
+	}
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+	sys_cache_data_flush_all();
+}
+
+static void xtensa_mmu_init(bool is_core0)
+{
+	volatile uint8_t entry;
+	uint32_t ps, vecbase;
+
+	if (is_core0) {
+		/* This is normally done via arch_kernel_init() inside z_cstart().
+		 * However, before that is called, we go through the sys_init of
+		 * INIT_LEVEL_EARLY, which is going to result in TLB misses.
+		 * So setup whatever necessary so the exception handler can work
+		 * properly.
+		 */
+		z_xtensa_kernel_init();
+		xtensa_init_page_tables();
+	}
+
+	/* Set the page table location in the virtual address */
+	xtensa_ptevaddr_set((void *)Z_XTENSA_PTEVADDR);
+
+	/* Next step is to invalidate the tlb entry that contains the top level
+	 * page table. This way we don't cause a multi hit exception.
+	 */
+	xtensa_dtlb_entry_invalidate_sync(Z_XTENSA_TLB_ENTRY(Z_XTENSA_PAGE_TABLE_VADDR, 6));
+	xtensa_itlb_entry_invalidate_sync(Z_XTENSA_TLB_ENTRY(Z_XTENSA_PAGE_TABLE_VADDR, 6));
+
+	/* We are not using a flat table page, so we need to map
+	 * only the top level page table (which maps the page table itself).
+	 *
+	 * Lets use one of the wired entry, so we never have tlb miss for
+	 * the top level table.
+	 */
+	xtensa_dtlb_entry_write(Z_XTENSA_PTE((uint32_t)l1_page_table, MMU_KERNEL_RING,
+				Z_XTENSA_MMU_CACHED_WT),
+			Z_XTENSA_TLB_ENTRY(Z_XTENSA_PAGE_TABLE_VADDR, MMU_PTE_WAY));
+
+	/* Before invalidate the text region in the TLB entry 6, we need to
+	 * map the exception vector into one of the wired entries to avoid
+	 * a page miss for the exception.
+	 */
+	__asm__ volatile("rsr.vecbase %0" : "=r"(vecbase));
+
+	xtensa_itlb_entry_write_sync(
+		Z_XTENSA_PTE(vecbase, MMU_KERNEL_RING,
+			Z_XTENSA_MMU_X | Z_XTENSA_MMU_CACHED_WT),
+		Z_XTENSA_TLB_ENTRY(
+			Z_XTENSA_PTEVADDR + MB(4), 3));
+
+	xtensa_dtlb_entry_write_sync(
+		Z_XTENSA_PTE(vecbase, MMU_KERNEL_RING,
+			Z_XTENSA_MMU_X | Z_XTENSA_MMU_CACHED_WT),
+		Z_XTENSA_TLB_ENTRY(
+			Z_XTENSA_PTEVADDR + MB(4), 3));
+
+	__asm__ volatile("wsr.vecbase %0; rsync\n\t"
+			:: "a"(Z_XTENSA_PTEVADDR + MB(4)));
+
+
+	/* Finally, lets invalidate entries in the way 6 that are no longer
+	 * needed. We keep 0x00000000 to 0x200000000 since
+	 * this region is directly accessed elsewhere
+	 * and remove them now is not gonna work. TODO: Map whathever is necessary
+	 * into the kernel virtual space and unmap these regions.
+	 */
+	for (entry = 1; entry < 8; entry++) {
+		__asm__ volatile("idtlb %[idx]\n\t"
+				"iitlb %[idx]\n\t"
+				"dsync\n\t"
+				"isync"
+				:: [idx] "a"((entry << 29) | 6));
+	}
+
+	/* To finish, just restore vecbase and invalidate TLB entries
+	 * used to map the relocated vecbase.
+	 */
+	__asm__ volatile("wsr.vecbase %0; rsync\n\t"
+			:: "a"(vecbase));
+
+	xtensa_dtlb_entry_invalidate_sync(Z_XTENSA_TLB_ENTRY(Z_XTENSA_PTEVADDR + MB(4), 3));
+	xtensa_itlb_entry_invalidate_sync(Z_XTENSA_TLB_ENTRY(Z_XTENSA_PTEVADDR + MB(4), 3));
+
+	/*
+	 * Pre-load TLB for vecbase so exception handling won't result
+	 * in TLB miss during boot, and that we can handle single
+	 * TLB misses.
+	 */
+	xtensa_itlb_entry_write_sync(
+		Z_XTENSA_PTE(vecbase, MMU_KERNEL_RING,
+			Z_XTENSA_MMU_X | Z_XTENSA_MMU_CACHED_WT),
+		Z_XTENSA_AUTOFILL_TLB_ENTRY(vecbase));
+	xtensa_dtlb_entry_write_sync(
+		Z_XTENSA_PTE(vecbase, MMU_KERNEL_RING,
+			Z_XTENSA_MMU_X | Z_XTENSA_MMU_CACHED_WT),
+		Z_XTENSA_AUTOFILL_TLB_ENTRY(vecbase));
+}
+
+void z_xtensa_mmu_init(void)
+{
+	xtensa_mmu_init(true);
+}
+
+void z_xtensa_mmu_smp_init(void)
+{
+	xtensa_mmu_init(false);
+}
+
+static bool l2_page_table_map(void *vaddr, uintptr_t phys, uint32_t flags)
+{
+	uint32_t l1_pos = (uint32_t)vaddr >> 22;
+	uint32_t pte = Z_XTENSA_PTE(phys, MMU_KERNEL_RING, flags);
+	uint32_t l2_pos = Z_XTENSA_L2_POS((uint32_t)vaddr);
+	uint32_t *table;
+
+	if (l1_page_table[l1_pos] == Z_XTENSA_MMU_ILLEGAL) {
+		table  = alloc_l2_table();
+
+		if (table == NULL) {
+			return false;
+		}
+
+		l1_page_table[l1_pos] = Z_XTENSA_PTE((uint32_t)table, MMU_KERNEL_RING,
+				Z_XTENSA_MMU_CACHED_WT);
+	}
+
+	table = (uint32_t *)(l1_page_table[l1_pos] & Z_XTENSA_PTE_PPN_MASK);
+	table[l2_pos] = pte;
+
+	if ((flags & Z_XTENSA_MMU_X) == Z_XTENSA_MMU_X) {
+		xtensa_itlb_vaddr_invalidate(vaddr);
+	}
+	xtensa_dtlb_vaddr_invalidate(vaddr);
+	return true;
+}
+
+void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
+{
+	uint32_t va = (uint32_t)virt;
+	uint32_t pa = (uint32_t)phys;
+	uint32_t rem_size = (uint32_t)size;
+	uint32_t xtensa_flags = 0;
+	int key;
+
+	if (size == 0) {
+		LOG_ERR("Cannot map physical memory at 0x%08X: invalid "
+			"zero size", (uint32_t)phys);
+		k_panic();
+	}
+
+	switch (flags & K_MEM_CACHE_MASK) {
+
+	case K_MEM_CACHE_WB:
+		xtensa_flags |= Z_XTENSA_MMU_CACHED_WB;
+		break;
+	case K_MEM_CACHE_WT:
+		xtensa_flags |= Z_XTENSA_MMU_CACHED_WT;
+		break;
+	case K_MEM_CACHE_NONE:
+		__fallthrough;
+	default:
+		break;
+	}
+
+	if ((flags & K_MEM_PERM_RW) == K_MEM_PERM_RW) {
+		xtensa_flags |= Z_XTENSA_MMU_W;
+	}
+	if ((flags & K_MEM_PERM_EXEC) == K_MEM_PERM_EXEC) {
+		xtensa_flags |= Z_XTENSA_MMU_X;
+	}
+
+	key = arch_irq_lock();
+
+	while (rem_size > 0) {
+		bool ret = l2_page_table_map((void *)va, pa, xtensa_flags);
+
+		ARG_UNUSED(ret);
+		__ASSERT(ret, "Virtual address (%u) already mapped", (uint32_t)virt);
+		rem_size -= (rem_size >= KB(4)) ? KB(4) : rem_size;
+		va += KB(4);
+		pa += KB(4);
+	}
+
+	arch_irq_unlock(key);
+}
+
+static void l2_page_table_unmap(void *vaddr)
+{
+	uint32_t l1_pos = (uint32_t)vaddr >> 22;
+	uint32_t l2_pos = Z_XTENSA_L2_POS((uint32_t)vaddr);
+	uint32_t *table;
+	uint32_t table_pos;
+	bool exec;
+
+	if (l1_page_table[l1_pos] == Z_XTENSA_MMU_ILLEGAL) {
+		return;
+	}
+
+	exec = l1_page_table[l1_pos] & Z_XTENSA_MMU_X;
+
+	table = (uint32_t *)(l1_page_table[l1_pos] & Z_XTENSA_PTE_PPN_MASK);
+	table[l2_pos] = Z_XTENSA_MMU_ILLEGAL;
+
+	for (l2_pos = 0; l2_pos < XTENSA_L2_PAGE_TABLE_ENTRIES; l2_pos++) {
+		if (table[l2_pos] != Z_XTENSA_MMU_ILLEGAL) {
+			goto end;
+		}
+	}
+
+	l1_page_table[l1_pos] = Z_XTENSA_MMU_ILLEGAL;
+	table_pos = (table - (uint32_t *)l2_page_tables) / (XTENSA_L2_PAGE_TABLE_ENTRIES);
+	atomic_clear_bit(l2_page_tables_track, table_pos);
+
+	/* Need to invalidate L2 page table as it is no longer valid. */
+	xtensa_dtlb_vaddr_invalidate((void *)table);
+
+end:
+	if (exec) {
+		xtensa_itlb_vaddr_invalidate(vaddr);
+	}
+	xtensa_dtlb_vaddr_invalidate(vaddr);
+}
+
+void arch_mem_unmap(void *addr, size_t size)
+{
+	uint32_t va = (uint32_t)addr;
+	uint32_t rem_size = (uint32_t)size;
+	int key;
+
+	if (addr == NULL) {
+		LOG_ERR("Cannot unmap NULL pointer");
+		return;
+	}
+
+	if (size == 0) {
+		LOG_ERR("Cannot unmap virtual memory with zero size");
+		return;
+	}
+
+	key = arch_irq_lock();
+
+	while (rem_size > 0) {
+		l2_page_table_unmap((void *)va);
+		rem_size -= (rem_size >= KB(4)) ? KB(4) : rem_size;
+		va += KB(4);
+	}
+
+	arch_irq_unlock(key);
+}

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -25,7 +25,7 @@ extern void z_xtensa_fatal_error(unsigned int reason, const z_arch_esf_t *esf);
 K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 			     CONFIG_ISR_STACK_SIZE);
 
-static ALWAYS_INLINE void arch_kernel_init(void)
+static ALWAYS_INLINE void z_xtensa_kernel_init(void)
 {
 	_cpu_t *cpu0 = &_kernel.cpus[0];
 
@@ -51,6 +51,16 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 	 * win.
 	 */
 	XTENSA_WSR(ZSR_CPU_STR, cpu0);
+}
+
+static ALWAYS_INLINE void arch_kernel_init(void)
+{
+#ifndef CONFIG_XTENSA_MMU
+	/* This is called in z_xtensa_mmu_init() before z_cstart()
+	 * so we do not need to call it again.
+	 */
+	z_xtensa_kernel_init();
+#endif
 
 #ifdef CONFIG_INIT_STACKS
 	memset(Z_KERNEL_STACK_BUFFER(z_interrupt_stacks[0]), 0xAA,

--- a/arch/xtensa/include/xtensa-asm2-s.h
+++ b/arch/xtensa/include/xtensa-asm2-s.h
@@ -562,15 +562,6 @@ _Level\LVL\()Vector:
 	/* Preload PTE entry page of current stack. */
 	PRELOAD_PTEVADDR a3, a2
 
-	/* Preload PTE entry page of VECBASE. This is due to
-	 * _handle_excint_imm* and _c_handler_imm* (below).
-	 * We cannot afford a TLB miss while already handling
-	 * an exception. So make sure the VECBASE page is
-	 * mapped in TLB.
-	 */
-	rsr.vecbase a2
-	PRELOAD_PTEVADDR a3, a2
-
 	/* Preload PTE entry page of new stack, where
 	 * it will be used later (in EXCINT_HANDLER above).
 	 */

--- a/arch/xtensa/include/xtensa-asm2-s.h
+++ b/arch/xtensa/include/xtensa-asm2-s.h
@@ -185,6 +185,100 @@
 #endif
 .endm
 
+#ifdef CONFIG_XTENSA_MMU
+/*
+ * CALC_PTEVADDR_BASE
+ *
+ * This calculates the virtual address of the first PTE page
+ * (PTEVADDR base, the one mapping 0x00000000) so that we can
+ * use this to obtain the virtual address of the PTE page we are
+ * interested in. This can be obtained via
+ * (1 << CONFIG_XTENSA_MMU_PTEVADDR_SHIFT).
+ *
+ * Note that this is done this way is to avoid any TLB
+ * miss if we are to use l32r to load the PTEVADDR base.
+ * If the page containing the PTEVADDR base address is
+ * not in TLB, we will need to handle the TLB miss which
+ * we are trying to avoid here.
+ *
+ * @param ADDR_REG Register to store the calculated
+ *                 PTEVADDR base address.
+ *
+ * @note The content of ADDR_REG will be modified.
+ *       Save and restore it around this macro usage.
+ */
+.macro CALC_PTEVADDR_BASE ADDR_REG
+	movi \ADDR_REG, 1
+	slli \ADDR_REG, \ADDR_REG, CONFIG_XTENSA_MMU_PTEVADDR_SHIFT
+.endm
+
+/*
+ * PRELOAD_PTEVADDR
+ *
+ * This preloads the page table entries for a 4MB region to avoid TLB
+ * misses. This 4MB region is mapped via a page (4KB) of page table
+ * entries (PTE). Each entry is 4 bytes mapping a 4KB region. Each page,
+ * then, has 1024 entries mapping a 4MB region. Filling TLB entries is
+ * automatically done via hardware, as long as the PTE page associated
+ * with a particular address is also in TLB. If the PTE page is not in
+ * TLB, an exception will be raised that must be handled. This TLB miss
+ * is problematic when we are in the middle of dealing with another
+ * exception or handling an interrupt. So we need to put the PTE page
+ * into TLB by simply do a load operation.
+ *
+ * @param ADDR_REG Register containing the target address
+ * @param PTEVADDR_BASE_REG Register containing the PTEVADDR base
+ *
+ * @note Both the content of ADDR_REG will be modified.
+ *       Save and restore it around this macro usage.
+ */
+.macro PRELOAD_PTEVADDR ADDR_REG, PTEVADDR_BASE_REG
+	/*
+	 * Calculate the offset to first PTE page of all memory.
+	 *
+	 * Every page (4KB) of page table entries contains
+	 * 1024 entires (as each entry is 4 bytes). Each entry
+	 * maps one 4KB page. So one page of entries maps 4MB of
+	 * memory.
+	 *
+	 * 1. We need to find the virtual address of the PTE page
+	 *    having the page table entry mapping the address in
+	 *    register ADDR_REG. To do this, we first need to find
+	 *    the offset of this PTE page from the first PTE page
+	 *    (the one mapping memory 0x00000000):
+	 *    a. Find the beginning address of the 4KB page
+	 *       containing address in ADDR_REG. This can simply
+	 *       be done by discarding 11 bits (or shifting right
+	 *	 and then left 12 bits).
+	 *    b. Since each PTE page contains 1024 entries,
+	 *	 we divide the address obtained in step (a) by
+	 *       further dividing it by 1024 (shifting right and
+	 *       then left 10 bits) to obtain the offset of
+	 *       the PTE page.
+	 *
+	 *    Step (a) and (b) can be obtained together so that
+	 *    we can shift right 22 bits, and then shift left
+	 *    12 bits.
+	 *
+	 * 2. Once we have combine the results from step (1) and
+	 *    PTEVADDR_BASE_REG to get the virtual address of
+	 *    the PTE page.
+	 *
+	 * 3. Do a l32i to force the PTE page to be in TLB.
+	 */
+
+	/* Step 1 */
+	srli \ADDR_REG, \ADDR_REG, 22
+	slli \ADDR_REG, \ADDR_REG, 12
+
+	/* Step 2 */
+	add \ADDR_REG, \ADDR_REG, \PTEVADDR_BASE_REG
+
+	/* Step 3 */
+	l32i \ADDR_REG, \ADDR_REG, 0
+.endm
+#endif /* CONFIG_XTENSA_MMU */
+
 /*
  * CROSS_STACK_CALL
  *
@@ -302,7 +396,7 @@ _xstack_returned_\@:
  * that struct which contains an interrupt stack top and a "nest
  * count" word.
  */
-.macro EXCINT_HANDLER SR, NEST_OFF, INTSTACK_OFF
+.macro EXCINT_HANDLER NEST_OFF, INTSTACK_OFF
 	/* A2 contains our handler function which will get clobbered
 	 * by the save.  Stash it into the unused "a1" slot in the
 	 * BSA and recover it immediately after.  Kind of a hack.
@@ -347,7 +441,11 @@ _not_l1:
 	 * guaranteed unused across the call)
 	 */
 	rsil a0, 0xf
-	movi a3, ~(PS_EXCM_MASK)
+
+	/* Since we are unmasking EXCM, we need to set RING bits to kernel
+	 * mode, otherwise we won't be able to run the exception handler in C.
+	 */
+	movi a3, ~(PS_EXCM_MASK) & ~(PS_RING_MASK)
 	and a0, a0, a3
 	wsr.ZSR_EPS a0
 	wsr.PS a0
@@ -359,7 +457,7 @@ _not_l1:
 	 * entirely new area depending on whether we find a 1 in our
 	 * SR[off] macro argument.
 	 */
-	rsr.\SR a3
+	rsr.ZSR_CPU a3
 	l32i a0, a3, \NEST_OFF
 	beqz a0, _switch_stacks_\@
 
@@ -384,7 +482,7 @@ _do_call_\@:
 	rsil a0, XCHAL_NMILEVEL
 
 	/* Decrement nest count */
-	rsr.\SR a3
+	rsr.ZSR_CPU a3
 	l32i a0, a3, \NEST_OFF
 	addi a0, a0, -1
 	s32i a0, a3, \NEST_OFF
@@ -448,6 +546,40 @@ _Level\LVL\()VectorHelper :
 .global _Level\LVL\()Vector
 _Level\LVL\()Vector:
 #endif
+#ifdef CONFIG_XTENSA_MMU
+	wsr.ZSR_EXTRA0 a2
+	wsr.ZSR_EXTRA1 a3
+	rsync
+
+	/* Calculations below will clobber registers used.
+	 * So we make a copy of the stack pointer to avoid
+	 * changing it.
+	 */
+	mov a3, a1
+
+	CALC_PTEVADDR_BASE a2
+
+	/* Preload PTE entry page of current stack. */
+	PRELOAD_PTEVADDR a3, a2
+
+	/* Preload PTE entry page of VECBASE. This is due to
+	 * _handle_excint_imm* and _c_handler_imm* (below).
+	 * We cannot afford a TLB miss while already handling
+	 * an exception. So make sure the VECBASE page is
+	 * mapped in TLB.
+	 */
+	rsr.vecbase a2
+	PRELOAD_PTEVADDR a3, a2
+
+	/* Preload PTE entry page of new stack, where
+	 * it will be used later (in EXCINT_HANDLER above).
+	 */
+	rsr.ZSR_CPU a3
+	PRELOAD_PTEVADDR a3, a2
+
+	rsr.ZSR_EXTRA1 a3
+	rsr.ZSR_EXTRA0 a2
+#endif /* CONFIG_XTENSA_MMU */
 	addi a1, a1, -___xtensa_irq_bsa_t_SIZEOF
 	s32i a0, a1, ___xtensa_irq_bsa_t_a0_OFFSET
 	s32i a2, a1, ___xtensa_irq_bsa_t_a2_OFFSET
@@ -460,7 +592,18 @@ _Level\LVL\()Vector:
 	 */
 .if \LVL == 1
 	rsr.PS a0
+#ifdef CONFIG_XTENSA_MMU
+	/* TLB misses also come through level 1 interrupts.
+	 * We do not want to unconditionally unmask interrupts.
+	 * Execution continues after a TLB miss is handled,
+	 * and we need to preserve the interrupt mask.
+	 * The interrupt mask will be cleared for non-TLB-misses
+	 * level 1 interrupt later in the handler code.
+	 */
+	movi a2, ~PS_EXCM_MASK
+#else
 	movi a2, ~(PS_EXCM_MASK | PS_INTLEVEL_MASK)
+#endif
 	and a0, a0, a2
 	s32i a0, a1, ___xtensa_irq_bsa_t_ps_OFFSET
 .else

--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -30,6 +30,8 @@
 #include <zephyr/arch/xtensa/gdbstub.h>
 #include <zephyr/debug/sparse.h>
 
+#include <zephyr/arch/xtensa/xtensa_mmu.h>
+
 #ifdef CONFIG_KERNEL_COHERENCE
 #define ARCH_STACK_PTR_ALIGN XCHAL_DCACHE_LINESIZE
 #else

--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -104,6 +104,20 @@ static inline bool arch_mem_coherent(void *ptr)
 }
 #endif
 
+static inline bool arch_xtensa_is_ptr_cached(void *ptr)
+{
+	size_t addr = (size_t) ptr;
+
+	return (addr >> 29) == CONFIG_XTENSA_CACHED_REGION;
+}
+
+static inline bool arch_xtensa_is_ptr_uncached(void *ptr)
+{
+	size_t addr = (size_t) ptr;
+
+	return (addr >> 29) == CONFIG_XTENSA_UNCACHED_REGION;
+}
+
 static ALWAYS_INLINE uint32_t z_xtrpoflip(uint32_t addr, uint32_t rto, uint32_t rfrom)
 {
 	/* The math here is all compile-time: when the two regions

--- a/include/zephyr/arch/xtensa/xtensa_mmu.h
+++ b/include/zephyr/arch/xtensa/xtensa_mmu.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_XTENSA_MMU_H
+#define ZEPHYR_INCLUDE_ARCH_XTENSA_XTENSA_MMU_H
+
+#define Z_XTENSA_MMU_X  BIT(0)
+#define Z_XTENSA_MMU_W  BIT(1)
+#define Z_XTENSA_MMU_CACHED_WB BIT(2)
+#define Z_XTENSA_MMU_CACHED_WT BIT(3)
+#define Z_XTENSA_MMU_ILLEGAL (BIT(3) | BIT(2))
+
+/* Struct used to map a memory region */
+struct xtensa_mmu_range {
+	const char *name;
+	const uint32_t start;
+	const uint32_t end;
+	const uint32_t attrs;
+};
+
+extern const struct xtensa_mmu_range xtensa_soc_mmu_ranges[];
+extern int xtensa_soc_mmu_ranges_num;
+
+void z_xtensa_mmu_init(void);
+
+void z_xtensa_mmu_smp_init(void);
+
+#endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_XTENSA_MMU_H */

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -114,7 +114,14 @@ struct z_page_frame {
 	 * flags bits which shouldn't clobber each other. At all costs
 	 * the total size of struct z_page_frame must be minimized.
 	 */
+
+	/* On Xtensa we can't pack this struct because of the memory alignment.
+	 */
+#ifdef CONFIG_XTENSA
+} __aligned(4);
+#else
 } __packed;
+#endif
 
 static inline bool z_page_frame_is_pinned(struct z_page_frame *pf)
 {


### PR DESCRIPTION
Initial support for xtensa mmu version 3.

There is not support for userspace yet. The current implementation allows to run from a minimal page table instead of having the whole memory space mapped in way 6 on TLB. Also it allows to map/unmap  arbitrary memory using Zephyr APIs. This enable everything needed to run tests/kernel/mem_protect/protection/.

For more detailed information please look each commit message individually.