### PR TITLE
soc: xtensa: nxp: invoke `west sign` at `west build` time

### DIFF
--- a/soc/xtensa/nxp_adsp/CMakeLists.txt
+++ b/soc/xtensa/nxp_adsp/CMakeLists.txt
@@ -4,3 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
+
+#  west sign
+
+# See detailed comments in soc/xtensa/intel_adsp/common/CMakeLists.txt
+add_custom_target(zephyr.ri ALL
+  DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
+)
+
+add_custom_command(
+  OUTPUT ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
+  COMMENT "west sign --if-tool-available --tool rimage ..."
+  COMMAND  west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR}
+  DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf
+)


### PR DESCRIPTION
This aligns `soc/xtensa/nxp_adsp/` with commit
fad2da39aaaf ("intel_adsp: move `west sign` from `west flash` to earlier `west build`")

The --if-tool-available option preserves backwards-compatibility: nothing happens if rimage is not found.