### PR TITLE
net: net_pkt: Fix cpp compatibility

### DIFF
--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -320,7 +320,7 @@ static inline void net_pkt_set_iface(struct net_pkt *pkt, struct net_if *iface)
 	 * that the address type is properly set and is not forgotten.
 	 */
 	if (iface) {
-		enum net_link_type type = net_if_get_link_addr(iface)->type;
+		uint8_t type = net_if_get_link_addr(iface)->type;
 
 		pkt->lladdr_src.type = type;
 		pkt->lladdr_dst.type = type;


### PR DESCRIPTION
Assignment uint8_t to enum without casting, makes error in cpp compiler.

```
In file included from /media/code/zephyr/samples/cpp/cpp_synchronization/src/main.cpp:25:
/media/code/zephyr/include/zephyr/net/net_pkt.h: In function 'void net_pkt_set_iface(net_pkt*, net_if*)':
/media/code/zephyr/include/zephyr/net/net_pkt.h:323:72: error: invalid conversion from 'uint8_t' {aka 'unsigned char'} to 'net_link_type' [-fpermissive]
  323 |                 enum net_link_type type = net_if_get_link_addr(iface)->type;
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
      |                                                                        |
      |                                                                        uint8_t {aka unsigned char}
ninja: build stopped: subcommand failed.
```