### PR TITLE
mcumgr: Mark as stable API

### DIFF
--- a/doc/develop/api/overview.rst
+++ b/doc/develop/api/overview.rst
@@ -189,6 +189,10 @@ between major releases are available in the :ref:`zephyr_release_notes`.
      - Experimental
      - 1.0
 
+   * - :ref:`mcu_mgr`
+     - Stable
+     - 1.11
+
    * - :ref:`mqtt_socket_interface`
      - Unstable
      - 1.14

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -548,6 +548,8 @@ Libraries / Subsystems
     :ref:`MCUmgr SMP protocol specification <mcumgr_smp_protocol_specification>`
     for details.
 
+  * MCUmgr has now been marked as a stable Zephyr API.
+
 * Retention
 
   * Retention subsystem has been added which adds enhanced features over


### PR DESCRIPTION
    doc: release: 3.4: Add note on MCUmgr being marked as stable API
    
    Adds a note that MCUmgr is now a stable API.

    doc: api: Add MCUmgr as stable API
    
    Adds MCUmgr as a stable API.

Fixes #54480