### PR TITLE
Board: nsim_hs: fix nsim dccm size property

### DIFF
--- a/boards/arc/nsim/support/nsim_hs.props
+++ b/boards/arc/nsim/support/nsim_hs.props
@@ -38,7 +38,7 @@
 	nsim_isa_dc_mem_cycles=2
 	icache=65536,64,4,a
 	nsim_isa_ic_feature_level=2
-	dccm_size=0x40000
+	dccm_size=0x100000
 	dccm_base=0x80000000
 	nsim_isa_dccm_mem_cycles=2
 	iccm0_size=0x40000

--- a/boards/arc/nsim/support/nsim_hs3x_hostlink.props
+++ b/boards/arc/nsim/support/nsim_hs3x_hostlink.props
@@ -38,7 +38,7 @@
 	nsim_isa_dc_mem_cycles=2
 	icache=65536,64,4,a
 	nsim_isa_ic_feature_level=2
-	dccm_size=0x40000
+	dccm_size=0x100000
 	dccm_base=0x80000000
 	nsim_isa_dccm_mem_cycles=2
 	iccm0_size=0x40000

--- a/boards/arc/nsim/support/nsim_hs_mpuv6.props
+++ b/boards/arc/nsim/support/nsim_hs_mpuv6.props
@@ -40,7 +40,7 @@
 	nsim_isa_dc_mem_cycles=2
 	icache=65536,64,4,a
 	nsim_isa_ic_feature_level=2
-	dccm_size=0x40000
+	dccm_size=0x100000
 	dccm_base=0x80000000
 	nsim_isa_dccm_mem_cycles=2
 	iccm0_size=0x40000


### PR DESCRIPTION
Actual DCCM size is 100000 in nsim_hs_mpuv6, nsim_hs and nsim_hs3x_hostlink, but their nsim property is
40000. Now fixed the difference to avoid data access to unpopulated region.

Fixes #57924
