### PR TITLE
driver: uart: pl011: imporve pl011 driver

### DIFF
--- a/drivers/serial/Kconfig.pl011
+++ b/drivers/serial/Kconfig.pl011
@@ -4,7 +4,7 @@
 menuconfig UART_PL011
 	bool "ARM PL011 UART Driver"
 	default y
-	depends on DT_HAS_ARM_PL011_ENABLED
+	depends on DT_HAS_ARM_PL011_ENABLED || DT_HAS_ARM_SBSA_UART_ENABLED
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	help
@@ -14,6 +14,7 @@ if UART_PL011
 
 config UART_PL011_SBSA
 	bool "SBSA UART"
+	default y if DT_HAS_ARM_SBSA_UART_ENABLED
 	help
 	  Enable SBSA mode for PL011 driver. SBSA stands for
 	  Server Based System Architecture. This specification


### PR DESCRIPTION
Improve the uart pl011 driver.

- refine pl011_sbsa driver.
- fix pl011 interrupt driven API.
  - `pl011_irq_tx_enable` expects to enable and trigger TX interrupt.
    Due to HW limitation, PL011 won't trigger TX interrupt if some data
    wasn't filled to TX FIFO at the beginning. So that `isr_cb` must be
    called at the first time to enable TX irq.
    
   - `pl011_irq_tx_ready` will return true when FIFO can accept more
     data.
    
   - `pl011_irq_tx_complete` will return true when all data have been
     sent from the shift register.