### PR TITLE
tests: drivers: uart async testing on the stm32f103 nucleo

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/nucleo_f103rb.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_f103rb.overlay
@@ -1,8 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+/* Connect pin (PA10) D2 of the CN9:2 to D8 (PA9) of the CN5:1 */
 dut: &usart1 {
-	dmas = <&dma1 4 STM32_DMA_PERIPH_TX>,
-	       <&dma1 5 STM32_DMA_PERIPH_RX>;
+	dmas = <&dma1 4 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dma1 5 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
 	dma-names = "tx", "rx";
 };
 


### PR DESCRIPTION
Configure the overlay to have DMA transfer with high priority when running the tests/drivers/uart/uart_async_api on nucleo_f103rb.

On the stm32f103rb board, Connect the D2 to D8 of the Arduino connectors to PASS the test.
`$ west build -p auto -b nucleo_f103rb tests/drivers/uart/uart_async_api`

Else the test fails:
```
Running TESTSUITE uart_async_write_abort                                                                                                                                                                
===================================================================                                                                                                                                     
START - test_write_abort                                                                                                                                                                                
                                                                                                                                                                                                        
    Assertion failed at WEST_TOPDIR/zephyr/tests/drivers/uart/uart_async_api/src/test_uart_async.c:526: uart_async_write_abort_test_write_abort: (sent not equal to received)                           
Sent is not equal to received.                                                                                                                                                                          
 FAIL - test_write_abort in 0.120 seconds  
```                                                                                                                                                             


Signed-off-by: Francois Ramu <francois.ramu@st.com>