### PR TITLE
boards: arm: stm32l562 disco kit console clocked by HSI

### DIFF
--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -53,6 +53,10 @@
 	status = "okay";
 };
 
+&clk_hsi {
+	status = "okay";
+};
+
 &pll {
 	div-m = <1>;
 	mul-n = <55>;
@@ -78,6 +82,9 @@
 };
 
 &usart1 {
+	/* HSI clock is stable before PCLK2 for usart1 console output */
+	clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>,
+		<&rcc STM32_SRC_HSI USART1_SEL(2)>;
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pa10>;
 	pinctrl-names = "default";


### PR DESCRIPTION
Configure the usart1 for the zephyr console so that the clock source is HSI instead of (default PCLK2). HSI oscillator is stable before the PCLK2. The first char is sent faster to the console output.

With usart1-console clocked by the (default) PCLK2, it can happen that some twister results fail due to missing char.
Example samples/subsys/zbus/hello_world output log is :
```
Sensor sample started raw reading, version 0.1-2!
I: Channel list:
I: 0 - Channel acc_data_chan:
I:       Message size: 12
I:       Observers:
...
```

when expecting (sample.yaml)
```
I: Sensor sample started raw reading, version 0.1-2!
I: Channel list:
I: 0 - Channel acc_data_chan:
I:       Message size: 12
I:       Observers:
...
```
--> first char is missing

With USART1 (console) clocked by HSI, the output log is complete.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55679


Signed-off-by: Francois Ramu <francois.ramu@st.com>
