### PR TITLE
doc: Various Doxygen fixes (legit warnings not surfacing w/ latest Doxygen)

### DIFF
--- a/include/zephyr/drivers/misc/pio_rpi_pico/pio_rpi_pico.h
+++ b/include/zephyr/drivers/misc/pio_rpi_pico/pio_rpi_pico.h
@@ -122,7 +122,8 @@
 /**
  * @brief Get the pin number of a pin by its name.
  *
- * @param name Name of the pin (e.g. tx, rx, sck).
+ * @param inst instance number
+ * @param name name of the pin (e.g. tx, rx, sck).
  */
 #define DT_INST_PIO_PIN_BY_NAME(inst, name) \
 	DT_PIO_PIN_BY_NAME(DT_DRV_INST(inst), name)

--- a/include/zephyr/dt-bindings/clock/stm32f1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f1_clock.h
@@ -24,6 +24,16 @@
 /** System clock */
 #define STM32_SRC_SYSCLK	0x005
 
+
+#define STM32_CLOCK_REG_MASK    0xFFU
+#define STM32_CLOCK_REG_SHIFT   0U
+#define STM32_CLOCK_SHIFT_MASK  0x1FU
+#define STM32_CLOCK_SHIFT_SHIFT 8U
+#define STM32_CLOCK_MASK_MASK   0x7U
+#define STM32_CLOCK_MASK_SHIFT  13U
+#define STM32_CLOCK_VAL_MASK    0x7U
+#define STM32_CLOCK_VAL_SHIFT   16U
+
 /**
  * @brief STM32 clock configuration bit field.
  *
@@ -37,16 +47,6 @@
  * @param mask Mask for the RCC_CFGRx field.
  * @param val Clock value (0, 1, ... 7).
  */
-
-#define STM32_CLOCK_REG_MASK    0xFFU
-#define STM32_CLOCK_REG_SHIFT   0U
-#define STM32_CLOCK_SHIFT_MASK  0x1FU
-#define STM32_CLOCK_SHIFT_SHIFT 8U
-#define STM32_CLOCK_MASK_MASK   0x7U
-#define STM32_CLOCK_MASK_SHIFT  13U
-#define STM32_CLOCK_VAL_MASK    0x7U
-#define STM32_CLOCK_VAL_SHIFT   16U
-
 #define STM32_CLOCK(val, mask, shift, reg)					\
 	((((reg) & STM32_CLOCK_REG_MASK) << STM32_CLOCK_REG_SHIFT) |		\
 	 (((shift) & STM32_CLOCK_SHIFT_MASK) << STM32_CLOCK_SHIFT_SHIFT) |	\

--- a/include/zephyr/dt-bindings/clock/stm32f4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f4_clock.h
@@ -36,6 +36,16 @@
 /* I2S_CKIN not supported yet */
 /* #define STM32_SRC_I2S_CKIN	0x008 */
 
+
+#define STM32_CLOCK_REG_MASK    0xFFU
+#define STM32_CLOCK_REG_SHIFT   0U
+#define STM32_CLOCK_SHIFT_MASK  0x1FU
+#define STM32_CLOCK_SHIFT_SHIFT 8U
+#define STM32_CLOCK_MASK_MASK   0x7U
+#define STM32_CLOCK_MASK_SHIFT  13U
+#define STM32_CLOCK_VAL_MASK    0x7U
+#define STM32_CLOCK_VAL_SHIFT   16U
+
 /**
  * @brief STM32 clock configuration bit field.
  *
@@ -49,16 +59,6 @@
  * @param mask Mask for the RCC_CFGRx field.
  * @param val Clock value (0, 1, ... 7).
  */
-
-#define STM32_CLOCK_REG_MASK    0xFFU
-#define STM32_CLOCK_REG_SHIFT   0U
-#define STM32_CLOCK_SHIFT_MASK  0x1FU
-#define STM32_CLOCK_SHIFT_SHIFT 8U
-#define STM32_CLOCK_MASK_MASK   0x7U
-#define STM32_CLOCK_MASK_SHIFT  13U
-#define STM32_CLOCK_VAL_MASK    0x7U
-#define STM32_CLOCK_VAL_SHIFT   16U
-
 #define STM32_CLOCK(val, mask, shift, reg)					\
 	((((reg) & STM32_CLOCK_REG_MASK) << STM32_CLOCK_REG_SHIFT) |		\
 	 (((shift) & STM32_CLOCK_SHIFT_MASK) << STM32_CLOCK_SHIFT_SHIFT) |	\

--- a/include/zephyr/dt-bindings/clock/stm32f7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f7_clock.h
@@ -35,6 +35,16 @@
 /** Peripheral bus clock */
 #define STM32_SRC_PCLK	0x007
 
+
+#define STM32_CLOCK_REG_MASK    0xFFU
+#define STM32_CLOCK_REG_SHIFT   0U
+#define STM32_CLOCK_SHIFT_MASK  0x1FU
+#define STM32_CLOCK_SHIFT_SHIFT 8U
+#define STM32_CLOCK_MASK_MASK   0x7U
+#define STM32_CLOCK_MASK_SHIFT  13U
+#define STM32_CLOCK_VAL_MASK    0x7U
+#define STM32_CLOCK_VAL_SHIFT   16U
+
 /**
  * @brief STM32 clock configuration bit field.
  *
@@ -48,16 +58,6 @@
  * @param mask Mask for the RCC_CFGRx field.
  * @param val Clock value (0, 1, ... 7).
  */
-
-#define STM32_CLOCK_REG_MASK    0xFFU
-#define STM32_CLOCK_REG_SHIFT   0U
-#define STM32_CLOCK_SHIFT_MASK  0x1FU
-#define STM32_CLOCK_SHIFT_SHIFT 8U
-#define STM32_CLOCK_MASK_MASK   0x7U
-#define STM32_CLOCK_MASK_SHIFT  13U
-#define STM32_CLOCK_VAL_MASK    0x7U
-#define STM32_CLOCK_VAL_SHIFT   16U
-
 #define STM32_CLOCK(val, mask, shift, reg)					\
 	((((reg) & STM32_CLOCK_REG_MASK) << STM32_CLOCK_REG_SHIFT) |		\
 	 (((shift) & STM32_CLOCK_SHIFT_MASK) << STM32_CLOCK_SHIFT_SHIFT) |	\

--- a/include/zephyr/dt-bindings/pinctrl/numicro-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/numicro-pinctrl.h
@@ -7,6 +7,13 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_NUMICRO_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_NUMICRO_PINCTRL_H_
 
+#define NUMICRO_MFP_SHIFT 0U
+#define NUMICRO_MFP_MASK  0xFU
+#define NUMICRO_PIN_SHIFT 4U
+#define NUMICRO_PIN_MASK  0xFU
+#define NUMICRO_PORT_SHIFT 8U
+#define NUMICRO_PORT_MASK  0xFU
+
 /**
  * @brief Pin configuration configuration bit field.
  *
@@ -20,13 +27,6 @@
  * @param pin  Pin (0..15)
  * @param mfp  Multi-function value (0..15)
  */
-#define NUMICRO_MFP_SHIFT 0U
-#define NUMICRO_MFP_MASK  0xFU
-#define NUMICRO_PIN_SHIFT 4U
-#define NUMICRO_PIN_MASK  0xFU
-#define NUMICRO_PORT_SHIFT 8U
-#define NUMICRO_PORT_MASK  0xFU
-
 #define NUMICRO_PINMUX(port, pin, mfp)					\
 	(((((port) - 'A') & NUMICRO_PORT_MASK) << NUMICRO_PORT_SHIFT) |	\
 	(((pin) & NUMICRO_PIN_MASK) << NUMICRO_PIN_SHIFT) |		\

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -538,9 +538,7 @@ char *utf8_lcpy(char *dst, const char *src, size_t n);
  * @note This macro expands its argument multiple times (to permit use
  *       in constant expressions), which must not have side effects.
  *
- * @param x An unsigned integral value
- *
- * @param x value to compute logarithm of (positive only)
+ * @param x An unsigned integral value to compute logarithm of (positive only)
  *
  * @return log2(x) when 1 <= x <= max(x), -1 when x < 1
  */


### PR DESCRIPTION
Doxygen 1.9.6 seems to not output warnings for some actual problems. 
Using 1.9.4/1.9.5 version of the tool, I was able to flag a few errors in files that were touched/created since we're on 1.9.6

- doc: fix STM32_CLOCK bit field documentation
- doc: add missing param in DT_INST_PIO_PIN_BY_NAME
- doc: fix Doxygen doc for LOG2(x)
- doc: fix NUMICRO_PINMUX bit field documentation

another fix is addressed through: https://github.com/zephyrproject-rtos/zephyr/pull/57928
