### PR TITLE
Use correct CHECKIF macro instead of CHECK

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -448,23 +448,23 @@ config MISRA_SANE
 endmenu
 
 choice
-	prompt "Error checking behavior for CHECK macro"
+	prompt "Error checking behavior for CHECKIF macro"
 	default RUNTIME_ERROR_CHECKS
 
 config ASSERT_ON_ERRORS
 	bool "Assert on all errors"
 	help
-	  Assert on errors covered with the CHECK macro.
+	  Assert on errors covered with the CHECKIF macro.
 
 config NO_RUNTIME_CHECKS
 	bool "No runtime error checks"
 	help
-	  Do not do any runtime checks or asserts when using the CHECK macro.
+	  Do not do any runtime checks or asserts when using the CHECKIF macro.
 
 config RUNTIME_ERROR_CHECKS
 	bool "Runtime error checks"
 	help
-	  Always perform runtime checks covered with the CHECK macro. This
+	  Always perform runtime checks covered with the CHECKIF macro. This
 	  option is the default and the only option used during testing.
 
 endchoice


### PR DESCRIPTION
Referencing the non-existent CHECK macro, was confusing, since the Kconfig values are used for the CHECKIF macro in zephyr/sys/check.h.