### PR TITLE
soc: smartbond: Global Foundries support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: f2d791d28cd8fdbc5861652b863822632c91f690
+      revision: 346e87d5425f3a12ec8aed87cfc14d949d5ce8c7
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Add the min. SoC changes to support the GF silicon variant. 