### PR TITLE
doc: security: Refresh hardening tool doc page

### DIFF
--- a/doc/security/hardening-tool.rst
+++ b/doc/security/hardening-tool.rst
@@ -3,42 +3,46 @@
 Hardening Tool
 ##############
 
-Zephyr contains several optional features that make the overall system
-more secure. As we take advantage of hardware features, many of these
-options are platform specific and besides it, some of them are unknown
-by developers.
+Before launching a product, it's crucial to ensure that your software is as secure as possible. This
+process, known as "hardening", involves strengthening the security of a system to protect it from
+potential threats and vulnerabilities.
 
-To address this problem, Zephyr provides a tool that helps to check an
-application configuration option list against a list of hardening
-preferences defined by the **Security Group**. The tool can identify the build
-target and based on that provides suggestions and recommendations on how to
-optimize the configuration for security.
+At a high-level, hardening a Zephyr application can be seen as a two-fold process:
+
+#. Disabling features and compilation flags that might lead to security vulnerabilities (ex. making
+   sure that no "experimental" features are being used, disabling features typically used for
+   debugging purposes such as assertions, shell, etc.).
+#. Enabling optional features that can lead to improve security (ex. stack sentinel, hardware stack
+   protection, etc.). Some of these features might be hardware-dependent.
+
+To simplify this process, Zephyr offers a **hardening tool** designed to analyze an application's
+configuration against a set of hardening preferences defined by the **Security Working Group**. The
+tool looks at the KConfig options in the build target and provides tailored suggestions and
+recommendations to adjust security-related options.
 
 Usage
 *****
 
-After configure of your application, change directory to the build folder and:
+.. zephyr-app-commands::
+    :tool: all
+    :app: samples/hello_world
+    :board: reel_board
+    :goals: hardenconfig
+
+The output should be similar to the table below. For each configuration option set to a value that
+could lead to a security vulnerability, the table will propose a recommended value that should be
+used instead.
 
 .. code-block:: console
 
-   # ninja build system:
-   $ ninja hardenconfig
-   # make build system:
-   $ make hardenconfig
-
-The output should be similar to the one bellow:
-
-.. code-block:: console
-
-
-                          name                       |   current   |    recommended     ||        check result
-   ===================================================================================================================
-   CONFIG_HW_STACK_PROTECTION                        |      n      |         y          ||            FAIL
-   CONFIG_BOOT_BANNER                                |      y      |         n          ||            FAIL
-   CONFIG_PRINTK                                     |      y      |         n          ||            FAIL
-   CONFIG_EARLY_CONSOLE                              |      y      |         n          ||            FAIL
-   CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT             |      n      |         y          ||            FAIL
-   CONFIG_DEBUG_INFO                                 |      y      |         n          ||            FAIL
-   CONFIG_TEST_RANDOM_GENERATOR                      |      y      |         n          ||            FAIL
-   CONFIG_BUILD_OUTPUT_STRIPPED                      |      n      |         y          ||            FAIL
-   CONFIG_STACK_SENTINEL                             |      n      |         y          ||            FAIL
+                  name                       |   current   |  recommended   ||    check result
+   ================================================================================================
+   CONFIG_BOOT_BANNER                        |      y      |       n        ||       FAIL
+   CONFIG_BUILD_OUTPUT_STRIPPED              |      n      |       y        ||       FAIL
+   CONFIG_FAULT_DUMP                         |      2      |       0        ||       FAIL
+   CONFIG_HW_STACK_PROTECTION                |      n      |       y        ||       FAIL
+   CONFIG_MPU_STACK_GUARD                    |      n      |       y        ||       FAIL
+   CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT     |      n      |       y        ||       FAIL
+   CONFIG_STACK_SENTINEL                     |      n      |       y        ||       FAIL
+   CONFIG_EARLY_CONSOLE                      |      y      |       n        ||       FAIL
+   CONFIG_PRINTK                             |      y      |       n        ||       FAIL


### PR DESCRIPTION
Improved the wording of the Hardening tool documentation to better reflect that it provides suggestions for both options that could be enabled for improved security, as well as options that should be disabled for they may expose to vulnerabilities. 
Also fixed the "Usage" section which was stale.

DIRECT LINK TO NEW HTML PAGE: https://builds.zephyrproject.io/zephyr/pr/57958/docs/security/hardening-tool.html
