### PR TITLE
ci: do_not_merge: check for TSC tag as well

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -6,12 +6,13 @@ on:
 
 jobs:
   do-not-merge:
-    if: ${{ contains(github.event.*.labels.*.name, 'DNM') }}
+    if: ${{ contains(github.event.*.labels.*.name, 'DNM') ||
+            contains(github.event.*.labels.*.name, 'TSC') }}
     name: Prevent Merging
     runs-on: ubuntu-22.04
     steps:
       - name: Check for label
         run: |
-          echo "Pull request is labeled as 'DNM'"
+          echo "Pull request is labeled as 'DNM' or 'TSC'"
           echo "This workflow fails so that the pull request cannot be merged"
           exit 1


### PR DESCRIPTION
Check for TSC tag in addition to the DNM one, so that PR scheduled for TSC discussion can't be merged by mistake.