### PR TITLE
intel_adsp: ace: Fix heap in the linker

### DIFF
--- a/soc/xtensa/intel_adsp/ace/ace-link.ld
+++ b/soc/xtensa/intel_adsp/ace/ace-link.ld
@@ -395,7 +395,6 @@ SECTIONS {
   {
     _heap_start = .;
     *(.heap_mem)
-    _heap_end = .;
   } >ucram
 
   .unused_ram_start_marker SEGSTART_CACHED (NOLOAD) :
@@ -408,6 +407,7 @@ SECTIONS {
 
   . = L2_SRAM_BASE + L2_SRAM_SIZE;
   . = SEGSTART_UNCACHED;
+  _heap_end = .;
   _heap_sentry = .;
 
   /* dma buffers */


### PR DESCRIPTION
The end of the heap should be the same as _heap_sentry. The current end marker just covers the range of memory that is explictely put in .heap_memand not account until the end of L2_SRAM_BASE + L2_SRAM_SIZE memory.