### PR TITLE
Bluetooth: Controller: Use NRF_CCM HEADERMASK for ISO PDU encryption 

### DIFF
--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -245,6 +245,7 @@
 			reg = <0x4000f000 0x1000>;
 			interrupts = <15 NRF_DEFAULT_IRQ_PRIORITY>;
 			length-field-length-8-bits;
+			headermask-supported;
 			status = "okay";
 		};
 

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -265,6 +265,7 @@
 			reg = <0x4000f000 0x1000>;
 			interrupts = <15 NRF_DEFAULT_IRQ_PRIORITY>;
 			length-field-length-8-bits;
+			headermask-supported;
 			status = "okay";
 		};
 

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -144,6 +144,7 @@
 			reg = <0x4100e000 0x1000>;
 			interrupts = <14 NRF_DEFAULT_IRQ_PRIORITY>;
 			length-field-length-8-bits;
+			headermask-supported;
 			status = "okay";
 		};
 

--- a/dts/bindings/crypto/nordic,nrf-ccm.yaml
+++ b/dts/bindings/crypto/nordic,nrf-ccm.yaml
@@ -20,3 +20,10 @@ properties:
       Indicates whether the CCM peripheral supports the extended length
       (8 bits) of the LENGTH field in encrypted/decrypted packets.
       If not set, only the default length (5 bits) is supported.
+
+  headermask-supported:
+    type: boolean
+    description: |
+      Indicates whether the CCM peripheral supports the headermask register to
+      set the PDU header bitmask used to derive the additional authentication
+      data (AAD) in CCM for Bluetooth Low Energy ACL, BIS and CIS PDUs.

--- a/soc/arm/nordic_nrf/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/Kconfig.peripherals
@@ -24,6 +24,9 @@ config HAS_HW_NRF_CCM
 config HAS_HW_NRF_CCM_LFLEN_8BIT
 	def_bool $(dt_nodelabel_bool_prop,ccm,length-field-length-8-bits)
 
+config HAS_HW_NRF_CCM_HEADERMASK
+	def_bool $(dt_nodelabel_bool_prop,ccm,headermask-supported)
+
 config HAS_HW_NRF_CLOCK
 	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_CLOCK))
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -6,25 +6,25 @@
  */
 
 /* Set of macros related with Radio packet configuration flags */
-/* PDU type, 1 bit field*/
+/* PDU type, 2 bit field*/
 #define RADIO_PKT_CONF_PDU_TYPE_POS (0U)
-#define RADIO_PKT_CONF_PDU_TYPE_MSK BIT(RADIO_PKT_CONF_PDU_TYPE_POS)
+#define RADIO_PKT_CONF_PDU_TYPE_MSK (BIT_MASK(2U))
 #define RADIO_PKT_CONF_PDU_TYPE_AC  (0U)
 #define RADIO_PKT_CONF_PDU_TYPE_DC  (1U)
-#define RADIO_PKT_CONF_PDU_TYPE_BIS (1U)
-#define RADIO_PKT_CONF_PDU_TYPE_CIS (1U)
+#define RADIO_PKT_CONF_PDU_TYPE_BIS (2U)
+#define RADIO_PKT_CONF_PDU_TYPE_CIS (3U)
 /* PHY type, three bit field */
-#define RADIO_PKT_CONF_PHY_POS (1U)
-#define RADIO_PKT_CONF_PHY_MSK (BIT_MASK(3U))
-#define RADIO_PKT_CONF_PHY_LEGACY (0U)
-#define RADIO_PKT_CONF_PHY_1M (BIT(0U))
-#define RADIO_PKT_CONF_PHY_2M (BIT(1U))
-#define RADIO_PKT_CONF_PHY_CODED (BIT(2U))
+#define RADIO_PKT_CONF_PHY_POS      (2U)
+#define RADIO_PKT_CONF_PHY_MSK      (BIT_MASK(3U))
+#define RADIO_PKT_CONF_PHY_LEGACY   (0U)
+#define RADIO_PKT_CONF_PHY_1M       (BIT(0U))
+#define RADIO_PKT_CONF_PHY_2M       (BIT(1U))
+#define RADIO_PKT_CONF_PHY_CODED    (BIT(2U))
 /* CTE enabled, 1 bit field */
-#define RADIO_PKT_CONF_CTE_POS (4U)
-#define RADIO_PKT_CONF_CTE_MSK BIT(0)
+#define RADIO_PKT_CONF_CTE_POS      (5U)
+#define RADIO_PKT_CONF_CTE_MSK      (BIT_MASK(1U))
 #define RADIO_PKT_CONF_CTE_DISABLED (0U)
-#define RADIO_PKT_CONF_CTE_ENABLED (1U)
+#define RADIO_PKT_CONF_CTE_ENABLED  (1U)
 
 /* Macro to define length of the BLE packet length field in bits */
 #define RADIO_PKT_CONF_LENGTH_8BIT (8U)
@@ -164,7 +164,9 @@ void radio_gpio_pa_lna_enable(uint32_t trx_us);
 void radio_gpio_pa_lna_disable(void);
 
 void *radio_ccm_rx_pkt_set(struct ccm *ccm, uint8_t phy, void *pkt);
+void *radio_ccm_iso_rx_pkt_set(struct ccm *ccm, uint8_t phy, uint8_t pdu_type, void *pkt);
 void *radio_ccm_tx_pkt_set(struct ccm *ccm, void *pkt);
+void *radio_ccm_iso_tx_pkt_set(struct ccm *ccm, uint8_t pdu_type, void *pkt);
 uint32_t radio_ccm_is_done(void);
 uint32_t radio_ccm_mic_is_valid(void);
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -361,7 +361,9 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
 				    (lll->max_pdu + PDU_MIC_SIZE), pkt_flags);
-		radio_pkt_tx_set(radio_ccm_tx_pkt_set(&lll->ccm_tx, pdu));
+		radio_pkt_tx_set(radio_ccm_iso_tx_pkt_set(&lll->ccm_tx,
+						RADIO_PKT_CONF_PDU_TYPE_BIS,
+						pdu));
 	} else {
 		uint8_t pkt_flags;
 
@@ -691,7 +693,9 @@ static void isr_tx_common(void *param,
 		(void)memcpy(lll->ccm_tx.iv, lll->giv, 4U);
 		mem_xor_32(lll->ccm_tx.iv, lll->ccm_tx.iv, access_addr);
 
-		radio_pkt_tx_set(radio_ccm_tx_pkt_set(&lll->ccm_tx, pdu));
+		radio_pkt_tx_set(radio_ccm_iso_tx_pkt_set(&lll->ccm_tx,
+						RADIO_PKT_CONF_PDU_TYPE_BIS,
+						pdu));
 	} else {
 		radio_pkt_tx_set(pdu);
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -312,20 +312,21 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 		cis_lll->tx.ccm.counter = payload_count;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
 				    (cis_lll->tx.max_pdu + PDU_MIC_SIZE),
 				    pkt_flags);
-		radio_pkt_tx_set(radio_ccm_tx_pkt_set(&cis_lll->tx.ccm,
+		radio_pkt_tx_set(radio_ccm_iso_tx_pkt_set(&cis_lll->tx.ccm,
+						      RADIO_PKT_CONF_PDU_TYPE_CIS,
 						      pdu_tx));
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	} else {
 		uint8_t pkt_flags;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
@@ -506,23 +507,25 @@ static void isr_tx(void *param)
 
 		payload_count = (cis_lll->event_count * cis_lll->rx.bn) +
 				(cis_lll->rx.bn_curr - 1U);
+
 		cis_lll->rx.ccm.counter = payload_count;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 cis_lll->rx.phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
 				    (cis_lll->rx.max_pdu + PDU_MIC_SIZE),
 				    pkt_flags);
-		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&cis_lll->rx.ccm,
-						      cis_lll->rx.phy,
-						      node_rx->pdu));
+		radio_pkt_rx_set(radio_ccm_iso_rx_pkt_set(&cis_lll->rx.ccm,
+							  cis_lll->rx.phy,
+							  RADIO_PKT_CONF_PDU_TYPE_CIS,
+							  node_rx->pdu));
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	} else {
 		uint8_t pkt_flags;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 cis_lll->rx.phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
@@ -1093,19 +1096,20 @@ static void isr_prepare_subevent(void *param)
 
 		cis_lll->tx.ccm.counter = payload_count;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 cis_lll->tx.phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
 				    (cis_lll->tx.max_pdu + PDU_MIC_SIZE), pkt_flags);
-		radio_pkt_tx_set(radio_ccm_tx_pkt_set(&cis_lll->tx.ccm,
+		radio_pkt_tx_set(radio_ccm_iso_tx_pkt_set(&cis_lll->tx.ccm,
+						      RADIO_PKT_CONF_PDU_TYPE_CIS,
 						      pdu_tx));
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	} else {
 		uint8_t pkt_flags;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 cis_lll->tx.phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -264,20 +264,21 @@ static int prepare_cb(struct lll_prepare_param *p)
 			      (cis_lll->rx.bn_curr - 1U);
 		cis_lll->rx.ccm.counter = payload_cnt;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
 				    (cis_lll->rx.max_pdu + PDU_MIC_SIZE),
 				    pkt_flags);
-		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&cis_lll->rx.ccm, phy,
-						      node_rx->pdu));
+		radio_pkt_rx_set(radio_ccm_iso_rx_pkt_set(&cis_lll->rx.ccm, phy,
+							  RADIO_PKT_CONF_PDU_TYPE_CIS,
+							  node_rx->pdu));
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	} else {
 		uint8_t pkt_flags;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
@@ -746,20 +747,21 @@ static void isr_rx(void *param)
 
 		cis_lll->tx.ccm.counter = payload_count;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 cis_lll->tx.phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
 				    (cis_lll->tx.max_pdu + PDU_MIC_SIZE),
 				    pkt_flags);
-		radio_pkt_tx_set(radio_ccm_tx_pkt_set(&cis_lll->tx.ccm,
+		radio_pkt_tx_set(radio_ccm_iso_tx_pkt_set(&cis_lll->tx.ccm,
+						      RADIO_PKT_CONF_PDU_TYPE_CIS,
 						      pdu_tx));
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	} else {
 		uint8_t pkt_flags;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 cis_lll->tx.phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
@@ -890,21 +892,22 @@ static void isr_tx(void *param)
 				(cis_lll->rx.bn_curr - 1U);
 		cis_lll->rx.ccm.counter = payload_count;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 cis_lll->rx.phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
 				    (cis_lll->rx.max_pdu + PDU_MIC_SIZE),
 				    pkt_flags);
-		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&cis_lll->rx.ccm,
-						      cis_lll->rx.phy,
-						      node_rx->pdu));
+		radio_pkt_rx_set(radio_ccm_iso_rx_pkt_set(&cis_lll->rx.ccm,
+							  cis_lll->rx.phy,
+							  RADIO_PKT_CONF_PDU_TYPE_CIS,
+							  node_rx->pdu));
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	} else {
 		uint8_t pkt_flags;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 cis_lll->rx.phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
@@ -1103,21 +1106,22 @@ static void isr_prepare_subevent_common(void *param)
 				(cis_lll->rx.bn_curr - 1U);
 		cis_lll->rx.ccm.counter = payload_count;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 cis_lll->rx.phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
 				    (cis_lll->rx.max_pdu + PDU_MIC_SIZE),
 				    pkt_flags);
-		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&cis_lll->rx.ccm,
-						      cis_lll->rx.phy,
-						      node_rx->pdu));
+		radio_pkt_rx_set(radio_ccm_iso_rx_pkt_set(&cis_lll->rx.ccm,
+							  cis_lll->rx.phy,
+							  RADIO_PKT_CONF_PDU_TYPE_CIS,
+							  node_rx->pdu));
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	} else {
 		uint8_t pkt_flags;
 
-		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
+		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_CIS,
 						 cis_lll->rx.phy,
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -320,8 +320,9 @@ static int prepare_cb_common(struct lll_prepare_param *p)
 						 RADIO_PKT_CONF_CTE_DISABLED);
 		radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT,
 				    (lll->max_pdu + PDU_MIC_SIZE), pkt_flags);
-		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&lll->ccm_rx, phy,
-						      node_rx->pdu));
+		radio_pkt_rx_set(radio_ccm_iso_rx_pkt_set(&lll->ccm_rx, phy,
+							  RADIO_PKT_CONF_PDU_TYPE_BIS,
+							  node_rx->pdu));
 	} else {
 		uint8_t pkt_flags;
 
@@ -905,7 +906,9 @@ isr_rx_next_subevent:
 		(void)memcpy(lll->ccm_rx.iv, lll->giv, 4U);
 		mem_xor_32(lll->ccm_rx.iv, lll->ccm_rx.iv, access_addr);
 
-		radio_pkt_rx_set(radio_ccm_rx_pkt_set(&lll->ccm_rx, lll->phy, pdu));
+		radio_pkt_rx_set(radio_ccm_iso_rx_pkt_set(&lll->ccm_rx, lll->phy,
+							  RADIO_PKT_CONF_PDU_TYPE_BIS,
+							  pdu));
 
 	} else {
 		struct pdu_bis *pdu;


### PR DESCRIPTION
Add missing headermask binding for NRF_CCM peripheral and
define HAS_HW_NRF_CCM_HEADERMASK Kconfig.

Use NRF_CCM HEADERMASK register to use correct Additional
Authentication Data (AAD) from ISO PDU header.

Fixes #55263.