### PR TITLE
[Backport v2.7-branch]logging: Fix user space crash when runtime filtering is on

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -302,10 +302,8 @@ static inline char z_log_minimal_level_to_char(int level)
 	} \
 	\
 	bool is_user_context = k_is_user_context(); \
-	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-						(_dsource)->filters : 0;\
 	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && !is_user_context && \
-	    _level > Z_LOG_RUNTIME_FILTER(filters)) { \
+	    _level > Z_LOG_RUNTIME_FILTER((_dsource)->filters)) { \
 		break; \
 	} \
 	if (IS_ENABLED(CONFIG_LOG2)) { \
@@ -347,8 +345,6 @@ static inline char z_log_minimal_level_to_char(int level)
 		break; \
 	} \
 	bool is_user_context = k_is_user_context(); \
-	uint32_t filters = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-						(_dsource)->filters : 0;\
 	\
 	if (IS_ENABLED(CONFIG_LOG_MINIMAL)) { \
 		Z_LOG_TO_PRINTK(_level, "%s", _str); \
@@ -357,7 +353,7 @@ static inline char z_log_minimal_level_to_char(int level)
 		break; \
 	} \
 	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && !is_user_context && \
-	    _level > Z_LOG_RUNTIME_FILTER(filters)) { \
+	    _level > Z_LOG_RUNTIME_FILTER((_dsource)->filters)) { \
 		break; \
 	} \
 	if (IS_ENABLED(CONFIG_LOG2)) { \


### PR DESCRIPTION
Logging module data (including filters) are not accessible by the user space. Macro for creating logs where creating local variable with filters before checking is we are in the user context. It was not used in that case but creating variable was violating access writes that resulted in failure.

Removing variable creation and using filters directly in the if clause but after checking condition that it is not the user context. With this approach data is accessed only in the kernel mode.

Cherry-picked with modifications from
4ee59e2cdbc88c16ad3432fcc38aa38c30a7dc94.

Original PR: #57879.

Fixes  #55323.