### PR TITLE
cmake: mcuboot: Add warning if missing Kconfig signing options

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Nordic Semiconductor ASA
+# Copyright (c) 2020-2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 # This file includes extra build system logic that is enabled when
@@ -25,6 +25,9 @@ function(zephyr_mcuboot_tasks)
     if("${keyfile}" STREQUAL "")
       # No signature key file, no signed binaries. No error, though:
       # this is the documented behavior.
+      message(WARNING "Neither CONFIG_MCUBOOT_GENERATE_UNSIGNED_IMAGE or "
+                      "CONFIG_MCUBOOT_SIGNATURE_KEY_FILE are set, the generated build will not be "
+                      "bootable by MCUboot unless it is signed manually/externally.")
       return()
     endif()
   endif()


### PR DESCRIPTION
Adds a warning if neither Kconfig is enabled to generate an unsigned image or a signing key are set, this is not an error but warns the user in case they have forgot to set these modes or if they have been set manually and have been cleared by a cmake rebuild occurring (e.g. when bisecting).

Fixes #57963