### PR TITLE
mgmt: mcumgr: grp: img_mgmt: Remove useless hash variable

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -147,9 +147,7 @@ img_mgmt_slot_in_use(int slot)
 int
 img_mgmt_state_set_pending(int slot, int permanent)
 {
-	uint8_t hash[IMAGE_HASH_LEN];
 	uint8_t state_flags;
-	const uint8_t *hashp;
 	int rc;
 
 	state_flags = img_mgmt_state_flags(slot);
@@ -165,12 +163,6 @@ img_mgmt_state_set_pending(int slot, int permanent)
 	rc = img_mgmt_write_pending(slot, permanent);
 
 done:
-	/* Log the image hash if we know it. */
-	if (img_mgmt_read_info(slot, NULL, hash, NULL)) {
-		hashp = NULL;
-	} else {
-		hashp = hash;
-	}
 
 	return rc;
 }


### PR DESCRIPTION
Removes a hash variable that was set then never used.

Supersedes #56623