### PR TITLE
drivers: pwm: pwm_nrfx: Apply workaround for stopping PWM instance

### DIFF
--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -198,7 +198,13 @@ static int pwm_nrfx_set_cycles(const struct device *dev, uint32_t channel,
 			 * and till that moment, it ignores any start requests,
 			 * so ensure here that it is stopped.
 			 */
-			while (!nrfx_pwm_stopped_check(&config->pwm)) {
+			/* TODO: Remove nrfy_pwm_events_process() that is temporarly
+			 * added as a workaround for missing functionality in
+			 * nrfx_pwm_stopped_check()
+			 */
+			while (!nrfx_pwm_stopped_check(&config->pwm) &&
+			       !nrfy_pwm_events_process(config->pwm.p_reg,
+					NRFY_EVENT_TO_INT_BITMASK(NRF_PWM_EVENT_STOPPED))) {
 			}
 		}
 


### PR DESCRIPTION
Current implementation of `nrfx_pwm_stopped_check()` doesn't work as expected when user doesn't provide event handler. Workaround for that is to wait for event after triggering STOP task.

The workaround should be removed when `nrfx_pwm_stopped_check()` will contain needed functionality.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/57960