### PR TITLE
Tests: Bluetooth: Mesh: test Remote provisioning timeout

### DIFF
--- a/tests/bsim/bluetooth/mesh/src/test_provision.c
+++ b/tests/bsim/bluetooth/mesh/src/test_provision.c
@@ -28,6 +28,9 @@
 #define LOG_MODULE_NAME mesh_prov
 
 #include <zephyr/logging/log.h>
+#include "mesh/adv.h"
+#include "mesh/rpr.h"
+
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 /*
@@ -39,6 +42,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define PROV_REPROV_COUNT 3
 #define WAIT_TIME 120 /*seconds*/
 #define IS_RPR_PRESENT  (CONFIG_BT_MESH_RPR_SRV && CONFIG_BT_MESH_RPR_CLI)
+#define IMPOSTER_MODEL_ID 0xe000
 
 enum test_flags {
 	IS_PROVISIONER,
@@ -83,14 +87,17 @@ extern const uint8_t test_app_key[16];
 
 /* Timeout semaphore */
 static struct k_sem prov_sem;
+static K_SEM_DEFINE(link_open_sem, 0, 1);
 static uint16_t prov_addr = 0x0002;
 static uint16_t current_dev_addr;
 static const uint8_t dev_key[16] = { 0x01, 0x02, 0x03, 0x04, 0x05 };
 static uint8_t dev_uuid[16] = { 0x6c, 0x69, 0x6e, 0x67, 0x61, 0x6f };
 static uint8_t *uuid_to_provision;
 static struct k_sem reprov_sem;
+static uint32_t link_close_timestamp;
 
 #if IS_RPR_PRESENT
+static struct k_sem pdu_send_sem;
 static struct k_sem scan_sem;
 /* Remote Provisioning models related variables. */
 static uint8_t *uuid_to_provision_remote;
@@ -119,6 +126,48 @@ static const struct bt_mesh_comp rpr_srv_comp = {
 			BT_MESH_ELEM(1,
 				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
 						BT_MESH_MODEL_RPR_SRV),
+				     BT_MESH_MODEL_NONE),
+		},
+	.elem_count = 1,
+};
+
+static int mock_pdu_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
+{
+	/* Device becomes unresponsive and doesn't communicate with other nodes anymore */
+	bt_mesh_suspend();
+
+	k_sem_give(&pdu_send_sem);
+
+	return 0;
+}
+
+static const struct bt_mesh_model_op model_rpr_op1[] = {
+	{ RPR_OP_PDU_SEND, 0, mock_pdu_send },
+	BT_MESH_MODEL_OP_END
+};
+
+static int mock_model_init(struct bt_mesh_model *mod)
+{
+	mod->keys[0] = BT_MESH_KEY_DEV_LOCAL;
+	mod->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+
+	return 0;
+}
+
+const struct bt_mesh_model_cb mock_model_cb = {
+	.init = mock_model_init
+};
+
+static const struct bt_mesh_comp rpr_srv_comp_unresponsive = {
+	.elem =
+		(struct bt_mesh_elem[]){
+			BT_MESH_ELEM(1,
+				     MODEL_LIST(BT_MESH_MODEL_CFG_SRV,
+						BT_MESH_MODEL_CB(IMPOSTER_MODEL_ID,
+								 model_rpr_op1, NULL, NULL,
+								 &mock_model_cb),
+						BT_MESH_MODEL_RPR_SRV,),
 				     BT_MESH_MODEL_NONE),
 		},
 	.elem_count = 1,
@@ -190,6 +239,16 @@ static void prov_complete(uint16_t net_idx, uint16_t addr)
 	if (!atomic_test_bit(test_flags, IS_PROVISIONER)) {
 		k_sem_give(&prov_sem);
 	}
+}
+
+static void prov_link_open(bt_mesh_prov_bearer_t bearer)
+{
+	k_sem_give(&link_open_sem);
+}
+
+static void prov_link_close(bt_mesh_prov_bearer_t bearer)
+{
+	link_close_timestamp = k_uptime_get_32();
 }
 
 static void prov_node_added(uint16_t net_idx, uint8_t uuid[16], uint16_t addr,
@@ -267,6 +326,8 @@ static struct bt_mesh_prov prov = {
 	.uuid = dev_uuid,
 	.unprovisioned_beacon = unprovisioned_beacon,
 	.complete = prov_complete,
+	.link_open = prov_link_open,
+	.link_close = prov_link_close,
 	.reprovisioned = prov_reprovisioned,
 	.node_added = prov_node_added,
 	.output_number = output_number,
@@ -695,6 +756,34 @@ static void test_provisioner_pb_adv_reprovision(void)
 	PASS();
 }
 
+/** @brief Device starts unprovisioned. Stops being responsive to Mesh message after initial setup.
+ * Later becomes responsive but becomes unresponsive again after provisioning link opens.
+ * Then becomes responsive again allowing successful provisioning. Never stops advertising
+ * Unprovisioned Device beacons.
+ */
+static void test_device_unresponsive(void)
+{
+	bt_mesh_device_setup(&prov, &comp);
+
+	k_sem_init(&prov_sem, 0, 1);
+
+	ASSERT_OK(bt_mesh_prov_enable(BT_MESH_PROV_ADV));
+
+	/* stop responding for 30s to timeout PB-ADV link establishment. */
+	bt_mesh_scan_disable();
+	k_sleep(K_SECONDS(30));
+	bt_mesh_scan_enable();
+
+	k_sem_take(&link_open_sem, K_SECONDS(20));
+	/* stop responding for 60s to timeout protocol */
+	bt_mesh_scan_disable();
+	k_sleep(K_SECONDS(60));
+	bt_mesh_scan_enable();
+
+	k_sem_take(&prov_sem, K_SECONDS(20));
+	PASS();
+}
+
 #if IS_RPR_PRESENT
 static int provision_adv(uint8_t dev_idx, uint16_t *addr)
 {
@@ -885,6 +974,67 @@ static void test_provisioner_pb_remote_client_parallel(void)
 	PASS();
 }
 
+/** @brief Test Provisioning procedure on Remote Provisioning client:
+ * - verify procedure timeouts on unresponsive unprovisioned device.
+ */
+static void test_provisioner_pb_remote_client_provision_timeout(void)
+{
+	uint16_t pb_remote_server_addr;
+	uint8_t uuid[16];
+	uint32_t link_close_wait_start;
+	struct bt_mesh_rpr_scan_status scan_status;
+
+	k_sem_init(&scan_sem, 0, 1);
+
+	provisioner_pb_remote_client_setup();
+	bt_mesh_test_cfg_set(NULL, 300);
+
+	/* Provision the 2nd device over PB-Adv. */
+	ASSERT_OK(provision_adv(1, &pb_remote_server_addr));
+
+	/* Provision the 3rd device over PB-Remote. */
+	struct bt_mesh_rpr_node srv = {
+		.addr = pb_remote_server_addr,
+		.net_idx = 0,
+		.ttl = 3,
+	};
+
+	rpr_cli.scan_report = rpr_scan_report_parallel;
+
+	/* Offset timeline of test to give some time to 3rd device to setup and disable scanning */
+	k_sleep(K_SECONDS(10));
+
+	memcpy(uuid, dev_uuid, 16);
+	uuid[6] = '0' + 2;
+	uuid_to_provision_remote = uuid;
+
+	LOG_INF("Starting scanning for an unprov device...");
+	ASSERT_OK(bt_mesh_rpr_scan_start(&rpr_cli, &srv, uuid, 5, 1, &scan_status));
+	ASSERT_EQUAL(BT_MESH_RPR_SUCCESS, scan_status.status);
+	ASSERT_EQUAL(BT_MESH_RPR_SCAN_SINGLE, scan_status.scan);
+	ASSERT_EQUAL(1, scan_status.max_devs);
+	ASSERT_EQUAL(5, scan_status.timeout);
+
+	ASSERT_OK(k_sem_take(&scan_sem, K_SECONDS(20)));
+
+	/* Invalidate earlier timestamp */
+	link_close_timestamp = -1;
+	ASSERT_OK(bt_mesh_provision_remote(&rpr_cli, &srv, uuid, 0, prov_addr));
+	link_close_wait_start = k_uptime_get_32();
+	ASSERT_EQUAL(k_sem_take(&prov_sem, K_SECONDS(20)), -EAGAIN);
+	ASSERT_EQUAL((link_close_timestamp - link_close_wait_start) / MSEC_PER_SEC, 10);
+
+	/* 3rd device should now respond but stop again after link is opened */
+	link_close_timestamp = -1;
+	ASSERT_OK(bt_mesh_provision_remote(&rpr_cli, &srv, uuid, 0, prov_addr));
+	ASSERT_OK(k_sem_take(&link_open_sem, K_SECONDS(20)));
+	link_close_wait_start = k_uptime_get_32();
+	ASSERT_EQUAL(k_sem_take(&prov_sem, K_SECONDS(61)), -EAGAIN);
+	ASSERT_EQUAL((link_close_timestamp - link_close_wait_start) / MSEC_PER_SEC, 60);
+
+	PASS();
+}
+
 /** @brief Verify robustness of NPPI procedures on a RPR Client by running Device Key Refresh,
  * Node Composition Refresh and Node Address Refresh procedures.
  */
@@ -1020,6 +1170,23 @@ static void test_device_pb_remote_server_unproved(void)
 #endif
 
 	device_pb_remote_server_setup_unproved(&rpr_srv_comp);
+
+	PASS();
+}
+
+/** @brief A device running a Remote Provisioning server that is used to provision unprovisioned
+ * devices over PB-Remote. Always starts unprovisioned. Stops being responsive after receives
+ * Remote Provisioning PDU Send message from RPR Client
+ */
+static void test_device_pb_remote_server_unproved_unresponsive(void)
+{
+#if defined(CONFIG_BT_SETTINGS)
+	settings_test_backend_clear();
+#endif
+	device_pb_remote_server_setup_unproved(&rpr_srv_comp_unresponsive);
+
+	k_sem_init(&pdu_send_sem, 0, 1);
+	ASSERT_OK(k_sem_take(&pdu_send_sem, K_SECONDS(200)));
 
 	PASS();
 }
@@ -1320,11 +1487,15 @@ static const struct bst_test_instance test_connect[] = {
 		  "Device: pb-adv provisioning use oob public key"),
 	TEST_CASE(device, pb_adv_reprovision,
 		  "Device: pb-adv provisioning, reprovision"),
+	TEST_CASE(device, unresponsive,
+		  "Device: pb-adv provisioning, stops and resumes responding to provisioning"),
 #if IS_RPR_PRESENT
 	TEST_CASE(device, pb_remote_server_unproved,
 		  "Device: used for remote provisioning, starts unprovisioned"),
 	TEST_CASE(device, pb_remote_server_nppi_robustness,
 		  "Device: pb-remote reprovisioning, NPPI robustness"),
+	TEST_CASE(device, pb_remote_server_unproved_unresponsive,
+		  "Device: used for remote provisioning, starts unprovisioned, stops responding"),
 #endif
 
 	TEST_CASE(provisioner, pb_adv_no_oob,
@@ -1350,6 +1521,8 @@ static const struct bst_test_instance test_connect[] = {
 		  "Provisioner: pb-remote provisioning, NPPI robustness."),
 	TEST_CASE(provisioner, pb_remote_client_parallel,
 		  "Provisioner: pb-remote provisioning, parallel scanning and provisioning."),
+	TEST_CASE(provisioner, pb_remote_client_provision_timeout,
+		  "Provisioner: provisioning test, devices stop responding"),
 #endif
 
 	BSTEST_END_MARKER

--- a/tests/bsim/bluetooth/mesh/tests_scripts/provision/pb_remote_timeout.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/provision/pb_remote_timeout.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test timeout on RPR Client and server during remote provisioning procedure.
+# Devices:
+# 1. Tester node with RPR Client, provisioner
+# 2. Unprovisioned device with RPR server, provisionee
+# 3. Unprovisioned device, provisionee
+# Procedure
+# 1. All devices start as unprovisioned;
+# 2. 1st device self provisions and provisions 2nd device over PB-Adv.
+# 3. 3rd device enables Mesh and starts advertising unprovisioned device beacons.
+# 4. 3rd device disables Mesh scan while still advertising. Mesh stack remains active.
+# 5. RPR Client on 1st device requests 2nd device to perform RPR Scan for UUID of 3rd device.
+# 6. Unprovisioned device beacon of 3rd device gets reported to RPR Client.
+# 7. RPR Client starts Remote Provisioning procedure for 3rd device.
+# 8. Remote provisioning timeouts of 10s is reached on RPR Server. 2nd device sends Link Report
+#    with status BT_MESH_RPR_ERR_LINK_OPEN_FAILED to 1st device, which closes provisioning link.
+# 9. 3rd device enables Mesh scan again and becomes responsive.
+# 10. RPR Client restarts provisioning.
+# 11. 3rd device opens provisioning link.
+# 12. 2nd device stops communicating with either devices.
+# 13. After 60s RPR timeout is reached on 1st device. RPR Client closes provisioning link.
+conf=prj_mesh1d1_conf
+RunTest mesh_prov_pb_remote_provisioning_timeout \
+	prov_provisioner_pb_remote_client_provision_timeout \
+	prov_device_pb_remote_server_unproved_unresponsive \
+	prov_device_unresponsive


### PR DESCRIPTION
Test timeout of Remote Provisioning procedure when provisioned device is unresponsive. Test if device can be provisioned when becomes responsive.