### PR TITLE
mgmt: mcumgr: grp: fs_mgmt: Fix not checking offset

### DIFF
--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
@@ -233,7 +233,7 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 	ok = zcbor_map_decode_bulk(zsd, fs_download_decode,
 		ARRAY_SIZE(fs_download_decode), &decoded) == 0;
 
-	if (!ok || name.len == 0 || name.len > (sizeof(path) - 1)) {
+	if (!ok || off == ULLONG_MAX || name.len == 0 || name.len > (sizeof(path) - 1)) {
 		return MGMT_ERR_EINVAL;
 	}
 


### PR DESCRIPTION
Fixes an issue whereby the user supplied offset was not checked if it was provided or not.