### PR TITLE
net: tcp: Make sure we shift by less then bit width

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1404,8 +1404,8 @@ static void tcp_send_zwp(struct k_work *work)
 	if (conn->send_win == 0) {
 		uint64_t timeout = TCP_RTO_MS;
 
-		/* Make sure the retry counter does not overflow. */
-		if (conn->zwp_retries < UINT8_MAX) {
+		/* Make sure the bitwise shift does not result in undefined behaviour */
+		if (conn->zwp_retries < 63) {
 			conn->zwp_retries++;
 		}
 


### PR DESCRIPTION
Shifting "timeout <<= conn->zwp_retries" by more then 63 bits results in undefined behaviour.