### PR TITLE
STM32 ADC: rework oversampling

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -440,20 +440,38 @@ static void adc_stm32_disable(ADC_TypeDef *adc)
 	!defined(CONFIG_SOC_SERIES_STM32F3X) && \
 	!DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
 
+#define OVS_SHIFT(n)		LL_ADC_OVS_SHIFT_RIGHT_##n
+static const uint32_t table_oversampling_shift[] = {
+	LL_ADC_OVS_SHIFT_NONE,
+	OVS_SHIFT(1),
+	OVS_SHIFT(2),
+	OVS_SHIFT(3),
+	OVS_SHIFT(4),
+	OVS_SHIFT(5),
+	OVS_SHIFT(6),
+	OVS_SHIFT(7),
+	OVS_SHIFT(8),
+#if defined(CONFIG_SOC_SERIES_STM32H7X) || \
+	defined(CONFIG_SOC_SERIES_STM32U5X)
+	OVS_SHIFT(9),
+	OVS_SHIFT(10),
+#endif
+};
+
 #ifdef LL_ADC_OVS_RATIO_2
-/* table for shifting oversampling mostly for ADC3 != ADC_VER_V5_V90 */
-	static const uint32_t stm32_adc_ratio_table[] = {
-		0,
-		LL_ADC_OVS_RATIO_2,
-		LL_ADC_OVS_RATIO_4,
-		LL_ADC_OVS_RATIO_8,
-		LL_ADC_OVS_RATIO_16,
-		LL_ADC_OVS_RATIO_32,
-		LL_ADC_OVS_RATIO_64,
-		LL_ADC_OVS_RATIO_128,
-		LL_ADC_OVS_RATIO_256,
-	};
-#endif /* ! ADC_VER_V5_V90 */
+#define OVS_RATIO(n)		LL_ADC_OVS_RATIO_##n
+static const uint32_t table_oversampling_ratio[] = {
+	0,
+	OVS_RATIO(2),
+	OVS_RATIO(4),
+	OVS_RATIO(8),
+	OVS_RATIO(16),
+	OVS_RATIO(32),
+	OVS_RATIO(64),
+	OVS_RATIO(128),
+	OVS_RATIO(256),
+};
+#endif
 
 /*
  * Function to configure the oversampling scope. It is basically a wrapper over
@@ -482,8 +500,6 @@ static void adc_stm32_oversampling_scope(ADC_TypeDef *adc, uint32_t ovs_scope)
  */
 static void adc_stm32_oversampling_ratioshift(ADC_TypeDef *adc, uint32_t ratio, uint32_t shift)
 {
-#if defined(CONFIG_SOC_SERIES_STM32L0X) || \
-	defined(CONFIG_SOC_SERIES_STM32WLX)
 	/*
 	 * setting OVS bits is conditioned to ADC state: ADC must be disabled
 	 * or enabled without conversion on going : disable it, it will stop
@@ -493,7 +509,7 @@ static void adc_stm32_oversampling_ratioshift(ADC_TypeDef *adc, uint32_t ratio, 
 		return;
 	}
 	adc_stm32_disable(adc);
-#endif
+
 	LL_ADC_ConfigOverSamplingRatioShift(adc, ratio, shift);
 }
 
@@ -502,9 +518,20 @@ static void adc_stm32_oversampling_ratioshift(ADC_TypeDef *adc, uint32_t ratio, 
  * ratio is directly the sequence->oversampling (a 2^n value)
  * shift is the corresponding LL_ADC_OVS_SHIFT_RIGHT_x constant
  */
-static void adc_stm32_oversampling(ADC_TypeDef *adc, uint8_t ratio, uint32_t shift)
+static int adc_stm32_oversampling(ADC_TypeDef *adc, uint8_t ratio)
 {
-	adc_stm32_oversampling_scope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
+	if (ratio == 0) {
+		adc_stm32_oversampling_scope(adc, LL_ADC_OVS_DISABLE);
+		return 0;
+	} else if (ratio < ARRAY_SIZE(table_oversampling_shift)) {
+		adc_stm32_oversampling_scope(adc, LL_ADC_OVS_GRP_REGULAR_CONTINUED);
+	} else {
+		LOG_ERR("Invalid oversampling");
+		return -EINVAL;
+	}
+
+	uint32_t shift = table_oversampling_shift[ratio];
+
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	/* Certain variants of the H7, such as STM32H72x/H73x has ADC3
 	 * as a separate entity and require special handling.
@@ -515,23 +542,25 @@ static void adc_stm32_oversampling(ADC_TypeDef *adc, uint8_t ratio, uint32_t shi
 		adc_stm32_oversampling_ratioshift(adc, 1 << ratio, shift);
 	} else {
 		/* the LL function expects a value LL_ADC_OVS_RATIO_x */
-		adc_stm32_oversampling_ratioshift(adc, stm32_adc_ratio_table[ratio], shift);
+		adc_stm32_oversampling_ratioshift(adc, table_oversampling_ratio[ratio], shift);
 	}
 #else
 	/* the LL function expects a value from 1 to 1024 */
 	adc_stm32_oversampling_ratioshift(adc, 1 << ratio, shift);
 #endif /* defined(ADC_VER_V5_V90) */
 #elif defined(CONFIG_SOC_SERIES_STM32U5X)
-	if (adc == ADC1) {
+	if (adc != ADC4) {
 		/* the LL function expects a value from 1 to 1024 */
 		adc_stm32_oversampling_ratioshift(adc, (1 << ratio), shift);
 	} else {
 		/* the LL function expects a value LL_ADC_OVS_RATIO_x */
-		adc_stm32_oversampling_ratioshift(adc, stm32_adc_ratio_table[ratio], shift);
+		adc_stm32_oversampling_ratioshift(adc, table_oversampling_ratio[ratio], shift);
 	}
 #else /* CONFIG_SOC_SERIES_STM32H7X */
-	adc_stm32_oversampling_ratioshift(adc, stm32_adc_ratio_table[ratio], shift);
+	adc_stm32_oversampling_ratioshift(adc, table_oversampling_ratio[ratio], shift);
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+	return 0;
 }
 #endif /* CONFIG_SOC_SERIES_STM32xxx */
 
@@ -908,48 +937,9 @@ static int start_read(const struct device *dev,
 	!defined(CONFIG_SOC_SERIES_STM32F1X) && \
 	!defined(CONFIG_SOC_SERIES_STM32F3X) && \
 	!DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
-
-	switch (sequence->oversampling) {
-	case 0:
-		adc_stm32_oversampling_scope(adc, LL_ADC_OVS_DISABLE);
-		break;
-	case 1:
-		adc_stm32_oversampling(adc, 1, LL_ADC_OVS_SHIFT_RIGHT_1);
-		break;
-	case 2:
-		adc_stm32_oversampling(adc, 2, LL_ADC_OVS_SHIFT_RIGHT_2);
-		break;
-	case 3:
-		adc_stm32_oversampling(adc, 3, LL_ADC_OVS_SHIFT_RIGHT_3);
-		break;
-	case 4:
-		adc_stm32_oversampling(adc, 4, LL_ADC_OVS_SHIFT_RIGHT_4);
-		break;
-	case 5:
-		adc_stm32_oversampling(adc, 5, LL_ADC_OVS_SHIFT_RIGHT_5);
-		break;
-	case 6:
-		adc_stm32_oversampling(adc, 6, LL_ADC_OVS_SHIFT_RIGHT_6);
-		break;
-	case 7:
-		adc_stm32_oversampling(adc, 7, LL_ADC_OVS_SHIFT_RIGHT_7);
-		break;
-	case 8:
-		adc_stm32_oversampling(adc, 8, LL_ADC_OVS_SHIFT_RIGHT_8);
-		break;
-#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32U5X)
-	/* stm32 U5, H7 ADC1 & 2 have oversampling ratio from 1..1024 */
-	case 9:
-		adc_stm32_oversampling(adc, 9, LL_ADC_OVS_SHIFT_RIGHT_9);
-		break;
-	case 10:
-		adc_stm32_oversampling(adc, 10, LL_ADC_OVS_SHIFT_RIGHT_10);
-		break;
-#endif /* CONFIG_SOC_SERIES_STM32H7X */
-	default:
-		LOG_ERR("Invalid oversampling");
-		adc_stm32_enable(adc);
-		return -EINVAL;
+	err = adc_stm32_oversampling(adc, sequence->oversampling);
+	if (err) {
+		return err;
 	}
 #else
 	if (sequence->oversampling) {


### PR DESCRIPTION
This PR aims to simplify the STM32 ADC driver a bit further by refactoring the oversampling part. It adds a constant table in order to replace a switch case.
Also adds two macros to indicate the presence of a feature (calibration and oversampling), and uses them to condition part of the code instead of a list of series.