### PR TITLE
mgmt: mcumgr: grp: os_mgmt: Use new error for invalid format

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
@@ -24,6 +24,20 @@ extern "C" {
 #define OS_MGMT_ID_MCUMGR_PARAMS	6
 #define OS_MGMT_ID_INFO			7
 
+/**
+ * Command result codes for OS management group.
+ */
+enum os_mgmt_ret_code_t {
+	/** No error, this is implied if there is no ret value in the response */
+	OS_MGMT_RET_RC_OK = 0,
+
+	/** Unknown error occurred. */
+	OS_MGMT_RET_RC_UNKNOWN,
+
+	/** The provided format value is not valid. */
+	OS_MGMT_RET_RC_INVALID_FORMAT,
+};
+
 /* Bitmask values used by the os info command handler. Note that the width of this variable is
  * 32-bits, allowing 32 flags, custom user-level implementations should start at
  * OS_MGMT_INFO_FORMAT_USER_CUSTOM_START and reference that directly as additional format
@@ -82,6 +96,17 @@ struct os_mgmt_info_append {
 	/* If there has been prior output, must be set to true if a response has been output */
 	bool *prior_output;
 };
+
+#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
+/*
+ * @brief	Translate OS mgmt group error code into MCUmgr error code
+ *
+ * @param ret	#os_mgmt_ret_code_t error code
+ *
+ * @return	#mcumgr_err_t error code
+ */
+int os_mgmt_translate_error_code(uint16_t ret);
+#endif
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/smp/src/smp.c
@@ -31,6 +31,9 @@
 #ifdef CONFIG_MCUMGR_GRP_IMG
 #include <zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h>
 #endif
+#ifdef CONFIG_MCUMGR_GRP_OS
+#include <zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h>
+#endif
 #ifdef CONFIG_MCUMGR_GRP_SHELL
 #include <zephyr/mgmt/mcumgr/grp/shell_mgmt/shell_mgmt.h>
 #endif
@@ -45,6 +48,11 @@
 static int smp_translate_error_code(uint16_t group, uint16_t ret)
 {
 	switch (group) {
+#ifdef CONFIG_MCUMGR_GRP_OS
+	case MGMT_GROUP_ID_OS:
+	return os_mgmt_translate_error_code(ret);
+#endif
+
 #ifdef CONFIG_MCUMGR_GRP_IMG
 	case MGMT_GROUP_ID_IMAGE:
 	return img_mgmt_translate_error_code(ret);


### PR DESCRIPTION
Uses the new error system to report an error if the user provides an invalid format for the OS info command.