### PR TITLE
Add module and toolchain-bundled Picolibc synchronisation policy

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -496,8 +496,8 @@ that are used to emulate, flash and debug Zephyr applications.
 
       .. _ubuntu_zephyr_sdk:
 
-      #. Download and verify the `latest Zephyr SDK bundle
-         <https://github.com/zephyrproject-rtos/sdk-ng/releases>`_:
+      #. Download and verify the `Zephyr SDK bundle
+         <https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.1>`_:
 
          .. code-block:: bash
 
@@ -553,8 +553,8 @@ that are used to emulate, flash and debug Zephyr applications.
 
       .. _macos_zephyr_sdk:
 
-      #. Download and verify the `latest Zephyr SDK bundle
-         <https://github.com/zephyrproject-rtos/sdk-ng/releases>`_:
+      #. Download and verify the `Zephyr SDK bundle
+         <https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.1>`_:
 
          .. code-block:: bash
 
@@ -604,8 +604,8 @@ that are used to emulate, flash and debug Zephyr applications.
 
       #. Open a ``cmd.exe`` window by pressing the Windows key typing "cmd.exe".
 
-      #. Download the `latest Zephyr SDK bundle
-         <https://github.com/zephyrproject-rtos/sdk-ng/releases>`_:
+      #. Download the `Zephyr SDK bundle
+         <https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.1>`_:
 
          .. code-block:: console
 

--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -317,5 +317,5 @@ To make sure this variable is unset, run:
 
    unset ZEPHYR_SDK_INSTALL_DIR
 
-.. _Zephyr SDK Releases: https://github.com/zephyrproject-rtos/sdk-ng/releases
+.. _Zephyr SDK Releases: https://github.com/zephyrproject-rtos/sdk-ng/tags
 .. _CMake Downloads: https://cmake.org/download

--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -227,8 +227,8 @@ The Zephyr SDK supports the following target architectures:
 
 Follow these steps to install the Zephyr SDK:
 
-#. Download and verify the `latest Zephyr SDK bundle
-   <https://github.com/zephyrproject-rtos/sdk-ng/releases>`_:
+#. Download and verify the `Zephyr SDK bundle
+   <https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.1>`_:
 
    .. code-block:: bash
 

--- a/doc/develop/languages/c/picolibc.rst
+++ b/doc/develop/languages/c/picolibc.rst
@@ -23,6 +23,8 @@ the library internal system calls to the equivalent Zephyr API calls.
 .. _`C17 (ISO/IEC 9899:2018)`: https://www.iso.org/standard/74528.html
 .. _`POSIX 2018 (IEEE Std 1003.1-2017)`: https://pubs.opengroup.org/onlinepubs/9699919799/functions/printf.html
 
+.. _c_library_picolibc_module:
+
 Picolibc Module
 ===============
 
@@ -38,6 +40,12 @@ The Picolibc module can be enabled by selecting
 :kconfig:option:`CONFIG_PICOLIBC_USE_MODULE` in the application
 configuration file.
 
+When updating the Picolibc module to a newer version, the
+:ref:`toolchain-bundled Picolibc in the Zephyr SDK
+<c_library_picolibc_toolchain>` must also be updated to the same version.
+
+.. _c_library_picolibc_toolchain:
+
 Toolchain Picolibc
 ==================
 
@@ -48,6 +56,11 @@ precompiled versions of libstdc++.
 The toolchain version of Picolibc can be enabled by de-selecting
 :kconfig:option:`CONFIG_PICOLIBC_USE_MODULE` in the application
 configuration file.
+
+For every release of Zephyr, the toolchain-bundled Picolibc and the
+:ref:`Picolibc module <c_library_picolibc_module>` are guaranteed to be in
+sync when using the
+:ref:`recommended version of Zephyr SDK <toolchain_zephyr_sdk_compatibility>`.
 
 Formatted Output
 ****************

--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -56,6 +56,17 @@ example, you can set ``ZEPHYR_SDK_INSTALL_DIR`` to ``/company/tools``, where the
 This allows the Zephyr build system to choose the correct version of the SDK,
 while allowing multiple Zephyr SDKs to be grouped together at a specific path.
 
+.. _toolchain_zephyr_sdk_compatibility:
+
+Zephyr SDK version compatibility
+********************************
+
+In general, the Zephyr SDK version referenced in this page should be considered
+the recommended version for the corresponding Zephyr version.
+
+For the full list of compatible Zephyr and Zephyr SDK versions, refer to the
+`Zephyr SDK Version Compatibility Matrix`_.
+
 .. _toolchain_zephyr_sdk_install_linux:
 
 Install Zephyr SDK on Linux
@@ -205,3 +216,4 @@ Install Zephyr SDK on Windows
 
 .. _latest Zephyr SDK bundle: https://github.com/zephyrproject-rtos/sdk-ng/releases
 .. _Zephyr SDK Releases: https://github.com/zephyrproject-rtos/sdk-ng/releases
+.. _Zephyr SDK Version Compatibility Matrix: https://github.com/zephyrproject-rtos/sdk-ng/wiki/Zephyr-SDK-Version-Compatibility-Matrix

--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -215,5 +215,5 @@ Install Zephyr SDK on Windows
       the initial setup.
 
 .. _Zephyr SDK bundle: https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.1
-.. _Zephyr SDK Releases: https://github.com/zephyrproject-rtos/sdk-ng/releases
+.. _Zephyr SDK Releases: https://github.com/zephyrproject-rtos/sdk-ng/tags
 .. _Zephyr SDK Version Compatibility Matrix: https://github.com/zephyrproject-rtos/sdk-ng/wiki/Zephyr-SDK-Version-Compatibility-Matrix

--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -72,7 +72,7 @@ For the full list of compatible Zephyr and Zephyr SDK versions, refer to the
 Install Zephyr SDK on Linux
 ***************************
 
-#. Download and verify the `latest Zephyr SDK bundle`_:
+#. Download and verify the `Zephyr SDK bundle`_:
 
    .. code-block:: bash
 
@@ -125,7 +125,7 @@ If you relocate the SDK directory, you need to re-run the setup script.
 Install Zephyr SDK on macOS
 ***************************
 
-#. Download and verify the `latest Zephyr SDK bundle`_:
+#. Download and verify the `Zephyr SDK bundle`_:
 
    .. code-block:: bash
 
@@ -177,7 +177,7 @@ Install Zephyr SDK on Windows
 
 #. Open a ``cmd.exe`` window by pressing the Windows key typing "cmd.exe".
 
-#. Download the `latest Zephyr SDK bundle`_:
+#. Download the `Zephyr SDK bundle`_:
 
    .. code-block:: console
 
@@ -214,6 +214,6 @@ Install Zephyr SDK on Windows
       You must rerun the setup script if you relocate the Zephyr SDK bundle directory after
       the initial setup.
 
-.. _latest Zephyr SDK bundle: https://github.com/zephyrproject-rtos/sdk-ng/releases
+.. _Zephyr SDK bundle: https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.16.1
 .. _Zephyr SDK Releases: https://github.com/zephyrproject-rtos/sdk-ng/releases
 .. _Zephyr SDK Version Compatibility Matrix: https://github.com/zephyrproject-rtos/sdk-ng/wiki/Zephyr-SDK-Version-Compatibility-Matrix


### PR DESCRIPTION
This series adds the policy for keeping the Picolibc module and the toolchain-bundled Picolibc in sync.

Related to https://github.com/zephyrproject-rtos/sdk-ng/pull/673

Part of https://github.com/zephyrproject-rtos/zephyr/issues/49922