### PR TITLE
drivers: fuel_gauge: sbs_gauge: Add support for buffer registers

### DIFF
--- a/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
+++ b/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Google LLC
+ * Copyright 2023 Microsoft Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -46,3 +47,26 @@ static inline int z_vrfy_fuel_gauge_set_prop(const struct device *dev,
 }
 
 #include <syscalls/fuel_gauge_set_prop_mrsh.c>
+
+static inline int z_vrfy_fuel_gauge_get_buffer_prop(const struct device *dev,
+						    struct fuel_gauge_get_buffer_property *prop,
+						    void *dst, size_t dst_len)
+{
+	struct fuel_gauge_get_buffer_property k_prop;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, get_buffer_property));
+
+	Z_OOPS(z_user_from_copy(&k_prop, prop,
+				sizeof(struct fuel_gauge_get_buffer_property)));
+
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(dst, dst_len));
+
+	int ret = z_impl_fuel_gauge_get_buffer_prop(dev, &k_prop, dst, dst_len);
+
+	Z_OOPS(z_user_to_copy(prop, &k_prop,
+			      sizeof(struct fuel_gauge_get_buffer_property)));
+
+	return ret;
+}
+
+#include <syscalls/fuel_gauge_get_buffer_prop_mrsh.c>

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2022 Leica Geosystems AG
  *
  * Copyright 2022 Google LLC
+ * Copyright 2023 Microsoft Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -43,6 +44,22 @@ static int sbs_cmd_reg_write(const struct device *dev, uint8_t reg_addr, uint16_
 	sys_put_le16(val, buf);
 
 	return i2c_burst_write_dt(&config->i2c, reg_addr, buf, sizeof(buf));
+}
+
+static int sbs_cmd_buffer_read(const struct device *dev, uint8_t reg_addr, char *buffer,
+			      const uint8_t buffer_size)
+{
+	const struct sbs_gauge_config *cfg;
+	int status;
+
+	cfg = dev->config;
+	status = i2c_burst_read_dt(&cfg->i2c, reg_addr, buffer, buffer_size);
+	if (status < 0) {
+		LOG_ERR("Unable to read register");
+		return status;
+	}
+
+	return 0;
 }
 
 static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_property *prop)
@@ -196,6 +213,45 @@ static int sbs_gauge_set_prop(const struct device *dev, struct fuel_gauge_set_pr
 	return rc;
 }
 
+static int sbs_gauge_get_buffer_prop(const struct device *dev,
+				    struct fuel_gauge_get_buffer_property *prop, void *dst,
+				    size_t dst_len)
+{
+	int rc = 0;
+
+	switch (prop->property_type) {
+	case FUEL_GAUGE_MANUFACTURER_NAME:
+		if (dst_len == sizeof(struct sbs_gauge_manufacturer_name)) {
+			rc = sbs_cmd_buffer_read(dev, SBS_GAUGE_CMD_MANUFACTURER_NAME, (char *)dst,
+						dst_len);
+		} else {
+			rc = -EINVAL;
+		}
+		break;
+	case FUEL_GAUGE_DEVICE_NAME:
+		if (dst_len == sizeof(struct sbs_gauge_device_name)) {
+			rc = sbs_cmd_buffer_read(dev, SBS_GAUGE_CMD_DEVICE_NAME, (char *)dst,
+						dst_len);
+		} else {
+			rc = -EINVAL;
+		}
+		break;
+	case FUEL_GAUGE_DEVICE_CHEMISTRY:
+		if (dst_len == sizeof(struct sbs_gauge_device_chemistry)) {
+			rc = sbs_cmd_buffer_read(dev, SBS_GAUGE_CMD_DEVICE_CHEMISTRY, (char *)dst,
+						dst_len);
+		} else {
+			rc = -EINVAL;
+		}
+		break;
+	default:
+		rc = -ENOTSUP;
+	}
+
+	prop->status = rc;
+	return rc;
+}
+
 static int sbs_gauge_get_props(const struct device *dev, struct fuel_gauge_get_property *props,
 			       size_t len)
 {
@@ -250,6 +306,7 @@ static int sbs_gauge_init(const struct device *dev)
 static const struct fuel_gauge_driver_api sbs_gauge_driver_api = {
 	.get_property = &sbs_gauge_get_props,
 	.set_property = &sbs_gauge_set_props,
+	.get_buffer_property = &sbs_gauge_get_buffer_prop,
 };
 
 /* FIXME: fix init priority */

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.h
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.h
@@ -42,7 +42,7 @@
 #define SBS_GAUGE_CMD_SN                    0x1C /* SerialNumber */
 #define SBS_GAUGE_CMD_MANUFACTURER_NAME     0x20 /* ManufacturerName */
 #define SBS_GAUGE_CMD_DEVICE_NAME           0x21 /* DeviceName */
-#define SBS_GAUGE_CMD_DEVICE_CHEM           0x22 /* DeviceChemistry */
+#define SBS_GAUGE_CMD_DEVICE_CHEMISTRY      0x22 /* DeviceChemistry */
 #define SBS_GAUGE_CMD_MANUFACTURER_DATA     0x23 /* ManufacturerData */
 
 #define SBS_GAUGE_DELAY                     1000

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Google LLC
+ * Copyright 2023 Microsoft Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -316,5 +317,32 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_props__returns_ok)
 
 	zassert_ok(ret);
 }
+
+
+ZTEST_USER_F(sbs_gauge_new_api, test_get_buffer_props__returns_ok)
+{
+	/* Validate what properties are supported by the driver */
+	struct fuel_gauge_get_buffer_property prop;
+	struct sbs_gauge_manufacturer_name mfg_name;
+	struct sbs_gauge_device_name dev_name;
+	struct sbs_gauge_device_chemistry chem;
+	int ret;
+
+	prop.property_type = FUEL_GAUGE_MANUFACTURER_NAME;
+	ret = fuel_gauge_get_buffer_prop(fixture->dev, &prop, &mfg_name, sizeof(mfg_name));
+	zassert_ok(prop.status, "Property %d has a bad status.", prop.property_type);
+	zassert_ok(ret);
+
+	prop.property_type = FUEL_GAUGE_DEVICE_NAME;
+	ret = fuel_gauge_get_buffer_prop(fixture->dev, &prop, &dev_name, sizeof(dev_name));
+	zassert_ok(prop.status, "Property %d has a bad status.", prop.property_type);
+	zassert_ok(ret);
+
+	prop.property_type = FUEL_GAUGE_DEVICE_CHEMISTRY;
+	ret = fuel_gauge_get_buffer_prop(fixture->dev, &prop, &chem, sizeof(chem));
+	zassert_ok(prop.status, "Property %d has a bad status.", prop.property_type);
+	zassert_ok(ret);
+}
+
 
 ZTEST_SUITE(sbs_gauge_new_api, NULL, sbs_gauge_new_api_setup, NULL, NULL, NULL);


### PR DESCRIPTION
The buffer registers (chemistry, manufacturer name, device name) were not implemented. Implemented by adding a new api interface for retrieving buffer properties. fuel_gauge_get_block_property has been added, and uses a memory buffer allocated in the app in order to store the fuel gauge information.