### PR TITLE
ARC: use 64bit MDB binary by default

### DIFF
--- a/cmake/emu/nsim.cmake
+++ b/cmake/emu/nsim.cmake
@@ -3,7 +3,7 @@ if("${BOARD_DEBUG_RUNNER}" STREQUAL "mdb-nsim" OR "${BOARD_FLASH_RUNNER}" STREQU
 # mdb is required to run nsim multicore targets
 find_program(
   MDB
-  mdb
+  mdb64
   )
 set(MDB_BASIC_OPTIONS -nooptions -nogoifmain -toggle=include_local_symbols=1)
 

--- a/scripts/west_commands/runners/mdb.py
+++ b/scripts/west_commands/runners/mdb.py
@@ -35,7 +35,7 @@ def is_flash_cmd_need_exit_immediately(mdb_runner):
         return True
 
 def mdb_do_run(mdb_runner, command):
-    commander = "mdb"
+    commander = "mdb64"
 
     mdb_runner.require(commander)
 

--- a/scripts/west_commands/tests/test_mdb.py
+++ b/scripts/west_commands/tests/test_mdb.py
@@ -13,7 +13,7 @@ from runners.mdb import MdbNsimBinaryRunner, MdbHwBinaryRunner
 from conftest import RC_KERNEL_ELF, RC_BOARD_DIR, RC_BUILD_DIR
 
 
-TEST_DRIVER_CMD = 'mdb'
+TEST_DRIVER_CMD = 'mdb64'
 TEST_NSIM_ARGS='test_nsim.args'
 TEST_TARGET = 'test-target'
 TEST_BOARD_NSIM_ARGS = '@' + path.join(RC_BOARD_DIR, 'support', TEST_NSIM_ARGS)


### PR DESCRIPTION
Currently we use in our scripting  `mdb` binary which can be either 32 or 64 bit (regardless the MDB instllation options) and which is still 32 bit for latest version. 

Let's use 64bit MDB binary (`mdb64`) by default instead of `mdb` binary. This significantly improve user experience as 32bit mdb binary require to install multiple libraries before it can be used on modern linux distros.

Closes: #55468