### PR TITLE
Bluetooth: Mesh: fix SRPL clearing

### DIFF
--- a/subsys/bluetooth/mesh/sol_pdu_rpl_srv.c
+++ b/subsys/bluetooth/mesh/sol_pdu_rpl_srv.c
@@ -67,7 +67,7 @@ static int item_clear(struct bt_mesh_model *mod,
 		return -EINVAL;
 	}
 
-	for (int i = 0; i < len; i++) {
+	for (int i = 0; i < len || i == 0; i++) {
 		bt_mesh_srpl_entry_clear(primary + i);
 	}
 


### PR DESCRIPTION
`item_clear` should clear adresses from primary to primary + len. Change lt to le comparison in for loop.