### PR TITLE
net: shell: Fix for PS timeout param type.

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -679,7 +679,7 @@ static int cmd_wifi_ps_timeout(const struct shell *sh, size_t argc, char *argv[]
 	}
 
 	params.timeout_ms = timeout_ms;
-	params.type = WIFI_PS_PARAM_MODE;
+	params.type = WIFI_PS_PARAM_TIMEOUT;
 
 	if (net_mgmt(NET_REQUEST_WIFI_PS, iface, &params, sizeof(params))) {
 		shell_fprintf(sh, SHELL_WARNING,


### PR DESCRIPTION
Param type is set to correct type for power save timeout.