### PR TITLE
DTSI file updates

### DIFF
--- a/dts/arm/infineon/psoc6/mpns/CY8C6016BZI_F04.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6016BZI_F04.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6016BZI_F04.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6016BZI_F04.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6036BZI_F04.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6036BZI_F04.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6036BZI_F04.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6036BZI_F04.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6116BZI_F54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6116BZI_F54.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6116BZI_F54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6116BZI_F54.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6117BZI_F34.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6117BZI_F34.dtsi
@@ -8,12 +8,16 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
-&sram0 {
-	reg = <0x8000000 0x48000>;
+cpus {
+	/delete-node/ cpu@0;
 };
 
 &flash0 {
 	reg = <0x10000000 0x100000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x48000>;
 };
 
 &nvic {

--- a/dts/arm/infineon/psoc6/mpns/CY8C6117BZI_F34.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6117BZI_F34.dtsi
@@ -12,14 +12,6 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6117FDI_F02.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6117FDI_F02.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.80-wlcsp.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &flash0 {
 	reg = <0x10000000 0x100000>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6117FDI_F02.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6117FDI_F02.dtsi
@@ -12,14 +12,6 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6117WI_F34.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6117WI_F34.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &flash0 {
 	reg = <0x10000000 0x100000>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6117WI_F34.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6117WI_F34.dtsi
@@ -12,14 +12,6 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6136BZI_F14.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6136BZI_F14.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6136BZI_F14.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6136BZI_F14.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6136BZI_F34.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6136BZI_F34.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6136BZI_F34.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6136BZI_F34.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6136FDI_F42.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6136FDI_F42.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6136FDI_F42.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6136FDI_F42.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.80-wlcsp.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6136FTI_F42.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6136FTI_F42.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6136FTI_F42.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6136FTI_F42.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.80-wlcsp.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6137BZI_F14.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6137BZI_F14.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &flash0 {
 	reg = <0x10000000 0x100000>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6137BZI_F14.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6137BZI_F14.dtsi
@@ -12,14 +12,6 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6137BZI_F34.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6137BZI_F34.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &flash0 {
 	reg = <0x10000000 0x100000>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6137BZI_F34.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6137BZI_F34.dtsi
@@ -12,14 +12,6 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6137BZI_F54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6137BZI_F54.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &flash0 {
 	reg = <0x10000000 0x100000>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6137BZI_F54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6137BZI_F54.dtsi
@@ -12,14 +12,6 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6137FDI_F02.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6137FDI_F02.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.80-wlcsp.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &flash0 {
 	reg = <0x10000000 0x100000>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6137FDI_F02.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6137FDI_F02.dtsi
@@ -12,14 +12,6 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6137WI_F54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6137WI_F54.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &flash0 {
 	reg = <0x10000000 0x100000>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6137WI_F54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6137WI_F54.dtsi
@@ -12,14 +12,6 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6246BZI_D04.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6246BZI_D04.dtsi
@@ -8,6 +8,14 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6246BZI_D04.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6246BZI_D04.dtsi
@@ -8,10 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
-/ {
-
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6247BFI_D54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6247BFI_D54.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6247BZI_AUD54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6247BZI_AUD54.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6247BZI_D34.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6247BZI_D34.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6247BZI_D44.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6247BZI_D44.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6247BZI_D54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6247BZI_D54.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6247FDI_D02.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6247FDI_D02.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.80-wlcsp.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6247FDI_D32.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6247FDI_D32.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.80-wlcsp.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6247FDI_D52.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6247FDI_D52.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.80-wlcsp.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6247FTI_D52.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6247FTI_D52.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.80-wlcsp.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6247WI_D54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6247WI_D54.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C624ABZI_S2D44.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C624ABZI_S2D44.dtsi
@@ -8,50 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_02/psoc6_02.124-bga.dtsi"
 
-/ {
-	cpus {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		cpu@0 {
-			device_type = "cpu";
-			compatible = "arm,cortex-m0+";
-			reg = <0>;
-		};
-		cpu@1 {
-			device_type = "cpu";
-			compatible = "arm,cortex-m4f";
-			reg = <1>;
-		};
-	};
-
-	flash-controller@40240000 {
-		compatible = "infineon,cat1-flash-controller";
-		reg = < 0x40240000 0x10000 >;
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		flash0: flash@10000000 {
-			compatible = "soc-nv-flash";
-			reg = <0x10000000 0x200000>;
-			write-block-size = <512>;
-			erase-block-size = <512>;
-		};
-		flash1: flash@14000000 {
-			compatible = "soc-nv-flash";
-			reg = <0x14000000 0x8000>;
-			write-block-size = <512>;
-			erase-block-size = <512>;
-		};
-	};
-
-	sram0: memory@8000000 {
-		compatible = "mmio-sram";
-		reg = <0x8000000 0x100000>;
-	};
-
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF03.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF03.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF03.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF03.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-ble.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF04.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF04.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF04.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF04.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga-sip.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF53.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF53.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF53.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF53.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-ble.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF54.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6316BZI_BLF54.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga-sip.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLD13.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLD13.dtsi
@@ -8,6 +8,14 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-ble.dtsi"
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLD13.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLD13.dtsi
@@ -8,10 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-ble.dtsi"
 
-/ {
-
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLD14.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLD14.dtsi
@@ -8,6 +8,14 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga-sip.dtsi"
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLD14.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLD14.dtsi
@@ -8,10 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga-sip.dtsi"
 
-/ {
-
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLF03.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLF03.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLF03.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLF03.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-ble.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLF04.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLF04.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLF04.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BLF04.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga-sip.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BUD13.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BUD13.dtsi
@@ -8,10 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-usb.dtsi"
 
-/ {
-
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BUD13.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336BZI_BUD13.dtsi
@@ -8,6 +8,14 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-usb.dtsi"
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336LQI_BLF02.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336LQI_BLF02.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336LQI_BLF02.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336LQI_BLF02.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.68-qfn-ble.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336LQI_BLF42.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336LQI_BLF42.dtsi
@@ -12,6 +12,14 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
+&flash0 {
+	reg = <0x10000000 0x80000>;
+};
+
+&sram0 {
+	reg = <0x8000000 0x20000>;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6336LQI_BLF42.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6336LQI_BLF42.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.68-qfn-ble.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6337BZI_BLF13.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6337BZI_BLF13.dtsi
@@ -8,6 +8,10 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-ble.dtsi"
 
+cpus {
+	/delete-node/ cpu@0;
+};
+
 &flash0 {
 	reg = <0x10000000 0x100000>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6337BZI_BLF13.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6337BZI_BLF13.dtsi
@@ -12,14 +12,6 @@ cpus {
 	/delete-node/ cpu@0;
 };
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BLD33.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BLD33.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-ble.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BLD34.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BLD34.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga-sip.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BLD43.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BLD43.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-ble.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BLD44.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BLD44.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga-sip.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BLD53.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BLD53.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-ble.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BLD54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BLD54.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.124-bga-sip.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BUD33.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BUD33.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-usb.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BUD43.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BUD43.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-usb.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BUD53.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347BZI_BUD53.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.116-bga-usb.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BLD13.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BLD13.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.104-m-csp-ble.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BLD33.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BLD33.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.104-m-csp-ble.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BLD43.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BLD43.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.104-m-csp-ble.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BLD53.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BLD53.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.104-m-csp-ble.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BUD13.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BUD13.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.104-m-csp-ble-usb.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BUD33.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BUD33.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.104-m-csp-ble-usb.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BUD43.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BUD43.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.104-m-csp-ble-usb.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BUD53.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347FMI_BUD53.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.104-m-csp-ble-usb.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CY8C6347LQI_BLD52.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CY8C6347LQI_BLD52.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.68-qfn-ble.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CYB06447BZI_BLD53.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CYB06447BZI_BLD53.dtsi
@@ -12,10 +12,6 @@
 	reg = <0x10000000 0xd0000>;
 };
 
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CYB06447BZI_BLD54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CYB06447BZI_BLD54.dtsi
@@ -12,10 +12,6 @@
 	reg = <0x10000000 0xd0000>;
 };
 
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CYB06447BZI_D54.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CYB06447BZI_D54.dtsi
@@ -12,10 +12,6 @@
 	reg = <0x10000000 0xd0000>;
 };
 
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/mpns/CYBLE_416045_02.dtsi
+++ b/dts/arm/infineon/psoc6/mpns/CYBLE_416045_02.dtsi
@@ -8,14 +8,6 @@
 #include <arm/armv7-m.dtsi>
 #include "../psoc6_01/psoc6_01.43-smt.dtsi"
 
-&flash0 {
-	reg = <0x10000000 0x100000>;
-};
-
-&sram0 {
-	reg = <0x8000000 0x48000>;
-};
-
 &nvic {
 	arm,num-irq-priority-bits = <3>;
 };

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.104-m-csp-ble-usb.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.104-m-csp-ble-usb.dtsi
@@ -16,7 +16,6 @@
 		/delete-node/ gpio@40320200; // gpio_prt4
 
 		pinctrl: pinctrl@40310000 {
-
 			/* scb_i2c_scl */
 			/omit-if-no-ref/ p0_2_scb0_i2c_scl: p0_2_scb0_i2c_scl {
 				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_ACT_7)>;

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.104-m-csp-ble.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.104-m-csp-ble.dtsi
@@ -14,11 +14,9 @@
 		/delete-node/ gpio@40320100; // gpio_prt2
 		/delete-node/ gpio@40320180; // gpio_prt3
 		/delete-node/ gpio@40320200; // gpio_prt4
-
 		/delete-node/ gpio@40320700; // gpio_prt14
 
 		pinctrl: pinctrl@40310000 {
-
 			/* scb_i2c_scl */
 			/omit-if-no-ref/ p0_2_scb0_i2c_scl: p0_2_scb0_i2c_scl {
 				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_ACT_7)>;

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.116-bga-ble.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.116-bga-ble.dtsi
@@ -14,11 +14,9 @@
 		/delete-node/ gpio@40320100; // gpio_prt2
 		/delete-node/ gpio@40320180; // gpio_prt3
 		/delete-node/ gpio@40320200; // gpio_prt4
-
 		/delete-node/ gpio@40320700; // gpio_prt14
 
 		pinctrl: pinctrl@40310000 {
-
 			/* scb_i2c_scl */
 			/omit-if-no-ref/ p0_2_scb0_i2c_scl: p0_2_scb0_i2c_scl {
 				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_ACT_7)>;

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.116-bga-usb.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.116-bga-usb.dtsi
@@ -16,7 +16,6 @@
 		/delete-node/ gpio@40320200; // gpio_prt4
 
 		pinctrl: pinctrl@40310000 {
-
 			/* scb_i2c_scl */
 			/omit-if-no-ref/ p0_2_scb0_i2c_scl: p0_2_scb0_i2c_scl {
 				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_ACT_7)>;

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.124-bga-sip.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.124-bga-sip.dtsi
@@ -11,12 +11,11 @@
 
 / {
 	soc {
+		/delete-node/ gpio@40320100; // gpio_prt2
+		/delete-node/ gpio@40320180; // gpio_prt3
+		/delete-node/ gpio@40320200; // gpio_prt4
+
 		pinctrl: pinctrl@40310000 {
-
-			/delete-node/ gpio_prt2;
-			/delete-node/ gpio_prt3;
-			/delete-node/ gpio_prt4;
-
 			/* scb_i2c_scl */
 			/omit-if-no-ref/ p0_2_scb0_i2c_scl: p0_2_scb0_i2c_scl {
 				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_ACT_7)>;

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.124-bga.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.124-bga.dtsi
@@ -11,8 +11,8 @@
 
 / {
 	soc {
-		pinctrl: pinctrl@40310000 {
 
+		pinctrl: pinctrl@40310000 {
 			/* scb_i2c_scl */
 			/omit-if-no-ref/ p0_2_scb0_i2c_scl: p0_2_scb0_i2c_scl {
 				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_ACT_7)>;

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.43-smt.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.43-smt.dtsi
@@ -15,16 +15,12 @@
 		/delete-node/ gpio@40320100; // gpio_prt2
 		/delete-node/ gpio@40320180; // gpio_prt3
 		/delete-node/ gpio@40320200; // gpio_prt4
-
 		/delete-node/ gpio@40320400; // gpio_prt8
-
 		/delete-node/ gpio@40320580; // gpio_prt11
-
 		/delete-node/ gpio@40320680; // gpio_prt13
 		/delete-node/ gpio@40320700; // gpio_prt14
 
 		pinctrl: pinctrl@40310000 {
-
 			/* scb_i2c_scl */
 			/omit-if-no-ref/ p5_0_scb5_i2c_scl: p5_0_scb5_i2c_scl {
 				pinmux = <DT_CAT1_PINMUX(5, 0, HSIOM_SEL_ACT_7)>;

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.68-qfn-ble.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.68-qfn-ble.dtsi
@@ -15,12 +15,11 @@
 		/delete-node/ gpio@40320100; // gpio_prt2
 		/delete-node/ gpio@40320180; // gpio_prt3
 		/delete-node/ gpio@40320200; // gpio_prt4
-
+		/delete-node/ gpio@40320280; // gpio_prt5
 		/delete-node/ gpio@40320680; // gpio_prt13
 		/delete-node/ gpio@40320700; // gpio_prt14
 
 		pinctrl: pinctrl@40310000 {
-
 			/* scb_i2c_scl */
 			/omit-if-no-ref/ p0_2_scb0_i2c_scl: p0_2_scb0_i2c_scl {
 				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_ACT_7)>;

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.80-wlcsp.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.80-wlcsp.dtsi
@@ -14,11 +14,9 @@
 		/delete-node/ gpio@40320100; // gpio_prt2
 		/delete-node/ gpio@40320180; // gpio_prt3
 		/delete-node/ gpio@40320200; // gpio_prt4
-
 		/delete-node/ gpio@40320680; // gpio_prt13
 
 		pinctrl: pinctrl@40310000 {
-
 			/* scb_i2c_scl */
 			/omit-if-no-ref/ p0_2_scb0_i2c_scl: p0_2_scb0_i2c_scl {
 				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_ACT_7)>;

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.dtsi
@@ -68,142 +68,142 @@
 				interrupts = <15 6>, <16 6>;
 				status = "disabled";
 			};
-		};
 
-		gpio_prt0: gpio@40320000 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320000 0x80>;
-			interrupts = <0 6>;
-			gpio-controller;
-			ngpios = <6>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt1: gpio@40320080 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320080 0x80>;
-			interrupts = <1 6>;
-			gpio-controller;
-			ngpios = <6>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt2: gpio@40320100 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320100 0x80>;
-			interrupts = <2 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt3: gpio@40320180 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320180 0x80>;
-			interrupts = <3 6>;
-			gpio-controller;
-			ngpios = <6>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt4: gpio@40320200 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320200 0x80>;
-			interrupts = <4 6>;
-			gpio-controller;
-			ngpios = <2>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt5: gpio@40320280 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320280 0x80>;
-			interrupts = <5 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt6: gpio@40320300 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320300 0x80>;
-			interrupts = <6 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt7: gpio@40320380 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320380 0x80>;
-			interrupts = <7 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt8: gpio@40320400 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320400 0x80>;
-			interrupts = <8 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt9: gpio@40320480 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320480 0x80>;
-			interrupts = <9 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt10: gpio@40320500 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320500 0x80>;
-			interrupts = <10 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt11: gpio@40320580 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320580 0x80>;
-			interrupts = <11 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt12: gpio@40320600 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320600 0x80>;
-			interrupts = <12 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt13: gpio@40320680 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320680 0x80>;
-			interrupts = <13 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt14: gpio@40320700 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40320700 0x80>;
-			interrupts = <14 6>;
-			gpio-controller;
-			ngpios = <2>;
-			status = "disabled";
-			#gpio-cells = <2>;
+			gpio_prt0: gpio@40320000 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320000 0x80>;
+				interrupts = <0 6>;
+				gpio-controller;
+				ngpios = <6>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt1: gpio@40320080 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320080 0x80>;
+				interrupts = <1 6>;
+				gpio-controller;
+				ngpios = <6>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt2: gpio@40320100 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320100 0x80>;
+				interrupts = <2 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt3: gpio@40320180 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320180 0x80>;
+				interrupts = <3 6>;
+				gpio-controller;
+				ngpios = <6>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt4: gpio@40320200 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320200 0x80>;
+				interrupts = <4 6>;
+				gpio-controller;
+				ngpios = <2>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt5: gpio@40320280 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320280 0x80>;
+				interrupts = <5 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt6: gpio@40320300 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320300 0x80>;
+				interrupts = <6 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt7: gpio@40320380 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320380 0x80>;
+				interrupts = <7 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt8: gpio@40320400 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320400 0x80>;
+				interrupts = <8 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt9: gpio@40320480 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320480 0x80>;
+				interrupts = <9 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt10: gpio@40320500 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320500 0x80>;
+				interrupts = <10 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt11: gpio@40320580 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320580 0x80>;
+				interrupts = <11 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt12: gpio@40320600 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320600 0x80>;
+				interrupts = <12 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt13: gpio@40320680 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320680 0x80>;
+				interrupts = <13 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt14: gpio@40320700 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40320700 0x80>;
+				interrupts = <14 6>;
+				gpio-controller;
+				ngpios = <2>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
 		};
 
 		adc0: adc@411f0000 {
@@ -284,15 +284,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			interrupts = <18 6>;
-			status = "disabled";
-		};
-
-		spi0: spi@40610000 {
-			compatible = "infineon,cat1-spi";
-			reg = <0x40610000 0x10000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			interrupts = <41 6>;
 			status = "disabled";
 		};
 

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.dtsi
@@ -12,7 +12,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu0: cpu@0 {
+		cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
@@ -32,7 +32,7 @@
 
 		flash0: flash@10000000 {
 			compatible = "soc-nv-flash";
-			reg = <0x10000000 0x80000>;
+			reg = <0x10000000 0x100000>;
 			write-block-size = <512>;
 			erase-block-size = <512>;
 		};
@@ -46,16 +46,10 @@
 
 	sram0: memory@8000000 {
 		compatible = "mmio-sram";
-		reg = <0x8000000 0x20000>;
+		reg = <0x8000000 0x48000>;
 	};
 
 	soc {
-		uid: device_uid@16000600 {
-			compatible = "infineon,cat1-uid";
-			reg = <0x16000600 0xb>;
-			status = "disabled";
-		};
-
 		pinctrl: pinctrl@40310000 {
 			compatible = "infineon,cat1-pinctrl";
 			reg = <0x40310000 0x20000>;
@@ -204,6 +198,11 @@
 				status = "disabled";
 				#gpio-cells = <2>;
 			};
+		};
+		uid: device_uid@16000600 {
+			compatible = "infineon,cat1-uid";
+			reg = <0x16000600 0xb>;
+			status = "disabled";
 		};
 
 		adc0: adc@411f0000 {

--- a/dts/arm/infineon/psoc6/psoc6_02/psoc6_02.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_02/psoc6_02.dtsi
@@ -21,141 +21,142 @@
 				interrupts = <15 6>, <16 6>;
 				status = "disabled";
 			};
-		};
-		gpio_prt0: gpio@40310000 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310000 0x80>;
-			interrupts = <0 6>;
-			gpio-controller;
-			ngpios = <6>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt1: gpio@40310080 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310080 0x80>;
-			interrupts = <1 6>;
-			gpio-controller;
-			ngpios = <6>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt2: gpio@40310100 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310100 0x80>;
-			interrupts = <2 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt3: gpio@40310180 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310180 0x80>;
-			interrupts = <3 6>;
-			gpio-controller;
-			ngpios = <6>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt4: gpio@40310200 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310200 0x80>;
-			interrupts = <4 6>;
-			gpio-controller;
-			ngpios = <2>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt5: gpio@40310280 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310280 0x80>;
-			interrupts = <5 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt6: gpio@40310300 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310300 0x80>;
-			interrupts = <6 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt7: gpio@40310380 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310380 0x80>;
-			interrupts = <7 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt8: gpio@40310400 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310400 0x80>;
-			interrupts = <8 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt9: gpio@40310480 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310480 0x80>;
-			interrupts = <9 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt10: gpio@40310500 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310500 0x80>;
-			interrupts = <10 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt11: gpio@40310580 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310580 0x80>;
-			interrupts = <11 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt12: gpio@40310600 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310600 0x80>;
-			interrupts = <12 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt13: gpio@40310680 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310680 0x80>;
-			interrupts = <13 6>;
-			gpio-controller;
-			ngpios = <8>;
-			status = "disabled";
-			#gpio-cells = <2>;
-		};
-		gpio_prt14: gpio@40310700 {
-			compatible = "infineon,cat1-gpio";
-			reg = <0x40310700 0x80>;
-			interrupts = <14 6>;
-			gpio-controller;
-			ngpios = <2>;
-			status = "disabled";
-			#gpio-cells = <2>;
+
+			gpio_prt0: gpio@40310000 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310000 0x80>;
+				interrupts = <0 6>;
+				gpio-controller;
+				ngpios = <6>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt1: gpio@40310080 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310080 0x80>;
+				interrupts = <1 6>;
+				gpio-controller;
+				ngpios = <6>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt2: gpio@40310100 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310100 0x80>;
+				interrupts = <2 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt3: gpio@40310180 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310180 0x80>;
+				interrupts = <3 6>;
+				gpio-controller;
+				ngpios = <6>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt4: gpio@40310200 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310200 0x80>;
+				interrupts = <4 6>;
+				gpio-controller;
+				ngpios = <2>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt5: gpio@40310280 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310280 0x80>;
+				interrupts = <5 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt6: gpio@40310300 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310300 0x80>;
+				interrupts = <6 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt7: gpio@40310380 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310380 0x80>;
+				interrupts = <7 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt8: gpio@40310400 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310400 0x80>;
+				interrupts = <8 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt9: gpio@40310480 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310480 0x80>;
+				interrupts = <9 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt10: gpio@40310500 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310500 0x80>;
+				interrupts = <10 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt11: gpio@40310580 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310580 0x80>;
+				interrupts = <11 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt12: gpio@40310600 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310600 0x80>;
+				interrupts = <12 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt13: gpio@40310680 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310680 0x80>;
+				interrupts = <13 6>;
+				gpio-controller;
+				ngpios = <8>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
+			gpio_prt14: gpio@40310700 {
+				compatible = "infineon,cat1-gpio";
+				reg = <0x40310700 0x80>;
+				interrupts = <14 6>;
+				gpio-controller;
+				ngpios = <2>;
+				status = "disabled";
+				#gpio-cells = <2>;
+			};
 		};
 		scb0: scb@40600000 {
 			compatible = "infineon,cat1-scb";

--- a/dts/arm/infineon/psoc6/psoc6_02/psoc6_02.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_02/psoc6_02.dtsi
@@ -8,6 +8,47 @@
 #include <mem.h>
 
 / {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m0+";
+			reg = <0>;
+		};
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m4f";
+			reg = <1>;
+		};
+	};
+
+	flash-controller@40240000 {
+		compatible = "infineon,cat1-flash-controller";
+		reg = < 0x40240000 0x10000 >;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		flash0: flash@10000000 {
+			compatible = "soc-nv-flash";
+			reg = <0x10000000 0x200000>;
+			write-block-size = <512>;
+			erase-block-size = <512>;
+		};
+		flash1: flash@14000000 {
+			compatible = "soc-nv-flash";
+			reg = <0x14000000 0x8000>;
+			write-block-size = <512>;
+			erase-block-size = <512>;
+		};
+	};
+
+	sram0: memory@8000000 {
+		compatible = "mmio-sram";
+		reg = <0x8000000 0x100000>;
+	};
+
 	soc {
 		pinctrl: pinctrl@40300000 {
 			compatible = "infineon,cat1-pinctrl";

--- a/dts/bindings/i2c/infineon,cat1-i2c.yaml
+++ b/dts/bindings/i2c/infineon,cat1-i2c.yaml
@@ -7,7 +7,7 @@ description: Infineon CAT1 I2C
 
 compatible: "infineon,cat1-i2c"
 
-include: [i2c-controller.yaml, pinctrl-device.yaml]
+include: [i2c-controller.yaml, pinctrl-device.yaml, "infineon,cat1-scb.yaml"]
 
 properties:
   reg:

--- a/dts/bindings/serial/infineon,cat1-uart.yaml
+++ b/dts/bindings/serial/infineon,cat1-uart.yaml
@@ -9,7 +9,7 @@ description: Infineon CAT1 UART
 
 compatible: "infineon,cat1-uart"
 
-include: [uart-controller.yaml, pinctrl-device.yaml]
+include: [uart-controller.yaml, pinctrl-device.yaml, "infineon,cat1-scb.yaml"]
 
 properties:
   reg:


### PR DESCRIPTION
Cleanup PSoC06 DTSI files

- Update the default Flash and SRAM size to 1024kb and 288kb, Update the
mpn file overrides accordingly

- cpu@0 node is not supported on some mpn's so it should be deleted from
the mpn files and not the package files.

- Remove the spi node from an older commit since its replaced with the
SCB node now

- GPIO nodes should have been part of pinctrl

- Include the infineon,cat1-scb.yaml for I2c and UART bindings to convey
that they are using SCB (Serial Control Block)
