### PR TITLE
boards: nrf5340: use nrf_reset_network_force_off

### DIFF
--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpunet_reset.c
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpunet_reset.c
@@ -10,6 +10,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
+#include <hal/nrf_reset.h>
 
 LOG_MODULE_REGISTER(bl5340_dvk_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -49,7 +50,7 @@ static int remoteproc_mgr_boot(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_cpunet_reset.c
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_cpunet_reset.c
@@ -9,6 +9,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
+#include <hal/nrf_reset.h>
 
 #include <nrfx_gpiote.h>
 
@@ -71,7 +72,7 @@ static int remoteproc_mgr_boot(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpunet_reset.c
@@ -9,6 +9,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
+#include <hal/nrf_reset.h>
 
 LOG_MODULE_REGISTER(nrf5340dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -48,7 +49,7 @@ static int remoteproc_mgr_boot(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/arm/thingy53_nrf5340/board.c
+++ b/boards/arm/thingy53_nrf5340/board.c
@@ -8,6 +8,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <soc.h>
+#include <hal/nrf_reset.h>
 
 LOG_MODULE_REGISTER(thingy53_board_init);
 
@@ -51,7 +52,7 @@ static void enable_cpunet(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */


### PR DESCRIPTION
The function nrf_reset_network_force_off contains workaround for errata 161 for nRF5340 SoC. This function should be used instead of manual writing to NRF_RESET->NETWORK.FORCEOFF register.