### PR TITLE
drivers: adc: stm32: allow to use multiple ADCs with STM32F3 series

### DIFF
--- a/drivers/adc/Kconfig.stm32
+++ b/drivers/adc/Kconfig.stm32
@@ -23,7 +23,7 @@ config ADC_STM32_DMA
 	  Enable the ADC DMA mode for ADC instances
 	  that enable dma channels in their device tree node.
 
-if SOC_SERIES_STM32F2X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32G4X
+if SOC_SERIES_STM32F2X || (SOC_SERIES_STM32F3X && !SOC_STM32F373XC) || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32G4X
 
 config ADC_STM32_SHARED_IRQS
 	bool "STM32 ADC shared interrupts"

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1393,11 +1393,11 @@ static const struct adc_driver_api api_stm32_driver_api = {
 
 bool adc_stm32_is_irq_active(ADC_TypeDef *adc)
 {
-#if defined(CONFIG_SOC_SERIES_STM32G4X)
-	return LL_ADC_IsActiveFlag_EOC(adc) ||
-#else
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc)
 	return LL_ADC_IsActiveFlag_EOCS(adc) ||
-#endif /* CONFIG_SOC_SERIES_STM32G4X */
+#else
+	return LL_ADC_IsActiveFlag_EOC(adc) ||
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc) */
 	       LL_ADC_IsActiveFlag_OVR(adc) ||
 	       LL_ADC_IsActiveFlag_JEOS(adc) ||
 	       LL_ADC_IsActiveFlag_AWD1(adc);

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -156,5 +156,21 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
 		};
+
+		adc2: adc@50000100 {
+			compatible = "st,stm32-adc";
+			reg = <0x50000100 0x4c>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
+			interrupts = <18 0>;
+			status = "disabled";
+			vref-mv = <3000>;
+			#io-channel-cells = <1>;
+			vref-channel = <18>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 3 5 8 20 62 182 602>;
+		};
 	};
 };


### PR DESCRIPTION
STM32F3 have multiple ADCs that share the same IRQ.