### PR TITLE
MAINTAINERS: Fix outdated reference to modules/Kconfig.mcuboot_bootutil

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3034,7 +3034,7 @@ West:
     - de-nordic
     - nordicjm
   files:
-    - modules/Kconfig.mcuboot_bootutil
+    - modules/Kconfig.mcuboot
     - tests/boot/test_mcuboot/
   labels:
     - manifest-mcuboot


### PR DESCRIPTION
The commit 837245fcecf1883d37540db04b562003918d0cf2 relocated `modules/Kconfig.mcuboot_bootutil` to `modules/Kconfig.mcuboot`.

---

Hotfix for the currently failing "Pull Request Assigner" workflow.