### PR TITLE
Fix arm64 FPU deadlock

### DIFF
--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -153,6 +153,10 @@ static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)
 
 #ifdef CONFIG_SMP
 	while (!atomic_cas(&l->locked, 0, 1)) {
+#if defined(CONFIG_ARM64) && defined(CONFIG_FPU_SHARING)
+		extern void z_arm64_flush_local_fpu_proactive(void);
+		z_arm64_flush_local_fpu_proactive();
+#endif
 	}
 #endif
 


### PR DESCRIPTION
[RFC] As discussed in #58056, this PR fixed arm64 FPU deadlock but is really a workaround. Expecting a better way to fix the issue

Using FPU with FPU sharing in a spin-locked critical section might cause a 'deadlock'. When core 0 got a spinlock that other cores are waiting for, it will 'deadlock' if the core 0 current threads' FPU context is living in another one that is waiting for the spinlock but never receives the FPU IPI. 

The issue is found in the test case `tests/lib/p4workq/` `test_stress` with SMP on the arm FVP platform
threads use spinlock to sync, core 0 got a spinlock, other cores (say core 1,2,3) are waiting in `cas` loop (spinlock, with IRQ disabled). The test case on core 0 goes into the spin-locked section and calls the `assert` which will access FPU registers thus causing an FPU trap. Then it finds out the current thread's FPU context is living in core 1. So core 0 raises IPI to inform core 1 to save the FPU context. But core 1 is in spinlock with IRQ disabled, so deadlock happens.

CC @npitre @carlocaione 