### PR TITLE
net: openthread: Fix double initialization problem in openthread usb.

### DIFF
--- a/modules/openthread/platform/uart.c
+++ b/modules/openthread/platform/uart.c
@@ -173,7 +173,7 @@ otError otPlatUartEnable(void)
 		uint32_t dtr = 0U;
 
 		ret = usb_enable(NULL);
-		if (ret != 0) {
+		if (ret != 0 && ret != -EALREADY) {
 			LOG_ERR("Failed to enable USB");
 			return OT_ERROR_FAILED;
 		}


### PR DESCRIPTION
nRF52 in case of USB CDC required `CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT=n` Due to incorrect error check in `otPlatUartEnable`.