### PR TITLE
intc: miwu: npcx: Add wui info of registerd callbaock in miwu driver

### DIFF
--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -176,8 +176,8 @@ static const struct npcx_vw_out_config vw_out_gpio_tbl1[] = {
 };
 
 /* Callbacks for eSPI bus reset and Virtual Wire signals. */
-static struct miwu_callback espi_rst_callback;
-static struct miwu_callback vw_in_callback[ARRAY_SIZE(vw_in_tbl)];
+static struct miwu_dev_callback espi_rst_callback;
+static struct miwu_dev_callback vw_in_callback[ARRAY_SIZE(vw_in_tbl)];
 
 /* eSPI VW service function forward declarations */
 static int espi_npcx_receive_vwire(const struct device *dev,
@@ -188,7 +188,7 @@ static void espi_vw_send_bootload_done(const struct device *dev);
 
 /* eSPI local initialization functions */
 static void espi_init_wui_callback(const struct device *dev,
-		struct miwu_callback *callback, const struct npcx_wui *wui,
+		struct miwu_dev_callback *callback, const struct npcx_wui *wui,
 		miwu_dev_callback_handler_t handler)
 {
 	/* VW signal which has no wake-up input source */
@@ -197,7 +197,7 @@ static void espi_init_wui_callback(const struct device *dev,
 
 	/* Install callback function */
 	npcx_miwu_init_dev_callback(callback, wui, handler, dev);
-	npcx_miwu_manage_callback(callback, 1);
+	npcx_miwu_manage_dev_callback(callback, 1);
 
 	/* Configure MIWU setting and enable its interrupt */
 	npcx_miwu_interrupt_configure(wui, NPCX_MIWU_MODE_EDGE,

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -356,7 +356,6 @@ static int gpio_npcx_manage_callback(const struct device *dev,
 				      struct gpio_callback *callback, bool set)
 {
 	const struct gpio_npcx_config *const config = dev->config;
-	struct miwu_callback *miwu_cb = (struct miwu_callback *)callback;
 	int pin = find_lsb_set(callback->pin_mask) - 1;
 
 	/* pin_mask should not be zero */
@@ -372,11 +371,10 @@ static int gpio_npcx_manage_callback(const struct device *dev,
 	}
 
 	/* Initialize WUI information in unused bits field */
-	npcx_miwu_init_gpio_callback(miwu_cb, &config->wui_maps[pin],
-			config->port);
+	npcx_miwu_init_gpio_callback(&config->wui_maps[pin], config->port, pin);
 
 	/* Insert or remove a IO callback which being called in MIWU ISRs */
-	return npcx_miwu_manage_callback(miwu_cb, set);
+	return npcx_miwu_manage_gpio_callback(callback, &config->wui_maps[pin], set);
 }
 
 /* GPIO driver registration */

--- a/drivers/kscan/kscan_npcx.c
+++ b/drivers/kscan/kscan_npcx.c
@@ -59,7 +59,7 @@ struct kscan_npcx_data {
 	uint8_t matrix_new_state[KSCAN_COL_SIZE];
 	/* Index in to the scan_clock_cycle to indicate start of debouncing */
 	uint8_t scan_cycle_idx[KSCAN_COL_SIZE * KSCAN_ROW_SIZE];
-	struct miwu_callback ksi_callback[KSCAN_ROW_SIZE];
+	struct miwu_dev_callback ksi_callback[KSCAN_ROW_SIZE];
 	/* Track previous "elapsed clock cycles" per matrix scan. This
 	 * is used to calculate the debouncing time for every key
 	 */
@@ -393,7 +393,7 @@ static void kscan_matrix_polling_thread(const struct device *dev, void *dummy2, 
 }
 
 static void kscan_npcx_init_ksi_wui_callback(const struct device *dev,
-					     struct miwu_callback *callback,
+					     struct miwu_dev_callback *callback,
 					     const struct npcx_wui *wui,
 					     miwu_dev_callback_handler_t handler)
 {
@@ -404,7 +404,7 @@ static void kscan_npcx_init_ksi_wui_callback(const struct device *dev,
 
 	/* Install callback function */
 	npcx_miwu_init_dev_callback(callback, wui, handler, dev);
-	npcx_miwu_manage_callback(callback, 1);
+	npcx_miwu_manage_dev_callback(callback, 1);
 
 	/* Configure MIWU setting and enable its interrupt */
 	npcx_miwu_interrupt_configure(wui, NPCX_MIWU_MODE_EDGE, NPCX_MIWU_TRIG_BOTH);

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -47,7 +47,7 @@ enum uart_pm_policy_state_flag {
 struct uart_npcx_data {
 	/* Baud rate */
 	uint32_t baud_rate;
-	struct miwu_callback uart_rx_cb;
+	struct miwu_dev_callback uart_rx_cb;
 	struct k_spinlock lock;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t user_cb;
@@ -519,7 +519,7 @@ static int uart_npcx_init(const struct device *dev)
 		/* Initialize a miwu device input and its callback function */
 		npcx_miwu_init_dev_callback(&data->uart_rx_cb, &config->uart_rx_wui,
 					    uart_npcx_rx_wk_isr, dev);
-		npcx_miwu_manage_callback(&data->uart_rx_cb, true);
+		npcx_miwu_manage_dev_callback(&data->uart_rx_cb, true);
 		/*
 		 * Configure the UART wake-up event triggered from a falling
 		 * edge on CR_SIN pin. No need for callback function.

--- a/drivers/watchdog/wdt_npcx.c
+++ b/drivers/watchdog/wdt_npcx.c
@@ -82,7 +82,7 @@ struct wdt_npcx_data {
 	bool timeout_installed;
 };
 
-struct miwu_callback miwu_cb;
+struct miwu_dev_callback miwu_cb;
 
 /* Driver convenience defines */
 #define HAL_INSTANCE(dev) ((struct twd_reg *)((const struct wdt_npcx_config *)(dev)->config)->base)
@@ -153,7 +153,7 @@ static void wdt_config_t0out_interrupt(const struct device *dev)
 	/* Initialize a miwu device input and its callback function */
 	npcx_miwu_init_dev_callback(&miwu_cb, &config->t0out, wdt_t0out_isr,
 			dev);
-	npcx_miwu_manage_callback(&miwu_cb, true);
+	npcx_miwu_manage_dev_callback(&miwu_cb, true);
 
 	/*
 	 * Configure the T0 wake-up event triggered from a rising edge

--- a/soc/arm/nuvoton_npcx/common/soc_miwu.h
+++ b/soc/arm/nuvoton_npcx/common/soc_miwu.h
@@ -50,12 +50,6 @@ enum miwu_int_trig {
 	NPCX_MIWU_TRIG_BOTH, /** Both edge rising and failing detection */
 };
 
-/* NPCX miwu driver callback type */
-enum {
-	NPCX_MIWU_CALLBACK_GPIO,
-	NPCX_MIWU_CALLBACK_DEV,
-};
-
 /**
  * @brief NPCX wake-up input source structure
  *
@@ -69,6 +63,17 @@ struct npcx_wui {
 };
 
 /**
+ * @brief NPCX wake-up input of GPIO structure
+ *
+ * It contains GPIO information which is used for distinguishing which wui event
+ * occurs in its ISR.
+ */
+struct wui_io {
+	uint8_t port:5; /** Up to 32 GPIO devices */
+	uint8_t pin:3; /** GPIO pin (0-7) */
+};
+
+/**
  * Define npcx miwu driver callback handler signature for wake-up input source
  * of generic hardware. Its parameters contain the device issued interrupt
  * and corresponding WUI source.
@@ -77,58 +82,22 @@ typedef void (*miwu_dev_callback_handler_t)(const struct device *source,
 							struct npcx_wui *wui);
 
 /**
- * @brief MIWU/GPIO information structure
+ * @brief MIWU callback structure for a device input
  *
- * It contains both GPIO and MIWU information which is stored in unused field
- * of struct gpio_port_pins_t since a interested mask of pins is only 8 bits.
- * Beware the size of such structure must equal struct gpio_port_pins_t.
- */
-struct miwu_io_params {
-	uint8_t pin_mask; /** A mask of pins the callback is interested in. */
-	uint8_t gpio_port; /** GPIO device index */
-	uint8_t cb_type; /** Callback type */
-	struct npcx_wui wui; /** Wake-up input source of GPIO */
-};
-
-/**
- * @brief MIWU/generic device information structure
- *
- * It contains the information used for MIWU generic device event. Please notice
- * the offset of cb_type must be the same as cb_type in struct miwu_io_params.
- */
-struct miwu_dev_params {
-	uint8_t reserve1;
-	uint8_t reserve2;
-	uint8_t cb_type; /** Callback type */
-	struct npcx_wui wui; /** Device instance register callback function */
-	const struct device *source; /** Wake-up input source */
-};
-
-/**
- * @brief MIWU callback structure for a gpio or device input
- *
- * Used to register a generic gpio/device callback in the driver instance
+ * Used to register a generic hardware device callback in the driver instance
  * callback list. Beware such structure should not be allocated on stack.
  *
- * Note: To help setting it, see npcx_miwu_init_dev_callback() and
- *       npcx_miwu_manage_callback() below
+ * Note: To help setting it, see npcx_miwu_init_dev_callback() below
  */
-struct miwu_callback {
+struct miwu_dev_callback {
 	/** Node of single-linked list */
 	sys_snode_t node;
-	union {
-		struct {
-			/** Callback function being called when GPIO event occurred */
-			gpio_callback_handler_t handler;
-			struct miwu_io_params params;
-		} io_cb;
-
-		struct {
-			/** Callback function being called when device event occurred */
-			miwu_dev_callback_handler_t handler;
-			struct miwu_dev_params params;
-		} dev_cb;
-	};
+	/** Callback function being called when device event occurred */
+	miwu_dev_callback_handler_t handler;
+	/** Device instance register callback function */
+	const struct device *source;
+	/* Wake-up input source */
+	struct npcx_wui wui;
 };
 
 /**
@@ -191,38 +160,51 @@ int npcx_miwu_interrupt_configure(const struct npcx_wui *wui,
 		enum miwu_int_mode mode, enum miwu_int_trig trig);
 
 /**
- * @brief Function to initialize a struct miwu_callback with gpio properly
+ * @brief Function to initialize a struct miwu_io_callback properly
  *
- * @param callback Pointer to io callback structure for initialization
  * @param io_wui Pointer to wake-up input IO source
  * @param port GPIO port issued a callback function
+ * @param pin GPIO pin issued a callback function
  */
-void npcx_miwu_init_gpio_callback(struct miwu_callback *callback,
-				const struct npcx_wui *io_wui, int port);
+void npcx_miwu_init_gpio_callback(const struct npcx_wui *io_wui, int port, int pin);
 
 /**
- * @brief Function to initialize a struct miwu_callback with device properly
+ * @brief Function to initialize a struct miwu_dev_callback properly
  *
  * @param callback Pointer to device callback structure for initialization
  * @param dev_wui Pointer to wake-up input device source
  * @param handler A function called when its device input event issued
  * @param source Pointer to device instance issued a callback function
  */
-void npcx_miwu_init_dev_callback(struct miwu_callback *callback,
+void npcx_miwu_init_dev_callback(struct miwu_dev_callback *callback,
 				const struct npcx_wui *dev_wui,
 				miwu_dev_callback_handler_t handler,
 				const struct device *source);
 
 /**
- * @brief Function to insert or remove a miwu callback from a callback list
+ * @brief Function to insert or remove a IO callback from a callback list
  *
- * @param callback Pointer to miwu callback structure
+ * @param callback Pointer to io callback structure
+ * @param io_wui Pointer to wake-up input IO source
  * @param set A boolean indicating insertion or removal of the callback
  *
  * @retval 0 If successful.
  * @retval -EINVAL Invalid parameters
  */
-int npcx_miwu_manage_callback(struct miwu_callback *cb, bool set);
+int npcx_miwu_manage_gpio_callback(struct gpio_callback *cb,
+				const struct npcx_wui *io_wui, bool set);
+
+
+/**
+ * @brief Function to insert or remove a device callback from a callback list
+ *
+ * @param callback Pointer to device callback structure
+ * @param set A boolean indicating insertion or removal of the callback
+ *
+ * @retval 0 If successful.
+ * @retval -EINVAL Invalid parameters
+ */
+int npcx_miwu_manage_dev_callback(struct miwu_dev_callback *cb, bool set);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is a further discussion from [PR 57914](https://github.com/zephyrproject-rtos/zephyr/pull/57914)

To remove the deviation of GPIO callback function usage, this PR won't use unused bit fields of `pin_mask` to distinguish when a GPIO event occurs in MIWU's ISR. It reserved a look-up table which size is  196 (3x8x8) bytes to store those configurations instead. Considering the single-list for each MIWU group, the following table is the comparison of RAM usage with the version before [PR 57914](https://github.com/zephyrproject-rtos/zephyr/pull/57914) :

|  Version   |   RO |     RW  |  Total (Uint: bytes)|
| ------------- | ------------- |------------- |------------- |
|PR 57914 |   -100 |   +160   | +60
|This PR  |   +60  |  +380   | +440

And here is the comparison of GPIO interrupt latency with the order of the target callback function in the list:
|  Version      |1st item | 8th item |16th item | 24th item|
| ------------- | ------------- |------------- |------------- |------------- |
| Old version  | 15us   |  25us   |   35us    |     45us |
| PR 57914     | 10us    |  20us |  X  | X  | 
|This PR     | 15us   |  25us   | X  |  X  | 

Ps. We have a mistake in calculating the latency of the 8th item of the list for PR 57914. it should be 20us not 12 us. Sorry for that.

On myst Chromebook, there are 24 gpio interrupt sources and the maximum interrupt latency is ~45us in the old miwu driver (before PR 57914). Besides improving gpio interrupt latency, PR 57914 also improves the interrupt latency of generic devices such as tachometer, eSPI VW events, watchdog, and so on. The maximum latency is 20us no matter source is GPIO or generic devices. But the other approaches need to wait for completing the search of gpio callback list. Then, start to search the items of the generic device callback list. 

Hence, an interrupt latency of generic devices needs to add the maximum interrupt latency of gpio in this PR. If users can choose `pin_mask &= ~BIT(x)` instead of `pin_mask = 0` to cancel gpio callback function, we suggest keeping using PR 57914 since its ram usage is acceptable and improves gpio and device interrupt latency both.

Ps. The CPU clock is 15MHz during calculating the interrupt latency.
