### PR TITLE
kernel: mmu: add direct-map support in z_phys_map()

### DIFF
--- a/include/zephyr/sys/mem_manage.h
+++ b/include/zephyr/sys/mem_manage.h
@@ -55,6 +55,13 @@
 #define K_MEM_PERM_USER		BIT(5)
 
 /*
+ * Region mapping behaviour attributes
+ */
+
+/** Region will be mapped to 1:1 virtual and physical address */
+#define K_MEM_DIRECT_MAP	BIT(6)
+
+/*
  * This is the offset to subtract from a virtual address mapped in the
  * kernel's permanent mapping of RAM, to obtain its physical address.
  *

--- a/kernel/Kconfig.vm
+++ b/kernel/Kconfig.vm
@@ -80,6 +80,22 @@ config KERNEL_VM_SIZE
 	  implement a notion of "high" memory in Zephyr to work around physical
 	  RAM size larger than the defined bounds of the virtual address space.
 
+config KERNEL_DIRECT_MAP
+	bool "Memory region direct-map support"
+	depends on MMU
+	help
+	  This enables the direct-map support, namely the region can be 1:1
+	  mapping between virtual address and physical address.
+
+	  If the specific memory region is in the virtual memory space and
+	  there isn't overlap with the existed mappings, it will reserve the
+	  region from the virtual memory space and do the mapping, otherwise
+	  it will fail. And any attempt across the boundary of the virtual
+	  memory space will fail.
+
+	  Note that this is for compatibility and portable apps shouldn't
+	  be using it.
+
 endif # KERNEL_VM_SUPPORT
 
 menuconfig MMU


### PR DESCRIPTION
Many RTOS applications assume the virtual and physical address is 1:1 mapping, so add the 1:1 mapping support in z_phys_map() to easy adapt these applications.