### PR TITLE
driver: i2c: npcx_controller: use the non I2C device init macro

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -1109,7 +1109,7 @@ static int i2c_ctrl_init(const struct device *dev)
 									       \
 	static struct i2c_ctrl_data i2c_ctrl_data_##inst;                      \
 									       \
-	I2C_DEVICE_DT_INST_DEFINE(inst,                                        \
+	DEVICE_DT_INST_DEFINE(inst,                                            \
 			    NPCX_I2C_CTRL_INIT_FUNC(inst),                     \
 			    NULL,                                              \
 			    &i2c_ctrl_data_##inst, &i2c_ctrl_cfg_##inst,       \


### PR DESCRIPTION
The i2c_npcx_controller does not actually implement the i2c API, that's implemented in the port driver and the controller one is in support of that. This means there's no need to use the I2C specific instance define, as that would end up adding the stats structure that would never get used.

This was originally added in 7b1349cfe6.