### PR TITLE
arch: arm: aarch32: Remove CPU type dependency from CONFIG_FP16

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -285,7 +285,6 @@ endchoice
 
 config FP16
 	bool "Half-precision floating point support"
-	depends on CPU_AARCH32_CORTEX_A || CPU_AARCH32_CORTEX_R || CPU_CORTEX_M55
 	default y
 	help
 	  This option enables the half-precision (16-bit) floating point support


### PR DESCRIPTION
The commit 434ca63e2f55ac07fea45f40f72aaec5c2fcc62f introduced the Cortex-A and Cortex-R CPU type dependency to `CONFIG_FP16` based on the reasoning that the hardware half-precision support is only available on them.

While it is true that the _hardware_ half-precision support is limited to these targets, the compiler will provide the _software_ emulation for the targets that lack the hardware half-precision support, as mentioned in 41fd6e003cb10f8a02023311319566233d621201 (the original commit that introduced `CONFIG_FP16`).