### PR TITLE
drivers: sensor: add helper functions to convert float

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -738,6 +738,17 @@ static inline double sensor_value_to_double(const struct sensor_value *val)
 }
 
 /**
+ * @brief Helper function for converting struct sensor_value to float.
+ *
+ * @param val A pointer to a sensor_value struct.
+ * @return The converted value.
+ */
+static inline float sensor_value_to_float(const struct sensor_value *val)
+{
+	return (float)val->val1 + (float)val->val2 / 1000000;
+}
+
+/**
  * @brief Helper function for converting double to struct sensor_value.
  *
  * @param val A pointer to a sensor_value struct.
@@ -753,6 +764,27 @@ static inline int sensor_value_from_double(struct sensor_value *val, double inp)
 	double val2 = (inp - (int32_t)inp) * 1000000.0;
 
 	if (val2 < INT32_MIN || val2 > INT32_MAX) {
+		return -ERANGE;
+	}
+
+	val->val1 = (int32_t)inp;
+	val->val2 = (int32_t)val2;
+
+	return 0;
+}
+
+/**
+ * @brief Helper function for converting float to struct sensor_value.
+ *
+ * @param val A pointer to a sensor_value struct.
+ * @param inp The converted value.
+ * @return 0 if successful, negative errno code if failure.
+ */
+static inline int sensor_value_from_float(struct sensor_value *val, float inp)
+{
+	float val2 = (inp - (int32_t)inp) * 1000000.0;
+
+	if (val2 < INT32_MIN || val2 > (float)(INT32_MAX - 1)) {
 		return -ERANGE;
 	}
 

--- a/tests/drivers/sensor/generic/src/main.c
+++ b/tests/drivers/sensor/generic/src/main.c
@@ -306,10 +306,25 @@ ZTEST(sensor_api, test_sensor_unit_conversion)
 	/* reset test data to positive value */
 	data.val1 = -data.val1;
 	data.val2 = -data.val2;
-	/* Test struct sensor_value to double */
 #if defined(CONFIG_FPU)
+	/* Test struct sensor_value to double and float */
 	zassert_equal((long long)(sensor_value_to_double(&data) * 1000000LL),
 			SENSOR_PI, "the data does not match");
+	zassert_equal((long long)(sensor_value_to_float(&data) * 1000000LL),
+			SENSOR_PI, "the data does not match");
+
+	/* Test struct sensor_value from double and float */
+	sensor_value_from_double(&data, (double)(SENSOR_PI) / 1000000.0);
+	zassert_equal(data.val1, SENSOR_PI/1000000LL,
+			"the data does not match");
+	zassert_equal(data.val2, SENSOR_PI%(data.val1 * 1000000LL),
+			"the data does not match");
+
+	sensor_value_from_float(&data, (float)(SENSOR_PI) / 1000000.0);
+	zassert_equal(data.val1, SENSOR_PI/1000000LL,
+			"the data does not match");
+	zassert_equal(data.val2, SENSOR_PI%(data.val1 * 1000000LL),
+			"the data does not match");
 #endif
 	/* reset test data to positive value */
 	data.val1 = 3;


### PR DESCRIPTION
These helper functions can be used to avoid dependancy to double type and save some space in ROM.