### PR TITLE
CODEOWNERS: remove myself as mcumgr/smp_udp owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -809,7 +809,6 @@ scripts/build/gen_image_info.py           @tejlmand
 /subsys/mgmt/ec_host_cmd/                 @jettr
 /subsys/mgmt/mcumgr/                      @carlescufi @de-nordic @nordicjm
 /subsys/mgmt/hawkbit/                     @Navin-Sankar
-/subsys/mgmt/mcumgr/transport/src/smp_udp.c @aunsbjerg
 /subsys/mgmt/updatehub/                   @nandojve @otavio
 /subsys/mgmt/osdp/                        @sidcha
 /subsys/modbus/                           @jfischer-no


### PR DESCRIPTION
The mcumgr subsystem as a whole is already maintained by @nordicjm (#57780) and I am no longer actively using mcumgr, so removing myself from the equation and letting more capable hands take over.