### PR TITLE
net: lwm2m: Allow overiding of default socket behaviour

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -163,6 +163,12 @@ struct lwm2m_ctx {
 	 */
 	int (*load_credentials)(struct lwm2m_ctx *client_ctx);
 #endif
+	/** Client can override default socket options by providing
+	 * a callback that is called afer a socket is created and before
+	 * connect.
+	 */
+	int (*set_socketoptions)(struct lwm2m_ctx *client_ctx);
+
 	/** Flag to indicate if context should use DTLS.
 	 *  Enabled via the use of coaps:// protocol prefix in connection
 	 *  information.

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -224,10 +224,22 @@ config LWM2M_TLS_SESSION_CACHING
 	help
 	  Enabling this only when feature is supported in TLS library.
 
+choice
+prompt "Socket handling at idle state"
+
+config LWM2M_RD_CLIENT_CLOSE_SOCKET_AT_IDLE
+	bool "Close socket when entering RX idle"
+
 config LWM2M_RD_CLIENT_SUSPEND_SOCKET_AT_IDLE
-	bool "Socket close is skipped at RX_ON_IDLE state"
-	help
-	  This config suspend socket handler which skip socket polling process.
+	bool "Stop polling on RX idle and close only when resuming"
+
+config  LWM2M_RD_CLIENT_STOP_POLLING_AT_IDLE
+	bool "Stop polling the socket on RX idle"
+
+config  LWM2M_RD_CLIENT_LISTEN_AT_IDLE
+	bool "Keep open and listening"
+
+endchoice
 
 config LWM2M_RD_CLIENT_SUPPORT
 	bool "support for LWM2M client bootstrap/registration state machine"

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -221,9 +221,10 @@ static void set_sm_state(uint8_t sm_state)
 
 	/* Suspend socket after Event callback */
 	if (event == LWM2M_RD_CLIENT_EVENT_QUEUE_MODE_RX_OFF) {
-		if (IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUSPEND_SOCKET_AT_IDLE)) {
+		if (IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUSPEND_SOCKET_AT_IDLE) ||
+		    IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_STOP_POLLING_AT_IDLE)) {
 			lwm2m_socket_suspend(client.ctx);
-		} else {
+		} else if (IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_CLOSE_SOCKET_AT_IDLE)) {
 			lwm2m_close_socket(client.ctx);
 		}
 	}


### PR DESCRIPTION
In order to support external IP stacks that might have Connection ID support, the LwM2M engine should allow client to bypass default behaviour.

New set_socketoptions() callback added into client context that allows overriding all socket opetions. This is called after a socket is opened, but before the connect() is called. This cannot be combined with load_credentials() callback on all platforms as for example nRF91 requires modem offline when credentials are written. This would cause socket to be closed as well.

Second change is that we allow fine tuning of what we do with socket handle when QUEUE mode is enabled and engine enters idle state.

First option would be to close the socket. That would cause TLS Alert(Close Notify) to be send. This is a band choice if LTE modem was already in PSM or eDRX power saving mode.

Second option would be to delay socket closing until we are going to send LwM2M update. There TLS Alert is also send, but most probably lost due to NAT mapping timed out. This is a best choice for LTE modem with DTL session cache enabled.

Two new options are to keep socket open, and either stop listening or just keep listening. Both of these options work fine when we have DTLS Connection ID support.