### PR TITLE
drivers: flash: spi_nor: Add reset pin

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -66,6 +66,10 @@ struct spi_nor_config {
 	/* Devicetree SPI configuration */
 	struct spi_dt_spec spi;
 
+#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
+	const struct gpio_dt_spec reset;
+#endif
+
 	/* Runtime SFDP stores no static configuration. */
 
 #ifndef CONFIG_SPI_NOR_SFDP_RUNTIME
@@ -1143,6 +1147,23 @@ static int spi_nor_configure(const struct device *dev)
 		return -ENODEV;
 	}
 
+#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
+	if (cfg->reset) {
+		if (!device_is_ready(cfg->reset->port)) {
+			LOG_ERR("Reset pin not ready");
+			return -ENODEV;
+		}
+		if (gpio_pin_configure_dt(cfg->reset, GPIO_OUTPUT_ACTIVE)) {
+			LOG_ERR("Couldn't configure reset pin");
+			return -ENODEV;
+		}
+		rc = gpio_pin_set_dt(cfg->reset, 0);
+		if (rc) {
+			return rc;
+		}
+	}
+#endif
+
 	/* After a soft-reset the flash might be in DPD or busy writing/erasing.
 	 * Exit DPD and wait until flash is ready.
 	 */
@@ -1359,6 +1380,10 @@ BUILD_ASSERT(DT_INST_PROP(0, has_lock) == (DT_INST_PROP(0, has_lock) & 0xFF),
 static const struct spi_nor_config spi_nor_config_0 = {
 	.spi = SPI_DT_SPEC_INST_GET(0, SPI_WORD_SET(8),
 				    CONFIG_SPI_NOR_CS_WAIT_DELAY),
+#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
+	.reset = GPIO_DT_SPEC_INST_GET(0, reset_gpios)
+#endif
+
 #if !defined(CONFIG_SPI_NOR_SFDP_RUNTIME)
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)


### PR DESCRIPTION
Add Reset pin initialization during Spi NOR driver start-up. Toggle the pin to reset the device.