### PR TITLE
fix possible deadlock with FPU sharing on ARM64 and RISC-V

### DIFF
--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -57,6 +57,29 @@ bool arm_gic_irq_is_enabled(unsigned int irq)
 	return (enabler & (1 << int_off)) != 0;
 }
 
+bool arm_gic_irq_is_pending(unsigned int irq)
+{
+	int int_grp, int_off;
+	unsigned int enabler;
+
+	int_grp = irq / 32;
+	int_off = irq % 32;
+
+	enabler = sys_read32(GICD_ISPENDRn + int_grp * 4);
+
+	return (enabler & (1 << int_off)) != 0;
+}
+
+void arm_gic_irq_clear_pending(unsigned int irq)
+{
+	int int_grp, int_off;
+
+	int_grp = irq / 32;
+	int_off = irq % 32;
+
+	sys_write32((1 << int_off), (GICD_ICPENDRn + int_grp * 4));
+}
+
 void arm_gic_irq_set_priority(
 	unsigned int irq, unsigned int prio, uint32_t flags)
 {

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -213,6 +213,25 @@ bool arm_gic_irq_is_enabled(unsigned int intid)
 	return (val & mask) != 0;
 }
 
+bool arm_gic_irq_is_pending(unsigned int intid)
+{
+	uint32_t mask = BIT(intid & (GIC_NUM_INTR_PER_REG - 1));
+	uint32_t idx = intid / GIC_NUM_INTR_PER_REG;
+	uint32_t val;
+
+	val = sys_read32(ISPENDR(GET_DIST_BASE(intid), idx));
+
+	return (val & mask) != 0;
+}
+
+void arm_gic_irq_clear_pending(unsigned int intid)
+{
+	uint32_t mask = BIT(intid & (GIC_NUM_INTR_PER_REG - 1));
+	uint32_t idx = intid / GIC_NUM_INTR_PER_REG;
+
+	sys_write32(mask, ICPENDR(GET_DIST_BASE(intid), idx));
+}
+
 unsigned int arm_gic_get_active(void)
 {
 	int intid;

--- a/include/zephyr/drivers/interrupt_controller/gic.h
+++ b/include/zephyr/drivers/interrupt_controller/gic.h
@@ -295,6 +295,21 @@ void arm_gic_irq_disable(unsigned int irq);
 bool arm_gic_irq_is_enabled(unsigned int irq);
 
 /**
+ * @brief Check if an interrupt is pending
+ *
+ * @param irq interrupt ID
+ * @return Returns true if interrupt is pending, false otherwise
+ */
+bool arm_gic_irq_is_pending(unsigned int irq);
+
+/**
+ * @brief Clear the pending irq
+ *
+ * @param irq interrupt ID
+ */
+void arm_gic_irq_clear_pending(unsigned int irq);
+
+/**
  * @brief Set interrupt priority
  *
  * @param irq interrupt ID

--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -153,6 +153,7 @@ static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)
 
 #ifdef CONFIG_SMP
 	while (!atomic_cas(&l->locked, 0, 1)) {
+		arch_spin_relax();
 	}
 #endif
 

--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -1190,6 +1190,16 @@ bool arch_pcie_msi_vector_connect(msi_vector_t *vector,
 
 #endif /* CONFIG_PCIE_MSI_MULTI_VECTOR */
 
+/**
+ * @brief Perform architecture specific processing within spin loops
+ *
+ * This is invoked from busy loops with IRQs disabled such as the contended
+ * spinlock loop. The default implementation is a weak function that calls
+ * arch_nop(). Architectures may implement this function to perform extra
+ * checks or power management tricks if needed.
+ */
+void arch_spin_relax(void);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -106,3 +106,11 @@ void idle(void *unused1, void *unused2, void *unused3)
 #endif
 	}
 }
+
+void __weak arch_spin_relax(void)
+{
+	__ASSERT(!arch_irq_unlocked(arch_irq_lock()),
+		 "this is meant to be called with IRQs disabled");
+
+	arch_nop();
+}


### PR DESCRIPTION
We should allow for architecture-specific special processing while 
waiting on a spinlock.

This is especially critical in the case where such a CPU is being
sent an IPI from a second CPU which already has the same spinlock taken
and is synchronously waiting for that first CPU to process the IPI.
This scenario may occurs on ARM64 and RISC-V with FPU sharing enabled.

This is an alternative to PR #58058 that should benefit all architectures.
