### PR TITLE
Bluetooth: controller: Move DF feat selection to LL_SW_SPLIT KConfig

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -3,17 +3,14 @@
 # Copyright (c) 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-# BT_CTLR_DF_SUPPORT is a wrapper for all DF features.
-# If only certain DF features are supported, those should be selected
-# individually.
+# BT_CTLR_DF_SUPPORT is a wrapper for all DF features. It is referenced by Host
+# to enable its DF related Kconfigs when build together with the Controller.
+# It is required to enable it when Controller supports any DF related feature
+# but particular features are selected individually.
 config BT_CTLR_DF_SUPPORT
 	bool
-	depends on BT_LL_SW_SPLIT && !BT_CTLR_TIFS_HW
-	select BT_CTLR_DF_CTE_TX_SUPPORT
-	select BT_CTLR_DF_ANT_SWITCH_2US_SUPPORT
-	select BT_CTLR_DF_ANT_SWITCH_1US_SUPPORT
-	select BT_CTLR_DF_CTE_RX_SUPPORT
-	select BT_CTLR_DF_CTE_RX_SAMPLE_1US_SUPPORT
+
+if BT_CTLR_DF_SUPPORT
 
 config BT_CTLR_DF_CTE_TX_SUPPORT
 	bool
@@ -32,6 +29,8 @@ config BT_CTLR_DF_ANT_SWITCH_1US_SUPPORT
 
 config BT_CTLR_CTEINLINE_SUPPORT
 	bool
+
+endif # BT_CTLR_DF_SUPPORT
 
 menuconfig BT_CTLR_DF
 	bool "LE Direction Finding"

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -74,6 +74,16 @@ config BT_LLL_VENDOR_OPENISA
 	help
 	  Use OpenISA Lower Link Layer implementation.
 
+# BT_CTLR_DF_SUPPORT is a wrapper for all DF features. Here we select features that are supported by
+# Zephyr's BLE Controller.
+config BT_CTLR_DF_SUPPORT
+	depends on BT_LL_SW_SPLIT && !BT_CTLR_TIFS_HW
+	select BT_CTLR_DF_CTE_TX_SUPPORT
+	select BT_CTLR_DF_ANT_SWITCH_2US_SUPPORT
+	select BT_CTLR_DF_ANT_SWITCH_1US_SUPPORT
+	select BT_CTLR_DF_CTE_RX_SUPPORT
+	select BT_CTLR_DF_CTE_RX_SAMPLE_1US_SUPPORT
+
 config BT_CTLR_XTAL_ADVANCED_SUPPORT
 	bool
 


### PR DESCRIPTION
The BT_CTLR_DF_SUPPORTED KConfig was a wrapper for DF related features
set that are supported by Zephyr's BLE Controller. At the same time the
KConfig is used by Host in compound build to enable BT_DF. That makes
the whole thing a bit coupled with Zephyr's controller.
External implementations of controller must provide same feature set
as Zephyr's Controller or there will be an error during build.

The PR moves the Zephyr's Controller DF supported features set to
BT_LL_SW_SPLIT_DF_SUPPORT KConfig. BT_CTLR_DF_SUPPORTED is now a
top DF_SUPPORTED KConfig option that enables possibility to select
actual DF features. That allows to select individual set of DF
features by any controller implementation and makes possible to
enable BT_DF and build selected DF Host features.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>