### PR TITLE
Fix zephyr module error handling

### DIFF
--- a/doc/develop/west/west-apis.rst
+++ b/doc/develop/west/west-apis.rst
@@ -484,10 +484,10 @@ Manifest and sub-objects
 Exceptions
 ==========
 
-.. autoclass:: west.manifest.MalformedManifest
+.. autoclass:: west.configuration.MalformedConfig
    :show-inheritance:
 
-.. autoclass:: west.manifest.MalformedConfig
+.. autoclass:: west.manifest.MalformedManifest
    :show-inheritance:
 
 .. autoclass:: west.manifest.ManifestVersionError

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -29,7 +29,7 @@ anytree
 intelhex
 
 # it's west
-west>=0.10.1
+west>=0.14.0
 
 # used for windows based 'menuconfig'
 # "win32" is used for 64-bit Windows as well

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -521,14 +521,21 @@ def west_projects(manifest = None):
     # (and thus maybe not installed)
     # if user is providing a specific modules list.
     try:
-        from west.manifest import Manifest, \
-            ManifestImportFailed, MalformedManifest, ManifestVersionError
-        from west.configuration import MalformedConfig
-        from west.util import WestNotFound
-        from west.version import __version__ as WestVersion
+        from west.manifest import Manifest
     except ImportError:
         # West is not installed, so don't return any projects.
         return None
+
+    # If west *is* installed, we need all of the following imports to
+    # work. West versions that are excessively old may fail here:
+    # west.configuration.MalformedConfig was
+    # west.manifest.MalformedConfig until west v0.14.0, for example.
+    # These should be hard errors.
+    from west.manifest import \
+        ManifestImportFailed, MalformedManifest, ManifestVersionError
+    from west.configuration import MalformedConfig
+    from west.util import WestNotFound
+    from west.version import __version__ as WestVersion
 
     from packaging import version
     try:


### PR DESCRIPTION
Commit ce2a7d9a1ad5a0d355e878c294ed3c189f5e7a52
("scripts: zephyr_module: handle expected west errors")
introduced some better error handling that requires
west version v0.14.0 or later to work.

Bump the west version in requirements-base.txt accordingly.

Due to the way zephyr_module.py is handling imports, this API change
resulted in zephyr_module.py running on older versions of west
reacting as if west was not installed, instead of erroring out.
Fix that so users who are on older west will get a hard error.

(We're about to force everyone to move to west v1.1 as soon as I can
get that release done, but this hotfix should still be helpful in the
interim as well.)
