### PR TITLE
driver: adc: infineon: Adding ADC driver support to cy8cproto_063_ble

### DIFF
--- a/boards/arm/cy8cproto_063_ble/cy8cproto_063_ble.yaml
+++ b/boards/arm/cy8cproto_063_ble/cy8cproto_063_ble.yaml
@@ -13,6 +13,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
   - gpio
   - uart
   - i2c

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.dtsi
@@ -211,6 +211,7 @@
 			reg = <0x411f0000 0x10000>;
 			interrupts = <138 6>;
 			status = "disabled";
+			#io-channel-cells = <1>;
 		};
 
 		scb0: scb@40610000 {

--- a/samples/drivers/adc/boards/cy8cproto_063_ble.overlay
+++ b/samples/drivers/adc/boards/cy8cproto_063_ble.overlay
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 1>, <&adc0 2>, <&adc0 3>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 1)>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <0>;   /* P10.0 */
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 1)>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <1>;   /* P10.1 */
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 1)>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <2>;   /* P10.2 */
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 1)>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <3>;   /* P10.3 */
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/cy8cproto_063_ble.overlay
+++ b/tests/drivers/adc/adc_api/boards/cy8cproto_063_ble.overlay
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 1)>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <0>;   /* P10.0 */
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 1)>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <1>;   /* P10.1 */
+	};
+};


### PR DESCRIPTION
- The boards\arm\cy8cproto_063_ble board now has ADC enabled
- This includes overlay files for the test app and sample app