### PR TITLE
drivers:fuel_gauge:sbs_gauge: Fix copy/paste error in RTTF

### DIFF
--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -94,7 +94,7 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 		break;
 	case FUEL_GAUGE_RUNTIME_TO_FULL:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AVG_TIME2FULL, &val);
-		prop->value.runtime_to_empty = val;
+		prop->value.runtime_to_full = val;
 		break;
 	case FUEL_GAUGE_SBS_MFR_ACCESS:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_MANUFACTURER_ACCESS, &val);


### PR DESCRIPTION
Looks like a copy/paste error when copying runtime to empty to runtime to full.  Fixing so that we're assigning to the right union member.