### PR TITLE
west.cmake: make MIN_WEST_VERSION catch up with requirements-base.txt

### DIFF
--- a/cmake/modules/west.cmake
+++ b/cmake/modules/west.cmake
@@ -62,7 +62,8 @@ else()
   # We can import west from PYTHON_EXECUTABLE and have its version.
 
   # Make sure its version matches the minimum required one.
-  set_ifndef(MIN_WEST_VERSION 0.7.1)
+  # Keep this version identical to the one in scripts/requirements-base.txt
+  set_ifndef(MIN_WEST_VERSION 0.14.0)
   if(${west_version} VERSION_LESS ${MIN_WEST_VERSION})
     message(FATAL_ERROR "The detected west version, ${west_version}, is unsupported.\n\
   The minimum supported version is ${MIN_WEST_VERSION}.\n\

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -29,6 +29,7 @@ anytree
 intelhex
 
 # it's west
+# Keep the version identical to the minimum required in cmake/modules/west.cmake
 west>=0.14.0
 
 # used for windows based 'menuconfig'


### PR DESCRIPTION
Also add a comment in each file reminding to keep them the same.

Fixes 251f269e23f6 ("west: v0.14.0 is required now (and soon, v1.1")

Confusing error message before this commit:

```
-- Found west (found suitable version 0.13.1, minimum required is 0.7.1)
CMake Error at SOF/zephyr/cmake/modules/zephyr_module.cmake:77 (message):
  Traceback (most recent call last):

    File "SOF/zephyr/scripts/zephyr_module.py", line 733, in <module>
      main()
    File "SOF/zephyr/scripts/zephyr_module.py", line 678, in main
      west_projs = west_projects()
                   ^^^^^^^^^^^^^^^
    File "SOF/zephyr/scripts/zephyr_module.py", line 536, in west_projects
      from west.configuration import MalformedConfig

  ImportError: cannot import name 'MalformedConfig'
                      from 'west.configuration'
  (west/src/west/configuration.py)
```

Clearer error message after this commit:

```
CMake Error at SOF/zephyr/cmake/modules/west.cmake:68 (message):
  The detected west version, 0.13.1, is unsupported.

    The minimum supported version is 0.14.0.
    Please upgrade with:
        /usr/bin/python3.11 -m pip install --upgrade west
```