### PR TITLE
modules/lib/picolibc: Use version with _ZEPHYR_SOURCE support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -214,7 +214,7 @@ manifest:
       path: modules/lib/openthread
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 93b5d5f2ad44867b60267417cd6d6250dbf68983
+      revision: dc780962322dbaf2b326305f312721ea8cf7c265
     - name: segger
       revision: 4bfaf28a11c3e5ec29badac744fab6d2f342749e
       path: modules/debug/segger


### PR DESCRIPTION
Merge in picolibc support for _ZEPHYR_SOURCE so that picolibc will expose the Zephyr C library API.

Synchronized with sdk-ng PR https://github.com/zephyrproject-rtos/sdk-ng/pull/676