### PR TITLE
lib/libc/picolibc: Use SDK picolibc by default

### DIFF
--- a/lib/libc/picolibc/Kconfig
+++ b/lib/libc/picolibc/Kconfig
@@ -5,11 +5,13 @@ if PICOLIBC
 
 config PICOLIBC_USE_MODULE
 	bool "Picolibc as module"
-	default y
+	default y if "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "zephyr"
 	depends on ZEPHYR_PICOLIBC_MODULE
 	depends on !GLIBCXX_LIBCPP
 	help
-	  Use picolibc module instead of picolibc included with toolchain
+	  Use picolibc module instead of picolibc included with toolchain.
+	  This is enabled by default for toolchains other than the Zephyr
+	  SDK.
 
 config PICOLIBC_HEAP_SIZE
 	int "[DEPRECATED] Picolibc heap size (bytes)"


### PR DESCRIPTION
When using the Zephyr SDK toolchain, prefer the pre-built version of picolibc over using the picolibc module. This will reduce the time it takes to build applications.