### PR TITLE
tests/kernel/common: Add an explicit test using the minimal C library

### DIFF
--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -22,6 +22,11 @@ tests:
       - native_posix
     extra_configs:
       - CONFIG_MISRA_SANE=y
+  kernel.common.minimallibc:
+    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
+    tags: libc
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y
   kernel.common.nano32:
     filter: not CONFIG_KERNEL_COHERENCE
     extra_configs:


### PR DESCRIPTION
When the default C library is switched to picolibc, we need some tests to make sure things still build with the minimal C library.