### PR TITLE
drivers: clock_control: stm32u5: fix chain-load with asserts

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -78,6 +78,10 @@ static uint32_t get_startup_frequency(void)
 		return get_msis_frequency();
 	case LL_RCC_SYS_CLKSOURCE_STATUS_HSI:
 		return STM32_HSI_FREQ;
+	case LL_RCC_SYS_CLKSOURCE_STATUS_HSE:
+		return STM32_HSE_FREQ;
+	case LL_RCC_SYS_CLKSOURCE_STATUS_PLL1:
+		return get_pllsrc_frequency(PLL1_ID);
 	default:
 		__ASSERT(0, "Unexpected startup freq");
 		return 0;

--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -19,3 +19,9 @@ tests:
     integration_platforms:
       - frdm_k64f
       - nrf52840dk_nrf52840
+  boot.mcuboot.assert:
+    tags: mcuboot
+    platform_allow:
+      - b_u585i_iot02a
+    extra_configs:
+      - CONFIG_ASSERT=y


### PR DESCRIPTION
It is possible that stm32_clock_control_init function is started when the image is chain-loaded and hardware clocks are already initialized to some state (PLL1).

Currently due to an assert in get_startup_frequency function (which will trigger k_fatal_halt) the boot will stop on the early stage if CONFIG_ASSERT=y. This is reproducible for example with standalone MCUboot and TF-M with MCUboot.

Fixed by adding support for HSE and PLL1 clock sources at get_startup_frequency. tests/boot/test_mcuboot is modified to do a separate check with CONFIG_ASSERT=y.

There is a draft pull request on the same place, but it is not related to chain-loading (so should not fix this problem): https://github.com/zephyrproject-rtos/zephyr/pull/57224

b_u585i_iot02a test has to be done by openocd runner, as the default stm32cubeprogrammer erases full flash on each sysbuild's domain flashing now.

Test without a fix:

```
$ west twister --device-testing --device-serial /dev/ttyACM0 -p b_u585i_iot02a -T zephyr/tests/boot/test_mcuboot/ --west-flash --west-runner openocd
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.3.0-4116-g6828ebc8c05f
INFO    - Using 'zephyr' toolchain.

Device testing on:
 
| Platform       | ID   | Serial device   |
|----------------|------|-----------------|
| b_u585i_iot02a |      | /dev/ttyACM0    |
 
ERROR   - b_u585i_iot02a            tests/boot/test_mcuboot/boot.mcuboot.assert         FAILED : Timeout
INFO    - Total complete:    2/   2  100%  skipped:    1, failed:    1, error:    0
INFO    - 2 test scenarios (2 test instances) selected, 1 configurations skipped (1 by static filter, 0 at runtime).
INFO    - 0 of 2 test configurations passed (0.00%), 1 failed, 0 errored, 1 skipped with 0 warnings in 91.41 seconds
 ```

After fix:

```
$ west twister --device-testing --device-serial /dev/ttyACM0 -p b_u585i_iot02a -T zephyr/tests/boot/test_mcuboot/ --west-flash --west-runner openocd
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.3.0-4116-g6828ebc8c05f
INFO    - Using 'zephyr' toolchain.
 
Device testing on:
 
| Platform       | ID   | Serial device   |
|----------------|------|-----------------|
| b_u585i_iot02a |      | /dev/ttyACM0    |
 
INFO    - Total complete:    2/   2  100%  skipped:    1, failed:    0, error:    0
INFO    - 2 test scenarios (2 test instances) selected, 1 configurations skipped (1 by static filter, 0 at runtime).
INFO    - 1 of 2 test configurations passed (100.00%), 0 failed, 0 errored, 1 skipped with 0 warnings in 33.36 seconds
INFO    - In total 1 test cases were executed, 1 skipped on 1 out of total 571 platforms (0.18%)
INFO    - 1 test configurations executed on platforms, 0 test configurations were only built.
```