### PR TITLE
NXP: mimxrt1024_evk: Ethernet issue: Fixes #57808

### DIFF
--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -95,8 +95,8 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
-	int-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
-	reset-gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+	int-gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+	reset-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
 	ptp {
 		status = "okay";
 		pinctrl-0 = <&pinmux_ptp>;


### PR DESCRIPTION
PHY reset and GPIO interrupt pins were reversed. Resolves #57808