### PR TITLE
drivers:sensor:adxl372: fix software reset delay

### DIFF
--- a/drivers/sensor/adxl372/adxl372.c
+++ b/drivers/sensor/adxl372/adxl372.c
@@ -398,7 +398,7 @@ static int adxl372_reset(const struct device *dev)
 	}
 	/* Writing code 0x52 resets the device */
 	ret = data->hw_tf->write_reg(dev, ADXL372_RESET, ADXL372_RESET_CODE);
-	k_sleep(K_MSEC(1000));
+	k_sleep(K_MSEC(1));
 
 	return ret;
 }


### PR DESCRIPTION
The indended value for the delay after the software reset of adxl372 is 1ms. Adjust the value accordingly.

Fixes: a3e7cea ("drivers: sensors: adxl372: Add driver for ADXL372 high-g accelerometer")

Related issue: https://github.com/zephyrproject-rtos/zephyr/issues/58099