### PR TITLE
Bluetooth: hci: spi: don't block on IRQ line

### DIFF
--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -411,7 +411,6 @@ static void bt_spi_rx_thread(void)
 static int bt_spi_send(struct net_buf *buf)
 {
 	uint8_t header[5] = { SPI_WRITE, 0x00,  0x00,  0x00,  0x00 };
-	int pending;
 	int ret;
 
 	LOG_DBG("");
@@ -422,15 +421,7 @@ static int bt_spi_send(struct net_buf *buf)
 		return -EINVAL;
 	}
 
-	/* Allow time for the read thread to handle interrupt */
-	while (true) {
-		pending = gpio_pin_get_dt(&irq_gpio);
-		if (pending <= 0) {
-			break;
-		}
-		k_sleep(K_MSEC(1));
-	}
-
+	/* Wait for SPI bus to be available */
 	k_sem_take(&sem_busy, K_FOREVER);
 
 	switch (bt_buf_get_type(buf)) {


### PR DESCRIPTION
Don't wait for the IRQ line to be de-asserted in `bt_spi_send`. As this function can be called by the RX processing thread, the previous behaviour could cause deadlocks under heavy load:
 * SPI RX thread starts blocking on `bt_buf_get_evt` due to load
 * BT controller generates another event, asserting the IRQ line
 * RX processing thread calls `bt_spi_send` in reponse to event
 * RX processing thread blocks forever on the removed condition

There is no need to attempt to rate-limit how often `bt_spi_send` is called to allow the RX thread to run. If the bus is so congested that there is no remaining capacity, prioritising RX over TX is not going to improve the situation.