### PR TITLE
drivers: gpio: andes_atcgpio100: implement port_get_direction function

### DIFF
--- a/drivers/gpio/gpio_andes_atcgpio100.c
+++ b/drivers/gpio/gpio_andes_atcgpio100.c
@@ -288,6 +288,29 @@ static int gpio_atcgpio100_manage_callback(const struct device *port,
 	return gpio_manage_callback(&data->cb, callback, set);
 }
 
+#ifdef CONFIG_GPIO_GET_DIRECTION
+static int gpio_atcgpio100_port_get_dir(const struct device *port,
+					gpio_port_pins_t map,
+					gpio_port_pins_t *inputs,
+					gpio_port_pins_t *outputs)
+{
+	const struct gpio_atcgpio100_config * const dev_cfg = port->config;
+	uint32_t direction = sys_read32(GPIO_DIR(port));
+
+	map &= dev_cfg->common.port_pin_mask;
+
+	if (inputs != NULL) {
+		*inputs = map & ~direction;
+	}
+
+	if (outputs != NULL) {
+		*outputs = map & direction;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_GPIO_GET_DIRECTION */
+
 static void gpio_atcgpio100_irq_handler(const struct device *port)
 {
 	struct gpio_atcgpio100_data * const data = port->data;
@@ -309,6 +332,9 @@ static const struct gpio_driver_api gpio_atcgpio100_api = {
 	.port_toggle_bits        = gpio_atcgpio100_toggle_bits,
 	.pin_interrupt_configure = gpio_atcgpio100_pin_interrupt_configure,
 	.manage_callback         = gpio_atcgpio100_manage_callback
+#ifdef CONFIG_GPIO_GET_DIRECTION
+	.port_get_direction      = gpio_atcgpio100_port_get_dir,
+#endif /* CONFIG_GPIO_GET_DIRECTION */
 };
 
 static int gpio_atcgpio100_init(const struct device *port)

--- a/drivers/gpio/gpio_andes_atcgpio100.c
+++ b/drivers/gpio/gpio_andes_atcgpio100.c
@@ -70,9 +70,6 @@
 #define GPIO_DEBE(dev) (GPIO_BASE(dev) + REG_DEBE)
 #define GPIO_DEBC(dev) (GPIO_BASE(dev) + REG_DEBC)
 
-#define INWORD(x)     sys_read32(x)
-#define OUTWORD(x, d) sys_write32(d, x)
-
 #define SET_GPIO_INT_MODE(cur_val, mode, ch_idx)			\
 		do {							\
 			cur_val &= ~(BIT_MASK(3) << (ch_idx * 4));	\
@@ -120,16 +117,16 @@ static int gpio_atcgpio100_config(const struct device *port,
 	if (flags & GPIO_OUTPUT) {
 
 		if (flags & GPIO_OUTPUT_INIT_HIGH) {
-			OUTWORD(GPIO_DSET(port), pin_mask);
+			sys_write32(pin_mask, GPIO_DSET(port));
 		} else if (flags & GPIO_OUTPUT_INIT_LOW) {
-			OUTWORD(GPIO_DCLR(port), pin_mask);
+			sys_write32(pin_mask, GPIO_DCLR(port));
 		}
 
 		key = k_spin_lock(&data->lock);
 
 		/* Set channel output */
-		port_value = INWORD(GPIO_DIR(port));
-		OUTWORD(GPIO_DIR(port), port_value | pin_mask);
+		port_value = sys_read32(GPIO_DIR(port));
+		sys_write32((port_value | pin_mask), GPIO_DIR(port));
 
 		k_spin_unlock(&data->lock, key);
 
@@ -146,14 +143,14 @@ static int gpio_atcgpio100_config(const struct device *port,
 			/* Default settings: Filter out pulses which are
 			 *  less than 4 de-bounce clock period
 			 */
-			OUTWORD(GPIO_DEBC(port), DF_DEBOUNCED_SETTING);
-			port_value = INWORD(GPIO_DEBE(port));
-			OUTWORD(GPIO_DEBE(port), port_value | pin_mask);
+			sys_write32(DF_DEBOUNCED_SETTING, GPIO_DEBC(port));
+			port_value = sys_read32(GPIO_DEBE(port));
+			sys_write32((port_value | pin_mask), GPIO_DEBE(port));
 		}
 
 		/* Set channel input */
-		port_value = INWORD(GPIO_DIR(port));
-		OUTWORD(GPIO_DIR(port), port_value & ~pin_mask);
+		port_value = sys_read32(GPIO_DIR(port));
+		sys_write32((port_value & ~pin_mask), GPIO_DIR(port));
 
 		k_spin_unlock(&data->lock, key);
 
@@ -167,7 +164,7 @@ static int gpio_atcgpio100_config(const struct device *port,
 static int gpio_atcgpio100_port_get_raw(const struct device *port,
 					gpio_port_value_t *value)
 {
-	*value = INWORD(GPIO_DIN(port));
+	*value = sys_read32(GPIO_DIN(port));
 	return 0;
 }
 
@@ -180,8 +177,8 @@ static int gpio_atcgpio100_set_masked_raw(const struct device *port,
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	port_value = INWORD(GPIO_DOUT(port));
-	OUTWORD(GPIO_DOUT(port), (port_value & ~mask) | (value & mask));
+	port_value = sys_read32(GPIO_DOUT(port));
+	sys_write32((port_value & ~mask) | (value & mask), GPIO_DOUT(port));
 
 	k_spin_unlock(&data->lock, key);
 
@@ -191,14 +188,14 @@ static int gpio_atcgpio100_set_masked_raw(const struct device *port,
 static int gpio_atcgpio100_set_bits_raw(const struct device *port,
 					gpio_port_pins_t pins)
 {
-	OUTWORD(GPIO_DSET(port), pins);
+	sys_write32(pins, GPIO_DSET(port));
 	return 0;
 }
 
 static int gpio_atcgpio100_clear_bits_raw(const struct device *port,
 					gpio_port_pins_t pins)
 {
-	OUTWORD(GPIO_DCLR(port), pins);
+	sys_write32(pins, GPIO_DCLR(port));
 	return 0;
 }
 
@@ -210,8 +207,8 @@ static int gpio_atcgpio100_toggle_bits(const struct device *port,
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	port_value = INWORD(GPIO_DOUT(port));
-	OUTWORD(GPIO_DOUT(port), port_value ^ pins);
+	port_value = sys_read32(GPIO_DOUT(port));
+	sys_write32((port_value ^ pins), GPIO_DOUT(port));
 
 	k_spin_unlock(&data->lock, key);
 
@@ -256,21 +253,21 @@ static int gpio_atcgpio100_pin_interrupt_configure(
 
 	if (int_mode == INT_NO_OPERATION) {
 		/* Disable interrupt of pin */
-		port_value = INWORD(GPIO_INTE(port));
-		OUTWORD(GPIO_INTE(port), port_value & ~BIT(pin));
+		port_value = sys_read32(GPIO_INTE(port));
+		sys_write32((port_value & ~BIT(pin)), GPIO_INTE(port));
 
 		/* Clear the remain pending interrupt */
-		port_value = INWORD(GPIO_ISTA(port));
-		OUTWORD(GPIO_ISTA(port), port_value);
+		port_value = sys_read32(GPIO_ISTA(port));
+		sys_write32(port_value, GPIO_ISTA(port));
 	} else {
 		/* Set interrupt mode of pin */
-		port_value = INWORD(GPIO_IMD(port, imr_idx));
+		port_value = sys_read32(GPIO_IMD(port, imr_idx));
 		SET_GPIO_INT_MODE(port_value, int_mode, ch_idx);
-		OUTWORD(GPIO_IMD(port, imr_idx), port_value);
+		sys_write32(port_value, GPIO_IMD(port, imr_idx));
 
 		/* Enable interrupt of pin */
-		port_value = INWORD(GPIO_INTE(port));
-		OUTWORD(GPIO_INTE(port), port_value | BIT(pin));
+		port_value = sys_read32(GPIO_INTE(port));
+		sys_write32((port_value | BIT(pin)), GPIO_INTE(port));
 	}
 
 	k_spin_unlock(&data->lock, key);
@@ -316,8 +313,8 @@ static void gpio_atcgpio100_irq_handler(const struct device *port)
 	struct gpio_atcgpio100_data * const data = port->data;
 	uint32_t port_value;
 
-	port_value = INWORD(GPIO_ISTA(port));
-	OUTWORD(GPIO_ISTA(port), port_value);
+	port_value = sys_read32(GPIO_ISTA(port));
+	sys_write32(port_value, GPIO_ISTA(port));
 
 	gpio_fire_callbacks(&data->cb, port, port_value);
 
@@ -331,7 +328,7 @@ static const struct gpio_driver_api gpio_atcgpio100_api = {
 	.port_clear_bits_raw     = gpio_atcgpio100_clear_bits_raw,
 	.port_toggle_bits        = gpio_atcgpio100_toggle_bits,
 	.pin_interrupt_configure = gpio_atcgpio100_pin_interrupt_configure,
-	.manage_callback         = gpio_atcgpio100_manage_callback
+	.manage_callback         = gpio_atcgpio100_manage_callback,
 #ifdef CONFIG_GPIO_GET_DIRECTION
 	.port_get_direction      = gpio_atcgpio100_port_get_dir,
 #endif /* CONFIG_GPIO_GET_DIRECTION */
@@ -342,10 +339,10 @@ static int gpio_atcgpio100_init(const struct device *port)
 	const struct gpio_atcgpio100_config * const dev_cfg = port->config;
 
 	/* Disable all interrupts */
-	OUTWORD(GPIO_INTE(port), BIT_MASK(0));
+	sys_write32(BIT_MASK(0), GPIO_INTE(port));
 
 	/* Write 1 to clear interrupt status */
-	OUTWORD(GPIO_ISTA(port), (uint32_t) BIT64_MASK(32));
+	sys_write32((uint32_t) BIT64_MASK(32), GPIO_ISTA(port));
 
 	/* Configure GPIO device */
 	dev_cfg->cfg_func();


### PR DESCRIPTION
Add support for port_get_direction function in andes atcgpio100 driver.

Signed-off-by: Wei-Tai Lee [wtlee@andestech.com](mailto:wtlee@andestech.com)