### PR TITLE
mgmt: mcumgr: fs_mgmt: Add other access hooks and minor fixes

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -165,6 +165,14 @@ Changes in this release
   implemented for the STM32 DAC driver. Implicitly for this driver this changes
   the default from being buffered to unbuffered.
 
+* MCUmgr fs_mgmt group's file access hook is now called for all fs_mgmt group
+  functions (adding support for file status and file hash/checksum). In
+  addition, if the file access state is not lost, it will now only be called
+  once for the file access instead of each time a command is received.
+  Note that the structure for the notification has changed, the ``upload`` bool
+  has been replaced with an enum to indicate what function is used, see
+  :c:struct:`fs_mgmt_file_access` for the new structure definition.
+
 Removed APIs in this release
 ============================
 

--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
@@ -19,6 +19,21 @@ extern "C" {
  * @{
  */
 
+/** The type of operation that is being requested for a given file access callback. */
+enum fs_mgmt_file_access_types {
+	/** Access to read file (file upload). */
+	FS_MGMT_FILE_ACCESS_READ,
+
+	/** Access to write file (file download). */
+	FS_MGMT_FILE_ACCESS_WRITE,
+
+	/** Access to get status of file. */
+	FS_MGMT_FILE_ACCESS_STATUS,
+
+	/** Access to calculate hash or checksum of file. */
+	FS_MGMT_FILE_ACCESS_HASH_CHECKSUM,
+};
+
 /**
  * Structure provided in the #MGMT_EVT_OP_FS_MGMT_FILE_ACCESS notification callback: This callback
  * function is used to notify the application about a pending file read/write request and to
@@ -26,8 +41,8 @@ extern "C" {
  * #MGMT_ERR_EOK, if one returns an error then access will be denied.
  */
 struct fs_mgmt_file_access {
-	/** True if the request is for uploading data to the file, otherwise false */
-	bool upload;
+	/** Specifies the type of the operation that is being requested. */
+	enum fs_mgmt_file_access_types access;
 
 	/**
 	 * Path and filename of file be accesses, note that this can be changed by handlers to

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
@@ -154,15 +154,16 @@ config MCUMGR_GRP_FS_PATH_LEN
 	  and download commands.
 
 config MCUMGR_GRP_FS_FILE_ACCESS_HOOK
-	bool "File read/write access hook"
+	bool "File access hooks"
 	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
 	help
-	  Allows applications to control file read and write access by
-	  registering for a callback which is then triggered whenever a file
-	  read or write attempt is made. This also, optionally, allows
-	  re-writing or changing of supplied file paths.
-	  Note that this will be called multiple times for each file read and
-	  write due to mcumgr's method of stateless operation.
+	  Allows applications to control file access (e.g. for uploading and
+	  downloading of files) by registering for a callback which is then
+	  triggered whenever a files are accessed using the FS management group
+	  function. This also, optionally, allows re-writing or changing of
+	  supplied file paths.
+	  Note that this may be called multiple times for each file read and
+	  write due to MCUmgr's method of operation with a single file state.
 
 config MCUMGR_GRP_FS_FILE_SEMAPHORE_TAKE_TIME
 	int "File handle semaphore take time (ms)"

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
@@ -221,7 +221,7 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 
 #if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
 	struct fs_mgmt_file_access file_access_data = {
-		.upload = false,
+		.access = FS_MGMT_FILE_ACCESS_READ,
 		.filename = path,
 	};
 
@@ -230,8 +230,8 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 	uint16_t ret_group;
 #endif
 
-	ok = zcbor_map_decode_bulk(zsd, fs_download_decode,
-		ARRAY_SIZE(fs_download_decode), &decoded) == 0;
+	ok = zcbor_map_decode_bulk(zsd, fs_download_decode, ARRAY_SIZE(fs_download_decode),
+				   &decoded) == 0;
 
 	if (!ok || off == ULLONG_MAX || name.len == 0 || name.len > (sizeof(path) - 1)) {
 		return MGMT_ERR_EINVAL;
@@ -239,23 +239,6 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 
 	memcpy(path, name.value, name.len);
 	path[name.len] = '\0';
-
-#if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
-	/* Send request to application to check if access should be allowed or not */
-	status = mgmt_callback_notify(MGMT_EVT_OP_FS_MGMT_FILE_ACCESS, &file_access_data,
-				      sizeof(file_access_data), &ret_rc, &ret_group);
-
-	if (status != MGMT_CB_OK) {
-		bool ok;
-
-		if (status == MGMT_CB_ERROR_RC) {
-			return ret_rc;
-		}
-
-		ok = smp_add_cmd_ret(zse, ret_group, (uint16_t)ret_rc);
-		return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
-	}
-#endif
 
 	if (k_sem_take(&fs_mgmt_ctxt.lock_sem, FILE_SEMAPHORE_MAX_TAKE_TIME)) {
 		return MGMT_ERR_EBUSY;
@@ -265,6 +248,23 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 	if (ctxt->smpt != fs_mgmt_ctxt.transport ||
 	    fs_mgmt_ctxt.state != STATE_DOWNLOAD ||
 	    strcmp(path, fs_mgmt_ctxt.path)) {
+#if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
+		/* Send request to application to check if access should be allowed or not */
+		status = mgmt_callback_notify(MGMT_EVT_OP_FS_MGMT_FILE_ACCESS, &file_access_data,
+					      sizeof(file_access_data), &ret_rc, &ret_group);
+
+		if (status != MGMT_CB_OK) {
+			bool ok;
+
+			if (status == MGMT_CB_ERROR_RC) {
+				return ret_rc;
+			}
+
+			ok = smp_add_cmd_ret(zse, ret_group, (uint16_t)ret_rc);
+			goto end;
+		}
+#endif
+
 		fs_mgmt_cleanup();
 	}
 
@@ -273,9 +273,8 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 		rc = fs_mgmt_filelen(path, &fs_mgmt_ctxt.len);
 
 		if (rc != FS_MGMT_RET_RC_OK) {
-			k_sem_give(&fs_mgmt_ctxt.lock_sem);
 			ok = smp_add_cmd_ret(zse, MGMT_GROUP_ID_FS, rc);
-			return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
+			goto end;
 		}
 
 		fs_mgmt_ctxt.off = 0;
@@ -372,7 +371,7 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 
 #if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
 	struct fs_mgmt_file_access file_access_data = {
-		.upload = true,
+		.access = FS_MGMT_FILE_ACCESS_WRITE,
 		.filename = file_name,
 	};
 
@@ -381,40 +380,16 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 	uint16_t ret_group;
 #endif
 
-	ok = zcbor_map_decode_bulk(zsd, fs_upload_decode,
-		ARRAY_SIZE(fs_upload_decode), &decoded) == 0;
+	ok = zcbor_map_decode_bulk(zsd, fs_upload_decode, ARRAY_SIZE(fs_upload_decode),
+				   &decoded) == 0;
 
-	if (!ok || off == ULLONG_MAX || name.len == 0 ||
-	    name.len > (sizeof(file_name) - 1)) {
+	if (!ok || off == ULLONG_MAX || name.len == 0 || name.len > (sizeof(file_name) - 1) ||
+	    (off == 0 && len == ULLONG_MAX)) {
 		return MGMT_ERR_EINVAL;
 	}
 
 	memcpy(file_name, name.value, name.len);
 	file_name[name.len] = '\0';
-
-#if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
-	/* Send request to application to check if access should be allowed or not */
-	status = mgmt_callback_notify(MGMT_EVT_OP_FS_MGMT_FILE_ACCESS, &file_access_data,
-				      sizeof(file_access_data), &ret_rc, &ret_group);
-
-	if (status != MGMT_CB_OK) {
-		bool ok;
-
-		if (status == MGMT_CB_ERROR_RC) {
-			return ret_rc;
-		}
-
-		ok = smp_add_cmd_ret(zse, ret_group, (uint16_t)ret_rc);
-		return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
-	}
-#endif
-
-	if (off == 0) {
-		/* Total file length is a required field in the first chunk request. */
-		if (len == ULLONG_MAX) {
-			return MGMT_ERR_EINVAL;
-		}
-	}
 
 	if (k_sem_take(&fs_mgmt_ctxt.lock_sem, FILE_SEMAPHORE_MAX_TAKE_TIME)) {
 		return MGMT_ERR_EBUSY;
@@ -424,6 +399,23 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 	if (ctxt->smpt != fs_mgmt_ctxt.transport ||
 	    fs_mgmt_ctxt.state != STATE_UPLOAD ||
 	    strcmp(file_name, fs_mgmt_ctxt.path)) {
+#if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
+		/* Send request to application to check if access should be allowed or not */
+		status = mgmt_callback_notify(MGMT_EVT_OP_FS_MGMT_FILE_ACCESS, &file_access_data,
+					      sizeof(file_access_data), &ret_rc, &ret_group);
+
+		if (status != MGMT_CB_OK) {
+			bool ok;
+
+			if (status == MGMT_CB_ERROR_RC) {
+				return ret_rc;
+			}
+
+			ok = smp_add_cmd_ret(zse, ret_group, (uint16_t)ret_rc);
+			goto end;
+		}
+#endif
+
 		fs_mgmt_cleanup();
 	}
 
@@ -561,7 +553,6 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 
 	/* Send the response. */
 	ok = fs_mgmt_file_rsp(zse, MGMT_ERR_EOK, fs_mgmt_ctxt.off);
-
 	fs_mgmt_upload_download_finish_check();
 
 end:
@@ -590,6 +581,17 @@ static int fs_mgmt_file_status(struct smp_streamer *ctxt)
 		ZCBOR_MAP_DECODE_KEY_DECODER("name", zcbor_tstr_decode, &name),
 	};
 
+#if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
+	struct fs_mgmt_file_access file_access_data = {
+		.access = FS_MGMT_FILE_ACCESS_STATUS,
+		.filename = path,
+	};
+
+	enum mgmt_cb_return status;
+	int32_t ret_rc;
+	uint16_t ret_group;
+#endif
+
 	ok = zcbor_map_decode_bulk(zsd, fs_status_decode,
 		ARRAY_SIZE(fs_status_decode), &decoded) == 0;
 
@@ -600,6 +602,23 @@ static int fs_mgmt_file_status(struct smp_streamer *ctxt)
 	/* Copy path and ensure it is null-teminated */
 	memcpy(path, name.value, name.len);
 	path[name.len] = '\0';
+
+#if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
+	/* Send request to application to check if access should be allowed or not */
+	status = mgmt_callback_notify(MGMT_EVT_OP_FS_MGMT_FILE_ACCESS, &file_access_data,
+				      sizeof(file_access_data), &ret_rc, &ret_group);
+
+	if (status != MGMT_CB_OK) {
+		bool ok;
+
+		if (status == MGMT_CB_ERROR_RC) {
+			return ret_rc;
+		}
+
+		ok = smp_add_cmd_ret(zse, ret_group, (uint16_t)ret_rc);
+		return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
+	}
+#endif
 
 	/* Retrieve file size */
 	rc = fs_mgmt_filelen(path, &file_len);
@@ -656,6 +675,17 @@ static int fs_mgmt_file_hash_checksum(struct smp_streamer *ctxt)
 		ZCBOR_MAP_DECODE_KEY_DECODER("len", zcbor_uint64_decode, &len),
 	};
 
+#if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
+	struct fs_mgmt_file_access file_access_data = {
+		.access = FS_MGMT_FILE_ACCESS_HASH_CHECKSUM,
+		.filename = path,
+	};
+
+	enum mgmt_cb_return status;
+	int32_t ret_rc;
+	uint16_t ret_group;
+#endif
+
 	ok = zcbor_map_decode_bulk(zsd, fs_hash_checksum_decode,
 		ARRAY_SIZE(fs_hash_checksum_decode), &decoded) == 0;
 
@@ -681,6 +711,23 @@ static int fs_mgmt_file_hash_checksum(struct smp_streamer *ctxt)
 				     FS_MGMT_RET_RC_CHECKSUM_HASH_NOT_FOUND);
 		goto end;
 	}
+
+#if defined(CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
+	/* Send request to application to check if access should be allowed or not */
+	status = mgmt_callback_notify(MGMT_EVT_OP_FS_MGMT_FILE_ACCESS, &file_access_data,
+				      sizeof(file_access_data), &ret_rc, &ret_group);
+
+	if (status != MGMT_CB_OK) {
+		bool ok;
+
+		if (status == MGMT_CB_ERROR_RC) {
+			return ret_rc;
+		}
+
+		ok = smp_add_cmd_ret(zse, ret_group, (uint16_t)ret_rc);
+		return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
+	}
+#endif
 
 	/* Check provided offset is valid for target file */
 	rc = fs_mgmt_filelen(path, &file_len);


### PR DESCRIPTION
    Adds callback checks to other fs_mgmt group file access functions
    which allows for file access control, and moves where the callback
    is triggered for uploads and downloads to prevent getting the
    callback multiple times for the same file. The callback struct has
    been modified so applications using the previous signature will
    need to be updated.
