### PR TITLE
mgmt: mcumgr: grp: fs_mgmt: Change insecure warning

### DIFF
--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2018-2021 mcumgr authors
 # Copyright (c) 2022 Laird Connectivity
-# Copyright (c) 2022 Nordic Semiconductor ASA
+# Copyright (c) 2022-2023 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -14,10 +14,18 @@ zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH src/fs_mgmt_hash
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_FS_CHECKSUM_IEEE_CRC32 src/fs_mgmt_hash_checksum_crc32.c)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_FS_HASH_SHA256 src/fs_mgmt_hash_checksum_sha256.c)
 
-if (CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH AND CONFIG_MCUMGR_GRP_FS_HASH_SHA256)
-  if (NOT CONFIG_TINYCRYPT)
+if(CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH AND CONFIG_MCUMGR_GRP_FS_HASH_SHA256)
+  if(NOT CONFIG_TINYCRYPT)
     zephyr_library_link_libraries(mbedTLS)
   endif()
 endif()
 
 zephyr_library_include_directories(include)
+
+if(CONFIG_MCUMGR_GRP_FS AND NOT CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK)
+  message(WARNING "Note: MCUmgr file system management is enabled but file access hooks are "
+                  "disabled, this is an insecure configuration and not recommended for production "
+                  "use, as all files on the filesystem can be manipulated by a remote device. See "
+                  "https://docs.zephyrproject.org/latest/services/device_mgmt/mcumgr_callbacks.html "
+                  "for details on enabling and using MCUmgr hooks.")
+endif()

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
@@ -13,16 +13,19 @@
 # try to group them together by the same stem after prefix.
 
 menuconfig MCUMGR_GRP_FS
-	bool "Mcumgr handlers for file management (insecure)"
+	bool "MCUmgr handlers for file management"
 	depends on FILE_SYSTEM
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
 	help
-	  Enables mcumgr handlers for file management
+	  Enables MCUmgr handlers for file management
 
-	  This option allows mcumgr clients to access anything in the
+	  This option allows MCUmgr clients to access anything in the
 	  file system, including application-stored secrets like
-	  private keys. Use of this feature in production is strongly
-	  discouraged.
+	  private keys. Use of this feature in production without adequate
+	  protection mechanisms is strongly discouraged (applications can
+	  enable MCUMGR_GRP_FS_FILE_ACCESS_HOOK and register to receive
+	  callbacks when file access is attempted, which they can then filter,
+	  allow, deny or rewrite paths).
 
 if MCUMGR_GRP_FS
 
@@ -66,7 +69,7 @@ config MCUMGR_GRP_FS_DL_CHUNK_SIZE_LIMIT
 	bool "Setting custom size of download file chunk"
 	help
 	  By default file chunk, that will be read off storage and fit into
-	  mcumgr frame, is automatically calculated to fit into buffer
+	  MCUmgr frame, is automatically calculated to fit into buffer
 	  of size MCUGMR_TRANSPORT_NETBUF_SIZE with all headers.
 	  Enabling this option allows to set MAXIMUM value that will be
 	  allowed for such chunk.
@@ -96,9 +99,9 @@ config MCUMGR_GRP_FS_FILE_STATUS
 	  at present only the size of the file is returned (if it exists).
 
 config MCUMGR_GRP_FS_CHECKSUM_HASH
-	bool "Checksum/hash mcumgr functions"
+	bool "Checksum/hash MCUmgr functions"
 	help
-	  Enable this to support the hash/checksum mcumgr functionality,
+	  Enable this to support the hash/checksum MCUmgr functionality,
 	  individual checksum and hash types need to be enabled below.
 	  Note that this requires enough stack space to buffer data
 	  from the file being read and generate the output hash/checksum.
@@ -117,13 +120,13 @@ config MCUMGR_GRP_FS_CHECKSUM_IEEE_CRC32
 	bool "IEEE CRC32 checksum support"
 	default y
 	help
-	  Enable IEEE CRC32 checksum support for mcumgr.
+	  Enable IEEE CRC32 checksum support for MCUmgr.
 
 config MCUMGR_GRP_FS_HASH_SHA256
 	bool "SHA256 hash support"
 	depends on TINYCRYPT_SHA256 || MBEDTLS_MAC_SHA256_ENABLED
 	help
-	  Enable SHA256 hash support for mcumgr.
+	  Enable SHA256 hash support for MCUmgr.
 
 config MCUMGR_GRP_FS_CHECKSUM_HASH_SUPPORTED_CMD
 	bool "Supported hash/checksum command"

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -20,7 +20,7 @@ menuconfig MCUMGR_GRP_IMG
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
 	help
-	  Enables mcumgr handlers for image management
+	  Enables MCUmgr handlers for image management
 
 if MCUMGR_GRP_IMG
 
@@ -48,7 +48,7 @@ config MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER
 	  Sets how many application images are supported (pairs of secondary and primary slots).
 	  Setting this to 2 requires MCUMGR_TRANSPORT_NETBUF_SIZE to be at least 512b.
 	  NOTE: The UPDATEABLE_IMAGE_NUMBER of MCUBOOT configuration, even for Zephyr build,
-	  needs to be set to the same value; this is due to the fact that the mcumgr uses
+	  needs to be set to the same value; this is due to the fact that the MCUmgr uses
 	  boot_util and the UPDATEABLE_IMAGE_NUMBER controls number of images supported
 	  by that library.
 
@@ -63,8 +63,8 @@ config MCUMGR_GRP_IMG_DIRECT_UPLOAD
 	bool "Allow direct image upload"
 	help
 	  Enables directly uploading image to selected image partition.
-	  This changes how "image" is understood by mcumgr: normally the mcumgr allows to upload
-	  to first slot of the only image it knows, where image is understood as two slots
+	  This changes how "image" is understood by MCUmgr: normally MCUmgr allows uploading to
+	  the first slot of the only image it knows, where image is understood as two slots
 	  (two DTS images for Zephyr); this allows to treat every DTS defined image as direct
 	  target for upload, and more than two may be used (4 at this time).
 	  NOTE: When direct upload is used the image numbers are shifted by + 1, and the default
@@ -74,7 +74,7 @@ config MCUMGR_GRP_IMG_DIRECT_UPLOAD
 config MCUMGR_GRP_IMG_REJECT_DIRECT_XIP_MISMATCHED_SLOT
 	bool "Reject Direct-XIP applications with mismatched address"
 	help
-	  When enabled, the mcumgr will compare base address of application,
+	  When enabled, the MCUmgr will compare base address of application,
 	  encoded into .bin file header with use of imgtool, on upload and will
 	  reject binaries that would not be able to start from available
 	  Direct-XIP address.
@@ -87,7 +87,7 @@ config MCUMGR_GRP_IMG_FRUGAL_LIST
 	  The status list send back from the device will only be filled with data that is non-zero,
 	  non-empty or true.  This option slightly reduces number of bytes transferred back from
 	  a device but requires support in client software, which has to default omitted values.
-	  Works correctly with mcumgr-cli.
+	  Works correctly with the go mcumgr-cli application.
 
 config MCUMGR_GRP_IMG_VERSION_CMP_USE_BUILD_NUMBER
 	bool "Use build number while comparing image version"

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
@@ -16,7 +16,7 @@ menuconfig MCUMGR_GRP_OS
 	bool "Mcumgr handlers for OS management"
 	select REBOOT
 	help
-	  Enables mcumgr handlers for OS management
+	  Enables MCUmgr handlers for OS management
 
 if MCUMGR_GRP_OS
 
@@ -26,7 +26,7 @@ config MCUMGR_GRP_OS_RESET_MS
 	depends on REBOOT
 	help
 	  When a reset command is received, the system waits this many milliseconds
-	  before performing the reset.  This delay allows time for the mcumgr
+	  before performing the reset.  This delay allows time for the MCUmgr
 	  response to be delivered.
 
 config MCUMGR_GRP_OS_RESET_HOOK
@@ -35,7 +35,7 @@ config MCUMGR_GRP_OS_RESET_HOOK
 	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
 	help
 	  Allows applications to control and get notifications of when a reset
-	  command has been issued via an mcumgr command. With this option
+	  command has been issued via an MCUmgr command. With this option
 	  disabled, modules will reboot when the command is received without
 	  notification, when this is enabled and a handler is registered, the
 	  application will be notified that a reset command has been received

--- a/subsys/mgmt/mcumgr/grp/shell_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/shell_mgmt/Kconfig
@@ -18,7 +18,7 @@ menuconfig MCUMGR_GRP_SHELL
 	depends on SHELL_BACKEND_DUMMY
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
 	help
-	  Enables mcumgr handlers for shell management. The handler will utilize
+	  Enables MCUmgr handlers for shell management. The handler will utilize
 	  the dummy backend to execute shell commands and capture the output to
 	  an internal memory buffer. This way, there is no interaction with
 	  physical interfaces outside of the scope of the user.
@@ -29,7 +29,7 @@ menuconfig MCUMGR_GRP_SHELL
 	  increase the value. Remember to set MCUMGR_TRANSPORT_NETBUF_SIZE accordingly.
 	  Note that maximum length of shell command accepted is regulated by
 	  the CONFIG_SHELL_CMD_BUFF_SIZE, and a buffer for a command is allocated
-	  on a stack, by the mcumgr, so enabling MCUMGR_GRP_SHELL and
+	  on a stack, by the MCUmgr, so enabling MCUMGR_GRP_SHELL and
 	  changes to the CONFIG_SHELL_CMD_BUFF_SIZE may increase stack size
 	  requirements.
 

--- a/subsys/mgmt/mcumgr/grp/stat_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/stat_mgmt/Kconfig
@@ -17,7 +17,7 @@ menuconfig MCUMGR_GRP_STAT
 	depends on STATS
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
 	help
-	  Enables mcumgr handlers for statistics management.
+	  Enables MCUmgr handlers for statistics management.
 
 if MCUMGR_GRP_STAT
 
@@ -26,7 +26,7 @@ config MCUMGR_GRP_STAT_MAX_NAME_LEN
 	default 32
 	depends on MCUMGR_GRP_STAT
 	help
-	  Limits the maximum stat group name length in mcumgr requests, in bytes.
+	  Limits the maximum stat group name length in MCUmgr requests, in bytes.
 	  A buffer of this size gets allocated on the stack during handling of all
 	  stat read commands.  If a stat group's name exceeds this limit, it will
 	  be impossible to retrieve its values with a stat show command.

--- a/subsys/mgmt/mcumgr/grp/zephyr_basic/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/zephyr_basic/Kconfig
@@ -4,7 +4,7 @@
 menuconfig MCUMGR_GRP_ZBASIC
 	bool "Zephyr specific basic group of commands"
 	help
-	  Enables mcumgr to processing of Zephyr specific groups.
+	  Enables MCUmgr to processing of Zephyr specific groups.
 
 if MCUMGR_GRP_ZBASIC
 


### PR DESCRIPTION
    Changes the warning from being text in Kconfig for filesystem
    management as a whole to being a cmake warning which is displayed
    if the user has not enabled file access hooks with a link to the
    documentation on how to set them up.

and

    mgmt: mcumgr: Change from mcumgr to MCUmgr
