### PR TITLE
scripts: twister: create build dir for logs

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -398,6 +398,7 @@ class CMake:
             results = {"returncode": p.returncode}
 
         if out:
+            os.makedirs(self.build_dir, exist_ok=True)
             with open(os.path.join(self.build_dir, self.log), "a", encoding=self.default_encoding) as log:
                 log_msg = out.decode(self.default_encoding)
                 log.write(log_msg)


### PR DESCRIPTION
In some cases CMake doesn't create build directory and in those cases Twister should create this directory by itself to make possible to create `build.log`. Otherwise, Twister rise an internal error (`FileNotFoundError`), and then test is marked as SKIP in final report and thus it is hard to detect such error.

To reproduce:
Intentionally make defect in [tests/bluetooth/shell/testcase.yaml](https://github.com/zephyrproject-rtos/zephyr/blob/main/tests/bluetooth/shell/testcase.yaml):
```diff
--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -14,9 +14,7 @@ tests:
     harness: keyboard
     min_flash: 145
   bluetooth.shell.cdc_acm:
-    extra_args:
-      - OVERLAY_CONFIG=cdc_acm.conf
-      - DTC_OVERLAY_FILE="usb.overlay"
+    extra_args: OVERLAY_CONFIG=cdc_acm.conf usb.overlay
     depends_on: usb_device
     platform_allow:
       - native_posix
```
Call Twister by:
```
./scripts/twister -p native_posix -T tests/bluetooth/shell -s tests/bluetooth/shell/bluetooth.shell.cdc_acm
```
and observe output.

Without changes in this PR:
```
$ ./scripts/twister -p native_posix -T tests/bluetooth/shell -s tests/bluetooth/shell/bluetooth.shell.cdc_acm
ZEPHYR_BASE unset, using "/home/redbeard/zephyrproject/zephyr"
Renaming output directory to /home/redbeard/zephyrproject/zephyr/twister-out.16
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.3.0-4112-g6051b6f14dc1
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/redbeard/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 4
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
ERROR   - Cmake build failure: /home/redbeard/zephyrproject/zephyr/tests/bluetooth/shell for native_posix
Process Process-3:
Traceback (most recent call last):
  File "/usr/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/redbeard/zephyrproject/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 1204, in pipeline_mgr
    pb.process(pipeline, done_queue, task, lock, results)
  File "/home/redbeard/zephyrproject/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 582, in process
    res = self.cmake()
  File "/home/redbeard/zephyrproject/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 998, in cmake
    res = self.run_cmake(args,filter_stages)
  File "/home/redbeard/zephyrproject/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 402, in run_cmake
    with open(os.path.join(self.build_dir, self.log), "a", encoding=self.default_encoding) as log:
FileNotFoundError: [Errno 2] No such file or directory: '/home/redbeard/zephyrproject/zephyr/twister-out/native_posix/tests/bluetooth/shell/bluetooth.shell.cdc_acm/build.log'

INFO    - 1 test scenarios (1 test instances) selected, 0 configurations skipped (0 by static filter, 0 at runtime).
INFO    - 0 of 1 test configurations passed (0.00%), 0 failed, 0 errored, 0 skipped with 0 warnings in 1.39 seconds
INFO    - In total 0 test cases were executed, 0 skipped on 1 out of total 571 platforms (0.18%)
INFO    - 0 test configurations executed on platforms, 1 test configurations were only built.
```

With changes in this PR:
```
$ ./scripts/twister -p native_posix -T tests/bluetooth/shell -s tests/bluetooth/shell/bluetooth.shell.cdc_acm
ZEPHYR_BASE unset, using "/home/redbeard/zephyrproject/zephyr"
Renaming output directory to /home/redbeard/zephyrproject/zephyr/twister-out.17
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.3.0-4112-g6051b6f14dc1
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/redbeard/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 4
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
ERROR   - Cmake build failure: /home/redbeard/zephyrproject/zephyr/tests/bluetooth/shell for native_posix
ERROR   - native_posix              tests/bluetooth/shell/bluetooth.shell.cdc_acm       ERROR : Cmake build failure
ERROR   - see: /home/redbeard/zephyrproject/zephyr/twister-out/native_posix/tests/bluetooth/shell/bluetooth.shell.cdc_acm/build.log
INFO    - Total complete:    1/   1  100%  skipped:    0, failed:    0, error:    1
INFO    - 1 test scenarios (1 test instances) selected, 0 configurations skipped (0 by static filter, 0 at runtime).
INFO    - 0 of 1 test configurations passed (0.00%), 0 failed, 1 errored, 0 skipped with 0 warnings in 1.33 seconds
INFO    - In total 1 test cases were executed, 0 skipped on 1 out of total 571 platforms (0.18%)
INFO    - 0 test configurations executed on platforms, 1 test configurations were only built.

```