### PR TITLE
boards: nrf9160dk_nrf9160: Apply a few corrections to revision 0.14.0

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common-pinctrl.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common-pinctrl.dtsi
@@ -96,6 +96,7 @@
 			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
 				<NRF_PSEL(SPIM_MISO, 0, 12)>,
 				<NRF_PSEL(SPIM_MOSI, 0, 11)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
 		};
 	};
 

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common_0_14_0.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common_0_14_0.dtsi
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		spi-flash0 = &mx25r64;
+	};
+};
+
 &interface_to_nrf52840 {
 	gpio-map = <0 0 &gpio0 17 0>,
 		   <1 0 &gpio0 18 0>,
@@ -29,7 +35,6 @@
 		compatible = "nxp,pcal6408a";
 		status = "disabled";
 		reg = <0x20>;
-		label = "GPIO_P0";
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <8>;
@@ -37,7 +42,7 @@
 	};
 };
 
-&spi3 {
+&arduino_spi {
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>, /* D10 */
 		   <&gpio0 25 GPIO_ACTIVE_LOW>;
 	mx25r64: mx25r6435f@1 {
@@ -45,12 +50,11 @@
 		status = "disabled";
 		reg = <1>;
 		spi-max-frequency = <8000000>;
-		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		sfdp-bfp = [
 			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
 			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
-			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 68 44
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 48 44
 			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
 		];
 		size = <67108864>;


### PR DESCRIPTION
- remove deprecated `label` properties
- add `spi-flash0` alias
- correct `sfdp-bfp` property value to reflect exactly what is returned by the flash chip

Also use H0H1 drive for arduino_spi pins by default as this is usually needed for reliable SPI communication when SCK
frequency is >= 4 MHz.