### PR TITLE
Bluetooth: Mesh: Shell: fix vnd model pub command

### DIFF
--- a/subsys/bluetooth/mesh/shell/cfg.c
+++ b/subsys/bluetooth/mesh/shell/cfg.c
@@ -1564,7 +1564,7 @@ static int cmd_mod_pub(const struct shell *sh, size_t argc, char *argv[])
 	argc -= 3;
 	argv += 3;
 
-	if (argc == 1 || argc == 8) {
+	if (argc == 1 || argc == 9) {
 		cid = shell_strtoul(argv[0], 0, &err);
 		argc--;
 		argv++;


### PR DESCRIPTION
The command at most takes 11 args. argc = num of args + 1 (command name) => 12. We substruct 3 from argc (cmd name, mod id, addr). This gives argc = 9 when all args are provided for vendor model.