### PR TITLE
boards: arm: atsamc21n_xpro: list CAN as supported

### DIFF
--- a/boards/arm/atsamc21n_xpro/atsamc21n_xpro.yaml
+++ b/boards/arm/atsamc21n_xpro/atsamc21n_xpro.yaml
@@ -12,6 +12,7 @@ toolchain:
   - xtools
 supported:
   - adc
+  - can
   - dma
   - gpio
   - i2c


### PR DESCRIPTION
List CAN as being supported by the atsamc21n_xpro board configuration.

Fixes: a206e8ce53660559850c49c36932253565848a60