### PR TITLE
scripts: requirements: Update protobuf and grpcio-tools requirements

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -22,7 +22,8 @@ Pillow
 imgtool>=1.9
 
 # used by nanopb module to generate sources from .proto files
-grpcio-tools
+grpcio-tools>=1.47.0
+protobuf>=3.20.3
 
 # used by scripts/release/bug_bash.py for generating top ten bug squashers
 PyGithub


### PR DESCRIPTION
Minimal requirements for nanopb were not accurate to allow its usage (and causing related tests to build fail). This change updates requirements for protobuf (>=3.20.3) and grpcio-tools (>=1.47.0) to use protocol buffer. 

Fixes #56103