### PR TITLE
scripts: twister: skip unknown platform from hardware map

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -166,7 +166,7 @@ class HardwareMap:
                 if not self.options.platform:
                     self.options.platform = []
                     for d in self.duts:
-                        if d.connected:
+                        if d.connected and d.platform != 'unknown':
                             self.options.platform.append(d.platform)
 
             elif self.options.device_serial:


### PR DESCRIPTION
After generating a hardware-map a platform field is marked as `unknown`. If it is not changed, do not process them when running `--device-testing`.
Why?
Scenario 1: you have many boards connected in CI-setup, but want to use only part of them. 
Scenario 2: you use board with more than one serial port (e.g. nrf52840dk_nrf52840).

After generating a hardware map:
`./scripts/twister --generate-hardware-map hardware_map.yml`
you update only platform strings for boards / serial ports that you want to use. You do not need to remove other entries. They will be skipped.
After re-generating the hardware map, you do not need to update the hardware map file (till now you must remove unwanted entries, because the are added when re-generating hardware map, or change `connected` to False to not process them).

Before change, when you re-generate the hardware map file, you receive error:
```
DEBUG   - adding unit_testing to default platforms
DEBUG   - platform filter: ['nrf9160dk_nrf9160', 'unknown', 'unknown', 'nrf52840dk_nrf52840', 'unknown']
DEBUG   -     arch_filter: None
DEBUG   -      tag_filter: None
DEBUG   -     exclude_tag: None
ERROR   - platform_filter - unrecognized platform - unknown
```
