### PR TITLE
drivers: led_strip: apa102: add multi instances support

### DIFF
--- a/drivers/led_strip/apa102.c
+++ b/drivers/led_strip/apa102.c
@@ -91,16 +91,26 @@ static int apa102_init(const struct device *dev)
 	return 0;
 }
 
-static const struct apa102_config apa102_config = {
-	.bus = SPI_DT_SPEC_INST_GET(
-		0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8), 0)
-};
-
 static const struct led_strip_driver_api apa102_api = {
 	.update_rgb = apa102_update_rgb,
 	.update_channels = apa102_update_channels,
 };
 
-DEVICE_DT_INST_DEFINE(0, apa102_init, NULL,
-		      NULL, &apa102_config, POST_KERNEL,
-		      CONFIG_LED_STRIP_INIT_PRIORITY, &apa102_api);
+#define APA102_DEVICE(idx)						 \
+	static const struct apa102_config apa102_##idx##_config = {	 \
+		.bus = SPI_DT_SPEC_INST_GET(				 \
+			idx,						 \
+			SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8), \
+			0),						 \
+	};								 \
+									 \
+	DEVICE_DT_INST_DEFINE(idx,					 \
+			      apa102_init,				 \
+			      NULL,					 \
+			      NULL,					 \
+			      &apa102_##idx##_config,			 \
+			      POST_KERNEL,				 \
+			      CONFIG_LED_STRIP_INIT_PRIORITY,		 \
+			      &apa102_api);
+
+DT_INST_FOREACH_STATUS_OKAY(APA102_DEVICE)


### PR DESCRIPTION
This allows for multiple apa102 strips on multiple spi ports.

For example:

```
&spi1 {
	led_strip_0: apa102@0 {
		compatible = "apa,apa102";
		reg = <0>;
		spi-max-frequency = <5250000>;
	};
};
&spi2 {
	led_strip_1: apa102@0 {
		compatible = "apa,apa102";
		reg = <0>;
		spi-max-frequency = <5250000>;
	};
};
```