### PR TITLE
drivers: uart: fix compiler warnings in uart emulator

### DIFF
--- a/include/zephyr/drivers/serial/uart_emul.h
+++ b/include/zephyr/drivers/serial/uart_emul.h
@@ -12,6 +12,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SERIAL_UART_EMUL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SERIAL_UART_EMUL_H_
 
+#include <zephyr/device.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
By explicitly adding the include for the Zephyr device one solves the compiler warnings in the UART emulator (_include/zephyr/drivers/serial/uart_emul.h_):

```
/zephyr_os/zephyr/include/zephyr/drivers/serial/uart_emul.h:29:65: error: ‘struct device’ declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
   29 | typedef void (*uart_emul_callback_tx_data_ready_t)(const struct device *dev, size_t size,
      |                                                                 ^~~~~~
/zephyr_os/zephyr/include/zephyr/drivers/serial/uart_emul.h:42:56: error: ‘struct device’ declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
   42 | void uart_emul_callback_tx_data_ready_set(const struct device *dev,
      |                                                        ^~~~~~
/zephyr_os/zephyr/include/zephyr/drivers/serial/uart_emul.h:54:45: error: ‘struct device’ declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
   54 | uint32_t uart_emul_put_rx_data(const struct device *dev, uint8_t *data, size_t size);
      |                                             ^~~~~~
/zephyr_os/zephyr/include/zephyr/drivers/serial/uart_emul.h:65:45: error: ‘struct device’ declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
   65 | uint32_t uart_emul_get_tx_data(const struct device *dev, uint8_t *data, size_t size);
      |                                             ^~~~~~
/zephyr_os/zephyr/include/zephyr/drivers/serial/uart_emul.h:74:47: error: ‘struct device’ declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
   74 | uint32_t uart_emul_flush_rx_data(const struct device *dev);
      |                                               ^~~~~~
/zephyr_os/zephyr/include/zephyr/drivers/serial/uart_emul.h:83:47: error: ‘struct device’ declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
   83 | uint32_t uart_emul_flush_tx_data(const struct device *dev);
      |                                               ^~~~~~
cc1: all warnings being treated as errors
```

I stumbled upon this as I compile with Werror.