### PR TITLE
CIS Central Qualification Fixes

### DIFF
--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -1899,6 +1899,21 @@ struct bt_hci_rp_le_read_iso_tx_sync {
 	uint8_t  offset[3];
 } __packed;
 
+#define BT_HCI_ISO_CIG_ID_MAX                   0xFE
+#define BT_HCI_ISO_CIS_COUNT_MAX                0x1F
+#define BT_HCI_ISO_SDU_INTERVAL_MIN             0x0000FF
+#define BT_HCI_ISO_SDU_INTERVAL_MAX             0x0FFFFF
+#define BT_HCI_ISO_WORST_CASE_SCA_VALID_MASK    0x07
+#define BT_HCI_ISO_PACKING_VALID_MASK           0x01
+#define BT_HCI_ISO_FRAMING_VALID_MASK           0x01
+#define BT_HCI_ISO_MAX_TRANSPORT_LATENCY_MIN    0x0005
+#define BT_HCI_ISO_MAX_TRANSPORT_LATENCY_MAX    0x0FA0
+#define BT_HCI_ISO_CIS_ID_VALID_MAX             0xEF
+#define BT_HCI_ISO_MAX_SDU_VALID_MASK           0x0FFF
+#define BT_HCI_ISO_PHY_VALID_MASK               0x07
+#define BT_HCI_ISO_INTERVAL_MIN                 0x0004
+#define BT_HCI_ISO_INTERVAL_MAX                 0x0C80
+
 #define BT_HCI_OP_LE_SET_CIG_PARAMS             BT_OP(BT_OGF_LE, 0x0062)
 struct bt_hci_cis_params {
 	uint8_t  cis_id;

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2025,26 +2025,21 @@ static void le_set_cig_parameters(struct net_buf *buf, struct net_buf **evt)
 
 	rp = hci_cmd_complete(evt, sizeof(*rp) + cis_count * sizeof(uint16_t));
 	rp->cig_id = cig_id;
-	rp->num_handles = cis_count;
 
 	/* Only apply parameters if all went well */
 	if (!status) {
-		status = ll_cig_parameters_commit(cig_id);
+		uint16_t handles[CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP];
+
+		status = ll_cig_parameters_commit(cig_id, handles);
 
 		if (status == BT_HCI_ERR_SUCCESS) {
-			struct ll_conn_iso_group *cig;
-			uint16_t handle;
-
-			cig = ll_conn_iso_group_get_by_id(cig_id);
-			handle = UINT16_MAX;
-
 			for (uint8_t i = 0; i < cis_count; i++) {
-				(void)ll_conn_iso_stream_get_by_group(cig, &handle);
-				rp->handle[i] = sys_cpu_to_le16(handle);
+				rp->handle[i] = sys_cpu_to_le16(handles[i]);
 			}
 		}
 	}
 
+	rp->num_handles = status ? 0U : cis_count;
 	rp->status = status;
 }
 
@@ -2102,26 +2097,21 @@ static void le_set_cig_params_test(struct net_buf *buf, struct net_buf **evt)
 
 	rp = hci_cmd_complete(evt, sizeof(*rp) + cis_count * sizeof(uint16_t));
 	rp->cig_id = cig_id;
-	rp->num_handles = cis_count;
 
 	/* Only apply parameters if all went well */
 	if (!status) {
-		status = ll_cig_parameters_commit(cig_id);
+		uint16_t handles[CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP];
+
+		status = ll_cig_parameters_commit(cig_id, handles);
 
 		if (status == BT_HCI_ERR_SUCCESS) {
-			struct ll_conn_iso_group *cig;
-			uint16_t handle;
-
-			cig = ll_conn_iso_group_get_by_id(cig_id);
-			handle = UINT16_MAX;
-
 			for (uint8_t i = 0; i < cis_count; i++) {
-				(void)ll_conn_iso_stream_get_by_group(cig, &handle);
-				rp->handle[i] = sys_cpu_to_le16(handle);
+				rp->handle[i] = sys_cpu_to_le16(handles[i]);
 			}
 		}
 	}
 
+	rp->num_handles = status ? 0U : cis_count;
 	rp->status = status;
 }
 

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -148,7 +148,7 @@ uint8_t ll_cis_parameters_set(uint8_t cis_id,
 			      uint16_t c_sdu, uint16_t p_sdu,
 			      uint8_t c_phy, uint8_t p_phy,
 			      uint8_t c_rtn, uint8_t p_rtn);
-uint8_t ll_cig_parameters_commit(uint8_t cig_id);
+uint8_t ll_cig_parameters_commit(uint8_t cig_id, uint16_t *handles);
 uint8_t ll_cig_parameters_test_open(uint8_t cig_id,
 				    uint32_t c_interval,
 				    uint32_t p_interval,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -561,7 +561,7 @@ uint8_t ll_big_terminate(uint8_t big_handle, uint8_t reason)
 		stream_handle = lll_adv_iso->stream_handle[num_bis];
 		handle = LL_BIS_ADV_HANDLE_FROM_IDX(stream_handle);
 		err = ll_remove_iso_path(handle,
-					 BT_HCI_DATAPATH_DIR_HOST_TO_CTLR);
+					 BIT(BT_HCI_DATAPATH_DIR_HOST_TO_CTLR));
 		if (err) {
 			return err;
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -1078,9 +1078,8 @@ static void cis_disabled_cb(void *param)
 				 * CIS for both directions.
 				 */
 				ll_remove_iso_path(cis->lll.handle,
-						   BT_HCI_DATAPATH_DIR_CTLR_TO_HOST);
-				ll_remove_iso_path(cis->lll.handle,
-						   BT_HCI_DATAPATH_DIR_HOST_TO_CTLR);
+						   BIT(BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) |
+						   BIT(BT_HCI_DATAPATH_DIR_HOST_TO_CTLR));
 
 				ll_conn_iso_stream_release(cis);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_internal.h
@@ -31,6 +31,7 @@ struct ll_conn_iso_stream *ll_conn_iso_stream_get_by_acl(struct ll_conn *conn,
 							 uint16_t *cis_iter);
 struct ll_conn_iso_stream *ll_conn_iso_stream_get_by_group(struct ll_conn_iso_group *cig,
 							   uint16_t *handle_iter);
+struct ll_conn_iso_stream *ll_conn_iso_stream_get_by_id(uint8_t cis_id);
 
 void ull_conn_iso_start(struct ll_conn *acl, uint16_t cis_handle,
 			uint32_t ticks_at_expire, uint32_t remainder,

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -8,6 +8,10 @@ struct ll_conn;
 
 typedef void (*ll_iso_stream_released_cb_t)(struct ll_conn *conn);
 
+#define CIG_STATE_NO_CIG       0
+#define CIG_STATE_CONFIGURABLE 1 /* Central only */
+#define CIG_STATE_ACTIVE       2
+#define CIG_STATE_INACTIVE     3
 
 struct ll_conn_iso_stream {
 	struct ll_iso_stream_hdr hdr;
@@ -67,7 +71,9 @@ struct ll_conn_iso_group {
 	uint16_t iso_interval;
 	uint8_t  cig_id;
 
-	uint8_t  started:1;     /* 1 if CIG started and ticker is running */
+	uint8_t  state:2;       /* CIG_STATE_NO_CIG, CIG_STATE_CONFIGURABLE (central only),
+				 * CIG_STATE_ACTIVE or CIG_STATE_INACTIVE.
+				 */
 	uint8_t  sca_update:4;  /* (new SCA)+1 to trigger restart of ticker */
 
 	union {

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -307,7 +307,7 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 	cis_offset = sys_get_le24(ind->cis_offset);
 
 #if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO_EARLY_CIG_START)
-	if (!cig->started) {
+	if (cig->state != CIG_STATE_ACTIVE) {
 		/* This is the first CIS. Make sure we can make the anchorpoint, otherwise
 		 * we need to move up the instant up by one connection interval.
 		 */

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1371,9 +1371,9 @@ static void bt_iso_remove_data_path(struct bt_conn *iso)
 
 		/* Only remove one data path for BIS as per the spec */
 		if (tx_qos) {
-			dir = BT_HCI_DATAPATH_DIR_HOST_TO_CTLR;
+			dir = BIT(BT_HCI_DATAPATH_DIR_HOST_TO_CTLR);
 		} else {
-			dir = BT_HCI_DATAPATH_DIR_CTLR_TO_HOST;
+			dir = BIT(BT_HCI_DATAPATH_DIR_CTLR_TO_HOST);
 		}
 
 		(void)hci_le_remove_iso_data_path(iso, dir);
@@ -1385,9 +1385,8 @@ static void bt_iso_remove_data_path(struct bt_conn *iso)
 		 * data paths that are not setup
 		 */
 		(void)hci_le_remove_iso_data_path(iso,
-						  BT_HCI_DATAPATH_DIR_CTLR_TO_HOST);
-		(void)hci_le_remove_iso_data_path(iso,
-						  BT_HCI_DATAPATH_DIR_HOST_TO_CTLR);
+			BIT(BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) |
+			BIT(BT_HCI_DATAPATH_DIR_HOST_TO_CTLR));
 	} else {
 		__ASSERT(false, "Invalid iso.type: %u", type);
 	}


### PR DESCRIPTION
**Bluetooth: controller: Fix reconfiguring of CIG and CISes**
Up until now, it has not been possible to reconfigure a CIG and its
CISes after initial configuration, without first removing the CIG.

With this commit, le_set_cig_parameters allows the following
reconfiguration operations in configuration state:
- Set new CIG configuration parameters on existing CIG
- Iteratively configure single CIS (of more CISes)
- Increment number of CISes via multiple configuration calls
- Keep handle- and CIS_ID relation

Changes:
- Pass handles in le_set_cig_parameters from ll_cig_parameters_commit
  via output variable.
- Implement CIG state variable instead of 'started', with states
  IDLE/CONFIGURABLE, ACTIVE and INACTIVE.
- Implement ll_conn_iso_stream_get_by_id for easier access to specific
  CIS.

This fixes the following CIS Central EBQ tests:
- HCI/CIS/BI-10-C
- HCI/CIS/BI-11-C
- HCI/CIS/BI-13-C
- HCI/CIS/BV-05-C

**Bluetooth: controller: Validate parameters for CIG configuration**
Parameter checking updates for passing HCI/CIS/BI* EBQ tests.

**Bluetooth: host: Fix hci_le_remove_iso_data_path direction parameters**

The path_dir variable of BT_HCI_OP_LE_REMOVE_ISO_PATH must be bitflags,
with the following meaning:
- BIT(0) : DIR_HOST_TO_CTLR
- BIT(1) : DIR_CTLR_TO_HOST

**Bluetooth: controller: Fix ll_remove_iso_path direction parameter**
According to the Core spec, the direction parameter passed to this function
should be bitfields, i.e.:
- BIT(0) : DIR_HOST_TO_CTLR
- BIT(1) : DIR_CTLR_TO_HOST

Signed-off-by: Morten Priess <mtpr@oticon.com>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/57904