### PR TITLE
Bluetooth: Host: Add L2CAP `seg_recv` API

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -2350,6 +2350,7 @@ PREDEFINED             = __DOXYGEN__ \
                          CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN \
                          CONFIG_BT_BREDR \
                          CONFIG_BT_EATT \
+                         CONFIG_BT_L2CAP_SEG_RECV \
                          CONFIG_BT_MESH_MODEL_EXTENSIONS \
                          CONFIG_BT_REMOTE_INFO \
                          CONFIG_BT_USER_DATA_LEN_UPDATE \

--- a/subsys/bluetooth/host/Kconfig.l2cap
+++ b/subsys/bluetooth/host/Kconfig.l2cap
@@ -1,6 +1,7 @@
 # Bluetooth ATT/GATT configuration options
 
 # Copyright (c) 2019 Intel Corporation
+# Copyright (c) 2023 Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
 menu "L2CAP Options"
@@ -71,5 +72,17 @@ config BT_L2CAP_ECRED
 	help
 	  This option enables support for LE Connection oriented Channels with
 	  Enhanced Credit Based Flow Control support on dynamic L2CAP Channels.
+
+config BT_L2CAP_SEG_RECV
+	bool "L2CAP Receive segment direct API [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+
+	  Enable API for direct receiving of L2CAP SDU segments, bypassing the
+	  Host's fixed-function SDU re-assembler, RX SDU buffer management and
+	  credit issuer.
+
+	  This API enforces conformance with L2CAP TS, but is otherwise as
+	  flexible and semantically simple as possible.
 
 endmenu

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2015-2016 Intel Corporation
+ * Copyright (c) 2023 Nordic Semiconductor
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,6 +12,7 @@
 #include <errno.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/util.h>
 
 #include <zephyr/bluetooth/hci.h>
@@ -504,8 +506,7 @@ static int l2cap_le_conn_req(struct bt_l2cap_le_chan *ch)
 	req->scid = sys_cpu_to_le16(ch->rx.cid);
 	req->mtu = sys_cpu_to_le16(ch->rx.mtu);
 	req->mps = sys_cpu_to_le16(ch->rx.mps);
-	req->credits = sys_cpu_to_le16(1);
-	atomic_set(&ch->rx.credits, 1);
+	req->credits = sys_cpu_to_le16(ch->rx.credits);
 
 	l2cap_chan_send_req(&ch->chan, buf, L2CAP_CONN_TIMEOUT);
 
@@ -541,7 +542,7 @@ static int l2cap_ecred_conn_req(struct bt_l2cap_chan **chan, int channels)
 	req->psm = sys_cpu_to_le16(ch->psm);
 	req->mtu = sys_cpu_to_le16(ch->rx.mtu);
 	req->mps = sys_cpu_to_le16(ch->rx.mps);
-	req->credits = sys_cpu_to_le16(1);
+	req->credits = sys_cpu_to_le16(ch->rx.credits);
 	req_psm = ch->psm;
 	req_mtu = ch->tx.mtu;
 
@@ -839,9 +840,30 @@ int bt_l2cap_server_register(struct bt_l2cap_server *server)
 	return 0;
 }
 
+#if defined(CONFIG_BT_L2CAP_SEG_RECV)
+static void l2cap_chan_seg_recv_rx_init(struct bt_l2cap_le_chan *chan)
+{
+	if (chan->rx.mps > BT_L2CAP_RX_MTU) {
+		LOG_ERR("Limiting RX MPS by stack buffer size.");
+		chan->rx.mps = BT_L2CAP_RX_MTU;
+	}
+
+	chan->_sdu_len = 0;
+	chan->_sdu_len_done = 0;
+}
+#endif /* CONFIG_BT_L2CAP_SEG_RECV */
+
 static void l2cap_chan_rx_init(struct bt_l2cap_le_chan *chan)
 {
 	LOG_DBG("chan %p", chan);
+
+	/* Redirect to experimental API. */
+	IF_ENABLED(CONFIG_BT_L2CAP_SEG_RECV, ({
+		if (chan->chan.ops->seg_recv) {
+			l2cap_chan_seg_recv_rx_init(chan);
+			return;
+		}
+	}))
 
 	/* Use existing MTU if defined */
 	if (!chan->rx.mtu) {
@@ -1029,10 +1051,17 @@ static uint16_t l2cap_chan_accept(struct bt_conn *conn,
 		return le_err_to_result(err);
 	}
 
+#if defined(CONFIG_BT_L2CAP_SEG_RECV)
+	if (!(*chan)->ops->recv == !(*chan)->ops->seg_recv) {
+		LOG_ERR("Exactly one of 'recv' or 'seg_recv' must be set");
+		return BT_L2CAP_LE_ERR_UNACCEPT_PARAMS;
+	}
+#else
 	if (!(*chan)->ops->recv) {
 		LOG_ERR("Mandatory callback 'recv' missing");
 		return BT_L2CAP_LE_ERR_UNACCEPT_PARAMS;
 	}
+#endif
 
 	le_chan = BT_L2CAP_LE_CHAN(*chan);
 
@@ -1051,7 +1080,6 @@ static uint16_t l2cap_chan_accept(struct bt_conn *conn,
 
 	/* Init RX parameters */
 	l2cap_chan_rx_init(le_chan);
-	atomic_set(&le_chan->rx.credits, 1);
 
 	/* Set channel PSM */
 	le_chan->psm = server->psm;
@@ -1119,7 +1147,7 @@ static void le_conn_req(struct bt_l2cap *l2cap, uint8_t ident,
 	LOG_DBG("psm 0x%02x scid 0x%04x mtu %u mps %u credits %u", psm, scid, mtu, mps, credits);
 
 	if (mtu < L2CAP_LE_MIN_MTU || mps < L2CAP_LE_MIN_MTU) {
-		LOG_ERR("Invalid LE-Conn Req params");
+		LOG_ERR("Invalid LE-Conn Req params: mtu %u mps %u", mtu, mps);
 		return;
 	}
 
@@ -1159,8 +1187,7 @@ static void le_conn_req(struct bt_l2cap *l2cap, uint8_t ident,
 	rsp->dcid = sys_cpu_to_le16(le_chan->rx.cid);
 	rsp->mps = sys_cpu_to_le16(le_chan->rx.mps);
 	rsp->mtu = sys_cpu_to_le16(le_chan->rx.mtu);
-	rsp->credits = sys_cpu_to_le16(1);
-	atomic_set(&le_chan->rx.credits, 1);
+	rsp->credits = sys_cpu_to_le16(le_chan->rx.credits);
 
 	rsp->result = BT_L2CAP_LE_SUCCESS;
 
@@ -1211,7 +1238,7 @@ static void le_ecred_conn_req(struct bt_l2cap *l2cap, uint8_t ident,
 	LOG_DBG("psm 0x%02x mtu %u mps %u credits %u", psm, mtu, mps, credits);
 
 	if (mtu < L2CAP_ECRED_MIN_MTU || mps < L2CAP_ECRED_MIN_MTU) {
-		LOG_ERR("Invalid ecred conn req params");
+		LOG_ERR("Invalid ecred conn req params. mtu %u mps %u", mtu, mps);
 		result = BT_L2CAP_LE_ERR_INVALID_PARAMS;
 		goto response;
 	}
@@ -1270,7 +1297,7 @@ response:
 	if (ch) {
 		rsp->mps = sys_cpu_to_le16(ch->rx.mps);
 		rsp->mtu = sys_cpu_to_le16(ch->rx.mtu);
-		rsp->credits = sys_cpu_to_le16(1);
+		rsp->credits = sys_cpu_to_le16(ch->rx.credits);
 	}
 	rsp->result = sys_cpu_to_le16(result);
 
@@ -1632,7 +1659,6 @@ static void le_ecred_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 
 			/* Give credits */
 			l2cap_chan_tx_give_credits(chan, credits);
-			atomic_set(&chan->rx.credits, 1);
 
 			succeeded++;
 		}
@@ -1708,7 +1734,6 @@ static void le_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 
 		/* Give credits */
 		l2cap_chan_tx_give_credits(chan, credits);
-		atomic_set(&chan->rx.credits, 1);
 
 		break;
 	case BT_L2CAP_LE_ERR_AUTHENTICATION:
@@ -2267,6 +2292,95 @@ static void l2cap_chan_send_credits(struct bt_l2cap_le_chan *chan,
 	LOG_DBG("chan %p credits %lu", chan, atomic_get(&chan->rx.credits));
 }
 
+#if defined(CONFIG_BT_L2CAP_SEG_RECV)
+static int l2cap_chan_send_credits_pdu(struct bt_conn *conn, uint16_t cid, uint16_t credits)
+{
+	int err;
+	struct net_buf *buf;
+	struct bt_l2cap_le_credits *ev;
+
+	buf = l2cap_create_le_sig_pdu(NULL, BT_L2CAP_LE_CREDITS, get_ident(), sizeof(*ev));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	ev = net_buf_add(buf, sizeof(*ev));
+	*ev = (struct bt_l2cap_le_credits){
+		.cid = sys_cpu_to_le16(cid),
+		.credits = sys_cpu_to_le16(credits),
+	};
+
+	err = bt_l2cap_send(conn, BT_L2CAP_CID_LE_SIG, buf);
+	if (err) {
+		net_buf_unref(buf);
+		return err;
+	}
+
+	return 0;
+}
+
+/**
+ * Combination of @ref atomic_add and @ref u16_add_overflow. Leaves @p
+ * target unchanged if an overflow would occur. Assumes the current
+ * value of @p target is representable by uint16_t.
+ */
+static bool atomic_add_safe_u16(atomic_t *target, uint16_t addition)
+{
+	uint16_t target_old, target_new;
+
+	do {
+		target_old = atomic_get(target);
+		if (u16_add_overflow(target_old, addition, &target_new)) {
+			return true;
+		}
+	} while (!atomic_cas(target, target_old, target_new));
+
+	return false;
+}
+
+int bt_l2cap_chan_give_credits(struct bt_l2cap_chan *chan, uint16_t additional_credits)
+{
+	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
+
+	if (!chan || !chan->ops) {
+		LOG_ERR("%s: Invalid chan object.", __func__);
+		return -EINVAL;
+	}
+
+	if (!chan->ops->seg_recv) {
+		LOG_ERR("%s: Available only with seg_recv.", __func__);
+		return -EINVAL;
+	}
+
+	if (additional_credits == 0) {
+		LOG_ERR("%s: Refusing to give 0.", __func__);
+		return -EINVAL;
+	}
+
+	if (bt_l2cap_chan_get_state(chan) == BT_L2CAP_CONNECTING) {
+		LOG_ERR("%s: Cannot give credits while connecting.", __func__);
+		return -EBUSY;
+	}
+
+	if (atomic_add_safe_u16(&le_chan->rx.credits, additional_credits)) {
+		LOG_ERR("%s: Overflow.", __func__);
+		return -EOVERFLOW;
+	}
+
+	if (bt_l2cap_chan_get_state(chan) == BT_L2CAP_CONNECTED) {
+		int err;
+
+		err = l2cap_chan_send_credits_pdu(chan->conn, le_chan->rx.cid, additional_credits);
+		if (err) {
+			LOG_ERR("%s: PDU failed %d.", __func__, err);
+			return err;
+		}
+	}
+
+	return 0;
+}
+#endif /* CONFIG_BT_L2CAP_SEG_RECV */
+
 int bt_l2cap_chan_recv_complete(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
@@ -2392,6 +2506,49 @@ static void l2cap_chan_le_recv_seg(struct bt_l2cap_le_chan *chan,
 	l2cap_chan_le_recv_sdu(chan, buf, seg);
 }
 
+#if defined(CONFIG_BT_L2CAP_SEG_RECV)
+static void l2cap_chan_le_recv_seg_direct(struct bt_l2cap_le_chan *chan, struct net_buf *seg)
+{
+	uint16_t seg_offset;
+	uint16_t sdu_remaining;
+
+	if (chan->_sdu_len_done == chan->_sdu_len) {
+
+		/* This is the first PDU in a SDU. */
+
+		if (seg->len < 2) {
+			LOG_WRN("Missing SDU header");
+			bt_l2cap_chan_disconnect(&chan->chan);
+			return;
+		}
+
+		/* Pop off the "SDU header". */
+		chan->_sdu_len = net_buf_pull_le16(seg);
+		chan->_sdu_len_done = 0;
+
+		if (chan->_sdu_len > chan->rx.mtu) {
+			LOG_WRN("SDU exceeds MTU");
+			bt_l2cap_chan_disconnect(&chan->chan);
+			return;
+		}
+	}
+
+	seg_offset = chan->_sdu_len_done;
+	sdu_remaining = chan->_sdu_len - chan->_sdu_len_done;
+
+	if (seg->len > sdu_remaining) {
+		LOG_WRN("L2CAP RX PDU total exceeds SDU");
+		bt_l2cap_chan_disconnect(&chan->chan);
+	}
+
+	/* Commit receive. */
+	chan->_sdu_len_done += seg->len;
+
+	/* Tail call. */
+	chan->chan.ops->seg_recv(&chan->chan, chan->_sdu_len, seg_offset, &seg->b);
+}
+#endif /* CONFIG_BT_L2CAP_SEG_RECV */
+
 static void l2cap_chan_le_recv(struct bt_l2cap_le_chan *chan,
 			       struct net_buf *buf)
 {
@@ -2409,6 +2566,14 @@ static void l2cap_chan_le_recv(struct bt_l2cap_le_chan *chan,
 		bt_l2cap_chan_disconnect(&chan->chan);
 		return;
 	}
+
+	/* Redirect to experimental API. */
+	IF_ENABLED(CONFIG_BT_L2CAP_SEG_RECV, (
+		if (chan->chan.ops->seg_recv) {
+			l2cap_chan_le_recv_seg_direct(chan, buf);
+			return;
+		}
+	))
 
 	/* Check if segments already exist */
 	if (chan->_sdu) {

--- a/tests/bsim/bluetooth/host/compile.sh
+++ b/tests/bsim/bluetooth/host/compile.sh
@@ -49,6 +49,8 @@ app=tests/bsim/bluetooth/host/l2cap/split/dut compile
 app=tests/bsim/bluetooth/host/l2cap/split/tester compile
 app=tests/bsim/bluetooth/host/l2cap/credits compile
 app=tests/bsim/bluetooth/host/l2cap/credits conf_file=prj_ecred.conf compile
+app=tests/bsim/bluetooth/host/l2cap/credits_seg_recv compile
+app=tests/bsim/bluetooth/host/l2cap/credits_seg_recv conf_file=prj_ecred.conf compile
 
 app=tests/bsim/bluetooth/host/misc/disable compile
 

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/CMakeLists.txt
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(bsim_test_l2cap_credits_seg_recv)
+
+target_sources(app PRIVATE
+  src/common.c
+  src/main.c
+  )
+
+zephyr_include_directories(
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  )

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/prj.conf
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/prj.conf
@@ -1,0 +1,24 @@
+CONFIG_BT=y
+CONFIG_BT_CENTRAL=y
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_DEVICE_NAME="L2CAP credits test"
+
+CONFIG_BT_EATT=n
+CONFIG_BT_L2CAP_ECRED=n
+
+CONFIG_BT_SMP=y # Next config depends on it
+CONFIG_BT_L2CAP_DYNAMIC_CHANNEL=y
+
+# Disable auto-initiated procedures so they don't
+# mess with the test's execution.
+CONFIG_BT_AUTO_PHY_UPDATE=n
+CONFIG_BT_AUTO_DATA_LEN_UPDATE=n
+CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=n
+
+CONFIG_LOG=y
+CONFIG_ASSERT=y
+
+CONFIG_BT_L2CAP_SEG_RECV=y
+
+# Enable when the test fails
+# CONFIG_BT_L2CAP_LOG_LEVEL_DBG=y

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/prj_ecred.conf
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/prj_ecred.conf
@@ -1,0 +1,23 @@
+CONFIG_BT=y
+CONFIG_BT_CENTRAL=y
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_DEVICE_NAME="L2CAP credits test"
+
+CONFIG_BT_L2CAP_ECRED=y
+
+CONFIG_BT_SMP=y # Next config depends on it
+CONFIG_BT_L2CAP_DYNAMIC_CHANNEL=y
+
+# Disable auto-initiated procedures so they don't
+# mess with the test's execution.
+CONFIG_BT_AUTO_PHY_UPDATE=n
+CONFIG_BT_AUTO_DATA_LEN_UPDATE=n
+CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=n
+
+CONFIG_LOG=y
+CONFIG_ASSERT=y
+
+CONFIG_BT_L2CAP_SEG_RECV=y
+
+# Enable when the test fails
+# CONFIG_BT_L2CAP_LOG_LEVEL_DBG=y

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/common.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/common.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "common.h"
+
+extern enum bst_result_t bst_result;
+
+void test_init(void)
+{
+	bst_ticker_set_next_tick_absolute(WAIT_TIME);
+	bst_result = In_progress;
+}
+
+void test_tick(bs_time_t HW_device_time)
+{
+	if (bst_result != Passed) {
+		FAIL("test failed (not passed after %i seconds)\n", WAIT_SECONDS);
+	}
+}

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/common.h
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/common.h
@@ -1,0 +1,57 @@
+/*
+ * Common functions and helpers for L2CAP tests
+ *
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+
+#include <zephyr/types.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include "bs_types.h"
+#include "bs_tracing.h"
+#include "bstests.h"
+#include "bs_pc_backchannel.h"
+
+extern enum bst_result_t bst_result;
+
+#define CREATE_FLAG(flag) static atomic_t flag = (atomic_t)false
+#define SET_FLAG(flag) (void)atomic_set(&flag, (atomic_t)true)
+#define UNSET_FLAG(flag) (void)atomic_set(&flag, (atomic_t)false)
+#define TEST_FLAG(flag) (atomic_get(&flag) == (atomic_t)true)
+#define WAIT_FOR_FLAG_SET(flag)		   \
+	while (!(bool)atomic_get(&flag)) { \
+		(void)k_sleep(K_MSEC(1));  \
+	}
+#define WAIT_FOR_FLAG_UNSET(flag)	  \
+	while ((bool)atomic_get(&flag)) { \
+		(void)k_sleep(K_MSEC(1)); \
+	}
+
+
+#define WAIT_SECONDS 30 /* seconds */
+#define WAIT_TIME (WAIT_SECONDS * USEC_PER_SEC) /* microseconds*/
+
+#define FAIL(...)				       \
+	do {					       \
+		bst_result = Failed;		       \
+		bs_trace_error_time_line(__VA_ARGS__); \
+	} while (0)
+
+#define PASS(...)				    \
+	do {					    \
+		bst_result = Passed;		    \
+		bs_trace_info_time(1, __VA_ARGS__); \
+	} while (0)
+
+#define ASSERT(expr, ...) if (!(expr)) {FAIL(__VA_ARGS__); }
+
+void test_init(void);
+void test_tick(bs_time_t HW_device_time);

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
@@ -1,0 +1,461 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bstests.h"
+#include "common.h"
+
+#define LOG_MODULE_NAME main
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL_DBG);
+
+CREATE_FLAG(is_connected);
+CREATE_FLAG(flag_l2cap_connected);
+
+#define L2CAP_MPS CONFIG_BT_L2CAP_TX_MTU
+#define SDU_NUM   3
+#define SDU_LEN   (2 * L2CAP_MPS)
+/* We intentionally send smaller SDUs than the channel can fit */
+#define L2CAP_MTU (2 * SDU_LEN)
+
+/* Only one SDU transmitted or received at a time */
+NET_BUF_POOL_DEFINE(sdu_pool, 1, L2CAP_MTU, 8, NULL);
+
+static uint8_t tx_data[SDU_LEN];
+static uint16_t rx_cnt;
+
+K_SEM_DEFINE(sdu_received, 0, 1);
+
+struct test_ctx {
+	struct bt_l2cap_le_chan le_chan;
+	size_t tx_left;
+} test_ctx;
+
+int l2cap_chan_send(struct bt_l2cap_chan *chan, uint8_t *data, size_t len)
+{
+	struct net_buf *buf;
+	int ret;
+
+	LOG_DBG("chan %p conn %u data %p len %d", chan, bt_conn_index(chan->conn), data, len);
+
+	buf = net_buf_alloc(&sdu_pool, K_NO_WAIT);
+
+	if (buf == NULL) {
+		FAIL("No more memory\n");
+		return -ENOMEM;
+	}
+
+	net_buf_reserve(buf, BT_L2CAP_SDU_CHAN_SEND_RESERVE);
+	net_buf_add_mem(buf, data, len);
+
+	ret = bt_l2cap_chan_send(chan, buf);
+
+	ASSERT(ret >= 0, "Failed sending: err %d", ret);
+
+	LOG_DBG("sent %d len %d", ret, len);
+	return ret;
+}
+
+struct net_buf *alloc_buf_cb(struct bt_l2cap_chan *chan)
+{
+	return net_buf_alloc(&sdu_pool, K_NO_WAIT);
+}
+
+void continue_sending(struct test_ctx *ctx)
+{
+	struct bt_l2cap_chan *chan = &ctx->le_chan.chan;
+
+	LOG_DBG("%p, left %d", chan, ctx->tx_left);
+
+	if (ctx->tx_left) {
+		l2cap_chan_send(chan, tx_data, sizeof(tx_data));
+	} else {
+		LOG_DBG("Done sending %u", bt_conn_index(chan->conn));
+	}
+}
+
+void sent_cb(struct bt_l2cap_chan *chan)
+{
+	LOG_DBG("%p", chan);
+
+	if (test_ctx.tx_left) {
+		test_ctx.tx_left--;
+	}
+
+	continue_sending(&test_ctx);
+}
+
+void recv_cb(struct bt_l2cap_chan *l2cap_chan, size_t sdu_len, off_t seg_offset,
+	     struct net_buf_simple *seg)
+{
+	LOG_DBG("sdu len %u frag offset %u frag len %u", sdu_len, seg_offset, seg->len);
+
+	ASSERT(sdu_len == sizeof(tx_data), "Recv SDU length does not match send length.");
+
+	/* Verify SDU data matches TX'd data. */
+	ASSERT(memcmp(seg->data, &tx_data[seg_offset], seg->len) == 0, "RX data doesn't match TX");
+
+	if (seg_offset + seg->len == sdu_len) {
+		/* Don't give credits right away. The taker of this
+		 * semaphore will give the credits after sleeping a bit.
+		 */
+		rx_cnt++;
+		k_sem_give(&sdu_received);
+	} else {
+		/* To test that we really gave two initial credits, we
+		 * "forget" to send one credit after the first PDU of
+		 * the first SDU.
+		 */
+		if (!(rx_cnt == 0 && seg_offset == 0)) {
+			/* Give more credits to complete SDU. */
+			LOG_DBG("Giving credits for continuing SDU.");
+			bt_l2cap_chan_give_credits(&test_ctx.le_chan.chan, 1);
+		}
+	}
+}
+
+void l2cap_chan_connected_cb(struct bt_l2cap_chan *l2cap_chan)
+{
+	struct bt_l2cap_le_chan *chan = CONTAINER_OF(l2cap_chan, struct bt_l2cap_le_chan, chan);
+
+	/* TODO: check that actual MPS < expected MPS */
+
+	SET_FLAG(flag_l2cap_connected);
+	LOG_DBG("%x (tx mtu %d mps %d) (tx mtu %d mps %d)", l2cap_chan, chan->tx.mtu, chan->tx.mps,
+		chan->rx.mtu, chan->rx.mps);
+}
+
+void l2cap_chan_disconnected_cb(struct bt_l2cap_chan *chan)
+{
+	UNSET_FLAG(flag_l2cap_connected);
+	LOG_DBG("%p", chan);
+}
+
+static struct bt_l2cap_chan_ops ops = {
+	.connected = l2cap_chan_connected_cb,
+	.disconnected = l2cap_chan_disconnected_cb,
+	.alloc_buf = alloc_buf_cb,
+	.seg_recv = recv_cb,
+	.sent = sent_cb,
+};
+
+int server_accept_cb(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+{
+	struct bt_l2cap_le_chan *le_chan = &test_ctx.le_chan;
+
+	*chan = &le_chan->chan;
+
+	/* Always default initialize the chan. */
+	memset(le_chan, 0, sizeof(*le_chan));
+	le_chan->chan.ops = &ops;
+
+	le_chan->rx.mtu = L2CAP_MTU;
+	le_chan->rx.mps = BT_L2CAP_RX_MTU;
+
+	/* Credits can be given before returning from this
+	 * accept-handler and after the 'connected' event. Credits given
+	 * before completing the accept are sent in the 'initial
+	 * credits' field of the connection response PDU.
+	 */
+	bt_l2cap_chan_give_credits(*chan, 2);
+
+	return 0;
+}
+
+static struct bt_l2cap_server test_l2cap_server = {.accept = server_accept_cb};
+
+static int l2cap_server_register(bt_security_t sec_level)
+{
+	int err;
+
+	test_l2cap_server.psm = 0;
+	test_l2cap_server.sec_level = sec_level;
+
+	err = bt_l2cap_server_register(&test_l2cap_server);
+
+	ASSERT(err == 0, "Failed to register l2cap server.");
+
+	return test_l2cap_server.psm;
+}
+
+static void connected(struct bt_conn *conn, uint8_t conn_err)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	if (conn_err) {
+		FAIL("Failed to connect to %s (%u)", addr, conn_err);
+		return;
+	}
+
+	LOG_DBG("%s", addr);
+
+	SET_FLAG(is_connected);
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	LOG_DBG("%p %s (reason 0x%02x)", conn, addr, reason);
+
+	UNSET_FLAG(is_connected);
+}
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = connected,
+	.disconnected = disconnected,
+};
+
+static void disconnect_device(struct bt_conn *conn, void *data)
+{
+	int err;
+
+	SET_FLAG(is_connected);
+
+	err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	ASSERT(!err, "Failed to initate disconnect (err %d)", err);
+
+	LOG_DBG("Waiting for disconnection...");
+	WAIT_FOR_FLAG_UNSET(is_connected);
+}
+
+#define BT_LE_ADV_CONN_NAME_OT                                                                     \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_USE_NAME |                       \
+				BT_LE_ADV_OPT_ONE_TIME,                                            \
+			BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL)
+
+static const struct bt_data ad[] = {
+	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+};
+
+static void test_peripheral_main(void)
+{
+	int err;
+	int psm;
+
+	LOG_DBG("*L2CAP CREDITS Peripheral started*");
+
+	/* Prepare tx_data */
+	for (size_t i = 0; i < sizeof(tx_data); i++) {
+		tx_data[i] = (uint8_t)i;
+	}
+
+	err = bt_enable(NULL);
+	if (err) {
+		FAIL("Can't enable Bluetooth (err %d)", err);
+		return;
+	}
+
+	LOG_DBG("Peripheral Bluetooth initialized.");
+	LOG_DBG("Connectable advertising...");
+	err = bt_le_adv_start(BT_LE_ADV_CONN_NAME_OT, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		FAIL("Advertising failed to start (err %d)", err);
+		return;
+	}
+
+	LOG_DBG("Advertising started.");
+	LOG_DBG("Peripheral waiting for connection...");
+	WAIT_FOR_FLAG_SET(is_connected);
+	LOG_DBG("Peripheral Connected.");
+
+	psm = l2cap_server_register(BT_SECURITY_L1);
+
+	LOG_DBG("Registered server PSM %x", psm);
+
+	LOG_DBG("Peripheral waiting for transfer completion");
+	while (rx_cnt < SDU_NUM) {
+		k_sem_take(&sdu_received, K_FOREVER);
+
+		/* Sleep enough so the peer has time to attempt sending another
+		 * SDU. If it still has credits, it's in its right to do so. If
+		 * it does so before we release the ref below, then allocation
+		 * will fail and the channel will be disconnected.
+		 */
+		k_sleep(K_SECONDS(5));
+		LOG_DBG("release SDU ref");
+		LOG_DBG("Giving credits for new SDU.");
+		bt_l2cap_chan_give_credits(&test_ctx.le_chan.chan, 1);
+	}
+
+	bt_conn_foreach(BT_CONN_TYPE_LE, disconnect_device, NULL);
+	LOG_INF("Total received: %d", rx_cnt);
+
+	ASSERT(rx_cnt == SDU_NUM, "Did not receive expected no of SDUs\n");
+
+	PASS("L2CAP CREDITS Peripheral passed\n");
+}
+
+static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
+			 struct net_buf_simple *ad)
+{
+	char str[BT_ADDR_LE_STR_LEN];
+	int err;
+	struct bt_conn *conn;
+	struct bt_le_conn_param *param;
+
+	err = bt_le_scan_stop();
+	if (err) {
+		FAIL("Stop LE scan failed (err %d)", err);
+		return;
+	}
+
+	bt_addr_le_to_str(addr, str, sizeof(str));
+
+	LOG_DBG("Connecting to %s", str);
+
+	param = BT_LE_CONN_PARAM_DEFAULT;
+	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, param, &conn);
+	if (err) {
+		FAIL("Create conn failed (err %d)", err);
+		return;
+	}
+}
+
+static void connect_peripheral(void)
+{
+	struct bt_le_scan_param scan_param = {
+		.type = BT_LE_SCAN_TYPE_ACTIVE,
+		.options = BT_LE_SCAN_OPT_NONE,
+		.interval = BT_GAP_SCAN_FAST_INTERVAL,
+		.window = BT_GAP_SCAN_FAST_WINDOW,
+	};
+	int err;
+
+	UNSET_FLAG(is_connected);
+
+	err = bt_le_scan_start(&scan_param, device_found);
+
+	ASSERT(!err, "Scanning failed to start (err %d)\n", err);
+
+	LOG_DBG("Central initiating connection...");
+	WAIT_FOR_FLAG_SET(is_connected);
+}
+
+static void connect_l2cap_channel(struct bt_conn *conn, void *data)
+{
+	int err;
+	struct bt_l2cap_le_chan *le_chan = &test_ctx.le_chan;
+
+	*le_chan = (struct bt_l2cap_le_chan){
+		.chan.ops = &ops,
+		.rx.mtu = L2CAP_MTU,
+		.rx.mps = BT_L2CAP_RX_MTU,
+	};
+
+	UNSET_FLAG(flag_l2cap_connected);
+
+	/* Credits can be given before requesting the connection and
+	 * after the 'connected' event. Credits given before connecting
+	 * are sent in the 'initial credits' field of the connection
+	 * request PDU.
+	 */
+	bt_l2cap_chan_give_credits(&le_chan->chan, 1);
+
+	err = bt_l2cap_chan_connect(conn, &le_chan->chan, 0x0080);
+	ASSERT(!err, "Error connecting l2cap channel (err %d)\n", err);
+
+	WAIT_FOR_FLAG_SET(flag_l2cap_connected);
+}
+
+static void connect_l2cap_ecred_channel(struct bt_conn *conn, void *data)
+{
+	int err;
+	struct bt_l2cap_le_chan *le_chan = &test_ctx.le_chan;
+	struct bt_l2cap_chan *chan_list[2] = {&le_chan->chan, 0};
+
+	*le_chan = (struct bt_l2cap_le_chan){
+		.chan.ops = &ops,
+		.rx.mtu = L2CAP_MTU,
+		.rx.mps = BT_L2CAP_RX_MTU,
+	};
+
+	UNSET_FLAG(flag_l2cap_connected);
+
+	/* Credits can be given before requesting the connection and
+	 * after the 'connected' event. Credits given before connecting
+	 * are sent in the 'initial credits' field of the connection
+	 * request PDU.
+	 */
+	bt_l2cap_chan_give_credits(&le_chan->chan, 1);
+
+	err = bt_l2cap_ecred_chan_connect(conn, chan_list, 0x0080);
+	ASSERT(!err, "Error connecting l2cap channel (err %d)\n", err);
+
+	WAIT_FOR_FLAG_SET(flag_l2cap_connected);
+}
+
+static void test_central_main(void)
+{
+	int err;
+
+	LOG_DBG("*L2CAP CREDITS Central started*");
+
+	/* Prepare tx_data */
+	for (size_t i = 0; i < sizeof(tx_data); i++) {
+		tx_data[i] = (uint8_t)i;
+	}
+
+	err = bt_enable(NULL);
+	ASSERT(err == 0, "Can't enable Bluetooth (err %d)\n", err);
+	LOG_DBG("Central Bluetooth initialized.");
+
+	connect_peripheral();
+
+	/* Connect L2CAP channels */
+	LOG_DBG("Connect L2CAP channels");
+	if (IS_ENABLED(CONFIG_BT_L2CAP_ECRED)) {
+		bt_conn_foreach(BT_CONN_TYPE_LE, connect_l2cap_ecred_channel, NULL);
+	} else {
+		bt_conn_foreach(BT_CONN_TYPE_LE, connect_l2cap_channel, NULL);
+	}
+
+	/* Send SDU_NUM SDUs to each peripheral */
+	test_ctx.tx_left = SDU_NUM;
+	l2cap_chan_send(&test_ctx.le_chan.chan, tx_data, sizeof(tx_data));
+
+	LOG_DBG("Wait until all transfers are completed.");
+	while (test_ctx.tx_left) {
+		k_msleep(100);
+	}
+
+	WAIT_FOR_FLAG_UNSET(is_connected);
+	LOG_DBG("Peripheral disconnected.");
+	PASS("L2CAP CREDITS Central passed\n");
+}
+
+static const struct bst_test_instance test_def[] = {
+	{.test_id = "peripheral",
+	 .test_descr = "Peripheral L2CAP CREDITS",
+	 .test_post_init_f = test_init,
+	 .test_tick_f = test_tick,
+	 .test_main_f = test_peripheral_main},
+	{.test_id = "central",
+	 .test_descr = "Central L2CAP CREDITS",
+	 .test_post_init_f = test_init,
+	 .test_tick_f = test_tick,
+	 .test_main_f = test_central_main},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_main_l2cap_credits_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_def);
+}
+
+extern struct bst_test_list *test_main_l2cap_credits_install(struct bst_test_list *tests);
+
+bst_test_install_t test_installers[] = {test_main_l2cap_credits_install, NULL};
+
+int main(void)
+{
+	bst_main();
+
+	return 0;
+}

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests_scripts/_compile.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Usage: Place yourself in the test's root (i.e. ./../)
+
+export BOARD=nrf52_bsim
+
+# Path checks, etc
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+rm -rf ${BSIM_OUT_PATH}/bin/bs_nrf52_bsim_tests*
+
+# terminate running simulations (if any)
+${BSIM_COMPONENTS_PATH}/common/stop_bsim.sh
+
+bsim_exe=bs_nrf52_bsim_tests_bsim_bluetooth_host_l2cap_credits_seg_recv_prj_conf
+west build -b nrf52_bsim && \
+    cp build/zephyr/zephyr.exe ${BSIM_OUT_PATH}/bin/${bsim_exe}
+
+bsim_exe=bs_nrf52_bsim_tests_bsim_bluetooth_host_l2cap_credits_seg_recv_prj_ecred_conf
+west build -b nrf52_bsim -d build_ecred -- -DCONF_FILE=prj_ecred.conf && \
+    cp build_ecred/zephyr/zephyr.exe ${BSIM_OUT_PATH}/bin/${bsim_exe}

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests_scripts/l2cap_credits_seg_recv.sh
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests_scripts/l2cap_credits_seg_recv.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright (c) 2023 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+verbosity_level=2
+EXECUTE_TIMEOUT=20
+
+cd ${BSIM_OUT_PATH}/bin
+
+simulation_id=bluetooth_host_l2cap_credits_seg_recv_prj_conf
+bsim_exe=./bs_nrf52_bsim_tests_bsim_bluetooth_host_l2cap_credits_seg_recv_prj_conf
+
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -rs=420
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -rs=100
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_length=30e6 $@
+
+wait_for_background_jobs
+
+simulation_id=$(basename $BASH_SOURCE)_ecred
+bsim_exe=./bs_nrf52_bsim_tests_bsim_bluetooth_host_l2cap_credits_seg_recv_prj_ecred_conf
+
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -rs=420
+Execute "${bsim_exe}" -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -rs=100
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_length=30e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
This is an alternative API for the L2CAP receive functionality. It allows an application the receive L2CAP segments directly and manage credits explictly. The API is guarded by an experimental kconfig option.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/57485