### PR TITLE
arch: arm64: Added ISBs after SCTLR Modifications

### DIFF
--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -45,6 +45,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__reset_prep_c)
 	/* Reinitialize SCTLR from scratch in EL3 */
 	ldr	w0, =(SCTLR_EL3_RES1 | SCTLR_I_BIT | SCTLR_SA_BIT)
 	msr	sctlr_el3, x0
+	isb
 
 	/* Custom plat prep_c init */
 	bl	z_arm64_el3_plat_prep_c
@@ -58,6 +59,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__reset_prep_c)
 	mrs	x0, sctlr_el2
 	bic	x0, x0, SCTLR_A_BIT
 	msr	sctlr_el2, x0
+	isb
 
 	/* Custom plat prep_c init */
 	bl	z_arm64_el2_plat_prep_c
@@ -71,6 +73,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__reset_prep_c)
 	mrs	x0, sctlr_el1
 	bic	x0, x0, SCTLR_A_BIT
 	msr	sctlr_el1, x0
+	isb
 
 	/* Custom plat prep_c init */
 	bl	z_arm64_el1_plat_prep_c


### PR DESCRIPTION
Per the ARMv8 architecture document, modification of the system control register is a context-changing operation.  Context-changing operations are only guaranteed to be seen after a context synchronization event. An ISB is a context synchronization event.  One has been placed after each SCTLR modification.  Issue was found running full speed on target.  Without ISB's device crashes/resets. 