### PR TITLE
arch: arm64: SCR_EL3 EEL2 Enablement

### DIFF
--- a/arch/arm64/core/reset.c
+++ b/arch/arm64/core/reset.c
@@ -79,6 +79,10 @@ void z_arm64_el3_init(void)
 	reg = 0U;			/* Reset */
 #ifdef CONFIG_ARMV8_A_NS
 	reg |= SCR_NS_BIT;		/* EL2 / EL3 non-secure */
+#else
+	if (is_in_secure_state() && is_el2_sec_supported()) {
+		reg |= SCR_EEL2_BIT;	/* Enable EL2 secure */
+	}
 #endif
 	reg |= (SCR_RES1 |		/* RES1 */
 		SCR_RW_BIT |		/* EL2 execution state is AArch64 */

--- a/include/zephyr/arch/arm64/cpu.h
+++ b/include/zephyr/arch/arm64/cpu.h
@@ -63,6 +63,7 @@
 #define SCR_HCE_BIT		BIT(8)
 #define SCR_RW_BIT		BIT(10)
 #define SCR_ST_BIT		BIT(11)
+#define SCR_EEL2_BIT		BIT(18)
 
 #define SCR_RES1		(BIT(4) | BIT(5))
 


### PR DESCRIPTION
For secure EL2 to be entered the EEL2 bit in SCR_EL3 must be set.  This should only be set if Zephyr has not been configured for NS mode only, if the device is currently in secure EL3, and if secure EL2 is supported via the SEL2 bit in AA64PFRO_EL1.  Added logic to enable EEL2 if all conditions are met.  Exception is seen on target where it is trying to enter secure EL2 from secure EL3.