### PR TITLE
nrf_802154: nrf_802154_serialization_error never returns

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -1144,6 +1144,7 @@ void nrf_802154_energy_detection_failed(nrf_802154_ed_error_t error)
 void nrf_802154_serialization_error(const nrf_802154_ser_err_data_t *err)
 {
 	__ASSERT(false, "802.15.4 serialization error: %d", err->reason);
+	k_oops();
 }
 #endif
 

--- a/samples/boards/nrf/ieee802154/802154_rpmsg/src/main.c
+++ b/samples/boards/nrf/ieee802154/802154_rpmsg/src/main.c
@@ -13,9 +13,11 @@ void nrf_802154_serialization_error(const nrf_802154_ser_err_data_t *err)
 {
 	(void)err;
 	__ASSERT(false, "802.15.4 serialization error");
+	k_oops();
 }
 
 void nrf_802154_sl_fault_handler(uint32_t id, int32_t line, const char *err)
 {
 	__ASSERT(false, "module_id: %u, line: %d, %s", id, line, err);
+	k_oops();
 }


### PR DESCRIPTION
Functions nrf_802154_serialization_error and
nrf_802154_sl_fault_handler shall never return.
However `__ASSERT()` might expand to an empty instruction CONFIG_ASSERT=n and is not enough to stop execution.