### PR TITLE
mgmt: mcumgr: grp: fs_mgmt: Fix cmake selection

### DIFF
--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/CMakeLists.txt
@@ -15,7 +15,7 @@ zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_FS_CHECKSUM_IEEE_CRC32 src/fs_mgm
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_FS_HASH_SHA256 src/fs_mgmt_hash_checksum_sha256.c)
 
 if(CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH AND CONFIG_MCUMGR_GRP_FS_HASH_SHA256)
-  if(NOT CONFIG_TINYCRYPT)
+  if(CONFIG_MBEDTLS_MAC_SHA256_ENABLED)
     zephyr_library_link_libraries(mbedTLS)
   endif()
 endif()


### PR DESCRIPTION
Fixes an issue whereby mbedtls will not be included if tinycrypt is included in the build.