### PR TITLE
tests: boards: esp32: cache_coex: add esp32s2

### DIFF
--- a/tests/boards/espressif_esp32/cache_coex/testcase.yaml
+++ b/tests/boards/espressif_esp32/cache_coex/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   boards.esp32.cache_coex:
-    platform_allow: esp32
+    platform_allow: esp32 esp32s2_saola
     tags:
       - spiram
       - spiflash


### PR DESCRIPTION
Add esp32s2_saola to supported platforms