### PR TITLE
zbus: remove POSIX arch iterable sections restriction

### DIFF
--- a/samples/subsys/zbus/hello_world/sample.yaml
+++ b/samples/subsys/zbus/hello_world/sample.yaml
@@ -27,7 +27,6 @@ tests:
         - "I: Pub a valid value to a channel with validator successfully."
         - "I: Pub an invalid value to a channel with validator successfully."
     arch_exclude:
-      - posix
       - xtensa
     platform_exclude: qemu_leon3
     tags: zbus
@@ -45,6 +44,5 @@ tests:
         - "I: Pub a valid value to a channel with validator successfully."
         - "I: Pub an invalid value to a channel with validator successfully."
     arch_allow:
-      - posix
       - xtensa
     tags: zbus

--- a/subsys/zbus/Kconfig
+++ b/subsys/zbus/Kconfig
@@ -10,7 +10,7 @@ if ZBUS
 
 config ZBUS_STRUCTS_ITERABLE_ACCESS
 	bool "Zbus iterable sections support."
-	depends on !XTENSA && !ARCH_POSIX
+	depends on !XTENSA
 	default y
 
 config ZBUS_CHANNEL_NAME


### PR DESCRIPTION
Zbus iterable sections config in Kconfig unnecessarily excluded POSIX architectures. Remove the constraints and adjust the sample YAML file to enable that.