### PR TITLE
device: Fix doc syntax for DEVICE_DT_GET_ONE

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -265,7 +265,7 @@ typedef int16_t device_handle_t;
  * If an enabled devicetree node has the given compatible and a device object
  * was created from it, this returns a pointer to that device.
  *
- * If there no such devices, this will fail at compile time.
+ * If there are no such devices, this will fail at compile time.
  *
  * If there are multiple, this returns an arbitrary one.
  *


### PR DESCRIPTION
Add the missing verb.