### PR TITLE
net: allow UDP missing checksum by default

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -547,6 +547,7 @@ config NET_UDP_CHECKSUM
 
 config NET_UDP_MISSING_CHECKSUM
 	bool "Accept missing checksum (IPv4 only)"
+	default y
 	depends on NET_UDP && NET_IPV4
 	help
 	  RFC 768 states the possibility to have a missing checksum, for


### PR DESCRIPTION
According to RFC768 UDP packets with zero checksum are allowed with IPv4. Enable this by default.
For example, some routers use zero checksum in DHCP packets.
As discussed in Discord with @rlubos by @clamattia.