### PR TITLE
mgmt/MCUmgr/grp/img: Fix possible missing failure check

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -271,7 +271,7 @@ img_mgmt_state_read(struct smp_streamer *ctxt)
 			}
 		}
 
-		ok = zcbor_tstr_put_term(zse, "hash")						&&
+		ok = ok && zcbor_tstr_put_term(zse, "hash")					&&
 		     zcbor_bstr_encode(zse, &zhash)						&&
 		     ZCBOR_ENCODE_FLAG(zse, "bootable", !(flags & IMAGE_F_NON_BOOTABLE))	&&
 		     ZCBOR_ENCODE_FLAG(zse, "pending",


### PR DESCRIPTION
No reason to continue zcbor encoding of slot information for image list when already failed at encoding version.