### PR TITLE
logging: fix multidomain helpers Doxygen

### DIFF
--- a/include/zephyr/logging/log_multidomain_helper.h
+++ b/include/zephyr/logging/log_multidomain_helper.h
@@ -7,13 +7,22 @@
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_MULTIDOMAIN_HELPER_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_MULTIDOMAIN_HELPER_H_
 
-/* This module aims to provide baseline for links and backends and simplify
+/**
+ * @brief Logger multidomain backend helpers
+ *
+ * This module aims to provide baseline for links and backends and simplify
  * the implementation. It is not core part of logging in similar way as
  * log_output module is just a helper for log message formatting. Links and
  * backends can be implemented without this helper.
+ *
+ * @defgroup log_backend_multidomain Logger multidomain backend helpers
+ * @ingroup log_backend
+ * @{
  */
 
-/**@defgroup LOG_MULTIDOMAIN_HALPER_MESSAGE_IDS IDs of message.
+/**
+ * @name Multidomain message IDs
+ * @anchor LOG_MULTIDOMAIN_HELPER_MESSAGE_IDS
  * @{
  */
 
@@ -46,7 +55,9 @@
 
 /**@} */
 
-/**@defgroup LOG_MULTIDOMAIN_STATUS.
+/**
+ * @name Multidomain status flags
+ * @anchor LOG_MULTIDOMAIN_STATUS
  * @{
  */
 
@@ -233,5 +244,7 @@ void log_multidomain_backend_on_error(struct log_multidomain_backend *backend, i
  * @param err Error code.
  */
 void log_multidomain_backend_on_started(struct log_multidomain_backend *backend, int err);
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_LOGGING_LOG_MULTIDOMAIN_HELPER_H_ */


### PR DESCRIPTION
I realized today that we had a "." and "IDs of message." top level Doxygen sections. It looks like the multidomain helpers module was merged without a proper Doxygen structure. This patch adds the helpers to a subgroup within `log_backend` and uses `@name` to group definitions.

![image](https://github.com/zephyrproject-rtos/zephyr/assets/25011557/263aafa9-250e-4e2a-88e5-5c24c1b5c074)
![image](https://github.com/zephyrproject-rtos/zephyr/assets/25011557/264a29fc-adc8-4cac-9b64-3dead40b10fc)
