### PR TITLE
bluetooth: mesh: fix some Doxygen groups location

### DIFF
--- a/include/zephyr/bluetooth/mesh/blob.h
+++ b/include/zephyr/bluetooth/mesh/blob.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @defgroup bt_mesh_blob Bluetooth mesh BLOB model API
- * @{
- * @brief API for the Bluetooth mesh Binary Large Object Transfer models.
- */
-
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_H__
 
@@ -21,6 +14,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup bt_mesh_blob Bluetooth Mesh BLOB model API
+ * @ingroup bt_mesh
+ * @{
+ */
 
 #ifndef CONFIG_BT_MESH_BLOB_CHUNK_COUNT_MAX
 #define CONFIG_BT_MESH_BLOB_CHUNK_COUNT_MAX 0
@@ -254,10 +253,10 @@ struct bt_mesh_blob_io {
 		  const struct bt_mesh_blob_chunk *chunk);
 };
 
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_H__ */
-
-/** @} */

--- a/include/zephyr/bluetooth/mesh/blob_cli.h
+++ b/include/zephyr/bluetooth/mesh/blob_cli.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @defgroup bt_mesh_blob_cli BLOB Transfer Client model API
- * @{
- * @brief API for the Binary Large Object Transfer Client model.
- */
-
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_CLI_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_CLI_H_
 
@@ -22,6 +15,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup bt_mesh_blob_cli Bluetooth Mesh BLOB Transfer Client model API
+ * @ingroup bt_mesh
+ * @{
+ */
 
 struct bt_mesh_blob_cli;
 
@@ -425,10 +424,10 @@ extern const struct bt_mesh_model_op _bt_mesh_blob_cli_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_blob_cli_cb;
 /** @endcond */
 
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_CLI_H_ */
-
-/** @} */

--- a/include/zephyr/bluetooth/mesh/blob_io_flash.h
+++ b/include/zephyr/bluetooth/mesh/blob_io_flash.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @defgroup bt_mesh_blob_io_flash Bluetooth mesh BLOB flash stream
- * @{
- * @brief
- */
-
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_IO_FLASH_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_IO_FLASH_H__
 
@@ -19,6 +12,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup bt_mesh_blob_io_flash Bluetooth Mesh BLOB flash stream
+ * @ingroup bt_mesh
+ * @{
+ */
 
 /** BLOB flash stream. */
 struct bt_mesh_blob_io_flash {
@@ -47,10 +46,10 @@ struct bt_mesh_blob_io_flash {
 int bt_mesh_blob_io_flash_init(struct bt_mesh_blob_io_flash *flash,
 			       uint8_t area_id, off_t offset);
 
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_IO_FLASH_H__ */
-
-/** @} */

--- a/include/zephyr/bluetooth/mesh/blob_srv.h
+++ b/include/zephyr/bluetooth/mesh/blob_srv.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @defgroup bt_mesh_blob_srv Bluetooth mesh BLOB Transfer Server model API
- * @{
- * @brief API for the Bluetooth Mesh Binary Large Object (BLOB) Transfer Server model.
- */
-
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_SRV_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_SRV_H_
 
@@ -20,6 +13,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup bt_mesh_blob_srv Bluetooth Mesh BLOB Transfer Server model API
+ * @ingroup bt_mesh
+ * @{
+ */
 
 struct bt_mesh_blob_srv;
 
@@ -212,10 +211,10 @@ extern const struct bt_mesh_model_op _bt_mesh_blob_srv_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_blob_srv_cb;
 /** @endcond */
 
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_SRV_H_ */
-
-/** @} */

--- a/include/zephyr/bluetooth/mesh/dfu.h
+++ b/include/zephyr/bluetooth/mesh/dfu.h
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @defgroup bt_mesh_dfu Bluetooth mesh Device Firmware Update
- * @{
- * @brief Common types and functions for the Bluetooth mesh Device Firmware
- *        Update procedure.
- */
-
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFU_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFU_H__
 
@@ -23,6 +15,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup bt_mesh_dfu Bluetooth Mesh Device Firmware Update
+ * @ingroup bt_mesh
+ * @{
+ */
 
 #ifndef CONFIG_BT_MESH_DFU_FWID_MAXLEN
 #define CONFIG_BT_MESH_DFU_FWID_MAXLEN 0
@@ -171,10 +169,10 @@ struct bt_mesh_dfu_slot {
 	char uri[CONFIG_BT_MESH_DFU_URI_MAXLEN];
 };
 
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFU_H__ */
-
-/** @} */

--- a/include/zephyr/bluetooth/mesh/od_priv_proxy_cli.h
+++ b/include/zephyr/bluetooth/mesh/od_priv_proxy_cli.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @defgroup bt_mesh_od_priv_proxy_cli Bluetooth Mesh On-Demand Private GATT Proxy Client
- * @{
- * @brief
- */
-
 #ifndef BT_MESH_OD_PRIV_PROXY_CLI_H__
 #define BT_MESH_OD_PRIV_PROXY_CLI_H__
 
@@ -19,6 +12,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup bt_mesh_od_priv_proxy_cli Bluetooth Mesh On-Demand Private GATT Proxy Client
+ * @ingroup bt_mesh
+ * @{
+ */
 
 /** On-Demand Private Proxy Client Model Context */
 struct bt_mesh_od_priv_proxy_cli {
@@ -93,10 +92,10 @@ extern const struct bt_mesh_model_op _bt_mesh_od_priv_proxy_cli_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_od_priv_proxy_cli_cb;
 /** @endcond */
 
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* BT_MESH_OD_PRIV_PROXY_CLI_H__ */
-
-/** @} */

--- a/include/zephyr/bluetooth/mesh/od_priv_proxy_srv.h
+++ b/include/zephyr/bluetooth/mesh/od_priv_proxy_srv.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @defgroup bt_mesh_od_priv_proxy_srv Bluetooth Mesh On-Demand Private GATT Proxy Server
- * @{
- * @brief
- */
-
 #ifndef BT_MESH_OD_PRIV_PROXY_SRV_H__
 #define BT_MESH_OD_PRIV_PROXY_SRV_H__
 
@@ -19,6 +12,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup bt_mesh_od_priv_proxy_srv Bluetooth Mesh On-Demand Private GATT Proxy Server
+ * @ingroup bt_mesh
+ * @{
+ */
 
 /**
  *  @brief On-Demand Private Proxy Server model composition data entry.
@@ -34,10 +33,10 @@ extern const struct bt_mesh_model_op _bt_mesh_od_priv_proxy_srv_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_od_priv_proxy_srv_cb;
 /** @endcond */
 
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* BT_MESH_OD_PRIV_PROXY_SRV_H__ */
-
-/** @} */

--- a/include/zephyr/bluetooth/mesh/priv_beacon_cli.h
+++ b/include/zephyr/bluetooth/mesh/priv_beacon_cli.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @defgroup bt_mesh_priv_beacon_cli Bluetooth Mesh Private Beacon Client
- * @{
- * @brief
- */
-
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_PRIV_BEACON_CLI_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_PRIV_BEACON_CLI_H__
 
@@ -19,6 +12,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup bt_mesh_priv_beacon_cli Bluetooth Mesh Private Beacon Client
+ * @ingroup bt_mesh
+ * @{
+ */
 
 /**
  *
@@ -175,10 +174,10 @@ extern const struct bt_mesh_model_op bt_mesh_priv_beacon_cli_op[];
 extern const struct bt_mesh_model_cb bt_mesh_priv_beacon_cli_cb;
 /** @endcond */
 
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_MESH_PRIV_BEACON_CLI_H__ */
-
-/** @} */

--- a/include/zephyr/bluetooth/mesh/priv_beacon_srv.h
+++ b/include/zephyr/bluetooth/mesh/priv_beacon_srv.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @defgroup bt_mesh_priv_beacon_srv Bluetooth Mesh Private Beacon Server
- * @{
- * @brief
- */
-
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_PRIV_BEACON_SRV_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_PRIV_BEACON_SRV_H__
 
@@ -19,6 +12,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup bt_mesh_priv_beacon_srv Bluetooth Mesh Private Beacon Server
+ * @ingroup bt_mesh
+ * @{
+ */
 
 /**
  *
@@ -34,10 +33,10 @@ extern const struct bt_mesh_model_op bt_mesh_priv_beacon_srv_op[];
 extern const struct bt_mesh_model_cb bt_mesh_priv_beacon_srv_cb;
 /** @endcond */
 
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_MESH_PRIV_BEACON_SRV_H__ */
-
-/** @} */

--- a/include/zephyr/bluetooth/mesh/sol_pdu_rpl_cli.h
+++ b/include/zephyr/bluetooth/mesh/sol_pdu_rpl_cli.h
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @defgroup bt_mesh_sol_pdu_rpl_cli Bluetooth Mesh Solicitation PDU RPL Client
- * @{
- * @brief
- */
-
 #ifndef BT_MESH_SOL_PDU_RPL_CLI_H__
 #define BT_MESH_SOL_PDU_RPL_CLI_H__
 
@@ -19,6 +12,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup bt_mesh_sol_pdu_rpl_cli Bluetooth Mesh Solicitation PDU RPL Client
+ * @ingroup bt_mesh
+ * @{
+ */
 
 /** Solicitation PDU RPL Client Model Context */
 struct bt_mesh_sol_pdu_rpl_cli {
@@ -96,10 +95,10 @@ extern const struct bt_mesh_model_op _bt_mesh_sol_pdu_rpl_cli_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_sol_pdu_rpl_cli_cb;
 /** @endcond */
 
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* BT_MESH_SOL_PDU_RPL_CLI_H__ */
-
-/** @} */

--- a/include/zephyr/bluetooth/mesh/sol_pdu_rpl_srv.h
+++ b/include/zephyr/bluetooth/mesh/sol_pdu_rpl_srv.h
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @defgroup bt_mesh_sol_pdu_rpl_srv Bluetooth Mesh Solicitation PDU RPL Server
- * @{
- * @brief
- */
-
 #ifndef BT_MESH_SOL_PDU_RPL_SRV_H__
 #define BT_MESH_SOL_PDU_RPL_SRV_H__
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @defgroup bt_mesh_sol_pdu_rpl_srv Bluetooth Mesh Solicitation PDU RPL Server
+ * @ingroup bt_mesh
+ * @{
+ */
 
 /**
  *  @brief Solicitation PDU RPL Server model composition data entry.
@@ -30,9 +30,9 @@ extern const struct bt_mesh_model_op _bt_mesh_sol_pdu_rpl_srv_op[];
 extern const struct bt_mesh_model_cb _bt_mesh_sol_pdu_rpl_srv_cb;
 /** @endcond */
 
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif
 #endif /* BT_MESH_SOL_PDU_RPL_SRV_H__ */
-
-/** @} */


### PR DESCRIPTION
Bluetooth mesh had many groups defined as top level Doxygen groups. Place all of them to `bt_mesh`. Also removed redundant `@brief` entries, and placed the block at the right location (just below extern "C" entry).

![image](https://github.com/zephyrproject-rtos/zephyr/assets/25011557/f4bf8b82-920b-4a28-a337-1a00ec6b389e)
