### PR TITLE
soc: arm: st_stm32: stm32l0: Add support for stm32l051X6

### DIFF
--- a/dts/arm/st/l0/stm32l051X6.dtsi
+++ b/dts/arm/st/l0/stm32l051X6.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Muxen SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/l0/stm32l051.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(8)>;
+	};
+
+	soc {
+		flash-controller@40022000{
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(32)>;
+			};
+		};
+
+	};
+};


### PR DESCRIPTION
This commit add the dts for the STM32L051X6.