### PR TITLE
doc: Cleanup/org Distinguishing Features list

### DIFF
--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -79,15 +79,6 @@ Zephyr offers a large and ever growing number of features including:
      * Red/black tree ready queue
      * Traditional multi-queue ready queue
 
-**Highly configurable / Modular for flexibility**
-   Allows an application to incorporate *only* the capabilities it needs as it
-   needs them, and to specify their quantity and size.
-
-**Cross Architecture**
-   Supports a wide variety of :ref:`supported boards<boards>` with different CPU
-   architectures and developer tools. Contributions have added support
-   for an increasing number of SoCs, platforms, and drivers.
-
 **Memory Protection**
    Implements configurable architecture-specific stack-overflow protection,
    kernel object and device driver permission tracking, and thread isolation
@@ -99,10 +90,6 @@ Zephyr offers a large and ever growing number of features including:
    monolithic image that gets loaded and executed on a system's hardware. Both
    the application code and kernel code execute in a single shared address
    space.
-
-**Compile-time resource definition**
-   Allows system resources to be defined at compile-time, which reduces code
-   size and increases performance for resource-limited systems.
 
 **Optimized Device Driver Model**
    Provides a consistent device model for configuring the drivers that are part
@@ -141,11 +128,6 @@ Zephyr offers a large and ever growing number of features including:
    * Both Provisioning bearers supported (PB-ADV & PB-GATT)
    * Highly configurable, fitting in devices with at least 16k RAM
 
-**Native Linux, macOS, and Windows Development**
-   A command-line CMake build environment runs on popular developer OS
-   systems. A native POSIX port, lets you build and run Zephyr as a native
-   application on Linux and other OSes, aiding development and testing.
-
 **Virtual File System Interface with LittleFS and FATFS Support**
    LittleFS and FATFS Support,
    FCB (Flash Circular Buffer) for memory constrained applications, and
@@ -178,9 +160,36 @@ Zephyr offers a large and ever growing number of features including:
 **Reusable, extensible framework**
   Zephyr offers a number of familiar features for development:
 
+  * *Highly configurable / Modular for flexibility*
+
+    that allows an application to incorporate *only* the capabilities
+    it needs as it needs them, and to specify their quantity and size.
+
+  * *Native Linux, macOS, and Windows Development*
+
+    to a command-line CMake build environment that runs on popular
+    developer host systems. A native POSIX port that lets you build
+    and run Zephyr as a native application on Linux and other OSes,
+    aiding development and testing.
+
+
 **Configurable, extensible domain architecture**
   Zephyr supports efficiently retargeting functionality at a wide variety
   of target architectures.
+
+  * *Cross CPU Architecture*
+
+    that supports a wide variety of :ref:`supported boards <boards>`
+    with different CPU architectures and developer tools. Contributions
+    have added support for an increasing number of SoCs, platforms,
+    and drivers.
+
+  * *Compile-time resource definition*
+
+    that allows system resources to be defined at compile-time,
+    which reduces code size and increases performance for
+    resource-limited systems.
+
 
 **Extensive reusable asset base**
   Zephyr offers a large and ever growing number of features including:

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -42,42 +42,9 @@ Distinguishing Features
 
 Zephyr offers a large and ever growing number of features including:
 
-**Optimized Device Driver Model**
-   Provides a consistent device model for configuring the drivers that are part
-   of the platform/system and a consistent model for initializing all the
-   drivers configured into the system and Allows the reuse of drivers across
-   platforms that have common devices/IP blocks
-
 **Devicetree Support**
    Use of :ref:`devicetree <dt-guide>` to describe hardware.
    Information from devicetree is used to create the application image.
-
-**Native Networking Stack supporting multiple protocols**
-   Networking support is fully featured and optimized, including LwM2M and BSD
-   sockets compatible support.  OpenThread support (on Nordic chipsets) is also
-   provided - a mesh network designed to securely and reliably connect hundreds
-   of products around the home.
-
-**Bluetooth Low Energy 5.0 support**
-   Bluetooth 5.0 compliant (ESR10) and Bluetooth Low Energy Controller support
-   (LE Link Layer). Includes Bluetooth mesh and a Bluetooth qualification-ready
-   Bluetooth controller.
-
-   * Generic Access Profile (GAP) with all possible LE roles.
-   * GATT (Generic Attribute Profile)
-   * Pairing support, including the Secure Connections feature from Bluetooth
-     4.2
-   * Clean HCI driver abstraction
-   * Raw HCI interface to run Zephyr as a Controller instead of a full Host
-     stack
-   * Verified with multiple popular controllers
-   * Highly configurable
-
-   Mesh Support:
-
-   * Relay, Friend Node, Low-Power Node (LPN) and GATT Proxy features
-   * Both Provisioning bearers supported (PB-ADV & PB-GATT)
-   * Highly configurable, fitting in devices with at least 16k RAM
 
 **Virtual File System Interface with LittleFS and FATFS Support**
    LittleFS and FATFS Support,
@@ -207,6 +174,42 @@ Zephyr offers a large and ever growing number of features including:
        Both the application code and kernel code execute in a single
        shared address space.
 
+
+  * *Optimized Device Driver Model*
+
+    Provides a consistent device model for configuring the drivers that are part
+    of the platform/system and a consistent model for initializing all the
+    drivers configured into the system and Allows the reuse of drivers across
+    platforms that have common devices/IP blocks
+
+  * *Native Networking Stack supporting multiple protocols*
+
+    Networking support is fully featured and optimized, including LwM2M and BSD
+    sockets compatible support.  OpenThread support (on Nordic chipsets) is also
+    provided - a mesh network designed to securely and reliably connect hundreds
+    of products around the home.
+
+  * *Bluetooth Low Energy 5.0 support*
+
+    Bluetooth 5.0 compliant (ESR10) and Bluetooth Low Energy Controller support
+    (LE Link Layer). Includes Bluetooth mesh and a Bluetooth qualification-ready
+    Bluetooth controller.
+
+    * Generic Access Profile (GAP) with all possible LE roles.
+    * GATT (Generic Attribute Profile)
+    * Pairing support, including the Secure Connections feature from Bluetooth
+      4.2
+    * Clean HCI driver abstraction
+    * Raw HCI interface to run Zephyr as a Controller instead of a full Host
+      stack
+    * Verified with multiple popular controllers
+    * Highly configurable
+
+    Mesh Support:
+
+    * Relay, Friend Node, Low-Power Node (LPN) and GATT Proxy features
+    * Both Provisioning bearers supported (PB-ADV & PB-GATT)
+    * Highly configurable, fitting in devices with at least 16k RAM
 
 .. include:: ../../README.rst
    :start-after: start_include_here

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -46,30 +46,6 @@ Zephyr offers a large and ever growing number of features including:
    Use of :ref:`devicetree <dt-guide>` to describe hardware.
    Information from devicetree is used to create the application image.
 
-**Virtual File System Interface with LittleFS and FATFS Support**
-   LittleFS and FATFS Support,
-   FCB (Flash Circular Buffer) for memory constrained applications, and
-   file system enhancements for logging and configuration.
-
-**Powerful multi-backend logging Framework**
-   Support for log filtering, object dumping, panic mode, multiple backends
-   (memory, networking, filesystem, console, ..) and integration with the shell
-   subsystem.
-
-**User friendly and full-featured Shell interface**
-   A multi-instance shell subsystem with user-friendly features such as
-   autocompletion, wildcards, coloring, metakeys (arrows, backspace, ctrl+u,
-   etc.) and history. Support for static commands and dynamic sub-commands.
-
-**Settings on non-volatile storage**
-   The settings subsystem gives modules a way to store persistent per-device
-   configuration and runtime state.  Settings items are stored as key-value pair
-   strings.
-
-**Non-volatile storage (NVS)**
-  NVS allows storage of binary blobs, strings, integers, longs, and any
-  combination of these.
-
 **Native POSIX port**
   Supports running Zephyr as a Linux application with support for various
   subsystems and networking.
@@ -210,6 +186,36 @@ Zephyr offers a large and ever growing number of features including:
     * Relay, Friend Node, Low-Power Node (LPN) and GATT Proxy features
     * Both Provisioning bearers supported (PB-ADV & PB-GATT)
     * Highly configurable, fitting in devices with at least 16k RAM
+
+  * *Virtual File System Interface with LittleFS and FATFS Support*
+
+    LittleFS and FATFS Support,
+    FCB (Flash Circular Buffer) for memory constrained applications, and
+    file system enhancements for logging and configuration.
+
+  * *Powerful multi-backend logging Framework*
+
+    Support for log filtering, object dumping, panic mode, multiple backends
+    (memory, networking, filesystem, console, ..) and integration with the shell
+    subsystem.
+
+  * *User friendly and full-featured Shell interface*
+
+    A multi-instance shell subsystem with user-friendly features such as
+    autocompletion, wildcards, coloring, metakeys (arrows, backspace, ctrl+u,
+    etc.) and history. Support for static commands and dynamic sub-commands.
+
+  * *Settings on non-volatile storage*
+
+    The settings subsystem gives modules a way to store persistent per-device
+    configuration and runtime state.  Settings items are stored as key-value pair
+    strings.
+
+  * *Non-volatile storage (NVS)*
+
+    NVS allows storage of binary blobs, strings, integers, longs, and any
+    combination of these.
+
 
 .. include:: ../../README.rst
    :start-after: start_include_here

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -42,55 +42,6 @@ Distinguishing Features
 
 Zephyr offers a large and ever growing number of features including:
 
-**Extensive suite of Kernel services**
-   Zephyr offers a number of familiar services for development:
-
-   * *Multi-threading Services* for cooperative, priority-based,
-     non-preemptive, and preemptive threads with optional round robin
-     time-slicing. Includes POSIX pthreads compatible API support.
-
-   * *Interrupt Services* for compile-time registration of interrupt handlers.
-
-   * *Memory Allocation Services* for dynamic allocation and freeing of
-     fixed-size or variable-size memory blocks.
-
-   * *Inter-thread Synchronization Services* for binary semaphores,
-     counting semaphores, and mutex semaphores.
-
-   * *Inter-thread Data Passing Services* for basic message queues, enhanced
-     message queues, and byte streams.
-
-   * *Power Management Services* such as overarching, application or
-     policy-defined, System Power Management and fine-grained, driver-defined,
-     Device Power Management.
-
-**Multiple Scheduling Algorithms**
-   Zephyr provides a comprehensive set of thread scheduling choices:
-
-   * Cooperative and Preemptive Scheduling
-   * Earliest Deadline First (EDF)
-   * Meta IRQ scheduling implementing "interrupt bottom half" or "tasklet"
-     behavior
-   * Timeslicing: Enables time slicing between preemptible threads of equal
-     priority
-   * Multiple queuing strategies:
-
-     * Simple linked-list ready queue
-     * Red/black tree ready queue
-     * Traditional multi-queue ready queue
-
-**Memory Protection**
-   Implements configurable architecture-specific stack-overflow protection,
-   kernel object and device driver permission tracking, and thread isolation
-   with thread-level memory protection on x86, ARC, and ARM architectures,
-   userspace, and memory domains.
-
-   For platforms without MMU/MPU and memory constrained devices, supports
-   combining application-specific code with a custom kernel to create a
-   monolithic image that gets loaded and executed on a system's hardware. Both
-   the application code and kernel code execute in a single shared address
-   space.
-
 **Optimized Device Driver Model**
    Provides a consistent device model for configuring the drivers that are part
    of the platform/system and a consistent model for initializing all the
@@ -193,6 +144,69 @@ Zephyr offers a large and ever growing number of features including:
 
 **Extensive reusable asset base**
   Zephyr offers a large and ever growing number of features including:
+
+  * *Extensive suite of Kernel services*
+
+    Zephyr offers a number of familiar services for development:
+
+    * *Multi-threading Services*
+
+      for cooperative, priority-based,
+      non-preemptive, and preemptive threads with optional round robin
+      time-slicing. Includes POSIX pthreads compatible API support.
+
+    * *Interrupt Services*
+
+      for compile-time registration of interrupt handlers.
+
+    * *Memory Allocation Services*
+
+      for dynamic allocation and freeing of fixed-size or
+      variable-size memory blocks.
+
+    * *Inter-thread Synchronization Services*
+
+      for binary semaphores, counting semaphores, and mutex semaphores.
+
+    * *Inter-thread Data Passing Services*
+
+      for basic message queues, enhanced message queues, and byte streams.
+
+    * *Power Management Services*
+
+      such as overarching, application or policy-defined,
+      System Power Management and fine-grained, driver-defined,
+      Device Power Management.
+
+    * *Multiple Scheduling Algorithms*
+
+      Zephyr provides a comprehensive set of thread scheduling choices:
+
+      * Cooperative and Preemptive Scheduling
+      * Earliest Deadline First (EDF)
+      * Meta IRQ scheduling implementing "interrupt bottom half" or "tasklet"
+        behavior
+      * Timeslicing: Enables time slicing between preemptible threads of equal
+        priority
+      * Multiple queuing strategies:
+
+        * Simple linked-list ready queue
+        * Red/black tree ready queue
+        * Traditional multi-queue ready queue
+
+    * *Memory Protection*
+
+       Implements configurable architecture-specific stack-overflow protection,
+       kernel object and device driver permission tracking, and thread isolation
+       with thread-level memory protection on x86, ARC, and ARM architectures,
+       userspace, and memory domains.
+
+       For platforms without MMU/MPU and memory constrained devices, supports
+       combining application-specific code with a custom kernel to create a
+       monolithic image that gets loaded and executed on a system's hardware.
+       Both the application code and kernel code execute in a single
+       shared address space.
+
 
 .. include:: ../../README.rst
    :start-after: start_include_here

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -45,10 +45,34 @@ Zephyr offers a large and ever growing number of features including:
 **Reusable, extensible framework**
   Zephyr offers a number of familiar features for development:
 
+  * *Project-specific feature-based configuration management*
+
+    built around Kconfig.  For describing which high-level features to build
+    into a specific product.
+
   * *Board-specific hardware descriptions*
 
     built around :ref:`devicetree <dt-guide>` to describe hardware.
     Information from devicetree is used to create the application image.
+
+  * *Test framework, test runner, and code coverage tools*
+
+    to verify only the specified functionality exists in the code-under-test.
+
+  * *Extenensible, modular workspace*
+
+    to support integration of non-child source repositories as well as
+    Git submodules into the ecosystem.
+
+  * *Extensible documentation*
+
+    to capture all the content in the workspace.
+
+  * *Generated linker directives and system interfaces*
+
+  * *Extensible build system*
+
+    for integration of modules using other tools to build libraries.
 
   * *Highly configurable / Modular for flexibility*
 

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -175,6 +175,16 @@ Zephyr offers a large and ever growing number of features including:
   subsystems and networking.
 
 
+**Reusable, extensible framework**
+  Zephyr offers a number of familiar features for development:
+
+**Configurable, extensible domain architecture**
+  Zephyr supports efficiently retargeting functionality at a wide variety
+  of target architectures.
+
+**Extensive reusable asset base**
+  Zephyr offers a large and ever growing number of features including:
+
 .. include:: ../../README.rst
    :start-after: start_include_here
 

--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -42,17 +42,13 @@ Distinguishing Features
 
 Zephyr offers a large and ever growing number of features including:
 
-**Devicetree Support**
-   Use of :ref:`devicetree <dt-guide>` to describe hardware.
-   Information from devicetree is used to create the application image.
-
-**Native POSIX port**
-  Supports running Zephyr as a Linux application with support for various
-  subsystems and networking.
-
-
 **Reusable, extensible framework**
   Zephyr offers a number of familiar features for development:
+
+  * *Board-specific hardware descriptions*
+
+    built around :ref:`devicetree <dt-guide>` to describe hardware.
+    Information from devicetree is used to create the application image.
 
   * *Highly configurable / Modular for flexibility*
 
@@ -215,6 +211,11 @@ Zephyr offers a large and ever growing number of features including:
 
     NVS allows storage of binary blobs, strings, integers, longs, and any
     combination of these.
+
+  * *Native POSIX port*
+
+    Supports running Zephyr as a Linux application with support for various
+    subsystems and networking.
 
 
 .. include:: ../../README.rst


### PR DESCRIPTION
Clean up the organization of the Distinguishing Features list re-grouped under:
- Reusable, extensible framework
- Configurable, extensible domain architecture
- Extensible reusable asset base

Verified by:

1. make html-fast

Fix #58201