### PR TITLE
boards: arm: adafruit_feather_m0_lora: add lora0 to dts in order to compile lora samples

### DIFF
--- a/boards/arm/adafruit_feather_m0_lora/adafruit_feather_m0_lora.dts
+++ b/boards/arm/adafruit_feather_m0_lora/adafruit_feather_m0_lora.dts
@@ -25,6 +25,7 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
+		lora0 = &lora;
 	};
 
 	leds {


### PR DESCRIPTION
Just a tiny fix to build the samples under `drivers/lora/send|receive` for the `adafruit_feather_m0_lora` board.

Was able to compile and run it successfully on two boards with send and receive functionality.