### PR TITLE
manifest: mcuboot: update mcuboot revision to get fix for zcbor usage

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 2878eb4e32fabc14bc391c3221cbf285064d9db4
+      revision: pull/105/head
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update MCUBoot revision to get fix for zcbor API usage, which was causing serial recovery mode to fail on some iMX RT boards.

Fixes #57272