### PR TITLE
kernel: add macro to define threads to run in kernel mode only

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -680,6 +680,22 @@ struct _static_thread_data {
 	.init_name = STRINGIFY(tname),                           \
 	}
 
+/*
+ * Refer to K_THREAD_DEFINE() and K_KERNEL_THREAD_DEFINE() for
+ * information on arguments.
+ */
+#define Z_THREAD_COMMON_DEFINE(name, stack_size,			\
+			       entry, p1, p2, p3,			\
+			       prio, options, delay)			\
+	struct k_thread _k_thread_obj_##name;				\
+	STRUCT_SECTION_ITERABLE(_static_thread_data,			\
+				_k_thread_data_##name) =		\
+		Z_THREAD_INITIALIZER(&_k_thread_obj_##name,		\
+				     _k_thread_stack_##name, stack_size,\
+				     entry, p1, p2, p3, prio, options,	\
+				     delay, name);			\
+	const k_tid_t name = (k_tid_t)&_k_thread_obj_##name
+
 /**
  * INTERNAL_HIDDEN @endcond
  */
@@ -719,13 +735,8 @@ struct _static_thread_data {
 			entry, p1, p2, p3,                               \
 			prio, options, delay)                            \
 	K_THREAD_STACK_DEFINE(_k_thread_stack_##name, stack_size);	 \
-	struct k_thread _k_thread_obj_##name;				 \
-	STRUCT_SECTION_ITERABLE(_static_thread_data, _k_thread_data_##name) = \
-		Z_THREAD_INITIALIZER(&_k_thread_obj_##name,		 \
-				    _k_thread_stack_##name, stack_size,  \
-				entry, p1, p2, p3, prio, options, delay, \
-				name);					 \
-	const k_tid_t name = (k_tid_t)&_k_thread_obj_##name
+	Z_THREAD_COMMON_DEFINE(name, stack_size, entry, p1, p2, p3,	 \
+			       prio, options, delay)
 
 /**
  * @brief Statically define and initialize a thread intended to run only in kernel mode.
@@ -761,14 +772,8 @@ struct _static_thread_data {
 			       entry, p1, p2, p3,			\
 			       prio, options, delay)			\
 	K_KERNEL_STACK_DEFINE(_k_thread_stack_##name, stack_size);	\
-	struct k_thread _k_thread_obj_##name;				\
-	STRUCT_SECTION_ITERABLE(_static_thread_data,			\
-				_k_thread_data_##name) =		\
-		Z_THREAD_INITIALIZER(&_k_thread_obj_##name,		\
-				     _k_thread_stack_##name, stack_size,\
-				     entry, p1, p2, p3, prio, options,	\
-				     delay, name);			\
-	const k_tid_t name = (k_tid_t)&_k_thread_obj_##name
+	Z_THREAD_COMMON_DEFINE(name, stack_size, entry, p1, p2, p3,	\
+			       prio, options, delay)
 
 /**
  * @brief Get a thread's priority.

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -728,6 +728,49 @@ struct _static_thread_data {
 	const k_tid_t name = (k_tid_t)&_k_thread_obj_##name
 
 /**
+ * @brief Statically define and initialize a thread intended to run only in kernel mode.
+ *
+ * The thread may be scheduled for immediate execution or a delayed start.
+ *
+ * Thread options are architecture-specific, and can include K_ESSENTIAL,
+ * K_FP_REGS, and K_SSE_REGS. Multiple options may be specified by separating
+ * them using "|" (the logical OR operator).
+ *
+ * The ID of the thread can be accessed using:
+ *
+ * @code extern const k_tid_t <name>; @endcode
+ *
+ * @note Threads defined by this can only run in kernel mode, and cannot be
+ *       transformed into user thread via k_thread_user_mode_enter().
+ *
+ * @warning Depending on the architecture, the stack size (@p stack_size)
+ *          may need to be multiples of CONFIG_MMU_PAGE_SIZE (if MMU)
+ *          or in power-of-two size (if MPU).
+ *
+ * @param name Name of the thread.
+ * @param stack_size Stack size in bytes.
+ * @param entry Thread entry function.
+ * @param p1 1st entry point parameter.
+ * @param p2 2nd entry point parameter.
+ * @param p3 3rd entry point parameter.
+ * @param prio Thread priority.
+ * @param options Thread options.
+ * @param delay Scheduling delay (in milliseconds), zero for no delay.
+ */
+#define K_KERNEL_THREAD_DEFINE(name, stack_size,			\
+			       entry, p1, p2, p3,			\
+			       prio, options, delay)			\
+	K_KERNEL_STACK_DEFINE(_k_thread_stack_##name, stack_size);	\
+	struct k_thread _k_thread_obj_##name;				\
+	STRUCT_SECTION_ITERABLE(_static_thread_data,			\
+				_k_thread_data_##name) =		\
+		Z_THREAD_INITIALIZER(&_k_thread_obj_##name,		\
+				     _k_thread_stack_##name, stack_size,\
+				     entry, p1, p2, p3, prio, options,	\
+				     delay, name);			\
+	const k_tid_t name = (k_tid_t)&_k_thread_obj_##name
+
+/**
  * @brief Get a thread's priority.
  *
  * This routine gets the priority of @a thread.

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -714,11 +714,6 @@ struct _static_thread_data {
  * affect anything in the OS per se, but consider it bad practice.
  * Use a SYS_INIT() callback if you need to run code before entrance
  * to the application main().
- *
- * @internal It has been observed that the x86 compiler by default aligns
- * these _static_thread_data structures to 32-byte boundaries, thereby
- * wasting space. To work around this, force a 4-byte alignment.
- *
  */
 #define K_THREAD_DEFINE(name, stack_size,                                \
 			entry, p1, p2, p3,                               \

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -1015,6 +1015,65 @@ ZTEST(userspace, test_tls_pointer)
 #endif
 }
 
+K_APP_BMEM(default_part) volatile bool kernel_only_thread_ran;
+K_APP_BMEM(default_part) volatile bool kernel_only_thread_user_ran;
+static K_SEM_DEFINE(kernel_only_thread_run_sem, 0, 1);
+
+void kernel_only_thread_user_entry(void *p1, void *p2, void *p3)
+{
+	printk("kernel only thread in user mode\n");
+
+	kernel_only_thread_user_ran = true;
+}
+
+void kernel_only_thread_entry(void *p1, void *p2, void *p3)
+{
+	k_sem_take(&kernel_only_thread_run_sem, K_FOREVER);
+
+	printk("kernel only thread in kernel mode\n");
+
+	/* Some architectures emit kernel OOPS instead of panic. */
+#if defined(CONFIG_ARM64)
+	set_fault(K_ERR_KERNEL_OOPS);
+#else
+	set_fault(K_ERR_KERNEL_PANIC);
+#endif
+
+	kernel_only_thread_ran = true;
+
+	k_thread_user_mode_enter(kernel_only_thread_user_entry, NULL, NULL, NULL);
+}
+
+#ifdef CONFIG_MMU
+#define KERNEL_ONLY_THREAD_STACK_SIZE (ROUND_UP(512, CONFIG_MMU_PAGE_SIZE))
+#else
+#define KERNEL_ONLY_THREAD_STACK_SIZE (512)
+#endif
+
+static K_KERNEL_THREAD_DEFINE(kernel_only_thread,
+			      KERNEL_ONLY_THREAD_STACK_SIZE,
+			      kernel_only_thread_entry, NULL, NULL, NULL,
+			      0, 0, 0);
+
+ZTEST(userspace, test_kernel_only_thread)
+{
+	kernel_only_thread_ran = false;
+	kernel_only_thread_user_ran = false;
+
+	k_sem_give(&kernel_only_thread_run_sem);
+
+	k_sleep(K_MSEC(500));
+
+	if (!kernel_only_thread_ran) {
+		printk("kernel only thread not running in kernel mode!\n");
+		ztest_test_fail();
+	}
+
+	if (kernel_only_thread_user_ran) {
+		printk("kernel only thread should not have run in user mode!\n");
+		ztest_test_fail();
+	}
+}
 
 void *userspace_setup(void)
 {
@@ -1053,6 +1112,7 @@ void *userspace_setup(void)
 #endif
 	k_thread_access_grant(k_current_get(),
 			      &test_thread, &test_stack,
+			      &kernel_only_thread_run_sem,
 			      &test_revoke_sem, &kpipe);
 	return NULL;
 }


### PR DESCRIPTION
This adds a macro `K_KERNEL_THREAD_DEFINE()` to enable defining threads that only run in kernel mode (when USERSPACE is enabled).

The first commit was originally from https://github.com/zephyrproject-rtos/zephyr/pull/54948, and has been slightly modified. A test has also been added to test it such a thread cannot be made into a user thread.