### PR TITLE
New WEST_SIGN_OPTS for board-specific customization. intel_adsp_generic.rst update.

### DIFF
--- a/boards/xtensa/intel_adsp_cavs25/doc/intel_adsp_generic.rst
+++ b/boards/xtensa/intel_adsp_cavs25/doc/intel_adsp_generic.rst
@@ -68,17 +68,28 @@ you will also need to set up the SOF rimage signing tool and key.
    git clone https://github.com/thesofproject/rimage --recurse-submodules
    cd rimage
 
-Follow the instructions in the :file:`README.md` to build and install the tool
-globally on your system. You should be able to invoke the binary from the
-command line with the name "rimage". For example:
+Follow the instructions in the rimage :file:`README.md` to build the tool on
+your system. You can either copy the executable to a directory in your PATH or
+use ``west config rimage.path /path/to/rimage-build/rimage``; see more details
+in the output of ``west sign -h``. Running directly from the build directory
+makes you less likely to use an obsolete rimage version by mistake.
 
-.. code-block:: shell
+Until https://github.com/zephyrproject-rtos/zephyr/issues/58212 gets
+implemented, you must manually and regularly update and rebuild rimage.
 
-   which rimage
-   /usr/local/bin/rimage
+The SOF project does not require this manual step because its west manifest
+automatically downloads and builds a specific rimage version validated with
+matching SOF sources. An indirect Zephyr -> SOF -> rimage dependency chain is
+unfortunately not appropriate because unlike rimage, SOF is *not* required to
+run Zephyr on cAVS/ACE hardware.
 
-If you are unable to install it, you can also pass the path to the tool binary
-as an argument to ``west flash``, though this is not recommended.
+Until https://github.com/thesofproject/sof/issues/7270 is implemented,
+platform-specific configuration files are also located in the rimage
+repository, more specifically in the ``rimage/config/`` subdirectory; this is
+another reason to update rimage regularly. If you cloned rimage in a location
+different from above (not recommended) then you must also run ``west config
+build.cmake-args -- -DRIMAGE_CONFIG_PATH=/path/to/source/rimage/config``.
+
 
 Xtensa Toolchain (Optional)
 ---------------------------
@@ -121,13 +132,30 @@ Build as usual.
 Signing
 -------
 
-West automatically signs the binary as the first step of flashing, but if you
-need to sign the binary yourself without flashing, you can invoke the west sign
-command directly. Read the output of a ``west flash`` command to find the
-``west sign`` invocation. You can copy and modify it for your own purposes.
+``west build`` tries to sign the binary at the end of the build. If you need
+to sign the binary yourself, you can invoke ``west sign`` directly. Read the
+``west`` logs to find the ``west sign`` invocation; you can copy and modify
+the command logged for your own purposes. Run ``west sign -h`` for more
+details.
 
-As mentioned previously, if you're unable to install the rimage tool
-globally, you can pass it the path to the tool binary as an argument to
+The build tries to provide as many default rimage parameters are possible. If
+needed, there are several ways to override them depending on your specific
+situation and use case. They're often not mutually exclusive but to avoid
+undocumented rimage precedence rules it's best to use only one way at a time.
+
+- For local, interactive use prefer ``rimage.extra-args`` in west config, see
+  ``west sign -h``. The WEST_CONFIG_LOCAL environment variable can point at a
+  different west configuration file if needed.
+
+- You can add or overwrite a ``$platform.toml`` file(s) in your
+  ``rimage/config/`` directory
+
+- For board-specific needs you can define WEST_SIGN_OPTS in
+  ``boards/my/board/board.cmake``, see example in
+  ``soc/xtensa/intel_adsp/common/CMakeLists.txt``
+
+For backwards compatibility reasons, you can also pass rimage parameters like
+the path to the tool binary as arguments to
 ``west flash`` if the flash target exists for your board. To see a list
 of all arguments to the Intel ADSP runner, run the following after you have
 built the binary. There are multiple arguments related to signing, including a

--- a/boards/xtensa/intel_adsp_cavs25/doc/intel_adsp_generic.rst
+++ b/boards/xtensa/intel_adsp_cavs25/doc/intel_adsp_generic.rst
@@ -90,7 +90,8 @@ may desire to build with the proprietary Xtensa toolchain distributed by
 installed the toolchain(s) and core(s) for your board following their
 instructions.
 
-First, make sure to set ``XTENSAD_LICENSE_FILE`` as instructed by Cadence.
+First, make sure to set the ``$HOME/.flexlmrc`` file or
+``XTENSAD_LICENSE_FILE`` variable as instructed by Cadence.
 Next, set the following environment variables:
 
 .. code-block:: shell

--- a/boards/xtensa/intel_adsp_cavs25/doc/intel_adsp_generic.rst
+++ b/boards/xtensa/intel_adsp_cavs25/doc/intel_adsp_generic.rst
@@ -27,7 +27,7 @@ Intel open-sources firmware for its ADSP hardware under the Sound Open Firmware
 (`SOF`_) project. SOF can be built with either Zephyr or Cadence's proprietary
 Xtensa OS (XTOS) and run on a variety of Intel and non-Intel platforms.
 
-In general, the Intel `UP2`_ and `UP Xtreme`_ product lines are the publicly
+The Intel `UP Xtreme`_ product line has the publicly
 available reference boards for Zephyr's Intel ADSP support. This guide uses the
 `UP Xtreme i11-0001 series`_ (:ref:`intel_adsp_cavs25`) board as an example.
 However, the instructions are generic and will work on other boards unless
@@ -53,7 +53,7 @@ Note that if you plan to use SOF on your board, you will need to build and
 install the modified Linux SOF kernel instead of the default kernel. It is
 recommended you follow the `SOF instructions`_ to build and run SOF on Zephyr.
 
-UP2 and UP Xtreme users can refer to the `UP Community wiki`_ for help installing a
+UP Xtreme users can refer to the `UP Community wiki`_ for help installing a
 Linux operating system on their board.
 
 Signing Tool
@@ -326,8 +326,6 @@ exporting ``FLEXLM_DIAGNOSTICS=3``.
 .. _SOF: https://thesofproject.github.io/latest/index.html
 
 .. _Chromebooks: https://www.hp.com/us-en/shop/pdp/hp-chromebook-x360-14c-cc0047nr
-
-.. _UP2: https://up-board.org/upsquared/specifications/
 
 .. _UP Xtreme: https://up-board.org/up-xtreme/
 

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -121,6 +121,20 @@ add_custom_target(zephyr.ri ALL
   DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
 )
 
+# If some of your board(s) need to override default rimage parameters
+# then you can define WEST_SIGN_OPTS in  boards/my/board/board.cmake.
+# Example:
+#
+#   set(WEST_SIGN_OPTS -- -c "/home/sweet  home/rimage/config/abc.toml" -i 4)
+
+# Parameters after the double dash -- are passed through to rimage.  For
+# other ways to override default rimage parameters check
+# boards/xtensa/intel_adsp_cavs25/doc/intel_adsp_generic.rst
+
+# Warning: because `west sign` can also be used interactively, using
+# ${WEST_SIGN_OPTS} like this has _higher_ precedence than `west config
+# rimage.extra-args`! Avoid overriding default rimage parameters in
+# multiple places to avoid unexpected precedence rules.
 add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
   COMMENT "west sign --if-tool-available --tool rimage ..."
@@ -129,7 +143,7 @@ add_custom_command(
   # require signing. When rimage is missing, `west flash` fails with a
   # clear "zephyr.ri missing" error with an "rimage not found" warning
   # from west sign immediately before it.
-  COMMAND  west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR}
+  COMMAND  west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR} ${WEST_SIGN_OPTS}
   DEPENDS gen_modules
           ${CMAKE_BINARY_DIR}/zephyr/boot.mod ${CMAKE_BINARY_DIR}/zephyr/main.mod
 )


### PR DESCRIPTION
- Add a new CMake variable WEST_SIGN_OPTS for board-specific rimage customization
- Overdue intel_adsp_generic.rst updates related to rimage and west sign

See commit messages