### PR TITLE
xec_test_qspi_twister_fix

### DIFF
--- a/tests/boards/mec15xxevb_assy6853/qspi/boards/mec15xxevb_assy6853.overlay
+++ b/tests/boards/mec15xxevb_assy6853/qspi/boards/mec15xxevb_assy6853.overlay
@@ -9,4 +9,11 @@
         port_sel = <0>;
         chip_select = <0>;
         lines = <4>;
+
+        pinctrl-0 = < &shd_cs0_n_gpio055
+                      &shd_clk_gpio056
+                      &shd_io0_gpio223
+                      &shd_io1_gpio224
+                      &shd_io2_gpio227
+                      &shd_io3_gpio016 >;
 };


### PR DESCRIPTION
Updated the overlay file to enable spi quad IOs.
Fix: #55078