### PR TITLE
twister: Remove newline suffix in BinaryHandler

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -203,7 +203,7 @@ class BinaryHandler(Handler):
                 reader_t.join(this_timeout)
                 if not reader_t.is_alive() and self.line != b"":
                     line_decoded = self.line.decode('utf-8', "replace")
-                    stripped_line = line_decoded.rstrip()
+                    stripped_line = line_decoded.rstrip().removesuffix('\\r\\n')
                     logger.debug("OUTPUT: %s", stripped_line)
                     log_out_fp.write(line_decoded)
                     log_out_fp.flush()


### PR DESCRIPTION
Simics converts newline characters when writing console output to stdout, so we need to remove them as a suffix string. Otherwise the console harness fails to match expected PASS/FAIL/RunID string patterns and twister tests timeout.