### PR TITLE
tests/samples: use integration_platforms more where it makes sense

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86.yaml
+++ b/boards/x86/qemu_x86/qemu_x86.yaml
@@ -3,6 +3,7 @@ name: QEMU Emulation for X86
 type: qemu
 simulation: qemu
 arch: x86
+ram: 3000
 toolchain:
   - zephyr
   - xtools

--- a/samples/compression/lz4/sample.yaml
+++ b/samples/compression/lz4/sample.yaml
@@ -14,6 +14,9 @@ common:
       - "Validation done. (.*)"
 tests:
   sample.compression.lz4:
+    integration_platforms:
+      - mps2_an385
+      - qemu_riscv64
     tags:
       - compression
       - lz4

--- a/samples/kernel/metairq_dispatch/sample.yaml
+++ b/samples/kernel/metairq_dispatch/sample.yaml
@@ -3,6 +3,9 @@ sample:
     MetaIRQ thread
   name: MetaIRQ Dispatch
 common:
+  integration_platforms:
+    - mps2_an385
+    - qemu_x86
   harness: console
   harness_config:
     type: one_line

--- a/samples/modules/tflite-micro/tflm_ethosu/sample.yaml
+++ b/samples/modules/tflite-micro/tflm_ethosu/sample.yaml
@@ -6,3 +6,5 @@ tests:
     tags: NPU
     filter: dt_compat_enabled("arm,ethos-u")
     build_only: true
+    integration_platforms:
+      - mps3_an547

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -17,3 +17,5 @@ tests:
       - gui
     modules:
       - lvgl
+    integration_platforms:
+      - native_posix_64

--- a/samples/subsys/fs/fat_fs/sample.yaml
+++ b/samples/subsys/fs/fat_fs/sample.yaml
@@ -40,3 +40,5 @@ tests:
   sample.filesystem.fat_fs.has_sdmmc_disk:
     build_only: true
     filter: dt_compat_enabled("zephyr,sdmmc-disk")
+    integration_platforms:
+      - frdm_k64f

--- a/tests/benchmarks/app_kernel/testcase.yaml
+++ b/tests/benchmarks/app_kernel/testcase.yaml
@@ -4,6 +4,9 @@ common:
 tests:
   benchmark.kernel.application:
     min_flash: 34
+    integration_platforms:
+      - mps2_an385
+      - qemu_x86
   benchmark.kernel.application.fp:
     extra_args: CONF_FILE=prj_fp.conf
     extra_configs:
@@ -19,6 +22,9 @@ tests:
     toolchain_exclude:
       - llvm
       - oneApi
+    integration_platforms:
+      - mps2_an385
+      - qemu_x86
   benchmark.kernel.application.fp.x86.no_sse:
     extra_args: CONF_FILE=prj_fp.conf
     extra_configs:
@@ -29,6 +35,8 @@ tests:
     min_flash: 34
     min_ram: 32
     slow: true
+    integration_platforms:
+      - qemu_x86
   benchmark.kernel.application.fp.x86.sse:
     extra_args: CONF_FILE=prj_fp.conf
     extra_configs:
@@ -39,3 +47,5 @@ tests:
     min_flash: 34
     min_ram: 32
     slow: true
+    integration_platforms:
+      - qemu_x86

--- a/tests/benchmarks/data_structure_perf/dlist_perf/testcase.yaml
+++ b/tests/benchmarks/data_structure_perf/dlist_perf/testcase.yaml
@@ -3,3 +3,5 @@ tests:
     tags:
       - benchmark
       - dlist
+    integration_platforms:
+      - native_posix

--- a/tests/benchmarks/data_structure_perf/rbtree_perf/testcase.yaml
+++ b/tests/benchmarks/data_structure_perf/rbtree_perf/testcase.yaml
@@ -3,3 +3,5 @@ tests:
     tags:
       - benchmark
       - rbtree
+    integration_platforms:
+      - native_posix

--- a/tests/benchmarks/footprints/testcase.yaml
+++ b/tests/benchmarks/footprints/testcase.yaml
@@ -2,12 +2,16 @@ tests:
   benchmark.kernel.footprints.default:
     tags: benchmark
     build_only: true
+    integration_platforms:
+      - mps2_an385
   benchmark.kernel.footprints.pm:
     tags:
       - benchmark
       - pm
     build_only: true
     extra_args: CONF_FILE=prj_pm.conf
+    integration_platforms:
+      - mps2_an385
   benchmark.kernel.footprints.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_args: CONF_FILE=prj_userspace.conf
@@ -19,3 +23,5 @@ tests:
       - benchmark
       - userspace
     build_only: true
+    integration_platforms:
+      - mps2_an385

--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -7,6 +7,9 @@ tests:
     filter: CONFIG_PRINTK and not CONFIG_SOC_FAMILY_STM32
     tags: benchmark
     harness: console
+    integration_platforms:
+      - qemu_x86
+      - qemu_arc_em
     harness_config:
       type: one_line
       record:

--- a/tests/benchmarks/sched/testcase.yaml
+++ b/tests/benchmarks/sched/testcase.yaml
@@ -1,6 +1,9 @@
 tests:
   benchmark.kernel.scheduler:
     tags: benchmark
+    integration_platforms:
+      - mps2_an385
+      - qemu_x86
     slow: true
     harness: console
     harness_config:

--- a/tests/drivers/build_all/led/testcase.yaml
+++ b/tests/drivers/build_all/led/testcase.yaml
@@ -5,3 +5,5 @@ tests:
     tags:
       - drivers
       - led
+    integration_platforms:
+      - native_posix

--- a/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
+++ b/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
@@ -17,6 +17,8 @@ tests:
       - qemu_kvm_arm64
       - xenvm
       - xenvm_gicv3
+    integration_platforms:
+      - qemu_x86
   drivers.sbs_gauge_new_api.emulated_64_bit_i2c_addr:
     tags:
       - drivers
@@ -31,6 +33,8 @@ tests:
       - qemu_kvm_arm64
       - xenvm
       - xenvm_gicv3
+    integration_platforms:
+      - qemu_cortex_a53
     extra_args:
       - CONF_FILE="prj.conf;boards/qemu_cortex_a53.conf"
       - DTC_OVERLAY_FILE="boards/qemu_cortex_a53.overlay"

--- a/tests/drivers/mm/sys_mm_drv_api/testcase.yaml
+++ b/tests/drivers/mm/sys_mm_drv_api/testcase.yaml
@@ -4,3 +4,5 @@ tests:
       - drivers
       - mm
     filter: dt_compat_enabled("intel,adsp-mtl-tlb") or dt_compat_enabled("intel,adsp-tlb")
+    integration_platforms:
+      - intel_adsp_ace15_mtpm

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -38,6 +38,8 @@ tests:
       fixture: gpio_loopback
     depends_on: gpio
     extra_args: DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840.overlay;boards/nrf_uart.overlay"
+    integration_platforms:
+      - nrf52840dk_nrf52840
   drivers.uart.async_api.rtt:
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_HAS_SEGGER_RTT
       and not CONFIG_UART_MCUX_LPUART
@@ -49,6 +51,8 @@ tests:
       - xmc45_relax_kit
       - xmc47_relax_kit
     build_only: true
+    integration_platforms:
+      - qemu_cortex_m0
   drivers.uart.async_api.lpuart:
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_UART_MCUX_LPUART
     harness: ztest

--- a/tests/lib/mem_blocks/testcase.yaml
+++ b/tests/lib/mem_blocks/testcase.yaml
@@ -3,3 +3,5 @@ tests:
     tags:
       - heap
       - mem_blocks
+    integration_platforms:
+      - native_posix

--- a/tests/lib/mem_blocks_stats/testcase.yaml
+++ b/tests/lib/mem_blocks_stats/testcase.yaml
@@ -3,3 +3,5 @@ tests:
     tags:
       - heap
       - mem_blocks.stats
+    integration_platforms:
+      - native_posix

--- a/tests/lib/sys_util/testcase.yaml
+++ b/tests/lib/sys_util/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   libraries.sys_util:
     tags: sys_util
+    integration_platforms:
+      - native_posix

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -6,7 +6,6 @@ common:
   tags: posix
   min_ram: 64
   timeout: 240
-
 tests:
   portability.posix.common:
     platform_exclude:
@@ -14,6 +13,8 @@ tests:
       - ehl_crb
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
+    integration_platforms:
+      - qemu_x86
   portability.posix.common.newlib:
     platform_exclude:
       - nsim_sem_mpu_stack_guard
@@ -22,6 +23,8 @@ tests:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
+    integration_platforms:
+      - qemu_x86
   portability.posix.common.armclang_std_libc:
     toolchain_allow: armclang
     extra_configs:
@@ -39,6 +42,8 @@ tests:
       - CONFIG_NEWLIB_LIBC=n
       - CONFIG_THREAD_LOCAL_STORAGE=y
       - CONFIG_MAIN_STACK_SIZE=1152
+    integration_platforms:
+      - qemu_x86
   portability.posix.common.tls.newlib:
     platform_exclude:
       - nsim_sem_mpu_stack_guard
@@ -46,6 +51,8 @@ tests:
       - lpcxpresso55s06
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and
       CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
+    integration_platforms:
+      - qemu_x86
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_THREAD_LOCAL_STORAGE=y
@@ -64,5 +71,7 @@ tests:
   portability.posix.common.picolibc:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
+    integration_platforms:
+      - qemu_x86
     extra_configs:
       - CONFIG_PICOLIBC=y

--- a/tests/posix/eventfd/testcase.yaml
+++ b/tests/posix/eventfd/testcase.yaml
@@ -3,6 +3,8 @@ common:
   tags:
     - posix
     - eventfd
+  integration_platforms:
+    - qemu_x86
 tests:
   portability.posix.eventfd:
     min_ram: 32

--- a/tests/posix/eventfd_basic/testcase.yaml
+++ b/tests/posix/eventfd_basic/testcase.yaml
@@ -4,6 +4,8 @@ common:
     - posix
     - eventfd
   min_ram: 32
+  integration_platforms:
+    - qemu_x86
 tests:
   portability.posix.eventfd_basic:
     extra_configs:

--- a/tests/posix/fs/testcase.yaml
+++ b/tests/posix/fs/testcase.yaml
@@ -12,28 +12,40 @@ tests:
   portability.posix.fs:
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
+    integration_platforms:
+      - qemu_x86
   portability.posix.fs.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
+    integration_platforms:
+      - qemu_x86
   portability.posix.fs.tls:
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
       - CONFIG_THREAD_LOCAL_STORAGE=y
+    integration_platforms:
+      - qemu_x86
   portability.posix.fs.tls.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and
       CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_THREAD_LOCAL_STORAGE=y
+    integration_platforms:
+      - qemu_x86
   portability.posix.fs.picolibc:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_PICOLIBC=y
+    integration_platforms:
+      - qemu_x86
   portability.posix.fs.tls.picolibc:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_PICOLIBC=y
+    integration_platforms:
+      - qemu_x86

--- a/tests/posix/getopt/testcase.yaml
+++ b/tests/posix/getopt/testcase.yaml
@@ -3,10 +3,10 @@ common:
   tags:
     - posix
     - getopt
+  integration_platforms:
+    - qemu_x86
 tests:
   portability.posix.getopt:
-    integration_platforms:
-      - qemu_x86
     min_flash: 64
     min_ram: 32
   portability.posix.getopt.newlib:
@@ -19,8 +19,6 @@ tests:
     extra_configs:
       - CONFIG_PICOLIBC=y
   portability.posix.getopt.logger:
-    integration_platforms:
-      - qemu_x86
     extra_configs:
       - CONFIG_LOG=y
     build_only: true

--- a/tests/posix/headers/testcase.yaml
+++ b/tests/posix/headers/testcase.yaml
@@ -5,37 +5,48 @@ common:
     - net
     - socket
   min_ram: 32
-
 tests:
   portability.posix.headers.with_posix_api:
     extra_configs:
       - CONFIG_POSIX_API=y
+    integration_platforms:
+      - qemu_x86
   portability.posix.headers.without_posix_api:
     extra_configs:
       - CONFIG_POSIX_API=n
+    integration_platforms:
+      - qemu_x86
   portability.posix.headers.picolibc.with_posix_api:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_POSIX_API=y
       - CONFIG_PICOLIBC=y
+    integration_platforms:
+      - qemu_x86
   portability.posix.headers.picolibc.without_posix_api:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_POSIX_API=n
       - CONFIG_PICOLIBC=y
+    integration_platforms:
+      - qemu_x86
   portability.posix.headers.newlib.with_posix_api:
     tags: newlib
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_POSIX_API=y
       - CONFIG_NEWLIB_LIBC=y
+    integration_platforms:
+      - qemu_x86
   portability.posix.headers.newlib.without_posix_api:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_POSIX_API=n
       - CONFIG_NEWLIB_LIBC=y
+    integration_platforms:
+      - qemu_x86
   portability.posix.headers.arcmwdtlib.with_posix_api:
     toolchain_allow: arcmwdt
     extra_configs:

--- a/tests/subsys/fs/fs_api/testcase.yaml
+++ b/tests/subsys/fs/fs_api/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   filesystem.api:
     tags: filesystem
+    integration_platforms:
+      - native_posix

--- a/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported/testcase.yaml
@@ -8,6 +8,8 @@ common:
     - mgmt
     - mcumgr
     - fs_mgmt_hash_supported
+  integration_platforms:
+    - native_posix
 tests:
   mgmt.mcumgr.fs.mgmt.hash.supported.crc32:
     extra_args: >

--- a/tests/subsys/portability/cmsis_rtos_v2/testcase.yaml
+++ b/tests/subsys/portability/cmsis_rtos_v2/testcase.yaml
@@ -4,3 +4,5 @@ tests:
     tags: cmsis_rtos
     min_ram: 32
     min_flash: 34
+    integration_platforms:
+      - native_posix

--- a/tests/subsys/zbus/integration/testcase.yaml
+++ b/tests/subsys/zbus/integration/testcase.yaml
@@ -5,3 +5,5 @@ tests:
       - hifive_unleashed
       - fvp_base_revc_2xaemv8a_smp_ns
     tags: zbus
+    integration_platforms:
+      - native_posix


### PR DESCRIPTION
Use integration platforms to limit churn and build time in PR CI .

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
