### PR TITLE
arm64: update the value type of macro MPIDR_AFFLVL_MASK

### DIFF
--- a/include/zephyr/arch/arm64/cpu.h
+++ b/include/zephyr/arch/arm64/cpu.h
@@ -67,7 +67,7 @@
 #define SCR_RES1		(BIT(4) | BIT(5))
 
 /* MPIDR */
-#define MPIDR_AFFLVL_MASK	(0xff)
+#define MPIDR_AFFLVL_MASK	(0xffULL)
 
 #define MPIDR_AFF0_SHIFT	(0)
 #define MPIDR_AFF1_SHIFT	(8)


### PR DESCRIPTION
Fix build warning: left shift count >= width of type.
Such as in the case: mpidr & (MPIDR_AFFLVL_MASK << MPIDR_AFF3_SHIFT)