### PR TITLE
boards: arm: nucleo_u575zi_q: Added jlink runner

### DIFF
--- a/boards/arm/nucleo_l552ze_q/board.cmake
+++ b/boards/arm/nucleo_l552ze_q/board.cmake
@@ -3,7 +3,7 @@ if(CONFIG_BUILD_WITH_TFM)
   set(FLASH_BASE_ADDRESS_S 0x0C000000)
 
   # Flash merged TF-M + Zephyr binary
-  set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
+  set_property(TARGET runners_yaml_props_target PROPERTY hex_file "${CMAKE_BINARY_DIR}/tfm_merged.hex")
 
   if (CONFIG_HAS_FLASH_LOAD_OFFSET)
     MATH(EXPR TFM_HEX_BASE_ADDRESS_NS "${FLASH_BASE_ADDRESS_S}+${CONFIG_FLASH_LOAD_OFFSET}")

--- a/boards/arm/nucleo_l552ze_q/board.cmake
+++ b/boards/arm/nucleo_l552ze_q/board.cmake
@@ -16,6 +16,8 @@ set_ifndef(BOARD_DEBUG_RUNNER pyocd)
 set_ifndef(BOARD_FLASH_RUNNER pyocd)
 
 board_runner_args(pyocd "--target=stm32l552zetxq")
+board_runner_args(jlink "--device=STM32L552ZE" "--speed=4000" "--reset-after-load")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
@@ -115,3 +115,25 @@
 &vbat {
 	status = "okay";
 };
+
+&flash0 {
+	partitions{
+		compatible = "fixed-partitions";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+			read-only;
+		};
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <DT_SIZE_K(64) DT_SIZE_K(444)>;
+		};
+		storage_partition: partition@7f000 {
+			label = "storage";
+			reg = <DT_SIZE_K(444 + 64) DT_SIZE_K(4)>;
+		};
+	};
+};

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -182,3 +182,29 @@
 &vbat4 {
 	status = "okay";
 };
+
+&flash0{
+	partitions{
+		compatible = "fixed-partitions";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+			read-only;
+		};
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <DT_SIZE_K(64) DT_SIZE_K(988)>;
+		};
+		slot1_partition: partition@107000 {
+			label = "image-1";
+			reg = <DT_SIZE_K(64 + 988) DT_SIZE_K(988)>;
+		};
+		storage_partition: partition@1fe000 {
+			label = "storage";
+			reg = <DT_SIZE_K(64 + 988 + 988) DT_SIZE_K(8)>;
+		};
+	};
+};


### PR DESCRIPTION
Segger provides a method for updating a Nucleo evaluation board's firmware to JLink firmware as documented [here](https://www.segger.com/products/debug-probes/j-link/models/other-j-links/st-link-on-board/). I have tested this with the Nucleo L552ZE_Q board and confirmed the runner functions properly.