### PR TITLE
pm: System Power Manager performs devices power transition on specified Core

### DIFF
--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -73,6 +73,19 @@ config PM_DEVICE
 	  like turning off device clocks and peripherals. The device drivers
 	  may also save and restore states in these hook functions.
 
+config PM_DEVICE_ACTION_CORE_ID
+	int "Core managing devices power transition"
+	depends on PM_DEVICE
+	depends on !CONFIG_PM_DEVICE_RUNTIME_EXCLUSIVE
+	default 0
+	help
+	  This option sets the ID of the Core that will perform power transition
+	  of the devices. Hook functions defined in for the Device Power Management
+	  interface will be called using core of matching ID. When multiple cores are
+	  available, all other cores must be inactive for power transition to occur.
+	  SoC must also define architecture specific arch_cpu_active(id) function
+	  implementation to determine whether core with give ID is active.
+
 if PM_DEVICE
 
 module = PM_DEVICE


### PR DESCRIPTION
Added new feature to Device Power Management Infrastructure that allows to define a new option CONFIG_PM_DEVICE_ACTION_CORE_ID. This option defines ID of the Core that will perform devices power transition (suspend/resume).
When multiple cores enter `pm_system_suspend()` and enable `CONFIG_PM_DEVICE_ACTION_CORE_ID` function will simply return and will not execute suspend.
This was originally done as fix to the issue with `z_cpus_active` that is resolved by the https://github.com/zephyrproject-rtos/zephyr/pull/58446 .
However, I think this approach may be beneficial as new feature, because:

- Zephyr application may wish to execute [pm_device_action](https://docs.zephyrproject.org/latest/services/pm/api/index.html#c.pm_device_action) suspend/resume on the concrete Core.
Currently it would require adding a runtime check in every definition of device_pm_action:
`if (cpuId != expectedCpuId) return;`
Or alternatively implementing a custom PM policy to make sure only given core is active before suspend action is taken.
With this approach we have a warranty of specified core performing a Device suspend/resume.
- A check to `arch_cpu_active()` has some performance cost but we are in the idle thread so it is not that relevant.

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>