### PR TITLE
mgmt/MCUmgr/grp/img: DirectXIP flag pending slot as permanent

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -127,7 +127,7 @@ img_mgmt_state_flags(int query_slot)
 		int rca = img_mgmt_read_info(active_slot, &aver, NULL, NULL);
 
 		if (rcs == 0 && rca == 0 && img_mgmt_vercmp(&aver, &sver) < 0) {
-			flags = IMG_MGMT_STATE_F_PENDING;
+			flags = IMG_MGMT_STATE_F_PENDING | IMG_MGMT_STATE_F_PERMANENT;
 		}
 	}
 


### PR DESCRIPTION
Image list should also flag pending slot as permanent. This follows the image list for swap configuration where slot confirmed for next boot is marked as permanent.
The difference is that in DirectXIP mode it is still possible to erase slot marked as pending and permanent, before restart happens.