### PR TITLE
dts: arm: st: stm32h750: Add usbotg_fs node

### DIFF
--- a/dts/arm/st/h7/stm32h750.dtsi
+++ b/dts/arm/st/h7/stm32h750.dtsi
@@ -35,6 +35,20 @@
 			dma-requests= <107>;
 		};
 
+		usbotg_fs: usb@40080000 {
+			compatible = "st,stm32-otgfs";
+			reg = <0x40080000 0x40000>;
+			interrupts = <98 0>, <99 0>, <100 0>, <101 0>;
+			interrupt-names = "ep1_out", "ep1_in", "wkup", "otgfs";
+			num-bidir-endpoints = <9>;
+			ram-size = <DT_SIZE_K(4)>;
+			maximum-speed = "full-speed";
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x08000000>,
+				 <&rcc STM32_SRC_HSI48 USB_SEL(3)>;
+			phys = <&otghs_fs_phy>;
+			status = "disabled";
+		};
+
 		ltdc: display-controller@50001000 {
 			compatible = "st,stm32-ltdc";
 			reg = <0x50001000 0x200>;
@@ -91,6 +105,11 @@
 		compatible = "zephyr,memory-region", "arm,dtcm";
 		reg = <0x20000000 DT_SIZE_K(128)>;
 		zephyr,memory-region = "DTCM";
+	};
+
+	otghs_fs_phy: otghs_fs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
 	};
 
 	vref: vref {


### PR DESCRIPTION
Add missing USB-OTG control nodes. Like other STM32-platforms it's disabled by default and uses the internal 48 MHz clock by default.