### PR TITLE
boards: efr32_radio: Fix brd4187c's LED logic level

### DIFF
--- a/boards/arm/efr32_radio/efr32_radio_brd4187c.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4187c.dts
@@ -31,11 +31,11 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpiob GECKO_PIN(2) GPIO_ACTIVE_LOW>;
+			gpios = <&gpiob GECKO_PIN(2) GPIO_ACTIVE_HIGH>;
 			label = "LED 0";
 		};
 		led1: led_1 {
-			gpios = <&gpiob GECKO_PIN(4) GPIO_ACTIVE_LOW>;
+			gpios = <&gpiob GECKO_PIN(4) GPIO_ACTIVE_HIGH>;
 			label = "LED 1";
 		};
 	};


### PR DESCRIPTION
Fix LED logic levels of board brd4187c to be active high.