### PR TITLE
drivers: flash stm32 qspi driver dma callback for positive statuses

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -556,7 +556,9 @@ static void qspi_dma_callback(const struct device *dev, void *arg,
 {
 	DMA_HandleTypeDef *hdma = arg;
 
-	if (status != 0) {
+	ARG_UNUSED(dev);
+
+	if (status < 0) {
 		LOG_ERR("DMA callback error with channel %d.", channel);
 
 	}


### PR DESCRIPTION
Like other stm32 drivers, especially the stm32 flash ospi, the DMA callback accepts a null or positive status. It returns an error in case of negative.
BTW it also sets variable as unused, like stm32 flash ospi does.

This PR completes the https://github.com/zephyrproject-rtos/zephyr/pull/52780 which missed the flash/flash_stm32_qspi driver.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/58028

Signed-off-by: Francois Ramu <francois.ramu@st.com>