### PR TITLE
soc/arm/silabs: bugfix - disable PMGR if no DEV_INIT

### DIFF
--- a/soc/arm/silabs_exx32/Kconfig
+++ b/soc/arm/silabs_exx32/Kconfig
@@ -130,6 +130,7 @@ if PM
 
 config SOC_GECKO_PM_BACKEND_PMGR
 	bool
+	depends on SOC_GECKO_DEV_INIT
 	default y if SOC_GECKO_SERIES2
 	help
 	  Implement PM using sl_power_manager service from Gecko SDK


### PR DESCRIPTION
sl_power_manager can only be used if HAL services infrastructure is enabled, and that is controlled by SOC_GECKO_DEV_INIT kconfig option. Therefore, SOC_GECKO_PM_BACKEND_PMGR may not be enabled without SOC_GECKO_DEV_INIT.

This should fix the build issue reported in #58262 