### PR TITLE
VL53L0X add PM

### DIFF
--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -130,7 +130,7 @@
 	vl53l0x@29 {
 		compatible = "st,vl53l0x";
 		reg = <0x29>;
-		xshut-gpios = <&gpioc 6 GPIO_ACTIVE_HIGH>;
+		xshut-gpios = <&gpioc 6 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -163,7 +163,7 @@
 	vl53l0x@29 {
 		compatible = "st,vl53l0x";
 		reg = <0x29>;
-		xshut-gpios = <&gpioc 6 GPIO_ACTIVE_HIGH>;
+		xshut-gpios = <&gpioc 6 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/boards/shields/x_nucleo_53l0a1/x_nucleo_53l0a1.overlay
+++ b/boards/shields/x_nucleo_53l0a1/x_nucleo_53l0a1.overlay
@@ -23,18 +23,18 @@
 	vl53l0x_c_x_nucleo_53l0a1: vl53l0x@30 {
 		compatible = "st,vl53l0x";
 		reg = <0x30>;
-		xshut-gpios = <&expander1_x_nucleo_53l0a1 15 0>;
+		xshut-gpios = <&expander1_x_nucleo_53l0a1 15 GPIO_ACTIVE_LOW>;
 	};
 
 	/* Satellites optional sensors */
 	vl53l0x_l_x_nucleo_53l0a1: vl53l0x@31 {
 		compatible = "st,vl53l0x";
 		reg = <0x31>;
-		xshut-gpios = <&expander2_x_nucleo_53l0a1 14 0>;
+		xshut-gpios = <&expander2_x_nucleo_53l0a1 14 GPIO_ACTIVE_LOW>;
 	};
 	vl53l0x_r_x_nucleo_53l0a1: vl53l0x@32 {
 		compatible = "st,vl53l0x";
 		reg = <0x32>;
-		xshut-gpios = <&expander2_x_nucleo_53l0a1 15 0>;
+		xshut-gpios = <&expander2_x_nucleo_53l0a1 15 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -81,7 +81,7 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 	}
 
 	ret = VL53L0X_PerformRefSpadManagement(&drv_data->vl53l0x,
-					       (uint32_t *)&refSpadCount,
+					       &refSpadCount,
 					       &isApertureSpads);
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_PerformRefSpadManagement failed",
@@ -171,7 +171,7 @@ static int vl53l0x_start(const struct device *dev)
 	int r;
 	VL53L0X_Error ret;
 	uint16_t vl53l0x_id = 0U;
-	VL53L0X_DeviceInfo_t vl53l0x_dev_info;
+	VL53L0X_DeviceInfo_t vl53l0x_dev_info = { 0 };
 
 	LOG_DBG("[%s] Starting", dev->name);
 
@@ -200,9 +200,6 @@ static int vl53l0x_start(const struct device *dev)
 	}
 #endif
 
-	/* Get info from sensor */
-	(void)memset(&vl53l0x_dev_info, 0, sizeof(VL53L0X_DeviceInfo_t));
-
 	ret = VL53L0X_GetDeviceInfo(&drv_data->vl53l0x, &vl53l0x_dev_info);
 	if (ret < 0) {
 		LOG_ERR("[%s] Could not get info from device.", dev->name);
@@ -220,7 +217,7 @@ static int vl53l0x_start(const struct device *dev)
 
 	ret = VL53L0X_RdWord(&drv_data->vl53l0x,
 			     VL53L0X_REG_WHO_AM_I,
-			     (uint16_t *) &vl53l0x_id);
+			     &vl53l0x_id);
 	if ((ret < 0) || (vl53l0x_id != VL53L0X_CHIP_ID)) {
 		LOG_ERR("[%s] Issue on device identification", dev->name);
 		return -ENOTSUP;

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -40,6 +40,9 @@ LOG_MODULE_REGISTER(VL53L0X, CONFIG_SENSOR_LOG_LEVEL);
 #define VL53L0X_SETUP_PRE_RANGE_VCSEL_PERIOD    18
 #define VL53L0X_SETUP_FINAL_RANGE_VCSEL_PERIOD  14
 
+/* tBOOT (1.2ms max.) VL53L0X firmware boot period */
+#define T_BOOT K_USEC(1200)
+
 struct vl53l0x_config {
 	struct i2c_dt_spec i2c;
 	struct gpio_dt_spec xshut;
@@ -178,7 +181,7 @@ static int vl53l0x_start(const struct device *dev)
 				dev->name, r);
 			return -EIO;
 		}
-		k_sleep(K_MSEC(2));
+		k_sleep(T_BOOT);
 	}
 
 #ifdef CONFIG_VL53L0X_RECONFIGURE_ADDRESS
@@ -192,7 +195,7 @@ static int vl53l0x_start(const struct device *dev)
 
 		drv_data->vl53l0x.I2cDevAddr = config->i2c.addr;
 		LOG_DBG("[%s] I2C address reconfigured", dev->name);
-		k_sleep(K_MSEC(2));
+		k_sleep(T_BOOT);
 	}
 #endif
 

--- a/dts/bindings/sensor/st,vl53l0x.yaml
+++ b/dts/bindings/sensor/st,vl53l0x.yaml
@@ -10,3 +10,5 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
   xshut-gpios:
     type: phandle-array
+    description: |
+      Xshutdown pin, Active LOW.


### PR DESCRIPTION
Adds power management APIs to the VL53L0X sensor
Fixes XSHUT pin to active low

Updates firmware boot time wait from 2ms to 1.2ms as per datasheet specification
Removes redundant casts.
Replaces memset() with struct { 0 } initialisation.