### PR TITLE
STM32F7 clock support should not be limited to F4

### DIFF
--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -20,9 +20,10 @@
 #elif defined(CONFIG_SOC_SERIES_STM32F3X)
 #include <zephyr/dt-bindings/clock/stm32f3_clock.h>
 #elif defined(CONFIG_SOC_SERIES_STM32F2X) || \
-	defined(CONFIG_SOC_SERIES_STM32F4X) || \
-	defined(CONFIG_SOC_SERIES_STM32F7X)
+	defined(CONFIG_SOC_SERIES_STM32F4X)
 #include <zephyr/dt-bindings/clock/stm32f4_clock.h>
+#elif defined(CONFIG_SOC_SERIES_STM32F7X)
+#include <zephyr/dt-bindings/clock/stm32f7_clock.h>
 #elif defined(CONFIG_SOC_SERIES_STM32G0X)
 #include <zephyr/dt-bindings/clock/stm32g0_clock.h>
 #elif defined(CONFIG_SOC_SERIES_STM32G4X)


### PR DESCRIPTION
The include/zephyr/drivers/clock_control/stm32_clock_control.h header file treats F2X, F4X and F7X as all being supported by the stmf4_clock.h header. However, the F7 has additional clocks that are available as domain clocks for devices (such as the stm32 uart) and these do not work with the f4 header.

Fixes #58249