### PR TITLE
test:i2s_api: exclude NXP rtxxx platform

### DIFF
--- a/tests/drivers/i2s/i2s_api/testcase.yaml
+++ b/tests/drivers/i2s/i2s_api/testcase.yaml
@@ -5,6 +5,9 @@ tests:
       - drivers
       - userspace
     filter: not CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
+    platform_exclude:
+      - mimxrt595_evk_cm33
+      - mimxrt685_evk_cm33
   drivers.i2s.gpio_loopback:
     depends_on:
       - i2s
@@ -14,5 +17,8 @@ tests:
       - userspace
     filter: CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
     harness: ztest
+    platform_exclude:
+      - mimxrt595_evk_cm33
+      - mimxrt685_evk_cm33
     harness_config:
       fixture: gpio_loopback


### PR DESCRIPTION
as NXP rtxxx series i2s driver using a ping-pong
buffer, which is not supported by this test, and
use the i2s_speed only to test on those platform