### PR TITLE
ci: scripts_test: rebase before running tests

### DIFF
--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -34,6 +34,17 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Rebase
+        continue-on-error: true
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git config --global user.email "actions@zephyrproject.org"
+          git config --global user.name "Github Actions"
+          git rebase origin/${BASE_REF}
+          git log --graph --oneline HEAD...${PR_HEAD}
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Fix for runs like this one: https://github.com/zephyrproject-rtos/zephyr/actions/runs/5081946586/jobs/9131292706, pytest does not like to run with no tests apparently.

---

Add a rebase on top of BASE_REF before the pytest run to make sure that PRs that predates the test introduction runs on top of the current HEAD. This prevents pytest from failing with error code 5 because no tests are found.