### PR TITLE
doc: release: 3.4: add a note about build time priority checking

### DIFF
--- a/doc/build/cmake/index.rst
+++ b/doc/build/cmake/index.rst
@@ -410,6 +410,8 @@ The following is a detailed description of the scripts used during the build pro
    :start-after: """
    :end-before: """
 
+.. _check_init_priorities.py:
+
 :zephyr_file:`scripts/build/check_init_priorities.py`
 -----------------------------------------------------
 

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -371,6 +371,10 @@ Build system and infrastructure
 
 * Twister now supports ``gtest`` harness for running tests written in gTest.
 
+* Added an option to validate device initialization priorities at build time.
+  To use it, enable :kconfig:option:`CONFIG_CHECK_INIT_PRIORITIES`, see
+  :ref:`check_init_priorities.py` for more details.
+
 Drivers and Sensors
 *******************
 


### PR DESCRIPTION
Add a release note entry about the new build time priority check option.