### PR TITLE
Revert "arch: riscv: Enable builds without the multithreading"

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -59,7 +59,7 @@ GTEXT(__soc_restore_context)
 #endif /* CONFIG_RISCV_SOC_CONTEXT_SAVE */
 
 GTEXT(z_riscv_fatal_error)
-GTEXT(z_arch_get_next_switch_handle)
+GTEXT(z_get_next_switch_handle)
 GTEXT(z_riscv_switch)
 GTEXT(z_riscv_thread_start)
 
@@ -562,14 +562,16 @@ check_reschedule:
 	lr a1, ___cpu_t_current_OFFSET(s0)
 
 	/*
-	 * Get next thread to schedule with z_arch_get_next_switch_handle().
+	 * Get next thread to schedule with z_get_next_switch_handle().
 	 * We pass it a NULL as we didn't save the whole thread context yet.
 	 * If no scheduling is necessary then NULL will be returned.
 	 */
 	addi sp, sp, -16
 	sr a1, 0(sp)
 	mv a0, zero
-	call z_arch_get_next_switch_handle
+#ifdef CONFIG_MULTITHREADING
+	call z_get_next_switch_handle
+#endif
 	lr a1, 0(sp)
 	addi sp, sp, 16
 	beqz a0, no_reschedule

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -115,22 +115,6 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	thread->switch_handle = thread;
 }
 
-#ifdef CONFIG_MULTITHREADING
-void *z_arch_get_next_switch_handle(struct k_thread **old_thread)
-{
-	ARG_UNUSED(old_thread);
-
-	return z_get_next_switch_handle(NULL);
-}
-#else
-void *z_arch_get_next_switch_handle(struct k_thread **old_thread)
-{
-	ARG_UNUSED(old_thread);
-
-	return NULL;
-}
-#endif /* CONFIG_MULTITHREADING */
-
 #ifdef CONFIG_USERSPACE
 
 /*


### PR DESCRIPTION
This reverts commit f0b458a6192c33cbd7a88199c0691acfc80dc1ff.

This is a pointless change that simply increases footprint.
Existing code already supports compilation without multithreading.
