### PR TITLE
west.yaml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 676934427632a51fd7b428044babc66a79514262
+      revision: a6aef32619455cb1697c42d66db489c1608f8410
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  a6aef32619455cb1697c42d66db489c1608f8410

Brings following Zephyr relevant fixes:
 - d6a7741 zephyr: Add VERSION file
 - fac2cab boot_serial: Add image state set/get
 - c393b54 boot: boot_serial: fix usage of zcbor_new_encode_state API
 - 9380135 ci: zephyr: Update Zephyr image and SDK version
 - 9ced459 boot: zephyr: fix s/junping/jumping/ typo
 - 1dbe0cf boot: zephyr: Use mcuboot-led0 in MCUBOOT_INDICATION_LED help section
 - 256bc37 bootutil: Fixing memset not beeing called
 - eb7658e zephyr: fix link to Zephyr application docs
 - cb07e88 boot_serial: Replace cbor auto-generated code with zcbor functions
 - db6ba46 boot_serial: Unify zcbor include paths