### PR TITLE
drivers: spi: fix spi_dw interrupt mask

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -436,7 +436,7 @@ static int transceive(const struct device *dev,
 	/* Enable interrupts */
 	reg_data = !rx_bufs ?
 		DW_SPI_IMR_UNMASK & DW_SPI_IMR_MASK_RX :
-		DW_SPI_IMR_UNMASK & DW_SPI_IMR_MASK_TX;
+		DW_SPI_IMR_UNMASK;
 	write_imr(info, reg_data);
 
 	spi_context_cs_control(&spi->ctx, true);

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -258,17 +258,12 @@ static int reg_test_bit(uint8_t bit, uint32_t addr, uint32_t off)
 					 DW_SPI_IMR_TXOIM | \
 					 DW_SPI_IMR_RXUIM | \
 					 DW_SPI_IMR_RXOIM | \
-					 DW_SPI_IMR_RXFIM | \
-					 DW_SPI_IMR_MSTIM)
-#define DW_SPI_IMR_MASK_TX		(~(DW_SPI_IMR_RXUIM | \
-					   DW_SPI_IMR_TXOIM | \
+					 DW_SPI_IMR_RXFIM)
+#define DW_SPI_IMR_MASK_TX		(~(DW_SPI_IMR_TXEIM | \
+					   DW_SPI_IMR_TXOIM))
+#define DW_SPI_IMR_MASK_RX		(~(DW_SPI_IMR_RXUIM | \
 					   DW_SPI_IMR_RXOIM | \
-					   DW_SPI_IMR_MSTIM))
-#define DW_SPI_IMR_MASK_RX		(~(DW_SPI_IMR_TXEIM |\
-					   DW_SPI_IMR_RXUIM | \
-					   DW_SPI_IMR_TXOIM | \
-					   DW_SPI_IMR_RXOIM | \
-					   DW_SPI_IMR_MSTIM))
+					   DW_SPI_IMR_RXFIM))
 
 /*
  * Including the right register definition file


### PR DESCRIPTION
Found EMSDP board SPI-FLASH sample broke after adding DFSS into spi_dw. Found wrong interrput mask resulting in false interrupt enabled. Now fixed it to fit both DFSS and DW.

Fixes #58302