### PR TITLE
Bluetooth: Mesh: Disable models initialization macros for C++

### DIFF
--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -242,16 +242,31 @@ struct bt_mesh_model_op {
 
 /** End of the opcode list. Must always be present. */
 #define BT_MESH_MODEL_OP_END { 0, 0, NULL }
-/** Helper to define an empty opcode list. */
+
+#if !defined(__cplusplus) || defined(__DOXYGEN__)
+/**
+ * @brief Helper to define an empty opcode list.
+ *
+ * This macro uses compound literal feature of C99 standard and thus is available only from C,
+ * not C++.
+ */
 #define BT_MESH_MODEL_NO_OPS ((struct bt_mesh_model_op []) \
 			      { BT_MESH_MODEL_OP_END })
 
-/** Helper to define an empty model array */
+/**
+ *  @brief Helper to define an empty model array
+ *
+ * This macro uses compound literal feature of C99 standard and thus is available only from C,
+ * not C++.
+ */
 #define BT_MESH_MODEL_NONE ((struct bt_mesh_model []){})
 
 /**
  *  @brief Composition data SIG model entry with callback functions
  *	   with specific number of keys & groups.
+ *
+ * This macro uses compound literal feature of C99 standard and thus is available only from C,
+ * not C++.
  *
  *  @param _id        Model ID.
  *  @param _op        Array of model opcode handlers.
@@ -279,6 +294,9 @@ struct bt_mesh_model_op {
 /**
  *  @brief Composition data vendor model entry with callback functions
  *	   with specific number of keys & groups.
+ *
+ * This macro uses compound literal feature of C99 standard and thus is available only from C,
+ * not C++.
  *
  *  @param _company   Company ID.
  *  @param _id        Model ID.
@@ -308,6 +326,9 @@ struct bt_mesh_model_op {
 /**
  *  @brief Composition data SIG model entry with callback functions.
  *
+ * This macro uses compound literal feature of C99 standard and thus is available only from C,
+ * not C++.
+ *
  *  @param _id        Model ID.
  *  @param _op        Array of model opcode handlers.
  *  @param _pub       Model publish parameters.
@@ -323,6 +344,9 @@ struct bt_mesh_model_op {
 /**
  *
  *  @brief Composition data SIG model entry with callback functions and metadata.
+ *
+ * This macro uses compound literal feature of C99 standard and thus is available only from C,
+ * not C++.
  *
  *  @param _id        Model ID.
  *  @param _op        Array of model opcode handlers.
@@ -354,6 +378,9 @@ struct bt_mesh_model_op {
  *
  *  @brief Composition data vendor model entry with callback functions.
  *
+ * This macro uses compound literal feature of C99 standard and thus is available only from C,
+ * not C++.
+ *
  *  @param _company   Company ID.
  *  @param _id        Model ID.
  *  @param _op        Array of model opcode handlers.
@@ -369,6 +396,9 @@ struct bt_mesh_model_op {
 /**
  *
  *  @brief Composition data vendor model entry with callback functions and metadata.
+ *
+ * This macro uses compound literal feature of C99 standard and thus is available only from C,
+ * not C++.
  *
  *  @param _company   Company ID.
  *  @param _id        Model ID.
@@ -396,6 +426,9 @@ struct bt_mesh_model_op {
 /**
  *  @brief Composition data SIG model entry.
  *
+ * This macro uses compound literal feature of C99 standard and thus is available only from C,
+ * not C++.
+ *
  *  @param _id        Model ID.
  *  @param _op        Array of model opcode handlers.
  *  @param _pub       Model publish parameters.
@@ -407,6 +440,9 @@ struct bt_mesh_model_op {
 /**
  *  @brief Composition data vendor model entry.
  *
+ * This macro uses compound literal feature of C99 standard and thus is available only from C,
+ * not C++.
+ *
  *  @param _company   Company ID.
  *  @param _id        Model ID.
  *  @param _op        Array of model opcode handlers.
@@ -415,6 +451,7 @@ struct bt_mesh_model_op {
  */
 #define BT_MESH_MODEL_VND(_company, _id, _op, _pub, _user_data)                \
 	BT_MESH_MODEL_VND_CB(_company, _id, _op, _pub, _user_data, NULL)
+#endif /* !defined(__cplusplus) || defined(__DOXYGEN__) */
 
 /**
  *  @brief Encode transmission count & interval steps.


### PR DESCRIPTION
These macros use Compound Literal C99 feature which is not supported by C++.