### PR TITLE
driver: npcx: i2c: set a dedicated priority for the port driver

### DIFF
--- a/drivers/i2c/Kconfig.npcx
+++ b/drivers/i2c/Kconfig.npcx
@@ -11,3 +11,11 @@ config I2C_NPCX
 	  This option enables the I2C driver for NPCX family of
 	  processors.
 	  Say y if you wish to use I2C modules on NPCX MCU.
+
+config I2C_NPCX_PORT_INIT_PRIORITY
+	int "NPCX I2C port init priority"
+	default 51
+	depends on I2C_NPCX
+	help
+	  Initialization priority for the I2C port on an NPCX device, must be
+	  set to a lower priority than the controller one (I2C_INIT_PRIORITY).

--- a/drivers/i2c/i2c_npcx_port.c
+++ b/drivers/i2c/i2c_npcx_port.c
@@ -226,7 +226,7 @@ static const struct i2c_driver_api i2c_port_npcx_driver_api = {
 			    i2c_npcx_port_init,                                \
 			    NULL, NULL,                                        \
 			    &i2c_npcx_port_cfg_##inst,                         \
-			    PRE_KERNEL_1, CONFIG_I2C_INIT_PRIORITY,            \
+			    PRE_KERNEL_1, CONFIG_I2C_NPCX_PORT_INIT_PRIORITY,  \
 			    &i2c_port_npcx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(NPCX_I2C_PORT_INIT)


### PR DESCRIPTION
Hi, started to test stuff with CONFIG_CHECK_INIT_PRIORITIES, this adjusts the priority of the port-controller on NCPX to reflect the tree hierarchy.

---

The NPCX I2C controller has a port-controller hierarchy and the driver is split in two files, with separate device struct and init functions.

These are currently initialized at the same level and priority, so the actual order depends on what the linker does.

To avoid relying on the linking order, add a dedicated priority option for the port that is set to go after the normal I2C one by default.

Found this by building with CONFIG_CHECK_INIT_PRIORITIES.