### PR TITLE
net: sockets: Fix accept() not being interrupted on close()

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -370,7 +370,10 @@ static void zsock_accepted_cb(struct net_context *new_ctx,
 		 * closing handshake for stack to perform.
 		 */
 		net_context_ref(new_ctx);
+
+		(void)k_condvar_signal(&parent->cond.recv);
 	}
+
 }
 
 static void zsock_received_cb(struct net_context *ctx,
@@ -577,38 +580,33 @@ static inline int z_vrfy_zsock_listen(int sock, int backlog)
 int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 		     socklen_t *addrlen)
 {
-	k_timeout_t timeout = K_FOREVER;
 	struct net_context *ctx;
 	struct net_pkt *last_pkt;
-	int fd;
+	int fd, ret;
 
 	fd = z_reserve_fd();
 	if (fd < 0) {
 		return -1;
 	}
 
-	if (sock_is_nonblock(parent)) {
-		timeout = K_NO_WAIT;
+	if (!sock_is_nonblock(parent)) {
+		k_timeout_t timeout = K_FOREVER;
+
+		/* accept() can reuse zsock_wait_data(), as underneath it's
+		 * monitoring the same queue (accept_q is an alias for recv_q).
+		 */
+		ret = zsock_wait_data(parent, &timeout);
+		if (ret < 0) {
+			z_free_fd(fd);
+			errno = -ret;
+			return -1;
+		}
 	}
 
-	ctx = k_fifo_get(&parent->accept_q, timeout);
+	ctx = k_fifo_get(&parent->accept_q, K_NO_WAIT);
 	if (ctx == NULL) {
 		z_free_fd(fd);
-		if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
-			/* For non-blocking sockets return EAGAIN because it
-			 * just means the fifo is empty at this time
-			 */
-			errno = EAGAIN;
-		} else {
-			/* For blocking sockets return EINVAL because it means
-			 * the socket was closed while we were waiting for
-			 * connections. This is the same error code returned
-			 * under Linux when calling shutdown on a blocked accept
-			 * call
-			 */
-			errno = EINVAL;
-		}
-
+		errno = EAGAIN;
 		return -1;
 	}
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1953,7 +1953,10 @@ int ztls_accept_ctx(struct tls_context *parent, struct sockaddr *addr,
 		return -1;
 	}
 
+
+	k_mutex_unlock(parent->lock);
 	sock = zsock_accept(parent->sock, addr, addrlen);
+	k_mutex_lock(parent->lock, K_FOREVER);
 	if (sock < 0) {
 		ret = -errno;
 		goto error;

--- a/tests/net/socket/tls/src/main.c
+++ b/tests/net/socket/tls/src/main.c
@@ -50,12 +50,17 @@ static void test_config_psk(int s_sock, int c_sock)
 					 psk_id, strlen(psk_id)),
 		      0, "Failed to register PSK ID");
 
-	zassert_equal(setsockopt(s_sock, SOL_TLS, TLS_SEC_TAG_LIST,
-				 sec_tag_list, sizeof(sec_tag_list)),
-		      0, "Failed to set PSK on server socket");
-	zassert_equal(setsockopt(c_sock, SOL_TLS, TLS_SEC_TAG_LIST,
-				 sec_tag_list, sizeof(sec_tag_list)),
-		      0, "Failed to set PSK on client socket");
+	if (s_sock >= 0) {
+		zassert_equal(setsockopt(s_sock, SOL_TLS, TLS_SEC_TAG_LIST,
+					 sec_tag_list, sizeof(sec_tag_list)),
+			      0, "Failed to set PSK on server socket");
+	}
+
+	if (c_sock >= 0) {
+		zassert_equal(setsockopt(c_sock, SOL_TLS, TLS_SEC_TAG_LIST,
+					 sec_tag_list, sizeof(sec_tag_list)),
+			      0, "Failed to set PSK on client socket");
+	}
 }
 
 static void test_bind(int sock, struct sockaddr *addr, socklen_t addrlen)
@@ -596,6 +601,48 @@ ZTEST(net_socket_tls, test_v6_dtls_sendmsg)
 	test_dtls_sendmsg(client_sock, server_sock,
 			  (struct sockaddr *)&client_addr, sizeof(client_addr),
 			  (struct sockaddr *)&server_addr, sizeof(server_addr));
+}
+
+struct close_data {
+	struct k_work_delayable work;
+	int fd;
+};
+
+static void close_work(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct close_data *data = CONTAINER_OF(dwork, struct close_data, work);
+
+	close(data->fd);
+}
+
+ZTEST(net_socket_tls, test_close_while_accept)
+{
+	int s_sock;
+	int new_sock;
+	struct sockaddr_in6 s_saddr;
+	struct sockaddr addr;
+	socklen_t addrlen = sizeof(addr);
+	struct close_data close_work_data;
+
+	prepare_sock_tls_v6(MY_IPV6_ADDR, ANY_PORT, &s_sock, &s_saddr, IPPROTO_TLS_1_2);
+
+	test_config_psk(s_sock, -1);
+
+	test_bind(s_sock, (struct sockaddr *)&s_saddr, sizeof(s_saddr));
+	test_listen(s_sock);
+
+	/* Schedule close() from workqueue */
+	k_work_init_delayable(&close_work_data.work, close_work);
+	close_work_data.fd = s_sock;
+	k_work_schedule(&close_work_data.work, K_MSEC(10));
+
+	/* Start blocking accept(), which should be unblocked by close() from
+	 * another thread and return an error.
+	 */
+	new_sock = accept(s_sock, &addr, &addrlen);
+	zassert_equal(new_sock, -1, "accept did not return error");
+	zassert_equal(errno, EINTR, "Unexpected errno value: %d", errno);
 }
 
 ZTEST_SUITE(net_socket_tls, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
The accept() so far would block with mutex held, making it impossible to
interrupt it from another thread when the socket was closed.

Fix this, by reusing the condvar mechanism used for receiving. It's OK
to use the same routine, as underneath accept() is monitoring the same
FIFO as recv().

Additionally, simplify k_fifo_get() handling in accept() - as the
waiting now takes place on condvar, it can be used in a non-blocking
manner. Blocking accept() call should not reach this place if there's no
new incoming connection waiting on the FIFO.

Also fix the same issue for TLS sockets.

Fixes #58277

~~Depends on https://github.com/zephyrproject-rtos/zephyr/pull/58308, so marking DNM until the dependency is merged..~~