### PR TITLE
arch: riscv: Fix bogus condition

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -569,9 +569,7 @@ check_reschedule:
 	addi sp, sp, -16
 	sr a1, 0(sp)
 	mv a0, zero
-#ifdef CONFIG_MULTITHREADING
 	call z_get_next_switch_handle
-#endif
 	lr a1, 0(sp)
 	addi sp, sp, 16
 	beqz a0, no_reschedule


### PR DESCRIPTION
Remove the double precompiler condition added by mistake.