### PR TITLE
drivers: can: mcan: use per-instance message RAM configuration

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -500,7 +500,7 @@ static void can_mcan_tc_event_handler(const struct device *dev)
 			return;
 		}
 
-		tx_idx = tx_event.mm.idx;
+		tx_idx = tx_event.mm;
 
 		/* Acknowledge TX event */
 		err = can_mcan_write_reg(dev, CAN_MCAN_TXEFA, event_idx);
@@ -817,7 +817,6 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 #endif /* !CONFIG_CAN_FD_MODE */
 		.efc = 1U,
 	};
-	struct can_mcan_mm mm;
 	uint32_t put_idx;
 	uint32_t reg;
 	int err;
@@ -894,10 +893,7 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 	k_mutex_lock(&data->tx_mtx, K_FOREVER);
 
 	put_idx = FIELD_GET(CAN_MCAN_TXFQS_TFQPI, reg);
-
-	mm.idx = put_idx;
-	mm.cnt = data->mm.cnt++;
-	tx_hdr.mm = mm;
+	tx_hdr.mm = put_idx;
 
 	if ((frame->flags & CAN_FRAME_IDE) != 0U) {
 		tx_hdr.ext_id = frame->id;

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -389,12 +389,13 @@
 #define MCAN_DT_PATH DT_PATH(soc, can)
 #endif
 
-#define NUM_STD_FILTER_ELEMENTS DT_PROP(MCAN_DT_PATH, std_filter_elements)
-#define NUM_EXT_FILTER_ELEMENTS DT_PROP(MCAN_DT_PATH, ext_filter_elements)
-#define NUM_RX_FIFO0_ELEMENTS	DT_PROP(MCAN_DT_PATH, rx_fifo0_elements)
-#define NUM_RX_FIFO1_ELEMENTS	DT_PROP(MCAN_DT_PATH, rx_fifo0_elements)
-#define NUM_RX_BUF_ELEMENTS	DT_PROP(MCAN_DT_PATH, rx_buffer_elements)
-#define NUM_TX_BUF_ELEMENTS	DT_PROP(MCAN_DT_PATH, tx_buffer_elements)
+#define NUM_STD_FILTER_ELEMENTS    DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 1)
+#define NUM_EXT_FILTER_ELEMENTS    DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 2)
+#define NUM_RX_FIFO0_ELEMENTS      DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 3)
+#define NUM_RX_FIFO1_ELEMENTS      DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 4)
+#define NUM_RX_BUF_ELEMENTS        DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 5)
+#define NUM_TX_EVENT_FIFO_ELEMENTS DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 6)
+#define NUM_TX_BUF_ELEMENTS        DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 7)
 
 #ifdef CONFIG_CAN_STM32FD
 #define NUM_STD_FILTER_DATA CONFIG_CAN_MAX_STD_ID_FILTER
@@ -529,7 +530,7 @@ struct can_mcan_msg_sram {
 	volatile struct can_mcan_rx_fifo rx_fifo0[NUM_RX_FIFO0_ELEMENTS];
 	volatile struct can_mcan_rx_fifo rx_fifo1[NUM_RX_FIFO1_ELEMENTS];
 	volatile struct can_mcan_rx_fifo rx_buffer[NUM_RX_BUF_ELEMENTS];
-	volatile struct can_mcan_tx_event_fifo tx_event_fifo[NUM_TX_BUF_ELEMENTS];
+	volatile struct can_mcan_tx_event_fifo tx_event_fifo[NUM_TX_EVENT_FIFO_ELEMENTS];
 	volatile struct can_mcan_tx_buffer tx_buffer[NUM_TX_BUF_ELEMENTS];
 } __packed __aligned(4);
 

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -384,27 +384,34 @@
 #define CAN_MCAN_TXEFA      0x0F8
 #define CAN_MCAN_TXEFA_EFAI GENMASK(4, 0)
 
-#ifdef CONFIG_CAN_MCUX_MCAN
-#define MCAN_DT_PATH DT_NODELABEL(can0)
-#else
-#define MCAN_DT_PATH DT_PATH(soc, can)
-#endif
-
 /**
- * @brief Indexes for the cells in the devicetree bosch,mram-cfg property. These match the
- * description of the cells in the bosch,m_can-base devicetree binding.
+ * @name Indexes for the cells in the devicetree bosch,mram-cfg property
+ * @anchor CAN_MCAN_MRAM_CFG
+
+ * These match the description of the cells in the bosch,m_can-base devicetree binding.
+ *
+ * @{
  */
-enum can_mcan_mram_cfg {
-	CAN_MCAN_MRAM_CFG_OFFSET = 0,
-	CAN_MCAN_MRAM_CFG_STD_FILTER,
-	CAN_MCAN_MRAM_CFG_EXT_FILTER,
-	CAN_MCAN_MRAM_CFG_RX_FIFO0,
-	CAN_MCAN_MRAM_CFG_RX_FIFO1,
-	CAN_MCAN_MRAM_CFG_RX_BUFFER,
-	CAN_MCAN_MRAM_CFG_TX_EVENT,
-	CAN_MCAN_MRAM_CFG_TX_BUFFER,
-	CAN_MCAN_MRAM_CFG_NUM_CELLS
-};
+/** offset cell index */
+#define CAN_MCAN_MRAM_CFG_OFFSET        0
+/** std-filter-elements cell index */
+#define CAN_MCAN_MRAM_CFG_STD_FILTER    1
+/** ext-filter-elements cell index */
+#define CAN_MCAN_MRAM_CFG_EXT_FILTER    2
+/** rx-fifo0-elements cell index */
+#define CAN_MCAN_MRAM_CFG_RX_FIFO0      3
+/** rx-fifo1-elements cell index */
+#define CAN_MCAN_MRAM_CFG_RX_FIFO1      4
+/** rx-buffer-elements cell index */
+#define CAN_MCAN_MRAM_CFG_RX_BUFFER     5
+/** tx-event-fifo-elements cell index */
+#define CAN_MCAN_MRAM_CFG_TX_EVENT_FIFO 6
+/** tx-buffer-elements cell index */
+#define CAN_MCAN_MRAM_CFG_TX_BUFFER     7
+/** Total number of cells in bosch,mram-cfg property */
+#define CAN_MCAN_MRAM_CFG_NUM_CELLS     8
+
+/** @} */
 
 /**
  * @brief Get the Bosch M_CAN Message RAM offset
@@ -412,8 +419,8 @@ enum can_mcan_mram_cfg {
  * @param node_id node identifier
  * @return the Message RAM offset in bytes
  */
-#define CAN_MCAN_DT_MRAM_OFFSET(node_id) \
-	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 0)
+#define CAN_MCAN_DT_MRAM_OFFSET(node_id)                                                           \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, CAN_MCAN_MRAM_CFG_OFFSET)
 
 /**
  * @brief Get the number of standard (11-bit) filter elements in Bosch M_CAN Message RAM
@@ -421,8 +428,8 @@ enum can_mcan_mram_cfg {
  * @param node_id node identifier
  * @return the number of standard (11-bit) filter elements
  */
-#define CAN_MCAN_DT_MRAM_STD_FILTER_ELEM(node_id) \
-	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 1)
+#define CAN_MCAN_DT_MRAM_STD_FILTER_ELEMENTS(node_id)                                              \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, CAN_MCAN_MRAM_CFG_STD_FILTER)
 
 /**
  * @brief Get the number of extended (29-bit) filter elements in Bosch M_CAN Message RAM
@@ -430,8 +437,8 @@ enum can_mcan_mram_cfg {
  * @param node_id node identifier
  * @return the number of extended (29-bit) filter elements
  */
-#define CAN_MCAN_DT_MRAM_EXT_FILTER_ELEM(node_id) \
-	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 2)
+#define CAN_MCAN_DT_MRAM_EXT_FILTER_ELEMENTS(node_id)                                              \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, CAN_MCAN_MRAM_CFG_EXT_FILTER)
 
 /**
  * @brief Get the number of Rx FIFO 0 elements in Bosch M_CAN Message RAM
@@ -439,8 +446,8 @@ enum can_mcan_mram_cfg {
  * @param node_id node identifier
  * @return the number of Rx FIFO 0 elements
  */
-#define CAN_MCAN_DT_MRAM_RX_FIFO0_ELEM(node_id) \
-	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 3)
+#define CAN_MCAN_DT_MRAM_RX_FIFO0_ELEMENTS(node_id)                                                \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, CAN_MCAN_MRAM_CFG_RX_FIFO0)
 
 /**
  * @brief Get the number of Rx FIFO 1 elements in Bosch M_CAN Message RAM
@@ -448,8 +455,8 @@ enum can_mcan_mram_cfg {
  * @param node_id node identifier
  * @return the number of Rx FIFO 1 elements
  */
-#define CAN_MCAN_DT_MRAM_RX_FIFO1_ELEM(node_id) \
-	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 4)
+#define CAN_MCAN_DT_MRAM_RX_FIFO1_ELEMENTS(node_id)                                                \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, CAN_MCAN_MRAM_CFG_RX_FIFO1)
 
 /**
  * @brief Get the number of Rx Buffer elements in Bosch M_CAN Message RAM
@@ -457,8 +464,8 @@ enum can_mcan_mram_cfg {
  * @param node_id node identifier
  * @return the number of Rx Buffer elements
  */
-#define CAN_MCAN_DT_MRAM_RX_BUFFER_ELEM(node_id) \
-	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 5)
+#define CAN_MCAN_DT_MRAM_RX_BUFFER_ELEMENTS(node_id)                                               \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, CAN_MCAN_MRAM_CFG_RX_BUFFER)
 
 /**
  * @brief Get the number of Tx Event FIFO elements in Bosch M_CAN Message RAM
@@ -466,8 +473,8 @@ enum can_mcan_mram_cfg {
  * @param node_id node identifier
  * @return the number of Tx Event FIFO elements
  */
-#define CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEM(node_id) \
-	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 6)
+#define CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEMENTS(node_id)                                           \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, CAN_MCAN_MRAM_CFG_TX_EVENT_FIFO)
 
 /**
  * @brief Get the number of Tx Buffer elements in Bosch M_CAN Message RAM
@@ -475,8 +482,163 @@ enum can_mcan_mram_cfg {
  * @param node_id node identifier
  * @return the number of Tx Buffer elements
  */
-#define CAN_MCAN_DT_MRAM_TX_BUFFER_ELEM(node_id) \
-	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 7)
+#define CAN_MCAN_DT_MRAM_TX_BUFFER_ELEMENTS(node_id)                                               \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, CAN_MCAN_MRAM_CFG_TX_BUFFER)
+
+/**
+ * @brief Get the base offset of standard (11-bit) filter elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the base offset of standard (11-bit) filter elements in bytes
+ */
+#define CAN_MCAN_DT_MRAM_STD_FILTER_OFFSET(node_id) (0U)
+
+/**
+ * @brief Get the base offset of extended (29-bit) filter elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the base offset of extended (29-bit) filter elements in bytes
+ */
+#define CAN_MCAN_DT_MRAM_EXT_FILTER_OFFSET(node_id)                                                \
+	(CAN_MCAN_DT_MRAM_STD_FILTER_OFFSET(node_id) +                                             \
+	 CAN_MCAN_DT_MRAM_STD_FILTER_ELEMENTS(node_id) * sizeof(struct can_mcan_std_filter))
+
+/**
+ * @brief Get the base offset of Rx FIFO 0 elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the base offset of Rx FIFO 0 elements in bytes
+ */
+#define CAN_MCAN_DT_MRAM_RX_FIFO0_OFFSET(node_id)                                                  \
+	(CAN_MCAN_DT_MRAM_EXT_FILTER_OFFSET(node_id) +                                             \
+	 CAN_MCAN_DT_MRAM_EXT_FILTER_ELEMENTS(node_id) * sizeof(struct can_mcan_ext_filter))
+
+/**
+ * @brief Get the base offset of Rx FIFO 1 elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the base offset of Rx FIFO 1 elements in bytes
+ */
+#define CAN_MCAN_DT_MRAM_RX_FIFO1_OFFSET(node_id)                                                  \
+	(CAN_MCAN_DT_MRAM_RX_FIFO0_OFFSET(node_id) +                                               \
+	 CAN_MCAN_DT_MRAM_RX_FIFO0_ELEMENTS(node_id) * sizeof(struct can_mcan_rx_fifo))
+
+/**
+ * @brief Get the base offset of Rx Buffer elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the base offset of Rx Buffer elements in bytes
+ */
+#define CAN_MCAN_DT_MRAM_RX_BUFFER_OFFSET(node_id)                                                 \
+	(CAN_MCAN_DT_MRAM_RX_FIFO1_OFFSET(node_id) +                                               \
+	 CAN_MCAN_DT_MRAM_RX_FIFO1_ELEMENTS(node_id) * sizeof(struct can_mcan_rx_fifo))
+
+/**
+ * @brief Get the base offset of Tx Event FIFO elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the base offset of Tx Event FIFO elements in bytes
+ */
+#define CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_OFFSET(node_id)                                             \
+	(CAN_MCAN_DT_MRAM_RX_BUFFER_OFFSET(node_id) +                                              \
+	 CAN_MCAN_DT_MRAM_RX_BUFFER_ELEMENTS(node_id) * sizeof(struct can_mcan_rx_fifo))
+
+/**
+ * @brief Get the base offset of Tx Buffer elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the base offset of Tx Buffer elements in bytes
+ */
+#define CAN_MCAN_DT_MRAM_TX_BUFFER_OFFSET(node_id)                                                 \
+	(CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_OFFSET(node_id) +                                          \
+	 CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEMENTS(node_id) * sizeof(struct can_mcan_tx_event_fifo))
+
+/**
+ * @brief Get the Bosch M_CAN register base address
+ *
+ * For devicetree nodes with just one register block, this macro returns the base address of that
+ * register block.
+ *
+ * If a devicetree node has more than one register block, this macros returns the base address of
+ * the register block named "m_can".
+ *
+ * @param node_id node identifier
+ * @return the Bosch M_CAN register base address
+ */
+#define CAN_MCAN_DT_MCAN_ADDR(node_id)                                                             \
+	COND_CODE_1(DT_NUM_REGS(node_id), ((mm_reg_t)DT_REG_ADDR(node_id)),                        \
+		    ((mm_reg_t)DT_REG_ADDR_BY_NAME(node_id, m_can)))
+
+/**
+ * @brief Get the Bosch M_CAN Message RAM base address
+ *
+ * For devicetree nodes with dedicated Message RAM area defined via devicetree, this macro returns
+ * the base address of the Message RAM, taking in the Message RAM offset into account.
+ *
+ * @param node_id node identifier
+ * @return the Bosch M_CAN Message RAM base address
+ */
+#define CAN_MCAN_DT_MRAM_ADDR(node_id)                                                             \
+	(mem_addr_t)(DT_REG_ADDR_BY_NAME(node_id, message_ram) + CAN_MCAN_DT_MRAM_OFFSET(node_id))
+
+/**
+ * @brief Get the Bosch M_CAN Message RAM size
+ *
+ * For devicetree nodes with dedicated Message RAM area defined via devicetree, this macro returns
+ * the size of the Message RAM, taking in the Message RAM offset into account.
+ *
+ * @param node_id node identifier
+ * @return the Bosch M_CAN Message RAM base address
+ * @see CAN_MCAN_DT_MRAM_ELEMENTS_SIZE()
+ */
+#define CAN_MCAN_DT_MRAM_SIZE(node_id)                                                             \
+	(mem_addr_t)(DT_REG_SIZE_BY_NAME(node_id, message_ram) - CAN_MCAN_DT_MRAM_OFFSET(node_id))
+
+/**
+ * @brief Get the total size of all Bosch M_CAN Message RAM elements
+ *
+ * @param node_id node identifier
+ * @return the total size of all Message RAM elements in bytes
+ * @see CAN_MCAN_DT_MRAM_SIZE()
+ */
+#define CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id)                                                    \
+	(CAN_MCAN_DT_MRAM_TX_BUFFER_OFFSET(node_id) +                                              \
+	 CAN_MCAN_DT_MRAM_TX_BUFFER_ELEMENTS(node_id) * sizeof(struct can_mcan_tx_buffer))
+
+/**
+ * @brief Define a RAM buffer for Bosch M_CAN Message RAM
+ *
+ * For devicetree nodes without dedicated Message RAM area, this macro defines a suitable RAM buffer
+ * to hold the Message RAM elements. Since this buffer cannot be shared between multiple Bosch M_CAN
+ * instances, the Message RAM offset must be set to 0x0.
+ *
+ * @param node_id node identifier
+ * @param _name buffer variable name
+ */
+#define CAN_MCAN_DT_MRAM_DEFINE(node_id, _name)                                                    \
+	BUILD_ASSERT(CAN_MCAN_DT_MRAM_OFFSET(node_id) == 0, "offset must be 0");                   \
+	static char __noinit __nocache __aligned(4) _name[CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id)];
+
+/**
+ * @brief Assert that the Message RAM configuration meets the Bosch M_CAN IP core restrictions
+ *
+ * @param node_id node identifier
+ */
+#define CAN_MCAN_DT_BUILD_ASSERT_MRAM_CFG(node_id)                                                 \
+	BUILD_ASSERT(CAN_MCAN_DT_MRAM_STD_FILTER_ELEMENTS(node_id) <= 128,                         \
+		     "Maximum Standard filter elements exceeded");                                 \
+	BUILD_ASSERT(CAN_MCAN_DT_MRAM_EXT_FILTER_ELEMENTS(node_id) <= 64,                          \
+		     "Maximum Extended filter elements exceeded");                                 \
+	BUILD_ASSERT(CAN_MCAN_DT_MRAM_RX_FIFO0_ELEMENTS(node_id) <= 64,                            \
+		     "Maximum Rx FIFO 0 elements exceeded");                                       \
+	BUILD_ASSERT(CAN_MCAN_DT_MRAM_RX_FIFO1_ELEMENTS(node_id) <= 64,                            \
+		     "Maximum Rx FIFO 1 elements exceeded");                                       \
+	BUILD_ASSERT(CAN_MCAN_DT_MRAM_RX_BUFFER_ELEMENTS(node_id) <= 64,                           \
+		     "Maximum Rx Buffer elements exceeded");                                       \
+	BUILD_ASSERT(CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEMENTS(node_id) <= 32,                       \
+		     "Maximum Tx Buffer elements exceeded");                                       \
+	BUILD_ASSERT(CAN_MCAN_DT_MRAM_TX_BUFFER_ELEMENTS(node_id) <= 32,                           \
+		     "Maximum Tx Buffer elements exceeded");
 
 /**
  * @brief Equivalent to CAN_MCAN_DT_MRAM_OFFSET(DT_DRV_INST(inst))
@@ -484,96 +646,181 @@ enum can_mcan_mram_cfg {
  * @return the Message RAM offset in bytes
  * @see CAN_MCAN_DT_MRAM_OFFSET()
  */
-#define CAN_MCAN_DT_INST_MRAM_OFFSET(inst)			\
-	CAN_MCAN_DT_MRAM_OFFSET(DT_DRV_INST(inst))
+#define CAN_MCAN_DT_INST_MRAM_OFFSET(inst) CAN_MCAN_DT_MRAM_OFFSET(DT_DRV_INST(inst))
 
 /**
- * @brief Equivalent to CAN_MCAN_DT_MRAM_STD_FILTER_ELEM(DT_DRV_INST(inst))
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_STD_FILTER_ELEMENTS(DT_DRV_INST(inst))
  * @param inst DT_DRV_COMPAT instance number
  * @return the number of standard (11-bit) elements
- * @see CAN_MCAN_DT_MRAM_STD_FILTER_ELEM()
+ * @see CAN_MCAN_DT_MRAM_STD_FILTER_ELEMENTS()
  */
-#define CAN_MCAN_DT_INST_MRAM_STD_FILTER_ELEM(inst)		\
-	CAN_MCAN_DT_MRAM_STD_FILTER_ELEMDT_DRV_INST(inst))
+#define CAN_MCAN_DT_INST_MRAM_STD_FILTER_ELEMENTS(inst)                                            \
+	CAN_MCAN_DT_MRAM_STD_FILTER_ELEMENTS(DT_DRV_INST(inst))
 
 /**
- * @brief Equivalent to CAN_MCAN_DT_MRAM_EXT_FILTER_ELEM(DT_DRV_INST(inst))
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_EXT_FILTER_ELEMENTS(DT_DRV_INST(inst))
  * @param inst DT_DRV_COMPAT instance number
  * @return the number of extended (29-bit) elements
- * @see CAN_MCAN_DT_MRAM_EXT_FILTER_ELEM()
+ * @see CAN_MCAN_DT_MRAM_EXT_FILTER_ELEMENTS()
  */
-#define CAN_MCAN_DT_INST_MRAM_EXT_FILTER_ELEM(inst)		\
-	CAN_MCAN_DT_MRAM_EXT_FILTER_ELEM(DT_DRV_INST(inst))
+#define CAN_MCAN_DT_INST_MRAM_EXT_FILTER_ELEMENTS(inst)                                            \
+	CAN_MCAN_DT_MRAM_EXT_FILTER_ELEMENTS(DT_DRV_INST(inst))
 
 /**
- * @brief Equivalent to CAN_MCAN_DT_MRAM_RX_FIFO0_ELEM(DT_DRV_INST(inst))
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_RX_FIFO0_ELEMENTS(DT_DRV_INST(inst))
  * @param inst DT_DRV_COMPAT instance number
  * @return the number of Rx FIFO 0 elements
- * @see CAN_MCAN_DT_MRAM_RX_FIFO0_ELEM()
+ * @see CAN_MCAN_DT_MRAM_RX_FIFO0_ELEMENTS()
  */
-#define CAN_MCAN_DT_INST_MRAM_RX_FIFO0_ELEM(inst)		\
-	CAN_MCAN_DT_MRAM_RX_FIFO0_ELEM(DT_DRV_INST(inst))
+#define CAN_MCAN_DT_INST_MRAM_RX_FIFO0_ELEMENTS(inst)                                              \
+	CAN_MCAN_DT_MRAM_RX_FIFO0_ELEMENTS(DT_DRV_INST(inst))
 
 /**
- * @brief Equivalent to CAN_MCAN_DT_MRAM_RX_FIFO1_ELEM(DT_DRV_INST(inst))
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_RX_FIFO1_ELEMENTS(DT_DRV_INST(inst))
  * @param inst DT_DRV_COMPAT instance number
  * @return the number of Rx FIFO 1 elements
- * @see CAN_MCAN_DT_MRAM_RX_FIFO1_ELEM()
+ * @see CAN_MCAN_DT_MRAM_RX_FIFO1_ELEMENTS()
  */
-#define CAN_MCAN_DT_INST_MRAM_RX_FIFO1_ELEM(inst)		\
-	CAN_MCAN_DT_MRAM_RX_FIFO1_ELEM(DT_DRV_INST(inst))
+#define CAN_MCAN_DT_INST_MRAM_RX_FIFO1_ELEMENTS(inst)                                              \
+	CAN_MCAN_DT_MRAM_RX_FIFO1_ELEMENTS(DT_DRV_INST(inst))
 
 /**
- * @brief Equivalent to CAN_MCAN_DT_MRAM_RX_BUFFER_ELEM(DT_DRV_INST(inst))
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_RX_BUFFER_ELEMENTS(DT_DRV_INST(inst))
  * @param inst DT_DRV_COMPAT instance number
  * @return the number of Rx Buffer elements
- * @see CAN_MCAN_DT_MRAM_RX_BUFFER_ELEM()
+ * @see CAN_MCAN_DT_MRAM_RX_BUFFER_ELEMENTS()
  */
-#define CAN_MCAN_DT_INST_MRAM_RX_BUFFER_ELEM(inst)		\
-	CAN_MCAN_DT_MRAM_RX_BUFFER_ELEM(DT_DRV_INST(inst))
+#define CAN_MCAN_DT_INST_MRAM_RX_BUFFER_ELEMENTS(inst)                                             \
+	CAN_MCAN_DT_MRAM_RX_BUFFER_ELEMENTS(DT_DRV_INST(inst))
 
 /**
- * @brief Equivalent to CAN_MCAN_DT_MRAM_TX_EVENT_ELEM(DT_DRV_INST(inst))
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEMENTS(DT_DRV_INST(inst))
  * @param inst DT_DRV_COMPAT instance number
  * @return the number of Tx Event FIFO elements
- * @see CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEM()
+ * @see CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEMENTS()
  */
-#define CAN_MCAN_DT_INST_MRAM_TX_EVENT_FIFO_ELEM(inst)		\
-	CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEM(DT_DRV_INST(inst))
+#define CAN_MCAN_DT_INST_MRAM_TX_EVENT_FIFO_ELEMENTS(inst)                                         \
+	CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEMENTS(DT_DRV_INST(inst))
 
 /**
- * @brief Equivalent to CAN_MCAN_DT_MRAM_TX_BUFFER_ELEM(DT_DRV_INST(inst))
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_TX_BUFFER_ELEMENTS(DT_DRV_INST(inst))
  * @param inst DT_DRV_COMPAT instance number
  * @return the number of Tx Buffer elements
- * @see CAN_MCAN_DT_MRAM_TX_BUFFER_ELEM()
+ * @see CAN_MCAN_DT_MRAM_TX_BUFFER_ELEMENTS()
  */
-#define CAN_MCAN_DT_INST_MRAM_TX_BUFFER_ELEM(inst)		\
-	CAN_MCAN_DT_MRAM_TX_BUFFER_ELEM(DT_DRV_INST(inst))
+#define CAN_MCAN_DT_INST_MRAM_TX_BUFFER_ELEMENTS(inst)                                             \
+	CAN_MCAN_DT_MRAM_TX_BUFFER_ELEMENTS(DT_DRV_INST(inst))
 
-#define NUM_STD_FILTER_ELEMENTS    CAN_MCAN_DT_MRAM_STD_FILTER_ELEM(MCAN_DT_PATH)
-#define NUM_EXT_FILTER_ELEMENTS    CAN_MCAN_DT_MRAM_EXT_FILTER_ELEM(MCAN_DT_PATH)
-#define NUM_RX_FIFO0_ELEMENTS      CAN_MCAN_DT_MRAM_RX_FIFO0_ELEM(MCAN_DT_PATH)
-#define NUM_RX_FIFO1_ELEMENTS      CAN_MCAN_DT_MRAM_RX_FIFO1_ELEM(MCAN_DT_PATH)
-#define NUM_RX_BUF_ELEMENTS        CAN_MCAN_DT_MRAM_RX_BUFFER_ELEM(MCAN_DT_PATH)
-#define NUM_TX_EVENT_FIFO_ELEMENTS CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEM(MCAN_DT_PATH)
-#define NUM_TX_BUF_ELEMENTS        CAN_MCAN_DT_MRAM_TX_BUFFER_ELEM(MCAN_DT_PATH)
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_STD_FILTER_OFFSET(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the base offset of standard (11-bit) filter elements in bytes
+ * @see CAN_MCAN_DT_MRAM_STD_FILTER_OFFSET()
+ */
+#define CAN_MCAN_DT_INST_MRAM_STD_FILTER_OFFSET(inst)                                              \
+	CAN_MCAN_DT_MRAM_STD_FILTER_OFFSET(DT_DRV_INST(inst))
 
-/* Assert that the Message RAM configuration meets the M_CAN IP core restrictions */
-BUILD_ASSERT(NUM_STD_FILTER_ELEMENTS <= 128, "Maximum Standard filter elements exceeded");
-BUILD_ASSERT(NUM_EXT_FILTER_ELEMENTS <= 64, "Maximum Extended filter elements exceeded");
-BUILD_ASSERT(NUM_RX_FIFO0_ELEMENTS <= 64, "Maximum Rx FIFO 0 elements exceeded");
-BUILD_ASSERT(NUM_RX_FIFO1_ELEMENTS <= 64, "Maximum Rx FIFO 1 elements exceeded");
-BUILD_ASSERT(NUM_RX_BUF_ELEMENTS <= 64, "Maximum Rx Buffer elements exceeded");
-BUILD_ASSERT(NUM_TX_EVENT_FIFO_ELEMENTS <= 32, "Maximum Tx Buffer elements exceeded");
-BUILD_ASSERT(NUM_TX_BUF_ELEMENTS <= 32, "Maximum Tx Buffer elements exceeded");
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_EXT_FILTER_OFFSET(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the base offset of extended (29-bit) filter elements in bytes
+ * @see CAN_MCAN_DT_MRAM_EXT_FILTER_OFFSET()
+ */
+#define CAN_MCAN_DT_INST_MRAM_EXT_FILTER_OFFSET(inst)                                              \
+	CAN_MCAN_DT_MRAM_EXT_FILTER_OFFSET(DT_DRV_INST(inst))
 
-#ifdef CONFIG_CAN_STM32FD
-#define NUM_STD_FILTER_DATA CONFIG_CAN_MAX_STD_ID_FILTER
-#define NUM_EXT_FILTER_DATA CONFIG_CAN_MAX_EXT_ID_FILTER
-#else
-#define NUM_STD_FILTER_DATA NUM_STD_FILTER_ELEMENTS
-#define NUM_EXT_FILTER_DATA NUM_EXT_FILTER_ELEMENTS
-#endif
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_RX_FIFO0_OFFSET(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the base offset of Rx FIFO 0 elements in bytes
+ * @see CAN_MCAN_DT_MRAM_RX_FIFO0_OFFSET()
+ */
+#define CAN_MCAN_DT_INST_MRAM_RX_FIFO0_OFFSET(inst)                                                \
+	CAN_MCAN_DT_MRAM_RX_FIFO0_OFFSET(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_RX_FIFO1_OFFSET(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the base offset of Rx FIFO 1 elements in bytes
+ * @see CAN_MCAN_DT_MRAM_RX_FIFO1_OFFSET()
+ */
+#define CAN_MCAN_DT_INST_MRAM_RX_FIFO1_OFFSET(inst)                                                \
+	CAN_MCAN_DT_MRAM_RX_FIFO1_OFFSET(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_RX_BUFFER_OFFSET(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the base offset of Rx Buffer elements in bytes
+ * @see CAN_MCAN_DT_MRAM_RX_BUFFER_OFFSET()
+ */
+#define CAN_MCAN_DT_INST_MRAM_RX_BUFFER_OFFSET(inst)                                               \
+	CAN_MCAN_DT_MRAM_RX_BUFFER_OFFSET(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_OFFSET(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the base offset of Tx Event FIFO elements in bytes
+ * @see CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_OFFSET()
+ */
+#define CAN_MCAN_DT_INST_MRAM_TX_EVENT_FIFO_OFFSET(inst)                                           \
+	CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_OFFSET(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_TX_BUFFER_OFFSET(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the base offset of Tx Buffer elements in bytes
+ * @see CAN_MCAN_DT_MRAM_TX_BUFFER_OFFSET()
+ */
+#define CAN_MCAN_DT_INST_MRAM_TX_BUFFER_OFFSET(inst)                                               \
+	CAN_MCAN_DT_MRAM_TX_BUFFER_OFFSET(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MCAN_ADDR(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the Bosch M_CAN register base address
+ * @see CAN_MCAN_DT_MRAM_ADDR()
+ */
+#define CAN_MCAN_DT_INST_MCAN_ADDR(inst) CAN_MCAN_DT_MCAN_ADDR(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_ADDR(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the Bosch M_CAN Message RAM base address
+ * @see CAN_MCAN_DT_MRAM_ADDR()
+ */
+#define CAN_MCAN_DT_INST_MRAM_ADDR(inst) CAN_MCAN_DT_MRAM_ADDR(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_SIZE(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the Bosch M_CAN Message RAM size in bytes
+ * @see CAN_MCAN_DT_MRAM_SIZE()
+ */
+#define CAN_MCAN_DT_INST_MRAM_SIZE(inst) CAN_MCAN_DT_MRAM_SIZE(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the total size of all Message RAM elements in bytes
+ * @see CAN_MCAN_DT_MRAM_ELEMENTS_SIZE()
+ */
+#define CAN_MCAN_DT_INST_MRAM_ELEMENTS_SIZE(inst) CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_DEFINE(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @param _name buffer variable name
+ * @see CAN_MCAN_DT_MRAM_DEFINE()
+ */
+#define CAN_MCAN_DT_INST_MRAM_DEFINE(inst, _name) CAN_MCAN_DT_MRAM_DEFINE(DT_DRV_INST(inst), _name)
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_BUILD_ASSERT_MRAM_CFG(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @see CAN_MCAN_DT_BUILD_ASSERT_MRAM_CFG()
+ */
+#define CAN_MCAN_DT_INST_BUILD_ASSERT_MRAM_CFG(inst)                                               \
+	CAN_MCAN_DT_BUILD_ASSERT_MRAM_CFG(DT_DRV_INST(inst))
 
 struct can_mcan_rx_fifo_hdr {
 	union {
@@ -689,42 +936,12 @@ struct can_mcan_ext_filter {
 	uint32_t eft: 2; /* Filter type */
 } __packed __aligned(4);
 
-struct can_mcan_msg_sram {
-	struct can_mcan_std_filter std_filt[NUM_STD_FILTER_ELEMENTS];
-	struct can_mcan_ext_filter ext_filt[NUM_EXT_FILTER_ELEMENTS];
-	struct can_mcan_rx_fifo rx_fifo0[NUM_RX_FIFO0_ELEMENTS];
-	struct can_mcan_rx_fifo rx_fifo1[NUM_RX_FIFO1_ELEMENTS];
-	struct can_mcan_rx_fifo rx_buffer[NUM_RX_BUF_ELEMENTS];
-	struct can_mcan_tx_event_fifo tx_event_fifo[NUM_TX_EVENT_FIFO_ELEMENTS];
-	struct can_mcan_tx_buffer tx_buffer[NUM_TX_BUF_ELEMENTS];
-} __packed __aligned(4);
-
-#define CAN_MCAN_MRAM_OFFSET_STD_FILTER offsetof(struct can_mcan_msg_sram, std_filt)
-#define CAN_MCAN_MRAM_OFFSET_EXT_FILTER offsetof(struct can_mcan_msg_sram, ext_filt)
-#define CAN_MCAN_MRAM_OFFSET_RX_FIFO0 offsetof(struct can_mcan_msg_sram, rx_fifo0)
-#define CAN_MCAN_MRAM_OFFSET_RX_FIFO1 offsetof(struct can_mcan_msg_sram, rx_fifo1)
-#define CAN_MCAN_MRAM_OFFSET_RX_BUFFER offsetof(struct can_mcan_msg_sram, rx_buffer)
-#define CAN_MCAN_MRAM_OFFSET_TX_EVENT_FIFO offsetof(struct can_mcan_msg_sram, tx_event_fifo)
-#define CAN_MCAN_MRAM_OFFSET_TX_BUFFER offsetof(struct can_mcan_msg_sram, tx_buffer)
-
 struct can_mcan_data {
 	struct k_mutex lock;
 	struct k_sem tx_sem;
 	struct k_mutex tx_mtx;
-	can_tx_callback_t tx_fin_cb[NUM_TX_BUF_ELEMENTS];
-	void *tx_fin_cb_arg[NUM_TX_BUF_ELEMENTS];
-	can_rx_callback_t rx_cb_std[NUM_STD_FILTER_DATA];
-	can_rx_callback_t rx_cb_ext[NUM_EXT_FILTER_DATA];
-	void *cb_arg_std[NUM_STD_FILTER_DATA];
-	void *cb_arg_ext[NUM_EXT_FILTER_DATA];
 	can_state_change_callback_t state_change_cb;
 	void *state_change_cb_data;
-	uint32_t std_filt_fd_frame;
-	uint32_t std_filt_rtr;
-	uint32_t std_filt_rtr_mask;
-	uint16_t ext_filt_fd_frame;
-	uint16_t ext_filt_rtr;
-	uint16_t ext_filt_rtr_mask;
 	bool started;
 #ifdef CONFIG_CAN_FD_MODE
 	bool fd;
@@ -814,8 +1031,90 @@ struct can_mcan_ops {
 	can_mcan_clear_mram_t clear_mram;
 };
 
+/**
+ * @brief Bosch M_CAN driver internal Tx callback structure.
+ */
+struct can_mcan_tx_callback {
+	can_tx_callback_t function;
+	void *user_data;
+};
+
+/**
+ * @brief Bosch M_CAN driver internal Rx callback structure.
+ */
+struct can_mcan_rx_callback {
+	can_rx_callback_t function;
+	void *user_data;
+	uint8_t flags;
+};
+
+/**
+ * @brief Bosch M_CAN driver internal Tx + Rx callbacks structure.
+ */
+struct can_mcan_callbacks {
+	struct can_mcan_tx_callback *tx;
+	struct can_mcan_rx_callback *std;
+	struct can_mcan_rx_callback *ext;
+	uint8_t num_tx;
+	uint8_t num_std;
+	uint8_t num_ext;
+};
+
+/**
+ * @brief Define Bosch M_CAN TX and RX callbacks
+ *
+ * This macro allows a Bosch M_CAN driver frontend using a fixed Message RAM configuration to limit
+ * the required software resources (e.g. limit the number of the standard (11-bit) or extended
+ * (29-bit) filters in use).
+ *
+ * Frontend drivers supporting dynamic Message RAM configuration should use @ref
+ * CAN_MCAN_DT_CALLBACKS_DEFINE() or @ref CAN_MCAN_DT_INST_CALLBACKS_DEFINE() instead.
+ *
+ * @param _name callbacks variable name
+ * @param _tx Number of Tx callbacks
+ * @param _std Number of standard (11-bit) filter callbacks
+ * @param _ext Number of extended (29-bit) filter callbacks
+ * @see CAN_MCAN_DT_CALLBACKS_DEFINE()
+ */
+#define CAN_MCAN_CALLBACKS_DEFINE(_name, _tx, _std, _ext)                                          \
+	static struct can_mcan_tx_callback _name##_tx_cbs[_tx];                                    \
+	static struct can_mcan_rx_callback _name##_std_cbs[_std];                                  \
+	static struct can_mcan_rx_callback _name##_ext_cbs[_ext];                                  \
+	static const struct can_mcan_callbacks _name = {                                           \
+		.tx = _name##_tx_cbs,                                                              \
+		.std = _name##_std_cbs,                                                            \
+		.ext = _name##_ext_cbs,                                                            \
+		.num_tx = _tx,                                                                     \
+		.num_std = _std,                                                                   \
+		.num_ext = _ext,                                                                   \
+	}
+
+/**
+ * @brief Define Bosch M_CAN TX and RX callbacks
+ * @param node_id node identifier
+ * @param _name callbacks variable name
+ * @see CAN_MCAN_CALLBACKS_DEFINE()
+ */
+#define CAN_MCAN_DT_CALLBACKS_DEFINE(node_id, _name)                                               \
+	CAN_MCAN_CALLBACKS_DEFINE(_name, CAN_MCAN_DT_MRAM_TX_BUFFER_ELEMENTS(node_id),             \
+				  CAN_MCAN_DT_MRAM_STD_FILTER_ELEMENTS(node_id),                   \
+				  CAN_MCAN_DT_MRAM_EXT_FILTER_ELEMENTS(node_id))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_CALLBACKS_DEFINE(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @param _name callbacks variable name
+ * @see CAN_MCAN_DT_CALLBACKS_DEFINE()
+ */
+#define CAN_MCAN_DT_INST_CALLBACKS_DEFINE(inst, _name)                                             \
+	CAN_MCAN_DT_CALLBACKS_DEFINE(DT_DRV_INST(inst), _name)
+
 struct can_mcan_config {
-	struct can_mcan_ops *ops;
+	const struct can_mcan_ops *ops;
+	const struct can_mcan_callbacks *callbacks;
+	uint16_t mram_elements[CAN_MCAN_MRAM_CFG_NUM_CELLS];
+	uint16_t mram_offsets[CAN_MCAN_MRAM_CFG_NUM_CELLS];
+	size_t mram_size;
 	uint32_t bus_speed;
 	uint16_t sjw;
 	uint16_t sample_point;
@@ -835,16 +1134,61 @@ struct can_mcan_config {
 };
 
 /**
+ * @brief Get an array containing the number of elements in Bosch M_CAN Message RAM
+ *
+ * The order of the array entries is given by the @ref CAN_MCAN_MRAM_CFG definitions.
+ *
+ * @param node_id node identifier
+ * @return array of number of elements
+ */
+#define CAN_MCAN_DT_MRAM_ELEMENTS_GET(node_id)                                                     \
+	{                                                                                          \
+		0, /* offset cell */                                                               \
+			CAN_MCAN_DT_MRAM_STD_FILTER_ELEMENTS(node_id),                             \
+			CAN_MCAN_DT_MRAM_EXT_FILTER_ELEMENTS(node_id),                             \
+			CAN_MCAN_DT_MRAM_RX_FIFO0_ELEMENTS(node_id),                               \
+			CAN_MCAN_DT_MRAM_RX_FIFO1_ELEMENTS(node_id),                               \
+			CAN_MCAN_DT_MRAM_RX_BUFFER_ELEMENTS(node_id),                              \
+			CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEMENTS(node_id),                          \
+			CAN_MCAN_DT_MRAM_TX_BUFFER_ELEMENTS(node_id)                               \
+	}
+
+/**
+ * @brief Get an array containing the base offsets for element in Bosch M_CAN Message RAM
+ *
+ * The order of the array entries is given by the @ref CAN_MCAN_MRAM_CFG definitions.
+ *
+ * @param node_id node identifier
+ * @return array of base offsets for elements
+ */
+#define CAN_MCAN_DT_MRAM_OFFSETS_GET(node_id)                                                      \
+	{                                                                                          \
+		0, /* offset cell */                                                               \
+			CAN_MCAN_DT_MRAM_STD_FILTER_OFFSET(node_id),                               \
+			CAN_MCAN_DT_MRAM_EXT_FILTER_OFFSET(node_id),                               \
+			CAN_MCAN_DT_MRAM_RX_FIFO0_OFFSET(node_id),                                 \
+			CAN_MCAN_DT_MRAM_RX_FIFO1_OFFSET(node_id),                                 \
+			CAN_MCAN_DT_MRAM_RX_BUFFER_OFFSET(node_id),                                \
+			CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_OFFSET(node_id),                            \
+			CAN_MCAN_DT_MRAM_TX_BUFFER_OFFSET(node_id)                                 \
+	}
+
+/**
  * @brief Static initializer for @p can_mcan_config struct
  *
  * @param node_id Devicetree node identifier
  * @param _custom Pointer to custom driver frontend configuration structure
  * @param _ops Pointer to front-end @a can_mcan_ops
+ * @param _cbs Pointer to front-end @a can_mcan_callbacks
  */
 #ifdef CONFIG_CAN_FD_MODE
-#define CAN_MCAN_DT_CONFIG_GET(node_id, _custom, _ops)                                             \
+#define CAN_MCAN_DT_CONFIG_GET(node_id, _custom, _ops, _cbs)                                       \
 	{                                                                                          \
 		.ops = _ops,                                                                       \
+		.callbacks = _cbs,                                                                 \
+		.mram_elements = CAN_MCAN_DT_MRAM_ELEMENTS_GET(node_id),                           \
+		.mram_offsets = CAN_MCAN_DT_MRAM_OFFSETS_GET(node_id),                             \
+		.mram_size = CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id),                              \
 		.bus_speed = DT_PROP(node_id, bus_speed),                                          \
 		.sjw = DT_PROP(node_id, sjw),                                                      \
 		.sample_point = DT_PROP_OR(node_id, sample_point, 0),                              \
@@ -862,9 +1206,13 @@ struct can_mcan_config {
 		.custom = _custom,                                                                 \
 	}
 #else /* CONFIG_CAN_FD_MODE */
-#define CAN_MCAN_DT_CONFIG_GET(node_id, _custom, _ops)                                             \
+#define CAN_MCAN_DT_CONFIG_GET(node_id, _custom, _ops, _cbs)                                       \
 	{                                                                                          \
 		.ops = _ops,                                                                       \
+		.callbacks = _cbs,                                                                 \
+		.mram_elements = CAN_MCAN_DT_MRAM_ELEMENTS_GET(node_id),                           \
+		.mram_offsets = CAN_MCAN_DT_MRAM_OFFSETS_GET(node_id),                             \
+		.mram_size = CAN_MCAN_DT_MRAM_ELEMENTS_SIZE(node_id),                              \
 		.bus_speed = DT_PROP(node_id, bus_speed),                                          \
 		.sjw = DT_PROP(node_id, sjw),                                                      \
 		.sample_point = DT_PROP_OR(node_id, sample_point, 0),                              \
@@ -882,14 +1230,14 @@ struct can_mcan_config {
  * @param inst DT_DRV_COMPAT instance number
  * @param _custom Pointer to custom driver frontend configuration structure
  * @param _ops Pointer to front-end @a can_mcan_ops
+ * @param _cbs Pointer to front-end @a can_mcan_callbacks
  * @see CAN_MCAN_DT_CONFIG_GET()
  */
-#define CAN_MCAN_DT_CONFIG_INST_GET(inst, _custom, _ops)                                           \
-	CAN_MCAN_DT_CONFIG_GET(DT_DRV_INST(inst), _custom, _ops)
+#define CAN_MCAN_DT_CONFIG_INST_GET(inst, _custom, _ops, _cbs)                                     \
+	CAN_MCAN_DT_CONFIG_GET(DT_DRV_INST(inst), _custom, _ops, _cbs)
 
 /**
  * @brief Initializer for a @a can_mcan_data struct
- * @param _msg_ram Pointer to message RAM structure
  * @param _custom Pointer to custom driver frontend data structure
  */
 #define CAN_MCAN_DATA_INITIALIZER(_custom)                                                         \

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -21,7 +21,7 @@
  */
 
 /* Core Release register */
-#define CAN_MCAN_CREL	      0x000
+#define CAN_MCAN_CREL         0x000
 #define CAN_MCAN_CREL_REL     GENMASK(31, 28)
 #define CAN_MCAN_CREL_STEP    GENMASK(27, 24)
 #define CAN_MCAN_CREL_SUBSTEP GENMASK(23, 20)
@@ -30,15 +30,15 @@
 #define CAN_MCAN_CREL_DAY     GENMASK(7, 0)
 
 /* Endian register */
-#define CAN_MCAN_ENDN	  0x004
+#define CAN_MCAN_ENDN     0x004
 #define CAN_MCAN_ENDN_ETV GENMASK(31, 0)
 
 /* Customer register */
-#define CAN_MCAN_CUST	   0x008
+#define CAN_MCAN_CUST      0x008
 #define CAN_MCAN_CUST_CUST GENMASK(31, 0)
 
 /* Data Bit Timing & Prescaler register */
-#define CAN_MCAN_DBTP	     0x00C
+#define CAN_MCAN_DBTP        0x00C
 #define CAN_MCAN_DBTP_TDC    BIT(23)
 #define CAN_MCAN_DBTP_DBRP   GENMASK(20, 16)
 #define CAN_MCAN_DBTP_DTSEG1 GENMASK(12, 8)
@@ -46,22 +46,22 @@
 #define CAN_MCAN_DBTP_DSJW   GENMASK(3, 0)
 
 /* Test register */
-#define CAN_MCAN_TEST 0x010
+#define CAN_MCAN_TEST       0x010
 #define CAN_MCAN_TEST_SVAL  BIT(21)
 #define CAN_MCAN_TEST_TXBNS GENMASK(20, 16)
 #define CAN_MCAN_TEST_PVAL  BIT(13)
 #define CAN_MCAN_TEST_TXBNP GENMASK(12, 8)
-#define CAN_MCAN_TEST_RX   BIT(7)
-#define CAN_MCAN_TEST_TX   GENMASK(6, 5)
-#define CAN_MCAN_TEST_LBCK BIT(4)
+#define CAN_MCAN_TEST_RX    BIT(7)
+#define CAN_MCAN_TEST_TX    GENMASK(6, 5)
+#define CAN_MCAN_TEST_LBCK  BIT(4)
 
 /* RAM Watchdog register */
-#define CAN_MCAN_RWD	 0x014
+#define CAN_MCAN_RWD     0x014
 #define CAN_MCAN_RWD_WDV GENMASK(15, 8)
 #define CAN_MCAN_RWD_WDC GENMASK(7, 0)
 
 /* CC Control register */
-#define CAN_MCAN_CCCR	   0x018
+#define CAN_MCAN_CCCR      0x018
 #define CAN_MCAN_CCCR_NISO BIT(15)
 #define CAN_MCAN_CCCR_TXP  BIT(14)
 #define CAN_MCAN_CCCR_EFBI BIT(13)
@@ -80,81 +80,81 @@
 #define CAN_MCAN_CCCR_INIT BIT(0)
 
 /* Nominal Bit Timing & Prescaler register */
-#define CAN_MCAN_NBTP	     0x01C
+#define CAN_MCAN_NBTP        0x01C
 #define CAN_MCAN_NBTP_NSJW   GENMASK(31, 25)
 #define CAN_MCAN_NBTP_NBRP   GENMASK(24, 16)
 #define CAN_MCAN_NBTP_NTSEG1 GENMASK(15, 8)
 #define CAN_MCAN_NBTP_NTSEG2 GENMASK(6, 0)
 
 /* Timestamp Counter Configuration register */
-#define CAN_MCAN_TSCC	  0x020
+#define CAN_MCAN_TSCC     0x020
 #define CAN_MCAN_TSCC_TCP GENMASK(19, 16)
 #define CAN_MCAN_TSCC_TSS GENMASK(1, 0)
 
 /* Timestamp Counter Value register */
-#define CAN_MCAN_TSCV	  0x024
+#define CAN_MCAN_TSCV     0x024
 #define CAN_MCAN_TSCV_TSC GENMASK(15, 0)
 
 /* Timeout Counter Configuration register */
-#define CAN_MCAN_TOCC	   0x028
+#define CAN_MCAN_TOCC      0x028
 #define CAN_MCAN_TOCC_TOP  GENMASK(31, 16)
 #define CAN_MCAN_TOCC_TOS  GENMASK(2, 1)
 #define CAN_MCAN_TOCC_ETOC BIT(1)
 
 /* Timeout Counter Value register */
-#define CAN_MCAN_TOCV	  0x02C
+#define CAN_MCAN_TOCV     0x02C
 #define CAN_MCAN_TOCV_TOC GENMASK(15, 0)
 
 /* Error Counter register */
-#define CAN_MCAN_ECR	 0x040
+#define CAN_MCAN_ECR     0x040
 #define CAN_MCAN_ECR_CEL GENMASK(23, 16)
-#define CAN_MCAN_ECR_RP	 BIT(15)
+#define CAN_MCAN_ECR_RP  BIT(15)
 #define CAN_MCAN_ECR_REC GENMASK(14, 8)
 #define CAN_MCAN_ECR_TEC GENMASK(7, 0)
 
 /* Protocol Status register */
-#define CAN_MCAN_PSR	  0x044
+#define CAN_MCAN_PSR      0x044
 #define CAN_MCAN_PSR_TDCV GENMASK(22, 16)
 #define CAN_MCAN_PSR_PXE  BIT(14)
 #define CAN_MCAN_PSR_RFDF BIT(13)
 #define CAN_MCAN_PSR_RBRS BIT(12)
 #define CAN_MCAN_PSR_RESI BIT(11)
 #define CAN_MCAN_PSR_DLEC GENMASK(10, 8)
-#define CAN_MCAN_PSR_BO	  BIT(7)
-#define CAN_MCAN_PSR_EW	  BIT(6)
-#define CAN_MCAN_PSR_EP	  BIT(5)
+#define CAN_MCAN_PSR_BO   BIT(7)
+#define CAN_MCAN_PSR_EW   BIT(6)
+#define CAN_MCAN_PSR_EP   BIT(5)
 #define CAN_MCAN_PSR_ACT  GENMASK(4, 3)
 #define CAN_MCAN_PSR_LEC  GENMASK(2, 0)
 
 /* Transmitter Delay Compensation register */
-#define CAN_MCAN_TDCR	   0x048
+#define CAN_MCAN_TDCR      0x048
 #define CAN_MCAN_TDCR_TDCO GENMASK(14, 8)
 #define CAN_MCAN_TDCR_TDCF GENMASK(6, 0)
 
 /* Interrupt register */
-#define CAN_MCAN_IR 0x050
-#define CAN_MCAN_IR_ARA	 BIT(29)
-#define CAN_MCAN_IR_PED	 BIT(28)
-#define CAN_MCAN_IR_PEA	 BIT(27)
-#define CAN_MCAN_IR_WDI	 BIT(26)
-#define CAN_MCAN_IR_BO	 BIT(25)
-#define CAN_MCAN_IR_EW	 BIT(24)
-#define CAN_MCAN_IR_EP	 BIT(23)
-#define CAN_MCAN_IR_ELO	 BIT(22)
-#define CAN_MCAN_IR_BEU	 BIT(21)
-#define CAN_MCAN_IR_BEC	 BIT(20)
-#define CAN_MCAN_IR_DRX	 BIT(19)
-#define CAN_MCAN_IR_TOO	 BIT(18)
+#define CAN_MCAN_IR      0x050
+#define CAN_MCAN_IR_ARA  BIT(29)
+#define CAN_MCAN_IR_PED  BIT(28)
+#define CAN_MCAN_IR_PEA  BIT(27)
+#define CAN_MCAN_IR_WDI  BIT(26)
+#define CAN_MCAN_IR_BO   BIT(25)
+#define CAN_MCAN_IR_EW   BIT(24)
+#define CAN_MCAN_IR_EP   BIT(23)
+#define CAN_MCAN_IR_ELO  BIT(22)
+#define CAN_MCAN_IR_BEU  BIT(21)
+#define CAN_MCAN_IR_BEC  BIT(20)
+#define CAN_MCAN_IR_DRX  BIT(19)
+#define CAN_MCAN_IR_TOO  BIT(18)
 #define CAN_MCAN_IR_MRAF BIT(17)
-#define CAN_MCAN_IR_TSW	 BIT(16)
+#define CAN_MCAN_IR_TSW  BIT(16)
 #define CAN_MCAN_IR_TEFL BIT(15)
 #define CAN_MCAN_IR_TEFF BIT(14)
 #define CAN_MCAN_IR_TEFW BIT(13)
 #define CAN_MCAN_IR_TEFN BIT(12)
-#define CAN_MCAN_IR_TFE	 BIT(11)
-#define CAN_MCAN_IR_TCF	 BIT(10)
-#define CAN_MCAN_IR_TC	 BIT(9)
-#define CAN_MCAN_IR_HPM	 BIT(8)
+#define CAN_MCAN_IR_TFE  BIT(11)
+#define CAN_MCAN_IR_TCF  BIT(10)
+#define CAN_MCAN_IR_TC   BIT(9)
+#define CAN_MCAN_IR_HPM  BIT(8)
 #define CAN_MCAN_IR_RF1L BIT(7)
 #define CAN_MCAN_IR_RF1F BIT(6)
 #define CAN_MCAN_IR_RF1W BIT(5)
@@ -165,14 +165,14 @@
 #define CAN_MCAN_IR_RF0N BIT(0)
 
 /* Interrupt Enable register */
-#define CAN_MCAN_IE 0x054
+#define CAN_MCAN_IE       0x054
 #define CAN_MCAN_IE_ARAE  BIT(29)
 #define CAN_MCAN_IE_PEDE  BIT(28)
 #define CAN_MCAN_IE_PEAE  BIT(27)
 #define CAN_MCAN_IE_WDIE  BIT(26)
-#define CAN_MCAN_IE_BOE	  BIT(25)
-#define CAN_MCAN_IE_EWE	  BIT(24)
-#define CAN_MCAN_IE_EPE	  BIT(23)
+#define CAN_MCAN_IE_BOE   BIT(25)
+#define CAN_MCAN_IE_EWE   BIT(24)
+#define CAN_MCAN_IE_EPE   BIT(23)
 #define CAN_MCAN_IE_ELOE  BIT(22)
 #define CAN_MCAN_IE_BEUE  BIT(21)
 #define CAN_MCAN_IE_BECE  BIT(20)
@@ -186,7 +186,7 @@
 #define CAN_MCAN_IE_TEFNE BIT(12)
 #define CAN_MCAN_IE_TFEE  BIT(11)
 #define CAN_MCAN_IE_TCFE  BIT(10)
-#define CAN_MCAN_IE_TCE	  BIT(9)
+#define CAN_MCAN_IE_TCE   BIT(9)
 #define CAN_MCAN_IE_HPME  BIT(8)
 #define CAN_MCAN_IE_RF1LE BIT(7)
 #define CAN_MCAN_IE_RF1FE BIT(6)
@@ -198,7 +198,7 @@
 #define CAN_MCAN_IE_RF0NE BIT(0)
 
 /* Interrupt Line Select register */
-#define CAN_MCAN_ILS 0x058
+#define CAN_MCAN_ILS       0x058
 #define CAN_MCAN_ILS_ARAL  BIT(29)
 #define CAN_MCAN_ILS_PEDL  BIT(28)
 #define CAN_MCAN_ILS_PEAL  BIT(27)
@@ -231,55 +231,55 @@
 #define CAN_MCAN_ILS_RF0NL BIT(0)
 
 /* Interrupt Line Enable register */
-#define CAN_MCAN_ILE	   0x05C
+#define CAN_MCAN_ILE       0x05C
 #define CAN_MCAN_ILE_EINT1 BIT(1)
 #define CAN_MCAN_ILE_EINT0 BIT(0)
 
 /* Global filter configuration register */
-#define CAN_MCAN_GFC	  0x080
+#define CAN_MCAN_GFC      0x080
 #define CAN_MCAN_GFC_ANFS GENMASK(5, 4)
 #define CAN_MCAN_GFC_ANFE GENMASK(3, 2)
 #define CAN_MCAN_GFC_RRFS BIT(1)
 #define CAN_MCAN_GFC_RRFE BIT(0)
 
 /* Standard ID Filter Configuration register */
-#define CAN_MCAN_SIDFC	     0x084
+#define CAN_MCAN_SIDFC       0x084
 #define CAN_MCAN_SIDFC_LSS   GENMASK(23, 16)
 #define CAN_MCAN_SIDFC_FLSSA GENMASK(15, 2)
 
 /* Extended ID Filter Configuration register */
-#define CAN_MCAN_XIDFC	     0x088
+#define CAN_MCAN_XIDFC       0x088
 #define CAN_MCAN_XIDFC_LSS   GENMASK(22, 16)
 #define CAN_MCAN_XIDFC_FLESA GENMASK(15, 2)
 
 /* Extended ID AND Mask register */
-#define CAN_MCAN_XIDAM 0x090
+#define CAN_MCAN_XIDAM      0x090
 #define CAN_MCAN_XIDAM_EIDM GENMASK(28, 0)
 
 /* High Priority Message Status register */
-#define CAN_MCAN_HPMS 0x094
+#define CAN_MCAN_HPMS      0x094
 #define CAN_MCAN_HPMS_FLST BIT(15)
 #define CAN_MCAN_HPMS_FIDX GENMASK(14, 8)
-#define CAN_MCAN_HPMS_MSI GENMASK(7, 6)
+#define CAN_MCAN_HPMS_MSI  GENMASK(7, 6)
 #define CAN_MCAN_HPMS_BIDX GENMASK(5, 0)
 
 /* New Data 1 register */
-#define CAN_MCAN_NDAT1	  0x098
+#define CAN_MCAN_NDAT1    0x098
 #define CAN_MCAN_NDAT1_ND GENMASK(31, 0)
 
 /* New Data 2 register */
-#define CAN_MCAN_NDAT2	  0x09C
+#define CAN_MCAN_NDAT2    0x09C
 #define CAN_MCAN_NDAT2_ND GENMASK(31, 0)
 
 /* Rx FIFO 0 Configuration register */
-#define CAN_MCAN_RXF0C	    0x0A0
+#define CAN_MCAN_RXF0C      0x0A0
 #define CAN_MCAN_RXF0C_F0OM BIT(31)
 #define CAN_MCAN_RXF0C_F0WM GENMASK(30, 24)
 #define CAN_MCAN_RXF0C_F0S  GENMASK(22, 16)
 #define CAN_MCAN_RXF0C_F0SA GENMASK(15, 2)
 
 /* Rx FIFO 0 Status register */
-#define CAN_MCAN_RXF0S 0x0A4
+#define CAN_MCAN_RXF0S      0x0A4
 #define CAN_MCAN_RXF0S_RF0L BIT(25)
 #define CAN_MCAN_RXF0S_F0F  BIT(24)
 #define CAN_MCAN_RXF0S_F0PI GENMASK(21, 16)
@@ -287,22 +287,22 @@
 #define CAN_MCAN_RXF0S_F0FL GENMASK(6, 0)
 
 /* Rx FIFO 0 Acknowledge register */
-#define CAN_MCAN_RXF0A	    0x0A8
+#define CAN_MCAN_RXF0A      0x0A8
 #define CAN_MCAN_RXF0A_F0AI GENMASK(5, 0)
 
 /* Rx Buffer Configuration register */
-#define CAN_MCAN_RXBC	   0x0AC
+#define CAN_MCAN_RXBC      0x0AC
 #define CAN_MCAN_RXBC_RBSA GENMASK(15, 2)
 
 /* Rx FIFO 1 Configuration register */
-#define CAN_MCAN_RXF1C	    0x0B0
+#define CAN_MCAN_RXF1C      0x0B0
 #define CAN_MCAN_RXF1C_F1OM BIT(31)
 #define CAN_MCAN_RXF1C_F1WM GENMASK(30, 24)
 #define CAN_MCAN_RXF1C_F1S  GENMASK(22, 16)
 #define CAN_MCAN_RXF1C_F1SA GENMASK(15, 2)
 
 /* Rx FIFO 1 Status register */
-#define CAN_MCAN_RXF1S 0x0B4
+#define CAN_MCAN_RXF1S      0x0B4
 #define CAN_MCAN_RXF1S_RF1L BIT(25)
 #define CAN_MCAN_RXF1S_F1F  BIT(24)
 #define CAN_MCAN_RXF1S_F1PI GENMASK(21, 16)
@@ -310,69 +310,69 @@
 #define CAN_MCAN_RXF1S_F1FL GENMASK(6, 0)
 
 /* Rx FIFO 1 Acknowledge register */
-#define CAN_MCAN_RXF1A	    0x0B8
+#define CAN_MCAN_RXF1A      0x0B8
 #define CAN_MCAN_RXF1A_F1AI GENMASK(5, 0)
 
 /* Rx Buffer/FIFO Element Size Configuration register */
-#define CAN_MCAN_RXESC	    0x0BC
+#define CAN_MCAN_RXESC      0x0BC
 #define CAN_MCAN_RXESC_RBDS GENMASK(10, 8)
 #define CAN_MCAN_RXESC_F1DS GENMASK(6, 4)
 #define CAN_MCAN_RXESC_F0DS GENMASK(2, 0)
 
 /* Tx Buffer Configuration register */
-#define CAN_MCAN_TXBC 0x0C0
+#define CAN_MCAN_TXBC      0x0C0
 #define CAN_MCAN_TXBC_TFQM BIT(30)
 #define CAN_MCAN_TXBC_TFQS GENMASK(29, 24)
 #define CAN_MCAN_TXBC_NDTB GENMASK(21, 16)
 #define CAN_MCAN_TXBC_TBSA GENMASK(15, 2)
 
 /* Tx FIFO/Queue Status register */
-#define CAN_MCAN_TXFQS	    0x0C4
-#define CAN_MCAN_TXFQS_TFQF BIT(21)
+#define CAN_MCAN_TXFQS       0x0C4
+#define CAN_MCAN_TXFQS_TFQF  BIT(21)
 #define CAN_MCAN_TXFQS_TFQPI GENMASK(20, 16)
 #define CAN_MCAN_TXFQS_TFGI  GENMASK(12, 8)
 #define CAN_MCAN_TXFQS_TFFL  GENMASK(5, 0)
 
 /* Tx Buffer Element Size Configuration register */
-#define CAN_MCAN_TXESC	    0x0C8
+#define CAN_MCAN_TXESC      0x0C8
 #define CAN_MCAN_TXESC_TBDS GENMASK(2, 0)
 
 /* Tx Buffer Request Pending register */
-#define CAN_MCAN_TXBRP	   0x0CC
+#define CAN_MCAN_TXBRP     0x0CC
 #define CAN_MCAN_TXBRP_TRP GENMASK(31, 0)
 
 /* Tx Buffer Add Request register */
-#define CAN_MCAN_TXBAR	  0x0D0
+#define CAN_MCAN_TXBAR    0x0D0
 #define CAN_MCAN_TXBAR_AR GENMASK(31, 0)
 
 /* Tx Buffer Cancellation Request register */
-#define CAN_MCAN_TXBCR	  0x0D4
+#define CAN_MCAN_TXBCR    0x0D4
 #define CAN_MCAN_TXBCR_CR GENMASK(31, 0)
 
 /* Tx Buffer Transmission Occurred register */
-#define CAN_MCAN_TXBTO	  0x0D8
+#define CAN_MCAN_TXBTO    0x0D8
 #define CAN_MCAN_TXBTO_TO GENMASK(31, 0)
 
 /* Tx Buffer Cancellation Finished register */
-#define CAN_MCAN_TXBCF	  0x0DC
+#define CAN_MCAN_TXBCF    0x0DC
 #define CAN_MCAN_TXBCF_CF GENMASK(31, 0)
 
 /* Tx Buffer Transmission Interrupt Enable register */
-#define CAN_MCAN_TXBTIE	    0x0E0
+#define CAN_MCAN_TXBTIE     0x0E0
 #define CAN_MCAN_TXBTIE_TIE GENMASK(31, 0)
 
 /* Tx Buffer Cancellation Finished Interrupt Enable register */
-#define CAN_MCAN_TXBCIE	     0x0E4
+#define CAN_MCAN_TXBCIE      0x0E4
 #define CAN_MCAN_TXBCIE_CFIE GENMASK(31, 0)
 
 /* Tx Event FIFO Configuration register */
-#define CAN_MCAN_TXEFC	    0x0F0
+#define CAN_MCAN_TXEFC      0x0F0
 #define CAN_MCAN_TXEFC_EFWM GENMASK(29, 24)
 #define CAN_MCAN_TXEFC_EFS  GENMASK(21, 16)
 #define CAN_MCAN_TXEFC_EFSA GENMASK(15, 2)
 
 /* Tx Event FIFO Status register */
-#define CAN_MCAN_TXEFS 0x0F4
+#define CAN_MCAN_TXEFS      0x0F4
 #define CAN_MCAN_TXEFS_TEFL BIT(25)
 #define CAN_MCAN_TXEFS_EFF  BIT(24)
 #define CAN_MCAN_TXEFS_EFPI GENMASK(20, 16)
@@ -380,7 +380,7 @@
 #define CAN_MCAN_TXEFS_EFFL GENMASK(5, 0)
 
 /* Tx Event FIFO Acknowledge register */
-#define CAN_MCAN_TXEFA	    0x0F8
+#define CAN_MCAN_TXEFA      0x0F8
 #define CAN_MCAN_TXEFA_EFAI GENMASK(4, 0)
 
 #ifdef CONFIG_CAN_MCUX_MCAN

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -558,6 +558,15 @@ enum can_mcan_mram_cfg {
 #define NUM_TX_EVENT_FIFO_ELEMENTS CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEM(MCAN_DT_PATH)
 #define NUM_TX_BUF_ELEMENTS        CAN_MCAN_DT_MRAM_TX_BUFFER_ELEM(MCAN_DT_PATH)
 
+/* Assert that the Message RAM configuration meets the M_CAN IP core restrictions */
+BUILD_ASSERT(NUM_STD_FILTER_ELEMENTS <= 128, "Maximum Standard filter elements exceeded");
+BUILD_ASSERT(NUM_EXT_FILTER_ELEMENTS <= 64, "Maximum Extended filter elements exceeded");
+BUILD_ASSERT(NUM_RX_FIFO0_ELEMENTS <= 64, "Maximum Rx FIFO 0 elements exceeded");
+BUILD_ASSERT(NUM_RX_FIFO1_ELEMENTS <= 64, "Maximum Rx FIFO 1 elements exceeded");
+BUILD_ASSERT(NUM_RX_BUF_ELEMENTS <= 64, "Maximum Rx Buffer elements exceeded");
+BUILD_ASSERT(NUM_TX_EVENT_FIFO_ELEMENTS <= 32, "Maximum Tx Buffer elements exceeded");
+BUILD_ASSERT(NUM_TX_BUF_ELEMENTS <= 32, "Maximum Tx Buffer elements exceeded");
+
 #ifdef CONFIG_CAN_STM32FD
 #define NUM_STD_FILTER_DATA CONFIG_CAN_MAX_STD_ID_FILTER
 #define NUM_EXT_FILTER_DATA CONFIG_CAN_MAX_EXT_ID_FILTER

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -607,11 +607,6 @@ struct can_mcan_rx_fifo {
 	};
 } __packed __aligned(4);
 
-struct can_mcan_mm {
-	uint8_t idx: 5;
-	uint8_t cnt: 3;
-} __packed;
-
 struct can_mcan_tx_buffer_hdr {
 	union {
 		struct {
@@ -632,7 +627,7 @@ struct can_mcan_tx_buffer_hdr {
 	uint8_t fdf: 1;  /* FD Format */
 	uint8_t res2: 1; /* Reserved */
 	uint8_t efc: 1;  /* Event FIFO control (Store Tx events) */
-	struct can_mcan_mm mm;	  /* Message marker */
+	uint8_t mm;      /* Message marker */
 } __packed __aligned(4);
 
 struct can_mcan_tx_buffer {
@@ -657,7 +652,7 @@ struct can_mcan_tx_event_fifo {
 	uint8_t brs: 1; /* Bit Rate Switch */
 	uint8_t fdf: 1; /* FD Format */
 	uint8_t et: 2;	/* Event type */
-	struct can_mcan_mm mm;	 /* Message marker */
+	uint8_t mm;	/* Message marker */
 } __packed __aligned(4);
 
 #define CAN_MCAN_FCE_DISABLE	0x0
@@ -730,7 +725,6 @@ struct can_mcan_data {
 	uint16_t ext_filt_fd_frame;
 	uint16_t ext_filt_rtr;
 	uint16_t ext_filt_rtr_mask;
-	struct can_mcan_mm mm;
 	bool started;
 #ifdef CONFIG_CAN_FD_MODE
 	bool fd;

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -568,6 +568,7 @@ struct can_mcan_data {
  * @param[out] val Register value
  *
  * @retval 0 If successful.
+ * @retval -ENOTSUP Register not supported.
  * @retval -EIO General input/output error.
  */
 typedef int (*can_mcan_read_reg_t)(const struct device *dev, uint16_t reg, uint32_t *val);
@@ -580,6 +581,7 @@ typedef int (*can_mcan_read_reg_t)(const struct device *dev, uint16_t reg, uint3
  * @param val Register value
  *
  * @retval 0 If successful.
+ * @retval -ENOTSUP Register not supported.
  * @retval -EIO General input/output error.
  */
 typedef int (*can_mcan_write_reg_t)(const struct device *dev, uint16_t reg, uint32_t val);

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -9,6 +9,7 @@
 #ifndef ZEPHYR_DRIVERS_CAN_MCAN_H_
 #define ZEPHYR_DRIVERS_CAN_MCAN_H_
 
+#include <zephyr/cache.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/can.h>
 #include <zephyr/kernel.h>
@@ -389,13 +390,173 @@
 #define MCAN_DT_PATH DT_PATH(soc, can)
 #endif
 
-#define NUM_STD_FILTER_ELEMENTS    DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 1)
-#define NUM_EXT_FILTER_ELEMENTS    DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 2)
-#define NUM_RX_FIFO0_ELEMENTS      DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 3)
-#define NUM_RX_FIFO1_ELEMENTS      DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 4)
-#define NUM_RX_BUF_ELEMENTS        DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 5)
-#define NUM_TX_EVENT_FIFO_ELEMENTS DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 6)
-#define NUM_TX_BUF_ELEMENTS        DT_PROP_BY_IDX(MCAN_DT_PATH, bosch_mram_cfg, 7)
+/**
+ * @brief Indexes for the cells in the devicetree bosch,mram-cfg property. These match the
+ * description of the cells in the bosch,m_can-base devicetree binding.
+ */
+enum can_mcan_mram_cfg {
+	CAN_MCAN_MRAM_CFG_OFFSET = 0,
+	CAN_MCAN_MRAM_CFG_STD_FILTER,
+	CAN_MCAN_MRAM_CFG_EXT_FILTER,
+	CAN_MCAN_MRAM_CFG_RX_FIFO0,
+	CAN_MCAN_MRAM_CFG_RX_FIFO1,
+	CAN_MCAN_MRAM_CFG_RX_BUFFER,
+	CAN_MCAN_MRAM_CFG_TX_EVENT,
+	CAN_MCAN_MRAM_CFG_TX_BUFFER,
+	CAN_MCAN_MRAM_CFG_NUM_CELLS
+};
+
+/**
+ * @brief Get the Bosch M_CAN Message RAM offset
+ *
+ * @param node_id node identifier
+ * @return the Message RAM offset in bytes
+ */
+#define CAN_MCAN_DT_MRAM_OFFSET(node_id) \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 0)
+
+/**
+ * @brief Get the number of standard (11-bit) filter elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the number of standard (11-bit) filter elements
+ */
+#define CAN_MCAN_DT_MRAM_STD_FILTER_ELEM(node_id) \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 1)
+
+/**
+ * @brief Get the number of extended (29-bit) filter elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the number of extended (29-bit) filter elements
+ */
+#define CAN_MCAN_DT_MRAM_EXT_FILTER_ELEM(node_id) \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 2)
+
+/**
+ * @brief Get the number of Rx FIFO 0 elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the number of Rx FIFO 0 elements
+ */
+#define CAN_MCAN_DT_MRAM_RX_FIFO0_ELEM(node_id) \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 3)
+
+/**
+ * @brief Get the number of Rx FIFO 1 elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the number of Rx FIFO 1 elements
+ */
+#define CAN_MCAN_DT_MRAM_RX_FIFO1_ELEM(node_id) \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 4)
+
+/**
+ * @brief Get the number of Rx Buffer elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the number of Rx Buffer elements
+ */
+#define CAN_MCAN_DT_MRAM_RX_BUFFER_ELEM(node_id) \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 5)
+
+/**
+ * @brief Get the number of Tx Event FIFO elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the number of Tx Event FIFO elements
+ */
+#define CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEM(node_id) \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 6)
+
+/**
+ * @brief Get the number of Tx Buffer elements in Bosch M_CAN Message RAM
+ *
+ * @param node_id node identifier
+ * @return the number of Tx Buffer elements
+ */
+#define CAN_MCAN_DT_MRAM_TX_BUFFER_ELEM(node_id) \
+	DT_PROP_BY_IDX(node_id, bosch_mram_cfg, 7)
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_OFFSET(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the Message RAM offset in bytes
+ * @see CAN_MCAN_DT_MRAM_OFFSET()
+ */
+#define CAN_MCAN_DT_INST_MRAM_OFFSET(inst)			\
+	CAN_MCAN_DT_MRAM_OFFSET(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_STD_FILTER_ELEM(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the number of standard (11-bit) elements
+ * @see CAN_MCAN_DT_MRAM_STD_FILTER_ELEM()
+ */
+#define CAN_MCAN_DT_INST_MRAM_STD_FILTER_ELEM(inst)		\
+	CAN_MCAN_DT_MRAM_STD_FILTER_ELEMDT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_EXT_FILTER_ELEM(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the number of extended (29-bit) elements
+ * @see CAN_MCAN_DT_MRAM_EXT_FILTER_ELEM()
+ */
+#define CAN_MCAN_DT_INST_MRAM_EXT_FILTER_ELEM(inst)		\
+	CAN_MCAN_DT_MRAM_EXT_FILTER_ELEM(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_RX_FIFO0_ELEM(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the number of Rx FIFO 0 elements
+ * @see CAN_MCAN_DT_MRAM_RX_FIFO0_ELEM()
+ */
+#define CAN_MCAN_DT_INST_MRAM_RX_FIFO0_ELEM(inst)		\
+	CAN_MCAN_DT_MRAM_RX_FIFO0_ELEM(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_RX_FIFO1_ELEM(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the number of Rx FIFO 1 elements
+ * @see CAN_MCAN_DT_MRAM_RX_FIFO1_ELEM()
+ */
+#define CAN_MCAN_DT_INST_MRAM_RX_FIFO1_ELEM(inst)		\
+	CAN_MCAN_DT_MRAM_RX_FIFO1_ELEM(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_RX_BUFFER_ELEM(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the number of Rx Buffer elements
+ * @see CAN_MCAN_DT_MRAM_RX_BUFFER_ELEM()
+ */
+#define CAN_MCAN_DT_INST_MRAM_RX_BUFFER_ELEM(inst)		\
+	CAN_MCAN_DT_MRAM_RX_BUFFER_ELEM(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_TX_EVENT_ELEM(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the number of Tx Event FIFO elements
+ * @see CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEM()
+ */
+#define CAN_MCAN_DT_INST_MRAM_TX_EVENT_FIFO_ELEM(inst)		\
+	CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEM(DT_DRV_INST(inst))
+
+/**
+ * @brief Equivalent to CAN_MCAN_DT_MRAM_TX_BUFFER_ELEM(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the number of Tx Buffer elements
+ * @see CAN_MCAN_DT_MRAM_TX_BUFFER_ELEM()
+ */
+#define CAN_MCAN_DT_INST_MRAM_TX_BUFFER_ELEM(inst)		\
+	CAN_MCAN_DT_MRAM_TX_BUFFER_ELEM(DT_DRV_INST(inst))
+
+#define NUM_STD_FILTER_ELEMENTS    CAN_MCAN_DT_MRAM_STD_FILTER_ELEM(MCAN_DT_PATH)
+#define NUM_EXT_FILTER_ELEMENTS    CAN_MCAN_DT_MRAM_EXT_FILTER_ELEM(MCAN_DT_PATH)
+#define NUM_RX_FIFO0_ELEMENTS      CAN_MCAN_DT_MRAM_RX_FIFO0_ELEM(MCAN_DT_PATH)
+#define NUM_RX_FIFO1_ELEMENTS      CAN_MCAN_DT_MRAM_RX_FIFO1_ELEM(MCAN_DT_PATH)
+#define NUM_RX_BUF_ELEMENTS        CAN_MCAN_DT_MRAM_RX_BUFFER_ELEM(MCAN_DT_PATH)
+#define NUM_TX_EVENT_FIFO_ELEMENTS CAN_MCAN_DT_MRAM_TX_EVENT_FIFO_ELEM(MCAN_DT_PATH)
+#define NUM_TX_BUF_ELEMENTS        CAN_MCAN_DT_MRAM_TX_BUFFER_ELEM(MCAN_DT_PATH)
 
 #ifdef CONFIG_CAN_STM32FD
 #define NUM_STD_FILTER_DATA CONFIG_CAN_MAX_STD_ID_FILTER
@@ -408,68 +569,68 @@
 struct can_mcan_rx_fifo_hdr {
 	union {
 		struct {
-			volatile uint32_t ext_id: 29; /* Extended Identifier */
-			volatile uint32_t rtr: 1;     /* Remote Transmission Request*/
-			volatile uint32_t xtd: 1;     /* Extended identifier */
-			volatile uint32_t esi: 1;     /* Error state indicator */
+			uint32_t ext_id: 29; /* Extended Identifier */
+			uint32_t rtr: 1;     /* Remote Transmission Request*/
+			uint32_t xtd: 1;     /* Extended identifier */
+			uint32_t esi: 1;     /* Error state indicator */
 		};
 		struct {
-			volatile uint32_t pad1: 18;
-			volatile uint32_t std_id: 11; /* Standard Identifier */
-			volatile uint32_t pad2: 3;
+			uint32_t pad1: 18;
+			uint32_t std_id: 11; /* Standard Identifier */
+			uint32_t pad2: 3;
 		};
 	};
 
-	volatile uint32_t rxts: 16; /* Rx timestamp */
-	volatile uint32_t dlc: 4;   /* Data Length Code */
-	volatile uint32_t brs: 1;   /* Bit Rate Switch */
-	volatile uint32_t fdf: 1;   /* FD Format */
-	volatile uint32_t res: 2;   /* Reserved */
-	volatile uint32_t fidx: 7;  /* Filter Index */
-	volatile uint32_t anmf: 1;  /* Accepted non-matching frame */
+	uint32_t rxts: 16; /* Rx timestamp */
+	uint32_t dlc: 4;   /* Data Length Code */
+	uint32_t brs: 1;   /* Bit Rate Switch */
+	uint32_t fdf: 1;   /* FD Format */
+	uint32_t res: 2;   /* Reserved */
+	uint32_t fidx: 7;  /* Filter Index */
+	uint32_t anmf: 1;  /* Accepted non-matching frame */
 } __packed __aligned(4);
 
 struct can_mcan_rx_fifo {
 	struct can_mcan_rx_fifo_hdr hdr;
 	union {
-		volatile uint8_t data[64];
-		volatile uint32_t data_32[16];
+		uint8_t data[64];
+		uint32_t data_32[16];
 	};
 } __packed __aligned(4);
 
 struct can_mcan_mm {
-	volatile uint8_t idx: 5;
-	volatile uint8_t cnt: 3;
+	uint8_t idx: 5;
+	uint8_t cnt: 3;
 } __packed;
 
 struct can_mcan_tx_buffer_hdr {
 	union {
 		struct {
-			volatile uint32_t ext_id: 29; /* Identifier */
-			volatile uint32_t rtr: 1;     /* Remote Transmission Request*/
-			volatile uint32_t xtd: 1;     /* Extended identifier */
-			volatile uint32_t esi: 1;     /* Error state indicator */
+			uint32_t ext_id: 29; /* Identifier */
+			uint32_t rtr: 1;     /* Remote Transmission Request*/
+			uint32_t xtd: 1;     /* Extended identifier */
+			uint32_t esi: 1;     /* Error state indicator */
 		};
 		struct {
-			volatile uint32_t pad1: 18;
-			volatile uint32_t std_id: 11; /* Identifier */
-			volatile uint32_t pad2: 3;
+			uint32_t pad1: 18;
+			uint32_t std_id: 11; /* Identifier */
+			uint32_t pad2: 3;
 		};
 	};
-	volatile uint16_t res1;	  /* Reserved */
-	volatile uint8_t dlc: 4;  /* Data Length Code */
-	volatile uint8_t brs: 1;  /* Bit Rate Switch */
-	volatile uint8_t fdf: 1;  /* FD Format */
-	volatile uint8_t res2: 1; /* Reserved */
-	volatile uint8_t efc: 1;  /* Event FIFO control (Store Tx events) */
+	uint16_t res1;   /* Reserved */
+	uint8_t dlc: 4;  /* Data Length Code */
+	uint8_t brs: 1;  /* Bit Rate Switch */
+	uint8_t fdf: 1;  /* FD Format */
+	uint8_t res2: 1; /* Reserved */
+	uint8_t efc: 1;  /* Event FIFO control (Store Tx events) */
 	struct can_mcan_mm mm;	  /* Message marker */
 } __packed __aligned(4);
 
 struct can_mcan_tx_buffer {
 	struct can_mcan_tx_buffer_hdr hdr;
 	union {
-		volatile uint8_t data[64];
-		volatile uint32_t data_32[16];
+		uint8_t data[64];
+		uint32_t data_32[16];
 	};
 } __packed __aligned(4);
 
@@ -477,16 +638,16 @@ struct can_mcan_tx_buffer {
 #define CAN_MCAN_TE_TXC 0x2 /* TX event in spite of cancellation */
 
 struct can_mcan_tx_event_fifo {
-	volatile uint32_t id: 29; /* Identifier */
-	volatile uint32_t rtr: 1; /* Remote Transmission Request*/
-	volatile uint32_t xtd: 1; /* Extended identifier */
-	volatile uint32_t esi: 1; /* Error state indicator */
+	uint32_t id: 29; /* Identifier */
+	uint32_t rtr: 1; /* Remote Transmission Request*/
+	uint32_t xtd: 1; /* Extended identifier */
+	uint32_t esi: 1; /* Error state indicator */
 
-	volatile uint16_t txts;	 /* TX Timestamp */
-	volatile uint8_t dlc: 4; /* Data Length Code */
-	volatile uint8_t brs: 1; /* Bit Rate Switch */
-	volatile uint8_t fdf: 1; /* FD Format */
-	volatile uint8_t et: 2;	 /* Event type */
+	uint16_t txts;  /* TX Timestamp */
+	uint8_t dlc: 4; /* Data Length Code */
+	uint8_t brs: 1; /* Bit Rate Switch */
+	uint8_t fdf: 1; /* FD Format */
+	uint8_t et: 2;	/* Event type */
 	struct can_mcan_mm mm;	 /* Message marker */
 } __packed __aligned(4);
 
@@ -504,11 +665,11 @@ struct can_mcan_tx_event_fifo {
 #define CAN_MCAN_SFT_DISABLED 0x3
 
 struct can_mcan_std_filter {
-	volatile uint32_t id2: 11; /* ID2 for dual or range, mask otherwise */
-	volatile uint32_t res: 5;
-	volatile uint32_t id1: 11;
-	volatile uint32_t sfce: 3; /* Filter config */
-	volatile uint32_t sft: 2;  /* Filter type */
+	uint32_t id2: 11; /* ID2 for dual or range, mask otherwise */
+	uint32_t res: 5;
+	uint32_t id1: 11;
+	uint32_t sfce: 3; /* Filter config */
+	uint32_t sft: 2;  /* Filter type */
 } __packed __aligned(4);
 
 #define CAN_MCAN_EFT_RANGE_XIDAM 0x0
@@ -517,25 +678,32 @@ struct can_mcan_std_filter {
 #define CAN_MCAN_EFT_RANGE	 0x3
 
 struct can_mcan_ext_filter {
-	volatile uint32_t id1: 29;
-	volatile uint32_t efce: 3; /* Filter config */
-	volatile uint32_t id2: 29; /* ID2 for dual or range, mask otherwise */
-	volatile uint32_t res: 1;
-	volatile uint32_t eft: 2; /* Filter type */
+	uint32_t id1: 29;
+	uint32_t efce: 3; /* Filter config */
+	uint32_t id2: 29; /* ID2 for dual or range, mask otherwise */
+	uint32_t res: 1;
+	uint32_t eft: 2; /* Filter type */
 } __packed __aligned(4);
 
 struct can_mcan_msg_sram {
-	volatile struct can_mcan_std_filter std_filt[NUM_STD_FILTER_ELEMENTS];
-	volatile struct can_mcan_ext_filter ext_filt[NUM_EXT_FILTER_ELEMENTS];
-	volatile struct can_mcan_rx_fifo rx_fifo0[NUM_RX_FIFO0_ELEMENTS];
-	volatile struct can_mcan_rx_fifo rx_fifo1[NUM_RX_FIFO1_ELEMENTS];
-	volatile struct can_mcan_rx_fifo rx_buffer[NUM_RX_BUF_ELEMENTS];
-	volatile struct can_mcan_tx_event_fifo tx_event_fifo[NUM_TX_EVENT_FIFO_ELEMENTS];
-	volatile struct can_mcan_tx_buffer tx_buffer[NUM_TX_BUF_ELEMENTS];
+	struct can_mcan_std_filter std_filt[NUM_STD_FILTER_ELEMENTS];
+	struct can_mcan_ext_filter ext_filt[NUM_EXT_FILTER_ELEMENTS];
+	struct can_mcan_rx_fifo rx_fifo0[NUM_RX_FIFO0_ELEMENTS];
+	struct can_mcan_rx_fifo rx_fifo1[NUM_RX_FIFO1_ELEMENTS];
+	struct can_mcan_rx_fifo rx_buffer[NUM_RX_BUF_ELEMENTS];
+	struct can_mcan_tx_event_fifo tx_event_fifo[NUM_TX_EVENT_FIFO_ELEMENTS];
+	struct can_mcan_tx_buffer tx_buffer[NUM_TX_BUF_ELEMENTS];
 } __packed __aligned(4);
 
+#define CAN_MCAN_MRAM_OFFSET_STD_FILTER offsetof(struct can_mcan_msg_sram, std_filt)
+#define CAN_MCAN_MRAM_OFFSET_EXT_FILTER offsetof(struct can_mcan_msg_sram, ext_filt)
+#define CAN_MCAN_MRAM_OFFSET_RX_FIFO0 offsetof(struct can_mcan_msg_sram, rx_fifo0)
+#define CAN_MCAN_MRAM_OFFSET_RX_FIFO1 offsetof(struct can_mcan_msg_sram, rx_fifo1)
+#define CAN_MCAN_MRAM_OFFSET_RX_BUFFER offsetof(struct can_mcan_msg_sram, rx_buffer)
+#define CAN_MCAN_MRAM_OFFSET_TX_EVENT_FIFO offsetof(struct can_mcan_msg_sram, tx_event_fifo)
+#define CAN_MCAN_MRAM_OFFSET_TX_BUFFER offsetof(struct can_mcan_msg_sram, tx_buffer)
+
 struct can_mcan_data {
-	struct can_mcan_msg_sram *msg_ram;
 	struct k_mutex lock;
 	struct k_sem tx_sem;
 	struct k_mutex tx_mtx;
@@ -587,16 +755,71 @@ typedef int (*can_mcan_read_reg_t)(const struct device *dev, uint16_t reg, uint3
  */
 typedef int (*can_mcan_write_reg_t)(const struct device *dev, uint16_t reg, uint32_t val);
 
-struct can_mcan_config {
+/**
+ * @brief Bosch M_CAN driver front-end callback for reading from Message RAM
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param offset Offset from the start of the Message RAM for the given Bosch M_CAN instance. The
+ *        offset must be 32-bit aligned.
+ * @param[out] dst Destination for the data read. The destination address must be 32-bit aligned.
+ * @param len Number of bytes to read. Must be a multiple of 4.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error.
+ */
+typedef int (*can_mcan_read_mram_t)(const struct device *dev, uint16_t offset, void *dst,
+				    size_t len);
+
+/**
+ * @brief Bosch M_CAN driver front-end callback for writing to Message RAM
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param offset Offset from the start of the Message RAM for the given Bosch M_CAN instance. The
+ *        offset must be 32-bit aligned.
+ * @param src Source for the data to be written. The source address must be 32-bit aligned.
+ * @param len Number of bytes to write. Must be a multiple of 4.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error.
+ */
+typedef int (*can_mcan_write_mram_t)(const struct device *dev, uint16_t offset, const void *src,
+				     size_t len);
+
+/**
+ * @brief Bosch M_CAN driver front-end callback for clearing Message RAM
+ *
+ * Clear Message RAM by writing 0 to all words.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param offset Offset from the start of the Message RAM for the given Bosch M_CAN instance. The
+ *        offset must be 32-bit aligned.
+ * @param len Number of bytes to clear. Must be a multiple of 4.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error.
+ */
+typedef int (*can_mcan_clear_mram_t)(const struct device *dev, uint16_t offset, size_t len);
+
+/**
+ * @brief Bosch M_CAN driver front-end operations.
+ */
+struct can_mcan_ops {
 	can_mcan_read_reg_t read_reg;
 	can_mcan_write_reg_t write_reg;
+	can_mcan_read_mram_t read_mram;
+	can_mcan_write_mram_t write_mram;
+	can_mcan_clear_mram_t clear_mram;
+};
+
+struct can_mcan_config {
+	struct can_mcan_ops *ops;
 	uint32_t bus_speed;
-	uint32_t bus_speed_data;
 	uint16_t sjw;
 	uint16_t sample_point;
 	uint16_t prop_ts1;
 	uint16_t ts2;
 #ifdef CONFIG_CAN_FD_MODE
+	uint32_t bus_speed_data;
 	uint16_t sample_point_data;
 	uint8_t sjw_data;
 	uint8_t prop_ts1_data;
@@ -613,14 +836,14 @@ struct can_mcan_config {
  *
  * @param node_id Devicetree node identifier
  * @param _custom Pointer to custom driver frontend configuration structure
- * @param _read_reg Driver frontend Bosch M_CAN register read function
- * @param _write_reg Driver frontend Bosch M_CAN register write function
+ * @param _ops Pointer to front-end @a can_mcan_ops
  */
 #ifdef CONFIG_CAN_FD_MODE
-#define CAN_MCAN_DT_CONFIG_GET(node_id, _custom, _read_reg, _write_reg)                            \
+#define CAN_MCAN_DT_CONFIG_GET(node_id, _custom, _ops)                                             \
 	{                                                                                          \
-		.read_reg = _read_reg, .write_reg = _write_reg,                                    \
-		.bus_speed = DT_PROP(node_id, bus_speed), .sjw = DT_PROP(node_id, sjw),            \
+		.ops = _ops,                                                                       \
+		.bus_speed = DT_PROP(node_id, bus_speed),                                          \
+		.sjw = DT_PROP(node_id, sjw),                                                      \
 		.sample_point = DT_PROP_OR(node_id, sample_point, 0),                              \
 		.prop_ts1 = DT_PROP_OR(node_id, prop_seg, 0) + DT_PROP_OR(node_id, phase_seg1, 0), \
 		.ts2 = DT_PROP_OR(node_id, phase_seg2, 0),                                         \
@@ -636,10 +859,11 @@ struct can_mcan_config {
 		.custom = _custom,                                                                 \
 	}
 #else /* CONFIG_CAN_FD_MODE */
-#define CAN_MCAN_DT_CONFIG_GET(node_id, _custom, _read_reg, _write_reg)                            \
+#define CAN_MCAN_DT_CONFIG_GET(node_id, _custom, _ops)                                             \
 	{                                                                                          \
-		.read_reg = _read_reg, .write_reg = _write_reg,                                    \
-		.bus_speed = DT_PROP(node_id, bus_speed), .sjw = DT_PROP(node_id, sjw),            \
+		.ops = _ops,                                                                       \
+		.bus_speed = DT_PROP(node_id, bus_speed),                                          \
+		.sjw = DT_PROP(node_id, sjw),                                                      \
 		.sample_point = DT_PROP_OR(node_id, sample_point, 0),                              \
 		.prop_ts1 = DT_PROP_OR(node_id, prop_seg, 0) + DT_PROP_OR(node_id, phase_seg1, 0), \
 		.ts2 = DT_PROP_OR(node_id, phase_seg2, 0),                                         \
@@ -654,21 +878,20 @@ struct can_mcan_config {
  *
  * @param inst DT_DRV_COMPAT instance number
  * @param _custom Pointer to custom driver frontend configuration structure
- * @param _read_reg Driver frontend Bosch M_CAN register read function
- * @param _write_reg Driver frontend Bosch M_CAN register write function
+ * @param _ops Pointer to front-end @a can_mcan_ops
  * @see CAN_MCAN_DT_CONFIG_GET()
  */
-#define CAN_MCAN_DT_CONFIG_INST_GET(inst, _custom, _read_reg, _write_reg)                          \
-	CAN_MCAN_DT_CONFIG_GET(DT_DRV_INST(inst), _custom, _read_reg, _write_reg)
+#define CAN_MCAN_DT_CONFIG_INST_GET(inst, _custom, _ops)                                           \
+	CAN_MCAN_DT_CONFIG_GET(DT_DRV_INST(inst), _custom, _ops)
 
 /**
  * @brief Initializer for a @a can_mcan_data struct
  * @param _msg_ram Pointer to message RAM structure
  * @param _custom Pointer to custom driver frontend data structure
  */
-#define CAN_MCAN_DATA_INITIALIZER(_msg_ram, _custom)                                               \
+#define CAN_MCAN_DATA_INITIALIZER(_custom)                                                         \
 	{                                                                                          \
-		.msg_ram = _msg_ram, .custom = _custom,                                            \
+		.custom = _custom,                                                                 \
 	}
 
 /**
@@ -704,6 +927,116 @@ static inline int can_mcan_sys_write_reg(mm_reg_t base, uint16_t reg, uint32_t v
 }
 
 /**
+ * @brief Bosch M_CAN driver front-end callback helper for reading from memory mapped Message RAM
+ *
+ * @param base Base address of the Message RAM for the given Bosch M_CAN instance. The base address
+ *        must be 32-bit aligned.
+ * @param offset Offset from the start of the Message RAM for the given Bosch M_CAN instance. The
+ *        offset must be 32-bit aligned.
+ * @param[out] dst Destination for the data read. The destination address must be 32-bit aligned.
+ * @param len Number of bytes to read. Must be a multiple of 4.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error.
+ */
+static inline int can_mcan_sys_read_mram(mem_addr_t base, uint16_t offset, void *dst, size_t len)
+{
+	volatile uint32_t *src32 = (volatile uint32_t *)(base + offset);
+	uint32_t *dst32 = (uint32_t *)dst;
+	size_t len32 = len / sizeof(uint32_t);
+
+	__ASSERT(base % 4U == 0U, "base must be a multiple of 4");
+	__ASSERT(offset % 4U == 0U, "offset must be a multiple of 4");
+	__ASSERT(POINTER_TO_UINT(dst) % 4U == 0U, "dst must be 32-bit aligned");
+	__ASSERT(len % 4U == 0U, "len must be a multiple of 4");
+
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	int err;
+
+	err = sys_cache_data_invd_range((void *)(base + offset), len);
+	if (err != 0) {
+		return err;
+	}
+#endif /* !defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE) */
+
+	while (len32-- > 0) {
+		*dst32++ = *src32++;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Bosch M_CAN driver front-end callback helper for writing to memory mapped Message RAM
+ *
+ * @param base Base address of the Message RAM for the given Bosch M_CAN instance. The base address
+ *        must be 32-bit aligned.
+ * @param offset Offset from the start of the Message RAM for the given Bosch M_CAN instance. The
+ *        offset must be 32-bit aligned.
+ * @param src Source for the data to be written. The source address must be 32-bit aligned.
+ * @param len Number of bytes to write. Must be a multiple of 4.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error.
+ */
+static inline int can_mcan_sys_write_mram(mem_addr_t base, uint16_t offset, const void *src,
+					  size_t len)
+{
+	volatile uint32_t *dst32 = (volatile uint32_t *)(base + offset);
+	const uint32_t *src32 = (const uint32_t *)src;
+	size_t len32 = len / sizeof(uint32_t);
+
+	__ASSERT(base % 4U == 0U, "base must be a multiple of 4");
+	__ASSERT(offset % 4U == 0U, "offset must be a multiple of 4");
+	__ASSERT(POINTER_TO_UINT(src) % 4U == 0U, "src must be 32-bit aligned");
+	__ASSERT(len % 4U == 0U, "len must be a multiple of 4");
+
+	while (len32-- > 0) {
+		*dst32++ = *src32++;
+	}
+
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	return sys_cache_data_flush_range((void *)(base + offset), len);
+#else /* defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE) */
+	return 0;
+#endif /* !defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE) */
+}
+
+/**
+ * @brief Bosch M_CAN driver front-end callback helper for clearing memory mapped Message RAM
+ *
+ * Clear Message RAM by writing 0 to all words.
+ *
+ * @param base Base address of the Message RAM for the given Bosch M_CAN instance. The base address
+ *        must be 32-bit aligned.
+ * @param offset Offset from the start of the Message RAM for the given Bosch M_CAN instance. The
+ *        offset must be 32-bit aligned.
+ * @param len Number of bytes to clear. Must be a multiple of 4.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error.
+ */
+static inline int can_mcan_sys_clear_mram(mem_addr_t base, uint16_t offset, size_t len)
+{
+	volatile uint32_t *dst32 = (volatile uint32_t *)(base + offset);
+	size_t len32 = len / sizeof(uint32_t);
+
+	__ASSERT(base % 4U == 0U, "base must be a multiple of 4");
+	__ASSERT(offset % 4U == 0U, "offset must be a multiple of 4");
+	__ASSERT(len % 4U == 0U, "len must be a multiple of 4");
+
+	while (len32-- > 0) {
+		*dst32++ = 0U;
+	}
+
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	return sys_cache_data_flush_range((void *)(base + offset), len);
+#else /* defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE) */
+	return 0;
+#endif /* !defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE) */
+}
+
+/**
  * @brief Read a Bosch M_CAN register
  *
  * @param dev Pointer to the device structure for the driver instance.
@@ -730,6 +1063,66 @@ int can_mcan_read_reg(const struct device *dev, uint16_t reg, uint32_t *val);
 int can_mcan_write_reg(const struct device *dev, uint16_t reg, uint32_t val);
 
 /**
+ * @brief Read from Bosch M_CAN Message RAM
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param offset Offset from the start of the Message RAM for the given Bosch M_CAN instance. The
+ *        offset must be 32-bit aligned.
+ * @param[out] dst Destination for the data read.
+ * @param len Number of bytes to read. Must be a multiple of 4.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error.
+ */
+static inline int can_mcan_read_mram(const struct device *dev, uint16_t offset, void *dst,
+				     size_t len)
+{
+	const struct can_mcan_config *config = dev->config;
+
+	return config->ops->read_mram(dev, offset, dst, len);
+}
+
+/**
+ * @brief Write to Bosch M_CAN Message RAM
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param offset Offset from the start of the Message RAM for the given Bosch M_CAN instance. The
+ *        offset must be 32-bit aligned.
+ * @param src Source for the data to be written
+ * @param len Number of bytes to write. Must be a multiple of 4.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error.
+ */
+static inline int can_mcan_write_mram(const struct device *dev, uint16_t offset, const void *src,
+				      size_t len)
+{
+	const struct can_mcan_config *config = dev->config;
+
+	return config->ops->write_mram(dev, offset, src, len);
+}
+
+/**
+ * @brief Clear Bosch M_CAN Message RAM
+ *
+ * Clear Message RAM by writing 0 to all words.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param offset Offset from the start of the Message RAM for the given Bosch M_CAN instance. The
+ *        offset must be 32-bit aligned.
+ * @param len Number of bytes to clear. Must be a multiple of 4.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General input/output error.
+ */
+static inline int can_mcan_clear_mram(const struct device *dev, uint16_t offset, size_t len)
+{
+	const struct can_mcan_config *config = dev->config;
+
+	return config->ops->clear_mram(dev, offset, len);
+}
+
+/**
  * @brief Configure Bosch M_MCAN Message RAM start addresses.
  *
  * Bosch M_CAN driver front-end callback helper function for configuring the start addresses of the
@@ -746,11 +1139,12 @@ int can_mcan_write_reg(const struct device *dev, uint16_t reg, uint32_t val);
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param mrba Message RAM Base Address.
+ * @param mram Message RAM Address.
  *
  * @retval 0 If successful.
  * @retval -EIO General input/output error.
  */
-int can_mcan_configure_message_ram(const struct device *dev, uintptr_t mrba);
+int can_mcan_configure_mram(const struct device *dev, uintptr_t mrba, uintptr_t mram);
 
 int can_mcan_get_capabilities(const struct device *dev, can_mode_t *cap);
 

--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -21,16 +21,13 @@ LOG_MODULE_REGISTER(can_sam0, CONFIG_CAN_LOG_LEVEL);
 
 struct can_sam0_config {
 	mm_reg_t base;
+	mem_addr_t mram;
 	void (*config_irq)(void);
 	const struct pinctrl_dev_config *pcfg;
 	volatile uint32_t *mclk;
 	uint32_t mclk_mask;
 	uint16_t gclk_core_id;
 	int divider;
-};
-
-struct can_sam0_data {
-	struct can_mcan_msg_sram msg_ram;
 };
 
 static int can_sam0_read_reg(const struct device *dev, uint16_t reg, uint32_t *val)
@@ -67,27 +64,27 @@ static int can_sam0_write_reg(const struct device *dev, uint16_t reg, uint32_t v
 
 static int can_sam0_read_mram(const struct device *dev, uint16_t offset, void *dst, size_t len)
 {
-	struct can_mcan_data *mcan_data = dev->data;
-	struct can_sam0_data *sam_data = mcan_data->custom;
+	const struct can_mcan_config *mcan_config = dev->config;
+	const struct can_sam0_config *sam_config = mcan_config->custom;
 
-	return can_mcan_sys_read_mram(POINTER_TO_UINT(&sam_data->msg_ram), offset, dst, len);
+	return can_mcan_sys_read_mram(sam_config->mram, offset, dst, len);
 }
 
 static int can_sam0_write_mram(const struct device *dev, uint16_t offset, const void *src,
 				size_t len)
 {
-	struct can_mcan_data *mcan_data = dev->data;
-	struct can_sam0_data *sam_data = mcan_data->custom;
+	const struct can_mcan_config *mcan_config = dev->config;
+	const struct can_sam0_config *sam_config = mcan_config->custom;
 
-	return can_mcan_sys_write_mram(POINTER_TO_UINT(&sam_data->msg_ram), offset, src, len);
+	return can_mcan_sys_write_mram(sam_config->mram, offset, src, len);
 }
 
 static int can_sam0_clear_mram(const struct device *dev, uint16_t offset, size_t len)
 {
-	struct can_mcan_data *mcan_data = dev->data;
-	struct can_sam0_data *sam_data = mcan_data->custom;
+	const struct can_mcan_config *mcan_config = dev->config;
+	const struct can_sam0_config *sam_config = mcan_config->custom;
 
-	return can_mcan_sys_clear_mram(POINTER_TO_UINT(&sam_data->msg_ram), offset, len);
+	return can_mcan_sys_clear_mram(sam_config->mram, offset, len);
 }
 
 void can_sam0_line_x_isr(const struct device *dev)
@@ -125,8 +122,6 @@ static int can_sam0_init(const struct device *dev)
 {
 	const struct can_mcan_config *mcan_cfg = dev->config;
 	const struct can_sam0_config *sam_cfg = mcan_cfg->custom;
-	struct can_mcan_data *mcan_data = dev->data;
-	struct can_sam0_data *sam_data = mcan_data->custom;
 	int ret;
 
 	can_sam0_clock_enable(sam_cfg);
@@ -137,7 +132,7 @@ static int can_sam0_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = can_mcan_configure_mram(dev, 0U, POINTER_TO_UINT(&sam_data->msg_ram));
+	ret = can_mcan_configure_mram(dev, 0U, sam_cfg->mram);
 	if (ret != 0) {
 		LOG_ERR("failed to configure message ram");
 		return ret;
@@ -223,8 +218,12 @@ static void config_can_##inst##_irq(void)						\
 }
 
 #define CAN_SAM0_CFG_INST(inst)								\
+	CAN_MCAN_DT_INST_CALLBACKS_DEFINE(inst, can_sam0_cbs_##inst);			\
+	CAN_MCAN_DT_INST_MRAM_DEFINE(inst, can_sam0_mram_##inst);			\
+											\
 	static const struct can_sam0_config can_sam0_cfg_##inst = {			\
-		.base = (mm_reg_t)DT_INST_REG_ADDR(inst),				\
+		.base = CAN_MCAN_DT_INST_MCAN_ADDR(inst),				\
+		.mram = (mem_addr_t)POINTER_TO_UINT(&can_sam0_mram_##inst),		\
 		.mclk = (volatile uint32_t *)MCLK_MASK_DT_INT_REG_ADDR(inst),		\
 		.mclk_mask = BIT(DT_INST_CLOCKS_CELL_BY_NAME(inst, mclk, bit)),		\
 		.gclk_core_id = DT_INST_CLOCKS_CELL_BY_NAME(inst, gclk, periph_ch),	\
@@ -234,13 +233,12 @@ static void config_can_##inst##_irq(void)						\
 	};										\
 											\
 	static const struct can_mcan_config can_mcan_cfg_##inst =			\
-		CAN_MCAN_DT_CONFIG_INST_GET(inst, &can_sam0_cfg_##inst, &can_sam0_ops);
+		CAN_MCAN_DT_CONFIG_INST_GET(inst, &can_sam0_cfg_##inst, &can_sam0_ops,  \
+					    &can_sam0_cbs_##inst);
 
 #define CAN_SAM0_DATA_INST(inst)							\
-	static struct can_sam0_data can_sam0_data_##inst;				\
-											\
 	static struct can_mcan_data can_mcan_data_##inst =				\
-		CAN_MCAN_DATA_INITIALIZER(&can_sam0_data_##inst);
+		CAN_MCAN_DATA_INITIALIZER(NULL);
 
 #define CAN_SAM0_DEVICE_INST(inst)							\
 	DEVICE_DT_INST_DEFINE(inst, &can_sam0_init, NULL,				\
@@ -250,6 +248,7 @@ static void config_can_##inst##_irq(void)						\
 			      &can_sam0_driver_api);
 
 #define CAN_SAM0_INST(inst)								\
+	CAN_MCAN_DT_INST_BUILD_ASSERT_MRAM_CFG(inst);					\
 	PINCTRL_DT_INST_DEFINE(inst);							\
 	CAN_SAM0_IRQ_CFG_FUNCTION(inst)							\
 	CAN_SAM0_CFG_INST(inst)								\

--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -65,6 +65,31 @@ static int can_sam0_write_reg(const struct device *dev, uint16_t reg, uint32_t v
 	return can_mcan_sys_write_reg(sam_config->base, reg, val);
 }
 
+static int can_sam0_read_mram(const struct device *dev, uint16_t offset, void *dst, size_t len)
+{
+	struct can_mcan_data *mcan_data = dev->data;
+	struct can_sam0_data *sam_data = mcan_data->custom;
+
+	return can_mcan_sys_read_mram(POINTER_TO_UINT(&sam_data->msg_ram), offset, dst, len);
+}
+
+static int can_sam0_write_mram(const struct device *dev, uint16_t offset, const void *src,
+				size_t len)
+{
+	struct can_mcan_data *mcan_data = dev->data;
+	struct can_sam0_data *sam_data = mcan_data->custom;
+
+	return can_mcan_sys_write_mram(POINTER_TO_UINT(&sam_data->msg_ram), offset, src, len);
+}
+
+static int can_sam0_clear_mram(const struct device *dev, uint16_t offset, size_t len)
+{
+	struct can_mcan_data *mcan_data = dev->data;
+	struct can_sam0_data *sam_data = mcan_data->custom;
+
+	return can_mcan_sys_clear_mram(POINTER_TO_UINT(&sam_data->msg_ram), offset, len);
+}
+
 void can_sam0_line_x_isr(const struct device *dev)
 {
 	can_mcan_line_0_isr(dev);
@@ -100,6 +125,8 @@ static int can_sam0_init(const struct device *dev)
 {
 	const struct can_mcan_config *mcan_cfg = dev->config;
 	const struct can_sam0_config *sam_cfg = mcan_cfg->custom;
+	struct can_mcan_data *mcan_data = dev->data;
+	struct can_sam0_data *sam_data = mcan_data->custom;
 	int ret;
 
 	can_sam0_clock_enable(sam_cfg);
@@ -110,7 +137,7 @@ static int can_sam0_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = can_mcan_configure_message_ram(dev, 0U);
+	ret = can_mcan_configure_mram(dev, 0U, POINTER_TO_UINT(&sam_data->msg_ram));
 	if (ret != 0) {
 		LOG_ERR("failed to configure message ram");
 		return ret;
@@ -177,6 +204,14 @@ static const struct can_driver_api can_sam0_driver_api = {
 #endif /* CONFIG_CAN_FD_MODE */
 };
 
+static const struct can_mcan_ops can_sam0_ops = {
+	.read_reg = can_sam0_read_reg,
+	.write_reg = can_sam0_write_reg,
+	.read_mram = can_sam0_read_mram,
+	.write_mram = can_sam0_write_mram,
+	.clear_mram = can_sam0_clear_mram,
+};
+
 #define CAN_SAM0_IRQ_CFG_FUNCTION(inst)							\
 static void config_can_##inst##_irq(void)						\
 {											\
@@ -199,16 +234,13 @@ static void config_can_##inst##_irq(void)						\
 	};										\
 											\
 	static const struct can_mcan_config can_mcan_cfg_##inst =			\
-		CAN_MCAN_DT_CONFIG_INST_GET(inst, &can_sam0_cfg_##inst,			\
-					    can_sam0_read_reg,				\
-					    can_sam0_write_reg);
+		CAN_MCAN_DT_CONFIG_INST_GET(inst, &can_sam0_cfg_##inst, &can_sam0_ops);
 
 #define CAN_SAM0_DATA_INST(inst)							\
 	static struct can_sam0_data can_sam0_data_##inst;				\
 											\
 	static struct can_mcan_data can_mcan_data_##inst =				\
-		CAN_MCAN_DATA_INITIALIZER(&can_sam0_data_##inst.msg_ram,		\
-					  &can_sam0_data_##inst);			\
+		CAN_MCAN_DATA_INITIALIZER(&can_sam0_data_##inst);
 
 #define CAN_SAM0_DEVICE_INST(inst)							\
 	DEVICE_DT_INST_DEFINE(inst, &can_sam0_init, NULL,				\

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -635,9 +635,9 @@ static const struct can_mcan_ops can_stm32fd_ops = {
 	.clear_mram = can_stm32fd_clear_mram,
 };
 
-/* Assert that the Message RAM configuration meets the hardware limitiations */
-BUILD_ASSERT(NUM_STD_FILTER_ELEMENTS <= 28, "Standard filter elements must be 28");
-BUILD_ASSERT(NUM_EXT_FILTER_ELEMENTS <= 8, "Extended filter elements must be 8");
+/* Assert that the Message RAM configuration matches the fixed hardware configuration */
+BUILD_ASSERT(NUM_STD_FILTER_ELEMENTS == 28, "Standard filter elements must be 28");
+BUILD_ASSERT(NUM_EXT_FILTER_ELEMENTS == 8, "Extended filter elements must be 8");
 BUILD_ASSERT(NUM_RX_FIFO0_ELEMENTS == 3, "Rx FIFO 0 elements must be 3");
 BUILD_ASSERT(NUM_RX_FIFO1_ELEMENTS == 3, "Rx FIFO 1 elements must be 3");
 BUILD_ASSERT(NUM_RX_BUF_ELEMENTS == 0, "Rx Buffer elements must be 0");

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -215,13 +215,19 @@ static const struct can_mcan_ops can_stm32h7_ops = {
 };
 
 #define CAN_STM32H7_MCAN_INIT(n)					    \
+	CAN_MCAN_DT_INST_BUILD_ASSERT_MRAM_CFG(n);			    \
+	BUILD_ASSERT(CAN_MCAN_DT_INST_MRAM_ELEMENTS_SIZE(n) <=		    \
+		     CAN_MCAN_DT_INST_MRAM_SIZE(n),			    \
+		     "Insufficient Message RAM size to hold elements");	    \
+									    \
 	static void stm32h7_mcan_irq_config_##n(void);			    \
 									    \
 	PINCTRL_DT_INST_DEFINE(n);					    \
+	CAN_MCAN_DT_INST_CALLBACKS_DEFINE(n, can_stm32h7_cbs_##n);	    \
 									    \
 	static const struct can_stm32h7_config can_stm32h7_cfg_##n = {	    \
-		.base = (mm_reg_t)DT_INST_REG_ADDR_BY_NAME(n, m_can),       \
-		.mram = (mem_addr_t)DT_INST_REG_ADDR_BY_NAME(n, message_ram), \
+		.base = CAN_MCAN_DT_INST_MCAN_ADDR(n),			    \
+		.mram = CAN_MCAN_DT_INST_MRAM_ADDR(n),			    \
 		.config_irq = stm32h7_mcan_irq_config_##n,		    \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		    \
 		.pclken = {						    \
@@ -232,7 +238,8 @@ static const struct can_mcan_ops can_stm32h7_ops = {
 									    \
 	static const struct can_mcan_config can_mcan_cfg_##n =		    \
 		CAN_MCAN_DT_CONFIG_INST_GET(n, &can_stm32h7_cfg_##n,	    \
-					    &can_stm32h7_ops);		    \
+					    &can_stm32h7_ops,		    \
+					    &can_stm32h7_cbs_##n);	    \
 									    \
 	static struct can_mcan_data can_mcan_data_##n =			    \
 		CAN_MCAN_DATA_INITIALIZER(NULL);			    \

--- a/dts/arm/atmel/samc21.dtsi
+++ b/dts/arm/atmel/samc21.dtsi
@@ -44,41 +44,36 @@
 			status = "disabled";
 		};
 
-		can {
-			compatible = "bosch,m_can-base";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		can0: can@42001c00 {
+			compatible = "atmel,sam0-can";
+			reg = <0x42001c00 0x100>;
+			interrupts = <15 0>;
+			interrupt-names = "LINE_0";
+			clocks = <&gclk 26>, <&mclk 0x10 8>;
+			clock-names = "GCLK", "MCLK";
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
+			divider = <12>;
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
+		};
 
-			can0: can@42001c00 {
-				compatible = "atmel,sam0-can";
-				reg = <0x42001c00 0x100>;
-				interrupts = <15 0>;
-				interrupt-names = "LINE_0";
-				clocks = <&gclk 26>, <&mclk 0x10 8>;
-				clock-names = "GCLK", "MCLK";
-				divider = <12>;
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-				status = "disabled";
-			};
-
-			can1: can@42002000 {
-				compatible = "atmel,sam0-can";
-				reg = <0x42002000 0x100>;
-				interrupts = <16 0>;
-				interrupt-names = "LINE_0";
-				clocks = <&gclk 27>, <&mclk 0x10 9>;
-				clock-names = "GCLK", "MCLK";
-				divider = <12>;
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-				status = "disabled";
-			};
+		can1: can@42002000 {
+			compatible = "atmel,sam0-can";
+			reg = <0x42002000 0x100>;
+			interrupts = <16 0>;
+			interrupt-names = "LINE_0";
+			clocks = <&gclk 27>, <&mclk 0x10 9>;
+			clock-names = "GCLK", "MCLK";
+			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
+			divider = <12>;
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
 		};
 	};
 };

--- a/dts/arm/atmel/samc21.dtsi
+++ b/dts/arm/atmel/samc21.dtsi
@@ -48,12 +48,7 @@
 			compatible = "bosch,m_can-base";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			std-filter-elements = <28>;
-			ext-filter-elements = <8>;
-			rx-fifo0-elements = <3>;
-			rx-fifo1-elements = <3>;
-			rx-buffer-elements = <0>;
-			tx-buffer-elements = <1>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
 
 			can0: can@42001c00 {
 				compatible = "atmel,sam0-can";

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -408,39 +408,34 @@
 			status = "disabled";
 		};
 
-		can {
-			compatible = "bosch,m_can-base";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		can0: can@40030000 {
+			compatible = "atmel,sam-can";
+			reg = <0x40030000 0x100>;
+			interrupts = <35 0>, <36 0>;
+			interrupt-names = "LINE_0", "LINE_1";
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 35>;
+			divider = <6>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
+		};
 
-			can0: can@40030000 {
-				compatible = "atmel,sam-can";
-				reg = <0x40030000 0x100>;
-				interrupts = <35 0>, <36 0>;
-				interrupt-names = "LINE_0", "LINE_1";
-				clocks = <&pmc PMC_TYPE_PERIPHERAL 35>;
-				divider = <6>;
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-				status = "disabled";
-			};
-
-			can1: can@40034000 {
-				compatible = "atmel,sam-can";
-				reg = <0x40034000 0x100>;
-				interrupts = <37 0>, <38 0>;
-				interrupt-names = "LINE_0", "LINE_1";
-				clocks = <&pmc PMC_TYPE_PERIPHERAL 37>;
-				divider = <6>;
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-				status = "disabled";
-			};
+		can1: can@40034000 {
+			compatible = "atmel,sam-can";
+			reg = <0x40034000 0x100>;
+			interrupts = <37 0>, <38 0>;
+			interrupt-names = "LINE_0", "LINE_1";
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 37>;
+			divider = <6>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
 		};
 
 		rstc: rstc@400e1800 {

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -412,12 +412,7 @@
 			compatible = "bosch,m_can-base";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			std-filter-elements = <28>;
-			ext-filter-elements = <8>;
-			rx-fifo0-elements = <3>;
-			rx-fifo1-elements = <3>;
-			rx-buffer-elements = <0>;
-			tx-buffer-elements = <1>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
 
 			can0: can@40030000 {
 				compatible = "atmel,sam-can";

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -222,12 +222,7 @@
 		reg = <0x9d000 0x1000>;
 		interrupts = <43 0>, <44 0>;
 		clocks = <&syscon MCUX_MCAN_CLK>;
-		std-filter-elements = <15>;
-		ext-filter-elements = <15>;
-		rx-fifo0-elements = <8>;
-		rx-fifo1-elements = <8>;
-		rx-buffer-elements = <8>;
-		tx-buffer-elements = <15>;
+		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
 		sjw = <1>;
 		sample-point = <875>;
 		sjw-data = <1>;

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -216,12 +216,7 @@
 		reg = <0x9d000 0x1000>;
 		interrupts = <43 0>, <44 0>;
 		clocks = <&syscon MCUX_MCAN_CLK>;
-		std-filter-elements = <15>;
-		ext-filter-elements = <15>;
-		rx-fifo0-elements = <8>;
-		rx-fifo1-elements = <8>;
-		rx-buffer-elements = <8>;
-		tx-buffer-elements = <15>;
+		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
 		sjw = <1>;
 		sample-point = <875>;
 		sjw-data = <1>;

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -259,12 +259,7 @@
 		reg = <0x4009d000 0x1000>;
 		interrupts = <43 0>, <44 0>;
 		clocks = <&syscon MCUX_MCAN_CLK>;
-		std-filter-elements = <15>;
-		ext-filter-elements = <15>;
-		rx-fifo0-elements = <8>;
-		rx-fifo1-elements = <8>;
-		rx-buffer-elements = <8>;
-		tx-buffer-elements = <15>;
+		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
 		sjw = <1>;
 		sample-point = <875>;
 		sjw-data = <1>;

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -30,25 +30,19 @@
 			};
 		};
 
-		can {
-			compatible = "bosch,m_can-base";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		can1: can@40006400 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x40006400 0x400>, <0x4000b400 0x350>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <21 0>, <22 0>;
+			interrupt-names = "LINE_0", "LINE_1";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00001000>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-
-			can1: can@40006400 {
-				compatible = "st,stm32-fdcan";
-				reg = <0x40006400 0x400>, <0x4000B400 0x350>;
-				reg-names = "m_can", "message_ram";
-				interrupts = <21 0>, <22 0>;
-				interrupt-names = "LINE_0", "LINE_1";
-				clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00001000>;
-				status = "disabled";
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-			};
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
 		};
 
 		usart5: serial@40005000 {

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -34,12 +34,7 @@
 			compatible = "bosch,m_can-base";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			std-filter-elements = <28>;
-			ext-filter-elements = <8>;
-			rx-fifo0-elements = <3>;
-			rx-fifo1-elements = <3>;
-			rx-buffer-elements = <0>;
-			tx-buffer-elements = <3>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 
 			can1: can@40006400 {
 				compatible = "st,stm32-fdcan";

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -385,12 +385,7 @@
 			compatible = "bosch,m_can-base";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			std-filter-elements = <28>;
-			ext-filter-elements = <8>;
-			rx-fifo0-elements = <3>;
-			rx-fifo1-elements = <3>;
-			rx-buffer-elements = <0>;
-			tx-buffer-elements = <3>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 
 			can1: can@40006400 {
 				compatible = "st,stm32-fdcan";

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -381,25 +381,19 @@
 			status = "disabled";
 		};
 
-		can {
-			compatible = "bosch,m_can-base";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		can1: can@40006400 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x40006400 0x400>, <0x4000a400 0x350>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <21 0>, <22 0>;
+			interrupt-names = "LINE_0", "LINE_1";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-
-			can1: can@40006400 {
-				compatible = "st,stm32-fdcan";
-				reg = <0x40006400 0x400>, <0x4000A400 0x350>;
-				reg-names = "m_can", "message_ram";
-				interrupts = <21 0>, <22 0>;
-				interrupt-names = "LINE_0", "LINE_1";
-				clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
-				status = "disabled";
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-			};
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
 		};
 
 		lptim1: timers@40007c00 {

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -84,20 +84,19 @@
 			status = "disabled";
 		};
 
-		can {
-			can3: can@40006C00 {
-				compatible = "st,stm32-fdcan";
-				reg = <0x40006C00 0x400>, <0x4000AAA0 0x350>;
-				reg-names = "m_can", "message_ram";
-				interrupts = <88 0>, <89 0>;
-				interrupt-names = "LINE_0", "LINE_1";
-				clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
-				status = "disabled";
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-			};
+		can3: can@40006c00 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x40006c00 0x400>, <0x4000a400 0x9f0>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <88 0>, <89 0>;
+			interrupt-names = "LINE_0", "LINE_1";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
+			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
 		};
 	};
 };

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -10,20 +10,19 @@
 	soc {
 		compatible = "st,stm32g491", "st,stm32g4", "simple-bus";
 
-		can {
-			can2: can@40006800 {
-				compatible = "st,stm32-fdcan";
-				reg = <0x40006800 0x400>, <0x4000A750 0x350>;
-				reg-names = "m_can", "message_ram";
-				interrupts = <86 0>, <87 0>;
-				interrupt-names = "LINE_0", "LINE_1";
-				clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
-				status = "disabled";
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-			};
+		can2: can@40006800 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x40006800 0x400>, <0x4000a400 0x6a0>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <86 0>, <87 0>;
+			interrupt-names = "LINE_0", "LINE_1";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
+			sjw = <1>;
+			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
 		};
 
 		timers20: timers@40015000 {

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -436,25 +436,19 @@
 			status = "disabled";
 		};
 
-		can {
-			compatible = "bosch,m_can-base";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		can1: can@4000a400 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <39 0>, <40 0>;
+			interrupt-names = "LINE_0", "LINE_1";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-
-			can1: can@4000a400 {
-				compatible = "st,stm32-fdcan";
-				reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
-				reg-names = "m_can", "message_ram";
-				interrupts = <39 0>, <40 0>;
-				interrupt-names = "LINE_0", "LINE_1";
-				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
-				status = "disabled";
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-			};
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
 		};
 
 		rng: rng@420c0800 {

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -440,12 +440,7 @@
 			compatible = "bosch,m_can-base";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			std-filter-elements = <28>;
-			ext-filter-elements = <8>;
-			rx-fifo0-elements = <3>;
-			rx-fifo1-elements = <3>;
-			rx-buffer-elements = <0>;
-			tx-buffer-elements = <3>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 
 			can1: can@4000a400 {
 				compatible = "st,stm32-fdcan";

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -293,21 +293,20 @@
 			status = "disabled";
 		};
 
-		can {
-			can2: can@4000a800 {
-				compatible = "st,stm32-fdcan";
-				reg = <0x4000a800 0x400>, <0x4000af50 0x350>;
-				reg-names = "m_can", "message_ram";
-				interrupts = <109 0>, <110 0>;
-				interrupt-names = "LINE_0", "LINE_1";
-				/* common clock FDCAN 1 & 2 */
-				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
-				status = "disabled";
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-			};
+		can2: can@4000a800 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a800 0x400>, <0x4000ac00 0x6a0>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <109 0>, <110 0>;
+			interrupt-names = "LINE_0", "LINE_1";
+			/* common clock FDCAN 1 & 2 */
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
+			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
 		};
 	};
 };

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -469,12 +469,7 @@
 			compatible = "bosch,m_can-base";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			std-filter-elements = <28>;
-			ext-filter-elements = <8>;
-			rx-fifo0-elements = <3>;
-			rx-fifo1-elements = <3>;
-			rx-buffer-elements = <3>;
-			tx-buffer-elements = <3>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 
 			can1: can@4000a000 {
 				compatible = "st,stm32h7-fdcan";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -465,39 +465,34 @@
 			status = "disabled";
 		};
 
-		can {
-			compatible = "bosch,m_can-base";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		can1: can@4000a000 {
+			compatible = "st,stm32h7-fdcan";
+			reg = <0x4000a000 0x400>, <0x4000ac00 0x350>;
+			reg-names = "m_can", "message_ram";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
+			interrupts = <19 0>, <21 0>, <63 0>;
+			interrupt-names = "LINE_0", "LINE_1", "CALIB";
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
+		};
 
-			can1: can@4000a000 {
-				compatible = "st,stm32h7-fdcan";
-				reg = <0x4000a000 0x400>, <0x4000ac00 0x350>;
-				reg-names = "m_can", "message_ram";
-				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
-				interrupts = <19 0>, <21 0>, <63 0>;
-				interrupt-names = "LINE_0", "LINE_1", "CALIB";
-				status = "disabled";
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-			};
-
-			can2: can@4000a400 {
-				compatible = "st,stm32h7-fdcan";
-				reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
-				reg-names = "m_can", "message_ram";
-				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
-				interrupts = <20 0>, <22 0>, <63 0>;
-				interrupt-names = "LINE_0", "LINE_1", "CALIB";
-				status = "disabled";
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-			};
+		can2: can@4000a400 {
+			compatible = "st,stm32h7-fdcan";
+			reg = <0x4000a400 0x400>, <0x4000ac00 0x6a0>;
+			reg-names = "m_can", "message_ram";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
+			interrupts = <20 0>, <22 0>, <63 0>;
+			interrupt-names = "LINE_0", "LINE_1", "CALIB";
+			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
 		};
 
 		timers1: timers@40010000 {

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -117,20 +117,19 @@
 			status = "disabled";
 		};
 
-		can {
-			can3: can@4000D400 {
-				compatible = "st,stm32h7-fdcan";
-				reg = <0x4000D400 0x400>, <0x4000ac00 0x350>;
-				reg-names = "m_can", "message_ram";
-				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
-				interrupts = <159 0>, <160 0>, <63 0>;
-				interrupt-names = "LINE_0", "LINE_1", "CALIB";
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-				status = "disabled";
-			};
+		can3: can@4000d400 {
+			compatible = "st,stm32h7-fdcan";
+			reg = <0x4000d400 0x400>, <0x4000ac00 0x9f0>;
+			reg-names = "m_can", "message_ram";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>;
+			interrupts = <159 0>, <160 0>, <63 0>;
+			interrupt-names = "LINE_0", "LINE_1", "CALIB";
+			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
 		};
 
 		rtc@58004000 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -770,25 +770,19 @@
 			num-sampling-time-common-channels = <2>;
 		};
 
-		can {
-			compatible = "bosch,m_can-base";
-			#address-cells = <1>;
-			#size-cells = <1>;
+		can1: can@4000a400 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <39 0>, <40 0>;
+			interrupt-names = "LINE_0", "LINE_1";
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-
-			can1: can@4000a400 {
-				compatible = "st,stm32-fdcan";
-				reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
-				reg-names = "m_can", "message_ram";
-				interrupts = <39 0>, <40 0>;
-				interrupt-names = "LINE_0", "LINE_1";
-				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
-				status = "disabled";
-				sjw = <1>;
-				sample-point = <875>;
-				sjw-data = <1>;
-				sample-point-data = <875>;
-			};
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+			status = "disabled";
 		};
 
 		ucpd1: ucpd@4000dc00 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -774,12 +774,7 @@
 			compatible = "bosch,m_can-base";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			std-filter-elements = <28>;
-			ext-filter-elements = <8>;
-			rx-fifo0-elements = <3>;
-			rx-fifo1-elements = <3>;
-			rx-buffer-elements = <0>;
-			tx-buffer-elements = <3>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 
 			can1: can@4000a400 {
 				compatible = "st,stm32-fdcan";

--- a/dts/bindings/can/atmel,sam-can.yaml
+++ b/dts/bindings/can/atmel,sam-can.yaml
@@ -3,7 +3,7 @@ description: Specialization of Bosch m_can CAN-FD controller for Atmel SAM
 compatible: "atmel,sam-can"
 
 include:
-  - name: can-fd-controller.yaml
+  - name: bosch,m_can-base.yaml
   - name: pinctrl-device.yaml
 
 properties:

--- a/dts/bindings/can/atmel,sam0-can.yaml
+++ b/dts/bindings/can/atmel,sam0-can.yaml
@@ -3,7 +3,7 @@ description: Specialization of Bosch m_can CAN-FD controller for Atmel SAM0
 compatible: "atmel,sam0-can"
 
 include:
-  - name: can-fd-controller.yaml
+  - name: bosch,m_can-base.yaml
   - name: pinctrl-device.yaml
 
 properties:

--- a/dts/bindings/can/bosch,m_can-base.yaml
+++ b/dts/bindings/can/bosch,m_can-base.yaml
@@ -1,6 +1,6 @@
 description: Bosch M_CAN CAN-FD controller base
 
-compatible: "bosch,m_can-base"
+include: [can-fd-controller.yaml]
 
 properties:
   bosch,mram-cfg:

--- a/dts/bindings/can/bosch,m_can-base.yaml
+++ b/dts/bindings/can/bosch,m_can-base.yaml
@@ -3,26 +3,24 @@ description: Bosch M_CAN CAN-FD controller base
 compatible: "bosch,m_can-base"
 
 properties:
-  std-filter-elements:
-    type: int
+  bosch,mram-cfg:
+    type: array
     required: true
+    description: |
+      Bosch M_CAN message RAM configuration. The cells in the array have the following format:
 
-  ext-filter-elements:
-    type: int
-    required: true
+      <offset std-filter-elements ext-filter-elements rx-fifo0-elements rx-fifo1-elements
+      rx-buffer-elements tx-event-fifo-elements tx-buffer-elements>
 
-  rx-fifo0-elements:
-    type: int
-    required: true
+      The 'offset' is an address offset of the message RAM where the following elements start
+      from. This is normally set to 0x0 when using a non-shared message RAM. The remaining cells
+      specify how many elements are allocated for each filter type/FIFO/buffer.
 
-  rx-fifo1-elements:
-    type: int
-    required: true
-
-  rx-buffer-elements:
-    type: int
-    required: true
-
-  tx-buffer-elements:
-    type: int
-    required: true
+      The Bosch M_CAN IP supports the following elements:
+      11-bit Filter	 0-128 elements / 0-128 words
+      29-bit Filter	  0-64 elements / 0-128 words
+      Rx FIFO 0		    0-64 elements / 0-1152 words
+      Rx FIFO 1		    0-64 elements / 0-1152 words
+      Rx Buffers	    0-64 elements / 0-1152 words
+      Tx Event FIFO	  0-32 elements / 0-64 words
+      Tx Buffers	    0-32 elements / 0-576 words

--- a/dts/bindings/can/nxp,lpc-mcan.yaml
+++ b/dts/bindings/can/nxp,lpc-mcan.yaml
@@ -2,7 +2,7 @@ description: NXP LPC SoC series MCAN CAN-FD controller
 
 compatible: "nxp,lpc-mcan"
 
-include: [can-fd-controller.yaml, "bosch,m_can-base.yaml", pinctrl-device.yaml]
+include: ["bosch,m_can-base.yaml", pinctrl-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/can/st,stm32-fdcan.yaml
+++ b/dts/bindings/can/st,stm32-fdcan.yaml
@@ -2,7 +2,7 @@ description: ST STM32 FDCAN CAN-FD controller
 
 compatible: "st,stm32-fdcan"
 
-include: ["can-fd-controller.yaml", "pinctrl-device.yaml"]
+include: ["bosch,m_can-base.yaml", "pinctrl-device.yaml"]
 
 properties:
   reg:

--- a/dts/bindings/can/st,stm32h7-fdcan.yaml
+++ b/dts/bindings/can/st,stm32h7-fdcan.yaml
@@ -2,7 +2,7 @@ description: ST STM32H7 series FDCAN CAN-FD controller
 
 compatible: "st,stm32h7-fdcan"
 
-include: ["can-fd-controller.yaml", "pinctrl-device.yaml"]
+include: ["bosch,m_can-base.yaml", "pinctrl-device.yaml"]
 
 properties:
   clocks:


### PR DESCRIPTION
Switch the Bosch M_CAN devicetree binding to use a bosch,mram-cfg property for specifying the memory layout of the Bosch M_CAN Message RAM. This is  identical to the Linux kernel devicetree binding for Bosch M_CAN IP core based CAN controllers. This introduces an offset cell which can be used for controllers with shared Message RAM between Bosch M_CAN instances.

Restructure the Bosch M_CAN driver backend to use per-instance Message RAM configuration. This removes the need for a common, artificial "can" devicetree node for SoCs with multiple Bosch M_CAN-based CAN controllers and allows for per-instance configuration of the number of e.g. standard (11-bit) and extended (29-bit) filter elements.
    
As part of the restructure, software handling of CAN filter flags was moved from per-flags bitfields to per-filter bitfields, solving an issue when using more than 32 standard (11-bit) filter elements or more than 16 extended (29-bit) filter elements.

Now there is no longer a need for iterating all the Bosch M_CAN filter elements in  Message RAM in order to find a free filter as the driver already keeps track of assigned filters.
    
Fixes: #42030, #53417
