### PR TITLE
drivers: sensors: tcs3400: add support for enabling the IR filter

### DIFF
--- a/include/zephyr/drivers/sensor/tcs3400.h
+++ b/include/zephyr/drivers/sensor/tcs3400.h
@@ -12,6 +12,11 @@
 enum sensor_attribute_tcs3400 {
 	/** RGBC Integration Cycles */
 	SENSOR_ATTR_TCS3400_INTEGRATION_CYCLES = SENSOR_ATTR_PRIV_START,
+	/**
+	 * If set the clear channel reports the measurement from the IR
+	 * sensor.
+	 */
+	SENSOR_ATTR_TCS3400_IR_ENABLE,
 };
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_TCS3400_H_ */


### PR DESCRIPTION
This light sensor has an IR filter that can be enabled from a specific register bit to allow measuring only visible light. Add one more custom attribute to allow toggling the filter on and off.