### PR TITLE
scripts: Typo in the word 'platform'

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -227,7 +227,7 @@ class TestInstance:
                 if cond_config[0] == "arch" and len(cond_config) == 3:
                     if self.platform.arch == cond_config[1]:
                         new_config_list.append(cond_config[2])
-                elif cond_config[0] == "plaform" and len(cond_config) == 3:
+                elif cond_config[0] == "platform" and len(cond_config) == 3:
                     if self.platform.name == cond_config[1]:
                         new_config_list.append(cond_config[2])
                 else:

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -56,22 +56,30 @@ def test_check_build_or_run(class_testplan, monkeypatch, all_testsuites_dict, pl
     assert not run
 
 TESTDATA_2 = [
-    (True, True, True, ["demo_board_2"], "native", '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y\nCONFIG_ASAN=y\nCONFIG_UBSAN=y'),
-    (True, False, True, ["demo_board_2"], "native", '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y\nCONFIG_ASAN=y'),
-    (False, False, True, ["demo_board_2"], 'native', '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y'),
-    (True, False, True, ["demo_board_2"], 'mcu', '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y'),
-    (False, False, False, ["demo_board_2"], 'native', ''),
-    (False, False, True, ['demo_board_1'], 'native', ''),
-    (True, False, False, ["demo_board_2"], 'native', '\nCONFIG_ASAN=y'),
-    (False, True, False, ["demo_board_2"], 'native', '\nCONFIG_UBSAN=y'),
+    (True, True, True, ["demo_board_2"], "native", None, '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y\nCONFIG_ASAN=y\nCONFIG_UBSAN=y'),
+    (True, False, True, ["demo_board_2"], "native", None, '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y\nCONFIG_ASAN=y'),
+    (False, False, True, ["demo_board_2"], 'native', None, '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y'),
+    (True, False, True, ["demo_board_2"], 'mcu', None, '\nCONFIG_COVERAGE=y\nCONFIG_COVERAGE_DUMP=y'),
+    (False, False, False, ["demo_board_2"], 'native', None, ''),
+    (False, False, True, ['demo_board_1'], 'native', None, ''),
+    (True, False, False, ["demo_board_2"], 'native', None, '\nCONFIG_ASAN=y'),
+    (False, True, False, ["demo_board_2"], 'native', None, '\nCONFIG_UBSAN=y'),
+    (False, False, False, ["demo_board_2"], 'native', ["CONFIG_LOG=y"], 'CONFIG_LOG=y'),
+    (False, False, False, ["demo_board_2"], 'native', ["arch:x86_demo:CONFIG_LOG=y"], 'CONFIG_LOG=y'),
+    (False, False, False, ["demo_board_2"], 'native', ["arch:arm_demo:CONFIG_LOG=y"], ''),
+    (False, False, False, ["demo_board_2"], 'native', ["platform:demo_board_2:CONFIG_LOG=y"], 'CONFIG_LOG=y'),
+    (False, False, False, ["demo_board_2"], 'native', ["platform:demo_board_1:CONFIG_LOG=y"], ''),
 ]
 
-@pytest.mark.parametrize("enable_asan, enable_ubsan, enable_coverage, coverage_platform, platform_type, expected_content", TESTDATA_2)
-def test_create_overlay(class_testplan, all_testsuites_dict, platforms_list, enable_asan, enable_ubsan, enable_coverage, coverage_platform, platform_type, expected_content):
-    """Test correct content is written to testcase_extra.conf based on if conditions
-    TO DO: Add extra_configs to the input list"""
+@pytest.mark.parametrize("enable_asan, enable_ubsan, enable_coverage, coverage_platform, platform_type, extra_configs, expected_content", TESTDATA_2)
+def test_create_overlay(class_testplan, all_testsuites_dict, platforms_list, enable_asan, enable_ubsan, enable_coverage, coverage_platform, platform_type, extra_configs, expected_content):
+    """Test correct content is written to testcase_extra.conf based on if conditions."""
     class_testplan.testsuites = all_testsuites_dict
     testcase = class_testplan.testsuites.get('scripts/tests/twister/test_data/testsuites/samples/test_app/sample_test.app')
+
+    if extra_configs:
+        testcase.extra_configs = extra_configs
+
     class_testplan.platforms = platforms_list
     platform = class_testplan.get_platform("demo_board_2")
 

--- a/subsys/testsuite/ztest/src/ztress.c
+++ b/subsys/testsuite/ztest/src/ztress.c
@@ -461,9 +461,9 @@ static int ztress_cpu_clock_to_sys_clock_check(void)
 	}
 
 	t = sys_clock_tick_get_32() - t;
-	/* Threshold is arbitrary. Derived from nRF platorm where CPU runs at 64MHz and
-	 * system clock at 32kHz (sys clock interrupt every 1950 cycles). That ratio is
-	 * ok even for no optimization case.
+	/* Threshold is arbitrary. Derived from nRF platform where CPU runs
+	 * at 64MHz and system clock at 32kHz (sys clock interrupt every 1950
+	 * cycles). That ratio is ok even for no optimization case.
 	 * If some valid platforms are cut because of that, it can be changed.
 	 */
 	cpu_sys_clock_ok = t <= 12;

--- a/tests/kernel/mem_heap/shared_multi_heap/src/main.c
+++ b/tests/kernel/mem_heap/shared_multi_heap/src/main.c
@@ -120,8 +120,8 @@ static void fill_multi_heap(void)
 		 * address retrieved by DT at run-time because the SMH
 		 * framework expects virtual addresses.
 		 *
-		 * For MPU-enabled plaform the code is assuming that the region
-		 * are configured at build-time, so no map is needed.
+		 * For MPU-enabled platform the code is assuming that the
+		 * region are configured at build-time, so no map is needed.
 		 */
 		smh_reg_map(&reg_map->region);
 #endif /* CONFIG_MMU */

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1369,7 +1369,7 @@ ZTEST(devicetree_api, test_arrays)
 ZTEST(devicetree_api, test_foreach)
 {
 	/*
-	 * We don't know what plaform we are running on, so settle for
+	 * We don't know what platform we are running on, so settle for
 	 * some basic checks related to nodes we know are in our overlay.
 	 */
 #define IS_ALIASES(node_id) + DT_SAME_NODE(DT_PATH(aliases), node_id)


### PR DESCRIPTION
`testinstance.py` contains a string literal comparison to the word `platform`, which has been misspelled as `plaform`.

That typo and a few others, contained within docstrings, have been corrected to `platform`.

The change is verified by a test expansion.

Fixes #58322