### PR TITLE
ARC: MWDT: rework GNU helper tools usage

### DIFF
--- a/cmake/bintools/arcmwdt/target.cmake
+++ b/cmake/bintools/arcmwdt/target.cmake
@@ -22,17 +22,7 @@ find_program(CMAKE_GDB     ${CROSS_COMPILE}mdb     PATHS ${TOOLCHAIN_HOME} NO_DE
 
 # MWDT binutils don't support required features like section renaming, so we
 # temporarily had to use GNU objcopy instead
-find_program(CMAKE_OBJCOPY arc-elf32-objcopy)
-if (NOT CMAKE_OBJCOPY)
-  find_program(CMAKE_OBJCOPY arc-linux-objcopy)
-endif()
-
-if (NOT CMAKE_OBJCOPY)
-  find_program(CMAKE_OBJCOPY objcopy)
-endif()
-
-if(NOT CMAKE_OBJCOPY)
-  message(FATAL_ERROR "Zephyr unable to find any GNU objcopy (ARC or host one)")
-endif()
+find_program(CMAKE_OBJCOPY ${ZEPHYR_SDK_CROSS_COMPILE}objcopy PATHS ${ZEPHYR_SDK_INSTALL_DIR} NO_DEFAULT_PATH)
+message(STATUS "Found GNU objcopy helper for MWDT: ${CMAKE_OBJCOPY} (Zephyr SDK ${SDK_VERSION})")
 
 include(${ZEPHYR_BASE}/cmake/bintools/arcmwdt/target_bintools.cmake)

--- a/cmake/compiler/arcmwdt/generic.cmake
+++ b/cmake/compiler/arcmwdt/generic.cmake
@@ -2,21 +2,8 @@
 
 # Configures CMake for using ccac
 
-# MWDT compiler (CCAC) can't be used for preprocessing the DTS sources as it has
-# weird restrictions about file extensions. Synopsys Jira issue: P10019563-38578
-# Let's temporarily use GNU compiler instead.
-find_program(CMAKE_DTS_PREPROCESSOR arc-elf32-gcc)
-if (NOT CMAKE_DTS_PREPROCESSOR)
-  find_program(CMAKE_DTS_PREPROCESSOR arc-linux-gcc)
-endif()
-
-if (NOT CMAKE_DTS_PREPROCESSOR)
-  find_program(CMAKE_DTS_PREPROCESSOR gcc)
-endif()
-
-if(NOT CMAKE_DTS_PREPROCESSOR)
-  message(FATAL_ERROR "Zephyr was unable to find any GNU compiler (ARC or host one) for DTS preprocessing")
-endif()
+find_program(CMAKE_DTS_PREPROCESSOR ${ZEPHYR_SDK_CROSS_COMPILE}gcc PATHS ${ZEPHYR_SDK_INSTALL_DIR} NO_DEFAULT_PATH)
+message(STATUS "Found dts preprocessor: ${CMAKE_DTS_PREPROCESSOR} (Zephyr SDK ${SDK_VERSION})")
 
 find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}ccac PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 find_program(CMAKE_LLVM_COV ${CROSS_COMPILE}llvm-cov PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)

--- a/cmake/modules/FindZephyr-sdk.cmake
+++ b/cmake/modules/FindZephyr-sdk.cmake
@@ -34,7 +34,8 @@ zephyr_get(ZEPHYR_SDK_INSTALL_DIR)
 # Until we completely deprecate it
 if(("zephyr" STREQUAL ${ZEPHYR_TOOLCHAIN_VARIANT}) OR
    (NOT DEFINED ZEPHYR_TOOLCHAIN_VARIANT) OR
-   (DEFINED ZEPHYR_SDK_INSTALL_DIR))
+   (DEFINED ZEPHYR_SDK_INSTALL_DIR) OR
+   (Zephyr-sdk_FIND_REQUIRED))
 
   # No toolchain was specified, so inform user that we will be searching.
   if (NOT DEFINED ZEPHYR_SDK_INSTALL_DIR AND

--- a/cmake/toolchain/arcmwdt/generic.cmake
+++ b/cmake/toolchain/arcmwdt/generic.cmake
@@ -17,6 +17,18 @@ if(NOT EXISTS ${ARCMWDT_TOOLCHAIN_PATH})
   message(FATAL_ERROR "Nothing found at ARCMWDT_TOOLCHAIN_PATH: '${ARCMWDT_TOOLCHAIN_PATH}'")
 endif()
 
+# arcmwdt relies on Zephyr SDK for the use of C preprocessor (devicetree) and objcopy
+find_package(Zephyr-sdk 0.15 REQUIRED)
+# Handling to be improved in Zephyr SDK, we can drop setting TOOLCHAIN_HOME after
+# https://github.com/zephyrproject-rtos/sdk-ng/pull/682 got merged and we switch to proper SDK
+# version.
+set(TOOLCHAIN_HOME ${ZEPHYR_SDK_INSTALL_DIR})
+include(${ZEPHYR_SDK_INSTALL_DIR}/cmake/zephyr/target.cmake)
+set(ZEPHYR_SDK_CROSS_COMPILE ${CROSS_COMPILE})
+# Handling to be improved in Zephyr SDK, to avoid overriding ZEPHYR_TOOLCHAIN_VARIANT by
+# find_package(Zephyr-sdk) if it's already set
+set(ZEPHYR_TOOLCHAIN_VARIANT arcmwdt)
+
 set(TOOLCHAIN_HOME ${ARCMWDT_TOOLCHAIN_PATH}/MetaWare)
 
 set(COMPILER arcmwdt)


### PR DESCRIPTION
As of today MWDT toolchain in case of Zephyr may use few tools from GNU toolchain - GNU compiler for DTS preprocessing and objcopy for section renaming.

Currently we were trying to find any GNU compiler & objcopy which start to cause compatibility issues for new targets - i.e. not every objcopy knows new ARC targets.

Let's use ARC GNU tools from Zephyr SDK as we still usually require it when building with MWDT for other tools like DTC (device tree compiler)