### PR TITLE
dts: mec172x: move the uart device node off espi

### DIFF
--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -823,6 +823,28 @@
 			pcrs = <2 12>;
 			status = "disabled";
 		};
+		uart0: uart@400f2400 {
+			compatible = "microchip,xec-uart";
+			reg = <0x400f2400 0x400>;
+			interrupts = <40 1>;
+			clock-frequency = <1843200>;
+			current-speed = <38400>;
+			girqs = <15 0>;
+			pcrs = <2 1>;
+			ldn = <9>;
+			status = "disabled";
+		};
+		uart1: uart@400f2800 {
+			compatible = "microchip,xec-uart";
+			reg = <0x400f2800 0x400>;
+			interrupts = <41 1>;
+			clock-frequency = <1843200>;
+			current-speed = <38400>;
+			girqs = <15 1>;
+			pcrs = <2 2>;
+			ldn = <10>;
+			status = "disabled";
+		};
 		espi0: espi@400f3400 {
 			compatible = "microchip,xec-espi-v2";
 			/* reg tuple contains one 32-bit address cell and one
@@ -948,28 +970,6 @@
 				compatible = "microchip,xec-espi-host-dev";
 				reg = <0x400f2000 0x400>;
 				ldn = <8>;
-				status = "disabled";
-			};
-			uart0: uart@400f2400 {
-				compatible = "microchip,xec-uart";
-				reg = <0x400f2400 0x400>;
-				interrupts = <40 1>;
-				clock-frequency = <1843200>;
-				current-speed = <38400>;
-				girqs = <15 0>;
-				pcrs = <2 1>;
-				ldn = <9>;
-				status = "disabled";
-			};
-			uart1: uart@400f2800 {
-				compatible = "microchip,xec-uart";
-				reg = <0x400f2800 0x400>;
-				interrupts = <41 1>;
-				clock-frequency = <1843200>;
-				current-speed = <38400>;
-				girqs = <15 1>;
-				pcrs = <2 2>;
-				ldn = <10>;
 				status = "disabled";
 			};
 			emi0: emi@400f4000 {


### PR DESCRIPTION
Hi, bumped into this while checking the build, was getting an error as the uart driver is initialized before espi. Moving it up so that the tree matches the actual init hierarchy, as best as I can tell it should not affect anything else (as in: I don't see the upper driver doing anything with the child nodes directly, and from the datasheet I don't see that connection anyway).

---

Move the two UART nodes so that they are under "soc" rather than "espi", leave only xec-espi-host-dev nodes there.

The UART device can be used indepdently by the driver uart_mchp_xec.c and it's normally initialized before before the espi one.

Moving the device node up a level so this does not trigger a false positive on the build time priority checking.