### PR TITLE
drivers: serial: ite_it8xxx2: add a dedicated priority symbol

### DIFF
--- a/drivers/serial/Kconfig.it8xxx2
+++ b/drivers/serial/Kconfig.it8xxx2
@@ -11,3 +11,12 @@ config UART_ITE_IT8XXX2
 	  to handle IT8XXX2 specific UART features. In addition
 	  to use pm_action_cb, we also need to make some setting
 	  at uart_it8xxx2_init.
+
+config UART_ITE_IT8XXX2_INIT_PRIORITY
+	int "ITE IT8XXX2 UART wrapper init priority"
+	default 51
+	depends on UART_ITE_IT8XXX2
+	help
+	  Initialization priority for the UART wrapper driver on ITE IT8XXX2,
+	  must be set to a lower priority than the matching ns16550 device
+	  (CONFIG_SERIAL_INIT_PRIORITY).

--- a/drivers/serial/uart_ite_it8xxx2.c
+++ b/drivers/serial/uart_ite_it8xxx2.c
@@ -203,7 +203,7 @@ static int uart_it8xxx2_init(const struct device *dev)
 			      &uart_it8xxx2_data_##inst,                       \
 			      &uart_it8xxx2_cfg_##inst,                        \
 			      PRE_KERNEL_1,                                    \
-			      CONFIG_SERIAL_INIT_PRIORITY,                     \
+			      CONFIG_UART_ITE_IT8XXX2_INIT_PRIORITY,           \
 			      NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(UART_ITE_IT8XXX2_INIT)


### PR DESCRIPTION
Hi, bumped into this while checking priorities with `west build -p -b it8xxx2_evb samples/hello_world -DCONFIG_CHECK_INIT_PRIORITIES=y`, trying to handle drivers that depends on each other but initialize at the same level.

---

The uart_ite_it8xxx2 is relying on a node that depends on a matching ns16550 symbol, such as:

```
ite_uart1_wrapper: uartwrapper@f02720 {
        compatible = "ite,it8xxx2-uart";
	...
        uart-dev = <&uart1>;
};
```

But the two are currently setup to initialize at the same level and priority. Add a dedicated priority symbol so that the wrapper device is always initialized after the main one, regardless of the linker order.