### PR TITLE
soc: nxp_rt: Enable INIT_ARCH_HW_AT_BOOT and CACHE_MANAGEMENT

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.series
@@ -8,5 +8,6 @@ config SOC_SERIES_IMX_RT
 	select ARM
 	select SOC_FAMILY_IMX
 	select CLOCK_CONTROL
+	select CACHE_MANAGEMENT
 	help
 	  Enable support for i.MX RT MCU series

--- a/soc/arm/nxp_imx/rt5xx/Kconfig.series
+++ b/soc/arm/nxp_imx/rt5xx/Kconfig.series
@@ -10,5 +10,6 @@ config SOC_SERIES_IMX_RT5XX
 	select CPU_CORTEX_M_HAS_DWT
 	select SOC_FAMILY_IMX
 	select CLOCK_CONTROL
+	select CACHE_MANAGEMENT
 	help
 	  Enable support for i.MX RT5XX Series MCU series

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.series
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.series
@@ -12,5 +12,6 @@ config SOC_SERIES_IMX_RT6XX
 	select CLOCK_CONTROL
 	select CODE_DATA_RELOCATION_SRAM if FLASH_MCUX_FLEXSPI_XIP
 	select PLATFORM_SPECIFIC_INIT
+	select CACHE_MANAGEMENT
 	help
 	  Enable support for i.MX RT6XX Series MCU series


### PR DESCRIPTION
Enable INIT_ARCH_HW_AT_BOOT and CACHE_MANAGEMENT so the cache and other hardware registers are cleared on boot.
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54731