### PR TITLE
drivers: intc: stm32: add appropriate operand types

### DIFF
--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -61,9 +61,9 @@ void stm32_exti_enable(int line)
 
 	/* Enable requested line interrupt */
 #if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CONFIG_CPU_CORTEX_M4)
-	LL_C2_EXTI_EnableIT_0_31(1 << line);
+	LL_C2_EXTI_EnableIT_0_31(BIT((uint32_t)line));
 #else
-	LL_EXTI_EnableIT_0_31(1 << line);
+	LL_EXTI_EnableIT_0_31(BIT((uint32_t)line));
 #endif
 
 	/* Enable exti irq interrupt */
@@ -76,9 +76,9 @@ void stm32_exti_disable(int line)
 
 	if (line < 32) {
 #if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CONFIG_CPU_CORTEX_M4)
-		LL_C2_EXTI_DisableIT_0_31(1 << line);
+		LL_C2_EXTI_DisableIT_0_31(BIT((uint32_t)line));
 #else
-		LL_EXTI_DisableIT_0_31(1 << line);
+		LL_EXTI_DisableIT_0_31(BIT((uint32_t)line));
 #endif
 	} else {
 		__ASSERT_NO_MSG(line);
@@ -95,12 +95,12 @@ static inline int stm32_exti_is_pending(int line)
 {
 	if (line < 32) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32g0_exti)
-		return (LL_EXTI_IsActiveRisingFlag_0_31(1 << line) ||
-			LL_EXTI_IsActiveFallingFlag_0_31(1 << line));
+		return (LL_EXTI_IsActiveRisingFlag_0_31(BIT((uint32_t)line)) ||
+			LL_EXTI_IsActiveFallingFlag_0_31(BIT((uint32_t)line)));
 #elif defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CONFIG_CPU_CORTEX_M4)
-		return LL_C2_EXTI_IsActiveFlag_0_31(1 << line);
+		return LL_C2_EXTI_IsActiveFlag_0_31(BIT((uint32_t)line));
 #else
-		return LL_EXTI_IsActiveFlag_0_31(1 << line);
+		return LL_EXTI_IsActiveFlag_0_31(BIT((uint32_t)line));
 #endif
 	} else {
 		__ASSERT_NO_MSG(line);
@@ -117,12 +117,12 @@ static inline void stm32_exti_clear_pending(int line)
 {
 	if (line < 32) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32g0_exti)
-		LL_EXTI_ClearRisingFlag_0_31(1 << line);
-		LL_EXTI_ClearFallingFlag_0_31(1 << line);
+		LL_EXTI_ClearRisingFlag_0_31(BIT((uint32_t)line));
+		LL_EXTI_ClearFallingFlag_0_31(BIT((uint32_t)line));
 #elif defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CONFIG_CPU_CORTEX_M4)
-		LL_C2_EXTI_ClearFlag_0_31(1 << line);
+		LL_C2_EXTI_ClearFlag_0_31(BIT((uint32_t)line));
 #else
-		LL_EXTI_ClearFlag_0_31(1 << line);
+		LL_EXTI_ClearFlag_0_31(BIT((uint32_t)line));
 #endif
 	} else {
 		__ASSERT_NO_MSG(line);
@@ -140,20 +140,20 @@ void stm32_exti_trigger(int line, int trigger)
 
 	switch (trigger) {
 	case STM32_EXTI_TRIG_NONE:
-		LL_EXTI_DisableRisingTrig_0_31(1 << line);
-		LL_EXTI_DisableFallingTrig_0_31(1 << line);
+		LL_EXTI_DisableRisingTrig_0_31(BIT((uint32_t)line));
+		LL_EXTI_DisableFallingTrig_0_31(BIT((uint32_t)line));
 		break;
 	case STM32_EXTI_TRIG_RISING:
-		LL_EXTI_EnableRisingTrig_0_31(1 << line);
-		LL_EXTI_DisableFallingTrig_0_31(1 << line);
+		LL_EXTI_EnableRisingTrig_0_31(BIT((uint32_t)line));
+		LL_EXTI_DisableFallingTrig_0_31(BIT((uint32_t)line));
 		break;
 	case STM32_EXTI_TRIG_FALLING:
-		LL_EXTI_EnableFallingTrig_0_31(1 << line);
-		LL_EXTI_DisableRisingTrig_0_31(1 << line);
+		LL_EXTI_EnableFallingTrig_0_31(BIT((uint32_t)line));
+		LL_EXTI_DisableRisingTrig_0_31(BIT((uint32_t)line));
 		break;
 	case STM32_EXTI_TRIG_BOTH:
-		LL_EXTI_EnableRisingTrig_0_31(1 << line);
-		LL_EXTI_EnableFallingTrig_0_31(1 << line);
+		LL_EXTI_EnableRisingTrig_0_31(BIT((uint32_t)line));
+		LL_EXTI_EnableFallingTrig_0_31(BIT((uint32_t)line));
 		break;
 	default:
 		__ASSERT_NO_MSG(trigger);


### PR DESCRIPTION
1. add explicit unsigned long type suffix for decimal constants, avoiding possible [shiftTooManyBitsSigned], and

2. add an explicit uint32_t cast to right hand operands of left shift operators , thus complying with required [misra-c2012-10.1] rule which states; operands shall not be of an inappropriate essential type.

Found as a coding guideline violation (Rule 10.1) by static code scanning tool.

Note: Tested on STM32L5 Nucleo-144 board (stm32l552xx).