### PR TITLE
drivers: intc: stm32: add break to switch-clause

### DIFF
--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -157,6 +157,7 @@ void stm32_exti_trigger(int line, int trigger)
 		break;
 	default:
 		__ASSERT_NO_MSG(trigger);
+		break;
 	}
 	z_stm32_hsem_unlock(CFG_HW_EXTI_SEMID);
 }


### PR DESCRIPTION
add an unconditional break to switch-clause's default case, complying with required [misra-c2012-16.3] rule which states; An unconditional break statement terminate every switch-clause.

Found as a coding guideline violation (Rule 16.3) by static code scanning tool.

Note: Tested on STM32L5 Nucleo-144 board (stm32l552xx).