### PR TITLE
drivers: intc: stm32: correct for counter type

### DIFF
--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -176,7 +176,7 @@ static void stm32_exti_isr(const void *exti_range)
 	int line;
 
 	/* see which bits are set */
-	for (int i = 0; i <= range->len; i++) {
+	for (uint8_t i = 0; i <= range->len; i++) {
 		line = range->start + i;
 		/* check if interrupt is pending */
 		if (stm32_exti_is_pending(line)) {


### PR DESCRIPTION
change for loop iterator/counter type to unsigned int, thus matching that of struct stm32_exti_range's len member var, complying with required [misra-c2012-10.4] rule which states; Both operands of an operator in which the usual arithmetic conversions are performed shall have the same essential type category.

Found as a coding guideline violation (Rule 10.4) by static code scanning tool.

Note: Tested on STM32L5 Nucleo-144 board (stm32l552xx).