### PR TITLE
drivers: intc: stm32: clarify controlling expression

### DIFF
--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -179,7 +179,7 @@ static void stm32_exti_isr(const void *exti_range)
 	for (int i = 0; i <= range->len; i++) {
 		line = range->start + i;
 		/* check if interrupt is pending */
-		if (stm32_exti_is_pending(line)) {
+		if (stm32_exti_is_pending(line) != 0) {
 			/* clear pending interrupt */
 			stm32_exti_clear_pending(line);
 


### PR DESCRIPTION
add explicit boolean type to 'if' statement controlling expression, consolidating it with 'stm32_exti_is_pending' function return type, thus improving code readability and maintainability, complying with required [misra-c2012-14.4] rule which states; The controlling expression of an if statement and the controlling expression of an iteration-statement shall have essentially boolean type.

Found as a coding guideline violation (Rule 14.4) by static code scanning tool.

Note: Tested on STM32L5 Nucleo-144 board (stm32l552xx).