### PR TITLE
drivers: intc: stm32: explicitly set operator precedence

### DIFF
--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -248,7 +248,7 @@ int stm32_exti_set_callback(int line, stm32_exti_callback_t cb, void *arg)
 	const struct device *const dev = DEVICE_DT_GET(EXTI_NODE);
 	struct stm32_exti_data *data = dev->data;
 
-	if (data->cb[line].cb == cb && data->cb[line].data == arg) {
+	if ((data->cb[line].cb == cb) && (data->cb[line].data == arg)) {
 		return 0;
 	}
 


### PR DESCRIPTION
add enclosing parentheses enforcing and clarifying precedence of operators, thus improving code readability and maintainability, complying with *advisory* [misra-c2012-12.1] rule which states; The precedence of operators within expressions should be made explicit.

Found as a coding guideline recommendation (Rule 12.1) by static code scanning tool.

Note: Tested on STM32L5 Nucleo-144 board (stm32l552xx).