### PR TITLE
drivers: intc: stm32: clarify controlling expression

### DIFF
--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -252,7 +252,8 @@ int stm32_exti_set_callback(int line, stm32_exti_callback_t cb, void *arg)
 		return 0;
 	}
 
-	if (data->cb[line].cb) {
+	/* if callback already exists/maybe-running return busy */
+	if (data->cb[line].cb != NULL) {
 		return -EBUSY;
 	}
 


### PR DESCRIPTION
add explicit boolean type to 'if' statement controlling expression, consolidating it with 'stm32_exti_callback_t' (function pointer), thus improving code readability and maintainability, complying with required [misra-c2012-14.4] rule which states; The controlling expression of an if statement and the controlling expression of an iteration-statement shall have essentially Boolean type.

Found as a coding guideline violation (Rule 14.4) by static code scanning tool.

Note: Tested on STM32L5 Nucleo-144 board (stm32l552xx).