### PR TITLE
device: add explicit variable type cast

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -844,7 +844,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * The maximum length is set so that device_get_binding() can be used from
  * userspace.
  */
-#define Z_DEVICE_MAX_NAME_LEN 48
+#define Z_DEVICE_MAX_NAME_LEN 48U
 
 /**
  * @brief Compile time check for device name length


### PR DESCRIPTION
add explicit cast to size_t for 'Z_DEVICE_MAX_NAME_LEN' macro, matching it to return type of sizeof (size_t), thus the comparison operator '<=' has the same essential types, complying with required [misra-c2012-10.4] rule which states; Both operands of an operator in which the usual arithmetic conversions are performed shall have the same essential type category.

Found as a coding guideline violation (Rule 10.4) by static code scanning tool.

Note: Tested on STM32L5 Nucleo-144 board (stm32l552xx).