### PR TITLE
scripts: build: elf_parser: fix relocatable data offsets

### DIFF
--- a/scripts/build/elf_parser.py
+++ b/scripts/build/elf_parser.py
@@ -147,15 +147,14 @@ class ZephyrElf:
         """
         Retrieve the raw bytes associated with a symbol from the elf file.
         """
+        # Symbol data parameters
         addr = sym.entry.st_value
-        len = sym.entry.st_size
-        for section in self.elf.iter_sections():
-            start = section['sh_addr']
-            end = start + section['sh_size']
-
-            if (start <= addr) and (addr + len) <= end:
-                offset = addr - section['sh_addr']
-                return bytes(section.data()[offset:offset + len])
+        length = sym.entry.st_size
+        # Section associated with the symbol
+        section = self.elf.get_section(sym.entry['st_shndx'])
+        offset = addr - section['sh_addr']
+        # Extract bytes
+        return bytes(section.data()[offset:offset + length])
 
     def _symbols_find_value(self, names):
         symbols = {}

--- a/scripts/build/gen_handles.py
+++ b/scripts/build/gen_handles.py
@@ -121,6 +121,13 @@ def main():
         edt = pickle.load(f)
 
     parsed_elf = ZephyrElf(args.kernel, edt, args.start_symbol)
+    if parsed_elf.relocatable:
+        # While relocatable elf files will load cleanly, the pointers pulled from
+        # the symbol table are invalid (as expected, because the structures have not
+        # yet been allocated addresses). Fixing this will require iterating over
+        # the relocation sections to find the symbols those pointers will end up
+        # referring to.
+        sys.exit('Relocatable elf files are not yet supported')
 
     if args.output_graphviz:
         # Try and output the dependency tree


### PR DESCRIPTION
Retrieve the section holding the symbol data directly from the symbol information, instead of trying to find a section that contains data at the correct address. The later approach does not work for relocatable files, which contain multiple sections all containing data in overlapping temporary memory addresses (usually starting at 0).

Based on investigations with relocatable `.elf` files, the symbol table data in relocatable files is not shifted by the section address. Remove the shift from these files to ensure that data can be pulled from the symbol table.

Problems were investigated at the request of @aescolar, and correct parsing was validated with a relocatable `.elf` file that he provided. Tests will validate that this change does not break standard applications, but will not test the relocatable case (which is not currently tested anyway).
```
jordan@FIDO:~/code/zephyr$ ./zephyr/scripts/build/gen_handles.py -o handles.c -s __device_start -z zephyr -k zephyr_pre0.reloc.elf
jordan@FIDO:~/code/zephyr$ ./zephyr/scripts/build/gen_handles.py -o handles.c -s __device_start -z zephyr -k zephyr_pre0.normal.elf
```