### PR TITLE
west: sign.py: give rimage a key placeholder when there's none

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -522,7 +522,8 @@ class RimageSigner(Signer):
         sign_config_extra_args = config_get_words(command.config, 'rimage.extra-args', [])
 
         if '-k' not in sign_config_extra_args + args.tool_args:
-            cmake_default_key = cache.get('RIMAGE_SIGN_KEY')
+            # rimage requires a key argument even when it does not sign
+            cmake_default_key = cache.get('RIMAGE_SIGN_KEY', 'key placeholder from sign.py')
             extra_ri_args += [ '-k', str(sof_src_dir / 'keys' / cmake_default_key) ]
 
         if '-c' not in sign_config_extra_args + args.tool_args:


### PR DESCRIPTION
rimage always requires a key argument even when it does not use it.

Some configurations (IMX) use rimage only for "stitching" the image but not for signing. These were failing to build directly from west with pretty cryptic stack trace, see below. This has never been a problem for the SOF project because it has always worked around this rimage limitation by providing a bogus -k argument - very much like the one added by this commit.

```
File "zephyrproject/zephyr/scripts/west_commands/sign.py",  in sign
  extra_ri_args += [ '-k', str(sof_src_dir / 'keys' / cmake_default_key) ]
TypeError: unsupported operand type(s) for /: 'PosixPath' and 'NoneType'
ninja: build stopped: subcommand failed.
```