### PR TITLE
net: lib: LwM2M: fix for SystemView macro conflict

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -163,6 +163,16 @@ struct lwm2m_message;
 #define LWM2M_PATH_LEVEL_RESOURCE 3
 #define LWM2M_PATH_LEVEL_RESOURCE_INST 4
 
+#ifdef CONFIG_SEGGER_SYSTEMVIEW
+/*
+ * If not undefined these SystemView macros will
+ * break the OBJ_FIELD macro provided below
+ */
+#undef U8
+#undef U16
+#undef U32
+#endif
+
 /* path representing object instances */
 #define OBJ_FIELD(_id, _perm, _type) \
 	{ .res_id = _id, \


### PR DESCRIPTION
SystemView U8, U16, U32 macros conflict with macros provided by lwm2m_object.h

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/58359