### PR TITLE
fb: cfb: Introducing 'no offscreen buffer' mode

### DIFF
--- a/include/zephyr/display/cfb.h
+++ b/include/zephyr/display/cfb.h
@@ -105,6 +105,8 @@ int cfb_draw_text(const struct device *dev, const char *const str, int16_t x, in
 /**
  * @brief Draw a point.
  *
+ * Not supported if set CONFIG_CHARACTER_FRAMEBUFFER_USE_OFFSCREEN_BUFFER
+ *
  * @param dev Pointer to device structure for driver instance
  * @param pos position of the point
  *
@@ -114,6 +116,8 @@ int cfb_draw_point(const struct device *dev, const struct cfb_position *pos);
 
 /**
  * @brief Draw a line.
+ *
+ * Not supported if set CONFIG_CHARACTER_FRAMEBUFFER_USE_OFFSCREEN_BUFFER
  *
  * @param dev Pointer to device structure for driver instance
  * @param start start position of the line
@@ -126,6 +130,8 @@ int cfb_draw_line(const struct device *dev, const struct cfb_position *start,
 
 /**
  * @brief Draw a rectangle.
+ *
+ * Not supported if set CONFIG_CHARACTER_FRAMEBUFFER_USE_OFFSCREEN_BUFFER
  *
  * @param dev Pointer to device structure for driver instance
  * @param start Top-Left position of the rectangle
@@ -141,6 +147,7 @@ int cfb_draw_rect(const struct device *dev, const struct cfb_position *start,
  *
  * @param dev Pointer to device structure for driver instance
  * @param clear_display Clear the display as well
+ *                      Always clear if set CONFIG_CHARACTER_FRAMEBUFFER_USE_OFFSCREEN_BUFFER.
  *
  * @return 0 on success, negative value otherwise
  */
@@ -158,6 +165,8 @@ int cfb_framebuffer_invert(const struct device *dev);
 /**
  * @brief Invert Pixels in selected area.
  *
+ * Not supported if set CONFIG_CHARACTER_FRAMEBUFFER_USE_OFFSCREEN_BUFFER
+ *
  * @param dev Pointer to device structure for driver instance
  * @param x Position in X direction of the beginning of area
  * @param y Position in Y direction of the beginning of area
@@ -172,6 +181,8 @@ int cfb_invert_area(const struct device *dev, uint16_t x, uint16_t y,
 /**
  * @brief Finalize framebuffer and write it to display RAM,
  * invert or reorder pixels if necessary.
+ *
+ * Not supported if set CONFIG_CHARACTER_FRAMEBUFFER_USE_OFFSCREEN_BUFFER
  *
  * @param dev Pointer to device structure for driver instance
  *

--- a/subsys/fb/Kconfig
+++ b/subsys/fb/Kconfig
@@ -31,6 +31,26 @@ config CHARACTER_FRAMEBUFFER_SHELL_DRIVER_NAME
 	help
 	  Character Framebuffer Display Driver Name
 
+config CHARACTER_FRAMEBUFFER_USE_OFFSCREEN_BUFFER
+	bool "Use offscreen buffer"
+	default y
+	help
+	  Allocate and use an offscreen buffer for rendering.
+	  If this option is disabled, some functions that depend on
+	  offscreen buffers are unsupported.
+
+if !CHARACTER_FRAMEBUFFER_USE_OFFSCREEN_BUFFER
+
+config CHARACTER_FRAMEBUFFER_TRANSFER_BUFFER_SIZE
+	int "Size of buffer for transferring"
+	default 0
+	help
+	  Buffer size for transferring to display
+	  If set to zero, it allocates a buffer of the same number
+	  of bytes as the width of the display.
+
+endif #!CHARACTER_FRAMEBUFFER_USE_OFFSCREEN_BUFFER
+
 module = CFB
 module-str = cfb
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -18,7 +18,8 @@
 #define HELP_NONE "[none]"
 #define HELP_INIT "call \"cfb init\" first"
 #define HELP_PRINT "<col: pos> <row: pos> \"<text>\""
-#define HELP_DRAW_POINT "<x> <y0>"
+#define HELP_DRAW_TEXT "<x> <y> \"<text>\""
+#define HELP_DRAW_POINT "<x> <y>"
 #define HELP_DRAW_LINE "<x0> <y0> <x1> <y1>"
 #define HELP_DRAW_RECT "<x0> <y0> <x1> <y1>"
 #ifdef CONFIG_CHARACTER_FRAMEBUFFER_USE_OFFSCREEN_BUFFER
@@ -630,7 +631,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmd_scroll,
 );
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmd_draw,
-	SHELL_CMD_ARG(text, NULL, HELP_PRINT, cmd_draw_text, 4, 0),
+	SHELL_CMD_ARG(text, NULL, HELP_DRAW_TEXT, cmd_draw_text, 4, 0),
 
 #ifdef CONFIG_CHARACTER_FRAMEBUFFER_USE_OFFSCREEN_BUFFER
 	SHELL_CMD_ARG(point, NULL, HELP_DRAW_POINT, cmd_draw_point, 3, 0),
@@ -652,7 +653,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(cfb_cmds,
 	SHELL_CMD_ARG(print, NULL, HELP_PRINT, cmd_print, 4, 0),
 	SHELL_CMD(scroll, &sub_cmd_scroll, "scroll a text in vertical or "
 		  "horizontal direction", NULL),
-	SHELL_CMD(draw, &sub_cmd_draw, "drawing text", NULL),
+	SHELL_CMD(draw, &sub_cmd_draw, "drawing text and shapes", NULL),
 	SHELL_CMD_ARG(clear, NULL, HELP_NONE, cmd_clear, 1, 0),
 	SHELL_SUBCMD_SET_END
 );


### PR DESCRIPTION
The 'no offscreen buffer' mode uses memory to transfer instead of
an offscreen buffer. It works even with a tiny buffer size,
but in that case, the transfer frequency increases, so the drawing
speed becomes slower.
This mode also disables features that rely on image processing using
offscreen buffers.

- Not supported in 'no offscreen buffer' mode
  - cfb_draw_point
  - cfb_draw_line
  - cfb_draw_rect
  - cfb_invert_area

- behavior changes in 'no offscreen buffer' mode
  - cfb_framebuffer_clear
    Clears the display regardless of the clear_display setting.

  - cfb_framebuffer_finalize
    In 'no offscreen buffer' mode drawing is apply immediate,
    so this method does nothing

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>