### PR TITLE
drivers: uart: add support for serial ports on native posix

### DIFF
--- a/boards/posix/native_posix/doc/index.rst
+++ b/boards/posix/native_posix/doc/index.rst
@@ -266,9 +266,18 @@ The following peripherals are currently provided with this board:
   Please refer to the section `About time in native_posix`_ for more
   information.
 
-**UART**
-  An optional UART driver can be compiled with native_posix.
-  For more information refer to the section `UART`_.
+**UART/Serial**
+   Two optional native UART drivers are available:
+
+   **PTTY driver (UART_NATIVE_POSIX)**
+      With this driver, one or two Zephyr UART devices can be created. These
+      can be connected to the Linux process stdin/stdout or a newly created
+      pseudo-tty. For more information refer to the section `PTTY UART`_.
+
+   **TTY driver (UART_NATIVE_TTY)**
+      An UART driver for interacting with host-attached serial port devices
+      (eg. USB to UART dongles). For more information refer to the section
+      `TTY UART`_.
 
 **Real time clock**
   The real time clock model provides a model of a constantly powered clock.
@@ -371,8 +380,8 @@ The following peripherals are currently provided with this board:
   The flash content can be accessed from the host system, as explained in the
   `Host based flash access`_ section.
 
-UART
-****
+PTTY UART
+*********
 
 This driver can be configured with :kconfig:option:`CONFIG_UART_NATIVE_POSIX`
 to instantiate up to two UARTs. By default only one UART is enabled.
@@ -408,6 +417,42 @@ option ``-attach_uart_cmd=<"cmd">``. Where the default command is given by
 Note that the default command assumes both ``xterm`` and ``screen`` are
 installed in the system.
 
+.. _native_tty_uart:
+
+TTY UART
+********
+
+With this driver an application can use the polling UART API (``uart_poll_out``,
+``uart_poll_in``) to write and read characters to and from a connected serial
+port device.
+
+This driver is automatically enabled when a devicetree contains a node
+with ``"zephyr,native-tty-uart"`` compatible property and ``okay`` status, such
+as one below::
+
+	uart {
+		status = "okay";
+		compatible = "zephyr,native-tty-uart";
+		serial-port = "/dev/ttyUSB0";
+		current-speed = <115200>;
+	};
+
+Interaction with serial ports can be configured in several different ways:
+
+* The default serial port and baud rate can be set via the device tree
+  properties ``serial-port`` and ``current-speed`` respectively.  The
+  ``serial-port`` property is optional.
+* Serial port and baud rate can also be set via command line options ``X_port``
+  and ``X_baud`` respectively, where ``X`` is a name of a node. Command line
+  options override values from the devicetree.
+* The rest of the configuration options such as number of data and stop bits,
+  parity, as well as baud rate can be set at runtime with ``uart_configure``.
+
+Multiple instances of such uart drivers are supported.
+
+The :ref:`sample-uart-native-tty` sample app provides a working example of the
+driver.
+
 Subsystems backends
 *******************
 
@@ -420,7 +465,7 @@ development by integrating more seamlessly with the host operating system:
   redirect any :c:func:`printk` write to the native host application's
   ``stdout``.
 
-  This driver is selected by default if the `UART`_ is not compiled in.
+  This driver is selected by default if the `PTTY UART`_ is not compiled in.
   Otherwise :kconfig:option:`CONFIG_UART_CONSOLE` will be set to select the UART as
   console backend.
 
@@ -437,7 +482,8 @@ development by integrating more seamlessly with the host operating system:
 
   This backend can be selected with :kconfig:option:`CONFIG_LOG_BACKEND_NATIVE_POSIX`
   and is enabled by default unless the native_posix UART is compiled in.
-  In this later case, by default, the logger is set to output to the `UART`_.
+  In this later case, by default, the logger is set to output to the
+  `PTTY UART`_.
 
 **Tracing**:
   A backend/"bottom" for Zephyr's CTF tracing subsystem which writes the tracing

--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -69,4 +69,9 @@ if(CONFIG_UART_NATIVE_POSIX)
   zephyr_library_sources(uart_native_posix.c)
 endif()
 
+if(CONFIG_UART_NATIVE_TTY)
+  zephyr_library_compile_definitions(NO_POSIX_CHEATS)
+  zephyr_library_sources(uart_native_tty.c)
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_SERIAL_TEST		serial_test.c)

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -218,4 +218,6 @@ source "drivers/serial/Kconfig.hostlink"
 
 source "drivers/serial/Kconfig.emul"
 
+source "drivers/serial/Kconfig.native_tty"
+
 endif # SERIAL

--- a/drivers/serial/Kconfig.native_tty
+++ b/drivers/serial/Kconfig.native_tty
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 Marko Sagadin
+# SPDX-License-Identifier: Apache-2.0
+config UART_NATIVE_TTY
+	bool "UART driver for interacting with host serial ports"
+	default y
+	depends on DT_HAS_ZEPHYR_NATIVE_TTY_UART_ENABLED
+	select SERIAL_HAS_DRIVER

--- a/drivers/serial/uart_native_tty.c
+++ b/drivers/serial/uart_native_tty.c
@@ -1,0 +1,454 @@
+/**
+ * @brief UART Driver for interacting with host serial ports
+ *
+ * @note  Driver can open and send characters to the host serial ports (such as /dev/ttyUSB0 or
+ * /dev/ttyACM0). Only polling Uart API is implemented. Driver can be configured via devicetree,
+ * command line options or at runtime.
+ *
+ * To learn more see Native TYY section at:
+ * https://docs.zephyrproject.org/latest/boards/posix/native_posix/doc/index.html
+ * or
+ * ${ZEPHYR_BASE}/boards/posix/native_posix/doc/index.rst
+ *
+ * Copyright (c) 2023 Marko Sagadin
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/kernel.h>
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <termios.h>
+#include <unistd.h>
+
+#include "cmdline.h"
+#include "posix_native_task.h"
+
+#define WARN(msg, ...)  posix_print_warning(msg, ##__VA_ARGS__)
+#define ERROR(msg, ...) posix_print_error_and_exit(msg, ##__VA_ARGS__)
+
+#define DT_DRV_COMPAT zephyr_native_tty_uart
+
+struct native_tty_data {
+	/* File descriptor used for the tty device. */
+	int fd;
+	/* Absolute path to the tty device. */
+	char *serial_port;
+	/* Baudrate set from the command line. If UINT32_MAX, it was not set. */
+	int cmd_baudrate;
+	/* Serial port set from the command line. If NULL, it was not set. */
+	char *cmd_serial_port;
+};
+
+struct native_tty_config {
+	struct uart_config uart_config;
+};
+
+struct baudrate_termios_pair {
+	int baudrate;
+	speed_t termios_baudrate;
+};
+
+/**
+ * @brief Lookup table for mapping the baud rate to the macro understood by termios.
+ */
+static const struct baudrate_termios_pair baudrate_lut[] = {
+	{1200, B1200},       {1800, B1800},       {2400, B2400},       {4800, B4800},
+	{9600, B9600},       {19200, B19200},     {38400, B38400},     {57600, B57600},
+	{115200, B115200},   {230400, B230400},   {460800, B460800},   {500000, B500000},
+	{576000, B576000},   {921600, B921600},   {1000000, B1000000}, {1152000, B1152000},
+	{1500000, B1500000}, {2000000, B2000000}, {2500000, B2500000}, {3000000, B3000000},
+	{3500000, B3500000}, {4000000, B4000000},
+};
+
+/**
+ * @brief Set given termios to defaults appropriate for communicating with serial port devices.
+ *
+ * @param ter
+ */
+static inline void native_tty_termios_defaults_set(struct termios *ter)
+{
+	/* Set terminal in "serial" mode:
+	 *  - Not canonical (no line input)
+	 *  - No signal generation from Ctr+{C|Z..}
+	 *  - No echoing
+	 */
+	ter->c_lflag &= ~(ICANON | ISIG | ECHO);
+
+	/* No special interpretation of output bytes.
+	 * No conversion of newline to carriage return/line feed.
+	 */
+	ter->c_oflag &= ~(OPOST | ONLCR);
+
+	/* No software flow control. */
+	ter->c_iflag &= ~(IXON | IXOFF | IXANY);
+
+	/* No blocking, return immediately with what is available. */
+	ter->c_cc[VMIN] = 0;
+	ter->c_cc[VTIME] = 0;
+
+	/* No special handling of bytes on receive. */
+	ter->c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL);
+
+	/* - Enable reading data and ignore control lines */
+	ter->c_cflag |= CREAD | CLOCAL;
+}
+
+/**
+ * @brief Set the baud rate speed in the termios structure
+ *
+ * @param ter
+ * @param baudrate
+ *
+ * @retval 0		If successful,
+ * @retval -ENOTSUP	If requested baud rate is not supported.
+ */
+static inline int native_tty_baud_speed_set(struct termios *ter, int baudrate)
+{
+	for (int i = 0; i < ARRAY_SIZE(baudrate_lut); i++) {
+		if (baudrate_lut[i].baudrate == baudrate) {
+			cfsetospeed(ter, baudrate_lut[i].termios_baudrate);
+			cfsetispeed(ter, baudrate_lut[i].termios_baudrate);
+			return 0;
+		}
+	}
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Set parity setting in the termios structure
+ *
+ * @param ter
+ * @param parity
+ *
+ * @retval 0		If successful.
+ * @retval -ENOTSUP	If requested parity is not supported.
+ */
+static inline int native_tty_baud_parity_set(struct termios *ter, enum uart_config_parity parity)
+{
+	switch (parity) {
+	case UART_CFG_PARITY_NONE:
+		ter->c_cflag &= ~PARENB;
+		break;
+	case UART_CFG_PARITY_ODD:
+		ter->c_cflag |= PARENB;
+		ter->c_cflag |= PARODD;
+		break;
+	case UART_CFG_PARITY_EVEN:
+		ter->c_cflag |= PARENB;
+		ter->c_cflag &= ~PARODD;
+		break;
+	default:
+		/* Parity options mark and space (UART_CFG_PARITY_MARK and UART_CFG_PARITY_SPACE)
+		 * are not supported on this driver.
+		 */
+		return -ENOTSUP;
+	}
+	return 0;
+}
+
+/**
+ * @brief Set the number of stop bits in the termios structure
+ *
+ * @param ter
+ * @param stop_bits
+ *
+ * @retval 0		If successful.
+ * @retval -ENOTSUP	If requested number of stop bits is not supported.
+ */
+static inline int native_tty_stop_bits_set(struct termios *ter,
+					   enum uart_config_stop_bits stop_bits)
+{
+	switch (stop_bits) {
+	case UART_CFG_STOP_BITS_1:
+		ter->c_cflag &= ~CSTOPB;
+		break;
+	case UART_CFG_STOP_BITS_2:
+		ter->c_cflag |= CSTOPB;
+		break;
+	default:
+		/* Anything else is not supported in termios. */
+		return -ENOTSUP;
+	}
+	return 0;
+}
+
+/**
+ * @brief Set the number of data bits in the termios structure
+ *
+ * @param ter
+ * @param stop_bits
+ *
+ * @retval 0		If successful.
+ * @retval -ENOTSUP	If requested number of data bits is not supported.
+ */
+static inline int native_tty_data_bits_set(struct termios *ter,
+					   enum uart_config_data_bits data_bits)
+{
+	unsigned int data_bits_to_set;
+
+	switch (data_bits) {
+	case UART_CFG_DATA_BITS_5:
+		data_bits_to_set = CS5;
+		break;
+	case UART_CFG_DATA_BITS_6:
+		data_bits_to_set = CS6;
+		break;
+	case UART_CFG_DATA_BITS_7:
+		data_bits_to_set = CS7;
+		break;
+	case UART_CFG_DATA_BITS_8:
+		data_bits_to_set = CS8;
+		break;
+	default:
+		/* Anything else is not supported in termios */
+		return -ENOTSUP;
+	}
+
+	/* Clear all bits that set the data size */
+	ter->c_cflag &= ~CSIZE;
+	ter->c_cflag |= data_bits_to_set;
+	return 0;
+}
+
+/*
+ * @brief Output a character towards the serial port
+ *
+ * @param dev		UART device structure.
+ * @param out_char	Character to send.
+ */
+static void native_tty_uart_poll_out(const struct device *dev, unsigned char out_char)
+{
+	struct native_tty_data *data = dev->data;
+
+	int ret = write(data->fd, &out_char, 1);
+
+	if (ret == -1) {
+		ERROR("Could not write to %s, reason: %s\n", data->serial_port, strerror(errno));
+	}
+}
+
+/**
+ * @brief Poll the device for input.
+ *
+ * @param dev		UART device structure.
+ * @param p_char	Pointer to a character.
+ *
+ * @retval 0	If a character arrived.
+ * @retval -1	If no character was available to read.
+ */
+static int native_tty_uart_poll_in(const struct device *dev, unsigned char *p_char)
+{
+	struct native_tty_data *data = dev->data;
+
+	return read(data->fd, p_char, 1) > 0 ? 0 : -1;
+}
+
+static int native_tty_configure(const struct device *dev, const struct uart_config *cfg)
+{
+	int rc, err;
+	int fd = ((struct native_tty_data *)dev->data)->fd;
+
+	/* Structure used to control properties of a serial port */
+	struct termios ter;
+
+	/* Read current terminal driver settings */
+	rc = tcgetattr(fd, &ter);
+	if (rc) {
+		WARN("Could not read terminal driver settings\n");
+		return rc;
+	}
+
+	native_tty_termios_defaults_set(&ter);
+
+	rc = native_tty_baud_speed_set(&ter, cfg->baudrate);
+	if (rc) {
+		WARN("Could not set baudrate, as %d is not supported.\n", cfg->baudrate);
+		return rc;
+	}
+
+	rc = native_tty_baud_parity_set(&ter, cfg->parity);
+	if (rc) {
+		WARN("Could not set parity.\n");
+		return rc;
+	}
+
+	rc = native_tty_stop_bits_set(&ter, cfg->stop_bits);
+	if (rc) {
+		WARN("Could not set number of data bits.\n");
+		return rc;
+	}
+
+	rc = native_tty_data_bits_set(&ter, cfg->data_bits);
+	if (rc) {
+		WARN("Could not set number of data bits.\n");
+		return rc;
+	}
+
+	if (cfg->flow_ctrl != UART_CFG_FLOW_CTRL_NONE) {
+		WARN("Could not set flow control, any kind of hw flow control is not supported.\n");
+		return -ENOTSUP;
+	}
+
+	rc = tcsetattr(fd, TCSANOW, &ter);
+	if (rc) {
+		err = errno;
+		WARN("Could not set serial port settings, reason: %s\n", strerror(err));
+		return err;
+	}
+
+	/* tcsetattr returns success if ANY of the requested changes were successfully carried out,
+	 * not if ALL were. So we need to read back the settings and check if they are equal to the
+	 * requested ones.
+	 */
+	struct termios read_ter;
+
+	rc = tcgetattr(fd, &read_ter);
+	if (rc) {
+		err = errno;
+		WARN("Could not read serial port settings, reason: %s\n", strerror(err));
+		return err;
+	}
+
+	if (ter.c_cflag != read_ter.c_cflag || ter.c_iflag != read_ter.c_iflag ||
+	    ter.c_oflag != read_ter.c_oflag || ter.c_lflag != read_ter.c_lflag ||
+	    ter.c_line != read_ter.c_line || ter.c_ispeed != read_ter.c_ispeed ||
+	    ter.c_ospeed != read_ter.c_ospeed || 0 != memcmp(ter.c_cc, read_ter.c_cc, NCCS)) {
+		WARN("Read serial port settings do not match set ones.\n");
+		return -EBADE;
+	}
+
+	/* Flush both input and output */
+	rc = tcflush(fd, TCIOFLUSH);
+	if (rc) {
+		WARN("Could not flush serial port\n");
+		return rc;
+	}
+
+	return 0;
+}
+
+static int native_tty_serial_init(const struct device *dev)
+{
+	struct native_tty_data *data = dev->data;
+	struct uart_config uart_config = ((struct native_tty_config *)dev->config)->uart_config;
+
+	/* Default value for cmd_serial_port is NULL, this is due to the set 's' type in command
+	 * line opts. If it is anything else then it was configured via command line.
+	 */
+	if (data->cmd_serial_port) {
+		data->serial_port = data->cmd_serial_port;
+	}
+
+	/* Default value for cmd_baudrate is UINT32_MAX, this is due to the set 'u' type in command
+	 * line opts. If it is anything else then it was configured via command line.
+	 */
+	if (data->cmd_baudrate != UINT32_MAX) {
+		uart_config.baudrate = data->cmd_baudrate;
+	}
+
+	/* Serial port needs to be set either in the devicetree or provided via command line opts,
+	 * if that is not the case, then abort.
+	 */
+	if (!data->serial_port) {
+		ERROR("%s: path to the serial port was not set.\n", dev->name);
+	}
+
+	/* Try to open a serial port as with read/write access, also prevent serial port
+	 * from becoming the controlling terminal.
+	 */
+	data->fd = open(data->serial_port, O_RDWR | O_NOCTTY);
+	if (data->fd < 0) {
+		ERROR("%s: failed to open serial port %s, reason: %s\n", dev->name,
+		      data->serial_port, strerror(errno));
+	}
+
+	if (native_tty_configure(dev, &uart_config)) {
+		ERROR("%s: could not configure serial port %s\n", dev->name, data->serial_port);
+	}
+
+	posix_print_trace("%s connected to the serial port: %s\n", dev->name, data->serial_port);
+
+	return 0;
+}
+
+static struct uart_driver_api native_tty_uart_driver_api = {
+	.poll_out = native_tty_uart_poll_out,
+	.poll_in = native_tty_uart_poll_in,
+	.configure = native_tty_configure,
+};
+
+#define NATIVE_TTY_INSTANCE(inst)                                                                  \
+	static const struct native_tty_config native_tty_##inst##_cfg = {                          \
+		.uart_config =                                                                     \
+			{                                                                          \
+				.data_bits = UART_CFG_DATA_BITS_8,                                 \
+				.flow_ctrl = UART_CFG_FLOW_CTRL_NONE,                              \
+				.parity = UART_CFG_PARITY_NONE,                                    \
+				.stop_bits = UART_CFG_STOP_BITS_1,                                 \
+				.baudrate = DT_INST_PROP(inst, current_speed),                     \
+			},                                                                         \
+	};                                                                                         \
+                                                                                                   \
+	static struct native_tty_data native_tty_##inst##_data = {                                 \
+		.serial_port = DT_INST_PROP_OR(inst, serial_port, NULL),                           \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, native_tty_serial_init, NULL, &native_tty_##inst##_data,       \
+			      &native_tty_##inst##_cfg, PRE_KERNEL_1, 55,                          \
+			      &native_tty_uart_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(NATIVE_TTY_INSTANCE);
+
+#define INST_NAME(inst) DEVICE_DT_NAME(DT_DRV_INST(inst))
+
+
+#define NATIVE_TTY_COMMAND_LINE_OPTS(inst)                                                         \
+	{                                                                                          \
+		.option = INST_NAME(inst) "_port",						   \
+		.name = "\"serial_port\"",                                                         \
+		.type = 's',                                                                       \
+		.dest = &native_tty_##inst##_data.cmd_serial_port,                                 \
+		.descript = "Set a serial port for " INST_NAME(inst) " uart device, "		   \
+		"overriding the one in devicetree.",						   \
+	},                                                                                         \
+	{											   \
+		.option = INST_NAME(inst) "_baud",						   \
+		.name = "baudrate",								   \
+		.type = 'u',									   \
+		.dest = &native_tty_##inst##_data.cmd_baudrate,					   \
+		.descript = "Set a baudrate for " INST_NAME(inst) " device, overriding the "	   \
+		"baudrate of " STRINGIFY(DT_INST_PROP(inst, current_speed))			   \
+		"set in the devicetree.",							   \
+	},
+
+/**
+ * @brief Adds command line options for setting serial port and baud rate for each uart device.
+ */
+static void native_tty_add_serial_options(void)
+{
+	static struct args_struct_t opts[] = {
+		DT_INST_FOREACH_STATUS_OKAY(NATIVE_TTY_COMMAND_LINE_OPTS) ARG_TABLE_ENDMARKER};
+
+	native_add_command_line_opts(opts);
+}
+
+#define NATIVE_TTY_CLEANUP(inst)                                                                   \
+	if (native_tty_##inst##_data.fd != 0) {                                                    \
+		close(native_tty_##inst##_data.fd);                                                \
+	}
+
+/**
+ * @brief Cleans up any open serial ports on the exit.
+ */
+static void native_tty_cleanup_uart(void)
+{
+	DT_INST_FOREACH_STATUS_OKAY(NATIVE_TTY_CLEANUP);
+}
+
+NATIVE_TASK(native_tty_add_serial_options, PRE_BOOT_1, 11);
+NATIVE_TASK(native_tty_cleanup_uart, ON_EXIT, 99);

--- a/dts/bindings/serial/zephyr,native-tty-uart.yaml
+++ b/dts/bindings/serial/zephyr,native-tty-uart.yaml
@@ -1,0 +1,40 @@
+description: Native TTY UART
+
+include: uart-controller.yaml
+
+compatible: "zephyr,native-tty-uart"
+bus: uart
+
+properties:
+  serial-port:
+    type: string
+    description: |
+      Full path to the serial port device, such as "/dev/ttyUSB0" or
+      "/dev/ttyACM0".
+  current-speed:
+    description: |
+      Initial baud rate setting for UART. Only a fixed set of baud rates are
+      selectable on these devices.
+    enum:
+      - 1200
+      - 1800
+      - 2400
+      - 4800
+      - 9600
+      - 19200
+      - 38400
+      - 57600
+      - 115200
+      - 230400
+      - 460800
+      - 500000
+      - 576000
+      - 921600
+      - 1000000
+      - 1152000
+      - 1500000
+      - 2000000
+      - 2500000
+      - 3000000
+      - 3500000
+      - 4000000

--- a/samples/drivers/uart/native_tty/CMakeLists.txt
+++ b/samples/drivers/uart/native_tty/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(native_tty)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS on)
+zephyr_compile_options(-fdiagnostics-color=always)
+
+file(GLOB app_sources src/main.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/drivers/uart/native_tty/README.rst
+++ b/samples/drivers/uart/native_tty/README.rst
@@ -1,0 +1,96 @@
+.. _sample-uart-native-tty:
+
+Native TTY UART
+###############
+
+Overview
+********
+
+This sample demonstrates the usage of the Native TTY UART driver. It uses two
+UART to USB bridge dongles that are wired together, writing demo data to one
+dongle and reading it from the other."
+
+The source code for this sample application can be found at:
+:zephyr_file:`samples/drivers/uart/native-tty`.
+
+You can learn more about the Native TTY UART driver in the
+:ref:`TTY UART <native_tty_uart>` section of the Native posix board
+documentation.
+
+Requirements
+************
+
+#. Two UART to USB bridge dongles. Each dongle must have its TX pin wired to the
+   other dongle's RX pin. The ground connection is not needed. Both dongles must
+   be plugged into the host machine.
+#. The DT overlay provided with the sample expects the dongles to appear as
+   ``/dev/ttyUSB0`` and ``/dev/ttyUSB1`` in the system. You can check what they
+   are in your system by running the command ``ls -l /dev/tty*``. If that is not
+   the case on your machine you can either change the ``serial-port`` properties
+   in the ``boards/native_posix.overlay`` file or using the command line options
+   ``-uart_port`` and ``-uart_port2``.
+
+Building and Running
+********************
+
+This application can be built and executed on Native Posix as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/uart/native_tty
+   :host-os: unix
+   :board: native_posix
+   :goals: run
+   :compact:
+
+Sample Output
+=============
+
+.. code-block:: console
+
+   uart_1 connected to pseudotty: /dev/pts/6
+   uart2 connected to the serial port: /dev/ttyUSB1
+   uart connected to the serial port: /dev/ttyUSB0
+   *** Booting Zephyr OS build v3.4.0-rc2-97-ge586d02c137d ***
+   Device uart sent: "Hello from device uart, num 9"
+   Device uart2 received: "Hello from device uart, num 9"
+   Device uart sent: "Hello from device uart, num 8"
+   Device uart2 received: "Hello from device uart, num 8"
+   Device uart sent: "Hello from device uart, num 7"
+   Device uart2 received: "Hello from device uart, num 7"
+   Device uart sent: "Hello from device uart, num 6"
+   Device uart2 received: "Hello from device uart, num 6"
+   Device uart sent: "Hello from device uart, num 5"
+   Device uart2 received: "Hello from device uart, num 5"
+   Device uart sent: "Hello from device uart, num 4"
+   Device uart2 received: "Hello from device uart, num 4"
+   Device uart sent: "Hello from device uart, num 3"
+   Device uart2 received: "Hello from device uart, num 3"
+   Device uart sent: "Hello from device uart, num 2"
+   Device uart2 received: "Hello from device uart, num 2"
+   Device uart sent: "Hello from device uart, num 1"
+   Device uart2 received: "Hello from device uart, num 1"
+   Device uart sent: "Hello from device uart, num 0"
+   Device uart2 received: "Hello from device uart, num 0"
+
+   Changing baudrate of both uart devices to 9600!
+
+   Device uart sent: "Hello from device uart, num 9"
+   Device uart2 received: "Hello from device uart, num 9"
+   Device uart sent: "Hello from device uart, num 8"
+   Device uart2 received: "Hello from device uart, num 8"
+   Device uart sent: "Hello from device uart, num 7"
+   Device uart2 received: "Hello from device uart, num 7"
+   Device uart sent: "Hello from device uart, num 6"
+   Device uart2 received: "Hello from device uart, num 6"
+   Device uart sent: "Hello from device uart, num 5"
+   Device uart2 received: "Hello from device uart, num 5"
+   Device uart sent: "Hello from device uart, num 4"
+   Device uart2 received: "Hello from device uart, num 4"
+   Device uart sent: "Hello from device uart, num 3"
+   Device uart2 received: "Hello from device uart, num 3"
+   Device uart sent: "Hello from device uart, num 2"
+   Device uart2 received: "Hello from device uart, num 2"
+   Device uart sent: "Hello from device uart, num 1"
+   Device uart2 received: "Hello from device uart, num 1"
+   Device uart sent: "Hello from device uart, num 0"
+   Device uart2 received: "Hello from device uart, num 0"

--- a/samples/drivers/uart/native_tty/boards/native_posix.overlay
+++ b/samples/drivers/uart/native_tty/boards/native_posix.overlay
@@ -1,0 +1,15 @@
+/ {
+	uart0: uart {
+		status = "okay";
+		compatible = "zephyr,native-tty-uart";
+		current-speed = <115200>;
+		serial-port = "/dev/ttyUSB0";
+	};
+
+	uart2: uart2 {
+		status = "okay";
+		compatible = "zephyr,native-tty-uart";
+		current-speed = <115200>;
+		serial-port = "/dev/ttyUSB1";
+	};
+};

--- a/samples/drivers/uart/native_tty/prj.conf
+++ b/samples/drivers/uart/native_tty/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_SERIAL=y

--- a/samples/drivers/uart/native_tty/sample.yaml
+++ b/samples/drivers/uart/native_tty/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+  name: Native TTY sample
+tests:
+  sample.drivers.uart.native_tty:
+    build_only: true
+    platform_allow: native_posix
+    tags:
+      - serial
+      - uart

--- a/samples/drivers/uart/native_tty/src/main.c
+++ b/samples/drivers/uart/native_tty/src/main.c
@@ -1,0 +1,92 @@
+/*
+ * @brief Native TTY UART sample
+ *
+ * Copyright (c) 2023 Marko Sagadin
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+
+#include <stdio.h>
+#include <string.h>
+
+const struct device *uart0 = DEVICE_DT_GET(DT_NODELABEL(uart0));
+const struct device *uart2 = DEVICE_DT_GET(DT_NODELABEL(uart2));
+
+struct uart_config uart_cfg = {
+	.baudrate = 9600,
+	.parity = UART_CFG_PARITY_NONE,
+	.stop_bits = UART_CFG_STOP_BITS_1,
+	.flow_ctrl = UART_CFG_FLOW_CTRL_NONE,
+	.data_bits = UART_CFG_DATA_BITS_8,
+};
+
+void send_str(const struct device *uart, char *str)
+{
+	int msg_len = strlen(str);
+
+	for (int i = 0; i < msg_len; i++) {
+		uart_poll_out(uart, str[i]);
+	}
+
+	printk("Device %s sent: \"%s\"\n", uart->name, str);
+}
+
+void recv_str(const struct device *uart, char *str)
+{
+	char *head = str;
+	char c;
+
+	while (!uart_poll_in(uart, &c)) {
+		*head++ = c;
+	}
+	*head = '\0';
+
+	printk("Device %s received: \"%s\"\n", uart->name, str);
+}
+
+int main(void)
+{
+	int rc;
+	char send_buf[64];
+	char recv_buf[64];
+	int i = 10;
+
+	while (i--) {
+		snprintf(send_buf, 64, "Hello from device %s, num %d", uart0->name, i);
+		send_str(uart0, send_buf);
+		/* Wait some time for the messages to arrive to the second uart. */
+		k_sleep(K_MSEC(100));
+		recv_str(uart2, recv_buf);
+
+		k_sleep(K_MSEC(1000));
+	}
+
+	uart_cfg.baudrate = 9600;
+	printk("\nChanging baudrate of both uart devices to %d!\n\n", uart_cfg.baudrate);
+
+	rc = uart_configure(uart0, &uart_cfg);
+	if (rc) {
+		printk("Could not configure device %s", uart0->name);
+	}
+	rc = uart_configure(uart2, &uart_cfg);
+	if (rc) {
+		printk("Could not configure device %s", uart2->name);
+	}
+
+	i = 10;
+	while (i--) {
+		snprintf(send_buf, 64, "Hello from device %s, num %d", uart0->name, i);
+		send_str(uart0, send_buf);
+		/* Wait some time for the messages to arrive to the second uart. */
+		k_sleep(K_MSEC(100));
+		recv_str(uart2, recv_buf);
+
+		k_sleep(K_MSEC(1000));
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Add support for communication with serial ports on native POSIX platform via UART driver API. Serial port driver supports polling API, configuration of the serial ports used via devicetree and command line options, and runtime configuration with `uart_configure`. Multiple instances of the driver are supported.

Closes: #56586

## Extra

I have two questions/things to discuss regarding the introduced changes:
1. I have added some minor documentation to the Native Posix page. I wanted to locally build the html content to see the added changes. I managed to get the build system running within Conda environment, even past the point where I could resolve some syntax issues, but now I am at the point where I get an `EOFError` from Python's multiprocessing lib. I can not validate locally that my changes are really ok.  I guess that there is probably CI check in place for validating the documentation, or someone can take the branch and build the docs. (See below toggles for the Sphinx output and log)
2. There is currently no code in the project that at least includes the driver and tries to compile it. This could be done with a small sample. I have two UART/USB dongles at hand that I could connect, plug in the laptop and write some code that ping-pongs messages between them. Would that be sufficient? I am open to any other propositions as well. 

<details><summary>Errors from Sphinx </summary>
<p>
<pre><code>~/Work/zephyr_native_posix_serial/zephyr/doc native_posix_serial_port*
test ❯ make html
cmake \
        -GNinja \
        -B_build \
        -S. \
        -DDOC_TAG=development \
        -DSPHINXOPTS="-j auto" \
        -DLATEXMKOPTS="-halt-on-error -no-shell-escape" \
        -DDT_TURBO_MODE=0
Loading Zephyr module(s) (Zephyr base (cached)): doc
-- Cache files will be written to: /home/skobec/.cache/zephyr
-- Found west (found suitable version "1.0.0", minimum required is "1.0.0")
-- Zephyr base: /home/skobec/Work/zephyr_native_posix_serial/zephyr
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_build
cmake --build _build --target html
[0/2] Generating Devicetree bindings documentation...
[1/2] Running Sphinx HTML build...
Running Sphinx v5.3.0
Building Kconfig database...... warning: LV_Z_FULL_REFRESH (defined at boards/arm/mimxrt1060_evk/Kconfig.defconfig:69, boards/arm/mimxrt1170_evk/Kconfig.defconfig:94, boards/arm/mimxrt595_evk/Kconfig.defconfig:59) defined without a type
warning: LV_Z_VDB_ALIGN (defined at boards/arm/mimxrt1060_evk/Kconfig.defconfig:79, boards/arm/mimxrt595_evk/Kconfig.defconfig:69) defined without a type
warning: LV_Z_VBD_CUSTOM_SECTION (defined at boards/arm/mimxrt595_evk/Kconfig.defconfig:74) defined without a type
done
Preparing Doxyfile...
Checking if Doxygen needs to be run...
Running Doxygen...
Syncing Doxygen output...
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 2844 source files that are out of date
updating environment: [new config] 2855 added, 0 changed, 0 removed
reading sources... [ 80%] kernel/services/other/atomic .. releases/release-notes-1.12
Exception occurred:
  File "/home/skobec/miniconda3/envs/test/lib/python3.8/multiprocessing/connection.py", line 383, in _recv
    raise EOFError
EOFError
The full traceback has been saved in /tmp/sphinx-err-t_h1q3p9.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
FAILED: CMakeFiles/html /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_build/CMakeFiles/html
cd /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_build && /usr/bin/cmake -E env DOXYGEN_EXECUTABLE=/usr/bin/doxygen DOT_EXECUTABLE=/usr/bin/dot /home/skobec/miniconda3/envs/test/bin/sphinx-build -b html -c /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc -d /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_build/doctrees -w /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_build/html.log -t development -j auto /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_build/src /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_build/html
ninja: build stopped: subcommand failed.
make: *** [Makefile:20: html] Error 1
</code></pre>
</p>
</details> 

<details><summary>Sphinx log file</summary>
<p>
<pre><code># Sphinx version: 5.3.0
# Python version: 3.8.16 (CPython)
# Docutils version: 0.18.1 release
# Jinja2 version: 3.1.2
# Last messages:
#   reading sources... [ 67%] build/dts/api/compatibles/nxp,fxas21002 .. build/kconfig/preprocessor-functions
#   reading sources... [ 69%] build/kconfig/setting .. connectivity/bluetooth/api/mesh/heartbeat
#   reading sources... [ 70%] connectivity/bluetooth/api/mesh/models .. connectivity/bluetooth/index
#   reading sources... [ 72%] connectivity/bluetooth/l2cap-pics .. connectivity/networking/api/net_tech
#   reading sources... [ 73%] connectivity/networking/api/net_timeout .. contribute/index
#   reading sources... [ 75%] contribute/proposals_and_rfcs .. develop/toolchains/custom_cmake
#   reading sources... [ 76%] develop/toolchains/designware_arc_mwdt .. hardware/peripherals/audio/index
#   reading sources... [ 77%] hardware/peripherals/auxdisplay .. hardware/peripherals/smbus
#   reading sources... [ 79%] hardware/peripherals/spi .. kernel/services/interrupts
#   reading sources... [ 80%] kernel/services/other/atomic .. releases/release-notes-1.12
# Loaded extensions:
#   sphinx.ext.mathjax (5.3.0) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/ext/mathjax.py
#   sphinxcontrib.applehelp (1.0.4) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinxcontrib/applehelp/__init__.py
#   sphinxcontrib.devhelp (1.0.2) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinxcontrib/devhelp/__init__.py
#   sphinxcontrib.htmlhelp (2.0.1) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinxcontrib/htmlhelp/__init__.py
#   sphinxcontrib.serializinghtml (1.1.5) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinxcontrib/serializinghtml/__init__.py
#   sphinxcontrib.qthelp (1.0.3) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinxcontrib/qthelp/__init__.py
#   alabaster (0.7.13) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/alabaster/__init__.py
#   breathe (4.35.0) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/breathe/__init__.py
#   sphinx.ext.todo (5.3.0) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/ext/todo.py
#   sphinx.ext.extlinks (5.3.0) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/ext/extlinks.py
#   sphinx.ext.autodoc.preserve_defaults (5.3.0) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/ext/autodoc/preserve_defaults.py
#   sphinx.ext.autodoc.type_comment (5.3.0) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/ext/autodoc/type_comment.py
#   sphinx.ext.autodoc.typehints (5.3.0) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/ext/autodoc/typehints.py
#   sphinx.ext.autodoc (5.3.0) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/ext/autodoc/__init__.py
#   sphinx.ext.graphviz (5.3.0) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/ext/graphviz.py
#   zephyr.application (1.0) from /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_extensions/zephyr/application.py
#   zephyr.html_redirects (unknown version) from /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_extensions/zephyr/html_redirects.py
#   zephyr.kconfig (0.1.0) from /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_extensions/zephyr/kconfig/__init__.py
#   zephyr.dtcompatible-role (unknown version) from /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_extensions/zephyr/dtcompatible-role.py
#   zephyr.link-roles (unknown version) from /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_extensions/zephyr/link-roles.py
#   sphinx_tabs.tabs (unknown version) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx_tabs/tabs.py
#   zephyr.warnings_filter (0.1.0) from /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_extensions/zephyr/warnings_filter.py
#   zephyr.doxyrunner (0.1.0) from /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_extensions/zephyr/doxyrunner.py
#   zephyr.vcs_link (0.1.0) from /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_extensions/zephyr/vcs_link.py
#   notfound.extension (0.8.3) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/notfound/extension.py
#   sphinx_copybutton (0.5.2) from /home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx_copybutton/__init__.py
#   zephyr.external_content (0.1.0) from /home/skobec/Work/zephyr_native_posix_serial/zephyr/doc/_extensions/zephyr/external_content.py
Traceback (most recent call last):
  File "/home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/cmd/build.py", line 281, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/application.py", line 347, in build
    self.builder.build_update()
  File "/home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 310, in build_update
    self.build(to_build,
  File "/home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 326, in build
    updated_docnames = set(self.read())
  File "/home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 431, in read
    self._read_parallel(docnames, nproc=self.app.parallel)
  File "/home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 487, in _read_parallel
    tasks.join()
  File "/home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/util/parallel.py", line 105, in join
    if not self._join_one():
  File "/home/skobec/miniconda3/envs/test/lib/python3.8/site-packages/sphinx/util/parallel.py", line 124, in _join_one
    exc, logs, result = pipe.recv()
  File "/home/skobec/miniconda3/envs/test/lib/python3.8/multiprocessing/connection.py", line 250, in recv
    buf = self._recv_bytes()
  File "/home/skobec/miniconda3/envs/test/lib/python3.8/multiprocessing/connection.py", line 414, in _recv_bytes
    buf = self._recv(4)
  File "/home/skobec/miniconda3/envs/test/lib/python3.8/multiprocessing/connection.py", line 383, in _recv
    raise EOFError
EOFError
</code></pre>
</p>
</details> 