### PR TITLE
boards: kv260_r5: should not marked as default twister board

### DIFF
--- a/boards/arm/kv260_r5/kv260_r5.yaml
+++ b/boards/arm/kv260_r5/kv260_r5.yaml
@@ -6,7 +6,6 @@ toolchain:
 ram: 65536
 flash: 32768
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth


### PR DESCRIPTION
This platform does not support simulation, it should not be built by CI
by default.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
