### PR TITLE
manifest: zscilib: update to latest ztest API

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -265,7 +265,7 @@ manifest:
       path: modules/lib/zcbor
     - name: zscilib
       path: modules/lib/zscilib
-      revision: 0035be5e6a45e4ab89755b176d305d7a877fc79c
+      revision: 34c3432e81085bb717e4871d21ca419ae0058ec5
     - name: thrift
       path: modules/lib/thrift
       revision: 10023645a0e6cb7ce23fcd7fd3dbac9f18df6234


### PR DESCRIPTION
Includes an update for compatibility with the latest ztest API.