### PR TITLE
samples: cfb: support MONO01 pixel format

### DIFF
--- a/samples/subsys/display/cfb/src/main.c
+++ b/samples/subsys/display/cfb/src/main.c
@@ -24,8 +24,10 @@ int main(void)
 	}
 
 	if (display_set_pixel_format(dev, PIXEL_FORMAT_MONO10) != 0) {
-		printf("Failed to set required pixel format\n");
-		return 0;
+		if (display_set_pixel_format(dev, PIXEL_FORMAT_MONO01) != 0) {
+			printf("Failed to set required pixel format");
+			return 0;
+		}
 	}
 
 	printf("Initialized %s\n", dev->name);

--- a/samples/subsys/display/cfb_custom_font/src/main.c
+++ b/samples/subsys/display/cfb_custom_font/src/main.c
@@ -21,8 +21,10 @@ int main(void)
 	}
 
 	if (display_set_pixel_format(display, PIXEL_FORMAT_MONO10) != 0) {
-		printk("Failed to set required pixel format\n");
-		return 0;
+		if (display_set_pixel_format(display, PIXEL_FORMAT_MONO01) != 0) {
+			printk("Failed to set required pixel format");
+			return 0;
+		}
 	}
 
 	if (display_blanking_off(display) != 0) {


### PR DESCRIPTION
When the pixel format fails to set to MONO10, try to set it to MONO01.