### PR TITLE
net: lib: lwm2m: add missing #include to lwm2m_rd_client.h

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.h
@@ -38,6 +38,8 @@
 #ifndef LWM2M_RD_CLIENT_H
 #define LWM2M_RD_CLIENT_H
 
+#include <zephyr/net/lwm2m.h> /* struct lwm2m_ctx */
+
 int lwm2m_rd_client_init(void);
 void engine_trigger_update(bool update_objects);
 int engine_trigger_bootstrap(void);


### PR DESCRIPTION
Definition for 'struct lwm2m_ctx' was missing and build warnings were generated.