### PR TITLE
drivers: serial: stm32 uart driver asserts when baudRate >=16

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -188,7 +188,7 @@ static inline void uart_stm32_set_baudrate(const struct device *dev, uint32_t ba
 #endif
 				     baud_rate);
 		/* Check BRR is greater than or equal to 16d */
-		__ASSERT(LL_USART_ReadReg(config->usart, BRR) > 16,
+		__ASSERT(LL_USART_ReadReg(config->usart, BRR) >= 16,
 			 "BaudRateReg >= 16");
 
 #if HAS_LPUART_1


### PR DESCRIPTION
Change the assertion when evaluating the baudrate to trig if result is greater or equal to 16.
This will also match the comment : checking BRR.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/58250

Signed-off-by: Francois Ramu <francois.ramu@st.com>