### PR TITLE
drivers: sensor: bq274xx: add support for fetch SENSOR_CHAN_ALL

### DIFF
--- a/drivers/sensor/bq274xx/bq274xx_trigger.c
+++ b/drivers/sensor/bq274xx/bq274xx_trigger.c
@@ -69,7 +69,7 @@ int bq274xx_trigger_mode_init(const struct device *dev)
 {
 	const struct bq274xx_config *const config = dev->config;
 	struct bq274xx_data *data = dev->data;
-	int ret = 0;
+	int ret;
 
 	data->dev = dev;
 


### PR DESCRIPTION
Sensor extension for shell executes "fetch all" operation before getting the sensor readings.