### PR TITLE
drivers: sensors: npcx_tach: Clear stale data

### DIFF
--- a/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -259,6 +259,8 @@ int tach_npcx_sample_fetch(const struct device *dev, enum sensor_channel chan)
 	if (tach_npcx_is_underflow(dev)) {
 		/* Clear pending flags */
 		tach_npcx_clear_underflow_flag(dev);
+		/* Clear stale captured data */
+		tach_npcx_clear_captured_flag(dev);
 		data->capture = 0;
 
 		return 0;


### PR DESCRIPTION
Tachometer collect data continuously setting a "data ready" bit when the data is available.
The availability bit has to be cleared before the register is updated.
The driver also supports underflow detection, when the bit indicating it is set the reading of "0" is returned.
The problem here is that there is that once the underflow bit is cleared we might end up reading stale data.
To prevent that clear the "data ready" bit when underflow is detected