### PR TITLE
west: build: keep kconfig quotes from testcase.yaml

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -285,7 +285,7 @@ class Build(Forceable):
                     arg_list = extra.split(" ")
                 else:
                     arg_list = extra
-                args = ["-D{}".format(arg.replace('"', '')) for arg in arg_list]
+                args = ["-D{}".format(arg.replace('"', '\"')) for arg in arg_list]
                 if self.args.cmake_opts:
                     self.args.cmake_opts.extend(args)
                 else:


### PR DESCRIPTION
When parsing extra configs from the yaml file, keep quotes.

Fixes #56248

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
