### PR TITLE
test: Change loop calibration count initialization

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -385,7 +385,7 @@ ZTEST(context_cpu_idle, test_cpu_idle_atomic)
 static void _test_kernel_interrupts(disable_int_func disable_int,
 				    enable_int_func enable_int, int irq)
 {
-	unsigned long long count = 0;
+	unsigned long long count = 1ull;
 	unsigned long long i = 0;
 	int tick;
 	int tick2;


### PR DESCRIPTION
The kernel/context test_timer_interrupts() test has a loop calibration phase to estimate the number of loops needed for 1 system tick. By initializing this calibration to 1 instead of 0, we can avoid an edge condition where the calibration phase indicates 0 loops are required (a case that could happen when running on a slow simulator).