### PR TITLE
twister: coverage: set coverage platforms default to an empty list

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -483,7 +483,7 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
                         """)
 
     parser.add_argument(
-        "-p", "--platform", action="append",
+        "-p", "--platform", action="append", default=[],
         help="Platform filter for testing. This option may be used multiple "
              "times. Test suites will only be built/run on the platforms "
              "specified. If this option is not used, then platforms marked "


### PR DESCRIPTION
When calling twister with --coverage and no platform specified on the
command line, set the the value of coverage platforms to an empty list.

Fixes #57534

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
