### PR TITLE
Improve ROUND_UP and ROUND_DOWN macros

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -224,19 +224,17 @@ extern "C" {
 	((type *)(((char *)(ptr)) - offsetof(type, field)))
 
 /**
- * @brief Value of @p x rounded up to the next multiple of @p align,
- *        which must be a power of 2.
+ * @brief Value of @p x rounded up to the next multiple of @p align.
  */
 #define ROUND_UP(x, align)                                   \
-	(((unsigned long)(x) + ((unsigned long)(align) - 1)) & \
-	 ~((unsigned long)(align) - 1))
+	((((unsigned long)(x) + ((unsigned long)(align) - 1)) / \
+	  (unsigned long)(align)) * (unsigned long)(align))
 
 /**
- * @brief Value of @p x rounded down to the previous multiple of @p
- *        align, which must be a power of 2.
+ * @brief Value of @p x rounded down to the previous multiple of @p align.
  */
 #define ROUND_DOWN(x, align)                                 \
-	((unsigned long)(x) & ~((unsigned long)(align) - 1))
+	(((unsigned long)(x) / (unsigned long)(align)) * (unsigned long)(align))
 
 /** @brief Value of @p x rounded up to the next word boundary. */
 #define WB_UP(x) ROUND_UP(x, sizeof(void *))


### PR DESCRIPTION
This PR improves the utility macros `ROUND_UP` and `ROUND_DOWN` to work with alignments that are not a power of 2.