### PR TITLE
net: openthread: Fix `OPENTHREAD_FTD` dependency.

### DIFF
--- a/modules/openthread/Kconfig.features
+++ b/modules/openthread/Kconfig.features
@@ -287,3 +287,4 @@ config OPENTHREAD_UDP_FORWARD
 
 config OPENTHREAD_UPTIME
 	bool "Openthread uptime counter"
+	default y if OPENTHREAD_FTD


### PR DESCRIPTION
Thic commit fixes `OPENTHREAD_FTD` dependency to `OPENTHREAD_UPTIME`.