### PR TITLE
Fix ESP32 linker issues and update the Soc init

### DIFF
--- a/soc/xtensa/esp32s3/default.ld
+++ b/soc/xtensa/esp32s3/default.ld
@@ -46,18 +46,14 @@
 #endif
 
 #ifdef CONFIG_BOOTLOADER_ESP_IDF
-
 #define IROM_SEG_ORG 0x42000020
 #define IROM_SEG_LEN FLASH_SIZE-0x20
-#define IROM_SEG_ALIGN 0x4
-
 #else
-
 #define IROM_SEG_ORG 0x42000000
 #define IROM_SEG_LEN FLASH_SIZE
-#define IROM_SEG_ALIGN 0x10000
-
 #endif
+
+#define IROM_SEG_ALIGN 0x10000
 
 MEMORY
 {

--- a/soc/xtensa/esp32s3/soc.c
+++ b/soc/xtensa/esp32s3/soc.c
@@ -40,16 +40,23 @@
 #include <zephyr/sys/printk.h>
 
 extern void z_cstart(void);
-extern void rom_config_instruction_cache_mode(uint32_t cfg_cache_size, uint8_t cfg_cache_ways,
-					      uint8_t cfg_cache_line_size);
-extern void rom_config_data_cache_mode(uint32_t cfg_cache_size, uint8_t cfg_cache_ways,
-				       uint8_t cfg_cache_line_size);
-extern uint32_t Cache_Set_IDROM_MMU_Size(uint32_t irom_size, uint32_t drom_size);
-extern void Cache_Set_IDROM_MMU_Info(uint32_t instr_page_num, uint32_t rodata_page_num,
-				     uint32_t rodata_start, uint32_t rodata_end, int i_off,
-				     int ro_off);
-extern int _rodata_reserved_start;
-extern int _rodata_reserved_end;
+
+#ifndef CONFIG_MCUBOOT
+static void IRAM_ATTR esp_errata(void)
+{
+	REG_CLR_BIT(SYSTEM_CORE_1_CONTROL_0_REG, SYSTEM_CONTROL_CORE_1_CLKGATE_EN);
+	/* The clock gating signal of the App core is invalid. We use RUNSTALL and RESETTING
+	 * signals to ensure that the App core stops running in single-core mode.
+	 */
+	REG_SET_BIT(SYSTEM_CORE_1_CONTROL_0_REG, SYSTEM_CONTROL_CORE_1_RUNSTALL);
+	REG_CLR_BIT(SYSTEM_CORE_1_CONTROL_0_REG, SYSTEM_CONTROL_CORE_1_RESETTING);
+
+#if CONFIG_ESP32S3_DATA_CACHE_16KB
+	Cache_Invalidate_DCache_All();
+	Cache_Occupy_Addr(SOC_DROM_LOW, 0x4000);
+#endif
+}
+#endif /* CONFIG_MCUBOOT */
 
 /*
  * This is written in C rather than assembly since, during the port bring up,
@@ -58,7 +65,6 @@ extern int _rodata_reserved_end;
  */
 void IRAM_ATTR __esp_platform_start(void)
 {
-	volatile soc_reset_reason_t rst_reas[SOC_CPU_CORES_NUM];
 	extern uint32_t _init_start;
 
 	/* Move the exception vector table to IRAM. */
@@ -82,39 +88,15 @@ void IRAM_ATTR __esp_platform_start(void)
 	}
 #else
 	/* Configure the mode of instruction cache : cache size, cache line size. */
-	rom_config_instruction_cache_mode(CONFIG_ESP32S3_INSTRUCTION_CACHE_SIZE,
-					CONFIG_ESP32S3_ICACHE_ASSOCIATED_WAYS,
-					CONFIG_ESP32S3_INSTRUCTION_CACHE_LINE_SIZE);
+	esp_config_instruction_cache_mode();
 
 	/* If we need use SPIRAM, we should use data cache.
 	 * Configure the mode of data : cache size, cache line size.
 	 */
-	Cache_Suspend_DCache();
-	rom_config_data_cache_mode(CONFIG_ESP32S3_DATA_CACHE_SIZE,
-				CONFIG_ESP32S3_DCACHE_ASSOCIATED_WAYS,
-				CONFIG_ESP32S3_DATA_CACHE_LINE_SIZE);
-	Cache_Resume_DCache(0);
-	/* Configure the Cache MMU size for instruction and rodata in flash. */
-	uint32_t rodata_reserved_start_align =
-		(uint32_t)&_rodata_reserved_start & ~(MMU_PAGE_SIZE - 1);
-	uint32_t cache_mmu_irom_size =
-		((rodata_reserved_start_align - SOC_DROM_LOW) / MMU_PAGE_SIZE) * sizeof(uint32_t);
-	uint32_t cache_mmu_drom_size =
-		(((uint32_t)&_rodata_reserved_end - rodata_reserved_start_align + MMU_PAGE_SIZE - 1)
-		 / MMU_PAGE_SIZE) * sizeof(uint32_t);
-	Cache_Set_IDROM_MMU_Size(cache_mmu_irom_size, CACHE_DROM_MMU_MAX_END - cache_mmu_irom_size);
+	esp_config_data_cache_mode();
 
-	REG_CLR_BIT(SYSTEM_CORE_1_CONTROL_0_REG, SYSTEM_CONTROL_CORE_1_CLKGATE_EN);
-	/* The clock gating signal of the App core is invalid. We use RUNSTALL and RESETTING
-	 * signals to ensure that the App core stops running in single-core mode.
-	 */
-	REG_SET_BIT(SYSTEM_CORE_1_CONTROL_0_REG, SYSTEM_CONTROL_CORE_1_RUNSTALL);
-	REG_CLR_BIT(SYSTEM_CORE_1_CONTROL_0_REG, SYSTEM_CONTROL_CORE_1_RESETTING);
-
-#if CONFIG_ESP32S3_DATA_CACHE_16KB
-	Cache_Invalidate_DCache_All();
-	Cache_Occupy_Addr(SOC_DROM_LOW, 0x4000);
-#endif
+	/* Apply fixes */
+	esp_errata();
 
 	/* ESP-IDF/MCUboot 2nd stage bootloader enables RTC WDT to check on startup sequence
 	 * related issues in application. Hence disable that as we are about to start

--- a/soc/xtensa/esp32s3/soc_cache.c
+++ b/soc/xtensa/esp32s3/soc_cache.c
@@ -6,99 +6,43 @@
 
 #include "soc.h"
 
-/*
- * Instruction Cache definitions
- */
-#if defined(CONFIG_ESP32S3_INSTRUCTION_CACHE_16KB)
-#define ESP32S3_ICACHE_SIZE ICACHE_SIZE_16KB
-#else
-#define ESP32S3_ICACHE_SIZE ICACHE_SIZE_32KB
-#endif
-
-#if defined(CONFIG_ESP32S3_INSTRUCTION_CACHE_LINE_16B)
-#define ESP32S3_ICACHE_LINE_SIZE CACHE_LINE_SIZE_16B
-#else
-#define ESP32S3_ICACHE_LINE_SIZE CACHE_LINE_SIZE_32B
-#endif
-
-/*
- * Data Cache definitions
- */
-#if defined(CONFIG_ESP32S3_DATA_CACHE_16KB) || defined(CONFIG_ESP32S3_DATA_CACHE_32KB)
-#define ESP32S3_DCACHE_SIZE DCACHE_SIZE_32KB
-#else
-#define ESP32S3_DCACHE_SIZE DCACHE_SIZE_64KB
-#endif
-
-#if defined(CONFIG_ESP32S3_DATA_CACHE_LINE_16B)
-#define ESP32S3_DCACHE_LINE_SIZE CACHE_LINE_SIZE_16B
-#elif defined(CONFIG_ESP32S3_DATA_CACHE_LINE_32B)
-#define ESP32S3_DCACHE_LINE_SIZE CACHE_LINE_SIZE_32B
-#else
-#define ESP32S3_DCACHE_LINE_SIZE CACHE_LINE_SIZE_32B
-#endif
-
-#define CACHE_MEMORY_ICACHE_LOW CACHE_ICACHE0
-
 #ifndef CONFIG_MCUBOOT
+extern int _rodata_reserved_start;
+extern int _rodata_reserved_end;
+extern void rom_config_data_cache_mode(uint32_t cfg_cache_size, uint8_t cfg_cache_ways,
+						uint8_t cfg_cache_line_size);
+extern void rom_config_instruction_cache_mode(uint32_t cfg_cache_size, uint8_t cfg_cache_ways,
+						uint8_t cfg_cache_line_size);
+extern uint32_t Cache_Set_IDROM_MMU_Size(uint32_t irom_size, uint32_t drom_size);
+extern void Cache_Set_IDROM_MMU_Info(uint32_t instr_page_num, uint32_t rodata_page_num,
+					uint32_t rodata_start, uint32_t rodata_end,
+					int i_off, int ro_off);
 extern void Cache_Enable_ICache(uint32_t autoload);
 
 void IRAM_ATTR esp_config_instruction_cache_mode(void)
 {
-	cache_size_t cache_size;
-	cache_ways_t cache_ways;
-	cache_line_size_t cache_line_size;
+	rom_config_instruction_cache_mode(CONFIG_ESP32S3_INSTRUCTION_CACHE_SIZE,
+					CONFIG_ESP32S3_ICACHE_ASSOCIATED_WAYS,
+					CONFIG_ESP32S3_INSTRUCTION_CACHE_LINE_SIZE);
 
-#if CONFIG_ESP32S3_INSTRUCTION_CACHE_16KB
-	Cache_Occupy_ICache_MEMORY(CACHE_MEMORY_IBANK0, CACHE_MEMORY_INVALID);
-	cache_size = CACHE_SIZE_HALF;
-#else
-	Cache_Occupy_ICache_MEMORY(CACHE_MEMORY_IBANK0, CACHE_MEMORY_IBANK1);
-	cache_size = CACHE_SIZE_FULL;
-#endif
-#if CONFIG_ESP32S3_INSTRUCTION_CACHE_4WAYS
-	cache_ways = CACHE_4WAYS_ASSOC;
-#else
-	cache_ways = CACHE_8WAYS_ASSOC;
-#endif
-#if CONFIG_ESP32S3_INSTRUCTION_CACHE_LINE_16B
-	cache_line_size = CACHE_LINE_SIZE_16B;
-#elif CONFIG_ESP32S3_INSTRUCTION_CACHE_LINE_32B
-	cache_line_size = CACHE_LINE_SIZE_32B;
-#else
-	cache_line_size = CACHE_LINE_SIZE_64B;
-#endif
-	Cache_Set_ICache_Mode(cache_size, cache_ways, cache_line_size);
-	Cache_Invalidate_ICache_All();
-	Cache_Enable_ICache(0);
+	Cache_Suspend_DCache();
 }
 
 void IRAM_ATTR esp_config_data_cache_mode(void)
 {
-	cache_size_t cache_size;
-	cache_ways_t cache_ways;
-	cache_line_size_t cache_line_size;
+	rom_config_data_cache_mode(CONFIG_ESP32S3_DATA_CACHE_SIZE,
+				CONFIG_ESP32S3_DCACHE_ASSOCIATED_WAYS,
+				CONFIG_ESP32S3_DATA_CACHE_LINE_SIZE);
+	Cache_Resume_DCache(0);
 
-#if CONFIG_ESP32S3_DATA_CACHE_32KB
-	Cache_Occupy_DCache_MEMORY(CACHE_MEMORY_DBANK1, CACHE_MEMORY_INVALID);
-	cache_size = CACHE_SIZE_HALF;
-#else
-	Cache_Occupy_DCache_MEMORY(CACHE_MEMORY_DBANK0, CACHE_MEMORY_DBANK1);
-	cache_size = CACHE_SIZE_FULL;
-#endif
-#if CONFIG_ESP32S3_DATA_CACHE_4WAYS
-	cache_ways = CACHE_4WAYS_ASSOC;
-#else
-	cache_ways = CACHE_8WAYS_ASSOC;
-#endif
-#if CONFIG_ESP32S3_DATA_CACHE_LINE_16B
-	cache_line_size = CACHE_LINE_SIZE_16B;
-#elif CONFIG_ESP32S3_DATA_CACHE_LINE_32B
-	cache_line_size = CACHE_LINE_SIZE_32B;
-#else
-	cache_line_size = CACHE_LINE_SIZE_64B;
-#endif
-	Cache_Set_DCache_Mode(cache_size, cache_ways, cache_line_size);
-	Cache_Invalidate_DCache_All();
+	/* Configure the Cache MMU size for instruction and rodata in flash. */
+	uint32_t rodata_reserved_start_align =
+		(uint32_t)&_rodata_reserved_start & ~(MMU_PAGE_SIZE - 1);
+	uint32_t cache_mmu_irom_size =
+		((rodata_reserved_start_align - SOC_DROM_LOW) / MMU_PAGE_SIZE) * sizeof(uint32_t);
+	uint32_t cache_mmu_drom_size =
+		(((uint32_t)&_rodata_reserved_end - rodata_reserved_start_align + MMU_PAGE_SIZE - 1)
+		/ MMU_PAGE_SIZE) * sizeof(uint32_t);
+	Cache_Set_IDROM_MMU_Size(cache_mmu_irom_size, CACHE_DROM_MMU_MAX_END - cache_mmu_irom_size);
 }
 #endif /* CONFIG_MCUBOOT */

--- a/west.yml
+++ b/west.yml
@@ -64,7 +64,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 8d8d537fa2131c43fd55caa8cfce69f7723b0562
+      revision: abe299333411cb37a1cb1dd0aa2ea35c27382604
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This PR provides the fix for the IDF bootloader issue on ESP32s3.
In addition, it fixes hard coded flash size of ESP32 linker and
provides S3 cache helpers, and cleans up the Soc init function.