### PR TITLE
tests: Remove `_*_SOURCE` defines

### DIFF
--- a/tests/lib/c_lib/src/test_qsort.c
+++ b/tests/lib/c_lib/src/test_qsort.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define _GNU_SOURCE
 #include <stdbool.h>
 #include <stdlib.h>
 #include <zephyr/ztest.h>

--- a/tests/lib/mem_alloc/src/main.c
+++ b/tests/lib/mem_alloc/src/main.c
@@ -24,7 +24,6 @@
 #pragma GCC diagnostic ignored "-Walloc-size-larger-than="
 #endif
 
-#define _BSD_SOURCE
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <stdlib.h>


### PR DESCRIPTION
Remove all remaining C library API defines from tests as they are no longer necessary. C libraries should be configured to express the standard Zephyr API by default.