### PR TITLE
gcc/target.cmake: fix build with gcc-13

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -34,7 +34,21 @@ if(NOT DEFINED NOSYSDEF_CFLAG)
   set(NOSYSDEF_CFLAG -undef)
 endif()
 
-foreach(file_name include/stddef.h include-fixed/limits.h)
+# GCC-13, does not install limits.h on include-fixed anymore
+# https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=be9dd80f933480
+# Add check for GCC version >= 13.1
+execute_process(
+    COMMAND ${CMAKE_C_COMPILER} -dumpversion
+    OUTPUT_VARIABLE temp_compiler_version
+    )
+
+if("${temp_compiler_version}" VERSION_GREATER_EQUAL 13.1.0)
+    set(fix_header_file include/limits.h)
+else()
+    set(fix_header_file include-fixed/limits.h)
+endif()
+
+foreach(file_name include/stddef.h "${fix_header_file}")
   execute_process(
     COMMAND ${CMAKE_C_COMPILER} --print-file-name=${file_name}
     OUTPUT_VARIABLE _OUTPUT


### PR DESCRIPTION
Configuration error:
| -- Configuring done (4.9s)
| CMake Error in CMakeLists.txt:
|   Target "zephyr_interface" contains relative path in its
|   INTERFACE_INCLUDE_DIRECTORIES:
|
|     "include-fixed"

With GCC-13, limits.h and syslimits.h header files are always being installed to include folder.
https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=be9dd80f933480