### PR TITLE
Bluetooth: host: hci_core: handle additional error code

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -337,6 +337,8 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 		switch (status) {
 		case BT_HCI_ERR_CONN_LIMIT_EXCEEDED:
 			return -ECONNREFUSED;
+		case BT_HCI_ERR_INSUFFICIENT_RESOURCES:
+			return -ENOMEM;
 		default:
 			return -EIO;
 		}


### PR DESCRIPTION
Some Bluetooth controllers (Nordic Softdevice) now use `BT_HCI_ERR_INSUFFICIENT_RESOURCES` to signify when advertising sets cannot be created, instead of the old `BT_HCI_ERR_CONN_LIMIT_EXCEEDED`.

See https://github.com/nrfconnect/sdk-nrfxlib/blob/main/softdevice_controller/CHANGELOG.rst#changes
