### PR TITLE
tests: logging: log_link_order: Fix uninitialized memory access

### DIFF
--- a/tests/subsys/logging/log_link_order/src/mock_log_link.c
+++ b/tests/subsys/logging/log_link_order/src/mock_log_link.c
@@ -22,18 +22,32 @@ static int activate(const struct log_link *link)
 static int get_domain_name(const struct log_link *link, uint32_t domain_id,
 			char *buf, size_t *length)
 {
+	if (length) {
+		*length = 0;
+	}
 	return 0;
 }
 
 static int get_source_name(const struct log_link *link, uint32_t domain_id,
 			uint16_t source_id, char *buf, size_t *length)
 {
+	if (length) {
+		*length = 0;
+	}
+
 	return 0;
 }
 
 static int get_levels(const struct log_link *link, uint32_t domain_id,
 			uint16_t source_id, uint8_t *level, uint8_t *runtime_level)
 {
+	if (level) {
+		*level = LOG_LEVEL_INF;
+	}
+	if (runtime_level) {
+		*runtime_level = LOG_LEVEL_INF;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Mocks used in the test were not initializing certain variables. Valgrind detected that. Test was passing but could fail if some garbage would end up in that memory.

Fixes #57659.