### PR TITLE
clang: Fix some compilation errors

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -363,11 +363,11 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	stream->dst_size	= config->dest_data_size;
 
 	/* Check dest or source memory address, warn if 0 */
-	if ((config->head_block->source_address == 0)) {
+	if (config->head_block->source_address == 0) {
 		LOG_WRN("source_buffer address is null.");
 	}
 
-	if ((config->head_block->dest_address == 0)) {
+	if (config->head_block->dest_address == 0) {
 		LOG_WRN("dest_buffer address is null.");
 	}
 

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -377,11 +377,14 @@ static void pool_filling_work_handler(struct k_work *work)
 	}
 }
 
-#pragma GCC push_options
 #if defined(CONFIG_BT_CTLR_FAST_ENC)
-#pragma GCC optimize ("Ofast")
+#define __fast __attribute__((optimize("Ofast")))
+#else
+#define __fast
 #endif
-static uint16_t rng_pool_get(struct rng_pool *rngp, uint8_t *buf, uint16_t len)
+
+__fast static uint16_t rng_pool_get(struct rng_pool *rngp, uint8_t *buf,
+	uint16_t len)
 {
 	uint32_t last  = rngp->last;
 	uint32_t mask  = rngp->mask;
@@ -445,7 +448,7 @@ static uint16_t rng_pool_get(struct rng_pool *rngp, uint8_t *buf, uint16_t len)
 
 	return len;
 }
-#pragma GCC pop_options
+#undef __fast
 
 static int rng_pool_put(struct rng_pool *rngp, uint8_t byte)
 {

--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -200,6 +200,11 @@ static void stm32_fill_irq_table(int8_t start, int8_t len, int32_t irqn)
 	}
 }
 
+/* This macro provides body for stm32_exti_range structure initialization. */
+#define STM32_EXTI_RANGE(idx)						    \
+	.start = DT_PROP_BY_IDX(DT_NODELABEL(exti), line_ranges, 2 * idx),  \
+	.len = DT_PROP_BY_IDX(DT_NODELABEL(exti), line_ranges, 2 * idx + 1)
+
 /* This macro:
  * - populates line_range_x from line_range dt property
  * - fill exti_irq_table through stm32_fill_irq_table()
@@ -207,8 +212,7 @@ static void stm32_fill_irq_table(int8_t start, int8_t len, int32_t irqn)
  */
 #define STM32_EXTI_INIT(node_id, interrupts, idx)			\
 	static const struct stm32_exti_range line_range_##idx = {	\
-		range[2 * idx],						\
-		range[2 * idx + 1]					\
+		STM32_EXTI_RANGE(idx)					\
 	};								\
 	stm32_fill_irq_table(line_range_##idx.start,			\
 			     line_range_##idx.len,			\
@@ -224,8 +228,6 @@ static void stm32_fill_irq_table(int8_t start, int8_t len, int32_t irqn)
 static int stm32_exti_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
-	const uint8_t range[2*NUM_EXTI_LINES] =
-					DT_PROP(DT_NODELABEL(exti), line_ranges);
 	DT_FOREACH_PROP_ELEM(DT_NODELABEL(exti),
 			     interrupt_names,
 			     STM32_EXTI_INIT);

--- a/lib/libc/minimal/source/stdlib/atoi.c
+++ b/lib/libc/minimal/source/stdlib/atoi.c
@@ -43,6 +43,7 @@ int atoi(const char *s)
 		break;	/* artifact to quiet coverity warning */
 	case '+':
 		s++;
+		break;
 	default:
 		/* Add an empty default with break, this is a defensive programming.
 		 * Static analysis tool won't raise a violation if default is empty,


### PR DESCRIPTION
Fix clang compilation issues when compiling firmware for STM32 with minimal libc.