### PR TITLE
rtio: Fix cpp compatibility

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -1366,7 +1366,7 @@ static inline int z_impl_rtio_cqe_copy_out(struct rtio *r,
 {
 	size_t copied = 0;
 	struct rtio_cqe *cqe;
-	uint64_t end = sys_clock_timeout_end_calc(timeout);
+	int64_t end = sys_clock_timeout_end_calc(timeout);
 
 	do {
 		cqe = K_TIMEOUT_EQ(timeout, K_FOREVER) ? rtio_cqe_consume_block(r)


### PR DESCRIPTION
Fixed comparison between signed(int64_t) and unsigned(uint64_t) variables.

Fixed the following g++ compilation error:
```
In file included from /mycode/zephyr/include/zephyr/drivers/sensor.h:27,

/mycode/zephyr/include/zephyr/rtio/rtio.h: In function 'int z_impl_rtio_cqe_copy_out(rtio*, rtio_cqe*, size_t, k_timeout_t)':
/mycode/zephyr/include/zephyr/rtio/rtio.h:1385:44: error: comparison of integer expressions of different signedness: 'uint64_t' {aka 'long long unsigned int'} and 'int64_t' {aka 'long long int'} [-Werror=sign-compare]
 1385 |         } while (copied < cqe_count && end > k_uptime_ticks());
 ```