### PR TITLE
samples: unicast audio: Wrap start of the send timer

### DIFF
--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -1101,8 +1101,10 @@ int main(void)
 		}
 		printk("Streams started\n");
 
-		/* Start send timer */
-		k_work_schedule(&audio_send_work, K_MSEC(0));
+		if (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0) {
+			/* Start send timer */
+			k_work_schedule(&audio_send_work, K_MSEC(0));
+		}
 
 		/* Wait for disconnect */
 		err = k_sem_take(&sem_disconnected, K_FOREVER);

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -782,7 +782,10 @@ int main(void)
 
 		printk("Advertising successfully started\n");
 
-		k_work_init_delayable(&audio_send_work, audio_timer_timeout);
+		if (CONFIG_BT_ASCS_ASE_SRC_COUNT > 0) {
+			/* Start send timer */
+			k_work_init_delayable(&audio_send_work, audio_timer_timeout);
+		}
 
 		err = k_sem_take(&sem_disconnected, K_FOREVER);
 		if (err != 0) {


### PR DESCRIPTION
Enable the send timer only when at least one ASE source is enabled,
CONFIG_BT_ASCS_ASE_SRC_COUNT > 0 in case of unicast_audio_server,
CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0 for unicast_audio_client.