### PR TITLE
tests: coap_client: Type cast to uint8_t after shift

### DIFF
--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -38,7 +38,7 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake(int sock, void *buf, size_t max
 		0x68, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	};
 
-	ack_data[2] = (uint8_t) last_message_id >> 8;
+	ack_data[2] = (uint8_t) (last_message_id >> 8);
 	ack_data[3] = (uint8_t) last_message_id;
 
 	memcpy(buf, ack_data, sizeof(ack_data));
@@ -69,7 +69,7 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_response(int sock, void *buf, s
 		0x48, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	};
 
-	ack_data[2] = (uint8_t) last_message_id >> 8;
+	ack_data[2] = (uint8_t) (last_message_id >> 8);
 	ack_data[3] = (uint8_t) last_message_id;
 
 	memcpy(buf, ack_data, sizeof(ack_data));
@@ -85,7 +85,7 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_empty_ack(int sock, void *buf, 
 		0x68, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	};
 
-	ack_data[2] = (uint8_t) last_message_id >> 8;
+	ack_data[2] = (uint8_t) (last_message_id >> 8);
 	ack_data[3] = (uint8_t) last_message_id;
 
 	memcpy(buf, ack_data, sizeof(ack_data));
@@ -103,7 +103,7 @@ static ssize_t z_impl_zsock_recvfrom_custom_fake_unmatching(int sock, void *buf,
 		0x68, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
 	};
 
-	ack_data[2] = (uint8_t) last_message_id >> 8;
+	ack_data[2] = (uint8_t) (last_message_id >> 8);
 	ack_data[3] = (uint8_t) last_message_id;
 
 	memcpy(buf, ack_data, sizeof(ack_data));


### PR DESCRIPTION
Type casting to uint8_t before shift by 8 does not make sense.