### PR TITLE
scripts: footprint: Fix size_report on freestanding apps

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -520,8 +520,10 @@ def find_common_path_prefix(symbol_dict):
             for file in symbol['mapped_files']:
                 paths.append(file)
 
-    return os.path.commonpath(paths)
-
+    try:
+        return os.path.commonpath(paths)
+    except ValueError:
+        return None
 
 class TreeNode(NodeMixin):
     """
@@ -560,7 +562,7 @@ def generate_any_tree(symbol_dict, total_size, path_prefix):
     root = TreeNode('Root', "root")
     node_no_paths = TreeNode('(no paths)', ":", parent=root)
 
-    if Path(path_prefix) == Path(args.zephyrbase):
+    if path_prefix and Path(path_prefix) == Path(args.zephyrbase):
         # All source files are under ZEPHYR_BASE so there is
         # no need for another level.
         node_zephyr_base = root


### PR DESCRIPTION
os.path.commonpath() throws a ValueError exception when paths in the list provided share nothing in common (like for example two Windows paths on different drive letters). Handle that special case properly instead of letting the exception propagate up.

Fixes #51549.