### PR TITLE
drivers: can: mcan: add static initializer macros for timing parameters

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -210,8 +210,8 @@ int can_mcan_set_timing(const struct device *dev, const struct can_timing *timin
 	}
 
 	__ASSERT_NO_MSG(timing->prop_seg == 0U);
-	__ASSERT_NO_MSG(timing->phase_seg1 <= 0x100 && timing->phase_seg1 > 0U);
-	__ASSERT_NO_MSG(timing->phase_seg2 <= 0x80 && timing->phase_seg2 > 0U);
+	__ASSERT_NO_MSG(timing->phase_seg1 <= 0x100 && timing->phase_seg1 > 1U);
+	__ASSERT_NO_MSG(timing->phase_seg2 <= 0x80 && timing->phase_seg2 > 1U);
 	__ASSERT_NO_MSG(timing->prescaler <= 0x200 && timing->prescaler > 0U);
 	__ASSERT_NO_MSG(timing->sjw == CAN_SJW_NO_CHANGE ||
 			(timing->sjw <= 0x80 && timing->sjw > 0U));
@@ -260,7 +260,7 @@ int can_mcan_set_timing_data(const struct device *dev, const struct can_timing *
 	__ASSERT_NO_MSG(timing_data->phase_seg2 <= 0x10 && timing_data->phase_seg2 > 0U);
 	__ASSERT_NO_MSG(timing_data->prescaler <= 0x20 && timing_data->prescaler > 0U);
 	__ASSERT_NO_MSG(timing_data->sjw == CAN_SJW_NO_CHANGE ||
-			(timing_data->sjw <= 0x80 && timing_data->sjw > 0U));
+			(timing_data->sjw <= 0x10 && timing_data->sjw > 0U));
 
 	k_mutex_lock(&data->lock, K_FOREVER);
 

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -815,6 +815,54 @@
 #define CAN_MCAN_DT_INST_MRAM_DEFINE(inst, _name) CAN_MCAN_DT_MRAM_DEFINE(DT_DRV_INST(inst), _name)
 
 /**
+ * @brief Bosch M_CAN specific static initializer for a minimum nominal @p can_timing struct
+ */
+#define CAN_MCAN_TIMING_MIN_INITIALIZER                                                            \
+	{                                                                                          \
+		.sjw = 1,                                                                          \
+		.prop_seg = 0,                                                                     \
+		.phase_seg1 = 2,                                                                   \
+		.phase_seg2 = 2,                                                                   \
+		.prescaler = 1                                                                     \
+	}
+
+/**
+ * @brief Bosch M_CAN specific static initializer for a maximum nominal @p can_timing struct
+ */
+#define CAN_MCAN_TIMING_MAX_INITIALIZER                                                            \
+	{                                                                                          \
+		.sjw = 128,                                                                        \
+		.prop_seg = 0,                                                                     \
+		.phase_seg1 = 256,                                                                 \
+		.phase_seg2 = 128,                                                                 \
+		.prescaler = 512                                                                   \
+	}
+
+/**
+ * @brief Bosch M_CAN specific static initializer for a minimum data phase @p can_timing struct
+ */
+#define CAN_MCAN_TIMING_DATA_MIN_INITIALIZER                                                       \
+	{                                                                                          \
+		.sjw = 1,                                                                          \
+		.prop_seg = 0,                                                                     \
+		.phase_seg1 = 1,                                                                   \
+		.phase_seg2 = 1,                                                                   \
+		.prescaler = 1                                                                     \
+	}
+
+/**
+ * @brief Bosch M_CAN specific static initializer for a maximum data phase @p can_timing struct
+ */
+#define CAN_MCAN_TIMING_DATA_MAX_INITIALIZER                                                       \
+	{                                                                                          \
+		.sjw = 16,                                                                         \
+		.prop_seg = 0,                                                                     \
+		.phase_seg1 = 32,                                                                  \
+		.phase_seg2 = 16,                                                                  \
+		.prescaler = 32                                                                    \
+	}
+
+/**
  * @brief Equivalent to CAN_MCAN_DT_BUILD_ASSERT_MRAM_CFG(DT_DRV_INST(inst))
  * @param inst DT_DRV_COMPAT instance number
  * @see CAN_MCAN_DT_BUILD_ASSERT_MRAM_CFG()

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -148,21 +148,13 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 	 * Note that the values here are the "physical" timing limits, whereas
 	 * the register field limits are physical values minus 1 (which is
 	 * handled by the register assignments in the common MCAN driver code).
+	 *
+	 * Beware that at least some SoC reference manuals contain a bug
+	 * regarding the minimum values for nominal phase segments. Valid
+	 * register values are 1 and up.
 	 */
-	.timing_min = {
-		.sjw = 1,
-		.prop_seg = 0,
-		.phase_seg1 = 1,
-		.phase_seg2 = 1,
-		.prescaler = 1
-	},
-	.timing_max = {
-		.sjw = 128,
-		.prop_seg = 0,
-		.phase_seg1 = 256,
-		.phase_seg2 = 128,
-		.prescaler = 512,
-	},
+	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
+	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE
 	.set_timing_data = can_mcan_set_timing_data,
 	/*
@@ -172,21 +164,13 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 	 * Note that the values here are the "physical" timing limits, whereas
 	 * the register field limits are physical values minus 1 (which is
 	 * handled by the register assignments in the common MCAN driver code).
+	 *
+	 * Beware that at least some SoC reference manuals contain a bug
+	 * regarding the maximum value for data phase segment 2. Valid register
+	 * values are 0 to 31.
 	 */
-	.timing_data_min = {
-		.sjw = 1,
-		.prop_seg = 0,
-		.phase_seg1 = 1,
-		.phase_seg2 = 1,
-		.prescaler = 1,
-	},
-	.timing_data_max = {
-		.sjw = 16,
-		.prop_seg = 0,
-		.phase_seg1 = 16,
-		.phase_seg2 = 16,
-		.prescaler = 32,
-	}
+	.timing_data_min = CAN_MCAN_TIMING_DATA_MIN_INITIALIZER,
+	.timing_data_max = CAN_MCAN_TIMING_DATA_MAX_INITIALIZER,
 #endif /* CONFIG_CAN_FD_MODE */
 };
 

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -134,36 +134,12 @@ static const struct can_driver_api can_sam_driver_api = {
 	.get_max_filters = can_mcan_get_max_filters,
 	.get_max_bitrate = can_mcan_get_max_bitrate,
 	.set_state_change_callback =  can_mcan_set_state_change_callback,
-	.timing_min = {
-		.sjw = 0x1,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x01,
-		.prescaler = 0x01
-		},
-	.timing_max = {
-		.sjw = 0x7f,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x100,
-		.phase_seg2 = 0x80,
-		.prescaler = 0x200
-		},
+	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
+	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE
 	.set_timing_data = can_mcan_set_timing_data,
-	.timing_data_min = {
-		.sjw = 0x01,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x01,
-		.prescaler = 0x01
-		},
-	.timing_data_max = {
-		.sjw = 0x10,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x20,
-		.phase_seg2 = 0x10,
-		.prescaler = 0x20
-		}
+	.timing_data_min = CAN_MCAN_TIMING_DATA_MIN_INITIALIZER,
+	.timing_data_max = CAN_MCAN_TIMING_DATA_MAX_INITIALIZER,
 #endif /* CONFIG_CAN_FD_MODE */
 };
 

--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -164,36 +164,12 @@ static const struct can_driver_api can_sam0_driver_api = {
 	.get_max_filters = can_mcan_get_max_filters,
 	.get_max_bitrate = can_mcan_get_max_bitrate,
 	.set_state_change_callback =  can_mcan_set_state_change_callback,
-	.timing_min = {
-		.sjw = 0x1,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x01,
-		.prescaler = 0x01
-	},
-	.timing_max = {
-		.sjw = 0x7f,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x100,
-		.phase_seg2 = 0x80,
-		.prescaler = 0x200
-	},
+	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
+	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE
 	.set_timing_data = can_mcan_set_timing_data,
-	.timing_data_min = {
-		.sjw = 0x01,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x01,
-		.prescaler = 0x01
-	},
-	.timing_data_max = {
-		.sjw = 0x10,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x20,
-		.phase_seg2 = 0x10,
-		.prescaler = 0x20
-	}
+	.timing_data_min = CAN_MCAN_TIMING_DATA_MIN_INITIALIZER,
+	.timing_data_max = CAN_MCAN_TIMING_DATA_MAX_INITIALIZER,
 #endif /* CONFIG_CAN_FD_MODE */
 };
 

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -594,36 +594,12 @@ static const struct can_driver_api can_stm32fd_driver_api = {
 	.get_max_bitrate = can_mcan_get_max_bitrate,
 	.get_max_filters = can_mcan_get_max_filters,
 	.set_state_change_callback = can_mcan_set_state_change_callback,
-	.timing_min = {
-		.sjw = 0x01,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x01,
-		.prescaler = 0x01
-	},
-	.timing_max = {
-		.sjw = 0x80,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x100,
-		.phase_seg2 = 0x80,
-		.prescaler = 0x200
-	},
+	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
+	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE
 	.set_timing_data = can_mcan_set_timing_data,
-	.timing_data_min = {
-		.sjw = 0x01,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x01,
-		.prescaler = 0x01
-	},
-	.timing_data_max = {
-		.sjw = 0x10,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x20,
-		.phase_seg2 = 0x10,
-		.prescaler = 0x20
-	}
+	.timing_data_min = CAN_MCAN_TIMING_DATA_MIN_INITIALIZER,
+	.timing_data_max = CAN_MCAN_TIMING_DATA_MAX_INITIALIZER,
 #endif /* CONFIG_CAN_FD_MODE */
 };
 

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -168,41 +168,20 @@ static const struct can_driver_api can_stm32h7_driver_api = {
 	/* Timing limits are per the STM32H7 Reference Manual (RM0433 Rev 7),
 	 * section 56.5.7, FDCAN nominal bit timing and prescaler register
 	 * (FDCAN_NBTP).
+	 *
+	 * Beware that the reference manual contains a bug regarding the minimum
+	 * values for nominal phase segments. Valid register values are 1 and up.
 	 */
-	.timing_min = {
-		.sjw = 0x01,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x01,
-		.prescaler = 0x01
-	},
-	.timing_max = {
-		.sjw = 0x80,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x100,
-		.phase_seg2 = 0x80,
-		.prescaler = 0x200
-	},
+	.timing_min = CAN_MCAN_TIMING_MIN_INITIALIZER,
+	.timing_max = CAN_MCAN_TIMING_MAX_INITIALIZER,
 #ifdef CONFIG_CAN_FD_MODE
 	.set_timing_data = can_mcan_set_timing_data,
 	/* Data timing limits are per the STM32H7 Reference Manual
 	 * (RM0433 Rev 7), section 56.5.3, FDCAN data bit timing and prescaler
 	 * register (FDCAN_DBTP).
 	 */
-	.timing_data_min = {
-		.sjw = 0x01,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x01,
-		.prescaler = 0x01
-	},
-	.timing_data_max = {
-		.sjw = 0x10,
-		.prop_seg = 0x00,
-		.phase_seg1 = 0x20,
-		.phase_seg2 = 0x10,
-		.prescaler = 0x20
-	}
+	.timing_data_min = CAN_MCAN_TIMING_DATA_MIN_INITIALIZER,
+	.timing_data_max = CAN_MCAN_TIMING_DATA_MAX_INITIALIZER,
 #endif
 };
 


### PR DESCRIPTION
Add static initializers for the Bosch M_CAN minimum/maximum CAN timing parameter values and use these in all frontend drivers.

Fixes: #58429