### PR TITLE
subsys: pm: Fix cpus active count

### DIFF
--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -193,6 +193,8 @@ typedef struct z_kernel _kernel_t;
 
 extern struct z_kernel _kernel;
 
+extern atomic_t _cpus_active;
+
 #ifdef CONFIG_SMP
 
 /* True if the current context can be preempted and migrated to

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -45,6 +45,9 @@ BUILD_ASSERT(CONFIG_MP_NUM_CPUS == CONFIG_MP_MAX_NUM_CPUS,
 __pinned_bss
 struct z_kernel _kernel;
 
+__pinned_bss
+atomic_t _cpus_active;
+
 /* init/main and idle threads */
 K_THREAD_PINNED_STACK_DEFINE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
 struct k_thread z_main_thread;
@@ -395,6 +398,12 @@ void z_init_cpu(int id)
 	_kernel.cpus[id].usage.track_usage =
 		CONFIG_SCHED_THREAD_USAGE_AUTO_ENABLE;
 #endif
+
+	/*
+	 * Increment number of CPUs active. The pm subsystem
+	 * will keep track of this from here.
+	 */
+	atomic_inc(&_cpus_active);
 }
 
 /**


### PR DESCRIPTION
Only set a cpu as active (on pm subsystem) when the cpu is effectively initialized. We cannot assume on pm subsystem that all cpus were initialized since when the option CONFIG_SMP_BOOT_DELAY is used cpus are initialized on demand by the application.

Note that once cpus are properly initialized the subystem is able to track their status.

Fixes #58502