### PR TITLE
libc/common: malloc fixes

### DIFF
--- a/lib/libc/common/Kconfig
+++ b/lib/libc/common/Kconfig
@@ -22,7 +22,7 @@ config COMMON_LIBC_MALLOC_ARENA_SIZE
 	depends on COMMON_LIBC_MALLOC
 	default 0 if MINIMAL_LIBC
 	default 16384 if MMU
-	default 1024 if USERSPACE && MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
+	default 2048 if USERSPACE && MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 	default -1
 	help
 	  Indicate the size in bytes of the memory arena used for

--- a/lib/libc/common/source/stdlib/malloc.c
+++ b/lib/libc/common/source/stdlib/malloc.c
@@ -56,11 +56,11 @@ K_APPMEM_PARTITION_DEFINE(z_malloc_partition);
 #     endif
 #     define HEAP_ALIGN	CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE
 #    elif defined(CONFIG_ARM) || defined(CONFIG_ARM64)
-#     define HEAP_ALIGN	CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE
+#     define HEAP_ALIGN	MAX(sizeof(double), CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE)
 #    elif defined(CONFIG_ARC)
-#     define HEAP_ALIGN	Z_ARC_MPU_ALIGN
+#     define HEAP_ALIGN	MAX(sizeof(double), Z_ARC_MPU_ALIGN)
 #    elif defined(CONFIG_RISCV)
-#     define HEAP_ALIGN	Z_POW2_CEIL(Z_RISCV_STACK_GUARD_SIZE)
+#     define HEAP_ALIGN	Z_POW2_CEIL(MAX(sizeof(double), Z_RISCV_STACK_GUARD_SIZE))
 #    else
 /* Default to 64-bytes; we'll get a run-time error if this doesn't work. */
 #     define HEAP_ALIGN	64


### PR DESCRIPTION
A couple of minor fixes for the common malloc implementation:

 1. Make sure the arena is at least double aligned
 2. Increase default arena to make more tests work.