### PR TITLE
tests/c_lib: strerror_r is POSIX

### DIFF
--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -12,7 +12,6 @@ if(NOT CONFIG_PICOLIBC_USE_MODULE)
   # Use picolibc provided with the toolchain
 
   zephyr_compile_options(--specs=picolibc.specs)
-  zephyr_compile_definitions(_POSIX_C_SOURCE=200809)
   zephyr_libc_link_libraries(--specs=picolibc.specs c -lgcc)
   if(CONFIG_PICOLIBC_IO_FLOAT)
     zephyr_compile_definitions(PICOLIBC_DOUBLE_PRINTF_SCANF)

--- a/tests/lib/c_lib/src/test_strerror.c
+++ b/tests/lib/c_lib/src/test_strerror.c
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifdef CONFIG_NEWLIB_LIBC
+/*
+ * strerror_r is not part of the Zephyr C API. Define this so that a C
+ * library which supports POSIX will declare it.
+ */
 #define _POSIX_C_SOURCE 200809
-#endif
 
 #include <errno.h>
 #include <string.h>


### PR DESCRIPTION
Add "#define _POSIX_C_SOURCE 200809" so that picolibc will declare the complete POSIX API, including strerror_r, not just the Zephyr C library API.