### PR TITLE
doc: smbus: Correct syntax for SMBus documentation

### DIFF
--- a/doc/hardware/peripherals/smbus.rst
+++ b/doc/hardware/peripherals/smbus.rst
@@ -13,26 +13,26 @@ Overview
 System Management Bus (SMBus) is derived from  I2C for communication
 with devices on the motherboard. A system may use SMBus to communicate
 with the peripherals on the motherboard without using dedicated control
-lines. With SMBus peripheral can provide various manufacturer information,
+lines. SMBus peripherals can provide various manufacturer information,
 report errors, accept control parameters, etc.
 
-Devices on the bus can operate in three roles: as a "controller" that
-initiates transactions and controls the clock, a "peripheral" that
-responds to transaction commands, or a "host", which is a specialized
-controller, that provides the main interface to the system's CPU.
-Zephyr has API for "controller" role.
+Devices on the bus can operate in three roles: as a Controller that
+initiates transactions and controls the clock, a Peripheral that
+responds to transaction commands, or a Host, which is a specialized
+Controller, that provides the main interface to the system's CPU.
+Zephyr has API for the Controller role.
 
-In SMBus peripheral devices can initiate communication with Controller
+SMBus peripheral devices can initiate communication with Controller
 with two methods:
 
-* **Host Notify protocol**: Peripheral device that supports Host Notify
-  protocol behaive as a Controller to perform the notification. It writes
-  three-bytes message to a special address "SMBus Host (0x08)" with own
+* **Host Notify protocol**: Peripheral device that supports the Host Notify
+  protocol behaves as a Controller to perform the notification. It writes
+  a three-bytes message to a special address "SMBus Host (0x08)" with own
   address and two bytes of relevant data.
 * **SMBALERT# signal**: Peripheral device uses special signal SMBALERT# to
-  to request attention from the Controller. Controller needs to read one byte
+  request attention from the Controller. The Controller needs to read one byte
   from the special "SMBus Alert Response Address (ARA) (0x0c)". The peripheral
-  device responds with data byte containing own address.
+  device responds with a data byte containing its own address.
 
 Currently, the API is based on `SMBus Specification`_ version 2.0
 
@@ -46,8 +46,8 @@ SMBus Controller API
 ********************
 
 Zephyr's SMBus controller API is used when an SMBus device controls the bus,
-in particularly the start and stop conditions and the clock.  This is
-the most common mode, used to interact with SMbus peripherals.
+particularly the start and stop conditions and the clock.  This is
+the most common mode used to interact with SMBus peripherals.
 
 Configuration Options
 *********************

--- a/drivers/smbus/intel_pch_smbus.c
+++ b/drivers/smbus/intel_pch_smbus.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2022 Intel Corporation
  *
  * Intel I/O Controller Hub (ICH) later renamed to Intel Platform Controller
- * Hub (PCH) SMbus driver.
+ * Hub (PCH) SMBus driver.
  *
  * PCH provides SMBus 2.0 - compliant Host Controller.
  *

--- a/drivers/smbus/intel_pch_smbus.h
+++ b/drivers/smbus/intel_pch_smbus.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2022 Intel Corporation
  *
  * Intel I/O Controller Hub (ICH) later renamed to Intel Platform Controller
- * Hub (PCH) SMbus driver.
+ * Hub (PCH) SMBus driver.
  *
  * PCH provides SMBus 2.0 - compliant Host Controller.
  *

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -25,11 +25,11 @@ extern "C" {
  * @name SMBus Protocol commands
  * @{
  *
- * SMBus Specification defines following SMBus protocols operations
+ * SMBus Specification defines the following SMBus protocols operations
  */
 
 /**
- * SMBus Quick protocol is very simple command with no data sent or
+ * SMBus Quick protocol is a very simple command with no data sent or
  * received. Peripheral may denote only R/W bit, which can still be
  * used for the peripheral management, for example to switch peripheral
  * On/Off. Quick protocol can also be used for peripheral devices
@@ -69,7 +69,7 @@ extern "C" {
 #define SMBUS_CMD_BYTE			0b001
 
 /**
- * SMBus Byte Data protocol send first byte (command) followed
+ * SMBus Byte Data protocol sends the first byte (command) followed
  * by read or write one byte.
  *
  * @code
@@ -95,7 +95,7 @@ extern "C" {
 #define SMBUS_CMD_BYTE_DATA		0b010
 
 /**
- * SMBus Word Data protocol send first byte (command) followed
+ * SMBus Word Data protocol sends the first byte (command) followed
  * by read or write two bytes.
  *
  * @code
@@ -123,9 +123,9 @@ extern "C" {
 #define SMBUS_CMD_WORD_DATA		0b011
 
 /**
- * SMBus Process Call protocol is basically Write Word followed by
- * Wead Word. It is named so because command sends data and waits
- * for the perihperal to return reply.
+ * SMBus Process Call protocol is Write Word followed by
+ * Read Word. It is named so because the command sends data and waits
+ * for the peripheral to return a reply.
  *
  * @code
  * 0                   1                   2
@@ -142,8 +142,8 @@ extern "C" {
 #define SMBUS_CMD_PROC_CALL		0b100
 
 /**
- * SMBus Block protocol reads or writes block of data up to 32 bytes.
- * Count byte specifies the amount of data.
+ * SMBus Block protocol reads or writes a block of data up to 32 bytes.
+ * The Count byte specifies the amount of data.
  *
  * @code
  *
@@ -173,8 +173,8 @@ extern "C" {
 #define SMBUS_CMD_BLOCK			0b101
 
 /**
- * SMBus Block Write - Block Read Process Call protocol is basically
- * Block Write followed by Block Read
+ * SMBus Block Write - Block Read Process Call protocol is
+ * Block Write followed by Block Read.
  *
  * @code
  * 0                   1                   2
@@ -200,7 +200,7 @@ extern "C" {
  * @name SMBus device functionality
  * @{
  *
- * Following parameters describes functionality of SMBus device
+ * The following parameters describe the functionality of the SMBus device
  */
 
 /** Peripheral to act as Controller. */
@@ -221,7 +221,7 @@ extern "C" {
  * @name SMBus special reserved addresses
  * @{
  *
- * Following addresses are reserved by SMBus specification
+ * The following addresses are reserved by SMBus specification
  */
 
 /**
@@ -241,9 +241,9 @@ extern "C" {
 
 /** @brief SMBus read / write direction */
 enum smbus_direction {
-	/** Write message to SMBus */
+	/** Write a message to SMBus peripheral */
 	SMBUS_MSG_WRITE = 0,
-	/** Read message from SMBus */
+	/** Read a message from SMBus peripheral */
 	SMBUS_MSG_READ = 1,
 };
 
@@ -271,7 +271,7 @@ typedef void (*smbus_callback_handler_t)(const struct device *dev,
  *
  * Used to register a callback in the driver instance callback list.
  * As many callbacks as needed can be added as long as each of them
- * are unique pointers of struct smbus_callback.
+ * is a unique pointer of struct smbus_callback.
  *
  * Note: Such struct should not be allocated on stack.
  */


### PR DESCRIPTION
Fix typos and correct syntax.