### PR TITLE
ci: twister: Run on schedule once per week on Sunday

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -10,8 +10,8 @@ on:
       - main
       - v*-branch
   schedule:
-    # Run at 00:00 on Wednesday and Saturday
-    - cron: '0 0 * * 3,6'
+    # Run at 03:00 UTC on every Sunday
+    - cron: '0 3 * * 0'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
This commit updates the twister workflow to run once per week on Sunday instead of twice per week on Wednesday and Saturday because the scheduled run results are not checked very often and once-per-week should be sufficient for the purpose of catching broken tests.

---

This is mainly for minimising the amount of wasted computing resources; thereby, reducing the overall CI cost. Every full build currently costs us approximately $78 (i.e. $625/month).