### PR TITLE
net: buf: fix data ref_count offset in generic_data_ref()

### DIFF
--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -97,7 +97,7 @@ static uint8_t *generic_data_ref(struct net_buf *buf, uint8_t *data)
 {
 	uint8_t *ref_count;
 
-	ref_count = data - 1;
+	ref_count = data - sizeof(void *);
 	(*ref_count)++;
 
 	return data;


### PR DESCRIPTION
This patch fixes commit b70f92e5702b
("net: buf: keep memory alignment provided by k_heap_alloc and k_malloc"). One-line was overlooked in the above patch and may result in a cloned net_buf using a data block that has already been freed.

See also https://github.com/zephyrproject-rtos/zephyr/pull/45689#issuecomment-1570113234