### PR TITLE
Bluetooth: ISO data path fix and test

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -1090,11 +1090,13 @@ static void cis_disabled_cb(void *param)
 
 			if (IS_PERIPHERAL(cig)) {
 				/* Remove data path and ISOAL sink/source associated with this
-				 * CIS for both directions.
+				 * CIS for both directions. Disable them one at a time to make sure
+				 * both are removed, even if only one is set.
 				 */
 				ll_remove_iso_path(cis->lll.handle,
-						   BIT(BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) |
 						   BIT(BT_HCI_DATAPATH_DIR_HOST_TO_CTLR));
+				ll_remove_iso_path(cis->lll.handle,
+						   BIT(BT_HCI_DATAPATH_DIR_CTLR_TO_HOST));
 
 				ll_conn_iso_stream_release(cis);
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1384,9 +1384,8 @@ static void bt_iso_remove_data_path(struct bt_conn *iso)
 		/* TODO: Check which has been setup first to avoid removing
 		 * data paths that are not setup
 		 */
-		(void)hci_le_remove_iso_data_path(iso,
-			BIT(BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) |
-			BIT(BT_HCI_DATAPATH_DIR_HOST_TO_CTLR));
+		(void)hci_le_remove_iso_data_path(iso, BIT(BT_HCI_DATAPATH_DIR_HOST_TO_CTLR));
+		(void)hci_le_remove_iso_data_path(iso, BIT(BT_HCI_DATAPATH_DIR_CTLR_TO_HOST));
 	} else {
 		__ASSERT(false, "Invalid iso.type: %u", type);
 	}

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_test.c
@@ -722,6 +722,7 @@ static void unicast_group_delete(struct bt_bap_unicast_group *unicast_group)
 static void test_cap_initiator_unicast(void)
 {
 	struct bt_bap_unicast_group *unicast_group;
+	const size_t iterations = 2;
 
 	init();
 
@@ -734,20 +735,24 @@ static void test_cap_initiator_unicast(void)
 
 	discover_sink();
 
-	unicast_group_create(&unicast_group);
+	for (size_t i = 0U; i < iterations; i++) {
+		unicast_group_create(&unicast_group);
 
-	unicast_audio_start_inval(unicast_group);
-	unicast_audio_start(unicast_group);
+		for (size_t j = 0U; j < iterations; j++) {
+			unicast_audio_start_inval(unicast_group);
+			unicast_audio_start(unicast_group);
 
-	unicast_audio_update_inval();
-	unicast_audio_update();
+			unicast_audio_update_inval();
+			unicast_audio_update();
 
-	unicast_audio_stop_inval();
-	unicast_audio_stop(unicast_group);
+			unicast_audio_stop_inval();
+			unicast_audio_stop(unicast_group);
+		}
 
-	unicast_group_delete_inval();
-	unicast_group_delete(unicast_group);
-	unicast_group = NULL;
+		unicast_group_delete_inval();
+		unicast_group_delete(unicast_group);
+		unicast_group = NULL;
+	}
 
 	PASS("CAP initiator unicast passed\n");
 }


### PR DESCRIPTION
Fixes issues with clearing data paths in both host and controller. Adds additional testing of this in babblesim. 