### PR TITLE
net: ieee802154: Remove IEEE802154_2015 option usage

### DIFF
--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -81,7 +81,8 @@ source "drivers/ieee802154/Kconfig.dw1000"
 source "drivers/ieee802154/Kconfig.uart_pipe"
 
 config IEEE802154_2015
-	bool "Support for IEEE 802.15.4-2015 frames"
+	bool "Support for IEEE 802.15.4-2015 frames (DEPRECATED)"
+	select DEPRECATED
 	help
 	  Enable radio driver support for IEEE 802.15.4-2015 frames, including security handling of frames and ACKs.
 

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -624,7 +624,7 @@ static int nrf5_tx(const struct device *dev,
 
 	LOG_DBG("Result: %d", nrf5_data.tx_result);
 
-#if defined(CONFIG_IEEE802154_2015)
+#if defined(CONFIG_NRF_802154_ENCRYPTION)
 	/*
 	 * When frame encryption by the radio driver is enabled, the frame stored in
 	 * the tx_psdu buffer is:
@@ -795,7 +795,7 @@ static void nrf5_iface_init(struct net_if *iface)
 	ieee802154_init(iface);
 }
 
-#if defined(CONFIG_IEEE802154_2015)
+#if defined(CONFIG_NRF_802154_ENCRYPTION)
 static void nrf5_config_mac_keys(struct ieee802154_key *mac_keys)
 {
 	static nrf_802154_key_id_t stored_key_ids[NRF_802154_SECURITY_KEY_STORAGE_SIZE];
@@ -830,7 +830,7 @@ static void nrf5_config_mac_keys(struct ieee802154_key *mac_keys)
 		stored_key_ids[i].p_key_id = &stored_ids[i];
 	};
 }
-#endif /* CONFIG_IEEE802154_2015 */
+#endif /* CONFIG_NRF_802154_ENCRYPTION */
 
 static int nrf5_configure(const struct device *dev,
 			  enum ieee802154_config_type type,
@@ -896,7 +896,7 @@ static int nrf5_configure(const struct device *dev,
 		nrf5_data.event_handler = config->event_handler;
 		break;
 
-#if defined(CONFIG_IEEE802154_2015)
+#if defined(CONFIG_NRF_802154_ENCRYPTION)
 	case IEEE802154_CONFIG_MAC_KEYS:
 		nrf5_config_mac_keys(config->mac_keys);
 		break;
@@ -908,7 +908,7 @@ static int nrf5_configure(const struct device *dev,
 	case IEEE802154_CONFIG_FRAME_COUNTER_IF_LARGER:
 		nrf_802154_security_global_frame_counter_set_if_larger(config->frame_counter);
 		break;
-#endif /* CONFIG_IEEE802154_2015 */
+#endif /* CONFIG_NRF_802154_ENCRYPTION */
 
 	case IEEE802154_CONFIG_ENH_ACK_HEADER_IE: {
 		uint8_t short_addr_le[SHORT_ADDRESS_SIZE];

--- a/include/zephyr/net/ieee802154_pkt.h
+++ b/include/zephyr/net/ieee802154_pkt.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 struct net_pkt_cb_ieee802154 {
-#if defined(CONFIG_IEEE802154_2015)
+#if defined(CONFIG_NET_L2_OPENTHREAD)
 	uint32_t ack_fc;   /* Frame counter set in the ACK */
 	uint8_t ack_keyid; /* Key index set in the ACK */
 #endif
@@ -58,7 +58,7 @@ struct net_pkt_cb_ieee802154 {
 				    * it requires further modifications,
 				    * e.g. Frame Counter injection.
 				    */
-#if defined(CONFIG_IEEE802154_2015)
+#if defined(CONFIG_NET_L2_OPENTHREAD)
 	uint8_t fv2015 : 1;  /* Frame version is IEEE 802.15.4-2015 or later */
 	uint8_t ack_seb : 1; /* Security Enabled Bit was set in the ACK */
 #endif
@@ -144,7 +144,7 @@ static inline void net_pkt_set_ieee802154_mac_hdr_rdy(struct net_pkt *pkt, bool 
 	net_pkt_cb_ieee802154(pkt)->mac_hdr_rdy = rdy;
 }
 
-#if defined(CONFIG_IEEE802154_2015)
+#if defined(CONFIG_NET_L2_OPENTHREAD)
 static inline uint32_t net_pkt_ieee802154_ack_fc(struct net_pkt *pkt)
 {
 	return net_pkt_cb_ieee802154(pkt)->ack_fc;
@@ -184,7 +184,7 @@ static inline void net_pkt_set_ieee802154_ack_seb(struct net_pkt *pkt, bool seb)
 {
 	net_pkt_cb_ieee802154(pkt)->ack_seb = seb;
 }
-#endif /* CONFIG_IEEE802154_2015 */
+#endif /* CONFIG_NET_L2_OPENTHREAD */
 
 /** @endcond */
 

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -40,10 +40,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 
 #define FCS_SIZE     2
 #define PHR_DURATION 32
-#if defined(CONFIG_IEEE802154_2015)
-#define ACK_PKT_LENGTH 127
-#else
+#if defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 #define ACK_PKT_LENGTH 5
+#else
+#define ACK_PKT_LENGTH 127
 #endif
 
 #define FRAME_TYPE_MASK 0x07
@@ -401,7 +401,6 @@ static void openthread_handle_received_frame(otInstance *instance,
 					      pkt_time->nanosecond / NSEC_PER_USEC - PHR_DURATION;
 #endif
 
-#if defined(CONFIG_IEEE802154_2015)
 	if (net_pkt_ieee802154_arb(pkt) && net_pkt_ieee802154_fv2015(pkt)) {
 		recv_frame.mInfo.mRxInfo.mAckedWithSecEnhAck =
 			net_pkt_ieee802154_ack_seb(pkt);
@@ -410,7 +409,6 @@ static void openthread_handle_received_frame(otInstance *instance,
 		recv_frame.mInfo.mRxInfo.mAckKeyId =
 			net_pkt_ieee802154_ack_keyid(pkt);
 	}
-#endif
 
 	if (IS_ENABLED(CONFIG_OPENTHREAD_DIAG) && otPlatDiagModeGet()) {
 		otPlatDiagRadioReceiveDone(instance, &recv_frame, OT_ERROR_NONE);
@@ -804,7 +802,7 @@ otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
 		caps |= OT_RADIO_CAPS_SLEEP_TO_TX;
 	}
 
-#if defined(CONFIG_IEEE802154_2015)
+#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 	if (radio_caps & IEEE802154_HW_TX_SEC) {
 		caps |= OT_RADIO_CAPS_TRANSMIT_SEC;
 	}
@@ -1067,7 +1065,7 @@ uint64_t otPlatRadioGetNow(otInstance *aInstance)
 }
 #endif
 
-#if defined(CONFIG_IEEE802154_2015)
+#if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 void otPlatRadioSetMacKey(otInstance *aInstance, uint8_t aKeyIdMode, uint8_t aKeyId,
 			  const otMacKeyMaterial *aPrevKey, const otMacKeyMaterial *aCurrKey,
 			  const otMacKeyMaterial *aNextKey, otRadioKeyType aKeyType)


### PR DESCRIPTION
The IEEE802154_2015 option is misleading, as it does not introduce full 802.15.4-2015 standard compliance but only random bits, plus it's defined at the radio driver level, which brings yet another confusion. Because of that, the option will be deprecated, and respective parts of code that made use of it converted to use more specific configurations:

* nRF driver will now use CONFIG_NRF_802154_ENCRYPTION to specify whether to compile in TX security
* net_pkt will only add extra 802.15.4 control block fields if OpenThread is used, as they were solely used by this L2
* OpenThread radio layer will now use the OpenThread version to determine whether to compile in TX security.