### PR TITLE
posix: eventfd: fix read deadlock and add test coverage

### DIFF
--- a/include/zephyr/posix/sys/eventfd.h
+++ b/include/zephyr/posix/sys/eventfd.h
@@ -16,10 +16,10 @@
 extern "C" {
 #endif
 
-#define EFD_IN_USE    0x1
+#define EFD_IN_USE    0x1 __DEPRECATED_MACRO
 #define EFD_SEMAPHORE 0x2
 #define EFD_NONBLOCK  O_NONBLOCK
-#define EFD_FLAGS_SET (EFD_SEMAPHORE | EFD_NONBLOCK)
+#define EFD_FLAGS_SET (EFD_SEMAPHORE | EFD_NONBLOCK) __DEPRECATED_MACRO
 
 typedef uint64_t eventfd_t;
 

--- a/include/zephyr/posix/sys/eventfd.h
+++ b/include/zephyr/posix/sys/eventfd.h
@@ -7,10 +7,9 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_EVENTFD_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_EVENTFD_H_
 
-#include <zephyr/kernel.h>
-#include <zephyr/sys/fdtable.h>
-#include <sys/types.h>
+#include <stdint.h>
 
+#include <zephyr/kernel.h>
 #include <zephyr/posix/fcntl.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/sys/eventfd.h
+++ b/include/zephyr/posix/sys/eventfd.h
@@ -51,23 +51,7 @@ int eventfd(unsigned int initval, int flags);
  *
  * @return 0 on success, -1 on error
  */
-static inline int eventfd_read(int fd, eventfd_t *value)
-{
-	const struct fd_op_vtable *efd_vtable;
-	struct k_mutex *lock;
-	ssize_t ret;
-	void *obj;
-
-	obj = z_get_fd_obj_and_vtable(fd, &efd_vtable, &lock);
-
-	(void)k_mutex_lock(lock, K_FOREVER);
-
-	ret = efd_vtable->read(obj, value, sizeof(*value));
-
-	k_mutex_unlock(lock);
-
-	return ret == sizeof(eventfd_t) ? 0 : -1;
-}
+int eventfd_read(int fd, eventfd_t *value);
 
 /**
  * @brief Write to an eventfd
@@ -77,23 +61,7 @@ static inline int eventfd_read(int fd, eventfd_t *value)
  *
  * @return 0 on success, -1 on error
  */
-static inline int eventfd_write(int fd, eventfd_t value)
-{
-	const struct fd_op_vtable *efd_vtable;
-	struct k_mutex *lock;
-	ssize_t ret;
-	void *obj;
-
-	obj = z_get_fd_obj_and_vtable(fd, &efd_vtable, &lock);
-
-	(void)k_mutex_lock(lock, K_FOREVER);
-
-	ret = efd_vtable->write(obj, &value, sizeof(value));
-
-	k_mutex_unlock(lock);
-
-	return ret == sizeof(eventfd_t) ? 0 : -1;
-}
+int eventfd_write(int fd, eventfd_t value);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/sys/fdtable.h
+++ b/include/zephyr/sys/fdtable.h
@@ -108,6 +108,24 @@ void *z_get_fd_obj_and_vtable(int fd, const struct fd_op_vtable **vtable,
 			      struct k_mutex **lock);
 
 /**
+ * @brief Get the mutex and condition variable associated with the given object and vtable.
+ *
+ * @param obj Object previously returned by a call to e.g. @ref z_get_fd_obj.
+ * @param vtable A pointer the vtable associated with @p obj.
+ * @param lock An optional pointer to a pointer variable to store the mutex
+ *        preventing concurrent descriptor access. The lock is not taken,
+ *        it is just returned for the caller to use if necessary. Pass NULL
+ *        if the lock is not needed by the caller.
+ * @param cond An optional pointer to a pointer variable to store the condition variable
+ *        to notify waiting threads in the case of concurrent descriptor access. Pass NULL
+ *        if the condition variable is not needed by the caller.
+ *
+ * @return `true` on success, `false` otherwise.
+ */
+bool z_get_obj_lock_and_cond(void *obj, const struct fd_op_vtable *vtable, struct k_mutex **lock,
+			     struct k_condvar **cond);
+
+/**
  * @brief Call ioctl vmethod on an object using varargs.
  *
  * We need this helper function because ioctl vmethod is declared to

--- a/lib/posix/eventfd.c
+++ b/lib/posix/eventfd.c
@@ -1,55 +1,57 @@
 /*
  * Copyright (c) 2020 Tobias Svehagen
+ * Copyright (c) 2023, Meta
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-#include <zephyr/wait_q.h>
-#include <zephyr/posix/sys/eventfd.h>
-#include <zephyr/net/socket.h>
 #include <ksched.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/posix/sys/eventfd.h>
+#include <zephyr/sys/bitarray.h>
+#include <zephyr/sys/fdtable.h>
+#include <zephyr/sys/math_extras.h>
 
 struct eventfd {
-	struct k_poll_signal read_sig;
-	struct k_poll_signal write_sig;
 	struct k_spinlock lock;
-	_wait_q_t wait_q;
 	eventfd_t cnt;
 	int flags;
 };
 
-K_MUTEX_DEFINE(eventfd_mtx);
+static ssize_t eventfd_rw_op(void *obj, void *buf, size_t sz,
+			     int (*op)(struct eventfd *efd, eventfd_t *value));
+
+SYS_BITARRAY_DEFINE_STATIC(efds_bitarray, CONFIG_EVENTFD_MAX);
 static struct eventfd efds[CONFIG_EVENTFD_MAX];
+static const struct fd_op_vtable eventfd_fd_vtable;
+
+static inline bool eventfd_is_in_use(struct eventfd *efd)
+{
+	return (efd->flags & EFD_IN_USE) != 0;
+}
+
+static inline bool eventfd_is_semaphore(struct eventfd *efd)
+{
+	return (efd->flags & EFD_SEMAPHORE) != 0;
+}
+
+static inline bool eventfd_is_blocking(struct eventfd *efd)
+{
+	return (efd->flags & EFD_NONBLOCK) == 0;
+}
 
 static int eventfd_poll_prepare(struct eventfd *efd,
 				struct zsock_pollfd *pfd,
 				struct k_poll_event **pev,
 				struct k_poll_event *pev_end)
 {
-	if (pfd->events & ZSOCK_POLLIN) {
+	if ((pfd->events & (ZSOCK_POLLOUT | ZSOCK_POLLIN)) != 0) {
 		if (*pev == pev_end) {
 			errno = ENOMEM;
 			return -1;
 		}
-
-		(*pev)->obj = &efd->read_sig;
-		(*pev)->type = K_POLL_TYPE_SIGNAL;
-		(*pev)->mode = K_POLL_MODE_NOTIFY_ONLY;
-		(*pev)->state = K_POLL_STATE_NOT_READY;
-		(*pev)++;
-	}
-
-	if (pfd->events & ZSOCK_POLLOUT) {
-		if (*pev == pev_end) {
-			errno = ENOMEM;
-			return -1;
-		}
-
-		(*pev)->obj = &efd->write_sig;
-		(*pev)->type = K_POLL_TYPE_SIGNAL;
-		(*pev)->mode = K_POLL_MODE_NOTIFY_ONLY;
-		(*pev)->state = K_POLL_STATE_NOT_READY;
+		**pev = (struct k_poll_event){0};
 		(*pev)++;
 	}
 
@@ -60,141 +62,147 @@ static int eventfd_poll_update(struct eventfd *efd,
 			       struct zsock_pollfd *pfd,
 			       struct k_poll_event **pev)
 {
-	ARG_UNUSED(efd);
-
 	if (pfd->events & ZSOCK_POLLIN) {
-		if ((*pev)->state != K_POLL_STATE_NOT_READY) {
-			pfd->revents |= ZSOCK_POLLIN;
-		}
+		pfd->revents |= ZSOCK_POLLIN * (efd->cnt > 0);
 		(*pev)++;
 	}
 
 	if (pfd->events & ZSOCK_POLLOUT) {
-		if ((*pev)->state != K_POLL_STATE_NOT_READY) {
-			pfd->revents |= ZSOCK_POLLOUT;
-		}
+		pfd->revents |= ZSOCK_POLLOUT * (efd->cnt < UINT64_MAX - 1);
 		(*pev)++;
 	}
+
+	return 0;
+}
+
+static int eventfd_read_locked(struct eventfd *efd, eventfd_t *value)
+{
+	if (!eventfd_is_in_use(efd)) {
+		/* file descriptor has been closed */
+		return -EBADF;
+	}
+
+	if (efd->cnt == 0) {
+		/* would block / try again */
+		return -EAGAIN;
+	}
+
+	/* successful read */
+	if (eventfd_is_semaphore(efd)) {
+		*value = 1;
+		--efd->cnt;
+	} else {
+		*value = efd->cnt;
+		efd->cnt = 0;
+	}
+
+	return 0;
+}
+
+static int eventfd_write_locked(struct eventfd *efd, eventfd_t *value)
+{
+	eventfd_t result;
+
+	if (!eventfd_is_in_use(efd)) {
+		/* file descriptor has been closed */
+		return -EBADF;
+	}
+
+	if (*value == UINT64_MAX) {
+		/* not a permitted value */
+		return -EINVAL;
+	}
+
+	if (u64_add_overflow(efd->cnt, *value, &result) || result == UINT64_MAX) {
+		/* would block / try again */
+		return -EAGAIN;
+	}
+
+	/* successful write */
+	efd->cnt = result;
 
 	return 0;
 }
 
 static ssize_t eventfd_read_op(void *obj, void *buf, size_t sz)
 {
-	struct eventfd *efd = obj;
-	int result = 0;
-	eventfd_t count = 0;
-	k_spinlock_key_t key;
-
-	if (sz < sizeof(eventfd_t)) {
-		errno = EINVAL;
-		return -1;
-	}
-
-	for (;;) {
-		key = k_spin_lock(&efd->lock);
-		if ((efd->flags & EFD_NONBLOCK) && efd->cnt == 0) {
-			result = EAGAIN;
-			break;
-		} else if (efd->cnt == 0) {
-			z_pend_curr(&efd->lock, key, &efd->wait_q, K_FOREVER);
-		} else {
-			count = (efd->flags & EFD_SEMAPHORE) ? 1 : efd->cnt;
-			efd->cnt -= count;
-			if (efd->cnt == 0) {
-				k_poll_signal_reset(&efd->read_sig);
-			}
-			k_poll_signal_raise(&efd->write_sig, 0);
-			break;
-		}
-	}
-	if (z_unpend_all(&efd->wait_q) != 0) {
-		z_reschedule(&efd->lock, key);
-	} else {
-		k_spin_unlock(&efd->lock, key);
-	}
-
-	if (result != 0) {
-		errno = result;
-		return -1;
-	}
-
-	*(eventfd_t *)buf = count;
-
-	return sizeof(eventfd_t);
+	return eventfd_rw_op(obj, buf, sz, eventfd_read_locked);
 }
 
 static ssize_t eventfd_write_op(void *obj, const void *buf, size_t sz)
 {
-	struct eventfd *efd = obj;
-	int result = 0;
-	eventfd_t count;
-	bool overflow;
-	k_spinlock_key_t key;
-
-	if (sz < sizeof(eventfd_t)) {
-		errno = EINVAL;
-		return -1;
-	}
-
-	count = *((eventfd_t *)buf);
-
-	if (count == UINT64_MAX) {
-		errno = EINVAL;
-		return -1;
-	}
-
-	if (count == 0) {
-		return sizeof(eventfd_t);
-	}
-
-	for (;;) {
-		key = k_spin_lock(&efd->lock);
-		overflow = UINT64_MAX - count <= efd->cnt;
-		if ((efd->flags & EFD_NONBLOCK) && overflow) {
-			result = EAGAIN;
-			break;
-		} else if (overflow) {
-			z_pend_curr(&efd->lock, key, &efd->wait_q, K_FOREVER);
-		} else {
-			efd->cnt += count;
-			if (efd->cnt == (UINT64_MAX - 1)) {
-				k_poll_signal_reset(&efd->write_sig);
-			}
-			k_poll_signal_raise(&efd->read_sig, 0);
-			break;
-		}
-	}
-	if (z_unpend_all(&efd->wait_q) != 0) {
-		z_reschedule(&efd->lock, key);
-	} else {
-		k_spin_unlock(&efd->lock, key);
-	}
-
-	if (result != 0) {
-		errno = result;
-		return -1;
-	}
-
-	return sizeof(eventfd_t);
+	return eventfd_rw_op(obj, (eventfd_t *)buf, sz, eventfd_write_locked);
 }
 
 static int eventfd_close_op(void *obj)
 {
+	int ret;
+	int err;
+	k_spinlock_key_t key;
+	struct k_mutex *lock = NULL;
+	struct k_condvar *cond = NULL;
 	struct eventfd *efd = (struct eventfd *)obj;
 
-	efd->flags = 0;
+	if (k_is_in_isr()) {
+		/* not covered by the man page, but necessary in Zephyr */
+		errno = EWOULDBLOCK;
+		return -1;
+	}
 
-	return 0;
+	err = (int)z_get_obj_lock_and_cond(obj, &eventfd_fd_vtable, &lock, &cond);
+	__ASSERT((bool)err, "z_get_obj_lock_and_cond() failed");
+	__ASSERT_NO_MSG(lock != NULL);
+	__ASSERT_NO_MSG(cond != NULL);
+
+	err = k_mutex_lock(lock, K_FOREVER);
+	__ASSERT(err == 0, "k_mutex_lock() failed: %d", err);
+
+	key = k_spin_lock(&efd->lock);
+
+	if (!eventfd_is_in_use(efd)) {
+		errno = EBADF;
+		ret = -1;
+		goto unlock;
+	}
+
+	err = sys_bitarray_free(&efds_bitarray, 1, (struct eventfd *)obj - efds);
+	__ASSERT(err == 0, "sys_bitarray_free() failed: %d", err);
+
+	efd->flags = 0;
+	efd->cnt = 0;
+
+	ret = 0;
+
+unlock:
+	k_spin_unlock(&efd->lock, key);
+	/* when closing an eventfd, broadcast to all waiters */
+	err = k_condvar_broadcast(cond);
+	__ASSERT(err == 0, "k_condvar_broadcast() failed: %d", err);
+	err = k_mutex_unlock(lock);
+	__ASSERT(err == 0, "k_mutex_unlock() failed: %d", err);
+
+	return ret;
 }
 
 static int eventfd_ioctl_op(void *obj, unsigned int request, va_list args)
 {
+	int ret;
+	k_spinlock_key_t key;
 	struct eventfd *efd = (struct eventfd *)obj;
+
+	/* note: zsock_poll_internal() has already taken the mutex */
+	key = k_spin_lock(&efd->lock);
+
+	if (!eventfd_is_in_use(efd)) {
+		errno = EBADF;
+		ret = -1;
+		goto unlock;
+	}
 
 	switch (request) {
 	case F_GETFL:
-		return efd->flags & EFD_FLAGS_SET;
+		ret = efd->flags & EFD_FLAGS_SET;
+		break;
 
 	case F_SETFL: {
 		int flags;
@@ -203,13 +211,12 @@ static int eventfd_ioctl_op(void *obj, unsigned int request, va_list args)
 
 		if (flags & ~EFD_FLAGS_SET) {
 			errno = EINVAL;
-			return -1;
+			ret = -1;
+		} else {
+			efd->flags = flags;
+			ret = 0;
 		}
-
-		efd->flags = flags;
-
-		return 0;
-	}
+	} break;
 
 	case ZFD_IOCTL_POLL_PREPARE: {
 		struct zsock_pollfd *pfd;
@@ -220,8 +227,8 @@ static int eventfd_ioctl_op(void *obj, unsigned int request, va_list args)
 		pev = va_arg(args, struct k_poll_event **);
 		pev_end = va_arg(args, struct k_poll_event *);
 
-		return eventfd_poll_prepare(obj, pfd, pev, pev_end);
-	}
+		ret = eventfd_poll_prepare(obj, pfd, pev, pev_end);
+	} break;
 
 	case ZFD_IOCTL_POLL_UPDATE: {
 		struct zsock_pollfd *pfd;
@@ -230,13 +237,19 @@ static int eventfd_ioctl_op(void *obj, unsigned int request, va_list args)
 		pfd = va_arg(args, struct zsock_pollfd *);
 		pev = va_arg(args, struct k_poll_event **);
 
-		return eventfd_poll_update(obj, pfd, pev);
-	}
+		ret = eventfd_poll_update(obj, pfd, pev);
+	} break;
 
 	default:
 		errno = EOPNOTSUPP;
-		return -1;
+		ret = -1;
+		break;
 	}
+
+unlock:
+	k_spin_unlock(&efd->lock, key);
+
+	return ret;
 }
 
 static const struct fd_op_vtable eventfd_fd_vtable = {
@@ -246,87 +259,181 @@ static const struct fd_op_vtable eventfd_fd_vtable = {
 	.ioctl = eventfd_ioctl_op,
 };
 
+/* common to both eventfd_read_op() and eventfd_write_op() */
+static ssize_t eventfd_rw_op(void *obj, void *buf, size_t sz,
+			     int (*op)(struct eventfd *efd, eventfd_t *value))
+{
+	int err;
+	ssize_t ret;
+	k_spinlock_key_t key;
+	struct eventfd *efd = obj;
+	struct k_mutex *lock = NULL;
+	struct k_condvar *cond = NULL;
+
+	if (sz < sizeof(eventfd_t)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (buf == NULL) {
+		errno = EFAULT;
+		return -1;
+	}
+
+	key = k_spin_lock(&efd->lock);
+
+	if (!eventfd_is_blocking(efd)) {
+		/*
+		 * Handle the non-blocking case entirely within this scope
+		 */
+		ret = op(efd, buf);
+		if (ret < 0) {
+			errno = -ret;
+			ret = -1;
+		} else {
+			ret = sizeof(eventfd_t);
+		}
+
+		goto unlock_spin;
+	}
+
+	/*
+	 * Handle the blocking case below
+	 */
+	__ASSERT_NO_MSG(eventfd_is_blocking(efd));
+
+	if (k_is_in_isr()) {
+		/* not covered by the man page, but necessary in Zephyr */
+		errno = EWOULDBLOCK;
+		ret = -1;
+		goto unlock_spin;
+	}
+
+	err = (int)z_get_obj_lock_and_cond(obj, &eventfd_fd_vtable, &lock, &cond);
+	__ASSERT((bool)err, "z_get_obj_lock_and_cond() failed");
+	__ASSERT_NO_MSG(lock != NULL);
+	__ASSERT_NO_MSG(cond != NULL);
+
+	/* do not hold a spinlock when taking a mutex */
+	k_spin_unlock(&efd->lock, key);
+	err = k_mutex_lock(lock, K_FOREVER);
+	__ASSERT(err == 0, "k_mutex_lock() failed: %d", err);
+
+	while (true) {
+		/* retake the spinlock */
+		key = k_spin_lock(&efd->lock);
+
+		ret = op(efd, buf);
+		switch (ret) {
+		case -EAGAIN:
+			/* not an error in blocking mode. break and try again */
+			break;
+		case 0:
+			/* success! */
+			ret = sizeof(eventfd_t);
+			goto unlock_mutex;
+		default:
+			/* some other error */
+			__ASSERT_NO_MSG(ret < 0);
+			errno = -ret;
+			ret = -1;
+			goto unlock_mutex;
+		}
+
+		/* do not hold a spinlock when taking a mutex */
+		k_spin_unlock(&efd->lock, key);
+
+		/* wait for a write or close */
+		err = k_condvar_wait(cond, lock, K_FOREVER);
+		__ASSERT(err == 0, "k_condvar_wait() failed: %d", err);
+	}
+
+unlock_mutex:
+	k_spin_unlock(&efd->lock, key);
+	/* only wake a single waiter */
+	err = k_condvar_signal(cond);
+	__ASSERT(err == 0, "k_condvar_signal() failed: %d", err);
+	err = k_mutex_unlock(lock);
+	__ASSERT(err == 0, "k_mutex_unlock() failed: %d", err);
+	goto out;
+
+unlock_spin:
+	k_spin_unlock(&efd->lock, key);
+
+out:
+	return ret;
+}
+
+/*
+ * Public-facing API
+ */
+
 int eventfd(unsigned int initval, int flags)
 {
+	int fd = 1;
+	size_t offset;
 	struct eventfd *efd = NULL;
-	int fd = -1;
-	int i;
 
 	if (flags & ~EFD_FLAGS_SET) {
 		errno = EINVAL;
 		return -1;
 	}
 
-	k_mutex_lock(&eventfd_mtx, K_FOREVER);
-
-	for (i = 0; i < ARRAY_SIZE(efds); ++i) {
-		if (!(efds[i].flags & EFD_IN_USE)) {
-			efd = &efds[i];
-			break;
-		}
-	}
-
-	if (efd == NULL) {
+	if (sys_bitarray_alloc(&efds_bitarray, 1, &offset) < 0) {
 		errno = ENOMEM;
-		goto exit_mtx;
+		return -1;
 	}
+
+	efd = &efds[offset];
 
 	fd = z_reserve_fd();
 	if (fd < 0) {
-		goto exit_mtx;
+		sys_bitarray_free(&efds_bitarray, 1, offset);
+		return -1;
 	}
 
 	efd->flags = EFD_IN_USE | flags;
 	efd->cnt = initval;
 
-	k_poll_signal_init(&efd->write_sig);
-	k_poll_signal_init(&efd->read_sig);
-	z_waitq_init(&efd->wait_q);
-
-	if (initval != 0) {
-		k_poll_signal_raise(&efd->read_sig, 0);
-	}
-	k_poll_signal_raise(&efd->write_sig, 0);
-
 	z_finalize_fd(fd, efd, &eventfd_fd_vtable);
 
-exit_mtx:
-	k_mutex_unlock(&eventfd_mtx);
 	return fd;
 }
 
 int eventfd_read(int fd, eventfd_t *value)
 {
-	const struct fd_op_vtable *efd_vtable;
-	struct k_mutex *lock;
-	ssize_t ret;
+	int ret;
 	void *obj;
 
-	obj = z_get_fd_obj_and_vtable(fd, &efd_vtable, &lock);
+	obj = z_get_fd_obj(fd, &eventfd_fd_vtable, EBADF);
+	if (obj == NULL) {
+		return -1;
+	}
 
-	(void)k_mutex_lock(lock, K_FOREVER);
+	ret = eventfd_rw_op(obj, value, sizeof(eventfd_t), eventfd_read_locked);
+	__ASSERT_NO_MSG(ret == -1 || ret == sizeof(eventfd_t));
+	if (ret < 0) {
+		return -1;
+	}
 
-	ret = efd_vtable->read(obj, value, sizeof(*value));
-
-	k_mutex_unlock(lock);
-
-	return ret == sizeof(eventfd_t) ? 0 : -1;
+	return 0;
 }
 
 int eventfd_write(int fd, eventfd_t value)
 {
-	const struct fd_op_vtable *efd_vtable;
-	struct k_mutex *lock;
-	ssize_t ret;
+	int ret;
 	void *obj;
 
-	obj = z_get_fd_obj_and_vtable(fd, &efd_vtable, &lock);
+	obj = z_get_fd_obj(fd, &eventfd_fd_vtable, EBADF);
+	if (obj == NULL) {
+		return -1;
+	}
 
-	(void)k_mutex_lock(lock, K_FOREVER);
+	ret = eventfd_rw_op(obj, &value, sizeof(eventfd_t), eventfd_write_locked);
+	__ASSERT_NO_MSG(ret == -1 || ret == sizeof(eventfd_t));
+	if (ret < 0) {
+		return -1;
+	}
 
-	ret = efd_vtable->write(obj, &value, sizeof(value));
-
-	k_mutex_unlock(lock);
-
-	return ret == sizeof(eventfd_t) ? 0 : -1;
+	return 0;
 }

--- a/lib/posix/eventfd.c
+++ b/lib/posix/eventfd.c
@@ -294,3 +294,39 @@ exit_mtx:
 	k_mutex_unlock(&eventfd_mtx);
 	return fd;
 }
+
+int eventfd_read(int fd, eventfd_t *value)
+{
+	const struct fd_op_vtable *efd_vtable;
+	struct k_mutex *lock;
+	ssize_t ret;
+	void *obj;
+
+	obj = z_get_fd_obj_and_vtable(fd, &efd_vtable, &lock);
+
+	(void)k_mutex_lock(lock, K_FOREVER);
+
+	ret = efd_vtable->read(obj, value, sizeof(*value));
+
+	k_mutex_unlock(lock);
+
+	return ret == sizeof(eventfd_t) ? 0 : -1;
+}
+
+int eventfd_write(int fd, eventfd_t value)
+{
+	const struct fd_op_vtable *efd_vtable;
+	struct k_mutex *lock;
+	ssize_t ret;
+	void *obj;
+
+	obj = z_get_fd_obj_and_vtable(fd, &efd_vtable, &lock);
+
+	(void)k_mutex_lock(lock, K_FOREVER);
+
+	ret = efd_vtable->write(obj, &value, sizeof(value));
+
+	k_mutex_unlock(lock);
+
+	return ret == sizeof(eventfd_t) ? 0 : -1;
+}

--- a/tests/posix/eventfd/Kconfig
+++ b/tests/posix/eventfd/Kconfig
@@ -1,0 +1,43 @@
+# Copyright (c) 2023, Meta
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config TEST_DURATION_S
+	int "Number of seconds to run the test"
+	range 1 21600
+	default 5
+	help
+	   Duration for the test, in seconds. The range has a reblatively high
+	   upper bound because we should expect that eventfd_read() and
+	   eventfd_write() are stable enough to run for an arbitrarily long
+	   period of time without encountering any race conditions.
+
+config TEST_TIMEOUT_S
+	int "Number of seconds to run the test"
+	range 1 21600
+	default 10
+
+config TEST_STACK_SIZE
+	int "Size of each thread stack in this test"
+	default 2048
+	help
+	  The minimal stack size required to run a no-op thread.
+
+config TEST_EXTRA_ASSERTIONS
+	bool "Add extra assertions into the hot path"
+	help
+	  In order to get a true benchmark, there should be as few branches
+	  as possible on the hot path. Say 'y' here to add extra assertions
+	  on the hot path as well to verify functionality.
+
+config TEST_EXTRA_QUIET
+	bool "Do not print out regular reports"
+	help
+	  In order to get a true benchmark, there should be as few branches
+	  as possible on the hot path. Say 'y' here to skip reporting.
+
+module = EVENTFD_TEST
+module-str = eventfd
+source "subsys/logging/Kconfig.template.log_config"

--- a/tests/posix/eventfd/src/blocking.c
+++ b/tests/posix/eventfd/src/blocking.c
@@ -71,7 +71,7 @@ ZTEST_F(eventfd, test_unset_poll_event_block)
 	eventfd_poll_unset_common(fixture->fd);
 }
 
-K_THREAD_STACK_DEFINE(thread_stack, 2048);
+K_THREAD_STACK_DEFINE(thread_stack, CONFIG_TEST_STACK_SIZE);
 
 static void thread_fun(void *arg1, void *arg2, void *arg3)
 {

--- a/tests/posix/eventfd/src/blocking.c
+++ b/tests/posix/eventfd/src/blocking.c
@@ -21,12 +21,8 @@ ZTEST_F(eventfd, test_write_then_read)
 	zassert_true(ret == 0, "read ret %d", ret);
 	zassert_true(val == 5, "val == %d", val);
 
-	close(fixture->fd);
-
 	/* Test EFD_SEMAPHORE */
-
-	fixture->fd = eventfd(0, EFD_SEMAPHORE);
-	zassert_true(fixture->fd >= 0, "fd == %d", fixture->fd);
+	reopen(&fixture->fd, 0, EFD_SEMAPHORE);
 
 	ret = eventfd_write(fixture->fd, 3);
 	zassert_true(ret == 0, "write ret %d", ret);

--- a/tests/posix/eventfd/src/stress.c
+++ b/tests/posix/eventfd/src/stress.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2023, Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "_main.h"
+
+/* update interval for printing stats */
+#if CONFIG_TEST_DURATION_S >= 60
+#define UPDATE_INTERVAL_S 10
+#elif CONFIG_TEST_DURATION_S >= 30
+#define UPDATE_INTERVAL_S 5
+#else
+#define UPDATE_INTERVAL_S 1
+#endif
+
+enum th_id {
+	WRITER,
+	READER,
+};
+
+typedef int (*eventfd_op_t)(int fd);
+
+static size_t count[2];
+static struct k_thread th[2];
+static const char *msg[2] = {
+	[READER] = "reads",
+	[WRITER] = "writes",
+};
+
+static int read_op(int fd);
+static int write_op(int fd);
+
+static const eventfd_op_t op[2] = {
+	[READER] = read_op,
+	[WRITER] = write_op,
+};
+static K_THREAD_STACK_ARRAY_DEFINE(th_stack, 2, CONFIG_TEST_STACK_SIZE);
+
+static int read_op(int fd)
+{
+	eventfd_t value;
+
+	return eventfd_read(fd, &value);
+}
+
+static int write_op(int fd)
+{
+	return eventfd_write(fd, 1);
+}
+
+static void th_fun(void *arg1, void *arg2, void *arg3)
+{
+
+	int ret;
+	uint64_t now;
+	uint64_t end;
+	uint64_t report;
+	enum th_id id = POINTER_TO_UINT(arg1);
+	struct eventfd_fixture *fixture = arg2;
+	const uint64_t report_ms = UPDATE_INTERVAL_S * MSEC_PER_SEC;
+	const uint64_t end_ms = CONFIG_TEST_DURATION_S * MSEC_PER_SEC;
+
+	for (now = k_uptime_get(), end = now + end_ms, report = now + report_ms; now < end;
+	     now = k_uptime_get()) {
+
+		ret = op[id](fixture->fd);
+		if (IS_ENABLED(CONFIG_TEST_EXTRA_ASSERTIONS)) {
+			zassert_true(ret == 0 || (ret == -1 && errno == EAGAIN),
+				     "ret: %d errno: %d", ret, errno);
+		}
+		count[id] += (ret == 0);
+
+		if (!IS_ENABLED(CONFIG_TEST_EXTRA_QUIET)) {
+			if (now >= report) {
+				printk("%zu %s\n", count[id], msg[id]);
+				report += report_ms;
+			}
+		}
+	}
+
+	printk("avg: %zu %s/s\n", (size_t)((count[id] * MSEC_PER_SEC) / end_ms), msg[id]);
+}
+
+ZTEST_F(eventfd, test_stress)
+{
+	enum th_id i;
+	enum th_id begin = MIN(READER, WRITER);
+	enum th_id end = MAX(READER, WRITER) + 1;
+
+	printk("BOARD: %s\n", CONFIG_BOARD);
+	printk("TEST_DURATION_S: %u\n", CONFIG_TEST_DURATION_S);
+	printk("UPDATE_INTERVAL_S: %u\n", UPDATE_INTERVAL_S);
+
+	reopen(&fixture->fd, 0, EFD_NONBLOCK | EFD_SEMAPHORE);
+
+	for (i = begin; i < end; ++i) {
+		k_thread_create(&th[i], th_stack[i], K_THREAD_STACK_SIZEOF(th_stack[0]), th_fun,
+				UINT_TO_POINTER(i), fixture, NULL, K_LOWEST_APPLICATION_THREAD_PRIO,
+				0, K_NO_WAIT);
+	}
+
+	for (i = begin; i < end; ++i) {
+		zassert_ok(k_thread_join(&th[i], K_FOREVER));
+	}
+
+	zassert_true(count[READER] > 0, "read count is zero");
+	zassert_true(count[WRITER] > 0, "write count is zero");
+	zassert_true(count[WRITER] >= count[READER], "read count (%zu) > write count (%zu)",
+		     count[READER], count[WRITER]);
+}


### PR DESCRIPTION
7 commits (please see each commit message for details)

* tests: posix: eventfd: use reopen in test_write_then_read (should have gone into #58406)
* lib: os: add `k_condvar` for each fdtable entry
* posix: eventfd: un-inline `eventfd_read()` and `eventfd_write()`
* posix: eventfd: revise locking, signaling, and allocation
* tests: posix: eventfd: blocking read-write test for deadlock bug
* posix: eventfd: deprecate non-public EFD macros
* tests: posix: eventfd: add stress test

Fixes #58426

Note: this improves non-blocking `eventfd` performance significantly.

I would suggest reading each commit individually with the exception of the eventfd revision.

For that one, it's probably easiest just to look at the end result [here](https://github.com/zephyrproject-rtos/zephyr/blob/5d67c8a8037d0c6b974cdc45ae2e779fae8a5c42/lib/posix/eventfd.c).