### PR TITLE
toolchain: xtensa: enable C11 features with xt-clang

### DIFF
--- a/include/zephyr/toolchain/xcc.h
+++ b/include/zephyr/toolchain/xcc.h
@@ -18,6 +18,21 @@
 #define __BYTE_ORDER__
 #endif
 
+#ifdef __clang__
+#if __clang_major__ >= 10
+#define __fallthrough __attribute__((fallthrough))
+#endif
+
+#define TOOLCHAIN_CLANG_VERSION \
+	((__clang_major__ * 10000) + (__clang_minor__ * 100) + \
+	__clang_patchlevel__)
+
+#if TOOLCHAIN_CLANG_VERSION >= 30800
+#define TOOLCHAIN_HAS_C_GENERIC 1
+#define TOOLCHAIN_HAS_C_AUTO_TYPE 1
+#endif
+#endif
+
 #include <zephyr/toolchain/gcc.h>
 
 #ifndef __clang__


### PR DESCRIPTION
If XCC toolchain is clang based, enabled C11 features by defining TOOLCHAIN_HAS_C_GENERIC and TOOLCHAIN_HAS_C_AUTO_TYPE. Mirror the definitions in include/zephyr/toolchain/llvm.h

This is required to build Zephyr with features requiring tagged arguments like LOG_MIPI_SYST_USE_CATALOG.

Suggested-by: Daniel Leung <daniel.leung@intel.com>