### PR TITLE
logging: fix format strings not being put in log_strings_area

### DIFF
--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -342,7 +342,8 @@ do { \
 #define Z_LOG_MSG_STR_VAR_IN_SECTION(_name, ...) \
 	COND_CODE_0(NUM_VA_ARGS_LESS_1(_, ##__VA_ARGS__), \
 		    (/* No args provided, no variable */), \
-		    (static const TYPE_SECTION_ITERABLE(char *, _name, log_strings, _name) = \
+		    (static const char _name[] \
+		     __in_section(_log_strings, static, _CONCAT(_name, _)) __used __noasan = \
 			GET_ARG_N(1, __VA_ARGS__);))
 
 /** @brief Create variable in the dedicated memory section (if enabled).


### PR DESCRIPTION
Commit caea9dc1966588de0a6ea712cb388d237acbfa83
("logging: Use TYPE_SECTION macros for log strings") changed to use TYPE_SECTION macros for log strings. However, the data type was changed from char[] to (char *), resulting in the pointer to log strings are being put in the log_strings_area section instead of the actual strings. Fix this by reverting the data type change back to before that commit but semantically uses TYPE_SECTION_ITERABLE() by expanding it manually.

Fixes #58476