### PR TITLE
[Backport v2.7-branch] Bluetooth: host: add missing meta data destroy callback

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -528,7 +528,11 @@ static bool send_frag(struct bt_conn *conn, struct net_buf *buf, uint8_t flags,
 fail:
 	k_sem_give(bt_conn_get_pkts(conn));
 	if (tx) {
-		tx_free(tx);
+		/* `buf` might not get destroyed, and its `tx` pointer will still be reachable.
+		 * Make sure that we don't try to use the destroyed context later.
+		 */
+		tx_data(buf)->tx = NULL;
+		conn_tx_destroy(conn, tx);
 	}
 
 	if (always_consume) {
@@ -640,11 +644,17 @@ static void conn_cleanup(struct bt_conn *conn)
 
 	/* Give back any allocated buffers */
 	while ((buf = net_buf_get(&conn->tx_queue, K_NO_WAIT))) {
-		if (tx_data(buf)->tx) {
-			tx_free(tx_data(buf)->tx);
-		}
+		struct bt_conn_tx *tx = tx_data(buf)->tx;
 
+		tx_data(buf)->tx = NULL;
+
+		/* destroy the buffer */
 		net_buf_unref(buf);
+
+		/* destroy the tx context (and any associated meta-data) */
+		if (tx) {
+			conn_tx_destroy(conn, tx);
+		}
 	}
 
 	__ASSERT(sys_slist_is_empty(&conn->tx_pending), "Pending TX packets");

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -734,7 +734,17 @@ void bt_conn_process_tx(struct bt_conn *conn)
 	buf = net_buf_get(&conn->tx_queue, K_NO_WAIT);
 	BT_ASSERT(buf);
 	if (!send_buf(conn, buf)) {
+		struct bt_conn_tx *tx = tx_data(buf)->tx;
+
+		tx_data(buf)->tx = NULL;
+
+		/* destroy the buffer */
 		net_buf_unref(buf);
+
+		/* destroy the tx context (and any associated meta-data) */
+		if (tx) {
+			conn_tx_destroy(conn, tx);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/58481