### PR TITLE
Bluetooth: Mesh: Fix unable sent mesh message

### DIFF
--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -307,8 +307,10 @@ static void send_pending_adv(struct k_work *work)
 		return;
 	}
 
-	if (!bt_mesh_adv_gatt_send()) {
-		atomic_set_bit(adv->flags, ADV_FLAG_PROXY);
+	atomic_set_bit(adv->flags, ADV_FLAG_PROXY);
+
+	if (bt_mesh_adv_gatt_send()) {
+		atomic_clear_bit(adv->flags, ADV_FLAG_PROXY);
 	}
 
 	if (atomic_test_and_clear_bit(adv->flags, ADV_FLAG_SCHEDULE_PENDING)) {


### PR DESCRIPTION
The `bt_mesh_adv_gatt_send` not immediately returning, and receiving connection establishment and advertising termination event at this time, so the flag `ADV_FLAG_PROXY` not set at all, so the cb `connected` will not process correctly.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/58721