### PR TITLE
input: check for gpio_add_callback error codes.

### DIFF
--- a/drivers/input/input_ft5336.c
+++ b/drivers/input/input_ft5336.c
@@ -173,7 +173,11 @@ static int ft5336_init(const struct device *dev)
 
 	gpio_init_callback(&data->int_gpio_cb, ft5336_isr_handler,
 			   BIT(config->int_gpio.pin));
-	gpio_add_callback(config->int_gpio.port, &data->int_gpio_cb);
+	r = gpio_add_callback(config->int_gpio.port, &data->int_gpio_cb);
+	if (r < 0) {
+		LOG_ERR("Could not set gpio callback");
+		return r;
+	}
 #else
 	k_timer_init(&data->timer, ft5336_timer_handler, NULL);
 	k_timer_start(&data->timer, K_MSEC(CONFIG_INPUT_FT5336_PERIOD),

--- a/drivers/input/input_gpio_keys.c
+++ b/drivers/input/input_gpio_keys.c
@@ -97,11 +97,17 @@ static void gpio_keys_interrupt(const struct device *dev, struct gpio_callback *
 static int gpio_keys_interrupt_configure(const struct gpio_dt_spec *gpio_spec,
 					 struct gpio_keys_callback *cb, uint32_t zephyr_code)
 {
-	int retval = -ENODEV;
+	int retval;
 	gpio_flags_t flags;
 
 	gpio_init_callback(&cb->gpio_cb, gpio_keys_interrupt, BIT(gpio_spec->pin));
-	gpio_add_callback(gpio_spec->port, &cb->gpio_cb);
+
+	retval = gpio_add_callback(gpio_spec->port, &cb->gpio_cb);
+	if (retval < 0) {
+		LOG_ERR("Could not set gpio callback");
+		return retval;
+	}
+
 	cb->zephyr_code = zephyr_code;
 	cb->pin_state = -1;
 	flags = GPIO_INT_EDGE_BOTH & ~GPIO_INT_MODE_DISABLED;


### PR DESCRIPTION
Add two error code check for gpio_add_callback functions to avoid triggering a coverity warning.

Drop a redundant initialization in the process.

Fixes #58598