### PR TITLE
net: wifi_mgmt: Reject TWT setup till DHCP IP address is configured

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -351,6 +351,7 @@ enum wifi_twt_fail_reason {
 	WIFI_TWT_FAIL_PEER_NOT_TWT_CAPAB,
 	WIFI_TWT_FAIL_OPERATION_IN_PROGRESS,
 	WIFI_TWT_FAIL_INVALID_FLOW_ID,
+	WIFI_TWT_FAIL_IP_NOT_ASSIGNED,
 };
 
 static const char * const twt_err_code_tbl[] = {
@@ -368,6 +369,8 @@ static const char * const twt_err_code_tbl[] = {
 		"Operation already in progress",
 	[WIFI_TWT_FAIL_INVALID_FLOW_ID] =
 		"Invalid negotiated flow id",
+	[WIFI_TWT_FAIL_IP_NOT_ASSIGNED] =
+		"IP address not assigned",
 };
 
 static inline const char *get_twt_err_code_str(int16_t err_no)

--- a/subsys/net/l2/wifi/Kconfig
+++ b/subsys/net/l2/wifi/Kconfig
@@ -27,3 +27,14 @@ config WIFI_MGMT_RAW_SCAN_RESULTS_ONLY
 	  to the application.
 
 endif # WIFI_MGMT_RAW_SCAN_RESULTS
+
+config WIFI_MGMT_TWT_CHECK_IP
+	bool "Check IP Assignment for TWT"
+	default y
+	help
+	  This option enables check for valid IP address before TWT setup.
+	  If TWT setup is triggered early in the connection, then device might
+	  enter deep sleep without having a valid IP, this can result in device
+	  being unreachable (IP Level) or unable to receive down link traffic
+	  even when it is awake intervals. Rejecting TWT setup till Wi-Fi
+	  interface has a valid IP address might be desirable in most scenarios.

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -310,6 +310,18 @@ static int wifi_set_twt(uint32_t mgmt_request, struct net_if *iface,
 		goto fail;
 	}
 
+#ifdef CONFIG_WIFI_MGMT_TWT_CHECK_IP
+	if ((!net_if_ipv4_get_global_addr(iface, NET_ADDR_PREFERRED)) &&
+	    (!net_if_ipv6_get_global_addr(NET_ADDR_PREFERRED, &iface))) {
+		twt_params->fail_reason =
+			WIFI_TWT_FAIL_IP_NOT_ASSIGNED;
+		goto fail;
+	}
+#else
+	NET_WARN("Check for valid IP address been disabled. "
+		 "Device might be unreachable or might not receive traffic.\n");
+#endif /* CONFIG_WIFI_MGMT_TWT_CHECK_IP */
+
 	if (info.link_mode < WIFI_6) {
 		twt_params->fail_reason =
 			WIFI_TWT_FAIL_PEER_NOT_HE_CAPAB;


### PR DESCRIPTION
If a user tries to enable TWT too early in the connection, then we might enter TWT sleep even before DHCP is completed, this can result in packet loss as when we wakeup we cannot receive traffic and completing DHCP itself can take multiple intervals. Reject TWT till Wi-Fi interface has a valid DHCP IP address.