### PR TITLE
drivers: can: mcan: fix IRQ acknowledge

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -541,6 +541,11 @@ void can_mcan_line_0_isr(const struct device *dev)
 	}
 
 	while ((ir & events) != 0U) {
+		err = can_mcan_write_reg(dev, CAN_MCAN_IR, ir & events);
+		if (err != 0) {
+			return;
+		}
+
 		if ((ir & (CAN_MCAN_IR_BO | CAN_MCAN_IR_EP | CAN_MCAN_IR_EW)) != 0U) {
 			can_mcan_state_change_handler(dev);
 		}
@@ -561,11 +566,6 @@ void can_mcan_line_0_isr(const struct device *dev)
 
 		if (ir & CAN_MCAN_IR_MRAF) {
 			LOG_ERR("Message RAM access failure");
-		}
-
-		err = can_mcan_write_reg(dev, CAN_MCAN_IR, events);
-		if (err != 0) {
-			return;
 		}
 
 		err = can_mcan_read_reg(dev, CAN_MCAN_IR, &ir);
@@ -722,6 +722,11 @@ void can_mcan_line_1_isr(const struct device *dev)
 	}
 
 	while ((ir & events) != 0U) {
+		err = can_mcan_write_reg(dev, CAN_MCAN_IR, events & ir);
+		if (err != 0) {
+			return;
+		}
+
 		if ((ir & CAN_MCAN_IR_RF0N) != 0U) {
 			LOG_DBG("RX FIFO0 INT");
 			can_mcan_get_message(dev, config->mram_offsets[CAN_MCAN_MRAM_CFG_RX_FIFO0],
@@ -740,11 +745,6 @@ void can_mcan_line_1_isr(const struct device *dev)
 
 		if ((ir & CAN_MCAN_IR_RF1L) != 0U) {
 			LOG_ERR("Message lost on FIFO1");
-		}
-
-		err = can_mcan_write_reg(dev, CAN_MCAN_IR, events);
-		if (err != 0) {
-			return;
 		}
 
 		err = can_mcan_read_reg(dev, CAN_MCAN_IR, &ir);


### PR DESCRIPTION
Change the Bosch M_CAN ISRs to only acknowledge the IRQs handled in the given loop iteration (and not all IRQs supported by the given ISR) and move IRQ acknowledge to the front of the ISRs.

Fixes: #58631