### PR TITLE
Bluetooth: Audio: Cap initiator cancel procedure

### DIFF
--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -78,10 +78,12 @@ struct bt_cap_initiator_cb {
 	 *
 	 * @param unicast_group  The unicast group pointer supplied to
 	 *                       bt_cap_initiator_unicast_audio_start().
-	 * @param err            0 if success, else BT_GATT_ERR() with a
-	 *                       specific ATT (BT_ATT_ERR_*) error code.
+	 * @param err            0 if success, BT_GATT_ERR() with a
+	 *                       specific ATT (BT_ATT_ERR_*) error code or -ECANCELED if cancelled
+	 *                       by bt_cap_initiator_unicast_audio_cancel().
 	 * @param conn           Pointer to the connection where the error
-	 *                       occurred. NULL if @p err is 0.
+	 *                       occurred. NULL if @p err is 0 or if cancelled by
+	 *                       bt_cap_initiator_unicast_audio_cancel()
 	 */
 	void (*unicast_start_complete)(struct bt_bap_unicast_group *unicast_group,
 				       int err, struct bt_conn *conn);
@@ -89,10 +91,12 @@ struct bt_cap_initiator_cb {
 	/**
 	 * @brief Callback for bt_cap_initiator_unicast_audio_update().
 	 *
-	 * @param err            0 if success, else BT_GATT_ERR() with a
-	 *                       specific ATT (BT_ATT_ERR_*) error code.
+	 * @param err            0 if success, BT_GATT_ERR() with a
+	 *                       specific ATT (BT_ATT_ERR_*) error code or -ECANCELED if cancelled
+	 *                       by bt_cap_initiator_unicast_audio_cancel().
 	 * @param conn           Pointer to the connection where the error
-	 *                       occurred. NULL if @p err is 0.
+	 *                       occurred. NULL if @p err is 0 or if cancelled by
+	 *                       bt_cap_initiator_unicast_audio_cancel()
 	 */
 	void (*unicast_update_complete)(int err, struct bt_conn *conn);
 
@@ -107,10 +111,12 @@ struct bt_cap_initiator_cb {
 	 *
 	 * @param unicast_group  The unicast group pointer supplied to
 	 *                       bt_cap_initiator_unicast_audio_stop().
-	 * @param err            0 if success, else BT_GATT_ERR() with a
-	 *                       specific ATT (BT_ATT_ERR_*) error code.
+	 * @param err            0 if success, BT_GATT_ERR() with a
+	 *                       specific ATT (BT_ATT_ERR_*) error code or -ECANCELED if cancelled
+	 *                       by bt_cap_initiator_unicast_audio_cancel().
 	 * @param conn           Pointer to the connection where the error
-	 *                       occurred. NULL if @p err is 0.
+	 *                       occurred. NULL if @p err is 0 or if cancelled by
+	 *                       bt_cap_initiator_unicast_audio_cancel()
 	 */
 	void (*unicast_stop_complete)(struct bt_bap_unicast_group *unicast_group,
 				      int err, struct bt_conn *conn);
@@ -268,6 +274,30 @@ int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_upda
  * @return 0 on success or negative error value on failure.
  */
 int bt_cap_initiator_unicast_audio_stop(struct bt_bap_unicast_group *unicast_group);
+
+/** @brief Cancel any current Common Audio Profile procedure
+ *
+ * This will stop the current procedure from continuing and making it possible to run a new
+ * Common Audio Profile procedure.
+ *
+ * It is recommended to do this if any existing procedure take longer time than expected, which
+ * could indicate a missing response from the Common Audio Profile Acceptor.
+ *
+ * This does not send any requests to any Common Audio Profile Acceptors involved with the current
+ * procedure, and thus notifications from the Common Audio Profile Acceptors may arrive after this
+ * has been called. It is thus recommended to either only use this if a procedure has stalled, or
+ * wait a short while before starting any new Common Audio Profile procedure after this has been
+ * called to avoid getting notifications from the cancelled procedure. The wait time depends on
+ * the connection interval, the number of devices in the previous procedure and the behavior of the
+ * Common Audio Profile Acceptors.
+ *
+ * The respective callbacks of the procedure will be called as part of this with the connection
+ * pointer set to 0 and the err value set to -ECANCELED.
+ *
+ * @retval 0 on success
+ * @retval -EALREADY if no procedure is active
+ */
+int bt_cap_initiator_unicast_audio_cancel(void);
 
 struct bt_cap_initiator_broadcast_stream_param {
 	/** Audio stream */

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -469,6 +469,19 @@ static int cmd_cap_initiator_unicast_stop(const struct shell *sh, size_t argc,
 	return err;
 }
 
+static int cmd_cap_initiator_unicast_cancel(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = 0;
+
+	err = bt_cap_initiator_unicast_audio_cancel();
+	if (err != 0) {
+		shell_print(sh, "Failed to cancel unicast audio procedure: %d", err);
+
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 
 static int cmd_cap_initiator(const struct shell *sh, size_t argc, char **argv)
@@ -499,6 +512,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(cap_initiator_cmds,
 		      CAP_UNICAST_CLIENT_STREAM_COUNT),
 	SHELL_CMD_ARG(unicast-stop, NULL, "Unicast stop all streams",
 		      cmd_cap_initiator_unicast_stop, 1, 0),
+	SHELL_CMD_ARG(unicast-cancel, NULL, "Unicast cancel current procedure",
+		      cmd_cap_initiator_unicast_cancel, 1, 0),
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 	SHELL_SUBCMD_SET_END
 );

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2022 Nordic Semiconductor ASA
+# Copyright (c) 2022-2023 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -15,10 +15,10 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running CAP broadcast test =========\n\n"
 
 Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_acceptor_broadcast -rs=23
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_broadcast -rs=46
 
 Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_initiator_broadcast -rs=46
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_broadcast -rs=23
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2022 Nordic Semiconductor ASA
+# Copyright (c) 2022-2023 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -15,10 +15,10 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running CAP unicast test =========\n\n"
 
 Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_acceptor_unicast -rs=23
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_unicast -rs=46
 
 Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_initiator_unicast -rs=46
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_unicast -rs=23
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+SIMULATION_ID="cap_unicast_timeout"
+VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=20
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+cd ${BSIM_OUT_PATH}/bin
+
+printf "\n\n======== Running CAP unicast timeout test =========\n\n"
+
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_acceptor_unicast_timeout -rs=23
+
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_initiator_unicast_timeout -rs=46
+
+# Simulation time should be larger than the WAIT_TIME in common.h
+Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+  -D=2 -sim_length=60e6 $@
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
@@ -15,10 +15,10 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running CAP unicast timeout test =========\n\n"
 
 Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_acceptor_unicast_timeout -rs=23
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_unicast_timeout -rs=46
 
 Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_initiator_unicast_timeout -rs=46
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_unicast_timeout -rs=23
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \


### PR DESCRIPTION
Adds support for cancelling any pending procedures if we are not receiving a response from the CAP acceptor. 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/57776