### PR TITLE
debug: coredump: xtensa: Add support for espressif socs

### DIFF
--- a/arch/xtensa/core/coredump.c
+++ b/arch/xtensa/core/coredump.c
@@ -17,6 +17,7 @@ enum xtensa_soc_code {
 	XTENSA_SOC_SAMPLE_CONTROLLER,
 	XTENSA_SOC_ESP32,
 	XTENSA_SOC_INTEL_ADSP,
+	XTENSA_SOC_ESP32S2,
 };
 
 struct xtensa_arch_block {
@@ -111,6 +112,8 @@ void arch_coredump_info_dump(const z_arch_esf_t *esf)
 		arch_blk.soc = XTENSA_SOC_ESP32;
 	#elif CONFIG_SOC_FAMILY_INTEL_ADSP
 		arch_blk.soc = XTENSA_SOC_INTEL_ADSP;
+	#elif CONFIG_SOC_ESP32S2
+		arch_blk.soc = XTENSA_SOC_ESP32S2;
 	#else
 		arch_blk.soc = XTENSA_SOC_UNKNOWN;
 	#endif

--- a/arch/xtensa/core/coredump.c
+++ b/arch/xtensa/core/coredump.c
@@ -18,6 +18,7 @@ enum xtensa_soc_code {
 	XTENSA_SOC_ESP32,
 	XTENSA_SOC_INTEL_ADSP,
 	XTENSA_SOC_ESP32S2,
+	XTENSA_SOC_ESP32S3,
 };
 
 struct xtensa_arch_block {
@@ -114,6 +115,8 @@ void arch_coredump_info_dump(const z_arch_esf_t *esf)
 		arch_blk.soc = XTENSA_SOC_INTEL_ADSP;
 	#elif CONFIG_SOC_ESP32S2
 		arch_blk.soc = XTENSA_SOC_ESP32S2;
+	#elif CONFIG_SOC_ESP32S3
+		arch_blk.soc = XTENSA_SOC_ESP32S3;
 	#else
 		arch_blk.soc = XTENSA_SOC_UNKNOWN;
 	#endif

--- a/doc/services/debugging/coredump.rst
+++ b/doc/services/debugging/coredump.rst
@@ -18,6 +18,8 @@ Configure this module using the following options.
 Here are the options to enable output backends for core dump:
 
 * ``DEBUG_COREDUMP_BACKEND_LOGGING``: use log module for core dump output.
+* ``DEBUG_COREDUMP_BACKEND_FLASH_PARTITION``: use flash partition for core
+  dump output.
 * ``DEBUG_COREDUMP_BACKEND_NULL``: fallback core dump backend if other
   backends cannot be enabled. All output is sent to null.
 
@@ -61,6 +63,20 @@ This usually involves the following steps:
    Developers for Intel ADSP CAVS 15-25 platforms using
    ``ZEPHYR_TOOLCHAIN_VARIANT=zephyr`` should use the debugger in the
    ``xtensa-intel_apl_adsp`` toolchain of the SDK.
+
+5. When ``DEBUG_COREDUMP_BACKEND_FLASH_PARTITION`` is enabled the core dump
+   data is stored in the flash partition. The flash partition must be defined
+   in the device tree:
+
+	.. code-block:: devicetree
+
+		&flash0 {
+			partitions {
+				coredump_partition: partition@255000 {
+					label = "coredump-partition";
+					reg = <0x255000 DT_SIZE_K(4)>;
+				};
+		};
 
 Example
 -------

--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -57,6 +57,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(flash_esp32, CONFIG_FLASH_LOG_LEVEL);
 
+#define FLASH_SEM_TIMEOUT (k_is_in_isr() ? K_NO_WAIT : K_FOREVER)
+
 struct flash_esp32_dev_config {
 	spi_dev_t *controller;
 };
@@ -77,7 +79,7 @@ static inline void flash_esp32_sem_take(const struct device *dev)
 {
 	struct flash_esp32_dev_data *data = dev->data;
 
-	k_sem_take(&data->sem, K_FOREVER);
+	k_sem_take(&data->sem, FLASH_SEM_TIMEOUT);
 }
 
 static inline void flash_esp32_sem_give(const struct device *dev)

--- a/scripts/coredump/gdbstubs/arch/xtensa.py
+++ b/scripts/coredump/gdbstubs/arch/xtensa.py
@@ -292,12 +292,6 @@ class GdbRegDef_Sample_Controller:
 # espressif xtensa-overlays -> xtensa_esp32/gdb/gdb/xtensa-config.c
 class GdbRegDef_ESP32:
     ARCH_DATA_BLK_STRUCT_REGS = '<IIIIIIIIIIIIIIIIIIIIIIIII'
-
-    # Maximum index register that can be sent in a group packet is
-    # 104, which prevents us from sending An registers directly.
-    # We get around this by assigning each An in the dump to ARn
-    # and setting WINDOWBASE to 0 and WINDOWSTART to 1; ESP32 GDB
-    # will recalculate the corresponding An.
     SOC_GDB_GPKT_BIN_SIZE = 420
 
     class RegNum(Enum):
@@ -307,22 +301,22 @@ class GdbRegDef_ESP32:
         SAR = 68
         PS = 73
         SCOMPARE1 = 76
-        AR0 = 1
-        AR1 = 2
-        AR2 = 3
-        AR3 = 4
-        AR4 = 5
-        AR5 = 6
-        AR6 = 7
-        AR7 = 8
-        AR8 = 9
-        AR9 = 10
-        AR10 = 11
-        AR11 = 12
-        AR12 = 13
-        AR13 = 14
-        AR14 = 15
-        AR15 = 16
+        A0 = 157
+        A1 = 158
+        A2 = 159
+        A3 = 160
+        A4 = 161
+        A5 = 162
+        A6 = 163
+        A7 = 164
+        A8 = 165
+        A9 = 166
+        A10 = 167
+        A11 = 168
+        A12 = 169
+        A13 = 170
+        A14 = 171
+        A15 = 172
         LBEG = 65
         LEND = 66
         LCOUNT = 67

--- a/scripts/coredump/gdbstubs/arch/xtensa.py
+++ b/scripts/coredump/gdbstubs/arch/xtensa.py
@@ -23,7 +23,7 @@ class XtensaSoc(Enum):
     SAMPLE_CONTROLLER = 1
     ESP32 = 2
     INTEL_ADSP_CAVS = 3
-
+    ESP32S2 = 4
 
 # The previous version of this script didn't need to know
 # what toolchain Zephyr was built with; it assumed sample_controller
@@ -62,6 +62,8 @@ def get_gdb_reg_definition(soc, toolchain):
             sys.exit(1)
         else:
             raise NotImplementedError
+    elif soc == XtensaSoc.ESP32S2:
+        return GdbRegDef_ESP32S2
     else:
         raise NotImplementedError
 
@@ -323,6 +325,34 @@ class GdbRegDef_ESP32:
         WINDOWBASE = 69
         WINDOWSTART = 70
 
+class GdbRegDef_ESP32S2:
+    ARCH_DATA_BLK_STRUCT_REGS = '<IIIIIIIIIIIIIIIIIIIII'
+    SOC_GDB_GPKT_BIN_SIZE = 420
+
+    class RegNum(Enum):
+        PC = 0
+        EXCCAUSE = 99
+        EXCVADDR = 115
+        SAR = 65
+        PS = 70
+        A0 = 155
+        A1 = 156
+        A2 = 157
+        A3 = 158
+        A4 = 159
+        A5 = 160
+        A6 = 161
+        A7 = 162
+        A8 = 163
+        A9 = 164
+        A10 = 165
+        A11 = 166
+        A12 = 167
+        A13 = 168
+        A14 = 169
+        A15 = 170
+        WINDOWBASE = 66
+        WINDOWSTART = 67
 
 # sdk-ng -> overlays/xtensa_intel_apl/gdb/gdb/xtensa-config.c
 class GdbRegDef_Intel_Adsp_CAVS_Zephyr:

--- a/scripts/coredump/gdbstubs/arch/xtensa.py
+++ b/scripts/coredump/gdbstubs/arch/xtensa.py
@@ -24,6 +24,8 @@ class XtensaSoc(Enum):
     ESP32 = 2
     INTEL_ADSP_CAVS = 3
     ESP32S2 = 4
+    ESP32S3 = 5
+
 
 # The previous version of this script didn't need to know
 # what toolchain Zephyr was built with; it assumed sample_controller
@@ -64,6 +66,8 @@ def get_gdb_reg_definition(soc, toolchain):
             raise NotImplementedError
     elif soc == XtensaSoc.ESP32S2:
         return GdbRegDef_ESP32S2
+    elif soc == XtensaSoc.ESP32S3:
+        return GdbRegDef_ESP32S3
     else:
         raise NotImplementedError
 
@@ -147,9 +151,12 @@ class GdbStub_Xtensa(GdbStub):
         arch_data_blk = self.logfile.get_arch_data()['data']
 
         self.version = struct.unpack('H', arch_data_blk[1:3])[0]
+        logger.debug("Xtensa GDB stub version: %d" % self.version)
 
         # Get SOC and toolchain to get correct format for unpack
         self.soc = XtensaSoc(bytearray(arch_data_blk)[0])
+        logger.debug("Xtensa SOC: %s" % self.soc.name)
+
         if self.version >= 2:
             self.toolchain = XtensaToolchain(bytearray(arch_data_blk)[3])
             arch_data_blk_regs = arch_data_blk[4:]
@@ -161,6 +168,8 @@ class GdbStub_Xtensa(GdbStub):
             else:
                 self.toolchain = XtensaToolchain.ZEPHYR
             arch_data_blk_regs = arch_data_blk[3:]
+
+        logger.debug("Xtensa toolchain: %s" % self.toolchain.name)
 
         self.gdb_reg_def = get_gdb_reg_definition(self.soc, self.toolchain)
 
@@ -353,6 +362,39 @@ class GdbRegDef_ESP32S2:
         A15 = 170
         WINDOWBASE = 66
         WINDOWSTART = 67
+
+class GdbRegDef_ESP32S3:
+    ARCH_DATA_BLK_STRUCT_REGS = '<IIIIIIIIIIIIIIIIIIIIIIIII'
+    SOC_GDB_GPKT_BIN_SIZE = 420
+
+    class RegNum(Enum):
+        PC = 0
+        EXCCAUSE = 166
+        EXCVADDR = 172
+        SAR = 68
+        PS = 73
+        SCOMPARE1 = 76
+        A0 = 212
+        A1 = 213
+        A2 = 214
+        A3 = 215
+        A4 = 216
+        A5 = 217
+        A6 = 218
+        A7 = 219
+        A8 = 220
+        A9 = 221
+        A10 = 222
+        A11 = 223
+        A12 = 224
+        A13 = 225
+        A14 = 226
+        A15 = 227
+        LBEG = 65
+        LEND = 66
+        LCOUNT = 67
+        WINDOWBASE = 69
+        WINDOWSTART = 70
 
 # sdk-ng -> overlays/xtensa_intel_apl/gdb/gdb/xtensa-config.c
 class GdbRegDef_Intel_Adsp_CAVS_Zephyr:

--- a/soc/xtensa/esp32s2/Kconfig.soc
+++ b/soc/xtensa/esp32s2/Kconfig.soc
@@ -10,6 +10,7 @@ config SOC_ESP32S2
 	select PINCTRL
 	select XIP if !MCUBOOT
 	select HAS_ESPRESSIF_HAL
+	select ARCH_SUPPORTS_COREDUMP
 
 if SOC_ESP32S2
 

--- a/subsys/debug/coredump/coredump_backend_flash_partition.c
+++ b/subsys/debug/coredump/coredump_backend_flash_partition.c
@@ -48,6 +48,8 @@ LOG_MODULE_REGISTER(coredump, CONFIG_KERNEL_LOG_LEVEL);
 
 #define HDR_VER			1
 
+#define FLASH_BACKEND_SEM_TIMEOUT (k_is_in_isr() ? K_NO_WAIT : K_FOREVER)
+
 typedef int (*data_read_cb_t)(void *arg, uint8_t *buf, size_t len);
 
 static struct {
@@ -104,7 +106,7 @@ static int partition_open(void)
 {
 	int ret;
 
-	(void)k_sem_take(&flash_sem, K_FOREVER);
+	(void)k_sem_take(&flash_sem, FLASH_BACKEND_SEM_TIMEOUT);
 
 	ret = flash_area_open(FLASH_PARTITION_ID, &backend_ctx.flash_area);
 	if (ret != 0) {
@@ -617,7 +619,6 @@ struct coredump_backend_api coredump_backend_flash_partition = {
 	.query = coredump_flash_backend_query,
 	.cmd = coredump_flash_backend_cmd,
 };
-
 
 #ifdef CONFIG_DEBUG_COREDUMP_SHELL
 #include <zephyr/shell/shell.h>

--- a/tests/subsys/debug/coredump_backends/boards/esp32.overlay
+++ b/tests/subsys/debug/coredump_backends/boards/esp32.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	partitions {
+		/*
+		 * Reduce storage_partition to make space for
+		 * coredump_partition
+		 */
+
+		storage_partition: partition@250000 {
+			label = "storage";
+			reg = <0x00250000 0x00005000>;
+		};
+
+		coredump_partition: partition@255000 {
+			label = "coredump-partition";
+			reg = <0x255000 DT_SIZE_K(4)>;
+		};
+
+	};
+};

--- a/tests/subsys/debug/coredump_backends/boards/esp32c3_devkitm.overlay
+++ b/tests/subsys/debug/coredump_backends/boards/esp32c3_devkitm.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	partitions {
+		/*
+		 * Reduce storage_partition to make space for
+		 * coredump_partition
+		 */
+
+		storage_partition: partition@250000 {
+			label = "storage";
+			reg = <0x00250000 0x00005000>;
+		};
+
+		coredump_partition: partition@255000 {
+			label = "coredump-partition";
+			reg = <0x255000 DT_SIZE_K(4)>;
+		};
+
+	};
+};

--- a/tests/subsys/debug/coredump_backends/boards/esp32s2_saola.overlay
+++ b/tests/subsys/debug/coredump_backends/boards/esp32s2_saola.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	partitions {
+		/*
+		 * Reduce storage_partition to make space for
+		 * coredump_partition
+		 */
+
+		storage_partition: partition@250000 {
+			label = "storage";
+			reg = <0x00250000 0x00005000>;
+		};
+
+		coredump_partition: partition@255000 {
+			label = "coredump-partition";
+			reg = <0x255000 DT_SIZE_K(4)>;
+		};
+
+	};
+};

--- a/tests/subsys/debug/coredump_backends/boards/esp32s3_devkitm.overlay
+++ b/tests/subsys/debug/coredump_backends/boards/esp32s3_devkitm.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	partitions {
+		/*
+		 * Reduce storage_partition to make space for
+		 * coredump_partition
+		 */
+
+		storage_partition: partition@250000 {
+			label = "storage";
+			reg = <0x00250000 0x00005000>;
+		};
+
+		coredump_partition: partition@255000 {
+			label = "coredump-partition";
+			reg = <0x255000 DT_SIZE_K(4)>;
+		};
+
+	};
+};

--- a/tests/subsys/debug/coredump_backends/testcase.yaml
+++ b/tests/subsys/debug/coredump_backends/testcase.yaml
@@ -18,7 +18,12 @@ tests:
   coredump.backends.flash:
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     extra_args: CONF_FILE=prj_flash_partition.conf
-    platform_allow: qemu_x86
+    platform_allow:
+      - qemu_x86
+      - esp32
+      - esp32s2_saola
+      - esp32s3_devkitm
+      - esp32c3_devkitm
   coredump.backends.other:
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     extra_args: CONF_FILE=prj_backend_other.conf

--- a/west.yml
+++ b/west.yml
@@ -144,7 +144,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: abe299333411cb37a1cb1dd0aa2ea35c27382604
+      revision: 9531c1c17873aa4935f85864ebafd20c02062a8f
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
The current toolchain version for espressif SoCs does not
have the same limitation on registers indexing as the previous
one, enabling sending the correct A0-A15 register values directly

Add coredump support for esp32s2 and esp32s3.

Avoid timeout when taking semaphores in ISR.
Use K_NO_WAIT when in ISR

Add flash partition guide to coredump documentation.

Add overlay for esp32xx boards to coredump backends test.
