### PR TITLE
lorawan: initialise data structures earlier

### DIFF
--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -708,4 +708,4 @@ static int lorawan_init(void)
 	return 0;
 }
 
-SYS_INIT(lorawan_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(lorawan_init, POST_KERNEL, 0);


### PR DESCRIPTION
Now that `lorawan_init` only initialises data structures and does not start the stack or communicate with a physical device, run the init as soon as possible. This allows `lorawan_register_downlink_callback` to be called much earlier by other init functions.