### PR TITLE
manifest: Update nRF HW models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -204,7 +204,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: c8d2ecd25d6976d2d77eccf66878420fdb8ef5a1
+      revision: 37c571ef7c4a86dad852566fc43eb36f42534e9f
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: c904a01d4a882bcbb39987e0e2ce5308f49ac7ad


### PR DESCRIPTION
The nRF HW models have been updated to include the following fixes and improvements.

* PPI: add support for nrf_ppi_group_enable
* BLECrypt: Widen search for crypto library
* Makefile: Switch to gnu11 from c11 due to HAL
* NVMC: Minor fixes in command line options descriptions

Which enable more 15.4 functionality with the nrf driver