### PR TITLE
Bluetooth: Host: Fix bt_addr_from_str for str starting with ':'

### DIFF
--- a/include/zephyr/bluetooth/addr.h
+++ b/include/zephyr/bluetooth/addr.h
@@ -272,7 +272,8 @@ static inline int bt_addr_le_to_str(const bt_addr_le_t *addr, char *str,
  *  @param[in]  str   The string representation of a Bluetooth address.
  *  @param[out] addr  Address of buffer to store the Bluetooth address
  *
- *  @return Zero on success or (negative) error code otherwise.
+ *  @retval 0 Success. The parsed address is stored in @p addr.
+ *  @return -EINVAL Invalid address string. @p str is not a well-formed Bluetooth address.
  */
 int bt_addr_from_str(const char *str, bt_addr_t *addr);
 

--- a/tests/bluetooth/addr/CMakeLists.txt
+++ b/tests/bluetooth/addr/CMakeLists.txt
@@ -6,4 +6,5 @@ project(app)
 
 target_sources(app PRIVATE
 	src/test_bt_addr_le_eq.c
+	src/test_bt_addr_from_str.c
 )

--- a/tests/bluetooth/addr/src/test_bt_addr_from_str.c
+++ b/tests/bluetooth/addr/src/test_bt_addr_from_str.c
@@ -1,0 +1,162 @@
+/* Copyright (c) 2023 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/ztest.h>
+
+ZTEST_SUITE(bt_addr_from_str, NULL, NULL, NULL, NULL, NULL);
+
+ZTEST(bt_addr_from_str, test_reject_empty_string)
+{
+	char *addr_str = "";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_missing_octet)
+{
+	char *addr_str = "ab:ab:ab:ab:ab";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_empty_octet)
+{
+	char *addr_str = "ab:ab:ab:ab::ab";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_short_octet)
+{
+	char *addr_str = "ab:ab:ab:ab:b:ab";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_trailing_colon)
+{
+	char *addr_str = "ab:ab:ab:ab:ab:ab:";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_octet_colon_a)
+{
+	char *addr_str = "ab:ab:ab:ab:a::ab";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_octet_colon_b)
+{
+	char *addr_str = "ab:ab:ab:ab::b:ab";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_octet_space_a)
+{
+	char *addr_str = "ab:ab:ab:ab: b:ab";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_octet_space_b)
+{
+	char *addr_str = "ab:ab:ab:ab:a :ab";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_extra_space_before)
+{
+	char *addr_str = " 00:00:00:00:00:00";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_extra_space_after)
+{
+	char *addr_str = "00:00:00:00:00:00 ";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_replace_space_first)
+{
+	char *addr_str = " 0:00:00:00:00:00";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_replace_colon_first)
+{
+	char *addr_str = ":0:00:00:00:00:00";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_non_hex)
+{
+	char *addr_str = "00:00:00:00:g0:00";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_reject_bad_colon)
+{
+	char *addr_str = "00.00:00:00:00:00";
+	bt_addr_t a;
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), -EINVAL);
+}
+
+ZTEST(bt_addr_from_str, test_order)
+{
+	char *addr_str = "01:02:03:04:05:06";
+	bt_addr_t a;
+	bt_addr_t b = {{6, 5, 4, 3, 2, 1}};
+
+	zassert_equal(bt_addr_from_str(addr_str, &a), 0);
+	zassert_true(bt_addr_eq(&a, &b));
+}
+
+ZTEST(bt_addr_from_str, test_hex_case_equal)
+{
+	char *addr_str_a = "ab:cd:ef:00:00:00";
+	char *addr_str_b = "AB:CD:EF:00:00:00";
+	bt_addr_t a;
+	bt_addr_t b;
+
+	zassert_equal(bt_addr_from_str(addr_str_a, &a), 0);
+	zassert_equal(bt_addr_from_str(addr_str_b, &b), 0);
+	zassert_true(bt_addr_eq(&a, &b));
+}
+
+ZTEST(bt_addr_from_str, test_hex_case_not_equal)
+{
+	char *addr_str_a = "aa:aa:aa:00:00:00";
+	char *addr_str_b = "bb:bb:bb:00:00:00";
+	bt_addr_t a;
+	bt_addr_t b;
+
+	zassert_equal(bt_addr_from_str(addr_str_a, &a), 0);
+	zassert_equal(bt_addr_from_str(addr_str_b, &b), 0);
+	zassert_false(bt_addr_eq(&a, &b));
+}


### PR DESCRIPTION
The previous implementation would read from `addr->val[0]` before it was initialized if the input string started with a colon ':'.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/58504