### PR TITLE
boards: arm: stm32mp157c_dk2: set HSE_CLOCK speed

### DIFF
--- a/boards/arm/stm32mp157c_dk2/Kconfig.defconfig
+++ b/boards/arm/stm32mp157c_dk2/Kconfig.defconfig
@@ -12,4 +12,7 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
+config CLOCK_STM32_HSE_CLOCK
+	default 24000000
+
 endif # BOARD_STM32MP157_Dk2


### PR DESCRIPTION
Since clocks aren't declared in the devicetree for the stm32mp1 co-processor. Set it here to match the clock for the board stm32mp157c_dk2 board setup in u-boot and the linux kernel.
This will fix the clock speed declared for timers etc.

Without this HSE_CLOCK will be set to the default 8000000 declared in `drivers/clock_control/Kconfig.stm32`