### PR TITLE
tests: userspace: Support RT 3 digit

### DIFF
--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -539,3 +539,8 @@ zephyr_udc0: &usbhs {
 
 	status = "okay";
 };
+
+/* Disable this node if not using USB and need another MPU region */
+&sram1 {
+	status = "okay";
+};

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -403,3 +403,8 @@ zephyr_udc0: &usbhs {
 
 	status = "okay";
 };
+
+/* Disable this node if not using USB and need another MPU region */
+&sram1 {
+	status = "okay";
+};

--- a/tests/kernel/mem_protect/userspace/boards/mimxrt595_evk_cm33.overlay
+++ b/tests/kernel/mem_protect/userspace/boards/mimxrt595_evk_cm33.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Disable USB SRAM node because this test does not
+ * need USB but needs an extra MPU region which
+ * otherwise would be taken up for the SRAM1 USB region.
+ */
+&sram1 {
+	status = "disabled";
+};

--- a/tests/kernel/mem_protect/userspace/boards/mimxrt685_evk_cm33.overlay
+++ b/tests/kernel/mem_protect/userspace/boards/mimxrt685_evk_cm33.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Disable USB SRAM node because this test does not
+ * need USB but needs an extra MPU region which
+ * otherwise would be taken up for the SRAM1 USB region.
+ */
+&sram1 {
+	status = "disabled";
+};


### PR DESCRIPTION
RT 3 digit ran out of mpu regions to do this test, so add board overlays to disable the USB SRAM MPU region definition because it is not needed for this test.

Also add a comment to the board dts making it clear that this is possible.

Fixes #58222