### PR TITLE
[DNM] libc: minimal: add minimal wchar.h header

### DIFF
--- a/lib/libc/minimal/include/wchar.h
+++ b/lib/libc/minimal/include/wchar.h
@@ -1,0 +1,24 @@
+/* wchar.h */
+
+/*
+ *  Copyright(c) 2023 Intel Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_WCHAR_H_
+#define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_WCHAR_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define WCHAR_MAX 0xFFFFU
+
+typedef int wint_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_WCHAR_H_ */

--- a/modules/Kconfig.syst
+++ b/modules/Kconfig.syst
@@ -3,7 +3,6 @@
 
 config MIPI_SYST_LIB
 	bool "MIPI SyS-T Library Support"
-	select REQUIRES_FULL_LIBC
 	help
 	  This option enables the MIPI SyS-T Library
 


### PR DESCRIPTION
    [DNM] libc: minimal: add minimal wchar.h header
    
    Currently MIPI_SYST_LIB requires a full C-library implementation
    just because of few definitions it needs from wchar.h.
    
    It's quite inconvenient to have to change libc implementation
    just to enable MIPI Sys-T logs, so this patch provides a minimal
    wchar.h definitions to cver needs of MIPI_SYST_LIB.
    
    Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>
