### PR TITLE
scripts: check_init_priorities: add debugging output

### DIFF
--- a/scripts/build/check_init_priorities.py
+++ b/scripts/build/check_init_priorities.py
@@ -194,6 +194,9 @@ class Validator():
             obj = ZephyrObjectFile(file)
             if obj.defined_devices:
                 self._objs.append(obj)
+                for dev in obj.defined_devices:
+                    dev_path = self._ord2node[dev].path
+                    self.log.debug(f"{file}: {dev_path}")
 
         self._dev_priorities = {}
         for obj in self._objs:
@@ -279,8 +282,9 @@ def _parse_args(argv):
 
     parser.add_argument("-d", "--build-dir", default="build",
                         help="build directory to use")
-    parser.add_argument("-v", "--verbose", action="store_true",
-                        help="enable verbose Output")
+    parser.add_argument("-v", "--verbose", action="count",
+                        help=("enable verbose output, can be used multiple times "
+                              "to increase verbosity level"))
     parser.add_argument("-w", "--fail-on-warning", action="store_true",
                         help="fail on both warnings and errors")
     parser.add_argument("--always-succeed", action="store_true",
@@ -306,7 +310,9 @@ def _init_log(verbose, output):
         file.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
         log.addHandler(file)
 
-    if verbose:
+    if verbose and verbose > 1:
+        log.setLevel(logging.DEBUG)
+    elif verbose and verbose > 0:
         log.setLevel(logging.INFO)
     else:
         log.setLevel(logging.WARNING)

--- a/scripts/build/check_init_priorities_test.py
+++ b/scripts/build/check_init_priorities_test.py
@@ -143,13 +143,14 @@ class testValidator(unittest.TestCase):
     def test_initialize(self, mock_pl, mock_fbo, mock_zof):
         mock_fbo.return_value = ["filepath"]
 
+        mock_log = mock.Mock()
         mock_prio = mock.Mock()
         mock_obj = mock.Mock()
         mock_obj.defined_devices = {123: mock_prio}
         mock_zof.return_value = mock_obj
 
         with mock.patch("builtins.open", mock.mock_open()) as mock_open:
-            validator = check_init_priorities.Validator("path", "pickle", None)
+            validator = check_init_priorities.Validator("path", "pickle", mock_log)
 
         self.assertListEqual(validator._objs, [mock_obj])
         self.assertDictEqual(validator._dev_priorities, {123: mock_prio})
@@ -160,7 +161,9 @@ class testValidator(unittest.TestCase):
     @mock.patch("pathlib.Path")
     @mock.patch("check_init_priorities.Validator.__init__", return_value=None)
     def test_find_build_objfiles(self, mock_vinit, mock_path):
-        validator = check_init_priorities.Validator("", "", None)
+        mock_log = mock.Mock()
+
+        validator = check_init_priorities.Validator("", "", mock_log)
 
         mock_file = mock.Mock()
         mock_file.is_file.return_value = True


### PR DESCRIPTION
Add a -D flag to enable debugging output and add a first debug print to output the file to device path mapping. Found this to be extremely useful to find what file is instantiating a specific device for non obvious cases.

---

Output something like this:

```
$ ./scripts/build/check_init_priorities.py -v -D
INFO: check_init_priorities build_dir: build
DEBUG: zephyr/build/zephyr/drivers/adc/CMakeFiles/drivers__adc.dir/adc_mchp_xec.c.obj: /soc/adc@40007c00
DEBUG: zephyr/build/zephyr/drivers/espi/CMakeFiles/drivers__espi.dir/espi_mchp_xec_v2.c.obj: /soc/espi@400f3400
DEBUG: zephyr/build/zephyr/drivers/serial/CMakeFiles/drivers__serial.dir/uart_mchp_xec.c.obj: /soc/espi@400f3400/uart@400f2800
DEBUG: zephyr/build/zephyr/drivers/interrupt_controller/CMakeFiles/drivers__interrupt_controller.dir/intc_mchp_ecia_xec.c.obj: /soc/ecia@4000e000
DEBUG: zephyr/build/zephyr/drivers/interrupt_controller/CMakeFiles/drivers__interrupt_controller.dir/intc_mchp_ecia_xec.c.obj: /soc/ecia@4000e000/girq25@154
DEBUG: zephyr/build/zephyr/drivers/interrupt_controller/CMakeFiles/drivers__interrupt_controller.dir/intc_mchp_ecia_xec.c.obj: /soc/ecia@4000e000/girq24@140
DEBUG: zephyr/build/zephyr/drivers/i2c/CMakeFiles/drivers__i2c.dir/i2c_mchp_xec_v2.c.obj: /soc/i2c@40004800
DEBUG: zephyr/build/zephyr/drivers/i2c/CMakeFiles/drivers__i2c.dir/i2c_mchp_xec_v2.c.obj: /soc/i2c@40004400
DEBUG: zephyr/build/zephyr/drivers/i2c/CMakeFiles/drivers__i2c.dir/i2c_mchp_xec_v2.c.obj: /soc/i2c@40004000
DEBUG: zephyr/build/zephyr/drivers/clock_control/CMakeFiles/drivers__clock_control.dir/clock_control_mchp_xec.c.obj: /soc/pcr@40080100
DEBUG: zephyr/build/zephyr/drivers/gpio/CMakeFiles/drivers__gpio.dir/gpio_mchp_xec_v2.c.obj: /soc/pin-controller@40081000/gpio@40081280
DEBUG: zephyr/build/zephyr/drivers/gpio/CMakeFiles/drivers__gpio.dir/gpio_mchp_xec_v2.c.obj: /soc/pin-controller@40081000/gpio@40081200
DEBUG: zephyr/build/zephyr/drivers/gpio/CMakeFiles/drivers__gpio.dir/gpio_mchp_xec_v2.c.obj: /soc/pin-controller@40081000/gpio@40081180
DEBUG: zephyr/build/zephyr/drivers/gpio/CMakeFiles/drivers__gpio.dir/gpio_mchp_xec_v2.c.obj: /soc/pin-controller@40081000/gpio@40081100
DEBUG: zephyr/build/zephyr/drivers/gpio/CMakeFiles/drivers__gpio.dir/gpio_mchp_xec_v2.c.obj: /soc/pin-controller@40081000/gpio@40081080
DEBUG: zephyr/build/zephyr/drivers/gpio/CMakeFiles/drivers__gpio.dir/gpio_mchp_xec_v2.c.obj: /soc/pin-controller@40081000/gpio@40081000
DEBUG: zephyr/build/zephyr/drivers/gpio/CMakeFiles/drivers__gpio.dir/gpio_pca95xx.c.obj: /soc/i2c@40004000/pca9555@26
```

In this example the `girq` devices are instantiated with a `FOREACH_CHILD` so it was a bit less obvious how to find them. Would also help debugging duplicate nodes, may even be worth its own flag but for now I reckon debug will do.