### PR TITLE
doc: releases: update LTSv2 release date and version

### DIFF
--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -50,7 +50,7 @@ Supported Releases
 +-----------------+----------------+---------------+
 | Release         | Release date   | EOL           |
 +=================+================+===============+
-| `Zephyr 2.7.4`_ | 23/12/2022     | 31/08/2024    |
+| `Zephyr 2.7.5`_ | 01/06/2023     | 31/08/2024    |
 +-----------------+----------------+---------------+
 | `Zephyr 3.3.0`_ | 19/02/2023     | 31/10/2023    |
 +-----------------+----------------+---------------+
@@ -92,6 +92,6 @@ specific release and can be found at https://docs.zephyrproject.org/.
 
 .. _`GitHub repository`: https://github.com/zephyrproject-rtos/zephyr
 .. _`GitHub tagged releases`: https://github.com/zephyrproject-rtos/zephyr/tags
-.. _`Zephyr 2.7.4`: https://docs.zephyrproject.org/2.7.4/
+.. _`Zephyr 2.7.5`: https://docs.zephyrproject.org/2.7.5/
 .. _`Zephyr 3.2.0`: https://docs.zephyrproject.org/3.2.0/
 .. _`Zephyr 3.3.0`: https://docs.zephyrproject.org/3.3.0/


### PR DESCRIPTION
Update the LTSv2 release date and link to documentation.