### PR TITLE
drivers: can: mcp2515: increase default stack size

### DIFF
--- a/drivers/can/Kconfig.mcp2515
+++ b/drivers/can/Kconfig.mcp2515
@@ -15,7 +15,7 @@ if CAN_MCP2515
 
 config CAN_MCP2515_INT_THREAD_STACK_SIZE
 	int "Stack size for interrupt handler"
-	default 512
+	default 1024
 	help
 	  Size of the stack used for internal thread which is ran for
 	  interrupt handling and incoming packets.

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -938,6 +938,7 @@ static int mcp2515_init(const struct device *dev)
 	const struct mcp2515_config *dev_cfg = dev->config;
 	struct mcp2515_data *dev_data = dev->data;
 	struct can_timing timing;
+	k_tid_t tid;
 	int ret;
 
 	k_sem_init(&dev_data->int_sem, 0, 1);
@@ -986,11 +987,12 @@ static int mcp2515_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	k_thread_create(&dev_data->int_thread, dev_data->int_thread_stack,
-			dev_cfg->int_thread_stack_size,
-			(k_thread_entry_t) mcp2515_int_thread, (void *)dev,
-			NULL, NULL, K_PRIO_COOP(dev_cfg->int_thread_priority),
-			0, K_NO_WAIT);
+	tid = k_thread_create(&dev_data->int_thread, dev_data->int_thread_stack,
+			      dev_cfg->int_thread_stack_size,
+			      (k_thread_entry_t) mcp2515_int_thread, (void *)dev,
+			      NULL, NULL, K_PRIO_COOP(dev_cfg->int_thread_priority),
+			      0, K_NO_WAIT);
+	(void)k_thread_name_set(tid, "mcp2515");
 
 	(void)memset(dev_data->rx_cb, 0, sizeof(dev_data->rx_cb));
 	(void)memset(dev_data->filter, 0, sizeof(dev_data->filter));


### PR DESCRIPTION
Increase the default stack size for the MCP2515 CAN controller driver from 512 to 1024 bytes. Set the thread name for the MCP2515 CAN controller driver to aid in debugging.

Fixes: #58761