### PR TITLE
tests/samples: cleanup tests and improve filtering PR CI

### DIFF
--- a/samples/arch/smp/pktqueue/sample.yaml
+++ b/samples/arch/smp/pktqueue/sample.yaml
@@ -12,7 +12,11 @@ common:
 
 tests:
   sample.smp.pktqueue:
-    tags: introduction
+    tags:
+      - introduction
+      - kernel
+    depends_on:
+      - smp
     filter: (CONFIG_MP_MAX_NUM_CPUS > 1)
     platform_exclude:
       - esp32

--- a/samples/drivers/peci/sample.yaml
+++ b/samples/drivers/peci/sample.yaml
@@ -5,6 +5,8 @@ tests:
     # theoretically EVB can be connected to Intel RVP as well,
     # but HW setup is not documented, hence qualifying as unsupported.
     platform_exclude: mec15xxevb_assy6853
+    integration_platforms:
+      - npcx9m6f_evb
     filter: dt_alias_exists("peci-0")
     tags:
       - drivers

--- a/samples/drivers/uart/echo_bot/sample.yaml
+++ b/samples/drivers/uart/echo_bot/sample.yaml
@@ -2,6 +2,8 @@ sample:
   name: UART driver sample
 tests:
   sample.drivers.uart:
+    integration_platforms:
+      - qemu_x86
     tags:
       - serial
       - uart

--- a/samples/kernel/metairq_dispatch/sample.yaml
+++ b/samples/kernel/metairq_dispatch/sample.yaml
@@ -3,6 +3,8 @@ sample:
     MetaIRQ thread
   name: MetaIRQ Dispatch
 common:
+  tags:
+    - kernel
   integration_platforms:
     - mps2_an385
     - qemu_x86
@@ -18,5 +20,5 @@ common:
 # sample is designed to demonstrate completely arbitrary CPU work.
 tests:
   sample.kernel.metairq_dispatch:
-    tags: introduction
-    filter: not CONFIG_ARCH_POSIX
+    arch_exclude:
+      - posix

--- a/samples/net/sockets/tcp/sample.yaml
+++ b/samples/net/sockets/tcp/sample.yaml
@@ -8,6 +8,7 @@ tests:
     platform_allow: qemu_x86
     tags:
       - socket
+      - net
       - tcp
     integration_platforms:
       - qemu_x86

--- a/samples/net/wpan_serial/sample.yaml
+++ b/samples/net/wpan_serial/sample.yaml
@@ -5,6 +5,7 @@ common:
   depends_on: usb_device
   harness: net
   tags:
+    - net
     - usb
     - ieee802154
   platform_exclude: pinnacle_100_dvk
@@ -12,6 +13,6 @@ tests:
   sample.net.wpan.serial:
     filter: dt_chosen_enabled("zephyr,ieee802154")
     platform_exclude: thingy53_nrf5340_cpuapp_ns
-  sample.net.wpan_serial.frdm_cr20a:
+  sample.net.wpan.serial.frdm_cr20a:
     extra_args: SHIELD=frdm_cr20a
     platform_allow: frdm_k64f

--- a/samples/philosophers/sample.yaml
+++ b/samples/philosophers/sample.yaml
@@ -2,7 +2,9 @@ sample:
   name: Dining Philosophers
 common:
   extra_args: DEBUG_PRINTF=1
-  tags: introduction
+  tags:
+    - inroduction
+    - kernel
   harness: console
   integration_platforms:
     - native_posix
@@ -15,8 +17,7 @@ common:
       - ".*THINKING.*"
       - ".*EATING.*"
 tests:
-  sample.kernel.philosopher:
-    tags: introduction
+  sample.kernel.philosopher: {}
   sample.kernel.philosopher.same_prio:
     extra_args: SAME_PRIO=1
   sample.kernel.philosopher.static:

--- a/samples/sensor/die_temp_polling/sample.yaml
+++ b/samples/sensor/die_temp_polling/sample.yaml
@@ -5,8 +5,9 @@ tests:
   sample.sensor.die_temperature_polling:
     tags:
       - sensors
-      - tests
     filter: dt_alias_exists("die-temp0")
+    integration_platforms:
+      - stm32f3_disco
     harness: console
     harness_config:
       type: one_line

--- a/samples/sensor/esp32_temp_sensor/sample.yaml
+++ b/samples/sensor/esp32_temp_sensor/sample.yaml
@@ -5,7 +5,8 @@ tests:
   sample.sensor.esp32_temp_sensor:
     tags:
       - sensors
-      - tests
+    integration_platforms:
+      - esp32c3_devkitm
     filter: dt_compat_enabled("espressif,esp32-temp")
     harness: console
     harness_config:

--- a/samples/sensor/lsm6dso/sample.yaml
+++ b/samples/sensor/lsm6dso/sample.yaml
@@ -3,9 +3,12 @@ sample:
 tests:
   sample.sensor.lsm6dso:
     harness: console
-    tags: sensors
+    tags:
+      - sensors
     timeout: 15
     filter: dt_compat_enabled("st,lsm6dso")
+    integration_platforms:
+      - stm32l562e_dk
     harness_config:
       type: multi_line
       ordered: true

--- a/samples/subsys/input/input_dump/sample.yaml
+++ b/samples/subsys/input/input_dump/sample.yaml
@@ -4,3 +4,5 @@ tests:
   sample.input.input_dump:
     tags: input
     build_only: true
+    integration_platforms:
+      - native_posix

--- a/samples/subsys/testsuite/integration/testcase.yaml
+++ b/samples/subsys/testsuite/integration/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     platform_allow: native_posix
     integration_platforms:
       - native_posix
-    tags: testing
+    tags: test_framework

--- a/samples/subsys/testsuite/pytest/basic/testcase.yaml
+++ b/samples/subsys/testsuite/pytest/basic/testcase.yaml
@@ -5,7 +5,7 @@ tests:
     harness_config:
       pytest_args: ["--custom-pytest-arg", "foo", "--cmdopt", "."]
     tags:
-      - testing
+      - test_framework
       - pytest
     integration_platforms:
       - native_posix

--- a/samples/subsys/testsuite/pytest/shell/testcase.yaml
+++ b/samples/subsys/testsuite/pytest/shell/testcase.yaml
@@ -9,6 +9,6 @@ tests:
       - native_posix
       - qemu_cortex_m3
     tags:
-      - testing
+      - test_framework
       - pytest
       - shell

--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -24,6 +24,8 @@ tests:
       - posix
       - xtensa
     platform_exclude: qemu_x86_64
+    integration_platforms:
+      - qemu_x86
   sample.tracing.transport.uart:
     platform_allow:
       - qemu_x86

--- a/samples/subsys/zbus/benchmark/sample.yaml
+++ b/samples/subsys/zbus/benchmark/sample.yaml
@@ -1,5 +1,5 @@
 sample:
-  name: Benchmark
+  name: Zbus Benchmark
 tests:
   sample.zbus.benchmark_async:
     tags: zbus
@@ -22,6 +22,8 @@ tests:
       - arch:nios2:CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
       - CONFIG_IDLE_STACK_SIZE=1024
     platform_exclude: nrf52_bsim
+    integration_platforms:
+      - qemu_x86
   sample.zbus.benchmark_sync:
     tags: zbus
     min_ram: 16
@@ -43,3 +45,5 @@ tests:
       - arch:nios2:CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
       - CONFIG_IDLE_STACK_SIZE=1024
     platform_exclude: nrf52_bsim
+    integration_platforms:
+      - qemu_x86

--- a/samples/subsys/zbus/uart_bridge/sample.yaml
+++ b/samples/subsys/zbus/uart_bridge/sample.yaml
@@ -18,3 +18,5 @@ tests:
   sample.zbus.uart_bridge_build:
     tags: zbus
     filter: dt_nodelabel_enabled("uart1")
+    integration_platforms:
+      - qemu_x86

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -46,6 +46,10 @@ bluetooth:
     - subsys/bluetooth/
     - subsys/net/l2/bluetooth/
 
+testsuite:
+  files:
+    - subsys/testsuite/
+
 cmsis_dsp:
   files:
     - modules/Kconfig.cmsis_dsp

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -46,9 +46,12 @@ bluetooth:
     - subsys/bluetooth/
     - subsys/net/l2/bluetooth/
 
-testsuite:
+test_framework:
   files:
     - subsys/testsuite/
+    - samples/subsys/testsuite/
+    - tests/subsys/testsuite/
+    - tests/ztest/
 
 cmsis_dsp:
   files:

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -65,6 +65,12 @@ cmsis_dsp:
     # change to west.yml is updating something we need to re-test for.
     - west.yml
 
+mcumgr:
+  files:
+    - subsys/mcumgr/
+    - tests/subsys/mgmt/mcumgr/
+    - samples/subsys/mgmt/mcumgr/
+    - include/zephyr/mgmt/mcumgr/
 kernel:
   files:
     - kernel/

--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -46,6 +46,11 @@ bluetooth:
     - subsys/bluetooth/
     - subsys/net/l2/bluetooth/
 
+net:
+  files:
+    - subsys/net/
+    - include/zephyr/net/
+
 test_framework:
   files:
     - subsys/testsuite/

--- a/tests/benchmarks/app_kernel/testcase.yaml
+++ b/tests/benchmarks/app_kernel/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: benchmark
+  tags:
+    - benchmark
+    - kernel
   timeout: 420
 tests:
   benchmark.kernel.application:

--- a/tests/benchmarks/data_structure_perf/dlist_perf/testcase.yaml
+++ b/tests/benchmarks/data_structure_perf/dlist_perf/testcase.yaml
@@ -3,5 +3,6 @@ tests:
     tags:
       - benchmark
       - dlist
+      - kernel
     integration_platforms:
       - native_posix

--- a/tests/benchmarks/data_structure_perf/rbtree_perf/testcase.yaml
+++ b/tests/benchmarks/data_structure_perf/rbtree_perf/testcase.yaml
@@ -3,5 +3,6 @@ tests:
     tags:
       - benchmark
       - rbtree
+      - kernel
     integration_platforms:
       - native_posix

--- a/tests/benchmarks/footprints/testcase.yaml
+++ b/tests/benchmarks/footprints/testcase.yaml
@@ -1,12 +1,14 @@
+common:
+  tags:
+    - benchmark
+    - kernel
 tests:
   benchmark.kernel.footprints.default:
-    tags: benchmark
     build_only: true
     integration_platforms:
       - mps2_an385
   benchmark.kernel.footprints.pm:
     tags:
-      - benchmark
       - pm
     build_only: true
     extra_args: CONF_FILE=prj_pm.conf
@@ -20,7 +22,6 @@ tests:
       - arm
       - arc
     tags:
-      - benchmark
       - userspace
     build_only: true
     integration_platforms:

--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -1,3 +1,7 @@
+common:
+  tags:
+    - kernel
+    - benchmark
 tests:
   benchmark.kernel.latency:
     # FIXME: no DWT and no RTC_TIMER for qemu_cortex_m0
@@ -5,7 +9,6 @@ tests:
       - qemu_cortex_m0
       - m2gl025_miv
     filter: CONFIG_PRINTK and not CONFIG_SOC_FAMILY_STM32
-    tags: benchmark
     harness: console
     integration_platforms:
       - qemu_x86
@@ -24,7 +27,6 @@ tests:
   benchmark.kernel.latency.stm32:
     arch_allow: arm
     filter: CONFIG_PRINTK and CONFIG_SOC_FAMILY_STM32
-    tags: benchmark
     extra_configs:
       - CONFIG_SYS_CLOCK_TICKS_PER_SEC=20
     harness: console

--- a/tests/benchmarks/sched/testcase.yaml
+++ b/tests/benchmarks/sched/testcase.yaml
@@ -1,6 +1,8 @@
 tests:
   benchmark.kernel.scheduler:
-    tags: benchmark
+    tags:
+      - benchmark
+      - kernel
     integration_platforms:
       - mps2_an385
       - qemu_x86

--- a/tests/benchmarks/sched_userspace/testcase.yaml
+++ b/tests/benchmarks/sched_userspace/testcase.yaml
@@ -2,6 +2,7 @@ tests:
   benchmark.kernel.scheduler_userspace:
     arch_allow: arm64
     tags:
+      - kernel
       - benchmark
       - userspace
     slow: true

--- a/tests/benchmarks/sys_kernel/testcase.yaml
+++ b/tests/benchmarks/sys_kernel/testcase.yaml
@@ -1,8 +1,9 @@
 tests:
   benchmark.kernel.core:
+    tags:
+      - kernel
     arch_exclude:
       - nios2
       - xtensa
     min_ram: 32
-    tags: benchmark
     timeout: 120

--- a/tests/crypto/mbedtls/testcase.yaml
+++ b/tests/crypto/mbedtls/testcase.yaml
@@ -12,3 +12,6 @@ tests:
     extra_configs:
       - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=0
       - arch:riscv64:CONFIG_ZTEST_STACK_SIZE=8192
+    integration_platforms:
+      - qemu_x86
+      - native_posix

--- a/tests/crypto/rand32/testcase.yaml
+++ b/tests/crypto/rand32/testcase.yaml
@@ -1,34 +1,22 @@
+common:
+  tags:
+    - crypto
+    - random
+    - security
+  integration_platforms:
+    - qemu_x86
 tests:
   crypto.rand32:
-    tags:
-      - crypto
-      - random
-      - security
     min_ram: 16
   crypto.rand32.random_sw_systimer:
     extra_args: CONF_FILE=prj_sw_random_systimer.conf
-    tags:
-      - crypto
-      - random
-      - security
-    min_ram: 16
   crypto.rand32.random_hw_xoshiro:
     extra_args: CONF_FILE=prj_hw_random_xoshiro.conf
     filter: CONFIG_ENTROPY_HAS_DRIVER
-    tags:
-      - crypto
-      - entropy
-      - random
-      - security
     min_ram: 16
   crypto.rand32.random_ctr_drbg:
     extra_args: CONF_FILE=prj_ctr_drbg.conf
     filter: CONFIG_ENTROPY_HAS_DRIVER
-    tags:
-      - crypto
-      - entropy
-      - random
-      - security
     min_ram: 16
   drivers.rand32.random_psa_crypto:
     filter: CONFIG_BUILD_WITH_TFM
@@ -36,8 +24,4 @@ tests:
       - DTC_OVERLAY_FILE=./entropy_psa_crypto.overlay
       - CONF_FILE=prj_hw_random_psa_crypto.conf
     tags:
-      - crypto
-      - entropy
-      - random
-      - security
       - psa-crypto

--- a/tests/drivers/bbram/testcase.yaml
+++ b/tests/drivers/bbram/testcase.yaml
@@ -11,8 +11,14 @@ common:
 tests:
   drivers.bbram.it8xxx2:
     filter: dt_compat_enabled("ite,it8xxx2-bbram")
+    integration_platforms:
+      - it82xx2_evb
   drivers.bbram.npcx:
     filter: dt_compat_enabled("nuvoton,npcx-bbram")
+    integration_platforms:
+      - npcx9m6f_evb
   drivers.bbram.stm32:
     extra_args: OVERLAY_CONFIG="stm32.conf"
     filter: dt_compat_enabled("st,stm32-bbram")
+    integration_platforms:
+      - stm32f746g_disco

--- a/tests/drivers/coredump/coredump_api/testcase.yaml
+++ b/tests/drivers/coredump/coredump_api/testcase.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 common:
-  tags: coredump
+  tags:
+    - coredump
   ignore_faults: true
   ignore_qemu_crash: true
 tests:
@@ -33,6 +34,8 @@ tests:
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     platform_exclude: qemu_riscv32
     harness: console
+    integration_platforms:
+      - qemu_x86
     harness_config:
       type: multi_line
       # Verify core dump contains test values saved in memory

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -32,6 +32,8 @@ tests:
   drivers.flash.common.default:
     filter: ((CONFIG_FLASH_HAS_DRIVER_ENABLED and not CONFIG_TRUSTED_EXECUTION_NONSECURE)
       and dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions"))
+    integration_platforms:
+      - qemu_x86
   drivers.flash.common.tfm_ns:
     build_only: true
     filter: (CONFIG_FLASH_HAS_DRIVER_ENABLED and CONFIG_TRUSTED_EXECUTION_NONSECURE

--- a/tests/drivers/ipm/testcase.yaml
+++ b/tests/drivers/ipm/testcase.yaml
@@ -6,3 +6,5 @@ tests:
     tags:
       - drivers
       - ipc
+    integration_platforms:
+      - qemu_x86

--- a/tests/drivers/mm/sys_mm_drv_bank/testcase.yaml
+++ b/tests/drivers/mm/sys_mm_drv_bank/testcase.yaml
@@ -4,3 +4,5 @@ tests:
       - drivers
       - mm
     filter: dt_compat_enabled("intel,adsp-mtl-tlb") or dt_compat_enabled("intel,adsp-tlb")
+    integration_platforms:
+      - intel_adsp_ace15_mtpm

--- a/tests/kernel/early_sleep/testcase.yaml
+++ b/tests/kernel/early_sleep/testcase.yaml
@@ -3,8 +3,3 @@ tests:
     tags:
       - kernel
       - sleep
-  kernel.common.sleep.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/events/event_api/testcase.yaml
+++ b/tests/kernel/events/event_api/testcase.yaml
@@ -1,8 +1,3 @@
 tests:
   kernel.events:
     tags: kernel
-  kernel.events.linker_generator:
-    platform_allow: qemu_x86
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/fifo/fifo_api/testcase.yaml
+++ b/tests/kernel/fifo/fifo_api/testcase.yaml
@@ -1,8 +1,5 @@
+common:
+  tags:
+    - kernel
 tests:
-  kernel.fifo:
-    tags: kernel
-  kernel.fifo.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y
+  kernel.fifo: {}

--- a/tests/kernel/fifo/fifo_timeout/testcase.yaml
+++ b/tests/kernel/fifo/fifo_timeout/testcase.yaml
@@ -1,8 +1,3 @@
 tests:
   kernel.fifo.timeout:
     tags: kernel
-  kernel.fifo.timeout.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/fifo/fifo_usage/testcase.yaml
+++ b/tests/kernel/fifo/fifo_usage/testcase.yaml
@@ -3,8 +3,3 @@ tests:
     tags:
       - kernel
       - fifo
-  kernel.fifo.usage.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -12,7 +12,8 @@ tests:
   arch.interrupt.gen_isr_table.arm_baseline.linker_generator:
     platform_allow: qemu_cortex_m3
     filter: CONFIG_GEN_ISR_TABLES and CONFIG_ARMV6_M_ARMV8_M_BASELINE
-    tags: linker_generator
+    tags:
+      - linker_generator
     extra_configs:
       - CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
       - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -6,11 +6,3 @@ tests:
       - kernel
       - interrupt
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
-
-  arch.interrupt.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags:
-      - interrupt
-      - linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/lifo/lifo_api/testcase.yaml
+++ b/tests/kernel/lifo/lifo_api/testcase.yaml
@@ -1,8 +1,3 @@
 tests:
   kernel.lifo:
     tags: kernel
-  kernel.lifo.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/lifo/lifo_usage/testcase.yaml
+++ b/tests/kernel/lifo/lifo_usage/testcase.yaml
@@ -4,8 +4,3 @@ tests:
     platform_exclude: m2gl025_miv
     tags: kernel
     min_ram: 20
-  kernel.lifo.usage.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/mbox/mbox_api/testcase.yaml
+++ b/tests/kernel/mbox/mbox_api/testcase.yaml
@@ -3,8 +3,3 @@ tests:
     tags:
       - kernel
       - mailbox
-  kernel.mailbox.api.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/mbox/mbox_usage/testcase.yaml
+++ b/tests/kernel/mbox/mbox_usage/testcase.yaml
@@ -3,8 +3,3 @@ tests:
     tags:
       - kernel
       - mailbox
-  kernel.mailbox.usage.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/mem_heap/k_heap_api/testcase.yaml
+++ b/tests/kernel/mem_heap/k_heap_api/testcase.yaml
@@ -1,12 +1,5 @@
 tests:
   kernel.k_heap_api:
     tags:
-      - k_heap_api
+      - heap
       - kernel
-  kernel.k_heap_api.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags:
-      - kernel
-      - linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
+++ b/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
@@ -28,9 +28,3 @@ tests:
       - qemu_cortex_m3
     extra_configs:
       - CONFIG_MULTITHREADING=n
-  kernel.memory_heap.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_IRQ_OFFLOAD=y
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/mem_slab/mslab/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab/testcase.yaml
@@ -3,8 +3,3 @@ tests:
     tags:
       - kernel
       - memory_slabs
-  kernel.memory_slabs.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/mem_slab/mslab_api/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_api/testcase.yaml
@@ -27,8 +27,3 @@ tests:
       - qemu_arc_hs
     extra_configs:
       - CONFIG_MULTITHREADING=n
-  kernel.memory_slabs.api.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/mem_slab/mslab_concept/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_concept/testcase.yaml
@@ -2,8 +2,3 @@ tests:
   kernel.memory_slabs.concept:
     tags: kernel
     timeout: 80
-  kernel.memory_slabs.concept.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/mem_slab/mslab_threadsafe/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_threadsafe/testcase.yaml
@@ -1,8 +1,3 @@
 tests:
   kernel.memory_slabs.threadsafe:
     tags: kernel
-  kernel.memory_slabs.threadsafe.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/mp/testcase.yaml
+++ b/tests/kernel/mp/testcase.yaml
@@ -4,9 +4,3 @@ tests:
       - kernel
       - smp
     filter: CONFIG_MP_MAX_NUM_CPUS > 1
-  kernel.multiprocessing.linker_generator:
-    platform_allow: qemu_x86_64
-    tags: linker_generator
-    filter: CONFIG_MP_MAX_NUM_CPUS > 1
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/msgq/msgq_usage/testcase.yaml
+++ b/tests/kernel/msgq/msgq_usage/testcase.yaml
@@ -1,8 +1,3 @@
 tests:
   kernel.message_queue_usage:
     tags: kernel
-  kernel.message_queue_usage.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/sched/deadline/testcase.yaml
+++ b/tests/kernel/sched/deadline/testcase.yaml
@@ -1,8 +1,3 @@
 tests:
   kernel.scheduler.deadline:
     tags: kernel
-  kernel.scheduler.deadline.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/sched/metairq/testcase.yaml
+++ b/tests/kernel/sched/metairq/testcase.yaml
@@ -2,8 +2,3 @@ tests:
   kernel.scheduler.metairq:
     tags: kernel
     platform_exclude: nrf52dk_nrf52810
-  kernel.scheduler.metairq.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/sched/preempt/testcase.yaml
+++ b/tests/kernel/sched/preempt/testcase.yaml
@@ -2,9 +2,3 @@ tests:
   kernel.scheduler.preempt:
     tags: kernel
     platform_exclude: nrf52dk_nrf52810
-  kernel.scheduler.preempt.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    platform_exclude: nrf52dk_nrf52810
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -37,10 +37,3 @@ tests:
     extra_args: CONF_FILE=prj_dumb.conf
     extra_configs:
       - CONFIG_TIMESLICING=n
-  kernel.scheduler.linker_generator:
-    filter: not CONFIG_SCHED_MULTIQ
-    platform_allow: qemu_cortex_m3
-    extra_configs:
-      - CONFIG_TIMESLICING=y
-      - CONFIG_CMAKE_LINKER_GENERATOR=y
-    tags: linker_generator

--- a/tests/kernel/smp/testcase.yaml
+++ b/tests/kernel/smp/testcase.yaml
@@ -5,10 +5,3 @@ tests:
       - smp
     ignore_faults: true
     filter: (CONFIG_MP_MAX_NUM_CPUS > 1)
-  kernel.multiprocessing.smp.linker_generator:
-    platform_allow: qemu_x86_64
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y
-    tags: linker_generator
-    ignore_faults: true
-    filter: (CONFIG_MP_MAX_NUM_CPUS > 1)

--- a/tests/kernel/timer/timer_monotonic/testcase.yaml
+++ b/tests/kernel/timer/timer_monotonic/testcase.yaml
@@ -15,8 +15,3 @@ tests:
     extra_configs:
       - CONFIG_APIC_TSC_DEADLINE_TIMER=y
       - CONFIG_HPET_TIMER=n
-  kernel.timer.monotonic.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/workq/critical/testcase.yaml
+++ b/tests/kernel/workq/critical/testcase.yaml
@@ -1,6 +1,5 @@
 common:
   tags:
-
     - kernel
     - workqueue
 tests:
@@ -15,8 +14,3 @@ tests:
     platform_allow: nsim_sem_mpu_stack_guard
     extra_configs:
       - CONFIG_TEST_HW_STACK_PROTECTION=n
-  kernel.workqueue.critical.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/workq/work/testcase.yaml
+++ b/tests/kernel/workq/work/testcase.yaml
@@ -6,8 +6,3 @@ tests:
     # the related CI checks got blocked, so exclude it.
     platform_exclude: hifive1
     timeout: 80
-  kernel.work.api.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/workq/work_queue/testcase.yaml
+++ b/tests/kernel/workq/work_queue/testcase.yaml
@@ -1,9 +1,6 @@
 tests:
   kernel.workqueue:
     min_flash: 34
-    tags: kernel
-  kernel.workqueue.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y
+    tags:
+      - kernel
+      - workqueue

--- a/tests/kernel/xip/testcase.yaml
+++ b/tests/kernel/xip/testcase.yaml
@@ -7,8 +7,3 @@ tests:
     integration_platforms:
       - qemu_arc_em
       - qemu_x86_xip
-  arch.common.xip.linker_generator:
-    platform_allow: qemu_cortex_m3
-    tags: linker_generator
-    extra_configs:
-      - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/lib/c_lib/testcase.yaml
+++ b/tests/lib/c_lib/testcase.yaml
@@ -1,6 +1,9 @@
 common:
-  tags: clib
+  tags:
+    - clib
   arch_exclude: posix
+  integration_platforms:
+    - mps2_an385
 tests:
   libraries.libc:
     ignore_faults: true
@@ -11,10 +14,12 @@ tests:
     extra_configs:
       - CONFIG_PICOLIBC=y
   libraries.libc.minimal.strerror_table:
+    tags: minimal_libc
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y
       - CONFIG_MINIMAL_LIBC_STRING_ERROR_TABLE=y
   libraries.libc.minimal.no_strerror_table:
+    tags: minimal_libc
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y
       - CONFIG_MINIMAL_LIBC_STRING_ERROR_TABLE=n

--- a/tests/lib/heap/testcase.yaml
+++ b/tests/lib/heap/testcase.yaml
@@ -15,3 +15,6 @@ tests:
       - esp32s3_devkitm
     filter: not CONFIG_SOC_NSIM
     timeout: 480
+    integration_platforms:
+      - native_posix
+      - qemu_x86

--- a/tests/lib/heap_align/testcase.yaml
+++ b/tests/lib/heap_align/testcase.yaml
@@ -3,3 +3,6 @@ tests:
     tags:
       - heap
       - heap_align
+    integration_platforms:
+      - native_posix
+      - mps2_an521

--- a/tests/lib/mem_alloc/testcase.yaml
+++ b/tests/lib/mem_alloc/testcase.yaml
@@ -1,47 +1,38 @@
 common:
   arch_exclude: posix
+  tags:
+    - clib
+    - userspace
+  integration_platforms:
+    - qemu_x86
 tests:
   libraries.libc.minimal.mem_alloc:
     extra_args: CONF_FILE=prj.conf
     platform_exclude: twr_ke18f
     tags:
-      - clib
       - minimal_libc
-      - userspace
   libraries.libc.minimal.mem_alloc_negative_testing:
     extra_args: CONF_FILE=prj_negative_testing.conf
     platform_exclude: twr_ke18f
     tags:
-      - clib
       - minimal_libc
-      - userspace
   libraries.libc.newlib.mem_alloc:
     extra_args: CONF_FILE=prj_newlib.conf
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     min_ram: 16
     platform_exclude:
       - twr_ke18f
-      - native_posix_64
-      - nrf52_bsim
     tags:
-      - clib
       - newlib
-      - userspace
   libraries.libc.newlib_nano.mem_alloc:
     extra_args: CONF_FILE=prj_newlibnano.conf
     filter: CONFIG_HAS_NEWLIB_LIBC_NANO
     tags:
-      - clib
       - newlib
-      - userspace
   libraries.libc.picolibc.mem_alloc:
     extra_args: CONF_FILE=prj_picolibc.conf
     filter: CONFIG_PICOLIBC_SUPPORTED
     platform_exclude:
       - twr_ke18f
-      - native_posix_64
-      - nrf52_bsim
     tags:
-      - clib
       - picolibc
-      - userspace

--- a/tests/lib/newlib/heap_listener/testcase.yaml
+++ b/tests/lib/newlib/heap_listener/testcase.yaml
@@ -4,3 +4,6 @@ tests:
       - clib
       - newlib
     filter: TOOLCHAIN_HAS_NEWLIB == 1
+    integration_platforms:
+      - mps2_an385
+      - qemu_x86

--- a/tests/lib/newlib/thread_safety/testcase.yaml
+++ b/tests/lib/newlib/thread_safety/testcase.yaml
@@ -1,25 +1,23 @@
 common:
   filter: TOOLCHAIN_HAS_NEWLIB == 1
+  tags:
+    - clib
+    - newlib
+  integration_platforms:
+    - mps2_an521
+    - qemu_x86
 tests:
   libraries.libc.newlib.thread_safety:
-    tags:
-      - clib
-      - newlib
     min_ram: 64
   libraries.libc.newlib.thread_safety.stress:
     extra_configs:
       - CONFIG_NEWLIB_THREAD_SAFETY_TEST_STRESS=y
     slow: true
-    tags:
-      - clib
-      - newlib
     min_ram: 192
   libraries.libc.newlib.thread_safety.userspace:
     extra_args: CONF_FILE=prj_userspace.conf
     filter: CONFIG_ARCH_HAS_USERSPACE
     tags:
-      - clib
-      - newlib
       - userspace
     min_ram: 64
   libraries.libc.newlib.thread_safety.userspace.stress:
@@ -30,8 +28,6 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     slow: true
     tags:
-      - clib
-      - newlib
       - userspace
     min_ram: 192
     timeout: 120
@@ -39,9 +35,6 @@ tests:
     extra_configs:
       - CONFIG_NEWLIB_LIBC_NANO=y
     filter: CONFIG_HAS_NEWLIB_LIBC_NANO
-    tags:
-      - clib
-      - newlib
     min_ram: 64
   libraries.libc.newlib_nano.thread_safety.stress:
     extra_configs:
@@ -49,9 +42,6 @@ tests:
       - CONFIG_NEWLIB_LIBC_NANO=y
     filter: CONFIG_HAS_NEWLIB_LIBC_NANO
     slow: true
-    tags:
-      - clib
-      - newlib
     min_ram: 192
   libraries.libc.newlib_nano.thread_safety.userspace:
     extra_args: CONF_FILE=prj_userspace.conf
@@ -59,8 +49,6 @@ tests:
       - CONFIG_NEWLIB_LIBC_NANO=y
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_HAS_NEWLIB_LIBC_NANO
     tags:
-      - clib
-      - newlib
       - userspace
     min_ram: 64
   libraries.libc.newlib_nano.thread_safety.userspace.stress:
@@ -72,8 +60,6 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_HAS_NEWLIB_LIBC_NANO
     slow: true
     tags:
-      - clib
-      - newlib
       - userspace
     min_ram: 192
     timeout: 120

--- a/tests/lib/p4workq/testcase.yaml
+++ b/tests/lib/p4workq/testcase.yaml
@@ -1,3 +1,7 @@
 tests:
   libraries.p4wq:
-    tags: p4wq
+    tags:
+      - kernel
+    integration_platforms:
+      - qemu_x86
+      - native_posix

--- a/tests/lib/sprintf/testcase.yaml
+++ b/tests/lib/sprintf/testcase.yaml
@@ -1,3 +1,6 @@
+common:
+  tags:
+    - libc
 tests:
   libraries.libc.sprintf:
     extra_args: CONF_FILE=prj.conf
@@ -5,31 +8,34 @@ tests:
     integration_platforms:
       - qemu_x86
     arch_exclude: posix
-    tags: libc
     ignore_faults: true
   libraries.libc.sprintf_new:
     extra_args: CONF_FILE=prj_new.conf
     arch_exclude: posix
-    tags: libc
+    integration_platforms:
+      - qemu_x86
   libraries.libc.picolibc.sprintf:
     extra_args: CONF_FILE=prj_picolibc.conf
     tags:
-      - libc
       - picolibc
     ignore_faults: true
     filter: CONFIG_PICOLIBC_SUPPORTED
+    integration_platforms:
+      - qemu_x86
   libraries.libc.picolibc.sprintf_new:
     extra_args: CONF_FILE=prj_picolibc_new.conf
     tags:
-      - libc
       - picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
+    integration_platforms:
+      - qemu_x86
   libraries.libc.picolibc.sprintf_inexact:
     extra_args: CONF_FILE=prj_picolibc_new.conf
     extra_configs:
       - CONFIG_PICOLIBC_USE_MODULE=y
       - CONFIG_PICOLIBC_IO_FLOAT_EXACT=n
     tags:
-      - libc
       - picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
+    integration_platforms:
+      - qemu_x86

--- a/tests/misc/print_format/testcase.yaml
+++ b/tests/misc/print_format/testcase.yaml
@@ -1,4 +1,7 @@
 common:
+  integration_platforms:
+    - native_posix
+    - qemu_x86
   harness: console
   harness_config:
     type: multi_line

--- a/tests/subsys/debug/coredump/testcase.yaml
+++ b/tests/subsys/debug/coredump/testcase.yaml
@@ -5,6 +5,8 @@ tests:
     ignore_qemu_crash: true
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP
     platform_exclude: acrn_ehl_crb
+    integration_platforms:
+      - qemu_x86
     harness: console
     harness_config:
       type: multi_line

--- a/tests/subsys/debug/coredump_backends/testcase.yaml
+++ b/tests/subsys/debug/coredump_backends/testcase.yaml
@@ -2,6 +2,8 @@ common:
   tags: coredump
   ignore_faults: true
   ignore_qemu_crash: true
+  integration_platforms:
+    - qemu_x86
 tests:
   coredump.backends.logging:
     filter: CONFIG_ARCH_SUPPORTS_COREDUMP

--- a/tests/subsys/modbus/testcase.yaml
+++ b/tests/subsys/modbus/testcase.yaml
@@ -11,3 +11,5 @@ tests:
     build_only: true
     tags: modbus
     filter: CONFIG_UART_CONSOLE and CONFIG_UART_INTERRUPT_DRIVEN
+    integration_platforms:
+      - frdm_k64f

--- a/tests/subsys/pm/device_runtime_api/testcase.yaml
+++ b/tests/subsys/pm/device_runtime_api/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   pm.device_runtime.api:
     tags: pm
+    integration_platforms:
+      - native_posix

--- a/tests/subsys/portability/cmsis_rtos_v1/testcase.yaml
+++ b/tests/subsys/portability/cmsis_rtos_v1/testcase.yaml
@@ -3,3 +3,5 @@ tests:
     tags: cmsis_rtos
     min_ram: 32
     min_flash: 34
+    integration_platforms:
+      - native_posix

--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -7,11 +7,15 @@ tests:
   rtio.api:
     filter: not CONFIG_ARCH_HAS_USERSPACE
     tags: rtio
+    integration_platforms:
+      - native_posix
   rtio.api.submit_sem:
     filter: not CONFIG_ARCH_HAS_USERSPACE
     tags: rtio
     extra_configs:
       - CONFIG_RTIO_SUBMIT_SEM=y
+    integration_platforms:
+      - native_posix
   rtio.api.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
@@ -19,6 +23,8 @@ tests:
     tags:
       - rtio
       - userspace
+    integration_platforms:
+      - qemu_x86
   rtio.api.userspace.submit_sem:
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
@@ -27,3 +33,5 @@ tests:
     tags:
       - rtio
       - userspace
+    integration_platforms:
+      - qemu_x86

--- a/tests/subsys/zbus/dyn_channel/testcase.yaml
+++ b/tests/subsys/zbus/dyn_channel/testcase.yaml
@@ -2,3 +2,5 @@ tests:
   message_bus.zbus.dyn_channel.static_and_dynamic_channels:
     platform_exclude: fvp_base_revc_2xaemv8a_smp_ns
     tags: zbus
+    integration_platforms:
+      - native_posix

--- a/tests/subsys/zbus/runtime_observers_registration/testcase.yaml
+++ b/tests/subsys/zbus/runtime_observers_registration/testcase.yaml
@@ -1,3 +1,5 @@
 tests:
   message_bus.zbus.runtime_obs_reg.add_and_remove_observers:
     tags: zbus
+    integration_platforms:
+      - native_posix

--- a/tests/subsys/zbus/unittests/testcase.yaml
+++ b/tests/subsys/zbus/unittests/testcase.yaml
@@ -2,3 +2,5 @@ tests:
   message_bus.zbus.hard_and_readonly_channels:
     platform_exclude: fvp_base_revc_2xaemv8a_smp_ns
     tags: zbus
+    integration_platforms:
+      - native_posix

--- a/tests/subsys/zbus/user_data/testcase.yaml
+++ b/tests/subsys/zbus/user_data/testcase.yaml
@@ -2,3 +2,5 @@ tests:
   message_bus.zbus.user_data.channel_user_data:
     platform_exclude: fvp_base_revc_2xaemv8a_smp_ns
     tags: zbus
+    integration_platforms:
+      - native_posix

--- a/tests/ztest/base/testcase.yaml
+++ b/tests/ztest/base/testcase.yaml
@@ -1,21 +1,20 @@
+common:
+  tags:
+    - test_framework
 tests:
   testing.ztest.base:
-    tags: test_framework
     type: unit
   testing.ztest.base.cpp:
     extra_args: CONF_FILE=prj_cpp.conf
-    tags: test_framework
     platform_allow: native_posix
   testing.ztest.base.verbose_0:
     extra_args: CONF_FILE=prj_verbose_0.conf
-    tags: test_framework
     integration_platforms:
       - native_posix
   testing.ztest.base.verbose_0_userspace:
     filter: CONFIG_USERSPACE
     extra_args: CONF_FILE=prj_verbose_0.conf
     tags:
-      - test_framework
       - userspace
     extra_configs:
       - CONFIG_TEST_USERSPACE=y
@@ -23,11 +22,9 @@ tests:
       - native_posix
   testing.ztest.base.verbose_1:
     extra_args: CONF_FILE=prj_verbose_1.conf
-    tags: test_framework
     integration_platforms:
       - native_posix
   testing.ztest.base.verbose_2:
     extra_args: CONF_FILE=prj_verbose_2.conf
-    tags: test_framework
     integration_platforms:
       - native_posix

--- a/tests/ztest/busy_sim/testcase.yaml
+++ b/tests/ztest/busy_sim/testcase.yaml
@@ -1,5 +1,6 @@
 common:
-  tags: test_framework
+  tags:
+    - test_framework
   depends_on: counter
 tests:
   testing.ztest.busy_sim:

--- a/tests/ztest/error_hook/testcase.yaml
+++ b/tests/ztest/error_hook/testcase.yaml
@@ -1,11 +1,12 @@
+common:
+  tags:
+    - test_framework
 tests:
   testing.ztest.error_hook:
     filter: CONFIG_ARCH_HAS_USERSPACE
     tags:
-      - test_framework
       - userspace
     ignore_faults: true
   testing.ztest.error_hook.no_userspace:
     extra_args: CONF_FILE=prj_no_userspace.conf
-    tags: test_framework
     ignore_faults: true

--- a/tests/ztest/fail/testcase.yaml
+++ b/tests/ztest/fail/testcase.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 common:
-  tags: ztest
+  tags:
+    - test_framework
   # test has dependencies on host libc
   platform_allow: native_posix
 tests:

--- a/tests/ztest/summary/testcase.yaml
+++ b/tests/ztest/summary/testcase.yaml
@@ -1,3 +1,4 @@
 tests:
   testing.ztest.summary.shared_unit_test:
-    tags: test_framework
+    tags:
+      - test_framework

--- a/tests/ztest/zexpect/testcase.yaml
+++ b/tests/ztest/zexpect/testcase.yaml
@@ -4,6 +4,8 @@
 common:
   integration_platforms:
     - native_posix
+  tags:
+    - test_framework
 tests:
   testing.ztest.expect:
     integration_platforms:

--- a/tests/ztest/ztress/testcase.yaml
+++ b/tests/ztest/ztress/testcase.yaml
@@ -1,5 +1,6 @@
 common:
-  tags: test_framework
+  tags:
+    - test_framework
   platform_type:
     - qemu
 tests:


### PR DESCRIPTION
- ci: manage when to build testsuite tests
- tests: ztest: fix tags for testsuite and unify them
- tests: remove linker_generator sub tests from kernel
- ci: tags: add networking to tags file
- ci: tags: add mcumgr to tags file
- tests: add kernel tag to all benchmarks and samples
- samples: net: fix tags/identifiers
- tests: samples: cleanup test tags, add integration_platforms
