### PR TITLE
drivers: ieee802154: rf2xx: Check gpio_add_callback return

### DIFF
--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -902,7 +902,11 @@ static int power_on_and_setup(const struct device *dev)
 
 	gpio_init_callback(&ctx->irq_cb, trx_isr_handler,
 			   BIT(conf->irq_gpio.pin));
-	gpio_add_callback(conf->irq_gpio.port, &ctx->irq_cb);
+
+	if (gpio_add_callback(conf->irq_gpio.port, &ctx->irq_cb) < 0) {
+		LOG_ERR("Could not set IRQ callback.");
+		return -ENXIO;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
The rf2xx does not check the return value from gpio_add_callback function, which can prevent it from detecting unexpected states and conditions. This add error processing check and log.

Fixes: #58595