### PR TITLE
Bluetooth: Audio: Shell: Fix long/int32_t value checks

### DIFF
--- a/subsys/bluetooth/audio/shell/mcc.c
+++ b/subsys/bluetooth/audio/shell/mcc.c
@@ -731,7 +731,7 @@ static int cmd_mcc_set_track_position(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	if (!IN_RANGE(pos, INT32_MIN, INT32_MAX)) {
+	if (sizeof(long) != sizeof(int32_t) && !IN_RANGE(pos, INT32_MIN, INT32_MAX)) {
 		shell_error(sh, "Invalid pos: %ld", pos);
 
 		return -ENOEXEC;
@@ -1105,7 +1105,7 @@ static int cmd_mcc_move_relative(const struct shell *sh, size_t argc,
 		return err;
 	}
 
-	if (!IN_RANGE(offset, INT32_MIN, INT32_MAX)) {
+	if (sizeof(long) != sizeof(int32_t) && !IN_RANGE(offset, INT32_MIN, INT32_MAX)) {
 		shell_error(sh, "Invalid offset: %ld", offset);
 
 		return -ENOEXEC;
@@ -1211,7 +1211,7 @@ static int cmd_mcc_goto_segment(const struct shell *sh, size_t argc,
 		return err;
 	}
 
-	if (!IN_RANGE(segment, INT32_MIN, INT32_MAX)) {
+	if (sizeof(long) != sizeof(int32_t) && !IN_RANGE(segment, INT32_MIN, INT32_MAX)) {
 		shell_error(sh, "Invalid segment: %ld", segment);
 
 		return -ENOEXEC;
@@ -1313,7 +1313,7 @@ static int cmd_mcc_goto_track(const struct shell *sh, size_t argc, char *argv[])
 		return err;
 	}
 
-	if (!IN_RANGE(track, INT32_MIN, INT32_MAX)) {
+	if (sizeof(long) != sizeof(int32_t) && !IN_RANGE(track, INT32_MIN, INT32_MAX)) {
 		shell_error(sh, "Invalid track: %ld", track);
 
 		return -ENOEXEC;
@@ -1415,7 +1415,7 @@ static int cmd_mcc_goto_group(const struct shell *sh, size_t argc, char *argv[])
 		return err;
 	}
 
-	if (!IN_RANGE(group, INT32_MIN, INT32_MAX)) {
+	if (sizeof(long) != sizeof(int32_t) && !IN_RANGE(group, INT32_MIN, INT32_MAX)) {
 		shell_error(sh, "Invalid group: %ld", group);
 
 		return -ENOEXEC;

--- a/subsys/bluetooth/audio/shell/media_controller.c
+++ b/subsys/bluetooth/audio/shell/media_controller.c
@@ -576,7 +576,7 @@ static int cmd_media_set_track_position(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	if (!IN_RANGE(position, INT32_MIN, INT32_MAX)) {
+	if (sizeof(long) != sizeof(int32_t) && !IN_RANGE(position, INT32_MIN, INT32_MAX)) {
 		shell_error(sh, "Invalid position: %ld", position);
 
 		return -ENOEXEC;
@@ -865,7 +865,7 @@ static int cmd_media_move_relative(const struct shell *sh, size_t argc,
 		return err;
 	}
 
-	if (!IN_RANGE(offset, INT32_MIN, INT32_MAX)) {
+	if (sizeof(long) != sizeof(int32_t) && !IN_RANGE(offset, INT32_MIN, INT32_MAX)) {
 		shell_error(sh, "Invalid offset: %ld", offset);
 
 		return -ENOEXEC;
@@ -976,7 +976,7 @@ static int cmd_media_goto_segment(const struct shell *sh, size_t argc,
 		return err;
 	}
 
-	if (!IN_RANGE(segment, INT32_MIN, INT32_MAX)) {
+	if (sizeof(long) != sizeof(int32_t) && !IN_RANGE(segment, INT32_MIN, INT32_MAX)) {
 		shell_error(sh, "Invalid segment: %ld", segment);
 
 		return -ENOEXEC;
@@ -1086,7 +1086,7 @@ static int cmd_media_goto_track(const struct shell *sh, size_t argc,
 		return err;
 	}
 
-	if (!IN_RANGE(track, INT32_MIN, INT32_MAX)) {
+	if (sizeof(long) != sizeof(int32_t) && !IN_RANGE(track, INT32_MIN, INT32_MAX)) {
 		shell_error(sh, "Invalid track: %ld", track);
 
 		return -ENOEXEC;
@@ -1194,7 +1194,7 @@ static int cmd_media_goto_group(const struct shell *sh, size_t argc,
 		return err;
 	}
 
-	if (!IN_RANGE(group, INT32_MIN, INT32_MAX)) {
+	if (sizeof(long) != sizeof(int32_t) && !IN_RANGE(group, INT32_MIN, INT32_MAX)) {
 		shell_error(sh, "Invalid group: %ld", group);
 
 		return -ENOEXEC;


### PR DESCRIPTION
In places where we verify that the value of the long variable does not exceed the limits of int32_t, we do actually not need to compare the values if the two types are the same size, which is often the case for 32-bit systems.

This fixes a variety of coverity reported issues.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/58513
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58514
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58519
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58520
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58523
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58527
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58541
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58548
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58550
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58509