### PR TITLE
soc: intel_adsp: cavs: add simple imr functionality

### DIFF
--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -97,6 +97,13 @@
 		wovcro-supported;
 	};
 
+	IMR1: memory@0xb0000000 {
+		compatible = "intel,adsp-imr";
+		reg = <0xB0000000 DT_SIZE_M(16)>;
+		block-size = <0x1000>;
+		zephyr,memory-region = "IMR1";
+	};
+
 	soc {
 		shim: shim@71f00 {
 			compatible = "intel,adsp-shim";

--- a/soc/xtensa/intel_adsp/cavs/include/intel_tgl_adsp/adsp_imr_layout.h
+++ b/soc/xtensa/intel_adsp/cavs/include/intel_tgl_adsp/adsp_imr_layout.h
@@ -1,0 +1,39 @@
+/* Copyright (c) 2023 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_SOC_INTEL_ADSP_TGL_IMR_LAYOUT_H_
+#define ZEPHYR_SOC_INTEL_ADSP_TGL_IMR_LAYOUT_H_
+
+/* These structs and macros are from the ROM code header
+ * on cAVS platforms, please keep them immutable.
+ *
+ * The ROM structs and code is lifted from:
+ * https://github.com/thesofproject/sof
+ * 6c0db22c65 - platform: cavs: configure resume from IMR
+ */
+
+/*
+ * A magic that tells ROM to jump to imr_restore_vector instead of normal boot
+ */
+#define ADSP_IMR_MAGIC_VALUE		0x02468ACE
+
+struct imr_header {
+	uint32_t adsp_imr_magic;
+	uint32_t structure_version;
+	uint32_t structure_size;
+	uint32_t imr_state;
+	uint32_t imr_size;
+	void (*imr_restore_vector)(void);
+};
+
+struct imr_state {
+	struct imr_header header;
+	uint8_t reserved[0x1000 - sizeof(struct imr_header)];
+};
+
+struct imr_layout {
+	uint8_t css_reserved[0x1000];
+	struct imr_state imr_state;
+};
+
+#endif /* ZEPHYR_SOC_INTEL_ADSP_TGL_IMR_LAYOUT_H_ */

--- a/soc/xtensa/intel_adsp/cavs/include/intel_tgl_adsp/adsp_memory.h
+++ b/soc/xtensa/intel_adsp/cavs/include/intel_tgl_adsp/adsp_memory.h
@@ -29,6 +29,9 @@
 #define HPSRAM_SEGMENTS (HPSRAM_EBB_COUNT + EBB_SEG_SIZE - 1) / EBB_SEG_SIZE
 #define HPSRAM_MEMMASK(idx) ((1ULL << (HPSRAM_EBB_COUNT - EBB_SEG_SIZE * idx)) - 1)
 
+/* L3 region (IMR), located in host memory */
+#define L3_MEM_BASE_ADDR (DT_REG_ADDR(DT_NODELABEL(imr1)))
+
 /* The rimage tool produces two blob addresses we need to find: one is
  * our bootloader code block which starts at its entry point, the
  * other is the "manifest" containing the HP-SRAM data to unpack,


### PR DESCRIPTION
Add simple imr mechanism to load the image from rom instead of doing cold boot. Basically we are only setting a flag for the boot to load existing image from imr area.