### PR TITLE
net: lwm2m: Fix lwm2m_socket_start() error handling

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -875,8 +875,8 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 	} else if ((client_ctx->remote_addr).sa_family == AF_INET6) {
 		addr_len = sizeof(struct sockaddr_in6);
 	} else {
-		lwm2m_engine_stop(client_ctx);
-		return -EPROTONOSUPPORT;
+		ret = -EPROTONOSUPPORT;
+		goto error;
 	}
 
 	if (zsock_connect(client_ctx->sock_fd, &client_ctx->remote_addr, addr_len) < 0) {
@@ -901,7 +901,7 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 	LOG_INF("Connected, sock id %d", client_ctx->sock_fd);
 	return 0;
 error:
-	lwm2m_engine_stop(client_ctx);
+	lwm2m_socket_close(client_ctx);
 	return ret;
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1219,6 +1219,7 @@ static void sm_do_network_error(void)
 
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 	if (client.ctx->bootstrap_mode) {
+		lwm2m_engine_context_close(client.ctx);
 		set_sm_state(ENGINE_DO_BOOTSTRAP_REG);
 		return;
 	}
@@ -1226,6 +1227,7 @@ static void sm_do_network_error(void)
 
 	if (!client.last_update || (k_uptime_get() - client.last_update) / 1000 > client.lifetime) {
 		/* do full registration as there is no active registration or lifetime exceeded */
+		lwm2m_engine_context_close(client.ctx);
 		set_sm_state(ENGINE_DO_REGISTRATION);
 		return;
 	}


### PR DESCRIPTION
In case lwm2m_socket_start() internal error, it should only do cleanup on the socket, i. e. call lwm2m_socket_close(), not lwm2m_engine_stop(). The latter resets the entire lwm2m_context, which results in removal of active observations.

This should not be done, as it collides with the RD client logic, where connection resumption may skip the full registration phase, in result not notifying the server that it should restart the observations.

At the same time, the RD client should clean the lwm2m_context when it's done trying to update the registration and proceeds with regular registration/bootstrap in the network error handler. In that case, only the socket was closed, so the lwm2m_context needs to be reset separately.

Fixes #58278