### PR TITLE
lib: os: cbprintf_nano: Fix Coverity issue 316025

### DIFF
--- a/lib/os/cbprintf_nano.c
+++ b/lib/os/cbprintf_nano.c
@@ -38,7 +38,7 @@ static inline int convert_value(uint_value_type num, unsigned int base,
 		if (c >= 10) {
 			c += alpha;
 		}
-		buftop[--i] = c + '0';
+		buftop[i--] = c + '0';
 		num /= base;
 	} while (num);
 
@@ -244,7 +244,7 @@ start:
 			} else {
 				;
 			}
-			data_len = convert_value(d, 10, 0, buf + sizeof(buf));
+			data_len = convert_value(d, 10, 0, buf + sizeof(buf) - 1);
 			data = buf + sizeof(buf) - data_len;
 			break;
 		}
@@ -286,7 +286,7 @@ start:
 				min_width -= 2;
 			}
 			data_len = convert_value(x, 16, ALPHA(*fmt),
-						 buf + sizeof(buf));
+						 buf + sizeof(buf) - 1);
 			data = buf + sizeof(buf) - data_len;
 			break;
 		}


### PR DESCRIPTION
Coverity does not like that we are passing a pointer to a location just beyond fixed array. Inside the function access is done through negative indexes so there was no memory corruption but to satisfy Coverity pointer to the last element of the array is passed and we start from index 0 instead of -1.

Fixes #58688.