### PR TITLE
Bluetooth: Shell: Change strcpy to strncpy for addr copy

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -136,7 +136,7 @@ static struct bt_auto_connect {
 static struct bt_scan_filter {
 	char name[NAME_LEN];
 	bool name_set;
-	char addr[18]; /* fits xx:xx:xx:xx:xx:xx\0 */
+	char addr[BT_ADDR_STR_LEN];
 	bool addr_set;
 	int8_t rssi;
 	bool rssi_set;
@@ -1293,7 +1293,7 @@ static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 		}
 	}
 
-	strcpy(scan_filter.addr, addr_arg);
+	strncpy(scan_filter.addr, addr_arg, sizeof(scan_filter.addr));
 	scan_filter.addr_set = true;
 
 	return 0;


### PR DESCRIPTION
When copying the address in cmd_scan_filter_set_addr we now use strncpy to not copy more bytes than what fits. This should already have been fixed with a check earlier in the function, but coverity still complains.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/58503