### PR TITLE
driver: counter: Add driver to NXP PCF85263A rtc

### DIFF
--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -24,6 +24,7 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_XEC                 counter_mchp_xec
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPTMR          counter_mcux_lptmr.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MAXIM_DS3231        maxim_ds3231.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NATIVE_POSIX        counter_native_posix.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_NXP_PCF85263A       nxp_pcf85263a.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE                   counter_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_PIT            counter_mcux_pit.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_XLNX_AXI_TIMER      counter_xlnx_axi_timer.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -76,6 +76,8 @@ source "drivers/counter/Kconfig.andes_atcpit100"
 
 source "drivers/counter/Kconfig.nxp_s32"
 
+source "drivers/counter/Kconfig.nxp_pcf85263a"
+
 source "drivers/counter/Kconfig.gd32"
 
 endif # COUNTER

--- a/drivers/counter/Kconfig.nxp_pcf85263a
+++ b/drivers/counter/Kconfig.nxp_pcf85263a
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2022 Fraunhofer AICOS
+#
+
+config COUNTER_NXP_PCF85263A
+	bool "NXP PCF85263A RTC/Stop-watch"
+	depends on I2C
+	help
+	  Enable counter driver based on NXP PCF85263A I2C device.
+
+choice
+	prompt "PCF85263A INTA pin mode"
+
+config NXP_PCF85263A_INTA_CLK_OUT
+	bool "CLK output mode"
+
+config NXP_PCF85263A_INTA_BATT_OUT
+	bool "Battery mode indication"
+
+config NXP_PCF85263A_INTA_INT_OUT
+	bool "Interrupt (INTA) output"
+
+config NXP_PCF85263A_INTA_HIZ
+	bool "Hi-Z"
+
+endchoice
+
+
+choice
+	prompt "PCF85263A TS pin mode"
+
+config NXP_PCF85263A_TS_DISABLED
+	bool "Disabled"
+
+config NXP_PCF85263A_TS_INTB_OUT
+	bool "Interrupt (INTB) output"
+
+config NXP_PCF85263A_TS_CLK_OUT
+	bool "Clock output"
+
+config NXP_PCF85263A_TS_INPUT
+	bool "Input mode"
+
+endchoice

--- a/drivers/counter/nxp_pcf85263a.c
+++ b/drivers/counter/nxp_pcf85263a.c
@@ -1,0 +1,493 @@
+/*
+ * Copyright (c) 2022 Fraunhofer AICOS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_pcf85263a
+
+#include <time.h>
+
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/counter.h>
+#include <zephyr/sys/timeutil.h>
+#include <zephyr/drivers/rtc/nxp_pcf85263a.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(PCF85263A, CONFIG_COUNTER_LOG_LEVEL);
+
+enum nxp_pcf85263a_registers {
+	PCF85263A_REG_TIME = 0x00,
+	PCF85263A_REG_ALARM1 = 0x08,
+	PCF85263A_REG_ALARM2 = 0x0D,
+	PCF85263A_REG_ALARM_ENABLES = 0x10,
+	PCF85263A_REG_CTRL_OSCILLATOR = 0x25,
+	PCF85263A_REG_PIN_IO = 0x27,
+	PCF85263A_REG_CTRL_FUNCTION = 0x28,
+	PCF85263A_REG_INTA_ENABLE,
+	PCF85263A_REG_INTB_ENABLE,
+	PCF85263A_REG_FLAGS,
+	PCF85263A_REG_STOP = 0x2E,
+	PCF85263A_REG_RESET = 0x2F,
+};
+
+#define PCF85263A_CTRL_FUNCTION_100TH            BIT(7)
+#define PCF85263A_CTRL_FUNCTION_INT_PER_SEC      BIT(5)
+#define PCF85263A_CTRL_FUNCTION_INT_PER_MIN      BIT(6)
+#define PCF85263A_CTRL_FUNCTION_INT_PER_H        BIT(6) || BIT(5)
+#define PCF85263A_CTRL_FUNCTION_STOPWATCH_MODE   BIT(4)
+#define PCF85263A_CTRL_FUNCTION_STOP_MODE_TS_PIN BIT(3)
+
+#define PCF85263A_FLAGS_PERIODIC_INTERRUPT  BIT(7)
+#define PCF85263A_FLAGS_ALARM2              BIT(6)
+#define PCF85263A_FLAGS_ALARM1              BIT(5)
+#define PCF85263A_FLAGS_WATCHDOG            BIT(4)
+#define PCF85263A_FLAGS_BATTERY_SWITCH      BIT(3)
+#define PCF85263A_FLAGS_TSTAMP_REG3         BIT(2)
+#define PCF85263A_FLAGS_TSTAMP_REG2         BIT(1)
+#define PCF85263A_FLAGS_TSTAMP_REG1         BIT(0)
+
+#define PCF85263A_ALARM_ENABLE_A1_SECONDS   BIT(0)
+#define PCF85263A_ALARM_ENABLE_A1_MINUTES   BIT(1)
+#define PCF85263A_ALARM_ENABLE_A1_HOURS     BIT(2)
+#define PCF85263A_ALARM_ENABLE_A1_DAYS      BIT(3)
+#define PCF85263A_ALARM_ENABLE_A1_MONTHS    BIT(4)
+#define PCF85263A_ALARM_ENABLE_A2_MINUTES   BIT(5)
+#define PCF85263A_ALARM_ENABLE_A2_HOURS     BIT(2)
+#define PCF85263A_ALARM_ENABLE_A2_DAYS      BIT(3)
+#define PCF85263A_ALARM_ENABLE_ALARM1       0x0F
+#define PCF85263A_ALARM_ENABLE_ALARM2       0x70
+
+
+enum nxp_pcf85263a_mode {
+	NXP_PCF85263A_MODE_RTC = 0,
+	NXP_PCF85263A_MODE_STOPWATCH
+};
+
+struct nxp_pcf85263a_data {
+	enum nxp_pcf85263a_mode mode;
+	nxp_pcf8523a_alarm_callback_t alarm_callbacks[2];
+	void *alarm_user_data[2];
+	struct gpio_callback int_cb;
+	const struct device *dev;
+	struct k_work interrupt_worker;
+};
+
+struct nxp_pcf85263a_config {
+	const struct i2c_dt_spec i2c;
+	const struct gpio_dt_spec inta_gpio;
+	const struct gpio_dt_spec ts_gpio;
+};
+
+static int configure_inta_pin(const struct device *dev)
+{
+	int rc = 0;
+	const struct nxp_pcf85263a_config *cfg = dev->config;
+	uint8_t intapm_value;
+
+#ifdef CONFIG_NXP_PCF85263A_INTA_CLK_OUT
+	intapm_value = 0x00;
+#elif CONFIG_NXP_PCF85263A_INTA_BATT_OUT
+	intapm_value = 0x01;
+#elif CONFIG_NXP_PCF85263A_INTA_INT_OUT
+	intapm_value = 0x02;
+#elif CONFIG_NXP_PCF85263A_INTA_HIZ
+	intapm_value = 0x03;
+#endif
+
+	rc = i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_PIN_IO,
+	BIT(1) | BIT(0), intapm_value);
+
+	return rc;
+}
+
+static int configure_ts_pin(const struct device *dev)
+{
+	int rc = 0;
+	const struct nxp_pcf85263a_config *cfg = dev->config;
+	uint8_t tspm_value = 0;
+
+#ifdef CONFIG_NXP_PCF85263A_TS_DISABLED
+	tspm_value = 0x00;
+#elif CONFIG_NXP_PCF85263A_TS_INTB_OUT
+	tspm_value = 0x01;
+#elif CONFIG_NXP_PCF85263A_TS_CLK_OUT
+	tspm_value = 0x02;
+#elif CONFIG_NXP_PCF85263A_TS_INPUT
+	tspm_value = 0x03;
+#endif
+
+	rc = i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_PIN_IO,
+	BIT(3) | BIT(2), (tspm_value << 2));
+
+	return rc;
+}
+
+#if defined(CONFIG_NXP_PCF85263A_INTA_INT_OUT) || defined(CONFIG_NXP_PCF85263A_TS_INTB_OUT)
+static void nxp_pcf85263a_int_callback(const struct device *port, struct gpio_callback *cb, uint32_t pin)
+{
+	struct nxp_pcf85263a_data *data = CONTAINER_OF(cb, struct nxp_pcf85263a_data, int_cb);
+	k_work_submit(&data->interrupt_worker);
+}
+
+static void nxp_pcf85263a_interrupt_worker(struct k_work *work)
+{
+	struct nxp_pcf85263a_data * const data = CONTAINER_OF(
+		work, struct nxp_pcf85263a_data, interrupt_worker);
+	const struct nxp_pcf85263a_config *cfg = (struct nxp_pcf85263a_config *)data->dev->config;
+	uint8_t flags;
+	uint64_t time = 0;
+	i2c_reg_read_byte_dt(&cfg->i2c, PCF85263A_REG_FLAGS, &flags);
+	nxp_pcf85263a_get_value(data->dev, &val);
+	if (flags & PCF85263A_FLAGS_ALARM1) {
+		data->alarm_callbacks[0](data->dev, 1, (uint32_t)val, data->alarm_user_data[0]);
+		i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_FLAGS, PCF85263A_FLAGS_ALARM1,
+			0x00);
+	} else if (flags & PCF85263A_FLAGS_ALARM2) {
+		data->alarm_callbacks[1](data->dev, 2, (uint32_t)val, data->alarm_user_data[1]);
+		i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_FLAGS, PCF85263A_FLAGS_ALARM2,
+			0x00);
+	}
+
+}
+#endif
+
+int nxp_pcf85263a_init(const struct device *dev)
+{
+	int rc = 0;
+	uint8_t read_byte;
+	struct nxp_pcf85263a_data *data = dev->data;
+	const struct nxp_pcf85263a_config *cfg = dev->config;
+
+	data->dev = dev;
+
+	if (!device_is_ready(cfg->i2c.bus)) {
+		LOG_ERR("I2C device not ready");
+		return -ENODEV;
+	}
+
+	rc = i2c_reg_read_byte_dt(&cfg->i2c, PCF85263A_REG_CTRL_FUNCTION, &read_byte);
+	if(rc < 0)
+		return rc;
+
+	if(read_byte & PCF85263A_CTRL_FUNCTION_STOPWATCH_MODE){
+		data->mode = NXP_PCF85263A_MODE_STOPWATCH;
+	} else {
+		data->mode = NXP_PCF85263A_MODE_RTC;
+	}
+
+	rc = configure_inta_pin(dev);
+	if (rc != 0) {
+		return rc;
+	};
+
+	rc = configure_ts_pin(dev);
+	if (rc != 0) {
+		return rc;
+	};
+
+	if (device_is_ready(cfg->inta_gpio.port)) {
+		rc = gpio_pin_configure_dt(&cfg->inta_gpio, GPIO_INPUT);
+		if (rc < 0) {
+			return rc;
+		}
+	}
+
+#if defined(CONFIG_NXP_PCF85263A_INTA_INT_OUT) || defined(CONFIG_NXP_PCF85263A_TS_INTB_OUT)
+	k_work_init(&data->interrupt_worker, nxp_pcf85263a_interrupt_worker);
+#endif
+
+#if defined(CONFIG_NXP_PCF85263A_TS_INTB_OUT) || defined(CONFIG_NXP_PCF85263A_TS_CLK_OUT)
+	if (device_is_ready(cfg->ts_gpio.port)) {
+		rc = gpio_pin_configure_dt(&cfg->ts_gpio, GPIO_INPUT);
+		if (rc < 0) {
+			return rc;
+		}
+	}
+#else
+	if (device_is_ready(cfg->ts_gpio.port)) {
+		rc = gpio_pin_configure_dt(&cfg->ts_gpio, GPIO_OUTPUT);
+		if (rc < 0) {
+			return rc;
+		}
+	}
+#endif
+
+	return rc;
+}
+
+int nxp_pcf85263a_get_value(const struct device *dev, uint64_t *value)
+{
+	int rc = 0;
+	struct nxp_pcf85263a_data *data = dev->data;
+	const struct nxp_pcf85263a_config *cfg = dev->config;
+	uint8_t len = 0;
+	uint8_t time_registers[8];
+	static struct tm time = { 0 };
+
+	if(data->mode == NXP_PCF85263A_MODE_RTC){
+		len = 8;
+	}else{
+		len = 6;
+	}
+
+	rc = i2c_burst_read_dt(&cfg->i2c, PCF85263A_REG_TIME, &time_registers[0], len);
+	if (rc < 0) {
+		return rc;
+	};
+
+	if(data->mode == NXP_PCF85263A_MODE_RTC){
+		time.tm_sec  = bcd2bin(time_registers[1]  & 0x7F);
+		time.tm_min  = bcd2bin(time_registers[2]  & 0x7F);
+		time.tm_hour = bcd2bin(time_registers[3]  & 0x3F);
+		time.tm_mday = bcd2bin(time_registers[4]  & 0x3F);
+		time.tm_wday = bcd2bin(time_registers[5]  & 0x07);
+		time.tm_mon  = bcd2bin(time_registers[6]  & 0x1F) - 1;
+		time.tm_year = bcd2bin(time_registers[7]) + 70;
+		*value = timeutil_timegm(&time);
+	}else{
+		/* TODO: Implement stop-watch bcd2bin translation */
+		LOG_ERR("Stop-watch mode is not implemented.");
+		return -ENOSYS;
+	}
+
+	return rc;
+}
+
+int nxp_pcf85263a_start(const struct device *dev)
+{
+	int rc = 0;
+	const struct nxp_pcf85263a_config *cfg = dev->config;
+
+	rc = i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_STOP, BIT(0), 0x00);
+
+	return rc;
+}
+
+int nxp_pcf85263a_stop(const struct device *dev)
+{
+	int rc = 0;
+	const struct nxp_pcf85263a_config *cfg = dev->config;
+
+	rc = i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_STOP, BIT(0), 0x01);
+
+	return rc;
+}
+
+static int nxp_pcf85263a_clear_prescaler(const struct device *dev)
+{
+	int rc = 0;
+	const struct nxp_pcf85263a_config *cfg = dev->config;
+	rc = i2c_reg_write_byte_dt(&cfg->i2c, PCF85263A_REG_RESET, 0xA4);
+
+	return rc;
+}
+
+int nxp_pcf85263a_set_value(const struct device *dev, uint64_t value)
+{
+	int rc = 0;
+	struct nxp_pcf85263a_data *data = dev->data;
+	const struct nxp_pcf85263a_config *cfg = dev->config;
+	uint8_t len = 0;
+	uint8_t time_registers[8];
+	struct tm tm;
+
+	if(data->mode == NXP_PCF85263A_MODE_RTC){
+		len = 8;
+		(void)gmtime_r((time_t *)&value, &tm);
+		time_registers[0] = 0;
+		time_registers[1] = bin2bcd(tm.tm_sec);
+		time_registers[2] = bin2bcd(tm.tm_min);
+		time_registers[3] = bin2bcd(tm.tm_hour);
+		time_registers[4] = bin2bcd(tm.tm_mday);
+		time_registers[5] = bin2bcd(tm.tm_wday);
+		time_registers[6] = bin2bcd(tm.tm_mon + 1);
+		time_registers[7] = bin2bcd(tm.tm_year-70);
+	}else{
+		len = 6;
+		/* TODO: Implement stop-watch bin2bcd translation */
+		LOG_ERR("Stop-watch mode is not implemented.");
+		return -ENOSYS;
+	}
+	rc = nxp_pcf85263a_stop(dev);
+	if (rc < 0) {
+		return rc;
+	};
+	rc = nxp_pcf85263a_clear_prescaler(dev);
+	if (rc < 0) {
+		return rc;
+	};
+	rc = i2c_burst_write_dt(&cfg->i2c, PCF85263A_REG_TIME, &time_registers[0], len);
+	if (rc < 0) {
+		return rc;
+	}
+	rc = nxp_pcf85263a_start(dev);
+	if (rc < 0) {
+		return rc;
+	};
+	return rc;
+}
+
+int nxp_pcf85263a_set_alarm(const struct device *dev, uint8_t id, const struct nxp_pcf85263a_alarm_cfg *alarm_cfg)
+{
+	int rc = 0;
+	struct nxp_pcf85263a_data *data = dev->data;
+	const struct nxp_pcf85263a_config *cfg = dev->config;
+	uint8_t addr, len;
+	struct tm tm;
+	uint8_t time_registers[5];
+
+	if(id == 1){
+		addr = PCF85263A_REG_ALARM1;
+		len = 5;
+		rc = i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_ALARM_ENABLES,
+			PCF85263A_ALARM_ENABLE_ALARM1, 0x00);
+		if (rc < 0) {
+			return rc;
+		};
+	} else if (id == 2) {
+		addr = PCF85263A_REG_ALARM2;
+		len = 3;
+		rc = i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_ALARM_ENABLES,
+			PCF85263A_ALARM_ENABLE_ALARM2, 0x00);
+		if (rc < 0) {
+			return rc;
+		};
+	} else {
+		return -EINVAL;
+	}
+
+	(void)gmtime_r(&alarm_cfg->time, &tm);
+
+	if(id == 1 && (tm.tm_wday != 0 || tm.tm_year != 0))
+		LOG_WRN("Alarm channel 1 can only be set with day, month, hour, minutes and seconds. Other time elements (such as year and weekday) will be ignored.");
+
+	if(id == 2 && (tm.tm_year != 0 || tm.tm_mon != 0 || tm.tm_mday != 0 || tm.tm_sec != 0))
+		LOG_WRN("Alarm channel 2 can only be set with weekday, hour and minutes. Other time elements (such as day, month, year and seconds) will be ignored.");
+
+	if(id == 1){
+		time_registers[0] = bin2bcd(tm.tm_sec);
+		time_registers[1] = bin2bcd(tm.tm_min);
+		time_registers[2] = bin2bcd(tm.tm_hour);
+		time_registers[3] = bin2bcd(tm.tm_mday);
+		time_registers[4] = bin2bcd(tm.tm_mon+1);
+	} else if(id == 2){
+		time_registers[0] = bin2bcd(tm.tm_min);
+		time_registers[1] = bin2bcd(tm.tm_hour);
+		time_registers[2] = bin2bcd(tm.tm_wday);
+	}
+
+	rc = i2c_burst_write_dt(&cfg->i2c, addr, time_registers, len);
+	if (rc < 0) {
+		return rc;
+	};
+
+	data->alarm_callbacks[id-1] = alarm_cfg->callback;
+	data->alarm_user_data[id-1] = alarm_cfg->user_data;
+
+	#if CONFIG_NXP_PCF85263A_INTA_INT_OUT
+		if(alarm_cfg->flags & PCF85263A_ALARM_FLAGS_USE_INTA){
+			if(cfg->inta_gpio.port == NULL){
+				LOG_ERR("INTA pin not found.");
+				return -EINVAL;
+			}
+			rc = gpio_pin_interrupt_configure_dt(&cfg->inta_gpio,
+				GPIO_INT_EDGE_TO_ACTIVE);
+			if (rc < 0) {
+				return rc;
+			};
+			gpio_init_callback(&data->int_cb, nxp_pcf85263a_int_callback,
+				BIT(cfg->inta_gpio.pin));
+			rc = gpio_add_callback(cfg->inta_gpio.port, &data->int_cb);
+			if (rc < 0) {
+				return rc;
+			};
+			if (id == 1)
+				rc = i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_INTA_ENABLE,
+					BIT(4)|BIT(3), (0x02 << 3));
+			if (id == 2)
+				rc = i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_INTA_ENABLE,
+					BIT(4)|BIT(3), (0x01 << 3));
+			if (rc < 0)
+				return rc;
+		}
+	#elif CONFIG_NXP_PCF85263A_TS_INTB_OUT
+		if(alarm_cfg->flags & PCF85263A_ALARM_FLAGS_USE_INTB){
+			if(cfg->ts_gpio.port == NULL){
+				LOG_ERR("TS pin not found.");
+				return -EINVAL;
+			}
+			rc = gpio_pin_interrupt_configure_dt(&cfg->ts_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+			if(rc < 0)
+				return rc;
+			gpio_init_callback(&data->int_cb, nxp_pcf85263a_int_callback,
+				BIT(cfg->ts_gpio.pin));
+			rc = gpio_add_callback(cfg->ts_gpio.port, &data->int_cb);
+			if (rc < 0) {
+				return rc;
+			};
+			if (id == 1)
+				rc = i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_INTB_ENABLE,
+					BIT(4)|BIT(3), (0x02 << 3));
+			if (id == 2)
+				rc = i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_INTB_ENABLE,
+					BIT(4)|BIT(3), (0x01 << 3));
+			if (rc < 0)
+				return rc;
+		}
+	#else
+	#warning "NXP_PXF85263A: No interrupt pin (INTA or INTB) configured."
+	#endif
+
+	if(id == 1){
+		i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_ALARM_ENABLES, PCF85263A_ALARM_ENABLE_ALARM1, 0x0F);
+	}
+	if(id == 2){
+		i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_ALARM_ENABLES, PCF85263A_ALARM_ENABLE_ALARM2, 0x70);
+	}
+
+	return rc;
+}
+
+int nxp_pcf85263a_cancel_alarm(const struct device *dev, uint8_t id)
+{
+	int rc = 0;
+	struct nxp_pcf85263a_data *data = dev->data;
+	const struct nxp_pcf85263a_config *cfg = dev->config;
+	uint8_t reg;
+
+	if (id == 1) {
+		reg = PCF85263A_ALARM_ENABLE_ALARM1;
+	} else if (id == 2) {
+		reg = PCF85263A_ALARM_ENABLE_ALARM2;
+	} else {
+		return -EINVAL;
+	}
+
+	data->alarm_callbacks[id-1] = NULL;
+	data->alarm_user_data[id-1] = NULL;
+
+	rc = i2c_reg_update_byte_dt(&cfg->i2c, PCF85263A_REG_ALARM_ENABLES, reg, 0x00);
+	return rc;
+}
+
+static const struct counter_driver_api pcf85263a_api;
+
+#define INST_DT_PCF85263A(index)                                                    	\
+											\
+	static struct nxp_pcf85263a_data pcf85263a_data_##index;                        \
+											\
+	static const struct nxp_pcf85263a_config pcf85263a_config_##index = {           \
+		.i2c = I2C_DT_SPEC_INST_GET(index),					\
+		.inta_gpio = GPIO_DT_SPEC_INST_GET_OR(index, inta_gpios, {0}),		\
+		.ts_gpio = GPIO_DT_SPEC_INST_GET_OR(index, ts_gpios, {0}),		\
+	};                                                                              \
+											\
+	DEVICE_DT_INST_DEFINE(index, nxp_pcf85263a_init, NULL, &pcf85263a_data_##index,	\
+		&pcf85263a_config_##index, POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY,	\
+		&pcf85263a_api);
+
+DT_INST_FOREACH_STATUS_OKAY(INST_DT_PCF85263A);

--- a/dts/bindings/rtc/nxp, pcf85263a.yaml
+++ b/dts/bindings/rtc/nxp, pcf85263a.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2022 Fraunhofer AICOS
+#
+
+description: NXP PCF85263A I2C RTC and Stop-watch
+
+compatible: "nxp,pcf85263a"
+
+include: i2c-device.yaml
+
+properties:
+  inta-gpios:
+    type: phandle-array
+
+  ts-gpios:
+    type: phandle-array

--- a/include/zephyr/drivers/rtc/nxp_pcf85263a.h
+++ b/include/zephyr/drivers/rtc/nxp_pcf85263a.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2022 Fraunhofer AICOS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_RTC_PCF8526A_H_
+#define ZEPHYR_INCLUDE_DRIVERS_RTC_PCF8526A_H_
+
+#include <time.h>
+
+/** @brief Flag indicating that the alarm must use INTA
+ * pin for signaling that an alarm has been triggered.
+ */
+#define PCF85263A_ALARM_FLAGS_USE_INTA           BIT(0)
+
+/** @brief Flag indicating that the alarm must use INTB
+ * pin for signaling that an alarm has been triggered.
+ */
+#define PCF85263A_ALARM_FLAGS_USE_INTB           BIT(1)
+
+/**
+ * @brief Signature for PCF85263a alarm callbacks.
+ *
+ * @param dev the device from which the callback originated.
+ *
+ * @param id the alarm id from which the callback originated.
+ *
+ * @param value posix offset from nxp_pcf85263a_get_value() at the
+ * time the alarm interrupt was processed.
+ *
+ * @param user_data user provided pointer passed to alarm callback.
+ */
+typedef void (*nxp_pcf8523a_alarm_callback_t)(const struct device *dev,
+					 uint8_t id, uint32_t value,
+					 void *user_data);
+
+/** @brief Structure defining the alarm configuration. */
+struct nxp_pcf85263a_alarm_cfg {
+	/** @brief Time specification for an RTC alarm. */
+	time_t time;
+	/** @brief Function to be called when alarm is signalled.
+	 * The callback will be invoked from the system work queue.
+	 */
+	nxp_pcf8523a_alarm_callback_t callback;
+	/** @brief User-provided pointer passed to alarm callback. */
+	void *user_data;
+	/** @brief Flags controlling configuration of the alarm.
+	 * At the moment, two flags are available:
+	 * - PCF85263A_ALARM_FLAGS_USE_INTA
+	 * - PCF85263A_ALARM_FLAGS_USE_INTB
+	 * This two flags define which interrupt line must be signaled
+	 * when the current time reaches the time set on alarm.
+	 */
+	uint8_t flags;
+};
+
+/**
+ * @brief Gets date and time posix offset in seconds.
+ *
+ * @param dev the PCF85263a device pointer.
+ *
+ * @param value pointer into which current posix offset in seconds will be stored.
+ *
+ * @return a non-negative value on success, or a negative error code from
+ * an I2C transaction or not implemented feature (stop-watch mode).
+ */
+int nxp_pcf85263a_get_value(const struct device *dev, uint64_t *value);
+
+/**
+ * @brief Sets date and time.
+ *
+ * @param dev the PCF85263a device pointer.
+ *
+ * @param value date and time posix offset in seconds.
+ *
+ * @note This function starts time counting right after setting a new initial value.
+ *
+ * @return a non-negative value on success, or a negative error code from
+ * an I2C transaction or not implemented feature (stop-watch mode).
+ */
+int nxp_pcf85263a_set_value(const struct device *dev, uint64_t value);
+
+/**
+ * @brief Starts time counting.
+ *
+ * @param dev the PCF85263a device pointer.
+ *
+ * @return a non-negative value on success, or a negative error code from
+ * an I2C transaction.
+ */
+int nxp_pcf85263a_start(const struct device *dev);
+
+/**
+ * @brief Stops time counting.
+ *
+ * @param dev the PCF85263a device pointer.
+ *
+ * @return a non-negative value on success, or a negative error code from
+ * an I2C transaction.
+ */
+int nxp_pcf85263a_stop(const struct device *dev);
+
+/**
+ * @brief Sets alarm on PCF85263a RTC.
+ *
+ * @param dev the PCF85263a device pointer.
+ *
+ * @param id the alarm id. PCF85263a supports two alarms simultaneously. @c ALARM1 is 1
+ * and can be configured froms seconds to months. @c ALARM2 is 2 and operates on minutes,
+ * seconds and weekday.
+ *
+ * @param alarm_cfg a pointer to the desired alarm configuration.
+ *
+ * @return a non-negative value on success, or a negative error code from
+ * an I2C transaction or an invallid parameter.
+ */
+int nxp_pcf85263a_set_alarm(const struct device *dev, uint8_t id,
+	const struct nxp_pcf85263a_alarm_cfg *alarm_cfg);
+
+/**
+ * @brief Cancels alarm on PCF85263a RTC.
+ *
+ * @param dev the PCF85263a device pointer.
+ *
+ * @param id the alarm id.
+ *
+ * @return a non-negative value on success, or a negative error code from
+ * an I2C transaction or an invallid parameter.
+ */
+int nxp_pcf85263a_cancel_alarm(const struct device *dev, uint8_t id);
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_RTC_PCF8526A_H_ */


### PR DESCRIPTION
* Add NXP PCF85263A device driver
* Add proper interfaces to allow NXP PCF85263A to be used as both an RTC and a counter
* Add a device-tree binding for the NXP PCF85263A rtc