### PR TITLE
Bluetooth: BAP: Broadcast assistant add idx check for read recv state

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -319,9 +319,12 @@ static uint8_t read_recv_state_cb(struct bt_conn *conn, uint8_t err,
 			}
 		}
 	} else {
-		for (int i = 0; i < broadcast_assistant.recv_state_cnt; i++) {
+		for (uint8_t i = 0U; i < broadcast_assistant.recv_state_cnt; i++) {
 			if (handle == broadcast_assistant.recv_state_handles[i]) {
-				(void)bt_bap_broadcast_assistant_read_recv_state(conn, i + 1);
+				if (i + 1 < ARRAY_SIZE(broadcast_assistant.recv_state_handles)) {
+					(void)bt_bap_broadcast_assistant_read_recv_state(conn,
+											 i + 1);
+				}
 				break;
 			}
 		}
@@ -947,6 +950,12 @@ int bt_bap_broadcast_assistant_read_recv_state(struct bt_conn *conn,
 
 	if (conn == NULL) {
 		LOG_DBG("conn is NULL");
+
+		return -EINVAL;
+	}
+
+	CHECKIF(idx >= ARRAY_SIZE(broadcast_assistant.recv_state_handles)) {
+		LOG_DBG("Invalid idx: %u", idx);
 
 		return -EINVAL;
 	}


### PR DESCRIPTION
Add check for the index in the function itself, as well as where we call it internally, to ensure that we do not attempt to access invalid indexes of broadcast_assistant.recv_state_handles.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/58563