### PR TITLE
Bluetooth: BAP: Remove lower check in BT_BAP_BASS_VALID_OPCODE

### DIFF
--- a/subsys/bluetooth/audio/bap_internal.h
+++ b/subsys/bluetooth/audio/bap_internal.h
@@ -33,9 +33,7 @@
 #define BT_BAP_BASS_PA_REQ_SYNC_PAST          0x01
 #define BT_BAP_BASS_PA_REQ_SYNC               0x02
 
-#define BT_BAP_BASS_VALID_OPCODE(opcode) \
-	((opcode) >= BT_BAP_BASS_OP_SCAN_STOP && \
-	 (opcode) <= BT_BAP_BASS_OP_REM_SRC)
+#define BT_BAP_BASS_VALID_OPCODE(opcode) ((opcode) <= BT_BAP_BASS_OP_REM_SRC)
 
 struct bt_bap_bass_cp_scan_stop {
 	uint8_t opcode;


### PR DESCRIPTION
Remove the lower check (BT_BAP_BASS_OP_SCAN_STOP) in BT_BAP_BASS_VALID_OPCODE as it is always used on unsigned variables, so no point in check if it is lower than 0.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/58507