### PR TITLE
net: coap: Validate token length in coap_header_get_token()

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -748,6 +748,10 @@ uint8_t coap_header_get_token(const struct coap_packet *cpkt, uint8_t *token)
 	}
 
 	tkl = cpkt->data[0] & 0x0f;
+	if (tkl > COAP_TOKEN_MAX_LEN) {
+		return 0;
+	}
+
 	if (tkl) {
 		memcpy(token, cpkt->data + BASIC_HEADER_SIZE, tkl);
 	}


### PR DESCRIPTION
In theory, coap_header_get_token() should only be used on already parsed packets, and coap_packet_parse() would detect an invalid token length in a packet. Coverity however complains about possible out-of-bound access, as in theory the function can return token length up to 15. Therefore add an extra validation of the token length within the function, to avoid out-of-bound access due to programming errors and to make Coverity happy.

Fixes #58607
Fixes #58611
Fixes #58618
Fixes #58621
Fixes #58623
Fixes #58627
Fixes #58632
Fixes #58649
Fixes #58659
Fixes #58674