### PR TITLE
Bluetooth: Audio: Shell: Fix use of IN_RANGE when MIN is 0

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -1086,7 +1086,7 @@ static int cmd_stream_qos(const struct shell *sh, size_t argc, char *argv[])
 			return -ENOEXEC;
 		}
 
-		if (!IN_RANGE(framing, BT_ISO_FRAMING_UNFRAMED, BT_ISO_FRAMING_FRAMED)) {
+		if (framing != BT_ISO_FRAMING_UNFRAMED && framing != BT_ISO_FRAMING_FRAMED) {
 			return -ENOEXEC;
 		}
 

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -453,7 +453,7 @@ static int cmd_bap_broadcast_assistant_add_src(const struct shell *sh,
 			return -ENOEXEC;
 		}
 
-		if (!IN_RANGE(bis_sync, 0, UINT32_MAX)) {
+		if (bis_sync > UINT32_MAX) {
 			shell_error(sh, "Invalid bis_sync: %lu", bis_sync);
 
 			return -ENOEXEC;
@@ -630,7 +630,7 @@ static int cmd_bap_broadcast_assistant_add_broadcast_id(const struct shell *sh,
 			shell_error(sh, "failed to parse bis_sync: %d", err);
 
 			return -ENOEXEC;
-		} else if (!IN_RANGE(bis_sync, 0, UINT32_MAX)) {
+		} else if (bis_sync > UINT32_MAX) {
 			shell_error(sh, "Invalid bis_sync: %lu", bis_sync);
 
 			return -ENOEXEC;
@@ -727,7 +727,7 @@ static int cmd_bap_broadcast_assistant_mod_src(const struct shell *sh,
 			return -ENOEXEC;
 		}
 
-		if (!IN_RANGE(bis_sync, 0, UINT32_MAX)) {
+		if (bis_sync > UINT32_MAX) {
 			shell_error(sh, "Invalid bis_sync: %lu", bis_sync);
 
 			return -ENOEXEC;


### PR DESCRIPTION
If the minimal value of an IN_RANGE is 0, then it is a useless check, and the cases have been modified to not use IN_RANGE. This also fixes some coverity issues.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/58561
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58558
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58542
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58537