### PR TITLE
Bluetooth: TBS: Add missing NULL check when notifying terminate

### DIFF
--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -1178,8 +1178,12 @@ static void notify_app(struct bt_conn *conn, uint16_t len,
 		break;
 	case BT_TBS_CALL_OPCODE_TERMINATE:
 		if (tbs_cbs->terminate_call != NULL) {
-			const struct tbs_service_inst *inst =
-				lookup_inst_by_call_index(ccp->terminate.call_index);
+			const struct tbs_service_inst *inst = lookup_inst_by_call_index(call_index);
+
+			if (inst == NULL) {
+				LOG_DBG("Could not find instance by call index 0x%02X", call_index);
+				break;
+			}
 
 			tbs_cbs->terminate_call(conn, call_index,
 						inst->terminate_reason.reason);


### PR DESCRIPTION
When notify_app is called for BT_TBS_CALL_OPCODE_TERMINATE we did a lookup on the call index, but never did a NULL check before dereferecing it.

This does not fix the issue that the instance will always be NULL in this case, as we have terminated the call so we cannot possibly look up the call afterwards.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/58553