### PR TITLE
tests: posix headers: RT1015 increase RAM

### DIFF
--- a/tests/posix/headers/boards/mimxrt1015_evk.overlay
+++ b/tests/posix/headers/boards/mimxrt1015_evk.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,sram = &ocram;
+	};
+};


### PR DESCRIPTION
RT1015 needs more RAM to do this test, increase size of Zephyr SRAM by switching zephyr,sram to the OCRAM allocation of the FLEXRAM.

Fixes #58730