### PR TITLE
net: dns_sd: Prevent dead code in query parsing

### DIFF
--- a/subsys/net/lib/dns/dns_sd.c
+++ b/subsys/net/lib/dns/dns_sd.c
@@ -1064,6 +1064,12 @@ int dns_sd_query_extract(const uint8_t *query, size_t query_size, struct dns_sd_
 		size[i] = 0;
 	}
 
+	if (qlabels > N) {
+		NET_DBG("too few buffers to extract query: qlabels: %zu, N: %zu",
+			qlabels, N);
+		return -ENOBUFS;
+	}
+
 	if (qlabels < DNS_SD_MIN_LABELS) {
 		NET_DBG("too few labels in query %zu, DNS_SD_MIN_LABELS: %d", qlabels,
 			DNS_SD_MIN_LABELS);
@@ -1120,10 +1126,6 @@ int dns_sd_query_extract(const uint8_t *query, size_t query_size, struct dns_sd_
 			NET_DBG("domain '%s' is invalid", record->domain);
 			return -EINVAL;
 		}
-	} else if (qlabels > N) {
-		NET_DBG("too few buffers to extract query: qlabels: %zu, N: %zu",
-			qlabels, N);
-		return -ENOBUFS;
 	}
 
 	return offset;


### PR DESCRIPTION
The number of buffer provided was verified in the final else block of a long validation sequence. It would never be executed though, as one of the conditions before would always evaluate to true.

As the number of buffers provided verification appears to be significant in this case, as the buffers are referenced during other validations, move this check at the beginning of the sequence instead. This also eliminates the dead-code problem.

Fixes #58625