### PR TITLE
drivers: usb_dc_mcux: Increase driver stack size when debug logging level enabled

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -183,6 +183,7 @@ config USB_DC_MSG_QUEUE_LEN
 
 config USB_MCUX_THREAD_STACK_SIZE
 	int "Stack size for the USB driver"
+	default 2048 if USB_DEVICE_LOG_LEVEL_DBG
 	default 1024
 	help
 	  Size of the stack used for the internal USB thread.


### PR DESCRIPTION
Increase the size of the MCUX USB driver thread stack if using the CONFIG_USB_DEVICE_LOG_LEVEL_DBG Kconfig, to avoid stack overflow caused by many stack frames coming from the debug logs.

Fixes #56009