### PR TITLE
mgmt/MCUmgr/grp/img: Support for MCUboot mode DirectXIP with revert

### DIFF
--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -176,6 +176,21 @@ config MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
 	  means major.minor.patch triple, unless BOOT_VERSION_CMP_USE_BUILD_NUMBER
 	  is also selected that enables comparison of build number.
 
+config MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT
+	bool "MCUboot has been configured for DirectXIP with revert"
+	select MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP
+	help
+	  MCUboot expects slot0_partition and slot1_partition to exist in DT.
+	  In this mode MCUboot will boot the application with the higher version
+	  from either slot, as long as it has been marked to be boot
+	  next time for test or permanently. In case when application is marked
+	  for test it needs to confirm itself, on the first boot, or it will
+	  be removed and MCUboot will revert to booting previously approved
+	  application.
+	  This mode does not allow freely switching between application
+	  versions, as, once higher version application is approved, it is
+	  not possible to select lower version for boot.
+
 endchoice # MCUBOOT_BOOTLOADER_MODE
 
 endif # BOOTLOADER_MCUBOOT
@@ -207,5 +222,14 @@ config BOOT_IMAGE_ACCESS_HOOKS
 	  MCUboot's routines required for access the image data.
 	  It is up to the application project to add source file which
 	  implements hooks to the build.
+
+if MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT
+
+config MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP
+	bool
+	help
+	  Adds support for setting for test and confirming images
+	  when bootloader is in DirectXIP-revert mode.
+endif
 
 endif # MCUBOOT_BOOTUTIL_LIB

--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -43,6 +43,19 @@ tests:
       - mg100
     integration_platforms:
       - nrf52840dk_nrf52840
+  # In mcuboot_flags test overlay-serial.conf is used for convenience as it is the simplest
+  # transport. Transport does not affect flags so it does not really matter which is selected,
+  # flags should affect any transport the same way.
+  sample.mcumgr.smp_svr.mcuboot_flags.direct_xip_withrevert:
+    extra_args: OVERLAY_CONFIG="overlay-serial.conf"
+    extra_configs:
+      - CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT=y
+    platform_allow:
+      - nrf52840dk_nrf52840
+      - pinnacle_100_dvk
+      - mg100
+    integration_platforms:
+      - nrf52840dk_nrf52840
   sample.mcumgr.smp_svr.serial-console:
     extra_args: OVERLAY_CONFIG="overlay-serial-console.conf"
     platform_allow:


### PR DESCRIPTION
The series of commits that:
~~1) Provide some modifications to how MCUmgr composes image list to make it easier to work without actually knowing meaning of MCUboot flags.~~
~~2) Provide img_mgmt_get_next_boot_slot function that allows to get info on next boot slot and type of boot~~
3) Provide Kconfig options that allow to enable DirectXIP with revert mode in bootutil when compiled to Zephyr application.
4) Provide support for controlling DirectXIP with revert boot process from MCUmgr.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/61342

**Update 2023-08-11 16:58 UTC**
Rebase onto the https://github.com/zephyrproject-rtos/zephyr/pull/61342
**Update 2023-08-18 10:00 UTC**
Squashed Kconfig commits to the main commit providing the feature; updated with fixes for review comments.
**update 2023-08-23 16:00 UTC**
Review fixes and update from base.

**Update 2023-09-08 16:00 UTC**
Review comments applied and updated from base.


