### PR TITLE
soc/xtensa/nxp_adsp/CMakeLists.txt: use new WEST_SIGN_OPTS variable

### DIFF
--- a/soc/xtensa/nxp_adsp/CMakeLists.txt
+++ b/soc/xtensa/nxp_adsp/CMakeLists.txt
@@ -15,6 +15,6 @@ add_custom_target(zephyr.ri ALL
 add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
   COMMENT "west sign --if-tool-available --tool rimage ..."
-  COMMAND  west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR}
+  COMMAND  west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR} ${WEST_SIGN_OPTS}
   DEPENDS ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
 )


### PR DESCRIPTION
Align `soc/nxp_adsp` with new `WEST_SIGN_OPTS` option added to `soc/intel_adsp` by recent commit d98a7c2f8ddb ("soc: xtensa: cmake: add new WEST_SIGN_OPTS variable").

This allows per-board rimage customization at the CMake level. For instance, add this line in `zephyr/boards/xtensa/nxp_adsp_NEWBOARD/board.cmake`:
```
  set(WEST_SIGN_OPTS -- -c rimage/config/special.toml)
```