### PR TITLE
boards: mec172xmodular_assy6930: Correct EC bootloader settings

### DIFF
--- a/boards/arm/mec172xmodular_assy6930/support/spi_cfg_4MBit.txt
+++ b/boards/arm/mec172xmodular_assy6930/support/spi_cfg_4MBit.txt
@@ -14,10 +14,10 @@ TagAddr1 = 0
 BoardID = 0
 
 [IMAGE "0"]
-ImageLocation = 0x1000
+ImageLocation = 0x100
 SpiFreqMHz = 24
-SpiReadCommand = Dual
-SpiDriveStrength = 4
+SpiReadCommand = Quad
+SpiDriveStrength = 8
 SpiSlewFast = false
 SpiSignalControl = 0x00
 FwBinFile = zephyr.bin


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/56332

 Changing the EC ROM bootloader mode to Quad from Dual and
    SPI drivestrength to 8mA
    This changes are required because of the different SPI flash
    used which doesn't support Dual mode.

    Signed-off-by: Chintha, Ramakrishna <ramakrishna.chintha@intel.com>
    Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>

