### PR TITLE
board: arm: black_f407ve fixes

### DIFF
--- a/boards/arm/black_f407ve/black_f407ve.dts
+++ b/boards/arm/black_f407ve/black_f407ve.dts
@@ -13,8 +13,8 @@
 	compatible = "st,stm32f407";
 
 	chosen {
-		zephyr,console = &usart2;
-		zephyr,shell-uart = &usart2;
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,ccm = &ccm0;
@@ -84,7 +84,7 @@
 };
 
 &usart1 {
-	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pb7>;
+	pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pa10>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";

--- a/boards/arm/black_f407ve/board.cmake
+++ b/boards/arm/black_f407ve/board.cmake
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(dfu-util "--pid=0483:df11" "--alt=0" "--dfuse")
 board_runner_args(jlink "--device=STM32F407VE" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)

--- a/boards/arm/black_f407ve/doc/index.rst
+++ b/boards/arm/black_f407ve/doc/index.rst
@@ -146,8 +146,8 @@ Default Zephyr Peripheral Mapping:
 
 .. rst-class:: rst-columns
 
-- UART_1_TX : PB6
-- UART_1_RX : PB7
+- UART_1_TX : PA9
+- UART_1_RX : PA10
 - UART_2_TX : PA2
 - UART_2_RX : PA3
 - USER_PB : PA0
@@ -179,11 +179,11 @@ at 168MHz, driven by 8MHz high speed external clock.
 Serial Port
 ===========
 
-BLACK_F407VE has up to 6 UARTs. The Zephyr console output is assigned to UART2.
+BLACK_F407VE has up to 6 UARTs. The Zephyr console output is assigned to UART1.
 Default settings are 115200 8N1.
 Please note that ST-Link Virtual Com Port is not wired to chip serial port.
 In order to enable console output you should use a serial cable and connect
-it to UART2 pins (PA2/PA3).
+it to UART1 pins (PA9/PA10).
 
 
 Programming and Debugging


### PR DESCRIPTION
- board: arm: black_f407ve: fix uart1 default pinmux and console uart
- board:arm: black_f407ve: add dfu programming support