### PR TITLE
rp2040: Fix I2C frequency for all boards

### DIFF
--- a/boards/arm/adafruit_kb2040/Kconfig.defconfig
+++ b/boards/arm/adafruit_kb2040/Kconfig.defconfig
@@ -9,4 +9,11 @@ config BOARD
 config RP2_FLASH_W25Q080
 	default y
 
+if I2C_DW
+
+config I2C_DW_CLOCK_SPEED
+	default 125
+
+endif #I2C_DW
+
 endif # BOARD_ADAFRUIT_KB2040

--- a/boards/arm/rpi_pico/Kconfig.defconfig
+++ b/boards/arm/rpi_pico/Kconfig.defconfig
@@ -13,7 +13,7 @@ config RP2_FLASH_W25Q080
 if I2C_DW
 
 config I2C_DW_CLOCK_SPEED
-	default 100
+	default 125
 
 endif #I2C_DW
 

--- a/boards/arm/sparkfun_pro_micro_rp2040/Kconfig.defconfig
+++ b/boards/arm/sparkfun_pro_micro_rp2040/Kconfig.defconfig
@@ -9,4 +9,11 @@ config BOARD
 config RP2_FLASH_W25Q080
 	default y
 
+if I2C_DW
+
+config I2C_DW_CLOCK_SPEED
+	default 125
+
+endif #I2C_DW
+
 endif # BOARD_SPARKFUN_PRO_MICRO_RP2040


### PR DESCRIPTION
The DW driver used by the RP2040 boards uses a Kconfig symbol to determine the clock speed of the board. This value was set incorrectly by the pico board to 100MHz (instead of 125). For the other boards, it wasn't set at all.
This commit fixes the kconfig defaults. In the future, this value should be taken directly from the devicetree. This is not currently possible as there is no clock control driver for the RP2040 (see #52901).

Fixes #56230