### PR TITLE
rp2040: Fix USB self powered for all boards

### DIFF
--- a/boards/arm/adafruit_kb2040/Kconfig.defconfig
+++ b/boards/arm/adafruit_kb2040/Kconfig.defconfig
@@ -16,4 +16,7 @@ config I2C_DW_CLOCK_SPEED
 
 endif #I2C_DW
 
+config USB_SELF_POWERED
+	default n
+
 endif # BOARD_ADAFRUIT_KB2040

--- a/boards/arm/rpi_pico/Kconfig.defconfig
+++ b/boards/arm/rpi_pico/Kconfig.defconfig
@@ -17,4 +17,7 @@ config I2C_DW_CLOCK_SPEED
 
 endif #I2C_DW
 
+config USB_SELF_POWERED
+	default n
+
 endif # BOARD_RPI_PICO || BOARD_RPI_PICO_W

--- a/boards/arm/sparkfun_pro_micro_rp2040/Kconfig.defconfig
+++ b/boards/arm/sparkfun_pro_micro_rp2040/Kconfig.defconfig
@@ -16,4 +16,7 @@ config I2C_DW_CLOCK_SPEED
 
 endif #I2C_DW
 
+config USB_SELF_POWERED
+	default n
+
 endif # BOARD_SPARKFUN_PRO_MICRO_RP2040


### PR DESCRIPTION
The USB configuration for all rp2040 boards wrongfully left USB_SELF_POWERED as true by default. This commit fixes it for all rp2040 boards.

Fixes #53993