### PR TITLE
drivers: gpio: fxl6408: Fix Kconfig dependency for log level configuration

### DIFF
--- a/drivers/gpio/Kconfig.fxl6408
+++ b/drivers/gpio/Kconfig.fxl6408
@@ -9,13 +9,16 @@ menuconfig GPIO_FXL6408
 	help
 	  Enable driver for FXL6408 I2C-based GPIO chip.
 
+if GPIO_FXL6408
+
 config GPIO_FXL6408_INIT_PRIORITY
 	int "Init priority"
 	default 80
-	depends on GPIO_FXL6408
 	help
 	  Device driver initialization priority.
 
 module = FXL6408
 module-str = fxl6408
 source "subsys/logging/Kconfig.template.log_config"
+
+endif # GPIO_FXL6408


### PR DESCRIPTION
This makes Kconfig logging options for this driver depending on whether the driver is enabled or not.