### PR TITLE
drivers: pinctrl_emsdp: add dummy mux for unmuxed peripheral

### DIFF
--- a/boards/arc/emsdp/emsdp-pinctrl.dtsi
+++ b/boards/arc/emsdp/emsdp-pinctrl.dtsi
@@ -130,4 +130,9 @@
 	arduino_CFG6_i2c: arduino_CFG6_i2c {
 		pinmux = <ARDUINO_PIN_AD5 ARDUINO_I2C>;
 	};
+
+	/* INNER_CONNECT, DUMMY MUX */
+	unmuxed_pin: unmuxed_pin {
+		pinmux = <INNER_CONNECT NOT_PINMUX>;
+	};
 };

--- a/boards/arc/emsdp/emsdp-pinctrl.dtsi
+++ b/boards/arc/emsdp/emsdp-pinctrl.dtsi
@@ -133,6 +133,6 @@
 
 	/* INNER_CONNECT, DUMMY MUX */
 	unmuxed_pin: unmuxed_pin {
-		pinmux = <INNER_CONNECT NOT_PINMUX>;
+		pinmux = <UNMUXED_PIN NOT_PINMUX>;
 	};
 };

--- a/boards/arc/emsdp/emsdp.dts
+++ b/boards/arc/emsdp/emsdp.dts
@@ -49,6 +49,8 @@
 
 		spi@f1000000 {
 			interrupts = <84 1>;
+			pinctrl-0 = <&unmuxed_pin>;
+			pinctrl-names = "default";
 		};
 
 		spi@80010000 {

--- a/drivers/pinctrl/pinctrl_emsdp.c
+++ b/drivers/pinctrl/pinctrl_emsdp.c
@@ -103,6 +103,10 @@ static int pinctrl_emsdp_set(uint32_t pin, uint32_t type)
 	const uint32_t mux_regs = (EMSDP_CREG_BASE + EMSDP_CREG_PMOD_MUX_OFFSET);
 	uint32_t reg;
 
+	if (pin == INNER_CONNECT) {
+		return 0;
+	}
+
 	if (pin <= PMOD_C) {
 		reg = sys_read32(mux_regs + PMOD_MUX_CTRL);
 	} else {

--- a/drivers/pinctrl/pinctrl_emsdp.c
+++ b/drivers/pinctrl/pinctrl_emsdp.c
@@ -11,6 +11,12 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/emsdp-pinctrl.h>
 
+/**
+ * Mux Control Register Index
+ */
+#define PMOD_MUX_CTRL 0 /*!< 32-bits, offset 0x0 */
+#define ARDUINO_MUX_CTRL 4 /*!< 32-bits, offset 0x4 */
+
 #define EMSDP_CREG_BASE            DT_INST_REG_ADDR(0)
 #define EMSDP_CREG_PMOD_MUX_OFFSET (0x0030)
 
@@ -103,7 +109,7 @@ static int pinctrl_emsdp_set(uint32_t pin, uint32_t type)
 	const uint32_t mux_regs = (EMSDP_CREG_BASE + EMSDP_CREG_PMOD_MUX_OFFSET);
 	uint32_t reg;
 
-	if (pin == INNER_CONNECT) {
+	if (pin == UNMUXED_PIN) {
 		return 0;
 	}
 

--- a/include/zephyr/dt-bindings/pinctrl/emsdp-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/emsdp-pinctrl.h
@@ -7,13 +7,6 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_EMSDP_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_EMSDP_PINCTRL_H_
 
-/**
- * Mux Control Register Index
- */
-#define PMOD_MUX_CTRL 0 /*!< 32-bits, offset 0x0 */
-
-#define ARDUINO_MUX_CTRL 4 /*!< 32-bits, offset 0x4 */
-
 #define PMOD_A              0
 #define PMOD_B              1
 #define PMOD_C              2
@@ -37,7 +30,7 @@
 #define ARDUINO_PIN_AD3     20
 #define ARDUINO_PIN_AD4     21
 #define ARDUINO_PIN_AD5     22
-#define INNER_CONNECT       23
+#define UNMUXED_PIN       23
 
 #define PMOD_GPIO           0
 #define PMOD_UARTA          1

--- a/include/zephyr/dt-bindings/pinctrl/emsdp-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/emsdp-pinctrl.h
@@ -37,6 +37,7 @@
 #define ARDUINO_PIN_AD3     20
 #define ARDUINO_PIN_AD4     21
 #define ARDUINO_PIN_AD5     22
+#define INNER_CONNECT       23
 
 #define PMOD_GPIO           0
 #define PMOD_UARTA          1
@@ -52,6 +53,7 @@
 #define ARDUINO_I2C         11
 #define ARDUINO_PWM         12
 #define ARDUINO_ADC         13
+#define NOT_PINMUX          14
 
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_EMSDP_PINCTRL_H_ */


### PR DESCRIPTION
ARC EMSDP board has some peripherals are internal connected, such as DW spi1 and DFSS i2c0. They are unmuxed and have fix
connection to spi-flash or sensor. For these peripheral, add dummy mux type to avoid pinctrl ENOENT error.