### PR TITLE
drivers: i2c: target: Virtual EEPROM add ability to change i2c address

### DIFF
--- a/drivers/i2c/target/Kconfig.eeprom
+++ b/drivers/i2c/target/Kconfig.eeprom
@@ -7,3 +7,9 @@ config I2C_EEPROM_TARGET
 	bool "I2C Target EEPROM driver"
 	help
 	  Enable virtual I2C Target EEPROM driver
+
+config I2C_EEPROM_TARGET_RUNTIME_ADDR
+	bool "Set I2C Target EEPROM Address at Runtime"
+	depends on I2C_EEPROM_TARGET
+	help
+	  Enable changing virtual I2C Target EEPROM device address at runtime

--- a/drivers/i2c/target/eeprom_target.c
+++ b/drivers/i2c/target/eeprom_target.c
@@ -59,6 +59,25 @@ int eeprom_target_read(const struct device *dev, uint8_t *eeprom_data,
 	return 0;
 }
 
+#ifdef CONFIG_I2C_EEPROM_TARGET_RUNTIME_ADDR
+int eeprom_target_set_addr(const struct device *dev, uint8_t addr)
+{
+	const struct i2c_eeprom_target_config *cfg = dev->config;
+	struct i2c_eeprom_target_data *data = dev->data;
+	int ret;
+
+	ret = i2c_target_unregister(cfg->bus.bus, &data->config);
+	if (ret) {
+		LOG_DBG("eeprom target failed to unregister");
+		return ret;
+	}
+
+	data->config.address = addr;
+
+	return i2c_target_register(cfg->bus.bus, &data->config);
+}
+#endif /* CONFIG_I2C_EEPROM_TARGET_RUNTIME_ADDR */
+
 static int eeprom_target_write_requested(struct i2c_target_config *config)
 {
 	struct i2c_eeprom_target_data *data = CONTAINER_OF(config,

--- a/include/zephyr/drivers/i2c/target/eeprom.h
+++ b/include/zephyr/drivers/i2c/target/eeprom.h
@@ -46,6 +46,19 @@ int eeprom_target_read(const struct device *dev, uint8_t *eeprom_data,
 		      unsigned int offset);
 
 /**
+ * @brief Change the address of eeprom taget at runtime
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param addr New address to assign to the eeprom target devide
+ *
+ * @retval 0 Is successful
+ * @retval -EINVAL If parameters are invalid
+ * @retval -EIO General input / output error during i2c_taget_register
+ * @retval -ENOSYS If target mode is not implemented
+ */
+int eeprom_target_set_addr(const struct device *dev, uint8_t addr);
+
+/**
  * @}
  */
 


### PR DESCRIPTION
This patch adds the ability to change virtual i2c eeprom target address at runtime using a single function.
Added CONFIG_I2C_EEPROM_TARGET_RUNTIME_ADDR as an optional Kconfig.