### PR TITLE
Bluetooth: Mesh: Fix unable sent mesh message

### DIFF
--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -41,6 +41,8 @@ enum {
 	ADV_FLAG_SENT,
 	/** Currently performing proxy advertising */
 	ADV_FLAG_PROXY,
+	/** The proxy has been start, but maybe pending. */
+	ADV_FLAG_PROXY_START,
 	/** The send-call has been scheduled. */
 	ADV_FLAG_SCHEDULED,
 	/** The send-call has been pending. */
@@ -267,6 +269,7 @@ static void send_pending_adv(struct k_work *work)
 
 		atomic_clear_bit(adv->flags, ADV_FLAG_ACTIVE);
 		atomic_clear_bit(adv->flags, ADV_FLAG_PROXY);
+		atomic_clear_bit(adv->flags, ADV_FLAG_PROXY_START);
 
 		if (adv->buf) {
 			net_buf_unref(adv->buf);
@@ -307,10 +310,10 @@ static void send_pending_adv(struct k_work *work)
 		return;
 	}
 
-	atomic_set_bit(adv->flags, ADV_FLAG_PROXY);
+	atomic_set_bit(adv->flags, ADV_FLAG_PROXY_START);
 
-	if (bt_mesh_adv_gatt_send()) {
-		atomic_clear_bit(adv->flags, ADV_FLAG_PROXY);
+	if (!bt_mesh_adv_gatt_send()) {
+		atomic_set_bit(adv->flags, ADV_FLAG_PROXY);
 	}
 
 	if (atomic_test_and_clear_bit(adv->flags, ADV_FLAG_SCHEDULE_PENDING)) {
@@ -326,7 +329,9 @@ static bool schedule_send(struct bt_mesh_ext_adv *adv)
 	timestamp = adv->timestamp;
 
 	if (atomic_test_and_clear_bit(adv->flags, ADV_FLAG_PROXY)) {
+		atomic_clear_bit(adv->flags, ADV_FLAG_PROXY_START);
 		(void)bt_le_ext_adv_stop(adv->instance);
+
 		atomic_clear_bit(adv->flags, ADV_FLAG_ACTIVE);
 	}
 
@@ -438,7 +443,7 @@ static void connected(struct bt_le_ext_adv *instance,
 {
 	struct bt_mesh_ext_adv *adv = gatt_adv_get();
 
-	if (atomic_test_and_clear_bit(adv->flags, ADV_FLAG_PROXY)) {
+	if (atomic_test_and_clear_bit(adv->flags, ADV_FLAG_PROXY_START)) {
 		atomic_clear_bit(adv->flags, ADV_FLAG_ACTIVE);
 		(void)schedule_send(adv);
 	}


### PR DESCRIPTION
In PR (https://github.com/zephyrproject-rtos/zephyr/pull/58723) has introduce another bug, that, the flag `ADV_FLAG_PROXY` set before actually enabled.

When ctx:: BT RX call `schedule_send` will atomic_test_and_clear `ADV_FLAG_PROXY`, but at this time, the proxy advertising will not at advertising state, maybe in update params or set adverting data phase,

so that, call `bt_le_ext_adv_stop` will nothing, and then call `k_work_reschedule` --> `send_pending_adv`(at this time, the proxy advertising actually enabled, but the upper layer clear proxy flags), cause latest advertising unable start, because unable in advertising state to update params(`-EINVAL`).

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/58721