### PR TITLE
Bluetooth: Mesh: Remove unintentional dbg string

### DIFF
--- a/subsys/bluetooth/mesh/shell/cfg.c
+++ b/subsys/bluetooth/mesh/shell/cfg.c
@@ -807,7 +807,6 @@ static int cmd_node_id(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (argc <= 2) {
-		printk("ANders\n");
 		err = bt_mesh_cfg_cli_node_identity_get(bt_mesh_shell_target_ctx.net_idx,
 						    bt_mesh_shell_target_ctx.dst, net_idx, &status,
 						    &identify);


### PR DESCRIPTION
Remove debug string that accidentally got merged to the mesh shell cfg file.