### PR TITLE
Bluetooth: Shell: Ensure scan_filter.addr is null terminated

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1271,10 +1271,11 @@ static int cmd_scan_filter_set_name(const struct shell *sh, size_t argc,
 static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
+	const size_t max_cpy_len = sizeof(scan_filter.addr) - 1;
 	const char *addr_arg = argv[1];
 
 	/* Validate length including null terminator. */
-	if (strlen(addr_arg) >= sizeof(scan_filter.addr)) {
+	if (strlen(addr_arg) > max_cpy_len) {
 		shell_error(ctx_shell, "Invalid address string: %s\n",
 			    addr_arg);
 		return -ENOEXEC;
@@ -1293,7 +1294,8 @@ static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 		}
 	}
 
-	strncpy(scan_filter.addr, addr_arg, sizeof(scan_filter.addr));
+	strncpy(scan_filter.addr, addr_arg, max_cpy_len);
+	scan_filter.addr[max_cpy_len] = '\0'; /* ensure NULL termination */
 	scan_filter.addr_set = true;
 
 	return 0;


### PR DESCRIPTION
Ensure that scan_filter.addr is NULL terminated by only copying the sizeof the buffer -1 and then always setting the last byte to \0.

Fixes a coverity issue