### PR TITLE
Bluetooth: TBS: Fix copy of friendly name

### DIFF
--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -2126,7 +2126,7 @@ int bt_tbs_remote_incoming(uint8_t bearer_index, const char *to,
 
 	if (friendly_name) {
 		inst->friendly_name.call_index = call->index;
-		(void)strcpy(inst->friendly_name.uri, friendly_name);
+		utf8_lcpy(inst->friendly_name.uri, friendly_name, sizeof(inst->friendly_name.uri));
 		friend_name_ind_len = strlen(from) + 1;
 
 		bt_gatt_notify_uuid(NULL, BT_UUID_TBS_FRIENDLY_NAME,
@@ -2156,7 +2156,8 @@ int bt_tbs_remote_incoming(uint8_t bearer_index, const char *to,
 
 		if (friendly_name) {
 			gtbs_inst.friendly_name.call_index = call->index;
-			(void)strcpy(gtbs_inst.friendly_name.uri, friendly_name);
+			utf8_lcpy(inst->friendly_name.uri, friendly_name,
+				  sizeof(inst->friendly_name.uri));
 			friend_name_ind_len = strlen(from) + 1;
 
 			bt_gatt_notify_uuid(NULL, BT_UUID_TBS_FRIENDLY_NAME,


### PR DESCRIPTION
The friendly copy always assumed that the friendly name could fit in memory, which could cause overflows. Fixed by using utf8_lcpy as that not only ensures that the copy is truncated to fit in memory, but also ensures that it is null terminated and truncated in a way that supports multi-byte UTF8 characters.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/58562