### PR TITLE
net: tcp: populate context's local address for incoming connections

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1762,16 +1762,12 @@ static struct tcp *tcp_conn_new(struct net_pkt *pkt)
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    net_context_get_family(context) == AF_INET6) {
-		if (net_sin6_ptr(&context->local)->sin6_addr) {
-			net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
-				     net_sin6_ptr(&context->local)->sin6_addr);
-		}
+		net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
+				&conn->src.sin6.sin6_addr);
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   net_context_get_family(context) == AF_INET) {
-		if (net_sin_ptr(&context->local)->sin_addr) {
-			net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
-				      net_sin_ptr(&context->local)->sin_addr);
-		}
+		net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
+				&conn->src.sin.sin_addr);
 	}
 
 	ret = net_context_bind(context, &local_addr, sizeof(local_addr));


### PR DESCRIPTION
Someone with actual knowledge of the network stack please double check my reasoning here, I'm very unsure if this is a correct and safe thing to do:

`local_addr` would only be initialized if `context->local->sin*_addr` was non-null. However, since `context` is a fresh context object, `local_addr` always remains at its initial value of `INADDR_ANY`, which is propagated to the context by `net_context_bind()`.

By populating `local_addr` using the TCP endpoint, `getsockname()` now returns the correct local address.
