### PR TITLE
Bluetooth: audio: has: Fix building with preset support disabled

### DIFF
--- a/samples/bluetooth/hap_ha/sample.yaml
+++ b/samples/bluetooth/hap_ha/sample.yaml
@@ -7,6 +7,13 @@ tests:
     platform_allow: native_posix
     tags: bluetooth
     build_only: true
+  sample.bluetooth.hap_ha.monaural_no_presets:
+    harness: bluetooth
+    platform_allow: native_posix
+    tags: bluetooth
+    build_only: true
+    extra_configs:
+      - CONFIG_BT_HAS_PRESET_COUNT=0
   sample.bluetooth.hap_ha.banded:
     harness: bluetooth
     platform_allow: native_posix

--- a/samples/bluetooth/hap_ha/src/has_server.c
+++ b/samples/bluetooth/hap_ha/src/has_server.c
@@ -96,5 +96,9 @@ int has_server_init(void)
 		return err;
 	}
 
-	return has_server_preset_init();
+	if (IS_ENABLED(CONFIG_BT_HAS_PRESET_SUPPORT)) {
+		return has_server_preset_init();
+	}
+
+	return 0;
 }

--- a/subsys/bluetooth/audio/Kconfig.has
+++ b/subsys/bluetooth/audio/Kconfig.has
@@ -41,7 +41,7 @@ config BT_HAS_PRESET_NAME_DYNAMIC
 
 config BT_HAS_PRESET_CONTROL_POINT_NOTIFIABLE
 	bool "Preset Control Point Notifiable support"
-	depends on BT_HAS_PRESET_SUPPORT && BT_EATT
+	depends on BT_EATT
 	help
 	  This option enables support for clients to subscribe for notifications
 	  on the Hearing Aid Preset Control Point characteristic.

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -188,9 +188,9 @@ static struct has_client {
 #if defined(CONFIG_BT_HAS_PRESET_SUPPORT)
 	union {
 		struct bt_gatt_indicate_params ind;
-#if defined(CONFIG_BT_EATT)
+#if defined(CONFIG_BT_HAS_PRESET_CONTROL_POINT_NOTIFIABLE)
 		struct bt_gatt_notify_params ntf;
-#endif /* CONFIG_BT_EATT */
+#endif /* CONFIG_BT_HAS_PRESET_CONTROL_POINT_NOTIFIABLE */
 	} params;
 
 	uint8_t preset_changed_index_next;
@@ -468,7 +468,7 @@ static void control_point_ind_complete(struct bt_conn *conn,
 
 static int control_point_send(struct has_client *client, struct net_buf_simple *buf)
 {
-#if defined(BT_HAS_PRESET_CONTROL_POINT_NOTIFIABLE)
+#if defined(CONFIG_BT_HAS_PRESET_CONTROL_POINT_NOTIFIABLE)
 	if (bt_eatt_count(client->conn) > 0 &&
 	    bt_gatt_is_subscribed(client->conn, PRESET_CONTROL_POINT_ATTR, BT_GATT_CCC_NOTIFY)) {
 		client->params.ntf.attr = PRESET_CONTROL_POINT_ATTR;
@@ -478,7 +478,7 @@ static int control_point_send(struct has_client *client, struct net_buf_simple *
 
 		return bt_gatt_notify_cb(client->conn, &client->params.ntf);
 	}
-#endif /* CONFIG_BT_EATT */
+#endif /* CONFIG_BT_HAS_PRESET_CONTROL_POINT_NOTIFIABLE */
 
 	if (bt_gatt_is_subscribed(client->conn, PRESET_CONTROL_POINT_ATTR, BT_GATT_CCC_INDICATE)) {
 		client->params.ind.attr = PRESET_CONTROL_POINT_ATTR;


### PR DESCRIPTION
This fixes regression causing compilation errors seen when the
code is built without preset support (BT_HAS_PRESET_COUNT = 0).

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>