### PR TITLE
Bluetooth: OTS: Fix offset maximum range check

### DIFF
--- a/subsys/bluetooth/services/ots/ots_client.c
+++ b/subsys/bluetooth/services/ots/ots_client.c
@@ -1399,7 +1399,7 @@ int bt_ots_client_write_object_data(struct bt_ots_client *otc_inst,
 		return -EINVAL;
 	}
 
-	CHECKIF((offset > UINT32_MAX) || (offset < 0)) {
+	CHECKIF((sizeof(offset) > sizeof(uint32_t) && (offset > UINT32_MAX)) || (offset < 0)) {
 		LOG_ERR("offset %ld exceeds UINT32 and must be >= 0", offset);
 		return -EINVAL;
 	}
@@ -1460,7 +1460,7 @@ int bt_ots_client_get_object_checksum(struct bt_ots_client *otc_inst, struct bt_
 		return -EINVAL;
 	}
 
-	CHECKIF((offset > UINT32_MAX) || (offset < 0)) {
+	CHECKIF((sizeof(offset) > sizeof(uint32_t) && (offset > UINT32_MAX)) || (offset < 0)) {
 		LOG_DBG("offset exceeds %ld UINT32 and must be >= 0", offset);
 		return -EINVAL;
 	}


### PR DESCRIPTION
If offset is only 32-bit, then it can never be > UINT32_MAX, so added another conditional that only if the type (off_t) is larger than 32-bit, we perform the maximum value check.

off_t is not a standard type and thus the size of it is poorly defined, and are just defined as a signed integer type.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/58535
fixes https://github.com/zephyrproject-rtos/zephyr/issues/58560