### PR TITLE
cmake: boards: Fix issue with relative paths

### DIFF
--- a/cmake/modules/root.cmake
+++ b/cmake/modules/root.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (c) 2021, Nordic Semiconductor ASA
+# Copyright (c) 2021-2023, Nordic Semiconductor ASA
 
 # Convert Zephyr roots to absolute paths.
 #
@@ -21,27 +21,19 @@ include_guard(GLOBAL)
 
 include(extensions)
 
-# Convert paths to absolute, relative from APPLICATION_SOURCE_DIR
-zephyr_file(APPLICATION_ROOT MODULE_EXT_ROOT)
-
-# Convert paths to absolute, relative from APPLICATION_SOURCE_DIR
-zephyr_file(APPLICATION_ROOT BOARD_ROOT)
-
-# Convert paths to absolute, relative from APPLICATION_SOURCE_DIR
-zephyr_file(APPLICATION_ROOT SOC_ROOT)
-
-# Convert paths to absolute, relative from APPLICATION_SOURCE_DIR
-zephyr_file(APPLICATION_ROOT ARCH_ROOT)
-
-# Convert paths to absolute, relative from APPLICATION_SOURCE_DIR
-zephyr_file(APPLICATION_ROOT SCA_ROOT)
-
 # Merge in variables from other sources (e.g. sysbuild)
 zephyr_get(MODULE_EXT_ROOT MERGE SYSBUILD GLOBAL)
 zephyr_get(BOARD_ROOT MERGE SYSBUILD GLOBAL)
 zephyr_get(SOC_ROOT MERGE SYSBUILD GLOBAL)
 zephyr_get(ARCH_ROOT MERGE SYSBUILD GLOBAL)
 zephyr_get(SCA_ROOT MERGE SYSBUILD GLOBAL)
+
+# Convert paths to absolute, relative from APPLICATION_SOURCE_DIR
+zephyr_file(APPLICATION_ROOT MODULE_EXT_ROOT)
+zephyr_file(APPLICATION_ROOT BOARD_ROOT)
+zephyr_file(APPLICATION_ROOT SOC_ROOT)
+zephyr_file(APPLICATION_ROOT ARCH_ROOT)
+zephyr_file(APPLICATION_ROOT SCA_ROOT)
 
 if(unittest IN_LIST Zephyr_FIND_COMPONENTS)
   # Zephyr used in unittest mode, use dedicated unittest root.

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -640,6 +640,11 @@ Build system and infrastructure
      | "image-1"                       | slot1_partition           |
      +---------------------------------+---------------------------+
 
+* Fixed an issue whereby relative paths supplied for the ``BOARD_ROOT`` value
+  might wrongly emit a warning about a ``boards`` directory not being found.
+
+* Fixed an issue whereby relative paths did not work for sysbuild images.
+
 Drivers and Sensors
 *******************
 

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -182,6 +182,17 @@ function(ExternalZephyrProject_Add)
       )
     endif()
   endif()
+
+  # Update ROOT variables with relative paths to use absolute paths based on
+  # the source application directory.
+  foreach(type MODULE_EXT BOARD SOC ARCH SCA)
+    if(DEFINED CACHE{${ZBUILD_APPLICATION}_${type}_ROOT} AND NOT IS_ABSOLUTE $CACHE{${ZBUILD_APPLICATION}_${type}_ROOT})
+      set(rel_path $CACHE{${ZBUILD_APPLICATION}_${type}_ROOT})
+      cmake_path(ABSOLUTE_PATH rel_path BASE_DIRECTORY "${ZBUILD_SOURCE_DIR}" NORMALIZE OUTPUT_VARIABLE abs_path)
+      set(${ZBUILD_APPLICATION}_${type}_ROOT ${abs_path} CACHE PATH "Sysbuild adjusted absolute path" FORCE)
+    endif()
+  endforeach()
+
   # CMake variables which must be known by all Zephyr CMake build systems
   # Those are settings which controls the build and must be known to CMake at
   # invocation time, and thus cannot be passed though the sysbuild cache file.
@@ -314,6 +325,16 @@ function(ExternalZephyrProject_Cmake)
   get_target_property(${ZCMAKE_APPLICATION}_CACHE_FILE ${ZCMAKE_APPLICATION} CACHE_FILE)
   get_target_property(${ZCMAKE_APPLICATION}_BOARD      ${ZCMAKE_APPLICATION} BOARD)
   get_target_property(${ZCMAKE_APPLICATION}_MAIN_APP   ${ZCMAKE_APPLICATION} MAIN_APP)
+
+  # Update ROOT variables with relative paths to use absolute paths based on
+  # the source application directory.
+  foreach(type MODULE_EXT BOARD SOC ARCH SCA)
+    if(DEFINED CACHE{${type}_ROOT} AND NOT IS_ABSOLUTE $CACHE{${type}_ROOT})
+      set(rel_path $CACHE{${type}_ROOT})
+      cmake_path(ABSOLUTE_PATH rel_path BASE_DIRECTORY "${APP_DIR}" NORMALIZE OUTPUT_VARIABLE abs_path)
+      set(${type}_ROOT ${abs_path} CACHE PATH "Sysbuild adjusted absolute path" FORCE)
+    endif()
+  endforeach()
 
   get_cmake_property(sysbuild_cache CACHE_VARIABLES)
   foreach(var_name ${sysbuild_cache})


### PR DESCRIPTION
Fixes an issue with relative paths causing a cmake warning to be emitted.

Fixes #58812