### PR TITLE
modules: tf-m: Add missing FWU API file

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -209,6 +209,7 @@ if (CONFIG_BUILD_WITH_TFM)
 
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_attest_api.c
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_crypto_api.c
+    ${TFM_INTERFACE_SOURCE_DIR}/tfm_fwu_api.c
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_its_api.c
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_platform_api.c
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_ps_api.c


### PR DESCRIPTION
`tfm_fwu_api.c` was missing from the list of possible source files to be exported from TF-M, which is required when
`CONFIG_TFM_PARTITION_FIRMWARE_UPDATE` is defined.

Fixes #58822 