### PR TITLE
west.yaml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: a6aef32619455cb1697c42d66db489c1608f8410
+      revision: 74c4d1c52fd51d07904b27a7aa9b2303e896a4e3
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  74c4d1c52fd51d07904b27a7aa9b2303e896a4e3

Brings following Zephyr relevant fixes:
 - 74c4d1c zephyr: Restore default log level of info
 - 8a8a241 zephyr: single_loader: Fix typo