### PR TITLE
Bluetooth: Mesh: Fix Proxy Privacy parameter support

### DIFF
--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -153,15 +153,11 @@ static int private_random_update(void)
 	uint64_t uptime = k_uptime_get();
 	int err;
 
-	/* If private beacon will not be sent there is no point in generating new random */
-	if (bt_mesh_priv_beacon_get() != BT_MESH_FEATURE_ENABLED) {
-		return 0;
-	}
-
 	/* The Private beacon random value should change every N seconds to maintain privacy.
 	 * N = (10 * interval) seconds, or on every beacon creation, if the interval is 0.
 	 */
-	if (interval &&
+	if (bt_mesh_priv_beacon_get() == BT_MESH_FEATURE_ENABLED &&
+	    interval &&
 	    uptime - priv_random.timestamp < (10 * interval * MSEC_PER_SEC) &&
 	    priv_random.timestamp != 0) {
 		/* Not time yet */

--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -227,11 +227,10 @@ static int private_beacon_create(struct bt_mesh_subnet *sub,
 }
 #endif
 
-int bt_mesh_beacon_create(struct bt_mesh_subnet *sub,
-			  struct net_buf_simple *buf)
+int bt_mesh_beacon_create(struct bt_mesh_subnet *sub, struct net_buf_simple *buf, bool priv)
 {
 #if defined(CONFIG_BT_MESH_PRIV_BEACONS)
-	if (bt_mesh_priv_beacon_get() == BT_MESH_FEATURE_ENABLED) {
+	if (priv) {
 		return private_beacon_create(sub, buf);
 	}
 #endif

--- a/subsys/bluetooth/mesh/beacon.h
+++ b/subsys/bluetooth/mesh/beacon.h
@@ -11,8 +11,7 @@ void bt_mesh_beacon_ivu_initiator(bool enable);
 
 void bt_mesh_beacon_recv(struct net_buf_simple *buf);
 
-int bt_mesh_beacon_create(struct bt_mesh_subnet *sub,
-			  struct net_buf_simple *buf);
+int bt_mesh_beacon_create(struct bt_mesh_subnet *sub, struct net_buf_simple *buf, bool priv);
 
 void bt_mesh_beacon_init(void);
 void bt_mesh_beacon_update(struct bt_mesh_subnet *sub);

--- a/subsys/bluetooth/mesh/cfg.c
+++ b/subsys/bluetooth/mesh/cfg.c
@@ -33,6 +33,7 @@ struct cfg_val {
 #if defined(CONFIG_BT_MESH_PRIV_BEACONS)
 	uint8_t priv_beacon;
 	uint8_t priv_beacon_int;
+	uint8_t priv_gatt_proxy;
 #endif
 #if defined(CONFIG_BT_MESH_OD_PRIV_PROXY_SRV)
 	uint8_t on_demand_state;
@@ -442,6 +443,7 @@ static int cfg_set(const char *name, size_t len_rd,
 #if defined(CONFIG_BT_MESH_PRIV_BEACONS)
 	bt_mesh_priv_beacon_set(cfg.priv_beacon);
 	bt_mesh_priv_beacon_update_interval_set(cfg.priv_beacon_int);
+	bt_mesh_priv_gatt_proxy_set(cfg.priv_gatt_proxy);
 #endif
 #if defined(CONFIG_BT_MESH_OD_PRIV_PROXY_SRV)
 	bt_mesh_od_priv_proxy_set(cfg.on_demand_state);
@@ -481,6 +483,7 @@ static void store_pending_cfg(void)
 #if defined(CONFIG_BT_MESH_PRIV_BEACONS)
 	val.priv_beacon = bt_mesh_priv_beacon_get();
 	val.priv_beacon_int = bt_mesh_priv_beacon_update_interval_get();
+	val.priv_gatt_proxy = bt_mesh_priv_gatt_proxy_get();
 #endif
 #if defined(CONFIG_BT_MESH_OD_PRIV_PROXY_SRV)
 	val.on_demand_state = bt_mesh_od_priv_proxy_get();

--- a/subsys/bluetooth/mesh/cfg.c
+++ b/subsys/bluetooth/mesh/cfg.c
@@ -187,6 +187,13 @@ int bt_mesh_gatt_proxy_set(enum bt_mesh_feat_state gatt_proxy)
 		return err;
 	}
 
+	/* The binding from section 4.2.45.1 disables Private GATT Proxy state when non-private
+	 * state is enabled.
+	 */
+	if (gatt_proxy == BT_MESH_FEATURE_ENABLED) {
+		feature_set(BT_MESH_PRIV_GATT_PROXY, BT_MESH_FEATURE_DISABLED);
+	}
+
 	if ((gatt_proxy == BT_MESH_FEATURE_ENABLED) ||
 	    (gatt_proxy == BT_MESH_FEATURE_DISABLED &&
 	     !bt_mesh_subnet_find(node_id_is_running, NULL))) {
@@ -218,6 +225,13 @@ int bt_mesh_priv_gatt_proxy_set(enum bt_mesh_feat_state priv_gatt_proxy)
 
 	if (!IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY) || !IS_ENABLED(CONFIG_BT_MESH_PRIV_BEACONS)) {
 		return BT_MESH_FEATURE_NOT_SUPPORTED;
+	}
+
+	/* Reverse binding from section 4.2.45.1 doesn't allow to enable private state if
+	 * non-private state is enabled.
+	 */
+	if (bt_mesh_gatt_proxy_get() == BT_MESH_FEATURE_ENABLED) {
+		return BT_MESH_FEATURE_DISABLED;
 	}
 
 	err = feature_set(BT_MESH_PRIV_GATT_PROXY, priv_gatt_proxy);

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -67,6 +67,9 @@ static struct bt_mesh_proxy_client {
 		REJECT,
 	} filter_type;
 	struct k_work send_beacons;
+#if defined(CONFIG_BT_MESH_PRIV_BEACONS)
+	bool privacy;
+#endif
 } clients[CONFIG_BT_MAX_CONN] = {
 	[0 ... (CONFIG_BT_MAX_CONN - 1)] = {
 		.send_beacons = Z_WORK_INITIALIZER(proxy_send_beacons),
@@ -324,7 +327,12 @@ static int beacon_send(struct bt_mesh_proxy_client *client,
 	NET_BUF_SIMPLE_DEFINE(buf, 28);
 
 	net_buf_simple_reserve(&buf, 1);
-	err = bt_mesh_beacon_create(sub, &buf);
+
+#if defined(CONFIG_BT_MESH_PRIV_BEACONS)
+	err = bt_mesh_beacon_create(sub, &buf, client->privacy);
+#else
+	err = bt_mesh_beacon_create(sub, &buf, false);
+#endif
 	if (err) {
 		return err;
 	}
@@ -1043,6 +1051,21 @@ static void gatt_connected(struct bt_conn *conn, uint8_t err)
 	(void)memset(client->filter, 0, sizeof(client->filter));
 	client->cli = bt_mesh_proxy_role_setup(conn, proxy_send,
 					       proxy_msg_recv);
+
+#if defined(CONFIG_BT_MESH_PRIV_BEACONS)
+	/* Binding from section 7.2.2.2.6 of MshPRTv1.1. */
+	enum bt_mesh_subnets_node_id_state cur_node_id = bt_mesh_subnets_node_id_state_get();
+
+	if (bt_mesh_gatt_proxy_get() == BT_MESH_FEATURE_ENABLED ||
+	    cur_node_id == BT_MESH_SUBNETS_NODE_ID_STATE_ENABLED) {
+		client->privacy = false;
+	} else {
+		client->privacy = (bt_mesh_priv_gatt_proxy_get() == BT_MESH_FEATURE_ENABLED) ||
+				  (cur_node_id == BT_MESH_SUBNETS_NODE_ID_STATE_ENABLED_PRIVATE);
+	}
+
+	LOG_DBG("privacy: %d", client->privacy);
+#endif
 
 	/* If connection was formed after Proxy Solicitation we need to stop future
 	 * Private Network ID advertisements

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -652,6 +652,24 @@ uint8_t bt_mesh_subnet_priv_node_id_get(uint16_t net_idx,
 	return STATUS_SUCCESS;
 }
 
+enum bt_mesh_subnets_node_id_state bt_mesh_subnets_node_id_state_get(void)
+{
+	for (int i = 0; i < ARRAY_SIZE(subnets); i++) {
+		bool priv_node_id = false;
+
+#if CONFIG_BT_MESH_PRIV_BEACONS
+		priv_node_id = subnets[i].priv_beacon_ctx.node_id;
+#endif
+
+		if (subnets[i].node_id || priv_node_id) {
+			return priv_node_id ? BT_MESH_SUBNETS_NODE_ID_STATE_ENABLED_PRIVATE :
+					      BT_MESH_SUBNETS_NODE_ID_STATE_ENABLED;
+		}
+	}
+
+	return BT_MESH_SUBNETS_NODE_ID_STATE_NONE;
+}
+
 ssize_t bt_mesh_subnets_get(uint16_t net_idxs[], size_t max, off_t skip)
 {
 	size_t count = 0;

--- a/subsys/bluetooth/mesh/subnet.h
+++ b/subsys/bluetooth/mesh/subnet.h
@@ -224,6 +224,24 @@ bt_mesh_subnet_has_new_key(const struct bt_mesh_subnet *sub)
 	return sub->kr_phase != BT_MESH_KR_NORMAL;
 }
 
+/** Kind of currently enabled Node Identity state on one or more subnets. */
+enum bt_mesh_subnets_node_id_state {
+	/* None node identity states are enabled on any subnets. */
+	BT_MESH_SUBNETS_NODE_ID_STATE_NONE,
+	/* Node Identity state is enabled on one or more subnets. */
+	BT_MESH_SUBNETS_NODE_ID_STATE_ENABLED,
+	/* Private Node Identity state is enabled on one or more subnets. */
+	BT_MESH_SUBNETS_NODE_ID_STATE_ENABLED_PRIVATE,
+};
+
+/** @brief Returns what kind of node identity state is currently enabled on one or more subnets.
+ *
+ * Only one kind (either non-private or private) can be enabled at the same time on all subnets.
+ *
+ * @returns Kind of node identity state that is currently enabled.
+ */
+enum bt_mesh_subnets_node_id_state bt_mesh_subnets_node_id_state_get(void);
+
 /** @brief Store the Subnet information in persistent storage.
  *
  * @param net_idx Network index to store.


### PR DESCRIPTION
Upon connection (section 6.7), Proxy Server shall determine value of Proxy Privacy parameter (section 6.5). The value of Proxy Privacy parameter stays the same until Proxy Client disconnects. Proxy Privacy depends on GATT Proxy, Node Identity states and Private GATT Proxy, Private Node Identity states (section 7.2.2.2.6). When GATT Proxy state is enabled, Private GATT Proxy state should be disabled (section 4.2.45.1). When Node Identity state is enabled, Private Node Identity state should be disabled (section 4.2.46.1). Proxy Privacy parameter can be enabled regardless of Private Beacon state. To keep privacy of the network, Private Beacon that sent over GATT should be re-generated upon connection as well.

This PR fixes bindings between states, determination of Proxy Privacy parameter upon connection and Private Beacon regeneration. It also fixes storing of Private GATT Proxy state in persistent storage.