### PR TITLE
Bluetooth: BAP: Improve handling of ASCS notification error

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1126,7 +1126,8 @@ struct bt_bap_unicast_client_cb {
 	 * This will be called for each stream in the group that was being QoS
 	 * configured.
 	 *
-	 * @param stream   Stream the operation was performed on.
+	 * @param stream   Stream the operation was performed on. May be NULL if there is no stream
+	 *                 associated with the ASE ID sent by the server.
 	 * @param rsp_code Response code.
 	 * @param reason   Reason code.
 	 */
@@ -1138,7 +1139,8 @@ struct bt_bap_unicast_client_cb {
 	 *
 	 * Called when the enable operation is completed on the server.
 	 *
-	 * @param stream   Stream the operation was performed on.
+	 * @param stream   Stream the operation was performed on. May be NULL if there is no stream
+	 *                 associated with the ASE ID sent by the server.
 	 * @param rsp_code Response code.
 	 * @param reason   Reason code.
 	 */
@@ -1152,7 +1154,8 @@ struct bt_bap_unicast_client_cb {
 	 * only be called if the stream supplied to bt_bap_stream_start() is
 	 * for a @ref BT_AUDIO_DIR_SOURCE endpoint.
 	 *
-	 * @param stream   Stream the operation was performed on.
+	 * @param stream   Stream the operation was performed on. May be NULL if there is no stream
+	 *                 associated with the ASE ID sent by the server.
 	 * @param rsp_code Response code.
 	 * @param reason   Reason code.
 	 */
@@ -1166,7 +1169,8 @@ struct bt_bap_unicast_client_cb {
 	 * only be called if the stream supplied to bt_bap_stream_stop() is
 	 * for a @ref BT_AUDIO_DIR_SOURCE endpoint.
 	 *
-	 * @param stream   Stream the operation was performed on.
+	 * @param stream   Stream the operation was performed on. May be NULL if there is no stream
+	 *                 associated with the ASE ID sent by the server.
 	 * @param rsp_code Response code.
 	 * @param reason   Reason code.
 	 */
@@ -1178,7 +1182,8 @@ struct bt_bap_unicast_client_cb {
 	 *
 	 * Called when the disable operation is completed on the server.
 	 *
-	 * @param stream   Stream the operation was performed on.
+	 * @param stream   Stream the operation was performed on. May be NULL if there is no stream
+	 *                 associated with the ASE ID sent by the server.
 	 * @param rsp_code Response code.
 	 * @param reason   Reason code.
 	 */
@@ -1190,7 +1195,8 @@ struct bt_bap_unicast_client_cb {
 	 *
 	 * Called when the metadata operation is completed on the server.
 	 *
-	 * @param stream   Stream the operation was performed on.
+	 * @param stream   Stream the operation was performed on. May be NULL if there is no stream
+	 *                 associated with the ASE ID sent by the server.
 	 * @param rsp_code Response code.
 	 * @param reason   Reason code.
 	 */
@@ -1202,7 +1208,8 @@ struct bt_bap_unicast_client_cb {
 	 *
 	 * Called when the release operation is completed on the server.
 	 *
-	 * @param stream   Stream the operation was performed on.
+	 * @param stream   Stream the operation was performed on. May be NULL if there is no stream
+	 *                 associated with the ASE ID sent by the server.
 	 * @param rsp_code Response code.
 	 * @param reason   Reason code.
 	 */

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -885,7 +885,7 @@ static void ascs_cp_rsp_add(uint8_t id, uint8_t code, uint8_t reason)
 	 */
 	case BT_BAP_ASCS_RSP_CODE_NOT_SUPPORTED:
 	case BT_BAP_ASCS_RSP_CODE_INVALID_LENGTH:
-		rsp->num_ase = 0xff;
+		rsp->num_ase = BT_ASCS_UNSUPP_OR_LENGTH_ERR_NUM_ASE;
 		break;
 	default:
 		rsp->num_ase++;

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -9,6 +9,11 @@
 
 #define BT_ASCS_ASE_ID_NONE              0x00
 
+/* The number of ASEs in the notification when the opcode is unsupported or the length of the
+ * control point write request is incorrect
+ */
+#define BT_ASCS_UNSUPP_OR_LENGTH_ERR_NUM_ASE 0xFFU
+
 /* Transport QoS Packing */
 #define BT_ASCS_QOS_PACKING_SEQ          0x00
 #define BT_ASCS_QOS_PACKING_INT          0x01


### PR DESCRIPTION
If the num_ase == 0xff then it is a special case that needs to be handled like if num_ase == 0x01.

If there is an error with ase_id = 0x00 then the error cannot be translated to a specific stream, so the callbacks may now get NULL for the stream object.