### PR TITLE
BMM150 add power management

### DIFF
--- a/drivers/sensor/bmm150/bmm150.c
+++ b/drivers/sensor/bmm150/bmm150.c
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2023 FTP Technologies
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -80,40 +81,21 @@ failed:
 	return ret;
 }
 
-static int bmm150_set_power_mode(const struct device *dev,
-				 enum bmm150_power_modes mode,
-				 int state)
+/* Power control = 'bit' */
+static int bmm150_power_control(const struct device *dev, uint8_t bit)
 {
-	switch (mode) {
-	case BMM150_POWER_MODE_SUSPEND:
-		if (bmm150_reg_update_byte(dev,
-					   BMM150_REG_POWER,
-					   BMM150_MASK_POWER_CTL,
-					   !state) < 0) {
-			return -EIO;
-		}
-		k_busy_wait(USEC_PER_MSEC * 5U);
-
-		return 0;
-	case BMM150_POWER_MODE_SLEEP:
-		return bmm150_reg_update_byte(dev,
-					      BMM150_REG_OPMODE_ODR,
-					      BMM150_MASK_OPMODE,
-					      BMM150_MODE_SLEEP <<
-					      BMM150_SHIFT_OPMODE);
-		break;
-	case BMM150_POWER_MODE_NORMAL:
-		return bmm150_reg_update_byte(dev,
-					      BMM150_REG_OPMODE_ODR,
-					      BMM150_MASK_OPMODE,
-					      BMM150_MODE_NORMAL <<
-					      BMM150_SHIFT_OPMODE);
-		break;
-	}
-
-	return -ENOTSUP;
-
+	return bmm150_reg_update_byte(dev, BMM150_REG_POWER,
+				      BMM150_MASK_POWER_CTL, bit);
 }
+
+/* OpMode = 'mode' */
+static int bmm150_opmode(const struct device *dev, uint8_t mode)
+{
+	return bmm150_reg_update_byte(dev, BMM150_REG_OPMODE_ODR,
+				      BMM150_MASK_OPMODE,
+				      mode << BMM150_SHIFT_OPMODE);
+}
+
 
 static int bmm150_set_odr(const struct device *dev, uint8_t val)
 {
@@ -515,33 +497,63 @@ static const struct sensor_driver_api bmm150_api_funcs = {
 	.channel_get = bmm150_channel_get,
 };
 
+static int bmm150_full_por(const struct device *dev)
+{
+	int ret;
+
+	/* Ensure we are not in suspend mode so soft reset is not ignored */
+	ret = bmm150_power_control(dev, 1);
+	if (ret != 0) {
+		LOG_ERR("failed to ensure not in suspend mode: %d", ret);
+		return ret;
+	}
+
+	k_sleep(BMM150_START_UP_TIME);
+
+	/* Soft reset always brings the device into sleep mode */
+	ret = bmm150_reg_update_byte(dev, BMM150_REG_POWER,
+				     BMM150_MASK_SOFT_RESET,
+				     BMM150_SOFT_RESET);
+	if (ret != 0) {
+		LOG_ERR("failed soft reset: %d", ret);
+		return ret;
+	}
+
+	/*
+	 * To perform full POR (after soft reset), bring the device into suspend
+	 * mode then back into sleep mode, see datasheet section 5.6
+	 */
+	ret = bmm150_power_control(dev, 0);
+	if (ret != 0) {
+		LOG_ERR("failed to enter suspend mode: %d", ret);
+		return ret;
+	}
+
+	k_sleep(BMM150_POR_TIME);
+
+	/* Full POR - back into sleep mode */
+	ret = bmm150_power_control(dev, 1);
+	if (ret != 0) {
+		LOG_ERR("failed to go back into sleep mode: %d", ret);
+		return ret;
+	}
+
+	k_sleep(BMM150_START_UP_TIME);
+
+	return 0;
+}
+
 static int bmm150_init_chip(const struct device *dev)
 {
 	struct bmm150_data *data = dev->data;
-	uint8_t chip_id;
 	struct bmm150_preset preset;
+	uint8_t chip_id;
 
-	/* Soft reset chip */
-	if (bmm150_reg_update_byte(dev, BMM150_REG_POWER, BMM150_MASK_SOFT_RESET,
-				   BMM150_SOFT_RESET) < 0) {
-		LOG_ERR("failed reset chip");
+	if (bmm150_full_por(dev) != 0) {
 		goto err_poweroff;
 	}
 
-	/* Sleep for 1ms after software reset */
-	k_sleep(K_MSEC(1));
-
-	/* Suspend mode to sleep mode */
-	if (bmm150_set_power_mode(dev, BMM150_POWER_MODE_SUSPEND, 0)
-	    < 0) {
-		LOG_ERR("failed to bring up device from suspend mode");
-		return -EIO;
-	}
-
-	/* Sleep for 3ms from suspend to sleep mode */
-	k_sleep(K_MSEC(3));
-
-	/* Read chip ID */
+	/* Read chip ID (can only be read in sleep mode)*/
 	if (bmm150_reg_read(dev, BMM150_REG_CHIP_ID, &chip_id, 1) < 0) {
 		LOG_ERR("failed reading chip id");
 		goto err_poweroff;
@@ -574,9 +586,8 @@ static int bmm150_init_chip(const struct device *dev)
 	}
 
 	/* Set chip normal mode */
-	if (bmm150_set_power_mode(dev, BMM150_POWER_MODE_NORMAL, 1)
-	    < 0) {
-		LOG_ERR("failed to power on device");
+	if (bmm150_opmode(dev, BMM150_MODE_NORMAL) < 0) {
+		LOG_ERR("failed to enter normal mode");
 	}
 
 	/* Reads the trim registers of the sensor */
@@ -603,8 +614,8 @@ static int bmm150_init_chip(const struct device *dev)
 	return 0;
 
 err_poweroff:
-	bmm150_set_power_mode(dev, BMM150_POWER_MODE_NORMAL, 0);
-	bmm150_set_power_mode(dev, BMM150_POWER_MODE_SUSPEND, 1);
+	(void)bmm150_power_control(dev, 0); /* Suspend */
+
 	return -EIO;
 }
 

--- a/drivers/sensor/bmm150/bmm150.h
+++ b/drivers/sensor/bmm150/bmm150.h
@@ -60,6 +60,7 @@ extern const struct bmm150_bus_io bmm150_bus_io_i2c;
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/pm/device.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/drivers/gpio.h>

--- a/drivers/sensor/bmm150/bmm150.h
+++ b/drivers/sensor/bmm150/bmm150.h
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2023 FTP Technologies
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -116,7 +117,7 @@ extern const struct bmm150_bus_io bmm150_bus_io_i2c;
 #define BMM150_REG_INT_DRDY                0x4E
 #define BMM150_MASK_DRDY_EN                BIT(7)
 #define BMM150_SHIFT_DRDY_EN               7
-#define BMM150_DRDY_INT3              BIT(6)
+#define BMM150_DRDY_INT3                   BIT(6)
 #define BMM150_MASK_DRDY_Z_EN              BIT(5)
 #define BMM150_MASK_DRDY_Y_EN              BIT(4)
 #define BMM150_MASK_DRDY_X_EN              BIT(3)
@@ -164,12 +165,6 @@ struct bmm150_data {
 	int sample_x, sample_y, sample_z;
 };
 
-enum bmm150_power_modes {
-	BMM150_POWER_MODE_SUSPEND,
-	BMM150_POWER_MODE_SLEEP,
-	BMM150_POWER_MODE_NORMAL
-};
-
 enum bmm150_axis {
 	BMM150_AXIS_X,
 	BMM150_AXIS_Y,
@@ -195,6 +190,12 @@ enum bmm150_presets {
 #elif defined(CONFIG_BMM150_PRESET_HIGH_ACCURACY)
 	#define BMM150_DEFAULT_PRESET BMM150_HIGH_ACCURACY_PRESET
 #endif
+
+/* Power On Reset time - from OFF to Suspend (Max) */
+#define BMM150_POR_TIME K_MSEC(1)
+
+/* Start-Up Time - from suspend to sleep (Max) */
+#define BMM150_START_UP_TIME K_MSEC(3)
 
 int bmm150_reg_update_byte(const struct device *dev, uint8_t reg,
 			   uint8_t mask, uint8_t value);

--- a/drivers/sensor/bmm150/bmm150.h
+++ b/drivers/sensor/bmm150/bmm150.h
@@ -82,8 +82,8 @@ extern const struct bmm150_bus_io bmm150_bus_io_i2c;
 
 #define BMM150_REG_POWER           0x4B
 #define BMM150_MASK_POWER_CTL      BIT(0)
-#define BMM150_MASK_SOFT_RESET     (BIT(1) | BIT(7))
-#define BMM150_SOFT_RESET          0x81
+#define BMM150_MASK_SOFT_RESET     (BIT(7) | BIT(1))
+#define BMM150_SOFT_RESET          BMM150_MASK_SOFT_RESET
 
 #define BMM150_REG_OPMODE_ODR      0x4C
 #define BMM150_MASK_OPMODE         (BIT(2) | BIT(1))


### PR DESCRIPTION
Add PM to driver.

Update driver with low level power control and OpMode functions to better represent operations used in power mode transition diagram Figure 2 from the datasheet.

Extend the soft reset at initialisation to a full POR.

Add defines for maximum POR time and start up time.

Fix soft reset - Bit 7 and 1 is 0x82 not 0x81.