### PR TITLE
scripts: dts: Support DT_NODE_HAS_PROP(node_id, ranges)

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -3176,6 +3176,7 @@ _BindingLoader.add_constructor("!include", _binding_include)
 _DEFAULT_PROP_TYPES: Dict[str, str] = {
     "compatible": "string-array",
     "status": "string",
+    "ranges": "compound",  # NUMS or EMPTY
     "reg": "array",
     "reg-names": "string-array",
     "label": "string",

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -540,6 +540,14 @@
 				ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
 				         <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
 			};
+
+			test_ranges_empty: empty@2 {
+				reg = <0 2 1>;
+				#address-cells = <2>;
+				#size-cells = <1>;
+
+				ranges;
+			};
 		};
 
 		device-with-props-0 {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -86,6 +86,7 @@
 
 #define TEST_RANGES_PCIE  DT_NODELABEL(test_ranges_pcie)
 #define TEST_RANGES_OTHER DT_NODELABEL(test_ranges_other)
+#define TEST_RANGES_EMPTY DT_NODELABEL(test_ranges_empty)
 
 #define ZEPHYR_USER DT_PATH(zephyr_user)
 
@@ -2208,6 +2209,22 @@ ZTEST(devicetree_api, test_ranges_other)
 #undef CHILD_BUS_ADDR
 #undef PARENT_BUS_ADDR
 #undef LENGTH
+}
+
+ZTEST(devicetree_api, test_ranges_empty)
+{
+	zassert_equal(DT_NODE_HAS_PROP(TEST_RANGES_EMPTY, ranges), 1, "");
+
+	zassert_equal(DT_NUM_RANGES(TEST_RANGES_EMPTY), 0, "");
+
+	zassert_equal(DT_RANGES_HAS_IDX(TEST_RANGES_EMPTY, 0), 0, "");
+	zassert_equal(DT_RANGES_HAS_IDX(TEST_RANGES_EMPTY, 1), 0, "");
+
+#define FAIL(node_id, idx) ztest_test_fail();
+
+	DT_FOREACH_RANGE(TEST_RANGES_EMPTY, FAIL);
+
+#undef FAIL
 }
 
 ZTEST(devicetree_api, test_compat_get_any_status_okay)


### PR DESCRIPTION
This is a one-line fix for edtlib, which lets gen_defines.py indicate whether the `ranges` property exists within a given node.

Although address translation through ranges is typically automatic, users can choose to manually inspect ranges using DT_FOREACH_RANGE(), DT_NUM_RANGES(), and other DT_RANGES_* macros. These can be used to implement manual translation at runtime, which is currently done for PCIe controllers.

The only thing missing is being able to check if a node contains an empty `ranges;`, which signifies a 1:1 translation to the parent bus. Checking DT_NUM_RANGES() is insufficient, because it returns zero whether or not `ranges;` is present.

It should be possible to use DT_NODE_HAS_PROP(), but it was not working, because edtlib ignores properties which are undeclared in bindings and don't have a default type. Add a missing PropertySpec for `ranges` with "compound" type; it can't be "array" because it can be empty-valued.