### PR TITLE
drivers: uart_nrfx_uart: Request next buffer only when needed

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -581,7 +581,8 @@ static void rx_isr(const struct device *dev)
 		/* Byte received when receiving is disabled - data lost. */
 		nrf_uart_rxd_get(uart0_addr);
 	} else {
-		if (uart0_cb.rx_counter == 0) {
+		if (uart0_cb.rx_counter == 0 &&
+		    uart0_cb.rx_secondary_buffer_length == 0) {
 			event.type = UART_RX_BUF_REQUEST;
 			user_callback(dev, &event);
 		}


### PR DESCRIPTION
Recent refactoring of the uart_async_api test (see commit eb44414af99a44447afa52bb81ac0767f2ff791e) revealed an issue in the uart_nrfx_uart driver that it requested the next RX buffer even if one was already set up (such request was just ignored in the previous form of the test, so the problem did not come out so far).
This patch prevents such incorrect requests from appearing.

Fixes #58829.