### PR TITLE
tests: workq: Add timeout parameters

### DIFF
--- a/tests/kernel/workq/work_queue/Kconfig
+++ b/tests/kernel/workq/work_queue/Kconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config TEST_WORK_ITEM_WAIT_MS
+	int "Test item working time, msec."
+	default 100
+
+config TEST_SUBMIT_WAIT_MS
+	int "Test item submission interval, msec."
+	default 50

--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -21,8 +21,9 @@
 #include <zephyr/sys/util.h>
 
 #define NUM_TEST_ITEMS          6
-/* Each work item takes 100ms */
-#define WORK_ITEM_WAIT          100
+
+/* Each work item takes 100ms by default. */
+#define WORK_ITEM_WAIT (CONFIG_TEST_WORK_ITEM_WAIT_MS)
 
 /* In fact, each work item could take up to this value */
 #define WORK_ITEM_WAIT_ALIGNED	\
@@ -32,7 +33,8 @@
  * Wait 50ms between work submissions, to ensure co-op and prempt
  * preempt thread submit alternatively.
  */
-#define SUBMIT_WAIT	50
+#define SUBMIT_WAIT	(CONFIG_TEST_SUBMIT_WAIT_MS)
+
 #define STACK_SIZE      (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
 
 /* How long to wait for the full test suite to complete.  Allow for a


### PR DESCRIPTION
Add TEST_WORK_ITEM_WAIT_MS and TEST_SUBMIT_WAIT_MS config parameters
instead of hardcoded timeouts at kernel.workqueue test to allow its customization e.g. on slow simulated platforms.