### PR TITLE
tests: kernel: mslab: Add timeout parameter

### DIFF
--- a/tests/kernel/mem_slab/mslab/Kconfig
+++ b/tests/kernel/mem_slab/mslab/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config TEST_ALLOC_TIMEOUT_MS
+	int "k_mem_slab_alloc() test timeout, ms."
+	default 50
+	help
+	  Use as k_mem_slab_alloc() timeout for the tests.
+	  Adjust to platform performance if needed.

--- a/tests/kernel/mem_slab/mslab/src/main.c
+++ b/tests/kernel/mem_slab/mslab/src/main.c
@@ -241,13 +241,13 @@ ZTEST(memory_slab_1cpu, test_mslab)
 	TC_PRINT("(3) - Further allocation results in  timeout "
 		 "in <%s>\n", __func__);
 
-	ret_value = k_mem_slab_alloc(&map_lgblks, &b, K_MSEC(20));
+	ret_value = k_mem_slab_alloc(&map_lgblks, &b, K_MSEC(CONFIG_TEST_ALLOC_TIMEOUT_MS));
 	zassert_equal(-EAGAIN, ret_value,
 		      "Failed k_mem_slab_alloc, retValue %d\n", ret_value);
 
 	TC_PRINT("%s: start to wait for block\n", __func__);
 	k_sem_give(&SEM_REGRESSDONE);    /* Allow helper thread to run part 4 */
-	ret_value = k_mem_slab_alloc(&map_lgblks, &b, K_MSEC(50));
+	ret_value = k_mem_slab_alloc(&map_lgblks, &b, K_MSEC(CONFIG_TEST_ALLOC_TIMEOUT_MS));
 	zassert_equal(0, ret_value,
 		      "Failed k_mem_slab_alloc, ret_value %d\n", ret_value);
 

--- a/tests/kernel/mem_slab/mslab/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab/testcase.yaml
@@ -3,3 +3,5 @@ tests:
     tags:
       - kernel
       - memory_slabs
+    extra_configs:
+      - platform:intel_ish_5_8_0/intel_ish_5_8_0:CONFIG_TEST_ALLOC_TIMEOUT_MS=180


### PR DESCRIPTION
Add TEST_ALLOC_TIMEOUT_MS config parameter instead of hardcoded timeout at kernel.memory_slabs test to allow its customization e.g. on slow simulated platforms.