### PR TITLE
boards: nordic: thingy53: Add StemmaQT

### DIFF
--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common-pinctrl.dtsi
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common-pinctrl.dtsi
@@ -34,6 +34,21 @@
 		};
 	};
 
+	i2c0_default: i2c0_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SCL, 0, 4)>,
+				<NRF_PSEL(TWIM_SDA, 0, 5)>;
+		};
+	};
+
+	i2c0_sleep: i2c0_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SCL, 0, 4)>,
+				<NRF_PSEL(TWIM_SDA, 0, 5)>;
+			low-power-enable;
+		};
+	};
+
 	i2c1_default: i2c1_default {
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dtsi
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dtsi
@@ -167,6 +167,17 @@
 	status = "okay";
 };
 
+/* StemmaQT/Qwiic/Groove external connector */
+&i2c0 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-1 = <&i2c0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
 &i2c1 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";


### PR DESCRIPTION
Added a devicetree definition for the StemmaQT/Qwiic/Groove external connector for the Thingy53 to enable use of external devices.

Signed-off-by: Kelly Helmut Lord <kellyhlord@gmail.com>