### PR TITLE
kconfig: Avoid possible incosistence in CPUs count

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -890,7 +890,7 @@ config SMP_BOOT_DELAY
 config MP_NUM_CPUS
 	int "Number of CPUs/cores"
 	default MP_MAX_NUM_CPUS
-	range 1 5
+	range 1 MP_MAX_NUM_CPUS
 	help
 	  Number of multiprocessing-capable cores available to the
 	  multicpu API and SMP features.


### PR DESCRIPTION
MP_NUM_CPUS has to be <= MAX_NUM_CPUS. Changing the range to be in this interval and avoid inconsistences if we change MAX_NUM_CPUS.