### PR TITLE
tests: ignore benchmark on some qemu platforms

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86_64_nokpti.yaml
+++ b/boards/x86/qemu_x86/qemu_x86_64_nokpti.yaml
@@ -13,3 +13,5 @@ testing:
   only_tags:
     - kernel
     - userspace
+  ignore_tags:
+    - benchmark

--- a/boards/x86/qemu_x86/qemu_x86_lakemont.yaml
+++ b/boards/x86/qemu_x86/qemu_x86_lakemont.yaml
@@ -11,3 +11,5 @@ testing:
   default: true
   only_tags:
     - kernel
+  ignore_tags:
+    - benchmark

--- a/boards/x86/qemu_x86/qemu_x86_nokpti.yaml
+++ b/boards/x86/qemu_x86/qemu_x86_nokpti.yaml
@@ -11,3 +11,5 @@ testing:
   only_tags:
     - kernel
     - userspace
+  ignore_tags:
+    - benchmark

--- a/boards/x86/qemu_x86/qemu_x86_nopae.yaml
+++ b/boards/x86/qemu_x86/qemu_x86_nopae.yaml
@@ -11,3 +11,5 @@ testing:
   only_tags:
     - kernel
     - userspace
+  ignore_tags:
+    - benchmark

--- a/boards/x86/qemu_x86/qemu_x86_tiny.yaml
+++ b/boards/x86/qemu_x86/qemu_x86_tiny.yaml
@@ -11,3 +11,5 @@ testing:
   only_tags:
     - kernel
     - userspace
+  ignore_tags:
+    - benchmark

--- a/boards/x86/qemu_x86/qemu_x86_virt.yaml
+++ b/boards/x86/qemu_x86/qemu_x86_virt.yaml
@@ -11,3 +11,5 @@ testing:
   only_tags:
     - kernel
     - userspace
+  ignore_tags:
+    - benchmark

--- a/tests/benchmarks/sys_kernel/testcase.yaml
+++ b/tests/benchmarks/sys_kernel/testcase.yaml
@@ -2,6 +2,7 @@ tests:
   benchmark.kernel.core:
     tags:
       - kernel
+      - benchmark
     arch_exclude:
       - nios2
       - xtensa


### PR DESCRIPTION
Do not run benchmarks on some special qemu platforms. Those were
previously ignored, but due to tag changes, they started running again.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
