### PR TITLE
sample: sensor: mpu6050: Add emsdp support

### DIFF
--- a/samples/sensor/mpu6050/boards/emsdp.overlay
+++ b/samples/sensor/mpu6050/boards/emsdp.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Synopsys
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c0 {
+	mpu6050@68 {
+		compatible = "invensense,mpu6050";
+		reg = <0x68>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Add emsdp support in mpu6050 driver sample. Actually, the sensor in emsdp is mpu9250, but mpu6050 is part of mpu9250, and they share same driver except magnetic sensor part.