### PR TITLE
Bluetooth: CSIP: Shell: Fix discover_members

### DIFF
--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -240,7 +240,7 @@ static int cmd_csip_set_coordinator_discover(const struct shell *sh,
 	char addr[BT_ADDR_LE_STR_LEN];
 	static bool initialized;
 	struct bt_conn *conn;
-	int err;
+	int err = 0;
 
 	if (!initialized) {
 		k_work_init_delayable(&discover_members_timer,
@@ -307,9 +307,44 @@ static int cmd_csip_set_coordinator_discover_members(const struct shell *sh,
 		return -EINVAL;
 	}
 
-	if (members_found > 1) {
-		members_found = 1;
+	/* Reset and populate based on current connections */
+	memset(addr_found, 0, sizeof(addr_found));
+	members_found = 0;
+	for (size_t i = 0U; i < ARRAY_SIZE(set_members); i++) {
+		const struct bt_csip_set_coordinator_set_member *set_member = set_members[i];
+
+		if (set_member == NULL) {
+			continue;
+		}
+
+		for (size_t j = 0U; j < ARRAY_SIZE(set_members[i]->insts); j++) {
+			const struct bt_csip_set_coordinator_csis_inst *inst =
+				&set_members[i]->insts[j];
+
+			if (memcmp(inst->info.set_sirk, cur_inst->info.set_sirk,
+				   BT_CSIP_SET_SIRK_SIZE) == 0) {
+				bt_addr_le_copy(&addr_found[members_found++],
+						bt_conn_get_dst(conns[i]));
+				break;
+			}
+		}
 	}
+
+	if (cur_inst->info.set_size > 0) {
+		if (members_found == cur_inst->info.set_size) {
+			shell_print(sh, "All members already known");
+
+			return 0;
+		} else if (members_found > cur_inst->info.set_size) {
+			shell_error(sh, "Found %u members but set size is %u", members_found,
+				    cur_inst->info.set_size);
+
+			return -ENOEXEC;
+		}
+	}
+
+	shell_print(sh, "Already know %u/%u members, start scanning for remaining", members_found,
+		    cur_inst->info.set_size);
 
 	err = k_work_reschedule(&discover_members_timer,
 				BT_CSIP_SET_COORDINATOR_DISCOVER_TIMER_VALUE);


### PR DESCRIPTION
The cmd_csip_set_coordinator_discover_members did not properly handle the members_found and addr_found values.

It has been modified to run through all known values before scanning, and set the value appropriately.

This also fixes a minor bug where err = 0 was missing.