### PR TITLE
net: mqtt-sn: fix port in mqtt-sn debug message

### DIFF
--- a/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
@@ -61,7 +61,7 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 	out = get_ip_str((struct sockaddr *)&udp->gwaddr, ip, sizeof(ip));
 	if (out != NULL) {
 		LOG_DBG("Connecting to IP %s:%u", out,
-			((struct sockaddr_in *)&udp->gwaddr)->sin_port);
+			ntohs(((struct sockaddr_in *)&udp->gwaddr)->sin_port));
 	}
 #endif
 


### PR DESCRIPTION
The port we are connecting to is stored in network byte order, thus, we need to convert it to the CPU's byte order before logging