### PR TITLE
Release notes: POSIX arch/boards + bsim relates entries

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -260,15 +260,18 @@ Architectures
 *************
 
 * ARC
+
   * Removed absolute symbols :c:macro:`___callee_saved_t_SIZEOF` and
-  :c:macro:`_K_THREAD_NO_FLOAT_SIZEOF`
+    :c:macro:`_K_THREAD_NO_FLOAT_SIZEOF`
 
 * ARM
+
   * Removed absolute symbols :c:macro:`___basic_sf_t_SIZEOF`,
-  :c:macro:`_K_THREAD_NO_FLOAT_SIZEOF`, :c:macro:`___cpu_context_t_SIZEOF`
-  and :c:macro:`___thread_stack_info_t_SIZEOF`
+    :c:macro:`_K_THREAD_NO_FLOAT_SIZEOF`, :c:macro:`___cpu_context_t_SIZEOF`
+    and :c:macro:`___thread_stack_info_t_SIZEOF`
 
 * ARM64
+
   * Removed absolute symbol :c:macro:`___callee_saved_t_SIZEOF`
   * Enabled FPU and FPU_SHARING for v8r aarch64
   * Fixed the STACK_INIT logic during the reset
@@ -277,6 +280,7 @@ Architectures
   * Added ISBs after SCTLR Modifications
 
 * NIOS2
+
   * Removed absolute symbol :c:macro:`_K_THREAD_NO_FLOAT_SIZEOF`
 
 * POSIX:
@@ -296,6 +300,7 @@ Architectures
   * Enabled single-threading support.
 
 * SPARC
+
   * Removed absolute symbol :c:macro:`_K_THREAD_NO_FLOAT_SIZEOF`
 
 * X86

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -493,6 +493,9 @@ Build system and infrastructure
   if signing is performed manually or outside of zephyr. This warning informs
   the user that the generated image will not be bootable by MCUboot as-is.
 
+* Babblesim is now included in the west manifest. Users can fetch it by enabling
+  the ``babblesim`` group with west config.
+
 Drivers and Sensors
 *******************
 
@@ -865,6 +868,9 @@ Documentation
 
 Tests and Samples
 *****************
+
+* Two Babblesim based networking (802.15.4) tests have been added, which are run in Zephyr's CI
+  system. One of them including the OpenThread stack.
 
 * For native_posix and the nrf52_bsim: Many tests have been fixed and enabled.
 

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -577,9 +577,15 @@ Drivers and Sensors
     with ``nrf_qspi_nor_xip_enable`` which apart from forcing the clock divider
     prevents the driver from deactivating the QSPI peripheral so that the XIP
     operation is actually possible.
-  * flash_simulator: A memory region can now be used as the storage area for the
-    flash simulator. Using the memory region allows the flash simulator to keep
-    its contents over a device reboot.
+  * flash_simulator:
+
+    * A memory region can now be used as the storage area for the
+      flash simulator. Using the memory region allows the flash simulator to keep
+      its contents over a device reboot.
+    * When building in native_posix, command line options have been added to select
+      if the flash should be cleared at boot, the flash content kept in RAM,
+      or the flash content file be deleted on exit.
+
   * spi_flash_at45: Fixed erase procedure to properly handle chips that have
     their initial sector split into two parts (usually marked as 0a and 0b).
 

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -279,6 +279,11 @@ Architectures
 * NIOS2
   * Removed absolute symbol :c:macro:`_K_THREAD_NO_FLOAT_SIZEOF`
 
+* POSIX:
+
+  * Added :c:macro:`Z_SPIN_DELAY` to allow to conditionally compile a k_busy_wait() for this arch
+    in tests and samples.
+
 * RISC-V
 
   * Added :kconfig:option:`CONFIG_PMP_NO_TOR`, :kconfig:option:`CONFIG_PMP_NO_NA4`, and
@@ -359,6 +364,17 @@ Boards & SoC Support
 * Made these changes for ARM64 boards:
 
   * FVP revc_2xaemv8a / aemv8r: Added ethernet, PHY and MDIO nodes
+
+* Made these changes to POSIX boards:
+
+   * nrf52_bsim now includes support and models for:
+
+     * 802.15.4 in the RADIO.
+     * EGU.
+     * FLASH (NVMC & UICR).
+     * TEMP.
+     * UART connected to a host ptty.
+     * Many more minor CMSIS API and nRF APIs and drivers.
 
 * Made these changes for RISC-V boards:
 
@@ -518,6 +534,11 @@ Drivers and Sensors
 
   * Atmel SAM/SAM0: Introduce peripheral clock control.
   * Atmel SAM0: Improved ``samd20``/``samd21``/``samr21`` clocking mechanism.
+
+* Console:
+
+  * The native_posix and bsim console drivers have been merged into one generic
+    driver usable by all POSIX arch based boards.
 
 * Counter
 
@@ -838,6 +859,8 @@ Documentation
 
 Tests and Samples
 *****************
+
+* For native_posix and the nrf52_bsim: Many tests have been fixed and enabled.
 
 Issue Related Items
 *******************


### PR DESCRIPTION
    doc: release: 3.4: Add POSIX arch and POSIX boards changes
    
    Add points related to the POSIX arch and boards to the
    3.4 release notes.
   
-----

    doc: release: 3.4: Add BabbleSim related points
    
    Add relevant bsim related changes.
    
------

    doc: release: 3.4: Add more flash simulator changes
    
    Add some extra relevant changes to the flash simulator
    
-----

    doc: release: 3.4: Fix indent in ARCH's lists
    
    So they render properly
    

    
