### PR TITLE
ARC: SMP: fix livelock in thread abort due to exception

### DIFF
--- a/arch/arc/core/fault_s.S
+++ b/arch/arc/core/fault_s.S
@@ -118,6 +118,11 @@ _exc_return:
 
 	BREQR r0, 0, _exc_return_from_exc
 
+	/* Save old thread into switch handle which is required by z_sched_switch_spin which
+	 * will be called during old thread abort.
+	 */
+	STR r2, r2, ___thread_t_switch_handle_OFFSET
+
 	MOVR r2, r0
 
 #ifdef CONFIG_ARC_SECURE_FIRMWARE


### PR DESCRIPTION
We are missing setting of switch_handle for the thread which is aborting due to exception (i.e. in case of k_panic or __ASSERT triggered). This may cause livelock in SMP code after a08e23f68e03 commit ("kernel/sched: Fix SMP must-wait-for-switch conditions in abort/join"). Fix that.