### PR TITLE
twister: Use natural sort when generating hardware map

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -13,6 +13,7 @@ import yaml
 import scl
 import logging
 from pathlib import Path
+from natsort import natsorted
 
 from twisterlib.environment import ZEPHYR_BASE
 
@@ -321,7 +322,7 @@ class HardwareMap:
 
     def save(self, hwm_file):
         # use existing map
-        self.detected.sort(key=lambda x: x.serial or '')
+        self.detected = natsorted(self.detected, key=lambda x: x.serial or '')
         if os.path.exists(hwm_file):
             with open(hwm_file, 'r') as yaml_file:
                 hwm = yaml.load(yaml_file, Loader=SafeLoader)

--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -7,6 +7,7 @@ pyocd>=0.35.0
 
 # used by twister for board/hardware map
 tabulate
+natsort
 
 # used by mcuboot
 cbor>=1.0.0


### PR DESCRIPTION
Use the natural sort of list when generating a hardware map. The list is sorted with a serial port as a key. When more than 10 ports are active and some of devices use more than one port, the ports of one device may be listed in wrong sequence, which may cause further problems with selecting the right port for listening to the device.

To reproduce (on setup with multiple connected devices):
`./scripts/twister --generate-hardware-map map.yml`
Output before change:
```
INFO    - Detected devices:

| Platform   |           ID | Serial device   |
|------------|--------------|-----------------|
| unknown    | 000683443878 | /dev/ttyACM0    |
| unknown    | 001050264345 | /dev/ttyACM1    |
| unknown    | 000960063726 | /dev/ttyACM10   |
| unknown    | 001050058652 | /dev/ttyACM11   |
...
| unknown    | 000960019514 | /dev/ttyACM18   |
| unknown    | 000960019514 | /dev/ttyACM19   |
| unknown    | 001050264345 | /dev/ttyACM2    |
| unknown    | 000683061004 | /dev/ttyACM20   |
```
And after change:
```
INFO    - Detected devices:

| Platform   |           ID | Serial device   |
|------------|--------------|-----------------|
| unknown    | 000683443878 | /dev/ttyACM0    |
| unknown    | 001050264345 | /dev/ttyACM1    |
...
| unknown    | 000960063726 | /dev/ttyACM8    |
| unknown    | 000960063726 | /dev/ttyACM9    |
| unknown    | 000960063726 | /dev/ttyACM10   |
| unknown    | 001050058652 | /dev/ttyACM11   |
| unknown    | 001050058652 | /dev/ttyACM12   |
```

On one of our CI setup we found a problem, where `nrf91` DK receives ports `ACM8, ACM9, ACM10`, and `ACM10` is received as the first one.
The fix is easy to apply in our internal CI scripts, but here (in Twister) is the best place, in case any other team will find similar issue.
