### PR TITLE
ci: Fix setup of ccache in twister workflow

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -86,7 +86,7 @@ jobs:
         uses: zephyrproject-rtos/action-s3-cache@v1.2.0
         with:
           key: ${{ steps.ccache_cache_timestamp.outputs.repo }}-${{ github.ref_name }}-clang-${{ matrix.platform }}-ccache
-          path: /github/home/.ccache
+          path: /github/home/.cache/ccache
           aws-s3-bucket: ccache.zephyrproject.org
           aws-access-key-id: ${{ vars.AWS_CCACHE_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_CCACHE_SECRET_ACCESS_KEY }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: ccache stats initial
         run: |
-          test -d github/home/.ccache && rm -rf /github/home/.ccache && mv github/home/.ccache /github/home/.ccache
+          test -d github/home/.cache/ccache && rm -rf /github/home/.cache/ccache && mv github/home/.cache/ccache /github/home/.cache/ccache
           ccache -M 10G -s
 
       - name: Run Tests with Twister
@@ -119,6 +119,7 @@ jobs:
       - name: ccache stats post
         run: |
           ccache -s
+          ccache -p
 
       - name: Upload Unit Test Results
         if: always() && steps.twister.outputs.report_needed != 0

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -70,7 +70,7 @@ jobs:
         uses: zephyrproject-rtos/action-s3-cache@v1.2.0
         with:
           key: ${{ steps.ccache_cache_prop.outputs.repo }}-${{github.event_name}}-${{matrix.platform}}-codecov-ccache
-          path: /github/home/.ccache
+          path: /github/home/.cache/ccache
           aws-s3-bucket: ccache.zephyrproject.org
           aws-access-key-id: ${{ vars.AWS_CCACHE_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_CCACHE_SECRET_ACCESS_KEY }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: ccache stats initial
         run: |
-          test -d github/home/.ccache && mv github/home/.ccache /github/home/.ccache
+          test -d github/home/.cache/ccache && mv github/home/.cache/ccache /github/home/.cache/ccache
           ccache -M 10G -s
 
       - name: Run Tests with Twister (Push)
@@ -100,6 +100,7 @@ jobs:
       - name: ccache stats post
         run: |
           ccache -s
+          ccache -p
 
       - name: Upload Coverage Results
         if: always()

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -200,7 +200,7 @@ jobs:
         continue-on-error: true
         with:
           key: ${{ steps.ccache_cache_timestamp.outputs.repo }}-${{ github.ref_name }}-${{github.event_name}}-${{ matrix.subset }}-ccache
-          path: /github/home/.ccache
+          path: /github/home/.cache/ccache
           aws-s3-bucket: ccache.zephyrproject.org
           aws-access-key-id: ${{ vars.AWS_CCACHE_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_CCACHE_SECRET_ACCESS_KEY }}
@@ -208,7 +208,7 @@ jobs:
 
       - name: ccache stats initial
         run: |
-          test -d github/home/.ccache && rm -rf /github/home/.ccache && mv github/home/.ccache /github/home/.ccache
+          test -d github/home/.cache/ccache && rm -rf /github/home/.cache/ccache && mv github/home/.cache/ccache /github/home/.cache/ccache
           ccache -M 10G -s
 
       - if: github.event_name == 'push'
@@ -254,6 +254,7 @@ jobs:
 
       - name: ccache stats post
         run: |
+          ccache -p
           ccache -s
 
       - name: Upload Unit Test Results


### PR DESCRIPTION
Path for cache directory has changed, adapt workflow accordingly.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
