### PR TITLE
BQ274xx cleanup 

### DIFF
--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -33,11 +33,11 @@ static int bq274xx_command_reg_read(const struct device *dev, uint8_t reg_addr,
 {
 	const struct bq274xx_config *config = dev->config;
 	uint8_t i2c_data[2];
-	int status;
+	int ret;
 
-	status = i2c_burst_read_dt(&config->i2c, reg_addr,
+	ret = i2c_burst_read_dt(&config->i2c, reg_addr,
 				   i2c_data, 2);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Unable to read register");
 		return -EIO;
 	}
@@ -52,14 +52,14 @@ static int bq274xx_control_reg_write(const struct device *dev,
 {
 	const struct bq274xx_config *config = dev->config;
 	uint8_t i2c_data, reg_addr;
-	int status = 0;
+	int ret = 0;
 
 	reg_addr = BQ274XX_COMMAND_CONTROL_LOW;
 	i2c_data = (uint8_t)((subcommand)&0x00FF);
 
-	status = i2c_reg_write_byte_dt(&config->i2c, reg_addr,
+	ret = i2c_reg_write_byte_dt(&config->i2c, reg_addr,
 				       i2c_data);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to write into control low register");
 		return -EIO;
 	}
@@ -69,9 +69,9 @@ static int bq274xx_control_reg_write(const struct device *dev,
 	reg_addr = BQ274XX_COMMAND_CONTROL_HIGH;
 	i2c_data = (uint8_t)((subcommand >> 8) & 0x00FF);
 
-	status = i2c_reg_write_byte_dt(&config->i2c, reg_addr,
+	ret = i2c_reg_write_byte_dt(&config->i2c, reg_addr,
 				       i2c_data);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to write into control high register");
 		return -EIO;
 	}
@@ -84,14 +84,14 @@ static int bq274xx_command_reg_write(const struct device *dev, uint8_t command,
 {
 	const struct bq274xx_config *config = dev->config;
 	uint8_t i2c_data, reg_addr;
-	int status = 0;
+	int ret = 0;
 
 	reg_addr = command;
 	i2c_data = data;
 
-	status = i2c_reg_write_byte_dt(&config->i2c, reg_addr,
+	ret = i2c_reg_write_byte_dt(&config->i2c, reg_addr,
 				       i2c_data);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to write into control register");
 		return -EIO;
 	}
@@ -104,13 +104,13 @@ static int bq274xx_read_data_block(const struct device *dev, uint8_t offset,
 {
 	const struct bq274xx_config *config = dev->config;
 	uint8_t i2c_data;
-	int status = 0;
+	int ret = 0;
 
 	i2c_data = BQ274XX_EXTENDED_BLOCKDATA_START + offset;
 
-	status = i2c_burst_read_dt(&config->i2c, i2c_data,
+	ret = i2c_burst_read_dt(&config->i2c, i2c_data,
 				   data, bytes);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to read block");
 		return -EIO;
 	}
@@ -122,19 +122,19 @@ static int bq274xx_read_data_block(const struct device *dev, uint8_t offset,
 
 static int bq274xx_get_device_type(const struct device *dev, uint16_t *val)
 {
-	int status;
+	int ret;
 
-	status =
+	ret =
 		bq274xx_control_reg_write(dev, BQ274XX_CONTROL_DEVICE_TYPE);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Unable to write control register");
 		return -EIO;
 	}
 
-	status = bq274xx_command_reg_read(dev, BQ274XX_COMMAND_CONTROL_LOW,
+	ret = bq274xx_command_reg_read(dev, BQ274XX_COMMAND_CONTROL_LOW,
 					  val);
 
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Unable to read register");
 		return -EIO;
 	}
@@ -229,133 +229,133 @@ static int bq274xx_sample_fetch(const struct device *dev,
 				enum sensor_channel chan)
 {
 	struct bq274xx_data *bq274xx = dev->data;
-	int status = 0;
+	int ret = 0;
 
 	if (!bq274xx->configured) {
-		status = bq274xx_gauge_configure(dev);
+		ret = bq274xx_gauge_configure(dev);
 
-		if (status < 0) {
-			return status;
+		if (ret < 0) {
+			return ret;
 		}
 	}
 
 	switch (chan) {
 	case SENSOR_CHAN_GAUGE_VOLTAGE:
-		status = bq274xx_command_reg_read(
+		ret = bq274xx_command_reg_read(
 			dev, BQ274XX_COMMAND_VOLTAGE, &bq274xx->voltage);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Failed to read voltage");
 			return -EIO;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_CURRENT:
-		status = bq274xx_command_reg_read(dev,
+		ret = bq274xx_command_reg_read(dev,
 						  BQ274XX_COMMAND_AVG_CURRENT,
 						  &bq274xx->avg_current);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Failed to read average current ");
 			return -EIO;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_TEMP:
-		status = bq274xx_command_reg_read(
+		ret = bq274xx_command_reg_read(
 			dev, BQ274XX_COMMAND_INT_TEMP,
 			&bq274xx->internal_temperature);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Failed to read internal temperature");
 			return -EIO;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_STDBY_CURRENT:
-		status = bq274xx_command_reg_read(dev,
+		ret = bq274xx_command_reg_read(dev,
 						  BQ274XX_COMMAND_STDBY_CURRENT,
 						  &bq274xx->stdby_current);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Failed to read standby current");
 			return -EIO;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT:
-		status = bq274xx_command_reg_read(dev,
+		ret = bq274xx_command_reg_read(dev,
 						  BQ274XX_COMMAND_MAX_CURRENT,
 						  &bq274xx->max_load_current);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Failed to read maximum current");
 			return -EIO;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_CHARGE:
-		status = bq274xx_command_reg_read(dev, BQ274XX_COMMAND_SOC,
+		ret = bq274xx_command_reg_read(dev, BQ274XX_COMMAND_SOC,
 						  &bq274xx->state_of_charge);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Failed to read state of charge");
 			return -EIO;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY:
-		status = bq274xx_command_reg_read(
+		ret = bq274xx_command_reg_read(
 			dev, BQ274XX_COMMAND_FULL_CAPACITY,
 			&bq274xx->full_charge_capacity);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Failed to read full charge capacity");
 			return -EIO;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY:
-		status = bq274xx_command_reg_read(
+		ret = bq274xx_command_reg_read(
 			dev, BQ274XX_COMMAND_REM_CAPACITY,
 			&bq274xx->remaining_charge_capacity);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Failed to read remaining charge capacity");
 			return -EIO;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY:
-		status = bq274xx_command_reg_read(dev,
+		ret = bq274xx_command_reg_read(dev,
 						  BQ274XX_COMMAND_NOM_CAPACITY,
 						  &bq274xx->nom_avail_capacity);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Failed to read nominal available capacity");
 			return -EIO;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY:
-		status =
+		ret =
 			bq274xx_command_reg_read(dev,
 						 BQ274XX_COMMAND_AVAIL_CAPACITY,
 						 &bq274xx->full_avail_capacity);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Failed to read full available capacity");
 			return -EIO;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_POWER:
-		status = bq274xx_command_reg_read(dev,
+		ret = bq274xx_command_reg_read(dev,
 						  BQ274XX_COMMAND_AVG_POWER,
 						  &bq274xx->avg_power);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Failed to read battery average power");
 			return -EIO;
 		}
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_HEALTH:
-		status = bq274xx_command_reg_read(dev, BQ274XX_COMMAND_SOH,
+		ret = bq274xx_command_reg_read(dev, BQ274XX_COMMAND_SOH,
 						  &bq274xx->state_of_health);
 
 		bq274xx->state_of_health = (bq274xx->state_of_health) & 0x00FF;
 
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Failed to read state of health");
 			return -EIO;
 		}
@@ -376,7 +376,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 static int bq274xx_gauge_init(const struct device *dev)
 {
 	const struct bq274xx_config *const config = dev->config;
-	int status = 0;
+	int ret = 0;
 	uint16_t id;
 
 	if (!device_is_ready(config->i2c.bus)) {
@@ -391,8 +391,8 @@ static int bq274xx_gauge_init(const struct device *dev)
 	}
 #endif
 
-	status = bq274xx_get_device_type(dev, &id);
-	if (status < 0) {
+	ret = bq274xx_get_device_type(dev, &id);
+	if (ret < 0) {
 		LOG_ERR("Unable to get device ID");
 		return -EIO;
 	}
@@ -403,18 +403,18 @@ static int bq274xx_gauge_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_BQ274XX_TRIGGER
-	status = bq274xx_trigger_mode_init(dev);
-	if (status < 0) {
+	ret = bq274xx_trigger_mode_init(dev);
+	if (ret < 0) {
 		LOG_ERR("Unable set up trigger mode.");
-		return status;
+		return ret;
 	}
 #endif
 
 	if (!config->lazy_loading) {
-		status = bq274xx_gauge_configure(dev);
+		ret = bq274xx_gauge_configure(dev);
 	}
 
-	return status;
+	return ret;
 }
 
 static int bq274xx_gauge_configure(const struct device *dev)
@@ -422,7 +422,7 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	const struct bq274xx_config *const config = dev->config;
 	struct bq274xx_data *data = dev->data;
 
-	int status = 0;
+	int ret = 0;
 	uint8_t tmp_checksum = 0, checksum_old = 0, checksum_new = 0;
 	uint16_t flags = 0, designenergy_mwh = 0, taperrate = 0;
 	uint8_t designcap_msb, designcap_lsb, designenergy_msb, designenergy_lsb,
@@ -435,31 +435,31 @@ static int bq274xx_gauge_configure(const struct device *dev)
 		(uint16_t)config->design_capacity / (0.1 * config->taper_current);
 
 	/** Unseal the battery control register **/
-	status = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
-	if (status < 0) {
+	ret = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	if (ret < 0) {
 		LOG_ERR("Unable to unseal the battery");
 		return -EIO;
 	}
 
-	status = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
-	if (status < 0) {
+	ret = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	if (ret < 0) {
 		LOG_ERR("Unable to unseal the battery");
 		return -EIO;
 	}
 
 	/* Send CFG_UPDATE */
-	status = bq274xx_control_reg_write(dev,
+	ret = bq274xx_control_reg_write(dev,
 					   BQ274XX_CONTROL_SET_CFGUPDATE);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Unable to set CFGUpdate");
 		return -EIO;
 	}
 
 	/** Step to place the Gauge into CONFIG UPDATE Mode **/
 	do {
-		status = bq274xx_command_reg_read(
+		ret = bq274xx_command_reg_read(
 			dev, BQ274XX_COMMAND_FLAGS, &flags);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Unable to read flags");
 			return -EIO;
 		}
@@ -470,25 +470,25 @@ static int bq274xx_gauge_configure(const struct device *dev)
 
 	} while (!(flags & 0x0010));
 
-	status = bq274xx_command_reg_write(dev,
+	ret = bq274xx_command_reg_write(dev,
 					   BQ274XX_EXTENDED_DATA_CONTROL, 0x00);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to enable block data memory");
 		return -EIO;
 	}
 
 	/* Access State subclass */
-	status = bq274xx_command_reg_write(dev, BQ274XX_EXTENDED_DATA_CLASS,
+	ret = bq274xx_command_reg_write(dev, BQ274XX_EXTENDED_DATA_CLASS,
 					   0x52);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to update state subclass");
 		return -EIO;
 	}
 
 	/* Write the block offset */
-	status = bq274xx_command_reg_write(dev, BQ274XX_EXTENDED_DATA_BLOCK,
+	ret = bq274xx_command_reg_write(dev, BQ274XX_EXTENDED_DATA_BLOCK,
 					   0x00);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to update block offset");
 		return -EIO;
 	}
@@ -497,8 +497,8 @@ static int bq274xx_gauge_configure(const struct device *dev)
 		block[i] = 0;
 	}
 
-	status = bq274xx_read_data_block(dev, 0x00, block, 32);
-	if (status < 0) {
+	ret = bq274xx_read_data_block(dev, 0x00, block, 32);
+	if (ret < 0) {
 		LOG_ERR("Unable to read block data");
 		return -EIO;
 	}
@@ -510,9 +510,9 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	tmp_checksum = 255 - tmp_checksum;
 
 	/* Read the block checksum */
-	status = i2c_reg_read_byte_dt(&config->i2c,
+	ret = i2c_reg_read_byte_dt(&config->i2c,
 				      BQ274XX_EXTENDED_CHECKSUM, &checksum_old);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Unable to read block checksum");
 		return -EIO;
 	}
@@ -526,65 +526,65 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	taperrate_msb = taperrate >> 8;
 	taperrate_lsb = taperrate & 0x00FF;
 
-	status = i2c_reg_write_byte_dt(&config->i2c,
+	ret = i2c_reg_write_byte_dt(&config->i2c,
 				       BQ274XX_EXTENDED_BLOCKDATA_DESIGN_CAP_HIGH,
 				       designcap_msb);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to write designCAP MSB");
 		return -EIO;
 	}
 
-	status = i2c_reg_write_byte_dt(&config->i2c,
+	ret = i2c_reg_write_byte_dt(&config->i2c,
 				       BQ274XX_EXTENDED_BLOCKDATA_DESIGN_CAP_LOW,
 				       designcap_lsb);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to write designCAP LSB");
 		return -EIO;
 	}
 
-	status = i2c_reg_write_byte_dt(&config->i2c,
+	ret = i2c_reg_write_byte_dt(&config->i2c,
 				       BQ274XX_EXTENDED_BLOCKDATA_DESIGN_ENR_HIGH,
 				       designenergy_msb);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to write designEnergy MSB");
 		return -EIO;
 	}
 
-	status = i2c_reg_write_byte_dt(&config->i2c,
+	ret = i2c_reg_write_byte_dt(&config->i2c,
 				       BQ274XX_EXTENDED_BLOCKDATA_DESIGN_ENR_LOW,
 				       designenergy_lsb);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to write designEnergy LSB");
 		return -EIO;
 	}
 
-	status = i2c_reg_write_byte_dt(&config->i2c,
+	ret = i2c_reg_write_byte_dt(&config->i2c,
 				       BQ274XX_EXTENDED_BLOCKDATA_TERMINATE_VOLT_HIGH,
 				       terminatevolt_msb);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to write terminateVolt MSB");
 		return -EIO;
 	}
 
-	status = i2c_reg_write_byte_dt(&config->i2c, BQ274XX_EXTENDED_BLOCKDATA_TERMINATE_VOLT_LOW,
+	ret = i2c_reg_write_byte_dt(&config->i2c, BQ274XX_EXTENDED_BLOCKDATA_TERMINATE_VOLT_LOW,
 				       terminatevolt_lsb);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to write terminateVolt LSB");
 		return -EIO;
 	}
 
-	status = i2c_reg_write_byte_dt(&config->i2c,
+	ret = i2c_reg_write_byte_dt(&config->i2c,
 				       BQ274XX_EXTENDED_BLOCKDATA_TAPERRATE_HIGH,
 				       taperrate_msb);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to write taperRate MSB");
 		return -EIO;
 	}
 
-	status = i2c_reg_write_byte_dt(&config->i2c,
+	ret = i2c_reg_write_byte_dt(&config->i2c,
 				       BQ274XX_EXTENDED_BLOCKDATA_TAPERRATE_LOW,
 				       taperrate_lsb);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to write taperRate LSB");
 		return -EIO;
 	}
@@ -593,8 +593,8 @@ static int bq274xx_gauge_configure(const struct device *dev)
 		block[i] = 0;
 	}
 
-	status = bq274xx_read_data_block(dev, 0x00, block, 32);
-	if (status < 0) {
+	ret = bq274xx_read_data_block(dev, 0x00, block, 32);
+	if (ret < 0) {
 		LOG_ERR("Unable to read block data");
 		return -EIO;
 	}
@@ -605,29 +605,29 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	}
 	checksum_new = 255 - checksum_new;
 
-	status = bq274xx_command_reg_write(dev, BQ274XX_EXTENDED_CHECKSUM,
+	ret = bq274xx_command_reg_write(dev, BQ274XX_EXTENDED_CHECKSUM,
 					   checksum_new);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to update new checksum");
 		return -EIO;
 	}
 
 	tmp_checksum = 0;
-	status = i2c_reg_read_byte_dt(&config->i2c,
+	ret = i2c_reg_read_byte_dt(&config->i2c,
 				      BQ274XX_EXTENDED_CHECKSUM, &tmp_checksum);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Failed to read checksum");
 		return -EIO;
 	}
 
-	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_BAT_INSERT);
-	if (status < 0) {
+	ret = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_BAT_INSERT);
+	if (ret < 0) {
 		LOG_ERR("Unable to configure BAT Detect");
 		return -EIO;
 	}
 
-	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SOFT_RESET);
-	if (status < 0) {
+	ret = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SOFT_RESET);
+	if (ret < 0) {
 		LOG_ERR("Failed to soft reset the gauge");
 		return -EIO;
 	}
@@ -635,9 +635,9 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	flags = 0;
 	/* Poll Flags   */
 	do {
-		status = bq274xx_command_reg_read(
+		ret = bq274xx_command_reg_read(
 			dev, BQ274XX_COMMAND_FLAGS, &flags);
-		if (status < 0) {
+		if (ret < 0) {
 			LOG_ERR("Unable to read flags");
 			return -EIO;
 		}
@@ -648,8 +648,8 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	} while (flags & 0x0010);
 
 	/* Seal the gauge */
-	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SEALED);
-	if (status < 0) {
+	ret = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SEALED);
+	if (ret < 0) {
 		LOG_ERR("Failed to seal the gauge");
 		return -EIO;
 	}
@@ -662,37 +662,37 @@ static int bq274xx_gauge_configure(const struct device *dev)
 #ifdef CONFIG_BQ274XX_PM
 static int bq274xx_enter_shutdown_mode(const struct device *dev)
 {
-	int status;
+	int ret;
 
-	status = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
-	if (status < 0) {
+	ret = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	if (ret < 0) {
 		LOG_ERR("Unable to unseal the battery");
-		return status;
+		return ret;
 	}
 
-	status = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
-	if (status < 0) {
+	ret = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	if (ret < 0) {
 		LOG_ERR("Unable to unseal the battery");
-		return status;
+		return ret;
 	}
 
-	status = bq274xx_control_reg_write(dev,
+	ret = bq274xx_control_reg_write(dev,
 					   BQ274XX_CONTROL_SHUTDOWN_ENABLE);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Unable to enable shutdown mode");
-		return status;
+		return ret;
 	}
 
-	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SHUTDOWN);
-	if (status < 0) {
+	ret = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SHUTDOWN);
+	if (ret < 0) {
 		LOG_ERR("Unable to enter shutdown mode");
-		return status;
+		return ret;
 	}
 
-	status = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SEALED);
-	if (status < 0) {
+	ret = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SEALED);
+	if (ret < 0) {
 		LOG_ERR("Failed to seal the gauge");
-		return status;
+		return ret;
 	}
 
 	return 0;
@@ -701,36 +701,36 @@ static int bq274xx_enter_shutdown_mode(const struct device *dev)
 static int bq274xx_exit_shutdown_mode(const struct device *dev)
 {
 	const struct bq274xx_config *const config = dev->config;
-	int status = 0;
+	int ret = 0;
 
-	status = gpio_pin_configure_dt(&config->int_gpios,
+	ret = gpio_pin_configure_dt(&config->int_gpios,
 			   GPIO_OUTPUT | GPIO_OPEN_DRAIN);
-	if (status < 0) {
+	if (ret < 0) {
 		LOG_ERR("Unable to configure interrupt pin to output and open drain");
-		return status;
+		return ret;
 	}
 
-	status = gpio_pin_set_dt(&config->int_gpios, 0);
-	if (status < 0) {
+	ret = gpio_pin_set_dt(&config->int_gpios, 0);
+	if (ret < 0) {
 		LOG_ERR("Unable to set interrupt pin to low");
-		return status;
+		return ret;
 	}
 
 	k_msleep(PIN_DELAY_TIME);
 
-	status = gpio_pin_configure_dt(&config->int_gpios, GPIO_INPUT);
-	if (status < 0) {
+	ret = gpio_pin_configure_dt(&config->int_gpios, GPIO_INPUT);
+	if (ret < 0) {
 		LOG_ERR("Unable to configure interrupt pin to input");
-		return status;
+		return ret;
 	}
 
 	if (!config->lazy_loading) {
 		k_msleep(INIT_TIME);
 
-		status = bq274xx_gauge_configure(dev);
-		if (status < 0) {
+		ret = bq274xx_gauge_configure(dev);
+		if (ret < 0) {
 			LOG_ERR("Unable to configure bq274xx gauge");
-			return status;
+			return ret;
 		}
 	}
 

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -20,23 +20,24 @@
 
 LOG_MODULE_REGISTER(bq274xx, CONFIG_SENSOR_LOG_LEVEL);
 
-#define BQ274XX_SUBCLASS_DELAY 5 /* subclass 64 & 82 needs 5ms delay */
+/* subclass 64 & 82 needs 5ms delay */
+#define BQ274XX_SUBCLASS_DELAY 5
+
 /* Time to set pin in order to exit shutdown mode */
-#define PIN_DELAY_TIME 1U
+#define PIN_DELAY_TIME         1U
+
 /* Time it takes device to initialize before doing any configuration */
-#define INIT_TIME 100U
+#define INIT_TIME              100U
 
 static int gauge_configure(const struct device *dev);
 
-static int cmd_reg_read(const struct device *dev, uint8_t reg_addr,
-				    int16_t *val)
+static int cmd_reg_read(const struct device *dev, uint8_t reg_addr, int16_t *val)
 {
 	const struct bq274xx_config *config = dev->config;
 	uint8_t i2c_data[2];
 	int ret;
 
-	ret = i2c_burst_read_dt(&config->i2c, reg_addr,
-				   i2c_data, 2);
+	ret = i2c_burst_read_dt(&config->i2c, reg_addr, i2c_data, 2);
 	if (ret < 0) {
 		LOG_ERR("Unable to read register");
 		return -EIO;
@@ -47,8 +48,7 @@ static int cmd_reg_read(const struct device *dev, uint8_t reg_addr,
 	return 0;
 }
 
-static int ctrl_reg_write(const struct device *dev,
-				     uint16_t subcommand)
+static int ctrl_reg_write(const struct device *dev, uint16_t subcommand)
 {
 	const struct bq274xx_config *config = dev->config;
 	uint8_t i2c_data, reg_addr;
@@ -57,8 +57,7 @@ static int ctrl_reg_write(const struct device *dev,
 	reg_addr = BQ274XX_CMD_CONTROL_LOW;
 	i2c_data = (uint8_t)((subcommand)&0x00FF);
 
-	ret = i2c_reg_write_byte_dt(&config->i2c, reg_addr,
-				       i2c_data);
+	ret = i2c_reg_write_byte_dt(&config->i2c, reg_addr, i2c_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to write into control low register");
 		return -EIO;
@@ -69,8 +68,7 @@ static int ctrl_reg_write(const struct device *dev,
 	reg_addr = BQ274XX_CMD_CONTROL_HIGH;
 	i2c_data = (uint8_t)((subcommand >> 8) & 0x00FF);
 
-	ret = i2c_reg_write_byte_dt(&config->i2c, reg_addr,
-				       i2c_data);
+	ret = i2c_reg_write_byte_dt(&config->i2c, reg_addr, i2c_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to write into control high register");
 		return -EIO;
@@ -79,8 +77,7 @@ static int ctrl_reg_write(const struct device *dev,
 	return 0;
 }
 
-static int cmd_reg_write(const struct device *dev, uint8_t command,
-				     uint8_t data)
+static int cmd_reg_write(const struct device *dev, uint8_t command, uint8_t data)
 {
 	const struct bq274xx_config *config = dev->config;
 	uint8_t i2c_data, reg_addr;
@@ -89,8 +86,7 @@ static int cmd_reg_write(const struct device *dev, uint8_t command,
 	reg_addr = command;
 	i2c_data = data;
 
-	ret = i2c_reg_write_byte_dt(&config->i2c, reg_addr,
-				       i2c_data);
+	ret = i2c_reg_write_byte_dt(&config->i2c, reg_addr, i2c_data);
 	if (ret < 0) {
 		LOG_ERR("Failed to write into control register");
 		return -EIO;
@@ -100,7 +96,7 @@ static int cmd_reg_write(const struct device *dev, uint8_t command,
 }
 
 static int read_data_block(const struct device *dev, uint8_t offset,
-				   uint8_t *data, uint8_t bytes)
+			   uint8_t *data, uint8_t bytes)
 {
 	const struct bq274xx_config *config = dev->config;
 	uint8_t i2c_data;
@@ -108,8 +104,7 @@ static int read_data_block(const struct device *dev, uint8_t offset,
 
 	i2c_data = BQ274XX_EXT_BLKDAT_START + offset;
 
-	ret = i2c_burst_read_dt(&config->i2c, i2c_data,
-				   data, bytes);
+	ret = i2c_burst_read_dt(&config->i2c, i2c_data, data, bytes);
 	if (ret < 0) {
 		LOG_ERR("Failed to read block");
 		return -EIO;
@@ -124,15 +119,13 @@ static int get_device_type(const struct device *dev, uint16_t *val)
 {
 	int ret;
 
-	ret =
-		ctrl_reg_write(dev, BQ274XX_CTRL_DEVICE_TYPE);
+	ret = ctrl_reg_write(dev, BQ274XX_CTRL_DEVICE_TYPE);
 	if (ret < 0) {
 		LOG_ERR("Unable to write control register");
 		return -EIO;
 	}
 
-	ret = cmd_reg_read(dev, BQ274XX_CMD_CONTROL_LOW,
-					  val);
+	ret = cmd_reg_read(dev, BQ274XX_CMD_CONTROL_LOW, val);
 
 	if (ret < 0) {
 		LOG_ERR("Unable to read register");
@@ -147,9 +140,8 @@ static int get_device_type(const struct device *dev, uint16_t *val)
  *
  * @return -ENOTSUP for unsupported channels
  */
-static int channel_get(const struct device *dev,
-			       enum sensor_channel chan,
-			       struct sensor_value *val)
+static int channel_get(const struct device *dev, enum sensor_channel chan,
+		       struct sensor_value *val)
 {
 	struct bq274xx_data *data = dev->data;
 	float int_temp;
@@ -199,8 +191,7 @@ static int channel_get(const struct device *dev,
 
 	case SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY:
 		val->val1 = (data->remaining_charge_capacity / 1000);
-		val->val2 =
-			((data->remaining_charge_capacity % 1000) * 1000U);
+		val->val2 = ((data->remaining_charge_capacity % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY:
@@ -225,8 +216,7 @@ static int channel_get(const struct device *dev,
 	return 0;
 }
 
-static int sample_fetch(const struct device *dev,
-				enum sensor_channel chan)
+static int sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct bq274xx_data *data = dev->data;
 	int ret = 0;
@@ -241,8 +231,7 @@ static int sample_fetch(const struct device *dev,
 
 	switch (chan) {
 	case SENSOR_CHAN_GAUGE_VOLTAGE:
-		ret = cmd_reg_read(
-			dev, BQ274XX_CMD_VOLTAGE, &data->voltage);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_VOLTAGE, &data->voltage);
 		if (ret < 0) {
 			LOG_ERR("Failed to read voltage");
 			return -EIO;
@@ -250,9 +239,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_CURRENT:
-		ret = cmd_reg_read(dev,
-						  BQ274XX_CMD_AVG_CURRENT,
-						  &data->avg_current);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_AVG_CURRENT,
+				   &data->avg_current);
 		if (ret < 0) {
 			LOG_ERR("Failed to read average current ");
 			return -EIO;
@@ -260,9 +248,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_TEMP:
-		ret = cmd_reg_read(
-			dev, BQ274XX_CMD_INT_TEMP,
-			&data->internal_temperature);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_INT_TEMP,
+				   &data->internal_temperature);
 		if (ret < 0) {
 			LOG_ERR("Failed to read internal temperature");
 			return -EIO;
@@ -270,9 +257,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_STDBY_CURRENT:
-		ret = cmd_reg_read(dev,
-						  BQ274XX_CMD_STDBY_CURRENT,
-						  &data->stdby_current);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_STDBY_CURRENT,
+				   &data->stdby_current);
 		if (ret < 0) {
 			LOG_ERR("Failed to read standby current");
 			return -EIO;
@@ -280,9 +266,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT:
-		ret = cmd_reg_read(dev,
-						  BQ274XX_CMD_MAX_CURRENT,
-						  &data->max_load_current);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_MAX_CURRENT,
+				   &data->max_load_current);
 		if (ret < 0) {
 			LOG_ERR("Failed to read maximum current");
 			return -EIO;
@@ -290,8 +275,7 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_CHARGE:
-		ret = cmd_reg_read(dev, BQ274XX_CMD_SOC,
-						  &data->state_of_charge);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_SOC, &data->state_of_charge);
 		if (ret < 0) {
 			LOG_ERR("Failed to read state of charge");
 			return -EIO;
@@ -299,9 +283,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY:
-		ret = cmd_reg_read(
-			dev, BQ274XX_CMD_FULL_CAPACITY,
-			&data->full_charge_capacity);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_FULL_CAPACITY,
+				   &data->full_charge_capacity);
 		if (ret < 0) {
 			LOG_ERR("Failed to read full charge capacity");
 			return -EIO;
@@ -309,9 +292,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY:
-		ret = cmd_reg_read(
-			dev, BQ274XX_CMD_REM_CAPACITY,
-			&data->remaining_charge_capacity);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_REM_CAPACITY,
+				   &data->remaining_charge_capacity);
 		if (ret < 0) {
 			LOG_ERR("Failed to read remaining charge capacity");
 			return -EIO;
@@ -319,9 +301,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY:
-		ret = cmd_reg_read(dev,
-						  BQ274XX_CMD_NOM_CAPACITY,
-						  &data->nom_avail_capacity);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_NOM_CAPACITY,
+				   &data->nom_avail_capacity);
 		if (ret < 0) {
 			LOG_ERR("Failed to read nominal available capacity");
 			return -EIO;
@@ -329,10 +310,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY:
-		ret =
-			cmd_reg_read(dev,
-						 BQ274XX_CMD_AVAIL_CAPACITY,
-						 &data->full_avail_capacity);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_AVAIL_CAPACITY,
+				   &data->full_avail_capacity);
 		if (ret < 0) {
 			LOG_ERR("Failed to read full available capacity");
 			return -EIO;
@@ -340,9 +319,7 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_POWER:
-		ret = cmd_reg_read(dev,
-						  BQ274XX_CMD_AVG_POWER,
-						  &data->avg_power);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_AVG_POWER, &data->avg_power);
 		if (ret < 0) {
 			LOG_ERR("Failed to read battery average power");
 			return -EIO;
@@ -350,8 +327,7 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_HEALTH:
-		ret = cmd_reg_read(dev, BQ274XX_CMD_SOH,
-						  &data->state_of_health);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_SOH, &data->state_of_health);
 
 		data->state_of_health = (data->state_of_health) & 0x00FF;
 
@@ -426,13 +402,11 @@ static int gauge_configure(const struct device *dev)
 	uint8_t tmp_checksum = 0, checksum_old = 0, checksum_new = 0;
 	uint16_t flags = 0, designenergy_mwh = 0, taperrate = 0;
 	uint8_t designcap_msb, designcap_lsb, designenergy_msb, designenergy_lsb,
-		terminatevolt_msb, terminatevolt_lsb, taperrate_msb,
-		taperrate_lsb;
+		terminatevolt_msb, terminatevolt_lsb, taperrate_msb, taperrate_lsb;
 	uint8_t block[32];
 
 	designenergy_mwh = (uint16_t)3.7 * config->design_capacity;
-	taperrate =
-		(uint16_t)config->design_capacity / (0.1 * config->taper_current);
+	taperrate = (uint16_t)config->design_capacity / (0.1 * config->taper_current);
 
 	/** Unseal the battery control register **/
 	ret = ctrl_reg_write(dev, BQ274XX_UNSEAL_KEY);
@@ -448,8 +422,7 @@ static int gauge_configure(const struct device *dev)
 	}
 
 	/* Send CFG_UPDATE */
-	ret = ctrl_reg_write(dev,
-					   BQ274XX_CTRL_SET_CFGUPDATE);
+	ret = ctrl_reg_write(dev, BQ274XX_CTRL_SET_CFGUPDATE);
 	if (ret < 0) {
 		LOG_ERR("Unable to set CFGUpdate");
 		return -EIO;
@@ -457,8 +430,7 @@ static int gauge_configure(const struct device *dev)
 
 	/** Step to place the Gauge into CONFIG UPDATE Mode **/
 	do {
-		ret = cmd_reg_read(
-			dev, BQ274XX_CMD_FLAGS, &flags);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_FLAGS, &flags);
 		if (ret < 0) {
 			LOG_ERR("Unable to read flags");
 			return -EIO;
@@ -470,24 +442,21 @@ static int gauge_configure(const struct device *dev)
 
 	} while (!(flags & 0x0010));
 
-	ret = cmd_reg_write(dev,
-					   BQ274XX_EXT_DATA_CONTROL, 0x00);
+	ret = cmd_reg_write(dev, BQ274XX_EXT_DATA_CONTROL, 0x00);
 	if (ret < 0) {
 		LOG_ERR("Failed to enable block data memory");
 		return -EIO;
 	}
 
 	/* Access State subclass */
-	ret = cmd_reg_write(dev, BQ274XX_EXT_DATA_CLASS,
-					   0x52);
+	ret = cmd_reg_write(dev, BQ274XX_EXT_DATA_CLASS, 0x52);
 	if (ret < 0) {
 		LOG_ERR("Failed to update state subclass");
 		return -EIO;
 	}
 
 	/* Write the block offset */
-	ret = cmd_reg_write(dev, BQ274XX_EXT_DATA_BLOCK,
-					   0x00);
+	ret = cmd_reg_write(dev, BQ274XX_EXT_DATA_BLOCK, 0x00);
 	if (ret < 0) {
 		LOG_ERR("Failed to update block offset");
 		return -EIO;
@@ -510,8 +479,7 @@ static int gauge_configure(const struct device *dev)
 	tmp_checksum = 255 - tmp_checksum;
 
 	/* Read the block checksum */
-	ret = i2c_reg_read_byte_dt(&config->i2c,
-				      BQ274XX_EXT_CHECKSUM, &checksum_old);
+	ret = i2c_reg_read_byte_dt(&config->i2c, BQ274XX_EXT_CHECKSUM, &checksum_old);
 	if (ret < 0) {
 		LOG_ERR("Unable to read block checksum");
 		return -EIO;
@@ -526,64 +494,56 @@ static int gauge_configure(const struct device *dev)
 	taperrate_msb = taperrate >> 8;
 	taperrate_lsb = taperrate & 0x00FF;
 
-	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXT_BLKDAT_DESIGN_CAP_HIGH,
-				       designcap_msb);
+	ret = i2c_reg_write_byte_dt(&config->i2c, BQ274XX_EXT_BLKDAT_DESIGN_CAP_HIGH,
+				    designcap_msb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write designCAP MSB");
 		return -EIO;
 	}
 
-	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXT_BLKDAT_DESIGN_CAP_LOW,
-				       designcap_lsb);
+	ret = i2c_reg_write_byte_dt(&config->i2c, BQ274XX_EXT_BLKDAT_DESIGN_CAP_LOW,
+				    designcap_lsb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write designCAP LSB");
 		return -EIO;
 	}
 
-	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXT_BLKDAT_DESIGN_ENR_HIGH,
-				       designenergy_msb);
+	ret = i2c_reg_write_byte_dt(&config->i2c, BQ274XX_EXT_BLKDAT_DESIGN_ENR_HIGH,
+				    designenergy_msb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write designEnergy MSB");
 		return -EIO;
 	}
 
-	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXT_BLKDAT_DESIGN_ENR_LOW,
-				       designenergy_lsb);
+	ret = i2c_reg_write_byte_dt(&config->i2c, BQ274XX_EXT_BLKDAT_DESIGN_ENR_LOW,
+				    designenergy_lsb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write designEnergy LSB");
 		return -EIO;
 	}
 
-	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXT_BLKDAT_TERMINATE_VOLT_HIGH,
-				       terminatevolt_msb);
+	ret = i2c_reg_write_byte_dt(&config->i2c, BQ274XX_EXT_BLKDAT_TERMINATE_VOLT_HIGH,
+				    terminatevolt_msb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write terminateVolt MSB");
 		return -EIO;
 	}
 
 	ret = i2c_reg_write_byte_dt(&config->i2c, BQ274XX_EXT_BLKDAT_TERMINATE_VOLT_LOW,
-				       terminatevolt_lsb);
+				    terminatevolt_lsb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write terminateVolt LSB");
 		return -EIO;
 	}
 
-	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXT_BLKDAT_TAPERRATE_HIGH,
-				       taperrate_msb);
+	ret = i2c_reg_write_byte_dt(&config->i2c, BQ274XX_EXT_BLKDAT_TAPERRATE_HIGH,
+				    taperrate_msb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write taperRate MSB");
 		return -EIO;
 	}
 
-	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXT_BLKDAT_TAPERRATE_LOW,
-				       taperrate_lsb);
+	ret = i2c_reg_write_byte_dt(&config->i2c, BQ274XX_EXT_BLKDAT_TAPERRATE_LOW, taperrate_lsb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write taperRate LSB");
 		return -EIO;
@@ -605,16 +565,14 @@ static int gauge_configure(const struct device *dev)
 	}
 	checksum_new = 255 - checksum_new;
 
-	ret = cmd_reg_write(dev, BQ274XX_EXT_CHECKSUM,
-					   checksum_new);
+	ret = cmd_reg_write(dev, BQ274XX_EXT_CHECKSUM, checksum_new);
 	if (ret < 0) {
 		LOG_ERR("Failed to update new checksum");
 		return -EIO;
 	}
 
 	tmp_checksum = 0;
-	ret = i2c_reg_read_byte_dt(&config->i2c,
-				      BQ274XX_EXT_CHECKSUM, &tmp_checksum);
+	ret = i2c_reg_read_byte_dt(&config->i2c, BQ274XX_EXT_CHECKSUM, &tmp_checksum);
 	if (ret < 0) {
 		LOG_ERR("Failed to read checksum");
 		return -EIO;
@@ -635,8 +593,7 @@ static int gauge_configure(const struct device *dev)
 	flags = 0;
 	/* Poll Flags   */
 	do {
-		ret = cmd_reg_read(
-			dev, BQ274XX_CMD_FLAGS, &flags);
+		ret = cmd_reg_read(dev, BQ274XX_CMD_FLAGS, &flags);
 		if (ret < 0) {
 			LOG_ERR("Unable to read flags");
 			return -EIO;
@@ -676,8 +633,7 @@ static int enter_shutdown_mode(const struct device *dev)
 		return ret;
 	}
 
-	ret = ctrl_reg_write(dev,
-					   BQ274XX_CTRL_SHUTDOWN_ENABLE);
+	ret = ctrl_reg_write(dev, BQ274XX_CTRL_SHUTDOWN_ENABLE);
 	if (ret < 0) {
 		LOG_ERR("Unable to enable shutdown mode");
 		return ret;
@@ -703,8 +659,7 @@ static int exit_shutdown_mode(const struct device *dev)
 	const struct bq274xx_config *const config = dev->config;
 	int ret = 0;
 
-	ret = gpio_pin_configure_dt(&config->int_gpios,
-			   GPIO_OUTPUT | GPIO_OPEN_DRAIN);
+	ret = gpio_pin_configure_dt(&config->int_gpios, GPIO_OUTPUT | GPIO_OPEN_DRAIN);
 	if (ret < 0) {
 		LOG_ERR("Unable to configure interrupt pin to output and open drain");
 		return ret;
@@ -737,8 +692,7 @@ static int exit_shutdown_mode(const struct device *dev)
 	return 0;
 }
 
-static int pm_action(const struct device *dev,
-			     enum pm_device_action action)
+static int pm_action(const struct device *dev, enum pm_device_action action)
 {
 	int ret;
 
@@ -767,9 +721,9 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 };
 
 #if defined(CONFIG_BQ274XX_PM) || defined(CONFIG_BQ274XX_TRIGGER)
-#define BQ274XX_INT_CFG(index)						      \
+#define BQ274XX_INT_CFG(index)							\
 	.int_gpios = GPIO_DT_SPEC_INST_GET(index, int_gpios),
-#define PM_BQ274XX_DT_INST_DEFINE(index, pm_action) \
+#define PM_BQ274XX_DT_INST_DEFINE(index, pm_action)				\
 	PM_DEVICE_DT_INST_DEFINE(index, pm_action)
 #define PM_BQ274XX_DT_INST_GET(index) PM_DEVICE_DT_INST_GET(index)
 #else
@@ -791,9 +745,9 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 		.lazy_loading = DT_INST_PROP(index, zephyr_lazy_load),		\
 	};									\
 										\
-	PM_BQ274XX_DT_INST_DEFINE(index, pm_action);			\
+	PM_BQ274XX_DT_INST_DEFINE(index, pm_action);				\
 										\
-	SENSOR_DEVICE_DT_INST_DEFINE(index, &gauge_init,		\
+	SENSOR_DEVICE_DT_INST_DEFINE(index, &gauge_init,			\
 			    PM_BQ274XX_DT_INST_GET(index),			\
 			    &bq274xx_driver_##index,				\
 			    &bq274xx_config_##index, POST_KERNEL,		\

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -26,9 +26,9 @@ LOG_MODULE_REGISTER(bq274xx, CONFIG_SENSOR_LOG_LEVEL);
 /* Time it takes device to initialize before doing any configuration */
 #define INIT_TIME 100U
 
-static int bq274xx_gauge_configure(const struct device *dev);
+static int gauge_configure(const struct device *dev);
 
-static int bq274xx_command_reg_read(const struct device *dev, uint8_t reg_addr,
+static int command_reg_read(const struct device *dev, uint8_t reg_addr,
 				    int16_t *val)
 {
 	const struct bq274xx_config *config = dev->config;
@@ -47,7 +47,7 @@ static int bq274xx_command_reg_read(const struct device *dev, uint8_t reg_addr,
 	return 0;
 }
 
-static int bq274xx_control_reg_write(const struct device *dev,
+static int control_reg_write(const struct device *dev,
 				     uint16_t subcommand)
 {
 	const struct bq274xx_config *config = dev->config;
@@ -79,7 +79,7 @@ static int bq274xx_control_reg_write(const struct device *dev,
 	return 0;
 }
 
-static int bq274xx_command_reg_write(const struct device *dev, uint8_t command,
+static int command_reg_write(const struct device *dev, uint8_t command,
 				     uint8_t data)
 {
 	const struct bq274xx_config *config = dev->config;
@@ -99,7 +99,7 @@ static int bq274xx_command_reg_write(const struct device *dev, uint8_t command,
 	return 0;
 }
 
-static int bq274xx_read_data_block(const struct device *dev, uint8_t offset,
+static int read_data_block(const struct device *dev, uint8_t offset,
 				   uint8_t *data, uint8_t bytes)
 {
 	const struct bq274xx_config *config = dev->config;
@@ -120,18 +120,18 @@ static int bq274xx_read_data_block(const struct device *dev, uint8_t offset,
 	return 0;
 }
 
-static int bq274xx_get_device_type(const struct device *dev, uint16_t *val)
+static int get_device_type(const struct device *dev, uint16_t *val)
 {
 	int ret;
 
 	ret =
-		bq274xx_control_reg_write(dev, BQ274XX_CONTROL_DEVICE_TYPE);
+		control_reg_write(dev, BQ274XX_CONTROL_DEVICE_TYPE);
 	if (ret < 0) {
 		LOG_ERR("Unable to write control register");
 		return -EIO;
 	}
 
-	ret = bq274xx_command_reg_read(dev, BQ274XX_COMMAND_CONTROL_LOW,
+	ret = command_reg_read(dev, BQ274XX_COMMAND_CONTROL_LOW,
 					  val);
 
 	if (ret < 0) {
@@ -147,7 +147,7 @@ static int bq274xx_get_device_type(const struct device *dev, uint16_t *val)
  *
  * @return -ENOTSUP for unsupported channels
  */
-static int bq274xx_channel_get(const struct device *dev,
+static int channel_get(const struct device *dev,
 			       enum sensor_channel chan,
 			       struct sensor_value *val)
 {
@@ -225,14 +225,14 @@ static int bq274xx_channel_get(const struct device *dev,
 	return 0;
 }
 
-static int bq274xx_sample_fetch(const struct device *dev,
+static int sample_fetch(const struct device *dev,
 				enum sensor_channel chan)
 {
 	struct bq274xx_data *data = dev->data;
 	int ret = 0;
 
 	if (!data->configured) {
-		ret = bq274xx_gauge_configure(dev);
+		ret = gauge_configure(dev);
 
 		if (ret < 0) {
 			return ret;
@@ -241,7 +241,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 
 	switch (chan) {
 	case SENSOR_CHAN_GAUGE_VOLTAGE:
-		ret = bq274xx_command_reg_read(
+		ret = command_reg_read(
 			dev, BQ274XX_COMMAND_VOLTAGE, &data->voltage);
 		if (ret < 0) {
 			LOG_ERR("Failed to read voltage");
@@ -250,7 +250,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_CURRENT:
-		ret = bq274xx_command_reg_read(dev,
+		ret = command_reg_read(dev,
 						  BQ274XX_COMMAND_AVG_CURRENT,
 						  &data->avg_current);
 		if (ret < 0) {
@@ -260,7 +260,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_TEMP:
-		ret = bq274xx_command_reg_read(
+		ret = command_reg_read(
 			dev, BQ274XX_COMMAND_INT_TEMP,
 			&data->internal_temperature);
 		if (ret < 0) {
@@ -270,7 +270,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_STDBY_CURRENT:
-		ret = bq274xx_command_reg_read(dev,
+		ret = command_reg_read(dev,
 						  BQ274XX_COMMAND_STDBY_CURRENT,
 						  &data->stdby_current);
 		if (ret < 0) {
@@ -280,7 +280,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT:
-		ret = bq274xx_command_reg_read(dev,
+		ret = command_reg_read(dev,
 						  BQ274XX_COMMAND_MAX_CURRENT,
 						  &data->max_load_current);
 		if (ret < 0) {
@@ -290,7 +290,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_CHARGE:
-		ret = bq274xx_command_reg_read(dev, BQ274XX_COMMAND_SOC,
+		ret = command_reg_read(dev, BQ274XX_COMMAND_SOC,
 						  &data->state_of_charge);
 		if (ret < 0) {
 			LOG_ERR("Failed to read state of charge");
@@ -299,7 +299,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY:
-		ret = bq274xx_command_reg_read(
+		ret = command_reg_read(
 			dev, BQ274XX_COMMAND_FULL_CAPACITY,
 			&data->full_charge_capacity);
 		if (ret < 0) {
@@ -309,7 +309,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY:
-		ret = bq274xx_command_reg_read(
+		ret = command_reg_read(
 			dev, BQ274XX_COMMAND_REM_CAPACITY,
 			&data->remaining_charge_capacity);
 		if (ret < 0) {
@@ -319,7 +319,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY:
-		ret = bq274xx_command_reg_read(dev,
+		ret = command_reg_read(dev,
 						  BQ274XX_COMMAND_NOM_CAPACITY,
 						  &data->nom_avail_capacity);
 		if (ret < 0) {
@@ -330,7 +330,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 
 	case SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY:
 		ret =
-			bq274xx_command_reg_read(dev,
+			command_reg_read(dev,
 						 BQ274XX_COMMAND_AVAIL_CAPACITY,
 						 &data->full_avail_capacity);
 		if (ret < 0) {
@@ -340,7 +340,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_POWER:
-		ret = bq274xx_command_reg_read(dev,
+		ret = command_reg_read(dev,
 						  BQ274XX_COMMAND_AVG_POWER,
 						  &data->avg_power);
 		if (ret < 0) {
@@ -350,7 +350,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_HEALTH:
-		ret = bq274xx_command_reg_read(dev, BQ274XX_COMMAND_SOH,
+		ret = command_reg_read(dev, BQ274XX_COMMAND_SOH,
 						  &data->state_of_health);
 
 		data->state_of_health = (data->state_of_health) & 0x00FF;
@@ -373,7 +373,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
  *
  * @return 0 for success
  */
-static int bq274xx_gauge_init(const struct device *dev)
+static int gauge_init(const struct device *dev)
 {
 	const struct bq274xx_config *const config = dev->config;
 	int ret = 0;
@@ -391,7 +391,7 @@ static int bq274xx_gauge_init(const struct device *dev)
 	}
 #endif
 
-	ret = bq274xx_get_device_type(dev, &id);
+	ret = get_device_type(dev, &id);
 	if (ret < 0) {
 		LOG_ERR("Unable to get device ID");
 		return -EIO;
@@ -411,13 +411,13 @@ static int bq274xx_gauge_init(const struct device *dev)
 #endif
 
 	if (!config->lazy_loading) {
-		ret = bq274xx_gauge_configure(dev);
+		ret = gauge_configure(dev);
 	}
 
 	return ret;
 }
 
-static int bq274xx_gauge_configure(const struct device *dev)
+static int gauge_configure(const struct device *dev)
 {
 	const struct bq274xx_config *const config = dev->config;
 	struct bq274xx_data *data = dev->data;
@@ -435,20 +435,20 @@ static int bq274xx_gauge_configure(const struct device *dev)
 		(uint16_t)config->design_capacity / (0.1 * config->taper_current);
 
 	/** Unseal the battery control register **/
-	ret = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	ret = control_reg_write(dev, BQ274XX_UNSEAL_KEY);
 	if (ret < 0) {
 		LOG_ERR("Unable to unseal the battery");
 		return -EIO;
 	}
 
-	ret = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	ret = control_reg_write(dev, BQ274XX_UNSEAL_KEY);
 	if (ret < 0) {
 		LOG_ERR("Unable to unseal the battery");
 		return -EIO;
 	}
 
 	/* Send CFG_UPDATE */
-	ret = bq274xx_control_reg_write(dev,
+	ret = control_reg_write(dev,
 					   BQ274XX_CONTROL_SET_CFGUPDATE);
 	if (ret < 0) {
 		LOG_ERR("Unable to set CFGUpdate");
@@ -457,7 +457,7 @@ static int bq274xx_gauge_configure(const struct device *dev)
 
 	/** Step to place the Gauge into CONFIG UPDATE Mode **/
 	do {
-		ret = bq274xx_command_reg_read(
+		ret = command_reg_read(
 			dev, BQ274XX_COMMAND_FLAGS, &flags);
 		if (ret < 0) {
 			LOG_ERR("Unable to read flags");
@@ -470,7 +470,7 @@ static int bq274xx_gauge_configure(const struct device *dev)
 
 	} while (!(flags & 0x0010));
 
-	ret = bq274xx_command_reg_write(dev,
+	ret = command_reg_write(dev,
 					   BQ274XX_EXTENDED_DATA_CONTROL, 0x00);
 	if (ret < 0) {
 		LOG_ERR("Failed to enable block data memory");
@@ -478,7 +478,7 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	}
 
 	/* Access State subclass */
-	ret = bq274xx_command_reg_write(dev, BQ274XX_EXTENDED_DATA_CLASS,
+	ret = command_reg_write(dev, BQ274XX_EXTENDED_DATA_CLASS,
 					   0x52);
 	if (ret < 0) {
 		LOG_ERR("Failed to update state subclass");
@@ -486,7 +486,7 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	}
 
 	/* Write the block offset */
-	ret = bq274xx_command_reg_write(dev, BQ274XX_EXTENDED_DATA_BLOCK,
+	ret = command_reg_write(dev, BQ274XX_EXTENDED_DATA_BLOCK,
 					   0x00);
 	if (ret < 0) {
 		LOG_ERR("Failed to update block offset");
@@ -497,7 +497,7 @@ static int bq274xx_gauge_configure(const struct device *dev)
 		block[i] = 0;
 	}
 
-	ret = bq274xx_read_data_block(dev, 0x00, block, 32);
+	ret = read_data_block(dev, 0x00, block, 32);
 	if (ret < 0) {
 		LOG_ERR("Unable to read block data");
 		return -EIO;
@@ -593,7 +593,7 @@ static int bq274xx_gauge_configure(const struct device *dev)
 		block[i] = 0;
 	}
 
-	ret = bq274xx_read_data_block(dev, 0x00, block, 32);
+	ret = read_data_block(dev, 0x00, block, 32);
 	if (ret < 0) {
 		LOG_ERR("Unable to read block data");
 		return -EIO;
@@ -605,7 +605,7 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	}
 	checksum_new = 255 - checksum_new;
 
-	ret = bq274xx_command_reg_write(dev, BQ274XX_EXTENDED_CHECKSUM,
+	ret = command_reg_write(dev, BQ274XX_EXTENDED_CHECKSUM,
 					   checksum_new);
 	if (ret < 0) {
 		LOG_ERR("Failed to update new checksum");
@@ -620,13 +620,13 @@ static int bq274xx_gauge_configure(const struct device *dev)
 		return -EIO;
 	}
 
-	ret = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_BAT_INSERT);
+	ret = control_reg_write(dev, BQ274XX_CONTROL_BAT_INSERT);
 	if (ret < 0) {
 		LOG_ERR("Unable to configure BAT Detect");
 		return -EIO;
 	}
 
-	ret = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SOFT_RESET);
+	ret = control_reg_write(dev, BQ274XX_CONTROL_SOFT_RESET);
 	if (ret < 0) {
 		LOG_ERR("Failed to soft reset the gauge");
 		return -EIO;
@@ -635,7 +635,7 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	flags = 0;
 	/* Poll Flags   */
 	do {
-		ret = bq274xx_command_reg_read(
+		ret = command_reg_read(
 			dev, BQ274XX_COMMAND_FLAGS, &flags);
 		if (ret < 0) {
 			LOG_ERR("Unable to read flags");
@@ -648,7 +648,7 @@ static int bq274xx_gauge_configure(const struct device *dev)
 	} while (flags & 0x0010);
 
 	/* Seal the gauge */
-	ret = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SEALED);
+	ret = control_reg_write(dev, BQ274XX_CONTROL_SEALED);
 	if (ret < 0) {
 		LOG_ERR("Failed to seal the gauge");
 		return -EIO;
@@ -660,36 +660,36 @@ static int bq274xx_gauge_configure(const struct device *dev)
 }
 
 #ifdef CONFIG_BQ274XX_PM
-static int bq274xx_enter_shutdown_mode(const struct device *dev)
+static int enter_shutdown_mode(const struct device *dev)
 {
 	int ret;
 
-	ret = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	ret = control_reg_write(dev, BQ274XX_UNSEAL_KEY);
 	if (ret < 0) {
 		LOG_ERR("Unable to unseal the battery");
 		return ret;
 	}
 
-	ret = bq274xx_control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	ret = control_reg_write(dev, BQ274XX_UNSEAL_KEY);
 	if (ret < 0) {
 		LOG_ERR("Unable to unseal the battery");
 		return ret;
 	}
 
-	ret = bq274xx_control_reg_write(dev,
+	ret = control_reg_write(dev,
 					   BQ274XX_CONTROL_SHUTDOWN_ENABLE);
 	if (ret < 0) {
 		LOG_ERR("Unable to enable shutdown mode");
 		return ret;
 	}
 
-	ret = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SHUTDOWN);
+	ret = control_reg_write(dev, BQ274XX_CONTROL_SHUTDOWN);
 	if (ret < 0) {
 		LOG_ERR("Unable to enter shutdown mode");
 		return ret;
 	}
 
-	ret = bq274xx_control_reg_write(dev, BQ274XX_CONTROL_SEALED);
+	ret = control_reg_write(dev, BQ274XX_CONTROL_SEALED);
 	if (ret < 0) {
 		LOG_ERR("Failed to seal the gauge");
 		return ret;
@@ -698,7 +698,7 @@ static int bq274xx_enter_shutdown_mode(const struct device *dev)
 	return 0;
 }
 
-static int bq274xx_exit_shutdown_mode(const struct device *dev)
+static int exit_shutdown_mode(const struct device *dev)
 {
 	const struct bq274xx_config *const config = dev->config;
 	int ret = 0;
@@ -727,7 +727,7 @@ static int bq274xx_exit_shutdown_mode(const struct device *dev)
 	if (!config->lazy_loading) {
 		k_msleep(INIT_TIME);
 
-		ret = bq274xx_gauge_configure(dev);
+		ret = gauge_configure(dev);
 		if (ret < 0) {
 			LOG_ERR("Unable to configure bq274xx gauge");
 			return ret;
@@ -737,17 +737,17 @@ static int bq274xx_exit_shutdown_mode(const struct device *dev)
 	return 0;
 }
 
-static int bq274xx_pm_action(const struct device *dev,
+static int pm_action(const struct device *dev,
 			     enum pm_device_action action)
 {
 	int ret;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_TURN_OFF:
-		ret = bq274xx_enter_shutdown_mode(dev);
+		ret = enter_shutdown_mode(dev);
 		break;
 	case PM_DEVICE_ACTION_RESUME:
-		ret = bq274xx_exit_shutdown_mode(dev);
+		ret = exit_shutdown_mode(dev);
 		break;
 	default:
 		ret = -ENOTSUP;
@@ -759,8 +759,8 @@ static int bq274xx_pm_action(const struct device *dev,
 #endif /* CONFIG_BQ274XX_PM */
 
 static const struct sensor_driver_api bq274xx_battery_driver_api = {
-	.sample_fetch = bq274xx_sample_fetch,
-	.channel_get = bq274xx_channel_get,
+	.sample_fetch = sample_fetch,
+	.channel_get = channel_get,
 #ifdef CONFIG_BQ274XX_TRIGGER
 	.trigger_set = bq274xx_trigger_set,
 #endif
@@ -769,12 +769,12 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 #if defined(CONFIG_BQ274XX_PM) || defined(CONFIG_BQ274XX_TRIGGER)
 #define BQ274XX_INT_CFG(index)						      \
 	.int_gpios = GPIO_DT_SPEC_INST_GET(index, int_gpios),
-#define PM_BQ274XX_DT_INST_DEFINE(index, bq274xx_pm_action) \
-	PM_DEVICE_DT_INST_DEFINE(index, bq274xx_pm_action)
+#define PM_BQ274XX_DT_INST_DEFINE(index, pm_action) \
+	PM_DEVICE_DT_INST_DEFINE(index, pm_action)
 #define PM_BQ274XX_DT_INST_GET(index) PM_DEVICE_DT_INST_GET(index)
 #else
 #define BQ274XX_INT_CFG(index)
-#define PM_BQ274XX_DT_INST_DEFINE(index, bq274xx_pm_action)
+#define PM_BQ274XX_DT_INST_DEFINE(index, pm_action)
 #define PM_BQ274XX_DT_INST_GET(index) NULL
 #endif
 
@@ -791,9 +791,9 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 		.lazy_loading = DT_INST_PROP(index, zephyr_lazy_load),		\
 	};									\
 										\
-	PM_BQ274XX_DT_INST_DEFINE(index, bq274xx_pm_action);			\
+	PM_BQ274XX_DT_INST_DEFINE(index, pm_action);			\
 										\
-	SENSOR_DEVICE_DT_INST_DEFINE(index, &bq274xx_gauge_init,		\
+	SENSOR_DEVICE_DT_INST_DEFINE(index, &gauge_init,		\
 			    PM_BQ274XX_DT_INST_GET(index),			\
 			    &bq274xx_driver_##index,				\
 			    &bq274xx_config_##index, POST_KERNEL,		\

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -151,71 +151,71 @@ static int bq274xx_channel_get(const struct device *dev,
 			       enum sensor_channel chan,
 			       struct sensor_value *val)
 {
-	struct bq274xx_data *bq274xx = dev->data;
+	struct bq274xx_data *data = dev->data;
 	float int_temp;
 
 	switch (chan) {
 	case SENSOR_CHAN_GAUGE_VOLTAGE:
-		val->val1 = ((bq274xx->voltage / 1000));
-		val->val2 = ((bq274xx->voltage % 1000) * 1000U);
+		val->val1 = ((data->voltage / 1000));
+		val->val2 = ((data->voltage % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_CURRENT:
-		val->val1 = ((bq274xx->avg_current / 1000));
-		val->val2 = ((bq274xx->avg_current % 1000) * 1000U);
+		val->val1 = ((data->avg_current / 1000));
+		val->val2 = ((data->avg_current % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_STDBY_CURRENT:
-		val->val1 = ((bq274xx->stdby_current / 1000));
-		val->val2 = ((bq274xx->stdby_current % 1000) * 1000U);
+		val->val1 = ((data->stdby_current / 1000));
+		val->val2 = ((data->stdby_current % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT:
-		val->val1 = ((bq274xx->max_load_current / 1000));
-		val->val2 = ((bq274xx->max_load_current % 1000) * 1000U);
+		val->val1 = ((data->max_load_current / 1000));
+		val->val2 = ((data->max_load_current % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_TEMP:
-		int_temp = (bq274xx->internal_temperature * 0.1f);
+		int_temp = (data->internal_temperature * 0.1f);
 		int_temp = int_temp - 273.15f;
 		val->val1 = (int32_t)int_temp;
 		val->val2 = (int_temp - (int32_t)int_temp) * 1000000;
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_CHARGE:
-		val->val1 = bq274xx->state_of_charge;
+		val->val1 = data->state_of_charge;
 		val->val2 = 0;
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_HEALTH:
-		val->val1 = bq274xx->state_of_health;
+		val->val1 = data->state_of_health;
 		val->val2 = 0;
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY:
-		val->val1 = (bq274xx->full_charge_capacity / 1000);
-		val->val2 = ((bq274xx->full_charge_capacity % 1000) * 1000U);
+		val->val1 = (data->full_charge_capacity / 1000);
+		val->val2 = ((data->full_charge_capacity % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY:
-		val->val1 = (bq274xx->remaining_charge_capacity / 1000);
+		val->val1 = (data->remaining_charge_capacity / 1000);
 		val->val2 =
-			((bq274xx->remaining_charge_capacity % 1000) * 1000U);
+			((data->remaining_charge_capacity % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY:
-		val->val1 = (bq274xx->nom_avail_capacity / 1000);
-		val->val2 = ((bq274xx->nom_avail_capacity % 1000) * 1000U);
+		val->val1 = (data->nom_avail_capacity / 1000);
+		val->val2 = ((data->nom_avail_capacity % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY:
-		val->val1 = (bq274xx->full_avail_capacity / 1000);
-		val->val2 = ((bq274xx->full_avail_capacity % 1000) * 1000U);
+		val->val1 = (data->full_avail_capacity / 1000);
+		val->val2 = ((data->full_avail_capacity % 1000) * 1000U);
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_POWER:
-		val->val1 = (bq274xx->avg_power / 1000);
-		val->val2 = ((bq274xx->avg_power % 1000) * 1000U);
+		val->val1 = (data->avg_power / 1000);
+		val->val2 = ((data->avg_power % 1000) * 1000U);
 		break;
 
 	default:
@@ -228,10 +228,10 @@ static int bq274xx_channel_get(const struct device *dev,
 static int bq274xx_sample_fetch(const struct device *dev,
 				enum sensor_channel chan)
 {
-	struct bq274xx_data *bq274xx = dev->data;
+	struct bq274xx_data *data = dev->data;
 	int ret = 0;
 
-	if (!bq274xx->configured) {
+	if (!data->configured) {
 		ret = bq274xx_gauge_configure(dev);
 
 		if (ret < 0) {
@@ -242,7 +242,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 	switch (chan) {
 	case SENSOR_CHAN_GAUGE_VOLTAGE:
 		ret = bq274xx_command_reg_read(
-			dev, BQ274XX_COMMAND_VOLTAGE, &bq274xx->voltage);
+			dev, BQ274XX_COMMAND_VOLTAGE, &data->voltage);
 		if (ret < 0) {
 			LOG_ERR("Failed to read voltage");
 			return -EIO;
@@ -252,7 +252,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 	case SENSOR_CHAN_GAUGE_AVG_CURRENT:
 		ret = bq274xx_command_reg_read(dev,
 						  BQ274XX_COMMAND_AVG_CURRENT,
-						  &bq274xx->avg_current);
+						  &data->avg_current);
 		if (ret < 0) {
 			LOG_ERR("Failed to read average current ");
 			return -EIO;
@@ -262,7 +262,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 	case SENSOR_CHAN_GAUGE_TEMP:
 		ret = bq274xx_command_reg_read(
 			dev, BQ274XX_COMMAND_INT_TEMP,
-			&bq274xx->internal_temperature);
+			&data->internal_temperature);
 		if (ret < 0) {
 			LOG_ERR("Failed to read internal temperature");
 			return -EIO;
@@ -272,7 +272,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 	case SENSOR_CHAN_GAUGE_STDBY_CURRENT:
 		ret = bq274xx_command_reg_read(dev,
 						  BQ274XX_COMMAND_STDBY_CURRENT,
-						  &bq274xx->stdby_current);
+						  &data->stdby_current);
 		if (ret < 0) {
 			LOG_ERR("Failed to read standby current");
 			return -EIO;
@@ -282,7 +282,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 	case SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT:
 		ret = bq274xx_command_reg_read(dev,
 						  BQ274XX_COMMAND_MAX_CURRENT,
-						  &bq274xx->max_load_current);
+						  &data->max_load_current);
 		if (ret < 0) {
 			LOG_ERR("Failed to read maximum current");
 			return -EIO;
@@ -291,7 +291,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_CHARGE:
 		ret = bq274xx_command_reg_read(dev, BQ274XX_COMMAND_SOC,
-						  &bq274xx->state_of_charge);
+						  &data->state_of_charge);
 		if (ret < 0) {
 			LOG_ERR("Failed to read state of charge");
 			return -EIO;
@@ -301,7 +301,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 	case SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY:
 		ret = bq274xx_command_reg_read(
 			dev, BQ274XX_COMMAND_FULL_CAPACITY,
-			&bq274xx->full_charge_capacity);
+			&data->full_charge_capacity);
 		if (ret < 0) {
 			LOG_ERR("Failed to read full charge capacity");
 			return -EIO;
@@ -311,7 +311,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 	case SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY:
 		ret = bq274xx_command_reg_read(
 			dev, BQ274XX_COMMAND_REM_CAPACITY,
-			&bq274xx->remaining_charge_capacity);
+			&data->remaining_charge_capacity);
 		if (ret < 0) {
 			LOG_ERR("Failed to read remaining charge capacity");
 			return -EIO;
@@ -321,7 +321,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 	case SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY:
 		ret = bq274xx_command_reg_read(dev,
 						  BQ274XX_COMMAND_NOM_CAPACITY,
-						  &bq274xx->nom_avail_capacity);
+						  &data->nom_avail_capacity);
 		if (ret < 0) {
 			LOG_ERR("Failed to read nominal available capacity");
 			return -EIO;
@@ -332,7 +332,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 		ret =
 			bq274xx_command_reg_read(dev,
 						 BQ274XX_COMMAND_AVAIL_CAPACITY,
-						 &bq274xx->full_avail_capacity);
+						 &data->full_avail_capacity);
 		if (ret < 0) {
 			LOG_ERR("Failed to read full available capacity");
 			return -EIO;
@@ -342,7 +342,7 @@ static int bq274xx_sample_fetch(const struct device *dev,
 	case SENSOR_CHAN_GAUGE_AVG_POWER:
 		ret = bq274xx_command_reg_read(dev,
 						  BQ274XX_COMMAND_AVG_POWER,
-						  &bq274xx->avg_power);
+						  &data->avg_power);
 		if (ret < 0) {
 			LOG_ERR("Failed to read battery average power");
 			return -EIO;
@@ -351,9 +351,9 @@ static int bq274xx_sample_fetch(const struct device *dev,
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_HEALTH:
 		ret = bq274xx_command_reg_read(dev, BQ274XX_COMMAND_SOH,
-						  &bq274xx->state_of_health);
+						  &data->state_of_health);
 
-		bq274xx->state_of_health = (bq274xx->state_of_health) & 0x00FF;
+		data->state_of_health = (data->state_of_health) & 0x00FF;
 
 		if (ret < 0) {
 			LOG_ERR("Failed to read state of health");

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(bq274xx, CONFIG_SENSOR_LOG_LEVEL);
 
 static int gauge_configure(const struct device *dev);
 
-static int command_reg_read(const struct device *dev, uint8_t reg_addr,
+static int cmd_reg_read(const struct device *dev, uint8_t reg_addr,
 				    int16_t *val)
 {
 	const struct bq274xx_config *config = dev->config;
@@ -47,14 +47,14 @@ static int command_reg_read(const struct device *dev, uint8_t reg_addr,
 	return 0;
 }
 
-static int control_reg_write(const struct device *dev,
+static int ctrl_reg_write(const struct device *dev,
 				     uint16_t subcommand)
 {
 	const struct bq274xx_config *config = dev->config;
 	uint8_t i2c_data, reg_addr;
 	int ret = 0;
 
-	reg_addr = BQ274XX_COMMAND_CONTROL_LOW;
+	reg_addr = BQ274XX_CMD_CONTROL_LOW;
 	i2c_data = (uint8_t)((subcommand)&0x00FF);
 
 	ret = i2c_reg_write_byte_dt(&config->i2c, reg_addr,
@@ -66,7 +66,7 @@ static int control_reg_write(const struct device *dev,
 
 	k_msleep(BQ274XX_SUBCLASS_DELAY);
 
-	reg_addr = BQ274XX_COMMAND_CONTROL_HIGH;
+	reg_addr = BQ274XX_CMD_CONTROL_HIGH;
 	i2c_data = (uint8_t)((subcommand >> 8) & 0x00FF);
 
 	ret = i2c_reg_write_byte_dt(&config->i2c, reg_addr,
@@ -79,7 +79,7 @@ static int control_reg_write(const struct device *dev,
 	return 0;
 }
 
-static int command_reg_write(const struct device *dev, uint8_t command,
+static int cmd_reg_write(const struct device *dev, uint8_t command,
 				     uint8_t data)
 {
 	const struct bq274xx_config *config = dev->config;
@@ -106,7 +106,7 @@ static int read_data_block(const struct device *dev, uint8_t offset,
 	uint8_t i2c_data;
 	int ret = 0;
 
-	i2c_data = BQ274XX_EXTENDED_BLOCKDATA_START + offset;
+	i2c_data = BQ274XX_EXT_BLKDAT_START + offset;
 
 	ret = i2c_burst_read_dt(&config->i2c, i2c_data,
 				   data, bytes);
@@ -125,13 +125,13 @@ static int get_device_type(const struct device *dev, uint16_t *val)
 	int ret;
 
 	ret =
-		control_reg_write(dev, BQ274XX_CONTROL_DEVICE_TYPE);
+		ctrl_reg_write(dev, BQ274XX_CTRL_DEVICE_TYPE);
 	if (ret < 0) {
 		LOG_ERR("Unable to write control register");
 		return -EIO;
 	}
 
-	ret = command_reg_read(dev, BQ274XX_COMMAND_CONTROL_LOW,
+	ret = cmd_reg_read(dev, BQ274XX_CMD_CONTROL_LOW,
 					  val);
 
 	if (ret < 0) {
@@ -241,8 +241,8 @@ static int sample_fetch(const struct device *dev,
 
 	switch (chan) {
 	case SENSOR_CHAN_GAUGE_VOLTAGE:
-		ret = command_reg_read(
-			dev, BQ274XX_COMMAND_VOLTAGE, &data->voltage);
+		ret = cmd_reg_read(
+			dev, BQ274XX_CMD_VOLTAGE, &data->voltage);
 		if (ret < 0) {
 			LOG_ERR("Failed to read voltage");
 			return -EIO;
@@ -250,8 +250,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_CURRENT:
-		ret = command_reg_read(dev,
-						  BQ274XX_COMMAND_AVG_CURRENT,
+		ret = cmd_reg_read(dev,
+						  BQ274XX_CMD_AVG_CURRENT,
 						  &data->avg_current);
 		if (ret < 0) {
 			LOG_ERR("Failed to read average current ");
@@ -260,8 +260,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_TEMP:
-		ret = command_reg_read(
-			dev, BQ274XX_COMMAND_INT_TEMP,
+		ret = cmd_reg_read(
+			dev, BQ274XX_CMD_INT_TEMP,
 			&data->internal_temperature);
 		if (ret < 0) {
 			LOG_ERR("Failed to read internal temperature");
@@ -270,8 +270,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_STDBY_CURRENT:
-		ret = command_reg_read(dev,
-						  BQ274XX_COMMAND_STDBY_CURRENT,
+		ret = cmd_reg_read(dev,
+						  BQ274XX_CMD_STDBY_CURRENT,
 						  &data->stdby_current);
 		if (ret < 0) {
 			LOG_ERR("Failed to read standby current");
@@ -280,8 +280,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT:
-		ret = command_reg_read(dev,
-						  BQ274XX_COMMAND_MAX_CURRENT,
+		ret = cmd_reg_read(dev,
+						  BQ274XX_CMD_MAX_CURRENT,
 						  &data->max_load_current);
 		if (ret < 0) {
 			LOG_ERR("Failed to read maximum current");
@@ -290,7 +290,7 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_CHARGE:
-		ret = command_reg_read(dev, BQ274XX_COMMAND_SOC,
+		ret = cmd_reg_read(dev, BQ274XX_CMD_SOC,
 						  &data->state_of_charge);
 		if (ret < 0) {
 			LOG_ERR("Failed to read state of charge");
@@ -299,8 +299,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY:
-		ret = command_reg_read(
-			dev, BQ274XX_COMMAND_FULL_CAPACITY,
+		ret = cmd_reg_read(
+			dev, BQ274XX_CMD_FULL_CAPACITY,
 			&data->full_charge_capacity);
 		if (ret < 0) {
 			LOG_ERR("Failed to read full charge capacity");
@@ -309,8 +309,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY:
-		ret = command_reg_read(
-			dev, BQ274XX_COMMAND_REM_CAPACITY,
+		ret = cmd_reg_read(
+			dev, BQ274XX_CMD_REM_CAPACITY,
 			&data->remaining_charge_capacity);
 		if (ret < 0) {
 			LOG_ERR("Failed to read remaining charge capacity");
@@ -319,8 +319,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY:
-		ret = command_reg_read(dev,
-						  BQ274XX_COMMAND_NOM_CAPACITY,
+		ret = cmd_reg_read(dev,
+						  BQ274XX_CMD_NOM_CAPACITY,
 						  &data->nom_avail_capacity);
 		if (ret < 0) {
 			LOG_ERR("Failed to read nominal available capacity");
@@ -330,8 +330,8 @@ static int sample_fetch(const struct device *dev,
 
 	case SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY:
 		ret =
-			command_reg_read(dev,
-						 BQ274XX_COMMAND_AVAIL_CAPACITY,
+			cmd_reg_read(dev,
+						 BQ274XX_CMD_AVAIL_CAPACITY,
 						 &data->full_avail_capacity);
 		if (ret < 0) {
 			LOG_ERR("Failed to read full available capacity");
@@ -340,8 +340,8 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_POWER:
-		ret = command_reg_read(dev,
-						  BQ274XX_COMMAND_AVG_POWER,
+		ret = cmd_reg_read(dev,
+						  BQ274XX_CMD_AVG_POWER,
 						  &data->avg_power);
 		if (ret < 0) {
 			LOG_ERR("Failed to read battery average power");
@@ -350,7 +350,7 @@ static int sample_fetch(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_GAUGE_STATE_OF_HEALTH:
-		ret = command_reg_read(dev, BQ274XX_COMMAND_SOH,
+		ret = cmd_reg_read(dev, BQ274XX_CMD_SOH,
 						  &data->state_of_health);
 
 		data->state_of_health = (data->state_of_health) & 0x00FF;
@@ -435,21 +435,21 @@ static int gauge_configure(const struct device *dev)
 		(uint16_t)config->design_capacity / (0.1 * config->taper_current);
 
 	/** Unseal the battery control register **/
-	ret = control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	ret = ctrl_reg_write(dev, BQ274XX_UNSEAL_KEY);
 	if (ret < 0) {
 		LOG_ERR("Unable to unseal the battery");
 		return -EIO;
 	}
 
-	ret = control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	ret = ctrl_reg_write(dev, BQ274XX_UNSEAL_KEY);
 	if (ret < 0) {
 		LOG_ERR("Unable to unseal the battery");
 		return -EIO;
 	}
 
 	/* Send CFG_UPDATE */
-	ret = control_reg_write(dev,
-					   BQ274XX_CONTROL_SET_CFGUPDATE);
+	ret = ctrl_reg_write(dev,
+					   BQ274XX_CTRL_SET_CFGUPDATE);
 	if (ret < 0) {
 		LOG_ERR("Unable to set CFGUpdate");
 		return -EIO;
@@ -457,8 +457,8 @@ static int gauge_configure(const struct device *dev)
 
 	/** Step to place the Gauge into CONFIG UPDATE Mode **/
 	do {
-		ret = command_reg_read(
-			dev, BQ274XX_COMMAND_FLAGS, &flags);
+		ret = cmd_reg_read(
+			dev, BQ274XX_CMD_FLAGS, &flags);
 		if (ret < 0) {
 			LOG_ERR("Unable to read flags");
 			return -EIO;
@@ -470,15 +470,15 @@ static int gauge_configure(const struct device *dev)
 
 	} while (!(flags & 0x0010));
 
-	ret = command_reg_write(dev,
-					   BQ274XX_EXTENDED_DATA_CONTROL, 0x00);
+	ret = cmd_reg_write(dev,
+					   BQ274XX_EXT_DATA_CONTROL, 0x00);
 	if (ret < 0) {
 		LOG_ERR("Failed to enable block data memory");
 		return -EIO;
 	}
 
 	/* Access State subclass */
-	ret = command_reg_write(dev, BQ274XX_EXTENDED_DATA_CLASS,
+	ret = cmd_reg_write(dev, BQ274XX_EXT_DATA_CLASS,
 					   0x52);
 	if (ret < 0) {
 		LOG_ERR("Failed to update state subclass");
@@ -486,7 +486,7 @@ static int gauge_configure(const struct device *dev)
 	}
 
 	/* Write the block offset */
-	ret = command_reg_write(dev, BQ274XX_EXTENDED_DATA_BLOCK,
+	ret = cmd_reg_write(dev, BQ274XX_EXT_DATA_BLOCK,
 					   0x00);
 	if (ret < 0) {
 		LOG_ERR("Failed to update block offset");
@@ -511,7 +511,7 @@ static int gauge_configure(const struct device *dev)
 
 	/* Read the block checksum */
 	ret = i2c_reg_read_byte_dt(&config->i2c,
-				      BQ274XX_EXTENDED_CHECKSUM, &checksum_old);
+				      BQ274XX_EXT_CHECKSUM, &checksum_old);
 	if (ret < 0) {
 		LOG_ERR("Unable to read block checksum");
 		return -EIO;
@@ -527,7 +527,7 @@ static int gauge_configure(const struct device *dev)
 	taperrate_lsb = taperrate & 0x00FF;
 
 	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXTENDED_BLOCKDATA_DESIGN_CAP_HIGH,
+				       BQ274XX_EXT_BLKDAT_DESIGN_CAP_HIGH,
 				       designcap_msb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write designCAP MSB");
@@ -535,7 +535,7 @@ static int gauge_configure(const struct device *dev)
 	}
 
 	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXTENDED_BLOCKDATA_DESIGN_CAP_LOW,
+				       BQ274XX_EXT_BLKDAT_DESIGN_CAP_LOW,
 				       designcap_lsb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write designCAP LSB");
@@ -543,7 +543,7 @@ static int gauge_configure(const struct device *dev)
 	}
 
 	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXTENDED_BLOCKDATA_DESIGN_ENR_HIGH,
+				       BQ274XX_EXT_BLKDAT_DESIGN_ENR_HIGH,
 				       designenergy_msb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write designEnergy MSB");
@@ -551,7 +551,7 @@ static int gauge_configure(const struct device *dev)
 	}
 
 	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXTENDED_BLOCKDATA_DESIGN_ENR_LOW,
+				       BQ274XX_EXT_BLKDAT_DESIGN_ENR_LOW,
 				       designenergy_lsb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write designEnergy LSB");
@@ -559,14 +559,14 @@ static int gauge_configure(const struct device *dev)
 	}
 
 	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXTENDED_BLOCKDATA_TERMINATE_VOLT_HIGH,
+				       BQ274XX_EXT_BLKDAT_TERMINATE_VOLT_HIGH,
 				       terminatevolt_msb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write terminateVolt MSB");
 		return -EIO;
 	}
 
-	ret = i2c_reg_write_byte_dt(&config->i2c, BQ274XX_EXTENDED_BLOCKDATA_TERMINATE_VOLT_LOW,
+	ret = i2c_reg_write_byte_dt(&config->i2c, BQ274XX_EXT_BLKDAT_TERMINATE_VOLT_LOW,
 				       terminatevolt_lsb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write terminateVolt LSB");
@@ -574,7 +574,7 @@ static int gauge_configure(const struct device *dev)
 	}
 
 	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXTENDED_BLOCKDATA_TAPERRATE_HIGH,
+				       BQ274XX_EXT_BLKDAT_TAPERRATE_HIGH,
 				       taperrate_msb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write taperRate MSB");
@@ -582,7 +582,7 @@ static int gauge_configure(const struct device *dev)
 	}
 
 	ret = i2c_reg_write_byte_dt(&config->i2c,
-				       BQ274XX_EXTENDED_BLOCKDATA_TAPERRATE_LOW,
+				       BQ274XX_EXT_BLKDAT_TAPERRATE_LOW,
 				       taperrate_lsb);
 	if (ret < 0) {
 		LOG_ERR("Failed to write taperRate LSB");
@@ -605,7 +605,7 @@ static int gauge_configure(const struct device *dev)
 	}
 	checksum_new = 255 - checksum_new;
 
-	ret = command_reg_write(dev, BQ274XX_EXTENDED_CHECKSUM,
+	ret = cmd_reg_write(dev, BQ274XX_EXT_CHECKSUM,
 					   checksum_new);
 	if (ret < 0) {
 		LOG_ERR("Failed to update new checksum");
@@ -614,19 +614,19 @@ static int gauge_configure(const struct device *dev)
 
 	tmp_checksum = 0;
 	ret = i2c_reg_read_byte_dt(&config->i2c,
-				      BQ274XX_EXTENDED_CHECKSUM, &tmp_checksum);
+				      BQ274XX_EXT_CHECKSUM, &tmp_checksum);
 	if (ret < 0) {
 		LOG_ERR("Failed to read checksum");
 		return -EIO;
 	}
 
-	ret = control_reg_write(dev, BQ274XX_CONTROL_BAT_INSERT);
+	ret = ctrl_reg_write(dev, BQ274XX_CTRL_BAT_INSERT);
 	if (ret < 0) {
 		LOG_ERR("Unable to configure BAT Detect");
 		return -EIO;
 	}
 
-	ret = control_reg_write(dev, BQ274XX_CONTROL_SOFT_RESET);
+	ret = ctrl_reg_write(dev, BQ274XX_CTRL_SOFT_RESET);
 	if (ret < 0) {
 		LOG_ERR("Failed to soft reset the gauge");
 		return -EIO;
@@ -635,8 +635,8 @@ static int gauge_configure(const struct device *dev)
 	flags = 0;
 	/* Poll Flags   */
 	do {
-		ret = command_reg_read(
-			dev, BQ274XX_COMMAND_FLAGS, &flags);
+		ret = cmd_reg_read(
+			dev, BQ274XX_CMD_FLAGS, &flags);
 		if (ret < 0) {
 			LOG_ERR("Unable to read flags");
 			return -EIO;
@@ -648,7 +648,7 @@ static int gauge_configure(const struct device *dev)
 	} while (flags & 0x0010);
 
 	/* Seal the gauge */
-	ret = control_reg_write(dev, BQ274XX_CONTROL_SEALED);
+	ret = ctrl_reg_write(dev, BQ274XX_CTRL_SEALED);
 	if (ret < 0) {
 		LOG_ERR("Failed to seal the gauge");
 		return -EIO;
@@ -664,32 +664,32 @@ static int enter_shutdown_mode(const struct device *dev)
 {
 	int ret;
 
-	ret = control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	ret = ctrl_reg_write(dev, BQ274XX_UNSEAL_KEY);
 	if (ret < 0) {
 		LOG_ERR("Unable to unseal the battery");
 		return ret;
 	}
 
-	ret = control_reg_write(dev, BQ274XX_UNSEAL_KEY);
+	ret = ctrl_reg_write(dev, BQ274XX_UNSEAL_KEY);
 	if (ret < 0) {
 		LOG_ERR("Unable to unseal the battery");
 		return ret;
 	}
 
-	ret = control_reg_write(dev,
-					   BQ274XX_CONTROL_SHUTDOWN_ENABLE);
+	ret = ctrl_reg_write(dev,
+					   BQ274XX_CTRL_SHUTDOWN_ENABLE);
 	if (ret < 0) {
 		LOG_ERR("Unable to enable shutdown mode");
 		return ret;
 	}
 
-	ret = control_reg_write(dev, BQ274XX_CONTROL_SHUTDOWN);
+	ret = ctrl_reg_write(dev, BQ274XX_CTRL_SHUTDOWN);
 	if (ret < 0) {
 		LOG_ERR("Unable to enter shutdown mode");
 		return ret;
 	}
 
-	ret = control_reg_write(dev, BQ274XX_CONTROL_SEALED);
+	ret = ctrl_reg_write(dev, BQ274XX_CTRL_SEALED);
 	if (ret < 0) {
 		LOG_ERR("Failed to seal the gauge");
 		return ret;

--- a/drivers/sensor/bq274xx/bq274xx.h
+++ b/drivers/sensor/bq274xx/bq274xx.h
@@ -15,66 +15,66 @@
 #define BQ274XX_DEVICE_ID 0x0421 /* Default device ID */
 
 /*** Standard Commands ***/
-#define BQ274XX_COMMAND_CONTROL_LOW 0x00 /* Control() low register */
-#define BQ274XX_COMMAND_CONTROL_HIGH 0x01 /* Control() high register */
-#define BQ274XX_COMMAND_TEMP 0x02 /* Temperature() */
-#define BQ274XX_COMMAND_VOLTAGE 0x04 /* Voltage() */
-#define BQ274XX_COMMAND_FLAGS 0x06 /* Flags() */
-#define BQ274XX_COMMAND_NOM_CAPACITY 0x08 /* NominalAvailableCapacity() */
-#define BQ274XX_COMMAND_AVAIL_CAPACITY 0x0A /* FullAvailableCapacity() */
-#define BQ274XX_COMMAND_REM_CAPACITY 0x0C /* RemainingCapacity() */
-#define BQ274XX_COMMAND_FULL_CAPACITY 0x0E /* FullChargeCapacity() */
-#define BQ274XX_COMMAND_AVG_CURRENT 0x10 /* AverageCurrent() */
-#define BQ274XX_COMMAND_STDBY_CURRENT 0x12 /* StandbyCurrent() */
-#define BQ274XX_COMMAND_MAX_CURRENT 0x14 /* MaxLoadCurrent() */
-#define BQ274XX_COMMAND_AVG_POWER 0x18 /* AveragePower() */
-#define BQ274XX_COMMAND_SOC 0x1C /* StateOfCharge() */
-#define BQ274XX_COMMAND_INT_TEMP 0x1E /* InternalTemperature() */
-#define BQ274XX_COMMAND_SOH 0x20 /* StateOfHealth() */
-#define BQ274XX_COMMAND_REM_CAP_UNFL 0x28 /* RemainingCapacityUnfiltered() */
-#define BQ274XX_COMMAND_REM_CAP_FIL 0x2A /* RemainingCapacityFiltered() */
-#define BQ274XX_COMMAND_FULL_CAP_UNFL 0x2C /* FullChargeCapacityUnfiltered() */
-#define BQ274XX_COMMAND_FULL_CAP_FIL 0x2E /* FullChargeCapacityFiltered() */
-#define BQ274XX_COMMAND_SOC_UNFL 0x30 /* StateOfChargeUnfiltered() */
+#define BQ274XX_CMD_CONTROL_LOW 0x00 /* Control() low register */
+#define BQ274XX_CMD_CONTROL_HIGH 0x01 /* Control() high register */
+#define BQ274XX_CMD_TEMP 0x02 /* Temperature() */
+#define BQ274XX_CMD_VOLTAGE 0x04 /* Voltage() */
+#define BQ274XX_CMD_FLAGS 0x06 /* Flags() */
+#define BQ274XX_CMD_NOM_CAPACITY 0x08 /* NominalAvailableCapacity() */
+#define BQ274XX_CMD_AVAIL_CAPACITY 0x0A /* FullAvailableCapacity() */
+#define BQ274XX_CMD_REM_CAPACITY 0x0C /* RemainingCapacity() */
+#define BQ274XX_CMD_FULL_CAPACITY 0x0E /* FullChargeCapacity() */
+#define BQ274XX_CMD_AVG_CURRENT 0x10 /* AverageCurrent() */
+#define BQ274XX_CMD_STDBY_CURRENT 0x12 /* StandbyCurrent() */
+#define BQ274XX_CMD_MAX_CURRENT 0x14 /* MaxLoadCurrent() */
+#define BQ274XX_CMD_AVG_POWER 0x18 /* AveragePower() */
+#define BQ274XX_CMD_SOC 0x1C /* StateOfCharge() */
+#define BQ274XX_CMD_INT_TEMP 0x1E /* InternalTemperature() */
+#define BQ274XX_CMD_SOH 0x20 /* StateOfHealth() */
+#define BQ274XX_CMD_REM_CAP_UNFL 0x28 /* RemainingCapacityUnfiltered() */
+#define BQ274XX_CMD_REM_CAP_FIL 0x2A /* RemainingCapacityFiltered() */
+#define BQ274XX_CMD_FULL_CAP_UNFL 0x2C /* FullChargeCapacityUnfiltered() */
+#define BQ274XX_CMD_FULL_CAP_FIL 0x2E /* FullChargeCapacityFiltered() */
+#define BQ274XX_CMD_SOC_UNFL 0x30 /* StateOfChargeUnfiltered() */
 
 /*** Control Sub-Commands ***/
-#define BQ274XX_CONTROL_STATUS 0x0000
-#define BQ274XX_CONTROL_DEVICE_TYPE 0x0001
-#define BQ274XX_CONTROL_FW_VERSION 0x0002
-#define BQ274XX_CONTROL_DM_CODE 0x0004
-#define BQ274XX_CONTROL_PREV_MACWRITE 0x0007
-#define BQ274XX_CONTROL_CHEM_ID 0x0008
-#define BQ274XX_CONTROL_BAT_INSERT 0x000C
-#define BQ274XX_CONTROL_BAT_REMOVE 0x000D
-#define BQ274XX_CONTROL_SET_HIBERNATE 0x0011
-#define BQ274XX_CONTROL_CLEAR_HIBERNATE 0x0012
-#define BQ274XX_CONTROL_SET_CFGUPDATE 0x0013
-#define BQ274XX_CONTROL_SHUTDOWN_ENABLE 0x001B
-#define BQ274XX_CONTROL_SHUTDOWN 0x001C
-#define BQ274XX_CONTROL_SEALED 0x0020
-#define BQ274XX_CONTROL_PULSE_SOC_INT 0x0023
-#define BQ274XX_CONTROL_RESET 0x0041
-#define BQ274XX_CONTROL_SOFT_RESET 0x0042
-#define BQ274XX_CONTROL_EXIT_CFGUPDATE 0x0043
-#define BQ274XX_CONTROL_EXIT_RESIM 0x0044
+#define BQ274XX_CTRL_STATUS 0x0000
+#define BQ274XX_CTRL_DEVICE_TYPE 0x0001
+#define BQ274XX_CTRL_FW_VERSION 0x0002
+#define BQ274XX_CTRL_DM_CODE 0x0004
+#define BQ274XX_CTRL_PREV_MACWRITE 0x0007
+#define BQ274XX_CTRL_CHEM_ID 0x0008
+#define BQ274XX_CTRL_BAT_INSERT 0x000C
+#define BQ274XX_CTRL_BAT_REMOVE 0x000D
+#define BQ274XX_CTRL_SET_HIBERNATE 0x0011
+#define BQ274XX_CTRL_CLEAR_HIBERNATE 0x0012
+#define BQ274XX_CTRL_SET_CFGUPDATE 0x0013
+#define BQ274XX_CTRL_SHUTDOWN_ENABLE 0x001B
+#define BQ274XX_CTRL_SHUTDOWN 0x001C
+#define BQ274XX_CTRL_SEALED 0x0020
+#define BQ274XX_CTRL_PULSE_SOC_INT 0x0023
+#define BQ274XX_CTRL_RESET 0x0041
+#define BQ274XX_CTRL_SOFT_RESET 0x0042
+#define BQ274XX_CTRL_EXIT_CFGUPDATE 0x0043
+#define BQ274XX_CTRL_EXIT_RESIM 0x0044
 
 /*** Extended Data Commands ***/
-#define BQ274XX_EXTENDED_OPCONFIG 0x3A /* OpConfig() */
-#define BQ274XX_EXTENDED_CAPACITY 0x3C /* DesignCapacity() */
-#define BQ274XX_EXTENDED_DATA_CLASS 0x3E /* DataClass() */
-#define BQ274XX_EXTENDED_DATA_BLOCK 0x3F /* DataBlock() */
-#define BQ274XX_EXTENDED_BLOCKDATA_START 0x40 /* BlockData_start() */
-#define BQ274XX_EXTENDED_BLOCKDATA_END 0x5F /* BlockData_end() */
-#define BQ274XX_EXTENDED_CHECKSUM 0x60 /* BlockDataCheckSum() */
-#define BQ274XX_EXTENDED_DATA_CONTROL 0x61 /* BlockDataControl() */
-#define BQ274XX_EXTENDED_BLOCKDATA_DESIGN_CAP_HIGH 0x4A /* BlockData */
-#define BQ274XX_EXTENDED_BLOCKDATA_DESIGN_CAP_LOW 0x4B
-#define BQ274XX_EXTENDED_BLOCKDATA_DESIGN_ENR_HIGH 0x4C
-#define BQ274XX_EXTENDED_BLOCKDATA_DESIGN_ENR_LOW 0x4D
-#define BQ274XX_EXTENDED_BLOCKDATA_TERMINATE_VOLT_HIGH 0x50
-#define BQ274XX_EXTENDED_BLOCKDATA_TERMINATE_VOLT_LOW 0x51
-#define BQ274XX_EXTENDED_BLOCKDATA_TAPERRATE_HIGH 0x5B
-#define BQ274XX_EXTENDED_BLOCKDATA_TAPERRATE_LOW 0x5C
+#define BQ274XX_EXT_OPCONFIG 0x3A /* OpConfig() */
+#define BQ274XX_EXT_CAPACITY 0x3C /* DesignCapacity() */
+#define BQ274XX_EXT_DATA_CLASS 0x3E /* DataClass() */
+#define BQ274XX_EXT_DATA_BLOCK 0x3F /* DataBlock() */
+#define BQ274XX_EXT_BLKDAT_START 0x40 /* BlockData_start() */
+#define BQ274XX_EXT_BLKDAT_END 0x5F /* BlockData_end() */
+#define BQ274XX_EXT_CHECKSUM 0x60 /* BlockDataCheckSum() */
+#define BQ274XX_EXT_DATA_CONTROL 0x61 /* BlockDataControl() */
+#define BQ274XX_EXT_BLKDAT_DESIGN_CAP_HIGH 0x4A /* BlockData */
+#define BQ274XX_EXT_BLKDAT_DESIGN_CAP_LOW 0x4B
+#define BQ274XX_EXT_BLKDAT_DESIGN_ENR_HIGH 0x4C
+#define BQ274XX_EXT_BLKDAT_DESIGN_ENR_LOW 0x4D
+#define BQ274XX_EXT_BLKDAT_TERMINATE_VOLT_HIGH 0x50
+#define BQ274XX_EXT_BLKDAT_TERMINATE_VOLT_LOW 0x51
+#define BQ274XX_EXT_BLKDAT_TAPERRATE_HIGH 0x5B
+#define BQ274XX_EXT_BLKDAT_TAPERRATE_LOW 0x5C
 
 #define BQ274XX_DELAY 1000
 

--- a/drivers/sensor/bq274xx/bq274xx.h
+++ b/drivers/sensor/bq274xx/bq274xx.h
@@ -12,69 +12,69 @@
 
 /*** General Constant ***/
 #define BQ274XX_UNSEAL_KEY 0x8000 /* Secret code to unseal the BQ27441-G1A */
-#define BQ274XX_DEVICE_ID 0x0421 /* Default device ID */
+#define BQ274XX_DEVICE_ID  0x0421 /* Default device ID */
 
 /*** Standard Commands ***/
-#define BQ274XX_CMD_CONTROL_LOW 0x00 /* Control() low register */
-#define BQ274XX_CMD_CONTROL_HIGH 0x01 /* Control() high register */
-#define BQ274XX_CMD_TEMP 0x02 /* Temperature() */
-#define BQ274XX_CMD_VOLTAGE 0x04 /* Voltage() */
-#define BQ274XX_CMD_FLAGS 0x06 /* Flags() */
-#define BQ274XX_CMD_NOM_CAPACITY 0x08 /* NominalAvailableCapacity() */
+#define BQ274XX_CMD_CONTROL_LOW    0x00 /* Control() low register */
+#define BQ274XX_CMD_CONTROL_HIGH   0x01 /* Control() high register */
+#define BQ274XX_CMD_TEMP           0x02 /* Temperature() */
+#define BQ274XX_CMD_VOLTAGE        0x04 /* Voltage() */
+#define BQ274XX_CMD_FLAGS          0x06 /* Flags() */
+#define BQ274XX_CMD_NOM_CAPACITY   0x08 /* NominalAvailableCapacity() */
 #define BQ274XX_CMD_AVAIL_CAPACITY 0x0A /* FullAvailableCapacity() */
-#define BQ274XX_CMD_REM_CAPACITY 0x0C /* RemainingCapacity() */
-#define BQ274XX_CMD_FULL_CAPACITY 0x0E /* FullChargeCapacity() */
-#define BQ274XX_CMD_AVG_CURRENT 0x10 /* AverageCurrent() */
-#define BQ274XX_CMD_STDBY_CURRENT 0x12 /* StandbyCurrent() */
-#define BQ274XX_CMD_MAX_CURRENT 0x14 /* MaxLoadCurrent() */
-#define BQ274XX_CMD_AVG_POWER 0x18 /* AveragePower() */
-#define BQ274XX_CMD_SOC 0x1C /* StateOfCharge() */
-#define BQ274XX_CMD_INT_TEMP 0x1E /* InternalTemperature() */
-#define BQ274XX_CMD_SOH 0x20 /* StateOfHealth() */
-#define BQ274XX_CMD_REM_CAP_UNFL 0x28 /* RemainingCapacityUnfiltered() */
-#define BQ274XX_CMD_REM_CAP_FIL 0x2A /* RemainingCapacityFiltered() */
-#define BQ274XX_CMD_FULL_CAP_UNFL 0x2C /* FullChargeCapacityUnfiltered() */
-#define BQ274XX_CMD_FULL_CAP_FIL 0x2E /* FullChargeCapacityFiltered() */
-#define BQ274XX_CMD_SOC_UNFL 0x30 /* StateOfChargeUnfiltered() */
+#define BQ274XX_CMD_REM_CAPACITY   0x0C /* RemainingCapacity() */
+#define BQ274XX_CMD_FULL_CAPACITY  0x0E /* FullChargeCapacity() */
+#define BQ274XX_CMD_AVG_CURRENT    0x10 /* AverageCurrent() */
+#define BQ274XX_CMD_STDBY_CURRENT  0x12 /* StandbyCurrent() */
+#define BQ274XX_CMD_MAX_CURRENT    0x14 /* MaxLoadCurrent() */
+#define BQ274XX_CMD_AVG_POWER      0x18 /* AveragePower() */
+#define BQ274XX_CMD_SOC            0x1C /* StateOfCharge() */
+#define BQ274XX_CMD_INT_TEMP       0x1E /* InternalTemperature() */
+#define BQ274XX_CMD_SOH            0x20 /* StateOfHealth() */
+#define BQ274XX_CMD_REM_CAP_UNFL   0x28 /* RemainingCapacityUnfiltered() */
+#define BQ274XX_CMD_REM_CAP_FIL    0x2A /* RemainingCapacityFiltered() */
+#define BQ274XX_CMD_FULL_CAP_UNFL  0x2C /* FullChargeCapacityUnfiltered() */
+#define BQ274XX_CMD_FULL_CAP_FIL   0x2E /* FullChargeCapacityFiltered() */
+#define BQ274XX_CMD_SOC_UNFL       0x30 /* StateOfChargeUnfiltered() */
 
 /*** Control Sub-Commands ***/
-#define BQ274XX_CTRL_STATUS 0x0000
-#define BQ274XX_CTRL_DEVICE_TYPE 0x0001
-#define BQ274XX_CTRL_FW_VERSION 0x0002
-#define BQ274XX_CTRL_DM_CODE 0x0004
-#define BQ274XX_CTRL_PREV_MACWRITE 0x0007
-#define BQ274XX_CTRL_CHEM_ID 0x0008
-#define BQ274XX_CTRL_BAT_INSERT 0x000C
-#define BQ274XX_CTRL_BAT_REMOVE 0x000D
-#define BQ274XX_CTRL_SET_HIBERNATE 0x0011
+#define BQ274XX_CTRL_STATUS          0x0000
+#define BQ274XX_CTRL_DEVICE_TYPE     0x0001
+#define BQ274XX_CTRL_FW_VERSION      0x0002
+#define BQ274XX_CTRL_DM_CODE         0x0004
+#define BQ274XX_CTRL_PREV_MACWRITE   0x0007
+#define BQ274XX_CTRL_CHEM_ID         0x0008
+#define BQ274XX_CTRL_BAT_INSERT      0x000C
+#define BQ274XX_CTRL_BAT_REMOVE      0x000D
+#define BQ274XX_CTRL_SET_HIBERNATE   0x0011
 #define BQ274XX_CTRL_CLEAR_HIBERNATE 0x0012
-#define BQ274XX_CTRL_SET_CFGUPDATE 0x0013
+#define BQ274XX_CTRL_SET_CFGUPDATE   0x0013
 #define BQ274XX_CTRL_SHUTDOWN_ENABLE 0x001B
-#define BQ274XX_CTRL_SHUTDOWN 0x001C
-#define BQ274XX_CTRL_SEALED 0x0020
-#define BQ274XX_CTRL_PULSE_SOC_INT 0x0023
-#define BQ274XX_CTRL_RESET 0x0041
-#define BQ274XX_CTRL_SOFT_RESET 0x0042
-#define BQ274XX_CTRL_EXIT_CFGUPDATE 0x0043
-#define BQ274XX_CTRL_EXIT_RESIM 0x0044
+#define BQ274XX_CTRL_SHUTDOWN        0x001C
+#define BQ274XX_CTRL_SEALED          0x0020
+#define BQ274XX_CTRL_PULSE_SOC_INT   0x0023
+#define BQ274XX_CTRL_RESET           0x0041
+#define BQ274XX_CTRL_SOFT_RESET      0x0042
+#define BQ274XX_CTRL_EXIT_CFGUPDATE  0x0043
+#define BQ274XX_CTRL_EXIT_RESIM      0x0044
 
 /*** Extended Data Commands ***/
-#define BQ274XX_EXT_OPCONFIG 0x3A /* OpConfig() */
-#define BQ274XX_EXT_CAPACITY 0x3C /* DesignCapacity() */
-#define BQ274XX_EXT_DATA_CLASS 0x3E /* DataClass() */
-#define BQ274XX_EXT_DATA_BLOCK 0x3F /* DataBlock() */
-#define BQ274XX_EXT_BLKDAT_START 0x40 /* BlockData_start() */
-#define BQ274XX_EXT_BLKDAT_END 0x5F /* BlockData_end() */
-#define BQ274XX_EXT_CHECKSUM 0x60 /* BlockDataCheckSum() */
-#define BQ274XX_EXT_DATA_CONTROL 0x61 /* BlockDataControl() */
-#define BQ274XX_EXT_BLKDAT_DESIGN_CAP_HIGH 0x4A /* BlockData */
-#define BQ274XX_EXT_BLKDAT_DESIGN_CAP_LOW 0x4B
-#define BQ274XX_EXT_BLKDAT_DESIGN_ENR_HIGH 0x4C
-#define BQ274XX_EXT_BLKDAT_DESIGN_ENR_LOW 0x4D
+#define BQ274XX_EXT_OPCONFIG                   0x3A /* OpConfig() */
+#define BQ274XX_EXT_CAPACITY                   0x3C /* DesignCapacity() */
+#define BQ274XX_EXT_DATA_CLASS                 0x3E /* DataClass() */
+#define BQ274XX_EXT_DATA_BLOCK                 0x3F /* DataBlock() */
+#define BQ274XX_EXT_BLKDAT_START               0x40 /* BlockData_start() */
+#define BQ274XX_EXT_BLKDAT_END                 0x5F /* BlockData_end() */
+#define BQ274XX_EXT_CHECKSUM                   0x60 /* BlockDataCheckSum() */
+#define BQ274XX_EXT_DATA_CONTROL               0x61 /* BlockDataControl() */
+#define BQ274XX_EXT_BLKDAT_DESIGN_CAP_HIGH     0x4A /* BlockData */
+#define BQ274XX_EXT_BLKDAT_DESIGN_CAP_LOW      0x4B
+#define BQ274XX_EXT_BLKDAT_DESIGN_ENR_HIGH     0x4C
+#define BQ274XX_EXT_BLKDAT_DESIGN_ENR_LOW      0x4D
 #define BQ274XX_EXT_BLKDAT_TERMINATE_VOLT_HIGH 0x50
-#define BQ274XX_EXT_BLKDAT_TERMINATE_VOLT_LOW 0x51
-#define BQ274XX_EXT_BLKDAT_TAPERRATE_HIGH 0x5B
-#define BQ274XX_EXT_BLKDAT_TAPERRATE_LOW 0x5C
+#define BQ274XX_EXT_BLKDAT_TERMINATE_VOLT_LOW  0x51
+#define BQ274XX_EXT_BLKDAT_TAPERRATE_HIGH      0x5B
+#define BQ274XX_EXT_BLKDAT_TAPERRATE_LOW       0x5C
 
 #define BQ274XX_DELAY 1000
 

--- a/drivers/sensor/bq274xx/bq274xx_trigger.c
+++ b/drivers/sensor/bq274xx/bq274xx_trigger.c
@@ -69,7 +69,7 @@ int bq274xx_trigger_mode_init(const struct device *dev)
 {
 	const struct bq274xx_config *const config = dev->config;
 	struct bq274xx_data *data = dev->data;
-	int status = 0;
+	int ret = 0;
 
 	data->dev = dev;
 
@@ -86,10 +86,10 @@ int bq274xx_trigger_mode_init(const struct device *dev)
 	k_work_init(&data->work, bq274xx_work_handler);
 #endif
 
-	status = gpio_pin_configure_dt(&config->int_gpios, GPIO_INPUT);
-	if (status < 0) {
+	ret = gpio_pin_configure_dt(&config->int_gpios, GPIO_INPUT);
+	if (ret < 0) {
 		LOG_ERR("Unable to configure interrupt pin to input");
-		return status;
+		return ret;
 	}
 	gpio_init_callback(&data->ready_callback,
 			   bq274xx_ready_callback_handler,
@@ -104,7 +104,7 @@ int bq274xx_trigger_set(const struct device *dev,
 {
 	const struct bq274xx_config *config = dev->config;
 	struct bq274xx_data *data = dev->data;
-	int status;
+	int ret;
 
 #ifdef CONFIG_BQ274XX_PM
 	enum pm_device_state state;
@@ -128,35 +128,35 @@ int bq274xx_trigger_set(const struct device *dev,
 	data->ready_trig = trig;
 
 	if (handler) {
-		status = gpio_pin_configure_dt(&config->int_gpios, GPIO_INPUT);
-		if (status < 0) {
-			LOG_ERR("Unable to configure interrupt pin to input (%d)", status);
-			return status;
+		ret = gpio_pin_configure_dt(&config->int_gpios, GPIO_INPUT);
+		if (ret < 0) {
+			LOG_ERR("Unable to configure interrupt pin to input (%d)", ret);
+			return ret;
 		}
 
-		status = gpio_add_callback(config->int_gpios.port, &data->ready_callback);
-		if (status < 0) {
-			LOG_ERR("Unable to add interrupt callback (%d)", status);
-			return status;
+		ret = gpio_add_callback(config->int_gpios.port, &data->ready_callback);
+		if (ret < 0) {
+			LOG_ERR("Unable to add interrupt callback (%d)", ret);
+			return ret;
 		}
 
-		status = gpio_pin_interrupt_configure_dt(&config->int_gpios,
+		ret = gpio_pin_interrupt_configure_dt(&config->int_gpios,
 							 GPIO_INT_EDGE_TO_ACTIVE);
-		if (status < 0) {
-			LOG_ERR("Unable to configure interrupt (%d)", status);
-			return status;
+		if (ret < 0) {
+			LOG_ERR("Unable to configure interrupt (%d)", ret);
+			return ret;
 		}
 	} else {
-		status = gpio_remove_callback(config->int_gpios.port, &data->ready_callback);
-		if (status < 0) {
-			LOG_ERR("Unable to remove interrupt callback (%d)", status);
-			return status;
+		ret = gpio_remove_callback(config->int_gpios.port, &data->ready_callback);
+		if (ret < 0) {
+			LOG_ERR("Unable to remove interrupt callback (%d)", ret);
+			return ret;
 		}
 
-		status = gpio_pin_interrupt_configure_dt(&config->int_gpios, GPIO_INT_DISABLE);
-		if (status < 0) {
-			LOG_ERR("Unable to configure interrupt (%d)", status);
-			return status;
+		ret = gpio_pin_interrupt_configure_dt(&config->int_gpios, GPIO_INT_DISABLE);
+		if (ret < 0) {
+			LOG_ERR("Unable to configure interrupt (%d)", ret);
+			return ret;
 		}
 	}
 

--- a/drivers/sensor/bq274xx/bq274xx_trigger.c
+++ b/drivers/sensor/bq274xx/bq274xx_trigger.c
@@ -49,11 +49,11 @@ static void work_handler(struct k_work *work)
 }
 #endif
 
-static void ready_callback_handler(const struct device *port,
-					   struct gpio_callback *cb,
-					   gpio_port_pins_t pins)
+static void ready_callback_handler(const struct device *port, struct gpio_callback *cb,
+				   gpio_port_pins_t pins)
 {
-	struct bq274xx_data *data = CONTAINER_OF(cb, struct bq274xx_data, ready_callback);
+	struct bq274xx_data *data = CONTAINER_OF(cb, struct bq274xx_data,
+						 ready_callback);
 
 	ARG_UNUSED(port);
 	ARG_UNUSED(pins);
@@ -88,7 +88,7 @@ int bq274xx_trigger_mode_init(const struct device *dev)
 
 	ret = gpio_pin_configure_dt(&config->int_gpios, GPIO_INPUT);
 	if (ret < 0) {
-		LOG_ERR("Unable to configure interrupt pin to input");
+		LOG_ERR("Unable to configure interrupt pin");
 		return ret;
 	}
 	gpio_init_callback(&data->ready_callback,
@@ -120,7 +120,7 @@ int bq274xx_trigger_set(const struct device *dev,
 	}
 
 	if (!device_is_ready(config->int_gpios.port)) {
-		LOG_ERR("GPIO device pointer is not ready to be used");
+		LOG_ERR("GPIO device is not ready");
 		return -ENODEV;
 	}
 
@@ -130,32 +130,34 @@ int bq274xx_trigger_set(const struct device *dev,
 	if (handler) {
 		ret = gpio_pin_configure_dt(&config->int_gpios, GPIO_INPUT);
 		if (ret < 0) {
-			LOG_ERR("Unable to configure interrupt pin to input (%d)", ret);
+			LOG_ERR("Unable to configure interrupt pin: %d", ret);
 			return ret;
 		}
 
-		ret = gpio_add_callback(config->int_gpios.port, &data->ready_callback);
+		ret = gpio_add_callback(config->int_gpios.port,
+					&data->ready_callback);
 		if (ret < 0) {
-			LOG_ERR("Unable to add interrupt callback (%d)", ret);
+			LOG_ERR("Unable to add interrupt callback: %d", ret);
 			return ret;
 		}
 
 		ret = gpio_pin_interrupt_configure_dt(&config->int_gpios,
-							 GPIO_INT_EDGE_TO_ACTIVE);
+						      GPIO_INT_EDGE_TO_ACTIVE);
 		if (ret < 0) {
-			LOG_ERR("Unable to configure interrupt (%d)", ret);
+			LOG_ERR("Unable to configure interrupt: %d", ret);
 			return ret;
 		}
 	} else {
-		ret = gpio_remove_callback(config->int_gpios.port, &data->ready_callback);
+		ret = gpio_remove_callback(config->int_gpios.port,
+					   &data->ready_callback);
 		if (ret < 0) {
-			LOG_ERR("Unable to remove interrupt callback (%d)", ret);
+			LOG_ERR("Unable to remove interrupt callback: %d", ret);
 			return ret;
 		}
 
 		ret = gpio_pin_interrupt_configure_dt(&config->int_gpios, GPIO_INT_DISABLE);
 		if (ret < 0) {
-			LOG_ERR("Unable to configure interrupt (%d)", ret);
+			LOG_ERR("Unable to disable interrupt: %d", ret);
 			return ret;
 		}
 	}

--- a/drivers/sensor/bq274xx/bq274xx_trigger.c
+++ b/drivers/sensor/bq274xx/bq274xx_trigger.c
@@ -18,7 +18,7 @@
 
 LOG_MODULE_DECLARE(bq274xx, CONFIG_SENSOR_LOG_LEVEL);
 
-static void bq274xx_handle_interrupts(const struct device *dev)
+static void handle_interrupts(const struct device *dev)
 {
 	struct bq274xx_data *data = dev->data;
 
@@ -31,25 +31,25 @@ static void bq274xx_handle_interrupts(const struct device *dev)
 static K_KERNEL_STACK_DEFINE(bq274xx_thread_stack, CONFIG_BQ274XX_THREAD_STACK_SIZE);
 static struct k_thread bq274xx_thread;
 
-static void bq274xx_thread_main(struct bq274xx_data *data)
+static void thread_main(struct bq274xx_data *data)
 {
 	while (1) {
 		k_sem_take(&data->sem, K_FOREVER);
-		bq274xx_handle_interrupts(data->dev);
+		handle_interrupts(data->dev);
 	}
 }
 #endif
 
 #ifdef CONFIG_BQ274XX_TRIGGER_GLOBAL_THREAD
-static void bq274xx_work_handler(struct k_work *work)
+static void work_handler(struct k_work *work)
 {
 	struct bq274xx_data *data = CONTAINER_OF(work, struct bq274xx_data, work);
 
-	bq274xx_handle_interrupts(data->dev);
+	handle_interrupts(data->dev);
 }
 #endif
 
-static void bq274xx_ready_callback_handler(const struct device *port,
+static void ready_callback_handler(const struct device *port,
 					   struct gpio_callback *cb,
 					   gpio_port_pins_t pins)
 {
@@ -78,12 +78,12 @@ int bq274xx_trigger_mode_init(const struct device *dev)
 
 	k_thread_create(&bq274xx_thread, bq274xx_thread_stack,
 			CONFIG_BQ274XX_THREAD_STACK_SIZE,
-			(k_thread_entry_t)bq274xx_thread_main,
+			(k_thread_entry_t)thread_main,
 			data, NULL, NULL,
 			K_PRIO_COOP(CONFIG_BQ274XX_THREAD_PRIORITY),
 			0, K_NO_WAIT);
 #elif defined(CONFIG_BQ274XX_TRIGGER_GLOBAL_THREAD)
-	k_work_init(&data->work, bq274xx_work_handler);
+	k_work_init(&data->work, work_handler);
 #endif
 
 	ret = gpio_pin_configure_dt(&config->int_gpios, GPIO_INPUT);
@@ -92,7 +92,7 @@ int bq274xx_trigger_mode_init(const struct device *dev)
 		return ret;
 	}
 	gpio_init_callback(&data->ready_callback,
-			   bq274xx_ready_callback_handler,
+			   ready_callback_handler,
 			   BIT(config->int_gpios.pin));
 
 	return 0;


### PR DESCRIPTION
I can see more issues with this driver I would like to fix but hoping to get this code cleanup in first.

The majority of the commits are taken (with permission from @olsky) from PR: https://github.com/zephyrproject-rtos/zephyr/pull/56256

- Reduce line lengths and broken line count of driver
- Use more common and shorter variable names.
- Use shorter macro names.
- Remove prefixes from static function names to improve logging output.

