### PR TITLE
docs: bluetooth: mesh: Add note about storing runtime configuration

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/cfg.rst
+++ b/doc/connectivity/bluetooth/api/mesh/cfg.rst
@@ -14,6 +14,10 @@ cases, the mesh node can't rely on the Configuration Client to detect or determi
 local constraints, such as low battery power or changes in topology. For these
 scenarios, this API can be used to change the configuration locally.
 
+.. note::
+   Runtime configuration changes before the node is provisioned will not be stored
+   in the :ref:`persistent storage <bluetooth_mesh_persistent_storage>`.
+
 API reference
 *************
 

--- a/doc/connectivity/bluetooth/api/mesh/core.rst
+++ b/doc/connectivity/bluetooth/api/mesh/core.rst
@@ -67,6 +67,8 @@ vulnerability and flash wear out.
    the RPL between reboots, will make the device vulnerable to replay attacks
    and not perform the replay protection required by the spec.
 
+.. _bluetooth_mesh_persistent_storage:
+
 Persistent storage
 ******************
 


### PR DESCRIPTION
All public API declared in cfg.h won't schedule storing of the change persistently if BT_MESH_VALID flag is not set. The flag is set after the node is provisioned.