### PR TITLE
ci: workflows: create cache directory for ccache

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -94,6 +94,7 @@ jobs:
 
       - name: ccache stats initial
         run: |
+          mkdir -p /github/home/.cache
           test -d github/home/.cache/ccache && rm -rf /github/home/.cache/ccache && mv github/home/.cache/ccache /github/home/.cache/ccache
           ccache -M 10G -s
 

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -78,6 +78,7 @@ jobs:
 
       - name: ccache stats initial
         run: |
+          mkdir -p /github/home/.cache
           test -d github/home/.cache/ccache && mv github/home/.cache/ccache /github/home/.cache/ccache
           ccache -M 10G -s
 

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -208,6 +208,7 @@ jobs:
 
       - name: ccache stats initial
         run: |
+          mkdir -p /github/home/.cache
           test -d github/home/.cache/ccache && rm -rf /github/home/.cache/ccache && mv github/home/.cache/ccache /github/home/.cache/ccache
           ccache -M 10G -s
 


### PR DESCRIPTION
Create cache directory before moving ccache.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
