### PR TITLE
doc: Cleanup dead links in the documentation.

### DIFF
--- a/boards/arm/adafruit_feather_m0_lora/doc/index.rst
+++ b/boards/arm/adafruit_feather_m0_lora/doc/index.rst
@@ -167,7 +167,7 @@ References
 .. target-notes::
 
 .. _Adafruit Feather M0 with LoRa radio module Learn site:
-    https://learn.adafruit.com/adafruit-feather-m0-radio-with-lora-radio-module.
+    https://learn.adafruit.com/adafruit-feather-m0-radio-with-lora-radio-module
 
 .. _pinouts:
     https://learn.adafruit.com/adafruit-feather-m0-radio-with-lora-radio-module/pinouts

--- a/boards/arm/arduino_nicla_sense_me/doc/index.rst
+++ b/boards/arm/arduino_nicla_sense_me/doc/index.rst
@@ -137,7 +137,7 @@ References
    https://docs.arduino.cc/resources/datasheets/ABX00050-datasheet.pdf
 
 .. _full pinout:
-    https://docs.arduino.cc/static/5eff7076d9a031ce823972d6f1faac4a/ABX00050-full-pinout.pdf
+    https://docs.arduino.cc/static/b35956b631d757a0455c286da441641b/ABX00050-full-pinout.pdf
 
 .. _schematics:
-    https://docs.arduino.cc/static/aa5abe05aeec6f8b5fe6f3f605a986b5/ABX00050-schematics.pdf
+    https://docs.arduino.cc/static/ebd652e859efba8536a7e275c79d5f79/ABX00050-schematics.pdf

--- a/boards/arm/bl5340_dvk/doc/index.rst
+++ b/boards/arm/bl5340_dvk/doc/index.rst
@@ -424,7 +424,7 @@ References
 .. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
 .. _TI TCA9538 datasheet: https://www.ti.com/lit/gpn/TCA9538
 .. _Macronix MX25R6435FZNIL0 datasheet: https://www.macronix.com/Lists/Datasheet/Attachments/8868/MX25R6435F,%20Wide%20Range,%2064Mb,%20v1.6.pdf
-.. _Giantec GT24C256C-2GLI-TR datasheet: http://www.giantec-semi.com/Upload/datasheet/CU/GT24C256C_DS_Cu.pdf
+.. _Giantec GT24C256C-2GLI-TR datasheet: https://www.giantec-semi.com/juchen1123/uploads/pdf/GT24C256C_DS_Cu.pdf
 .. _Bosch BME680 datasheet: https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme680-ds001.pdf
 .. _ST Microelectronics LIS3DH datasheet: https://www.st.com/resource/en/datasheet/lis3dh.pdf
 .. _Microchip ENC424J600 datasheet: https://ww1.microchip.com/downloads/en/DeviceDoc/39935c.pdf

--- a/boards/arm/blackpill_f401cc/doc/index.rst
+++ b/boards/arm/blackpill_f401cc/doc/index.rst
@@ -153,13 +153,13 @@ References
 .. target-notes::
 
 .. _board release notes:
-   https://github.com/WeActTC/MiniF4-STM32F4x1/blob/master/HDK/README.md
+   https://github.com/WeActStudio/WeActStudio.MiniSTM32F4x1/blob/master/HDK/README.md
 
 .. _Zadig:
    https://zadig.akeo.ie/
 
 .. _WeAct Github:
-   https://github.com/WeActTC/MiniF4-STM32F4x1
+   https://github.com/WeActStudio/WeActStudio.MiniSTM32F4x1
 
 .. _stm32-base-board-page:
    https://stm32-base.org/boards/STM32F401CCU6-WeAct-Black-Pill-V1.2.html

--- a/boards/arm/blackpill_f401ce/doc/index.rst
+++ b/boards/arm/blackpill_f401ce/doc/index.rst
@@ -158,13 +158,13 @@ References
 .. target-notes::
 
 .. _board release notes:
-   https://github.com/WeActTC/MiniF4-STM32F4x1/blob/master/HDK/README.md
+   https://github.com/WeActStudio/WeActStudio.MiniSTM32F4x1/blob/master/HDK/README.md
 
 .. _Zadig:
    https://zadig.akeo.ie/
 
 .. _WeAct Github:
-   https://github.com/WeActTC/MiniF4-STM32F4x1
+   https://github.com/WeActStudio/WeActStudio.MiniSTM32F4x1
 
 .. _stm32-base-board-page:
    https://stm32-base.org/boards/STM32F401CEU6-WeAct-Black-Pill-V3.0.html

--- a/boards/arm/blackpill_f411ce/doc/index.rst
+++ b/boards/arm/blackpill_f411ce/doc/index.rst
@@ -158,13 +158,13 @@ References
 .. target-notes::
 
 .. _board release notes:
-   https://github.com/WeActTC/MiniF4-STM32F4x1/blob/master/HDK/README.md
+   https://github.com/WeActStudio/WeActStudio.MiniSTM32F4x1/blob/master/HDK/README.md
 
 .. _Zadig:
    https://zadig.akeo.ie/
 
 .. _WeAct Github:
-   https://github.com/WeActTC/MiniF4-STM32F4x1
+   https://github.com/WeActStudio/WeActStudio.MiniSTM32F4x1
 
 .. _stm32-base-board-page:
    https://stm32-base.org/boards/STM32F411CEU6-WeAct-Black-Pill-V2.0.html

--- a/boards/arm/bt510/doc/bt510.rst
+++ b/boards/arm/bt510/doc/bt510.rst
@@ -254,7 +254,7 @@ References
 
 .. _Sentrius BT510 website: https://www.lairdconnect.com/iot-devices/iot-sensors/bt510-bluetooth-5-long-range-ip67-multi-sensor
 .. _TagConnect TC2050 product page: https://www.tag-connect.com/product/tc2050-idc-050
-.. _USB SWD Programmer product page: https://www.lairdconnect.com/usb-swd-programmer/
+.. _USB SWD Programmer product page: https://www.lairdconnect.com/wireless-modules/programming-kits/usb-swd-programming-kit
 .. _MAX3232 datasheet: https://www.ti.com/lit/ds/symlink/max3232.pdf
 .. _Silabs 7055 datasheet: https://www.silabs.com/documents/public/data-sheets/Si7050-1-3-4-5-A20.pdf
 .. _ST Microelectronics LIS2DH datasheet: https://www.st.com/resource/en/datasheet/lis2dh.pdf

--- a/boards/arm/cy8ckit_062_wifi_bt/doc/index.rst
+++ b/boards/arm/cy8ckit_062_wifi_bt/doc/index.rst
@@ -99,7 +99,7 @@ The board configuration supports the following hardware features:
 
 
 The default configuration can be found in the Kconfig
-:zephyr_file:`boards/arm/cy8ckit_062_wifi_bt_m0/cy8ckit_062_wifi_bt_m0_defconfig`.
+:zephyr_file:`boards/arm/cy8ckit_062_wifi_bt/cy8ckit_062_wifi_bt_m0_defconfig`.
 
 
 System Clock

--- a/boards/arm/mimx8mp_phyboard_pollux/doc/index.rst
+++ b/boards/arm/mimx8mp_phyboard_pollux/doc/index.rst
@@ -75,7 +75,7 @@ features:
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
-:zephyr_file:`boards/arm/mimx8mp_phyboard_polis/mimx8mm_phyboard_polis_defconfig`.
+:zephyr_file:`boards/arm/mimx8mp_phyboard_pollux/mimx8mp_phyboard_pollux_defconfig`.
 
 It's recommended to disable peripherals used by the M7-Core on the host running
 on the Linux host.

--- a/boards/arm/mm_feather/doc/index.rst
+++ b/boards/arm/mm_feather/doc/index.rst
@@ -235,4 +235,4 @@ should see the following message in the terminal:
    https://madmachine.io
 
 .. _SwiftIO API Reference:
-   https://swiftioapi.madmachine.io
+   https://madmachineio.github.io/SwiftIO/documentation/swiftio/

--- a/boards/arm/raytac_mdbt50q_db_33_nrf52833/doc/index.rst
+++ b/boards/arm/raytac_mdbt50q_db_33_nrf52833/doc/index.rst
@@ -208,6 +208,6 @@ References
 .. _MDBT50Q-DB-33 Specification:
 	https://www.raytac.com/download/index.php?index_id=46
 .. _MDBT50Q-DB-33 Schematic:
-	https://www.raytac.com/upload/catalog_b/da53e5bd46d899e68bd4c323716dfa82.jpg
+	https://www.raytac.com/upload/catalog_b/407c1150fa33511a47e8a2f85d106ff3.jpg
 .. _J-Link Software and documentation pack:
 	https://www.segger.com/jlink-software.html

--- a/boards/arm/ronoth_lodev/doc/s76s.rst
+++ b/boards/arm/ronoth_lodev/doc/s76s.rst
@@ -231,7 +231,7 @@ References
 
 .. _AcSIP S76S: http://www.acsip.com.tw/index.php?action=products-detail&fid1=11&fid2=29&fid3=27&id=79&lang=3
 
-.. _AcSIP S76S Product Information Brief: http://www.acsip.com.tw/upload/product_attach/S76S_Brief_ver02.pdf
+.. _AcSIP S76S Product Information Brief: https://www.acsip.com.tw/index.php?action=download_pro&perm=d&id=365
 
 .. _AcSIP Product Data Download: http://www.acsip.com.tw/index.php?action=technical
 
@@ -241,7 +241,7 @@ References
 
 .. _LoDev: https://ronoth.com/products/lodev-s76s-lora-soc-development-board?variant=31608819417220
 
-.. _STMicro STM32L073RZ: STMicro STM32L073RZ
+.. _STMicro STM32L073RZ: https://www.st.com/en/microcontrollers-microprocessors/stm32l073rz.html
 
 .. _Semtech SX1276: https://www.semtech.com/products/wireless-rf/lora-transceivers/sx1276
 

--- a/boards/arm/stm32f4_disco/doc/index.rst
+++ b/boards/arm/stm32f4_disco/doc/index.rst
@@ -211,4 +211,4 @@ You can debug an application in the usual way.  Here is an example for the
    http://www.st.com/resource/en/reference_manual/dm00031020.pdf
 
 .. _SK Pang CAN breakout board:
-   http://skpang.co.uk/catalog/canbus-can-fd-breakout-board-5v-p-242.html
+   https://www.skpang.co.uk/products/can-bus-can-fd-breakout-board-5v-supply-and-3-3v-logic

--- a/boards/arm/tdk_robokit1/doc/index.rst
+++ b/boards/arm/tdk_robokit1/doc/index.rst
@@ -107,7 +107,7 @@ features:
      - N/A
 
 The default configuration can be found in the Kconfig
-:zephyr_file:`boards/arm/tdk_robokit1/tdk_robotkit1_defconfig`.
+:zephyr_file:`boards/arm/tdk_robokit1/tdk_robokit1_defconfig`.
 
 Connections and IOs
 ===================

--- a/boards/arm/v2m_musca_b1/doc/index.rst
+++ b/boards/arm/v2m_musca_b1/doc/index.rst
@@ -399,7 +399,7 @@ serial port:
    https://developer.arm.com/documentation/dto0051/latest/subsystem-overview/about-the-sse-200
 
 .. _Srecord Manual:
-   http://srecord.sourceforge.net/man/man1/srec_cat.html
+   https://srecord.sourceforge.net/man/man1/srec_cat.1.html
 
 .. _IDAU:
    https://developer.arm.com/documentation/100690/latest/Attribution-units--SAU-and-IDAU-

--- a/boards/arm/v2m_musca_s1/doc/index.rst
+++ b/boards/arm/v2m_musca_s1/doc/index.rst
@@ -427,7 +427,7 @@ corresponding TF-M integration example's README file.
    https://developer.arm.com/documentation/dto0051/latest/subsystem-overview/about-the-sse-200
 
 .. _Srecord Manual:
-   http://srecord.sourceforge.net/man/man1/srec_cat.html
+   https://srecord.sourceforge.net/man/man1/srec_cat.1.html
 
 .. _IDAU:
    https://developer.arm.com/documentation/100690/latest/Attribution-units--SAU-and-IDAU-

--- a/boards/xtensa/esp32_net/doc/index.rst
+++ b/boards/xtensa/esp32_net/doc/index.rst
@@ -165,5 +165,5 @@ References
 .. _`ESP32 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
 .. _`JTAG debugging for ESP32`: http://esp-idf.readthedocs.io/en/latest/api-guides/jtag-debugging/index.html
 .. _`Hardware Reference`: https://esp-idf.readthedocs.io/en/latest/hw-reference/index.html
-.. _`ESP-WROVER-32 V3 Getting Started Guide`: https://dl.espressif.com/doc/esp-idf/latest/get-started/get-started-wrover-kit.html
+.. _`ESP-WROVER-32 V3 Getting Started Guide`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-wrover-kit.html
 .. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/doc/build/snippets/writing.rst
+++ b/doc/build/snippets/writing.rst
@@ -58,7 +58,7 @@ The build system looks for snippets in these places:
 
 #. In directories configured by the :makevar:`SNIPPET_ROOT` CMake variable.
    This always includes the zephyr repository (so
-   :zephyr_file:`zephyr/snippets` is always a source of snippets) and the
+   :zephyr_file:`snippets/` is always a source of snippets) and the
    application source directory (so :file:`<app>/snippets` is also).
 
    Additional directories can be added manually at CMake time.

--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -631,7 +631,7 @@ part of the sysbuild build invocation, but ``west flash`` or ``west debug``
 will not be aware of the application. Instead, you must manually flash and
 debug the application.
 
-.. _MCUboot with Zephyr: https://mcuboot.com/documentation/readme-zephyr/
+.. _MCUboot with Zephyr: https://docs.mcuboot.com/readme-zephyr
 .. _ExternalProject: https://cmake.org/cmake/help/latest/module/ExternalProject.html
 
 Extending sysbuild

--- a/doc/contribute/contributor_expectations.rst
+++ b/doc/contribute/contributor_expectations.rst
@@ -121,7 +121,7 @@ PR Requirements
       :zephyr_file:`kernel timer <kernel/timer.c>`, measured by lines of code.
     - Emulators for off-chip peripherals are an effective way to test driver
       APIs. The :zephyr_file:`fuel gauge tests <tests/drivers/fuel_gauge/sbs_gauge>`
-      use the :zephyr_file:`smart battery emulator <drivers/sensor/sbs_gauge/emul_sbs_gauge.c>`,
+      use the :zephyr_file:`smart battery emulator <drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c>`,
       providing test coverage for the
       :zephyr_file:`fuel gauge API <include/zephyr/drivers/fuel_gauge.h>`
       and the :zephyr_file:`smart battery driver <drivers/fuel_gauge/sbs_gauge/sbs_gauge.c>`.

--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -138,7 +138,7 @@ source files that are compiled to generate the built library files.
   document, :file:`sdk.spdx`, which lists header files included from the SDK.
 
 .. _SPDX specification clause 6:
-   https://spdx.github.io/spdx-spec/document-creation-information/
+   https://spdx.github.io/spdx-spec/v2.2.2/document-creation-information/
 
 .. _west-blobs:
 

--- a/doc/hardware/peripherals/auxdisplay.rst
+++ b/doc/hardware/peripherals/auxdisplay.rst
@@ -8,7 +8,7 @@ Overview
 
 Auxiliary Displays are text-based displays that have simple interfaces for
 displaying textual, numeric or alphanumeric data, as opposed to the
-`Display API <display_api>`_, auxiliary displays do not support custom
+:ref:`display_api`, auxiliary displays do not support custom
 graphical output to displays (and and most often monochrome), the most
 advanced custom feature supported is generation of custom characters.
 These inexpensive displays are commonly found with various configurations

--- a/doc/hardware/peripherals/i2c.rst
+++ b/doc/hardware/peripherals/i2c.rst
@@ -12,7 +12,7 @@ Overview
    `NXP I2C Bus Specification Rev 7.0 <i2c-specification_>`_. These changed
    from previous revisions as of its release October 1, 2021.
 
-`I2C <i2c-specification>`_ (Inter-Integrated Circuit, pronounced "eye
+`I2C`_ (Inter-Integrated Circuit, pronounced "eye
 squared see") is a commonly-used two-signal shared peripheral interface
 bus.  Many system-on-chip solutions provide controllers that communicate
 on an I2C bus.  Devices on the bus can operate in two roles: as a
@@ -63,3 +63,5 @@ API Reference
 
 .. _i2c-specification:
    https://www.nxp.com/docs/en/user-guide/UM10204.pdf
+
+.. _I2C: i2c-specification_

--- a/doc/hardware/pinctrl/index.rst
+++ b/doc/hardware/pinctrl/index.rst
@@ -502,4 +502,4 @@ Dynamic pin control
 Other reference material
 ************************
 
-- `Introduction to pin muxing and GPIO control under Linux <https://static.sched.com/hosted_files/osselc21/b6/ELC-2021_Introduction_to_pin_muxing_and_GPIO_control_under_Linux.pdf>`_
+- `Introduction to pin muxing and GPIO control under Linux <https://elinux.org/images/a/a7/ELC-2021_Introduction_to_pin_muxing_and_GPIO_control_under_Linux.pdf>`_

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -174,8 +174,8 @@ Changes in this release
   :c:struct:`fs_mgmt_file_access` for the new structure definition.
 
 * Iterable sections API is now available at
-  :zephyr_file:`zephyr/sys/iterable_sections.h`. LD linker snippets are
-  available at :zephyr_file:`zephyr/linker/iterable_sections.h`.
+  :zephyr_file:`include/zephyr/sys/iterable_sections.h`. LD linker snippets are
+  available at :zephyr_file:`include/zephyr/linker/iterable_sections.h`.
 
 * Cache API functions are now fully inlined by compilers.
 

--- a/doc/services/device_mgmt/dfu.rst
+++ b/doc/services/device_mgmt/dfu.rst
@@ -86,5 +86,5 @@ More detailed information regarding the use of MCUboot with Zephyr  can be found
 in the `MCUboot with Zephyr`_ documentation page on the MCUboot website.
 
 .. _MCUboot boot loader: https://mcuboot.com/
-.. _MCUboot with Zephyr: https://mcuboot.com/documentation/readme-zephyr/
+.. _MCUboot with Zephyr: https://docs.mcuboot.com/readme-zephyr
 .. _MCUboot GitHub Project: https://github.com/runtimeco/mcuboot

--- a/doc/services/device_mgmt/mcumgr_backporting.rst
+++ b/doc/services/device_mgmt/mcumgr_backporting.rst
@@ -14,7 +14,7 @@ version of Zephyr (backports), and one for issues that are being fixed only in a
 
 The upstream MCUmgr repository is located `in this page <https://github.com/apache/mynewt-mcumgr>`_.
 The Zephyr fork used in version 2.7 and earlier is `located here <https://github.com/zephyrproject-rtos/mcumgr>`_.
-Versions of Zephyr past 2.7 use the MCUmgr library that is `part of the Zephyr code base <https://github.com/zephyrproject-rtos/zephyr/tree/main/subsys/mgmt/mcumgr/lib>`_.
+Versions of Zephyr past 2.7 use the MCUmgr library that is `part of the Zephyr code base <https://github.com/zephyrproject-rtos/zephyr/tree/main/subsys/mgmt/mcumgr>`_.
 
 Possible origins of a code change
 *********************************

--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -198,7 +198,7 @@ where:
 .. note::
     For more information on how does image/slots function, please refer to
     the MCUBoot documentation
-    https://www.mcuboot.com/documentation/design/#image-slots
+    https://docs.mcuboot.com/design.html#image-slots
     For information on MCUboot image format, please reset to the MCUboot
     documentation https://docs.mcuboot.com/design.html#image-format
 

--- a/doc/services/storage/flash_map/flash_map.rst
+++ b/doc/services/storage/flash_map/flash_map.rst
@@ -72,7 +72,7 @@ documentation`_ for more details.
 The ``storage_partition`` node is defined for use by a file system or other
 nonvolatile storage API.
 
-.. _MCUboot documentation: https://mcuboot.com/
+.. _MCUboot documentation: https://docs.mcuboot.com
 
 Numeric flash area ID is obtained by passing DTS node label to
 :c:macro:`FIXED_PARTITION_ID()`; for example to obtain ID number

--- a/doc/services/tfm/requirements.rst
+++ b/doc/services/tfm/requirements.rst
@@ -76,4 +76,4 @@ And on OS X via:
 
 For Windows-based systems, please make sure you have a copy of the utility
 available on your system path. See, for example:
-`SRecord for Windows <http://srecord.sourceforge.net/windows.html>`_
+`SRecord for Windows <https://sourceforge.net/projects/srecord/files/srecord-win32>`_

--- a/samples/bluetooth/hci_uart/README.rst
+++ b/samples/bluetooth/hci_uart/README.rst
@@ -147,7 +147,7 @@ Check the :ref:`bluetooth_direction_finding_connectionless_rx` and the :ref:`blu
 Using a USB CDC ACM UART
 ========================
 
-The sample can be configured to use a USB UART instead. See :zephyr_file:`samples/bluetooth/hci_uart/nrf52840dongle_nrf52840.conf` and :zephyr_file:`samples/bluetooth/hci_uart/nrf52840dongle_nrf52840.overlay`.
+The sample can be configured to use a USB UART instead. See :zephyr_file:`samples/bluetooth/hci_uart/boards/nrf52840dongle_nrf52840.conf` and :zephyr_file:`samples/bluetooth/hci_uart/boards/nrf52840dongle_nrf52840.overlay`.
 
 Using the controller with the Zephyr host
 =========================================

--- a/samples/bluetooth/unicast_audio_client/README.rst
+++ b/samples/bluetooth/unicast_audio_client/README.rst
@@ -19,6 +19,6 @@ Requirements
 Building and Running
 ********************
 This sample can be found under
-:zephyr_file:`samples/bluetooth/audio_unicast_client` in the Zephyr tree.
+:zephyr_file:`samples/bluetooth/unicast_audio_client` in the Zephyr tree.
 
 See :ref:`bluetooth samples section <bluetooth-samples>` for details.

--- a/samples/boards/esp32/flash_encryption/README.rst
+++ b/samples/boards/esp32/flash_encryption/README.rst
@@ -109,4 +109,4 @@ memory reading using proper spi_flash call, which decrypts the content as expect
    https://docs.espressif.com/projects/esp-idf/en/latest/esp32/security/flash-encryption.html
 
 .. _MCUBoot Readme:
-   https://www.mcuboot.com/documentation/readme-espressif/
+   https://docs.mcuboot.com/readme-espressif

--- a/samples/boards/qomu/README.rst
+++ b/samples/boards/qomu/README.rst
@@ -9,7 +9,7 @@ usbserial driver.
 Requirements
 ************
 * Zephyr RTOS with printk enabled
-* `QuickLogic Qomu board <https://github.com/QuickLogic-Corp/qomu-feather-dev-board>`_
+* `QuickLogic Qomu board <https://www.quicklogic.com/products/eos-s3/quickfeather-development-kit/>`_
 
 Building
 ********

--- a/samples/drivers/auxdisplay/README.rst
+++ b/samples/drivers/auxdisplay/README.rst
@@ -15,7 +15,7 @@ Building and Running
 Note that this sample requires a board with an auxiliary display setup. A
 sample overlay is provided for the `nucleo_f746zg` board fly-wired to a Hitachi
 HD44780-compatible 20 character by 4 line display. See the overlay file
-:zephyr_file:`samples/drivers/auxdisplayboards/nucleo_f746zg.overlay` for
+:zephyr_file:`samples/drivers/auxdisplay/boards/nucleo_f746zg.overlay` for
 wiring configuration.
 
 .. zephyr-app-commands::

--- a/samples/drivers/ipm/ipm_mhu_dual_core/README.rst
+++ b/samples/drivers/ipm/ipm_mhu_dual_core/README.rst
@@ -80,4 +80,4 @@ Sample Output
 
 
 .. _Srecord Manual:
-   http://srecord.sourceforge.net/man/man1/srec_cat.html
+   https://srecord.sourceforge.net/man/man1/srec_cat.1.html

--- a/samples/modules/canopennode/README.rst
+++ b/samples/modules/canopennode/README.rst
@@ -433,13 +433,13 @@ generation.
 
 A popular choice is the EDS editor from the `libedssharp`_
 project. With that, the
-:zephyr_file:`samples/modules/canopennode/objdict/objdicts.xml`
+:zephyr_file:`samples/modules/canopennode/objdict/objdict.xml`
 project file can be opened and modified, and new implementation files
 (:zephyr_file:`samples/modules/canopennode/objdict/CO_OD.h` and
 :zephyr_file:`samples/modules/canopennode/objdict/CO_OD.c`) can be
 generated. The EDS editor can also export an updated Electronic Data
 Sheet (EDS) file
-(:zephyr_file:`samples/modules/canopennode/objdict/objdicts.eds`).
+(:zephyr_file:`samples/modules/canopennode/objdict/objdict.eds`).
 
 .. _CANopenNode:
    https://github.com/CANopenNode/CANopenNode

--- a/samples/net/cloud/aws_iot_mqtt/README.rst
+++ b/samples/net/cloud/aws_iot_mqtt/README.rst
@@ -36,7 +36,7 @@ the certificate and private key in order to embed them in the application.
 
 Register a *thing* in AWS IoT Core and download the certificate and private key.
 Copy these files to the :zephyr_file:`samples/net/cloud/aws_iot_mqtt/src/creds`
-directory. Run the :zephyr_file:`samples/net/cloud/aws_iot_mqtt/src/creds/convert_certs.py`
+directory. Run the :zephyr_file:`samples/net/cloud/aws_iot_mqtt/src/creds/convert_keys.py`
 script, which will generate files ``ca.c``, ``cert.c`` and ``key.c``.
 
 To configure the sample, set the following Kconfig options based on your AWS IoT

--- a/samples/sensor/wsen_itds/README.rst
+++ b/samples/sensor/wsen_itds/README.rst
@@ -21,7 +21,7 @@ Requirements
 References
 **********
 
- - WSEN-ITDS: https://www.we-online.com/catalog/manual/2533020201601_WSEN-ITDS%202533020201601%20Manual_rev1.pdf
+ - WSEN-ITDS: https://www.we-online.com/components/products/manual/2533020201601_WSEN-ITDS%202533020201601%20Manual_rev2.3.pdf
 
 Building and Running
 ********************

--- a/samples/shields/x_nucleo_iks01a2/standard/README.rst
+++ b/samples/shields/x_nucleo_iks01a2/standard/README.rst
@@ -22,7 +22,7 @@ configured for the I2C Arduino connector in the devicetree. See for
 example the :ref:`nucleo_f401re_board` board source code:
 
 - :zephyr_file:`boards/arm/nucleo_f401re/nucleo_f401re.dts`
-- :zephyr_file:`boards/arm/nucleo_f401re/arduino_r3_connector.dts`
+- :zephyr_file:`boards/arm/nucleo_f401re/arduino_r3_connector.dtsi`
 
 Please note that this sample can't be used with boards already supporting
 one of the sensors available on the shield (such as disco_l475_iot1) as zephyr

--- a/samples/subsys/tracing/README.rst
+++ b/samples/subsys/tracing/README.rst
@@ -71,7 +71,7 @@ After the serial console has stable output like this:
 	threadB: Hello World!
 
 Connect the board's USB port to the host device and
-run the :zephyr_file:`trace_capture_usb.py` script on the host:
+run the :zephyr_file:`scripts/tracing/trace_capture_usb.py` script on the host:
 
 .. code-block:: console
 

--- a/samples/subsys/usb/dfu/README.rst
+++ b/samples/subsys/usb/dfu/README.rst
@@ -153,4 +153,4 @@ Note the ``Swap type: perm``.
 
 
 .. _MCUboot GitHub repo: https://github.com/zephyrproject-rtos/mcuboot
-.. _Using MCUboot with Zephyr: https://mcuboot.com/documentation/readme-zephyr/
+.. _Using MCUboot with Zephyr: https://docs.mcuboot.com/readme-zephyr

--- a/samples/subsys/usb/mass/README.rst
+++ b/samples/subsys/usb/mass/README.rst
@@ -273,5 +273,5 @@ from the Zephyr mount log messages:
 If any of the parameters are inconsistent between the Zephyr and Linux
 specification the file system will not mount correctly.
 
-.. _littlefs: https://github.com/ARMmbed/littlefs
-.. _littlefs-FUSE: https://github.com/ARMmbed/littlefs-fuse
+.. _littlefs: https://github.com/littlefs-project/littlefs
+.. _littlefs-FUSE: https://github.com/littlefs-project/littlefs-fuse


### PR DESCRIPTION
I had a go at fixing the most obvious (and fixable) dead links in the documentation with the help of Sphinx's link checker.