### PR TITLE
linker: mark priv_stacks_noinit as NOLOAD

### DIFF
--- a/include/zephyr/linker/kobject-priv-stacks.ld
+++ b/include/zephyr/linker/kobject-priv-stacks.ld
@@ -6,7 +6,7 @@
 
 #ifdef CONFIG_USERSPACE
 #ifdef CONFIG_GEN_PRIV_STACKS
-	SECTION_DATA_PROLOGUE(priv_stacks_noinit,,)
+	SECTION_DATA_PROLOGUE(priv_stacks_noinit,(NOLOAD),)
 	{
 	z_priv_stacks_ram_start = .;
 


### PR DESCRIPTION
Currently priv_stacks_noinit is being put onto the flash waiting to be copied into memory at boot. This is a waste of flash space as priviledge stacks are initialized at runtime. So mark the linker section as NOLOAD to save some flash space.