### PR TITLE
doc: spi: fix doxygen comment for MISO Lines doc

### DIFF
--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -122,7 +122,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name SPI MISO lines (if @kconfig{CONFIG_SPI_EXTENDED_MODES} is enabled)
+ * @name SPI MISO lines
  * @{
  *
  * Some controllers support dual, quad or octal MISO lines connected to slaves.


### PR DESCRIPTION
Update SPI MISO Lines documentation to remove incorrect use of @kconfig. 
Fixes #58912.