### PR TITLE
doc: develop: api: overview: tag DAC API as Unstable

### DIFF
--- a/doc/develop/api/overview.rst
+++ b/doc/develop/api/overview.rst
@@ -62,7 +62,7 @@ between major releases are available in the :ref:`zephyr_release_notes`.
      - 1.7
 
    * - :ref:`dac_api`
-     - Experimental
+     - Unstable
      - 2.3
 
    * - :ref:`dai_api`


### PR DESCRIPTION
Promote DAC API from Experimental to Unstable.

The API is well adopted and used in more than 2 implementations.

See also: #58487