### PR TITLE
doc: develop: api: overview: tag Task Watchdog API as Unstable

### DIFF
--- a/doc/develop/api/overview.rst
+++ b/doc/develop/api/overview.rst
@@ -298,7 +298,7 @@ between major releases are available in the :ref:`zephyr_release_notes`.
      - 3.1
 
    * - :ref:`task_wdt_api`
-     - Experimental
+     - Unstable
      - 2.5
 
    * - :ref:`tcpc_api`


### PR DESCRIPTION
Promote Task Watchdog API from Experimental to Unstable.

The API has proven to be suitable for its purpose.

See also: #58487