### PR TITLE
test: ARC: skip div-by-zero test in case of SW div implementation

### DIFF
--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -122,7 +122,7 @@ __no_optimization static void trigger_fault_divide_zero(void)
 	defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || \
 	defined(CONFIG_BOARD_QEMU_CORTEX_R5) || \
 	defined(CONFIG_BOARD_FVP_BASER_AEMV8R) || defined(CONFIG_BOARD_FVP_BASE_REVC_2XAEMV8A) || \
-	defined(CONFIG_BOARD_FVP_BASER_AEMV8R_AARCH32)
+	defined(CONFIG_BOARD_FVP_BASER_AEMV8R_AARCH32) || defined(CONFIG_SOC_NSIM_EM11D)
 	ztest_test_skip();
 #endif
 }


### PR DESCRIPTION
The SW div implementation from libgcc doesn't handle division by zero case, so the HW exception isn't triggered.

So, skip this test case (as we are already doing for some other ARC targets).