### PR TITLE
tests: drivers: dac channel structure has a buffered parameter boolean

### DIFF
--- a/samples/drivers/dac/src/main.c
+++ b/samples/drivers/dac/src/main.c
@@ -27,7 +27,8 @@ static const struct device *const dac_dev = DEVICE_DT_GET(DAC_NODE);
 
 static const struct dac_channel_cfg dac_ch_cfg = {
 	.channel_id  = DAC_CHANNEL_ID,
-	.resolution  = DAC_RESOLUTION
+	.resolution  = DAC_RESOLUTION,
+	.buffered = true
 };
 
 int main(void)

--- a/tests/drivers/dac/dac_api/src/test_dac.c
+++ b/tests/drivers/dac/dac_api/src/test_dac.c
@@ -87,7 +87,8 @@
 
 static const struct dac_channel_cfg dac_ch_cfg = {
 	.channel_id  = DAC_CHANNEL_ID,
-	.resolution  = DAC_RESOLUTION
+	.resolution  = DAC_RESOLUTION,
+	.buffered = true
 };
 
 const struct device *get_dac_device(void)

--- a/tests/drivers/dac/dac_loopback/src/test_dac.c
+++ b/tests/drivers/dac/dac_loopback/src/test_dac.c
@@ -148,7 +148,8 @@
 
 static const struct dac_channel_cfg dac_ch_cfg = {
 	.channel_id = DAC_CHANNEL_ID,
-	.resolution = DAC_RESOLUTION
+	.resolution = DAC_RESOLUTION,
+	.buffered = true
 };
 
 static const struct adc_channel_cfg adc_ch_cfg = {


### PR DESCRIPTION
Add the '.buffered' field to the dac_channel_cfg structure when testing the DAC.
This boolean parameter is initialised to 'true' to PASS the test. 
It follows the https://github.com/zephyrproject-rtos/zephyr/pull/57730


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/58931

Signed-off-by: Francois Ramu <francois.ramu@st.com>