### PR TITLE
arch: arm64: Use atomic for fpu_owner pointer

### DIFF
--- a/include/zephyr/arch/arm64/structs.h
+++ b/include/zephyr/arch/arm64/structs.h
@@ -10,7 +10,7 @@
 /* Per CPU architecture specifics */
 struct _cpu_arch {
 #ifdef CONFIG_FPU_SHARING
-	struct k_thread *fpu_owner;
+	atomic_ptr_val_t fpu_owner;
 #endif
 #ifdef CONFIG_ARM64_SAFE_EXCEPTION_STACK
 	uint64_t safe_exception_stack;


### PR DESCRIPTION
Currently the lazy fpu saving algorithm in arm64 is using the fpu_owner pointer from the cpu structure to understand the owner of the context in the cpu and save it in case someone different from the owner is accessing the fpu.

The semantics for memory consistency across smp systems is quite prone to errors and reworks on the current code might miss some barriers that could lead to inconsistent state across cores, so to overcome the issue, use atomics to hide the complexity and be sure that the code will behave as intended.

While there, add some isb barriers after writes to cpacr_el1, following the guidance of ARM ARM specs about writes on system registers.