### PR TITLE
Bluetooth: Mesh: Updated ACL configuration settings

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -9,6 +9,7 @@ menu "Bluetooth buffer configuration"
 config BT_BUF_ACL_TX_SIZE
 	int "Maximum supported ACL size for outgoing data"
 	range 27 65535
+	default 37 if BT_MESH_GATT
 	default 27
 	help
 	  Maximum supported ACL size of data packets sent from the Host to the
@@ -48,11 +49,9 @@ config BT_BUF_ACL_TX_COUNT
 config BT_BUF_ACL_RX_SIZE
 	int "Maximum supported ACL size for incoming data"
 	default 200 if BT_BREDR
-	# Mesh Proxy Recommended: 64 Pkey + 2 Bytes Mesh header.
-	# Overhead: ATT Write command Header (3) in an L2CAP PDU (4).
-	default 73 if BT_MESH_GATT
 	default 70 if BT_EATT
 	default 69 if BT_SMP
+	default 37 if BT_MESH_GATT
 	default 27
 	range 70 65535 if BT_EATT
 	range 69 65535 if BT_SMP

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -456,6 +456,7 @@ config BT_CTLR_DATA_LENGTH
 config BT_CTLR_DATA_LENGTH_MAX
 	int "Maximum data length supported"
 	depends on BT_CTLR_DATA_LENGTH
+	default BT_BUF_ACL_RX_SIZE if BT_BUF_ACL_RX_SIZE < 251
 	default 27
 	range 27 BT_BUF_ACL_RX_SIZE if BT_BUF_ACL_RX_SIZE < 251
 	range 27 251


### PR DESCRIPTION
Setting default value for  BT_BUF_ACL_TX/RX_SIZE to 37, as this will process the incoming data the most efficient way.
When GATT is enable BT_BUF_ACL_RX_SIZE does not have to be 73, as this will just give segmented messages for the public keys exchange during provisioning.