### PR TITLE
net: websockets: Fix implicit type conversion Coverity warning

### DIFF
--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -796,7 +796,7 @@ static int websocket_parse(struct websocket_context *ctx, struct websocket_buffe
 				break;
 			case WEBSOCKET_PARSER_STATE_EXT_LEN:
 				ctx->parser_remaining--;
-				ctx->message_len |= (data << (ctx->parser_remaining * 8));
+				ctx->message_len |= ((uint64_t)data << (ctx->parser_remaining * 8));
 				if (ctx->parser_remaining == 0) {
 					if (ctx->masked) {
 						ctx->masking_value = 0;


### PR DESCRIPTION
Coverity reported potential issues with implicit signed/unsigned type conversions and potential problems with this. Fix this, by casing the byte-shifted data variable to uint64_t type explicitly.

Fixes #58617