### PR TITLE
net: lwm2m: Fix pointless variable assignment

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -1661,9 +1661,6 @@ static int lwm2m_perform_read_object_instance(struct lwm2m_message *msg,
 			if (ret < 0 && msg->path.level > LWM2M_PATH_LEVEL_OBJECT_INST) {
 				break;
 			}
-
-			/* when reading multiple resources ignore return code */
-			ret = 0;
 		}
 
 move_forward:


### PR DESCRIPTION
Coverity reported that assigning ret = 0 is pointless, as in any scenario (loop continues or ends) the ret variable is overwritten anyway, w/o using the assigned value. Therefore remove the needless assignment.

Fixes #58608