### PR TITLE
tests: timer_behavior: Use bigger drift tolerance for nRF RTC timer

### DIFF
--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -31,6 +31,13 @@ config TIMER_TEST_MAX_DRIFT
 
 config TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT
 	int "Maximum drift percentage for the timer period"
+	# Use 13% on nRF platforms using the RTC timer because one tick there is
+	# ~122 us (see SYS_CLOCK_TICKS_PER_SEC configuration above) and one tick
+	# difference in the test period is nothing unusual (it can happen for
+	# example if a new tick elapses right after the kernel gets the number
+	# of elapsed ticks when scheduling a new timeout but before the timer
+	# driver sets up that timeout).
+	default 13 if NRF_RTC_TIMER && TICKLESS_KERNEL
 	default 10
 	help
 	  A value of 10 means 10%.


### PR DESCRIPTION
Use 13% instead of the default 10% when the nRF RTC timer is used so that the allowed drift is at least one tick long (~122 us in this case).

Fixes #57326.