### PR TITLE
net: ieee802154_mgmt: Fix memcpy to uninitialized pointer location

### DIFF
--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -455,6 +455,7 @@ static int ieee802154_disassociate(uint32_t mgmt_request, struct net_if *iface,
 				   void *data, size_t len)
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
+	uint8_t ext_addr[IEEE802154_MAX_ADDR_LENGTH];
 	struct ieee802154_frame_params params;
 	struct ieee802154_command *cmd;
 	struct net_pkt *pkt;
@@ -477,6 +478,7 @@ static int ieee802154_disassociate(uint32_t mgmt_request, struct net_if *iface,
 		params.dst.short_addr = ctx->coord_short_addr;
 	} else {
 		params.dst.len = IEEE802154_EXT_ADDR_LENGTH;
+		params.dst.ext_addr = ext_addr;
 		sys_memcpy_swap(params.dst.ext_addr, ctx->coord_ext_addr,
 				IEEE802154_EXT_ADDR_LENGTH);
 	}


### PR DESCRIPTION
As since commit bff6a5c, `params.dst.ext_addr` is no longer assigned with the `ctx->coord_ext_addr` pointer, but an endianness swap is included, it should be assigned with a proper buffer before the memcpy.

Fixes #58606