### PR TITLE
ci: testplan: do not start more runners than needed

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -359,12 +359,6 @@ if __name__ == "__main__":
         else:
             nodes = round(total_tests / args.tests_per_builder)
 
-        if total_tests % args.tests_per_builder != total_tests:
-            nodes = nodes + 1
-
-        if args.default_matrix > nodes > 5:
-            nodes = args.default_matrix
-
         tp.write(f"TWISTER_TESTS={total_tests}\n")
         tp.write(f"TWISTER_NODES={nodes}\n")
         tp.write(f"TWISTER_FULL={f.full_twister}\n")


### PR DESCRIPTION
We have been launching 10 runners up a certain number of tests, although
we only neeed half of that for some scenarios.
Too many runners started that have to execute just a small number of
tests wastes times on setup and blocks the queue. Just start the number
of nodes needed based on initial calculation.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
