### PR TITLE
tests: timer_api: Decrease tick rate for nRF RTC timer

### DIFF
--- a/tests/kernel/timer/timer_api/Kconfig
+++ b/tests/kernel/timer/timer_api/Kconfig
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 Nordic Semiconductor ASA
+
+config SYS_CLOCK_TICKS_PER_SEC
+	default 16384 if NRF_RTC_TIMER && TICKLESS_KERNEL
+
+source "Kconfig.zephyr"


### PR DESCRIPTION
The default tick rate for the nRF RTC timer is 32768 Hz, so one tick is ~30 us. This turns out to be too little for the following loop executed in user mode on the Network core in nRF5340:
```
	do {
		t0 = k_uptime_ticks();
		rem_ticks = k_timer_remaining_ticks(&remain_timer);
		t1 = k_uptime_ticks();
	} while (t0 != t1);
```
The time between the two calls to `k_uptime_tick()` is there always above 30 us, so the loop never ends.

This patch decreases the tick rate for all nRF platforms because on other nRf SoCs the time mentioned above is also close to 30 us and apparently changes in code completely unrelated to this test affect execution time of system calls in the above loop - the test started to fail after commit 0014dd05f017c167827bf0e10846b641727b7a18 that changes fdtable was merged and if `fdtable.c` is for example just temporarily excluded from the build, the test passes.

The root cause of the problem seems to be related to user space handling and this should to be investigated further. This patch is applied only to allow this test to pass for the time being.

Fixes #58831.