### PR TITLE
net: context: Fix ambigous pointer check in net_context_connect()

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1032,17 +1032,16 @@ int net_context_connect(struct net_context *context,
 			goto unlock;
 		}
 
+		NET_ASSERT(net_sin6_ptr(&context->local)->sin6_addr != NULL);
+
 		net_sin6_ptr(&context->local)->sin6_family = AF_INET6;
 		net_sin6(&local_addr)->sin6_family = AF_INET6;
 		net_sin6(&local_addr)->sin6_port = lport =
 			net_sin6((struct sockaddr *)&context->local)->sin6_port;
+		net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
+				net_sin6_ptr(&context->local)->sin6_addr);
 
-		if (net_sin6_ptr(&context->local)->sin6_addr) {
-			net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
-				     net_sin6_ptr(&context->local)->sin6_addr);
-
-			laddr = &local_addr;
-		}
+		laddr = &local_addr;
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   net_context_get_family(context) == AF_INET) {
 		struct sockaddr_in *addr4 = (struct sockaddr_in *)
@@ -1074,17 +1073,16 @@ int net_context_connect(struct net_context *context,
 			goto unlock;
 		}
 
+		NET_ASSERT(net_sin_ptr(&context->local)->sin_addr != NULL);
+
 		net_sin_ptr(&context->local)->sin_family = AF_INET;
 		net_sin(&local_addr)->sin_family = AF_INET;
 		net_sin(&local_addr)->sin_port = lport =
 			net_sin((struct sockaddr *)&context->local)->sin_port;
+		net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
+				net_sin_ptr(&context->local)->sin_addr);
 
-		if (net_sin_ptr(&context->local)->sin_addr) {
-			net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
-				       net_sin_ptr(&context->local)->sin_addr);
-
-			laddr = &local_addr;
-		}
+		laddr = &local_addr;
 	} else {
 		ret = -EINVAL; /* Not IPv4 or IPv6 */
 		goto unlock;


### PR DESCRIPTION
Coverity reported, that `laddr` pointer used in `net_context_connect()` could be passed as NULL to `net_tcp_connect()`, where it could be dereferenced. This is because the actual setting of `laddr` to a valid address structure was only done after
`net_sin/sin6_ptr(&context->local)->sin/sin6_addr` verification.

In practice though, the aforementioned pointer verification would always pass, as the `bind_default()` guarantee that the `context->local` address is set to an unspecified address (if it hasn't been set earlier).

Therefore refactor the code a bit: replace the pointer verification with NET_ASSERT - only to assure that we can catch regression in case for any reason the behavior of `bind_default()` changes. This should also ensure that Coverity no longer reports that `laddr` is NULL when reaching `net_tcp_connect()`.

Fixes #58991