### PR TITLE
fs/littlefs/sample: Increase stack size

### DIFF
--- a/samples/subsys/fs/littlefs/prj.conf
+++ b/samples/subsys/fs/littlefs/prj.conf
@@ -8,7 +8,7 @@
 #CONFIG_APP_WIPE_STORAGE=y
 
 # fs_dirent structures are big.
-CONFIG_MAIN_STACK_SIZE=2048
+CONFIG_MAIN_STACK_SIZE=4096
 
 # Let __ASSERT do its job
 CONFIG_DEBUG=y


### PR DESCRIPTION
Increase stack size to prevent sample crashes.

Fixes #57525