### PR TITLE
Bluetooth: Mesh: Avoid undefined behavior in bit shift in blob_cli.c

### DIFF
--- a/subsys/bluetooth/mesh/blob_cli.c
+++ b/subsys/bluetooth/mesh/blob_cli.c
@@ -1550,9 +1550,9 @@ int bt_mesh_blob_cli_send(struct bt_mesh_blob_cli *cli,
 		return -ENODEV;
 	}
 
-	LOG_DBG("\n\tblock size: %u\n\tchunk size: %u\n"
+	LOG_DBG("\n\tblock size log: %u\n\tchunk size: %u\n"
 		"\tblob size: %u\n\tmode: %x",
-		(1 << cli->xfer->block_size_log), cli->xfer->chunk_size,
+		cli->xfer->block_size_log, cli->xfer->chunk_size,
 		cli->xfer->size, cli->xfer->mode);
 
 	return xfer_start(cli);


### PR DESCRIPTION
block_size_log can be 0x20 which will shift 1 by 32 bits which will cause undefined behavior. Adding ULL to 1 is an option but this will add little bit more code when debug option is enabled. So simply print the logarithmic value.

Coverity-ID: 316387
Fixes #58951