### PR TITLE
samples: drivers: peci: Exclude MEC172x EVB from test

### DIFF
--- a/samples/drivers/peci/sample.yaml
+++ b/samples/drivers/peci/sample.yaml
@@ -4,7 +4,9 @@ tests:
   sample.drivers.peci:
     # theoretically EVB can be connected to Intel RVP as well,
     # but HW setup is not documented, hence qualifying as unsupported.
-    platform_exclude: mec15xxevb_assy6853
+    platform_exclude:
+      - mec15xxevb_assy6853
+      - mec172xevb_assy6906
     integration_platforms:
       - npcx9m6f_evb
     filter: dt_alias_exists("peci-0")


### PR DESCRIPTION
PECI bus sample requires a controller and a target Intel system(PECI controller) + Embedded controller(PECI target), where EC HW can be add-on card (mec172xmodular) or onboard EC.

MEC172x EVB is not intended to be connected hence excluding the platform.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54435