### PR TITLE
include: zephyr: drivers: ps2: Add missing err codes header

### DIFF
--- a/include/zephyr/drivers/ps2.h
+++ b/include/zephyr/drivers/ps2.h
@@ -14,6 +14,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PS2_H_
 #define ZEPHYR_INCLUDE_DRIVERS_PS2_H_
 
+#include <errno.h>
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <zephyr/device.h>


### PR DESCRIPTION
Fix compilation error when enabling PS2 driver and userspace.