### PR TITLE
drivers/serial: Add ftdi FT201X I2C to USB bridge driver

### DIFF
--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -59,6 +59,7 @@ zephyr_library_sources_ifdef(CONFIG_UART_CDNS uart_cdns.c)
 zephyr_library_sources_ifdef(CONFIG_UART_OPENTITAN uart_opentitan.c)
 zephyr_library_sources_ifdef(CONFIG_UART_HOSTLINK uart_hostlink.c)
 zephyr_library_sources_ifdef(CONFIG_UART_EMUL uart_emul.c)
+zephyr_library_sources_ifdef(CONFIG_SERIAL_FT201X serial_ft201x.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   uart_handlers.c)
 

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -218,4 +218,6 @@ source "drivers/serial/Kconfig.hostlink"
 
 source "drivers/serial/Kconfig.emul"
 
+source "drivers/serial/Kconfig.ft201x"
+
 endif # SERIAL

--- a/drivers/serial/Kconfig.ft201x
+++ b/drivers/serial/Kconfig.ft201x
@@ -1,0 +1,11 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+config SERIAL_FT201X
+	bool "FTDI FT201X I2C to USB bridge"
+	default y
+	depends on DT_HAS_FTDI_FT201X_ENABLED
+	depends on I2C
+	select SERIAL_HAS_DRIVER
+	help
+	  This option enables the FTDI I2C to USB bridge driver

--- a/drivers/serial/serial_ft201x.c
+++ b/drivers/serial/serial_ft201x.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ftdi_ft201x
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/drivers/i2c.h>
+
+struct ftdi_ft201x_config {
+	struct i2c_dt_spec i2c_spec;
+};
+
+static int ftdi_ft201x_poll_in(const struct device *dev, unsigned char *p_char)
+{
+	struct ftdi_ft201x_config *config = (struct ftdi_ft201x_config *)dev->config;
+
+	return i2c_read_dt(&config->i2c_spec, p_char, 1) == 0 ? 0 : -1;
+}
+
+static void ftdi_ft201x_poll_out(const struct device *dev, unsigned char c)
+{
+	struct ftdi_ft201x_config *config = (struct ftdi_ft201x_config *)dev->config;
+
+	i2c_write_dt(&config->i2c_spec, &c, 1);
+}
+
+static const struct uart_driver_api ftdi_ft201x_api = {
+	.poll_in = ftdi_ft201x_poll_in,
+	.poll_out = ftdi_ft201x_poll_out,
+};
+
+static int ftdi_ft201x_init(const struct device *dev)
+{
+	struct ftdi_ft201x_config *config = (struct ftdi_ft201x_config *)dev->config;
+
+	if (!device_is_ready(config->i2c_spec.bus)) {
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+#define FTDI_FT201X_DEVICE(inst)						\
+	struct ftdi_ft201x_config ftdi_ft201x_config##inst = {		\
+		.i2c_spec = I2C_DT_SPEC_INST_GET(inst),				\
+	};									\
+										\
+	DEVICE_DT_INST_DEFINE(inst, ftdi_ft201x_init, NULL, NULL,		\
+			      &ftdi_ft201x_config##inst, POST_KERNEL,		\
+			      CONFIG_SERIAL_INIT_PRIORITY, &ftdi_ft201x_api);
+
+DT_INST_FOREACH_STATUS_OKAY(FTDI_FT201X_DEVICE)

--- a/dts/bindings/serial/ftdi,ft201x.yaml
+++ b/dts/bindings/serial/ftdi,ft201x.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  FTDI FT201X I2C to USB bridge
+
+  example:
+
+    &i2c0 {
+      ft201x@22 {
+        reg = <0x22>;
+        compatible = "ftdi,ft201x";
+        status = "okay";
+      };
+    };
+
+compatible: "ftdi,ft201x"
+
+include:
+  - uart-controller.yaml
+  - i2c-device.yaml


### PR DESCRIPTION
This PR adds support for the FT201X I2C to USB bridge from FTDI. It only implements the UART polling API.

The entire driver is simply a wrapper for the I2C API. For this reason, no internal state is kept, and thread safety is delegated to the I2C controller which interacts with the FTDI device.