### PR TITLE
Shell: Add missing long long type in shell_strtoull

### DIFF
--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -565,7 +565,7 @@ unsigned long shell_strtoul(const char *str, int base, int *err)
 
 unsigned long long shell_strtoull(const char *str, int base, int *err)
 {
-	unsigned long val;
+	unsigned long long val;
 	char *endptr = NULL;
 
 	if (*str == '-') {


### PR DESCRIPTION
shell_strtoull used a unsigned long instead of a unsigned long long to store the result in stroull, so the return value may have been truncated.