### PR TITLE
sysbuild: Fix value propagation of signature type to MCUboot

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -608,7 +608,11 @@ flagged.
         "BOOT_SERIAL_CDC_ACM",       # Used in (sysbuild-based) test
         "BOOT_SERIAL_ENTRANCE_GPIO", # Used in (sysbuild-based) test
         "BOOT_SERIAL_IMG_GRP_HASH",  # Used in documentation
-        "BOOT_SIGNATURE_KEY_FILE",   # MCUboot idefined setting used by sysbuild.
+        "BOOT_SIGNATURE_KEY_FILE", # MCUboot setting used by sysbuild
+        "BOOT_SIGNATURE_TYPE_ECDSA_P256", # MCUboot setting used by sysbuild
+        "BOOT_SIGNATURE_TYPE_ED25519", # MCUboot setting used by sysbuild
+        "BOOT_SIGNATURE_TYPE_NONE", # MCUboot setting used by sysbuild
+        "BOOT_SIGNATURE_TYPE_RSA", # MCUboot setting used by sysbuild
         "BOOT_VALIDATE_SLOT0",       # Used in (sysbuild-based) test
         "BOOT_WATCHDOG_FEED",        # Used in (sysbuild-based) test
         "BTTESTER_LOG_LEVEL",  # Used in tests/bluetooth/tester

--- a/share/sysbuild/image_config.cmake
+++ b/share/sysbuild/image_config.cmake
@@ -13,6 +13,29 @@ if((NOT image_board) OR ("${image_BOARD}" STREQUAL "${BOARD}"))
     set_config_string(${image} CONFIG_MCUBOOT_SIGNATURE_KEY_FILE
                                "${SB_CONFIG_BOOT_SIGNATURE_KEY_FILE}"
     )
+  else()
+    set(keytypes CONFIG_BOOT_SIGNATURE_TYPE_NONE
+                 CONFIG_BOOT_SIGNATURE_TYPE_RSA
+                 CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256
+                 CONFIG_BOOT_SIGNATURE_TYPE_ED25519)
+
+    if(SB_CONFIG_BOOT_SIGNATURE_TYPE_NONE)
+      set(keytype CONFIG_BOOT_SIGNATURE_TYPE_NONE)
+    elseif(SB_CONFIG_BOOT_SIGNATURE_TYPE_RSA)
+      set(keytype CONFIG_BOOT_SIGNATURE_TYPE_RSA)
+    elseif(SB_CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256)
+      set(keytype CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256)
+    elseif(SB_CONFIG_BOOT_SIGNATURE_TYPE_ED25519)
+      set(keytype CONFIG_BOOT_SIGNATURE_TYPE_ED25519)
+    endif()
+
+    foreach(loopkeytype ${keytypes})
+      if("${loopkeytype}" STREQUAL "${keytype}")
+        set_config_bool(${image} ${loopkeytype} y)
+      else()
+        set_config_bool(${image} ${loopkeytype} n)
+      endif()
+    endforeach()
   endif()
 
   if(SB_CONFIG_BOOTLOADER_MCUBOOT)


### PR DESCRIPTION
Fixes an issue whereby the type of the signature was not passed to MCUboot.

Fixes #57366