### PR TITLE
ARC: Fix portability.posix.common.arcmwdtlib test

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -47,9 +47,11 @@ struct pthread_attr {
 	int32_t detachstate;
 	uint32_t initialized;
 };
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC)
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \
+	|| defined(CONFIG_ARCMWDT_LIBC)
 typedef struct pthread_attr pthread_attr_t;
 #endif
+
 BUILD_ASSERT(sizeof(pthread_attr_t) >= sizeof(struct pthread_attr));
 
 typedef uint32_t pthread_t;
@@ -63,7 +65,8 @@ typedef uint32_t pthread_mutex_t;
 struct pthread_mutexattr {
 	int type;
 };
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC)
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \
+	|| defined(CONFIG_ARCMWDT_LIBC)
 typedef struct pthread_mutexattr pthread_mutexattr_t;
 #endif
 BUILD_ASSERT(sizeof(pthread_mutexattr_t) >= sizeof(struct pthread_mutexattr));
@@ -74,7 +77,8 @@ typedef uint32_t pthread_cond_t;
 struct pthread_condattr {
 };
 
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC)
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \
+	|| defined(CONFIG_ARCMWDT_LIBC)
 typedef struct pthread_condattr pthread_condattr_t;
 #endif
 BUILD_ASSERT(sizeof(pthread_condattr_t) >= sizeof(struct pthread_condattr));

--- a/include/zephyr/posix/pthread_key.h
+++ b/include/zephyr/posix/pthread_key.h
@@ -13,9 +13,11 @@
 extern "C" {
 #endif
 
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \
+	|| defined(CONFIG_ARCMWDT_LIBC)
+
 #ifdef CONFIG_PTHREAD_IPC
 
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC)
 typedef struct {
 	int is_initialized;
 	int init_executed;

--- a/include/zephyr/posix/sched.h
+++ b/include/zephyr/posix/sched.h
@@ -25,7 +25,8 @@ extern "C" {
 /* Priority based preemptive scheduling policy */
 #define SCHED_RR 2
 
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC)
+#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \
+	|| defined(CONFIG_ARCMWDT_LIBC)
 struct sched_param {
 	int sched_priority;
 };

--- a/lib/libc/arcmwdt/include/sys/cdefs.h
+++ b/lib/libc/arcmwdt/include/sys/cdefs.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 Synopsys.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* MWDT has no it's own cdefs. Add this one for satisfy dependencies */

--- a/lib/libc/arcmwdt/include/sys/types.h
+++ b/lib/libc/arcmwdt/include/sys/types.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Synopsys.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LIB_LIBC_ARCMWDT_INCLUDE_SYS_TYPES_H_
+#define LIB_LIBC_ARCMWDT_INCLUDE_SYS_TYPES_H_
+
+#include_next "sys/types.h"
+
+#define _DEV_T_DECLARED
+#define _INO_T_DECLARED
+#define _NLINK_T_DECLARED
+#define _UID_T_DECLARED
+#define _GID_T_DECLARED
+
+#endif /* LIB_LIBC_ARCMWDT_INCLUDE_SYS_TYPES_H_ */

--- a/lib/libc/arcmwdt/libc-hooks.c
+++ b/lib/libc/arcmwdt/libc-hooks.c
@@ -13,6 +13,18 @@
 #include <unistd.h>
 #include <errno.h>
 
+#ifndef STDIN_FILENO
+  #define STDIN_FILENO    0
+#endif
+
+#ifndef STDOUT_FILENO
+  #define STDOUT_FILENO   1
+#endif
+
+#ifndef STDERR_FILENO
+  #define STDERR_FILENO   2
+#endif
+
 static int _stdout_hook_default(int c)
 {
 	ARG_UNUSED(c);


### PR DESCRIPTION
portability.posix.common.arcmwdtlib test fails with ARCMWDT libc. This path fixes the test.

STDIN_FILENO and others macros  are used in libc-hooks.c only. So they defined locally.

Fixes: #59093
