### PR TITLE
sysbuild: ensure warning is only printed when VAR is not used

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -75,7 +75,7 @@ function(sysbuild_get variable)
     message(FATAL_ERROR "sysbuild_get(...) requires IMAGE.")
   endif()
 
-  if(DEFINED ${variable})
+  if(DEFINED ${variable} AND NOT DEFINED GET_VAR_VAR)
     message(WARNING "Return variable ${variable} already defined with a value. "
                     "sysbuild_get(${variable} ...) may overwrite existing value. "
 		    "Please use sysbuild_get(<variable> ... VAR <image-variable>) "


### PR DESCRIPTION
When calling `sysbuild_get(<out-var> VAR <lookup-var> ...)` user specifically specify the output variable and in such cases the overwrite warning should not be printed, because such invocation is similar to a regular `set(<var> <val>)` CMake call.

Only the invocation where the same variable name is used for lookup and return variable, then the warning must be printed to avoid unintentional overwriting of existing variables.