### PR TITLE
tests: Bluetooth: Split cap initiator unicast inval test to new func

### DIFF
--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -639,7 +639,6 @@ static void test_main_cap_initiator_unicast(void)
 
 	WAIT_FOR_FLAG(flag_mtu_exchanged);
 
-	discover_cas_inval();
 	discover_cas();
 
 	discover_sink();
@@ -648,22 +647,51 @@ static void test_main_cap_initiator_unicast(void)
 		unicast_group_create(&unicast_group);
 
 		for (size_t j = 0U; j < iterations; j++) {
-			unicast_audio_start_inval(unicast_group);
 			unicast_audio_start(unicast_group, true);
 
-			unicast_audio_update_inval();
 			unicast_audio_update();
 
-			unicast_audio_stop_inval();
 			unicast_audio_stop(unicast_group);
 		}
 
-		unicast_group_delete_inval();
 		unicast_group_delete(unicast_group);
 		unicast_group = NULL;
 	}
 
 	PASS("CAP initiator unicast passed\n");
+}
+
+static void test_main_cap_initiator_unicast_inval(void)
+{
+	struct bt_bap_unicast_group *unicast_group;
+
+	init();
+
+	scan_and_connect();
+
+	WAIT_FOR_FLAG(flag_mtu_exchanged);
+
+	discover_cas_inval();
+	discover_cas();
+
+	discover_sink();
+
+	unicast_group_create(&unicast_group);
+
+	unicast_audio_start_inval(unicast_group);
+	unicast_audio_start(unicast_group, true);
+
+	unicast_audio_update_inval();
+	unicast_audio_update();
+
+	unicast_audio_stop_inval();
+	unicast_audio_stop(unicast_group);
+
+	unicast_group_delete_inval();
+	unicast_group_delete(unicast_group);
+	unicast_group = NULL;
+
+	PASS("CAP initiator unicast inval passed\n");
 }
 
 static void test_cap_initiator_unicast_timeout(void)
@@ -702,7 +730,7 @@ static void test_cap_initiator_unicast_timeout(void)
 	unicast_group_delete(unicast_group);
 	unicast_group = NULL;
 
-	PASS("CAP initiator unicast passed\n");
+	PASS("CAP initiator unicast timeout passed\n");
 }
 
 static const struct bst_test_instance test_cap_initiator_unicast[] = {
@@ -717,6 +745,12 @@ static const struct bst_test_instance test_cap_initiator_unicast[] = {
 		.test_post_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = test_cap_initiator_unicast_timeout,
+	},
+	{
+		.test_id = "cap_initiator_unicast_inval",
+		.test_post_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_main_cap_initiator_unicast_inval,
 	},
 	BSTEST_END_MARKER,
 };

--- a/tests/bsim/bluetooth/audio/test_scripts/_cap.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/_cap.sh
@@ -6,6 +6,8 @@
 
 dir_path=$(dirname "$0")
 
+$dir_path/cap_unicast_inval.sh
+
 $dir_path/cap_unicast.sh
 
 $dir_path/cap_broadcast.sh

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_inval.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_inval.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+SIMULATION_ID="cap_unicast_inval"
+VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=20
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+cd ${BSIM_OUT_PATH}/bin
+
+printf "\n\n======== Running CAP unicast test =========\n\n"
+
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_unicast_inval -rs=46
+
+Execute ./bs_${BOARD}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_unicast -rs=23
+
+# Simulation time should be larger than the WAIT_TIME in common.h
+Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+  -D=2 -sim_length=60e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
Add a new test function to test invalid behavior to keep the valid behavior test cleaner.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/59057