### PR TITLE
Bluetooth: Host: Set valid default for secondary adv phy

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1156,12 +1156,11 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 	adv->options = param->options;
 
 	cp->prim_adv_phy = BT_HCI_LE_PHY_1M;
-	if (param->options & BT_LE_ADV_OPT_EXT_ADV) {
-		if (param->options & BT_LE_ADV_OPT_NO_2M) {
-			cp->sec_adv_phy = BT_HCI_LE_PHY_1M;
-		} else {
-			cp->sec_adv_phy = BT_HCI_LE_PHY_2M;
-		}
+	if ((param->options & BT_LE_ADV_OPT_EXT_ADV) &&
+	    !(param->options & BT_LE_ADV_OPT_NO_2M)) {
+		cp->sec_adv_phy = BT_HCI_LE_PHY_2M;
+	} else {
+		cp->sec_adv_phy = BT_HCI_LE_PHY_1M;
 	}
 
 	if (param->options & BT_LE_ADV_OPT_CODED) {


### PR DESCRIPTION
Set the secondary advertising PHY to a valid value when using legacy advertising through the LE Set Extended Advertising Parameters command.

Fixes #57885.