### PR TITLE
tests: bluetooth: tester: Fix ATT max attr size assert

### DIFF
--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -415,7 +415,7 @@ static ssize_t write_value(struct bt_conn *conn,
 	value->len = len;
 
 	/* Maximum attribute value size is 512 bytes */
-	__ASSERT_NO_MSG(value->len < 512);
+	__ASSERT_NO_MSG(value->len <= 512);
 
 	attr_value_changed_ev(attr->handle, value->data, value->len);
 


### PR DESCRIPTION
ATT attributes can be up to 512 bytes long, so the comparisong needed fixing.

See spec v5.4, Vol 3, Part F, 3.2.9.

Fixes #57930.