### PR TITLE
Update benchmark latency_measure test reporting

### DIFF
--- a/tests/benchmarks/latency_measure/src/coop_ctx_switch.c
+++ b/tests/benchmarks/latency_measure/src/coop_ctx_switch.c
@@ -95,6 +95,10 @@ int coop_ctx_switch(void)
 {
 	ctx_switch_counter = 0U;
 	ctx_switch_balancer = 0;
+	char error_string[80];
+	const char *notes = "";
+	bool failed = false;
+	int  end;
 
 	timing_start();
 	bench_test_start();
@@ -106,17 +110,24 @@ int coop_ctx_switch(void)
 			(k_thread_entry_t)thread_two, NULL, NULL, NULL,
 			K_PRIO_COOP(6), 0, K_NO_WAIT);
 
-	if (ctx_switch_balancer > 3 || ctx_switch_balancer < -3) {
-		printk(" Balance is %d. FAILED", ctx_switch_balancer);
-	} else if (bench_test_end() != 0) {
-		error_count++;
-		PRINT_OVERFLOW_ERROR();
-	} else {
-		uint32_t diff;
+	end = bench_test_end();
 
-		diff = timing_cycles_get(&timestamp_start, &timestamp_end);
-		PRINT_STATS_AVG("Average context switch time between threads (coop)", diff, ctx_switch_counter);
+	if (ctx_switch_balancer > 3 || ctx_switch_balancer < -3) {
+		error_count++;
+		snprintk(error_string, 78, " Balance is %d",
+			 ctx_switch_balancer);
+		notes = error_string;
+		failed = true;
+	} else if (end != 0) {
+		error_count++;
+		notes = TICK_OCCURRENCE_ERROR;
 	}
+
+	uint32_t diff;
+
+	diff = timing_cycles_get(&timestamp_start, &timestamp_end);
+	PRINT_STATS_AVG("Average context switch time between threads (coop)",
+			diff, ctx_switch_counter, failed, notes);
 
 	timing_stop();
 

--- a/tests/benchmarks/latency_measure/src/heap_malloc_free.c
+++ b/tests/benchmarks/latency_measure/src/heap_malloc_free.c
@@ -23,6 +23,10 @@ void heap_malloc_free(void)
 	uint32_t sum_malloc = 0U;
 	uint32_t sum_free = 0U;
 
+	bool  failed = false;
+	char  error_string[80];
+	const char *notes = "";
+
 	timing_start();
 
 	while (count != TEST_COUNT) {
@@ -31,8 +35,10 @@ void heap_malloc_free(void)
 
 		heap_malloc_end_time = timing_counter_get();
 		if (allocated_mem == NULL) {
-			printk("Failed to alloc memory from heap "
-					"at count %d\n", count);
+			error_count++;
+			snprintk(error_string, 78,
+				  "alloc memory @ iteration %d", count);
+			notes = error_string;
 			break;
 		}
 
@@ -47,18 +53,20 @@ void heap_malloc_free(void)
 		count++;
 	}
 
-	/* if count is 0, it means that there is not enough memory heap
-	 * to do k_malloc at least once, then it's meaningless to
-	 * calculate average time of memory allocation and free.
+	/*
+	 * If count is 0, it means that there is not enough memory heap
+	 * to do k_malloc at least once. Override the error string.
 	 */
+
 	if (count == 0) {
-		printk("Error: there isn't enough memory heap to do "
-				"k_malloc at least once, please "
-				"increase heap size\n");
-	} else {
-		PRINT_STATS_AVG("Average time for heap malloc", sum_malloc, count);
-		PRINT_STATS_AVG("Average time for heap free", sum_free, count);
+		failed = true;
+		notes = "Memory heap too small--increase it.";
 	}
+
+	PRINT_STATS_AVG("Average time for heap malloc", sum_malloc, count,
+			failed, notes);
+	PRINT_STATS_AVG("Average time for heap free", sum_free, count,
+			failed, notes);
 
 	timing_stop();
 }

--- a/tests/benchmarks/latency_measure/src/int_to_thread.c
+++ b/tests/benchmarks/latency_measure/src/int_to_thread.c
@@ -51,11 +51,7 @@ static void make_int(void)
 {
 	flag_var = 0;
 	irq_offload(latency_test_isr, NULL);
-	if (flag_var != 1) {
-		printk(" Flag variable has not changed. FAILED\n");
-	} else {
-		timestamp_end = timing_counter_get();
-	}
+	timestamp_end = timing_counter_get();
 }
 
 /**
@@ -67,14 +63,21 @@ static void make_int(void)
 int int_to_thread(void)
 {
 	uint32_t diff;
+	bool  failed = false;
+	const char *notes = "";
 
 	timing_start();
 	TICK_SYNCH();
 	make_int();
-	if (flag_var == 1) {
-		diff = timing_cycles_get(&timestamp_start, &timestamp_end);
-		PRINT_STATS("Switch from ISR back to interrupted thread", diff);
+	if (flag_var != 1) {
+		error_count++;
+		notes = "Flag variable did not change";
+		failed = true;
 	}
+
+	diff = timing_cycles_get(&timestamp_start, &timestamp_end);
+	PRINT_STATS("Switch from ISR back to interrupted thread",
+		    diff, failed, notes);
 	timing_stop();
 	return 0;
 }

--- a/tests/benchmarks/latency_measure/src/int_to_thread_evt.c
+++ b/tests/benchmarks/latency_measure/src/int_to_thread_evt.c
@@ -90,7 +90,7 @@ int int_to_thread_evt(void)
 
 	diff = timing_cycles_get(&timestamp_start, &timestamp_end);
 
-	PRINT_STATS("Time from ISR to executing a different thread", diff)
+	PRINT_STATS("Time from ISR to executing a different thread", diff);
 
 	return 0;
 }

--- a/tests/benchmarks/latency_measure/src/int_to_thread_evt.c
+++ b/tests/benchmarks/latency_measure/src/int_to_thread_evt.c
@@ -90,7 +90,8 @@ int int_to_thread_evt(void)
 
 	diff = timing_cycles_get(&timestamp_start, &timestamp_end);
 
-	PRINT_STATS("Time from ISR to executing a different thread", diff);
+	PRINT_STATS("Time from ISR to executing a different thread",
+		    diff, false, "");
 
 	return 0;
 }

--- a/tests/benchmarks/latency_measure/src/mutex_lock_unlock.c
+++ b/tests/benchmarks/latency_measure/src/mutex_lock_unlock.c
@@ -30,8 +30,11 @@ int mutex_lock_unlock(void)
 	uint32_t diff;
 	timing_t timestamp_start;
 	timing_t timestamp_end;
+	const char *notes = "";
+	int  end;
 
 	timing_start();
+	bench_test_start();
 
 	timestamp_start = timing_counter_get();
 
@@ -40,10 +43,19 @@ int mutex_lock_unlock(void)
 	}
 
 	timestamp_end = timing_counter_get();
+	end = bench_test_end();
 
 	diff = timing_cycles_get(&timestamp_start, &timestamp_end);
-	PRINT_STATS_AVG("Average time to lock a mutex", diff, N_TEST_MUTEX);
 
+	if (end != 0) {
+		notes = TICK_OCCURRENCE_ERROR;
+		error_count++;
+	}
+
+	PRINT_STATS_AVG("Average time to lock a mutex", diff, N_TEST_MUTEX,
+			false, notes);
+
+	bench_test_start();
 	timestamp_start = timing_counter_get();
 
 	for (i = 0; i < N_TEST_MUTEX; i++) {
@@ -51,9 +63,17 @@ int mutex_lock_unlock(void)
 	}
 
 	timestamp_end = timing_counter_get();
+	end = bench_test_end();
 	diff = timing_cycles_get(&timestamp_start, &timestamp_end);
 
-	PRINT_STATS_AVG("Average time to unlock a mutex", diff, N_TEST_MUTEX);
+	if (end != 0) {
+		notes = TICK_OCCURRENCE_ERROR;
+		error_count++;
+	}
+
+	PRINT_STATS_AVG("Average time to unlock a mutex", diff, N_TEST_MUTEX,
+			false, notes);
+
 	timing_stop();
 	return 0;
 }

--- a/tests/benchmarks/latency_measure/src/sema_test_signal_release.c
+++ b/tests/benchmarks/latency_measure/src/sema_test_signal_release.c
@@ -45,7 +45,6 @@ int sema_context_switch(void)
 {
 	uint32_t diff;
 
-	bench_test_start();
 	timing_start();
 
 	k_thread_create(&thread_one_data, thread_one_stack,
@@ -57,13 +56,13 @@ int sema_context_switch(void)
 
 	timestamp_end_sema_t_c = timing_counter_get();
 	diff = timing_cycles_get(&timestamp_start_sema_t_c, &timestamp_end_sema_t_c);
-	PRINT_STATS("Semaphore take time (context switch)", diff);
+	PRINT_STATS("Semaphore take time (context switch)", diff, false, "");
 
 
 	timestamp_start_sema_g_c = timing_counter_get();
 	k_sem_give(&sem_bench);
 	diff = timing_cycles_get(&timestamp_start_sema_g_c, &timestamp_end_sema_g_c);
-	PRINT_STATS("Semaphore give time (context switch)", diff);
+	PRINT_STATS("Semaphore give time (context switch)", diff, false, "");
 
 	timing_stop();
 
@@ -85,6 +84,8 @@ int sema_test_signal(void)
 	uint32_t diff;
 	timing_t timestamp_start;
 	timing_t timestamp_end;
+	const char *notes = "";
+	int  end;
 
 	bench_test_start();
 	timing_start();
@@ -96,15 +97,17 @@ int sema_test_signal(void)
 	}
 
 	timestamp_end = timing_counter_get();
+	end = bench_test_end();
 	timing_stop();
 
-	if (bench_test_end() == 0) {
-		diff = timing_cycles_get(&timestamp_start, &timestamp_end);
-		PRINT_STATS_AVG("Average semaphore signal time", diff, N_TEST_SEMA);
-	} else {
+	if (end != 0) {
 		error_count++;
-		PRINT_OVERFLOW_ERROR();
+		notes = TICK_OCCURRENCE_ERROR;
 	}
+
+	diff = timing_cycles_get(&timestamp_start, &timestamp_end);
+	PRINT_STATS_AVG("Average semaphore signal time", diff, N_TEST_SEMA,
+			false, notes);
 
 	bench_test_start();
 	timing_start();
@@ -116,15 +119,17 @@ int sema_test_signal(void)
 	}
 
 	timestamp_end = timing_counter_get();
+	end = bench_test_end();
 	timing_stop();
 
-	if (bench_test_end() == 0) {
-		diff = timing_cycles_get(&timestamp_start, &timestamp_end);
-		PRINT_STATS_AVG("Average semaphore test time", diff, N_TEST_SEMA);
-	} else {
+	if (end != 0) {
 		error_count++;
-		PRINT_OVERFLOW_ERROR();
+		notes = TICK_OCCURRENCE_ERROR;
 	}
+
+	diff = timing_cycles_get(&timestamp_start, &timestamp_end);
+	PRINT_STATS_AVG("Average semaphore test time", diff, N_TEST_SEMA,
+			false, notes);
 
 	return 0;
 }

--- a/tests/benchmarks/latency_measure/src/thread.c
+++ b/tests/benchmarks/latency_measure/src/thread.c
@@ -60,19 +60,19 @@ int suspend_resume(void)
 
 	diff = timing_cycles_get(&timestamp_start_create_c,
 				 &timestamp_end_create_c);
-	PRINT_STATS("Time to create a thread (without start)", diff);
+	PRINT_STATS("Time to create a thread (without start)", diff, false, "");
 
 	diff = timing_cycles_get(&timestamp_start_start_c,
 				 &timestamp_start_suspend_c);
-	PRINT_STATS("Time to start a thread", diff);
+	PRINT_STATS("Time to start a thread", diff, false, "");
 
 	diff = timing_cycles_get(&timestamp_start_suspend_c,
 				 &timestamp_end_suspend_c);
-	PRINT_STATS("Time to suspend a thread", diff);
+	PRINT_STATS("Time to suspend a thread", diff, false, "");
 
 	diff = timing_cycles_get(&timestamp_start_resume_c,
 				 &timestamp_end_resume_c);
-	PRINT_STATS("Time to resume a thread", diff);
+	PRINT_STATS("Time to resume a thread", diff, false, "");
 
 	timestamp_start_abort_1 = timing_counter_get();
 	k_thread_abort(t1_tid);
@@ -80,7 +80,7 @@ int suspend_resume(void)
 
 	diff = timing_cycles_get(&timestamp_start_abort_1,
 				 &timestamp_end_abort_1);
-	PRINT_STATS("Time to abort a thread (not running)", diff);
+	PRINT_STATS("Time to abort a thread (not running)", diff, false, "");
 
 	timing_stop();
 	return 0;

--- a/tests/benchmarks/latency_measure/src/thread_switch_yield.c
+++ b/tests/benchmarks/latency_measure/src/thread_switch_yield.c
@@ -49,6 +49,10 @@ void thread_switch_yield(void)
 	timing_t timestamp_start;
 	timing_t timestamp_end;
 	uint32_t ts_diff;
+	const char *notes = "";
+	char error_string[80];
+	bool failed = false;
+	int  end;
 
 	timing_start();
 	bench_test_start();
@@ -71,6 +75,7 @@ void thread_switch_yield(void)
 
 	/* get the number of cycles it took to do the test */
 	timestamp_end = timing_counter_get();
+	end = bench_test_end();
 
 	/* Ensure both helper and this routine were context switching back &
 	 * forth.
@@ -80,23 +85,29 @@ void thread_switch_yield(void)
 	 * back and forth.
 	 */
 	delta = iterations - helper_thread_iterations;
-	if (bench_test_end() < 0) {
-		error_count++;
-		PRINT_OVERFLOW_ERROR();
-	} else if (abs(delta) > 1) {
+	if (abs(delta) > 1) {
 		/* expecting even alternating context switch, seems one routine
 		 * called yield without the other having chance to execute
 		 */
 		error_count++;
-		printk(" Error, iteration:%u, helper iteration:%u",
-			     iterations, helper_thread_iterations);
-	} else {
-		/* thread_yield is called (iterations + helper_thread_iterations)
-		 * times in total.
-		 */
-		ts_diff = timing_cycles_get(&timestamp_start, &timestamp_end);
-		PRINT_STATS_AVG("Average thread context switch using yield", ts_diff, (iterations + helper_thread_iterations));
+		snprintk(error_string, 78,
+			 "Error: iteration:%u : helper iteration:%u",
+			 iterations, helper_thread_iterations);
+		notes = error_string;
+		failed = true;
+	} else if (end != 0) {
+		error_count++;
+		notes = TICK_OCCURRENCE_ERROR;
 	}
+
+	/*
+	 * thread_yield is called (iterations + helper_thread_iterations)
+	 * times in total.
+	 */
+
+	ts_diff = timing_cycles_get(&timestamp_start, &timestamp_end);
+	PRINT_STATS_AVG("Average thread context switch using yield", ts_diff,
+			(iterations + helper_thread_iterations), failed, notes);
 
 	timing_stop();
 }

--- a/tests/benchmarks/latency_measure/src/utils.h
+++ b/tests/benchmarks/latency_measure/src/utils.h
@@ -25,17 +25,29 @@ extern int error_count;
 	printk(" Error: tick occurred\n")
 
 #ifdef CSV_FORMAT_OUTPUT
-#define FORMAT "%-60s,%8u,%8u\n"
+#define FORMAT_STR   "%-60s,%s,%s\n"
+#define CYCLE_FORMAT "%8u"
+#define NSEC_FORMAT  "%8u"
 #else
-#define FORMAT "%-60s:%8u cycles , %8u ns\n"
+#define FORMAT_STR   "%-60s:%s , %s\n"
+#define CYCLE_FORMAT "%8u cycles"
+#define NSEC_FORMAT  "%8u ns"
 #endif
 
-#define PRINT_F(...)						\
-	{							\
-		char sline[256]; 				\
-		snprintk(sline, 254, FORMAT, ##__VA_ARGS__); 	\
-		printk("%s", sline);			     	\
-	}
+#define PRINT_F(summary, cycles, nsec, error, notes)                     \
+	do {                                                             \
+		char cycle_str[32];                                      \
+		char nsec_str[32];                                       \
+									 \
+		if (!error) {                                            \
+			snprintk(cycle_str, 30, CYCLE_FORMAT, cycles);   \
+			snprintk(nsec_str, 30, NSEC_FORMAT, nsec);       \
+		} else {                                                 \
+			snprintk(cycle_str, 30, "%15s", "FAILED");       \
+			snprintk(nsec_str, 30, "%15s", "FAILED");        \
+		}                                                        \
+		printk(FORMAT_STR, summary, cycle_str, nsec_str, notes); \
+	} while (0)
 
 #define PRINT_STATS(summary, value) \
 	PRINT_F(summary, value, (uint32_t)timing_cycles_to_ns(value))

--- a/tests/benchmarks/latency_measure/src/utils.h
+++ b/tests/benchmarks/latency_measure/src/utils.h
@@ -21,19 +21,30 @@
 
 extern int error_count;
 
-#define PRINT_OVERFLOW_ERROR()			\
-	printk(" Error: tick occurred\n")
+#define TICK_OCCURRENCE_ERROR  "Error: Tick Occurred"
 
 #ifdef CSV_FORMAT_OUTPUT
-#define FORMAT_STR   "%-60s,%s,%s\n"
+#define FORMAT_STR   "%-52s,%s,%s,%s\n"
 #define CYCLE_FORMAT "%8u"
 #define NSEC_FORMAT  "%8u"
 #else
-#define FORMAT_STR   "%-60s:%s , %s\n"
+#define FORMAT_STR   "%-52s:%s , %s : %s\n"
 #define CYCLE_FORMAT "%8u cycles"
 #define NSEC_FORMAT  "%8u ns"
 #endif
 
+/**
+ * @brief Display a line of statistics
+ *
+ * This macro displays the following:
+ *  1. Test description summary
+ *  2. Number of cycles - See Note
+ *  3. Number of nanoseconds - See Note
+ *  4. Additional notes describing the nature of any errors
+ *
+ * Note - If the @a error parameter is not false, then the test has no
+ * numerical information to print and it will instead print "FAILED".
+ */
 #define PRINT_F(summary, cycles, nsec, error, notes)                     \
 	do {                                                             \
 		char cycle_str[32];                                      \
@@ -49,11 +60,15 @@ extern int error_count;
 		printk(FORMAT_STR, summary, cycle_str, nsec_str, notes); \
 	} while (0)
 
-#define PRINT_STATS(summary, value) \
-	PRINT_F(summary, value, (uint32_t)timing_cycles_to_ns(value))
+#define PRINT_STATS(summary, value, error, notes)     \
+	PRINT_F(summary, value,                       \
+		(uint32_t)timing_cycles_to_ns(value), \
+		error, notes)
 
-#define PRINT_STATS_AVG(summary, value, counter)	\
-	PRINT_F(summary, value / counter, (uint32_t)timing_cycles_to_ns_avg(value, counter));
+#define PRINT_STATS_AVG(summary, value, counter, error, notes)      \
+	PRINT_F(summary, value / counter,                           \
+		(uint32_t)timing_cycles_to_ns_avg(value, counter),  \
+		error, notes);
 
 
 #endif

--- a/tests/benchmarks/latency_measure/src/utils.h
+++ b/tests/benchmarks/latency_measure/src/utils.h
@@ -37,11 +37,11 @@ extern int error_count;
 		printk("%s", sline);			     	\
 	}
 
-#define PRINT_STATS(x, y) \
-	PRINT_F(x, y, (uint32_t)timing_cycles_to_ns(y))
+#define PRINT_STATS(summary, value) \
+	PRINT_F(summary, value, (uint32_t)timing_cycles_to_ns(value))
 
-#define PRINT_STATS_AVG(x, y, counter)	\
-	PRINT_F(x, y / counter, (uint32_t)timing_cycles_to_ns_avg(y, counter));
+#define PRINT_STATS_AVG(summary, value, counter)	\
+	PRINT_F(summary, value / counter, (uint32_t)timing_cycles_to_ns_avg(value, counter));
 
 
 #endif


### PR DESCRIPTION
Updates the benchmark latency_measure test reporting so that ... 

1. The test description is always shown--even when it fails to make it even easier to identify which test failed.
2. Tests that report average results that take longer than one second (a scenario for a guaranteed system tick processing) will still register as a failure, but they will now display both the calculated results and a note indicating what went "wrong". There is no need to hide the results in this case.

Fixes #58064