### PR TITLE
samples: Bluetooth: hci_usb: Disable USB_CDC_ACM

### DIFF
--- a/boards/arm/adafruit_itsybitsy_nrf52840/Kconfig.defconfig
+++ b/boards/arm/adafruit_itsybitsy_nrf52840/Kconfig.defconfig
@@ -17,13 +17,13 @@ config USB_DEVICE_STACK
 	default y
 
 config USB_CDC_ACM
-	default y
+	default SERIAL
 
 config UART_CONSOLE
 	default CONSOLE
 
 config USB_DEVICE_INITIALIZE_AT_BOOT
-	default y
+	default y if CONSOLE
 
 config SHELL_BACKEND_SERIAL_CHECK_DTR
 	default SHELL

--- a/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
@@ -31,13 +31,13 @@ config USB_DEVICE_STACK
 	default y
 
 config USB_CDC_ACM
-	default y
+	default SERIAL
 
 config UART_CONSOLE
 	default CONSOLE
 
 config USB_DEVICE_INITIALIZE_AT_BOOT
-	default y if !MCUBOOT
+	default y if !MCUBOOT && CONSOLE
 
 config SHELL_BACKEND_SERIAL_CHECK_DTR
 	default SHELL

--- a/samples/bluetooth/hci_usb/prj.conf
+++ b/samples/bluetooth/hci_usb/prj.conf
@@ -1,9 +1,3 @@
-CONFIG_STDOUT_CONSOLE=y
-CONFIG_GPIO=y
-CONFIG_SERIAL=y
-CONFIG_UART_INTERRUPT_DRIVEN=y
-CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT=n
-
 CONFIG_BT=y
 CONFIG_BT_HCI_RAW=y
 
@@ -11,6 +5,12 @@ CONFIG_USB_DEVICE_STACK=y
 CONFIG_USB_DEVICE_PID=0x000B
 CONFIG_USB_DEVICE_BLUETOOTH=y
 CONFIG_USB_DEVICE_BLUETOOTH_VS_H4=n
+CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT=n
+
+# We dont want any console or CDC ACM that may cause BlueZ to not detect hci_usb
+CONFIG_SERIAL=n
+CONFIG_CONSOLE=n
+CONFIG_UART_CONSOLE=n
 
 # Workaround: Unable to allocate command buffer when using K_NO_WAIT since
 # Host number of completed commands does not follow normal flow control.


### PR DESCRIPTION
BlueZ btusb does not recognize hci_usb sample as Bluetooth Controller when CDC ACM is enabled in the sample.

Refer to https://github.com/zephyrproject-rtos/zephyr/issues/29107

https://github.com/zephyrproject-rtos/zephyr/issues/29107#issuecomment-1048705158 :
> you cannot use hci_usb and CDC ACM in composite configuration with btusb.