### PR TITLE
shell: Fix shell_vfprintf when vt100 is disabled

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1503,11 +1503,11 @@ void shell_vfprintf(const struct shell *sh, enum shell_vt100_color color,
 	}
 
 	k_mutex_lock(&sh->ctx->wr_mtx, K_FOREVER);
-	if (!z_flag_cmd_ctx_get(sh) && !sh->ctx->bypass) {
+	if (!z_flag_cmd_ctx_get(sh) && !sh->ctx->bypass && z_flag_use_vt100_get(sh)) {
 		z_shell_cmd_line_erase(sh);
 	}
 	z_shell_vfprintf(sh, color, fmt, args);
-	if (!z_flag_cmd_ctx_get(sh) && !sh->ctx->bypass) {
+	if (!z_flag_cmd_ctx_get(sh) && !sh->ctx->bypass && z_flag_use_vt100_get(sh)) {
 		z_shell_print_prompt_and_cmd(sh);
 	}
 	z_transport_buffer_flush(sh);


### PR DESCRIPTION
Without this fix, for every call to shell_vfprintf, a prompt string and vt100 codes are printed too, resulting in mangled log output.

Example snippet from running `bap discover` without the fix (and vt100 off):

```
uart:~$ uart:~$ data_count 5
uart:~$ data #0: type 0x01 len 2
uart:~$ 00000000: uart:~$ 04 uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$  uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$ |uart:~$ .uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$ |
uart:~$ data #1: type 0x02 len 1
uart:~$ data #2: type 0x03 len 1
uart:~$ data #3: type 0x04 len 4
uart:~$ 00000000: uart:~$ 28 uart:~$ 00 uart:~$ 28 uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$  uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$ |uart:~$ (uart:~$ .uart:~$ (uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$ |
uart:~$ data #4: type 0x05 len 1
uart:~$ meta_count 5
uart:~$ meta #0: type 0x01 len 2
uart:~$ 00000000: uart:~$ 07 uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$  uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$    uart:~$ |uart:~$ .uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$  uart:~$ |
uart:~$ dir 2 loc 1
```

Example snippet from running `bap discover` WITH the fix (and vt100 off):

```
uart:~$ data_count 5
data #0: type 0x01 len 2
00000000: 04                                               |.                |
data #1: type 0x02 len 1
data #2: type 0x03 len 1
data #3: type 0x04 len 4
00000000: 28 00 28                                         |(.(              |
data #4: type 0x05 len 1
meta_count 5
meta #0: type 0x01 len 2
00000000: 07                                               |.                |
dir 2 loc 1
```
