### PR TITLE
boards: arm: mimxrt1060_evk: added additional PWM outputs

### DIFF
--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk-pinctrl.dtsi
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk-pinctrl.dtsi
@@ -98,9 +98,32 @@
 	};
 
 	/* flexpwm output for board LED */
-	pinmux_flexpwm2: pinmux_flexpwm2 {
+	pinmux_flexpwm2_3: pinmux_flexpwm2_3 {
 		group0 {
 			pinmux = <&iomuxc_gpio_ad_b0_09_flexpwm2_pwma3>;
+			drive-strength = "r0-4";
+			bias-pull-up;
+			bias-pull-up-value = "47k";
+			slew-rate = "slow";
+			nxp,speed = "100-mhz";
+		};
+	};
+
+	/* Conflicts with SD and SPI pins. Requires R281/R356 be populated */
+	pinmux_flexpwm1_0: pinmux_flexpwm1_0 {
+		group0 {
+			pinmux = <&iomuxc_gpio_sd_b0_01_flexpwm1_pwmb0>;
+			drive-strength = "r0-4";
+			bias-pull-up;
+			bias-pull-up-value = "47k";
+			slew-rate = "slow";
+			nxp,speed = "100-mhz";
+		};
+	};
+
+	pinmux_flexpwm1: pinmux_flexpwm1 {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_b0_10_flexpwm1_pwma3>;
 			drive-strength = "r0-4";
 			bias-pull-up;
 			bias-pull-up-value = "47k";

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -237,7 +237,17 @@ zephyr_udc0: &usb1 {
 
 &flexpwm2_pwm3 {
 	status = "okay";
-	pinctrl-0 = <&pinmux_flexpwm2>;
+	pinctrl-0 = <&pinmux_flexpwm2_3>;
+	pinctrl-names = "default";
+};
+
+&flexpwm1_pwm0 {
+	pinctrl-0 = <&pinmux_flexpwm1_0>;
+	pinctrl-names = "default";
+};
+
+&flexpwm1_pwm3 {
+	pinctrl-0 = <&pinmux_flexpwm1>;
 	pinctrl-names = "default";
 };
 

--- a/tests/drivers/pwm/pwm_api/boards/mimxrt1060_evk.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/mimxrt1060_evk.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Enable PWM outputs on J24 pin 3 and J22 pin 6. These outputs are not used
+ * by the test, but can be tested using the PWM shell.
+ */
+
+&flexpwm1_pwm3 {
+	status = "okay";
+};
+
+&flexpwm1_pwm0 {
+	status = "okay";
+};


### PR DESCRIPTION
Added PWM outputs to arduino header, to make testing PWM support with this EVK simpler.