### PR TITLE
lib: os: dec: add misra-c2012 compliance changes

### DIFF
--- a/lib/os/dec.c
+++ b/lib/os/dec.c
@@ -12,10 +12,10 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value)
 	uint8_t num_digits = 0;
 	uint8_t digit;
 
-	while (buflen > 0 && divisor > 0) {
+	while ((buflen > 0) && (divisor > 0)) {
 		digit = value / divisor;
-		if (digit != 0 || divisor == 1 || num_digits != 0) {
-			*buf = (char)digit + '0';
+		if ((digit != 0) || (divisor == 1) || (num_digits != 0)) {
+			*buf = digit + (char)'0';
 			buf++;
 			buflen--;
 			num_digits++;
@@ -25,7 +25,7 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value)
 		divisor /= 10;
 	}
 
-	if (buflen) {
+	if (buflen != 0) {
 		*buf = '\0';
 	}
 


### PR DESCRIPTION
1. change explicit type cast of essential character type, complying with required [misra-c2012-10.2] rule which states; Expressions of essentially character type shall not be used inappropriately in addition and subtraction operations, and

2. add explicit boolean type to 'if' statement controlling expression, consolidating it with 'buflen' type, thus improving code readability and maintainability , complying with required [misra-c2012-14.4] rule which states; ; The controlling expression of an if statement and the controlling expression of an iteration-statement shall have essentially boolean type, and

3. add enclosing parentheses enforcing and clarifying precedence of operators, improving code readability and maintainability, complying with *advisory* [misra-c2012-12.1] rule which states; The precedence of operators within expressions should be made explicit.

Found as a coding guideline violation (Rules 10.2, 14.4), and coding guideline recommendation (Rule 12.1) by static code scanning tool.

Note: Tested on STM32L5 Nucleo-144 board (stm32l552xx).