### PR TITLE
sysbuild: Fix exporting BOARD.+ through sysbuild cache

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -317,7 +317,7 @@ function(ExternalZephyrProject_Cmake)
 
   get_cmake_property(sysbuild_cache CACHE_VARIABLES)
   foreach(var_name ${sysbuild_cache})
-    if(NOT ("${var_name}" MATCHES "^CMAKE_.*" OR "${var_name}" MATCHES "^BOARD"))
+    if(NOT "${var_name}" MATCHES "^(CMAKE_.*|BOARD)$")
       # Perform a dummy read to prevent a false warning about unused variables
       # being emitted due to a cmake bug: https://gitlab.kitware.com/cmake/cmake/-/issues/24555
       set(unused_tmp_var ${${var_name}})


### PR DESCRIPTION
Lately, sysbuild started filtering out variable names matching ^BOARD during sysbuild cache file generation. As a result, one of the cache variables that is no longer exported to other domains is BOARD_ROOT, which breaks the recent support for out-of-tree boards in sysbuild.

Of those variables, the only one which is reasonable to filter out is BOARD itself, because the purpose of that is to substitute a different value for the one found in sysbuild's own CMake cache, which has the board revision stripped out.

Update the relevant if-condition and use a single regex for brevity.

Fixes #59114.