### PR TITLE
drivers: sensor: ism330dhcx: fix pulse mode interrupts

### DIFF
--- a/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
+++ b/drivers/sensor/ism330dhcx/ism330dhcx_trigger.c
@@ -283,8 +283,8 @@ int ism330dhcx_init_interrupt(const struct device *dev)
 	}
 
 	/* enable interrupt on int1/int2 in pulse mode */
-	if (ism330dhcx_int_notification_set(ism330dhcx->ctx,
-					    ISM330DHCX_ALL_INT_PULSED) < 0) {
+	if (ism330dhcx_data_ready_mode_set(ism330dhcx->ctx,
+					   ISM330DHCX_DRDY_PULSED) < 0) {
 		LOG_ERR("Could not set pulse mode");
 		return -EIO;
 	}


### PR DESCRIPTION
On my end, the ISM330DHCX was stopping working after a few seconds.

After investigation, it seems that the function used to set the device in pulse mode only works for special modes like tap and embedded functions and not for data-ready as intended.

The data-ready was then in the default latched mode which does not work sustainably with the rest of the driver logic. In this mode, the driver can miss an interrupt and be forever waiting on a new data-ready pulse which will never happen as the interrupt line is already active.

This calls the correct function to enable pulsed data-ready mode as described in the datasheet section 9.7 COUNTER_BDR_REG1 (0Bh).

This was further verified looking at the interrupt pin behavior.

![DS2_QuickPrint28](https://github.com/zephyrproject-rtos/zephyr/assets/5411996/59ad4af7-7dd0-474b-b819-899acc7cf927)

This is the current interrupt pin behavior. This does not look like pulse mode as the active time is not fixed. It is also far from the expected 75us width described in the datasheet.

![DS2_QuickPrint26](https://github.com/zephyrproject-rtos/zephyr/assets/5411996/6f905d07-b244-4c45-9fa8-5f2551cfd423)
![DS2_QuickPrint25](https://github.com/zephyrproject-rtos/zephyr/assets/5411996/773a9a14-b283-41e4-b301-8d34e3b6ec7d)

This is with the modification which does exhibit the fixed pulses. Curiously they also are not 75us. The datasheet might need to be corrected.

