### PR TITLE
Bug: drivers/clock_control: SAM PMC missing soc.h

### DIFF
--- a/drivers/clock_control/clock_control_sam_pmc.c
+++ b/drivers/clock_control/clock_control_sam_pmc.c
@@ -13,6 +13,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
+#include <soc.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(clock_control, CONFIG_CLOCK_CONTROL_LOG_LEVEL);


### PR DESCRIPTION
The source clock_control_sam_pmc.c can not build without the symbol SOC_ATMEL_SAM_MCK_FREQ_HZ which is contained in soc.h

This bug only shows itself if CONFIG_ARM_MPU is not enabled, which probably includes soc.h through the <zephyr/arch/cpu.h> which is not desired behavior.

This commit adds the missing header, making the source build regardless of CONFIG_ARM_MPU.

Fixes #59136