### PR TITLE
modules: mbedtls: Fix for incorrect label name

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -107,7 +107,7 @@ zephyr_interface_library_named(mbedTLS)
 
     zephyr_library_named(mbedTLSCrypto)
 
-    if (MBEDTLS_USE_PSA_CRYPTO)
+    if (CONFIG_MBEDTLS_PSA_CRYPTO_C)
       list(APPEND crypto_source
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_aead.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_cipher.c


### PR DESCRIPTION
`MBEDTLS_USE_PSA_CRYPTO` does not match label defined in `Kconfig`.

Proposing to change to `CONFIG_MBEDTLS_PSA_CRYPTO_C`

Signed-off-by: Michele Sardo [msmttchr@gmail.com](msmttchr@gmail.com)

