### PR TITLE
[v2.7-branch] drivers: nrf_rtc_timer: Always set an initial timeout

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -341,10 +341,11 @@ int sys_clock_driver_init(const struct device *dev)
 		alloc_mask = BIT_MASK(EXT_CHAN_COUNT) << 1;
 	}
 
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		compare_set(0, counter() + CYC_PER_TICK,
-			    sys_clock_timeout_handler, NULL);
-	}
+	uint32_t initial_timeout = IS_ENABLED(CONFIG_TICKLESS_KERNEL) ?
+		MAX_CYCLES : CYC_PER_TICK;
+
+	compare_set(0, counter() + initial_timeout,
+		    sys_clock_timeout_handler, NULL);
 
 	z_nrf_clock_control_lf_on(mode);
 


### PR DESCRIPTION
In the tickless kernel mode, the nRF system timer does not schedule any timeout on initialization. This can lead to a situation that for certain applications no timeout is scheduled at all (for example, when an application does not create any threads, it exits `main()` without any sleeping and only handles interrupts) and in consequence `sys_clock_announce()` is never called (the nRF system timer calls this function only from the timeout handler). This in turn causes that uptime is reported correctly only until the RTC used as the system timer overflows (what happens after 512 seconds).

Fix this by setting a maximum allowed timeout when initializing the nRF system timer for the tickless kernel mode.

Fixes #56604.