### PR TITLE
mgmt: mcumgr: grp: img_mgmt: Add image data written callback

### DIFF
--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -228,6 +228,15 @@ struct mgmt_evt_op_cmd_arg {
 };
 
 /**
+ * @brief Get event ID index from event.
+ *
+ * @param event		Event to get ID index from.
+ *
+ * @return		Event index.
+ */
+uint8_t mgmt_evt_get_index(uint32_t event);
+
+/**
  * @brief This function is called to notify registered callbacks about mcumgr notifications/events.
  *
  * @param event		#mcumgr_op_t.

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -151,22 +151,25 @@ enum fs_mgmt_group_events {
  */
 enum img_mgmt_group_events {
 	/** Callback when a client sends a file upload chunk, data is img_mgmt_upload_check(). */
-	MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 0),
+	MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 0),
 
 	/** Callback when a DFU operation is stopped. */
-	MGMT_EVT_OP_IMG_MGMT_DFU_STOPPED	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 1),
+	MGMT_EVT_OP_IMG_MGMT_DFU_STOPPED		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 1),
 
 	/** Callback when a DFU operation is started. */
-	MGMT_EVT_OP_IMG_MGMT_DFU_STARTED	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 2),
+	MGMT_EVT_OP_IMG_MGMT_DFU_STARTED		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 2),
 
 	/** Callback when a DFU operation has finished being transferred. */
-	MGMT_EVT_OP_IMG_MGMT_DFU_PENDING	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 3),
+	MGMT_EVT_OP_IMG_MGMT_DFU_PENDING		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 3),
 
 	/** Callback when an image has been confirmed. */
-	MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 4),
+	MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 4),
+
+	/** Callback when an image write command has finished writing to flash. */
+	MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK_WRITE_COMPLETE	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 5),
 
 	/** Used to enable all img_mgmt_group events. */
-	MGMT_EVT_OP_IMG_MGMT_ALL		= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_IMG),
+	MGMT_EVT_OP_IMG_MGMT_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_IMG),
 };
 
 /**

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -642,6 +642,10 @@ img_mgmt_upload(struct smp_streamer *ctxt)
 #if defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS)
 			(void)mgmt_callback_notify(MGMT_EVT_OP_IMG_MGMT_DFU_PENDING, NULL, 0,
 						   &ret_rc, &ret_group);
+		} else {
+			/* Notify that the write has completed */
+			(void)mgmt_callback_notify(MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK_WRITE_COMPLETE,
+						   NULL, 0, &ret_rc, &ret_group);
 #endif
 		}
 	}

--- a/subsys/mgmt/mcumgr/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/mgmt/src/mgmt.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <assert.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/device.h>
@@ -142,6 +143,28 @@ enum mgmt_cb_return mgmt_callback_notify(uint32_t event, void *data, size_t data
 	}
 
 	return return_status;
+}
+
+uint8_t mgmt_evt_get_index(uint32_t event)
+{
+	uint8_t index = 0;
+
+	event &= MGMT_EVT_OP_ID_ALL;
+	__ASSERT((event != 0), "Event cannot be 0.");
+
+	while (index < 16) {
+		if (event & 0x1) {
+			break;
+		}
+
+		++index;
+		event = event >> 1;
+	}
+
+	event = event >> 1;
+	__ASSERT((event == 0), "Event cannot contain multiple values.");
+
+	return index;
 }
 #endif
 


### PR DESCRIPTION
    Adds an optional callback upon image data being written, can be
    used for syncing or timeout purposes.

and

    Adds a function which gets the callback ID index of a given
    event ID.