### PR TITLE
usb: device: class: rndis: Limit response length

### DIFF
--- a/subsys/usb/device/class/netusb/function_rndis.c
+++ b/subsys/usb/device/class/netusb/function_rndis.c
@@ -834,12 +834,18 @@ static int handle_encapsulated_rsp(uint8_t **data, uint32_t *len)
 		return -ENODATA;
 	}
 
+	*len = buf->len;
+	if (*len > CONFIG_USB_REQUEST_BUFFER_SIZE) {
+		LOG_ERR("Response too long %u, truncating to %u", buf->len,
+			CONFIG_USB_REQUEST_BUFFER_SIZE);
+		*len = CONFIG_USB_REQUEST_BUFFER_SIZE;
+	}
+
 	if (VERBOSE_DEBUG) {
 		net_hexdump("RSP <", buf->data, buf->len);
 	}
 
-	memcpy(*data, buf->data, buf->len);
-	*len = buf->len;
+	memcpy(*data, buf->data, *len);
 
 	net_buf_unref(buf);
 


### PR DESCRIPTION
Prevent potential buffer overflow when encapsulated response is more than CONFIG_USB_REQUEST_BUFFER_SIZE. Log error and truncate response if USB control transfer request buffer is not large enough.