### PR TITLE
tests: posix: pthread_pressure: enable pthread barrier in twister

### DIFF
--- a/tests/posix/pthread_pressure/testcase.yaml
+++ b/tests/posix/pthread_pressure/testcase.yaml
@@ -8,4 +8,8 @@ common:
   platform_exclude:
     - qemu_leon3
 tests:
-  portability.posix.pthread_pressure: {}
+  portability.posix.pthread_pressure:
+    extra_configs:
+      # Enabled for GitHub CI to reduce host scheduling noise while running
+      # several concurrent Qemu processes each under stressful SMP load.
+      - CONFIG_PTHREAD_CREATE_BARRIER=y


### PR DESCRIPTION
In some cases, when GitHub CI is running several Qemu processes, each with heavy loads, SMP tests have shown some flakiness. This exhibits itself as something like

```
... pthread_pressure on qemu_riscv32 failed (Timeout)
```

That is actually not at all limited to POSIX or any particular architecture, but is mainly to do with the host scheduler and perhaps memory barrier operations being lost in ISA translation by Qemu.

Collectively, we can refer to these issues as "scheduler noise".

To reduce scheduler noise in the `pthread_pressure` testsuite, enable `CONFIG_PTHREAD_CREATE_BARRIER` in `testcase.yaml`.

Note: end-users will likely not experience the need to enable this in `prj.conf`. E.g. the following basic test demonstrates 0 failures locallly.

```shell
TEST=tests/posix/pthread_pressure
twister --build-only -T $TEST &>/dev/null
FAIL=0
for ((i=0; i < 100; i++)); do
  echo "Run $((i+1))/100"
  twister --test-only -T $TEST &>/dev/null
  if [ $? -ne 0 ]; then
    FAIL=$((FAIL+1))
    echo "Failed $FAIL times"
  fi
done
echo "Failure Rate: $((FAIL))/100"
```