### PR TITLE
net: context: Verify that laddr was set before use in connect

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1112,6 +1112,8 @@ int net_context_connect(struct net_context *context,
 		ret = 0;
 	} else if (IS_ENABLED(CONFIG_NET_TCP) &&
 		   net_context_get_type(context) == SOCK_STREAM) {
+		NET_ASSERT(laddr != NULL);
+
 		ret = net_tcp_connect(context, addr, laddr, rport, lport,
 				      timeout, cb, user_data);
 	} else {

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1032,16 +1032,17 @@ int net_context_connect(struct net_context *context,
 			goto unlock;
 		}
 
-		NET_ASSERT(net_sin6_ptr(&context->local)->sin6_addr != NULL);
-
 		net_sin6_ptr(&context->local)->sin6_family = AF_INET6;
 		net_sin6(&local_addr)->sin6_family = AF_INET6;
 		net_sin6(&local_addr)->sin6_port = lport =
 			net_sin6((struct sockaddr *)&context->local)->sin6_port;
-		net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
-				net_sin6_ptr(&context->local)->sin6_addr);
 
-		laddr = &local_addr;
+		if (net_sin6_ptr(&context->local)->sin6_addr) {
+			net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
+				     net_sin6_ptr(&context->local)->sin6_addr);
+
+			laddr = &local_addr;
+		}
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   net_context_get_family(context) == AF_INET) {
 		struct sockaddr_in *addr4 = (struct sockaddr_in *)
@@ -1073,16 +1074,17 @@ int net_context_connect(struct net_context *context,
 			goto unlock;
 		}
 
-		NET_ASSERT(net_sin_ptr(&context->local)->sin_addr != NULL);
-
 		net_sin_ptr(&context->local)->sin_family = AF_INET;
 		net_sin(&local_addr)->sin_family = AF_INET;
 		net_sin(&local_addr)->sin_port = lport =
 			net_sin((struct sockaddr *)&context->local)->sin_port;
-		net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
-				net_sin_ptr(&context->local)->sin_addr);
 
-		laddr = &local_addr;
+		if (net_sin_ptr(&context->local)->sin_addr) {
+			net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
+				       net_sin_ptr(&context->local)->sin_addr);
+
+			laddr = &local_addr;
+		}
 	} else {
 		ret = -EINVAL; /* Not IPv4 or IPv6 */
 		goto unlock;


### PR DESCRIPTION
In previous patch fixing this issue, I've missed the fact that offloaded
drivers would not set the context->local address, which resulted in a
regression, where the previously introduced assert would hit in
offloaded cases. Not setting laddr is not a problem in case of
offloading, as it's only used in net_tcp_connect() which would not be
reached in this case.

Therefore I propose to remove previous patch to get rid of regression.
As an alternative fix, verify the laddr just before use, so that it is
only checked when native net stack is in use.

Fixes #58991