### PR TITLE
twister: pytest: Parse report file to get testcases

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -40,6 +40,7 @@ logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
 
 SUPPORTED_SIMS = ["mdb-nsim", "nsim", "renode", "qemu", "tsim", "armfvp", "xt-sim", "native"]
+SUPPORTED_SIMS_IN_PYTEST = ['native', 'qemu']
 
 
 def terminate_process(proc):

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2018-2022 Intel Corporation
 # Copyright 2022 NXP
 # SPDX-License-Identifier: Apache-2.0
-
+from __future__ import annotations
 import os
 import hashlib
 import random
@@ -11,11 +11,19 @@ import logging
 import shutil
 import glob
 
-from twisterlib.testsuite import TestCase
+from twisterlib.testsuite import TestCase, TestSuite
+from twisterlib.platform import Platform
 from twisterlib.error import BuildError
 from twisterlib.size_calc import SizeCalculator
-from twisterlib.handlers import Handler, SimulationHandler, BinaryHandler, QEMUHandler, DeviceHandler, SUPPORTED_SIMS
-from twisterlib.harness import SUPPORTED_SIMS_IN_PYTEST
+from twisterlib.handlers import (
+    Handler,
+    SimulationHandler,
+    BinaryHandler,
+    QEMUHandler,
+    DeviceHandler,
+    SUPPORTED_SIMS,
+    SUPPORTED_SIMS_IN_PYTEST,
+)
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
@@ -33,8 +41,8 @@ class TestInstance:
 
     def __init__(self, testsuite, platform, outdir):
 
-        self.testsuite = testsuite
-        self.platform = platform
+        self.testsuite: TestSuite = testsuite
+        self.platform: Platform = platform
 
         self.status = None
         self.reason = "Unknown"
@@ -51,7 +59,7 @@ class TestInstance:
         self.domains = None
 
         self.run = False
-        self.testcases = []
+        self.testcases: list[TestCase] = []
         self.init_cases()
         self.filters = []
         self.filter_type = None

--- a/scripts/tests/twister/conftest.py
+++ b/scripts/tests/twister/conftest.py
@@ -9,6 +9,8 @@ import os
 import sys
 import pytest
 
+pytest_plugins = ["pytester"]
+
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts"))

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import pytest
+import textwrap
+
+from unittest import mock
+from pathlib import Path
+
+from twisterlib.harness import Pytest
+from twisterlib.testsuite import TestSuite
+from twisterlib.testinstance import TestInstance
+from twisterlib.platform import Platform
+
+
+@pytest.fixture
+def testinstance() -> TestInstance:
+    testsuite = TestSuite('.', 'samples/hello', 'unit.test')
+    testsuite.harness_config = {}
+    testsuite.ignore_faults = False
+    platform = Platform()
+
+    testinstance = TestInstance(testsuite, platform, 'outdir')
+    testinstance.handler = mock.Mock()
+    testinstance.handler.options = mock.Mock()
+    testinstance.handler.options.verbose = 1
+    testinstance.handler.type_str = 'native'
+    return testinstance
+
+
+@pytest.mark.parametrize('device_type', ['native', 'qemu'])
+def test_pytest_command(testinstance: TestInstance, device_type):
+    pytest_harness = Pytest()
+    pytest_harness.configure(testinstance)
+
+    testinstance.handler.type_str = device_type
+    ref_command = [
+        'pytest',
+        'samples/hello/pytest',
+        f'--build-dir={testinstance.build_dir}',
+        f'--junit-xml={testinstance.build_dir}/report.xml',
+        f'--device-type={device_type}'
+    ]
+
+    command = pytest_harness.generate_command()
+    for c in ref_command:
+        assert c in command
+
+
+def test_if_report_is_parsed(pytester, testinstance: TestInstance):
+    test_file_content = textwrap.dedent("""
+        def test_1():
+            pass
+        def test_2():
+            pass
+    """)
+    test_file = pytester.path / 'test_valid.py'
+    test_file.write_text(test_file_content)
+    report_file = Path('report.xml')
+    result = pytester.runpytest(
+        str(test_file),
+        f'--junit-xml={str(report_file)}'
+    )
+    result.assert_outcomes(passed=2)
+    assert report_file.is_file()
+
+    pytest_harness = Pytest()
+    pytest_harness.configure(testinstance)
+    pytest_harness.report_file = report_file
+
+    pytest_harness._update_test_status()
+
+    assert pytest_harness.state == "passed"
+    assert testinstance.status == "passed"
+    assert len(testinstance.testcases) == 2
+    for tc in testinstance.testcases:
+        assert tc.status == "passed"
+
+
+def test_if_report_with_error(pytester, testinstance: TestInstance):
+    test_file_content = textwrap.dedent("""
+        def test_exp():
+            raise Exception('Test error')
+        def test_err():
+            assert False
+    """)
+    test_file = pytester.path / 'test_error.py'
+    test_file.write_text(test_file_content)
+    report_file = pytester.path / 'report.xml'
+    result = pytester.runpytest(
+        str(test_file),
+        f'--junit-xml={str(report_file)}'
+    )
+    result.assert_outcomes(failed=2)
+    assert report_file.is_file()
+
+    pytest_harness = Pytest()
+    pytest_harness.configure(testinstance)
+    pytest_harness.report_file = report_file
+
+    pytest_harness._update_test_status()
+
+    assert pytest_harness.state == "failed"
+    assert testinstance.status == "failed"
+    assert len(testinstance.testcases) == 2
+    for tc in testinstance.testcases:
+        assert tc.status == "failed"
+        assert tc.output
+        assert tc.reason
+
+
+def test_if_report_with_skip(pytester, testinstance: TestInstance):
+    test_file_content = textwrap.dedent("""
+        import pytest
+        @pytest.mark.skip('Test skipped')
+        def test_skip_1():
+            pass
+        def test_skip_2():
+            pytest.skip('Skipped on runtime')
+    """)
+    test_file = pytester.path / 'test_skip.py'
+    test_file.write_text(test_file_content)
+    report_file = pytester.path / 'report.xml'
+    result = pytester.runpytest(
+        str(test_file),
+        f'--junit-xml={str(report_file)}'
+    )
+    result.assert_outcomes(skipped=2)
+    assert report_file.is_file()
+
+    pytest_harness = Pytest()
+    pytest_harness.configure(testinstance)
+    pytest_harness.report_file = report_file
+
+    pytest_harness._update_test_status()
+
+    assert pytest_harness.state == "skipped"
+    assert testinstance.status == "skipped"
+    assert len(testinstance.testcases) == 2
+    for tc in testinstance.testcases:
+        assert tc.status == "skipped"


### PR DESCRIPTION
Extended parsing of report.xml file - produced by pytest-twister-harness plugin. Now testcases are properly extracted and added to twister report. Added unit tests.

To test just run:
`./scripts/twister -vv -T samples/subsys/testsuite/pytest/shell -p native_posix -p qemu_x86`
in test reports: `twister.json` and `twiseter_report.xml` you should find testcases: `test_shell_print_help` and `test_shell_print_version`.

Some changes also added to correct error handling. In couple of places I added annotations (just to help my IDE understanding the code).



