### PR TITLE
samples: fs: littlefs: make sample workable for mmc disk driver

### DIFF
--- a/samples/subsys/fs/littlefs/README.rst
+++ b/samples/subsys/fs/littlefs/README.rst
@@ -44,7 +44,7 @@ in this case).
 Block device (e.g. SD card)
 ---------------------------
 
-One needs to prepare the SD card with littlefs file system on
+One needs to prepare the SD/MMC card with littlefs file system on
 the host machine with the `lfs`_ program.
 
 .. _lfs:
@@ -77,7 +77,7 @@ Block device (e.g. SD card)
 ---------------------------
 
 This example has been devised and initially tested on :ref:`Nucleo H743ZI <nucleo_h743zi_board>`
-board. It can be also run on any other board with SD card connected to it.
+board. It can be also run on any other board with SD/MMC card connected to it.
 
 To build the test:
 
@@ -88,9 +88,21 @@ To build the test:
    :gen-args: -DCONF_FILE=prj_blk.conf
    :compact:
 
-One can also set ``CONFIG_SDMMC_VOLUME_NAME`` to provide the mount point name
-for `littlefs` file system block device.
+At the moment, only two types of block devices are acceptable in this sample: SDMMC and MMC.
 
+It is possible that both the `zephyr,sdmmc-disk` and `zephyr,mmc-disk` block devices will be
+present and enabled in the final board dts and configuration files simultaneously, the mount
+point name for the `littlefs` file system block device will be determined based on the
+following logic:
+
+* if the ``CONFIG_SDMMC_VOLUME_NAME`` configuration is defined, it will be used
+  as the mount point name;
+* if the ``CONFIG_SDMMC_VOLUME_NAME`` configuration is not defined, but the
+  ``CONFIG_MMC_VOLUME_NAME`` configuration is defined, ``CONFIG_MMC_VOLUME_NAME`` will
+  be used as the mount point name;
+* if neither ``CONFIG_SDMMC_VOLUME_NAME`` nor ``CONFIG_MMC_VOLUME_NAME`` configurations
+  are defined, the mount point name will not be determined, and an appropriate error will
+  apear during the sample build.
 
 NRF52840 Development Kit
 ========================

--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -309,6 +309,15 @@ static int littlefs_mount(struct fs_mount_t *mp)
 #endif /* CONFIG_APP_LITTLEFS_STORAGE_FLASH */
 
 #ifdef CONFIG_APP_LITTLEFS_STORAGE_BLK_SDMMC
+
+#if defined(CONFIG_DISK_DRIVER_SDMMC)
+#define DISK_NAME CONFIG_SDMMC_VOLUME_NAME
+#elif IS_ENABLED(CONFIG_DISK_DRIVER_MMC)
+#define DISK_NAME CONFIG_MMC_VOLUME_NAME
+#else
+#error "No disk device defined, is your board supported?"
+#endif
+
 struct fs_littlefs lfsfs;
 static struct fs_mount_t __mp = {
 	.type = FS_LITTLEFS,
@@ -319,8 +328,8 @@ struct fs_mount_t *mp = &__mp;
 
 static int littlefs_mount(struct fs_mount_t *mp)
 {
-	static const char *disk_mount_pt = "/"CONFIG_SDMMC_VOLUME_NAME":";
-	static const char *disk_pdrv = CONFIG_SDMMC_VOLUME_NAME;
+	static const char *disk_mount_pt = "/"DISK_NAME":";
+	static const char *disk_pdrv = DISK_NAME;
 
 	mp->storage_dev = (void *)disk_pdrv;
 	mp->mnt_point = disk_mount_pt;


### PR DESCRIPTION
The LittleFS sample may be used for both SDMMC and MMC disk drivers, so make it possible to work with different volume disk driver names.