### PR TITLE
arch: arm64: cache: fix usage of extern C linkage specification

### DIFF
--- a/include/zephyr/arch/arm64/cache.h
+++ b/include/zephyr/arch/arm64/cache.h
@@ -312,10 +312,11 @@ static ALWAYS_INLINE void arch_icache_disable(void)
 }
 
 #endif /* CONFIG_ICACHE */
-#endif /* ZEPHYR_INCLUDE_ARCH_ARM64_CACHE_H_ */
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* _ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM64_CACHE_H_ */


### PR DESCRIPTION
Reorder preprocessor condition endings in arm64/cache.h, this eliminates the breaking of the 'extern "C"' construction.