### PR TITLE
boot: banner: Remove delaying message

### DIFF
--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -25,8 +25,8 @@
 void boot_banner(void)
 {
 #if defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0)
-	printk("***** delaying boot " DELAY_STR "ms (per build configuration) *****\n");
 	k_busy_wait(CONFIG_BOOT_DELAY * USEC_PER_MSEC);
+	printk("***** delaying boot " DELAY_STR "ms (per build configuration) *****\n");
 #endif /* defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0) */
 
 #if CONFIG_BOOT_BANNER


### PR DESCRIPTION
One purpose of CONFIG_BOOT_DELAY is allowing serial port to get ready before starting to print information, it does not make sense print any message before this delay happens.

This commit is completely removing this message because the banner message already prints the delay information and in case of building without boot banner enabled is very unlikely that the application wants to have any message printed.