### PR TITLE
Bluetooth: Controller: Fix BT_CTLR_CENTRAL_SPACING to ticks conversion

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -752,7 +752,7 @@ static struct ull_hdr *ull_hdr_get_cb(uint8_t ticker_id, uint32_t *ticks_slot)
 				*ticks_slot = conn->ull.ticks_slot;
 			}
 
-			if (*ticks_slot < CONFIG_BT_CTLR_CENTRAL_SPACING) {
+			if (*ticks_slot < HAL_TICKER_US_TO_TICKS(CONFIG_BT_CTLR_CENTRAL_SPACING)) {
 				*ticks_slot =
 					HAL_TICKER_US_TO_TICKS(CONFIG_BT_CTLR_CENTRAL_SPACING);
 			}


### PR DESCRIPTION
Fix missing BT_CTLR_CENTRAL_SPACING in microseconds to ticks conversion.