### PR TITLE
Bluetooth: Controller: Fix CIS accept fails with unsupp parameters

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -377,6 +377,16 @@ config BT_CTLR_SCAN_ENABLE_STRICT
 	  Enforce returning HCI Error Command Disallowed on enabling/disabling
 	  already enabled/disabled scanning.
 
+config BT_CTLR_CIS_ACCEPT_MIN_OFFSET_STRICT
+	bool "Enforce Strict CIS Minimum Offset Check"
+	depends on BT_CTLR_PERIPHERAL_ISO
+	help
+	  Enforce strict check of CIS minimum offset accepted by the peripheral
+	  considering that there will be no overlap of ACL connection with the
+	  CIG events. Radio and CPU overheads for an ACL connection event is
+	  considered and checks the CIS minimum offset is greater than the time
+	  reservation for the ACL connection.
+
 config BT_CTLR_ISOAL_SN_STRICT
 	bool "Enforce Strict Tx ISO Data Sequence Number use"
 	depends on BT_CTLR_ADV_ISO || BT_CTLR_CONN_ISO

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -104,7 +104,8 @@ uint8_t ll_cis_accept(uint16_t handle)
 	if (conn) {
 		uint32_t cis_offset_min;
 
-		if (IS_ENABLED(CONFIG_BT_CTLR_JIT_SCHEDULING)) {
+		if (IS_ENABLED(CONFIG_BT_CTLR_JIT_SCHEDULING) ||
+		    !IS_ENABLED(CONFIG_BT_CTLR_CIS_ACCEPT_MIN_OFFSET_STRICT)) {
 			cis_offset_min = MAX(400, EVENT_OVERHEAD_CIS_SETUP_US);
 		} else {
 			cis_offset_min = HAL_TICKER_TICKS_TO_US(conn->ull.ticks_slot) +


### PR DESCRIPTION
Fix CIS accepted by Host being failed in the Controller with reason 0x20 Unsupported LL Parameter Value, but relaxing the check that the ACL connection is sufficiently placed such that the time reservation using in the Controller
implementation does not overlap with the CIG event.