### PR TITLE
Bluetooth: Host: Use custom settings API for Bluetooth subsystem

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -332,28 +332,16 @@ static struct gatt_sc_cfg *find_sc_cfg(uint8_t id, const bt_addr_le_t *addr)
 
 static void sc_store(struct gatt_sc_cfg *cfg)
 {
-	char key[BT_SETTINGS_KEY_MAX];
 	int err;
 
-	if (cfg->id) {
-		char id_str[4];
-
-		u8_to_dec(id_str, sizeof(id_str), cfg->id);
-		bt_settings_encode_key(key, sizeof(key), "sc",
-				       &cfg->peer, id_str);
-	} else {
-		bt_settings_encode_key(key, sizeof(key), "sc",
-				       &cfg->peer, NULL);
-	}
-
-	err = settings_save_one(key, (char *)&cfg->data, sizeof(cfg->data));
+	err = bt_settings_store_sc(cfg->id, &cfg->peer, &cfg->data, sizeof(cfg->data));
 	if (err) {
 		LOG_ERR("failed to store SC (err %d)", err);
 		return;
 	}
 
-	LOG_DBG("stored SC for %s (%s, 0x%04x-0x%04x)", bt_addr_le_str(&cfg->peer), key,
-		cfg->data.start, cfg->data.end);
+	LOG_DBG("stored SC for %s (0x%04x-0x%04x)", bt_addr_le_str(&cfg->peer), cfg->data.start,
+		cfg->data.end);
 }
 
 static void clear_sc_cfg(struct gatt_sc_cfg *cfg)
@@ -372,25 +360,13 @@ static int bt_gatt_clear_sc(uint8_t id, const bt_addr_le_t *addr)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		char key[BT_SETTINGS_KEY_MAX];
 		int err;
 
-		if (cfg->id) {
-			char id_str[4];
-
-			u8_to_dec(id_str, sizeof(id_str), cfg->id);
-			bt_settings_encode_key(key, sizeof(key), "sc",
-					       &cfg->peer, id_str);
-		} else {
-			bt_settings_encode_key(key, sizeof(key), "sc",
-					       &cfg->peer, NULL);
-		}
-
-		err = settings_delete(key);
+		err = bt_settings_delete_sc(cfg->id, &cfg->peer);
 		if (err) {
 			LOG_ERR("failed to delete SC (err %d)", err);
 		} else {
-			LOG_DBG("deleted SC for %s (%s)", bt_addr_le_str(&cfg->peer), key);
+			LOG_DBG("deleted SC for %s", bt_addr_le_str(&cfg->peer));
 		}
 	}
 
@@ -836,7 +812,7 @@ static void db_hash_store(void)
 #if defined(CONFIG_BT_SETTINGS)
 	int err;
 
-	err = settings_save_one("bt/hash", &db_hash.hash, sizeof(db_hash.hash));
+	err = bt_settings_store_hash(&db_hash.hash, sizeof(db_hash.hash));
 	if (err) {
 		LOG_ERR("Failed to save Database Hash (err %d)", err);
 	}
@@ -1032,7 +1008,6 @@ static int bt_gatt_store_cf(uint8_t id, const bt_addr_le_t *peer)
 {
 #if defined(CONFIG_BT_GATT_CACHING)
 	struct gatt_cf_cfg *cfg;
-	char key[BT_SETTINGS_KEY_MAX];
 	char dst[CF_NUM_BYTES + CF_FLAGS_STORE_LEN];
 	char *str;
 	size_t len;
@@ -1048,14 +1023,6 @@ static int bt_gatt_store_cf(uint8_t id, const bt_addr_le_t *peer)
 		str = (char *)cfg->data;
 		len = sizeof(cfg->data);
 
-		if (id) {
-			char id_str[4];
-
-			u8_to_dec(id_str, sizeof(id_str), id);
-			bt_settings_encode_key(key, sizeof(key), "cf",
-					       peer, id_str);
-		}
-
 		/* add the CF data to a temp array */
 		memcpy(dst, str, len);
 
@@ -1069,18 +1036,13 @@ static int bt_gatt_store_cf(uint8_t id, const bt_addr_le_t *peer)
 		str = dst;
 	}
 
-	if (!cfg || !id) {
-		bt_settings_encode_key(key, sizeof(key), "cf",
-				       peer, NULL);
-	}
-
-	err = settings_save_one(key, str, len);
+	err = bt_settings_store_cf(id, peer, str, len);
 	if (err) {
 		LOG_ERR("Failed to store Client Features (err %d)", err);
 		return err;
 	}
 
-	LOG_DBG("Stored CF for %s (%s)", bt_addr_le_str(peer), key);
+	LOG_DBG("Stored CF for %s", bt_addr_le_str(peer));
 	LOG_HEXDUMP_DBG(str, len, "Saved data");
 #endif /* CONFIG_BT_GATT_CACHING */
 	return 0;
@@ -5702,7 +5664,7 @@ static int ccc_set_cb(const char *name, size_t len_rd, settings_read_cb read_cb,
 	return ccc_set(name, len_rd, read_cb, cb_arg);
 }
 
-SETTINGS_STATIC_HANDLER_DEFINE(bt_ccc, "bt/ccc", NULL, ccc_set_cb, NULL, NULL);
+BT_SETTINGS_DEFINE(ccc, "ccc", ccc_set_cb, NULL);
 
 static int ccc_set_direct(const char *key, size_t len, settings_read_cb read_cb,
 			  void *cb_arg, void *param)
@@ -5938,7 +5900,6 @@ static uint8_t ccc_save(const struct bt_gatt_attr *attr, uint16_t handle,
 int bt_gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr)
 {
 	struct ccc_save save;
-	char key[BT_SETTINGS_KEY_MAX];
 	size_t len;
 	char *str;
 	int err;
@@ -5949,15 +5910,6 @@ int bt_gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr)
 
 	bt_gatt_foreach_attr(0x0001, 0xffff, ccc_save, &save);
 
-	if (id) {
-		char id_str[4];
-
-		u8_to_dec(id_str, sizeof(id_str), id);
-		bt_settings_encode_key(key, sizeof(key), "ccc", addr, id_str);
-	} else {
-		bt_settings_encode_key(key, sizeof(key), "ccc", addr, NULL);
-	}
-
 	if (save.count) {
 		str = (char *)save.store;
 		len = save.count * sizeof(*save.store);
@@ -5967,13 +5919,13 @@ int bt_gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr)
 		len = 0;
 	}
 
-	err = settings_save_one(key, str, len);
+	err = bt_settings_store_ccc(id, addr, str, len);
 	if (err) {
 		LOG_ERR("Failed to store CCCs (err %d)", err);
 		return err;
 	}
 
-	LOG_DBG("Stored CCCs for %s (%s)", bt_addr_le_str(addr), key);
+	LOG_DBG("Stored CCCs for %s", bt_addr_le_str(addr));
 	if (len) {
 		for (size_t i = 0; i < save.count; i++) {
 			LOG_DBG("  CCC: handle 0x%04x value 0x%04x", save.store[i].handle,
@@ -6069,7 +6021,7 @@ static int sc_commit(void)
 	return 0;
 }
 
-SETTINGS_STATIC_HANDLER_DEFINE(bt_sc, "bt/sc", NULL, sc_set, sc_commit, NULL);
+BT_SETTINGS_DEFINE(sc, "sc", sc_set, sc_commit);
 #endif /* CONFIG_BT_GATT_SERVICE_CHANGED */
 
 #if defined(CONFIG_BT_GATT_CACHING)
@@ -6159,7 +6111,7 @@ static int cf_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	return 0;
 }
 
-SETTINGS_STATIC_HANDLER_DEFINE(bt_cf, "bt/cf", NULL, cf_set, NULL, NULL);
+BT_SETTINGS_DEFINE(cf, "cf", cf_set, NULL);
 
 static int db_hash_set(const char *name, size_t len_rd,
 		       settings_read_cb read_cb, void *cb_arg)
@@ -6190,8 +6142,7 @@ static int db_hash_commit(void)
 	return 0;
 }
 
-SETTINGS_STATIC_HANDLER_DEFINE(bt_hash, "bt/hash", NULL, db_hash_set,
-			       db_hash_commit, NULL);
+BT_SETTINGS_DEFINE(hash, "hash", db_hash_set, db_hash_commit);
 #endif /*CONFIG_BT_GATT_CACHING */
 #endif /* CONFIG_BT_SETTINGS */
 
@@ -6229,20 +6180,7 @@ static int bt_gatt_clear_ccc(uint8_t id, const bt_addr_le_t *addr)
 			     &addr_with_id);
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		char key[BT_SETTINGS_KEY_MAX];
-
-		if (id) {
-			char id_str[4];
-
-			u8_to_dec(id_str, sizeof(id_str), id);
-			bt_settings_encode_key(key, sizeof(key), "ccc",
-					       addr, id_str);
-		} else {
-			bt_settings_encode_key(key, sizeof(key), "ccc",
-					       addr, NULL);
-		}
-
-		return settings_delete(key);
+		return bt_settings_delete_ccc(id, addr);
 	}
 
 	return 0;
@@ -6258,20 +6196,7 @@ static int bt_gatt_clear_cf(uint8_t id, const bt_addr_le_t *addr)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		char key[BT_SETTINGS_KEY_MAX];
-
-		if (id) {
-			char id_str[4];
-
-			u8_to_dec(id_str, sizeof(id_str), id);
-			bt_settings_encode_key(key, sizeof(key), "cf",
-					       addr, id_str);
-		} else {
-			bt_settings_encode_key(key, sizeof(key), "cf",
-					       addr, NULL);
-		}
-
-		return settings_delete(key);
+		return bt_settings_delete_ccc(id, addr);
 	}
 
 	return 0;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4093,7 +4093,7 @@ int bt_set_name(const char *name)
 	bt_dev.name[len] = '\0';
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		err = settings_save_one("bt/name", bt_dev.name, len);
+		err = bt_settings_store_name(bt_dev.name, len);
 		if (err) {
 			LOG_WRN("Unable to store name");
 		}
@@ -4128,9 +4128,7 @@ int bt_set_appearance(uint16_t appearance)
 {
 	if (bt_dev.appearance != appearance) {
 		if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-			int err = settings_save_one("bt/appearance", &appearance,
-					sizeof(appearance));
-
+			int err = bt_settings_store_appearance(&appearance, sizeof(appearance));
 			if (err) {
 				LOG_ERR("Unable to save setting 'bt/appearance' (err %d).", err);
 				return err;

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -1229,7 +1229,8 @@ static int id_create(uint8_t id, bt_addr_le_t *addr, uint8_t *irk)
 	 */
 	if (IS_ENABLED(CONFIG_BT_SETTINGS) &&
 	    atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
-		bt_settings_save_id();
+		(void)bt_settings_store_id();
+		(void)bt_settings_store_irk();
 	}
 
 	return 0;
@@ -1378,7 +1379,8 @@ int bt_id_delete(uint8_t id)
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS) &&
 	    atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
-		bt_settings_save_id();
+		(void)bt_settings_store_id();
+		(void)bt_settings_store_irk();
 	}
 
 	return 0;

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -311,22 +311,8 @@ void bt_keys_clear(struct bt_keys *keys)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		char key[BT_SETTINGS_KEY_MAX];
-
 		/* Delete stored keys from flash */
-		if (keys->id) {
-			char id[4];
-
-			u8_to_dec(id, sizeof(id), keys->id);
-			bt_settings_encode_key(key, sizeof(key), "keys",
-					       &keys->addr, id);
-		} else {
-			bt_settings_encode_key(key, sizeof(key), "keys",
-					       &keys->addr, NULL);
-		}
-
-		LOG_DBG("Deleting key %s", key);
-		settings_delete(key);
+		bt_settings_delete_keys(keys->id, &keys->addr);
 	}
 
 	(void)memset(keys, 0, sizeof(*keys));
@@ -335,29 +321,18 @@ void bt_keys_clear(struct bt_keys *keys)
 #if defined(CONFIG_BT_SETTINGS)
 int bt_keys_store(struct bt_keys *keys)
 {
-	char key[BT_SETTINGS_KEY_MAX];
 	int err;
 
 	__ASSERT_NO_MSG(keys != NULL);
 
-	if (keys->id) {
-		char id[4];
-
-		u8_to_dec(id, sizeof(id), keys->id);
-		bt_settings_encode_key(key, sizeof(key), "keys", &keys->addr,
-				       id);
-	} else {
-		bt_settings_encode_key(key, sizeof(key), "keys", &keys->addr,
-				       NULL);
-	}
-
-	err = settings_save_one(key, keys->storage_start, BT_KEYS_STORAGE_LEN);
+	err = bt_settings_store_keys(keys->id, &keys->addr, keys->storage_start,
+				     BT_KEYS_STORAGE_LEN);
 	if (err) {
 		LOG_ERR("Failed to save keys (err %d)", err);
 		return err;
 	}
 
-	LOG_DBG("Stored keys for %s (%s)", bt_addr_le_str(&keys->addr), key);
+	LOG_DBG("Stored keys for %s", bt_addr_le_str(&keys->addr));
 
 	return 0;
 }
@@ -473,8 +448,7 @@ static int keys_commit(void)
 	return 0;
 }
 
-SETTINGS_STATIC_HANDLER_DEFINE(bt_keys, "bt/keys", NULL, keys_set, keys_commit,
-			       NULL);
+BT_SETTINGS_DEFINE(keys, "keys", keys_set, keys_commit);
 
 #endif /* CONFIG_BT_SETTINGS */
 

--- a/subsys/bluetooth/host/keys_br.c
+++ b/subsys/bluetooth/host/keys_br.c
@@ -98,14 +98,12 @@ struct bt_keys_link_key *bt_keys_get_link_key(const bt_addr_t *addr)
 void bt_keys_link_key_clear(struct bt_keys_link_key *link_key)
 {
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-		char key[BT_SETTINGS_KEY_MAX];
 		bt_addr_le_t le_addr;
 
 		le_addr.type = BT_ADDR_LE_PUBLIC;
 		bt_addr_copy(&le_addr.a, &link_key->addr);
-		bt_settings_encode_key(key, sizeof(key), "link_key",
-				       &le_addr, NULL);
-		settings_delete(key);
+
+		bt_settings_delete_link_key(&le_addr);
 	}
 
 	LOG_DBG("%s", bt_addr_str(&link_key->addr));
@@ -135,16 +133,13 @@ void bt_keys_link_key_store(struct bt_keys_link_key *link_key)
 {
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		int err;
-		char key[BT_SETTINGS_KEY_MAX];
 		bt_addr_le_t le_addr;
 
 		le_addr.type = BT_ADDR_LE_PUBLIC;
 		bt_addr_copy(&le_addr.a, &link_key->addr);
-		bt_settings_encode_key(key, sizeof(key), "link_key",
-				       &le_addr, NULL);
 
-		err = settings_save_one(key, link_key->storage_start,
-					BT_KEYS_LINK_KEY_STORAGE_LEN);
+		err = bt_settings_store_link_key(&le_addr, link_key->storage_start,
+						 BT_KEYS_LINK_KEY_STORAGE_LEN);
 		if (err) {
 			LOG_ERR("Failed to save link key (err %d)", err);
 		}

--- a/subsys/bluetooth/host/settings.h
+++ b/subsys/bluetooth/host/settings.h
@@ -4,11 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/settings/settings.h>
+
 /* Max settings key length (with all components) */
 #define BT_SETTINGS_KEY_MAX 36
 
 /* Base64-encoded string buffer size of in_size bytes */
 #define BT_SETTINGS_SIZE(in_size) ((((((in_size) - 1) / 3) * 4) + 4) + 1)
+
+#define BT_SETTINGS_DEFINE(_hname, _subtree, _set, _commit)                                        \
+	SETTINGS_STATIC_HANDLER_DEFINE(bt_##_hname, "bt/" _subtree, NULL, _set, _commit, NULL)
+
+#define ID_DATA_LEN(array) (bt_dev.id_count * sizeof(array[0]))
+
+int bt_settings_store(const char *key, uint8_t id, const bt_addr_le_t *addr, const void *value,
+		      size_t val_len);
+int bt_settings_delete(const char *key, uint8_t id, const bt_addr_le_t *addr);
 
 /* Helpers for keys containing a bdaddr */
 void bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
@@ -18,3 +29,33 @@ int bt_settings_decode_key(const char *key, bt_addr_le_t *addr);
 void bt_settings_save_id(void);
 
 int bt_settings_init(void);
+
+int bt_settings_store_sc(uint8_t id, const bt_addr_le_t *addr, const void *value, size_t val_len);
+int bt_settings_delete_sc(uint8_t id, const bt_addr_le_t *addr);
+
+int bt_settings_store_cf(uint8_t id, const bt_addr_le_t *addr, const void *value, size_t val_len);
+int bt_settings_delete_cf(uint8_t id, const bt_addr_le_t *addr);
+
+int bt_settings_store_ccc(uint8_t id, const bt_addr_le_t *addr, const void *value, size_t val_len);
+int bt_settings_delete_ccc(uint8_t id, const bt_addr_le_t *addr);
+
+int bt_settings_store_hash(const void *value, size_t val_len);
+int bt_settings_delete_hash(void);
+
+int bt_settings_store_name(const void *value, size_t val_len);
+int bt_settings_delete_name(void);
+
+int bt_settings_store_appearance(const void *value, size_t val_len);
+int bt_settings_delete_appearance(void);
+
+int bt_settings_store_id(void);
+int bt_settings_delete_id(void);
+
+int bt_settings_store_irk(void);
+int bt_settings_delete_irk(void);
+
+int bt_settings_store_link_key(const bt_addr_le_t *addr, const void *value, size_t val_len);
+int bt_settings_delete_link_key(const bt_addr_le_t *addr);
+
+int bt_settings_store_keys(uint8_t id, const bt_addr_le_t *addr, const void *value, size_t val_len);
+int bt_settings_delete_keys(uint8_t id, const bt_addr_le_t *addr);

--- a/tests/bluetooth/host/id/bt_id_delete/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_delete/src/main.c
@@ -64,7 +64,8 @@ ZTEST(bt_id_delete, test_delete_non_default_no_last_item)
 
 	err = bt_id_delete(id);
 
-	expect_not_called_bt_settings_save_id();
+	expect_not_called_bt_settings_store_id();
+	expect_not_called_bt_settings_store_irk();
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 	zassert_true(bt_dev.id_count == id_count, "Incorrect ID count %d was set", bt_dev.id_count);
@@ -109,7 +110,8 @@ ZTEST(bt_id_delete, test_delete_last_id)
 
 	err = bt_id_delete(id);
 
-	expect_not_called_bt_settings_save_id();
+	expect_not_called_bt_settings_store_id();
+	expect_not_called_bt_settings_store_irk();
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 

--- a/tests/bluetooth/host/id/bt_id_delete/src/test_suite_bt_settings.c
+++ b/tests/bluetooth/host/id/bt_id_delete/src/test_suite_bt_settings.c
@@ -21,8 +21,8 @@ ZTEST_SUITE(bt_id_delete_bt_settings, NULL, NULL, NULL, NULL, NULL);
 
 /*
  *  Test deleting an ID, but not the last one
- *  As 'CONFIG_BT_SETTINGS' is enabled, settings should be saved by calling bt_settings_save_id()
- *  if 'BT_DEV_READY' flag in bt_dev.flags is set
+ *  As 'CONFIG_BT_SETTINGS' is enabled, settings should be saved by calling bt_settings_store_id()
+ *  and bt_settings_store_irk() if 'BT_DEV_READY' flag in bt_dev.flags is set
  *
  *  Constraints:
  *   - ID value used is neither corresponds to default index nor the last index
@@ -32,7 +32,7 @@ ZTEST_SUITE(bt_id_delete_bt_settings, NULL, NULL, NULL, NULL, NULL);
  *  Expected behaviour:
  *   - bt_dev.id_addr[] at index equals to the ID value used is cleared
  *   - bt_dev.irk[] at index equals to the ID value used is cleared (if privacy is enabled)
- *   - bt_settings_save_id() is called to save settings
+ *   - bt_settings_store_id() and bt_settings_store_irk() are called to save settings
  *   - bt_dev.id_count is kept unchanged
  *   - bt_id_delete() returns 0
  */
@@ -59,7 +59,8 @@ ZTEST(bt_id_delete_bt_settings, test_delete_non_default_no_last_item_settings_en
 
 	err = bt_id_delete(id);
 
-	expect_single_call_bt_settings_save_id();
+	expect_single_call_bt_settings_store_id();
+	expect_single_call_bt_settings_store_irk();
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 	zassert_true(bt_dev.id_count == id_count, "Incorrect ID count %d was set", bt_dev.id_count);
@@ -73,9 +74,9 @@ ZTEST(bt_id_delete_bt_settings, test_delete_non_default_no_last_item_settings_en
 }
 
 /*
- *  Test deleting last ID.
- *  As 'CONFIG_BT_SETTINGS' is enabled, settings should be saved by calling bt_settings_save_id()
- *  if 'BT_DEV_READY' flag in bt_dev.flags is set
+ *  Test deleting last ID. As 'CONFIG_BT_SETTINGS' is enabled, settings should
+ *  be saved by calling bt_settings_store_id() and bt_settings_store_irk() if
+ *  'BT_DEV_READY' flag in bt_dev.flags is set
  *
  *  Constraints:
  *   - ID value used corresponds to the last item in the list bt_dev.id_addr[]
@@ -84,8 +85,9 @@ ZTEST(bt_id_delete_bt_settings, test_delete_non_default_no_last_item_settings_en
  *
  *  Expected behaviour:
  *   - bt_dev.id_addr[] at index equals to the ID value used is cleared
- *   - bt_dev.irk[] at index equals to the ID value used is cleared (if privacy is enabled)
- *   - bt_settings_save_id() is called to save settings
+ *   - bt_dev.irk[] at index equals to the ID value used is cleared (if privacy
+ *     is enabled)
+ *   - bt_settings_store_id() and bt_settings_store_irk() are called to save settings
  *   - bt_dev.id_count is decremented
  *   - bt_id_delete() returns 0
  */
@@ -111,7 +113,8 @@ ZTEST(bt_id_delete_bt_settings, test_delete_last_id_settings_enabled)
 
 	err = bt_id_delete(id);
 
-	expect_single_call_bt_settings_save_id();
+	expect_single_call_bt_settings_store_id();
+	expect_single_call_bt_settings_store_irk();
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 	zassert_true(bt_dev.id_count == (id_count - 1), "Incorrect ID count %d was set",

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/src/test_suite_bt_settings_enabled.c
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/src/test_suite_bt_settings_enabled.c
@@ -50,7 +50,7 @@ ZTEST_SUITE(bt_setup_public_id_addr_bt_settings_enabled, NULL, NULL, tc_setup, N
  *
  *  Expected behaviour:
  *   - ID count is set to 0 and bt_setup_public_id_addr() returns 0
- *   - No expected calls to bt_settings_save_id()
+ *   - No expected calls to bt_settings_store_id()
  */
 ZTEST(bt_setup_public_id_addr_bt_settings_enabled, test_bt_id_read_public_addr_returns_zero)
 {
@@ -61,7 +61,7 @@ ZTEST(bt_setup_public_id_addr_bt_settings_enabled, test_bt_id_read_public_addr_r
 
 	err = bt_setup_public_id_addr();
 
-	expect_not_called_bt_settings_save_id();
+	expect_not_called_bt_settings_store_id();
 
 	zassert_true(bt_dev.id_count == 0, "Incorrect value '%d' was set to bt_dev.id_count",
 		     bt_dev.id_count);
@@ -86,7 +86,7 @@ static int bt_hci_cmd_send_sync_custom_fake(uint16_t opcode, struct net_buf *buf
 
 /*
  *  Test reading controller public address through bt_hci_cmd_send_sync().
- *  Even if the operation succeeded, bt_settings_save_id() shouldn't be called to
+ *  Even if the operation succeeded, bt_settings_store_id() shouldn't be called to
  *  store settings as the 'BT_DEV_READY' bit isn't set.
  *
  *  Constraints:
@@ -112,7 +112,7 @@ ZTEST(bt_setup_public_id_addr_bt_settings_enabled,
 
 	err = bt_setup_public_id_addr();
 
-	expect_not_called_bt_settings_save_id();
+	expect_not_called_bt_settings_store_id();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 	zassert_mem_equal(&bt_dev.id_addr[BT_ID_DEFAULT], BT_LE_ADDR, sizeof(bt_addr_le_t),
@@ -122,8 +122,8 @@ ZTEST(bt_setup_public_id_addr_bt_settings_enabled,
 }
 
 /*
- *  Test reading controller public address through bt_hci_cmd_send_sync().
- *  With the 'BT_DEV_READY' bit set, bt_settings_save_id() should be called to store
+ *  Test reading controller public address through bt_hci_cmd_send_sync(). With
+ *  the 'BT_DEV_READY' bit set, bt_settings_store_id() should be called to store
  *  settings to persistent memory.
  *
  *  Constraints:
@@ -149,7 +149,7 @@ ZTEST(bt_setup_public_id_addr_bt_settings_enabled,
 
 	err = bt_setup_public_id_addr();
 
-	expect_single_call_bt_settings_save_id();
+	expect_single_call_bt_settings_store_id();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 	zassert_mem_equal(&bt_dev.id_addr[BT_ID_DEFAULT], BT_LE_ADDR, sizeof(bt_addr_le_t),

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_bt_settings_enabled.c
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_bt_settings_enabled.c
@@ -54,7 +54,7 @@ ZTEST_SUITE(bt_setup_random_id_addr_bt_settings_enabled, NULL, NULL, tc_setup, N
  *
  *  Expected behaviour:
  *   - ID count is set to 0 and bt_setup_random_id_addr() returns a negative error code
- *   - No expected calls to bt_settings_save_id()
+ *   - No expected calls to bt_settings_store_id()
  */
 ZTEST(bt_setup_random_id_addr_bt_settings_enabled, test_bt_read_static_addr_returns_zero)
 {
@@ -65,7 +65,7 @@ ZTEST(bt_setup_random_id_addr_bt_settings_enabled, test_bt_read_static_addr_retu
 
 	err = bt_setup_random_id_addr();
 
-	expect_not_called_bt_settings_save_id();
+	expect_not_called_bt_settings_store_id();
 
 	zassert_true(bt_dev.id_count == 0, "Incorrect value '%d' was set to bt_dev.id_count",
 		     bt_dev.id_count);
@@ -90,7 +90,7 @@ static int bt_hci_cmd_send_sync_custom_fake(uint16_t opcode, struct net_buf *buf
 
 /*
  *  Test reading controller static random address through bt_hci_cmd_send_sync().
- *  Even if the operation succeeded, bt_settings_save_id() shouldn't be called to
+ *  Even if the operation succeeded, bt_settings_store_id() shouldn't be called to
  *  store settings as the 'BT_DEV_READY' bit isn't set.
  *
  *  Constraints:
@@ -101,7 +101,7 @@ static int bt_hci_cmd_send_sync_custom_fake(uint16_t opcode, struct net_buf *buf
  *  Expected behaviour:
  *   - Return value is 0
  *   - Static random address is loaded to bt_dev.id_addr[]
- *   - No expected calls to bt_settings_save_id()
+ *   - No expected calls to bt_settings_store_id()
  */
 ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
 	  test_bt_read_static_addr_succeeds_bt_dev_ready_cleared)
@@ -126,7 +126,7 @@ ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
 
 	err = bt_setup_random_id_addr();
 
-	expect_not_called_bt_settings_save_id();
+	expect_not_called_bt_settings_store_id();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 	zassert_mem_equal(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),
@@ -136,8 +136,9 @@ ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
 }
 
 /*
- *  Test reading controller static random address through bt_hci_cmd_send_sync().
- *  With the 'BT_DEV_READY' bit set, bt_settings_save_id() should be called to store
+ *  Test reading controller static random address through
+ *  bt_hci_cmd_send_sync(). With the 'BT_DEV_READY' bit set,
+ *  bt_settings_store_id() and bt_settings_store_irk() should be called to store
  *  settings to persistent memory.
  *
  *  Constraints:
@@ -148,7 +149,7 @@ ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
  *  Expected behaviour:
  *   - Return value is 0
  *   - Static random address is loaded to bt_dev.id_addr[]
- *   - No expected calls to bt_settings_save_id()
+ *   - No expected calls to bt_settings_store_id()
  */
 ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
 	  test_bt_read_static_addr_succeeds_bt_dev_ready_set)
@@ -173,7 +174,8 @@ ZTEST(bt_setup_random_id_addr_bt_settings_enabled,
 
 	err = bt_setup_random_id_addr();
 
-	expect_single_call_bt_settings_save_id();
+	expect_single_call_bt_settings_store_id();
+	expect_single_call_bt_settings_store_irk();
 
 	zassert_true(err == 0, "Unexpected error code '%d' was returned", err);
 	zassert_mem_equal(&bt_dev.id_addr[0], BT_STATIC_RANDOM_LE_ADDR_1, sizeof(bt_addr_le_t),

--- a/tests/bluetooth/host/id/mocks/kernel.c
+++ b/tests/bluetooth/host/id/mocks/kernel.c
@@ -13,3 +13,4 @@ DEFINE_FAKE_VALUE_FUNC(int, k_work_schedule, struct k_work_delayable *, k_timeou
 DEFINE_FAKE_VALUE_FUNC(bool, k_work_cancel_delayable_sync, struct k_work_delayable *,
 		       struct k_work_sync *);
 DEFINE_FAKE_VOID_FUNC(k_work_init_delayable, struct k_work_delayable *, k_work_handler_t);
+DEFINE_FAKE_VALUE_FUNC(int, k_work_submit, struct k_work *);

--- a/tests/bluetooth/host/id/mocks/kernel.h
+++ b/tests/bluetooth/host/id/mocks/kernel.h
@@ -20,3 +20,4 @@ DECLARE_FAKE_VALUE_FUNC(int, k_work_schedule, struct k_work_delayable *, k_timeo
 DECLARE_FAKE_VALUE_FUNC(bool, k_work_cancel_delayable_sync, struct k_work_delayable *,
 			struct k_work_sync *);
 DECLARE_FAKE_VOID_FUNC(k_work_init_delayable, struct k_work_delayable *, k_work_handler_t);
+DECLARE_FAKE_VALUE_FUNC(int, k_work_submit, struct k_work *);

--- a/tests/bluetooth/host/id/mocks/settings.c
+++ b/tests/bluetooth/host/id/mocks/settings.c
@@ -8,4 +8,7 @@
 
 #include <zephyr/kernel.h>
 
-DEFINE_FAKE_VOID_FUNC(bt_settings_save_id);
+DEFINE_FAKE_VOID_FUNC(bt_settings_store_id);
+DEFINE_FAKE_VOID_FUNC(bt_settings_delete_id);
+DEFINE_FAKE_VOID_FUNC(bt_settings_store_irk);
+DEFINE_FAKE_VOID_FUNC(bt_settings_delete_irk);

--- a/tests/bluetooth/host/id/mocks/settings.h
+++ b/tests/bluetooth/host/id/mocks/settings.h
@@ -8,6 +8,13 @@
 #include <zephyr/kernel.h>
 
 /* List of fakes used by this unit tester */
-#define SETTINGS_FFF_FAKES_LIST(FAKE) FAKE(bt_settings_save_id)
+#define SETTINGS_FFF_FAKES_LIST(FAKE)                                                              \
+	FAKE(bt_settings_store_id)                                                                 \
+	FAKE(bt_settings_delete_id)                                                                \
+	FAKE(bt_settings_store_irk)                                                                \
+	FAKE(bt_settings_delete_irk)
 
-DECLARE_FAKE_VOID_FUNC(bt_settings_save_id);
+DECLARE_FAKE_VOID_FUNC(bt_settings_store_id);
+DECLARE_FAKE_VOID_FUNC(bt_settings_delete_id);
+DECLARE_FAKE_VOID_FUNC(bt_settings_store_irk);
+DECLARE_FAKE_VOID_FUNC(bt_settings_delete_irk);

--- a/tests/bluetooth/host/id/mocks/settings_expects.c
+++ b/tests/bluetooth/host/id/mocks/settings_expects.c
@@ -9,18 +9,34 @@
 
 #include <zephyr/kernel.h>
 
-void expect_single_call_bt_settings_save_id(void)
+void expect_single_call_bt_settings_store_id(void)
 {
-	const char *func_name = "bt_settings_save_id";
+	const char *func_name = "bt_settings_store_id";
 
-	zassert_equal(bt_settings_save_id_fake.call_count, 1, "'%s()' was called more than once",
+	zassert_equal(bt_settings_store_id_fake.call_count, 1, "'%s()' was called more than once",
 		      func_name);
 }
 
-void expect_not_called_bt_settings_save_id(void)
+void expect_not_called_bt_settings_store_id(void)
 {
-	const char *func_name = "bt_settings_save_id";
+	const char *func_name = "bt_settings_store_id";
 
-	zassert_equal(bt_settings_save_id_fake.call_count, 0, "'%s()' was called unexpectedly",
+	zassert_equal(bt_settings_store_id_fake.call_count, 0, "'%s()' was called unexpectedly",
+		      func_name);
+}
+
+void expect_single_call_bt_settings_store_irk(void)
+{
+	const char *func_name = "bt_settings_store_irk";
+
+	zassert_equal(bt_settings_store_irk_fake.call_count, 1, "'%s()' was called more than once",
+		      func_name);
+}
+
+void expect_not_called_bt_settings_store_irk(void)
+{
+	const char *func_name = "bt_settings_store_irk";
+
+	zassert_equal(bt_settings_store_irk_fake.call_count, 0, "'%s()' was called unexpectedly",
 		      func_name);
 }

--- a/tests/bluetooth/host/id/mocks/settings_expects.h
+++ b/tests/bluetooth/host/id/mocks/settings_expects.h
@@ -7,17 +7,33 @@
 #include <zephyr/kernel.h>
 
 /*
- *  Validate expected behaviour when bt_settings_save_id() is called
+ *  Validate expected behaviour when bt_settings_store_id() is called
  *
  *  Expected behaviour:
- *   - bt_settings_save_id() to be called once with correct parameters
+ *   - bt_settings_store_id() to be called once with correct parameters
  */
-void expect_single_call_bt_settings_save_id(void);
+void expect_single_call_bt_settings_store_id(void);
 
 /*
- *  Validate expected behaviour when bt_settings_save_id() isn't called
+ *  Validate expected behaviour when bt_settings_store_id() isn't called
  *
  *  Expected behaviour:
- *   - bt_settings_save_id() isn't called at all
+ *   - bt_settings_store_id() isn't called at all
  */
-void expect_not_called_bt_settings_save_id(void);
+void expect_not_called_bt_settings_store_id(void);
+
+/*
+ *  Validate expected behaviour when bt_settings_store_irk() is called
+ *
+ *  Expected behaviour:
+ *   - bt_settings_store_irk() to be called once with correct parameters
+ */
+void expect_single_call_bt_settings_store_irk(void);
+
+/*
+ *  Validate expected behaviour when bt_settings_store_irk) isn't called
+ *
+ *  Expected behaviour:
+ *   - bt_settings_store_irk() isn't called at all
+ */
+void expect_not_called_bt_settings_store_irk(void);

--- a/tests/bluetooth/host/keys/bt_keys_clear/src/test_suite_bt_settings.c
+++ b/tests/bluetooth/host/keys/bt_keys_clear/src/test_suite_bt_settings.c
@@ -68,9 +68,7 @@ ZTEST(bt_keys_clear_bt_settings_enabled, test_clear_key_with_id_equal_0)
 	zassert_true(find_returned_ref == NULL,
 		     "bt_keys_find_addr() returned a non-NULL reference");
 
-	expect_not_called_u8_to_dec();
-	expect_single_call_bt_settings_encode_key_with_null_key(&returned_key->addr);
-	expect_single_call_settings_delete();
+	expect_single_call_bt_settings_delete_keys();
 }
 
 /*
@@ -108,7 +106,5 @@ ZTEST(bt_keys_clear_bt_settings_enabled, test_clear_key_with_id_not_equal_0)
 	zassert_true(find_returned_ref == NULL,
 		     "bt_keys_find_addr() returned a non-NULL reference");
 
-	expect_single_call_u8_to_dec(id);
-	expect_single_call_bt_settings_encode_key_with_not_null_key(&returned_key->addr);
-	expect_single_call_settings_delete();
+	expect_single_call_bt_settings_delete_keys();
 }

--- a/tests/bluetooth/host/keys/bt_keys_store/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_store/src/main.c
@@ -36,12 +36,12 @@ ZTEST_SUITE(bt_keys_store_key_bt_settings_enabled, NULL, NULL, tc_setup, NULL, N
 
 /*
  *  Store an existing key (ID = 0) and verify the result.
- *  settings_save_one() returns 0 which represents success.
+ *  bt_settings_store_keys() returns 0 which represents success.
  *
  *  Constraints:
  *   - Key reference points to a valid item
  *   - Item ID is set to 0
- *   - Return value from settings_save_one() is 0
+ *   - Return value from bt_settings_store_keys() is 0
  *
  *  Expected behaviour:
  *   - bt_keys_store() returns 0 which represent success
@@ -57,26 +57,25 @@ ZTEST(bt_keys_store_key_bt_settings_enabled, test_id_equal_0_with_no_error)
 	returned_key = bt_keys_get_addr(id, addr);
 	zassert_true(returned_key != NULL, "bt_keys_get_addr() returned a non-valid reference");
 
-	settings_save_one_fake.return_val = 0;
+	bt_settings_store_keys_fake.return_val = 0;
 
 	/* Store the key */
 	returned_code = bt_keys_store(returned_key);
 
 	zassert_true(returned_code == 0, "bt_keys_store() returned a non-zero code");
 
-	expect_not_called_u8_to_dec();
-	expect_single_call_bt_settings_encode_key_with_null_key(&returned_key->addr);
-	expect_single_call_settings_save_one(returned_key->storage_start);
+	expect_single_call_bt_settings_store_keys(returned_key->storage_start);
 }
 
 /*
  *  Store an existing key (ID = 0) and verify the result.
- *  settings_save_one() returns a negative value of -1 which represents failure.
+ *  bt_settings_store_keys() returns a negative value of -1 which represents
+ *  failure.
  *
  *  Constraints:
  *   - Key reference points to a valid item
  *   - Item ID is set to 0
- *   - Return value from settings_save_one() is -1
+ *   - Return value from bt_settings_store_keys() is -1
  *
  *  Expected behaviour:
  *   - bt_keys_store() returns a negative error code of -1
@@ -92,26 +91,24 @@ ZTEST(bt_keys_store_key_bt_settings_enabled, test_id_equal_0_with_error)
 	returned_key = bt_keys_get_addr(id, addr);
 	zassert_true(returned_key != NULL, "bt_keys_get_addr() returned a non-valid reference");
 
-	settings_save_one_fake.return_val = -1;
+	bt_settings_store_keys_fake.return_val = -1;
 
 	/* Store the key */
 	returned_code = bt_keys_store(returned_key);
 
 	zassert_true(returned_code == -1, "bt_keys_store() returned a non-zero code");
 
-	expect_not_called_u8_to_dec();
-	expect_single_call_bt_settings_encode_key_with_null_key(&returned_key->addr);
-	expect_single_call_settings_save_one(returned_key->storage_start);
+	expect_single_call_bt_settings_store_keys(returned_key->storage_start);
 }
 
 /*
  *  Store an existing key (ID != 0) and verify the result.
- *  settings_save_one() returns 0 which represents success.
+ *  bt_settings_store_keys() returns 0 which represents success.
  *
  *  Constraints:
  *   - Key reference points to a valid item
  *   - Item ID isn't set to 0
- *   - Return value from settings_save_one() is 0
+ *   - Return value from bt_settings_store_keys() is 0
  *
  *  Expected behaviour:
  *   - bt_keys_store() returns 0 which represent success
@@ -127,21 +124,20 @@ ZTEST(bt_keys_store_key_bt_settings_enabled, test_id_not_equal_0_with_no_error)
 	returned_key = bt_keys_get_addr(id, addr);
 	zassert_true(returned_key != NULL, "bt_keys_get_addr() returned a non-valid reference");
 
-	settings_save_one_fake.return_val = 0;
+	bt_settings_store_keys_fake.return_val = 0;
 
 	/* Store the key */
 	returned_code = bt_keys_store(returned_key);
 
 	zassert_true(returned_code == 0, "bt_keys_store() returned a non-zero code");
 
-	expect_single_call_u8_to_dec(id);
-	expect_single_call_bt_settings_encode_key_with_not_null_key(&returned_key->addr);
-	expect_single_call_settings_save_one(returned_key->storage_start);
+	expect_single_call_bt_settings_store_keys(returned_key->storage_start);
 }
 
 /*
  *  Store an existing key (ID != 0) and verify the result
- *  settings_save_one() returns a negative value of -1 which represents failure.
+ *  bt_settings_store_keys() returns a negative value of -1 which represents
+ *  failure.
  *
  *  Constraints:
  *   - Key reference points to a valid item
@@ -162,14 +158,12 @@ ZTEST(bt_keys_store_key_bt_settings_enabled, test_id_not_equal_0_with_error)
 	returned_key = bt_keys_get_addr(id, addr);
 	zassert_true(returned_key != NULL, "bt_keys_get_addr() returned a non-valid reference");
 
-	settings_save_one_fake.return_val = -1;
+	bt_settings_store_keys_fake.return_val = -1;
 
 	/* Store the key */
 	returned_code = bt_keys_store(returned_key);
 
 	zassert_true(returned_code == -1, "bt_keys_store() returned a non-zero code");
 
-	expect_single_call_u8_to_dec(id);
-	expect_single_call_bt_settings_encode_key_with_not_null_key(&returned_key->addr);
-	expect_single_call_settings_save_one(returned_key->storage_start);
+	expect_single_call_bt_settings_store_keys(returned_key->storage_start);
 }

--- a/tests/bluetooth/host/keys/bt_keys_update_usage/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_update_usage/src/main.c
@@ -134,6 +134,6 @@ ZTEST(bt_keys_update_usage_overwrite_oldest_enabled, test_update_non_latest_refe
 			bt_keys_get_last_keys_updated(), expected_updated_keys,
 			"bt_keys_update_usage() changed last updated key reference unexpectedly");
 
-		expect_not_called_settings_save_one();
+		expect_not_called_bt_settings_store_keys();
 	}
 }

--- a/tests/bluetooth/host/keys/bt_keys_update_usage/src/test_suite_save_aging_counter.c
+++ b/tests/bluetooth/host/keys/bt_keys_update_usage/src/test_suite_save_aging_counter.c
@@ -77,6 +77,6 @@ ZTEST(bt_keys_update_usage_save_aging_counter, test_update_usage_and_save_aging_
 			"bt_keys_update_usage() changed last updated key reference unexpectedly");
 
 		/* Check if bt_keys_store() was called */
-		expect_single_call_settings_save_one(expected_updated_keys->storage_start);
+		expect_single_call_bt_settings_store_keys(expected_updated_keys->storage_start);
 	}
 }

--- a/tests/bluetooth/host/keys/mocks/settings_expects.c
+++ b/tests/bluetooth/host/keys/mocks/settings_expects.c
@@ -31,8 +31,9 @@ void expect_single_call_bt_settings_encode_key_with_null_key(const bt_addr_le_t 
 {
 	const char *func_name = "bt_settings_encode_key";
 
-	zassert_equal(bt_settings_encode_key_fake.call_count, 1, "'%s()' was called more than once",
-		      func_name);
+	zassert_equal(bt_settings_encode_key_fake.call_count, 1,
+		      "'%s()' was called more than once (%d)", func_name,
+		      bt_settings_encode_key_fake.call_count);
 	zassert_not_null(bt_settings_encode_key_fake.arg0_val,
 			 "'%s()' was called with incorrect '%s' value", func_name, "path");
 	zassert_true(bt_settings_encode_key_fake.arg1_val != 0,

--- a/tests/bluetooth/host/keys/mocks/settings_store.c
+++ b/tests/bluetooth/host/keys/mocks/settings_store.c
@@ -7,5 +7,6 @@
 #include <zephyr/kernel.h>
 #include "mocks/settings_store.h"
 
-DEFINE_FAKE_VALUE_FUNC(int, settings_delete, const char *);
-DEFINE_FAKE_VALUE_FUNC(int, settings_save_one, const char *, const void *, size_t);
+DEFINE_FAKE_VALUE_FUNC(int, bt_settings_store_keys, uint8_t, struct bt_addr_le_t *, const void *,
+		       size_t);
+DEFINE_FAKE_VALUE_FUNC(int, bt_settings_delete_keys, uint8_t, struct bt_addr_le_t *);

--- a/tests/bluetooth/host/keys/mocks/settings_store.h
+++ b/tests/bluetooth/host/keys/mocks/settings_store.h
@@ -6,11 +6,13 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/fff.h>
+#include <zephyr/bluetooth/addr.h>
 
 /* List of fakes used by this unit tester */
-#define SETTINGS_STORE_FFF_FAKES_LIST(FAKE)     \
-		FAKE(settings_delete)					\
-		FAKE(settings_save_one)					\
+#define SETTINGS_STORE_FFF_FAKES_LIST(FAKE)                                                        \
+	FAKE(bt_settings_store_keys)                                                               \
+	FAKE(bt_settings_delete_keys)
 
-DECLARE_FAKE_VALUE_FUNC(int, settings_delete, const char *);
-DECLARE_FAKE_VALUE_FUNC(int, settings_save_one, const char *, const void *, size_t);
+DECLARE_FAKE_VALUE_FUNC(int, bt_settings_store_keys, uint8_t, struct bt_addr_le_t *, const void *,
+			size_t);
+DECLARE_FAKE_VALUE_FUNC(int, bt_settings_delete_keys, uint8_t, struct bt_addr_le_t *);

--- a/tests/bluetooth/host/keys/mocks/settings_store_expects.c
+++ b/tests/bluetooth/host/keys/mocks/settings_store_expects.c
@@ -10,36 +10,31 @@
 #include "mocks/settings_store.h"
 #include "mocks/settings_store_expects.h"
 
-void expect_single_call_settings_delete(void)
+void expect_single_call_bt_settings_delete_keys(void)
 {
-	const char *func_name = "settings_delete";
+	const char *func_name = "bt_settings_delete_keys";
 
-	zassert_equal(settings_delete_fake.call_count, 1, "'%s()' was called more than once",
-		      func_name);
-
-	zassert_not_null(settings_delete_fake.arg0_val,
-			 "'%s()' was called with incorrect '%s' value", func_name, "key");
+	zassert_equal(bt_settings_delete_keys_fake.call_count, 1,
+		      "'%s()' was called more than once", func_name);
 }
 
-void expect_single_call_settings_save_one(const void *value)
+void expect_single_call_bt_settings_store_keys(const void *value)
 {
-	const char *func_name = "settings_save_one";
+	const char *func_name = "bt_settings_store_keys";
 
-	zassert_equal(settings_save_one_fake.call_count, 1, "'%s()' was called more than once",
+	zassert_equal(bt_settings_store_keys_fake.call_count, 1, "'%s()' was called more than once",
 		      func_name);
 
-	zassert_not_null(settings_save_one_fake.arg0_val,
-			 "'%s()' was called with incorrect '%s' value", func_name, "key");
-	zassert_equal(settings_save_one_fake.arg1_val, value,
+	zassert_equal(bt_settings_store_keys_fake.arg2_val, value,
 		      "'%s()' was called with incorrect '%s' value", func_name, "value");
-	zassert_equal(settings_save_one_fake.arg2_val, BT_KEYS_STORAGE_LEN,
+	zassert_equal(bt_settings_store_keys_fake.arg3_val, BT_KEYS_STORAGE_LEN,
 		      "'%s()' was called with incorrect '%s' value", func_name, "val_len");
 }
 
-void expect_not_called_settings_save_one(void)
+void expect_not_called_bt_settings_store_keys(void)
 {
-	const char *func_name = "settings_save_one";
+	const char *func_name = "bt_settings_store_keys";
 
-	zassert_equal(settings_save_one_fake.call_count, 0, "'%s()' was called unexpectedly",
+	zassert_equal(bt_settings_store_keys_fake.call_count, 0, "'%s()' was called unexpectedly",
 		      func_name);
 }

--- a/tests/bluetooth/host/keys/mocks/settings_store_expects.h
+++ b/tests/bluetooth/host/keys/mocks/settings_store_expects.h
@@ -7,25 +7,25 @@
 #include <zephyr/kernel.h>
 
 /*
- *  Validate expected behaviour when settings_delete() is called
+ *  Validate expected behaviour when bt_settings_delete_keys() is called
  *
  *  Expected behaviour:
- *   - settings_delete() to be called once with correct parameters
+ *   - bt_settings_delete_keys() to be called once with correct parameters
  */
-void expect_single_call_settings_delete(void);
+void expect_single_call_bt_settings_delete_keys(void);
 
 /*
- *  Validate expected behaviour when settings_save_one() is called
+ *  Validate expected behaviour when bt_settings_store_keys() is called
  *
  *  Expected behaviour:
- *   - settings_save_one() to be called once with correct parameters
+ *   - bt_settings_store_keys() to be called once with correct parameters
  */
-void expect_single_call_settings_save_one(const void *value);
+void expect_single_call_bt_settings_store_keys(const void *value);
 
 /*
- *  Validate expected behaviour when settings_save_one() isn't called
+ *  Validate expected behaviour when bt_settings_store_keys() isn't called
  *
  *  Expected behaviour:
- *   - settings_save_one() isn't called at all
+ *   - bt_settings_store_keys() isn't called at all
  */
-void expect_not_called_settings_save_one(void);
+void expect_not_called_bt_settings_store_keys(void);


### PR DESCRIPTION
The first commit wrap the `settings_set_one` and `settings_delete` functions in `bt_settings_store_one` and `bt_settings_delete`. By doing that the Bluetooth settings can be managed in a single place.

This commit also introduce a new API to manage Bluetooth storage with `bt_settings_store_*` and `bt_settings_delete_*` functions. Each Bluetooth settings key have their own store and delete functions. Doing that so custom behavior for key can be done if necessary.

This change is motivated by a need of keeping track of different persistently stored settings inside the Bluetooth subsystem. This will allow a better management of the settings that the Bluetooth subsystem is responsible of.

The second commit update some tests to use this new API.

This is a first step to fix https://github.com/zephyrproject-rtos/zephyr/issues/55475