### PR TITLE
stm32: Add reinitialization feature for SPI and UART

### DIFF
--- a/doc/services/pm/system.rst
+++ b/doc/services/pm/system.rst
@@ -93,3 +93,16 @@ applications to configure the policy manager to block system from transitioning
 into certain power states. This can be used by devices when executing tasks in
 background to prevent the system from going to a specific state where it would
 lose context.
+
+Some power states above S2RAM may also affect peripheral context; this can lead
+to a peripheral losing configuration when certain SoCs enters these specific
+low-power states.
+
+These exception states can be described in a peripheral's devicetree node with
+the ``reinit-power-states`` property:
+
+.. code-block:: devicetree
+
+   device-1 {
+      reinit-power-states = <&stop2>;
+   };

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/pm/pm.h>
 
 #include <stm32_ll_usart.h>
 
@@ -59,6 +60,9 @@ struct uart_stm32_config {
 	/* Device defined as wake-up source */
 	bool wakeup_source;
 	uint32_t wakeup_line;
+	struct pm_notifier *notifier;
+	const struct pm_state_info *reinit_states;
+	size_t reinit_states_size;
 #endif /* CONFIG_PM */
 };
 

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -1011,6 +1011,27 @@ static int spi_stm32_clock_configure(const struct spi_stm32_config *cfg)
 	return 0;
 }
 
+#ifdef CONFIG_PM
+/**
+ * @brief Reinitialization of SPI context
+ *
+ * This function reenables clocks, which is required upon exiting certain
+ * low-power modes on select SoCs.
+ *
+ * @param dev SPI device struct
+ *
+ * @return 0
+ */
+static void spi_stm32_reinit(uint8_t direction, void *ctx)
+{
+	ARG_UNUSED(direction);
+	const struct device *dev = ctx;
+	const struct spi_stm32_config *cfg = dev->config;
+
+	spi_stm32_clock_configure(cfg);
+}
+#endif /* CONFIG_PM */
+
 static int spi_stm32_init(const struct device *dev)
 {
 	struct spi_stm32_data *data __attribute__((unused)) = dev->data;
@@ -1058,6 +1079,15 @@ static int spi_stm32_init(const struct device *dev)
 	}
 
 	spi_context_unlock_unconditionally(&data->ctx);
+
+#ifdef CONFIG_PM
+	if (cfg->reinit_states_size > 0) {
+		for (size_t i = 0; i < cfg->reinit_states_size; i++) {
+			pm_notifier_register(cfg->notifier, cfg->reinit_states[i].state,
+					     cfg->reinit_states[i].substate_id);
+		}
+	}
+#endif /* CONFIG_PM */
 
 	return 0;
 }
@@ -1130,10 +1160,29 @@ static void spi_stm32_irq_config_func_##id(const struct device *dev)		\
 #define STM32_SPI_USE_SUBGHZSPI_NSS_CONFIG(id)
 #endif
 
+#ifdef CONFIG_PM
+#define STM32_SPI_REINIT_STATE_INIT(id)					\
+	static const struct pm_state_info reinit_states_##id[]		\
+		= PM_STATE_INFO_LIST_FROM_DT_REINIT(DT_DRV_INST(id))
+
+#define STM32_SPI_REINIT_CFG_INIT(id)					\
+	.notifier = &PM_NOTIFIER(DT_INST_DEP_ORD(id)),			\
+	.reinit_states = reinit_states_##id,				\
+	.reinit_states_size = ARRAY_SIZE(reinit_states_##id),
+#else
+#define STM32_SPI_REINIT_STATE_INIT(id)
+#define STM32_SPI_REINIT_CFG_INIT(id)
+#endif /* CONFIG_PM */
+
 #define STM32_SPI_INIT(id)						\
 STM32_SPI_IRQ_HANDLER_DECL(id);						\
 									\
 PINCTRL_DT_INST_DEFINE(id);						\
+									\
+STM32_SPI_REINIT_STATE_INIT(id);					\
+									\
+PM_NOTIFIER_DEFINE(DT_INST_DEP_ORD(id), PM_STATE_EXIT,			\
+		   spi_stm32_reinit, DEVICE_DT_INST_GET(id));		\
 									\
 static const struct stm32_pclken pclken_##id[] =			\
 					       STM32_DT_INST_CLOCKS(id);\
@@ -1145,6 +1194,7 @@ static const struct spi_stm32_config spi_stm32_cfg_##id = {		\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),			\
 	STM32_SPI_IRQ_HANDLER_FUNC(id)					\
 	STM32_SPI_USE_SUBGHZSPI_NSS_CONFIG(id)				\
+	STM32_SPI_REINIT_CFG_INIT(id)					\
 };									\
 									\
 static struct spi_stm32_data spi_stm32_dev_data_##id = {		\

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_DRIVERS_SPI_SPI_LL_STM32_H_
 #define ZEPHYR_DRIVERS_SPI_SPI_LL_STM32_H_
 
+#include <stm32_ll_spi.h>
+
 #include "spi_context.h"
 
 typedef void (*irq_config_func_t)(const struct device *port);

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -7,6 +7,7 @@
 #ifndef ZEPHYR_DRIVERS_SPI_SPI_LL_STM32_H_
 #define ZEPHYR_DRIVERS_SPI_SPI_LL_STM32_H_
 
+#include <zephyr/pm/pm.h>
 #include <stm32_ll_spi.h>
 
 #include "spi_context.h"
@@ -32,6 +33,11 @@ struct spi_stm32_config {
 #endif
 	size_t pclk_len;
 	const struct stm32_pclken *pclken;
+#ifdef CONFIG_PM
+	struct pm_notifier *notifier;
+	const struct pm_state_info *reinit_states;
+	size_t reinit_states_size;
+#endif
 };
 
 #ifdef CONFIG_SPI_STM32_DMA

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -229,6 +229,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00004000>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <36 0>;
+			reinit-power-states = <&stop2>;
 			status = "disabled";
 		};
 
@@ -238,6 +239,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00020000>;
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <37 0>;
+			reinit-power-states = <&stop2>;
 			status = "disabled";
 		};
 
@@ -293,6 +295,7 @@
 			reg = <0x40013000 0x400>;
 			interrupts = <34 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			reinit-power-states = <&stop2>;
 			status = "disabled";
 		};
 
@@ -303,6 +306,7 @@
 			reg = <0x40003800 0x400>;
 			interrupts = <35 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
+			reinit-power-states = <&stop2>;
 			status = "disabled";
 		};
 
@@ -313,6 +317,7 @@
 			reg = <0x58010000 0x400>;
 			interrupts = <44 5>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000001>;
+			reinit-power-states = <&stop2>;
 			status = "disabled";
 			use-subghzspi-nss;
 

--- a/dts/bindings/base/pm.yaml
+++ b/dts/bindings/base/pm.yaml
@@ -30,3 +30,12 @@ properties:
     description: |
       Automatically configure the device for runtime power management after the
       init function runs.
+
+  reinit-power-states:
+    type: phandles
+    description: |
+      Specifies special power states where a peripheral requires
+      reinitialization due to configuration loss.
+
+      While states at or beyond S2RAM are naturally assumed to need
+      reinitialization, this property highlights the exceptions to that rule.

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -350,6 +350,27 @@ struct pm_state_info {
 uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states);
 
 /**
+ * Retrieve the index of a CPU's DT cpu-power-states array element.
+ *
+ * @param cpu CPU index.
+ * @param state pm_state state.
+ * @param substate_id pm_state substate ID.
+ *
+ * @return Index of the PM state, or -1.
+ */
+uint8_t pm_state_cpu_get_index(uint8_t cpu, enum pm_state state, uint8_t substate_id);
+
+/**
+ * Retrieve the index of a DT power-states array element.
+ *
+ * @param state pm_state state.
+ * @param substate_id pm_state substate ID.
+ *
+ * @return Index of the PM state, or -1.
+ */
+uint8_t pm_state_get_index(enum pm_state state, uint8_t substate_id);
+
+/**
  * @}
  */
 

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -205,6 +205,18 @@ struct pm_state_info {
 	COND_CODE_1(DT_NODE_HAS_STATUS(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i), okay),    \
 		    (PM_STATE_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i)),), ())
 
+/**
+ * @brief Call a function for an enabled power-state phandle list item
+ *
+ * @param node_id zephyr,power-state node identifier
+ * @param prop Property holding power-state phandle(s)
+ * @param idx Index within the phandle list
+ * @param fn Function taking a power-state node_id
+ */
+#define Z_PM_STATE_DT_PHANDLE_GEN(node_id, prop, idx, fn)					 \
+	COND_CODE_1(DT_NODE_HAS_STATUS(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, idx), okay), \
+		    (fn(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, idx))), ())
+
 /** @endcond */
 
 /**

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -156,6 +156,16 @@ struct pm_state_info {
 	uint32_t exit_latency_us;
 };
 
+/**
+ * @brief PM state transition direction: state entry bit field value
+ */
+#define PM_STATE_ENTRY        BIT(0)
+
+/**
+ * @brief PM state transition direction: state exit bit field value
+ */
+#define PM_STATE_EXIT         BIT(1)
+
 /** @cond INTERNAL_HIDDEN */
 
 /**

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -40,11 +40,19 @@ BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
 DT_FOREACH_CHILD(DT_PATH(cpus), CHECK_POWER_STATES_CONSISTENCY)
 
 #define DEFINE_CPU_STATES(n) \
-	static const struct pm_state_info pmstates_##n[] \
+	static const struct pm_state_info pmstates_cpu##n[] \
 		= PM_STATE_INFO_LIST_FROM_DT_CPU(n);
-#define CPU_STATE_REF(n) pmstates_##n
+#define CPU_STATE_REF(n) pmstates_cpu##n
 
 DT_FOREACH_CHILD(DT_PATH(cpus), DEFINE_CPU_STATES);
+
+#if CONFIG_MP_NUM_CPUS > 1 && DT_NODE_EXISTS(DT_PATH(cpus, power_states))
+/** General power-states list on SMP platforms, as individual per-CPU states may vary */
+static const struct pm_state_info pmstates_all[] = {
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus, power_states),
+					 PM_STATE_INFO_DT_INIT, (,)),
+};
+#endif
 
 /** CPU power states information for each CPU */
 static const struct pm_state_info *cpus_states[] = {
@@ -66,3 +74,34 @@ uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states)
 
 	return states_per_cpu[cpu];
 }
+
+inline uint8_t pm_state_cpu_get_index(uint8_t cpu, enum pm_state state, uint8_t substate_id)
+{
+	for (uint8_t i = 0; i < states_per_cpu[cpu]; i++) {
+		if (cpus_states[cpu][i].state == state &&
+		    cpus_states[cpu][i].substate_id == substate_id) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+#if CONFIG_MP_NUM_CPUS > 1
+inline uint8_t pm_state_get_index(enum pm_state state, uint8_t substate_id)
+{
+	for (uint8_t i = 0; i < ARRAY_SIZE(pmstates_all); i++) {
+		if (pmstates_all[i].state == state &&
+		    pmstates_all[i].substate_id == substate_id) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+#else
+inline uint8_t pm_state_get_index(enum pm_state state, uint8_t substate_id)
+{
+	return pm_state_cpu_get_index(0U, state, substate_id);
+}
+#endif

--- a/tests/subsys/pm/device_wakeup_api/boards/native_posix.overlay
+++ b/tests/subsys/pm/device_wakeup_api/boards/native_posix.overlay
@@ -9,3 +9,18 @@
 	gpio-controller;
 	wakeup-source;
 };
+
+/ {
+	cpus {
+		power-states {
+			s2ram: s2ram {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-ram";
+			};
+		};
+	};
+};
+
+&cpu0 {
+	cpu-power-states = <&s2ram>;
+};

--- a/tests/subsys/pm/power_mgmt/boards/native_posix.overlay
+++ b/tests/subsys/pm/power_mgmt/boards/native_posix.overlay
@@ -5,6 +5,15 @@
  */
 
 / {
+	cpus {
+		power-states {
+			suspend: suspend {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+			};
+		};
+	};
+
 	device_a: device_a {
 		compatible = "test-device-pm";
 	};
@@ -20,4 +29,8 @@
 	device_d: device_d {
 		compatible = "test-device-pm";
 	};
+};
+
+&cpu0 {
+	cpu-power-states = <&suspend>;
 };

--- a/tests/subsys/pm/power_mgmt_multicore/boards/qemu_x86_64.overlay
+++ b/tests/subsys/pm/power_mgmt_multicore/boards/qemu_x86_64.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Kenneth J. Miller <ken@miller.ec>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	cpus {
+		cpu@0 {
+			cpu-power-states = <&idle &s2idle &stdby>;
+		};
+
+		power-states {
+			idle: idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "runtime-idle";
+			};
+
+			s2idle: s2idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+			};
+
+			stdby: stdby {
+				compatible = "zephyr,power-state";
+				power-state-name = "standby";
+			};
+		};
+	};
+};


### PR DESCRIPTION
This PR adds device reinitialization for SPI and UART, as these will lose their hardware configuration when certain SoC series enter certain STOP/Standby modes.

Unfortunately, I've had to remove ADC and I2C reinit from this PR, as they require deeper PM work, seeing how they need to block during reinit process.

#### Depends on commits from PRs

- #60998 
- #60369

#### References

See RM0461, chapter 5.4 - Low-Power Modes, Table 37, and chapter 5.4.9 - Stop 2 Mode:

1. [RM0461 Reference manual - STM32WLEx advanced Arm-based 32-bit MCUs with sub-GHz radio solution](https://www.st.com/resource/en/reference_manual/rm0461-stm32wlex-advanced-armbased-32bit-mcus-with-subghz-radio-solution-stmicroelectronics.pdf)