### PR TITLE
portability cmsis_rtosv2: Fix test & add check of return of k_mem_slab_init()

### DIFF
--- a/subsys/portability/cmsis_rtos_v2/mempool.c
+++ b/subsys/portability/cmsis_rtos_v2/mempool.c
@@ -68,7 +68,15 @@ osMemoryPoolId_t osMemoryPoolNew(uint32_t block_count, uint32_t block_size,
 		mslab->is_dynamic_allocation = FALSE;
 	}
 
-	k_mem_slab_init(&mslab->z_mslab, mslab->pool, block_size, block_count);
+	int rc = k_mem_slab_init(&mslab->z_mslab, mslab->pool, block_size, block_count);
+
+	if (rc != 0) {
+		k_mem_slab_free(&cv2_mem_slab, (void *) &mslab);
+		if (attr->mp_mem == NULL) {
+			k_free(mslab->pool);
+		}
+		return NULL;
+	}
 
 	if (attr->name == NULL) {
 		strncpy(mslab->name, init_mslab_attrs.name,

--- a/tests/subsys/portability/cmsis_rtos_v2/src/mempool.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/mempool.c
@@ -16,7 +16,7 @@ struct mem_block {
 	int member2;
 };
 
-static char __aligned(4) sample_mem[sizeof(struct mem_block) * MAX_BLOCKS];
+static char __aligned(sizeof(void *)) sample_mem[sizeof(struct mem_block) * MAX_BLOCKS];
 static const osMemoryPoolAttr_t mp_attrs = {
 	.name = "TestMempool",
 	.attr_bits = 0,


### PR DESCRIPTION
    portability cmsis_rtosv2: Check return of k_mem_slab_init()
    
    Instead of trusting blindly that k_mem_slab_init()
    will succeed, let's check it, and handle failures
    appropriately.
    Otherwise, a buffer of garbage will be passed
    around, leading to misterious failures later on.
    
-------

    tests: portability cmsis_rtosv2: Fix buffer aligment
    
    The kernel requires the buffer to be word aligned.
    Instead of assuming the word size is 32bits,
    lets align the buffer to the size of a pointer,
    which should match the word size (and which
    is the check the kernel performs).

-------

Found due to a crash on a 64bit platform.