### PR TITLE
boards: efr32 thunderboard: correct default high freq oscillator frequency

### DIFF
--- a/boards/arm/efr32_thunderboard/Kconfig.defconfig
+++ b/boards/arm/efr32_thunderboard/Kconfig.defconfig
@@ -18,7 +18,7 @@ config BOARD
 endif # BOARD_EFR32BG27_BRD2602A
 
 config CMU_HFXO_FREQ
-	default 40000000
+	default 38400000
 
 config CMU_LFXO_FREQ
 	default 32768


### PR DESCRIPTION
The efr32bg22 thunderboard has a 38.4MHz high frequency oscillator. This is standard for these micros, as the core runs at 76.8MHz.

The default frequency was incorrectly set to 40MHz. Fairly minor fix, tested on hardware and it works fine.