### PR TITLE
kernel: Explicitly define the main prototype if C++

### DIFF
--- a/include/zephyr/types.h
+++ b/include/zephyr/types.h
@@ -30,6 +30,11 @@ typedef union {
 } z_max_align_t;
 
 #ifdef __cplusplus
+/* Zephyr requires an int main(void) signature with C linkage for the application main if present */
+extern int main(void);
+#endif
+
+#ifdef __cplusplus
 }
 #endif
 


### PR DESCRIPTION
If the embedded application has a `main()`, Zephyr requires it to have a signature with C linkage (no C++ name mangling).
Otherwise Zephyr's init will not call it, but will call the default weak stub.

But, when building with clang/llvm, when we build calling the compiler with `--frestanding` (for ex if CONFIG_MINIMAL_LIBC is set), the compiler will mangle the `main()` symbol name.
This is not incorrect behavior from the compiler, as, in principle, in a freestanding environment `main()` does not have a special meaning.
gcc is still not mangling it when called with `--frestanding`.
It is difficult to guess what other compilers will do; My guess is that all based on clang will mangle it.

To avoid this issue, we can define explicitly, in a header the application will always include, the `main` linkage as `extern C`.


    When building C++ code, let's explicitly define the prototype of the application main() function,
    to ensure the compiler does not mangle it, even if it was built freestanding.

    This fixes an issue with clang builds with
    freestanding, where a C++ application main()
    function name would be mangled otherwise.