### PR TITLE
ARC: fix excessive ROM memory consumption 

### DIFF
--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -17,13 +17,16 @@
 #ifdef CONFIG_HARVARD
 	#define ROMABLE_REGION ICCM
 	#define RAMABLE_REGION DCCM
+	#define ROM_RAM_IN_SAME_REGION 0
 #else
 	#if defined(CONFIG_XIP) && (FLASH_SIZE != 0)
 		#define ROMABLE_REGION FLASH
 		#define RAMABLE_REGION SRAM
+		#define ROM_RAM_IN_SAME_REGION 0
 	#else
 		#define ROMABLE_REGION SRAM
 		#define RAMABLE_REGION SRAM
+		#define ROM_RAM_IN_SAME_REGION 1
 	#endif
 #endif
 
@@ -138,7 +141,13 @@ SECTIONS {
 		_ectors = .;
 #endif /* CONFIG_CPP && !CONFIG_CPP_STATIC_INIT_GNU && __MWDT_LINKER_CMD__ */
 
+/* This extra MPU alignment of RAMABLE_REGION is only required if we put ROMABLE_REGION and
+ * RAMABLE_REGION into the same (continuous) memory - otherwise we can get beginning of the
+ * RAMABLE_REGION in the end of ROMABLE_REGION MPU aperture.
+ */
+#if ROM_RAM_IN_SAME_REGION
 		MPU_ALIGN(ABSOLUTE(.) - __rom_region_start);
+#endif
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 	__rodata_region_end = .;


### PR DESCRIPTION
This extra MPU alignment of RAMABLE_REGION is only required if we put ROMABLE_REGION and RAMABLE_REGION into the same (continuous) memory (i.e. SRAM) - so we won't get beginning of the RAMABLE_REGION in the end of ROMABLE_REGION MPU aperture.

If we use different regions (ICCM & DCCM, FLASH & SRAM, etc...) we don't need this extra MPU alignment.

Let's drop it to decrease ROM region memory usage.

Fixes: #55267