### PR TITLE
soc: arm: nxp_imx: do not enable RT boot header for CM4 core

### DIFF
--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1160_evk_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1160_evk_cm4.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,7 @@
 / {
 	/* Switch to lpuart2, since primary core uses lpuart1 */
 	chosen {
+		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,ipc_shm = &ocram2_overlay;

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_cm4.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,7 @@
 / {
 	/* Switch to lpuart2, since primary core uses lpuart1 */
 	chosen {
+		zephyr,flash = &ocram;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,ipc_shm = &ocram2_overlay;

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -703,7 +703,7 @@ config PM_MCUX_PMU
 
 menuconfig NXP_IMX_RT_BOOT_HEADER
 	bool "Boot header"
-	depends on (!BOOTLOADER_MCUBOOT)
+	depends on (!BOOTLOADER_MCUBOOT) && CPU_CORTEX_M7
 	help
 	  Enable data structures required by the boot ROM to boot the
 	  application from an external flash device.


### PR DESCRIPTION
Disable RT boot header for CM4 core. This will ensure the boot header is
not present when building an application targeting RAM on the CM4.

Fixes #59213

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>