### PR TITLE
device: dynamic device handles were declared as const

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -897,6 +897,10 @@ zephyr_get_include_directories_for_lang(C
   )
 
 if(CONFIG_HAS_DTS)
+  if(CONFIG_HAS_DYNAMIC_DEVICE_HANDLES)
+    set(dynamic_handles --dynamic-handles)
+  endif()
+
   if(CONFIG_PM_DEVICE_POWER_DOMAIN_DYNAMIC)
     set(number_of_dynamic_devices ${CONFIG_PM_DEVICE_POWER_DOMAIN_DYNAMIC_NUM})
   else()
@@ -912,6 +916,7 @@ if(CONFIG_HAS_DTS)
     ${ZEPHYR_BASE}/scripts/build/gen_handles.py
     --output-source dev_handles.c
     --output-graphviz dev_graph.dot
+    ${dynamic_handles}
     --num-dynamic-devices ${number_of_dynamic_devices}
     --kernel $<TARGET_FILE:${ZEPHYR_LINK_STAGE_EXECUTABLE}>
     --zephyr-base ${ZEPHYR_BASE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -896,13 +896,13 @@ zephyr_get_include_directories_for_lang(C
   STRIP_PREFIX # Don't use a -I prefix
   )
 
-if(CONFIG_PM_DEVICE_POWER_DOMAIN_DYNAMIC)
-  set(number_of_dynamic_devices ${CONFIG_PM_DEVICE_POWER_DOMAIN_DYNAMIC_NUM})
-else()
-  set(number_of_dynamic_devices 0)
-endif()
-
 if(CONFIG_HAS_DTS)
+  if(CONFIG_PM_DEVICE_POWER_DOMAIN_DYNAMIC)
+    set(number_of_dynamic_devices ${CONFIG_PM_DEVICE_POWER_DOMAIN_DYNAMIC_NUM})
+  else()
+    set(number_of_dynamic_devices 0)
+  endif()
+
   # dev_handles.c is generated from ${ZEPHYR_LINK_STAGE_EXECUTABLE} by
   # gen_handles.py
   add_custom_command(

--- a/scripts/build/gen_handles.py
+++ b/scripts/build/gen_handles.py
@@ -46,6 +46,8 @@ def parse_args():
 
     parser.add_argument("-k", "--kernel", required=True,
                         help="Input zephyr ELF binary")
+    parser.add_argument("--dynamic-handles", action="store_true",
+                        help="Indicates if device handles are dynamic")
     parser.add_argument("-d", "--num-dynamic-devices", required=False, default=0,
                         type=int, help="Input number of dynamic devices allowed")
     parser.add_argument("-o", "--output-source", required=True,
@@ -93,7 +95,7 @@ def c_handle_comment(dev, handles):
     lines.append(' */')
     return lines
 
-def c_handle_array(dev, handles, extra_support_handles=0):
+def c_handle_array(dev, handles, dynamic_handles, extra_support_handles=0):
     handles = [
         *[str(d.handle) for d in handles["depends"]],
         'DEVICE_HANDLE_SEP',
@@ -103,7 +105,10 @@ def c_handle_array(dev, handles, extra_support_handles=0):
         *(extra_support_handles * ['DEVICE_HANDLE_NULL']),
         'DEVICE_HANDLE_ENDS',
     ]
-    ctype = 'const Z_DECL_ALIGN(device_handle_t) __attribute__((__section__(".__device_handles_pass2")))'
+    ctype = (
+        '{:s}Z_DECL_ALIGN(device_handle_t) '
+        '__attribute__((__section__(".__device_handles_pass2")))'
+    ).format('const ' if not dynamic_handles else '')
     return [
         # The `extern` line pretends this was first declared in some .h
         # file to silence "should it be static?" warnings in some
@@ -153,7 +158,9 @@ def main():
             }
             extra_sups = args.num_dynamic_devices if dev.pm and dev.pm.is_power_domain else 0
             lines = c_handle_comment(dev, sorted_handles)
-            lines.extend(c_handle_array(dev, sorted_handles, extra_sups))
+            lines.extend(
+                c_handle_array(dev, sorted_handles, args.dynamic_handles, extra_sups)
+            )
             lines.extend([''])
             fp.write('\n'.join(lines))
 


### PR DESCRIPTION
When CONFIG_HAS_DYNAMIC_DEVICE_HANDLES is selected, devices handles are placed in RAM region so that they can be modified at runtime. However, the gen_handles.py script added the `const` attribute to the device handle arrays regardless of this setting, leading to faults when running the application. This may be an indicator that this feature is not actively used.

Thanks to @aescolar for reporting.