### PR TITLE
soc: esp32*: do not enable HAS_DYNAMIC_DEVICE_HANDLES

### DIFF
--- a/soc/riscv/esp32c3/Kconfig.defconfig
+++ b/soc/riscv/esp32c3/Kconfig.defconfig
@@ -19,9 +19,6 @@ config MCUBOOT_GENERATE_CONFIRMED_IMAGE
 config ROM_START_OFFSET
 	default 0x20
 
-config HAS_DYNAMIC_DEVICE_HANDLES
-	default y
-
 endif
 
 config SOC

--- a/soc/xtensa/esp32/Kconfig.defconfig
+++ b/soc/xtensa/esp32/Kconfig.defconfig
@@ -17,9 +17,6 @@ if BOOTLOADER_MCUBOOT
 
 	config ROM_START_OFFSET
 		default 0x20
-
-	config HAS_DYNAMIC_DEVICE_HANDLES
-		default y
 endif
 
 config SOC

--- a/soc/xtensa/esp32s3/Kconfig.defconfig
+++ b/soc/xtensa/esp32s3/Kconfig.defconfig
@@ -17,9 +17,6 @@ if BOOTLOADER_MCUBOOT
 
 	config ROM_START_OFFSET
 		default 0x20
-
-	config HAS_DYNAMIC_DEVICE_HANDLES
-		default y
 endif
 
 config SOC


### PR DESCRIPTION
It doesn't make sense to select this option at SoC level. This feature is meant for subsystems/modules that need device handles to be modifiable at runtime.