### PR TITLE
Bluetooth: controller: Fix CIS peripheral conditional offset_min

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -854,8 +854,7 @@ int ull_central_iso_cis_offset_get(uint16_t cis_handle,
 			  cig->sync_delay;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_JIT_SCHEDULING)) {
-		*cis_offset_min = MAX(400, EVENT_OVERHEAD_CIS_SETUP_US);
-
+		*cis_offset_min = MAX(CIS_MIN_OFFSET_MIN, EVENT_OVERHEAD_CIS_SETUP_US);
 		return 0;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_internal.h
@@ -12,6 +12,9 @@
 	(IS_ENABLED(CONFIG_BT_CTLR_CENTRAL_ISO) && \
 	 (cig->lll.role == BT_HCI_ROLE_CENTRAL))
 
+/* BT Core 5.4, Vol 6, Part B, section 2.4.2.29 */
+#define CIS_MIN_OFFSET_MIN 500U
+
 /* Helper functions to initialize and reset ull_conn_iso module */
 int ull_conn_iso_init(void);
 int ull_conn_iso_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -104,8 +104,9 @@ uint8_t ll_cis_accept(uint16_t handle)
 	if (conn) {
 		uint32_t cis_offset_min;
 
-		if (IS_ENABLED(CONFIG_BT_CTLR_JIT_SCHEDULING)) {
-			cis_offset_min = MAX(400, EVENT_OVERHEAD_CIS_SETUP_US);
+		if (IS_ENABLED(CONFIG_BT_CTLR_PERIPHERAL_ISO_EARLY_CIG_START)) {
+			/* Early start allows offset down to spec defined minimum */
+			cis_offset_min = CIS_MIN_OFFSET_MIN;
 		} else {
 			cis_offset_min = HAL_TICKER_TICKS_TO_US(conn->ull.ticks_slot) +
 					 (EVENT_TICKER_RES_MARGIN_US << 1U);


### PR DESCRIPTION
When config BT_CTLR_PERIPHERAL_ISO_EARLY_CIG_START is enabled, the minimum accepted offset value in the CIS_REQ is the minimum defined by the spec.
Add define CIS_MIN_OFFSET_MIN with value 500 us, as defined in the Core spec. The previously used value of 400 us was incorrect.