### PR TITLE
mgmt: mcumgr: grp: img_mgmt: Fix using signed values

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -1037,6 +1037,10 @@ Libraries / Subsystems
     fs_mgmt, :kconfig:option:`CONFIG_FLASH` and
     :kconfig:option:`CONFIG_IMG_MANAGER` are needed to enable MCUmgr img_mgmt.
 
+  * MCUmgr img_mgmt group now uses unsigned integer values for image and slot
+    numbers, these numbers would never have been negative and should have been
+    unsigned.
+
 * POSIX API
 
   * Improved the locking strategy for :c:func:`eventfd_read()` and

--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -110,8 +110,8 @@ CBOR data of successful response:
     {
         (str)"images" : [
             {
-                (str,opt)"image"        : (int)
-                (str)"slot"             : (int)
+                (str,opt)"image"        : (uint)
+                (str)"slot"             : (uint)
                 (str)"version"          : (str)
                 (str,opt*)"hash"        : (byte str)
                 (str,opt)"bootable"     : (bool)

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -237,7 +237,7 @@ img_mgmt_state_read(struct smp_streamer *ctxt)
 	struct image_version ver;
 	uint32_t flags;
 	uint8_t state_flags;
-	int i;
+	uint32_t i;
 	zcbor_state_t *zse = ctxt->writer->zs;
 	bool ok;
 	struct zcbor_string zhash = { .value = hash, .len = IMAGE_HASH_LEN };
@@ -256,9 +256,9 @@ img_mgmt_state_read(struct smp_streamer *ctxt)
 		ok = zcbor_map_start_encode(zse, MAX_IMG_CHARACTERISTICS)	&&
 		     (CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER == 1	||
 		      (zcbor_tstr_put_lit(zse, "image")			&&
-		       zcbor_int32_put(zse, i >> 1)))				&&
+		       zcbor_uint32_put(zse, i >> 1)))				&&
 		     zcbor_tstr_put_lit(zse, "slot")				&&
-		     zcbor_int32_put(zse, i % 2)				&&
+		     zcbor_uint32_put(zse, i % 2)				&&
 		     zcbor_tstr_put_lit(zse, "version");
 
 		if (ok) {


### PR DESCRIPTION
    Fixes wrongly using signed values for slot and image number when
    listing images.
