### PR TITLE
doc: releases: updates for SDHC and Disk driver release notes

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -758,6 +758,7 @@ Drivers and Sensors
 * Disk
 
   * SDMMC STM32L4+: Now compatible with internal DMA
+  * NVME disks are now supported using FATFS, with a single I/O queue enabled
 
 * Display
 
@@ -898,6 +899,9 @@ Drivers and Sensors
 * Reset
 
 * SDHC
+
+  * Support was added for using CPOL/CPHA SPI clock modes with SD cards, as
+    some cards require the SPI clock switch to low when not active
 
 * Sensor
 


### PR DESCRIPTION
Add release notes for SDHC and Disk drivers, highlighting addition of NVME support in the disk driver layer as well as CPOL/CPHA clock modes within the SDHC SPI driver.