### PR TITLE
shell: kernel threads, stacks commands - iterate unlocked on SMP

### DIFF
--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -164,7 +164,12 @@ static int cmd_kernel_threads(const struct shell *sh,
 
 	shell_print(sh, "Scheduler: %u since last call", sys_clock_elapsed());
 	shell_print(sh, "Threads:");
+
+#ifdef CONFIG_SMP
+	k_thread_foreach_unlocked(shell_tdata_dump, (void *)sh);
+#else
 	k_thread_foreach(shell_tdata_dump, (void *)sh);
+#endif
 	return 0;
 }
 
@@ -208,7 +213,11 @@ static int cmd_kernel_stacks(const struct shell *sh,
 
 	memset(pad, ' ', MAX((THREAD_MAX_NAM_LEN - strlen("IRQ 00")), 1));
 
+#ifdef CONFIG_SMP
+	k_thread_foreach_unlocked(shell_stack_dump, (void *)sh);
+#else
 	k_thread_foreach(shell_stack_dump, (void *)sh);
+#endif
 
 	/* Placeholder logic for interrupt stack until we have better
 	 * kernel support, including dumping arch-specific exception-related


### PR DESCRIPTION
call k_thread_foreach_unlocked to avoid an assertion caused by calling shell_print while holding a global lock

Fixes #32145 