### PR TITLE
doc: release: Add missing boards

### DIFF
--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -492,6 +492,7 @@ Boards & SoC Support
   * NXP MIMXRT1062 FMURT6
   * PHYTEC PhyBOARD Polis (NXP i.MX8M Mini)
   * PHYTEC PhyBOARD Pollux (NXP i.MX8M Plus)
+  * Raspberry Pi Pico W
   * Raytac MDBT50Q-DB-33
   * Raytac MDBT50Q-DB-40
   * Seeed Studio Wio Terminal
@@ -503,7 +504,6 @@ Boards & SoC Support
   * ST Nucleo F042K6
   * ST Nucleo H563ZI
   * ST STM32H573I-DK Discovery
-  * Raspberry Pi Pico W
   * Xilinx KV260 (Cortex-R5)
 
 * Added support for these ARM64 boards:

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -509,7 +509,7 @@ Boards & SoC Support
 * Added support for these ARM64 boards:
 
   * PHYTEC phyCORE-AM62x A53
-  * MIMX93 EVK A53 (SOF)
+  * NXP i.MX93 EVK A55 (SOF variant)
 
 * Added support for these RISC-V boards:
 

--- a/doc/releases/release-notes-3.4.rst
+++ b/doc/releases/release-notes-3.4.rst
@@ -474,12 +474,33 @@ Boards & SoC Support
 
 * Added support for these ARC boards:
 
+  * DesignWare ARC HS4x/HS4xD Development Kit
+  * DesignWare ARC nSIM and HAPS FPGA
+
 * Added support for these ARM boards:
 
+  * Aconno ACN52832
   * Alientek STM32L475 Pandora
+  * Arduino GIGA R1 Wi-Fi
+  * BeagleConnect Freedom
+  * Infineon PSoC™ 6 BLE Prototyping Kit (CY8CPROTO-063-BLE)
+  * Infineon PSoC™ 6 Wi-Fi BT Prototyping Kit (CY8CPROTO-062-4343W)
+  * Infineon XMC4700 Relax Kit
   * MXChip AZ3166 IoT DevKit
+  * Nordic Semiconductor nRF9161 DK
+  * NXP MIMXRT1040-EVK
+  * NXP MIMXRT1062 FMURT6
+  * PHYTEC PhyBOARD Polis (NXP i.MX8M Mini)
+  * PHYTEC PhyBOARD Pollux (NXP i.MX8M Plus)
+  * Raytac MDBT50Q-DB-33
+  * Raytac MDBT50Q-DB-40
   * Seeed Studio Wio Terminal
+  * Seeed Studio XIAO BLE Sense
+  * Silicon Labs BRD2601B
+  * Silicon Labs BRD4187C
+  * Silicon Labs EFR32 Thunderboard-style boards
   * ST Nucleo C031C6
+  * ST Nucleo F042K6
   * ST Nucleo H563ZI
   * ST STM32H573I-DK Discovery
   * Raspberry Pi Pico W
@@ -492,9 +513,14 @@ Boards & SoC Support
 
 * Added support for these RISC-V boards:
 
+  * Intel FPGA Nios® V/m
+  * ITE IT82XX2 EV-Board
+
 * Added support for these X86 boards:
 
 * Added support for these Xtensa boards:
+
+  * ESP32S3-DevKitM
 
 * Made these changes for ARC boards:
 


### PR DESCRIPTION
Ran a diff with v3.3.0 to add a bunch of missing boards. I release that some of the additions I made to e.g ARC might generate conflicts if an upcoming PR ends up adding them, but on the other hand I am pretty confident the list is pretty complete now, and more importantly this PR fixes missing entries to sections that had already been populated (ex. ARM, ARM64)

