### PR TITLE
retained_mem/retention: Allow disabling mutex support

### DIFF
--- a/drivers/retained_mem/Kconfig
+++ b/drivers/retained_mem/Kconfig
@@ -16,13 +16,18 @@ config RETAINED_MEM_INIT_PRIORITY
 	  Retained memory devices initialization priority,
 
 config RETAINED_MEM_MUTEXES
-	bool "Retained memory mutex support"
+	bool
 	default y
 	depends on MULTITHREADING
+	depends on !RETAINED_MEM_MUTEX_FORCE_DISABLE
+
+config RETAINED_MEM_MUTEX_FORCE_DISABLE
+	bool "Disable retained memory mutex support"
+	depends on MULTITHREADING
 	help
-	  Use mutexes to prevent issues with concurrent retained memory access.
-	  Should only be disabled whereby retained memory access is required
-	  in an ISR or for special use cases.
+	  Disable use of mutexes which prevent issues with concurrent retained
+	  memory access. This option should only be enabled when retained
+	  memory access is required in an ISR or for special use cases.
 
 module = RETAINED_MEM
 module-str = retained_mem

--- a/subsys/retention/Kconfig
+++ b/subsys/retention/Kconfig
@@ -20,13 +20,18 @@ config RETENTION_INIT_PRIORITY
 	  priorities for retained memory drivers.
 
 config RETENTION_MUTEXES
-	bool "Retention mutex support"
+	bool
 	default y
 	depends on MULTITHREADING
+	depends on !RETENTION_MUTEX_FORCE_DISABLE
+
+config RETENTION_MUTEX_FORCE_DISABLE
+	bool "Disable retention mutex support"
+	depends on MULTITHREADING
 	help
-	  Use mutexes to prevent issues with concurrent retention device
-	  access. Should only be disabled whereby retained memory access is
-	  required in an ISR or for special use cases.
+	  Disable use of mutexes which prevent issues with concurrent retention
+	  device access. This option should only be enabled when retention
+	  access is required in an ISR or for special use cases.
 
 config RETENTION_BUFFER_SIZE
 	int "Retention stack buffer sizes"


### PR DESCRIPTION
    drivers: retained_mem: Allow disabling mutex support
    
    Changes the Kconfig option to allow disabling mutex support, this
    is to allow other Kconfig options to disable the feature.

and

    retention: Allow disabling mutex support
    
    Changes the Kconfig option to allow disabling mutex support, this
    is to allow other Kconfig options to disable the feature. Also
    adds an optional dts option which can be used to disable mutex
    support for a specific retention area.

Fixes #59254