### PR TITLE
Bluetooth: l2cap: add helpers to initialize segment-based channels

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -603,8 +603,8 @@ int bt_l2cap_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf);
  *  Each credit given allows the peer to send one segment.
  *
  *  This function depends on a valid @p chan object. Make sure to
- *  default-initialize or memset @p chan when allocating or reusing it for new
- *  connections.
+ *  default-initialize @p chan when allocating or reusing it for new
+ *  connections. This can be achieved with @ref bt_l2cap_chan_clear.
  *
  *  Adding zero credits is not allowed.
  *
@@ -616,6 +616,35 @@ int bt_l2cap_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf);
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_l2cap_chan_give_credits(struct bt_l2cap_chan *chan, uint16_t additional_credits);
+
+/** @brief Clear the channel struct so it can be re-used.
+ *
+ *  Only available for channels using @ref bt_l2cap_chan_ops.seg_recv.
+ *  @kconfig{CONFIG_BT_L2CAP_SEG_RECV} must be enabled to make this function
+ *  available.
+ *
+ *  Should only be called in the accept callback.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_l2cap_chan_seg_clear(struct bt_l2cap_chan *chan);
+
+/** @brief Clear and initialize a channel before usage.
+ *
+ *  Only available for channels using @ref bt_l2cap_chan_ops.seg_recv.
+ *  @kconfig{CONFIG_BT_L2CAP_SEG_RECV} must be enabled to make this function
+ *  available.
+ *
+ *  Convenient helper to clear the channel, set up the MTU and MPS and give an
+ *  initial amount of credits.
+ *  Should be called in the .accept callback.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_l2cap_chan_seg_init(struct bt_l2cap_chan *chan,
+			   uint16_t mtu,
+			   uint16_t mps,
+			   uint16_t initial_credits);
 
 /** @brief Complete receiving L2CAP channel data
  *

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2320,6 +2320,32 @@ static int l2cap_chan_send_credits_pdu(struct bt_conn *conn, uint16_t cid, uint1
 	return 0;
 }
 
+int bt_l2cap_chan_clear(struct bt_l2cap_chan *chan)
+{
+	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
+
+	memset(&le_chan->rx, 0, sizeof(le_chan->rx));
+
+	return 0;
+}
+
+int bt_l2cap_chan_seg_init(struct bt_l2cap_chan *chan,
+			   uint16_t mtu,
+			   uint16_t mps,
+			   uint16_t initial_credits)
+{
+	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
+
+	bt_l2cap_chan_clear(chan);
+
+	le_chan->rx.mtu = mtu;
+	le_chan->rx.mps = mps;
+
+	bt_l2cap_chan_give_credits(chan, initial_credits);
+
+	return 0;
+}
+
 /**
  * Combination of @ref atomic_add and @ref u16_add_overflow. Leaves @p
  * target unchanged if an overflow would occur. Assumes the current


### PR DESCRIPTION
This lessens the boilerplate in the app, and reduces mistakes. Also easier to make changes to what needs to be cleared later.