### PR TITLE
drivers: sensor: shtcx: fix val2 calculation

### DIFF
--- a/drivers/sensor/shtcx/shtcx.c
+++ b/drivers/sensor/shtcx/shtcx.c
@@ -53,7 +53,7 @@ static void shtcx_temperature_from_raw(uint16_t raw, struct sensor_value *val)
 	tmp = (int32_t)raw * 175U - (45 << 16);
 	val->val1 = tmp / 0x10000;
 	/* x * 1.000.000 / 65.536 == x * 15625 / 2^10 */
-	val->val2 = ((tmp % 0x10000) * 15625U) / 1024;
+	val->val2 = ((tmp % 0x10000) * 15625) / 1024;
 }
 
 /* val = 100 * sample / (2^16) */


### PR DESCRIPTION
The calculation of the sensor val2 did not correctly take the sign into account.

Fixes #53172.