### PR TITLE
soc: xtensa: intel_adsp: fix memory bank shutdown

### DIFF
--- a/soc/xtensa/intel_adsp/cavs/include/intel_tgl_adsp/adsp_memory.h
+++ b/soc/xtensa/intel_adsp/cavs/include/intel_tgl_adsp/adsp_memory.h
@@ -6,7 +6,6 @@
 #ifndef ZEPHYR_SOC_INTEL_ADSP_MEMORY_H_
 #define ZEPHYR_SOC_INTEL_ADSP_MEMORY_H_
 
-
 #include <zephyr/devicetree.h>
 #include <adsp-vectors.h>
 
@@ -21,6 +20,14 @@
 /* Linker-usable RAM region */
 #define RAM_BASE (L2_SRAM_BASE + CONFIG_HP_SRAM_RESERVE + VECTOR_TBL_SIZE)
 #define RAM_SIZE (L2_SRAM_SIZE - CONFIG_HP_SRAM_RESERVE - VECTOR_TBL_SIZE)
+
+#define SRAM_BANK_SIZE		(64 * 1024)
+#define EBB_SEG_SIZE	32
+#define HPSRAM_EBB_COUNT (DT_REG_SIZE(DT_NODELABEL(sram0)) / SRAM_BANK_SIZE)
+
+/* div_round_up, but zephyr version is not defined for assembler where this is also used */
+#define HPSRAM_SEGMENTS (HPSRAM_EBB_COUNT + EBB_SEG_SIZE - 1) / EBB_SEG_SIZE
+#define HPSRAM_MEMMASK(idx) ((1ULL << (HPSRAM_EBB_COUNT - EBB_SEG_SIZE * idx)) - 1)
 
 /* The rimage tool produces two blob addresses we need to find: one is
  * our bootloader code block which starts at its entry point, the

--- a/soc/xtensa/intel_adsp/cavs/power.c
+++ b/soc/xtensa/intel_adsp/cavs/power.c
@@ -15,6 +15,7 @@
 #include <zephyr/cache.h>
 #include <cpu_init.h>
 
+#include <adsp_memory.h>
 #include <adsp_shim.h>
 #include <adsp_clk.h>
 #include <cavs-idc.h>
@@ -36,7 +37,6 @@ LOG_MODULE_REGISTER(soc);
 #ifdef CONFIG_PM_POLICY_CUSTOM
 #define SRAM_ALIAS_BASE		0x9E000000
 #define SRAM_ALIAS_MASK		0xFF000000
-#define EBB_BANKS_IN_SEGMENT	32
 #define SRAM_ALIAS_OFFSET	0x20000000
 
 #define L2_INTERRUPT_NUMBER     4
@@ -81,11 +81,12 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		soc_cpus_active[cpu] = false;
 		sys_cache_data_flush_and_invd_all();
 		if (cpu == 0) {
-			uint32_t ebb = EBB_BANKS_IN_SEGMENT;
+			uint32_t hpsram_mask[HPSRAM_SEGMENTS];
 			/* turn off all HPSRAM banks - get a full bitmap */
-			uint32_t hpsram_mask = (1 << ebb) - 1;
+			for (int i = 0; i < HPSRAM_SEGMENTS; i++)
+				hpsram_mask[i] = HPSRAM_MEMMASK(i);
 			/* do power down - this function won't return */
-			power_down_cavs(true, uncache_to_cache(&hpsram_mask));
+			power_down_cavs(true, uncache_to_cache(&hpsram_mask[0]));
 		} else {
 			z_xt_ints_on(core_desc[cpu].intenable);
 			k_cpu_idle();

--- a/soc/xtensa/intel_adsp/cavs/power_down_cavs.S
+++ b/soc/xtensa/intel_adsp/cavs/power_down_cavs.S
@@ -4,6 +4,7 @@
 
 #include "asm_ldo_management.h"
 #include "asm_memory_management.h"
+#include "adsp_memory.h"
 
 #define IPC_HOST_BASE		0x00071E00
 #define IPC_DIPCIDD		0x18
@@ -41,8 +42,6 @@ sram_dis_loop_cnt:
 #define temp_reg3                    a9
 #define host_base		     a10
 #define pfl_reg                      a15
-
-#define MAX_MEMORY_SEGMENTS 2
 
 power_down_cavs:
 	entry sp, 32
@@ -102,8 +101,8 @@ _PD_DISABLE_HPSRAM:
  * where mask is given in pu32_hpsram_mask register
  */
 
-	.set seg_index, MAX_MEMORY_SEGMENTS - 1
-	.rept MAX_MEMORY_SEGMENTS
+	.set seg_index, HPSRAM_SEGMENTS - 1
+	.rept HPSRAM_SEGMENTS
 	l32i temp_reg0, pu32_hpsram_mask, 4 * seg_index
 	m_cavs_hpsram_power_change\
 	/*segment_index=*/	seg_index,\

--- a/soc/xtensa/intel_adsp/cavs/sram.c
+++ b/soc/xtensa/intel_adsp/cavs/sram.c
@@ -13,15 +13,11 @@
 #include <cpu_init.h>
 #include "manifest.h"
 
-
 #define DELAY_COUNT			256
 #define LPSRAM_MASK(x)		0x00000003
-#define SRAM_BANK_SIZE		(64 * 1024)
-#define EBB_SEGMENT_SIZE	32
 #define PLATFORM_INIT_HPSRAM
 #define PLATFORM_INIT_LPSRAM
 
-#define PLATFORM_HPSRAM_EBB_COUNT (DT_REG_SIZE(DT_NODELABEL(sram0)) / SRAM_BANK_SIZE)
 BUILD_ASSERT((DT_REG_SIZE(DT_NODELABEL(sram0)) % SRAM_BANK_SIZE) == 0,
 		"sram0 must be divisible by 64*1024 bank size.");
 
@@ -33,7 +29,7 @@ static __imr void hp_sram_pm_banks(uint32_t banks)
 {
 #ifdef CONFIG_ADSP_INIT_HPSRAM
 	uint32_t status, ebb_mask0, ebb_mask1, ebb_avail_mask0, ebb_avail_mask1,
-		total_banks_count = PLATFORM_HPSRAM_EBB_COUNT;
+		total_banks_count = HPSRAM_EBB_COUNT;
 
 	CAVS_SHIM.ldoctl = SHIM_LDOCTL_HPSRAM_LDO_ON;
 
@@ -44,19 +40,19 @@ static __imr void hp_sram_pm_banks(uint32_t banks)
 	 * bit masks reflect total number of available EBB (banks) in each
 	 * segment; current implementation supports 2 segments 0,1
 	 */
-	if (total_banks_count > EBB_SEGMENT_SIZE) {
-		ebb_avail_mask0 = (uint32_t)GENMASK(EBB_SEGMENT_SIZE - 1, 0);
+	if (total_banks_count > EBB_SEG_SIZE) {
+		ebb_avail_mask0 = (uint32_t)GENMASK(EBB_SEG_SIZE - 1, 0);
 		ebb_avail_mask1 = (uint32_t)GENMASK(total_banks_count -
-						    EBB_SEGMENT_SIZE - 1, 0);
+						    EBB_SEG_SIZE - 1, 0);
 	} else {
 		ebb_avail_mask0 = (uint32_t)GENMASK(total_banks_count - 1, 0);
 		ebb_avail_mask1 = 0;
 	}
 
 	/* bit masks of banks that have to be powered up in each segment */
-	if (banks > EBB_SEGMENT_SIZE) {
-		ebb_mask0 = (uint32_t)GENMASK(EBB_SEGMENT_SIZE - 1, 0);
-		ebb_mask1 = (uint32_t)GENMASK(banks - EBB_SEGMENT_SIZE - 1,
+	if (banks > EBB_SEG_SIZE) {
+		ebb_mask0 = (uint32_t)GENMASK(EBB_SEG_SIZE - 1, 0);
+		ebb_mask1 = (uint32_t)GENMASK(banks - EBB_SEG_SIZE - 1,
 		0);
 	} else {
 		/* assumption that ebb_in_use is > 0 */


### PR DESCRIPTION
Amount of memory banks should vary depending on platform, otherwise power down sequence might result in ipc timeout as the memory used by the ipc itself is shutdown.

Lift the needed defines from sram.c to adsp_memory.h and shorten the names to avoid collision with sof code. No functional change to sram.c.