### PR TITLE
dts: xtensa: intel: update cavs25 sram size

### DIFF
--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -58,7 +58,7 @@
 	sram0: memory@be000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0xbe000000 DT_SIZE_K(1920)>;
+		reg = <0xbe000000 DT_SIZE_K(2944)>;
 	};
 
 	sram1: memory@be800000 {


### PR DESCRIPTION
Cavs25 sram size should be 3MB instead of 2MB, thus update the correct value.