### PR TITLE
tests: lib: devicetree: api: test the 'reserved' status

### DIFF
--- a/dts/bindings/test/vnd,reserved-compat.yaml
+++ b/dts/bindings/test/vnd,reserved-compat.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test reserved compatible
+
+compatible: "vnd,reserved-compat"
+
+include: base.yaml

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -105,13 +105,19 @@
 		};
 
 		/*
-		 * This should be the only node with this
+		 * disabled/reserved should be the only nodes with their
 		 * compatible in the tree.
 		 */
 		disabled-node@0 {
 			compatible = "vnd,disabled-compat";
 			reg = < 0x0 0x1000 >;
 			status = "disabled";
+		};
+
+		reserved-node@0 {
+			compatible = "vnd,reserved-node";
+			reg = < 0x0 0x1000 >;
+			status = "reserved";
 		};
 
 		disabled_gpio: gpio@0 {
@@ -122,6 +128,16 @@
 			#gpio-cells = < 0x2 >;
 			label = "TEST_GPIO_0";
 			status = "disabled";
+		};
+
+		reserved_gpio: gpio@1 {
+			compatible = "vnd,gpio-device";
+			gpio-controller;
+			reg = < 0x1 0x1000 >;
+			interrupts = <3 1>;
+			#gpio-cells = < 0x2 >;
+			label = "TEST_GPIO_1";
+			status = "reserved";
 		};
 
 		test_no_status: intc_no_status@0 {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -292,6 +292,7 @@ ZTEST(devicetree_api, test_has_compat)
 	zassert_true(DT_HAS_COMPAT_STATUS_OKAY(vnd_gpio_device), "");
 	zassert_true(DT_HAS_COMPAT_STATUS_OKAY(vnd_gpio_device), "");
 	zassert_false(DT_HAS_COMPAT_STATUS_OKAY(vnd_disabled_compat), "");
+	zassert_false(DT_HAS_COMPAT_STATUS_OKAY(vnd_reserved_compat), "");
 
 	zassert_equal(TA_HAS_COMPAT(vnd_array_holder), 1, "");
 	zassert_equal(TA_HAS_COMPAT(vnd_undefined_compat), 1, "");
@@ -308,15 +309,28 @@ ZTEST(devicetree_api, test_has_status)
 		      1, "");
 	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(test_gpio_1), disabled),
 		      0, "");
+	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(test_gpio_1), reserved),
+		      0, "");
 
 	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(test_no_status), okay),
 		      1, "");
 	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(test_no_status), disabled),
 		      0, "");
+	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(test_no_status), reserved),
+		      0, "");
 
 	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(disabled_gpio), disabled),
 		      1, "");
 	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(disabled_gpio), okay),
+		      0, "");
+	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(disabled_gpio), reserved),
+		      0, "");
+
+	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(reserved_gpio), reserved),
+		      1, "");
+	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(reserved_gpio), disabled),
+		      0, "");
+	zassert_equal(DT_NODE_HAS_STATUS(DT_NODELABEL(reserved_gpio), okay),
 		      0, "");
 }
 


### PR DESCRIPTION
The `reserved` status, even though supported, was not tested. Add coverage for it.