### PR TITLE
bluetooth: controller: kconfig: Move BT_CTLR_SCAN_SYNC_ISO_SET

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -799,6 +799,14 @@ config BT_CTLR_ADV_ISO_PDU_LEN_MAX
 	help
 	  Maximum Broadcast Isochronous Channel PDU Length.
 
+config BT_CTLR_SCAN_SYNC_ISO_SET
+	int "LE ISO Broadcast Isochronous Groups Sync Sets"
+	depends on BT_CTLR_SYNC_ISO
+	range 1 64
+	default 1
+	help
+	  Maximum supported broadcast isochronous groups (BIGs) sync sets.
+
 config BT_CTLR_SYNC_ISO_STREAM_MAX
 	int "Maximum supported ISO Synchronized Receiver Streams per Broadcast ISO group"
 	depends on BT_CTLR_SYNC_ISO

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -355,14 +355,6 @@ config BT_CTLR_SCAN_AUX_SET
 	help
 	  Maximum supported auxiliary channel scan sets.
 
-config BT_CTLR_SCAN_SYNC_ISO_SET
-	int "LE ISO Broadcast Isochronous Groups Sync Sets"
-	depends on BT_CTLR_SYNC_ISO
-	range 1 64
-	default 1
-	help
-	  Maximum supported broadcast isochronous groups (BIGs) sync sets.
-
 config BT_CTLR_ADV_ENABLE_STRICT
 	bool "Enforce Strict Advertising Enable/Disable"
 	depends on BT_BROADCASTER


### PR DESCRIPTION
Move BT_CTLR_SCAN_SYNC_ISO_SET to Kconfig from Kconfig.ll_sw_split
This means it can be used by other controllers and aligns with location of other iso configs - e.g. BT_CTLR_SYNC_ISO_STREAM_COUNT

Signed-off-by: Sean Madigan <sean.madigan@nordicsemi.no>