### PR TITLE
Fix posix stat

### DIFF
--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -20,7 +20,7 @@ BUILD_ASSERT(PATH_MAX >= MAX_FILE_NAME, "PATH_MAX is less than MAX_FILE_NAME");
 struct posix_fs_desc {
 	union {
 		struct fs_file_t file;
-		struct fs_dir_t	dir;
+		struct fs_dir_t dir;
 	};
 	bool is_dir;
 	bool used;
@@ -349,22 +349,47 @@ int unlink(const char *path)
 int stat(const char *path, struct stat *buf)
 {
 	int rc;
-	struct fs_statvfs stat;
+	struct fs_statvfs stat_vfs;
+	struct fs_dirent stat_file;
 
 	if (buf == NULL) {
 		errno = EBADF;
 		return -1;
 	}
 
-	rc = fs_statvfs(path, &stat);
+	rc = fs_statvfs(path, &stat_vfs);
 	if (rc < 0) {
 		errno = -rc;
 		return -1;
 	}
 
-	buf->st_size = stat.f_bsize * stat.f_blocks;
-	buf->st_blksize = stat.f_bsize;
-	buf->st_blocks = stat.f_blocks;
+	rc = fs_stat(path, &stat_file);
+	if (rc < 0) {
+		errno = -rc;
+		return -1;
+	}
+
+	memset(buf, 0, sizeof(struct stat));
+
+	switch (stat_file.type) {
+	case FS_DIR_ENTRY_FILE:
+		buf->st_mode = S_IFREG;
+		break;
+	case FS_DIR_ENTRY_DIR:
+		buf->st_mode = S_IFDIR;
+		break;
+	default:
+		errno = EIO;
+		return -1;
+	}
+	buf->st_size = stat_file.size;
+	buf->st_blksize = stat_vfs.f_bsize;
+	/*
+	 * This is a best effort guess, as this information is not provided
+	 * by the fs_stat function.
+	 */
+	buf->st_blocks = (stat_file.size + stat_vfs.f_bsize - 1) / stat_vfs.f_bsize;
+
 	return 0;
 }
 

--- a/tests/posix/fs/src/test_fs.h
+++ b/tests/posix/fs/src/test_fs.h
@@ -7,6 +7,7 @@
 #include <zephyr/ztest.h>
 
 #define FATFS_MNTP	"/RAM:"
+#define TEST_ROOT	FATFS_MNTP"/"
 #define TEST_FILE	FATFS_MNTP"/testfile.txt"
 #define TEST_DIR	FATFS_MNTP"/testdir"
 #define TEST_DIR_FILE	FATFS_MNTP"/testdir/testfile.txt"

--- a/tests/posix/fs/src/test_fs_stat.c
+++ b/tests/posix/fs/src/test_fs_stat.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2023 Nikhef
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/posix/fcntl.h>
+#include <zephyr/posix/unistd.h>
+#include <zephyr/posix/dirent.h>
+#include "test_fs.h"
+
+#define FILL_SIZE 128
+
+#define TEST_FILE_SIZE     80
+#define TEST_DIR_FILE_SIZE 1000
+
+#define TEST_EMPTY_FILE FATFS_MNTP "/empty.dat"
+
+static void create_file(const char *filename, uint32_t size)
+{
+	int fh;
+
+	fh = open(filename, O_CREAT | O_WRONLY);
+	zassert(fh >= 0, "Failed creating test file");
+
+	uint8_t filling[FILL_SIZE];
+
+	while (size > FILL_SIZE) {
+		zassert_equal(FILL_SIZE, write(fh, filling, FILL_SIZE));
+		size -= FILL_SIZE;
+	}
+
+	zassert_equal(size, write(fh, filling, size));
+
+	zassert_ok(close(fh));
+}
+
+static void before_fn(void *unused)
+{
+	ARG_UNUSED(unused);
+
+	zassert_ok(mkdir(TEST_DIR, 0070));
+
+	create_file(TEST_FILE, TEST_FILE_SIZE);
+	create_file(TEST_DIR_FILE, TEST_DIR_FILE_SIZE);
+	create_file(TEST_EMPTY_FILE, 0);
+}
+
+static void after_fn(void *unused)
+{
+	ARG_UNUSED(unused);
+
+	zassert_ok(unlink(TEST_FILE));
+	zassert_ok(unlink(TEST_DIR_FILE));
+	zassert_ok(unlink(TEST_DIR));
+}
+
+ZTEST_SUITE(posix_fs_stat_test, NULL, test_mount, before_fn, after_fn, test_unmount);
+
+/**
+ * @brief Test stat command on file
+ *
+ * @details Tests file in root, file in directroy, non-existing file and empty file.
+ */
+ZTEST(posix_fs_stat_test, test_fs_stat_file)
+{
+	struct stat buf;
+
+	zassert_equal(0, stat(TEST_FILE, &buf));
+	zassert_equal(TEST_FILE_SIZE, buf.st_size);
+	zassert_equal(S_IFREG, buf.st_mode);
+
+	zassert_equal(0, stat(TEST_DIR_FILE, &buf));
+	zassert_equal(TEST_DIR_FILE_SIZE, buf.st_size);
+	zassert_equal(S_IFREG, buf.st_mode);
+
+	zassert_not_equal(0, stat(TEST_ROOT "foo.txt", &buf));
+	zassert_not_equal(0, stat("", &buf));
+
+	zassert_equal(0, stat(TEST_EMPTY_FILE, &buf));
+
+	zassert_equal(0, buf.st_size);
+	zassert_equal(S_IFREG, buf.st_mode);
+}
+
+/**
+ * @brief Test stat command on dir
+ *
+ * @details Tests if we can retrieve stastics for a directory. This should only provide S_IFDIR
+ *          return value.
+ */
+ZTEST(posix_fs_stat_test, test_fs_stat_dir)
+{
+	struct stat buf;
+
+	zassert_equal(0, stat(TEST_DIR, &buf));
+
+	zassert_equal(0, buf.st_size);
+	zassert_equal(S_IFDIR, buf.st_mode);
+
+	/* note: for posix compatibility should should actually work */
+	zassert_not_equal(0, stat(TEST_ROOT, &buf));
+}


### PR DESCRIPTION
This commit fixes [#58911](https://github.com/zephyrproject-rtos/zephyr/issues/58911) where the stat command only returned information on the filesystem, and not the actual file itself. It also adds some tests for the POSIX stat command. 