### PR TITLE
modules: mipi-syst: support minimal C library

### DIFF
--- a/modules/Kconfig.syst
+++ b/modules/Kconfig.syst
@@ -3,7 +3,6 @@
 
 config MIPI_SYST_LIB
 	bool "MIPI SyS-T Library Support"
-	select REQUIRES_FULL_LIBC
 	help
 	  This option enables the MIPI SyS-T Library
 
@@ -19,5 +18,12 @@ config MIPI_SYST_RAW_DATA
 	bool "output MIPI SyS-T raw data packet"
 	help
 	  This option outputs MIPI SyS-T raw data packet
+
+config MIPI_SYST_NO_WHCAR
+	bool
+	default y if MINIMAL_LIBC
+	help
+	  Tell MIPI Sys-T library to not build with
+	  wchar support.
 
 endif

--- a/west.yml
+++ b/west.yml
@@ -274,7 +274,7 @@ manifest:
       path: modules/debug/mipi-sys-t
       groups:
         - debug
-      revision: 0d521d8055f3b2b4842f728b0365d3f0ece9c37f
+      revision: a819419603a2dfcb47f7f39092e1bc112e45d1ef
     - name: nanopb
       revision: 42fa8b211e946b90b9d968523fce7b1cfe27617e
       path: modules/lib/nanopb


### PR DESCRIPTION
This allows the MIPI Sys-T library to be built with minimal C library. This is due to lack of support for wchar in our minimal C library. This simply tells the library to skip any wchar support.