### PR TITLE
net: websockets: do not close tcp socket in websocket

### DIFF
--- a/doc/connectivity/networking/api/websocket.rst
+++ b/doc/connectivity/networking/api/websocket.rst
@@ -62,7 +62,8 @@ If normal BSD socket functions are used, then currently only TEXT data
 is supported. In order to send BINARY data, the :c:func:`websocket_send_msg()`
 must be used.
 
-When done, the Websocket transport socket must be closed.
+When done, the Websocket transport socket must be closed. User should handle
+the lifecycle(close/re-use) of tcp socket after websocket_disconnect.
 
 .. code-block:: c
 

--- a/samples/net/sockets/websocket_client/src/main.c
+++ b/samples/net/sockets/websocket_client/src/main.c
@@ -431,8 +431,16 @@ int main(void)
 		close(websock4);
 	}
 
+	if (sock4 >= 0) {
+		close(sock4);
+	}
+
 	if (websock6 >= 0) {
 		close(websock6);
+	}
+
+	if (sock6 >= 0) {
+		close(sock6);
 	}
 
 	k_sleep(K_FOREVER);

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -425,8 +425,6 @@ static int websocket_interal_disconnect(struct websocket_context *ctx)
 		NET_ERR("[%p] Failed to send close message (err %d).", ctx, ret);
 	}
 
-	ret = close(ctx->real_sock);
-
 	websocket_context_unref(ctx);
 
 	return ret;


### PR DESCRIPTION
The websocket_connect api expects connected tcp socket. Closing tcp socket at websocket layer is incorrect