### PR TITLE
drivers: bluetooth: hci: spi: add small read delay

### DIFF
--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -23,3 +23,15 @@ properties:
     description:
       Minimum duration to hold the reset-gpios pin low for.
       If not specified no delay beyond the code path execution time is guaranteed.
+
+  controller-data-delay-us:
+    type: int
+    default: 20
+    description:
+      Duration to delay between reading a valid header and reading the data associated
+      with that header. This delay gives the controller time to configure the SPI data
+      transaction after finishing the header transaction. Without this delay the host
+      can attempt to read before the controller is ready, resulting in empty data that
+      then needs to be read a second time. The default of 20uS was chosen as the lowest
+      delay that reliably eliminated double transmits between a nRF9160 host and a
+      nRF52832 controller.


### PR DESCRIPTION
Add a small delay between reading the transport header and reading the HCI data. Failing to do so on a nRF9160<->nRF52832 link was reliably resulting in the nRF9160 trying to read data before the nRF52832 had set up the SPI transaction, resulting in the host reading a buffer full of 0x00 and having to run the entire read result again.

Transceiving a 10 byte packet takes at least 31uS, while 100 byte packets are around 150uS (duration of `spi_transceive` call). Waiting 1 tick to eliminate the need for most retransmissions is a valid tradeoff.