### PR TITLE
xtensa: intel_adsp: lnl: Fix dspcs struct

### DIFF
--- a/soc/xtensa/intel_adsp/ace/include/intel_ace20_lnl/adsp_boot.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace20_lnl/adsp_boot.h
@@ -21,8 +21,8 @@ struct dspcs {
 	struct {
 		uint32_t cap;
 		uint32_t ctl;
-	} capctl[3];
-	uint32_t unused0[10];
+	} capctl[5];
+	uint32_t unused0[6];
 
 	/*
 	 * DSPBRx
@@ -40,7 +40,7 @@ struct dspcs {
 		uint32_t baddr;
 		uint32_t battr;
 		uint32_t unused2;
-	} bootctl[3];
+	} bootctl[5];
 };
 
 #define DSPCS_CTL_SPA					BIT(0)


### PR DESCRIPTION
This is struct is used to access two contiguous registers for each core and lnl has 5.