### PR TITLE
Bluetooth: Mesh: clarification about adv local identity

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/core.rst
+++ b/doc/connectivity/bluetooth/api/mesh/core.rst
@@ -108,6 +108,14 @@ This means that the system workqueue is blocked for the time it takes to store
 the stack's configuration. It is not recommended to disable this option as this
 will make the device non-responsive for a noticeable amount of time.
 
+Advertisement identity
+**********************
+
+All mesh stack bearers advertise data with the :c:macro:`BT_ID_DEFAULT` local identity.
+The value is preset in the mesh stack implementation. When Bluetooth® Low Energy (LE)
+and Bluetooth mesh coexist on the same device, the application should allocate and
+configure another local identity for Bluetooth LE purposes before starting the communication.
+
 API reference
 **************
 

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -274,6 +274,7 @@ int bt_mesh_pb_gatt_srv_adv_start(void)
 	}
 
 	struct bt_le_adv_param fast_adv_param = {
+		.id = BT_ID_DEFAULT,
 		.options = ADV_OPT_PROV,
 		ADV_FAST_INT,
 	};
@@ -286,6 +287,7 @@ int bt_mesh_pb_gatt_srv_adv_start(void)
 
 	if (elapsed_time > FAST_ADV_TIME) {
 		struct bt_le_adv_param slow_adv_param = {
+			.id = BT_ID_DEFAULT,
 			.options = ADV_OPT_PROV,
 			ADV_SLOW_INT,
 		};

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -487,10 +487,12 @@ static int enc_id_adv(struct bt_mesh_subnet *sub, uint8_t type,
 		      uint8_t hash[16], int32_t duration)
 {
 	struct bt_le_adv_param slow_adv_param = {
+		.id = BT_ID_DEFAULT,
 		.options = ADV_OPT_PROXY,
 		ADV_SLOW_INT,
 	};
 	struct bt_le_adv_param fast_adv_param = {
+		.id = BT_ID_DEFAULT,
 		.options = ADV_OPT_PROXY,
 		ADV_FAST_INT,
 	};
@@ -587,6 +589,7 @@ static int priv_net_id_adv(struct bt_mesh_subnet *sub, int32_t duration)
 static int net_id_adv(struct bt_mesh_subnet *sub, int32_t duration)
 {
 	struct bt_le_adv_param slow_adv_param = {
+		.id = BT_ID_DEFAULT,
 		.options = ADV_OPT_PROXY,
 		ADV_SLOW_INT,
 	};


### PR DESCRIPTION
BT_ID_DEFAULT is hardcoded in mesh. Added clarification about the necessity of another local identity allocation for BLE if it coexists with mesh.