### PR TITLE
drivers: intel_adsp_gpdma: Fix release ownership

### DIFF
--- a/drivers/dma/dma_intel_adsp_gpdma.c
+++ b/drivers/dma/dma_intel_adsp_gpdma.c
@@ -292,7 +292,7 @@ static void intel_adsp_gpdma_release_ownership(const struct device *dev)
 #ifdef CONFIG_SOC_SERIES_INTEL_ACE
 	const struct intel_adsp_gpdma_cfg *const dev_cfg = dev->config;
 	uint32_t reg = dev_cfg->shim + GPDMA_CTL_OFFSET;
-	uint32_t val = sys_read32(reg) & ~GPDMA_OSEL(0x0);
+	uint32_t val = sys_read32(reg) & ~GPDMA_OSEL(0x3);
 
 	sys_write32(val, reg);
 	/* CHECKME: Do CAVS platforms set ownership over DMA,


### PR DESCRIPTION
Fixes a bug in intel_adsp_gpdma_release_ownership(). Before fix, this function actually did nothing for ACE platform and the ownership was not released. Now ownership is released to host CPU + DSP.