### PR TITLE
[Backport v3.3-branch] Bluetooth: Host: Fix wrong ID being stored

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -1266,12 +1266,11 @@ int bt_id_create(bt_addr_le_t *addr, uint8_t *irk)
 		}
 	}
 
-	new_id = bt_dev.id_count;
+	new_id = bt_dev.id_count++;
 	err = id_create(new_id, addr, irk);
 	if (err) {
+		bt_dev.id_count--;
 		return err;
-	} else {
-		bt_dev.id_count++;
 	}
 
 	return new_id;


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/59312.

The test has been dropped because it was relying on new feature of BabbleSim that were not available.