### PR TITLE
drivers: src: hwinfo: Report reset cause for lockup_sysresetreq

### DIFF
--- a/drivers/hwinfo/hwinfo_mcux_src.c
+++ b/drivers/hwinfo/hwinfo_mcux_src.c
@@ -37,6 +37,12 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 		flags |= RESET_CPU_LOCKUP;
 	}
 #endif
+#if (defined(FSL_FEATURE_SRC_HAS_SRSR_LOCKUP_SYSRESETREQ) && \
+	FSL_FEATURE_SRC_HAS_SRSR_LOCKUP_SYSRESETREQ)
+	if (reason & kSRC_LockupSysResetFlag) {
+		flags |= RESET_CPU_LOCKUP | RESET_SOFTWARE;
+	}
+#endif
 #if (defined(FSL_FEATURE_SRC_HAS_SRSR_CSU_RESET_B) && FSL_FEATURE_SRC_HAS_SRSR_CSU_RESET_B)
 	if (reason & kSRC_CsuResetFlag) {
 		flags |= RESET_SECURITY;
@@ -114,6 +120,10 @@ int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 #endif
 #if (defined(FSL_FEATURE_SRC_HAS_SCR_LOCKUP_RST) && FSL_FEATURE_SRC_HAS_SCR_LOCKUP_RST)
 		      | RESET_CPU_LOCKUP
+#endif
+#if (defined(FSL_FEATURE_SRC_HAS_SRSR_LOCKUP_SYSRESETREQ) && \
+		      FSL_FEATURE_SRC_HAS_SRSR_LOCKUP_SYSRESETREQ)
+		      | RESET_CPU_LOCKUP | RESET_SOFTWARE
 #endif
 #if (defined(FSL_FEATURE_SRC_HAS_SRSR_CSU_RESET_B) && FSL_FEATURE_SRC_HAS_SRSR_CSU_RESET_B)
 		      | RESET_SECURITY


### PR DESCRIPTION
Fix  incomplete reset cause to be reported for NXP MIMXRT1062-evkb.

In the event of a reset due to core lockup
or software reset request on a 1062 board,
the current NXP hwinfo driver reports an incomplete reset cause (only Ipp reset pin).

This is happening because the 1062 uses a combined CPU lockup and system reset request register bit that should be checked, whereas the current driver only checks for the existence of a lockup-only status bit.

This commit adds a check on the flag
FSL_FEATURE_SRC_HAS_SRSR_LOCKUP_SYSRESETREQ
already present in MIMXRT1062_features.h,
to report such a reset cause should it occur.