### PR TITLE
tests: drivers: adc: Add an integration platform

### DIFF
--- a/tests/drivers/adc/adc_api/testcase.yaml
+++ b/tests/drivers/adc/adc_api/testcase.yaml
@@ -7,3 +7,5 @@ tests:
   drivers.adc:
     depends_on: adc
     min_flash: 40
+    integration_platforms:
+      - native_posix


### PR DESCRIPTION
Add native_posix as integration_platform in order to avoid compiling full list of boards declaring adc support when not required

Fixes #59315