### PR TITLE
tests: kernel/mp: extend to more CPUs

### DIFF
--- a/tests/kernel/mp/src/main.c
+++ b/tests/kernel/mp/src/main.c
@@ -14,13 +14,13 @@
 
 BUILD_ASSERT(CONFIG_MP_MAX_NUM_CPUS > 1);
 
-#define CPU1_STACK_SIZE 1024
+#define CPU_STACK_SIZE 1024
 
-K_THREAD_STACK_DEFINE(cpu1_stack, CPU1_STACK_SIZE);
+K_THREAD_STACK_ARRAY_DEFINE(cpu_stacks, CONFIG_MP_MAX_NUM_CPUS, CPU_STACK_SIZE);
 
 int cpu_arg;
 
-volatile int cpu_running;
+volatile int cpu_running[CONFIG_MP_MAX_NUM_CPUS];
 
 /**
  * @brief Tests for multi processing
@@ -32,11 +32,16 @@ volatile int cpu_running;
  * @{
  * @}
  */
-FUNC_NORETURN void cpu1_fn(void *arg)
+FUNC_NORETURN void cpu_fn(void *arg)
 {
-	zassert_true(arg == &cpu_arg && *(int *)arg == 12345, "wrong arg");
+	zassert_true(arg == &cpu_arg, "mismatched arg");
 
-	cpu_running = 1;
+	int cpu_id = (*(int *)arg) / 12345;
+	int mod = (*(int *)arg) % 12345;
+
+	zassert_true(mod == 0, "wrong arg");
+
+	cpu_running[cpu_id] = 1;
 
 	while (1) {
 	}
@@ -93,14 +98,28 @@ FUNC_NORETURN void cpu1_fn(void *arg)
  */
 ZTEST(multiprocessing, test_mp_start)
 {
-	cpu_arg = 12345;
+	for (int i = 1; i < CONFIG_MP_MAX_NUM_CPUS; i++) {
+		int wait_count;
 
-	arch_start_cpu(1, cpu1_stack, CPU1_STACK_SIZE, cpu1_fn, &cpu_arg);
+		TC_PRINT("Starting CPU #%d...\n", i);
 
-	while (!cpu_running) {
+		cpu_arg = 12345 * i;
+
+		arch_start_cpu(i, cpu_stacks[i], CPU_STACK_SIZE, cpu_fn, &cpu_arg);
+
+		/* Wait for about 5 (500 * 10ms) seconds for CPU to start. */
+		wait_count = 500;
+		while (!cpu_running[i]) {
+			k_busy_wait(10 * USEC_PER_MSEC);
+
+			wait_count--;
+			if (wait_count < 0) {
+				break;
+			}
+		}
+
+		zassert_true(cpu_running[i], "cpu #%d didn't start", i);
 	}
-
-	zassert_true(cpu_running, "cpu1 didn't start");
 }
 
 ZTEST_SUITE(multiprocessing, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
This extends the multi-processor start tests to more than 2 CPUs.