### PR TITLE
x86: x86_64 can only support max 4 CPUs

### DIFF
--- a/arch/x86/core/Kconfig.intel64
+++ b/arch/x86/core/Kconfig.intel64
@@ -87,4 +87,7 @@ config X86_USERSPACE
 	 supporting user-level threads that are protected from each other and
 	 from crashing the kernel.
 
+config MP_MAX_NUM_CPUS
+	range 1 4
+
 endif # X86_64

--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -13,6 +13,8 @@
 #include <zephyr/drivers/interrupt_controller/loapic.h>
 #include <zephyr/arch/x86/acpi.h>
 
+BUILD_ASSERT(CONFIG_MP_MAX_NUM_CPUS <= 4, "Only supports max 4 CPUs");
+
 /*
  * Map of CPU logical IDs to CPU local APIC IDs. By default,
  * we assume this simple identity mapping, as found in QEMU.


### PR DESCRIPTION
With all the stacks and TSS (etc), the x86_64 arch code can only support maximum of 4 CPUs at the moment. So add a build assert if more CPUs are specified via CONFIG_MP_MAX_NUM_CPUS, also overwrite the range value for CONFIG_MP_MAX_NUM_CPUS.