### PR TITLE
drivers: wifi: esp_at: various reset improvements

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -1173,7 +1173,7 @@ static void esp_init_work(struct k_work *work)
 static int esp_reset(const struct device *dev)
 {
 	struct esp_data *data = dev->data;
-	int ret;
+	int ret = -EAGAIN;
 
 	if (net_if_is_carrier_ok(data->net_iface)) {
 		net_if_carrier_off(data->net_iface);
@@ -1192,9 +1192,14 @@ static int esp_reset(const struct device *dev)
 	k_sleep(K_MSEC(100));
 	gpio_pin_set_dt(&config->reset, 0);
 #else
+#if DT_INST_NODE_HAS_PROP(0, external_reset)
+	/* Wait to see if the interface comes up by itself */
+	ret = k_sem_take(&data->sem_if_ready, K_MSEC(CONFIG_WIFI_ESP_AT_RESET_TIMEOUT));
+#endif
 	int retries = 3;
 
-	while (retries--) {
+	/* Don't need to run this if the interface came up by itself */
+	while ((ret != 0) && retries--) {
 		ret = modem_cmd_send(&data->mctx.iface, &data->mctx.cmd_handler,
 				     NULL, 0, "AT+RST", &data->sem_if_ready,
 				     K_MSEC(CONFIG_WIFI_ESP_AT_RESET_TIMEOUT));

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -1220,7 +1220,6 @@ static int esp_reset(const struct device *dev)
 
 static void esp_iface_init(struct net_if *iface)
 {
-	net_if_carrier_off(iface);
 	esp_offload_init(iface);
 }
 

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -1166,11 +1166,14 @@ static void esp_init_work(struct k_work *work)
 	LOG_INF("ESP Wi-Fi ready");
 
 	net_if_carrier_on(dev->net_iface);
+
+	k_sem_give(&dev->sem_if_up);
 }
 
 static int esp_reset(const struct device *dev)
 {
 	struct esp_data *data = dev->data;
+	int ret;
 
 	if (net_if_is_carrier_ok(data->net_iface)) {
 		net_if_carrier_off(data->net_iface);
@@ -1189,7 +1192,6 @@ static int esp_reset(const struct device *dev)
 	k_sleep(K_MSEC(100));
 	gpio_pin_set_dt(&config->reset, 0);
 #else
-	int ret;
 	int retries = 3;
 
 	while (retries--) {
@@ -1206,7 +1208,14 @@ static int esp_reset(const struct device *dev)
 		return -EAGAIN;
 	}
 #endif
-	return 0;
+	LOG_INF("Waiting for interface to come up");
+
+	ret = k_sem_take(&data->sem_if_up, ESP_INIT_TIMEOUT);
+	if (ret == -EAGAIN) {
+		LOG_ERR("Timeout waiting for interface");
+	}
+
+	return ret;
 }
 
 static void esp_iface_init(struct net_if *iface)
@@ -1247,6 +1256,7 @@ static int esp_init(const struct device *dev)
 	k_sem_init(&data->sem_tx_ready, 0, 1);
 	k_sem_init(&data->sem_response, 0, 1);
 	k_sem_init(&data->sem_if_ready, 0, 1);
+	k_sem_init(&data->sem_if_up, 0, 1);
 
 	k_work_init(&data->init_work, esp_init_work);
 	k_work_init_delayable(&data->ip_addr_work, esp_ip_addr_work);

--- a/drivers/wifi/esp_at/esp.h
+++ b/drivers/wifi/esp_at/esp.h
@@ -264,6 +264,7 @@ struct esp_data {
 	struct k_sem sem_tx_ready;
 	struct k_sem sem_response;
 	struct k_sem sem_if_ready;
+	struct k_sem sem_if_up;
 };
 
 int esp_offload_init(struct net_if *iface);

--- a/dts/bindings/wifi/espressif,esp-at.yaml
+++ b/dts/bindings/wifi/espressif,esp-at.yaml
@@ -14,6 +14,12 @@ properties:
   reset-gpios:
     type: phandle-array
 
+  external-reset:
+    type: boolean
+    description:
+      Modem is reset by an external source. In most situations this will
+      be the microcontroller and the ESP modem on a common reset line.
+
   target-speed:
     type: int
     description:


### PR DESCRIPTION
Wait for the init process to finish again, previously removed in
a8e6fc0b83. The original reasoning (deadlock with net interface locking)
no longer applies now that `esp_reset` is called in the device init
function, not in `esp_iface_init` (332a6f084a).

Without this change, if `reset-gpios` or `power-gpios` is set,
`device_is_ready` will return true even if the chip has fallen off the
board, as no communication is validated with the board.

Add an option that signifies that the ESP modem may be reset at the same
time as the SoC by an external source. When this is the case, we first
wait for an unsolicited "ready" message from the modem, before
attempting to reset the device. This prevents two initialisation
sequences attempting to run at the same time.