### PR TITLE
lib: os: hex: correct explicit cast type

### DIFF
--- a/lib/os/hex.c
+++ b/lib/os/hex.c
@@ -27,9 +27,9 @@ int char2hex(char c, uint8_t *x)
 int hex2char(uint8_t x, char *c)
 {
 	if (x <= 9) {
-		*c = x + '0';
+		*c = x + (char)'0';
 	} else  if (x <= 15) {
-		*c = x - 10 + 'a';
+		*c = x - 10 + (char)'a';
 	} else {
 		return -EINVAL;
 	}


### PR DESCRIPTION
change explicit type cast of essential character type, complying with required [misra-c2012-10.2] rule which states; Expressions of essentially character type shall not be used inappropriately in addition and subtraction operations.

Found as a coding guideline violation (Rule 10.2) by static code scanning tool.

Note: Tested on STM32L5 Nucleo-144 board (stm32l552xx).