### PR TITLE
lib: os: hex: clarify controlling expression

### DIFF
--- a/lib/os/hex.c
+++ b/lib/os/hex.c
@@ -65,7 +65,7 @@ size_t hex2bin(const char *hex, size_t hexlen, uint8_t *buf, size_t buflen)
 	}
 
 	/* if hexlen is uneven, insert leading zero nibble */
-	if (hexlen % 2U) {
+	if ((hexlen % 2U) != 0) {
 		if (char2hex(hex[0], &dec) < 0) {
 			return 0;
 		}


### PR DESCRIPTION
add explicit boolean type to 'if' statement controlling expression, thus improving code readability and maintainability, complying with required [misra-c2012-14.4] rule which states; The controlling expression of an if statement and the controlling expression of an iteration-statement shall have essentially boolean type.

Found as a coding guideline violation (Rule 14.4) by static code scanning tool.

Note: Tested on STM32L5 Nucleo-144 board (stm32l552xx).