### PR TITLE
net: eth: Fix ethernet max header size on VLAN presence

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -96,8 +96,14 @@ struct net_eth_addr {
 
 #define NET_ETH_MINIMAL_FRAME_SIZE	60
 #define NET_ETH_MTU			1500
-#define _NET_ETH_MAX_FRAME_SIZE	(NET_ETH_MTU + sizeof(struct net_eth_hdr))
+
+#if defined(CONFIG_NET_VLAN)
+#define _NET_ETH_MAX_HDR_SIZE		(sizeof(struct net_eth_vlan_hdr))
+#else
 #define _NET_ETH_MAX_HDR_SIZE		(sizeof(struct net_eth_hdr))
+#endif
+
+#define _NET_ETH_MAX_FRAME_SIZE	(NET_ETH_MTU + _NET_ETH_MAX_HDR_SIZE)
 /*
  * Extend the max frame size for DSA (KSZ8794) by one byte (to 1519) to
  * store tail tag.


### PR DESCRIPTION
Currently NET_ETH_MAX_HDR_SIZE is computed as the size of the structure struct net_eth_hdr, but this does not take into account the additional 4 bytes on the ethernet frame header in the presence of VLAN, fix the issue using the size of struct net_eth_vlan_hdr when CONFIG_NET_VLAN is enabled.