### PR TITLE
net: config: Add VLAN identifier as network initial configuration

### DIFF
--- a/subsys/net/lib/config/Kconfig
+++ b/subsys/net/lib/config/Kconfig
@@ -71,6 +71,13 @@ menuconfig NET_CONFIG_SETTINGS
 
 if NET_CONFIG_SETTINGS
 
+config NET_CONFIG_MY_VLAN_ID
+	int "My VLAN identifier"
+	default 0
+	depends on NET_VLAN
+	help
+	  Use 0 here if uncertain.
+
 if NET_IPV6
 
 config NET_CONFIG_MY_IPV6_ADDR

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(net_config, CONFIG_NET_CONFIG_LOG_LEVEL);
 #include <stdlib.h>
 
 #include <zephyr/logging/log_backend.h>
+#include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_if.h>
@@ -110,6 +111,22 @@ static void setup_dhcpv4(struct net_if *iface)
 #else
 #define setup_dhcpv4(...)
 #endif /* CONFIG_NET_DHCPV4 */
+
+#if defined(CONFIG_NET_VLAN) && (CONFIG_NET_CONFIG_MY_VLAN_ID > 0)
+
+static void setup_vlan(struct net_if *iface)
+{
+	int ret = net_eth_vlan_enable(iface, CONFIG_NET_CONFIG_MY_VLAN_ID);
+
+	if (ret < 0) {
+		NET_ERR("Network interface %d (%p): cannot set VLAN tag (%d)",
+			net_if_get_by_iface(iface), iface, ret);
+	}
+}
+
+#else
+#define setup_vlan(...)
+#endif /* CONFIG_NET_VLAN && (CONFIG_NET_CONFIG_MY_VLAN_ID > 0) */
 
 #if defined(CONFIG_NET_NATIVE_IPV4) && !defined(CONFIG_NET_DHCPV4) && \
 	!defined(CONFIG_NET_CONFIG_MY_IPV4_ADDR)
@@ -379,6 +396,7 @@ int net_config_init_by_iface(struct net_if *iface, const char *app_info,
 #endif
 	}
 
+	setup_vlan(iface);
 	setup_ipv4(iface);
 	setup_dhcpv4(iface);
 	setup_ipv6(iface, flags);


### PR DESCRIPTION
Add a new Kconfig parameter NET_CONFIG_MY_VLAN_ID as initial network configuration to enable users to set VLAN identifier at startup.

Add a call in net_config_init_by_iface(...) function to setup the VLAN identifier in the device if the Kconfig parameter is different from zero.