### PR TITLE
dts: vendor-prefixes: Add OpenThread.io binding vendor prefix

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -439,6 +439,7 @@ opalkelly	Opal Kelly Incorporated
 opencores	OpenCores.org
 openisa	open-isa.org
 openrisc	OpenRISC.io
+openthread	OpenThread.io
 option	Option NV
 oranth	Shenzhen Oranth Technology Co., Ltd.
 ORCL	Oracle Corporation


### PR DESCRIPTION
Added OpenThread.io vendor prefix to enable `openthread,config` dts binding for additional OpenThread configurations, as used in https://github.com/zephyrproject-rtos/zephyr/commit/bf10d0dd165126f089ee1c57e7e0766f243dc455 for `diag-gpios` node

