### PR TITLE
scripts: build: parse_syscalls: Fix duplicate paths on windows

### DIFF
--- a/scripts/build/parse_syscalls.py
+++ b/scripts/build/parse_syscalls.py
@@ -29,6 +29,7 @@ import re
 import argparse
 import os
 import json
+from pathlib import PurePath
 
 regex_flags = re.MULTILINE | re.VERBOSE
 
@@ -100,6 +101,8 @@ def analyze_headers(include_dir, scan_dir, file_list):
                         path.endswith(os.path.join(os.sep, 'toolchain',
                                                    'common.h'))):
                     continue
+
+                path = PurePath(os.path.normpath(path)).as_posix()
 
                 if path not in syscall_files:
                     if include_dir and base_path in include_dir:


### PR DESCRIPTION
    Fixes an issue on windows where there would be many permutations
    of paths with different folder separators by converting to
    posix-style path separators.
    
    Issue was introduced by
    https://github.com/zephyrproject-rtos/zephyr/pull/58351

Fixes #59340

**Needs verification to ensure this is the proper fix.**