### PR TITLE
Two fixes around licensing of external components

### DIFF
--- a/doc/LICENSING.rst
+++ b/doc/LICENSING.rst
@@ -16,7 +16,7 @@ licensing in this document.
 .. _GPLv2 License:
    https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/COPYING
 
-*scripts/{checkpatch.pl,checkstack.pl,get_maintainers.pl,spelling.txt}*
+*scripts/{checkpatch.pl,checkstack.pl,spelling.txt}*
   *Origin:* Linux Kernel
 
   *Licensing:* `GPLv2 License`_

--- a/doc/contribute/external.rst
+++ b/doc/contribute/external.rst
@@ -87,7 +87,8 @@ automatically implies that the imported source code becomes part of the
 - The code is subject to the same checks and verification requirements as the
   rest of the code in the main tree, including static analysis
 - All files contain an SPDX tag if not already present
-- An entry is added to the `licensing page <zephyr_licensing>`
+- If the source is not Apache 2.0 licensed,
+  an entry is added to the :ref:`licensing page <zephyr_licensing>`.
 
 This mode of integration can be applicable to both small and large external
 codebases, but it is typically used more commonly with the former.


### PR DESCRIPTION
    doc: contribute external: Fix link and add if not Apache2
    
    The link to the zephyr_licensing page was broken
    => fix it.
    
    Also add a relatively evident "if" to the list:
    There is no need to add an entry to the licensing
    list if the integrated code is Apache 2.
    
------------

    doc licensing: Remove get_maintainers.pl
    
    There is no get_maintainers.pl in the tree, and
    hasn't been for as long as the git history lasts.
    
    Remove its mentiona as a GPL component.
    
    get_maintainers.py is Apache 2.

------

Here the rendered broken link:
https://docs.zephyrproject.org/latest/contribute/external.html#integration-in-the-main-tree
