### PR TITLE
mgmt: mcumgr: smp: Allow preventing command execution via hook

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -232,6 +232,11 @@ Devicetree
 Libraries / Subsystems
 **********************
 
+* Management
+
+  * Added response checking to MCUmgr's :c:enumerator:`MGMT_EVT_OP_CMD_RECV`
+    notification callback to allow applications to reject MCUmgr commands.
+
 HALs
 ****
 


### PR DESCRIPTION
Adds status checking to the command status hook which allows an application to inspect a request and, optionally, reject it.