### PR TITLE
net: lwm2m: Ensure string termination

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -1149,23 +1149,23 @@ int lwm2m_get_opaque(const struct lwm2m_obj_path *path, void *buf, uint16_t bufl
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[out] str String buffer to copy data into
- * @param[in] strlen Length of buffer
+ * @param[in] buflen Length of buffer
  *
  * @return 0 for success or negative in case of error.
  */
 __deprecated
-int lwm2m_engine_get_string(const char *pathstr, void *str, uint16_t strlen);
+int lwm2m_engine_get_string(const char *pathstr, void *str, uint16_t buflen);
 
 /**
  * @brief Get resource (instance) value (string)
  *
  * @param[in] path LwM2M path as a struct
  * @param[out] str String buffer to copy data into
- * @param[in] strlen Length of buffer
+ * @param[in] buflen Length of buffer
  *
  * @return 0 for success or negative in case of error.
  */
-int lwm2m_get_string(const struct lwm2m_obj_path *path, void *str, uint16_t strlen);
+int lwm2m_get_string(const struct lwm2m_obj_path *path, void *str, uint16_t buflen);
 
 /**
  * @brief Get resource (instance) value (u8)

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -436,6 +436,22 @@ int path_to_objs(const struct lwm2m_obj_path *path, struct lwm2m_engine_obj_inst
 
 	return 0;
 }
+
+static bool is_string(const struct lwm2m_obj_path *path)
+{
+	struct lwm2m_engine_obj_field *obj_field;
+	int ret;
+
+	ret = path_to_objs(path, NULL, &obj_field, NULL, NULL);
+	if (ret < 0 || !obj_field) {
+		return false;
+	}
+	if (obj_field->data_type == LWM2M_RES_TYPE_STRING) {
+		return true;
+	}
+	return false;
+}
+
 /* User data setter functions */
 
 int lwm2m_set_res_buf(const struct lwm2m_obj_path *path, void *buffer_ptr, uint16_t buffer_len,
@@ -632,15 +648,8 @@ static int lwm2m_engine_set(const struct lwm2m_obj_path *path, const void *value
 		break;
 
 	case LWM2M_RES_TYPE_STRING:
-		/* check length (note: we add 1 to string length for NULL pad) */
-		if (len > max_data_len - 1) {
-			LOG_ERR("String length %u is too long for res instance %d data", len,
-				path->res_id);
-			k_mutex_unlock(&registry_lock);
-			return -ENOMEM;
-		}
-		memcpy((uint8_t *)data_ptr, value, len);
-		((uint8_t *)data_ptr)[len] = '\0';
+		strncpy(data_ptr, value, len - 1);
+		((char *)data_ptr)[len - 1] = '\0';
 		break;
 
 	case LWM2M_RES_TYPE_U32:
@@ -753,7 +762,14 @@ int lwm2m_engine_set_opaque(const char *pathstr, const char *data_ptr, uint16_t 
 
 int lwm2m_set_string(const struct lwm2m_obj_path *path, const char *data_ptr)
 {
-	return lwm2m_engine_set(path, data_ptr, strlen(data_ptr));
+	uint16_t len = strlen(data_ptr);
+
+	/* String resources contain terminator as well, opaque resources don't */
+	if (is_string(path)) {
+		len += 1;
+	}
+
+	return lwm2m_engine_set(path, data_ptr, len);
 }
 
 int lwm2m_engine_set_string(const char *pathstr, const char *data_ptr)
@@ -1134,7 +1150,8 @@ static int lwm2m_engine_get(const struct lwm2m_obj_path *path, void *buf, uint16
 			break;
 
 		case LWM2M_RES_TYPE_STRING:
-			strncpy((uint8_t *)buf, (uint8_t *)data_ptr, buflen);
+			strncpy(buf, data_ptr, buflen - 1);
+			((char *)buf)[buflen - 1] = '\0';
 			break;
 
 		case LWM2M_RES_TYPE_U32:
@@ -1229,12 +1246,18 @@ int lwm2m_engine_get_opaque(const char *pathstr, void *buf, uint16_t buflen)
 	return lwm2m_get_opaque(&path, buf, buflen);
 }
 
-int lwm2m_get_string(const struct lwm2m_obj_path *path, void *str, uint16_t strlen)
+int lwm2m_get_string(const struct lwm2m_obj_path *path, void *str, uint16_t buflen)
 {
-	return lwm2m_engine_get(path, str, strlen);
+	/* Ensure termination, in case resource is not a string type */
+	if (!is_string(path)) {
+		memset(str, 0, buflen);
+		buflen -= 1; /* Last terminator cannot be overwritten */
+	}
+
+	return lwm2m_engine_get(path, str, buflen);
 }
 
-int lwm2m_engine_get_string(const char *pathstr, void *str, uint16_t strlen)
+int lwm2m_engine_get_string(const char *pathstr, void *str, uint16_t buflen)
 {
 	struct lwm2m_obj_path path;
 	int ret = 0;
@@ -1243,7 +1266,7 @@ int lwm2m_engine_get_string(const char *pathstr, void *str, uint16_t strlen)
 	if (ret < 0) {
 		return ret;
 	}
-	return lwm2m_get_opaque(&path, str, strlen);
+	return lwm2m_get_string(&path, str, buflen);
 }
 
 int lwm2m_get_u8(const struct lwm2m_obj_path *path, uint8_t *value)

--- a/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
+++ b/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
@@ -294,3 +294,60 @@ ZTEST(lwm2m_registry, test_callbacks)
 	zassert_equal(ret, 0);
 	zassert_equal(callback_checker, 0x7F);
 }
+
+ZTEST(lwm2m_registry, test_strings)
+{
+	int ret;
+	char buf[256] = {0};
+	struct lwm2m_obj_path path = LWM2M_OBJ(0, 0, 0);
+	static const char uri[] = "coap://127.0.0.1";
+	uint16_t len;
+	uint8_t *p;
+
+	ret = lwm2m_get_res_buf(&path, (void **)&p, &len, NULL, NULL);
+	zassert_equal(ret, 0);
+	memset(p, 0xff, len); /* Pre-fill buffer to check */
+
+	/* Handle strings in string resources */
+	ret = lwm2m_set_string(&path, uri);
+	zassert_equal(ret, 0);
+	ret = lwm2m_get_res_buf(&path, (void **)&p, NULL, &len, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(len, sizeof(uri));
+	zassert_equal(p[len - 1], '\0'); /* string terminator in buffer */
+	zassert_equal(p[len], 0xff);
+
+	ret = lwm2m_get_string(&path, buf, sizeof(buf));
+	zassert_equal(ret, 0);
+	zassert_equal(memcmp(uri, buf, sizeof(uri)), 0);
+	ret = lwm2m_get_string(&path, buf, sizeof(uri));
+	zassert_equal(ret, 0);
+	ret = lwm2m_get_string(&path, buf, strlen(uri));
+	zassert_equal(ret, -ENOMEM);
+
+	/* Handle strings in opaque resources (no terminator) */
+	path = LWM2M_OBJ(0, 0, 3);
+	ret = lwm2m_get_res_buf(&path, (void **)&p, &len, NULL, NULL);
+	zassert_equal(ret, 0);
+	memset(p, 0xff, len); /* Pre-fill buffer to check */
+
+	ret = lwm2m_set_string(&path, uri);
+	zassert_equal(ret, 0);
+	ret = lwm2m_get_res_buf(&path, (void **)&p, NULL, &len, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(len, strlen(uri)); /* No terminator counted in data length */
+	zassert_equal(p[len - 1], '1'); /* Last character in buffer is not terminator */
+	zassert_equal(p[len], 0xff);
+	memset(buf, 0xff, sizeof(buf));
+	ret = lwm2m_get_string(&path, buf, sizeof(buf)); /* get_string ensures termination */
+	zassert_equal(ret, 0);
+	zassert_equal(memcmp(uri, buf, sizeof(uri)), 0);
+	ret = lwm2m_get_string(&path, buf, sizeof(uri));
+	zassert_equal(ret, 0);
+	ret = lwm2m_get_string(&path, buf, strlen(uri));
+	zassert_equal(ret, -ENOMEM);
+	/* Corner case: we request exactly as much is stored in opaque resource, */
+	/* but because we request as a string, it must have room for terminator. */
+	ret = lwm2m_get_string(&path, buf, len);
+	zassert_equal(ret, -ENOMEM);
+}


### PR DESCRIPTION
When writing string data to resources which are string types, we should count in the terminating character into the data length.

Corner cases exist where LwM2M resource type is opaque but lwm2m_get_string() or lwm2m_set_string() are used to read/write the data. We must ensure string termination on those case, but terminating character must not be stored in the engine buffer or counted in the data length as this might be considered as part of the binary data.

Fixes #59196