### PR TITLE
drivers: sensor: lsm6dso: ODR values better match datasheet

### DIFF
--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -23,8 +23,8 @@
 
 LOG_MODULE_REGISTER(LSM6DSO, CONFIG_SENSOR_LOG_LEVEL);
 
-static const uint16_t lsm6dso_odr_map[] = {0, 12, 26, 52, 104, 208, 416, 833,
-					1660, 3330, 6660};
+static const uint16_t lsm6dso_odr_map[] = {0, 12, 26, 52, 104, 208, 417, 833,
+					1667, 3333, 6667};
 
 static int lsm6dso_freq_to_odr_val(uint16_t freq)
 {


### PR DESCRIPTION
Values now match better with the ODR values specified in the datasheet (see page 30, table 18).
The now also match with the values define in [lsm6dso-common.yaml ](https://github.com/zephyrproject-rtos/zephyr/blob/68589ca0f1d0af789bf1853c6a296d39fe5ebfe1/dts/bindings/sensor/st%2Clsm6dso-common.yaml)
