### PR TITLE
drivers: gsm_ppp: Fix possible NULL pointer dereference

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -615,7 +615,7 @@ static struct net_if *ppp_net_if(void)
 static void set_ppp_carrier_on(struct gsm_modem *gsm)
 {
 	const struct device *ppp_dev = device_get_binding(CONFIG_NET_PPP_DRV_NAME);
-	const struct ppp_api *api = (const struct ppp_api *)ppp_dev->api;
+	const struct ppp_api *api;
 	struct net_if *iface = gsm->iface;
 	int ret;
 
@@ -623,6 +623,8 @@ static void set_ppp_carrier_on(struct gsm_modem *gsm)
 		LOG_ERR("Cannot find PPP %s!", CONFIG_NET_PPP_DRV_NAME);
 		return;
 	}
+
+	api = (const struct ppp_api *)ppp_dev->api;
 
 	ret = api->start(ppp_dev);
 


### PR DESCRIPTION
Assign api value after NULL check.

Fixes: #59532