### PR TITLE
arm64: Remove ARCH_IRQ_DIRECT_CONNECT

### DIFF
--- a/include/zephyr/arch/arm64/irq.h
+++ b/include/zephyr/arch/arm64/irq.h
@@ -88,12 +88,6 @@ extern void z_arm64_interrupt_init(void);
 	z_arm64_irq_priority_set(irq_p, priority_p, flags_p); \
 }
 
-#define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
-{ \
-	Z_ISR_DECLARE(irq_p, ISR_FLAG_DIRECT, isr_p, NULL); \
-	z_arm64_irq_priority_set(irq_p, priority_p, flags_p); \
-}
-
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus


### PR DESCRIPTION
There is no support for direct IRQs on ARM64. Remove the macro.