### PR TITLE
ipc_service: icmsg: Improve packets reception

### DIFF
--- a/include/zephyr/ipc/icmsg.h
+++ b/include/zephyr/ipc/icmsg.h
@@ -45,9 +45,9 @@ struct icmsg_data_t {
 	/* Tx/Rx buffers. */
 	struct spsc_pbuf *tx_ib;
 	struct spsc_pbuf *rx_ib;
-	atomic_t send_buffer_state;
+	atomic_t tx_buffer_state;
 #ifdef CONFIG_IPC_SERVICE_ICMSG_SHMEM_ACCESS_SYNC
-	struct k_mutex send;
+	struct k_mutex tx_lock;
 #endif
 
 	/* Callbacks for an endpoint. */

--- a/include/zephyr/ipc/icmsg.h
+++ b/include/zephyr/ipc/icmsg.h
@@ -45,7 +45,7 @@ struct icmsg_data_t {
 	/* Tx/Rx buffers. */
 	struct spsc_pbuf *tx_ib;
 	struct spsc_pbuf *rx_ib;
-	atomic_t send_buffer_reserved;
+	atomic_t send_buffer_state;
 #ifdef CONFIG_IPC_SERVICE_ICMSG_SHMEM_ACCESS_SYNC
 	struct k_mutex send;
 #endif
@@ -59,11 +59,11 @@ struct icmsg_data_t {
 	struct k_work_delayable notify_work;
 	struct k_work mbox_work;
 	atomic_t state;
-	uint8_t rx_buffer[CONFIG_IPC_SERVICE_ICMSG_CB_BUF_SIZE] __aligned(4);
-
 	/* No-copy */
 #ifdef CONFIG_IPC_SERVICE_ICMSG_NOCOPY_RX
-	atomic_t rx_buffer_held;
+	atomic_t rx_buffer_state;
+	const void *rx_buffer;
+	uint16_t rx_len;
 #endif
 };
 

--- a/include/zephyr/sys/spsc_pbuf.h
+++ b/include/zephyr/sys/spsc_pbuf.h
@@ -90,7 +90,7 @@ struct spsc_pbuf_ext_nocache {
  *
  * The SPSC packet buffer implements lightweight unidirectional packet buffer
  * with read/write semantics on top of a memory region shared
- * by the reader and writer. It optionally embeds cache and memory barier
+ * by the reader and writer. It optionally embeds cache and memory barrier
  * management to ensure correct data access.
  *
  * This structure supports single writer and reader. Data stored in the buffer
@@ -190,7 +190,7 @@ int spsc_pbuf_alloc(struct spsc_pbuf *pb, uint16_t len, char **buf);
  * @brief Commit packet to the buffer.
  *
  * Commit a packet which was previously allocated (@ref spsc_pbuf_alloc).
- * If cache is used, cache writeback is perfromed on the written data.
+ * If cache is used, cache writeback is performed on the written data.
  *
  * @param pb	A buffer to which to write.
  * @param len	Packet length. Must be equal or less than the length used for allocation.
@@ -219,12 +219,16 @@ int spsc_pbuf_read(struct spsc_pbuf *pb, char *buf, uint16_t len);
 /**
  * @brief Claim packet from the buffer.
  *
- * Claimed packet must be freed using @ref spsc_pbuf_free.
+ * It claims a single packet from the buffer in the order of the commitment
+ * by the @ref spsc_pbuf_commit function. The first commited packet will be claimed first.
+ * The returned buffer is 32 bit word aligned and points to the continuous memory.
+ * Claimed packet must be freed using the @ref spsc_pbuf_free function.
  *
  * @note If data cache is used, cache is invalidate on the packet.
  *
  * @param[in] pb	A buffer from which packet will be claimed.
  * @param[in,out] buf	A location where claimed packet address is written.
+ *                      It is 32 bit word aligned and points to the continuous memory.
  *
  * @retval 0 No packets in the buffer.
  * @retval positive packet length.

--- a/include/zephyr/sys/spsc_pbuf.h
+++ b/include/zephyr/sys/spsc_pbuf.h
@@ -220,7 +220,7 @@ int spsc_pbuf_read(struct spsc_pbuf *pb, char *buf, uint16_t len);
  * @brief Claim packet from the buffer.
  *
  * It claims a single packet from the buffer in the order of the commitment
- * by the @ref spsc_pbuf_commit function. The first commited packet will be claimed first.
+ * by the @ref spsc_pbuf_commit function. The first committed packet will be claimed first.
  * The returned buffer is 32 bit word aligned and points to the continuous memory.
  * Claimed packet must be freed using the @ref spsc_pbuf_free function.
  *

--- a/subsys/ipc/ipc_service/lib/Kconfig.icmsg
+++ b/subsys/ipc/ipc_service/lib/Kconfig.icmsg
@@ -1,16 +1,6 @@
 # Copyright (c) 2022 Nordic Semiconductor (ASA)
 # SPDX-License-Identifier: Apache-2.0
 
-config IPC_SERVICE_ICMSG_CB_BUF_SIZE
-	int "Size of callback buffer size"
-	range 1 65535
-	default 255
-	help
-	  Size of callback buffer used for processing received data in work
-	  queue thread. If you are sure that your application never sends data
-	  data bigger than some size, you can safely change this option to
-	  reduce RAM consumption in your application.
-
 config IPC_SERVICE_ICMSG_NOCOPY_RX
 	bool
 	depends on IPC_SERVICE_ICMSG

--- a/subsys/ipc/ipc_service/lib/icmsg.c
+++ b/subsys/ipc/ipc_service/lib/icmsg.c
@@ -11,19 +11,22 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/spsc_pbuf.h>
 
-#define RX_BUF_SIZE		CONFIG_IPC_SERVICE_ICMSG_CB_BUF_SIZE
 #define BOND_NOTIFY_REPEAT_TO	K_MSEC(CONFIG_IPC_SERVICE_ICMSG_BOND_NOTIFY_REPEAT_TO_MS)
 #define SHMEM_ACCESS_TO		K_MSEC(CONFIG_IPC_SERVICE_ICMSG_SHMEM_ACCESS_TO_MS)
 
-#define RX_BUFFER_RELEASED	0
-#define RX_BUFFER_HELD		1
-#define SEND_BUFFER_UNUSED	0
-#define SEND_BUFFER_RESERVED	1
+enum rx_buffer_state {
+	RX_BUFFER_STATE_RELEASED,
+	RX_BUFFER_STATE_RELEASING,
+	RX_BUFFER_STATE_HELD
+};
+
+enum send_buffer_state {
+	SEND_BUFFER_STATE_UNUSED,
+	SEND_BUFFER_STATE_RESERVED
+};
 
 static const uint8_t magic[] = {0x45, 0x6d, 0x31, 0x6c, 0x31, 0x4b,
 				0x30, 0x72, 0x6e, 0x33, 0x6c, 0x69, 0x34};
-BUILD_ASSERT(sizeof(magic) <= RX_BUF_SIZE);
-BUILD_ASSERT(RX_BUF_SIZE <= UINT16_MAX);
 
 static int mbox_deinit(const struct icmsg_config_t *conf,
 		       struct icmsg_data_t *dev_data)
@@ -72,8 +75,8 @@ static bool is_endpoint_ready(struct icmsg_data_t *dev_data)
 
 static bool is_send_buffer_reserved(struct icmsg_data_t *dev_data)
 {
-	return atomic_get(&dev_data->send_buffer_reserved) ==
-			SEND_BUFFER_RESERVED;
+	return atomic_get(&dev_data->send_buffer_state) ==
+			SEND_BUFFER_STATE_RESERVED;
 }
 
 static int reserve_send_buffer_if_unused(struct icmsg_data_t *dev_data)
@@ -86,16 +89,16 @@ static int reserve_send_buffer_if_unused(struct icmsg_data_t *dev_data)
 	}
 #endif
 
-	bool was_unused = atomic_cas(&dev_data->send_buffer_reserved,
-				  SEND_BUFFER_UNUSED, SEND_BUFFER_RESERVED);
+	bool was_unused = atomic_cas(&dev_data->send_buffer_state,
+				  SEND_BUFFER_STATE_UNUSED, SEND_BUFFER_STATE_RESERVED);
 
 	return was_unused ? 0 : -EALREADY;
 }
 
 static int release_send_buffer(struct icmsg_data_t *dev_data)
 {
-	bool was_reserved = atomic_cas(&dev_data->send_buffer_reserved,
-					SEND_BUFFER_RESERVED, SEND_BUFFER_UNUSED);
+	bool was_reserved = atomic_cas(&dev_data->send_buffer_state,
+					SEND_BUFFER_STATE_RESERVED, SEND_BUFFER_STATE_UNUSED);
 
 	if (!was_reserved) {
 		return -EALREADY;
@@ -108,13 +111,21 @@ static int release_send_buffer(struct icmsg_data_t *dev_data)
 #endif
 }
 
-
 static bool is_rx_buffer_free(struct icmsg_data_t *dev_data)
 {
 #ifdef CONFIG_IPC_SERVICE_ICMSG_NOCOPY_RX
-	return atomic_get(&dev_data->rx_buffer_held) == RX_BUFFER_RELEASED;
+	return atomic_get(&dev_data->rx_buffer_state) == RX_BUFFER_STATE_RELEASED;
 #else
 	return true;
+#endif
+}
+
+static bool is_rx_buffer_held(struct icmsg_data_t *dev_data)
+{
+#ifdef CONFIG_IPC_SERVICE_ICMSG_NOCOPY_RX
+	return atomic_get(&dev_data->rx_buffer_state) == RX_BUFFER_STATE_HELD;
+#else
+	return false;
 #endif
 }
 
@@ -159,31 +170,48 @@ static void submit_work_if_buffer_free_and_data_available(
 
 static void mbox_callback_process(struct k_work *item)
 {
+	char *rx_buffer;
 	struct icmsg_data_t *dev_data = CONTAINER_OF(item, struct icmsg_data_t, mbox_work);
 
 	atomic_t state = atomic_get(&dev_data->state);
-	int len = spsc_pbuf_read(dev_data->rx_ib, dev_data->rx_buffer,
-				 RX_BUF_SIZE);
 
-	__ASSERT_NO_MSG(len <= RX_BUF_SIZE);
+	uint16_t len = spsc_pbuf_claim(dev_data->rx_ib, &rx_buffer);
 
-	if (len == -EAGAIN) {
-		__ASSERT_NO_MSG(false);
-		submit_mbox_work(dev_data);
-		return;
-	} else if (len <= 0) {
+	if (len == 0) {
+		/* Unlikely, no data in buffer. */
 		return;
 	}
 
 	if (state == ICMSG_STATE_READY) {
 		if (dev_data->cb->received) {
-			dev_data->cb->received(dev_data->rx_buffer, len,
+#if CONFIG_IPC_SERVICE_ICMSG_NOCOPY_RX
+			dev_data->rx_buffer = rx_buffer;
+			dev_data->rx_len = len;
+#endif
+
+			dev_data->cb->received(rx_buffer, len,
 					       dev_data->ctx);
+
+			/* Release Rx buffer here only in case when user did not request
+			 * to hold it.
+			 */
+			if (!is_rx_buffer_held(dev_data)) {
+				spsc_pbuf_free(dev_data->rx_ib, len);
+
+#if CONFIG_IPC_SERVICE_ICMSG_NOCOPY_RX
+				dev_data->rx_buffer = NULL;
+				dev_data->rx_len = 0;
+#endif
+			}
 		}
 	} else {
 		__ASSERT_NO_MSG(state == ICMSG_STATE_BUSY);
-		if (len != sizeof(magic) ||
-		    memcmp(magic, dev_data->rx_buffer, len)) {
+
+		bool endpoint_invalid = (len != sizeof(magic) || memcmp(magic, rx_buffer, len));
+
+		spsc_pbuf_free(dev_data->rx_ib, len);
+
+		if (endpoint_invalid) {
 			__ASSERT_NO_MSG(false);
 			return;
 		}
@@ -202,7 +230,6 @@ static void mbox_callback(const struct device *instance, uint32_t channel,
 			  void *user_data, struct mbox_msg *msg_data)
 {
 	struct icmsg_data_t *dev_data = user_data;
-
 	submit_work_if_buffer_free(dev_data);
 }
 
@@ -446,8 +473,8 @@ int icmsg_hold_rx_buffer(const struct icmsg_config_t *conf,
 		return -EINVAL;
 	}
 
-	was_released = atomic_cas(&dev_data->rx_buffer_held,
-				  RX_BUFFER_RELEASED, RX_BUFFER_HELD);
+	was_released = atomic_cas(&dev_data->rx_buffer_state,
+				  RX_BUFFER_STATE_RELEASED, RX_BUFFER_STATE_HELD);
 	if (!was_released) {
 		return -EALREADY;
 	}
@@ -469,11 +496,23 @@ int icmsg_release_rx_buffer(const struct icmsg_config_t *conf,
 		return -EINVAL;
 	}
 
-	was_held = atomic_cas(&dev_data->rx_buffer_held,
-			      RX_BUFFER_HELD, RX_BUFFER_RELEASED);
+	/* Do not schedule new packet processing until buffer will be released.
+	 * Protect buffer against being freed multiple times.
+	 */
+	was_held = atomic_cas(&dev_data->rx_buffer_state,
+			      RX_BUFFER_STATE_HELD, RX_BUFFER_STATE_RELEASING);
 	if (!was_held) {
 		return -EALREADY;
 	}
+
+	spsc_pbuf_free(dev_data->rx_ib, dev_data->rx_len);
+
+#if CONFIG_IPC_SERVICE_ICMSG_NOCOPY_RX
+	dev_data->rx_buffer = NULL;
+	dev_data->rx_len = 0;
+#endif
+
+	atomic_set(&dev_data->rx_buffer_state, RX_BUFFER_STATE_RELEASED);
 
 	submit_work_if_buffer_free_and_data_available(dev_data);
 


### PR DESCRIPTION
This improves packets reception in the icmsg backend. The remote can receive the same amount of data that were send by host. It removes local data coping into the internal buffer and fix and issue where data from host larger than remote buffer was silently dropped. Additionally this PR contains documentation clarification for the spsc_pbuf_claim function.