### PR TITLE
mgmt: mcumgr: Allow additional cbor states for encoding

### DIFF
--- a/include/zephyr/mgmt/mcumgr/smp/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp/smp.h
@@ -54,7 +54,7 @@ struct cbor_nb_reader {
 
 struct cbor_nb_writer {
 	struct net_buf *nb;
-	zcbor_state_t zs[2];
+	zcbor_state_t zs[CONFIG_MCUMGR_SMP_CBOR_MAX_ENCODING_LEVELS + 2];
 
 #if IS_ENABLED(CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL)
 	uint16_t error_group;

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
@@ -130,6 +130,7 @@ config MCUMGR_GRP_FS_HASH_SHA256
 
 config MCUMGR_GRP_FS_CHECKSUM_HASH_SUPPORTED_CMD
 	bool "Supported hash/checksum command"
+	select MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_3 if ZCBOR_CANONICAL
 	help
 	  Enable the supported hash/checksum command which will return details on
 	  supported hash and checksum types that can be used.

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -19,6 +19,7 @@ menuconfig MCUMGR_GRP_IMG
 	depends on !MCUBOOT_BOOTLOADER_MODE_SINGLE_APP
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
+	select MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_3 if ZCBOR_CANONICAL
 	help
 	  Enables MCUmgr handlers for image management
 

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
@@ -48,6 +48,7 @@ endif
 
 config MCUMGR_GRP_OS_TASKSTAT
 	bool "Support for taskstat command"
+	select MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_3 if ZCBOR_CANONICAL
 	depends on THREAD_MONITOR
 
 if MCUMGR_GRP_OS_TASKSTAT

--- a/subsys/mgmt/mcumgr/grp/stat_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/stat_mgmt/Kconfig
@@ -16,6 +16,7 @@ menuconfig MCUMGR_GRP_STAT
 	bool "Mcumgr handlers for statistics management"
 	depends on STATS
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
+	select MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_3 if ZCBOR_CANONICAL
 	help
 	  Enables MCUmgr handlers for statistics management.
 

--- a/subsys/mgmt/mcumgr/smp/Kconfig
+++ b/subsys/mgmt/mcumgr/smp/Kconfig
@@ -35,6 +35,8 @@ config MCUMGR_SMP_CBOR_MIN_DECODING_LEVELS
 	  A group or command that adds additional maps/lists above the
 	  base map, which is already taken into account, should
 	  select one of the MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_?.
+	default 7 if MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_7
+	default 6 if MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_6
 	default 5 if MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_5
 	default 4 if MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_4
 	default 3 if MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_3
@@ -57,8 +59,14 @@ config MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_4
 config MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_5
 	bool
 
+config MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_6
+	bool
+
+config MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_7
+	bool
+
 config MCUMGR_SMP_CBOR_MAX_DECODING_LEVELS
-	int "Number of map/list encapsulations allowed by SMP encoding"
+	int "Number of map/list encapsulations allowed for SMP decoding"
 	range MCUMGR_SMP_CBOR_MIN_DECODING_LEVELS 15
 	default MCUMGR_SMP_CBOR_MIN_DECODING_LEVELS
 	help
@@ -72,6 +80,56 @@ config MCUMGR_SMP_CBOR_MAX_DECODING_LEVELS
 	  it will need 2 levels.
 	  This number translates to zcbor backup states, it increases
 	  size of cbor_nb_reader structure by zcbor_state_t size per
+	  one unit selected here.
+
+config MCUMGR_SMP_CBOR_MIN_ENCODING_LEVELS
+	int
+	help
+	  Minimal encoding levels, map/list encapsulation, required
+	  to be supported by zcbor encoding of SMP responses
+	  is auto genereated from MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_? options.
+	  A group or command that adds additional maps/lists above the
+	  base map, which is already taken into account, should
+	  select one of the MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_?.
+	default 7 if MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_7
+	default 6 if MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_6
+	default 5 if MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_5
+	default 4 if MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_4
+	default 3 if MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_3
+	default 2 if MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_2
+	default 1 if MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_1 || ZCBOR_CANONICAL
+	default 0
+
+config MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_1
+	bool
+
+config MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_2
+	bool
+
+config MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_3
+	bool
+
+config MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_4
+	bool
+
+config MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_5
+	bool
+
+config MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_6
+	bool
+
+config MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_7
+	bool
+
+config MCUMGR_SMP_CBOR_MAX_ENCODING_LEVELS
+	int "Number of map/list encapsulations allowed for SMP encoding"
+	range MCUMGR_SMP_CBOR_MIN_ENCODING_LEVELS 15
+	default MCUMGR_SMP_CBOR_MIN_ENCODING_LEVELS
+	help
+	  This is a maximum number of levels of maps/lists that will
+	  be encoded within different comm&& groups.
+	  This number translates to zcbor backup states, it increases
+	  size of cbor_nb_writer structure by zcbor_state_t size per
 	  one unit selected here.
 
 config MCUMGR_SMP_COMMAND_STATUS_HOOKS

--- a/subsys/mgmt/mcumgr/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/smp/src/smp.c
@@ -61,7 +61,7 @@ static void cbor_nb_writer_init(struct cbor_nb_writer *cnw, struct net_buf *nb)
 	net_buf_reset(nb);
 	cnw->nb = nb;
 	cnw->nb->len = sizeof(struct smp_hdr);
-	zcbor_new_encode_state(cnw->zs, 2, nb->data + sizeof(struct smp_hdr),
+	zcbor_new_encode_state(cnw->zs, ARRAY_SIZE(cnw->zs), nb->data + sizeof(struct smp_hdr),
 			       net_buf_tailroom(nb), 0);
 }
 


### PR DESCRIPTION
Allows selecting more than the default number of encoding states.

Fixes #59341