### PR TITLE
Bluetooth: Mesh: fix missed old encryption in dfu metadata

### DIFF
--- a/subsys/bluetooth/mesh/dfu_metadata.c
+++ b/subsys/bluetooth/mesh/dfu_metadata.c
@@ -77,7 +77,7 @@ int bt_mesh_dfu_metadata_comp_hash_get(struct net_buf_simple *buf, uint8_t *key,
 	int err;
 	struct bt_mesh_sg sg = {.data = buf->data, .len = buf->len};
 
-	err = bt_mesh_aes_cmac(key, &sg, 1, mac);
+	err = bt_mesh_aes_cmac_raw_key(key, &sg, 1, mac);
 	if (err) {
 		return err;
 	}


### PR DESCRIPTION
PR fixes the old internal encryption api usage
for dfu metadata.