### PR TITLE
SMP: fix build failure if SMP=y and SYS_CLOCK_EXISTS=n

### DIFF
--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -141,7 +141,9 @@ z_thread_return_value_set_with_data(struct k_thread *thread,
 
 #ifdef CONFIG_SMP
 extern void z_smp_init(void);
+#ifdef CONFIG_SYS_CLOCK_EXISTS
 extern void smp_timer_init(void);
+#endif
 #endif
 
 extern void z_early_boot_rand_get(uint8_t *buf, size_t length);

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -85,7 +85,9 @@ static inline FUNC_NORETURN void smp_init_top(void *arg)
 
 	wait_for_start_signal(arg);
 	z_dummy_thread_init(&dummy_thread);
+#ifdef CONFIG_SYS_CLOCK_EXISTS
 	smp_timer_init();
+#endif
 
 	z_swap_unlocked();
 


### PR DESCRIPTION
Fix build failure for the SMP configurations without sysclock.