### PR TITLE
Bluetooth: BAP: Shell: Register CAP callbacks if CAP initiator

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2275,6 +2275,15 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 #if defined(CONFIG_BT_BAP_UNICAST)
 	for (i = 0; i < ARRAY_SIZE(unicast_streams); i++) {
 		bt_bap_stream_cb_register(&unicast_streams[i].stream.bap_stream, &stream_ops);
+
+		if (IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
+		    IS_ENABLED(CONFIG_BT_CAP_INITIATOR)) {
+			/* If we use the cap initiator, we need to register the callbacks for CAP
+			 * as well, as CAP will override and use the BAP callbacks if doing a CAP
+			 * procedure
+			 */
+			bt_cap_stream_ops_register(&unicast_streams[i].stream, &stream_ops);
+		}
 	}
 #endif /* CONFIG_BT_BAP_UNICAST */
 


### PR DESCRIPTION
If we are use the shell as a CAP initiator, then we need to register the stream callbacks for the CAP streams as well, as CAP will use the BAP callbacks.