### PR TITLE
Bluetooth: BAP: Shell: Fix missing src_id in mod_src

### DIFF
--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -685,6 +685,7 @@ static int cmd_bap_broadcast_assistant_mod_src(const struct shell *sh,
 
 		return -ENOEXEC;
 	}
+	param.src_id = src_id;
 
 	param.pa_sync = shell_strtobool(argv[2], 0, &result);
 	if (result != 0) {


### PR DESCRIPTION
The src_id was never set in
cmd_bap_broadcast_assistant_mod_src.