### PR TITLE
Bluetooth: BAP: Shell: Print received broadcast code

### DIFF
--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -294,6 +294,7 @@ static void broadcast_code_cb(struct bt_conn *conn,
 	struct sync_state *state;
 
 	shell_info(ctx_shell, "Broadcast code received for %p", recv_state);
+	shell_hexdump(ctx_shell, broadcast_code, BT_AUDIO_BROADCAST_CODE_SIZE);
 
 	state = sync_state_get(recv_state);
 	if (state == NULL) {


### PR DESCRIPTION
Print the received broadcast code as the scan delegator.