### PR TITLE
Bluetooth: BAP: Filter PA data duplicates by default

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -832,8 +832,8 @@ static uint16_t interval_to_sync_timeout(uint16_t interval)
 static void sync_broadcast_pa(const struct bt_le_scan_recv_info *info,
 			      uint32_t broadcast_id)
 {
+	struct bt_le_per_adv_sync_param param = {0};
 	struct bt_bap_broadcast_sink_cb *listener;
-	struct bt_le_per_adv_sync_param param;
 	struct bt_bap_broadcast_sink *sink;
 	int err;
 
@@ -853,7 +853,7 @@ static void sync_broadcast_pa(const struct bt_le_scan_recv_info *info,
 	}
 
 	bt_addr_le_copy(&param.addr, info->addr);
-	param.options = 0;
+	param.options = BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE;
 	param.sid = info->sid;
 	param.skip = PA_SYNC_SKIP;
 	param.timeout = interval_to_sync_timeout(info->interval);

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -178,6 +178,7 @@ static int pa_sync_no_past(struct sync_state *state,
 	recv_state = state->recv_state;
 
 	bt_addr_le_copy(&param.addr, &recv_state->addr);
+	param.options = BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE;
 	param.sid = recv_state->adv_sid;
 	param.skip = PA_SYNC_SKIP;
 	param.timeout = interval_to_sync_timeout(pa_interval);


### PR DESCRIPTION
When syncing via the broadcast sink or the scan delegator it makes more sense to filter on duplicates, as the expected data rarely changes.