### PR TITLE
kernel: Change locking in k_thread_suspend()

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -621,11 +621,7 @@ static inline k_tid_t k_current_get(void)
  * this is done via blocking the caller (in the same manner as
  * k_thread_join()), but in interrupt context on SMP systems the
  * implementation is required to spin for threads that are running on
- * other CPUs.  Note that as specified, this means that on SMP
- * platforms it is possible for application code to create a deadlock
- * condition by simultaneously aborting a cycle of threads using at
- * least one termination from interrupt context.  Zephyr cannot detect
- * all such conditions.
+ * other CPUs.
  *
  * @param thread ID of thread to abort.
  */
@@ -977,6 +973,11 @@ int k_thread_cpu_pin(k_tid_t thread, int cpu);
  * (e.g. k_sleep(), or a timeout argument to k_sem_take() et. al.)
  * will be canceled.  On resume, the thread will begin running
  * immediately and return from the blocked call.
+ *
+ * When the target thread is active on another CPU, the caller will block until
+ * the target thread is halted (suspended or aborted).  But if the caller is in
+ * an interrupt context, it will spin waiting for that target thread active on
+ * another CPU to halt.
  *
  * If @a thread is already suspended, the routine has no effect.
  *

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -351,6 +351,11 @@ struct k_thread {
 	struct k_obj_core  obj_core;
 #endif
 
+#ifdef CONFIG_SMP
+	/** threads waiting in k_thread_suspend() */
+	_wait_q_t  halt_queue;
+#endif
+
 	/** arch-specifics: must always be at the end */
 	struct _thread_arch arch;
 };

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -60,8 +60,11 @@ extern "C" {
 /* Thread is suspended */
 #define _THREAD_SUSPENDED (BIT(4))
 
-/* Thread is being aborted */
+/* Thread is in the process of aborting */
 #define _THREAD_ABORTING (BIT(5))
+
+/* Thread is in the process of suspending */
+#define _THREAD_SUSPENDING (BIT(6))
 
 /* Thread is present in the ready queue */
 #define _THREAD_QUEUED (BIT(7))

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -311,15 +311,33 @@ static size_t copy_bytes(char *dest, size_t dest_size, const char *src, size_t s
 	return bytes_to_copy;
 }
 
+#define Z_STATE_STR_DUMMY       "dummy"
+#define Z_STATE_STR_PENDING     "pending"
+#define Z_STATE_STR_PRESTART    "prestart"
+#define Z_STATE_STR_DEAD        "dead"
+#define Z_STATE_STR_SUSPENDED   "suspended"
+#define Z_STATE_STR_ABORTING    "aborting"
+#define Z_STATE_STR_SUSPENDING  "suspending"
+#define Z_STATE_STR_QUEUED      "queued"
+
 const char *k_thread_state_str(k_tid_t thread_id, char *buf, size_t buf_size)
 {
 	size_t      off = 0;
 	uint8_t     bit;
 	uint8_t     thread_state = thread_id->base.thread_state;
-	static const char  *states_str[8] = {"dummy", "pending", "prestart",
-					     "dead", "suspended", "aborting",
-					     "", "queued"};
-	static const size_t states_sz[8] = {5, 7, 8, 4, 9, 8, 0, 6};
+	static const struct {
+		const char *str;
+		size_t      len;
+	} state_string[] = {
+		{ Z_STATE_STR_DUMMY, sizeof(Z_STATE_STR_DUMMY) - 1},
+		{ Z_STATE_STR_PENDING, sizeof(Z_STATE_STR_PENDING) - 1},
+		{ Z_STATE_STR_PRESTART, sizeof(Z_STATE_STR_PRESTART) - 1},
+		{ Z_STATE_STR_DEAD, sizeof(Z_STATE_STR_DEAD) - 1},
+		{ Z_STATE_STR_SUSPENDED, sizeof(Z_STATE_STR_SUSPENDED) - 1},
+		{ Z_STATE_STR_ABORTING, sizeof(Z_STATE_STR_ABORTING) - 1},
+		{ Z_STATE_STR_SUSPENDING, sizeof(Z_STATE_STR_SUSPENDING) - 1},
+		{ Z_STATE_STR_QUEUED, sizeof(Z_STATE_STR_QUEUED) - 1},
+	};
 
 	if ((buf == NULL) || (buf_size == 0)) {
 		return "";
@@ -333,14 +351,16 @@ const char *k_thread_state_str(k_tid_t thread_id, char *buf, size_t buf_size)
 	 * separate the descriptive strings with a '+'.
 	 */
 
-	for (uint8_t index = 0; thread_state != 0; index++) {
+
+	for (unsigned int index = 0; thread_state != 0; index++) {
 		bit = BIT(index);
 		if ((thread_state & bit) == 0) {
 			continue;
 		}
 
 		off += copy_bytes(buf + off, buf_size - off,
-				  states_str[index], states_sz[index]);
+				  state_string[index].str,
+				  state_string[index].len);
 
 		thread_state &= ~bit;
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -681,6 +681,10 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 #endif
 	new_thread->resource_pool = _current->resource_pool;
 
+#ifdef CONFIG_SMP
+	z_waitq_init(&new_thread->halt_queue);
+#endif
+
 #ifdef CONFIG_SCHED_THREAD_USAGE
 	new_thread->base.usage = (struct k_cycle_stats) {};
 	new_thread->base.usage.track_usage =


### PR DESCRIPTION
Updates k_thread_suspend() to work on SMP systems. It functions much like k_thread_abort().

If the target thread is running on another CPU, the target thread gets marked as "halting with a reason". Meanwhile the calling thread waits for the target thread to finish halting (suspend or abort). Note that the reason bit has been implemented such that an abort takes precedence over a suspend to cover the case a thread running on another CPU gets suspended and then aborted (or vice versa). If the target thread is not running on another CPU, then the target thread can be immediately aborted/suspended.

Fixes #58392