### PR TITLE
Bluetooth: Shell: Move scan filter to function

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -1504,6 +1504,10 @@ static bool broadcast_scan_recv(const struct bt_le_scan_recv_info *info,
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
+	if (!passes_scan_filter(info, ad)) {
+		return false;
+	}
+
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	shell_print(ctx_shell, "Found broadcaster with ID 0x%06X and addr %s",

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -561,6 +561,10 @@ static void scan_recv_cb(const struct bt_le_scan_recv_info *info,
 		return;
 	}
 
+	if (!passes_scan_filter(info, ad)) {
+		return;
+	}
+
 	bt_data_parse(ad, broadcast_source_found, (void *)info);
 }
 

--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -165,6 +165,10 @@ static void csip_set_coordinator_scan_recv(const struct bt_le_scan_recv_info *in
 {
 	/* We're only interested in connectable events */
 	if (info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE) {
+		if (!passes_scan_filter(info, ad)) {
+			return;
+		}
+
 		if (cur_inst != NULL) {
 			bt_data_parse(ad, csip_found, (void *)info->addr);
 		}

--- a/subsys/bluetooth/shell/bt.h
+++ b/subsys/bluetooth/shell/bt.h
@@ -19,6 +19,8 @@
 extern const struct shell *ctx_shell;
 extern struct bt_conn *default_conn;
 
+bool passes_scan_filter(const struct bt_le_scan_recv_info *info, const struct net_buf_simple *buf);
+
 #if defined(CONFIG_BT_ISO)
 extern struct bt_iso_chan iso_chan;
 #endif /* CONFIG_BT_ISO */


### PR DESCRIPTION
Move the scan filter to a new function so that it may be reused by other shell modules.