### PR TITLE
drivers: serial: stm32: Refactor for PM handling

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1853,13 +1853,13 @@ static int uart_stm32_init(const struct device *dev)
 
 	LL_USART_Disable(config->usart);
 
-	if (!device_is_ready(data->reset.dev)) {
+	if (!device_is_ready(config->reset.dev)) {
 		LOG_ERR("reset controller not ready");
 		return -ENODEV;
 	}
 
 	/* Reset UART to default state using RCC */
-	(void)reset_line_toggle_dt(&data->reset);
+	(void)reset_line_toggle_dt(&config->reset);
 
 	/* TX/RX direction */
 	LL_USART_SetTransferDirection(config->usart,
@@ -2143,6 +2143,7 @@ static const struct stm32_pclken pclken_##index[] =			\
 									\
 static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 	.usart = (USART_TypeDef *)DT_INST_REG_ADDR(index),		\
+	.reset = RESET_DT_SPEC_GET(DT_DRV_INST(index)),			\
 	.pclken = pclken_##index,					\
 	.pclk_len = DT_INST_NUM_CLOCKS(index),				\
 	.hw_flow_control = DT_INST_PROP(index, hw_flow_control),	\
@@ -2162,7 +2163,6 @@ static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 									\
 static struct uart_stm32_data uart_stm32_data_##index = {		\
 	.baud_rate = DT_INST_PROP(index, current_speed),		\
-	.reset = RESET_DT_SPEC_GET(DT_DRV_INST(index)),			\
 	UART_DMA_CHANNEL(index, rx, RX, PERIPHERAL, MEMORY)		\
 	UART_DMA_CHANNEL(index, tx, TX, MEMORY, PERIPHERAL)		\
 };									\

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -20,9 +20,7 @@
 #include <soc.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/interrupt_controller/exti_stm32.h>
-#include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
-#include <zephyr/drivers/reset.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/pm/device.h>
 

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -18,6 +18,11 @@
 
 #include <stm32_ll_usart.h>
 
+#define STM32_UART_DEFAULT_BAUDRATE	115200
+#define STM32_UART_DEFAULT_PARITY	UART_CFG_PARITY_NONE
+#define STM32_UART_DEFAULT_STOP_BITS	UART_CFG_STOP_BITS_1
+#define STM32_UART_DEFAULT_DATA_BITS	UART_CFG_DATA_BITS_8
+
 /* device config */
 struct uart_stm32_config {
 	/* USART instance */
@@ -28,10 +33,6 @@ struct uart_stm32_config {
 	const struct stm32_pclken *pclken;
 	/* number of clock subsystems */
 	size_t pclk_len;
-	/* initial hardware flow control, 1 for RTS/CTS */
-	bool hw_flow_control;
-	/* initial parity, 0 for none, 1 for odd, 2 for even */
-	int  parity;
 	/* switch to enable single wire / half duplex feature */
 	bool single_wire;
 	/* enable tx/rx pin swap */
@@ -48,6 +49,7 @@ struct uart_stm32_config {
 	uint8_t de_deassert_time;
 	/* enable de pin inversion */
 	bool de_invert;
+	/* pin muxing */
 	const struct pinctrl_dev_config *pcfg;
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) || \
 	defined(CONFIG_PM)
@@ -82,10 +84,10 @@ struct uart_dma_stream {
 
 /* driver data */
 struct uart_stm32_data {
-	/* Baud rate */
-	uint32_t baud_rate;
 	/* clock device */
 	const struct device *clock;
+	/* uart config */
+	struct uart_config *uart_cfg;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t user_cb;
 	void *user_data;

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -22,6 +22,8 @@
 struct uart_stm32_config {
 	/* USART instance */
 	USART_TypeDef *usart;
+	/* Reset controller device configuration */
+	const struct reset_dt_spec reset;
 	/* clock subsystem driving this peripheral */
 	const struct stm32_pclken *pclken;
 	/* number of clock subsystems */
@@ -84,8 +86,6 @@ struct uart_stm32_data {
 	uint32_t baud_rate;
 	/* clock device */
 	const struct device *clock;
-	/* Reset controller device configuration */
-	const struct reset_dt_spec reset;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	uart_irq_callback_user_data_t user_cb;
 	void *user_data;

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -13,6 +13,8 @@
 #define ZEPHYR_DRIVERS_SERIAL_UART_STM32_H_
 
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/reset.h>
+#include <zephyr/drivers/uart.h>
 
 #include <stm32_ll_usart.h>
 


### PR DESCRIPTION
### Summary

This PR refactors the initialization/configuration logic of STM32 UART driver. It is intended to complement PR #59200 by making reinitialization of the peripheral clocks and registers more straightforward, for when the SoC loses their context and contents in certain low-power modes.

In refactoring I've also stumbled on a few bugs that I've fixed.

- Added static `uart_config` struct to `STM32_UART_INIT` macro
- Added `uart_config` struct pointer as `uart_stm32_config` member
- (Re)moved now superfluous `baud_rate`, `parity`, and `hw_flow_control` struct members
- Moved overlapping baudrate/parity/data-/stop-bits/flow control configuration to common function, with persistence in static instance `uart_config` struct
- Removed incorrect runtime parity/data bits configuration, and replaced with thoroughly tested compile-time `BUILD_ASSERT` statements
  - Original runtime logic in `init` forced a very small subset of UART configurations, and straight-up ignored many valid DT property combinations (e.g 7E1)
  - This now also allows invalid configurations to get flagged compile-time
  - The previous logic partially conflicted with the logic in `uart_stm32_configure`, especially that relating to parity/data-bits combinations, where either enforced opposite configurations
- The `#if defined(LL_USART_STOPBITS_1_5) && HAS_LPUART_1` conditional broke "half-bit" parity application configurations of USARTs, this is now fixed


### Change Description

Add static uart_config struct to init macro with corresponding pointer as uart_stm32_config struct member. This struct will store boot and runtime UART configuration for reinitialization upon exiting low-power modes, where register contents might be lost.

Remove hw_flow_control, parity, and baud_rate from uart_stm32_config and uart_stm32_data structs, respectively, as the need for these is now obviated by the presence of the uart_config struct, which contains equivalent members.

Add default baudrate, parity, stop, and data bits constants, used to initialize the uart_config struct, in case the corresponding UART DT properties are not set.

Move overlapping UART parameter configuration to new uart_stm32_parameters_set function. This function is called by uart_stm32_configure upon application/subsystem configuration, and uart_stm32_registers_configure upon (re-)initialization of driver instances.

Fix flawed stop bit/LPUART conditionals, which didn't allow for 0.5/1.5 stop bit USART configurations via application uart_configure syscalls.

Replace incorrect and limited runtime parity/data bits conditional configuration with build-time logic using BUILD_ASSERT. This allows for more flexible UART configurations, while preventing invalid DTS configurations at build-time.

### Issues Closed by this PR

- #56003

### Related Issues or Pull Requests

- #59200