### PR TITLE
nrf52_bsim: Give better description on test not yet passed

### DIFF
--- a/boards/posix/nrf52_bsim/bstests_entry.c
+++ b/boards/posix/nrf52_bsim/bstests_entry.c
@@ -233,5 +233,13 @@ uint8_t bst_delete(void)
 		test_list_top = tmp;
 	}
 
+	if (bst_result == In_progress) {
+		bs_trace_raw_time(2, "TESTCASE NOT PASSED at exit (test return "
+				  "(%u) indicates it was still in progress)\n", bst_result);
+	} else if (bst_result != Passed) {
+		bs_trace_raw_time(2, "The TESTCASE FAILED (test return code %u)\n",
+				  bst_result);
+	}
+
 	return bst_result;
 }

--- a/boards/posix/nrf52_bsim/main.c
+++ b/boards/posix/nrf52_bsim/main.c
@@ -39,10 +39,6 @@ uint8_t inner_main_clean_up(int exit_code)
 
 	uint8_t bst_result = bst_delete();
 
-	if (bst_result != 0U) {
-		bs_trace_raw_time(2, "main: The TESTCASE FAILED with return "
-				  "code %u\n", bst_result);
-	}
 	return BS_MAX(bst_result, max_exit_code);
 }
 


### PR DESCRIPTION
When a bs_test is stopped before it passes, the
current description is not informative enough.
Improve it.