### PR TITLE
boards: shields: Fix naming scheme for shield node labels

### DIFF
--- a/boards/shields/x_nucleo_iks01a2/boards/stm32mp157c_dk2.overlay
+++ b/boards/shields/x_nucleo_iks01a2/boards/stm32mp157c_dk2.overlay
@@ -10,11 +10,11 @@
  */
 
 &arduino_i2c {
-	lsm303agr-magn_x_nucleo_iks01a2: lsm303agr-magn@1e {
+	lsm303agr_magn_1e_x_nucleo_iks01a2: lsm303agr-magn@1e {
 		/delete-property/ irq-gpios;	/* A3 */
 	};
 
-	lsm303agr-accel_x_nucleo_iks01a2: lsm303agr-accel@19 {
+	lsm303agr_accel_19_x_nucleo_iks01a2: lsm303agr-accel@19 {
 		/delete-property/ irq-gpios;	/* A3 */
 	};
 };


### PR DESCRIPTION
Replaced incorrect names with correct ones.
Fixes: #50526

Signed-off-by: Nicolas Granger <nicolas.granger01@st.com>