### PR TITLE
net: if: default `NET_IF_LOWER_UP` at compile time

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2562,6 +2562,7 @@ struct net_if_api {
 		.l2 = &(NET_L2_GET_NAME(_l2)),				\
 		.l2_data = &(NET_L2_GET_DATA(dev_id, sfx)),		\
 		.mtu = _mtu,						\
+		.flags = {BIT(NET_IF_LOWER_UP)},			\
 	};								\
 	static Z_DECL_ALIGN(struct net_if)				\
 		       NET_IF_GET_NAME(dev_id, sfx)[_num_configs]	\
@@ -2579,6 +2580,7 @@ struct net_if_api {
 		.dev = &(DEVICE_NAME_GET(dev_id)),			\
 		.mtu = _mtu,						\
 		.l2 = &(NET_L2_GET_NAME(OFFLOADED_NETDEV)),		\
+		.flags = {BIT(NET_IF_LOWER_UP)},			\
 	};								\
 	static Z_DECL_ALIGN(struct net_if)				\
 		NET_IF_GET_NAME(dev_id, sfx)[NET_IF_MAX_CONFIGS]	\

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -425,8 +425,6 @@ static inline void init_iface(struct net_if *iface)
 	net_if_flag_set(iface, NET_IF_IPV6);
 #endif
 
-	net_if_flag_test_and_set(iface, NET_IF_LOWER_UP);
-
 	net_virtual_init(iface);
 
 	NET_DBG("On iface %p", iface);


### PR DESCRIPTION
The `net_if` layer should not be forcing `NET_IF_LOWER_UP` to be set on all interfaces at runtime. Because `net_init` runs relatively late by default, this is overriding any control the driver itself may have performed using `net_if_carrier_on/off`.

Initialise this bit at compile-time instead. As the structure is already being initialised, this doesn't increase any footprints.