### PR TITLE
twister: add support for misc emulator

### DIFF
--- a/cmake/emu/custom.cmake
+++ b/cmake/emu/custom.cmake
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# ${ZEPHYR_BASE}/CMakeLists.txt looks for ${ZEPHYR_BASE}/cmake/emu/${EMU_PLATFORM}.cmake
+# when building the `run` target. Create this placeholder file so it doesn't complain.
+# The real 'run' custom_target should be defined in `board.cmake` instead.
+#
+# See https://docs.zephyrproject.org/latest/develop/test/twister.html#running-tests-on-custom-emulator
+#

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -643,6 +643,42 @@ integration keyword in the testcase definition file (testcase.yaml and
 sample.yaml).
 
 
+Running tests on custom emulator
+********************************
+
+Apart from the already supported QEMU and other simulated environments, Twister
+supports running any out-of-tree custom emulator defined in the board's :file:`board.cmake`.
+To use this type of simulation, add the following properties to
+:file:`custom_board/custom_board.yaml`:
+
+::
+
+   simulation: custom
+   simulation_exec: <name_of_emu_binary>
+
+This tells Twister that the board is using a custom emulator called ``<name_of_emu_binary>``,
+make sure this binary exists in the PATH.
+
+Then, in :file:`custom_board/board.cmake`, set the supported emulation platforms to ``custom``:
+
+::
+
+   set(SUPPORTED_EMU_PLATFORMS custom)
+
+Finally, implement the ``run_custom`` target in :file:`custom_board/board.cmake`.
+It should look something like this:
+
+::
+
+   add_custom_target(run_custom
+     COMMAND
+     <name_of_emu_binary to invoke during 'run'>
+     <any args to be passed to the command, i.e. ${BOARD}, ${APPLICATION_BINARY_DIR}/zephyr/zephyr.elf>
+     WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
+     DEPENDS ${logical_target_for_zephyr_elf}
+     USES_TERMINAL
+     )
+
 Running Tests on Hardware
 *************************
 

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -39,7 +39,7 @@ except ImportError as capture_error:
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
 
-SUPPORTED_SIMS = ["mdb-nsim", "nsim", "renode", "qemu", "tsim", "armfvp", "xt-sim", "native"]
+SUPPORTED_SIMS = ["mdb-nsim", "nsim", "renode", "qemu", "tsim", "armfvp", "xt-sim", "native", "custom"]
 SUPPORTED_SIMS_IN_PYTEST = ['native', 'qemu']
 
 

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -24,7 +24,19 @@ mapping:
     enum: ["mcu", "qemu", "sim", "unit", "native"]
   "simulation":
     type: str
-    enum: ["qemu", "simics", "xt-sim", "renode", "nsim", "mdb-nsim", "tsim", "armfvp", "native"]
+    enum:
+      [
+        "qemu",
+        "simics",
+        "xt-sim",
+        "renode",
+        "nsim",
+        "mdb-nsim",
+        "tsim",
+        "armfvp",
+        "native",
+        "custom",
+      ]
   "simulation_exec":
     type: str
   "arch":


### PR DESCRIPTION
This PR adds a `misc` emulator type to twister. Much like the `misc-flasher` for `west flash`, it allows **any** proprietary simulators that can't be upstreamed to be implemented with ease in a custom board.

The first commit is the `misc` emulator itself, basically introducing `misc` to twister & the schema, and adds an empty `misc.cmake` to make the CMake happy and commented to show how it can be used. Normally a custom cmake `run` target is defined in these `<emu>.cmake` files, here we just leave it as empty so that it can be implemented in a custom board's `board.cmake`.

The second commit is an example of how this `misc` emu works - it basically sleeps for 5s and use `cat` to print something (`Hello World!`) to the stdout, then sleep for 10 minutes, but it should be killed immediately once twister reads something interesting, which is 5s+ for the `hello_world` example, much less than the 10 minutes.

```shell
cd $ZEPHYR_BASE
scripts/twister -i -p adp_xc7k_ae350 -s samples/hello_world/sample.basic.helloworld
```

`twister.log`:

```log
2023-06-20 16:49:22,280 - twister - INFO - Using Ninja..
2023-06-20 16:49:22,366 - twister - INFO - Zephyr version: zephyr-v3.4.0-171-g0ba587dcd0b8
2023-06-20 16:49:22,402 - twister - DEBUG - Running cmake script /Users/ycsin/zephyrproject/zephyr/cmake/verify-toolchain.cmake
2023-06-20 16:49:22,402 - twister - DEBUG - Calling cmake: /Users/ycsin/homebrew/bin/cmake -DFORMAT=json -P /Users/ycsin/zephyrproject/zephyr/cmake/verify-toolchain.cmake
2023-06-20 16:49:23,166 - twister - DEBUG - Finished running  /Users/ycsin/zephyrproject/zephyr/cmake/verify-toolchain.cmake
2023-06-20 16:49:23,167 - twister - INFO - Using 'zephyr' toolchain.
2023-06-20 16:49:23,275 - twister - DEBUG - Reading test case configuration files under /Users/ycsin/zephyrproject/zephyr/tests...
...
2023-06-20 16:49:43,693 - twister - DEBUG - Found possible testsuite in /Users/ycsin/zephyrproject/zephyr/samples/kernel/condition_variables/condvar
2023-06-20 16:49:43,704 - twister - DEBUG - No duplicates found.
2023-06-20 16:49:43,708 - twister - DEBUG - Reading platform configuration files under /Users/ycsin/zephyrproject/zephyr/boards...
...
2023-06-20 16:49:44,316 - twister - DEBUG - adding qemu_nios2 to default platforms
2023-06-20 16:49:44,317 - twister - DEBUG - Reading platform configuration files under /Users/ycsin/zephyrproject/zephyr/scripts/pylib/twister/boards...
2023-06-20 16:49:44,319 - twister - DEBUG - adding unit_testing to default platforms
2023-06-20 16:49:44,319 - twister - DEBUG - platform filter: ['adp_xc7k_ae350']
2023-06-20 16:49:44,319 - twister - DEBUG -     arch_filter: None
2023-06-20 16:49:44,319 - twister - DEBUG -      tag_filter: None
2023-06-20 16:49:44,319 - twister - DEBUG -     exclude_tag: None
2023-06-20 16:49:44,319 - twister - INFO - Building initial testsuite list...
2023-06-20 16:49:44,322 - twister - INFO - Writing JSON report /Users/ycsin/zephyrproject/zephyr/twister-out/testplan.json
2023-06-20 16:49:44,869 - twister - INFO - Adding tasks to the queue...
2023-06-20 16:49:44,869 - twister - DEBUG - adding adp_xc7k_ae350/samples/hello_world/sample.basic.helloworld
2023-06-20 16:49:44,869 - twister - INFO - Added initial list of jobs to queue
2023-06-20 16:49:44,869 - twister - DEBUG - Launch process 0
...
2023-06-20 16:50:00,161 - twister - INFO - 1 test scenarios (1 test instances) selected, 0 configurations skipped (0 by static filter, 0 at runtime).
2023-06-20 16:50:00,161 - twister - INFO - 1 of 1 test configurations passed (100.00%), 0 failed, 0 errored, 0 skipped with 0 warnings in 37.88 seconds
2023-06-20 16:50:00,161 - twister - INFO - In total 1 test cases were executed, 0 skipped on 1 out of total 574 platforms (0.17%)
2023-06-20 16:50:00,161 - twister - INFO - 1 test configurations executed on platforms, 0 test configurations were only built.
2023-06-20 16:50:00,161 - twister - INFO - Saving reports...
2023-06-20 16:50:00,161 - twister - INFO - Writing JSON report /Users/ycsin/zephyrproject/zephyr/twister-out/twister.json
2023-06-20 16:50:00,162 - twister - INFO - Writing xunit report /Users/ycsin/zephyrproject/zephyr/twister-out/twister.xml...
2023-06-20 16:50:00,165 - twister - INFO - Writing xunit report /Users/ycsin/zephyrproject/zephyr/twister-out/twister_report.xml...
2023-06-20 16:50:00,165 - twister - INFO - Run completed
```

`twister.json`:

```json
{
    "environment":{
        "os":"posix",
        "zephyr_version":"zephyr-v3.4.0-171-g0ba587dcd0b8",
        "toolchain":"zephyr",
        "commit_date":"2023-06-20T16:48:57+08:00",
        "run_date":"2023-06-20T08:49:23+00:00"
    },
    "testsuites":[
        {
            "name":"samples/hello_world/sample.basic.helloworld",
            "arch":"riscv32",
            "platform":"adp_xc7k_ae350",
            "run_id":"e87916cdaee3bea6672d5d74ad51c543",
            "runnable":true,
            "retries":0,
            "status":"passed",
            "execution_time":"7.68",
            "testcases":[
                {
                    "identifier":"sample.basic.helloworld",
                    "execution_time":"7.68",
                    "status":"passed"
                }
            ]
        }
    ]
}
```

`handler.log`:

```log
[0/1] cd /Users/ycsin/zephyrproject/zephyr/twister-out/adp_xc7k_ae350/samples/hello_world/sample.basic.helloworld && sleep 5 && cat /Users/ycsin/zephyrproject/zephyr/twister-out/adp_xc7k_ae350/samples/hello_world/sample.basic.helloworld/tmp/script && sleep 600
Hello World! adp_xc7k_ae350
```