### PR TITLE
drivers: dai: intel: dmic: fix irq argument cast

### DIFF
--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -255,7 +255,7 @@ static void dai_dmic_stop_fifo_packers(struct dai_intel_dmic *dmic,
  */
 static void dai_dmic_irq_handler(const void *data)
 {
-	struct dai_intel_dmic *dmic = (struct dai_intel_dmic *) data;
+	struct dai_intel_dmic *dmic = ((struct device *)data)->data;
 	uint32_t val0;
 	uint32_t val1;
 


### PR DESCRIPTION
The argument to the dmic irq is of type "struct device *" and dmic data is actually part of it, thus make the cast correctly.