### PR TITLE
twister: pytest: Simplify interface to pytest-twister-harness

### DIFF
--- a/doc/develop/test/pytest.rst
+++ b/doc/develop/test/pytest.rst
@@ -57,16 +57,14 @@ Pytest scans the given folder looking for tests, following its default
 One can also pass some extra arguments to the pytest from yaml file using ``pytest_args`` keyword
 under ``harness_config``, e.g.: ``pytest_args: [‘-k=test_method’, ‘--log-level=DEBUG’]``.
 
-Two imports are important to include in .py sources:
+Following import is required to include in .py sources:
 
 .. code-block:: python
 
-   import pytest  # noqa # pylint: disable=unused-import
-   from pytest_twister_harness.device.device_abstract import DeviceAbstract
+   from twister_harness import Device
 
-The first enables pytest-twister-harness plugin indirectly, as it is added with pytest.
-It also gives access to ``dut`` fixture. The second is important for type checking and enabling
-IDE hints for duts. The ``dut`` fixture is the core of pytest harness plugin. When used as an
+It is important for type checking and enabling IDE hints for ``dut``s (objects representing
+Devices Under Test). The ``dut`` fixture is the core of pytest harness plugin. When used as an
 argument of a test function it gives access to a DeviceAbstract type object. The fixture yields a
 device prepared according to the requested type (native posix, qemu, hardware, etc.). All types of
 devices share the same API. This allows for writing tests which are device-type-agnostic.

--- a/samples/subsys/testsuite/pytest/shell/pytest/test_shell.py
+++ b/samples/subsys/testsuite/pytest/shell/pytest/test_shell.py
@@ -5,12 +5,12 @@
 import time
 import logging
 
-from twister_harness.device.device_abstract import DeviceAbstract
+from twister_harness import Device
 
 logger = logging.getLogger(__name__)
 
 
-def wait_for_message(dut: DeviceAbstract, message, timeout=20):
+def wait_for_message(dut: Device, message, timeout=20):
     time_started = time.time()
     for line in dut.iter_stdout:
         if line:
@@ -21,7 +21,7 @@ def wait_for_message(dut: DeviceAbstract, message, timeout=20):
             return False
 
 
-def wait_for_prompt(dut: DeviceAbstract, prompt='uart:~$', timeout=20):
+def wait_for_prompt(dut: Device, prompt='uart:~$', timeout=20):
     time_started = time.time()
     while True:
         dut.write(b'\n')
@@ -33,13 +33,13 @@ def wait_for_prompt(dut: DeviceAbstract, prompt='uart:~$', timeout=20):
             return False
 
 
-def test_shell_print_help(dut: DeviceAbstract):
+def test_shell_print_help(dut: Device):
     wait_for_prompt(dut)
     dut.write(b'help\n')
     assert wait_for_message(dut, "Available commands")
 
 
-def test_shell_print_version(dut: DeviceAbstract):
+def test_shell_print_version(dut: Device):
     wait_for_prompt(dut)
     dut.write(b'kernel version\n')
     assert wait_for_message(dut, "Zephyr version")

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/__init__.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/__init__.py
@@ -2,4 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# flake8: noqa
+
+from twister_harness.device.device_abstract import DeviceAbstract as Device
+
+__all__= ['Device']
+
 __version__ = '0.0.1'


### PR DESCRIPTION
Add DeviceAbstract class to default imports from `pytest-twister-harness` package to simplify importing DUT package, when creating tests.

When creating test with DUT fixture, just add
`from twister_harness import Device`
instead of
`from twister_harness.device.device_abstract import DeviceAbstract`
