### PR TITLE
samples: Bluetooth: Fix TMAP peripheral off-by-one URI schemes

### DIFF
--- a/samples/bluetooth/tmap_peripheral/src/ccp_call_ctrl.c
+++ b/samples/bluetooth/tmap_peripheral/src/ccp_call_ctrl.c
@@ -100,7 +100,7 @@ static void read_uri_schemes_string_cb(struct bt_conn *conn, int err,
 		}
 	}
 
-	if (i > sizeof(remote_uri)) {
+	if (i >= sizeof(remote_uri)) {
 		printk("Cannot store URI of length %zu: %s\n", i, value);
 		return;
 	}


### PR DESCRIPTION
i has to be less than the size of the array, as we use i as the index.