### PR TITLE
samples: Bluetooth: Unicast client missing err check on sem

### DIFF
--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -963,7 +963,11 @@ static int set_stream_qos(void)
 
 	for (size_t i = 0U; i < configured_stream_count; i++) {
 		printk("QoS: waiting for %zu streams\n", configured_stream_count);
-		k_sem_take(&sem_stream_qos, K_FOREVER);
+		err = k_sem_take(&sem_stream_qos, K_FOREVER);
+		if (err != 0) {
+			printk("failed to take sem_stream_qos (err %d)\n", err);
+			return err;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
Added missing error check when taking the sem_stream_qos.