### PR TITLE
lib: os: spsc_pbuf: Add support for full capacity packets

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -683,6 +683,7 @@
 /include/zephyr/sip_svc/                         @maheshraotm
 /include/zephyr/sys_clock.h                      @dcpleung @nashif @andyross
 /include/zephyr/sys/sys_io.h                     @dcpleung @nashif @andyross
+/include/zephyr/sys/spsc_pbuf.h                  @nordic-krch
 /include/zephyr/sys/kobject.h                    @dcpleung @nashif
 /include/zephyr/toolchain.h                      @dcpleung @andyross @nashif
 /include/zephyr/toolchain/                       @dcpleung @nashif @andyross
@@ -694,6 +695,7 @@
 /lib/util/fnmatch/                        @carlescufi @jakub-uC
 /lib/open-amp/                            @arnopo
 /lib/os/                                  @dcpleung @nashif @andyross
+/lib/os/spsc_pbuf.c                       @nordic-krch
 /lib/os/cbprintf_packaged.c               @npitre
 /lib/posix/                               @cfriedt
 /lib/posix/getopt/                        @jakub-uC
@@ -881,6 +883,7 @@ scripts/build/gen_image_info.py           @tejlmand
 /tests/kernel/                            @dcpleung @andyross @nashif
 /tests/lib/                               @nashif
 /tests/lib/cmsis_dsp/                     @stephanosio
+/tests/lib/spsc_pbuf/                     @nordic-krch
 /tests/net/                               @rlubos @tbursztyka
 /tests/net/buf/                           @jhedberg @tbursztyka
 /tests/net/lib/                           @rlubos @tbursztyka

--- a/include/zephyr/ipc/icmsg.h
+++ b/include/zephyr/ipc/icmsg.h
@@ -62,8 +62,6 @@ struct icmsg_data_t {
 	/* No-copy */
 #ifdef CONFIG_IPC_SERVICE_ICMSG_NOCOPY_RX
 	atomic_t rx_buffer_state;
-	const void *rx_buffer;
-	uint16_t rx_len;
 #endif
 };
 

--- a/tests/lib/spsc_pbuf/testcase.yaml
+++ b/tests/lib/spsc_pbuf/testcase.yaml
@@ -37,6 +37,6 @@ tests:
     platform_allow: qemu_x86
     timeout: 120
     extra_configs:
-      - CONFIG_SYS_CLOCK_TICKS_PER_SEC=100000
+      - CONFIG_SYS_CLOCK_TICKS_PER_SEC=10000
     integration_platforms:
       - qemu_x86


### PR DESCRIPTION
Currently, a largest packet that can be stored in an empty packet buffer was approx. half of the capacity. That is because of a rule that producer modifies only the write index and consumer only the read index. There are cases when user expects that a buffer will be able to hold packets of size much closer to the buffer full capacity.

Adding such feature requires producer to modify the read index (but only when the buffer is empty). With certain limitations that still can perform reliably but because of limitations this mode of operation is optional, enabled by the configuration flag.

To support this option spsc_pbuf_free had to be changed to return an information if freed packet is the last one. Same with spsc_pbuf_read where additional parameter was added (set to null for backward compatibility).

Commit updates test and ipc_service to the modified API.

Fixes #59443.