### PR TITLE
PCIe Virtual Channel support

### DIFF
--- a/drivers/pcie/host/CMakeLists.txt
+++ b/drivers/pcie/host/CMakeLists.txt
@@ -1,6 +1,6 @@
 zephyr_library()
 
-zephyr_library_sources(pcie.c)
+zephyr_library_sources(pcie.c vc.c)
 zephyr_library_sources_ifdef(CONFIG_PCIE_CONTROLLER controller.c)
 zephyr_library_sources_ifdef(CONFIG_PCIE_ECAM pcie_ecam.c)
 zephyr_library_sources_ifdef(CONFIG_PCIE_MSI msi.c)

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -14,6 +14,7 @@
 
 #include <zephyr/drivers/pcie/cap.h>
 
+#include <zephyr/drivers/pcie/vc.h>
 #include "vc.h"
 
 struct pcie_cap_id_to_str {

--- a/drivers/pcie/host/vc.c
+++ b/drivers/pcie/host/vc.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+
+#include <zephyr/kernel.h>
+
+#include <zephyr/drivers/pcie/pcie.h>
+#include <zephyr/drivers/pcie/cap.h>
+
+#include "vc.h"
+
+uint32_t pcie_vc_cap_lookup(pcie_bdf_t bdf, struct pcie_vc_regs *regs)
+{
+	uint32_t base;
+
+	base = pcie_get_ext_cap(bdf, PCIE_EXT_CAP_ID_VC);
+	if (base == 0) {
+		base = pcie_get_ext_cap(bdf, PCIE_EXT_CAP_ID_MFVC_VC);
+		if (base == 0) {
+			return 0;
+		}
+	}
+
+	regs->cap_reg_1.raw = pcie_conf_read(bdf, base +
+					     PCIE_VC_CAP_REG_1_OFFSET);
+	regs->cap_reg_2.raw = pcie_conf_read(bdf, base +
+					     PCIE_VC_CAP_REG_2_OFFSET);
+	regs->ctrl_reg.raw = pcie_conf_read(bdf, base +
+					    PCIE_VC_CTRL_STATUS_REG_OFFSET);
+
+	return base;
+}
+
+void pcie_vc_load_resources_regs(pcie_bdf_t bdf,
+				 uint32_t base,
+				 struct pcie_vc_resource_regs *regs,
+				 int nb_regs)
+{
+	int idx;
+
+	for (idx = 0; idx < nb_regs; idx++) {
+		regs->cap_reg.raw =
+			pcie_conf_read(bdf, base +
+				       PCIE_VC_RES_CAP_REG_OFFSET(idx));
+		regs->ctrl_reg.raw =
+			pcie_conf_read(bdf, base +
+				       PCIE_VC_RES_CTRL_REG_OFFSET(idx));
+		regs->status_reg.raw =
+			pcie_conf_read(bdf, base +
+				       PCIE_VC_RES_STATUS_REG_OFFSET(idx));
+		regs++;
+	}
+}

--- a/drivers/pcie/host/vc.h
+++ b/drivers/pcie/host/vc.h
@@ -7,8 +7,6 @@
 #ifndef ZEPHYR_DRIVERS_PCIE_HOST_VC_H_
 #define ZEPHYR_DRIVERS_PCIE_HOST_VC_H_
 
-#define PCIE_VC_MAX_COUNT 8
-
 #define PCIE_VC_CAP_REG_1_OFFSET	0x04U
 #define PCIE_VC_CAP_REG_2_OFFSET	0x08U
 #define PCIE_VC_CTRL_STATUS_REG_OFFSET	0x0CU
@@ -61,6 +59,13 @@ struct pcie_vc_regs {
 #define PCIE_VC_RES_CAP_REG_OFFSET(_vc)		(0x10U + _vc * 0X0CU)
 #define PCIE_VC_RES_CTRL_REG_OFFSET(_vc)	(0x14U + _vc * 0X0CU)
 #define PCIE_VC_RES_STATUS_REG_OFFSET(_vc)	(0x18U + _vc * 0X0CU)
+
+#define PCIE_VC_PA_RR		BIT(0)
+#define PCIE_VC_PA_WRR		BIT(1)
+#define PCIE_VC_PA_WRR64	BIT(2)
+#define PCIE_VC_PA_WRR128	BIT(3)
+#define PCIE_VC_PA_TMWRR128	BIT(4)
+#define PCIE_VC_PA_WRR256	BIT(5)
 
 /** Virtual Channel Resource Registers */
 struct pcie_vc_resource_regs {

--- a/drivers/pcie/host/vc.h
+++ b/drivers/pcie/host/vc.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_PCIE_HOST_VC_H_
+#define ZEPHYR_DRIVERS_PCIE_HOST_VC_H_
+
+#define PCIE_VC_MAX_COUNT 8
+
+#define PCIE_VC_CAP_REG_1_OFFSET	0x04U
+#define PCIE_VC_CAP_REG_2_OFFSET	0x08U
+#define PCIE_VC_CTRL_STATUS_REG_OFFSET	0x0CU
+
+/** Virtual Channel capability and control Registers */
+struct pcie_vc_regs {
+	union {
+		struct {
+			/** Virtual Channel Count */
+			uint32_t vc_count              : 3;
+			uint32_t _reserved1            : 1;
+			/** Low Priority Virtual Channel Count */
+			uint32_t lpvc_count            : 3;
+			uint32_t _reserved2            : 1;
+			/** Reference Clock */
+			uint32_t reference_clock       : 2;
+			/** Port Arbitration Table Entry Size */
+			uint32_t pat_entry_size        : 3;
+			uint32_t _reserved3            : 19;
+		};
+		uint32_t raw;
+	} cap_reg_1;
+
+	union {
+		struct {
+			/** Virtual Channel Arbitration Capability */
+			uint32_t vca_cap               : 8;
+			uint32_t _reserved1            : 16;
+			/** Virtual Channel Arbitration Table Offset */
+			uint32_t vca_table_offset      : 8;
+		};
+		uint32_t raw;
+	} cap_reg_2;
+
+	union {
+		struct {
+			/** Load Virtual Channel Arbitration Table */
+			uint32_t load_vca_table        : 1;
+			/** Virtual Channel Arbitration Select */
+			uint32_t vca_select            : 3;
+			uint32_t _reserved1            : 12;
+			/** Virtual Channel Arbitration Table Status */
+			uint32_t vca_table_status      : 1;
+			uint32_t _reserved2            : 15;
+		};
+		uint32_t raw;
+	} ctrl_reg;
+};
+
+#define PCIE_VC_RES_CAP_REG_OFFSET(_vc)		(0x10U + _vc * 0X0CU)
+#define PCIE_VC_RES_CTRL_REG_OFFSET(_vc)	(0x14U + _vc * 0X0CU)
+#define PCIE_VC_RES_STATUS_REG_OFFSET(_vc)	(0x18U + _vc * 0X0CU)
+
+/** Virtual Channel Resource Registers */
+struct pcie_vc_resource_regs {
+	union {
+		struct {
+			/** Port Arbitration Capability */
+			uint32_t pa_cap                : 8;
+			uint32_t _reserved1            : 6;
+			uint32_t undefined             : 1;
+			/** Reject Snoop Transactions */
+			uint32_t rst                   : 1;
+			/** Maximum Time Slots */
+			uint32_t max_time_slots        : 7;
+			uint32_t _reserved2            : 1;
+			/** Port Arbitration Table Offset */
+			uint32_t pa_table_offset       : 8;
+		};
+		uint32_t raw;
+	} cap_reg;
+
+	union {
+		struct {
+			/** Traffic Class to Virtual Channel Map */
+			uint32_t tc_vc_map             : 8;
+			uint32_t _reserved1            : 8;
+			/** Load Port Arbitration Table */
+			uint32_t load_pa_table         : 1;
+			/** Port Arbitration Select */
+			uint32_t pa_select             : 3;
+			uint32_t _reserved2            : 4;
+			/** Virtual Channel ID */
+			uint32_t vc_id                 : 3;
+			uint32_t _reserved3            : 4;
+			/** Virtual Channel Enable */
+			uint32_t vc_enable             : 1;
+		};
+		uint32_t raw;
+	} ctrl_reg;
+
+	union {
+		struct {
+			uint32_t _reserved1            : 16;
+			/** Port Arbitration Table Status */
+			uint32_t pa_table_status       : 1;
+			/** Virtual Channel Negociation Pending */
+			uint32_t vc_negocation_pending : 1;
+			uint32_t _reserved2            : 14;
+		};
+		uint32_t raw;
+	} status_reg;
+};
+
+uint32_t pcie_vc_cap_lookup(pcie_bdf_t bdf, struct pcie_vc_regs *regs);
+
+void pcie_vc_load_resources_regs(pcie_bdf_t bdf,
+				 uint32_t base,
+				 struct pcie_vc_resource_regs *regs,
+				 int nb_regs);
+
+#endif /* ZEPHYR_DRIVERS_PCIE_HOST_VC_H_ */

--- a/include/zephyr/drivers/pcie/vc.h
+++ b/include/zephyr/drivers/pcie/vc.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PCIE_VC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PCIE_VC_H_
+
+/**
+ * @brief PCIe Virtual Channel Host Interface
+ * @defgroup pcie_vc_host_interface PCIe Virtual Channel Host Interface
+ * @ingroup pcie_host_interface
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/kernel.h>
+#include <zephyr/types.h>
+#include <stdbool.h>
+
+#include <zephyr/drivers/pcie/pcie.h>
+
+/*
+ * 1 default VC + 7 extended VCs
+ */
+#define PCIE_VC_MAX_COUNT 8U
+
+#define PCIE_VC_SET_TC0 BIT(0)
+#define PCIE_VC_SET_TC1 BIT(1)
+#define PCIE_VC_SET_TC2 BIT(2)
+#define PCIE_VC_SET_TC3 BIT(3)
+#define PCIE_VC_SET_TC4 BIT(4)
+#define PCIE_VC_SET_TC5 BIT(5)
+#define PCIE_VC_SET_TC6 BIT(6)
+#define PCIE_VC_SET_TC7 BIT(7)
+
+struct pcie_vctc_map {
+	/*
+	 * Map the TCs for each VC by setting bits relevantly
+	 * Note: one bit cannot be set more than once among the VCs
+	 */
+	uint8_t vc_tc[PCIE_VC_MAX_COUNT];
+	/*
+	 * Number of VCs being addressed
+	 */
+	int vc_count;
+};
+
+/**
+ * @brief Enable PCIe Virtual Channel handling
+ * @param bdf the target PCI endpoint
+ * @return 0 on success, a negative error code otherwise
+ *
+ * Note: Not being able to enable such feature is a non-fatal error
+ * and any code using it should behave accordingly (displaying some info,
+ * and ignoring it for instance).
+ */
+int pcie_vc_enable(pcie_bdf_t bdf);
+
+/**
+ * @brief Disable PCIe Virtual Channel handling
+ * @param bdf the target PCI endpoint
+ * @return 0 on success, a negative error code otherwise
+ */
+int pcie_vc_disable(pcie_bdf_t bdf);
+
+/**
+ * @brief Map PCIe TC/VC
+ * @param bdf the target PCI endpoint
+ * @param map the tc/vc map to apply
+ * @return 0 on success, a negative error code otherwise
+ *
+ * Note: VC must be disabled prior to call this function and
+ * enabled afterward in order for the endpoint to take advandage of the map.
+ *
+ * Note: Not being able to enable such feature is a non-fatal error
+ * and any code using it should behave accordingly (displaying some info,
+ * and ignoring it for instance).
+ */
+int pcie_vc_map_tc(pcie_bdf_t bdf, struct pcie_vctc_map *map);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_PCIE_VC_H_ */


### PR DESCRIPTION
Here is a basic support for enabling VC on an endpoint.

Only hw round robin is accounted for in port arbitration. It is the simplest (and default) one. Others are non-testable atm also.