### PR TITLE
Bluetooth: CAP: Add null check for free_conn

### DIFF
--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -944,8 +944,11 @@ void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream)
 			continue;
 		}
 
-		__ASSERT(free_conn, "No free conns");
-		*free_conn = stream_conn;
+		if (free_conn != NULL) {
+			*free_conn = stream_conn;
+		} else {
+			__ASSERT_PRINT("No free conns");
+		}
 	}
 
 	/* All streams in the procedure share the same unicast group, so we just


### PR DESCRIPTION
When populating the conns array in
bt_cap_initiator_codec_configured, coverity did not like just having the __ASSERT, so added a `if` as well.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/59526