### PR TITLE
Bluetooth: CSIP: Update CSIP duplicate rank search

### DIFF
--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -1494,9 +1494,12 @@ static int verify_members(const struct bt_csip_set_coordinator_set_member **memb
 			LOG_DBG("Found mix of 0 and non-0 ranks");
 			return -EINVAL;
 		}
+	}
 
-		if (!zero_rank) {
-			for (size_t j = 0U; j < i; j++) {
+	if (CONFIG_BT_MAX_CONN > 1 && !zero_rank && count > 1U) {
+		/* Search for duplicate ranks */
+		for (uint8_t i = 0U; i < count - 1; i++) {
+			for (uint8_t j = i + 1; j < count; j++) {
 				if (ranks[j] == ranks[i]) {
 					/* duplicate rank */
 					LOG_DBG("Duplicate rank (%u) for members[%zu] "


### PR DESCRIPTION
In the CSIP Set Coordinator verify_members we verify that all members have unique ranks.

This was done as part of the initial loop, but it is more efficient to do this as a separate loop as we can reduce the number of items to compare, as well as guarding this properly by !zero_rank.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/59528