### PR TITLE
VCP and MICP: AICS and VOCS count fix

### DIFF
--- a/subsys/bluetooth/audio/micp_mic_dev.c
+++ b/subsys/bluetooth/audio/micp_mic_dev.c
@@ -116,6 +116,10 @@ static int prepare_aics_inst(struct bt_micp_mic_dev_register_param *param)
 	int j;
 	int err;
 
+	if (CONFIG_BT_MICP_MIC_DEV_AICS_INSTANCE_COUNT == 0) {
+		return 0;
+	}
+
 	for (j = 0, i = 0; i < ARRAY_SIZE(mics_attrs); i++) {
 		if (bt_uuid_cmp(mics_attrs[i].uuid, BT_UUID_GATT_INCLUDE) == 0) {
 			micp_inst.aics_insts[j] = bt_aics_free_instance_get();

--- a/subsys/bluetooth/audio/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/vcp_vol_rend.c
@@ -260,6 +260,10 @@ static int prepare_vocs_inst(struct bt_vcp_vol_rend_register_param *param)
 	int j;
 	int i;
 
+	if (CONFIG_BT_VCP_VOL_REND_VOCS_INSTANCE_COUNT == 0) {
+		return 0;
+	}
+
 	__ASSERT(param, "NULL param");
 
 	for (j = 0, i = 0; i < ARRAY_SIZE(vcs_attrs); i++) {
@@ -302,6 +306,10 @@ static int prepare_aics_inst(struct bt_vcp_vol_rend_register_param *param)
 	int err;
 	int j;
 	int i;
+
+	if (CONFIG_BT_VCP_VOL_REND_AICS_INSTANCE_COUNT == 0) {
+		return 0;
+	}
 
 	__ASSERT(param, "NULL param");
 


### PR DESCRIPTION
Add early returns if the count is 0. 

This does not change anything as the function themselves are not called when it is 0, but this fixes a coverity issue. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/59523
fixes https://github.com/zephyrproject-rtos/zephyr/issues/59531