### PR TITLE
Bluetooth: IAS: Fix alert level loop

### DIFF
--- a/subsys/bluetooth/services/ias/ias.c
+++ b/subsys/bluetooth/services/ias/ias.c
@@ -41,10 +41,10 @@ static enum bt_ias_alert_lvl curr_lvl;
 
 static void set_alert_level(void)
 {
-	enum bt_ias_alert_lvl alert_level;
+	enum bt_ias_alert_lvl alert_level = BT_IAS_ALERT_LVL_NO_ALERT;
 
-	alert_level = devices[0].alert_level;
-	for (int i = 1; i < CONFIG_BT_MAX_CONN; i++) {
+	/* Set the alert_level as the highest requested by any device */
+	for (int i = 0; i < CONFIG_BT_MAX_CONN; i++) {
 		if (alert_level < devices[i].alert_level) {
 			alert_level = devices[i].alert_level;
 		}


### PR DESCRIPTION
The loop was supposed to set the alert level to the highest value by any device. The loop, however, only made sense if CONFIG_BT_MAX_CONN > 1.

It has been modified to start from [0] instead of [1] and the initial condition was modified.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/59525