### PR TITLE
boards: arm: efr32_thunderboard: add 'zephyr,bt-c2h-uart'

### DIFF
--- a/boards/arm/efr32_thunderboard/thunderboard.dtsi
+++ b/boards/arm/efr32_thunderboard/thunderboard.dtsi
@@ -6,6 +6,7 @@
 
 / {
 	chosen {
+		zephyr,bt-c2h-uart = &usart1;
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;


### PR DESCRIPTION
Include `zephyr,bt-c2h-uart` in `chosen` node to make it possible to use HCI raw mode over UART. This was tested with `efr32bg22_brd4184b` board running `hci_uart` sample with Linux machine as a host (kernel 6.2).