### PR TITLE
Bluetooth: OTS: Add explicit ignore of ret error when reset dir_list

### DIFF
--- a/subsys/bluetooth/services/ots/ots_dir_list.c
+++ b/subsys/bluetooth/services/ots/ots_dir_list.c
@@ -126,7 +126,9 @@ static void dir_list_object_encode(const struct bt_gatt_ots_object *obj,
 static void bt_ots_dir_list_reset_anchor(struct bt_ots_dir_list *dir_list, void *obj_manager)
 {
 	dir_list->anchor_offset = 0;
-	bt_gatt_ots_obj_manager_first_obj_get(obj_manager, &dir_list->anchor_object);
+
+	/* Reset the dir_list - Ignore any error as we can't do anything about it anyways */
+	(void)bt_gatt_ots_obj_manager_first_obj_get(obj_manager, &dir_list->anchor_object);
 }
 
 static int bt_ots_dir_list_search_forward(struct bt_ots_dir_list *dir_list, void *obj_manager,


### PR DESCRIPTION
When doing the bt_ots_dir_list_reset_anchor we now explicitly ignore the return value of bt_gatt_ots_obj_manager_first_obj_get to fix a coverity issue.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/59524