### PR TITLE
cmake: remove extraneous newlines in build output

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -2934,7 +2934,7 @@ function(target_byproducts)
   endif()
 
   add_custom_command(TARGET ${TB_TARGET}
-                     POST_BUILD COMMAND ${CMAKE_COMMAND} -E echo ""
+                     POST_BUILD COMMAND ${CMAKE_COMMAND} -E true
                      BYPRODUCTS ${TB_BYPRODUCTS}
                      COMMENT "Logical command for additional byproducts on target: ${TB_TARGET}"
   )


### PR DESCRIPTION
Using `west build --board=stm32f769i_disco --pristine=always samples/subsys/shell/fs/` as an example:

Before:

```
[...]
-- west build: building application
[1/205] Preparing syscall dependency handling

[2/205] Generating include/generated/version.h
-- Zephyr version: 3.4.0 ($ZEPHYR_HOME), build: zephyr-v3.4.0-9-gec9b30d354ec
[195/205] Linking C executable zephyr/zephyr_pre0.elf

[199/205] Linking C executable zephyr/zephyr_pre1.elf

[205/205] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       94040 B         2 MB      4.48%
             RAM:       39528 B       384 KB     10.05%
            QSPI:          0 GB       256 MB      0.00%
            DTCM:          0 GB       128 KB      0.00%
          SDRAM1:          0 GB        16 MB      0.00%
        IDT_LIST:          0 GB         2 KB      0.00%
```

After:

```
[...]
-- west build: building application
[1/205] Preparing syscall dependency handling

[2/205] Generating include/generated/version.h
-- Zephyr version: 3.4.0 ($ZEPHYR_HOME), build: zephyr-v3.4.0-9-gec9b30d354ec
[205/205] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       94040 B         2 MB      4.48%
             RAM:       39528 B       384 KB     10.05%
            QSPI:          0 GB       256 MB      0.00%
            DTCM:          0 GB       128 KB      0.00%
          SDRAM1:          0 GB        16 MB      0.00%
        IDT_LIST:          0 GB         2 KB      0.00%
```