### PR TITLE
dts: xtensa: intel: add imr entry to cavs25_tgph

### DIFF
--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -83,6 +83,13 @@
 		wovcro-supported;
 	};
 
+	IMR1: memory@0xb0000000 {
+		compatible = "intel,adsp-imr";
+		reg = <0xB0000000 DT_SIZE_M(16)>;
+		block-size = <0x1000>;
+		zephyr,memory-region = "IMR1";
+	};
+
 	soc {
 		shim: shim@71f00 {
 			compatible = "intel,adsp-shim";


### PR DESCRIPTION
Add similar imr definition to cavs25_tpgh as in cavs25.