### PR TITLE
tests: kernel/mp: move CONFIG_KERNEL_COHERENCE to Kconfig

### DIFF
--- a/tests/kernel/mp/Kconfig
+++ b/tests/kernel/mp/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Must have this on where available, otherwise the linker will place
+# the shared variables in cached/incoherent memory.
+config KERNEL_COHERENCE
+	bool
+	default y if ARCH_HAS_COHERENCE
+
+source "Kconfig.zephyr"

--- a/tests/kernel/mp/prj.conf
+++ b/tests/kernel/mp/prj.conf
@@ -1,7 +1,3 @@
 CONFIG_ZTEST=y
 CONFIG_ZTEST_NEW_API=y
 CONFIG_SMP=n
-
-# Must have this on where available, otherwise the linker will place
-# the shared variables in cached/incoherent memory.
-CONFIG_KERNEL_COHERENCE=y


### PR DESCRIPTION
This moves CONFIG_KERNEL_COHERENCE from prj.conf to Kconfig. This gets rid of the cmake warning where CONFIG_KERNEL_COHERENCE is assigned the value 'y' but gets the value ''. This is simply done to avoid confusion when running the test manually.