### PR TITLE
cmake: Fix FindLlvmLld usage of unimported package

### DIFF
--- a/cmake/modules/FindGnuLd.cmake
+++ b/cmake/modules/FindGnuLd.cmake
@@ -23,6 +23,8 @@
 # Note that this will use CROSS_COMPILE, if defined,
 # as a prefix to the linker executable.
 
+include(FindPackageHandleStandardArgs)
+
 # GNULD_LINKER exists on repeated builds or defined manually...
 if(EXISTS "${GNULD_LINKER}")
   if(NOT DEFINED GNULD_LINKER_IS_BFD)

--- a/cmake/modules/FindLlvmLld.cmake
+++ b/cmake/modules/FindLlvmLld.cmake
@@ -17,6 +17,8 @@
 # 'LLVMLLD_VERSION_STRING'
 # The version of LLVM lld.
 
+include(FindPackageHandleStandardArgs)
+
 # See if the compiler has a preferred linker
 execute_process(COMMAND ${CMAKE_C_COMPILER} --print-prog-name=ld.lld
                 OUTPUT_VARIABLE LLVMLLD_LINKER

--- a/cmake/modules/Findarmclang.cmake
+++ b/cmake/modules/Findarmclang.cmake
@@ -12,6 +12,8 @@
 # 'ARMCLANG_VERSION'
 # The version of the arm clang toolchain.
 
+include(FindPackageHandleStandardArgs)
+
 if(CMAKE_C_COMPILER)
   # Parse the 'clang --version' output to find the installed version.
   execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${triple} --version OUTPUT_VARIABLE ARMCLANG_VERSION)

--- a/cmake/modules/FindoneApi.cmake
+++ b/cmake/modules/FindoneApi.cmake
@@ -12,6 +12,8 @@
 # 'ONEAPI_VERSION'
 # The version of the oneAPI toolchain.
 
+include(FindPackageHandleStandardArgs)
+
 if(CMAKE_C_COMPILER)
   # Parse the 'clang --version' output to find the installed version.
   execute_process(COMMAND ${CMAKE_C_COMPILER} --version OUTPUT_VARIABLE ONEAPI_VERSION)


### PR DESCRIPTION
The find_package_handle_standard_args function is used in FindLlvmLld without being imported. This may cause FindLlvmLld to fail non-determistically based on if it's evaluated in a CMake build/process before find_package_handle_standard_args is included.

We should include what we use. Explicitly include
find_package_handle_standard_args.