### PR TITLE
tests: Bluetooth: don't assume handle is 0

### DIFF
--- a/tests/bsim/bluetooth/host/l2cap/split/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/split/tester/src/main.c
@@ -41,6 +41,7 @@ static K_SEM_DEFINE(cmd_sem, 1, 1);
 static struct k_sem acl_pkts;
 static struct k_sem tx_credits;
 static uint16_t peer_mps;
+static uint16_t conn_handle;
 
 static uint16_t active_opcode = 0xFFFF;
 static struct net_buf *cmd_rsp;
@@ -123,6 +124,9 @@ static void handle_meta_event(struct net_buf *buf)
 
 	switch (code) {
 	case BT_HCI_EVT_LE_ENH_CONN_COMPLETE:
+	case BT_HCI_EVT_LE_ENH_CONN_COMPLETE_V2:
+		conn_handle = sys_get_le16(&buf->data[4]);
+		LOG_DBG("connected: handle: %d", conn_handle);
 		SET_FLAG(is_connected);
 		break;
 	case BT_HCI_EVT_LE_DATA_LEN_CHANGE:
@@ -488,7 +492,7 @@ static int send_acl(struct net_buf *buf)
 	uint8_t flags = BT_ACL_START_NO_FLUSH;
 
 	hdr = net_buf_push(buf, sizeof(*hdr));
-	hdr->handle = sys_cpu_to_le16(bt_acl_handle_pack(0, flags));
+	hdr->handle = sys_cpu_to_le16(bt_acl_handle_pack(conn_handle, flags));
 	hdr->len = sys_cpu_to_le16(buf->len - sizeof(*hdr));
 
 	bt_buf_set_type(buf, BT_BUF_ACL_OUT);


### PR DESCRIPTION
Don't assume the connection handle will always be 0. This is currently the case with the Zephyr link layer, but recently changed in the Softdevice Controller.

Another problem is that apparently the spec allows the controller to just blackhole data instead of returning `BT_HCI_ERR_UNKNOWN_CONN_ID` if the host uses a wrong handle.