### PR TITLE
net: ip: always cancel IPv6 DAD when address is removed

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1339,10 +1339,6 @@ void net_if_ipv6_dad_failed(struct net_if *iface, const struct in6_addr *addr)
 	}
 
 
-	k_mutex_lock(&lock, K_FOREVER);
-	sys_slist_find_and_remove(&active_dad_timers, &ifaddr->dad_node);
-	k_mutex_unlock(&lock);
-
 	net_mgmt_event_notify_with_info(NET_EVENT_IPV6_DAD_FAILED, iface,
 					&ifaddr->address.in6_addr,
 					sizeof(struct in6_addr));
@@ -1851,6 +1847,14 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 
 			k_mutex_unlock(&lock);
 		}
+
+#if defined(CONFIG_NET_IPV6_DAD)
+		if (!net_if_flag_is_set(iface, NET_IF_IPV6_NO_ND)) {
+			k_mutex_lock(&lock, K_FOREVER);
+			sys_slist_find_and_remove(&active_dad_timers, &ipv6->unicast[i].dad_node);
+			k_mutex_unlock(&lock);
+		}
+#endif
 
 		ipv6->unicast[i].is_used = false;
 


### PR DESCRIPTION
If the address was removed immediately after being added (e.g. because the interface MAC address is changed on boot), it would remain in the DAD timer list.

In one scenario, the DAD timeout would eventually fire, causing the now-removed address to be modified, potentially causing issues that way.

In another scenario, if the interface was immediately brought back up again with a different link-local address, this new address would reuse the first address slot on the interface. Starting the DAD process for this new address would lead to the same address slot being added to the DAD timer list a second time, causing an infinite list and associated lockup during iteration.

Always remove the address from the DAD timer list when it is removed from the interface, not just when DAD fails.