### PR TITLE
tests: drivers: rtc: add a y2k test

### DIFF
--- a/drivers/rtc/rtc_mc146818.c
+++ b/drivers/rtc/rtc_mc146818.c
@@ -191,8 +191,8 @@ static int rtc_mc146818_set_time(const struct device *dev, const struct rtc_time
 	value = rtc_read(RTC_DATA);
 	rtc_write(RTC_DATA, value | RTC_UCI_BIT);
 
-	year = (1970 + timeptr->tm_year) % 100;
-	cent = (1970 + timeptr->tm_year) / 100;
+	year = (1900 + timeptr->tm_year) % 100;
+	cent = (1900 + timeptr->tm_year) / 100;
 
 	if (!(rtc_read(RTC_DATA) & RTC_DMODE_BIT)) {
 		rtc_write(RTC_SEC, (uint8_t)bin2bcd(timeptr->tm_sec));
@@ -271,7 +271,7 @@ static int rtc_mc146818_get_time(const struct device *dev, struct rtc_time  *tim
 		timeptr->tm_sec = bcd2bin(timeptr->tm_sec);
 	}
 
-	timeptr->tm_year = 100 * (int)cent + year - 1970;
+	timeptr->tm_year = 100 * (int)cent + year - 1900;
 
 	timeptr->tm_nsec = 0;
 	timeptr->tm_yday = 0;

--- a/tests/drivers/rtc/rtc_api/CMakeLists.txt
+++ b/tests/drivers/rtc/rtc_api/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(app PRIVATE
 	src/main.c
 	src/test_time_incrementing.c
 	src/test_time.c
+	src/test_y2k.c
 )
 
 if(DEFINED CONFIG_RTC_ALARM)

--- a/tests/drivers/rtc/rtc_api/src/test_y2k.c
+++ b/tests/drivers/rtc/rtc_api/src/test_y2k.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/rtc.h>
+
+#include <time.h>
+
+/* date "+%s" -d "Sat Jan  1 2000 00:00:00 GMT+0000" */
+#define Y2K_STAMP 946684800UL
+
+#define SECONDS_BEFORE 1
+#define SECONDS_AFTER 1
+
+#define RTC_TEST_START_TIME (Y2K_STAMP - SECONDS_BEFORE)
+#define RTC_TEST_STOP_TIME (Y2K_STAMP + SECONDS_AFTER)
+
+static const struct device *rtc = DEVICE_DT_GET(DT_ALIAS(rtc));
+
+ZTEST(rtc_api, test_y2k)
+{
+	enum test_time {
+		Y99,
+		Y2K,
+	};
+
+	static struct rtc_time rtm[2];
+	struct tm *const tm[2] = {
+		(struct tm *const)&rtm[0],
+		(struct tm *const)&rtm[1],
+	};
+	const time_t t[] = {
+		[Y99] = RTC_TEST_START_TIME,
+		[Y2K] = RTC_TEST_STOP_TIME,
+	};
+
+	/* Party like it's 1999 */
+	zassert_not_null(gmtime_r(&t[Y99], tm[Y99]));
+	zassert_ok(rtc_set_time(rtc, &rtm[Y99]));
+
+	/* Living after midnight */
+	k_sleep(K_SECONDS(SECONDS_BEFORE + SECONDS_AFTER));
+	zassert_ok(rtc_get_time(rtc, &rtm[Y2K]));
+
+	/* It's the end of the world as we know it */
+	zassert_equal(rtm[Y2K].tm_year + 1900, 2000, "wrong year: %d", rtm[Y2K].tm_year + 1900);
+	zassert_equal(rtm[Y2K].tm_mon, 0, "wrong month: %d", rtm[Y2K].tm_mon);
+	zassert_equal(rtm[Y2K].tm_mday, 1, "wrong day-of-month: %d", rtm[Y2K].tm_mday);
+	zassert_equal(rtm[Y2K].tm_yday, 0, "wrong day-of-year: %d", rtm[Y2K].tm_yday);
+	zassert_equal(rtm[Y2K].tm_wday, 6, "wrong day-of-week: %d", rtm[Y2K].tm_wday);
+	zassert_equal(rtm[Y2K].tm_hour, 0, "wrong hour: %d", rtm[Y2K].tm_hour);
+	zassert_equal(rtm[Y2K].tm_min, 0, "wrong minute: %d", rtm[Y2K].tm_min);
+	zassert_equal(rtm[Y2K].tm_sec, SECONDS_AFTER, "wrong second: %d", rtm[Y2K].tm_sec);
+}


### PR DESCRIPTION
* Correct year offset in the mc146818 RTC driver
* Add a test to ensure that the RTC is capable of transitioning from Dec 31, 1999 to Jan 1, 2000