### PR TITLE
twister: pytest: Added fixture for mcumgr with unittests

### DIFF
--- a/doc/develop/test/pytest.rst
+++ b/doc/develop/test/pytest.rst
@@ -63,17 +63,48 @@ Following import is required to include in .py sources:
 
    from twister_harness import Device
 
-It is important for type checking and enabling IDE hints for ``dut``s (objects representing
+It is important for type checking and enabling IDE hints for ``dut`` s (objects representing
 Devices Under Test). The ``dut`` fixture is the core of pytest harness plugin. When used as an
 argument of a test function it gives access to a DeviceAbstract type object. The fixture yields a
 device prepared according to the requested type (native posix, qemu, hardware, etc.). All types of
 devices share the same API. This allows for writing tests which are device-type-agnostic.
 
+Helpers & fixtures
+==================
+
+mcumgr
+------
+
+Sample fixture to wrap ``mcumgr`` command-line tool used to manage remote devices.
+More information about MCUmgr can be found here :ref:`mcu_mgr`.
+
+.. note::
+   This fixture requires the ``mcumgr`` available in the system PATH
+
+Only selected functionality of MCUmgr is wrapped by this fixture.
+
+For example, here is a test with a fixture ``mcumgr``
+
+.. code-block:: python
+
+   from twister_harness import Device, McuMgr
+
+   def test_upgrade(dut: Device, mcumgr: McuMgr):
+      # wait for dut is up
+      time.sleep(2)
+      # upload the signed image
+      mcumgr.image_upload('path/to/zephyr.signed.bin')
+      # obtain the hash of uploaded image from the device
+      second_hash = mcumgr.get_hash_to_test()
+      # test a new upgrade image
+      mcumgr.image_test(second_hash)
+      # reset the device remotely
+      mcumgr.reset_device()
+      # continue test scenario, check version etc.
 
 Limitations
 ***********
 
-* The whole pytest call is reported as one test in the final twister report (xml or json).
 * Device adapters in pytest plugin provide `iter_stdout` method to read from devices. In some
   cases, it is not the most convenient way, and it will be considered how to improve this
   (for example replace it with a simple read function with a given byte size and timeout arguments).

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/__init__.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/__init__.py
@@ -5,7 +5,8 @@
 # flake8: noqa
 
 from twister_harness.device.device_abstract import DeviceAbstract as Device
+from twister_harness.fixtures.mcumgr import MCUmgr
 
-__all__= ['Device']
+__all__= ['Device', 'MCUmgr']
 
 __version__ = '0.0.1'

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures/mcumgr.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures/mcumgr.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import pytest
+import logging
+import re
+import shlex
+
+from typing import Generator
+from subprocess import check_output, getstatusoutput
+from pathlib import Path
+from dataclasses import dataclass
+
+from twister_harness.device.device_abstract import DeviceAbstract
+
+
+logger = logging.getLogger(__name__)
+
+
+class MCUmgrException(Exception):
+    """General MCUmgr exception."""
+
+
+@dataclass
+class MCUmgrImage:
+    image: int
+    slot: int
+    version: str = ''
+    flags: str = ''
+    hash: str = ''
+
+
+class MCUmgr:
+    """Sample wrapper for mcumgr command-line tool"""
+    mcumgr_exec = 'mcumgr'
+
+    def __init__(self, connection_options: str):
+        self.conn_opts = connection_options
+
+    @classmethod
+    def create_for_serial(cls, serial_port: str) -> MCUmgr:
+        return cls(connection_options=f'--conntype serial --connstring={serial_port}')
+
+    @classmethod
+    def is_available(cls) -> bool:
+        exitcode, output = getstatusoutput(f'{cls.mcumgr_exec} version')
+        if exitcode != 0:
+            logger.warning(f'mcumgr tool not available: {output}')
+            return False
+        return True
+
+    def run_command(self, cmd: str) -> str:
+        command = f'{self.mcumgr_exec} {self.conn_opts} {cmd}'
+        logger.info(f'CMD: {command}')
+        return check_output(shlex.split(command), text=True)
+
+    def reset_device(self):
+        self.run_command('reset')
+
+    def image_upload(self, image: Path | str, timeout: int = 30):
+        self.run_command(f'-t {timeout} image upload {image}')
+        logger.info('Image successfully uploaded')
+
+    def get_image_list(self) -> list[MCUmgrImage]:
+        output = self.run_command('image list')
+        return self._parse_image_list(output)
+
+    @staticmethod
+    def _parse_image_list(cmd_output: str) -> list[MCUmgrImage]:
+        image_list = []
+        re_image = re.compile(r'image=(\d+)\s+slot=(\d+)')
+        re_version = re.compile(r'version:\s+(\S+)')
+        re_flags = re.compile(r'flags:\s+(.+)')
+        re_hash = re.compile(r'hash:\s+(\w+)')
+        for line in cmd_output.splitlines():
+            if m := re_image.search(line):
+                image_list.append(
+                    MCUmgrImage(
+                        image=int(m.group(1)),
+                        slot=int(m.group(2))
+                    )
+                )
+            elif image_list:
+                if m := re_version.search(line):
+                    image_list[-1].version = m.group(1)
+                elif m := re_flags.search(line):
+                    image_list[-1].flags = m.group(1)
+                elif m := re_hash.search(line):
+                    image_list[-1].hash = m.group(1)
+        return image_list
+
+    def get_hash_to_test(self) -> str:
+        image_list = self.get_image_list()
+        if len(image_list) < 2:
+            logger.info(image_list)
+            raise MCUmgrException('Please check image list returned by mcumgr')
+        return image_list[1].hash
+
+    def image_test(self, hash: str | None = None):
+        if not hash:
+            hash = self.get_hash_to_test()
+        self.run_command(f'image test {hash}')
+
+    def image_confirm(self, hash: str | None = None):
+        if not hash:
+            image_list = self.get_image_list()
+            hash = image_list[0].hash
+        self.run_command(f'image confirm {hash}')
+
+
+@pytest.fixture(scope='session')
+def is_mcumgr_available() -> None:
+    if not MCUmgr.is_available():
+        pytest.skip('mcumgr not available')
+
+
+@pytest.fixture()
+def mcumgr(is_mcumgr_available: None, dut: DeviceAbstract) -> Generator[MCUmgr, None, None]:
+    yield MCUmgr.create_for_serial(dut.device_config.serial)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -16,7 +16,8 @@ from twister_harness.twister_harness_config import TwisterHarnessConfig
 logger = logging.getLogger(__name__)
 
 pytest_plugins = (
-    'twister_harness.fixtures.dut'
+    'twister_harness.fixtures.dut',
+    'twister_harness.fixtures.mcumgr'
 )
 
 

--- a/scripts/pylib/pytest-twister-harness/tests/fixtures/mcumgr_fixture_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/fixtures/mcumgr_fixture_test.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import textwrap
+
+from unittest import mock
+from twister_harness.fixtures.mcumgr import MCUmgr, MCUmgrException
+
+
+@pytest.fixture(name='mcumgr')
+def fixture_mcumgr() -> MCUmgr:
+    return MCUmgr.create_for_serial('SERIAL_PORT')
+
+
+@mock.patch('twister_harness.fixtures.mcumgr.MCUmgr.run_command', return_value='')
+def test_if_mcumgr_fixture_generate_proper_command(
+    patched_run_command: mock.Mock, mcumgr: MCUmgr
+) -> None:
+    mcumgr.reset_device()
+    patched_run_command.assert_called_with('reset')
+
+    mcumgr.get_image_list()
+    patched_run_command.assert_called_with('image list')
+
+    mcumgr.image_upload('/path/to/image', timeout=100)
+    patched_run_command.assert_called_with('-t 100 image upload /path/to/image')
+
+    mcumgr.image_test(hash='ABCD')
+    patched_run_command.assert_called_with('image test ABCD')
+
+    mcumgr.image_confirm(hash='ABCD')
+    patched_run_command.assert_called_with('image confirm ABCD')
+
+
+def test_if_mcumgr_fixture_raises_exception_when_no_hash_to_test(mcumgr: MCUmgr) -> None:
+    cmd_output = textwrap.dedent("""
+        Images:
+        image=0 slot=0
+            version: 0.0.0
+            bootable: true
+            flags: active confirmed
+            hash: 1234
+        Split status: N/A (0)
+    """)
+    mcumgr.run_command = mock.Mock(return_value=cmd_output)
+    with pytest.raises(MCUmgrException):
+        mcumgr.image_test()
+
+
+def test_if_mcumgr_fixture_parse_image_list(mcumgr: MCUmgr) -> None:
+    cmd_output = textwrap.dedent("""
+        Images:
+        image=0 slot=0
+            version: 0.0.0
+            bootable: true
+            flags:
+            hash: 0000
+        image=0 slot=1
+            version: 1.1.1
+            bootable: true
+            flags: pending
+            hash: 1111
+        Split status: N/A (0)
+    """)
+    mcumgr.run_command = mock.Mock(return_value=cmd_output)
+    image_list = mcumgr.get_image_list()
+    assert image_list[0].image == 0
+    assert image_list[0].slot == 0
+    assert image_list[0].version == '0.0.0'
+    assert image_list[0].flags == ''
+    assert image_list[0].hash == '0000'
+    assert image_list[1].image == 0
+    assert image_list[1].slot == 1
+    assert image_list[1].version == '1.1.1'
+    assert image_list[1].flags == 'pending'
+    assert image_list[1].hash == '1111'
+
+    # take second hash to test
+    mcumgr.image_test()
+    mcumgr.run_command.assert_called_with('image test 1111')
+
+    # take first hash to confirm
+    mcumgr.image_confirm()
+    mcumgr.run_command.assert_called_with('image confirm 0000')


### PR DESCRIPTION
Added mcumgr fixture to pytest-twister-harness. Added unittests for new fixture.

This is cherry-picked from PR #58393 
and there are examples, how new fixture can be used to test MCUBoot
