### PR TITLE
mm_drv: tlb: Fix driver tests

### DIFF
--- a/drivers/mm/mm_drv_bank.c
+++ b/drivers/mm/mm_drv_bank.c
@@ -15,7 +15,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/sys/__assert.h>
 #include <zephyr/drivers/mm/mm_drv_bank.h>
 #include <zephyr/sys/mem_stats.h>
 
@@ -30,7 +29,9 @@ uint32_t sys_mm_drv_bank_page_mapped(struct mem_drv_bank *bank)
 {
 	bank->unmapped_pages--;
 	bank->mapped_pages++;
-	__ASSERT_NO_MSG(bank->mapped_pages <= bank->max_mapped_pages);
+	if (bank->mapped_pages > bank->max_mapped_pages) {
+		bank->max_mapped_pages = bank->mapped_pages;
+	}
 	return bank->mapped_pages;
 }
 
@@ -38,7 +39,6 @@ uint32_t sys_mm_drv_bank_page_unmapped(struct mem_drv_bank *bank)
 {
 	bank->unmapped_pages++;
 	bank->mapped_pages--;
-	__ASSERT_NO_MSG(bank->unmapped_pages <= bank->max_mapped_pages);
 	return bank->unmapped_pages;
 }
 

--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -678,6 +678,11 @@ static int sys_mm_drv_mm_init(const struct device *dev)
 
 	ret = sys_mm_drv_unmap_region(UINT_TO_POINTER(UNUSED_L2_START_ALIGNED),
 				      unused_size);
+
+	/* Need to reset max pages statistics after unmap */
+	for (int i = 0; i < L2_SRAM_BANK_NUM; i++) {
+		sys_mm_drv_bank_stats_reset_max(&hpsram_bank[i]);
+	}
 #endif
 
 	/*

--- a/tests/drivers/mm/sys_mm_drv_bank/src/main.c
+++ b/tests/drivers/mm/sys_mm_drv_bank/src/main.c
@@ -39,10 +39,17 @@ ZTEST(sys_mm_bank_api, test_sys_mm_drv_bank)
 	/* Verify that the initialization routine works as expected. */
 	/* It set mapped state for all pages                         */
 	sys_mm_drv_bank_init(&bank_data, BANK_PAGES);
+	expected.free_bytes = EXPECTED(0);
+	expected.allocated_bytes = EXPECTED(BANK_PAGES);
+	expected.max_allocated_bytes = EXPECTED(BANK_PAGES);
+	sys_mm_drv_bank_stats_get(&bank_data, &stats);
+	test_stats("MM Bank Init Error", &stats, &expected);
+
 	/* Now unmap all pages */
 	for (index = 0; index < BANK_PAGES; index++) {
 		sys_mm_drv_bank_page_unmapped(&bank_data);
 	}
+	sys_mm_drv_bank_stats_reset_max(&bank_data);
 
 	expected.free_bytes = EXPECTED(BANK_PAGES);
 	expected.allocated_bytes = EXPECTED(0);
@@ -51,7 +58,6 @@ ZTEST(sys_mm_bank_api, test_sys_mm_drv_bank)
 	test_stats("MM Bank Init Error", &stats, &expected);
 
 	/* Verify mapped pages are counted correctly */
-
 	count = sys_mm_drv_bank_page_mapped(&bank_data);
 	zassert_equal(count, 1,
 		      "MM Page Mapped Error: 1st mapped = %u, not %u\n",
@@ -121,7 +127,6 @@ ZTEST(sys_mm_bank_api, test_sys_mm_drv_bank)
 	expected.max_allocated_bytes = EXPECTED(2);
 	sys_mm_drv_bank_stats_get(&bank_data, &stats);
 	test_stats("MM Bank Reset Max Error", &stats, &expected);
-
 }
 
 ZTEST_SUITE(sys_mm_bank_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Previous fix https://github.com/zephyrproject-rtos/zephyr/pull/58891 introduced failure in driver tests suite. This patch corrects the error and reverts definition of max_mapped_page field in stats.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>