### PR TITLE
mgmt: mcumgr: Make SMP version 2 to legacy error lookup extensible

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -237,6 +237,11 @@ Libraries / Subsystems
   * Added response checking to MCUmgr's :c:enumerator:`MGMT_EVT_OP_CMD_RECV`
     notification callback to allow applications to reject MCUmgr commands.
 
+  * MCUmgr SMP version 2 error translation (to legacy MCUmgr error code) is now
+    supported in function handlers by setting ``mg_translate_error`` of
+    :c:struct:`mgmt_group` when registering a transport. See
+    :c:type:`smp_translate_error_fn` for function details.
+
 HALs
 ****
 

--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
@@ -75,17 +75,6 @@ enum fs_mgmt_ret_code_t {
 	FS_MGMT_RET_RC_CHECKSUM_HASH_NOT_FOUND,
 };
 
-#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
-/*
- * @brief	Translate FS mgmt group error code into MCUmgr error code
- *
- * @param ret	#fs_mgmt_ret_code_t error code
- *
- * @return	#mcumgr_err_t error code
- */
-int fs_mgmt_translate_error_code(uint16_t ret);
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -341,17 +341,6 @@ int img_mgmt_vercmp(const struct image_version *a, const struct image_version *b
 void img_mgmt_reset_upload(void);
 #endif
 
-#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
-/*
- * @brief	Translate IMG mgmt group error code into MCUmgr error code
- *
- * @param ret	#img_mgmt_ret_code_t error code
- *
- * @return	#mcumgr_err_t error code
- */
-int img_mgmt_translate_error_code(uint16_t ret);
-#endif
-
 #ifdef CONFIG_MCUMGR_GRP_IMG_VERBOSE_ERR
 #define IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, rsn) ((action)->rc_rsn = (rsn))
 #define IMG_MGMT_UPLOAD_ACTION_RC_RSN(action) ((action)->rc_rsn)

--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
  * Copyright (c) 2022 Laird Connectivity
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -96,17 +97,6 @@ struct os_mgmt_info_append {
 	/* If there has been prior output, must be set to true if a response has been output */
 	bool *prior_output;
 };
-
-#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
-/*
- * @brief	Translate OS mgmt group error code into MCUmgr error code
- *
- * @param ret	#os_mgmt_ret_code_t error code
- *
- * @return	#mcumgr_err_t error code
- */
-int os_mgmt_translate_error_code(uint16_t ret);
-#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/mgmt/mcumgr/grp/shell_mgmt/shell_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/shell_mgmt/shell_mgmt.h
@@ -34,17 +34,6 @@ enum shell_mgmt_ret_code_t {
 	SHELL_MGMT_RET_RC_EMPTY_COMMAND,
 };
 
-#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
-/*
- * @brief	Translate shell mgmt group error code into MCUmgr error code
- *
- * @param ret	#shell_mgmt_ret_code_t error code
- *
- * @return	#mcumgr_err_t error code
- */
-int shell_mgmt_translate_error_code(uint16_t ret);
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/mgmt/mcumgr/grp/stat_mgmt/stat_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/stat_mgmt/stat_mgmt.h
@@ -49,17 +49,6 @@ struct stat_mgmt_entry {
 	uint64_t value;
 };
 
-#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
-/*
- * @brief	Translate stat mgmt group error code into MCUmgr error code
- *
- * @param ret	#stat_mgmt_ret_code_t error code
- *
- * @return	#mcumgr_err_t error code
- */
-int stat_mgmt_translate_error_code(uint16_t ret);
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/mgmt/mcumgr/grp/zephyr/zephyr_basic.h
+++ b/include/zephyr/mgmt/mcumgr/grp/zephyr/zephyr_basic.h
@@ -35,17 +35,6 @@ enum zephyr_basic_group_ret_code_t {
 	ZEPHYR_MGMT_GRP_CMD_RC_FLASH_ERASE_FAILED,
 };
 
-#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
-/*
- * @brief	Translate zephyr basic group error code into MCUmgr error code
- *
- * @param ret	#zephyr_basic_group_ret_code_t error code
- *
- * @return	#mcumgr_err_t error code
- */
-int zephyr_basic_group_translate_error_code(uint16_t ret);
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/mgmt/mcumgr/mgmt/mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/mgmt.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -195,8 +195,15 @@ struct mgmt_group {
 	const struct mgmt_handler *mg_handlers;
 	uint16_t mg_handlers_count;
 
-	/* The numeric ID of this group. */
+	/** The numeric ID of this group. */
 	uint16_t mg_group_id;
+
+#if IS_ENABLED(CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL)
+	/** A function handler for translating version 2 SMP error codes to version 1 SMP error
+	 * codes (optional)
+	 */
+	smp_translate_error_fn mg_translate_error;
+#endif
 };
 
 /**
@@ -223,6 +230,19 @@ void mgmt_unregister_group(struct mgmt_group *group);
  *		NULL on failure.
  */
 const struct mgmt_handler *mgmt_find_handler(uint16_t group_id, uint16_t command_id);
+
+#if IS_ENABLED(CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL)
+/**
+ * @brief		Finds a registered error translation function for converting from SMP
+ *			version 2 error codes to legacy SMP version 1 error codes.
+ *
+ * @param group_id	The group of the translation function to find.
+ *
+ * @return		Requested lookup function on success.
+ * @return		NULL on failure.
+ */
+smp_translate_error_fn mgmt_find_error_translation_function(uint16_t group_id);
+#endif
 
 /**
  * @}

--- a/include/zephyr/mgmt/mcumgr/smp/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp/smp.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -55,7 +56,7 @@ struct cbor_nb_writer {
 	struct net_buf *nb;
 	zcbor_state_t zs[2];
 
-#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
+#if IS_ENABLED(CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL)
 	uint16_t error_group;
 	uint16_t error_ret;
 #endif
@@ -119,6 +120,17 @@ int smp_process_request_packet(struct smp_streamer *streamer, void *req);
  * @return true on success, false on failure (memory error).
  */
 bool smp_add_cmd_ret(zcbor_state_t *zse, uint16_t group, uint16_t ret);
+
+#if IS_ENABLED(CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL)
+/** @typedef	smp_translate_error_fn
+ * @brief	Translates a SMP version 2 error response to a legacy SMP version 1 error code.
+ *
+ * @param ret	The SMP version 2 error ret/rc value.
+ *
+ * @return	#enum mcumgr_err_t Legacy SMP version 1 error code to return to client.
+ */
+typedef int (*smp_translate_error_fn)(uint16_t ret);
+#endif
 
 #ifdef __cplusplus
 }

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
@@ -896,6 +896,46 @@ static int fs_mgmt_close_opened_file(struct smp_streamer *ctxt)
 	return MGMT_ERR_EOK;
 }
 
+#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
+/*
+ * @brief	Translate FS mgmt group error code into MCUmgr error code
+ *
+ * @param ret	#fs_mgmt_ret_code_t error code
+ *
+ * @return	#mcumgr_err_t error code
+ */
+static int fs_mgmt_translate_error_code(uint16_t ret)
+{
+	int rc;
+
+	switch (ret) {
+	case FS_MGMT_RET_RC_FILE_INVALID_NAME:
+	case FS_MGMT_RET_RC_CHECKSUM_HASH_NOT_FOUND:
+	rc = MGMT_ERR_EINVAL;
+	break;
+
+	case FS_MGMT_RET_RC_FILE_NOT_FOUND:
+	case FS_MGMT_RET_RC_FILE_IS_DIRECTORY:
+	rc = MGMT_ERR_ENOENT;
+	break;
+
+	case FS_MGMT_RET_RC_UNKNOWN:
+	case FS_MGMT_RET_RC_FILE_OPEN_FAILED:
+	case FS_MGMT_RET_RC_FILE_SEEK_FAILED:
+	case FS_MGMT_RET_RC_FILE_READ_FAILED:
+	case FS_MGMT_RET_RC_FILE_TRUNCATE_FAILED:
+	case FS_MGMT_RET_RC_FILE_DELETE_FAILED:
+	case FS_MGMT_RET_RC_FILE_WRITE_FAILED:
+	case FS_MGMT_RET_RC_FILE_OFFSET_NOT_VALID:
+	case FS_MGMT_RET_RC_FILE_OFFSET_LARGER_THAN_FILE:
+	default:
+	rc = MGMT_ERR_EUNKNOWN;
+	}
+
+	return rc;
+}
+#endif
+
 static const struct mgmt_handler fs_mgmt_handlers[] = {
 	[FS_MGMT_ID_FILE] = {
 		.mh_read = fs_mgmt_file_download,
@@ -931,6 +971,9 @@ static struct mgmt_group fs_mgmt_group = {
 	.mg_handlers = fs_mgmt_handlers,
 	.mg_handlers_count = FS_MGMT_HANDLER_CNT,
 	.mg_group_id = MGMT_GROUP_ID_FS,
+#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
+	.mg_translate_error = fs_mgmt_translate_error_code,
+#endif
 };
 
 static void fs_mgmt_register_group(void)
@@ -953,38 +996,5 @@ static void fs_mgmt_register_group(void)
 #endif
 #endif
 }
-
-#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
-int fs_mgmt_translate_error_code(uint16_t ret)
-{
-	int rc;
-
-	switch (ret) {
-	case FS_MGMT_RET_RC_FILE_INVALID_NAME:
-	case FS_MGMT_RET_RC_CHECKSUM_HASH_NOT_FOUND:
-	rc = MGMT_ERR_EINVAL;
-	break;
-
-	case FS_MGMT_RET_RC_FILE_NOT_FOUND:
-	case FS_MGMT_RET_RC_FILE_IS_DIRECTORY:
-	rc = MGMT_ERR_ENOENT;
-	break;
-
-	case FS_MGMT_RET_RC_UNKNOWN:
-	case FS_MGMT_RET_RC_FILE_OPEN_FAILED:
-	case FS_MGMT_RET_RC_FILE_SEEK_FAILED:
-	case FS_MGMT_RET_RC_FILE_READ_FAILED:
-	case FS_MGMT_RET_RC_FILE_TRUNCATE_FAILED:
-	case FS_MGMT_RET_RC_FILE_DELETE_FAILED:
-	case FS_MGMT_RET_RC_FILE_WRITE_FAILED:
-	case FS_MGMT_RET_RC_FILE_OFFSET_NOT_VALID:
-	case FS_MGMT_RET_RC_FILE_OFFSET_LARGER_THAN_FILE:
-	default:
-	rc = MGMT_ERR_EUNKNOWN;
-	}
-
-	return rc;
-}
-#endif
 
 MCUMGR_HANDLER_DEFINE(fs_mgmt, fs_mgmt_register_group);

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -729,42 +729,15 @@ int img_mgmt_my_version(struct image_version *ver)
 				  ver, NULL, NULL);
 }
 
-static const struct mgmt_handler img_mgmt_handlers[] = {
-	[IMG_MGMT_ID_STATE] = {
-		.mh_read = img_mgmt_state_read,
-#ifdef CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
-		.mh_write = NULL
-#else
-		.mh_write = img_mgmt_state_write,
-#endif
-	},
-	[IMG_MGMT_ID_UPLOAD] = {
-		.mh_read = NULL,
-		.mh_write = img_mgmt_upload
-	},
-	[IMG_MGMT_ID_ERASE] = {
-		.mh_read = NULL,
-		.mh_write = img_mgmt_erase
-	},
-};
-
-static const struct mgmt_handler img_mgmt_handlers[];
-
-#define IMG_MGMT_HANDLER_CNT ARRAY_SIZE(img_mgmt_handlers)
-
-static struct mgmt_group img_mgmt_group = {
-	.mg_handlers = (struct mgmt_handler *)img_mgmt_handlers,
-	.mg_handlers_count = IMG_MGMT_HANDLER_CNT,
-	.mg_group_id = MGMT_GROUP_ID_IMAGE,
-};
-
-static void img_mgmt_register_group(void)
-{
-	mgmt_register_group(&img_mgmt_group);
-}
-
 #ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
-int img_mgmt_translate_error_code(uint16_t ret)
+/*
+ * @brief	Translate IMG mgmt group error code into MCUmgr error code
+ *
+ * @param ret	#img_mgmt_ret_code_t error code
+ *
+ * @return	#mcumgr_err_t error code
+ */
+static int img_mgmt_translate_error_code(uint16_t ret)
 {
 	int rc;
 
@@ -817,5 +790,42 @@ int img_mgmt_translate_error_code(uint16_t ret)
 	return rc;
 }
 #endif
+
+static const struct mgmt_handler img_mgmt_handlers[] = {
+	[IMG_MGMT_ID_STATE] = {
+		.mh_read = img_mgmt_state_read,
+#ifdef CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
+		.mh_write = NULL
+#else
+		.mh_write = img_mgmt_state_write,
+#endif
+	},
+	[IMG_MGMT_ID_UPLOAD] = {
+		.mh_read = NULL,
+		.mh_write = img_mgmt_upload
+	},
+	[IMG_MGMT_ID_ERASE] = {
+		.mh_read = NULL,
+		.mh_write = img_mgmt_erase
+	},
+};
+
+static const struct mgmt_handler img_mgmt_handlers[];
+
+#define IMG_MGMT_HANDLER_CNT ARRAY_SIZE(img_mgmt_handlers)
+
+static struct mgmt_group img_mgmt_group = {
+	.mg_handlers = (struct mgmt_handler *)img_mgmt_handlers,
+	.mg_handlers_count = IMG_MGMT_HANDLER_CNT,
+	.mg_group_id = MGMT_GROUP_ID_IMAGE,
+#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
+	.mg_translate_error = img_mgmt_translate_error_code,
+#endif
+};
+
+static void img_mgmt_register_group(void)
+{
+	mgmt_register_group(&img_mgmt_group);
+}
 
 MCUMGR_HANDLER_DEFINE(img_mgmt, img_mgmt_register_group);

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -674,6 +674,32 @@ fail:
 }
 #endif
 
+#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
+/*
+ * @brief	Translate OS mgmt group error code into MCUmgr error code
+ *
+ * @param ret	#os_mgmt_ret_code_t error code
+ *
+ * @return	#mcumgr_err_t error code
+ */
+static int os_mgmt_translate_error_code(uint16_t ret)
+{
+	int rc;
+
+	switch (ret) {
+	case OS_MGMT_RET_RC_INVALID_FORMAT:
+	rc = MGMT_ERR_EINVAL;
+	break;
+
+	case OS_MGMT_RET_RC_UNKNOWN:
+	default:
+	rc = MGMT_ERR_EUNKNOWN;
+	}
+
+	return rc;
+}
+#endif
+
 static const struct mgmt_handler os_mgmt_group_handlers[] = {
 #ifdef CONFIG_MCUMGR_GRP_OS_ECHO
 	[OS_MGMT_ID_ECHO] = {
@@ -708,30 +734,14 @@ static struct mgmt_group os_mgmt_group = {
 	.mg_handlers = os_mgmt_group_handlers,
 	.mg_handlers_count = OS_MGMT_GROUP_SZ,
 	.mg_group_id = MGMT_GROUP_ID_OS,
+#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
+	.mg_translate_error = os_mgmt_translate_error_code,
+#endif
 };
 
 static void os_mgmt_register_group(void)
 {
 	mgmt_register_group(&os_mgmt_group);
 }
-
-#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
-int os_mgmt_translate_error_code(uint16_t ret)
-{
-	int rc;
-
-	switch (ret) {
-	case OS_MGMT_RET_RC_INVALID_FORMAT:
-	rc = MGMT_ERR_EINVAL;
-	break;
-
-	case OS_MGMT_RET_RC_UNKNOWN:
-	default:
-	rc = MGMT_ERR_EUNKNOWN;
-	}
-
-	return rc;
-}
-#endif
 
 MCUMGR_HANDLER_DEFINE(os_mgmt, os_mgmt_register_group);

--- a/subsys/mgmt/mcumgr/grp/shell_mgmt/src/shell_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/shell_mgmt/src/shell_mgmt.c
@@ -131,25 +131,15 @@ end:
 	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
 
-static struct mgmt_handler shell_mgmt_handlers[] = {
-	[SHELL_MGMT_ID_EXEC] = { NULL, shell_mgmt_exec },
-};
-
-#define SHELL_MGMT_HANDLER_CNT ARRAY_SIZE(shell_mgmt_handlers)
-
-static struct mgmt_group shell_mgmt_group = {
-	.mg_handlers = shell_mgmt_handlers,
-	.mg_handlers_count = SHELL_MGMT_HANDLER_CNT,
-	.mg_group_id = MGMT_GROUP_ID_SHELL,
-};
-
-static void shell_mgmt_register_group(void)
-{
-	mgmt_register_group(&shell_mgmt_group);
-}
-
 #ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
-int shell_mgmt_translate_error_code(uint16_t ret)
+/*
+ * @brief	Translate shell mgmt group error code into MCUmgr error code
+ *
+ * @param ret	#shell_mgmt_ret_code_t error code
+ *
+ * @return	#mcumgr_err_t error code
+ */
+static int shell_mgmt_translate_error_code(uint16_t ret)
 {
 	int rc;
 
@@ -166,5 +156,25 @@ int shell_mgmt_translate_error_code(uint16_t ret)
 	return rc;
 }
 #endif
+
+static struct mgmt_handler shell_mgmt_handlers[] = {
+	[SHELL_MGMT_ID_EXEC] = { NULL, shell_mgmt_exec },
+};
+
+#define SHELL_MGMT_HANDLER_CNT ARRAY_SIZE(shell_mgmt_handlers)
+
+static struct mgmt_group shell_mgmt_group = {
+	.mg_handlers = shell_mgmt_handlers,
+	.mg_handlers_count = SHELL_MGMT_HANDLER_CNT,
+	.mg_group_id = MGMT_GROUP_ID_SHELL,
+#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
+	.mg_translate_error = shell_mgmt_translate_error_code,
+#endif
+};
+
+static void shell_mgmt_register_group(void)
+{
+	mgmt_register_group(&shell_mgmt_group);
+}
 
 MCUMGR_HANDLER_DEFINE(shell_mgmt, shell_mgmt_register_group);

--- a/subsys/mgmt/mcumgr/grp/stat_mgmt/src/stat_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/stat_mgmt/src/stat_mgmt.c
@@ -239,26 +239,15 @@ stat_mgmt_list(struct smp_streamer *ctxt)
 	return 0;
 }
 
-static struct mgmt_handler stat_mgmt_handlers[] = {
-	[STAT_MGMT_ID_SHOW] = { stat_mgmt_show, NULL },
-	[STAT_MGMT_ID_LIST] = { stat_mgmt_list, NULL },
-};
-
-#define STAT_MGMT_HANDLER_CNT ARRAY_SIZE(stat_mgmt_handlers)
-
-static struct mgmt_group stat_mgmt_group = {
-	.mg_handlers = stat_mgmt_handlers,
-	.mg_handlers_count = STAT_MGMT_HANDLER_CNT,
-	.mg_group_id = MGMT_GROUP_ID_STAT,
-};
-
-static void stat_mgmt_register_group(void)
-{
-	mgmt_register_group(&stat_mgmt_group);
-}
-
 #ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
-int stat_mgmt_translate_error_code(uint16_t ret)
+/*
+ * @brief	Translate stat mgmt group error code into MCUmgr error code
+ *
+ * @param ret	#stat_mgmt_ret_code_t error code
+ *
+ * @return	#mcumgr_err_t error code
+ */
+static int stat_mgmt_translate_error_code(uint16_t ret)
 {
 	int rc;
 
@@ -280,5 +269,26 @@ int stat_mgmt_translate_error_code(uint16_t ret)
 	return rc;
 }
 #endif
+
+static struct mgmt_handler stat_mgmt_handlers[] = {
+	[STAT_MGMT_ID_SHOW] = { stat_mgmt_show, NULL },
+	[STAT_MGMT_ID_LIST] = { stat_mgmt_list, NULL },
+};
+
+#define STAT_MGMT_HANDLER_CNT ARRAY_SIZE(stat_mgmt_handlers)
+
+static struct mgmt_group stat_mgmt_group = {
+	.mg_handlers = stat_mgmt_handlers,
+	.mg_handlers_count = STAT_MGMT_HANDLER_CNT,
+	.mg_group_id = MGMT_GROUP_ID_STAT,
+#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
+	.mg_translate_error = stat_mgmt_translate_error_code,
+#endif
+};
+
+static void stat_mgmt_register_group(void)
+{
+	mgmt_register_group(&stat_mgmt_group);
+}
 
 MCUMGR_HANDLER_DEFINE(stat_mgmt, stat_mgmt_register_group);

--- a/subsys/mgmt/mcumgr/grp/zephyr_basic/src/basic_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/zephyr_basic/src/basic_mgmt.c
@@ -64,26 +64,15 @@ static int storage_erase_handler(struct smp_streamer *ctxt)
 	return MGMT_ERR_EOK;
 }
 
-static const struct mgmt_handler zephyr_mgmt_basic_handlers[] = {
-	[ZEPHYR_MGMT_GRP_BASIC_CMD_ERASE_STORAGE] = {
-		.mh_read  = NULL,
-		.mh_write = storage_erase_handler,
-	},
-};
-
-static struct mgmt_group zephyr_basic_mgmt_group = {
-	.mg_handlers = (struct mgmt_handler *)zephyr_mgmt_basic_handlers,
-	.mg_handlers_count = ARRAY_SIZE(zephyr_mgmt_basic_handlers),
-	.mg_group_id = (ZEPHYR_MGMT_GRP_BASIC),
-};
-
-static void zephyr_basic_mgmt_init(void)
-{
-	mgmt_register_group(&zephyr_basic_mgmt_group);
-}
-
 #ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
-int zephyr_basic_group_translate_error_code(uint16_t ret)
+/*
+ * @brief	Translate zephyr basic group error code into MCUmgr error code
+ *
+ * @param ret	#zephyr_basic_group_ret_code_t error code
+ *
+ * @return	#mcumgr_err_t error code
+ */
+static int zephyr_basic_group_translate_error_code(uint16_t ret)
 {
 	int rc;
 
@@ -104,5 +93,26 @@ int zephyr_basic_group_translate_error_code(uint16_t ret)
 	return rc;
 }
 #endif
+
+static const struct mgmt_handler zephyr_mgmt_basic_handlers[] = {
+	[ZEPHYR_MGMT_GRP_BASIC_CMD_ERASE_STORAGE] = {
+		.mh_read  = NULL,
+		.mh_write = storage_erase_handler,
+	},
+};
+
+static struct mgmt_group zephyr_basic_mgmt_group = {
+	.mg_handlers = (struct mgmt_handler *)zephyr_mgmt_basic_handlers,
+	.mg_handlers_count = ARRAY_SIZE(zephyr_mgmt_basic_handlers),
+	.mg_group_id = (ZEPHYR_MGMT_GRP_BASIC),
+#ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
+	.mg_translate_error = zephyr_basic_group_translate_error_code,
+#endif
+};
+
+static void zephyr_basic_mgmt_init(void)
+{
+	mgmt_register_group(&zephyr_basic_mgmt_group);
+}
 
 MCUMGR_HANDLER_DEFINE(zephyr_basic_mgmt, zephyr_basic_mgmt_init);

--- a/subsys/mgmt/mcumgr/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/mgmt/src/mgmt.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -67,6 +67,30 @@ mgmt_find_handler(uint16_t group_id, uint16_t command_id)
 
 	return &group->mg_handlers[command_id];
 }
+
+#if IS_ENABLED(CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL)
+smp_translate_error_fn mgmt_find_error_translation_function(uint16_t group_id)
+{
+	struct mgmt_group *group = NULL;
+	sys_snode_t *snp, *sns;
+
+	/* Find the group with the specified group ID. */
+	SYS_SLIST_FOR_EACH_NODE_SAFE(&mgmt_group_list, snp, sns) {
+		struct mgmt_group *loop_group =
+			CONTAINER_OF(snp, struct mgmt_group, node);
+		if (loop_group->mg_group_id == group_id) {
+			group = loop_group;
+			break;
+		}
+	}
+
+	if (group == NULL) {
+		return NULL;
+	}
+
+	return group->mg_translate_error;
+}
+#endif
 
 void
 mgmt_register_group(struct mgmt_group *group)

--- a/subsys/mgmt/mcumgr/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/smp/src/smp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,62 +25,26 @@
 #include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
 #endif
 
-#ifdef CONFIG_MCUMGR_GRP_FS
-#include <zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h>
-#endif
-#ifdef CONFIG_MCUMGR_GRP_IMG
-#include <zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h>
-#endif
-#ifdef CONFIG_MCUMGR_GRP_OS
-#include <zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h>
-#endif
-#ifdef CONFIG_MCUMGR_GRP_SHELL
-#include <zephyr/mgmt/mcumgr/grp/shell_mgmt/shell_mgmt.h>
-#endif
-#ifdef CONFIG_MCUMGR_GRP_STAT
-#include <zephyr/mgmt/mcumgr/grp/stat_mgmt/stat_mgmt.h>
-#endif
-#ifdef CONFIG_MCUMGR_GRP_ZBASIC
-#include <zephyr/mgmt/mcumgr/grp/zephyr/zephyr_basic.h>
-#endif
-
 #ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
+/*
+ * @brief	Translate SMP version 2 error code to legacy SMP version 1 MCUmgr error code.
+ *
+ * @param group	#mcumgr_group_t group ID
+ * @param ret	Group-specific error code
+ *
+ * @return	#mcumgr_err_t error code
+ */
 static int smp_translate_error_code(uint16_t group, uint16_t ret)
 {
-	switch (group) {
-#ifdef CONFIG_MCUMGR_GRP_OS
-	case MGMT_GROUP_ID_OS:
-	return os_mgmt_translate_error_code(ret);
-#endif
+	smp_translate_error_fn translate_error_function = NULL;
 
-#ifdef CONFIG_MCUMGR_GRP_IMG
-	case MGMT_GROUP_ID_IMAGE:
-	return img_mgmt_translate_error_code(ret);
-#endif
+	translate_error_function = mgmt_find_error_translation_function(group);
 
-#ifdef CONFIG_MCUMGR_GRP_STAT
-	case MGMT_GROUP_ID_STAT:
-	return stat_mgmt_translate_error_code(ret);
-#endif
-
-#ifdef CONFIG_MCUMGR_GRP_FS
-	case MGMT_GROUP_ID_FS:
-	return fs_mgmt_translate_error_code(ret);
-#endif
-
-#ifdef CONFIG_MCUMGR_GRP_SHELL
-	case MGMT_GROUP_ID_SHELL:
-	return shell_mgmt_translate_error_code(ret);
-#endif
-
-#ifdef CONFIG_MCUMGR_GRP_ZBASIC
-	case ZEPHYR_MGMT_GRP_BASIC:
-	return zephyr_basic_group_translate_error_code(ret);
-#endif
-
-	default:
-	return MGMT_ERR_EUNKNOWN;
+	if (translate_error_function == NULL) {
+		return MGMT_ERR_EUNKNOWN;
 	}
+
+	return translate_error_function(ret);
 }
 #endif
 


### PR DESCRIPTION
Replaces the manual lookup function with a lookup function which is provided when registering MCUmgr handlers which can be used to find the function to translate error codes, allowing out of tree MCUmgr handlers to provide error translation handlers.

Fixes #59343

- [x] Code
- [x] Release notes
- [ ] ~~Documentation update~~ *will do as part of #59492*