### PR TITLE
cache: Add note about buffer alignment and size

### DIFF
--- a/include/zephyr/arch/cache.h
+++ b/include/zephyr/arch/cache.h
@@ -89,6 +89,13 @@ extern int arch_dcache_flush_and_invd_all(void);
  *
  * Flush the specified address range of the data cache.
  *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being flushed, all the portions of the
+ *       data structures sharing the same line will be flushed. This is usually
+ *       not a problem because writing back is a non-destructive process that
+ *       could be triggered by hardware at any time, so having an aligned
+ *       @p addr or a padded @p size is not strictly necessary.
+ *
  * @param addr Starting address to flush.
  * @param size Range size.
  *
@@ -105,6 +112,14 @@ extern int arch_dcache_flush_range(void *addr, size_t size);
  *
  * Invalidate the specified address range of the data cache.
  *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being invalidated, all the portions of the
+ *       non-read-only data structures sharing the same line will be
+ *       invalidated as well. This is a destructive process that could lead to
+ *       data loss and/or corruption. When @p addr is not aligned to the cache
+ *       line and/or @p size is not a multiple of the cache line size the
+ *       behaviour is undefined.
+ *
  * @param addr Starting address to invalidate.
  * @param size Range size.
  *
@@ -120,6 +135,14 @@ extern int arch_dcache_invd_range(void *addr, size_t size);
  * @brief Flush and Invalidate an address range in the d-cache
  *
  * Flush and Invalidate the specified address range of the data cache.
+ *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being flushed, all the portions of the
+ *       data structures sharing the same line will be flushed before being
+ *       invalidated. This is usually not a problem because writing back is a
+ *       non-destructive process that could be triggered by hardware at any
+ *       time, so having an aligned @p addr or a padded @p size is not strictly
+ *       necessary.
  *
  * @param addr Starting address to flush and invalidate.
  * @param size Range size.
@@ -221,6 +244,13 @@ extern int arch_icache_flush_and_invd_all(void);
  *
  * Flush the specified address range of the instruction cache.
  *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being flushed, all the portions of the
+ *       data structures sharing the same line will be flushed. This is usually
+ *       not a problem because writing back is a non-destructive process that
+ *       could be triggered by hardware at any time, so having an aligned
+ *       @p addr or a padded @p size is not strictly necessary.
+ *
  * @param addr Starting address to flush.
  * @param size Range size.
  *
@@ -237,6 +267,14 @@ extern int arch_icache_flush_range(void *addr, size_t size);
  *
  * Invalidate the specified address range of the instruction cache.
  *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being invalidated, all the portions of the
+ *       non-read-only data structures sharing the same line will be
+ *       invalidated as well. This is a destructive process that could lead to
+ *       data loss and/or corruption. When @p addr is not aligned to the cache
+ *       line and/or @p size is not a multiple of the cache line size the
+ *       behaviour is undefined.
+ *
  * @param addr Starting address to invalidate.
  * @param size Range size.
  *
@@ -252,6 +290,14 @@ extern int arch_icache_invd_range(void *addr, size_t size);
  * @brief Flush and Invalidate an address range in the i-cache
  *
  * Flush and Invalidate the specified address range of the instruction cache.
+ *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being flushed, all the portions of the
+ *       data structures sharing the same line will be flushed before being
+ *       invalidated. This is usually not a problem because writing back is a
+ *       non-destructive process that could be triggered by hardware at any
+ *       time, so having an aligned @p addr or a padded @p size is not strictly
+ *       necessary.
  *
  * @param addr Starting address to flush and invalidate.
  * @param size Range size.

--- a/include/zephyr/cache.h
+++ b/include/zephyr/cache.h
@@ -202,6 +202,13 @@ static ALWAYS_INLINE int sys_cache_instr_flush_and_invd_all(void)
  *
  * Flush the specified address range of the data cache.
  *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being flushed, all the portions of the
+ *       data structures sharing the same line will be flushed. This is usually
+ *       not a problem because writing back is a non-destructive process that
+ *       could be triggered by hardware at any time, so having an aligned
+ *       @p addr or a padded @p size is not strictly necessary.
+ *
  * @param addr Starting address to flush.
  * @param size Range size.
  *
@@ -227,6 +234,13 @@ static ALWAYS_INLINE int z_impl_sys_cache_data_flush_range(void *addr, size_t si
  *
  * Flush the specified address range of the instruction cache.
  *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being flushed, all the portions of the
+ *       data structures sharing the same line will be flushed. This is usually
+ *       not a problem because writing back is a non-destructive process that
+ *       could be triggered by hardware at any time, so having an aligned
+ *       @p addr or a padded @p size is not strictly necessary.
+ *
  * @param addr Starting address to flush.
  * @param size Range size.
  *
@@ -249,6 +263,14 @@ static ALWAYS_INLINE int sys_cache_instr_flush_range(void *addr, size_t size)
  * @brief Invalidate an address range in the d-cache
  *
  * Invalidate the specified address range of the data cache.
+ *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being invalidated, all the portions of the
+ *       non-read-only data structures sharing the same line will be
+ *       invalidated as well. This is a destructive process that could lead to
+ *       data loss and/or corruption. When @p addr is not aligned to the cache
+ *       line and/or @p size is not a multiple of the cache line size the
+ *       behaviour is undefined.
  *
  * @param addr Starting address to invalidate.
  * @param size Range size.
@@ -275,6 +297,14 @@ static ALWAYS_INLINE int z_impl_sys_cache_data_invd_range(void *addr, size_t siz
  *
  * Invalidate the specified address range of the instruction cache.
  *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being invalidated, all the portions of the
+ *       non-read-only data structures sharing the same line will be
+ *       invalidated as well. This is a destructive process that could lead to
+ *       data loss and/or corruption. When @p addr is not aligned to the cache
+ *       line and/or @p size is not a multiple of the cache line size the
+ *       behaviour is undefined.
+ *
  * @param addr Starting address to invalidate.
  * @param size Range size.
  *
@@ -297,6 +327,14 @@ static ALWAYS_INLINE int sys_cache_instr_invd_range(void *addr, size_t size)
  * @brief Flush and Invalidate an address range in the d-cache
  *
  * Flush and Invalidate the specified address range of the data cache.
+ *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being flushed, all the portions of the
+ *       data structures sharing the same line will be flushed before being
+ *       invalidated. This is usually not a problem because writing back is a
+ *       non-destructive process that could be triggered by hardware at any
+ *       time, so having an aligned @p addr or a padded @p size is not strictly
+ *       necessary.
  *
  * @param addr Starting address to flush and invalidate.
  * @param size Range size.
@@ -322,6 +360,14 @@ static ALWAYS_INLINE int z_impl_sys_cache_data_flush_and_invd_range(void *addr, 
  * @brief Flush and Invalidate an address range in the i-cache
  *
  * Flush and Invalidate the specified address range of the instruction cache.
+ *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being flushed, all the portions of the
+ *       data structures sharing the same line will be flushed before being
+ *       invalidated. This is usually not a problem because writing back is a
+ *       non-destructive process that could be triggered by hardware at any
+ *       time, so having an aligned @p addr or a padded @p size is not strictly
+ *       necessary.
  *
  * @param addr Starting address to flush and invalidate.
  * @param size Range size.

--- a/include/zephyr/drivers/cache.h
+++ b/include/zephyr/drivers/cache.h
@@ -79,6 +79,13 @@ int cache_data_flush_and_invd_all(void);
  *
  * Flush the specified address range of the data cache.
  *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being flushed, all the portions of the
+ *       data structures sharing the same line will be flushed. This is usually
+ *       not a problem because writing back is a non-destructive process that
+ *       could be triggered by hardware at any time, so having an aligned
+ *       @p addr or a padded @p size is not strictly necessary.
+ *
  * @param addr Starting address to flush.
  * @param size Range size.
  *
@@ -93,6 +100,14 @@ int cache_data_flush_range(void *addr, size_t size);
  *
  * Invalidate the specified address range of the data cache.
  *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being invalidated, all the portions of the
+ *       non-read-only data structures sharing the same line will be
+ *       invalidated as well. This is a destructive process that could lead to
+ *       data loss and/or corruption. When @p addr is not aligned to the cache
+ *       line and/or @p size is not a multiple of the cache line size the
+ *       behaviour is undefined.
+ *
  * @param addr Starting address to invalidate.
  * @param size Range size.
  *
@@ -106,6 +121,14 @@ int cache_data_invd_range(void *addr, size_t size);
  * @brief Flush and Invalidate an address range in the d-cache
  *
  * Flush and Invalidate the specified address range of the data cache.
+ *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being flushed, all the portions of the
+ *       data structures sharing the same line will be flushed before being
+ *       invalidated. This is usually not a problem because writing back is a
+ *       non-destructive process that could be triggered by hardware at any
+ *       time, so having an aligned @p addr or a padded @p size is not strictly
+ *       necessary.
  *
  * @param addr Starting address to flush and invalidate.
  * @param size Range size.
@@ -190,6 +213,13 @@ int cache_instr_flush_and_invd_all(void);
  *
  * Flush the specified address range of the instruction cache.
  *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being flushed, all the portions of the
+ *       data structures sharing the same line will be flushed. This is usually
+ *       not a problem because writing back is a non-destructive process that
+ *       could be triggered by hardware at any time, so having an aligned
+ *       @p addr or a padded @p size is not strictly necessary.
+ *
  * @param addr Starting address to flush.
  * @param size Range size.
  *
@@ -204,6 +234,14 @@ int cache_instr_flush_range(void *addr, size_t size);
  *
  * Invalidate the specified address range of the instruction cache.
  *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being invalidated, all the portions of the
+ *       non-read-only data structures sharing the same line will be
+ *       invalidated as well. This is a destructive process that could lead to
+ *       data loss and/or corruption. When @p addr is not aligned to the cache
+ *       line and/or @p size is not a multiple of the cache line size the
+ *       behaviour is undefined.
+ *
  * @param addr Starting address to invalidate.
  * @param size Range size.
  *
@@ -217,6 +255,14 @@ int cache_instr_invd_range(void *addr, size_t size);
  * @brief Flush and Invalidate an address range in the i-cache
  *
  * Flush and Invalidate the specified address range of the instruction cache.
+ *
+ * @note the cache operations act on cache line. When multiple data structures
+ *       share the same cache line being flushed, all the portions of the
+ *       data structures sharing the same line will be flushed before being
+ *       invalidated. This is usually not a problem because writing back is a
+ *       non-destructive process that could be triggered by hardware at any
+ *       time, so having an aligned @p addr or a padded @p size is not strictly
+ *       necessary.
  *
  * @param addr Starting address to flush and invalidate.
  * @param size Range size.


### PR DESCRIPTION
Cache operations that act on unaligned buffers (with respect to cache line) or buffers that are not multiple of the cache line size are at least dangerous with an high risk of data and memory corruption.

While we do not enforce a contract on the buffer characteristics between users and APIs, we can at least add a note in the documentation specifying an undefined behaviour when the passed buffer is unaligned or wrongly sized.