### PR TITLE
net: lwm2m: Update next event timestamp on PMAX change

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_observation.c
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.c
@@ -913,7 +913,7 @@ static int lwm2m_engine_observer_timestamp_update(sys_slist_t *observer,
 
 	/* update observe_node accordingly */
 	SYS_SLIST_FOR_EACH_CONTAINER(observer, obs, node) {
-		if (!obs->resource_update) {
+		if (obs->resource_update) {
 			/* Resource Update on going skip this*/
 			continue;
 		}


### PR DESCRIPTION
When PMAX value is changed, it should update all events. I believe there is a bug that caused the code only to update events that are ongoing (to be send).

Now if PMAX changes, next event timestamp is recalculated.

Fixes #59397

Verified the functionality with Wireshark:
![image](https://github.com/zephyrproject-rtos/zephyr/assets/3104794/b3efd923-c616-414e-87d7-6c113c7a1cee)
On the screencap: PMAX was 300 and observation was scheduled earlier. Changing the PMAX caused Notify on 60 second mark from observation (reference time).