### PR TITLE
Bluetooth: CAP: Shell: Handle -ECANCELED error code specifically

### DIFF
--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -36,9 +36,10 @@ static void cap_discover_cb(struct bt_conn *conn, int err,
 static void cap_unicast_start_complete_cb(struct bt_bap_unicast_group *unicast_group,
 					  int err, struct bt_conn *conn)
 {
-	if (err != 0) {
-		shell_error(ctx_shell, "Unicast start failed for conn %p (%d)",
-			    conn, err);
+	if (err == -ECANCELED) {
+		shell_print(ctx_shell, "Unicast start was cancelled for conn %p", conn);
+	} else if (err != 0) {
+		shell_error(ctx_shell, "Unicast start failed for conn %p (%d)", conn, err);
 	} else {
 		shell_print(ctx_shell, "Unicast start completed");
 	}
@@ -46,7 +47,9 @@ static void cap_unicast_start_complete_cb(struct bt_bap_unicast_group *unicast_g
 
 static void unicast_update_complete_cb(int err, struct bt_conn *conn)
 {
-	if (err != 0) {
+	if (err == -ECANCELED) {
+		shell_print(ctx_shell, "Unicast update was cancelled for conn %p", conn);
+	} else if (err != 0) {
 		shell_error(ctx_shell, "Unicast update failed for conn %p (%d)",
 			    conn, err);
 	} else {
@@ -62,7 +65,9 @@ static void unicast_stop_complete_cb(struct bt_bap_unicast_group *unicast_group,
 		return;
 	}
 
-	if (err != 0) {
+	if (err == -ECANCELED) {
+		shell_print(ctx_shell, "Unicast stop was cancelled for conn %p", conn);
+	} else if (err != 0) {
 		shell_error(ctx_shell,
 			    "Unicast stop failed for group %p and conn %p (%d)",
 			    unicast_group, conn, err);


### PR DESCRIPTION
If the procedure was called, we print a more specific string to let the user know that there was not an actual issue.