### PR TITLE
shell: make ascii filtering optional

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -104,6 +104,14 @@ config SHELL_TAB_AUTOCOMPLETION
 	  Enable commands and subcommands autocompletion with the Tab
 	  key. This function can be deactivated to save some flash.
 
+config SHELL_ASCII_FILTER
+	bool "Filter incoming ASCII characters"
+	default y
+	help
+	  Shell will not collect characters that are not in
+	  ASCII range: <0, 127>. As a result filtered characters will not be
+	  printed on the terminal and passed to the command handler.
+
 config SHELL_WILDCARD
 	bool "Wildcard support in shell"
 	select FNMATCH

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -952,7 +952,11 @@ static bool process_nl(const struct shell *sh, uint8_t data)
 #define SHELL_ASCII_MAX_CHAR (127u)
 static inline int ascii_filter(const char data)
 {
-	return (uint8_t) data > SHELL_ASCII_MAX_CHAR ? -EINVAL : 0;
+	if (IS_ENABLED(CONFIG_SHELL_ASCII_FILTER)) {
+		return (uint8_t) data > SHELL_ASCII_MAX_CHAR ? -EINVAL : 0;
+	} else {
+		return 0;
+	}
 }
 
 static void state_collect(const struct shell *sh)


### PR DESCRIPTION
Added configuration parameter to toggle shell ascii filtering feature.

Fixes #59048