### PR TITLE
Bluetooth: BAP: Shell: Fix endianess of broadcast_id in adv data

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2622,9 +2622,7 @@ static ssize_t nonconnectable_ad_data_add(struct bt_data *data_array,
 			return -1;
 		}
 
-		ad_bap_broadcast_announcement[2] = (uint8_t)(broadcast_id >> 16);
-		ad_bap_broadcast_announcement[3] = (uint8_t)(broadcast_id >> 8);
-		ad_bap_broadcast_announcement[4] = (uint8_t)(broadcast_id >> 0);
+		sys_put_le24(broadcast_id, &ad_bap_broadcast_announcement[2]);
 		data_array[ad_len].type = BT_DATA_SVC_DATA16;
 		data_array[ad_len].data_len = ARRAY_SIZE(ad_bap_broadcast_announcement);
 		data_array[ad_len].data = ad_bap_broadcast_announcement;


### PR DESCRIPTION
The broadcast ID was encoded as big instead of little endian in the advertising data.