### PR TITLE
Bluetooth: BAP: Shell: Remove duplicate increment of seq_num

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -322,7 +322,6 @@ static void lc3_audio_send_data(struct k_work *work)
 				lc3_sdu_cnt, tx_sdu_len);
 	}
 	lc3_sdu_cnt++;
-	seq_num++;
 }
 
 static K_WORK_DEFINE(audio_send_work, lc3_audio_send_data);


### PR DESCRIPTION
The seq_num in lc3_audio_send_data was updated twice: Once when calling get_next_seq_num and once at the end of the function.

This increased the sequence numbers too fast, and made TX not worker properly.

Modified to only use get_next_seq_num.