### PR TITLE
subsys: modbus: support emulated 7E1 UART

### DIFF
--- a/subsys/modbus/Kconfig
+++ b/subsys/modbus/Kconfig
@@ -53,6 +53,12 @@ config MODBUS_ASCII_MODE
 	help
 	  Enable ASCII transmission mode.
 
+config MODBUS_EMULATED_7E1
+	depends on MODBUS_ASCII_MODE
+	bool "Emulate UART 7E1 using software"
+	help
+	  For use with UARTs that do not support 7 data bits.
+
 config MODBUS_RAW_ADU
 	bool "Modbus raw ADU support"
 	help


### PR DESCRIPTION
ASCII Modbus requires 7 stop bits, even parity, but this mode is not supported on all UARTs. This patch implements 7E1 by configuring the UART for 8N1 and then manually masking in the parity bit.