### PR TITLE
dmic: Allow use of reserved bits in CIC_CONTROL register

### DIFF
--- a/drivers/dai/intel/dmic/dmic_nhlt.c
+++ b/drivers/dai/intel/dmic/dmic_nhlt.c
@@ -474,9 +474,8 @@ int dai_dmic_set_config_nhlt(struct dai_intel_dmic *dmic, const void *bespoke_cf
 				;
 			LOG_DBG("  stereo_mode=%d", bf7);
 			if (ref != val) {
-				LOG_ERR("dmic_set_config_nhlt(): illegal CIC_CONTROL = 0x%08x",
+				LOG_WRN("dmic_set_config_nhlt(): illegal CIC_CONTROL = 0x%08x",
 					val);
-				return -EINVAL;
 			}
 
 			/* Clear CIC_START_A and CIC_START_B */


### PR DESCRIPTION
Since the mtl platform, the stereo bit has been removed from the CIC_CONTROL register and now it is marked as resered. On some platforms (mtl and above), the configuration blob still has this bit set, causing the dmic driver to report an error. This commit changes the behavior of the driver to only display a warning.