### PR TITLE
ztest: Allow 'before' functions to run in privilaged mode

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
@@ -236,6 +236,32 @@ extern struct ztest_suite_node _ztest_suite_node_list_end[];
 void ztest_run_all(const void *state);
 
 /**
+ * The result of the current running test. It's possible that the setup function sets the result
+ * to ZTEST_RESULT_SUITE_* which will apply the failure/skip to every test in the suite.
+ */
+enum ztest_result {
+	ZTEST_RESULT_PENDING,
+	ZTEST_RESULT_PASS,
+	ZTEST_RESULT_FAIL,
+	ZTEST_RESULT_SKIP,
+	ZTEST_RESULT_SUITE_SKIP,
+	ZTEST_RESULT_SUITE_FAIL,
+};
+/**
+ * Each enum member represents a distinct phase of execution for the test binary.
+ * TEST_PHASE_FRAMEWORK is active when internal ztest code is executing; the rest refer to
+ * corresponding phases of user test code.
+ */
+enum ztest_phase {
+	TEST_PHASE_SETUP,
+	TEST_PHASE_BEFORE,
+	TEST_PHASE_TEST,
+	TEST_PHASE_AFTER,
+	TEST_PHASE_TEARDOWN,
+	TEST_PHASE_FRAMEWORK,
+};
+
+/**
  * Run the registered unit tests which return true from their predicate function.
  *
  * @param state The current state of the machine as it relates to the test executable.
@@ -251,6 +277,26 @@ static inline int ztest_run_test_suites(const void *state)
 
 #else
 __syscall int ztest_run_test_suites(const void *state);
+#endif
+
+#ifdef ZTEST_UNITTEST
+void z_impl___ztest_set_test_result(enum ztest_result new_result);
+static inline void __ztest_set_test_result(enum ztest_result new_result)
+{
+	z_impl___ztest_set_test_result(new_result);
+}
+
+void z_impl___ztest_set_test_phase(enum ztest_phase new_phase);
+static inline void __ztest_set_test_phase(enum ztest_phase new_phase)
+{
+	z_impl___ztest_set_test_phase(new_phase);
+}
+#else
+__syscall void __ztest_set_test_result(enum ztest_result new_result);
+__syscall void __ztest_set_test_phase(enum ztest_phase new_phase);
+#endif
+
+#ifndef ZTEST_UNITTEST
 #include <syscalls/ztest_test_new.h>
 #endif
 

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -33,21 +33,6 @@ static bool failed_expectation;
 /* ZTEST_DMEM and ZTEST_BMEM are used for the application shared memory test  */
 
 /**
- * @brief Each enum member represents a distinct phase of execution for the
- *        test binary. TEST_PHASE_FRAMEWORK is active when internal ztest code
- *        is executing; the rest refer to corresponding phases of user test
- *        code.
- */
-enum ztest_phase {
-	TEST_PHASE_SETUP,
-	TEST_PHASE_BEFORE,
-	TEST_PHASE_TEST,
-	TEST_PHASE_AFTER,
-	TEST_PHASE_TEARDOWN,
-	TEST_PHASE_FRAMEWORK
-};
-
-/**
  * @brief The current status of the test binary
  */
 enum ztest_status {
@@ -222,18 +207,10 @@ __maybe_unused static void run_test_rules(bool is_before, struct ztest_unit_test
 static void run_test_functions(struct ztest_suite_node *suite, struct ztest_unit_test *test,
 			       void *data)
 {
-	phase = TEST_PHASE_TEST;
+	__ztest_set_test_phase(TEST_PHASE_TEST);
 	test->test(data);
 }
 
-enum ztest_result {
-	ZTEST_RESULT_PENDING,
-	ZTEST_RESULT_PASS,
-	ZTEST_RESULT_FAIL,
-	ZTEST_RESULT_SKIP,
-	ZTEST_RESULT_SUITE_SKIP,
-	ZTEST_RESULT_SUITE_FAIL,
-};
 COND_CODE_1(KERNEL, (ZTEST_BMEM), ()) static enum ztest_result test_result;
 
 static int get_final_test_result(const struct ztest_unit_test *test, int ret)
@@ -393,7 +370,7 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 	int ret = TC_PASS;
 
 	TC_START(test->name);
-	phase = TEST_PHASE_BEFORE;
+	__ztest_set_test_phase(TEST_PHASE_BEFORE);
 
 	if (test_result == ZTEST_RESULT_SUITE_FAIL) {
 		ret = TC_FAIL;
@@ -426,14 +403,14 @@ out:
 		ret = TC_FAIL;
 	}
 
-	phase = TEST_PHASE_AFTER;
+	__ztest_set_test_phase(TEST_PHASE_AFTER);
 	if (test_result != ZTEST_RESULT_SUITE_FAIL) {
 		if (suite->after != NULL) {
 			suite->after(data);
 		}
 		run_test_rules(/*is_before=*/false, test, data);
 	}
-	phase = TEST_PHASE_FRAMEWORK;
+	__ztest_set_test_phase(TEST_PHASE_FRAMEWORK);
 	ret |= cleanup_test(test);
 
 	ret = get_final_test_result(test, ret);
@@ -470,11 +447,11 @@ void ztest_test_fail(void)
 {
 	switch (phase) {
 	case TEST_PHASE_SETUP:
-		test_result = ZTEST_RESULT_SUITE_FAIL;
+		__ztest_set_test_result(ZTEST_RESULT_SUITE_FAIL);
 		break;
 	case TEST_PHASE_BEFORE:
 	case TEST_PHASE_TEST:
-		test_result = ZTEST_RESULT_FAIL;
+		__ztest_set_test_result(ZTEST_RESULT_FAIL);
 		test_finalize();
 		break;
 	default:
@@ -489,7 +466,7 @@ void ztest_test_pass(void)
 {
 	switch (phase) {
 	case TEST_PHASE_TEST:
-		test_result = ZTEST_RESULT_PASS;
+		__ztest_set_test_result(ZTEST_RESULT_PASS);
 		test_finalize();
 		break;
 	default:
@@ -506,11 +483,11 @@ void ztest_test_skip(void)
 {
 	switch (phase) {
 	case TEST_PHASE_SETUP:
-		test_result = ZTEST_RESULT_SUITE_SKIP;
+		__ztest_set_test_result(ZTEST_RESULT_SUITE_SKIP);
 		break;
 	case TEST_PHASE_BEFORE:
 	case TEST_PHASE_TEST:
-		test_result = ZTEST_RESULT_SKIP;
+		__ztest_set_test_result(ZTEST_RESULT_SKIP);
 		test_finalize();
 		break;
 	default:
@@ -542,14 +519,20 @@ static void test_cb(void *a, void *b, void *c)
 {
 	struct ztest_suite_node *suite = a;
 	struct ztest_unit_test *test = b;
+	const bool config_user_mode = FIELD_GET(K_USER, test->thread_options) != 0;
 
-	test_result = ZTEST_RESULT_PENDING;
-	run_test_rules(/*is_before=*/true, test, /*data=*/c);
-	if (suite->before) {
-		suite->before(/*data=*/c);
+	if (!IS_ENABLED(CONFIG_USERSPACE) || !k_is_user_context()) {
+		__ztest_set_test_result(ZTEST_RESULT_PENDING);
+		run_test_rules(/*is_before=*/true, test, /*data=*/c);
+		if (suite->before) {
+			suite->before(/*data=*/c);
+		}
+		if (IS_ENABLED(CONFIG_USERSPACE) && config_user_mode) {
+			k_thread_user_mode_enter(test_cb, a, b, c);
+		}
 	}
 	run_test_functions(suite, test, c);
-	test_result = ZTEST_RESULT_PASS;
+	__ztest_set_test_result(ZTEST_RESULT_PASS);
 }
 
 static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test, void *data)
@@ -561,7 +544,7 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 #endif
 	TC_START(test->name);
 
-	phase = TEST_PHASE_BEFORE;
+	__ztest_set_test_phase(TEST_PHASE_BEFORE);
 
 	/* If the suite's setup function marked us as skipped, don't bother
 	 * running the tests.
@@ -572,7 +555,7 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 				K_THREAD_STACK_SIZEOF(ztest_thread_stack),
 				(k_thread_entry_t)test_cb, suite, test, data,
 				CONFIG_ZTEST_THREAD_PRIORITY,
-				test->thread_options | K_INHERIT_PERMS, K_FOREVER);
+				K_INHERIT_PERMS, K_FOREVER);
 
 		k_thread_access_grant(&ztest_thread, suite, test, suite->stats);
 		if (test->name != NULL) {
@@ -586,7 +569,7 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 		}
 	} else if (test_result != ZTEST_RESULT_SUITE_SKIP &&
 		   test_result != ZTEST_RESULT_SUITE_FAIL) {
-		test_result = ZTEST_RESULT_PENDING;
+		__ztest_set_test_result(ZTEST_RESULT_PENDING);
 		get_start_time_cyc();
 		run_test_rules(/*is_before=*/true, test, data);
 		if (suite->before) {
@@ -595,7 +578,7 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 		run_test_functions(suite, test, data);
 	}
 
-	phase = TEST_PHASE_AFTER;
+	__ztest_set_test_phase(TEST_PHASE_AFTER);
 	if (suite->after != NULL) {
 		suite->after(data);
 	}
@@ -606,7 +589,7 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 		test->stats->duration_worst_ms = tc_spend_time;
 	}
 
-	phase = TEST_PHASE_FRAMEWORK;
+	__ztest_set_test_phase(TEST_PHASE_FRAMEWORK);
 
 	/* Flush all logs in case deferred mode and default logging thread are used. */
 	while (IS_ENABLED(CONFIG_TEST_LOGGING_FLUSH_AFTER_TEST) &&
@@ -714,11 +697,11 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite)
 
 	TC_SUITE_START(suite->name);
 	current_test_failed_assumption = false;
-	test_result = ZTEST_RESULT_PENDING;
-	phase = TEST_PHASE_SETUP;
+	__ztest_set_test_result(ZTEST_RESULT_PENDING);
+	__ztest_set_test_phase(TEST_PHASE_SETUP);
 #ifndef KERNEL
 	if (setjmp(test_suite_fail)) {
-		test_result = ZTEST_RESULT_SUITE_FAIL;
+		__ztest_set_test_result(ZTEST_RESULT_SUITE_FAIL);
 	}
 #endif
 	if (test_result != ZTEST_RESULT_SUITE_FAIL && suite->setup != NULL) {
@@ -789,7 +772,7 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite)
 	}
 
 	TC_SUITE_END(suite->name, (fail > 0 ? TC_FAIL : TC_PASS));
-	phase = TEST_PHASE_TEARDOWN;
+	__ztest_set_test_phase(TEST_PHASE_TEARDOWN);
 	if (suite->teardown != NULL) {
 		suite->teardown(data);
 	}
@@ -1001,6 +984,30 @@ int z_impl_ztest_run_test_suites(const void *state)
 
 	return count;
 }
+
+void z_impl___ztest_set_test_result(enum ztest_result new_result)
+{
+	test_result = new_result;
+}
+
+void z_impl___ztest_set_test_phase(enum ztest_phase new_phase)
+{
+	phase = new_phase;
+}
+
+#ifdef CONFIG_USERSPACE
+void z_vrfy___ztest_set_test_result(enum ztest_result new_result)
+{
+	z_impl___ztest_set_test_result(new_result);
+}
+#include <syscalls/__ztest_set_test_result_mrsh.c>
+
+void z_vrfy___ztest_set_test_phase(enum ztest_phase new_phase)
+{
+	z_impl___ztest_set_test_phase(new_phase);
+}
+#include <syscalls/__ztest_set_test_phase_mrsh.c>
+#endif /* CONFIG_USERSPACE */
 
 void ztest_verify_all_test_suites_ran(void)
 {

--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -221,7 +221,7 @@ RTIO_BMEM uint8_t syscall_bufs[4];
 RTIO_DEFINE(r_syscall, SQE_POOL_SIZE, CQE_POOL_SIZE);
 RTIO_IODEV_TEST_DEFINE(iodev_test_syscall);
 
-void rtio_syscall_test(void *p1, void *p2, void *p3)
+ZTEST_USER(rtio_api, test_rtio_syscalls)
 {
 	int res;
 	struct rtio_sqe sqe = {0};
@@ -250,24 +250,6 @@ void rtio_syscall_test(void *p1, void *p2, void *p3)
 				  "Expected in order completions");
 	}
 }
-
-#ifdef CONFIG_USERSPACE
-ZTEST(rtio_api, test_rtio_syscalls_usermode)
-{
-
-	TC_PRINT("syscalls from user mode test\n");
-	TC_PRINT("test iodev init\n");
-	rtio_iodev_test_init(&iodev_test_syscall);
-	TC_PRINT("mem domain add current\n");
-	k_mem_domain_add_thread(&rtio_domain, k_current_get());
-	TC_PRINT("rtio access grant\n");
-	rtio_access_grant(&r_syscall, k_current_get());
-	TC_PRINT("rtio iodev access grant, ptr %p\n", &iodev_test_syscall);
-	k_object_access_grant(&iodev_test_syscall, k_current_get());
-	TC_PRINT("user mode enter\n");
-	k_thread_user_mode_enter(rtio_syscall_test, NULL, NULL, NULL);
-}
-#endif /* CONFIG_USERSPACE */
 
 RTIO_BMEM uint8_t mempool_data[MEM_BLK_SIZE];
 
@@ -311,30 +293,11 @@ static void test_rtio_simple_mempool_(struct rtio *r, int run_count)
 	rtio_release_buffer(r, buffer, buffer_len);
 }
 
-static void rtio_simple_mempool_test(void *a, void *b, void *c)
+ZTEST_USER(rtio_api, test_rtio_simple_mempool)
 {
-	ARG_UNUSED(a);
-	ARG_UNUSED(b);
-	ARG_UNUSED(c);
-
-	TC_PRINT("rtio simple mempool from thread %p\n", k_current_get());
 	for (int i = 0; i < TEST_REPEATS * 2; i++) {
 		test_rtio_simple_mempool_(&r_simple, i);
 	}
-
-}
-
-ZTEST(rtio_api, test_rtio_simple_mempool)
-{
-	rtio_iodev_test_init(&iodev_test_simple);
-#ifdef CONFIG_USERSPACE
-	k_mem_domain_add_thread(&rtio_domain, k_current_get());
-	rtio_access_grant(&r_simple, k_current_get());
-	k_object_access_grant(&iodev_test_simple, k_current_get());
-	k_thread_user_mode_enter(rtio_simple_mempool_test, NULL, NULL, NULL);
-#else
-	rtio_simple_mempool_test(NULL, NULL, NULL);
-#endif
 }
 
 static void test_rtio_simple_cancel_(struct rtio *r)
@@ -365,28 +328,11 @@ static void test_rtio_simple_cancel_(struct rtio *r)
 	}
 }
 
-static void rtio_simple_cancel_test(void *a, void *b, void *c)
+ZTEST_USER(rtio_api, test_rtio_simple_cancel)
 {
-	ARG_UNUSED(a);
-	ARG_UNUSED(b);
-	ARG_UNUSED(c);
-
 	for (int i = 0; i < TEST_REPEATS; i++) {
 		test_rtio_simple_cancel_(&r_simple);
 	}
-}
-
-ZTEST(rtio_api, test_rtio_simple_cancel)
-{
-	rtio_iodev_test_init(&iodev_test_simple);
-#ifdef CONFIG_USERSPACE
-	k_mem_domain_add_thread(&rtio_domain, k_current_get());
-	rtio_access_grant(&r_simple, k_current_get());
-	k_object_access_grant(&iodev_test_simple, k_current_get());
-	k_thread_user_mode_enter(rtio_simple_cancel_test, NULL, NULL, NULL);
-#else
-	rtio_simple_cancel_test(NULL, NULL, NULL);
-#endif
 }
 
 static void test_rtio_chain_cancel_(struct rtio *r)
@@ -396,14 +342,21 @@ static void test_rtio_chain_cancel_(struct rtio *r)
 	struct rtio_sqe *handle;
 
 	/* Prepare the chain */
+	TC_PRINT("1\n");
+	k_msleep(20);
 	rtio_sqe_prep_nop(&sqe[0], (struct rtio_iodev *)&iodev_test_simple, NULL);
 	rtio_sqe_prep_nop(&sqe[1], (struct rtio_iodev *)&iodev_test_simple, NULL);
 	sqe[0].flags |= RTIO_SQE_CHAINED;
 
 	/* Copy the chain */
+	TC_PRINT("2\n");
+	k_msleep(20);
 	rtio_sqe_copy_in_get_handles(r, sqe, &handle, 2);
+	TC_PRINT("3\n");
+	k_msleep(20);
 	rtio_sqe_cancel(handle);
 	TC_PRINT("Submitting 2 to RTIO\n");
+	k_msleep(20);
 	rtio_submit(r, 0);
 
 	/* Check that we don't get a CQE */
@@ -422,28 +375,13 @@ static void test_rtio_chain_cancel_(struct rtio *r)
 	}
 }
 
-static void rtio_chain_cancel_test(void *a, void *b, void *c)
+ZTEST_USER(rtio_api, test_rtio_chain_cancel)
 {
-	ARG_UNUSED(a);
-	ARG_UNUSED(b);
-	ARG_UNUSED(c);
-
+	TC_PRINT("start test\n");
+	k_msleep(20);
 	for (int i = 0; i < TEST_REPEATS; i++) {
 		test_rtio_chain_cancel_(&r_simple);
 	}
-}
-
-ZTEST(rtio_api, test_rtio_chain_cancel)
-{
-	rtio_iodev_test_init(&iodev_test_simple);
-#ifdef CONFIG_USERSPACE
-	k_mem_domain_add_thread(&rtio_domain, k_current_get());
-	rtio_access_grant(&r_simple, k_current_get());
-	k_object_access_grant(&iodev_test_simple, k_current_get());
-	k_thread_user_mode_enter(rtio_chain_cancel_test, NULL, NULL, NULL);
-#else
-	rtio_chain_cancel_test(NULL, NULL, NULL);
-#endif
 }
 
 static void test_rtio_transaction_cancel_(struct rtio *r)
@@ -479,28 +417,11 @@ static void test_rtio_transaction_cancel_(struct rtio *r)
 	}
 }
 
-static void rtio_transaction_cancel_test(void *a, void *b, void *c)
+ZTEST_USER(rtio_api, test_rtio_transaction_cancel)
 {
-	ARG_UNUSED(a);
-	ARG_UNUSED(b);
-	ARG_UNUSED(c);
-
 	for (int i = 0; i < TEST_REPEATS; i++) {
 		test_rtio_transaction_cancel_(&r_simple);
 	}
-}
-
-ZTEST(rtio_api, test_rtio_transaction_cancel)
-{
-	rtio_iodev_test_init(&iodev_test_simple);
-#ifdef CONFIG_USERSPACE
-	k_mem_domain_add_thread(&rtio_domain, k_current_get());
-	rtio_access_grant(&r_simple, k_current_get());
-	k_object_access_grant(&iodev_test_simple, k_current_get());
-	k_thread_user_mode_enter(rtio_transaction_cancel_test, NULL, NULL, NULL);
-#else
-	rtio_transaction_cancel_test(NULL, NULL, NULL);
-#endif
 }
 
 static inline void test_rtio_simple_multishot_(struct rtio *r, int idx)
@@ -558,38 +479,10 @@ static inline void test_rtio_simple_multishot_(struct rtio *r, int idx)
 	}
 }
 
-static void rtio_simple_multishot_test(void *a, void *b, void *c)
+ZTEST_USER(rtio_api, test_rtio_multishot)
 {
-	ARG_UNUSED(a);
-	ARG_UNUSED(b);
-	ARG_UNUSED(c);
-
 	for (int i = 0; i < TEST_REPEATS; i++) {
 		test_rtio_simple_multishot_(&r_simple, i);
-	}
-}
-
-ZTEST(rtio_api, test_rtio_multishot)
-{
-	rtio_iodev_test_init(&iodev_test_simple);
-#ifdef CONFIG_USERSPACE
-	k_mem_domain_add_thread(&rtio_domain, k_current_get());
-	rtio_access_grant(&r_simple, k_current_get());
-	k_object_access_grant(&iodev_test_simple, k_current_get());
-	k_thread_user_mode_enter(rtio_simple_multishot_test, NULL, NULL, NULL);
-#else
-	rtio_simple_multishot_test(NULL, NULL, NULL);
-#endif
-}
-
-
-ZTEST(rtio_api, test_rtio_syscalls)
-{
-	TC_PRINT("test iodev init\n");
-	rtio_iodev_test_init(&iodev_test_syscall);
-	TC_PRINT("syscalls from kernel mode\n");
-	for (int i = 0; i < TEST_REPEATS; i++) {
-		rtio_syscall_test(NULL, NULL, NULL);
 	}
 }
 
@@ -739,6 +632,16 @@ static void rtio_api_before(void *a)
 		while (rtio_cqe_copy_out(r, &cqe, 1, K_MSEC(15))) {
 		}
 	}
+
+	rtio_iodev_test_init(&iodev_test_simple);
+	rtio_iodev_test_init(&iodev_test_syscall);
+#ifdef CONFIG_USERSPACE
+	k_mem_domain_add_thread(&rtio_domain, k_current_get());
+	rtio_access_grant(&r_simple, k_current_get());
+	rtio_access_grant(&r_syscall, k_current_get());
+	k_object_access_grant(&iodev_test_simple, k_current_get());
+	k_object_access_grant(&iodev_test_syscall, k_current_get());
+#endif
 }
 
 ZTEST_SUITE(rtio_api, NULL, rtio_api_setup, rtio_api_before, NULL, NULL);


### PR DESCRIPTION
When writing a test suite, it's more common to want the 'before' hook to run in privilaged mode, even when the test is run in userspace. Reconfigure ztest to first run the test thread callback in privilaged mode and only enter userspace after the test rule and suite's 'before' functions ran.