### PR TITLE
drivers: counter: stm32 counter timer driver fixing coverity warning

### DIFF
--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -652,7 +652,7 @@ void counter_stm32_irq_handler(const struct device *dev)
 			    DEVICE_DT_INST_GET(idx),				  \
 			    0);							  \
 		irq_enable(DT_IRQN(TIMER(idx)));				  \
-	}									  \
+	};									  \
 										  \
 	static const struct counter_stm32_config counter##idx##_config = {	  \
 		.info = {							  \


### PR DESCRIPTION
Fixing the coverity warning [Coverity CID: 321118]

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/59538

Signed-off-by: Francois Ramu <francois.ramu@st.com>