### PR TITLE
Documentation: Show code fragment parsed in shell doc

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -274,12 +274,14 @@ struct shell_static_entry {
  * function body.
  *
  * Example usage:
- * SHELL_STATIC_SUBCMD_SET_CREATE(
- *	foo,
- *	SHELL_CMD(abc, ...),
- *	SHELL_CMD(def, ...),
- *	SHELL_SUBCMD_SET_END
- * )
+ * @code{.c}
+ *	SHELL_STATIC_SUBCMD_SET_CREATE(
+ *		foo,
+ *		SHELL_CMD(abc, ...),
+ *		SHELL_CMD(def, ...),
+ *		SHELL_SUBCMD_SET_END
+ *	)
+ * @endcode
  *
  * @param[in] name	Name of the subcommand set.
  * @param[in] ...	List of commands created with @ref SHELL_CMD_ARG or
@@ -532,6 +534,7 @@ static int UTIL_CAT(UTIL_CAT(cmd_dict_, UTIL_CAT(_handler, _)),		\
  *			passed to the _handler as user data.
  *
  * Example usage:
+ * @code{.c}
  *	static int my_handler(const struct shell *sh,
  *			      size_t argc, char **argv, void *data)
  *	{
@@ -546,6 +549,7 @@ static int UTIL_CAT(UTIL_CAT(cmd_dict_, UTIL_CAT(_handler, _)),		\
  *		(value_2, 2, "value 2"), (value_3, 3, "value 3")
  *	);
  *	SHELL_CMD_REGISTER(dictionary, &sub_dict_cmds, NULL, NULL);
+ * @endcode
  */
 #define SHELL_SUBCMD_DICT_SET_CREATE(_name, _handler, ...)		\
 	FOR_EACH_FIXED_ARG(Z_SHELL_CMD_DICT_HANDLER_CREATE, (),		\


### PR DESCRIPTION
In the documation section regarding the shell, the [code sections](https://docs.zephyrproject.org/latest/services/shell/index.html#c.SHELL_STATIC_SUBCMD_SET_CREATE) are not nicely parsed:
![image](https://github.com/zephyrproject-rtos/zephyr/assets/44026484/49c96e5b-9ebb-4294-87d3-3bfb6f97489f)
