### PR TITLE
Bluetooth: Host: Check that `conn` is not NULL in `bt_gatt_ccc_cfg_conn_lookup()`

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2068,7 +2068,7 @@ static struct bt_conn *bt_gatt_ccc_cfg_conn_lookup(const struct bt_gatt_ccc_cfg 
 
 	conn = bt_conn_lookup_addr_le(cfg->id, &cfg->peer);
 
-	if (bt_gatt_ccc_cfg_is_matching_conn(conn, cfg)) {
+	if (conn && bt_gatt_ccc_cfg_is_matching_conn(conn, cfg)) {
 		return conn;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/59513.