### PR TITLE
drivers: dma: stm32 dmamux device must be initialized after dma

### DIFF
--- a/drivers/dma/Kconfig.stm32
+++ b/drivers/dma/Kconfig.stm32
@@ -67,4 +67,12 @@ config DMA_STM32_BDMA
 	help
 	  BDMA driver for STM32H7 series SoCs.
 
+config DMAMUX_STM32_INIT_PRIORITY
+	int "STM32 DMAMUX init priority"
+	depends on DT_HAS_ST_STM32_DMAMUX_ENABLED
+	default 41
+	help
+	  DMAMUX driver device must be init'd after the DMA (CONFIG_DMA_INIT_PRIORITY)
+	  DMAMUX driver device initialization priority is greater than DMA one's
+
 endif # DMA_STM32

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -422,7 +422,13 @@ DEVICE_DT_INST_DEFINE(index,						\
 		    &dmamux_stm32_init,					\
 		    NULL,						\
 		    &dmamux_stm32_data_##index, &dmamux_stm32_config_##index,\
-		    PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,		\
+		    PRE_KERNEL_1, CONFIG_DMAMUX_STM32_INIT_PRIORITY,	\
 		    &dma_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(DMAMUX_INIT)
+
+/*
+ * Make sure that this driver is initialized after the DMA driver (higher priority)
+ */
+BUILD_ASSERT(CONFIG_DMAMUX_STM32_INIT_PRIORITY >= CONFIG_DMA_INIT_PRIORITY,
+	     "CONFIG_DMAMUX_STM32_INIT_PRIORITY must be higher than CONFIG_DMA_INIT_PRIORITY");


### PR DESCRIPTION
Add specific init priority for the stm32 DMAMUX device higher than the CONFIG_DMA_INIT_PRIORITY, to be sure that the DMAMUX
 initialization always comes after the stm32 DMA device init.
Its default value is set to 41 when the DMA_INIT_PRIORITY is KERNEL_INIT_PRIORITY_DEFAULT (=40).

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/57376

Signed-off-by: Francois Ramu <francois.ramu@st.com>