### PR TITLE
drivers: uart_mcux_lpuart: move critical function call out of assert()

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -855,8 +855,6 @@ static void mcux_lpuart_isr(const struct device *dev)
 			data->tx_poll_stream_on = false;
 			mcux_lpuart_pm_policy_state_lock_put(dev);
 		}
-		assert(LPUART_ClearStatusFlags(config->base,
-			kLPUART_TransmissionCompleteFlag) == 0U);
 	}
 #endif /* CONFIG_PM */
 
@@ -874,7 +872,7 @@ static void mcux_lpuart_isr(const struct device *dev)
 	if (status & kLPUART_IdleLineFlag) {
 		async_timer_start(&data->async.rx_dma_params.timeout_work,
 				  data->async.rx_dma_params.timeout_us);
-		assert(LPUART_ClearStatusFlags(config->base, kLPUART_IdleLineFlag) == 0U);
+		LPUART_ClearStatusFlags(config->base, kLPUART_IdleLineFlag);
 	}
 #endif /* CONFIG_UART_ASYNC_API */
 }


### PR DESCRIPTION
CONFIG_ASSERTS=n removes the assert() including the call of LPUART_ClearStatusFlags(). Without the call of LPUART_ClearStatusFlags(), the interrupt can immediately trigger again, blocking the application.

Signed-off-by: Jan Peters <peters@kt-elektronik.de>