### PR TITLE
drivers: clock control: stm32h5 set the clock freq for voltage scaling

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -367,11 +367,11 @@ static uint32_t get_vco_output_range(uint32_t vco_input_range)
 
 static void set_regu_voltage(uint32_t hclk_freq)
 {
-	if (hclk_freq < MHZ(80)) {
+	if (hclk_freq <= MHZ(100)) {
 		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE3);
-	} else if (hclk_freq < MHZ(130)) {
+	} else if (hclk_freq <= MHZ(150)) {
 		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE2);
-	} else if (hclk_freq < MHZ(180)) {
+	} else if (hclk_freq <= MHZ(200)) {
 		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
 	} else {
 		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);


### PR DESCRIPTION
According to the stm32h5x product specifications ( [DS14053](https://www.st.com/resource/en/datasheet/stm32h503rb.pdf)   or [DS14121](https://www.st.com/resource/en/datasheet/stm32h573zi.pdf)) the values of the voltage regulator depends on the system clock as follows:

-   VOS0 (Vcore = 1.35V) with CPU and peripherals running at up to 250 MHz
-   VOS1 (Vcore = 1.2V) with CPU and peripherals running at up to 200 MHz
-   VOS2 (Vcore = 1.1V) with CPU and peripherals running at up to 150 MHz
-   VOS3 (Vcore = 1.0V) with CPU and peripherals running at up to 100 MHz

Signed-off-by: Francois Ramu <francois.ramu@st.com>
