### PR TITLE
soc: xtensa: nxp: invoke west sign only for SOF

### DIFF
--- a/soc/xtensa/nxp_adsp/CMakeLists.txt
+++ b/soc/xtensa/nxp_adsp/CMakeLists.txt
@@ -5,16 +5,19 @@
 
 add_subdirectory(common)
 
+#  use rimage only when compiling Sound Open Firmware (SOF)
+if(CONFIG_SOF)
 #  west sign
 
 # See detailed comments in soc/xtensa/intel_adsp/common/CMakeLists.txt
-add_custom_target(zephyr.ri ALL
-  DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
-)
+  add_custom_target(zephyr.ri ALL
+    DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
+  )
 
-add_custom_command(
-  OUTPUT ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
-  COMMENT "west sign --if-tool-available --tool rimage ..."
-  COMMAND  west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR}
-  DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf
-)
+  add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
+    COMMENT "west sign --if-tool-available --tool rimage ..."
+    COMMAND  west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR}
+    DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf
+  )
+endif()


### PR DESCRIPTION
west sign is used only for Sound Open Firmware (SOF) sample.
So, add this only if CONFIG_SOF is enabled.
Otherwise, when compiling other samples they're not building because of the rimage dependency.

Fixes: 5ae7bd84d3 ("soc: xtensa: nxp: invoke west sign at west build time")