### PR TITLE
Bluetooth: tbs_client: Fix possible NULL pointer dereference

### DIFF
--- a/subsys/bluetooth/audio/aics_internal.h
+++ b/subsys/bluetooth/audio/aics_internal.h
@@ -64,7 +64,6 @@ struct bt_aics_client {
 	struct bt_gatt_subscribe_params state_sub_params;
 	struct bt_gatt_subscribe_params status_sub_params;
 	struct bt_gatt_subscribe_params desc_sub_params;
-	uint8_t subscribe_cnt;
 	bool cp_retried;
 
 	bool busy;

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -543,15 +543,16 @@ static uint8_t notify_handler(struct bt_conn *conn,
 			      const void *data, uint16_t length)
 {
 	uint16_t handle = params->value_handle;
-	struct bt_tbs_instance *tbs_inst = lookup_inst_by_handle(conn, handle);
+	struct bt_tbs_instance *tbs_inst;
 
-	if (data == NULL) {
+	if (data == NULL || conn == NULL) {
 		LOG_DBG("[UNSUBSCRIBED] 0x%04X", params->value_handle);
 		params->value_handle = 0U;
 
 		return BT_GATT_ITER_STOP;
 	}
 
+	tbs_inst = lookup_inst_by_handle(conn, handle);
 	if (tbs_inst != NULL) {
 		uint8_t inst_index = tbs_index(conn, tbs_inst);
 

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -548,9 +548,6 @@ static uint8_t notify_handler(struct bt_conn *conn,
 	if (data == NULL) {
 		LOG_DBG("[UNSUBSCRIBED] 0x%04X", params->value_handle);
 		params->value_handle = 0U;
-		if (tbs_inst != NULL) {
-			tbs_inst->subscribe_cnt--;
-		}
 
 		return BT_GATT_ITER_STOP;
 	}

--- a/subsys/bluetooth/audio/tbs_internal.h
+++ b/subsys/bluetooth/audio/tbs_internal.h
@@ -331,7 +331,6 @@ struct bt_tbs_instance {
 	uint16_t termination_reason_handle;
 
 	bool busy;
-	uint8_t subscribe_cnt;
 #if defined(CONFIG_BT_TBS_CLIENT_CCID)
 	uint8_t ccid;
 #endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */

--- a/subsys/bluetooth/audio/vocs_internal.h
+++ b/subsys/bluetooth/audio/vocs_internal.h
@@ -46,7 +46,6 @@ struct bt_vocs_client {
 	struct bt_gatt_subscribe_params state_sub_params;
 	struct bt_gatt_subscribe_params location_sub_params;
 	struct bt_gatt_subscribe_params desc_sub_params;
-	uint8_t subscribe_cnt;
 	bool cp_retried;
 
 	bool busy;


### PR DESCRIPTION
This fixes notification callback that can be called with NULL conn
parameter when peer is being unpaired.