### PR TITLE
Bluetooth: Host: Fix connection reference leak in GATT

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2067,9 +2067,12 @@ static struct bt_conn *bt_gatt_ccc_cfg_conn_lookup(const struct bt_gatt_ccc_cfg 
 	struct bt_conn *conn;
 
 	conn = bt_conn_lookup_addr_le(cfg->id, &cfg->peer);
+	if (conn) {
+		if (bt_gatt_ccc_cfg_is_matching_conn(conn, cfg)) {
+			return conn;
+		}
 
-	if (conn && bt_gatt_ccc_cfg_is_matching_conn(conn, cfg)) {
-		return conn;
+		bt_conn_unref(conn);
 	}
 
 	return NULL;


### PR DESCRIPTION
If connection reference is acquired from `bt_conn_lookup_addr_le` but `bt_gatt_ccc_cfg_is_matching_conn` return false the connection was not unreferenced properly. This commit fix the issue by unreferencing the connection if the condition is false.

Issue raised here: https://github.com/zephyrproject-rtos/zephyr/pull/59598#discussion_r1238462936