### PR TITLE
Bluetooth: Controller: Remove assign to terminate_ack

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -290,8 +290,6 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	/* Setup the PRT reload */
 	ull_cp_prt_reload_set(conn, conn_interval_us);
 
-	conn->central.terminate_ack = 0U;
-
 	conn->llcp_terminate.reason_final = 0U;
 	/* NOTE: use allocated link for generating dedicated
 	 * terminate ind rx node

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1004,11 +1004,6 @@ void ull_conn_done(struct node_rx_event_done *done)
 			}
 #endif /* CONFIG_BT_PERIPHERAL */
 
-#if defined(CONFIG_BT_CENTRAL)
-		} else if (reason_final) {
-			conn->central.terminate_ack = 1;
-#endif /* CONFIG_BT_CENTRAL */
-
 		}
 
 		/* Reset connection failed to establish countdown */

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -196,15 +196,6 @@ struct ll_conn {
 			uint32_t ticks_to_offset;
 		} periph;
 #endif /* CONFIG_BT_PERIPHERAL */
-
-#if defined(CONFIG_BT_CENTRAL)
-		struct {
-#if defined(CONFIG_BT_CTLR_CONN_META)
-			uint8_t  is_must_expire:1;
-#endif /* CONFIG_BT_CTLR_CONN_META */
-			uint8_t terminate_ack:1;
-		} central;
-#endif /* CONFIG_BT_CENTRAL */
 	};
 
 	/* Cancel the prepare in the instant a Connection Update takes place */


### PR DESCRIPTION
Assignment to conn->central.terminate_ack is not accessible after 2ada005d7c74f89dfbabaacb4bc4f5059761b618.
Remove dead code.

Fixes #58971