### PR TITLE
add Ethernet driver for stm32 h5xx

### DIFF
--- a/boards/arm/nucleo_h563zi/Kconfig.defconfig
+++ b/boards/arm/nucleo_h563zi/Kconfig.defconfig
@@ -8,4 +8,11 @@ if BOARD_NUCLEO_H563ZI
 config BOARD
 	default "nucleo_h563zi"
 
+if NETWORKING
+
+config NET_L2_ETHERNET
+	default y
+
+endif # NETWORKING
+
 endif # BOARD_NUCLEO_H563ZI

--- a/boards/arm/nucleo_h563zi/nucleo_h563zi.dts
+++ b/boards/arm/nucleo_h563zi/nucleo_h563zi.dts
@@ -8,6 +8,7 @@
 /dts-v1/;
 #include "nucleo_h563zi-common.dtsi"
 
+
 / {
 	model = "STMicroelectronics STM32H563ZI-NUCLEO board";
 	compatible = "st,stm32h563zi-nucleo";
@@ -18,7 +19,7 @@
 	chosen {
 		zephyr,console = &usart3;
 		zephyr,shell-uart = &usart3;
-		zephyr,sram = &sram0;
+		zephyr,sram = &sram1;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 	};
@@ -35,4 +36,18 @@
 
 &rng {
 	status = "okay";
+};
+
+&mac {
+	status = "okay";
+	pinctrl-0 = <&eth_mdc_pc1
+		     &eth_rxd0_pc4
+		     &eth_rxd1_pc5
+		     &eth_ref_clk_pa1
+		     &eth_mdio_pa2
+		     &eth_crs_dv_pa7
+		     &eth_tx_en_pg11
+		     &eth_txd0_pg13
+		     &eth_txd1_pb15>;
+	pinctrl-names = "default";
 };

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -22,12 +22,13 @@ choice ETH_STM32_HAL_API_VERSION
 
 config ETH_STM32_HAL_API_V2
 	bool "Use new HAL driver"
-	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
+	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32H5X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
 	help
 	  Use the new HAL driver instead of the legacy one.
 
 config ETH_STM32_HAL_API_V1
 	bool "Use new HAL driver"
+	depends on !SOC_SERIES_STM32H5X
 	select DEPRECATED if SOC_SERIES_STM32H7X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
 	help
 	  Driver version based on legacy HAL version. Deprecated unless using STM32F2 series.
@@ -135,7 +136,7 @@ config ETH_STM32_AUTO_NEGOTIATION_ENABLE
 
 config ETH_STM32_HW_CHECKSUM
 	bool "Use TX and RX hardware checksum"
-	depends on !SOC_SERIES_STM32H7X
+	depends on (!SOC_SERIES_STM32H7X && !SOC_SERIES_STM32H5X )
 	help
 	  Enable receive and transmit checksum offload to enhance throughput
 	  performances.
@@ -157,7 +158,7 @@ config ETH_STM32_MODE_HALFDUPLEX
 
 endif # !ETH_STM32_AUTO_NEGOTIATION_ENABLE
 
-if SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
+if SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X || SOC_SERIES_STM32H5X
 
 config PTP_CLOCK_STM32_HAL
 	bool "STM32 HAL PTP clock driver support"
@@ -197,7 +198,7 @@ config ETH_STM32_HAL_PTP_CLOCK_INIT_PRIO
 	  a dependency from the network stack that this device
 	  initializes before network stack (NET_INIT_PRIO).
 
-endif # SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
+endif # SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X || SOC_SERIES_STM32H5X
 
 config ETH_STM32_MULTICAST_FILTER
 	bool "Multicast hash filter support"

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -41,9 +41,10 @@ struct eth_stm32_hal_dev_data {
 	const struct device *clock;
 	struct k_mutex tx_mutex;
 	struct k_sem rx_int_sem;
-#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_ETH_STM32_HAL_API_V2)
+#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32H5X) || \
+	defined(CONFIG_ETH_STM32_HAL_API_V2)
 	struct k_sem tx_int_sem;
-#endif /* CONFIG_SOC_SERIES_STM32H7X || CONFIG_ETH_STM32_HAL_API_V2*/
+#endif /* CONFIG_SOC_SERIES_STM32H7X || CONFIG_SOC_SERIES_STM32H5X || CONFIG_ETH_STM32_HAL_API_V2*/
 	K_KERNEL_STACK_MEMBER(rx_thread_stack,
 		CONFIG_ETH_STM32_HAL_RX_THREAD_STACK_SIZE);
 	struct k_thread rx_thread;

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -461,6 +461,17 @@
 			status = "disabled";
 		};
 
+		mac: ethernet@40028000 {
+			compatible = "st,stm32-ethernet";
+			reg = <0x40028000 0x8000>;
+			interrupts = <106 0>;
+			clock-names = "stmmaceth", "mac-clk-tx", "mac-clk-rx";
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00080000>,
+				 <&rcc STM32_CLOCK_BUS_AHB1 0x00100000>,
+				 <&rcc STM32_CLOCK_BUS_AHB1 0x00200000>;
+			status = "disabled";
+		};
+
 		gpdma1: dma@40020000 {
 			compatible = "st,stm32u5-dma";
 			#dma-cells = <3>;

--- a/dts/arm/st/h5/stm32h563Xi.dtsi
+++ b/dts/arm/st/h5/stm32h563Xi.dtsi
@@ -8,8 +8,22 @@
 #include <st/h5/stm32h563.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(640)>;
+	sram1: memory@20000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x20000000 DT_SIZE_K(256)>;
+		zephyr,memory-region = "SRAM1";
+	};
+
+	sram2: memory@20040000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x20040000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "SRAM2";
+	};
+
+	sram3: memory@20050000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x20050000 DT_SIZE_K(320)>;
+		zephyr,memory-region = "SRAM3";
 	};
 
 	soc {

--- a/soc/arm/st_stm32/stm32h5/CMakeLists.txt
+++ b/soc/arm/st_stm32/stm32h5/CMakeLists.txt
@@ -4,3 +4,4 @@ zephyr_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_sources(
   soc.c
   )
+zephyr_linker_sources(SECTIONS sections.ld)

--- a/soc/arm/st_stm32/stm32h5/sections.ld
+++ b/soc/arm/st_stm32/stm32h5/sections.ld
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2020 Mario Jaun
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(mac), okay)
+
+SECTION_DATA_PROLOGUE(eth_stm32,(NOLOAD),)
+{
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sram3), okay)
+    . = ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram3)));
+    *(.eth_stm32_desc)
+    . = ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram3))) + 256;
+    *(.eth_stm32_buf)
+    . = ABSOLUTE(DT_REG_ADDR(DT_NODELABEL(sram3))) + 16K;
+} GROUP_DATA_LINK_IN(LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(sram3)), LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(sram3)))
+#endif
+#endif


### PR DESCRIPTION
add Ethernet driver and try to test with samples/net/zperf
I perform Ethernet Iperf test as follow: see documents after : Ethernet driver for STM32H563zi test with zperf and Zperf_Iperf_Nucleo_F429ZI_Bis.docx [Ethernet driver for STM32H563zi test with zperf.docx](https://github.com/zephyrproject-rtos/zephyr/files/11879169/Ethernet.driver.for.STM32H563zi.test.with.zperf.docx) [Zperf_Iperf_Nucleo_F429ZI_Bis.docx](https://github.com/zephyrproject-rtos/zephyr/files/11879172/Zperf_Iperf_Nucleo_F429ZI_Bis.docx)

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/59311