### PR TITLE
cmake: Add partial linking abstraction

### DIFF
--- a/cmake/linker/ld/linker_flags.cmake
+++ b/cmake/linker/ld/linker_flags.cmake
@@ -10,6 +10,8 @@ else()
   set_property(TARGET linker PROPERTY no_position_independent)
 endif()
 
+set_property(TARGET linker PROPERTY partial_linking "-r")
+
 # Some linker flags might not be purely ld specific, but a combination of
 # linker and compiler, such as:
 # --coverage for clang

--- a/cmake/linker/linker_flags_template.cmake
+++ b/cmake/linker/linker_flags_template.cmake
@@ -16,3 +16,7 @@ set_property(TARGET linker PROPERTY warnings_as_errors)
 # Linker flag for disabling position independent binaries,
 # such as, "-no-pie" for LD, and "--no-pie" for LLD.
 set_property(TARGET linker PROPERTY no_position_independent)
+
+# Linker flag for doing partial linking
+# such as, "-r" or "--relocatable" for LD and LLD.
+set_property(TARGET linker PROPERTY partial_linking)

--- a/cmake/linker/lld/linker_flags.cmake
+++ b/cmake/linker/lld/linker_flags.cmake
@@ -5,3 +5,5 @@
 include(${ZEPHYR_BASE}/cmake/linker/ld/${COMPILER}/linker_flags.cmake OPTIONAL)
 
 set_property(TARGET linker PROPERTY no_position_independent "${LINKERFLAGPREFIX},--no-pie")
+
+set_property(TARGET linker PROPERTY partial_linking "-r")


### PR DESCRIPTION
Add a property to abstract the partial linking/rellocatable linking for gcc ld and llvm's lld.

This is used by #59302