### PR TITLE
fix error: 'struct modem_shell_user_data' has no member named shell

### DIFF
--- a/drivers/modem/modem_shell.c
+++ b/drivers/modem/modem_shell.c
@@ -159,7 +159,7 @@ static void uart_mux_cb(const struct device *uart, const struct device *dev,
 			int dlci_address, void *user_data)
 {
 	struct modem_shell_user_data *data = user_data;
-	const struct shell *sh = data->shell;
+	const struct shell *sh = data->sh;
 	int *count = data->user_data;
 	const char *ch = "?";
 
@@ -235,7 +235,7 @@ static int cmd_modem_info(const struct shell *sh, size_t argc, char *argv[])
 	struct modem_shell_user_data user_data;
 	int count = 0;
 
-	user_data.shell = sh;
+	user_data.sh = sh;
 	user_data.user_data = &count;
 
 	uart_mux_foreach(uart_mux_cb, &user_data);


### PR DESCRIPTION
no big deal, just noticed a compilation error if one compiles this with CONFIG_GSM_MUX=y