### PR TITLE
libc fixes for native builds

### DIFF
--- a/lib/libc/common/Kconfig
+++ b/lib/libc/common/Kconfig
@@ -23,6 +23,7 @@ config COMMON_LIBC_MALLOC_ARENA_SIZE
 	default 0 if MINIMAL_LIBC
 	default 16384 if MMU
 	default 2048 if USERSPACE && MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
+	default 16384 if ARCH_POSIX
 	default -1
 	help
 	  Indicate the size in bytes of the memory arena used for

--- a/lib/libc/minimal/source/stdlib/exit.c
+++ b/lib/libc/minimal/source/stdlib/exit.c
@@ -11,5 +11,6 @@ void _exit(int status)
 {
 	printk("exit\n");
 	while (1) {
+		Z_SPIN_DELAY(100);
 	}
 }

--- a/lib/libc/picolibc/libc-hooks.c
+++ b/lib/libc/picolibc/libc-hooks.c
@@ -131,7 +131,7 @@ __weak void _exit(int status)
 {
 	printk("exit\n");
 	while (1) {
-		;
+		Z_SPIN_DELAY(100);
 	}
 }
 


### PR DESCRIPTION
3 trivial changes (these changes can be merged in the tree ahead of the native_sim board, they don't break anything. To test them with the posix architecture, the new board is needed though)

-----

To be able to use this libraries in the POSIX arch/for native builds,
For both minimal and picoblic,  the spin loop in exit() needs a Z_SPIN_DELAY(),
so it does not hang the whole executable on that infinite loop but only the thread
that exit'ed.

Note that for embedded targets this macro defines to nothing.

------

libC COMMON_LIBC_MALLOC_ARENA_SIZE: provide default for POSIX ARCH

Provide a sensible default for the POSIX architecture.

----

This is used by https://github.com/zephyrproject-rtos/zephyr/pull/59302