### PR TITLE
POSIX API and net: minor change in ifdefs for POSIX arch

### DIFF
--- a/include/zephyr/net/socket_types.h
+++ b/include/zephyr/net/socket_types.h
@@ -34,7 +34,7 @@ struct timeval {
 
 #else /* CONFIG_NEWLIB_LIBC */
 
-#ifdef CONFIG_ARCH_POSIX
+#if defined(CONFIG_ARCH_POSIX) && defined(CONFIG_EXTERNAL_LIBC)
 #include <bits/types/struct_timeval.h>
 #else
 #include <sys/_timeval.h>

--- a/include/zephyr/posix/time.h
+++ b/include/zephyr/posix/time.h
@@ -48,7 +48,7 @@ struct itimerspec {
 
 #else /* CONFIG_NEWLIB_LIBC */
 /* Not Newlib */
-# ifdef CONFIG_ARCH_POSIX
+# if defined(CONFIG_ARCH_POSIX) && defined(CONFIG_EXTERNAL_LIBC)
 #  include <bits/types/struct_timespec.h>
 #  include <bits/types/struct_itimerspec.h>
 # else
@@ -82,7 +82,7 @@ static inline int32_t _ts_to_ms(const struct timespec *to)
 	return (to->tv_sec * MSEC_PER_SEC) + (to->tv_nsec / NSEC_PER_MSEC);
 }
 
-#ifdef CONFIG_ARCH_POSIX
+#if defined(CONFIG_ARCH_POSIX) && defined(CONFIG_EXTERNAL_LIBC)
 int clock_gettime(clockid_t clock_id, struct timespec *ts);
 #else
 __syscall int clock_gettime(clockid_t clock_id, struct timespec *ts);
@@ -100,7 +100,7 @@ int nanosleep(const struct timespec *rqtp, struct timespec *rmtp);
 }
 #endif
 
-#ifndef CONFIG_ARCH_POSIX
+#if !(defined(CONFIG_ARCH_POSIX) && defined(CONFIG_EXTERNAL_LIBC))
 #include <syscalls/time.h>
 #endif /* CONFIG_ARCH_POSIX */
 

--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -12,7 +12,7 @@ config POSIX_MAX_FDS
 	  files, sockets, special devices, etc.
 
 config POSIX_API
-	depends on !ARCH_POSIX
+	depends on !NATIVE_APPLICATION
 	bool "POSIX APIs"
 	help
 	  Enable mostly-standards-compliant implementations of
@@ -160,7 +160,7 @@ config APP_LINK_WITH_POSIX_SUBSYS
 
 config EVENTFD
 	bool "Support for eventfd"
-	depends on !ARCH_POSIX
+	depends on !NATIVE_APPLICATION
 	select POLL
 	default y if POSIX_API
 	help


### PR DESCRIPTION
As enablers of running the POSIX compatibility API shim on native_sim and have better support for net/sockets,
change the choice of which kconfig symbols we use to decide what to includes and what kconfig options prevent using the POSIX API.

As is in the tree, today this is not changing anything, as with the current kconfig this new symbol combinations are always set at the same time as the old.
But with the remaining changes in #59302 they enable building this functionality for native_sim and with embedded libraries.

This is part of #59302