### PR TITLE
Bluetooth: att: Reset ATT timer when retrying on security error

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2457,6 +2457,12 @@ static uint8_t att_error_rsp(struct bt_att_chan *chan, struct net_buf *buf)
 #if defined(CONFIG_BT_ATT_RETRY_ON_SEC_ERR)
 	/* Check if error can be handled by elevating security. */
 	if (!att_change_security(chan->chan.chan.conn, err)) {
+		/* ATT timeout work is normally cancelled in att_handle_rsp.
+		 * However retrying is special case, so the timeout shall
+		 * be cancelled here.
+		 */
+		k_work_cancel_delayable(&chan->timeout_work);
+
 		chan->req->retrying = true;
 		return 0;
 	}


### PR DESCRIPTION
If the remote responds with and security related error the stack tries to increase the security level to satisfy the remote permissions. This fixes missing ATT timer reset on security related ATT Error Response as the ATT operation is considered as complete.

```
< ACL Data TX: Handle 0 flags 0x00 dlen 7
      ATT: Read Request (0x0a) len 2
        Handle: 0x0084
        TMAS: Role
> ACL Data RX: Handle 0 flags 0x02 dlen 9
      ATT: Error Response (0x01) len 4
        Read Request (0x0a)
        Handle: 0x0084
        Error: Insufficient Authentication (0x05)
          TMAS: Role
           Error code: 0x05
< ACL Data TX: Handle 0 flags 0x00 dlen 6
      SMP: Security Request (0x0b) len 1
        Authentication requirement: Bonding, No MITM, SC, No Keypresses (0x09)
= bt: bt_att: ATT Timeout
```