### PR TITLE
ztests: Build POSIX arch extra functionality only if possible

### DIFF
--- a/subsys/testsuite/ztest/CMakeLists.txt
+++ b/subsys/testsuite/ztest/CMakeLists.txt
@@ -24,7 +24,7 @@ zephyr_library_sources_ifdef(CONFIG_ZTEST_MOCKING  src/ztest_mock.c)
 zephyr_library_sources_ifdef(CONFIG_ZTRESS         src/ztress.c)
 
 
-if(CONFIG_ARCH_POSIX)
+if(CONFIG_ARCH_POSIX AND CONFIG_EXTERNAL_LIBC)
   zephyr_library_sources_ifdef(CONFIG_ZTEST_NEW_API src/ztest_posix.c)
 else()
   zephyr_library_sources_ifdef(CONFIG_ZTEST_NEW_API src/ztest_defaults.c)


### PR DESCRIPTION
The extra ztest functionality for the posix arch requires the host libC. 
So let's disable it if we are building with an embedded libC.

As things are in the tree today, this change does not really do anything, as all posix arch boards today set use the external libC, the difference will come with the native_sim board which can use other libCs.  (This is part of https://github.com/zephyrproject-rtos/zephyr/pull/59302)