### PR TITLE
tests libC: Filter based on type of target not whole arch

### DIFF
--- a/tests/lib/c_lib/testcase.yaml
+++ b/tests/lib/c_lib/testcase.yaml
@@ -1,12 +1,13 @@
 common:
   tags:
     - clib
-  arch_exclude: posix
+  filter: not CONFIG_NATIVE_APPLICATION
   integration_platforms:
     - mps2_an385
 tests:
   libraries.libc:
     ignore_faults: true
+    filter: not (CONFIG_ARCH_POSIX and CONFIG_EXTERNAL_LIBC)
   libraries.libc.picolibc:
     filter: CONFIG_PICOLIBC_SUPPORTED
     tags: picolibc


### PR DESCRIPTION
The POSIX arch will now also support embedded libCs for some targets. Narrow the test filter accordingly.


As is in the tree today, this change does not really do anything, as all posix arch boards today set NATIVE_APPLICATION and external libc, the difference will come with the native_sim board which will set NATIVE_LIBRARY instead and have the option to choose libC. (This is part of https://github.com/zephyrproject-rtos/zephyr/pull/59302)