### PR TITLE
cmake/toolchain: Support LLVM-style profiling/coverage for native_posix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2003,6 +2003,11 @@ if(CONFIG_MINIMAL_LIBCPP)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,nostdincxx>>)
 endif()
 
+if(CONFIG_LLVM_PROFILE)
+  zephyr_compile_options(-fprofile-instr-generate -fcoverage-mapping)
+  zephyr_link_libraries(-fprofile-instr-generate -fcoverage-mapping)
+endif()
+
 # Finally export all build flags from Zephyr
 add_subdirectory_ifdef(
   CONFIG_MAKEFILE_EXPORTS

--- a/cmake/toolchain/llvm/Kconfig
+++ b/cmake/toolchain/llvm/Kconfig
@@ -17,3 +17,15 @@ config LLVM_USE_LLD
 	  Use LLVM built-in lld linker with llvm/clang.
 
 endchoice
+
+config LLVM_PROFILE
+	bool "Enable profiling output"
+	depends on ARCH_POSIX
+	help
+	  Builds the (posix) app with profiling and instruction
+	  instrumentation arguments such that it can be used with
+	  external coverage tools.  Note that this is not the same
+	  feature as the gprof-based coverage tools used elsewhere in
+	  Zephyr!  Requires ARCH_POSIX currently, as there is no
+	  infrastructure for retrieving the resulting .profraw data on
+	  embedded builds.


### PR DESCRIPTION
Downstream POSIX build consumers (specifcially oss-fuzz) are set up to do analysis on LLVM coverage data.  Provide a simple kconfig to turn that on for them.

In theory this is available for any LLVM/clang setup, though in practice only host builds are working.  The infrastructure and docs to extract the profiling data from embedded target builds are... thin.