### PR TITLE
pinctrl: kinetis: use kernel default init priority

### DIFF
--- a/drivers/pinctrl/pinctrl_kinetis.c
+++ b/drivers/pinctrl/pinctrl_kinetis.c
@@ -76,7 +76,7 @@ static int pinctrl_mcux_init(const struct device *dev)
 			    NULL,					\
 			    NULL, &pinctrl_mcux_##n##_config,		\
 			    PRE_KERNEL_1,				\
-			    0,						\
+			    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
 			    NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(PINCTRL_MCUX_INIT)


### PR DESCRIPTION
Set the initialization priority for the pinctrl_mcux_init to CONFIG_KERNEL_INIT_PRIORITY_DEFAULT.

The pinmux nodes depend on pcc, which is currently initializing at a later stage, using the default priority fixes it.

Found the error with:

```
$ west build -p -b frdm_k64f samples/basic/blinky \
  -DCONFIG_CHECK_INIT_PRIORITIES=y
...
ERROR: /soc/pinmux@4004d000 PRE_KERNEL_1 0 <
  /soc/pcc@40065000 PRE_KERNEL_1 30
ERROR: /soc/pinmux@4004c000 PRE_KERNEL_1 0 <
  /soc/pcc@40065000 PRE_KERNEL_1 30
ERROR: /soc/pinmux@4004b000 PRE_KERNEL_1 0 <
  /soc/pcc@40065000 PRE_KERNEL_1 30
ERROR: /soc/pinmux@4004a000 PRE_KERNEL_1 0 <
  /soc/pcc@40065000 PRE_KERNEL_1 30
ERROR: /soc/pinmux@40049000 PRE_KERNEL_1 0 <
  /soc/pcc@40065000 PRE_KERNEL_1 30
```