### PR TITLE
gpio: npm1300: lower init priority

### DIFF
--- a/drivers/gpio/Kconfig.npm1300
+++ b/drivers/gpio/Kconfig.npm1300
@@ -13,7 +13,7 @@ config GPIO_NPM1300
 config GPIO_NPM1300_INIT_PRIORITY
 	int "nPM1300 GPIO driver initialization priority"
 	depends on GPIO_NPM1300
-	default 80
+	default 70
 	help
 	  Initialization priority for the nPM1300 GPIO driver. It must be
 	  greater than the I2C controller init priority.


### PR DESCRIPTION
Lower the priority of the npm1300 gpio driver. The GPIOs are used by some regulator nodes in the default shield config, but regulators are initialized before the gpios. Lowering the GPIO priority to sort thigs out.

Found with the build time priority checking feature:

```
$ west build -p -b nrf52dk_nrf52832 samples/shields/npm1300_ek \
  -DCONFIG_CHECK_INIT_PRIORITIES=y
...
ERROR: /soc/i2c@40003000/pmic@6b/regulators/LDO2 POST_KERNEL 76 <
  /soc/i2c@40003000/pmic@6b/gpio-controller POST_KERNEL 80
ERROR: /soc/i2c@40003000/pmic@6b/regulators/LDO1 POST_KERNEL 76 <
  /soc/i2c@40003000/pmic@6b/gpio-controller POST_KERNEL 80
ERROR: /soc/i2c@40003000/pmic@6b/regulators/BUCK2 POST_KERNEL 76 <
  /soc/i2c@40003000/pmic@6b/gpio-controller POST_KERNEL 80
ERROR: /soc/i2c@40003000/pmic@6b/regulators POST_KERNEL 75 <
  /soc/i2c@40003000/pmic@6b/gpio-controller POST_KERNEL 80
ERROR: /soc/i2c@40003000/pmic@6b/regulators POST_KERNEL 75 <
  /soc/i2c@40003000/pmic@6b/gpio-controller POST_KERNEL 80
ERROR: /soc/i2c@40003000/pmic@6b/regulators POST_KERNEL 75 <
  /soc/i2c@40003000/pmic@6b/gpio-controller POST_KERNEL 80
```