### PR TITLE
rtio: Implement a NO_RESPONSE flag for SQEs

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -115,25 +115,6 @@ extern "C" {
 
 
 /**
- * @brief Equivalent to the I2C_MSG_STOP flag
- */
-#define RTIO_IODEV_I2C_STOP BIT(0)
-
-/**
- * @brief Equivalent to the I2C_MSG_RESTART flag
- */
-#define RTIO_IODEV_I2C_RESTART BIT(1)
-
-/**
- * @brief Equivalent to the I2C_MSG_10_BITS
- */
-#define RTIO_IODEV_I2C_10_BITS BIT(2)
-
-/**
- * @brief Equivalent to the I2C_MSG_ADDR_10_BITS
- */
-
-/**
  * @brief The buffer should be allocated by the RTIO mempool
  *
  * This flag can only exist if the CONFIG_RTIO_SYS_MEM_BLOCKS Kconfig was
@@ -159,6 +140,11 @@ extern "C" {
  * complete. It should be placed back in queue until canceled.
  */
 #define RTIO_SQE_MULTISHOT BIT(4)
+
+/**
+ * @brief The SQE does not produce a CQE.
+ */
+#define RTIO_SQE_NO_RESPONSE BIT(5)
 
 /**
  * @}
@@ -211,6 +197,21 @@ extern "C" {
 /**
  * @}
  */
+
+/**
+ * @brief Equivalent to the I2C_MSG_STOP flag
+ */
+#define RTIO_IODEV_I2C_STOP BIT(0)
+
+/**
+ * @brief Equivalent to the I2C_MSG_RESTART flag
+ */
+#define RTIO_IODEV_I2C_RESTART BIT(1)
+
+/**
+ * @brief Equivalent to the I2C_MSG_ADDR_10_BITS
+ */
+#define RTIO_IODEV_I2C_10_BITS BIT(2)
 
 /** @cond ignore */
 struct rtio;

--- a/subsys/rtio/rtio_executor.c
+++ b/subsys/rtio/rtio_executor.c
@@ -149,7 +149,7 @@ static inline void rtio_executor_done(struct rtio_iodev_sqe *iodev_sqe, int resu
 			/* SQE is no longer needed, release it */
 			rtio_sqe_pool_free(r->sqe_pool, curr);
 		}
-		if (!is_canceled) {
+		if (!is_canceled && FIELD_GET(RTIO_SQE_NO_RESPONSE, sqe_flags) == 0) {
 			/* Request was not canceled, generate a CQE */
 			rtio_cqe_submit(r, result, userdata, cqe_flags);
 		}

--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -77,6 +77,27 @@ ZTEST(rtio_api, test_rtio_simple)
 	}
 }
 
+ZTEST(rtio_api, test_rtio_no_response)
+{
+	int res;
+	uintptr_t userdata[2] = {0, 1};
+	struct rtio_sqe *sqe;
+	struct rtio_cqe cqe;
+
+	rtio_iodev_test_init(&iodev_test_simple);
+
+	sqe = rtio_sqe_acquire(&r_simple);
+	zassert_not_null(sqe, "Expected a valid sqe");
+	rtio_sqe_prep_nop(sqe, (struct rtio_iodev *)&iodev_test_simple, &userdata[0]);
+	sqe->flags |= RTIO_SQE_NO_RESPONSE;
+
+	res = rtio_submit(&r_simple, 0);
+	zassert_ok(res, "Should return ok from rtio_execute");
+
+	res = rtio_cqe_copy_out(&r_simple, &cqe, 1, K_MSEC(500));
+	zassert_equal(0, res, "Expected no CQEs");
+}
+
 RTIO_DEFINE(r_chain, SQE_POOL_SIZE, CQE_POOL_SIZE);
 
 RTIO_IODEV_TEST_DEFINE(iodev_test_chain0);


### PR DESCRIPTION
When added, the SQE's completion will not generate a CQE. Fixes #59284