### PR TITLE
drivers: pwm: pwm_stm32: reset timer using RCC before initialization

### DIFF
--- a/drivers/pwm/Kconfig.stm32
+++ b/drivers/pwm/Kconfig.stm32
@@ -9,6 +9,7 @@ config PWM_STM32
 	depends on DT_HAS_ST_STM32_PWM_ENABLED
 	select USE_STM32_LL_TIM
 	select USE_STM32_LL_RCC if SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
+	select RESET
 	help
 	  This option enables the PWM driver for STM32 family of
 	  processors. Say y if you wish to use PWM port on STM32

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -722,27 +722,29 @@ static int pwm_stm32_init(const struct device *dev)
 	return 0;
 }
 
+#define PWM(index) DT_INST_PARENT(index)
+
 #ifdef CONFIG_PWM_CAPTURE
 #define IRQ_CONNECT_AND_ENABLE_BY_NAME(index, name)				\
 {										\
-	IRQ_CONNECT(DT_IRQ_BY_NAME(DT_INST_PARENT(index), name, irq),		\
-			DT_IRQ_BY_NAME(DT_INST_PARENT(index), name, priority),	\
+	IRQ_CONNECT(DT_IRQ_BY_NAME(PWM(index), name, irq),			\
+			DT_IRQ_BY_NAME(PWM(index), name, priority),		\
 			pwm_stm32_isr, DEVICE_DT_INST_GET(index), 0);		\
-	irq_enable(DT_IRQ_BY_NAME(DT_INST_PARENT(index), name, irq));		\
+	irq_enable(DT_IRQ_BY_NAME(PWM(index), name, irq));			\
 }
 
 #define IRQ_CONNECT_AND_ENABLE_DEFAULT(index)					\
 {										\
-	IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(index)),				\
-			DT_IRQ(DT_INST_PARENT(index), priority),		\
+	IRQ_CONNECT(DT_IRQN(PWM(index)),					\
+			DT_IRQ(PWM(index), priority),				\
 			pwm_stm32_isr, DEVICE_DT_INST_GET(index), 0);		\
-	irq_enable(DT_IRQN(DT_INST_PARENT(index)));				\
+	irq_enable(DT_IRQN(PWM(index)));					\
 }
 
 #define IRQ_CONFIG_FUNC(index)                                                  \
 static void pwm_stm32_irq_config_func_##index(const struct device *dev)		\
 {										\
-	COND_CODE_1(DT_IRQ_HAS_NAME(DT_INST_PARENT(index), cc),			\
+	COND_CODE_1(DT_IRQ_HAS_NAME(PWM(index), cc),				\
 		(IRQ_CONNECT_AND_ENABLE_BY_NAME(index, cc)),			\
 		(IRQ_CONNECT_AND_ENABLE_DEFAULT(index))				\
 	);									\
@@ -756,9 +758,10 @@ static void pwm_stm32_irq_config_func_##index(const struct device *dev)		\
 
 #define DT_INST_CLK(index, inst)                                               \
 	{                                                                      \
-		.bus = DT_CLOCKS_CELL(DT_INST_PARENT(index), bus),             \
-		.enr = DT_CLOCKS_CELL(DT_INST_PARENT(index), bits)             \
+		.bus = DT_CLOCKS_CELL(PWM(index), bus),				\
+		.enr = DT_CLOCKS_CELL(PWM(index), bits)				\
 	}
+
 
 #define PWM_DEVICE_INIT(index)                                                 \
 	static struct pwm_stm32_data pwm_stm32_data_##index;                   \
@@ -767,9 +770,9 @@ static void pwm_stm32_irq_config_func_##index(const struct device *dev)		\
 	PINCTRL_DT_INST_DEFINE(index);					       \
 									       \
 	static const struct pwm_stm32_config pwm_stm32_config_##index = {      \
-		.timer = (TIM_TypeDef *)DT_REG_ADDR(DT_INST_PARENT(index)),    \
-		.prescaler = DT_PROP(DT_INST_PARENT(index), st_prescaler),     \
-		.countermode = DT_PROP(DT_INST_PARENT(index), st_countermode), \
+		.timer = (TIM_TypeDef *)DT_REG_ADDR(PWM(index)),	       \
+		.prescaler = DT_PROP(PWM(index), st_prescaler),		       \
+		.countermode = DT_PROP(PWM(index), st_countermode),	       \
 		.pclken = DT_INST_CLK(index, timer),                           \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),		       \
 		CAPTURE_INIT(index)					       \


### PR DESCRIPTION
If a timer is left running on an stm32mp1, (most likely) on the next run the timer is stuck.
A simple timer reset before initialization fixes the issue.