### PR TITLE
Add TDM support to I2S API

### DIFF
--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -583,6 +583,18 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 				 word_size_bits, num_words,
 				 dev_cfg->tx_channel);
 		break;
+	case I2S_FMT_DATA_FORMAT_TDM_MODE_A:
+		SAI_GetTDMConfig(&config, kSAI_FrameSyncLenOneBitClk,
+				 word_size_bits, num_words,
+				 dev_cfg->tx_channel);
+		config.frameSync.frameSyncEarly = true;
+		break;
+	case I2S_FMT_DATA_FORMAT_TDM_MODE_B:
+		SAI_GetTDMConfig(&config, kSAI_FrameSyncLenOneBitClk,
+				 word_size_bits, num_words,
+				 dev_cfg->tx_channel);
+		config.frameSync.frameSyncEarly = false;
+		break;
 	default:
 		LOG_ERR("Unsupported I2S data format");
 		if (dir == I2S_DIR_TX) {
@@ -654,6 +666,10 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 	}
 
 	config.frameSync.frameSyncWidth = (uint8_t)word_size_bits;
+	if (((i2s_cfg->format & I2S_FMT_DATA_FORMAT_MASK) == I2S_FMT_DATA_FORMAT_TDM_MODE_A) ||
+	    ((i2s_cfg->format & I2S_FMT_DATA_FORMAT_MASK) == I2S_FMT_DATA_FORMAT_TDM_MODE_B)) {
+		config.frameSync.frameSyncWidth = 1;
+	}
 
 	if (dir == I2S_DIR_TX) {
 		memcpy(&dev_data->tx.cfg, i2s_cfg, sizeof(struct i2s_config));

--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -142,6 +142,50 @@ typedef uint8_t i2s_fmt_t;
  */
 #define I2S_FMT_DATA_FORMAT_RIGHT_JUSTIFIED (4 << I2S_FMT_DATA_FORMAT_SHIFT)
 
+/**
+ * @brief Time Division Multiplexed (TDM) mode A Data Format.
+ *
+ * Serial data is transmitted with the MSB first. Both Frame Synchronization
+ * (WS) and Serial Data (SD) signals are sampled on the rising edge of the
+ * clock (SCK) signal. The bits within the data word are left justified.
+ * The frame sync is one clock cycle long.
+ *
+ * Mode A: the beginning of the channel data is delayed one period of SCK
+ * following the rising edge of the WS signal.
+ *
+ *          .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-.
+ *     SCK -' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-
+ *            .---.                                                           .-
+ *     WS  ---'   '-----------------------------------------------------------'
+ *         ---.---.---.---.---.---.---.---.---.---.---.---.---.---.---.---.---.-
+ *     SD     |   |MSB|   |...|   |LSB|MSB|   |...|   |LSB|MSB|   |...|   |LSB|
+ *         ---'---'---'---'---'---'---'---'---'---'---'---'---'---'---'---'---'-
+ *                | Channel 1         | Channel 2         | Ch 3    | Ch n    |
+ */
+#define I2S_FMT_DATA_FORMAT_TDM_MODE_A (5 << I2S_FMT_DATA_FORMAT_SHIFT)
+
+/**
+ * @brief Time Division Multiplexed (TDM) mode B Data Format.
+ *
+ * Serial data is transmitted with the MSB first. Both Frame Synchronization
+ * (WS) and Serial Data (SD) signals are sampled on the rising edge of the
+ * clock (SCK) signal. The bits within the data word are left justified.
+ * The frame sync is one clock cycle long.
+ *
+ * Mode B: the beginning of the channel data is aligned with the rising edge
+ * of the WS signal.
+ *
+ *          .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-. .-.
+ *     SCK -' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-' '-
+ *            .---.                                                       .---.
+ *     WS  ---'   '-------------------------------------------------------'   '-
+ *         ---.---.---.---.---.---.---.---.---.---.---.---.---.---.---.---.---.-
+ *     SD     |MSB|   |...|   |LSB|MSB|   |...|   |LSB|MSB|   |...|   |LSB|   |
+ *         ---'---'---'---'---'---'---'---'---'---'---'---'---'---'---'---'---'-
+ *            | Channel 1         | Channel 2         | Ch 3    | Ch n    |
+ */
+#define I2S_FMT_DATA_FORMAT_TDM_MODE_B (6 << I2S_FMT_DATA_FORMAT_SHIFT)
+
 /** Send MSB first */
 #define I2S_FMT_DATA_ORDER_MSB              (0 << 3)
 /** Send LSB first */


### PR DESCRIPTION
Add TDM support to I2S API:
- add new `I2S_FMT_DATA_FORMAT_TDM_MODE_A` and `I2S_FMT_DATA_FORMAT_TDM_MODE_B` formats
- add TDM support to MCUX SAI driver