### PR TITLE
boards: stm32: Fix board vendor when required

### DIFF
--- a/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
+++ b/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "Adafruit Feather STM32F405 Express";
-	compatible = "st,adafruit_feather_stm32f405", "st,stm32f405";
+	compatible = "adafruit,adafruit_feather_stm32f405", "st,stm32f405";
 
 	chosen {
 		zephyr,console = &usart3;

--- a/boards/arm/black_f407ve/black_f407ve.dts
+++ b/boards/arm/black_f407ve/black_f407ve.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "black_f407ve board";
-	compatible = "st,stm32f407";
+	compatible = "black-stm32f407";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/stm32_min_dev/stm32_min_dev_black.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_black.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STM32 Minimum Development Board (Black)";
-	compatible = "st,stm32_min_dev_black", "st,stm32f103c8";
+	compatible = "stm32_min_dev_black", "st,stm32f103c8";
 
 	leds {
 		led: led {

--- a/boards/arm/stm32_min_dev/stm32_min_dev_blue.dts
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_blue.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "STM32 Minimum Development Board (Blue)";
-	compatible = "st,stm32_min_dev_blue", "st,stm32f103c8";
+	compatible = "stm32_min_dev_blue", "st,stm32f103c8";
 
 	leds {
 		led: led {

--- a/boards/arm/stm32f030_demo/stm32f030_demo.dts
+++ b/boards/arm/stm32f030_demo/stm32f030_demo.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "STM32F030 DEMO board";
-	compatible = "st,stm32f030-demo";
+	compatible = "stm32f030-demo";
 
 	chosen {
 		zephyr,console = &usart1;

--- a/boards/arm/stm32f103_mini/stm32f103_mini.dts
+++ b/boards/arm/stm32f103_mini/stm32f103_mini.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "stm32f103_mini board";
-	compatible = "st,stm32f103";
+	compatible = "stm32f103";
 
 	chosen {
 		zephyr,console = &usart1;


### PR DESCRIPTION
When vendor is unknown, no vendor is provided and compatible used is "board_name" instead of "vendor,board_name".