### PR TITLE
Bluetooth: ascs: Drop ISO PDUs if ASE is not in streaming state

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -671,10 +671,12 @@ static void ascs_iso_recv(struct bt_iso_chan *chan,
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_BAP_DEBUG_STREAM_DATA) &&
-	    ep->status.state != BT_BAP_EP_STATE_STREAMING) {
-		LOG_DBG("ep %p is not in the streaming state: %s", ep,
-			bt_bap_ep_state_str(ep->status.state));
+	if (ep->status.state != BT_BAP_EP_STATE_STREAMING) {
+		if (IS_ENABLED(CONFIG_BT_BAP_DEBUG_STREAM_DATA)) {
+			LOG_DBG("ep %p is not in the streaming state: %s", ep,
+				bt_bap_ep_state_str(ep->status.state));
+		}
+
 		return;
 	}
 

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -227,10 +227,12 @@ static void unicast_client_ep_iso_recv(struct bt_iso_chan *chan,
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_BAP_DEBUG_STREAM_DATA) &&
-	    ep->status.state != BT_BAP_EP_STATE_STREAMING) {
-		LOG_DBG("ep %p is not in the streaming state: %s", ep,
-			bt_bap_ep_state_str(ep->status.state));
+	if (ep->status.state != BT_BAP_EP_STATE_STREAMING) {
+		if (IS_ENABLED(CONFIG_BT_BAP_DEBUG_STREAM_DATA)) {
+			LOG_DBG("ep %p is not in the streaming state: %s", ep,
+				bt_bap_ep_state_str(ep->status.state));
+		}
+
 		return;
 	}
 

--- a/tests/bluetooth/audio/mocks/CMakeLists.txt
+++ b/tests/bluetooth/audio/mocks/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(mocks STATIC
   src/iso.c
   src/kernel.c
   src/mem_slab.c
+  src/net_buf.c
   src/pacs.c
 )
 

--- a/tests/bluetooth/audio/mocks/src/net_buf.c
+++ b/tests/bluetooth/audio/mocks/src/net_buf.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Codecoup
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <zephyr/net/buf.h>
+
+void net_buf_unref(struct net_buf *buf)
+{
+
+}


### PR DESCRIPTION
This fixes missing drop of ISO Data PDUs received in non-streaming state.
The server shall indicate first it's readiness to receive the ISO Data
by calling bt_bap_stream_start that triggers state transition from
Enabling to Streaming state.

This adds tests for receiving ISO Data PDU.
* test_recv_in_streaming_state - test whether received ISO Data PDU is
  sent to upper layers.
* test_recv_in_enabling_state - test whether received ISO Data PDu is
  dropped because upper layer is not ready to receive the data yet.