### PR TITLE
drivers/sensor: check xyz_mem_bank_set() ret value

### DIFF
--- a/drivers/sensor/lsm6dso/lsm6dso_shub.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_shub.c
@@ -629,7 +629,10 @@ int lsm6dso_shub_fetch_external_devs(const struct device *dev)
 	struct lsm6dso_shub_slist *sp;
 
 	/* read data from external target */
-	lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+	if (lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK) < 0) {
+		LOG_DBG("failed to enter SENSOR_HUB bank");
+		return -EIO;
+	}
 
 	for (n = 0; n < data->num_ext_dev; n++) {
 		sp = &lsm6dso_shub_slist[data->shub_ext[n]];
@@ -637,14 +640,12 @@ int lsm6dso_shub_fetch_external_devs(const struct device *dev)
 		if (lsm6dso_read_reg(ctx, sp->sh_out_reg,
 				     data->ext_data[n], sp->out_data_len) < 0) {
 			LOG_DBG("shub: failed to read sample");
-			lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+			(void) lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 			return -EIO;
 		}
 	}
 
-	lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
-
-	return 0;
+	return lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
 }
 
 int lsm6dso_shub_config(const struct device *dev, enum sensor_channel chan,

--- a/drivers/sensor/lsm6dso16is/lsm6dso16is_shub.c
+++ b/drivers/sensor/lsm6dso16is/lsm6dso16is_shub.c
@@ -725,7 +725,10 @@ int lsm6dso16is_shub_fetch_external_devs(const struct device *dev)
 	struct lsm6dso16is_shub_slist *sp;
 
 	/* read data from external target */
-	lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK);
+	if (lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_SENSOR_HUB_MEM_BANK) < 0) {
+		LOG_DBG("failed to enter SENSOR_HUB bank");
+		return -EIO;
+	}
 
 	for (n = 0; n < data->num_ext_dev; n++) {
 		sp = &lsm6dso16is_shub_slist[data->shub_ext[n]];
@@ -733,14 +736,12 @@ int lsm6dso16is_shub_fetch_external_devs(const struct device *dev)
 		if (lsm6dso16is_read_reg(ctx, sp->sh_out_reg,
 				     data->ext_data[n], sp->out_data_len) < 0) {
 			LOG_DBG("shub: failed to read sample");
-			lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
+			(void) lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 			return -EIO;
 		}
 	}
 
-	lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
-
-	return 0;
+	return lsm6dso16is_mem_bank_set(ctx, LSM6DSO16IS_MAIN_MEM_BANK);
 }
 
 int lsm6dso16is_shub_config(const struct device *dev, enum sensor_channel chan,

--- a/drivers/sensor/lsm6dsv16x/lsm6dsv16x_shub.c
+++ b/drivers/sensor/lsm6dsv16x/lsm6dsv16x_shub.c
@@ -725,7 +725,10 @@ int lsm6dsv16x_shub_fetch_external_devs(const struct device *dev)
 	struct lsm6dsv16x_shub_slist *sp;
 
 	/* read data from external target */
-	lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
+	if (lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK) < 0) {
+		LOG_DBG("failed to enter SENSOR_HUB bank");
+		return -EIO;
+	}
 
 	for (n = 0; n < data->num_ext_dev; n++) {
 		sp = &lsm6dsv16x_shub_slist[data->shub_ext[n]];
@@ -733,14 +736,12 @@ int lsm6dsv16x_shub_fetch_external_devs(const struct device *dev)
 		if (lsm6dsv16x_read_reg(ctx, sp->sh_out_reg,
 				     data->ext_data[n], sp->out_data_len) < 0) {
 			LOG_DBG("shub: failed to read sample");
-			lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
+			(void) lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 			return -EIO;
 		}
 	}
 
-	lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-
-	return 0;
+	return lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 }
 
 int lsm6dsv16x_shub_config(const struct device *dev, enum sensor_channel chan,


### PR DESCRIPTION
Check xyz_mem_bank_set() API return value to catch and report as soon as possible the error condition. Impacted stmemsc API:

  - lsm6dso_mem_bank_set()
  - lsm6dso16is_mem_bank_set()
  - lsm6dsv16x_mem_bank_set()

Fixes #58579 
  Coverity-CID: 316212
Fixes #58580
  Coverity-CID: 316224
Fixes #58586
  Coverity-CID: 316307