### PR TITLE
boards: shields: npm1300_ek: Specify regulator initial modes

### DIFF
--- a/boards/shields/npm1300_ek/npm1300_ek.overlay
+++ b/boards/shields/npm1300_ek/npm1300_ek.overlay
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <dt-bindings/regulator/npm1300.h>
+
 &arduino_i2c {
 	npm1300_ek_pmic: pmic@6b {
 		compatible = "nordic,npm1300";
@@ -37,12 +39,14 @@
 			npm1300_ek_ldo1: LDO1 {
 				regulator-min-microvolt = <1000000>;
 				regulator-max-microvolt = <3300000>;
+				regulator-initial-mode = <NPM1300_LDSW_MODE_LDO>;
 				enable-gpios = <&npm1300_ek_gpio 2 GPIO_ACTIVE_LOW>;
 			};
 
 			npm1300_ek_ldo2: LDO2 {
 				regulator-min-microvolt = <1000000>;
 				regulator-max-microvolt = <3300000>;
+				regulator-initial-mode = <NPM1300_LDSW_MODE_LDSW>;
 				enable-gpios = <&npm1300_ek_gpio 2 GPIO_ACTIVE_LOW>;
 			};
 		};


### PR DESCRIPTION
The npm1300_ek overlay has been updated to explictly specify the initialisation modes for the dual purpose LDO / LDSW outputs.