### PR TITLE
intel_adsp: remove deprecated cache macros

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/soc.h
+++ b/soc/xtensa/intel_adsp/common/include/soc.h
@@ -27,10 +27,6 @@ extern void soc_start_core(int cpu_num);
 extern bool soc_cpus_active[CONFIG_MP_MAX_NUM_CPUS];
 
 /* Legacy cache APIs still used in a few places */
-#define SOC_DCACHE_FLUSH(addr, size)		\
-	sys_cache_data_flush_range((addr), (size))
-#define SOC_DCACHE_INVALIDATE(addr, size)	\
-	sys_cache_data_invd_range((addr), (size))
 #define z_soc_cached_ptr(p) arch_xtensa_cached_ptr(p)
 #define z_soc_uncached_ptr(p) arch_xtensa_uncached_ptr(p)
 

--- a/soc/xtensa/nxp_adsp/common/include/adsp/cache.h
+++ b/soc/xtensa/nxp_adsp/common/include/adsp/cache.h
@@ -9,10 +9,4 @@
 
 #include <xtensa/hal.h>
 
-/* Macros for data cache operations */
-#define SOC_DCACHE_FLUSH(addr, size)		\
-	sys_cache_data_flush_range((addr), (size))
-#define SOC_DCACHE_INVALIDATE(addr, size)	\
-	sys_cache_data_invd_range((addr), (size))
-
 #endif


### PR DESCRIPTION
SOC_DCACHE_FLUSH and SOC_DCACHE_INVALIDATE are not being used anywhere.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
