### PR TITLE
samples: drivers: auxdisplay requires a fixture to run on a platform

### DIFF
--- a/samples/drivers/auxdisplay/sample.yaml
+++ b/samples/drivers/auxdisplay/sample.yaml
@@ -4,6 +4,8 @@ sample:
 tests:
   sample.drivers.auxdisplay:
     tags: auxdisplay
+    harness_config:
+      fixture: fixture_auxdisplay
     platform_allow: nucleo_f746zg
     integration_platforms:
       - nucleo_f746zg


### PR DESCRIPTION
Add a config "fixture_auxdisplay" to make the samples/drivers/auxdisplay runnable on a platform, 
else the application is useless
This fixture will differ from the existing "fixture_display"

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/59668

Signed-off-by: Francois Ramu <francois.ramu@st.com>