### PR TITLE
kernel: fix z_is_inactive_timeout stab when missing sys clock

### DIFF
--- a/include/zephyr/timeout_q.h
+++ b/include/zephyr/timeout_q.h
@@ -63,7 +63,7 @@ k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 /* Stubs when !CONFIG_SYS_CLOCK_EXISTS */
 #define z_init_thread_timeout(thread_base) do {} while (false)
 #define z_abort_thread_timeout(to) (0)
-#define z_is_inactive_timeout(to) 0
+#define z_is_inactive_timeout(to) 1
 #define z_get_next_timeout_expiry() ((int32_t) K_TICKS_FOREVER)
 #define z_set_timeout_expiry(ticks, is_idle) do {} while (false)
 


### PR DESCRIPTION
Currently we provide incorrect stab value of z_is_inactive_timeout in case of the configuration without system clock
(CONFIG_SYS_CLOCK_EXISTS=n). This prevents threads from being scheduled (we don't even schedule main thread in hello world example if CONFIG_SYS_CLOCK_EXISTS=n).

Fix that.

Test case for initial issue is: https://github.com/zephyrproject-rtos/zephyr/pull/59712