### PR TITLE
Fix Laird Connectivity DTS compatible fields

### DIFF
--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "Laird BL652 DVK";
-	compatible = "laird,bl652_dvk";
+	compatible = "lairdconnect,bl652_dvk";
 
 	chosen {
 		zephyr,console = &uart0;

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "Laird BL654 Dev Kit";
-	compatible = "nordic,pca10056-dk";
+	compatible = "lairdconnect,bl654_dvk";
 
 	chosen {
 		zephyr,console = &uart0;


### PR DESCRIPTION
Compatible field should properly represent the manufacturer and board name.