### PR TITLE
DTS: corrected clk_lse in stm32g4.dtsi

### DIFF
--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -62,8 +62,9 @@
 
 		clk_lse: clk-lse {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32-lse-clock";
 			clock-frequency = <32768>;
+			driving-capability = <0>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Altered LSE in stm32g4.dtsi to use correct compatible string and allow for setting of driving-capability via device tree.