### PR TITLE
drivers: kscan: use zephyr_syscall_header

### DIFF
--- a/drivers/kscan/CMakeLists.txt
+++ b/drivers/kscan/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/kscan.h)
+
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_KSCAN_GT911  	kscan_gt911.c)


### PR DESCRIPTION
Add call to zephyr_syscall_header to kscan driver CMakeLists.txt, so that the required syscalls will be generated when kscan drivers are used.

Fixes #59710