### PR TITLE
docs: flash_debug: host_tools: Fix reference to jlink host tools

### DIFF
--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -14,7 +14,6 @@ more information on these commands.
 
 .. _atmel_sam_ba_bootloader:
 
-
 SAM Boot Assistant (SAM-BA)
 ***************************
 
@@ -182,10 +181,9 @@ As a quick reference, see these three board documentation pages:
   - :ref:`arduino_nano_33_iot` (Arduino bootloader)
   - :ref:`arduino_nano_33_ble` (Arduino legacy bootloader)
 
-.. _jlink-debug-host-tools:
-
 Enabling BOSSAC on Windows Native [Experimental]
 ------------------------------------------------
+
 Zephyr SDK´s bossac is only currenty support on Linux and macOS. Windows support
 can be achieved by using the bossac version from `BOSSA oficial releases`_.
 After installing using default options, the :file:`bossac.exe` must be added to
@@ -199,6 +197,9 @@ Windows PATH. A specific bossac executable can be used by passing the
 .. note::
 
    WSL is not currently supported.
+
+
+.. _jlink-debug-host-tools:
 
 J-Link Debug Host Tools
 ***********************


### PR DESCRIPTION
Fix reference to JLink host tools to be located in correct section, so that output documentation fills in the correct header name when this section is referenced.

Before:

![image](https://github.com/zephyrproject-rtos/zephyr/assets/34665051/abcac250-52b7-470b-b9ec-4c9e8e02f566)


With this change:
![image](https://github.com/zephyrproject-rtos/zephyr/assets/34665051/271e5a66-fd15-4521-9723-0f918f6cc080)

