### PR TITLE
mgmt/MCUmgr/img: Fix img_mgmt_get_unused_slot_area_id checks

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -221,14 +221,11 @@ static int img_mgmt_get_unused_slot_area_id(int slot)
 #endif
 }
 #elif CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER >= 2
-static int img_mgmt_get_unused_slot_area_id(int image)
+static int img_mgmt_get_unused_slot_area_id(unsigned int image)
 {
 	int area_id = -1;
 	int slot = 0;
 
-	if (image == -1) {
-		image = 0;
-	}
 	slot = img_mgmt_get_opposite_slot(img_mgmt_active_slot(image));
 
 	if (!img_mgmt_slot_in_use(slot)) {


### PR DESCRIPTION
Remove image == -1 check that can not happen anymore.