### PR TITLE
soc: adsp: cmake: fix sign.py when CONFIG_KERNEL_BIN_NAME is used

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -430,7 +430,9 @@ class RimageSigner(Signer):
         if not target:
             log.die('rimage target not defined')
 
+        # TODO: make this a new sign.py --bootloader option.
         if target in ('imx8', 'imx8m'):
+            bootloader = None
             kernel = str(b / 'zephyr' / 'zephyr.elf')
             out_bin = str(b / 'zephyr' / 'zephyr.ri')
             out_xman = str(b / 'zephyr' / 'zephyr.ri.xman')
@@ -516,7 +518,7 @@ class RimageSigner(Signer):
         if not args.quiet and args.verbose:
             sign_base += ['-v'] * args.verbose
 
-        components = [ ] if (target in ('imx8', 'imx8m')) else [ bootloader ]
+        components = [ ] if bootloader is None else [ bootloader ]
         components += [ kernel ]
 
         sign_config_extra_args = config_get_words(command.config, 'rimage.extra-args', [])

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -117,9 +117,29 @@ endif()
 
 
 #  west sign
+
+# Warning: most of this code is for now duplicated in
+# soc/xtensa/nxp_adsp/CMakeLists.txt
+
 add_custom_target(zephyr.ri ALL
   DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
 )
+
+# Copy/normalize any weird ${CONFIG_KERNEL_BIN_NAME}.elf to zephyr.elf
+# if different.
+#
+# zephyr.elf is not used by sign.py when a boot.mod bootloader is used
+# BUT others do expect a zephyr.elf file: smex, debuggers, CI and other
+# automation, etc. (Ab)using Kconfig to merely rename a file seems like
+# a bad idea because it breaks build directory expectations.
+if(NOT CONFIG_KERNEL_BIN_NAME STREQUAL "zephyr")
+  add_custom_command(OUTPUT  ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf
+    DEPENDS ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+    ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf
+)
+endif()
 
 # If some of your board(s) need to override default rimage parameters
 # then you can define WEST_SIGN_OPTS in  boards/my/board/board.cmake.
@@ -146,4 +166,6 @@ add_custom_command(
   COMMAND  west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR} ${WEST_SIGN_OPTS}
   DEPENDS gen_modules
           ${CMAKE_BINARY_DIR}/zephyr/boot.mod ${CMAKE_BINARY_DIR}/zephyr/main.mod
+          # Not necessary but see above
+          ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf
 )

--- a/soc/xtensa/nxp_adsp/CMakeLists.txt
+++ b/soc/xtensa/nxp_adsp/CMakeLists.txt
@@ -8,9 +8,22 @@ add_subdirectory(common)
 #  west sign
 
 # See detailed comments in soc/xtensa/intel_adsp/common/CMakeLists.txt
+# where most of this code is for now duplicated.
+
 add_custom_target(zephyr.ri ALL
   DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
 )
+
+# sign.py supports `zephyr.elf` only. Copy/normalize any weird
+# ${CONFIG_KERNEL_BIN_NAME}.elf to zephyr.elf if different.
+if(NOT CONFIG_KERNEL_BIN_NAME STREQUAL "zephyr")
+  add_custom_command(OUTPUT  ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf
+    DEPENDS ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+    ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf
+)
+endif()
 
 add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri


### PR DESCRIPTION
This fixes the build error below reported in https://github.com/zephyrproject-rtos/zephyr/pull/59603 when
CONFIG_KERNEL_BIN_NAME is used.

```
zephyr/zephyr.elf', needed by 'zephyr/zephyr.ri', missing and no known
rule to make it
```

Note `rimage` is _still_ optional. As before, to avoid using rimage:
- make sure it's not in your PATH
- west config -d rimage.path
