### PR TITLE
mgmt/MCUmgr/img: Fix img_mgmt_get_other_slot

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -302,13 +302,13 @@ img_mgmt_get_other_slot(void)
 	switch (slot) {
 	case 1:
 		return 0;
-#if CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER
+#if CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER > 2
 	case 2:
 		return 3;
 	case 3:
 		return 2;
-	}
 #endif
+	}
 	return 1;
 }
 


### PR DESCRIPTION
Fix conditional compilation within img_mgmt_get_other_slot, where CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER has been incorrectly checked and #endif incorrectly placed.