### PR TITLE
Add support for three pairs of image slots

### DIFF
--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -89,7 +89,7 @@ if !MCUBOOT
 config UPDATEABLE_IMAGE_NUMBER
 	int "Number of updateable images"
 	default 1
-	range 1 2
+	range 1 3
 	help
 	  If value is set to 2 or greater then, this enables support needed when
 	  application is combined with MCUboot multi-image boot.

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -46,7 +46,7 @@ endif
 config MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER
 	int "Number of supported images"
 	default UPDATEABLE_IMAGE_NUMBER
-	range 1 2
+	range 1 3
 	help
 	  Sets how many application images are supported (pairs of secondary and primary slots).
 	  Setting this to 2 requires MCUMGR_TRANSPORT_NETBUF_SIZE to be at least 512b.

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -41,42 +41,37 @@
 #define FIXED_PARTITION_IS_RUNNING_APP_PARTITION(label)	\
 	 (FIXED_PARTITION_OFFSET(label) == CONFIG_FLASH_LOAD_OFFSET)
 
-#if FIXED_PARTITION_EXISTS(slot0_partition)
-#if FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot0_partition)
-#define NUMBER_OF_ACTIVE_IMAGE 0
-#endif
-#endif
+BUILD_ASSERT(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
+	     "struct image_header not required size");
 
-#if !defined(NUMBER_OF_ACTIVE_IMAGE) && FIXED_PARTITION_EXISTS(slot0_ns_partition)
-#if FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot0_ns_partition)
-#define NUMBER_OF_ACTIVE_IMAGE 0
+#if CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER >= 2
+#if FIXED_PARTITION_EXISTS(slot0_ns_partition) &&			\
+	FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot0_ns_partition)
+#define ACTIVE_IMAGE_IS 0
+#elif FIXED_PARTITION_EXISTS(slot0_partition) &&			\
+	FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot0_partition)
+#define ACTIVE_IMAGE_IS 0
+#elif FIXED_PARTITION_EXISTS(slot1_partition) &&			\
+	FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot1_partition)
+#define ACTIVE_IMAGE_IS 0
+#elif FIXED_PARTITION_EXISTS(slot2_partition) &&			\
+	FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot2_partition)
+#define ACTIVE_IMAGE_IS 1
+#elif FIXED_PARTITION_EXISTS(slot3_partition) &&			\
+	FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot3_partition)
+#define ACTIVE_IMAGE_IS 1
+#elif FIXED_PARTITION_EXISTS(slot4_partition) &&			\
+	FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot4_partition)
+#define ACTIVE_IMAGE_IS 2
+#elif FIXED_PARTITION_EXISTS(slot5_partition) &&			\
+	FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot5_partition)
+#define ACTIVE_IMAGE_IS 2
+#else
+#define ACTIVE_IMAGE_IS 0
 #endif
+#else
+#define ACTIVE_IMAGE_IS 0
 #endif
-
-#if !defined(NUMBER_OF_ACTIVE_IMAGE) && FIXED_PARTITION_EXISTS(slot1_partition)
-#if FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot1_partition)
-#define NUMBER_OF_ACTIVE_IMAGE 0
-#endif
-#endif
-
-#if !defined(NUMBER_OF_ACTIVE_IMAGE) && FIXED_PARTITION_EXISTS(slot2_partition)
-#if FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot2_partition)
-#define NUMBER_OF_ACTIVE_IMAGE 1
-#endif
-#endif
-
-#if !defined(NUMBER_OF_ACTIVE_IMAGE) && FIXED_PARTITION_EXISTS(slot3_partition)
-#if FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot3_partition)
-#define NUMBER_OF_ACTIVE_IMAGE 1
-#endif
-#endif
-
-#ifndef NUMBER_OF_ACTIVE_IMAGE
-#error "Unsupported code parition is set as active application partition"
-#endif
-
-_Static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
-		"struct image_header not required size");
 
 LOG_MODULE_REGISTER(mcumgr_img_grp, CONFIG_MCUMGR_GRP_IMG_LOG_LEVEL);
 
@@ -159,7 +154,7 @@ int img_mgmt_active_slot(int image)
 
 int img_mgmt_active_image(void)
 {
-	return NUMBER_OF_ACTIVE_IMAGE;
+	return ACTIVE_IMAGE_IS;
 }
 
 /*

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -25,12 +25,26 @@ LOG_MODULE_DECLARE(mcumgr_img_grp, CONFIG_MCUMGR_GRP_IMG_LOG_LEVEL);
 #define SLOT1_PARTITION		slot1_partition
 #define SLOT2_PARTITION		slot2_partition
 #define SLOT3_PARTITION		slot3_partition
+#define SLOT4_PARTITION		slot4_partition
+#define SLOT5_PARTITION		slot5_partition
 
-BUILD_ASSERT(CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER == 1 ||
-	     (CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER == 2 &&
-	      FIXED_PARTITION_EXISTS(SLOT2_PARTITION) &&
-	      FIXED_PARTITION_EXISTS(SLOT3_PARTITION)),
+/* SLOT0_PARTITION and SLOT1_PARTITION are not checked because
+ * there is not conditional code that depends on them. If they do
+ * not exist compilation will fail, but in case if some of other
+ * partitions do not exist, code will compile and will not work
+ * properly.
+ */
+#if CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER >= 2
+BUILD_ASSERT(FIXED_PARTITION_EXISTS(SLOT2_PARTITION) &&
+	     FIXED_PARTITION_EXISTS(SLOT3_PARTITION),
 	     "Missing partitions?");
+#endif
+
+#if CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER == 3
+BUILD_ASSERT(FIXED_PARTITION_EXISTS(SLOT4_PARTITION) &&
+	     FIXED_PARTITION_EXISTS(SLOT5_PARTITION),
+	     "Missing partitions?");
+#endif
 
 /**
  * Determines if the specified area of flash is completely unwritten.
@@ -137,6 +151,18 @@ img_mgmt_flash_area_id(int slot)
 		break;
 #endif
 
+#if FIXED_PARTITION_EXISTS(SLOT4_PARTITION)
+	case 4:
+		fa_id = FIXED_PARTITION_ID(SLOT4_PARTITION);
+		break;
+#endif
+
+#if FIXED_PARTITION_EXISTS(SLOT5_PARTITION)
+	case 5:
+		fa_id = FIXED_PARTITION_ID(SLOT5_PARTITION);
+		break;
+#endif
+
 	default:
 		fa_id = -1;
 		break;
@@ -194,7 +220,7 @@ static int img_mgmt_get_unused_slot_area_id(int slot)
 	return slot != -1  ? img_mgmt_flash_area_id(slot) : -1;
 #endif
 }
-#elif CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER == 2
+#elif CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER >= 2
 static int img_mgmt_get_unused_slot_area_id(int image)
 {
 	int area_id = -1;


### PR DESCRIPTION
[DNM] [DNM] Currently the mcu-tools/mcuboot and Zephyr fork are out of sync because there is something circularly
broken... the west manifest here brings the mcu-tools/mcuboot commit with changes taken from Zephyr fork, for this thing to just compile and work, but until both things are fixed merging of this PR will not be possible.

Support for three pairs of image slots.
This PR mainly contains configuration of slots as the main job, that did the change possible, is done via PR https://github.com/zephyrproject-rtos/zephyr/pull/61342.

Set to DNM due to dependency on other PR in review.

**Update 2023-08-17 16:01 UTC**
Fixed compliance issues
**Update 2023-08-18 17:55 UTC**
Update of base PR.
**Update 2023-08-24 10:30 UTC**
Update from base and main.
**Update 2023-09-08 16:05 UTC**
Rebase from main.