### PR TITLE
shell: Add shell comment command rem

### DIFF
--- a/subsys/shell/shell_cmds.c
+++ b/subsys/shell/shell_cmds.c
@@ -12,6 +12,7 @@
 #include "shell_vt100.h"
 
 #define SHELL_MSG_CMD_NOT_SUPPORTED	"Command not supported.\n"
+#define SHELL_HELP_COMMENT		"Ignore lines beginning with 'rem '"
 #define SHELL_HELP_RETVAL		"Print return value of most recent command"
 #define SHELL_HELP_CLEAR		"Clear screen."
 #define SHELL_HELP_BACKENDS		"List active shell backends.\n"
@@ -200,6 +201,15 @@ static int terminal_size_get(const struct shell *sh)
 
 	z_cursor_restore(sh);
 	return ret_val;
+}
+
+static int cmd_comment(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return 0;
 }
 
 static int cmd_clear(const struct shell *sh, size_t argc, char **argv)
@@ -530,6 +540,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(m_sub_resize,
 	SHELL_SUBCMD_SET_END
 );
 
+SHELL_COND_CMD_REGISTER(CONFIG_SHELL_VT100_COMMANDS, rem, NULL,
+				SHELL_HELP_COMMENT, cmd_comment);
 SHELL_COND_CMD_ARG_REGISTER(CONFIG_SHELL_VT100_COMMANDS, clear, NULL,
 			    SHELL_HELP_CLEAR, cmd_clear, 1, 0);
 SHELL_CMD_REGISTER(shell, &m_sub_shell, SHELL_HELP_SHELL, NULL);


### PR DESCRIPTION
Added the shell comment command.

Use case: executing scripts that may contain comments.