### PR TITLE
soc: adsp: cmake: disable sign.py when CONFIG_KERNEL_BIN_NAME is used

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -430,7 +430,9 @@ class RimageSigner(Signer):
         if not target:
             log.die('rimage target not defined')
 
+        # TODO: make this a new sign.py --bootloader option.
         if target in ('imx8', 'imx8m'):
+            bootloader = None
             kernel = str(b / 'zephyr' / 'zephyr.elf')
             out_bin = str(b / 'zephyr' / 'zephyr.ri')
             out_xman = str(b / 'zephyr' / 'zephyr.ri.xman')
@@ -516,7 +518,7 @@ class RimageSigner(Signer):
         if not args.quiet and args.verbose:
             sign_base += ['-v'] * args.verbose
 
-        components = [ ] if (target in ('imx8', 'imx8m')) else [ bootloader ]
+        components = [ ] if bootloader is None else [ bootloader ]
         components += [ kernel ]
 
         sign_config_extra_args = config_get_words(command.config, 'rimage.extra-args', [])

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -117,6 +117,16 @@ endif()
 
 
 #  west sign
+
+# Warning: most of this code is for now duplicated in
+# soc/xtensa/nxp_adsp/CMakeLists.txt
+
+# zephyr.elf is not used by sign.py when a boot.mod bootloader is used
+# BUT others do expect a zephyr.elf file: smex, debuggers, CI and other
+# automation, etc. (Ab)using Kconfig to merely rename a file seems like
+# a bad idea because it breaks build directory expectations.
+if(CONFIG_KERNEL_BIN_NAME STREQUAL "zephyr")
+
 add_custom_target(zephyr.ri ALL
   DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
 )
@@ -147,3 +157,5 @@ add_custom_command(
   DEPENDS gen_modules
           ${CMAKE_BINARY_DIR}/zephyr/boot.mod ${CMAKE_BINARY_DIR}/zephyr/main.mod
 )
+
+endif() # CONFIG_KERNEL_BIN_NAME == "zephyr"

--- a/soc/xtensa/nxp_adsp/CMakeLists.txt
+++ b/soc/xtensa/nxp_adsp/CMakeLists.txt
@@ -8,6 +8,11 @@ add_subdirectory(common)
 #  west sign
 
 # See detailed comments in soc/xtensa/intel_adsp/common/CMakeLists.txt
+# where most of this code is for now duplicated.
+
+# sign.py supports `zephyr.elf` only.
+if(CONFIG_KERNEL_BIN_NAME STREQUAL "zephyr")
+
 add_custom_target(zephyr.ri ALL
   DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
 )
@@ -18,3 +23,5 @@ add_custom_command(
   COMMAND  west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR}
   DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf
 )
+
+endif() # CONFIG_KERNEL_BIN_NAME == "zephyr"


### PR DESCRIPTION
This alternative competes with
- #59721

-------

sign.py, sof/scripts/xtensa-build-zephyr.py and other SOF infrastructure
do not support the (rarely used) CONFIG_KERNEL_BIN_NAME so stop
pretending they do.

This fixes the build error below reported in https://github.com/zephyrproject-rtos/zephyr/pull/59603 when
CONFIG_KERNEL_BIN_NAME is used:
```
zephyr/zephyr.elf', needed by 'zephyr/zephyr.ri', missing and no known
rule to make it
```

Note `rimage` is _still_ optional, even when CONFIG_KERNEL_BIN_NAME is
not used. As before, to avoid using rimage:
- make sure it's not in your PATH
- west config -d rimage.path

Signed-off-by: Marc Herbert <marc.herbert@intel.com>