### PR TITLE
Updaes for Olimex STM32 H103

### DIFF
--- a/boards/arm/olimex_stm32_h103/board.cmake
+++ b/boards/arm/olimex_stm32_h103/board.cmake
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(blackmagicprobe "--connect-rst")
 board_runner_args(jlink "--device=STM32F103RB" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)

--- a/boards/arm/olimex_stm32_h103/doc/index.rst
+++ b/boards/arm/olimex_stm32_h103/doc/index.rst
@@ -63,30 +63,15 @@ Other hardware features have not been enabled yet for this board.
 Connections and IOs
 ===================
 
-Default Zephyr Peripheral Mapping:
-----------------------------------
-
-- UART_1 TX/RX: PA9/PA10
-- UART_2 TX/RX: PA2/PA3
-- UART_3 TX/RX: PC10/PC11 (not enabled)
-- I2C_1 SCL/SDA : PB6/PB7
-- I2C_2 SCL/SDA : PB10/PB11
-- PWM_1_CH1: PA8
-- SPI_1 NSS_OE/SCK/MISO/MOSI: PA4/PA5/PA6/PA7
-- SPI_2 NSS_OE/SCK/MISO/MOSI: PB12/PB13/PB14/PB15
-- USB_DC DM/DP/DISC/PWR: PA11/PA12/PC11/PC4 (not enabled)
-- ADC_1: PA1
-
 System Clock
 ------------
 
 The on-board 8 MHz crystal is used to produce a 72 MHz system clock with PLL.
 
-Serial Port
------------
+Zephyr Console
+--------------
 
-The board has 3 U(S)ARTs, UART1 and UART2 are enabled by default, with UART2
-used as Zephyr's console. Default settings are 115200 8N1.
+UART2 is used as Zephyr's console. Default settings are 115200 8N1.
 
 On-Board LEDs
 -------------
@@ -104,11 +89,13 @@ The board has one user button connected to PA0.
 USB
 ---
 
-USB is not enabled by default, however PC4 is configured by default as an ADC
-input to sense the USB voltage (see schematic). It is possible to disconnect
-it by desoldering the appropriate pad in the PCB.
+USB is not enabled by default.
 
-The board uses PC11 to disconnect the pull-up resistor on the USB-DP line.
+PC4 can be configured as a GPIO input to detect power on the USB port. It is
+possible to disconnect it by desoldering the appropriate pad in the PCB.
+
+PC11 can be used to disconnect the pull-up resistor on the USB-DP line by
+setting it high.
 
 External Connectors
 -------------------
@@ -118,7 +105,7 @@ JTAG/SWD debug
 +-------+----------------------+-------+--------------+
 | PIN # | Signal Name          | PIN # | Signal Name  |
 +=======+======================+=======+==============+
-| 1     | +3.3V                | 2     | TVCC 3.3V    |
+| 1     | TVCC +3.3V           | 2     | TVCC 3.3V    |
 +-------+----------------------+-------+--------------+
 | 3     | PB4 / TRST           | 4     | GND          |
 +-------+----------------------+-------+--------------+
@@ -144,27 +131,27 @@ EXTENSION 1
 +-------+-----------------------+-------+-----------------------+
 | PIN # | Name / STM32F103 Port | PIN # | Name / STM32F103 Port |
 +=======+=======================+=======+=======================+
-| 1     | PA11 / USB_DM         | 2     | PA8 / **PWM_1_CH1**   |
+| 1     | PA11 / **USB_DM**     | 2     | PA8                   |
 +-------+-----------------------+-------+-----------------------+
-| 3     | PA12 / USB_DP         | 4     | PA9 / **UART1_TX**    |
+| 3     | PA12 / **USB_DP**     | 4     | PA9                   |
 +-------+-----------------------+-------+-----------------------+
 | 5     | +3.3V                 | 6     | GND                   |
 +-------+-----------------------+-------+-----------------------+
-| 7     | PA10 / **UART1_RX**   | 8     | PC10                  |
+| 7     | PA10                  | 8     | PC10                  |
 +-------+-----------------------+-------+-----------------------+
 | 9     | PC11 / **USB_DISC**   | 10    | PC12 / **LED**        |
 +-------+-----------------------+-------+-----------------------+
-| 11    | PD2                   | 12    | PB5/I2C1_SMBA         |
+| 11    | PD2                   | 12    | PB5                   |
 +-------+-----------------------+-------+-----------------------+
-| 13    | PB6 / **I2C1_SCL**    | 14    | PA6 / **SPI1_MISO**   |
+| 13    | PB6                   | 14    | PA6                   |
 +-------+-----------------------+-------+-----------------------+
-| 15    | PB7 / **I2C1_SDA**    | 16    | PB8                   |
+| 15    | PB7                   | 16    | PB8                   |
 +-------+-----------------------+-------+-----------------------+
-| 17    | PB9                   | 18    | PA5 / **SPI1_SCK**    |
+| 17    | PB9                   | 18    | PA5                   |
 +-------+-----------------------+-------+-----------------------+
 | 19    | PC0                   | 20    | PC1                   |
 +-------+-----------------------+-------+-----------------------+
-| 21    | PB0                   | 22    | PA7 / **SPI1_MOSI**   |
+| 21    | PB0                   | 22    | PA7                   |
 +-------+-----------------------+-------+-----------------------+
 | 23    | VBAT                  | 24    | PC13                  |
 +-------+-----------------------+-------+-----------------------+
@@ -182,19 +169,19 @@ EXTENSION 2
 +-------+------------------------+-------+-----------------------+
 | 5     | +3.3V                  | 6     | GND                   |
 +-------+------------------------+-------+-----------------------+
-| 7     | PA2 / **USART2_TX**    | 8     | PA1 / **ADC_1**       |
+| 7     | PA2 / **USART2_TX**    | 8     | PA1                   |
 +-------+------------------------+-------+-----------------------+
 | 9     | PC3                    | 10    | PA3 / **USART2_RX**   |
 +-------+------------------------+-------+-----------------------+
-| 11    | PA4 / **SPI1_NSS**     | 12    | PC4 / **USB-P**       |
+| 11    | PA4                    | 12    | PC4 / **USB_POWER**   |
 +-------+------------------------+-------+-----------------------+
-| 13    | PC5                    | 14    | PB10 / **I2C2_SCL**   |
+| 13    | PC5                    | 14    | PB10                  |
 +-------+------------------------+-------+-----------------------+
-| 15    | P11 / **I2C2_SDA**     | 16    | PB13 / **SPI2_SCK**   |
+| 15    | P11                    | 16    | PB13                  |
 +-------+------------------------+-------+-----------------------+
-| 17    | PB12 / **SPI2_NSS**    | 18    | PB14 / **SPI2_MISO**  |
+| 17    | PB12                   | 18    | PB14                  |
 +-------+------------------------+-------+-----------------------+
-| 19    | PB15 / **SPI2_MOSI**   | 20    | PC6                   |
+| 19    | PB15                   | 20    | PC6                   |
 +-------+------------------------+-------+-----------------------+
 | 21    | PC7                    | 22    | PC8                   |
 +-------+------------------------+-------+-----------------------+
@@ -240,6 +227,10 @@ You can debug an application in the usual way.  Here is an example for the
 
 References
 **********
+
+- `OLIMEX-STM32-H103 website`_
+- `OLIMEX-STM32-H103 user manual`_
+- `OLIMEX-STM32-H103 schematic`_
 
 .. _OLIMEX-STM32-H103 website:
    https://www.olimex.com/Products/ARM/ST/STM32-H103/

--- a/boards/arm/olimex_stm32_h103/doc/index.rst
+++ b/boards/arm/olimex_stm32_h103/doc/index.rst
@@ -203,6 +203,8 @@ SWD transport, but it is also possible to use JTAG with the Olimex ARM-USB-OCD-H
 probe, for instance. For the latter, you should replace the file ``openocd.cfg``
 by ``openocd_olimex_jtag.cfg``, located in the board's support directory.
 
+The ``blackmagicprobe`` can also be used to program the device.
+
 Flashing
 ========
 

--- a/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
+++ b/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
@@ -65,7 +65,7 @@
 	pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pa10>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
-	status = "okay";
+	status = "disabled";
 };
 
 &usart2 {
@@ -79,19 +79,20 @@
 	pinctrl-0 = <&usart3_tx_remap1_pc10 &usart3_rx_remap1_pc11>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "disabled";
 };
 
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
-	status = "okay";
+	status = "disabled";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
-	status = "okay";
+	status = "disabled";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
@@ -99,35 +100,17 @@
 	pinctrl-0 = <&spi1_nss_master_pa4 &spi1_sck_master_pa5
 		      &spi1_miso_master_pa6 &spi1_mosi_master_pa7>;
 	pinctrl-names = "default";
-	status = "okay";
+	status = "disabled";
 };
 
 &spi2 {
 	pinctrl-0 = <&spi2_nss_master_pb12 &spi2_sck_master_pb13
 		     &spi2_miso_master_pb14 &spi2_mosi_master_pb15>;
 	pinctrl-names = "default";
-	status = "okay";
-};
-
-&timers1 {
-	st,prescaler = <10000>;
-	status = "okay";
-
-	pwm1: pwm {
-		status = "okay";
-		pinctrl-0 = <&tim1_ch1_pwm_out_pa8>;
-		pinctrl-names = "default";
-	};
+	status = "disabled";
 };
 
 &iwdg {
-	status = "okay";
-};
-
-&adc1 {
-	/* adc1_in14_pc4 is used to sense the USB voltage */
-	pinctrl-0 = <&adc1_in1_pa1 &adc1_in14_pc4>;
-	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/boards/arm/olimex_stm32_h103/olimex_stm32_h103.yaml
+++ b/boards/arm/olimex_stm32_h103/olimex_stm32_h103.yaml
@@ -9,11 +9,7 @@ toolchain:
 ram: 20
 flash: 128
 supported:
-  - adc
   - gpio
-  - i2c
-  - pwm
-  - spi
   - uart
   - watchdog
 testing:


### PR DESCRIPTION
- Disables peripherals that are not used by default
- Adds support for Black Magic Probe debug tool