### PR TITLE
board: it8xxx2_evb/it82xx2_evb: Fix the dts compatible field of board

### DIFF
--- a/boards/riscv/it82xx2_evb/it82xx2_evb.dts
+++ b/boards/riscv/it82xx2_evb/it82xx2_evb.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "IT82XX2 EV-Board";
-	compatible = "riscv,it82xx2-evb";
+	compatible = "ite,it82xx2-evb";
 
 	aliases {
 		i2c-0 = &i2c0;

--- a/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
+++ b/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "IT8XXX2 EV-Board";
-	compatible = "riscv,it8xxx2-evb";
+	compatible = "ite,it8xxx2-evb";
 
 	aliases {
 		i2c-0 = &i2c0;


### PR DESCRIPTION
The dts compatible field should be corrected to ite.