### PR TITLE
mcumgr: img_mgmt: Fix unused "status" variable warning

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -456,10 +456,13 @@ img_mgmt_upload(struct smp_streamer *ctxt)
 	bool data_match = false;
 #endif
 
+#if defined(CONFIG_MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK)
+	enum mgmt_cb_return status;
+#endif
+
 #if defined(CONFIG_MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK) ||	\
 defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS) ||		\
 defined(CONFIG_MCUMGR_SMP_COMMAND_STATUS_HOOKS)
-	enum mgmt_cb_return status;
 	int32_t ret_rc;
 	uint16_t ret_group;
 #endif


### PR DESCRIPTION
Changes aligns ifdefs to fix compilation warnings related to unused "status" variable.