### PR TITLE
scripts: build: generate mapping between device type and enum k_objects

### DIFF
--- a/cmake/kobj.cmake
+++ b/cmake/kobj.cmake
@@ -8,17 +8,19 @@ function(gen_kobj gen_dir_out)
   endif ()
 
   set(KOBJ_TYPES ${gen_dir}/kobj-types-enum.h)
+  set(KOBJ_MAP_TYPES ${gen_dir}/kobj-map-to-types.h)
   set(KOBJ_OTYPE ${gen_dir}/otype-to-str.h)
   set(KOBJ_SIZE ${gen_dir}/otype-to-size.h)
 
   file(MAKE_DIRECTORY ${gen_dir})
 
   add_custom_command(
-    OUTPUT ${KOBJ_TYPES} ${KOBJ_OTYPE} ${KOBJ_SIZE}
+    OUTPUT ${KOBJ_TYPES} ${KOBJ_MAP_TYPES} ${KOBJ_OTYPE} ${KOBJ_SIZE}
     COMMAND
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/build/gen_kobject_list.py
     --kobj-types-output ${KOBJ_TYPES}
+    --kobj-map-types-output ${KOBJ_MAP_TYPES}
     --kobj-otype-output ${KOBJ_OTYPE}
     --kobj-size-output ${KOBJ_SIZE}
     ${gen_kobject_list_include_args}
@@ -28,7 +30,7 @@ function(gen_kobj gen_dir_out)
     ${PARSE_SYSCALLS_TARGET}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
-  add_custom_target(${KOBJ_TYPES_H_TARGET} DEPENDS ${KOBJ_TYPES} ${KOBJ_OTYPE})
+  add_custom_target(${KOBJ_TYPES_H_TARGET} DEPENDS ${KOBJ_TYPES} ${KOBJ_MAP_TYPES} ${KOBJ_OTYPE})
 
   set(${gen_dir_out} ${gen_dir} PARENT_SCOPE)
 

--- a/include/zephyr/sys/kobject.h
+++ b/include/zephyr/sys/kobject.h
@@ -196,6 +196,13 @@ void k_object_access_all_grant(const void *object);
 /* LCOV_EXCL_START */
 #define K_THREAD_ACCESS_GRANT(thread, ...)
 
+/** @cond
+ *  Doxygen should ignore this build-time generated include file
+ *  when generating API documentation.  Mapping for driver types
+ *  are generated during build by gen_kobject_list.py.
+ */
+#include <kobj-map-to-types.h>
+
 /**
  * @internal
  */

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -984,6 +984,12 @@ config DEVICE_DEPS_DYNAMIC
 	  Option that makes it possible to manipulate device dependencies at
 	  runtime.
 
+config DEVICE_RUNTIME_TYPES
+	bool "Keep record of device type at runtime"
+	depends on !USERSPACE
+	help
+	  Option that makes it possible to check device type at runtime.
+
 endmenu
 
 rsource "Kconfig.vm"

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -930,6 +930,19 @@ def write_kobj_types_output(fp):
         fp.write("K_OBJ_DRIVER_%s,\n" % subsystem)
 
 
+def write_kobj_map_types_output(fp):
+    fp.write("/* Mapping driver subsystem types to enum constants */\n")
+    fp.write("#define K_OBJ_MAP_TO_TYPE(api_)    \\\n")
+    for subsystem in subsystems:
+        fp.write("COND_CODE_1(UTIL_BOOL(typeof(api_) == typeof(struct %s *)), " % subsystem)
+        subsystem = subsystem.replace("_driver_api", "").upper()
+        fp.write("(K_OBJ_DRIVER_%s), \\\n" % subsystem)
+    fp.write("            (K_OBJ_ANY)    \\\n")
+    for subsystem in subsystems:
+        fp.write(")")
+    fp.write("\n")
+
+
 def write_kobj_otype_output(fp):
     fp.write("/* Core kernel objects */\n")
     for kobj, obj_info in kobjects.items():
@@ -996,6 +1009,9 @@ def parse_args():
         "-K", "--kobj-types-output", required=False,
         help="Output k_object enum constants")
     parser.add_argument(
+        "-M", "--kobj-map-types-output", required=False,
+        help="Output mapping of devices' k_object types to enum constants")
+    parser.add_argument(
         "-S", "--kobj-otype-output", required=False,
         help="Output case statements for otype_to_str()")
     parser.add_argument(
@@ -1047,6 +1063,10 @@ def main():
     if args.kobj_types_output:
         with open(args.kobj_types_output, "w") as fp:
             write_kobj_types_output(fp)
+
+    if args.kobj_map_types_output:
+        with open(args.kobj_map_types_output, "w") as fp:
+            write_kobj_map_types_output(fp)
 
     if args.kobj_otype_output:
         with open(args.kobj_otype_output, "w") as fp:


### PR DESCRIPTION
Currently there is no reliable way to check the type of a given
device when CONFIG_USERSPACE is not enable. This makes type-cast of API
pointer quite risky.
This PR provides basic support for driver's type detection.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/44789