### PR TITLE
Bluetooth: ascs: Fix possible ASE stuck in releasing state

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -212,10 +212,10 @@ static void ascs_disconnect_stream_work_handler(struct k_work *work)
 		(void)k_work_cancel_delayable(&pair_ase->disconnect_work);
 	}
 
-
 	if (stream != NULL &&
 	    ep->iso != NULL &&
-	    ep->iso->chan.state == BT_ISO_STATE_CONNECTED) {
+	    (ep->iso->chan.state == BT_ISO_STATE_CONNECTED ||
+	     ep->iso->chan.state == BT_ISO_STATE_CONNECTING)) {
 		const int err = bt_bap_stream_disconnect(stream);
 
 		if (err != 0) {


### PR DESCRIPTION
It may happen that CIS is scheduled in the future and did not started yet once accepted. When ASE goes to Releasing state in such case the ISO has to be disconnected, because otherwise ASE will stuck in releasing state.