### PR TITLE
soc/arm/silabs: Kconfig: add SOC_GECKO_USE_RAIL kconfig option

### DIFF
--- a/boards/arm/efr32_radio/Kconfig.defconfig
+++ b/boards/arm/efr32_radio/Kconfig.defconfig
@@ -29,6 +29,13 @@ config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO
 
+if SOC_GECKO_USE_RAIL
+
+config FPU
+	default y
+
+endif # SOC_GECKO_USE_RAIL
+
 if BT
 
 config FPU

--- a/boards/arm/efr32_thunderboard/Kconfig.defconfig
+++ b/boards/arm/efr32_thunderboard/Kconfig.defconfig
@@ -23,6 +23,13 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
+if SOC_GECKO_USE_RAIL
+
+config FPU
+	default y
+
+endif # SOC_GECKO_USE_RAIL
+
 if BT
 
 config FPU

--- a/boards/arm/efr32xg24_dk2601b/Kconfig.defconfig
+++ b/boards/arm/efr32xg24_dk2601b/Kconfig.defconfig
@@ -18,6 +18,13 @@ config FLASH_BASE_ADDRESS
 	hex
 	default 0x08000000
 
+if SOC_GECKO_USE_RAIL
+
+config FPU
+	default y
+
+endif # SOC_GECKO_USE_RAIL
+
 if BT
 
 config FPU

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -60,6 +60,7 @@ config BT_SILABS_HCI
 	bool "Silicon Labs Bluetooth interface"
 	depends on SOC_SERIES_EFR32BG22 || SOC_SERIES_EFR32MG24 || SOC_SERIES_EFR32BG27
 	depends on !PM || SOC_GECKO_PM_BACKEND_PMGR
+	select SOC_GECKO_USE_RAIL
 	select ENTROPY_GENERATOR
 	select MBEDTLS
 	select MBEDTLS_PSA_CRYPTO_C

--- a/soc/arm/silabs_exx32/Kconfig
+++ b/soc/arm/silabs_exx32/Kconfig
@@ -319,4 +319,11 @@ config SOC_GECKO_HAS_HFRCO_FREQRANGE
 	  If disabled, indicates that configuration of HFRCO frequency for corresponding SOC
 	  is not supported via this field. This is the case for e.g. efm32hg, efm32wg series.
 
+config SOC_GECKO_USE_RAIL
+	bool "Use RAIL (Radio Abstraction Interface Layer)"
+	help
+	  RAIL (Radio Abstraction Interface Layer) is a library needed to use the EFR radio
+	  hardware. This option enable the proper set of features to allow to properly compile
+	  with the RAIL blob.
+
 endif # SOC_FAMILY_EXX32


### PR DESCRIPTION
Currently on zephyr, RAIL library is used only by Bluetooth applications and depends on BT_SILABS_HCI option. RAIL library is needed to use efr32 radio regardless of the protocol used. As other wireless protocols will certainly be supported in zephyr for efr32, I think it's good idea to use an other option to use RAIL. Associate changes are in the PR: [zephyrproject-rtos/hal_silabs#32](https://github.com/zephyrproject-rtos/hal_silabs/pull/32)