### PR TITLE
tests: boot: mcuboot_recovery_retention: Fix configuration issue

### DIFF
--- a/tests/boot/mcuboot_recovery_retention/sysbuild.cmake
+++ b/tests/boot/mcuboot_recovery_retention/sysbuild.cmake
@@ -1,1 +1,13 @@
 set(mcuboot_EXTRA_ZEPHYR_MODULES "${CMAKE_CURRENT_LIST_DIR}/test_module" CACHE INTERNAL "test_module directory")
+
+if(DEFINED mcuboot_TARGET_OVERLAY_CONFIG)
+  list(APPEND mcuboot_OVERLAY_CONFIG "${CMAKE_CURRENT_LIST_DIR}/sysbuild/mcuboot/${mcuboot_TARGET_OVERLAY_CONFIG}")
+  list(REMOVE_DUPLICATES mcuboot_OVERLAY_CONFIG)
+  set(mcuboot_OVERLAY_CONFIG "${mcuboot_OVERLAY_CONFIG}" CACHE INTERNAL "")
+endif()
+
+if(DEFINED mcuboot_TARGET_DTC_OVERLAY_FILE)
+  list(APPEND mcuboot_DTC_OVERLAY_FILE "${CMAKE_CURRENT_LIST_DIR}/sysbuild/mcuboot/${mcuboot_TARGET_DTC_OVERLAY_FILE}")
+  list(REMOVE_DUPLICATES mcuboot_DTC_OVERLAY_FILE)
+  set(mcuboot_DTC_OVERLAY_FILE "${mcuboot_DTC_OVERLAY_FILE}" CACHE INTERNAL "")
+endif()

--- a/tests/boot/mcuboot_recovery_retention/sysbuild/mcuboot/boards/nrf52840dk_nrf52840_mem.conf
+++ b/tests/boot/mcuboot_recovery_retention/sysbuild/mcuboot/boards/nrf52840dk_nrf52840_mem.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_RETAINED_MEM_NRF_GPREGRET=n
+CONFIG_RETAINED_MEM_ZEPHYR_RAM=y

--- a/tests/boot/mcuboot_recovery_retention/sysbuild/mcuboot/boards/nrf52840dk_nrf52840_mem.overlay
+++ b/tests/boot/mcuboot_recovery_retention/sysbuild/mcuboot/boards/nrf52840dk_nrf52840_mem.overlay
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#include "../../../boards/nrf52840dk_nrf52840_mem.overlay"
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};
+
+&zephyr_udc0 {
+	cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+	};
+};

--- a/tests/boot/mcuboot_recovery_retention/testcase.yaml
+++ b/tests/boot/mcuboot_recovery_retention/testcase.yaml
@@ -30,8 +30,10 @@ tests:
   mcuboot.recovery.retention.mem:
     platform_allow: nrf52840dk_nrf52840
     extra_args:
-      - "'OVERLAY_CONFIG=\"nrf52840dk_nrf52840_mem.conf\"'"
-      - "'DTC_OVERLAY_FILE=\"boards/nrf52840dk_nrf52840_mem.overlay\"'"
+      - OVERLAY_CONFIG="boards/nrf52840dk_nrf52840_mem.conf"
+      - DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840_mem.overlay"
+      - mcuboot_TARGET_OVERLAY_CONFIG="boards/nrf52840dk_nrf52840_mem.conf"
+      - mcuboot_TARGET_DTC_OVERLAY_FILE="boards/nrf52840dk_nrf52840_mem.overlay"
     tags:
       - mcuboot
       - sysbuild


### PR DESCRIPTION
Fixes an issue with the tests whereby the RAM memory configuration files were not being used, and could not be passed to the mcuboot image.