### PR TITLE
boards: nucleo_*: add ST Morpho connector nexus nodes

### DIFF
--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -8,6 +8,7 @@
 #include <st/f0/stm32f030X8.dtsi>
 #include <st/f0/stm32f030r8tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F030R8-NUCLEO board";

--- a/boards/arm/nucleo_f030r8/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_f030r8/st_morpho_connector.dtsi
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_9 0 &gpiof 6 0>,
+			   <ST_MORPHO_CN7_11 0 &gpiof 7 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpiof 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpiof 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_36 0 &gpiof 5 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>,
+			   <ST_MORPHO_CN10_38 0 &gpiof 4 0>;
+	};
+};

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -8,6 +8,7 @@
 #include <st/f0/stm32f070Xb.dtsi>
 #include <st/f0/stm32f070rbtx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics NUCLEO-F070RB board";

--- a/boards/arm/nucleo_f070rb/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_f070rb/st_morpho_connector.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpiof 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpiof 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -8,6 +8,7 @@
 #include <st/f0/stm32f091Xc.dtsi>
 #include <st/f0/stm32f091r(b-c)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F091RC-NUCLEO board";

--- a/boards/arm/nucleo_f091rc/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_f091rc/st_morpho_connector.dtsi
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_7 0 &gpiof 11 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpiof 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpiof 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -8,6 +8,7 @@
 #include <st/f1/stm32f103Xb.dtsi>
 #include <st/f1/stm32f103r(8-b)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F103RB-NUCLEO board";

--- a/boards/arm/nucleo_f103rb/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_f103rb/st_morpho_connector.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpiod 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpiod 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/arm/nucleo_f303re/nucleo_f303re.dts
@@ -8,6 +8,7 @@
 #include <st/f3/stm32f303Xe.dtsi>
 #include <st/f3/stm32f303r(d-e)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F303RE-NUCLEO board";

--- a/boards/arm/nucleo_f303re/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_f303re/st_morpho_connector.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpiof 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpiof 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -8,6 +8,7 @@
 #include <st/f3/stm32f334X8.dtsi>
 #include <st/f3/stm32f334r(6-8)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F334R8-NUCLEO board";

--- a/boards/arm/nucleo_f334r8/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_f334r8/st_morpho_connector.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpiof 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpiof 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -9,6 +9,7 @@
 #include <st/f4/stm32f401Xe.dtsi>
 #include <st/f4/stm32f401r(d-e)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F401RE-NUCLEO board";

--- a/boards/arm/nucleo_f401re/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_f401re/st_morpho_connector.dtsi
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpioh 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpioh 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_f410rb/nucleo_f410rb.dts
+++ b/boards/arm/nucleo_f410rb/nucleo_f410rb.dts
@@ -8,6 +8,7 @@
 #include <st/f4/stm32f410Xb.dtsi>
 #include <st/f4/stm32f410r(8-b)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F410RB-NUCLEO board";

--- a/boards/arm/nucleo_f410rb/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_f410rb/st_morpho_connector.dtsi
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpioh 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpioh 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -8,6 +8,7 @@
 #include <st/f4/stm32f411Xe.dtsi>
 #include <st/f4/stm32f411r(c-e)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F411RE-NUCLEO board";

--- a/boards/arm/nucleo_f411re/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_f411re/st_morpho_connector.dtsi
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpioh 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpioh 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -8,6 +8,7 @@
 #include <st/f4/stm32f446Xe.dtsi>
 #include <st/f4/stm32f446r(c-e)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32F446RE-NUCLEO board";

--- a/boards/arm/nucleo_f446re/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_f446re/st_morpho_connector.dtsi
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpioh 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpioh 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
@@ -8,6 +8,7 @@
 #include <st/l0/stm32l053X8.dtsi>
 #include <st/l0/stm32l053r(6-8)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L053R8-NUCLEO board";

--- a/boards/arm/nucleo_l053r8/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_l053r8/st_morpho_connector.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpioh 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpioh 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -8,6 +8,7 @@
 #include <st/l0/stm32l073Xz.dtsi>
 #include <st/l0/stm32l073r(b-z)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L073RZ-NUCLEO board";

--- a/boards/arm/nucleo_l073rz/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_l073rz/st_morpho_connector.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpioh 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpioh 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -8,6 +8,7 @@
 #include <st/l1/stm32l152Xe.dtsi>
 #include <st/l1/stm32l152retx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L152RE-NUCLEO board";

--- a/boards/arm/nucleo_l152re/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_l152re/st_morpho_connector.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpioh 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpioh 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_l452re/nucleo_l452re.dts
+++ b/boards/arm/nucleo_l452re/nucleo_l452re.dts
@@ -9,6 +9,7 @@
 #include "nucleo_l452re_common.dtsi"
 #include <st/l4/stm32l452r(c-e)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L452RE-NUCLEO board";

--- a/boards/arm/nucleo_l452re/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_l452re/st_morpho_connector.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpioh 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpioh 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -8,6 +8,7 @@
 #include <st/l4/stm32l476Xg.dtsi>
 #include <st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include "st_morpho_connector.dtsi"
 
 / {
 	model = "STMicroelectronics STM32L476RG-NUCLEO board";

--- a/boards/arm/nucleo_l476rg/st_morpho_connector.dtsi
+++ b/boards/arm/nucleo_l476rg/st_morpho_connector.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/st-morpho-header.h>
+
+/ {
+	st_morpho_header: st-morpho-header {
+		compatible = "st-morpho-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <ST_MORPHO_PIN_MASK 0x0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map = <ST_MORPHO_CN7_1 0 &gpioc 10 0>,
+			   <ST_MORPHO_CN7_2 0 &gpioc 11 0>,
+			   <ST_MORPHO_CN7_3 0 &gpioc 12 0>,
+			   <ST_MORPHO_CN7_4 0 &gpiod 2 0>,
+			   <ST_MORPHO_CN7_13 0 &gpioa 13 0>,
+			   <ST_MORPHO_CN7_15 0 &gpioa 14 0>,
+			   <ST_MORPHO_CN7_17 0 &gpioa 15 0>,
+			   <ST_MORPHO_CN7_21 0 &gpiob 7 0>,
+			   <ST_MORPHO_CN7_23 0 &gpioc 13 0>,
+			   <ST_MORPHO_CN7_25 0 &gpioc 14 0>,
+			   <ST_MORPHO_CN7_27 0 &gpioc 15 0>,
+			   <ST_MORPHO_CN7_28 0 &gpioa 0 0>,
+			   <ST_MORPHO_CN7_29 0 &gpioh 0 0>,
+			   <ST_MORPHO_CN7_30 0 &gpioa 1 0>,
+			   <ST_MORPHO_CN7_31 0 &gpioh 1 0>,
+			   <ST_MORPHO_CN7_32 0 &gpioa 4 0>,
+			   <ST_MORPHO_CN7_34 0 &gpiob 0 0>,
+			   <ST_MORPHO_CN7_35 0 &gpioc 2 0>,
+			   <ST_MORPHO_CN7_36 0 &gpioc 1 0>, /* SB56=ON, SB46=OFF */
+			   <ST_MORPHO_CN7_37 0 &gpioc 3 0>,
+			   <ST_MORPHO_CN7_38 0 &gpioc 0 0>, /* SB51=ON, SB52=OFF */
+			   <ST_MORPHO_CN10_1 0 &gpioc 9 0>,
+			   <ST_MORPHO_CN10_2 0 &gpioc 8 0>,
+			   <ST_MORPHO_CN10_3 0 &gpiob 8 0>,
+			   <ST_MORPHO_CN10_4 0 &gpioc 6 0>,
+			   <ST_MORPHO_CN10_5 0 &gpiob 9 0>,
+			   <ST_MORPHO_CN10_6 0 &gpioc 5 0>,
+			   <ST_MORPHO_CN10_11 0 &gpioa 5 0>,
+			   <ST_MORPHO_CN10_12 0 &gpioa 12 0>,
+			   <ST_MORPHO_CN10_13 0 &gpioa 6 0>,
+			   <ST_MORPHO_CN10_14 0 &gpioa 11 0>,
+			   <ST_MORPHO_CN10_15 0 &gpioa 7 0>,
+			   <ST_MORPHO_CN10_16 0 &gpiob 12 0>,
+			   <ST_MORPHO_CN10_17 0 &gpiob 6 0>,
+			   <ST_MORPHO_CN10_18 0 &gpiob 11 0>,
+			   <ST_MORPHO_CN10_19 0 &gpioc 7 0>,
+			   <ST_MORPHO_CN10_21 0 &gpioa 9 0>,
+			   <ST_MORPHO_CN10_22 0 &gpiob 2 0>,
+			   <ST_MORPHO_CN10_23 0 &gpioa 8 0>,
+			   <ST_MORPHO_CN10_24 0 &gpiob 1 0>,
+			   <ST_MORPHO_CN10_25 0 &gpiob 10 0>,
+			   <ST_MORPHO_CN10_26 0 &gpiob 15 0>,
+			   <ST_MORPHO_CN10_27 0 &gpiob 4 0>,
+			   <ST_MORPHO_CN10_28 0 &gpiob 14 0>,
+			   <ST_MORPHO_CN10_29 0 &gpiob 5 0>,
+			   <ST_MORPHO_CN10_30 0 &gpiob 13 0>,
+			   <ST_MORPHO_CN10_31 0 &gpiob 3 0>,
+			   <ST_MORPHO_CN10_33 0 &gpioa 10 0>,
+			   <ST_MORPHO_CN10_34 0 &gpioc 4 0>,
+			   <ST_MORPHO_CN10_35 0 &gpioa 2 0>,
+			   <ST_MORPHO_CN10_37 0 &gpioa 3 0>;
+	};
+};


### PR DESCRIPTION
Add ST Morpho connector nodes for all upstream boards documented in
[UM1724 User Manual for STM32 Nucleo-64 boards (MB1136)](https://www.st.com/resource/en/user_manual/um1724-stm32-nucleo64-boards-mb1136-stmicroelectronics.pdf).