### PR TITLE
scripts: west: Check for sysbuild flag when parsing test item

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -290,6 +290,7 @@ class Build(Forceable):
                     self.args.cmake_opts.extend(args)
                 else:
                     self.args.cmake_opts = args
+            self.args.sysbuild = item.get('sysbuild')
         return found_test_metadata
 
     def _sanity_precheck(self):


### PR DESCRIPTION
If build is used with -T option, sysbuild flag was ignored neverthelesss being present in sample.yaml/testcase.yaml file.