### PR TITLE
net: lwm2m: Allow setting string to zero length

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -626,7 +626,7 @@ static int lwm2m_engine_set(const struct lwm2m_obj_path *path, const void *value
 		return ret;
 	}
 
-	if (memcmp(data_ptr, value, len) != 0) {
+	if (memcmp(data_ptr, value, len) != 0 || res_inst->data_len != len) {
 		changed = true;
 	}
 
@@ -644,12 +644,18 @@ static int lwm2m_engine_set(const struct lwm2m_obj_path *path, const void *value
 	switch (obj_field->data_type) {
 
 	case LWM2M_RES_TYPE_OPAQUE:
-		memcpy((uint8_t *)data_ptr, value, len);
+		if (len) {
+			memcpy((uint8_t *)data_ptr, value, len);
+		}
 		break;
 
 	case LWM2M_RES_TYPE_STRING:
-		strncpy(data_ptr, value, len - 1);
-		((char *)data_ptr)[len - 1] = '\0';
+		if (len) {
+			strncpy(data_ptr, value, len - 1);
+			((char *)data_ptr)[len - 1] = '\0';
+		} else {
+			((char *)data_ptr)[0] = '\0';
+		}
 		break;
 
 	case LWM2M_RES_TYPE_U32:

--- a/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
+++ b/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
@@ -351,3 +351,37 @@ ZTEST(lwm2m_registry, test_strings)
 	ret = lwm2m_get_string(&path, buf, len);
 	zassert_equal(ret, -ENOMEM);
 }
+
+ZTEST(lwm2m_registry, test_null_strings)
+{
+	int ret;
+	char buf[256] = {0};
+	struct lwm2m_obj_path path = LWM2M_OBJ(0, 0, 0);
+
+	ret = lwm2m_register_post_write_callback(&path, post_write_cb);
+	zassert_equal(ret, 0);
+
+	callback_checker = 0;
+	ret = lwm2m_set_string(&path, "string");
+	zassert_equal(ret, 0);
+	zassert_equal(callback_checker, 0x02);
+	ret = lwm2m_get_string(&path, buf, sizeof(buf));
+	zassert_equal(ret, 0);
+	zassert_equal(strlen(buf), strlen("string"));
+
+	callback_checker = 0;
+	ret = lwm2m_set_string(&path, "");
+	zassert_equal(ret, 0);
+	zassert_equal(callback_checker, 0x02);
+	ret = lwm2m_get_string(&path, buf, sizeof(buf));
+	zassert_equal(ret, 0);
+	zassert_equal(strlen(buf), 0);
+
+	callback_checker = 0;
+	ret = lwm2m_set_opaque(&path, NULL, 0);
+	zassert_equal(ret, 0);
+	zassert_equal(callback_checker, 0x02);
+	ret = lwm2m_get_string(&path, buf, sizeof(buf));
+	zassert_equal(ret, 0);
+	zassert_equal(strlen(buf), 0);
+}


### PR DESCRIPTION
Lwm2m firmware object have defined a write of zero length string as a cancel operation.
So allow lwm2m_set_opaque(path, NULL, 0);