### PR TITLE
doc: css: Various fixes of figures' styling

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -866,6 +866,10 @@ kbd, .kbd,
     text-align: center;
 }
 
+.rst-content figure img {
+    background-color: var(--figure-image-background-color);
+}
+
 .wy-alert.wy-alert-danger {
     background-color: var(--admonition-danger-background-color);
 }

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -39,15 +39,11 @@ legend,
     font-weight: 500;
 }
 
-.rst-content div.figure p.caption {
+.rst-content div.figure p.caption, figcaption {
     /* Tweak caption styling to be closer to typical captions */
     text-align: center;
     margin-top: 8px;
     opacity: 0.75;
-}
-
-.rst-content div.figure.figure-w480 {
-    max-width: 480px;
 }
 
 p,

--- a/doc/_static/css/dark.css
+++ b/doc/_static/css/dark.css
@@ -90,4 +90,5 @@
     --btn-neutral-background-color: #404040;
     --btn-neutral-hover-background-color: #505050;
     --footer-color: #aaa;
+    --figure-image-background-color: white;
 }

--- a/doc/_static/css/light.css
+++ b/doc/_static/css/light.css
@@ -88,4 +88,5 @@
     --btn-neutral-background-color: #f3f6f6;
     --btn-neutral-hover-background-color: #e5ebeb;
     --footer-color: #808080;
+    --figure-image-background-color: none;
 }


### PR DESCRIPTION
Fixed a non-working rule for the styling of figure caption, but more notably added a white background to figures when using the dark theme, as a transparent bg would otherwise make many diagrams unreadable (as reported in #57069).