### PR TITLE
drivers: dma_mcux_lpc: Fix some DT issues

### DIFF
--- a/boards/arm/lpcxpresso55s28/lpcxpresso55s28.dts
+++ b/boards/arm/lpcxpresso55s28/lpcxpresso55s28.dts
@@ -87,15 +87,6 @@
 };
 
 &dma0 {
-	/*
-	 * The total number of dma channels available is defined by
-	 * FSL_FEATURE_DMA_NUMBER_OF_CHANNELS in the SoC features file.
-	 * Since memory from the heap pool is allocated based on the number
-	 * of DMA channels, set this property to as many channels is needed
-	 * for the platform. Adjust HEAP_MEM_POOL_SIZE in case you need more
-	 * memory.
-	 */
-	dma-channels = <20>;
 	status = "okay";
 };
 

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -191,7 +191,6 @@ mikrobus_spi: &hs_lspi {
 	 * memory.
 	 */
 	dma-channels = <20>;
-	nxp,dma-num-of-otrigs = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -181,19 +181,6 @@ mikrobus_serial: &flexcomm2 {
 mikrobus_spi: &hs_lspi {
 };
 
-&dma0 {
-	/*
-	 * The total number of dma channels available is defined by
-	 * FSL_FEATURE_DMA_NUMBER_OF_CHANNELS in the SoC features file.
-	 * Since memory from the heap pool is allocated based on the number
-	 * of DMA channels, set this property to as many channels is needed
-	 * for the platform. Adjust HEAP_MEM_POOL_SIZE in case you need more
-	 * memory.
-	 */
-	dma-channels = <20>;
-	status = "okay";
-};
-
 &flexcomm0 {
 	pinctrl-0 = <&pinmux_flexcomm0_usart>;
 	pinctrl-names = "default";

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -146,13 +146,11 @@
 	 * memory.
 	 */
 	dma-channels = <20>;
-	nxp,dma-num-of-otrigs = <4>;
 	status = "okay";
 };
 
 &dma1 {
 	dma-channels = <10>;
-	nxp,dma-num-of-otrigs = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -136,24 +136,6 @@
 	pinctrl-names = "default";
 };
 
-&dma0 {
-	/*
-	 * The total number of dma channels available is defined by
-	 * FSL_FEATURE_DMA_NUMBER_OF_CHANNELS in the SoC features file.
-	 * Since memory from the heap pool is allocated based on the number
-	 * of DMA channels, set this property to as many channels is needed
-	 * for the platform. Adjust HEAP_MEM_POOL_SIZE in case you need more
-	 * memory.
-	 */
-	dma-channels = <20>;
-	status = "okay";
-};
-
-&dma1 {
-	dma-channels = <10>;
-	status = "okay";
-};
-
 &mailbox0 {
 	status = "okay";
 };
@@ -208,5 +190,13 @@ i2s1: &flexcomm7 {
 };
 
 &sc_timer {
+	status = "okay";
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&dma1 {
 	status = "okay";
 };

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -364,15 +364,6 @@ arduino_serial: &flexcomm12 {
 };
 
 &dma0 {
-	/*
-	 * The total number of dma channels available is defined by
-	 * FSL_FEATURE_DMA_NUMBER_OF_CHANNELS in the SoC features file.
-	 * Since memory from the heap pool is allocated based on the number
-	 * of DMA channels, set this property to as many channels is needed
-	 * for the platform. Adjust HEAP_MEM_POOL_SIZE in case you need more
-	 * memory.
-	 */
-	dma-channels = <37>;
 	status = "okay";
 };
 

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -311,15 +311,6 @@ i2s1: &flexcomm3 {
 };
 
 &dma0 {
-	/*
-	 * The total number of dma channels available is defined by
-	 * FSL_FEATURE_DMA_NUMBER_OF_CHANNELS in the SoC features file.
-	 * Since memory from the heap pool is allocated based on the number
-	 * of DMA channels, set this property to as many channels is needed
-	 * for the platform. Adjust HEAP_MEM_POOL_SIZE in case you need more
-	 * memory.
-	 */
-	dma-channels = <20>;
 	status = "okay";
 };
 

--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -266,7 +266,6 @@ static int dma_mcux_lpc_configure(const struct device *dev, uint32_t channel,
 	struct dma_mcux_lpc_dma_data *dma_data;
 	struct dma_block_config *block_config;
 	uint32_t virtual_channel;
-	uint32_t total_dma_channels;
 	uint8_t otrig_index;
 	uint8_t src_inc, dst_inc;
 	bool is_periph = true;
@@ -298,14 +297,8 @@ static int dma_mcux_lpc_configure(const struct device *dev, uint32_t channel,
 		return -EINVAL;
 	}
 
-#if defined FSL_FEATURE_DMA_NUMBER_OF_CHANNELS
-	total_dma_channels = FSL_FEATURE_DMA_NUMBER_OF_CHANNELS;
-#else
-	total_dma_channels = FSL_FEATURE_DMA_NUMBER_OF_CHANNELSn(DEV_BASE(dev));
-#endif
-
 	/* Check if the dma channel number is valid */
-	if (channel >= total_dma_channels) {
+	if (channel >= dev_config->num_of_channels) {
 		LOG_ERR("invalid DMA channel number %d", channel);
 		return -EINVAL;
 	}
@@ -676,7 +669,6 @@ static int dma_mcux_lpc_init(const struct device *dev)
 {
 	const struct dma_mcux_lpc_config *config = dev->config;
 	struct dma_mcux_lpc_dma_data *data = dev->data;
-	int total_dma_channels;
 
 	/* Indicate that the Otrig Muxes are not connected */
 	for (int i = 0; i < config->num_of_otrigs; i++) {
@@ -684,17 +676,11 @@ static int dma_mcux_lpc_init(const struct device *dev)
 		data->otrig_array[i].linked_channel = EMPTY_OTRIG;
 	}
 
-#if defined FSL_FEATURE_DMA_NUMBER_OF_CHANNELS
-	total_dma_channels = FSL_FEATURE_DMA_NUMBER_OF_CHANNELS;
-#else
-	total_dma_channels = FSL_FEATURE_DMA_NUMBER_OF_CHANNELSn(DEV_BASE(dev));
-#endif
-
 	/*
 	 * Initialize to -1 to indicate dma channel does not have a slot
 	 * assigned to store dma channel data
 	 */
-	for (int i = 0; i < total_dma_channels; i++) {
+	for (int i = 0; i < config->num_of_channels; i++) {
 		data->channel_index[i] = -1;
 	}
 
@@ -739,13 +725,6 @@ static const struct dma_mcux_lpc_config dma_##n##_config = {		\
 	IRQ_FUNC_INIT							\
 }
 
-#ifdef FSL_FEATURE_DMA_NUMBER_OF_CHANNELS
-#define TOTAL_DMA_CHANNELS FSL_FEATURE_DMA_NUMBER_OF_CHANNELS
-#else
-#define TOTAL_DMA_CHANNELS FSL_FEATURE_DMA_NUMBER_OF_CHANNELSn		\
-				((DMA_Type *)DT_INST_REG_ADDR(n))
-#endif
-
 #define DMA_INIT(n) \
 									\
 	static const struct dma_mcux_lpc_config dma_##n##_config;	\
@@ -757,7 +736,8 @@ static const struct dma_mcux_lpc_config dma_##n##_config = {		\
 			[DT_INST_PROP_OR(n, nxp_dma_num_of_otrigs, 0)]; \
 									\
 	static int8_t							\
-		dma_##n##_channel_index_arr[TOTAL_DMA_CHANNELS] = {0};	\
+		dma_##n##_channel_index_arr				\
+				[DT_INST_PROP(n, dma_channels)] = {0};	\
 									\
 	static struct dma_mcux_lpc_dma_data dma_data_##n = {		\
 		.channel_data = dma_##n##_channel_data_arr,		\

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -159,6 +159,7 @@
 		compatible = "nxp,lpc-dma";
 		reg = <0x82000 0x1000>;
 		interrupts = <1 0>;
+		dma-channels = <23>;
 		status = "disabled";
 		#dma-cells = <1>;
 	};
@@ -167,6 +168,7 @@
 		compatible = "nxp,lpc-dma";
 		reg = <0xa7000 0x1000>;
 		interrupts = <58 0>;
+		dma-channels = <10>;
 		status = "disabled";
 		#dma-cells = <1>;
 	};

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -179,6 +179,7 @@
 		compatible = "nxp,lpc-dma";
 		reg = <0x82000 0x1000>;
 		interrupts = <1 0>;
+		nxp,dma-num-of-otrigs = <4>;
 		nxp,dma-otrig-base-address = <LPC55S69_DMA0_OTRIG_BASE>;
 		nxp,dma-itrig-base-address = <LPC55S69_DMA0_ITRIG_BASE>;
 		status = "disabled";
@@ -189,6 +190,7 @@
 		compatible = "nxp,lpc-dma";
 		reg = <0xa7000 0x1000>;
 		interrupts = <58 0>;
+		nxp,dma-num-of-otrigs = <4>;
 		nxp,dma-otrig-base-address = <LPC55S69_DMA1_OTRIG_BASE>;
 		nxp,dma-itrig-base-address = <LPC55S69_DMA1_ITRIG_BASE>;
 		status = "disabled";

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -179,6 +179,7 @@
 		compatible = "nxp,lpc-dma";
 		reg = <0x82000 0x1000>;
 		interrupts = <1 0>;
+		dma-channels = <23>;
 		nxp,dma-num-of-otrigs = <4>;
 		nxp,dma-otrig-base-address = <LPC55S69_DMA0_OTRIG_BASE>;
 		nxp,dma-itrig-base-address = <LPC55S69_DMA0_ITRIG_BASE>;
@@ -190,6 +191,7 @@
 		compatible = "nxp,lpc-dma";
 		reg = <0xa7000 0x1000>;
 		interrupts = <58 0>;
+		dma-channels = <10>;
 		nxp,dma-num-of-otrigs = <4>;
 		nxp,dma-otrig-base-address = <LPC55S69_DMA1_OTRIG_BASE>;
 		nxp,dma-itrig-base-address = <LPC55S69_DMA1_ITRIG_BASE>;

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -326,6 +326,7 @@
 		compatible = "nxp,lpc-dma";
 		reg = <0x104000 0x1000>;
 		interrupts = <1 0>;
+		dma-channels = <37>;
 		status = "disabled";
 		#dma-cells = <1>;
 	};
@@ -334,6 +335,7 @@
 		compatible = "nxp,lpc-dma";
 		reg = <0x105000 0x1000>;
 		interrupts = <54 0>;
+		dma-channels = <37>;
 		status = "disabled";
 		#dma-cells = <1>;
 	};

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -258,6 +258,7 @@
 		compatible = "nxp,lpc-dma";
 		reg = <0x104000 0x1000>;
 		interrupts = <1 0>;
+		dma-channels = <33>;
 		status = "disabled";
 		#dma-cells = <1>;
 	};
@@ -266,6 +267,7 @@
 		compatible = "nxp,lpc-dma";
 		reg = <0x105000 0x1000>;
 		interrupts = <54 0>;
+		dma-channels = <33>;
 		status = "disabled";
 		#dma-cells = <1>;
 	};


### PR DESCRIPTION
* remove the sdk based TOTAL_DMA_CHANNELS macro and instead just use the zephyr driver's num_of_channels field,
* use dma-channels DT prop correctly (describe hardware not boot configuration), 
* fix the dma-channels property to be the correct number for platforms that currently have an incorrect value in DT
* add the dma-channels property to "enabled" lpc dma nodes that don't currently have it
* set num of otrigs at SOC level