### PR TITLE
drivers: pwm: Add Intel PCH blinky PWM driver

### DIFF
--- a/boards/x86/rpl_crb/rpl_crb.yaml
+++ b/boards/x86/rpl_crb/rpl_crb.yaml
@@ -10,6 +10,7 @@ supported:
   - smbus
   - watchdog
   - rtc
+  - pwm
 testing:
   ignore_tags:
     - net

--- a/drivers/pwm/CMakeLists.txt
+++ b/drivers/pwm/CMakeLists.txt
@@ -32,6 +32,7 @@ zephyr_library_sources_ifdef(CONFIG_PWM_PCA9685 	pwm_pca9685.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_TEST		pwm_test.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_RPI_PICO	pwm_rpi_pico.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_BBLED_XEC	pwm_mchp_xec_bbled.c)
+zephyr_library_sources_ifdef(CONFIG_PWM_INTEL_BLINKY	pwm_intel_blinky.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   pwm_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_PWM_CAPTURE pwm_capture.c)

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -85,4 +85,6 @@ source "drivers/pwm/Kconfig.test"
 
 source "drivers/pwm/Kconfig.rpi_pico"
 
+source "drivers/pwm/Kconfig.intel_blinky"
+
 endif # PWM

--- a/drivers/pwm/Kconfig.intel_blinky
+++ b/drivers/pwm/Kconfig.intel_blinky
@@ -1,0 +1,11 @@
+# Intel Blinky PWM configuration options
+
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config PWM_INTEL_BLINKY
+	bool "Blinky PWM driver"
+	default y
+	depends on DT_HAS_INTEL_BLINKY_PWM_ENABLED
+	help
+	  Enable the INTEL PCH PWM driver found on Intel SoCs

--- a/drivers/pwm/pwm_intel_blinky.c
+++ b/drivers/pwm/pwm_intel_blinky.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT intel_blinky_pwm
+
+#include <errno.h>
+#include <soc.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/pwm.h>
+
+#define PWM_ENABLE              0x80000000
+#define PWM_SWUP                0x40000000
+#define PWM_FREQ_INT_SHIFT      8
+#define PWM_BASE_UNIT_FRACTION	14
+#define PWM_FREQ_MAX            0x100
+#define PWM_DUTY_MAX            0x100
+
+struct bk_intel_config {
+	DEVICE_MMIO_NAMED_ROM(reg_base);
+	uint32_t reg_offset;
+	uint32_t clock_freq;
+	uint32_t max_pins;
+};
+
+struct bk_intel_runtime {
+	DEVICE_MMIO_NAMED_RAM(reg_base);
+};
+
+static int bk_intel_set_cycles(const struct device *dev, uint32_t pin,
+			       uint32_t period_cycles, uint32_t pulse_cycles,
+			       pwm_flags_t flags)
+{
+	struct bk_intel_runtime *rt = dev->data;
+	const struct bk_intel_config *cfg = dev->config;
+	uint32_t ret = 0;
+	uint32_t val = 0;
+	uint32_t duty;
+	float period;
+	float out_freq;
+	uint32_t base_unit;
+
+	if (pin >= cfg->max_pins) {
+		ret = -EINVAL;
+		goto err;
+	}
+
+	out_freq = cfg->clock_freq / (float) period_cycles;
+	period = (out_freq * PWM_FREQ_MAX) / cfg->clock_freq;
+	base_unit = (uint32_t) (period * (1 << PWM_BASE_UNIT_FRACTION));
+	duty = (pulse_cycles * PWM_DUTY_MAX) / period_cycles;
+
+	if (duty) {
+		val = PWM_DUTY_MAX - duty;
+		val |= (base_unit << PWM_FREQ_INT_SHIFT);
+	} else {
+		val = PWM_DUTY_MAX - 1;
+	}
+
+	val |= PWM_ENABLE | PWM_SWUP;
+
+	if (period >= PWM_FREQ_MAX) {
+		ret = -EINVAL;
+		goto err;
+	}
+
+	if (duty > PWM_DUTY_MAX) {
+		ret = -EINVAL;
+		goto err;
+	}
+
+	sys_write32(val, rt->reg_base + cfg->reg_offset);
+err:
+	return ret;
+}
+
+static int bk_intel_get_cycles_per_sec(const struct device *dev, uint32_t pin,
+				       uint64_t *cycles)
+{
+	const struct bk_intel_config *cfg = dev->config;
+
+	if (pin >= cfg->max_pins) {
+		return -EINVAL;
+	}
+
+	*cycles = cfg->clock_freq;
+
+	return 0;
+}
+
+static const struct pwm_driver_api api_funcs = {
+	.set_cycles = bk_intel_set_cycles,
+	.get_cycles_per_sec = bk_intel_get_cycles_per_sec,
+};
+
+static int bk_intel_init(const struct device *dev)
+{
+	struct bk_intel_runtime *runtime = dev->data;
+	const struct bk_intel_config *config = dev->config;
+
+	device_map(&runtime->reg_base,
+		   config->reg_base.phys_addr & ~0xFFU,
+		   config->reg_base.size,
+		   K_MEM_CACHE_NONE);
+
+	return 0;
+}
+
+#define BK_INTEL_DEV_CFG(n)						       \
+	static const struct bk_intel_config bk_cfg_##n = {		       \
+		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)),	       \
+		.reg_offset = DT_INST_PROP(n, reg_offset),		       \
+		.max_pins = DT_INST_PROP(n, max_pins),			       \
+		.clock_freq = DT_INST_PROP(n, clock_frequency),		       \
+	};								       \
+									       \
+	static struct bk_intel_runtime bk_rt_##n;			       \
+	DEVICE_DT_INST_DEFINE(n, &bk_intel_init, NULL,			       \
+			      &bk_rt_##n, &bk_cfg_##n,			       \
+			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      &api_funcs);				       \
+
+DT_INST_FOREACH_STATUS_OKAY(BK_INTEL_DEV_CFG)

--- a/dts/bindings/pwm/intel,blinky-pwm.yaml
+++ b/dts/bindings/pwm/intel,blinky-pwm.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Intel blinky PWM
+
+compatible: "intel,blinky-pwm"
+
+include: [pwm-controller.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  reg-offset:
+    type: int
+    required: true
+    description: PWM control register offset from base
+
+  clock-frequency:
+    type: int
+    required: true
+    description: PWM Peripheral Clock frequency in Hz
+
+  max-pins:
+    type: int
+    required: true
+    description: Maximum number of pins supported by platform
+
+  "#pwm-cells":
+    const: 2
+
+pwm-cells:
+  - channel
+  - period

--- a/dts/x86/intel/raptor_lake.dtsi
+++ b/dts/x86/intel/raptor_lake.dtsi
@@ -496,6 +496,16 @@
 			status = "okay";
 		};
 
+		pwm0: pwm@e06a0000 {
+			compatible = "intel,blinky-pwm";
+			reg = <0xe06a0000 0x400>;
+			reg-offset = <0x304>;
+			clock-frequency = <32768>;
+			max-pins = <1>;
+			#pwm-cells = <2>;
+			status = "okay";
+		};
+
 		rtc: counter: rtc@70 {
 			compatible = "motorola,mc146818";
 			reg = <0x70 0x0D 0x71 0x0D>;

--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -47,6 +47,9 @@
 #elif DT_HAS_COMPAT_STATUS_OKAY(nxp_kinetis_ftm_pwm)
 #define PWM_DEV_NODE DT_INST(0, nxp_kinetis_ftm_pwm)
 
+#elif DT_HAS_COMPAT_STATUS_OKAY(intel_blinky_pwm)
+#define PWM_DEV_NODE DT_INST(0, intel_blinky_pwm)
+
 #else
 #error "Define a PWM device"
 #endif
@@ -56,6 +59,11 @@
 	defined(CONFIG_SOC_ESP32S3) || defined(CONFIG_SOC_ESP32C3)
 #define DEFAULT_PERIOD_CYCLE 1024
 #define DEFAULT_PULSE_CYCLE 512
+#define DEFAULT_PERIOD_NSEC 2000000
+#define DEFAULT_PULSE_NSEC 500000
+#elif DT_HAS_COMPAT_STATUS_OKAY(intel_blinky_pwm)
+#define DEFAULT_PERIOD_CYCLE 32768
+#define DEFAULT_PULSE_CYCLE 16384
 #define DEFAULT_PERIOD_NSEC 2000000
 #define DEFAULT_PULSE_NSEC 500000
 #else

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -6,4 +6,5 @@ tests:
       - userspace
     filter: dt_alias_exists("pwm-0") or dt_alias_exists("pwm-1") or dt_alias_exists("pwm-2")
       or dt_alias_exists("pwm-3") or dt_compat_enabled("st,stm32-pwm")
+      or dt_compat_enabled("intel,blinky-pwm")
     depends_on: pwm


### PR DESCRIPTION
Submitting this PR for review for new PWM driver for the IP found in multiple intel PCH hardwares.
This PR includes commits for
a) The driver code
b) dts node for pwm
c) enable pwm_api test for rpl_crb

we can verify using "west build -b rpl_crb tests/drivers/pwm/pwm_api/"