### PR TITLE
soc: xtensa: esp32s3: add support for SPIRAM

### DIFF
--- a/soc/xtensa/espressif_esp32/common/Kconfig.soc
+++ b/soc/xtensa/espressif_esp32/common/Kconfig.soc
@@ -40,6 +40,15 @@ config ESP_HEAP_SEARCH_ALL_REGIONS
 menu "SPI RAM config"
 	depends on ESP_SPIRAM
 
+choice SPIRAM_MODE
+	prompt "Mode (QUAD/OCT) of SPI RAM chip in use"
+	default SPIRAM_MODE_QUAD
+
+config SPIRAM_MODE_QUAD
+	bool "Quad Mode PSRAM"
+
+endchoice # SPIRAM_MODE
+
 choice SPIRAM_TYPE
 	prompt "Type of SPI RAM chip in use"
 	depends on ESP_SPIRAM
@@ -97,6 +106,10 @@ config SPIRAM_SPEED_40M
 config SPIRAM_SPEED_80M
 	depends on ESPTOOLPY_FLASHFREQ_80M
 	bool "80MHz clock speed"
+
+config SPIRAM_SPEED_120M
+	depends on SPIRAM_MODE_QUAD && SOC_SERIES_ESP32S3
+	bool "120MHz clock speed"
 
 endchoice # SPIRAM_SPEED
 

--- a/soc/xtensa/espressif_esp32/esp32s3/Kconfig.soc
+++ b/soc/xtensa/espressif_esp32/esp32s3/Kconfig.soc
@@ -293,4 +293,23 @@ config MAC_BB_PD
 
 endmenu  # Cache config
 
+menu "PSRAM Clock and CS IO for ESP32S3"
+	depends on ESP_SPIRAM
+
+config DEFAULT_PSRAM_CLK_IO
+	int "PSRAM CLK IO number"
+	range 0 33
+	default 30
+	help
+	  The PSRAM Clock IO can be any unused GPIO, please refer to your hardware design.
+
+config DEFAULT_PSRAM_CS_IO
+	int "PSRAM CS IO number"
+	range 0 33
+	default 26
+	help
+	  The PSRAM CS IO can be any unused GPIO, please refer to your hardware design.
+
+endmenu # PSRAM clock and cs IO for ESP32S3
+
 endif # SOC_SERIES_ESP32S3

--- a/soc/xtensa/espressif_esp32/esp32s3/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32s3/default.ld
@@ -39,6 +39,8 @@
 #define RAMABLE_REGION dram0_0_seg
 #define ROMABLE_REGION ROM
 
+#define EXT_RAM_ORG (0x3E000000 - CONFIG_ESP_SPIRAM_SIZE)
+
 #ifdef CONFIG_FLASH_SIZE
 #define FLASH_SIZE CONFIG_FLASH_SIZE
 #else
@@ -70,7 +72,13 @@ MEMORY
    * Hence, an offset of 0x40 is added to DROM segment origin.
    */
   drom0_0_seg(R): org = 0x3C000040, len = FLASH_SIZE - 0x40
-
+  /**
+   * `extern_ram_seg` and `drom0_0_seg` share the same bus and the address region.
+   * so we allocate `extern_ram_seg` at the end of the address region.
+   */
+#if defined(CONFIG_ESP_SPIRAM)
+  ext_ram_seg(RWX): org = EXT_RAM_ORG, len = CONFIG_ESP_SPIRAM_SIZE
+#endif
   /* RTC fast memory (executable). Persists over deep sleep.
    */
   rtc_iram_seg(RWX): org = 0x600fe000, len = 0x2000
@@ -219,6 +227,17 @@ SECTIONS
     _image_rodata_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)
 
+#if defined(CONFIG_ESP_SPIRAM)
+  /* This section holds .ext_ram.bss data, and will be put in PSRAM */
+  .ext_ram.bss (NOLOAD) :
+  {
+    _ext_ram_bss_start = ABSOLUTE(.);
+    *(.ext_ram.bss*)
+    . = ALIGN(4);
+    _ext_ram_bss_end = ABSOLUTE(.);
+  } > ext_ram_seg
+#endif
+
   /* Send .iram0 code to iram */
   .iram0.vectors : ALIGN(4)
   {
@@ -272,6 +291,9 @@ SECTIONS
     *libsoc.a:rtc_*.*(.literal .text .literal.* .text.*)
     *libsoc.a:cpu_util.*(.literal .text .literal.* .text.*)
     *libgcc.a:lib2funcs.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spiram*.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spi_timing*.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:spi_flash*.*(.literal .text .literal.* .text.*)
     *libdrivers__flash.a:flash_esp32.*(.literal .text .literal.* .text.*)
     *libzephyr.a:windowspill_asm.*(.literal .text .literal.* .text.*)
     *libzephyr.a:log_noos.*(.literal .text .literal.* .text.*)
@@ -642,3 +664,8 @@ SECTIONS
 
 ASSERT(((_iram_end - ORIGIN(iram0_0_seg)) <= LENGTH(iram0_0_seg)),
           "IRAM0 segment data does not fit.")
+
+#if defined(CONFIG_ESP_SPIRAM)
+ASSERT(((ORIGIN(ext_ram_seg)) > _image_rodata_end),
+          "External RAM segment does not fit.")
+#endif

--- a/soc/xtensa/espressif_esp32/esp32s3/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32s3/default.ld
@@ -236,6 +236,17 @@ SECTIONS
     . = ALIGN(4);
     _ext_ram_bss_end = ABSOLUTE(.);
   } > ext_ram_seg
+
+  .ext_ram_noinit (NOLOAD) :
+  {
+#if defined(CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM)
+    *libdrivers__wifi.a:(.noinit .noinit.*)
+    *libsubsys__net__l2__ethernet.a:(.noinit .noinit.*)
+    *libsubsys__net__lib__config.a:(.noinit .noinit.*)
+    *libsubsys__net__ip.a:(.noinit .noinit.*)
+    *libsubsys__net.a:(.noinit .noinit.*)
+#endif
+  } > ext_ram_seg
 #endif
 
   /* Send .iram0 code to iram */

--- a/tests/boards/espressif_esp32/cache_coex/README.rst
+++ b/tests/boards/espressif_esp32/cache_coex/README.rst
@@ -12,32 +12,44 @@ with a random generated pattern. At the same time, a whole SPI Flash page is upd
 value. By the end of the thread iterations, both PSRAM and SPI Flash have its contents compared against
 expected values to check for integrity.
 
+Supported Boards
+****************
+- esp32_devkitc_wrover
+- esp32s2_saola
+- esp32s3_devkitm
+
 Building and Running
 ********************
 
-Make sure you have the ESP32 DevKitC connected over USB port.
+Make sure you have the target connected over USB port.
 
 .. code-block:: console
 
-   west build -b esp32_devkitc_wrover tests/boards/espressif_esp32/cache_coex
-   west flash --esp-device /dev/ttyUSB0
+   west build -b <board> tests/boards/espressif_esp32/cache_coex
+   west flash && west espressif monitor
 
 Sample Output
 =============
 
-To check output of this test, any serial console program can be used (i.e. on Linux picocom, putty, screen, etc).
-This test uses ``minicom`` on the serial port ``/dev/ttyUS0``. The following lines indicate a successful test:
-
 .. code-block:: console
 
-    Running test suite cache_coex_test
-    ===================================================================
-    START - flash_integrity_test
-     PASS - flash_integrity_test in 0.1 seconds
-    ===================================================================
-    START - ram_integrity_test
-     PASS - ram_integrity_test in 0.1 seconds
-    ===================================================================
-    Test suite cache_coex_test succeeded
-    ===================================================================
-    PROJECT EXECUTION SUCCESSFUL
+	Running TESTSUITE cache_coex
+	===================================================================
+	START - test_flash_integrity
+	PASS - test_flash_integrity in 0.001 seconds
+	===================================================================
+	START - test_ram_integrity
+	PASS - test_ram_integrity in 0.001 seconds
+	===================================================================
+	START - test_using_spiram
+	PASS - test_using_spiram in 0.001 seconds
+	===================================================================
+	TESTSUITE cache_coex succeeded
+	------ TESTSUITE SUMMARY START ------
+	SUITE PASS - 100.00% [cache_coex]: pass = 3, fail = 0, skip = 0, total = 3 duration = 0.003 seconds
+	- PASS - [cache_coex.test_flash_integrity] duration = 0.001 seconds
+	- PASS - [cache_coex.test_ram_integrity] duration = 0.001 seconds
+	- PASS - [cache_coex.test_using_spiram] duration = 0.001 seconds
+	------ TESTSUITE SUMMARY END ------
+	===================================================================
+	PROJECT EXECUTION SUCCESSFUL

--- a/tests/boards/espressif_esp32/cache_coex/testcase.yaml
+++ b/tests/boards/espressif_esp32/cache_coex/testcase.yaml
@@ -1,6 +1,9 @@
 tests:
   boards.esp32.cache_coex:
-    platform_allow: esp32_devkitc_wrover esp32s2_saola
+    platform_allow:
+      - esp32_devkitc_wrover
+      - esp32s2_saola
+      - esp32s3_devkitm
     tags:
       - spiram
       - spiflash


### PR DESCRIPTION
Add support for external PSRAM for esp32s3.
Test esp32s3 for cache coexistence. Update test documentation.
Add section to allocate memory of WiFi and NET stack in SPIRAM