### PR TITLE
drivers: power_domain: gpio: Allow enabled at boot

### DIFF
--- a/dts/bindings/power-domain/power-domain-gpio.yaml
+++ b/dts/bindings/power-domain/power-domain-gpio.yaml
@@ -28,3 +28,7 @@ properties:
     type: int
     default: 0
     description: Off delay time, in microseconds
+
+  boot-on:
+    type: boolean
+    description: If set, enable power at boot time


### PR DESCRIPTION
Allow for gpio power domain to be enabled at boot time.