### PR TITLE
Bluetooth: ascs: Handle ASE control point operations in separate thread

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -795,7 +795,6 @@ static void ascs_iso_connected(struct bt_iso_chan *chan)
 static void ascs_ep_iso_disconnected(struct bt_bap_ep *ep, uint8_t reason)
 {
 	struct bt_ascs_ase *ase = CONTAINER_OF(ep, struct bt_ascs_ase, ep);
-	const struct bt_bap_stream_ops *ops;
 	struct bt_bap_stream *stream;
 
 	stream = ep->stream;
@@ -803,8 +802,6 @@ static void ascs_ep_iso_disconnected(struct bt_bap_ep *ep, uint8_t reason)
 		LOG_ERR("No stream for ep %p", ep);
 		return;
 	}
-
-	ops = stream->ops;
 
 	LOG_DBG("stream %p ep %p reason 0x%02x", stream, stream->ep, reason);
 

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -340,7 +340,7 @@ static inline const char *bt_ascs_reason_str(uint8_t reason)
 int bt_ascs_init(const struct bt_bap_unicast_server_cb *cb);
 void bt_ascs_cleanup(void);
 
-void ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state);
+int ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state);
 
 int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 		       struct bt_audio_codec_cfg *codec_cfg,

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -86,9 +86,7 @@ int bt_bap_unicast_server_reconfig(struct bt_bap_stream *stream,
 
 	(void)memcpy(&ep->codec_cfg, codec_cfg, sizeof(*codec_cfg));
 
-	ascs_ep_set_state(ep, BT_BAP_EP_STATE_CODEC_CONFIGURED);
-
-	return 0;
+	return ascs_ep_set_state(ep, BT_BAP_EP_STATE_CODEC_CONFIGURED);
 }
 
 int bt_bap_unicast_server_start(struct bt_bap_stream *stream)
@@ -106,10 +104,10 @@ int bt_bap_unicast_server_start(struct bt_bap_stream *stream)
 	 * else wait for ISO to be connected
 	 */
 	if (ep->iso->chan.state == BT_ISO_STATE_CONNECTED) {
-		ascs_ep_set_state(ep, BT_BAP_EP_STATE_STREAMING);
-	} else {
-		ep->receiver_ready = true;
+		return ascs_ep_set_state(ep, BT_BAP_EP_STATE_STREAMING);
 	}
+
+	ep->receiver_ready = true;
 
 	return 0;
 }
@@ -140,9 +138,7 @@ int bt_bap_unicast_server_metadata(struct bt_bap_stream *stream, struct bt_audio
 	}
 
 	/* Set the state to the same state to trigger the notifications */
-	ascs_ep_set_state(ep, ep->status.state);
-
-	return 0;
+	return ascs_ep_set_state(ep, ep->status.state);
 }
 
 int bt_bap_unicast_server_disable(struct bt_bap_stream *stream)

--- a/tests/bluetooth/audio/mocks/src/kernel.c
+++ b/tests/bluetooth/audio/mocks/src/kernel.c
@@ -56,6 +56,23 @@ int k_work_cancel_delayable(struct k_work_delayable *dwork)
 	return 0;
 }
 
+void k_work_init(struct k_work *work, k_work_handler_t handler)
+{
+	work->handler = handler;
+}
+
+int k_work_submit(struct k_work *work)
+{
+	work->handler(work);
+
+	return 0;
+}
+
+int k_work_busy_get(const struct k_work *work)
+{
+	return 0;
+}
+
 int32_t k_sleep(k_timeout_t timeout)
 {
 	struct k_work *work;


### PR DESCRIPTION
This adds handling of ASE control point operations in separate thread
so that the notifications of ASE state changes are sent from non-BTRX
thread. This ensures bt_gatt_notify_cb to be blocking waiting for
available buffers to send the notifications.