### PR TITLE
subsys: net: lib: lwm2m: Use int16_t for signal strength

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_connmon.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_connmon.c
@@ -84,7 +84,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 /* resource state variables */
 static int8_t net_bearer;
-static int8_t rss;
+static int16_t rss;
 static uint8_t link_quality;
 static uint32_t cellid;
 static uint16_t mnc;
@@ -99,7 +99,7 @@ static struct lwm2m_engine_obj connmon;
 static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(CONNMON_NETWORK_BEARER_ID, R, U8),
 	OBJ_FIELD_DATA(CONNMON_AVAIL_NETWORK_BEARER_ID, R, U8),
-	OBJ_FIELD_DATA(CONNMON_RADIO_SIGNAL_STRENGTH, R, S8),
+	OBJ_FIELD_DATA(CONNMON_RADIO_SIGNAL_STRENGTH, R, S16),
 	OBJ_FIELD_DATA(CONNMON_LINK_QUALITY, R, U8),
 	OBJ_FIELD_DATA(CONNMON_IP_ADDRESSES, R, STRING),
 	OBJ_FIELD_DATA(CONNMON_ROUTER_IP_ADDRESSES, R_OPT, STRING),

--- a/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
+++ b/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
@@ -130,12 +130,12 @@ ZTEST(lwm2m_registry, test_connmon)
 	int ret;
 	uint16_t u16_buf = 0;
 	uint32_t u32_buf = 0;
-	int8_t s8_buf = 0;
+	int16_t s16_buf = 0;
 	int32_t s32_buf = 0;
 
 	uint16_t u16_getbuf = 0;
 	uint32_t u32_getbuf = 0;
-	int8_t s8_getbuf = 0;
+	int16_t s16_getbuf = 0;
 	int32_t s32_getbuf = 0;
 
 	ret = lwm2m_set_res_buf(&LWM2M_OBJ(4, 0, 9), &u16_buf, sizeof(u16_buf),
@@ -144,8 +144,8 @@ ZTEST(lwm2m_registry, test_connmon)
 	ret = lwm2m_set_res_buf(&LWM2M_OBJ(4, 0, 8), &u32_buf, sizeof(u32_buf),
 				sizeof(u32_buf), 0);
 	zassert_equal(ret, 0);
-	ret = lwm2m_set_res_buf(&LWM2M_OBJ(4, 0, 2), &s8_buf, sizeof(s8_buf),
-				sizeof(s8_buf), 0);
+	ret = lwm2m_set_res_buf(&LWM2M_OBJ(4, 0, 2), &s16_buf, sizeof(s16_buf),
+				sizeof(s16_buf), 0);
 	zassert_equal(ret, 0);
 	ret = lwm2m_set_res_buf(&LWM2M_OBJ(4, 0, 11), &s32_buf, sizeof(s32_buf),
 				sizeof(s32_buf), 0);
@@ -155,28 +155,28 @@ ZTEST(lwm2m_registry, test_connmon)
 	zassert_equal(ret, 0);
 	ret = lwm2m_set_u32(&LWM2M_OBJ(4, 0, 8), 0xDEADBEEF);
 	zassert_equal(ret, 0);
-	ret = lwm2m_set_s8(&LWM2M_OBJ(4, 0, 2), -5);
+	ret = lwm2m_set_s16(&LWM2M_OBJ(4, 0, 2), -5);
 	zassert_equal(ret, 0);
 	ret = lwm2m_set_s32(&LWM2M_OBJ(4, 0, 11), 0xCC00CC00);
 	zassert_equal(ret, 0);
 
 	zassert_equal(u16_buf, 0x5A5A);
 	zassert_equal(u32_buf, 0xDEADBEEF);
-	zassert_equal(s8_buf, -5);
+	zassert_equal(s16_buf, -5);
 	zassert_equal(s32_buf, 0xCC00CC00);
 
 	ret = lwm2m_get_u16(&LWM2M_OBJ(4, 0, 9), &u16_getbuf);
 	zassert_equal(ret, 0);
 	ret = lwm2m_get_u32(&LWM2M_OBJ(4, 0, 8), &u32_getbuf);
 	zassert_equal(ret, 0);
-	ret = lwm2m_get_s8(&LWM2M_OBJ(4, 0, 2), &s8_getbuf);
+	ret = lwm2m_get_s16(&LWM2M_OBJ(4, 0, 2), &s16_getbuf);
 	zassert_equal(ret, 0);
 	ret = lwm2m_get_s32(&LWM2M_OBJ(4, 0, 11), &s32_getbuf);
 	zassert_equal(ret, 0);
 
 	zassert_equal(u16_buf, u16_getbuf);
 	zassert_equal(u32_buf, u32_getbuf);
-	zassert_equal(s8_buf, s8_getbuf);
+	zassert_equal(s16_buf, s16_getbuf);
 	zassert_equal(s32_buf, s32_getbuf);
 }
 


### PR DESCRIPTION
### Description
The signal strength for the connectivity monitor was defined as int8_t.
However this was too small for LTE RSRP values, which has range [-140,-44].