### PR TITLE
devicetree: Prefix and Postfix helpers for enums

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -918,6 +918,226 @@
 	DT_CAT4(node_id, _P_, prop, _STRING_TOKEN)
 
 /**
+ * @brief Get a string property's value as a token.
+ *
+ * This removes "the quotes" from a string property's value,
+ * converting any non-alphanumeric characters to underscores. This can
+ * be useful, for example, when programmatically using the value to
+ * form a C variable or code.
+ *
+ * DT_STRING_TOKEN_PREFIX() can only be used for properties with string type.
+ *
+ * It is an error to use DT_STRING_TOKEN_PREFIX() in other circumstances.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     n1: node-1 {
+ *             prop = "foo";
+ *     };
+ *     n2: node-2 {
+ *             prop = "BAR";
+ *     }
+ *     n3: node-3 {
+ *             prop = "foo BAR";
+ *     };
+ * @endcode
+ *
+ * Example bindings fragment:
+ *
+ * @code{.yaml}
+ *     properties:
+ *       prop:
+ *         type: string
+ *         enum:
+ *           - "foo"
+ *           - "BAR"
+ *           - "foo BAR"
+ * @endcode
+ *
+ * Example enumeration
+ *
+ * @code{.c}
+ *     enum prop_value {
+ *         PROP_VAL_foo = 0x10,
+ *         PROP_VAL_BAR = 0x20,
+ *         PROP_VAL_foo_BAR = 0x40,
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_STRING_TOKEN_PREFIX(DT_NODELABEL(n1), prop, PROP_VAL_) // PROP_VAL_foo
+ *     DT_STRING_TOKEN_PREFIX(DT_NODELABEL(n2), prop, PROP_VAL_) // PROP_VAL_BAR
+ *     DT_STRING_TOKEN_PREFIX(DT_NODELABEL(n3), prop, PROP_VAL_) // PROP_VAL_foo_BAR
+ * @endcode
+ *
+ * Notice how:
+ *
+ * - The uppercased `"FOO"` in the DTS remains `FOO` as a token. It is
+ *   *not* converted to `foo`.
+ *
+ * - The whitespace in the DTS `"123 foo"` string is converted to
+ *   `123_foo` as a token.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param prefix Prefix prepended to the string token
+ * @return the value of @p prop as a token, i.e. without any quotes
+ *         and with special characters converted to underscores
+ */
+#define DT_STRING_TOKEN_PREFIX(node_id, prop, prefix) \
+	UTIL_CAT(prefix, DT_STRING_TOKEN(node_id, prop))
+
+/**
+ * @brief Get a string property's value as a token.
+ *
+ * This removes "the quotes" from a string property's value,
+ * converting any non-alphanumeric characters to underscores. This can
+ * be useful, for example, when programmatically using the value to
+ * form a C variable or code.
+ *
+ * DT_STRING_TOKEN_PREFIX() can only be used for properties with string type.
+ *
+ * It is an error to use DT_STRING_TOKEN_PREFIX() in other circumstances.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     n1: node-1 {
+ *             prop = "foo";
+ *     };
+ *     n2: node-2 {
+ *             prop = "BAR";
+ *     }
+ *     n3: node-3 {
+ *             prop = "foo BAR";
+ *     };
+ * @endcode
+ *
+ * Example bindings fragment:
+ *
+ * @code{.yaml}
+ *     properties:
+ *       prop:
+ *         type: string
+ *         enum:
+ *          - "foo"
+ *          - "BAR"
+ *          - "foo BAR"
+ * @endcode
+ *
+ * Example enumeration
+ *
+ * @code{.c}
+ *     enum prop_value {
+ *         foo_PROP = 0x10,
+ *         BAR_PROP = 0x20,
+ *         foo_BAR_PROP = 0x40,
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_STRING_TOKEN_POSTFIX(DT_NODELABEL(n1), prop, _PROP) // foo_PROP
+ *     DT_STRING_TOKEN_POSTFIX(DT_NODELABEL(n2), prop, _PROP) // BAR_PROP
+ *     DT_STRING_TOKEN_POSTFIX(DT_NODELABEL(n3), prop, _PROP) // foo_BAR_PROP
+ * @endcode
+ *
+ * Notice how:
+ *
+ * - The uppercased `"BAR"` in the DTS remains `BAR` as a token. It is
+ *   *not* converted to `BAR`.
+ *
+ * - The whitespace in the DTS `"foo BAR"` string is converted to
+ *   `foo_BAR` as a token.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param postfix Appended to the token
+ * @return the value of @p prop as a token, i.e. without any quotes
+ *         and with special characters converted to underscores
+ */
+#define DT_STRING_TOKEN_POSTFIX(node_id, prop, postfix) \
+	UTIL_CAT(DT_STRING_TOKEN(node_id, prop), postfix)
+
+/**
+ * @brief Get a string property's value as a token.
+ *
+ * This removes "the quotes" from a string property's value,
+ * converting any non-alphanumeric characters to underscores. This can
+ * be useful, for example, when programmatically using the value to
+ * form a C variable or code.
+ *
+ * DT_STRING_TOKEN_PREFIX() can only be used for properties with string type.
+ *
+ * It is an error to use DT_STRING_TOKEN_PREFIX() in other circumstances.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     n1: node-1 {
+ *             prop = "foo";
+ *     };
+ *     n2: node-2 {
+ *             prop = "BAR";
+ *     }
+ *     n3: node-3 {
+ *             prop = "foo BAR";
+ *     };
+ * @endcode
+ *
+ * Example bindings fragment:
+ *
+ * @code{.yaml}
+ *     properties:
+ *       prop:
+ *         type: string
+ *         enum:
+ *           - "foo"
+ *           - "BAR"
+ *           - "foo BAR"
+ * @endcode
+ *
+ * Example enumeration
+ *
+ * @code{.c}
+ *     enum prop_value {
+ *         PROP_foo_VAL = 0x10,
+ *         PROP_BAR_VAL = 0x20,
+ *         PROP_foo_BAR_VAL = 0x40,
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_STRING_TOKEN_PREFIX_POSTFIX(DT_NODELABEL(n1), prop, PROP_, _VAL) // PROP_VAL_foo
+ *     DT_STRING_TOKEN_PREFIX_POSTFIX(DT_NODELABEL(n2), prop, PROP_, _VAL) // PROP_VAL_BAR
+ *     DT_STRING_TOKEN_PREFIX_POSTFIX(DT_NODELABEL(n3), prop, PROP_, _VAL) // PROP_VAL_foo_BAR
+ * @endcode
+ *
+ * Notice how:
+ *
+ * - The uppercased `"FOO"` in the DTS remains `FOO` as a token. It is
+ *   *not* converted to `foo`.
+ *
+ * - The whitespace in the DTS `"123 foo"` string is converted to
+ *   `123_foo` as a token.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param prefix Prepended to the token
+ * @param postfix Appended to the token
+ * @return the value of @p prop as a token, i.e. without any quotes
+ *         and with special characters converted to underscores
+ */
+#define DT_STRING_TOKEN_PREFIX_POSTFIX(node_id, prop, prefix, postfix) \
+	UTIL_CAT(UTIL_CAT(prefix, DT_STRING_TOKEN(node_id, prop)), postfix)
+
+/**
  * @brief Like DT_STRING_TOKEN(), but with a fallback to @p default_value
  *
  * If the value exists, this expands to DT_STRING_TOKEN(node_id, prop).
@@ -932,7 +1152,66 @@
  */
 #define DT_STRING_TOKEN_OR(node_id, prop, default_value) \
 	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
-		(DT_STRING_TOKEN(node_id, prop)), (default_value))
+		(DT_STRING_TOKEN(node_id, prop)), \
+		(default_value))
+
+/**
+ * @brief Like DT_STRING_TOKEN_PREFIX(), but with a fallback to @p default_value
+ *
+ * If the value exists, this expands to DT_STRING_TOKEN(node_id, prop).
+ * The @p default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to @p default_value.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param prefix Prefix prepended to the token
+ * @param default_value a fallback value to expand to
+ * @return the property's value as a token, or @p default_value
+ */
+#define DT_STRING_TOKEN_PREFIX_OR(node_id, prop, prefix, default_value) \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
+		(DT_STRING_TOKEN_PREFIX(node_id, prop, prefix)), \
+		(default_value))
+
+/**
+ * @brief Like DT_STRING_TOKEN_POSTFIX(), but with a fallback to @p default_value
+ *
+ * If the value exists, this expands to DT_STRING_TOKEN(node_id, prop).
+ * The @p default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to @p default_value.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param postfix Postfix appended to the token
+ * @param default_value a fallback value to expand to
+ * @return the property's value as a token, or @p default_value
+ */
+#define DT_STRING_TOKEN_POSTFIX_OR(node_id, prop, postfix, default_value) \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
+		(DT_STRING_TOKEN_POSTFIX(node_id, prop, postfix)), \
+		(default_value))
+
+/**
+ * @brief Like DT_STRING_TOKEN_PREFIX_POSTFIX(), but with a fallback to @p default_value
+ *
+ * If the value exists, this expands to DT_STRING_TOKEN(node_id, prop).
+ * The @p default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to @p default_value.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param prefix Prefix prepended to the token
+ * @param postfix Postfix appended to the token
+ * @param default_value a fallback value to expand to
+ * @return the property's value as a token, or @p default_value
+ */
+#define DT_STRING_TOKEN_PREFIX_POSTFIX_OR(node_id, prop, prefix, postfix, default_value) \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
+		(DT_STRING_TOKEN_PREFIX_POSTFIX(node_id, prop, prefix, postfix)), \
+		(default_value))
 
 /**
  * @brief Like DT_STRING_TOKEN(), but uppercased.
@@ -995,6 +1274,123 @@
 	DT_CAT4(node_id, _P_, prop, _STRING_UPPER_TOKEN)
 
 /**
+ * @brief Like DT_STRING_TOKEN_PREFIX(), but uppercased.
+ *
+ * This removes "the quotes" from a string property's value,
+ * converting any non-alphanumeric characters to underscores, and
+ * capitalizing the result. This can be useful, for example, when
+ * programmatically using the value to form a C variable or code.
+ *
+ * DT_STRING_UPPER_TOKEN_PREFIX() can only be used for properties with string type.
+ *
+ * It is an error to use DT_STRING_UPPER_TOKEN_PREFIX() in other circumstances.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     n1: node-1 {
+ *             prop = "foo";
+ *     };
+ *     n2: node-2 {
+ *             prop = "foo BAR";
+ *     };
+ * @endcode
+ *
+ * Example bindings fragment:
+ *
+ * @code{.yaml}
+ *     properties:
+ *       prop:
+ *         type: string
+ *         enum:
+ *           - "foo"
+ *           - "BAR"
+ *           - "foo BAR"
+ * @endcode
+ *
+ * Example enumeration
+ *
+ * @code{.c}
+ *     enum prop_value {
+ *         PROP_VAL_FOO = 0x10,
+ *         PROP_VAL_BAR = 0x20,
+ *         PROP_VAL_FOO_BAR = 0x40,
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_STRING_UPPER_TOKEN_PREFIX(DT_NODELABEL(n1), prop, PROP_VAL_) // PROP_VAL_FOO
+ *     DT_STRING_UPPER_TOKEN_PREFIX(DT_NODELABEL(n2), prop, PROP_VAL_) // PROP_VAL_FOO_BAR
+ * @endcode
+ *
+ * Notice how:
+ *
+ * - The lowercased `"foo"` in the DTS becomes `FOO` as a token, i.e.
+ *   it is uppercased.
+ *
+ * - The whitespace in the DTS `"foo BAR"` string is converted to
+ *   `FOO_BAR` as a token, i.e. it is uppercased and whitespace becomes
+ *   an underscore.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param prefix Prepended to the token
+ * @return the value of @p prop as an uppercased token, i.e. without
+ *         any quotes and with special characters converted to underscores
+ */
+#define DT_STRING_UPPER_TOKEN_PREFIX(node_id, prop, prefix) \
+	UTIL_CAT(prefix, DT_STRING_UPPER_TOKEN(node_id, prop))
+
+/**
+ * @brief Like DT_STRING_TOKEN_POSTFIX(), but with an uppercased token.
+ *
+ * This removes "the quotes" from a string property's value,
+ * converting any non-alphanumeric characters to underscores, and
+ * capitalizing the result. This can be useful, for example, when
+ * programmatically using the value to form a C variable or code.
+ *
+ * DT_STRING_UPPER_TOKEN_POSTFIX() can only be used for properties with string type.
+ *
+ * It is an error to use DT_STRING_UPPER_TOKEN_POSTFIX() in other circumstances.
+ *
+ * For examples check, DT_STRING_UPPER_TOKEN_PREFIX() and DT_STRING_TOKEN_POSTFIX()
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param postfix Appended to the token
+ * @return the value of @p prop as an uppercased token, i.e. without
+ *         any quotes and with special characters converted to underscores
+ */
+#define DT_STRING_UPPER_TOKEN_POSTFIX(node_id, prop, postfix) \
+	UTIL_CAT(DT_STRING_UPPER_TOKEN(node_id, prop), postfix)
+
+/**
+ * @brief Like DT_STRING_TOKEN_PREFIX_POSTFIX(), but with an uppercased token.
+ *
+ * This removes "the quotes" from a string property's value,
+ * converting any non-alphanumeric characters to underscores, and
+ * capitalizing the result. This can be useful, for example, when
+ * programmatically using the value to form a C variable or code.
+ *
+ * DT_STRING_UPPER_TOKEN_PREFIX_POSTFIX() can only be used for properties with string type.
+ *
+ * It is an error to use DT_STRING_UPPER_TOKEN_PREFIX_POSTFIX() in other circumstances.
+ *
+ * For examples check, DT_STRING_UPPER_TOKEN_PREFIX() and DT_STRING_TOKEN_PREFIX_POSTFIX()
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param prefix Prepended to the token
+ * @param postfix Appended to the token
+ * @return the value of @p prop as an uppercased token, i.e. without
+ *         any quotes and with special characters converted to underscores
+ */
+#define DT_STRING_UPPER_TOKEN_PREFIX_POSTFIX(node_id, prop, prefix, postfix) \
+	UTIL_CAT(UTIL_CAT(prefix, DT_STRING_UPPER_TOKEN(node_id, prop)), postfix)
+
+/**
  * @brief Like DT_STRING_UPPER_TOKEN(), but with a fallback to @p default_value
  *
  * If the value exists, this expands to DT_STRING_UPPER_TOKEN(node_id, prop).
@@ -1011,6 +1407,70 @@
 #define DT_STRING_UPPER_TOKEN_OR(node_id, prop, default_value) \
 	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
 		(DT_STRING_UPPER_TOKEN(node_id, prop)), (default_value))
+
+/**
+ * @brief Like DT_STRING_UPPER_TOKEN_PREFIX(), but with a fallback
+ *        to @p default_value
+ *
+ * If the value exists, this expands to DT_STRING_UPPER_TOKEN_PREFIX(node_id, prop).
+ * The @p default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to @p default_value.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param prefix Prepended to the token
+ * @param default_value a fallback value to expand to
+ * @return the property's value as an uppercased token,
+ *         or @p default_value
+ */
+#define DT_STRING_UPPER_TOKEN_PREFIX_OR(node_id, prop, prefix, default_value) \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
+		(DT_STRING_UPPER_TOKEN_PREFIX(node_id, prop, prefix)), \
+		(default_value))
+
+/**
+ * @brief Like DT_STRING_UPPER_TOKEN_POSTFIX(), but with a fallback
+ *        to @p default_value
+ *
+ * If the value exists, this expands to DT_STRING_UPPER_TOKEN_POSTFIX(node_id, prop).
+ * The @p default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to @p default_value.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param postfix Appended to the token
+ * @param default_value a fallback value to expand to
+ * @return the property's value as an uppercased token,
+ *         or @p default_value
+ */
+#define DT_STRING_UPPER_TOKEN_POSTFIX_OR(node_id, prop, postfix, default_value) \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
+		(DT_STRING_UPPER_TOKEN_POSTFIX(node_id, prop, postfix)), \
+		(default_value))
+
+/**
+ * @brief Like DT_STRING_UPPER_TOKEN_PREFIX_POSTFIX(), but with a fallback
+ *        to @p default_value
+ *
+ * If the value exists, this expands to
+ * DT_STRING_UPPER_TOKEN_PREFIX_POSTFIX(node_id, prop). The @p default_value
+ * parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to @p default_value.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param postfix Appended to the token
+ * @param default_value a fallback value to expand to
+ * @return the property's value as an uppercased token,
+ *         or @p default_value
+ */
+#define DT_STRING_UPPER_TOKEN_PREFIX_POSTFIX_OR(node_id, prop, prefix, postfix, default_value) \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
+		(DT_STRING_UPPER_TOKEN_PREFIX_POSTFIX(node_id, prop, prefix, postfix)), \
+		(default_value))
 
 /**
  * @brief Get a string property's value as an unquoted sequence of tokens
@@ -3470,6 +3930,46 @@
 	DT_STRING_TOKEN(DT_DRV_INST(inst), prop)
 
 /**
+ * @brief Get a `DT_DRV_COMPAT` instance's string property's value prepended
+ *        with prefix as a token.
+ *
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param prefix Prefix prepended to the string
+ * @return the value of @p prop as a token, i.e. without any quotes
+ *         and with special characters converted to underscores
+ */
+#define DT_INST_STRING_TOKEN_PREFIX(inst, prop, prefix) \
+	DT_STRING_TOKEN_PREFIX(DT_DRV_INST(inst), prop, prefix)
+
+/**
+ * @brief Get a `DT_DRV_COMPAT` instance's string property's value appened
+ *		  with postfix as a token.
+ *
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param postfix Postfix appended to the string
+ * @return the value of @p prop as a token, i.e. without any quotes
+ *         and with special characters converted to underscores
+ */
+#define DT_INST_STRING_TOKEN_POSTFIX(inst, prop, postfix) \
+	DT_STRING_TOKEN_POSTFIX(DT_DRV_INST(inst), prop, postfix)
+
+/**
+ * @brief Get a `DT_DRV_COMPAT` instance's string property's value prepended
+ *        with prefix and appened with postfix as a token.
+ *
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param prefix Prefix prepended to the string
+ * @param postfix Postfix appended to the string
+ * @return the value of @p prop as a token, i.e. without any quotes
+ *         and with special characters converted to underscores
+ */
+#define DT_INST_STRING_TOKEN_PREFIX_POSTFIX(inst, prop, prefix, postfix) \
+	DT_STRING_TOKEN_PREFIX_POSTFIX(DT_DRV_INST(inst), prop, prefix, postfix)
+
+/**
  * @brief Like DT_INST_STRING_TOKEN(), but uppercased.
  * @param inst instance number
  * @param prop lowercase-and-underscores property name
@@ -3478,6 +3978,40 @@
  */
 #define DT_INST_STRING_UPPER_TOKEN(inst, prop) \
 	DT_STRING_UPPER_TOKEN(DT_DRV_INST(inst), prop)
+
+/**
+ * @brief Like DT_INST_STRING_TOKEN_PREFIX(), but with uppercased string.
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param prefix Prefix prepended to the string
+ * @return the value of @p prop as an uppercased token, i.e. without
+ *         any quotes and with special characters converted to underscores
+ */
+#define DT_INST_STRING_UPPER_TOKEN_PREFIX(inst, prop, prefix) \
+	DT_STRING_UPPER_TOKEN_PREFIX(DT_DRV_INST(inst), prop, prefix)
+
+/**
+ * @brief Like DT_INST_STRING_TOKEN_POSTFIX(), but with uppercased string.
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param postfix Postfix appended to the string
+ * @return the value of @p prop as an uppercased token, i.e. without
+ *         any quotes and with special characters converted to underscores
+ */
+#define DT_INST_STRING_UPPER_TOKEN_POSTFIX(inst, prop, postfix) \
+	DT_STRING_UPPER_TOKEN_POSTFIX(DT_DRV_INST(inst), prop, postfix)
+
+/**
+ * @brief Like DT_INST_STRING_TOKEN_PREFIX_POSTFIX(), but with uppercased string.
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property name
+ * @param prefix Prefix prepended to the string
+ * @param postfix Postfix appended to the string
+ * @return the value of @p prop as an uppercased token, i.e. without
+ *         any quotes and with special characters converted to underscores
+ */
+#define DT_INST_STRING_UPPER_TOKEN_PREFIX_POSTFIX(inst, prop, prefix, postfix) \
+	DT_STRING_UPPER_TOKEN_PREFIX_POSTFIX(DT_DRV_INST(inst), prop, prefix, postfix)
 
 /**
  * @brief Get a `DT_DRV_COMPAT` instance's string property's value as
@@ -3778,6 +4312,46 @@
 	DT_STRING_TOKEN_OR(DT_DRV_INST(inst), name, default_value)
 
 /**
+ * @brief Like DT_INST_STRING_TOKEN_PREFIX(), but with a fallback to @p default_value
+ * @param inst instance number
+ * @param name lowercase-and-underscores property name
+ * @param prefix Prefix prepended to the string
+ * @param default_value a fallback value to expand to
+ * @return if @p prop exists, its value as a token, i.e. without any quotes and
+ *         with special characters converted to underscores. Othewise
+ *         @p default_value
+ */
+#define DT_INST_STRING_TOKEN_PREFIX_OR(inst, name, prefix, default_value) \
+	DT_STRING_TOKEN_PREFIX_OR(DT_DRV_INST(inst), name, prefix, default_value)
+
+/**
+ * @brief Like DT_INST_STRING_TOKEN_POSTFIX(), but with a fallback to @p default_value
+ * @param inst instance number
+ * @param name lowercase-and-underscores property name
+ * @param postfix Postfix appended to the string
+ * @param default_value a fallback value to expand to
+ * @return if @p prop exists, its value as a token, i.e. without any quotes and
+ *         with special characters converted to underscores. Othewise
+ *         @p default_value
+ */
+#define DT_INST_STRING_TOKEN_POSTFIX_OR(inst, name, postfix, default_value) \
+	DT_STRING_TOKEN_POSTFIX_OR(DT_DRV_INST(inst), name, postfix, default_value)
+
+/**
+ * @brief Like DT_INST_STRING_TOKEN_PREFIX_POSTFIX(), but with a fallback to @p default_value
+ * @param inst instance number
+ * @param name lowercase-and-underscores property name
+ * @param prefix Prefix prepended to the string
+ * @param postfix Postfix appended to the string
+ * @param default_value a fallback value to expand to
+ * @return if @p prop exists, its value as a token, i.e. without any quotes and
+ *         with special characters converted to underscores. Othewise
+ *         @p default_value
+ */
+#define DT_INST_STRING_TOKEN_PREFIX_POSTFIX_OR(inst, name, prefix, postfix, default_value) \
+	DT_STRING_TOKEN_PREFIX_POSTFIX_OR(DT_DRV_INST(inst), name, prefix, postfix, default_value)
+
+/**
  * @brief Like DT_INST_STRING_UPPER_TOKEN(), but with a fallback to
  *        @p default_value
  * @param inst instance number
@@ -3787,6 +4361,46 @@
  */
 #define DT_INST_STRING_UPPER_TOKEN_OR(inst, name, default_value) \
 	DT_STRING_UPPER_TOKEN_OR(DT_DRV_INST(inst), name, default_value)
+
+/**
+ * @brief Like DT_INST_STRING_UPPER_TOKEN_PREFIX(), but with a fallback to
+ *        @p default_value
+ * @param inst instance number
+ * @param name lowercase-and-underscores property name
+ * @param prefix Prefix prepended to the string
+ * @param default_value a fallback value to expand to
+ * @return the property's value as an uppercased token, or @p default_value
+ */
+#define DT_INST_STRING_UPPER_TOKEN_PREFIX_OR(inst, name, prefix, default_value) \
+	DT_STRING_UPPER_TOKEN_PREFIX_OR(DT_DRV_INST(inst), name, prefix, default_value)
+
+/**
+ * @brief Like DT_INST_STRING_UPPER_TOKEN_POSTFIX(), but with a fallback to
+ *        @p default_value
+ * @param inst instance number
+ * @param name lowercase-and-underscores property name
+ * @param postfix Postfix appended to the string
+ * @param default_value a fallback value to expand to
+ * @return the property's value as an uppercased token, or @p default_value
+ */
+#define DT_INST_STRING_UPPER_TOKEN_POSTFIX_OR(inst, name, postfix, default_value) \
+	DT_STRING_UPPER_TOKEN_POSTFIX_OR(DT_DRV_INST(inst), name, postfix, default_value)
+
+/**
+ * @brief Like DT_INST_STRING_UPPER_TOKEN_PREFIX_POSTFIX(), but with a fallback to
+ *        @p default_value
+ * @param inst instance number
+ * @param name lowercase-and-underscores property name
+ * @param prefix Prefix prepended to the string
+ * @param postfix Postfix appended to the string
+ * @param default_value a fallback value to expand to
+ * @return the property's value as an uppercased token, or @p default_value
+ */
+#define DT_INST_STRING_UPPER_TOKEN_PREFIX_POSTFIX_OR(inst, name, prefix, postfix, default_value) \
+	DT_STRING_UPPER_TOKEN_PREFIX_POSTFIX_OR( \
+		DT_DRV_INST(inst), \
+		name, prefix, postfix, default_value \
+	)
 
 /**
  * @brief Like DT_INST_STRING_UNQUOTED(), but with a fallback to

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2714,6 +2714,158 @@ ZTEST(devicetree_api, test_string_token)
 }
 
 #undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_enum_holder
+ZTEST(devicetree_api, test_string_prefix)
+{
+	enum token_string_value {
+		token_zero,
+		token_one,
+		token_two,
+		token_ZERO,
+		token_ONE,
+		token_TWO,
+		zero_value,
+		one_value,
+		two_value,
+		ZERO_value,
+		ONE_value,
+		TWO_value,
+		token_zero_value,
+		token_one_value,
+		token_two_value,
+		token_ZERO_value,
+		token_ONE_value,
+		token_TWO_value,
+	};
+
+	zassert_equal(
+		DT_STRING_TOKEN_PREFIX(DT_NODELABEL(test_enum_0), val, token_),
+		token_zero,
+		""
+	);
+	zassert_equal(
+		DT_STRING_TOKEN_PREFIX(DT_NODELABEL(test_enum_1), val, token_),
+		token_two,
+		""
+	);
+	zassert_equal(
+		DT_STRING_TOKEN_POSTFIX(DT_NODELABEL(test_enum_0), val, _value),
+		zero_value,
+		""
+	);
+	zassert_equal(
+		DT_STRING_TOKEN_POSTFIX(DT_NODELABEL(test_enum_1), val, _value),
+		two_value,
+		""
+	);
+	zassert_equal(
+		DT_STRING_TOKEN_PREFIX_POSTFIX(DT_NODELABEL(test_enum_0), val, token_, _value),
+		token_zero_value,
+		""
+	);
+	zassert_equal(
+		DT_STRING_TOKEN_PREFIX_POSTFIX(DT_NODELABEL(test_enum_1), val, token_, _value),
+		token_two_value,
+		""
+	);
+
+	zassert_equal(
+		DT_STRING_UPPER_TOKEN_PREFIX(DT_NODELABEL(test_enum_0), val, token_),
+		token_ZERO,
+		""
+	);
+	zassert_equal(
+		DT_STRING_UPPER_TOKEN_PREFIX(DT_NODELABEL(test_enum_1), val, token_),
+		token_TWO,
+		""
+	);
+	zassert_equal(
+		DT_STRING_UPPER_TOKEN_POSTFIX(DT_NODELABEL(test_enum_0), val, _value),
+		ZERO_value,
+		""
+	);
+	zassert_equal(
+		DT_STRING_UPPER_TOKEN_POSTFIX(DT_NODELABEL(test_enum_1), val, _value),
+		TWO_value,
+		""
+	);
+	zassert_equal(
+		DT_STRING_UPPER_TOKEN_PREFIX_POSTFIX(
+			DT_NODELABEL(test_enum_0), val, token_, _value),
+		token_ZERO_value,
+		""
+	);
+	zassert_equal(
+		DT_STRING_UPPER_TOKEN_PREFIX_POSTFIX(
+			DT_NODELABEL(test_enum_1), val, token_, _value),
+		token_TWO_value,
+		""
+	);
+
+	zassert_equal(
+		DT_INST_STRING_TOKEN_PREFIX(0, val, token_),
+		token_zero,
+		""
+	);
+	zassert_equal(
+		DT_INST_STRING_TOKEN_PREFIX(1, val, token_),
+		token_two,
+		""
+	);
+	zassert_equal(
+		DT_INST_STRING_TOKEN_POSTFIX(0, val, _value),
+		zero_value,
+		""
+	);
+	zassert_equal(
+		DT_INST_STRING_TOKEN_POSTFIX(1, val, _value),
+		two_value,
+		""
+	);
+	zassert_equal(
+		DT_INST_STRING_TOKEN_PREFIX_POSTFIX(0, val, token_, _value),
+		token_zero_value,
+		""
+	);
+	zassert_equal(
+		DT_INST_STRING_TOKEN_PREFIX_POSTFIX(1, val, token_, _value),
+		token_two_value,
+		""
+	);
+
+	zassert_equal(
+		DT_INST_STRING_UPPER_TOKEN_PREFIX(0, val, token_),
+		token_ZERO,
+		""
+	);
+	zassert_equal(
+		DT_INST_STRING_UPPER_TOKEN_PREFIX(1, val, token_),
+		token_TWO,
+		""
+	);
+	zassert_equal(
+		DT_INST_STRING_UPPER_TOKEN_POSTFIX(0, val, _value),
+		ZERO_value,
+		""
+	);
+	zassert_equal(
+		DT_INST_STRING_UPPER_TOKEN_POSTFIX(1, val, _value),
+		TWO_value,
+		""
+	);
+	zassert_equal(
+		DT_INST_STRING_UPPER_TOKEN_PREFIX_POSTFIX(0, val, token_, _value),
+		token_ZERO_value,
+		""
+	);
+	zassert_equal(
+		DT_INST_STRING_UPPER_TOKEN_PREFIX_POSTFIX(1, val, token_, _value),
+		token_TWO_value,
+		""
+	);
+}
+
+#undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_string_array_token
 ZTEST(devicetree_api, test_string_idx_token)
 {


### PR DESCRIPTION
Added helper macros to simplify handling of enum-strings defined in the dt-bindings. With these new macros you can define C-enums and generate by parsing the devicetree the enum values.

This makes the devicetree simpler to read and the implementation of device drivers more straight-forward. 

Enumerations with possible (device) register values are neat because the author or reviewers of a driver can easily get the meaning of different values. But this has the drawback that you're not able to directly bring these (C-enums) into the devictree. One alternative solution would be to use defines. But then you'd need to maintain (bugs?) the same value in two different locations. The solution I propose is using string-enums in the dt-bindings with a meaningful name. You could document these values in the dt-bindings. 

If you implement a driver you could then parse the string as a token. But usually we are using prefixes, so we have unique enum members. Here comes the new macros of this PR into play. These macros are helping users to prefix the string tokens with the corresponding prefixes and automagically use the enum values while parsing the devicetree. 

Related to: #59256

_Edit: Added some background on why I've implemented the change_