### PR TITLE
net: if: do not remove the solicited-node multicast address if used

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1812,6 +1812,7 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 	struct net_if_ipv6 *ipv6;
 	struct in6_addr maddr;
 	int found = -1;
+	unsigned int maddr_count = 0;
 
 	NET_ASSERT(addr);
 
@@ -1825,8 +1826,19 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 	net_ipv6_addr_create_solicited_node(addr, &maddr);
 
 	for (int i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+		struct in6_addr unicast_maddr;
+
 		if (!ipv6->unicast[i].is_used) {
 			continue;
+		}
+
+		/* count how many times this solicited-node multicast address is identical
+		 * for all the used unicast addresses
+		 */
+		net_ipv6_addr_create_solicited_node(&ipv6->unicast[i].address.in6_addr,
+						    &unicast_maddr);
+		if (net_ipv6_addr_cmp(&maddr, &unicast_maddr)) {
+			maddr_count++;
 		}
 
 		if (!net_ipv6_addr_cmp(&ipv6->unicast[i].address.in6_addr,
@@ -1835,7 +1847,6 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 		}
 
 		found = i;
-		break;
 	}
 
 	if (found >= 0) {
@@ -1866,7 +1877,12 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 
 		ipv6->unicast[found].is_used = false;
 
-		net_if_ipv6_maddr_rm(iface, &maddr);
+		if (maddr_count == 1) {
+			/* remove the solicited-node multicast address only if no other
+			 * unicast address is also using it
+			 */
+			net_if_ipv6_maddr_rm(iface, &maddr);
+		}
 
 		NET_DBG("[%d] interface %p address %s type %s removed",
 			found, iface, net_sprint_ipv6_addr(addr),

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1810,6 +1810,7 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 {
 	bool ret = false;
 	struct net_if_ipv6 *ipv6;
+	struct in6_addr maddr;
 	int i;
 
 	NET_ASSERT(addr);
@@ -1821,9 +1822,9 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 		goto out;
 	}
 
-	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
-		struct in6_addr maddr;
+	net_ipv6_addr_create_solicited_node(addr, &maddr);
 
+	for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
 		if (!ipv6->unicast[i].is_used) {
 			continue;
 		}
@@ -1858,8 +1859,6 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 #endif
 
 		ipv6->unicast[i].is_used = false;
-
-		net_ipv6_addr_create_solicited_node(addr, &maddr);
 
 		net_if_ipv6_maddr_rm(iface, &maddr);
 

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -55,8 +55,7 @@ static struct in6_addr ll_addr = { { { 0xfe, 0x80, 0x43, 0xb8, 0, 0, 0, 0,
 				       0, 0, 0, 0xf2, 0xaa, 0x29, 0x02,
 				       0x04 } } };
 
-static struct in6_addr in6addr_mcast = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
-					     0, 0, 0, 0, 0, 0, 0, 0x1 } } };
+static struct in6_addr in6addr_mcast;
 
 static struct net_if *iface1;
 static struct net_if *iface2;

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -879,6 +879,60 @@ ZTEST(net_iface, test_v6_addr_add_rm)
 	v6_addr_rm();
 }
 
+ZTEST(net_iface, test_v6_addr_add_rm_solicited)
+{
+	const struct in6_addr prefix = { { { 0x20, 0x01, 0x1b, 0x98, 0x24, 0xb8, 0x7e, 0xbb,
+					     0, 0, 0, 0, 0, 0, 0, 0 } } };
+	struct in6_addr iid_addr = { };
+	struct in6_addr iid_addr_mcast = { };
+	struct in6_addr unicast_addr = { };
+	struct in6_addr unicast_addr_mcast = { };
+	struct net_if_addr *ifaddr;
+	struct net_if_mcast_addr *maddr;
+	bool ret;
+
+	/* Add a link-local address based on the interface identifier */
+	net_ipv6_addr_create_iid(&iid_addr, net_if_get_link_addr(iface4));
+	ifaddr = net_if_ipv6_addr_add(iface4, &iid_addr,
+				      NET_ADDR_AUTOCONF, 0);
+	zassert_not_null(ifaddr, "Cannot add IPv6 link-local address");
+
+	/* Add the corresponding solicited-node multicast address */
+	net_ipv6_addr_create_solicited_node(&iid_addr, &iid_addr_mcast);
+	maddr = net_if_ipv6_maddr_add(iface4, &iid_addr_mcast);
+	zassert_not_null(maddr, "Cannot add solicited-node multicast address");
+
+	/* Add an autoconfigured global unicast address */
+	net_ipv6_addr_create_iid(&unicast_addr, net_if_get_link_addr(iface4));
+	memcpy(&unicast_addr, &prefix, sizeof(prefix) / 2);
+	ifaddr = net_if_ipv6_addr_add(iface4, &unicast_addr,
+				      NET_ADDR_AUTOCONF, 0);
+	zassert_not_null(ifaddr, "Cannot add IPv6 global unicast address");
+
+	/* Add the corresponding solicited-node multicast address (should exist) */
+	net_ipv6_addr_create_solicited_node(&unicast_addr, &unicast_addr_mcast);
+	zassert_mem_equal(&unicast_addr_mcast, &iid_addr_mcast,
+			  sizeof(struct in6_addr));
+	maddr = net_if_ipv6_maddr_add(iface4, &unicast_addr_mcast);
+	zassert_is_null(maddr, "Solicited-node multicast address was added twice");
+
+	/* Remove the global unicast address */
+	ret = net_if_ipv6_addr_rm(iface4, &unicast_addr);
+	zassert_true(ret, "Cannot remove IPv6 global unicast address");
+
+	/* The solicited-node multicast address should stay */
+	maddr = net_if_ipv6_maddr_lookup(&iid_addr_mcast, &iface4);
+	zassert_not_null(maddr, "Solicited-node multicast address was removed");
+
+	/* Remove the link-local address */
+	ret = net_if_ipv6_addr_rm(iface4, &iid_addr);
+	zassert_true(ret, "Cannot remove IPv6 link-local address");
+
+	/* The solicited-node multicast address should be gone */
+	maddr = net_if_ipv6_maddr_lookup(&iid_addr_mcast, &iface4);
+	zassert_is_null(maddr, "Solicited-node multicast address was not removed");
+}
+
 #define MY_ADDR_V6_USER { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, \
 			      0, 0, 0, 0, 0, 0, 0, 0x65 } } }
 


### PR DESCRIPTION
Two different IPv6 addresses can have the same solicited node multicast
address, for example when they are derived from the same EUI-64
interface identifier during the auto-configuration process. For example,
an interface with a physical address `70:07:12:34:56:78` can have the
following:
- link-local address `FE80::7207:12FF:FE34:5678`
- global unicast address `2001:1234:::7207:12FF:FE34:5678`

Both addresses will have the same solicited-node multicast address
`FF02::1:FF34:5678`. Currently, if one removes the global unicast address,
the solicited-node multicast address is also removed, leaving the
link-local address out of the solicited-node multicast group. This
breaks some protocols like Neighbour Discovery.

Count how many times the solicited-node multicast address is used and
remove it only if it is not shared by any other unicast address.

Result of the unit test without the fix:
```
START - test_v6_addr_add_rm_solicited
[00:00:00.000,000] <wrn> net_if: Multicast address ff02::1:ff00:0 is is already registered.

    Assertion failed at WEST_TOPDIR/zephyr/tests/net/iface/src/main.c:925: net_iface_test_v6_addr_add_rm_solicited: (maddr is NULL)
Solicited-node multicast address was removed
 FAIL - test_v6_addr_add_rm_solicited in 0.000 seconds
```

And with the fix:
```
 START - test_v6_addr_add_rm_solicited
[00:00:00.000,000] <wrn> net_if: Multicast address ff02::1:ff00:0 is is already registered.
 PASS - test_v6_addr_add_rm_solicited in 0.000 seconds
```

Fixes #59683