### PR TITLE
linker: Introduce linker-tool-lld.h

### DIFF
--- a/cmake/linker/lld/target_base.cmake
+++ b/cmake/linker/lld/target_base.cmake
@@ -5,7 +5,7 @@
 macro(toolchain_ld_base)
 
   if(NOT PROPERTY_LINKER_SCRIPT_DEFINES)
-    set_property(GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__GCC_LINKER_CMD__)
+    set_property(GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__LLD_LINKER_CMD__)
   endif()
 
   # TOOLCHAIN_LD_FLAGS comes from compiler/clang/target.cmake

--- a/include/zephyr/linker/linker-tool-lld.h
+++ b/include/zephyr/linker/linker-tool-lld.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Google, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief LLVM LLD linker defs
+ *
+ * This header file defines the necessary macros used by the linker script for
+ * use with the LLD linker.
+ */
+
+#ifndef ZEPHYR_INCLUDE_LINKER_LINKER_TOOL_LLD_H_
+#define ZEPHYR_INCLUDE_LINKER_LINKER_TOOL_LLD_H_
+
+#include <zephyr/linker/linker-tool-gcc.h>
+
+/**
+ * @def SECTION_PROLOGUE
+ *
+ * The SECTION_PROLOGUE() macro is used to define the beginning of a section.
+ *
+ * When --omagic (-N) option is provided to LLD then only the first output
+ * section of given region has aligned LMA (by default, without --omagic, LLD
+ * aligns LMA and VMA of every section to the same value) and the difference
+ * between VMA addresses (0 is this is the first section) is added.
+ * The difference between LMA and VMA is constant for every section, so this
+ * emulates ALIGN_WITH_INPUT option present in GNU LD (required by XIP systems).
+ *
+ * The --omagic flag is defined in cmake/linker/lld/target_baremetal.cmake
+ *
+ * @param name Name of the output section
+ * @param options Section options, such as (NOLOAD), or left blank
+ * @param align Alignment directives, such as SUBALIGN(). May be blank.
+ */
+#undef SECTION_PROLOGUE
+#define SECTION_PROLOGUE(name, options, align) \
+	name options : align
+
+/**
+ * @def SECTION_DATA_PROLOGUE
+ *
+ * Same as for SECTION_PROLOGUE(), except that this one must be used
+ * for data sections which on XIP platforms will have differing
+ * virtual and load addresses (i.e. they'll be copied into RAM at
+ * program startup).  Such a section must also use
+ * GROUP_DATA_LINK_IN to specify the correct output load address.
+ *
+ * This is equivalent to SECTION_PROLOGUE() when linking using LLD.
+ *
+ * @param name Name of the output section
+ * @param options Section options, or left blank
+ * @param align Alignment directives, such as SUBALIGN(). May be blank.
+ */
+#undef SECTION_DATA_PROLOGUE
+#define SECTION_DATA_PROLOGUE(name, options, align) \
+	SECTION_PROLOGUE(name, options, align)
+
+#endif /* ZEPHYR_INCLUDE_LINKER_LINKER_TOOL_LLD_H_ */

--- a/include/zephyr/linker/linker-tool.h
+++ b/include/zephyr/linker/linker-tool.h
@@ -20,6 +20,8 @@
 #include <zephyr/linker/linker-tool-gcc.h>
 #elif defined(__MWDT_LINKER_CMD__)
 #include <zephyr/linker/linker-tool-mwdt.h>
+#elif defined(__LLD_LINKER_CMD__)
+#include <zephyr/linker/linker-tool-lld.h>
 #else
 #error "Unknown toolchain"
 #endif

--- a/include/zephyr/toolchain.h
+++ b/include/zephyr/toolchain.h
@@ -44,7 +44,7 @@
 #include <zephyr/toolchain/mwdt.h>
 #elif defined(__ARMCOMPILER_VERSION)
 #include <zephyr/toolchain/armclang.h>
-#elif defined(__llvm__)
+#elif defined(__llvm__) || (defined(_LINKER) && defined(__LLD_LINKER_CMD__))
 #include <zephyr/toolchain/llvm.h>
 #elif defined(__GNUC__) || (defined(_LINKER) && defined(__GCC_LINKER_CMD__))
 #include <zephyr/toolchain/gcc.h>


### PR DESCRIPTION
Until now, linker-tool-gcc.h was used when LLD linker was chosen. This causes linking issues because for GNU LD we use ALIGN_WITH_INPUT attribute which is not available in LLVM LLD.

When using GNU LD we have to use ALIGN_WITH_INPUT to make sure that the difference between VMA and LMA remains the same between output sections that have different memory regions for VMA and LMA (RAM and FLASH). With ALIGN_WITH_INPUT it's safe to do the memcpy of sections that needs to be copied from flash to RAM in one function call:

(from z_data_copy() in kernel/xip.c)
```
z_early_memcpy(&__data_region_start, &__data_region_load_start,
               __data_region_end - __data_region_start);
```

LLVM LLD aligns both VMA and LMA to the same value (in the following example it's maximum of input section alignment):

```
MEMORY {
  ROM : ORIGIN = 0x1000, LENGTH = 1K
  RAM : ORIGIN = 0x11000, LENGTH = 1K
}
SECTIONS {
  .text 0x1000 : {
  	*(.text*)
  } >ROM

  .data.rel.ro : {
  	*(.data.rel.ro)
  } >RAM AT>ROM

  .data : {
  	*(.data*)
  } >RAM AT>ROM
}
```

```
echo '.globl _start; _start: nop; .byte 1;'\
     '.data.rel.ro; .balign 16; .byte 0;'\
     '.data; .balign 32; .byte 0;' | \
     llvm-mc -filetype=obj -triple=arm - -o test.o

armv7m-cros-eabi-ld.lld --sort-section=alignment -T script.ld \
     test.o -o lld_out
```

```
Idx Name          Size      VMA       LMA       File off  Algn
  0 .text         00000005  00001000  00001000  00001000  2**2
  1 .data.rel.ro  00000001  00011000  00001010  00011000  2**4
  2 .data         00000001  00011020  00001040  00011020  2**5
```

In this example the first section has lower alignment than the following section, despite of aligning both LMA and VMA there is a different gap size between `.data.rel.ro` and `.data` sections. To fix that, we can set output section alignment of `.data.rel.ro` to 32:

```
  .data.rel.ro : ALIGN(32) {
  	*(.data.rel.ro)
  } >RAM AT>ROM
```

which results in the following:

```
Idx Name          Size      VMA       LMA       File off  Algn
  0 .text         00000005  00001000  00001000  00001000  2**2
  1 .data.rel.ro  00000001  00011000  00001020  00011000  2**5
  2 .data         00000001  00011020  00001040  00011020  2**5
```

For comparison, using BFD linker with ALIGN_WITH_INPUT results in the following:
```
Idx Name          Size      VMA       LMA       File off  Algn
  0 .text         00000005  00001000  00001000  00001000  2**2
  1 .data.rel.ro  00000001  00011000  00001005  00011000  2**4
  2 .data         00000001  00011020  00001025  00011020  2**5
```