### PR TITLE
MAINTAINERS: Add self as network collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1804,6 +1804,7 @@ Networking:
     - rlubos
   collaborators:
     - tbursztyka
+    - ssharks
   files:
     - drivers/net/
     - include/zephyr/net/


### PR DESCRIPTION
I would want suggest myself as collaborator for the networking subsystem.