### PR TITLE
drivers:flash:atmel SAM0 fix flash_write so it can handle smaller writes

### DIFF
--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.yaml
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.yaml
@@ -10,6 +10,7 @@ toolchain:
   - xtools
 supported:
   - adc
+  - flash
   - gpio
   - i2c
   - spi

--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -138,3 +138,21 @@ zephyr_udc0: &usb0 {
 		reg = <0>;
 	};
 };
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/*
+		 * The final 16 KiB is reserved for the application.
+		 * Storage partition will be used by FCB/LittleFS/NVS
+		 * if enabled.
+		 */
+		storage_partition: partition@fc000 {
+			label = "storage";
+			reg = <0x000fc000 0x00004000>;
+		};
+	};
+};

--- a/boards/arm/atsame54_xpro/atsame54_xpro.yaml
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.yaml
@@ -12,6 +12,7 @@ toolchain:
   - xtools
 supported:
   - adc
+  - flash
   - gpio
   - pwm
   - spi

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -207,3 +207,21 @@ ext2_spi: &sercom5 {
 
 ext2_i2c: &sercom1 {
 };
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/*
+		 * The final 16 KiB is reserved for the application.
+		 * Storage partition will be used by FCB/LittleFS/NVS
+		 * if enabled.
+		 */
+		storage_partition: partition@3c000 {
+			label = "storage";
+			reg = <0x0003c000 0x00004000>;
+		};
+	};
+};

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.yaml
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.yaml
@@ -13,6 +13,7 @@ toolchain:
   - xtools
 supported:
   - adc
+  - flash
   - gpio
   - i2c
   - netif

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -5,6 +5,7 @@
  */
 
 #define DT_DRV_COMPAT atmel_sam0_nvmctrl
+#define SOC_NV_FLASH_NODE DT_INST(0, soc_nv_flash)
 
 #define LOG_LEVEL CONFIG_FLASH_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -16,6 +17,9 @@ LOG_MODULE_REGISTER(flash_sam0);
 #include <zephyr/kernel.h>
 #include <soc.h>
 #include <string.h>
+
+#define FLASH_WRITE_BLK_SZ DT_PROP(SOC_NV_FLASH_NODE, write_block_size)
+BUILD_ASSERT((FLASH_WRITE_BLK_SZ % sizeof(uint32_t)) == 0, "unsupported write-block-size");
 
 /*
  * Zephyr and the SAM0 series use different and conflicting names for
@@ -67,7 +71,7 @@ static const struct flash_parameters flash_sam0_parameters = {
 #if CONFIG_SOC_FLASH_SAM0_EMULATE_BYTE_PAGES
 	.write_block_size = 1,
 #else
-	.write_block_size = DT_PROP(DT_INST(0, soc_nv_flash), write_block_size),
+	.write_block_size = FLASH_WRITE_BLK_SZ,
 #endif
 	.erase_value = 0xff,
 };
@@ -147,11 +151,18 @@ static int flash_sam0_check_status(off_t offset)
 	return 0;
 }
 
+/*
+ * Data to be written to the NVM block are first written to and stored
+ * in an internal buffer called the page buffer. The page buffer contains
+ * the same number of bytes as an NVM page. Writes to the page buffer must
+ * be 16 or 32 bits. 8-bit writes to the page buffer are not allowed and
+ * will cause a system exception
+ */
 static int flash_sam0_write_page(const struct device *dev, off_t offset,
-				 const void *data)
+				 const void *data, size_t len)
 {
 	const uint32_t *src = data;
-	const uint32_t *end = src + FLASH_PAGE_SIZE / sizeof(*src);
+	const uint32_t *end = src + (len / sizeof(*src));
 	uint32_t *dst = FLASH_MEM(offset);
 	int err;
 
@@ -178,7 +189,7 @@ static int flash_sam0_write_page(const struct device *dev, off_t offset,
 		return err;
 	}
 
-	if (memcmp(data, FLASH_MEM(offset), FLASH_PAGE_SIZE) != 0) {
+	if (memcmp(data, FLASH_MEM(offset), len) != 0) {
 		LOG_ERR("verify error at offset 0x%lx", (long)offset);
 		return -EIO;
 	}
@@ -213,7 +224,7 @@ static int flash_sam0_commit(const struct device *dev, off_t base)
 	for (page = 0; page < PAGES_PER_ROW; page++) {
 		err = flash_sam0_write_page(
 			dev, base + page * FLASH_PAGE_SIZE,
-			&ctx->buf[page * FLASH_PAGE_SIZE]);
+			&ctx->buf[page * FLASH_PAGE_SIZE], ROW_SIZE);
 		if (err != 0) {
 			return err;
 		}
@@ -280,19 +291,18 @@ static int flash_sam0_write(const struct device *dev, off_t offset,
 {
 	const uint8_t *pdata = data;
 	int err;
-	size_t idx;
 
 	err = flash_sam0_valid_range(offset, len);
 	if (err != 0) {
 		return err;
 	}
 
-	if ((offset % FLASH_PAGE_SIZE) != 0) {
+	if ((offset % FLASH_WRITE_BLK_SZ) != 0) {
 		LOG_WRN("0x%lx: not on a write block boundary", (long)offset);
 		return -EINVAL;
 	}
 
-	if ((len % FLASH_PAGE_SIZE) != 0) {
+	if ((len % FLASH_WRITE_BLK_SZ) != 0) {
 		LOG_WRN("%zu: not a integer number of write blocks", len);
 		return -EINVAL;
 	}
@@ -301,12 +311,20 @@ static int flash_sam0_write(const struct device *dev, off_t offset,
 
 	err = flash_sam0_write_protection(dev, false);
 	if (err == 0) {
-		for (idx = 0; idx < len; idx += FLASH_PAGE_SIZE) {
-			err = flash_sam0_write_page(dev, offset + idx,
-						    &pdata[idx]);
+		/* Maximum size without crossing a page */
+		size_t eop_len = FLASH_PAGE_SIZE - (offset % FLASH_PAGE_SIZE);
+		size_t write_len = MIN(len, eop_len);
+
+		while (len > 0) {
+			err = flash_sam0_write_page(dev, offset, pdata, write_len);
 			if (err != 0) {
 				break;
 			}
+
+			offset += write_len;
+			pdata += write_len;
+			len -= write_len;
+			write_len = MIN(len, FLASH_PAGE_SIZE);
 		}
 	}
 
@@ -454,6 +472,9 @@ static int flash_sam0_init(const struct device *dev)
 #ifdef NVMCTRL_CTRLB_MANW
 	/* Require an explicit write command */
 	NVMCTRL->CTRLB.bit.MANW = 1;
+#elif NVMCTRL_CTRLA_WMODE
+	/* Set manual write mode */
+	NVMCTRL->CTRLA.bit.WMODE = NVMCTRL_CTRLA_WMODE_MAN_Val;
 #endif
 
 	return flash_sam0_write_protection(dev, false);

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -83,3 +83,8 @@ tests:
     extra_args:
       - OVERLAY_CONFIG=boards/nrf52840dk_flash_spi.conf
       - DTC_OVERLAY_FILE=boards/nrf52840dk_spi_nor_wp_hold.overlay
+  drivers.flash.common.sam0:
+    platform_allow:
+      - atsamd20_xpro
+      - atsamr21_xpro
+      - atsame54_xpro


### PR DESCRIPTION
flash_sam0_write currently only allows page writes of FLASH_PAGE_SIZE.  Following advice from @Laczen I used the flash_sam_write as guide for how to modify flash_sam0_write.  MCUBOOT will not work with the sam0 processors without this modification since it tries to write 8 or 16 bytes of header information.

Tested on the SAMD51 by doing a MCUBOOT SWAP/MOVE and update was completed successfully.