### PR TITLE
cmake: python module cleanup.

### DIFF
--- a/cmake/modules/FindDeprecated.cmake
+++ b/cmake/modules/FindDeprecated.cmake
@@ -114,6 +114,18 @@ if("PRJ_BOARD" IN_LIST Deprecated_FIND_COMPONENTS)
                       "replaced with board Kconfig fragments instead.")
 endif()
 
+if("PYTHON_PREFER" IN_LIST Deprecated_FIND_COMPONENTS)
+  # This code was deprecated after Zephyr v3.4.0
+  list(REMOVE_ITEM Deprecated_FIND_COMPONENTS PYTHON_PREFER)
+  if(DEFINED PYTHON_PREFER)
+    message(DEPRECATION "'PYTHON_PREFER' variable is deprecated. Please use "
+                        "Python3_EXECUTABLE instead.")
+    if(NOT DEFINED Python3_EXECUTABLE)
+      set(Python3_EXECUTABLE ${PYTHON_PREFER})
+    endif()
+  endif()
+endif()
+
 if(NOT "${Deprecated_FIND_COMPONENTS}" STREQUAL "")
   message(STATUS "The following deprecated component(s) could not be found: "
                  "${Deprecated_FIND_COMPONENTS}")

--- a/cmake/modules/python.cmake
+++ b/cmake/modules/python.cmake
@@ -13,35 +13,35 @@ endif()
 
 set(PYTHON_MINIMUM_REQUIRED 3.8)
 
-# We are using foreach here, instead of find_program(PYTHON_EXECUTABLE_SYSTEM_DEFAULT "python" "python3")
-# cause just using find_program directly could result in a python2.7 as python, and not finding a valid python3.
-foreach(PYTHON_PREFER ${PYTHON_PREFER} ${WEST_PYTHON} "python" "python3")
-  find_program(PYTHON_PREFER_EXECUTABLE ${PYTHON_PREFER})
-  if(PYTHON_PREFER_EXECUTABLE)
-      execute_process (COMMAND "${PYTHON_PREFER_EXECUTABLE}" -c
-                               "import sys; sys.stdout.write('.'.join([str(x) for x in sys.version_info[:2]]))"
-                       RESULT_VARIABLE result
-                       OUTPUT_VARIABLE version
-                       ERROR_QUIET
-                       OUTPUT_STRIP_TRAILING_WHITESPACE)
+find_package(Deprecated COMPONENTS PYTHON_PREFER)
 
-     if(version VERSION_LESS PYTHON_MINIMUM_REQUIRED)
-       set(PYTHON_PREFER_EXECUTABLE "PYTHON_PREFER_EXECUTABLE-NOTFOUND")
-     else()
-       set(PYTHON_MINIMUM_REQUIRED ${version})
-       set(PYTHON_EXACT EXACT)
-       # Python3_ROOT_DIR ensures that location will be preferred by FindPython3.
-       # On Linux, this has no impact as it will usually be /usr/bin
-       # but on Windows it solve issues when both 32 and 64 bit versions are
-       # installed, as version is not enough and FindPython3 might pick the
-       # version not on %PATH%. Setting Python3_ROOT_DIR ensures we are using
-       # the version we just tested.
-       get_filename_component(PYTHON_PATH ${PYTHON_PREFER_EXECUTABLE} DIRECTORY)
-       set(Python3_ROOT_DIR ${PYTHON_PATH})
-       break()
-     endif()
-  endif()
-endforeach()
+if(NOT DEFINED Python3_EXECUTABLE AND DEFINED WEST_PYTHON)
+  set(Python3_EXECUTABLE "${WEST_PYTHON}")
+endif()
 
-find_package(Python3 ${PYTHON_MINIMUM_REQUIRED} REQUIRED ${PYTHON_EXACT})
+if(NOT Python3_EXECUTABLE)
+  # We are using foreach here, instead of
+  # find_program(PYTHON_EXECUTABLE_SYSTEM_DEFAULT "python" "python3")
+  # cause just using find_program directly could result in a python2.7 as python,
+  # and not finding a valid python3.
+  foreach(candidate "python" "python3")
+    find_program(Python3_EXECUTABLE ${candidate})
+    if(Python3_EXECUTABLE)
+        execute_process (COMMAND "${Python3_EXECUTABLE}" -c
+                                 "import sys; sys.stdout.write('.'.join([str(x) for x in sys.version_info[:2]]))"
+                         RESULT_VARIABLE result
+                         OUTPUT_VARIABLE version
+                         ERROR_QUIET
+                         OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+       if(version VERSION_LESS PYTHON_MINIMUM_REQUIRED)
+         set(Python3_EXECUTABLE "Python3_EXECUTABLE-NOTFOUND" CACHE INTERNAL "Path to a program")
+       endif()
+    endif()
+  endforeach()
+endif()
+
+find_package(Python3 ${PYTHON_MINIMUM_REQUIRED} REQUIRED)
+
+# Zephyr internally used Python variable.
 set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})


### PR DESCRIPTION
CMake 3.16 find_python3 module introduced `Python3_EXECUTABLE` as artifact specifier.
This allows Zephyr to cleanup its Python detection mechanism and thus remove the Zephyr specific `PYTHON_PREFER` variable, which is now deprecated.

This further improves the Python detection mechanism in Zephyr as it allows users to specify Python3_EXECUTABLE and thereby follows CMake documentation.

------

This PR supersedes the following proposals:
- #57291 
- #56205 