### PR TITLE
drivers: uart: atmel_sam: Added reset after error check

### DIFF
--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -91,6 +91,8 @@ static int uart_sam_err_check(const struct device *dev)
 		errors |= UART_ERROR_FRAMING;
 	}
 
+	uart->UART_CR = UART_CR_RSTSTA;
+
 	return errors;
 }
 


### PR DESCRIPTION
Following the sam4s datasheet, the OVRE, PARE and FRAME flags should be cleared after a uart error occured. This is done writing a 1 to the RSTSTA bit in the UART_CR.