### PR TITLE
Bluetooth: CSIP: Add missing input validation for csis_int_by_handle

### DIFF
--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -1375,8 +1375,21 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 struct bt_csip_set_coordinator_csis_inst *bt_csip_set_coordinator_csis_inst_by_handle(
 	struct bt_conn *conn, uint16_t start_handle)
 {
-	const struct bt_csip_set_coordinator_svc_inst *svc_inst =
-		lookup_instance_by_handle(conn, start_handle);
+	const struct bt_csip_set_coordinator_svc_inst *svc_inst;
+
+	CHECKIF(conn == NULL) {
+		LOG_DBG("conn is NULL");
+
+		return NULL;
+	}
+
+	CHECKIF(start_handle == 0) {
+		LOG_DBG("start_handle is 0");
+
+		return NULL;
+	}
+
+	svc_inst = lookup_instance_by_handle(conn, start_handle);
 
 	if (svc_inst != NULL) {
 		struct bt_csip_set_coordinator_inst *client;


### PR DESCRIPTION
The bt_csip_set_coordinator_csis_inst_by_handle did not check the input parameters and could call lookup_instance_by_handle with handle == 0 which triggers an ASSERT.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/59621