### PR TITLE
Bluetooth: controller: fix failing EBQ scanner tests

### DIFF
--- a/samples/bluetooth/broadcaster_multiple/src/broadcaster_multiple.c
+++ b/samples/bluetooth/broadcaster_multiple/src/broadcaster_multiple.c
@@ -47,11 +47,18 @@
 					BT_AD_DATA_FORMAT_LEN_SIZE - \
 					BT_AD_DATA_FORMAT_TYPE_SIZE - \
 					BT_DEVICE_NAME_AD_DATA_LEN)))
-
+/*
+ * Datalength is an integer, so BT_MFG_DATA_LEN can not be larger than 255.
+ * To ensure that we need to chain PDUs we therefore add manufacturer data
+ * twice when chaining is enabled
+ */
 static uint8_t mfg_data[BT_MFG_DATA_LEN] = { 0xFF, 0xFF, };
 
 static const struct bt_data ad[] = {
 	BT_DATA(BT_DATA_MANUFACTURER_DATA, mfg_data, sizeof(mfg_data)),
+#if defined(CONFIG_BT_CTLR_ADV_DATA_CHAIN)
+	BT_DATA(BT_DATA_MANUFACTURER_DATA, mfg_data, sizeof(mfg_data)),
+#endif
 };
 
 static struct bt_le_ext_adv *adv[CONFIG_BT_EXT_ADV_MAX_ADV_SET];
@@ -75,6 +82,7 @@ int broadcaster_multiple(void)
 		printk("Bluetooth init failed (err %d)\n", err);
 		return err;
 	}
+
 	for (int index = 0; index < CONFIG_BT_EXT_ADV_MAX_ADV_SET; index++) {
 		/* Use advertising set instance index as SID */
 		adv_param.sid = index;

--- a/samples/bluetooth/broadcaster_multiple/src/broadcaster_multiple.c
+++ b/samples/bluetooth/broadcaster_multiple/src/broadcaster_multiple.c
@@ -75,7 +75,6 @@ int broadcaster_multiple(void)
 		printk("Bluetooth init failed (err %d)\n", err);
 		return err;
 	}
-
 	for (int index = 0; index < CONFIG_BT_EXT_ADV_MAX_ADV_SET; index++) {
 		/* Use advertising set instance index as SID */
 		adv_param.sid = index;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -117,6 +117,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 	uint8_t ad_len_overflow;
 	uint8_t ad_len_chain;
 	struct pdu_adv *pdu;
+	uint8_t ad_len = 0U;
 #endif /* CONFIG_BT_CTLR_ADV_AUX_PDU_LINK */
 
 	/* Get the advertising set instance */
@@ -301,7 +302,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		struct pdu_adv *pdu_chain_prev;
 		struct pdu_adv *pdu_chain;
 		uint16_t ad_len_total;
-		uint8_t ad_len_prev;
+		uint8_t ad_len_prev = 0U;
 
 		/* Traverse to next set clear hdr data parameter */
 		val_ptr += sizeof(data);
@@ -317,28 +318,22 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		ad_len_total = 0U;
 		pdu_chain_prev = pdu_prev;
 		pdu_chain = pdu;
+		/* make a copy of the previous chain, until we reach the end */
 		do {
-			/* Prepare for aux ptr field reference to be returned, hence
-			 * second parameter will be for AD data field.
-			 */
-			*val_ptr = 0U;
-			(void)memset((void *)&val_ptr[ULL_ADV_HDR_DATA_DATA_PTR_OFFSET],
-				     0U, ULL_ADV_HDR_DATA_DATA_PTR_SIZE);
+			val_ptr = hdr_data;
+			*val_ptr++ = 0U;
+			(void)memset((void *)val_ptr, 0U,
+				     ULL_ADV_HDR_DATA_DATA_PTR_SIZE);
 
 			pdu_prev = pdu_chain_prev;
 			pdu = pdu_chain;
 
-			/* Add Aux Ptr field if not already present */
 			err = ull_adv_aux_pdu_set_clear(adv, pdu_prev, pdu,
-						(ULL_ADV_PDU_HDR_FIELD_AD_DATA |
-						 ULL_ADV_PDU_HDR_FIELD_AUX_PTR),
-						0, hdr_data);
-			LL_ASSERT(!err || (err == BT_HCI_ERR_PACKET_TOO_LONG));
+							ULL_ADV_PDU_HDR_FIELD_AD_DATA,
+							0U, hdr_data);
+			ad_len_prev = hdr_data[ULL_ADV_HDR_DATA_LEN_OFFSET];
 
-			/* Get PDUs previous AD data length */
-			ad_len_prev =
-				hdr_data[ULL_ADV_HDR_DATA_AUX_PTR_PTR_OFFSET +
-					 ULL_ADV_HDR_DATA_AUX_PTR_PTR_SIZE];
+			LL_ASSERT(!err || (err == BT_HCI_ERR_PACKET_TOO_LONG));
 
 			/* Check of max supported AD data len */
 			ad_len_total += ad_len_prev;
@@ -365,31 +360,10 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 				  (!pdu_chain_prev && !pdu_chain));
 		} while (pdu_chain_prev);
 
-		if (err == BT_HCI_ERR_PACKET_TOO_LONG) {
-			ad_len_overflow =
-				hdr_data[ULL_ADV_HDR_DATA_AUX_PTR_PTR_OFFSET +
-					 ULL_ADV_HDR_DATA_AUX_PTR_PTR_SIZE +
-					 ULL_ADV_HDR_DATA_DATA_PTR_OFFSET +
-					 ULL_ADV_HDR_DATA_DATA_PTR_SIZE];
-
-			/* Prepare for aux ptr field reference to be returned,
-			 * hence second parameter will be for AD data field.
-			 * Fill it with reduced AD data length.
-			 */
-			*val_ptr = ad_len_prev - ad_len_overflow;
-
-			/* AD data len in chain PDU */
-			ad_len_chain = len;
-
-			/* Proceed to add chain PDU */
-			err = 0U;
-		} else {
-			/* No AD data overflow */
-			ad_len_overflow = 0U;
-
-			/* No AD data in chain PDU */
-			ad_len_chain = 0U;
-		}
+		/* No AD data overflow */
+		ad_len_overflow = 0U;
+		/* No AD data in chain PDU */
+		ad_len_chain = 0U;
 	}
 #else /* !CONFIG_BT_CTLR_ADV_AUX_PDU_LINK */
 	} else {
@@ -411,8 +385,88 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 
 #if defined(CONFIG_BT_CTLR_ADV_AUX_PDU_LINK)
 	if ((op == BT_HCI_LE_EXT_ADV_OP_INTERM_FRAG) ||
-	    (op == BT_HCI_LE_EXT_ADV_OP_LAST_FRAG) ||
-	    ad_len_overflow) {
+	    (op == BT_HCI_LE_EXT_ADV_OP_LAST_FRAG)) {
+		/* in the previous step we duplicated the chain
+		 * the next step is to append new data in the last existing pdu in the chain,
+		 */
+
+		uint8_t chain_err = 0U;
+
+		val_ptr = hdr_data;
+		*val_ptr++ = len;
+		(void)memcpy(val_ptr, &data, sizeof(data));
+
+		/* Append data to the last PDU */
+		chain_err = ull_adv_aux_pdu_set_clear(adv, pdu_prev, pdu,
+						      ULL_ADV_PDU_HDR_FIELD_AD_DATA_APPEND,
+						      0U, hdr_data);
+
+		LL_ASSERT((!chain_err) || (chain_err == BT_HCI_ERR_PACKET_TOO_LONG));
+
+		/* FIXME: the code has become quite complex, an alternative and simpler
+		 * implementation would be to first fill an array with all data that
+		 * must be send, and create the chained PDUs from this array
+		 */
+		if (chain_err == BT_HCI_ERR_PACKET_TOO_LONG) {
+			/* We could not fit all the data, append as much as possible
+			 * ad_len_overflow is how much overflows with the AUX ptr
+			 */
+			uint8_t ad_len_overflow_first_try;
+			const uint16_t chain_add_fields = ULL_ADV_PDU_HDR_FIELD_AD_DATA_APPEND |
+							  ULL_ADV_PDU_HDR_FIELD_AUX_PTR;
+
+			ad_len_overflow_first_try = hdr_data[ULL_ADV_HDR_DATA_DATA_PTR_OFFSET +
+							     ULL_ADV_HDR_DATA_DATA_PTR_SIZE];
+
+			val_ptr = hdr_data;
+			*val_ptr++ = len;
+			(void)memcpy(val_ptr, &data, sizeof(data));
+			val_ptr += sizeof(data);
+			*val_ptr++ = len;
+			(void)memcpy(val_ptr, &data, sizeof(data));
+			chain_err = ull_adv_aux_pdu_set_clear(adv, pdu_prev, pdu,
+							      chain_add_fields,
+							      0U, hdr_data);
+			ad_len_overflow = hdr_data[ULL_ADV_HDR_DATA_AUX_PTR_PTR_OFFSET +
+						   ULL_ADV_HDR_DATA_AUX_PTR_PTR_SIZE +
+						   ULL_ADV_HDR_DATA_DATA_PTR_OFFSET +
+						   ULL_ADV_HDR_DATA_DATA_PTR_SIZE];
+
+			/* ad_len_overflow - ad_len_overflow_first_try is the size of
+			 * the aux pointer
+			 * ad_len_prev is how much data is already present, ad_len is how
+			 * much data we can add to this PDU
+			 */
+			ad_len = PDU_AC_PAYLOAD_SIZE_MAX - ad_len_prev -
+				(ad_len_overflow - ad_len_overflow_first_try) - 4;
+
+			val_ptr = hdr_data;
+			*val_ptr++ =  ad_len;
+			(void)memcpy(val_ptr, &data, sizeof(data));
+			val_ptr += sizeof(data);
+			*val_ptr++ =  ad_len;
+			(void)memcpy(val_ptr, &data, sizeof(data));
+
+			/* we now know how much data we can add to the
+			 * last PDU without getting an overflow
+			 */
+			chain_err = ull_adv_aux_pdu_set_clear(adv, pdu_prev, pdu,
+							      chain_add_fields,
+							      0U, hdr_data);
+			LL_ASSERT(chain_err == 0U);
+			/*
+			 * in the next PDU we still need to add ad_len_chain bytes of data
+			 * but we do not have overflow, since we already added
+			 * the exact amount that would fit
+			 */
+			ad_len_chain = len - ad_len;
+			ad_len_overflow = 0U;
+		} else {
+			ad_len_overflow = 0U;
+		}
+	}
+
+	if (ad_len_chain || ad_len_overflow) {
 		struct pdu_adv_com_ext_adv *com_hdr_chain;
 		struct pdu_adv_com_ext_adv *com_hdr;
 		struct pdu_adv_ext_hdr *hdr_chain;
@@ -425,6 +479,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		uint16_t sec_len;
 		uint8_t *dptr;
 
+		len = ad_len_chain;
 		/* Get reference to flags in superior PDU */
 		com_hdr = &pdu->adv_ext_ind;
 		if (com_hdr->ext_hdr_len) {
@@ -450,6 +505,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		hdr_chain = (void *)&com_hdr_chain->ext_hdr_adv_data[0];
 		dptr_chain = (void *)hdr_chain;
 
+		LL_ASSERT(dptr_chain);
 		/* Flags */
 		*dptr_chain = 0U;
 
@@ -498,6 +554,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		if (ad_len_overflow) {
 			uint8_t *ad_overflow;
 
+			val_ptr = hdr_data;
 			/* Copy overflowed AD data from previous PDU into this
 			 * new chain PDU
 			 */
@@ -505,6 +562,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 				     &val_ptr[ULL_ADV_HDR_DATA_DATA_PTR_OFFSET],
 				     sizeof(ad_overflow));
 			ad_overflow += *val_ptr;
+
 			(void)memcpy(dptr_chain, ad_overflow, ad_len_overflow);
 			dptr_chain += ad_len_overflow;
 
@@ -529,8 +587,6 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 				return err;
 			}
 
-			/* AD data len in chain PDU besides the overflow */
-			len = ad_len_chain;
 		}
 
 		/* Check AdvData overflow */
@@ -555,7 +611,13 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		pdu_chain->len = sec_len + ad_len_overflow + len;
 
 		/* Fill AD Data in chain PDU */
-		(void)memcpy(dptr_chain, data, len);
+		if (ad_len_overflow != 0U) {
+			(void)memcpy(dptr_chain, data, ad_len_overflow);
+		}
+
+		if (ad_len_chain != 0U) {
+			(void)memcpy(dptr_chain, &data[ad_len + ad_len_overflow], ad_len_chain);
+		}
 
 		/* Get reference to aux ptr in superior PDU */
 		(void)memcpy(&aux_ptr,

--- a/tests/bsim/bluetooth/host/adv/chain/prj.conf
+++ b/tests/bsim/bluetooth/host/adv/chain/prj.conf
@@ -30,8 +30,9 @@ CONFIG_BT_EXT_SCAN_BUF_SIZE=1650
 # Set maximum scan data length for Extended Scanning in Bluetooth LE Controller
 CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX=1650
 
-# Zephyr Bluetooth LE Controller needs 16 event buffers to generate Extended
-# Advertising Report for receiving the complete 1650 bytes of data
+# Zephyr Controller does not combine all the 1650 bytes before fragmenting them
+# into 8 HCI reports, if a PDU has 255 bytes, it will generate 2 HCI reports
+# and so we need to reserve 16 buffers
 CONFIG_BT_BUF_EVT_RX_COUNT=16
 
 # Increase Zephyr Bluetooth LE Controller Rx buffer to receive complete chain

--- a/tests/bsim/bluetooth/host/adv/chain/prj.conf
+++ b/tests/bsim/bluetooth/host/adv/chain/prj.conf
@@ -30,9 +30,9 @@ CONFIG_BT_EXT_SCAN_BUF_SIZE=1650
 # Set maximum scan data length for Extended Scanning in Bluetooth LE Controller
 CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX=1650
 
-# Zephyr Controller does not combine all the 1650 bytes before fragmenting them
-# into 8 HCI reports, if a PDU has 255 bytes, it will generate 2 HCI reports
-# and so we need to reserve 16 buffers
+# The Zephyr Controller does not combine all the 1650 bytes before
+# fragmenting into 8 HCI reports, if a PDU has 255 bytes,
+# it will generate 2 HCI reports and so we need to reserve 16 buffers
 CONFIG_BT_BUF_EVT_RX_COUNT=16
 
 # Increase Zephyr Bluetooth LE Controller Rx buffer to receive complete chain

--- a/tests/bsim/bluetooth/host/adv/chain/src/main.c
+++ b/tests/bsim/bluetooth/host/adv/chain/src/main.c
@@ -34,8 +34,12 @@
 #define NAME_LEN 30
 #define BT_AD_DATA_NAME_SIZE     (sizeof(CONFIG_BT_DEVICE_NAME) - 1U + 2U)
 #define BT_AD_DATA_MFG_DATA_SIZE (254U + 2U)
+/*
+ * for testing chaining the manufacturing data is duplicated, hence DATA_LEN needs to
+ * add twice the size for this element
+ */
 #define DATA_LEN                 MIN((BT_AD_DATA_NAME_SIZE + \
-				      BT_AD_DATA_MFG_DATA_SIZE), \
+				      BT_AD_DATA_MFG_DATA_SIZE + BT_AD_DATA_MFG_DATA_SIZE), \
 				     CONFIG_BT_CTLR_ADV_DATA_LEN_MAX)
 
 static K_SEM_DEFINE(sem_recv, 0, 1);
@@ -94,6 +98,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 
 	data_len = buf->len;
 	if (data_len != DATA_LEN) {
+		printk("Received datalength: %d\n", data_len);
 		return;
 	}
 
@@ -101,11 +106,13 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 	bt_data_parse(buf, data_cb, name);
 
 	if (strcmp(name, CONFIG_BT_DEVICE_NAME)) {
+		printk("Wrong name %s\n", name);
 		return;
 	}
 
 	for (uint8_t i = 0; i < sid_count; i++) {
 		if (sid[i] == info->sid) {
+			printk("Received SID %d\n", info->sid);
 			return;
 		}
 	}
@@ -113,6 +120,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 	sid[sid_count++] = info->sid;
 
 	if (sid_count < CONFIG_BT_EXT_ADV_MAX_ADV_SET) {
+		printk("Received advertising sets: %d\n", sid_count);
 		return;
 	}
 


### PR DESCRIPTION
In the case that chaining is enabled when adding new data to an advertising chain a new PDU is created for this data. This limits how often data can be added to the number of available PDUs.

The changes in this PR add the data to the last PDU in the chain, and only if there is not enough room a new PDU is created

A test was added to CI where the name is set to an extra long length to force an overflow of data to occur so that this new functionality is tested

See issues #63288 and #63290 for further improvements

fixes #59580