### PR TITLE
add Ethernet twister test on nucleo board

### DIFF
--- a/samples/net/zperf/sample.yaml
+++ b/samples/net/zperf/sample.yaml
@@ -1,5 +1,4 @@
 common:
-  harness: net
   tags:
     - net
     - zperf
@@ -14,12 +13,26 @@ sample:
   name: zperf
 tests:
   sample.net.zperf:
+    harness: net
     platform_allow: qemu_x86
+  sample.net.zperf_st:
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "coming up"
+    platform_allow:
+      - nucleo_h563zi
+      - nucleo_h743zi
+      - nucleo_f429zi
+      - nucleo_f746zg
   sample.net.zperf_no_shell:
+    harness: net
     extra_configs:
       - CONFIG_NET_SHELL=n
     platform_allow: qemu_x86
   sample.net.zperf.netusb_ecm:
+    harness: net
     extra_args: OVERLAY_CONFIG="overlay-netusb.conf"
     tags:
       - usb
@@ -27,12 +40,14 @@ tests:
       - zperf
     depends_on: usb_device
   sample.net.zperf.device_next_ecm:
+    harness: net
     extra_args: OVERLAY_CONFIG="overlay-usbd_next_ecm.conf"
                 DTC_OVERLAY_FILE="usbd_next_ecm.overlay"
     platform_allow: nrf52840dk_nrf52840 frdm_k64f
     tags: usb net zperf
     depends_on: usb_device
   sample.net.zperf.netusb_eem:
+    harness: net
     extra_args: OVERLAY_CONFIG="overlay-netusb.conf"
     extra_configs:
       - CONFIG_USB_DEVICE_NETWORK_ECM=n
@@ -43,6 +58,7 @@ tests:
       - zperf
     depends_on: usb_device
   sample.net.zperf.netusb_rndis:
+    harness: net
     extra_args: OVERLAY_CONFIG="overlay-netusb.conf"
     extra_configs:
       - CONFIG_USB_DEVICE_NETWORK_ECM=n
@@ -53,6 +69,7 @@ tests:
       - zperf
     depends_on: usb_device
   sample.net.zperf.shield:
+    harness: net
     platform_allow: reel_board
     extra_args: SHIELD=link_board_eth
     tags:


### PR DESCRIPTION
add one Ethernet twister test for nucleo_h563zi,
nucleo_h743zi, nucleo_f429zi, nucleo_f746zg.
remove the common: harnesses: net  that are not supported leave harnesses: net for all other test execpt the one we use