### PR TITLE
Bluetooth: Mesh: Reduce BT_L2CAP_TX_MTU for mesh to 33

### DIFF
--- a/subsys/bluetooth/host/Kconfig.l2cap
+++ b/subsys/bluetooth/host/Kconfig.l2cap
@@ -30,7 +30,6 @@ config BT_L2CAP_TX_FRAG_COUNT
 config BT_L2CAP_TX_MTU
 	int "Maximum supported L2CAP MTU for L2CAP TX buffers"
 	default 253 if BT_BREDR
-	default 69 if BT_MESH_GATT
 	default 66 if BT_EATT
 	default 65 if BT_SMP
 	default 64 if BT_BAP_UNICAST_SERVER || \
@@ -39,6 +38,7 @@ config BT_L2CAP_TX_MTU
 		      BT_BAP_SCAN_DELEGATOR || \
 		      BT_BAP_BROADCAST_ASSISTANT
 	default 49 if BT_HAS || BT_HAS_CLIENT
+	default 33 if BT_MESH_GATT
 	default 23
 	range 66 2000 if BT_EATT
 	range 65 2000 if BT_SMP


### PR DESCRIPTION
Since the acl mtu for mesh is reduced to 37 in PR #59004, there is no need in BT_L2CAP_TX_MTU to be longer than 33 bytes for mesh.