### PR TITLE
tests: kernel/sys_mutex: sleep a bit for private_mutex to lock

### DIFF
--- a/tests/kernel/mutex/sys_mutex/src/main.c
+++ b/tests/kernel/mutex/sys_mutex/src/main.c
@@ -397,7 +397,7 @@ ZTEST_USER_OR_NOT(mutex_complex, test_mutex)
 	k_thread_create(&thread_12_thread_data, thread_12_stack_area, STACKSIZE,
 			(k_thread_entry_t)thread_12, NULL, NULL, NULL,
 			K_PRIO_PREEMPT(12), PARTICIPANT_THREAD_OPTIONS, K_NO_WAIT);
-	k_sleep(K_MSEC(1));     /* Give thread_12 a chance to block on the mutex */
+	k_sleep(K_MSEC(5));     /* Give thread_12 a chance to block on the mutex */
 
 	sys_mutex_unlock(&private_mutex);
 	sys_mutex_unlock(&private_mutex); /* thread_12 should now have lock */


### PR DESCRIPTION
With SMP, the private_mutex may not be locked fast enough by thread_12 after the thread creation as it might take longer for a thread to start running the entry function, resulting in test failure when the main test thread goes into locking it again. So give it a bit more delay after thread creation so thread_12 has a chance to lock the private_mutex.