### PR TITLE
drivers/sensor: lis2dh: move h/w reg debug print right after it is read

### DIFF
--- a/drivers/sensor/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/lis2dh/lis2dh_trigger.c
@@ -387,6 +387,8 @@ static void lis2dh_thread_cb(const struct device *dev)
 				LOG_ERR("clearing interrupt 2 failed: %d", status);
 				return;
 			}
+
+			LOG_DBG("@tick=%u int2_src=0x%x", k_cycle_get_32(), reg_val);
 		}
 
 		if (likely(lis2dh->handler_anymotion != NULL)) {
@@ -399,9 +401,6 @@ static void lis2dh_thread_cb(const struct device *dev)
 		if (lis2dh->handler_anymotion != NULL) {
 			setup_int2(dev, true);
 		}
-
-		LOG_DBG("@tick=%u int2_src=0x%x", k_cycle_get_32(),
-			    reg_val);
 
 		return;
 	}


### PR DESCRIPTION
Move LOG_DBG print just after the printed h/w register is read, to avoid coverity complaining about uninitialized variable.

  Fixes #58591
  Coverity-CID: 316407