### PR TITLE
soc: arm: imx_rt10xx: support enet1 external clock

### DIFF
--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -195,8 +195,13 @@ static ALWAYS_INLINE void clock_init(void)
 
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(enet), okay) && CONFIG_NET_L2_ETHERNET
+#if CONFIG_ETH_MCUX_RMII_EXT_CLK
+	/* Enable clock input for ENET1 */
+	IOMUXC_EnableMode(IOMUXC_GPR, kIOMUXC_GPR_ENET1TxClkOutputDir, false);
+#else
 	/* Enable clock output for ENET1 */
 	IOMUXC_EnableMode(IOMUXC_GPR, kIOMUXC_GPR_ENET1TxClkOutputDir, true);
+#endif
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usb1), okay) && CONFIG_USB_DC_NXP_EHCI


### PR DESCRIPTION
Configure `ENET_REF_CLK` direction as input when `CONFIG_ETH_MCUX_RMII_EXT_CLK` is set to allow Ethernet external clock usage.