### PR TITLE
drivers: uart_mcux_flexcomm: fix mcux_flexcomm_isr unused for polled uart

### DIFF
--- a/drivers/serial/Kconfig.mcux_flexcomm
+++ b/drivers/serial/Kconfig.mcux_flexcomm
@@ -14,3 +14,10 @@ config UART_MCUX_FLEXCOMM
 	select PINCTRL
 	help
 	  Enable the MCUX USART driver.
+
+config UART_MCUX_FLEXCOMM_ISR_SUPPORT
+	bool
+	depends on UART_MCUX_FLEXCOMM
+	default y if UART_INTERRUPT_DRIVEN || UART_ASYNC_API
+	help
+	  Enable UART interrupt service routine.

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -39,7 +39,7 @@ struct mcux_flexcomm_config {
 	clock_control_subsys_t clock_subsys;
 	uint32_t baud_rate;
 	uint8_t parity;
-#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
+#ifdef CONFIG_UART_MCUX_FLEXCOMM_ISR_SUPPORT
 	void (*irq_config_func)(const struct device *dev);
 #endif
 	const struct pinctrl_dev_config *pincfg;
@@ -916,7 +916,7 @@ static int flexcomm_uart_async_init(const struct device *dev)
 
 #endif /* CONFIG_UART_ASYNC_API */
 
-#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
+#ifdef CONFIG_UART_MCUX_FLEXCOMM_ISR_SUPPORT
 static void mcux_flexcomm_isr(const struct device *dev)
 {
 	struct mcux_flexcomm_data *data = dev->data;
@@ -985,9 +985,9 @@ static void mcux_flexcomm_isr(const struct device *dev)
 		}
 
 	}
-#endif
+#endif /* CONFIG_UART_ASYNC_API */
 }
-#endif
+#endif /* CONFIG_UART_MCUX_FLEXCOMM_ISR_SUPPORT */
 
 
 static int mcux_flexcomm_init(const struct device *dev)
@@ -1042,7 +1042,7 @@ static int mcux_flexcomm_init(const struct device *dev)
 
 	USART_Init(config->base, &usart_config, clock_freq);
 
-#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
+#ifdef CONFIG_UART_MCUX_FLEXCOMM_ISR_SUPPORT
 	config->irq_config_func(dev);
 #endif
 
@@ -1091,7 +1091,7 @@ static const struct uart_driver_api mcux_flexcomm_driver_api = {
 };
 
 
-#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
+#ifdef CONFIG_UART_MCUX_FLEXCOMM_ISR_SUPPORT
 #define UART_MCUX_FLEXCOMM_IRQ_CFG_FUNC(n)					\
 	static void mcux_flexcomm_irq_config_func_##n(const struct device *dev)	\
 	{									\
@@ -1106,7 +1106,7 @@ static const struct uart_driver_api mcux_flexcomm_driver_api = {
 #else
 #define UART_MCUX_FLEXCOMM_IRQ_CFG_FUNC(n)
 #define UART_MCUX_FLEXCOMM_IRQ_CFG_FUNC_INIT(n)
-#endif /* defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) */
+#endif /* CONFIG_UART_MCUX_FLEXCOMM_ISR_SUPPORT */
 
 #ifdef CONFIG_UART_ASYNC_API
 #define UART_MCUX_FLEXCOMM_TX_TIMEOUT_FUNC(n)					\

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -39,7 +39,7 @@ struct mcux_flexcomm_config {
 	clock_control_subsys_t clock_subsys;
 	uint32_t baud_rate;
 	uint8_t parity;
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 	void (*irq_config_func)(const struct device *dev);
 #endif
 	const struct pinctrl_dev_config *pincfg;
@@ -916,7 +916,7 @@ static int flexcomm_uart_async_init(const struct device *dev)
 
 #endif /* CONFIG_UART_ASYNC_API */
 
-
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 static void mcux_flexcomm_isr(const struct device *dev)
 {
 	struct mcux_flexcomm_data *data = dev->data;
@@ -987,6 +987,7 @@ static void mcux_flexcomm_isr(const struct device *dev)
 	}
 #endif
 }
+#endif
 
 
 static int mcux_flexcomm_init(const struct device *dev)
@@ -1041,7 +1042,7 @@ static int mcux_flexcomm_init(const struct device *dev)
 
 	USART_Init(config->base, &usart_config, clock_freq);
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 	config->irq_config_func(dev);
 #endif
 
@@ -1090,7 +1091,7 @@ static const struct uart_driver_api mcux_flexcomm_driver_api = {
 };
 
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 #define UART_MCUX_FLEXCOMM_IRQ_CFG_FUNC(n)					\
 	static void mcux_flexcomm_irq_config_func_##n(const struct device *dev)	\
 	{									\
@@ -1105,7 +1106,7 @@ static const struct uart_driver_api mcux_flexcomm_driver_api = {
 #else
 #define UART_MCUX_FLEXCOMM_IRQ_CFG_FUNC(n)
 #define UART_MCUX_FLEXCOMM_IRQ_CFG_FUNC_INIT(n)
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+#endif /* defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) */
 
 #ifdef CONFIG_UART_ASYNC_API
 #define UART_MCUX_FLEXCOMM_TX_TIMEOUT_FUNC(n)					\


### PR DESCRIPTION
When `UART_INTERRUPT_DRIVEN`=`n`,  `mcux_flexcomm_isr` and the data structure inside is left unused.
This patch turns off the build of the entire ISR.

First noticed as part of a CI run in https://github.com/zephyrproject-rtos/zephyr/pull/52208
CI run link: https://github.com/zephyrproject-rtos/zephyr/actions/runs/5403369165/jobs/9816093378?pr=52208#step:13:469

Fixes #59853