### PR TITLE
Bluetooth: Shell: Restore missing `bt_addr_le_to_str` in `scan_recv`

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -408,6 +408,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_si
 	(void)memset(name, 0, sizeof(name));
 
 	bt_data_parse(buf, data_cb, name);
+	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
 	shell_print(ctx_shell, "%s%s, AD evt type %u, RSSI %i %s "
 		    "C:%u S:%u D:%d SR:%u E:%u Prim: %s, Secn: %s, "


### PR DESCRIPTION
This restores a line of code that was accidentally deleted in 5580cb439188f4a5a1804127e474c8a872393fe2. This fixes an uninitialized `le_addr` resulting in garbage output in the scan results.