### PR TITLE
Bluetooth: Modify stream_ops->stopped to be called on leaving streaming

### DIFF
--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -43,6 +43,9 @@ struct bt_bap_ep {
 	struct bt_codec_qos_pref qos_pref;
 	struct bt_bap_iso *iso;
 
+	/* unicast stopped reason */
+	uint8_t reason;
+
 	/* Used by the unicast server and client */
 	bool receiver_ready;
 

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -166,6 +166,9 @@ int bt_bap_unicast_server_disable(struct bt_bap_stream *stream)
 
 	ep = stream->ep;
 
+	/* Set reason in case this exits the streaming state */
+	ep->reason = BT_HCI_ERR_LOCALHOST_TERM_CONN;
+
 	/* The ASE state machine goes into different states from this operation
 	 * based on whether it is a source or a sink ASE.
 	 */
@@ -182,6 +185,7 @@ int bt_bap_unicast_server_release(struct bt_bap_stream *stream)
 {
 	struct bt_bap_ascs_rsp rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS,
 						     BT_BAP_ASCS_REASON_NONE);
+	struct bt_bap_ep *ep;
 	int err;
 
 	if (unicast_server_cb != NULL && unicast_server_cb->release != NULL) {
@@ -195,10 +199,15 @@ int bt_bap_unicast_server_release(struct bt_bap_stream *stream)
 		return err;
 	}
 
+	ep = stream->ep;
+
+	/* Set reason in case this exits the streaming state */
+	ep->reason = BT_HCI_ERR_LOCALHOST_TERM_CONN;
+
 	/* ase_process will set the state to IDLE after sending the
 	 * notification, finalizing the release
 	 */
-	ascs_ep_set_state(stream->ep, BT_BAP_EP_STATE_RELEASING);
+	ascs_ep_set_state(ep, BT_BAP_EP_STATE_RELEASING);
 
 	return 0;
 }

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -281,6 +281,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_releasing)
 
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	expect_bt_bap_stream_ops_released_called_once(stream);
 }
 
@@ -317,6 +318,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_qos_configured)
 
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
+	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
 }
 
@@ -545,6 +547,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_qos_configured)
 
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
+	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
 	expect_bt_bap_stream_ops_qos_set_called_once(stream);
 }
 
@@ -568,6 +571,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_releasing)
 
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
+	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
 	expect_bt_bap_stream_ops_released_called_once(stream);
 }
 
@@ -816,7 +820,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_releasing)
 
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_stopped_called_once(stream, EMPTY);
+	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	expect_bt_bap_stream_ops_released_called_once(stream);
 }
 
@@ -853,6 +857,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling)
 
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
+	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	expect_bt_bap_stream_ops_disabled_called_once(stream);
 }
 
@@ -886,6 +891,10 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling_to_
 
 	test_preamble_state_streaming(conn, ase_id, stream, &chan, true);
 	test_ase_control_client_disable(conn, ase_id);
+
+	/* Verify that stopped callback was called by disable */
+	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+
 	test_mocks_reset();
 
 	test_ase_control_client_receiver_stop_ready(conn, ase_id);
@@ -1097,6 +1106,7 @@ ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_disabling)
 
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_disable_called_once(stream);
+	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
 	expect_bt_bap_stream_ops_disabled_called_once(stream);
 }
 
@@ -1120,6 +1130,6 @@ ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_releasing)
 
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
-	expect_bt_bap_stream_ops_stopped_called_once(stream, EMPTY);
+	expect_bt_bap_stream_ops_stopped_called_once(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
 	expect_bt_bap_stream_ops_released_called_once(stream);
 }


### PR DESCRIPTION
When a stream leaves the streaming state the `stopped` callback will now be called, similar to how the `started` callback works.

This ensures that `stopped` is always called and not just when the CIS disconnects.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/59658