### PR TITLE
Fixes for LL/DDI/SCN/BI-04-C test failure

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -3499,7 +3499,6 @@ static void le_set_ext_adv_enable(struct net_buf *buf, struct net_buf **evt)
 	struct bt_hci_cp_le_set_ext_adv_enable *cmd = (void *)buf->data;
 	struct bt_hci_ext_adv_set *s;
 	uint8_t set_num;
-	uint8_t enable;
 	uint8_t status;
 	uint8_t handle;
 
@@ -3522,7 +3521,6 @@ static void le_set_ext_adv_enable(struct net_buf *buf, struct net_buf **evt)
 	}
 
 	s = (void *) cmd->s;
-	enable = cmd->enable;
 	do {
 		status = ll_adv_set_by_hci_handle_get(s->handle, &handle);
 		if (status) {

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6878,7 +6878,14 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 			uint8_t aux_phy;
 
 			aux_ptr = (void *)ptr;
-			if (PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) > EXT_ADV_AUX_PHY_LE_CODED) {
+
+			/* Don't report if invalid phy or AUX_ADV_IND was not received
+			 * See BT Core 5.4, Vol 6, Part B, Section 4.4.3.5:
+			 * If the Controller does not listen for or does not receive the
+			 * AUX_ADV_IND PDU, no report shall be generated
+			 */
+			if ((node_rx_curr == node_rx && !node_rx_next) ||
+			    PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) > EXT_ADV_AUX_PHY_LE_CODED) {
 				struct node_rx_ftr *ftr;
 
 				ftr = &node_rx->hdr.rx_ftr;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -149,6 +149,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 				      ull_scan_handle_get(scan);
 		break;
 
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 	case NODE_RX_TYPE_EXT_CODED_REPORT:
 		lll_aux = NULL;
 		aux = NULL;
@@ -166,6 +167,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		ticker_yield_handle = TICKER_ID_SCAN_BASE +
 				      ull_scan_handle_get(scan);
 		break;
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
 
 	case NODE_RX_TYPE_EXT_AUX_REPORT:
 		sync_iso = NULL;
@@ -246,9 +248,11 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 			case PHY_2M:
 				rx->type = NODE_RX_TYPE_EXT_2M_REPORT;
 				break;
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
 			case PHY_CODED:
 				rx->type = NODE_RX_TYPE_EXT_CODED_REPORT;
 				break;
+#endif /* CONFIG_BT_CTLR_PHY_CODED */
 			default:
 				LL_ASSERT(0);
 				return;
@@ -456,10 +460,12 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 	/* Do not ULL schedule auxiliary PDU reception if no aux pointer
 	 * or aux pointer is zero or scannable advertising has erroneous aux
-	 * pointer being present or PHY in the aux pointer is invalid.
+	 * pointer being present or PHY in the aux pointer is invalid or unsupported.
 	 */
 	if (!aux_ptr || !PDU_ADV_AUX_PTR_OFFSET_GET(aux_ptr) || is_scan_req ||
-	    (PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) > EXT_ADV_AUX_PHY_LE_CODED)) {
+	    (PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) > EXT_ADV_AUX_PHY_LE_CODED) ||
+		(!IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED) &&
+		  PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) == EXT_ADV_AUX_PHY_LE_CODED)) {
 		if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && sync_lll) {
 			struct ll_sync_set *sync;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -50,8 +50,10 @@ static inline struct ll_scan_aux_set *aux_acquire(void);
 static inline void aux_release(struct ll_scan_aux_set *aux);
 static inline uint8_t aux_handle_get(struct ll_scan_aux_set *aux);
 static inline struct ll_sync_set *sync_create_get(struct ll_scan_set *scan);
+#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 static inline struct ll_sync_iso_set *
 	sync_iso_create_get(struct ll_sync_set *sync);
+#endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 static void done_disabled_cb(void *param);
 static void flush_safe(void *param);
 static void flush(void *param);
@@ -1082,6 +1084,7 @@ static inline struct ll_sync_set *sync_create_get(struct ll_scan_set *scan)
 #endif /* !CONFIG_BT_CTLR_SYNC_PERIODIC */
 }
 
+#if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 static inline struct ll_sync_iso_set *
 	sync_iso_create_get(struct ll_sync_set *sync)
 {
@@ -1091,6 +1094,7 @@ static inline struct ll_sync_iso_set *
 	return NULL;
 #endif /* !CONFIG_BT_CTLR_SYNC_ISO */
 }
+#endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 
 static void done_disabled_cb(void *param)
 {


### PR DESCRIPTION
Fixes some issues that caused the LL/DDI/SCN/BI-04-C test case to fail (Passive Scanning, Invalid or Unsupported PHY, LE Coded PHY Not Supported)

- Handle unsupported coded phy in ull_scan_aux
- Suppress HCI advertising report for ADV_EXT_IND when the AUX_ADV_IND has not been received

In addition, fixes a couple of compiler warnings in the files touched