### PR TITLE
net: context: set default offloaded iface during net_context_get()

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -337,6 +337,8 @@ int net_context_get(sa_family_t family, enum net_sock_type type, uint16_t proto,
 			*context = NULL;
 			return ret;
 		}
+
+		net_context_set_iface(*context, net_if_get_default());
 	}
 
 	return 0;


### PR DESCRIPTION
Set default offloaded interface during `net_context_get()` call, so that
`net_context_recv()` can be called before `net_context_connect()`. There is
already an assumption about using default network interface, so this should
not be harmful.

Fixes: 2c7507036050 ("net: sockets: tcp: Fix possible race between
  connect/recv")
Fixes: #59850