### PR TITLE
cmake/compiler/clang/target.cmake: Improve support for different runtime libraries

### DIFF
--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -32,6 +32,10 @@ if(NOT "${ARCH}" STREQUAL "posix")
     include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_arm.cmake)
   endif()
 
+  if(DEFINED CMAKE_C_COMPILER_TARGET)
+    set(clang_target_flag "--target=${CMAKE_C_COMPILER_TARGET}")
+  endif()
+
   foreach(file_name include/stddef.h)
     execute_process(
       COMMAND ${CMAKE_C_COMPILER} --print-file-name=${file_name}
@@ -57,7 +61,8 @@ if(NOT "${ARCH}" STREQUAL "posix")
 
   # This libgcc code is partially duplicated in compiler/*/target.cmake
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
+    COMMAND ${CMAKE_C_COMPILER} ${clang_target_flag} ${TOOLCHAIN_C_FLAGS}
+            --print-libgcc-file-name
     OUTPUT_VARIABLE RTLIB_FILE_NAME
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -58,16 +58,16 @@ if(NOT "${ARCH}" STREQUAL "posix")
   # This libgcc code is partially duplicated in compiler/*/target.cmake
   execute_process(
     COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
-    OUTPUT_VARIABLE LIBGCC_FILE_NAME
+    OUTPUT_VARIABLE RTLIB_FILE_NAME
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-  get_filename_component(LIBGCC_DIR ${LIBGCC_FILE_NAME} DIRECTORY)
+  get_filename_component(RTLIB_DIR ${RTLIB_FILE_NAME} DIRECTORY)
+  get_filename_component(RTLIB_NAME_WITH_PREFIX ${RTLIB_FILE_NAME} NAME_WLE)
+  string(REPLACE lib "" RTLIB_NAME ${RTLIB_NAME_WITH_PREFIX})
 
-  list(APPEND LIB_INCLUDE_DIR "-L\"${LIBGCC_DIR}\"")
-  if(LIBGCC_DIR)
-    list(APPEND TOOLCHAIN_LIBS gcc)
-  endif()
+  list(APPEND LIB_INCLUDE_DIR -L${RTLIB_DIR})
+  list(APPEND TOOLCHAIN_LIBS ${RTLIB_NAME})
 
   list(APPEND CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags})
   string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")


### PR DESCRIPTION
Use rtlib provided by compiler instead of hardcoding libgcc

Clang provides runtime library `libclang_rt.builtins.<arch>.a` but `libgcc.a` is also supported.
The compiler can provide full path to the selected library using the `--print-libgcc-file-name` option, for example:
```
/usr/lib64/clang/17/lib/baremetal/libclang_rt.builtins-armv7m.a
```

If `--rtlib=libgcc` option is provided, clang will also provide appropriate path.

Replace hardcoded `libgcc` with library name extracted from path, so we are compatible with both libraries.