### PR TITLE
drivers: sensor: ina23x: Use micro-ohms for rshunt.

### DIFF
--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -156,7 +156,7 @@
 					INA230_CONV_TIME_4156,
 					INA230_AVG_MODE_1024)>;
 		current-lsb-microamps = <1>;
-		rshunt-milliohms = <510>;
+		rshunt-micro-ohms = <510000>;
 	};
 
 	vdd1_codec_sensor: ina231@45 {
@@ -167,7 +167,7 @@
 					INA230_CONV_TIME_4156,
 					INA230_AVG_MODE_1024)>;
 		current-lsb-microamps = <1>;
-		rshunt-milliohms = <2200>;
+		rshunt-micro-ohms = <2200000>;
 	};
 
 	vdd2_codec_sensor: ina231@41 {
@@ -178,7 +178,7 @@
 					INA230_CONV_TIME_4156,
 					INA230_AVG_MODE_1024)>;
 		current-lsb-microamps = <1>;
-		rshunt-milliohms = <2200>;
+		rshunt-micro-ohms = <2200000>;
 	};
 
 	vdd2_nrf_sensor: ina231@40 {
@@ -189,7 +189,7 @@
 					INA230_CONV_TIME_4156,
 					INA230_AVG_MODE_1024)>;
 		current-lsb-microamps = <1>;
-		rshunt-milliohms = <1000>;
+		rshunt-micro-ohms = <1000000>;
 	};
 };
 

--- a/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
+++ b/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
@@ -144,7 +144,7 @@
 			INA230_CONV_TIME_1100,
 			INA230_AVG_MODE_1)>;
 		current-lsb-microamps = <1000>;
-		rshunt-milliohms = <15>;
+		rshunt-micro-ohms = <15000>;
 	};
 };
 

--- a/drivers/sensor/ina23x/ina230.c
+++ b/drivers/sensor/ina23x/ina230.c
@@ -192,7 +192,7 @@ static int ina230_calibrate(const struct device *dev)
 
 	/* See datasheet "Programming" section */
 	val = (INA230_CAL_SCALING * 10000U) /
-	      (config->current_lsb * config->rshunt);
+	      ((config->current_lsb * config->rshunt) / 1000U);
 
 	ret = ina23x_reg_write(&config->bus, INA230_REG_CALIB, val);
 	if (ret < 0) {
@@ -276,7 +276,7 @@ static const struct sensor_driver_api ina230_driver_api = {
 		.bus = I2C_DT_SPEC_INST_GET(inst),		    \
 		.config = DT_INST_PROP(inst, config),		    \
 		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),\
-		.rshunt = DT_INST_PROP(inst, rshunt_milliohms),	    \
+		.rshunt = DT_INST_PROP(inst, rshunt_micro_ohms),	    \
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, alert_gpios),\
 			    (INA230_CFG_IRQ(inst)), ())		    \
 	};							    \

--- a/drivers/sensor/ina23x/ina230.c
+++ b/drivers/sensor/ina23x/ina230.c
@@ -16,7 +16,7 @@
 LOG_MODULE_REGISTER(INA230, CONFIG_SENSOR_LOG_LEVEL);
 
 /** @brief Calibration scaling value (value scaled by 100000) */
-#define INA230_CAL_SCALING 512U
+#define INA230_CAL_SCALING 512ULL
 
 /** @brief The LSB value for the bus voltage register, in microvolts/LSB. */
 #define INA230_BUS_VOLTAGE_UV_LSB 1250U
@@ -24,8 +24,7 @@ LOG_MODULE_REGISTER(INA230, CONFIG_SENSOR_LOG_LEVEL);
 /** @brief The scaling for the power register. */
 #define INA230_POWER_SCALING 25
 
-static int ina230_channel_get(const struct device *dev,
-			      enum sensor_channel chan,
+static int ina230_channel_get(const struct device *dev, enum sensor_channel chan,
 			      struct sensor_value *val)
 {
 	struct ina230_data *data = dev->data;
@@ -61,8 +60,7 @@ static int ina230_channel_get(const struct device *dev,
 		break;
 
 	case SENSOR_CHAN_POWER:
-		power_uw = data->power * INA230_POWER_SCALING
-			   * config->current_lsb;
+		power_uw = data->power * INA230_POWER_SCALING * config->current_lsb;
 
 		/* convert to fractional watts */
 		val->val1 = (int32_t)(power_uw / 1000000U);
@@ -77,16 +75,13 @@ static int ina230_channel_get(const struct device *dev,
 	return 0;
 }
 
-static int ina230_sample_fetch(const struct device *dev,
-			       enum sensor_channel chan)
+static int ina230_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct ina230_data *data = dev->data;
 	const struct ina230_config *config = dev->config;
 	int ret;
 
-	if (chan != SENSOR_CHAN_ALL &&
-	    chan != SENSOR_CHAN_VOLTAGE &&
-	    chan != SENSOR_CHAN_CURRENT &&
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_VOLTAGE && chan != SENSOR_CHAN_CURRENT &&
 	    chan != SENSOR_CHAN_POWER) {
 		return -ENOTSUP;
 	}
@@ -119,8 +114,7 @@ static int ina230_sample_fetch(const struct device *dev,
 }
 
 static int ina230_attr_set(const struct device *dev, enum sensor_channel chan,
-			   enum sensor_attribute attr,
-			   const struct sensor_value *val)
+			   enum sensor_attribute attr, const struct sensor_value *val)
 {
 	const struct ina230_config *config = dev->config;
 	uint16_t data = val->val1;
@@ -141,8 +135,7 @@ static int ina230_attr_set(const struct device *dev, enum sensor_channel chan,
 }
 
 static int ina230_attr_get(const struct device *dev, enum sensor_channel chan,
-			   enum sensor_attribute attr,
-			   struct sensor_value *val)
+			   enum sensor_attribute attr, struct sensor_value *val)
 {
 	const struct ina230_config *config = dev->config;
 	uint16_t data;
@@ -187,14 +180,10 @@ static int ina230_attr_get(const struct device *dev, enum sensor_channel chan,
 static int ina230_calibrate(const struct device *dev)
 {
 	const struct ina230_config *config = dev->config;
-	uint16_t val;
 	int ret;
 
 	/* See datasheet "Programming" section */
-	val = (INA230_CAL_SCALING * 10000U) /
-	      ((config->current_lsb * config->rshunt) / 1000U);
-
-	ret = ina23x_reg_write(&config->bus, INA230_REG_CALIB, val);
+	ret = ina23x_reg_write(&config->bus, INA230_REG_CALIB, config->cal);
 	if (ret < 0) {
 		return ret;
 	}
@@ -232,8 +221,7 @@ static int ina230_init(const struct device *dev)
 			return ret;
 		}
 
-		ret = ina23x_reg_write(&config->bus, INA230_REG_ALERT,
-				       config->alert_limit);
+		ret = ina23x_reg_write(&config->bus, INA230_REG_ALERT, config->alert_limit);
 		if (ret < 0) {
 			LOG_ERR("Failed to write alert register!");
 			return ret;
@@ -245,7 +233,7 @@ static int ina230_init(const struct device *dev)
 			return ret;
 		}
 	}
-#endif  /* CONFIG_INA230_TRIGGER */
+#endif /* CONFIG_INA230_TRIGGER */
 
 	return 0;
 }
@@ -261,32 +249,27 @@ static const struct sensor_driver_api ina230_driver_api = {
 };
 
 #ifdef CONFIG_INA230_TRIGGER
-#define INA230_CFG_IRQ(inst)				\
-	.trig_enabled = true,				\
-	.mask = DT_INST_PROP(inst, mask),		\
-	.alert_limit = DT_INST_PROP(inst, alert_limit),	\
+#define INA230_CFG_IRQ(inst)                                                                       \
+	.trig_enabled = true, .mask = DT_INST_PROP(inst, mask),                                    \
+	.alert_limit = DT_INST_PROP(inst, alert_limit),                                            \
 	.alert_gpio = GPIO_DT_SPEC_INST_GET(inst, alert_gpios)
 #else
 #define INA230_CFG_IRQ(inst)
 #endif /* CONFIG_INA230_TRIGGER */
 
-#define INA230_DRIVER_INIT(inst)				    \
-	static struct ina230_data drv_data_##inst;		    \
-	static const struct ina230_config drv_config_##inst = {	    \
-		.bus = I2C_DT_SPEC_INST_GET(inst),		    \
-		.config = DT_INST_PROP(inst, config),		    \
-		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),\
-		.rshunt = DT_INST_PROP(inst, rshunt_micro_ohms),	    \
-		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, alert_gpios),\
-			    (INA230_CFG_IRQ(inst)), ())		    \
-	};							    \
-	SENSOR_DEVICE_DT_INST_DEFINE(inst,			    \
-			      &ina230_init,			    \
-			      NULL,				    \
-			      &drv_data_##inst,			    \
-			      &drv_config_##inst,		    \
-			      POST_KERNEL,			    \
-			      CONFIG_SENSOR_INIT_PRIORITY,	    \
-			      &ina230_driver_api);
+#define INA230_DRIVER_INIT(inst)                                                                   \
+	static struct ina230_data drv_data_##inst;                                                 \
+	static const struct ina230_config drv_config_##inst = {                                    \
+		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.config = DT_INST_PROP(inst, config),                                              \
+		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),                          \
+		.cal = (uint16_t)((INA230_CAL_SCALING * 10000000ULL) /                             \
+				  ((uint64_t)DT_INST_PROP(inst, current_lsb_microamps) *           \
+				   DT_INST_PROP(inst, rshunt_micro_ohms))),                        \
+		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, alert_gpios), (INA230_CFG_IRQ(inst)),      \
+			    ())};                                                                  \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, &ina230_init, NULL, &drv_data_##inst,                   \
+				     &drv_config_##inst, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, \
+				     &ina230_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INA230_DRIVER_INIT)

--- a/drivers/sensor/ina23x/ina230.h
+++ b/drivers/sensor/ina23x/ina230.h
@@ -50,7 +50,7 @@ struct ina230_config {
 	struct i2c_dt_spec bus;
 	uint16_t config;
 	uint32_t current_lsb;
-	uint16_t rshunt;
+	uint32_t rshunt;
 #ifdef CONFIG_INA230_TRIGGER
 	bool trig_enabled;
 	uint16_t mask;

--- a/drivers/sensor/ina23x/ina230.h
+++ b/drivers/sensor/ina23x/ina230.h
@@ -50,7 +50,7 @@ struct ina230_config {
 	struct i2c_dt_spec bus;
 	uint16_t config;
 	uint32_t current_lsb;
-	uint32_t rshunt;
+	uint16_t cal;
 #ifdef CONFIG_INA230_TRIGGER
 	bool trig_enabled;
 	uint16_t mask;

--- a/drivers/sensor/ina23x/ina237.c
+++ b/drivers/sensor/ina23x/ina237.c
@@ -17,7 +17,7 @@
 LOG_MODULE_REGISTER(INA237, CONFIG_SENSOR_LOG_LEVEL);
 
 /** @brief Calibration scaling value (scaled by 10^-5) */
-#define INA237_CAL_SCALING 8192U
+#define INA237_CAL_SCALING 8192ULL
 
 /** @brief The LSB value for the bus voltage register, in microvolts/LSB. */
 #define INA237_BUS_VOLTAGE_UV_LSB 3125
@@ -25,8 +25,7 @@ LOG_MODULE_REGISTER(INA237, CONFIG_SENSOR_LOG_LEVEL);
 /** @brief Power scaling (scaled by 10) */
 #define INA237_POWER_SCALING 2
 
-static int ina237_channel_get(const struct device *dev,
-			      enum sensor_channel chan,
+static int ina237_channel_get(const struct device *dev, enum sensor_channel chan,
 			      struct sensor_value *val)
 {
 	struct ina237_data *data = dev->data;
@@ -61,8 +60,7 @@ static int ina237_channel_get(const struct device *dev,
 
 	case SENSOR_CHAN_POWER:
 		/* see datasheet "Current and Power calculations" section */
-		power_uw = (data->power * INA237_POWER_SCALING *
-			    config->current_lsb) / 10000U;
+		power_uw = (data->power * INA237_POWER_SCALING * config->current_lsb) / 10000U;
 
 		/* convert to fractional watts */
 		val->val1 = (int32_t)(power_uw / 1000000U);
@@ -166,14 +164,11 @@ static int ina237_read_data(const struct device *dev)
  * @retval 0 for success
  * @retval negative errno code on fail
  */
-static int ina237_sample_fetch(const struct device *dev,
-			       enum sensor_channel chan)
+static int ina237_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct ina237_data *data = dev->data;
 
-	if (chan != SENSOR_CHAN_ALL &&
-	    chan != SENSOR_CHAN_VOLTAGE &&
-	    chan != SENSOR_CHAN_CURRENT &&
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_VOLTAGE && chan != SENSOR_CHAN_CURRENT &&
 	    chan != SENSOR_CHAN_POWER) {
 		return -ENOTSUP;
 	}
@@ -188,8 +183,7 @@ static int ina237_sample_fetch(const struct device *dev,
 }
 
 static int ina237_attr_set(const struct device *dev, enum sensor_channel chan,
-			   enum sensor_attribute attr,
-			   const struct sensor_value *val)
+			   enum sensor_attribute attr, const struct sensor_value *val)
 {
 	const struct ina237_config *config = dev->config;
 	uint16_t data = val->val1;
@@ -206,8 +200,7 @@ static int ina237_attr_set(const struct device *dev, enum sensor_channel chan,
 }
 
 static int ina237_attr_get(const struct device *dev, enum sensor_channel chan,
-			   enum sensor_attribute attr,
-			   struct sensor_value *val)
+			   enum sensor_attribute attr, struct sensor_value *val)
 {
 	const struct ina237_config *config = dev->config;
 	uint16_t data;
@@ -240,14 +233,10 @@ static int ina237_attr_get(const struct device *dev, enum sensor_channel chan,
 static int ina237_calibrate(const struct device *dev)
 {
 	const struct ina237_config *config = dev->config;
-	uint16_t val;
 	int ret;
 
 	/* see datasheet "Current and Power calculations" section */
-	val = (INA237_CAL_SCALING * ((config->current_lsb * config->rshunt) /
-	       1000U)) / 10000000U;
-
-	ret = ina23x_reg_write(&config->bus, INA237_REG_CALIB, val);
+	ret = ina23x_reg_write(&config->bus, INA237_REG_CALIB, config->cal);
 	if (ret < 0) {
 		return ret;
 	}
@@ -347,8 +336,7 @@ static int ina237_init(const struct device *dev)
 	return 0;
 }
 
-static int ina237_trigger_set(const struct device *dev,
-			      const struct sensor_trigger *trig,
+static int ina237_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
 			      sensor_trigger_handler_t handler)
 {
 	ARG_UNUSED(trig);
@@ -372,24 +360,20 @@ static const struct sensor_driver_api ina237_driver_api = {
 	.channel_get = ina237_channel_get,
 };
 
-#define INA237_DRIVER_INIT(inst)						\
-	static struct ina237_data ina237_data_##inst;				\
-	static const struct ina237_config ina237_config_##inst = {		\
-		.bus = I2C_DT_SPEC_INST_GET(inst),				\
-		.config = DT_INST_PROP(inst, config),				\
-		.adc_config = DT_INST_PROP(inst, adc_config),			\
-		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),	\
-		.rshunt = DT_INST_PROP(inst, rshunt_micro_ohms),			\
-		.alert_config = DT_INST_PROP_OR(inst, alert_config, 0x01),	\
-		.alert_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, alert_gpios, {0}),	\
-	};							    \
-	SENSOR_DEVICE_DT_INST_DEFINE(inst,			    \
-			      &ina237_init,			    \
-			      NULL,				    \
-			      &ina237_data_##inst,		    \
-			      &ina237_config_##inst,		    \
-			      POST_KERNEL,			    \
-			      CONFIG_SENSOR_INIT_PRIORITY,	    \
-			      &ina237_driver_api);
+#define INA237_DRIVER_INIT(inst)                                                                   \
+	static struct ina237_data ina237_data_##inst;                                              \
+	static const struct ina237_config ina237_config_##inst = {                                 \
+		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.config = DT_INST_PROP(inst, config),                                              \
+		.adc_config = DT_INST_PROP(inst, adc_config),                                      \
+		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),                          \
+		.cal = INA237_CAL_SCALING * DT_INST_PROP(inst, current_lsb_microamps) *            \
+		       DT_INST_PROP(inst, rshunt_micro_ohms) / 10000000000ULL,                     \
+		.alert_config = DT_INST_PROP_OR(inst, alert_config, 0x01),                         \
+		.alert_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, alert_gpios, {0}),                    \
+	};                                                                                         \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, &ina237_init, NULL, &ina237_data_##inst,                \
+				     &ina237_config_##inst, POST_KERNEL,                           \
+				     CONFIG_SENSOR_INIT_PRIORITY, &ina237_driver_api);             \
 
 DT_INST_FOREACH_STATUS_OKAY(INA237_DRIVER_INIT)

--- a/drivers/sensor/ina23x/ina237.c
+++ b/drivers/sensor/ina23x/ina237.c
@@ -244,8 +244,8 @@ static int ina237_calibrate(const struct device *dev)
 	int ret;
 
 	/* see datasheet "Current and Power calculations" section */
-	val = (INA237_CAL_SCALING * config->current_lsb * config->rshunt) /
-	       10000000U;
+	val = (INA237_CAL_SCALING * ((config->current_lsb * config->rshunt) /
+	       1000U)) / 10000000U;
 
 	ret = ina23x_reg_write(&config->bus, INA237_REG_CALIB, val);
 	if (ret < 0) {
@@ -379,7 +379,7 @@ static const struct sensor_driver_api ina237_driver_api = {
 		.config = DT_INST_PROP(inst, config),				\
 		.adc_config = DT_INST_PROP(inst, adc_config),			\
 		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),	\
-		.rshunt = DT_INST_PROP(inst, rshunt_milliohms),			\
+		.rshunt = DT_INST_PROP(inst, rshunt_micro_ohms),			\
 		.alert_config = DT_INST_PROP_OR(inst, alert_config, 0x01),	\
 		.alert_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, alert_gpios, {0}),	\
 	};							    \

--- a/drivers/sensor/ina23x/ina237.h
+++ b/drivers/sensor/ina23x/ina237.h
@@ -49,7 +49,7 @@ struct ina237_config {
 	uint16_t config;
 	uint16_t adc_config;
 	uint32_t current_lsb;
-	uint32_t rshunt;
+	uint16_t cal;
 	const struct gpio_dt_spec alert_gpio;
 	uint16_t alert_config;
 };

--- a/drivers/sensor/ina23x/ina237.h
+++ b/drivers/sensor/ina23x/ina237.h
@@ -49,7 +49,7 @@ struct ina237_config {
 	uint16_t config;
 	uint16_t adc_config;
 	uint32_t current_lsb;
-	uint16_t rshunt;
+	uint32_t rshunt;
 	const struct gpio_dt_spec alert_gpio;
 	uint16_t alert_config;
 };

--- a/dts/bindings/sensor/ti,ina23x-common.yaml
+++ b/dts/bindings/sensor/ti,ina23x-common.yaml
@@ -34,10 +34,10 @@ properties:
       while keeping a good measurement resolution. The units are in uA/LSB
       so that low maximum currents can be measured with enough resolution.
 
-  rshunt-milliohms:
+  rshunt-micro-ohms:
     type: int
     required: true
-    description: Shunt resistor value in milliohms
+    description: Shunt resistor value in microOhms
 
   alert-gpios:
     type: phandle-array

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -591,7 +591,7 @@ test_i2c_ina230: ina230@5e {
 	reg = <0x5e>;
 	config = <0>;
 	current-lsb-microamps = <1000>;
-	rshunt-micro-ohms = <0>;
+	rshunt-micro-ohms = <1000>;
 	mask = <0>;
 	alert-limit = <0>;
 	alert-gpios = <&test_gpio 0 0>;
@@ -608,7 +608,7 @@ test_i2c_ina231: ina231@60 {
 	reg = <0x60>;
 	config = <0>;
 	current-lsb-microamps = <1000>;
-	rshunt-micro-ohms = <0>;
+	rshunt-micro-ohms = <1000>;
 	mask = <0>;
 	alert-limit = <0>;
 	alert-gpios = <&test_gpio 0 0>;
@@ -620,7 +620,7 @@ test_i2c_ina237: ina237@61 {
 	config = <0>;
 	current-lsb-microamps = <1000>;
 	adc-config = <0>;
-	rshunt-micro-ohms = <0>;
+	rshunt-micro-ohms = <1000>;
 	alert-config = <0>;
 	alert-gpios = <&test_gpio 0 0>;
 };

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -591,7 +591,7 @@ test_i2c_ina230: ina230@5e {
 	reg = <0x5e>;
 	config = <0>;
 	current-lsb-microamps = <1000>;
-	rshunt-milliohms = <0>;
+	rshunt-micro-ohms = <0>;
 	mask = <0>;
 	alert-limit = <0>;
 	alert-gpios = <&test_gpio 0 0>;
@@ -608,7 +608,7 @@ test_i2c_ina231: ina231@60 {
 	reg = <0x60>;
 	config = <0>;
 	current-lsb-microamps = <1000>;
-	rshunt-milliohms = <0>;
+	rshunt-micro-ohms = <0>;
 	mask = <0>;
 	alert-limit = <0>;
 	alert-gpios = <&test_gpio 0 0>;
@@ -620,7 +620,7 @@ test_i2c_ina237: ina237@61 {
 	config = <0>;
 	current-lsb-microamps = <1000>;
 	adc-config = <0>;
-	rshunt-milliohms = <0>;
+	rshunt-micro-ohms = <0>;
 	alert-config = <0>;
 	alert-gpios = <&test_gpio 0 0>;
 };


### PR DESCRIPTION
Changes rshunt-milliohms to rshunt-microohms allowing for current sensing of greater than 16.4A (1mOhm resistor). This is commonly set to 100 uOhm for VMU/FMU boards/applications.

Fixes #59862