### PR TITLE
drivers gpio_nrfx: Minor fixes for simulation

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -406,7 +406,7 @@ static const struct gpio_driver_api gpio_nrfx_drv_api_funcs = {
 			.port_pin_mask =				\
 			GPIO_PORT_PIN_MASK_FROM_DT_INST(id),		\
 		},							\
-		.port = (NRF_GPIO_Type *)DT_INST_REG_ADDR(id),		\
+		.port = _CONCAT(NRF_P, DT_INST_PROP(id, port)),		\
 		.port_num = DT_INST_PROP(id, port),			\
 		.edge_sense = DT_INST_PROP_OR(id, sense_edge_mask, 0)	\
 	};								\

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -303,7 +303,7 @@ static int gpio_nrfx_port_get_direction(const struct device *port,
 
 	if (inputs != NULL) {
 		while (map) {
-			uint32_t pin = __CLZ(__RBIT(map));
+			uint32_t pin = NRF_CTZ(map);
 			uint32_t pin_cnf = reg->PIN_CNF[pin];
 
 			/* Check if the pin has its input buffer connected. */


### PR DESCRIPTION
drivers gpio_nrfx: Get peripheral address from HAL

Instead of getting the hardcoded address from the DT structure use its symbolic name (also from DT) which will be resolved by the nRF HAL definitions.

This allows the GPIO peripherals' addresses to be redefined for the simulated targets.

------

drivers gpio_nrfx: Don't use directly CMSIS instrunction intrinsic
    
To ease building for workstation tests, instead of using
the ARM CMSIS instructions instrinsics directly,
use the NRFX macro that uses the compiler builtins when
necessary.
