### PR TITLE
driver: tcpc/vbus: Add TI TSP25750 driver

### DIFF
--- a/drivers/usb_c/tcpc/CMakeLists.txt
+++ b/drivers/usb_c/tcpc/CMakeLists.txt
@@ -3,3 +3,4 @@
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_USBC_TCPC_STM32 ucpd_stm32.c)
+zephyr_library_sources_ifdef(CONFIG_USBC_TCPC_TPS25750 ucpd_tps25750.c)

--- a/drivers/usb_c/tcpc/Kconfig
+++ b/drivers/usb_c/tcpc/Kconfig
@@ -20,6 +20,7 @@ config USBC_INIT_PRIORITY
 	  so that it can start before the USBC sub-system.
 
 source "drivers/usb_c/tcpc/Kconfig.tcpc_stm32"
+source "drivers/usb_c/tcpc/Kconfig.tcpc_tps25750"
 
 module = USBC
 module-str = usbc

--- a/drivers/usb_c/tcpc/Kconfig.tcpc_tps25750
+++ b/drivers/usb_c/tcpc/Kconfig.tcpc_tps25750
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, ithinx GmbH
+# Copyright (c) 2023, Tonies GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config USBC_TCPC_TPS25750
+	bool "USB-C TCPC device controller driver"
+	default y
+	depends on DT_HAS_TI_TPS25750_ENABLED

--- a/drivers/usb_c/tcpc/ucpd_tps25750.c
+++ b/drivers/usb_c/tcpc/ucpd_tps25750.c
@@ -1,0 +1,533 @@
+/*
+ * Copyright (c) 2023, ithinx GmbH
+ * Copyright (c) 2023, Tonies GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/usb_c/usbc_tc.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/byteorder.h>
+#define DT_DRV_COMPAT ti_tps25750
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(ucpd_tps25750, CONFIG_USBC_LOG_LEVEL);
+
+#include <zephyr/device.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/kernel.h>
+#include <soc.h>
+#include <stddef.h>
+#include <zephyr/math/ilog2.h>
+#include <zephyr/irq.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/gpio.h>
+
+#include "ucpd_tps25750_priv.h"
+
+#define TEST_BIT_ARR_ELEM(bit) (bit / 8)
+#define TEST_BIT(buf, bit)     ((buf[TEST_BIT_ARR_ELEM(bit)] & (1 << (bit % 8))) != 0)
+#define CLEAR_BIT(buf, bit)    (buf[TEST_BIT_ARR_ELEM(bit)] &= ~(1 << (bit % 8)))
+#define SET_BIT(buf, bit)      (buf[TEST_BIT_ARR_ELEM(bit)] |= (1 << (bit % 8)))
+
+#define MAX_I2C_TRANSFER_SIZE 64
+#define CMD_WAIT_TIME_MS      1
+
+/**
+ * @brief Read from the TPS25750 I2C interface
+ *
+ * @note Skips the first "Byte Count" byte when returning data to the user
+ *
+ * @param dev Device pointer
+ * @param reg Register to read from
+ * @param data Buffer to put the data to
+ * @param len Length to read
+ * @return 0 on success
+ * @return -EINVAL in case the requested len is too big
+ * @return other error code returned by i2c_burst_read_dt
+ */
+static int tps25750_i2c_read(const struct device *dev, uint8_t reg, uint8_t *data, size_t len)
+{
+	if (len > MAX_I2C_TRANSFER_SIZE) {
+		return -EINVAL;
+	}
+
+	const struct tcpc_config *const cfg = dev->config;
+	uint8_t read_data[MAX_I2C_TRANSFER_SIZE + 1];
+
+	const int ret = i2c_burst_read_dt(&cfg->i2c, reg, read_data, len + 1);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Skip the byte count given in the 0th byte when returning data to the user */
+	memcpy(data, &read_data[1], len);
+
+	return 0;
+}
+
+/**
+ * @brief Read from the TPS25750 I2C interface
+ *
+ * @note Automatically adds the "Byte Count" byte to the I2C operation
+ *
+ * @param dev Device pointer
+ * @param reg Register to write to
+ * @param data Data to write
+ * @param len Length to write
+ * @return other error code returned by i2c_write_dt
+ */
+static int tps25750_i2c_write(const struct device *dev, uint8_t reg, uint8_t const *data,
+			      size_t len)
+{
+	if (len > MAX_I2C_TRANSFER_SIZE) {
+		return -EINVAL;
+	}
+
+	const struct tcpc_config *const cfg = dev->config;
+	uint8_t send_data[MAX_I2C_TRANSFER_SIZE + 2];
+
+	send_data[0] = reg;
+	send_data[1] = len;
+	memcpy(&send_data[2], data, len);
+
+	return i2c_write_dt(&cfg->i2c, send_data, len + 2);
+}
+
+/**
+ * @brief Issue a so called 4 character command (4CC) to the chip
+ *
+ * With 4CC commands different tasks can be started. E.g. changing
+ * between sink/source mode.
+ *
+ * @param dev Device
+ * @param cmd The command to isse
+ * @return int
+ * @return other error code returned by tps25750_i2c_write
+ */
+static int tps25750_issue_4cc(const struct device *dev, char *cmd)
+{
+	int ret = tps25750_i2c_write(dev, TPS_CMD1_REG, (uint8_t *)cmd, 4);
+
+	if (ret != 0) {
+		LOG_ERR("Issuing 4cc %.4s failed\r", cmd);
+		return ret;
+	}
+
+	const uint8_t max_retries = 25;
+
+	for (uint8_t i = 0; i < max_retries; i++) {
+		uint8_t read_cmd[TPS_CMD1_REG_SIZE];
+
+		ret = tps25750_i2c_read(dev, TPS_CMD1_REG, read_cmd, TPS_CMD1_REG_SIZE);
+
+		if (ret != 0) {
+			LOG_ERR("I2C error");
+			return ret;
+		}
+
+		if (strncmp((char *)read_cmd, "!CMD", 4) == 0) {
+			LOG_ERR("Command %.4s rejected", cmd);
+			return -EIO; /* TODO: better err codes */
+		}
+
+		const uint8_t compare_data[] = {0, 0, 0, 0};
+
+		if (memcmp(read_cmd, compare_data, 4) != 0) {
+			k_msleep(CMD_WAIT_TIME_MS);
+			continue;
+		}
+
+		uint8_t task_ret_code;
+
+		ret = tps25750_i2c_read(dev, TPS_DATA_REG, &task_ret_code, 1);
+		if (ret != 0) {
+			LOG_ERR("I2C error");
+			return ret;
+		}
+		if (task_ret_code != 0) {
+			LOG_ERR("Task %.4s execution failed. Task result = %u", cmd, task_ret_code);
+			return -EIO; /* TODO: better err codes */
+		}
+
+		return 0;
+	}
+
+	return -EIO; /* TODO: better err codes */
+}
+
+/**
+ * @brief Get the chip's operating mode
+ *
+ * Writes 'APP ', 'BOOT' or 'PTCH' into the user-provided buffer mode.
+ *
+ * @note: No string-terminator is added!
+ *
+ * @param dev Device
+ * @param mode A user allocated buffer of at least 4
+ * @return int value of tps25750_i2c_read()
+ */
+static int tps25750_get_mode(const struct device *dev, uint8_t *mode)
+{
+	return tps25750_i2c_read(dev, TPS_MODE_REG, mode, 4);
+}
+
+static bool ucpd_get_snk_ctrl(const struct device *dev)
+{
+	uint8_t buf[TPS_STATUS_REG_SIZE];
+	const int ret = tps25750_i2c_read(dev, TPS_STATUS_REG, buf, TPS_STATUS_REG_SIZE);
+
+	if (ret != 0) {
+		LOG_ERR("Failed to read from i2c");
+	}
+	return (buf[0] & 0x20) == 0;
+}
+
+static bool ucpd_get_src_ctrl(const struct device *dev)
+{
+	return !ucpd_get_snk_ctrl(dev);
+}
+
+static int ucpd_get_cc(const struct device *dev, enum tc_cc_voltage_state *cc1,
+		       enum tc_cc_voltage_state *cc2)
+{
+	uint8_t buf[TPS_TYPEC_STATE_REG_SIZE];
+
+	const int ret = tps25750_i2c_read(dev, TPS_TYPEC_STATE_REG, buf, TPS_TYPEC_STATE_REG_SIZE);
+
+	if (ret != 0) {
+		LOG_ERR("cc read failed");
+		return ret;
+	}
+
+	*cc1 = buf[1];
+	*cc2 = buf[2];
+
+	return 0;
+}
+
+static int ucpd_set_cc(const struct device *dev, enum tc_cc_pull cc_pull)
+{
+	/* TODO: this shall be implemented */
+	LOG_ERR("called unimplemented %s(cc_pull=%u)", __func__, cc_pull);
+	return 0;
+}
+
+static int ucpd_set_roles(const struct device *dev, enum tc_power_role power_role,
+			  enum tc_data_role data_role)
+{
+	int power_role_ret;
+	int data_role_ret;
+
+	switch (power_role) {
+	case TC_ROLE_SINK:
+		if (!ucpd_get_snk_ctrl(dev)) {
+			power_role_ret = tps25750_issue_4cc(dev, "SWSk");
+		}
+	case TC_ROLE_SOURCE:
+		if (!ucpd_get_src_ctrl(dev)) {
+			power_role_ret = tps25750_issue_4cc(dev, "SWSr");
+		}
+	default:
+		return -ENOSYS;
+	}
+
+	if (power_role_ret) {
+		/* TODO: return here? What about data direction setting below? */
+		return power_role_ret;
+	}
+
+	uint8_t buf[TPS_STATUS_REG_SIZE];
+
+	const int ret = tps25750_i2c_read(dev, TPS_STATUS_REG, buf, TPS_STATUS_REG_SIZE);
+
+	if (ret != 0) {
+		/* TODO: return here? What about data direction setting below? */
+		return -EIO;
+	}
+
+	bool is_ufp = buf[0] & 0x40;
+
+	switch (data_role) {
+	case TC_ROLE_UFP:
+		if (!is_ufp) {
+			data_role_ret = tps25750_issue_4cc(dev, "SWUF");
+		}
+	case TC_ROLE_DFP:
+		if (is_ufp) {
+			data_role_ret = tps25750_issue_4cc(dev, "SWDF");
+		}
+	case TC_ROLE_DISCONNECTED:
+		LOG_ERR("## calling unimpl. TC_ROLE_DISCONNECTED"); /* TODO: what to do here? */
+	default:
+		return -ENOSYS;
+	}
+
+	return data_role_ret;
+}
+
+/**
+ * @brief Wrapper function for calling alert handler
+ */
+static void ucpd_notify_handler(struct alert_info *info, enum tcpc_alert alert)
+{
+	if (info->handler) {
+		info->handler(info->dev, info->data, alert);
+	}
+}
+
+/**
+ * @brief Alert handler
+ */
+static void ucpd_alert_handler(struct k_work *item)
+{
+	struct alert_info *info = CONTAINER_OF(item, struct alert_info, work);
+	const struct device *dev = info->dev;
+	uint8_t buf[TPS_INT_EVENT1_REG_SIZE] = {0};
+	uint8_t clear_mask[TPS_INT_EVENT1_REG_SIZE] = {0};
+
+	int ret = tps25750_i2c_read(dev, TPS_INT_EVENT1_REG, buf, TPS_INT_EVENT1_REG_SIZE);
+
+	if (ret != 0) {
+		LOG_ERR("Err reading from TPS25750");
+		return;
+	}
+
+	if (TEST_BIT(buf, EVENT_BIT_PLUG_INSERT_OR_REMOVAL)) {
+		LOG_DBG("  EVENT_BIT_PLUG_INSERT_OR_REMOVAL");
+		ucpd_notify_handler(info, TCPC_ALERT_CC_STATUS);
+		SET_BIT(clear_mask, EVENT_BIT_PLUG_INSERT_OR_REMOVAL);
+	}
+	if (TEST_BIT(buf, EVENT_BIT_PD_HARD_RESET)) {
+		LOG_DBG("  EVENT_BIT_PD_HARD_RESET");
+		ucpd_notify_handler(info, TCPC_ALERT_HARD_RESET_RECEIVED);
+		SET_BIT(clear_mask, EVENT_BIT_PD_HARD_RESET);
+	}
+	if (TEST_BIT(buf, EVENT_BIT_POWER_STATUS_UPDATE)) {
+		LOG_DBG("  EVENT_BIT_POWER_STATUS_UPDATE");
+		ucpd_notify_handler(info, TCPC_ALERT_POWER_STATUS);
+	}
+	if (TEST_BIT(buf, EVENT_BIT_ERROR_POWER_EVENT_OCCURRED)) {
+		LOG_DBG("  EVENT_BIT_ERROR_POWER_EVENT_OCCURRED");
+		/* ucpd_notify_handler(info, TCPC_ALERT_VBUS_ALARM_HI); */
+		/* ucpd_notify_handler(info, TCPC_ALERT_VBUS_ALARM_LO); */
+		/* SET_BIT(clear_mask, EVENT_BIT_ERROR_POWER_EVENT_OCCURRED); */
+	}
+	if (TEST_BIT(buf, EVENT_BIT_SOURCE_CAP_MSG_RCVD)) {
+		LOG_DBG("  EVENT_BIT_SOURCE_CAP_MSG_RCVD");
+	}
+
+	/* TCPC_ALERT_FAULT_STATUS */
+	/* TCPC_ALERT_RX_BUFFER_OVERFLOW */
+	/* TCPC_ALERT_VBUS_SNK_DISCONNECT */
+	/* TCPC_ALERT_EXTENDED_STATUS */
+	/* TCPC_ALERT_EXTENDED */
+	/* TCPC_ALERT_VENDOR_DEFINED */
+	/* TCPC_ALERT_MSG_STATUS */
+	/* TCPC_ALERT_BEGINNING_MSG_STATUS */
+	/* TCPC_ALERT_TRANSMIT_MSG_FAILED */
+	/* TCPC_ALERT_TRANSMIT_MSG_DISCARDED */
+	/* TCPC_ALERT_TRANSMIT_MSG_SUCCESS */
+
+	memset(clear_mask, 0xFF, TPS_INT_CLEAR1_REG_SIZE);
+
+	/* clear interrupts */
+	ret = tps25750_i2c_write(dev, TPS_INT_CLEAR1_REG, clear_mask, TPS_INT_CLEAR1_REG_SIZE);
+	if (ret != 0) {
+		LOG_ERR("Err clearing interrupt bits on TPS25750");
+		return;
+	}
+}
+
+static void ucpd_isr(const struct device *dev, struct gpio_callback *cb, uint32_t pin)
+{
+	struct tcpc_data *data = CONTAINER_OF(cb, struct tcpc_data, gpio_cb);
+	struct alert_info *info = &data->alert_info;
+
+	k_work_submit(&info->work);
+}
+
+static int ucpd_dump_std_reg(const struct device *dev)
+{
+	const struct tcpc_config *config = dev->config;
+	uint8_t buf[32];
+
+	const int ret = tps25750_get_mode(dev, buf);
+
+	if (ret != 0) {
+		LOG_ERR("Could not read mode\r");
+		return -EIO;
+	}
+	LOG_INF("Mode: %.4s", buf);
+
+	tps25750_i2c_read(dev, TPS_STATUS_REG, buf, TPS_STATUS_REG_SIZE);
+	LOG_INF("STATUS:     0x%02x 0x%02x 0x%02x 0x%02x 0x%02x", buf[0], buf[1], buf[2], buf[3],
+		buf[4]);
+
+	tps25750_i2c_read(dev, TPS_INT_EVENT1_REG, buf, TPS_INT_EVENT1_REG_SIZE);
+	LOG_INF("INT_EVENT1: 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x "
+		"0x%02x",
+		buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7], buf[8], buf[9],
+		buf[10]);
+
+	tps25750_i2c_read(dev, TPS_INT_MASK1_REG, buf, TPS_INT_MASK1_REG_SIZE);
+	LOG_INF("INT_MASK1:  0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x "
+		"0x%02x",
+		buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7], buf[8], buf[9],
+		buf[10]);
+
+	const int pin_lvl = gpio_pin_get_dt(&config->irq_gpio);
+
+	LOG_INF("IRQ logical level = %d", pin_lvl);
+
+	return 0;
+}
+
+static int ucpd_set_alert_handler_cb(const struct device *dev, tcpc_alert_handler_cb_t handler,
+				     void *alert_data)
+{
+	struct tcpc_data *data = dev->data;
+
+	data->alert_info.handler = handler;
+	data->alert_info.data = alert_data;
+
+	return 0;
+}
+
+static void ucpd_set_vconn_cb(const struct device *dev, tcpc_vconn_control_cb_t vconn_cb)
+{
+	/* TODO: this shall be implemented */
+	LOG_DBG("called unimplemented %s()", __func__);
+}
+
+static void ucpd_set_vconn_discharge_cb(const struct device *dev, tcpc_vconn_discharge_cb_t cb)
+{
+	/* TODO: this shall be implemented */
+	LOG_ERR("called unimplemented %s()", __func__);
+}
+
+static int ucpd_get_status_register(const struct device *dev, enum tcpc_status_reg reg,
+				    int32_t *status)
+{
+	uint8_t buf[4];
+	uint8_t i2c_reg;
+
+	switch (reg) {
+	case TCPC_CC_STATUS:
+		i2c_reg = TPS_TYPEC_STATE_REG;
+		break;
+	case TCPC_POWER_STATUS:
+		i2c_reg = TPS_POWER_STATUS_REG;
+		break;
+	case TCPC_FAULT_STATUS:
+	case TCPC_EXTENDED_STATUS:
+	case TCPC_EXTENDED_ALERT_STATUS:
+	case TCPC_VENDOR_DEFINED_STATUS:
+	default:
+		return -ENOSYS;
+	}
+
+	const int ret = tps25750_i2c_read(dev, i2c_reg, buf, 4);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	*status = sys_get_le32(buf);
+
+	return 0;
+}
+
+static int ucpd_cc_set_polarity(const struct device *dev, enum tc_cc_polarity polarity)
+{
+	/* TODO: this is unimplemented since the chip doesn't support it */
+	LOG_DBG("called unimplemented %s()", __func__);
+	return -ENOSYS;
+}
+
+static int ucpd_init(const struct device *dev)
+{
+	struct tcpc_data *data = dev->data;
+	struct alert_info *info = &data->alert_info;
+	const struct tcpc_config *config = dev->config;
+
+	info->dev = dev;
+
+	uint8_t buf[TPS_INT_MASK1_REG_SIZE];
+
+	/* TODO: add ability to define capabilities in dev-tree and send them to the chip */
+
+	/* set interrupt mask */
+	tps25750_i2c_write(dev, TPS_INT_MASK1_REG, buf, TPS_INT_MASK1_REG_SIZE);
+
+	memset(buf, 0xFF, TPS_INT_MASK1_REG_SIZE);
+	tps25750_i2c_write(dev, TPS_INT_CLEAR1_REG, buf, TPS_INT_CLEAR1_REG_SIZE);
+
+	/* Initialize the work handler */
+	k_work_init(&info->work, ucpd_alert_handler);
+
+	/* Configure the GPIO to trigger an ISR */
+	int ret;
+
+	if (!gpio_is_ready_dt(&config->irq_gpio)) {
+		LOG_ERR("Error: button device %s is not ready", config->irq_gpio.port->name);
+		return 0;
+	}
+
+	ret = gpio_pin_configure_dt(&config->irq_gpio, GPIO_INPUT);
+	if (ret != 0) {
+		LOG_ERR("Error %d: failed to configure %s pin %d", ret, config->irq_gpio.port->name,
+			config->irq_gpio.pin);
+		return 0;
+	}
+
+	gpio_init_callback(&data->gpio_cb, ucpd_isr, (1 << config->irq_gpio.pin));
+	ret = gpio_add_callback(config->irq_gpio.port, &data->gpio_cb);
+	if (ret != 0) {
+		LOG_ERR("Failed to add gpio callback (ret=%d)", ret);
+		return -EIO;
+	}
+
+	LOG_DBG("Configuring %s interrupt", config->irq_gpio.port->name);
+	ret = gpio_pin_interrupt_configure_dt(&config->irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret != 0) {
+		LOG_ERR("Failed to configure interrupt on pin %d (ret=%d)", config->irq_gpio.pin,
+			ret);
+		return -EIO;
+	}
+
+	/* Set GPIO data to dev data */
+
+	return 0;
+}
+
+static const struct tcpc_driver_api driver_api = {
+	.init = ucpd_init,
+	.set_alert_handler_cb = ucpd_set_alert_handler_cb,
+	.get_cc = ucpd_get_cc,
+	.set_cc = ucpd_set_cc,
+	.set_roles = ucpd_set_roles,
+	.set_vconn_cb = ucpd_set_vconn_cb,
+	.set_vconn_discharge_cb = ucpd_set_vconn_discharge_cb,
+	.set_cc_polarity = ucpd_cc_set_polarity,
+	.dump_std_reg = ucpd_dump_std_reg,
+	.get_status_register = ucpd_get_status_register,
+	.get_snk_ctrl = ucpd_get_snk_ctrl,
+	.get_src_ctrl = ucpd_get_src_ctrl,
+};
+
+BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 0,
+	     "No compatible TPS25750 TCPC instance found");
+
+#define TCPC_DRIVER_INIT(inst)                                                                     \
+	static struct tcpc_data drv_data_##inst;                                                   \
+	static const struct tcpc_config drv_config_##inst = {                                      \
+		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.irq_gpio = GPIO_DT_SPEC_INST_GET(inst, irq_gpios),                                \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, &ucpd_init, NULL, &drv_data_##inst, &drv_config_##inst,        \
+			      POST_KERNEL, CONFIG_USBC_INIT_PRIORITY, &driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(TCPC_DRIVER_INIT)

--- a/drivers/usb_c/tcpc/ucpd_tps25750_priv.h
+++ b/drivers/usb_c/tcpc/ucpd_tps25750_priv.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2023, ithinx GmbH
+ * Copyright (c) 2023, Tonies GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_USBC_DEVICE_UCPD_STM32_PRIV_H_
+#define ZEPHYR_DRIVERS_USBC_DEVICE_UCPD_STM32_PRIV_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/drivers/usb_c/usbc_tcpc.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/gpio.h>
+
+#define TPS_MODE_REG                     0x03
+#define TPS_MODE_REG_SIZE                4
+#define TPS_TYPE_REG                     0x04
+#define TPS_TYPE_REG_SIZE                4
+#define TPS_CUSTUSE_REG                  0x06
+#define TPS_CUSTUSE_REG_SIZE             8
+#define TPS_CMD1_REG                     0x08
+#define TPS_CMD1_REG_SIZE                4
+#define TPS_DATA_REG                     0x09
+#define TPS_DATA_REG_SIZE                64
+#define TPS_DEVICE_CAP_REG               0x0D
+#define TPS_DEVICE_CAP_REG_SIZE          1
+#define TPS_VERSION_REG                  0x0F
+#define TPS_VERSION_REG_SIZE             4
+#define TPS_INT_EVENT1_REG               0x14
+#define TPS_INT_EVENT1_REG_SIZE          11
+#define TPS_INT_MASK1_REG                0x16
+#define TPS_INT_MASK1_REG_SIZE           11
+#define TPS_INT_CLEAR1_REG               0x18
+#define TPS_INT_CLEAR1_REG_SIZE          11
+#define TPS_STATUS_REG                   0x1A
+#define TPS_STATUS_REG_SIZE              5
+#define TPS_POWER_PATH_STATUS_REG        0x26
+#define TPS_POWER_PATH_STATUS_REG_SIZE   5
+#define TPS_PORT_CONTROL_REG             0x29
+#define TPS_PORT_CONTROL_REG_SIZE        4
+#define TPS_BOOT_STATUS_REG              0x2D
+#define TPS_BOOT_STATUS_REG_SIZE         5
+#define TPS_BUILD_DESCRIPTION            0x2E
+#define TPS_BUILD_DESCRIPTION_SIZE       49
+#define TPS_DEVICE_INFO_REG              0x2F
+#define TPS_DEVICE_INFO_REG_SIZE         40
+#define TPS_RX_SOURCE_CAPS_REG           0X30
+#define TPS_RX_SOURCE_CAPS_REG_SIZE      29
+#define TPS_RX_SINK_CAPS_REG             0X31
+#define TPS_RX_SINK_CAPS_REG_SIZE        29
+#define TPS_TX_SOURCE_CAPS_REG           0x32
+#define TPS_TX_SOURCE_CAPS_REG_SIZE      31
+#define TPS_TX_SINK_CAPS_REG             0x33
+#define TPS_TX_SINK_CAPS_REG_SIZE        29
+#define TPS_ACTIVE_CONTRACT_PDO_REG      0x34
+#define TPS_ACTIVE_CONTRACT_PDO_REG_SIZE 6
+#define TPS_ACTIVE_CONTRACT_RDO_REG      0x35
+#define TPS_ACTIVE_CONTRACT_RDO_REG_SIZE 4
+#define TPS_POWER_STATUS_REG             0x3F
+#define TPS_POWER_STATUS_REG_SIZE        2
+#define TPS_PD_STATUS_REG                0x40
+#define TPS_PD_STATUS_REG_SIZE           4
+#define TPS_TYPEC_STATE_REG              0x69
+#define TPS_TYPEC_STATE_REG_SIZE         4
+#define TPS_GPIO_STATUS_REG              0x72
+#define TPS_GPIO_STATUS_REG_SIZE         8
+#define TPS_CAP_POWER_ROLE_M             0x03
+#define TPS_CAP_USBPD_CAP_M              0x04
+#define TPS_CAP_I2CMLEVEL_VOLT_M         0x80
+
+enum tps25750_event_bits {
+	/* Byte 11: Patch Status (common to all slave ports) */
+	EVENT_BIT_I2C_MASTER_NACKED = 82,
+	EVENT_BIT_READY_FOR_PATCH = 81,
+	EVENT_BIT_PATCH_LOADED = 80,
+	/* Bytes 9-10: */
+	EVENT_BIT_TX_MEM_BUFFER_EMPTY = 64,
+	EVENT_BIT_ERROR_UNABLE_TO_SOURCE = 46,
+	EVENT_BIT_PLUG_EARLY_NOTIFICATION = 43,
+	EVENT_BIT_SNK_TRANSITION_COMPLETE = 42,
+	EVENT_BIT_ERROR_MESSAGE_DATA = 39,
+	EVENT_BIT_ERROR_PROTOCOL_ERROR = 38,
+	EVENT_BIT_ERROR_MISSING_GET_CAP_MESSAGE = 36,
+	EVENT_BIT_ERROR_POWER_EVENT_OCCURRED = 35,
+	EVENT_BIT_ERROR_CAN_PROVIDE_VOLTAGE_OR_CURRENT_LATER = 34,
+	EVENT_BIT_ERROR_CANNOT_PROVIDE_VOLTAGE_OR_CURRENT = 33,
+	EVENT_BIT_ERROR_DEVICE_INCOMPATIBLE = 32,
+	/* Bytes 1-4: */
+	EVENT_BIT_CMD_COMPLETE = 30,
+	EVENT_BIT_PD_STATUS_UPDATE = 27,
+	EVENT_BIT_STATUS_UPDATE = 26,
+	EVENT_BIT_POWER_STATUS_UPDATE = 24,
+	EVENT_BIT_P_PSWITCH_CHANGED = 23,
+	EVENT_BIT_USB_HOST_PRESENT_NO_LONGER = 21,
+	EVENT_BIT_USB_HOST_PRESENT = 20,
+	EVENT_BIT_DR_SWAP_REQUESTED = 18,
+	EVENT_BIT_PR_SWAP_REQUESTED = 17,
+	EVENT_BIT_SOURCE_CAP_MSG_RCVD = 14,
+	EVENT_BIT_NEW_CONTRACT_AS_PROV = 13,
+	EVENT_BIT_NEW_CONTRACT_AS_CONS = 12,
+	EVENT_BIT_DR_SWAP_COMPLETE = 5,
+	EVENT_BIT_PR_SWAP_COMPLETE = 4,
+	EVENT_BIT_PLUG_INSERT_OR_REMOVAL = 3,
+	EVENT_BIT_PD_HARD_RESET = 1,
+};
+
+/**
+ * @brief Alert handler information
+ */
+struct alert_info {
+	/* Runtime device structure */
+	const struct device *dev;
+	/* Application supplied data that's passed to the
+	 * application's alert handler callback
+	 **/
+	void *data;
+	/* Application's alert handler callback */
+	tcpc_alert_handler_cb_t handler;
+	/*
+	 * Kernel worker used to call the application's
+	 * alert handler callback
+	 */
+	struct k_work work;
+};
+
+/**
+ * @brief Driver config
+ */
+struct tcpc_config {
+	struct i2c_dt_spec i2c;
+	struct gpio_dt_spec irq_gpio;
+};
+
+/**
+ * @brief Driver data
+ */
+struct tcpc_data {
+	struct alert_info alert_info;
+	struct gpio_callback gpio_cb;
+};
+
+#endif /* ZEPHYR_DRIVERS_USBC_DEVICE_UCPD_STM32_PRIV_H_ */

--- a/drivers/usb_c/vbus/CMakeLists.txt
+++ b/drivers/usb_c/vbus/CMakeLists.txt
@@ -3,3 +3,4 @@
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_USBC_VBUS_ADC usbc_vbus_adc.c)
+zephyr_library_sources_ifdef(CONFIG_USBC_VBUS_I2C usbc_vbus_i2c.c)

--- a/drivers/usb_c/vbus/Kconfig
+++ b/drivers/usb_c/vbus/Kconfig
@@ -11,6 +11,7 @@ menuconfig USBC_VBUS_DRIVER
 if USBC_VBUS_DRIVER
 
 source "drivers/usb_c/vbus/Kconfig.usbc_vbus_adc"
+source "drivers/usb_c/vbus/Kconfig.usbc_vbus_i2c"
 
 endif # USBC_VBUS_DRIVER
 

--- a/drivers/usb_c/vbus/Kconfig.usbc_vbus_i2c
+++ b/drivers/usb_c/vbus/Kconfig.usbc_vbus_i2c
@@ -1,0 +1,11 @@
+# USB-C VBUS device configuration options
+
+# Copyright 2022 The Chromium OS Authors
+# SPDX-License-Identifier: Apache-2.0
+
+config USBC_VBUS_I2C
+	bool "USB-C VBUS I2C"
+	default y
+	depends on DT_HAS_ZEPHYR_USB_C_VBUS_I2C_ENABLED
+	help
+	  Measure VBUS with an I2C through a voltage divider

--- a/drivers/usb_c/vbus/usbc_vbus_i2c.c
+++ b/drivers/usb_c/vbus/usbc_vbus_i2c.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2023, ithinx GmbH
+ * Copyright (c) 2023, Tonies GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "zephyr/sys/byteorder.h"
+#define DT_DRV_COMPAT zephyr_usb_c_vbus_i2c
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(usbc_vbus_i2c, CONFIG_USBC_LOG_LEVEL);
+
+#include <zephyr/device.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/usb_c/usbc_pd.h>
+#include <zephyr/drivers/usb_c/usbc_vbus.h>
+#include <soc.h>
+#include <stddef.h>
+
+#include "usbc_vbus_i2c_priv.h"
+
+static int tps25750_i2c_read(const struct device *dev, uint8_t reg, uint8_t *data, size_t len)
+{
+	const struct usbc_vbus_config *const cfg = dev->config;
+	uint8_t read_data[5];
+
+	const int ret = i2c_burst_read_dt(&cfg->i2c, reg, read_data, len + 1);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	memcpy(data, &read_data[1], len);
+
+	return 0;
+}
+
+/**
+ * @brief Reads and returns VBUS measured in mV
+ *
+ * @retval 0 on success
+ * @retval -EIO on failure
+ */
+static int adc_vbus_measure(const struct device *dev, int *meas)
+{
+	return -EIO;
+}
+
+/**
+ * @brief Checks if VBUS is at a particular level
+ *
+ * @retval true if VBUS is at the level voltage, else false
+ */
+static bool adc_vbus_check_level(const struct device *dev, enum tc_vbus_level level)
+{
+	uint32_t meas;
+	int ret;
+	uint8_t buf[4];
+
+	ret = tps25750_i2c_read(dev, 0x1A, buf, 4);
+	if (ret) {
+		return false;
+	}
+
+	meas = sys_get_le32(buf);
+	const int vbus_status = (meas >> 20) & 0x3;
+
+	if (vbus_status == 3) {
+		return false;
+	}
+
+	switch (level) {
+	case TC_VBUS_SAFE0V:
+		return vbus_status == 0;
+	case TC_VBUS_PRESENT:
+		return vbus_status == 1;
+	case TC_VBUS_REMOVED:
+		return vbus_status == 2;
+	}
+
+	return false;
+}
+
+/**
+ * @brief Sets pin to discharge VBUS
+ *
+ * @retval 0 on success
+ * @retval -EIO on failure
+ * @retval -ENOENT if enable pin isn't defined
+ */
+static int adc_vbus_discharge(const struct device *dev, bool enable)
+{
+	return -ENOENT;
+}
+
+/**
+ * @brief Sets pin to enable VBUS measurments
+ *
+ * @retval 0 on success
+ * @retval -EIO on failure
+ * @retval -ENOENT if enable pin isn't defined
+ */
+static int adc_vbus_enable(const struct device *dev, bool enable)
+{
+	return -ENOENT;
+}
+
+/**
+ * @brief Initializes the ADC VBUS Driver
+ *
+ * @retval 0 on success
+ * @retval -EIO on failure
+ */
+static int adc_vbus_init(const struct device *dev)
+{
+	return 0;
+}
+
+static const struct usbc_vbus_driver_api driver_api = {.measure = adc_vbus_measure,
+						       .check_level = adc_vbus_check_level,
+						       .discharge = adc_vbus_discharge,
+						       .enable = adc_vbus_enable};
+
+BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 0,
+	     "No compatible USB-C VBUS Measurement instance found");
+
+#define DRIVER_INIT(inst)                                                                          \
+	static const struct usbc_vbus_config drv_config_##inst = {                                 \
+		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, &adc_vbus_init, NULL, NULL, &drv_config_##inst, POST_KERNEL,   \
+			      CONFIG_USBC_INIT_PRIORITY, &driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(DRIVER_INIT)

--- a/drivers/usb_c/vbus/usbc_vbus_i2c_priv.h
+++ b/drivers/usb_c/vbus/usbc_vbus_i2c_priv.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023, ithinx GmbH
+ * Copyright (c) 2023, Tonies GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_USBC_VBUS_I2C_PRIV_H_
+#define ZEPHYR_DRIVERS_USBC_VBUS_I2C_PRIV_H_
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
+
+
+struct usbc_vbus_config {
+	struct i2c_dt_spec i2c;
+};
+
+#endif /* ZEPHYR_DRIVERS_USBC_VBUS_I2C_PRIV_H_ */

--- a/dts/bindings/tcpc/ti,tps25750.yaml
+++ b/dts/bindings/tcpc/ti,tps25750.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2023, ithinx GmbH
+# Copyright (c) 2023, Tonies GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    TI TPS25750 Type-C Port Switch / Power Delivery (PD) Controller device.
+    The default values were taken from the LL_UCPD_StructInit function defined in the HAL.
+
+compatible: "ti,tps25750"
+
+include: [base.yaml, i2c-device.yaml]
+
+properties:
+    irq-gpios:
+      type: phandle-array
+      required: true

--- a/dts/bindings/usb-c/zephyr,usb-c-vbus-i2c.yaml
+++ b/dts/bindings/usb-c/zephyr,usb-c-vbus-i2c.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2023, ithinx GmbH
+# Copyright (c) 2023, Tonies GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    This device is used to measure VBUS on a Type-C Port and to
+    discharge VBUS when needed.
+
+compatible: "zephyr,usb-c-vbus-i2c"
+
+include: [base.yaml, i2c-device.yaml]


### PR DESCRIPTION
**Disclaimer**: I'm not experienced with the USB-C stack and this is only my second PR to zephyr.

This PR adds a driver for the Texas Instruments TPS25750 USB-C PD Controller. Furthermore it includes a rudimentary driver for VBUS which gets it information also from the TPS25750. **The VBUS-Driver is not ready** and just for demonstration purposes part of this PR.

My problem is that in the way the current USB-C subsystem is designed, it will probably not play nicely with this chip. For instance I cannot implement the required APIs

- cc_set_polarity
- set_cc
- set_vconn_cb
- set_vconn_discharge_cb

The chip simply doesn't support this and manages this internally. In consequence if I try to run the USB sink sample the USB subsystem shuts down:

```
*** Booting Zephyr OS build zephyr-v3.4.0-507-g2f5068fcda0c ***
[00:00:00.001,000] <err> ucpd_tps25750: called unimplemented ucpd_set_cc(cc_pull=3)
[00:00:00.001,000] <inf> usbc_stack: Disabled
[00:00:00.001,000] <inf> usbc_stack: PE_SUSPEND
[00:00:00.001,000] <inf> usbc_stack: PRL_HR_SUSPEND
[00:00:00.001,000] <inf> usbc_stack: PRL_TX_SUSPEND
[00:00:00.001,000] <inf> power_domain_gpio: pd_3v3 is now ON
[00:00:00.002,000] <inf> power_domain_gpio: pd_5v is now ON
[00:00:00.006,000] <inf> usbc_stack: ErrorRecovery
[00:00:00.246,000] <err> ucpd_tps25750: called unimplemented ucpd_set_cc(cc_pull=2)
[00:00:00.246,000] <inf> usbc_stack: Unattached.SNK
[00:00:00.252,000] <inf> usbc_stack: AttachWait.SNK
[00:01:59.885,000] <inf> usbc_stack: Unattached.SNK
[00:02:04.274,000] <inf> usbc_stack: AttachWait.SNK
```

How to proceed here? Did I misunderstand something regarding how to implement TCPC API? Or is this kind of chip really not properly supported by the USB-C subsystem?