### PR TITLE
native_posix: Add support for `west debug`

### DIFF
--- a/boards/posix/native_posix/board.cmake
+++ b/boards/posix/native_posix/board.cmake
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set(SUPPORTED_EMU_PLATFORMS native)
+
+board_set_debugger_ifnset(native_gdb)
+board_finalize_runner_args(native_gdb)

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -39,6 +39,7 @@ _names = [
     'jlink',
     'mdb',
     'misc',
+    'native_gdb',
     'nios2',
     'nrfjprog',
     'nrfutil',

--- a/scripts/west_commands/runners/native_gdb.py
+++ b/scripts/west_commands/runners/native_gdb.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2023 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+"""This file provides a ZephyrBinaryRunner that launches GDB."""
+
+import argparse
+from runners.core import ZephyrBinaryRunner, RunnerCaps, RunnerConfig
+
+class NativeGDBBinaryRunner(ZephyrBinaryRunner):
+    """Runs the ELF binary under GDB."""
+
+    @classmethod
+    def name(cls):
+        return 'native_gdb'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'debug'})
+
+    @classmethod
+    def do_add_parser(cls, parser: argparse.ArgumentParser):
+        pass
+
+    @classmethod
+    def do_create(cls, cfg: RunnerConfig, args: argparse.Namespace) -> ZephyrBinaryRunner:
+        return NativeGDBBinaryRunner(cfg)
+
+    def do_run(self, command: str, **kwargs):
+        assert command == 'debug'
+
+        # Clues to debug missing RunnerConfig values (in context of `west debug`):
+        #   build/zephyr/runners.yaml is missing `gdb` or `elf_file`.
+        #   board.cmake should have `board_finalize_runner_args(native_gdb)`.
+        #   build/CMakeCache.txt should have `CMAKE_GDB`.
+
+        if self.cfg.gdb is None:
+            raise ValueError("The provided RunnerConfig is missing the required field 'gdb'.")
+
+        if self.cfg.elf_file is None:
+            raise ValueError("The provided RunnerConfig is missing the required field 'elf_file'.")
+
+        self.call([
+            self.cfg.gdb,
+            '--quiet',
+            self.cfg.elf_file,
+        ])

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -30,6 +30,7 @@ def test_runner_imports():
                     'mdb-nsim',
                     'mdb-hw',
                     'misc-flasher',
+                    'native_gdb',
                     'nios2',
                     'nrfjprog',
                     'nrfutil',


### PR DESCRIPTION
This change adds the convenience of `west debug` to native builds. It simply launches GDB with the build's ELF-file.