### PR TITLE
bluetooth: ots: Fix bt_ots_init paramter struct naming 

### DIFF
--- a/include/zephyr/bluetooth/services/ots.h
+++ b/include/zephyr/bluetooth/services/ots.h
@@ -749,7 +749,7 @@ struct bt_ots_cb {
 };
 
 /** @brief Descriptor for OTS initialization. */
-struct bt_ots_init {
+struct bt_ots_init_param {
 	/* OTS features */
 	struct bt_ots_feat features;
 
@@ -803,7 +803,7 @@ void *bt_ots_svc_decl_get(struct bt_ots *ots);
  *
  *  @return 0 in case of success or negative value in case of error.
  */
-int bt_ots_init(struct bt_ots *ots, struct bt_ots_init *ots_init);
+int bt_ots_init(struct bt_ots *ots, struct bt_ots_init_param *ots_init);
 
 /** @brief Get a free instance of OTS from the pool.
  *

--- a/samples/bluetooth/peripheral_ots/src/main.c
+++ b/samples/bluetooth/peripheral_ots/src/main.c
@@ -223,7 +223,7 @@ static int ots_init(void)
 	int err;
 	struct bt_ots *ots;
 	struct object_creation_data obj_data;
-	struct bt_ots_init ots_init;
+	struct bt_ots_init_param ots_init;
 	struct bt_ots_obj_add_param param;
 	const char * const first_object_name = "first_object.txt";
 	const char * const second_object_name = "second_object.gif";

--- a/subsys/bluetooth/audio/mcs.c
+++ b/subsys/bluetooth/audio/mcs.c
@@ -1348,7 +1348,7 @@ int bt_mcs_init(struct bt_ots_cb *ots_cbs)
 	mcs = (struct bt_gatt_service)BT_GATT_SERVICE(svc_attrs);
 
 #ifdef CONFIG_BT_OTS
-	struct bt_ots_init ots_init;
+	struct bt_ots_init_param ots_init;
 
 	ots = bt_ots_free_instance_get();
 	if (!ots) {

--- a/subsys/bluetooth/services/ots/ots.c
+++ b/subsys/bluetooth/services/ots/ots.c
@@ -443,7 +443,7 @@ void *bt_ots_svc_decl_get(struct bt_ots *ots)
 #endif
 
 int bt_ots_init(struct bt_ots *ots,
-		     struct bt_ots_init *ots_init)
+		     struct bt_ots_init_param *ots_init)
 {
 	int err;
 


### PR DESCRIPTION
Patch to rename struct bt_ots_init to struct bt_ots_init_param
fixes [#45968](https://github.com/zephyrproject-rtos/zephyr/issues/45968)