### PR TITLE
drivers: dma: intel-adsp-hda: add a missing "break"

### DIFF
--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -212,6 +212,7 @@ int intel_adsp_hda_dma_status(const struct device *dev, uint32_t channel,
 			intel_adsp_hda_underrun_clear(cfg->base, cfg->regblock_size, channel);
 			return -EPIPE;
 		}
+		break;
 	case PERIPHERAL_TO_MEMORY:
 		xrun_det = intel_adsp_hda_is_buffer_overrun(cfg->base, cfg->regblock_size,
 							    channel);
@@ -219,6 +220,7 @@ int intel_adsp_hda_dma_status(const struct device *dev, uint32_t channel,
 			intel_adsp_hda_overrun_clear(cfg->base, cfg->regblock_size, channel);
 			return -EPIPE;
 		}
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
A "switch" statement in intel_adsp_hda_dma_status() seems to be missing a "break". The second "break" is unneeded but seems to be a part of the coding style.