### PR TITLE
cmake: Fix code relocation functions with absolute paths

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1331,11 +1331,16 @@ function(zephyr_code_relocate)
     message(FATAL_ERROR "zephyr_code_relocate() requires a LOCATION argument")
   endif()
   if(CODE_REL_LIBRARY)
-    # Use cmake generator expression to convert library to file list
+    # Use cmake generator expression to convert library to file list,
+    # supporting relative and absolute paths
     set(genex_src_dir "$<TARGET_PROPERTY:${CODE_REL_LIBRARY},SOURCE_DIR>")
     set(genex_src_list "$<TARGET_PROPERTY:${CODE_REL_LIBRARY},SOURCES>")
-    set(file_list
-      "${genex_src_dir}/$<JOIN:${genex_src_list},$<SEMICOLON>${genex_src_dir}/>")
+    set(src_list_abs "$<FILTER:${genex_src_list},INCLUDE,^/>")
+    set(src_list_rel "$<FILTER:${genex_src_list},EXCLUDE,^/>")
+    set(src_list "${genex_src_dir}/$<JOIN:${src_list_rel},$<SEMICOLON>${genex_src_dir}/>")
+    set(nonempty_src_list "$<$<BOOL:${src_list_rel}>:${src_list}>")
+    set(sep_list "$<$<AND:$<BOOL:${src_list_abs}>,$<BOOL:${src_list_rel}>>:$<SEMICOLON>>")
+    set(file_list "${src_list_abs}${sep_list}${nonempty_src_list}")
   else()
     # Check if CODE_REL_FILES is a generator expression, if so leave it
     # untouched.

--- a/tests/application_development/code_relocation/CMakeLists.txt
+++ b/tests/application_development/code_relocation/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # Code relocation feature
 zephyr_code_relocate(FILES src/test_file1.c ${SRAM2_PHDR} LOCATION SRAM2)
 
-zephyr_code_relocate(FILES src/test_file2.c ${RAM_PHDR} LOCATION RAM)
+zephyr_code_relocate(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/test_file2.c ${RAM_PHDR} LOCATION RAM)
 
 # Add custom library that we can relocate code for
 add_subdirectory(test_lib)

--- a/tests/application_development/code_relocation/test_lib/CMakeLists.txt
+++ b/tests/application_development/code_relocation/test_lib/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2022 NXP
 
 add_library(test_lib STATIC "")
-target_sources(test_lib PRIVATE test_lib1.c test_lib2.c)
+target_sources(test_lib PRIVATE test_lib1.c ${CMAKE_CURRENT_SOURCE_DIR}/test_lib2.c)
 get_target_property(include_dirs app INCLUDE_DIRECTORIES)
 target_link_libraries(test_lib PUBLIC zephyr_interface)
 add_dependencies(test_lib zephyr_generated_headers)


### PR DESCRIPTION
Fixes an issue whereby absolute paths in libraries would have duplicate paths in the name, causing issues in that they would not be relocated.

Fixes #57423