### PR TITLE
Add support for STM32 ADC clock and prescaler

### DIFF
--- a/boards/arm/96b_aerocore2/96b_aerocore2.dts
+++ b/boards/arm/96b_aerocore2/96b_aerocore2.dts
@@ -175,6 +175,8 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&adc1_in10_pc0 &adc1_in11_pc1
 		     &adc1_in12_pc2 &adc1_in13_pc3>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/b_g474e_dpow1/b_g474e_dpow1.dts
+++ b/boards/arm/b_g474e_dpow1/b_g474e_dpow1.dts
@@ -134,6 +134,8 @@
 &adc2 {
 	pinctrl-0 = <&adc2_in8_pc2>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 
 	#address-cells = <1>;

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -189,12 +189,16 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in15_pb0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <ASYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 
 &adc4 {
 	pinctrl-0 = <&adc4_in19_pb1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <ASYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/blackpill_f401cc/blackpill_f401cc.dts
+++ b/boards/arm/blackpill_f401cc/blackpill_f401cc.dts
@@ -125,6 +125,8 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/blackpill_f401ce/blackpill_f401ce.dts
+++ b/boards/arm/blackpill_f401ce/blackpill_f401ce.dts
@@ -125,6 +125,8 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/blackpill_f411ce/blackpill_f411ce.dts
+++ b/boards/arm/blackpill_f411ce/blackpill_f411ce.dts
@@ -126,6 +126,8 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -292,6 +292,8 @@ zephyr_udc0: &usbotg_fs {
 		     &adc1_in4_pc3 &adc1_in13_pc4
 		     &adc1_in14_pc5>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/google_twinkie_v2/google_twinkie_v2.dts
+++ b/boards/arm/google_twinkie_v2/google_twinkie_v2.dts
@@ -101,6 +101,8 @@
 		     &adc1_in18_pc5	/* CSA_CC2	 */
 		    >;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 
 	channel@1 {

--- a/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -157,6 +157,8 @@
 &adc1 {
 	pinctrl-0 = <&adc_in2_pb3>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/mikroe_clicker_2/mikroe_clicker_2.dts
+++ b/boards/arm/mikroe_clicker_2/mikroe_clicker_2.dts
@@ -146,6 +146,8 @@ zephyr_udc0: &usbotg_fs {
 	status ="okay";
 	pinctrl-0 = <&adc1_in2_pa2 &adc1_in3_pa3>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 };
 
 &vref {

--- a/boards/arm/nucleo_c031c6/nucleo_c031c6.dts
+++ b/boards/arm/nucleo_c031c6/nucleo_c031c6.dts
@@ -117,6 +117,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1 &adc1_in4_pa4>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -118,6 +118,8 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f031k6/nucleo_f031k6.dts
+++ b/boards/arm/nucleo_f031k6/nucleo_f031k6.dts
@@ -103,6 +103,8 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f042k6/nucleo_f042k6.dts
+++ b/boards/arm/nucleo_f042k6/nucleo_f042k6.dts
@@ -98,6 +98,8 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -116,6 +116,8 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -151,6 +151,8 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -164,6 +164,8 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
@@ -124,6 +124,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
+++ b/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
@@ -99,6 +99,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -173,6 +173,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -90,6 +90,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/arm/nucleo_f446ze/nucleo_f446ze.dts
@@ -87,6 +87,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -177,6 +177,8 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -172,6 +172,8 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_g070rb/nucleo_g070rb.dts
+++ b/boards/arm/nucleo_g070rb/nucleo_g070rb.dts
@@ -138,6 +138,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 	vref-mv = <3300>;
 };

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -140,6 +140,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 	vref-mv = <3300>;
 };

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -161,6 +161,8 @@ zephyr_udc0: &usb {
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -189,6 +189,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -140,6 +140,8 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_inp15_pa3>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 
@@ -150,6 +152,8 @@ zephyr_udc0: &usbotg_fs {
 &adc3 {
 	pinctrl-0 = <&adc3_inp5_pf3>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
@@ -137,6 +137,8 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_inp15_pa3>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
+++ b/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
@@ -116,6 +116,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_inp15_pa3>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -135,6 +135,8 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -124,6 +124,8 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <ASYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l412rb_p/nucleo_l412rb_p.dts
+++ b/boards/arm/nucleo_l412rb_p/nucleo_l412rb_p.dts
@@ -117,6 +117,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in5_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -167,6 +167,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pc0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -206,6 +206,8 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pc0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -177,6 +177,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in3_pc2>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_wba52cg/nucleo_wba52cg.dts
+++ b/boards/arm/nucleo_wba52cg/nucleo_wba52cg.dts
@@ -98,6 +98,8 @@
 &adc4 {
 	pinctrl-0 = <&adc4_in8_pa1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <ASYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -144,6 +144,8 @@
 &adc1 {
 	pinctrl-0 = <&adc_in5_pb1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/ronoth_lodev/ronoth_lodev.dts
+++ b/boards/arm/ronoth_lodev/ronoth_lodev.dts
@@ -163,6 +163,8 @@
 &adc1 {
 	pinctrl-0 = <&adc_in0_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -220,6 +220,8 @@ zephyr_udc0: &usb {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32f401_mini/stm32f401_mini.dts
+++ b/boards/arm/stm32f401_mini/stm32f401_mini.dts
@@ -117,6 +117,8 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pa1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <2>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
+++ b/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
@@ -131,6 +131,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in3_pa3 &adc1_in9_pb1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 
 	#address-cells = <1>;

--- a/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
@@ -206,6 +206,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_inp6_pf12>; /* Arduino A5 */
 	pinctrl-names = "default";
+	st,adc-clock-source = <ASYNC>;
+	st,adc-prescaler = <6>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -113,6 +113,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_inp0_pa0_c>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/arm/stm32l496g_disco/stm32l496g_disco.dts
@@ -165,6 +165,8 @@
 &adc1 {
 	pinctrl-0 = < &adc1_in2_pc1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -202,6 +202,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in13_pc4>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/swan_r5/swan_r5.dts
+++ b/boards/arm/swan_r5/swan_r5.dts
@@ -195,6 +195,8 @@ zephyr_udc0: &usbotg_fs {
 &adc1 {
 	pinctrl-0 = <&adc1_in6_pa1>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -373,6 +373,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 58 84 112 144 480>;
+			st,adc-clock-source = <SYNC>;
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -522,6 +522,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
+			st,adc-clock-source = <SYNC>;
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -257,6 +257,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
+			st,adc-clock-source = <SYNC>;
 		};
 
 		adc3: adc@40012200 {
@@ -271,6 +272,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
+			st,adc-clock-source = <SYNC>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -750,6 +750,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
+			st,adc-clock-source = <SYNC>;
 		};
 
 		adc2: adc@40012100 {
@@ -764,6 +765,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
+			st,adc-clock-source = <SYNC>;
 		};
 
 		adc3: adc@40012200 {
@@ -778,6 +780,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
+			st,adc-clock-source = <SYNC>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -223,6 +223,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <4 9 16 24 48 96 192 384>;
+			st,adc-clock-source = <ASYNC>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -751,6 +751,7 @@
 				       STM32_ADC_RES(10, 0x02)
 				       STM32_ADC_RES(8, 0x03)>;
 			sampling-times = <5 6 12 20 36 68 391 814>;
+			st,adc-clock-source = <ASYNC>;
 		};
 
 		adc4: adc@46021000 {
@@ -769,6 +770,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 4 8 13 20 40 80 815>;
 			num-sampling-time-common-channels = <2>;
+			st,adc-clock-source = <ASYNC>;
 		};
 
 		fdcan1: can@4000a400 {

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -383,6 +383,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 4 8 13 20 40 80 815>;
 			num-sampling-time-common-channels = <2>;
+			st,adc-clock-source = <ASYNC>;
 		};
 
 		lptim1: timers@46004400 {

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -27,6 +27,44 @@ properties:
   pinctrl-names:
     required: true
 
+  st,adc-clock-source:
+    type: int
+    required: true
+    enum:
+      - 1 # SYNC for synchronous ADC clock source
+      - 2 # ASYNC for asynchronous ADC clock source
+    description: |
+      Type of ADC clock source :
+      - <SYNC>: derived from the bus clock.
+      - <ASYNC> : independent and asynchronous with the bus clock
+      One of the two values may not apply to some series. Refer to the RefMan.
+
+  st,adc-prescaler:
+    type: int
+    required: true
+    enum:
+      - 1 # not divided
+      - 2
+      - 4
+      - 6
+      - 8
+      - 10
+      - 12
+      - 16
+      - 32
+      - 64
+      - 128
+      - 256
+    description: |
+      Clock prescaler at the input of the ADC:
+      Apply to synchronous or asynchronous clock depending on the STM32
+      st,adc-clock-source.
+      Some of the values may not apply to some series, and may depend on the
+      selected clock source. Refer to the RefMan.
+      On STM32F3x (except STM32F37x), this configures only the synchronous
+      prescaler (see properties adcXX-prescaler in st,stm32f3-rcc bindings to
+      set asynchronous prescaler).
+
   vref-mv:
     type: int
     default: 3300

--- a/dts/bindings/adc/st,stm32f1-adc.yaml
+++ b/dts/bindings/adc/st,stm32f1-adc.yaml
@@ -5,8 +5,15 @@
 description: |
         ST STM32F1 family ADC
         This compatible stands for all ADC blocks similar to the one on STM32F1,
-        like F37x.
+        like STM32F37x.
+        Remove the st,adc-clock-source and st,adc-prescaler property.
+        See adc-prescaler property in st,stm32f1-rcc binding to configure ADC
+        prescaler.
 
 compatible: "st,stm32f1-adc"
 
-include: st,stm32-adc.yaml
+include:
+  - name: st,stm32-adc.yaml
+    property-blocklist:
+      - st,adc-clock-source
+      - st,adc-prescaler

--- a/include/zephyr/dt-bindings/adc/stm32_adc.h
+++ b/include/zephyr/dt-bindings/adc/stm32_adc.h
@@ -64,4 +64,14 @@
 	STM32_ADC(resolution, reg_val, STM32_ADC_RES_MASK, STM32_ADC_RES_SHIFT, \
 		  STM32_ADC_RES_REG)
 
+/**
+ * @name STM32 ADC clock source
+ * This value is to set <st,adc-clock-source>
+ * One or both values may not apply to all series. Refer to the RefMan
+ * @{
+ */
+#define SYNC  1
+#define ASYNC 2
+/** @} */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_STM32_ADC_H_ */


### PR DESCRIPTION
This PR adds the support and configuration of the full clock capabilities of the STM32 ADCs.

On many series, the ADC can be configured to use as clock source either a synchronous clock or an asynchronous one, though only one of them may be available on some series. Furthermore, a prescaler is configurable to divide the chosen clock. Also, depending on the series, the asynchronous clock can be selected between different clocks (for example SYSCLK, PLL out, HSE...).

Functionalities vary between series, and this PR tries to address all cases, while remaining as minimal as possible.
- This PR first deals with the clocks of the F1 / F3 series that are fully / partly configured in RCC. New RCC bindings are thus added for them to allow configuring the ADC prescaler clock. Split in #60332
- The support for the HSI14 dedicated ADC clock is added for the F0 family. Split in #60333
- For all series except F1 and F37x, two new ADC bindings are added to define the type of clock, and the prescaler. When combined, these values are used to configure the clock in the ADC registers.
- Finally, the support for secondary/kernel source clock is added, allowing to configure the source of the asynchronous clock. This works just the same as the secondary clock for other STM32 drivers (like UART, SPI or I2C)

Fixes #40955