### PR TITLE
Bluetooth: Controller: Option to ignore Tx ISO Data Packet Seq Num

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -371,7 +371,8 @@ config BT_CTLR_SCAN_ENABLE_STRICT
 
 config BT_CTLR_ISOAL_SN_STRICT
 	bool "Enforce Strict Tx ISO Data Sequence Number use"
-	depends on BT_CTLR_ADV_ISO || BT_CTLR_CONN_ISO
+	depends on !BT_CTLR_ISOAL_PSN_IGNORE && (BT_CTLR_ADV_ISO || \
+						 BT_CTLR_CONN_ISO)
 	default y
 	help
 	  Enforce strict sequencing of released payloads based on the TX SDU's
@@ -385,6 +386,21 @@ config BT_CTLR_ISOAL_SN_STRICT
 	  interval.
 
 	  When disabled, TX SDUs could be shifted from their stream aligned
+	  position and fragmented into payloads that are less likely to be
+	  dropped. This will result in better delivery of data to the receiver
+	  but at the cost of creating skews in the received stream of SDUs.
+
+config BT_CTLR_ISOAL_PSN_IGNORE
+	bool "Ignore Tx ISO Data Packet Sequence Number use"
+	depends on BT_CTLR_ADV_ISO || BT_CTLR_CONN_ISO
+	help
+	  Ignore the use of Tx ISO Data Packet Sequence Number.
+
+	  Use this option to turn off ISO Data Packet Sequence Number use to
+	  place the ISO Data in the correct radio event, instead simply buffer
+	  it to next radio event.
+
+	  When enabled, TX SDUs could be shifted from their stream aligned
 	  position and fragmented into payloads that are less likely to be
 	  dropped. This will result in better delivery of data to the receiver
 	  but at the cost of creating skews in the received stream of SDUs.

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -804,6 +804,9 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 #endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
 
 	cis->central.instant = instant;
+#if defined(CONFIG_BT_CTLR_ISOAL_PSN_IGNORE)
+	cis->pkt_seq_num = 0U;
+#endif /* CONFIG_BT_CTLR_ISOAL_PSN_IGNORE */
 	cis->lll.next_subevent = 0U;
 	cis->lll.sn = 0U;
 	cis->lll.nesn = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -47,6 +47,10 @@ struct ll_conn_iso_stream {
 				    */
 	uint8_t  terminate_reason;
 	uint8_t  cis_id;
+
+#if defined(CONFIG_BT_CTLR_ISOAL_PSN_IGNORE)
+	uint64_t pkt_seq_num:39;
+#endif /* CONFIG_BT_CTLR_ISOAL_PSN_IGNORE */
 };
 
 struct ll_conn_iso_group {

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -322,6 +322,9 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 	cis->sync_delay = sys_get_le24(ind->cis_sync_delay);
 	cis->offset = cis_offset;
 	memcpy(cis->lll.access_addr, ind->aa, sizeof(ind->aa));
+#if defined(CONFIG_BT_CTLR_ISOAL_PSN_IGNORE)
+	cis->pkt_seq_num = 0U;
+#endif /* CONFIG_BT_CTLR_ISOAL_PSN_IGNORE */
 	cis->lll.event_count = LLL_CONN_ISO_EVENT_COUNT_MAX;
 	cis->lll.next_subevent = 0U;
 	cis->lll.sn = 0U;


### PR DESCRIPTION
Kconfig option to turn off ISO Data Packet Sequence Number use to place the ISO Data in the correct radio event, instead simply buffer it to next radio event.