### PR TITLE
soc: nuvoton_numaker: add guard in defconfig

### DIFF
--- a/soc/arm/nuvoton_numaker/Kconfig.defconfig
+++ b/soc/arm/nuvoton_numaker/Kconfig.defconfig
@@ -4,5 +4,9 @@
 
 source "soc/arm/nuvoton_numaker/*/Kconfig.defconfig.series"
 
+if SOC_FAMILY_NUMAKER
+
 config RESET
 	default y
+
+endif


### PR DESCRIPTION
It must be guarded so the option selection doesn't appear at root level.

Fixes #59876