### PR TITLE
shields: semtech_sx1276mb1mas: new shield

### DIFF
--- a/boards/shields/semtech_sx1276mb1mas/Kconfig.shield
+++ b/boards/shields/semtech_sx1276mb1mas/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 Marcin Niestroj
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_SEMTECH_SX1276MB1MAS
+	def_bool $(shields_list_contains,semtech_sx1276mb1mas)

--- a/boards/shields/semtech_sx1276mb1mas/doc/index.rst
+++ b/boards/shields/semtech_sx1276mb1mas/doc/index.rst
@@ -1,0 +1,76 @@
+.. _semtech_sx1276mb1mas:
+
+Semtech SX1276MB1MAS LoRa Shield
+################################
+
+Overview
+********
+
+The Semtech SX1276MB1MAS LoRa shield is an Arduino compatible shield based on
+the SX1276 LoRa transceiver from Semtech.
+
+More information about the shield can be found at the `mbed SX1276MB1xAS
+website`_.
+
+Pins Assignment of the Semtech SX1276MB1MAS LoRa Shield
+=======================================================
+
++-----------------------+-----------------+
+| Shield Connector Pin  | Function        |
++=======================+=================+
+| A0                    | SX1276 RESET    |
++-----------------------+-----------------+
+| A3                    | SX1276 DIO4 (1) |
++-----------------------+-----------------+
+| A4                    | Antenna RX/TX   |
++-----------------------+-----------------+
+| D2                    | SX1276 DIO0     |
++-----------------------+-----------------+
+| D3                    | SX1276 DIO1     |
++-----------------------+-----------------+
+| D4                    | SX1276 DIO2     |
++-----------------------+-----------------+
+| D5                    | SX1276 DIO3     |
++-----------------------+-----------------+
+| D8                    | SX1276 DIO4 (1) |
++-----------------------+-----------------+
+| D9                    | SX1276 DIO5     |
++-----------------------+-----------------+
+| D10                   | SX1276 SPI NSS  |
++-----------------------+-----------------+
+| D11                   | SX1276 SPI MOSI |
++-----------------------+-----------------+
+| D12                   | SX1276 SPI MISO |
++-----------------------+-----------------+
+| D13                   | SX1276 SPI SCK  |
++-----------------------+-----------------+
+
+(1) SX1276 DIO4 is configured on D8 by default. It is possible to reconfigure it
+    in devicetree to A3 if needed.
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration for
+Arduino connectors and defines node aliases for SPI and GPIO interfaces (see
+:ref:`shields` for more details).
+
+Programming
+***********
+
+Set ``-DSHIELD=semtech_sx1271mb1mas`` when you invoke ``west build``. For
+example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/lorawan/class_a
+   :board: nucleo_l073rz
+   :shield: semtech_sx1276mb1mas
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _mbed SX1276MB1xAS website:
+   https://os.mbed.com/components/SX1276MB1xAS/

--- a/boards/shields/semtech_sx1276mb1mas/semtech_sx1276mb1mas.overlay
+++ b/boards/shields/semtech_sx1276mb1mas/semtech_sx1276mb1mas.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Marcin Niestroj
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		lora0 = &lora_semtech_sx1276mb1mas;
+	};
+};
+
+&arduino_spi {
+	status = "okay";
+
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
+
+	lora_semtech_sx1276mb1mas: lora@0 {
+		compatible = "semtech,sx1276";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+
+		reset-gpios = <&arduino_header 0 GPIO_ACTIVE_LOW>;   /* A0 */
+
+		dio-gpios = <&arduino_header 8 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO0 is D2 */
+		            <&arduino_header 9 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO1 is D3 */
+			    <&arduino_header 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO2 is D4 */
+			    <&arduino_header 11 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO3 is D5 */
+			    <&arduino_header 14 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,	   /* DIO4 is D8 */
+			    <&arduino_header 15 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;	   /* DIO5 is D9 */
+
+		rfo-enable-gpios = <&arduino_header 4 GPIO_ACTIVE_HIGH>; /* RXTX_EXT is A4 */
+	};
+};


### PR DESCRIPTION
Add Arduino compatible LoRaWAN shield based on SX1276 tranceiver from
Semtech. Provide minimal documentation on how to use it.

Tested with `nucleo_l073rz` platform.