### PR TITLE
west: runners: uf2: Add more fstype check for is_uf2_partition.

### DIFF
--- a/scripts/west_commands/runners/uf2.py
+++ b/scripts/west_commands/runners/uf2.py
@@ -49,7 +49,7 @@ class UF2BinaryRunner(ZephyrBinaryRunner):
     @staticmethod
     def is_uf2_partition(part):
         try:
-            return ((part.fstype in ['vfat', 'FAT']) and
+            return ((part.fstype in ['vfat', 'FAT', 'msdos']) and
                     UF2BinaryRunner.get_uf2_info_path(part).is_file())
         except PermissionError:
             return False


### PR DESCRIPTION
The current check code checks the partition type by hard-coding it. 

During testing it was found that if the partition type was displayed as **msdos** it could not be detected correctly, so this partition type determination was added.

<img width="1142" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/20263334/3c5c941f-c50f-4926-8da3-ea22915fb603">
<img width="1829" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/20263334/4ddf10fb-3680-48cf-b073-e6c20bc01e10">

However, maybe a better approach is to refer to the code at [microsoft/uf2](https://github.com/microsoft/uf2/blob/master/utils/uf2conv.py#L243) to avoid hard-coding and additional partition type checking. 

If you think the code in the link is a better fit, I'm more than happy to continue updating the current detection logic.