### PR TITLE
zephyr/linker: Add NOLOAD attribute to .last_ram_section

### DIFF
--- a/include/zephyr/linker/ram-end.ld
+++ b/include/zephyr/linker/ram-end.ld
@@ -3,7 +3,7 @@
  * end-of-used-memory symbols
  */
 
-    SECTION_PROLOGUE(.last_ram_section,,)
+    SECTION_PROLOGUE(.last_ram_section, (NOLOAD),)
     {
 #ifdef LAST_RAM_ALIGN
 	LAST_RAM_ALIGN


### PR DESCRIPTION
Currently, this section has LOAD flag which means that it's part of image layout. Attempt to generate binary file with --gap-fill results in creating a very big file, because LMA of the section is RAM address (e.g. 0x20000000 for STM32F4) instead of FLASH (e.g. 0x8000000 for STM32F4).

This problem doesn't appear when linking using GNU LD, because it removes the section in garbage collect process. However, LLVM LLD doesn't garbage collect sections that define used symbols, so the section is present in final ELF image.

There is no need to load this section (it has 0 size), so we can safely add NOLOAD attribute to the section.

Fixes: #57727