### PR TITLE
Bluetooth: Controller: Fix coverity issue 318615

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -441,8 +441,8 @@ void ull_periph_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 		 * Deferred attempt to stop can fail as it would have
 		 * expired, hence ignore failure.
 		 */
-		ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
-			    TICKER_ID_ADV_STOP, NULL, NULL);
+		(void)ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
+				  TICKER_ID_ADV_STOP, NULL, NULL);
 	}
 
 	/* Start Peripheral */


### PR DESCRIPTION
[Coverity CID: 318615] Unchecked return value in
subsys/bluetooth/controller/ll_sw/ull_peripheral.c

Fixes #58975.