### PR TITLE
Bluetooth: Controller: Fix coverity issue 318635

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -859,8 +859,8 @@ void ull_central_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 	 * Deferred attempt to stop can fail as it would have
 	 * expired, hence ignore failure.
 	 */
-	ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
-		    TICKER_ID_SCAN_STOP, NULL, NULL);
+	(void)ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH, TICKER_ID_SCAN_STOP,
+			  NULL, NULL);
 
 	/* Start central */
 	ticker_id_conn = TICKER_ID_CONN_BASE + ll_conn_handle_get(conn);


### PR DESCRIPTION
[Coverity CID: 318635] Unchecked return value in
subsys/bluetooth/controller/ll_sw/ull_central.c

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/58992.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>