### PR TITLE
dts: bindings: display: st7735r: Remove requirement for reset-gpios

### DIFF
--- a/dts/bindings/display/sitronix,st7735r.yaml
+++ b/dts/bindings/display/sitronix,st7735r.yaml
@@ -10,7 +10,6 @@ include: [spi-device.yaml, display-controller.yaml]
 properties:
   reset-gpios:
     type: phandle-array
-    required: true
     description: RESET pin.
 
       The RESET pin of ST7735R is active low.


### PR DESCRIPTION
The display controller supports software reset and the driver already implements it. Therefore it's not necessary to require a reset gpio in device tree.