### PR TITLE
drivers: i2c: i2c_eos_s3: Add I2C driver support for EOS S3

### DIFF
--- a/boards/arm/quick_feather/Kconfig.defconfig
+++ b/boards/arm/quick_feather/Kconfig.defconfig
@@ -8,4 +8,9 @@ if BOARD_QUICK_FEATHER
 config BOARD
 	default "quick_feather"
 
+config BUILD_OUTPUT_BIN
+bool
+default n
+depends on BOARD_QUICK_FEATHER
+
 endif # BOARD_QUICK_FEATHER

--- a/boards/arm/quick_feather/board.c
+++ b/boards/arm/quick_feather/board.c
@@ -14,6 +14,8 @@ static int eos_s3_board_init(void)
 	/* IO MUX setup for UART */
 	eos_s3_io_mux(UART_TX_PAD, UART_TX_PAD_CFG);
 	eos_s3_io_mux(UART_RX_PAD, UART_RX_PAD_CFG);
+    /* NOTE: this already is set in the qorc bootloader */
+	eos_s3_io_mux(BUTTON_PAD, BUTTON_PAD_CFG);
 
 	IO_MUX->UART_rxd_SEL = UART_RX_SEL;
 

--- a/boards/arm/quick_feather/board.h
+++ b/boards/arm/quick_feather/board.h
@@ -9,11 +9,14 @@
 
 #include <soc_pinmap.h>
 
-#define UART_TX_PAD		44
-#define UART_TX_PAD_CFG		UART_TXD_PAD44
-#define UART_RX_PAD		45
-#define UART_RX_PAD_CFG		UART_RXD_PAD45
+#define UART_TX_PAD     44
+#define UART_TX_PAD_CFG UART_TXD_PAD44
+#define UART_RX_PAD     45
+#define UART_RX_PAD_CFG UART_RXD_PAD45
 
-#define UART_RX_SEL		UART_RXD_SEL_PAD45
+#define BUTTON_PAD     6
+#define BUTTON_PAD_CFG BUTTON_PAD_CFG6
+
+#define UART_RX_SEL UART_RXD_SEL_PAD45
 
 #endif /* __INC_BOARD_H */

--- a/boards/arm/quick_feather/quick_feather.dts
+++ b/boards/arm/quick_feather/quick_feather.dts
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2020 Antmicro <www.antmicro.com>
+ * Copyright (c) 2023 Szymon Duchniewicz
+ * Copyright (c) 2023 Jakub Duhcniewicz
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/boards/arm/quick_feather/quick_feather.dts
+++ b/boards/arm/quick_feather/quick_feather.dts
@@ -71,4 +71,5 @@
 
 &i2c0 {
 	status = "okay";
+	clock-frequency = <400000>;
 };

--- a/boards/arm/quick_feather/quick_feather.dts
+++ b/boards/arm/quick_feather/quick_feather.dts
@@ -68,3 +68,7 @@
 	status = "okay";
 	current-speed = <115200>;
 };
+
+&i2c0 {
+	status = "okay";
+};

--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -52,6 +52,7 @@ zephyr_library_sources_ifdef(CONFIG_I2C_SC18IM704	i2c_sc18im704.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SMARTBOND	i2c_smartbond.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_XILINX_AXI	i2c_xilinx_axi.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_MCHP_MSS		i2c_mchp_mss.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_EOS_S3      i2c_eos_s3.c)
 
 zephyr_library_sources_ifdef(CONFIG_I2C_STM32_V1
 	i2c_ll_stm32_v1.c

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -76,6 +76,7 @@ source "drivers/i2c/Kconfig.sc18im704"
 source "drivers/i2c/Kconfig.smartbond"
 source "drivers/i2c/Kconfig.xilinx_axi"
 source "drivers/i2c/Kconfig.mchp_mss"
+source "drivers/i2c/Kconfig.eos_s3"
 
 config I2C_INIT_PRIORITY
 	int "Init priority"

--- a/drivers/i2c/Kconfig.eos_s3
+++ b/drivers/i2c/Kconfig.eos_s3
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Jakub Duchniewicz
+# SPDX-License-Identifier: Apache-2.0
+
+config I2C_EOS_S3
+	bool "EOS S3 SoC I2C driver"
+	default y
+	depends on DT_HAS_EOS_S3_ENABLED
+	help
+	  Enables EOS S3 I2C via Wishbone bus driver.

--- a/drivers/i2c/Kconfig.eos_s3
+++ b/drivers/i2c/Kconfig.eos_s3
@@ -4,6 +4,6 @@
 config I2C_EOS_S3
 	bool "EOS S3 SoC I2C driver"
 	default y
-	depends on DT_HAS_EOS_S3_ENABLED
+	depends on DT_HAS_QUICKLOGIC_EOS_S3_I2C_ENABLED
 	help
 	  Enables EOS S3 I2C via Wishbone bus driver.

--- a/drivers/i2c/i2c_eos_s3.c
+++ b/drivers/i2c/i2c_eos_s3.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2023 Jakub Duchniewicz
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT eos_s3_i2c0
+
+#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(i2c_eos_s3);
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <soc.h>
+#include <zephyr/sys/sys_io.h>
+
+#include <eoss3_hal_i2c.h>
+
+#include "i2c-priv.h"
+
+/* Macros */
+#define EOS_S3_MAX_I2C_IDX (1)
+
+struct i2c_eos_s3_cfg {
+	uint32_t idx;
+	uint32_t base;
+	uint32_t f_sys;
+	uint32_t f_bus;
+};
+
+/* Helper functions */
+
+static inline int i2c_eos_s3_translate_config(const struct *i2c_eos_s3_cfg config,
+					      I2C_Config *hal_config)
+{
+	if (config->idx > EOS_S3_MAX_I2C_IDX) {
+		LOG_ERR("Unsupported I2C index requested");
+		return -ENOTSUP;
+	}
+	/* switch (I2C_SPEED_GET(dev_config)) {
+	 *    case I2C_SPEED_STANDARD:
+	 *	i2c_speed = 100000U; // 100 KHz
+	 *	break;
+	 *    case I2C_SPEED_FAST:
+	 *	i2c_speed = 400000U; // 400 KHz
+	 *	break;
+	 *    case I2C_SPEED_FAST_PLUS:
+	 *    case I2C_SPEED_HIGH:
+	 *    case I2C_SPEED_ULTRA:
+	 *    default:
+	 *	LOG_ERR("Unsupported I2C speed requested");
+	 *	return -ENOTSUP;
+	 *}
+	 * TODO: for now static config
+	 */
+	hal_config->eI2CFreq = I2C_100KHZ;
+	hal_config->eI2CInt = I2C_DISABLE;
+	hal_config->ucI2Cn = config->idx;
+	return 0;
+}
+
+/* API Functions */
+/* TODO: is this necessary? */
+static int i2c_eos_s3_configure(const struct device *dev, uint32_t dev_config)
+{
+	const struct i2c_eos_s3_cfg *config = NULL;
+	uint32_t i2c_speed = 0U;
+	uint16_t prescale = 0U;
+
+	/* Check for NULL pointers */
+	if (dev == NULL) {
+		LOG_ERR("Device handle is NULL");
+		return -EINVAL;
+	}
+	config = dev->config;
+	if (config == NULL) {
+		LOG_ERR("Device config is NULL");
+		return -EINVAL;
+	}
+
+	/* Disable the I2C peripheral */
+	/* sys_write8(0, I2C_REG(config, REG_CONTROL)); */
+
+	/* Configure bus frequency */
+	switch (I2C_SPEED_GET(dev_config)) {
+	case I2C_SPEED_STANDARD:
+		i2c_speed = 100000U; /* 100 KHz */
+		break;
+	case I2C_SPEED_FAST:
+		i2c_speed = 400000U; /* 400 KHz */
+		break;
+	case I2C_SPEED_FAST_PLUS:
+	case I2C_SPEED_HIGH:
+	case I2C_SPEED_ULTRA:
+	default:
+		LOG_ERR("Unsupported I2C speed requested");
+		return -ENOTSUP;
+	}
+
+	/* Calculate prescale value */
+	prescale = (config->f_sys / (i2c_speed * 5U)) - 1;
+
+	/* Configure peripheral with calculated prescale */
+	/* sys_write8((uint8_t) (0xFF & prescale), I2C_REG(config, REG_PRESCALE_LOW));
+	 * sys_write8((uint8_t) (0xFF & (prescale >> 8)),
+	 *	   I2C_REG(config, REG_PRESCALE_HIGH));
+	 */
+
+	/* Support I2C Master mode only */
+	if (!(dev_config & I2C_MODE_CONTROLLER)) {
+		LOG_ERR("I2C only supports operation as master");
+		return -ENOTSUP;
+	}
+
+	/*
+	 * Driver does not support 10-bit addressing. This can be added
+	 * in the future when needed.
+	 */
+	if (dev_config & I2C_ADDR_10_BITS) {
+		LOG_ERR("I2C driver does not support 10-bit addresses");
+		return -ENOTSUP;
+	}
+
+	/* Enable the I2C peripheral */
+	/* sys_write8(SF_CONTROL_EN, I2C_REG(config, REG_CONTROL)); */
+
+	return 0;
+}
+
+static int i2c_eos_s3_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
+			       uint16_t addr)
+{
+	const struct i2c_eos_s3_cfg *config = dev->config;
+	int rc = 0;
+
+	/* Check for NULL pointers */
+	if (dev == NULL) {
+		LOG_ERR("Device handle is NULL");
+		return -EINVAL;
+	}
+	if (dev->config == NULL) {
+		LOG_ERR("Device config is NULL");
+		return -EINVAL;
+	}
+	if (msgs == NULL) {
+		return -EINVAL;
+	}
+
+	for (int i = 0; i < num_msgs; i++) {
+		if (msgs[i].flags & I2C_MSG_READ) {
+			rc = HAL_I2C_Read(config->base, addr, msgs[i].buf, msgs[i].len);
+		} else {
+			rc = HAL_I2C_Write(config->base, addr, msgs[i].buf, msgs[i].len);
+		}
+
+		if (rc != 0) {
+			LOG_ERR("I2C failed to transfer messages\n");
+			return rc;
+		}
+	}
+
+	return 0;
+};
+
+static int i2c_eos_s3_init(const struct device *dev)
+{
+	const struct i2c_eos_s3_cfg *config = dev->config;
+	/* uint32_t dev_config = 0U; */
+	struct I2C_Config hal_config;
+	int rc = 0;
+
+	/* dev_config = (I2C_MODE_CONTROLLER | i2c_map_dt_bitrate(config->f_bus)); */
+
+	/* TODO: needed? */
+	/* rc = i2c_eos_s3_configure(dev, dev_config);
+	 * if (rc != 0) {
+	 *	LOG_ERR("Failed to configure I2C on init");
+	 *	return rc;
+	 *}
+	 */
+
+	rc = i2c_eos_s3_translate_config(config, hal_config);
+	if (rc != 0) {
+		LOG_ERR("Failed to translate I2C config to HAL");
+		return rc;
+	}
+
+	rc = HAL_I2C_Init(hal_config);
+	if (rc != 0) {
+		LOG_ERR("Failed to init HAL I2C");
+		return rc;
+	}
+
+	return 0;
+}
+
+static struct i2c_driver_api i2c_eos_s3_api = {
+	.configure = i2c_eos_s3_configure,
+	.transfer = i2c_eos_s3_transfer,
+};
+
+/* Device instantiation */
+
+#define I2C_EOS_S3_INIT(n)                                                                         \
+	static struct i2c_eos_s3_cfg i2c_eos_s3_cfg_##n = {                                        \
+		.idx = n.base = DT_INST_REG_ADDR(n),                                               \
+		.f_sys = SIFIVE_PERIPHERAL_CLOCK_FREQUENCY,                                        \
+		.f_bus = DT_INST_PROP(n, clock_frequency),                                         \
+	};                                                                                         \
+	I2C_DEVICE_DT_INST_DEFINE(n, i2c_eos_s3_init, NULL, NULL, &i2c_eos_s3_cfg_##n,             \
+				  POST_KERNEL, CONFIG_I2C_INIT_PRIORITY, &i2c_eos_s3_api);
+
+DT_INST_FOREACH_STATUS_OKAY(I2C_EOS_S3_INIT)

--- a/dts/arm/quicklogic/quicklogic_eos_s3.dtsi
+++ b/dts/arm/quicklogic/quicklogic_eos_s3.dtsi
@@ -64,6 +64,13 @@
 			pin-secondary-config = <0x00>;
 			gpio-controller;
 		};
+
+        i2c0: i2c@04004A000 {
+            compatible = "eos_s3_i2c0";
+            reg = <0x4004A000 0x170>;
+            #address-cells = <1>;
+            #size-cells = <1>;
+        };
 	};
 };
 

--- a/dts/arm/quicklogic/quicklogic_eos_s3.dtsi
+++ b/dts/arm/quicklogic/quicklogic_eos_s3.dtsi
@@ -65,12 +65,12 @@
 			gpio-controller;
 		};
 
-        i2c0: i2c@04004A000 {
-            compatible = "eos_s3_i2c0";
-            reg = <0x4004A000 0x170>;
-            #address-cells = <1>;
-            #size-cells = <1>;
-        };
+		i2c0: i2c@4004a000 {
+			compatible = "quicklogic,eos-s3-i2c";
+			reg = <0x4004a000 0x170>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
 	};
 };
 

--- a/dts/bindings/i2c/quicklogic,eos-s3-i2c.yaml
+++ b/dts/bindings/i2c/quicklogic,eos-s3-i2c.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Szymon Duchniewicz
+# SPDX-License-Identifier: Apache-2.0
+
+description: Quicklogic EOS S3 I2C interface
+
+compatible: "quicklogic,eos-s3-i2c"
+
+include: i2c-controller.yaml
+
+properties:
+  reg:
+    required: true

--- a/soc/arm/quicklogic_eos_s3/soc_pinmap.h
+++ b/soc/arm/quicklogic_eos_s3/soc_pinmap.h
@@ -10,13 +10,21 @@
 #include <soc.h>
 
 /* Set UART TX to PAD44 */
-#define UART_TXD_PAD44 (UART_TXD_SEL_PAD44 | PAD_CTRL_SEL_AO_REG \
-	| PAD_OEN_NORMAL | PAD_P_Z | PAD_SR_SLOW \
-	| PAD_E_4MA | PAD_REN_DISABLE | PAD_SMT_DISABLE)
+#define UART_TXD_PAD44                                                                             \
+	(UART_TXD_SEL_PAD44 | PAD_CTRL_SEL_AO_REG | PAD_OEN_NORMAL | PAD_P_Z | PAD_SR_SLOW |       \
+	 PAD_E_4MA | PAD_REN_DISABLE | PAD_SMT_DISABLE)
 
 /* Set UART RX to PAD45 */
-#define UART_RXD_PAD45 (UART_RXD_SEL_PAD45 | PAD_CTRL_SEL_AO_REG \
-	| PAD_OEN_DISABLE | PAD_P_Z | PAD_SR_SLOW \
-	| PAD_E_4MA | PAD_REN_ENABLE | PAD_SMT_DISABLE)
+#define UART_RXD_PAD45                                                                             \
+	(UART_RXD_SEL_PAD45 | PAD_CTRL_SEL_AO_REG | PAD_OEN_DISABLE | PAD_P_Z | PAD_SR_SLOW |      \
+	 PAD_E_4MA | PAD_REN_ENABLE | PAD_SMT_DISABLE)
+
+/* Set USR_BUTTON to PAD6 */
+#define IO_REG_SEL           0x160
+#define EXT_REG_OFFSET_SHIFT 20
+#define PAD6_FUNC_SEL_GPIO_0 ((uint32_t)(0x03 | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define BUTTON_PAD_CFG6                                                                            \
+	(PAD6_FUNC_SEL_GPIO_0 | PAD_CTRL_SEL_AO_REG | PAD_OEN_DISABLE | PAD_P_PULLUP |             \
+	 PAD_SR_SLOW | PAD_E_4MA | PAD_REN_ENABLE | PAD_SMT_DISABLE)
 
 #endif /* _QUICKLOGIC_EOS_S3_SOC_PINMAP_H_ */

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_quicklogic
-      revision: b3a66fe6d04d87fd1533a5c8de51d0599fcd08d0
+      revision: pull/4/head
       path: modules/hal/quicklogic
       repo-path: hal_quicklogic
       groups:


### PR DESCRIPTION
# Module dependent PR
> **Warning**
> This PR depends on https://github.com/zephyrproject-rtos/hal_quicklogic being updated
 **DO NOT** merge this PR until https://github.com/zephyrproject-rtos/hal_quicklogic/pull/4 is merged

## Description

This PR adds basic i2c driver implementation for the EOS S3 SoC, used with the [Sparkfun QuickLogic Thing Plus](https://github.com/sparkfun/QuickLogic_Thing_Plus) board (which is very similar to the intree [QuickLogic QuickFeather](https://docs.zephyrproject.org/latest/boards/arm/quick_feather/doc/index.html) ) based on the HAL module ported from [QuickLogic's QORC SDK](https://github.com/QuickLogic-Corp/qorc-sdk/).

Since there is an API mismatch between the actual HAL and the zephyr i2c driver API, I left a comment explaining my current approach in `drivers/i2c/i2c_eos_s3.c` file (https://github.com/zephyrproject-rtos/zephyr/compare/main...Willmish:zephyr:eos_s3_fixes?expand=1#diff-586321414cf511e0b1f1b99e041b736fe987a5d03a43eb9073e47c7ca2943f26R152). I would strongly appreciate guidance whether this is a correct approach or not.

Additionally this PR adds a tiny change to set up pinmuxing for the builtin button pad by default (this is normally muxed by the default bootloader provided by QuickLogic, but IMO the board port should be bootloader independent, so planning to add future PRs for elements of the bootloader that are taken for granted/add support for MCUBoot)
 
## Comprehensive list of changes:
- [ ] Update Kconfig.defconfig to include a BUILD_OUTPUT_BIN boolean flag - not sure if this is absolutely necessary, but current flasher for all EOS S3 based boards - [TinyFPGAProgrammer](https://github.com/QuickLogic-Corp/TinyFPGA-Programmer-Application)  requires  a binary file for flashing
- [ ] Add Button pad pinmuxing to `board.c` file for quickfeather board
- [ ] add necessary defines to  `board.h` and `soc_pinmap.h` files for the abovementioned pinmuxing for the `quickfeather` board
- [ ] Add all required files for i2c driver, including:
  - [ ] Updated `CMakeLists.txt`
  - [ ] Updated `Kconfig`
  - [ ] Added `Kconfig.eos_s3`
  - [ ] Added `i2c_eos_s3.c`
  - [ ] Added `quicklogic,eos-s3-i2c.yaml` dts binding
- [ ] Additionally : Updated `soc/arm/quicklogic_eos_s3/soc.c` to enable Flexible Fusion Engine Clocks, setup its dividors and properly gate/route them to be used by I2C peripherals (based on [EOS S3 Technical Reference Manual, Chapter 36.1 Setup FFE clocks, page 340](https://www.quicklogic.com/wp-content/uploads/2020/06/QL-S3-Technical-Reference-Manual-Vol-1.pdf)
- [ ] Updated SoC .dtsi file to `quicklogic_eos_s3.dtsi` to define the i2c0 device (there are two, should I also add a skeleton definition for i2c1?)
- [ ] Updated QuickFeather board dts to enable i2c0 by default

## Additional info
Opening as draft for now to be visible in https://github.com/zephyrproject-rtos/hal_quicklogic/pull/4 , but requires commit cleanup and code cleanup to conform to [Zephyr's Contribution guidelines](https://docs.zephyrproject.org/latest/contribute/contributor_expectations.html)

Created in collaboration with @JDuchniewicz in preparation for [Embedded Open Source Summit 2023](https://eoss2023.sched.com/event/1LcM4/porting-an-ai-powered-wearable-health-monitor-to-zephyr-on-open-hardware-szymon-duchniewicz-avanade-jakub-duchniewicz-tietoevry)