### PR TITLE
devicetree: Add DT_FIXED_PARTITION_ADDR macro

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -289,6 +289,8 @@ Devicetree
   :c:macro:`DT_FOREACH_STATUS_OKAY_NODE_VARGS`
   :c:macro:`DT_MEMORY_ATTR_FOREACH_NODE`
   :c:macro:`DT_MEMORY_ATTR_APPLY`
+  :c:macro:`DT_MEM_FROM_FIXED_PARTITION`
+  :c:macro:`DT_FIXED_PARTITION_ADDR`
 
 Libraries / Subsystems
 **********************

--- a/include/zephyr/devicetree/fixed-partitions.h
+++ b/include/zephyr/devicetree/fixed-partitions.h
@@ -78,15 +78,24 @@ extern "C" {
 #define DT_FIXED_PARTITION_ID(node_id) DT_CAT(node_id, _PARTITION_ID)
 
 /**
- * @brief Get the node identifier of the flash device for a partition
+ * @brief Get the node identifier of the flash memory for a partition
+ * @param node_id node identifier for a fixed-partitions child node
+ * @return the node identifier of the internal memory that contains the
+ * fixed-partitions node, or @ref DT_INVALID_NODE if it doesn't exist.
+ */
+#define DT_MEM_FROM_FIXED_PARTITION(node_id)                                                       \
+	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_GPARENT(node_id), soc_nv_flash), (DT_GPARENT(node_id)),  \
+		    (DT_INVALID_NODE))
+
+/**
+ * @brief Get the node identifier of the flash controller for a partition
  * @param node_id node identifier for a fixed-partitions child node
  * @return the node identifier of the memory technology device that
  * contains the fixed-partitions node.
  */
-#define DT_MTD_FROM_FIXED_PARTITION(node_id)				\
-	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_GPARENT(node_id), soc_nv_flash), \
-		    (DT_PARENT(DT_GPARENT(node_id))),			\
-		    (DT_GPARENT(node_id)))
+#define DT_MTD_FROM_FIXED_PARTITION(node_id)                                                       \
+	COND_CODE_1(DT_NODE_EXISTS(DT_MEM_FROM_FIXED_PARTITION(node_id)),                          \
+		    (DT_PARENT(DT_MEM_FROM_FIXED_PARTITION(node_id))), (DT_GPARENT(node_id)))
 
 /**
  * @}

--- a/include/zephyr/devicetree/fixed-partitions.h
+++ b/include/zephyr/devicetree/fixed-partitions.h
@@ -98,6 +98,42 @@ extern "C" {
 		    (DT_PARENT(DT_MEM_FROM_FIXED_PARTITION(node_id))), (DT_GPARENT(node_id)))
 
 /**
+ * @brief Get the absolute address of a fixed partition
+ *
+ * Example devicetree fragment:
+ *
+ *     &flash_controller {
+ *             flash@1000000 {
+ *                     compatible = "soc-nv-flash";
+ *                     partitions {
+ *                             compatible = "fixed-partitions";
+ *                             storage_partition: partition@3a000 {
+ *                                     label = "storage";
+ *                             };
+ *                     };
+ *             };
+ *     };
+ *
+ * Here, the "storage" partition is seen to belong to flash memory
+ * starting at address 0x1000000. The partition's unit address of
+ * 0x3a000 represents an offset inside that flash memory.
+ *
+ * Example usage:
+ *
+ *     DT_FIXED_PARTITION_ADDR(DT_NODELABEL(storage_partition)) // 0x103a000
+ *
+ * This macro can only be used with partitions of internal memory
+ * addressable by the CPU. Otherwise, it may produce a compile-time
+ * error, such as: `'__REG_IDX_0_VAL_ADDRESS' undeclared`.
+ *
+ * @param node_id node identifier for a fixed-partitions child node
+ * @return the partition's offset plus the base address of the flash
+ * node containing it.
+ */
+#define DT_FIXED_PARTITION_ADDR(node_id)                                                           \
+	(DT_REG_ADDR(DT_MEM_FROM_FIXED_PARTITION(node_id)) + DT_REG_ADDR(node_id))
+
+/**
  * @}
  */
 

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -657,6 +657,45 @@
 			zephyr,memory-attr = "RAM_NOCACHE";
 		};
 
+		test-mtd@ffeeddcc {
+			reg = < 0x0 0x1000 >;
+			#address-cells = < 1 >;
+			#size-cells = < 1 >;
+
+			flash@20000000 {
+				compatible = "soc-nv-flash";
+				reg = < 0x20000000 0x100 >;
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = < 1 >;
+					#size-cells = < 1 >;
+
+					partition@0 {
+						reg = < 0x0 0xc0 >;
+						label = "test-partition-0";
+					};
+					partition@c0 {
+						reg = < 0xc0 0x40 >;
+						label = "test-partition-1";
+					};
+				};
+			};
+		};
+
+		test-mtd@33221100 {
+			reg = < 0x33221100 0x1000 >;
+
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = < 1 >;
+				#size-cells = < 1 >;
+
+				partition@6ff80 {
+					reg = < 0x6ff80 0x80 >;
+					label = "test-partition-2";
+				};
+			};
+		};
 	};
 
 	test_64 {


### PR DESCRIPTION
This convenience API returns the absolute address of a fixed partition, i.e., relative offset + base address. It's distinct from `DT_REG_ADDR()` and `FIXED_PARTITION_OFFSET()`, both of which return just the offset.

The base address is taken from the parent memory node as given by the newly added `DT_MEM_FROM_FIXED_PARTITION()`. This is expected to ensure that the returned address is directly addressable by the CPU. This is also meant to prevent `DT_FIXED_PARTITION_ADDR()` from working with external memory partitions.