### PR TITLE
Bluetooth: Mesh: Restructure Kconfig options

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -13,163 +13,11 @@ menuconfig BT_MESH
 
 if BT_MESH
 
-choice BT_MESH_CRYPTO_LIB
-	prompt "Crypto library selection for mesh security"
-	default BT_MESH_USES_TFM_PSA if BUILD_WITH_TFM
-	default BT_MESH_USES_TINYCRYPT
+###################################################################################################
+# Invisible options
+###################################################################################################
 
-config BT_MESH_USES_TINYCRYPT
-	bool "Use TinyCrypt"
-	select TINYCRYPT
-	select TINYCRYPT_AES
-	select TINYCRYPT_AES_CMAC
-	select TINYCRYPT_ECC_DH
-	select TINYCRYPT_SHA256
-	select TINYCRYPT_SHA256_HMAC
-	select BT_HOST_CCM
-	help
-	  Use TinyCrypt library to perform crypto operations.
-
-config BT_MESH_USES_MBEDTLS_PSA
-	bool "Use mbed TLS PSA [EXPERIMENTAL]"
-	select EXPERIMENTAL
-	select MBEDTLS
-	select MBEDTLS_ZEPHYR_ENTROPY
-	select MBEDTLS_PSA_CRYPTO_C
-	select MBEDTLS_MAC_CMAC_ENABLED
-	select MBEDTLS_CIPHER_AES_ENABLED
-	select MBEDTLS_AES_ROM_TABLES
-	select MBEDTLS_CIPHER_CCM_ENABLED
-	select MBEDTLS_ECP_C
-	select MBEDTLS_ECDH_C
-	select MBEDTLS_ECDSA_C
-	select MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
-	select MBEDTLS_ECP_DP_SECP256R1_ENABLED
-	select MBEDTLS_PK_WRITE_C
-	help
-	  Use mbed TLS library to perform crypto operations. Support of
-	  mbed TLS and PSA is experimental and only BabbleSim tests were run.
-	  Mbed TLS still does not support ITS (internal trust storage) based
-	  on Zephyr's settings subsystem.
-	  Not possible to use for embedded devices yet.
-
-config BT_MESH_USES_TFM_PSA
-	bool "Use TF-M PSA [EXPERIMENTAL]"
-	select EXPERIMENTAL
-	depends on BUILD_WITH_TFM
-	help
-	  Use TF-M that implements PSA security framework. Support of TF-M is
-	  experimental. It is only possible to use with platforms that TF-M supports.
-	  For more platform details see TF-M documentation.
-
-endchoice
-
-if BT_MESH_USES_MBEDTLS_PSA || BT_MESH_USES_TFM_PSA
-
-config BT_MESH_PSA_KEY_ID_USER_MIN_OFFSET
-	int "Offset of BLE Mesh key id range regarding PSA_KEY_ID_USER_MIN"
-	default 0
-	help
-	  The PSA specification mandates to set key identifiers for keys
-	  with persistent lifetime. The users of the PSA API is responsible
-	  (BLE Mesh is user of PSA API) to provide correct and unique identifiers.
-	  The BLE Mesh identifier range should be between PSA_KEY_ID_USER_MIN and
-	  PSA_KEY_ID_USER_MAX. BLE Mesh requires two ids for each subnetwork, two ids
-	  for each application key, and two ids for the device key and device key candidate.
-	  It should consider the Mesh Configuration Database instances if database enabled.
-
-endif # BT_MESH_USES_MBEDTLS_PSA || BT_MESH_USES_TFM_PSA
-
-# Virtual option enabled whenever Generic Provisioning layer is needed
-config BT_MESH_PROV
-	bool
-
-config BT_MESH_PROV_DEVICE
-	bool "Provisioning device role support"
-	depends on BT_MESH_PROV
-	default y
-	help
-	  Enable this option to allow the device to be provisioned into a mesh network.
-
-config BT_MESH_PROV_OOB_PUBLIC_KEY
-	bool "OOB Public key support"
-	depends on BT_MESH_PROV_DEVICE
-	help
-	  Enable this option if public key is to be exchanged via Out of Band (OOB) technology.
-
-config BT_MESH_PB_ADV
-	bool "Provisioning support using the advertising bearer (PB-ADV)"
-	select BT_MESH_PROV
-	default y
-	help
-	  Enable this option to allow the device to be provisioned over
-	  the advertising bearer.
-
-config BT_MESH_UNPROV_BEACON_INT
-	int
-	prompt "The interval (in seconds) to send the unprovisioned beacon" if BT_MESH_PB_ADV
-	default 5
-	range 1 10
-	help
-	  This option specifies the interval (in seconds) at which the
-	  device sends unprovisioned beacon.
-
-config BT_MESH_PB_ADV_RETRANS_TIMEOUT
-	int "Timeout value of retransmit provisioning PDUs"
-	default 500
-	range 100 800
-	help
-	  Timeout value of retransmit provisioning PDUs.
-
-config BT_MESH_PROVISIONER
-	bool "Provisioner support"
-	depends on BT_MESH_CDB
-	depends on BT_MESH_PROV
-	depends on BT_MESH_PB_ADV || BT_MESH_PB_GATT_CLIENT
-	help
-	  Enable this option to have support for provisioning remote devices.
-
-config BT_MESH_CDB
-	bool "Mesh Configuration Database"
-
-config BT_MESH_ECDH_P256_CMAC_AES128_AES_CCM
-	bool "Support CMAC AES128 for OOB authentication"
-	depends on BT_MESH_PROV
-	default y
-	help
-	  Enable this option to support CMAC AES128 for OOB authentication.
-
-if BT_MESH_CDB
-
-config BT_MESH_CDB_NODE_COUNT
-	int "Maximum number of nodes in the database"
-	default 8
-	range 1 4096
-	help
-	  This option specifies how many nodes each network can at most
-	  save in the configuration database.
-
-config BT_MESH_CDB_SUBNET_COUNT
-	int "Maximum number of subnets in the database"
-	default 1
-	range 1 4096
-	help
-	  This option specifies how many subnets that can at most be
-	  saved in the configuration database.
-
-config BT_MESH_CDB_APP_KEY_COUNT
-	int "Maximum number of application keys in the database"
-	default 1
-	range 1 4096
-	help
-	  This option specifies how many application keys that can at most
-	  be saved in the configuration database.
-
-endif # BT_MESH_CDB
-
-if BT_CONN
-
-# Virtual option enabled whenever any Proxy protocol is needed
+# Virtual option enabled whenever Proxy Server or Client is needed
 config BT_MESH_PROXY
 	bool
 
@@ -194,261 +42,22 @@ config BT_MESH_GATT_SERVER
 config BT_MESH_PB_GATT_COMMON
 	bool
 
-config BT_MESH_PB_GATT_CLIENT
-	bool "Provisioner support using GATT (PB-GATT)"
-	select BT_MESH_PROV
-	select BT_GATT_CLIENT
-	select BT_MESH_GATT_CLIENT
-	select BT_MESH_PB_GATT_COMMON
-	select BT_MESH_PROVISIONER
-	depends on BT_CENTRAL
-	help
-	  Enable this option to allow the provisioner provisioning the
-	  device over GATT.
+# Virtual option enabled whenever Generic Provisioning layer is needed
+config BT_MESH_PROV
+	bool
 
-config BT_MESH_PB_GATT
-	bool "Provisioning support using GATT (PB-GATT)"
-	select BT_MESH_GATT_SERVER
-	select BT_MESH_PROV
-	select BT_MESH_PB_GATT_COMMON
-	help
-	  Enable this option to allow the device to be provisioned over
-	  GATT.
+###################################################################################################
+# Visible options
+###################################################################################################
 
-config BT_MESH_PB_GATT_USE_DEVICE_NAME
-	bool "Include Bluetooth device name in scan response"
-	depends on BT_MESH_PB_GATT
-	default y
-	help
-	  This option includes GAP device name in scan response when
-	  the PB-GATT is enabled.
-
-config BT_MESH_PROXY_CLIENT
-	bool "Proxy client support"
-	select BT_GATT_CLIENT
-	select BT_MESH_GATT_CLIENT
-	depends on BT_CENTRAL
-	help
-	  This option enables support for the Mesh GATT Proxy Client,
-	  i.e. the ability to act as a proxy between a Mesh GATT Service
-	  and a Mesh network.
-
-config BT_MESH_GATT_PROXY
-	bool "GATT Proxy Service support"
-	select BT_MESH_GATT_SERVER
-	select BT_MESH_PROXY
-	help
-	  This option enables support for the Mesh GATT Proxy Service,
-	  i.e. the ability to act as a proxy between a Mesh GATT Client
-	  and a Mesh network.
-
-config BT_MESH_GATT_PROXY_ENABLED
-	bool "GATT Proxy enabled"
-	depends on BT_MESH_GATT_PROXY
-	default y
-	help
-	  Controls whether the GATT Proxy feature is enabled by default.
-	  Can be changed through runtime configuration.
-
-config BT_MESH_NODE_ID_TIMEOUT
-	int "Node Identity advertising timeout"
-	depends on BT_MESH_GATT_PROXY
-	range 1 60
-	default 60
-	help
-	  This option determines for how long the local node advertises
-	  using Node Identity. The given value is in seconds. The
-	  specification limits this to 60 seconds, and implies that to
-	  be the appropriate value as well, so just leaving this as the
-	  default is the safest option.
-
-config BT_MESH_PROXY_USE_DEVICE_NAME
-	bool "Include Bluetooth device name in scan response"
-	depends on BT_MESH_GATT_PROXY
-	help
-	  This option includes GAP device name in scan response when
-	  the GATT Proxy feature is enabled.
-
-config BT_MESH_PROXY_FILTER_SIZE
-	int "Maximum number of filter entries per Proxy Client"
-	default 16
-	range 1 32767
-	depends on BT_MESH_GATT_PROXY
-	help
-	  This option specifies how many Proxy Filter entries the local
-	  node supports. This helps in reducing unwanted traffic getting sent to
-	  the proxy client. This value is application specific and should be large
-	  enough so that proxy client can communicate with several devices through
-	  this proxy server node using the default accept list filter type.
-
-config BT_MESH_MAX_CONN
-	int "Maximum number of simultaneous connections used by the stack"
-	default BT_MAX_CONN
-	range 1 BT_MAX_CONN
-	help
-	  Maximum number of simultaneous Bluetooth connections that the Bluetooth
-	  mesh stack can use.
-
-endif # BT_CONN
-
-config BT_MESH_ACCESS_LAYER_MSG
-	bool "Direct Bluetooth message access layer messages"
-	help
-	  This option allows the application to directly access
-	  Bluetooth access layer messages without the need to
-	  instantiate Bluetooth mesh models.
-
-config BT_MESH_SELF_TEST
-	bool "Perform self-tests"
-	help
-	  This option adds extra self-tests which are run every time
-	  mesh networking is initialized.
-
-config BT_MESH_IV_UPDATE_TEST
-	bool "Test the IV Update Procedure"
-	help
-	  This option removes the 96 hour limit of the IV Update
-	  Procedure and lets the state be changed at any time.
-
-config BT_MESH_SUBNET_COUNT
-	int "Maximum number of mesh subnets per network"
-	default 1
-	range 1 4096
-	help
-	  This option specifies how many subnets a Mesh network can
-	  participate in at the same time.
-
-config BT_MESH_APP_KEY_COUNT
-	int "Maximum number of application keys per network"
-	default 1
-	range 1 4096
-	help
-	  This option specifies how many application keys the device can
-	  store per network.
-
-config BT_MESH_MODEL_KEY_COUNT
-	int "Maximum number of application keys per model"
-	default 1
-	range 1 4096
-	help
-	  This option specifies how many application keys each model can
-	  at most be bound to.
-
-config BT_MESH_MODEL_GROUP_COUNT
-	int "Maximum number of group address subscriptions per model"
-	default 1
-	range 1 4096
-	help
-	  This option specifies how many group addresses each model can
-	  at most be subscribed to.
-
-config BT_MESH_MODEL_VND_MSG_CID_FORCE
-	bool "Force vendor model to use the corresponding CID field message"
-	default y
-	help
-	  This option forces vendor model to use messages for the
-	  corresponding CID field.
-
-config BT_MESH_LABEL_COUNT
-	int "Maximum number of Label UUIDs used for Virtual Addresses"
-	default 1
-	range 0 4096
-	help
-	  This option specifies how many Label UUIDs can be stored.
-
-config BT_MESH_LABEL_NO_RECOVER
-	bool "[DEPRECATED] Don't recover Label UUIDs from groups address subscription list"
-	select DEPRECATED
-	depends on BT_MESH_LABEL_COUNT > 0
-	help
-	  After adding support for virtual addresses with collision (where two Label UUIDs have the
-	  same virtual address), the format of the data in the persistent storage with the Label
-	  UUIDs which a model is subscribed to or publishes to has been changed. The recovery
-	  code is added and the Label UUIDs will be recovered by picking first Label UUID matching
-	  to the virtual address in the subscription list or model publication. This options can
-	  disable the recovery code and save some flash if the recovery is not required (e.g.
-	  virtual address support wasn't enabled before this option was added, or the devices were
-	  unprovisioned before upgrading to the version with this option). The option is marked as
-	  deprecated to remove the recovery code eventually.
-
-config BT_MESH_CRPL
-	int "Maximum capacity of the replay protection list"
-	default 10
-	range 2 65535
-	help
-	  This options specifies the maximum capacity of the replay
-	  protection list. This option is similar to the network message
-	  cache size, but has a different purpose.
-
-choice BT_MESH_RPL_STORAGE_MODE
-	prompt "Replay protection list storage mode"
-	default BT_MESH_RPL_STORAGE_MODE_SETTINGS
-
-config BT_MESH_RPL_STORAGE_MODE_SETTINGS
-	bool "Persistent storage of RPL in Settings"
-	help
-	  Persistent storage of RPL in Settings. If BT_SETTINGS is not
-	  enabled this choise will provide a non-persistent implementation
-	  variant of the RPL list.
-
-endchoice
-
-if BT_MESH_RPL_STORAGE_MODE_SETTINGS && BT_SETTINGS
-
-config BT_MESH_RPL_STORE_TIMEOUT
-	int "Minimum interval after which unsaved RPL and SRPL entries are updated in the settings subsystem"
-	range -1 1000000
-	default 5
-	help
-	  This value defines time in seconds until unsaved RPL and SRPL entries
-	  are written to the persistent storage. Setting this value
-	  to a large number may lead to security vulnerabilities if a node
-	  gets powered off before the timer is fired. When flash is used
-	  as the persistent storage setting this value to a low number
-	  may wear out flash sooner or later. However, if the RPL gets
-	  updated infrequently a value as low as 0 (write immediately)
-	  may make sense. Setting this value to -1 will disable this timer.
-	  In this case, a user is responsible to store pending RPL entries
-	  using @ref bt_mesh_rpl_pending_store. In the mean time, when
-	  IV Index is updated, the outdated RPL entries will still be
-	  stored by @ref BT_MESH_STORE_TIMEOUT. Finding the right balance
-	  between this timeout and calling @ref bt_mesh_rpl_pending_store
-	  may reduce a risk of security vulnerability and flash wear out.
-	  Failure to store the RPL and becoming vulnerable after reboot
-	  will cause the device to not perform the replay protection
-	  required by the spec.
-
-endif # BT_MESH_RPL_STORAGE_MODE_SETTINGS && BT_SETTINGS
-
-config BT_MESH_MSG_CACHE_SIZE
-	int "Network message cache size"
-	default 32
-	range 2 65535
-	help
-	  Number of messages that are cached by the node to avoid acting on the
-	  recently seen duplicate messages. This option is similar to
-	  the replay protection list, but has a different purpose. Network message
-	  cache helps prevent unnecessary decryption operations. This also prevents
-	  unnecessary relaying and helps in getting rid of relay loops. Setting
-	  this value to a very low number can cause unnecessary network traffic.
-	  Setting this value to a very large number can impact the processing time
-	  for each received network PDU and increases RAM footprint proportionately.
-
-config BT_MESH_ADV_BUF_COUNT
-	int "Number of advertising buffers for local messages"
-	default 6
-	range 1 256
-	help
-	  Number of advertising buffers available for sending local messages.
-	  This should be chosen based on the number of local messages that the node
-	  can send simultaneously.
+menu "Advertiser"
 
 choice BT_MESH_ADV
 	prompt "Advertiser mode"
 	default BT_MESH_ADV_EXT if BT_EXT_ADV
 	default BT_MESH_ADV_LEGACY
 
-config BT_MESH_ADV_LEGACY
+menuconfig BT_MESH_ADV_LEGACY
 	bool "Legacy advertising"
 	help
 	  Use legacy advertising commands for mesh sending. Legacy
@@ -459,7 +68,31 @@ config BT_MESH_ADV_LEGACY
 	  retransmissions than requested because of limitations of HCI
 	  interface API.
 
-config BT_MESH_ADV_EXT
+if BT_MESH_ADV_LEGACY
+
+config BT_MESH_ADV_STACK_SIZE
+	int "Mesh advertiser thread stack size"
+	default 1024 if BT_HOST_CRYPTO
+	default 776 if BT_MESH_PRIV_BEACONS
+	default 768
+	help
+	  Size of bt mesh adv thread stack.
+
+	  NOTE: This is an advanced setting and should not be changed unless
+	  absolutely necessary
+
+config BT_MESH_ADV_PRIO
+	int "Mesh advertiser thread priority"
+	default 7
+	help
+	  Priority of bt mesh adv thread.
+
+	  NOTE: This is an advanced setting and should not be changed unless
+	  absolutely necessary
+
+endif # BT_MESH_ADV_LEGACY
+
+menuconfig BT_MESH_ADV_EXT
 	bool "Extended advertising"
 	depends on BT_CTLR_ADV_EXT || !BT_CTLR
 	depends on BT_EXT_ADV
@@ -467,8 +100,6 @@ config BT_MESH_ADV_EXT
 	  Use extended advertising commands for operating the advertiser.
 	  Extended advertising is faster and uses less memory than legacy
 	  advertising, but isn't supported by all controllers.
-
-endchoice
 
 if BT_MESH_ADV_EXT
 
@@ -519,60 +150,241 @@ config BT_MESH_ADV_EXT_FRIEND_SEPARATE
 
 endif # BT_MESH_ADV_EXT
 
-config BT_MESH_ADV_STACK_SIZE
-	int "Mesh advertiser thread stack size"
-	depends on BT_MESH_ADV_LEGACY
-	default 1024 if BT_HOST_CRYPTO
-	default 776 if BT_MESH_PRIV_BEACONS
-	default 768
+endchoice
+
+config BT_MESH_ADV_BUF_COUNT
+	int "Number of advertising buffers for local messages"
+	default 6
+	range 1 256
 	help
-	  Size of bt mesh adv thread stack.
+	  Number of advertising buffers available for sending local messages.
+	  This should be chosen based on the number of local messages that the node
+	  can send simultaneously.
 
-	  NOTE: This is an advanced setting and should not be changed unless
-	  absolutely necessary
-
-config BT_MESH_ADV_PRIO
-	int "Mesh advertiser thread priority"
-	depends on BT_MESH_ADV_LEGACY
-	default 7
+config BT_MESH_DEBUG_USE_ID_ADDR
+	bool "Use identity address for all advertising"
 	help
-	  Priority of bt mesh adv thread.
+	  This option forces the usage of the local identity address for
+	  all advertising. This can be a help for debugging (analyzing
+	  traces), however it should never be enabled for a production
+	  build as it compromises the privacy of the device.
 
-	  NOTE: This is an advanced setting and should not be changed unless
-	  absolutely necessary
+endmenu # Advertiser
 
-config BT_MESH_IV_UPDATE_SEQ_LIMIT
-	hex "Sequence number limit to start iv update"
-	default 0x800000
-	range 0x000001 0xFFFFFE
+menu "Provisioning"
+
+menuconfig BT_MESH_PB_ADV
+	bool "PB-ADV support"
+	select BT_MESH_PROV
+	default y
 	help
-	  This option specifies the sequence number value to start iv update.
+	  Enable this option to allow the device to be provisioned over
+	  the advertising bearer.
 
-config BT_MESH_IVU_DIVIDER
-	int "Divider for IV Update state refresh timer"
-	default 4
-	range 2 96
+config BT_MESH_UNPROV_BEACON_INT
+	int
+	prompt "The interval (in seconds) to send the unprovisioned beacon" if BT_MESH_PB_ADV
+	default 5
+	range 1 10
 	help
-	  When the IV Update state enters Normal operation or IV Update
-	  in Progress, we need to keep track of how many hours has passed
-	  in the state, since the specification requires us to remain in
-	  the state at least for 96 hours (Update in Progress has an
-	  additional upper limit of 144 hours).
+	  This option specifies the interval (in seconds) at which the
+	  device sends unprovisioned beacon.
 
-	  In order to fulfill the above requirement, even if the node might
-	  be powered off once in a while, we need to store persistently
-	  how many hours the node has been in the state. This doesn't
-	  necessarily need to happen every hour (thanks to the flexible
-	  duration range). The exact cadence will depend a lot on the
-	  ways that the node will be used and what kind of power source it
-	  has.
+if BT_MESH_PB_ADV
 
-	  Since there is no single optimal answer, this configuration
-	  option allows specifying a divider, i.e. how many intervals
-	  the 96 hour minimum gets split into. After each interval the
-	  duration that the node has been in the current state gets
-	  stored to flash. E.g. the default value of 4 means that the
-	  state is saved every 24 hours (96 / 4).
+config BT_MESH_PB_ADV_RETRANS_TIMEOUT
+	int "Timeout value of retransmit provisioning PDUs"
+	default 500
+	range 100 800
+	help
+	  Timeout value of retransmit provisioning PDUs.
+
+endif # BT_MESH_PB_ADV
+
+if BT_CONN
+
+config BT_MESH_PB_GATT
+	bool "PB-GATT Server support"
+	select BT_MESH_GATT_SERVER
+	select BT_MESH_PROV
+	select BT_MESH_PB_GATT_COMMON
+	select BT_MESH_PROV_DEVICE
+	help
+	  Enable this option to allow the device to be provisioned over
+	  GATT.
+
+config BT_MESH_PB_GATT_USE_DEVICE_NAME
+	bool "Include Bluetooth device name in scan response"
+	depends on BT_MESH_PB_GATT
+	default y
+	help
+	  This option includes GAP device name in scan response when
+	  the PB-GATT is enabled.
+
+config BT_MESH_PB_GATT_CLIENT
+	bool "PB-GATT Client support"
+	select BT_MESH_PROV
+	select BT_GATT_CLIENT
+	select BT_MESH_GATT_CLIENT
+	select BT_MESH_PB_GATT_COMMON
+	select BT_MESH_PROVISIONER
+	depends on BT_CENTRAL
+	help
+	  Enable this option to allow the provisioner provisioning the
+	  device over GATT.
+
+endif # BT_CONN
+
+config BT_MESH_PROV_DEVICE
+	bool "Provisioning device role support"
+	depends on BT_MESH_PB_ADV || BT_MESH_PB_GATT
+	default y
+	help
+	  Enable this option to allow the device to be provisioned into a mesh network.
+
+config BT_MESH_PROV_OOB_PUBLIC_KEY
+	bool "OOB Public key support"
+	depends on BT_MESH_PROV_DEVICE
+	help
+	  Enable this option if public key is to be exchanged via Out of Band (OOB) technology.
+
+config BT_MESH_PROVISIONER
+	bool "Provisioner support"
+	depends on BT_MESH_CDB
+	depends on BT_MESH_PROV
+	depends on BT_MESH_PB_ADV || BT_MESH_PB_GATT_CLIENT
+	help
+	  Enable this option to have support for provisioning remote devices.
+
+menuconfig BT_MESH_CDB
+	bool "Mesh Configuration Database"
+
+if BT_MESH_CDB
+
+config BT_MESH_CDB_NODE_COUNT
+	int "Maximum number of nodes in the database"
+	default 8
+	range 1 4096
+	help
+	  This option specifies how many nodes each network can at most
+	  save in the configuration database.
+
+config BT_MESH_CDB_SUBNET_COUNT
+	int "Maximum number of subnets in the database"
+	default 1
+	range 1 4096
+	help
+	  This option specifies how many subnets that can at most be
+	  saved in the configuration database.
+
+config BT_MESH_CDB_APP_KEY_COUNT
+	int "Maximum number of application keys in the database"
+	default 1
+	range 1 4096
+	help
+	  This option specifies how many application keys that can at most
+	  be saved in the configuration database.
+
+endif # BT_MESH_CDB
+
+endmenu # Provisioning
+
+menu "Network layer"
+
+config BT_MESH_LOOPBACK_BUFS
+	int "Number of loopback buffers"
+	default 3
+	help
+	  The number of buffers allocated for the network loopback mechanism.
+	  Loopback is used when the device sends messages to itself.
+
+config BT_MESH_NETWORK_TRANSMIT_COUNT
+	int "Network Transmit Count"
+	default 2
+	range 0 7
+	help
+	  Controls the initial number of retransmissions of original messages,
+	  in addition to the first transmission. Can be changed through runtime
+	  configuration.
+
+config BT_MESH_NETWORK_TRANSMIT_INTERVAL
+	int "Network Transmit Interval"
+	default 20
+	range 10 330
+	help
+	  Controls the initial interval between retransmissions of original
+	  messages, in milliseconds. Can be changed through runtime
+	  configuration.
+
+config BT_MESH_MSG_CACHE_SIZE
+	int "Network message cache size"
+	default 32
+	range 2 65535
+	help
+	  Number of messages that are cached by the node to avoid acting on the
+	  recently seen duplicate messages. This option is similar to
+	  the replay protection list, but has a different purpose. Network message
+	  cache helps prevent unnecessary decryption operations. This also prevents
+	  unnecessary relaying and helps in getting rid of relay loops. Setting
+	  this value to a very low number can cause unnecessary network traffic.
+	  Setting this value to a very large number can impact the processing time
+	  for each received network PDU and increases RAM footprint proportionately.
+
+menuconfig BT_MESH_RELAY
+	bool "Relay support"
+	help
+	  Support for acting as a Mesh Relay Node.
+
+if BT_MESH_RELAY
+
+config BT_MESH_RELAY_ENABLED
+	bool "Relay feature enabled by default"
+	default y
+	help
+	  Controls whether the Relay feature is enabled by default when the
+	  device boots up for the first time or unprovisioned. Can be changed
+	  at runtime using bt_mesh_relay_set() function.
+
+config BT_MESH_RELAY_RETRANSMIT_COUNT
+	int "Relay Retransmit Count"
+	default 2
+	range 0 7
+	help
+	  Controls the initial number of retransmissions of relayed messages, in
+	  addition to the first transmission. Can be changed through runtime
+	  configuration.
+
+config BT_MESH_RELAY_RETRANSMIT_INTERVAL
+	int "Relay Retransmit Interval"
+	default 20
+	range 10 330
+	help
+	  Controls the initial interval between retransmissions of relayed
+	  messages, in milliseconds. Can be changed through runtime
+	  configuration.
+
+config BT_MESH_RELAY_BUF_COUNT
+	int "Number of advertising buffers for relayed messages"
+	default 32
+	range 1 256
+	help
+	  Number of advertising buffers available for messages to be relayed.
+	  High number of advertising buffers increases the reliability of the
+	  mesh network. Low number of advertising buffers reduces the message
+	  latency on the Relay Node, but at the same time increases the amount
+	  of packet drops. When considering the message latency, also consider
+	  the values of BT_MESH_RELAY_RETRANSMIT_COUNT and
+	  BT_MESH_RELAY_RETRANSMIT_INTERVAL. A higher number of
+	  BT_MESH_RELAY_ADV_SETS allows the increase in the number of buffers
+	  while maintaining the latency.
+
+endif # BT_MESH_RELAY
+
+endmenu # Network layer
+
+menu "Transport layer"
+
+menu "Transport SAR configuration"
 
 config BT_MESH_TX_SEG_MSG_COUNT
 	int "Maximum number of simultaneous outgoing segmented messages"
@@ -659,6 +471,30 @@ config BT_MESH_TX_SEG_MAX
 	  which leaves 56 bytes for application layer data using a
 	  4-byte MIC and 52 bytes using an 8-byte MIC.
 
+if !BT_MESH_V1d1
+
+config BT_MESH_TX_SEG_RETRANS_COUNT
+	int "Transport message segment retransmit attempts"
+	default 4
+	range 1 8
+	help
+	  Maximum number of transport message segment retransmit attempts
+	  for outgoing segment message.
+
+config BT_MESH_TX_SEG_RETRANS_TIMEOUT_UNICAST
+	int "Transport message segment retransmit interval for unicast messages"
+	default 400
+	range 200 500
+	help
+	  Maximum time of retransmit segment message to unicast address.
+
+config BT_MESH_TX_SEG_RETRANS_TIMEOUT_GROUP
+	int "Transport message segment retransmit interval for group messages"
+	default 50
+	range 20 200
+	help
+	  Maximum time of retransmit segment message to group address.
+
 config BT_MESH_SEG_ACK_BASE_TIMEOUT
 	int "SegAck transmission base timeout"
 	default 150
@@ -683,6 +519,10 @@ config BT_MESH_SEG_ACK_PER_SEGMENT_TIMEOUT
 	  Defines an additional timeout for the acknowledgment timer for every
 	  segment not yet received.
 
+endif # !BT_MESH_V1d1
+
+endmenu # Transport SAR configuration
+
 config BT_MESH_DEFAULT_TTL
 	int "Default TTL value"
 	default 7
@@ -691,79 +531,243 @@ config BT_MESH_DEFAULT_TTL
 	  Controls the default TTL value for outgoing messages. Can be changed
 	  through runtime configuration.
 
-config BT_MESH_LOOPBACK_BUFS
-	int "Number of loopback buffers"
-	default 3
+menu "Replay Protection List"
+
+config BT_MESH_CRPL
+	int "Maximum capacity of the replay protection list"
+	default 10
+	range 2 65535
 	help
-	  The number of buffers allocated for the network loopback mechanism.
-	  Loopback is used when the device sends messages to itself.
+	  This options specifies the maximum capacity of the replay
+	  protection list. This option is similar to the network message
+	  cache size, but has a different purpose.
 
-config BT_MESH_NETWORK_TRANSMIT_COUNT
-	int "Network Transmit Count"
-	default 2
-	range 0 7
+choice BT_MESH_RPL_STORAGE_MODE
+	prompt "Replay protection list storage mode"
+	default BT_MESH_RPL_STORAGE_MODE_SETTINGS
+
+config BT_MESH_RPL_STORAGE_MODE_SETTINGS
+	bool "Persistent storage of RPL in Settings"
 	help
-	  Controls the initial number of retransmissions of original messages,
-	  in addition to the first transmission. Can be changed through runtime
-	  configuration.
+	  Persistent storage of RPL in Settings. If BT_SETTINGS is not
+	  enabled this choise will provide a non-persistent implementation
+	  variant of the RPL list.
 
-config BT_MESH_NETWORK_TRANSMIT_INTERVAL
-	int "Network Transmit Interval"
-	default 20
-	range 10 330
+endchoice
+
+endmenu # Replay Protection List
+
+endmenu # Transport layer
+
+menu "Access layer"
+
+config BT_MESH_ACCESS_LAYER_MSG
+	bool "Direct Bluetooth message access layer messages"
 	help
-	  Controls the initial interval between retransmissions of original
-	  messages, in milliseconds. Can be changed through runtime
-	  configuration.
+	  This option allows the application to directly access
+	  Bluetooth access layer messages without the need to
+	  instantiate Bluetooth mesh models.
 
-menuconfig BT_MESH_RELAY
-	bool "Relay support"
-	help
-	  Support for acting as a Mesh Relay Node.
-
-if BT_MESH_RELAY
-
-config BT_MESH_RELAY_ENABLED
-	bool "Relay enabled"
+config BT_MESH_MODEL_VND_MSG_CID_FORCE
+	bool "Force vendor model to use the corresponding CID field message"
 	default y
 	help
-	  Controls whether the Mesh Relay feature is enabled by default. Can be
-	  changed through runtime configuration.
+	  This option forces vendor model to use messages for the
+	  corresponding CID field.
 
-config BT_MESH_RELAY_RETRANSMIT_COUNT
-	int "Relay Retransmit Count"
-	default 2
-	range 0 7
+config BT_MESH_MODEL_EXTENSIONS
+	bool "Support for Model extensions"
 	help
-	  Controls the initial number of retransmissions of relayed messages, in
-	  addition to the first transmission. Can be changed through runtime
-	  configuration.
+	  Enable support for the model extension concept, allowing the Access
+	  layer to know about mesh model relationships.
 
-config BT_MESH_RELAY_RETRANSMIT_INTERVAL
-	int "Relay Retransmit Interval"
-	default 20
-	range 10 330
+config BT_MESH_LABEL_NO_RECOVER
+	bool "[DEPRECATED] Don't recover Label UUIDs from groups address subscription list"
+	select DEPRECATED
+	depends on BT_MESH_LABEL_COUNT > 0
 	help
-	  Controls the initial interval between retransmissions of relayed
-	  messages, in milliseconds. Can be changed through runtime
-	  configuration.
+	  After adding support for virtual addresses with collision (where two Label UUIDs have the
+	  same virtual address), the format of the data in the persistent storage with the Label
+	  UUIDs which a model is subscribed to or publishes to has been changed. The recovery
+	  code is added and the Label UUIDs will be recovered by picking first Label UUID matching
+	  to the virtual address in the subscription list or model publication. This options can
+	  disable the recovery code and save some flash if the recovery is not required (e.g.
+	  virtual address support wasn't enabled before this option was added, or the devices were
+	  unprovisioned before upgrading to the version with this option). The option is marked as
+	  deprecated to remove the recovery code eventually.
 
-config BT_MESH_RELAY_BUF_COUNT
-	int "Number of advertising buffers for relayed messages"
-	default 32
-	range 1 256
+endmenu # Access layer
+
+menu "Models"
+
+config BT_MESH_CFG_CLI
+	bool "Support for Configuration Client Model"
 	help
-	  Number of advertising buffers available for messages to be relayed.
-	  High number of advertising buffers increases the reliability of the
-	  mesh network. Low number of advertising buffers reduces the message
-	  latency on the Relay Node, but at the same time increases the amount
-	  of packet drops. When considering the message latency, also consider
-	  the values of BT_MESH_RELAY_RETRANSMIT_COUNT and
-	  BT_MESH_RELAY_RETRANSMIT_INTERVAL. A higher number of
-	  BT_MESH_RELAY_ADV_SETS allows the increase in the number of buffers
-	  while maintaining the latency.
+	  Enable support for the configuration client model.
 
-endif
+if BT_MESH_CFG_CLI
+
+config BT_MESH_CFG_CLI_TIMEOUT
+	int "Config Client model timeout in milliseconds"
+	default 5000
+	help
+	  This timeout controls how long config client waits for a response
+	  message to arrive. This value can be changed at runtime using
+	  @ref bt_mesh_cfg_cli_timeout_set.
+
+endif # BT_MESH_CFG_CLI
+
+config BT_MESH_HEALTH_CLI
+	bool "Support for Health Client Model"
+	help
+	  Enable support for the health client model.
+
+if BT_MESH_HEALTH_CLI
+
+config BT_MESH_HEALTH_CLI_TIMEOUT
+	int "Health Client model timeout in milliseconds"
+	default 2000
+	help
+	  This timeout controls how long health client waits for a response
+	  message to arrive. This value can be changed at runtime using
+	  @ref bt_mesh_health_cli_timeout_set.
+
+endif # BT_MESH_HEALTH_CLI
+
+endmenu # Models
+
+menu "Proxy"
+	visible if BT_CONN
+
+menuconfig BT_MESH_GATT_PROXY
+	bool "GATT Proxy Service support"
+	select BT_MESH_GATT_SERVER
+	select BT_MESH_PROXY
+	help
+	  This option enables support for the Mesh GATT Proxy Service,
+	  i.e. the ability to act as a proxy between a Mesh GATT Client
+	  and a Mesh network.
+
+if BT_MESH_GATT_PROXY
+
+config BT_MESH_GATT_PROXY_ENABLED
+	bool "GATT Proxy enabled"
+	depends on BT_MESH_GATT_PROXY
+	default y
+	help
+	  Controls whether the GATT Proxy feature is enabled by default.
+	  Can be changed through runtime configuration.
+
+config BT_MESH_NODE_ID_TIMEOUT
+	int "Node Identity advertising timeout"
+	range 1 60
+	default 60
+	help
+	  This option determines for how long the local node advertises
+	  using Node Identity. The given value is in seconds. The
+	  specification limits this to 60 seconds, and implies that to
+	  be the appropriate value as well, so just leaving this as the
+	  default is the safest option.
+
+config BT_MESH_PROXY_USE_DEVICE_NAME
+	bool "Include Bluetooth device name in scan response"
+	help
+	  This option includes GAP device name in scan response when
+	  the GATT Proxy feature is enabled.
+
+config BT_MESH_PROXY_FILTER_SIZE
+	int "Maximum number of filter entries per Proxy Client"
+	default 16
+	range 1 32767
+	help
+	  This option specifies how many Proxy Filter entries the local
+	  node supports. This helps in reducing unwanted traffic getting sent to
+	  the proxy client. This value is application specific and should be large
+	  enough so that proxy client can communicate with several devices through
+	  this proxy server node using the default accept list filter type.
+
+endif # BT_MESH_GATT_PROXY
+
+config BT_MESH_PROXY_CLIENT
+	bool "Proxy client support"
+	select BT_GATT_CLIENT
+	select BT_MESH_GATT_CLIENT
+	depends on BT_CENTRAL
+	help
+	  This option enables support for the Mesh GATT Proxy Client,
+	  i.e. the ability to act as a proxy between a Mesh GATT Service
+	  and a Mesh network.
+
+endmenu # Proxy
+
+choice BT_MESH_CRYPTO_LIB
+	prompt "Crypto library:"
+	default BT_MESH_USES_TFM_PSA if BUILD_WITH_TFM
+	default BT_MESH_USES_TINYCRYPT
+	help
+	  Crypto library selection for mesh security.
+
+config BT_MESH_USES_TINYCRYPT
+	bool "TinyCrypt"
+	select TINYCRYPT
+	select TINYCRYPT_AES
+	select TINYCRYPT_AES_CMAC
+	select TINYCRYPT_ECC_DH
+	select TINYCRYPT_SHA256
+	select TINYCRYPT_SHA256_HMAC
+	select BT_HOST_CCM
+	help
+	  Use TinyCrypt library to perform crypto operations.
+
+config BT_MESH_USES_MBEDTLS_PSA
+	bool "mbed TLS PSA [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	select MBEDTLS
+	select MBEDTLS_ZEPHYR_ENTROPY
+	select MBEDTLS_PSA_CRYPTO_C
+	select MBEDTLS_MAC_CMAC_ENABLED
+	select MBEDTLS_CIPHER_AES_ENABLED
+	select MBEDTLS_AES_ROM_TABLES
+	select MBEDTLS_CIPHER_CCM_ENABLED
+	select MBEDTLS_ECP_C
+	select MBEDTLS_ECDH_C
+	select MBEDTLS_ECDSA_C
+	select MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
+	select MBEDTLS_ECP_DP_SECP256R1_ENABLED
+	select MBEDTLS_PK_WRITE_C
+	help
+	  Use mbed TLS library to perform crypto operations. Support of
+	  mbed TLS and PSA is experimental and only BabbleSim tests were run.
+	  Mbed TLS still does not support ITS (internal trust storage) based
+	  on Zephyr's settings subsystem.
+	  Not possible to use for embedded devices yet.
+
+config BT_MESH_USES_TFM_PSA
+	bool "Use TF-M PSA [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	depends on BUILD_WITH_TFM
+	help
+	  Use TF-M that implements PSA security framework. Support of TF-M is
+	  experimental. It is only possible to use with platforms that TF-M supports.
+	  For more platform details see TF-M documentation.
+
+endchoice
+
+if BT_MESH_USES_MBEDTLS_PSA || BT_MESH_USES_TFM_PSA
+
+config BT_MESH_PSA_KEY_ID_USER_MIN_OFFSET
+	int "Offset of BLE Mesh key id range regarding PSA_KEY_ID_USER_MIN"
+	default 0
+	help
+	  The PSA specification mandates to set key identifiers for keys
+	  with persistent lifetime. The users of the PSA API is responsible
+	  (BLE Mesh is user of PSA API) to provide correct and unique identifiers.
+	  The BLE Mesh identifier range should be between PSA_KEY_ID_USER_MIN and
+	  PSA_KEY_ID_USER_MAX. BLE Mesh requires two ids for each subnetwork, two ids
+	  for each application key, and two ids for the device key and device key candidate.
+	  It should consider the Mesh Configuration Database instances if database enabled.
+
+endif # BT_MESH_USES_MBEDTLS_PSA || BT_MESH_USES_TFM_PSA
 
 config BT_MESH_BEACON_ENABLED
 	bool "Secure network beacon enabled"
@@ -772,7 +776,50 @@ config BT_MESH_BEACON_ENABLED
 	  Controls whether the Secure network beacon feature is enabled by
 	  default. Can be changed through runtime configuration.
 
-config BT_MESH_LOW_POWER
+menu "IV Index & Sequence number"
+
+config BT_MESH_IV_UPDATE_TEST
+	bool "Test the IV Update Procedure"
+	help
+	  This option removes the 96 hour limit of the IV Update
+	  Procedure and lets the state be changed at any time.
+
+config BT_MESH_IV_UPDATE_SEQ_LIMIT
+	hex "Sequence number limit to start iv update"
+	default 0x800000
+	range 0x000001 0xFFFFFE
+	help
+	  This option specifies the sequence number value to start iv update.
+
+config BT_MESH_IVU_DIVIDER
+	int "Divider for IV Update state refresh timer"
+	default 4
+	range 2 96
+	help
+	  When the IV Update state enters Normal operation or IV Update
+	  in Progress, we need to keep track of how many hours has passed
+	  in the state, since the specification requires us to remain in
+	  the state at least for 96 hours (Update in Progress has an
+	  additional upper limit of 144 hours).
+
+	  In order to fulfill the above requirement, even if the node might
+	  be powered off once in a while, we need to store persistently
+	  how many hours the node has been in the state. This doesn't
+	  necessarily need to happen every hour (thanks to the flexible
+	  duration range). The exact cadence will depend a lot on the
+	  ways that the node will be used and what kind of power source it
+	  has.
+
+	  Since there is no single optimal answer, this configuration
+	  option allows specifying a divider, i.e. how many intervals
+	  the 96 hour minimum gets split into. After each interval the
+	  duration that the node has been in the current state gets
+	  stored to flash. E.g. the default value of 4 means that the
+	  state is saved every 24 hours (96 / 4).
+
+endmenu # IV Index & Sequence number
+
+menuconfig BT_MESH_LOW_POWER
 	bool "Support for Low Power features"
 	help
 	  Enable this option to be able to act as a Low Power Node.
@@ -900,7 +947,7 @@ config BT_MESH_LPN_SUB_ALL_NODES_ADDR
 
 endif # BT_MESH_LOW_POWER
 
-config BT_MESH_FRIEND
+menuconfig BT_MESH_FRIEND
 	bool "Support for acting as a Friend Node"
 	help
 	  Enable this option to be able to act as a Friend Node.
@@ -908,11 +955,12 @@ config BT_MESH_FRIEND
 if BT_MESH_FRIEND
 
 config BT_MESH_FRIEND_ENABLED
-	bool "Friend feature enabled"
+	bool "Friend feature enabled by default"
 	default y
 	help
-	  Controls whether the Friend feature is enabled by default. Can be
-	  changed through runtime configuration.
+	  Controls whether the Friend feature is enabled by default when the
+	  device boots up for the first time or unprovisioned. Can be changed
+	  at runtime using bt_mesh_friend_set() function.
 
 config BT_MESH_FRIEND_RECV_WIN
 	int "Friend Receive Window"
@@ -968,40 +1016,6 @@ config BT_MESH_FRIEND_ADV_LATENCY
 
 endif # BT_MESH_FRIEND
 
-config BT_MESH_CFG_CLI
-	bool "Support for Configuration Client Model"
-	help
-	  Enable support for the configuration client model.
-
-if BT_MESH_CFG_CLI
-
-config BT_MESH_CFG_CLI_TIMEOUT
-	int "Config Client model timeout in milliseconds"
-	default 5000
-	help
-	  This timeout controls how long config client waits for a response
-	  message to arrive. This value can be changed at runtime using
-	  @ref bt_mesh_cfg_cli_timeout_set.
-
-endif # BT_MESH_CFG_CLI
-
-config BT_MESH_HEALTH_CLI
-	bool "Support for Health Client Model"
-	help
-	  Enable support for the health client model.
-
-if BT_MESH_HEALTH_CLI
-
-config BT_MESH_HEALTH_CLI_TIMEOUT
-	int "Health Client model timeout in milliseconds"
-	default 2000
-	help
-	  This timeout controls how long health client waits for a response
-	  message to arrive. This value can be changed at runtime using
-	  @ref bt_mesh_health_cli_timeout_set.
-
-endif # BT_MESH_HEALTH_CLI
-
 menuconfig BT_MESH_V1d1
 	bool "Bluetooth mesh v1.1 support [EXPERIMENTAL]"
 	select EXPERIMENTAL
@@ -1010,6 +1024,13 @@ menuconfig BT_MESH_V1d1
 	  is backward compatible with v1.0.1. The stack cannot be qualified
 	  with this option enabled because the Bluetooth mesh v1.1 specification
 	  is in a draft state.
+
+config BT_MESH_ECDH_P256_CMAC_AES128_AES_CCM
+	bool "Support CMAC AES128 for OOB authentication" if BT_MESH_V1d1
+	depends on BT_MESH_PROV
+	default y
+	help
+	  Enable this option to support CMAC AES128 for OOB authentication.
 
 if BT_MESH_V1d1
 
@@ -1562,42 +1583,51 @@ endmenu
 
 endif # BT_MESH_V1d1
 
-# Configuration options for 1.0.1 transport layer
-if !BT_MESH_V1d1
+menu "Capabilities"
 
-config BT_MESH_TX_SEG_RETRANS_COUNT
-	int "Transport message segment retransmit attempts"
-	default 4
-	range 1 8
+config BT_MESH_SUBNET_COUNT
+	int "Maximum number of mesh subnets per network"
+	default 1
+	range 1 4096
 	help
-	  Maximum number of transport message segment retransmit attempts
-	  for outgoing segment message.
+	  This option specifies how many subnets a Mesh network can
+	  participate in at the same time.
 
-config BT_MESH_TX_SEG_RETRANS_TIMEOUT_UNICAST
-	int "Transport message segment retransmit interval for unicast messages"
-	default 400
-	range 200 500
+config BT_MESH_APP_KEY_COUNT
+	int "Maximum number of application keys per network"
+	default 1
+	range 1 4096
 	help
-	  Maximum time of retransmit segment message to unicast address.
+	  This option specifies how many application keys the device can
+	  store per network.
 
-config BT_MESH_TX_SEG_RETRANS_TIMEOUT_GROUP
-	int "Transport message segment retransmit interval for group messages"
-	default 50
-	range 20 200
+config BT_MESH_MODEL_KEY_COUNT
+	int "Maximum number of application keys per model"
+	default 1
+	range 1 4096
 	help
-	  Maximum time of retransmit segment message to group address.
+	  This option specifies how many application keys each model can
+	  at most be bound to.
 
-endif #!BT_MESH_V1d1
-
-rsource "shell/Kconfig"
-
-config BT_MESH_MODEL_EXTENSIONS
-	bool "Support for Model extensions"
+config BT_MESH_MODEL_GROUP_COUNT
+	int "Maximum number of group address subscriptions per model"
+	default 1
+	range 1 4096
 	help
-	  Enable support for the model extension concept, allowing the Access
-	  layer to know about mesh model relationships.
+	  This option specifies how many group addresses each model can
+	  at most be subscribed to.
 
-if BT_SETTINGS
+config BT_MESH_LABEL_COUNT
+	int "Maximum number of Label UUIDs used for Virtual Addresses"
+	default 1
+	range 0 4096
+	help
+	  This option specifies how many Label UUIDs can be stored.
+
+endmenu # Capabilities
+
+menu "Persistent storage"
+	visible if BT_SETTINGS
 
 config BT_MESH_STORE_TIMEOUT
 	int "Delay (in seconds) before storing anything persistently"
@@ -1612,6 +1642,7 @@ config BT_MESH_SEQ_STORE_RATE
 	int "How often the sequence number gets updated in storage"
 	range 0 1000000
 	default 128
+	default 1 if !BT_SETTINGS # To keep compiling the code
 	help
 	  This value defines how often the local sequence number gets
 	  updated in persistent storage (i.e. flash). E.g. a value of 100
@@ -1623,6 +1654,33 @@ config BT_MESH_SEQ_STORE_RATE
 	  will add this number to the last stored one, so that it starts
 	  off with a value that's guaranteed to be larger than the last
 	  one used before power off.
+
+if BT_MESH_RPL_STORAGE_MODE_SETTINGS && BT_SETTINGS
+
+config BT_MESH_RPL_STORE_TIMEOUT
+	int "Minimum interval after which unsaved RPL and SRPL entries are updated in the settings subsystem"
+	range -1 1000000
+	default 5
+	help
+	  This value defines time in seconds until unsaved RPL and SRPL entries
+	  are written to the persistent storage. Setting this value
+	  to a large number may lead to security vulnerabilities if a node
+	  gets powered off before the timer is fired. When flash is used
+	  as the persistent storage setting this value to a low number
+	  may wear out flash sooner or later. However, if the RPL gets
+	  updated infrequently a value as low as 0 (write immediately)
+	  may make sense. Setting this value to -1 will disable this timer.
+	  In this case, a user is responsible to store pending RPL entries
+	  using @ref bt_mesh_rpl_pending_store. In the mean time, when
+	  IV Index is updated, the outdated RPL entries will still be
+	  stored by @ref BT_MESH_STORE_TIMEOUT. Finding the right balance
+	  between this timeout and calling @ref bt_mesh_rpl_pending_store
+	  may reduce a risk of security vulnerability and flash wear out.
+	  Failure to store the RPL and becoming vulnerable after reboot
+	  will cause the device to not perform the replay protection
+	  required by the spec.
+
+endif # BT_MESH_RPL_STORAGE_MODE_SETTINGS && BT_SETTINGS
 
 config BT_MESH_SETTINGS_WORKQ
 	bool "Store the Bluetooth mesh settings in a separate work queue"
@@ -1652,18 +1710,27 @@ config BT_MESH_SETTINGS_WORKQ_STACK_SIZE
 	  Size of the settings workqueue stack.
 
 endif # BT_MESH_SETTINGS_WORKQ
-endif # BT_SETTINGS
 
-if BT_MESH_LOG_LEVEL_DBG
+endmenu # Persistent storage
 
-config BT_MESH_DEBUG_USE_ID_ADDR
-	bool "Use identity address for all advertising"
+rsource "shell/Kconfig"
+
+if BT_CONN
+
+config BT_MESH_MAX_CONN
+	int "Maximum number of simultaneous Bluetooth connections"
+	default BT_MAX_CONN
+	range 1 BT_MAX_CONN
 	help
-	  This option forces the usage of the local identity address for
-	  all advertising. This can be a help for debugging (analyzing
-	  traces), however it should never be enabled for a production
-	  build as it compromises the privacy of the device.
+	  Maximum number of simultaneous Bluetooth connections that the Bluetooth
+	  mesh stack can use.
 
-endif # BT_MESH_LOG_LEVEL_DBG
+endif # BT_CONN
+
+config BT_MESH_SELF_TEST
+	bool "Perform self-tests"
+	help
+	  This option adds extra self-tests which are run every time
+	  mesh networking is initialized.
 
 endif # BT_MESH

--- a/subsys/bluetooth/mesh/TODO
+++ b/subsys/bluetooth/mesh/TODO
@@ -1,6 +1,0 @@
-Bluetooth mesh implementation tasks
-===================================
-
- * Ability to act as provisioner
-
- * More generally useful models from the Model Specification

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -57,13 +57,6 @@ LOG_MODULE_REGISTER(bt_mesh_net);
 #define SRC(pdu)           (sys_get_be16(&(pdu)[5]))
 #define DST(pdu)           (sys_get_be16(&(pdu)[7]))
 
-/** Define CONFIG_BT_MESH_SEQ_STORE_RATE even if settings are disabled to
- * compile the code.
- */
-#ifndef CONFIG_BT_SETTINGS
-#define CONFIG_BT_MESH_SEQ_STORE_RATE 1
-#endif
-
 /* Mesh network information for persistent storage. */
 struct net_val {
 	uint16_t primary_addr;


### PR DESCRIPTION
Current structure of Bluetooth Mesh Kconfig options is quite messy. This makes impossible to understand which configuration belongs to which feature. Especially when using interactive Kconfig interface, like menuconfig or guiconfig.

This commit restructures the options grouping them by protocol layer they belong to (Network, Transport, Access, etc.), or specific feature (LPN, Friend, Proxy, Relay, etc.), or implementation (Advertiser, Shell, Persistent storage). Amount of supported keys, subnets, group addresses and labels are grouped under Capabilities menu. Generic options that don't fall to any category are kept at the root menu. For better visibility, if a specific feature or layer has more than 1 option, they are hidden under menu.