### PR TITLE
samples/synchronization: Fix outdated comments and code structure

### DIFF
--- a/samples/synchronization/src/main.c
+++ b/samples/synchronization/src/main.c
@@ -12,8 +12,8 @@
 /*
  * The synchronization demo has two threads that utilize semaphores and sleeping
  * to take turns printing a greeting message at a controlled rate. The demo
- * shows only the dynamic approach for spawning a thread. Alternatively,
- * a thread can be declared at compile time by calling K_THREAD_DEFINE.
+ * shows both the static and dynamic approaches for spawning a thread; a real
+ * world application would likely use the static approach for both threads.
  */
 
 #define PIN_THREADS (IS_ENABLED(CONFIG_SMP) && IS_ENABLED(CONFIG_SCHED_CPU_MASK))
@@ -33,7 +33,7 @@
  * @param my_sem       thread's own semaphore
  * @param other_sem    other thread's semaphore
  */
-void helloLoop(const char *my_name,
+void hello_loop(const char *my_name,
 		   struct k_sem *my_sem, struct k_sem *other_sem)
 {
 	const char *tname;
@@ -68,62 +68,52 @@ void helloLoop(const char *my_name,
 }
 
 /* define semaphores */
-K_SEM_DEFINE(threadA_sem, 1, 1);	/* starts off "available" */
-K_SEM_DEFINE(threadB_sem, 0, 1);	/* starts off "not available" */
+K_SEM_DEFINE(thread_a_sem, 1, 1);	/* starts off "available" */
+K_SEM_DEFINE(thread_b_sem, 0, 1);	/* starts off "not available" */
 
-/* threadA is a dynamic thread that is spawned in main */
-void threadA(void *dummy1, void *dummy2, void *dummy3)
+/* thread_a is a dynamic thread that is spawned in main */
+void thread_a_entry_point(void *dummy1, void *dummy2, void *dummy3)
 {
 	ARG_UNUSED(dummy1);
 	ARG_UNUSED(dummy2);
 	ARG_UNUSED(dummy3);
 
-	/* invoke routine to ping-pong hello messages with threadB */
-	helloLoop(__func__, &threadA_sem, &threadB_sem);
+	/* invoke routine to ping-pong hello messages with thread_b */
+	hello_loop(__func__, &thread_a_sem, &thread_b_sem);
 }
+K_THREAD_STACK_DEFINE(thread_a_stack_area, STACKSIZE);
+static struct k_thread thread_a_data;
 
-K_THREAD_STACK_DEFINE(threadB_stack_area, STACKSIZE);
-static struct k_thread threadB_data;
-
-/* threadB is a dynamic thread that is spawned in main */
-void threadB(void *dummy1, void *dummy2, void *dummy3)
+/* thread_b is a static thread spawned immediately */
+void thread_b_entry_point(void *dummy1, void *dummy2, void *dummy3)
 {
 	ARG_UNUSED(dummy1);
 	ARG_UNUSED(dummy2);
 	ARG_UNUSED(dummy3);
 
-	/* invoke routine to ping-pong hello messages with threadA */
-	helloLoop(__func__, &threadB_sem, &threadA_sem);
+	/* invoke routine to ping-pong hello messages with thread_a */
+	hello_loop(__func__, &thread_b_sem, &thread_a_sem);
 }
-
-K_THREAD_STACK_DEFINE(threadA_stack_area, STACKSIZE);
-static struct k_thread threadA_data;
+K_THREAD_DEFINE(thread_b, STACKSIZE,
+				thread_b_entry_point, NULL, NULL, NULL,
+				PRIORITY, 0, 0);
+extern const k_tid_t thread_b;
 
 int main(void)
 {
-	k_thread_create(&threadA_data, threadA_stack_area,
-			K_THREAD_STACK_SIZEOF(threadA_stack_area),
-			threadA, NULL, NULL, NULL,
+	k_thread_create(&thread_a_data, thread_a_stack_area,
+			K_THREAD_STACK_SIZEOF(thread_a_stack_area),
+			thread_a_entry_point, NULL, NULL, NULL,
 			PRIORITY, 0, K_FOREVER);
-	k_thread_name_set(&threadA_data, "thread_a");
+	k_thread_name_set(&thread_a_data, "thread_a");
+
 #if PIN_THREADS
 	if (arch_num_cpus() > 1) {
-		k_thread_cpu_pin(&threadA_data, 0);
+		k_thread_cpu_pin(&thread_a_data, 0);
+		k_thread_cpu_pin(thread_b, 1);
 	}
 #endif
 
-	k_thread_create(&threadB_data, threadB_stack_area,
-			K_THREAD_STACK_SIZEOF(threadB_stack_area),
-			threadB, NULL, NULL, NULL,
-			PRIORITY, 0, K_FOREVER);
-	k_thread_name_set(&threadB_data, "thread_b");
-#if PIN_THREADS
-	if (arch_num_cpus() > 1) {
-		k_thread_cpu_pin(&threadB_data, 1);
-	}
-#endif
-
-	k_thread_start(&threadA_data);
-	k_thread_start(&threadB_data);
+	k_thread_start(&thread_a_data);
 	return 0;
 }


### PR DESCRIPTION
This commit has no functional changes. It makes the comments up to date with the code and changes the code structure to ensure consistency. 

These inconsistencies were introduced when the static thread definition was replaced with dynamic, but the comments remained unchanged.

 - Fixed outdated comments about the static approach that were not corresponding to the code.
 - Rearrange thread definitions, to obtain similar code structure for both threads.