### PR TITLE
cmake: kconfig: Minor command-line assignment improvements

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1552,39 +1552,61 @@ endfunction()
 #                     CMake namespace.
 function(import_kconfig prefix kconfig_fragment)
   cmake_parse_arguments(IMPORT_KCONFIG "" "TARGET" "" ${ARGN})
-  # Parse the lines prefixed with 'prefix' in ${kconfig_fragment}
   file(
     STRINGS
     ${kconfig_fragment}
     DOT_CONFIG_LIST
-    REGEX "^${prefix}"
     ENCODING "UTF-8"
   )
 
-  foreach (CONFIG ${DOT_CONFIG_LIST})
-    # CONFIG could look like: CONFIG_NET_BUF=y
+  foreach (LINE ${DOT_CONFIG_LIST})
+    if("${LINE}" MATCHES "^(${prefix}[^=]+)=([ymn]|.+$)")
+      # Matched a normal value assignment, like: CONFIG_NET_BUF=y
+      # Note: if the value starts with 'y', 'm', or 'n', then we assume it's a
+      # bool or tristate (we don't know the type from <kconfig_fragment> alone)
+      # and we only match the first character. This is to align with Kconfiglib.
+      set(CONF_VARIABLE_NAME "${CMAKE_MATCH_1}")
+      set(CONF_VARIABLE_VALUE "${CMAKE_MATCH_2}")
+    elseif("${LINE}" MATCHES "^# (${prefix}[^ ]+) is not set")
+      # Matched something like: # CONFIG_FOO is not set
+      # This is interpreted as: CONFIG_FOO=n
+      set(CONF_VARIABLE_NAME "${CMAKE_MATCH_1}")
+      set(CONF_VARIABLE_VALUE "n")
+    else()
+      # Ignore this line.
+      # Note: we also ignore assignments which don't have the desired <prefix>.
+      continue()
+    endif()
 
-    # Match the first part, the variable name
-    string(REGEX MATCH "[^=]+" CONF_VARIABLE_NAME ${CONFIG})
+    # If the provided value is n, then the corresponding CMake variable or
+    # target property will be unset.
+    if("${CONF_VARIABLE_VALUE}" STREQUAL "n")
+      if(DEFINED IMPORT_KCONFIG_TARGET)
+        set_property(TARGET ${IMPORT_KCONFIG_TARGET} PROPERTY "${CONF_VARIABLE_NAME}")
+      else()
+        unset("${CONF_VARIABLE_NAME}" PARENT_SCOPE)
+      endif()
+      list(REMOVE_ITEM keys "${CONF_VARIABLE_NAME}")
+      continue()
+    endif()
 
-    # Match the second part, variable value
-    string(REGEX MATCH "=(.+$)" CONF_VARIABLE_VALUE ${CONFIG})
-    # The variable name match we just did included the '=' symbol. To just get the
-    # part on the RHS we use match group 1
-    set(CONF_VARIABLE_VALUE ${CMAKE_MATCH_1})
-
-    if("${CONF_VARIABLE_VALUE}" MATCHES "^\"(.*)\"$") # Is surrounded by quotes
+    # Otherwise, the variable/property will be set to the provided value.
+    # For string values, we also remove the surrounding quotation marks.
+    if("${CONF_VARIABLE_VALUE}" MATCHES "^\"(.*)\"$")
       set(CONF_VARIABLE_VALUE ${CMAKE_MATCH_1})
     endif()
 
     if(DEFINED IMPORT_KCONFIG_TARGET)
-      set_property(TARGET ${IMPORT_KCONFIG_TARGET} APPEND PROPERTY "kconfigs" "${CONF_VARIABLE_NAME}")
       set_property(TARGET ${IMPORT_KCONFIG_TARGET} PROPERTY "${CONF_VARIABLE_NAME}" "${CONF_VARIABLE_VALUE}")
     else()
       set("${CONF_VARIABLE_NAME}" "${CONF_VARIABLE_VALUE}" PARENT_SCOPE)
     endif()
     list(APPEND keys "${CONF_VARIABLE_NAME}")
   endforeach()
+
+  if(DEFINED IMPORT_KCONFIG_TARGET)
+    set_property(TARGET ${IMPORT_KCONFIG_TARGET} PROPERTY "kconfigs" "${keys}")
+  endif()
 
   list(LENGTH IMPORT_KCONFIG_UNPARSED_ARGUMENTS unparsed_length)
   if(unparsed_length GREATER 0)


### PR DESCRIPTION
Summary:

1. Preserve boolean (=n) assignments from command-line.
2. Discard invalid assignments from command-line.
3. Avoid writing a new `.config` when nothing changes.