### PR TITLE
Bluetooth: Controller: Fix coverity issue 318804

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -863,7 +863,7 @@ isr_rx_next_subevent:
 
 		/* Adjust nesn when flushing Rx */
 		/* FIXME: When Flush Timeout is implemented */
-		if (cis_lll->tx.bn_curr <= cis_lll->rx.bn) {
+		if (cis_lll->rx.bn_curr <= cis_lll->rx.bn) {
 			lll_flush_rx(cis_lll);
 		}
 


### PR DESCRIPTION
[Coverity CID: 318804] Copy-paste error in
subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c

Fixes #59512.