### PR TITLE
tests: Bluetooth: ascs: Fix build warning

### DIFF
--- a/tests/bluetooth/audio/mocks/src/pacs.c
+++ b/tests/bluetooth/audio/mocks/src/pacs.c
@@ -13,7 +13,7 @@
 #define PACS_FFF_FAKES_LIST(FAKE)                                                                  \
 	FAKE(bt_pacs_cap_foreach)                                                                  \
 
-static struct bt_audio_codec_cfg lc3_codec =
+static struct bt_audio_codec_cap lc3_codec =
 	BT_AUDIO_CODEC_LC3(BT_AUDIO_CODEC_LC3_FREQ_ANY, BT_AUDIO_CODEC_LC3_DURATION_10,
 		     BT_AUDIO_CODEC_LC3_CHAN_COUNT_SUPPORT(1), 40u, 120u, 1u,
 		     (BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL | BT_AUDIO_CONTEXT_TYPE_MEDIA));


### PR DESCRIPTION
This fixes incompatible pointer type warning.