### PR TITLE
driver: gpio: fix shell blink command

### DIFF
--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -157,6 +157,9 @@ static int cmd_gpio_blink(const struct shell *sh,
 		shell_fprintf(sh, SHELL_NORMAL, "Blinking port %s index %d.", argv[1], index);
 		shell_fprintf(sh, SHELL_NORMAL, " Hit any key to exit");
 
+		/* dummy read to clear any pending input */
+		(void)sh->iface->api->read(sh->iface, &data, sizeof(data), &count);
+
 		while (true) {
 			(void)sh->iface->api->read(sh->iface, &data, sizeof(data), &count);
 			if (count != 0) {


### PR DESCRIPTION
The blink command should blink until the user presses a key, however on some systems a pending keypress is present when entering the loop causing it to immediate exit before getting a chance to blink.

Add a dummy read to clear the buffer before starting the blink loop.