### PR TITLE
scripts: compliance: Fix handling of integer node items

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -440,9 +440,13 @@ deliberately adding new entries, then bump the 'max_top_items' variable in
         # Checks that no symbols are (re)defined in defconfigs.
 
         for node in kconf.node_iter():
+            # 'kconfiglib' is global
+            # pylint: disable=undefined-variable
             if "defconfig" in node.filename and (node.prompt or node.help):
+                name = (node.item.name if node.item not in
+                        (kconfiglib.MENU, kconfiglib.COMMENT) else str(node))
                 self.failure(f"""
-Kconfig node '{node.item.name}' found with prompt or help in {node.filename}.
+Kconfig node '{name}' found with prompt or help in {node.filename}.
 Options must not be defined in defconfig files.
 """)
                 continue


### PR DESCRIPTION
Some node items in Kconfig can be kconfiglib.MENU or kconfiglib.COMMENT. Those are integers and thus do not contain a node.item.name field. Handle those separately to avoid hitting the followig exception:

```
Traceback (most recent call last):
  File "/home/runner/work/zephyr/zephyr/./scripts/ci/check_compliance.py", line 1307, in main
    n_fails = _main(args)
  File "/home/runner/work/zephyr/zephyr/./scripts/ci/check_compliance.py", line 1242, in _main
    test.run()
  File "/home/runner/work/zephyr/zephyr/./scripts/ci/check_compliance.py", line 277, in run
    self.check_no_redefined_in_defconfig(kconf)
  File "/home/runner/work/zephyr/zephyr/./scripts/ci/check_compliance.py", line 445, in check_no_redefined_in_defconfig
    Kconfig node '{node.item.name}' found with prompt or help in {node.filename}.
AttributeError: 'int' object has no attribute 'name'
```

Seen in #58454.