### PR TITLE
Fix potential functions redefinition for IPC subsystem and example

### DIFF
--- a/samples/subsys/ipc/openamp/src/main.c
+++ b/samples/subsys/ipc/openamp/src/main.c
@@ -63,27 +63,26 @@ static struct rpmsg_virtio_device rvdev;
 static struct metal_io_region *io;
 static struct virtqueue *vq[2];
 
-static unsigned char virtio_get_status(struct virtio_device *vdev)
+static unsigned char ipc_virtio_get_status(struct virtio_device *vdev)
 {
 	return VIRTIO_CONFIG_STATUS_DRIVER_OK;
 }
 
-static void virtio_set_status(struct virtio_device *vdev, unsigned char status)
+static void ipc_virtio_set_status(struct virtio_device *vdev, unsigned char status)
 {
 	sys_write8(status, VDEV_STATUS_ADDR);
 }
 
-static uint32_t virtio_get_features(struct virtio_device *vdev)
+static uint32_t ipc_virtio_get_features(struct virtio_device *vdev)
 {
 	return 1 << VIRTIO_RPMSG_F_NS;
 }
 
-static void virtio_set_features(struct virtio_device *vdev,
-				uint32_t features)
+static void ipc_virtio_set_features(struct virtio_device *vdev, uint32_t features)
 {
 }
 
-static void virtio_notify(struct virtqueue *vq)
+static void ipc_virtio_notify(struct virtqueue *vq)
 {
 #if defined(CONFIG_SOC_MPS2_AN521) || \
 	defined(CONFIG_SOC_V2M_MUSCA_B1)
@@ -98,11 +97,11 @@ static void virtio_notify(struct virtqueue *vq)
 }
 
 struct virtio_dispatch dispatch = {
-	.get_status = virtio_get_status,
-	.set_status = virtio_set_status,
-	.get_features = virtio_get_features,
-	.set_features = virtio_set_features,
-	.notify = virtio_notify,
+	.get_status = ipc_virtio_get_status,
+	.set_status = ipc_virtio_set_status,
+	.get_features = ipc_virtio_get_features,
+	.set_features = ipc_virtio_set_features,
+	.notify = ipc_virtio_notify,
 };
 
 static K_SEM_DEFINE(data_sem, 0, 1);
@@ -301,7 +300,7 @@ int main(void)
  */
 int init_status_flag(void)
 {
-	virtio_set_status(NULL, 0);
+	ipc_virtio_set_status(NULL, 0);
 
 	return 0;
 }

--- a/subsys/ipc/ipc_service/lib/ipc_static_vrings.c
+++ b/subsys/ipc/ipc_service/lib/ipc_static_vrings.c
@@ -12,7 +12,7 @@
 #define RPMSG_VQ_0		(0) /* TX virtqueue queue index */
 #define RPMSG_VQ_1		(1) /* RX virtqueue queue index */
 
-static void virtio_notify(struct virtqueue *vq)
+static void ipc_virtio_notify(struct virtqueue *vq)
 {
 	struct ipc_static_vrings *vr;
 
@@ -23,12 +23,12 @@ static void virtio_notify(struct virtqueue *vq)
 	}
 }
 
-static void virtio_set_features(struct virtio_device *vdev, uint32_t features)
+static void ipc_virtio_set_features(struct virtio_device *vdev, uint32_t features)
 {
 	/* No need for implementation */
 }
 
-static void virtio_set_status(struct virtio_device *p_vdev, unsigned char status)
+static void ipc_virtio_set_status(struct virtio_device *p_vdev, unsigned char status)
 {
 	struct ipc_static_vrings *vr;
 
@@ -42,12 +42,12 @@ static void virtio_set_status(struct virtio_device *p_vdev, unsigned char status
 	sys_cache_data_flush_range((void *) vr->status_reg_addr, sizeof(status));
 }
 
-static uint32_t virtio_get_features(struct virtio_device *vdev)
+static uint32_t ipc_virtio_get_features(struct virtio_device *vdev)
 {
 	return BIT(VIRTIO_RPMSG_F_NS);
 }
 
-static unsigned char virtio_get_status(struct virtio_device *p_vdev)
+static unsigned char ipc_virtio_get_status(struct virtio_device *p_vdev)
 {
 	struct ipc_static_vrings *vr;
 	uint8_t ret;
@@ -65,11 +65,11 @@ static unsigned char virtio_get_status(struct virtio_device *p_vdev)
 }
 
 const static struct virtio_dispatch dispatch = {
-	.get_status = virtio_get_status,
-	.get_features = virtio_get_features,
-	.set_status = virtio_set_status,
-	.set_features = virtio_set_features,
-	.notify = virtio_notify,
+	.get_status = ipc_virtio_get_status,
+	.get_features = ipc_virtio_get_features,
+	.set_status = ipc_virtio_set_status,
+	.set_features = ipc_virtio_set_features,
+	.notify = ipc_virtio_notify,
 };
 
 static int libmetal_setup(struct ipc_static_vrings *vr)

--- a/subsys/ipc/rpmsg_service/rpmsg_backend.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_backend.c
@@ -92,7 +92,7 @@ static struct virtqueue *vq[2];
 
 static struct k_work ipm_work;
 
-static unsigned char virtio_get_status(struct virtio_device *vdev)
+static unsigned char ipc_virtio_get_status(struct virtio_device *vdev)
 {
 #if MASTER
 	return VIRTIO_CONFIG_STATUS_DRIVER_OK;
@@ -101,22 +101,21 @@ static unsigned char virtio_get_status(struct virtio_device *vdev)
 #endif
 }
 
-static void virtio_set_status(struct virtio_device *vdev, unsigned char status)
+static void ipc_virtio_set_status(struct virtio_device *vdev, unsigned char status)
 {
 	sys_write8(status, VDEV_STATUS_ADDR);
 }
 
-static uint32_t virtio_get_features(struct virtio_device *vdev)
+static uint32_t ipc_virtio_get_features(struct virtio_device *vdev)
 {
 	return BIT(VIRTIO_RPMSG_F_NS);
 }
 
-static void virtio_set_features(struct virtio_device *vdev,
-				uint32_t features)
+static void ipc_virtio_set_features(struct virtio_device *vdev, uint32_t features)
 {
 }
 
-static void virtio_notify(struct virtqueue *vq)
+static void ipc_virtio_notify(struct virtqueue *vq)
 {
 	int status;
 
@@ -143,11 +142,11 @@ static void virtio_notify(struct virtqueue *vq)
 }
 
 const struct virtio_dispatch dispatch = {
-	.get_status = virtio_get_status,
-	.set_status = virtio_set_status,
-	.get_features = virtio_get_features,
-	.set_features = virtio_set_features,
-	.notify = virtio_notify,
+	.get_status = ipc_virtio_get_status,
+	.set_status = ipc_virtio_set_status,
+	.get_features = ipc_virtio_get_features,
+	.set_features = ipc_virtio_set_features,
+	.notify = ipc_virtio_notify,
 };
 
 static void ipm_callback_process(struct k_work *work)
@@ -285,7 +284,7 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev)
  */
 int init_status_flag(void)
 {
-	virtio_set_status(NULL, 0);
+	ipc_virtio_set_status(NULL, 0);
 
 	return 0;
 }


### PR DESCRIPTION
open-amp CI Zephyr test fails on this PR: https://github.com/OpenAMP/open-amp/pull/495

The issue comes from the redefinition of functions in Zephy IPC subsystem/applications that reuses the `virtio_` prefix for local function.

Fix this by replacing by `ipc_virtio_` prefix in local functions.