### PR TITLE
boards/qemu_x86: Fix emulated boards and their RTCs

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -116,6 +116,11 @@
 		compatible = "zephyr,ieee802154-uart-pipe";
 	};
 
+	rtc: rtc {
+		status = "okay";
+		compatible = "zephyr,rtc-emul";
+		alarms-count = <2>;
+	};
 };
 
 &uart0 {

--- a/boards/x86/qemu_x86/qemu_x86.yaml
+++ b/boards/x86/qemu_x86/qemu_x86.yaml
@@ -14,5 +14,6 @@ supported:
   - netif:serial-net
   - eeprom
   - can
+  - rtc
 testing:
   default: true

--- a/boards/x86/qemu_x86/qemu_x86_64.yaml
+++ b/boards/x86/qemu_x86/qemu_x86_64.yaml
@@ -9,6 +9,7 @@ simulation: qemu
 supported:
   - can
   - smp
+  - rtc
 testing:
   default: true
   ignore_tags:

--- a/dts/x86/intel/ia32.dtsi
+++ b/dts/x86/intel/ia32.dtsi
@@ -67,16 +67,5 @@
 
 			status = "disabled";
 		};
-
-		rtc: counter: rtc@70 {
-			compatible = "motorola,mc146818";
-			reg = <0x70 0x0D 0x71 0x0D>;
-			interrupts = <8 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
-			interrupt-parent = <&intc>;
-			alarms-count = <1>;
-
-			status = "okay";
-		};
-
 	};
 };

--- a/tests/drivers/rtc/rtc_api/src/test_update_callback.c
+++ b/tests/drivers/rtc/rtc_api/src/test_update_callback.c
@@ -10,46 +10,63 @@
 #include <zephyr/sys/atomic.h>
 
 static const struct device *rtc = DEVICE_DT_GET(DT_ALIAS(rtc));
-static atomic_t callback_called_counter;
-static atomic_t callback_test_user_data_address;
+static uint32_t callback_called_counter;
+static void *callback_test_user_data_address;
 static uint32_t test_user_data = 0x1234;
+static struct k_spinlock lock;
 
 static void test_rtc_update_callback_handler(const struct device *dev, void *user_data)
 {
-	atomic_inc(&callback_called_counter);
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	atomic_set(&callback_test_user_data_address, (uint32_t)user_data);
+	callback_called_counter++;
+	callback_test_user_data_address = user_data;
+
+	k_spin_unlock(&lock, key);
 }
 
 ZTEST(rtc_api, test_update_callback)
 {
 	int ret;
+	k_spinlock_key_t key;
 	uint32_t counter;
-	uint32_t address;
+	void *address;
 
 	ret = rtc_update_set_callback(rtc, NULL, NULL);
 
-	zassert_true(ret == 0, "Failed to clear and disable update callback");
+	zassert_equal(ret, 0, "Failed to clear and disable update callback");
 
-	atomic_set(&callback_called_counter, 0);
+	key = k_spin_lock(&lock);
+
+	callback_called_counter = 0;
+	address = callback_test_user_data_address;
+
+	k_spin_unlock(&lock, key);
 
 	k_msleep(5000);
 
-	counter = atomic_get(&callback_called_counter);
+	key = k_spin_lock(&lock);
 
-	zassert_true(counter == 0, "Update callback should not have been called");
+	counter = callback_called_counter;
+
+	k_spin_unlock(&lock, key);
+
+	zassert_equal(counter, 0, "Update callback should not have been called");
 
 	ret = rtc_update_set_callback(rtc, test_rtc_update_callback_handler, &test_user_data);
 
-	zassert_true(ret == 0, "Failed to set and enable update callback");
+	zassert_equal(ret, 0, "Failed to set and enable update callback");
 
 	k_msleep(10000);
 
-	counter = atomic_get(&callback_called_counter);
+	key = k_spin_lock(&lock);
 
-	address = atomic_get(&callback_test_user_data_address);
+	counter = callback_called_counter;
+	address = callback_test_user_data_address;
+
+	k_spin_unlock(&lock, key);
 
 	zassert_true(counter < 12 && counter > 8, "Invalid update callback called counter");
 
-	zassert_true(address == ((uint32_t)(&test_user_data)), "Incorrect user data");
+	zassert_equal(address, ((void *)&test_user_data), "Incorrect user data");
 }

--- a/tests/drivers/rtc/rtc_api/testcase.yaml
+++ b/tests/drivers/rtc/rtc_api/testcase.yaml
@@ -2,10 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 tests:
-  drivers.rtc.rtc_api:
+  drivers.rtc.rtc_api.emul:
     tags:
       - drivers
       - rtc
       - api
     filter: dt_alias_exists("rtc")
     depends_on: rtc
+    platform_allow:
+      - native_posix
+      - native_posix_64
+      - qemu_x86
+      - qemu_x86_64
+    integration_platforms:
+      - native_posix
+      - native_posix_64
+      - qemu_x86
+    extra_configs:
+      - CONFIG_RTC_ALARM=y
+      - CONFIG_RTC_UPDATE=y
+      - CONFIG_RTC_CALIBRATION=y


### PR DESCRIPTION
This PR has been created in response to this issue #59448 which identified that the RTC was not behaving as expected on the qemu_x86 board. This PR contains the patch for issue along with an improvement to the test suite to catch similar issues in the future.

The QEMU emulated MC146818 seems to have a bug where it is not able to invoke an interrupt, which has not been caught by the developer who wrote the driver for it, since he was building the driver for a real board with real hardware. The unit tests where not running for the QEMU boards since it's YAML files did not indicate they supported the RTC, which is my mistake, since I didn't realize the QEMU boards had RTC support at all.

The fix suggested by this commit is to replace the QEMU emulated MC146818 it with the emulated RTC, which is currently used for the native posix boards as well.

Furthermore, the yaml files for the emulated boards have been updated to include support for the rtc. The test suite has been updated to only test qemu_x86 and and native_posix during integration testing as the qemu_x86_64 runs in real time, causing the test suite to time out...

This addition revealed that the RTC test suite has a bug where it cant run one of the tests on 64-bit architectures. This has been fixed.