### PR TITLE
posix: Implement pthread_barrieratter functions

### DIFF
--- a/doc/services/portability/posix.rst
+++ b/doc/services/portability/posix.rst
@@ -140,10 +140,10 @@ multiple processes.
     pthread_barrier_destroy(),yes
     pthread_barrier_init(),yes
     pthread_barrier_wait(),yes
-    pthread_barrierattr_destroy(),
-    pthread_barrierattr_getpshared(),
-    pthread_barrierattr_init(),
-    pthread_barrierattr_setpshared(),
+    pthread_barrierattr_destroy(),yes
+    pthread_barrierattr_getpshared(),yes
+    pthread_barrierattr_init(),yes
+    pthread_barrierattr_setpshared(),yes
     pthread_cancel(),yes
     pthread_cleanup_pop(),
     pthread_cleanup_push(),

--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -88,6 +88,7 @@ BUILD_ASSERT(sizeof(pthread_condattr_t) >= sizeof(struct pthread_condattr));
 typedef uint32_t pthread_barrier_t;
 
 typedef struct pthread_barrierattr {
+	int pshared;
 } pthread_barrierattr_t;
 
 typedef uint32_t pthread_rwlockattr_t;

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -297,6 +297,12 @@ static inline int pthread_mutexattr_destroy(pthread_mutexattr_t *m)
 
 #define PTHREAD_BARRIER_SERIAL_THREAD 1
 
+/*
+ *  Barrier attributes - type
+ */
+#define PTHREAD_PROCESS_PRIVATE		0
+#define PTHREAD_PROCESS_PUBLIC		1
+
 /**
  * @brief POSIX threading compatibility API
  *
@@ -323,29 +329,30 @@ int pthread_barrier_destroy(pthread_barrier_t *b);
  * @brief POSIX threading compatibility API
  *
  * See IEEE 1003.1
- *
- * Note that pthread attribute structs are currently noops in Zephyr.
  */
-static inline int pthread_barrierattr_init(pthread_barrierattr_t *b)
-{
-	ARG_UNUSED(b);
-
-	return 0;
-}
+int pthread_barrierattr_init(pthread_barrierattr_t *b);
 
 /**
  * @brief POSIX threading compatibility API
  *
  * See IEEE 1003.1
- *
- * Note that pthread attribute structs are currently noops in Zephyr.
  */
-static inline int pthread_barrierattr_destroy(pthread_barrierattr_t *b)
-{
-	ARG_UNUSED(b);
+int pthread_barrierattr_destroy(pthread_barrierattr_t *b);
 
-	return 0;
-}
+/**
+ * @brief POSIX threading compatibility API
+ *
+ * See IEEE 1003.1
+ */
+int pthread_barrierattr_setpshared(pthread_barrierattr_t *attr, int pshared);
+
+/**
+ * @brief POSIX threading compatibility API
+ *
+ * See IEEE 1003.1
+ */
+int pthread_barrierattr_getpshared(const pthread_barrierattr_t *ZRESTRICT attr,
+				   int *ZRESTRICT pshared);
 
 /* Predicates and setters for various pthread attribute values that we
  * don't support (or always support: the "process shared" attribute
@@ -370,8 +377,6 @@ int pthread_mutexattr_getrobust(const pthread_mutexattr_t * int *);
 int pthread_mutexattr_setprioceiling(pthread_mutexattr_t *, int);
 int pthread_mutexattr_setpshared(pthread_mutexattr_t *, int);
 int pthread_mutexattr_setrobust(pthread_mutexattr_t *, int);
-int pthread_barrierattr_getpshared(const pthread_barrierattr_t *, int *);
-int pthread_barrierattr_setpshared(pthread_barrierattr_t *, int);
 */
 
 /* Base Pthread related APIs */

--- a/lib/posix/barrier.c
+++ b/lib/posix/barrier.c
@@ -161,6 +161,40 @@ int pthread_barrier_destroy(pthread_barrier_t *b)
 	return 0;
 }
 
+int pthread_barrierattr_init(pthread_barrierattr_t *attr)
+{
+	__ASSERT_NO_MSG(attr != NULL);
+
+	attr->pshared = PTHREAD_PROCESS_PRIVATE;
+
+	return 0;
+}
+
+int pthread_barrierattr_setpshared(pthread_barrierattr_t *attr, int pshared)
+{
+	if (pshared != PTHREAD_PROCESS_PRIVATE && pshared != PTHREAD_PROCESS_PUBLIC) {
+		return -EINVAL;
+	}
+
+	attr->pshared = pshared;
+	return 0;
+}
+
+int pthread_barrierattr_getpshared(const pthread_barrierattr_t *restrict attr,
+				   int *restrict pshared)
+{
+	*pshared = attr->pshared;
+
+	return 0;
+}
+
+int pthread_barrierattr_destroy(pthread_barrierattr_t *attr)
+{
+	ARG_UNUSED(attr);
+
+	return 0;
+}
+
 static int pthread_barrier_pool_init(void)
 {
 	int err;

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -743,3 +743,31 @@ ZTEST(posix_apis, test_sched_policy)
 		}
 	}
 }
+
+ZTEST(posix_apis, test_posix_pthread_barrier)
+{
+	int ret, pshared;
+	pthread_barrierattr_t attr;
+
+	ret = pthread_barrierattr_init(&attr);
+	zassert_equal(ret, 0, "pthread_barrierattr_init failed");
+
+	ret = pthread_barrierattr_getpshared(&attr, &pshared);
+	zassert_equal(ret, 0, "pthread_barrierattr_getpshared failed");
+	zassert_equal(pshared, PTHREAD_PROCESS_PRIVATE, "pshared attribute not set correctly");
+
+	ret = pthread_barrierattr_setpshared(&attr, PTHREAD_PROCESS_PRIVATE);
+	zassert_equal(ret, 0, "pthread_barrierattr_setpshared failed");
+
+	ret = pthread_barrierattr_setpshared(&attr, PTHREAD_PROCESS_PUBLIC);
+	zassert_equal(ret, 0, "pthread_barrierattr_setpshared failed");
+
+	ret = pthread_barrierattr_getpshared(&attr, &pshared);
+	zassert_equal(pshared, PTHREAD_PROCESS_PUBLIC, "pshared attribute not retrieved correctly");
+
+	ret = pthread_barrierattr_setpshared(&attr, 42);
+	zassert_equal(ret, -EINVAL, "pthread_barrierattr_setpshared did not return EINVAL");
+
+	ret = pthread_barrierattr_destroy(&attr);
+	zassert_equal(ret, 0, "pthread_barrierattr_destroy failed");
+}


### PR DESCRIPTION
Added pthread_barrieratter_init(),
pthread_barrieratter_destroy(),
pthread_barrieratter_getpshared() and
pthread_barrieratter_setpshared().

Fixes #59936
Fixes #59935
Fixes #59937
Fixes #59939