### PR TITLE
include: drivers: uart: remove incorrect comments about CDC ACM UART

### DIFF
--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -775,9 +775,6 @@ static inline int uart_fifo_fill_u16(const struct device *dev,
  * available data in the FIFO (i.e. until it returns less data
  * than was requested).
  *
- * Note that the calling context only applies to physical UARTs and
- * no to the virtual ones found in USB CDC ACM code.
- *
  * @param dev UART device instance.
  * @param rx_data Data container.
  * @param size Container size.
@@ -818,9 +815,6 @@ static inline int uart_fifo_read(const struct device *dev, uint8_t *rx_data,
  * detected, uart_fifo_read() must be called until it reads all
  * available data in the FIFO (i.e. until it returns less data
  * than was requested).
- *
- * Note that the calling context only applies to physical UARTs and
- * no to the virtual ones found in USB CDC ACM code.
  *
  * @param dev UART device instance.
  * @param rx_data Wide data container.


### PR DESCRIPTION
The CDC ACM implementation provides a virtual UART interface that is used by various samples and subsystems in a way that is compatible with the real UART interface.

Commit cc1b2c70cc8b
("uart: doc: Add special case for virtual UART")
added a questionable comment to uart_fifo_fill() API descriiption in an attempt to fix issue described in https://github.com/zephyrproject-rtos/zephyr/issues/11455

However, this did not fix the problem because the API is not designed to be used in this way.  Finally commit 0e57e4fb78e0 ("samples: usb: cdc_acm: Update CDC ACM echo sample") revised the sample to use the API in the correct way.

Remove incorrect comment in uart_fifo_fill(). For compatibility reasons and due to the design of the API, such differences must not exist.