### PR TITLE
doc: kernel: code-relocation: Remove erroneous note

### DIFF
--- a/doc/kernel/code-relocation.rst
+++ b/doc/kernel/code-relocation.rst
@@ -62,9 +62,6 @@ for  data copy operations from ROM to required memory type.
   .. note::
 
      function zephyr_code_relocate() can be called  as many times as required.
-     This step has to be performed before calling find_package(Zephyr ...)
-     in the application's CMakeLists.txt.
-
 
 Additional Configurations
 =========================


### PR DESCRIPTION
The note about required position for the function is not valid.

Fixes #59782