### PR TITLE
tests: drivers: can: api: do not quote overlay file name

### DIFF
--- a/tests/drivers/can/api/testcase.yaml
+++ b/tests/drivers/can/api/testcase.yaml
@@ -9,7 +9,7 @@ tests:
     tags:
       - drivers
       - can
-    extra_args: DTC_OVERLAY_FILE="twai-enable.overlay"
+    extra_args: DTC_OVERLAY_FILE=twai-enable.overlay
     harness: console
     harness_config:
       # actual CAN transceiver or shorted CAN RX/TX pins required for board testing


### PR DESCRIPTION
Remove quotes from DTC_OVERLAY_FILE as they break the build.