### PR TITLE
stm32h5 serie support of the usb

### DIFF
--- a/boards/arm/nucleo_h563zi/doc/index.rst
+++ b/boards/arm/nucleo_h563zi/doc/index.rst
@@ -173,6 +173,8 @@ The Zephyr nucleo_h563zi board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | independent watchdog                |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | USB full-speed host/device bus      |
++-----------+------------+-------------------------------------+
 
 
 Other hardware features are not yet supported on this Zephyr port.

--- a/boards/arm/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/arm/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -166,6 +166,12 @@
 	};
 };
 
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &vref {
 	status = "okay";
 };

--- a/boards/arm/nucleo_h563zi/nucleo_h563zi.yaml
+++ b/boards/arm/nucleo_h563zi/nucleo_h563zi.yaml
@@ -19,3 +19,5 @@ supported:
   - pwm
   - counter
   - spi
+  - usb_device
+  - usb

--- a/boards/arm/stm32h573i_dk/doc/index.rst
+++ b/boards/arm/stm32h573i_dk/doc/index.rst
@@ -191,6 +191,8 @@ hardware features:
 +-----------+------------+-------------------------------------+
 | AES       | on-chip    | crypto                              |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | USB full-speed host/device bus      |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/arm/stm32h573i_dk/stm32h573i_dk.dts
@@ -244,6 +244,12 @@
 	};
 };
 
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &die_temp {
 	status = "okay";
 };

--- a/boards/arm/stm32h573i_dk/stm32h573i_dk.yaml
+++ b/boards/arm/stm32h573i_dk/stm32h573i_dk.yaml
@@ -20,3 +20,5 @@ supported:
   - spi
   - octospi
   - can
+  - usb_device
+  - usb

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -484,6 +484,19 @@
 			dma-offset = <8>;
 			status = "disabled";
 		};
+
+		usb: usb@40016000 {
+			compatible = "st,stm32-usb";
+			reg = <0x40016000 0x400>;
+			interrupts = <74 0>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <8>;
+			ram-size = <2048>;
+			phys = <&usb_fs_phy>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x01000000>,
+				 <&rcc STM32_SRC_HSI48 USB_SEL(3)>;
+			status = "disabled";
+		};
 	};
 
 	die_temp: dietemp {
@@ -511,6 +524,11 @@
 		ratio = <4>;
 		io-channels = <&adc1 2>;
 		status = "disabled";
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
 	};
 };
 


### PR DESCRIPTION
Add the USB support to the stm32h5x serie 

- USB specification version 2.0 full-speed compliant
- Supports both Host and Device modes

Enables the USB node on the nucleo_h573i board and stm32h573i_dk disco kit
available on pin PA11/PA12

Signed-off-by: Francois Ramu <francois.ramu@st.com>