### PR TITLE
bmi270: Allow interrupt handling for spi too

### DIFF
--- a/dts/bindings/sensor/bosch,bmi270-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bmi270-i2c.yaml
@@ -5,9 +5,3 @@
 compatible: "bosch,bmi270"
 
 include: [i2c-device.yaml, "bosch,bmi270.yaml"]
-
-properties:
-  irq-gpios:
-    type: phandle-array
-    description: |
-      The INT1 and (optional) INT2 signal connections.

--- a/dts/bindings/sensor/bosch,bmi270.yaml
+++ b/dts/bindings/sensor/bosch,bmi270.yaml
@@ -9,3 +9,9 @@ description: |
 include: sensor-device.yaml
 
 compatible: "bosch,bmi270"
+
+properties:
+  irq-gpios:
+    type: phandle-array
+    description: |
+      The INT1 and (optional) INT2 signal connections.

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -527,6 +527,7 @@ test_i2c_bmi160: bmi160@52 {
 test_i2c_bmi270: bmi270@53 {
 	compatible = "bosch,bmi270";
 	reg = <0x53>;
+	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_fdc2x1x: fdc2x1x@54 {

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -162,6 +162,7 @@ test_spi_bmi270: bmi270@15 {
 	compatible = "bosch,bmi270";
 	reg = <0x15>;
 	spi-max-frequency = <0>;
+	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_spi_bmp388: bmp388@16 {


### PR DESCRIPTION
Interrupt handling is independent from the used BUS (i2c or spi) and therefore should be in the parent binding file instead of a bus-specific binding file. The interrupt code is handling interrupts already independently from the used BUS. See also this ticket for more information: https://github.com/zephyrproject-rtos/zephyr/issues/58843