### PR TITLE
docs: boards: sort the board architectures alphanumerically

### DIFF
--- a/boards/index.rst
+++ b/boards/index.rst
@@ -13,14 +13,14 @@ under :zephyr_file:`doc/templates/board.tmpl`
 .. toctree::
    :maxdepth: 2
 
-   x86/index.rst
+   arc/index.rst
    arm/index.rst
    arm64/index.rst
-   arc/index.rst
    mips/index.rst
    nios2/index.rst
-   xtensa/index.rst
    posix/index.rst
    riscv/index.rst
    sparc/index.rst
+   x86/index.rst
+   xtensa/index.rst
    shields/index.rst

--- a/boards/nios2/index.rst
+++ b/boards/nios2/index.rst
@@ -1,6 +1,6 @@
 .. _boards-nios2:
 
-NIOS II Boards
+Nios II Boards
 ##############
 
 .. toctree::

--- a/boards/posix/index.rst
+++ b/boards/posix/index.rst
@@ -1,6 +1,6 @@
 .. _boards_posix:
 
-POSIX/NATIVE Boards
+POSIX/Native Boards
 ###################
 
 .. toctree::

--- a/boards/riscv/index.rst
+++ b/boards/riscv/index.rst
@@ -1,7 +1,7 @@
 .. _boards-riscv:
 
-RISCV Boards
-##############
+RISC-V Boards
+#############
 
 .. toctree::
    :maxdepth: 1

--- a/boards/xtensa/index.rst
+++ b/boards/xtensa/index.rst
@@ -1,6 +1,6 @@
 .. _boards-xtensa:
 
-XTENSA Boards
+Xtensa Boards
 #############
 
 .. toctree::


### PR DESCRIPTION
Sort the list of board architectures alphanumerically except for shields, which are still listed at the very end.
Fix capitalization of the board architecture titles in the documentation while here.