### PR TITLE
tfm: Fix the merged hex file name for mps3_an547

### DIFF
--- a/boards/arm/mps3_an547/board.cmake
+++ b/boards/arm/mps3_an547/board.cmake
@@ -25,7 +25,7 @@ if (CONFIG_BUILD_WITH_TFM)
   # Override the binary used by qemu, to use the combined
   # TF-M (Secure) & Zephyr (Non Secure) image (when running
   # in-tree tests).
-  set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/zephyr/merged.hex")
+  set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/zephyr/tfm_merged.hex")
 endif()
 
 # FVP settings


### PR DESCRIPTION
This fixes a typo that leads to failure when running `west build` with the `run` target.