### PR TITLE
logging: cmake: Remove duplicate source entry

### DIFF
--- a/subsys/logging/CMakeLists.txt
+++ b/subsys/logging/CMakeLists.txt
@@ -12,7 +12,6 @@ if(NOT CONFIG_LOG_MODE_MINIMAL)
     log_mgmt.c
     log_cache.c
     log_msg.c
-    log_cache.c
   )
 
   zephyr_sources_ifdef(


### PR DESCRIPTION
`log_cache.c` was listed twice for `zephyr_sources_ifdef`.