### PR TITLE
arch: arm: aarch32: cortex_m: Add optional early boot function

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -469,4 +469,12 @@ endif # CORTEX_M_NULL_POINTER_EXCEPTION
 
 rsource "tz/Kconfig"
 
+config CORTEX_M_EARLY_BOOT_INIT
+	bool "Early boot init function"
+	help
+	  Enables an early boot function which is called prior to kernel initialisation
+	  ``z_arm_early_boot_init()``, this should be used for any setup that is required
+	  before any setup of the kernel takes place, for example to power up RAM sections
+	  that are needed if another image on the device has disabled them.
+
 endif # CPU_CORTEX_M

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -29,6 +29,10 @@
 #include <aarch32/cortex_a_r/stack.h>
 #endif
 
+#if defined(CONFIG_CPU_CORTEX_M) && defined(CONFIG_CORTEX_M_EARLY_BOOT_INIT)
+#include <aarch32/cortex_m/early_init.h>
+#endif
+
 #if defined(__GNUC__)
 /*
  * GCC can detect if memcpy is passed a NULL argument, however one of
@@ -259,6 +263,9 @@ void z_arm_prep_c(void)
 	relocate_vector_table();
 #if defined(CONFIG_CPU_HAS_FPU)
 	z_arm_floating_point_init();
+#endif
+#if defined(CONFIG_CORTEX_M_EARLY_BOOT_INIT)
+	z_arm_early_boot_init();
 #endif
 	z_bss_zero();
 	z_data_copy();

--- a/arch/arm/include/aarch32/cortex_m/early_init.h
+++ b/arch/arm/include/aarch32/cortex_m/early_init.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Early boot init
+ */
+
+#ifndef ZEPHYR_ARCH_ARM_INCLUDE_AARCH32_CORTEX_M_EARLY_INIT_H_
+#define ZEPHYR_ARCH_ARM_INCLUDE_AARCH32_CORTEX_M_EARLY_INIT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Function called at boot before C setup code has ran.
+ *
+ * This should only be used to setup things that would cause a boot failure
+ * in the early boot process if they are not configured correctly.
+ */
+void z_arm_early_boot_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_ARCH_ARM_INCLUDE_AARCH32_CORTEX_M_EARLY_INIT_H_ */


### PR DESCRIPTION
Adds a function that can be used prior to setup code being called. The intended use for this is for setup code that is needed prior to a system being initialised, for example if a CPU supports a RAM power down mode which is enabled by a previous boot image which could cause the zephyr initialisation to catastrophically fail if it is not re-enabled.