### PR TITLE
shields: Add arduino uno click shield

### DIFF
--- a/boards/shields/arduino_uno_click/Kconfig.shield
+++ b/boards/shields/arduino_uno_click/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 Andriy Gelman
+# SPDX-License-Identifier: Apache-2.0
+
+config ARDUINO_UNO_CLICK
+	def_bool $(shields_list_contains,arduino_uno_click)

--- a/boards/shields/arduino_uno_click/arduino_uno_click.overlay
+++ b/boards/shields/arduino_uno_click/arduino_uno_click.overlay
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Andriy Gelman
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	mikrobus_header_1: mikrobus-connector-1 {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0 0 &arduino_header 0 0>,	/* AN   -> A0  */
+				<1 0 &arduino_header 3 0>,	/* RST  -> A3  */
+				<2 0 &arduino_header 16 0>,	/* CS   -> D10 */
+				<3 0 &arduino_header 19 0>,	/* SCK  -> D13 */
+				<4 0 &arduino_header 18 0>,	/* MISO -> D12 */
+				<5 0 &arduino_header 17 0>,	/* MOSI -> D11 */
+								/* +3.3V */
+								/* GND */
+				<6 0 &arduino_header 12 0>,	/* PWM  -> D6  */
+				<7 0 &arduino_header 8 0>,	/* INT  -> D2  */
+				<8 0 &arduino_header 6 0>,	/* RX   -> D0  */
+				<9 0 &arduino_header 7 0>,	/* TX   -> D1  */
+				<10 0 &arduino_header 5 0>,	/* SCL  -> A5  */
+				<11 0 &arduino_header 4 0>;	/* SDA  -> A4  */
+								/* +5V */
+								/* GND */
+	};
+
+	mikrobus_header_2: mikrobus-connector-2 {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0 0 &arduino_header 1 0>,	/* AN   -> A1  */
+				<1 0 &arduino_header 2 0>,	/* RST  -> A2  */
+				<2 0 &arduino_header 15 0>,	/* CS   -> D9 */
+				<3 0 &arduino_header 19 0>,	/* SCK  -> D13 */
+				<4 0 &arduino_header 18 0>,	/* MISO -> D12 */
+				<5 0 &arduino_header 17 0>,	/* MOSI -> D11 */
+								/* +3.3V */
+								/* GND */
+				<6 0 &arduino_header 11 0>,	/* PWM  -> D5  */
+				<7 0 &arduino_header 9 0>,	/* INT  -> D3  */
+				<8 0 &arduino_header 6 0>,	/* RX   -> D0  */
+				<9 0 &arduino_header 7 0>,	/* TX   -> D1  */
+				<10 0 &arduino_header 5 0>,	/* SCL  -> A5  */
+				<11 0 &arduino_header 4 0>;	/* SDA  -> A4  */
+								/* +5V */
+								/* GND */
+	};
+};
+
+mikrobus_spi: &arduino_spi {};
+mikrobus_serial: &arduino_serial {};
+mikrobus_i2c: &arduino_i2c {};
+
+mikrobus_header: &mikrobus_header_1 {};

--- a/boards/shields/arduino_uno_click/doc/index.rst
+++ b/boards/shields/arduino_uno_click/doc/index.rst
@@ -1,0 +1,58 @@
+.. _arduino_uno_click:
+
+Arduino UNO click shield
+########################
+
+Overview
+********
+
+The Arduino UNO click is an extension to the Arduino UNO R3 headers.
+It's a simple shield that converts Arduino UNO R3 headers to two mikroBUS
+host sockets that allow you to connect many other click shields to your
+board.
+In other words, the Arduino UNO click will generally be used by other
+shields using the mikroBUS interface.
+
+Two mikroBUS headers are exposed by the overlay: ``mikrobus_header_1`` and
+``mikrobus_header_2``, each corresponding to a socket on the Arduino UNO
+click shield.
+
+The first socket (``mikrobus_header_1``) is the default socket which is
+assigned the node label ``mikrobus_header`` in the overlay.
+
+More information about the shield can be found at
+`Arduino UNO click shield website`_.
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration
+for Arduino R3 connector.
+
+The board must also define node aliases for arduino Serial,
+SPI and I2C interfaces (see :ref:`shields` for more details).
+
+Connecting shields should use the first socket (``mikrobus_header_1``). This
+socket is assigned the ``mikrobus_header`` node label.
+
+Programming
+***********
+
+Include ``-DSHIELD=arduino_uno_click`` when you invoke ``west build`` with
+other mikroBUS shields. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/net/sockets/echo_server
+   :host-os: unix
+   :board: sam_v71_xult
+   :gen-args: -DOVERLAY_CONFIG=overlay-802154.conf
+   :shield: "arduino_uno_click atmel_rf2xx_mikrobus"
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _Arduino UNO click shield website:
+   https://www.mikroe.com/arduino-uno-click-shield


### PR DESCRIPTION
The shield converts Arduino UNO R3 headers to two mikroBUS sockets.
Two mickoBUS sockets are exposed via the overlay labelled mikrobus_header_1 and mikrobus_header_2.

Edit:
mikrobus_header_1 is used as the default and assigned node label mikrobus_header.

~~The example depends on PRs:~~
~~https://github.com/zephyrproject-rtos/zephyr/pull/60008~~
~~https://github.com/zephyrproject-rtos/zephyr/pull/59968~~