### PR TITLE
Bluetooth: ascs: Make sure idle state can be always read

### DIFF
--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -125,19 +125,15 @@ ZTEST_F(ascs_test_suite, test_sink_ase_read_state_idle)
 {
 	const struct bt_gatt_attr *ase = fixture->ase_snk.attr;
 	struct bt_conn *conn = &fixture->conn;
-	struct test_ase_chrc_value_hdr *hdr;
+	struct test_ase_chrc_value_hdr hdr = { 0xff };
 	ssize_t ret;
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 	zexpect_not_null(fixture->ase_snk.attr);
 
-	ret = ase->read(conn, ase, NULL, 0, 0);
+	ret = ase->read(conn, ase, &hdr, sizeof(hdr), 0);
 	zassert_false(ret < 0, "attr->read returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
-
-	expect_bt_gatt_attr_read_called_once(conn, ase, EMPTY, EMPTY, 0x0000, EMPTY, sizeof(*hdr));
-
-	hdr = (void *)bt_gatt_attr_read_fake.arg5_val;
-	zassert_equal(0x00, hdr->ase_state, "unexpected ASE_State 0x%02x", hdr->ase_state);
+	zassert_equal(0x00, hdr.ase_state, "unexpected ASE_State 0x%02x", hdr.ase_state);
 }
 
 ZTEST_F(ascs_test_suite, test_release_ase_on_callback_unregister)

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -116,20 +116,13 @@ uint8_t test_ase_get(const struct bt_uuid *uuid, int num_ase, ...)
 
 uint8_t test_ase_id_get(const struct bt_gatt_attr *ase)
 {
-	const struct test_ase_chrc_value_hdr *hdr;
+	struct test_ase_chrc_value_hdr hdr = { 0 };
 	ssize_t ret;
 
-	ret = ase->read(NULL, ase, NULL, 0, 0);
+	ret = ase->read(NULL, ase, &hdr, sizeof(hdr), 0);
 	zassert_false(ret < 0, "ase->read returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
 
-	expect_bt_gatt_attr_read_called_once(NULL, ase, EMPTY, EMPTY, 0, EMPTY, sizeof(*hdr));
-
-	hdr = bt_gatt_attr_read_fake.arg5_val;
-
-	/* Reset the mock state */
-	bt_gatt_attr_read_reset();
-
-	return hdr->ase_id;
+	return hdr.ase_id;
 }
 
 static struct bt_bap_stream *stream_allocated;

--- a/tests/bluetooth/audio/mocks/include/gatt.h
+++ b/tests/bluetooth/audio/mocks/include/gatt.h
@@ -15,9 +15,6 @@ void mock_bt_gatt_cleanup(void);
 
 DECLARE_FAKE_VALUE_FUNC(int, mock_bt_gatt_notify_cb, struct bt_conn *,
 			struct bt_gatt_notify_params *);
-DECLARE_FAKE_VALUE_FUNC(ssize_t, bt_gatt_attr_read, struct bt_conn *,
-			const struct bt_gatt_attr *, void *, uint16_t, uint16_t, const void *,
-			uint16_t);
 
 void bt_gatt_notify_cb_reset(void);
 uint16_t bt_gatt_get_mtu(struct bt_conn *conn);

--- a/tests/bluetooth/audio/mocks/include/gatt_expects.h
+++ b/tests/bluetooth/audio/mocks/include/gatt_expects.h
@@ -12,51 +12,6 @@
 #include "gatt.h"
 #include "expects_util.h"
 
-#define expect_bt_gatt_attr_read_called_once(_conn, _attr, _buf, _buf_len, _offset, _value,        \
-					     _value_len)                                           \
-do {                                                                                               \
-	const char *func_name = "bt_gatt_attr_read";                                               \
-												   \
-	zassert_equal(1, bt_gatt_attr_read_fake.call_count,                                        \
-		      "'%s()' was called %u times, but expected once",                             \
-		      func_name, bt_gatt_attr_read_fake.call_count);                               \
-												   \
-	IF_NOT_EMPTY(_conn, (                                                                      \
-		     zassert_equal_ptr(_conn, bt_gatt_attr_read_fake.arg0_val,                     \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "conn");))                                       \
-												   \
-	IF_NOT_EMPTY(_attr, (                                                                      \
-		     zassert_equal_ptr(_attr, bt_gatt_attr_read_fake.arg1_val,                     \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "attr");))                                       \
-												   \
-	IF_NOT_EMPTY(_buf, (                                                                       \
-		     zassert_equal_ptr(_buf, bt_gatt_attr_read_fake.arg2_val,                      \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "buf");))                                        \
-												   \
-	IF_NOT_EMPTY(_buf_len, (                                                                   \
-		     zassert_equal(_buf_len, bt_gatt_attr_read_fake.arg3_val,                      \
-				       "'%s()' was called with incorrect '%s' value",              \
-				       func_name, "_buf_len");))                                   \
-												   \
-	IF_NOT_EMPTY(_offset, (                                                                    \
-		     zassert_equal(_offset, bt_gatt_attr_read_fake.arg4_val,                       \
-				   "'%s()' was called with incorrect '%s' value",                  \
-				   func_name, "offset");))                                         \
-												   \
-	/* assert if _data is valid, but _len is empty */                                          \
-	IF_EMPTY(_value_len, (IF_NOT_EMPTY(_value, (zassert_unreachable();))))                     \
-												   \
-	IF_NOT_EMPTY(_value_len, (                                                                 \
-		     zassert_equal(_value_len, bt_gatt_attr_read_fake.arg6_val,                    \
-				   "'%s()' was called with incorrect '%s' value",                  \
-				   func_name, "value_len");                                        \
-		     expect_data(func_name, "value", _value, bt_gatt_attr_read_fake.arg5_val,      \
-				 _value_len);))                                                    \
-} while (0)
-
 #define expect_bt_gatt_notify_cb_called_once(_conn, _uuid, _attr, _data, _len)                     \
 do {                                                                                               \
 	const char *func_name = "bt_gatt_notify_cb";                                               \
@@ -91,14 +46,6 @@ do {                                                                            
 				   func_name, "params->len");                                      \
 		     expect_data(func_name, "params->data", _data, params->data, _len);))          \
 } while (0)
-
-static inline void expect_bt_gatt_attr_read_not_called(void)
-{
-	const char *func_name = "bt_gatt_attr_read";
-
-	zassert_equal(0, bt_gatt_attr_read_fake.call_count,
-		      "'%s()' was called unexpectedly", func_name);
-}
 
 static inline void expect_bt_gatt_notify_cb_not_called(void)
 {


### PR DESCRIPTION
Instead of waiting for ase_buf to be available, the read of an
ASE in IDLE state can be handled without using ase_buf.