### PR TITLE
Bluetooth: ascs: Fix return without state change nor response

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -2482,7 +2482,6 @@ static void ase_stop(struct bt_ascs_ase *ase)
 		err = ascs_disconnect_stream(stream);
 		if (err < 0) {
 			LOG_ERR("Failed to disconnect stream %p: %d", stream, err);
-			return;
 		}
 	}
 


### PR DESCRIPTION
This fixes missing control point status and ASE status change, when failed to disconnect the CIS. As the server may, but does not have to disconnect the CIS, the operation should not be considered as failed when it happens.