### PR TITLE
drivers: clock_control: Export clock initialization function for STM32H7

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -818,7 +818,7 @@ static int set_up_plls(void)
 }
 
 #if defined(CONFIG_CPU_CORTEX_M7)
-static int stm32_clock_control_init(const struct device *dev)
+int stm32_clock_control_init(const struct device *dev)
 {
 	uint32_t old_hclk_freq = 0;
 	uint32_t new_hclk_freq = 0;
@@ -913,7 +913,7 @@ static int stm32_clock_control_init(const struct device *dev)
 	return r;
 }
 #else
-static int stm32_clock_control_init(const struct device *dev)
+int stm32_clock_control_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 


### PR DESCRIPTION
Since clock reinitialization is needed for STM32 SoC power management implementation, `stm32_clock_control_init` function declaration has been exported as global in `clock_stm32_ll_common.h` file.

This PR exports definition of `stm32_clock_control_init` function as global for STM32H7 series, making future power management implementation for this SoC possible.


With this change in clock control, I was able to implement transfering into DSTOP1 state as part of Zephyr's PM `suspend-to-idle` state for STM32H7 SoC, which I will contribute upstream later.