### PR TITLE
Bluetooth: Mesh: Fix OOB information endianness in scan report message

### DIFF
--- a/subsys/bluetooth/mesh/rpr_cli.c
+++ b/subsys/bluetooth/mesh/rpr_cli.c
@@ -290,9 +290,9 @@ static int handle_scan_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 
 	dev.rssi = net_buf_simple_pull_u8(buf);
 	memcpy(dev.uuid, net_buf_simple_pull_mem(buf, 16), 16);
-	dev.oob = net_buf_simple_pull_be16(buf);
+	dev.oob = net_buf_simple_pull_le16(buf);
 	if (buf->len == 4) {
-		dev.hash = net_buf_simple_pull_be32(buf);
+		memcpy(&dev.hash, net_buf_simple_pull_mem(buf, 4), 4);
 		dev.flags = BT_MESH_RPR_UNPROV_HASH;
 	} else if (buf->len) {
 		return -EINVAL;

--- a/subsys/bluetooth/mesh/rpr_srv.c
+++ b/subsys/bluetooth/mesh/rpr_srv.c
@@ -237,9 +237,9 @@ static void scan_report_send(void)
 		bt_mesh_model_msg_init(&buf, RPR_OP_SCAN_REPORT);
 		net_buf_simple_add_u8(&buf, dev->rssi);
 		net_buf_simple_add_mem(&buf, dev->uuid, 16);
-		net_buf_simple_add_be16(&buf, dev->oob);
+		net_buf_simple_add_le16(&buf, dev->oob);
 		if (dev->flags & BT_MESH_RPR_UNPROV_HASH) {
-			net_buf_simple_add_be32(&buf, dev->hash);
+			net_buf_simple_add_mem(&buf, &dev->hash, 4);
 		}
 
 		atomic_set_bit(srv.flags, SCAN_REPORT_PENDING);
@@ -1066,7 +1066,7 @@ adv_handle_beacon(const struct bt_le_scan_recv_info *info,
 	dev->rssi = info->rssi;
 
 	if (ad->data_len == 23) {
-		dev->hash = sys_get_le32(&ad->data[19]);
+		memcpy(&dev->hash, &ad->data[19], 4);
 		dev->flags |= BT_MESH_RPR_UNPROV_HASH;
 	}
 


### PR DESCRIPTION
OOB information should be in little endian in scan report messages.
URI hash should be retrieved as it is from unprovisioned device beacon
and encoded likewise into scan report messages like we do for UUID.