### PR TITLE
arch: arm: aarch32: Add optional early boot function

### DIFF
--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -20,6 +20,7 @@
 #include <kernel_internal.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/barrier.h>
+#include <aarch32/early_init.h>
 
 #if !defined(CONFIG_CPU_CORTEX_M)
 #include <zephyr/arch/arm/aarch32/cortex_a_r/lib_helpers.h>
@@ -245,6 +246,11 @@ static inline void z_arm_floating_point_init(void)
 #endif /* CONFIG_CPU_CORTEX_M */
 #endif /* CONFIG_CPU_HAS_FPU */
 
+void __weak z_arm_early_boot_init(void)
+{
+	/* Do nothing */
+}
+
 extern FUNC_NORETURN void z_cstart(void);
 
 /**
@@ -256,6 +262,7 @@ extern FUNC_NORETURN void z_cstart(void);
  */
 void z_arm_prep_c(void)
 {
+	z_arm_early_boot_init();
 	relocate_vector_table();
 #if defined(CONFIG_CPU_HAS_FPU)
 	z_arm_floating_point_init();

--- a/arch/arm/include/aarch32/early_init.h
+++ b/arch/arm/include/aarch32/early_init.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Early boot init
+ */
+
+#ifndef ZEPHYR_ARCH_ARM_INCLUDE_AARCH32_EARLY_INIT_H_
+#define ZEPHYR_ARCH_ARM_INCLUDE_AARCH32_EARLY_INIT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Function called at boot before C setup code has ran.
+ *
+ * This should only be used to setup things that would cause a boot failure
+ * in the early boot process if they are not configured correctly.
+ */
+void z_arm_early_boot_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_ARCH_ARM_INCLUDE_AARCH32_EARLY_INIT_H_ */


### PR DESCRIPTION
Adds a function that can be used prior to setup code being called. The intended use for this is for setup code that is needed prior to a system being initialised, for example if a CPU supports a RAM power down mode which is enabled by a previous boot image which could cause the zephyr initialisation to catastrophically fail if it is not re-enabled.