### PR TITLE
linker: devicetree_regions: Infer VMA when defining section

### DIFF
--- a/include/zephyr/linker/devicetree_regions.h
+++ b/include/zephyr/linker/devicetree_regions.h
@@ -138,7 +138,7 @@
  * will result in:
  *
  * @code{.unparsed}
- *    FOOBAR 0x20010000 (NOLOAD) :
+ *    FOOBAR (NOLOAD) :
  *    {
  *        __FOOBAR_start = .;
  *        KEEP(*(FOOBAR))
@@ -152,7 +152,7 @@
  * @param node_id devicetree node identifier
  */
 #define _SECTION_DECLARE(node_id)								\
-	LINKER_DT_NODE_REGION_NAME_TOKEN(node_id) DT_REG_ADDR(node_id) (NOLOAD) :		\
+	LINKER_DT_NODE_REGION_NAME_TOKEN(node_id) (NOLOAD) :					\
 	{											\
 		_DT_SECTION_START(node_id) = .;							\
 		KEEP(*(LINKER_DT_NODE_REGION_NAME_TOKEN(node_id)))				\


### PR DESCRIPTION
Explicitly setting the start of VMA can intefere if the memory region was used in another section, for example via zephyr_code_relocate().