### PR TITLE
Bluetooth: Controller: Maximize BIG event length and preempt PTO & CTRL

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -386,6 +386,18 @@ config BT_CTLR_ADV_RESERVE_MAX
 	  corresponding to the Advertising Data present at the time of the
 	  start/enable of Advertising is used.
 
+config BT_CTLR_ADV_ISO_RESERVE_MAX
+	bool "Use maximum Broadcast ISO event time reservation"
+	depends on BT_CTLR_ADV_ISO
+	default y
+	help
+	  Use maximum Broadcast ISO event time reservation. If disabled, then
+	  time reservation does not include the pre-transmissions of the last
+	  BIS and any Control subevents. This will allow extended or periodic
+	  advertising events to preempt the BIG events but allow higher radio
+	  utilizations by allowing larger BIG events when not overlapping with
+	  extended or periodic advertising.
+
 config BT_CTLR_ADV_AUX_SYNC_OFFSET
 	int "Pre-defined offset between AUX_ADV_IND and AUX_SYNC_IND"
 	depends on BT_CTLR_ADV_PERIODIC

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -205,7 +205,7 @@ ull_adv_aux_hdr_len_fill(struct pdu_adv_com_ext_adv *com_hdr, uint8_t len)
 void ull_adv_sync_started_stopped(struct ll_adv_aux_set *aux);
 
 /* notify adv_sync_set that an iso instance has been created for it */
-void ull_adv_iso_created(struct ll_adv_sync_set *sync);
+void ull_adv_sync_iso_created(struct ll_adv_sync_set *sync);
 
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_internal.h
@@ -322,6 +322,9 @@ struct lll_adv_iso_stream *ull_adv_iso_stream_get(uint16_t handle);
 /* helper function to release stream instances */
 void ull_adv_iso_stream_release(struct ll_adv_iso_set *adv_iso);
 
+/* helper function to return time reservation for Broadcast ISO event */
+uint32_t ull_adv_iso_max_time_get(const struct ll_adv_iso_set *adv_iso);
+
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
 /* helper function to release unused DF configuration memory */
 void ull_df_adv_cfg_release(struct lll_df_adv_cfg *df_adv_cfg);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -487,7 +487,7 @@ uint8_t ll_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 
 #if defined(CONFIG_BT_TICKER_EXT_EXPIRE_INFO)
 	/* Notify the sync instance */
-	ull_adv_iso_created(HDR_LLL2ULL(lll_adv_sync));
+	ull_adv_sync_iso_created(HDR_LLL2ULL(lll_adv_sync));
 #endif /* CONFIG_BT_TICKER_EXT_EXPIRE_INFO */
 
 	/* Commit the BIGInfo in the ACAD field of Periodic Advertising */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -57,6 +57,7 @@ static struct stream *adv_iso_stream_acquire(void);
 static uint16_t adv_iso_stream_handle_get(struct lll_adv_iso_stream *stream);
 static uint8_t ptc_calc(const struct lll_adv_iso *lll, uint32_t event_spacing,
 			uint32_t event_spacing_max);
+static uint32_t adv_iso_time_get(const struct ll_adv_iso_set *adv_iso, bool max);
 static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
 			      uint32_t iso_interval_us);
 static uint8_t adv_iso_chm_update(uint8_t big_handle);
@@ -945,6 +946,11 @@ void ull_adv_iso_stream_release(struct ll_adv_iso_set *adv_iso)
 	lll->adv = NULL;
 }
 
+uint32_t ull_adv_iso_max_time_get(const struct ll_adv_iso_set *adv_iso)
+{
+	return adv_iso_time_get(adv_iso, true);
+}
+
 static int init_reset(void)
 {
 	/* Add initializations common to power up initialization and HCI reset
@@ -998,22 +1004,12 @@ static uint8_t ptc_calc(const struct lll_adv_iso *lll, uint32_t event_spacing,
 	return 0U;
 }
 
-static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
-			      uint32_t iso_interval_us)
+static uint32_t adv_iso_time_get(const struct ll_adv_iso_set *adv_iso, bool max)
 {
-	uint32_t ticks_slot_overhead;
-	struct lll_adv_iso *lll_iso;
-	uint32_t ticks_slot_offset;
-	uint32_t volatile ret_cb;
-	uint32_t ticks_anchor;
+	const struct lll_adv_iso *lll_iso;
 	uint32_t ctrl_spacing;
 	uint32_t pdu_spacing;
-	uint32_t ticks_slot;
-	uint32_t slot_us;
-	uint32_t ret;
-	int err;
-
-	ull_hdr_init(&adv_iso->ull);
+	uint32_t time_us;
 
 	lll_iso = &adv_iso->lll;
 
@@ -1023,15 +1019,46 @@ static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
 	ctrl_spacing = PDU_BIS_US(sizeof(struct pdu_big_ctrl), lll_iso->enc,
 				  lll_iso->phy, lll_iso->phy_flags);
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_ISO_RESERVE_MAX)) {
-		slot_us = (pdu_spacing * lll_iso->nse * lll_iso->num_bis) +
+	/* 1. Maximum PDU transmission time in 1M/2M/S8 PHY is 17040 us, or
+	 * represented in 15-bits.
+	 * 2. NSE in the range 1 to 31 is represented in 5-bits
+	 * 3. num_bis in the range 1 to 31 is represented in 5-bits
+	 *
+	 * Hence, worst case event time can be represented in 25-bits plus
+	 * one each bit for added ctrl_spacing and radio event overheads. I.e.
+	 * 27-bits required and sufficiently covered by using 32-bit data type
+	 * for time_us.
+	 */
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_ISO_RESERVE_MAX) || max) {
+		time_us = (pdu_spacing * lll_iso->nse * lll_iso->num_bis) +
 			  ctrl_spacing;
 	} else {
-		slot_us = pdu_spacing * ((lll_iso->nse * lll_iso->num_bis) -
+		time_us = pdu_spacing * ((lll_iso->nse * lll_iso->num_bis) -
 					 lll_iso->ptc);
 	}
 
-	slot_us += EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
+	/* Add implementation defined radio event overheads */
+	time_us += EVENT_OVERHEAD_START_US + EVENT_OVERHEAD_END_US;
+
+	return time_us;
+}
+
+static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
+			      uint32_t iso_interval_us)
+{
+	uint32_t ticks_slot_overhead;
+	uint32_t ticks_slot_offset;
+	volatile uint32_t ret_cb;
+	uint32_t ticks_anchor;
+	uint32_t ticks_slot;
+	uint32_t slot_us;
+	uint32_t ret;
+	int err;
+
+	ull_hdr_init(&adv_iso->ull);
+
+	slot_us = adv_iso_time_get(adv_iso, false);
 
 	adv_iso->ull.ticks_active_to_start = 0U;
 	adv_iso->ull.ticks_prepare_to_start =
@@ -1066,7 +1093,7 @@ static uint32_t adv_iso_start(struct ll_adv_iso_set *adv_iso,
 
 	ret_cb = TICKER_STATUS_BUSY;
 	ret = ticker_start(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_THREAD,
-			   (TICKER_ID_ADV_ISO_BASE + lll_iso->handle),
+			   (TICKER_ID_ADV_ISO_BASE + adv_iso->lll.handle),
 			   ticks_anchor, 0U,
 			   HAL_TICKER_US_TO_TICKS(iso_interval_us),
 			   HAL_TICKER_REMAINDER(iso_interval_us),

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -222,7 +222,7 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 }
 
 #if defined(CONFIG_BT_CTLR_ADV_ISO) && defined(CONFIG_BT_TICKER_EXT_EXPIRE_INFO)
-void ull_adv_iso_created(struct ll_adv_sync_set *sync)
+void ull_adv_sync_iso_created(struct ll_adv_sync_set *sync)
 {
 	if (sync->lll.iso && sync->is_started) {
 		uint8_t iso_handle = sync->lll.iso->handle;

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -701,7 +701,10 @@ static struct ull_hdr *ull_hdr_get_cb(uint8_t ticker_id, uint32_t *ticks_slot)
 
 		adv_iso = ull_adv_iso_get(ticker_id - TICKER_ID_ADV_ISO_BASE);
 		if (adv_iso) {
-			*ticks_slot = adv_iso->ull.ticks_slot;
+			uint32_t time_us;
+
+			time_us = ull_adv_iso_max_time_get(adv_iso);
+			*ticks_slot = HAL_TICKER_US_TO_TICKS_CEIL(time_us);
 
 			return &adv_iso->ull;
 		}


### PR DESCRIPTION
Maximize BIG event length to extend upto ISO interval, and
allow PTO and Control subevents to be pre-emptible.

depends on https://github.com/zephyrproject-rtos/zephyr/pull/59180