### PR TITLE
regulator: shell: fix unitialized variable warning from SCA

### DIFF
--- a/drivers/regulator/regulator_shell.c
+++ b/drivers/regulator/regulator_shell.c
@@ -131,7 +131,7 @@ static int cmd_vlist(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
 	unsigned int volt_cnt;
-	int32_t last_volt_uv;
+	int32_t last_volt_uv = 0;
 
 	ARG_UNUSED(argc);
 


### PR DESCRIPTION
Static code analysis has highlighted that a variable is being accessed before initializing. This is a very minor fix to resolve this potential issue.