### PR TITLE
Fix configuration cache overwrites in ll_cig_parameters_commit

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -228,6 +228,7 @@ uint8_t ll_cig_parameters_commit(uint8_t cig_id, uint16_t *handles)
 	for (uint8_t i = 0U; i < ll_iso_setup.cis_count; i++) {
 		struct ll_conn_iso_stream *cis;
 		memq_link_t *link_tx_free;
+		memq_link_t link_tx;
 
 		cis = ll_conn_iso_stream_get_by_id(ll_iso_setup.stream[i].cis_id);
 		if (cis) {
@@ -254,8 +255,9 @@ uint8_t ll_cig_parameters_commit(uint8_t cig_id, uint16_t *handles)
 			cig->lll.num_cis++;
 		}
 
-		/* Store TX free link before transfer */
+		/* Store TX link and free link before transfer */
 		link_tx_free = cis->lll.link_tx_free;
+		link_tx = cis->lll.link_tx;
 
 		/* Transfer parameters from configuration cache */
 		memcpy(cis, &ll_iso_setup.stream[i], sizeof(struct ll_conn_iso_stream));
@@ -264,6 +266,7 @@ uint8_t ll_cig_parameters_commit(uint8_t cig_id, uint16_t *handles)
 		cis->framed = cig->central.framing || force_framed;
 
 		cis->lll.link_tx_free = link_tx_free;
+		cis->lll.link_tx = link_tx;
 		cis->lll.handle = ll_conn_iso_stream_handle_get(cis);
 		handles[i] = cis->lll.handle;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -167,7 +167,6 @@ uint8_t ll_cig_parameters_commit(uint8_t cig_id, uint16_t *handles)
 			/* No space for new CIG */
 			return BT_HCI_ERR_INSUFFICIENT_RESOURCES;
 		}
-		cig->state = CIG_STATE_CONFIGURABLE;
 		cig->lll.num_cis = 0U;
 
 	} else if (cig->state != CIG_STATE_CONFIGURABLE) {
@@ -180,6 +179,8 @@ uint8_t ll_cig_parameters_commit(uint8_t cig_id, uint16_t *handles)
 
 	/* Transfer parameters from configuration cache and clear LLL fields */
 	memcpy(cig, &ll_iso_setup.group, sizeof(struct ll_conn_iso_group));
+
+	cig->state = CIG_STATE_CONFIGURABLE;
 
 	/* Setup LLL parameters */
 	cig->lll.handle = ll_conn_iso_group_handle_get(cig);


### PR DESCRIPTION
**Bluetooth: controller: Fix link_tx overwrite at Central CIS creation**

In the case where memq_deinit in LLL flushing ends up with the free
link being the link provided by the CIS instance, and pointed to by
lll.link_tx_free, the free counter data in the link element is
overwritten during central CIS creation.

This has the effect that when starting the next CIG, there will suddenly
be 0 links available, and controller fails assertion.

By saving- and restoring the lll.link_tx before and after CIS
configuration cache copying, the free counter is intact.


**Bluetooth: controller: Fix CIG state overwrite in parameters_commit**

The CIG state variable is set to CIG_STATE_CONFIGURABLE, but then
cleared my memcpy from configuration cache. Set state after memcpy.

Fixes EBQ test /HCI/CIS/BI-10-C.
