### PR TITLE
drivers: entropy native: Refactor to support embedded libCs

### DIFF
--- a/arch/posix/core/CMakeLists.txt
+++ b/arch/posix/core/CMakeLists.txt
@@ -18,6 +18,7 @@ if(CONFIG_NATIVE_APPLICATION)
 		posix_core.c
 		nsi_compat/nsi_compat.c
 		${ZEPHYR_BASE}/scripts/native_simulator/common/src/nce.c
+		${ZEPHYR_BASE}/scripts/native_simulator/common/src/nsi_host_trampolines.c
 	)
 else()
 	zephyr_library_sources(

--- a/arch/posix/core/nsi_compat/nsi_host_trampolines.h
+++ b/arch/posix/core/nsi_compat/nsi_host_trampolines.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Note: This is a provisional header which exists to allow
+ * old POSIX arch based boards (i.e. native_posix) to provide access
+ * to the host C library as if the native simulator trampolines
+ * existed.
+ *
+ * Boards based on the native simulator do NOT use this file
+ */
+
+#ifndef ARCH_POSIX_CORE_NSI_COMPAT_NSI_HOST_TRAMPOLINES_H
+#define ARCH_POSIX_CORE_NSI_COMPAT_NSI_HOST_TRAMPOLINES_H
+
+#include "../scripts/native_simulator/common/src/include/nsi_host_trampolines.h"
+
+#endif /* ARCH_POSIX_CORE_NSI_COMPAT_NSI_HOST_TRAMPOLINES_H */

--- a/boards/posix/native_sim/doc/index.rst
+++ b/boards/posix/native_sim/doc/index.rst
@@ -109,7 +109,7 @@ host libC (:kconfig:option:`CONFIG_EXTERNAL_LIBC`).
      can, can native posix, :kconfig:option:`CONFIG_CAN_NATIVE_POSIX_LINUX`, host libC
      console backend, POSIX arch console, :kconfig:option:`CONFIG_POSIX_ARCH_CONSOLE`, all
      display, display SDL, :kconfig:option:`CONFIG_SDL_DISPLAY`, all
-     entropy, native posix entropy, :kconfig:option:`CONFIG_FAKE_ENTROPY_NATIVE_POSIX`, host libC
+     entropy, native posix entropy, :kconfig:option:`CONFIG_FAKE_ENTROPY_NATIVE_POSIX`, all
      eprom, eprom emulator, :kconfig:option:`CONFIG_EEPROM_EMULATOR`, host libC
      ethernet, eth native_posix, :kconfig:option:`CONFIG_ETH_NATIVE_POSIX`, host libC
      flash, flash simulator, :kconfig:option:`CONFIG_FLASH_SIMULATOR`, host libC

--- a/drivers/entropy/Kconfig.native_posix
+++ b/drivers/entropy/Kconfig.native_posix
@@ -4,7 +4,6 @@ config FAKE_ENTROPY_NATIVE_POSIX
 	bool "Native posix entropy driver"
 	default y
 	depends on DT_HAS_ZEPHYR_NATIVE_POSIX_RNG_ENABLED
-	depends on EXTERNAL_LIBC
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the test random number generator for the

--- a/drivers/entropy/fake_entropy_native_posix.c
+++ b/drivers/entropy/fake_entropy_native_posix.c
@@ -22,6 +22,7 @@
 #include <zephyr/arch/posix/posix_trace.h>
 #include "soc.h"
 #include "cmdline.h" /* native_posix command line options header */
+#include "nsi_host_trampolines.h"
 
 static unsigned int seed = 0x5678;
 
@@ -36,7 +37,7 @@ static int entropy_native_posix_get_entropy(const struct device *dev,
 		 * Note that only 1 thread (Zephyr thread or HW models), runs at
 		 * a time, therefore there is no need to use random_r()
 		 */
-		long int value = random();
+		long value = nsi_host_random();
 
 		size_t to_copy = MIN(length, sizeof(long int));
 
@@ -64,7 +65,7 @@ static int entropy_native_posix_get_entropy_isr(const struct device *dev,
 static int entropy_native_posix_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
-	srandom(seed);
+	nsi_host_srandom(seed);
 	posix_print_warning("WARNING: "
 			    "Using a test - not safe - entropy source\n");
 	return 0;

--- a/scripts/native_simulator/Makefile
+++ b/scripts/native_simulator/Makefile
@@ -10,6 +10,8 @@
 
 NSI_CONFIG_FILE?=nsi_config
 -include ${NSI_CONFIG_FILE}
+#If the file does not exist, we don't use it as a build dependency
+NSI_CONFIG_FILE:=$(wildcard ${NSI_CONFIG_FILE})
 
 NSI_PATH?=./
 NSI_BUILD_PATH?=$(abspath _build/)

--- a/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
+++ b/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
@@ -22,10 +22,20 @@
 extern "C" {
 #endif
 
+void *nsi_host_calloc(unsigned long nmemb, unsigned long size);
+int nsi_host_close(int fd);
 /* void nsi_host_exit (int status); Use nsi_exit() instead */
+void nsi_host_free(void *ptr);
+char *nsi_host_getcwd(char *buf, unsigned long size);
+int nsi_host_isatty(int fd);
+void *nsi_host_malloc(unsigned long size);
+int nsi_host_open(const char *pathname, int flags);
 /* int nsi_host_printf (const char *fmt, ...); Use the nsi_tracing.h equivalents */
 long nsi_host_random(void);
+long nsi_host_read(int fd, void *buffer, unsigned long size);
 void nsi_host_srandom(unsigned int seed);
+char *nsi_host_strdup(const char *s);
+long nsi_host_write(int fd, void *buffer, unsigned long size);
 
 #ifdef __cplusplus
 }

--- a/scripts/native_simulator/common/src/nsi_host_trampolines.c
+++ b/scripts/native_simulator/common/src/nsi_host_trampolines.c
@@ -7,13 +7,66 @@
  */
 
 #include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+
+void *nsi_host_calloc(unsigned long nmemb, unsigned long size)
+{
+	return calloc(nmemb, size);
+}
+
+int nsi_host_close(int fd)
+{
+	return close(fd);
+}
+
+void nsi_host_free(void *ptr)
+{
+	free(ptr);
+}
+
+char *nsi_host_getcwd(char *buf, unsigned long size)
+{
+	return getcwd(buf, size);
+}
+
+int nsi_host_isatty(int fd)
+{
+	return isatty(fd);
+}
+
+void *nsi_host_malloc(unsigned long size)
+{
+	return malloc(size);
+}
+
+int nsi_host_open(const char *pathname, int flags)
+{
+	return open(pathname, flags);
+}
 
 long nsi_host_random(void)
 {
 	return random();
 }
 
+long nsi_host_read(int fd, void *buffer, unsigned long size)
+{
+	return read(fd, buffer, size);
+}
+
 void nsi_host_srandom(unsigned int seed)
 {
 	srandom(seed);
+}
+
+char *nsi_host_strdup(const char *s)
+{
+	return strdup(s);
+}
+
+long nsi_host_write(int fd, void *buffer, unsigned long size)
+{
+	return write(fd, buffer, size);
 }

--- a/scripts/native_simulator/common/src/nsi_tasks.h
+++ b/scripts/native_simulator/common/src/nsi_tasks.h
@@ -42,7 +42,7 @@ extern "C" {
  * The function must take no parameters and return nothing.
  */
 #define NSI_TASK(fn, level, prio)	\
-	static void (* const NSI_CONCAT(__nsi_task_, fn))() \
+	static void (* const NSI_CONCAT(__nsi_task_, fn))(void) \
 	__attribute__((__used__)) \
 	__attribute__((__section__(".nsi_" #level NSI_STRINGIFY(prio) "_task")))\
 	= fn


### PR DESCRIPTION
Refactor the host libC accesses to use the native simulator host trampolines.
In this way we support building this driver with embedded libCs.

This PR sits directly on top of https://github.com/zephyrproject-rtos/zephyr/pull/60093