### PR TITLE
cmake: switch to misc/empty.ld instead of /dev/null

### DIFF
--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT CONFIG_PICOLIBC_USE_MODULE)
 
   zephyr_compile_options(--specs=picolibc.specs)
   zephyr_compile_definitions(_POSIX_C_SOURCE=200809)
-  zephyr_libc_link_libraries(-T/dev/null --specs=picolibc.specs c -lgcc)
+  zephyr_libc_link_libraries(-T${ZEPHYR_BASE}/misc/empty.ld --specs=picolibc.specs c -lgcc)
   if(CONFIG_PICOLIBC_IO_FLOAT)
     zephyr_compile_definitions(PICOLIBC_DOUBLE_PRINTF_SCANF)
     zephyr_link_libraries(-DPICOLIBC_DOUBLE_PRINTF_SCANF)


### PR DESCRIPTION
Fixes: #60040

Introduce misc/empty.ld for linking with picolibc.

Linking with picolibc requires an additional -T linking flag to an empty linker file. On Linux and similar systems, this is handled by using /dev/null, however /dev/null is not available on windows.

Instead introduce misc/empty.ld for linking. empty.ld is an empty and accomplishes the same as linking with /dev/null but works across all OS'es.