### PR TITLE
Bluetooth: Mesh: Fix err in mod_app_list packing

### DIFF
--- a/include/zephyr/bluetooth/mesh/cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/cfg_cli.h
@@ -1644,6 +1644,19 @@ struct bt_mesh_comp_p1_model_item *bt_mesh_comp_p1_item_pull(
 struct bt_mesh_comp_p1_ext_item *bt_mesh_comp_p1_pull_ext_item(
 	struct bt_mesh_comp_p1_model_item *item, struct bt_mesh_comp_p1_ext_item *ext_item);
 
+/** @brief Unpack a list of key index entries from a buffer.
+ *
+ * On success, @c dst_cnt is set to the amount of unpacked key index entries.
+ *
+ * @param buf Message buffer containing encoded AppKey or NetKey Indexes.
+ * @param dst_arr Destination array for the unpacked list.
+ * @param dst_cnt Size of the destination array.
+ *
+ * @return 0 on success.
+ * @return -EMSGSIZE if dst_arr size is to small to parse full message.
+ */
+int bt_mesh_key_idx_unpack_list(struct net_buf_simple *buf, uint16_t *dst_arr, size_t *dst_cnt);
+
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op bt_mesh_cfg_cli_op[];
 extern const struct bt_mesh_model_cb bt_mesh_cfg_cli_cb;

--- a/subsys/bluetooth/mesh/foundation.h
+++ b/subsys/bluetooth/mesh/foundation.h
@@ -154,15 +154,13 @@ void bt_mesh_attention(struct bt_mesh_model *model, uint8_t time);
 
 #include <zephyr/sys/byteorder.h>
 
-static inline void key_idx_pack(struct net_buf_simple *buf,
-				uint16_t idx1, uint16_t idx2)
+static inline void key_idx_pack_pair(struct net_buf_simple *buf, uint16_t idx1, uint16_t idx2)
 {
 	net_buf_simple_add_le16(buf, idx1 | ((idx2 & 0x00f) << 12));
 	net_buf_simple_add_u8(buf, idx2 >> 4);
 }
 
-static inline void key_idx_unpack(struct net_buf_simple *buf,
-				  uint16_t *idx1, uint16_t *idx2)
+static inline void key_idx_unpack_pair(struct net_buf_simple *buf, uint16_t *idx1, uint16_t *idx2)
 {
 	*idx1 = sys_get_le16(&buf->data[0]) & 0xfff;
 	*idx2 = sys_get_le16(&buf->data[1]) >> 4;


### PR DESCRIPTION
Fixes erroneous packing/unpacking in the configuration client and server. According to the mesh 1.1 protcol spec (4.3.1.1) two app indexes shall be packed in a 3 octet interleaved format. The current implementation packs them in 4 octets.