### PR TITLE
Move to and extend `zephyr,memory-attr`

### DIFF
--- a/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
+++ b/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
@@ -29,7 +29,7 @@
 		device_type = "memory";
 		reg = <0xc0000000 DT_SIZE_M(8)>;
 		zephyr,memory-region = "SDRAM1";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 
 	aliases {

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -45,7 +45,7 @@
 		device_type = "memory";
 		reg = <0xc0000000 DT_SIZE_M(16)>;
 		zephyr,memory-region = "SDRAM1";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 
 	aliases {

--- a/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
@@ -46,7 +46,7 @@
 		device_type = "memory";
 		reg = <0xc0000000 DT_SIZE_M(16)>;
 		zephyr,memory-region = "SDRAM1";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 
 	aliases {

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -28,7 +28,7 @@
 		device_type = "memory";
 		reg = <0xc0000000 DT_SIZE_M(16)>;
 		zephyr,memory-region = "SDRAM1";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 
 	leds {

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -27,7 +27,7 @@
 		device_type = "memory";
 		reg = <0xd0000000 DT_SIZE_M(32)>;
 		zephyr,memory-region = "SDRAM2";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 
 	leds {

--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -48,7 +48,7 @@
 		device_type = "memory";
 		reg = <0xd0000000 DT_SIZE_M(16)>;
 		zephyr,memory-region = "SDRAM2";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 
 	transceiver0: can-phy0 {

--- a/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.dts
+++ b/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.dts
@@ -41,7 +41,7 @@
 			compatible = "zephyr,memory-region", "mmio-dram";
 			reg = <0x80000000 DT_SIZE_M(2048)>;
 			zephyr,memory-region = "DEVICE_REGION";
-			zephyr,memory-region-mpu = "IO";
+			zephyr,memory-attr = "IO";
 		};
 	};
 };

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -294,6 +294,15 @@ and properties related to them.
 
 .. doxygengroup:: devicetree-mbox
 
+.. _devicetree-memory-attr-api:
+
+Memory attributes
+=================
+
+These conveniences may be used for nodes with a memory attribute property.
+
+.. doxygengroup:: devicetree-memory-attr
+
 .. _devicetree-pinctrl-api:
 
 Pinctrl (pin control)

--- a/doc/hardware/arch/arm_cortex_m.rst
+++ b/doc/hardware/arch/arm_cortex_m.rst
@@ -440,9 +440,8 @@ are programmed during system boot.
   SRAM. (An exception to this setting is when :kconfig:option:`CONFIG_MPU_GAP_FILLING` is disabled (Arm v8-M only);
   in that case no SRAM MPU programming is done so the access is determined by the default
   Arm memory map policies, allowing for privileged-only RWX permissions on SRAM).
-* All the memory regions defined in the devicetree with the compatible
-  :dtcompatible:`zephyr,memory-region` and at least the property
-  ``zephyr,memory-region-mpu`` defining the MPU permissions for the memory region.
+* All the memory regions defined in the devicetree with the property
+  ``zephyr,memory-attr`` defining the MPU permissions for the memory region.
   See the next section for more details.
 
 The above MPU regions are defined in :file:`soc/arm/common/cortex_m/arm_mpu_regions.c`.
@@ -453,13 +452,12 @@ configure its own fixed MPU regions in the SoC definition.
 Fixed MPU regions defined in devicetree
 ---------------------------------------
 
-The user can define memory regions to be allocated and created in the linker
-script using nodes with the :dtcompatible:`zephyr,memory-region` devicetree
-compatible. When the property ``zephyr,memory-region-mpu`` is present in such
-a node, a new MPU region will be allocated and programmed during system
-boot.
+When the property ``zephyr,memory-attr`` is present in a memory node, a new MPU
+region will be allocated and programmed during system boot. When used with the
+:dtcompatible:`zephyr,memory-region` devicetree compatible, it will result in a
+linker section being generated associated to that MPU region.
 
-The property ``zephyr,memory-region-mpu`` is a string carrying the attributes
+The property ``zephyr,memory-attr`` is a string carrying the attributes
 for the MPU region. It is converted to a C token for use defining the attributes
 of the MPU region.
 
@@ -471,7 +469,7 @@ For example, to define a new non-cacheable memory region in devicetree:
         compatible = "zephyr,memory-region", "mmio-sram";
         reg = <0x20300000 0x100000>;
         zephyr,memory-region = "SRAM_NO_CACHE";
-        zephyr,memory-region-mpu = "RAM_NOCACHE";
+        zephyr,memory-attr = "RAM_NOCACHE";
    };
 
 This will automatically create a new MPU entry in

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -237,6 +237,14 @@ USB
 Devicetree
 **********
 
+* ``zephyr,memory-region-mpu`` was renamed ``zephyr,memory-attr``
+
+* The following macros were added:
+  :c:macro:`DT_FOREACH_NODE_VARGS`,
+  :c:macro:`DT_FOREACH_STATUS_OKAY_NODE_VARGS`
+  :c:macro:`DT_MEMORY_ATTR_FOREACH_NODE`
+  :c:macro:`DT_MEMORY_ATTR_APPLY`
+
 Libraries / Subsystems
 **********************
 

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -251,7 +251,7 @@ static int adc_stm32_dma_start(const struct device *dev,
  * The entire buffer must be in a single region.
  * An example of how the SRAM region can be defined in the DTS:
  *	&sram4 {
- *		zephyr,memory-region-mpu = "RAM_NOCACHE";
+ *		zephyr,memory-attr = "RAM_NOCACHE";
  *	};
  */
 static bool address_in_non_cacheable_sram(const uint16_t *buffer, const uint16_t size)
@@ -259,12 +259,12 @@ static bool address_in_non_cacheable_sram(const uint16_t *buffer, const uint16_t
 	/* Default if no valid SRAM region found or buffer+size not located in a single region */
 	bool cachable = false;
 #define IS_NON_CACHEABLE_REGION_FN(node_id)                                                    \
-	COND_CODE_1(DT_NODE_HAS_PROP(node_id, zephyr_memory_region_mpu), ({                    \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, zephyr_memory_attr), ({                          \
 			const uint32_t region_start = DT_REG_ADDR(node_id);                    \
 			const uint32_t region_end = region_start + DT_REG_SIZE(node_id);       \
 			if (((uint32_t)buffer >= region_start) &&                              \
 				(((uint32_t)buffer + size) < region_end)) {                    \
-				cachable = strcmp(DT_PROP(node_id, zephyr_memory_region_mpu),  \
+				cachable = strcmp(DT_PROP(node_id, zephyr_memory_attr),        \
 						"RAM_NOCACHE") == 0;                           \
 			}                                                                      \
 		}),                                                                            \

--- a/drivers/dma/dma_stm32_bdma.c
+++ b/drivers/dma/dma_stm32_bdma.c
@@ -809,11 +809,11 @@ static int bdma_stm32_init(const struct device *dev)
 	 * This check verifies that the non-cachable flag is set in the DTS.
 	 * For example:
 	 *	&sram4 {
-	 *		zephyr,memory-region-mpu = "RAM_NOCACHE";
+	 *		zephyr,memory-attr = "RAM_NOCACHE";
 	 *	};
 	 */
-#if DT_NODE_HAS_PROP(DT_NODELABEL(sram4), zephyr_memory_region_mpu)
-	if (strcmp(DT_PROP(DT_NODELABEL(sram4), zephyr_memory_region_mpu), "RAM_NOCACHE") != 0) {
+#if DT_NODE_HAS_PROP(DT_NODELABEL(sram4), zephyr_memory_attr)
+	if (strcmp(DT_PROP(DT_NODELABEL(sram4), zephyr_memory_attr), "RAM_NOCACHE") != 0) {
 		LOG_ERR("SRAM4 is not set as non-cachable.");
 		return -EIO;
 	}

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -61,7 +61,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20010000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "USB_SRAM";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 };
 

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -75,7 +75,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x40100000  DT_SIZE_K(16)>;
 		zephyr,memory-region = "USB_SRAM";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 };
 

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -95,7 +95,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x100000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "USB_SRAM";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 
 	syscon: syscon@0 {

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -49,7 +49,7 @@
 		compatible =  "zephyr,memory-region", "mmio-sram";
 		reg = <0x40140000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM1";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -48,7 +48,7 @@
 		compatible =  "zephyr,memory-region", "mmio-sram";
 		reg = <0x40140000 DT_SIZE_K(16)>;
 		zephyr,memory-region = "SRAM1";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 };
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -47,7 +47,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x90000000 DT_SIZE_M(256)>;
 		zephyr,memory-region = "QSPI";
-		zephyr,memory-region-mpu = "EXTMEM";
+		zephyr,memory-attr = "EXTMEM";
 	};
 
 	clocks {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -48,7 +48,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x90000000 DT_SIZE_M(256)>;
 		zephyr,memory-region = "QSPI";
-		zephyr,memory-region-mpu = "EXTMEM";
+		zephyr,memory-attr = "EXTMEM";
 	};
 
 	clocks {

--- a/dts/bindings/base/zephyr,memory-attr.yaml
+++ b/dts/bindings/base/zephyr,memory-attr.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2023, Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+include: [base.yaml]
+
+properties:
+  zephyr,memory-attr:
+    type: string
+    enum:
+      - "RAM"
+      - "RAM_NOCACHE"
+      - "FLASH"
+      - "PPB"
+      - "IO"
+      - "EXTMEM"
+    description: |
+      Attribute for the memory region.
+
+  reg:
+    required: true

--- a/dts/bindings/base/zephyr,memory-region.yaml
+++ b/dts/bindings/base/zephyr,memory-region.yaml
@@ -5,7 +5,7 @@ description: Compatible for devices resulting in linker memory regions
 
 compatible: "zephyr,memory-region"
 
-include: base.yaml
+include: [base.yaml, "zephyr,memory-attr.yaml"]
 
 properties:
   zephyr,memory-region:
@@ -16,17 +16,3 @@ properties:
       memory region in the final executable. The region address and size
       is taken from the <reg> property, while the name is the value of
       this property.
-
-  zephyr,memory-region-mpu:
-    type: string
-    enum:
-      - "RAM"
-      - "RAM_NOCACHE"
-      - "FLASH"
-      - "PPB"
-      - "IO"
-      - "EXTMEM"
-    description: |
-      Signify that this node should result in a dedicated MPU region. The
-      region address and size are taken from the <reg> property, while the MPU
-      attribute is the value of this property.

--- a/dts/bindings/test/vnd,memory-attr.yaml
+++ b/dts/bindings/test/vnd,memory-attr.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 Linaro Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test memory and memory attributes
+
+compatible: "vnd,memory-attr"
+
+include: [base.yaml, "zephyr,memory-attr.yaml"]

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -4286,5 +4286,6 @@
 #include <zephyr/devicetree/can.h>
 #include <zephyr/devicetree/reset.h>
 #include <zephyr/devicetree/mbox.h>
+#include <zephyr/devicetree/memory-attr.h>
 
 #endif /* DEVICETREE_H */

--- a/include/zephyr/devicetree/memory-attr.h
+++ b/include/zephyr/devicetree/memory-attr.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2023 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_MEMORY_ATTR_H_
+#define ZEPHYR_INCLUDE_MEMORY_ATTR_H_
+
+#include <zephyr/devicetree.h>
+#include <zephyr/linker/devicetree_regions.h>
+#include <zephyr/sys/util.h>
+
+/**
+ * @file
+ * @brief Memory-attr helpers
+ */
+
+/**
+ * @defgroup devicetree-memory-attr Memory attributes
+ * @ingroup devicetree
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+
+#define _DT_MEM_ATTR	zephyr_memory_attr
+#define _DT_ATTR(token)	UTIL_CAT(UTIL_CAT(REGION_, token), _ATTR)
+
+#define _UNPACK(node_id, fn)						\
+	fn(COND_CODE_1(DT_NODE_HAS_PROP(node_id, zephyr_memory_region),	\
+		       (LINKER_DT_NODE_REGION_NAME(node_id)),		\
+		       (DT_NODE_FULL_NAME(node_id))),			\
+	   DT_REG_ADDR(node_id),					\
+	   DT_REG_SIZE(node_id),					\
+	   _DT_ATTR(DT_STRING_TOKEN(node_id, _DT_MEM_ATTR))),
+
+#define _APPLY(node_id, fn)					\
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, _DT_MEM_ATTR),	\
+		    (_UNPACK(node_id, fn)),			\
+		    ())
+
+
+#define _FILTER(node_id, fn)					\
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, _DT_MEM_ATTR),	\
+		    (fn(node_id)),				\
+		    ())
+
+/** @endcond */
+
+/**
+ * @brief Invokes @p fn for every node in the tree with property
+ *        `zephyr,memory-attr`
+ *
+ * The macro @p fn must take one parameter, which will be a node identifier
+ * with the `zephyr,memory-attr` property. The macro is expanded once for each
+ * node in the tree. The order that nodes are visited in is not specified.
+ *
+ * @param fn macro to invoke
+ */
+#define DT_MEMORY_ATTR_FOREACH_NODE(fn) \
+	DT_FOREACH_STATUS_OKAY_NODE_VARGS(_FILTER, fn)
+
+/**
+ * @brief Invokes @p fn for MPU/MMU regions generation from the device tree
+ *	  nodes with `zephyr,memory-attr` property.
+ *
+ * Helper macro to invoke a @p fn macro on all the memory regions declared
+ * using the `zephyr,memory-attr` property
+ *
+ * The macro @p fn must take the form:
+ *
+ * @code{.c}
+ *   #define MPU_FN(name, base, size, attr) ...
+ * @endcode
+ *
+ * The @p name, @p base and @p size parameters are retrieved from the DT node.
+ * When the `zephyr,memory-region` property is present in the node, the @p name
+ * parameter is retrived from there, otherwise the full node name is used.
+ *
+ * The `zephyr,memory-attr` enum property is passed as an extended token
+ * to the @p fn macro using the @p attr parameter in the form of a macro
+ * REGION_{attr}_ATTR.
+ *
+ * The following enums are supported for the `zephyr,memory-attr` property (see
+ * `zephyr,memory-attr.yaml` for a complete list):
+ *
+ *  - RAM
+ *  - RAM_NOCACHE
+ *  - FLASH
+ *  - PPB
+ *  - IO
+ *  - EXTMEM
+ *
+ * This means that usually the user code would provide some macros or defines
+ * with the same name of the extended property, that is:
+ *
+ *  - REGION_RAM_ATTR
+ *  - REGION_RAM_NOCACHE_ATTR
+ *  - REGION_FLASH_ATTR
+ *  - REGION_PPB_ATTR
+ *  - REGION_IO_ATTR
+ *  - REGION_EXTMEM_ATTR
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     / {
+ *             soc {
+ *                     res0: memory@20000000 {
+ *                         reg = <0x20000000 0x4000>;
+ *                         zephyr,memory-region = "MY_NAME";
+ *                         zephyr,memory-attr = "RAM_NOCACHE";
+ *                     };
+ *
+ *                     res1: memory@30000000 {
+ *                         reg = <0x30000000 0x2000>;
+ *                         zephyr,memory-attr = "RAM";
+ *                     };
+
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *   #define REGION_RAM_NOCACHE_ATTR 0xAAAA
+ *   #define REGION_RAM_ATTR         0xBBBB
+ *   #define REGION_FLASH_ATTR       0xCCCC
+ *
+ *   #define MPU_FN(p_name, p_base, p_size, p_attr) \
+ *       {                                          \
+ *           .name = p_name,                        \
+ *           .base = p_base,                        \
+ *           .size = p_size,                        \
+ *           .attr = p_attr,                        \
+ *       }
+ *
+ *   static const struct arm_mpu_region mpu_regions[] = {
+ *       DT_MEMORY_ATTR_APPLY(MPU_FN)
+ *   };
+ * @endcode
+ *
+ * This expands to:
+ *
+ * @code{.c}
+ *   static const struct arm_mpu_region mpu_regions[] = {
+ *       { "MY_NAME",         0x20000000, 0x4000, 0xAAAA },
+ *       { "memory@30000000", 0x30000000, 0x2000, 0xBBBB },
+ *   };
+ * @endcode
+ *
+ * @param fn macro to invoke
+ */
+#define DT_MEMORY_ATTR_APPLY(fn) \
+	DT_FOREACH_STATUS_OKAY_NODE_VARGS(_APPLY, fn)
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_MEMORY_ATTR_H_ */

--- a/include/zephyr/linker/devicetree_regions.h
+++ b/include/zephyr/linker/devicetree_regions.h
@@ -92,8 +92,6 @@
 #define _DT_SECTION_SIZE(node_id)	UTIL_CAT(_DT_SECTION_PREFIX(node_id), _size)
 #define _DT_SECTION_LOAD(node_id)	UTIL_CAT(_DT_SECTION_PREFIX(node_id), _load_start)
 
-#define _DT_ATTR(token)			UTIL_CAT(UTIL_CAT(REGION_, token), _ATTR)
-
 /**
  * @brief Declare a memory region
  *
@@ -162,35 +160,6 @@
 	_DT_SECTION_SIZE(node_id) = _DT_SECTION_END(node_id) - _DT_SECTION_START(node_id);	\
 	_DT_SECTION_LOAD(node_id) = LOADADDR(LINKER_DT_NODE_REGION_NAME_TOKEN(node_id));
 
-/**
- * Call the user-provided MPU_FN() macro passing the expected arguments
- */
-#define _EXPAND_MPU_FN(node_id, MPU_FN, ...)					\
-	MPU_FN(LINKER_DT_NODE_REGION_NAME(node_id),				\
-	       DT_REG_ADDR(node_id),						\
-	       DT_REG_SIZE(node_id),						\
-	       _DT_ATTR(DT_STRING_TOKEN(node_id, zephyr_memory_region_mpu))),
-
-/**
- * Check that the node_id has both properties:
- *  - zephyr,memory-region-mpu
- *  - zephyr,memory-region
- *
- * and call the EXPAND_MPU_FN() macro
- */
-#define _CHECK_ATTR_FN(node_id, EXPAND_MPU_FN, ...)					\
-	COND_CODE_1(UTIL_AND(DT_NODE_HAS_PROP(node_id, zephyr_memory_region_mpu),	\
-			     DT_NODE_HAS_PROP(node_id, zephyr_memory_region)),		\
-		   (EXPAND_MPU_FN(node_id, __VA_ARGS__)),				\
-		   ())
-
-/**
- * Call _CHECK_ATTR_FN() for each enabled node passing EXPAND_MPU_FN() as
- * explicit argument and the user-provided MPU_FN() macro in __VA_ARGS__
- */
-#define _CHECK_APPLY_FN(compat, EXPAND_MPU_FN, ...)					\
-	DT_FOREACH_STATUS_OKAY_VARGS(compat, _CHECK_ATTR_FN, EXPAND_MPU_FN, __VA_ARGS__)
-
 /** @endcond */
 
 /**
@@ -210,88 +179,5 @@
  */
 #define LINKER_DT_SECTIONS() \
 	DT_FOREACH_STATUS_OKAY(_DT_COMPATIBLE, _SECTION_DECLARE)
-
-/**
- * @brief Generate MPU regions from the device tree nodes with compatible
- *        'zephyr,memory-region' and 'zephyr,memory-region-mpu' attribute.
- *
- * Helper macro to apply an MPU_FN macro to all the memory regions declared
- * using the 'zephyr,memory-region-mpu' property and the 'zephyr,memory-region'
- * compatible.
- *
- * @p MPU_FN must take the form:
- *
- * @code{.c}
- *   #define MPU_FN(name, base, size, attr) ...
- * @endcode
- *
- * The 'name', 'base' and 'size' parameters are taken from the DT node.
- *
- * The 'zephyr,memory-region-mpu' enum property is passed as an extended token
- * to the MPU_FN macro using the 'attr' parameter, in the form
- * REGION_{attr}_ATTR.
- *
- * The following enums are supported for the 'zephyr,memory-region-mpu'
- * property:
- *
- *  - RAM
- *  - RAM_NOCACHE
- *  - FLASH
- *  - PPB
- *  - IO
- *
- * This means that usually the arch code would provide some macros or defines
- * with the same name of the extended property, that is:
- *
- *  - REGION_RAM_ATTR
- *  - REGION_RAM_NOCACHE_ATTR
- *  - REGION_FLASH_ATTR
- *  - REGION_PPB_ATTR
- *  - REGION_IO_ATTR
- *
- * Example devicetree fragment:
- *
- *     / {
- *             soc {
- *                     sram1: memory@2000000 {
- *                         zephyr,memory-region = "MY_NAME";
- *                         zephyr,memory-region-mpu = "RAM_NOCACHE";
- *                     };
- *             };
- *     };
- *
- * For detailed information about MPU region attribute define configuration refer
- * to the specific architecture MPU header.
- * For example: include/zephyr/arch/arm/aarch32/mpu/arm_mpu_v7m.h.
- *
- * The 'attr' parameter of the MPU_FN function will be the extended
- * 'REGION_RAM_NOCACHE_ATTR' token and the arch code will be usually
- * implementing a macro with the same name.
- *
- * Example:
- *
- * @code{.c}
- *
- *   #define REGION_RAM_NOCACHE_ATTR 0xAAAA
- *   #define REGION_RAM_ATTR         0xBBBB
- *   #define REGION_FLASH_ATTR       0xCCCC
- *
- *   #define MPU_FN(p_name, p_base, p_size, p_attr) \
- *       {                                          \
- *           .name = p_name,                        \
- *           .base = p_base,                        \
- *           .size = p_size,                        \
- *           .attr = p_attr,                        \
- *       }
- *
- *   static const struct arm_mpu_region mpu_regions[] = {
- *       ...
- *       LINKER_DT_REGION_MPU(MPU_FN)
- *       ...
- *   };
- * @endcode
- *
- */
-#define LINKER_DT_REGION_MPU(mpu_fn) _CHECK_APPLY_FN(_DT_COMPATIBLE, _EXPAND_MPU_FN, mpu_fn)
 
 #endif /* ZEPHYR_INCLUDE_LINKER_DEVICETREE_REGIONS_H_ */

--- a/samples/subsys/ipc/openamp/boards/mimxrt1160_evk_cm7.overlay
+++ b/samples/subsys/ipc/openamp/boards/mimxrt1160_evk_cm7.overlay
@@ -17,6 +17,6 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x202c0000 DT_SIZE_K(16)>;
 		zephyr,memory-region="OCRAM2_OVERLAY";
-		zephyr,memory-region-mpu = "IO";
+		zephyr,memory-attr = "IO";
 	};
 };

--- a/samples/subsys/ipc/openamp/boards/mimxrt1170_evk_cm7.overlay
+++ b/samples/subsys/ipc/openamp/boards/mimxrt1170_evk_cm7.overlay
@@ -17,6 +17,6 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x202c0000 DT_SIZE_K(16)>;
 		zephyr,memory-region="OCRAM2_OVERLAY";
-		zephyr,memory-region-mpu = "IO";
+		zephyr,memory-attr = "IO";
 	};
 };

--- a/samples/subsys/ipc/openamp/boards/mimxrt1170_evkb_cm7.overlay
+++ b/samples/subsys/ipc/openamp/boards/mimxrt1170_evkb_cm7.overlay
@@ -17,6 +17,6 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x202c0000 DT_SIZE_K(16)>;
 		zephyr,memory-region="OCRAM2_OVERLAY";
-		zephyr,memory-region-mpu = "IO";
+		zephyr,memory-attr = "IO";
 	};
 };

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1160_evk_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1160_evk_cm4.overlay
@@ -33,7 +33,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x202c0000 DT_SIZE_K(16)>;
 		zephyr,memory-region="OCRAM2_OVERLAY";
-		zephyr,memory-region-mpu = "IO";
+		zephyr,memory-attr = "IO";
 	};
 };
 

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evk_cm4.overlay
@@ -33,7 +33,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x202c0000 DT_SIZE_K(16)>;
 		zephyr,memory-region="OCRAM2_OVERLAY";
-		zephyr,memory-region-mpu = "IO";
+		zephyr,memory-attr = "IO";
 	};
 };
 

--- a/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evkb_cm4.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/mimxrt1170_evkb_cm4.overlay
@@ -33,7 +33,7 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x202c0000 DT_SIZE_K(16)>;
 		zephyr,memory-region="OCRAM2_OVERLAY";
-		zephyr,memory-region-mpu = "IO";
+		zephyr,memory-attr = "IO";
 	};
 };
 

--- a/soc/arm/common/cortex_m/arm_mpu_regions.c
+++ b/soc/arm/common/cortex_m/arm_mpu_regions.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/sys/slist.h>
 #include <zephyr/arch/arm/aarch32/mpu/arm_mpu.h>
-#include <zephyr/linker/devicetree_regions.h>
+#include <zephyr/devicetree/memory-attr.h>
 
 #include "arm_mpu_mem_cfg.h"
 
@@ -31,7 +31,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 #endif
 
 	/* DT-defined regions */
-	LINKER_DT_REGION_MPU(ARM_MPU_REGION_INIT)
+	DT_MEMORY_ATTR_APPLY(ARM_MPU_REGION_INIT)
 };
 
 const struct arm_mpu_config mpu_config = {

--- a/soc/arm/nxp_s32/s32k/mpu_regions.c
+++ b/soc/arm/nxp_s32/s32k/mpu_regions.c
@@ -37,7 +37,7 @@ static struct arm_mpu_region mpu_regions[] = {
 #endif
 
 	/* DT-defined regions */
-	LINKER_DT_REGION_MPU(ARM_MPU_REGION_INIT)
+	DT_MEMORY_ATTR_APPLY(ARM_MPU_REGION_INIT)
 };
 
 const struct arm_mpu_config mpu_config = {

--- a/soc/arm/st_stm32/stm32h7/mpu_regions.c
+++ b/soc/arm/st_stm32/stm32h7/mpu_regions.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/devicetree.h>
-#include <zephyr/linker/devicetree_regions.h>
 #include "../../common/cortex_m/arm_mpu_mem_cfg.h"
 
 static const struct arm_mpu_region mpu_regions[] = {
@@ -32,7 +31,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 #endif
 
 	/* DT-defined regions */
-	LINKER_DT_REGION_MPU(ARM_MPU_REGION_INIT)
+	DT_MEMORY_ATTR_APPLY(ARM_MPU_REGION_INIT)
 };
 
 const struct arm_mpu_config mpu_config = {

--- a/soc/arm64/arm/fvp_aemv8r/arm_mpu_regions.c
+++ b/soc/arm64/arm/fvp_aemv8r/arm_mpu_regions.c
@@ -7,7 +7,7 @@
 
 #include <zephyr/arch/arm64/cortex_r/arm_mpu.h>
 #include <zephyr/linker/linker-defs.h>
-#include <zephyr/linker/devicetree_regions.h>
+#include <zephyr/devicetree/memory-attr.h>
 #include <zephyr/sys/util.h>
 
 static const struct arm_mpu_region mpu_regions[] = {
@@ -41,7 +41,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 			 REGION_RAM_ATTR),
 
 	/* Extra regions defined in device tree */
-	LINKER_DT_REGION_MPU(MPU_REGION_ENTRY_FROM_DTS)
+	DT_MEMORY_ATTR_APPLY(MPU_REGION_ENTRY_FROM_DTS)
 };
 
 const struct arm_mpu_config mpu_config = {

--- a/tests/arch/arm/arm_mpu_regions/boards/mps2_an385.overlay
+++ b/tests/arch/arm/arm_mpu_regions/boards/mps2_an385.overlay
@@ -16,21 +16,21 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20200000 0x100000>;
 		zephyr,memory-region = "SRAM_CACHE";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 
 	sram_no_cache: memory@20300000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20300000 0x100000>;
 		zephyr,memory-region = "SRAM_NO_CACHE";
-		zephyr,memory-region-mpu = "RAM_NOCACHE";
+		zephyr,memory-attr = "RAM_NOCACHE";
 	};
 
 	sram_dtcm_fake: memory@abcdabcd {
 		compatible = "zephyr,memory-region", "arm,dtcm";
 		reg = <0xabcdabcd 0x100000>;
 		zephyr,memory-region = "SRAM_DTCM_FAKE";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 
 	sram_no_mpu: memory@deaddead {

--- a/tests/drivers/adc/adc_dma/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/adc/adc_dma/boards/nucleo_h743zi.overlay
@@ -22,7 +22,7 @@
 
 /* ADC driver expects a buffer in a non-cachable memory region */
 &sram4 {
-	zephyr,memory-region-mpu = "RAM_NOCACHE";
+	zephyr,memory-attr = "RAM_NOCACHE";
 };
 
 &dma1 {

--- a/tests/drivers/dma/chan_blen_transfer/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/nucleo_h743zi.overlay
@@ -18,7 +18,7 @@ test_dma0: &dmamux1 {
  * to be non-cachable.
  */
 &sram4 {
-	zephyr,memory-region-mpu = "RAM_NOCACHE";
+	zephyr,memory-attr = "RAM_NOCACHE";
 };
 
 &bdma1 {

--- a/tests/drivers/dma/loop_transfer/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/nucleo_h743zi.overlay
@@ -18,7 +18,7 @@ test_dma0: &dmamux1 {
  * to be non-cachable.
  */
 &sram4 {
-	zephyr,memory-region-mpu = "RAM_NOCACHE";
+	zephyr,memory-attr = "RAM_NOCACHE";
 };
 
 &bdma1 {

--- a/tests/kernel/mem_heap/shared_multi_heap/boards/mps2_an521.overlay
+++ b/tests/kernel/mem_heap/shared_multi_heap/boards/mps2_an521.overlay
@@ -17,20 +17,20 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x38100000 0x1000>;
 		zephyr,memory-region = "RES0";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 
 	res1: memory@38200000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x38200000 0x2000>;
 		zephyr,memory-region = "RES1";
-		zephyr,memory-region-mpu = "RAM_NOCACHE";
+		zephyr,memory-attr = "RAM_NOCACHE";
 	};
 
 	res2: memory@38300000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x38300000 0x3000>;
 		zephyr,memory-region = "RES2";
-		zephyr,memory-region-mpu = "RAM";
+		zephyr,memory-attr = "RAM";
 	};
 };

--- a/tests/kernel/mem_heap/shared_multi_heap/boards/qemu_cortex_a53.overlay
+++ b/tests/kernel/mem_heap/shared_multi_heap/boards/qemu_cortex_a53.overlay
@@ -10,14 +10,14 @@
 			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x0 0x42000000 0x0 0x1000>;
 			zephyr,memory-region = "RES0";
-			zephyr,memory-region-mpu = "RAM";
+			zephyr,memory-attr = "RAM";
 		};
 
 		res1: memory@43000000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x0 0x43000000 0x0 0x2000>;
 			zephyr,memory-region = "RES1";
-			zephyr,memory-region-mpu = "RAM_NOCACHE";
+			zephyr,memory-attr = "RAM_NOCACHE";
 		};
 
 		res_no_mpu: memory@45000000 {
@@ -30,7 +30,7 @@
 			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = <0x0 0x44000000 0x0 0x3000>;
 			zephyr,memory-region = "RES2";
-			zephyr,memory-region-mpu = "RAM";
+			zephyr,memory-attr = "RAM";
 		};
 	};
 };

--- a/tests/kernel/mem_heap/shared_multi_heap/src/main.c
+++ b/tests/kernel/mem_heap/shared_multi_heap/src/main.c
@@ -27,7 +27,7 @@ struct region_map {
 		.region = {								\
 			.addr = (uintptr_t) DT_INST_REG_ADDR(n),			\
 			.size = DT_INST_REG_SIZE(n),					\
-			.attr = DT_INST_ENUM_IDX_OR(n, zephyr_memory_region_mpu,	\
+			.attr = DT_INST_ENUM_IDX_OR(n, zephyr_memory_attr,		\
 						    SMH_REG_ATTR_NUM),			\
 		},									\
 	},
@@ -103,7 +103,7 @@ static void fill_multi_heap(void)
 	for (size_t idx = 0; idx < DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT); idx++) {
 		reg_map = &map[idx];
 
-		/* zephyr,memory-region-mpu property not found. Skip it. */
+		/* zephyr,memory-attr property not found. Skip it. */
 		if (reg_map->region.attr == SMH_REG_ATTR_NUM) {
 			continue;
 		}

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -636,6 +636,19 @@
 			compatible = "vnd,string-array-unquoted";
 			val = "XA XPLUS XB", "XC XPLUS XD", "XA XMINUS XB", "XC XMINUS XD";
 		};
+
+		test_mem_ram: memory@aabbccdd {
+			compatible = "vnd,memory-attr";
+			reg = < 0xaabbccdd 0x4000 >;
+			zephyr,memory-attr = "RAM";
+		};
+
+		test_mem_ram_nocache: memory@44332211 {
+			compatible = "vnd,memory-attr";
+			reg = < 0x44332211 0x2000 >;
+			zephyr,memory-attr = "RAM_NOCACHE";
+		};
+
 	};
 
 	test_64 {


### PR DESCRIPTION
The `zephyr,memory-region-mpu` property was added in #43119 as a convenient way to create and configure MPU regions using information coming from DT. It has been used a lot since it was introduced so I guess we can consider it a Zephyr success story ™ .

Unfortunately it has been proved to be a bit limited and with some important limitations:

1. It was introduced as a property of the compatible `zephyr,memory-region` that is used to create linker regions and sections from DT data. This means that we can actually create MPU regions only for DT-defined regions and sections.
2. The naming is unfortunate because it is implying that it is used only for MPU.
4. It is misplaced being in `include/zephyr/linker/devicetree_regions.h` and still it has nothing to do with the linker at all.
5. It is exporting a function called `LINKER_DT_REGION_MPU` that again has nothing to do with the linker.

Point (1) is also particularly limiting because it is preventing us to characterize memory regions that are not generated using the `zephyr,memory-region` compatible, like generic `mmio-sram` regions.

While we fix all the issues, we also want to extend a bit the range of usefulness of this property. We are renaming it `zephyr,memory-attr` and it is now carrying information about the type of memory the property is attached to (cacheable, non-cacheable, IO, eXecutable, etc...). The user can use this property and the DT API coming with it to act on the memory node it is accompanied by. 

We are still providing the `DT_MEMORY_ATTR_APPLY()` macro that can be used to create the MPU regions as before, but we are adding also a `DT_MEMORY_ATTR_FOREACH_NODE()` macro that can be used to cycle through the memory nodes and act on those.

Some use-cases:
- We want to be able to cycle and identify memory regions with some attributes.
- We want to be able to check whether a buffer is inside a memory region with some attribute (see for example #57786).
- We want to be able to generate MMU regions from DT.

In general the idea is being able to detect and work with memory regions and their attributes in an easy way instead of resorting to custom code.