### PR TITLE
scripts: west: runners: esp32: add support for disabling flasher stub

### DIFF
--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -69,7 +69,7 @@ jobs:
     - name: install pytest
       run: |
         pip3 install wheel
-        pip3 install pytest west pyelftools canopen progress mypy intelhex psutil ply pyserial
+        pip3 install pytest west pyelftools canopen natsort progress mypy intelhex psutil ply pyserial
     - name: run pytest-win
       if: runner.os == 'Windows'
       run: |


### PR DESCRIPTION
Add support for disabling loading of the flasher stub and instead only talk to the ROM bootloader.

Also, added missing `natsort` Python package for running the west_cmd Python tests (please see commit log).