### PR TITLE
bluetooth: tester: bap: Add support for AC 7(i) tests

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_ascs.h
+++ b/tests/bluetooth/tester/src/btp/btp_ascs.h
@@ -73,6 +73,14 @@ struct btp_ascs_update_metadata_cmd {
 	uint8_t ase_id;
 } __packed;
 
+#define BTP_ASCS_ADD_ASE_TO_CIS	0x0a
+struct btp_ascs_add_ase_to_cis {
+	bt_addr_le_t address;
+	uint8_t ase_id;
+	uint8_t cig_id;
+	uint8_t cis_id;
+} __packed;
+
 /* ASCS events */
 #define BTP_ASCS_EV_OPERATION_COMPLETED	0x80
 struct btp_ascs_operation_completed_ev {
@@ -83,6 +91,15 @@ struct btp_ascs_operation_completed_ev {
 
 	/* RFU */
 	uint8_t flags;
+} __packed;
+
+#define BTP_ASCS_EV_CHARACTERISTIC_SUBSCRIBED 0x81
+
+#define BTP_ASCS_EV_ASE_STATE_CHANGED	0x82
+struct btp_ascs_ase_state_changed_ev {
+	bt_addr_le_t address;
+	uint8_t ase_id;
+	uint8_t state;
 } __packed;
 
 #define BTP_ASCS_STATUS_SUCCESS	0x00


### PR DESCRIPTION
Allow to assing end points to CISes before creating a CIG. Previously the end points were assinged top-down, so the configuration 7(i) was not covered.