### PR TITLE
Get rid of need for -T /dev/null with picolibc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,8 +485,9 @@ if(CONFIG_USERSPACE)
 endif()
 
 get_property(TOPT GLOBAL PROPERTY TOPT)
-set_ifndef(  TOPT -Wl,-T) # clang doesn't pick -T for some reason and complains,
-                          # while -Wl,-T works for both, gcc and clang
+get_property(COMPILER_TOPT TARGET compiler PROPERTY linker_script)
+set_ifndef(  TOPT "${COMPILER_TOPT}")
+set_ifndef(  TOPT -Wl,-T) # Use this if the compiler driver doesn't set a value
 
 if(CONFIG_HAVE_CUSTOM_LINKER_SCRIPT)
   set(LINKER_SCRIPT ${APPLICATION_SOURCE_DIR}/${CONFIG_CUSTOM_LINKER_SCRIPT})

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -23,6 +23,9 @@ set_compiler_property(PROPERTY diagnostic -fcolor-diagnostics)
 # clang flag to save temporary object files
 set_compiler_property(PROPERTY save_temps -save-temps)
 
+# clang doesn't handle the -T flag
+set_compiler_property(PROPERTY linker_script -Wl,-T)
+
 #######################################################
 # This section covers flags related to warning levels #
 #######################################################

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -106,6 +106,9 @@ set_compiler_property(PROPERTY debug)
 # Flags to save temporary object files
 set_compiler_property(PROPERTY save_temps)
 
+# Flag to specify linker script
+set_compiler_property(PROPERTY linker_script)
+
 set_compiler_property(PROPERTY no_common)
 
 # Flags for imacros. The specific header must be appended by user.

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -182,6 +182,9 @@ set_compiler_property(PROPERTY debug -g)
 # Flags to save temporary object files
 set_compiler_property(PROPERTY save_temps -save-temps=obj)
 
+# Flag to specify linker script
+set_compiler_property(PROPERTY linker_script -T)
+
 # Flags to not track macro expansion
 set_compiler_property(PROPERTY no_track_macro_expansion -ftrack-macro-expansion=0)
 

--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT CONFIG_PICOLIBC_USE_MODULE)
 
   zephyr_compile_options(--specs=picolibc.specs)
   zephyr_compile_definitions(_POSIX_C_SOURCE=200809)
-  zephyr_libc_link_libraries(-T/dev/null --specs=picolibc.specs c -lgcc)
+  zephyr_libc_link_libraries(--specs=picolibc.specs c -lgcc)
   if(CONFIG_PICOLIBC_IO_FLOAT)
     zephyr_compile_definitions(PICOLIBC_DOUBLE_PRINTF_SCANF)
     zephyr_link_libraries(-DPICOLIBC_DOUBLE_PRINTF_SCANF)


### PR DESCRIPTION
Picolibc's linker flags includes `-T /dev/null`, which won't work on non-POSIX systems. This is used because the picolibc gcc .specs file looks to see if the linker command line includes a linker script. If it doesn't, the specs file inserts the picolibc linker script. This allows simple applications as are often used in build scripts to not need a linker script of their own. 

Zephyr provides a linker script itself, but because clang doesn't support the `-T` option, it used `-Wl,-T` to pass the script file name through the compiler driver to the linker. This meant that picolibc's heuristic for detecting whether a script file has been provided fails and the picolibc linker script gets added to the linker command line. This was kludged around by adding `-T /dev/null` in the picolibc zephyr cmake bits.

Fix this by using `-T` for gcc while leaving other compilers continuing to use `-Wl,-T` when specifying the Zephyr linker script. This allows us to remove the `-T /dev/null` from the picolibc bits.

This should be a reasonable replacement for #60042 
Fixes: #60040 