### PR TITLE
doc: Remove sphinx warning bt_ots_init pattern

### DIFF
--- a/doc/known-warnings.txt
+++ b/doc/known-warnings.txt
@@ -7,7 +7,6 @@
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*dmic_trigger.*'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: dma_config'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: net_if_mcast_monitor'.*
-.*Duplicate C declaration.*\n.*'\.\. c:struct:: bt_ots_init'.*
 
 # Struct and typedef name
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: zsock_fd_set'.*


### PR DESCRIPTION
The bt_ots_init struct has been renamed to bt_ots_init_param in commit:

  cf0ff30b530a9897c34fb5106c2716d3c13945d6

That was previously triggering a warning in Sphinx, due to the same name being used for a struct and function, and this pattern was designed to silence it. We don't need the pattern any more as the warning is gone.