### PR TITLE
intel_adsp: boot: d3: hp sram reinit

### DIFF
--- a/soc/xtensa/intel_adsp/ace/boot.c
+++ b/soc/xtensa/intel_adsp/ace/boot.c
@@ -48,6 +48,8 @@ __imr void boot_d3_restore(void)
 	/* reset memory hole */
 	CAVS_SHIM.l2mecs = 0;
 #endif
+	extern void hp_sram_init(uint32_t memory_size);
+	hp_sram_init(L2_SRAM_SIZE);
 
 	extern void lp_sram_init(void);
 	lp_sram_init();


### PR DESCRIPTION
Adding HP SRAM initialization in D3 power state exit procedure.