### PR TITLE
Picolibc fixes

### DIFF
--- a/lib/libc/picolibc/libc-hooks.c
+++ b/lib/libc/picolibc/libc-hooks.c
@@ -154,22 +154,6 @@ SYS_INIT(picolibc_locks_prepare, POST_KERNEL,
 	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif /* CONFIG_USERSPACE */
 
-/* Create a new dynamic non-recursive lock */
-void __retarget_lock_init(_LOCK_T *lock)
-{
-	__ASSERT_NO_MSG(lock != NULL);
-
-	/* Allocate semaphore object */
-#ifndef CONFIG_USERSPACE
-	*lock = malloc(sizeof(struct k_sem));
-#else
-	*lock = k_object_alloc(K_OBJ_SEM);
-#endif /* !CONFIG_USERSPACE */
-	__ASSERT(*lock != NULL, "non-recursive lock allocation failed");
-
-	k_sem_init((struct k_sem *)*lock, 1, 1);
-}
-
 /* Create a new dynamic recursive lock */
 void __retarget_lock_init_recursive(_LOCK_T *lock)
 {
@@ -186,15 +170,10 @@ void __retarget_lock_init_recursive(_LOCK_T *lock)
 	k_mutex_init((struct k_mutex *)*lock);
 }
 
-/* Close dynamic non-recursive lock */
-void __retarget_lock_close(_LOCK_T lock)
+/* Create a new dynamic non-recursive lock */
+void __retarget_lock_init(_LOCK_T *lock)
 {
-	__ASSERT_NO_MSG(lock != NULL);
-#ifndef CONFIG_USERSPACE
-	free(lock);
-#else
-	k_object_release(lock);
-#endif /* !CONFIG_USERSPACE */
+	__retarget_lock_init_recursive(lock);
 }
 
 /* Close dynamic recursive lock */
@@ -208,11 +187,10 @@ void __retarget_lock_close_recursive(_LOCK_T lock)
 #endif /* !CONFIG_USERSPACE */
 }
 
-/* Acquiure non-recursive lock */
-void __retarget_lock_acquire(_LOCK_T lock)
+/* Close dynamic non-recursive lock */
+void __retarget_lock_close(_LOCK_T lock)
 {
-	__ASSERT_NO_MSG(lock != NULL);
-	k_sem_take((struct k_sem *)lock, K_FOREVER);
+	__retarget_lock_close_recursive(lock);
 }
 
 /* Acquiure recursive lock */
@@ -222,11 +200,10 @@ void __retarget_lock_acquire_recursive(_LOCK_T lock)
 	k_mutex_lock((struct k_mutex *)lock, K_FOREVER);
 }
 
-/* Try acquiring non-recursive lock */
-int __retarget_lock_try_acquire(_LOCK_T lock)
+/* Acquiure non-recursive lock */
+void __retarget_lock_acquire(_LOCK_T lock)
 {
-	__ASSERT_NO_MSG(lock != NULL);
-	return !k_sem_take((struct k_sem *)lock, K_NO_WAIT);
+	__retarget_lock_acquire_recursive(lock);
 }
 
 /* Try acquiring recursive lock */
@@ -236,11 +213,10 @@ int __retarget_lock_try_acquire_recursive(_LOCK_T lock)
 	return !k_mutex_lock((struct k_mutex *)lock, K_NO_WAIT);
 }
 
-/* Release non-recursive lock */
-void __retarget_lock_release(_LOCK_T lock)
+/* Try acquiring non-recursive lock */
+int __retarget_lock_try_acquire(_LOCK_T lock)
 {
-	__ASSERT_NO_MSG(lock != NULL);
-	k_sem_give((struct k_sem *)lock);
+	return __retarget_lock_try_acquire_recursive(lock);
 }
 
 /* Release recursive lock */
@@ -248,6 +224,12 @@ void __retarget_lock_release_recursive(_LOCK_T lock)
 {
 	__ASSERT_NO_MSG(lock != NULL);
 	k_mutex_unlock((struct k_mutex *)lock);
+}
+
+/* Release non-recursive lock */
+void __retarget_lock_release(_LOCK_T lock)
+{
+	__retarget_lock_release_recursive(lock);
 }
 
 #endif /* CONFIG_MULTITHREADING */

--- a/subsys/net/ip/Kconfig.mgmt
+++ b/subsys/net/ip/Kconfig.mgmt
@@ -22,6 +22,7 @@ if NET_MGMT_EVENT
 config NET_MGMT_EVENT_STACK_SIZE
 	int "Stack size for the inner thread handling event callbacks"
 	default 2048 if COVERAGE_GCOV
+	default 800 if THREAD_LOCAL_STORAGE
 	default 768
 	help
 	  Set the internal stack size for NM to run registered callbacks


### PR DESCRIPTION
Recent changes in the kernel regressed a couple of test cases when using picolibc as the default C library.

 1. The kernel.memory_protection.mem_map failed on qemu_x86_tiny because the test case takes more memory. Before this fix, when using picolibc it used all available memory leaving no space for even a single page allocation.
 2. The 768 byte network management event stack was completely filled; allocating 8 bytes of thread local storage data caused a stack overflow fault.