### PR TITLE
west.yaml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -271,7 +271,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 74c4d1c52fd51d07904b27a7aa9b2303e896a4e3
+      revision: 6a8746d7acd75ff81fb6888d7776f412663f7897
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  6a8746d7acd75ff81fb6888d7776f412663f7897

Brings following Zephyr relevant fixes:
 - 6a8746d boot_serial: fix image number handle in image upload request
 - f2cb550 boot_serial: fix misuse of 'matched' param from zcbor_map_decode_bulk()
 - 82feb9a boot_serial: Fix showing images that are not valid
 - 61962b9 bootutil: fix FIH int conversion for security_cnt
 - e6e4801 zephyr/boot_serial_extension: Fix zcbor header path
 - a5db515 bootutil/crypto: SHA256 abort function return state
 - 0361ad3 bootutil/crypto: SHA256 init functions should return a status
 - f92a219 bootutil/crypto: Fix minor typos in comments for RSA modules
 - 4854700 bootutil: Add image_index to additional logging messages
 - 2f85b7e bootutil/crypto: Fix the common.h header
 - c321a70 bootutil/crypto: Add a crypto backend for SHA256 based on PSA Crypto APIs
 - 02bf072 bootutil/crypto: Refactor the RSA signature verification and encryption
 - ba5fb1c bootutil: Add image_index to common prints

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.