### PR TITLE
samples: zbus: add leading zeros while printing duration

### DIFF
--- a/samples/subsys/zbus/benchmark/src/benchmark.c
+++ b/samples/subsys/zbus/benchmark/src/benchmark.c
@@ -200,7 +200,7 @@ static void producer_thread(void)
 
 	LOG_INF("Bytes sent = %lld, received = %lu", BYTES_TO_BE_SENT, atomic_get(&count));
 	LOG_INF("Average data rate: %llu.%lluMB/s", i, f);
-	LOG_INF("Duration: %llu.%llus", duration / NSEC_PER_SEC, duration % NSEC_PER_SEC);
+	LOG_INF("Duration: %lld.%09llus", duration / NSEC_PER_SEC, duration % NSEC_PER_SEC);
 
 	printk("\n@%llu\n", duration);
 }


### PR DESCRIPTION

This change will print leading zeros in the event of duration being less that 0.1 nano-secs