### PR TITLE
samples: subsys: usb cdc acm composite with mini nb of USB EndPoints

### DIFF
--- a/samples/subsys/usb/cdc_acm_composite/sample.yaml
+++ b/samples/subsys/usb/cdc_acm_composite/sample.yaml
@@ -1,9 +1,14 @@
 sample:
+  description: Application with two CDC ACM instances requires at least
+    two OUT and four IN endpoints on the USB device controller.
   name: CDC ACM Composite USB
 tests:
   sample.usb.cdc-acm-composite:
     depends_on: usb_device
     tags: usb
+    platform_exclude:
+      - nucleo_f429zi
+      - nucleo_f207zg
     arch_exclude: posix
     harness: console
     harness_config:


### PR DESCRIPTION
The stm32f207 and stm32f429 target boards only have 4 bidir EP on the USB FS node
This is not enough to run the sample: simply exclude those 2 target platforms


Signed-off-by: Francois Ramu <francois.ramu@st.com>