### PR TITLE
Bluetooth: audio: unicast_server: Do not store metadata if rejected

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -129,14 +129,14 @@ int bt_bap_unicast_server_metadata(struct bt_bap_stream *stream, struct bt_audio
 		err = -ENOTSUP;
 	}
 
-	ep = stream->ep;
-	for (size_t i = 0U; i < meta_count; i++) {
-		(void)memcpy(&ep->codec_cfg.meta[i], &meta[i], sizeof(ep->codec_cfg.meta[i]));
-	}
-
 	if (err) {
 		LOG_ERR("Metadata failed: err %d, code %u, reason %u", err, rsp.code, rsp.reason);
 		return err;
+	}
+
+	ep = stream->ep;
+	for (size_t i = 0U; i < meta_count; i++) {
+		(void)memcpy(&ep->codec_cfg.meta[i], &meta[i], sizeof(ep->codec_cfg.meta[i]));
 	}
 
 	/* Set the state to the same state to trigger the notifications */


### PR DESCRIPTION
This moves copying of parameters after application return value validation so that the metadata is not stored if rejected.