### PR TITLE
mbedtls: fix _mbedtls_init() invocation

### DIFF
--- a/modules/mbedtls/zephyr_init.c
+++ b/modules/mbedtls/zephyr_init.c
@@ -105,5 +105,5 @@ SYS_INIT(_mbedtls_init, POST_KERNEL, 0);
  */
 int mbedtls_init(void)
 {
-	return _mbedtls_init(NULL);
+	return _mbedtls_init();
 }


### PR DESCRIPTION
`SYS_INIT()` requires pointer to function that takes `void` now, instead of
pointer to device structure. Since the commit was developed before that
switch, it still invoked it with `NULL`. Fix that now.

Fixes:
```
zephyr/modules/mbedtls/zephyr_init.c: In function 'mbedtls_init':
zephyr/modules/mbedtls/zephyr_init.c:108:16: error: too many arguments \
                                            to function '_mbedtls_init'
  108 |         return _mbedtls_init(NULL);
      |                ^~~~~~~~~~~~~
zephyr/modules/mbedtls/zephyr_init.c:86:12: note: declared here
   86 | static int _mbedtls_init(void)
      |
```