### PR TITLE
mbedtls: fix extra arg to function call

### DIFF
--- a/modules/mbedtls/zephyr_init.c
+++ b/modules/mbedtls/zephyr_init.c
@@ -105,5 +105,5 @@ SYS_INIT(_mbedtls_init, POST_KERNEL, 0);
  */
 int mbedtls_init(void)
 {
-	return _mbedtls_init(NULL);
+	return _mbedtls_init();
 }


### PR DESCRIPTION
_mbedtls_init doesnt accept any arg, remove the NULL.

Got this [error](https://github.com/zephyrproject-rtos/zephyr/actions/runs/5474196050/jobs/9968672109?pr=60083):
```
/__w/zephyr/zephyr/modules/mbedtls/zephyr_init.c:108:23: error: too many arguments to function call, expected 0, have 1
        return _mbedtls_init(NULL);
               ~~~~~~~~~~~~~ ^~~~
/usr/lib/llvm-16/lib/clang/16/include/stddef.h:89:16: note: expanded from macro 'NULL'
#  define NULL ((void*)0)
               ^~~~~~~~~~
/__w/zephyr/zephyr/modules/mbedtls/zephyr_init.c:86:12: note: '_mbedtls_init' declared here
static int _mbedtls_init(void)
           ^
1 error generated.
```
 in https://github.com/zephyrproject-rtos/zephyr/pull/60083