### PR TITLE
Bluetooth: audio: ascs: Refactor ASE Release and ASE Disable handlers

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -2885,37 +2885,14 @@ int bt_ascs_init(const struct bt_bap_unicast_server_cb *cb)
 	return 0;
 }
 
-static void ase_cleanup(struct bt_ascs_ase *ase)
-{
-	struct bt_bap_ascs_rsp rsp;
-	struct bt_bap_stream *stream;
-	enum bt_bap_ep_state state;
-
-	state = ascs_ep_get_state(&ase->ep);
-	if (state == BT_BAP_EP_STATE_IDLE || state == BT_BAP_EP_STATE_RELEASING) {
-		return;
-	}
-
-	stream = ase->ep.stream;
-	__ASSERT(stream != NULL, "ep.stream is NULL");
-
-	if (unicast_server_cb != NULL && unicast_server_cb->release != NULL) {
-		unicast_server_cb->release(stream, &rsp);
-	}
-
-	ascs_ep_set_state(&ase->ep, BT_BAP_EP_STATE_RELEASING);
-}
-
 void bt_ascs_cleanup(void)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(ase_pool); i++) {
 		struct bt_ascs_ase *ase = &ase_pool[i];
 
-		if (ase->conn == NULL) {
-			continue;
+		if (ase->conn != NULL) {
+			bt_ascs_release_ase(&ase->ep);
 		}
-
-		ase_cleanup(ase);
 	}
 
 	if (unicast_server_cb != NULL) {

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -345,6 +345,7 @@ void ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state);
 int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 		       struct bt_audio_codec_cfg *codec_cfg,
 		       const struct bt_audio_codec_qos_pref *qos_pref);
+int bt_ascs_disable_ase(struct bt_bap_ep *ep);
 int bt_ascs_release_ase(struct bt_bap_ep *ep);
 
 void bt_ascs_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func, void *user_data);

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -345,5 +345,6 @@ void ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state);
 int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 		       struct bt_audio_codec_cfg *codec_cfg,
 		       const struct bt_audio_codec_qos_pref *qos_pref);
+int bt_ascs_release_ase(struct bt_bap_ep *ep);
 
 void bt_ascs_foreach_ep(struct bt_conn *conn, bt_bap_ep_func_t func, void *user_data);

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -182,33 +182,7 @@ int bt_bap_unicast_server_disable(struct bt_bap_stream *stream)
 
 int bt_bap_unicast_server_release(struct bt_bap_stream *stream)
 {
-	struct bt_bap_ascs_rsp rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS,
-						     BT_BAP_ASCS_REASON_NONE);
-	struct bt_bap_ep *ep;
-	int err;
-
-	if (unicast_server_cb != NULL && unicast_server_cb->release != NULL) {
-		err = unicast_server_cb->release(stream, &rsp);
-	} else {
-		err = -ENOTSUP;
-	}
-
-	if (err != 0) {
-		LOG_ERR("Release failed: err %d, code %u, reason %u", err, rsp.code, rsp.reason);
-		return err;
-	}
-
-	ep = stream->ep;
-
-	/* Set reason in case this exits the streaming state */
-	ep->reason = BT_HCI_ERR_LOCALHOST_TERM_CONN;
-
-	/* ase_process will set the state to IDLE after sending the
-	 * notification, finalizing the release
-	 */
-	ascs_ep_set_state(ep, BT_BAP_EP_STATE_RELEASING);
-
-	return 0;
+	return bt_ascs_release_ase(stream->ep);
 }
 
 int bt_bap_unicast_server_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -147,37 +147,7 @@ int bt_bap_unicast_server_metadata(struct bt_bap_stream *stream, struct bt_audio
 
 int bt_bap_unicast_server_disable(struct bt_bap_stream *stream)
 {
-	struct bt_bap_ep *ep;
-	struct bt_bap_ascs_rsp rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS,
-						     BT_BAP_ASCS_REASON_NONE);
-	int err;
-
-	if (unicast_server_cb != NULL && unicast_server_cb->disable != NULL) {
-		err = unicast_server_cb->disable(stream, &rsp);
-	} else {
-		err = -ENOTSUP;
-	}
-
-	if (err != 0) {
-		LOG_ERR("Disable failed: err %d, code %u, reason %u", err, rsp.code, rsp.reason);
-		return err;
-	}
-
-	ep = stream->ep;
-
-	/* Set reason in case this exits the streaming state */
-	ep->reason = BT_HCI_ERR_LOCALHOST_TERM_CONN;
-
-	/* The ASE state machine goes into different states from this operation
-	 * based on whether it is a source or a sink ASE.
-	 */
-	if (ep->dir == BT_AUDIO_DIR_SOURCE) {
-		ascs_ep_set_state(ep, BT_BAP_EP_STATE_DISABLING);
-	} else {
-		ascs_ep_set_state(ep, BT_BAP_EP_STATE_QOS_CONFIGURED);
-	}
-
-	return 0;
+	return bt_ascs_disable_ase(stream->ep);
 }
 
 int bt_bap_unicast_server_release(struct bt_bap_stream *stream)


### PR DESCRIPTION
This removes code duplicates so that ase_release and ase_disable
functions can be called to handle both client and server initiated
operations.