### PR TITLE
native simulator: Update & make host trampolines available to all posix arch boards

### DIFF
--- a/arch/posix/core/CMakeLists.txt
+++ b/arch/posix/core/CMakeLists.txt
@@ -18,6 +18,7 @@ if(CONFIG_NATIVE_APPLICATION)
 		posix_core.c
 		nsi_compat/nsi_compat.c
 		${ZEPHYR_BASE}/scripts/native_simulator/common/src/nce.c
+		${ZEPHYR_BASE}/scripts/native_simulator/common/src/nsi_host_trampolines.c
 	)
 else()
 	zephyr_library_sources(

--- a/arch/posix/core/nsi_compat/nsi_host_trampolines.h
+++ b/arch/posix/core/nsi_compat/nsi_host_trampolines.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Note: This is a provisional header which exists to allow
+ * old POSIX arch based boards (i.e. native_posix) to provide access
+ * to the host C library as if the native simulator trampolines
+ * existed.
+ *
+ * Boards based on the native simulator do NOT use this file
+ */
+
+#ifndef ARCH_POSIX_CORE_NSI_COMPAT_NSI_HOST_TRAMPOLINES_H
+#define ARCH_POSIX_CORE_NSI_COMPAT_NSI_HOST_TRAMPOLINES_H
+
+#include "../scripts/native_simulator/common/src/include/nsi_host_trampolines.h"
+
+#endif /* ARCH_POSIX_CORE_NSI_COMPAT_NSI_HOST_TRAMPOLINES_H */

--- a/scripts/native_simulator/Makefile
+++ b/scripts/native_simulator/Makefile
@@ -10,6 +10,8 @@
 
 NSI_CONFIG_FILE?=nsi_config
 -include ${NSI_CONFIG_FILE}
+#If the file does not exist, we don't use it as a build dependency
+NSI_CONFIG_FILE:=$(wildcard ${NSI_CONFIG_FILE})
 
 NSI_PATH?=./
 NSI_BUILD_PATH?=$(abspath _build/)

--- a/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
+++ b/scripts/native_simulator/common/src/include/nsi_host_trampolines.h
@@ -22,10 +22,20 @@
 extern "C" {
 #endif
 
+void *nsi_host_calloc(unsigned long nmemb, unsigned long size);
+int nsi_host_close(int fd);
 /* void nsi_host_exit (int status); Use nsi_exit() instead */
+void nsi_host_free(void *ptr);
+char *nsi_host_getcwd(char *buf, unsigned long size);
+int nsi_host_isatty(int fd);
+void *nsi_host_malloc(unsigned long size);
+int nsi_host_open(const char *pathname, int flags);
 /* int nsi_host_printf (const char *fmt, ...); Use the nsi_tracing.h equivalents */
 long nsi_host_random(void);
+long nsi_host_read(int fd, void *buffer, unsigned long size);
 void nsi_host_srandom(unsigned int seed);
+char *nsi_host_strdup(const char *s);
+long nsi_host_write(int fd, void *buffer, unsigned long size);
 
 #ifdef __cplusplus
 }

--- a/scripts/native_simulator/common/src/nsi_host_trampolines.c
+++ b/scripts/native_simulator/common/src/nsi_host_trampolines.c
@@ -7,13 +7,66 @@
  */
 
 #include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+
+void *nsi_host_calloc(unsigned long nmemb, unsigned long size)
+{
+	return calloc(nmemb, size);
+}
+
+int nsi_host_close(int fd)
+{
+	return close(fd);
+}
+
+void nsi_host_free(void *ptr)
+{
+	free(ptr);
+}
+
+char *nsi_host_getcwd(char *buf, unsigned long size)
+{
+	return getcwd(buf, size);
+}
+
+int nsi_host_isatty(int fd)
+{
+	return isatty(fd);
+}
+
+void *nsi_host_malloc(unsigned long size)
+{
+	return malloc(size);
+}
+
+int nsi_host_open(const char *pathname, int flags)
+{
+	return open(pathname, flags);
+}
 
 long nsi_host_random(void)
 {
 	return random();
 }
 
+long nsi_host_read(int fd, void *buffer, unsigned long size)
+{
+	return read(fd, buffer, size);
+}
+
 void nsi_host_srandom(unsigned int seed)
 {
 	srandom(seed);
+}
+
+char *nsi_host_strdup(const char *s)
+{
+	return strdup(s);
+}
+
+long nsi_host_write(int fd, void *buffer, unsigned long size)
+{
+	return write(fd, buffer, size);
 }

--- a/scripts/native_simulator/common/src/nsi_tasks.h
+++ b/scripts/native_simulator/common/src/nsi_tasks.h
@@ -42,7 +42,7 @@ extern "C" {
  * The function must take no parameters and return nothing.
  */
 #define NSI_TASK(fn, level, prio)	\
-	static void (* const NSI_CONCAT(__nsi_task_, fn))() \
+	static void (* const NSI_CONCAT(__nsi_task_, fn))(void) \
 	__attribute__((__used__)) \
 	__attribute__((__section__(".nsi_" #level NSI_STRINGIFY(prio) "_task")))\
 	= fn


### PR DESCRIPTION
Update the native simulator to the latest from upstream
&
To ease writing common drivers, let's make the host trampolines
from the native simulator available to all posix based boards.