### PR TITLE
dts: arm: st: fix SDMMC2 for the H7 family

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -960,9 +960,9 @@
 		sdmmc2: sdmmc@48022400 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x48022400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000100>,
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000200>,
 				 <&rcc STM32_SRC_PLL1_Q SDMMC_SEL(0)>;
-			resets = <&rctl STM32_RESET(AHB2, 8U)>;
+			resets = <&rctl STM32_RESET(AHB2, 9U)>;
 			interrupts = <124 0>;
 			status = "disabled";
 		};


### PR DESCRIPTION
The different references manuals of the STM32H7 family (RM099, RM0433, RM0445 and RM0468) states that SDMMC2RTS and STMMC2EN are on bit 9 of respectively RCC_AHB2RSTR and RCC_AHB2ENR (not on bit 8). This PR fixes the stm32h7 dts accordingly.