### PR TITLE
ctf tracing: native/host backend: Refactor to support embedded C libraries

### DIFF
--- a/boards/posix/native_sim/doc/index.rst
+++ b/boards/posix/native_sim/doc/index.rst
@@ -124,5 +124,5 @@ host libC (:kconfig:option:`CONFIG_EXTERNAL_LIBC`).
      serial, uart native TTY, :kconfig:option:`CONFIG_UART_NATIVE_TTY`, host libC
      spi, SPI emul, :kconfig:option:`CONFIG_SPI_EMUL`, all
      system tick, native_posix timer, :kconfig:option:`CONFIG_NATIVE_POSIX_TIMER`, all
-     tracing, Posix tracing backend, :kconfig:option:`CONFIG_TRACING_BACKEND_POSIX`, host libC
+     tracing, Posix tracing backend, :kconfig:option:`CONFIG_TRACING_BACKEND_POSIX`, all
      usb, USB native posix, :kconfig:option:`CONFIG_USB_NATIVE_POSIX`, host libC

--- a/subsys/tracing/CMakeLists.txt
+++ b/subsys/tracing/CMakeLists.txt
@@ -27,10 +27,14 @@ zephyr_sources_ifdef(
   tracing_backend_uart.c
   )
 
-zephyr_sources_ifdef(
-  CONFIG_TRACING_BACKEND_POSIX
-  tracing_backend_posix.c
-  )
+if (CONFIG_TRACING_BACKEND_POSIX)
+  zephyr_sources(tracing_backend_posix.c)
+  if (CONFIG_NATIVE_APPLICATION)
+    zephyr_library_sources(tracing_backend_posix_bottom.c)
+  else()
+    target_sources(native_simulator INTERFACE tracing_backend_posix_bottom.c)
+  endif()
+endif()
 
 zephyr_sources_ifdef(
   CONFIG_TRACING_BACKEND_RAM

--- a/subsys/tracing/tracing_backend_posix.c
+++ b/subsys/tracing/tracing_backend_posix.c
@@ -5,11 +5,9 @@
  */
 
 #include <soc.h>
-#include <stdio.h>
-#include <zephyr/kernel.h>
 #include <cmdline.h>
-#include <zephyr/sys/__assert.h>
 #include <tracing_backend.h>
+#include "tracing_backend_posix_bottom.h"
 
 static void *out_stream;
 static const char *file_name;
@@ -20,20 +18,16 @@ static void tracing_backend_posix_init(void)
 		file_name = "channel0_0";
 	}
 
-	out_stream = (void *)fopen(file_name, "wb");
-
-	__ASSERT(out_stream != NULL, "posix backend init failed");
+	out_stream = tracing_backend_posix_init_bottom(file_name);
 }
 
 static void tracing_backend_posix_output(
 		const struct tracing_backend *backend,
 		uint8_t *data, uint32_t length)
 {
-	fwrite(data, length, 1, (FILE *)out_stream);
+	ARG_UNUSED(backend);
 
-	if (!k_is_in_isr()) {
-		fflush((FILE *)out_stream);
-	}
+	tracing_backend_posix_output_bottom(data, length, out_stream);
 }
 
 const struct tracing_backend_api tracing_backend_posix_api = {

--- a/subsys/tracing/tracing_backend_posix_bottom.c
+++ b/subsys/tracing/tracing_backend_posix_bottom.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Oticon A/S
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include "nsi_tracing.h"
+
+void *tracing_backend_posix_init_bottom(const char *file_name)
+{
+	FILE *f;
+
+	f = fopen(file_name, "wb");
+	if (f == NULL) {
+		nsi_print_error_and_exit("%s: Could not open CTF backend file %s\n",
+					 __func__, file_name);
+	}
+
+	return (void *)f;
+}
+
+void tracing_backend_posix_output_bottom(const void *data, unsigned long length, void *out_stream)
+{
+	int rc = fwrite(data, length, 1, (FILE *)out_stream);
+
+	if (rc != 1) {
+		nsi_print_warning("%s: Failure writing to CTF backend file\n", __func__);
+	}
+
+	fflush((FILE *)out_stream);
+}

--- a/subsys/tracing/tracing_backend_posix_bottom.h
+++ b/subsys/tracing/tracing_backend_posix_bottom.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * "Bottom" of the CTF tracing backend for the native/hosted targets.
+ * When built with the native_simulator this will be built in the runner context,
+ * that is, with the host C library, and with the host include paths.
+ *
+ * Note: None of these functions are public interfaces. But internal to this CTF backend.
+ */
+
+#ifndef DRIVERS_FLASH_FLASH_SIMULATOR_NATIVE_H
+#define DRIVERS_FLASH_FLASH_SIMULATOR_NATIVE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *tracing_backend_posix_init_bottom(const char *file_name);
+void tracing_backend_posix_output_bottom(const void *data, unsigned long length, void *out_stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DRIVERS_FLASH_FLASH_SIMULATOR_NATIVE_H */


### PR DESCRIPTION
Split this tracing backend in a top and bottom to enable building it with embedded libCs with the native simulator.