### PR TITLE
posix: spinlock: additional kconfig for k_spinlock being size 0

### DIFF
--- a/lib/posix/spinlock.c
+++ b/lib/posix/spinlock.c
@@ -15,7 +15,7 @@ union _spinlock_storage {
 	struct k_spinlock lock;
 	uint8_t byte;
 };
-#if !defined(CONFIG_SMP) && !defined(CONFIG_SPIN_VALIDATE)
+#if !defined(CONFIG_CPP) && !defined(CONFIG_SMP) && !defined(CONFIG_SPIN_VALIDATE)
 BUILD_ASSERT(sizeof(struct k_spinlock) == 0,
 	     "please remove the _spinlock_storage workaround if, at some point, k_spinlock is no "
 	     "longer zero bytes when CONFIG_SMP=n && CONFIG_SPIN_VALIDATE=n");


### PR DESCRIPTION
The `struct k_spinlock` size is zero bytes under certain circumstances. This is a bit of a problem, because it breaks a number of assumptions about things in C.

That should be fixed when #59922 is addressed.

This change is just a hotfix to correct the specific condition where we will need workarounds in other source files.
