### PR TITLE
Bluetooth: CAP: Add minimum metadata len req for CAP

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.cap
+++ b/subsys/bluetooth/audio/Kconfig.cap
@@ -11,6 +11,7 @@ config BT_CAP
 config BT_CAP_ACCEPTOR
 	bool "Common Audio Profile Acceptor Role Support [EXPERIMENTAL]"
 	depends on BT_BAP_UNICAST_SERVER || (BT_BAP_BROADCAST_SINK && BT_BAP_SCAN_DELEGATOR)
+	depends on BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE >= 4
 	select EXPERIMENTAL
 	help
 	  Enabling this will enable the CAP Acceptor role. This instantiates the
@@ -30,6 +31,7 @@ config BT_CAP_ACCEPTOR_SET_MEMBER
 config BT_CAP_INITIATOR
 	bool "Common Audio Profile Initiator Role Support [EXPERIMENTAL]"
 	depends on (BT_BAP_UNICAST_CLIENT && BT_CSIP_SET_COORDINATOR) || BT_BAP_BROADCAST_SOURCE
+	depends on BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE >= 4
 	select EXPERIMENTAL
 	help
 	  Enabling this will enable the CAP Initiator role.


### PR DESCRIPTION
CAP requires setting the streaming context in the metadata, which requires 4 octets of metadata, so the metadata for CAP must be greater than or equal to 4.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/58331