### PR TITLE
drivers: lpadc: fix ADC command chaining

### DIFF
--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -238,8 +238,8 @@ static int mcux_lpadc_start_read(const struct device *dev,
 			} else {
 				/* End of chain */
 				data->cmd_config[channel].chainedNextCommandNumber = 0;
-				last_enabled = channel;
 			}
+			last_enabled = channel;
 			LPADC_SetConvCommandConfig(config->base,
 				channel + 1, &data->cmd_config[channel]);
 		}


### PR DESCRIPTION
When reading multiple ADC channel in parallel, an ADC command chain will be build. This is similar to a linked list, as every command references the next command.

Before this patch every ADC command after the first, would always reference this initial command. So that during execution only two commands (the last and first) would be executed which resulted in readout of only two analog values. As Zephyr expected more to come in, the `read_adc` function would block endlessly.

The patch fixes the behaviour and allows a correct chain to build up, fixing the regression that has been introduced by 
https://github.com/zephyrproject-rtos/zephyr/commit/e587047dc6b77c28ea399e272c41beb2cd52f142