### PR TITLE
dts: arm: nxp: fix flexcan clock source

### DIFF
--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -848,7 +848,7 @@
 			interrupts = <36 0>;
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 14>;
-			clk-source = <2>;
+			clk-source = <0>;
 			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
@@ -860,7 +860,7 @@
 			interrupts = <37 0>;
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 18>;
-			clk-source = <2>;
+			clk-source = <0>;
 			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
@@ -872,7 +872,7 @@
 			interrupts = <154 0>;
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
-			clk-source = <2>;
+			clk-source = <0>;
 			sjw = <1>;
 			sjw-data = <1>;
 			sample-point = <875>;


### PR DESCRIPTION
The clk-source property is mapped to `__flexcan_clock_source` enum. The
allowed values of this enum is either 0 or 1. This fix changes the value
to 0 to map correctly with the enum.