### PR TITLE
emul: spi: SPI_EMUL_INIT(n) hard-coded to instance #0

### DIFF
--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -120,7 +120,7 @@ static struct spi_driver_api spi_emul_api = {
 
 #define SPI_EMUL_INIT(n)                                                                           \
 	static const struct emul_link_for_bus emuls_##n[] = { DT_FOREACH_CHILD(                    \
-		DT_DRV_INST(0), EMUL_LINK_AND_COMMA) };                                            \
+		DT_DRV_INST(n), EMUL_LINK_AND_COMMA) };                                            \
 	static struct emul_list_for_bus spi_emul_cfg_##n = {                                       \
 		.children = emuls_##n,                                                             \
 		.num_children = ARRAY_SIZE(emuls_##n),                                             \


### PR DESCRIPTION
The `SPI_EMUL_INIT(n)` macro used to instantiate SPI bus emulators builds an array of SPI devices attached to the bus, but always checks instance #0 of the bus and not `n`. This makes multiple instances of an emulated SPI bus unusable and popualtes them all with bus 0's devices.

Change the `0` to `n`, which matches how the I2C bus emulator does it.