### PR TITLE
fix sign when CONFIG_KERNEL_BIN_NAME is used

### DIFF
--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -427,22 +427,24 @@ class RimageSigner(Signer):
 
         # warning: RIMAGE_TARGET is a duplicate of CONFIG_RIMAGE_SIGNING_SCHEMA
         target = cache.get('RIMAGE_TARGET')
+        kernel_name = build_conf.get('CONFIG_KERNEL_BIN_NAME', 'zephyr')
+
         if not target:
             log.die('rimage target not defined')
 
         # TODO: make this a new sign.py --bootloader option.
         if target in ('imx8', 'imx8m'):
             bootloader = None
-            kernel = str(b / 'zephyr' / 'zephyr.elf')
-            out_bin = str(b / 'zephyr' / 'zephyr.ri')
-            out_xman = str(b / 'zephyr' / 'zephyr.ri.xman')
-            out_tmp = str(b / 'zephyr' / 'zephyr.rix')
+            kernel = str(b / 'zephyr' / f'{kernel_name}.elf')
+            out_bin = str(b / 'zephyr' / f'{kernel_name}.ri')
+            out_xman = str(b / 'zephyr' / f'{kernel_name}.ri.xman')
+            out_tmp = str(b / 'zephyr' / f'{kernel_name}.rix')
         else:
             bootloader = str(b / 'zephyr' / 'boot.mod')
             kernel = str(b / 'zephyr' / 'main.mod')
-            out_bin = str(b / 'zephyr' / 'zephyr.ri')
-            out_xman = str(b / 'zephyr' / 'zephyr.ri.xman')
-            out_tmp = str(b / 'zephyr' / 'zephyr.rix')
+            out_bin = str(b / 'zephyr' / f'{kernel_name}.ri')
+            out_xman = str(b / 'zephyr' / f'{kernel_name}.ri.xman')
+            out_tmp = str(b / 'zephyr' / f'{kernel_name}.rix')
 
         # Clean any stale output. This is especially important when using --if-tool-available
         # (but not just)

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -430,7 +430,9 @@ class RimageSigner(Signer):
         if not target:
             log.die('rimage target not defined')
 
+        # TODO: make this a new sign.py --bootloader option.
         if target in ('imx8', 'imx8m'):
+            bootloader = None
             kernel = str(b / 'zephyr' / 'zephyr.elf')
             out_bin = str(b / 'zephyr' / 'zephyr.ri')
             out_xman = str(b / 'zephyr' / 'zephyr.ri.xman')
@@ -516,7 +518,7 @@ class RimageSigner(Signer):
         if not args.quiet and args.verbose:
             sign_base += ['-v'] * args.verbose
 
-        components = [ ] if (target in ('imx8', 'imx8m')) else [ bootloader ]
+        components = [ ] if bootloader is None else [ bootloader ]
         components += [ kernel ]
 
         sign_config_extra_args = config_get_words(command.config, 'rimage.extra-args', [])

--- a/soc/xtensa/nxp_adsp/CMakeLists.txt
+++ b/soc/xtensa/nxp_adsp/CMakeLists.txt
@@ -16,5 +16,5 @@ add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/zephyr/zephyr.ri
   COMMENT "west sign --if-tool-available --tool rimage ..."
   COMMAND  west sign --if-tool-available --tool rimage --build-dir ${CMAKE_BINARY_DIR}
-  DEPENDS ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf
+  DEPENDS ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
 )


### PR DESCRIPTION
This fixes the following build error:

```
zephyr/zephyr.elf', needed by 'zephyr/zephyr.ri', missing and no known
rule to make it
```

This appears when CONFIG_KERNEL_BIN_NAME is used.

Therefore, do not use zephyr.elf since some samples might be called
based on CONFIG_KERNEL_BIN_NAME.