### PR TITLE
Bluetooth: Controller: Fix coverity issue 318648

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -591,6 +591,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 	/* Switching to ULL scheduling to receive auxiliary PDUs */
 	if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) || lll) {
+		LL_ASSERT(scan);
+
 		/* Do not ULL schedule if scan disable requested */
 		if (unlikely(scan->is_stop)) {
 			goto ull_scan_aux_rx_flush;
@@ -724,6 +726,8 @@ ull_scan_aux_rx_flush:
 		 * immediately since we are in sync context.
 		 */
 		if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) || aux->rx_last) {
+			LL_ASSERT(scan);
+
 			/* If scan is being disabled, rx could already be
 			 * enqueued before coming here to ull_scan_aux_rx_flush.
 			 * Check if rx not the last in the list of received PDUs


### PR DESCRIPTION
[Coverity CID: 318648] Explicit null dereferenced in subsys/bluetooth/controller/ll_sw/ull_scan_aux.c

Fixes #59002.