### PR TITLE
tests/spinlock: Terminate temporary thread after tests

### DIFF
--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -137,6 +137,8 @@ ZTEST(spinlock, test_spinlock_bounce)
 		bounce_once(1234, false);
 	}
 
+	k_thread_abort(&cpu1_thread);
+
 	bounce_done = 1;
 }
 
@@ -218,6 +220,8 @@ ZTEST(spinlock, test_trylock)
 	}
 
 	bounce_done = 1;
+
+	k_thread_abort(&cpu1_thread);
 
 	zassert_true(trylock_failures > 0);
 	zassert_true(trylock_successes > 0);


### PR DESCRIPTION
The spinlock tests start an additional thread to perform tests with. If the thread isn't stopped after each test, then when the same thread structure is used in subsequent tests, the thread structure will end up in an inconsistent state. In this particular cases, the second instance doesn't end up going through z_thread_entry and so z_tls_current is not set correctly, leading to faults whenever that value is used.

This fault can be demonstrated by running the test with thread local storage enabled:

    $ twister -p qemu_cortex_a53_smp \
      --test tests/kernel/spinlock/kernel.multiprocessing.spinlock \
      -xCONFIG_THREAD_LOCAL_STORAGE=y