### PR TITLE
Complete set of changes to enable picolibc by default

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -54,8 +54,8 @@ menu "C Library"
 choice LIBC_IMPLEMENTATION
 	prompt "C Library Implementation"
 	default EXTERNAL_LIBC if NATIVE_BUILD
+	default PICOLIBC
 	default NEWLIB_LIBC if REQUIRES_FULL_LIBC
-	default PICOLIBC if REQUIRES_FULL_LIBC
 	default MINIMAL_LIBC
 
 config MINIMAL_LIBC

--- a/tests/kernel/cache/testcase.yaml
+++ b/tests/kernel/cache/testcase.yaml
@@ -8,3 +8,15 @@ tests:
       - qemu_xtensa
       - qemu_cortex_a53
       - nsim_em
+  kernel.cache.api.minimallibc:
+    tags:
+      - kernel
+      - cache
+      - libc
+    filter: CONFIG_CACHE_MANAGEMENT and CONFIG_MINIMAL_LIBC_SUPPORTED
+    integration_platforms:
+      - qemu_xtensa
+      - qemu_cortex_a53
+      - nsim_em
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/context/testcase.yaml
+++ b/tests/kernel/context/testcase.yaml
@@ -4,6 +4,13 @@ tests:
     extra_configs:
       - CONFIG_TEST_EXTRA_STACK_SIZE=1024
     min_ram: 16
+  kernel.context.minimallibc:
+    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
+    tags: kernel libc
+    extra_configs:
+      - CONFIG_TEST_EXTRA_STACK_SIZE=1024
+      - CONFIG_MINIMAL_LIBC=y
+    min_ram: 16
   linker.linker_generator:
     platform_allow: qemu_cortex_m3
     tags:

--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -9,6 +9,14 @@ tests:
     tags:
       - kernel
       - device
+  kernel.device.minimallibc:
+    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
+    tags:
+      - kernel
+      - device
+      - libc
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y
   kernel.device.pm:
     tags:
       - kernel

--- a/tests/kernel/early_sleep/testcase.yaml
+++ b/tests/kernel/early_sleep/testcase.yaml
@@ -3,3 +3,11 @@ tests:
     tags:
       - kernel
       - sleep
+  kernel.common.sleep.minimallibc:
+    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
+    tags:
+      - kernel
+      - sleep
+      - libc
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -2,7 +2,16 @@ tests:
   arch.interrupt:
     # nios2 excluded, see #22956
     arch_exclude: nios2
+    platform_exclude: qemu_cortex_m0
     tags:
       - kernel
       - interrupt
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
+  arch.interrupt.qemu_cortex_m0:
+    platform_allow: qemu_cortex_m0
+    tags:
+      - kernel
+      - interrupt
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
+    extra_configs:
+      - CONFIG_QEMU_ICOUNT=y

--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -15,3 +15,26 @@ tests:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     extra_configs:
       - CONFIG_QEMU_ICOUNT=y
+  arch.interrupt.minimallibc:
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE and CONFIG_MINIMAL_LIBC_SUPPORTED
+    # nios2 excluded, see #22956
+    arch_exclude: nios2
+    platform_exclude: qemu_cortex_m0
+    tags:
+      - kernel
+      - interrupt
+      - libc
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y
+  arch.interrupt.qemu_cortex_m0.minimallibc:
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE and CONFIG_MINIMAL_LIBC_SUPPORTED
+    # nios2 excluded, see #22956
+    arch_exclude: nios2
+    platform_allow: qemu_cortex_m0
+    tags:
+      - kernel
+      - interrupt
+      - libc
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y
+      - CONFIG_QEMU_ICOUNT=y

--- a/tests/kernel/mp/testcase.yaml
+++ b/tests/kernel/mp/testcase.yaml
@@ -6,3 +6,13 @@ tests:
     filter: CONFIG_MP_MAX_NUM_CPUS > 1
     depends_on:
       - smp
+  kernel.multiprocessing.minimallibc:
+    tags:
+      - kernel
+      - smp
+      - libc
+    filter: CONFIG_MP_MAX_NUM_CPUS > 1 and CONFIG_MINIMAL_LIBC_SUPPORTED
+    depends_on:
+      - smp
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/obj_tracking/testcase.yaml
+++ b/tests/kernel/obj_tracking/testcase.yaml
@@ -2,3 +2,9 @@ tests:
   kernel.objects.tracking:
     tags: kernel
     platform_exclude: qemu_x86_tiny
+  kernel.objects.tracking.minimallibc:
+    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
+    tags: kernel libc
+    platform_exclude: qemu_x86_tiny
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/pending/testcase.yaml
+++ b/tests/kernel/pending/testcase.yaml
@@ -1,3 +1,8 @@
 tests:
   kernel.objects:
     tags: kernel
+  kernel.objects.minimallibc:
+    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
+    tags: kernel libc
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/poll/testcase.yaml
+++ b/tests/kernel/poll/testcase.yaml
@@ -8,3 +8,16 @@ tests:
     platform_exclude:
       - nrf52dk_nrf52810
       - qemu_arc_hs6x
+  kernel.poll.minimallibc:
+    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
+    ignore_faults: true
+    tags:
+      - kernel
+      - userspace
+      - libc
+    # FIXME: qemu_arc_hs6x is excluded due to a run-time failure, see #49492
+    platform_exclude:
+      - nrf52dk_nrf52810
+      - qemu_arc_hs6x
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/queue/testcase.yaml
+++ b/tests/kernel/queue/testcase.yaml
@@ -4,3 +4,12 @@ tests:
       - kernel
       - userspace
     ignore_faults: true
+  kernel.queue.minimallibc:
+    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
+    tags:
+      - kernel
+      - userspace
+      - libc
+    ignore_faults: true
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/sleep/testcase.yaml
+++ b/tests/kernel/sleep/testcase.yaml
@@ -3,3 +3,11 @@ tests:
     tags:
       - kernel
       - sleep
+  kernel.common.timing.minimallibc:
+    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
+    tags:
+      - kernel
+      - sleep
+      - libc
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/smp/testcase.yaml
+++ b/tests/kernel/smp/testcase.yaml
@@ -5,3 +5,12 @@ tests:
       - smp
     ignore_faults: true
     filter: (CONFIG_MP_MAX_NUM_CPUS > 1)
+  kernel.multiprocessing.smp.minimallibc:
+    tags:
+      - kernel
+      - smp
+      - libc
+    ignore_faults: true
+    filter: (CONFIG_MP_MAX_NUM_CPUS > 1) and CONFIG_MINIMAL_LIBC_SUPPORTED
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/smp_boot_delay/testcase.yaml
+++ b/tests/kernel/smp_boot_delay/testcase.yaml
@@ -6,3 +6,14 @@ tests:
     platform_allow: intel_adsp_cavs25
     integration_platforms:
       - intel_adsp_cavs25
+  kernel.multiprocessing.smp_boot_delay.minimallibc:
+    filter: CONFIG_MINIMAL_LIBC_SUPPORTED
+    tags:
+      - kernel
+      - smp
+      - libc
+    platform_allow: intel_adsp_cavs25
+    integration_platforms:
+      - intel_adsp_cavs25
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/spinlock/testcase.yaml
+++ b/tests/kernel/spinlock/testcase.yaml
@@ -7,3 +7,15 @@ tests:
     filter: CONFIG_SMP and CONFIG_MP_MAX_NUM_CPUS > 1 and CONFIG_MP_MAX_NUM_CPUS <= 4
     depends_on:
       - smp
+  kernel.multiprocessing.spinlock.minimallibc:
+    tags:
+      - kernel
+      - smp
+      - spinlock
+      - libc
+    filter: CONFIG_SMP and CONFIG_MP_MAX_NUM_CPUS > 1 and CONFIG_MP_MAX_NUM_CPUS <= 4 and
+      CONFIG_MINIMAL_LIBC_SUPPORTED
+    depends_on:
+      - smp
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y

--- a/tests/kernel/xip/testcase.yaml
+++ b/tests/kernel/xip/testcase.yaml
@@ -7,3 +7,13 @@ tests:
     integration_platforms:
       - qemu_arc_em
       - qemu_x86_xip
+  arch.common.xip.minimallibc:
+    filter: CONFIG_XIP and CONFIG_MINIMAL_LIBC_SUPPORTED
+    tags:
+      - kernel
+      - xip
+    integration_platforms:
+      - qemu_arc_em
+      - qemu_x86_xip
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
This series incorporates all of the patches necessary to switch to using picolibc by default. All of them are also available as separate PRs, this PR is designed to validate that the full set works as desired.

This is intended to have the changes mentioned in #49922