### PR TITLE
Bluetooth: Controller: Fix coverity issue 318807

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -235,7 +235,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 		 * Identifier (0x02)
 		 */
 		cis = ll_conn_iso_stream_get(handle);
-		if (!cis->group) {
+		if (!cis || !cis->group) {
 			/* CIS does not belong to a CIG */
 			return BT_HCI_ERR_UNKNOWN_CONN_ID;
 		}


### PR DESCRIPTION
[Coverity CID: 318807] Dereference before null check in subsys/bluetooth/controller/ll_sw/ull_iso.c

Fixes #59514.