### PR TITLE
net: openthread: remove unneeded `OPENTHREAD_MAX_CHILDREN` default value

### DIFF
--- a/modules/openthread/Kconfig.thread
+++ b/modules/openthread/Kconfig.thread
@@ -62,7 +62,6 @@ config OPENTHREAD_POLL_PERIOD
 config OPENTHREAD_MAX_CHILDREN
 	int "The maximum number of children"
 	range 1 511
-	default 1 if OPENTHREAD_MTD
 	default 32
 
 config OPENTHREAD_MAX_IP_ADDR_PER_CHILD


### PR DESCRIPTION
After https://github.com/openthread/openthread/pull/9213 there is no need to reduce the `ChildMask` size for MTD builds.