### PR TITLE
driver gpio nrfx: Fix undefined output in gpio_nrfx_port_get_direction

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -302,6 +302,7 @@ static int gpio_nrfx_port_get_direction(const struct device *port,
 	}
 
 	if (inputs != NULL) {
+		*inputs = 0;
 		while (map) {
 			uint32_t pin = NRF_CTZ(map);
 			uint32_t pin_cnf = reg->PIN_CNF[pin];


### PR DESCRIPTION
gpio_nrfx_port_get_direction() is meant to check which inputs are enabled, and does so by checking one bit at a time and setting that bit into the "input" parameter.
But "input" was never zeroed, so any garbage ones it may have remains.
Zero it.

This fixes a problem where if the "input" parameter was not zeroed by the caller, the result of the funcion call is undefined.

Detected by valgrind on:
tests/drivers/gpio/gpio_get_direction

Conditional jump or move depends on uninitialised value(s)
   by gpio_get_direction_test_disconnect (main.c:64)

Conditional jump or move depends on uninitialised value(s)
   by gpio_get_direction_test_output (main.c:102)

When running this test for the nrf52_bsim.