### PR TITLE
drivers: adc: fix missing ref_internal in iadc_gecko

### DIFF
--- a/drivers/adc/iadc_gecko.c
+++ b/drivers/adc/iadc_gecko.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(iadc_gecko, CONFIG_ADC_LOG_LEVEL);
 
 /* Number of channels available. */
 #define GECKO_CHANNEL_COUNT	16
+#define GECKO_INTERNAL_REFERENCE_mV	1210
 
 struct adc_gecko_channel_config {
 	IADC_CfgAnalogGain_t gain;
@@ -457,6 +458,7 @@ static const struct adc_driver_api api_gecko_adc_driver_api = {
 #ifdef CONFIG_ADC_ASYNC
 	.read_async = adc_gecko_read_async,
 #endif
+	.ref_internal = GECKO_INTERNAL_REFERENCE_mV,
 };
 
 #define GECKO_IADC_INIT(n)						\


### PR DESCRIPTION
The `adc_driver_api` structure provides `.ref_internal` which previously was unset.
Now `.ref_internal` is set to the proper value.

Fixes #59593.

CC @kmeinhar 