### PR TITLE
posix: pthread: fixes for coverity 321140 and 321092

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -509,14 +509,18 @@ int pthread_getschedparam(pthread_t pthread, int *policy, struct sched_param *pa
  */
 int pthread_once(pthread_once_t *once, void (*init_func)(void))
 {
-	k_mutex_lock(&pthread_once_lock, K_FOREVER);
+	__unused int ret;
+
+	ret = k_mutex_lock(&pthread_once_lock, K_FOREVER);
+	__ASSERT_NO_MSG(ret == 0);
 
 	if (once->is_initialized != 0 && once->init_executed == 0) {
 		init_func();
 		once->init_executed = 1;
 	}
 
-	k_mutex_unlock(&pthread_once_lock);
+	ret = k_mutex_unlock(&pthread_once_lock);
+	__ASSERT_NO_MSG(ret == 0);
 
 	return 0;
 }


### PR DESCRIPTION
The `pthread_once_lock` `k_mutex` is statically initialized and only visible within file scope. Coverity identified it as unsafe because the return values of `pthread_mutex_lock()` and `pthread_mutex_unlock()` were unchecked in `pthread_once()`. However, if those functions were to fail here, it would be indicative that something far worse has happened.

In any case, we add assertions that these functions succeed rather than silently ignoring with `(void)`, which ensures that we have coverage when assertions are enabled, in test, while removing unneeded code with assertions disable, in production.

Fixes #59559
Fixes #59561
