### PR TITLE
drivers: adc: iadc_gecko: select proper bits from sample

### DIFF
--- a/drivers/adc/iadc_gecko.c
+++ b/drivers/adc/iadc_gecko.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(iadc_gecko, CONFIG_ADC_LOG_LEVEL);
 /* Number of channels available. */
 #define GECKO_CHANNEL_COUNT	16
 #define GECKO_INTERNAL_REFERENCE_mV	1210
+#define GECKO_DATA_RES12BIT(DATA)	((DATA & 0xFFF0) >> 4);
 
 struct adc_gecko_channel_config {
 	IADC_CfgAnalogGain_t gain;
@@ -231,7 +232,7 @@ static void adc_gecko_isr(void *arg)
 	if (!err) {
 		sample = IADC_readSingleResult(iadc);
 
-		*data->buffer++ = (uint16_t)sample.data;
+		*data->buffer++ = GECKO_DATA_RES12BIT((uint16_t)sample.data);
 		data->channels &= ~BIT(data->channel_id);
 
 		if (data->channels) {


### PR DESCRIPTION
Only 12-bit resolution is currently available in the driver, and each of the 16-bit samples store the actual data aligned to the left.
A sample should be shifted 4 bits to the right to allow proper interpretation.

You can see it in this document, specifically p. 22:
https://www.silabs.com/documents/public/application-notes/an1189-efr32-iadc.pdf