### PR TITLE
drivers: pwm: pwm_mcux: fix for coverity 321142

### DIFF
--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -96,8 +96,8 @@ static int mcux_pwm_set_cycles(const struct device *dev, uint32_t channel,
 		data->channel[channel].level = level;
 
 		status = PWM_SetupPwm(config->base, config->index,
-				      &data->channel[channel], CHANNEL_COUNT,
-				      config->mode, 1, clock_freq);
+				      &data->channel[channel], 1U,
+				      config->mode, 1U, clock_freq);
 		if (status != kStatus_Success) {
 			LOG_ERR("Could not set up pwm");
 			return -ENOTSUP;


### PR DESCRIPTION
Fix `PWM_SetupPwm` function being called with `numOfChnls` argument equal to 2, when in fact only one channel is being set up.

Also add 'U' suffix to `pwmFreq_Hz` unsigned integer argument in the function call.

Fixes #59541