### PR TITLE
boards: nrf9161dk: Fix conflicts with Wi-Fi shield

### DIFF
--- a/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_common-pinctrl.dtsi
+++ b/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_common-pinctrl.dtsi
@@ -65,13 +65,13 @@
 
 	pwm0_default: pwm0_default {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 6)>;
 		};
 	};
 
 	pwm0_sleep: pwm0_sleep {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 6)>;
 			low-power-enable;
 		};
 	};

--- a/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_common.dtsi
+++ b/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_common.dtsi
@@ -18,11 +18,11 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
 			label = "Green LED 1";
 		};
 		led1: led_1 {
-			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
 			label = "Green LED 2";
 		};
 		led2: led_2 {


### PR DESCRIPTION
The GPIO's for LED0, LED1 and PWM0 overlap with Wi-Fi shield, so, use unused GPIO's for them.