### PR TITLE
soc: xtensa: disable SPIRAM when MCUBOOT

### DIFF
--- a/soc/xtensa/esp32/Kconfig.soc
+++ b/soc/xtensa/esp32/Kconfig.soc
@@ -56,6 +56,7 @@ config ESP_HEAP_MEM_POOL_REGION_1_SIZE
 
 config ESP_SPIRAM
 	bool "Support for external, SPI-connected RAM"
+	default n if MCUBOOT
 	help
 	  This enables support for an external SPI RAM chip, connected in
 	  parallel with the main SPI flash chip.


### PR DESCRIPTION
Some boards has ESP_SPIRAM enabled by default, which is causing issues when MCUboot is used as 2nd bootloader.