### PR TITLE
Add QSPI support on mr_canhubk3 board

### DIFF
--- a/boards/arm/mr_canhubk3/doc/index.rst
+++ b/boards/arm/mr_canhubk3/doc/index.rst
@@ -49,6 +49,7 @@ SIUL2         on-chip     | pinctrl
                           | gpio
                           | external interrupt controller
 LPUART        on-chip     serial
+QSPI          on-chip     flash
 ============  ==========  ================================
 
 The default configuration can be found in the Kconfig file
@@ -118,6 +119,13 @@ the watchdog so the FS26 must be started in debug mode following these steps:
 2. Remove the jumper ``JP1`` (pins 1-2 open), which is connected by default.
 3. Power on the board.
 4. Reconnect the jumper ``JP1`` (pins 1-2 shorted).
+
+External Flash
+==============
+
+The on-board MX25L6433F 64M-bit multi-I/O Serial NOR Flash memory is connected
+to the QSPI controller port A1. This board configuration selects it as the
+default flash controller.
 
 Programming and Debugging
 *************************

--- a/boards/arm/mr_canhubk3/mr_canhubk3-pinctrl.dtsi
+++ b/boards/arm/mr_canhubk3/mr_canhubk3-pinctrl.dtsi
@@ -90,4 +90,24 @@
 			input-enable;
 		};
 	};
+
+	qspi0_default: qspi0_default {
+		group1 {
+			pinmux = <(PTD11_QUADSPI_IOFA0_O | PTD11_QUADSPI_IOFA0_I)>,
+				<(PTD7_QUADSPI_IOFA1_O | PTD7_QUADSPI_IOFA1_I)>,
+				<(PTD12_QUADSPI_IOFA2_O | PTD12_QUADSPI_IOFA2_I)>,
+				<(PTC2_QUADSPI_IOFA3_O | PTC2_QUADSPI_IOFA3_I)>;
+			output-enable;
+			input-enable;
+		};
+		group2 {
+			pinmux = <PTD10_QUADSPI_SCKFA_O>;
+			output-enable;
+		};
+		group3 {
+			pinmux = <PTC3_QUADSPI_PCSFA>;
+			output-enable;
+			bias-pull-up;
+		};
+	};
 };

--- a/boards/arm/mr_canhubk3/mr_canhubk3.dts
+++ b/boards/arm/mr_canhubk3/mr_canhubk3.dts
@@ -21,6 +21,7 @@
 		zephyr,code-partition = &code_partition;
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
+		zephyr,flash-controller = &mx25l6433f;
 	};
 
 	aliases {
@@ -131,4 +132,39 @@
 &lpuart14 {
 	pinctrl-0 = <&lpuart14_default>;
 	pinctrl-names = "default";
+};
+
+&qspi0 {
+	pinctrl-0 = <&qspi0_default>;
+	pinctrl-names = "default";
+	data-rate = "SDR";
+	a-rx-clock-source = "LOOPBACK";
+	a-dll-mode = "BYPASSED";
+	ahb-buffers-masters = <0 1 2 3>;
+	ahb-buffers-sizes = <0 0 0 256>;
+	ahb-buffers-all-masters;
+	status = "okay";
+
+	mx25l6433f: mx25l6433f@0 {
+		compatible = "nxp,s32-qspi-nor";
+		reg = <0>;
+		size = <DT_SIZE_M(64)>;
+		jedec-id = [c2 20 17];
+		quad-enable-requirements = "S1B6";
+		readoc = "1-4-4";
+		writeoc = "1-4-4";
+		has-32k-erase;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				label = "storage";
+				reg = <0x0 0x100000>;
+			};
+		};
+	};
 };

--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -106,6 +106,12 @@ zephyr_library_include_directories_ifdef(
   ${ZEPHYR_BASE}/drivers/memc
 )
 
+zephyr_library_sources_ifdef(CONFIG_FLASH_NXP_S32_QSPI_NOR flash_nxp_s32_qspi_nor.c)
+zephyr_library_include_directories_ifdef(
+  CONFIG_FLASH_NXP_S32_QSPI_NOR
+  ${ZEPHYR_BASE}/drivers/memc
+)
+
 zephyr_library_sources_ifdef(CONFIG_FLASH_SHELL flash_shell.c)
 zephyr_library_sources_ifdef(CONFIG_FLASH_JESD216 jesd216.c)
 zephyr_library_sources_ifdef(CONFIG_FLASH_INFINEON_CAT1 flash_ifx_cat1.c)

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -154,4 +154,6 @@ source "drivers/flash/Kconfig.ifx_cat1"
 
 source "drivers/flash/Kconfig.numaker"
 
+source "drivers/flash/Kconfig.nxp_s32"
+
 endif # FLASH

--- a/drivers/flash/Kconfig.nxp_s32
+++ b/drivers/flash/Kconfig.nxp_s32
@@ -1,0 +1,54 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config FLASH_NXP_S32_QSPI_NOR
+	bool "NXP S32 QSPI NOR driver"
+	default y
+	depends on DT_HAS_NXP_S32_QSPI_NOR_ENABLED
+	select MEMC
+	select FLASH_HAS_PAGE_LAYOUT
+	select FLASH_HAS_DRIVER_ENABLED
+	select FLASH_JESD216
+	help
+	  Enable the Flash driver for a NOR Serial Flash Memory device connected
+	  to an NXP S32 QSPI bus.
+
+if FLASH_NXP_S32_QSPI_NOR
+
+config FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME
+	bool "Read flash parameters at runtime"
+	help
+	  Read flash device characteristics from the device at runtime.
+	  This option should provide functionality for all supported
+	  JESD216-compatible devices, with the following notes:
+	  - Quad Enable Requirements bitfield (DW15) must be present in the SFDP
+	    tables to configure Quad mode. Otherwise it defaults to Dual or
+	    Single mode as supported by the device.
+	  - Soft Reset bitfield (DW16) must be present in the SFDP tables to
+	    automatically reset the device at initialization time.
+	  - 0-X-X mode discovery not yet implemented by the HAL.
+
+	  If not selected, the driver uses a fixed configuration assuming 256 By
+	  page size and 4 KiBy, 32 KiBy and 64 KiBy erase instructions. The
+	  device size and jedec-id properties must be set in devicetree node.
+
+config FLASH_NXP_S32_QSPI_VERIFY_ERASE
+	bool "Verify memory after erased"
+	help
+	  Verify contents of memory after erased.
+
+config FLASH_NXP_S32_QSPI_VERIFY_WRITE
+	bool "Verify memory after written"
+	help
+	  Verify contents of memory after written.
+
+config FLASH_NXP_S32_QSPI_LAYOUT_PAGE_SIZE
+	int "Page size to use for FLASH_LAYOUT feature"
+	default 4096
+	help
+	  When CONFIG_FLASH_PAGE_LAYOUT is used this driver will support that API.
+	  By default the page size corresponds to the sector size (4096) for a NOR
+	  flash memory. Other options may include the 32K-byte erase size (32768),
+	  the block size (65536), or any non-zero multiple of the sector size.
+
+endif # FLASH_NXP_S32_QSPI_NOR

--- a/drivers/flash/flash_nxp_s32_qspi_nor.c
+++ b/drivers/flash/flash_nxp_s32_qspi_nor.c
@@ -1,0 +1,1106 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT	nxp_s32_qspi_nor
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(nxp_s32_qspi_nor, CONFIG_FLASH_LOG_LEVEL);
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/sys/util.h>
+
+#include <Qspi_Ip.h>
+
+#include "spi_nor.h"
+#include "jesd216.h"
+
+#include "memc_nxp_s32_qspi.h"
+
+#define QSPI_INST_NODE_HAS_PROP_EQ_AND_OR(n, prop, val)				\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, prop),				\
+		(IS_EQ(DT_INST_ENUM_IDX(n, prop), val)),			\
+		(0)) ||
+
+#define QSPI_ANY_INST_HAS_PROP_EQ(prop, val)					\
+	(DT_INST_FOREACH_STATUS_OKAY_VARGS(QSPI_INST_NODE_HAS_PROP_EQ_AND_OR, prop, val) 0)
+
+#define QSPI_INST_NODE_NOT_HAS_PROP_AND_OR(n, prop) \
+	!DT_INST_NODE_HAS_PROP(n, prop) ||
+
+#define QSPI_ANY_INST_HAS_PROP_STATUS_NOT_OKAY(prop) \
+	(DT_INST_FOREACH_STATUS_OKAY_VARGS(QSPI_INST_NODE_NOT_HAS_PROP_AND_OR, prop) 0)
+
+#define QSPI_QER_TYPE(n)							\
+	_CONCAT(JESD216_DW15_QER_VAL_,						\
+		DT_INST_STRING_TOKEN_OR(n, quad_enable_requirements, S1B6))
+
+#define QSPI_HAS_QUAD_MODE(n)							\
+	(QSPI_INST_NODE_HAS_PROP_EQ_AND_OR(n, readoc, 3)			\
+	QSPI_INST_NODE_HAS_PROP_EQ_AND_OR(n, readoc, 4)				\
+	QSPI_INST_NODE_HAS_PROP_EQ_AND_OR(n, writeoc, 2)			\
+	QSPI_INST_NODE_HAS_PROP_EQ_AND_OR(n, writeoc, 3)			\
+	0)
+
+#define QSPI_WRITE_SEQ(n)							\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, writeoc),				\
+		(_CONCAT(QSPI_SEQ_PP_, DT_INST_STRING_UPPER_TOKEN(n, writeoc))),\
+		(QSPI_SEQ_PP_1_1_1))
+
+#define QSPI_READ_SEQ(n)							\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, readoc),				\
+		(_CONCAT(QSPI_SEQ_READ_, DT_INST_STRING_UPPER_TOKEN(n, readoc))),\
+		(QSPI_SEQ_READ_1_1_1))
+
+#define QSPI_ERASE_VALUE 0xff
+#define QSPI_WRITE_BLOCK_SIZE 1U
+
+#define QSPI_IS_ALIGNED(addr, bits) (((addr) & BIT_MASK(bits)) == 0)
+
+#define QSPI_LUT_ENTRY_SIZE (FEATURE_QSPI_LUT_SEQUENCE_SIZE * 2)
+#define QSPI_LUT_IDX(n)	(n * QSPI_LUT_ENTRY_SIZE)
+
+#if defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+/* Size of LUT */
+#define QSPI_SFDP_LUT_SIZE 130U
+/* Size of init operations */
+#define QSPI_SFDP_INIT_OP_SIZE 8U
+#if defined(CONFIG_FLASH_JESD216_API)
+/* Size of all LUT sequences for JESD216 operations */
+#define QSPI_JESD216_SEQ_SIZE 8U
+#endif /* CONFIG_FLASH_JESD216_API */
+#endif /* CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME */
+
+struct nxp_s32_qspi_config {
+	const struct device *controller;
+	struct flash_parameters flash_parameters;
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	struct flash_pages_layout layout;
+#endif
+#if !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+	const Qspi_Ip_MemoryConfigType memory_cfg;
+	enum jesd216_dw15_qer_type qer_type;
+	bool quad_mode;
+#endif
+};
+
+struct nxp_s32_qspi_data {
+	uint8_t instance;
+	Qspi_Ip_MemoryConnectionType memory_conn_cfg;
+	uint8_t read_sfdp_lut_idx;
+#if defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+	Qspi_Ip_MemoryConfigType memory_cfg;
+	Qspi_Ip_InstrOpType lut_ops[QSPI_SFDP_LUT_SIZE];
+	Qspi_Ip_InitOperationType init_ops[QSPI_SFDP_INIT_OP_SIZE];
+#endif
+#if defined(CONFIG_MULTITHREADING)
+	struct k_sem sem;
+#endif
+};
+
+enum {
+	QSPI_SEQ_RDSR,
+	QSPI_SEQ_RDSR2,
+	QSPI_SEQ_WRSR,
+	QSPI_SEQ_WRSR2,
+	QSPI_SEQ_WREN,
+	QSPI_SEQ_RESET,
+	QSPI_SEQ_SE,
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(has_32k_erase)
+	QSPI_SEQ_BE_32K,
+#endif
+	QSPI_SEQ_BE,
+	QSPI_SEQ_CE,
+	QSPI_SEQ_READ_SFDP,
+	QSPI_SEQ_RDID,
+#if QSPI_ANY_INST_HAS_PROP_EQ(readoc, 0) || QSPI_ANY_INST_HAS_PROP_STATUS_NOT_OKAY(readoc)
+	QSPI_SEQ_READ_1_1_1,
+#endif
+#if QSPI_ANY_INST_HAS_PROP_EQ(readoc, 1)
+	QSPI_SEQ_READ_1_1_2,
+#endif
+#if QSPI_ANY_INST_HAS_PROP_EQ(readoc, 2)
+	QSPI_SEQ_READ_1_2_2,
+#endif
+#if QSPI_ANY_INST_HAS_PROP_EQ(readoc, 3)
+	QSPI_SEQ_READ_1_1_4,
+#endif
+#if QSPI_ANY_INST_HAS_PROP_EQ(readoc, 4)
+	QSPI_SEQ_READ_1_4_4,
+#endif
+#if QSPI_ANY_INST_HAS_PROP_EQ(writeoc, 0) || QSPI_ANY_INST_HAS_PROP_STATUS_NOT_OKAY(writeoc)
+	QSPI_SEQ_PP_1_1_1,
+#endif
+#if QSPI_ANY_INST_HAS_PROP_EQ(writeoc, 1)
+	QSPI_SEQ_PP_1_1_2,
+#endif
+#if QSPI_ANY_INST_HAS_PROP_EQ(writeoc, 2)
+	QSPI_SEQ_PP_1_1_4,
+#endif
+#if QSPI_ANY_INST_HAS_PROP_EQ(writeoc, 3)
+	QSPI_SEQ_PP_1_4_4,
+#endif
+};
+
+#if !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+static const Qspi_Ip_InstrOpType nxp_s32_qspi_lut[][QSPI_LUT_ENTRY_SIZE] = {
+	[QSPI_SEQ_RDSR] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_RDSR),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_READ, QSPI_IP_LUT_PADS_1, 1U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+
+	[QSPI_SEQ_RDSR2] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_RDSR2),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_READ, QSPI_IP_LUT_PADS_1, 1U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+
+	[QSPI_SEQ_WRSR] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_WRSR),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_WRITE, QSPI_IP_LUT_PADS_1, 1U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+
+	[QSPI_SEQ_WRSR2] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_WRSR2),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_WRITE, QSPI_IP_LUT_PADS_1, 1U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+
+	[QSPI_SEQ_WREN] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_WREN),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+
+	[QSPI_SEQ_RESET] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_RESET_EN),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_PADS_1, 0U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_RESET_MEM),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_PADS_1, 0U),
+	},
+
+	[QSPI_SEQ_SE] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_SE),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_1, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(has_32k_erase)
+	[QSPI_SEQ_BE_32K] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_BE_32K),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_1, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+#endif
+
+	[QSPI_SEQ_BE] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_BE),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_1, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+
+	[QSPI_SEQ_CE] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_CE),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+
+	[QSPI_SEQ_READ_SFDP] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, JESD216_CMD_READ_SFDP),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_1, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_DUMMY, QSPI_IP_LUT_PADS_1, 8U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_READ, QSPI_IP_LUT_PADS_1, 16U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+
+	[QSPI_SEQ_RDID] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, JESD216_CMD_READ_ID),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_READ, QSPI_IP_LUT_PADS_1, JESD216_READ_ID_LEN),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+
+#if QSPI_ANY_INST_HAS_PROP_EQ(readoc, 0) || QSPI_ANY_INST_HAS_PROP_STATUS_NOT_OKAY(readoc)
+	[QSPI_SEQ_READ_1_1_1] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_READ_FAST),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_1, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_DUMMY, QSPI_IP_LUT_PADS_1, 8U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_READ, QSPI_IP_LUT_PADS_1, 8U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+#endif
+
+#if QSPI_ANY_INST_HAS_PROP_EQ(readoc, 1)
+	[QSPI_SEQ_READ_1_1_2] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_DREAD),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_1, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_DUMMY, QSPI_IP_LUT_PADS_1, 8U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_READ, QSPI_IP_LUT_PADS_2, 8U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+#endif
+
+#if QSPI_ANY_INST_HAS_PROP_EQ(readoc, 2)
+	[QSPI_SEQ_READ_1_2_2] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_2READ),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_2, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_DUMMY, QSPI_IP_LUT_PADS_2, 4U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_READ, QSPI_IP_LUT_PADS_2, 8U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+#endif
+
+#if QSPI_ANY_INST_HAS_PROP_EQ(readoc, 3)
+	[QSPI_SEQ_READ_1_1_4] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_QREAD),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_1, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_DUMMY, QSPI_IP_LUT_PADS_1, 8U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_READ, QSPI_IP_LUT_PADS_4, 8U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+#endif
+
+#if QSPI_ANY_INST_HAS_PROP_EQ(readoc, 4)
+	[QSPI_SEQ_READ_1_4_4] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_4READ),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_4, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_MODE, QSPI_IP_LUT_PADS_4, 0U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_DUMMY, QSPI_IP_LUT_PADS_4, 4U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_READ, QSPI_IP_LUT_PADS_4, 8U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+#endif
+
+#if QSPI_ANY_INST_HAS_PROP_EQ(writeoc, 0) || QSPI_ANY_INST_HAS_PROP_STATUS_NOT_OKAY(writeoc)
+	[QSPI_SEQ_PP_1_1_1] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_PP),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_1, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_WRITE, QSPI_IP_LUT_PADS_1, 8U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+#endif
+
+#if QSPI_ANY_INST_HAS_PROP_EQ(writeoc, 1)
+	[QSPI_SEQ_PP_1_1_2] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_PP_1_1_2),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_1, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_WRITE, QSPI_IP_LUT_PADS_2, 8U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+#endif
+
+#if QSPI_ANY_INST_HAS_PROP_EQ(writeoc, 2)
+	[QSPI_SEQ_PP_1_1_4] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_PP_1_1_4),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_1, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_WRITE, QSPI_IP_LUT_PADS_4, 8U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+#endif
+
+#if QSPI_ANY_INST_HAS_PROP_EQ(writeoc, 3)
+	[QSPI_SEQ_PP_1_4_4] = {
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_PP_1_4_4),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_4, 24U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_WRITE, QSPI_IP_LUT_PADS_4, 16U),
+		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END, QSPI_IP_LUT_SEQ_END),
+	},
+#endif
+};
+#endif /* !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME) */
+
+static ALWAYS_INLINE Qspi_Ip_MemoryConfigType *get_memory_config(const struct device *dev)
+{
+#if defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+	return &((struct nxp_s32_qspi_data *)dev->data)->memory_cfg;
+#else
+	return ((Qspi_Ip_MemoryConfigType *)
+		&((const struct nxp_s32_qspi_config *)dev->config)->memory_cfg);
+#endif
+}
+
+static ALWAYS_INLINE bool area_is_subregion(const struct device *dev, off_t offset, size_t size)
+{
+	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
+
+	return ((offset >= 0) && (offset < memory_cfg->memSize)
+		&& ((size + offset) <= memory_cfg->memSize));
+}
+
+static inline void nxp_s32_qspi_lock(const struct device *dev)
+{
+#ifdef CONFIG_MULTITHREADING
+	struct nxp_s32_qspi_data *data = dev->data;
+
+	k_sem_take(&data->sem, K_FOREVER);
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline void nxp_s32_qspi_unlock(const struct device *dev)
+{
+#ifdef CONFIG_MULTITHREADING
+	struct nxp_s32_qspi_data *data = dev->data;
+
+	k_sem_give(&data->sem);
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+/* Must be called with lock */
+static int nxp_s32_qspi_wait_until_ready(const struct device *dev)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_StatusType status;
+	uint32_t timeout = 0xFFFFFF;
+	int ret = 0;
+
+	do {
+		status = Qspi_Ip_GetMemoryStatus(data->instance);
+		timeout--;
+	} while ((status == STATUS_QSPI_IP_BUSY) && (timeout > 0));
+
+	if (status != STATUS_QSPI_IP_SUCCESS) {
+		LOG_ERR("Failed to read memory status (%d)", status);
+		ret = -EIO;
+	} else if (timeout <= 0) {
+		LOG_ERR("Timeout, memory is busy");
+		ret = -ETIMEDOUT;
+	}
+
+	return ret;
+}
+
+#if !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+static int nxp_s32_qspi_read_status_register(const struct device *dev,
+					     uint8_t reg_num,
+					     uint8_t *val)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	uint16_t lut_idx;
+	Qspi_Ip_StatusType status;
+	int ret = 0;
+
+	switch (reg_num) {
+	case 1U:
+		lut_idx = QSPI_LUT_IDX(QSPI_SEQ_RDSR);
+		break;
+	case 2U:
+		lut_idx = QSPI_LUT_IDX(QSPI_SEQ_RDSR2);
+		break;
+	default:
+		LOG_ERR("Reading SR%u is not supported", reg_num);
+		return -EINVAL;
+	}
+
+	nxp_s32_qspi_lock(dev);
+
+	status = Qspi_Ip_RunReadCommand(data->instance, lut_idx, 0U, val, NULL, sizeof(*val));
+	if (status != STATUS_QSPI_IP_SUCCESS) {
+		LOG_ERR("Failed to read SR%u (%d)", reg_num, status);
+		ret = -EIO;
+	}
+
+	nxp_s32_qspi_unlock(dev);
+
+	return ret;
+}
+
+static int nxp_s32_qspi_write_enable(const struct device *dev)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
+	Qspi_Ip_StatusType status;
+	int ret = 0;
+
+	nxp_s32_qspi_lock(dev);
+
+	status = Qspi_Ip_RunCommand(data->instance, memory_cfg->statusConfig.writeEnableSRLut, 0U);
+	if (status != STATUS_QSPI_IP_SUCCESS) {
+		LOG_ERR("Failed to enable SR write (%d)", status);
+		ret = -EIO;
+	}
+
+	nxp_s32_qspi_unlock(dev);
+
+	return ret;
+}
+
+static int nxp_s32_qspi_write_status_register(const struct device *dev,
+					      uint8_t reg_num,
+					      uint8_t val)
+{
+	const struct nxp_s32_qspi_config *config = dev->config;
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_StatusType status;
+	uint8_t buf[2] = { 0 };
+	uint16_t lut_idx;
+	size_t size;
+	int ret;
+
+	if (reg_num == 1) {
+		/* buf = [val] or [val, SR2] */
+		lut_idx = QSPI_LUT_IDX(QSPI_SEQ_WRSR);
+		size = 1U;
+		buf[0] = val;
+
+		if (config->qer_type == JESD216_DW15_QER_S2B1v1) {
+			/* Writing SR1 clears SR2 */
+			size = 2U;
+			ret = nxp_s32_qspi_read_status_register(dev, 2, &buf[1]);
+			if (ret < 0) {
+				return ret;
+			}
+		}
+	} else if (reg_num == 2) {
+		/* buf = [val] or [SR1, val] */
+		if ((config->qer_type == JESD216_DW15_QER_VAL_S2B1v1) ||
+		    (config->qer_type == JESD216_DW15_QER_VAL_S2B1v4) ||
+		    (config->qer_type == JESD216_DW15_QER_VAL_S2B1v5)) {
+			/* Writing SR2 requires writing SR1 as well */
+			lut_idx = QSPI_LUT_IDX(QSPI_SEQ_WRSR);
+			size = 2U;
+			buf[1] = val;
+			ret = nxp_s32_qspi_read_status_register(dev, 1, &buf[0]);
+			if (ret < 0) {
+				return ret;
+			}
+		} else {
+			lut_idx = QSPI_LUT_IDX(QSPI_SEQ_WRSR2);
+			size = 1U;
+			buf[0] = val;
+		}
+	} else {
+		return -EINVAL;
+	}
+
+	nxp_s32_qspi_lock(dev);
+
+	status = Qspi_Ip_RunWriteCommand(data->instance, lut_idx, 0U, (const uint8_t *)buf,
+					 (uint32_t)size);
+	if (status == STATUS_QSPI_IP_SUCCESS) {
+		/* Wait for the write command to complete */
+		ret = nxp_s32_qspi_wait_until_ready(dev);
+	} else {
+		LOG_ERR("Failed to write to SR%u (%d)", reg_num, status);
+		ret = -EIO;
+	}
+
+	nxp_s32_qspi_unlock(dev);
+
+	return ret;
+}
+
+static int nxp_s32_qspi_set_quad_mode(const struct device *dev, bool enabled)
+{
+	const struct nxp_s32_qspi_config *config = dev->config;
+	uint8_t sr_num;
+	uint8_t sr_val;
+	uint8_t qe_mask;
+	bool qe_state;
+	int ret;
+
+	switch (config->qer_type) {
+	case JESD216_DW15_QER_NONE:
+		/* no QE bit, device detects reads based on opcode */
+		return 0;
+	case JESD216_DW15_QER_S1B6:
+		sr_num = 1U;
+		qe_mask = BIT(6U);
+		break;
+	case JESD216_DW15_QER_S2B7:
+		sr_num = 2U;
+		qe_mask = BIT(7U);
+		break;
+	case JESD216_DW15_QER_S2B1v1:
+		__fallthrough;
+	case JESD216_DW15_QER_S2B1v4:
+		__fallthrough;
+	case JESD216_DW15_QER_S2B1v5:
+		__fallthrough;
+	case JESD216_DW15_QER_S2B1v6:
+		sr_num = 2U;
+		qe_mask = BIT(1U);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	ret = nxp_s32_qspi_read_status_register(dev, sr_num, &sr_val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	qe_state = ((sr_val & qe_mask) != 0U);
+	if (qe_state == enabled) {
+		return 0;
+	}
+	sr_val ^= qe_mask;
+
+	ret = nxp_s32_qspi_write_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = nxp_s32_qspi_write_status_register(dev, sr_num, sr_val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Verify write was successful */
+	ret = nxp_s32_qspi_read_status_register(dev, sr_num, &sr_val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	qe_state = ((sr_val & qe_mask) != 0U);
+	if (qe_state != enabled) {
+		LOG_ERR("Failed to %s Quad mode", enabled ? "enable" : "disable");
+		return -EIO;
+	}
+
+	return ret;
+}
+#endif /* !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME) */
+
+static int nxp_s32_qspi_read(const struct device *dev, off_t offset, void *dest, size_t size)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_StatusType status;
+	int ret = 0;
+
+	if (!dest) {
+		return -EINVAL;
+	}
+
+	if (!area_is_subregion(dev, offset, size)) {
+		return -ENODEV;
+	}
+
+	if (size) {
+		nxp_s32_qspi_lock(dev);
+
+		status = Qspi_Ip_Read(data->instance, (uint32_t)offset, (uint8_t *)dest,
+				      (uint32_t)size);
+		if (status != STATUS_QSPI_IP_SUCCESS) {
+			LOG_ERR("Failed to read %zu bytes at 0x%lx (%d)",
+				size, offset, status);
+			ret = -EIO;
+		}
+
+		nxp_s32_qspi_unlock(dev);
+	}
+
+	return ret;
+}
+
+static int nxp_s32_qspi_write(const struct device *dev, off_t offset, const void *src, size_t size)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
+	Qspi_Ip_StatusType status;
+	size_t max_write = (size_t)MIN(QSPI_IP_MAX_WRITE_SIZE, memory_cfg->pageSize);
+	size_t len;
+	int ret = 0;
+
+	if (!src) {
+		return -EINVAL;
+	}
+
+	if (!area_is_subregion(dev, offset, size)) {
+		return -ENODEV;
+	}
+
+	nxp_s32_qspi_lock(dev);
+
+	while (size) {
+		len = MIN(max_write - (offset % max_write), size);
+		status = Qspi_Ip_Program(data->instance, (uint32_t)offset,
+					(const uint8_t *)src, (uint32_t)len);
+		if (status != STATUS_QSPI_IP_SUCCESS) {
+			LOG_ERR("Failed to write %zu bytes at 0x%lx (%d)",
+				len, offset, status);
+			ret = -EIO;
+			break;
+		}
+
+		ret = nxp_s32_qspi_wait_until_ready(dev);
+		if (ret != 0) {
+			break;
+		}
+
+		if (IS_ENABLED(CONFIG_FLASH_NXP_S32_QSPI_VERIFY_WRITE)) {
+			status = Qspi_Ip_ProgramVerify(data->instance, (uint32_t)offset,
+						       (const uint8_t *)src, (uint32_t)len);
+			if (status != STATUS_QSPI_IP_SUCCESS) {
+				LOG_ERR("Write verification failed at 0x%lx (%d)",
+					offset, status);
+				ret = -EIO;
+				break;
+			}
+		}
+
+		size -= len;
+		src = (const uint8_t *)src + len;
+		offset += len;
+	}
+
+	nxp_s32_qspi_unlock(dev);
+
+	return ret;
+}
+
+static int nxp_s32_qspi_erase_block(const struct device *dev, off_t offset,
+				    size_t size, size_t *erase_size)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
+	Qspi_Ip_EraseVarConfigType *etp = NULL;
+	Qspi_Ip_EraseVarConfigType *etp_tmp;
+	Qspi_Ip_StatusType status;
+	int ret = 0;
+
+	/*
+	 * Find the erase type with bigger size that can erase all or part of the
+	 * requested memory size
+	 */
+	for (uint8_t i = 0; i < QSPI_IP_ERASE_TYPES; i++) {
+		etp_tmp = (Qspi_Ip_EraseVarConfigType *)&(memory_cfg->eraseSettings.eraseTypes[i]);
+		if ((etp_tmp->eraseLut != QSPI_IP_LUT_INVALID)
+			&& QSPI_IS_ALIGNED(offset, etp_tmp->size)
+			&& (BIT(etp_tmp->size) <= size)
+			&& ((etp == NULL) || (etp_tmp->size > etp->size))) {
+
+			etp = etp_tmp;
+		}
+	}
+	if (etp != NULL) {
+		*erase_size = BIT(etp->size);
+		status = Qspi_Ip_EraseBlock(data->instance, (uint32_t)offset, *erase_size);
+		if (status != STATUS_QSPI_IP_SUCCESS) {
+			LOG_ERR("Failed to erase %zu bytes at 0x%lx (%d)",
+				*erase_size, (long)offset, status);
+			ret = -EIO;
+		}
+	} else {
+		LOG_ERR("Can't find erase size to erase %zu bytes", size);
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
+static int nxp_s32_qspi_erase(const struct device *dev, off_t offset, size_t size)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
+	Qspi_Ip_StatusType status;
+	size_t erase_size;
+	int ret = 0;
+
+	if (!area_is_subregion(dev, offset, size)) {
+		return -ENODEV;
+	}
+
+	nxp_s32_qspi_lock(dev);
+
+	if (size == memory_cfg->memSize) {
+		status = Qspi_Ip_EraseChip(data->instance);
+		if (status != STATUS_QSPI_IP_SUCCESS) {
+			LOG_ERR("Failed to erase chip (%d)", status);
+			ret = -EIO;
+		}
+	} else {
+		while (size > 0) {
+			erase_size = 0;
+
+			ret = nxp_s32_qspi_erase_block(dev, offset, size, &erase_size);
+			if (ret != 0) {
+				break;
+			}
+
+			ret = nxp_s32_qspi_wait_until_ready(dev);
+			if (ret != 0) {
+				break;
+			}
+
+			if (IS_ENABLED(CONFIG_FLASH_NXP_S32_QSPI_VERIFY_ERASE)) {
+				status = Qspi_Ip_EraseVerify(data->instance, (uint32_t)offset,
+							erase_size);
+				if (status != STATUS_QSPI_IP_SUCCESS) {
+					LOG_ERR("Erase verification failed at 0x%lx (%d)",
+						offset, status);
+					ret = -EIO;
+					break;
+				}
+			}
+
+			offset += erase_size;
+			size -= erase_size;
+		}
+	}
+
+	nxp_s32_qspi_unlock(dev);
+
+	return ret;
+}
+
+#if defined(CONFIG_FLASH_JESD216_API) || !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+static int nxp_s32_qspi_read_id(const struct device *dev, uint8_t *id)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_StatusType status;
+	int ret = 0;
+
+	nxp_s32_qspi_lock(dev);
+
+	status = Qspi_Ip_ReadId(data->instance, id);
+	if (status != STATUS_QSPI_IP_SUCCESS) {
+		LOG_ERR("Failed to read device ID (%d)", status);
+		ret = -EIO;
+	}
+
+	nxp_s32_qspi_unlock(dev);
+
+	return ret;
+}
+#endif /* CONFIG_FLASH_JESD216_API || !CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME */
+
+#if defined(CONFIG_FLASH_JESD216_API)
+static int nxp_s32_qspi_sfdp_read(const struct device *dev, off_t offset, void *buf, size_t len)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_StatusType status;
+	int ret = 0;
+
+	nxp_s32_qspi_lock(dev);
+
+	status = Qspi_Ip_RunReadCommand(data->instance, data->read_sfdp_lut_idx,
+					(uint32_t)offset, (uint8_t *)buf, NULL, (uint32_t)len);
+	if (status != STATUS_QSPI_IP_SUCCESS) {
+		LOG_ERR("Failed to read SFDP at 0x%lx (%d)", offset, status);
+		ret = -EIO;
+	}
+
+	nxp_s32_qspi_unlock(dev);
+
+	return ret;
+}
+#endif /* CONFIG_FLASH_JESD216_API */
+
+#if defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+static int nxp_s32_qspi_sfdp_config(const struct device *dev)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
+	Qspi_Ip_StatusType status;
+
+	/* Populate memory configuration with values obtained from SFDP */
+	memory_cfg->memType = QSPI_IP_SERIAL_FLASH;
+	memory_cfg->lutSequences.opCount = QSPI_SFDP_LUT_SIZE;
+	memory_cfg->lutSequences.lutOps = (Qspi_Ip_InstrOpType *)data->lut_ops;
+	memory_cfg->initConfiguration.opCount = QSPI_SFDP_INIT_OP_SIZE;
+	memory_cfg->initConfiguration.operations = (Qspi_Ip_InitOperationType *)data->init_ops;
+
+	status = Qspi_Ip_ReadSfdp(memory_cfg, &data->memory_conn_cfg);
+	if (status != STATUS_QSPI_IP_SUCCESS) {
+		LOG_ERR("Fail to read SFDP (%d)", status);
+		return -EIO;
+	}
+
+#if defined(CONFIG_FLASH_JESD216_API)
+	/* The HAL does not populate LUTs for read SFDP and read ID */
+	uint8_t lut_idx = QSPI_SFDP_LUT_SIZE;
+
+	for (int i = 0; i < QSPI_SFDP_LUT_SIZE - 1; i++) {
+		if ((data->lut_ops[i] == QSPI_IP_LUT_SEQ_END)
+				&& (data->lut_ops[i+1] == QSPI_IP_LUT_SEQ_END)) {
+			lut_idx = i + 1;
+			break;
+		}
+	}
+
+	/* Make sure there's enough space to add the LUT sequences */
+	if ((lut_idx + QSPI_JESD216_SEQ_SIZE - 1) >= QSPI_SFDP_LUT_SIZE) {
+		return -ENOMEM;
+	}
+
+	data->read_sfdp_lut_idx = lut_idx;
+	data->lut_ops[lut_idx++] = QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1,
+						JESD216_CMD_READ_SFDP);
+	data->lut_ops[lut_idx++] = QSPI_LUT_OP(QSPI_IP_LUT_INSTR_ADDR, QSPI_IP_LUT_PADS_1, 24U);
+	data->lut_ops[lut_idx++] = QSPI_LUT_OP(QSPI_IP_LUT_INSTR_DUMMY, QSPI_IP_LUT_PADS_1, 8U);
+	data->lut_ops[lut_idx++] = QSPI_LUT_OP(QSPI_IP_LUT_INSTR_READ, QSPI_IP_LUT_PADS_1, 16U);
+	data->lut_ops[lut_idx++] = QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END,
+						QSPI_IP_LUT_SEQ_END);
+
+	memory_cfg->readIdSettings.readIdLut = lut_idx;
+	memory_cfg->readIdSettings.readIdSize = JESD216_READ_ID_LEN;
+	data->lut_ops[lut_idx++] = QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1,
+						JESD216_CMD_READ_ID);
+	data->lut_ops[lut_idx++] = QSPI_LUT_OP(QSPI_IP_LUT_INSTR_READ, QSPI_IP_LUT_PADS_1,
+						JESD216_READ_ID_LEN);
+	data->lut_ops[lut_idx++] = QSPI_LUT_OP(QSPI_IP_LUT_INSTR_STOP, QSPI_IP_LUT_SEQ_END,
+						QSPI_IP_LUT_SEQ_END);
+#endif /* CONFIG_FLASH_JESD216_API */
+
+	return 0;
+}
+#endif
+
+static const struct flash_parameters *nxp_s32_qspi_get_parameters(const struct device *dev)
+{
+	const struct nxp_s32_qspi_config *config = dev->config;
+
+	return &config->flash_parameters;
+}
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+static void nxp_s32_qspi_pages_layout(const struct device *dev,
+				const struct flash_pages_layout **layout,
+				size_t *layout_size)
+{
+	const struct nxp_s32_qspi_config *config = dev->config;
+
+	*layout = &config->layout;
+	*layout_size = 1;
+}
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
+static int nxp_s32_qspi_init(const struct device *dev)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	const struct nxp_s32_qspi_config *config = dev->config;
+	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
+	Qspi_Ip_StatusType status;
+	static uint8_t instance_cnt;
+	int ret = 0;
+
+	/* Used by the HAL to retrieve the internal driver state */
+	data->instance = instance_cnt++;
+	__ASSERT_NO_MSG(data->instance < QSPI_IP_MEM_INSTANCE_COUNT);
+	data->memory_conn_cfg.qspiInstance = memc_nxp_s32_qspi_get_instance(config->controller);
+
+#if defined(CONFIG_MULTITHREADING)
+	k_sem_init(&data->sem, 1, 1);
+#endif
+
+#if defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+	nxp_s32_qspi_sfdp_config(dev);
+#endif
+
+	/* Init memory device connected to the bus */
+	status = Qspi_Ip_Init(data->instance,
+			(const Qspi_Ip_MemoryConfigType *)memory_cfg,
+			(const Qspi_Ip_MemoryConnectionType *)&data->memory_conn_cfg);
+	if (status != STATUS_QSPI_IP_SUCCESS) {
+		LOG_ERR("Fail to init memory device %d (%d)", data->instance, status);
+		return -EIO;
+	}
+
+
+#if !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+	uint8_t jedec_id[JESD216_READ_ID_LEN];
+
+	/* Verify connectivity by reading the device ID */
+	ret = nxp_s32_qspi_read_id(dev, jedec_id);
+	if (ret != 0) {
+		LOG_ERR("JEDEC ID read failed (%d)", ret);
+		return -ENODEV;
+	}
+
+	/*
+	 * Check the memory device ID against the one configured from devicetree
+	 * to verify we are talking to the correct device.
+	 */
+	if (memcmp(jedec_id, memory_cfg->readIdSettings.readIdExpected, sizeof(jedec_id)) != 0) {
+		LOG_ERR("Device id %02x %02x %02x does not match config %02x %02x %02x",
+			jedec_id[0], jedec_id[1], jedec_id[2],
+			memory_cfg->readIdSettings.readIdExpected[0],
+			memory_cfg->readIdSettings.readIdExpected[1],
+			memory_cfg->readIdSettings.readIdExpected[2]);
+		return -EINVAL;
+	}
+
+	ret = nxp_s32_qspi_set_quad_mode(dev, config->quad_mode);
+	if (ret < 0) {
+		return ret;
+	}
+#endif /* !CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME */
+
+	return ret;
+}
+
+static const struct flash_driver_api nxp_s32_qspi_api = {
+	.erase = nxp_s32_qspi_erase,
+	.write = nxp_s32_qspi_write,
+	.read = nxp_s32_qspi_read,
+	.get_parameters = nxp_s32_qspi_get_parameters,
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	.page_layout = nxp_s32_qspi_pages_layout,
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+#if defined(CONFIG_FLASH_JESD216_API)
+	.sfdp_read = nxp_s32_qspi_sfdp_read,
+	.read_jedec_id = nxp_s32_qspi_read_id,
+#endif /* CONFIG_FLASH_JESD216_API */
+};
+
+#define QSPI_PAGE_LAYOUT(n)							\
+	.layout = {								\
+		.pages_count = (DT_INST_PROP(n, size) / 8)			\
+			/ CONFIG_FLASH_NXP_S32_QSPI_LAYOUT_PAGE_SIZE,		\
+		.pages_size = CONFIG_FLASH_NXP_S32_QSPI_LAYOUT_PAGE_SIZE,	\
+	}
+
+#define QSPI_READ_ID_CFG(n)							\
+	{									\
+		.readIdLut = QSPI_LUT_IDX(QSPI_SEQ_RDID),			\
+		.readIdSize = DT_INST_PROP_LEN(n, jedec_id),			\
+		.readIdExpected = DT_INST_PROP(n, jedec_id),			\
+	}
+
+#define QSPI_MEMORY_CONN_CFG(n)							\
+	{									\
+		.connectionType = (Qspi_Ip_ConnectionType)DT_INST_REG_ADDR(n),	\
+		.memAlignment = DT_INST_PROP_OR(n, memory_alignment, 1)		\
+	}
+
+#define QSPI_ERASE_CFG(n)							\
+	{									\
+		.eraseTypes = {							\
+			{							\
+				.eraseLut = QSPI_LUT_IDX(QSPI_SEQ_SE),		\
+				.size = 12, /* 4 KB */				\
+			},							\
+			{							\
+				.eraseLut = QSPI_LUT_IDX(QSPI_SEQ_BE),		\
+				.size = 16, /* 64 KB */				\
+			},							\
+			COND_CODE_1(DT_INST_PROP(n, has_32k_erase), (		\
+			{							\
+				.eraseLut = QSPI_LUT_IDX(QSPI_SEQ_BE_32K),	\
+				.size = 15, /* 32 KB */				\
+			},							\
+			), (							\
+			{							\
+				.eraseLut = QSPI_IP_LUT_INVALID,		\
+			},							\
+			))							\
+			{							\
+				.eraseLut = QSPI_IP_LUT_INVALID,		\
+			},							\
+		},								\
+		.chipEraseLut = QSPI_LUT_IDX(QSPI_SEQ_CE),			\
+	}
+
+#define QSPI_RESET_CFG(n)							\
+	{									\
+		.resetCmdLut = QSPI_LUT_IDX(QSPI_SEQ_RESET),			\
+		.resetCmdCount = 4U,						\
+	}
+
+/*
+ * SR information used internally by the HAL to access fields BUSY and WEL
+ * during read/write/erase and polling status operations.
+ */
+#define QSPI_STATUS_REG_CFG(n)							\
+	{									\
+		.statusRegInitReadLut = QSPI_LUT_IDX(QSPI_SEQ_RDSR),		\
+		.statusRegReadLut = QSPI_LUT_IDX(QSPI_SEQ_RDSR),		\
+		.statusRegWriteLut = QSPI_LUT_IDX(QSPI_SEQ_WRSR),		\
+		.writeEnableSRLut = QSPI_LUT_IDX(QSPI_SEQ_WREN),		\
+		.writeEnableLut = QSPI_LUT_IDX(QSPI_SEQ_WREN),			\
+		.regSize = 1U,							\
+		.busyOffset = 0U,						\
+		.busyValue = 1U,						\
+		.writeEnableOffset = 1U,					\
+	}
+
+#define QSPI_INIT_CFG(n)							\
+	{									\
+		.opCount = 0U,							\
+		.operations = NULL,						\
+	}
+
+#define QSPI_LUT_CFG(n)								\
+	{									\
+		.opCount = ARRAY_SIZE(nxp_s32_qspi_lut),			\
+		.lutOps = (Qspi_Ip_InstrOpType *)nxp_s32_qspi_lut,		\
+	}
+
+#define QSPI_MEMORY_CFG(n)							\
+	{									\
+		.memType = QSPI_IP_SERIAL_FLASH,				\
+		.hfConfig = NULL,						\
+		.memSize = DT_INST_PROP(n, size) / 8,				\
+		.pageSize = CONFIG_FLASH_NXP_S32_QSPI_LAYOUT_PAGE_SIZE,		\
+		.writeLut = QSPI_LUT_IDX(QSPI_WRITE_SEQ(n)),			\
+		.readLut = QSPI_LUT_IDX(QSPI_READ_SEQ(n)),			\
+		.read0xxLut = QSPI_IP_LUT_INVALID,				\
+		.read0xxLutAHB = QSPI_IP_LUT_INVALID,				\
+		.eraseSettings = QSPI_ERASE_CFG(n),				\
+		.statusConfig = QSPI_STATUS_REG_CFG(n),				\
+		.resetSettings = QSPI_RESET_CFG(n),				\
+		.initResetSettings = QSPI_RESET_CFG(n),				\
+		.initConfiguration = QSPI_INIT_CFG(n),				\
+		.lutSequences = QSPI_LUT_CFG(n),				\
+		COND_CODE_1(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME, (), (	\
+			.readIdSettings = QSPI_READ_ID_CFG(n),)			\
+		)								\
+		.suspendSettings = {						\
+			.eraseSuspendLut = QSPI_IP_LUT_INVALID,			\
+			.eraseResumeLut = QSPI_IP_LUT_INVALID,			\
+			.programSuspendLut = QSPI_IP_LUT_INVALID,		\
+			.programResumeLut = QSPI_IP_LUT_INVALID,		\
+		},								\
+		.initCallout = NULL,						\
+		.resetCallout = NULL,						\
+		.errorCheckCallout = NULL,					\
+		.eccCheckCallout = NULL,					\
+		.ctrlAutoCfgPtr = NULL,						\
+	}
+
+#define FLASH_NXP_S32_QSPI_INIT_DEVICE(n)					\
+	COND_CODE_1(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME, (), (		\
+		BUILD_ASSERT(DT_INST_NODE_HAS_PROP(n, jedec_id),		\
+			"jedec-id is required for non-runtime SFDP");		\
+		BUILD_ASSERT(DT_INST_PROP_LEN(n, jedec_id) == JESD216_READ_ID_LEN,\
+			"jedec-id must be of size JESD216_READ_ID_LEN bytes");	\
+	))									\
+										\
+	static const struct nxp_s32_qspi_config nxp_s32_qspi_config_##n = {	\
+		.controller = DEVICE_DT_GET(DT_INST_BUS(n)),			\
+		.flash_parameters = {						\
+			.write_block_size = QSPI_WRITE_BLOCK_SIZE,		\
+			.erase_value = QSPI_ERASE_VALUE,			\
+		},								\
+		IF_ENABLED(CONFIG_FLASH_PAGE_LAYOUT,				\
+			(QSPI_PAGE_LAYOUT(n),))					\
+		COND_CODE_1(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME, (), (	\
+			.memory_cfg = QSPI_MEMORY_CFG(n),			\
+			.qer_type = QSPI_QER_TYPE(n),				\
+			.quad_mode = QSPI_HAS_QUAD_MODE(n)			\
+		))								\
+	};									\
+										\
+	static struct nxp_s32_qspi_data nxp_s32_qspi_data_##n = {		\
+		.memory_conn_cfg = QSPI_MEMORY_CONN_CFG(n),			\
+		COND_CODE_1(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME, (), (	\
+			.read_sfdp_lut_idx = QSPI_LUT_IDX(QSPI_SEQ_READ_SFDP),	\
+		))								\
+	};									\
+										\
+	DEVICE_DT_INST_DEFINE(n,						\
+			nxp_s32_qspi_init,					\
+			NULL,							\
+			&nxp_s32_qspi_data_##n,					\
+			&nxp_s32_qspi_config_##n,				\
+			POST_KERNEL,						\
+			CONFIG_FLASH_INIT_PRIORITY,				\
+			&nxp_s32_qspi_api);
+
+DT_INST_FOREACH_STATUS_OKAY(FLASH_NXP_S32_QSPI_INIT_DEVICE)

--- a/drivers/memc/CMakeLists.txt
+++ b/drivers/memc/CMakeLists.txt
@@ -18,3 +18,5 @@ zephyr_library_sources_ifdef(CONFIG_MEMC_HIFIVE_UNMATCHED_DRAM sifive_ddr.c)
 if((DEFINED CONFIG_FLASH_MCUX_FLEXSPI_XIP) AND (DEFINED CONFIG_FLASH))
   zephyr_code_relocate(FILES memc_mcux_flexspi.c LOCATION ${CONFIG_FLASH_MCUX_FLEXSPI_XIP_MEM}_TEXT)
 endif()
+
+zephyr_library_sources_ifdef(CONFIG_MEMC_NXP_S32_QSPI memc_nxp_s32_qspi.c)

--- a/drivers/memc/Kconfig
+++ b/drivers/memc/Kconfig
@@ -29,4 +29,6 @@ source "drivers/memc/Kconfig.sam"
 
 source "drivers/memc/Kconfig.sifive"
 
+source "drivers/memc/Kconfig.nxp_s32"
+
 endif

--- a/drivers/memc/Kconfig.nxp_s32
+++ b/drivers/memc/Kconfig.nxp_s32
@@ -1,0 +1,10 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config MEMC_NXP_S32_QSPI
+	bool "NXP S32 Quad Serial Peripheral Interface (QSPI) controller"
+	default y
+	depends on DT_HAS_NXP_S32_QSPI_ENABLED
+	select PINCTRL
+	help
+	  Enable NXP S32 Quad Serial Peripheral Interface (QSPI) controller.

--- a/drivers/memc/memc_nxp_s32_qspi.c
+++ b/drivers/memc/memc_nxp_s32_qspi.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT	nxp_s32_qspi
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(nxp_s32_qspi_memc, CONFIG_MEMC_LOG_LEVEL);
+
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/sys/util.h>
+
+#include <soc.h>
+#include "memc_nxp_s32_qspi.h"
+
+/* Mapping between QSPI chip select signals and devicetree chip select identifiers */
+#define QSPI_PCSFA1	0
+#define QSPI_PCSFA2	1
+#define QSPI_PCSFB1	2
+#define QSPI_PCSFB2	3
+
+struct memc_nxp_s32_qspi_data {
+	uint8_t instance;
+};
+
+struct memc_nxp_s32_qspi_config {
+	QuadSPI_Type *base;
+	const struct pinctrl_dev_config *pincfg;
+
+	const Qspi_Ip_ControllerConfigType *controller_cfg;
+};
+
+static inline uint8_t get_instance(QuadSPI_Type *base)
+{
+	QuadSPI_Type *const base_ptrs[QuadSPI_INSTANCE_COUNT] = IP_QuadSPI_BASE_PTRS;
+	uint8_t i;
+
+	for (i = 0; i < QuadSPI_INSTANCE_COUNT; i++) {
+		if (base_ptrs[i] == base) {
+			break;
+		}
+	}
+	__ASSERT_NO_MSG(i < QuadSPI_INSTANCE_COUNT);
+
+	return i;
+}
+
+static int memc_nxp_s32_qspi_init(const struct device *dev)
+{
+	const struct memc_nxp_s32_qspi_config *config = dev->config;
+	struct memc_nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_StatusType status;
+
+	data->instance = get_instance(config->base);
+
+	if (pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT)) {
+		return -EIO;
+	}
+
+	status = Qspi_Ip_ControllerInit(data->instance, config->controller_cfg);
+	if (status != STATUS_QSPI_IP_SUCCESS) {
+		LOG_ERR("Fail to initialize QSPI controller %d (%d)",
+			data->instance, status);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+uint8_t memc_nxp_s32_qspi_get_instance(const struct device *dev)
+{
+	struct memc_nxp_s32_qspi_data *data = dev->data;
+
+	return data->instance;
+}
+
+#define QSPI_DATA_CFG(n)								\
+	IF_ENABLED(FEATURE_QSPI_DDR, (							\
+		.dataRate = CONCAT(QSPI_IP_DATA_RATE_,					\
+			DT_INST_STRING_UPPER_TOKEN(n, data_rate)),			\
+		.dataAlign = COND_CODE_1(DT_INST_PROP(n, hold_time_2x),			\
+			(QSPI_IP_FLASH_DATA_ALIGN_2X_REFCLK),				\
+			(QSPI_IP_FLASH_DATA_ALIGN_REFCLK)),				\
+	))
+
+#define QSPI_ADDR_CFG(n) \
+	IF_ENABLED(FEATURE_QSPI_ADDR_CFG, (						\
+		.columnAddr = DT_INST_PROP_OR(n, column_space, 0),			\
+		.wordAddresable = DT_INST_PROP(n, word_addressable),			\
+	))
+
+#define QSPI_BYTES_SWAP_ADDR(n)								\
+	IF_ENABLED(FEATURE_QSPI_BYTES_SWAP_ADDR,					\
+		(.byteSwap = DT_INST_PROP(n, byte_swapping),))
+
+#define QSPI_SAMPLE_DELAY(n)								\
+	COND_CODE_1(DT_INST_PROP(n, sample_delay_half_cycle),				\
+		(QSPI_IP_SAMPLE_DELAY_HALFCYCLE_EARLY_DQS),				\
+		(QSPI_IP_SAMPLE_DELAY_SAME_DQS))
+
+#define QSPI_SAMPLE_PHASE(n)								\
+	COND_CODE_1(DT_INST_PROP(n, sample_phase_inverted),				\
+		(QSPI_IP_SAMPLE_PHASE_INVERTED),					\
+		(QSPI_IP_SAMPLE_PHASE_NON_INVERTED))
+
+#define QSPI_AHB_BUFFERS(n)								\
+	{										\
+		.masters = DT_INST_PROP(n, ahb_buffers_masters),			\
+		.sizes = DT_INST_PROP(n, ahb_buffers_sizes),				\
+		.allMasters = (bool)DT_INST_PROP(n, ahb_buffers_all_masters),		\
+	}
+
+#define QSPI_DLL_CFG(n, side, side_upper)						\
+	IF_ENABLED(FEATURE_QSPI_HAS_DLL, (						\
+		.dllSettings##side_upper = {						\
+			.dllMode = CONCAT(QSPI_IP_DLL_,					\
+				DT_INST_STRING_UPPER_TOKEN(n, side##_dll_mode)),	\
+			.freqEnable = DT_INST_PROP(n, side##_dll_freq_enable),		\
+			.coarseDelay = DT_INST_PROP(n, side##_dll_coarse_delay),	\
+			.fineDelay = DT_INST_PROP(n, side##_dll_fine_delay),		\
+			.tapSelect = DT_INST_PROP(n, side##_dll_tap_select),		\
+			IF_ENABLED(FEATURE_QSPI_DLL_LOOPCONTROL, (			\
+			.referenceCounter = DT_INST_PROP(n, side##_dll_ref_counter),	\
+			.resolution = DT_INST_PROP(n, side##_dll_resolution),		\
+			))								\
+		},									\
+	))
+
+#define QSPI_READ_MODE(n, side, side_upper)						\
+	CONCAT(QSPI_IP_READ_MODE_, DT_INST_STRING_UPPER_TOKEN(n, side##_rx_clock_source))
+
+#define QSPI_IDLE_SIGNAL_DRIVE(n, side, side_upper)					\
+	IF_ENABLED(FEATURE_QSPI_CONFIGURABLE_ISD, (					\
+		.io2IdleValue##side_upper = (uint8_t)DT_INST_PROP(n, side##_io2_idle_high),\
+		.io3IdleValue##side_upper = (uint8_t)DT_INST_PROP(n, side##_io3_idle_high),\
+	))
+
+#define QSPI_PORT_SIZE_FN(node_id, side_upper, port)					\
+	COND_CODE_1(IS_EQ(DT_REG_ADDR(node_id), QSPI_PCSF##side_upper##port),		\
+		(COND_CODE_1(DT_NODE_HAS_STATUS(node_id, okay),				\
+			(.memSize##side_upper##port = DT_PROP(node_id, size) / 8,),	\
+			(.memSize##side_upper##port = 0,))),				\
+		(EMPTY))
+
+#define QSPI_PORT_SIZE(n, side_upper)							\
+	DT_INST_FOREACH_CHILD_VARGS(n, QSPI_PORT_SIZE_FN, side_upper, 1)		\
+	DT_INST_FOREACH_CHILD_VARGS(n, QSPI_PORT_SIZE_FN, side_upper, 2)
+
+#define QSPI_SIDE_CFG(n, side, side_upper)						\
+	QSPI_IDLE_SIGNAL_DRIVE(n, side, side_upper)					\
+	QSPI_DLL_CFG(n, side, side_upper)						\
+	QSPI_PORT_SIZE(n, side_upper)							\
+	.readMode##side_upper = QSPI_READ_MODE(n, side, side_upper),
+
+#define MEMC_NXP_S32_QSPI_CONTROLLER_CONFIG(n)						\
+	BUILD_ASSERT(DT_INST_PROP_LEN(n, ahb_buffers_masters) == QSPI_IP_AHB_BUFFERS,	\
+		"ahb-buffers-masters must be of size QSPI_IP_AHB_BUFFERS");		\
+	BUILD_ASSERT(DT_INST_PROP_LEN(n, ahb_buffers_sizes) == QSPI_IP_AHB_BUFFERS,	\
+		"ahb-buffers-sizes must be of size QSPI_IP_AHB_BUFFERS");		\
+	BUILD_ASSERT(									\
+		CONCAT(FEATURE_QSPI_, DT_INST_STRING_UPPER_TOKEN(n, a_rx_clock_source)) == 1,\
+		"a-rx-clock-source source mode selected is not supported");		\
+											\
+	static const Qspi_Ip_ControllerConfigType					\
+	memc_nxp_s32_qspi_controller_cfg_##n = {					\
+		.csHoldTime = DT_INST_PROP(n, cs_hold_time),				\
+		.csSetupTime = DT_INST_PROP(n, cs_setup_time),				\
+		.sampleDelay = QSPI_SAMPLE_DELAY(n),					\
+		.samplePhase = QSPI_SAMPLE_PHASE(n),					\
+		.ahbConfig = QSPI_AHB_BUFFERS(n),					\
+		QSPI_SIDE_CFG(n, a, A)							\
+		QSPI_DATA_CFG(n)							\
+		QSPI_ADDR_CFG(n)							\
+		QSPI_BYTES_SWAP_ADDR(n)							\
+	}
+
+#define MEMC_NXP_S32_QSPI_INIT_DEVICE(n)						\
+	PINCTRL_DT_INST_DEFINE(n);							\
+	MEMC_NXP_S32_QSPI_CONTROLLER_CONFIG(n);						\
+	static struct memc_nxp_s32_qspi_data memc_nxp_s32_qspi_data_##n;		\
+	static const struct memc_nxp_s32_qspi_config memc_nxp_s32_qspi_config_##n = {	\
+		.base = (QuadSPI_Type *)DT_INST_REG_ADDR(n),				\
+		.controller_cfg = &memc_nxp_s32_qspi_controller_cfg_##n,		\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\
+	};										\
+	DEVICE_DT_INST_DEFINE(n,							\
+		memc_nxp_s32_qspi_init,							\
+		NULL,									\
+		&memc_nxp_s32_qspi_data_##n,						\
+		&memc_nxp_s32_qspi_config_##n,						\
+		POST_KERNEL,								\
+		CONFIG_MEMC_INIT_PRIORITY,						\
+		NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(MEMC_NXP_S32_QSPI_INIT_DEVICE)

--- a/drivers/memc/memc_nxp_s32_qspi.h
+++ b/drivers/memc/memc_nxp_s32_qspi.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <sys/types.h>
+
+#include <Qspi_Ip.h>
+
+/**
+ * @brief Build a QSPI Look-up Table (LUT) sequence entry.
+ *
+ * @param inst instruction
+ * @param pads pad information
+ * @param op operand
+ */
+#define QSPI_LUT_OP(inst, pads, op)				\
+	((Qspi_Ip_InstrOpType)((Qspi_Ip_InstrOpType)(inst)	\
+		| (Qspi_Ip_InstrOpType)(pads)			\
+		| (Qspi_Ip_InstrOpType)(op)))
+
+/**
+ * @brief Get the QSPI peripheral hardware instance number.
+ *
+ * @param dev device pointer
+ */
+uint8_t memc_nxp_s32_qspi_get_instance(const struct device *dev);

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -415,6 +415,14 @@
 			clocks = <&clock NXP_S32_LPUART15_CLK>;
 			status = "disabled";
 		};
+
+		qspi0: qspi@404cc000 {
+			compatible = "nxp,s32-qspi";
+			reg = <0x404cc000 0x4000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/bindings/mtd/nxp,s32-qspi-device.yaml
+++ b/dts/bindings/mtd/nxp,s32-qspi-device.yaml
@@ -1,0 +1,22 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  QSPI memory device supporting xSPI or Hyperbus.
+
+compatible: "nxp,s32-qspi-device"
+
+include: [base.yaml, "jedec,jesd216.yaml"]
+
+on-bus: qspi
+
+properties:
+  reg:
+    required: true
+
+  memory-alignment:
+    type: int
+    description: |
+      Memory alignment in bytes, used to calculate padding when performing
+      unaligned accesses.
+      If not provided, 1 byte alignment will be selected.

--- a/dts/bindings/mtd/nxp,s32-qspi-nor.yaml
+++ b/dts/bindings/mtd/nxp,s32-qspi-nor.yaml
@@ -1,0 +1,38 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  QSPI NOR flash connected to the NXP S32 QSPI bus.
+
+compatible: "nxp,s32-qspi-nor"
+
+include: "nxp,s32-qspi-device.yaml"
+
+properties:
+  has-32k-erase:
+    type: boolean
+    description: |
+      Set if the memory device supports 32 KiBy block erase operation.
+
+  readoc:
+    type: string
+    enum:
+      - "1-1-1"   # 0x0B
+      - "1-1-2"   # 0x3B
+      - "1-2-2"   # 0xBB
+      - "1-1-4"   # 0x6B
+      - "1-4-4"   # 0xEB
+    description: |
+      Specify the number of data lines and opcode used for reading.
+      If not provided, 1-1-1 will be selected.
+
+  writeoc:
+    type: string
+    enum:
+      - "1-1-1"   # 0x02
+      - "1-1-2"   # 0xA2
+      - "1-1-4"   # 0x32
+      - "1-4-4"   # 0x38
+    description: |
+      Specify the number of data lines and opcode used for writing.
+      If not provided, 1-1-1 will be selected.

--- a/dts/bindings/qspi/nxp,s32-qspi.yaml
+++ b/dts/bindings/qspi/nxp,s32-qspi.yaml
@@ -1,0 +1,208 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  NXP S32 Quad Serial Peripheral Interface (QSPI) Controller.
+
+  QSPI acts as an interface to up to two serial flash memory devices, each with
+  up to eight bidirectional bidirectional data lines, depending on the platform.
+
+compatible: "nxp,s32-qspi"
+
+include: [base.yaml, pinctrl-device.yaml]
+
+bus: qspi
+
+properties:
+  reg:
+    required: true
+
+  "#address-cells":
+    const: 1
+
+  "#size-cells":
+    const: 0
+
+  data-rate:
+    type: string
+    enum:
+      - SDR
+      - DDR
+    description: |
+      Selects the read mode:
+      - Single Data Rate (SDR): sampling of incoming data occurs on single edges.
+      - Double Data Rate (DDR): sampling of incoming data occurs on both edges.
+
+  hold-time-2x:
+    type: boolean
+    description: |
+      Set to align incoming data with 2x serial flash half clock, when in DDR
+      mode. Otherwise, data will be aligned to the posedge of the controller's
+      internal reference clock.
+
+  sample-delay-half-cycle:
+    type: boolean
+    description: |
+      Set to use half-cycle early DQS delay when sampling received data.
+
+  sample-phase-inverted:
+    type: boolean
+    description: |
+      Set to sample received data at inverted clock.
+
+  cs-setup-time:
+    type: int
+    default: 3
+    description: |
+      Chip select setup time, in serial clock cycles. A bigger value will pull
+      the CS signal earlier before the transaction starts.
+      The default corresponds to the reset value of the register field.
+
+  cs-hold-time:
+    type: int
+    default: 3
+    description: |
+      Chip select hold time, in serial clock cycles. A bigger value will release
+      the CS signal later after the transaction ends.
+      The default corresponds to the reset value of the register field.
+
+  column-space:
+    type: int
+    default: 0
+    description: |
+      Column Address Space bit width. For example, if the coulmn address is
+      [2:0] of QSPI_SFAR/AHB address, then the column address space bit width
+      must be 3. If there is no column address separation in any serial flash
+      device connected to this controller, this value must be programmed to 0.
+      The default corresponds to the reset value of the register field.
+
+  word-addressable:
+    type: boolean
+    description: |
+      Set if the serial flash device connected to this controller is word
+      (2 bytes) addressable.
+
+  byte-swapping:
+    type: boolean
+    description: |
+      In case of Octal DDR mode, specifies whether a word unit composed of two
+      bytes from posedge and negedge of a single DQS cycle needs to be swapped.
+
+  ahb-buffers-masters:
+    type: array
+    description: |
+      Masters ID's for the AHB receive buffers. The master ID of every incoming
+      request is checked and the data is returned or fetched into the
+      corresponding associated buffer. The maximum number of buffers is SoC
+      specific.
+
+  ahb-buffers-sizes:
+    type: array
+    description: |
+      Sizes (in bytes) of the AHB receive buffers. The maximum buffer size and
+      maximum number of buffers is SoC specific.
+
+  ahb-buffers-all-masters:
+    type: boolean
+    description: |
+      Any access from a master not associated with any other buffer is routed to
+      the last buffer.
+
+  a-rx-clock-source:
+    type: string
+    enum:
+      - LOOPBACK
+      - LOOPBACK DQS
+      - INTERNAL DQS
+      - EXTERNAL DQS
+    description: |
+      Selects DQS clock source for sampling read data at side A:
+      - LOOPBACK: use loopback clock from dummy internal PAD as strobe signal.
+      - LOOPBACK DQS: use loopback clock from PAD as strobe signal.
+      - INTERNAL DQS: use internally generated strobe signal.
+      - EXTERNAL DQS: use external strobe signal.
+
+  a-io2-idle-high:
+    type: boolean
+    description: |
+      Set if the logic level of IO2 signal output of this controller must be
+      driven high in the inactive state.
+      This property applies to side A of the controller.
+
+  a-io3-idle-high:
+    type: boolean
+    description: |
+      Set if the logic level of IO3 signal output of this controller must be
+      driven high in the inactive state.
+      This property applies to side A of the controller.
+
+  a-dll-mode:
+    type: string
+    enum:
+      - BYPASSED
+      - MANUAL UPDATE
+      - AUTO UPDATE
+    default: BYPASSED
+    description: |
+      DLL mode. The supported modes depends on the SoC.
+      This property applies to side A of the controller.
+
+  a-dll-freq-enable:
+    type: boolean
+    description: |
+      Selects delay-chain for high frequency of operation.
+      This property applies to side A of the controller.
+
+  a-dll-ref-counter:
+    type: int
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    default: 1
+    description: |
+      Select the "n+1" interval of DLL phase detection and reference delay
+      updating interval.
+      Minimum recommended value is 1 (reset value).
+      This property applies to side A of the controller.
+
+  a-dll-resolution:
+    type: int
+    enum: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    default: 2
+    description: |
+      Minimum resolution for DLL phase detector to remain locked/unlocked based
+      on flash memory clock jitter.
+      The minimum value is 2 (reset value).
+      This property applies to side A of the controller.
+
+  a-dll-coarse-delay:
+    type: int
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    default: 0
+    description: |
+      This field sets the number of delay elements in each delay tap. The field
+      is used to overwrite DLL-generated delay values.
+      Default to 0 (reset value).
+      This property applies to side A of the controller.
+
+  a-dll-fine-delay:
+    type: int
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    default: 0
+    description: |
+      This field sets the number of fine offset delay elements up to 16 in
+      incoming DQS.
+      Default to 0 (reset value).
+      This property applies to side A of the controller.
+
+  a-dll-tap-select:
+    type: int
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+    default: 0
+    description: |
+      Selects the Nth tap provided by the slave delay-chain.
+      Default to 0 (reset value).
+      This property applies to side A of the controller.
+
+child-binding:
+  description: NXP S32 QuadSPI port
+
+  include: nxp,s32-qspi-device.yaml

--- a/samples/drivers/jesd216/boards/mr_canhubk3.conf
+++ b/samples/drivers/jesd216/boards/mr_canhubk3.conf
@@ -1,0 +1,5 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Override defaults for SPI NOR flash driver
+CONFIG_SPI_NOR=n

--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -20,6 +20,8 @@
 #define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(st_stm32_qspi_nor)
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_ospi_nor)
 #define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(st_stm32_ospi_nor)
+#elif DT_HAS_COMPAT_STATUS_OKAY(nxp_s32_qspi_nor)
+#define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(nxp_s32_qspi_nor)
 #else
 #error Unsupported flash driver
 #define FLASH_NODE DT_INVALID_NODE

--- a/samples/subsys/fs/littlefs/sample.yaml
+++ b/samples/subsys/fs/littlefs/sample.yaml
@@ -14,6 +14,7 @@ tests:
       - native_posix
       - mimxrt1160_evk_cm7
       - lpcxpresso55s69_cpu0
+      - mr_canhubk3
     tags: filesystem
     integration_platforms:
       - nrf52840dk_nrf52840

--- a/samples/subsys/settings/boards/mr_canhubk3.conf
+++ b/samples/subsys/settings/boards/mr_canhubk3.conf
@@ -1,0 +1,8 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Use LittleFS file system as Settings backend
+CONFIG_FILE_SYSTEM=y
+CONFIG_FILE_SYSTEM_LITTLEFS=y
+CONFIG_SETTINGS_FILE=y
+CONFIG_SETTINGS_FILE_PATH="/ff/settings/run"

--- a/samples/subsys/settings/sample.yaml
+++ b/samples/subsys/settings/sample.yaml
@@ -9,6 +9,7 @@ tests:
       - qemu_x86
       - native_posix
       - native_posix_64
+      - mr_canhubk3
     integration_platforms:
       - native_posix
     harness: console

--- a/samples/subsys/shell/fs/sample.yaml
+++ b/samples/subsys/shell/fs/sample.yaml
@@ -10,6 +10,7 @@ tests:
     platform_allow:
       - reel_board
       - mimxrt1060_evk
+      - mr_canhubk3
     integration_platforms:
       - reel_board
 

--- a/tests/drivers/flash/boards/mr_canhubk3.conf
+++ b/tests/drivers/flash/boards/mr_canhubk3.conf
@@ -1,0 +1,4 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_MAIN_STACK_SIZE=1100

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -76,3 +76,7 @@ tests:
       - DTC_OVERLAY_FILE=boards/nrf52840dk_mx25r_high_perf.overlay
     integration_platforms:
       - nrf52840dk_nrf52840
+  drivers.flash.common.mr_canhubk3_sfdp_runtime:
+    platform_allow: mr_canhubk3
+    extra_configs:
+      - CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME=y

--- a/tests/subsys/fs/fcb/boards/mr_canhubk3.overlay
+++ b/tests/subsys/fs/fcb/boards/mr_canhubk3.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Currently there's no support for mcuboot, so create a partition for this test.
+ */
+&mx25l6433f {
+	partitions {
+		slot1_partition: partition@100000 {
+			reg = <0x100000 0x100000>;
+		};
+	};
+};

--- a/tests/subsys/fs/fcb/testcase.yaml
+++ b/tests/subsys/fs/fcb/testcase.yaml
@@ -6,6 +6,7 @@ tests:
       - nrf51dk_nrf51422
       - native_posix
       - native_posix_64
+      - mr_canhubk3
     tags: flash_circural_buffer
     integration_platforms:
       - nrf52840dk_nrf52840

--- a/tests/subsys/fs/littlefs/boards/mr_canhubk3.overlay
+++ b/tests/subsys/fs/littlefs/boards/mr_canhubk3.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&mx25l6433f {
+	partitions {
+		small_partition: partition@0 {
+			label = "small";
+			reg = <0x00000000 0x00010000>;
+		};
+		medium_partition: partition@10000 {
+			label = "medium";
+			reg = <0x00010000 0x000F0000>;
+		};
+		large_partition: partition@100000 {
+			label = "large";
+			reg = <0x00100000 0x00300000>;
+		};
+	};
+};

--- a/tests/subsys/fs/littlefs/testcase.yaml
+++ b/tests/subsys/fs/littlefs/testcase.yaml
@@ -5,6 +5,7 @@ common:
     - native_posix
     - native_posix_64
     - mimxrt1060_evk
+    - mr_canhubk3
   integration_platforms:
     - nrf52840dk_nrf52840
   modules:

--- a/tests/subsys/logging/log_backend_fs/boards/mr_canhubk3.overlay
+++ b/tests/subsys/logging/log_backend_fs/boards/mr_canhubk3.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+/ {
+	fstab {
+		compatible = "zephyr,fstab";
+		lfs1: lfs1 {
+			compatible = "zephyr,fstab,littlefs";
+			mount-point = "/lfs1";
+			partition = <&lfs1_part>;
+			read-size = <16>;
+			prog-size = <16>;
+			cache-size = <64>;
+			lookahead-size = <32>;
+			block-cycles = <512>;
+		};
+	};
+};
+
+&mx25l6433f {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		lfs1_part: partition@fc000 {
+			label = "storage";
+			reg = <0x000fc000 0x00010000>;
+		};
+	};
+};

--- a/tests/subsys/logging/log_backend_fs/testcase.yaml
+++ b/tests/subsys/logging/log_backend_fs/testcase.yaml
@@ -12,6 +12,7 @@ tests:
       - native_posix
       - native_posix_64
       - nrf52840dk_nrf52840
+      - mr_canhubk3
     integration_platforms:
       - native_posix
   logging.log_backend_fs.manualmounted.native_posix:
@@ -29,3 +30,6 @@ tests:
     extra_args: DTC_OVERLAY_FILE="./boards/nrf52840dk_nrf52840.overlay;./boards/automount.overlay"
     integration_platforms:
       - nrf52840dk_nrf52840
+  logging.log_backend_fs.manualmounted.mr_canhubk3:
+    platform_allow: mr_canhubk3
+    extra_args: DTC_OVERLAY_FILE="./boards/mr_canhubk3.overlay;./boards/automount.overlay"

--- a/tests/subsys/settings/fcb/testcase.yaml
+++ b/tests/subsys/settings/fcb/testcase.yaml
@@ -5,6 +5,7 @@ tests:
       - nrf52dk_nrf52832
       - native_posix
       - native_posix_64
+      - mr_canhubk3
     integration_platforms:
       - nrf52840dk_nrf52840
       - native_posix

--- a/tests/subsys/settings/file/boards/mr_canhubk3.overlay
+++ b/tests/subsys/settings/file/boards/mr_canhubk3.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&mx25l6433f {
+	partitions {
+		settings_file_partition: partition@0 {
+			label = "settings_file_partition";
+			reg = <0x00000000 0x00010000>;
+		};
+	};
+};

--- a/tests/subsys/settings/file/testcase.yaml
+++ b/tests/subsys/settings/file/testcase.yaml
@@ -7,6 +7,7 @@ tests:
       - nrf52840dk_nrf52840
       - native_posix
       - native_posix_64
+      - mr_canhubk3
     tags:
       - settings_file
       - settings_file_littlefs

--- a/tests/subsys/settings/functional/fcb/testcase.yaml
+++ b/tests/subsys/settings/functional/fcb/testcase.yaml
@@ -5,6 +5,7 @@ tests:
       - nrf52dk_nrf52832
       - native_posix
       - native_posix_64
+      - mr_canhubk3
     integration_platforms:
       - nrf52840dk_nrf52840
     tags: settings_fcb
@@ -13,6 +14,7 @@ tests:
     platform_allow:
       - native_posix
       - native_posix_64
+      - mr_canhubk3
     integration_platforms:
       - native_posix
     tags: settings_fcb

--- a/tests/subsys/settings/functional/file/testcase.yaml
+++ b/tests/subsys/settings/functional/file/testcase.yaml
@@ -5,6 +5,7 @@ tests:
       - nrf52dk_nrf52832
       - native_posix
       - native_posix_64
+      - mr_canhubk3
     integration_platforms:
       - native_posix
     tags: settings_file

--- a/tests/subsys/storage/flash_map/boards/mr_canhubk3.overlay
+++ b/tests/subsys/storage/flash_map/boards/mr_canhubk3.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../app.overlay"
+
+/*
+ * Currently there's no support for mcuboot, so create a partition for this test.
+ */
+&mx25l6433f {
+	partitions {
+		slot1_partition: partition@100000 {
+			reg = <0x100000 0x100000>;
+		};
+	};
+};

--- a/tests/subsys/storage/flash_map/testcase.yaml
+++ b/tests/subsys/storage/flash_map/testcase.yaml
@@ -5,6 +5,7 @@ tests:
       - qemu_x86
       - native_posix
       - native_posix_64
+      - mr_canhubk3
     tags: flash_map
     integration_platforms:
       - native_posix
@@ -26,6 +27,7 @@ tests:
       - qemu_x86
       - native_posix
       - native_posix_64
+      - mr_canhubk3
     tags: flash_map
     integration_platforms:
       - native_posix

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: e0116b8eae46c2d90f2c1b23baef73bb082d00bd
+      revision: 35b0e5afc4f061cedc5a0411e024dad6d9e8101f
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Introduce support for NXP S32 QSPI controller, which acts as an interface to up to two serial flash memory devices, each with up to eight bidirectional data lines, depending on the platform. It is based on a LUT engine to interface through commands with different memory types, including but not limited to, flash NOR.
This patch adds support for the QSPI in S32K344 which supports a single memory device (side A) with up to four bidirectional data lines and SDR only. Nevertheless, the memory controller is implemented flexible enough to be extended to support more feature-rich QSPI blocks.

Also introduce a shim driver for flash NOR memory devices on a NXP S32 QSPI bus. The driver uses a fixed LUT configuration assuming a default standard page size and erase types, and allows to select between multiple read/program instructions/modes. It is also possible to read the flash device characteristics from the device at run-time as long as the memory is JESD216 compatible, providing more flexibility.

Enable samples and tests for the mr_canhubk3 on-board MX25L6433F memory.