### PR TITLE
MAINTAINERS: Add vaishnavachath as maintainer for hal_ti

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2986,7 +2986,9 @@ West:
     - manifest-hal_telink
 
 "West project: hal_ti":
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - vaishnavachath
   collaborators:
     - cfriedt
   files: []


### PR DESCRIPTION
Add myself as a maintainer for TI HAL layer (hal_ti), this update was missed while changing the maintainer details for the rest of TI platforms.

CC: @cfriedt 