### PR TITLE
drivers: spi: eliminate dead code

### DIFF
--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -469,7 +469,7 @@ out:
 	return ret;
 }
 
-#endif
+#else
 
 static int transceive(const struct device *dev,
 		      const struct spi_config *spi_cfg,
@@ -502,6 +502,8 @@ out:
 	return ret;
 }
 
+#endif /*CONFIG_SPI_MCUX_LPSPI_DMA */
+
 static int spi_mcux_transceive(const struct device *dev,
 			       const struct spi_config *spi_cfg,
 			       const struct spi_buf_set *tx_bufs,
@@ -509,8 +511,9 @@ static int spi_mcux_transceive(const struct device *dev,
 {
 #ifdef CONFIG_SPI_MCUX_LPSPI_DMA
 	return transceive_dma(dev, spi_cfg, tx_bufs, rx_bufs, false, NULL, NULL);
-#endif /* CONFIG_SPI_MCUX_LPSPI_DMA */
+#else
 	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, false, NULL, NULL);
+#endif /* CONFIG_SPI_MCUX_LPSPI_DMA */
 }
 
 #ifdef CONFIG_SPI_ASYNC


### PR DESCRIPTION
The `spi_mcux_transceive` had 2 return calls when the `CONFIG_SPI_MCUX_LPSPI_DMA` flag was active. The first return would be called and the later was unreachable. With the fix, now the return calls are mutually exclusive. Also, the `transceive` call is not compiled with the `CONFIG_SPI_MCUX_LPSPI_DMA` flag is active.

Fixes #59533