### PR TITLE
Fix tests/application_development/code_relocation for mr_canhubk3

### DIFF
--- a/tests/application_development/code_relocation/linker_arm_sram2.ld
+++ b/tests/application_development/code_relocation/linker_arm_sram2.ld
@@ -36,4 +36,5 @@ MEMORY
 #endif
     }
 
-#include <zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld>
+/* Include the SoC-specific linker file */
+#include <linker.ld>

--- a/tests/application_development/code_relocation/testcase.yaml
+++ b/tests/application_development/code_relocation/testcase.yaml
@@ -6,12 +6,15 @@ tests:
     arch_allow: arm
     extra_configs:
       - CONFIG_RELOCATE_TO_ITCM=y
+    platform_allow:
+      - mimxrt1060_evk
   tests.application_development.code_relocation_kinetis:
-    filter: CONFIG_CPU_HAS_NXP_MPU and CONFIG_MINIMAL_LIBC and dt_chosen_enabled("zephyr,itcm")
+    filter: CONFIG_CPU_HAS_NXP_MPU and CONFIG_MINIMAL_LIBC
     arch_allow: arm
     extra_configs:
-      - CONFIG_RELOCATE_TO_ITCM=y
       - CONFIG_MPU_ALLOW_FLASH_WRITE=y
+    platform_allow:
+      - frdm_k64f
   tests.application_development.code_relocation.no_itcm:
     filter: not CONFIG_CPU_HAS_NXP_MPU and not dt_chosen_enabled("zephyr,itcm")
     arch_allow: arm

--- a/tests/application_development/code_relocation/testcase.yaml
+++ b/tests/application_development/code_relocation/testcase.yaml
@@ -15,6 +15,14 @@ tests:
       - CONFIG_MPU_ALLOW_FLASH_WRITE=y
     platform_allow:
       - frdm_k64f
+  tests.application_development.code_relocation.nxp_s32:
+    filter: not CONFIG_CPU_HAS_NXP_MPU and CONFIG_MINIMAL_LIBC and dt_chosen_enabled("zephyr,itcm")
+    arch_allow: arm
+    extra_configs:
+      - CONFIG_RELOCATE_TO_ITCM=y
+      - CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
+    platform_allow:
+      - mr_canhubk3
   tests.application_development.code_relocation.no_itcm:
     filter: not CONFIG_CPU_HAS_NXP_MPU and not dt_chosen_enabled("zephyr,itcm")
     arch_allow: arm


### PR DESCRIPTION
Add a memory region for the IVT header on NXP S32K3 devices. This is normally done from the SoC linker script but this test make use of a custom linker script.

In some platforms the MPU region used for NULL pointer detection conflicts with the ITCM region, causing access fault. Make disabling the null pointer exception detection the default behavior for the Arm ITCM relocation test.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/60165