### PR TITLE
video: mcux_csi: set a dedicated init priority for video_mcux_csi

### DIFF
--- a/drivers/video/Kconfig.mcux_csi
+++ b/drivers/video/Kconfig.mcux_csi
@@ -8,3 +8,10 @@ config VIDEO_MCUX_CSI
 	default y
 	depends on HAS_MCUX_CSI
 	depends on DT_HAS_NXP_IMX_CSI_ENABLED
+
+config VIDEO_MCUX_CSI_INIT_PRIORITY
+	int "NXP MCUX CSI init priority"
+	default 61
+	depends on VIDEO_MCUX_CSI
+	help
+	  Initialization priority for the CSI interface on an NXP MCUX device.

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -452,6 +452,6 @@ static int video_mcux_csi_init_0(const struct device *dev)
 DEVICE_DT_INST_DEFINE(0, &video_mcux_csi_init_0,
 		    NULL, &video_mcux_csi_data_0,
 		    &video_mcux_csi_config_0,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_VIDEO_MCUX_CSI_INIT_PRIORITY,
 		    &video_mcux_csi_driver_api);
 #endif


### PR DESCRIPTION
Set a dedicated priority for the video_mcux_csi instead of using the default kernel device init priority. This allows initializing the device in a sequence that matches the devicetree hirearchy compared to mt9m114.

Fixes the error:

ERROR: /soc/csi@402bc000 POST_KERNEL 50 < /soc/i2c@403f0000/mt9m114@48 POST_KERNEL 60

found using:

$ west build -p -b mimxrt1064_evk samples/subsys/video/capture \
		-DCONFIG_CHECK_INIT_PRIORITIES=y