### PR TITLE
drivers: mipi: delay initialization after display drivers

### DIFF
--- a/drivers/mipi_dsi/Kconfig
+++ b/drivers/mipi_dsi/Kconfig
@@ -17,7 +17,7 @@ source "subsys/logging/Kconfig.template.log_config"
 
 config MIPI_DSI_INIT_PRIORITY
 	int "Initialization priority"
-	default 40
+	default 86
 	help
 	  MIPI-DSI Host Controllers initialization priority.
 


### PR DESCRIPTION
Currently MIPI devices are set to initialize before display drivers, which is incoherent with how the mcux mipi-dsi device is declared in the device tree.

This is detected with build time priority checking:

west build -p -b mimxrt595_evk_cm33 samples/drivers/display \
	     -DCONFIG_CHECK_INIT_PRIORITIES=y

ERROR: /soc/peripheral@50000000/mipi_dsi@31000 POST_KERNEL 40 < \
		/soc/peripheral@50000000/lcdif@210000 POST_KERNEL 85

Note that this also changes the priority of dsi_stm32, though that should be ok since does not appear to have other dependencies in devicetree.