### PR TITLE
shields: lmp90100: drop GPIO and EEPROM priority override

### DIFF
--- a/boards/shields/lmp90100_evb/Kconfig.defconfig
+++ b/boards/shields/lmp90100_evb/Kconfig.defconfig
@@ -13,18 +13,4 @@ config ADC_INIT_PRIORITY
 
 endif # ADC
 
-if GPIO
-
-config GPIO_INIT_PRIORITY
-	default 99
-
-endif # GPIO
-
-if EEPROM
-
-config EEPROM_INIT_PRIORITY
-	default 75
-
-endif # EEPROM
-
 endif # SHIELD_LMP90100_EVB


### PR DESCRIPTION
Drop the GPIO and EEPROM priority override. The current settings have been introduced as part of a major priority refactoring but I don't think they are needed anymore, and they currently result in this error:

ERROR: /soc/spi@4002d000 POST_KERNEL 70 <
	/soc/gpio@400ff100 POST_KERNEL 99

found with:

west build -p -b frdm_k64f samples/shields/lmp90100_evb/rtd \
	     -DCONFIG_CHECK_INIT_PRIORITIES=y

Dropping the two overrides should work fine, leaving the ADC override as that seems like is still needed.