### PR TITLE
boards: shields: add rk055hdmipi4ma0 shield definition

### DIFF
--- a/boards/arm/mimxrt1170_evk/doc/index.rst
+++ b/boards/arm/mimxrt1170_evk/doc/index.rst
@@ -131,8 +131,9 @@ RT1170 EVKB (`mimxrt1170_evkb_cm7/cm4`)
 | HWINFO    | on-chip    | Unique device serial number         | Supported (M7)  | Supported (M7)  |
 +-----------+------------+-------------------------------------+-----------------+-----------------+
 | DISPLAY   | on-chip    | eLCDIF; MIPI-DSI. Tested with       | Supported (M7)  | Supported (M7)  |
-|           |            | :ref:`rk055hdmipi4m` and            |                 |                 |
-|           |            | :ref:`g1120b0mipi` shields          |                 |                 |
+|           |            | :ref:`rk055hdmipi4m`,               |                 |                 |
+|           |            | :ref:`rk055hdmipi4ma0`,             |                 |                 |
+|           |            | and :ref:`g1120b0mipi` shields      |                 |                 |
 +-----------+------------+-------------------------------------+-----------------+-----------------+
 | ACMP      | on-chip    | analog comparator                   | Supported       | No support      |
 +-----------+------------+-------------------------------------+-----------------+-----------------+

--- a/boards/arm/mimxrt595_evk/doc/index.rst
+++ b/boards/arm/mimxrt595_evk/doc/index.rst
@@ -109,7 +109,8 @@ already supported, which can also be re-used on this mimxrt595_evk board:
 | I2S       | on-chip    | i2s                                 |
 +-----------+------------+-------------------------------------+
 | DISPLAY   | on-chip    | LCDIF; MIPI-DSI. Tested with        |
-|           |            | :ref:`rk055hdmipi4m` and            |
+|           |            | :ref:`rk055hdmipi4m`,               |
+|           |            | :ref:`rk055hdmipi4ma0`, and         |
 |           |            | :ref:`g1120b0mipi` display shields  |
 +-----------+------------+-------------------------------------+
 

--- a/boards/shields/rk055hdmipi4ma0/Kconfig.defconfig
+++ b/boards/shields/rk055hdmipi4ma0/Kconfig.defconfig
@@ -1,0 +1,56 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_RK055HDMIPI4MA0
+
+if DISPLAY
+
+# Enable MIPI DSI, as this display controller requires it.
+
+config MIPI_DSI
+	default y
+
+endif # DISPLAY
+
+if LVGL
+
+# Configure LVGL to use touchscreen with KSCAN API
+
+config KSCAN
+	default y
+
+config INPUT
+	default y if KSCAN
+
+config INPUT_GT911_INTERRUPT
+	default y
+
+config LV_Z_POINTER_KSCAN
+	default y
+
+# LVGL should allocate buffers equal to size of display
+config LV_Z_VDB_SIZE
+	default 100
+
+# Enable double buffering
+config LV_Z_DOUBLE_VDB
+	default y
+
+# Force full refresh. This prevents memory copy associated with partial
+# display refreshes, which is not necessary for the eLCDIF driver
+config LV_Z_FULL_REFRESH
+	default y
+
+config LV_Z_BITS_PER_PIXEL
+	default 16
+
+config LV_DPI_DEF
+	default 128
+
+choice LV_COLOR_DEPTH
+	default LV_COLOR_DEPTH_16
+endchoice
+
+endif # LVGL
+
+endif # SHIELD_RK055HDMIPI4MA0

--- a/boards/shields/rk055hdmipi4ma0/Kconfig.shield
+++ b/boards/shields/rk055hdmipi4ma0/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_RK055HDMIPI4MA0
+	def_bool $(shields_list_contains,rk055hdmipi4ma0)

--- a/boards/shields/rk055hdmipi4ma0/boards/mimxrt595_evk_cm33.conf
+++ b/boards/shields/rk055hdmipi4ma0/boards/mimxrt595_evk_cm33.conf
@@ -1,0 +1,14 @@
+#
+# Copyright 2023, NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Use external framebuffer memory
+CONFIG_MCUX_DCNANO_LCDIF_EXTERNAL_FB_MEM=y
+CONFIG_LV_Z_VBD_CUSTOM_SECTION=y
+# Use FlexSPI2 for framebuffer (pSRAM is present on this bus)
+CONFIG_MCUX_DCNANO_LCDIF_EXTERNAL_FB_ADDR=0x38400000
+# M33 core and LCDIF both access FlexSPI2 through the same cache,
+# so coherency does not need to be managed.
+CONFIG_MCUX_DCNANO_LCDIF_MAINTAIN_CACHE=n

--- a/boards/shields/rk055hdmipi4ma0/boards/mimxrt595_evk_cm33.overlay
+++ b/boards/shields/rk055hdmipi4ma0/boards/mimxrt595_evk_cm33.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Configure FlexSPI2 to use 1KB of AHB RX buffer for GPU/Display master.
+ * This will improve performance when using external pSRAM.
+ */
+&flexspi2 {
+	rx-buffer-config = <1 7 11 1024>;
+};
+
+/* GT911 IRQ GPIO is active low on this board */
+&touch_controller_rk055hdmipi4ma0 {
+	irq-gpios = <&nxp_mipi_connector 29 GPIO_ACTIVE_LOW>;
+};

--- a/boards/shields/rk055hdmipi4ma0/doc/index.rst
+++ b/boards/shields/rk055hdmipi4ma0/doc/index.rst
@@ -1,0 +1,68 @@
+.. _rk055hdmipi4ma0:
+
+RK055HDMIPI4MA0 MIPI Display
+############################
+
+Overview
+********
+
+The Rocktech RK055HDMIPI4MA0 MIPI Display is a 5.5 inch TFT 720x1280 pixels
+panel with LED backlighting, full viewing angle, MIPI interface and
+capacitive touch panel from Rocktech.
+
+More information about the shield can be found
+at the `RK055HDMIPI4MA0 product page`_.
+
+This display uses a 40 pin FPC interface, which is available on many
+NXP EVKs.
+
+Pins Assignment of the Rocktech RK055HDMIPI4MA0 MIPI Display
+============================================================
+
++-----------------------+------------------------+
+| FPC Connector Pin     | Function               |
++=======================+========================+
+| 1                     | LED backlight cathode  |
++-----------------------+------------------------+
+| 21                    | Controller reset       |
++-----------------------+------------------------+
+| 22                    | Controller LPTE        |
++-----------------------+------------------------+
+| 26                    | Touch ctrl I2C SDA     |
++-----------------------+------------------------+
+| 27                    | Touch ctrl I2C SCL     |
++-----------------------+------------------------+
+| 28                    | Touch ctrl reset       |
++-----------------------+------------------------+
+| 29                    | Touch ctrl interrupt   |
++-----------------------+------------------------+
+| 32                    | LCD power enable       |
++-----------------------+------------------------+
+| 34                    | Backlight power enable |
++-----------------------+------------------------+
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration
+for the 40 pin FPC interface
+
+Programming
+***********
+
+Set ``-DSHIELD=rk055hdmipi4ma0`` when you invoke ``west build``. For
+example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/display
+   :board: mixmrt1170_evk_cm7
+   :shield: rk055hdmipi4ma0
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _RK055HDMIPI4MA0 product page:
+   https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/5-5-lcd-panel:RK055HDMIPI4MA0

--- a/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
+++ b/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/display/panel.h>
+
+/{
+	aliases {
+		kscan0 = &kscan_input_gt911;
+	};
+
+	chosen {
+		zephyr,display = &lcdif;
+		zephyr,keyboard-scan = &kscan_input_gt911;
+	};
+
+	en_mipi_display_rk055hdmipi4ma0: enable-mipi-display-rk055hdmipi4ma0 {
+		compatible = "regulator-fixed";
+		regulator-name = "en_mipi_display";
+		enable-gpios = <&nxp_mipi_connector 32 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
+	};
+};
+
+&nxp_mipi_i2c {
+	status = "okay";
+	touch_controller_rk055hdmipi4ma0: gt911-rk055hdmipi4ma0@5d {
+		compatible = "goodix,gt911";
+		reg = <0x5d>;
+		irq-gpios = <&nxp_mipi_connector 29 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&nxp_mipi_connector 28 GPIO_ACTIVE_HIGH>;
+		kscan_input_gt911: kscan-input {
+			compatible = "zephyr,kscan-input";
+		};
+	};
+};
+
+&zephyr_lcdif {
+	status = "okay";
+	width = <720>;
+	height = <1280>;
+	display-timings {
+		compatible = "zephyr,panel-timing";
+		hsync-len = <6>;
+		hfront-porch = <12>;
+		hback-porch = <24>;
+		vsync-len = <2>;
+		vfront-porch = <16>;
+		vback-porch = <14>;
+		hsync-active = <0>;
+		vsync-active = <0>;
+		de-active = <1>;
+		pixelclk-active = <1>;
+		/*
+		 * Pixel clock is given by the following formula:
+		 * (height + vsync-len + vfront-porch + vback-porch) *
+		 * (width + hsync-len + hfront-porch + hback-porch) * frame rate
+		 */
+		clock-frequency = <62346240>;
+	};
+	pixel-format = <PANEL_PIXEL_FORMAT_BGR_565>;
+	data-bus-width = "24-bit";
+	backlight-gpios = <&nxp_mipi_connector 0 GPIO_ACTIVE_HIGH>;
+};
+
+&zephyr_mipi_dsi {
+	status = "okay";
+	nxp,lcdif = <&lcdif>;
+	dpi-color-coding = "24-bit";
+	dpi-pixel-packet = "24-bit";
+	dpi-video-mode = "burst";
+	dpi-bllp-mode = "low-power";
+	autoinsert-eotp;
+	/*
+	 * PHY clock is given by the following formula:
+	 * (pixel clock * bits per pixel) / MIPI data lanes
+	 */
+	phy-clock = <748154880>;
+	hx8394-rk055hdmipi4ma0@0 {
+		status = "okay";
+		compatible = "himax,hx8394";
+		reg = <0x0>;
+		reset-gpios = <&nxp_mipi_connector 21 GPIO_ACTIVE_HIGH>;
+		data-lanes = <2>;
+		width = <720>;
+		height = <1280>;
+		pixel-format = <MIPI_DSI_PIXFMT_RGB565>;
+	};
+};

--- a/drivers/display/CMakeLists.txt
+++ b/drivers/display/CMakeLists.txt
@@ -22,6 +22,7 @@ zephyr_library_sources_ifdef(CONFIG_ST7735R		display_st7735r.c)
 zephyr_library_sources_ifdef(CONFIG_STM32_LTDC		display_stm32_ltdc.c)
 zephyr_library_sources_ifdef(CONFIG_RM68200		display_rm68200.c)
 zephyr_library_sources_ifdef(CONFIG_RM67162		display_rm67162.c)
+zephyr_library_sources_ifdef(CONFIG_HX8394		display_hx8394.c)
 
 zephyr_library_sources_ifdef(CONFIG_MICROBIT_DISPLAY
 	mb_display.c

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -39,5 +39,6 @@ source "drivers/display/Kconfig.max7219"
 source "drivers/display/Kconfig.intel_multibootfb"
 source "drivers/display/Kconfig.mcux_dcnano_lcdif"
 source "drivers/display/Kconfig.otm8009a"
+source "drivers/display/Kconfig.hx8394"
 
 endif # DISPLAY

--- a/drivers/display/Kconfig.hx8394
+++ b/drivers/display/Kconfig.hx8394
@@ -1,0 +1,10 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config HX8394
+	bool "HX8394 display driver"
+	default y
+	depends on MIPI_DSI
+	depends on DT_HAS_HIMAX_HX8394_ENABLED
+	help
+	  Enable driver for HX8394 display driver.

--- a/drivers/display/display_hx8394.c
+++ b/drivers/display/display_hx8394.c
@@ -1,0 +1,801 @@
+/*
+ * Copyright 2023, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT himax_hx8394
+
+#include <zephyr/drivers/display.h>
+#include <zephyr/drivers/mipi_dsi.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(hx8394, CONFIG_DISPLAY_LOG_LEVEL);
+
+struct hx8394_config {
+	const struct device *mipi_dsi;
+	const struct gpio_dt_spec reset_gpio;
+	const struct gpio_dt_spec bl_gpio;
+	uint8_t num_of_lanes;
+	uint8_t pixel_format;
+	uint16_t panel_width;
+	uint16_t panel_height;
+	uint8_t channel;
+};
+
+/* MIPI DCS commands specific to this display driver */
+#define HX8394_SETMIPI 0xBA
+#define HX8394_MIPI_LPTX_BTA_READ BIT(6)
+#define HX8394_MIPI_LP_CD_DIS BIT(5)
+#define HX8394_MIPI_TA_6TL 0x3
+#define HX8394_MIPI_DPHYCMD_LPRX_8NS 0x40
+#define HX8394_MIPI_DPHYCMD_LPRX_66mV 0x10
+#define HX8394_MIPI_DPHYCMD_LPTX_SRLIM 0x8
+#define HX8394_MIPI_DPHYCMD_LDO_1_55V 0x60
+#define HX8394_MIPI_DPHYCMD_HSRX_7X 0x8
+#define HX8394_MIPI_DPHYCMD_HSRX_100OHM 0x2
+#define HX8394_MIPI_DPHYCMD_LPCD_1X 0x1
+
+#define HX8394_SET_ADDRESS 0x36
+#define HX8394_FLIP_HORIZONTAL BIT(1)
+#define HX8394_FLIP_VERTICAL BIT(0)
+
+#define HX8394_SETPOWER 0xB1
+#define HX8394_POWER_AP_1_0UA 0x8
+#define HX8394_POWER_HX5186 0x40
+#define HX8394_POWER_VRHP_4_8V 0x12
+#define HX8394_POWER_VRHN_4_8V 0x12
+#define HX8394_POWER_VPPS_8_25V 0x60
+#define HX8394_POWER_XDK_X2 0x1
+#define HX8394_POWER_VSP_FBOFF 0x8
+#define HX8394_POWER_FS0_DIV_8 0x2
+#define HX8394_POWER_CLK_OPT_VGH_HSYNC_RST 0x10
+#define HX8394_POWER_CLK_OPT_VGL_HSYNC_RST 0x20
+#define HX8394_POWER_FS2_DIV_192 0x4
+#define HX8394_POWER_FS1_DIV_224 0x50
+#define HX8394_POWER_BTP_5_55V 0x11
+#define HX8394_POWER_VGH_RATIO_2VSPVSN 0x60
+#define HX8394_POWER_BTN_5_55V 0x11
+#define HX8394_POWER_VGL_RATIO_2VSPVSN 0x60
+#define HX8394_POWER_VGHS_16V 0x57
+#define HX8394_POWER_VGLS_12_4V 0x47
+
+#define HX8394_SETDISP 0xB2
+#define HX8394_DISP_COL_INV 0x0
+#define HX8394_DISP_MESSI_ENB 0x80
+#define HX8394_DISP_NL_1280 0x64
+#define HX8394_DISP_BP_14 0xC
+#define HX8394_DISP_FP_15 0xD
+#define HX8394_DISP_RTN_144 0x2F
+
+#define HX8394_SETCYC 0xB4
+
+#define HX8394_SETGIP0 0xD3
+#define HX8394_GIP0_EQ_OPT_BOTH 0x0
+#define HX8394_GIP0_EQ_HSYNC_NORMAL 0x0
+#define HX8394_GIP0_EQ_VSEL_VSSA 0x0
+#define HX8394_SHP_START_4 0x40
+#define HX8394_SCP_WIDTH_7X_HSYNC 0x7
+#define HX8394_CHR0_12X_HSYNC 0xA
+#define HX8394_CHR1_18X_HSYNC 0x10
+
+#define HX8394_SETGIP1 0xD5
+
+#define HX8394_SETGIP2 0xD6
+
+#define HX8394_SETVCOM 0xB6
+#define HX8394_VCMC_F_1_76V 0x92
+#define HX8394_VCMC_B_1_76V 0x92
+
+#define HX8394_SETGAMMA 0xE0
+
+#define HX8394_SETPANEL 0xCC
+#define HX8394_COLOR_BGR BIT(0)
+#define HX8394_REV_PANEL BIT(1)
+
+#define HX8394_SETBANK 0xBD
+
+#define HX8394_SET_TEAR 0x35
+#define HX8394_TEAR_VBLANK 0x0
+
+#define HX8394_SETEXTC 0xB9
+#define HX8394_EXTC1_MAGIC 0xFF
+#define HX8394_EXTC2_MAGIC 0x83
+#define HX8394_EXTC3_MAGIC 0x94
+
+
+const uint8_t enable_extension[] = {
+	HX8394_SETEXTC,
+	HX8394_EXTC1_MAGIC,
+	HX8394_EXTC2_MAGIC,
+	HX8394_EXTC3_MAGIC,
+};
+
+const uint8_t address_config[] = {
+	HX8394_SET_ADDRESS,
+	HX8394_FLIP_HORIZONTAL
+};
+
+const uint8_t power_config[] = {
+	HX8394_SETPOWER,
+	(HX8394_POWER_HX5186 | HX8394_POWER_AP_1_0UA),
+	HX8394_POWER_VRHP_4_8V,
+	(HX8394_POWER_VPPS_8_25V | HX8394_POWER_VRHN_4_8V),
+	(HX8394_POWER_VSP_FBOFF | HX8394_POWER_XDK_X2),
+	(HX8394_POWER_CLK_OPT_VGL_HSYNC_RST |
+		    HX8394_POWER_CLK_OPT_VGH_HSYNC_RST |
+		    HX8394_POWER_FS0_DIV_8),
+	(HX8394_POWER_FS1_DIV_224 | HX8394_POWER_FS2_DIV_192),
+	(HX8394_POWER_VGH_RATIO_2VSPVSN | HX8394_POWER_BTP_5_55V),
+	(HX8394_POWER_VGL_RATIO_2VSPVSN | HX8394_POWER_BTN_5_55V),
+	HX8394_POWER_VGHS_16V,
+	HX8394_POWER_VGLS_12_4V
+};
+
+const uint8_t line_config[] = {
+	HX8394_SETDISP,
+	HX8394_DISP_COL_INV,
+	HX8394_DISP_MESSI_ENB,
+	HX8394_DISP_NL_1280,
+	HX8394_DISP_BP_14,
+	HX8394_DISP_FP_15,
+	HX8394_DISP_RTN_144
+};
+
+const uint8_t cycle_config[] = {
+	HX8394_SETCYC,
+	0x73, /* SPON delay */
+	0x74, /* SPOFF delay */
+	0x73, /* CON delay */
+	0x74, /* COFF delay */
+	0x73, /* CON1 delay */
+	0x74, /* COFF1 delay */
+	0x1, /* EQON time */
+	0xC, /* SON time */
+	0x86, /* SOFF time */
+	0x75, /* SAP1_P, SAP2 (1st and second stage op amp bias) */
+	0x00, /* DX2 off, EQ off, EQ_MI off */
+	0x3F, /* DX2 off period setting */
+	0x73, /* SPON_MPU delay */
+	0x74, /* SPOFF_MPU delay */
+	0x73, /* CON_MPU delay */
+	0x74, /* COFF_MPU delay */
+	0x73, /* CON1_MPU delay */
+	0x74, /* COFF1_MPU delay */
+	0x1, /* EQON_MPU time */
+	0xC, /* SON_MPU time */
+	0x86 /* SOFF_MPU time */
+};
+
+const uint8_t gip0_config[] = {
+	HX8394_SETGIP0,
+	(HX8394_GIP0_EQ_OPT_BOTH | HX8394_GIP0_EQ_HSYNC_NORMAL),
+	HX8394_GIP0_EQ_VSEL_VSSA,
+	0x7, /* EQ_DELAY_ON1 (in cycles of TCON CLK */
+	0x7, /* EQ_DELAY_OFF1 (in cycles of TCON CLK */
+	0x40, /* GPWR signal frequency (64x per frame) */
+	0x7, /* GPWR signal non overlap timing (in cycles of TCON */
+	0xC, /* GIP dummy clock for first CKV */
+	0x00, /* GIP dummy clock for second CKV */
+	/* Group delays. Sets start/end signal delay from VYSNC
+	 * falling edge in multiples of HSYNC
+	 */
+	0x8, /* SHR0_2 = 8, SHR0_3 = 0 */
+	0x10, /* SHR0_1 = 1, SHR0[11:8] = 0x0 */
+	0x8, /* SHR0 = 0x8 */
+	0x0, /* SHR0_GS[11:8]. Unset. */
+	0x8, /* SHR0_GS = 0x8 */
+	0x54, /* SHR1_3 = 0x5, SHR1_2 = 0x4 */
+	0x15, /* SHR1_1 = 0x1, SHR1[11:8] = 0x5 */
+	0xA, /* SHR1[7:0] = 0xA (SHR1 = 0x50A) */
+	0x5, /* SHR1_GS[11:8] = 0x5 */
+	0xA, /* SHR1_GS[7:0] = 0xA (SHR1_GS = 0x50A) */
+	0x2, /* SHR2_3 = 0x0, SHR2_2 = 0x2 */
+	0x15, /* SHR2_1 = 0x1, SHR2[11:8] = 0x5 */
+	0x6, /* SHR2[7:0] = 0x6 (SHR2 = 0x506) */
+	0x5, /* SHR2_GS[11:8] = 0x5 */
+	0x6, /* SHR2_GS[7:0 = 0x6 (SHR2_GS = 0x506) */
+	(HX8394_SHP_START_4 | HX8394_SCP_WIDTH_7X_HSYNC),
+	0x44, /* SHP2 = 0x4, SHP1 = 0x4 */
+	HX8394_CHR0_12X_HSYNC,
+	HX8394_CHR0_12X_HSYNC,
+	0x4B, /* CHP0 = 4x hsync, CCP0 = 0xB */
+	HX8394_CHR1_18X_HSYNC,
+	0x7, /* CHR1_GS = 9x hsync */
+	0x7, /* CHP1 = 1x hsync, CCP1 = 0x7 */
+	/* These parameters are not documented in datasheet */
+	0xC,
+	0x40
+};
+
+const uint8_t gip1_config[] = {
+	HX8394_SETGIP1,
+	/* Select output clock sources
+	 * See COSn_L/COSn_R values in datasheet
+	 */
+	0x1C, /* COS1_L */
+	0x1C, /* COS1_R */
+	0x1D, /* COS2_L */
+	0x1D, /* COS2_R */
+	0x00, /* COS3_L */
+	0x01, /* COS3_R */
+	0x02, /* COS4_L */
+	0x03, /* COS4_R */
+	0x04, /* COS5_L */
+	0x05, /* COS5_R */
+	0x06, /* COS6_L */
+	0x07, /* COS6_R */
+	0x08, /* COS7_L */
+	0x09, /* COS7_R */
+	0x0A, /* COS8_L */
+	0x0B, /* COS8_R */
+	0x24, /* COS9_L */
+	0x25, /* COS9_R */
+	0x18, /* COS10_L */
+	0x18, /* COS10_R */
+	0x26, /* COS11_L */
+	0x27, /* COS11_R */
+	0x18, /* COS12_L */
+	0x18, /* COS12_R */
+	0x18, /* COS13_L */
+	0x18, /* COS13_R */
+	0x18, /* COS14_L */
+	0x18, /* COS14_R */
+	0x18, /* COS15_L */
+	0x18, /* COS15_R */
+	0x18, /* COS16_L */
+	0x18, /* COS16_R */
+	0x18, /* COS17_L */
+	0x18, /* COS17_R */
+	0x18, /* COS18_L */
+	0x18, /* COS18_R */
+	0x18, /* COS19_L */
+	0x18, /* COS19_R */
+	0x20, /* COS20_L */
+	0x21, /* COS20_R */
+	0x18, /* COS21_L */
+	0x18, /* COS21_R */
+	0x18, /* COS22_L */
+	0x18 /* COS22_R */
+};
+
+const uint8_t gip2_config[] = {
+	HX8394_SETGIP2,
+	/* Select output clock sources for GS mode.
+	 * See COSn_L_GS/COSn_R_GS values in datasheet
+	 */
+	0x1C, /* COS1_L_GS */
+	0x1C, /* COS1_R_GS */
+	0x1D, /* COS2_L_GS */
+	0x1D, /* COS2_R_GS */
+	0x07, /* COS3_L_GS */
+	0x06, /* COS3_R_GS */
+	0x05, /* COS4_L_GS */
+	0x04, /* COS4_R_GS */
+	0x03, /* COS5_L_GS */
+	0x02, /* COS5_R_GS */
+	0x01, /* COS6_L_GS */
+	0x00, /* COS6_R_GS */
+	0x0B, /* COS7_L_GS */
+	0x0A, /* COS7_R_GS */
+	0x09, /* COS8_L_GS */
+	0x08, /* COS8_R_GS */
+	0x21, /* COS9_L_GS */
+	0x20, /* COS9_R_GS */
+	0x18, /* COS10_L_GS */
+	0x18, /* COS10_R_GS */
+	0x27, /* COS11_L_GS */
+	0x26, /* COS11_R_GS */
+	0x18, /* COS12_L_GS */
+	0x18, /* COS12_R_GS */
+	0x18, /* COS13_L_GS */
+	0x18, /* COS13_R_GS */
+	0x18, /* COS14_L_GS */
+	0x18, /* COS14_R_GS */
+	0x18, /* COS15_L_GS */
+	0x18, /* COS15_R_GS */
+	0x18, /* COS16_L_GS */
+	0x18, /* COS16_R_GS */
+	0x18, /* COS17_L_GS */
+	0x18, /* COS17_R_GS */
+	0x18, /* COS18_L_GS */
+	0x18, /* COS18_R_GS */
+	0x18, /* COS19_L_GS */
+	0x18, /* COS19_R_GS */
+	0x25, /* COS20_L_GS */
+	0x24, /* COS20_R_GS */
+	0x18, /* COS21_L_GS */
+	0x18, /* COS21_R_GS */
+	0x18, /* COS22_L_GS */
+	0x18  /* COS22_R_GS */
+};
+
+const uint8_t vcom_config[] = {
+	HX8394_SETVCOM,
+	HX8394_VCMC_F_1_76V,
+	HX8394_VCMC_B_1_76V
+};
+
+const uint8_t gamma_config[] = {
+	HX8394_SETGAMMA,
+	0x00, /* VHP0 */
+	0x0A, /* VHP1 */
+	0x15, /* VHP2 */
+	0x1B, /* VHP3 */
+	0x1E, /* VHP4 */
+	0x21, /* VHP5 */
+	0x24, /* VHP6 */
+	0x22, /* VHP7 */
+	0x47, /* VMP0 */
+	0x56, /* VMP1 */
+	0x65, /* VMP2 */
+	0x66, /* VMP3 */
+	0x6E, /* VMP4 */
+	0x82, /* VMP5 */
+	0x88, /* VMP6 */
+	0x8B, /* VMP7 */
+	0x9A, /* VMP8 */
+	0x9D, /* VMP9 */
+	0x98, /* VMP10 */
+	0xA8, /* VMP11 */
+	0xB9, /* VMP12 */
+	0x5D, /* VLP0 */
+	0x5C, /* VLP1 */
+	0x61, /* VLP2 */
+	0x66, /* VLP3 */
+	0x6A, /* VLP4 */
+	0x6F, /* VLP5 */
+	0x7F, /* VLP6 */
+	0x7F, /* VLP7 */
+	0x00, /* VHN0 */
+	0x0A, /* VHN1 */
+	0x15, /* VHN2 */
+	0x1B, /* VHN3 */
+	0x1E, /* VHN4 */
+	0x21, /* VHN5 */
+	0x24, /* VHN6 */
+	0x22, /* VHN7 */
+	0x47, /* VMN0 */
+	0x56, /* VMN1 */
+	0x65, /* VMN2 */
+	0x65, /* VMN3 */
+	0x6E, /* VMN4 */
+	0x81, /* VMN5 */
+	0x87, /* VMN6 */
+	0x8B, /* VMN7 */
+	0x98, /* VMN8 */
+	0x9D, /* VMN9 */
+	0x99, /* VMN10 */
+	0xA8, /* VMN11 */
+	0xBA, /* VMN12 */
+	0x5D, /* VLN0 */
+	0x5D, /* VLN1 */
+	0x62, /* VLN2 */
+	0x67, /* VLN3 */
+	0x6B, /* VLN4 */
+	0x72, /* VLN5 */
+	0x7F, /* VLN6 */
+	0x7F  /* VLN7 */
+};
+
+const uint8_t hx8394_cmd1[] = {0xC0U, 0x1FU, 0x31U};
+
+const uint8_t panel_config[] = {
+	HX8394_SETPANEL,
+	(HX8394_COLOR_BGR | HX8394_REV_PANEL)
+};
+
+const uint8_t hx8394_cmd2[] = {0xD4, 0x2};
+
+const uint8_t hx8394_bank2[] = {
+	0xD8U, 0xFFU, 0xFFU, 0xFFU, 0xFFU, 0xFFU,
+	0xFFU, 0xFFU, 0xFFU, 0xFFU, 0xFFU, 0xFFU,
+	0xFFU
+};
+
+const uint8_t hx8394_bank1[] = {0xB1U, 0x00U};
+
+const uint8_t hx8394_bank0[] = {
+	0xBFU, 0x40U, 0x81U, 0x50U,
+	0x00U, 0x1AU, 0xFCU, 0x01
+};
+
+const uint8_t hx8394_cmd3[] = {0xC6U, 0xEDU};
+
+const uint8_t tear_config[] = {HX8394_SET_TEAR, HX8394_TEAR_VBLANK | 0x3};
+
+static int hx8394_write(const struct device *dev, const uint16_t x,
+			 const uint16_t y,
+			 const struct display_buffer_descriptor *desc,
+			 const void *buf)
+{
+	LOG_WRN("Write not supported, use LCD controller display driver");
+	return 0;
+}
+
+static int hx8394_read(const struct device *dev, const uint16_t x,
+			const uint16_t y,
+			const struct display_buffer_descriptor *desc,
+			void *buf)
+{
+	LOG_WRN("Read not implemented");
+	return -ENOTSUP;
+}
+
+static void *hx8394_get_framebuffer(const struct device *dev)
+{
+	LOG_WRN("Direct framebuffer access not implemented");
+	return NULL;
+}
+
+static int hx8394_blanking_off(const struct device *dev)
+{
+	const struct hx8394_config *config = dev->config;
+
+	if (config->bl_gpio.port != NULL) {
+		return gpio_pin_set_dt(&config->bl_gpio, 1);
+	} else {
+		return -ENOTSUP;
+	}
+}
+
+static int hx8394_blanking_on(const struct device *dev)
+{
+	const struct hx8394_config *config = dev->config;
+
+	if (config->bl_gpio.port != NULL) {
+		return gpio_pin_set_dt(&config->bl_gpio, 0);
+	} else {
+		return -ENOTSUP;
+	}
+}
+
+static int hx8394_set_brightness(const struct device *dev,
+				  const uint8_t brightness)
+{
+	LOG_WRN("Set brightness not implemented");
+	return -ENOTSUP;
+}
+
+static int hx8394_set_contrast(const struct device *dev,
+				const uint8_t contrast)
+{
+	LOG_WRN("Set contrast not implemented");
+	return -ENOTSUP;
+}
+
+static int hx8394_set_pixel_format(const struct device *dev,
+				    const enum display_pixel_format pixel_format)
+{
+	const struct hx8394_config *config = dev->config;
+
+	if (pixel_format == config->pixel_format) {
+		return 0;
+	}
+	LOG_WRN("Pixel format change not implemented");
+	return -ENOTSUP;
+}
+
+static int hx8394_set_orientation(const struct device *dev,
+				   const enum display_orientation orientation)
+{
+	const struct hx8394_config *config = dev->config;
+	uint8_t param[2] = {0};
+
+	/* Note- this simply flips the scan direction of the display
+	 * driver. Can be useful if your application needs the display
+	 * flipped on the X or Y axis
+	 */
+	param[0] = HX8394_SET_ADDRESS;
+	switch (orientation) {
+	case DISPLAY_ORIENTATION_NORMAL:
+		/* Default orientation for this display flips image on x axis */
+		param[1] = HX8394_FLIP_HORIZONTAL;
+		break;
+	case DISPLAY_ORIENTATION_ROTATED_90:
+		param[1] = HX8394_FLIP_VERTICAL;
+		break;
+	case DISPLAY_ORIENTATION_ROTATED_180:
+		param[1] = 0;
+		break;
+	case DISPLAY_ORIENTATION_ROTATED_270:
+		param[1] = HX8394_FLIP_HORIZONTAL | HX8394_FLIP_VERTICAL;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+	return mipi_dsi_generic_write(config->mipi_dsi, config->channel, param, 2);
+}
+
+static void hx8394_get_capabilities(const struct device *dev,
+				     struct display_capabilities *capabilities)
+{
+	const struct hx8394_config *config = dev->config;
+
+	memset(capabilities, 0, sizeof(struct display_capabilities));
+	capabilities->x_resolution = config->panel_width;
+	capabilities->y_resolution = config->panel_height;
+	capabilities->supported_pixel_formats = config->pixel_format;
+	capabilities->current_pixel_format = config->pixel_format;
+	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+}
+
+static const struct display_driver_api hx8394_api = {
+	.blanking_on = hx8394_blanking_on,
+	.blanking_off = hx8394_blanking_off,
+	.write = hx8394_write,
+	.read = hx8394_read,
+	.get_framebuffer = hx8394_get_framebuffer,
+	.set_brightness = hx8394_set_brightness,
+	.set_contrast = hx8394_set_contrast,
+	.get_capabilities = hx8394_get_capabilities,
+	.set_pixel_format = hx8394_set_pixel_format,
+	.set_orientation = hx8394_set_orientation,
+};
+
+static int hx8394_init(const struct device *dev)
+{
+	const struct hx8394_config *config = dev->config;
+	int ret;
+	struct mipi_dsi_device mdev;
+	uint8_t param[2];
+	uint8_t setmipi[7] = {
+		HX8394_SETMIPI,
+		(HX8394_MIPI_LPTX_BTA_READ | HX8394_MIPI_LP_CD_DIS),
+		HX8394_MIPI_TA_6TL,
+		(HX8394_MIPI_DPHYCMD_LPRX_8NS |
+		 HX8394_MIPI_DPHYCMD_LPRX_66mV |
+		 HX8394_MIPI_DPHYCMD_LPTX_SRLIM),
+		(HX8394_MIPI_DPHYCMD_LDO_1_55V |
+		HX8394_MIPI_DPHYCMD_HSRX_7X |
+		HX8394_MIPI_DPHYCMD_HSRX_100OHM |
+		HX8394_MIPI_DPHYCMD_LPCD_1X),
+		/* The remaining parameters here are not documented */
+		0xB2U, 0xC0U};
+
+	mdev.data_lanes = config->num_of_lanes;
+	mdev.pixfmt = config->pixel_format;
+	/* HX8394 runs in video mode */
+	mdev.mode_flags = MIPI_DSI_MODE_VIDEO;
+
+	ret = mipi_dsi_attach(config->mipi_dsi, config->channel, &mdev);
+	if (ret < 0) {
+		LOG_ERR("Could not attach to MIPI-DSI host");
+		return ret;
+	}
+
+	if (gpio_is_ready_dt(&config->reset_gpio)) {
+		/* Regulator API will have supplied power to the display
+		 * driver. Per datasheet, we must wait 1ms for the RESX
+		 * pin to be valid.
+		 */
+		k_sleep(K_MSEC(1));
+		/* Initialize reset GPIO */
+		ret = gpio_pin_configure_dt(&config->reset_gpio, GPIO_OUTPUT_INACTIVE);
+		if (ret < 0) {
+			return ret;
+		}
+		/* Pull reset GPIO low */
+		gpio_pin_set_dt(&config->reset_gpio, 0);
+		/* Datasheet says we must keep reset pin low at least 10us.
+		 * hold it low for 1ms to be safe.
+		 */
+		k_sleep(K_MSEC(1));
+		gpio_pin_set_dt(&config->reset_gpio, 1);
+		/* Per datasheet, we must delay at least 50ms before first
+		 * host command
+		 */
+		k_sleep(K_MSEC(50));
+	}
+	/* Enable extended commands */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			enable_extension, sizeof(enable_extension));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Set the number of lanes to DSISETUP0 parameter */
+	setmipi[1] |= (config->num_of_lanes - 1);
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+				setmipi, sizeof(setmipi));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Set scan direction */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			address_config, sizeof(address_config));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Set voltage and current targets */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			power_config, sizeof(power_config));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Setup display line count and front/back porch size */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			line_config, sizeof(line_config));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Setup display cycle counts (in counts of TCON CLK) */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			cycle_config, sizeof(cycle_config));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Set group delay values */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			gip0_config, sizeof(gip0_config));
+	if (ret < 0) {
+		return ret;
+	}
+
+
+	/* Set group clock selections */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			gip1_config, sizeof(gip1_config));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Set group clock selections for GS mode */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			gip2_config, sizeof(gip2_config));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Delay for a moment before setting VCOM. It is not clear
+	 * from the datasheet why this is required, but without this
+	 * delay the panel stops responding to additional commands
+	 */
+	k_msleep(1);
+	/* Set VCOM voltage config */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			vcom_config, sizeof(vcom_config));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Set manufacturer supplied gamma values */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			gamma_config, sizeof(gamma_config));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* This command is not documented in datasheet, but is included
+	 * in the display initialization done by MCUXpresso SDK
+	 */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			hx8394_cmd1, sizeof(hx8394_cmd1));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Set panel to BGR mode, and reverse colors */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			panel_config, sizeof(panel_config));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* This command is not documented in datasheet, but is included
+	 * in the display initialization done by MCUXpresso SDK
+	 */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			hx8394_cmd2, sizeof(hx8394_cmd2));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Write values to manufacturer register banks */
+	param[0] = HX8394_SETBANK;
+	param[1] = 0x2;
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			param, 2);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			hx8394_bank2, sizeof(hx8394_bank2));
+	if (ret < 0) {
+		return ret;
+	}
+	param[1] = 0x0;
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			param, 2);
+	if (ret < 0) {
+		return ret;
+	}
+	/* Select bank 1 */
+	param[1] = 0x1;
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			param, 2);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			hx8394_bank1, sizeof(hx8394_bank1));
+	if (ret < 0) {
+		return ret;
+	}
+	/* Select bank 0 */
+	param[1] = 0x0;
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			param, 2);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			hx8394_bank0, sizeof(hx8394_bank0));
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* This command is not documented in datasheet, but is included
+	 * in the display initialization done by MCUXpresso SDK
+	 */
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			hx8394_cmd3, sizeof(hx8394_cmd3));
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = mipi_dsi_generic_write(config->mipi_dsi, config->channel,
+			tear_config, sizeof(tear_config));
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = mipi_dsi_dcs_write(config->mipi_dsi, config->channel,
+				MIPI_DCS_EXIT_SLEEP_MODE, NULL, 0);
+	if (ret < 0) {
+		return ret;
+	}
+	/* We must delay 120ms after exiting sleep mode per datasheet */
+	k_sleep(K_MSEC(120));
+	ret = mipi_dsi_dcs_write(config->mipi_dsi, config->channel,
+				MIPI_DCS_SET_DISPLAY_ON, NULL, 0);
+
+	if (config->bl_gpio.port != NULL) {
+		ret = gpio_pin_configure_dt(&config->bl_gpio, GPIO_OUTPUT_ACTIVE);
+		if (ret < 0) {
+			LOG_ERR("Could not configure bl GPIO (%d)", ret);
+			return ret;
+		}
+	}
+
+	return ret;
+}
+
+#define HX8394_PANEL(id)							\
+	static const struct hx8394_config hx8394_config_##id = {		\
+		.mipi_dsi = DEVICE_DT_GET(DT_INST_BUS(id)),			\
+		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(id, reset_gpios, {0}),	\
+		.bl_gpio = GPIO_DT_SPEC_INST_GET_OR(id, bl_gpios, {0}),		\
+		.num_of_lanes = DT_INST_PROP_BY_IDX(id, data_lanes, 0),		\
+		.pixel_format = DT_INST_PROP(id, pixel_format),			\
+		.panel_width = DT_INST_PROP(id, width),				\
+		.panel_height = DT_INST_PROP(id, height),			\
+		.channel = DT_INST_REG_ADDR(id),				\
+	};									\
+	DEVICE_DT_INST_DEFINE(id,						\
+			    &hx8394_init,					\
+			    NULL,						\
+			    NULL,						\
+			    &hx8394_config_##id,				\
+			    POST_KERNEL,					\
+			    CONFIG_APPLICATION_INIT_PRIORITY,			\
+			    &hx8394_api);
+
+DT_INST_FOREACH_STATUS_OKAY(HX8394_PANEL)

--- a/drivers/mipi_dsi/dsi_mcux.c
+++ b/drivers/mipi_dsi/dsi_mcux.c
@@ -261,6 +261,9 @@ static ssize_t dsi_mcux_transfer(const struct device *dev, uint8_t channel,
 	case MIPI_DSI_GENERIC_SHORT_WRITE_2_PARAM:
 		dsi_xfer.txDataType = kDSI_TxDataGenShortWrTwoParam;
 		break;
+	case MIPI_DSI_GENERIC_LONG_WRITE:
+		dsi_xfer.txDataType = kDSI_TxDataGenLongWr;
+		break;
 	case MIPI_DSI_GENERIC_READ_REQUEST_0_PARAM:
 		__fallthrough;
 	case MIPI_DSI_GENERIC_READ_REQUEST_1_PARAM:

--- a/drivers/mipi_dsi/dsi_mcux_2l.c
+++ b/drivers/mipi_dsi/dsi_mcux_2l.c
@@ -191,6 +191,9 @@ static ssize_t dsi_mcux_transfer(const struct device *dev, uint8_t channel,
 	case MIPI_DSI_GENERIC_SHORT_WRITE_2_PARAM:
 		dsi_xfer.txDataType = kDSI_TxDataGenShortWrTwoParam;
 		break;
+	case MIPI_DSI_GENERIC_LONG_WRITE:
+		dsi_xfer.txDataType = kDSI_TxDataGenLongWr;
+		break;
 	case MIPI_DSI_GENERIC_READ_REQUEST_0_PARAM:
 		__fallthrough;
 	case MIPI_DSI_GENERIC_READ_REQUEST_1_PARAM:

--- a/dts/bindings/display/himax,hx8394.yaml
+++ b/dts/bindings/display/himax,hx8394.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright 2023 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+description: Himax HX8394 Panel
+
+compatible: "himax,hx8394"
+
+include: [mipi-dsi-device.yaml, display-controller.yaml]
+
+properties:
+  reset-gpios:
+    type: phandle-array
+    description: |
+      The RESX pin is asserted to disable the sensor causing a hard
+      reset.  The sensor receives this as an active-low signal.
+
+  bl-gpios:
+    type: phandle-array
+    description: |
+      The BLn pin is asserted to control the backlight of the panel.
+      The sensor receives this as an active-high signal.


### PR DESCRIPTION
Add rk055hdmipi4ma0 shield definition. This shield contains a HX8394 TFT LCD driver, as well as a GT911 touch IC.

This PR includes the following changes:
- touch IC driver for HX8394 IC
- updates to `dsi_mcux` and `dsi_mcux_2l` MIPI drivers to support MIPI_DSI_GENERIC_LONG_WRITE commands
- shield definition for the RK055HDMIPI4MA0


~Note- this PR depends on #55493*, and contains commits from it that will be dropped when that PR merges~

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>