### PR TITLE
drivers: input: gt911: enable fallback to alternate address

### DIFF
--- a/boards/shields/rk055hdmipi4m/boards/mimxrt595_evk_cm33.overlay
+++ b/boards/shields/rk055hdmipi4m/boards/mimxrt595_evk_cm33.overlay
@@ -12,7 +12,8 @@
 	rx-buffer-config = <1 7 11 1024>;
 };
 
-/* GT911 IRQ GPIO is active low on this board */
+/* GT911 IRQ GPIO is active low on this board, and needs probing mode */
 &touch_controller {
 	irq-gpios = <&nxp_mipi_connector 29 GPIO_ACTIVE_LOW>;
+	alt-addr = <0x14>;
 };

--- a/dts/bindings/input/goodix,gt911.yaml
+++ b/dts/bindings/input/goodix,gt911.yaml
@@ -12,3 +12,9 @@ properties:
     type: phandle-array
   reset-gpios:
     type: phandle-array
+  alt-addr:
+    type: int
+    description:
+      Alternate I2C address for this device. When provided, the driver will
+      use probing mode to determine the I2C address rather than setting the
+      INT pin low to force a specific address


### PR DESCRIPTION
GT911 IC uses the INT pin to select the correct I2C address during reset. However, some boards may not route this pin (or may only support receiving inputs on it). This results in the I2C address selected by the GT911 IC being arbitrary based on the state of the (floating) INT pin.

To resolve this, fall back to the other possible I2C address for the touch IC if the first I2C transaction fails. This way, boards with this issue can still properly interact with the touch IC.