### PR TITLE
scripts: snippets: add `DTS_EXTRA_CPPFLAGS` support

### DIFF
--- a/cmake/modules/configuration_files.cmake
+++ b/cmake/modules/configuration_files.cmake
@@ -13,6 +13,8 @@
 # - CONF_FILE:              List of Kconfig fragments
 # - EXTRA_CONF_FILE:        List of additional Kconfig fragments
 # - DTC_OVERLAY_FILE:       List of devicetree overlay files
+# - EXTRA_DTC_OVERLAY_FILE  List of additional devicetree overlay files
+# - DTS_EXTRA_CPPFLAGS      List of additional devicetree preprocessor defines
 # - APPLICATION_CONFIG_DIR: Root folder for application configuration
 #
 # If any of the above variables are already set when this CMake module is
@@ -118,3 +120,4 @@ zephyr_boilerplate_watch(DTC_OVERLAY_FILE)
 
 zephyr_get(EXTRA_CONF_FILE SYSBUILD LOCAL VAR EXTRA_CONF_FILE OVERLAY_CONFIG MERGE REVERSE)
 zephyr_get(EXTRA_DTC_OVERLAY_FILE SYSBUILD LOCAL MERGE REVERSE)
+zephyr_get(DTS_EXTRA_CPPFLAGS SYSBUILD LOCAL MERGE REVERSE)

--- a/doc/build/snippets/writing.rst
+++ b/doc/build/snippets/writing.rst
@@ -156,6 +156,20 @@ This :file:`snippet.yml` adds :file:`foo.conf` to the build:
 The path to :file:`foo.conf` is relative to the directory containing
 :file:`snippet.yml`.
 
+``DTS_EXTRA_CPPFLAGS``
+**********************
+
+This :file:`snippet.yml` adds ``DTS_EXTRA_CPPFLAGS`` CMake Cache variables
+to the build:
+
+.. code-block:: yaml
+
+   name: foo
+   append:
+     DTS_EXTRA_CPPFLAGS: -DMY_DTS_CONFIGURE
+
+Adding these flags enables control over the content of a devicetree file.
+
 Board-specific settings
 ***********************
 

--- a/scripts/schemas/snippet-schema.yml
+++ b/scripts/schemas/snippet-schema.yml
@@ -13,6 +13,8 @@ schema;append-schema:
       type: str
     EXTRA_CONF_FILE:
       type: str
+    DTS_EXTRA_CPPFLAGS:
+      type: str
 
 type: map
 mapping:

--- a/scripts/snippets.py
+++ b/scripts/snippets.py
@@ -57,6 +57,8 @@ class Snippet:
                 if not path.is_file():
                     _err(f'snippet file {pathobj}: {variable}: file not found: {path}')
                 return f'"{path}"'
+            if variable in ('DTS_EXTRA_CPPFLAGS'):
+                return f'"{value}"'
             _err(f'unknown append variable: {variable}')
 
         for variable, value in snippet_data.get('append', {}).items():

--- a/tests/cmake/snippets/snippets/foo/foo.overlay
+++ b/tests/cmake/snippets/snippets/foo/foo.overlay
@@ -4,4 +4,8 @@
 
 	/* This node will be deleted by the `bar` snippet if applied. */
 	added-by-foo {};
+
+#ifdef CMAKE_DTS_CONFIGURE
+	cmake-dts-configure {};
+#endif /* CMAKE_DTS_CONFIGURE */
 };

--- a/tests/cmake/snippets/snippets/foo/snippet.yml
+++ b/tests/cmake/snippets/snippets/foo/snippet.yml
@@ -2,3 +2,4 @@ name: foo
 append:
   EXTRA_CONF_FILE: foo.conf
   EXTRA_DTC_OVERLAY_FILE: foo.overlay
+  DTS_EXTRA_CPPFLAGS: -DCMAKE_DTS_CONFIGURE

--- a/tests/cmake/snippets/src/main.c
+++ b/tests/cmake/snippets/src/main.c
@@ -128,3 +128,14 @@ ZTEST(snippet_tests, test_dtc_overlay)
 		zassert(false, "Invalid test type");
 	}
 }
+
+ZTEST(snippet_tests, test_cmake_include)
+{
+	if (IS_ENABLED(CONFIG_TEST_TYPE_FOO) ||
+	    IS_ENABLED(CONFIG_TEST_TYPE_FOO_BAR) ||
+	    IS_ENABLED(CONFIG_TEST_TYPE_BAR_FOO)) {
+		zassert_true(DT_NODE_EXISTS(DT_PATH(cmake_dts_configure)));
+	} else {
+		zassert_false(DT_NODE_EXISTS(DT_PATH(cmake_dts_configure)));
+	}
+}


### PR DESCRIPTION
Add an additional option to the `append` schema for appending to the
`DTS_EXTRA_CPPFLAGS` cmake cache variable, enabling finer control over
the content of devicetree files.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>