### PR TITLE
soc: neorv32: Fix spelling in reset.S

### DIFF
--- a/soc/riscv/riscv-privileged/neorv32/reset.S
+++ b/soc/riscv/riscv-privileged/neorv32/reset.S
@@ -16,7 +16,7 @@ SECTION_FUNC(reset, __reset)
 	/* Zerorize zero register */
 	lui x0, 0
 
-	/* Disable insterrupts */
+	/* Disable interrupts */
 	csrw mstatus, x0
 	csrw mie, x0
 


### PR DESCRIPTION
Fixes minor misspelling of instruction in the neorv32 reset.S.