### PR TITLE
drivers: modem: skip quoted delimiters

### DIFF
--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -112,6 +112,7 @@ static int parse_params(struct modem_cmd_handler_data *data,  size_t match_len,
 {
 	int count = 0;
 	size_t begin, end, i;
+	bool quoted = false;
 
 	if (!data || !data->match_buf || !match_len || !cmd || !argv || !argc) {
 		return -EINVAL;
@@ -120,6 +121,15 @@ static int parse_params(struct modem_cmd_handler_data *data,  size_t match_len,
 	begin = cmd->cmd_len;
 	end = cmd->cmd_len;
 	while (end < match_len) {
+		/* Don't look for delimiters in the middle of a quoted parameter */
+		if (data->match_buf[end] == '"') {
+			quoted = !quoted;
+		}
+		if (quoted) {
+			end++;
+			continue;
+		}
+		/* Look for delimiter characters */
 		for (i = 0; i < strlen(cmd->delim); i++) {
 			if (data->match_buf[end] == cmd->delim[i]) {
 				/* mark a parameter beginning */

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -111,7 +111,7 @@ static int parse_params(struct modem_cmd_handler_data *data,  size_t match_len,
 			uint8_t **argv, size_t argv_len, uint16_t *argc)
 {
 	int count = 0;
-	size_t begin, end, i;
+	size_t delim_len, begin, end, i;
 	bool quoted = false;
 
 	if (!data || !data->match_buf || !match_len || !cmd || !argv || !argc) {
@@ -120,6 +120,7 @@ static int parse_params(struct modem_cmd_handler_data *data,  size_t match_len,
 
 	begin = cmd->cmd_len;
 	end = cmd->cmd_len;
+	delim_len = strlen(cmd->delim);
 	while (end < match_len) {
 		/* Don't look for delimiters in the middle of a quoted parameter */
 		if (data->match_buf[end] == '"') {
@@ -130,7 +131,7 @@ static int parse_params(struct modem_cmd_handler_data *data,  size_t match_len,
 			continue;
 		}
 		/* Look for delimiter characters */
-		for (i = 0; i < strlen(cmd->delim); i++) {
+		for (i = 0; i < delim_len; i++) {
 			if (data->match_buf[end] == cmd->delim[i]) {
 				/* mark a parameter beginning */
 				argv[*argc] = &data->match_buf[begin];


### PR DESCRIPTION
Given the following response: `+CIPSTA:ip6ll:"FE80::EDC:7EFF:FEDD:110C"`

The response delimiter is `:`, but there is also a quoted string that
contains the delimiter character. These delimiters should not be
considered when searching for the end of a parameter.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>