### PR TITLE
 drivers: spi: esp32: add option to handle lines state

### DIFF
--- a/drivers/spi/spi_esp32_spim.h
+++ b/drivers/spi/spi_esp32_spim.h
@@ -38,6 +38,7 @@ struct spi_esp32_config {
 	int dma_host;
 	int cs_setup;
 	int cs_hold;
+	bool line_idle_low;
 };
 
 struct spi_esp32_data {

--- a/dts/bindings/spi/espressif,esp32-spi.yaml
+++ b/dts/bindings/spi/espressif,esp32-spi.yaml
@@ -76,3 +76,8 @@ properties:
     description: |
       Chip select hold time setting, see TRF for SOC for details of
       timing applied.
+
+  line-idle-low:
+    type: boolean
+    description: |
+      Default MISO and MOSI pins GPIO level when idle. Defaults to high by default.


### PR DESCRIPTION
SPI driver is current working for common SPI devices. However, addressable LED like WS2812 requires MOSI line to be default LOW during initialization. This PR adds such option in SPI configuration. This has no effect on common SPI operation.