### PR TITLE
driver: loapic: add DTS binding for local APIC

### DIFF
--- a/arch/x86/core/ia32/intstub.S
+++ b/arch/x86/core/ia32/intstub.S
@@ -13,6 +13,7 @@
  * exception) stubs are implemented in this module.  The stubs are invoked when
  * entering and exiting a C interrupt handler.
  */
+#define LOAPIC_BASE_ADDRESS DT_REG_ADDR(DT_NODELABEL(intc_loapic))
 
 #include <zephyr/arch/x86/ia32/asm.h>
 #include <offsets_short.h>
@@ -197,10 +198,10 @@ alreadyOnIntStack:
 	wrmsr
 #else /* xAPIC */
 #ifdef DEVICE_MMIO_IS_IN_RAM
-	movl	z_loapic_regs, %edx
+	movl	Z_TOPLEVEL_RAM_NAME(LOAPIC_REGS_STR), %edx
 	movl	%eax, LOAPIC_EOI(%edx)
 #else
-	movl	%eax, (CONFIG_LOAPIC_BASE_ADDRESS + LOAPIC_EOI)
+	movl	%eax, (LOAPIC_BASE_ADDRESS + LOAPIC_EOI)
 #endif /* DEVICE_MMIO_IS_IN_RAM */
 #endif /* CONFIG_X2APIC */
 

--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -2,6 +2,7 @@
  * Copyright (c) 2019 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
+#define LOAPIC_BASE_ADDRESS DT_REG_ADDR(DT_NODELABEL(intc_loapic))
 
 #include <zephyr/toolchain.h>
 #include <zephyr/arch/x86/multiboot.h>
@@ -142,7 +143,7 @@ x86_ap_start:
 	 * so we can locate our x86_cpuboot[] bundle. Put it in EBP.
 	 */
 
-	movl CONFIG_LOAPIC_BASE_ADDRESS+LOAPIC_ID, %eax
+	movl LOAPIC_BASE_ADDRESS+LOAPIC_ID, %eax
 	shrl $24, %eax
 	andl $0x0F, %eax		/* local APIC ID -> EAX */
 
@@ -810,7 +811,7 @@ irq_dispatch:
 	movl $(X86_X2APIC_BASE_MSR + (LOAPIC_EOI >> 4)), %ecx
 	wrmsr
 #else /* xAPIC */
-	movq z_loapic_regs, %rdx
+	movq Z_TOPLEVEL_RAM_NAME(LOAPIC_REGS_STR), %rdx
 	movl %eax, LOAPIC_EOI(%rdx)
 #endif /* CONFIG_X2APIC */
 

--- a/drivers/interrupt_controller/Kconfig.loapic
+++ b/drivers/interrupt_controller/Kconfig.loapic
@@ -9,12 +9,6 @@ menuconfig LOAPIC
 
 if LOAPIC
 
-config LOAPIC_BASE_ADDRESS
-	hex "Local APIC Base Address"
-	default 0xFEE00000
-	help
-	  This option specifies the base address of the Local APIC device.
-
 config X2APIC
 	bool "Access local APIC in x2APIC mode"
 	help

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+#define DT_DRV_COMPAT intel_loapic
+
 /*
  * driver for x86 CPU local APIC (as an interrupt controller)
  */
@@ -59,18 +62,15 @@
 #define LOAPIC_SPURIOUS_VECTOR_ID CONFIG_LOAPIC_SPURIOUS_VECTOR_ID
 #endif
 
-#define LOPIC_SSPND_BITS_PER_IRQ  1  /* Just the one for enable disable*/
-#define LOPIC_SUSPEND_BITS_REQD (ROUND_UP((LOAPIC_IRQ_COUNT * LOPIC_SSPND_BITS_PER_IRQ), 32))
+#define LOAPIC_SSPND_BITS_PER_IRQ  1  /* Just the one for enable disable*/
+#define LOAPIC_SUSPEND_BITS_REQD (ROUND_UP((LOAPIC_IRQ_COUNT * LOAPIC_SSPND_BITS_PER_IRQ), 32))
 #ifdef CONFIG_PM_DEVICE
 #include <zephyr/pm/device.h>
 __pinned_bss
-uint32_t loapic_suspend_buf[LOPIC_SUSPEND_BITS_REQD / 32] = {0};
+uint32_t loapic_suspend_buf[LOAPIC_SUSPEND_BITS_REQD / 32] = {0};
 #endif
 
-#ifdef DEVICE_MMIO_IS_IN_RAM
-__pinned_bss
-mm_reg_t z_loapic_regs;
-#endif
+DEVICE_MMIO_TOPLEVEL(LOAPIC_REGS_STR, DT_DRV_INST(0));
 
 __pinned_func
 void send_eoi(void)
@@ -87,11 +87,8 @@ __pinned_func
 void z_loapic_enable(unsigned char cpu_number)
 {
 	int32_t loApicMaxLvt; /* local APIC Max LVT */
+	DEVICE_MMIO_TOPLEVEL_MAP(LOAPIC_REGS_STR, K_MEM_CACHE_NONE);
 
-#ifdef DEVICE_MMIO_IS_IN_RAM
-	device_map(&z_loapic_regs, CONFIG_LOAPIC_BASE_ADDRESS, 0x1000,
-		   K_MEM_CACHE_NONE);
-#endif /* DEVICE_MMIO_IS_IN_RAM */
 #ifndef CONFIG_X2APIC
 	/*
 	 * in xAPIC and flat model, bits 24-31 in LDR (Logical APIC ID) are
@@ -340,7 +337,7 @@ static int loapic_suspend(const struct device *port)
 
 	ARG_UNUSED(port);
 
-	(void)memset(loapic_suspend_buf, 0, (LOPIC_SUSPEND_BITS_REQD >> 3));
+	(void)memset(loapic_suspend_buf, 0, (LOAPIC_SUSPEND_BITS_REQD >> 3));
 
 	for (loapic_irq = 0; loapic_irq < LOAPIC_IRQ_COUNT; loapic_irq++) {
 

--- a/dts/bindings/interrupt-controller/intel,loapic.yaml
+++ b/dts/bindings/interrupt-controller/intel,loapic.yaml
@@ -1,0 +1,17 @@
+description: Local Advanced Programmable Interrupt Controller (APIC)
+
+compatible: "intel,loapic"
+
+include: [interrupt-controller.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  "#interrupt-cells":
+    const: 3
+
+interrupt-cells:
+  - irq
+  - sense
+  - priority

--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -37,6 +37,14 @@
 		interrupt-controller;
 	};
 
+	intc_loapic: loapic@fee00000  {
+		compatible = "intel,loapic";
+		reg = <0xfee00000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		#address-cells = <1>;
+	};
+
 	pcie0: pcie0 {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/dts/x86/intel/apollo_lake.dtsi
+++ b/dts/x86/intel/apollo_lake.dtsi
@@ -36,6 +36,14 @@
 		interrupt-controller;
 	};
 
+	intc_loapic: loapic@fee00000  {
+		compatible = "intel,loapic";
+		reg = <0xfee00000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		#address-cells = <1>;
+	};
+
 	pcie0: pcie0 {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/dts/x86/intel/atom.dtsi
+++ b/dts/x86/intel/atom.dtsi
@@ -32,6 +32,13 @@
 		#interrupt-cells = <3>;
 	};
 
+	intc_loapic: loapic@fee00000  {
+		compatible = "intel,loapic";
+		reg = <0xfee00000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -41,6 +41,14 @@
 		interrupt-controller;
 	};
 
+	intc_loapic: loapic@fee00000  {
+		compatible = "intel,loapic";
+		reg = <0xfee00000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		#address-cells = <1>;
+	};
+
 	pcie0: pcie0 {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/dts/x86/intel/ia32.dtsi
+++ b/dts/x86/intel/ia32.dtsi
@@ -29,6 +29,14 @@
 		interrupt-controller;
 	};
 
+	intc_loapic: loapic@fee00000  {
+		compatible = "intel,loapic";
+		reg = <0xfee00000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		#address-cells = <1>;
+	};
+
 	dram0: memory@0 {
 		device_type = "memory";
 		reg = <DT_DRAM_BASE DT_DRAM_SIZE>;

--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -60,6 +60,14 @@
 		interrupt-controller;
 	};
 
+	intc_loapic: loapic@fee00000  {
+		compatible = "intel,loapic";
+		reg = <0xfee00000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		#address-cells = <1>;
+	};
+
 	sram: memory@ff200000 {
 		device_type = "memory";
 		compatible = "mmio-sram";

--- a/dts/x86/intel/lakemont.dtsi
+++ b/dts/x86/intel/lakemont.dtsi
@@ -28,6 +28,13 @@
 		#interrupt-cells = <3>;
 	};
 
+	intc_loapic: loapic@fee00000  {
+		compatible = "intel,loapic";
+		reg = <0xfee00000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+	};
+
 	/*
 	 * Platforms with Lakemont SoC can have different hardware
 	 * configurations. So RAM and peripherals need to be

--- a/dts/x86/intel/raptor_lake.dtsi
+++ b/dts/x86/intel/raptor_lake.dtsi
@@ -36,6 +36,14 @@
 		interrupt-controller;
 	};
 
+	intc_loapic: loapic@fee00000  {
+		compatible = "intel,loapic";
+		reg = <0xfee00000 0x1000>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+		#address-cells = <1>;
+	};
+
 	pcie0: pcie0 {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/include/zephyr/drivers/interrupt_controller/loapic.h
+++ b/include/zephyr/drivers/interrupt_controller/loapic.h
@@ -49,11 +49,16 @@
 
 #define LOAPIC_LVT_MASKED 0x00010000   /* mask */
 
+/* Defined in intc_loapic.c */
+#define LOAPIC_REGS_STR				loapic_regs	/* mmio device name */
+
 #ifndef _ASMLANGUAGE
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+DEVICE_MMIO_TOPLEVEL_DECLARE(LOAPIC_REGS_STR);
 
 extern uint32_t z_loapic_irq_base(void);
 extern void z_loapic_enable(unsigned char cpu_number);
@@ -72,11 +77,6 @@ static inline uint64_t x86_read_x2apic(unsigned int reg)
 	return z_x86_msr_read(X86_X2APIC_BASE_MSR + reg);
 }
 
-/* Defined in intc_loapic.c */
-#ifdef DEVICE_MMIO_IS_IN_RAM
-extern mm_reg_t z_loapic_regs;
-#endif
-
 /**
  * @brief Read 32-bit value from the local APIC in xAPIC (MMIO) mode.
  *
@@ -85,11 +85,7 @@ extern mm_reg_t z_loapic_regs;
 static inline uint32_t x86_read_xapic(unsigned int reg)
 {
 	mm_reg_t base;
-#ifdef DEVICE_MMIO_IS_IN_RAM
-	base = z_loapic_regs;
-#else
-	base = CONFIG_LOAPIC_BASE_ADDRESS;
-#endif
+	base = DEVICE_MMIO_TOPLEVEL_GET(LOAPIC_REGS_STR);
 	return sys_read32(base + reg);
 }
 
@@ -133,11 +129,7 @@ static inline void x86_write_x2apic(unsigned int reg, uint64_t val)
 static inline void x86_write_xapic(unsigned int reg, uint32_t val)
 {
 	mm_reg_t base;
-#ifdef DEVICE_MMIO_IS_IN_RAM
-	base = z_loapic_regs;
-#else
-	base = CONFIG_LOAPIC_BASE_ADDRESS;
-#endif
+	base = DEVICE_MMIO_TOPLEVEL_GET(LOAPIC_REGS_STR);
 	sys_write32(val, base + reg);
 }
 


### PR DESCRIPTION
As highlighted in #26393, local APIC still used Kconfig based CONFIG_LOAPIC_BASE_ADDRESS. This patch set adds DTS support to local APIC. I/O APIC already uses DTS. Similar to I/O APIC:

- I have added a device tree entry in the relevant `.dtsi` files. 
- I have also added a binding for rules. 

~~Several Intel x86 architecture define a maximum set of LVT entries for local APIC, hence the reason for adding `num-irqs`.~~