### PR TITLE
Add nucleo_u575zi_q  ADC DMA test and fix data length

### DIFF
--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -24,13 +24,13 @@ LOG_MODULE_REGISTER(dma_stm32, CONFIG_DMA_LOG_LEVEL);
 
 #define DT_DRV_COMPAT st_stm32u5_dma
 
-static const uint32_t table_m_size[] = {
+static const uint32_t table_src_size[] = {
 	LL_DMA_SRC_DATAWIDTH_BYTE,
 	LL_DMA_SRC_DATAWIDTH_HALFWORD,
 	LL_DMA_SRC_DATAWIDTH_WORD,
 };
 
-static const uint32_t table_p_size[] = {
+static const uint32_t table_dst_size[] = {
 	LL_DMA_DEST_DATAWIDTH_BYTE,
 	LL_DMA_DEST_DATAWIDTH_HALFWORD,
 	LL_DMA_DEST_DATAWIDTH_WORD,
@@ -489,10 +489,10 @@ static int dma_stm32_configure(const struct device *dev,
 	/* Set the data width, when source_data_size equals dest_data_size */
 	int index = find_lsb_set(config->source_data_size) - 1;
 
-	DMA_InitStruct.SrcDataWidth = table_p_size[index];
+	DMA_InitStruct.SrcDataWidth = table_src_size[index];
 
 	index = find_lsb_set(config->dest_data_size) - 1;
-	DMA_InitStruct.DestDataWidth = table_m_size[index];
+	DMA_InitStruct.DestDataWidth = table_dst_size[index];
 
 	if (stream->source_periph) {
 		DMA_InitStruct.BlkDataLength = config->head_block->block_size /

--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -494,13 +494,7 @@ static int dma_stm32_configure(const struct device *dev,
 	index = find_lsb_set(config->dest_data_size) - 1;
 	DMA_InitStruct.DestDataWidth = table_dst_size[index];
 
-	if (stream->source_periph) {
-		DMA_InitStruct.BlkDataLength = config->head_block->block_size /
-					config->source_data_size;
-	} else {
-		DMA_InitStruct.BlkDataLength = config->head_block->block_size /
-					config->dest_data_size;
-	}
+	DMA_InitStruct.BlkDataLength = config->head_block->block_size;
 
 	/* The request ID is stored in the dma_slot */
 	DMA_InitStruct.Request = config->dma_slot;

--- a/tests/drivers/adc/adc_dma/boards/nucleo_u575zi_q.conf
+++ b/tests/drivers/adc/adc_dma/boards/nucleo_u575zi_q.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2023 Brett Witherspoon
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_ADC_STM32_DMA=y
+CONFIG_ADC_ASYNC=y

--- a/tests/drivers/adc/adc_dma/boards/nucleo_u575zi_q.overlay
+++ b/tests/drivers/adc/adc_dma/boards/nucleo_u575zi_q.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Brett Witherspoon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&adc1 {
+	dmas = <&gpdma1 0 0 (STM32_DMA_PERIPH_TO_MEMORY |
+		STM32_DMA_MEM_INC |  STM32_DMA_MEM_16BITS | STM32_DMA_PERIPH_16BITS) >;
+	dma-names = "dmamux";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};
+
+test_dma: &gpdma1 {
+	status = "okay";
+};

--- a/tests/drivers/adc/adc_dma/src/test_adc.c
+++ b/tests/drivers/adc/adc_dma/src/test_adc.c
@@ -50,6 +50,17 @@
 #define ALIGNMENT 32
 #define BUFFER_MEM_REGION __attribute__((__section__("SRAM4.dma")))
 
+#elif defined(CONFIG_BOARD_NUCLEO_U575ZI_Q)
+
+#define ADC_DEVICE_NODE DT_INST(0, st_stm32_adc)
+#define ADC_RESOLUTION 12
+#define ADC_GAIN ADC_GAIN_1
+#define ADC_REFERENCE ADC_REF_INTERNAL
+#define ADC_ACQUISITION_TIME ADC_ACQ_TIME_DEFAULT
+#define ADC_1ST_CHANNEL_ID 1
+#define ADC_2ND_CHANNEL_ID 7
+#define ALIGNMENT 32
+
 #endif
 
 /* Invalid value that is not supposed to be written by the driver. It is used

--- a/tests/drivers/adc/adc_dma/testcase.yaml
+++ b/tests/drivers/adc/adc_dma/testcase.yaml
@@ -12,5 +12,6 @@ tests:
       - frdm_k82f
       - frdm_k64f
       - nucleo_h743zi
+      - nucleo_u575zi_q
     integration_platforms:
       - frdm_k82f


### PR DESCRIPTION
This PR adds the nucleo_u575zi_q board to the ADC DMA test. To support this it fixes a data length issue and adds transfer error reporting.

Additional details are given in the commit messages.