### PR TITLE
chore: rewrite tlsCredtErrMsg comment

### DIFF
--- a/modules/thrift/src/thrift/transport/TSSLSocket.cpp
+++ b/modules/thrift/src/thrift/transport/TSSLSocket.cpp
@@ -565,7 +565,7 @@ int TSSLSocketFactory::passwordCallback(char *password, int size, int, void *dat
 	return length;
 }
 
-// extract error messages from error queue
+// generate error message for error status
 static void tlsCredtErrMsg(string &errors, const int status)
 {
 	if (status == EACCES) {


### PR DESCRIPTION
* There's no `queue` involved in this code / type signature.
* The input is an int, and thus it isn't possible to "extract" a message from it.