### PR TITLE
drivers: dma: remove unnecessary null check

### DIFF
--- a/drivers/dma/dma_mchp_xec.c
+++ b/drivers/dma/dma_mchp_xec.c
@@ -341,7 +341,7 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	uint32_t ctrl, mstart, mend, dstart, unit_size;
 	int ret;
 
-	if (!dev || !config || (channel >= (uint32_t)devcfg->dma_channels)) {
+	if (!config || (channel >= (uint32_t)devcfg->dma_channels)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
the dev pointer is already dereferenced before this function is called, so this check does not make any sense.