### PR TITLE
Add support for LPI2C on S32K344

### DIFF
--- a/boards/arm/mr_canhubk3/doc/index.rst
+++ b/boards/arm/mr_canhubk3/doc/index.rst
@@ -51,6 +51,7 @@ SIUL2         on-chip     | pinctrl
 LPUART        on-chip     serial
 QSPI          on-chip     flash
 FLEXCAN       on-chip     can
+LPI2C         on-chip     i2c
 ============  ==========  ================================
 
 The default configuration can be found in the Kconfig file
@@ -174,6 +175,21 @@ flexcan5         | 8 bytes   | 32 MBs          | 32 MBs
    A CAN bus usually requires 60 Ohm termination at both ends of the bus. This may be
    accomplished using one of the included CAN termination boards. For more details, refer
    to the section ``6.3 CAN Connectors`` in the Hardware User Manual of `NXP MR-CANHUBK3`_.
+
+I2C
+===
+
+I2C is provided through LPI2C interface with 2 instances ``lpi2c0`` and ``lpi2c1``
+on corresponding connectors ``P4``, ``P3``.
+
+=========  =====  ============
+Connector  Pin    Pin Function
+=========  =====  ============
+P3.2       PTD9   LPI2C1_SCL
+P3.3       PTD8   LPI2C1_SDA
+P4.3       PTD14  LPI2C0_SCL
+P4.4       PTD13  LPI2C0_SDA
+=========  =====  ============
 
 FS26 SBC Watchdog
 =================

--- a/boards/arm/mr_canhubk3/mr_canhubk3-pinctrl.dtsi
+++ b/boards/arm/mr_canhubk3/mr_canhubk3-pinctrl.dtsi
@@ -176,4 +176,22 @@
 			output-enable;
 		};
 	};
+
+	lpi2c0_default: lpi2c0_default {
+		group1 {
+			pinmux = <(PTD13_LPI2C0_SDA_I | PTD13_LPI2C0_SDA_O)>,
+				<(PTD14_LPI2C0_SCL_I | PTD14_LPI2C0_SCL_O)>;
+			input-enable;
+			output-enable;
+		};
+	};
+
+	lpi2c1_default: lpi2c1_default {
+		group1 {
+			pinmux = <(PTD8_LPI2C1_SDA_I | PTD8_LPI2C1_SDA_O)>,
+				<(PTD9_LPI2C1_SCL_I | PTD9_LPI2C1_SCL_O)>;
+			input-enable;
+			output-enable;
+		};
+	};
 };

--- a/boards/arm/mr_canhubk3/mr_canhubk3.dts
+++ b/boards/arm/mr_canhubk3/mr_canhubk3.dts
@@ -308,3 +308,15 @@
 	sample-point-data = <875>;
 	sjw-data = <1>;
 };
+
+&lpi2c0 {
+	pinctrl-0 = <&lpi2c0_default>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+};
+
+&lpi2c1 {
+	pinctrl-0 = <&lpi2c1_default>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+};

--- a/boards/arm/mr_canhubk3/mr_canhubk3.yaml
+++ b/boards/arm/mr_canhubk3/mr_canhubk3.yaml
@@ -13,3 +13,4 @@ supported:
   - gpio
   - uart
   - can
+  - i2c

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -494,6 +494,11 @@ static int mcux_lpi2c_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+	error = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+	if (error) {
+		return error;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;
@@ -509,11 +514,6 @@ static int mcux_lpi2c_init(const struct device *dev)
 	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
 
 	error = mcux_lpi2c_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
-	if (error) {
-		return error;
-	}
-
-	error = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (error) {
 		return error;
 	}

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -7,6 +7,7 @@
 #include <arm/armv7-m.dtsi>
 #include <mem.h>
 #include <zephyr/dt-bindings/clock/nxp_s32k344_clock.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {
@@ -482,6 +483,26 @@
 			clk-source = <0>;
 			interrupts = <123 0>, <124 0>;
 			interrupt-names = "ored", "ored_0_31_mb";
+			status = "disabled";
+		};
+
+		lpi2c0: i2c@40350000 {
+			compatible = "nxp,imx-lpi2c";
+			reg = <0x40350000 0x10000>;
+			clocks = <&clock NXP_S32_LPI2C0_CLK>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <161 0>;
+			status = "disabled";
+		};
+
+		lpi2c1: i2c@40354000 {
+			compatible = "nxp,imx-lpi2c";
+			reg = <0x40354000 0x10000>;
+			clocks = <&clock NXP_S32_LPI2C1_CLK>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <162 0>;
 			status = "disabled";
 		};
 	};

--- a/soc/arm/nxp_s32/s32k/Kconfig.series
+++ b/soc/arm/nxp_s32/s32k/Kconfig.series
@@ -17,5 +17,6 @@ config SOC_SERIES_S32K3_M7
 	select HAS_MCUX
 	select HAS_MCUX_LPUART
 	select HAS_MCUX_FLEXCAN
+	select HAS_MCUX_LPI2C
 	help
 	  Enable support for NXP S32K3 MCUs family on Cortex-M7 cores

--- a/tests/drivers/eeprom/api/boards/mr_canhubk3.overlay
+++ b/tests/drivers/eeprom/api/boards/mr_canhubk3.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Connect I2C0 (connector P4) to the external eeprom Microchip AT24C01C-XHM */
+
+/ {
+	aliases {
+		eeprom-0 = &eeprom0;
+	};
+};
+
+&lpi2c0 {
+	status = "okay";
+	eeprom0: eeprom@50 {
+		compatible = "atmel,at24";
+		reg = <0x50>;
+		size = <128>;
+		pagesize = <8>;
+		address-width = <8>;
+		timeout = <5>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/mr_canhubk3.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mr_canhubk3.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Connect P3.2 <-> P4.3 and P3.3 <-> P4.4 */
+
+&lpi2c0 {
+	status = "okay";
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		size = <1024>;
+	};
+};
+
+&lpi2c1 {
+	status = "okay";
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <1024>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_target_api/testcase.yaml
@@ -20,6 +20,7 @@ tests:
       - nucleo_l073rz
       - rpi_pico
       - efr32bg22_brd4184a
+      - mr_canhubk3
     integration_platforms:
       - nucleo_f091rc
     extra_configs:

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 9fb917ffde77b6ad7e9bfac35b0cb4012709e68c
+      revision: 3aed18634b19102cc0f9e56fcff88bd04edba6ec
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Reuse existing MCUX-based shim driver for LPI2C and update to compatible with the hardware block in S32K344. Configure the pins before initializing I2C to avoid happening bus busy.