### PR TITLE
Bluetooth: Mesh: Discard iv update 1 0 --> 1 1

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -283,6 +283,12 @@ bool bt_mesh_net_iv_update(uint32_t iv_index, bool iv_update)
 		return false;
 	}
 
+	/* Discard [iv, false] --> [iv, true] */
+	if (iv_index == bt_mesh.iv_index && iv_update) {
+		LOG_DBG("Ignore previous IV update procedure");
+		return false;
+	}
+
 	if ((iv_index > bt_mesh.iv_index + 1) ||
 	    (iv_index == bt_mesh.iv_index + 1 &&
 	     (atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS) || !iv_update))) {

--- a/tests/bsim/bluetooth/mesh/src/test_iv_index.c
+++ b/tests/bsim/bluetooth/mesh/src/test_iv_index.c
@@ -111,6 +111,9 @@ static void test_ivu_normal(void)
 	ASSERT_EQUAL(TEST_IV_IDX, bt_mesh.iv_index);
 	ASSERT_EQUAL(0, bt_mesh.seq);
 
+	/* Ignore same iv index but iv in progress */
+	ASSERT_FALSE(bt_mesh_net_iv_update(TEST_IV_IDX, BCN_IV_IN_PROGRESS));
+
 	bt_mesh.seq = 100;
 	/* update before minimum duration */
 	ASSERT_FALSE(bt_mesh_net_iv_update(TEST_IV_IDX + 1, BCN_IV_IN_PROGRESS));


### PR DESCRIPTION
According spec, for the same iv index, iv update flag should trans to false, when iv update procedure complete.

When local environment has attack-node
to store old network beacon(1,1), and re-send same network beacon(1,1) after 192hours, will cause whole bluetooth mesh network broke.

Fixes #60258