### PR TITLE
[v3.4-branch] west.yaml: MCUboot synchronization from upstream cherry-picks

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -268,7 +268,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 74c4d1c52fd51d07904b27a7aa9b2303e896a4e3
+      revision: 865f1d07a297c6150fdc8e0a5bc2522d148648cd
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Cherry-pick some MCUboot updates to Zephyr 3.4-branch.

Brings following Zephyr relevant fixes:

 - 865f1d0 boot_serial: fix image number handle in image upload
           request
 - fb2ff1d boot_serial: fix misuse of 'matched' param from
           zcbor_map_decode_bulk()
 - 7c2cfe6 boot_serial: Fix showing images that are not valid

Fixes #60198

Notes on process:
 1) Updates should from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) should be cherry-picked to [zephyrproject-rtos/mcuboot/backport-upstream-v3.4-branch-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/backport-upstream-v3.4-branch-sync) 
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the backport-upstream-v3.4-branch branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/backport-upstream-v3.4-branch-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/backport-upstream-v3.4-branch-sync) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.