### PR TITLE
Add support for FLexCAN on S32K344

### DIFF
--- a/boards/arm/mr_canhubk3/doc/index.rst
+++ b/boards/arm/mr_canhubk3/doc/index.rst
@@ -50,6 +50,7 @@ SIUL2         on-chip     | pinctrl
                           | external interrupt controller
 LPUART        on-chip     serial
 QSPI          on-chip     flash
+FLEXCAN       on-chip     can
 ============  ==========  ================================
 
 The default configuration can be found in the Kconfig file
@@ -106,6 +107,73 @@ Connector  Pin    Pin Function
 P6.2       PTA9   LPUART2_TX
 P6.3       PTA8   LPUART2_RX
 =========  =====  ============
+
+CAN
+===
+
+CAN is provided through FLEXCAN interface with 6 instances.
+
+===============  =======  ===============  =============
+Devicetree node  Pin      Pin Function     Bus Connector
+===============  =======  ===============  =============
+flexcan0         | PTA6   | PTA6_CAN0_RX   P12/P13
+                 | PTA7   | PTA7_CAN0_TX
+flexcan1         | PTC9   | PTC9_CAN0_RX   P14/P15
+                 | PTC8   | PTC8_CAN0_TX
+flexcan2         | PTE25  | PTE25_CAN0_RX  P16/P17
+                 | PTE24  | PTE24_CAN0_TX
+flexcan3         | PTC29  | PTC29_CAN0_RX  P18/019
+                 | PTC28  | PTC28_CAN0_TX
+flexcan4         | PTC31  | PTC31_CAN0_RX  P20/P21
+                 | PTC30  | PTC30_CAN0_TX
+flexcan5         | PTC11  | PTC11_CAN0_RX  P22/P23
+                 | PTC10  | PTC10_CAN0_TX
+===============  =======  ===============  =============
+
+.. note::
+   There is limitation by HAL SDK, so CAN only has support maximum 64 message buffers (MBs)
+   and support maximum 32 message buffers for concurrent active instances with 8 bytes
+   payload. We need to pay attention to configuration options:
+
+   1. :kconfig:option:`CONFIG_CAN_MAX_MB` must be less or equal than the
+      maximum number of message buffers that is according to the table below.
+
+   2. :kconfig:option:`CONFIG_CAN_MAX_FILTER` must be less or equal than
+      :kconfig:option:`CONFIG_CAN_MAX_MB`.
+
+===============  ==========  ================  ================
+Devicetree node  Payload     Hardware support  Software support
+===============  ==========  ================  ================
+flexcan0         | 8 bytes   | 96 MBs          | 64 MBs
+                 | 16 bytes  | 63 MBs          | 42 MBs
+                 | 32 bytes  | 36 MBs          | 24 MBs
+                 | 64 bytes  | 21 MBs          | 14 MBs
+flexcan1         | 8 bytes   | 64 MBs          | 64 MBs
+                 | 16 bytes  | 42 MBs          | 42 MBs
+                 | 32 bytes  | 24 MBs          | 24 MBs
+                 | 64 bytes  | 14 MBs          | 14 MBs
+flexcan2         | 8 bytes   | 64 MBs          | 64 MBs
+                 | 16 bytes  | 42 MBs          | 42 MBs
+                 | 32 bytes  | 24 MBs          | 24 MBs
+                 | 64 bytes  | 14 MBs          | 14 MBs
+flexcan3         | 8 bytes   | 32 MBs          | 32 MBs
+                 | 16 bytes  | 21 MBs          | 21 MBs
+                 | 32 bytes  | 12 MBs          | 12 MBs
+                 | 64 bytes  | 7 MBs           | 7 MBs
+flexcan4         | 8 bytes   | 32 MBs          | 32 MBs
+                 | 16 bytes  | 21 MBs          | 21 MBs
+                 | 32 bytes  | 12 MBs          | 12 MBs
+                 | 64 bytes  | 7 MBs           | 7 MBs
+flexcan5         | 8 bytes   | 32 MBs          | 32 MBs
+                 | 16 bytes  | 21 MBs          | 21 MBs
+                 | 32 bytes  | 12 MBs          | 12 MBs
+                 | 64 bytes  | 7 MBs           | 7 MBs
+===============  ==========  ================  ================
+
+.. note::
+   A CAN bus usually requires 60 Ohm termination at both ends of the bus. This may be
+   accomplished using one of the included CAN termination boards. For more details, refer
+   to the section ``6.3 CAN Connectors`` in the Hardware User Manual of `NXP MR-CANHUBK3`_.
 
 FS26 SBC Watchdog
 =================

--- a/boards/arm/mr_canhubk3/mr_canhubk3-pinctrl.dtsi
+++ b/boards/arm/mr_canhubk3/mr_canhubk3-pinctrl.dtsi
@@ -110,4 +110,70 @@
 			bias-pull-up;
 		};
 	};
+
+	flexcan0_default: flexcan0_default {
+		group1 {
+			pinmux = <PTA6_CAN0_RX>;
+			input-enable;
+		};
+		group2 {
+			pinmux = <PTA7_CAN0_TX>;
+			output-enable;
+		};
+	};
+
+	flexcan1_default: flexcan1_default {
+		group1 {
+			pinmux = <PTC9_CAN1_RX>;
+			input-enable;
+		};
+		group2 {
+			pinmux = <PTC8_CAN1_TX>;
+			output-enable;
+		};
+	};
+
+	flexcan2_default: flexcan2_default {
+		group1 {
+			pinmux = <PTE25_CAN2_RX>;
+			input-enable;
+		};
+		group2 {
+			pinmux = <PTE24_CAN2_TX>;
+			output-enable;
+		};
+	};
+
+	flexcan3_default: flexcan3_default {
+		group1 {
+			pinmux = <PTC29_CAN3_RX>;
+			input-enable;
+		};
+		group2 {
+			pinmux = <PTC28_CAN3_TX>;
+			output-enable;
+		};
+	};
+
+	flexcan4_default: flexcan4_default {
+		group1 {
+			pinmux = <PTC31_CAN4_RX>;
+			input-enable;
+		};
+		group2 {
+			pinmux = <PTC30_CAN4_TX>;
+			output-enable;
+		};
+	};
+
+	flexcan5_default: flexcan5_default {
+		group1 {
+			pinmux = <PTC11_CAN5_RX>;
+			input-enable;
+		};
+		group2 {
+			pinmux = <PTC10_CAN5_TX>;
+			output-enable;
+		};
+	};
 };

--- a/boards/arm/mr_canhubk3/mr_canhubk3.dts
+++ b/boards/arm/mr_canhubk3/mr_canhubk3.dts
@@ -22,6 +22,7 @@
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,flash-controller = &mx25l6433f;
+		zephyr,canbus = &flexcan0;
 	};
 
 	aliases {
@@ -59,6 +60,54 @@
 			gpios = <&gpioa_h 9 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
+	can_phy0: can-phy0 {
+		compatible = "nxp,tja1443", "can-transceiver-gpio";
+		enable-gpios = <&gpioc_h 8 GPIO_ACTIVE_HIGH>;
+		standby-gpios = <&gpioc_h 5 GPIO_ACTIVE_LOW>;
+		max-bitrate = <5000000>;
+		#phy-cells = <0>;
+	};
+
+	can_phy1: can-phy1 {
+		compatible = "nxp,tja1443", "can-transceiver-gpio";
+		enable-gpios = <&gpiod_l 2 GPIO_ACTIVE_HIGH>;
+		standby-gpios = <&gpiod_h 7 GPIO_ACTIVE_LOW>;
+		max-bitrate = <5000000>;
+		#phy-cells = <0>;
+	};
+
+	can_phy2: can-phy2 {
+		compatible = "nxp,tja1463", "can-transceiver-gpio";
+		enable-gpios = <&gpiod_l 4 GPIO_ACTIVE_HIGH>;
+		standby-gpios = <&gpiod_h 6 GPIO_ACTIVE_LOW>;
+		max-bitrate = <8000000>;
+		#phy-cells = <0>;
+	};
+
+	can_phy3: can-phy3 {
+		compatible = "nxp,tja1463", "can-transceiver-gpio";
+		enable-gpios = <&gpiob_l 0 GPIO_ACTIVE_HIGH>;
+		standby-gpios = <&gpiob_l 1 GPIO_ACTIVE_LOW>;
+		max-bitrate = <8000000>;
+		#phy-cells = <0>;
+	};
+
+	can_phy4: can-phy4 {
+		compatible = "nxp,tja1153", "can-transceiver-gpio";
+		enable-gpios = <&gpioc_h 10 GPIO_ACTIVE_HIGH>;
+		standby-gpios = <&gpioc_h 9 GPIO_ACTIVE_LOW>;
+		max-bitrate = <2000000>;
+		#phy-cells = <0>;
+	};
+
+	can_phy5: can-phy5 {
+		compatible = "nxp,tja1153", "can-transceiver-gpio";
+		enable-gpios = <&gpioe_h 1 GPIO_ACTIVE_HIGH>;
+		standby-gpios = <&gpiod_h 14 GPIO_ACTIVE_LOW>;
+		max-bitrate = <2000000>;
+		#phy-cells = <0>;
+	};
 };
 
 &flash0 {
@@ -87,7 +136,25 @@
 	status = "okay";
 };
 
+/* Enable gpio to control the CAN transceivers */
+
+&gpioc_h {
+	status = "okay";
+};
+
 &gpiod_l {
+	status = "okay";
+};
+
+&gpiod_h {
+	status = "okay";
+};
+
+&gpiob_l {
+	status = "okay";
+};
+
+&gpioe_h {
 	status = "okay";
 };
 
@@ -167,4 +234,77 @@
 			};
 		};
 	};
+};
+
+&flexcan0 {
+	pinctrl-0 = <&flexcan0_default>;
+	pinctrl-names = "default";
+	phys = <&can_phy0>;
+	bus-speed = <125000>;
+	sample-point = <875>;
+	sjw = <1>;
+	bus-speed-data = <1000000>;
+	sample-point-data = <875>;
+	sjw-data = <1>;
+	status = "okay";
+};
+
+&flexcan1 {
+	pinctrl-0 = <&flexcan1_default>;
+	pinctrl-names = "default";
+	phys = <&can_phy1>;
+	bus-speed = <125000>;
+	sample-point = <875>;
+	sjw = <1>;
+	bus-speed-data = <1000000>;
+	sample-point-data = <875>;
+	sjw-data = <1>;
+};
+
+&flexcan2 {
+	pinctrl-0 = <&flexcan2_default>;
+	pinctrl-names = "default";
+	phys = <&can_phy2>;
+	bus-speed = <125000>;
+	sample-point = <875>;
+	sjw = <1>;
+	bus-speed-data = <1000000>;
+	sample-point-data = <875>;
+	sjw-data = <1>;
+};
+
+&flexcan3 {
+	pinctrl-0 = <&flexcan3_default>;
+	pinctrl-names = "default";
+	phys = <&can_phy3>;
+	bus-speed = <125000>;
+	sample-point = <875>;
+	sjw = <1>;
+	bus-speed-data = <1000000>;
+	sample-point-data = <875>;
+	sjw-data = <1>;
+};
+
+&flexcan4 {
+	pinctrl-0 = <&flexcan4_default>;
+	pinctrl-names = "default";
+	phys = <&can_phy4>;
+	bus-speed = <125000>;
+	sample-point = <875>;
+	sjw = <1>;
+	bus-speed-data = <1000000>;
+	sample-point-data = <875>;
+	sjw-data = <1>;
+};
+
+&flexcan5 {
+	pinctrl-0 = <&flexcan5_default>;
+	pinctrl-names = "default";
+	phys = <&can_phy5>;
+	bus-speed = <125000>;
+	sample-point = <875>;
+	sjw = <1>;
+	bus-speed-data = <1000000>;
+	sample-point-data = <875>;
+	sjw-data = <1>;
 };

--- a/boards/arm/mr_canhubk3/mr_canhubk3.yaml
+++ b/boards/arm/mr_canhubk3/mr_canhubk3.yaml
@@ -12,3 +12,4 @@ toolchain:
 supported:
   - gpio
   - uart
+  - can

--- a/boards/arm/mr_canhubk3/mr_canhubk3_defconfig
+++ b/boards/arm/mr_canhubk3/mr_canhubk3_defconfig
@@ -21,6 +21,7 @@ CONFIG_NOCACHE_MEMORY=y
 # Drivers
 CONFIG_PINCTRL=y
 CONFIG_SERIAL=y
+CONFIG_GPIO=y # Enable support for GPIO controlled CAN transceivers
 
 # Serial console
 CONFIG_CONSOLE=y

--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -21,12 +21,21 @@ config CAN_MCUX_FLEXCAN_FD
 	help
 	  Enable support for CAN-FD capable NXP FlexCAN devices.
 
+config CAN_MAX_MB
+	int "Maximum number of message buffers for concurrent active instances"
+	default 16
+	depends on SOC_SERIES_S32K3_M7
+	range 1 96
+	help
+	  Defines maximum number of message buffers for concurrent active instances.
+
 config CAN_MAX_FILTER
 	int "Maximum number of concurrent active RX filters"
 	default 5
 	range 1 15 if SOC_SERIES_KINETIS_KE1XF || SOC_SERIES_KINETIS_K6X
 	range 1 13 if SOC_SERIES_IMX_RT && CAN_MCUX_FLEXCAN_FD
 	range 1 63 if SOC_SERIES_IMX_RT
+	range 1 96 if SOC_SERIES_S32K3_M7
 	help
 	  Defines maximum number of concurrent active RX filters
 

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -49,14 +49,19 @@ LOG_MODULE_REGISTER(can_mcux_flexcan, CONFIG_CAN_LOG_LEVEL);
 #define RX_START_IDX 0
 #endif
 
+/* The maximum number of message buffers for concurrent active instances */
+#ifdef CONFIG_CAN_MAX_MB
+#define MCUX_FLEXCAN_MAX_MB CONFIG_CAN_MAX_MB
+#else
+#define MCUX_FLEXCAN_MAX_MB FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(0)
+#endif
+
 /*
  * RX message buffers (filters) will take up the first N message
  * buffers. The rest are available for TX use.
  */
 #define MCUX_FLEXCAN_MAX_RX (CONFIG_CAN_MAX_FILTER + RX_START_IDX)
-#define MCUX_FLEXCAN_MAX_TX \
-	(FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(0) \
-	- MCUX_FLEXCAN_MAX_RX)
+#define MCUX_FLEXCAN_MAX_TX (MCUX_FLEXCAN_MAX_MB - MCUX_FLEXCAN_MAX_RX)
 
 /*
  * Convert from RX message buffer index to allocated filter ID and
@@ -1246,7 +1251,7 @@ static int mcux_flexcan_init(const struct device *dev)
 	data->dev = dev;
 
 	FLEXCAN_GetDefaultConfig(&flexcan_config);
-	flexcan_config.maxMbNum = FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(0);
+	flexcan_config.maxMbNum = MCUX_FLEXCAN_MAX_MB;
 	flexcan_config.clkSrc = config->clk_source;
 	flexcan_config.baudRate = clock_freq /
 	      (1U + data->timing.prop_seg + data->timing.phase_seg1 +

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -423,6 +423,67 @@
 			#size-cells = <0>;
 			status = "disabled";
 		};
+
+		flexcan0: can@40304000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x40304000 0x4000>;
+			clocks = <&clock NXP_S32_FLEXCANA_CLK>;
+			clk-source = <0>;
+			interrupts = <109 0>, <110 0>, <111 0>, <112 0>;
+			interrupt-names = "ored", "ored_0_31_mb",
+						"ored_32_63_mb", "ored_64_95_mb";
+			status = "disabled";
+		};
+
+		flexcan1: can@40308000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x40308000 0x4000>;
+			clocks = <&clock NXP_S32_FLEXCANA_CLK>;
+			clk-source = <0>;
+			interrupts = <113 0>, <114 0>, <115 0>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb";
+			status = "disabled";
+		};
+
+		flexcan2: can@4030c000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x4030c000 0x4000>;
+			clocks = <&clock NXP_S32_FLEXCANA_CLK>;
+			clk-source = <0>;
+			interrupts = <116 0>, <117 0>, <118 0>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb";
+			status = "disabled";
+		};
+
+		flexcan3: can@40310000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x40310000 0x4000>;
+			clocks = <&clock NXP_S32_FLEXCANB_CLK>;
+			clk-source = <0>;
+			interrupts = <119 0>, <120 0>;
+			interrupt-names = "ored", "ored_0_31_mb";
+			status = "disabled";
+		};
+
+		flexcan4: can@40314000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x40314000 0x4000>;
+			clocks = <&clock NXP_S32_FLEXCANB_CLK>;
+			clk-source = <0>;
+			interrupts = <121 0>, <122 0>;
+			interrupt-names = "ored", "ored_0_31_mb";
+			status = "disabled";
+		};
+
+		flexcan5: can@40318000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x40318000 0x4000>;
+			clocks = <&clock NXP_S32_FLEXCANB_CLK>;
+			clk-source = <0>;
+			interrupts = <123 0>, <124 0>;
+			interrupt-names = "ored", "ored_0_31_mb";
+			status = "disabled";
+		};
 	};
 };
 

--- a/soc/arm/nxp_s32/s32k/Kconfig.series
+++ b/soc/arm/nxp_s32/s32k/Kconfig.series
@@ -16,5 +16,6 @@ config SOC_SERIES_S32K3_M7
 	select CLOCK_CONTROL
 	select HAS_MCUX
 	select HAS_MCUX_LPUART
+	select HAS_MCUX_FLEXCAN
 	help
 	  Enable support for NXP S32K3 MCUs family on Cortex-M7 cores

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 35b0e5afc4f061cedc5a0411e024dad6d9e8101f
+      revision: 9fb917ffde77b6ad7e9bfac35b0cb4012709e68c
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Reuse existing MCUX-based shim driver for FlexCAN and update to compatible with the hardware block in S32K344. Each CAN instance of S32K344 has different maximum number of message buffers, depends on payload. Add kconfig that defines maximum number of message buffers for concurrent active instances and update driver to compatible.