### PR TITLE
Add missing include to thread_analyzer

### DIFF
--- a/include/zephyr/debug/thread_analyzer.h
+++ b/include/zephyr/debug/thread_analyzer.h
@@ -6,7 +6,9 @@
 
 #ifndef __STACK_SIZE_ANALYZER_H
 #define __STACK_SIZE_ANALYZER_H
+
 #include <stddef.h>
+#include <zephyr/kernel/thread.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -12,6 +12,7 @@
 #endif
 
 #include <zephyr/kernel/stats.h>
+#include <zephyr/sys/arch_interface.h>
 
 /**
  * @typedef k_thread_entry_t


### PR DESCRIPTION
Including thread_analyzer.h implicitly requires a previous include of thread.h. This adds this include directly to thread_analyzer to remove this implicit dependency.