### PR TITLE
drivers: sensor: Fix TMD2620 and ADXL362 coverity issues

### DIFF
--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -223,15 +223,18 @@ static int adxl362_set_range(const struct device *dev, uint8_t range)
 
 static int adxl362_set_output_rate(const struct device *dev, uint8_t out_rate)
 {
+	int ret;
 	uint8_t old_filter_ctl;
 	uint8_t new_filter_ctl;
 
-	adxl362_get_reg(dev, &old_filter_ctl, ADXL362_REG_FILTER_CTL, 1);
+	ret = adxl362_get_reg(dev, &old_filter_ctl, ADXL362_REG_FILTER_CTL, 1);
+	if (ret) {
+		return ret;
+	}
+
 	new_filter_ctl = old_filter_ctl & ~ADXL362_FILTER_CTL_ODR(0x7);
 	new_filter_ctl = new_filter_ctl | ADXL362_FILTER_CTL_ODR(out_rate);
-	adxl362_set_reg(dev, new_filter_ctl, ADXL362_REG_FILTER_CTL, 1);
-
-	return 0;
+	return adxl362_set_reg(dev, new_filter_ctl, ADXL362_REG_FILTER_CTL, 1);
 }
 
 
@@ -705,7 +708,7 @@ static int adxl362_chip_init(const struct device *dev)
 static int adxl362_init(const struct device *dev)
 {
 	const struct adxl362_config *config = dev->config;
-	uint8_t value;
+	uint8_t value = 0;
 	int err;
 
 	if (!spi_is_ready_dt(&config->bus)) {
@@ -722,7 +725,7 @@ static int adxl362_init(const struct device *dev)
 
 	k_sleep(K_MSEC(5));
 
-	adxl362_get_reg(dev, &value, ADXL362_REG_PARTID, 1);
+	(void)adxl362_get_reg(dev, &value, ADXL362_REG_PARTID, 1);
 	if (value != ADXL362_PART_ID) {
 		LOG_ERR("wrong part_id: %d", value);
 		return -ENODEV;

--- a/drivers/sensor/tmd2620/tmd2620.c
+++ b/drivers/sensor/tmd2620/tmd2620.c
@@ -175,7 +175,7 @@ static int tmd2620_sensor_setup(const struct device *dev)
 
 	/* trying to read the id twice, as the sensor does not answer the first request */
 	/* because of this no return code is checked in this line */
-	i2c_reg_read_byte_dt(&config->i2c, TMD2620_ID_REG, &chip_id);
+	(void)i2c_reg_read_byte_dt(&config->i2c, TMD2620_ID_REG, &chip_id);
 
 	ret = i2c_reg_read_byte_dt(&config->i2c, TMD2620_ID_REG, &chip_id);
 	if (ret < 0) {


### PR DESCRIPTION
### drivers: sensor: tmd2620: coverity 316443 unchecked return value

The return value is consciously not checked, because the operation
is expected to fail. And the real request is executed afterwards.

### drivers: sensor: adxl362: coverity: 316152 unchecked return value

Check and propagate two return values.
Don't need to check return of the part id request, but make
sure that the value is initialized before the comparison.

Fixes #58593
Coverity-CID: 316152
Fixes #58575
Coverity-CID: 316443