### PR TITLE
Bluetooth: controller: Fix CIS Central FT calculation

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -894,6 +894,14 @@ config BT_CTLR_CONN_ISO_STREAMS_MAX_NSE
 	help
 	  Maximum number of CIS subevents.
 
+config BT_CTLR_CONN_ISO_STREAMS_MAX_FT
+	int "LE Connected Isochronous Streams max flush timeout"
+	depends on BT_CTLR_CONN_ISO
+	range 1 255
+	default 255
+	help
+	  Maximum number of CIS flush timeout events.
+
 config BT_CTLR_ISO
 	bool
 	default BT_CTLR_BROADCAST_ISO || BT_CTLR_CONN_ISO


### PR DESCRIPTION
For config CONFIG_BT_CTLR_CONN_ISO_RELIABILITY_POLICY, set CIG_Sync_Delay fixed as high as possible, and calculate FT by iteration. This favors utilizing as much as possible of the Max_Transport_latency, and spreads out payloads over multiple CIS events (if necessary).

Add exit with cleanup as ll_cig_parameters_commit may fail after creating new CIG/CIS instances.

Fixes issue #59605.
Fixes EBQ test HCI/CIS/BI-12-C.