### PR TITLE
twister: Initialise unbound 'hardware' variable

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -452,6 +452,7 @@ class DeviceHandler(Handler):
                 logger.error("{} timed out".format(script))
 
     def get_hardware(self):
+        hardware = None
         try:
             hardware = self.device_is_available(self.instance)
             while not hardware:


### PR DESCRIPTION
hardware was referenced as return value, without being declared. When the program goes into the 'except' path, `hardware` is unbound, but returned, which throws an error:

`UnboundLocalError`: local variable 'hardware' referenced before assignment