### PR TITLE
Bluetooth: mesh: Update default values for transport SAR configuration

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1462,7 +1462,7 @@ menu "Transport SAR configuration"
 config BT_MESH_SAR_TX_SEG_INT_STEP
 	hex "Interval between sending two consecutive segments"
 	range 0x00 0x0F
-	default 0x01
+	default 0x05
 	help
 	  This value controls the interval between sending two consecutive
 	  segments in a segmented message. The interval is measured in
@@ -1520,7 +1520,7 @@ config BT_MESH_SAR_TX_MULTICAST_RETRANS_COUNT
 config BT_MESH_SAR_TX_MULTICAST_RETRANS_INT
 	hex "Interval between retransmissions to multicast address"
 	range 0x00 0x0F
-	default 0x03
+	default 0x09
 	help
 	  This value controls the interval between retransmissions of all
 	  segments in a segmented message to a multicast address. The
@@ -1542,7 +1542,7 @@ config BT_MESH_SAR_RX_SEG_THRESHOLD
 config BT_MESH_SAR_RX_ACK_DELAY_INC
 	hex "Acknowledgment delay increment"
 	range 0x00 0x07
-	default 0x02
+	default 0x01
 	help
 	  This value controls the delay increment of an interval used for
 	  delaying the transmission of an acknowledgment message after
@@ -1553,7 +1553,7 @@ config BT_MESH_SAR_RX_ACK_DELAY_INC
 config BT_MESH_SAR_RX_SEG_INT_STEP
 	hex "Segments reception interval step"
 	range 0x00 0x0F
-	default 0x01
+	default 0x05
 	help
 	  This value defines the segments reception interval step used for
 	  delaying the transmission of an acknowledgment message after
@@ -1572,7 +1572,7 @@ config BT_MESH_SAR_RX_DISCARD_TIMEOUT
 config BT_MESH_SAR_RX_ACK_RETRANS_COUNT
 	hex "Total number of acknowledgment message retransmission"
 	range 0x00 0x03
-	default 0x01
+	default 0x00
 	help
 	  This value defines the total number of retranmissions of an
 	  acknowledgment message that the stack will additionally send when the

--- a/tests/bsim/bluetooth/mesh/src/test_friendship.c
+++ b/tests/bsim/bluetooth/mesh/src/test_friendship.c
@@ -204,12 +204,10 @@ static void test_friend_msg(void)
 	 * after sending the segments.
 	 */
 	ASSERT_OK(bt_mesh_test_recv(15, cfg->addr, NULL, K_SECONDS(10)));
-	/* 4 polls (2 if legacy transport layer is used):
-	 * - The first one triggered manually by transport when sending segmented message;
-	 * - 2 for each SegAck (SegAcks are sent faster than Friend Poll messages);
+	/* - 2 for each SegAck (SegAcks are sent faster than Friend Poll messages);
 	 * - The last one with MD == 0;
 	 */
-	friend_wait_for_polls(IS_ENABLED(CONFIG_BT_MESH_V1d1) ? 4 : 2);
+	friend_wait_for_polls(2);
 
 	PASS();
 }

--- a/tests/bsim/bluetooth/mesh/src/test_transport.c
+++ b/tests/bsim/bluetooth/mesh/src/test_transport.c
@@ -235,7 +235,7 @@ static void test_tx_loopback(void)
 		err = bt_mesh_test_send(cfg->addr, NULL, test_vector[i].len, test_vector[i].flags,
 					K_NO_WAIT);
 		ASSERT_OK_MSG(err, "Failed sending vector %d", i);
-		bt_mesh_test_recv(test_vector[i].len, cfg->addr, NULL, K_SECONDS(1));
+		bt_mesh_test_recv(test_vector[i].len, cfg->addr, NULL, K_SECONDS(2));
 
 		if (test_stats.received != i + 1) {
 			FAIL("Didn't receive message %d", i);


### PR DESCRIPTION
Updated SAR default values to align with the latest mesh 1.1 drafts,
and relevant Bsim tests.