### PR TITLE
tfm: Fix board selection for Musca B1 board

### DIFF
--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -18,7 +18,7 @@ config TFM_BOARD
 	default "stm/b_u585i_iot02a" if BOARD_B_U585I_IOT02A
 	default "stm/nucleo_l552ze_q" if BOARD_NUCLEO_L552ZE_Q
 	default "stm/stm32l562e_dk" if BOARD_STM32L562E_DK
-	default "arm/musca_b1/sse_200" if BOARD_MUSCA_B1
+	default "arm/musca_b1" if BOARD_MUSCA_B1
 	default "arm/musca_s1" if BOARD_MUSCA_S1
 	default "lairdconnectivity/bl5340_dvk_cpuapp" if BOARD_BL5340_DVK_CPUAPP_NS
 	help


### PR DESCRIPTION
Fix board selection for Musca B1 board.
The platform path in TF-M was changed in the TF-M 1.7.0 update.