### PR TITLE
drivers: mbox: initialize before ipc

### DIFF
--- a/drivers/mbox/Kconfig
+++ b/drivers/mbox/Kconfig
@@ -16,7 +16,7 @@ source "drivers/mbox/Kconfig.nxp_s32"
 
 config MBOX_INIT_PRIORITY
 	int "MBOX init priority"
-	default KERNEL_INIT_PRIORITY_DEVICE
+	default 40
 	help
 	  MBOX driver device initialization priority.
 


### PR DESCRIPTION
Change the default mbox initialization priority so that it initializes before ipc, as some ipc drivers depends on it.

Found with:

```
$ west build -p -b nrf5340dk_nrf5340_cpuapp \
		samples/subsys/ipc/ipc_service/icmsg_me \
		-DCONFIG_CHECK_INIT_PRIORITIES=y
...
ERROR: /ipc/ipc1 POST_KERNEL 46 <
	/soc/peripheral@50000000/mbox@2a000 POST_KERNEL 50
ERROR: /ipc/ipc0 POST_KERNEL 46 <
	/soc/peripheral@50000000/mbox@2a000 POST_KERNEL 50
```