### PR TITLE
footprint: Add BT TMAP samples

### DIFF
--- a/scripts/footprint/plan.txt
+++ b/scripts/footprint/plan.txt
@@ -21,6 +21,8 @@ bt_mesh_demo,default,bbc_microbit,samples/bluetooth/mesh_demo,
 bt_hap_ha,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/hap_ha,
 bt_unicast_audio_client,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/unicast_audio_client,
 bt_unicast_audio_server,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/unicast_audio_server,
+bt_tmap_central,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/tmap_central,
+bt_tmap_peripheral,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/tmap_peripheral,
 bt_hci_rpmsg,default,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,
 bt_hci_rpmsg,iso-broadcast,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,-DCONF_FILE=nrf5340_cpunet_iso_broadcast-bt_ll_sw_split.conf
 bt_hci_rpmsg,iso-receive,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,-DCONF_FILE=nrf5340_cpunet_iso_receive-bt_ll_sw_split.conf


### PR DESCRIPTION
Add the BT Telephony and Media Audio Profile samples. These reflect devices that control telephone and media audio of LE Audio.

The central is typically a more resourceful device, and the peripheral a resource-constrained device.