### PR TITLE
drivers: sensor: mx5837: address integer overflow.

### DIFF
--- a/drivers/sensor/ms5837/ms5837.c
+++ b/drivers/sensor/ms5837/ms5837.c
@@ -73,7 +73,7 @@ static void ms5837_compensate_30(const struct device *dev,
 	 * SECOND ORDER TEMPERATURE COMPENSATION
 	 */
 
-	temp_sq = (data->temperature - 2000) * (data->temperature - 2000);
+	temp_sq = (int64_t)(data->temperature - 2000) * (data->temperature - 2000);
 	if (data->temperature < 2000) {
 		Ti = (3ll * dT * dT) / (1ll << 23);
 		OFFi = (3ll * temp_sq) / 1ll;
@@ -120,7 +120,7 @@ static void ms5837_compensate_02(const struct device *dev,
 	OFF = ((int64_t)(data->off_t1) << 17) + (dT * data->tco) / (1ll << 6);
 	SENS = ((int64_t)(data->sens_t1) << 16) + (dT * data->tcs) / (1ll << 7);
 
-	temp_sq = (data->temperature - 2000) * (data->temperature - 2000);
+	temp_sq = (int64_t)(data->temperature - 2000) * (data->temperature - 2000);
 	if (data->temperature < 2000) {
 		Ti = (11ll * dT * dT) / (1ll << 35);
 		OFFi = (31ll * temp_sq) / (1ll << 3);


### PR DESCRIPTION
Avoid integer overflow in temp_sq calculation.
Details see commit message.

Fixes #58585
Coverity-CID: 316294
Fixes #58594
Coverity-CID: 316521