### PR TITLE
tests/c_lib: Run basic libc tests using newlib and newlib-nano

### DIFF
--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -15,6 +15,10 @@
  * it guarantee that ALL functionality provided is working correctly.
  */
 
+#ifdef CONFIG_NEWLIB_LIBC
+#define _POSIX_C_SOURCE 200809
+#endif
+
 #include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/ztest.h>
@@ -33,6 +37,9 @@
 #include <time.h>
 #include <zephyr/ztest_error_hook.h>
 #ifdef CONFIG_PICOLIBC
+#include <unistd.h>
+#endif
+#ifdef CONFIG_NEWLIB_LIBC
 #include <unistd.h>
 #endif
 
@@ -1083,7 +1090,7 @@ ZTEST(test_c_lib, test_time)
  */
 ZTEST(test_c_lib, test_rand)
 {
-#ifndef CONFIG_PICOLIBC
+#ifdef CONFIG_MINIMAL_LIBC
 	int a;
 
 	a = rand();
@@ -1101,7 +1108,7 @@ ZTEST(test_c_lib, test_rand)
  */
 ZTEST(test_c_lib, test_srand)
 {
-#ifndef CONFIG_PICOLIBC
+#ifdef CONFIG_MINIMAL_LIBC
 	int a;
 
 	srand(0);
@@ -1135,7 +1142,7 @@ ZTEST(test_c_lib, test_srand)
  */
 ZTEST(test_c_lib, test_rand_reproducibility)
 {
-#ifndef CONFIG_PICOLIBC
+#ifdef CONFIG_MINIMAL_LIBC
 	int a;
 	int b;
 	int c;

--- a/tests/lib/c_lib/src/test_strerror.c
+++ b/tests/lib/c_lib/src/test_strerror.c
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef CONFIG_NEWLIB_LIBC
+#define _POSIX_C_SOURCE 200809
+#endif
+
 #include <errno.h>
 #include <string.h>
 

--- a/tests/lib/c_lib/testcase.yaml
+++ b/tests/lib/c_lib/testcase.yaml
@@ -14,6 +14,19 @@ tests:
     ignore_faults: true
     extra_configs:
       - CONFIG_PICOLIBC=y
+  libraries.libc.newlib:
+    filter: CONFIG_NEWLIB_LIBC_SUPPORTED
+    tags: newlib
+    ignore_faults: true
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
+  libraries.libc.newlib_nano:
+    filter: CONFIG_NEWLIB_LIBC_SUPPORTED and CONFIG_HAS_NEWLIB_LIBC_NANO
+    tags: newlib
+    ignore_faults: true
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
+      - CONFIG_NEWLIB_LIBC_NANO=y
   libraries.libc.minimal.strerror_table:
     tags: minimal_libc
     extra_configs:


### PR DESCRIPTION
Validate some basic Zephyr requirements from the newlib C library.