### PR TITLE
arch: x86: enhance number of cpu supports in smp

### DIFF
--- a/arch/x86/core/Kconfig.intel64
+++ b/arch/x86/core/Kconfig.intel64
@@ -88,7 +88,4 @@ config X86_USERSPACE
 	 supporting user-level threads that are protected from each other and
 	 from crashing the kernel.
 
-config MP_MAX_NUM_CPUS
-	range 1 4
-
 endif # X86_64

--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -80,6 +80,15 @@
 	movq %rax, %cr0
 .endm
 
+.macro DEFINE_TSS_STACK_ARRAY
+	.irp idx, DEFINE_STACK_ARRAY_IDX
+		.word __X86_TSS64_SIZEOF-1
+		.word tss\idx
+		.word 0x8900
+		.word 0, 0, 0, 0, 0
+	.endr
+.endm
+
 /* The .locore section begins the page-aligned initialization region
  * of low memory.  The first address is used as the architectural
  * entry point for auxiliary CPUs being brought up (in real mode!)
@@ -113,17 +122,13 @@ __start:
 	nop
 	nop
 
-#if CONFIG_MP_MAX_NUM_CPUS > 1
-
 .code16
 .global x86_ap_start
 x86_ap_start:
-
 	/*
 	 * First, we move to 32-bit protected mode, and set up the
 	 * same flat environment that the BSP gets from the loader.
 	 */
-
 	lgdt gdt48
 	lidt idt48
 	movl %cr0, %eax
@@ -145,7 +150,7 @@ x86_ap_start:
 
 	movl LOAPIC_BASE_ADDRESS+LOAPIC_ID, %eax
 	shrl $24, %eax
-	andl $0x0F, %eax		/* local APIC ID -> EAX */
+	andl $0xFF, %eax		/* local APIC ID -> EAX */
 
 	movl $x86_cpuboot, %ebp
 	xorl %ebx, %ebx
@@ -159,8 +164,6 @@ x86_ap_start:
 
 unknown_loapic_id:
 	jmp unknown_loapic_id
-
-#endif /* CONFIG_MP_MAX_NUM_CPUS > 1 */
 
 .code32
 .globl __start32
@@ -1094,31 +1097,7 @@ gdt:
 
 	/* Remaining entries are TSS for each enabled CPU */
 
-	.word __X86_TSS64_SIZEOF-1	/* 0x40: 64-bit TSS (16-byte entry) */
-	.word tss0
-	.word 0x8900
-	.word 0, 0, 0, 0, 0
-
-#if CONFIG_MP_MAX_NUM_CPUS > 1
-	.word __X86_TSS64_SIZEOF-1	/* 0x50: 64-bit TSS (16-byte entry) */
-	.word tss1
-	.word 0x8900
-	.word 0, 0, 0, 0, 0
-#endif
-
-#if CONFIG_MP_MAX_NUM_CPUS > 2
-	.word __X86_TSS64_SIZEOF-1	/* 0x60: 64-bit TSS (16-byte entry) */
-	.word tss2
-	.word 0x8900
-	.word 0, 0, 0, 0, 0
-#endif
-
-#if CONFIG_MP_MAX_NUM_CPUS > 3
-	.word __X86_TSS64_SIZEOF-1	/* 0x70: 64-bit TSS (16-byte entry) */
-	.word tss3
-	.word 0x8900
-	.word 0, 0, 0, 0, 0
-#endif
+	DEFINE_TSS_STACK_ARRAY
 
 gdt_end:
 
@@ -1129,80 +1108,3 @@ gdt48:  /* LGDT descriptor for 32 bit mode */
 gdt80:  /* LGDT descriptor for long mode */
 	.word (gdt_end - gdt - 1)
 	.quad gdt
-.section .lodata,"ad"
-
-/*
- * Known-good stack for handling CPU exceptions.
- */
-
-.global z_x86_exception_stack
-.align 16
-z_x86_exception_stack:
-	.fill CONFIG_X86_EXCEPTION_STACK_SIZE, 1, 0xAA
-.global z_x86_nmi_stack
-.align 16
-z_x86_nmi_stack:
-	.fill CONFIG_X86_EXCEPTION_STACK_SIZE, 1, 0xAA
-
-#if CONFIG_MP_MAX_NUM_CPUS > 1
-.global z_x86_exception_stack1
-.align 16
-z_x86_exception_stack1:
-	.fill CONFIG_X86_EXCEPTION_STACK_SIZE, 1, 0xAA
-.global z_x86_nmi_stack1
-.align 16
-z_x86_nmi_stack1:
-	.fill CONFIG_X86_EXCEPTION_STACK_SIZE, 1, 0xAA
-#endif
-
-#if CONFIG_MP_MAX_NUM_CPUS > 2
-.global z_x86_exception_stack2
-.align 16
-z_x86_exception_stack2:
-	.fill CONFIG_X86_EXCEPTION_STACK_SIZE, 1, 0xAA
-.global z_x86_nmi_stack2
-.align 16
-z_x86_nmi_stack2:
-	.fill CONFIG_X86_EXCEPTION_STACK_SIZE, 1, 0xAA
-#endif
-
-#if CONFIG_MP_MAX_NUM_CPUS > 3
-.global z_x86_exception_stack3
-.align 16
-z_x86_exception_stack3:
-	.fill CONFIG_X86_EXCEPTION_STACK_SIZE, 1, 0xAA
-.global z_x86_nmi_stack3
-.align 16
-z_x86_nmi_stack3:
-	.fill CONFIG_X86_EXCEPTION_STACK_SIZE, 1, 0xAA
-#endif
-
-#ifdef CONFIG_X86_KPTI
-.section .trampolines,"ad"
-
-.global z_x86_trampoline_stack
-.align 16
-z_x86_trampoline_stack:
-	.fill Z_X86_TRAMPOLINE_STACK_SIZE, 1, 0xAA
-
-#if CONFIG_MP_MAX_NUM_CPUS > 1
-.global z_x86_trampoline_stack1
-.align 16
-z_x86_trampoline_stack1:
-	.fill Z_X86_TRAMPOLINE_STACK_SIZE, 1, 0xAA
-#endif
-
-#if CONFIG_MP_MAX_NUM_CPUS > 2
-.global z_x86_trampoline_stack2
-.align 16
-z_x86_trampoline_stack2:
-	.fill Z_X86_TRAMPOLINE_STACK_SIZE, 1, 0xAA
-#endif
-
-#if CONFIG_MP_MAX_NUM_CPUS > 3
-.global z_x86_trampoline_stack3
-.align 16
-z_x86_trampoline_stack3:
-	.fill Z_X86_TRAMPOLINE_STACK_SIZE, 1, 0xAA
-#endif
-#endif /* CONFIG_X86_KPTI */

--- a/arch/x86/include/intel64/kernel_arch_data.h
+++ b/arch/x86/include/intel64/kernel_arch_data.h
@@ -26,6 +26,7 @@ struct x86_cpuboot {
 	size_t stack_size;	/* size of stack */
 	arch_cpustart_t fn;	/* kernel entry function */
 	void *arg;		/* argument for above function */
+	uint8_t cpu_id;		/* CPU ID */
 };
 
 typedef struct x86_cpuboot x86_cpuboot_t;
@@ -37,5 +38,45 @@ extern uint8_t x86_cpu_loapics[];	/* CPU logical ID -> local APIC ID */
 #ifdef CONFIG_X86_KPTI
 #define Z_X86_TRAMPOLINE_STACK_SIZE	128
 #endif
+
+#ifdef CONFIG_X86_KPTI
+#define TRAMPOLINE_STACK(n)									\
+	uint8_t z_x86_trampoline_stack##n[Z_X86_TRAMPOLINE_STACK_SIZE]				\
+		__attribute__ ((section(".trampolines")));
+
+#define TRAMPOLINE_INIT(n)									\
+	.ist2 = (uint64_t)z_x86_trampoline_stack##n + Z_X86_TRAMPOLINE_STACK_SIZE,
+#else
+#define TRAMPOLINE_STACK(n)
+#define TRAMPOLINE_INIT(n)
+#endif /* CONFIG_X86_KPTI */
+
+#define ACPI_CPU_INIT(n, _)									\
+	uint8_t z_x86_exception_stack##n[CONFIG_X86_EXCEPTION_STACK_SIZE] __aligned(16);	\
+	uint8_t z_x86_nmi_stack##n[CONFIG_X86_EXCEPTION_STACK_SIZE] __aligned(16);		\
+	TRAMPOLINE_STACK(n);									\
+	Z_GENERIC_SECTION(.tss)									\
+	struct x86_tss64 tss##n = {								\
+		TRAMPOLINE_INIT(n)								\
+		.ist6 =	(uint64_t)z_x86_nmi_stack##n + CONFIG_X86_EXCEPTION_STACK_SIZE,		\
+		.ist7 = (uint64_t)z_x86_exception_stack##n + CONFIG_X86_EXCEPTION_STACK_SIZE,	\
+		.iomapb = 0xFFFF, .cpu = &(_kernel.cpus[n])	\
+	}
+
+#define X86_CPU_BOOT_INIT(n, _)									\
+	{											\
+		.tr = (0x40 + (16 * n)),							\
+		.gs_base = &tss##n,								\
+		.sp = (uint64_t)z_interrupt_stacks[n] +						\
+		      K_KERNEL_STACK_LEN(CONFIG_ISR_STACK_SIZE),				\
+		.stack_size = K_KERNEL_STACK_LEN(CONFIG_ISR_STACK_SIZE),			\
+		.fn = z_prep_c,									\
+		.arg = &x86_cpu_boot_arg,							\
+	}
+
+#define STACK_ARRAY_IDX(n, _) n
+
+#define DEFINE_STACK_ARRAY_IDX\
+	LISTIFY(CONFIG_MP_MAX_NUM_CPUS, STACK_ARRAY_IDX, (,))
 
 #endif /* ZEPHYR_ARCH_X86_INCLUDE_INTEL64_KERNEL_ARCH_DATA_H_ */

--- a/tests/arch/x86/nmi/src/main.c
+++ b/tests/arch/x86/nmi/src/main.c
@@ -17,13 +17,13 @@
 
 static volatile int int_handler_executed;
 
-extern uint8_t z_x86_nmi_stack[];
+extern uint8_t z_x86_nmi_stack0[];
 extern uint8_t z_x86_nmi_stack1[];
 extern uint8_t z_x86_nmi_stack2[];
 extern uint8_t z_x86_nmi_stack3[];
 
 uint8_t *nmi_stacks[] = {
-	z_x86_nmi_stack,
+	z_x86_nmi_stack0,
 #if CONFIG_MP_MAX_NUM_CPUS > 1
 	z_x86_nmi_stack1,
 #if CONFIG_MP_MAX_NUM_CPUS > 2


### PR DESCRIPTION
Remove the limitation for number of cpu support in smp for x86 architecture. This changes remove x86 limitation for maximum number of CPUs supported and also update kernel limitation to 32 CPU instead of 8. 