### PR TITLE
Bluetooth: Host: Remove 'Experimental' Flag for Encrypted Advertising

### DIFF
--- a/subsys/bluetooth/lib/Kconfig
+++ b/subsys/bluetooth/lib/Kconfig
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BT_EAD
-	bool "Encrypted Advertising Data [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Encrypted Advertising Data"
 	select BT_HOST_CCM
 	help
 	  Enable the Encrypted Advertising Data library


### PR DESCRIPTION
Remove the 'Experimental' flag for the Encrypted Advertising feature.