### PR TITLE
drivers: clock_control: stm32h5: boot_clock_assert_fix

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -74,6 +74,10 @@ static uint32_t get_startup_frequency(void)
 		return STM32_CSI_FREQ;
 	case LL_RCC_SYS_CLKSOURCE_STATUS_HSI:
 		return STM32_HSI_FREQ;
+	case LL_RCC_SYS_CLKSOURCE_STATUS_HSE:
+		return STM32_HSE_FREQ;
+	case LL_RCC_SYS_CLKSOURCE_STATUS_PLL1:
+		return get_pllsrc_frequency(PLL1_ID);
 	default:
 		__ASSERT(0, "Unexpected startup freq");
 		return 0;


### PR DESCRIPTION
When the image is chain-loaded, clocks may already by initialized. The driver was lacking support for already configured HSE and PLL sources. When CONFIG_ASSERT=y get_startup_frequency was failing since it did not recognize these sources.

It's the same issue that was addressed in #58109 for stm32u5.