### PR TITLE
tests: subsys: rtio: Reset the spsc before the test starts

### DIFF
--- a/tests/subsys/rtio/rtio_api/src/test_rtio_spsc.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_spsc.c
@@ -247,5 +247,11 @@ ZTEST(rtio_spsc, test_spsc_throughput)
 		 THROUGHPUT_ITERS, ns/THROUGHPUT_ITERS);
 }
 
+static void rtio_spsc_before(void *data)
+{
+	ARG_UNUSED(data);
 
-ZTEST_SUITE(rtio_spsc, NULL, NULL, NULL, NULL, NULL);
+	rtio_spsc_reset(&spsc);
+}
+
+ZTEST_SUITE(rtio_spsc, NULL, NULL, rtio_spsc_before, NULL, NULL);


### PR DESCRIPTION
The test case `test_spsc_throughput` reuses spsc without reset.
Fix it by resetting the spsc before the test case starts.