### PR TITLE
arch: arm64: minor fixes for function declaration and mpu CHECKIF condition

### DIFF
--- a/arch/arm64/core/cortex_r/arm_mpu.c
+++ b/arch/arm64/core/cortex_r/arm_mpu.c
@@ -448,8 +448,9 @@ static int configure_dynamic_mpu_regions(struct k_thread *thread)
 					     partition->start,
 					     partition->size,
 					     &partition->attr);
-			CHECKIF(ret2 != 0) {
+			CHECKIF(ret2 < 0) {
 				ret = ret2;
+				goto out;
 			}
 
 			region_num = (uint8_t)ret2;
@@ -465,8 +466,9 @@ static int configure_dynamic_mpu_regions(struct k_thread *thread)
 				     thread->stack_info.start,
 				     thread->stack_info.size,
 				     &K_MEM_PARTITION_P_RW_U_RW);
-		CHECKIF(ret2 != 0) {
+		CHECKIF(ret2 < 0) {
 			ret = ret2;
+			goto out;
 		}
 
 		region_num = (uint8_t)ret2;

--- a/arch/arm64/include/kernel_arch_func.h
+++ b/arch/arm64/include/kernel_arch_func.h
@@ -43,7 +43,7 @@ static inline void arch_switch(void *switch_to, void **switched_from)
 	z_arm64_context_switch(new, old);
 }
 
-extern void z_arm64_fatal_error(z_arch_esf_t *esf, unsigned int reason);
+extern void z_arm64_fatal_error(unsigned int reason, z_arch_esf_t *esf);
 extern void z_arm64_set_ttbr0(uint64_t ttbr0);
 extern void z_arm64_mem_cfg_ipi(void);
 


### PR DESCRIPTION
1) arch: arm64: Fix z_arm64_fatal_error declaration error
2) arch: arm64: mpu: Fix some minor CHECKIF issues