### PR TITLE
drivers: mm: Fix cast warnings on build for RAT

### DIFF
--- a/drivers/mm/mm_drv_ti_rat.c
+++ b/drivers/mm/mm_drv_ti_rat.c
@@ -99,7 +99,7 @@ int sys_mm_drv_page_phys_get(void *virt, uintptr_t *phys)
 	if (virt == NULL) {
 		return -EINVAL;
 	}
-	uint64_t pa = ((uint64_t) (virt));
+	uintptr_t pa = (uintptr_t) virt;
 	uintptr_t *va = phys;
 
 	uint32_t found, regionId;
@@ -130,10 +130,10 @@ int sys_mm_drv_page_phys_get(void *virt, uintptr_t *phys)
 		uint32_t offset =
 			pa - translate_config.region_config[regionId].system_addr;
 
-		*va = (void *)(translate_config.region_config[regionId].local_addr + offset);
+		*va = (translate_config.region_config[regionId].local_addr + offset);
 	} else {
 		/* no mapping found, set output = input with 32b truncation */
-		*va = (void *)pa;
+		*va = pa;
 	}
 
 	if (va == NULL) {

--- a/include/zephyr/drivers/mm/rat.h
+++ b/include/zephyr/drivers/mm/rat.h
@@ -15,10 +15,10 @@ extern "C" {
 #include <stdint.h>
 
 #define ADDR_TRANSLATE_MAX_REGIONS (16u)
-#define RAT_CTRL(base_addr, i)     (volatile uint32_t *)(base_addr + 0x20 + 0x10 * (i))
-#define RAT_BASE(base_addr, i)     (volatile uint32_t *)(base_addr + 0x24 + 0x10 * (i))
-#define RAT_TRANS_L(base_addr, i)  (volatile uint32_t *)(base_addr + 0x28 + 0x10 * (i))
-#define RAT_TRANS_H(base_addr, i)  (volatile uint32_t *)(base_addr + 0x2C + 0x10 * (i))
+#define RAT_CTRL(base_addr, i)     (base_addr + 0x20 + 0x10 * (i))
+#define RAT_BASE(base_addr, i)     (base_addr + 0x24 + 0x10 * (i))
+#define RAT_TRANS_L(base_addr, i)  (base_addr + 0x28 + 0x10 * (i))
+#define RAT_TRANS_H(base_addr, i)  (base_addr + 0x2C + 0x10 * (i))
 #define RAT_CTRL_W(enable, size)   (((enable & 0x1) << 31u) | (size & 0x3F))
 
 /**


### PR DESCRIPTION
Removed the unneccessary casts in the functions to remove warnings during build for SoCs using RAT. Functionality reamins the same, tested on board.