### PR TITLE
kernel: Add support to override banner

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -390,6 +390,13 @@ config BOOT_BANNER
 	help
 	  This option outputs a banner to the console device during boot up.
 
+config BOOT_BANNER_STRING
+	string "Boot banner string"
+	depends on BOOT_BANNER
+	default "Booting Zephyr OS build"
+	help
+	  Use this option to set the boot banner.
+
 config BOOT_DELAY
 	int "Boot delay in milliseconds"
 	depends on MULTITHREADING

--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -29,7 +29,7 @@ void boot_banner(void)
 	k_busy_wait(CONFIG_BOOT_DELAY * USEC_PER_MSEC);
 #endif /* defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0) */
 
-#if CONFIG_BOOT_BANNER
-	printk("*** Booting Zephyr OS build " BANNER_VERSION BANNER_POSTFIX " ***\n");
+#ifdef CONFIG_BOOT_BANNER
+	printk("*** " CONFIG_BOOT_BANNER_STRING " " BANNER_VERSION BANNER_POSTFIX " ***\n");
 #endif /* CONFIG_BOOT_BANNER */
 }


### PR DESCRIPTION
This is useful for Zephyr customers to put their custom banners.