### PR TITLE
drivers: flash: nrf_qspi_nor: Process ret of qspi_device_init

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -1420,8 +1420,18 @@ static int qspi_nor_pm_action(const struct device *dev,
 void z_impl_nrf_qspi_nor_xip_enable(const struct device *dev, bool enable)
 {
 	struct qspi_nor_data *dev_data = dev->data;
+	int ret;
 
-	qspi_device_init(dev);
+	if (dev_data->xip_enabled == enable) {
+		return;
+	}
+
+	ret = qspi_device_init(dev);
+
+	if (ret != 0) {
+		LOG_ERR("NRF QSPI NOR XIP %s failed with %d\n", enable ? "enable" : "disable", ret);
+		return;
+	}
 
 #if NRF_QSPI_HAS_XIPEN
 	nrf_qspi_xip_set(NRF_QSPI, enable);


### PR DESCRIPTION
Commit slters z_impl_nrf_qspi_nor_xip_enable to not call qspi_device_init in case when xip_enabled has the same value as requested.
In case when qspi_device_init returns non-zero no further actions are taken and xip_enabled will not be to desired value.

Fixes #59535.

**Update 2023-07-13 14:52 UTC**
Fixed badly written commit message.