### PR TITLE
Bluetooth: BAP: Remove stream->dir field

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -445,9 +445,6 @@ int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info);
  * connected isochronous stream.
  */
 struct bt_bap_stream {
-	/** Stream direction */
-	enum bt_audio_dir dir;
-
 	/** Connection reference */
 	struct bt_conn *conn;
 

--- a/subsys/bluetooth/audio/bap_iso.c
+++ b/subsys/bluetooth/audio/bap_iso.c
@@ -234,7 +234,8 @@ struct bt_bap_ep *bt_bap_iso_get_paired_ep(const struct bt_bap_ep *ep)
 }
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
-void bt_bap_iso_bind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *stream)
+void bt_bap_iso_bind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *stream,
+			    enum bt_audio_dir dir)
 {
 	struct bt_bap_iso_dir *bap_iso_ep;
 
@@ -243,10 +244,10 @@ void bt_bap_iso_bind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *st
 	__ASSERT(stream->bap_iso == NULL, "stream %p bound with bap_iso %p already", stream,
 		 stream->bap_iso);
 
-	LOG_DBG("bap_iso %p stream %p dir %s", bap_iso, stream, bt_audio_dir_str(stream->dir));
+	LOG_DBG("bap_iso %p stream %p dir %s", bap_iso, stream, bt_audio_dir_str(dir));
 
 	/* For the unicast client, the direction and tx/rx is reversed */
-	if (stream->dir == BT_AUDIO_DIR_SOURCE) {
+	if (dir == BT_AUDIO_DIR_SOURCE) {
 		bap_iso_ep = &bap_iso->rx;
 	} else {
 		bap_iso_ep = &bap_iso->tx;
@@ -259,7 +260,8 @@ void bt_bap_iso_bind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *st
 	stream->bap_iso = bt_bap_iso_ref(bap_iso);
 }
 
-void bt_bap_iso_unbind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *stream)
+void bt_bap_iso_unbind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *stream,
+			      enum bt_audio_dir dir)
 {
 	struct bt_bap_iso_dir *bap_iso_ep;
 
@@ -267,10 +269,10 @@ void bt_bap_iso_unbind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *
 	__ASSERT_NO_MSG(bap_iso != NULL);
 	__ASSERT(stream->bap_iso != NULL, "stream %p not bound with an bap_iso", stream);
 
-	LOG_DBG("bap_iso %p stream %p dir %s", bap_iso, stream, bt_audio_dir_str(stream->dir));
+	LOG_DBG("bap_iso %p stream %p dir %s", bap_iso, stream, bt_audio_dir_str(dir));
 
 	/* For the unicast client, the direction and tx/rx is reversed */
-	if (stream->dir == BT_AUDIO_DIR_SOURCE) {
+	if (dir == BT_AUDIO_DIR_SOURCE) {
 		bap_iso_ep = &bap_iso->rx;
 	} else {
 		bap_iso_ep = &bap_iso->tx;

--- a/subsys/bluetooth/audio/bap_iso.h
+++ b/subsys/bluetooth/audio/bap_iso.h
@@ -47,6 +47,8 @@ struct bt_bap_ep *bt_bap_iso_get_ep(bool unicast_client, struct bt_bap_iso *iso,
 
 struct bt_bap_ep *bt_bap_iso_get_paired_ep(const struct bt_bap_ep *ep);
 /* Unicast client-only functions*/
-void bt_bap_iso_bind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *stream);
-void bt_bap_iso_unbind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *stream);
+void bt_bap_iso_bind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *stream,
+			    enum bt_audio_dir dir);
+void bt_bap_iso_unbind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *stream,
+			      enum bt_audio_dir dir);
 struct bt_bap_stream *bt_bap_iso_get_stream(struct bt_bap_iso *iso, enum bt_audio_dir dir);

--- a/tests/bluetooth/tester/src/btp_bap.c
+++ b/tests/bluetooth/tester/src/btp_bap.c
@@ -561,10 +561,17 @@ static void stream_released(struct bt_bap_stream *stream)
 static void stream_started(struct bt_bap_stream *stream)
 {
 	struct audio_stream *a_stream = CONTAINER_OF(stream, struct audio_stream, stream);
+	struct bt_bap_ep_info info;
+	int err;
 
 	LOG_DBG("Started stream %p", stream);
 
-	if (stream->dir == BT_AUDIO_DIR_SINK) {
+	err = bt_bap_ep_get_info(stream->ep, &info);
+	if (err) {
+		LOG_ERR("Could not get EP info for stream %p", stream);
+	}
+
+	if (info.dir == BT_AUDIO_DIR_SINK) {
 		/* Schedule first TX ISO data at seq_num 1 instead of 0 to ensure
 		 * we are in sync with the controller at start of streaming.
 		 */


### PR DESCRIPTION
The BAP stream object should not have a dir field. The dir field should be stored in the EP only (to avoid having two fields storing the same value, causing possible issues).

The field was removed, and the places that use it has been updated.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/56122