### PR TITLE
west.yml: hal stm32: Update STM32Cube packages

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 65b641345a5bfccd93de1fc21103d69c4a9ff1d6
+      revision: 1bc72c299d0365c0ee2575a97918b22df0899e10
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update STM32Cube packages:

update stm32c0 to cube version V1.1.0
update stm32f2 to cube version V1.9.4
update stm32h5 to cube version V1.1.0
update stm32l1 to cube version V1.10.4
update stm32u5 to cube version V1.3.0
update stm32wb to cube version V1.17.0
update stm32wba to cube version V1.1.0