### PR TITLE
emul: Only add enabled DT nodes to bus emulators

### DIFF
--- a/drivers/espi/espi_emul.c
+++ b/drivers/espi/espi_emul.c
@@ -232,8 +232,8 @@ static struct emul_espi_driver_api emul_espi_driver_api = {
 	},
 
 #define ESPI_EMUL_INIT(n)                                                                          \
-	static const struct emul_link_for_bus emuls_##n[] = { DT_FOREACH_CHILD(                    \
-		DT_DRV_INST(n), EMUL_LINK_AND_COMMA) };                                            \
+	static const struct emul_link_for_bus emuls_##n[] = {                                      \
+		DT_FOREACH_CHILD_STATUS_OKAY(DT_DRV_INST(n), EMUL_LINK_AND_COMMA)};                \
 	static struct emul_list_for_bus espi_emul_cfg_##n = {                                      \
 		.children = emuls_##n,                                                             \
 		.num_children = ARRAY_SIZE(emuls_##n),                                             \

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -144,8 +144,8 @@ static struct i2c_driver_api i2c_emul_api = {
 	},
 
 #define I2C_EMUL_INIT(n)                                                                           \
-	static const struct emul_link_for_bus emuls_##n[] = { DT_FOREACH_CHILD(                    \
-		DT_DRV_INST(n), EMUL_LINK_AND_COMMA) };                                            \
+	static const struct emul_link_for_bus emuls_##n[] = {                                      \
+		DT_FOREACH_CHILD_STATUS_OKAY(DT_DRV_INST(n), EMUL_LINK_AND_COMMA)};                \
 	static struct emul_list_for_bus i2c_emul_cfg_##n = {                                       \
 		.children = emuls_##n,                                                             \
 		.num_children = ARRAY_SIZE(emuls_##n),                                             \

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -119,8 +119,8 @@ static struct spi_driver_api spi_emul_api = {
 	},
 
 #define SPI_EMUL_INIT(n)                                                                           \
-	static const struct emul_link_for_bus emuls_##n[] = { DT_FOREACH_CHILD(                    \
-		DT_DRV_INST(n), EMUL_LINK_AND_COMMA) };                                            \
+	static const struct emul_link_for_bus emuls_##n[] = {                                      \
+		DT_FOREACH_CHILD_STATUS_OKAY(DT_DRV_INST(n), EMUL_LINK_AND_COMMA)};                \
 	static struct emul_list_for_bus spi_emul_cfg_##n = {                                       \
 		.children = emuls_##n,                                                             \
 		.num_children = ARRAY_SIZE(emuls_##n),                                             \


### PR DESCRIPTION
The eSPI, I2C, and SPI emulators use devicetree macros to build an array of devices on the virtual bus. Currently, they will add device nodes that are not status-okay. This leads to linker errors because the respective device drivers would not have instantiated device structs for these nodes --assuming the driver was even compiled. This can be frustrating if nodes need to be disabled for debugging or configuration purposes.

Update the bus emulators to only consider status-okay nodes by changing the macros used to iterate over bus devices.