### PR TITLE
scripts: gen_relocate_app: use its own cmake property name...

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -214,7 +214,7 @@ macro(toolchain_ld_relocation)
     ${ZEPHYR_BASE}/scripts/build/gen_relocate_app.py
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     -d ${APPLICATION_BINARY_DIR}
-    -i \"$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>\"
+    -i \"$<TARGET_PROPERTY:code_data_relocation_target,reloc_file_list>\"
     -o ${MEM_RELOCATION_LD}
     -s ${MEM_RELOCATION_SRAM_DATA_LD}
     -b ${MEM_RELOCATION_SRAM_BSS_LD}

--- a/cmake/linker/ld/target_relocation.cmake
+++ b/cmake/linker/ld/target_relocation.cmake
@@ -18,7 +18,7 @@ macro(toolchain_ld_relocation)
     ${ZEPHYR_BASE}/scripts/build/gen_relocate_app.py
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     -d ${APPLICATION_BINARY_DIR}
-    -i \"$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>\"
+    -i \"$<TARGET_PROPERTY:code_data_relocation_target,reloc_file_list>\"
     -o ${MEM_RELOCATION_LD}
     -s ${MEM_RELOCATION_SRAM_DATA_LD}
     -b ${MEM_RELOCATION_SRAM_BSS_LD}

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1371,9 +1371,9 @@ function(zephyr_code_relocate)
   # of using CMake lists. This way, the ";" character can be reserved for
   # generator expression file lists.
   get_property(code_rel_str TARGET code_data_relocation_target
-    PROPERTY COMPILE_DEFINITIONS)
+    PROPERTY reloc_file_list)
   set_property(TARGET code_data_relocation_target
-    PROPERTY COMPILE_DEFINITIONS
+    PROPERTY reloc_file_list
     "${code_rel_str}|${CODE_REL_LOCATION}:${copy_flag}:${file_list}")
 endfunction()
 


### PR DESCRIPTION
...instead of piggyback onto COMPILE_DEFINITIONS. This fixes an issue where an add_compile_definitions() would result in the compiler definition being appended to the relocation file list. This is because COMPILE_DEFINITIONS is populated by cmake to contain all compiler definitions of a target (think -D being passed to compiler). So by piggyback onto COMPILE_DEFINITIONS for the relocation file list, any of those definitions would be in the file list. To avoid this, we need to have a separate named property.
