### PR TITLE
libc: Add shell support

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -302,6 +302,9 @@ Libraries / Subsystems
     supported in function handlers by setting ``mg_translate_error`` of
     :c:struct:`mgmt_group` when registering a transport. See
     :c:type:`smp_translate_error_fn` for function details.
+* shell
+
+  * Added an application shell module with helpers common to all applications.
 
 * File systems
 

--- a/lib/libc/minimal/include/stdlib.h
+++ b/lib/libc/minimal/include/stdlib.h
@@ -16,6 +16,19 @@
 extern "C" {
 #endif
 
+struct mallinfo2 {
+	size_t arena;    /* total space allocated from system */
+	size_t ordblks;  /* number of non-inuse chunks */
+	size_t smblks;   /* unused -- always zero */
+	size_t hblks;    /* number of mmapped regions */
+	size_t hblkhd;   /* total space in mmapped regions */
+	size_t usmblks;  /* unused -- always zero */
+	size_t fsmblks;  /* unused -- always zero */
+	size_t uordblks; /* total allocated space */
+	size_t fordblks; /* total non-inuse space */
+	size_t keepcost; /* top-most, releasable (via malloc_trim) space */
+};
+
 unsigned long strtoul(const char *nptr, char **endptr, int base);
 long strtol(const char *nptr, char **endptr, int base);
 unsigned long long strtoull(const char *nptr, char **endptr, int base);
@@ -23,6 +36,7 @@ long long strtoll(const char *nptr, char **endptr, int base);
 int atoi(const char *s);
 
 void *malloc(size_t size);
+struct mallinfo2 mallinfo2(void);
 void *aligned_alloc(size_t alignment, size_t size); /* From C11 */
 
 void free(void *ptr);

--- a/subsys/shell/modules/CMakeLists.txt
+++ b/subsys/shell/modules/CMakeLists.txt
@@ -16,3 +16,7 @@ zephyr_sources_ifdef(
   CONFIG_DEVMEM_SHELL
   devmem_service.c
   )
+zephyr_sources_ifdef(
+  CONFIG_APP_SHELL
+  app_service.c
+  )

--- a/subsys/shell/modules/Kconfig
+++ b/subsys/shell/modules/Kconfig
@@ -45,3 +45,9 @@ config DEVMEM_SHELL
 	select GETOPT
 	help
 	  This shell command provides read/write access to physical memory.
+
+config APP_SHELL
+	bool "application shell (common to all applications)"
+	default y if !SHELL_MINIMAL
+	help
+	  This shell module provides access to common helpers.

--- a/subsys/shell/modules/app_service.c
+++ b/subsys/shell/modules/app_service.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/printk.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <kernel_internal.h>
+#if defined(CONFIG_LOG_RUNTIME_FILTERING)
+#include <zephyr/logging/log_ctrl.h>
+#endif
+
+#ifdef CONFIG_MINIMAL_LIBC
+#include <stdlib.h>
+#else
+#include <malloc.h>
+#endif /* CONFIG_MINIMAL_LIBC */
+
+static int cmd_app_heap(const struct shell *sh, size_t argc, char **argv)
+{
+#if defined(CONFIG_BOARD_NATIVE_POSIX) && __GLIBC__ == 2 && __GLIBC_MINOR__ < 33
+	/* mallinfo() was deprecated in glibc 2.33 and removed in 2.34. */
+	struct mallinfo mi = mallinfo();
+#else
+	struct mallinfo2 mi = mallinfo2();
+#endif /* CONFIG_BOARD_NATIVE_POSIX && __GLIBC__ == 2 && __GLIBC_MINOR__ < 33 */
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_print(sh, "Heap size: %d bytes", mi.arena);
+	shell_print(sh, "  used: %d bytes", mi.uordblks);
+	shell_print(sh, "  free: %d bytes", mi.fordblks);
+	shell_print(sh, "  max used: %d bytes", mi.usmblks);
+	shell_print(sh, "  free fastbin: %d bytes", mi.fsmblks);
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_app,
+	SHELL_CMD(heap, NULL, "app heap", cmd_app_heap),
+	SHELL_SUBCMD_SET_END /* Array terminated. */
+);
+
+SHELL_CMD_REGISTER(app, &sub_app, "application commands", NULL);


### PR DESCRIPTION
This is useful as a placeholder for all commands common to applications. For now we start with malloc stats, useful in debugging libc HEAP issues.