### PR TITLE
samples: lwm2m: Fix default ID length check for DTLS

### DIFF
--- a/samples/net/lwm2m_client/overlay-dtls.conf
+++ b/samples/net/lwm2m_client/overlay-dtls.conf
@@ -23,3 +23,8 @@ CONFIG_NET_SOCKETS_ENABLE_DTLS=y
 # MbedTLS needs a larger stack
 CONFIG_MAIN_STACK_SIZE=2048
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+
+# This has to be match length of LWM2M_APP_ID and if LWM2M_APP_ID is empty,
+# then this has to be match length of CONFIG_BOARD. Default 16 is not enough
+# for some boards, so, increase it to 32.
+CONFIG_LWM2M_SECURITY_KEY_SIZE=32

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -45,6 +45,11 @@ static struct lwm2m_ctx client;
 static const char *endpoint =
 	(sizeof(CONFIG_LWM2M_APP_ID) > 1 ? CONFIG_LWM2M_APP_ID : CONFIG_BOARD);
 
+#if defined(CONFIG_LWM2M_DTLS_SUPPORT)
+BUILD_ASSERT(sizeof(endpoint) <= CONFIG_LWM2M_SECURITY_KEY_SIZE,
+		"Client ID length is too long");
+#endif /* CONFIG_LWM2M_DTLS_SUPPORT */
+
 static struct k_sem quit_lock;
 
 static int device_reboot_cb(uint16_t obj_inst_id,


### PR DESCRIPTION
If the default which is set to CONFIG_BOARD is used, then the lwm2m client fails to set the client identity as the default maximum length allowed is only 16 and for some boards this exceeds.

So, increase the default length to accomodate almost all boards. Also add a build assert for the length validation.