### PR TITLE
tests: Clean up sensor driver build_all test

### DIFF
--- a/drivers/sensor/fdc2x1x/Kconfig
+++ b/drivers/sensor/fdc2x1x/Kconfig
@@ -7,7 +7,7 @@ menuconfig FDC2X1X
 	bool "FDC2X1X Capacitance-to-Digital Converter"
 	default y
 	depends on DT_HAS_TI_FDC2X1X_ENABLED
-	depends on NEWLIB_LIBC
+	depends on NEWLIB_LIBC || EXTERNAL_LIBC
 	select I2C
 	help
 	  Enable driver for FDC2X1X Capacitance-to-Digital Converter.

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -516,7 +516,7 @@ static int fdc2x1x_device_pm_action(const struct device *dev,
 
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
-		if (cfg->sd_gpio->port.name) {
+		if (cfg->sd_gpio.port->name) {
 			ret = fdc2x1x_set_shutdown(dev, true);
 		} else {
 			LOG_ERR("SD pin not defined");

--- a/subsys/emul/emul.c
+++ b/subsys/emul/emul.c
@@ -40,7 +40,10 @@ int emul_init_for_bus(const struct device *dev)
 	for (elp = cfg->children; elp < end; elp++) {
 		const struct emul *emul = emul_get_binding(elp->dev->name);
 
-		__ASSERT(emul, "Cannot find emulator for '%s'", elp->dev->name);
+		if (!emul) {
+			LOG_WRN("Cannot find emulator for '%s'", elp->dev->name);
+			continue;
+		}
 
 		switch (emul->bus_type) {
 		case EMUL_BUS_TYPE_I2C:

--- a/tests/drivers/build_all/sensor/app.overlay
+++ b/tests/drivers/build_all/sensor/app.overlay
@@ -48,7 +48,7 @@
 		test_i2c: i2c@11112222 {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			compatible = "vnd,i2c";
+			compatible = "zephyr,i2c-emul-controller";
 			reg = <0x11112222 0x1000>;
 			status = "okay";
 			clock-frequency = <100000>;
@@ -59,7 +59,7 @@
 		test_spi: spi@33334444 {
 			#address-cells = <1>;
 			#size-cells = <0>;
-			compatible = "vnd,spi";
+			compatible = "zephyr,spi-emul-controller";
 			reg = <0x33334444 0x1000>;
 			status = "okay";
 			clock-frequency = <2000000>;
@@ -101,35 +101,7 @@
 				   <&test_gpio 0 0>,
 				   <&test_gpio 0 0>,
 				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,	/* 0x30 */
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>;	/* 0x40 */
+				   <&test_gpio 0 0>;	/* 0x24 */
 
 			#include "spi.dtsi"
 		};

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -14,17 +14,20 @@ test_i2c_adt7420: adt7420@0 {
 	compatible = "adi,adt7420";
 	reg = <0x0>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
 test_i2c_adxl345: adxl345@1 {
 	compatible = "adi,adxl345";
 	reg = <0x1>;
+	status = "okay";
 };
 
 test_i2c_adxl372: adxl372@2 {
 	compatible = "adi,adxl372";
 	reg = <0x2>;
 	int1-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
 test_i2c_ccs811: ccs811@3 {
@@ -33,27 +36,32 @@ test_i2c_ccs811: ccs811@3 {
 	wake-gpios = <&test_gpio 0 0>;
 	reset-gpios = <&test_gpio 0 0>;
 	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
 test_i2c_ens210: ens210@4 {
 	compatible = "ams,ens210";
 	reg = <0x4>;
+	status = "okay";
 };
 
 test_i2c_iaqcore: iaqcore@5 {
 	compatible = "ams,iaqcore";
 	reg = <0x5>;
+	status = "okay";
 };
 
 test_i2c_bme280: bme280@6 {
 	compatible = "bosch,bme280";
 	reg = <0x6>;
+	status = "okay";
 };
 
 test_i2c_apds9960: apds9960@7 {
 	compatible = "avago,apds9960";
 	reg = <0x7>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
 test_i2c_bma280: bma280@8 {
@@ -61,461 +69,503 @@ test_i2c_bma280: bma280@8 {
 	reg = <0x8>;
 	int1-gpios = <&test_gpio 0 0>;
 	/* is-bmc150; */
+	status = "okay";
 };
 
 test_i2c_bmc150_magn: bmc150_magn@9 {
 	compatible = "bosch,bmc150_magn";
 	reg = <0x9>;
 	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
 test_i2c_ak8975: ak8975@a {
 	compatible = "asahi-kasei,ak8975";
 	reg = <0xa>;
+	status = "okay";
 };
 
 test_i2c_bme680: bme680@b {
 	compatible = "bosch,bme680";
 	reg = <0xb>;
+	status = "okay";
 };
 
 test_i2c_bmg160: bmg160@c {
 	compatible = "bosch,bmg160";
 	reg = <0xc>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
 test_i2c_bmm150: bmm150@d {
 	compatible = "bosch,bmm150";
 	reg = <0xd>;
+	status = "okay";
 };
 
-test_i2c_ht16k33: ht16k33@f {
-	compatible = "holtek,ht16k33";
-	reg = <0xf>;
-	#address-cells = <1>;
-	#size-cells = <0>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_i2c_hmc5883l: hmc5883l@10 {
+test_i2c_hmc5883l: hmc5883l@e {
 	compatible = "honeywell,hmc5883l";
-	reg = <0x10>;
+	reg = <0xe>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_hp206c: hp206c@11 {
+test_i2c_hp206c: hp206c@f {
 	compatible = "hoperf,hp206c";
-	reg = <0x11>;
+	reg = <0xf>;
+	status = "okay";
 };
 
-test_i2c_th02: th02@12 {
+test_i2c_th02: th02@10 {
 	compatible = "hoperf,th02";
-	reg = <0x12>;
+	reg = <0x10>;
+	status = "okay";
 };
 
-test_i2c_mpu6050: mpu6050@13 {
+test_i2c_mpu6050: mpu6050@11 {
 	compatible = "invensense,mpu6050";
-	reg = <0x13>;
+	reg = <0x11>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_mpu9250: mpu9250@14 {
+test_i2c_mpu9250: mpu9250@12 {
 	compatible = "invensense,mpu9250";
-	reg = <0x14>;
+	reg = <0x12>;
 	irq-gpios = <&test_gpio 0 0>;
 	gyro-sr-div = <10>;
 	gyro-dlpf = <5>;
 	gyro-fs = <250>;
 	accel-fs = <2>;
 	accel-dlpf="5.05";
+	status = "okay";
 };
 
-test_i2c_ina219: ina219@15 {
+test_i2c_ina219: ina219@13 {
 	compatible = "ti,ina219";
-	reg = <0x15>;
+	reg = <0x13>;
 	brng = <0>;
 	pg = <0>;
 	sadc = <13>;
 	badc = <13>;
 	shunt-milliohm = <100>;
 	lsb-microamp = <10>;
+	status = "okay";
 };
 
-test_i2c_isl29035: isl29035@16 {
+test_i2c_isl29035: isl29035@14 {
 	compatible = "isil,isl29035";
+	reg = <0x14>;
+	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
+};
+
+test_i2c_max30101: max30101@15 {
+	compatible = "maxim,max30101";
+	reg = <0x15>;
+	status = "okay";
+};
+
+test_i2c_max44009: max44009@16 {
+	compatible = "maxim,max44009";
 	reg = <0x16>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_max30101: max30101@17 {
-	compatible = "maxim,max30101";
-	reg = <0x17>;
-};
-
-test_i2c_max44009: max44009@18 {
-	compatible = "maxim,max44009";
-	reg = <0x18>;
-	int-gpios = <&test_gpio 0 0>;
-};
-
-test_i2c_ms5607: ms5607@19 {
+test_i2c_ms5607: ms5607@17 {
 	compatible = "meas,ms5607";
-	reg = <0x19>;
+	reg = <0x17>;
+	status = "okay";
 };
 
-test_i2c_ms5837: ms5837@1a {
+test_i2c_ms5837: ms5837@18 {
 	compatible = "meas,ms5837";
-	reg = <0x1a>;
+	reg = <0x18>;
+	status = "okay";
 };
 
-test_i2c_mcp9808: mcp9808@1b {
+test_i2c_mcp9808: mcp9808@19 {
 	compatible = "microchip,mcp9808";
-	reg = <0x1b>;
+	reg = <0x19>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_fxas21002: fxas21002@1c {
+test_i2c_fxas21002: fxas21002@1a {
 	compatible = "nxp,fxas21002";
-	reg = <0x1c>;
+	reg = <0x1a>;
 	int1-gpios = <&test_gpio 0 0>;
 	int2-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_fxos8700: fxos8700@1d {
+test_i2c_fxos8700: fxos8700@1b {
 	compatible = "nxp,fxos8700";
-	reg = <0x1d>;
+	reg = <0x1b>;
 	reset-gpios = <&test_gpio 0 0>;
 	int1-gpios = <&test_gpio 0 0>;
 	int2-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_pca9633: pca9633@1e {
-	compatible = "nxp,pca9633";
-	reg = <0x1e>;
-};
-
-test_i2c_amg88xx: amg88xx@1f {
+test_i2c_amg88xx: amg88xx@1c {
 	compatible = "panasonic,amg88xx";
-	reg = <0x1f>;
+	reg = <0x1c>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_sx9500: sx9500@20 {
+test_i2c_sx9500: sx9500@1d {
 	compatible = "semtech,sx9500";
-	reg = <0x20>;
+	reg = <0x1d>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_sgp40: sgp40@21 {
+test_i2c_sgp40: sgp40@1e {
 	compatible = "sensirion,sgp40";
-	reg = <0x21>;
+	reg = <0x1e>;
 	enable-selftest;
+	status = "okay";
 };
 
-test_i2c_sht3xd: sht3xd@22 {
+test_i2c_sht3xd: sht3xd@1f {
 	compatible = "sensirion,sht3xd";
-	reg = <0x22>;
+	reg = <0x1f>;
 	alert-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_sht4xd: sht4x@23 {
+test_i2c_sht4xd: sht4x@20 {
 	compatible = "sensirion,sht4x";
-	reg = <0x23>;
+	reg = <0x20>;
 	repeatability = <2>;
+	status = "okay";
 };
 
-test_i2c_shtc3: SHTC3@24 {
+test_i2c_shtc3: SHTC3@21 {
 	compatible = "sensirion,shtcx";
-	reg = <0x24>;
+	reg = <0x21>;
 	chip = "shtc3";
 	measure-mode = "normal";
 	clock-stretching;
+	status = "okay";
 };
 
-test_i2c_si7006: si7006@25 {
+test_i2c_si7006: si7006@22 {
 	compatible = "silabs,si7006";
-	reg = <0x25>;
+	reg = <0x22>;
+	status = "okay";
 };
 
-test_i2c_si7055: si7055@26 {
+test_i2c_si7055: si7055@23 {
 	compatible = "silabs,si7055";
-	reg = <0x26>;
+	reg = <0x23>;
+	status = "okay";
 };
 
-test_i2c_si7060: si7060@27 {
+test_i2c_si7060: si7060@24 {
 	compatible = "silabs,si7060";
-	reg = <0x27>;
+	reg = <0x24>;
+	status = "okay";
 };
 
-test_i2c_si7210: si7010@28 {
+test_i2c_si7210: si7010@25 {
 	compatible = "silabs,si7210";
-	reg = <0x28>;
+	reg = <0x25>;
+	status = "okay";
 };
 
-test_i2c_hts221: hts221@29 {
+test_i2c_hts221: hts221@26 {
 	compatible = "st,hts221";
+	reg = <0x26>;
+	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
+};
+
+test_i2c_iis2dlpc: iis2dlpc@27 {
+	compatible = "st,iis2dlpc";
+	reg = <0x27>;
+	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
+};
+
+test_i2c_iis2mdc: iis2mdc@28 {
+	compatible = "st,iis2mdc";
+	reg = <0x28>;
+	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
+};
+
+test_i2c_ism330dhcx: ism330dhcx@29 {
+	compatible = "st,ism330dhcx";
 	reg = <0x29>;
 	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_iis2dlpc: iis2dlpc@2a {
-	compatible = "st,iis2dlpc";
-	reg = <0x2a>;
-	drdy-gpios = <&test_gpio 0 0>;
-};
-
-test_i2c_iis2mdc: iis2mdc@2b {
-	compatible = "st,iis2mdc";
-	reg = <0x2b>;
-	drdy-gpios = <&test_gpio 0 0>;
-};
-
-test_i2c_ism330dhcx: ism330dhcx@2c {
-	compatible = "st,ism330dhcx";
-	reg = <0x2c>;
-	drdy-gpios = <&test_gpio 0 0>;
-};
-
-test_i2c_lis2dh: lis2dh@2d {
+test_i2c_lis2dh: lis2dh@2a {
 	compatible = "st,lis2dh";
+	reg = <0x2a>;
+	irq-gpios = <&test_gpio 0 0>;
+	/* disconnect-sdo-sa0-pull-up; */
+	status = "okay";
+};
+
+test_i2c_lis2dh12: lis2dh12@2b {
+	compatible = "st,lis2dh12";
+	reg = <0x2b>;
+	irq-gpios = <&test_gpio 0 0>;
+	status = "disabled";
+};
+
+test_i2c_lis2ds12: lis2ds12@2c {
+	compatible = "st,lis2ds12";
+	reg = <0x2c>;
+	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
+};
+
+test_i2c_lis2dw12: lis2dw12@2d {
+	compatible = "st,lis2dw12";
 	reg = <0x2d>;
 	irq-gpios = <&test_gpio 0 0>;
-	/* disconnect-sdo-sa0-pull-up; */
+	status = "okay";
 };
 
-test_i2c_lis2dh12: lis2dh12@2e {
-	compatible = "st,lis2dh12";
+test_i2c_lis2mdl: lis2mdl@2e {
+	compatible = "st,lis2mdl";
 	reg = <0x2e>;
 	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_lis2ds12: lis2ds12@2f {
-	compatible = "st,lis2ds12";
+test_i2c_lis3dh: lis3dh@2f {
+	compatible = "st,lis3dh";
 	reg = <0x2f>;
 	irq-gpios = <&test_gpio 0 0>;
+	status = "disabled";
 };
 
-test_i2c_lis2dw12: lis2dw12@30 {
-	compatible = "st,lis2dw12";
+test_i2c_lis3mdl_magn: lis3mdl-magn@30 {
+	compatible = "st,lis3mdl-magn";
 	reg = <0x30>;
 	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_lis2mdl: lis2mdl@31 {
-	compatible = "st,lis2mdl";
-	reg = <0x31>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_i2c_lis3dh: lis3dh@32 {
-	compatible = "st,lis3dh";
-	reg = <0x32>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_i2c_lis3mdl_magn: lis3mdl-magn@33 {
-	compatible = "st,lis3mdl-magn";
-	reg = <0x33>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_i2c_lps22hb_press: lps22hb-press@34 {
+test_i2c_lps22hb_press: lps22hb-press@31 {
 	compatible = "st,lps22hb-press";
-	reg = <0x34>;
+	reg = <0x31>;
+	status = "okay";
 };
 
-test_i2c_lps22hh: lps22hh@35 {
+test_i2c_lps22hh: lps22hh@32 {
 	compatible = "st,lps22hh";
-	reg = <0x35>;
+	reg = <0x32>;
 	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_lps25hb_press: lps25hb-press@36 {
+test_i2c_lps25hb_press: lps25hb-press@33 {
 	compatible = "st,lps25hb-press";
-	reg = <0x36>;
+	reg = <0x33>;
+	status = "okay";
 };
 
-test_i2c_lsm303agr_accel: lsm303agr-accel@37 {
+test_i2c_lsm303agr_accel: lsm303agr-accel@34 {
 	compatible = "st,lsm303agr-accel";
-	reg = <0x37>;
+	reg = <0x34>;
 	irq-gpios = <&test_gpio 0 0>;
 	/* disconnect-sdo-sa0-pull-up; */
+	status = "disabled";
 };
 
-test_i2c_lsm303dlhc_accel: lsm303dlhc-accel@38 {
+test_i2c_lsm303dlhc_accel: lsm303dlhc-accel@35 {
 	compatible = "st,lsm303dlhc-accel";
+	reg = <0x35>;
+	irq-gpios = <&test_gpio 0 0>;
+	/* disconnect-sdo-sa0-pull-up; */
+	status = "disabled";
+};
+
+test_i2c_lsm303dlhc_magn: lsm303dlhc-magn@36 {
+	compatible = "st,lsm303dlhc-magn";
+	reg = <0x36>;
+	status = "okay";
+};
+
+test_i2c_lsm6ds0: lsm6ds0@37 {
+	compatible = "st,lsm6ds0";
+	reg = <0x37>;
+	status = "okay";
+};
+
+test_i2c_lsm6dsl: lsm6dsl@38 {
+	compatible = "st,lsm6dsl";
 	reg = <0x38>;
 	irq-gpios = <&test_gpio 0 0>;
-	/* disconnect-sdo-sa0-pull-up; */
+	status = "okay";
 };
 
-test_i2c_lsm303dlhc_magn: lsm303dlhc-magn@39 {
-	compatible = "st,lsm303dlhc-magn";
+test_i2c_lsm6dso: lsm6dso@39 {
+	compatible = "st,lsm6dso";
 	reg = <0x39>;
+	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_lsm6ds0: lsm6ds0@3a {
-	compatible = "st,lsm6ds0";
+test_i2c_lsm9ds0_gyro: lsm9ds0-gyro@3a {
+	compatible = "st,lsm9ds0-gyro";
 	reg = <0x3a>;
+	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_lsm6dsl: lsm6dsl@3b {
-	compatible = "st,lsm6dsl";
+test_i2c_lsm9ds0_mfd: lsm9ds0-mfd@3b {
+	compatible = "st,lsm9ds0-mfd";
 	reg = <0x3b>;
 	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_lsm6dso: lsm6dso@3c {
-	compatible = "st,lsm6dso";
-	reg = <0x3c>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_i2c_lsm9ds0_gyro: lsm9ds0-gyro@3d {
-	compatible = "st,lsm9ds0-gyro";
-	reg = <0x3d>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_i2c_lsm9ds0_mfd: lsm9ds0-mfd@3e {
-	compatible = "st,lsm9ds0-mfd";
-	reg = <0x3e>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_i2c_stts751: stts751@3f {
+test_i2c_stts751: stts751@3c {
 	compatible = "st,stts751";
-	reg = <0x3f>;
+	reg = <0x3c>;
 	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_vl53l0x: vl53l0x@40 {
+test_i2c_vl53l0x: vl53l0x@3d {
 	compatible = "st,vl53l0x";
-	reg = <0x40>;
+	reg = <0x3d>;
 	xshut-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_hdc: hdc@41 {
+test_i2c_hdc: hdc@3e {
 	compatible = "ti,hdc";
-	reg = <0x41>;
+	reg = <0x3e>;
 	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_hdc2010: hdc2010@42 {
+test_i2c_hdc2010: hdc2010@3f {
 	compatible = "ti,hdc2010";
-	reg = <0x42>;
+	reg = <0x3f>;
+	status = "okay";
 };
 
-test_i2c_hdc2021: hdc2021@43 {
+test_i2c_hdc2021: hdc2021@40 {
 	compatible = "ti,hdc2021";
-	reg = <0x43>;
+	reg = <0x40>;
+	status = "okay";
 };
 
-test_i2c_hdc2022: hdc2022@44 {
+test_i2c_hdc2022: hdc2022@41 {
 	compatible = "ti,hdc2022";
-	reg = <0x44>;
+	reg = <0x41>;
+	status = "okay";
 };
 
-test_i2c_hdc2080: hdc2080@45 {
+test_i2c_hdc2080: hdc2080@42 {
 	compatible = "ti,hdc2080";
-	reg = <0x45>;
+	reg = <0x42>;
+	status = "okay";
 };
 
-test_i2c_lp3943: lp3943@46 {
-	compatible = "ti,lp3943";
-	reg = <0x46>;
-};
-
-test_i2c_lp5562: lp5562@47 {
-	compatible = "ti,lp5562";
-	reg = <0x47>;
-};
-
-test_i2c_opt3001: opt3001@48 {
+test_i2c_opt3001: opt3001@43 {
 	compatible = "ti,opt3001";
-	reg = <0x48>;
+	reg = <0x43>;
+	status = "okay";
 };
 
-test_i2c_tlv320dac: tlv320dac@49 {
-	compatible = "ti,tlv320dac";
-	reg = <0x49>;
-	reset-gpios = <&test_gpio 0 0>;
-};
-
-test_i2c_tmp007: tmp007@4a {
+test_i2c_tmp007: tmp007@44 {
 	compatible = "ti,tmp007";
-	reg = <0x4a>;
+	reg = <0x44>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_tmp108: tmp108@4b {
+test_i2c_tmp108: tmp108@45 {
 	compatible = "ti,tmp108";
-	reg = <0x4b>;
+	reg = <0x45>;
 	alert-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_tmp112: tmp112@4c {
+test_i2c_tmp112: tmp112@46 {
 	compatible = "ti,tmp112";
-	reg = <0x4c>;
+	reg = <0x46>;
+	status = "okay";
 };
 
-test_i2c_tmp116: tmp116@4d {
+test_i2c_tmp116: tmp116@47 {
 	compatible = "ti,tmp116";
-	reg = <0x4d>;
+	reg = <0x47>;
+	status = "okay";
 };
 
-test_i2c_bq274xx: bq27xx@4e {
+test_i2c_bq274xx: bq27xx@48 {
 	compatible = "ti,bq274xx";
-	reg = <0x4e>;
+	reg = <0x48>;
 	design-voltage = <3700>;
 	design-capacity = <1800>;
 	taper-current = <45>;
 	terminate-voltage = <3000>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_mpr: mpr@4f {
+test_i2c_mpr: mpr@49 {
 	compatible = "honeywell,mpr";
-	reg = <0x4f>;
+	reg = <0x49>;
+	status = "okay";
 };
 
-test_i2c_dps310: dps310@50 {
-		compatible = "infineon,dps310";
-		reg = <0x50>;
+test_i2c_dps310: dps310@4a {
+	compatible = "infineon,dps310";
+	reg = <0x4a>;
+	status = "okay";
 };
 
-test_i2c_iis2dh: iis2dh@51 {
+test_i2c_iis2dh: iis2dh@4b {
 	compatible = "st,iis2dh";
-	reg = <0x51>;
+	reg = <0x4b>;
 	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_iis2iclx: iis2iclx@52 {
+test_i2c_iis2iclx: iis2iclx@4c {
 	compatible = "st,iis2iclx";
-	reg = <0x52>;
+	reg = <0x4c>;
 	drdy-gpios = <&test_gpio 0 0>;
 	int-pin = <1>;
+	status = "okay";
 };
 
-test_i2c_wsen_hids: wsen_hids@53 {
+test_i2c_wsen_hids: wsen_hids@4d {
 	compatible = "we,wsen-hids";
-	reg = <0x53>;
+	reg = <0x4d>;
 	drdy-gpios = <&test_gpio 0 0>;
 	odr = "1";
+	status = "okay";
 };
 
-test_i2c_itds: itds@54 {
+test_i2c_itds: itds@4e {
 	compatible = "we,wsen-itds";
-	reg = <0x54>;
+	reg = <0x4e>;
 	int-gpios = <&test_gpio 0 0>;
 	odr = "800";
 	op-mode = "high-perf";
+	status = "okay";
 };
 
-test_i2c_max17055: max17055@55 {
+test_i2c_max17055: max17055@4f {
 	compatible = "maxim,max17055";
-	reg = <0x55>;
+	reg = <0x4f>;
 	design-capacity = <1500>;
 	design-voltage = <3860>;
 	desired-charging-current = <2000>;
@@ -523,11 +573,12 @@ test_i2c_max17055: max17055@55 {
 	i-chg-term = <100>;
 	rsense-mohms = <5>;
 	v-empty = <3300>;
+	status = "okay";
 };
 
-test_i2c_max17262: max17262@56 {
+test_i2c_max17262: max17262@50 {
 	compatible = "maxim,max17262";
-	reg = <0x56>;
+	reg = <0x50>;
 	design-voltage = <3600>;
 	desired-voltage = <3600>;
 	desired-charging-current = <2000>;
@@ -535,29 +586,34 @@ test_i2c_max17262: max17262@56 {
 	empty-voltage = <3300>;
 	recovery-voltage = <3880>;
 	charge-voltage = <3600>;
+	status = "okay";
 };
 
-test_i2c_vcnl4040: vcnl4040@57 {
+test_i2c_vcnl4040: vcnl4040@51 {
 	compatible = "vishay,vcnl4040";
-	reg = <0x57>;
+	reg = <0x51>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_bmi160: bmi160@58 {
+test_i2c_bmi160: bmi160@52 {
 	compatible = "bosch,bmi160";
-	reg = <0x58>;
+	reg = <0x52>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_bmi270: bmi270@59 {
+test_i2c_bmi270: bmi270@53 {
 	compatible = "bosch,bmi270";
-	reg = <0x59>;
+	reg = <0x53>;
+	status = "okay";
 };
 
-test_i2c_fdc2x1x: fdc2x1x@5a {
+test_i2c_fdc2x1x: fdc2x1x@54 {
 	compatible = "ti,fdc2x1x";
-	reg = <0x5a>;
+	reg = <0x54>;
 	intb-gpios = <&test_gpio 0 0>;
+	sd-gpios = <&test_gpio 0 0>;
 	deglitch = <5>;
 	fref = <43360>;
 	channel_0 {
@@ -568,109 +624,118 @@ test_i2c_fdc2x1x: fdc2x1x@5a {
 		fin-sel = <2>;
 		inductance = <18>;
 	};
+	status = "okay";
 };
 
-test_i2c_bmp388: bmp388@5b {
+test_i2c_bmp388: bmp388@55 {
 	compatible = "bosch,bmp388";
-	reg = <0x5b>;
+	reg = <0x55>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_sbc_gauge: sbsgauge@5c {
-	compatible = "sbs,sbs-gauge";
-	reg = <0x5c>;
-};
-
-test_i2c_lm75: lm75@5d {
+test_i2c_lm75: lm75@56 {
 	compatible = "lm75";
-	reg = <0x5d>;
+	reg = <0x56>;
+	status = "okay";
 };
 
-test_i2c_ina230: ina230@5e {
+test_i2c_ina230: ina230@57 {
 	compatible = "ti,ina230";
-	reg = <0x5e>;
+	reg = <0x57>;
 	config = <0>;
 	current-lsb-microamps = <1000>;
 	rshunt-micro-ohms = <1000>;
 	mask = <0>;
 	alert-limit = <0>;
 	alert-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_lm77: lm77@5f {
+test_i2c_lm77: lm77@58 {
 	compatible = "lm77";
-	reg = <0x5f>;
+	reg = <0x58>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_ina231: ina231@60 {
+test_i2c_ina231: ina231@59 {
 	compatible = "ti,ina230";
-	reg = <0x60>;
+	reg = <0x59>;
 	config = <0>;
 	current-lsb-microamps = <1000>;
 	rshunt-micro-ohms = <1000>;
 	mask = <0>;
 	alert-limit = <0>;
 	alert-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_ina237: ina237@61 {
+test_i2c_ina237: ina237@5a {
 	compatible = "ti,ina237";
-	reg = <0x61>;
+	reg = <0x5a>;
 	config = <0>;
 	current-lsb-microamps = <1000>;
 	adc-config = <0>;
 	rshunt-micro-ohms = <1000>;
 	alert-config = <0>;
 	alert-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_max31875: max31875@62 {
+test_i2c_max31875: max31875@5b {
 	compatible = "maxim,max31875";
-	reg = <0x62>;
+	reg = <0x5b>;
+	status = "okay";
 };
 
-test_i2c_icp10125: icp10125@63 {
+test_i2c_icp10125: icp10125@5c {
 	compatible = "invensense,icp10125";
-	reg = <0x63>;
+	reg = <0x5c>;
 	temperature-measurement-mode = "normal";
 	pressure-measurement-mode = "normal";
+	status = "okay";
 };
 
-test_i2c_as5600: as5600@64 {
+test_i2c_as5600: as5600@5d {
 	compatible = "ams,as5600";
-	reg = <0x64>;
+	reg = <0x5d>;
+	status = "okay";
 };
 
-test_i2c_bh1750: bh1750@65 {
+test_i2c_bh1750: bh1750@5e {
 	compatible = "rohm,bh1750";
-	reg = <0x65>;
+	reg = <0x5e>;
+	status = "okay";
 };
 
-test_i2c_akm09918c: akm09918c@66 {
+test_i2c_akm09918c: akm09918c@5f {
 	compatible = "asahi-kasei,akm09918c";
-	reg = <0x66>;
+	reg = <0x5f>;
+	status = "okay";
 };
 
-test_i2c_wsen_tids: wsen_tids@67 {
+test_i2c_wsen_tids: wsen_tids@60 {
 	compatible = "we,wsen-tids";
-	reg = <0x67>;
+	reg = <0x60>;
 	int-gpios = <&test_gpio 0 0>;
 	odr = <25>;
 	temp-high-threshold = <0>;
 	temp-low-threshold = <0>;
+	status = "okay";
 };
 
-test_i2c_vl53l1x: vl53l1x@68 {
+test_i2c_vl53l1x: vl53l1x@61 {
 	compatible = "st,vl53l1x";
-	reg = <0x68>;
+	reg = <0x61>;
 	int-gpios = <&test_gpio 0 0>;
 	xshut-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_tmd2620: tmd2620@69 {
+test_i2c_tmd2620: tmd2620@62 {
 	compatible = "ams,tmd2620";
-	reg = <0x69>;
+	reg = <0x62>;
 	int-gpios = <&test_gpio 0 0>;
 	proximity-gain = <4>;
 	proximity-pulse-length = <16>;
@@ -680,75 +745,86 @@ test_i2c_tmd2620: tmd2620@69 {
 	proximity-led-drive-strength = <4>;
 	proximity-interrupt-filter = <0>;
 	wait-time-factor = <0>;
+	status = "okay";
 };
 
-test_i2c_wsen_pads: wsen_pads@6A {
+test_i2c_wsen_pads: wsen_pads@63 {
 	compatible = "we,wsen-pads";
-	reg = <0x6A>;
+	reg = <0x63>;
 	drdy-gpios = <&test_gpio 0 0>;
 	odr = <1>;
+	status = "okay";
 };
 
-test_i2c_s11059: s11059@6b {
+test_i2c_s11059: s11059@64 {
 	compatible = "hamamatsu,s11059";
-	reg = <0x6b>;
+	reg = <0x64>;
 	integration-time = <546000>;
+	status = "okay";
 };
 
-test_i2c_wsen_pdus: wsen_pdus@6C {
+test_i2c_wsen_pdus: wsen_pdus@65 {
 	compatible = "we,wsen-pdus";
-	reg = <0x6C>;
+	reg = <0x65>;
 	sensor-type = <3>;
+	status = "okay";
 };
 
-test_i2c_veml7700: veml7700@6d {
+test_i2c_veml7700: veml7700@66 {
 	compatible = "vishay,veml7700";
-	reg = <0x6d>;
+	reg = <0x66>;
 	psm-mode = <0x03>;
+	status = "okay";
 };
 
-test_i2c_ina3221: ina3221@6e {
+test_i2c_ina3221: ina3221@67 {
 	compatible = "ti,ina3221";
-	reg = <0x6e>;
+	reg = <0x67>;
 	shunt-resistors = <1000 1000 1000>;
 	enable-channel = <1 0 0>;
 	conv-time-bus = <7>;
 	conv-time-shunt = <7>;
 	avg-mode = <2>;
+	status = "okay";
 };
 
-test_i2c_lsm6dso16is: lsm6dso16is@6f {
+test_i2c_lsm6dso16is: lsm6dso16is@68 {
 	compatible = "st,lsm6dso16is";
-	reg = <0x6f>;
+	reg = <0x68>;
 	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_lsm6dsv16x: lsm6dsv16x@70 {
+test_i2c_lsm6dsv16x: lsm6dsv16x@69 {
 	compatible = "st,lsm6dsv16x";
-	reg = <0x70>;
+	reg = <0x69>;
 	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_mcp9600: mcp9600@71 {
+test_i2c_mcp9600: mcp9600@6a {
 	compatible = "microchip,mcp9600";
-	reg = <0x71>;
+	reg = <0x6a>;
+	status = "okay";
 };
 
-test_i2c_tcs3400: tcs3400@72 {
+test_i2c_tcs3400: tcs3400@6b {
 	compatible = "ams,tcs3400";
-	reg = <0x72>;
+	reg = <0x6b>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_tcn75a: tcn75a@73 {
+test_tcn75a: tcn75a@6c {
 	compatible = "microchip,tcn75a";
-	reg = <0x73>;
+	reg = <0x6c>;
 	alert-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_i2c_bmi08x_accel: bmi08x@74 {
+test_i2c_bmi08x_accel: bmi08x@6d {
 	compatible = "bosch,bmi08x-accel";
-	reg = <0x74>;
+	reg = <0x6d>;
 	int-gpios = <&test_gpio 0 0>;
 	int1-map-io = <0x01>;
 	int2-map-io = <0x00>;
@@ -758,9 +834,9 @@ test_i2c_bmi08x_accel: bmi08x@74 {
 	accel-fs = <4>;
 };
 
-test_i2c_bmi08x_gyro: bmi08x@75 {
+test_i2c_bmi08x_gyro: bmi08x@6e {
 	compatible = "bosch,bmi08x-gyro";
-	reg = <0x75>;
+	reg = <0x6e>;
 	int-gpios = <&test_gpio 0 0>;
 	int3-4-map-io = <0x01>;
 	int3-4-conf-io = <0x01>;

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -15,6 +15,7 @@ test_spi_adxl362: adxl362@0 {
 	reg = <0x0>;
 	spi-max-frequency = <0>;
 	int1-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
 test_spi_adxl372: adxl372@1 {
@@ -22,383 +23,282 @@ test_spi_adxl372: adxl372@1 {
 	reg = <0x1>;
 	spi-max-frequency = <0>;
 	int1-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_apa102: apa102@2 {
-	compatible = "apa,apa102";
+test_spi_bme280: bme280@2 {
+	compatible = "bosch,bme280";
 	reg = <0x2>;
 	spi-max-frequency = <0>;
+	status = "okay";
 };
 
-test_spi_rf2xx: rf2xx@3 {
-	compatible = "atmel,rf2xx";
+test_spi_bmi160: bmi160@3 {
+	compatible = "bosch,bmi160";
 	reg = <0x3>;
 	spi-max-frequency = <0>;
-	irq-gpios = <&test_gpio 0 0>;
-	reset-gpios = <&test_gpio 0 0>;
-	slptr-gpios = <&test_gpio 0 0>;
-	dig2-gpios = <&test_gpio 0 0>;
-	clkm-gpios = <&test_gpio 0 0>;
+	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_winc1500: winc1500@4 {
-	compatible = "atmel,winc1500";
+test_spi_ms5607: ms5607@4 {
+	compatible = "meas,ms5607";
 	reg = <0x4>;
 	spi-max-frequency = <0>;
-	irq-gpios = <&test_gpio 0 0>;
-	reset-gpios = <&test_gpio 0 0>;
-	enable-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_bme280: bme280@5 {
-	compatible = "bosch,bme280";
+test_spi_iis2dlpc: iis2dlpc@5 {
+	compatible = "st,iis2dlpc";
 	reg = <0x5>;
 	spi-max-frequency = <0>;
+	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_bmi160: bmi160@6 {
-	compatible = "bosch,bmi160";
+test_spi_iis2mdc: iis2mdc@6 {
+	compatible = "st,iis2mdc";
 	reg = <0x6>;
 	spi-max-frequency = <0>;
-	int-gpios = <&test_gpio 0 0>;
+	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_lpd8803: lpd8803@7 {
-	compatible = "greeled,lpd8803";
+test_spi_iis3dhhc: iis3dhhc@7 {
+	compatible = "st,iis3dhhc";
 	reg = <0x7>;
 	spi-max-frequency = <0>;
+	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_lpd8806: lpd8806@8 {
-	compatible = "greeled,lpd8806";
+test_spi_ism330dhcx: ism330dhcx@8 {
+	compatible = "st,ism330dhcx";
 	reg = <0x8>;
 	spi-max-frequency = <0>;
+	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_uc8176: uc8176@9 {
-	compatible = "ultrachip,uc8176";
+test_spi_lis2dh: lis2dh@9 {
+	compatible = "st,lis2dh";
 	reg = <0x9>;
 	spi-max-frequency = <0>;
-	height = <0>;
-	width = <0>;
-	reset-gpios = <&test_gpio 0 0>;
-	dc-gpios = <&test_gpio 0 0>;
-	busy-gpios = <&test_gpio 0 0>;
+	irq-gpios = <&test_gpio 0 0>;
+	/* disconnect-sdo-sa0-pull-up; */
+	status = "okay";
 };
 
-test_spi_uc8179: uc8179@a {
-	compatible = "ultrachip,uc8179";
+test_spi_lis2ds12: lis2ds12@a {
+	compatible = "st,lis2ds12";
 	reg = <0xa>;
 	spi-max-frequency = <0>;
-	height = <0>;
-	width = <0>;
-	reset-gpios = <&test_gpio 0 0>;
-	dc-gpios = <&test_gpio 0 0>;
-	busy-gpios = <&test_gpio 0 0>;
-	softstart = [];
-	full {
-		pwr = [];
-		cdi = <0>;
-		tcon = <0>;
-	};
-	partial {
-		pwr = [];
-		cdi = <0>;
-		tcon = <0>;
-	};
+	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_eswifi: eswifi@b {
-	compatible = "inventek,eswifi";
+test_spi_lis2dw12: lis2dw12@b {
+	compatible = "st,lis2dw12";
 	reg = <0xb>;
 	spi-max-frequency = <0>;
-	resetn-gpios = <&test_gpio 0 0>;
-	data-gpios = <&test_gpio 0 0>;
-	wakeup-gpios = <&test_gpio 0 0>;
-	boot0-gpios = <&test_gpio 0 0>;
+	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_spi_nor: spi-nor@c {
-	compatible = "jedec,spi-nor";
+test_spi_lis2mdl: lis2mdl@c {
+	compatible = "st,lis2mdl";
 	reg = <0xc>;
 	spi-max-frequency = <0>;
-	wp-gpios = <&test_gpio 0 0>;
-	hold-gpios = <&test_gpio 0 0>;
-	reset-gpios = <&test_gpio 0 0>;
-	jedec-id = [];
-	/* requires-ulbpr; */
-	/* has-dpd; */
-	size = <0>;
+	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_ms5607: ms5607@d {
-	compatible = "meas,ms5607";
+test_spi_lps22hh: lps22hh@d {
+	compatible = "st,lps22hh";
 	reg = <0xd>;
 	spi-max-frequency = <0>;
+	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_mcr20a: mcr20a@e {
-	compatible = "nxp,mcr20a";
+test_spi_lsm303agr_accel: lsm303agr-accel@e {
+	compatible = "st,lsm303agr-accel";
 	reg = <0xe>;
 	spi-max-frequency = <0>;
-	irqb-gpios = <&test_gpio 0 0>;
-	reset-gpios = <&test_gpio 0 0>;
+	irq-gpios = <&test_gpio 0 0>;
+	/* disconnect-sdo-sa0-pull-up; */
+	status = "disabled";
 };
 
-test_spi_sx1276: sx1276@f {
-	compatible = "semtech,sx1276";
+test_spi_lsm6dsl: lsm6dsl@f {
+	compatible = "st,lsm6dsl";
 	reg = <0xf>;
 	spi-max-frequency = <0>;
-	reset-gpios = <&test_gpio 0 0>;
-	dio-gpios = <&test_gpio 0 0>;
-	power-amplifier-output = "rfo";
+	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_iis2dlpc: iis2dlpc@10 {
-	compatible = "st,iis2dlpc";
+test_spi_lsm6dso: lsm6dso@10 {
+	compatible = "st,lsm6dso";
 	reg = <0x10>;
 	spi-max-frequency = <0>;
-	drdy-gpios = <&test_gpio 0 0>;
+	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_iis2mdc: iis2mdc@11 {
-	compatible = "st,iis2mdc";
+test_spi_iis2dh: iis2dh@11 {
+	compatible = "st,iis2dh";
 	reg = <0x11>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_iis3dhhc: iis3dhhc@12 {
-	compatible = "st,iis3dhhc";
-	reg = <0x12>;
-	spi-max-frequency = <0>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_spi_ism330dhcx: ism330dhcx@13 {
-	compatible = "st,ism330dhcx";
-	reg = <0x13>;
-	spi-max-frequency = <0>;
-	drdy-gpios = <&test_gpio 0 0>;
-};
-
-test_spi_lis2dh: lis2dh@14 {
-	compatible = "st,lis2dh";
-	reg = <0x14>;
-	spi-max-frequency = <0>;
-	irq-gpios = <&test_gpio 0 0>;
-	/* disconnect-sdo-sa0-pull-up; */
-};
-
-test_spi_lis2ds12: lis2ds12@15 {
-	compatible = "st,lis2ds12";
-	reg = <0x15>;
-	spi-max-frequency = <0>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_spi_lis2dw12: lis2dw12@16 {
-	compatible = "st,lis2dw12";
-	reg = <0x16>;
-	spi-max-frequency = <0>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_spi_lis2mdl: lis2mdl@17 {
-	compatible = "st,lis2mdl";
-	reg = <0x17>;
-	spi-max-frequency = <0>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_spi_lps22hh: lps22hh@18 {
-	compatible = "st,lps22hh";
-	reg = <0x18>;
-	spi-max-frequency = <0>;
-	drdy-gpios = <&test_gpio 0 0>;
-};
-
-test_spi_lsm303agr_accel: lsm303agr-accel@19 {
-	compatible = "st,lsm303agr-accel";
-	reg = <0x19>;
-	spi-max-frequency = <0>;
-	irq-gpios = <&test_gpio 0 0>;
-	/* disconnect-sdo-sa0-pull-up; */
-};
-
-test_spi_lsm6dsl: lsm6dsl@1a {
-	compatible = "st,lsm6dsl";
-	reg = <0x1a>;
-	spi-max-frequency = <0>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_spi_lsm6dso: lsm6dso@1b {
-	compatible = "st,lsm6dso";
-	reg = <0x1b>;
-	spi-max-frequency = <0>;
-	irq-gpios = <&test_gpio 0 0>;
-};
-
-test_spi_ws2812_spi: ws2812-spi@1c {
-	compatible = "worldsemi,ws2812-spi";
-	reg = <0x1c>;
-	spi-max-frequency = <0>;
-	spi-one-frame = <0>;
-	spi-zero-frame = <0>;
-	chain-length = <0>;
-	color-mapping = <0 0 0>;
-};
-
-test_spi_bt_hci_spi: bt-hci-spi@1d {
-	compatible = "zephyr,bt-hci-spi";
-	reg = <0x1d>;
-	spi-max-frequency = <0>;
-	irq-gpios = <&test_gpio 0 0>;
-	reset-gpios = <&test_gpio 0 0>;
-};
-
-test_spi_mmc_spi_slot: mmc-spi-slot@1e {
-	compatible = "zephyr,mmc-spi-slot";
-	reg = <0x1e>;
-	spi-max-frequency = <0>;
-};
-
-test_spi_iis2dh: iis2dh@1f {
-	compatible = "st,iis2dh";
-	reg = <0x1f>;
-	spi-max-frequency = <0>;
-	drdy-gpios = <&test_gpio 0 0>;
-};
-
-test_spi_iis2iclx: iis2iclx@20 {
+test_spi_iis2iclx: iis2iclx@12 {
 	compatible = "st,iis2iclx";
-	reg = <0x20>;
+	reg = <0x12>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
 	int-pin = <1>;
+	status = "okay";
 };
 
-test_spi_icm42605: icm42605@21 {
+test_spi_icm42605: icm42605@13 {
 	compatible = "invensense,icm42605";
-	reg = <0x21>;
+	reg = <0x13>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_max6675: max6675@22 {
+test_spi_max6675: max6675@14 {
 	compatible = "maxim,max6675";
-	reg = <0x22>;
+	reg = <0x14>;
 	spi-max-frequency = <0>;
+	status = "okay";
 };
 
-test_spi_bmi270: bmi270@23 {
+test_spi_bmi270: bmi270@15 {
 	compatible = "bosch,bmi270";
-	reg = <0x23>;
+	reg = <0x15>;
 	spi-max-frequency = <0>;
+	status = "okay";
 };
 
-test_spi_bmp388: bmp388@24 {
+test_spi_bmp388: bmp388@16 {
 	compatible = "bosch,bmp388";
-	reg = <0x24>;
+	reg = <0x16>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_i3g4250d: i3g4250d@25 {
+test_spi_i3g4250d: i3g4250d@17 {
 	compatible = "st,i3g4250d";
-	reg = <0x25>;
+	reg = <0x17>;
 	spi-max-frequency = <0>;
+	status = "okay";
 };
 
-test_spi_icm42670: icm42670@26 {
+test_spi_icm42670: icm42670@18 {
 	compatible = "invensense,icm42670";
-	reg = <0x26>;
+	reg = <0x18>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
 	accel-hz = <800>;
 	accel-fs = <16>;
 	gyro-hz = <800>;
 	gyro-fs = <2000>;
+	status = "okay";
 };
 
-test_spi_bme680: bme680@27 {
+test_spi_bme680: bme680@19 {
 	compatible = "bosch,bme680";
-	reg = <0x27>;
+	reg = <0x19>;
 	spi-max-frequency = <0>;
+	status = "okay";
 };
 
-test_spi_icm426888: icm42688@28 {
+test_spi_icm426888: icm42688@1a {
 	compatible = "invensense,icm42688";
-	reg = <0x28>;
+	reg = <0x1a>;
 	spi-max-frequency = <24000000>;
 	accel-hz = <32000>;
 	accel-fs = <16>;
 	gyro-hz = <32000>;
 	gyro-fs = <2000>;
+	status = "okay";
 };
 
-test_spi_max31855: max31855@29 {
+test_spi_max31855: max31855@1b {
 	compatible = "maxim,max31855";
-	reg = <0x29>;
+	reg = <0x1b>;
 	spi-max-frequency = <0>;
+	status = "okay";
 };
 
-test_spi_max31865: max31865@2a {
+test_spi_max31865: max31865@1c {
 	compatible = "maxim,max31865";
-	reg = <0x2a>;
+	reg = <0x1c>;
 	spi-max-frequency = <125000>;
 	resistance-at-zero = <100>;
 	resistance-reference = <430>;
 	low-threshold = <6579>;
 	high-threshold = <32767>;
 	filter-50hz;
+	status = "okay";
 };
 
-test_spi_bmm150: bmm150@2b {
+test_spi_bmm150: bmm150@1d {
 	compatible = "bosch,bmm150";
-	reg = <0x2b>;
+	reg = <0x1d>;
 	spi-max-frequency = <0>;
+	status = "okay";
 };
 
-test_spi_hts221: hts221@2c {
+test_spi_hts221: hts221@1e {
 	compatible = "st,hts221";
-	reg = <0x2c>;
+	reg = <0x1e>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_adt7310: adt7310@2d {
+test_spi_adt7310: adt7310@1f {
 	compatible = "adi,adt7310";
-	reg = <0x2d>;
+	reg = <0x1f>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_bmi323: bmi323@2e {
+test_spi_bmi323: bmi323@20 {
 	compatible = "bosch,bmi323";
-	reg = <0x2e>;
+	reg = <0x20>;
 	spi-max-frequency = <8000000>;
 	int-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_lsm6dso16is: lsm6dso16is@2f {
+test_spi_lsm6dso16is: lsm6dso16is@21 {
 	compatible = "st,lsm6dso16is";
-	reg = <0x2f>;
+	reg = <0x21>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_lsm6dsv16x: lsm6dsv16x@30 {
+test_spi_lsm6dsv16x: lsm6dsv16x@22 {
 	compatible = "st,lsm6dsv16x";
-	reg = <0x30>;
+	reg = <0x22>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
+	status = "okay";
 };
 
-test_spi_bmi08x_accel: bmi08x@31 {
+test_spi_bmi08x_accel: bmi08x@23 {
 	compatible = "bosch,bmi08x-accel";
-	reg = <0x31>;
+	reg = <0x23>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
 	int1-map-io = <0x01>;
@@ -409,9 +309,9 @@ test_spi_bmi08x_accel: bmi08x@31 {
 	accel-fs = <4>;
 };
 
-test_spi_bmi08x_gyro: bmi08x@32 {
+test_spi_bmi08x_gyro: bmi08x@24 {
 	compatible = "bosch,bmi08x-gyro";
-	reg = <0x32>;
+	reg = <0x24>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
 	int3-4-map-io = <0x01>;


### PR DESCRIPTION
This PR performs a few cleanup actions for the build-all sensor driver
test:

   1. Remove many non-sensors from the test's device tree, including
      wireless radios, LED strips, flash memory, and displays. These
      devices don't belong in this test and in most cases were not being
      compiled anyways due to missing config flags and not being
      status-okay.
   2. For the remaining devices, enable them in the device tree so the
      sensors build and get instantiated. A handful of device nodes that
      caused linker errors due to the driver not instantiating are left
      disabled.
   3. Convert the test's I2C and SPI buses into emulated buses to support
      upcoming live testing over these sensor devices against emulators.
   4. Allow emulators to be missing when adding devices to emulated buses
      instead of panicking.
   6. Some quick fixes to the FDC2x1x driver to enable it to build
      successfully.

Please see individual commit messages for more details on each change.