### PR TITLE
tests: drivers: adc: support sampling more than 2 channels with test

### DIFF
--- a/tests/drivers/adc/adc_api/boards/lpcxpresso55s69_cpu0.overlay
+++ b/tests/drivers/adc/adc_api/boards/lpcxpresso55s69_cpu0.overlay
@@ -8,7 +8,7 @@
 
 / {
 	zephyr,user {
-		io-channels = <&adc0 0>, <&adc0 1>;
+		io-channels = <&adc0 0>, <&adc0 1>, <&adc0 2>;
 	};
 };
 
@@ -16,21 +16,45 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
+	/*
+	 * Channel 0 is used in single ended mode, with 12 bit resolution
+	 * CH0A is routed to P19 pin 4
+	 */
 	channel@0 {
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
-		zephyr,resolution = <12>;
-                zephyr,input-positive = <MCUX_LPADC_CH0A>;
+		zephyr,resolution = <13>;
+		zephyr,input-positive = <MCUX_LPADC_CH0A>;
 	};
 
+	/*
+	 * Channel 1 is used in single ended mode, with 16 bit resolution
+	 * CH4A is routed to P17 pin 19
+	 */
 	channel@1 {
 		reg = <1>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <16>;
+		zephyr,input-positive = <MCUX_LPADC_CH4A>;
+	};
+
+	/*
+	 * Channel 2 is used in single ended mode, with 12 bit resolution
+	 * CH4B is routed to P18 pin 1
+	 */
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-                zephyr,input-positive = <MCUX_LPADC_CH1A>;
+		zephyr,input-positive = <MCUX_LPADC_CH4B>;
 	};
 };

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -255,12 +255,12 @@ static enum adc_action repeated_samplings_callback(const struct device *dev,
 	++m_samplings_done;
 	TC_PRINT("%s: done %d\n", __func__, m_samplings_done);
 	if (m_samplings_done == 1U) {
-		check_samples(adc_channels_count);
+		check_samples(MIN(adc_channels_count, 2));
 
 		/* After first sampling continue normally. */
 		return ADC_ACTION_CONTINUE;
 	} else {
-		check_samples(2 * adc_channels_count);
+		check_samples(2 * MIN(adc_channels_count, 2));
 
 		/*
 		 * The second sampling is repeated 9 times (the samples are


### PR DESCRIPTION
Support sampling more than 2 channels using the ADC API test. This requires updates to the repeated samplings test, which samples using 2 channels even when more channels are defined by the ADC test overlay.