### PR TITLE
[Backport v3.4-branch] drivers: lpadc: fix ADC command chaining

### DIFF
--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -238,8 +238,8 @@ static int mcux_lpadc_start_read(const struct device *dev,
 			} else {
 				/* End of chain */
 				data->cmd_config[channel].chainedNextCommandNumber = 0;
-				last_enabled = channel;
 			}
+			last_enabled = channel;
 			LPADC_SetConvCommandConfig(config->base,
 				channel + 1, &data->cmd_config[channel]);
 		}


### PR DESCRIPTION
Backport of #60111. @tyalie, hope this is alright with you. Just wanted to fix this regression in the release it was introduced with.

Fixes #60277