### PR TITLE
net: lib: tls_credentials: earlier initialisation

### DIFF
--- a/subsys/net/lib/tls_credentials/tls_credentials.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials.c
@@ -24,7 +24,7 @@ static int credentials_init(void)
 
 	return 0;
 }
-SYS_INIT(credentials_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(credentials_init, POST_KERNEL, 0);
 
 static struct tls_credential *unused_credential_get(void)
 {

--- a/subsys/net/lib/tls_credentials/tls_credentials_trusted.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_trusted.c
@@ -164,7 +164,7 @@ static int credentials_init(void)
 
 	return 0;
 }
-SYS_INIT(credentials_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(credentials_init, POST_KERNEL, 0);
 
 static struct tls_credential *unused_credential_get(void)
 {


### PR DESCRIPTION
The TLS credentials libraries are purely software constructs with no external dependencies, run them immediately after the kernel setup to allow other initialisation functions to add credentials without the requirement to run in the back half of the `APPLICATION` priority.