### PR TITLE
dts: arm: silabs: Fix efr32bg22 usart node

### DIFF
--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -109,11 +109,8 @@
 			compatible = "silabs,gecko-spi-usart";
 			reg = <0x5005C000 0x400>;
 			interrupt-names = "rx", "tx";
-			status = "disabled";
-
 			#address-cells = <1>;
 			#size-cells = <0>;
-
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Remove duplicated property and unnecessary newlines.