### PR TITLE
drivers: spi: fix CS documentation

### DIFF
--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -280,34 +280,37 @@ typedef uint16_t spi_operation_t;
 
 /**
  * @brief SPI controller configuration structure
- *
- * @param frequency is the bus frequency in Hertz
- * @param operation is a bit field with the following parts:
- *
- *     operational mode    [ 0 ]       - master or slave.
- *     mode                [ 1 : 3 ]   - Polarity, phase and loop mode.
- *     transfer            [ 4 ]       - LSB or MSB first.
- *     word_size           [ 5 : 10 ]  - Size of a data frame in bits.
- *     duplex              [ 11 ]      - full/half duplex.
- *     cs_hold             [ 12 ]      - Hold on the CS line if possible.
- *     lock_on             [ 13 ]      - Keep resource locked for the caller.
- *     cs_active_high      [ 14 ]      - Active high CS logic.
- *     format              [ 15 ]      - Motorola or TI frame format (optional).
- * if @kconfig{CONFIG_SPI_EXTENDED_MODES} is defined:
- *     lines               [ 16 : 17 ] - MISO lines: Single/Dual/Quad/Octal.
- *     reserved            [ 18 : 31 ] - reserved for future use.
- * @param slave is the slave number from 0 to host controller slave limit.
- * @param cs GPIO chip-select line (optional, must be initialized to zero if not
- *           used).
- * @warning Most drivers use pointer comparison to determine whether a
- * passed configuration is different from one used in a previous
- * transaction.  Changes to fields in the structure may not be
- * detected.
  */
 struct spi_config {
-	uint32_t		frequency;
-	spi_operation_t		operation;
-	uint16_t		slave;
+	/** @brief Bus frequency in Hertz. */
+	uint32_t frequency;
+	/**
+	 * @brief Operation flags.
+	 *
+	 * It is a bit field with the following parts:
+	 *
+	 * - 0:      Master or slave.
+	 * - 1..3:   Polarity, phase and loop mode.
+	 * - 4:      LSB or MSB first.
+	 * - 5..10:  Size of a data frame in bits.
+	 * - 11:     Full/half duplex.
+	 * - 12:     Hold on the CS line if possible.
+	 * - 13:     Keep resource locked for the caller.
+	 * - 14:     Active high CS logic.
+	 * - 15:     Motorola or TI frame format (optional).
+	 *
+	 * If @kconfig{CONFIG_SPI_EXTENDED_MODES} is enabled:
+	 *
+	 * - 16..17: MISO lines (Single/Dual/Quad/Octal).
+	 * - 18..31: Reserved for future use.
+	 */
+	spi_operation_t operation;
+	/** @brief Slave number from 0 to host controller slave limit. */
+	uint16_t slave;
+	/**
+	 * @brief GPIO chip-select line (optional, must be initialized to zero
+	 * if not used).
+	 */
 	struct spi_cs_control cs;
 };
 

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -269,6 +269,16 @@ struct spi_cs_control {
 	SPI_CS_CONTROL_INIT(DT_DRV_INST(inst), delay_)
 
 /**
+ * @typedef spi_operation_t
+ * Opaque type to hold the SPI operation flags.
+ */
+#if defined(CONFIG_SPI_EXTENDED_MODES)
+typedef uint32_t spi_operation_t;
+#else
+typedef uint16_t spi_operation_t;
+#endif
+
+/**
  * @brief SPI controller configuration structure
  *
  * @param frequency is the bus frequency in Hertz
@@ -296,15 +306,8 @@ struct spi_cs_control {
  */
 struct spi_config {
 	uint32_t		frequency;
-#if defined(CONFIG_SPI_EXTENDED_MODES)
-	uint32_t		operation;
+	spi_operation_t		operation;
 	uint16_t		slave;
-	uint16_t		_unused;
-#else
-	uint16_t		operation;
-	uint16_t		slave;
-#endif /* CONFIG_SPI_EXTENDED_MODES */
-
 	struct spi_cs_control cs;
 };
 

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -287,8 +287,8 @@ struct spi_cs_control {
  *     lines               [ 16 : 17 ] - MISO lines: Single/Dual/Quad/Octal.
  *     reserved            [ 18 : 31 ] - reserved for future use.
  * @param slave is the slave number from 0 to host controller slave limit.
- * @param cs is a valid pointer on a struct spi_cs_control is CS line is
- *    emulated through a gpio line, or NULL otherwise.
+ * @param cs GPIO chip-select line (optional, must be initialized to zero if not
+ *           used).
  * @warning Most drivers use pointer comparison to determine whether a
  * passed configuration is different from one used in a previous
  * transaction.  Changes to fields in the structure may not be
@@ -314,10 +314,6 @@ struct spi_config {
  * This helper macro expands to a static initializer for a <tt>struct
  * spi_config</tt> by reading the relevant @p frequency, @p slave, and
  * @p cs data from the devicetree.
- *
- * Important: the @p cs field is initialized using
- * SPI_CS_CONTROL_INIT(). The @p gpio_dev value pointed to by this
- * structure must be checked using device_is_ready() before use.
  *
  * @param node_id Devicetree node identifier for the SPI device whose
  *                struct spi_config to create an initializer for


### PR DESCRIPTION
`spi_cs_control` `cs` field is no longer a pointer, but a struct member. Clarify it must be zero-initialized if not used. Remove confusing comment about the need to use `device_is_ready()` on `cs` field, `spi_is_ready_dt()` is the only thing users need to do.