### PR TITLE
mgmt: ec_host_cmd: fix init of npxc shi backend

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
@@ -687,7 +687,9 @@ static void shi_npcx_reset_prepare(const struct device *dev)
 	data->tx_msg = data->out_msg;
 	data->rx_buf = inst->IBUF;
 	data->tx_buf = inst->OBUF;
-	data->rx_ctx->len = 0;
+	if (data->rx_ctx) {
+		data->rx_ctx->len = 0;
+	}
 	data->sz_sending = 0;
 	data->sz_request = 0;
 	data->sz_response = 0;


### PR DESCRIPTION
Make sure not to access not assigned pointer at the begining of the initialization.