### PR TITLE
drivers: intel: ssp: delay initialization after dma

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -2280,7 +2280,7 @@ static const char irq_name_level5_z[] = "level5";
 			ssp_init, PM_DEVICE_DT_INST_GET(n),		\
 			&dai_intel_ssp_data_##n,			\
 			&dai_intel_ssp_config_##n,			\
-			POST_KERNEL, 32,				\
+			POST_KERNEL, 42,				\
 			&dai_intel_ssp_api_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(DAI_INTEL_SSP_DEVICE_INIT)


### PR DESCRIPTION
The SSP driver depends on DMA as there are references in the devicetree, but it currently initialize before the DMA driver itself. This is exposed by the build time priority checking
(CONFIG_CHECK_INIT_PRIORITIES=y) and shows up as:

```
ERROR: /soc/ssp@77a00 POST_KERNEL 32 < /soc/dma@7c000 POST_KERNEL 40
ERROR: /soc/ssp@77800 POST_KERNEL 32 < /soc/dma@7c000 POST_KERNEL 40
ERROR: /soc/ssp@77600 POST_KERNEL 32 < /soc/dma@7c000 POST_KERNEL 40
...
```

Bumping up the SSP priority so the initialization is in sync with the devicetree node hirearchy.