### PR TITLE
emul: doc: Fix SBS Gauge emulator doc typos

### DIFF
--- a/include/zephyr/drivers/emul_fuel_gauge.h
+++ b/include/zephyr/drivers/emul_fuel_gauge.h
@@ -22,7 +22,7 @@ extern "C" {
 
 /**
  * @brief Fuel gauge backend emulator APIs
- * @defgroup fuel_gauge_emulator_backend fuel gauge backed emulator APIs
+ * @defgroup fuel_gauge_emulator_backend Fuel gauge backend emulator APIs
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
Capitalized group name to preserve alphabetical order in device driver APIs list, and fixed minor typo (backed->backend)