### PR TITLE
samples: subsys: display: Add RK055HDMIPI4M shield testcase to LVGL

### DIFF
--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -19,3 +19,23 @@ tests:
       - lvgl
     integration_platforms:
       - native_posix_64
+  sample.display.lvgl.rk055hdmipi4m:
+    # This sample is intended to test the RT1170 and RT595, which require
+    # a display shield to work with LVGL
+    min_flash: 250
+    # The minimum RAM needed for this display is actually around 8MB,
+    # but the RT595 uses external PSRAM for the display buffer
+    min_ram: 32
+    harness: none
+    tags:
+      - samples
+      - display
+      - gui
+    modules:
+      - lvgl
+    extra_args: SHIELD="rk055hdmipi4m"
+    platform_allow:
+      - mimxrt1170_evk_cm7
+      - mimxrt595_evk_cm33
+    integration_platforms:
+      - mimxrt1170_evk_cm7


### PR DESCRIPTION
Add RK055HDMIPI4M specific testcase to LVGL. This allows LVGL to be verified on the RT1170 and RT595 EVKs from NXP, which support LVGL using this shield.