### PR TITLE
Fixes for ATT timeout

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2993,11 +2993,13 @@ static void att_chan_detach(struct bt_att_chan *chan)
 
 static void att_timeout(struct k_work *work)
 {
+	char addr[BT_ADDR_LE_STR_LEN];
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct bt_att_chan *chan = CONTAINER_OF(dwork, struct bt_att_chan,
 						timeout_work);
 
-	LOG_ERR("ATT Timeout");
+	bt_addr_le_to_str(bt_conn_get_dst(chan->att->conn), addr, sizeof(addr));
+	LOG_ERR("ATT Timeout for device %s", addr);
 
 	/* BLUETOOTH SPECIFICATION Version 4.2 [Vol 3, Part F] page 480:
 	 *

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1036,7 +1036,7 @@ static uint8_t att_find_info_rsp(struct bt_att_chan *chan, uint16_t start_handle
 
 	data.buf = bt_att_create_pdu(conn, BT_ATT_OP_FIND_INFO_RSP, 0);
 	if (!data.buf) {
-		return BT_ATT_ERR_UNLIKELY;
+		return BT_ATT_ERR_INSUFFICIENT_RESOURCES;
 	}
 
 	data.chan = chan;
@@ -1192,7 +1192,7 @@ static uint8_t att_find_type_rsp(struct bt_att_chan *chan, uint16_t start_handle
 
 	data.buf = bt_att_create_pdu(conn, BT_ATT_OP_FIND_TYPE_RSP, 0);
 	if (!data.buf) {
-		return BT_ATT_ERR_UNLIKELY;
+		return BT_ATT_ERR_INSUFFICIENT_RESOURCES;
 	}
 
 	data.chan = chan;
@@ -1425,7 +1425,7 @@ static uint8_t att_read_type_rsp(struct bt_att_chan *chan, struct bt_uuid *uuid,
 	data.buf = bt_att_create_pdu(conn, BT_ATT_OP_READ_TYPE_RSP,
 				     sizeof(*data.rsp));
 	if (!data.buf) {
-		return BT_ATT_ERR_UNLIKELY;
+		return BT_ATT_ERR_INSUFFICIENT_RESOURCES;
 	}
 
 	data.chan = chan;
@@ -1549,7 +1549,7 @@ static uint8_t att_read_rsp(struct bt_att_chan *chan, uint8_t op, uint8_t rsp,
 
 	data.buf = bt_att_create_pdu(conn, rsp, 0);
 	if (!data.buf) {
-		return BT_ATT_ERR_UNLIKELY;
+		return BT_ATT_ERR_INSUFFICIENT_RESOURCES;
 	}
 
 	data.chan = chan;
@@ -1624,7 +1624,7 @@ static uint8_t att_read_mult_req(struct bt_att_chan *chan, struct net_buf *buf)
 
 	data.buf = bt_att_create_pdu(conn, BT_ATT_OP_READ_MULT_RSP, 0);
 	if (!data.buf) {
-		return BT_ATT_ERR_UNLIKELY;
+		return BT_ATT_ERR_INSUFFICIENT_RESOURCES;
 	}
 
 	data.chan = chan;
@@ -1724,7 +1724,7 @@ static uint8_t att_read_mult_vl_req(struct bt_att_chan *chan, struct net_buf *bu
 
 	data.buf = bt_att_create_pdu(conn, BT_ATT_OP_READ_MULT_VL_RSP, 0);
 	if (!data.buf) {
-		return BT_ATT_ERR_UNLIKELY;
+		return BT_ATT_ERR_INSUFFICIENT_RESOURCES;
 	}
 
 	data.chan = chan;
@@ -1849,7 +1849,7 @@ static uint8_t att_read_group_rsp(struct bt_att_chan *chan, struct bt_uuid *uuid
 	data.buf = bt_att_create_pdu(conn, BT_ATT_OP_READ_GROUP_RSP,
 				     sizeof(*data.rsp));
 	if (!data.buf) {
-		return BT_ATT_ERR_UNLIKELY;
+		return BT_ATT_ERR_INSUFFICIENT_RESOURCES;
 	}
 
 	data.chan = chan;
@@ -1995,7 +1995,7 @@ static uint8_t att_write_rsp(struct bt_att_chan *chan, uint8_t req, uint8_t rsp,
 	if (rsp) {
 		data.buf = bt_att_chan_create_pdu(chan, rsp, 0);
 		if (!data.buf) {
-			return BT_ATT_ERR_UNLIKELY;
+			return BT_ATT_ERR_INSUFFICIENT_RESOURCES;
 		}
 	}
 
@@ -2140,7 +2140,7 @@ static uint8_t att_prep_write_rsp(struct bt_att_chan *chan, uint16_t handle,
 	/* Generate response */
 	data.buf = bt_att_create_pdu(conn, BT_ATT_OP_PREPARE_WRITE_RSP, 0);
 	if (!data.buf) {
-		return BT_ATT_ERR_UNLIKELY;
+		return BT_ATT_ERR_INSUFFICIENT_RESOURCES;
 	}
 
 	rsp = net_buf_add(data.buf, sizeof(*rsp));

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -103,6 +103,7 @@ struct bt_att_chan {
 	ATOMIC_DEFINE(flags, ATT_NUM_FLAGS);
 	struct bt_att_req	*req;
 	struct k_fifo		tx_queue;
+	struct net_buf		*rsp_buf;
 	struct bt_att_tx_meta_data rsp_meta;
 	struct k_work_delayable	timeout_work;
 	sys_snode_t		node;
@@ -658,7 +659,7 @@ static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t 
 	struct net_buf *buf;
 	struct bt_att_tx_meta_data *data;
 	k_timeout_t timeout;
-	bool is_rsp = false;
+	bool re_use = false;
 
 	if (len + sizeof(op) > bt_att_mtu(chan)) {
 		LOG_WRN("ATT MTU exceeded, max %u, wanted %zu", bt_att_mtu(chan),
@@ -671,19 +672,23 @@ static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t 
 	case ATT_CONFIRMATION:
 		/* Use a timeout only when responding/confirming */
 		timeout = BT_ATT_TIMEOUT;
-		is_rsp = true;
+		re_use = true;
 		break;
 	default:
 		timeout = K_FOREVER;
 	}
 
-	buf = bt_l2cap_create_pdu_timeout(NULL, 0, timeout);
-	if (!buf) {
-		LOG_ERR("Unable to allocate buffer for op 0x%02x", op);
-		return NULL;
+	if (IS_ENABLED(CONFIG_BT_GATT_READ_MULTIPLE) &&
+	    (op == BT_ATT_OP_READ_MULT_RSP ||
+	     op == BT_ATT_OP_READ_MULT_VL_RSP)) {
+		/* We can't re-use the REQ buffer (see below) for these two
+		 * opcodes, as the handler will read from it _after_ allocating
+		 * the RSP buffer.
+		 */
+		re_use = false;
 	}
 
-	if (is_rsp) {
+	if (re_use) {
 		/* There can only ever be one transaction at a time on a
 		 * bearer/channel. Use a dedicated channel meta-data to ensure
 		 * we can always queue an (error) RSP for each REQ. The ATT
@@ -700,8 +705,27 @@ static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t 
 			return NULL;
 		}
 		data = &chan->rsp_meta;
-		LOG_INF("alloc rsp meta");
+
+		/* Re-use REQ buf to avoid dropping the REQ and timing out.
+		 * This only works if the bearer used to RX REQs is the same as
+		 * for sending the RSP. That should always be the case
+		 * (per-spec).
+		 */
+		__ASSERT_NO_MSG(chan->rsp_buf);
+		buf = net_buf_ref(chan->rsp_buf);
+
+		net_buf_reset(buf);
+		net_buf_reserve(buf, BT_L2CAP_BUF_SIZE(0));
+
+		LOG_DBG("re-using REQ buf %p for RSP", buf);
 	} else {
+		LOG_DBG("alloc buf & meta from global pools");
+		buf = bt_l2cap_create_pdu_timeout(NULL, 0, timeout);
+		if (!buf) {
+			LOG_ERR("Unable to allocate buffer for op 0x%02x", op);
+			return NULL;
+		}
+
 		data = tx_meta_data_alloc(timeout);
 		if (!data) {
 			LOG_WRN("Unable to allocate ATT TX meta");
@@ -781,6 +805,7 @@ static void send_err_rsp(struct bt_att_chan *chan, uint8_t req, uint16_t handle,
 
 	buf = bt_att_chan_create_pdu(chan, BT_ATT_OP_ERROR_RSP, sizeof(*rsp));
 	if (!buf) {
+		LOG_ERR("unable to allocate buf for error response");
 		return;
 	}
 
@@ -2874,6 +2899,20 @@ static int bt_att_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		}
 	}
 
+	/* Thread-local variable, shouldn't be used by anything else */
+	__ASSERT_NO_MSG(!att_chan->rsp_buf);
+
+	/* Mark buffer free for re-use by the opcode handler.
+	 *
+	 * This allows ATT to always be able to send a RSP (or err RSP)
+	 * to the peer, regardless of the TX buffer usage by other stack
+	 * users (e.g. GATT notifications, L2CAP using global pool, SMP,
+	 * etc..), avoiding an ATT timeout due to resource usage.
+	 *
+	 * The ref is taken by `bt_att_chan_create_pdu`.
+	 */
+	att_chan->rsp_buf = net_buf_ref(buf);
+
 	if (!handler) {
 		LOG_WRN("Unhandled ATT code 0x%02x", hdr->code);
 		if (att_op_get_type(hdr->code) != ATT_COMMAND &&
@@ -2881,19 +2920,19 @@ static int bt_att_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 			send_err_rsp(att_chan, hdr->code, 0,
 				     BT_ATT_ERR_NOT_SUPPORTED);
 		}
-		return 0;
+		goto exit;
 	}
 
 	if (IS_ENABLED(CONFIG_BT_ATT_ENFORCE_FLOW)) {
 		if (handler->type == ATT_REQUEST &&
 		    atomic_test_and_set_bit(att_chan->flags, ATT_PENDING_RSP)) {
 			LOG_WRN("Ignoring unexpected request");
-			return 0;
+			goto exit;
 		} else if (handler->type == ATT_INDICATION &&
 			   atomic_test_and_set_bit(att_chan->flags,
 						   ATT_PENDING_CFM)) {
 			LOG_WRN("Ignoring unexpected indication");
-			return 0;
+			goto exit;
 		}
 	}
 
@@ -2908,6 +2947,10 @@ static int bt_att_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		LOG_DBG("ATT error 0x%02x", err);
 		send_err_rsp(att_chan, hdr->code, 0, err);
 	}
+
+exit:
+	net_buf_unref(att_chan->rsp_buf);
+	att_chan->rsp_buf = NULL;
 
 	return 0;
 }

--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -43,14 +43,15 @@ NET_BUF_POOL_FIXED_DEFINE(discardable_pool, CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT,
 #if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)
 NET_BUF_POOL_DEFINE(acl_in_pool, CONFIG_BT_BUF_ACL_RX_COUNT,
 		    BT_BUF_ACL_SIZE(CONFIG_BT_BUF_ACL_RX_SIZE),
-		    sizeof(struct acl_data), bt_hci_host_num_completed_packets);
+		    MAX(sizeof(struct bt_buf_data), CONFIG_BT_CONN_TX_USER_DATA_SIZE),
+		    bt_hci_host_num_completed_packets);
 
 NET_BUF_POOL_FIXED_DEFINE(evt_pool, CONFIG_BT_BUF_EVT_RX_COUNT,
 			  BT_BUF_EVT_RX_SIZE, 8,
 			  NULL);
 #else
 NET_BUF_POOL_FIXED_DEFINE(hci_rx_pool, BT_BUF_RX_COUNT,
-			  BT_BUF_RX_SIZE, 8,
+			  BT_BUF_RX_SIZE, CONFIG_BT_CONN_TX_USER_DATA_SIZE,
 			  NULL);
 #endif /* CONFIG_BT_HCI_ACL_FLOW_CONTROL */
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -146,17 +146,6 @@ struct bt_conn_tx {
 	uint32_t pending_no_cb;
 };
 
-struct acl_data {
-	/* Extend the bt_buf user data */
-	struct bt_buf_data buf_data;
-
-	/* Index into the bt_conn storage array */
-	uint8_t  index;
-
-	/** ACL connection handle */
-	uint16_t handle;
-};
-
 struct bt_conn {
 	uint16_t			handle;
 	enum bt_conn_type	type;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -111,8 +111,16 @@ struct cmd_data {
 
 static struct cmd_data cmd_data[CONFIG_BT_BUF_CMD_TX_COUNT];
 
+#if defined(CONFIG_BT_CONN)
+struct acl_data {
+	uint16_t acl_handle;
+};
+
+static struct acl_data acl_data[CONFIG_BT_BUF_ACL_RX_COUNT];
+#endif
+
 #define cmd(buf) (&cmd_data[net_buf_id(buf)])
-#define acl(buf) ((struct acl_data *)net_buf_user_data(buf))
+#define acl(buf) (&acl_data[net_buf_id(buf)])
 
 void bt_hci_cmd_state_set_init(struct net_buf *buf,
 			       struct bt_hci_cmd_state_set *state,
@@ -201,10 +209,9 @@ void bt_hci_host_num_completed_packets(struct net_buf *buf)
 {
 
 	struct bt_hci_cp_host_num_completed_packets *cp;
-	uint16_t handle = acl(buf)->handle;
+	uint16_t handle = acl(buf)->acl_handle;
 	struct bt_hci_handle_count *hc;
 	struct bt_conn *conn;
-	uint8_t index = acl(buf)->index;
 
 	net_buf_destroy(buf);
 
@@ -213,9 +220,9 @@ void bt_hci_host_num_completed_packets(struct net_buf *buf)
 		return;
 	}
 
-	conn = bt_conn_lookup_index(index);
+	conn = bt_conn_lookup_handle(handle, BT_CONN_TYPE_ALL);
 	if (!conn) {
-		LOG_WRN("Unable to look up conn with index 0x%02x", index);
+		LOG_WRN("Unable to look up conn with ACL handle %u", handle);
 		return;
 	}
 
@@ -509,10 +516,9 @@ static void hci_acl(struct net_buf *buf)
 	handle = sys_le16_to_cpu(hdr->handle);
 	flags = bt_acl_flags(handle);
 
-	acl(buf)->handle = bt_acl_handle(handle);
-	acl(buf)->index = BT_CONN_INDEX_INVALID;
+	acl(buf)->acl_handle = bt_acl_handle(handle);
 
-	LOG_DBG("handle %u len %u flags %u", acl(buf)->handle, len, flags);
+	LOG_DBG("handle %u len %u flags %u", acl(buf)->acl_handle, len, flags);
 
 	if (buf->len != len) {
 		LOG_ERR("ACL data length mismatch (%u != %u)", buf->len, len);
@@ -520,14 +526,12 @@ static void hci_acl(struct net_buf *buf)
 		return;
 	}
 
-	conn = bt_conn_lookup_handle(acl(buf)->handle, BT_CONN_TYPE_ALL);
+	conn = bt_conn_lookup_handle(acl(buf)->acl_handle, BT_CONN_TYPE_ALL);
 	if (!conn) {
-		LOG_ERR("Unable to find conn for handle %u", acl(buf)->handle);
+		LOG_ERR("Unable to find conn for handle %u", acl(buf)->acl_handle);
 		net_buf_unref(buf);
 		return;
 	}
-
-	acl(buf)->index = bt_conn_index(conn);
 
 	bt_conn_recv(conn, buf, flags);
 	bt_conn_unref(conn);

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1840,6 +1840,11 @@ static struct net_buf *l2cap_chan_create_seg(struct bt_l2cap_le_chan *ch,
 			net_buf_push_le16(buf, net_buf_frags_len(buf));
 		}
 		return net_buf_ref(buf);
+	} else {
+		/* Unnecessary fragmentation. Ensure the source buffer has
+		 * BT_L2CAP_SDU_BUF_SIZE(0) headroom.
+		 */
+		LOG_DBG("not enough headroom on %p", buf);
 	}
 
 segment:


### PR DESCRIPTION
Fixes ATT timeout when stack is under memory pressure.

The gist of it is:
- The host stack (ATT in this case) does not involve the application when handling REQuests
- ATT _requires two resources_ to enqueue a RSP: a buffer and a metadata struct
- These are allocated from two shared pools: `acl_tx_pool` and `tx_meta_data` 
- The global buffer pool is shared by all users of the stack (l2cap coc, smp, att)
- The metadata pool is shared by all users of att (can be multiple threads sending notifications)

If the application is putting pressure on those buffer and metadata pools (e.g. by sending notifications very very fast to multiple devices), then ATT can be starved and will fail to enqueue a response. 
Then the ATT timer will fire and we will get an ATT timeout. 

That is pretty bad in the current version of the host, as - apart from a log message - the application is not notified of this. What it can do is try to use GATT (eg send a notification) and carefully inspect the error value to determine if the ATT bearer has been shut down.

This PR proposes a two-part fix:
- add a struct member for the att metadata per-channel
- re-use the REQ buffer to enqueue the RSP

This way those two necessary resources are always available, as there can only ever be one transaction at a time on a bearer/channel.