### PR TITLE
arch: posix: break debugger on fatal error

### DIFF
--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -57,4 +57,10 @@ config ARCH_POSIX_FUZZ_TICKS
 
 endif # CONFIG_ARCH_POSIX_LIBFUZZER
 
+config ARCH_POSIX_TRAP_ON_FATAL
+	bool "Raise a SIGTRAP on fatal error"
+	help
+	  Raise a SIGTRAP signal on fatal error before exiting.
+	  This automatically suspends the target if a debugger is attached.
+
 endmenu

--- a/arch/posix/core/CMakeLists.txt
+++ b/arch/posix/core/CMakeLists.txt
@@ -10,6 +10,14 @@ zephyr_library_sources(
 	thread.c
 	)
 
+if(CONFIG_ARCH_POSIX_TRAP_ON_FATAL)
+  if(CONFIG_NATIVE_LIBRARY)
+    target_sources(native_simulator INTERFACE fatal_trap.c)
+  else()
+    zephyr_library_sources(fatal_trap.c)
+  endif()
+endif()
+
 if(CONFIG_NATIVE_APPLICATION)
 	zephyr_include_directories(
 		nsi_compat/

--- a/arch/posix/core/fatal.c
+++ b/arch/posix/core/fatal.c
@@ -13,9 +13,15 @@
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/arch/posix/posix_soc_if.h>
 
+extern void nsi_raise_sigtrap(void);
+
 FUNC_NORETURN void arch_system_halt(unsigned int reason)
 {
 	ARG_UNUSED(reason);
+
+	if (IS_ENABLED(CONFIG_ARCH_POSIX_TRAP_ON_FATAL)) {
+		nsi_raise_sigtrap();
+	}
 
 	posix_print_error_and_exit("Exiting due to fatal error\n");
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */

--- a/arch/posix/core/fatal_trap.c
+++ b/arch/posix/core/fatal_trap.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <signal.h>
+
+void nsi_raise_sigtrap(void)
+{
+	raise(SIGTRAP);
+}


### PR DESCRIPTION
Add option to raise a SIGTRAP on fatal error, making the debugger break instead of exiting.