### PR TITLE
doc: doxygen: Enable Doxygen autobrief

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -199,7 +199,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the JAVADOC_BANNER tag is set to YES then doxygen will interpret a line
 # such as
@@ -217,7 +217,7 @@ JAVADOC_BANNER         = NO
 # requiring an explicit \brief command for a brief description.)
 # The default value is: NO.
 
-QT_AUTOBRIEF           = NO
+QT_AUTOBRIEF           = YES
 
 # The MULTILINE_CPP_IS_BRIEF tag can be set to YES to make doxygen treat a
 # multi-line C++ special comment block (i.e. a block of //! or /// comments) as


### PR DESCRIPTION
Enable Doxygen "autobrief" feature for both Javadoc and Qt style documentation blocks. This treats the first sentence of a documentation block as a brief description even when no @brief tag is present. This makes the overview sections of the generated documentation much more useful.

See https://www.doxygen.nl/manual/config.html#cfg_javadoc_autobrief and https://www.doxygen.nl/manual/config.html#cfg_qt_autobrief

From what I can see after looking at the before/after of a couple dozens of pages in various places, it's a nice improvement, and not causing any obvious regression or issue that I could find. 

See ex. https://docs.zephyrproject.org/latest/doxygen/html/group__audio__codec__interface.html vs. https://builds.zephyrproject.io/zephyr/pr/60314/docs/doxygen/html/group__audio__codec__interface.html as an example of a page that's now much richer. 

Still not perfect, as some of the files that benefit from this PR also could use better/more complete documentation in the first place, but that's to be addressed (at least partly) by eventually tackling #56855 some day.