### PR TITLE
doc: requirements: update Sphinx and rtd

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -72,6 +72,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.autodoc",
     "sphinx.ext.graphviz",
+    "sphinxcontrib.jquery",
     "zephyr.application",
     "zephyr.html_redirects",
     "zephyr.kconfig",

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,8 +1,8 @@
 # DOC: used to generate docs
 
 docleaf==0.8.1
-sphinx~=6.0
-sphinx_rtd_theme~=1.0
+sphinx~=6.2
+sphinx_rtd_theme~=1.2
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter
 pygments>=2.9


### PR DESCRIPTION
1.2.x is required when using Sphinx >= 6.0, otherwise certain features
  like search are broken. Also update Sphinx to latest 6.x release, 6.2
  as it contains some fixes.