### PR TITLE
can: isotp: Add CAN-FD support to ISO-TP

### DIFF
--- a/include/zephyr/canbus/isotp.h
+++ b/include/zephyr/canbus/isotp.h
@@ -11,8 +11,8 @@
  * ISO-TP is a transport protocol for CAN (Controller Area Network)
  */
 
-#ifndef ZEPHYR_INCLUDE_ISOTP_H_
-#define ZEPHYR_INCLUDE_ISOTP_H_
+#ifndef ZEPHYR_INCLUDE_CANBUS_ISOTP_H_
+#define ZEPHYR_INCLUDE_CANBUS_ISOTP_H_
 
 /**
  * @brief CAN ISO-TP Protocol
@@ -34,10 +34,16 @@
  * DLC     Data length code
  * FC      Flow Control
  * FF      First Frame
+ * SF      Single Frame
  * FS      Flow Status
  * AE      Address Extension
+ * SN      Sequence Number
+ * ST      Separation time
  * SA      Source Address
  * TA      Target Address
+ * RX_DL   CAN RX LL data size
+ * TX_DL   CAN TX LL data size
+ * PCI     Process Control Information
  */
 
 /*
@@ -147,6 +153,12 @@ extern "C" {
 /** Message uses extended (29-bit) CAN ID */
 #define ISOTP_MSG_IDE BIT(2)
 
+/** Message uses CAN-FD format (FDF) */
+#define ISOTP_MSG_FDF BIT(3)
+
+/** Message uses CAN-FD Baud Rate Switch (BRS). Only valid in combination with ``ISOTP_MSG_FDF``. */
+#define ISOTP_MSG_BRS BIT(4)
+
 /** @} */
 
 /**
@@ -167,6 +179,17 @@ struct isotp_msg_id {
 	};
 	/** ISO-TP extended address (if used) */
 	uint8_t ext_addr;
+	/**
+	 * ISO-TP frame data length (TX_DL for TX address or RX_DL for RX address).
+	 *
+	 * Valid values are 8 for classical CAN or 8, 12, 16, 20, 24, 32, 48 and 64 for CAN-FD.
+	 *
+	 * 0 will be interpreted as 8 or 64 (if ISOTP_MSG_FDF is set).
+	 *
+	 * The value for incoming transmissions (RX_DL) is determined automatically based on the
+	 * received first frame and does not need to be set during initialization.
+	 */
+	uint8_t dl;
 	/** Flags. @see @ref ISOTP_MSG_FLAGS. */
 	uint8_t flags;
 };
@@ -459,4 +482,4 @@ struct isotp_recv_ctx {
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_ISOTP_H_ */
+#endif /* ZEPHYR_INCLUDE_CANBUS_ISOTP_H_ */

--- a/samples/subsys/canbus/isotp/Kconfig
+++ b/samples/subsys/canbus/isotp/Kconfig
@@ -22,4 +22,12 @@ config SAMPLE_RX_THREAD_PRIORITY
 	help
 	  Priority used for the RX threads.
 
+config SAMPLE_CAN_FD_MODE
+	bool "Use CAN-FD"
+	select CAN_FD_MODE
+
+config ISOTP_RX_BUF_COUNT
+	default 4 if SAMPLE_CAN_FD_MODE
+	default 2
+
 source "Kconfig.zephyr"

--- a/samples/subsys/canbus/isotp/prj.conf
+++ b/samples/subsys/canbus/isotp/prj.conf
@@ -4,9 +4,5 @@ CONFIG_CAN=y
 CONFIG_CAN_MAX_FILTER=8
 
 CONFIG_ISOTP=y
-CONFIG_ISOTP_RX_BUF_COUNT=2
-#A frame has 7 bytes payload, we are using a BS of 8 and need one char for the
-#string termination (7 * 8 + 1 = 57)
-CONFIG_ISOTP_RX_BUF_SIZE=57
-#We have two receiving contexts that are bound to a single address.
+# We have two receiving contexts that are bound to a single address.
 CONFIG_ISOTP_RX_SF_FF_BUF_COUNT=2

--- a/samples/subsys/canbus/isotp/sample.yaml
+++ b/samples/subsys/canbus/isotp/sample.yaml
@@ -14,3 +14,19 @@ tests:
       type: one_line
       regex:
         - "(.*)Got 247 bytes in total"
+  sample.subsys.canbus.isotp.fd:
+    tags:
+      - can
+      - isotp
+    depends_on: can
+    extra_configs:
+      - CONFIG_SAMPLE_LOOPBACK_MODE=y
+      - CONFIG_SAMPLE_CAN_FD_MODE=y
+    platform_allow:
+      - native_posix
+      - native_posix_64
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "(.*)Got 247 bytes in total"

--- a/subsys/canbus/isotp/Kconfig
+++ b/subsys/canbus/isotp/Kconfig
@@ -5,6 +5,7 @@
 
 menuconfig ISOTP
 	bool "ISO-TP Transport [EXPERIMENTAL]"
+	depends on CAN
 	select NET_BUF
 	select POLL
 	select EXPERIMENTAL
@@ -74,11 +75,12 @@ config ISOTP_RX_BUF_COUNT
 
 config ISOTP_RX_BUF_SIZE
 	int "Size of one buffer data block"
+	default 63 if CAN_FD_MODE
 	default 56
 	help
 	  This value defines the size of a single block in the pool. The number of
 	  blocks is given by ISOTP_RX_BUF_COUNT. To be efficient use a multiple of
-	  CAN_DL - 1 (for classic can : 8 - 1 = 7).
+	  CAN_MAX_DLEN - 1 (for classic CAN : 8 - 1 = 7, for CAN-FD : 64 - 1 = 63).
 
 config ISOTP_RX_SF_FF_BUF_COUNT
 	int "Number of SF and FF data buffers for receiving data"
@@ -87,7 +89,7 @@ config ISOTP_RX_SF_FF_BUF_COUNT
 	  This buffer is used for first and single frames. It is extra because the
 	  buffer has to be ready for the first reception in isr context and therefor
 	  is allocated when binding.
-	  Each buffer will occupy CAN_DL - 1 byte + header (sizeof(struct net_buf))
+	  Each buffer will occupy CAN_MAX_DLEN - 1 byte + header (sizeof(struct net_buf))
 	  amount of data.
 
 config ISOTP_USE_TX_BUF

--- a/subsys/canbus/isotp/isotp_internal.h
+++ b/subsys/canbus/isotp/isotp_internal.h
@@ -4,37 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_SUBSYS_NET_CAN_ISOTP_INTERNAL_H_
-#define ZEPHYR_SUBSYS_NET_CAN_ISOTP_INTERNAL_H_
-
+#ifndef ZEPHYR_SUBSYS_CANBUS_ISOTP_ISOTP_INTERNAL_H_
+#define ZEPHYR_SUBSYS_CANBUS_ISOTP_ISOTP_INTERNAL_H_
 
 #include <zephyr/canbus/isotp.h>
 #include <zephyr/sys/slist.h>
-
-/*
- * Abbreviations
- * BS      Block Size
- * CAN_DL  CAN LL data size
- * CF      Consecutive Frame
- * CTS     Continue to send
- * DLC     Data length code
- * FC      Flow Control
- * FF      First Frame
- * SF      Single Frame
- * FS      Flow Status
- * AE      Adders Extension
- * SN      Sequence Number
- * ST      Separation time
- * PCI     Process Control Information
- */
-
-/* This is for future use when we have CAN-FD */
-#ifdef ISOTP_USE_CAN_FD
-/* #define ISOTP_CAN_DL CONFIG_ISOTP_TX_DL* */
-#define ISOTP_CAN_DL 8
-#else
-#define ISOTP_CAN_DL 8
-#endif/*ISOTP_USE_CAN_FD*/
 
 /* Protocol control information*/
 #define ISOTP_PCI_SF 0x00 /* Single frame*/
@@ -67,7 +41,9 @@
 
 #define ISOTP_PCI_SN_MASK          0x0F
 
-#define ISOTP_FF_DL_MIN            (ISOTP_CAN_DL)
+#define ISOTP_FF_DL_MIN            8
+#define ISOTP_PADDED_FRAME_DL_MIN  8
+#define ISOTP_PAD_BYTE             0xCC
 
 #define ISOTP_STMIN_MAX            0xFA
 #define ISOTP_STMIN_MS_MAX         0x7F
@@ -75,6 +51,8 @@
 #define ISOTP_STMIN_US_END         0xF9
 
 #define ISOTP_WFT_FIRST            0xFF
+
+#define ISOTP_4BIT_SF_MAX_CAN_DL   8
 
 #define ISOTP_BS (CONFIG_ISOTP_BS_TIMEOUT)
 #define ISOTP_A  (CONFIG_ISOTP_A_TIMEOUT)
@@ -121,4 +99,4 @@ struct isotp_global_ctx {
 }
 #endif
 
-#endif /* ZEPHYR_SUBSYS_NET_CAN_ISOTP_INTERNAL_H_ */
+#endif /* ZEPHYR_SUBSYS_CANBUS_ISOTP_ISOTP_INTERNAL_H_ */

--- a/tests/subsys/canbus/isotp/conformance/Kconfig
+++ b/tests/subsys/canbus/isotp/conformance/Kconfig
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_USE_CAN_FD_MODE
+	bool "Use CAN-FD"
+	select CAN_FD_MODE
+
+config TEST_ISOTP_TX_DL
+	int "TX_DL to be used"
+	default 8
+	help
+	  ISO-TP TX_DL value.
+	  Valid values are 8, 12, 16, 20, 24, 32, 48 and 64.
+
+source "Kconfig.zephyr"

--- a/tests/subsys/canbus/isotp/conformance/prj.conf
+++ b/tests/subsys/canbus/isotp/conformance/prj.conf
@@ -7,3 +7,5 @@ CONFIG_ISOTP_ENABLE_CONTEXT_BUFFERS=y
 CONFIG_ISOTP_RX_BUF_COUNT=6
 CONFIG_ISOTP_RX_BUF_SIZE=128
 CONFIG_ISOTP_RX_SF_FF_BUF_COUNT=2
+# some tests may be skipped if CAN-FD should be used, but is not supported by the controller
+CONFIG_ZTEST_VERIFY_RUN_ALL=n

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -372,7 +372,7 @@ static void prepare_cf_frames(struct frame_desired *frames, size_t frames_cnt,
 	for (i = 0; i < frames_cnt && remaining_length; i++) {
 		frames[i].data[0] = CF_PCI_BYTE_1 | ((i+1) & 0x0F);
 		frames[i].length = TX_DL;
-		memcpy(&des_frames[i].data[1], data_ptr, DATA_SIZE_CF);
+		memcpy(&frames[i].data[1], data_ptr, DATA_SIZE_CF);
 
 		if (remaining_length < DATA_SIZE_CF) {
 			if ((IS_ENABLED(CONFIG_ISOTP_ENABLE_TX_PADDING) && tx) ||
@@ -380,7 +380,7 @@ static void prepare_cf_frames(struct frame_desired *frames, size_t frames_cnt,
 				uint8_t padded_dlc = can_bytes_to_dlc(MAX(8, remaining_length + 1));
 				uint8_t padded_len = can_dlc_to_bytes(padded_dlc);
 
-				memset(&des_frames[i].data[remaining_length + 1], 0xCC,
+				memset(&frames[i].data[remaining_length + 1], 0xCC,
 				       padded_len - remaining_length - 1);
 				frames[i].length = padded_len;
 			} else {

--- a/tests/subsys/canbus/isotp/conformance/src/mode_check.c
+++ b/tests/subsys/canbus/isotp/conformance/src/mode_check.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023 Libre Solar Technologies GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This test suite checks that correct errors are returned when trying to use the ISO-TP
+ * protocol with CAN-FD mode even though the controller does not support CAN-FD.
+ */
+
+#include <zephyr/canbus/isotp.h>
+#include <zephyr/ztest.h>
+
+static const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+static struct isotp_recv_ctx recv_ctx;
+static struct isotp_send_ctx send_ctx;
+static bool canfd_capable;
+
+static const struct isotp_fc_opts fc_opts = {
+	.bs = 0,
+	.stmin = 0
+};
+
+static const struct isotp_msg_id rx_addr = {
+	.std_id = 0x20,
+#ifdef CONFIG_TEST_USE_CAN_FD_MODE
+	.dl = CONFIG_TEST_ISOTP_TX_DL,
+	.flags = ISOTP_MSG_FDF | ISOTP_MSG_BRS,
+#endif
+};
+
+static const struct isotp_msg_id tx_addr = {
+	.std_id = 0x21,
+#ifdef CONFIG_TEST_USE_CAN_FD_MODE
+	.dl = CONFIG_TEST_ISOTP_TX_DL,
+	.flags = ISOTP_MSG_FDF | ISOTP_MSG_BRS,
+#endif
+};
+
+ZTEST(isotp_conformance_mode_check, test_bind)
+{
+	int err;
+
+	err = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr, &fc_opts, K_NO_WAIT);
+	if (IS_ENABLED(CONFIG_TEST_USE_CAN_FD_MODE) && !canfd_capable) {
+		zassert_equal(err, ISOTP_N_ERROR);
+	} else {
+		zassert_equal(err, ISOTP_N_OK);
+	}
+
+	isotp_unbind(&recv_ctx);
+}
+
+ZTEST(isotp_conformance_mode_check, test_send)
+{
+	uint8_t buf[] = { 1, 2, 3 };
+	int err;
+
+	err = isotp_send(&send_ctx, can_dev, buf, sizeof(buf), &rx_addr, &tx_addr, NULL, NULL);
+	if (IS_ENABLED(CONFIG_TEST_USE_CAN_FD_MODE) && !canfd_capable) {
+		zassert_equal(err, ISOTP_N_ERROR);
+	} else {
+		zassert_equal(err, ISOTP_N_OK);
+	}
+}
+
+static void *isotp_conformance_mode_check_setup(void)
+{
+	can_mode_t cap;
+	int err;
+
+	zassert_true(device_is_ready(can_dev), "CAN device not ready");
+
+	err = can_get_capabilities(can_dev, &cap);
+	zassert_equal(err, 0, "failed to get CAN controller capabilities (err %d)", err);
+
+	canfd_capable = (cap & CAN_MODE_FD) != 0;
+
+	(void)can_stop(can_dev);
+
+	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK | (canfd_capable ? CAN_MODE_FD : 0));
+	zassert_equal(err, 0, "Failed to set mode [%d]", err);
+
+	err = can_start(can_dev);
+	zassert_equal(err, 0, "Failed to start CAN controller [%d]", err);
+
+	return NULL;
+}
+
+ZTEST_SUITE(isotp_conformance_mode_check, NULL, isotp_conformance_mode_check_setup, NULL, NULL,
+	    NULL);

--- a/tests/subsys/canbus/isotp/conformance/testcase.yaml
+++ b/tests/subsys/canbus/isotp/conformance/testcase.yaml
@@ -1,7 +1,54 @@
+#
+# There are 4 different test cases that have to be considered:
+#
+# | Case # | Controller type        | Selected mode        |  Example board |
+# +--------+------------------------+----------------------+----------------+
+# |    1   | Classical CAN only     | CONFIG_CAN_FD_MODE=n | nucleo_f072    |
+# |    2   | Classical CAN only     | CONFIG_CAN_FD_MODE=y | nucleo_f072    |
+# |    3   | Classical CAN + CAN-FD | CONFIG_CAN_FD_MODE=n | native_posix   |
+# |    4   | Classical CAN + CAN-FD | CONFIG_CAN_FD_MODE=y | native_posix   |
+#
+# The test-specific CONFIG_TEST_USE_CAN_FD_MODE is used to decide if the test should use
+# CAN-FD independent of CONFIG_CAN_FD_MODE configuration.
+#
+
 tests:
+  # cases 1, 3
   canbus.isotp.conformance:
     tags:
       - can
       - isotp
+    depends_on: can
+    filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
+  # case 2
+  canbus.isotp.conformance.fd.unused:
+    tags:
+      - can
+      - isotp
+    extra_configs:
+      - CONFIG_TEST_USE_CAN_FD_MODE=n
+      - CONFIG_CAN_FD_MODE=y
+    depends_on: can
+    filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
+  # case 4
+  canbus.isotp.conformance.fd.txdl_32:
+    tags:
+      - can
+      - isotp
+    extra_configs:
+      - CONFIG_TEST_USE_CAN_FD_MODE=y
+      - CONFIG_TEST_ISOTP_TX_DL=32
+      - CONFIG_CAN_FD_MODE=y
+    depends_on: can
+    filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
+  # case 4
+  canbus.isotp.conformance.fd.txdl_64:
+    tags:
+      - can
+      - isotp
+    extra_configs:
+      - CONFIG_TEST_USE_CAN_FD_MODE=y
+      - CONFIG_TEST_ISOTP_TX_DL=64
+      - CONFIG_CAN_FD_MODE=y
     depends_on: can
     filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")


### PR DESCRIPTION
- Add CAN-FD support to ISO-TP
- Update ISO-TP sample to work with CAN-FD
- Update existing ISO-TP unit tests to work with CAN-FD
- Add CAN-FD specific unit tests
  - Mandatory padding of frames > 8 bytes to next DLC
  - Validation that RX_DL in consecutive frames matches first frame

Thanks @dale-herman for doing most of the work