### PR TITLE
drivers: mm: Fix macro call in RAT driver

### DIFF
--- a/drivers/mm/mm_drv_ti_rat.c
+++ b/drivers/mm/mm_drv_ti_rat.c
@@ -104,7 +104,7 @@ int sys_mm_drv_page_phys_get(void *virt, uintptr_t *phys)
 
 	uint32_t found, regionId;
 
-	__ASSERT(translate_config.num_regions < address_trans_MAX_REGIONS,
+	__ASSERT(translate_config.num_regions < ADDR_TRANSLATE_MAX_REGIONS,
 		 "Exceeding maximum number of regions");
 
 	found = 0;


### PR DESCRIPTION
The macro used in an assert statement in the sys_mm_page_phys_get()
function was used an older version of the naming scheme, and went 
unnoticed in the hardware testing.

This bug was not noticed earlier as the driver ran on the board
successfully, presumably bypassing the assert statement where it was    
used. It is only noticed in the twister builds as an undeclared error, 
and hence, it has been fixed.

The twister build has been run locally for the platform where it is 
being used right now, and all the tests pass with respect to this driver.

Signed-off-by: L Lakshmanan <l-lakshmanan@ti.com> 