### PR TITLE
arm64: Add frame-pointer based stack unwinding

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -128,6 +128,15 @@ config ARM64_SAFE_EXCEPTION_STACK
 	  used for user stack overflow checking, because kernel stack support
 	  the checking work.
 
+config ARM64_ENABLE_FRAME_POINTER
+	bool
+	default y
+	depends on OVERRIDE_FRAME_POINTER_DEFAULT && !OMIT_FRAME_POINTER
+	help
+	  Hidden option to simplify access to OVERRIDE_FRAME_POINTER_DEFAULT
+	  and OMIT_FRAME_POINTER. It is automatically enabled when the frame
+	  pointer unwinding is enabled.
+
 config ARM64_SAFE_EXCEPTION_STACK_SIZE
 	int "The stack size of the safe exception stack"
 	default 4096

--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -191,6 +191,45 @@ static void esf_dump(const z_arch_esf_t *esf)
 	LOG_ERR("x16: 0x%016llx  x17: 0x%016llx", esf->x16, esf->x17);
 	LOG_ERR("x18: 0x%016llx  lr:  0x%016llx", esf->x18, esf->lr);
 }
+
+#ifdef CONFIG_ARM64_ENABLE_FRAME_POINTER
+static void esf_unwind(const z_arch_esf_t *esf)
+{
+	/*
+	 * For GCC:
+	 *
+	 *  ^  +-----------------+
+	 *  |  |                 |
+	 *  |  |                 |
+	 *  |  |                 |
+	 *  |  |                 |
+	 *  |  | function stack  |
+	 *  |  |                 |
+	 *  |  |                 |
+	 *  |  |                 |
+	 *  |  |                 |
+	 *  |  +-----------------+
+	 *  |  |       LR        |
+	 *  |  +-----------------+
+	 *  |  |   previous FP   | <---+ FP
+	 *  +  +-----------------+
+	 */
+
+	uint64_t *fp = (uint64_t *) esf->fp;
+	unsigned int count = 0;
+	uint64_t lr;
+
+	LOG_ERR("");
+	while (fp != NULL) {
+		lr = fp[1];
+		LOG_ERR("backtrace %2d: fp: 0x%016llx lr: 0x%016llx",
+			 count++, (uint64_t) fp, lr);
+		fp = (uint64_t *) fp[0];
+	}
+	LOG_ERR("");
+}
+#endif
+
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
 static bool is_recoverable(z_arch_esf_t *esf, uint64_t esr, uint64_t far,
@@ -261,6 +300,10 @@ void z_arm64_fatal_error(unsigned int reason, z_arch_esf_t *esf)
 	if (esf != NULL) {
 		esf_dump(esf);
 	}
+
+#ifdef CONFIG_ARM64_ENABLE_FRAME_POINTER
+	esf_unwind(esf);
+#endif /* CONFIG_ARM64_ENABLE_FRAME_POINTER */
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
 	z_fatal_error(reason, esf);

--- a/arch/arm64/core/offsets/offsets.c
+++ b/arch/arm64/core/offsets/offsets.c
@@ -40,6 +40,10 @@ GEN_NAMED_OFFSET_SYM(_callee_saved_t, x27, x27_x28);
 GEN_NAMED_OFFSET_SYM(_callee_saved_t, x29, x29_sp_el0);
 GEN_NAMED_OFFSET_SYM(_callee_saved_t, sp_elx, sp_elx_lr);
 
+#ifdef CONFIG_ARM64_ENABLE_FRAME_POINTER
+GEN_NAMED_OFFSET_SYM(_esf_t, fp, fp);
+#endif
+
 GEN_NAMED_OFFSET_SYM(_esf_t, spsr, spsr_elr);
 GEN_NAMED_OFFSET_SYM(_esf_t, x18, x18_lr);
 GEN_NAMED_OFFSET_SYM(_esf_t, x16, x16_x17);

--- a/arch/arm64/core/vector_table.S
+++ b/arch/arm64/core/vector_table.S
@@ -72,6 +72,10 @@ _ASM_FILE_PROLOGUE
 	.endif
 #endif
 
+#ifdef CONFIG_ARM64_ENABLE_FRAME_POINTER
+	str	x29, [sp, ___esf_t_fp_OFFSET]
+#endif
+
 	mrs	\xreg0, spsr_el1
 	mrs	\xreg1, elr_el1
 	stp	\xreg0, \xreg1, [sp, ___esf_t_spsr_elr_OFFSET]
@@ -334,6 +338,10 @@ SECTION_FUNC(TEXT, z_arm64_exit_exc)
 	ldp	x14, x15, [sp, ___esf_t_x14_x15_OFFSET]
 	ldp	x16, x17, [sp, ___esf_t_x16_x17_OFFSET]
 	ldp	x18, lr, [sp, ___esf_t_x18_lr_OFFSET]
+
+#ifdef CONFIG_ARM64_ENABLE_FRAME_POINTER
+	ldr	x29, [sp,  ___esf_t_fp_OFFSET]
+#endif
 
 	add	sp, sp, ___esf_t_SIZEOF
 

--- a/include/zephyr/arch/arm64/exc.h
+++ b/include/zephyr/arch/arm64/exc.h
@@ -47,10 +47,13 @@ struct __esf {
 	uint64_t lr;
 	uint64_t spsr;
 	uint64_t elr;
+#ifdef CONFIG_ARM64_ENABLE_FRAME_POINTER
+	uint64_t fp;
+#endif
 #ifdef CONFIG_ARM64_SAFE_EXCEPTION_STACK
 	uint64_t sp;
 #endif
-} __aligned(16);
+} __packed __aligned(16);
 
 typedef struct __esf z_arch_esf_t;
 


### PR DESCRIPTION
Add the frame-pointer based stack unwinding on ARM64.

This is a typical output with the feature enabled:

```
*** Booting Zephyr OS build zephyr-v3.4.0-1029-gae22ff648c16 ***
E: ELR_ELn: 0x00000000400011c8
E: ESR_ELn: 0x0000000096000046
E:   EC:  0x25 (Data Abort taken without a change in Exception level)
E:   IL:  0x1
E:   ISS: 0x46
E: FAR_ELn: 0x0000000000000000
E: TPIDRRO: 0x0100000040011650
E: x0:  0x0000000000000000  x1:  0x0000000000000003
E: x2:  0x0000000000000003  x3:  0x000000004005c6a0
E: x4:  0x0000000000000000  x5:  0x000000004005c7f0
E: x6:  0x0000000048000000  x7:  0x0000000048000000
E: x8:  0x0000000000000005  x9:  0x0000000000000000
E: x10: 0x0000000000000000  x11: 0x0000000000000000
E: x12: 0x0000000000000000  x13: 0x0000000000000000
E: x14: 0x0000000000000000  x15: 0x0000000000000000
E: x16: 0x0000000040004290  x17: 0x0000000000000000
E: x18: 0x0000000000000000  lr:  0x0000000040001208
E:
E: backtrace  0: fp: 0x000000004005c690 lr: 0x0000000040001270
E: backtrace  1: fp: 0x000000004005c6b0 lr: 0x0000000040001290
E: backtrace  2: fp: 0x000000004005c7d0 lr: 0x0000000040004ac0
E: backtrace  3: fp: 0x000000004005c7f0 lr: 0x00000000400013a4
E: backtrace  4: fp: 0x000000004005c800 lr: 0x0000000000000000
E:
E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
E: Current thread: 0x40011310 (unknown)
E: Halting system
```