### PR TITLE
Add support for STM32F1 and F3 ADC prescaler in RCC

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -826,6 +826,15 @@ int stm32_clock_control_init(const struct device *dev)
 #if DT_NODE_HAS_PROP(DT_NODELABEL(rcc), ahb4_prescaler)
 	LL_RCC_SetAHB4Prescaler(ahb_prescaler(STM32_AHB4_PRESCALER));
 #endif
+#if DT_NODE_HAS_PROP(DT_NODELABEL(rcc), adc_prescaler)
+	LL_RCC_SetADCClockSource(adc_prescaler(STM32_ADC_PRESCALER));
+#endif
+#if DT_NODE_HAS_PROP(DT_NODELABEL(rcc), adc12_prescaler)
+	LL_RCC_SetADCClockSource(adc_prescaler(STM32_ADC12_PRESCALER));
+#endif
+#if DT_NODE_HAS_PROP(DT_NODELABEL(rcc), adc34_prescaler)
+	LL_RCC_SetADCClockSource(adc_prescaler(STM32_ADC34_PRESCALER));
+#endif
 
 	/* configure MCO1/MCO2 based on Kconfig */
 	stm32_clock_control_mco_init();

--- a/drivers/clock_control/clock_stm32f0_f3.c
+++ b/drivers/clock_control/clock_stm32f0_f3.c
@@ -15,6 +15,28 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include "clock_stm32_ll_common.h"
 
+#if defined(RCC_CFGR_ADCPRE)
+#define z_adc_prescaler(v) LL_RCC_ADC_CLKSRC_PCLK2_DIV_ ## v
+#define adc_prescaler(v) z_adc_prescaler(v)
+#elif defined(RCC_CFGR2_ADC1PRES)
+#define z_adc12_prescaler(v) \
+	COND_CODE_1(IS_EQ(v, 0), \
+		    LL_RCC_ADC1_CLKSRC_HCLK, \
+		    LL_RCC_ADC1_CLKSRC_PLL_DIV_ ## v)
+#define adc12_prescaler(v) z_adc12_prescaler(v)
+#else
+#define z_adc12_prescaler(v) \
+	COND_CODE_1(IS_EQ(v, 0), \
+		    LL_RCC_ADC12_CLKSRC_HCLK, \
+		    LL_RCC_ADC12_CLKSRC_PLL_DIV_ ## v)
+#define adc12_prescaler(v) z_adc12_prescaler(v)
+#define z_adc34_prescaler(v) \
+	COND_CODE_1(IS_EQ(v, 0), \
+		    LL_RCC_ADC34_CLKSRC_HCLK, \
+		    LL_RCC_ADC34_CLKSRC_PLL_DIV_ ## v)
+#define adc34_prescaler(v) z_adc34_prescaler(v)
+#endif
+
 #if defined(STM32_PLL_ENABLED)
 
 /**

--- a/drivers/clock_control/clock_stm32f1.c
+++ b/drivers/clock_control/clock_stm32f1.c
@@ -21,6 +21,9 @@
 #define STM32_USB_PRE_ENABLED	RCC_CFGR_OTGFSPRE
 #endif
 
+#define z_adc_prescaler(v) LL_RCC_ADC_CLKSRC_PCLK2_DIV_ ## v
+#define adc_prescaler(v) z_adc_prescaler(v)
+
 #if defined(STM32_PLL_ENABLED)
 
 /*

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -93,7 +93,7 @@
 		};
 
 		rcc: rcc@40021000 {
-			compatible = "st,stm32-rcc";
+			compatible = "st,stm32f1-rcc";
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
 

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -94,7 +94,7 @@
 		};
 
 		rcc: rcc@40021000 {
-			compatible = "st,stm32-rcc";
+			compatible = "st,stm32f3-rcc";
 			#clock-cells = <2>;
 			reg = <0x40021000 0x400>;
 

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -11,6 +11,14 @@
 	soc {
 		compatible = "st,stm32f373", "st,stm32f3", "simple-bus";
 
+		rcc: rcc@40021000 {
+			/*
+			 * Use the STM32F1 compatible that define the same ADC
+			 * prescaler in the RCC register
+			 */
+			compatible = "st,stm32f1-rcc";
+		};
+
 		pinctrl: pin-controller@48000000 {
 			gpioe: gpio@48001000 {
 				compatible = "st,stm32-gpio";

--- a/dts/bindings/clock/st,stm32f1-rcc.yaml
+++ b/dts/bindings/clock/st,stm32f1-rcc.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32F1 and STM32F37x Reset and Clock controller node.
+  Adds the ADC prescaler to the standard generic STM32 RCC.
+  For more description confere st,stm32-rcc.yaml
+
+compatible: "st,stm32f1-rcc"
+
+include: st,stm32-rcc.yaml
+
+properties:
+  adc-prescaler:
+    type: int
+    enum:
+      - 2
+      - 4
+      - 6
+      - 8
+    description: |
+        ADC prescaler. Defines ADC core clock frequency
+        based on APB2 frequency input.

--- a/dts/bindings/clock/st,stm32f3-rcc.yaml
+++ b/dts/bindings/clock/st,stm32f3-rcc.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2023 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32F3 Reset and Clock controller node.
+  Adds the STM32F3 ADC prescaler to the standard generic STM32 RCC.
+  For more description confere st,stm32-rcc.yaml
+
+compatible: "st,stm32f3-rcc"
+
+include: st,stm32-rcc.yaml
+
+properties:
+  adc12-prescaler:
+    type: int
+    enum:
+      - 0 # Synchronous mode
+      - 1 # not divided
+      - 2
+      - 4
+      - 6
+      - 8
+      - 10
+      - 12
+      - 16
+      - 32
+      - 64
+      - 128
+      - 256
+    description: |
+        ADC 1 and 2 prescaler
+        - 0: Disables the clock so the ADC can use AHB clock (synchronous mode)
+        - Other values n: The ADC can use the PLL clock divided by n
+
+  adc34-prescaler:
+    type: int
+    enum:
+      - 0 # Synchronous mode
+      - 1 # not divided
+      - 2
+      - 4
+      - 6
+      - 8
+      - 10
+      - 12
+      - 16
+      - 32
+      - 64
+      - 128
+      - 256
+    description: |
+        ADC 3 and 4 prescaler
+        - 0: Disables the clock so the ADC can use AHB clock (synchronous mode)
+        - Other values n: The ADC can use the PLL clock divided by n
+        Check RefMan for availabilty.

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -82,6 +82,10 @@
 #define STM32_FLASH_PRESCALER	STM32_CORE_PRESCALER
 #endif
 
+#define STM32_ADC_PRESCALER	DT_PROP(DT_NODELABEL(rcc), adc_prescaler)
+#define STM32_ADC12_PRESCALER	DT_PROP(DT_NODELABEL(rcc), adc12_prescaler)
+#define STM32_ADC34_PRESCALER	DT_PROP(DT_NODELABEL(rcc), adc34_prescaler)
+
 /** STM2H7 specifics RCC dividers */
 #define STM32_D1CPRE	DT_PROP(DT_NODELABEL(rcc), d1cpre)
 #define STM32_HPRE	DT_PROP(DT_NODELABEL(rcc), hpre)


### PR DESCRIPTION
Split from #59874
This is part of a large rework of the STM32 ADC clock configuration.
This PR first deals with the clocks of the F1 / F3 series that are fully / partly configured in RCC. New RCC bindings are thus added for them to allow configuring the ADC prescaler clock.