### PR TITLE
Add support for STM32F0 HSI14 clock

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -138,6 +138,13 @@ static int enabled_clock(uint32_t src_clk)
 		}
 		break;
 #endif /* STM32_SRC_LSI */
+#if defined(STM32_SRC_HSI14)
+	case STM32_SRC_HSI14:
+		if (!IS_ENABLED(STM32_HSI14_ENABLED)) {
+			r = -ENOTSUP;
+		}
+		break;
+#endif /* STM32_SRC_HSI14 */
 #if defined(STM32_SRC_HSI48)
 	case STM32_SRC_HSI48:
 		if (!IS_ENABLED(STM32_HSI48_ENABLED)) {
@@ -687,6 +694,15 @@ static void set_up_fixed_clock_sources(void)
 
 		z_stm32_hsem_unlock(CFG_HW_RCC_SEMID);
 	}
+
+#if defined(STM32_HSI14_ENABLED)
+	/* For all series with HSI 14 clock support */
+	if (IS_ENABLED(STM32_HSI14_ENABLED)) {
+		LL_RCC_HSI14_Enable();
+		while (LL_RCC_HSI14_IsReady() != 1) {
+		}
+	}
+#endif /* STM32_HSI48_ENABLED */
 
 #if defined(STM32_HSI48_ENABLED)
 	/* For all series with HSI 48 clock support */

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -51,6 +51,13 @@
 			status = "disabled";
 		};
 
+		clk_hsi14: clk-hsi14 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(14)>;
+			status = "disabled";
+		};
+
 		clk_lse: clk-lse {
 			#clock-cells = <0>;
 			compatible = "st,stm32-lse-clock";

--- a/include/zephyr/dt-bindings/clock/stm32f0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f0_clock.h
@@ -20,13 +20,14 @@
 #define STM32_SRC_HSI		0x001
 #define STM32_SRC_LSE		0x002
 #define STM32_SRC_LSI		0x003
-#define STM32_SRC_HSI48		0x004
+#define STM32_SRC_HSI14		0x004
+#define STM32_SRC_HSI48		0x005
 /** System clock */
-#define STM32_SRC_SYSCLK	0x005
+#define STM32_SRC_SYSCLK	0x006
 /** Bus clock */
-#define STM32_SRC_PCLK		0x006
+#define STM32_SRC_PCLK		0x007
 /** PLL clock */
-#define STM32_SRC_PLLCLK	0x007
+#define STM32_SRC_PLLCLK	0x008
 
 #define STM32_CLOCK_REG_MASK    0xFFU
 #define STM32_CLOCK_REG_SHIFT   0U
@@ -68,7 +69,6 @@
 #define I2C1_SEL(val)		STM32_CLOCK(val, 1, 4, CFGR3_REG)
 #define CEC_SEL(val)		STM32_CLOCK(val, 1, 6, CFGR3_REG)
 #define USB_SEL(val)		STM32_CLOCK(val, 1, 7, CFGR3_REG)
-#define ADC_SEL(val)		STM32_CLOCK(val, 1, 8, CFGR3_REG)
 #define USART2_SEL(val)		STM32_CLOCK(val, 3, 16, CFGR3_REG)
 #define USART3_SEL(val)		STM32_CLOCK(val, 3, 18, CFGR3_REG)
 /** BDCR devices */


### PR DESCRIPTION
Split from #59874
This is part of a large rework of the STM32 ADC clock configuration.
This PR adds the support of the HSI14 clock of the STM32F0 series, dedicated to the ADC