### PR TITLE
doc: align pseudo-Makefile with latest CMake changes

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,7 +4,8 @@
 
 BUILDDIR ?= _build
 DOC_TAG ?= development
-SPHINXOPTS ?= -j auto
+SPHINXOPTS ?= -j auto -W --keep-going -T
+SPHINXOPTS_EXTRA ?=
 LATEXMKOPTS ?= -halt-on-error -no-shell-escape
 DT_TURBO_MODE ?= 0
 
@@ -26,6 +27,7 @@ configure:
 		-S. \
 		-DDOC_TAG=${DOC_TAG} \
 		-DSPHINXOPTS="${SPHINXOPTS}" \
+		-DSPHINXOPTS_EXTRA="${SPHINXOPTS_EXTRA}" \
 		-DLATEXMKOPTS="${LATEXMKOPTS}" \
 		-DDT_TURBO_MODE=${DT_TURBO_MODE}
 

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -745,7 +745,7 @@ int bt_conn_le_create_synced(const struct bt_le_ext_adv *adv,
 			     const struct bt_conn_le_create_synced_param *synced_param,
 			     const struct bt_le_conn_param *conn_param, struct bt_conn **conn);
 
-/** @brief Automatically connect to remote devices in the filter accept list..
+/** @brief Automatically connect to remote devices in the filter accept list.
  *
  *  This uses the Auto Connection Establishment procedure.
  *  The procedure will continue until a single connection is established or the


### PR DESCRIPTION
The SPHINXOPTS option was not aligned with latest changes in CMake, and SPHINXOPTS_EXTRA was not present.