### PR TITLE
pinctrl: rv32m1: delay init priority after the clock controller

### DIFF
--- a/drivers/pinctrl/Kconfig.rv32m1
+++ b/drivers/pinctrl/Kconfig.rv32m1
@@ -7,3 +7,10 @@ config PINCTRL_RV32M1
 	depends on DT_HAS_OPENISA_RV32M1_PINMUX_ENABLED
 	help
 	  Enable the RV32M1 pin controller driver.
+
+config PINCTRL_RV32M1_INIT_PRIORITY
+	int "RV32M1 initialization priority"
+	default 35
+	depends on PINCTRL_RV32M1
+	help
+	  RV32M1 pin controller initialization priority.

--- a/drivers/pinctrl/pinctrl_rv32m1.c
+++ b/drivers/pinctrl/pinctrl_rv32m1.c
@@ -61,7 +61,7 @@ static int pinctrl_rv32m1_init(const struct device *dev)
 			    NULL,					\
 			    NULL, &pinctrl_rv32m1_##n##_config,		\
 			    PRE_KERNEL_1,				\
-			    1,						\
+			    CONFIG_PINCTRL_RV32M1_INIT_PRIORITY,	\
 			    NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(PINCTRL_RV32M1_INIT)


### PR DESCRIPTION
The rv32m1 pinctrl driver depends on clock controller, add a new symbol and set it so it gets initialized after that, and before other devices.

Fixes:

$ west build -p -b rv32m1_vega_ri5cy tests/kernel/common \
		-DCONFIG_CHECK_INIT_PRIORITIES=y
...
ERROR: /soc/pinmux@41037000 PRE_KERNEL_1 1 < \
		/soc/clock-controller@41027000 PRE_KERNEL_1 30