### PR TITLE
dma: iproc_pax_v2: delay initialization after pcie

### DIFF
--- a/drivers/dma/Kconfig.iproc_pax
+++ b/drivers/dma/Kconfig.iproc_pax
@@ -15,6 +15,13 @@ config DMA_IPROC_PAX_V2
 	depends on DT_HAS_BRCM_IPROC_PAX_DMA_V2_ENABLED
 	depends on PCIE_EP_IPROC_V2
 
+config DMA_IPROC_PAX_V2_INIT_PRIORITY
+	int "Broadcom PAX v2 initialization priority"
+	default 51
+	depends on DMA_IPROC_PAX_V2
+	help
+	  Broadcom PAX v2 initialization priority.
+
 if DMA_IPROC_PAX || DMA_IPROC_PAX_V2
 
 config DMA_IPROC_PAX_DEBUG

--- a/drivers/dma/dma_iproc_pax_v2.c
+++ b/drivers/dma/dma_iproc_pax_v2.c
@@ -1102,5 +1102,5 @@ DEVICE_DT_INST_DEFINE(0,
 		    &pax_dma_data,
 		    &pax_dma_cfg,
 		    POST_KERNEL,
-		    CONFIG_DMA_INIT_PRIORITY,
+		    CONFIG_DMA_IPROC_PAX_V2_INIT_PRIORITY,
 		    &pax_dma_driver_api);


### PR DESCRIPTION
The Broadcom pcie setup has a devicetree dependency like:

/pcie/paxdma -> /pcie/pcie -> /soc/pl330

Add a separate init symbol for iproc_pax_v2 so that these gets initialized in order, fixes this error:

```
$ west build -p -b bcm958402m2_m7 tests/kernel/common \
	-DCONFIG_CHECK_INIT_PRIORITIES=y
...
ERROR: /pcie/paxdma@4e100800 POST_KERNEL 40 < /pcie/pcie@4e100000 POST_KERNEL 50
```