### PR TITLE
net: ieee802154: Add transmission with multiple CCA

### DIFF
--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -103,6 +103,16 @@ config IEEE802154_SELECTIVE_TXPOWER
 	help
 	  Enable support for selectively setting TX power for every transmission request.
 
+config IEEE802154_MULTIPLE_CCA
+	bool "Support for multiple CCA attempts before transmission"
+	help
+	  This is an optional extension not conforming to IEEE Std. 802.15.4-2015.
+	  When this option is enabled the user of ieee802154_radio_api has possibility
+	  to express the maximum number of extra CCA attempts for net_pkt. The extra
+	  CCA attempts are performed back-to-back when previous CCA attempt ended with
+	  a busy channel condition. Because of that the moment of transmission can be
+	  delayed by the time taken by the extra CCA operations performed.
+
 module = IEEE802154_DRIVER
 module-str = IEEE 802.15.4 driver
 module-help = Sets log level for IEEE 802.15.4 Device Drivers.

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -88,15 +88,4 @@ config IEEE802154_NRF5_LOG_RX_FAILURES
 	  It can be helpful for the network traffic analyze but it generates also
 	  a lot of log records in a stress environment.
 
-config IEEE802154_NRF5_MULTIPLE_CCA
-	bool "Support for multiple CCA attempts before transmission"
-	help
-	  This is an optional extension not conforming to IEEE Std. 802.15.4-2015.
-	  When this option is enabled the user of ieee802154_nrf5 has possibility
-	  to express the maximum number of extra CCA attempts for a transmission.
-	  The CCA procedure is repeated back-to-back either until it returns
-	  idle channel and the transmission starts, or until 1 + `extra cca attempts`
-	  CCA attempts are performed. Because of that the moment of transmission can be
-	  delayed by the time taken by the extra CCA operations performed.
-
 endif

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -546,8 +546,7 @@ static uint64_t target_time_convert_to_64_bits(uint32_t target_time)
 	return result;
 }
 
-static bool nrf5_tx_at(struct nrf5_802154_data *nrf5_radio, struct net_pkt *pkt,
-		   uint8_t *payload, bool cca)
+static bool nrf5_tx_at(struct net_pkt *pkt, uint8_t *payload, bool cca)
 {
 	nrf_802154_transmit_at_metadata_t metadata = {
 		.frame_props = {
@@ -562,9 +561,6 @@ static bool nrf5_tx_at(struct nrf5_802154_data *nrf5_radio, struct net_pkt *pkt,
 			.power = net_pkt_ieee802154_txpwr(pkt),
 #endif
 		},
-#if defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA)
-		.extra_cca_attempts = nrf5_radio->extra_cca_attempts
-#endif
 	};
 	uint64_t tx_at = target_time_convert_to_64_bits(net_pkt_txtime(pkt) / NSEC_PER_USEC);
 
@@ -605,7 +601,7 @@ static int nrf5_tx(const struct device *dev,
 	case IEEE802154_TX_MODE_TXTIME:
 	case IEEE802154_TX_MODE_TXTIME_CCA:
 		__ASSERT_NO_MSG(pkt);
-		ret = nrf5_tx_at(nrf5_radio, pkt, nrf5_radio->tx_psdu,
+		ret = nrf5_tx_at(pkt, nrf5_radio->tx_psdu,
 				 mode == IEEE802154_TX_MODE_TXTIME_CCA);
 		break;
 #endif /* CONFIG_NET_PKT_TXTIME */
@@ -1160,22 +1156,6 @@ void nrf_802154_serialization_error(const nrf_802154_ser_err_data_t *err)
 	k_oops();
 }
 #endif
-
-#if defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA)
-void ieee802154_nrf5_extra_cca_attempts_set(const struct device *dev, uint8_t value)
-{
-	struct nrf5_802154_data *nrf5_radio = NRF5_802154_DATA(dev);
-
-	nrf5_radio->extra_cca_attempts = value;
-}
-
-uint8_t ieee802154_nrf5_extra_cca_attempts_get(const struct device *dev)
-{
-	struct nrf5_802154_data *nrf5_radio = NRF5_802154_DATA(dev);
-
-	return nrf5_radio->extra_cca_attempts;
-}
-#endif /* defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA) */
 
 static const struct nrf5_802154_config nrf5_radio_cfg = {
 	.irq_config_func = nrf5_irq_config,

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -561,6 +561,9 @@ static bool nrf5_tx_at(struct net_pkt *pkt, uint8_t *payload, bool cca)
 			.power = net_pkt_ieee802154_txpwr(pkt),
 #endif
 		},
+#if defined(CONFIG_IEEE802154_MULTIPLE_CCA)
+		.extra_cca_attempts = net_pkt_ieee802154_extra_cca_attempts(pkt),
+#endif
 	};
 	uint64_t tx_at = target_time_convert_to_64_bits(net_pkt_txtime(pkt) / NSEC_PER_USEC);
 

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -89,39 +89,6 @@ struct nrf5_802154_data {
 
 	/* Indicates if currently processed TX frame has dynamic data updated. */
 	bool tx_frame_mac_hdr_rdy;
-
-#if defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA)
-	/* The maximum number of extra CCA attempts to be performed before transmission. */
-	uint8_t extra_cca_attempts;
-#endif
 };
-
-#if defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA)
-/**
- * @brief Sets the maximum number of extra CCA attempts to be performed by a transmit operation
- *
- * The default value of extra cca attempts is 0.
- *
- * The maximum number of extra cca attempts set by this function is applied to transmissions
- * requested with mode IEEE802154_TX_MODE_TXTIME_CCA only. This might change in the future, so
- * it is recommended to restore previously used value after each transmission. See
- * @ref ieee802154_nrf5_extra_cca_attempts_get.
- *
- * @param dev    Pointer to a ieee802154_nrf5 device
- * @param value  Value to set. Allowed range is 0...254.
- */
-void ieee802154_nrf5_extra_cca_attempts_set(const struct device *dev, uint8_t value);
-
-/**
- * @brief Gets the maximum number of extra CCA attempts to be performed by a transmit operation.
- *
- * @sa @ref ieee802154_nrf5_extra_cca_attempts_set
- *
- * @param dev    Pointer to a ieee802154_nrf5 device
- * @return       Maximum number of extra CCA attempts.
- */
-uint8_t ieee802154_nrf5_extra_cca_attempts_get(const struct device *dev);
-
-#endif /* defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA) */
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_NRF5_H_ */

--- a/include/zephyr/net/ieee802154_pkt.h
+++ b/include/zephyr/net/ieee802154_pkt.h
@@ -59,10 +59,21 @@ struct net_pkt_cb_ieee802154 {
 			 */
 			uint8_t rssi;
 		};
-#if defined(CONFIG_IEEE802154_SELECTIVE_TXPOWER)
+#if defined(CONFIG_IEEE802154_SELECTIVE_TXPOWER) || \
+	defined(CONFIG_IEEE802154_MULTIPLE_CCA)
 		/* TX packets */
 		struct {
+#if defined(CONFIG_IEEE802154_SELECTIVE_TXPOWER)
 			int8_t txpwr; /* TX power in dBm. */
+#endif /* CONFIG_IEEE802154_SELECTIVE_TXPOWER */
+#if defined(CONFIG_IEEE802154_MULTIPLE_CCA)
+			/* The number of extra CCA attempts to be performed.
+			 * This field applies only to transmissions requested with
+			 * IEEE802154_TX_MODE_TXTIME_CCA mode.
+			 */
+			uint8_t extra_cca_attempts;
+#endif /* CONFIG_IEEE802154_MULTIPLE_CCA */
+
 		};
 #endif /* CONFIG_IEEE802154_SELECTIVE_TXPOWER */
 	};
@@ -200,6 +211,19 @@ static inline void net_pkt_set_ieee802154_txpwr(struct net_pkt *pkt, int8_t txpw
 	net_pkt_cb_ieee802154(pkt)->txpwr = txpwr;
 }
 #endif /* CONFIG_IEEE802154_SELECTIVE_TXPOWER */
+
+#if defined(CONFIG_IEEE802154_MULTIPLE_CCA)
+static inline uint8_t net_pkt_ieee802154_extra_cca_attempts(struct net_pkt *pkt)
+{
+	return net_pkt_cb_ieee802154(pkt)->extra_cca_attempts;
+}
+
+static inline void net_pkt_set_ieee802154_extra_cca_attempts(struct net_pkt *pkt,
+			uint8_t extra_cca_attempts)
+{
+	net_pkt_cb_ieee802154(pkt)->extra_cca_attempts = extra_cca_attempts;
+}
+#endif /* CONFIG_IEEE802154_MULTIPLE_CCA */
 
 static inline bool net_pkt_ieee802154_arb(struct net_pkt *pkt)
 {


### PR DESCRIPTION
The Kconfig IEEE802154_MULTIPLE_CCA option is added. The net_pkt_cb_ieee802154 is extended allowing to express the number of additional CCA attempts to perform.
The ieee802154_nrf5.c is updated allowing to pass extra cca attempts to nRF 802.15.4 Radio Driver.

This PR is to enable usage of new feature of nRF 802.15.4 Radio Driver from Nordic Semiconductor.
The nRF 802.15.4 Radio Driver will be delivered soon to https://github.com/zephyrproject-rtos/hal_nordic

This reverts also https://github.com/zephyrproject-rtos/zephyr/pull/60390 and moves the feature from vendor-specific space to general 802.15.4 space.