### PR TITLE
doc: Drop asterisk from Doxygen @params

### DIFF
--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -168,7 +168,7 @@ void stm32_exti_trigger(int line, int trigger)
  *
  * Check EXTI lines in exti_range for pending interrupts
  *
- * @param *exti_range Pointer to a exti_range structure
+ * @param exti_range Pointer to a exti_range structure
  */
 static void stm32_exti_isr(const void *exti_range)
 {

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -5004,8 +5004,8 @@ error:
 /**
  * @brief  compares two version strings with any delimiter
  *
- * @param  *v1: version string 1
- * @param  *v2: version string 2
+ * @param  v1: version string 1
+ * @param  v2: version string 2
  *
  * @retval 0 if equal, < 0 if v1 < v2, > 0 if v1 > v2.
  */

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -126,7 +126,7 @@ struct modem_cmd_handler_data {
 /**
  * @brief  get the last error code
  *
- * @param  *data: command handler data reference
+ * @param  data: command handler data reference
  *
  * @retval last handled error.
  */
@@ -135,8 +135,8 @@ int modem_cmd_handler_get_error(struct modem_cmd_handler_data *data);
 /**
  * @brief  set the last error code
  *
- * @param  *data: command handler data reference
- * @param  *error_code: error
+ * @param  data: command handler data reference
+ * @param  error_code: error
  *
  * @retval 0 if ok, < 0 if error.
  */
@@ -146,8 +146,8 @@ int modem_cmd_handler_set_error(struct modem_cmd_handler_data *data,
 /**
  * @brief  update the parser's handler commands
  *
- * @param  *data: handler data to use
- * @param  *handler_cmds: commands to attach
+ * @param  data: handler data to use
+ * @param  handler_cmds: commands to attach
  * @param  handler_cmds_len: size of commands array
  * @param  reset_error_flag: reset last error code
  *
@@ -165,12 +165,12 @@ int modem_cmd_handler_update_cmds(struct modem_cmd_handler_data *data,
  * specific behavior regarding acquiring tx_lock, setting and unsetting
  * @a handler_cmds.
  *
- * @param  *iface: interface to use
- * @param  *handler: command handler to use
- * @param  *handler_cmds: commands to attach
+ * @param  iface: interface to use
+ * @param  handler: command handler to use
+ * @param  handler_cmds: commands to attach
  * @param  handler_cmds_len: size of commands array
- * @param  *buf: NULL terminated send buffer
- * @param  *sem: wait for response semaphore
+ * @param  buf: NULL terminated send buffer
+ * @param  sem: wait for response semaphore
  * @param  timeout: timeout of command
  * @param  flags: flags which influence behavior of command sending
  *
@@ -185,12 +185,12 @@ int modem_cmd_send_ext(struct modem_iface *iface,
 /**
  * @brief  send AT command to interface w/o locking TX
  *
- * @param  *iface: interface to use
- * @param  *handler: command handler to use
- * @param  *handler_cmds: commands to attach
+ * @param  iface: interface to use
+ * @param  handler: command handler to use
+ * @param  handler_cmds: commands to attach
  * @param  handler_cmds_len: size of commands array
- * @param  *buf: NULL terminated send buffer
- * @param  *sem: wait for response semaphore
+ * @param  buf: NULL terminated send buffer
+ * @param  sem: wait for response semaphore
  * @param  timeout: timeout of command
  *
  * @retval 0 if ok, < 0 if error.
@@ -210,12 +210,12 @@ static inline int modem_cmd_send_nolock(struct modem_iface *iface,
 /**
  * @brief  send AT command to interface w/ a TX lock
  *
- * @param  *iface: interface to use
- * @param  *handler: command handler to use
- * @param  *handler_cmds: commands to attach
+ * @param  iface: interface to use
+ * @param  handler: command handler to use
+ * @param  handler_cmds: commands to attach
  * @param  handler_cmds_len: size of commands array
- * @param  *buf: NULL terminated send buffer
- * @param  *sem: wait for response semaphore
+ * @param  buf: NULL terminated send buffer
+ * @param  sem: wait for response semaphore
  * @param  timeout: timeout of command
  *
  * @retval 0 if ok, < 0 if error.
@@ -233,11 +233,11 @@ static inline int modem_cmd_send(struct modem_iface *iface,
 /**
  * @brief  send a series of AT commands w/ a TX lock
  *
- * @param  *iface: interface to use
- * @param  *handler: command handler to use
- * @param  *cmds: array of setup commands to send
+ * @param  iface: interface to use
+ * @param  handler: command handler to use
+ * @param  cmds: array of setup commands to send
  * @param  cmds_len: size of the setup command array
- * @param  *sem: wait for response semaphore
+ * @param  sem: wait for response semaphore
  * @param  timeout: timeout of command
  *
  * @retval 0 if ok, < 0 if error.
@@ -250,11 +250,11 @@ int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
 /**
  * @brief  send a series of AT commands w/o locking TX
  *
- * @param  *iface: interface to use
- * @param  *handler: command handler to use
- * @param  *cmds: array of setup commands to send
+ * @param  iface: interface to use
+ * @param  handler: command handler to use
+ * @param  cmds: array of setup commands to send
  * @param  cmds_len: size of the setup command array
- * @param  *sem: wait for response semaphore
+ * @param  sem: wait for response semaphore
  * @param  timeout: timeout of command
  *
  * @retval 0 if ok, < 0 if error.
@@ -325,7 +325,7 @@ int modem_cmd_handler_init(struct modem_cmd_handler *handler,
  * when one needs to prevent threads from sending UART data to the modem for an
  * extended period of time (for example during modem reset).
  *
- * @param  *handler: command handler to lock
+ * @param  handler: command handler to lock
  * @param  timeout: give up after timeout
  *
  * @retval 0 if ok, < 0 if error.
@@ -336,7 +336,7 @@ int modem_cmd_handler_tx_lock(struct modem_cmd_handler *handler,
 /**
  * @brief  Unlock the modem for sending cmds
  *
- * @param  *handler: command handler to unlock
+ * @param  handler: command handler to unlock
  */
 void modem_cmd_handler_tx_unlock(struct modem_cmd_handler *handler);
 

--- a/drivers/modem/modem_context.c
+++ b/drivers/modem/modem_context.c
@@ -76,7 +76,7 @@ int modem_context_get_addr_port(const struct sockaddr *addr, uint16_t *port)
 /**
  * @brief  Finds modem context which owns the iface device.
  *
- * @param  *dev: device used by the modem iface.
+ * @param  dev: device used by the modem iface.
  *
  * @retval Modem context or NULL.
  */
@@ -99,7 +99,7 @@ struct modem_context *modem_context_from_iface_dev(const struct device *dev)
  * @note   Amount of stored modem contexts is determined by
  *         CONFIG_MODEM_CONTEXT_MAX_NUM.
  *
- * @param  *ctx: modem context to persist.
+ * @param  ctx: modem context to persist.
  *
  * @retval 0 if ok, < 0 if error.
  */

--- a/drivers/modem/modem_context.h
+++ b/drivers/modem/modem_context.h
@@ -105,7 +105,7 @@ struct modem_context *modem_context_from_id(int id);
 /**
  * @brief  Finds modem context which owns the iface device.
  *
- * @param  *dev: device used by the modem iface.
+ * @param  dev: device used by the modem iface.
  *
  * @retval Modem context or NULL.
  */
@@ -116,7 +116,7 @@ struct modem_context *modem_context_from_iface_dev(const struct device *dev);
  *
  * @note   Prepares modem context to be used.
  *
- * @param  *ctx: modem context to register.
+ * @param  ctx: modem context to register.
  *
  * @retval 0 if ok, < 0 if error.
  */

--- a/drivers/modem/modem_iface_uart.h
+++ b/drivers/modem/modem_iface_uart.h
@@ -42,8 +42,8 @@ struct modem_iface_uart_data {
  *
  * @details This can be called after the init if the UART is changed.
  *
- * @param  *iface: modem interface to initialize.
- * @param  *dev_name: name of the UART device to use
+ * @param  iface: modem interface to initialize.
+ * @param  dev_name: name of the UART device to use
  *
  * @retval 0 if ok, < 0 if error.
  */

--- a/drivers/modem/modem_iface_uart_interrupt.c
+++ b/drivers/modem/modem_iface_uart_interrupt.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(modem_iface_uart, CONFIG_MODEM_LOG_LEVEL);
  *
  * @note   Discards remaining data.
  *
- * @param  *iface: modem interface.
+ * @param  iface: modem interface.
  *
  * @retval None.
  */
@@ -43,7 +43,7 @@ static void modem_iface_uart_flush(struct modem_iface *iface)
  * @note   Fills interfaces ring buffer with received data.
  *         When ring buffer is full the data is discarded.
  *
- * @param  *uart_dev: uart device.
+ * @param  uart_dev: uart device.
  *
  * @retval None.
  */

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -30,7 +30,7 @@ static struct mdm_receiver_context *contexts[MAX_MDM_CTX];
 /**
  * @brief  Finds receiver context which manages provided device.
  *
- * @param  *dev: device used by the receiver context.
+ * @param  dev: device used by the receiver context.
  *
  * @retval Receiver context or NULL.
  */
@@ -53,7 +53,7 @@ static struct mdm_receiver_context *context_from_dev(const struct device *dev)
  * @note   Amount of stored receiver contexts is determined by
  *         MAX_MDM_CTX.
  *
- * @param  *ctx: receiver context to persist.
+ * @param  ctx: receiver context to persist.
  *
  * @retval 0 if ok, < 0 if error.
  */
@@ -76,7 +76,7 @@ static int mdm_receiver_get(struct mdm_receiver_context *ctx)
  *
  * @note   Discards remaining data.
  *
- * @param  *ctx: receiver context.
+ * @param  ctx: receiver context.
  *
  * @retval None.
  */
@@ -98,7 +98,7 @@ static void mdm_receiver_flush(struct mdm_receiver_context *ctx)
  * @note   Fills contexts ring buffer with received data.
  *         When ring buffer is full the data is discarded.
  *
- * @param  *uart_dev: uart device.
+ * @param  uart_dev: uart device.
  *
  * @retval None.
  */
@@ -138,7 +138,7 @@ static void mdm_receiver_isr(const struct device *uart_dev, void *user_data)
 /**
  * @brief  Configures receiver context and assigned device.
  *
- * @param  *ctx: receiver context.
+ * @param  ctx: receiver context.
  *
  * @retval None.
  */

--- a/drivers/modem/modem_receiver.h
+++ b/drivers/modem/modem_receiver.h
@@ -52,10 +52,10 @@ struct mdm_receiver_context *mdm_receiver_context_from_id(int id);
 /**
  * @brief  Get received data.
  *
- * @param  *ctx: receiver context.
- * @param  *buf: buffer to copy the received data to.
+ * @param  ctx: receiver context.
+ * @param  buf: buffer to copy the received data to.
  * @param  size: buffer size.
- * @param  *bytes_read: amount of received bytes
+ * @param  bytes_read: amount of received bytes
  *
  * @retval 0 if ok, < 0 if error.
  */
@@ -65,8 +65,8 @@ int mdm_receiver_recv(struct mdm_receiver_context *ctx,
 /**
  * @brief  Sends the data over specified receiver context.
  *
- * @param  *ctx: receiver context.
- * @param  *buf: buffer with the data to send.
+ * @param  ctx: receiver context.
+ * @param  buf: buffer with the data to send.
  * @param  size: the amount of data to send.
  *
  * @retval 0 if ok, < 0 if error.
@@ -79,9 +79,9 @@ int mdm_receiver_send(struct mdm_receiver_context *ctx,
  *
  * @note   Acquires receivers device, and prepares the context to be used.
  *
- * @param  *ctx: receiver context to register.
- * @param  *uart_dev: communication device for the receiver context.
- * @param  *buf: rx buffer to use for received data.
+ * @param  ctx: receiver context to register.
+ * @param  uart_dev: communication device for the receiver context.
+ * @param  buf: rx buffer to use for received data.
  * @param  size: rx buffer size.
  *
  * @retval 0 if ok, < 0 if error.

--- a/include/zephyr/sensing/sensing.h
+++ b/include/zephyr/sensing/sensing.h
@@ -188,7 +188,7 @@ int sensing_get_sensors(int *num_sensors, const struct sensing_sensor_info **inf
  *
  * @param cb_list callback list to be registered to sensing.
  *
- * @param *handle The opened instance handle, if failed will be set to NULL.
+ * @param handle The opened instance handle, if failed will be set to NULL.
  *
  * @return 0 on success or negative error value on failure.
  */
@@ -209,7 +209,7 @@ int sensing_open_sensor(
  *
  * @param cb_list callback list to be registered to sensing.
  *
- * @param *handle The opened instance handle, if failed will be set to NULL.
+ * @param handle The opened instance handle, if failed will be set to NULL.
  *
  * @return 0 on success or negative error value on failure.
  */

--- a/include/zephyr/sensing/sensing_sensor.h
+++ b/include/zephyr/sensing/sensing_sensor.h
@@ -169,7 +169,7 @@ int sensing_sensor_post_data(
  * @param max_handles The max count of the \p reporter_handles array input. Can
  * get real count number via \ref sensing_sensor_get_reporters_count
  *
- * @param *reporter_handles Input handles array for receiving found reporter
+ * @param reporter_handles Input handles array for receiving found reporter
  * sensor instances
  *
  * @return number of reporters found, 0 returned if not found.

--- a/include/zephyr/sys/crc.h
+++ b/include/zephyr/sys/crc.h
@@ -215,7 +215,7 @@ static inline uint16_t crc16_ansi(const uint8_t *src, size_t len)
 /**
  * @brief Generate IEEE conform CRC32 checksum.
  *
- * @param  *data        Pointer to data on which the CRC should be calculated.
+ * @param  data         Pointer to data on which the CRC should be calculated.
  * @param  len          Data length.
  *
  * @return CRC32 value.
@@ -227,7 +227,7 @@ uint32_t crc32_ieee(const uint8_t *data, size_t len);
  * @brief Update an IEEE conforming CRC32 checksum.
  *
  * @param crc   CRC32 checksum that needs to be updated.
- * @param *data Pointer to data on which the CRC should be calculated.
+ * @param data  Pointer to data on which the CRC should be calculated.
  * @param len   Data length.
  *
  * @return CRC32 value.
@@ -239,7 +239,7 @@ uint32_t crc32_ieee_update(uint32_t crc, const uint8_t *data, size_t len);
  * @brief Calculate CRC32C (Castagnoli) checksum.
  *
  * @param crc       CRC32C checksum that needs to be updated.
- * @param *data     Pointer to data on which the CRC should be calculated.
+ * @param data      Pointer to data on which the CRC should be calculated.
  * @param len       Data length.
  * @param first_pkt Whether this is the first packet in the stream.
  * @param last_pkt  Whether this is the last packet in the stream.


### PR DESCRIPTION
The name of Doxygen `@param`s that are pointers should not include an asterisk.