### PR TITLE
samples: net: dns_resolve: Improve DHCPv4 handling

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1210,6 +1210,29 @@ __syscall bool net_if_ipv6_addr_rm_by_index(int index,
 					    const struct in6_addr *addr);
 
 /**
+ * @typedef net_if_ip_addr_cb_t
+ * @brief Callback used while iterating over network interface IP addresses
+ *
+ * @param iface Pointer to the network interface the address belongs to
+ * @param addr Pointer to current IP address
+ * @param user_data A valid pointer to user data or NULL
+ */
+typedef void (*net_if_ip_addr_cb_t)(struct net_if *iface,
+				    struct net_if_addr *addr,
+				    void *user_data);
+
+/**
+ * @brief Go through all IPv6 addresses on a network interface and call callback
+ * for each used address.
+ *
+ * @param iface Pointer to the network interface
+ * @param cb User-supplied callback function to call
+ * @param user_data User specified data
+ */
+void net_if_ipv6_addr_foreach(struct net_if *iface, net_if_ip_addr_cb_t cb,
+			      void *user_data);
+
+/**
  * @brief Add a IPv6 multicast address to an interface
  *
  * @param iface Network interface
@@ -1839,6 +1862,17 @@ __syscall bool net_if_ipv4_addr_add_by_index(int index,
  */
 __syscall bool net_if_ipv4_addr_rm_by_index(int index,
 					    const struct in_addr *addr);
+
+/**
+ * @brief Go through all IPv4 addresses on a network interface and call callback
+ * for each used address.
+ *
+ * @param iface Pointer to the network interface
+ * @param cb User-supplied callback function to call
+ * @param user_data User specified data
+ */
+void net_if_ipv4_addr_foreach(struct net_if *iface, net_if_ip_addr_cb_t cb,
+			      void *user_data);
 
 /**
  * @brief Add a IPv4 multicast address to an interface

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1982,6 +1982,36 @@ bool z_vrfy_net_if_ipv6_addr_rm_by_index(int index,
 #include <syscalls/net_if_ipv6_addr_rm_by_index_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
+void net_if_ipv6_addr_foreach(struct net_if *iface, net_if_ip_addr_cb_t cb,
+			      void *user_data)
+{
+	struct net_if_ipv6 *ipv6;
+
+	if (iface == NULL) {
+		return;
+	}
+
+	net_if_lock(iface);
+
+	ipv6 = iface->config.ip.ipv6;
+	if (ipv6 == NULL) {
+		goto out;
+	}
+
+	for (int i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+		struct net_if_addr *if_addr = &ipv6->unicast[i];
+
+		if (!if_addr->is_used) {
+			continue;
+		}
+
+		cb(iface, if_addr, user_data);
+	}
+
+out:
+	net_if_unlock(iface);
+}
+
 struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 						const struct in6_addr *addr)
 {
@@ -3783,6 +3813,36 @@ bool z_vrfy_net_if_ipv4_addr_rm_by_index(int index,
 
 #include <syscalls/net_if_ipv4_addr_rm_by_index_mrsh.c>
 #endif /* CONFIG_USERSPACE */
+
+void net_if_ipv4_addr_foreach(struct net_if *iface, net_if_ip_addr_cb_t cb,
+			      void *user_data)
+{
+	struct net_if_ipv4 *ipv4;
+
+	if (iface == NULL) {
+		return;
+	}
+
+	net_if_lock(iface);
+
+	ipv4 = iface->config.ip.ipv4;
+	if (ipv4 == NULL) {
+		goto out;
+	}
+
+	for (int i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+		struct net_if_addr *if_addr = &ipv4->unicast[i];
+
+		if (!if_addr->is_used) {
+			continue;
+		}
+
+		cb(iface, if_addr, user_data);
+	}
+
+out:
+	net_if_unlock(iface);
+}
 
 static struct net_if_mcast_addr *ipv4_maddr_find(struct net_if *iface,
 						 bool is_used,


### PR DESCRIPTION
There is some ambiguity with the DHCPv4 handling in the dns_resolve sample. On one hand, the sample uses net_config library, which does initiate the DHCPv4 on the interface (if enabled) and may block the initialization until the address is assigned (in case there is no other statically assigned IPv4 addresses.) On the other hand, the sample registers for NET_EVENT_IPV4_ADDR_ADD in case DHCPv4 is in use, delaying the DNS queries until address is assigned.

In case net_config delayed the initialization however, this will not work, as the event handler will be registered only after DHCPv4 address is assigned, so the callback will not get executed.

Fix this, by checking if DHCPv4 assigned address already exists on an interface - if so, schedule DNS queries immediately. Otherwise (for example in case when net_config was not configured to wait for address) register an event callback, and schedule queries from there.