### PR TITLE
net: if: Fix if_ipv4_get_addr() locking

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3285,11 +3285,11 @@ static struct in_addr *if_ipv4_get_addr(struct net_if *iface,
 	struct net_if_ipv4 *ipv4;
 	int i;
 
-	net_if_lock(iface);
-
 	if (!iface) {
-		goto out;
+		return NULL;
 	}
+
+	net_if_lock(iface);
 
 	ipv4 = iface->config.ip.ipv4;
 	if (!ipv4) {


### PR DESCRIPTION
net_if_lock() should be called only after iface pointer is verified not to be NULL, otherwise we can end up dereferencing NULL pointer in certain corner cases.