### PR TITLE
modules: hal_nordic: nrfx: Make ISO IN ZLP configurable

### DIFF
--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -381,6 +381,15 @@ config NRFX_USBD
 	bool "USBD driver"
 	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_USBD))
 
+config NRFX_USBD_ISO_IN_ZLP
+	bool "Send ZLP on ISO IN when not ready"
+	depends on NRFX_USBD
+	default y
+	help
+	  Controls the response of the ISO IN endpoint to an IN token when no
+	  data is ready to be sent. When enabled, ZLP is sent when no data is
+	  ready. When disabled, no response is sent (bus timeout occurs).
+
 config NRFX_USBREG
 	bool "USBREG driver"
 	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_USBREG))

--- a/modules/hal_nordic/nrfx/nrfx_config.h
+++ b/modules/hal_nordic/nrfx/nrfx_config.h
@@ -364,6 +364,10 @@
 #define NRFX_USBD_ENABLED 1
 #endif
 
+#ifdef CONFIG_NRFX_USBD_ISO_IN_ZLP
+#define NRFX_USBD_CONFIG_ISO_IN_ZLP 1
+#endif
+
 #ifdef CONFIG_NRFX_USBREG
 #define NRFX_USBREG_ENABLED 1
 #endif


### PR DESCRIPTION
nRF USBD ISOINCONFIG register controls USBD behavior after receiving IN token addressed to ISO IN endpoint when the endpoint was not armed with data. The options are:
  * NoResp, in which case there is no response (i.e. bus timeout)
  * ZeroData, in which case device responds with ZLP

This commit both makes the ISOINCONFIG value configurable and changes the default from NoResp to ZeroData. For reference, DWC_otg controller will always send ZLP in such case and does not have NoResp equivalent.

Automatically sending ZLP when ISO IN endpoint is not armed resolves periodic audio dropouts observed on Mac OS with USB Audio headset sample. Apple USB Audio class driver will attempt recovery (abort all pending URBs, switch to alternate config 0, switch to active alternate config and submit new URBs) every time it sees kIOReturnNotResponding status code. During recovery no audio data can be transferred and therefore there are gaps in the audio stream.

Apple USB Audio driver sees kIOReturnNotResponding when there is bus timeout (i.e. IN token was sent to nRF when the endpoint was not armed and NoResp option was active). Activating ZeroData option results in perfectly fine (albeit short) packet that does not trigger interface recovery and thus fixes the USB Audio issues on Mac OS.