### PR TITLE
Bluetooth: Host: Introduce BT_CONN_PARAM_ANY

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -299,6 +299,18 @@ config BT_CONN_TX_MAX
 	  callback. Normally this can be left to the default value, which
 	  is equal to the number of TX buffers in the stack-internal pool.
 
+config BT_CONN_PARAM_ANY
+	bool "Accept any values for connection parameters"
+	help
+	  Some controllers support additional connection parameter ranges
+	  beyond what is described in the specification. Enabling this option
+	  allows the application to set any value to all connection parameters.
+	  Tbe Host will perform no limits nor consistency checks on any of the
+	  connection parameters (conn interval min and max, latency and timeout).
+	  However, the Host will still use numerical comparisons between the
+	  min and max connection intervals in order to verify whether the
+	  desired parameters have been established in the connection.
+
 config BT_USER_PHY_UPDATE
 	bool "User control of PHY Update Procedure"
 	depends on BT_PHY_UPDATE

--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -223,26 +223,26 @@ if BT_GAP_PERIPHERAL_PREF_PARAMS
 config BT_PERIPHERAL_PREF_MIN_INT
 	int "Peripheral preferred minimum connection interval in 1.25ms units"
 	default 24
-	range 6 65535
+	range 6 65535 if !BT_CONN_PARAM_ANY
 	help
 	  Range 3200 to 65534 is invalid. 65535 represents no specific value.
 
 config BT_PERIPHERAL_PREF_MAX_INT
 	int "Peripheral preferred maximum connection interval in 1.25ms units"
 	default 40
-	range 6 65535
+	range 6 65535 if !BT_CONN_PARAM_ANY
 	help
 	  Range 3200 to 65534 is invalid. 65535 represents no specific value.
 
 config BT_PERIPHERAL_PREF_LATENCY
 	int "Peripheral preferred peripheral latency in Connection Intervals"
 	default 0
-	range 0 499
+	range 0 499 if !BT_CONN_PARAM_ANY
 
 config BT_PERIPHERAL_PREF_TIMEOUT
 	int "Peripheral preferred supervision timeout in 10ms units"
 	default 42
-	range 10 65535
+	range 10 65535 if !BT_CONN_PARAM_ANY
 	help
 	  It is up to user to provide valid timeout which pass required minimum
 	  value: in milliseconds it shall be larger than

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1699,6 +1699,10 @@ static void le_phy_update_complete(struct net_buf *buf)
 
 bool bt_le_conn_params_valid(const struct bt_le_conn_param *param)
 {
+	if (IS_ENABLED(CONFIG_BT_CONN_PARAM_ANY)) {
+		return true;
+	}
+
 	/* All limits according to BT Core spec 5.0 [Vol 2, Part E, 7.8.12] */
 
 	if (param->interval_min > param->interval_max ||


### PR DESCRIPTION
Some controllers support additional connection parameter ranges beyond what is described in the specification. Enabling this new option allows the application to set any value to all connection parameters. Tbe Host will perform no limits nor consistency checks on any of the connection parameters (conn interval min and max, latency and timeou). However, the Host will still use numerical comparisons between the min and max connection intervals in order to verify whether the desired parameters have been established in the connection.