### PR TITLE
dts: bindings: Add `st,reinit-power-states` DT property

### DIFF
--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -6,7 +6,7 @@ description: ST STM32 family ADC
 
 compatible: "st,stm32-adc"
 
-include: [adc-controller.yaml, pinctrl-device.yaml]
+include: [adc-controller.yaml, pinctrl-device.yaml, "st,power-management.yaml"]
 
 properties:
   reg:

--- a/dts/bindings/crypto/st,stm32-crypto-common.yaml
+++ b/dts/bindings/crypto/st,stm32-crypto-common.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Markus Fuchs <markus.fuchs@de.sauter-bc.com>
 # SPDX-License-Identifier: Apache-2.0
 
-include: base.yaml
+include: [base.yaml, "st,power-management.yaml"]
 
 properties:
   reg:

--- a/dts/bindings/dac/st,stm32-dac.yaml
+++ b/dts/bindings/dac/st,stm32-dac.yaml
@@ -5,7 +5,7 @@ description: ST STM32 family DAC
 
 compatible: "st,stm32-dac"
 
-include: [dac-controller.yaml, pinctrl-device.yaml]
+include: [dac-controller.yaml, pinctrl-device.yaml, "st,power-management.yaml"]
 
 properties:
   reg:

--- a/dts/bindings/dma/st,stm32-dma.yaml
+++ b/dts/bindings/dma/st,stm32-dma.yaml
@@ -13,7 +13,7 @@ description: |
 
 compatible: "st,stm32-dma"
 
-include: dma-controller.yaml
+include: [dma-controller.yaml, "st,power-management.yaml"]
 
 properties:
   reg:

--- a/dts/bindings/dma/st,stm32-dmamux.yaml
+++ b/dts/bindings/dma/st,stm32-dmamux.yaml
@@ -60,7 +60,7 @@ description: |
 
 compatible: "st,stm32-dmamux"
 
-include: dmamux-controller.yaml
+include: [dmamux-controller.yaml, "st,power-management.yaml"]
 
 properties:
   reg:

--- a/dts/bindings/i2c/st,stm32-i2c-v2.yaml
+++ b/dts/bindings/i2c/st,stm32-i2c-v2.yaml
@@ -5,7 +5,7 @@ description: STM32 I2C V2 controller
 
 compatible: "st,stm32-i2c-v2"
 
-include: [i2c-controller.yaml, pinctrl-device.yaml]
+include: [i2c-controller.yaml, pinctrl-device.yaml, "st,power-management.yaml"]
 
 properties:
   reg:

--- a/dts/bindings/power/st,power-management.yaml
+++ b/dts/bindings/power/st,power-management.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Kenneth J. Miller <ken@miller.ec>
+# SPDX-License-Identifier: Apache-2.0
+
+properties:
+  st,reinit-power-states:
+    type: phandles
+    description: |
+      Specifies special power states where a peripheral requires
+      reinitialization due to configuration loss.
+
+      While states at or beyond S2RAM are naturally assumed to need
+      reinitialization, this property highlights the exceptions to that rule.

--- a/dts/bindings/rng/st,stm32-rng.yaml
+++ b/dts/bindings/rng/st,stm32-rng.yaml
@@ -5,7 +5,7 @@ description: STM32 Random Number Generator
 
 compatible: "st,stm32-rng"
 
-include: base.yaml
+include: [base.yaml, "st,power-management.yaml"]
 
 properties:
   reg:

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -4,7 +4,7 @@
 # Common fields for STM32 UART peripherals.
 description: STM32 UART-BASE
 
-include: [uart-controller.yaml, pinctrl-device.yaml, reset-device.yaml]
+include: [uart-controller.yaml, pinctrl-device.yaml, reset-device.yaml, "st,power-management.yaml"]
 
 properties:
   reg:

--- a/dts/bindings/spi/st,stm32-spi-common.yaml
+++ b/dts/bindings/spi/st,stm32-spi-common.yaml
@@ -3,7 +3,7 @@
 
 # Common fields for STM32 SPI peripherals.
 
-include: [spi-controller.yaml, pinctrl-device.yaml]
+include: [spi-controller.yaml, pinctrl-device.yaml, "st,power-management.yaml"]
 
 properties:
   reg:

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -5,7 +5,7 @@ description: STM32 timers
 
 compatible: "st,stm32-timers"
 
-include: [base.yaml, reset-device.yaml]
+include: [base.yaml, reset-device.yaml, "st,power-management.yaml"]
 
 properties:
   reg:

--- a/include/zephyr/devicetree/pm_stm32.h
+++ b/include/zephyr/devicetree/pm_stm32.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 Kenneth J. Miller
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DEVICETREE_PM_STM32_H_
+#define ZEPHYR_INCLUDE_DEVICETREE_PM_STM32_H_
+
+#include <zephyr/pm/state.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Helper macro to initialize an entry of a struct pm_state_info array
+ * when using UTIL_LISTIFY in PM_STATE_INFO_LIST_FROM_DT_REINIT.
+ *
+ * @note Only enabled states are initialized.
+ *
+ * @param i UTIL_LISTIFY entry index.
+ * @param node_id A node identifier with compatible zephyr,power-state
+ */
+#define Z_PM_STATE_INFO_FROM_DT_REINIT(i, node_id)						   \
+	COND_CODE_1(										   \
+		DT_NODE_HAS_STATUS(DT_PHANDLE_BY_IDX(node_id, st_reinit_power_states, i), okay),   \
+		(PM_STATE_INFO_DT_INIT(DT_PHANDLE_BY_IDX(node_id, st_reinit_power_states, i)),),   \
+		())
+
+/**
+ * @brief Initialize an array of struct pm_state_info with information from all
+ * the states present and enabled in the given device node identifier.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *
+ *	cpus {
+ *		cpu0: cpu@0 {
+ *			device_type = "cpu";
+ *			...
+ *			cpu-power-states = <&state0 &state1>;
+ *		};
+ *
+ *		power-states {
+			stop1: state1 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <2>;
+				...
+			};
+			stop2: state2 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <3>;
+				...
+			};
+ *		};
+ *	};
+ *
+ *	soc {
+ *		i2c1: i2c@50000000 {
+ *			...
+ *			compatible = "st,stm32-i2c-v2";
+ *			st,reinit-power-states = <&stop2>;
+ *		};
+ *	};
+ *
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ * const struct pm_state_info states[] =
+ *	PM_STATE_INFO_LIST_FROM_DT_REINIT(DT_NODELABEL(i2c1));
+ * @endcode
+ *
+ * @param node_id A device node identifier.
+ */
+#define PM_STATE_INFO_LIST_FROM_DT_REINIT(node_id)						   \
+	{											   \
+		LISTIFY(DT_PROP_LEN_OR(node_id, st_reinit_power_states, 0),			   \
+			Z_PM_STATE_INFO_FROM_DT_REINIT, (), node_id)				   \
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DEVICETREE_PM_STM32_H_ */


### PR DESCRIPTION
### Summary

This PR adds the `st,reinit-power-states` DT binding property.
Said property is intended to describe exceptional System PM (sub)states, after which the defining peripheral instance requires reinitialization logic to regain normal operation.

Note: all states below and including S2RAM are expected to require driver action to restore operation, and these are not the target of this PR, but rather exceptions to the rule such as the S2idle state STOP2 on STM32WL.

A helper macro for building a `pm_state_info` struct array of these power-states, for various handling of critical driver sections is also included.

### Related

- #19755
- #59194 
- #37352
- #37414
- #59200 