### PR TITLE
arm64: Set FP to NULL before jumping to C code

### DIFF
--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -90,6 +90,9 @@ out:
 	/* Initialize stack */
 	mov	sp, x24
 
+	/* fp = NULL */
+	mov	fp, xzr
+
 	ret	x23
 
 /*


### PR DESCRIPTION
When the frame-pointer based unwinding is enabled, the stop condition for the stack backtrace is (FP == NULL).

Set FP to 0 before jumping to C code.