### PR TITLE
kconfig: Set `BOOTLOADER_SRAM_SIZE` default to 0

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -827,7 +827,7 @@ config IS_BOOTLOADER
 
 config BOOTLOADER_SRAM_SIZE
 	int "SRAM reserved for bootloader"
-	default 16
+	default 0
 	depends on !XIP || IS_BOOTLOADER
 	depends on ARM || XTENSA
 	help

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -20,6 +20,10 @@ API Changes
 Changes in this release
 =======================
 
+* Set :kconfig:option:`CONFIG_BOOTLOADER_SRAM_SIZE` default value to ``0`` (was
+  ``16``). Bootloaders that use a part of the SRAM should set this value to an
+  appropriate size. :github:`60371`
+
 Removed APIs in this release
 ============================
 


### PR DESCRIPTION
The current default value for `BOOTLOADER_SRAM_SIZE` is set to an arbitrary-seeming value of `16`, which feels like a random magic number.

Given that adding an offset in SRAM for a bootloader should always be a conscious choice for a specific platform, this PR sets the default to `0`. An appropriate value can be set at the SoC or board level, overriding this default.

Fixes: #49484 