### PR TITLE
include: zephyr: Fix build error in spinlock.h

### DIFF
--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -278,7 +278,7 @@ static ALWAYS_INLINE void k_spin_release(struct k_spinlock *l)
 }
 
 #if defined(CONFIG_SPIN_VALIDATE) && defined(__GNUC__)
-static ALWAYS_INLINE void z_spin_onexit(k_spinlock_key_t *k)
+static ALWAYS_INLINE void z_spin_onexit(__maybe_unused k_spinlock_key_t *k)
 {
 	__ASSERT(k->key, "K_SPINLOCK exited with goto, break or return, "
 			 "use K_SPINLOCK_BREAK instead.");


### PR DESCRIPTION
In function z_spin_onexit, when CONFIG_FORCE_NO_ASSERT=y and CONFIG_SPIN_VALIDATE=y the function parameter becomes unused. This generates a build error (unused parameter 'k').

Add __maybe_unused to fix this error.