### PR TITLE
Bluetooth: BAP: Shell: cmd_send used wrong stream for the seq_num

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2424,7 +2424,7 @@ static int cmd_send(const struct shell *sh, size_t argc, char *argv[])
 
 	net_buf_add_mem(buf, data, len);
 
-	ret = bt_bap_stream_send(default_stream, buf, get_next_seq_num(txing_stream),
+	ret = bt_bap_stream_send(default_stream, buf, get_next_seq_num(default_stream),
 				 BT_ISO_TIMESTAMP_NONE);
 	if (ret < 0) {
 		shell_print(sh, "Unable to send: %d", -ret);


### PR DESCRIPTION
get_next_seq_num was called with txing_stream instead of default_stream.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/60472