### PR TITLE
doc: Add hint for automatic power domain swiching

### DIFF
--- a/doc/services/pm/device_runtime.rst
+++ b/doc/services/pm/device_runtime.rst
@@ -26,6 +26,15 @@ asynchronously, it will be put into the
 :c:enumerator:`PM_DEVICE_STATE_SUSPENDING` state first and then into the
 :c:enumerator:`PM_DEVICE_STATE_SUSPENDED` state when the action is run.
 
+For devices on a power domain (via the devicetree 'power-domain' property), device runtime
+power management automatically attempts to request and release the dependent domain
+in response to :c:func:`pm_device_runtime_get` and :c:func:`pm_device_runtime_put`
+calls on the child device.
+
+For the previous to automatically control the power domain state, device runtime PM must be enabled
+on the power domain device (either through the `zephyr,pm-device-runtime-auto` devicetree property
+or :c:func:`pm_device_runtime_enable`).
+
 .. graphviz::
    :caption: Device states and transitions
 


### PR DESCRIPTION
Add a hint that when a device is on a power domain and the device and power domain have runtime PM,
the power domain will automatically resumed/susepended.

Shall I add this also to the API documentation somewhere? Any ideas about a good place to add it?