### PR TITLE
drivers: clock_control: stm32h5: Add MCO sources and dividers

### DIFF
--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -66,7 +66,8 @@ config CLOCK_STM32_MCO1_SRC_LSE
 	depends on SOC_SERIES_STM32F4X || \
 	           SOC_SERIES_STM32F7X || \
 	           SOC_SERIES_STM32L4X || \
-	           SOC_SERIES_STM32H7X
+	           SOC_SERIES_STM32H7X || \
+	           SOC_SERIES_STM32H5X
 	help
 	  Use LSE as source of MCO1
 
@@ -76,7 +77,8 @@ config CLOCK_STM32_MCO1_SRC_HSE
 	           SOC_SERIES_STM32F4X || \
 	           SOC_SERIES_STM32F7X || \
 	           SOC_SERIES_STM32L4X || \
-	           SOC_SERIES_STM32H7X
+	           SOC_SERIES_STM32H7X || \
+	           SOC_SERIES_STM32H5X
 	help
 	  Use HSE as source of MCO1
 
@@ -97,7 +99,8 @@ config CLOCK_STM32_MCO1_SRC_HSI
 	depends on SOC_SERIES_STM32F1X || \
 	           SOC_SERIES_STM32F4X || \
 	           SOC_SERIES_STM32F7X || \
-	           SOC_SERIES_STM32H7X
+	           SOC_SERIES_STM32H7X || \
+	           SOC_SERIES_STM32H5X
 	help
 	  Use HSI as source of MCO1
 
@@ -110,7 +113,8 @@ config CLOCK_STM32_MCO1_SRC_HSI16
 config CLOCK_STM32_MCO1_SRC_HSI48
 	bool "HSI48"
 	depends on SOC_SERIES_STM32L4X || \
-	           SOC_SERIES_STM32H7X
+	           SOC_SERIES_STM32H7X || \
+	           SOC_SERIES_STM32H5X
 	help
 	  Use HSI48 as source of MCO1
 
@@ -122,7 +126,8 @@ config CLOCK_STM32_MCO1_SRC_PLLCLK
 
 config CLOCK_STM32_MCO1_SRC_PLLQCLK
 	bool "PLLQ"
-	depends on SOC_SERIES_STM32H7X
+	depends on SOC_SERIES_STM32H7X || \
+	           SOC_SERIES_STM32H5X
 	help
 	  Use PLLQ as source of MCO1
 
@@ -163,11 +168,12 @@ config CLOCK_STM32_MCO1_DIV
 	             SOC_SERIES_STM32F4X || \
 	             SOC_SERIES_STM32F7X || \
 	             SOC_SERIES_STM32L4X || \
-	             SOC_SERIES_STM32H7X \
+	             SOC_SERIES_STM32H7X || \
+	             SOC_SERIES_STM32H5X \
 	           )
 	default 1
 	range 1   5 if SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
-	range 1   15 if SOC_SERIES_STM32H7X
+	range 1   15 if SOC_SERIES_STM32H7X || SOC_SERIES_STM32H5X
 	range 1   16 if SOC_SERIES_STM32L4X
 	help
 	  Prescaler for MCO1 output clock
@@ -185,7 +191,8 @@ config CLOCK_STM32_MCO2_SRC_SYSCLK
 	bool "SYSCLK"
 	depends on SOC_SERIES_STM32F4X || \
 	           SOC_SERIES_STM32F7X || \
-	           SOC_SERIES_STM32H7X
+	           SOC_SERIES_STM32H7X || \
+	           SOC_SERIES_STM32H5X
 	help
 	  Use SYSCLK as source of MCO2
 
@@ -199,19 +206,22 @@ config CLOCK_STM32_MCO2_SRC_HSE
 	bool "HSE"
 	depends on SOC_SERIES_STM32F4X || \
 	           SOC_SERIES_STM32F7X || \
-	           SOC_SERIES_STM32H7X
+	           SOC_SERIES_STM32H7X || \
+	           SOC_SERIES_STM32H5X
 	help
 	  Use HSE as source of MCO2
 
 config CLOCK_STM32_MCO2_SRC_LSI
 	bool "LSI"
-	depends on SOC_SERIES_STM32H7X
+	depends on SOC_SERIES_STM32H7X || \
+	           SOC_SERIES_STM32H5X
 	help
 	  Use LSI as source of MCO2
 
 config CLOCK_STM32_MCO2_SRC_CSI
 	bool "CSI"
-	depends on SOC_SERIES_STM32H7X
+	depends on SOC_SERIES_STM32H7X || \
+	           SOC_SERIES_STM32H5X
 	help
 	  Use CSI as source of MCO2
 
@@ -223,13 +233,15 @@ config CLOCK_STM32_MCO2_SRC_PLLCLK
 
 config CLOCK_STM32_MCO2_SRC_PLLPCLK
 	bool "PLLPCLK"
-	depends on SOC_SERIES_STM32H7X
+	depends on SOC_SERIES_STM32H7X || \
+	           SOC_SERIES_STM32H5X
 	help
 	  Use PLLPCLK as source of MC02
 
 config CLOCK_STM32_MCO2_SRC_PLL2PCLK
 	bool "PLL2PCLK"
-	depends on SOC_SERIES_STM32H7X
+	depends on SOC_SERIES_STM32H7X || \
+	           SOC_SERIES_STM32H5X
 	help
 	  Use PLL2PCLK as source of MC02
 endchoice
@@ -243,7 +255,7 @@ config CLOCK_STM32_MCO2_DIV
 	           )
 	default 1
 	range 1 5 if SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
-	range 1 15 if SOC_SERIES_STM32H7X
+	range 1 15 if SOC_SERIES_STM32H7X || SOC_SERIES_STM32H5X
 	help
 	  Prescaler for MCO2 output clock
 

--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -18,6 +18,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include "clock_stm32_ll_mco.h"
 
 /* Macros to fill up prescaler values */
 #define z_hsi_divider(v) LL_RCC_HSI_DIV_ ## v
@@ -751,6 +752,9 @@ int stm32_clock_control_init(const struct device *dev)
 
 	/* Update CMSIS variable */
 	SystemCoreClock = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
+
+	/* configure MCO1/MCO2 based on Kconfig */
+	stm32_clock_control_mco_init();
 
 	return 0;
 }


### PR DESCRIPTION
STM32H5 series lacked support for MCO configuration. Added SOC_SERIES_STM32H5X to approperiate kconfig MCO source configurations. Added new MCO sources from H5 series and updated the clock_stm32_ll_h5.c with MCO configuration.