### PR TITLE
Bluetooth: hci: spi: Use edge sensitive interrupt and mutex fixes.

### DIFF
--- a/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
+++ b/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
@@ -5,7 +5,7 @@
  */
 
 &arduino_spi {
-	cs-gpios = <&arduino_header 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;	      /* A1 */
+	cs-gpios = <&arduino_header 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;	      /* A1 */
 
 	spbtle_rf_x_nucleo_idb05a1: spbtle-rf@0 {
 		compatible = "zephyr,bt-hci-spi";
@@ -13,5 +13,6 @@
 		reset-gpios = <&arduino_header 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; /* D7 */
 		irq-gpios = <&arduino_header 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;  /* A0 */
 		spi-max-frequency = <2000000>;
+		controller-data-delay-us = <0>;  /* No need for extra delay for BlueNRG-MS */
 	};
 };

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -287,8 +287,6 @@ static void bt_spi_rx_thread(void)
 	int len;
 
 	(void)memset(&txmsg, 0xFF, SPI_MAX_MSG_LEN);
-	/* Enable the interrupt line */
-	gpio_pin_interrupt_configure_dt(&irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 	while (true) {
 
 		/* Wait for interrupt pin to be active */
@@ -497,12 +495,12 @@ static int bt_spi_open(void)
 		return err;
 	}
 
+	/* Enable the interrupt line */
+	gpio_pin_interrupt_configure_dt(&irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+
 	/* Take BLE out of reset */
 	k_sleep(K_MSEC(DT_INST_PROP_OR(0, reset_assert_duration_ms, 0)));
 	gpio_pin_set_dt(&rst_gpio, 0);
-
-	/* Give the controller some time to boot */
-	k_sleep(K_MSEC(1));
 
 	/* Start RX thread */
 	k_thread_create(&spi_rx_thread_data, spi_rx_stack,

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -68,7 +68,6 @@ static struct gpio_callback	gpio_cb;
 
 static K_SEM_DEFINE(sem_initialised, 0, 1);
 static K_SEM_DEFINE(sem_request, 0, 1);
-static K_SEM_DEFINE(sem_done, 0, 1);
 static K_SEM_DEFINE(sem_busy, 1, 1);
 
 static K_KERNEL_STACK_DEFINE(spi_rx_stack, CONFIG_BT_DRV_RX_STACK_SIZE);
@@ -162,27 +161,11 @@ static inline uint16_t bt_spi_get_evt(uint8_t *rxmsg)
 	return (rxmsg[EVT_VENDOR_CODE_MSB] << 8) | rxmsg[EVT_VENDOR_CODE_LSB];
 }
 
-static void bt_to_inactive_isr(const struct device *unused1,
+static void bt_spi_isr(const struct device *unused1,
 		       struct gpio_callback *unused2,
 		       uint32_t unused3)
 {
 	LOG_DBG("");
-
-	/* Disable until RX thread re-enables */
-	gpio_pin_interrupt_configure_dt(&irq_gpio, GPIO_INT_DISABLE);
-
-	k_sem_give(&sem_done);
-}
-
-static void bt_to_active_isr(const struct device *unused1,
-		       struct gpio_callback *unused2,
-		       uint32_t unused3)
-{
-	LOG_DBG("");
-
-	/* Watch for the IRQ line to go inactive */
-	gpio_init_callback(&gpio_cb, bt_to_inactive_isr, BIT(irq_gpio.pin));
-	gpio_pin_interrupt_configure_dt(&irq_gpio, GPIO_INT_LEVEL_INACTIVE);
 
 	k_sem_give(&sem_request);
 }
@@ -216,8 +199,8 @@ static bool bt_spi_handle_vendor_evt(uint8_t *rxmsg)
  */
 static int configure_cs(void)
 {
-	/* Configure pin as output and set to active */
-	return gpio_pin_configure_dt(&bus.config.cs.gpio, GPIO_OUTPUT_ACTIVE);
+	/* Configure pin as output and set to inactive */
+	return gpio_pin_configure_dt(&bus.config.cs.gpio, GPIO_OUTPUT_INACTIVE);
 }
 
 static void kick_cs(void)
@@ -304,21 +287,18 @@ static void bt_spi_rx_thread(void)
 	int len;
 
 	(void)memset(&txmsg, 0xFF, SPI_MAX_MSG_LEN);
-
+	/* Enable the interrupt line */
+	gpio_pin_interrupt_configure_dt(&irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 	while (true) {
-		/* Enable the interrupt line */
-		gpio_init_callback(&gpio_cb, bt_to_active_isr, BIT(irq_gpio.pin));
-		gpio_pin_interrupt_configure_dt(&irq_gpio, GPIO_INT_LEVEL_ACTIVE);
 
 		/* Wait for interrupt pin to be active */
 		k_sem_take(&sem_request, K_FOREVER);
 
-		/* Wait for SPI bus to be available */
-		k_sem_take(&sem_busy, K_FOREVER);
-
 		LOG_DBG("");
 
 		do {
+			/* Wait for SPI bus to be available */
+			k_sem_take(&sem_busy, K_FOREVER);
 			init_irq_high_loop();
 			do {
 				kick_cs();
@@ -413,9 +393,6 @@ static void bt_spi_rx_thread(void)
 		/* On BlueNRG-MS, host is expected to read */
 		/* as long as IRQ pin is high */
 		} while (irq_pin_high());
-
-		/* Wait for IRQ to have de-asserted */
-		k_sem_take(&sem_done, K_FOREVER);
 	}
 }
 
@@ -514,7 +491,7 @@ static int bt_spi_open(void)
 		return err;
 	}
 
-	gpio_init_callback(&gpio_cb, bt_to_active_isr, BIT(irq_gpio.pin));
+	gpio_init_callback(&gpio_cb, bt_spi_isr, BIT(irq_gpio.pin));
 	err = gpio_add_callback(irq_gpio.port, &gpio_cb);
 	if (err) {
 		return err;


### PR DESCRIPTION
Revert to edge sensitive interrupt. (Fixes #59459 )
Optimized BlueNRG-MS access.
Addressed issue for mutex access of SPI.
Fixed chip select active state for x_nucleo_idb05a1.
I also tested samples/bluetooth/beacon on 96b_carbon board and it works fine; however, without my modifications in spi.c file the application crashes since ST boards do not support level trigger interrupt.