### PR TITLE
drivers: ieee802154: nrf5: Add transmission with multiple CCA

### DIFF
--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -88,4 +88,15 @@ config IEEE802154_NRF5_LOG_RX_FAILURES
 	  It can be helpful for the network traffic analyze but it generates also
 	  a lot of log records in a stress environment.
 
+config IEEE802154_NRF5_MULTIPLE_CCA
+	bool "Support for multiple CCA attempts before transmission"
+	help
+	  This is an optional extension not conforming to IEEE Std. 802.15.4-2015.
+	  When this option is enabled the user of ieee802154_nrf5 has possibility
+	  to express the maximum number of extra CCA attempts for a transmission.
+	  The CCA procedure is repeated back-to-back either until it returns
+	  idle channel and the transmission starts, or until 1 + `extra cca attempts`
+	  CCA attempts are performed. Because of that the moment of transmission can be
+	  delayed by the time taken by the extra CCA operations performed.
+
 endif

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -89,6 +89,39 @@ struct nrf5_802154_data {
 
 	/* Indicates if currently processed TX frame has dynamic data updated. */
 	bool tx_frame_mac_hdr_rdy;
+
+#if defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA)
+	/* The maximum number of extra CCA attempts to be performed before transmission. */
+	uint8_t extra_cca_attempts;
+#endif
 };
+
+#if defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA)
+/**
+ * @brief Sets the maximum number of extra CCA attempts to be performed by a transmit operation
+ *
+ * The default value of extra cca attempts is 0.
+ *
+ * The maximum number of extra cca attempts set by this function is applied to transmissions
+ * requested with mode IEEE802154_TX_MODE_TXTIME_CCA only. This might change in the future, so
+ * it is recommended to restore previously used value after each transmission. See
+ * @ref ieee802154_nrf5_extra_cca_attempts_get.
+ *
+ * @param dev    Pointer to a ieee802154_nrf5 device
+ * @param value  Value to set. Allowed range is 0...254.
+ */
+void ieee802154_nrf5_extra_cca_attempts_set(const struct device *dev, uint8_t value);
+
+/**
+ * @brief Gets the maximum number of extra CCA attempts to be performed by a transmit operation.
+ *
+ * @sa @ref ieee802154_nrf5_extra_cca_attempts_set
+ *
+ * @param dev    Pointer to a ieee802154_nrf5 device
+ * @return       Maximum number of extra CCA attempts.
+ */
+uint8_t ieee802154_nrf5_extra_cca_attempts_get(const struct device *dev);
+
+#endif /* defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA) */
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_NRF5_H_ */


### PR DESCRIPTION
The Kconfig IEEE802154_NRF5_MULTIPLE_CCA option is added.
The new functions `z_ieee802154_nrf5_extra_cca_attempts_set` and `z_ieee802154_nrf5_extra_cca_attempts_get` are added. The ieee802154_nrf5.c is updated allowing to pass extra cca attempts to nRF 802.15.4 Radio Driver.

This PR is to enable usage of new feature of nRF 802.15.4 Radio Driver from Nordic Semiconductor.
The nRF 802.15.4 Radio Driver will be delivered soon to https://github.com/zephyrproject-rtos/hal_nordic

This is an alternative to what's proposed in https://github.com/zephyrproject-rtos/zephyr/pull/60343 due to caveats expressed here https://github.com/zephyrproject-rtos/zephyr/pull/60343#discussion_r1263387439