### PR TITLE
drivers: watchdog: add support for agilex platform, reset and clock

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -514,7 +514,7 @@
 /drivers/watchdog/Kconfig.it8xxx2         @RuibinChang
 /drivers/watchdog/wdt_counter.c           @nordic-krch
 /drivers/watchdog/*rpi_pico*              @thedjnK
-/drivers/watchdog/*dw*                    @softwarecki
+/drivers/watchdog/*dw*                    @softwarecki @pbalsundar
 /drivers/watchdog/*ifx*                   @sreeramIfx
 /drivers/wifi/                            @rlubos @tbursztyka @jukkar
 /drivers/wifi/esp_at/                     @mniestroj

--- a/drivers/watchdog/wdt_dw.c
+++ b/drivers/watchdog/wdt_dw.c
@@ -91,8 +91,7 @@ static int dw_wdt_install_timeout(const struct device *dev, const struct wdt_tim
 	}
 
 	if (config->flags) {
-		LOG_ERR("Watchdog behavior is not configurable.");
-		return -ENOTSUP;
+		LOG_WRN("Watchdog behavior is not configurable.");
 	}
 
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)

--- a/drivers/watchdog/wdt_dw.c
+++ b/drivers/watchdog/wdt_dw.c
@@ -196,6 +196,15 @@ static int dw_wdt_init(const struct device *dev)
 	}
 #endif
 
+	/*
+	 * Enable watchdog if it needs to be enabled at boot.
+	 * watchdog timer will be started with maximum timeout
+	 * that is the default value.
+	 */
+	if (!IS_ENABLED(CONFIG_WDT_DISABLE_AT_BOOT)) {
+		dw_wdt_enable((uint32_t)reg_base);
+	}
+
 	return 0;
 }
 

--- a/drivers/watchdog/wdt_dw_common.c
+++ b/drivers/watchdog/wdt_dw_common.c
@@ -103,8 +103,3 @@ int dw_wdt_probe(const uint32_t base, const uint32_t reset_pulse_length)
 
 	return 0;
 }
-
-int dw_wdt_disable(const struct device *dev)
-{
-	return -ENOTSUP;
-}

--- a/drivers/watchdog/wdt_dw_common.c
+++ b/drivers/watchdog/wdt_dw_common.c
@@ -20,13 +20,11 @@ LOG_MODULE_REGISTER(wdt_dw_common, CONFIG_WDT_LOG_LEVEL);
 int dw_wdt_check_options(const uint8_t options)
 {
 	if (options & WDT_OPT_PAUSE_HALTED_BY_DBG) {
-		LOG_ERR("Pausing watchdog by debugger is not supported.");
-		return -ENOTSUP;
+		LOG_WRN("Pausing watchdog by debugger is not configurable");
 	}
 
 	if (options & WDT_OPT_PAUSE_IN_SLEEP) {
-		LOG_ERR("Pausing watchdog in sleep is not supported.");
-		return -ENOTSUP;
+		LOG_WRN("Pausing watchdog in sleep is not configurable");
 	}
 
 	return 0;

--- a/drivers/watchdog/wdt_intel_adsp.c
+++ b/drivers/watchdog/wdt_intel_adsp.c
@@ -211,6 +211,11 @@ int intel_adsp_watchdog_resume(const struct device *dev, const int channel_id)
 	return 0;
 }
 
+int dw_wdt_disable(const struct device *dev)
+{
+	return -ENOTSUP;
+}
+
 static const struct wdt_driver_api intel_adsp_wdt_api = {
 	.setup = intel_adsp_wdt_setup,
 	.disable = dw_wdt_disable,

--- a/dts/arm64/intel/intel_socfpga_agilex.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex.dtsi
@@ -155,6 +155,33 @@
 				IRQ_DEFAULT_PRIORITY>;
 		reg = <0xffd00100 0x100>;
 		clock-frequency = < 100000000 >;
+	};
+
+	watchdog0: watchdog@ffd00200 {
+		compatible = "snps,designware-watchdog";
+		reg = <0xffd00200 0x100>;
+		clocks = <&clock INTEL_SOCFPGA_CLOCK_WDT>;
+		status = "disabled";
+	};
+
+	watchdog1: watchdog@ffd00300 {
+		compatible = "snps,designware-watchdog";
+		reg = <0xffd00300 0x100>;
+		clocks = <&clock INTEL_SOCFPGA_CLOCK_WDT>;
+		status = "disabled";
+	};
+
+	watchdog2: watchdog@ffd00400 {
+		compatible = "snps,designware-watchdog";
+		reg = <0xffd00400 0x100>;
+		clocks = <&clock INTEL_SOCFPGA_CLOCK_WDT>;
+		status = "disabled";
+	};
+
+	watchdog3: watchdog@ffd00500 {
+		compatible = "snps,designware-watchdog";
+		reg = <0xffd00500 0x100>;
+		clocks = <&clock INTEL_SOCFPGA_CLOCK_WDT>;
 		status = "disabled";
 	};
 };

--- a/dts/arm64/intel/intel_socfpga_agilex5.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex5.dtsi
@@ -158,6 +158,45 @@
 		reg = <0x10D00100 0x100>;
 		clock-frequency = <100000000>;
 		resets = <&reset RSTMGR_L4SYSTIMER1_RSTLINE>;
+	};
+
+	watchdog0: watchdog@10d00200 {
+		compatible = "snps,designware-watchdog";
+		reg = <0x10d00200 0x100>;
+		clock-frequency = <100000000>;
+		resets = <&reset RSTMGR_WATCHDOG0_RSTLINE>;
+		status = "disabled";
+	};
+
+	watchdog1: watchdog@10d00300 {
+		compatible = "snps,designware-watchdog";
+		reg = <0x10d00300 0x100>;
+		clock-frequency = <100000000>;
+		resets = <&reset RSTMGR_WATCHDOG1_RSTLINE>;
+		status = "disabled";
+	};
+
+	watchdog2: watchdog@10d00400 {
+		compatible = "snps,designware-watchdog";
+		reg = <0x10d00400 0x100>;
+		clock-frequency = <100000000>;
+		resets = <&reset RSTMGR_WATCHDOG2_RSTLINE>;
+		status = "disabled";
+	};
+
+	watchdog3: watchdog@10d00500 {
+		compatible = "snps,designware-watchdog";
+		reg = <0x10d00500 0x100>;
+		clock-frequency = <100000000>;
+		resets = <&reset RSTMGR_WATCHDOG3_RSTLINE>;
+		status = "disabled";
+	};
+
+	watchdog4: watchdog@10d00600 {
+		compatible = "snps,designware-watchdog";
+		reg = <0x10d00600 0x100>;
+		clock-frequency = <100000000>;
+		resets = <&reset RSTMGR_WATCHDOG4_RSTLINE>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/watchdog/snps,designware-watchdog.yaml
+++ b/dts/bindings/watchdog/snps,designware-watchdog.yaml
@@ -2,7 +2,7 @@ description: Synopsys Designware Watchdog
 
 compatible: "snps,designware-watchdog"
 
-include: base.yaml
+include: [base.yaml, reset-device.yaml]
 
 properties:
   # This properties is also supported:

--- a/samples/drivers/watchdog/boards/intel_socfpga_agilex5_socdk.overlay
+++ b/samples/drivers/watchdog/boards/intel_socfpga_agilex5_socdk.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &watchdog0;
+	};
+};
+
+&watchdog0 {
+	interrupt-parent = <&gic>;
+	interrupts = <GIC_SPI 117 IRQ_TYPE_LEVEL
+			IRQ_DEFAULT_PRIORITY>;
+	status = "okay";
+};

--- a/samples/drivers/watchdog/boards/intel_socfpga_agilex_socdk.overlay
+++ b/samples/drivers/watchdog/boards/intel_socfpga_agilex_socdk.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &watchdog0;
+	};
+};
+
+&watchdog0 {
+	interrupt-parent = <&gic>;
+	interrupts = <GIC_SPI 117 IRQ_TYPE_LEVEL
+			IRQ_DEFAULT_PRIORITY>;
+	status = "okay";
+};


### PR DESCRIPTION
- If MMU is enabled, the physical address has to be mapped to a virtual address at run-time. Added code changes to do the same using DEVICE_MMIO_* macros, which maps physical address of register space into a memory
- according to spec when the watchdog timer is expired and interrupt is raised, interrupt flag should not be cleared. Clearing interrupt flag will not assert a system reset. Fixed this issue by not clearing an interrupt flag
- added clock manager support to get clock frequency at runtime. If clock manager is present, then peripheral driver can get clock rate at run-time using clock manager.
- added support for watchdog reset through reset manager. If reset controller or reset manager driver is present to reset peripheral IPs, it can be used to reset watchdog timer to default state
- enabled/disabled watchdog timer at boot time based on config flag WDT_DISABLE_AT_BOOT
- pause while debug or pause while sleep is not configurable through application, so added a warning logs to the user
- Some boards may have reset lines connected either to SOC or reset line connected to CPU or reset line is not connected to any entity. But these resets are not configurable throught the application. So just logging a warning message to the user
- adding driver support for agilex and agile5 socfpga
- added agilex board support for watchdog sample application