### PR TITLE
tests: sensors: Emulator Backend API and Generic Test

### DIFF
--- a/doc/hardware/peripherals/sensor.rst
+++ b/doc/hardware/peripherals/sensor.rst
@@ -228,3 +228,4 @@ API Reference
 **************
 
 .. doxygengroup:: sensor_interface
+.. doxygengroup:: sensor_emulator_backend

--- a/drivers/sensor/akm09918c/akm09918c.h
+++ b/drivers/sensor/akm09918c/akm09918c.h
@@ -7,6 +7,7 @@
 #define ZEPHYR_DRIVERS_SENSOR_AKM09918C_AKM09918C_H_
 
 #include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/sensor.h>
 
 #include "akm09918c_reg.h"
@@ -15,7 +16,17 @@
 #define AKM09918C_MEASURE_TIME_US 9000
 
 /* Conversion values */
-#define AKM09918C_MICRO_GAUSS_PER_BIT INT64_C(500)
+#define AKM09918C_MICRO_GAUSS_PER_BIT INT64_C(1500)
+
+/* Maximum and minimum raw register values for magnetometer data per datasheet */
+#define AKM09918C_MAGN_MAX_DATA_REG (32752)
+#define AKM09918C_MAGN_MIN_DATA_REG (-32752)
+
+/* Maximum and minimum magnetometer values in microgauss. +/-32752 is the maximum range of the
+ * data registers (slightly less than the range of int16). This works out to +/- 49,128,000 uGs
+ */
+#define AKM09918C_MAGN_MAX_MICRO_GAUSS (AKM09918C_MAGN_MAX_DATA_REG * AKM09918C_MICRO_GAUSS_PER_BIT)
+#define AKM09918C_MAGN_MIN_MICRO_GAUSS (AKM09918C_MAGN_MIN_DATA_REG * AKM09918C_MICRO_GAUSS_PER_BIT)
 
 struct akm09918c_data {
 	int16_t x_sample;

--- a/include/zephyr/drivers/emul_sensor.h
+++ b/include/zephyr/drivers/emul_sensor.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/sensor.h>
+
+#include <stdint.h>
+
+/**
+ * @brief Sensor emulator backend API
+ * @defgroup sensor_emulator_backend Sensor emulator backend API
+ * @ingroup io_interfaces
+ * @{
+ */
+
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ * These are for internal use only, so skip these in public documentation.
+ */
+
+/**
+ * @brief Collection of function pointers implementing a common backend API for sensor emulators
+ */
+__subsystem struct emul_sensor_backend_api {
+	/** Sets a given fractional value for a given sensor channel. */
+	int (*set_channel)(const struct emul *target, enum sensor_channel ch, q31_t value,
+			   int8_t shift);
+	/** Retrieve a range of sensor values to use with test. */
+	int (*get_sample_range)(const struct emul *target, enum sensor_channel ch, q31_t *lower,
+				q31_t *upper, q31_t *epsilon, int8_t *shift);
+};
+/**
+ * @endcond
+ */
+
+/**
+ * @brief Check if a given sensor emulator supports the backend API
+ *
+ * @param target Pointer to emulator instance to query
+ *
+ * @return True if supported, false if unsupported or if \p target is NULL.
+ */
+static inline bool emul_sensor_backend_is_supported(const struct emul *target)
+{
+	return target && target->backend_api;
+}
+
+/**
+ * @brief Set an expected value for a given channel on a given sensor emulator
+ *
+ * @param target Pointer to emulator instance to operate on
+ * @param ch Sensor channel to set expected value for
+ * @param value Expected value in fixed-point format using standard SI unit for sensor type
+ * @param shift Shift value (scaling factor) applied to \p value
+ *
+ * @return 0 if successful
+ * @return -ENOTSUP if no backend API or if channel not supported by emul
+ * @return -ERANGE if provided value is not in the sensor's supported range
+ */
+static inline int emul_sensor_backend_set_channel(const struct emul *target, enum sensor_channel ch,
+						  q31_t value, int8_t shift)
+{
+	if (!target || !target->backend_api) {
+		return -ENOTSUP;
+	}
+
+	struct emul_sensor_backend_api *api = (struct emul_sensor_backend_api *)target->backend_api;
+
+	if (api->set_channel) {
+		return api->set_channel(target, ch, value, shift);
+	}
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Query an emulator for a channel's supported sample value range and tolerance
+ *
+ * @param target Pointer to emulator instance to operate on
+ * @param ch The channel to request info for. If \p ch is unsupported, return `-ENOTSUP`
+ * @param[out] lower Minimum supported sample value in SI units, fixed-point format
+ * @param[out] upper Maximum supported sample value in SI units, fixed-point format
+ * @param[out] epsilon Tolerance to use comparing expected and actual values to account for rounding
+ *             and sensor precision issues. This can usually be set to the minimum sample value step
+ *             size. Uses SI units and fixed-point format.
+ * @param[out] shift The shift value (scaling factor) associated with \p lower, \p upper, and
+ *             \p epsilon.
+ *
+ * @return 0 if successful
+ * @return -ENOTSUP if no backend API or if channel not supported by emul
+ *
+ */
+static inline int emul_sensor_backend_get_sample_range(const struct emul *target,
+						       enum sensor_channel ch, q31_t *lower,
+						       q31_t *upper, q31_t *epsilon, int8_t *shift)
+{
+	if (!target || !target->backend_api) {
+		return -ENOTSUP;
+	}
+
+	struct emul_sensor_backend_api *api = (struct emul_sensor_backend_api *)target->backend_api;
+
+	if (api->get_sample_range) {
+		return api->get_sample_range(target, ch, lower, upper, epsilon, shift);
+	}
+	return -ENOTSUP;
+}
+
+/**
+ * @}
+ */

--- a/tests/drivers/build_all/sensor/CMakeLists.txt
+++ b/tests/drivers/build_all/sensor/CMakeLists.txt
@@ -4,5 +4,6 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(build_all)
 
-FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
+# Exclude main when running the generic test because ztest supplies its own
+target_sources_ifndef(CONFIG_GENERIC_SENSOR_TEST app PRIVATE src/main.c)
+target_sources_ifdef(CONFIG_GENERIC_SENSOR_TEST app PRIVATE src/generic_test.c)

--- a/tests/drivers/build_all/sensor/Kconfig
+++ b/tests/drivers/build_all/sensor/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2023 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+config GENERIC_SENSOR_TEST
+	bool "Compile and run the generic sensor tests"
+	depends on ZTEST && ZTEST_NEW_API
+	help
+	  Enables building and running the generic sensor test suite that will
+	  iterate through the device tree and run sample path tests on any
+	  sensor that supports the backend sensor emulator API.
+
+config GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS
+	int "Number of expected values to use in test"
+	default 5
+	depends on GENERIC_SENSOR_TEST
+	help
+	  Controls the number of expected values to use in the generic sensor
+	  test, interpolated from the sensor's reported lower and upper sample
+	  range boundaries. The test will run one iteration for each expected
+	  value. For example, if GENERIC_TEST_NUM_EXPECTED_VALS == 5, and the
+	  sensor range is 0..100, the test will run 5 times with expected values
+	  0, 25, 50, 75, and 100. These iterations are run in parallel.
+
+source "Kconfig.zephyr"

--- a/tests/drivers/build_all/sensor/src/generic_test.c
+++ b/tests/drivers/build_all/sensor/src/generic_test.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/emul_sensor.h>
+#include <zephyr/drivers/emul.h>
+#include <zephyr/ztest.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/bitarray.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(generic_test);
+
+/*
+ * Set up an RTIO context that can be shared for all sensors
+ */
+
+static enum sensor_channel iodev_all_channels[SENSOR_CHAN_ALL];
+static struct sensor_read_config iodev_read_config = {
+	.channels = iodev_all_channels,
+	.max = SENSOR_CHAN_ALL,
+};
+RTIO_IODEV_DEFINE(iodev_read, &__sensor_iodev_api, &iodev_read_config);
+
+/* Create the RTIO context to service the reading */
+RTIO_DEFINE_WITH_MEMPOOL(sensor_read_rtio_ctx, 1, 1, 1, 64, 4);
+
+/**
+ * @brief Prepare the RTIO context for next test
+ */
+static void before(void *args)
+{
+	ARG_UNUSED(args);
+
+	/* Clear the array of requested channels */
+	memset(iodev_all_channels, 0, sizeof(iodev_all_channels));
+
+	/* Reset the channel count */
+	iodev_read_config.count = 0;
+
+	/* Remove previous sensor pointer */
+	iodev_read_config.sensor = NULL;
+
+	/* Wipe the mempool by marking every block free */
+	zassert_ok(sys_bitarray_clear_region(sensor_read_rtio_ctx_block_pool.mempool->bitmap,
+					     sensor_read_rtio_ctx_block_pool.mempool->num_blocks,
+					     0));
+
+	/* Flush the SQ and CQ */
+	rtio_sqe_drop_all(&sensor_read_rtio_ctx);
+	while (rtio_cqe_consume(&sensor_read_rtio_ctx))
+		;
+}
+
+/**
+ * @brief Helper function the carries out the generic sensor test for a given sensor device.
+ *        Verifies that the device has a suitable emulator that implements the backend API and
+ *        skips the test gracefully if not.
+ */
+static void run_generic_test(const struct device *dev)
+{
+	zassert_not_null(dev, "Cannot get device pointer. Is this driver properly instantiated?");
+
+	const struct emul *emul = emul_get_binding(dev->name);
+
+	/* Skip this sensor if there is no emulator loaded. */
+	if (!emul) {
+		ztest_test_skip();
+	}
+
+	/* Also skip if this emulator does not implement the backend API. */
+	if (!emul_sensor_backend_is_supported(emul)) {
+		ztest_test_skip();
+	}
+
+	/*
+	 * Begin the actual test sequence
+	 */
+
+	static struct {
+		bool supported;
+		bool received;
+		q31_t expected_values[CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS];
+		q31_t epsilon;
+		int8_t expected_value_shift;
+	} channel_table[SENSOR_CHAN_ALL];
+
+	memset(channel_table, 0, sizeof(channel_table));
+
+	/* Discover supported channels on this device and fill out our sensor read request */
+	for (enum sensor_channel ch = 0; ch < ARRAY_SIZE(channel_table); ch++) {
+		if (SENSOR_CHANNEL_3_AXIS(ch)) {
+			continue;
+		}
+
+		q31_t lower, upper;
+		int8_t shift;
+
+		if (emul_sensor_backend_get_sample_range(emul, ch, &lower, &upper,
+							 &channel_table[ch].epsilon, &shift) == 0) {
+			/* This channel is supported */
+			channel_table[ch].supported = true;
+
+			LOG_INF("CH %d: lower=%d, upper=%d, eps=%d, shift=%d", ch, lower, upper,
+				channel_table[ch].epsilon, shift);
+
+			/* Add to the list of channels to read */
+			iodev_all_channels[iodev_read_config.count++] = ch;
+
+			/* Generate a set of CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS test
+			 * values.
+			 */
+
+			channel_table[ch].expected_value_shift = shift;
+			for (size_t i = 0; i < CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS; i++) {
+				channel_table[ch].expected_values[i] =
+					lower +
+					(i * ((int64_t)upper - lower) /
+					 (CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS - 1));
+				LOG_INF("CH %d: Expected value %d/%d: %d", ch, i + 1,
+					CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS,
+					channel_table[ch].expected_values[i]);
+			}
+		}
+	}
+	iodev_read_config.sensor = dev;
+
+	/* Do a read of all channels for quantity CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS
+	 * iterations.
+	 */
+
+	for (size_t iteration = 0; iteration < CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS;
+	     iteration++) {
+		int rv;
+
+		/* Reset received flag */
+		for (size_t i = 0; i < ARRAY_SIZE(channel_table); i++) {
+			channel_table[i].received = false;
+		}
+
+		/* Set this iteration's expected values in emul for every supported channel */
+		for (size_t i = 0; i < iodev_read_config.count; i++) {
+			enum sensor_channel ch = iodev_all_channels[i];
+
+			rv = emul_sensor_backend_set_channel(
+				emul, ch, channel_table[ch].expected_values[iteration],
+				channel_table[ch].expected_value_shift);
+			zassert_ok(
+				rv,
+				"Cannot set value 0x%08x on channel %d (error %d, iteration %d/%d)",
+				channel_table[i].expected_values[iteration], ch, rv, iteration + 1,
+				CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS);
+		}
+
+		/* Perform the actual sensor read */
+		rv = sensor_read(&iodev_read, &sensor_read_rtio_ctx, NULL);
+		zassert_ok(rv, "Could not read sensor (error %d, iteration %d/%d)", rv,
+			   iteration + 1, CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS);
+
+		/* Wait for a CQE */
+		struct rtio_cqe *cqe = rtio_cqe_consume_block(&sensor_read_rtio_ctx);
+
+		zassert_ok(cqe->result, "CQE has failed status (error %d, iteration %d/%d)",
+			   cqe->result, iteration + 1,
+			   CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS);
+
+		uint8_t *buf = NULL;
+		uint32_t buf_len = 0;
+
+		/* Cache the data from the CQE */
+		rtio_cqe_get_mempool_buffer(&sensor_read_rtio_ctx, cqe, &buf, &buf_len);
+
+		/* Release the CQE */
+		rtio_cqe_release(&sensor_read_rtio_ctx, cqe);
+
+		enum sensor_channel channel;
+		sensor_frame_iterator_t fit = {0};
+		sensor_channel_iterator_t cit = {0};
+		const struct sensor_decoder_api *decoder;
+		int8_t shift;
+		q31_t q;
+
+		zassert_ok(sensor_get_decoder(dev, &decoder));
+
+		/* Decode the buffer and verify all channels */
+		while (decoder->decode(buf, &fit, &cit, &channel, &q, 1) > 0) {
+			zassert_true(channel_table[channel].supported);
+			zassert_false(channel_table[channel].received);
+			channel_table[channel].received = true;
+
+			zassert_ok(decoder->get_shift(buf, channel, &shift));
+
+			/* Align everything to be a 64-bit Q32.32 number for comparison */
+			int64_t expected_shifted =
+				(int64_t)channel_table[channel].expected_values[iteration]
+				<< channel_table[channel].expected_value_shift;
+			int64_t actual_shifted = (int64_t)q << shift;
+			int64_t epsilon_shifted = (int64_t)channel_table[channel].epsilon
+						  << channel_table[channel].expected_value_shift;
+
+			zassert_within(expected_shifted, actual_shifted, epsilon_shifted,
+				       "Expected %lld, got %lld (shift %d, ch %d, iteration %d/%d, "
+				       "Error %lld, Epsilon %lld)",
+				       expected_shifted, actual_shifted, shift, channel,
+				       iteration + 1, CONFIG_GENERIC_SENSOR_TEST_NUM_EXPECTED_VALS,
+				       expected_shifted - actual_shifted, epsilon_shifted);
+		}
+
+		/* Release the memory */
+		rtio_release_buffer(&sensor_read_rtio_ctx, buf, buf_len);
+
+		/* Ensure all supported channels were received */
+		int missing_channel_count = 0;
+
+		for (size_t i = 0; i < ARRAY_SIZE(channel_table); i++) {
+			if (channel_table[i].supported && !channel_table[i].received) {
+				missing_channel_count++;
+			}
+		}
+
+		zassert_equal(0, missing_channel_count);
+	}
+}
+
+#define DECLARE_ZTEST_PER_DEVICE(n)                                                                \
+	ZTEST(generic, test_##n)                                                                   \
+	{                                                                                          \
+		run_generic_test(DEVICE_DT_GET(n));                                                \
+	}
+
+/* Iterate through each of the emulated buses and create a test for each device. */
+DT_FOREACH_CHILD_STATUS_OKAY(DT_NODELABEL(test_i2c), DECLARE_ZTEST_PER_DEVICE)
+DT_FOREACH_CHILD_STATUS_OKAY(DT_NODELABEL(test_spi), DECLARE_ZTEST_PER_DEVICE)
+
+ZTEST_SUITE(generic, NULL, NULL, before, NULL, NULL);

--- a/tests/drivers/build_all/sensor/testcase.yaml
+++ b/tests/drivers/build_all/sensor/testcase.yaml
@@ -19,3 +19,12 @@ tests:
     extra_configs:
       - CONFIG_PM=y
       - CONFIG_PM_DEVICE=y
+  sensors.generic_test:
+    extra_configs:
+      - CONFIG_GENERIC_SENSOR_TEST=y
+      - CONFIG_ZTEST=y
+      - CONFIG_ZTEST_NEW_API=y
+      - CONFIG_EMUL=y
+      - CONFIG_NATIVE_UART_0_ON_STDINOUT=y
+      - CONFIG_SENSOR_ASYNC_API=y
+    build_only: false

--- a/tests/drivers/sensor/akm09918c/src/main.c
+++ b/tests/drivers/sensor/akm09918c/src/main.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/ztest.h>
 
+#include "akm09918c.h"
 #include "akm09918c_emul.h"
 #include "akm09918c_reg.h"
 
@@ -72,19 +73,19 @@ static void test_fetch_magnetic_field(const struct akm09918c_fixture *fixture,
 
 	/* Assert the data is within 0.000005 Gauss */
 	actual_ugauss = values[0].val1 * INT64_C(1000000) + values[0].val2;
-	expect_ugauss = magn_percent[0] * INT64_C(500);
+	expect_ugauss = magn_percent[0] * AKM09918C_MICRO_GAUSS_PER_BIT;
 	zassert_within(expect_ugauss, actual_ugauss, INT64_C(5),
 		       "(X) expected %" PRIi64 " micro-gauss, got %" PRIi64 " micro-gauss",
 		       expect_ugauss, actual_ugauss);
 
 	actual_ugauss = values[1].val1 * INT64_C(1000000) + values[1].val2;
-	expect_ugauss = magn_percent[1] * INT64_C(500);
+	expect_ugauss = magn_percent[1] * AKM09918C_MICRO_GAUSS_PER_BIT;
 	zassert_within(expect_ugauss, actual_ugauss, INT64_C(5),
 		       "(Y) expected %" PRIi64 " micro-gauss, got %" PRIi64 " micro-gauss",
 		       expect_ugauss, actual_ugauss);
 
 	actual_ugauss = values[2].val1 * INT64_C(1000000) + values[2].val2;
-	expect_ugauss = magn_percent[2] * INT64_C(500);
+	expect_ugauss = magn_percent[2] * AKM09918C_MICRO_GAUSS_PER_BIT;
 	zassert_within(expect_ugauss, actual_ugauss, INT64_C(5),
 		       "(Z) expected %" PRIi64 " micro-gauss, got %" PRIi64 " micro-gauss",
 		       expect_ugauss, actual_ugauss);
@@ -94,9 +95,9 @@ ZTEST_F(akm09918c, test_fetch_magn)
 {
 	/* Use (0.25, -0.33..., 0.91) as the factors */
 	const int16_t magn_percent[3] = {
-		INT16_C(32752) / INT16_C(4),
-		INT16_C(-32751) / INT16_C(3),
-		(int16_t)(INT16_C(32752) * INT32_C(91) / INT32_C(100)),
+		INT16_C(AKM09918C_MAGN_MAX_DATA_REG) / INT16_C(4),
+		INT16_C(AKM09918C_MAGN_MIN_DATA_REG) / INT16_C(3),
+		(int16_t)(INT16_C(AKM09918C_MAGN_MAX_DATA_REG) * INT32_C(91) / INT32_C(100)),
 	};
 
 	test_fetch_magnetic_field(fixture, magn_percent);


### PR DESCRIPTION
**Note:** this PR depends on https://github.com/zephyrproject-rtos/zephyr/pull/60275 You may ignore the bottom 4 commits.

This PR introduces a backend API to be implemented by sensor emulators
that creates a standardized mechanism for setting expected sensor
readings in tests. This unlocks the ability to create a generic sensor
test that can automatically set expected values in supported sensor
emulators and verify them through the existing sensor API. An
implementation of this API is provided for the AKM09918C magnetometer.

A generic sensor test is also created to exercise this implementation.
Observe that this test knows nothing about the AKM09918C; info about
supported channels and sample ranges is discovered through the backend
API. The test iterates over all devices attached to the virtual I2C and
SPI buses in the test binary's device tree, which (theoretically) covers
all sensors. Sensors whose emulator does not exist yet or does not
support the backend API are skipped.