### PR TITLE
boards: arm: seeeduino_xiao: support onboard DAC

### DIFF
--- a/boards/arm/seeeduino_xiao/doc/index.rst
+++ b/boards/arm/seeeduino_xiao/doc/index.rst
@@ -33,6 +33,8 @@ features:
 +===========+============+==========================================+
 | DMA       | on-chip    | Direct memory access                     |
 +-----------+------------+------------------------------------------+
+| DAC       | on-chip    | Digital to analogue converter            |
++-----------+------------+------------------------------------------+
 | Flash     | on-chip    | Can be used with LittleFS to store files |
 +-----------+------------+------------------------------------------+
 | GPIO      | on-chip    | I/O ports                                |
@@ -99,6 +101,12 @@ The SAMD21 MCU has a USB device port that can be used to communicate
 with a host PC.  See the :ref:`usb-samples` sample applications for
 more, such as the :ref:`usb_cdc-acm` sample which sets up a virtual
 serial port that echos characters back to the host PC.
+
+DAC
+===
+
+The SAMD21 MCU has a single channel DAC with 10 bits of resolution. On
+the XIAO, the DAC is available on pin 0.
 
 Programming and Debugging
 *************************

--- a/boards/arm/seeeduino_xiao/seeed_xiao_connector.dtsi
+++ b/boards/arm/seeeduino_xiao/seeed_xiao_connector.dtsi
@@ -29,3 +29,4 @@
 xiao_spi: &sercom0 {};
 xiao_i2c: &sercom2 {};
 xiao_serial: &sercom4 {};
+xiao_dac: &dac0 {};

--- a/boards/arm/seeeduino_xiao/seeeduino_xiao-pinctrl.dtsi
+++ b/boards/arm/seeeduino_xiao/seeeduino_xiao-pinctrl.dtsi
@@ -6,6 +6,12 @@
 #include <dt-bindings/pinctrl/samd21-da1gXabcd-pinctrl.h>
 
 &pinctrl {
+	dac_default: dac_default {
+		group1 {
+			pinmux = <PA2B_DAC_VOUT>;
+		};
+	};
+
 	sercom2_i2c_default: sercom2_i2c_default {
 		group1 {
 			pinmux = <PA8D_SERCOM2_PAD0>,

--- a/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
+++ b/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
@@ -90,6 +90,13 @@ zephyr_udc0: &usb0 {
 	pinctrl-names = "default";
 };
 
+&dac0 {
+	status = "okay";
+
+	pinctrl-0 = <&dac_default>;
+	pinctrl-names = "default";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/arm/seeeduino_xiao/seeeduino_xiao.yaml
+++ b/boards/arm/seeeduino_xiao/seeeduino_xiao.yaml
@@ -10,6 +10,7 @@ toolchain:
   - xtools
 supported:
   - dma
+  - dac
   - gpio
   - hwinfo
   - spi

--- a/tests/drivers/dac/dac_api/src/test_dac.c
+++ b/tests/drivers/dac/dac_api/src/test_dac.c
@@ -43,6 +43,7 @@
 #elif defined(CONFIG_BOARD_TWR_KE18F) || \
 	defined(CONFIG_BOARD_FRDM_K64F) || \
 	defined(CONFIG_BOARD_FRDM_K22F) || \
+	defined(CONFIG_BOARD_SEEEDUINO_XIAO) || \
 	defined(CONFIG_BOARD_ARDUINO_MKRZERO) || \
 	defined(CONFIG_BOARD_ARDUINO_ZERO)
 


### PR DESCRIPTION
this allows you to use the onboard DAC on the Seeed Xiao