### PR TITLE
samples: sensor: lsm6dso: fix double promotion warning

### DIFF
--- a/samples/sensor/lsm6dso/src/main.c
+++ b/samples/sensor/lsm6dso/src/main.c
@@ -28,7 +28,7 @@ static void fetch_and_display(const struct device *dev)
 	sensor_channel_get(dev, SENSOR_CHAN_ACCEL_Z, &z);
 
 	printf("accel x:%f ms/2 y:%f ms/2 z:%f ms/2\n",
-			out_ev(&x), out_ev(&y), out_ev(&z));
+			(double)out_ev(&x), (double)out_ev(&y), (double)out_ev(&z));
 
 	/* lsm6dso gyro */
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_GYRO_XYZ);
@@ -37,7 +37,7 @@ static void fetch_and_display(const struct device *dev)
 	sensor_channel_get(dev, SENSOR_CHAN_GYRO_Z, &z);
 
 	printf("gyro x:%f rad/s y:%f rad/s z:%f rad/s\n",
-			out_ev(&x), out_ev(&y), out_ev(&z));
+			(double)out_ev(&x), (double)out_ev(&y), (double)out_ev(&z));
 
 	printf("trig_cnt:%d\n\n", trig_cnt);
 }


### PR DESCRIPTION
fix double promotion warning when compiling with
-Wdouble-promotion