### PR TITLE
doc: fix :zephyr-app: paths

### DIFF
--- a/boards/arm/adafruit_feather_nrf52840/doc/index.rst
+++ b/boards/arm/adafruit_feather_nrf52840/doc/index.rst
@@ -116,7 +116,7 @@ an external programmer. The programmer is attached to the SWD header.
 Build the Zephyr kernel and the :ref:`blinky-sample` sample application.
 
    .. zephyr-app-commands::
-      :zephyr-app: samples/blinky
+      :zephyr-app: samples/basic/blinky
       :board: adafruit_feather_nrf52840
       :goals: build
       :compact:
@@ -124,7 +124,7 @@ Build the Zephyr kernel and the :ref:`blinky-sample` sample application.
 Flash the image.
 
    .. zephyr-app-commands::
-      :zephyr-app: samples/blinky
+      :zephyr-app: samples/basic/blinky
       :board: adafruit_feather_nrf52840
       :goals: flash
       :compact:

--- a/boards/arm/ebyte_e73_tbb_nrf52832/doc/index.rst
+++ b/boards/arm/ebyte_e73_tbb_nrf52832/doc/index.rst
@@ -187,7 +187,7 @@ To flash the board connect pins: SWDIO, SWDCLK, RST, GND from E73-TBB
 to corresponding pins on your J-Link device, then build and flash the application in the usual way.
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/blinky
+   :zephyr-app: samples/basic/blinky
    :board: ebyte_e73_tbb_nrf52832
    :goals: build flash
 

--- a/boards/arm/pinetime_devkit0/doc/index.rst
+++ b/boards/arm/pinetime_devkit0/doc/index.rst
@@ -116,10 +116,10 @@ Building
 ********
 
 In order to get started with Zephyr on the PineTime, you can use the
-board-specific sample:
+basic button sample:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/boards/pine64_pinetime
+   :zephyr-app: samples/basic/button
    :board: pinetime_devkit0
    :goals: build
 

--- a/boards/shields/arceli_eth_w5500/doc/index.rst
+++ b/boards/shields/arceli_eth_w5500/doc/index.rst
@@ -42,7 +42,7 @@ Programming
 Set ``-DSHIELD=arceli_eth_w5500`` when you invoke ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/net/dhcp_client
+   :zephyr-app: samples/net/dhcpv4_client
    :board: nrf52840dk_nrf52840
    :shield: arceli_eth_w5500
    :goals: build

--- a/boards/shields/boostxl_ulpsense/doc/index.rst
+++ b/boards/shields/boostxl_ulpsense/doc/index.rst
@@ -26,7 +26,7 @@ Programming
 Set ``-DSHIELD=boostxl_ulpsense`` when you invoke ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensor/adxl362
+   :zephyr-app: samples/sensor/accel_polling/
    :board: cc1352r1_launchxl
    :shield: boostxl_ulpsense
    :goals: build

--- a/boards/shields/lmp90100_evb/doc/index.rst
+++ b/boards/shields/lmp90100_evb/doc/index.rst
@@ -44,7 +44,7 @@ Programming
 Set ``-DSHIELD=lmp90100_evb`` when you invoke ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/shields/lmp90100_evb/thermocouple
+   :zephyr-app: samples/shields/lmp90100_evb/rtd
    :board: frdm_k64f
    :shield: lmp90100_evb
    :goals: build

--- a/boards/shields/mikroe_eth_click/doc/index.rst
+++ b/boards/shields/mikroe_eth_click/doc/index.rst
@@ -44,7 +44,7 @@ Programming
 Set ``-DSHIELD=mikroe_eth_click`` when you invoke ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/net/dhcp_client
+   :zephyr-app: samples/net/dhcpv4_client
    :board: lpcxpresso55s69
    :shield: mikroe_eth_click
    :goals: build

--- a/boards/shields/semtech_sx1272mb2das/doc/index.rst
+++ b/boards/shields/semtech_sx1272mb2das/doc/index.rst
@@ -54,7 +54,7 @@ Set ``-DSHIELD=semtech_sx1272mb2das`` when you invoke ``west build``. For
 example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/lorawan/class_a
+   :zephyr-app: samples/subsys/lorawan/class_a
    :board: nucleo_f429zi
    :shield: semtech_sx1272mb2das
    :goals: build

--- a/boards/shields/semtech_sx1276mb1mas/doc/index.rst
+++ b/boards/shields/semtech_sx1276mb1mas/doc/index.rst
@@ -62,7 +62,7 @@ Set ``-DSHIELD=semtech_sx1271mb1mas`` when you invoke ``west build``. For
 example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/lorawan/class_a
+   :zephyr-app: samples/subsys/lorawan/class_a
    :board: nucleo_l073rz
    :shield: semtech_sx1276mb1mas
    :goals: build

--- a/boards/shields/st7735r/doc/index.rst
+++ b/boards/shields/st7735r/doc/index.rst
@@ -53,7 +53,7 @@ Programming
 Set ``-DSHIELD=st7735r_ada_160x128`` when you invoke ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/gui/lvgl
+   :zephyr-app: samples/subsys/display/lvgl
    :board: nrf52840dk_nrf52840
    :shield: st7735r_ada_160x128
    :goals: build

--- a/samples/arch/mpu/mpu_test/README.rst
+++ b/samples/arch/mpu/mpu_test/README.rst
@@ -21,7 +21,7 @@ Building and Running
 This project can be built and executed as follows:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/mpu/mpu_test
+   :zephyr-app: samples/arch/mpu/mpu_test
    :board: v2m_beetle
    :goals: build flash
    :compact:
@@ -30,7 +30,7 @@ To build the single thread version, use the supplied configuration file for
 single thread: :file:`prj_single.conf`:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/mpu/mpu_test
+   :zephyr-app: samples/arch/mpu/mpu_test
    :board: v2m_beetle
    :conf: prj_single.conf
    :goals: run

--- a/samples/boards/nrf/system_off/README.rst
+++ b/samples/boards/nrf/system_off/README.rst
@@ -40,7 +40,7 @@ Building, Flashing and Running
 ******************************
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/boards/nrf52/system_off
+   :zephyr-app: samples/boards/nrf/system_off
    :board: nrf52dk_nrf52832
    :goals: build flash
    :compact:

--- a/samples/boards/stm32/backup_sram/README.rst
+++ b/samples/boards/stm32/backup_sram/README.rst
@@ -26,7 +26,7 @@ In order to run this sample, make sure to enable ``backup_sram`` node in your
 board DT file.
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/memc/stm32_backup_sram
+   :zephyr-app: samples/boards/stm32/backup_sram
    :board: nucleo_h743zi
    :goals: build
    :compact:

--- a/samples/boards/stm32/power_mgmt/standby_shutdown/README.rst
+++ b/samples/boards/stm32/power_mgmt/standby_shutdown/README.rst
@@ -30,7 +30,7 @@ Building and Running
 Build and flash standby_shutdown as follows, changing ``nucleo_L476RG`` for your board:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/samples/boards/stm32/power_mgmt/standby_shutdown
+   :zephyr-app: samples/boards/stm32/power_mgmt/standby_shutdown
    :board: nucleo_L476RG
    :goals: build flash
    :compact:

--- a/samples/boards/ti/cc13x2_cc26x2/system_off/README.rst
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/README.rst
@@ -28,7 +28,7 @@ Building, Flashing and Running
 ******************************
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/boards/cc13x2_cc26x2/system_off
+   :zephyr-app: samples/boards/ti/cc13x2_cc26x2/system_off
    :board: cc1352r1_launchxl
    :goals: build flash
    :compact:

--- a/samples/cpp/cpp_synchronization/README.rst
+++ b/samples/cpp/cpp_synchronization/README.rst
@@ -22,7 +22,7 @@ This kernel project outputs to the console.  It can be built and executed
 on QEMU as follows:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/cpp_synchronization
+   :zephyr-app: samples/cpp/cpp_synchronization
    :host-os: unix
    :board: qemu_x86
    :goals: run

--- a/samples/drivers/misc/grove_display/README.rst
+++ b/samples/drivers/misc/grove_display/README.rst
@@ -41,7 +41,7 @@ shield interface. For example, it can be run on the FRDM K64F board as
 described below:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/subsys/display/grove_display
+   :zephyr-app: samples/drivers/misc/grove_display
    :board: frdm_k64f
    :goals: flash
    :compact:

--- a/samples/sensor/adc_cmp_npcx/README.rst
+++ b/samples/sensor/adc_cmp_npcx/README.rst
@@ -21,7 +21,7 @@ to ADC channel 8, when voltages cross upper/lower limits, detection messages
 will be printed.
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensor/adc_cmp
+   :zephyr-app: samples/sensor/adc_cmp_npcx
    :board: npcx9m6f_evb
    :goals: flash
    :compact:

--- a/samples/sensor/dps310/README.rst
+++ b/samples/sensor/dps310/README.rst
@@ -22,7 +22,7 @@ Build and flash this sample (for example, for the nrf52840dk_nrf52840 board)
 using these commands:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/sensors/dps310
+   :zephyr-app: samples/sensor/dps310
    :board: nrf52840dk_nrf52840
    :goals: flash
    :compact:

--- a/samples/sensor/mcux_acmp/README.rst
+++ b/samples/sensor/mcux_acmp/README.rst
@@ -27,7 +27,7 @@ Build the application for the :ref:`twr_ke18f` board, and adjust the
 ACMP input voltage by turning the on-board potentiometer.
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/drivers/mcux_acmp
+   :zephyr-app: samples/sensor/mcux_acmp
    :board: twr_ke18f
    :goals: flash
    :compact:
@@ -38,7 +38,7 @@ Build the application for the MIMXRT1170-EVK board, and adjust the
 ACMP input voltage by changing the voltage input to J25-13.
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/drivers/mcux_acmp
+   :zephyr-app: samples/sensor/mcux_acmp
    :board: mimxrt1170_evk_cm7
    :goals: flash
    :compact:

--- a/samples/subsys/usb_c/sink/README.rst
+++ b/samples/subsys/usb_c/sink/README.rst
@@ -30,7 +30,7 @@ Building and Running
 Build and flash as follows, changing ``b_g474e_dpow1`` for your board:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/subsys/usb-c/sink
+   :zephyr-app: samples/subsys/usb_c/sink
    :board: b_g474e_dpow1
    :goals: build flash
    :compact:

--- a/samples/subsys/usb_c/source/README.rst
+++ b/samples/subsys/usb_c/source/README.rst
@@ -29,7 +29,7 @@ Building and Running
 Build and flash as follows, changing ``stm32g081b_eval`` for your board:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/subsys/usb-c/source
+   :zephyr-app: samples/subsys/usb_c/source
    :board: stm32g081b_eval
    :goals: build flash
    :compact:

--- a/samples/subsys/video/capture/README.rst
+++ b/samples/subsys/video/capture/README.rst
@@ -32,7 +32,7 @@ Building and Running
 For :ref:`mimxrt1064_evk`, build this sample application with the following commands:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/video/mt9m114
+   :zephyr-app: samples/subsys/video/capture
    :board: mimxrt1064_evk
    :goals: build
    :compact:

--- a/samples/subsys/video/tcpserversink/README.rst
+++ b/samples/subsys/video/tcpserversink/README.rst
@@ -31,7 +31,7 @@ Building and Running
 For :ref:`mimxrt1064_evk`, build this sample application with the following commands:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/video/mt9m114
+   :zephyr-app: samples/subsys/video/tcpserversink
    :board: mimxrt1064_evk
    :goals: build
    :compact:


### PR DESCRIPTION
During testing I've found one bad path and looked if there is more.

I've used this to find other places:

```
rg :zephyr-app: | awk '{ print $3 }' | while read dir
do
      test -d $dir || echo $dir
done | grep '^samples' | grep -v '<' | sort | uniq
```