### PR TITLE
arm64: Keep the frame pointer in leaf functions

### DIFF
--- a/arch/arm64/core/CMakeLists.txt
+++ b/arch/arm64/core/CMakeLists.txt
@@ -43,6 +43,7 @@ if ((CONFIG_MP_MAX_NUM_CPUS GREATER 1) OR (CONFIG_SMP))
 endif ()
 
 zephyr_cc_option_ifdef(CONFIG_USERSPACE -mno-outline-atomics)
+zephyr_cc_option_ifdef(CONFIG_ARM64_ENABLE_FRAME_POINTER -mno-omit-leaf-frame-pointer)
 
 # GCC may generate ldp/stp instructions with the Advanced SIMD Qn registers for
 # consecutive 32-byte loads and stores. Saving and restoring the Advanced SIMD


### PR DESCRIPTION
It helps with debugging and usually on ARM64 we don't care about a small increase in code size.