### PR TITLE
pm: device: add driver init helper

### DIFF
--- a/drivers/gpio/gpio_stellaris.c
+++ b/drivers/gpio/gpio_stellaris.c
@@ -107,6 +107,34 @@ static int gpio_stellaris_configure(const struct device *dev,
 	return 0;
 }
 
+#ifdef CONFIG_GPIO_GET_CONFIG
+static int gpio_stellaris_get_config(const struct device *dev,
+				 gpio_pin_t pin,
+				 gpio_flags_t *out_flags)
+{
+	const struct gpio_stellaris_config *cfg = dev->config;
+	uint32_t base = cfg->base;
+	gpio_flags_t flags = 0;
+	mm_reg_t mask_addr;
+
+	if (sys_test_bit(GPIO_REG_ADDR(base, GPIO_DEN_OFFSET), pin) == 0) {
+		flags = GPIO_DISCONNECTED;
+	} else if (sys_test_bit(GPIO_REG_ADDR(base, GPIO_DIR_OFFSET), pin)) {
+		mask_addr = GPIO_RW_MASK_ADDR(base, GPIO_DATA_OFFSET, BIT(pin));
+
+		if (sys_test_bit(mask_addr, pin)) {
+			flags |= GPIO_OUTPUT_HIGH;
+		} else {
+			flags |= GPIO_OUTPUT_LOW;
+		}
+	} else {
+		flags = GPIO_INPUT;
+	}
+	*out_flags = flags;
+	return 0;
+}
+#endif
+
 static int gpio_stellaris_port_get_raw(const struct device *dev,
 				       uint32_t *value)
 {
@@ -221,6 +249,9 @@ static int gpio_stellaris_manage_callback(const struct device *dev,
 
 static const struct gpio_driver_api gpio_stellaris_driver_api = {
 	.pin_configure = gpio_stellaris_configure,
+#ifdef CONFIG_GPIO_GET_CONFIG
+	.pin_get_config = gpio_stellaris_get_config,
+#endif
 	.port_get_raw = gpio_stellaris_port_get_raw,
 	.port_set_masked_raw = gpio_stellaris_port_set_masked_raw,
 	.port_set_bits_raw = gpio_stellaris_port_set_bits_raw,

--- a/drivers/power_domain/power_domain_gpio.c
+++ b/drivers/power_domain/power_domain_gpio.c
@@ -113,7 +113,6 @@ static int pd_gpio_init(const struct device *dev)
 {
 	const struct pd_gpio_config *cfg = dev->config;
 	struct pd_gpio_data *data = dev->data;
-	int rc;
 
 	if (!device_is_ready(cfg->enable.port)) {
 		LOG_ERR("GPIO port %s is not ready", cfg->enable.port->name);
@@ -122,16 +121,8 @@ static int pd_gpio_init(const struct device *dev)
 	/* We can't know how long the domain has been off for before boot */
 	data->next_boot = K_TIMEOUT_ABS_US(cfg->off_on_delay_us);
 
-	if (pm_device_on_power_domain(dev)) {
-		/* Device is unpowered */
-		pm_device_init_off(dev);
-		rc = gpio_pin_configure_dt(&cfg->enable, GPIO_DISCONNECTED);
-	} else {
-		pm_device_init_suspended(dev);
-		rc = gpio_pin_configure_dt(&cfg->enable, GPIO_OUTPUT_INACTIVE);
-	}
-
-	return rc;
+	/* Boot according to state */
+	return pm_device_driver_init(dev, pd_gpio_pm_action);
 }
 
 #define POWER_DOMAIN_DEVICE(id)						   \

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -849,6 +849,17 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 #endif /* CONFIG_DEVICE_DEPS */
 
 /**
+ * @brief Init sub-priority of the device
+ *
+ * The sub-priority is defined by the devicetree ordinal, which ensures that
+ * multiple drivers running at the same priority level run in an order that
+ * respects the devicetree dependencies.
+ */
+#define Z_DEVICE_INIT_SUB_PRIO(node_id)                                        \
+	COND_CODE_1(DT_NODE_EXISTS(node_id),                                   \
+		    (DT_DEP_ORD_STR_SORTABLE(node_id)), (0))
+
+/**
  * @brief Maximum device name length.
  *
  * The maximum length is set so that device_get_binding() can be used from
@@ -923,14 +934,17 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 /**
  * @brief Define the init entry for a device.
  *
+ * @param node_id Devicetree node id for the device (DT_INVALID_NODE if a
+ * software device).
  * @param dev_id Device identifier.
  * @param init_fn_ Device init function.
  * @param level Initialization level.
  * @param prio Initialization priority.
  */
-#define Z_DEVICE_INIT_ENTRY_DEFINE(dev_id, init_fn_, level, prio)              \
-	static const Z_DECL_ALIGN(struct init_entry)                           \
-		Z_INIT_ENTRY_SECTION(level, prio) __used __noasan              \
+#define Z_DEVICE_INIT_ENTRY_DEFINE(node_id, dev_id, init_fn_, level, prio)     \
+	static const Z_DECL_ALIGN(struct init_entry) __used __noasan           \
+		Z_INIT_ENTRY_SECTION(level, prio,                              \
+				     Z_DEVICE_INIT_SUB_PRIO(node_id))          \
 		Z_INIT_ENTRY_NAME(DEVICE_NAME_GET(dev_id)) = {                 \
 			.init_fn = {.dev = (init_fn_)},                        \
 			.dev = &DEVICE_NAME_GET(dev_id),                       \
@@ -967,7 +981,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 	Z_DEVICE_BASE_DEFINE(node_id, dev_id, name, pm, data, config, level,   \
 			     prio, api, state, Z_DEVICE_DEPS_NAME(dev_id));    \
                                                                                \
-	Z_DEVICE_INIT_ENTRY_DEFINE(dev_id, init_fn, level, prio)
+	Z_DEVICE_INIT_ENTRY_DEFINE(node_id, dev_id, init_fn, level, prio)
 
 #if defined(CONFIG_HAS_DTS) || defined(__DOXYGEN__)
 /**

--- a/include/zephyr/devicetree/ordinals.h
+++ b/include/zephyr/devicetree/ordinals.h
@@ -25,6 +25,13 @@
 #define DT_DEP_ORD(node_id) DT_CAT(node_id, _ORD)
 
 /**
+ * @brief Get a node's dependency ordinal in string sortable form
+ * @param node_id Node identifier
+ * @return the node's dependency ordinal as a zero-padded integer literal
+ */
+#define DT_DEP_ORD_STR_SORTABLE(node_id) DT_CAT(node_id, _ORD_STR_SORTABLE)
+
+/**
  * @brief Get a list of dependency ordinals of a node's direct dependencies
  *
  * There is a comma after each ordinal in the expansion, **including**

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -128,10 +128,12 @@ struct init_entry {
  * @brief Init entry section.
  *
  * Each init entry is placed in a section with a name crafted so that it allows
- * linker scripts to sort them according to the specified level/priority.
+ * linker scripts to sort them according to the specified
+ * level/priority/sub-priority.
  */
-#define Z_INIT_ENTRY_SECTION(level, prio)                                      \
-	__attribute__((__section__(".z_init_" #level STRINGIFY(prio)"_")))
+#define Z_INIT_ENTRY_SECTION(level, prio, sub_prio)                           \
+	__attribute__((__section__(                                           \
+		".z_init_" #level STRINGIFY(prio)"_" STRINGIFY(sub_prio)"_")))
 
 /** @endcond */
 
@@ -186,7 +188,7 @@ struct init_entry {
  */
 #define SYS_INIT_NAMED(name, init_fn_, level, prio)                            \
 	static const Z_DECL_ALIGN(struct init_entry)                           \
-		Z_INIT_ENTRY_SECTION(level, prio) __used __noasan              \
+		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan           \
 		Z_INIT_ENTRY_NAME(name) = {                                    \
 			.init_fn = {.sys = (init_fn_)},                        \
 			.dev = NULL,                                           \

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -581,6 +581,22 @@ int pm_device_power_domain_remove(const struct device *dev,
  * @retval false If device is not currently powered
  */
 bool pm_device_is_powered(const struct device *dev);
+
+/**
+ * @brief Setup a device driver into the lowest valid power mode
+ *
+ * This helper function is intended to be called at the end of a driver
+ * init function to automatically setup the device into the lowest power
+ * mode. It assumes that the device has been configured as if it is in
+ * @ref PM_DEVICE_STATE_OFF.
+ *
+ * @param dev Device instance.
+ * @param action_cb Device PM control callback function.
+ * @retval 0 On success.
+ * @retval -errno Error code from @a action_cb on failure.
+ */
+int pm_device_driver_init(const struct device *dev, pm_device_action_cb_t action_cb);
+
 #else
 static inline int pm_device_state_get(const struct device *dev,
 				      enum pm_device_state *state)
@@ -667,6 +683,19 @@ static inline bool pm_device_is_powered(const struct device *dev)
 	ARG_UNUSED(dev);
 	return true;
 }
+
+static inline int pm_device_driver_init(const struct device *dev, pm_device_action_cb_t action_cb)
+{
+	int rc;
+
+	/* When power management is not enabled, all drivers should initialise to active state */
+	rc = action_cb(dev, PM_DEVICE_ACTION_TURN_ON);
+	if (rc == 0) {
+		rc = action_cb(dev, PM_DEVICE_ACTION_RESUME);
+	}
+	return rc;
+}
+
 #endif /* CONFIG_PM_DEVICE */
 
 /** @} */

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -747,6 +747,7 @@ def write_dep_info(node):
 
     out_comment("Node's dependency ordinal:")
     out_dt_define(f"{node.z_path_id}_ORD", node.dep_ordinal)
+    out_dt_define(f"{node.z_path_id}_ORD_STR_SORTABLE", f"{node.dep_ordinal:0>5}")
 
     out_comment("Ordinals for what this node depends on directly:")
     out_dt_define(f"{node.z_path_id}_REQUIRES_ORDS",

--- a/tests/kernel/device/app.overlay
+++ b/tests/kernel/device/app.overlay
@@ -51,4 +51,21 @@
 			    "dale";
 		status = "okay";
 	};
+
+	fakedomain_0: fakedomain_0 {
+		compatible = "fakedomain";
+		status = "okay";
+		power-domain = <&fakedomain_2>;
+	};
+
+	fakedomain_1: fakedomain_1 {
+		compatible = "fakedomain";
+		status = "okay";
+		power-domain = <&fakedomain_0>;
+	};
+
+	fakedomain_2: fakedomain_2 {
+		compatible = "fakedomain";
+		status = "okay";
+	};
 };

--- a/tests/kernel/device/boards/hifive_unmatched.overlay
+++ b/tests/kernel/device/boards/hifive_unmatched.overlay
@@ -48,4 +48,21 @@
 			    "dale";
 		status = "okay";
 	};
+
+	fakedomain_0: fakedomain_0 {
+		compatible = "fakedomain";
+		status = "okay";
+		power-domain = <&fakedomain_2>;
+	};
+
+	fakedomain_1: fakedomain_1 {
+		compatible = "fakedomain";
+		status = "okay";
+		power-domain = <&fakedomain_0>;
+	};
+
+	fakedomain_2: fakedomain_2 {
+		compatible = "fakedomain";
+		status = "okay";
+	};
 };

--- a/tests/kernel/device/dts/bindings/fakedomain.yml
+++ b/tests/kernel/device/dts/bindings/fakedomain.yml
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, CSIRO
+# SPDX-License-Identifier: Apache-2.0
+
+description: Properties for fake power domain
+
+compatible: "fakedomain"
+
+include: base.yaml

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -265,6 +265,7 @@ ZTEST(device, test_sys_init_multiple)
 /* this is for storing sequence during initialization */
 extern int init_level_sequence[4];
 extern int init_priority_sequence[4];
+extern int init_sub_priority_sequence[3];
 extern unsigned int seq_level_cnt;
 extern unsigned int seq_priority_cnt;
 
@@ -298,7 +299,7 @@ ZTEST(device, test_device_init_level)
 /**
  * @brief Test initialization priorities for device driver instances
  *
- * details After the defined device instances have initialized, we check the
+ * @details After the defined device instances have initialized, we check the
  * sequence number that each driver stored during initialization. If the
  * sequence of initial priority stored is corresponding with our expectation, it
  * means assigning the priority for driver instance works.
@@ -322,6 +323,25 @@ ZTEST(device, test_device_init_priority)
 			"init sequence is not correct");
 }
 
+/**
+ * @brief Test initialization sub-priorities for device driver instances
+ *
+ * @details After the defined device instances have initialized, we check the
+ * sequence number that each driver stored during initialization. If the
+ * sequence of initial priority stored is corresponding with our expectation, it
+ * means using the devicetree for sub-priority sorting works.
+ *
+ * @ingroup kernel_device_tests
+ */
+ZTEST(device, test_device_init_sub_priority)
+{
+	/* fakedomain_1 depends on fakedomain_0 which depends on fakedomain_2,
+	 * therefore we require that the initialisation runs in the reverse order.
+	 */
+	zassert_equal(init_sub_priority_sequence[0], 1, "");
+	zassert_equal(init_sub_priority_sequence[1], 2, "");
+	zassert_equal(init_sub_priority_sequence[2], 0, "");
+}
 
 /**
  * @brief Test abstraction of device drivers with common functionalities

--- a/tests/kernel/device/src/test_driver_init.c
+++ b/tests/kernel/device/src/test_driver_init.c
@@ -39,8 +39,10 @@
 /* this is for storing sequence during initialization */
 __pinned_bss int init_level_sequence[4] = {0};
 __pinned_bss int init_priority_sequence[4] = {0};
+__pinned_bss int init_sub_priority_sequence[3] = {0};
 __pinned_bss unsigned int seq_level_cnt;
 __pinned_bss unsigned int seq_priority_cnt;
+__pinned_bss unsigned int seq_sub_priority_cnt;
 
 /* define driver type 1: for testing initialize levels and priorities */
 typedef int (*my_api_configure_t)(const struct device *dev, int dev_config);
@@ -126,6 +128,28 @@ static int my_driver_pri_4_init(const struct device *dev)
 	return 0;
 }
 
+/* driver init function of testing sub_priority */
+static int my_driver_sub_pri_0_init(const struct device *dev)
+{
+	init_sub_priority_sequence[0] = seq_sub_priority_cnt++;
+
+	return 0;
+}
+
+static int my_driver_sub_pri_1_init(const struct device *dev)
+{
+	init_sub_priority_sequence[1] = seq_sub_priority_cnt++;
+
+	return 0;
+}
+
+static int my_driver_sub_pri_2_init(const struct device *dev)
+{
+	init_sub_priority_sequence[2] = seq_sub_priority_cnt++;
+
+	return 0;
+}
+
 /**
  * @brief Test providing control device driver initialization order
  *
@@ -172,3 +196,13 @@ DEVICE_DEFINE(my_driver_priority_2, MY_DRIVER_PRI_2,
 DEVICE_DEFINE(my_driver_priority_3, MY_DRIVER_PRI_3,
 		&my_driver_pri_3_init, NULL, NULL, NULL, POST_KERNEL, 3,
 		&funcs_my_drivers);
+
+/* Create several devices at the same init priority that depend on each
+ * other in devicetree so that we can validate linker sorting.
+ */
+DEVICE_DT_DEFINE(DT_NODELABEL(fakedomain_0), my_driver_sub_pri_0_init,
+		NULL, NULL, NULL, APPLICATION, 33, NULL);
+DEVICE_DT_DEFINE(DT_NODELABEL(fakedomain_1), my_driver_sub_pri_1_init,
+		NULL, NULL, NULL, APPLICATION, 33, NULL);
+DEVICE_DT_DEFINE(DT_NODELABEL(fakedomain_2), my_driver_sub_pri_2_init,
+		NULL, NULL, NULL, APPLICATION, 33, NULL);

--- a/tests/subsys/pm/device_driver_init/CMakeLists.txt
+++ b/tests/subsys/pm/device_driver_init/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, CSIRO.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(device_driver_init)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/pm/device_driver_init/app.overlay
+++ b/tests/subsys/pm/device_driver_init/app.overlay
@@ -1,0 +1,44 @@
+/ {
+	test_reg: test_reg {
+		compatible = "power-domain-gpio";
+		enable-gpios = <&gpio0 0 0>;
+	};
+
+	test_reg_chained: test_reg_chained {
+		compatible = "power-domain-gpio";
+		enable-gpios = <&gpio0 1 0>;
+		power-domain = <&test_reg>;
+	};
+
+	test_reg_chained_auto: test_reg_chained_auto {
+		compatible = "power-domain-gpio";
+		enable-gpios = <&gpio0 2 0>;
+		power-domain = <&test_reg>;
+		zephyr,pm-device-runtime-auto;
+	};
+
+	test_reg_auto: test_reg_auto {
+		compatible = "power-domain-gpio";
+		enable-gpios = <&gpio0 3 0>;
+		zephyr,pm-device-runtime-auto;
+	};
+
+	test_reg_auto_chained: test_reg_auto_chained {
+		compatible = "power-domain-gpio";
+		enable-gpios = <&gpio0 4 0>;
+		power-domain = <&test_reg_auto>;
+	};
+
+	test_reg_auto_chained_auto: test_reg_auto_chained_auto {
+		compatible = "power-domain-gpio";
+		enable-gpios = <&gpio0 5 0>;
+		power-domain = <&test_reg_auto>;
+		zephyr,pm-device-runtime-auto;
+	};
+
+	test_reg_disabled: test_reg_disabled {
+		compatible = "power-domain-gpio";
+		enable-gpios = <&gpio0 6 0>;
+		status = "disabled";
+	};
+};

--- a/tests/subsys/pm/device_driver_init/prj.conf
+++ b/tests/subsys/pm/device_driver_init/prj.conf
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Commonwealth Scientific and Industrial Research
+# Organisation (CSIRO) ABN 41 687 119 230.
+CONFIG_ZTEST=y
+CONFIG_MP_MAX_NUM_CPUS=1
+
+CONFIG_GPIO=y
+CONFIG_GPIO_GET_CONFIG=y
+CONFIG_POWER_DOMAIN=y
+CONFIG_ZTEST_NEW_API=y

--- a/tests/subsys/pm/device_driver_init/src/main.c
+++ b/tests/subsys/pm/device_driver_init/src/main.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * State checking in this test is done via the GPIO state instead of
+ * the PM API as this test runs without the PM api enabled.
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+
+#define POWER_GPIO_CONFIG_IS(node_id, config)\
+	{\
+		const struct gpio_dt_spec gpio = GPIO_DT_SPEC_GET(node_id, enable_gpios);\
+		gpio_flags_t gpio_config; \
+		int rc = gpio_pin_get_config_dt(&gpio, &gpio_config); \
+		zassert_equal(rc, 0, "GPIO config retrieval failed"); \
+		zassert_equal(gpio_config, config, "Unexpected config");\
+	}
+
+#define DEVICE_STATE_IS(node_id, value) \
+	rc = pm_device_state_get(DEVICE_DT_GET(node_id), &state); \
+	zassert_equal(rc, 0, "Device state retrieval failed"); \
+	zassert_equal(state, value, "Unexpected device state");
+
+ZTEST(device_driver_init, test_demo)
+{
+#if !IS_ENABLED(CONFIG_PM) || !IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)
+	/* Every regulator should be in "active" mode automatically.
+	 * State checking via GPIO as PM API is disabled.
+	 */
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg), GPIO_OUTPUT_HIGH);
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_chained), GPIO_OUTPUT_HIGH);
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_chained_auto), GPIO_OUTPUT_HIGH);
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_auto), GPIO_OUTPUT_HIGH);
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_auto_chained), GPIO_OUTPUT_HIGH);
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_auto_chained_auto), GPIO_OUTPUT_HIGH);
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_disabled), GPIO_DISCONNECTED);
+#endif
+
+#if IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)
+	enum pm_device_state state;
+	int rc;
+
+	/* No device runtime PM, starts on */
+	DEVICE_STATE_IS(DT_NODELABEL(test_reg), PM_DEVICE_STATE_ACTIVE);
+	DEVICE_STATE_IS(DT_NODELABEL(test_reg_chained), PM_DEVICE_STATE_ACTIVE);
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg), GPIO_OUTPUT_HIGH);
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_chained), GPIO_OUTPUT_HIGH);
+
+	/* Device powered, zephyr,pm-device-runtime-auto, starts suspended */
+	DEVICE_STATE_IS(DT_NODELABEL(test_reg_chained_auto), PM_DEVICE_STATE_SUSPENDED);
+	DEVICE_STATE_IS(DT_NODELABEL(test_reg_auto), PM_DEVICE_STATE_SUSPENDED);
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_chained_auto), GPIO_OUTPUT_LOW);
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_auto), GPIO_OUTPUT_LOW);
+	/* Device not powered, starts off */
+	DEVICE_STATE_IS(DT_NODELABEL(test_reg_auto_chained), PM_DEVICE_STATE_OFF);
+	DEVICE_STATE_IS(DT_NODELABEL(test_reg_auto_chained_auto), PM_DEVICE_STATE_OFF);
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_auto_chained), GPIO_DISCONNECTED);
+	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_auto_chained_auto), GPIO_DISCONNECTED);
+#endif
+}
+
+ZTEST_SUITE(device_driver_init, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/pm/device_driver_init/testcase.yaml
+++ b/tests/subsys/pm/device_driver_init/testcase.yaml
@@ -1,0 +1,19 @@
+tests:
+  pm.device_driver_init:
+    tags: pm
+    platform_allow: qemu_cortex_m3
+  pm.device_driver_init.pm:
+    tags: pm
+    platform_allow: qemu_cortex_m3
+    extra_configs:
+      - CONFIG_PM=y
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_POWER_DOMAIN=y
+  pm.device_driver_init.pm_device_runtime:
+    tags: pm
+    platform_allow: qemu_cortex_m3
+    extra_configs:
+      - CONFIG_PM=y
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_POWER_DOMAIN=y
+      - CONFIG_PM_DEVICE_RUNTIME=y

--- a/tests/subsys/pm/device_power_domains/src/main.c
+++ b/tests/subsys/pm/device_power_domains/src/main.c
@@ -40,17 +40,17 @@ ZTEST(device_power_domain, test_demo)
 	/* Initial power state */
 	zassert_true(pm_device_is_powered(reg_0), "");
 	zassert_true(pm_device_is_powered(reg_1), "");
-	zassert_false(pm_device_is_powered(reg_chained), "");
-	zassert_false(pm_device_is_powered(dev), "");
+	zassert_true(pm_device_is_powered(reg_chained), "");
+	zassert_true(pm_device_is_powered(dev), "");
 
 	TC_PRINT("Enabling runtime power management on regulators\n");
 
-	pm_device_runtime_enable(reg_0);
-	pm_device_runtime_enable(reg_1);
-	pm_device_runtime_enable(reg_chained);
 	pm_device_runtime_enable(dev);
+	pm_device_runtime_enable(reg_chained);
+	pm_device_runtime_enable(reg_1);
+	pm_device_runtime_enable(reg_0);
 
-	/* State shouldn't have changed */
+	/* Power domains should now be suspended */
 	zassert_true(pm_device_is_powered(reg_0), "");
 	zassert_true(pm_device_is_powered(reg_1), "");
 	zassert_false(pm_device_is_powered(reg_chained), "");


### PR DESCRIPTION
Adds a helper function for initializing devices into the expected power
state, through the devices `pm_device_action_cb_t`. This eliminates code
duplication between the init functions and the PM callback.

The expected device states in order of priority are:
 * No power applied to device, `OFF`
 * `zephyr,pm-device-runtime-auto` enabled, `SUSPEND`
 * Otherwise, `ACTIVE`

Depends on #60410 (first 3 commits) to pass CI