### PR TITLE
drivers: reset: kconfig: Change default init priority to 35 from 40

### DIFF
--- a/drivers/reset/Kconfig
+++ b/drivers/reset/Kconfig
@@ -18,7 +18,7 @@ if RESET
 
 config RESET_INIT_PRIORITY
 	int "Reset Controller driver init priority"
-	default 40
+	default 35
 	help
 	  This option controls the priority of the reset controller device
 	  initialization. Higher priority ensures that the device is


### PR DESCRIPTION
Setting higher priority to reset controller to initialize it before other dependent 
drivers running at CONFIG_KERNEL_INIT_PRIORITY_DEFAULT priority which is 40.