### PR TITLE
 boards: arm: move nucleo_g474re storage_partition to end of flash 

### DIFF
--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -174,10 +174,10 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Set 4Kb of storage at the end of the 128Kb of flash */
-		storage_partition: partition@1f000 {
+		/* Set 4Kb of storage at the end of the 512Kb of flash */
+		storage_partition: partition@7f000 {
 			label = "storage";
-			reg = <0x0001f000 DT_SIZE_K(4)>;
+			reg = <0x0007f000 DT_SIZE_K(4)>;
 		};
 	};
 };


### PR DESCRIPTION
Board/MCU has 512 KiB of flash (see stm32g474Xe.dtsi).