### PR TITLE
posix: Implement pthread_equal function

### DIFF
--- a/doc/services/portability/posix.rst
+++ b/doc/services/portability/posix.rst
@@ -157,7 +157,7 @@ multiple processes.
     pthread_condattr_init(),yes
     pthread_create(),yes
     pthread_detach(),yes
-    pthread_equal(),
+    pthread_equal(),yes
     pthread_exit(),yes
     pthread_getspecific(),yes
     pthread_join(),yes

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -396,10 +396,7 @@ pthread_t pthread_self(void);
  *
  * See IEEE 1003.1
  */
-static inline int pthread_equal(pthread_t pt1, pthread_t pt2)
-{
-	return (pt1 == pt2);
-}
+int pthread_equal(pthread_t pt1, pthread_t pt2);
 
 /**
  * @brief Destroy the read-write lock attributes object.

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -848,4 +848,9 @@ static int posix_thread_pool_init(void)
 	return 0;
 }
 
+int pthread_equal(pthread_t pt1, pthread_t pt2)
+{
+	return (pt1 == pt2);
+}
+
 SYS_INIT(posix_thread_pool_init, PRE_KERNEL_1, 0);

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -771,3 +771,9 @@ ZTEST(posix_apis, test_barrier)
 	ret = pthread_barrierattr_destroy(&attr);
 	zassert_equal(ret, 0, "pthread_barrierattr_destroy failed");
 }
+
+ZTEST(posix_apis, test_pthread_equal)
+{
+	zassert_true(pthread_equal(pthread_self(), pthread_self()));
+	zassert_false(pthread_equal(pthread_self(), (pthread_t)4242));
+}


### PR DESCRIPTION
Patch implements pthread_equal function.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/59942