### PR TITLE
fb: cfb: cleanup

### DIFF
--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -407,16 +407,11 @@ static int cfb_invert(const struct char_framebuffer *fb)
 int cfb_framebuffer_clear(const struct device *dev, bool clear_display)
 {
 	const struct char_framebuffer *fb = &char_fb;
-	struct display_buffer_descriptor desc;
 
 	if (!fb || !fb->buf) {
 		return -ENODEV;
 	}
 
-	desc.buf_size = fb->size;
-	desc.width = fb->x_res;
-	desc.height = fb->y_res;
-	desc.pitch = fb->x_res;
 	memset(fb->buf, 0, fb->size);
 
 	if (clear_display) {

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -426,12 +426,11 @@ int cfb_framebuffer_clear(const struct device *dev, bool clear_display)
 	return 0;
 }
 
-
 int cfb_framebuffer_invert(const struct device *dev)
 {
 	struct char_framebuffer *fb = &char_fb;
 
-	if (!fb || !fb->buf) {
+	if (!fb) {
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Cleanup subsys/fb/cfb.c.

-----
fb: cfb: Remove sanity check for unused value

Remove needless sanity check

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>

-----
fb: cfb: Remove unused value

The `desc` value in cfb_framebuffer_clear is not used.
Removed it.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
