### PR TITLE
drivers: led_pwm: fix overflow in set_brightness

### DIFF
--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -65,7 +65,7 @@ static int led_pwm_set_brightness(const struct device *dev,
 	dt_led = &config->led[led];
 
 	return pwm_set_pulse_dt(&config->led[led],
-				dt_led->period * value / 100);
+			(uint32_t) ((uint64_t) dt_led->period * value / 100));
 }
 
 static int led_pwm_on(const struct device *dev, uint32_t led)

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -11,6 +11,14 @@ child-binding:
     pwms:
       required: true
       type: phandle-array
+      description: |
+        Reference to a PWM instance.
+
+        The period field is used by the set_brightness function of the LED API.
+        Its value should at least be greater that 100 nanoseconds (for a full
+        brigtness granularity) and lesser than 50 milliseconds (average visual
+        persistence time of the human eye). Typical values for the PWM period
+        are 10 or 20 milliseconds.
 
     label:
       type: string


### PR DESCRIPTION
This PR fixes an overflow bug in the `set_brightness` API function of the `led_pwm` driver. This issue has been reported by @scottwcpg in https://github.com/zephyrproject-rtos/zephyr/pull/58485#issuecomment-1634381062.

In addition this PR adds a description in the `pwm-leds` binding on how the PWM period is used by the `led-pwm` driver and how to choose its value.
