### PR TITLE
input: convert cap1203 from kscan

### DIFF
--- a/drivers/input/CMakeLists.txt
+++ b/drivers/input/CMakeLists.txt
@@ -3,6 +3,7 @@
 zephyr_library()
 zephyr_library_property(ALLOW_EMPTY TRUE)
 
+zephyr_library_sources_ifdef(CONFIG_INPUT_CAP1203 input_cap1203.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_CST816S input_cst816s.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_FT5336 input_ft5336.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_GPIO_KEYS input_gpio_keys.c)

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -5,6 +5,7 @@ if INPUT
 
 menu "Input drivers"
 
+source "drivers/input/Kconfig.cap1203"
 source "drivers/input/Kconfig.cst816s"
 source "drivers/input/Kconfig.ft5336"
 source "drivers/input/Kconfig.gpio_keys"

--- a/drivers/input/Kconfig.cap1203
+++ b/drivers/input/Kconfig.cap1203
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Keiya Nobuta
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig KSCAN_CAP1203
+menuconfig INPUT_CAP1203
 	bool "CAP1203 3-cannel capacitive touch sensor driver"
 	default y
 	depends on DT_HAS_MICROCHIP_CAP1203_ENABLED
@@ -10,18 +10,18 @@ menuconfig KSCAN_CAP1203
 	  Enable driver for microchip CAP1203 3-cannel capacitive
 	  touch sensor.
 
-if KSCAN_CAP1203
+if INPUT_CAP1203
 
-config KSCAN_CAP1203_POLL
+config INPUT_CAP1203_POLL
 	bool "Polling"
 	help
 	  Enable polling mode when interrupt GPIO is not specified.
 
-config KSCAN_CAP1203_PERIOD
+config INPUT_CAP1203_PERIOD
 	int "Sample period"
-	depends on KSCAN_CAP1203_POLL
+	depends on INPUT_CAP1203_POLL
 	default 10
 	help
 	  Sample period in milliseconds when in polling mode.
 
-endif # KSCAN_CAP1203
+endif # INPUT_CAP1203

--- a/drivers/kscan/CMakeLists.txt
+++ b/drivers/kscan/CMakeLists.txt
@@ -7,7 +7,6 @@ zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_KSCAN_ITE_IT8XXX2	kscan_ite_it8xxx2.c)
 zephyr_library_sources_ifdef(CONFIG_KSCAN_XEC		kscan_mchp_xec.c)
 zephyr_library_sources_ifdef(CONFIG_KSCAN_HT16K33	kscan_ht16k33.c)
-zephyr_library_sources_ifdef(CONFIG_KSCAN_CAP1203	kscan_cap1203.c)
 zephyr_library_sources_ifdef(CONFIG_KSCAN_INPUT		kscan_input.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE	    kscan_handlers.c)

--- a/drivers/kscan/Kconfig
+++ b/drivers/kscan/Kconfig
@@ -13,7 +13,6 @@ if KSCAN
 source "drivers/kscan/Kconfig.it8xxx2"
 source "drivers/kscan/Kconfig.xec"
 source "drivers/kscan/Kconfig.ht16k33"
-source "drivers/kscan/Kconfig.cap1203"
 source "drivers/kscan/Kconfig.input"
 
 module = KSCAN

--- a/dts/bindings/kscan/microchip,cap1203.yaml
+++ b/dts/bindings/kscan/microchip,cap1203.yaml
@@ -10,3 +10,9 @@ include: i2c-device.yaml
 properties:
   int-gpios:
     type: phandle-array
+
+  input-codes:
+    type: array
+    required: true
+    description: |
+      Array of input event key codes (INPUT_KEY_* or INPUT_BTN_*).

--- a/dts/bindings/kscan/microchip,cap1203.yaml
+++ b/dts/bindings/kscan/microchip,cap1203.yaml
@@ -5,7 +5,7 @@ description: CAP1203 3-channel capacitive touch sensor
 
 compatible: "microchip,cap1203"
 
-include: [kscan.yaml, i2c-device.yaml]
+include: i2c-device.yaml
 
 properties:
   int-gpios:

--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -71,6 +71,12 @@
 				irq-gpios = <&gpio0 0 0>;
 				rst-gpios = <&gpio0 0 0>;
 			};
+
+			cap1203@3 {
+				compatible = "microchip,cap1203";
+				reg = <0x3>;
+				int-gpios = <&gpio0 0 0>;
+			};
 		};
 
 		spi@2 {

--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -76,6 +76,7 @@
 				compatible = "microchip,cap1203";
 				reg = <0x3>;
 				int-gpios = <&gpio0 0 0>;
+				input-codes = <0 1 2>;
 			};
 		};
 


### PR DESCRIPTION
Convert the CAP1203 driver to the input subsystem, add to build_all tests. 

Some time ago I had a chat with @fabiobaltieri regarding lvgl and the kscan input depedency. Eventually the goal is to create a native lvgl input driver, but before that existing devices using the kscan api need to be converted. Noticing this PR being merged last week [https://github.com/zephyrproject-rtos/zephyr/pull/60161](https://github.com/zephyrproject-rtos/zephyr/pull/60161), I thought I could help making a dent in the ongoing conversion efforts :^)