### PR TITLE
Fix ENABLE bit blocking ADC channel setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ add_library(zephyr_interface INTERFACE)
 # flags that come with zephyr_interface.
 zephyr_library_named(zephyr)
 
-zephyr_include_directories(
+zephyr_system_include_directories(
   include
   ${PROJECT_BINARY_DIR}/include/generated
   ${USERINCLUDE}
@@ -123,7 +123,7 @@ foreach(optional_include_dir
   ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/include
   )
   if(EXISTS ${optional_include_dir})
-    zephyr_include_directories(${optional_include_dir})
+    zephyr_system_include_directories(${optional_include_dir})
   endif()
 endforeach()
 

--- a/arch/common/semihost.c
+++ b/arch/common/semihost.c
@@ -129,3 +129,9 @@ long semihost_write(long fd, const void *buf, long len)
 
 	return semihost_exec(SEMIHOST_WRITE, &args);
 }
+
+void semihost_exit(void)
+{
+	semihost_exec(SEMIHOST_EXIT, 0);
+	// return semihost_exec(SEMIHOST_EXIT, 0);
+}

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -89,7 +89,7 @@ endfunction()
 
 # https://cmake.org/cmake/help/latest/command/target_include_directories.html
 function(zephyr_include_directories)
-  target_include_directories(zephyr_interface INTERFACE ${ARGV})
+  target_include_directories(zephyr_interface SYSTEM INTERFACE ${ARGV})
 endfunction()
 
 # https://cmake.org/cmake/help/latest/command/target_include_directories.html

--- a/include/zephyr/arch/common/semihost.h
+++ b/include/zephyr/arch/common/semihost.h
@@ -19,6 +19,10 @@
  * @{
  */
 
+#ifdef __cplusplus
+extern "C" {
+	#endif
+
 #ifndef ZEPHYR_INCLUDE_ARCH_COMMON_SEMIHOST_H_
 #define ZEPHYR_INCLUDE_ARCH_COMMON_SEMIHOST_H_
 
@@ -48,6 +52,8 @@ enum semihost_instr {
 	SEMIHOST_REMOVE = 0x0E,
 	/** Rename a file on the host system. Possibly insecure! */
 	SEMIHOST_RENAME = 0x0F,
+	/** Exit semihosting */
+	SEMIHOST_EXIT = 0x18,
 
 	/*
 	 * Terminal I/O operations
@@ -193,8 +199,14 @@ long semihost_read(long fd, void *buf, long len);
  */
 long semihost_write(long fd, const void *buf, long len);
 
+void semihost_exit(void);
+
 /**
  * @}
  */
 
 #endif /* ZEPHYR_INCLUDE_ARCH_COMMON_SEMIHOST_H_ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/soc/arm/atmel_sam0/samc21/soc.h
+++ b/soc/arm/atmel_sam0/samc21/soc.h
@@ -52,6 +52,8 @@
 
 #endif /* _ASMLANGUAGE */
 
+#define ADC_SAM0_REFERENCE_ENABLE_PROTECTED
+
 #include "adc_fixup_sam0.h"
 #include "../common/soc_port.h"
 #include "../common/atmel_sam0_dt.h"

--- a/subsys/testsuite/ztest/include/zephyr/ztest.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest.h
@@ -41,15 +41,19 @@ typedef struct esf z_arch_esf_t;
 #endif
 #endif /* KERNEL */
 
-#include <zephyr/sys/printk.h>
-#define PRINT printk
+
 
 #include <zephyr/kernel.h>
 
+#include <zephyr/tc_util.h>
+#ifndef PRINT
+#include <zephyr/sys/printk.h>
+#define PRINT printk
+#endif
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_mock.h>
 #include <zephyr/ztest_test.h>
-#include <zephyr/tc_util.h>
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -30,6 +30,8 @@ static bool failed_expectation;
 #define NUM_ITER_PER_TEST  1
 #endif
 
+#include <zephyr/arch/common/semihost.h>
+
 /* ZTEST_DMEM and ZTEST_BMEM are used for the application shared memory test  */
 
 /**
@@ -1078,6 +1080,7 @@ int main(void)
 	z_init_mock();
 	test_main();
 	end_report();
+	semihost_exit();
 	flush_log();
 	LOG_PANIC();
 	if (IS_ENABLED(CONFIG_ZTEST_RETEST_IF_PASSED)) {


### PR DESCRIPTION
This issue inhibited proper ADC channel setup.

Eventually it will be resolved in zephyrproject-rtos/zephyr after merging the following PR: https://github.com/zephyrproject-rtos/zephyr/pull/60197

(If we update our own custom branch to the latest Zephyr version, this commit can be removed.)