### PR TITLE
drivers: can: sam: do not select cache management

### DIFF
--- a/drivers/can/Kconfig.sam
+++ b/drivers/can/Kconfig.sam
@@ -7,4 +7,3 @@ config CAN_SAM
 	default y
 	depends on DT_HAS_ATMEL_SAM_CAN_ENABLED
 	select CAN_MCAN
-	select CACHE_MANAGEMENT

--- a/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
@@ -37,4 +37,7 @@ config NUM_IRQS
 	default 74 if SOC_ATMEL_SAME70_REVB
 	default 71
 
+config CACHE_MANAGEMENT
+	default y
+
 endif # SOC_SERIES_SAME70

--- a/soc/arm/atmel_sam/samv71/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/samv71/Kconfig.defconfig.series
@@ -38,4 +38,7 @@ config NUM_IRQS
 	default 74 if SOC_ATMEL_SAMV71_REVB
 	default 71
 
+config CACHE_MANAGEMENT
+	default y
+
 endif # SOC_SERIES_SAMV71


### PR DESCRIPTION
Do not select CONFIG_CACHE_MANAGEMENT in the Microchip SAM CAN driver Kconfig but rather leave it up to the SoC/platform Kconfig to enable it as needed and enable CACHE_MANAGEMENT by default for the Atmel SAM E70/V71 SoC series.
