### PR TITLE
net: openthread: Refactor openthread entropy `otPlatEntropyGet`.

### DIFF
--- a/modules/openthread/platform/entropy.c
+++ b/modules/openthread/platform/entropy.c
@@ -5,21 +5,16 @@
  */
 
 #include <zephyr/kernel.h>
-#include <string.h>
-#include <zephyr/drivers/entropy.h>
+#include <zephyr/random/rand32.h>
 #include <zephyr/logging/log.h>
 
 #include <openthread/platform/entropy.h>
-
-#include "platform-zephyr.h"
 
 LOG_MODULE_REGISTER(net_otPlat_entropy, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 
 #if !defined(CONFIG_ENTROPY_HAS_DRIVER)
 #error OpenThread requires an entropy source for a TRNG
 #endif
-
-static const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 
 otError otPlatEntropyGet(uint8_t *aOutput, uint16_t aOutputLength)
 {
@@ -29,12 +24,7 @@ otError otPlatEntropyGet(uint8_t *aOutput, uint16_t aOutputLength)
 		return OT_ERROR_INVALID_ARGS;
 	}
 
-	if (!device_is_ready(dev)) {
-		LOG_ERR("Entropy device not ready");
-		return OT_ERROR_FAILED;
-	}
-
-	err = entropy_get_entropy(dev, aOutput, aOutputLength);
+	err = sys_csrand_get(aOutput, aOutputLength);
 	if (err != 0) {
 		LOG_ERR("Failed to obtain entropy, err %d", err);
 		return OT_ERROR_FAILED;


### PR DESCRIPTION
This comit removed direct entropy device driver calss to `sys_csrand_get`, which is recommended way of getting crypto secure random buffer.