### PR TITLE
drivers: i2c_dw: add support for agilex platform and reset

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -22,6 +22,12 @@ config I2C_SHELL
 	  The I2C shell supports scanning, bus recovery, I2C read and write
 	  operations.
 
+config I2C_ZERO_LEN_XFER_SUPPORTED
+	bool "I2C transfer without data (data length 0)"
+	default y
+	help
+	  Enable this flag to support 0 length I2C transfers(quick commands).
+
 config I2C_STATS
 	bool "I2C device Stats"
 	depends on STATS

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -1,7 +1,7 @@
-/* dw_i2c.h - header for Design Ware I2C operations */
+/* i2c_dw.h - header for Design Ware I2C operations */
 
 /*
- * Copyright (c) 2015 Intel Corporation
+ * Copyright (c) 2015-2023 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/dts/arm64/intel/intel_socfpga_agilex.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/clock/intel_socfpga_clock.h>
 #include <mem.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {
@@ -186,6 +187,66 @@
 		compatible = "snps,designware-watchdog";
 		reg = <0xffd00500 0x100>;
 		clocks = <&clock INTEL_SOCFPGA_CLOCK_WDT>;
+		status = "disabled";
+	};
+
+	i2c0: i2c@ffc02800 {
+		compatible = "snps,designware-i2c";
+		reg = <0xffc02800 0x100>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 103 IRQ_TYPE_LEVEL
+				IRQ_DEFAULT_PRIORITY>;
+		clock-frequency =  <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	i2c1: i2c@ffC02900 {
+		compatible = "snps,designware-i2c";
+		reg = <0xffC02900 0x100>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 104 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
+		clock-frequency =  <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	i2c2: i2c@ffC02A00 {
+		compatible = "snps,designware-i2c";
+		reg = <0xffC02A00 0x100>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 105 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
+		clock-frequency =  <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	i2c3: i2c@ffC02B00 {
+		compatible = "snps,designware-i2c";
+		reg = <0xffC02B00 0x100>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 106 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	i2c4: i2c@ffC02C00 {
+		compatible = "snps,designware-i2c";
+		reg = <0xffC02C00 0x100>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 107 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
 		status = "disabled";
 	};
 };

--- a/dts/bindings/i2c/snps,designware-i2c.yaml
+++ b/dts/bindings/i2c/snps,designware-i2c.yaml
@@ -5,7 +5,7 @@ description: Synopsys DesignWare I2C node
 
 compatible: "snps,designware-i2c"
 
-include: [i2c-controller.yaml, pinctrl-device.yaml, pcie-device.yaml]
+include: [i2c-controller.yaml, reset-device.yaml, pinctrl-device.yaml, pcie-device.yaml]
 
 properties:
   interrupts:


### PR DESCRIPTION
- Updated driver to reset the i2c node if its corresponding dtsi instance has a resets property.
- Handling invalid 0 length i2c transfer and logging error if i2c transfer is initiated with length 0.
- Modified i2c shell to support i2c scan command only if I2C_ZERO_LEN_XFER_SUPPORTED Kconfig flag is enabled.
- Updated i2c shell for checking i2c-speed parameter in i2c speed shell command.