### PR TITLE
doc: kernel: Fix Doxygen comments for stats.h

### DIFF
--- a/include/zephyr/kernel/stats.h
+++ b/include/zephyr/kernel/stats.h
@@ -10,19 +10,24 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-/*
- * [k_cycle_stats] is used to track internal statistics about both thread
+/**
+ * Structure used to track internal statistics about both thread
  * and CPU usage.
  */
 
 struct k_cycle_stats {
-	uint64_t  total;        /* total usage in cycles */
-#ifdef CONFIG_SCHED_THREAD_USAGE_ANALYSIS
-	uint64_t  current;      /* # of cycles in current usage window */
-	uint64_t  longest;      /* # of cycles in longest usage window */
-	uint32_t  num_windows;  /* # of usage windows */
+	uint64_t  total;        /**< total usage in cycles */
+#if defined(CONFIG_SCHED_THREAD_USAGE_ANALYSIS) || defined(__DOXYGEN__)
+	/**
+	 * @name Fields available when CONFIG_SCHED_THREAD_USAGE_ANALYSIS is selected.
+	 * @{
+	 */
+	uint64_t  current;      /**< \# of cycles in current usage window */
+	uint64_t  longest;      /**< \# of cycles in longest usage window */
+	uint32_t  num_windows;  /**< \# of usage windows */
+	/** @} */
 #endif
-	bool      track_usage;  /* true if gathering usage stats */
+	bool      track_usage;  /**< true if gathering usage stats */
 };
 
 #endif


### PR DESCRIPTION
Cleanup doxygen documentation by adding missing comments + enabling docs for fields guarded by CONFIG_SCHED_THREAD_USAGE_ANALYSIS.