### PR TITLE
smbus: tests: Use depends_on instead of platform_allow

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86_64.yaml
+++ b/boards/x86/qemu_x86/qemu_x86_64.yaml
@@ -9,6 +9,7 @@ simulation: qemu
 supported:
   - can
   - smp
+  - smbus
 testing:
   default: true
   ignore_tags:

--- a/tests/drivers/smbus/smbus_api/testcase.yaml
+++ b/tests/drivers/smbus/smbus_api/testcase.yaml
@@ -1,7 +1,6 @@
 common:
-  platform_allow:
-    - ehl_crb
-    - rpl_crb
+  depends_on:
+    - smbus
   tags: smbus
 tests:
   drivers.smbus.api:
@@ -11,22 +10,17 @@ tests:
     extra_configs:
       - CONFIG_SMBUS_INTEL_PCH_ACCESS_MMIO=y
   drivers.smbus.api_user:
-    platform_allow: qemu_x86_64
     extra_configs:
       - CONFIG_USERSPACE=y
   drivers.smbus.api_stats:
-    platform_allow: qemu_x86_64
     extra_configs:
       - CONFIG_STATS=y
   drivers.smbus.api.no_smbalert:
-    platform_allow: qemu_x86_64
     extra_configs:
       - CONFIG_SMBUS_INTEL_PCH_SMBALERT=n
   drivers.smbus.api.no_host_notify:
-    platform_allow: qemu_x86_64
     extra_configs:
       - CONFIG_SMBUS_INTEL_PCH_HOST_NOTIFY=n
   drivers.smbus.api.debug:
-    platform_allow: qemu_x86_64
     extra_configs:
       - CONFIG_SMBUS_LOG_LEVEL_DBG=y

--- a/tests/drivers/smbus/smbus_api/testcase.yaml
+++ b/tests/drivers/smbus/smbus_api/testcase.yaml
@@ -3,8 +3,9 @@ common:
     - smbus
   tags: smbus
 tests:
-  drivers.smbus.api:
-    platform_allow: qemu_x86_64
+  drivers.smbus.api.access.io:
+    extra_configs:
+      - CONFIG_SMBUS_INTEL_PCH_ACCESS_IO=y
   drivers.smbus.api.access.mmio:
     platform_exclude: qemu_x86_64
     extra_configs:


### PR DESCRIPTION
Make it easy to support new boards