### PR TITLE
soc: arm64: renesas: gen3: Move GIC version to DT

### DIFF
--- a/dts/arm64/renesas/rcar_gen3_ca57.dtsi
+++ b/dts/arm64/renesas/rcar_gen3_ca57.dtsi
@@ -29,7 +29,7 @@
 	};
 
 	gic: interrupt-controller@f1010000 {
-		compatible = "arm,gic-400", "arm,gic" ;
+		compatible = "arm,gic-400", "arm,gic-v2", "arm,gic" ;
 		#interrupt-cells = <4>;
 		#address-cells = <0>;
 		interrupt-controller;

--- a/soc/arm64/renesas_rcar/gen3/Kconfig.series
+++ b/soc/arm64/renesas_rcar/gen3/Kconfig.series
@@ -5,7 +5,6 @@ config SOC_SERIES_RCAR_GEN3
 	bool "Renesas RCAR Gen3 Cortex A"
 	select ARM64
 	select CPU_CORTEX_A57
-	select GIC_V2
 	select SOC_FAMILY_RCAR
 	select ARM_ARCH_TIMER
 	select CLOCK_CONTROL_RCAR_CPG_MSSR if CLOCK_CONTROL


### PR DESCRIPTION
Move the GIC version to the device tree for Renesas R-Car Gen3 to improve readability