### PR TITLE
west_commands: Fix parsing of extra args for test-item

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -285,7 +285,10 @@ class Build(Forceable):
                     arg_list = extra.split(" ")
                 else:
                     arg_list = extra
-                args = ["-D{}".format(arg.replace('"', '\"')) for arg in arg_list]
+                if data == 'extra_configs':
+                    args = ["-D{}".format(arg.replace('"', '\"')) for arg in arg_list]
+                elif data == 'extra_args':
+                    args = ["-D{}".format(arg.replace('"', '')) for arg in arg_list]
                 if self.args.cmake_opts:
                     self.args.cmake_opts.extend(args)
                 else:


### PR DESCRIPTION
An arg --test-item makes west loading twister's test configurations form sample/testcase.yaml. It has to mirror twister's behavior. It was not the case with "extra_args" section. Quotation  marks were not removed in west as they were in twister. The quotation marks have to be removed from the extra_args section but left in extra_configs. The commit adds differentiation for those.

fixes: #60297