### PR TITLE
Bluetooth: Host: Allow to use NRPA with connectable advertiser

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -685,6 +685,28 @@ enum {
 	 * @note Requires @ref BT_LE_ADV_OPT_USE_NAME
 	 */
 	BT_LE_ADV_OPT_FORCE_NAME_IN_AD = BIT(18),
+
+	/**
+	 * @brief Use new random address on every connectable advertising
+	 * start.
+	 *
+	 * By default, when starting advertising using the @ref
+	 * BT_LE_ADV_OPT_CONNECTABLE option and @kconfig{CONFIG_BT_PRIVACY} is
+	 * disabled, the advertiser set uses the identity address as the
+	 * advertising address.
+	 * When this option is enabled together with @ref
+	 * BT_LE_ADV_OPT_CONNECTABLE, the advertiser set will regenerate
+	 * the advertising address on every advertising start.
+	 * If this option gets disabled, the advertiser set starts using the
+	 * identity address back again.
+	 *
+	 * @note Requires @ref BT_LE_ADV_OPT_CONNECTABLE.
+	 *
+	 * @note Cannot be set if BT_LE_ADV_OPT_USE_IDENTITY is set.
+	 *
+	 * @note Has no effect if @kconfig{CONFIG_BT_PRIVACY} is enabled.
+	 */
+	BT_LE_ADV_OPT_USE_RANDOM = BIT(19),
 };
 
 /** LE Advertising Parameters. */

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -475,6 +475,12 @@ static bool valid_adv_ext_param(const struct bt_le_adv_param *param)
 		return false;
 	}
 
+	if ((param->options & BT_LE_ADV_OPT_USE_IDENTITY) &&
+	    (param->options & BT_LE_ADV_OPT_USE_RANDOM)) {
+		/* These options are mutually exclusive. */
+		return false;
+	}
+
 	return true;
 }
 
@@ -1108,6 +1114,9 @@ set_adv_state:
 	atomic_set_bit_to(adv->flags, BT_ADV_USE_IDENTITY,
 			  param->options & BT_LE_ADV_OPT_USE_IDENTITY);
 
+	atomic_set_bit_to(adv->flags, BT_ADV_USE_RANDOM,
+			  param->options & BT_LE_ADV_OPT_USE_RANDOM);
+
 	return 0;
 }
 
@@ -1254,6 +1263,9 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 
 	atomic_set_bit_to(adv->flags, BT_ADV_EXT_ADV,
 			  param->options & BT_LE_ADV_OPT_EXT_ADV);
+
+	atomic_set_bit_to(adv->flags, BT_ADV_USE_RANDOM,
+			  param->options & BT_LE_ADV_OPT_USE_RANDOM);
 
 	return 0;
 }
@@ -1495,8 +1507,9 @@ void bt_le_adv_resume(void)
 
 	LOG_DBG("Resuming connectable advertising");
 
-	if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
-	    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
+	if ((IS_ENABLED(CONFIG_BT_PRIVACY) &&
+	     !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) ||
+	    atomic_test_bit(adv->flags, BT_ADV_USE_RANDOM)) {
 		bt_id_set_adv_private_addr(adv);
 	} else {
 		uint8_t own_addr_type;
@@ -1630,8 +1643,9 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 			  (param->timeout > 0 || param->num_events > 0));
 
 	if (atomic_test_bit(adv->flags, BT_ADV_CONNECTABLE)) {
-		if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
-		    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
+		if ((IS_ENABLED(CONFIG_BT_PRIVACY) &&
+		     !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) ||
+		    atomic_test_bit(adv->flags, BT_ADV_USE_RANDOM)) {
 			bt_id_set_adv_private_addr(adv);
 		}
 	} else {

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -130,6 +130,9 @@ enum {
 	 */
 	BT_PER_ADV_CTE_ENABLED,
 
+	/* Generate new random address and use it on every connectable advertising start. */
+	BT_ADV_USE_RANDOM,
+
 	BT_ADV_NUM_FLAGS,
 };
 


### PR DESCRIPTION
When starting connectable advertising and when CONFIG_BT_PRIVACY
Kconfig option is disabled, the host uses the advertising address from
the identity. When identity is BT_ID_DEFAULT, the address is either
public or static random.

For Bluetooth mesh, in certain cases, it is required to advertise as
connnectable with either RPA or NRPA where the adverting addresss
is regenerated in certain conditions.

This commit adds a new option, BT_LE_ADV_OPT_USE_RANDOM, which makes the
advertiser set generate a new random address and use it when it starts
advertising a connectable event.

Fixes #60428