### PR TITLE
clang: Don't specify FP16 format

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -289,7 +289,7 @@ config FP16
 	help
 	  This option enables the half-precision (16-bit) floating point support
 	  via the `__fp16` (both IEEE and ARM alternative formats) and the
-	  `_Float16` (IEEE format only) types.
+	  `_Float16` (defined by ISO/IEC TS 18661-3:2015) types.
 
 choice
 	prompt "FP16 format"

--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -312,6 +312,8 @@ config FP16_ALT
 	  so that this format can represent normalized values in the range of
 	  2^(-14) to 131008.
 
+	  Please note that Clang doesn't support the ARM alternative format.
+
 endchoice
 
 rsource "cortex_m/Kconfig"

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -29,7 +29,7 @@ if(NOT "${ARCH}" STREQUAL "posix")
       -fshort-enums
       )
 
-    include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_arm.cmake)
+    include(${ZEPHYR_BASE}/cmake/compiler/clang/target_arm.cmake)
   endif()
 
   foreach(file_name include/stddef.h)

--- a/cmake/compiler/clang/target_arm.cmake
+++ b/cmake/compiler/clang/target_arm.cmake
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+
+set(ARM_C_FLAGS)
+
+list(APPEND ARM_C_FLAGS   -mcpu=${GCC_M_CPU})
+
+if(CONFIG_COMPILER_ISA_THUMB2)
+  list(APPEND ARM_C_FLAGS   -mthumb)
+endif()
+
+list(APPEND ARM_C_FLAGS -mabi=aapcs)
+
+if(CONFIG_FPU)
+  list(APPEND ARM_C_FLAGS   -mfpu=${GCC_M_FPU})
+
+  if(CONFIG_DCLS AND NOT CONFIG_FP_HARDABI)
+    # If the processor is equipped with VFP and configured in DCLS topology,
+    # the FP "hard" ABI must be used in order to facilitate the FP register
+    # initialisation and synchronisation.
+    set(FORCE_FP_HARDABI TRUE)
+  endif()
+
+  if    (CONFIG_FP_HARDABI OR FORCE_FP_HARDABI)
+    list(APPEND ARM_C_FLAGS   -mfloat-abi=hard)
+  elseif(CONFIG_FP_SOFTABI)
+    list(APPEND ARM_C_FLAGS   -mfloat-abi=softfp)
+  endif()
+endif()
+
+if(CONFIG_FP16)
+  # Clang only supports IEEE 754-2008 format for __fp16. It's enabled by
+  # default, so no need to do anything when CONFIG_FP16_IEEE is selected.
+  if(CONFIG_FP16_ALT)
+    message(FATAL_ERROR "Clang doesn't support ARM alternative format for FP16")
+  endif()
+endif()
+list(APPEND TOOLCHAIN_C_FLAGS ${ARM_C_FLAGS})
+list(APPEND TOOLCHAIN_LD_FLAGS NO_SPLIT ${ARM_C_FLAGS})


### PR DESCRIPTION
Clang only supports IEEE 754-2008 format for __fp16. It's enabled by default, so no need to provide any compiler options.
The ARM alternative format is not supported by Clang, so crash compilation if CONFIG_FP16_ALT is selected.

Fixes: #55562