### PR TITLE
llvm: Add ARMv6-M, ARMv7-M, ARMv8-M Mainline and Baseline targets

### DIFF
--- a/cmake/toolchain/llvm/target.cmake
+++ b/cmake/toolchain/llvm/target.cmake
@@ -7,7 +7,25 @@ elseif(CONFIG_LLVM_USE_LLD)
 endif()
 
 if("${ARCH}" STREQUAL "arm")
-  set(triple arm-none-eabi)
+  if(DEFINED CONFIG_ARMV8_M_MAINLINE)
+    # ARMv8-M mainline is ARMv7-M with additional features from ARMv8-M.
+    set(triple armv8m.main-none-eabi)
+  elseif(DEFINED CONFIG_ARMV8_M_BASELINE)
+    # ARMv8-M baseline is ARMv6-M with additional features from ARMv8-M.
+    set(triple armv8m.base-none-eabi)
+  elseif(DEFINED CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+    # ARMV7_M_ARMV8_M_MAINLINE means that ARMv7-M or backward compatible ARMv8-M
+    # processor is used.
+    set(triple armv7m-cros-eabi)
+  elseif(DEFINED CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+    # ARMV6_M_ARMV8_M_BASELINE means that ARMv6-M or ARMv8-M supporting the
+    # Baseline implementation processor is used.
+    set(triple armv6m-none-eabi)
+  else()
+    # Default ARM target supported by all processors.
+    set(triple arm-none-eabi)
+  endif()
+
   set(CMAKE_EXE_LINKER_FLAGS_INIT "--specs=nosys.specs")
 elseif("${ARCH}" STREQUAL "x86")
   if(CONFIG_64BIT)


### PR DESCRIPTION
Introduce more specific ARM targets basing on enabled options in Kconfig.