### PR TITLE
kernel: split k_busy_wait() out of timeout.c

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -41,6 +41,7 @@ else()
 list(APPEND kernel_files
   main_weak.c
   banner.c
+  busy_wait.c
   device.c
   errno.c
   fatal.c

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -755,6 +755,18 @@ config SYS_CLOCK_MAX_TIMEOUT_DAYS
 	  algorithm is selected for conversion if maximum timeout represented in
 	  source frequency domain multiplied by target frequency fits in 64 bits.
 
+config BUSYWAIT_CPU_LOOPS_PER_USEC
+	int "Number of CPU loops per microsecond for crude busy looping"
+	depends on !SYS_CLOCK_EXISTS && !ARCH_HAS_CUSTOM_BUSY_WAIT
+	default 500
+	help
+	  Calibration for crude CPU based busy loop duration. The default
+	  is assuming 1 GHz CPU and 2 cycles per loop. Reality is certainly
+	  much worse but all we want here is a ball-park figure that ought
+	  to be good enough for the purpose of being able to configure out
+	  system timer support. If accuracy is very important then
+	  implementing arch_busy_wait() should be considered.
+
 config XIP
 	bool "Execute in place"
 	help

--- a/kernel/busy_wait.c
+++ b/kernel/busy_wait.c
@@ -19,7 +19,7 @@ void z_impl_k_busy_wait(uint32_t usec_to_wait)
 
 #if defined(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT)
 	arch_busy_wait(usec_to_wait);
-#else
+#elif defined(CONFIG_SYS_CLOCK_EXISTS)
 	uint32_t start_cycles = k_cycle_get_32();
 
 	/* use 64-bit math to prevent overflow when multiplying */
@@ -36,6 +36,17 @@ void z_impl_k_busy_wait(uint32_t usec_to_wait)
 		if ((current_cycles - start_cycles) >= cycles_to_wait) {
 			break;
 		}
+	}
+#else
+	/*
+	 * Crude busy loop for the purpose of being able to configure out
+	 * system timer support.
+	 */
+	unsigned int loops_per_usec = CONFIG_BUSYWAIT_CPU_LOOPS_PER_USEC;
+	unsigned int loops = loops_per_usec * usec_to_wait;
+
+	while (loops-- > 0) {
+		arch_nop();
 	}
 #endif
 

--- a/kernel/busy_wait.c
+++ b/kernel/busy_wait.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/sys_clock.h>
+#include <kernel_arch_interface.h>
+
+void z_impl_k_busy_wait(uint32_t usec_to_wait)
+{
+	SYS_PORT_TRACING_FUNC_ENTER(k_thread, busy_wait, usec_to_wait);
+	if (usec_to_wait == 0U) {
+		SYS_PORT_TRACING_FUNC_EXIT(k_thread, busy_wait, usec_to_wait);
+		return;
+	}
+
+#if defined(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT)
+	arch_busy_wait(usec_to_wait);
+#else
+	uint32_t start_cycles = k_cycle_get_32();
+
+	/* use 64-bit math to prevent overflow when multiplying */
+	uint32_t cycles_to_wait = (uint32_t)(
+		(uint64_t)usec_to_wait *
+		(uint64_t)sys_clock_hw_cycles_per_sec() /
+		(uint64_t)USEC_PER_SEC
+	);
+
+	for (;;) {
+		uint32_t current_cycles = k_cycle_get_32();
+
+		/* this handles the rollover on an unsigned 32-bit value */
+		if ((current_cycles - start_cycles) >= cycles_to_wait) {
+			break;
+		}
+	}
+#endif
+
+	SYS_PORT_TRACING_FUNC_EXIT(k_thread, busy_wait, usec_to_wait);
+}
+
+#ifdef CONFIG_USERSPACE
+static inline void z_vrfy_k_busy_wait(uint32_t usec_to_wait)
+{
+	z_impl_k_busy_wait(usec_to_wait);
+}
+#include <syscalls/k_busy_wait_mrsh.c>
+#endif /* CONFIG_USERSPACE */

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -289,46 +289,6 @@ static inline int64_t z_vrfy_k_uptime_ticks(void)
 #include <syscalls/k_uptime_ticks_mrsh.c>
 #endif
 
-void z_impl_k_busy_wait(uint32_t usec_to_wait)
-{
-	SYS_PORT_TRACING_FUNC_ENTER(k_thread, busy_wait, usec_to_wait);
-	if (usec_to_wait == 0U) {
-		SYS_PORT_TRACING_FUNC_EXIT(k_thread, busy_wait, usec_to_wait);
-		return;
-	}
-
-#if !defined(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT)
-	uint32_t start_cycles = k_cycle_get_32();
-
-	/* use 64-bit math to prevent overflow when multiplying */
-	uint32_t cycles_to_wait = (uint32_t)(
-		(uint64_t)usec_to_wait *
-		(uint64_t)sys_clock_hw_cycles_per_sec() /
-		(uint64_t)USEC_PER_SEC
-	);
-
-	for (;;) {
-		uint32_t current_cycles = k_cycle_get_32();
-
-		/* this handles the rollover on an unsigned 32-bit value */
-		if ((current_cycles - start_cycles) >= cycles_to_wait) {
-			break;
-		}
-	}
-#else
-	arch_busy_wait(usec_to_wait);
-#endif /* CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT */
-	SYS_PORT_TRACING_FUNC_EXIT(k_thread, busy_wait, usec_to_wait);
-}
-
-#ifdef CONFIG_USERSPACE
-static inline void z_vrfy_k_busy_wait(uint32_t usec_to_wait)
-{
-	z_impl_k_busy_wait(usec_to_wait);
-}
-#include <syscalls/k_busy_wait_mrsh.c>
-#endif /* CONFIG_USERSPACE */
-
 /* Returns the uptime expiration (relative to an unlocked "now"!) of a
  * timeout object.  When used correctly, this should be called once,
  * synchronously with the user passing a new timeout value.  It should


### PR DESCRIPTION
This allows for builds with `CONFIG_SYS_CLOCK_EXISTS=n` in which case
busy waits are achieved with a crude CPU loop. If ever accuracy is
needed even with such a configuration then implementing `arch_busy_wait()`
should be considered. Otherwise the code is unchanged.
