### PR TITLE
fs: shell: littlefs: add support of block devices

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -354,6 +354,10 @@ Libraries / Subsystems
 * File systems
 
   * Added support for ext2 file system.
+  * Added support of mounting littlefs on the block device from the shell/fs.
+  * Added alignment parameter to FS_LITTLEFS_DECLARE_CUSTOM_CONFIG macro, it can speed up read/write
+    operation for SDMMC devices in case when we align buffers on CONFIG_SDHC_BUFFER_ALIGNMENT,
+    because we can avoid extra copy of data from card bffer to read/prog buffer.
 
 HALs
 ****

--- a/include/zephyr/fs/littlefs.h
+++ b/include/zephyr/fs/littlefs.h
@@ -62,15 +62,17 @@ struct fs_littlefs {
  *
  * @param name the name for the structure.  The defined object has
  * file scope.
+ * @param alignment needed alignment for read/prog buffer for specific device
  * @param read_sz see @kconfig{CONFIG_FS_LITTLEFS_READ_SIZE}
  * @param prog_sz see @kconfig{CONFIG_FS_LITTLEFS_PROG_SIZE}
  * @param cache_sz see @kconfig{CONFIG_FS_LITTLEFS_CACHE_SIZE}
  * @param lookahead_sz see @kconfig{CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE}
  */
-#define FS_LITTLEFS_DECLARE_CUSTOM_CONFIG(name, read_sz, prog_sz, cache_sz, lookahead_sz) \
-	static uint8_t __aligned(4) name ## _read_buffer[cache_sz];			  \
-	static uint8_t __aligned(4) name ## _prog_buffer[cache_sz];			  \
-	static uint32_t name ## _lookahead_buffer[(lookahead_sz) / sizeof(uint32_t)];		  \
+#define FS_LITTLEFS_DECLARE_CUSTOM_CONFIG(name, alignment, read_sz, prog_sz, cache_sz,	  \
+					  lookahead_sz)					  \
+	static uint8_t __aligned(alignment) name ## _read_buffer[cache_sz];		  \
+	static uint8_t __aligned(alignment) name ## _prog_buffer[cache_sz];		  \
+	static uint32_t name ## _lookahead_buffer[(lookahead_sz) / sizeof(uint32_t)];	  \
 	static struct fs_littlefs name = {						  \
 		.cfg = {								  \
 			.read_size = (read_sz),						  \
@@ -94,6 +96,7 @@ struct fs_littlefs {
  */
 #define FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(name)			 \
 	FS_LITTLEFS_DECLARE_CUSTOM_CONFIG(name,				 \
+					  4,				 \
 					  CONFIG_FS_LITTLEFS_READ_SIZE,	 \
 					  CONFIG_FS_LITTLEFS_PROG_SIZE,	 \
 					  CONFIG_FS_LITTLEFS_CACHE_SIZE, \

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -11,6 +11,7 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/init.h>
 #include <zephyr/fs/fs.h>
+#include <zephyr/sd/sd_spec.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -34,6 +35,33 @@ static struct fs_mount_t fatfs_mnt = {
 /* LITTLEFS */
 #ifdef CONFIG_FILE_SYSTEM_LITTLEFS
 #include <zephyr/fs/littlefs.h>
+
+/* TODO: Implement dynamic storage dev selection */
+#ifdef CONFIG_FS_LITTLEFS_BLK_DEV
+
+#if defined(CONFIG_DISK_DRIVER_SDMMC)
+#define DISK_NAME CONFIG_SDMMC_VOLUME_NAME
+#elif defined(CONFIG_DISK_DRIVER_MMC)
+#define DISK_NAME CONFIG_MMC_VOLUME_NAME
+#else
+#error "No disk device defined, is your board supported?"
+#endif
+
+FS_LITTLEFS_DECLARE_CUSTOM_CONFIG(
+	lfs_data,
+	CONFIG_SDHC_BUFFER_ALIGNMENT,
+	SDMMC_DEFAULT_BLOCK_SIZE,
+	SDMMC_DEFAULT_BLOCK_SIZE,
+	SDMMC_DEFAULT_BLOCK_SIZE,
+	2 * SDMMC_DEFAULT_BLOCK_SIZE);
+
+static struct fs_mount_t littlefs_mnt = {
+	.type = FS_LITTLEFS,
+	.fs_data = &lfs_data,
+	.flags = FS_MOUNT_FLAG_USE_DISK_ACCESS,
+	.storage_dev = DISK_NAME,
+};
+#else
 #include <zephyr/storage/flash_map.h>
 
 FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(lfs_data);
@@ -42,6 +70,7 @@ static struct fs_mount_t littlefs_mnt = {
 	.fs_data = &lfs_data,
 	.storage_dev = (void *)STORAGE_PARTITION_ID,
 };
+#endif
 #endif
 
 #define BUF_CNT 64

--- a/tests/subsys/fs/littlefs/src/testfs_lfs.c
+++ b/tests/subsys/fs/littlefs/src/testfs_lfs.c
@@ -27,7 +27,7 @@ struct fs_mount_t testfs_small_mnt = {
 };
 
 #if CONFIG_APP_TEST_CUSTOM
-FS_LITTLEFS_DECLARE_CUSTOM_CONFIG(medium, MEDIUM_IO_SIZE, MEDIUM_IO_SIZE,
+FS_LITTLEFS_DECLARE_CUSTOM_CONFIG(medium, 4, MEDIUM_IO_SIZE, MEDIUM_IO_SIZE,
 				  MEDIUM_CACHE_SIZE, MEDIUM_LOOKAHEAD_SIZE);
 struct fs_mount_t testfs_medium_mnt = {
 	.type = FS_LITTLEFS,

--- a/tests/subsys/fs/littlefs/src/testfs_mkfs.c
+++ b/tests/subsys/fs/littlefs/src/testfs_mkfs.c
@@ -47,6 +47,7 @@ ZTEST(littlefs, test_fs_mkfs_ops_lfs)
 
 /* Custom config with doubled the prog size */
 FS_LITTLEFS_DECLARE_CUSTOM_CONFIG(custom_cfg,
+		4,
 		CONFIG_FS_LITTLEFS_READ_SIZE,
 		CONFIG_FS_LITTLEFS_PROG_SIZE * 2,
 		CONFIG_FS_LITTLEFS_CACHE_SIZE,


### PR DESCRIPTION
For flash device, littlefs should be located at the partition. Current implementation of the fs shell is hardcoded for the flash device and the compilation fails if STORAGE_PARTITION isn't defined in the device tree.
Add options for block dev support. This allows to mount littlefs on the block device from the shell, and also removes the compile time dependency on STORAGE_PARTITION, if CONFIG_FS_LITTLEFS_BLK_DEV is set.

This is an incremental improvement, ideally, someone should implement selection of the storage dev from the shell args.