### PR TITLE
debug: thread_analyzer: use printk by default

### DIFF
--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -26,6 +26,7 @@ source "subsys/logging/Kconfig.template.log_config"
 
 choice
 	prompt "Thread analysis print mode"
+	default THREAD_ANALYZER_USE_PRINTK
 
 config THREAD_ANALYZER_USE_LOG
 	bool "Use logger output"


### PR DESCRIPTION
When enabling thread analyzer, use printk by default. Otherwise logging
subsystem is enabled which might not be desired.

Fixes #59919

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
