### PR TITLE
MAINTAINERS: fix path for native_simulator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1794,7 +1794,7 @@ Native POSIX/Sim and POSIX arch:
     - drivers/*/*/*native*
     - dts/posix/
     - include/zephyr/arch/posix/
-    - scripts/native_simulator/*
+    - scripts/native_simulator/
     - scripts/valgrind.supp
     - soc/posix/
     - tests/boards/native_posix/


### PR DESCRIPTION
Fix syntax of path for native_simulator.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
