### PR TITLE
serial: ns16550: check return of clock_control_get_rate()

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -458,8 +458,12 @@ static int uart_ns16550_configure(const struct device *dev,
 			goto out;
 		}
 
-		clock_control_get_rate(dev_cfg->clock_dev, dev_cfg->clock_subsys,
-			   &pclk);
+		if (clock_control_get_rate(dev_cfg->clock_dev,
+					   dev_cfg->clock_subsys,
+					   &pclk) != 0) {
+			ret = -EINVAL;
+			goto out;
+		}
 	}
 
 	set_baud_rate(dev, cfg->baudrate, pclk);


### PR DESCRIPTION
This adds a check of the return of clock_control_get_rate(), and returns error in uart_configure() if unsuccessful in getting clock rate.

Fixes #60478