### PR TITLE
serial: CONFIG_UART_USE_RUNTIME_CONFIGURE on API for cfg funcs

### DIFF
--- a/drivers/serial/uart_altera.c
+++ b/drivers/serial/uart_altera.c
@@ -350,7 +350,6 @@ static int uart_altera_configure(const struct device *dev,
 
 	return ret_val;
 }
-#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 /**
  * @brief Get UART configuration and stores in *cfg_out.
@@ -377,6 +376,7 @@ static int uart_altera_config_get(const struct device *dev,
 	*cfg_out = data->uart_cfg;
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 /**
@@ -907,8 +907,8 @@ static const struct uart_driver_api uart_altera_driver_api = {
 	.err_check = uart_altera_err_check,
 #ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = uart_altera_configure,
-#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 	.config_get = uart_altera_config_get,
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = uart_altera_fifo_fill,

--- a/drivers/serial/uart_b91.c
+++ b/drivers/serial/uart_b91.c
@@ -240,6 +240,7 @@ static void uart_b91_irq_handler(const struct device *dev)
 #endif
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 /* API implementation: configure */
 static int uart_b91_configure(const struct device *dev,
 			      const struct uart_config *cfg)
@@ -299,6 +300,7 @@ static int uart_b91_config_get(const struct device *dev,
 
 	return 0;
 }
+#endif
 
 /* API implementation: driver initialization */
 static int uart_b91_driver_init(const struct device *dev)
@@ -523,8 +525,10 @@ static const struct uart_driver_api uart_b91_driver_api = {
 	.poll_in = uart_b91_poll_in,
 	.poll_out = uart_b91_poll_out,
 	.err_check = uart_b91_err_check,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = uart_b91_configure,
 	.config_get = uart_b91_config_get,
+#endif
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = uart_b91_fifo_fill,
 	.fifo_read = uart_b91_fifo_read,

--- a/drivers/serial/uart_emul.c
+++ b/drivers/serial/uart_emul.c
@@ -81,6 +81,7 @@ int uart_emul_err_check(const struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 int uart_emul_configure(const struct device *dev, const struct uart_config *cfg)
 {
 	struct uart_emul_data *drv_data = dev->data;
@@ -96,12 +97,15 @@ int uart_emul_config_get(const struct device *dev, struct uart_config *cfg)
 	memcpy(cfg, &drv_data->cfg, sizeof(struct uart_config));
 	return 0;
 }
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 
 static const struct uart_driver_api uart_emul_api = {
 	.poll_in = uart_emul_poll_in,
 	.poll_out = uart_emul_poll_out,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.config_get = uart_emul_config_get,
 	.configure = uart_emul_configure,
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 	.err_check = uart_emul_err_check
 };
 

--- a/drivers/serial/uart_handlers.c
+++ b/drivers/serial/uart_handlers.c
@@ -58,6 +58,7 @@ static inline void z_vrfy_uart_poll_out_u16(const struct device *dev,
 }
 #include <syscalls/uart_poll_out_u16_mrsh.c>
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static inline int z_vrfy_uart_config_get(const struct device *dev,
 					 struct uart_config *cfg)
 {
@@ -77,6 +78,7 @@ static inline int z_vrfy_uart_configure(const struct device *dev,
 	return z_impl_uart_configure(dev, cfg);
 }
 #include <syscalls/uart_configure_mrsh.c>
+#endif
 
 #ifdef CONFIG_UART_ASYNC_API
 /* callback_set() excluded as we don't allow ISR callback installation from

--- a/drivers/serial/uart_native_tty.c
+++ b/drivers/serial/uart_native_tty.c
@@ -379,7 +379,9 @@ static int native_tty_serial_init(const struct device *dev)
 static struct uart_driver_api native_tty_uart_driver_api = {
 	.poll_out = native_tty_uart_poll_out,
 	.poll_in = native_tty_uart_poll_in,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = native_tty_configure,
+#endif
 };
 
 #define NATIVE_TTY_INSTANCE(inst)                                                                  \

--- a/drivers/serial/uart_neorv32.c
+++ b/drivers/serial/uart_neorv32.c
@@ -440,8 +440,10 @@ static int neorv32_uart_pm_action(const struct device *dev,
 static const struct uart_driver_api neorv32_uart_driver_api = {
 	.poll_in = neorv32_uart_poll_in,
 	.poll_out = neorv32_uart_poll_out,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	.configure = neorv32_uart_configure,
 	.config_get = neorv32_uart_config_get,
+#endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.fifo_fill = neorv32_uart_fifo_fill,
 	.fifo_read = neorv32_uart_fifo_read,

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -377,10 +377,12 @@ __subsystem struct uart_driver_api {
 	/** Console I/O function */
 	int (*err_check)(const struct device *dev);
 
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	/** UART configuration functions */
 	int (*configure)(const struct device *dev,
 			 const struct uart_config *cfg);
 	int (*config_get)(const struct device *dev, struct uart_config *cfg);
+#endif
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 
@@ -630,6 +632,7 @@ static inline void z_impl_uart_poll_out_u16(const struct device *dev,
  * @retval -errno Negative errno code in case of failure.
  * @retval -ENOSYS If configuration is not supported by device
  *                  or driver does not support setting configuration in runtime.
+ * @retval -ENOTSUP If API is not enabled.
  */
 __syscall int uart_configure(const struct device *dev,
 			     const struct uart_config *cfg);
@@ -637,6 +640,7 @@ __syscall int uart_configure(const struct device *dev,
 static inline int z_impl_uart_configure(const struct device *dev,
 					const struct uart_config *cfg)
 {
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	const struct uart_driver_api *api =
 				(const struct uart_driver_api *)dev->api;
 
@@ -644,6 +648,11 @@ static inline int z_impl_uart_configure(const struct device *dev,
 		return -ENOSYS;
 	}
 	return api->configure(dev, cfg);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cfg);
+	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -658,6 +667,7 @@ static inline int z_impl_uart_configure(const struct device *dev,
  * @retval 0 If successful.
  * @retval -errno Negative errno code in case of failure.
  * @retval -ENOSYS If driver does not support getting current configuration.
+ * @retval -ENOTSUP If API is not enabled.
  */
 __syscall int uart_config_get(const struct device *dev,
 			      struct uart_config *cfg);
@@ -665,6 +675,7 @@ __syscall int uart_config_get(const struct device *dev,
 static inline int z_impl_uart_config_get(const struct device *dev,
 					 struct uart_config *cfg)
 {
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 	const struct uart_driver_api *api =
 				(const struct uart_driver_api *)dev->api;
 
@@ -673,6 +684,11 @@ static inline int z_impl_uart_config_get(const struct device *dev,
 	}
 
 	return api->config_get(dev, cfg);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cfg);
+	return -ENOTSUP;
+#endif
 }
 
 /**


### PR DESCRIPTION
This adds the CONFIG_UART_USE_RUNTIME_CONFIGURE guard to disable the API function pointers if the kconfig is not enabled. Both .configure and .config_get should only be usable if runtime (re-)configuration of UART is needed.

Guards are also added to drivers lacking this guard.