### PR TITLE
uart: add API to de-/re-initialize UART hardware

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -110,6 +110,16 @@ config UART_PIPE
 	  data (as contrary to console UART driver) and all aspects of received
 	  protocol data are handled by application provided callback.
 
+config UART_REINIT_API
+	bool "UART Re-initialization API"
+	help
+	  This enables the use of uart_deinit() and uart_reinit() to
+	  de-initialize and re-initialize the UART. This allows
+	  the UART pins to be re-purposed for other functionalities
+	  depending on usage (usually via pinctrl).
+
+	  Says no if not sure.
+
 comment "Serial Drivers"
 
 source "drivers/serial/Kconfig.b91"

--- a/drivers/serial/uart_handlers.c
+++ b/drivers/serial/uart_handlers.c
@@ -184,3 +184,11 @@ static inline int z_vrfy_uart_drv_cmd(const struct device *dev, uint32_t cmd,
 }
 #include <syscalls/uart_drv_cmd_mrsh.c>
 #endif /* CONFIG_UART_DRV_CMD */
+
+#ifdef CONFIG_UART_REINIT_API
+UART_SIMPLE(deinit)
+#include <syscalls/uart_deinit_mrsh.c>
+
+UART_SIMPLE(reinit)
+#include <syscalls/uart_reinit_mrsh.c>
+#endif /* CONFIG_UART_REINIT_API */

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -453,6 +453,14 @@ __subsystem struct uart_driver_api {
 	int (*drv_cmd)(const struct device *dev, uint32_t cmd, uint32_t p);
 #endif
 
+#ifdef CONFIG_UART_REINIT_API
+	/** De-initialize UART */
+	int (*deinit)(const struct device *dev);
+
+	/** Re-initialize UART */
+	int (*reinit)(const struct device *dev);
+#endif
+
 };
 
 /** @endcond */
@@ -1648,6 +1656,63 @@ static inline int z_impl_uart_drv_cmd(const struct device *dev, uint32_t cmd,
 	return -ENOTSUP;
 #endif
 }
+
+/**
+ * @brief De-initialize UART device.
+ *
+ * @param dev UART device instance.
+ *
+ * @retval 0 if successful.
+ * @retval -ENOSYS If this function is not implemented.
+ * @retval -ENOTSUP If API is not enabled.
+ * @retval -errno Other negative errno value in case of failure.
+ */
+__syscall int uart_deinit(const struct device *dev);
+
+static inline int z_impl_uart_deinit(const struct device *dev)
+{
+#ifdef CONFIG_UART_REINIT_API
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->deinit == NULL) {
+		return -ENOSYS;
+	}
+	return api->deinit(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+/**
+ * @brief Re-initialize UART device.
+ *
+ * @param dev UART device instance.
+ *
+ * @retval 0 if successful.
+ * @retval -ENOSYS If this function is not implemented.
+ * @retval -ENOTSUP If API is not enabled.
+ * @retval -errno Other negative errno value in case of failure.
+ */
+__syscall int uart_reinit(const struct device *dev);
+
+static inline int z_impl_uart_reinit(const struct device *dev)
+{
+#ifdef CONFIG_UART_REINIT_API
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->reinit == NULL) {
+		return -ENOSYS;
+	}
+	return api->reinit(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This adds two APIs, uart_deinit() and uart_reinit() to allow application to de-initialize and re-initialize UART devices. One usage would be to allow application to re-purpose the UART pins for other activities (usually via pinctrl).

Fixes #31857