### PR TITLE
initial support of Intel ISH boards

### DIFF
--- a/boards/x86/intel_ish/Kconfig.board
+++ b/boards/x86/intel_ish/Kconfig.board
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config BOARD_INTEL_ISH_5_4_1
+	bool "Intel ISH 5.4.1 board"
+	depends on SOC_INTEL_ISH_5_4_1
+
+config BOARD_INTEL_ISH_5_6_0
+	bool "Intel ISH 5.6.0 board"
+	depends on SOC_INTEL_ISH_5_6_0
+
+config BOARD_INTEL_ISH_5_8_0
+	bool "Intel ISH 5.8.0 board"
+	depends on SOC_INTEL_ISH_5_8_0

--- a/boards/x86/intel_ish/Kconfig.defconfig
+++ b/boards/x86/intel_ish/Kconfig.defconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if BOARD_INTEL_ISH_5_4_1 || BOARD_INTEL_ISH_5_6_0 || BOARD_INTEL_ISH_5_8_0
+
+config BOARD
+	default "intel_ish_5_4_1" if BOARD_INTEL_ISH_5_4_1
+	default "intel_ish_5_6_0" if BOARD_INTEL_ISH_5_6_0
+	default "intel_ish_5_8_0" if BOARD_INTEL_ISH_5_8_0
+
+if TEST
+config TEST_EXTRA_STACK_SIZE
+	int
+	default 1024
+endif # TEST
+
+config HPET_TIMER
+	default y
+
+config SYS_CLOCK_TICKS_PER_SEC
+	default 2048 if HPET_TIMER # HPET is 32768 HZ
+
+endif # BOARD_INTEL_ISH_5_4_1 || BOARD_INTEL_ISH_5_6_0 || BOARD_INTEL_ISH_5_8_0

--- a/boards/x86/intel_ish/doc/index.rst
+++ b/boards/x86/intel_ish/doc/index.rst
@@ -1,0 +1,78 @@
+.. _intel_ish:
+
+Intel Integrated Sensor Hub (ISH)
+#################################
+
+Overview
+********
+Intel Integrated Sensor Hub (ISH) is a lower-power/always-on co-processor
+inside many Intel Processors. It helps offload sensor processing tasks from
+the core processor for better power saving.
+
+Hardware
+********
+
+- LMT MinuteIA Core, with
+  . 16KB instruction cache and 16KB data cache.
+  . 640KB SRAM space for code and data - implemented as L2 SRAM.
+  . 8KB AON RF space for code resident during deep D0i2/3 PG states.
+- Interface-to-Sensor peripherals (I2C, SPI, UART, I3C, GPIO, DMA).
+- Inter Process Communications (IPC) to core processor and other IP processors.
+
+.. include:: ../../../../soc/x86/intel_ish/doc/supported_features.txt
+
+Programming and Debugging
+*************************
+Use the following procedures for booting an ISH image on a ADL RVP board
+for Chrome.
+
+.. contents::
+   :depth: 1
+   :local:
+   :backlinks: top
+
+Build Zephyr application
+========================
+
+#. Build a Zephyr application; for instance, to build the ``hello_world``
+   application for ISH 5.4.1 on Intel ADL Processor:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: intel_ish_5_4_1
+      :goals: build
+
+   .. note::
+
+      A Zephyr image file named :file:`ish_fw.bin` is automatically
+      created in the build directory after the application is built.
+
+Run ish_fw.bin on ADL RVP board for Chrome
+==========================================
+
+# Power on the ADL RVP board.
+
+# Log in Chrome OS. (Note: the user must have root access right.)
+
+# Re-mount the root filesystem as read-write:
+
+   .. code-block:: console
+
+   $ mount -o remount,rw /
+
+  If re-mount fails, execute below commands to Remove rootfs verification:
+
+   .. code-block:: console
+
+   $ /usr/share/vboot/bin/make_dev_ssd.sh --remove_rootfs_verification --partitions
+   $ reboot
+
+# Go to the ISH firmware direcoty:
+
+   .. code-block:: console
+
+   $ cd /lib/firmware/intel
+
+  Relace the file adlrvp_ish.bin with zephyr image built out, ish_fw.bin.
+
+# Reboot, then observe zephyr log output via ISH UART0.

--- a/boards/x86/intel_ish/intel_ish_5_4_1.dts
+++ b/boards/x86/intel_ish/intel_ish_5_4_1.dts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include "intel/intel_ish5.dtsi"
+
+/ {
+	model = "intel_ish_5_4_1";
+	compatible = "intel,ish_5_4_1";
+
+	chosen {
+		zephyr,sram = &sram;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+	};
+};

--- a/boards/x86/intel_ish/intel_ish_5_4_1.yaml
+++ b/boards/x86/intel_ish/intel_ish_5_4_1.yaml
@@ -1,0 +1,13 @@
+identifier: intel_ish_5_4_1
+name: Intel ISH 5.4.1 SoC
+type: mcu
+arch: x86
+toolchain:
+  - zephyr
+ram: 640
+supported:
+  - serial
+testing:
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/x86/intel_ish/intel_ish_5_4_1_defconfig
+++ b/boards/x86/intel_ish/intel_ish_5_4_1_defconfig
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SOC_FAMILY_INTEL_ISH=y
+CONFIG_SOC_SERIES_INTEL_ISH5=y
+CONFIG_SOC_INTEL_ISH_5_4_1=y
+CONFIG_BOARD_INTEL_ISH_5_4_1=y
+
+# uart & console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_SERIAL=y

--- a/boards/x86/intel_ish/intel_ish_5_6_0.dts
+++ b/boards/x86/intel_ish/intel_ish_5_6_0.dts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include "intel/intel_ish5.dtsi"
+
+/ {
+	model = "intel_ish_5_6_0";
+	compatible = "intel,ish_5_6_0";
+
+	chosen {
+		zephyr,sram = &sram;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+	};
+};

--- a/boards/x86/intel_ish/intel_ish_5_6_0.yaml
+++ b/boards/x86/intel_ish/intel_ish_5_6_0.yaml
@@ -1,0 +1,13 @@
+identifier: intel_ish_5_6_0
+name: Intel ISH 5.6.0 SoC
+type: mcu
+arch: x86
+toolchain:
+  - zephyr
+ram: 640
+supported:
+  - serial
+testing:
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/x86/intel_ish/intel_ish_5_6_0_defconfig
+++ b/boards/x86/intel_ish/intel_ish_5_6_0_defconfig
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SOC_FAMILY_INTEL_ISH=y
+CONFIG_SOC_SERIES_INTEL_ISH5=y
+CONFIG_SOC_INTEL_ISH_5_6_0=y
+CONFIG_BOARD_INTEL_ISH_5_6_0=y
+
+# uart & console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_SERIAL=y

--- a/boards/x86/intel_ish/intel_ish_5_8_0.dts
+++ b/boards/x86/intel_ish/intel_ish_5_8_0.dts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include "intel/intel_ish5_8.dtsi"
+
+/ {
+	model = "intel_ish_5_8_0";
+	compatible = "intel,ish_5_8_0";
+
+	chosen {
+		zephyr,sram = &sram;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+	};
+};

--- a/boards/x86/intel_ish/intel_ish_5_8_0.yaml
+++ b/boards/x86/intel_ish/intel_ish_5_8_0.yaml
@@ -1,0 +1,13 @@
+identifier: intel_ish_5_8_0
+name: Intel ISH 5.8.0 SoC
+type: mcu
+arch: x86
+toolchain:
+  - zephyr
+ram: 640
+supported:
+  - serial
+testing:
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/x86/intel_ish/intel_ish_5_8_0_defconfig
+++ b/boards/x86/intel_ish/intel_ish_5_8_0_defconfig
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SOC_FAMILY_INTEL_ISH=y
+CONFIG_SOC_SERIES_INTEL_ISH5=y
+CONFIG_SOC_INTEL_ISH_5_8_0=y
+CONFIG_BOARD_INTEL_ISH_5_8_0=y
+
+# uart & console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_SERIAL=y

--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -63,6 +63,7 @@ zephyr_library_sources_ifdef(CONFIG_UART_HOSTLINK uart_hostlink.c)
 zephyr_library_sources_ifdef(CONFIG_UART_EMUL uart_emul.c)
 zephyr_library_sources_ifdef(CONFIG_UART_NUMAKER uart_numaker.c)
 zephyr_library_sources_ifdef(CONFIG_UART_EFINIX_SAPPIHIRE uart_efinix_sapphire.c)
+zephyr_library_sources_ifdef(CONFIG_UART_SEDI uart_sedi.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   uart_handlers.c)
 

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -239,4 +239,6 @@ source "drivers/serial/Kconfig.numaker"
 
 source "drivers/serial/Kconfig.efinix_sapphire"
 
+source "drivers/serial/Kconfig.sedi"
+
 endif # SERIAL

--- a/drivers/serial/Kconfig.sedi
+++ b/drivers/serial/Kconfig.sedi
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config UART_SEDI
+	bool "Intel SEDI UART driver"
+	default y
+	depends on DT_HAS_INTEL_SEDI_UART_ENABLED
+	select SERIAL_HAS_DRIVER
+	select SERIAL_SUPPORT_INTERRUPT
+	help
+	  This option enables the Intel SEDI UART driver.
+	  This driver is simply a shim driver built upon the SEDI
+	  bare metal UART driver in the hal-intel module

--- a/drivers/serial/uart_sedi.c
+++ b/drivers/serial/uart_sedi.c
@@ -1,0 +1,597 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <errno.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/pm/device.h>
+#include "sedi_driver_uart.h"
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+static void uart_sedi_isr(void *arg);
+static void uart_sedi_cb(struct device *port);
+#endif
+
+#define DT_DRV_COMPAT intel_sedi_uart
+
+/* Helper macro to set flow control. */
+#define UART_CONFIG_FLOW_CTRL_SET(n) \
+	.hw_fc = DT_INST_PROP(n, hw_flow_control)
+
+/* Helper macro to set line control. */
+#define UART_CONFIG_LINE_CTRL_SET \
+	.line_ctrl = SEDI_UART_LC_8N1
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+/*  UART IRQ handler declaration.  */
+#define  UART_IRQ_HANDLER_DECL(n) \
+	static void irq_config_uart_##n(const struct device *dev)
+
+/* Setting configuration function. */
+#define UART_CONFIG_IRQ_HANDLER_SET(n) \
+	.uart_irq_config_func = irq_config_uart_##n
+#define UART_IRQ_HANDLER_DEFINE(n)				       \
+	static void irq_config_uart_##n(const struct device *dev)      \
+	{							       \
+		ARG_UNUSED(dev);				       \
+		IRQ_CONNECT(DT_INST_IRQN(n),			       \
+			    DT_INST_IRQ(n, priority), uart_sedi_isr,   \
+			    DEVICE_DT_GET(DT_NODELABEL(uart##n)),      \
+			    DT_INST_IRQ(n, sense));		       \
+		irq_enable(DT_INST_IRQN(n));			       \
+	}
+#else /*CONFIG_UART_INTERRUPT_DRIVEN */
+#define UART_IRQ_HANDLER_DECL(n)
+#define UART_CONFIG_IRQ_HANDLER_SET(n) (0)
+
+#define UART_IRQ_HANDLER_DEFINE(n)
+#endif  /* !CONFIG_UART_INTERRUPT_DRIVEN */
+
+/* Device init macro for UART instance. As multiple uart instances follow a
+ * similar definition of data structures differing only in the instance
+ * number.This macro makes adding instances simpler.
+ */
+#define UART_SEDI_DEVICE_INIT(n)				      \
+	UART_IRQ_HANDLER_DECL(n);				      \
+	static K_MUTEX_DEFINE(uart_##n##_mutex);		      \
+	static K_SEM_DEFINE(uart_##n##_tx_sem, 1, 1);		      \
+	static K_SEM_DEFINE(uart_##n##_rx_sem, 1, 1);		      \
+	static K_SEM_DEFINE(uart_##n##_sync_read_sem, 0, 1);	      \
+	static const struct uart_sedi_config_info config_info_##n = { \
+		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),		      \
+		.instance = SEDI_UART_##n,			      \
+		.baud_rate = DT_INST_PROP(n, current_speed),	      \
+		UART_CONFIG_FLOW_CTRL_SET(n),			      \
+		UART_CONFIG_LINE_CTRL_SET,			      \
+		.mutex = &uart_##n##_mutex,			      \
+		.tx_sem = &uart_##n##_tx_sem,			      \
+		.rx_sem = &uart_##n##_rx_sem,			      \
+		.sync_read_sem = &uart_##n##_sync_read_sem,	      \
+		UART_CONFIG_IRQ_HANDLER_SET(n)			      \
+	};							      \
+								      \
+	static struct uart_sedi_drv_data drv_data_##n;		      \
+	PM_DEVICE_DT_DEFINE(DT_NODELABEL(uart##n),                    \
+			    uart_sedi_pm_action);		      \
+	DEVICE_DT_DEFINE(DT_NODELABEL(uart##n),		              \
+		      &uart_sedi_init,				      \
+		      PM_DEVICE_DT_GET(DT_NODELABEL(uart##n)),        \
+		      &drv_data_##n, &config_info_##n,		      \
+		      PRE_KERNEL_1,				      \
+		      CONFIG_SERIAL_INIT_PRIORITY, &api);	      \
+	UART_IRQ_HANDLER_DEFINE(n)
+
+
+
+/* Convenient macro to get the controller instance. */
+#define GET_CONTROLLER_INSTANCE(dev)		 \
+	(((const struct uart_sedi_config_info *) \
+	  dev->config)->instance)
+
+/* Convenient macro to get tx semamphore */
+#define GET_TX_SEM(dev)				 \
+	(((const struct uart_sedi_config_info *) \
+	  dev->config)->tx_sem)
+
+
+/* Convenient macro to get rx sempahore */
+#define GET_RX_SEM(dev)				 \
+	(((const struct uart_sedi_config_info *) \
+	  dev->config)->rx_sem)
+
+/* Convenient macro to get sync_read sempahore */
+#define GET_SYNC_READ_SEM(dev)			 \
+	(((const struct uart_sedi_config_info *) \
+	  dev->config)->sync_read_sem)
+
+#define GET_MUTEX(dev)				 \
+	(((const struct uart_sedi_config_info *) \
+	  dev->config)->mutex)
+
+struct uart_sedi_config_info {
+	DEVICE_MMIO_ROM;
+	/* Specifies the uart instance for configuration. */
+	sedi_uart_t instance;
+
+	/* Specifies the baudrate for the uart instance. */
+	uint32_t baud_rate;
+
+	/* Specifies the port line contorl settings */
+	sedi_uart_lc_t line_ctrl;
+
+	struct k_mutex *mutex;
+	struct k_sem *tx_sem;
+	struct k_sem *rx_sem;
+	struct k_sem *sync_read_sem;
+	/* Enable / disable hardware flow control for UART. */
+
+	bool hw_fc;
+
+	/* UART irq configuration function when supporting interrupt
+	 * mode.
+	 */
+	uart_irq_config_func_t uart_irq_config_func;
+};
+
+
+static int uart_sedi_init(const struct device *dev);
+
+struct uart_sedi_drv_data {
+	DEVICE_MMIO_RAM;
+	uart_irq_callback_user_data_t user_cb;
+	void *unsol_rx_usr_cb_param;
+	uint32_t sync_rx_len;
+	uint32_t sync_rx_status;
+	void *user_data;
+	void *usr_rx_buff;
+	uint32_t usr_rx_size;
+	uint8_t iir_cache;
+	uint8_t busy_count;
+};
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+static void uart_busy_set(const struct device *dev)
+{
+
+	struct uart_sedi_drv_data *context = dev->data;
+
+	context->busy_count++;
+
+	if (context->busy_count == 1) {
+		pm_device_busy_set(dev);
+	}
+}
+
+static void uart_busy_clear(const struct device *dev)
+{
+
+	struct uart_sedi_drv_data *context = dev->data;
+
+	context->busy_count--;
+
+	if (context->busy_count == 0) {
+		pm_device_busy_clear(dev);
+	}
+}
+#endif
+
+#ifdef CONFIG_PM_DEVICE
+
+#ifndef CONFIG_UART_CONSOLE
+
+static int uart_suspend_device(const struct device *dev)
+{
+	const struct uart_sedi_config_info *config = dev->config;
+
+	if (pm_device_is_busy(dev)) {
+		return -EBUSY;
+	}
+
+	int ret = sedi_uart_set_power(config->instance, SEDI_POWER_SUSPEND);
+
+	if (ret != SEDI_DRIVER_OK) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int uart_resume_device_from_suspend(const struct device *dev)
+{
+	const struct uart_sedi_config_info *config = dev->config;
+	int ret;
+
+	ret = sedi_uart_set_power(config->instance, SEDI_POWER_FULL);
+	if (ret != SEDI_DRIVER_OK) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int uart_sedi_pm_action(const struct device *dev,
+		enum pm_device_action action)
+{
+	int ret = 0;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		ret = uart_suspend_device(dev);
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		ret = uart_resume_device_from_suspend(dev);
+		break;
+
+	default:
+		ret = -ENOTSUP;
+	}
+	return ret;
+}
+
+#else
+
+static int uart_sedi_pm_action(const struct device *dev,
+		enum pm_device_action action)
+{
+	/* do nothing if using UART print log to avoid clock gating
+	 * pm driver already handled power management for uart.
+	 */
+	return 0;
+}
+
+#endif /* CONFIG_UART_CONSOLE */
+
+#endif /* CONFIG_PM_DEVICE */
+
+static int uart_sedi_poll_in(const struct device *dev, unsigned char *data)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+	uint32_t status;
+	int ret = 0;
+
+	sedi_uart_get_status(instance, (uint32_t *) &status);
+
+	/* In order to check if there is any data to read from UART
+	 * controller we should check if the SEDI_UART_RX_BUSY bit from
+	 * 'status' is not set. This bit is set only if there is any
+	 * pending character to read.
+	 */
+	if (!(status & SEDI_UART_RX_BUSY)) {
+		ret = -1;
+	} else {
+		if (sedi_uart_read(instance, data, (uint32_t *)&status)) {
+			ret = -1;
+		}
+	}
+	return ret;
+}
+
+static void uart_sedi_poll_out(const struct device *dev,
+			       unsigned char data)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	sedi_uart_write(instance, data);
+}
+
+#ifdef CONFIG_UART_LINE_CTRL
+static int get_xfer_error(int bsp_err)
+{
+	int err;
+
+	switch (bsp_err) {
+	case SEDI_DRIVER_OK:
+		err = 0;
+		break;
+	case SEDI_USART_ERROR_CANCELED:
+		err = -ECANCELED;
+		break;
+	case SEDI_DRIVER_ERROR:
+		err = -EIO;
+		break;
+	case SEDI_DRIVER_ERROR_PARAMETER:
+		err = -EINVAL;
+		break;
+	case SEDI_DRIVER_ERROR_UNSUPPORTED:
+		err = -ENOTSUP;
+		break;
+	default:
+		err = -EFAULT;
+	}
+	return err;
+}
+#endif  /* CONFIG_UART_LINE_CTRL */
+
+static int uart_sedi_err_check(const struct device *dev)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+	uint32_t status;
+	int ret_status = 0;
+
+	sedi_uart_get_status(instance, (uint32_t *const)&status);
+	if (status &  SEDI_UART_RX_OE) {
+		ret_status = UART_ERROR_OVERRUN;
+	}
+
+	if (status & SEDI_UART_RX_PE) {
+		ret_status = UART_ERROR_PARITY;
+	}
+
+	if (status & SEDI_UART_RX_FE) {
+		ret_status = UART_ERROR_FRAMING;
+	}
+
+	if (status & SEDI_UART_RX_BI) {
+		ret_status = UART_BREAK;
+	}
+
+	return ret_status;
+}
+
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+
+static int uart_sedi_fifo_fill(const struct device *dev, const uint8_t *tx_data,
+			       int size)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	return sedi_uart_fifo_fill(instance, tx_data, size);
+}
+
+static int uart_sedi_fifo_read(const struct device *dev, uint8_t *rx_data,
+			       const int size)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	return sedi_uart_fifo_read(instance, rx_data, size);
+}
+
+static void uart_sedi_irq_tx_enable(const struct device *dev)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	sedi_uart_irq_tx_enable(instance);
+}
+
+static void uart_sedi_irq_tx_disable(const struct device *dev)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	sedi_uart_irq_tx_disable(instance);
+}
+
+static int uart_sedi_irq_tx_ready(const struct device *dev)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	return sedi_uart_irq_tx_ready(instance);
+}
+
+static int uart_sedi_irq_tx_complete(const struct device *dev)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	return sedi_uart_is_tx_complete(instance);
+}
+
+static void uart_sedi_irq_rx_enable(const struct device *dev)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	uart_busy_set(dev);
+	sedi_uart_irq_rx_enable(instance);
+}
+
+static void uart_sedi_irq_rx_disable(const struct device *dev)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	sedi_uart_irq_rx_disable(instance);
+	uart_busy_clear(dev);
+}
+
+static int uart_sedi_irq_rx_ready(const struct device *dev)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	return sedi_uart_is_irq_rx_ready(instance);
+}
+
+static void uart_sedi_irq_err_enable(const struct device *dev)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	sedi_uart_irq_err_enable(instance);
+}
+
+static void uart_sedi_irq_err_disable(const struct device *dev)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	sedi_uart_irq_err_disable(instance);
+}
+
+static int uart_sedi_irq_is_pending(const struct device *dev)
+{
+
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	return sedi_uart_is_irq_pending(instance);
+}
+
+static int uart_sedi_irq_update(const struct device *dev)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+
+	sedi_uart_update_irq_cache(instance);
+	return 1;
+}
+
+static void uart_sedi_irq_callback_set(const struct device *dev,
+				       uart_irq_callback_user_data_t cb,
+				       void *user_data)
+{
+	struct uart_sedi_drv_data *drv_data = dev->data;
+
+	drv_data->user_cb = cb;
+	drv_data->user_data = user_data;
+
+}
+
+static void uart_sedi_isr(void *arg)
+{
+	struct device *dev = arg;
+	struct uart_sedi_drv_data *drv_data = dev->data;
+
+	if (drv_data->user_cb) {
+		drv_data->user_cb(dev, drv_data->user_data);
+	} else {
+		uart_sedi_cb(dev);
+	}
+}
+
+/* Called from generic callback of zephyr , set by set_cb. */
+static void uart_sedi_cb(struct device *port)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(port);
+
+	sedi_uart_isr_handler(instance);
+}
+
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+
+#ifdef CONFIG_UART_LINE_CTRL
+static int uart_sedi_line_ctrl_set(struct device *dev,
+		uint32_t ctrl, uint32_t val)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+	sedi_uart_config_t cfg;
+	uint32_t mask;
+	int ret;
+
+	k_mutex_lock(GET_MUTEX(dev), K_FOREVER);
+	switch (ctrl) {
+	case UART_LINE_CTRL_BAUD_RATE:
+		sedi_uart_get_config(instance, &cfg);
+		cfg.baud_rate = val;
+		ret = sedi_uart_set_config(instance, &cfg);
+		break;
+
+	default:
+		ret = -ENODEV;
+	}
+	k_mutex_unlock(GET_MUTEX(dev));
+	ret = get_xfer_error(ret);
+	return ret;
+}
+
+static int uart_sedi_line_ctrl_get(struct device *dev,
+		uint32_t ctrl, uint32_t *val)
+{
+	sedi_uart_t instance = GET_CONTROLLER_INSTANCE(dev);
+	sedi_uart_config_t cfg;
+	uint32_t mask;
+	int ret;
+
+	k_mutex_lock(GET_MUTEX(dev), K_FOREVER);
+	switch (ctrl) {
+	case UART_LINE_CTRL_BAUD_RATE:
+		ret = sedi_uart_get_config(instance, &cfg);
+		*val = cfg.baud_rate;
+		break;
+
+	case UART_LINE_CTRL_LOOPBACK:
+		ret = sedi_uart_get_loopback_mode(instance, (uint32_t *)val);
+		break;
+
+	case UART_LINE_CTRL_AFCE:
+		ret = sedi_uart_get_config(instance, &cfg);
+		*val = cfg.hw_fc;
+		break;
+
+	case UART_LINE_CTRL_LINE_STATUS_REPORT_MASK:
+		mask = 0;
+		*val = 0;
+		ret = sedi_get_ln_status_report_mask(instance,
+						     (uint32_t *)&mask);
+		*val |= ((mask & SEDI_UART_RX_OE) ? UART_ERROR_OVERRUN : 0);
+		*val |= ((mask & SEDI_UART_RX_PE) ? UART_ERROR_PARITY : 0);
+		*val |= ((mask & SEDI_UART_RX_FE) ? UART_ERROR_FRAMING : 0);
+		*val |= ((mask & SEDI_UART_RX_BI) ? UART_BREAK : 0);
+		break;
+
+	case UART_LINE_CTRL_RTS:
+		ret = sedi_uart_read_rts(instance, (uint32_t *)val);
+		break;
+
+	case UART_LINE_CTRL_CTS:
+		ret = sedi_uart_read_cts(instance, (uint32_t *)val);
+		break;
+
+
+	default:
+		ret = -ENODEV;
+	}
+	k_mutex_unlock(GET_MUTEX(dev));
+	ret = get_xfer_error(ret);
+	return ret;
+}
+
+#endif /* CONFIG_UART_LINE_CTRL */
+
+static const struct uart_driver_api api = {
+	.poll_in = uart_sedi_poll_in,
+	.poll_out = uart_sedi_poll_out,
+	.err_check = uart_sedi_err_check,
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	.fifo_fill = uart_sedi_fifo_fill,
+	.fifo_read = uart_sedi_fifo_read,
+	.irq_tx_enable = uart_sedi_irq_tx_enable,
+	.irq_tx_disable = uart_sedi_irq_tx_disable,
+	.irq_tx_ready = uart_sedi_irq_tx_ready,
+	.irq_tx_complete = uart_sedi_irq_tx_complete,
+	.irq_rx_enable = uart_sedi_irq_rx_enable,
+	.irq_rx_disable = uart_sedi_irq_rx_disable,
+	.irq_rx_ready = uart_sedi_irq_rx_ready,
+	.irq_err_enable = uart_sedi_irq_err_enable,
+	.irq_err_disable = uart_sedi_irq_err_disable,
+	.irq_is_pending = uart_sedi_irq_is_pending,
+	.irq_update = uart_sedi_irq_update,
+	.irq_callback_set = uart_sedi_irq_callback_set,
+#endif  /* CONFIG_UART_INTERRUPT_DRIVEN */
+#ifdef CONFIG_UART_LINE_CTRL
+	.line_ctrl_set = uart_sedi_line_ctrl_set,
+	.line_ctrl_get = uart_sedi_line_ctrl_get,
+#endif  /* CONFIG_UART_LINE_CTRL */
+
+};
+
+static int uart_sedi_init(const struct device *dev)
+{
+
+	const struct uart_sedi_config_info *config = dev->config;
+	sedi_uart_config_t cfg;
+
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+	sedi_uart_init(config->instance, (void *)DEVICE_MMIO_GET(dev));
+
+	cfg.line_control = config->line_ctrl;
+	cfg.baud_rate = config->baud_rate;
+	cfg.hw_fc = config->hw_fc;
+
+	/* Setting to full power and enabling clk. */
+	sedi_uart_set_power(config->instance, SEDI_POWER_FULL);
+
+	sedi_uart_set_config(config->instance, &cfg);
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	config->uart_irq_config_func(dev);
+#endif  /* CONFIG_UART_INTERRUPT_DRIVEN */
+
+	return 0;
+}
+
+DT_INST_FOREACH_STATUS_OKAY(UART_SEDI_DEVICE_INIT)

--- a/dts/bindings/cpu/intel,ish.yaml
+++ b/dts/bindings/cpu/intel,ish.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: INTEL ISH CPU
+
+compatible: "intel,ish"
+
+include: cpu.yaml

--- a/dts/bindings/serial/intel,sedi-uart.yaml
+++ b/dts/bindings/serial/intel,sedi-uart.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: INTEL SEDI UART
+
+compatible: "intel,sedi-uart"
+
+include: uart-controller.yaml
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true

--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "skeleton.dtsi"
+#include <dt-bindings/interrupt-controller/intel-ioapic.h>
+#include <mem.h>
+
+/ {
+	chosen {
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu0@0 {
+			device_type = "cpu";
+			compatible = "intel,ish";
+			reg = <0>;
+		};
+	};
+
+	intc: ioapic@fec00000  {
+		compatible = "intel,ioapic";
+		reg = <0xfec00000 0x100000>;
+		interrupt-controller;
+		#interrupt-cells = <3>;
+	};
+
+	sram: memory@ff200000 {
+		device_type = "memory";
+		compatible = "mmio-sram";
+		reg = <0xff200000 DT_SIZE_K(640)>;
+	};
+
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "simple-bus";
+		ranges;
+
+		hpet: hpet@4700000{
+			compatible = "intel,hpet";
+			reg = <0x04700000 0x400>;
+			interrupt-parent = <&intc>;
+			interrupts = <14 IRQ_TYPE_FIXED_LEVEL_HIGH 2>;
+			status = "okay";
+		};
+
+		uart0: uart@8100000 {
+			compatible = "intel,sedi-uart";
+			reg = <0x08100000 0x1000>;
+			interrupt-parent = <&intc>;
+			interrupts = <23 IRQ_TYPE_LOWEST_EDGE_RISING 6>;
+			current-speed = <115200>;
+			status = "okay";
+		};
+	};
+};

--- a/dts/x86/intel/intel_ish5_8.dtsi
+++ b/dts/x86/intel/intel_ish5_8.dtsi
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <intel/intel_ish5.dtsi>
+
+&hpet {
+	interrupts = <17 IRQ_TYPE_FIXED_LEVEL_HIGH 2>;
+
+	status = "okay";
+};
+
+&uart0 {
+	interrupts = <28 IRQ_TYPE_LOWEST_EDGE_RISING 6>;
+
+	status = "okay";
+};

--- a/modules/Kconfig
+++ b/modules/Kconfig
@@ -45,6 +45,7 @@ source "modules/Kconfig.wurthelektronik"
 source "modules/Kconfig.xtensa"
 source "modules/zcbor/Kconfig"
 source "modules/Kconfig.mcuboot"
+source "modules/Kconfig.intel"
 
 comment "Unavailable modules, please install those via the project manifest."
 

--- a/modules/Kconfig.intel
+++ b/modules/Kconfig.intel
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config INTEL_HAL
+	bool
+	help
+	  Build the Intel HAL module during build process.
+	  This is selected by the ARCH kconfig automatically.

--- a/soc/x86/intel_ish/CMakeLists.txt
+++ b/soc/x86/intel_ish/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Intel ISH SoC family
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(${SOC_SERIES})

--- a/soc/x86/intel_ish/Kconfig
+++ b/soc/x86/intel_ish/Kconfig
@@ -1,0 +1,13 @@
+# Intel ISH family configuration options
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_FAMILY_INTEL_ISH
+	bool "Intel ISH SoC family"
+	select X86
+	select X86_NO_SPECULATIVE_VULNERABILITIES
+	select IOAPIC
+	select LOAPIC
+	select CPU_HAS_FPU

--- a/soc/x86/intel_ish/Kconfig
+++ b/soc/x86/intel_ish/Kconfig
@@ -11,3 +11,4 @@ config SOC_FAMILY_INTEL_ISH
 	select IOAPIC
 	select LOAPIC
 	select CPU_HAS_FPU
+	select INTEL_HAL

--- a/soc/x86/intel_ish/Kconfig.defconfig
+++ b/soc/x86/intel_ish/Kconfig.defconfig
@@ -1,0 +1,30 @@
+# Intel ISH family default configuration options
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_FAMILY_INTEL_ISH
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 32768 if HPET_TIMER
+
+config SOC_FAMILY
+	string
+	default "intel_ish"
+
+config X86_VERY_EARLY_CONSOLE
+	default n
+
+config SRAM_OFFSET
+	hex
+	default 0x0
+
+# Target platforms are not PC-compatible
+# (e.g. without BIOS, ACPI, CMOS, etc.).
+config X86_PC_COMPATIBLE
+	default n
+
+endif # SOC_FAMILY_INTEL_ISH
+
+rsource "*/Kconfig.defconfig.series"

--- a/soc/x86/intel_ish/Kconfig.soc
+++ b/soc/x86/intel_ish/Kconfig.soc
@@ -1,0 +1,8 @@
+# Intel ISH family selection
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+rsource "*/Kconfig.series"
+rsource "*/Kconfig.soc"

--- a/soc/x86/intel_ish/doc/supported_features.txt
+++ b/soc/x86/intel_ish/doc/supported_features.txt
@@ -1,0 +1,7 @@
+Supported Features
+==================
+
+In addition to the standard architecture devices (HPET, local and I/O APICs,
+etc.), Zephyr supports the following ISH-specific SoC devices:
+
+* HSUART

--- a/soc/x86/intel_ish/intel_ish5/CMakeLists.txt
+++ b/soc/x86/intel_ish/intel_ish5/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_cc_option(-march=pentium -mtune=i486)
+
+zephyr_sources(soc.c)
+
+include(../utils/build_ish_firmware.cmake)

--- a/soc/x86/intel_ish/intel_ish5/Kconfig.defconfig.series
+++ b/soc/x86/intel_ish/intel_ish5/Kconfig.defconfig.series
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if SOC_SERIES_INTEL_ISH5
+
+config SOC_SERIES
+	string
+	default "intel_ish5"
+
+config SOC
+	string
+	default "intel_ish_5_4_1" if SOC_INTEL_ISH_5_4_1
+	default "intel_ish_5_6_0" if SOC_INTEL_ISH_5_6_0
+	default "intel_ish_5_8_0" if SOC_INTEL_ISH_5_8_0
+
+endif # SOC_SERIES_INTEL_ISH5

--- a/soc/x86/intel_ish/intel_ish5/Kconfig.series
+++ b/soc/x86/intel_ish/intel_ish5/Kconfig.series
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config SOC_SERIES_INTEL_ISH5
+	bool "Intel ISH5 SoC"
+	select SOC_FAMILY_INTEL_ISH

--- a/soc/x86/intel_ish/intel_ish5/Kconfig.soc
+++ b/soc/x86/intel_ish/intel_ish5/Kconfig.soc
@@ -1,0 +1,19 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+choice
+	prompt "Intel ISH5 SoCs"
+	depends on SOC_SERIES_INTEL_ISH5
+
+config SOC_INTEL_ISH_5_4_1
+	bool "Intel ISH 5.4.1 SoC"
+
+config SOC_INTEL_ISH_5_6_0
+	bool "Intel ISH 5.6.0 SoC"
+
+config SOC_INTEL_ISH_5_8_0
+	bool "Intel ISH 5.8.0 SoC"
+
+endchoice

--- a/soc/x86/intel_ish/intel_ish5/linker.ld
+++ b/soc/x86/intel_ish/intel_ish5/linker.ld
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/x86/memory.ld>
+#include <zephyr/arch/x86/ia32/linker.ld>

--- a/soc/x86/intel_ish/intel_ish5/soc.c
+++ b/soc/x86/intel_ish/intel_ish5/soc.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+#include "soc.h"
+
+#if defined(CONFIG_HPET_TIMER)
+#include "sedi_driver_hpet.h"
+#endif
+
+static int intel_ish_init(void)
+{
+#if defined(CONFIG_HPET_TIMER)
+	sedi_hpet_set_min_delay(HPET_CMP_MIN_DELAY);
+#endif
+
+	return 0;
+}
+
+SYS_INIT(intel_ish_init, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/x86/intel_ish/intel_ish5/soc.h
+++ b/soc/x86/intel_ish/intel_ish5/soc.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __SOC_H_
+#define __SOC_H_
+
+#include <zephyr/sys/util.h>
+
+#ifndef _ASMLANGUAGE
+#include <zephyr/device.h>
+#include <zephyr/random/rand32.h>
+
+#ifdef CONFIG_HPET_TIMER
+#include "sedi_driver_hpet.h"
+
+#define HPET_USE_CUSTOM_REG_ACCESS_FUNCS
+
+/* COUNTER_CLK_PERIOD (CLK_PERIOD_REG) is in picoseconds (1e-12 sec) */
+#define HPET_COUNTER_CLK_PERIOD		(1000000000000ULL)
+
+#define HPET_CMP_MIN_DELAY		(5)
+
+__pinned_func
+static inline void hpet_timer_comparator_set(uint64_t next)
+{
+	sedi_hpet_set_comparator(HPET_0, next);
+}
+
+#endif  /*CONFIG_HPET_TIMER */
+
+#endif  /* !_ASMLANGUAGE */
+
+/* ISH specific DMA channel direction */
+#define IMR_TO_MEMORY (DMA_CHANNEL_DIRECTION_PRIV_START)
+#define MEMORY_TO_IMR (DMA_CHANNEL_DIRECTION_PRIV_START + 1)
+
+#endif /* __SOC_H_ */

--- a/soc/x86/intel_ish/utils/build_ish_firmware.cmake
+++ b/soc/x86/intel_ish/utils/build_ish_firmware.cmake
@@ -1,0 +1,10 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/build_ish_firmware.py
+  ARGS -k ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.bin
+  -o ${PROJECT_BINARY_DIR}/ish_fw.bin
+)

--- a/soc/x86/intel_ish/utils/build_ish_firmware.py
+++ b/soc/x86/intel_ish/utils/build_ish_firmware.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-"
+
+# Copyright 2019 The Chromium OS Authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Script to pack EC binary with manifest header.
+
+Package ecos main FW binary (kernel) and AON task binary into final EC binary
+image with a manifest header, ISH shim loader will parse this header and load
+each binaries into right memory location.
+"""
+
+import argparse
+import struct
+import os
+
+MANIFEST_ENTRY_SIZE = 0x80
+HEADER_SIZE = 0x1000
+PAGE_SIZE = 0x1000
+
+def parseargs():
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    parser.add_argument("-k", "--kernel",
+                        help="EC kernel binary to pack, \
+                        usually ec.RW.bin or ec.RW.flat.",
+                        required=True)
+    parser.add_argument("-a", "--aon",
+                        help="EC aontask binary to pack, \
+                        usually ish_aontask.bin.",
+                        required=False)
+    parser.add_argument("-o", "--output",
+                        help="Output flash binary file")
+
+    return parser.parse_args()
+
+def gen_manifest(ext_id, comp_app_name, code_offset, module_size):
+    """Returns a binary blob that represents a manifest entry"""
+    m = bytearray(MANIFEST_ENTRY_SIZE)
+
+    # 4 bytes of ASCII encode ID (little endian)
+    struct.pack_into('<4s', m, 0, ext_id)
+    # 8 bytes of ASCII encode ID (little endian)
+    struct.pack_into('<8s', m, 32, comp_app_name)
+    # 4 bytes of code offset (little endian)
+    struct.pack_into('<I', m, 96, code_offset)
+    # 2 bytes of module in page size increments (little endian)
+    struct.pack_into('<H', m, 100, module_size)
+
+    return m
+
+def roundup_page(size):
+    """Returns roundup-ed page size from size of bytes"""
+    return int(size / PAGE_SIZE) + (size % PAGE_SIZE > 0)
+
+def main():
+    args = parseargs()
+    print("    Packing EC image file for ISH")
+
+    with open(args.output, 'wb') as f:
+        kernel_size = os.path.getsize(args.kernel)
+
+        if args.aon is not None:
+            aon_size = os.path.getsize(args.aon)
+
+        print("      kernel binary size:", kernel_size)
+        kern_rdup_pg_size = roundup_page(kernel_size)
+        # Add manifest for main ISH binary
+        f.write(gen_manifest(b'ISHM', b'ISH_KERN', HEADER_SIZE, kern_rdup_pg_size))
+
+        if args.aon is not None:
+            print("      AON binary size:   ", aon_size)
+            aon_rdup_pg_size = roundup_page(aon_size)
+            # Add manifest for aontask binary
+            f.write(gen_manifest(b'ISHM', b'AON_TASK',
+                                 (HEADER_SIZE + kern_rdup_pg_size * PAGE_SIZE -
+                                  MANIFEST_ENTRY_SIZE), aon_rdup_pg_size))
+
+        # Add manifest that signals end of manifests
+        f.write(gen_manifest(b'ISHE', b'', 0, 0))
+
+        # Pad the remaining HEADER with 0s
+        if args.aon is not None:
+            f.write(b'\x00' * (HEADER_SIZE - (MANIFEST_ENTRY_SIZE * 3)))
+        else:
+            f.write(b'\x00' * (HEADER_SIZE - (MANIFEST_ENTRY_SIZE * 2)))
+
+        # Append original kernel image
+        with open(args.kernel, 'rb') as in_file:
+            f.write(in_file.read())
+            # Filling padings due to size round up as pages
+            f.write(b'\x00' * (kern_rdup_pg_size * PAGE_SIZE - kernel_size))
+
+            if args.aon is not None:
+                # Append original aon image
+                with open(args.aon, 'rb') as in_file:
+                    f.write(in_file.read())
+                # Filling padings due to size round up as pages
+                f.write(b'\x00' * (aon_rdup_pg_size * PAGE_SIZE - aon_size))
+
+if __name__ == '__main__':
+    main()

--- a/west.yml
+++ b/west.yml
@@ -167,6 +167,11 @@ manifest:
       path: modules/hal/infineon
       groups:
         - hal
+    - name: hal_intel
+      revision: 89a0db5d9155484624447d62a5211bcf6f6f0387
+      path: modules/hal/intel
+      groups:
+        - hal
     - name: hal_microchip
       revision: 5d079f1683a00b801373bbbbf5d181d4e33b30d5
       path: modules/hal/microchip


### PR DESCRIPTION
It adds Intel ISH SoCs and boards.
Add a new HAL module hal-intel, https://github.com/intel/hal-intel.
Add SEDI UART driver, which is a shim driver built upon bare metal SEDI UART driver in hal-intel.

Tests pass on three sample APPs:
- hello_world
- philosophers
- subsys/shell/shell_module
