### PR TITLE
smbus: doc: Fix smbus_dt_spec documentation

### DIFF
--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -288,12 +288,11 @@ struct smbus_callback {
 
 /**
  * @brief Complete SMBus DT information
- *
- * @param bus SMBus bus
- * @param addr Address of the SMBus peripheral device.
  */
 struct smbus_dt_spec {
+	/** SMBus bus */
 	const struct device *bus;
+	/** Address of the SMBus peripheral device */
 	uint16_t addr;
 };
 


### PR DESCRIPTION
Fixed Doxygen doc for smbus_dt_spec.