### PR TITLE
tests: coap_client: Zero-initialize address structures

### DIFF
--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -188,7 +188,7 @@ ZTEST_SUITE(coap_client, NULL, suite_setup, test_setup, NULL, NULL);
 ZTEST(coap_client, test_get_request)
 {
 	int ret = 0;
-	struct sockaddr address;
+	struct sockaddr address = {0};
 	struct coap_client_request client_request = {
 		.method = COAP_METHOD_GET,
 		.confirmable = true,
@@ -217,7 +217,7 @@ ZTEST(coap_client, test_get_request)
 ZTEST(coap_client, test_get_no_path)
 {
 	int ret = 0;
-	struct sockaddr address;
+	struct sockaddr address = {0};
 	struct coap_client_request client_request = {
 		.method = COAP_METHOD_GET,
 		.confirmable = true,
@@ -242,7 +242,7 @@ ZTEST(coap_client, test_get_no_path)
 ZTEST(coap_client, test_send_large_data)
 {
 	int ret = 0;
-	struct sockaddr address;
+	struct sockaddr address = {0};
 	struct coap_client_request client_request = {
 		.method = COAP_METHOD_GET,
 		.confirmable = true,
@@ -271,7 +271,7 @@ ZTEST(coap_client, test_send_large_data)
 ZTEST(coap_client, test_no_response)
 {
 	int ret = 0;
-	struct sockaddr address;
+	struct sockaddr address = {0};
 	struct coap_client_request client_request = {
 		.method = COAP_METHOD_GET,
 		.confirmable = true,
@@ -298,7 +298,7 @@ ZTEST(coap_client, test_no_response)
 ZTEST(coap_client, test_separate_response)
 {
 	int ret = 0;
-	struct sockaddr address;
+	struct sockaddr address = {0};
 	struct coap_client_request client_request = {
 		.method = COAP_METHOD_GET,
 		.confirmable = true,
@@ -332,7 +332,7 @@ ZTEST(coap_client, test_separate_response)
 ZTEST(coap_client, test_multiple_requests)
 {
 	int ret = 0;
-	struct sockaddr address;
+	struct sockaddr address = {0};
 	struct coap_client_request client_request = {
 		.method = COAP_METHOD_GET,
 		.confirmable = true,
@@ -368,7 +368,7 @@ ZTEST(coap_client, test_multiple_requests)
 ZTEST(coap_client, test_unmatching_tokens)
 {
 	int ret = 0;
-	struct sockaddr address;
+	struct sockaddr address = {0};
 	struct coap_client_request client_request = {
 		.method = COAP_METHOD_GET,
 		.confirmable = true,


### PR DESCRIPTION
Even though tests don't use the address, it causes warnings on static analyzers.