### PR TITLE
drivers: flash: stm32l4: Fix STM32L4Q5 support in flash driver

### DIFF
--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -20,7 +20,9 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 
 #include "flash_stm32.h"
 
-#if !defined (STM32L4R5xx) && !defined (STM32L4R7xx) && !defined (STM32L4R9xx) && !defined (STM32L4S5xx) && !defined (STM32L4S7xx) && !defined (STM32L4S9xx)
+#if !defined(STM32L4R5xx) && !defined(STM32L4R7xx) && !defined(STM32L4R9xx) && \
+	!defined(STM32L4S5xx) && !defined(STM32L4S7xx) && !defined(STM32L4S9xx) && \
+	!defined(STM32L4Q5xx)
 #define STM32L4X_PAGE_SHIFT	11
 #else
 #define STM32L4X_PAGE_SHIFT	12


### PR DESCRIPTION
Add STM32L4Q5xx to the list of MCUs that have 4kB flash pages, instead of 2kB.