### PR TITLE
usb: audio: correctly report internal delay

### DIFF
--- a/subsys/usb/device/class/audio/usb_audio_internal.h
+++ b/subsys/usb/device/class/audio/usb_audio_internal.h
@@ -473,7 +473,7 @@ struct dev##_descriptor_##i {						\
 	.bDescriptorType = USB_DESC_CS_INTERFACE,	\
 	.bDescriptorSubtype = USB_AUDIO_AS_GENERAL,	\
 	.bTerminalLink = link,				\
-	.bDelay = 0,					\
+	.bDelay = 1,					\
 	.wFormatTag = sys_cpu_to_le16(0x0001),		\
 }
 


### PR DESCRIPTION
Every USB device must buffer isochronous data for at least 1 frame in order to remove packet jitter within a frame. USB Specification Revision 2.0 describes necessary buffering in 5.12.5 Data Prebuffering. USB Audio 1.0 specification mentions buffering in 3.4 Inter Channel Synchronization.

Set bDelay to 1 instead of 0, because bDelay 1 is both the minimum allowed value and matches the actual device behavior.