### PR TITLE
drivers: ieee802154: nrf5: multiple CCA support for OT

### DIFF
--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -88,4 +88,10 @@ config IEEE802154_NRF5_LOG_RX_FAILURES
 	  It can be helpful for the network traffic analyze but it generates also
 	  a lot of log records in a stress environment.
 
+config IEEE802154_NRF5_MULTIPLE_CCA
+	bool "Support for multiple CCA attempts before transmission"
+	help
+	  When this option is enabled the OpenThread capability
+	  IEEE802154_OPENTHREAD_HW_MULTIPLE_CCA is supported by the ieee802154_nrf5.
+
 endif

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -88,15 +88,4 @@ config IEEE802154_NRF5_LOG_RX_FAILURES
 	  It can be helpful for the network traffic analyze but it generates also
 	  a lot of log records in a stress environment.
 
-config IEEE802154_NRF5_MULTIPLE_CCA
-	bool "Support for multiple CCA attempts before transmission"
-	help
-	  This is an optional extension not conforming to IEEE Std. 802.15.4-2015.
-	  When this option is enabled the user of ieee802154_nrf5 has possibility
-	  to express the maximum number of extra CCA attempts for a transmission.
-	  The CCA procedure is repeated back-to-back either until it returns
-	  idle channel and the transmission starts, or until 1 + `extra cca attempts`
-	  CCA attempts are performed. Because of that the moment of transmission can be
-	  delayed by the time taken by the extra CCA operations performed.
-
 endif

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -546,8 +546,7 @@ static uint64_t target_time_convert_to_64_bits(uint32_t target_time)
 	return result;
 }
 
-static bool nrf5_tx_at(struct nrf5_802154_data *nrf5_radio, struct net_pkt *pkt,
-		   uint8_t *payload, bool cca)
+static bool nrf5_tx_at(struct net_pkt *pkt, uint8_t *payload, bool cca)
 {
 	nrf_802154_transmit_at_metadata_t metadata = {
 		.frame_props = {
@@ -562,9 +561,6 @@ static bool nrf5_tx_at(struct nrf5_802154_data *nrf5_radio, struct net_pkt *pkt,
 			.power = net_pkt_ieee802154_txpwr(pkt),
 #endif
 		},
-#if defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA)
-		.extra_cca_attempts = nrf5_radio->extra_cca_attempts
-#endif
 	};
 	uint64_t tx_at = target_time_convert_to_64_bits(net_pkt_txtime(pkt) / NSEC_PER_USEC);
 
@@ -610,7 +606,7 @@ static int nrf5_tx(const struct device *dev,
 	case IEEE802154_TX_MODE_TXTIME:
 	case IEEE802154_TX_MODE_TXTIME_CCA:
 		__ASSERT_NO_MSG(pkt);
-		ret = nrf5_tx_at(nrf5_radio, pkt, nrf5_radio->tx_psdu,
+		ret = nrf5_tx_at(pkt, nrf5_radio->tx_psdu,
 				 mode == IEEE802154_TX_MODE_TXTIME_CCA);
 		break;
 #endif /* CONFIG_NET_PKT_TXTIME */
@@ -1165,22 +1161,6 @@ void nrf_802154_serialization_error(const nrf_802154_ser_err_data_t *err)
 	k_oops();
 }
 #endif
-
-#if defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA)
-void ieee802154_nrf5_extra_cca_attempts_set(const struct device *dev, uint8_t value)
-{
-	struct nrf5_802154_data *nrf5_radio = NRF5_802154_DATA(dev);
-
-	nrf5_radio->extra_cca_attempts = value;
-}
-
-uint8_t ieee802154_nrf5_extra_cca_attempts_get(const struct device *dev)
-{
-	struct nrf5_802154_data *nrf5_radio = NRF5_802154_DATA(dev);
-
-	return nrf5_radio->extra_cca_attempts;
-}
-#endif /* defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA) */
 
 static const struct nrf5_802154_config nrf5_radio_cfg = {
 	.irq_config_func = nrf5_irq_config,

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -87,39 +87,6 @@ struct nrf5_802154_data {
 
 	/* Indicates if currently processed TX frame has dynamic data updated. */
 	bool tx_frame_mac_hdr_rdy;
-
-#if defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA)
-	/* The maximum number of extra CCA attempts to be performed before transmission. */
-	uint8_t extra_cca_attempts;
-#endif
 };
-
-#if defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA)
-/**
- * @brief Sets the maximum number of extra CCA attempts to be performed by a transmit operation
- *
- * The default value of extra cca attempts is 0.
- *
- * The maximum number of extra cca attempts set by this function is applied to transmissions
- * requested with mode IEEE802154_TX_MODE_TXTIME_CCA only. This might change in the future, so
- * it is recommended to restore previously used value after each transmission. See
- * @ref ieee802154_nrf5_extra_cca_attempts_get.
- *
- * @param dev    Pointer to a ieee802154_nrf5 device
- * @param value  Value to set. Allowed range is 0...254.
- */
-void ieee802154_nrf5_extra_cca_attempts_set(const struct device *dev, uint8_t value);
-
-/**
- * @brief Gets the maximum number of extra CCA attempts to be performed by a transmit operation.
- *
- * @sa @ref ieee802154_nrf5_extra_cca_attempts_set
- *
- * @param dev    Pointer to a ieee802154_nrf5 device
- * @return       Maximum number of extra CCA attempts.
- */
-uint8_t ieee802154_nrf5_extra_cca_attempts_get(const struct device *dev);
-
-#endif /* defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA) */
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_NRF5_H_ */

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -1,7 +1,7 @@
 /* ieee802154_nrf5.h - nRF5 802.15.4 driver */
 
 /*
- * Copyright (c) 2017 Nordic Semiconductor ASA
+ * Copyright (c) 2017-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -87,6 +87,11 @@ struct nrf5_802154_data {
 
 	/* Indicates if currently processed TX frame has dynamic data updated. */
 	bool tx_frame_mac_hdr_rdy;
+
+#if defined(CONFIG_IEEE802154_NRF5_MULTIPLE_CCA)
+	/* The maximum number of extra CCA attempts to be performed before transmission. */
+	uint8_t max_extra_cca_attempts;
+#endif
 };
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_NRF5_H_ */

--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -115,7 +115,16 @@ enum ieee802154_hw_caps {
 	IEEE802154_HW_SUB_GHZ = BIT(13),       /* Sub-GHz radio supported
 						* TODO: Replace with channel page attribute.
 						*/
+	/* Note: Update also IEEE802154_HW_CAPS_BITS_COMMON_COUNT when changing
+	 * the ieee802154_hw_caps type.
+	 */
 };
+
+/** @brief Number of bits used by ieee802154_hw_caps type. */
+#define IEEE802154_HW_CAPS_BITS_COMMON_COUNT (14)
+
+/** @brief This and higher values are specific to the protocol- or driver-specific extensions. */
+#define IEEE802154_HW_CAPS_BITS_PRIV_START IEEE802154_HW_CAPS_BITS_COMMON_COUNT
 
 enum ieee802154_filter_type {
 	IEEE802154_FILTER_TYPE_IEEE_ADDR,
@@ -188,6 +197,12 @@ enum ieee802154_tx_mode {
 	 * Requires IEEE802154_HW_TXTIME capability.
 	 */
 	IEEE802154_TX_MODE_TXTIME_CCA,
+
+	/** Number of modes defined in ieee802154_tx_mode. */
+	IEEE802154_TX_MODE_COMMON_COUNT,
+
+	/** This and higher values are specific to the protocol- or driver-specific extensions. */
+	IEEE802154_TX_MODE_PRIV_START = IEEE802154_TX_MODE_COMMON_COUNT,
 };
 
 /** IEEE802.15.4 Frame Pending Bit table address matching mode. */
@@ -296,6 +311,12 @@ enum ieee802154_config_type {
 	 *  should disable it for all enabled addresses.
 	 */
 	IEEE802154_CONFIG_ENH_ACK_HEADER_IE,
+
+	/** Number of types defined in ieee802154_config_type. */
+	IEEE802154_CONFIG_COMMON_COUNT,
+
+	/** This and higher values are specific to the protocol- or driver-specific extensions. */
+	IEEE802154_CONFIG_PRIV_START = IEEE802154_CONFIG_COMMON_COUNT,
 };
 
 /** IEEE802.15.4 driver configuration data. */

--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -397,6 +397,23 @@ struct ieee802154_config {
 	};
 };
 
+/** IEEE 802.15.4 attributes. */
+enum ieee802154_attr {
+	/** Number of attributes defined in ieee802154_attr. */
+	IEEE802154_ATTR_COMMON_COUNT,
+
+	/** This and higher values are specific to the protocol- or driver-specific extensions. */
+	IEEE802154_ATTR_PRIV_START = IEEE802154_ATTR_COMMON_COUNT,
+};
+
+/** IEEE 802.15.4 attribute value data. */
+struct ieee802154_attr_value {
+	union {
+		/* TODO: Please remove when first attribute is added. */
+		uint8_t dummy;
+	};
+};
+
 /**
  * @brief IEEE 802.15.4 radio interface API.
  *
@@ -476,6 +493,15 @@ struct ieee802154_radio_api {
 	 *  Requires IEEE802154_HW_TXTIME and/or IEEE802154_HW_RXTIME capabilities.
 	 */
 	uint8_t (*get_sch_acc)(const struct device *dev);
+
+	/** Get the value of an attribute.
+	 *  If the requested attribute is supported by implementation, this function returns 0
+	 *  and fills appropriate version of union in `value`.
+	 *  If requested attribute is not supported, this function returns -ENOENT.
+	 */
+	int (*attr_get)(const struct device *dev,
+			enum ieee802154_attr attr,
+			struct ieee802154_attr_value *value);
 };
 
 /* Make sure that the network interface API is properly setup inside

--- a/include/zephyr/net/ieee802154_radio_openthread.h
+++ b/include/zephyr/net/ieee802154_radio_openthread.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief This file extends interface of ieee802154_radio.h for OpenThread.
+ */
+
+#ifndef ZEPHYR_INCLUDE_NET_IEEE802154_RADIO_OPENTHREAD_H_
+#define ZEPHYR_INCLUDE_NET_IEEE802154_RADIO_OPENTHREAD_H_
+
+#include <zephyr/net/ieee802154_radio.h>
+
+/**
+ *  OpenThread specific capabilities of ieee802154 driver.
+ *  This type extends @ref ieee802154_hw_caps.
+ */
+enum ieee802154_openthread_hw_caps {
+	/** Capability to transmit with @ref IEEE802154_OPENTHREAD_TX_MODE_TXTIME_MULTIPLE_CCA
+	 *  mode.
+	 */
+	IEEE802154_OPENTHREAD_HW_MULTIPLE_CCA = BIT(IEEE802154_HW_CAPS_BITS_PRIV_START),
+};
+
+enum ieee802154_openthread_tx_mode {
+	/**
+	 * The @ref IEEE802154_OPENTHREAD_TX_MODE_TXTIME_MULTIPLE_CCA mode allows to send
+	 * a scheduled packet if the channel is reported idle after at most
+	 * 1 + max_extra_cca_attempts CCAs performed back-to-back.
+	 *
+	 * This mode is a non-standard experimental OpenThread feature. It allows transmission
+	 * of a packet within a certain time window.
+	 * The earliest transmission time is specified as in the other TXTIME modes:
+	 * When the first CCA reports an idle channel then the first symbol of the packet's SHR
+	 * SHALL be present at the local antenna at the time represented by the scheduled
+	 * TX timestamp (referred to as T_tx below).
+	 *
+	 * If the first CCA reports a busy channel, then additional CCAs up to
+	 * max_extra_cca_attempts will be done until one of them reports an idle channel and
+	 * the packet is sent out or the max number of attempts is reached in which case
+	 * the transmission fails.
+	 *
+	 * The timing of these additional CCAs depends on the capabilities of the driver
+	 * which reports them in the T_recca and T_ccatx driver attributes
+	 * (see @ref IEEE802154_OPENTHREAD_ATTR_T_RECCA and
+	 * @ref IEEE802154_OPENTHREAD_ATTR_T_CCATX). Based on these attributes the upper layer
+	 * can calculate the latest point in time (T_txmax) that the first symbol of the scheduled
+	 * packet's SHR SHALL be present at the local antenna:
+	 *
+	 * T_maxtxdelay = max_extra_cca_attempts * (aCcaTime + T_recca) - T_recca + T_ccatx
+	 * T_txmax = T_tx + T_maxtxdelay
+	 *
+	 * See IEEE 802.15.4-2020, section 11.3, table 11-1 for the definition of aCcaTime.
+	 *
+	 * Drivers implementing this TX mode SHOULD keep T_recca and T_ccatx as short as possible.
+	 * T_ccatx SHALL be less than or equal aTurnaroundTime as defined in ibid.,
+	 * section 11.3, table 11-1.
+	 *
+	 * CCA SHALL be executed as defined by the phyCcaMode PHY PIB attribute (see ibid.,
+	 * section 11.3, table 11-2).
+	 *
+	 * Requires IEEE802154_OPENTHREAD_HW_MULTIPLE_CCA capability.
+	 */
+	IEEE802154_OPENTHREAD_TX_MODE_TXTIME_MULTIPLE_CCA = IEEE802154_TX_MODE_PRIV_START
+};
+
+/**
+ *  OpenThread specific configuration types of ieee802154 driver.
+ *  This type extends @ref ieee802154_config_type.
+ */
+enum ieee802154_openthread_config_type {
+	/** Allows to configure extra CCA for transmission requested with mode
+	 *  @ref IEEE802154_OPENTHREAD_TX_MODE_TXTIME_MULTIPLE_CCA.
+	 *  Requires IEEE802154_OPENTHREAD_HW_MULTIPLE_CCA capability.
+	 */
+	IEEE802154_OPENTHREAD_CONFIG_MAX_EXTRA_CCA_ATTEMPTS  = IEEE802154_CONFIG_PRIV_START
+};
+
+/** OpenThread specific configuration data of ieee802154 driver. */
+struct ieee802154_openthread_config {
+	union {
+		struct ieee802154_config common;
+
+		/** ``IEEE802154_OPENTHREAD_CONFIG_MAX_EXTRA_CCA_ATTEMPTS``
+		 *
+		 *  The maximum number of extra CCAs to be performed when transmission is
+		 *  requested with mode @ref IEEE802154_OPENTHREAD_TX_MODE_TXTIME_MULTIPLE_CCA.
+		 */
+		uint8_t max_extra_cca_attempts;
+	};
+};
+
+/**
+ *  OpenThread specific attributes of ieee802154 driver.
+ *  This type extends @ref ieee802154_attr
+ */
+enum ieee802154_openthread_attr {
+
+	/** Attribute: Maximum time between consecutive CCAs performed back-to-back.
+	 *
+	 *  This is attribute for T_recca parameter mentioned for
+	 *  @ref IEEE802154_OPENTHREAD_TX_MODE_TXTIME_MULTIPLE_CCA.
+	 *  Time is expressed in microseconds.
+	 */
+	IEEE802154_OPENTHREAD_ATTR_T_RECCA = IEEE802154_ATTR_PRIV_START,
+
+	/** Attribute: Maximum time between detection of CCA idle channel and the moment of
+	 *  start of SHR at the local antenna.
+	 *
+	 *  This is attribute for T_ccatx parameter mentioned for
+	 *  @ref IEEE802154_OPENTHREAD_TX_MODE_TXTIME_MULTIPLE_CCA.
+	 *  Time is expressed in microseconds.
+	 */
+	IEEE802154_OPENTHREAD_ATTR_T_CCATX
+};
+
+/**
+ *  OpenThread specific attribute value data of ieee802154 driver.
+ *  This type extends @ref ieee802154_attr_value
+ */
+struct ieee802154_openthread_attr_value {
+	union {
+		struct ieee802154_attr_value common;
+
+		/** @brief Attribute value for @ref IEEE802154_OPENTHREAD_ATTR_T_RECCA */
+		uint16_t t_recca;
+
+		/** @brief Attribute value for @ref IEEE802154_OPENTHREAD_ATTR_T_CCATX */
+		uint16_t t_ccatx;
+
+	};
+};
+
+#endif /* ZEPHYR_INCLUDE_NET_IEEE802154_RADIO_OPENTHREAD_H_ */

--- a/subsys/net/l2/ieee802154/ieee802154_utils.h
+++ b/subsys/net/l2/ieee802154/ieee802154_utils.h
@@ -106,6 +106,20 @@ static inline int ieee802154_radio_stop(struct net_if *iface)
 	return radio->stop(net_if_get_device(iface));
 }
 
+static inline int ieee802154_radio_attr_get(struct net_if *iface,
+					    enum ieee802154_attr attr,
+					    struct ieee802154_attr_value *value)
+{
+	const struct ieee802154_radio_api *radio =
+		net_if_get_device(iface)->api;
+
+	if (!radio || !radio->attr_get) {
+		return -ENOENT;
+	}
+
+	return radio->attr_get(net_if_get_device(iface), attr, value);
+}
+
 /**
  * Sets the radio drivers extended address filter.
  *


### PR DESCRIPTION
This PR is an alternative to https://github.com/zephyrproject-rtos/zephyr/pull/60343

It reverts changes made by https://github.com/zephyrproject-rtos/zephyr/pull/60390 (justification https://github.com/zephyrproject-rtos/zephyr/pull/60390#issuecomment-1636129759)

For nrf802154_radio.h extension points are added that allow to extend enums by higher layer.

OpenThread-specific capability "Multiple CCA" is added as a separate file, leveraging exposed extension points provided by nrf820154_radio.h

Implementation of the "Multiple CCA" capability is added to the ieee802154_nrf5 driver.