### PR TITLE
(coverity fix) drivers: input: add few missing gpio_add_callback return check

### DIFF
--- a/drivers/input/input_gpio_qdec.c
+++ b/drivers/input/input_gpio_qdec.c
@@ -204,7 +204,11 @@ static int gpio_qdec_init(const struct device *dev)
 			return ret;
 		}
 
-		gpio_add_callback_dt(gpio, &data->gpio_cb);
+		ret = gpio_add_callback_dt(gpio, &data->gpio_cb);
+		if (ret < 0) {
+			LOG_ERR("Could not set gpio callback");
+			return ret;
+		}
 	}
 
 	data->prev_step = gpio_qdec_get_step(dev);

--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -278,7 +278,11 @@ static int gt911_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_INPUT_GT911_INTERRUPT
-	gpio_add_callback(config->int_gpio.port, &data->int_gpio_cb);
+	r = gpio_add_callback(config->int_gpio.port, &data->int_gpio_cb);
+	if (r < 0) {
+		LOG_ERR("Could not set gpio callback");
+		return ret;
+	}
 #else
 	k_timer_start(&data->timer, K_MSEC(CONFIG_INPUT_GT911_PERIOD_MS),
 		      K_MSEC(CONFIG_INPUT_GT911_PERIOD_MS));

--- a/drivers/input/input_xpt2046.c
+++ b/drivers/input/input_xpt2046.c
@@ -125,6 +125,7 @@ static void xpt2046_work_handler(struct k_work *kw)
 {
 	struct xpt2046_data *data = CONTAINER_OF(kw, struct xpt2046_data, work);
 	struct xpt2046_config *config = (struct xpt2046_config *)data->dev->config;
+	int ret;
 
 	const struct spi_buf txb = {.buf = tbuf, .len = sizeof(tbuf)};
 	const struct spi_buf rxb = {.buf = data->rbuf, .len = sizeof(data->rbuf)};
@@ -180,7 +181,12 @@ static void xpt2046_work_handler(struct k_work *kw)
 		/* Ensure that we send released event */
 		k_work_reschedule(&data->dwork, K_MSEC(100));
 	}
-	gpio_add_callback(config->int_gpio.port, &data->int_gpio_cb);
+
+	ret = gpio_add_callback(config->int_gpio.port, &data->int_gpio_cb);
+	if (ret < 0) {
+		LOG_ERR("Could not set gpio callback");
+		return;
+	}
 }
 
 static int xpt2046_init(const struct device *dev)


### PR DESCRIPTION
Add few missing check on gpio_add_callback and gpio_add_callback_dt calls, fixes a coverity warning.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/60475