### PR TITLE
boards: arm: nucleo_l476rg: add storage partition

### DIFF
--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -179,3 +179,17 @@
 &vbat {
 	status = "okay";
 };
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 32KB of storage at the end of 1024KB flash */
+		storage_partition: partition@f8000 {
+			label = "storage";
+			reg = <0x000f8000 DT_SIZE_K(32)>;
+		};
+	};
+};


### PR DESCRIPTION
This is useful to build the tests/bluetooth/shell. Default size is 32kB