### PR TITLE
tests: lib: c_lib testcase running with 32KB min ram

### DIFF
--- a/tests/lib/c_lib/testcase.yaml
+++ b/tests/lib/c_lib/testcase.yaml
@@ -16,6 +16,7 @@ tests:
       - CONFIG_PICOLIBC=y
   libraries.libc.newlib:
     filter: CONFIG_NEWLIB_LIBC_SUPPORTED
+    min_ram: 32
     tags: newlib
     ignore_faults: true
     extra_configs:


### PR DESCRIPTION
Limit the testcase to targets with more than 32KB RAM Because of the CONFIG_NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE 8192, the RAM used by the testcase on a too small target might fail at runtime. For example on a nucleo_l073rz target:
    RAM:       15292 B        20 KB     74.67%

This will fix the error on nucleo_l073rz board running the /tests/lib/c_lib/libraries.libc.newlib
`ASSERTION FAIL [((((size_t)20) << 10) - (((uintptr_t) (&_end)) - 0x20000000)) >= 8192] @ WEST_TOPDIR/zephyr/lib/libc/newlib/libc-hooks.c:128                                                                                                    memory space available for newlib heap is less than the minimum required size specified by CONFIG_NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE`
