### PR TITLE
drivers: ieee802154_nrf5: Add payload length check on TX

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -150,7 +150,7 @@ static void nrf5_rx_thread(void *arg1, void *arg2, void *arg3)
 		if (IS_ENABLED(CONFIG_IEEE802154_NRF5_FCS_IN_LENGTH)) {
 			pkt_len = rx_frame->psdu[0];
 		} else {
-			pkt_len = rx_frame->psdu[0] -  NRF5_FCS_LENGTH;
+			pkt_len = rx_frame->psdu[0] -  IEEE802154_FCS_LENGTH;
 		}
 
 #if defined(CONFIG_NET_BUF_DATA_SIZE)
@@ -378,7 +378,7 @@ static int handle_ack(struct nrf5_802154_data *nrf5_radio)
 	if (IS_ENABLED(CONFIG_IEEE802154_NRF5_FCS_IN_LENGTH)) {
 		ack_len = nrf5_radio->ack_frame.psdu[0];
 	} else {
-		ack_len = nrf5_radio->ack_frame.psdu[0] - NRF5_FCS_LENGTH;
+		ack_len = nrf5_radio->ack_frame.psdu[0] - IEEE802154_FCS_LENGTH;
 	}
 
 	ack_pkt = net_pkt_rx_alloc_with_buffer(nrf5_radio->iface, ack_len,
@@ -582,14 +582,14 @@ static int nrf5_tx(const struct device *dev,
 	uint8_t *payload = frag->data;
 	bool ret = true;
 
-	if (payload_len > NRF5_PSDU_LENGTH) {
+	if (payload_len > IEEE802154_MTU) {
 		LOG_ERR("Payload too large: %d", payload_len);
 		return -EMSGSIZE;
 	}
 
 	LOG_DBG("%p (%u)", payload, payload_len);
 
-	nrf5_radio->tx_psdu[0] = payload_len + NRF5_FCS_LENGTH;
+	nrf5_radio->tx_psdu[0] = payload_len + IEEE802154_FCS_LENGTH;
 	memcpy(nrf5_radio->tx_psdu + 1, payload, payload_len);
 
 	/* Reset semaphore in case ACK was received after timeout */

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -582,6 +582,11 @@ static int nrf5_tx(const struct device *dev,
 	uint8_t *payload = frag->data;
 	bool ret = true;
 
+	if (payload_len > NRF5_PSDU_LENGTH) {
+		LOG_ERR("Payload too large: %d", payload_len);
+		return -EMSGSIZE;
+	}
+
 	LOG_DBG("%p (%u)", payload, payload_len);
 
 	nrf5_radio->tx_psdu[0] = payload_len + NRF5_FCS_LENGTH;

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -10,8 +10,6 @@
 
 #include <zephyr/net/ieee802154_radio.h>
 
-#define NRF5_FCS_LENGTH   (2)
-#define NRF5_PSDU_LENGTH  (125)
 #define NRF5_PHR_LENGTH   (1)
 
 struct nrf5_802154_rx_frame {
@@ -61,7 +59,7 @@ struct nrf5_802154_data {
 	/* TX buffer. First byte is PHR (length), remaining bytes are
 	 * MPDU data.
 	 */
-	uint8_t tx_psdu[NRF5_PHR_LENGTH + NRF5_PSDU_LENGTH + NRF5_FCS_LENGTH];
+	uint8_t tx_psdu[NRF5_PHR_LENGTH + IEEE802154_MAX_PHY_PACKET_SIZE];
 
 	/* TX result, updated in radio transmit callbacks. */
 	uint8_t tx_result;


### PR DESCRIPTION
In case upper layer does not follow the convention, and the net_pkt provided to the nRF 15.4 driver had a payload larger than the maximum payload size of an individual 15.4 frame, the driver would end up with buffer overflow.

Fix this by adding an extra payload_len check before attempting to copy the payload to the internal buffer.