### PR TITLE
doc: shell: Update docstring regarding dictionnary

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -530,7 +530,7 @@ static int UTIL_CAT(UTIL_CAT(cmd_dict_, UTIL_CAT(_handler, _)),		\
  * @param[in] _name	Name of the dictionary subcommand set
  * @param[in] _handler	Command handler common for all dictionary commands.
  *			@see shell_dict_cmd_handler
- * @param[in] ...	Dictionary pairs: (command_syntax, value). Value will be
+ * @param[in] ...	Dictionary triplets: (command_syntax, value, helper). Value will be
  *			passed to the _handler as user data.
  *
  * Example usage:


### PR DESCRIPTION
The dictionary is a triplet, update generated documentation accordingly.

Since zephyr 3.3, the argument passed to `SHELL_SUBCMD_DICT_SET_CREATE` is a triplet and not a pair as the documentation suggested.

This PR update the docstring or the `SHELL_SUBCMD_DICT_SET_CREATE` macro.