### PR TITLE
Bluetooth: Host: Check connection status before sending credits

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2653,7 +2653,12 @@ static void l2cap_chan_le_recv(struct bt_l2cap_le_chan *chan,
 		return;
 	}
 
-	l2cap_chan_send_credits(chan, 1);
+	/* Only attempt to send credits if the channel wasn't disconnected
+	 * in the recv() callback above
+	 */
+	if (bt_l2cap_chan_get_state(&chan->chan) == BT_L2CAP_CONNECTED) {
+		l2cap_chan_send_credits(chan, 1);
+	}
 }
 
 static void l2cap_chan_recv_queue(struct bt_l2cap_le_chan *chan,


### PR DESCRIPTION
This PR adds a check upon receiving a L2CAP PDU  to only send credits back if the L2CAP channel hasn't been disconnected. The `recv()` callback called from `l2cap_chan_le_recv()` can trigger a disconnect, which would cause an assert failure when attempting to send credits back.

This check is already carried out in the following place: https://github.com/zephyrproject-rtos/zephyr/blob/6719caf05e0fc43166a959fdefa5375789dc4320/subsys/bluetooth/host/l2cap.c#L2423