### PR TITLE
bluetooth: ead: Fixed EAD not showing up in documentation

### DIFF
--- a/include/zephyr/bluetooth/ead.h
+++ b/include/zephyr/bluetooth/ead.h
@@ -11,6 +11,13 @@
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
+/**
+ * @brief Encrypted Advertising Data (EAD)
+ * @defgroup bt_ead Encrypted Advertising Data (EAD)
+ * @ingroup bluetooth
+ * @{
+ */
+
 /** Randomizer size in bytes */
 #define BT_EAD_RANDOMIZER_SIZE 5
 /** Key size in bytes */
@@ -92,5 +99,9 @@ int bt_ead_encrypt(const uint8_t session_key[BT_EAD_KEY_SIZE], const uint8_t iv[
 int bt_ead_decrypt(const uint8_t session_key[BT_EAD_KEY_SIZE], const uint8_t iv[BT_EAD_IV_SIZE],
 		   const uint8_t *encrypted_payload, size_t encrypted_payload_size,
 		   uint8_t *payload);
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_EAD_H_ */

--- a/include/zephyr/bluetooth/ead.h
+++ b/include/zephyr/bluetooth/ead.h
@@ -5,6 +5,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_EAD_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_EAD_H_
+
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
@@ -89,3 +92,5 @@ int bt_ead_encrypt(const uint8_t session_key[BT_EAD_KEY_SIZE], const uint8_t iv[
 int bt_ead_decrypt(const uint8_t session_key[BT_EAD_KEY_SIZE], const uint8_t iv[BT_EAD_IV_SIZE],
 		   const uint8_t *encrypted_payload, size_t encrypted_payload_size,
 		   uint8_t *payload);
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_EAD_H_ */


### PR DESCRIPTION
ead.h was missing Doxygen `@brief` and `@ingroup` causing it to not be mounted in the documentation.
