### PR TITLE
RFC Proposal: Bluetooth: Host: Pass pointer to server in L2CAP accept() callback

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -453,6 +453,7 @@ struct bt_l2cap_server {
 	 *  authorization.
 	 *
 	 *  @param conn The connection that is requesting authorization
+	 *  @param server Pointer to the server structure this callback relates to
 	 *  @param chan Pointer to received the allocated channel
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
@@ -460,7 +461,8 @@ struct bt_l2cap_server {
 	 *  @return -EACCES if application did not authorize the connection.
 	 *  @return -EPERM if encryption key size is too short.
 	 */
-	int (*accept)(struct bt_conn *conn, struct bt_l2cap_chan **chan);
+	int (*accept)(struct bt_conn *conn, struct bt_l2cap_server *server,
+		      struct bt_l2cap_chan **chan);
 
 	sys_snode_t node;
 };

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3723,7 +3723,8 @@ int bt_eatt_reconfigure(struct bt_conn *conn, uint16_t mtu)
 #endif /* CONFIG_BT_TESTING */
 #endif /* CONFIG_BT_EATT */
 
-static int bt_eatt_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+static int bt_eatt_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+			  struct bt_l2cap_chan **chan)
 {
 	struct bt_att_chan *att_chan = att_get_fixed_chan(conn);
 	struct bt_att *att = att_chan->att;

--- a/subsys/bluetooth/host/avdtp.c
+++ b/subsys/bluetooth/host/avdtp.c
@@ -220,7 +220,8 @@ int bt_avdtp_disconnect(struct bt_avdtp *session)
 	return bt_l2cap_chan_disconnect(&session->br_chan.chan);
 }
 
-int bt_avdtp_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+int bt_avdtp_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+			  struct bt_l2cap_chan **chan)
 {
 	struct bt_avdtp *session = NULL;
 	int result;

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1047,7 +1047,7 @@ static uint16_t l2cap_chan_accept(struct bt_conn *conn,
 	/* Request server to accept the new connection and allocate the
 	 * channel.
 	 */
-	err = server->accept(conn, chan);
+	err = server->accept(conn, server, chan);
 	if (err < 0) {
 		return le_err_to_result(err);
 	}

--- a/subsys/bluetooth/host/l2cap_br.c
+++ b/subsys/bluetooth/host/l2cap_br.c
@@ -746,7 +746,7 @@ static void l2cap_br_conn_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 	 * channel. If no free channels available for PSM server reply with
 	 * proper result and quit since chan pointer is uninitialized then.
 	 */
-	if (server->accept(conn, &chan) < 0) {
+	if (server->accept(conn, server, &chan) < 0) {
 		result = BT_L2CAP_BR_ERR_NO_RESOURCES;
 		goto no_chan;
 	}

--- a/subsys/bluetooth/host/rfcomm.c
+++ b/subsys/bluetooth/host/rfcomm.c
@@ -1702,7 +1702,8 @@ int bt_rfcomm_dlc_disconnect(struct bt_rfcomm_dlc *dlc)
 	return rfcomm_dlc_close(dlc);
 }
 
-static int rfcomm_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+static int rfcomm_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+			 struct bt_l2cap_chan **chan)
 {
 	struct bt_rfcomm_session *session;
 

--- a/subsys/bluetooth/host/sdp.c
+++ b/subsys/bluetooth/host/sdp.c
@@ -1389,7 +1389,8 @@ static int bt_sdp_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
  *
  *  @return 0 for success, or relevant error code
  */
-static int bt_sdp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+static int bt_sdp_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+			 struct bt_l2cap_chan **chan)
 {
 	static const struct bt_l2cap_chan_ops ops = {
 		.connected = bt_sdp_connected,

--- a/subsys/bluetooth/services/ots/ots_l2cap.c
+++ b/subsys/bluetooth/services/ots/ots_l2cap.c
@@ -184,7 +184,8 @@ static struct bt_gatt_ots_l2cap *find_free_l2cap_ctx(void)
 	return NULL;
 }
 
-static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+			struct bt_l2cap_chan **chan)
 {
 	struct bt_gatt_ots_l2cap *l2cap_ctx;
 

--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -243,7 +243,8 @@ static struct bt_l2cap_br_chan l2cap_chan = {
 	.rx.mtu		= 48,
 };
 
-static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+			struct bt_l2cap_chan **chan)
 {
 	shell_print(ctx_shell, "Incoming BR/EDR conn %p", conn);
 

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -211,7 +211,8 @@ static int l2cap_accept_policy(struct bt_conn *conn)
 	return 0;
 }
 
-static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+			struct bt_l2cap_chan **chan)
 {
 	int err;
 

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -315,7 +315,8 @@ static struct net_if_api bt_if_api = {
 	.init = bt_iface_init,
 };
 
-static int ipsp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+static int ipsp_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+		       struct bt_l2cap_chan **chan)
 {
 	struct bt_if_conn *if_conn = NULL;
 	int i;

--- a/tests/bluetooth/l2cap/src/main.c
+++ b/tests/bluetooth/l2cap/src/main.c
@@ -14,7 +14,8 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/l2cap.h>
 
-static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+			struct bt_l2cap_chan **chan)
 {
 	return -ENOSYS;
 }

--- a/tests/bluetooth/tester/src/btp_l2cap.c
+++ b/tests/bluetooth/tester/src/btp_l2cap.c
@@ -425,7 +425,8 @@ static bool is_free_psm(uint16_t psm)
 	return true;
 }
 
-static int accept(struct bt_conn *conn, struct bt_l2cap_chan **l2cap_chan)
+static int accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+		  struct bt_l2cap_chan **l2cap_chan)
 {
 	struct channel *chan;
 

--- a/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
@@ -135,7 +135,8 @@ static struct bt_l2cap_chan_ops ops = {
 	.sent = sent_cb,
 };
 
-int server_accept_cb(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+int server_accept_cb(struct bt_conn *conn, struct bt_l2cap_server *server,
+		     struct bt_l2cap_chan **chan)
 {
 	struct bt_l2cap_le_chan *le_chan = &test_ctx.le_chan;
 

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
@@ -141,7 +141,8 @@ static struct bt_l2cap_chan_ops ops = {
 	.sent = sent_cb,
 };
 
-int server_accept_cb(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+int server_accept_cb(struct bt_conn *conn, struct bt_l2cap_server *server,
+		     struct bt_l2cap_chan **chan)
 {
 	struct bt_l2cap_le_chan *le_chan = &test_ctx.le_chan;
 

--- a/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
+++ b/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
@@ -247,7 +247,8 @@ static void disconnect_all_channels(void)
 	}
 }
 
-static int accept(struct bt_conn *conn, struct bt_l2cap_chan **l2cap_chan)
+static int accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+		  struct bt_l2cap_chan **l2cap_chan)
 {
 	struct channel *chan;
 

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
@@ -75,7 +75,8 @@ static const struct bt_l2cap_chan_ops l2cap_ops = {
 
 static struct bt_l2cap_le_chan channel;
 
-static int accept(struct bt_conn *conn, struct bt_l2cap_chan **l2cap_chan)
+static int accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+		  struct bt_l2cap_chan **l2cap_chan)
 {
 	channel.chan.ops = &l2cap_ops;
 	*l2cap_chan = &channel.chan;

--- a/tests/bsim/bluetooth/host/l2cap/split/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/split/dut/src/main.c
@@ -89,7 +89,8 @@ static struct bt_l2cap_chan_ops ops = {
 	.sent = sent_cb,
 };
 
-int server_accept_cb(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+int server_accept_cb(struct bt_conn *conn, struct bt_l2cap_server *server,
+		     struct bt_l2cap_chan **chan)
 {
 	struct bt_l2cap_le_chan *le_chan = &test_chan;
 

--- a/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
@@ -205,7 +205,8 @@ struct test_ctx *alloc_test_context(void)
 	return NULL;
 }
 
-int server_accept_cb(struct bt_conn *conn, struct bt_l2cap_chan **chan)
+int server_accept_cb(struct bt_conn *conn, struct bt_l2cap_server *server,
+		     struct bt_l2cap_chan **chan)
 {
 	struct test_ctx *ctx = NULL;
 

--- a/tests/bsim/bluetooth/host/l2cap/userdata/src/main_l2cap_userdata.c
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/src/main_l2cap_userdata.c
@@ -48,7 +48,8 @@ static const struct bt_l2cap_chan_ops l2cap_ops = {
 
 static struct bt_l2cap_le_chan channel;
 
-static int accept(struct bt_conn *conn, struct bt_l2cap_chan **l2cap_chan)
+static int accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+		  struct bt_l2cap_chan **l2cap_chan)
 {
 	channel.chan.ops = &l2cap_ops;
 	*l2cap_chan = &channel.chan;


### PR DESCRIPTION
RFC Proposal: https://github.com/zephyrproject-rtos/zephyr/issues/58402.

This PR amends the existing L2CAP server accept() callback to pass the relevant `struct bt_l2cap_server*` as an argument. This allows writing modules which manage multiple servers/PSMs at runtime, as the shared `accept()` callback can now recover which specific server/PSM the connection request refers to.

Resolves: https://github.com/zephyrproject-rtos/zephyr/issues/58402