### PR TITLE
net: wifi_shell: Add user input validation for SSID and PSK

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -135,7 +135,9 @@ static inline const char *wifi_band_txt(enum wifi_frequency_bands band)
 }
 
 #define WIFI_SSID_MAX_LEN 32
+#define WIFI_PSK_MIN_LEN 8
 #define WIFI_PSK_MAX_LEN 64
+#define WIFI_SAE_PSWD_MAX_LEN 128
 #define WIFI_MAC_ADDR_LEN 6
 
 #define WIFI_CHANNEL_MAX 233

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -333,6 +333,9 @@ static int __wifi_args_to_params(size_t argc, char *argv[],
 	/* SSID */
 	params->ssid = argv[0];
 	params->ssid_length = strlen(params->ssid);
+	if (params->ssid_length > WIFI_SSID_MAX_LEN) {
+		return -EINVAL;
+	}
 
 	/* Channel (optional) */
 	if ((idx < argc) && (strlen(argv[idx]) <= 3)) {
@@ -377,6 +380,14 @@ static int __wifi_args_to_params(size_t argc, char *argv[],
 				}
 				idx++;
 			}
+		}
+
+		if (params->psk_length < WIFI_PSK_MIN_LEN ||
+		    (params->security != WIFI_SECURITY_TYPE_SAE &&
+		     params->psk_length > WIFI_PSK_MAX_LEN) ||
+		    (params->security == WIFI_SECURITY_TYPE_SAE &&
+		     params->psk_length > WIFI_SAE_PSWD_MAX_LEN)) {
+			return -EINVAL;
 		}
 	} else {
 		params->security = WIFI_SECURITY_TYPE_NONE;


### PR DESCRIPTION
When parsing user input for "wifi connect" and "wifi ap enable" commands, the SSID and PSK lengths were not verified. It's better to detect invalid connect/AP enable parameters early, so that help text can be printed, instead of letting wifi_mgmt command to fail.