### PR TITLE
app_memdomain: doc: Properly mount documentation page

### DIFF
--- a/include/zephyr/app_memory/app_memdomain.h
+++ b/include/zephyr/app_memory/app_memdomain.h
@@ -10,6 +10,13 @@
 #include <zephyr/sys/dlist.h>
 #include <zephyr/kernel.h>
 
+/**
+ * @brief Application memory domain APIs
+ * @defgroup mem_domain_apis_app Application memory domain APIs
+ * @ingroup mem_domain_apis
+ * @{
+ */
+
 #ifdef CONFIG_USERSPACE
 
 /**
@@ -142,4 +149,9 @@ struct z_app_region {
 #define K_APPMEM_PARTITION_DEFINE(name)
 
 #endif /* CONFIG_USERSPACE */
+
+/**
+ * @}
+ */
+
 #endif /* ZEPHYR_INCLUDE_APP_MEMORY_APP_MEMDOMAIN_H_ */


### PR DESCRIPTION
Properly mount App memory domain APIs into Doxygen doc hierarchy.