### PR TITLE
pcie: host: guard include of ACPICA header file

### DIFF
--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -14,7 +14,10 @@ LOG_MODULE_REGISTER(pcie, LOG_LEVEL_ERR);
 #include <stdbool.h>
 #include <zephyr/drivers/pcie/pcie.h>
 #include <zephyr/sys/iterable_sections.h>
+
+#ifdef CONFIG_ACPI
 #include <zephyr/acpi/acpi.h>
+#endif
 
 #if CONFIG_PCIE_MSI
 #include <zephyr/drivers/pcie/msi.h>
@@ -287,11 +290,11 @@ unsigned int pcie_alloc_irq(pcie_bdf_t bdf)
 	    irq >= CONFIG_MAX_IRQ_LINES ||
 	    arch_irq_is_used(irq)) {
 
-		if (IS_ENABLED(CONFIG_ACPI)) {
-			irq = acpi_legacy_irq_get(bdf);
-		} else {
-			irq = arch_irq_allocate();
-		}
+#ifdef CONFIG_ACPI
+		irq = acpi_legacy_irq_get(bdf);
+#else
+		irq = arch_irq_allocate();
+#endif
 
 		if (irq == UINT_MAX) {
 			return PCIE_CONF_INTR_IRQ_NONE;


### PR DESCRIPTION
This puts a ifdef guard around the inclusion of ACPICA header file. The ACPICA module is not active unless CONFIG_ACPI is also enabled so we should not be using that header without CONFIG_ACPI also being enabled.

This was discovered by Coverity.

Fixes #60484