### PR TITLE
tests: kernel: spinlock: retry test if trylock does not fail

### DIFF
--- a/tests/kernel/spinlock/Kconfig
+++ b/tests/kernel/spinlock/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2023 Meta
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config TEST_TRYLOCK_RETRIES
+	int "Max number of retries to ensure contention"
+	default 10
+	help
+	  The k_spin_trylock() function will return an error code in the case that the lock is owned
+	  by another thread and generally speaking, that is a type of resource contention. For this
+	  particular test, we actually do want to see trylock fail, because that is of course a code
+	  path that needs to be tested.
+
+	  This option will retry the test up to CONFIG_TEST_TRYLOCK_RETRIES times if a failure is
+	  not seen in an attempt to elicit the desired code path.

--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -206,18 +206,20 @@ void trylock_fn(void *p1, void *p2, void *p3)
 ZTEST(spinlock, test_trylock)
 {
 	int i;
+	int j;
 
-	k_thread_create(&cpu1_thread, cpu1_stack, CPU1_STACK_SIZE,
-			trylock_fn, NULL, NULL, NULL,
-			0, 0, K_NO_WAIT);
+	for (j = 0; trylock_failures == 0 && j < CONFIG_TEST_TRYLOCK_RETRIES; j++) {
+		k_thread_create(&cpu1_thread, cpu1_stack, CPU1_STACK_SIZE, trylock_fn, NULL, NULL,
+				NULL, 0, 0, K_NO_WAIT);
 
-	k_busy_wait(10);
+		k_busy_wait(10);
 
-	for (i = 0; i < 10000; i++) {
-		bounce_once(1234, true);
+		for (i = 0; i < 10000; i++) {
+			bounce_once(1234, true);
+		}
+
+		bounce_done = 1;
 	}
-
-	bounce_done = 1;
 
 	zassert_true(trylock_failures > 0);
 	zassert_true(trylock_successes > 0);


### PR DESCRIPTION
The original test was a bit naive in assuming that there would always be some contention for a spinlock, but that does not always need to be the case, even on SMP systems.

Repeat the test up to `CONFIG_TEST_TRYLOCK_RETRIES` times (default of 10) to ensure that we can demonstrate when `k_spin_trylock()` fails.

Fixes #60330