### PR TITLE
MAINTAINERS: remove cfriedt as GPIO collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -938,7 +938,6 @@ Release Notes:
   status: odd fixes
   collaborators:
     - henrikbrixandersen
-    - cfriedt
     - mnkp
   files:
     - doc/hardware/peripherals/gpio.rst


### PR DESCRIPTION
Unfortunately, I need to reclaim a bit more bandwidth.