### PR TITLE
MAINTAINERS: add cfriedt as kernel collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1610,6 +1610,7 @@ Kernel:
     - ceolin
     - dcpleung
     - peter-mitsis
+    - cfriedt
   files:
     - doc/kernel/
     - include/zephyr/kernel*.h


### PR DESCRIPTION
I sometimes do kernel-y things too.