### PR TITLE
assert: check format arguments for correctness

### DIFF
--- a/include/zephyr/sys/__assert.h
+++ b/include/zephyr/sys/__assert.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /* Wrapper around printk to avoid including printk.h in assert.h */
-void assert_print(const char *fmt, ...);
+void __printf_like(1, 2) assert_print(const char *fmt, ...);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This instructs the compiler to check that arguments to `__ASSERT`/`__ASSERT_NO_MSG` are valid for printf.