### PR TITLE
net: gptp: fix follow_up timestamp and announce byte order

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -860,7 +860,7 @@ static int eth_rx(struct eth_context *context)
 			ptpTimeData.second--;
 		}
 
-		pkt->timestamp.nanosecond = ptpTimeData.nanosecond;
+		pkt->timestamp.nanosecond = ts;
 		pkt->timestamp.second = ptpTimeData.second;
 	} else {
 		/* Invalid value. */

--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -61,13 +61,6 @@ static void gptp_md_follow_up_prepare(struct net_pkt *pkt,
 
 	hdr->log_msg_interval = sync_send->log_msg_interval;
 
-	fup->prec_orig_ts_secs_high =
-		htons(sync_send->precise_orig_ts._sec.high);
-	fup->prec_orig_ts_secs_low =
-		htonl(sync_send->precise_orig_ts._sec.low);
-	fup->prec_orig_ts_nsecs =
-		htonl(sync_send->precise_orig_ts.nanosecond);
-
 	fup->tlv_hdr.type = htons(GPTP_TLV_ORGANIZATION_EXT);
 	fup->tlv_hdr.len = htons(sizeof(struct gptp_follow_up_tlv));
 	fup->tlv.org_id[0] = GPTP_FUP_TLV_ORG_ID_BYTE_0;

--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -38,22 +38,6 @@ static void gptp_md_follow_up_prepare(struct net_pkt *pkt,
 	hdr = GPTP_HDR(pkt);
 	fup = GPTP_FOLLOW_UP(pkt);
 
-	/*
-	 * Compute correction field according to IEEE802.1AS 11.2.14.2.3.
-	 *
-	 * The correction_field already contains the timestamp of the sync
-	 * message.
-	 *
-	 * TODO: if the value to be stored in correction_field is too big to
-	 * be represented, the field should be set to all 1's except the most
-	 * significant bit.
-	 */
-	hdr->correction_field -= sync_send->upstream_tx_time;
-	hdr->correction_field *= sync_send->rate_ratio;
-	hdr->correction_field += sync_send->follow_up_correction_field;
-	hdr->correction_field <<= 16;
-	hdr->correction_field = htonll(hdr->correction_field);
-
 	memcpy(&hdr->port_id.clk_id, &sync_send->src_port_id.clk_id,
 	       GPTP_CLOCK_ID_LEN);
 

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -271,8 +271,11 @@ struct net_pkt *gptp_prepare_follow_up(int port, struct net_pkt *sync)
 	hdr->ptp_version = GPTP_VERSION;
 	hdr->sequence_id = sync_hdr->sequence_id;
 	hdr->domain_number = 0U;
-	/* Store timestamp value in correction field. */
-	hdr->correction_field = gptp_timestamp_to_nsec(&sync->timestamp);
+	/*
+	 * Grand master clock should keep correction_field at zero,
+	 * according to IEEE802.1AS Table 11-6 and 10.6.2.2.9
+	 */
+	hdr->correction_field = 0LL;
 	hdr->flags.octets[0] = 0U;
 	hdr->flags.octets[1] = GPTP_FLAG_PTP_TIMESCALE;
 	hdr->message_length = htons(sizeof(struct gptp_hdr) +

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -535,7 +535,7 @@ struct net_pkt *gptp_prepare_announce(int port)
 	hdr->reserved1 = 0U;
 	hdr->reserved2 = 0U;
 
-	ann->cur_utc_offset = global_ds->current_utc_offset;
+	ann->cur_utc_offset = htons(global_ds->current_utc_offset);
 	ann->time_source = global_ds->time_source;
 
 	switch (GPTP_PORT_BMCA_DATA(port)->info_is) {
@@ -543,9 +543,11 @@ struct net_pkt *gptp_prepare_announce(int port)
 		ann->root_system_id.grand_master_prio1 = default_ds->priority1;
 		ann->root_system_id.grand_master_prio2 = default_ds->priority2;
 
-		memcpy(&ann->root_system_id.clk_quality,
-		       &default_ds->clk_quality,
-		       sizeof(struct gptp_clock_quality));
+		ann->root_system_id.clk_quality.clock_accuracy =
+			default_ds->clk_quality.clock_accuracy;
+		ann->root_system_id.clk_quality.clock_class = default_ds->clk_quality.clock_class;
+		ann->root_system_id.clk_quality.offset_scaled_log_var =
+			htons(default_ds->clk_quality.offset_scaled_log_var);
 
 		memcpy(&ann->root_system_id.grand_master_id,
 		       default_ds->clk_id,


### PR DESCRIPTION
This PR include gPTP accuracy optimize and some byte order fix.

1. Change follow_up message preciseOriginTimestamp from software trigger to hardware egress capture
2. Fix announce message `cur_utc_offset` and `offset_scaled_log_var` fields byte order.

Using mimxrt1050-evk board and Intel i210 ethernet card direct cable connect, host using linuxptp stack,
and test PPS phase between 1588_EVENT2_OUT and SDP1 by oscilloscope.

Before:
mimxrt1050-evk as grandmaster, i210 as slave, PPS offset is 3.5ms
i210 as grandmaster, mimxrt1050-evk as slave, PPS offset is 20-30us

After:
mimxrt1050-evk as grandmaster, i210 as slave, PPS offset is 540-580ns
i210 as grandmaster, mimxrt1050-evk as slave, PPS offset is 1250-1380ns