### PR TITLE
Kconfig: Provide name to orphan configuration choice symbol

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -56,7 +56,7 @@ menu "Build and Link Features"
 
 menu "Linker Options"
 
-choice
+choice LINKER_ORPHAN_CONFIGURATION
 	prompt "Linker Orphan Section Handling"
 	default LINKER_ORPHAN_SECTION_WARN
 


### PR DESCRIPTION
Kconfig choice section for LINKER_ORPHAN configuration has no name. This prevents configuring a default value in .defconfig files and constrain to set in _defconfig /.prj files.
Then it is not possible to generalize this setting to a whole set of boards (soc series for instance) or make it dependent on another symbol. Provide it a name to add this flexibility.