### PR TITLE
lib: posix: mutex: to_posix_mutex should be spinlocked

### DIFF
--- a/lib/posix/mutex.c
+++ b/lib/posix/mutex.c
@@ -106,15 +106,17 @@ static int acquire_mutex(pthread_mutex_t *mu, k_timeout_t timeout)
 	struct k_mutex *m;
 	k_spinlock_key_t key;
 
+	key = k_spin_lock(&pthread_mutex_spinlock);
+
 	m = to_posix_mutex(mu);
 	if (m == NULL) {
+		k_spin_unlock(&pthread_mutex_spinlock, key);
 		return EINVAL;
 	}
 
 	bit = posix_mutex_to_offset(m);
 	type = posix_mutex_type[bit];
 
-	key = k_spin_lock(&pthread_mutex_spinlock);
 	if (m->owner == k_current_get()) {
 		switch (type) {
 		case PTHREAD_MUTEX_NORMAL:


### PR DESCRIPTION
to_posix_mutex allocates a mutex which will race to change the value of the lock, thus to_posix_mutex should be performed under the spinlock to prevent the racy issue.

Fixes #60613