### PR TITLE
pm: partially align power states with Linux idle-states

### DIFF
--- a/boards/arm/b_g474e_dpow1/b_g474e_dpow1.dts
+++ b/boards/arm/b_g474e_dpow1/b_g474e_dpow1.dts
@@ -65,7 +65,7 @@
 
 	cpus {
 		cpu@0 {
-			cpu-power-states = <&stop0 &stop1>;
+			cpu-idle-states = <&stop0 &stop1>;
 		};
 	};
 

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -72,7 +72,7 @@
 };
 
 &cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
+	cpu-idle-states = <&stop0 &stop1 &stop2>;
 };
 
 &lptim1 {

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -72,7 +72,7 @@
 };
 
 &cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
+	cpu-idle-states = <&stop0 &stop1 &stop2>;
 };
 
 &clk_lsi {

--- a/boards/arm/efr32_thunderboard/thunderboard.dtsi
+++ b/boards/arm/efr32_thunderboard/thunderboard.dtsi
@@ -65,7 +65,7 @@
 	/* Enable EM1,2. This means BURTC has to be used as sys_clock
 	 * or the system won't wake up
 	 */
-	cpu-power-states = <&pstate_em1 &pstate_em2>;
+	cpu-idle-states = <&pstate_em1 &pstate_em2>;
 };
 
 &usart0 {

--- a/boards/arm/nucleo_g070rb/nucleo_g070rb.dts
+++ b/boards/arm/nucleo_g070rb/nucleo_g070rb.dts
@@ -159,7 +159,7 @@
 };
 
 &cpu0 {
-	cpu-power-states = <&stop0 &stop1>;
+	cpu-idle-states = <&stop0 &stop1>;
 };
 
 &vref {

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -167,7 +167,7 @@
 };
 
 &cpu0 {
-	cpu-power-states = <&stop0 &stop1>;
+	cpu-idle-states = <&stop0 &stop1>;
 };
 
 &lptim1 {

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -210,7 +210,7 @@ zephyr_udc0: &usb {
 };
 
 &cpu0 {
-	cpu-power-states = <&stop0 &stop1>;
+	cpu-idle-states = <&stop0 &stop1>;
 };
 
 &lptim1 {

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -47,7 +47,7 @@
 
 	cpus {
 		cpu@0 {
-			cpu-power-states = <&stop0 &stop1>;
+			cpu-idle-states = <&stop0 &stop1>;
 		};
 	};
 

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -74,7 +74,7 @@
 };
 
 &cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
+	cpu-idle-states = <&stop0 &stop1 &stop2>;
 };
 
 &lptim1 {

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -104,7 +104,7 @@
 };
 
 &cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
+	cpu-idle-states = <&stop0 &stop1 &stop2>;
 };
 
 &usart1 {

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -67,7 +67,7 @@
 };
 
 &cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
+	cpu-idle-states = <&stop0 &stop1 &stop2>;
 };
 
 &clk_lsi {

--- a/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
+++ b/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
@@ -44,7 +44,7 @@
 };
 
 &cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
+	cpu-idle-states = <&stop0 &stop1 &stop2>;
 };
 
 &lptim1 {

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -38,7 +38,7 @@
 };
 
 &cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
+	cpu-idle-states = <&stop0 &stop1 &stop2>;
 };
 
 &clk_hsi48 {

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -140,7 +140,7 @@
 
 &cpu0 {
 	clock-frequency = <120000000>;
-	cpu-power-states = <&idle &stop>;
+	cpu-idle-states = <&idle &stop>;
 };
 
 &idle {

--- a/doc/services/pm/system.rst
+++ b/doc/services/pm/system.rst
@@ -54,14 +54,14 @@ power state the system should transition to based on states defined by the
 platform and other constraints such as a list of allowed states.
 
 More details on the states definition can be found in the
-:dtcompatible:`zephyr,power-state` binding documentation.
+:dtcompatible:`zephyr,idle-state` binding documentation.
 
 Residency
 ---------
 
 The power management system enters the power state which offers the highest
 power savings, and with a minimum residency value (see
-:dtcompatible:`zephyr,power-state`) less than or equal to the scheduled system
+:dtcompatible:`zephyr,idle-state`) less than or equal to the scheduled system
 idle time duration.
 
 This policy also accounts for the time necessary to become active

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -25,13 +25,13 @@
 
 		idle-states {
 			idle: idle {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				min-residency-us = <1000000>;
 			};
 
 			suspend_to_ram: suspend_to_ram {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-ram";
 				min-residency-us = <2000000>;
 			};

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -23,7 +23,7 @@
 			cpu-idle-states = <&idle &suspend_to_ram>;
 		};
 
-		power-states {
+		idle-states {
 			idle: idle {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -26,13 +26,13 @@
 		idle-states {
 			idle: idle {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				min-residency-us = <1000000>;
 			};
 
 			suspend_to_ram: suspend_to_ram {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-ram";
+				idle-state-name = "suspend-to-ram";
 				min-residency-us = <2000000>;
 			};
 		};

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -20,7 +20,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
-			cpu-power-states = <&idle &suspend_to_ram>;
+			cpu-idle-states = <&idle &suspend_to_ram>;
 		};
 
 		power-states {

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -31,13 +31,13 @@
 
 		idle-states {
 			idle: idle {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				min-residency-us = <1000000>;
 			};
 
 			suspend_to_ram: suspend_to_ram {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-ram";
 				min-residency-us = <2000000>;
 			};

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -32,13 +32,13 @@
 		idle-states {
 			idle: idle {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				min-residency-us = <1000000>;
 			};
 
 			suspend_to_ram: suspend_to_ram {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-ram";
+				idle-state-name = "suspend-to-ram";
 				min-residency-us = <2000000>;
 			};
 		};

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -26,7 +26,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
-			cpu-power-states = <&idle &suspend_to_ram>;
+			cpu-idle-states = <&idle &suspend_to_ram>;
 		};
 
 		power-states {

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -29,7 +29,7 @@
 			cpu-idle-states = <&idle &suspend_to_ram>;
 		};
 
-		power-states {
+		idle-states {
 			idle: idle {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/dts/arm/nuvoton/npcx/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx.dtsi
@@ -29,7 +29,7 @@
 			cpu-idle-states = <&suspend_to_idle0 &suspend_to_idle1>;
 		};
 
-		power-states {
+		idle-states {
 			suspend_to_idle0: suspend-to-idle0 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/dts/arm/nuvoton/npcx/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx.dtsi
@@ -31,14 +31,14 @@
 
 		idle-states {
 			suspend_to_idle0: suspend-to-idle0 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <0>;
 				min-residency-us = <1000>;
 			};
 
 			suspend_to_idle1: suspend-to-idle1 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <1>;
 				min-residency-us = <201000>;

--- a/dts/arm/nuvoton/npcx/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx.dtsi
@@ -33,14 +33,14 @@
 			suspend_to_idle0: suspend-to-idle0 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <0>;
+				zephyr,substate-id = <0>;
 				min-residency-us = <1000>;
 			};
 
 			suspend_to_idle1: suspend-to-idle1 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <1>;
+				zephyr,substate-id = <1>;
 				min-residency-us = <201000>;
 			};
 		};

--- a/dts/arm/nuvoton/npcx/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx.dtsi
@@ -26,7 +26,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
-			cpu-power-states = <&suspend_to_idle0 &suspend_to_idle1>;
+			cpu-idle-states = <&suspend_to_idle0 &suspend_to_idle1>;
 		};
 
 		power-states {

--- a/dts/arm/nuvoton/npcx/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx.dtsi
@@ -32,14 +32,14 @@
 		idle-states {
 			suspend_to_idle0: suspend-to-idle0 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <0>;
 				min-residency-us = <1000>;
 			};
 
 			suspend_to_idle1: suspend-to-idle1 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <1>;
 				min-residency-us = <201000>;
 			};

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -30,7 +30,7 @@
 			reg = <0>;
 		};
 
-		power-states {
+		idle-states {
 			idle: idle {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -39,19 +39,19 @@
 			stop: stop {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <0>;
+				zephyr,substate-id = <0>;
 			};
 
 			pstop1: pstop1 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <1>;
+				zephyr,substate-id = <1>;
 			};
 
 			pstop2: pstop2 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <2>;
+				zephyr,substate-id = <2>;
 			};
 		};
 	};

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -33,24 +33,24 @@
 		idle-states {
 			idle: idle {
 				compatible = "zephyr,power-state";
-				power-state-name = "runtime-idle";
+				idle-state-name = "runtime-idle";
 			};
 
 			stop: stop {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <0>;
 			};
 
 			pstop1: pstop1 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <1>;
 			};
 
 			pstop2: pstop2 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <2>;
 			};
 		};

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -32,24 +32,24 @@
 
 		idle-states {
 			idle: idle {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "runtime-idle";
 			};
 
 			stop: stop {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <0>;
 			};
 
 			pstop1: pstop1 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <1>;
 			};
 
 			pstop2: pstop2 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <2>;
 			};

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -45,13 +45,13 @@
 
 		idle-states {
 			idle: idle {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "runtime-idle";
 				exit-latency-us = <4000>;
 				min-residency-us = <5000>;
 			};
 			suspend: suspend {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				exit-latency-us = <5000>;
 				min-residency-us = <10000>;

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -43,7 +43,7 @@
 			};
 		};
 
-		power-states {
+		idle-states {
 			idle: idle {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -26,7 +26,7 @@
 			compatible = "arm,cortex-m7";
 			d-cache-line-size = <32>;
 			reg = <0>;
-			cpu-power-states = <&idle &suspend>;
+			cpu-idle-states = <&idle &suspend>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -46,13 +46,13 @@
 		idle-states {
 			idle: idle {
 				compatible = "zephyr,power-state";
-				power-state-name = "runtime-idle";
+				idle-state-name = "runtime-idle";
 				exit-latency-us = <4000>;
 				min-residency-us = <5000>;
 			};
 			suspend: suspend {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				exit-latency-us = <5000>;
 				min-residency-us = <10000>;
 			};

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -66,7 +66,7 @@
 			 */
 			idle: set_point_1_wait {
 				/* idle corresponds to set point 1 (wait) for RT1170 */
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name="runtime-idle";
 				zephyr,substate-id = <IMX_SPC_SET_POINT_1_WAIT>;
 				min-residency-us = <100>;
@@ -74,7 +74,7 @@
 
 			suspend: set_point_10_suspend {
 				/*  suspend corresponds to set point 10 for RT1170 */
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name="suspend-to-idle";
 				zephyr,substate-id = <IMX_SPC_SET_POINT_10_SUSPEND>;
 				min-residency-us = <5000>;

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -67,7 +67,7 @@
 			idle: set_point_1_wait {
 				/* idle corresponds to set point 1 (wait) for RT1170 */
 				compatible = "zephyr,power-state";
-				power-state-name="runtime-idle";
+				idle-state-name="runtime-idle";
 				substate-id = <IMX_SPC_SET_POINT_1_WAIT>;
 				min-residency-us = <100>;
 			};
@@ -75,7 +75,7 @@
 			suspend: set_point_10_suspend {
 				/*  suspend corresponds to set point 10 for RT1170 */
 				compatible = "zephyr,power-state";
-				power-state-name="suspend-to-idle";
+				idle-state-name="suspend-to-idle";
 				substate-id = <IMX_SPC_SET_POINT_10_SUSPEND>;
 				min-residency-us = <5000>;
 				exit-latency-us = <500>;

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -68,7 +68,7 @@
 				/* idle corresponds to set point 1 (wait) for RT1170 */
 				compatible = "zephyr,power-state";
 				idle-state-name="runtime-idle";
-				substate-id = <IMX_SPC_SET_POINT_1_WAIT>;
+				zephyr,substate-id = <IMX_SPC_SET_POINT_1_WAIT>;
 				min-residency-us = <100>;
 			};
 
@@ -76,7 +76,7 @@
 				/*  suspend corresponds to set point 10 for RT1170 */
 				compatible = "zephyr,power-state";
 				idle-state-name="suspend-to-idle";
-				substate-id = <IMX_SPC_SET_POINT_10_SUSPEND>;
+				zephyr,substate-id = <IMX_SPC_SET_POINT_10_SUSPEND>;
 				min-residency-us = <5000>;
 				exit-latency-us = <500>;
 			};

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -53,7 +53,7 @@
 			};
 		};
 
-		power-states {
+		idle-states {
 			/*
 			 * Power states are managed with set points (see page 30-35 of RT1170
 			 * datasheet). These set points correspond to various power

--- a/dts/arm/nxp/nxp_rt11xx_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx_cm4.dtsi
@@ -178,7 +178,7 @@
 
 /* Set default power states for CM4 cpu */
 &cpu1 {
-	cpu-power-states = <&idle &suspend>;
+	cpu-idle-states = <&idle &suspend>;
 };
 
 

--- a/dts/arm/nxp/nxp_rt11xx_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx_cm7.dtsi
@@ -197,7 +197,7 @@
 
 /* Set default power states for CM7 cpu */
 &cpu0 {
-	cpu-power-states = <&idle &suspend>;
+	cpu-idle-states = <&idle &suspend>;
 };
 
 

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -40,14 +40,14 @@
 			/* This is the setting Sleep Mode */
 			idle: idle {
 				compatible = "zephyr,power-state";
-				power-state-name = "runtime-idle";
+				idle-state-name = "runtime-idle";
 				min-residency-us = <0>;
 				exit-latency-us = <0>;
 			};
 			/* This is the setting for Deep-sleep Mode */
 			suspend: suspend {
 				compatible = "nxp,pdcfg-power", "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				min-residency-us = <500>;
 				exit-latency-us = <120>;
 				/*

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -36,7 +36,7 @@
 			};
 		};
 
-		power-states {
+		idle-states {
 			/* This is the setting Sleep Mode */
 			idle: idle {
 				compatible = "zephyr,power-state";

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -27,7 +27,7 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			cpu-power-states = <&idle &suspend>;
+			cpu-idle-states = <&idle &suspend>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -39,14 +39,14 @@
 		idle-states {
 			/* This is the setting Sleep Mode */
 			idle: idle {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "runtime-idle";
 				min-residency-us = <0>;
 				exit-latency-us = <0>;
 			};
 			/* This is the setting for Deep-sleep Mode */
 			suspend: suspend {
-				compatible = "nxp,pdcfg-power", "zephyr,power-state";
+				compatible = "nxp,pdcfg-power", "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				min-residency-us = <500>;
 				exit-latency-us = <120>;

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -36,12 +36,12 @@
 
 		idle-states {
 			idle: idle {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "runtime-idle";
 				min-residency-us = <10>;
 			};
 			suspend: suspend {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				min-residency-us = <1000>;
 			};

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -37,12 +37,12 @@
 		idle-states {
 			idle: idle {
 				compatible = "zephyr,power-state";
-				power-state-name = "runtime-idle";
+				idle-state-name = "runtime-idle";
 				min-residency-us = <10>;
 			};
 			suspend: suspend {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				min-residency-us = <1000>;
 			};
 		};

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -34,7 +34,7 @@
 			};
 		};
 
-		power-states {
+		idle-states {
 			idle: idle {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -23,7 +23,7 @@
 		cpu0: cpu@0 {
 			compatible = "arm,cortex-m33f";
 			reg = <0>;
-			cpu-power-states = <&idle &suspend>;
+			cpu-idle-states = <&idle &suspend>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -36,7 +36,7 @@
 			 * has implications on system performance. Read
 			 * KConfig documentation entry before enabling it.
 			 */
-			cpu-power-states = <&pstate_em1>;
+			cpu-idle-states = <&pstate_em1>;
 		};
 
 		power-states {

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -46,7 +46,7 @@
 			 */
 			pstate_em1: em1 {
 				compatible = "zephyr,power-state";
-				power-state-name = "runtime-idle";
+				idle-state-name = "runtime-idle";
 				min-residency-us = <4>;
 				/* HFXO remains active */
 				exit-latency-us = <2>;
@@ -58,7 +58,7 @@
 			 */
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				min-residency-us = <260>;
 				exit-latency-us = <250>;
 			};
@@ -71,7 +71,7 @@
 			 */
 			pstate_em3: em3 {
 				compatible = "zephyr,power-state";
-				power-state-name = "standby";
+				idle-state-name = "standby";
 				min-residency-us = <20000>;
 				exit-latency-us = <2000>;
 			};
@@ -84,7 +84,7 @@
 			 */
 			pstate_em4: em4 {
 				compatible = "zephyr,power-state";
-				power-state-name = "soft-off";
+				idle-state-name = "soft-off";
 				min-residency-us = <100000>;
 				exit-latency-us = <80000>;
 			};

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -39,7 +39,7 @@
 			cpu-idle-states = <&pstate_em1>;
 		};
 
-		power-states {
+		idle-states {
 			/*
 			 * EM1 is a basic "CPU WFI idle", all high-freq clocks remain
 			 * enabled.

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -45,7 +45,7 @@
 			 * enabled.
 			 */
 			pstate_em1: em1 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "runtime-idle";
 				min-residency-us = <4>;
 				/* HFXO remains active */
@@ -57,7 +57,7 @@
 			 * scaled down, etc.
 			 */
 			pstate_em2: em2 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				min-residency-us = <260>;
 				exit-latency-us = <250>;
@@ -70,7 +70,7 @@
 			 * wake up.
 			 */
 			pstate_em3: em3 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "standby";
 				min-residency-us = <20000>;
 				exit-latency-us = <2000>;
@@ -83,7 +83,7 @@
 			 * by the application in BURTC registers.
 			 */
 			pstate_em4: em4 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "soft-off";
 				min-residency-us = <100000>;
 				exit-latency-us = <80000>;

--- a/dts/arm/silabs/efr32mg24.dtsi
+++ b/dts/arm/silabs/efr32mg24.dtsi
@@ -25,7 +25,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&state0>;
+			cpu-idle-states = <&state0>;
 		};
 
 		power-states {

--- a/dts/arm/silabs/efr32mg24.dtsi
+++ b/dts/arm/silabs/efr32mg24.dtsi
@@ -28,7 +28,7 @@
 			cpu-idle-states = <&state0>;
 		};
 
-		power-states {
+		idle-states {
 			state0: state0 {
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";

--- a/dts/arm/silabs/efr32mg24.dtsi
+++ b/dts/arm/silabs/efr32mg24.dtsi
@@ -30,7 +30,7 @@
 
 		idle-states {
 			state0: state0 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "standby";
 				min-residency-us = <50000>;
 				exit-latency-us = <0>;

--- a/dts/arm/silabs/efr32mg24.dtsi
+++ b/dts/arm/silabs/efr32mg24.dtsi
@@ -31,7 +31,7 @@
 		idle-states {
 			state0: state0 {
 				compatible = "zephyr,power-state";
-				power-state-name = "standby";
+				idle-state-name = "standby";
 				min-residency-us = <50000>;
 				exit-latency-us = <0>;
 			};

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -38,13 +38,13 @@
 		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <1>;
 				min-residency-us = <20>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <2>;
 				min-residency-us = <100>;
 			};

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -35,7 +35,7 @@
 			reg = <0>;
 		};
 
-		power-states {
+		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -37,13 +37,13 @@
 
 		idle-states {
 			stop0: state0 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <1>;
 				min-residency-us = <20>;
 			};
 			stop1: state1 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <2>;
 				min-residency-us = <100>;

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -39,13 +39,13 @@
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <1>;
+				zephyr,substate-id = <1>;
 				min-residency-us = <20>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <2>;
+				zephyr,substate-id = <2>;
 				min-residency-us = <100>;
 			};
 		};

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -38,13 +38,13 @@
 			stop0: state0 {
 					compatible = "zephyr,power-state";
 					idle-state-name = "suspend-to-idle";
-					substate-id = <1>;
+					zephyr,substate-id = <1>;
 					min-residency-us = <20>;
 				};
 			stop1: state1 {
 					compatible = "zephyr,power-state";
 					idle-state-name = "suspend-to-idle";
-					substate-id = <2>;
+					zephyr,substate-id = <2>;
 					min-residency-us = <100>;
 				};
 		};

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -34,7 +34,7 @@
 			reg = <0>;
 		};
 
-		power-states {
+		idle-states {
 			stop0: state0 {
 					compatible = "zephyr,power-state";
 					power-state-name = "suspend-to-idle";

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -36,13 +36,13 @@
 
 		idle-states {
 			stop0: state0 {
-					compatible = "zephyr,power-state";
+					compatible = "zephyr,idle-state";
 					idle-state-name = "suspend-to-idle";
 					zephyr,substate-id = <1>;
 					min-residency-us = <20>;
 				};
 			stop1: state1 {
-					compatible = "zephyr,power-state";
+					compatible = "zephyr,idle-state";
 					idle-state-name = "suspend-to-idle";
 					zephyr,substate-id = <2>;
 					min-residency-us = <100>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -37,13 +37,13 @@
 		idle-states {
 			stop0: state0 {
 					compatible = "zephyr,power-state";
-					power-state-name = "suspend-to-idle";
+					idle-state-name = "suspend-to-idle";
 					substate-id = <1>;
 					min-residency-us = <20>;
 				};
 			stop1: state1 {
 					compatible = "zephyr,power-state";
-					power-state-name = "suspend-to-idle";
+					idle-state-name = "suspend-to-idle";
 					substate-id = <2>;
 					min-residency-us = <100>;
 				};

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -36,7 +36,7 @@
 		idle-states {
 			stop: stop {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				min-residency-us = <2000>;
 				exit-latency-us = <750>;
 			};

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -33,7 +33,7 @@
 			cpu-idle-states = <&stop>;
 		};
 
-		power-states {
+		idle-states {
 			stop: stop {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -35,7 +35,7 @@
 
 		idle-states {
 			stop: stop {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				min-residency-us = <2000>;
 				exit-latency-us = <750>;

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -30,7 +30,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
-			cpu-power-states = <&stop>;
+			cpu-idle-states = <&stop>;
 		};
 
 		power-states {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -37,19 +37,19 @@
 		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <1>;
 				min-residency-us = <500>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <2>;
 				min-residency-us = <700>;
 			};
 			stop2: state2 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <3>;
 				min-residency-us = <1000>;
 			};

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -38,19 +38,19 @@
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <1>;
+				zephyr,substate-id = <1>;
 				min-residency-us = <500>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <2>;
+				zephyr,substate-id = <2>;
 				min-residency-us = <700>;
 			};
 			stop2: state2 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <3>;
+				zephyr,substate-id = <3>;
 				min-residency-us = <1000>;
 			};
 		};

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -36,19 +36,19 @@
 
 		idle-states {
 			stop0: state0 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <1>;
 				min-residency-us = <500>;
 			};
 			stop1: state1 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <2>;
 				min-residency-us = <700>;
 			};
 			stop2: state2 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <3>;
 				min-residency-us = <1000>;

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -34,7 +34,7 @@
 			reg = <0>;
 		};
 
-		power-states {
+		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -47,19 +47,19 @@
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <1>;
+				zephyr,substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <2>;
+				zephyr,substate-id = <2>;
 				min-residency-us = <500>;
 			};
 			stop2: state2 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <3>;
+				zephyr,substate-id = <3>;
 				min-residency-us = <900>;
 			};
 		};

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -45,19 +45,19 @@
 
 		idle-states {
 			stop0: state0 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <2>;
 				min-residency-us = <500>;
 			};
 			stop2: state2 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <3>;
 				min-residency-us = <900>;

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -46,19 +46,19 @@
 		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <2>;
 				min-residency-us = <500>;
 			};
 			stop2: state2 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <3>;
 				min-residency-us = <900>;
 			};

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -43,7 +43,7 @@
 			};
 		};
 
-		power-states {
+		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -47,19 +47,19 @@
 		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <2>;
 				min-residency-us = <500>;
 			};
 			stop2: state2 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <3>;
 				min-residency-us = <900>;
 			};

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -48,19 +48,19 @@
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <1>;
+				zephyr,substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <2>;
+				zephyr,substate-id = <2>;
 				min-residency-us = <500>;
 			};
 			stop2: state2 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <3>;
+				zephyr,substate-id = <3>;
 				min-residency-us = <900>;
 			};
 		};

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -46,19 +46,19 @@
 
 		idle-states {
 			stop0: state0 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <2>;
 				min-residency-us = <500>;
 			};
 			stop2: state2 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <3>;
 				min-residency-us = <900>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -44,7 +44,7 @@
 			};
 		};
 
-		power-states {
+		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -35,19 +35,19 @@
 
 		idle-states {
 			stop0: state0 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <2>;
 				min-residency-us = <500>;
 			};
 			stop2: state2 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <3>;
 				min-residency-us = <900>;

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -33,7 +33,7 @@
 			reg = <0>;
 		};
 
-		power-states {
+		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -37,19 +37,19 @@
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <1>;
+				zephyr,substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <2>;
+				zephyr,substate-id = <2>;
 				min-residency-us = <500>;
 			};
 			stop2: state2 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <3>;
+				zephyr,substate-id = <3>;
 				min-residency-us = <900>;
 			};
 		};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -36,19 +36,19 @@
 		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <2>;
 				min-residency-us = <500>;
 			};
 			stop2: state2 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <3>;
 				min-residency-us = <900>;
 			};

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -45,13 +45,13 @@
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <1>;
+				zephyr,substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <2>;
+				zephyr,substate-id = <2>;
 				min-residency-us = <500>;
 			};
 		};

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -44,13 +44,13 @@
 		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <2>;
 				min-residency-us = <500>;
 			};

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -41,7 +41,7 @@
 			};
 		};
 
-		power-states {
+		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -43,13 +43,13 @@
 
 		idle-states {
 			stop0: state0 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <2>;
 				min-residency-us = <500>;

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -30,7 +30,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&stop0 &stop1>;
+			cpu-idle-states = <&stop0 &stop1>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -36,19 +36,19 @@
 
 		idle-states {
 			stop0: state0 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <2>;
 				min-residency-us = <500>;
 			};
 			stop2: state2 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				zephyr,substate-id = <3>;
 				min-residency-us = <900>;

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -38,19 +38,19 @@
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <1>;
+				zephyr,substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <2>;
+				zephyr,substate-id = <2>;
 				min-residency-us = <500>;
 			};
 			stop2: state2 {
 				compatible = "zephyr,power-state";
 				idle-state-name = "suspend-to-idle";
-				substate-id = <3>;
+				zephyr,substate-id = <3>;
 				min-residency-us = <900>;
 			};
 		};

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -34,7 +34,7 @@
 			cpu-idle-states = <&stop0 &stop1 &stop2>;
 		};
 
-		power-states {
+		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -37,19 +37,19 @@
 		idle-states {
 			stop0: state0 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <1>;
 				min-residency-us = <100>;
 			};
 			stop1: state1 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <2>;
 				min-residency-us = <500>;
 			};
 			stop2: state2 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				substate-id = <3>;
 				min-residency-us = <900>;
 			};

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -31,7 +31,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
-			cpu-power-states = <&stop0 &stop1 &stop2>;
+			cpu-idle-states = <&stop0 &stop1 &stop2>;
 		};
 
 		power-states {

--- a/dts/arm/ti/cc13xx_cc26xx.dtsi
+++ b/dts/arm/ti/cc13xx_cc26xx.dtsi
@@ -23,7 +23,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4";
 			reg = <0>;
-			cpu-power-states = <&idle &standby>;
+			cpu-idle-states = <&idle &standby>;
 		};
 
 		power-states {

--- a/dts/arm/ti/cc13xx_cc26xx.dtsi
+++ b/dts/arm/ti/cc13xx_cc26xx.dtsi
@@ -28,13 +28,13 @@
 
 		idle-states {
 			idle: idle {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				min-residency-us = <1000>;
 			};
 
 			standby: standby {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "standby";
 				min-residency-us = <5000>;
 				exit-latency-us = <240>;

--- a/dts/arm/ti/cc13xx_cc26xx.dtsi
+++ b/dts/arm/ti/cc13xx_cc26xx.dtsi
@@ -29,13 +29,13 @@
 		idle-states {
 			idle: idle {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				min-residency-us = <1000>;
 			};
 
 			standby: standby {
 				compatible = "zephyr,power-state";
-				power-state-name = "standby";
+				idle-state-name = "standby";
 				min-residency-us = <5000>;
 				exit-latency-us = <240>;
 			};

--- a/dts/arm/ti/cc13xx_cc26xx.dtsi
+++ b/dts/arm/ti/cc13xx_cc26xx.dtsi
@@ -26,7 +26,7 @@
 			cpu-idle-states = <&idle &standby>;
 		};
 
-		power-states {
+		idle-states {
 			idle: idle {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/dts/bindings/cpu/cpu.yaml
+++ b/dts/bindings/cpu/cpu.yaml
@@ -9,7 +9,7 @@ properties:
   clock-frequency:
     type: int
     description: Clock frequency in Hz
-  cpu-power-states:
+  cpu-idle-states:
     type: phandles
     description: List of power management states supported by this cpu
   i-cache-line-size:

--- a/dts/bindings/cpu/zephyr,idle-state.yaml
+++ b/dts/bindings/cpu/zephyr,idle-state.yaml
@@ -3,7 +3,7 @@
 
 description: Properties for power management state
 
-compatible: "zephyr,power-state"
+compatible: "zephyr,idle-state"
 
 properties:
   idle-state-name:

--- a/dts/bindings/power/nxp,pdcfg-power.yaml
+++ b/dts/bindings/power/nxp,pdcfg-power.yaml
@@ -5,7 +5,7 @@ description: Properties for NXP power management through the PDCFG register
 
 compatible: "nxp,pdcfg-power"
 
-include: zephyr,power-state.yaml
+include: zephyr,idle-state.yaml
 
 properties:
   deep-sleep-config:

--- a/dts/bindings/power/zephyr,power-state.yaml
+++ b/dts/bindings/power/zephyr,power-state.yaml
@@ -18,7 +18,7 @@ properties:
       - "suspend-to-ram"
       - "suspend-to-disk"
       - "soft-off"
-  substate-id:
+  zephyr,substate-id:
     type: int
     description: Platform specific identification.
   min-residency-us:

--- a/dts/bindings/power/zephyr,power-state.yaml
+++ b/dts/bindings/power/zephyr,power-state.yaml
@@ -6,7 +6,7 @@ description: Properties for power management state
 compatible: "zephyr,power-state"
 
 properties:
-  power-state-name:
+  idle-state-name:
     type: string
     required: true
     description: indicates a power state

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -38,14 +38,14 @@
 
 		idle-states {
 			light_sleep: light_sleep {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "standby";
 				min-residency-us = <200>;
 				exit-latency-us = <60>;
 			};
 
 			deep_sleep: deep_sleep {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "soft-off";
 				min-residency-us = <660>;
 				exit-latency-us = <105>;

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -39,14 +39,14 @@
 		idle-states {
 			light_sleep: light_sleep {
 				compatible = "zephyr,power-state";
-				power-state-name = "standby";
+				idle-state-name = "standby";
 				min-residency-us = <200>;
 				exit-latency-us = <60>;
 			};
 
 			deep_sleep: deep_sleep {
 				compatible = "zephyr,power-state";
-				power-state-name = "soft-off";
+				idle-state-name = "soft-off";
 				min-residency-us = <660>;
 				exit-latency-us = <105>;
 			};

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -33,7 +33,7 @@
 			device_type = "cpu";
 			compatible = "espressif,riscv";
 			reg = <0>;
-			cpu-power-states = <&light_sleep &deep_sleep>;
+			cpu-idle-states = <&light_sleep &deep_sleep>;
 		};
 
 		power-states {

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -36,7 +36,7 @@
 			cpu-idle-states = <&light_sleep &deep_sleep>;
 		};
 
-		power-states {
+		idle-states {
 			light_sleep: light_sleep {
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -37,7 +37,7 @@
 		idle-states {
 			standby: standby {
 				compatible = "zephyr,power-state";
-				power-state-name = "standby";
+				idle-state-name = "standby";
 				min-residency-us = <500>;
 			};
 		};

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -31,7 +31,7 @@
 			compatible = "ite,riscv-ite";
 			device_type = "cpu";
 			reg = <0>;
-			cpu-power-states = <&standby>;
+			cpu-idle-states = <&standby>;
 		};
 
 		power-states {

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -36,7 +36,7 @@
 
 		idle-states {
 			standby: standby {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "standby";
 				min-residency-us = <500>;
 			};

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -34,7 +34,7 @@
 			cpu-idle-states = <&standby>;
 		};
 
-		power-states {
+		idle-states {
 			standby: standby {
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -40,14 +40,14 @@
 		idle-states {
 			light_sleep: light_sleep {
 				compatible = "zephyr,power-state";
-				power-state-name = "standby";
+				idle-state-name = "standby";
 				min-residency-us = <200>;
 				exit-latency-us = <60>;
 			};
 
 			deep_sleep: deep_sleep {
 				compatible = "zephyr,power-state";
-				power-state-name = "soft-off";
+				idle-state-name = "soft-off";
 				min-residency-us = <2000>;
 				exit-latency-us = <212>;
 			};

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -39,14 +39,14 @@
 
 		idle-states {
 			light_sleep: light_sleep {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "standby";
 				min-residency-us = <200>;
 				exit-latency-us = <60>;
 			};
 
 			deep_sleep: deep_sleep {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "soft-off";
 				min-residency-us = <2000>;
 				exit-latency-us = <212>;

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -28,7 +28,7 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <0>;
-			cpu-power-states = <&light_sleep &deep_sleep>;
+			cpu-idle-states = <&light_sleep &deep_sleep>;
 		};
 
 		cpu1: cpu@1 {

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -37,7 +37,7 @@
 			reg = <1>;
 		};
 
-		power-states {
+		idle-states {
 			light_sleep: light_sleep {
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";

--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -34,7 +34,7 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <0>;
-			cpu-power-states = <&light_sleep &deep_sleep>;
+			cpu-idle-states = <&light_sleep &deep_sleep>;
 		};
 
 		power-states {

--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -40,14 +40,14 @@
 		idle-states {
 			light_sleep: light_sleep {
 				compatible = "zephyr,power-state";
-				power-state-name = "standby";
+				idle-state-name = "standby";
 				min-residency-us = <200>;
 				exit-latency-us = <60>;
 			};
 
 			deep_sleep: deep_sleep {
 				compatible = "zephyr,power-state";
-				power-state-name = "soft-off";
+				idle-state-name = "soft-off";
 				min-residency-us = <2000>;
 				exit-latency-us = <212>;
 			};

--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -39,14 +39,14 @@
 
 		idle-states {
 			light_sleep: light_sleep {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "standby";
 				min-residency-us = <200>;
 				exit-latency-us = <60>;
 			};
 
 			deep_sleep: deep_sleep {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "soft-off";
 				min-residency-us = <2000>;
 				exit-latency-us = <212>;

--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -37,7 +37,7 @@
 			cpu-idle-states = <&light_sleep &deep_sleep>;
 		};
 
-		power-states {
+		idle-states {
 			light_sleep: light_sleep {
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -35,7 +35,7 @@
 			cpu-idle-states = <&d0i3 &d3>;
 		};
 
-		power-states {
+		idle-states {
 			d0i3: idle {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -16,7 +16,7 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <0>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-idle-states = <&d0i3 &d3>;
 			i-cache-line-size = <64>;
 			d-cache-line-size = <64>;
 		};
@@ -25,14 +25,14 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-idle-states = <&d0i3 &d3>;
 		};
 
 		cpu2: cpu@2 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-idle-states = <&d0i3 &d3>;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -38,7 +38,7 @@
 		idle-states {
 			d0i3: idle {
 				compatible = "zephyr,power-state";
-				power-state-name = "runtime-idle";
+				idle-state-name = "runtime-idle";
 				min-residency-us = <200>;
 				exit-latency-us = <100>;
 			};
@@ -47,7 +47,7 @@
 			 */
 			d3: off {
 				compatible = "zephyr,power-state";
-				power-state-name = "soft-off";
+				idle-state-name = "soft-off";
 				min-residency-us = <2147483647>;
 				exit-latency-us = <0>;
 			};

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -37,7 +37,7 @@
 
 		idle-states {
 			d0i3: idle {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "runtime-idle";
 				min-residency-us = <200>;
 				exit-latency-us = <100>;
@@ -46,7 +46,7 @@
 			 * The procedure is triggered by IPC from the HOST (SET_DX).
 			 */
 			d3: off {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "soft-off";
 				min-residency-us = <2147483647>;
 				exit-latency-us = <0>;

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -49,7 +49,7 @@
 			cpu-idle-states = <&d0i3 &d3>;
 		};
 
-		power-states {
+		idle-states {
 			d0i3: idle {
 				compatible = "zephyr,power-state";
 				power-state-name = "runtime-idle";

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -16,7 +16,7 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <0>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-idle-states = <&d0i3 &d3>;
 			i-cache-line-size = <64>;
 			d-cache-line-size = <64>;
 		};
@@ -25,28 +25,28 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-idle-states = <&d0i3 &d3>;
 		};
 
 		cpu2: cpu@2 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-idle-states = <&d0i3 &d3>;
 		};
 
 		cpu3: cpu@3 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <3>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-idle-states = <&d0i3 &d3>;
 		};
 
 		cpu4: cpu@4 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <4>;
-			cpu-power-states = <&d0i3 &d3>;
+			cpu-idle-states = <&d0i3 &d3>;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -52,7 +52,7 @@
 		idle-states {
 			d0i3: idle {
 				compatible = "zephyr,power-state";
-				power-state-name = "runtime-idle";
+				idle-state-name = "runtime-idle";
 				min-residency-us = <200>;
 				exit-latency-us = <100>;
 			};
@@ -61,7 +61,7 @@
 			 */
 			d3: off {
 				compatible = "zephyr,power-state";
-				power-state-name = "soft-off";
+				idle-state-name = "soft-off";
 				min-residency-us = <2147483647>;
 				exit-latency-us = <0>;
 			};

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -51,7 +51,7 @@
 
 		idle-states {
 			d0i3: idle {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "runtime-idle";
 				min-residency-us = <200>;
 				exit-latency-us = <100>;
@@ -60,7 +60,7 @@
 			 * The procedure is triggered by IPC from the HOST (SET_DX).
 			 */
 			d3: off {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "soft-off";
 				min-residency-us = <2147483647>;
 				exit-latency-us = <0>;

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -48,7 +48,7 @@
 			 * from the HOST (SET_DX).
 			 */
 			d3: off {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "soft-off";
 				min-residency-us = <2147483647>;
 				exit-latency-us = <0>;

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -16,7 +16,7 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <0>;
-			cpu-power-states = <&d3>;
+			cpu-idle-states = <&d3>;
 			i-cache-line-size = <64>;
 			d-cache-line-size = <64>;
 		};
@@ -25,21 +25,21 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <1>;
-			cpu-power-states = <&d3>;
+			cpu-idle-states = <&d3>;
 		};
 
 		cpu2: cpu@2 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <2>;
-			cpu-power-states = <&d3>;
+			cpu-idle-states = <&d3>;
 		};
 
 		cpu3: cpu@3 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <3>;
-			cpu-power-states = <&d3>;
+			cpu-idle-states = <&d3>;
 		};
 
 		power-states {

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -49,7 +49,7 @@
 			 */
 			d3: off {
 				compatible = "zephyr,power-state";
-				power-state-name = "soft-off";
+				idle-state-name = "soft-off";
 				min-residency-us = <2147483647>;
 				exit-latency-us = <0>;
 			};

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -42,7 +42,7 @@
 			cpu-idle-states = <&d3>;
 		};
 
-		power-states {
+		idle-states {
 			/* PM_STATE_SOFT_OFF can be entered only by calling
 			 * pm_state_force. The procedure is triggered by IPC
 			 * from the HOST (SET_DX).

--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -35,7 +35,7 @@
 			 */
 			d3: off {
 				compatible = "zephyr,power-state";
-				power-state-name = "soft-off";
+				idle-state-name = "soft-off";
 				min-residency-us = <2147483647>;
 				exit-latency-us = <0>;
 			};

--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -28,7 +28,7 @@
 			cpu-idle-states = <&d3>;
 		};
 
-		power-states {
+		idle-states {
 			/* PM_STATE_SOFT_OFF can be entered only by calling
 			 * pm_state_force. The procedure is triggered by IPC
 			 * from the HOST (SET_DX).

--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -34,7 +34,7 @@
 			 * from the HOST (SET_DX).
 			 */
 			d3: off {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "soft-off";
 				min-residency-us = <2147483647>;
 				exit-latency-us = <0>;

--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -16,7 +16,7 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <0>;
-			cpu-power-states = <&d3>;
+			cpu-idle-states = <&d3>;
 			i-cache-line-size = <64>;
 			d-cache-line-size = <64>;
 		};
@@ -25,7 +25,7 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <1>;
-			cpu-power-states = <&d3>;
+			cpu-idle-states = <&d3>;
 		};
 
 		power-states {

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -166,7 +166,7 @@ struct pm_state_info {
  * @param node_id A node identifier with compatible zephyr,power-state
  */
 #define Z_PM_STATE_INFO_FROM_DT_CPU(i, node_id) \
-	PM_STATE_INFO_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i))
+	PM_STATE_INFO_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_idle_states, i))
 
 /**
  * @brief Helper macro to initialize an entry of a struct pm_state array when
@@ -176,7 +176,7 @@ struct pm_state_info {
  * @param node_id A node identifier with compatible zephyr,power-state
  */
 #define Z_PM_STATE_FROM_DT_CPU(i, node_id) \
-	PM_STATE_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i))
+	PM_STATE_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_idle_states, i))
 
 /** @endcond */
 
@@ -211,7 +211,7 @@ struct pm_state_info {
  * @return Number of supported CPU power states.
  */
 #define DT_NUM_CPU_POWER_STATES(node_id) \
-	DT_PROP_LEN_OR(node_id, cpu_power_states, 0)
+	DT_PROP_LEN_OR(node_id, cpu_idle_states, 0)
 
 /**
  * @brief Initialize an array of struct pm_state_info with information from all
@@ -225,7 +225,7 @@ struct pm_state_info {
  *		cpu0: cpu@0 {
  *			device_type = "cpu";
  *			...
- *			cpu-power-states = <&state0 &state1>;
+ *			cpu-idle-states = <&state0 &state1>;
  *		};
  *
  *		power-states {
@@ -274,7 +274,7 @@ struct pm_state_info {
  *		cpu0: cpu@0 {
  *			device_type = "cpu";
  *			...
- *			cpu-power-states = <&state0 &state1>;
+ *			cpu-idle-states = <&state0 &state1>;
  *		};
  *
  *		power-states {

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -124,14 +124,14 @@ struct pm_state_info {
 	 *		state0: state0 {
 	 *			compatible = "zephyr,power-state";
 	 *			idle-state-name = "suspend-to-idle";
-	 *			substate-id = <1>;
+	 *			zephyr,substate-id = <1>;
 	 *			min-residency-us = <10000>;
 	 *			exit-latency-us = <100>;
 	 *		};
 	 *		state1: state1 {
 	 *			compatible = "zephyr,power-state";
 	 *			idle-state-name = "suspend-to-idle";
-	 *			substate-id = <2>;
+	 *			zephyr,substate-id = <2>;
 	 *			min-residency-us = <20000>;
 	 *			exit-latency-us = <200>;
 	 *		};
@@ -189,7 +189,7 @@ struct pm_state_info {
 #define PM_STATE_INFO_DT_INIT(node_id)					       \
 	{								       \
 		.state = PM_STATE_DT_INIT(node_id),			       \
-		.substate_id = DT_PROP_OR(node_id, substate_id, 0),	       \
+		.substate_id = DT_PROP_OR(node_id, zephyr_substate_id, 0),     \
 		.min_residency_us = DT_PROP_OR(node_id, min_residency_us, 0),  \
 		.exit_latency_us = DT_PROP_OR(node_id, exit_latency_us, 0),    \
 	}

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -123,14 +123,14 @@ struct pm_state_info {
 	 *	idle-states {
 	 *		state0: state0 {
 	 *			compatible = "zephyr,power-state";
-	 *			power-state-name = "suspend-to-idle";
+	 *			idle-state-name = "suspend-to-idle";
 	 *			substate-id = <1>;
 	 *			min-residency-us = <10000>;
 	 *			exit-latency-us = <100>;
 	 *		};
 	 *		state1: state1 {
 	 *			compatible = "zephyr,power-state";
-	 *			power-state-name = "suspend-to-idle";
+	 *			idle-state-name = "suspend-to-idle";
 	 *			substate-id = <2>;
 	 *			min-residency-us = <20000>;
 	 *			exit-latency-us = <200>;
@@ -201,7 +201,7 @@ struct pm_state_info {
  * @param node_id A node identifier with compatible zephyr,power-state
  */
 #define PM_STATE_DT_INIT(node_id) \
-	DT_ENUM_IDX(node_id, power_state_name)
+	DT_ENUM_IDX(node_id, idle_state_name)
 
 /**
  * @brief Obtain number of CPU power states supported by the given CPU node
@@ -231,14 +231,14 @@ struct pm_state_info {
  *		idle-states {
  *			state0: state0 {
  *				compatible = "zephyr,power-state";
- *				power-state-name = "suspend-to-idle";
+ *				idle-state-name = "suspend-to-idle";
  *				min-residency-us = <10000>;
  *				exit-latency-us = <100>;
  *			};
  *
  *			state1: state1 {
  *				compatible = "zephyr,power-state";
- *				power-state-name = "suspend-to-ram";
+ *				idle-state-name = "suspend-to-ram";
  *				min-residency-us = <50000>;
  *				exit-latency-us = <500>;
  *			};
@@ -280,14 +280,14 @@ struct pm_state_info {
  *		idle-states {
  *			state0: state0 {
  *				compatible = "zephyr,power-state";
- *				power-state-name = "suspend-to-idle";
+ *				idle-state-name = "suspend-to-idle";
  *				min-residency-us = <10000>;
  *				exit-latency-us = <100>;
  *			};
  *
  *			state1: state1 {
  *				compatible = "zephyr,power-state";
- *				power-state-name = "suspend-to-ram";
+ *				idle-state-name = "suspend-to-ram";
  *				min-residency-us = <50000>;
  *				exit-latency-us = <500>;
  *			};

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -122,14 +122,14 @@ struct pm_state_info {
 	 * @code{.dts}
 	 *	idle-states {
 	 *		state0: state0 {
-	 *			compatible = "zephyr,power-state";
+	 *			compatible = "zephyr,idle-state";
 	 *			idle-state-name = "suspend-to-idle";
 	 *			zephyr,substate-id = <1>;
 	 *			min-residency-us = <10000>;
 	 *			exit-latency-us = <100>;
 	 *		};
 	 *		state1: state1 {
-	 *			compatible = "zephyr,power-state";
+	 *			compatible = "zephyr,idle-state";
 	 *			idle-state-name = "suspend-to-idle";
 	 *			zephyr,substate-id = <2>;
 	 *			min-residency-us = <20000>;
@@ -163,7 +163,7 @@ struct pm_state_info {
  * when using UTIL_LISTIFY in PM_STATE_INFO_LIST_FROM_DT_CPU.
  *
  * @param i UTIL_LISTIFY entry index.
- * @param node_id A node identifier with compatible zephyr,power-state
+ * @param node_id A node identifier with compatible zephyr,idle-state
  */
 #define Z_PM_STATE_INFO_FROM_DT_CPU(i, node_id) \
 	PM_STATE_INFO_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_idle_states, i))
@@ -173,7 +173,7 @@ struct pm_state_info {
  * using UTIL_LISTIFY in PM_STATE_LIST_FROM_DT_CPU.
  *
  * @param i UTIL_LISTIFY entry index.
- * @param node_id A node identifier with compatible zephyr,power-state
+ * @param node_id A node identifier with compatible zephyr,idle-state
  */
 #define Z_PM_STATE_FROM_DT_CPU(i, node_id) \
 	PM_STATE_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_idle_states, i))
@@ -182,9 +182,9 @@ struct pm_state_info {
 
 /**
  * @brief Initializer for struct pm_state_info given a DT node identifier with
- * zephyr,power-state compatible.
+ * zephyr,idle-state compatible.
  *
- * @param node_id A node identifier with compatible zephyr,power-state
+ * @param node_id A node identifier with compatible zephyr,idle-state
  */
 #define PM_STATE_INFO_DT_INIT(node_id)					       \
 	{								       \
@@ -196,9 +196,9 @@ struct pm_state_info {
 
 /**
  * @brief Initializer for enum pm_state given a DT node identifier with
- * zephyr,power-state compatible.
+ * zephyr,idle-state compatible.
  *
- * @param node_id A node identifier with compatible zephyr,power-state
+ * @param node_id A node identifier with compatible zephyr,idle-state
  */
 #define PM_STATE_DT_INIT(node_id) \
 	DT_ENUM_IDX(node_id, idle_state_name)
@@ -230,14 +230,14 @@ struct pm_state_info {
  *
  *		idle-states {
  *			state0: state0 {
- *				compatible = "zephyr,power-state";
+ *				compatible = "zephyr,idle-state";
  *				idle-state-name = "suspend-to-idle";
  *				min-residency-us = <10000>;
  *				exit-latency-us = <100>;
  *			};
  *
  *			state1: state1 {
- *				compatible = "zephyr,power-state";
+ *				compatible = "zephyr,idle-state";
  *				idle-state-name = "suspend-to-ram";
  *				min-residency-us = <50000>;
  *				exit-latency-us = <500>;
@@ -279,14 +279,14 @@ struct pm_state_info {
  *
  *		idle-states {
  *			state0: state0 {
- *				compatible = "zephyr,power-state";
+ *				compatible = "zephyr,idle-state";
  *				idle-state-name = "suspend-to-idle";
  *				min-residency-us = <10000>;
  *				exit-latency-us = <100>;
  *			};
  *
  *			state1: state1 {
- *				compatible = "zephyr,power-state";
+ *				compatible = "zephyr,idle-state";
  *				idle-state-name = "suspend-to-ram";
  *				min-residency-us = <50000>;
  *				exit-latency-us = <500>;

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -120,7 +120,7 @@ struct pm_state_info {
 	 * distinguish them. e.g:
 	 *
 	 * @code{.dts}
-	 *	power-states {
+	 *	idle-states {
 	 *		state0: state0 {
 	 *			compatible = "zephyr,power-state";
 	 *			power-state-name = "suspend-to-idle";
@@ -228,7 +228,7 @@ struct pm_state_info {
  *			cpu-idle-states = <&state0 &state1>;
  *		};
  *
- *		power-states {
+ *		idle-states {
  *			state0: state0 {
  *				compatible = "zephyr,power-state";
  *				power-state-name = "suspend-to-idle";
@@ -277,7 +277,7 @@ struct pm_state_info {
  *			cpu-idle-states = <&state0 &state1>;
  *		};
  *
- *		power-states {
+ *		idle-states {
  *			state0: state0 {
  *				compatible = "zephyr,power-state";
  *				power-state-name = "suspend-to-idle";

--- a/samples/boards/stm32/power_mgmt/blinky/sample.yaml
+++ b/samples/boards/stm32/power_mgmt/blinky/sample.yaml
@@ -10,7 +10,7 @@ tests:
       type: one_line
       regex:
         - "Device ready"
-    filter: dt_compat_enabled("zephyr,power-state") and
+    filter: dt_compat_enabled("zephyr,idle-state") and
             dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
             dt_compat_enabled("st,stm32-lptim")
     extra_args: "CONFIG_DEBUG=y"

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/sample.yaml
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/sample.yaml
@@ -16,6 +16,6 @@ tests:
         - "Wakeup source enabled"
     integration_platforms:
       - nucleo_wb55rg
-    filter: dt_compat_enabled("zephyr,power-state")
+    filter: dt_compat_enabled("zephyr,idle-state")
     extra_args: "CONFIG_DEBUG=y"
     platform_allow: nucleo_wb55rg

--- a/samples/boards/stm32/power_mgmt/standby_shutdown/sample.yaml
+++ b/samples/boards/stm32/power_mgmt/standby_shutdown/sample.yaml
@@ -17,6 +17,6 @@ tests:
         - "Press and hold the user button:"
         - "when LED2 is OFF to enter to Shutdown Mode"
         - "when LED2 is ON to enter to Standby Mode"
-    filter: dt_compat_enabled("zephyr,power-state") and dt_enabled_alias_with_parent_compat("led0",
+    filter: dt_compat_enabled("zephyr,idle-state") and dt_enabled_alias_with_parent_compat("led0",
       "gpio-leds") and dt_compat_enabled("st,stm32-lptim")
     extra_args: "CONFIG_DEBUG=y"

--- a/samples/subsys/pm/latency/boards/native_posix.overlay
+++ b/samples/subsys/pm/latency/boards/native_posix.overlay
@@ -4,7 +4,7 @@
  */
 
 / {
-	power-states {
+	idle-states {
 		runtime_idle: runtime-idle {
 			compatible = "zephyr,power-state";
 			power-state-name = "runtime-idle";

--- a/samples/subsys/pm/latency/boards/native_posix.overlay
+++ b/samples/subsys/pm/latency/boards/native_posix.overlay
@@ -27,5 +27,5 @@
 };
 
 &cpu0 {
-	cpu-power-states = <&runtime_idle &suspend_to_idle &standby>;
+	cpu-idle-states = <&runtime_idle &suspend_to_idle &standby>;
 };

--- a/samples/subsys/pm/latency/boards/native_posix.overlay
+++ b/samples/subsys/pm/latency/boards/native_posix.overlay
@@ -7,19 +7,19 @@
 	idle-states {
 		runtime_idle: runtime-idle {
 			compatible = "zephyr,power-state";
-			power-state-name = "runtime-idle";
+			idle-state-name = "runtime-idle";
 			min-residency-us = <1000000>;
 			exit-latency-us = <10000>;
 		};
 		suspend_to_idle: suspend-to-idle {
 			compatible = "zephyr,power-state";
-			power-state-name = "suspend-to-idle";
+			idle-state-name = "suspend-to-idle";
 			min-residency-us = <1100000>;
 			exit-latency-us = <20000>;
 		};
 		standby: standby {
 			compatible = "zephyr,power-state";
-			power-state-name = "standby";
+			idle-state-name = "standby";
 			min-residency-us = <1200000>;
 			exit-latency-us = <30000>;
 		};

--- a/samples/subsys/pm/latency/boards/native_posix.overlay
+++ b/samples/subsys/pm/latency/boards/native_posix.overlay
@@ -6,19 +6,19 @@
 / {
 	idle-states {
 		runtime_idle: runtime-idle {
-			compatible = "zephyr,power-state";
+			compatible = "zephyr,idle-state";
 			idle-state-name = "runtime-idle";
 			min-residency-us = <1000000>;
 			exit-latency-us = <10000>;
 		};
 		suspend_to_idle: suspend-to-idle {
-			compatible = "zephyr,power-state";
+			compatible = "zephyr,idle-state";
 			idle-state-name = "suspend-to-idle";
 			min-residency-us = <1100000>;
 			exit-latency-us = <20000>;
 		};
 		standby: standby {
-			compatible = "zephyr,power-state";
+			compatible = "zephyr,idle-state";
 			idle-state-name = "standby";
 			min-residency-us = <1200000>;
 			exit-latency-us = <30000>;

--- a/subsys/pm/policy.c
+++ b/subsys/pm/policy.c
@@ -15,7 +15,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/toolchain.h>
 
-#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_power_state)
+#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_idle_state)
 
 #define DT_SUB_LOCK_INIT(node_id)					\
 	{ .state = PM_STATE_DT_INIT(node_id),				\
@@ -39,7 +39,7 @@ static struct {
 	uint8_t substate_id;
 	atomic_t lock;
 } substate_lock_t[] = {
-	DT_FOREACH_STATUS_OKAY(zephyr_power_state, DT_SUB_LOCK_INIT)
+	DT_FOREACH_STATUS_OKAY(zephyr_idle_state, DT_SUB_LOCK_INIT)
 };
 
 #endif
@@ -193,7 +193,7 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 
 void pm_policy_state_lock_get(enum pm_state state, uint8_t substate_id)
 {
-#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_power_state)
+#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_idle_state)
 	for (size_t i = 0; i < ARRAY_SIZE(substate_lock_t); i++) {
 		if (substate_lock_t[i].state == state &&
 		   (substate_lock_t[i].substate_id == substate_id ||
@@ -206,7 +206,7 @@ void pm_policy_state_lock_get(enum pm_state state, uint8_t substate_id)
 
 void pm_policy_state_lock_put(enum pm_state state, uint8_t substate_id)
 {
-#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_power_state)
+#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_idle_state)
 	for (size_t i = 0; i < ARRAY_SIZE(substate_lock_t); i++) {
 		if (substate_lock_t[i].state == state &&
 		   (substate_lock_t[i].substate_id == substate_id ||
@@ -223,7 +223,7 @@ void pm_policy_state_lock_put(enum pm_state state, uint8_t substate_id)
 
 bool pm_policy_state_lock_is_active(enum pm_state state, uint8_t substate_id)
 {
-#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_power_state)
+#if DT_HAS_COMPAT_STATUS_OKAY(zephyr_idle_state)
 	for (size_t i = 0; i < ARRAY_SIZE(substate_lock_t); i++) {
 		if (substate_lock_t[i].state == state &&
 		   (substate_lock_t[i].substate_id == substate_id ||

--- a/subsys/pm/policy.c
+++ b/subsys/pm/policy.c
@@ -17,10 +17,10 @@
 
 #if DT_HAS_COMPAT_STATUS_OKAY(zephyr_power_state)
 
-#define DT_SUB_LOCK_INIT(node_id)				\
-	{ .state = PM_STATE_DT_INIT(node_id),			\
-	  .substate_id = DT_PROP_OR(node_id, substate_id, 0),	\
-	  .lock = ATOMIC_INIT(0),				\
+#define DT_SUB_LOCK_INIT(node_id)					\
+	{ .state = PM_STATE_DT_INIT(node_id),				\
+	  .substate_id = DT_PROP_OR(node_id, zephyr_substate_id, 0),	\
+	  .lock = ATOMIC_INIT(0),					\
 	},
 
 /**

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -19,9 +19,9 @@ BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
  */
 #define CHECK_POWER_STATE_CONSISTENCY(i, node_id)			       \
 	BUILD_ASSERT(							       \
-		DT_PROP_BY_PHANDLE_IDX_OR(node_id, cpu_power_states, i,	       \
+		DT_PROP_BY_PHANDLE_IDX_OR(node_id, cpu_idle_states, i,	       \
 					  min_residency_us, 0U) >=	       \
-		DT_PROP_BY_PHANDLE_IDX_OR(node_id, cpu_power_states, i,	       \
+		DT_PROP_BY_PHANDLE_IDX_OR(node_id, cpu_idle_states, i,	       \
 					  exit_latency_us, 0U),		       \
 		"Found CPU power state with min_residency < exit_latency")
 

--- a/tests/subsys/pm/policy_api/app.overlay
+++ b/tests/subsys/pm/policy_api/app.overlay
@@ -8,7 +8,7 @@
 		cpu1: cpu@1 {
 			compatible = "zephyr,native-posix-cpu";
 			reg = <1>;
-			cpu-power-states = <&state2>;
+			cpu-idle-states = <&state2>;
 		};
 	};
 
@@ -40,5 +40,5 @@
 };
 
 &cpu0 {
-	cpu-power-states = <&state0 &state1>;
+	cpu-idle-states = <&state0 &state1>;
 };

--- a/tests/subsys/pm/policy_api/app.overlay
+++ b/tests/subsys/pm/policy_api/app.overlay
@@ -12,7 +12,7 @@
 		};
 	};
 
-	power-states {
+	idle-states {
 		state0: state0 {
 			compatible = "zephyr,power-state";
 			power-state-name = "runtime-idle";

--- a/tests/subsys/pm/policy_api/app.overlay
+++ b/tests/subsys/pm/policy_api/app.overlay
@@ -14,7 +14,7 @@
 
 	idle-states {
 		state0: state0 {
-			compatible = "zephyr,power-state";
+			compatible = "zephyr,idle-state";
 			idle-state-name = "runtime-idle";
 			min-residency-us = <100000>;
 			exit-latency-us = <10000>;
@@ -22,7 +22,7 @@
 		};
 
 		state1: state1 {
-			compatible = "zephyr,power-state";
+			compatible = "zephyr,idle-state";
 			idle-state-name = "suspend-to-ram";
 			min-residency-us = <1000000>;
 			exit-latency-us = <100000>;
@@ -30,7 +30,7 @@
 		};
 
 		state2: state2 {
-			compatible = "zephyr,power-state";
+			compatible = "zephyr,idle-state";
 			idle-state-name = "suspend-to-ram";
 			min-residency-us = <500000>;
 			exit-latency-us = <50000>;

--- a/tests/subsys/pm/policy_api/app.overlay
+++ b/tests/subsys/pm/policy_api/app.overlay
@@ -15,7 +15,7 @@
 	idle-states {
 		state0: state0 {
 			compatible = "zephyr,power-state";
-			power-state-name = "runtime-idle";
+			idle-state-name = "runtime-idle";
 			min-residency-us = <100000>;
 			exit-latency-us = <10000>;
 			substate-id = <1>;
@@ -23,7 +23,7 @@
 
 		state1: state1 {
 			compatible = "zephyr,power-state";
-			power-state-name = "suspend-to-ram";
+			idle-state-name = "suspend-to-ram";
 			min-residency-us = <1000000>;
 			exit-latency-us = <100000>;
 			substate-id = <10>;
@@ -31,7 +31,7 @@
 
 		state2: state2 {
 			compatible = "zephyr,power-state";
-			power-state-name = "suspend-to-ram";
+			idle-state-name = "suspend-to-ram";
 			min-residency-us = <500000>;
 			exit-latency-us = <50000>;
 			substate-id = <100>;

--- a/tests/subsys/pm/policy_api/app.overlay
+++ b/tests/subsys/pm/policy_api/app.overlay
@@ -18,7 +18,7 @@
 			idle-state-name = "runtime-idle";
 			min-residency-us = <100000>;
 			exit-latency-us = <10000>;
-			substate-id = <1>;
+			zephyr,substate-id = <1>;
 		};
 
 		state1: state1 {
@@ -26,7 +26,7 @@
 			idle-state-name = "suspend-to-ram";
 			min-residency-us = <1000000>;
 			exit-latency-us = <100000>;
-			substate-id = <10>;
+			zephyr,substate-id = <10>;
 		};
 
 		state2: state2 {
@@ -34,7 +34,7 @@
 			idle-state-name = "suspend-to-ram";
 			min-residency-us = <500000>;
 			exit-latency-us = <50000>;
-			substate-id = <100>;
+			zephyr,substate-id = <100>;
 		};
 	};
 };

--- a/tests/subsys/pm/power_states_api/boards/native_posix.overlay
+++ b/tests/subsys/pm/power_states_api/boards/native_posix.overlay
@@ -12,21 +12,21 @@
 
 		idle-states {
 			state0: state0 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-idle";
 				min-residency-us = <10000>;
 				exit-latency-us = <100>;
 			};
 
 			state1: state1 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "suspend-to-ram";
 				min-residency-us = <50000>;
 				exit-latency-us = <500>;
 			};
 
 			state2: state2 {
-				compatible = "zephyr,power-state";
+				compatible = "zephyr,idle-state";
 				idle-state-name = "standby";
 			};
 		};

--- a/tests/subsys/pm/power_states_api/boards/native_posix.overlay
+++ b/tests/subsys/pm/power_states_api/boards/native_posix.overlay
@@ -10,7 +10,7 @@
 			cpu-idle-states = <&state0 &state1 &state2>;
 		};
 
-		power-states {
+		idle-states {
 			state0: state0 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";

--- a/tests/subsys/pm/power_states_api/boards/native_posix.overlay
+++ b/tests/subsys/pm/power_states_api/boards/native_posix.overlay
@@ -7,7 +7,7 @@
 / {
 	cpus {
 		cpu@0 {
-			cpu-power-states = <&state0 &state1 &state2>;
+			cpu-idle-states = <&state0 &state1 &state2>;
 		};
 
 		power-states {

--- a/tests/subsys/pm/power_states_api/boards/native_posix.overlay
+++ b/tests/subsys/pm/power_states_api/boards/native_posix.overlay
@@ -13,21 +13,21 @@
 		idle-states {
 			state0: state0 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-idle";
+				idle-state-name = "suspend-to-idle";
 				min-residency-us = <10000>;
 				exit-latency-us = <100>;
 			};
 
 			state1: state1 {
 				compatible = "zephyr,power-state";
-				power-state-name = "suspend-to-ram";
+				idle-state-name = "suspend-to-ram";
 				min-residency-us = <50000>;
 				exit-latency-us = <500>;
 			};
 
 			state2: state2 {
 				compatible = "zephyr,power-state";
-				power-state-name = "standby";
+				idle-state-name = "standby";
 			};
 		};
 	};

--- a/tests/subsys/pm/power_states_api/src/main.c
+++ b/tests/subsys/pm/power_states_api/src/main.c
@@ -18,7 +18,7 @@ static enum pm_state states[] = {PM_STATE_SUSPEND_TO_IDLE,
 static enum pm_state wrong_states[] = {PM_STATE_SUSPEND_TO_DISK,
 		PM_STATE_SUSPEND_TO_RAM, PM_STATE_SUSPEND_TO_RAM};
 
-ZTEST(power_states_1cpu, test_power_states)
+ZTEST(idle_states_1cpu, test_idle_states)
 {
 	enum pm_state dts_states[] =
 		PM_STATE_LIST_FROM_DT_CPU(DT_NODELABEL(cpu0));
@@ -38,5 +38,5 @@ ZTEST(power_states_1cpu, test_power_states)
 		     "Invalid pm-states array");
 }
 
-ZTEST_SUITE(power_states_1cpu, NULL, NULL, ztest_simple_1cpu_before,
+ZTEST_SUITE(idle_states_1cpu, NULL, NULL, ztest_simple_1cpu_before,
 			ztest_simple_1cpu_after, NULL);


### PR DESCRIPTION
This PR contains a series of patches to align Zephyr power states to Linux idle-states.yaml binding. It also fixes some bad practices like defining CPU idle states in board files.