### PR TITLE
os: hashmap: doc: Misc fixes to Hashmap documentation

### DIFF
--- a/include/zephyr/sys/hash_function.h
+++ b/include/zephyr/sys/hash_function.h
@@ -18,6 +18,12 @@ extern "C" {
 #endif
 
 /**
+ * @ingroup hashmap_apis
+ * @defgroup hash_functions Hash Functions
+ * @{
+ */
+
+/**
  * @brief 32-bit Hash function interface
  *
  * Hash functions are used to map data from an arbitrarily large space to a
@@ -70,7 +76,7 @@ static inline uint32_t sys_hash32_identity(const void *str, size_t n)
 }
 
 /**
- * @brief Daniel J. Bernstein's hash function
+ * @brief Daniel J.\ Bernstein's hash function
  *
  * Some notes:
  * - normally, this hash function is used on NUL-terminated strings
@@ -128,6 +134,10 @@ static inline uint32_t sys_hash32(const void *str, size_t n)
 
 	return 0;
 }
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/sys/hash_map.h
+++ b/include/zephyr/sys/hash_map.h
@@ -56,9 +56,9 @@ extern "C" {
 	}
 
 /**
- * @brief Declare a Hashmap (advanced)
+ * @brief Declare a Hashmap statically (advanced)
  *
- * Declare a Hashmap with control over advanced parameters.
+ * Declare a Hashmap statically with control over advanced parameters.
  *
  * @note The allocator @p _alloc is used for allocating internal Hashmap
  * entries and does not interact with any user-provided keys or values.
@@ -114,6 +114,7 @@ static inline void *sys_hashmap_default_allocator(void *ptr, size_t size)
 	return realloc(ptr, size);
 }
 
+/** @brief The default Hashmap allocator */
 #define SYS_HASHMAP_DEFAULT_ALLOCATOR sys_hashmap_default_allocator
 
 /** @brief The default Hashmap load factor (in hundredths) */
@@ -121,10 +122,15 @@ static inline void *sys_hashmap_default_allocator(void *ptr, size_t size)
 
 /** @brief Generic Hashmap */
 struct sys_hashmap {
+	/** Hashmap API */
 	const struct sys_hashmap_api *api;
+	/** Hashmap configuration */
 	const struct sys_hashmap_config *config;
+	/** Hashmap data */
 	struct sys_hashmap_data *data;
+	/** Hash function */
 	sys_hash_func32_t hash_func;
+	/** Allocator */
 	sys_hashmap_allocator_t alloc_func;
 };
 

--- a/include/zephyr/sys/hash_map.h
+++ b/include/zephyr/sys/hash_map.h
@@ -6,10 +6,8 @@
 
 /**
  * @file
- * @brief Hashmap (Hash Table) API
- *
- * Hashmaps (a.k.a Hash Tables) sacrifice space for speed. All operations
- * on a Hashmap (insert, delete, search) are O(1) complexity (on average).
+ * @addtogroup hashmap_apis
+ * @{
  */
 
 #ifndef ZEPHYR_INCLUDE_SYS_HASH_MAP_H_
@@ -28,11 +26,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @ingroup hashmap_apis
- * @{
- */
 
 /**
  * @brief Declare a Hashmap (advanced)

--- a/include/zephyr/sys/hash_map_api.h
+++ b/include/zephyr/sys/hash_map_api.h
@@ -29,6 +29,11 @@ extern "C" {
 /**
  * @defgroup hashmap_apis Hashmap
  * @ingroup datastructure_apis
+ *
+ * @defgroup hashmap_implementations Hashmap Implementations
+ * @ingroup hashmap_apis
+ *
+ * @addtogroup hashmap_apis
  * @{
  */
 

--- a/include/zephyr/sys/hash_map_api.h
+++ b/include/zephyr/sys/hash_map_api.h
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- * @brief Hashmap (Hash Table) API
- *
- * Hashmaps (a.k.a Hash Tables) sacrifice space for speed. All operations
- * on a Hashmap (insert, delete, search) are O(1) complexity (on average).
- */
-
 #ifndef ZEPHYR_INCLUDE_SYS_HASHMAP_API_H_
 #define ZEPHYR_INCLUDE_SYS_HASHMAP_API_H_
 
@@ -27,8 +19,14 @@ extern "C" {
 #endif
 
 /**
+ * @file
  * @defgroup hashmap_apis Hashmap
  * @ingroup datastructure_apis
+ *
+ * @brief Hashmap (Hash Table) API
+ *
+ * Hashmaps (a.k.a Hash Tables) sacrifice space for speed. All operations
+ * on a Hashmap (insert, delete, search) are O(1) complexity (on average).
  *
  * @defgroup hashmap_implementations Hashmap Implementations
  * @ingroup hashmap_apis

--- a/include/zephyr/sys/hash_map_cxx.h
+++ b/include/zephyr/sys/hash_map_cxx.h
@@ -6,6 +6,7 @@
 
 /**
  * @file
+ * @ingroup hashmap_implementations
  * @brief C++ Hashmap
  *
  * This is a C wrapper around `std::unordered_map`. It is mainly used for

--- a/include/zephyr/sys/hash_map_oa_lp.h
+++ b/include/zephyr/sys/hash_map_oa_lp.h
@@ -6,6 +6,7 @@
 
 /**
  * @file
+ * @ingroup hashmap_implementations
  * @brief Open-Addressing / Linear Probe Hashmap Implementation
  *
  * @note Enable with @kconfig{CONFIG_SYS_HASH_MAP_OA_LP}

--- a/include/zephyr/sys/hash_map_sc.h
+++ b/include/zephyr/sys/hash_map_sc.h
@@ -6,6 +6,7 @@
 
 /**
  * @file
+ * @ingroup hashmap_implementations
  * @brief Separate Chaining Hashmap Implementation
  *
  * @note Enable with @kconfig{CONFIG_SYS_HASH_MAP_SC}


### PR DESCRIPTION
See individual commits, but mostly a matter of "mounting" things like Hash functions and Implementations in the documentation for better navigability/discoverability.