### PR TITLE
MAINTAINERS: Add Kconfig.zephyr to Kconfig subsystem

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1595,6 +1595,7 @@ Kconfig:
   files:
     - scripts/kconfig/
     - doc/build/kconfig/
+    - Kconfig.zephyr
   labels:
     - "area: Kconfig"
   description: >-


### PR DESCRIPTION
Top file Kconfig.zephyr didn't belong to any maintained area. Add it to Kconfig