### PR TITLE
tests: posix: barrier: use consistent test names

### DIFF
--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -744,7 +744,7 @@ ZTEST(posix_apis, test_sched_policy)
 	}
 }
 
-ZTEST(posix_apis, test_posix_pthread_barrier)
+ZTEST(posix_apis, test_barrier)
 {
 	int ret, pshared;
 	pthread_barrierattr_t attr;


### PR DESCRIPTION
Test names were changed recently to change "test_posix_pthread_..." to "test_..." for brevity.

Make the same change to "test_posix_pthread_barrier".