### PR TITLE
modules: Updated Percepio TraceRecorder to version 4.8.0.hotfix2

### DIFF
--- a/modules/TraceRecorder/CMakeLists.txt
+++ b/modules/TraceRecorder/CMakeLists.txt
@@ -33,6 +33,8 @@ if(CONFIG_PERCEPIO_TRACERECORDER)
     ${TRACERECORDER_DIR}/trcString.c
     ${TRACERECORDER_DIR}/trcTask.c
     ${TRACERECORDER_DIR}/trcTimestamp.c
+    ${TRACERECORDER_DIR}/trcDependency.c
+    ${TRACERECORDER_DIR}/trcRunnable.c
     )
 
   if(CONFIG_PERCEPIO_TRC_CFG_STREAM_PORT_RTT)
@@ -68,11 +70,26 @@ if(CONFIG_PERCEPIO_TRACERECORDER)
     )
   endif()
 
+  if (CONFIG_PERCEPIO_TRC_CFG_STREAM_PORT_ZEPHYR_SEMIHOST)
+    zephyr_library_sources(
+      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/Semihost/trcStreamPort.c
+    )
+
+    zephyr_include_directories(
+      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/Semihost/config
+      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/Semihost/include
+    )
+  endif()
+
   zephyr_include_directories(
     ${TRACERECORDER_DIR}/kernelports/Zephyr/include
     ${TRACERECORDER_DIR}/kernelports/Zephyr/config
     ${TRACERECORDER_DIR}/kernelports/Zephyr/config/core
     ${TRACERECORDER_DIR}/include
+    )
+
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+      COMMAND python3 ${TRACERECORDER_DIR}/kernelports/Zephyr/scripts/tz_parse_syscalls.py ${CMAKE_BINARY_DIR} ${ZEPHYR_BASE}
     )
 
 endif()

--- a/west.yml
+++ b/west.yml
@@ -316,7 +316,7 @@ manifest:
       groups:
         - crypto
     - name: TraceRecorderSource
-      revision: bc839bf94904bcdb91b33760e918afbef82e3ab4
+      revision: 1ede7ce8e7ab226e9a84d95266241ba3f38d91d2
       path: modules/debug/TraceRecorder
       groups:
         - debug


### PR DESCRIPTION
This version is essentially a rewrite of the TraceRecorder. Also, this version introduces support for the syscalls extension, which reduces the amount of bandwidth being used for tracing syscalls.