### PR TITLE
stm32: typecast reset_line_toggle_dt() to void

### DIFF
--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -503,7 +503,7 @@ static int counter_stm32_init_timer(const struct device *dev)
 	}
 
 	/* Reset timer to default state using RCC */
-	reset_line_toggle_dt(&data->reset);
+	(void)reset_line_toggle_dt(&data->reset);
 
 	/* config/enable IRQ */
 	cfg->irq_config_func(dev);

--- a/drivers/mipi_dsi/dsi_stm32.c
+++ b/drivers/mipi_dsi/dsi_stm32.c
@@ -413,7 +413,7 @@ static int mipi_dsi_stm32_init(const struct device *dev)
 		return ret;
 	}
 
-	reset_line_toggle_dt(&config->reset);
+	(void)reset_line_toggle_dt(&config->reset);
 
 	ret = mipi_dsi_stm32_host_init(dev);
 	if (ret) {

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1701,7 +1701,7 @@ static int uart_stm32_init(const struct device *dev)
 	}
 
 	/* Reset UART to default state using RCC */
-	reset_line_toggle_dt(&data->reset);
+	(void)reset_line_toggle_dt(&data->reset);
 
 	/* TX/RX direction */
 	LL_USART_SetTransferDirection(config->usart,


### PR DESCRIPTION
@FRASTM mentioned we need to typecast `reset_line_toggle_dt()` https://github.com/zephyrproject-rtos/zephyr/pull/59648