### PR TITLE
drivers: pinctrl: remove unneeded TODO from Kconfig

### DIFF
--- a/drivers/pinctrl/Kconfig.gecko
+++ b/drivers/pinctrl/Kconfig.gecko
@@ -1,6 +1,5 @@
 # Copyright (c) 2022 Silicon Labs
 # SPDX-License-Identifier: Apache-2.0
-# TODO: copyright changes?
 
 config PINCTRL_GECKO
 	bool "Gecko pin controller driver"


### PR DESCRIPTION
This TODO seems to be no longer needed here.

CC @fkokosinski 