### PR TITLE
drivers: counter: stm32: Use const TIM_TypeDef on stm32f2 series

### DIFF
--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -44,7 +44,6 @@ static void(*const set_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *,
 /** Channel to compare get function mapping. */
 #if !defined(CONFIG_SOC_SERIES_STM32C0X) && \
 	!defined(CONFIG_SOC_SERIES_STM32F1X) && \
-	!defined(CONFIG_SOC_SERIES_STM32F2X) && \
 	!defined(CONFIG_SOC_SERIES_STM32F4X) && \
 	!defined(CONFIG_SOC_SERIES_STM32G4X) && \
 	!defined(CONFIG_SOC_SERIES_STM32L1X) && \
@@ -76,7 +75,6 @@ static void(*const disable_it[TIMER_MAX_CH])(TIM_TypeDef *) = {
 /** Channel to interrupt enable check function mapping. */
 #if !defined(CONFIG_SOC_SERIES_STM32C0X) && \
 	!defined(CONFIG_SOC_SERIES_STM32F1X) && \
-	!defined(CONFIG_SOC_SERIES_STM32F2X) && \
 	!defined(CONFIG_SOC_SERIES_STM32F4X) && \
 	!defined(CONFIG_SOC_SERIES_STM32G4X) && \
 	!defined(CONFIG_SOC_SERIES_STM32L1X) && \


### PR DESCRIPTION
A recent factorisation moved F2 to non const TIM_TypeDef. This is an error, move it back to const TIM_TypeDef.