### PR TITLE
lib: cbprintf: doc: Doxygen cleanup

### DIFF
--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -145,7 +145,7 @@ extern "C" {
 BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
 
 
-/**@defgroup CBPRINTF_PACKAGE_FLAGS Package flags.
+/**@defgroup CBPRINTF_PACKAGE_FLAGS Package flags
  * @{
  */
 
@@ -155,7 +155,7 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
  */
 #define CBPRINTF_PACKAGE_CONST_CHAR_RO BIT(0)
 
-/** @brief Append locations (within the package) of read-only string pointers.`*/
+/** @brief Append locations (within the package) of read-only string pointers. */
 #define CBPRINTF_PACKAGE_ADD_RO_STR_POS BIT(1)
 
 /** @brief Append locations (within the package) of read-write string pointers.
@@ -202,7 +202,8 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
 
 /**@} */
 
-/**@defgroup CBPRINTF_PACKAGE_CONVERT_FLAGS Package flags.
+/**
+ * @defgroup CBPRINTF_PACKAGE_CONVERT_FLAGS Package convert flags
  * @{
  */
 
@@ -215,6 +216,7 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
  * are also checked and if determined to be read-only they are also copied.
  */
 #define CBPRINTF_PACKAGE_CONVERT_RO_STR BIT(0)
+/** @deprecated Use @ref CBPRINTF_PACKAGE_CONVERT_RO_STR instead. */
 #define CBPRINTF_PACKAGE_COPY_RO_STR CBPRINTF_PACKAGE_CONVERT_RO_STR __DEPRECATED_MACRO
 
 /** @brief Append read-write strings from source package to destination package.
@@ -228,6 +230,7 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
  * package if @ref CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR is set.
  */
 #define CBPRINTF_PACKAGE_CONVERT_RW_STR BIT(1)
+/** @deprecated Use @ref CBPRINTF_PACKAGE_CONVERT_RW_STR instead. */
 #define CBPRINTF_PACKAGE_COPY_RW_STR CBPRINTF_PACKAGE_CONVERT_RW_STR __DEPRECATED_MACRO
 
 /** @brief Keep read-only location indexes in the package.
@@ -236,6 +239,7 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
  * not set they are discarded.
  */
 #define CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR BIT(2)
+/** @deprecated Use @ref CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR instead. */
 #define CBPRINTF_PACKAGE_COPY_KEEP_RO_STR CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR __DEPRECATED_MACRO
 
 /** @brief Check format string if %p argument was treated as %s in the package.
@@ -259,7 +263,8 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
 
 /**@} */
 
-/**@defgroup Z_CBVPRINTF_PROCESS_FLAGS cbvprintf processing flags.
+/**
+ * @defgroup Z_CBVPRINTF_PROCESS_FLAGS cbvprintf processing flags.
  * @{
  */
 


### PR DESCRIPTION
Fixed a couple typos and added `@deprecated` tags for deprecated macros.