### PR TITLE
lib: base64: doc: Promote to Utilities doc section

### DIFF
--- a/include/zephyr/sys/base64.h
+++ b/include/zephyr/sys/base64.h
@@ -32,6 +32,15 @@ extern "C" {
 #endif
 
 /**
+ * @file
+ *
+ * @defgroup base64 Base64
+ * @brief Base64 encoding/decoding functions
+ * @ingroup utilities
+ * @{
+ */
+
+/**
  * @brief          Encode a buffer into base64 format
  *
  * @param dst      destination buffer
@@ -71,6 +80,10 @@ int base64_encode(uint8_t *dst, size_t dlen, size_t *olen, const uint8_t *src,
  */
 int base64_decode(uint8_t *dst, size_t dlen, size_t *olen, const uint8_t *src,
 		  size_t slen);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Have base64 helpers show up in the Modules>Utilities section of the doc.