### PR TITLE
doc: include: Fix/improve docs for data structures

### DIFF
--- a/include/zephyr/sys/dlist.h
+++ b/include/zephyr/sys/dlist.h
@@ -6,6 +6,9 @@
 
 /**
  * @file
+ * @defgroup doubly-linked-list_apis Doubly-linked list
+ * @ingroup datastructure_apis
+ *
  * @brief Doubly-linked list implementation
  *
  * Doubly-linked list implementation using inline macros/functions.
@@ -15,6 +18,8 @@
  * The lists are expected to be initialized such that both the head and tail
  * pointers point to the list itself.  Initializing the lists in such a fashion
  * simplifies the adding and removing of nodes to/from the list.
+ *
+ * @{
  */
 
 #ifndef ZEPHYR_INCLUDE_SYS_DLIST_H_
@@ -28,11 +33,6 @@
 extern "C" {
 #endif
 
-/**
- * @defgroup doubly-linked-list_apis Doubly-linked list
- * @ingroup datastructure_apis
- * @{
- */
 
 struct _dnode {
 	union {

--- a/include/zephyr/sys/dlist.h
+++ b/include/zephyr/sys/dlist.h
@@ -45,7 +45,13 @@ struct _dnode {
 	};
 };
 
+/**
+ * @brief Doubly-linked list structure.
+ */
 typedef struct _dnode sys_dlist_t;
+/**
+ * @brief Doubly-linked list node structure.
+ */
 typedef struct _dnode sys_dnode_t;
 
 
@@ -116,7 +122,7 @@ typedef struct _dnode sys_dnode_t;
 	     __dn != NULL; __dn = __dns,				\
 		     __dns = sys_dlist_peek_next(__dl, __dn))
 
-/*
+/**
  * @brief Provide the primitive to resolve the container of a list node
  * Note: it is safe to use with NULL pointer nodes
  *
@@ -126,7 +132,7 @@ typedef struct _dnode sys_dnode_t;
  */
 #define SYS_DLIST_CONTAINER(__dn, __cn, __n) \
 	((__dn != NULL) ? CONTAINER_OF(__dn, __typeof__(*__cn), __n) : NULL)
-/*
+/**
  * @brief Provide the primitive to peek container of the list head
  *
  * @param __dl A pointer on a sys_dlist_t to peek
@@ -136,7 +142,7 @@ typedef struct _dnode sys_dnode_t;
 #define SYS_DLIST_PEEK_HEAD_CONTAINER(__dl, __cn, __n) \
 	SYS_DLIST_CONTAINER(sys_dlist_peek_head(__dl), __cn, __n)
 
-/*
+/**
  * @brief Provide the primitive to peek the next container
  *
  * @param __dl A pointer on a sys_dlist_t to peek
@@ -200,6 +206,9 @@ static inline void sys_dlist_init(sys_dlist_t *list)
 	list->tail = (sys_dnode_t *)list;
 }
 
+/**
+ * @brief Static initializer for a doubly-linked list
+ */
 #define SYS_DLIST_STATIC_INIT(ptr_to_list) { {(ptr_to_list)}, {(ptr_to_list)} }
 
 /**

--- a/include/zephyr/sys/rb.h
+++ b/include/zephyr/sys/rb.h
@@ -18,7 +18,10 @@
 
 /**
  * @file
- * @brief Red/Black balanced tree data structure
+ * @defgroup rbtree_apis Balanced Red/Black Tree
+ * @ingroup datastructure_apis
+ *
+ * @brief Balanced Red/Black Tree implementation
  *
  * This implements an intrusive balanced tree that guarantees
  * O(log2(N)) runtime for all operations and amortized O(1) behavior
@@ -38,6 +41,8 @@
  * structure of the tree being generated dynamically via a stack as
  * the tree is recursed.  So the overall memory overhead of a node is
  * just two pointers, identical with a doubly-linked list.
+ *
+ * @{
  */
 
 #ifndef ZEPHYR_INCLUDE_SYS_RB_H_
@@ -59,12 +64,6 @@ struct rbnode {
 #define Z_PBITS(t) (8 * sizeof(t))
 #define Z_MAX_RBTREE_DEPTH (2 * (Z_PBITS(int *) - Z_TBITS(int *) - 1) + 1)
 
-
- /**
-  * @defgroup rbtree_apis Balanced Red/Black Tree
-  * @ingroup datastructure_apis
-  * @{
-  */
 /**
  * @typedef rb_lessthan_t
  * @brief Red/black tree comparison predicate

--- a/include/zephyr/sys/rb.h
+++ b/include/zephyr/sys/rb.h
@@ -51,8 +51,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/**
+ * @brief Balanced red/black tree node structure
+ */
 struct rbnode {
+	/** @cond INTERNAL_HIDDEN */
 	struct rbnode *children[2];
+	/** @endcond */
 };
 
 /* Theoretical maximum depth of tree based on pointer size. If memory
@@ -79,16 +84,28 @@ struct rbnode {
  */
 typedef bool (*rb_lessthan_t)(struct rbnode *a, struct rbnode *b);
 
+/**
+ * @brief Balanced red/black tree structure
+ */
 struct rbtree {
+	/** Root node of the tree */
 	struct rbnode *root;
+	/** Comparison function for nodes in the tree */
 	rb_lessthan_t lessthan_fn;
+	/** @cond INTERNAL_HIDDEN */
 	int max_depth;
 #ifdef CONFIG_MISRA_SANE
 	struct rbnode *iter_stack[Z_MAX_RBTREE_DEPTH];
 	unsigned char iter_left[Z_MAX_RBTREE_DEPTH];
 #endif
+	/** @endcond */
 };
 
+/**
+ * @brief Prototype for node visitor callback.
+ * @param node Node being visited
+ * @param cookie User-specified data
+ */
 typedef void (*rb_visit_t)(struct rbnode *node, void *cookie);
 
 struct rbnode *z_rb_child(struct rbnode *node, uint8_t side);

--- a/include/zephyr/sys/rb.h
+++ b/include/zephyr/sys/rb.h
@@ -4,18 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Our SDK/toolchains integration seems to be inconsistent about
- * whether they expose alloca.h or not.  On gcc it's a moot point as
- * it's always builtin.
- */
-#ifdef __GNUC__
-#ifndef alloca
-#define alloca __builtin_alloca
-#endif
-#else
-#include <alloca.h>
-#endif
-
 /**
  * @file
  * @defgroup rbtree_apis Balanced Red/Black Tree
@@ -51,6 +39,18 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+
+/* Our SDK/toolchains integration seems to be inconsistent about
+ * whether they expose alloca.h or not.  On gcc it's a moot point as
+ * it's always builtin.
+ */
+#ifdef __GNUC__
+#ifndef alloca
+#define alloca __builtin_alloca
+#endif
+#else
+#include <alloca.h>
+#endif
 
 /**
  * @brief Balanced red/black tree node structure

--- a/include/zephyr/sys/rb.h
+++ b/include/zephyr/sys/rb.h
@@ -25,22 +25,23 @@
  *
  * This implements an intrusive balanced tree that guarantees
  * O(log2(N)) runtime for all operations and amortized O(1) behavior
- * for creation and destruction of whole trees.  The algorithms and
+ * for creation and destruction of whole trees. The algorithms and
  * naming are conventional per existing academic and didactic
  * implementations, c.f.:
  *
  * https://en.wikipedia.org/wiki/Red%E2%80%93black_tree
  *
  * The implementation is size-optimized to prioritize runtime memory
- * usage.  The data structure is intrusive, which is to say the struct
- * rbnode handle is intended to be placed in a separate struct the
- * same way other such structures (e.g. Zephyr's dlist list) and
- * requires no data pointer to be stored in the node.  The color bit
- * is unioned with a pointer (fairly common for such libraries).  Most
- * notably, there is no "parent" pointer stored in the node, the upper
- * structure of the tree being generated dynamically via a stack as
- * the tree is recursed.  So the overall memory overhead of a node is
- * just two pointers, identical with a doubly-linked list.
+ * usage. The data structure is intrusive, which is to say the @ref
+ * rbnode handle is intended to be placed in a separate struct, in the
+ * same way as with other such structures (e.g. Zephyr's @ref
+ * doubly-linked-list_apis), and requires no data pointer to be stored
+ * in the node. The color bit is unioned with a pointer (fairly common
+ * for such libraries). Most notably, there is no "parent" pointer
+ * stored in the node, the upper structure of the tree being generated
+ * dynamically via a stack as the tree is recursed. So the overall
+ * memory overhead of a node is just two pointers, identical with a
+ * doubly-linked list.
  *
  * @{
  */

--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -15,6 +15,7 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 /* The limit is used by algorithm for distinguishing between empty and full
  * state.
  */
@@ -22,11 +23,13 @@ extern "C" {
 
 #define RING_BUFFER_SIZE_ASSERT_MSG \
 	"Size too big"
+/** @endcond */
 
 /**
  * @brief A structure to represent a ring buffer
  */
 struct ring_buf {
+	/** @cond INTERNAL_HIDDEN */
 	uint8_t *buffer;
 	int32_t put_head;
 	int32_t put_tail;
@@ -35,6 +38,7 @@ struct ring_buf {
 	int32_t get_tail;
 	int32_t get_base;
 	uint32_t size;
+	/** @endcond */
 };
 
 /**

--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -1,11 +1,8 @@
-/* ring_buffer.h: Simple ring buffer API */
-
 /*
  * Copyright (c) 2015 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-/** @file */
 
 #ifndef ZEPHYR_INCLUDE_SYS_RING_BUFFER_H_
 #define ZEPHYR_INCLUDE_SYS_RING_BUFFER_H_
@@ -41,6 +38,16 @@ struct ring_buf {
 };
 
 /**
+ * @file
+ * @defgroup ring_buffer_apis Ring Buffer APIs
+ * @ingroup datastructure_apis
+ *
+ * @brief Simple ring buffer implementation.
+ *
+ * @{
+ */
+
+/**
  * @brief Function to force ring_buf internal states to given value
  *
  * Any value other than 0 makes sense only in validation testing context.
@@ -50,12 +57,6 @@ static inline void ring_buf_internal_reset(struct ring_buf *buf, int32_t value)
 	buf->put_head = buf->put_tail = buf->put_base = value;
 	buf->get_head = buf->get_tail = buf->get_base = value;
 }
-
-/**
- * @defgroup ring_buffer_apis Ring Buffer APIs
- * @ingroup datastructure_apis
- * @{
- */
 
 /**
  * @brief Define and initialize a ring buffer for byte data.

--- a/include/zephyr/sys/sflist.h
+++ b/include/zephyr/sys/sflist.h
@@ -4,15 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- *
- * @brief Single-linked list implementation
- *
- * Single-linked list implementation using inline macros/functions.
- * This API is not thread safe, and thus if a list is used across threads,
- * calls to functions must be protected with synchronization primitives.
- */
+ /**
+  * @file
+  * @defgroup flagged-single-linked-list_apis Flagged Single-linked list
+  * @ingroup datastructure_apis
+  *
+  * @brief Flagged single-linked list implementation.
+  *
+  * Similar to @ref single-linked-list_apis with the added ability to define
+  * two bits of user "flags" for each node. They can be accessed and modified
+  * using the sys_sfnode_flags_get() and sys_sfnode_flags_set() APIs.
+  *
+  * Flagged single-linked list implementation using inline macros/functions.
+  * This API is not thread safe, and thus if a list is used across threads,
+  * calls to functions must be protected with synchronization primitives.
+  *
+  * @{
+  */
 
 #ifndef ZEPHYR_INCLUDE_SYS_SFLIST_H_
 #define ZEPHYR_INCLUDE_SYS_SFLIST_H_
@@ -44,12 +52,6 @@ struct _sflist {
 };
 
 typedef struct _sflist sys_sflist_t;
-
- /**
-  * @defgroup flagged-single-linked-list_apis Flagged Single-linked list
-  * @ingroup datastructure_apis
-  * @{
-  */
 
 /**
  * @brief Provide the primitive to iterate on a list

--- a/include/zephyr/sys/sflist.h
+++ b/include/zephyr/sys/sflist.h
@@ -40,17 +40,23 @@ typedef uint64_t unative_t;
 typedef uint32_t unative_t;
 #endif
 
+/** @cond INTERNAL_HIDDEN */
 struct _sfnode {
 	unative_t next_and_flags;
 };
+/** @endcond */
 
+/** Flagged single-linked list node structure. */
 typedef struct _sfnode sys_sfnode_t;
 
+/** @cond INTERNAL_HIDDEN */
 struct _sflist {
 	sys_sfnode_t *head;
 	sys_sfnode_t *tail;
 };
+/** @endcond */
 
+/** Flagged single-linked list structure. */
 typedef struct _sflist sys_sflist_t;
 
 /**
@@ -113,7 +119,7 @@ typedef struct _sflist sys_sflist_t;
 #define SYS_SFLIST_FOR_EACH_NODE_SAFE(__sl, __sn, __sns)			\
 	Z_GENLIST_FOR_EACH_NODE_SAFE(sflist, __sl, __sn, __sns)
 
-/*
+/**
  * @brief Provide the primitive to resolve the container of a list node
  * Note: it is safe to use with NULL pointer nodes
  *
@@ -124,7 +130,7 @@ typedef struct _sflist sys_sflist_t;
 #define SYS_SFLIST_CONTAINER(__ln, __cn, __n) \
 	Z_GENLIST_CONTAINER(__ln, __cn, __n)
 
-/*
+/**
  * @brief Provide the primitive to peek container of the list head
  *
  * @param __sl A pointer on a sys_sflist_t to peek
@@ -134,7 +140,7 @@ typedef struct _sflist sys_sflist_t;
 #define SYS_SFLIST_PEEK_HEAD_CONTAINER(__sl, __cn, __n) \
 	Z_GENLIST_PEEK_HEAD_CONTAINER(sflist, __sl, __cn, __n)
 
-/*
+/**
  * @brief Provide the primitive to peek container of the list tail
  *
  * @param __sl A pointer on a sys_sflist_t to peek
@@ -144,7 +150,7 @@ typedef struct _sflist sys_sflist_t;
 #define SYS_SFLIST_PEEK_TAIL_CONTAINER(__sl, __cn, __n) \
 	Z_GENLIST_PEEK_TAIL_CONTAINER(sflist, __sl, __cn, __n)
 
-/*
+/**
  * @brief Provide the primitive to peek the next container
  *
  * @param __cn Container struct type pointer
@@ -207,6 +213,10 @@ static inline void sys_sflist_init(sys_sflist_t *list)
 	list->tail = NULL;
 }
 
+/**
+ * @brief Statically initialize a flagged single-linked list
+ * @param ptr_to_list A pointer on the list to initialize
+ */
 #define SYS_SFLIST_STATIC_INIT(ptr_to_list) {NULL, NULL}
 #define SYS_SFLIST_FLAGS_MASK	0x3UL
 

--- a/include/zephyr/sys/slist.h
+++ b/include/zephyr/sys/slist.h
@@ -29,17 +29,23 @@ extern "C" {
 #endif
 
 
+/** @cond INTERNAL_HIDDEN */
 struct _snode {
 	struct _snode *next;
 };
+/** @endcond */
 
+/** Single-linked list node structure. */
 typedef struct _snode sys_snode_t;
 
+/** @cond INTERNAL_HIDDEN */
 struct _slist {
 	sys_snode_t *head;
 	sys_snode_t *tail;
 };
+/** @endcond */
 
+/** Single-linked list structure. */
 typedef struct _slist sys_slist_t;
 
 /**
@@ -102,7 +108,7 @@ typedef struct _slist sys_slist_t;
 #define SYS_SLIST_FOR_EACH_NODE_SAFE(__sl, __sn, __sns)			\
 	Z_GENLIST_FOR_EACH_NODE_SAFE(slist, __sl, __sn, __sns)
 
-/*
+/**
  * @brief Provide the primitive to resolve the container of a list node
  * Note: it is safe to use with NULL pointer nodes
  *
@@ -113,7 +119,7 @@ typedef struct _slist sys_slist_t;
 #define SYS_SLIST_CONTAINER(__ln, __cn, __n) \
 	Z_GENLIST_CONTAINER(__ln, __cn, __n)
 
-/*
+/**
  * @brief Provide the primitive to peek container of the list head
  *
  * @param __sl A pointer on a sys_slist_t to peek
@@ -123,7 +129,7 @@ typedef struct _slist sys_slist_t;
 #define SYS_SLIST_PEEK_HEAD_CONTAINER(__sl, __cn, __n) \
 	Z_GENLIST_PEEK_HEAD_CONTAINER(slist, __sl, __cn, __n)
 
-/*
+/**
  * @brief Provide the primitive to peek container of the list tail
  *
  * @param __sl A pointer on a sys_slist_t to peek
@@ -133,7 +139,7 @@ typedef struct _slist sys_slist_t;
 #define SYS_SLIST_PEEK_TAIL_CONTAINER(__sl, __cn, __n) \
 	Z_GENLIST_PEEK_TAIL_CONTAINER(slist, __sl, __cn, __n)
 
-/*
+/**
  * @brief Provide the primitive to peek the next container
  *
  * @param __cn Container struct type pointer
@@ -196,6 +202,10 @@ static inline void sys_slist_init(sys_slist_t *list)
 	list->tail = NULL;
 }
 
+/**
+ * @brief Statically initialize a single-linked list
+ * @param ptr_to_list A pointer on the list to initialize
+ */
 #define SYS_SLIST_STATIC_INIT(ptr_to_list) {NULL, NULL}
 
 static inline sys_snode_t *z_snode_next_peek(sys_snode_t *node)

--- a/include/zephyr/sys/slist.h
+++ b/include/zephyr/sys/slist.h
@@ -4,15 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @file
- *
- * @brief Single-linked list implementation
- *
- * Single-linked list implementation using inline macros/functions.
- * This API is not thread safe, and thus if a list is used across threads,
- * calls to functions must be protected with synchronization primitives.
- */
+ /**
+  * @file
+  * @defgroup single-linked-list_apis Single-linked list
+  * @ingroup datastructure_apis
+  *
+  * @brief Single-linked list implementation.
+  *
+  * Single-linked list implementation using inline macros/functions.
+  * This API is not thread safe, and thus if a list is used across threads,
+  * calls to functions must be protected with synchronization primitives.
+  * @{
+  */
 
 #ifndef ZEPHYR_INCLUDE_SYS_SLIST_H_
 #define ZEPHYR_INCLUDE_SYS_SLIST_H_
@@ -38,12 +41,6 @@ struct _slist {
 };
 
 typedef struct _slist sys_slist_t;
-
- /**
-  * @defgroup single-linked-list_apis Single-linked list
-  * @ingroup datastructure_apis
-  * @{
-  */
 
 /**
  * @brief Provide the primitive to iterate on a list


### PR DESCRIPTION
A few fixes to improve the documentation for the data structures documented in Modules>Utilities>Data Structures

CI-built documentation can be viewed at: https://builds.zephyrproject.io/zephyr/pr/60591/docs/doxygen/html/group__datastructure__apis.html