### PR TITLE
tests: lib: c_lib: fix test_sqrt double promotion warnings

### DIFF
--- a/tests/lib/c_lib/src/test_sqrt.c
+++ b/tests/lib/c_lib/src/test_sqrt.c
@@ -167,8 +167,7 @@ int32_t *p_root_squared = (int32_t *)&root_squared;
 ZTEST(test_c_lib, test_sqrt)
 {
 int i;
-float	exponent;
-double	resd, error, square, root_squared;
+double	resd, error, square, root_squared, exponent;
 uint64_t max_error;
 int64_t ierror;
 int64_t *p_square = (int64_t *)&square;


### PR DESCRIPTION
Double promotion warnings are generated with the flag -Wdouble-promotion