### PR TITLE
xtensa: allow arch-specific arch_spin_relax() with more NOPs

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -103,6 +103,22 @@ config XTENSA_CCOUNT_HZ
 	  Rate in HZ of the Xtensa core as measured by the value of
 	  the CCOUNT register.
 
+config XTENSA_MORE_SPIN_RELAX_NOPS
+	bool "Use Xtensa specific arch_spin_relax() with more NOPs"
+	help
+	  Some Xtensa SoCs, especially under SMP, may need extra
+	  NOPs after failure to lock a spinlock. This gives
+	  the bus extra time to synchronize the RCW transaction
+	  among CPUs.
+
+config XTENSA_NUM_SPIN_RELAX_NOPS
+	int "Number of NOPs to be used in arch_spin_relax()"
+	default 1
+	depends on XTENSA_MORE_SPIN_RELAX_NOPS
+	help
+	  Specify the number of NOPs in Xtensa specific
+	  arch_spin_relax().
+
 if CPU_HAS_MMU
 
 config XTENSA_MMU

--- a/arch/xtensa/core/xtensa-asm2.c
+++ b/arch/xtensa/core/xtensa-asm2.c
@@ -455,3 +455,16 @@ int z_xtensa_irq_is_enabled(unsigned int irq)
 
 	return (ie & (1 << irq)) != 0U;
 }
+
+#ifdef CONFIG_XTENSA_MORE_SPIN_RELAX_NOPS
+/* Some compilers might "optimize out" (i.e. remove) continuous NOPs.
+ * So force no optimization to avoid that.
+ */
+__no_optimization
+void arch_spin_relax(void)
+{
+#define NOP1(_, __) __asm__ volatile("nop.n;");
+	LISTIFY(CONFIG_XTENSA_NUM_SPIN_RELAX_NOPS, NOP1, (;))
+#undef NOP1
+}
+#endif /* CONFIG_XTENSA_MORE_SPIN_RELAX_NOPS */


### PR DESCRIPTION
This adds a Kconfig to introduce the Xtensa specific arch_spin_relax() which can do more NOPs. Some Xtensa SoCs may need more NOPs after failure to lock a spinlock, especially under SMP. This gives the bus extra time to propagate the RCW transactions among CPUs.