### PR TITLE
tests: lib: cbprintf_package: fix long-double promotion warning

### DIFF
--- a/tests/lib/cbprintf_package/src/main.c
+++ b/tests/lib/cbprintf_package/src/main.c
@@ -148,7 +148,7 @@ ZTEST(cbprintf_package, test_cbprintf_package)
 		TEST_PACKAGING(0, "test %f %a", (double)f, d);
 #if CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE && !(defined(CONFIG_RISCV) && !defined(CONFIG_64BIT))
 		/* Excluding riscv32 which does not handle long double correctly. */
-		long double ld = 1.2333;
+		long double ld = 1.2333L;
 
 		TEST_PACKAGING(0, "test %Lf", ld);
 #endif


### PR DESCRIPTION
Long Double promotion warnings are generated with the flag -Wdouble-promotion