### PR TITLE
ITE: drivers/i2c: Modify the condition of assert

### DIFF
--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -1232,11 +1232,9 @@ static const struct i2c_driver_api i2c_it8xxx2_driver_api = {
 };
 
 #ifdef CONFIG_I2C_IT8XXX2_FIFO_MODE
-BUILD_ASSERT(((DT_INST_PROP(SMB_CHANNEL_B, fifo_enable) == true) &&
-	     (DT_INST_PROP(SMB_CHANNEL_C, fifo_enable) == false)) ||
-	     ((DT_INST_PROP(SMB_CHANNEL_B, fifo_enable) == false) &&
+BUILD_ASSERT(!((DT_INST_PROP(SMB_CHANNEL_B, fifo_enable) == true) &&
 	     (DT_INST_PROP(SMB_CHANNEL_C, fifo_enable) == true)),
-	     "FIFO2 only supports one channel of B or C.");
+	     "Channel B and C cannot support FIFO mode at the same time.");
 #endif
 
 #define I2C_ITE_IT8XXX2_INIT(inst)                                              \


### PR DESCRIPTION
Channel B or C do not necessarily have to use FIFO mode.