### PR TITLE
drivers: counter: stm32: Use const TIM_TypeDef on c0/l1/wba series

### DIFF
--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -42,13 +42,10 @@ static void(*const set_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *,
 };
 
 /** Channel to compare get function mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32C0X) && \
-	!defined(CONFIG_SOC_SERIES_STM32F1X) && \
+#if !defined(CONFIG_SOC_SERIES_STM32F1X) && \
 	!defined(CONFIG_SOC_SERIES_STM32F4X) && \
 	!defined(CONFIG_SOC_SERIES_STM32G4X) && \
-	!defined(CONFIG_SOC_SERIES_STM32L1X) && \
-	!defined(CONFIG_SOC_SERIES_STM32MP1X) && \
-	!defined(CONFIG_SOC_SERIES_STM32WBAX)
+	!defined(CONFIG_SOC_SERIES_STM32MP1X)
 static uint32_t(*const get_timer_compare[TIMER_MAX_CH])(const TIM_TypeDef *) = {
 	LL_TIM_OC_GetCompareCH1, LL_TIM_OC_GetCompareCH2,
 	LL_TIM_OC_GetCompareCH3, LL_TIM_OC_GetCompareCH4,
@@ -73,13 +70,10 @@ static void(*const disable_it[TIMER_MAX_CH])(TIM_TypeDef *) = {
 
 #ifdef CONFIG_ASSERT
 /** Channel to interrupt enable check function mapping. */
-#if !defined(CONFIG_SOC_SERIES_STM32C0X) && \
-	!defined(CONFIG_SOC_SERIES_STM32F1X) && \
+#if !defined(CONFIG_SOC_SERIES_STM32F1X) && \
 	!defined(CONFIG_SOC_SERIES_STM32F4X) && \
 	!defined(CONFIG_SOC_SERIES_STM32G4X) && \
-	!defined(CONFIG_SOC_SERIES_STM32L1X) && \
-	!defined(CONFIG_SOC_SERIES_STM32MP1X) && \
-	!defined(CONFIG_SOC_SERIES_STM32WBAX)
+	!defined(CONFIG_SOC_SERIES_STM32MP1X)
 static uint32_t(*const check_it_enabled[TIMER_MAX_CH])(const TIM_TypeDef *) = {
 	LL_TIM_IsEnabledIT_CC1, LL_TIM_IsEnabledIT_CC2,
 	LL_TIM_IsEnabledIT_CC3, LL_TIM_IsEnabledIT_CC4,


### PR DESCRIPTION
A recent Cube update moved C0/L1/WBA to use const TIM_TypeDef
Align counter driver implementation.