### PR TITLE
tracing_user: don't run sample instead of not compiling the code

### DIFF
--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -10,6 +10,7 @@ common:
       - "thread_b: Hello World from (.*)!"
 tests:
   sample.tracing.user:
+    filter: not (CONFIG_X86_EFI_CONSOLE and CONFIG_UART_CONSOLE)
     extra_args: CONF_FILE="prj_user.conf"
     integration_platforms:
       - qemu_x86

--- a/subsys/tracing/user/tracing_user.c
+++ b/subsys/tracing/user/tracing_user.c
@@ -54,9 +54,6 @@ void sys_trace_thread_name_set(struct k_thread *thread)
 
 void sys_trace_k_thread_switched_in(void)
 {
-/* FIXME: Limitation of the current x86 EFI cosnole implementation. */
-#if !defined(CONFIG_X86_EFI_CONSOLE) && !defined(CONFIG_UART_CONSOLE)
-
 	unsigned int key = irq_lock();
 
 	__ASSERT_NO_MSG(nested_interrupts[_current_cpu->id] == 0);
@@ -64,12 +61,10 @@ void sys_trace_k_thread_switched_in(void)
 	sys_trace_thread_switched_in_user(z_current_get());
 
 	irq_unlock(key);
-#endif
 }
 
 void sys_trace_k_thread_switched_out(void)
 {
-#if !defined(CONFIG_X86_EFI_CONSOLE) && !defined(CONFIG_UART_CONSOLE)
 	unsigned int key = irq_lock();
 
 	__ASSERT_NO_MSG(nested_interrupts[_current_cpu->id] == 0);
@@ -77,7 +72,6 @@ void sys_trace_k_thread_switched_out(void)
 	sys_trace_thread_switched_out_user(z_current_get());
 
 	irq_unlock(key);
-#endif
 }
 
 void sys_trace_thread_info(struct k_thread *thread)


### PR DESCRIPTION
#46918 disabled the tracing_user's k_thread_switched_in/out
as their implementation in the sample test uses printk which
probably caused some tests to fail at the time when both the
X86_EFI_CONSOLE & UART_CONSOLE are set, but the user's
implementation doesn't really relate to the tracing_user APIs,
the better way to do this would be to bar this specific configs
from running that test.

fixes #60295

quick and simple [test](https://godbolt.org/z/GcGf7avMs)
cc @dennisgr102 @alpsayin 