### PR TITLE
doc: mqtt: Add missing Doxygen comments

### DIFF
--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -11,9 +11,6 @@
  * @{
  * @brief MQTT Client Implementation
  *
- * @details
- * MQTT Client's Application interface is defined in this header.
- *
  * @note The implementation assumes TCP module is enabled.
  *
  * @note By default the implementation uses MQTT version 3.1.1.
@@ -207,36 +204,45 @@ struct mqtt_connack_param {
 
 /** @brief Parameters for MQTT publish acknowledgment (PUBACK). */
 struct mqtt_puback_param {
+	/** Message id of the PUBLISH message being acknowledged */
 	uint16_t message_id;
 };
 
 /** @brief Parameters for MQTT publish receive (PUBREC). */
 struct mqtt_pubrec_param {
+	/** Message id of the PUBLISH message being acknowledged */
 	uint16_t message_id;
 };
 
 /** @brief Parameters for MQTT publish release (PUBREL). */
 struct mqtt_pubrel_param {
+	/** Message id of the PUBREC message being acknowledged */
 	uint16_t message_id;
 };
 
 /** @brief Parameters for MQTT publish complete (PUBCOMP). */
 struct mqtt_pubcomp_param {
+	/** Message id of the PUBREL message being acknowledged */
 	uint16_t message_id;
 };
 
 /** @brief Parameters for MQTT subscription acknowledgment (SUBACK). */
 struct mqtt_suback_param {
+	/** Message id of the SUBSCRIBE message being acknowledged */
 	uint16_t message_id;
+	/** Return codes indicating maximum QoS level granted for each topic
+	 *  in the subscription list.
+	 */
 	struct mqtt_binstr return_codes;
 };
 
 /** @brief Parameters for MQTT unsubscribe acknowledgment (UNSUBACK). */
 struct mqtt_unsuback_param {
+	/** Message id of the UNSUBSCRIBE message being acknowledged */
 	uint16_t message_id;
 };
 
-/** @brief Parameters for a publish message. */
+/** @brief Parameters for a publish message (PUBLISH). */
 struct mqtt_publish_param {
 	/** Messages including topic, QoS and its payload (if any)
 	 *  to be published.


### PR DESCRIPTION
Completed the documentation of the mqtt.h header file.