### PR TITLE
drivers: ethernet: adin2111: add adin1110 support

### DIFF
--- a/drivers/ethernet/Kconfig.adin2111
+++ b/drivers/ethernet/Kconfig.adin2111
@@ -4,7 +4,7 @@
 menuconfig ETH_ADIN2111
 	bool "ADIN2111 2-port 10BASE-T1L Controller"
 	default y
-	depends on DT_HAS_ADI_ADIN2111_ENABLED
+	depends on DT_HAS_ADI_ADIN2111_ENABLED || DT_HAS_ADI_ADIN1110_ENABLED
 	select SPI
 	select MDIO
 	help

--- a/drivers/ethernet/eth_adin2111_priv.h
+++ b/drivers/ethernet/eth_adin2111_priv.h
@@ -20,6 +20,7 @@
 #define ADIN2111_PHYID				0x01U
 /* PHY Identification Register Reset Value */
 #define ADIN2111_PHYID_RST_VAL			0x0283BCA1U
+#define ADIN1110_PHYID_RST_VAL			0x0283BC91U
 
 /* Reset Control and Status Register */
 #define ADIN2111_RESET				0x03U
@@ -157,7 +158,13 @@
 /* Number of buffer bytes in TxFIFO to provide frame margin upon writes */
 #define ADIN2111_TX_FIFO_BUFFER_MARGIN		4U
 
+enum adin2111_chips_id {
+	ADIN2111_MAC = 0,
+	ADIN1110_MAC,
+};
+
 struct adin2111_config {
+	enum adin2111_chips_id id;
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec interrupt;
 	struct gpio_dt_spec reset;

--- a/drivers/ethernet/phy/phy_adin2111.c
+++ b/drivers/ethernet/phy/phy_adin2111.c
@@ -35,6 +35,7 @@ LOG_MODULE_REGISTER(phy_adin2111, CONFIG_PHY_LOG_LEVEL);
 
 /* ADIN2111 PHY identifier */
 #define ADIN2111_PHY_ID						0x0283BCA1U
+#define ADIN1110_PHY_ID						0x0283BC91U
 
 /* 10BASE-T1L PMA Status Register */
 #define ADIN2111_PHY_PMA_STATUS					0x000108F7U
@@ -353,7 +354,7 @@ static int phy_adin2111_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (phy_id != ADIN2111_PHY_ID) {
+	if (phy_id != ADIN2111_PHY_ID && phy_id != ADIN1110_PHY_ID) {
 		LOG_ERR("PHY %u unexpected PHY ID %X", cfg->phy_addr, phy_id);
 		return -EINVAL;
 	}

--- a/dts/bindings/ethernet/adi,adin1110.yaml
+++ b/dts/bindings/ethernet/adi,adin1110.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 Analog Devices Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  ADIN1110 standalone 10BASE-T1L Ethernet controller with SPI interface.
+
+  An example:
+
+  adin1110: adin1110@0 {
+          compatible = "adi,adin1110";
+          reg = <0x0>;
+          spi-max-frequency = <25000000>;
+          int-gpios   = <&gpioe 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+          reset-gpios = <&gpioe 8 GPIO_ACTIVE_LOW>;
+          port1 {
+              local-mac-address = [ CA 2F B7 10 23 63 ];
+          };
+          mdio: mdio {
+                  compatible = "adi,adin2111-mdio";
+                  status = "okay";
+                  #address-cells = <1>;
+                  #size-cells = <0>;
+                  phy@1 {
+                    reg = <0x1>;
+                    compatible = "adi,adin2111-phy";
+                    status = "okay";
+                  };
+          };
+  };
+
+compatible: "adi,adin1110"
+
+include: adi,adin2111.yaml


### PR DESCRIPTION
The ADIN1110 is an ultra low power, single port, 10BASE-T1L transceiver design for industrial Ethernet applications and is com- pliant with the IEEE® 802.3cg-2019™ Ethernet standard for long reach, 10 Mbps single pair Ethernet (SPE). Featuring an integrated media access control (MAC) interface, the ADIN1110 enables direct connectivity with a variety of host controllers via a 4-wire serial peripheral interface (SPI). This SPI enables the use of lower power processors without an integrated MAC, which provides for the lowest overall system level power consumption. The SPI can be configured to use the Open Alliance SPI protocol or a generic SPI protocol.

Documentation:
https://www.analog.com/en/products/adin1110.html