### PR TITLE
  drivers: i2c: stm32 i2c driver supports 10-bit addressing

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -120,18 +120,25 @@ static void stm32_i2c_slave_event(const struct device *dev)
 	I2C_TypeDef *i2c = cfg->i2c;
 	const struct i2c_target_callbacks *slave_cb;
 	struct i2c_target_config *slave_cfg;
-	uint8_t slave_address;
 
-	/* Choose the right slave from the address match code */
-	slave_address = LL_I2C_GetAddressMatchCode(i2c) >> 1;
-	if (data->slave_cfg != NULL && slave_address == data->slave_cfg->address) {
-		slave_cfg = data->slave_cfg;
-	} else if (data->slave2_cfg != NULL && slave_address == data->slave2_cfg->address) {
-		slave_cfg = data->slave2_cfg;
-	} else {
-		__ASSERT_NO_MSG(0);
-		return;
+	if (data->slave_cfg->flags != I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		uint8_t slave_address;
+
+		/* Choose the right slave from the address match code */
+		slave_address = LL_I2C_GetAddressMatchCode(i2c) >> 1;
+		if (data->slave_cfg != NULL &&
+				slave_address == data->slave_cfg->address) {
+			slave_cfg = data->slave_cfg;
+		} else if (data->slave2_cfg != NULL &&
+				slave_address == data->slave2_cfg->address) {
+			slave_cfg = data->slave2_cfg;
+		} else {
+			__ASSERT_NO_MSG(0);
+			return;
+		}
 	}
+
+	slave_cfg = data->slave_cfg;
 	slave_cb = slave_cfg->callbacks;
 
 	if (LL_I2C_IsActiveFlag_TXIS(i2c)) {


### PR DESCRIPTION
  When slave_address is 10 bits, data type should be
    uint16_t instead of uint8_t,
    like the data typeof data->slave_cfg->address.

This applies to the stm32 I2C V2 driver.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55987