### PR TITLE
footprint: Add BT TMAP broadcast samples

### DIFF
--- a/scripts/footprint/plan.txt
+++ b/scripts/footprint/plan.txt
@@ -23,6 +23,8 @@ bt_unicast_audio_client,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/unica
 bt_unicast_audio_server,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/unicast_audio_server,
 bt_tmap_central,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/tmap_central,
 bt_tmap_peripheral,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/tmap_peripheral,
+bt_tmap_bms,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/tmap_bms,
+bt_tmap_bmr,default,nrf5340dk_nrf5340_cpuapp,samples/bluetooth/tmap_bmr,
 bt_hci_rpmsg,default,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,
 bt_hci_rpmsg,iso-broadcast,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,-DCONF_FILE=nrf5340_cpunet_iso_broadcast-bt_ll_sw_split.conf
 bt_hci_rpmsg,iso-receive,nrf5340dk_nrf5340_cpunet,samples/bluetooth/hci_rpmsg,-DCONF_FILE=nrf5340_cpunet_iso_receive-bt_ll_sw_split.conf


### PR DESCRIPTION
Add the BT Telephony and Media Audio Profile broadcast samples. These reflect devices that control telephone and media audio of LE Audio.