### PR TITLE
Minor updates to the nrf52_bsim

### DIFF
--- a/boards/posix/nrf52_bsim/doc/index.rst
+++ b/boards/posix/nrf52_bsim/doc/index.rst
@@ -19,16 +19,18 @@ This board models some of the NRF52 SOC peripherals:
 
 * Radio
 * Timers
-* Real time counter
-* Random number generator
+* RTC (Real Time Counter)
+* RNG (Random Number Generator)
 * AES CCM & AES ECB encryption HW
-* Accelerated address resolver
-* Clock control
+* AAR (Accelerated Address Resolver)
+* CLOCK (Clock control)
 * PPI (Programmable Peripheral Interconnect)
 * EGU (Event Generator Unit)
+* GPIO & GPIOTE
 * TEMP (Temperature sensor)
-* UICR (User information configuration registers)
-* NVMC (Non-volatile memory controller)
+* UICR (User Information Configuration Registers)
+* FICR (Factory Information Configuration Registers)
+* NVMC (Non-Volatile Memory Controller)
 
 The nrf52_bsim board definition uses the POSIX architecture to
 run applications natively on the development system, this has the benefit of

--- a/west.yml
+++ b/west.yml
@@ -287,7 +287,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 33b999d50093da88cf935383da2bdac70ffd9456
+      revision: 7a5b67d9ee66d84e4ef5cb1f56c8f0f3252d5aa2
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: c904a01d4a882bcbb39987e0e2ce5308f49ac7ad


### PR DESCRIPTION
    manifest: Update nRF HW models to latest
    
    Which include a more complete model of the CLOCK peripheral.
    
-----

    doc: nrf52_bsim: Update list of supported peripherals
    
    The GPIO, GPIOTE and FICR are now also modeled to a reasonable degree.
    
