### PR TITLE
drivers: sdhc: enable pwr-gpios property within SPI SDHC driver

### DIFF
--- a/drivers/sdhc/sdhc_spi.c
+++ b/drivers/sdhc/sdhc_spi.c
@@ -738,14 +738,25 @@ static int sdhc_spi_init(const struct device *dev)
 {
 	const struct sdhc_spi_config *cfg = dev->config;
 	struct sdhc_spi_data *data = dev->data;
+	int ret = 0;
 
 	if (!device_is_ready(cfg->spi_dev)) {
 		return -ENODEV;
 	}
+	if (cfg->pwr_gpio.port) {
+		if (!gpio_is_ready_dt(&cfg->pwr_gpio)) {
+			return -ENODEV;
+		}
+		ret = gpio_pin_configure_dt(&cfg->pwr_gpio, GPIO_OUTPUT_INACTIVE);
+		if (ret != 0) {
+			LOG_ERR("Could not configure power gpio (%d)", ret);
+			return ret;
+		}
+	}
 	data->power_mode = SDHC_POWER_OFF;
 	data->spi_cfg = &data->cfg_a;
 	data->spi_cfg->frequency = 0;
-	return 0;
+	return ret;
 }
 
 static struct sdhc_driver_api sdhc_spi_api = {

--- a/dts/bindings/sdhc/zephyr,sdhc-spi-slot.yaml
+++ b/dts/bindings/sdhc/zephyr,sdhc-spi-slot.yaml
@@ -27,4 +27,11 @@ properties:
       capture will occur on low to high transition and high to low if
       this option is not set (default).
 
+  pwr-gpios:
+    type: phandle-array
+    description: |
+      Power pin
+      This pin defaults to active high when consumed by the SPI SDHC driver.
+      It can be used to toggle card power via an external control circuit
+
 bus: sd


### PR DESCRIPTION
Enable SPI SDHC driver to manage card power via pwr-gpios property. Control for this property was previously partially implemented. When this property is present, the SPI SDHC driver will use it to control power to the SD card.

Power is toggled during SD init, so this power control can make SD init more reliable as the power toggle will insure the SD card state is reset.