### PR TITLE
libc: remove no longer valid kconfig comment

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -37,7 +37,6 @@ config PICOLIBC_SUPPORTED
 	depends on !NATIVE_APPLICATION
 	depends on ("$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr") || (NATIVE_LIBRARY)
 	depends on !(CPP && "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr")
-	# picolibc text is outside .pinned.text on this board. #54148
 	default y
 	select FULL_LIBC_SUPPORTED
 	help


### PR DESCRIPTION
After commit 9a0aebc5fd9c39fb3d4a4a9741fcff7e1695e807, the exclusion of qemu_x86_tiny is no longer and the "depends on" option was removed. However, the comment about that remained. Remove the comment as it is no longer valid.