### PR TITLE
drivers: gpio: fix coverity memory overwrite error

### DIFF
--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -82,7 +82,7 @@ static int imx_gpio_configure(const struct device *port, gpio_pin_t pin,
 
 	/* Init pin configuration struct, and use pinctrl api to apply settings */
 	__ASSERT_NO_MSG(pin < config->mux_count);
-	memcpy(&pin_cfg.pinmux, &config->pin_muxes[pin], sizeof(pin_cfg));
+	memcpy(&pin_cfg.pinmux, &config->pin_muxes[pin], sizeof(pin_cfg.pinmux));
 	/* cfg register will be set by pinctrl_configure_pins */
 	pin_cfg.pin_ctrl_flags = reg;
 	pinctrl_configure_pins(&pin_cfg, 1, PINCTRL_REG_NONE);

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -186,7 +186,7 @@ static int mcux_igpio_configure(const struct device *dev,
 	}
 #endif /* CONFIG_SOC_SERIES_IMX_RT10XX */
 
-	memcpy(&pin_cfg.pinmux, &config->pin_muxes[cfg_idx], sizeof(pin_cfg));
+	memcpy(&pin_cfg.pinmux, &config->pin_muxes[cfg_idx], sizeof(pin_cfg.pinmux));
 	/* cfg register will be set by pinctrl_configure_pins */
 	pin_cfg.pin_ctrl_flags = reg;
 	pinctrl_configure_pins(&pin_cfg, 1, PINCTRL_REG_NONE);


### PR DESCRIPTION
drivers: gpio: fix coverity memory overwrite error

memcpy of a sub-structure in a structure was using the structure size
of the parent structure instead of the sub-structure.

fixes: https://github.com/zephyrproject-rtos/zephyr/issues/59548

Signed-off-by: David Leach <david.leach@nxp.com>