### PR TITLE
kconfig: Deprecate MP_NUM_CPUS

### DIFF
--- a/boards/x86/acrn/doc/index.rst
+++ b/boards/x86/acrn/doc/index.rst
@@ -125,7 +125,7 @@ Configure Zephyr CPUs
 Now you need to configure the CPU environment ACRN presents to the
 guest.  By default Zephyr builds in SMP mode, but ACRN's default
 configuration gives it only one CPU.  Find the value of
-``CONFIG_MP_NUM_CPUS`` in the Zephyr .config file give the guest that
+``CONFIG_MP_MAX_NUM_CPUS`` in the Zephyr .config file give the guest that
 many CPUs in the ``<cpu_affinity>`` tag.  For example:
 
     .. code-block:: xml

--- a/doc/kernel/services/smp/smp.rst
+++ b/doc/kernel/services/smp/smp.rst
@@ -18,7 +18,7 @@ variable.  This must be set to "y" to enable SMP features, otherwise
 a uniprocessor kernel will be built.  In general the platform default
 will have enabled this anywhere it's supported. When enabled, the
 number of physical CPUs available is visible at build time as
-:kconfig:option:`CONFIG_MP_NUM_CPUS`.  Likewise, the default for this will be the
+:kconfig:option:`CONFIG_MP_MAX_NUM_CPUS`.  Likewise, the default for this will be the
 number of available CPUs on the platform and it is not expected that
 typical apps will change it.  But it is legal and supported to set
 this to a smaller (but obviously not larger) number for special

--- a/drivers/mbox/mbox_andes_plic_sw.c
+++ b/drivers/mbox/mbox_andes_plic_sw.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(mbox_andes_plic_sw);
 static struct mbox_andes_data {
 	mbox_callback_t cb[IPI_NUM];
 	void *user_data[IPI_NUM];
-	uint32_t enabled_channel[CONFIG_MP_NUM_CPUS];
+	uint32_t enabled_channel[CONFIG_MP_MAX_NUM_CPUS];
 #ifdef CONFIG_SCHED_IPI_SUPPORTED
 	uint32_t reg_cb_channel;
 	uint32_t ipi_channel;

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -1020,12 +1020,12 @@ config TRACE_SCHED_IPI
 	  to check if schedule IPI has called or not, for testing
 	  purpose.
 	depends on SCHED_IPI_SUPPORTED
-	depends on MP_NUM_CPUS>1
+	depends on MP_MAX_NUM_CPUS>1
 
 config KERNEL_COHERENCE
 	bool "Place all shared data into coherent memory"
 	depends on ARCH_HAS_COHERENCE
-	default y if SMP && MP_NUM_CPUS > 1
+	default y if SMP && MP_MAX_NUM_CPUS > 1
 	select THREAD_STACK_INFO
 	help
 	  When available and selected, the kernel will build in a mode

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -987,12 +987,11 @@ config SMP_BOOT_DELAY
 	  secondary CPUs at a later time.
 
 config MP_NUM_CPUS
-	int "Number of CPUs/cores"
+	int "Number of CPUs/cores [DEPRECATED]"
 	default MP_MAX_NUM_CPUS
 	range 1 12
 	help
-	  Number of multiprocessing-capable cores available to the
-	  multicpu API and SMP features.
+	  This is deprecated, please use MP_MAX_NUM_CPUS instead.
 
 config MP_MAX_NUM_CPUS
 	int "Maximum number of CPUs/cores"

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -35,7 +35,7 @@ config BASE64
 
 config PRINTK_SYNC
 	bool "Serialize printk() calls"
-	default y if SMP && MP_NUM_CPUS > 1 && !(EFI_CONSOLE && LOG)
+	default y if SMP && MP_MAX_NUM_CPUS > 1 && !(EFI_CONSOLE && LOG)
 	help
 	  When true, a spinlock will be taken around the output from a
 	  single printk() call, preventing the output data from

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -257,7 +257,7 @@ config ASSERT_LEVEL
 config SPIN_VALIDATE
 	bool "Spinlock validation"
 	depends on MULTITHREADING
-	depends on MP_NUM_CPUS <= 4
+	depends on MP_MAX_NUM_CPUS <= 4
 	default y if !FLASH || FLASH_SIZE > 32
 	help
 	  There's a spinlock validation framework available when asserts are

--- a/tests/posix/pthread_pressure/Kconfig
+++ b/tests/posix/pthread_pressure/Kconfig
@@ -6,8 +6,8 @@ source "Kconfig.zephyr"
 
 config TEST_NUM_CPUS
 	int "Number of CPUs to use in parallel"
-	range 1 MP_NUM_CPUS
-	default MP_NUM_CPUS
+	range 1 MP_MAX_NUM_CPUS
+	default MP_MAX_NUM_CPUS
 	help
 	  The number of parallel threads to run during the test.
 


### PR DESCRIPTION
Zephyr's code base uses MP_MAX_NUM_CPUS to
know how many cores exists in the target. It is
also expected that both symbols MP_MAX_NUM_CPUS
and MP_NUM_CPUS have the same value, so lets
just keep MP_MAX_NUM_CPUS and simplify it.