### PR TITLE
drivers: flash: spi_nor: Allow page-size to be set via devicetree

### DIFF
--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -19,7 +19,8 @@ choice SPI_NOR_SFDP
 config SPI_NOR_SFDP_MINIMAL
 	bool "Fixed flash configuration"
 	help
-	  Synthesize a minimal configuration assuming 256 By page size and
+	  Synthesize a minimal configuration assuming 256 By page size (or as
+	  set by the page-size devicetree property) and
 	  standard 4 KiBy and 64 KiBy erase instructions.  Requires the size and
 	  jedec-id properties in the devicetree jedec,spi-nor node.
 

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -226,7 +226,7 @@ static inline uint32_t dev_flash_size(const struct device *dev)
 static inline uint16_t dev_page_size(const struct device *dev)
 {
 #ifdef CONFIG_SPI_NOR_SFDP_MINIMAL
-	return 256;
+	return DT_INST_PROP_OR(0, page_size, 256);
 #else /* CONFIG_SPI_NOR_SFDP_MINIMAL */
 	const struct spi_nor_data *data = dev->data;
 

--- a/dts/bindings/mtd/jedec,jesd216.yaml
+++ b/dts/bindings/mtd/jedec,jesd216.yaml
@@ -68,3 +68,16 @@ properties:
       addressing is require to access the full address range, and
       automatically puts the device into 4-byte address mode when the device
       is initialized.
+
+  page-size:
+    type: int
+    description: |
+      Number of bytes in a page from JESD216 BFP DW11
+
+      This property is only used in the CONFIG_SPI_NOR_SFDP_MINIMAL configuration.
+      It is ignored if the device is configured to use SFDP data
+      from the sfdp-bfp property (CONFIG_SPI_NOR_SFDP_DEVICETREE) or
+      if the SFDP parameters are read from the device at
+      runtime (CONFIG_SPI_NOR_SFDP_RUNTIME).
+
+      The default value is 256 bytes if the value is not specified.


### PR DESCRIPTION
Allow page-size to be set via devicetree
In the CONFIG_SPI_NOR_SFDP_MINIMAL configuration this value is hard coded to 256 bytes. Make it configurable via devicetree.