### PR TITLE
tests: build_all: input: add an alternate setting test case

### DIFF
--- a/tests/drivers/build_all/input/testcase.yaml
+++ b/tests/drivers/build_all/input/testcase.yaml
@@ -1,7 +1,15 @@
+common:
+  tags:
+    - drivers
+    - input
+  build_only: true
+  platform_allow: native_posix
 tests:
-  drivers.input.build:
-    tags:
-      - drivers
-      - input
-    build_only: true
-    platform_allow: native_posix
+  drivers.input.default: {}
+
+  # Touchscreen drivers, non-default option
+  drivers.input.touchscreen_interrupt:
+    extra_configs:
+      - CONFIG_INPUT_CST816S_INTERRUPT=n
+      - CONFIG_INPUT_FT5336_INTERRUPT=y
+      - CONFIG_INPUT_GT911_INTERRUPT=y


### PR DESCRIPTION
Many touchscreen drivers have an option interrupt mode that enables a different code path. Add an extra test for touchscreen drivers to build the non-default case.

---

This should spot issues like https://github.com/zephyrproject-rtos/zephyr/pull/60640