### PR TITLE
posix: eventfd: remove redundant conditional

### DIFF
--- a/lib/posix/eventfd.c
+++ b/lib/posix/eventfd.c
@@ -435,9 +435,8 @@ int eventfd(unsigned int initval, int flags)
 	if (initval != 0) {
 		k_poll_signal_raise(&efd->read_sig, 0);
 	}
-	if (initval < UINT64_MAX - 1) {
-		k_poll_signal_raise(&efd->write_sig, 0);
-	}
+
+	k_poll_signal_raise(&efd->write_sig, 0);
 
 	z_finalize_fd(fd, efd, &eventfd_fd_vtable);
 


### PR DESCRIPTION
Since the argument is a 32-bit unsigned int, all possible values satisfy the condition that `intval < UINT64_MAX - 1`.

Remove the redundant conditional.

Fixes #60483