### PR TITLE
canbus: isotp: ISO-TP padding refactor

### DIFF
--- a/subsys/canbus/isotp/Kconfig
+++ b/subsys/canbus/isotp/Kconfig
@@ -51,7 +51,7 @@ config ISOTP_CR_TIMEOUT
 config ISOTP_REQUIRE_RX_PADDING
 	bool "Require padding for received messages"
 	help
-	  If enabled, SFs and the last CF must always have a DLC of 8 bytes
+	  If enabled, SFs, FCs and the last CF must always have a DLC of 8 bytes
 	  (for classic CAN) and unused bytes must be padded by the sending
 	  device. This setting allows to be compliant to AUTOSAR Specification
 	  of CAN Transport Layer.

--- a/subsys/canbus/isotp/Kconfig
+++ b/subsys/canbus/isotp/Kconfig
@@ -60,6 +60,7 @@ config ISOTP_REQUIRE_RX_PADDING
 
 config ISOTP_ENABLE_TX_PADDING
 	bool "Padding for transmitted messages"
+	default y if ISOTP_REQUIRE_RX_PADDING
 	help
 	  Add padding bytes 0xCC (as recommended by Bosch) if the PDU payload
 	  does not fit exactly into the CAN frame.

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -137,8 +137,7 @@ static void receive_send_fc(struct isotp_recv_ctx *ctx, uint8_t fs)
 	*data++ = ctx->opts.stmin;
 	payload_len = data - frame.data;
 
-#if defined(CONFIG_ISOTP_REQUIRE_RX_PADDING) || \
-				defined(CONFIG_ISOTP_ENABLE_TX_PADDING)
+#ifdef CONFIG_ISOTP_ENABLE_TX_PADDING
 	/* AUTOSAR requirement SWS_CanTp_00347 */
 	memset(&frame.data[payload_len], 0xCC, ISOTP_CAN_DL - payload_len);
 	frame.dlc = ISOTP_CAN_DL;
@@ -776,7 +775,7 @@ static void send_process_fc(struct isotp_send_ctx *ctx,
 		return;
 	}
 
-#ifdef CONFIG_ISOTP_ENABLE_TX_PADDING
+#ifdef CONFIG_ISOTP_REQUIRE_RX_PADDING
 	/* AUTOSAR requirement SWS_CanTp_00349 */
 	if (frame->dlc != ISOTP_CAN_DL) {
 		LOG_ERR("FC DL invalid. Ignore");


### PR DESCRIPTION
Fix ISO-TP padding config usage:

- `ISOTP_ENABLE_TX_PADDING` makes the device transmit frames with TX padding
- `ISOTP_REQUIRE_RX_PADDING` ensures other devices on the bus use TX padding, by rejecting non-padded RX frames

Enable TX padding by default if RX padding is required:

- It would be strange to enforce padding for other bus participants but not use it yourself
- This default suggests the likely proper usage, although it is not a hard dependency

Update unit tests to check padding correctly:

- The tests now properly validate frames under all padding configurations
- Part of `test_sender_fc_errors` was testing a receive FC error, this sub-test is moved to `test_receiver_fc_errors`

