### PR TITLE
canbus: isotp: Fix context buffer memory leaks

### DIFF
--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -1179,6 +1179,7 @@ static int send(struct isotp_send_ctx *ctx, const struct device *can_dev,
 		ret = attach_fc_filter(ctx);
 		if (ret) {
 			LOG_ERR("Can't attach fc filter: %d", ret);
+			free_send_ctx(&ctx);
 			return ret;
 		}
 
@@ -1190,6 +1191,7 @@ static int send(struct isotp_send_ctx *ctx, const struct device *can_dev,
 		ctx->filter_id = -1;
 		ret = send_sf(ctx);
 		if (ret) {
+			free_send_ctx(&ctx);
 			return ret == -EAGAIN ?
 			       ISOTP_N_TIMEOUT_A : ISOTP_N_ERROR;
 		}


### PR DESCRIPTION
Ensure context buffers are free'd when errors occur

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/60707