### PR TITLE
tfm: Fix help text for crypto key module functionality

### DIFF
--- a/modules/trusted-firmware-m/Kconfig.tfm.crypto_modules
+++ b/modules/trusted-firmware-m/Kconfig.tfm.crypto_modules
@@ -19,7 +19,7 @@ config TFM_CRYPTO_KEY_MODULE_ENABLED
 	default y
 	help
 	  Enables the KEY crypto module within the crypto partition.
-	  Unset this option if the functionality provided by 'crypto_key.c'
+	  Unset this option if the functionality provided by 'crypto_key_management.c'
 	  is not used.
 
 config TFM_CRYPTO_AEAD_MODULE_ENABLED


### PR DESCRIPTION
Fix help text for crypto key module functionality, which is included in the source file of crypto_key_management.c source file. The crypto_key.c source file contains generic code that is always included.