### PR TITLE
test: Exclude qemu_cortex_a53_smp from portability.posix.eventfd

### DIFF
--- a/tests/posix/eventfd/testcase.yaml
+++ b/tests/posix/eventfd/testcase.yaml
@@ -5,5 +5,8 @@ common:
     - eventfd
   integration_platforms:
     - qemu_x86
+  # See issue #60678
+  platform_exclude:
+    - qemu_cortex_a53_smp
 tests:
   portability.posix.eventfd: {}


### PR DESCRIPTION
The test is failing for (so far) unknown reasons, blocking several PRs. Exclude it until a proper investigation finds the root cause.