### PR TITLE
MAINTAINERS: point release notes to Johan and Fabio

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -620,8 +620,8 @@ Documentation Infrastructure:
 Release Notes:
   status: maintained
   maintainers:
-    - nashif
-    - jgl-meta
+    - jhedberg
+    - fabiobaltieri
   files:
     - doc/releases/release-notes-*
   labels:


### PR DESCRIPTION
Change the release notes area to the release owners for 3.5.