### PR TITLE
sensors: icm42688: ensure SENSOR_ASYNC_API is selected

### DIFF
--- a/drivers/sensor/icm42688/Kconfig
+++ b/drivers/sensor/icm42688/Kconfig
@@ -24,6 +24,7 @@ config EMUL_ICM42688
 config ICM42688_DECODER
 	bool "ICM42688 decoder logic"
 	default y if ICM42688
+	select SENSOR_ASYNC_API
 	help
 	  Compile the ICM42688 decoder API which allows decoding raw data returned
 	  from the sensor.


### PR DESCRIPTION
Hi, found this in the biweekly build (https://github.com/zephyrproject-rtos/zephyr/runs/15075932568), can be reproduced with

`west build -p -b tdk_robokit1 -T samples/sensor/die_temp_polling/sample.sensor.die_temperature_polling`

---

This fix a build issue where ICM42688_DECODER is enabled but SENSOR_ASYNC_API is not, which results in some structures in an orphan section:

```
warning: orphan section
`._sensor_decoder_api.static.invensense_icm42688__decoder_api_' from `libdrivers__sensor__icm42688.a(icm42688_decoder.c.obj)' being placed in section
`._sensor_decoder_api.static.invensense_icm42688__decoder_api_'
```