### PR TITLE
hwinfo: gecko: fix warning when building for efr32bg27_brd2602a

### DIFF
--- a/drivers/hwinfo/hwinfo_gecko.c
+++ b/drivers/hwinfo/hwinfo_gecko.c
@@ -35,7 +35,7 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 {
 	uint32_t flags = 0;
-	uint32_t rmu_flags = RMU_ResetCauseGet();
+	uint32_t __maybe_unused rmu_flags = RMU_ResetCauseGet();
 
 #ifdef RMU_RSTCAUSE_PORST
 	if (rmu_flags & RMU_RSTCAUSE_PORST) {


### PR DESCRIPTION
Hi, spotted this in the bi-weekly build (https://github.com/zephyrproject-rtos/zephyr/runs/15075932568). LMK if there's a better fix (maybe excluding the driver for the specific SOC or something.

---

When building the driver for efr32bg27_brd2602a none of the condition matches and the compiler warns for:

```
hwinfo_gecko.c: In function 'z_impl_hwinfo_get_reset_cause':
hwinfo_gecko.c:38:18: warning: unused variable 'rmu_flags' [-Wunused-variable]
   38 |         uint32_t rmu_flags = RMU_ResetCauseGet();
```

This fails the bi-weekly build, add a __maybe_unused to silence the warning.