### PR TITLE
tests: mcumgr: exclude lpcxpresso51u68

### DIFF
--- a/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported/testcase.yaml
@@ -15,26 +15,29 @@ tests:
     extra_args: >
       OVERLAY_CONFIG="configuration/crc32.conf"
     platform_exclude:
-      - nucleo_h745zi_q_m4
-      - arduino_portenta_h7_m4
-      - stm32h747i_disco_m4
       - arduino_giga_r1_m4
+      - arduino_portenta_h7_m4
       - esp32_net
+      - lpcxpresso51u68
+      - nucleo_h745zi_q_m4
+      - stm32h747i_disco_m4
   mgmt.mcumgr.fs.mgmt.hash.supported.sha256:
     extra_args: >
       OVERLAY_CONFIG="configuration/sha256.conf"
     platform_exclude:
-      - nucleo_h745zi_q_m4
-      - arduino_portenta_h7_m4
-      - stm32h747i_disco_m4
       - arduino_giga_r1_m4
+      - arduino_portenta_h7_m4
       - esp32_net
+      - lpcxpresso51u68
+      - nucleo_h745zi_q_m4
+      - stm32h747i_disco_m4
   mgmt.mcumgr.fs.mgmt.hash.supported.all:
     extra_args: >
       OVERLAY_CONFIG="configuration/all.conf"
     platform_exclude:
-      - nucleo_h745zi_q_m4
-      - arduino_portenta_h7_m4
-      - stm32h747i_disco_m4
       - arduino_giga_r1_m4
+      - arduino_portenta_h7_m4
       - esp32_net
+      - lpcxpresso51u68
+      - nucleo_h745zi_q_m4
+      - stm32h747i_disco_m4


### PR DESCRIPTION
Hi, spotted this in the bi-weekly run https://github.com/zephyrproject-rtos/zephyr/runs/15075932568, guess that platform does not have a working flash driver right now or something.

---

The test is failing for lpcxpresso51u68 with:

```
soc_flash_lpc.c:25:2: error: #error No matching compatible for soc_flash_lpc.c
   25 | #error No matching compatible for soc_flash_lpc.c
      |  ^~~~~
```

Add the board to the exclude list, sort the list as well.