### PR TITLE
Bluetooth: att: Remove unused bt_att_free_tx_meta_data function

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3948,11 +3948,6 @@ bool bt_att_tx_meta_data_match(const struct net_buf *buf, bt_gatt_complete_func_
 		(bt_att_tx_meta_data(buf)->chan_opt == chan_opt));
 }
 
-void bt_att_free_tx_meta_data(const struct net_buf *buf)
-{
-	tx_meta_data_free(bt_att_tx_meta_data(buf));
-}
-
 bool bt_att_chan_opt_valid(struct bt_conn *conn, enum bt_att_chan_opt chan_opt)
 {
 	if ((chan_opt & (BT_ATT_CHAN_OPT_ENHANCED_ONLY | BT_ATT_CHAN_OPT_UNENHANCED_ONLY)) ==

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -340,8 +340,6 @@ void bt_att_increment_tx_meta_data_attr_count(struct net_buf *buf, uint16_t attr
 bool bt_att_tx_meta_data_match(const struct net_buf *buf, bt_gatt_complete_func_t func,
 			       const void *user_data, enum bt_att_chan_opt chan_opt);
 
-void bt_att_free_tx_meta_data(const struct net_buf *buf);
-
 #if defined(CONFIG_BT_EATT)
 #define BT_ATT_CHAN_OPT(_params) (_params)->chan_opt
 #else


### PR DESCRIPTION
This function seems to unused thus can be safely removed.