### PR TITLE
Bluetooth: att: Make bt_att_chan_create_pdu static function

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -638,8 +638,7 @@ static bt_conn_tx_cb_t att_cb(const struct net_buf *buf)
 	return att_unknown;
 }
 
-struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t op,
-				       size_t len)
+static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t op, size_t len)
 {
 	struct bt_att_hdr *hdr;
 	struct net_buf *buf;


### PR DESCRIPTION
This fixes missing `static` function specifier.
The bt_att_chan_create_pdu is not called outside of att.c.