### PR TITLE
Bluetooth: gatt: Fix setting actual error in notify_cb

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2761,11 +2761,11 @@ static uint8_t notify_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 
 		bt_conn_unref(conn);
 
+		data->err = err;
+
 		if (err < 0) {
 			return BT_GATT_ITER_STOP;
 		}
-
-		data->err = 0;
 	}
 
 	return BT_GATT_ITER_CONTINUE;


### PR DESCRIPTION
This fixes return error from notify_cb function that was never set up. As the result, the functions like bt_gatt_notify_cb and bt_gatt_indicate returned invalid error when failed to send notification.