### PR TITLE
driver: sensor: mcux qdec rt11xx support

### DIFF
--- a/drivers/sensor/qdec_mcux/qdec_mcux.c
+++ b/drivers/sensor/qdec_mcux/qdec_mcux.c
@@ -111,9 +111,8 @@ static int qdec_mcux_ch_get(const struct device *dev, enum sensor_channel ch,
 
 	switch (ch) {
 	case SENSOR_CHAN_ROTATION:
-		val->val1 = ((int64_t)data->position * 360) /
-			    data->counts_per_revolution;
-		val->val2 = 0;
+		sensor_value_from_float(val, (data->position * 360.0f)
+					/ data->counts_per_revolution);
 		break;
 	default:
 		return -ENOTSUP;

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -1062,6 +1062,25 @@
 			status = "okay";
 		};
 
+		xbar1: xbar1@4003c000 {
+			compatible = "nxp,mcux-xbar";
+			reg = <0x4003c000 0x4000>;
+			interrupts = <143 0>, <144 0>;
+			status = "disabled";
+		};
+
+		xbar2: xbar2@40040000 {
+			compatible = "nxp,mcux-xbar";
+			reg = <0x40040000 0x4000>;
+			status = "disabled";
+		};
+
+		xbar3: xbar3@40044000 {
+			compatible = "nxp,mcux-xbar";
+			reg = <0x40044000 0x4000>;
+			status = "disabled";
+		};
+
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -1062,6 +1062,35 @@
 			status = "okay";
 		};
 
+
+		qdec1: qdec@40174000 {
+			compatible = "nxp,mcux-qdec";
+			reg = <0x40174000 0x4000>;
+			interrupts = <165 0>;
+			status = "disabled";
+		};
+
+		qdec2: qdec@40178000 {
+			compatible = "nxp,mcux-qdec";
+			reg = <0x40178000 0x4000>;
+			interrupts = <166 0>;
+			status = "disabled";
+		};
+
+		qdec3: qdec@4017c000 {
+			compatible = "nxp,mcux-qdec";
+			reg = <0x4017c000 0x4000>;
+			interrupts = <167 0>;
+			status = "disabled";
+		};
+
+		qdec4: qdec@40180000 {
+			compatible = "nxp,mcux-qdec";
+			reg = <0x40180000 0x4000>;
+			interrupts = <168 0>;
+			status = "disabled";
+		};
+
 		xbar1: xbar1@4003c000 {
 			compatible = "nxp,mcux-xbar";
 			reg = <0x4003c000 0x4000>;

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -352,6 +352,7 @@ config SOC_MIMXRT1176_CM7
 	select HAS_MCUX_ACMP
 	select HAS_MCUX_SRC_V2
 	select HAS_MCUX_IOMUXC
+	select HAS_MCUX_XBARA
 	select HAS_SWO
 
 config SOC_MIMXRT1176_CM4


### PR DESCRIPTION
Adds qdec_mcux support for rt11xx.

Fixes value conversion for sensor subsystem by using `sensor_value_from_float` macro.