### PR TITLE
tests: drivers: can: add esp32 and esp32s2

### DIFF
--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -17,6 +17,7 @@
 	#size-cells = <1>;
 
 	chosen {
+		zephyr,canbus = &twai;
 		zephyr,entropy = &trng0;
 		zephyr,flash-controller = &flash;
 	};

--- a/tests/drivers/can/api/testcase.yaml
+++ b/tests/drivers/can/api/testcase.yaml
@@ -11,4 +11,9 @@ tests:
       - can
     extra_args: DTC_OVERLAY_FILE=twai-enable.overlay
     filter: dt_compat_enabled("espressif,esp32-twai")
-    platform_allow: esp32c3_devkitm esp32s3_devkitm xiao_esp32s3
+    platform_allow:
+      - esp32
+      - esp32c3_devkitm
+      - esp32s2_saola
+      - esp32s3_devkitm
+      - xiao_esp32s3


### PR DESCRIPTION
Add twai node as zephyr,canbus on esp32s2
Add esp32 and esp32s2_saola boards to platform allow list