### PR TITLE
driver: watchdog: wdt_ifx_cat1: masking added

### DIFF
--- a/drivers/watchdog/wdt_ifx_cat1.c
+++ b/drivers/watchdog/wdt_ifx_cat1.c
@@ -36,6 +36,7 @@ static void ifx_cat1_wdt_isr_handler(const struct device *dev)
 	if (dev_data->callback) {
 		dev_data->callback(dev, 0);
 	}
+	Cy_WDT_MaskInterrupt();
 }
 #endif /* IFX_CAT1_WDT_IS_IRQ_EN */
 


### PR DESCRIPTION
Masking is added so that WDT is not invoked multiple times