### PR TITLE
storage: flash_map: PM in `flash_area_open/close`

### DIFF
--- a/doc/services/storage/flash_map/flash_map.rst
+++ b/doc/services/storage/flash_map/flash_map.rst
@@ -104,6 +104,15 @@ using :c:func:`flash_area_open` and DTS node label:
    	flash_area_read(my_area, ...);
    }
 
+Power Management
+****************
+
+If :ref:`pm-device-runtime` is enabled on the device the flash area is on,
+opening the flash area with :c:func:`flash_map_open` will automatically
+request the device to be in active mode via :c:func:`pm_device_runtime_get`.
+The request is released when the flash area is closed with
+:c:func:`flash_map_close`.
+
 API Reference
 *************
 

--- a/tests/subsys/storage/flash_map/app.overlay
+++ b/tests/subsys/storage/flash_map/app.overlay
@@ -28,4 +28,20 @@
 			};
 		};
 	};
+
+	pm_flash: pm_flash {
+		compatible = "vnd,flash";
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			pm_partition: partition@0 {
+				label = "pm_partition";
+				reg = <0x00000000 0x00001000>;
+			};
+		};
+	};
 };

--- a/tests/subsys/storage/flash_map/testcase.yaml
+++ b/tests/subsys/storage/flash_map/testcase.yaml
@@ -8,6 +8,18 @@ tests:
     tags: flash_map
     integration_platforms:
       - native_posix
+  storage.flash_map.pm:
+    platform_allow:
+      - nrf51dk_nrf51422
+      - qemu_x86
+      - native_posix
+      - native_posix_64
+    extra_configs:
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
+    tags: flash_map pm
+    integration_platforms:
+      - native_posix
   storage.flash_map.mpu:
     extra_args: OVERLAY_CONFIG=overlay-mpu.conf
     platform_allow:


### PR DESCRIPTION
Run power management actions in `flash_area_open` and
`flash_area_close`. If the flash area is open it should be in the active
state, otherwise it should be left in its lowest power state.