### PR TITLE
Bluetooth: Userchan: Add support for TCP Connection

### DIFF
--- a/boards/posix/native_posix/doc/index.rst
+++ b/boards/posix/native_posix/doc/index.rst
@@ -345,6 +345,15 @@ The following peripherals are currently provided with this board:
   must be powered down and support Bluetooth Low Energy (i.e. support the
   Bluetooth specification version 4.0 or greater).
 
+  Another possibility is to use a HCI TCP server which acts as a
+  :ref:`virtual Bluetooth controller<bluetooth_virtual_posix>` over TCP.
+  To connect to a HCI TCP server its IP address and port number must
+  be specified. For example, to connect to a HCI TCP server with IP
+  address 127.0.0.0 and port number 1020 use ``zephyr.exe --bt-dev=127.0.0.1:1020``.
+  This alternative option is mainly aimed for testing Bluetooth connectivity over
+  a virtual Bluetooth controller that does not depend on the Linux Bluetooth
+  stack and its HCI interface.
+
 **USB controller**:
   It's possible to use the Virtual USB controller working over USB/IP
   protocol. More information can be found in

--- a/doc/connectivity/bluetooth/bluetooth-dev.rst
+++ b/doc/connectivity/bluetooth/bluetooth-dev.rst
@@ -92,10 +92,11 @@ which is comprised of the following devices:
 #. A :ref:`Host-only <bluetooth-build-types>` application running in the
    :ref:`QEMU <application_run_qemu>` emulator or the ``native_posix`` native
    port of Zephyr
-#. A Controller, which can be one of two types:
+#. A Controller, which can be one of the following types:
 
    * A commercially available Controller
    * A :ref:`Controller-only <bluetooth-build-types>` build of Zephyr
+   * A Virtual controller
 
 .. warning::
    Certain external Controllers are either unable to accept the Host to
@@ -129,11 +130,12 @@ The :ref:`Native POSIX <native_posix>` target builds your Zephyr application
 with the Zephyr kernel, and some minimal HW emulation as a native Linux
 executable.
 This executable is a normal Linux program, which can be debugged and
-instrumented like any other, and it communicates with a physical external
-Controller.
+instrumented like any other, and it communicates with a physical or virtual
+external Controller.
 
 Refer to :ref:`bluetooth_qemu_posix` for full instructions on how to build and
-run an application in this setup.
+run an application with a physical controller. For the virtual controller refer
+to :ref:`bluetooth_virtual_posix`.
 
 Simulated nRF52 with BabbleSim
 ==============================

--- a/doc/connectivity/bluetooth/bluetooth-tools.rst
+++ b/doc/connectivity/bluetooth/bluetooth-tools.rst
@@ -178,6 +178,69 @@ In order to see those logs, you can use the built-in ``btmon`` tool from BlueZ:
 
    $ btmon
 
+.. _bluetooth_virtual_posix:
+
+Running on a Virtual Controller and Native POSIX
+*************************************************
+
+An alternative to a Bluetooth physical controller is the use of a virtual
+controller. This controller can be connected over an HCI TCP server.
+This TCP server must support the HCI H4 protocol. In comparison to the physical controller
+variant, the virtual controller allows to test a Zephyr application running on the native
+boards without a physical Bluetooth controller.
+
+The main use case for a virtual controller is to do Bluetooth connectivity tests without
+the need of Bluetooth hardware. This allows to automate Bluetooth integration tests with
+external applications such as a Bluetooth gateway or a mobile application.
+
+To demonstrate this functionality an example is given to interact with a virtual controller.
+For this purpose, the experimental python module `Bumble`_ from Google is used as it allows to create
+a TCP Bluetooth virtual controller and connect with the Zephyr Bluetooth host. To install
+bumble follow the `Bumble Getting Started Guide`_.
+
+.. note::
+   If your Zephyr application requires the use of the HCI LE Set extended commands, install
+   the branch ``controller-extended-advertising`` from Bumble.
+
+Android Emulator
+=================
+
+You can test the virtual controller by connecting a Bluetooth Zephyr application
+to the `Android Emulator`_.
+
+To connect your application to the Android Emulator follow the next steps:
+
+    #. Build your Zephyr application and disable the HCI ACL flow
+       control (i.e. ``CONFIG_BT_HCI_ACL_FLOW_CONTROL=n``) as the
+       the virtual controller from android does not support it at the moment.
+
+    #. Install Android Emulator version >= 33.1.4.0. The easiest way to do this is by installing
+       the latest `Android Studio Preview`_ version.
+
+    #. Create a new Android Virtual Device (AVD) with the `Android Device Manager`_. The AVD should use at least SDK API 34.
+
+    #. Run the Android Emulator via terminal as follows:
+
+       ``emulator avd YOUR_AVD -packet-streamer-endpoint default``
+
+    #. Create a Bluetooth bridge between the Zephyr application and
+       the virtual controller from Android Emulator with the `Bumble`_ utility ``hci-bridge``.
+
+       ``bumble-hci-bridge tcp-server:_:1234 android-netsim``
+
+       This command will create a TCP server bridge on the local host IP address ``127.0.0.1``
+       and port number ``1234``.
+
+    #. Run the Zephyr application and connect to the TCP server created in the last step.
+
+       ``./zephyr.exe --bt-dev=127.0.0.1:1234``
+
+After following these steps the Zephyr application will be available to the Android Emulator
+over the virtual Bluetooth controller that was bridged with Bumble. You can verify that the
+Zephyr application can communicate over Bluetooth by opening the Bluetooth settings in your
+AVD and scanning for your Zephyr application device. To test this you can build the Bluetooth
+peripheral samples such as :ref:`Peripheral HR <peripheral_hr>` or :ref:`Peripheral DIS <peripheral_dis>`
+
 .. _bluetooth_ctlr_bluez:
 
 Using Zephyr-based Controllers with BlueZ
@@ -205,3 +268,8 @@ Additional information about :file:`btmgmt` can be found in its manual pages.
 .. _LightBlue for iOS: https://itunes.apple.com/us/app/lightblue-explorer/id557428110
 .. _nRF Mesh for Android: https://play.google.com/store/apps/details?id=no.nordicsemi.android.nrfmeshprovisioner&hl=en
 .. _nRF Mesh for iOS: https://itunes.apple.com/us/app/nrf-mesh/id1380726771
+.. _Bumble: https://github.com/google/bumble
+.. _Bumble Getting Started Guide: https://google.github.io/bumble/getting_started.html
+.. _Android Emulator: https://developer.android.com/studio/run/emulator
+.. _Android Device Manager: https://developer.android.com/studio/run/managing-avds
+.. _Android Studio Preview: https://developer.android.com/studio/preview


### PR DESCRIPTION
Added support to connect to an HCI TCP Server. This allows to do integration tests with other frameworks that support a virtual hci interface.

The use cases I see for this are:

- Test automatically mobile apps with zephyr applications. E.g. Android Emulator
- Integration tests that depend on Zephyr Bluetooth Peripheral devices without the real zephyr hardware. e.g., Test the correct 
functionality of a Bluetooth gateway by assigning a virtual hci controller bridge.

Attached is a proof of concept to show case emulating an Android device and connecting to a Zephyr Bluetooth sample (peripheral_hr). I am using the experimental python software from Google called bumble for connecting the Zephyr TCP HCI client and the Android [netsim](https://android.googlesource.com/platform/tools/netsim/)

https://github.com/google/bumble

Upper left screen is the HCI traffice between zephyr bluetooth stack (host) and the android-netsim (Controller). Lower window is the zephyr binary running the peripheral_hr example in the Windows Subsystem for Linux. And on the right is the Android emulator running with Android API 34 and the NRF Connect App to test the GATT notification of the peripheral_hr sample.


https://github.com/zephyrproject-rtos/zephyr/assets/47216966/d1469ca4-e624-41a1-9798-2cae13ad60dd

