### PR TITLE
Revert TFM update

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -266,18 +266,11 @@ HALs
 MCUboot
 *******
 
-Mbed TLS
-********
-
-* Update to Mbed TLS 3.4.0.
-
 Storage
 *******
 
 Trusted Firmware-M
 ******************
-
-* Update to TF-M 1.8.0
 
 Trusted Firmware-A
 ******************

--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -52,6 +52,7 @@ zephyr_interface_library_named(mbedTLS)
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/cipher.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/cipher_wrap.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/cmac.c
+      ${ZEPHYR_CURRENT_MODULE_DIR}/library/code_share.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/ctr_drbg.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/debug.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/des.c
@@ -76,7 +77,6 @@ zephyr_interface_library_named(mbedTLS)
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/mps_reader.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/mps_trace.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/poly1305.c
-      ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_util.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/ripemd160.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/rsa_alt_helpers.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/rsa.c

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -214,6 +214,7 @@ if (CONFIG_BUILD_WITH_TFM)
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_platform_api.c
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_ps_api.c
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_psa_ns_api.c
+    ${TFM_INTERFACE_SOURCE_DIR}/tfm_psa_ns_connection_api.c
 
     # Specific to nordic_nrf platform
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_ioctl_core_ns_api.c
@@ -408,6 +409,7 @@ if (CONFIG_BUILD_WITH_TFM)
     zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_INITIAL_ATTESTATION      ${TFM_INTERFACE_SOURCE_DIR}/tfm_attest_api.c)
     zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_FIRMWARE_UPDATE          ${TFM_INTERFACE_SOURCE_DIR}/tfm_fwu_api.c)
 
+    zephyr_library_sources_ifdef(CONFIG_TFM_CONNECTION_BASED_SERVICE_API       ${TFM_INTERFACE_SOURCE_DIR}/tfm_psa_ns_connection_api.c)
     zephyr_library_sources(${TFM_INTERFACE_SOURCE_DIR}/tfm_psa_ns_api.c)
 
     if(CONFIG_SOC_FAMILY_NRF)

--- a/modules/trusted-firmware-m/interface/interface.c
+++ b/modules/trusted-firmware-m/interface/interface.c
@@ -74,7 +74,7 @@ int32_t tfm_ns_interface_dispatch(veneer_fn fn,
 	return result;
 }
 
-uint32_t tfm_ns_interface_init(void)
+enum tfm_status_e tfm_ns_interface_init(void)
 {
 	/*
 	 * The static K_MUTEX_DEFINE handles mutex initialization,

--- a/west.yml
+++ b/west.yml
@@ -266,7 +266,7 @@ manifest:
       revision: 8e303c264fc21c2116dc612658003a22e933124d
       path: modules/lib/lz4
     - name: mbedtls
-      revision: c38dc78d9a8dcbe43b898cc1171ab33ba3e6fc26
+      revision: 6e7841e5a08eb5da3c82dbc8b6b6d82ae4b7d2a0
       path: modules/crypto/mbedtls
       groups:
         - crypto
@@ -321,7 +321,7 @@ manifest:
       groups:
         - debug
     - name: trusted-firmware-m
-      revision: bad0696f388d6f713742c5da8dfce426ec17ef20
+      revision: 79a6115d3a8d0e04864ae8156c1dc8532b750f5a
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee
@@ -331,7 +331,7 @@ manifest:
       groups:
         - tee
     - name: tf-m-tests
-      revision: a878426da78fbd1486dfc29d6c6b82be4ee79e72
+      revision: 0f80a65193ddbbe3f0ac38b33b07b26138c11fa7
       path: modules/tee/tf-m/tf-m-tests
       groups:
         - tee


### PR DESCRIPTION
Revert the recent TFM manifest update, it's breaking CI: https://github.com/zephyrproject-rtos/zephyr/runs/15256256468