### PR TITLE
bq274xx: rework configuration code, fix up bq27427 support

### DIFF
--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -86,11 +86,10 @@ static int bq274xx_ctrl_reg_write(const struct device *dev, uint16_t subcommand)
 	const struct bq274xx_config *config = dev->config;
 	int ret;
 
-	uint8_t tx_buf[3] = {
-		BQ274XX_CMD_CONTROL_LOW,
-		subcommand & 0xff,
-		subcommand >> 8,
-	};
+	uint8_t tx_buf[3];
+
+	tx_buf[0] = BQ274XX_CMD_CONTROL_LOW;
+	sys_put_le16(subcommand, &tx_buf[1]);
 
 	ret = i2c_write_dt(&config->i2c, tx_buf, sizeof(tx_buf));
 	if (ret < 0) {

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -2,6 +2,17 @@
  * Copyright (c) 2020 Linumiz
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * Relevant documents:
+ * - BQ27441
+ *   Datasheet: https://www.ti.com/lit/gpn/bq27441-g1
+ *   Technical reference manual: https://www.ti.com/lit/pdf/sluuac9
+ * - BQ27421
+ *   Datasheet: https://www.ti.com/lit/gpn/bq27421-g1
+ *   Technical reference manual: https://www.ti.com/lit/pdf/sluuac5
+ * - BQ27427
+ *   Datasheet: https://www.ti.com/lit/gpn/bq27427
+ *   Technical reference manual: https://www.ti.com/lit/pdf/sluucd5
  */
 
 #define DT_DRV_COMPAT ti_bq274xx

--- a/drivers/sensor/bq274xx/bq274xx.c
+++ b/drivers/sensor/bq274xx/bq274xx.c
@@ -458,28 +458,28 @@ static int bq274xx_channel_get(const struct device *dev, enum sensor_channel cha
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY:
-		val->val1 = (data->full_charge_capacity / 1000);
-		val->val2 = ((data->full_charge_capacity % 1000) * 1000U);
+		val->val1 = data->full_charge_capacity;
+		val->val2 = 0;
 		break;
 
 	case SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY:
-		val->val1 = (data->remaining_charge_capacity / 1000);
-		val->val2 = ((data->remaining_charge_capacity % 1000) * 1000U);
+		val->val1 = data->remaining_charge_capacity;
+		val->val2 = 0;
 		break;
 
 	case SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY:
-		val->val1 = (data->nom_avail_capacity / 1000);
-		val->val2 = ((data->nom_avail_capacity % 1000) * 1000U);
+		val->val1 = data->nom_avail_capacity;
+		val->val2 = 0;
 		break;
 
 	case SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY:
-		val->val1 = (data->full_avail_capacity / 1000);
-		val->val2 = ((data->full_avail_capacity % 1000) * 1000U);
+		val->val1 = data->full_avail_capacity;
+		val->val2 = 0;
 		break;
 
 	case SENSOR_CHAN_GAUGE_AVG_POWER:
-		val->val1 = (data->avg_power / 1000);
-		val->val2 = ((data->avg_power % 1000) * 1000U);
+		val->val1 = data->avg_power;
+		val->val2 = 0;
 		break;
 
 	default:

--- a/drivers/sensor/bq274xx/bq274xx.h
+++ b/drivers/sensor/bq274xx/bq274xx.h
@@ -17,8 +17,7 @@
 #define BQ27427_DEVICE_ID  0x0427
 
 /*** Standard Commands ***/
-#define BQ274XX_CMD_CONTROL_LOW    0x00 /* Control() low register */
-#define BQ274XX_CMD_CONTROL_HIGH   0x01 /* Control() high register */
+#define BQ274XX_CMD_CONTROL        0x00 /* Control() register */
 #define BQ274XX_CMD_TEMP           0x02 /* Temperature() */
 #define BQ274XX_CMD_VOLTAGE        0x04 /* Voltage() */
 #define BQ274XX_CMD_FLAGS          0x06 /* Flags() */


### PR DESCRIPTION
Second round of bq274xx fixes, main changes:
- rework the device configuration so we don't soft-reset it every time
- apply an interesting bq27427 fix to invert the CC gain polarity

The bq27427 fix is particularly entertaining, it involves flipping a bit in an undocumented register that happens to represent a float in a proprietary floating point format, none of which is currently documented in any datasheet or errata and the information only lives in the TI forums. I can only think that TI inadvertently flipped the sensing connection when they did the internal shunt version of the device and decided to ship it anyway and let it be fixed in software. All the details in the patch description.

Note that the fix is applied in runtime, this translates in a bit of dead code when the driver is used with a bq27421, but then one could drop in a bq27427 and the same firmware image would work automatically, which is nice since the two are pin-to-pin compatible.

@nixward @marco85mars20: could you give this a go on a bq27421?