### PR TITLE
rtc: Fix test filtering related bugs

### DIFF
--- a/boards/arm/nucleo_h563zi/nucleo_h563zi.yaml
+++ b/boards/arm/nucleo_h563zi/nucleo_h563zi.yaml
@@ -21,3 +21,4 @@ supported:
   - spi
   - usb_device
   - usb
+  - rtc

--- a/boards/x86/qemu_x86/qemu_x86.yaml
+++ b/boards/x86/qemu_x86/qemu_x86.yaml
@@ -14,5 +14,6 @@ supported:
   - netif:serial-net
   - eeprom
   - can
+  - rtc
 testing:
   default: true

--- a/drivers/rtc/Kconfig.stm32
+++ b/drivers/rtc/Kconfig.stm32
@@ -4,9 +4,9 @@
 config RTC_STM32
 	bool "STM32 RTC driver"
 	default y if !COUNTER
-	depends on DT_HAS_ST_STM32_RTC_ENABLED
+	depends on DT_HAS_ST_STM32_RTC_ENABLED && !SOC_SERIES_STM32F1X
 	select USE_STM32_LL_RTC
 	select USE_STM32_LL_PWR
 	select USE_STM32_LL_RCC
 	help
-	  Build RTC driver for STM32 SoCs.
+	  Build RTC driver for STM32 SoCs, excluding STM32F1 series.

--- a/tests/drivers/rtc/rtc_api_helpers/testcase.yaml
+++ b/tests/drivers/rtc/rtc_api_helpers/testcase.yaml
@@ -8,3 +8,4 @@ tests:
       - rtc
       - api
       - helpers
+    depends_on: rtc


### PR DESCRIPTION
Avoid testing on targets not supporting this api.
Declare support when required.
Fix specific case on STM32

Blocking https://github.com/zephyrproject-rtos/zephyr/pull/59650