### PR TITLE
pm: move _cpus_active to PM subsystem

### DIFF
--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -193,8 +193,6 @@ typedef struct z_kernel _kernel_t;
 
 extern struct z_kernel _kernel;
 
-extern atomic_t _cpus_active;
-
 #ifdef CONFIG_SMP
 
 /* True if the current context can be preempted and migrated to

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -45,9 +45,6 @@ BUILD_ASSERT(CONFIG_MP_NUM_CPUS == CONFIG_MP_MAX_NUM_CPUS,
 __pinned_bss
 struct z_kernel _kernel;
 
-__pinned_bss
-atomic_t _cpus_active;
-
 /* init/main and idle threads */
 K_THREAD_PINNED_STACK_DEFINE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
 struct k_thread z_main_thread;
@@ -398,12 +395,6 @@ void z_init_cpu(int id)
 	_kernel.cpus[id].usage.track_usage =
 		CONFIG_SCHED_THREAD_USAGE_AUTO_ENABLE;
 #endif
-
-	/*
-	 * Increment number of CPUs active. The pm subsystem
-	 * will keep track of this from here.
-	 */
-	atomic_inc(&_cpus_active);
 }
 
 /**

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -17,7 +17,7 @@
 #include <zephyr/pm/state.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/tracing/tracing.h>
-
+#include <zephyr/sys/atomic.h>
 #include "pm_stats.h"
 
 #include <zephyr/logging/log.h>
@@ -28,6 +28,10 @@ LOG_MODULE_REGISTER(pm, CONFIG_PM_LOG_LEVEL);
 
 static ATOMIC_DEFINE(z_post_ops_required, CONFIG_MP_MAX_NUM_CPUS);
 static sys_slist_t pm_notifiers = SYS_SLIST_STATIC_INIT(&pm_notifiers);
+
+#if defined(CONFIG_PM_DEVICE) && !defined(CONFIG_PM_DEVICE_RUNTIME_EXCLUSIVE)
+static atomic_t _cpus_active = ATOMIC_INIT(CONFIG_MP_NUM_CPUS);
+#endif
 
 /*
  * Properly initialize cpu power states. Do not make assumptions that


### PR DESCRIPTION
It looks like PM subsystem-specific needs were added to the Kernel code, but there was no real need to do so. When CONFIG_PM_DEVICE=y, active CPUs are tracked by the PM subsystem. This atomic counter is incremented/decremented every time devices are suspended so that it only happens after all CPUs go to idle. Because the number of CPUs is known at compile time, we can just initialize the atomic variable to the correct number instead of relying on `z_init_cpu` to increment the variable for each CPU.

This change will also save from keeping 1 atomic variable in RAM that is not required for most build configurations. Isolation between PM subsys and Kernel code is also improved.