### PR TITLE
MAINTAINERS: Remove myself from settings subsystem

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2072,8 +2072,6 @@ Twister:
 
 Settings:
   status: odd fixes
-  collaborators:
-    - de-nordic
   files:
     - include/zephyr/settings/
     - subsys/settings/


### PR DESCRIPTION
Unfortunately I have no capacity to take care of the subsystem.

With settings getting lower and lower on my list of priorities and actual lack of time to put any effort into the subsystem.

This is still used subsystem that gets fixes, and sometimes features, from other developers, with expectations for timely and careful reviews, something I can not deliver.