### PR TITLE
bleutooth: mesh: increase mesh scan window

### DIFF
--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -13,8 +13,14 @@
 #define BT_MESH_ADV(buf) (*(struct bt_mesh_adv **)net_buf_user_data(buf))
 
 #define BT_MESH_ADV_SCAN_UNIT(_ms) ((_ms) * 8 / 5)
+
+#if defined(CONFIG_BT_EXT_ADV)
+#define BT_MESH_SCAN_INTERVAL_MS 3000
+#define BT_MESH_SCAN_WINDOW_MS   3000
+#else
 #define BT_MESH_SCAN_INTERVAL_MS 30
 #define BT_MESH_SCAN_WINDOW_MS   30
+#endif
 
 enum bt_mesh_adv_type {
 	BT_MESH_ADV_PROV,


### PR DESCRIPTION
increaing mesh scan window in order to reduce the number of messages colliding into scan window end which happens every 30ms currently. Increasing the window to 3000ms.