### PR TITLE
Bluetooth: audio: tbs: Fix List_Item_Length value in CCL

### DIFF
--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -426,9 +426,8 @@ static void net_buf_put_current_calls(const void *inst_p)
 			}
 
 			uri_length = strlen(call->remote_uri);
-			item_len = sizeof(call->index != BT_TBS_FREE_CALL_INDEX) +
-					sizeof(call->state) +
-					sizeof(call->flags) + uri_length;
+			item_len = sizeof(call->index) + sizeof(call->state) +
+				   sizeof(call->flags) + uri_length;
 			net_buf_simple_add_u8(&read_buf, item_len);
 			net_buf_simple_add_u8(&read_buf, call->index);
 			net_buf_simple_add_u8(&read_buf, call->state);


### PR DESCRIPTION
This fixes setting invalid List_Item_Length in Current Calls List.
Complements 9c7ef8e.