### PR TITLE
Bluetooth: audio: tbs: Refactor service definition macro

### DIFF
--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -1686,44 +1686,26 @@ static void in_call_cfg_changed(const struct bt_gatt_attr *attr,
 		      read_friendly_name, NULL, inst), \
 	BT_AUDIO_CCC(friendly_name_cfg_changed)
 
-#define BT_TBS_SERVICE_DEFINITION(inst) {\
-	BT_GATT_PRIMARY_SERVICE(BT_UUID_TBS), \
-	BT_TBS_CHR_PROVIDER_NAME(&inst), \
-	BT_TBS_CHR_UCI(&inst), \
-	BT_TBS_CHR_TECHNOLOGY(&inst), \
-	BT_TBS_CHR_URI_LIST(&inst), \
-	BT_TBS_CHR_SIGNAL_STRENGTH(&inst), \
-	BT_TBS_CHR_SIGNAL_INTERVAL(&inst), \
-	BT_TBS_CHR_CURRENT_CALLS(&inst), \
-	BT_TBS_CHR_CCID(&inst), \
-	BT_TBS_CHR_STATUS_FLAGS(&inst), \
-	BT_TBS_CHR_INCOMING_URI(&inst), \
-	BT_TBS_CHR_CALL_STATE(&inst), \
-	BT_TBS_CHR_CONTROL_POINT(&inst), \
-	BT_TBS_CHR_OPTIONAL_OPCODES(&inst), \
-	BT_TBS_CHR_TERMINATE_REASON(&inst), \
-	BT_TBS_CHR_INCOMING_CALL(&inst), \
-	BT_TBS_CHR_FRIENDLY_NAME(&inst) \
-	}
+#define BT_TBS_SERVICE_DEFINE(_uuid, _inst)                                                        \
+	BT_GATT_PRIMARY_SERVICE(_uuid),                                                            \
+	BT_TBS_CHR_PROVIDER_NAME(_inst),                                                           \
+	BT_TBS_CHR_UCI(_inst),                                                                     \
+	BT_TBS_CHR_TECHNOLOGY(_inst),                                                              \
+	BT_TBS_CHR_URI_LIST(_inst),                                                                \
+	BT_TBS_CHR_SIGNAL_STRENGTH(_inst),                                                         \
+	BT_TBS_CHR_SIGNAL_INTERVAL(_inst),                                                         \
+	BT_TBS_CHR_CURRENT_CALLS(_inst),                                                           \
+	BT_TBS_CHR_CCID(_inst),                                                                    \
+	BT_TBS_CHR_STATUS_FLAGS(_inst),                                                            \
+	BT_TBS_CHR_INCOMING_URI(_inst),                                                            \
+	BT_TBS_CHR_CALL_STATE(_inst),                                                              \
+	BT_TBS_CHR_CONTROL_POINT(_inst),                                                           \
+	BT_TBS_CHR_OPTIONAL_OPCODES(_inst),                                                        \
+	BT_TBS_CHR_TERMINATE_REASON(_inst),                                                        \
+	BT_TBS_CHR_INCOMING_CALL(_inst),                                                           \
+	BT_TBS_CHR_FRIENDLY_NAME(_inst)
 
-#define BT_GTBS_SERVICE_DEFINITION(inst) \
-	BT_GATT_PRIMARY_SERVICE(BT_UUID_GTBS), \
-	BT_TBS_CHR_PROVIDER_NAME(inst), \
-	BT_TBS_CHR_UCI(inst), \
-	BT_TBS_CHR_TECHNOLOGY(inst), \
-	BT_TBS_CHR_URI_LIST(inst), \
-	BT_TBS_CHR_SIGNAL_STRENGTH(inst), \
-	BT_TBS_CHR_SIGNAL_INTERVAL(inst), \
-	BT_TBS_CHR_CURRENT_CALLS(inst), \
-	BT_TBS_CHR_CCID(inst), \
-	BT_TBS_CHR_STATUS_FLAGS(inst), \
-	BT_TBS_CHR_INCOMING_URI(inst), \
-	BT_TBS_CHR_CALL_STATE(inst), \
-	BT_TBS_CHR_CONTROL_POINT(inst), \
-	BT_TBS_CHR_OPTIONAL_OPCODES(inst), \
-	BT_TBS_CHR_TERMINATE_REASON(inst), \
-	BT_TBS_CHR_INCOMING_CALL(inst), \
-	BT_TBS_CHR_FRIENDLY_NAME(inst)
+#define BT_TBS_SERVICE_DEFINITION(_inst) { BT_TBS_SERVICE_DEFINE(BT_UUID_TBS, &(_inst)) }
 
 /*
  * Defining this as extern make it possible to link code that otherwise would
@@ -1733,7 +1715,7 @@ extern const struct bt_gatt_service_static gtbs_svc;
 
 /* TODO: Can we make the multiple service instance more generic? */
 #if CONFIG_BT_GTBS
-BT_GATT_SERVICE_DEFINE(gtbs_svc, BT_GTBS_SERVICE_DEFINITION(&gtbs_inst));
+BT_GATT_SERVICE_DEFINE(gtbs_svc, BT_TBS_SERVICE_DEFINE(BT_UUID_GTBS, &gtbs_inst));
 #endif /* CONFIG_BT_GTBS */
 
 BT_GATT_SERVICE_INSTANCE_DEFINE(tbs_service_list, svc_insts, CONFIG_BT_TBS_BEARER_COUNT,


### PR DESCRIPTION
This removes code duplications by unifying GTBS and TBS service definition macros.