### PR TITLE
drivers: crypto: stm32h5 CRYP_DATATYPE_8B define in hal

### DIFF
--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -48,10 +48,6 @@ LOG_MODULE_REGISTER(crypto_stm32);
 #define STM32_CRYPTO_TYPEDEF            AES_TypeDef
 #endif
 
-#if defined(CONFIG_SOC_SERIES_STM32H5X)
-#define CRYP_DATATYPE_8B CRYP_BYTE_SWAP
-#endif
-
 struct crypto_stm32_session crypto_stm32_sessions[CRYPTO_MAX_SESSION];
 
 static void copy_reverse_words(uint8_t *dst_buf, int dst_len,


### PR DESCRIPTION
Define only once the CRYP_DATATYPE_8B for the stm32h5 serie This macro is in modules/hal/stm32/stm32cube/stm32h5xx/drivers/include/stm32h5xx_hal_cryp.h

Fixes compilation error 
```
./drivers/crypto/crypto_stm32.c:52: warning: "CRYP_DATATYPE_8B" redefined
   52 | #define CRYP_DATATYPE_8B CRYP_BYTE_SWAP
      | 
In file included from ../modules/hal/stm32/stm32cube/stm32h5xx/drivers/include/stm32h5xx_hal_conf.h:300
```