### PR TITLE
kernel/sched: fix thread selection when ABORTING + PENDING

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -314,6 +314,12 @@ static inline bool is_aborting(struct k_thread *thread)
 
 static ALWAYS_INLINE struct k_thread *next_up(void)
 {
+#ifdef CONFIG_SMP
+	if (is_aborting(_current)) {
+		end_thread(_current);
+	}
+#endif
+
 	struct k_thread *thread = runq_best();
 
 #if (CONFIG_NUM_METAIRQ_PRIORITIES > 0) && (CONFIG_NUM_COOP_PRIORITIES > 0)
@@ -1081,10 +1087,6 @@ void *z_get_next_switch_handle(void *interrupted)
 
 	K_SPINLOCK(&sched_spinlock) {
 		struct k_thread *old_thread = _current, *new_thread;
-
-		if (is_aborting(_current)) {
-			end_thread(_current);
-		}
 
 		if (IS_ENABLED(CONFIG_SMP)) {
 			old_thread->switch_handle = NULL;


### PR DESCRIPTION
In commit d537267f, the check on thread abortion was moved from next_up to z_get_next_switch_handle. However, next_up is also called from z_swap_next_thread, so the check on thread abortion is now missing there. This sometimes caused the thread to be stuck in ABORTING + PENDING state during the test_smp_switch_torture in test/kernel/smp

To avoid such cases in the future, it is worth leaving the check in next_up

Fixes #60815