### PR TITLE
drivers: uart_nrfx_uarte: on clear async pointers when enabled

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -405,7 +405,7 @@ static int uart_nrfx_callback_set(const struct device *dev,
 	uart0_cb.callback = callback;
 	uart0_cb.user_data = user_data;
 
-#if defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS)
+#if defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS) && defined(CONFIG_UART_0_INTERRUPT_DRIVEN)
 	irq_callback = NULL;
 	irq_cb_data = NULL;
 #endif
@@ -929,7 +929,7 @@ static void uart_nrfx_irq_callback_set(const struct device *dev,
 	irq_callback = cb;
 	irq_cb_data = cb_data;
 
-#if defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS)
+#if defined(CONFIG_UART_0_ASYNC) && defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS)
 	uart0_cb.callback = NULL;
 	uart0_cb.user_data = NULL;
 #endif

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -937,7 +937,7 @@ static int uarte_nrfx_callback_set(const struct device *dev,
 	data->async->user_callback = callback;
 	data->async->user_data = user_data;
 
-#if defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS)
+#if defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS) && defined(UARTE_INTERRUPT_DRIVEN)
 	data->int_driven->cb = NULL;
 	data->int_driven->cb_data = NULL;
 #endif
@@ -1681,7 +1681,7 @@ static void uarte_nrfx_irq_callback_set(const struct device *dev,
 	data->int_driven->cb = cb;
 	data->int_driven->cb_data = cb_data;
 
-#if defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS)
+#if defined(UARTE_ANY_ASYNC) && defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS)
 	data->async->user_callback = NULL;
 	data->async->user_data = NULL;
 #endif


### PR DESCRIPTION
Hi, bumped into this in the weekly CI run (https://github.com/zephyrproject-rtos/zephyr/runs/15266827632)

To reproduce: `west build -p -b xiao_ble -T tests/drivers/uart/uart_async_api/drivers.uart.async_api` and `west build -p -b degu_evk -T tests/drivers/uart/uart_async_api/drivers.uart.async_api.rtt`

---

Fix a build error introduced in 9f02eeadf8, the async pointers are only available when UARTE_ANY_ASYNC is set.