### PR TITLE
soc: silabs_exx32: define an empty pm_state_exit_post_ops

### DIFF
--- a/soc/arm/silabs_exx32/common/soc_power_pmgr.c
+++ b/soc/arm/silabs_exx32/common/soc_power_pmgr.c
@@ -73,6 +73,11 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 	__enable_irq();
 }
 
+void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+}
 
 /**
  * Some SiLabs blobs, such as RAIL, call directly into sl_power_manager, and


### PR DESCRIPTION
Hi, bumped into this in the weekly CI run (https://github.com/zephyrproject-rtos/zephyr/runs/15266827632)

To reproduce: `west build -p -b efr32bg27_brd2602a -T tests/subsys/pm/device_runtime_api/pm.device_runtime.api`

@gmarull is this the right fix? `soc/arm/silabs_exx32/common/soc_power.c` is the other power management file for this platform and it also has this empty.

---

Some EFR32 build broke after 3d2194f11e with:

pm.c:152: undefined reference to `pm_state_exit_post_ops'

Add an extra empty function to make this one build again.