### PR TITLE
drivers: bluetooth: slz_hci: Fix incoming HCI packet handling

### DIFF
--- a/drivers/bluetooth/hci/slz_hci.c
+++ b/drivers/bluetooth/hci/slz_hci.c
@@ -76,7 +76,8 @@ uint32_t hci_common_transport_transmit(uint8_t *data, int16_t len)
 	}
 
 	net_buf_add_mem(buf, data, len);
-	if ((packet_type == h4_event) && (flags & BT_HCI_EVT_FLAG_RECV_PRIO)) {
+	if (IS_ENABLED(CONFIG_BT_RECV_BLOCKING) &&
+	    (packet_type == h4_event) && (flags & BT_HCI_EVT_FLAG_RECV_PRIO)) {
 		bt_recv_prio(buf);
 	} else {
 		bt_recv(buf);


### PR DESCRIPTION
Currently, HCI packet handling does not consider the BT_RECV_CONTEXT choice selection. It calls bt_recv() and bt_recv_prio() only depending on the HCI packet type and event flags.
However, for selections other than BT_RECV_BLOCKING, the "HCI driver shall not call bt_recv_prio()". Fix that by only calling bt_recv_prio() when CONFIG_BT_RECV_BLOCKING is enabled.