### PR TITLE
rtio: Remove references to simple executor

### DIFF
--- a/doc/services/rtio/index.rst
+++ b/doc/services/rtio/index.rst
@@ -147,8 +147,7 @@ is 4 byte aligned.
   #define MEM_BLK_SIZE  16
   #define MEM_BLK_ALIGN 4
 
-  RTIO_EXECUTOR_SIMPLE_DEFINE(simple_exec);
-  RTIO_DEFINE_WITH_MEMPOOL(rtio_context, (struct rtio_executor *)&simple_exec,
+  RTIO_DEFINE_WITH_MEMPOOL(rtio_context,
       SQ_SIZE, CQ_SIZE, MEM_BLK_COUNT, MEM_BLK_SIZE, MEM_BLK_ALIGN);
 
 When a read is needed, the caller simply needs to replace the call

--- a/drivers/i2c/i2c_sam_twihs_rtio.c
+++ b/drivers/i2c/i2c_sam_twihs_rtio.c
@@ -26,7 +26,6 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
 #include <zephyr/rtio/rtio.h>
-#include <zephyr/rtio/rtio_executor_simple.h>
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -422,9 +421,7 @@ static const struct i2c_driver_api i2c_sam_twihs_driver_api = {
 			    DEVICE_DT_INST_GET(n), 0);						\
 	}											\
 												\
-	RTIO_EXECUTOR_SIMPLE_DEFINE(_i2c##n##_sam_rtio_exec);					\
 	RTIO_DEFINE(_i2c##n##_sam_rtio,								\
-		    (struct rtio_executor *)&_i2c##n##_sam_rtio_exec,				\
 		    CONFIG_I2C_SAM_TWIHS_SQ_SIZE,						\
 		    CONFIG_I2C_SAM_TWIHS_CQ_SIZE);						\
 												\


### PR DESCRIPTION
The simple executor was removed with the usage of the spsc queue but some stray references remained. Remove those.

Fixes #60730 