### PR TITLE
cbprintf: use type instead of name in sizeof

### DIFF
--- a/include/zephyr/sys/cbprintf_cxx.h
+++ b/include/zephyr/sys/cbprintf_cxx.h
@@ -96,17 +96,12 @@ static inline size_t z_cbprintf_cxx_arg_size(float f)
 	return sizeof(double);
 }
 
-static inline size_t z_cbprintf_cxx_arg_size(void *p)
-{
-	ARG_UNUSED(p);
-
-	return sizeof(void *);
-}
-
 template < typename T >
 static inline size_t z_cbprintf_cxx_arg_size(T arg)
 {
-	return sizeof(arg + 0);
+	ARG_UNUSED(arg);
+
+	return MAX(sizeof(T), sizeof(int));
 }
 
 /* C++ version for storing arguments. */


### PR DESCRIPTION
Using `arg + 0` in sizeof causes problems with `void *`, so use the type name instead. This allows deleting the specialization for `void *`, which the linker wasn't choosing reliably anyway.