### PR TITLE
tests: drivers: spi loopback: esp32xx: Use internal loopback

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/esp32.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/esp32.overlay
@@ -36,6 +36,6 @@
 
 &spi3 {
 	dma-enabled;
-	pinctrl-0 = <&spim3_default>;
+	pinctrl-0 = <&spim3_loopback>;
 
 };

--- a/tests/drivers/spi/spi_loopback/boards/esp32c3_devkitm.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/esp32c3_devkitm.overlay
@@ -36,5 +36,5 @@
 
 &spi2 {
 	dma-enabled;
-	pinctrl-0 = <&spim2_default>;
+	pinctrl-0 = <&spim2_loopback>;
 };


### PR DESCRIPTION
Use pinctrl with internal loopback enabled for ESP32 and ESP32C3.