### PR TITLE
toolchain: gcc: fix GCC < 11.0.0 build with -Wundef 

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -639,7 +639,8 @@ do {                                                                    \
  *
  * @note Only supported for GCC >= 11.0.0 or Clang >= 7.
  */
-#if (TOOLCHAIN_GCC_VERSION >= 110000) || (TOOLCHAIN_CLANG_VERSION >= 70000)
+#if (TOOLCHAIN_GCC_VERSION >= 110000) || \
+	(defined(TOOLCHAIN_CLANG_VERSION) && (TOOLCHAIN_CLANG_VERSION >= 70000))
 #define FUNC_NO_STACK_PROTECTOR __attribute__((no_stack_protector))
 #else
 #define FUNC_NO_STACK_PROTECTOR


### PR DESCRIPTION
toolchain: gcc: fix GCC < 11.0.0 build with -Wundef

When building using GCC version < 11.0.0, TOOLCHAIN_CLANG_VERSION is not
yet defined in gcc.h. Nevertheless, it's still needed due to reuse of
gcc.h in llvm.h.

Guard access to TOOLCHAIN_CLANG_VERSION to fix that.
