### PR TITLE
tests: cpp/libcxx: change test filter for picolibc

### DIFF
--- a/tests/lib/cpp/libcxx/testcase.yaml
+++ b/tests/lib/cpp/libcxx/testcase.yaml
@@ -24,7 +24,7 @@ tests:
     integration_platforms:
       - mps2_an385
   cpp.libcxx.glibcxx.picolibc:
-    filter: TOOLCHAIN_HAS_PICOLIBC == 1
+    filter: CONFIG_PICOLIBC_SUPPORTED and not CONFIG_NATIVE_BUILD
     toolchain_exclude: xcc
     tags: cpp
     timeout: 60


### PR DESCRIPTION
TOOLCHAIN_HAS_PICOLIBC actually does not exist, so the test never runs under twister. Use CONFIG_PICOLIBC_SUPPORTED instead for filter (the same as in tests/lib/cpp/cxx).