### PR TITLE
stm32u5: fix incorrect flas write width

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -45,6 +45,15 @@ static const struct flash_parameters flash_stm32_parameters = {
 
 static int flash_stm32_write_protection(const struct device *dev, bool enable);
 
+bool __weak flash_stm32_valid_range(const struct device *dev, off_t offset,
+				    uint32_t len, bool write)
+{
+	if (write && !flash_stm32_valid_write(offset, len)) {
+		return false;
+	}
+	return flash_stm32_range_exists(dev, offset, len);
+}
+
 int __weak flash_stm32_check_configuration(void)
 {
 	return 0;

--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -257,6 +257,12 @@ static inline bool flash_stm32_range_exists(const struct device *dev,
 }
 #endif	/* CONFIG_FLASH_PAGE_LAYOUT */
 
+static inline bool flash_stm32_valid_write(off_t offset, uint32_t len)
+{
+	return ((offset % FLASH_STM32_WRITE_BLOCK_SIZE == 0) &&
+		(len % FLASH_STM32_WRITE_BLOCK_SIZE == 0U));
+}
+
 bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 			     uint32_t len, bool write);
 

--- a/drivers/flash/flash_stm32f1x.c
+++ b/drivers/flash/flash_stm32f1x.c
@@ -163,17 +163,6 @@ static int write_value(const struct device *dev, off_t offset,
 	return rc;
 }
 
-/* offset and len must be aligned on 2 for write
- * positive and not beyond end of flash
- */
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
-			     uint32_t len,
-			     bool write)
-{
-	return (!write || (offset % 2 == 0 && len % 2 == 0U)) &&
-		flash_stm32_range_exists(dev, offset, len);
-}
-
 int flash_stm32_block_erase_loop(const struct device *dev,
 				 unsigned int offset,
 				 unsigned int len)

--- a/drivers/flash/flash_stm32g0x.c
+++ b/drivers/flash/flash_stm32g0x.c
@@ -40,20 +40,6 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #define STM32G0_PAGES_PER_BANK		\
 	((STM32G0_FLASH_SIZE / STM32G0_FLASH_PAGE_SIZE) / STM32G0_BANK_COUNT)
 
-/*
- * offset and len must be aligned on 8 for write,
- * positive and not beyond end of flash
- * On dual-bank SoCs memory accesses starting on the first bank and continuing
- * beyond the first bank into the second bank are allowed.
- */
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
-			     uint32_t len,
-			     bool write)
-{
-	return (!write || (offset % 8 == 0 && len % 8 == 0)) &&
-		flash_stm32_range_exists(dev, offset, len);
-}
-
 static inline void flush_cache(FLASH_TypeDef *regs)
 {
 	if (regs->ACR & FLASH_ACR_ICEN) {

--- a/drivers/flash/flash_stm32g4x.c
+++ b/drivers/flash/flash_stm32g4x.c
@@ -42,8 +42,10 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 	}
 #endif
 
-	return (!write || (offset % 8 == 0 && len % 8 == 0U)) &&
-		flash_stm32_range_exists(dev, offset, len);
+	if (write && !flash_stm32_valid_write(offset, len)) {
+		return false;
+	}
+	return flash_stm32_range_exists(dev, offset, len);
 }
 
 static inline void flush_cache(FLASH_TypeDef *regs)

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -32,16 +32,6 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #define CONTROL_DCACHE
 #endif
 
-/* offset and len must be aligned on 8 for write
- * , positive and not beyond end of flash */
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
-			     uint32_t len,
-			     bool write)
-{
-	return (!write || (offset % 8 == 0 && len % 8 == 0U)) &&
-		flash_stm32_range_exists(dev, offset, len);
-}
-
 static inline void flush_cache(FLASH_TypeDef *regs)
 {
 	if (regs->ACR & FLASH_ACR_DCEN) {

--- a/drivers/flash/flash_stm32l5x.c
+++ b/drivers/flash/flash_stm32l5x.c
@@ -128,7 +128,7 @@ static int icache_wait_for_invalidate_complete(void)
 #endif /* CONFIG_SOC_SERIES_STM32H5X */
 
 /*
- * offset and len must be aligned on 8 for write,
+ * offset and len must be aligned on write-block-size for write,
  * positive and not beyond end of flash
  */
 bool flash_stm32_valid_range(const struct device *dev, off_t offset,
@@ -149,8 +149,10 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 		}
 	}
 
-	return (!write || (offset % 8 == 0 && len % 8 == 0U)) &&
-		flash_stm32_range_exists(dev, offset, len);
+	if (write && !flash_stm32_valid_write(offset, len)) {
+		return false;
+	}
+	return flash_stm32_range_exists(dev, offset, len);
 }
 
 static int write_dword(const struct device *dev, off_t offset, uint64_t val)

--- a/drivers/flash/flash_stm32wbax.c
+++ b/drivers/flash/flash_stm32wbax.c
@@ -105,18 +105,6 @@ static int icache_wait_for_invalidate_complete(void)
 	return status;
 }
 
-/*
- * offset and len must be aligned on 16 for write,
- * positive and not beyond end of flash
- */
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
-			     uint32_t len,
-			     bool write)
-{
-	return (!write || (offset % 16 == 0 && len % 16 == 0U)) &&
-		flash_stm32_range_exists(dev, offset, len);
-}
-
 static int write_qword(const struct device *dev, off_t offset, const uint32_t *buff)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);

--- a/drivers/flash/flash_stm32wbx.c
+++ b/drivers/flash/flash_stm32wbx.c
@@ -26,17 +26,6 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 
 #define STM32WBX_PAGE_SHIFT	12
 
-/* offset and len must be aligned on 8 for write,
- * positive and not beyond end of flash
- */
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
-			     uint32_t len,
-			     bool write)
-{
-	return (!write || (offset % 8 == 0 && len % 8 == 0U)) &&
-	       flash_stm32_range_exists(dev, offset, len);
-}
-
 /*
  * Up to 255 4K pages
  */


### PR DESCRIPTION
This fixes #60724 and it was tested on the nucleo_u575zi_q using the test program mentioned in the ticket.

I loosely inspired myself from `write_qword()` in drivers/flash/flash_stm32wbax.c. But I see now that `write_ndwords()` from drivers/flash/flash_stm32h7x.c is maybe a better example.

Other drivers are hardcoding the write block size in `flash_stm32_valid_range()`, we could consider giving them the same treatment:
```
drivers/flash/flash_stm32f1x.c:173:     return (!write || (offset % 2 == 0 && len % 2 == 0U)) &&  
drivers/flash/flash_stm32g0x.c:53:      return (!write || (offset % 8 == 0 && len % 8 == 0)) &&  
drivers/flash/flash_stm32g4x.c:45:      return (!write || (offset % 8 == 0 && len % 8 == 0U)) &&  
drivers/flash/flash_stm32l4x.c:41:      return (!write || (offset % 8 == 0 && len % 8 == 0U)) &&  
drivers/flash/flash_stm32wbax.c:116:    return (!write || (offset % 16 == 0 && len % 16 == 0U)) &&  
drivers/flash/flash_stm32wbx.c:36:      return (!write || (offset % 8 == 0 && len % 8 == 0U)) &&
```