### PR TITLE
Improve lwm2m block transfer continue

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -259,6 +259,9 @@ struct coap_option {
  * @typedef coap_reply_t
  * @brief Helper function to be called when a response matches the
  * a pending request.
+ * When sending blocks, the callback is only executed when the
+ * reply of the last block is received.
+ * i.e. it is not called when the code of the reply is 'continue' (2.31).
  */
 typedef int (*coap_reply_t)(const struct coap_packet *response,
 			    struct coap_reply *reply,

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1499,7 +1499,9 @@ struct coap_reply *coap_response_received(
 		/* handle observed requests only if received in order */
 		if (age == -ENOENT || is_newer(r->age, age)) {
 			r->age = age;
-			r->reply(response, r, from);
+			if (coap_header_get_code(response) != COAP_RESPONSE_CODE_CONTINUE) {
+				r->reply(response, r, from);
+			}
 		}
 
 		return r;

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -510,12 +510,6 @@ static int do_registration_reply_cb(const struct coap_packet *response,
 			client.server_ep);
 
 		return 0;
-	} else if (code == COAP_RESPONSE_CODE_CONTINUE) {
-#if defined(CONFIG_LWM2M_COAP_BLOCK_TRANSFER)
-		return 0;
-#else
-		LOG_ERR("Response code CONTINUE not supported");
-#endif
 	}
 
 	LOG_ERR("Failed with code %u.%u (%s). Not Retrying.",


### PR DESCRIPTION
When using CoAP block-wise transfer with lwm2m the reply callback is only called when the last block was transfered. If the response code is 'continue' (2.31) the callback is not executed.