### PR TITLE
soc: arm: stm32h7x mapping system memory region

### DIFF
--- a/soc/arm/st_stm32/stm32h7/mpu_regions.c
+++ b/soc/arm/st_stm32/stm32h7/mpu_regions.c
@@ -12,6 +12,15 @@ static const struct arm_mpu_region mpu_regions[] = {
 					 REGION_FLASH_ATTR(REGION_FLASH_SIZE)),
 	MPU_REGION_ENTRY("SRAM", CONFIG_SRAM_BASE_ADDRESS,
 					 REGION_RAM_ATTR(REGION_SRAM_SIZE)),
+	/*
+	 * System memory attributes inhibit the speculative fetch,
+	 * preventing the RDSERR Flash error
+	 */
+	MPU_REGION_ENTRY("SYSTEM", 0x1FF00000,
+					{ (STRONGLY_ORDERED_SHAREABLE |
+					REGION_512K |
+					MPU_RASR_XN_Msk | P_RW_U_NA_Msk) }),
+
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(mac), okay)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(sram3), okay)
 	MPU_REGION_ENTRY("SRAM3_ETH_BUF",


### PR DESCRIPTION
System memory declared by the MPU as 'Execute-Never' will inhibit the speculative fetch, preventing the RDSERR.

This is explained by the https://community.st.com/t5/stm32-mcu-products/spurious-rdperr-and-rdserr-when-all-protection-and-security/td-p/279852

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/60449