### PR TITLE
drivers: usb: fix common misspellings in USB drivers, device_next, host

### DIFF
--- a/drivers/usb/device/usb_dc_it82xx2.c
+++ b/drivers/usb/device/usb_dc_it82xx2.c
@@ -301,7 +301,7 @@ static void it8xxx2_usb_dc_wuc_init(const struct device *dev)
 	/* Enabling the WUI */
 	it8xxx2_wuc_enable(cfg->wuc_list[0].wucs, cfg->wuc_list[0].mask);
 
-	/* Connect WU90 (USB D+) interrupt but make it disabled initally */
+	/* Connect WU90 (USB D+) interrupt but make it disabled initially */
 	IRQ_CONNECT(IT8XXX2_WU90_IRQ, 0, it82xx2_wu90_isr, 0, 0);
 }
 
@@ -1157,7 +1157,7 @@ int usb_dc_ep_enable(const uint8_t ep)
 	if (ep_idx < EP4) {
 		LOG_DBG("ep_idx < 4");
 		ep_regs[ep_idx].ep_ctrl |= ENDPOINT_EN;
-		LOG_DBG("EP%d Enbabled %02x", ep_idx, ep_regs[ep_idx].ep_ctrl);
+		LOG_DBG("EP%d Enabled %02x", ep_idx, ep_regs[ep_idx].ep_ctrl);
 	} else {
 		LOG_DBG("ep_idx >= 4");
 		it82xx2_usb_extend_ep_ctrl(ep_idx, EXT_EP_ENABLE);

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -878,7 +878,7 @@ static void usb_kinetis_isr_handler(void)
 		/*
 		 * Device reset is not possible because the stack does not
 		 * configure the endpoints after the USB_DC_RESET event,
-		 * therefore, we must reenable the default control 0 endpoint
+		 * therefore, we must re-enable the default control 0 endpoint
 		 * after a reset event
 		 */
 		USB0->CTL |= USB_CTL_ODDRST_MASK;

--- a/drivers/usb/device/usb_dc_sam_usbc.c
+++ b/drivers/usb/device/usb_dc_sam_usbc.c
@@ -1109,7 +1109,7 @@ int usb_dc_ep_flush(uint8_t ep)
 
 	dev_data.ep_data[ep_idx].out_at = 0U;
 
-	/* Reenable interrupts */
+	/* Re-enable interrupts */
 	usb_dc_ep_enable_interrupts(ep_idx);
 
 	irq_unlock(key);

--- a/drivers/usb/device/usb_dc_sam_usbhs.c
+++ b/drivers/usb/device/usb_dc_sam_usbhs.c
@@ -710,7 +710,7 @@ int usb_dc_ep_flush(uint8_t ep)
 	/* Reset the endpoint */
 	usb_dc_ep_reset(ep_idx);
 
-	/* Reenable interrupts */
+	/* Re-enable interrupts */
 	usb_dc_ep_enable_interrupts(ep_idx);
 
 	LOG_DBG("ep 0x%x", ep);

--- a/drivers/usb/device/usb_dw_registers.h
+++ b/drivers/usb/device/usb_dw_registers.h
@@ -198,7 +198,7 @@ BUILD_ASSERT(sizeof(struct usb_dw_reg) <= 0x0D00);
  * IN endpoint offsets 0x0900 + (0x20 * n), n = 0 .. x,
  * offset 0x0900 and 0x0B00 are hardcoded to control type.
  *
- * REVISE: Better own defenitions for DIEPTCTL0, DOEPTCTL0...
+ * REVISE: Better own definitions for DIEPTCTL0, DOEPTCTL0...
  */
 #define USB_DW_DEPCTL_EP_ENA			BIT(31)
 #define USB_DW_DEPCTL_EP_DIS			BIT(30)
@@ -242,7 +242,7 @@ BUILD_ASSERT(sizeof(struct usb_dw_reg) <= 0x0D00);
  * IN at offsets 0x0910 + (0x20 * n), n = 0 .. x,
  * OUT at offsets 0x0B10 + (0x20 * n), n = 0 .. x
  *
- * REVISE: Better own defenitions for DIEPTSIZ0, DOEPTSIZ0...
+ * REVISE: Better own definitions for DIEPTSIZ0, DOEPTSIZ0...
  */
 #define USB_DW_DEPTSIZ_PKT_CNT_OFFSET		19
 #define USB_DW_DIEPTSIZ0_PKT_CNT_MASK		(0x3 << 19)

--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -40,7 +40,7 @@ LOG_MODULE_REGISTER(usbfsotg, CONFIG_UDC_DRIVER_LOG_LEVEL);
 #define USBFSOTG_REV		0x33
 
 /*
- * There is no real advantage to change control enpoint size
+ * There is no real advantage to change control endpoint size
  * but we can use it for testing UDC driver API and higher layers.
  */
 #define USBFSOTG_MPS0		UDC_MPS0_64
@@ -498,7 +498,7 @@ static void xfer_work_handler(struct k_work *item)
 			udc_submit_event(ev->dev, UDC_EVT_ERROR, err);
 		}
 
-		/* Peek next transer */
+		/* Peek next transfer */
 		if (ev->ep != USB_CONTROL_EP_OUT && !udc_ep_is_busy(ev->dev, ev->ep)) {
 			if (usbfsotg_xfer_next(ev->dev, ep_cfg) == 0) {
 				udc_ep_set_busy(ev->dev, ev->ep, true);

--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -29,7 +29,7 @@
 LOG_MODULE_REGISTER(udc_nrf, CONFIG_UDC_DRIVER_LOG_LEVEL);
 
 /*
- * There is no real advantage to change control enpoint size
+ * There is no real advantage to change control endpoint size
  * but we can use it for testing UDC driver API and higher layers.
  */
 #define UDC_NRF_MPS0		UDC_MPS0_64

--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -478,7 +478,7 @@ static inline int udc_host_wakeup(const struct device *dev)
  * of the endpoint. All properties of the descriptor,
  * such as direction, and transfer type, should be set correctly.
  * If wMaxPacketSize value is zero, it will be
- * updated to maximum buffer size of the enpoint.
+ * updated to maximum buffer size of the endpoint.
  *
  * @param[in] dev        Pointer to device struct of the driver instance
  * @param[in] ep         Endpoint address (same as bEndpointAddress)

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -126,7 +126,7 @@ enum usbd_ch9_state {
 struct usbd_ch9_data {
 	/** Setup packet, up-to-date for the respective control request */
 	struct usb_setup_packet setup;
-	/** Control type, internaly used for stage verification */
+	/** Control type, internally used for stage verification */
 	int ctrl_type;
 	/** Protocol state of the USB device stack */
 	enum usbd_ch9_state state;
@@ -183,7 +183,7 @@ struct usbd_contex {
  * @brief Vendor Requests Table
  */
 struct usbd_cctx_vendor_req {
-	/** Array of vendor requests supportd by the class */
+	/** Array of vendor requests supported by the class */
 	const uint8_t *reqs;
 	/** Length of the array */
 	uint8_t len;

--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(usb_loopback, CONFIG_USBD_LOOPBACK_LOG_LEVEL);
  * interface and endpoint configuration.
  */
 
-/* Internal buffer for intermidiate test data */
+/* Internal buffer for intermediate test data */
 static uint8_t lb_buf[1024];
 
 #define LB_VENDOR_REQ_OUT		0x5b

--- a/subsys/usb/device_next/class/usbd_msc_scsi.c
+++ b/subsys/usb/device_next/class/usbd_msc_scsi.c
@@ -459,7 +459,7 @@ static int fill_inquiry(struct scsi_ctx *ctx,
 
 	memset(&r, 0, sizeof(struct scsi_inquiry_response));
 
-	/* Accesible; Direct access block device (SBC) */
+	/* Accessible; Direct access block device (SBC) */
 	r.peripheral = 0x00;
 	/* Removable; not a part of conglomerate. Note that when device is
 	 * accessible via USB Mass Storage, it should always be marked as
@@ -526,7 +526,7 @@ static int fill_vpd_page(struct scsi_ctx *ctx, enum vpd_page_code page,
 		return -ENOTSUP;
 	}
 
-	/* Accesible; Direct access block device (SBC) */
+	/* Accessible; Direct access block device (SBC) */
 	buf[0] = 0x00;
 	buf[1] = page;
 	sys_put_be16(offset, &buf[2]);

--- a/subsys/usb/device_next/usbd_ch9.h
+++ b/subsys/usb/device_next/usbd_ch9.h
@@ -131,7 +131,7 @@ usbd_get_setup_pkt(struct usbd_contex *const uds_ctx)
  *
  * @param[in] uds_ctx Pointer to a device context
  * @param[in] buf     Pointer to UDC request buffer
- * @param[in] err     Trasnfer status
+ * @param[in] err     Transfer status
  *
  * @return 0 on success, other values on fail.
  */

--- a/subsys/usb/device_next/usbd_class.c
+++ b/subsys/usb/device_next/usbd_class.c
@@ -313,7 +313,7 @@ int usbd_register_class(struct usbd_contex *const uds_ctx,
 
 	/* TODO: does it still need to be atomic ? */
 	if (atomic_test_bit(&data->state, USBD_CCTX_REGISTERED)) {
-		LOG_WRN("Class instance allready registered");
+		LOG_WRN("Class instance already registered");
 		ret = -EBUSY;
 		goto register_class_error;
 	}

--- a/subsys/usb/device_next/usbd_class.h
+++ b/subsys/usb/device_next/usbd_class.h
@@ -14,7 +14,7 @@
  *
  * @param[in] uds_ctx Pointer to device context
  * @param[in] buf     Pointer to UDC request buffer
- * @param[in] err     Trasnfer status
+ * @param[in] err     Transfer status
  *
  * @return usbd_class_request() return value
  */

--- a/subsys/usb/device_next/usbd_class_api.h
+++ b/subsys/usb/device_next/usbd_class_api.h
@@ -190,7 +190,7 @@ static inline void usbd_class_resumed(struct usbd_class_node *const node)
 }
 
 /**
- * @brief Class associated configuration activ handler
+ * @brief Class associated configuration active handler
  *
  * @note The execution of the handler must not block.
  *

--- a/subsys/usb/device_next/usbd_desc.c
+++ b/subsys/usb/device_next/usbd_desc.c
@@ -68,7 +68,7 @@ static void usbd_ascii7_to_utf16le(struct usbd_desc_node *const dn)
 /**
  * @brief Get common USB descriptor
  *
- * Get descriptor from internal descrptor list.
+ * Get descriptor from internal descriptor list.
  *
  * @param[in] dn     Pointer to descriptor node
  *

--- a/subsys/usb/device_next/usbd_desc.h
+++ b/subsys/usb/device_next/usbd_desc.h
@@ -12,7 +12,7 @@
 /**
  * @brief Get common USB descriptor
  *
- * Get descriptor from internal descrptor list.
+ * Get descriptor from internal descriptor list.
  *
  * @param[in] ctx    Pointer to USB device support context
  * @param[in] type   Descriptor type (bDescriptorType)

--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -72,7 +72,7 @@ static int ALWAYS_INLINE usbh_event_handler(struct usbh_contex *const ctx,
 		}
 		break;
 	case UHC_EVT_RESETED:
-		LOG_DBG("Bus reseted");
+		LOG_DBG("Bus reset");
 		/* TODO */
 		if (class_data && class_data->removed) {
 			ret = class_data->removed(ctx);

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -510,7 +510,7 @@ static int cmd_bus_reset(const struct shell *sh,
 	if (err) {
 		shell_error(sh, "host: Failed to perform bus reset %d", err);
 	} else {
-		shell_print(sh, "host: USB bus reseted");
+		shell_print(sh, "host: USB bus reset");
 	}
 
 	err = uhc_sof_enable(uhs_ctx.dev);


### PR DESCRIPTION
Fix common misspellings in USB drivers, device_next, host.