### PR TITLE
Add functions regarding CoAP block options

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -604,6 +604,19 @@ int coap_block_transfer_init(struct coap_block_context *ctx,
 int coap_append_descriptive_block_option(struct coap_packet *cpkt, struct coap_block_context *ctx);
 
 /**
+ * @brief Check if a descriptive block option is set in the packet.
+ *
+ * If the CoAP packet is a request then an available BLOCK1 option
+ * would be checked otherwise a BLOCK2 option would be checked.
+ *
+ * @param cpkt Packet to be checked.
+ *
+ * @return true if the corresponding block option is set,
+ *        false otherwise.
+ */
+bool coap_has_descriptive_block_option(struct coap_packet *cpkt);
+
+/**
  * @brief Remove BLOCK1 or BLOCK2 option from the packet.
  *
  * If the CoAP packet is a request then BLOCK1 is removed

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -455,6 +455,16 @@ int coap_packet_append_option(struct coap_packet *cpkt, uint16_t code,
 			      const uint8_t *value, uint16_t len);
 
 /**
+ * @brief Remove an option from the packet.
+ *
+ * @param cpkt Packet to be updated
+ * @param code Option code to remove from the packet, see #coap_option_num
+ *
+ * @return 0 in case of success or negative in case of error.
+ */
+int coap_packet_remove_option(struct coap_packet *cpkt, uint16_t code);
+
+/**
  * @brief Converts an option to its integer representation.
  *
  * Assumes that the number is encoded in the network byte order in the

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -439,9 +439,8 @@ int coap_find_options(const struct coap_packet *cpkt, uint16_t code,
 /**
  * @brief Appends an option to the packet.
  *
- * Note: options must be added in numeric order of their codes. Otherwise
- * error will be returned.
- * TODO: Add support for placing options according to its delta value.
+ * Note: options can be added out of numeric order of their codes. But
+ * it's more efficient to add them in order.
  *
  * @param cpkt Packet to be updated
  * @param code Option code to add to the packet, see #coap_option_num

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -604,6 +604,18 @@ int coap_block_transfer_init(struct coap_block_context *ctx,
 int coap_append_descriptive_block_option(struct coap_packet *cpkt, struct coap_block_context *ctx);
 
 /**
+ * @brief Remove BLOCK1 or BLOCK2 option from the packet.
+ *
+ * If the CoAP packet is a request then BLOCK1 is removed
+ * otherwise BLOCK2 is removed.
+ *
+ * @param cpkt Packet to be updated.
+ *
+ * @return 0 in case of success or negative in case of error.
+ */
+int coap_remove_descriptive_block_option(struct coap_packet *cpkt);
+
+/**
  * @brief Append BLOCK1 option to the packet.
  *
  * @param cpkt Packet to be updated

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -335,7 +335,7 @@ int coap_packet_append_option(struct coap_packet *cpkt, uint16_t code,
 		code = (code == cpkt->delta) ? 0 : code - cpkt->delta;
 	}
 
-	r = encode_option(cpkt, code, value, len, cpkt->offset);
+	r = encode_option(cpkt, code, value, len, cpkt->hdr_len + cpkt->opt_len);
 	if (r < 0) {
 		return -EINVAL;
 	}
@@ -603,6 +603,111 @@ static int parse_option(uint8_t *data, uint16_t offset, uint16_t *pos,
 	}
 
 	return r;
+}
+
+/* Remove the raw data of an option. Also adjusting offsets.
+ * But not adjusting code delta of the option after the removed one.
+ */
+static void remove_option_data(struct coap_packet *cpkt,
+			       const uint16_t to_offset,
+			       const uint16_t from_offset)
+{
+	const uint16_t move_size = from_offset - to_offset;
+
+	memmove(cpkt->data + to_offset, cpkt->data + from_offset, cpkt->offset - from_offset);
+	cpkt->opt_len -= move_size;
+	cpkt->offset -= move_size;
+}
+
+/* Remove an option (that is not the last one).
+ * Also adjusting the code delta of the option following the removed one.
+ */
+static int remove_middle_option(struct coap_packet *cpkt,
+				uint16_t offset,
+				uint16_t opt_delta,
+				const uint16_t previous_offset,
+				const uint16_t previous_code)
+{
+	int r;
+	struct coap_option option;
+	uint16_t opt_len = 0;
+
+	/* get the option after the removed one */
+	r = parse_option(cpkt->data, offset, &offset, cpkt->hdr_len + cpkt->opt_len,
+			 &opt_delta, &opt_len, &option);
+	if (r < 0) {
+		return -EILSEQ;
+	}
+
+	/* clear requested option and the one after (delta changed) */
+	remove_option_data(cpkt, previous_offset, offset);
+
+	/* reinsert option that comes after the removed option (with adjusted delta) */
+	r = encode_option(cpkt, option.delta - previous_code, option.value, option.len,
+			  previous_offset);
+	if (r < 0) {
+		return -EINVAL;
+	}
+	cpkt->opt_len += r;
+
+	return 0;
+}
+int coap_packet_remove_option(struct coap_packet *cpkt, uint16_t code)
+{
+	uint16_t offset = cpkt->hdr_len;
+	uint16_t opt_delta = 0;
+	uint16_t opt_len = 0;
+	uint16_t previous_offset = cpkt->hdr_len;
+	uint16_t previous_code = 0;
+	struct coap_option option;
+	int r;
+
+	if (!cpkt) {
+		return -EINVAL;
+	}
+
+	if (cpkt->opt_len == 0) {
+		return 0;
+	}
+
+	if (code > cpkt->delta) {
+		return 0;
+	}
+
+	/* Find the requested option */
+	while (offset < cpkt->hdr_len + cpkt->opt_len) {
+		r = parse_option(cpkt->data, offset, &offset, cpkt->hdr_len + cpkt->opt_len,
+				 &opt_delta, &opt_len, &option);
+		if (r < 0) {
+			return -EILSEQ;
+		}
+
+		if (opt_delta == code) {
+			break;
+		}
+
+		if (opt_delta > code) {
+			return 0;
+		}
+
+		previous_code = opt_delta;
+		previous_offset = offset;
+	}
+
+	/* Check if the found option is the last option */
+	if (cpkt->opt_len > opt_len) {
+		/* not last option */
+		r = remove_middle_option(cpkt, offset, opt_delta, previous_offset, previous_code);
+		if (r < 0) {
+			return r;
+		}
+	} else {
+		/* last option */
+		remove_option_data(cpkt, previous_offset, cpkt->hdr_len + cpkt->opt_len);
+		cpkt->delta = previous_code;
+	}
+
+	return 0;
 }
 
 int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1096,6 +1096,15 @@ int coap_append_descriptive_block_option(struct coap_packet *cpkt, struct coap_b
 	}
 }
 
+bool coap_has_descriptive_block_option(struct coap_packet *cpkt)
+{
+	if (is_request(cpkt)) {
+		return coap_get_option_int(cpkt, COAP_OPTION_BLOCK1) >= 0;
+	} else {
+		return coap_get_option_int(cpkt, COAP_OPTION_BLOCK2) >= 0;
+	}
+}
+
 int coap_remove_descriptive_block_option(struct coap_packet *cpkt)
 {
 	if (is_request(cpkt)) {

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1096,6 +1096,15 @@ int coap_append_descriptive_block_option(struct coap_packet *cpkt, struct coap_b
 	}
 }
 
+int coap_remove_descriptive_block_option(struct coap_packet *cpkt)
+{
+	if (is_request(cpkt)) {
+		return coap_packet_remove_option(cpkt, COAP_OPTION_BLOCK1);
+	} else {
+		return coap_packet_remove_option(cpkt, COAP_OPTION_BLOCK2);
+	}
+}
+
 int coap_append_block1_option(struct coap_packet *cpkt,
 			      struct coap_block_context *ctx)
 {

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -1261,4 +1261,350 @@ ZTEST(coap, test_build_options_out_of_order_1)
 	zassert_equal(cpkt.offset, 52, "Wrong data size");
 }
 
+#define ASSERT_OPTIONS_AND_PAYLOAD(cpkt, expected_opt_len, expected_data, expected_offset,         \
+				   expected_delta)                                                 \
+	do {                                                                                       \
+		size_t expected_data_l = ARRAY_SIZE(expected_data);                                \
+		zassert_equal(expected_offset, expected_data_l);                                   \
+		static const uint8_t expected_hdr_len = 9;                                         \
+		zassert_equal(expected_hdr_len, cpkt.hdr_len, "Wrong header length");              \
+		zassert_equal(expected_opt_len, cpkt.opt_len, "Wrong option length");              \
+		zassert_equal(expected_offset, cpkt.offset, "Wrong offset");                       \
+		zassert_mem_equal(expected_data, cpkt.data, expected_offset, "Wrong data");        \
+		zassert_equal(expected_delta, cpkt.delta, "Wrong delta");                          \
+	} while (0)
+
+static void init_basic_test_msg(struct coap_packet *cpkt, uint8_t *data)
+{
+	static const char token[] = "token";
+	const char *uri_path = "path";
+	const char *uri_host = "hostname";
+	const char *uri_query0 = "query0";
+	const char *uri_query1 = "query1";
+
+	memset(data_buf[0], 0, ARRAY_SIZE(data_buf[0]));
+
+	int r;
+
+	r = coap_packet_init(cpkt, data, COAP_BUF_SIZE, COAP_VERSION_1, COAP_TYPE_CON,
+			     strlen(token), token, COAP_METHOD_POST, 0x1234);
+	zassert_equal(r, 0, "Could not initialize packet");
+
+	r = coap_append_option_int(cpkt, COAP_OPTION_SIZE2,
+				   coap_block_size_to_bytes(COAP_BLOCK_128));
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_packet_append_option(cpkt, COAP_OPTION_URI_PATH, uri_path, strlen(uri_path));
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_append_option_int(cpkt, COAP_OPTION_CONTENT_FORMAT, COAP_CONTENT_FORMAT_APP_JSON);
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_packet_append_option(cpkt, COAP_OPTION_URI_HOST, uri_host, strlen(uri_host));
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_append_option_int(cpkt, COAP_OPTION_URI_PORT, 5638);
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_packet_append_option(cpkt, COAP_OPTION_URI_QUERY, uri_query0, strlen(uri_query0));
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_packet_append_option(cpkt, COAP_OPTION_URI_QUERY, uri_query1, strlen(uri_query1));
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_append_option_int(cpkt, COAP_OPTION_ACCEPT, COAP_CONTENT_FORMAT_APP_CBOR);
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_append_option_int(cpkt, COAP_OPTION_OBSERVE, 0);
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_append_option_int(cpkt, COAP_OPTION_MAX_AGE, 3);
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_append_option_int(cpkt, COAP_OPTION_SIZE1, 64);
+	zassert_equal(r, 0, "Could not append option");
+
+	static const uint8_t expected_9[] = {
+		0x45, 0x02, 0x12, 0x34, 't',  'o',  'k',  'e',	'n',  0x38, 'h',  'o',	's',
+		't',  'n',  'a',  'm',	'e',  0x30, 0x12, 0x16, 0x06, 'D',  'p',  'a',	't',
+		'h',  0x11, 0x32, 0x21, 0x03, 0x16, 'q',  'u',	'e',  'r',  'y',  0x30, 0x06,
+		'q',  'u',  'e',  'r',	'y',  0x31, 0x21, 0x3c, 0xb1, 0x80, 0xd1, 0x13, 0x40,
+	};
+
+	ASSERT_OPTIONS((*cpkt), 43, expected_9, 52);
+
+	r = coap_packet_append_payload_marker(cpkt);
+	zassert_equal(r, 0, "Could not append payload marker");
+
+	static const uint8_t test_payload[] = {0xde, 0xad, 0xbe, 0xef};
+
+	r = coap_packet_append_payload(cpkt, test_payload, ARRAY_SIZE(test_payload));
+	zassert_equal(r, 0, "Could not append test payload");
+
+	zassert_equal((*cpkt).hdr_len, 9, "Wrong header len");
+	zassert_equal((*cpkt).opt_len, 43, "Wrong options size");
+	zassert_equal((*cpkt).delta, 60, "Wrong delta");
+	zassert_equal((*cpkt).offset, 57, "Wrong data size");
+}
+
+ZTEST(coap, test_remove_first_coap_option)
+{
+	int r;
+	struct coap_packet cpkt;
+	uint8_t *data = data_buf[0];
+
+	init_basic_test_msg(&cpkt, data);
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_URI_HOST);
+	zassert_equal(r, 0, "Could not remove option");
+
+	static const uint8_t expected_0[] = {
+		0x45, 0x02, 0x12, 0x34, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x60, 0x12, 0x16,
+		0x06, 0x44, 0x70, 0x61, 0x74, 0x68, 0x11, 0x32, 0x21, 0x03, 0x16, 0x71,
+		0x75, 0x65, 0x72, 0x79, 0x30, 0x06, 0x71, 0x75, 0x65, 0x72, 0x79, 0x31,
+		0x21, 0x3c, 0xb1, 0x80, 0xd1, 0x13, 0x40, 0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 34, expected_0, 48, 60);
+}
+
+ZTEST(coap, test_remove_middle_coap_option)
+{
+	int r;
+	struct coap_packet cpkt;
+	uint8_t *data = data_buf[0];
+
+	init_basic_test_msg(&cpkt, data);
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_OBSERVE);
+	zassert_equal(r, 0, "Could not remove option");
+
+	static const uint8_t expected_0[] = {
+		0x45, 0x02, 0x12, 0x34, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x38, 0x68, 0x6f, 0x73, 0x74,
+		0x6e, 0x61, 0x6d, 0x65, 0x42, 0x16, 0x06, 0x44, 0x70, 0x61, 0x74, 0x68, 0x11, 0x32,
+		0x21, 0x03, 0x16, 0x71, 0x75, 0x65, 0x72, 0x79, 0x30, 0x06, 0x71, 0x75, 0x65, 0x72,
+		0x79, 0x31, 0x21, 0x3c, 0xb1, 0x80, 0xd1, 0x13, 0x40, 0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 42, expected_0, 56, 60);
+}
+
+ZTEST(coap, test_remove_last_coap_option)
+{
+	int r;
+	struct coap_packet cpkt;
+	uint8_t *data = data_buf[0];
+
+	init_basic_test_msg(&cpkt, data);
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_SIZE1);
+	zassert_equal(r, 0, "Could not remove option");
+
+	static const uint8_t expected_0[] = {
+		0x45, 0x02, 0x12, 0x34, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x38, 0x68, 0x6f, 0x73, 0x74,
+		0x6e, 0x61, 0x6d, 0x65, 0x30, 0x12, 0x16, 0x06, 0x44, 0x70, 0x61, 0x74, 0x68, 0x11,
+		0x32, 0x21, 0x03, 0x16, 0x71, 0x75, 0x65, 0x72, 0x79, 0x30, 0x06, 0x71, 0x75, 0x65,
+		0x72, 0x79, 0x31, 0x21, 0x3c, 0xb1, 0x80, 0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 40, expected_0, 54, 28);
+
+	r = coap_append_option_int(&cpkt, COAP_OPTION_SIZE1, 65);
+	zassert_equal(r, 0, "Could not add option at end");
+
+	static const uint8_t expected_1[] = {
+		0x45, 0x02, 0x12, 0x34, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x38, 0x68, 0x6f,
+		0x73, 0x74, 0x6e, 0x61, 0x6d, 0x65, 0x30, 0x12, 0x16, 0x06, 0x44, 0x70,
+		0x61, 0x74, 0x68, 0x11, 0x32, 0x21, 0x03, 0x16, 0x71, 0x75, 0x65, 0x72,
+		0x79, 0x30, 0x06, 0x71, 0x75, 0x65, 0x72, 0x79, 0x31, 0x21, 0x3c, 0xb1,
+		0x80, 0xd1, 0x13, 0x41, 0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 43, expected_1, 57, 60);
+}
+
+ZTEST(coap, test_remove_single_coap_option)
+{
+	struct coap_packet cpkt;
+	uint8_t *data = data_buf[0];
+
+	static const char token[] = "token";
+	const char *uri_path = "path";
+
+	memset(data_buf[0], 0, ARRAY_SIZE(data_buf[0]));
+
+	int r1;
+
+	r1 = coap_packet_init(&cpkt, data, COAP_BUF_SIZE, COAP_VERSION_1, COAP_TYPE_CON,
+			      strlen(token), token, COAP_METHOD_POST, 0x1234);
+	zassert_equal(r1, 0, "Could not initialize packet");
+
+	r1 = coap_packet_append_option(&cpkt, COAP_OPTION_URI_PATH, uri_path, strlen(uri_path));
+	zassert_equal(r1, 0, "Could not append option");
+
+	r1 = coap_packet_append_payload_marker(&cpkt);
+	zassert_equal(r1, 0, "Could not append payload marker");
+
+	static const uint8_t test_payload[] = {0xde, 0xad, 0xbe, 0xef};
+
+	r1 = coap_packet_append_payload(&cpkt, test_payload, ARRAY_SIZE(test_payload));
+	zassert_equal(r1, 0, "Could not append test payload");
+
+	static const uint8_t expected_0[] = {0x45, 0x02, 0x12, 0x34, 0x74, 0x6f, 0x6b,
+					     0x65, 0x6e, 0xb4, 0x70, 0x61, 0x74, 0x68,
+					     0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 5, expected_0, 19, 11);
+
+	/* remove the one and only option */
+	r1 = coap_packet_remove_option(&cpkt, COAP_OPTION_URI_PATH);
+	zassert_equal(r1, 0, "Could not remove option");
+
+	static const uint8_t expected_1[] = {0x45, 0x02, 0x12, 0x34, 0x74, 0x6f, 0x6b,
+					     0x65, 0x6e, 0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 0, expected_1, 14, 0);
+}
+
+ZTEST(coap, test_remove_repeatable_coap_option)
+{
+	int r;
+	struct coap_packet cpkt;
+	uint8_t *data = data_buf[0];
+
+	init_basic_test_msg(&cpkt, data);
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_URI_QUERY);
+	zassert_equal(r, 0, "Could not remove option");
+
+	static const uint8_t expected_0[] = {
+		0x45, 0x02, 0x12, 0x34, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x38, 0x68, 0x6f, 0x73,
+		0x74, 0x6e, 0x61, 0x6d, 0x65, 0x30, 0x12, 0x16, 0x06, 0x44, 0x70, 0x61, 0x74,
+		0x68, 0x11, 0x32, 0x21, 0x03, 0x16, 0x71, 0x75, 0x65, 0x72, 0x79, 0x31, 0x21,
+		0x3c, 0xb1, 0x80, 0xd1, 0x13, 0x40, 0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 36, expected_0, 50, 60);
+}
+
+ZTEST(coap, test_remove_all_coap_options)
+{
+	int r;
+	struct coap_packet cpkt;
+	uint8_t *data = data_buf[0];
+
+	init_basic_test_msg(&cpkt, data);
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_URI_PORT);
+	zassert_equal(r, 0, "Could not remove option");
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_OBSERVE);
+	zassert_equal(r, 0, "Could not remove option");
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_SIZE1);
+	zassert_equal(r, 0, "Could not remove option");
+
+	static const uint8_t expected_0[] = {
+		0x45, 0x02, 0x12, 0x34, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x38, 0x68, 0x6f, 0x73,
+		0x74, 0x6e, 0x61, 0x6d, 0x65, 0x84, 0x70, 0x61, 0x74, 0x68, 0x11, 0x32, 0x21,
+		0x03, 0x16, 0x71, 0x75, 0x65, 0x72, 0x79, 0x30, 0x06, 0x71, 0x75, 0x65, 0x72,
+		0x79, 0x31, 0x21, 0x3c, 0xb1, 0x80, 0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 36, expected_0, 50, 28);
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_URI_HOST);
+	zassert_equal(r, 0, "Could not remove option");
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_SIZE2);
+	zassert_equal(r, 0, "Could not remove option");
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_CONTENT_FORMAT);
+	zassert_equal(r, 0, "Could not remove option");
+
+	static const uint8_t expected_1[] = {
+		0x45, 0x02, 0x12, 0x34, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0xb4, 0x70, 0x61, 0x74,
+		0x68, 0x31, 0x03, 0x16, 0x71, 0x75, 0x65, 0x72, 0x79, 0x30, 0x06, 0x71, 0x75,
+		0x65, 0x72, 0x79, 0x31, 0x21, 0x3c, 0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 23, expected_1, 37, 17);
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_ACCEPT);
+	zassert_equal(r, 0, "Could not remove option");
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_URI_PATH);
+	zassert_equal(r, 0, "Could not remove option");
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_URI_QUERY);
+	zassert_equal(r, 0, "Could not remove option");
+
+	static const uint8_t expected_2[] = {0x45, 0x02, 0x12, 0x34, 0x74, 0x6f, 0x6b, 0x65,
+					     0x6e, 0xd1, 0x01, 0x03, 0x16, 0x71, 0x75, 0x65,
+					     0x72, 0x79, 0x31, 0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 10, expected_2, 24, 15);
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_MAX_AGE);
+	zassert_equal(r, 0, "Could not remove option");
+
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_URI_QUERY);
+	zassert_equal(r, 0, "Could not remove option");
+
+	static const uint8_t expected_3[] = {0x45, 0x02, 0x12, 0x34, 0x74, 0x6f, 0x6b,
+					     0x65, 0x6e, 0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 0, expected_3, 14, 0);
+
+	/* remove option that is not there anymore */
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_MAX_AGE);
+	zassert_equal(r, 0, "Could not remove option");
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 0, expected_3, 14, 0);
+}
+
+ZTEST(coap, test_remove_non_existent_coap_option)
+{
+	int r;
+	struct coap_packet cpkt;
+	uint8_t *data = data_buf[0];
+	static const char token[] = "token";
+
+	memset(data_buf[0], 0, ARRAY_SIZE(data_buf[0]));
+
+	r = coap_packet_init(&cpkt, data, COAP_BUF_SIZE, COAP_VERSION_1, COAP_TYPE_CON,
+			     strlen(token), token, COAP_METHOD_POST, 0x1234);
+	zassert_equal(r, 0, "Could not initialize packet");
+
+	r = coap_append_option_int(&cpkt, COAP_OPTION_CONTENT_FORMAT, COAP_CONTENT_FORMAT_APP_CBOR);
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_append_option_int(&cpkt, COAP_OPTION_ACCEPT, COAP_CONTENT_FORMAT_APP_OCTET_STREAM);
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_packet_append_payload_marker(&cpkt);
+	zassert_equal(r, 0, "Could not append payload marker");
+
+	static const uint8_t test_payload[] = {0xde, 0xad, 0xbe, 0xef};
+
+	r = coap_packet_append_payload(&cpkt, test_payload, ARRAY_SIZE(test_payload));
+
+	static const uint8_t expected_original_msg[] = {0x45, 0x02, 0x12, 0x34, 0x74, 0x6f,
+							0x6b, 0x65, 0x6e, 0xc1, 0x3c, 0x51,
+							0x2a, 0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 4, expected_original_msg, 18, 17);
+
+	/* remove option that is not there but would be before existing options */
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_URI_PATH);
+	zassert_equal(r, 0, "Could not remove option");
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 4, expected_original_msg, 18, 17);
+
+	/* remove option that is not there but would be between existing options */
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_MAX_AGE);
+	zassert_equal(r, 0, "Could not remove option");
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 4, expected_original_msg, 18, 17);
+
+	/* remove option that is not there but would be after existing options */
+	r = coap_packet_remove_option(&cpkt, COAP_OPTION_LOCATION_QUERY);
+	zassert_equal(r, 0, "Could not remove option");
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 4, expected_original_msg, 18, 17);
+}
+
 ZTEST_SUITE(coap, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Some utility functions regarding CoAP options:

- Possibility to remove a CoAP option from a message
- Check if a block option is avalable in a message
- Documentation improvements
- Tests