### PR TITLE
soc: riscv: Add ability for SOC to use custom sys_io functions

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -90,6 +90,16 @@ config RISCV_SOC_HAS_CUSTOM_IRQ_LOCK_OPS
 	  the RISC-V SoC needs to do something different and more than reading and
 	  writing the mstatus register to lock and unlock the IRQs.
 
+config RISCV_SOC_HAS_CUSTOM_SYS_IO
+	bool
+	help
+	  Hidden option to allow SoC to overwrite sys_read*(), sys_write*() functions with
+	  platform-specific versions named z_soc_sys_read*() and z_soc_sys_write*().
+
+	  Enable this hidden option and specialize the z_soc_* functions when
+	  the RISC-V SoC needs to do something different and more than reading and
+	  writing the registers.
+
 config RISCV_SOC_CONTEXT_SAVE
 	bool "SOC-based context saving in IRQ handlers"
 	select RISCV_SOC_OFFSETS

--- a/include/zephyr/arch/riscv/arch.h
+++ b/include/zephyr/arch/riscv/arch.h
@@ -18,8 +18,8 @@
 #include <zephyr/arch/riscv/thread.h>
 #include <zephyr/arch/riscv/exp.h>
 #include <zephyr/arch/riscv/irq.h>
+#include <zephyr/arch/riscv/sys_io.h>
 #include <zephyr/arch/common/sys_bitops.h>
-#include <zephyr/arch/common/sys_io.h>
 #include <zephyr/arch/common/ffs.h>
 #if defined(CONFIG_USERSPACE)
 #include <zephyr/arch/riscv/syscall.h>

--- a/include/zephyr/arch/riscv/sys_io.h
+++ b/include/zephyr/arch/riscv/sys_io.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Memory mapped registers I/O functions in riscv arch C code */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_RISCV_SYS_IO_H_
+#define ZEPHYR_INCLUDE_ARCH_RISCV_SYS_IO_H_
+
+#ifndef _ASMLANGUAGE
+
+#include <zephyr/toolchain.h>
+#include <zephyr/types.h>
+#include <zephyr/sys/sys_io.h>
+
+#ifndef CONFIG_RISCV_SOC_HAS_CUSTOM_SYS_IO
+#include <zephyr/arch/common/sys_io.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef CONFIG_RISCV_SOC_HAS_CUSTOM_SYS_IO
+
+extern uint8_t z_soc_sys_read8(mem_addr_t addr);
+extern void z_soc_sys_write8(uint8_t data, mem_addr_t addr);
+extern uint16_t z_soc_sys_read16(mem_addr_t addr);
+extern void z_soc_sys_write16(uint16_t data, mem_addr_t addr);
+extern uint32_t z_soc_sys_read32(mem_addr_t addr);
+extern void z_soc_sys_write32(uint32_t data, mem_addr_t addr);
+extern uint64_t z_soc_sys_read64(mem_addr_t addr);
+extern void z_soc_sys_write64(uint64_t data, mem_addr_t addr);
+
+static ALWAYS_INLINE uint8_t sys_read8(mem_addr_t addr)
+{
+	return z_soc_sys_read8(addr);
+}
+
+static ALWAYS_INLINE void sys_write8(uint8_t data, mem_addr_t addr)
+{
+	return z_soc_sys_write8(data, addr);
+}
+
+static ALWAYS_INLINE uint16_t sys_read16(mem_addr_t addr)
+{
+	return z_soc_sys_read16(addr);
+}
+
+static ALWAYS_INLINE void sys_write16(uint16_t data, mem_addr_t addr)
+{
+	return z_soc_sys_write16(data, addr);
+}
+
+static ALWAYS_INLINE uint32_t sys_read32(mem_addr_t addr)
+{
+	return z_soc_sys_read32(addr);
+}
+
+static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
+{
+	return z_soc_sys_write32(data, addr);
+}
+
+static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
+{
+	return z_soc_sys_read64(addr);
+}
+
+static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
+{
+	return z_soc_sys_write64(data, addr);
+}
+
+#endif /* CONFIG_RISCV_SOC_HAS_CUSTOM_SYS_IO */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_RISCV_SYS_IO_H_ */

--- a/soc/riscv/litex-vexriscv/soc.h
+++ b/soc/riscv/litex-vexriscv/soc.h
@@ -9,7 +9,7 @@
 
 #include "../riscv-privileged/common/soc_common.h"
 #include <zephyr/devicetree.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/arch/riscv/sys_io.h>
 
 #ifndef _ASMLANGUAGE
 /* CSR access helpers */

--- a/soc/riscv/riscv-privileged/efinix-sapphire/soc.h
+++ b/soc/riscv/riscv-privileged/efinix-sapphire/soc.h
@@ -8,7 +8,7 @@
 #define __RISCV32_EFINIX_SAPPHIRE_SOC_H_
 
 #include "soc_common.h"
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/arch/riscv/sys_io.h>
 #include <zephyr/devicetree.h>
 
 #ifndef _ASMLANGUAGE


### PR DESCRIPTION
Add Kconfig `SOC_HAS_CUSTOM_SYS_IO` symbol that an SoC can set to specify that it has a custom implementation for sys_io functions.