### PR TITLE
pm: some more cleanups

### DIFF
--- a/boards/arm/b_g474e_dpow1/b_g474e_dpow1.dts
+++ b/boards/arm/b_g474e_dpow1/b_g474e_dpow1.dts
@@ -63,12 +63,6 @@
 		};
 	};
 
-	cpus {
-		cpu@0 {
-			cpu-power-states = <&stop0 &stop1>;
-		};
-	};
-
 	aliases {
 		led0 = &blue_led_2;
 		led1 = &orange_led_3;

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -71,10 +71,6 @@
 	apb3-prescaler = <1>;
 };
 
-&cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
-};
-
 &lptim1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000800>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -71,10 +71,6 @@
 	};
 };
 
-&cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
-};
-
 &clk_lsi {
 	status = "okay";
 };

--- a/boards/arm/efr32_thunderboard/thunderboard.dtsi
+++ b/boards/arm/efr32_thunderboard/thunderboard.dtsi
@@ -62,10 +62,10 @@
 
 &cpu0 {
 	clock-frequency = <76800000>;
-	/* Enable EM1,2. This means BURTC has to be used as sys_clock
-	 * or the system won't wake up
-	 */
-	cpu-power-states = <&pstate_em1 &pstate_em2>;
+};
+
+&pstate_em3 {
+	status = "disabled";
 };
 
 &usart0 {

--- a/boards/arm/nucleo_g070rb/nucleo_g070rb.dts
+++ b/boards/arm/nucleo_g070rb/nucleo_g070rb.dts
@@ -158,10 +158,6 @@
 	};
 };
 
-&cpu0 {
-	cpu-power-states = <&stop0 &stop1>;
-};
-
 &vref {
 	status = "okay";
 };

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -166,10 +166,6 @@
 	};
 };
 
-&cpu0 {
-	cpu-power-states = <&stop0 &stop1>;
-};
-
 &lptim1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -209,10 +209,6 @@ zephyr_udc0: &usb {
 	};
 };
 
-&cpu0 {
-	cpu-power-states = <&stop0 &stop1>;
-};
-
 &lptim1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -45,12 +45,6 @@
 		};
 	};
 
-	cpus {
-		cpu@0 {
-			cpu-power-states = <&stop0 &stop1>;
-		};
-	};
-
 	aliases {
 		led0 = &green_led;
 		pwm-led0 = &green_pwm_led;

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -73,10 +73,6 @@
 	apb2-prescaler = <1>;
 };
 
-&cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
-};
-
 &lptim1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -103,10 +103,6 @@
 	apb2-prescaler = <1>;
 };
 
-&cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
-};
-
 &usart1 {
 	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pb7>;
 	pinctrl-names = "default";

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -66,10 +66,6 @@
 	};
 };
 
-&cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
-};
-
 &clk_lsi {
 	status = "okay";
 };

--- a/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
+++ b/boards/arm/olimex_lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
@@ -43,10 +43,6 @@
 	};
 };
 
-&cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
-};
-
 &lptim1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -37,10 +37,6 @@
 	};
 };
 
-&cpu0 {
-	cpu-power-states = <&stop0 &stop1 &stop2>;
-};
-
 &clk_hsi48 {
 	status = "okay";
 };

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -140,7 +140,6 @@
 
 &cpu0 {
 	clock-frequency = <120000000>;
-	cpu-power-states = <&idle &stop>;
 };
 
 &idle {

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -28,6 +28,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			cpu-power-states = <&idle &stop &pstop1 &pstop2>;
 		};
 
 		power-states {

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -36,7 +36,7 @@
 			 * has implications on system performance. Read
 			 * KConfig documentation entry before enabling it.
 			 */
-			cpu-power-states = <&pstate_em1>;
+			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em3>;
 		};
 
 		power-states {

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -75,19 +75,6 @@
 				min-residency-us = <20000>;
 				exit-latency-us = <2000>;
 			};
-
-			/*
-			 * EM4 does not preserve CPU or RAM state, so system runs
-			 * through a cold boot upon wake up. BURTC can wake up the
-			 * system from EM4 but that has to be manually configured
-			 * by the application in BURTC registers.
-			 */
-			pstate_em4: em4 {
-				compatible = "zephyr,power-state";
-				power-state-name = "soft-off";
-				min-residency-us = <100000>;
-				exit-latency-us = <80000>;
-			};
 		};
 	};
 

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -33,6 +33,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m0+";
 			reg = <0>;
+			cpu-power-states = <&stop0 &stop1>;
 		};
 
 		power-states {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -32,6 +32,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			cpu-power-states = <&stop0 &stop1>;
 		};
 
 		power-states {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -32,6 +32,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			cpu-power-states = <&stop0 &stop1 &stop2>;
 		};
 
 		power-states {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -35,6 +35,7 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			cpu-power-states = <&stop0 &stop1 &stop2>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -36,6 +36,7 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			cpu-power-states = <&stop0 &stop1 &stop2>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -31,6 +31,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			cpu-power-states = <&stop0 &stop1 &stop2>;
 		};
 
 		power-states {

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -159,24 +159,41 @@ struct pm_state_info {
 /** @cond INTERNAL_HIDDEN */
 
 /**
+ * @brief Helper macro that expands to 1 if a phandle node is enabled, 0 otherwise.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property holding phandle-array.
+ * @param idx Index within the array.
+ */
+#define Z_DT_PHANDLE_01(node_id, prop, idx) \
+	COND_CODE_1(DT_NODE_HAS_STATUS(DT_PHANDLE_BY_IDX(node_id, prop, idx), okay), \
+		    (1), (0))
+
+/**
  * @brief Helper macro to initialize an entry of a struct pm_state_info array
  * when using UTIL_LISTIFY in PM_STATE_INFO_LIST_FROM_DT_CPU.
+ *
+ * @note Only enabled states are initialized.
  *
  * @param i UTIL_LISTIFY entry index.
  * @param node_id A node identifier with compatible zephyr,power-state
  */
-#define Z_PM_STATE_INFO_FROM_DT_CPU(i, node_id) \
-	PM_STATE_INFO_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i))
+#define Z_PM_STATE_INFO_FROM_DT_CPU(i, node_id)                                                   \
+	COND_CODE_1(DT_NODE_HAS_STATUS(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i), okay),    \
+		    (PM_STATE_INFO_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i)),), ())
 
 /**
  * @brief Helper macro to initialize an entry of a struct pm_state array when
  * using UTIL_LISTIFY in PM_STATE_LIST_FROM_DT_CPU.
  *
+ * @note Only enabled states are initialized.
+ *
  * @param i UTIL_LISTIFY entry index.
  * @param node_id A node identifier with compatible zephyr,power-state
  */
-#define Z_PM_STATE_FROM_DT_CPU(i, node_id) \
-	PM_STATE_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i))
+#define Z_PM_STATE_FROM_DT_CPU(i, node_id)                                                        \
+	COND_CODE_1(DT_NODE_HAS_STATUS(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i), okay),    \
+		    (PM_STATE_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i)),), ())
 
 /** @endcond */
 
@@ -204,18 +221,20 @@ struct pm_state_info {
 	DT_ENUM_IDX(node_id, power_state_name)
 
 /**
- * @brief Obtain number of CPU power states supported by the given CPU node
- * identifier.
+ * @brief Obtain number of CPU power states supported and enabled by the given
+ * CPU node identifier.
  *
  * @param node_id A CPU node identifier.
- * @return Number of supported CPU power states.
+ * @return Number of supported and enabled CPU power states.
  */
-#define DT_NUM_CPU_POWER_STATES(node_id) \
-	DT_PROP_LEN_OR(node_id, cpu_power_states, 0)
+#define DT_NUM_CPU_POWER_STATES(node_id)                                                           \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, cpu_power_states),                                   \
+		    (DT_FOREACH_PROP_ELEM_SEP(node_id, cpu_power_states, Z_DT_PHANDLE_01, (+))),   \
+		    (0))
 
 /**
  * @brief Initialize an array of struct pm_state_info with information from all
- * the states present in the given CPU node identifier.
+ * the states present and enabled in the given CPU node identifier.
  *
  * Example devicetree fragment:
  *
@@ -258,13 +277,13 @@ struct pm_state_info {
  */
 #define PM_STATE_INFO_LIST_FROM_DT_CPU(node_id)				       \
 	{								       \
-		LISTIFY(DT_NUM_CPU_POWER_STATES(node_id),		       \
-			Z_PM_STATE_INFO_FROM_DT_CPU, (,), node_id)	       \
+		LISTIFY(DT_PROP_LEN_OR(node_id, cpu_power_states, 0),	       \
+			Z_PM_STATE_INFO_FROM_DT_CPU, (), node_id)	       \
 	}
 
 /**
  * @brief Initialize an array of struct pm_state with information from all the
- * states present in the given CPU node identifier.
+ * states present and enabled in the given CPU node identifier.
  *
  * Example devicetree fragment:
  *
@@ -305,8 +324,8 @@ struct pm_state_info {
  */
 #define PM_STATE_LIST_FROM_DT_CPU(node_id)				       \
 	{								       \
-		LISTIFY(DT_NUM_CPU_POWER_STATES(node_id),		       \
-			Z_PM_STATE_FROM_DT_CPU, (,), node_id)		       \
+		LISTIFY(DT_PROP_LEN_OR(node_id, cpu_power_states, 0),	       \
+			Z_PM_STATE_FROM_DT_CPU, (), node_id)		       \
 	}
 
 

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -33,7 +33,7 @@ BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
  * @param node_id A CPU node identifier.
  */
 #define CHECK_POWER_STATES_CONSISTENCY(node_id)				       \
-	LISTIFY(DT_NUM_CPU_POWER_STATES(node_id),			       \
+	LISTIFY(DT_PROP_LEN_OR(node_id, cpu_power_states, 0),		       \
 		CHECK_POWER_STATE_CONSISTENCY, (;), node_id);		       \
 
 /* Check that all power states are consistent */
@@ -48,12 +48,12 @@ DT_FOREACH_CHILD(DT_PATH(cpus), DEFINE_CPU_STATES);
 
 /** CPU power states information for each CPU */
 static const struct pm_state_info *cpus_states[] = {
-	DT_FOREACH_CHILD_SEP(DT_PATH(cpus), CPU_STATE_REF, (,))
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), CPU_STATE_REF, (,))
 };
 
 /** Number of states for each CPU */
 static const uint8_t states_per_cpu[] = {
-	DT_FOREACH_CHILD_SEP(DT_PATH(cpus), DT_NUM_CPU_POWER_STATES, (,))
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_NUM_CPU_POWER_STATES, (,))
 };
 
 uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states)

--- a/tests/subsys/pm/power_states_api/boards/native_posix.overlay
+++ b/tests/subsys/pm/power_states_api/boards/native_posix.overlay
@@ -7,7 +7,7 @@
 / {
 	cpus {
 		cpu@0 {
-			cpu-power-states = <&state0 &state1 &state2>;
+			cpu-power-states = <&state0 &state1 &state2 &state3>;
 		};
 
 		power-states {
@@ -28,6 +28,12 @@
 			state2: state2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "standby";
+			};
+
+			state3: state3 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-ram";
+				status = "disabled";
 			};
 		};
 	};


### PR DESCRIPTION
- Move more power state definitions to SoC dts files (missed from previous PR)
- PM state API allows disabling certain CPU power states in Devicetree (used by Silabs)
- Other minor cleanups