### PR TITLE
arch/common: add 64bit register access functions for 64bit arch

### DIFF
--- a/include/zephyr/arch/common/sys_io.h
+++ b/include/zephyr/arch/common/sys_io.h
@@ -50,6 +50,16 @@ static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 	*(volatile uint32_t *)addr = data;
 }
 
+static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
+{
+	return *(volatile uint64_t *)addr;
+}
+
+static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
+{
+	*(volatile uint64_t *)addr = data;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Some custom 64bit arch SoC that we have happens to have register interfaces that are strictly 64bit.