### PR TITLE
drivers: spi_nrfx_spis: Fix obtaining dev pointer in event handler

### DIFF
--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(spi_nrfx_spis, CONFIG_SPI_LOG_LEVEL);
 
 struct spi_nrfx_data {
 	struct spi_context ctx;
+	const struct device *dev;
 };
 
 struct spi_nrfx_config {
@@ -219,10 +220,10 @@ static const struct spi_driver_api spi_nrfx_driver_api = {
 static void event_handler(const nrfx_spis_evt_t *p_event, void *p_context)
 {
 	struct spi_nrfx_data *dev_data = p_context;
-	struct device *dev = CONTAINER_OF(dev_data, struct device, data);
 
 	if (p_event->evt_type == NRFX_SPIS_XFER_DONE) {
-		spi_context_complete(&dev_data->ctx, dev, p_event->rx_amount);
+		spi_context_complete(&dev_data->ctx, dev_data->dev,
+				     p_event->rx_amount);
 	}
 }
 
@@ -273,6 +274,7 @@ static int spi_nrfx_init(const struct device *dev)
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
 		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \
 		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
+		.dev  = DEVICE_DT_GET(SPIS(idx)),			       \
 	};								       \
 	PINCTRL_DT_DEFINE(SPIS(idx));					       \
 	static const struct spi_nrfx_config spi_##idx##z_config = {	       \


### PR DESCRIPTION
This is a follow-up to commit 4c20403629df1ae6a58d37a7a5bd73d4698cc11a.

CONTAINER_OF() cannot be used to obtain the device pointer from its data pointer as this data is not contained in the device structure. Instead, use a dedicated member in the device data structure to store the device pointer.