### PR TITLE
dts: bindings: mmu_mpu: Remove arm,num-mpu-regions

### DIFF
--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -30,10 +30,6 @@ LOG_MODULE_DECLARE(mpu);
 #define MPU_NODEID DT_INST(0, arm_armv6m_mpu)
 #endif
 
-#if DT_NODE_HAS_PROP(MPU_NODEID, arm_num_mpu_regions)
-#define NUM_MPU_REGIONS   DT_PROP(MPU_NODEID, arm_num_mpu_regions)
-#endif
-
 #define NODE_HAS_PROP_AND_OR(node_id, prop) \
 	DT_NODE_HAS_PROP(node_id, prop) ||
 
@@ -526,11 +522,6 @@ int z_arm_mpu_init(void)
 	defined(CONFIG_CPU_CORTEX_M4)
 	__ASSERT(
 		(MPU->TYPE & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos == 8,
-		"Invalid number of MPU regions\n");
-#elif defined(NUM_MPU_REGIONS)
-	__ASSERT(
-		(MPU->TYPE & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos ==
-		NUM_MPU_REGIONS,
 		"Invalid number of MPU regions\n");
 #endif /* CORTEX_M0PLUS || CPU_CORTEX_M3 || CPU_CORTEX_M4 */
 

--- a/arch/arm/core/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v8_internal.h
@@ -720,12 +720,7 @@ static int mpu_mark_areas_for_dynamic_regions(
  */
 static inline uint8_t get_num_regions(void)
 {
-#if defined(NUM_MPU_REGIONS)
-	/* Retrieve the number of regions from DTS configuration. */
-	return NUM_MPU_REGIONS;
-#else
 	return mpu_get_num_regions();
-#endif /* NUM_MPU_REGIONS */
 }
 
 /* This internal function programs the dynamic MPU regions.

--- a/arch/arm/core/mpu/cortex_a_r/arm_mpu_internal.h
+++ b/arch/arm/core/mpu/cortex_a_r/arm_mpu_internal.h
@@ -10,10 +10,6 @@
  */
 static inline uint8_t get_num_regions(void)
 {
-#if defined(NUM_MPU_REGIONS)
-	/* Retrieve the number of regions from DTS configuration. */
-	return NUM_MPU_REGIONS;
-#else
 	uint32_t type;
 
 	__asm__ volatile("mrc p15, 0, %0, c0, c0, 4" : "=r" (type) ::);
@@ -21,7 +17,6 @@ static inline uint8_t get_num_regions(void)
 	type = (type & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos;
 
 	return (uint8_t)type;
-#endif /* NUM_MPU_REGIONS */
 }
 
 static inline uint32_t get_region_attributes(void)

--- a/arch/arm/core/mpu/cortex_m/arm_mpu_internal.h
+++ b/arch/arm/core/mpu/cortex_m/arm_mpu_internal.h
@@ -10,23 +10,11 @@
  */
 static inline uint8_t get_num_regions(void)
 {
-#if defined(CONFIG_CPU_CORTEX_M0PLUS) || \
-	defined(CONFIG_CPU_CORTEX_M3) || \
-	defined(CONFIG_CPU_CORTEX_M4)
-	/* Cortex-M0+, Cortex-M3, and Cortex-M4 MCUs may
-	 * have a fixed number of 8 MPU regions.
-	 */
-	return 8;
-#elif defined(NUM_MPU_REGIONS)
-	/* Retrieve the number of regions from DTS configuration. */
-	return NUM_MPU_REGIONS;
-#else
 	uint32_t type = MPU->TYPE;
 
 	type = (type & MPU_TYPE_DREGION_Msk) >> MPU_TYPE_DREGION_Pos;
 
 	return (uint8_t)type;
-#endif /* CPU_CORTEX_M0PLUS | CPU_CORTEX_M3 | CPU_CORTEX_M4 */
 }
 
 static inline void set_region_number(uint32_t index)

--- a/boards/arm/arty/arty_a7_arm_designstart_m3.dts
+++ b/boards/arm/arty/arty_a7_arm_designstart_m3.dts
@@ -25,7 +25,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/boards/arm/mps2_an521/mps2_an521.dts
+++ b/boards/arm/mps2_an521/mps2_an521.dts
@@ -79,7 +79,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/boards/arm/mps2_an521/mps2_an521_ns.dts
+++ b/boards/arm/mps2_an521/mps2_an521_ns.dts
@@ -71,7 +71,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/boards/arm/mps2_an521/mps2_an521_remote.dts
+++ b/boards/arm/mps2_an521/mps2_an521_remote.dts
@@ -71,7 +71,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/boards/arm/mps3_an547/mps3_an547.dts
+++ b/boards/arm/mps3_an547/mps3_an547.dts
@@ -118,7 +118,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8.1m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/boards/arm/mps3_an547/mps3_an547_ns.dts
+++ b/boards/arm/mps3_an547/mps3_an547_ns.dts
@@ -70,7 +70,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8.1m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/boards/arm/scobc_module1/scobc_module1.dts
+++ b/boards/arm/scobc_module1/scobc_module1.dts
@@ -31,7 +31,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1.dts
@@ -56,7 +56,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1_ns.dts
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1_ns.dts
@@ -37,7 +37,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/boards/arm/v2m_musca_s1/v2m_musca_s1.dts
+++ b/boards/arm/v2m_musca_s1/v2m_musca_s1.dts
@@ -56,7 +56,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/boards/arm/v2m_musca_s1/v2m_musca_s1_ns.dts
+++ b/boards/arm/v2m_musca_s1/v2m_musca_s1_ns.dts
@@ -37,7 +37,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -33,7 +33,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -29,7 +29,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -35,7 +35,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -29,7 +29,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -39,7 +39,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/dts/arm/broadcom/valkyrie.dtsi
+++ b/dts/arm/broadcom/valkyrie.dtsi
@@ -21,7 +21,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/dts/arm/broadcom/viper-m7.dtsi
+++ b/dts/arm/broadcom/viper-m7.dtsi
@@ -23,7 +23,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/dts/arm/gigadevice/gd32a50x/gd32a50x.dtsi
+++ b/dts/arm/gigadevice/gd32a50x/gd32a50x.dtsi
@@ -28,7 +28,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/gigadevice/gd32e50x/gd32e50x.dtsi
+++ b/dts/arm/gigadevice/gd32e50x/gd32e50x.dtsi
@@ -74,7 +74,6 @@
 		mpu: mpu@e000ed90 {
 			compatible = "arm,armv8m-mpu";
 			reg = <0xe000ed90 0x40>;
-			arm,num-mpu-regions = <8>;
 		};
 
 		usart0: usart@40013800 {

--- a/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
+++ b/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
@@ -28,7 +28,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
@@ -26,7 +26,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/nordic/nrf5340_cpuapp_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_qkaa.dtsi
@@ -15,10 +15,6 @@
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };
 
-&mpu {
-	arm,num-mpu-regions = <8>;
-};
-
 / {
 	soc {
 		compatible = "nordic,nrf5340-cpuapp-qkaa", "nordic,nrf5340-cpuapp",

--- a/dts/arm/nordic/nrf5340_cpuappns_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns_qkaa.dtsi
@@ -15,10 +15,6 @@
 	reg = <0x20000000 DT_SIZE_K(512)>;
 };
 
-&mpu {
-	arm,num-mpu-regions = <8>;
-};
-
 / {
 	soc {
 		compatible = "nordic,nrf5340-cpuapp-qkaa", "nordic,nrf5340-cpuapp",

--- a/dts/arm/nordic/nrf5340_cpunet_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet_qkaa.dtsi
@@ -19,10 +19,6 @@
 	reg = <0x21000000 DT_SIZE_K(64)>;
 };
 
-&mpu {
-	arm,num-mpu-regions = <8>;
-};
-
 / {
 	soc {
 		compatible = "nordic,nrf5340-cpunet-qkaa", "nordic,nrf5340-cpunet",

--- a/dts/arm/nordic/nrf91.dtsi
+++ b/dts/arm/nordic/nrf91.dtsi
@@ -22,7 +22,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/dts/arm/nordic/nrf91ns.dtsi
+++ b/dts/arm/nordic/nrf91ns.dtsi
@@ -22,7 +22,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/dts/arm/nxp/nxp_imx8ml_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx8ml_m7.dtsi
@@ -24,7 +24,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -23,7 +23,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -25,7 +25,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -34,7 +34,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -30,7 +30,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -35,7 +35,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 		cpu@1 {

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -35,7 +35,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 
 			itm: itm@e0000000 {

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -34,7 +34,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 		cpu1: cpu@1 {
@@ -49,7 +48,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -33,7 +33,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -31,7 +31,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -29,7 +29,6 @@
 		mpu: mpu@e000ed90 {
 			compatible = "arm,armv7m-mpu";
 			reg = <0xe000ed90 0x40>;
-			arm,num-mpu-regions = <16>;
 		};
 	};
 

--- a/dts/arm/quicklogic/quicklogic_eos_s3.dtsi
+++ b/dts/arm/quicklogic/quicklogic_eos_s3.dtsi
@@ -23,7 +23,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/silabs/efr32mg21.dtsi
+++ b/dts/arm/silabs/efr32mg21.dtsi
@@ -30,7 +30,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -40,7 +40,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -36,7 +36,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 	};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -41,7 +41,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <16>;
 			};
 		};
 	};

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -40,7 +40,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -41,7 +41,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -38,7 +38,6 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
-				arm,num-mpu-regions = <8>;
 			};
 		};
 

--- a/dts/bindings/mmu_mpu/arm,armv6m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv6m-mpu.yaml
@@ -12,7 +12,6 @@ properties:
     required: true
 
   arm,num-mpu-regions:
-    required: true
     type: int
     const: 8
     description: number of MPU regions supported by hardware

--- a/dts/bindings/mmu_mpu/arm,armv6m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv6m-mpu.yaml
@@ -10,8 +10,3 @@ include: base.yaml
 properties:
   reg:
     required: true
-
-  arm,num-mpu-regions:
-    type: int
-    const: 8
-    description: number of MPU regions supported by hardware

--- a/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
@@ -7,7 +7,3 @@ include: base.yaml
 properties:
   reg:
     required: true
-
-  arm,num-mpu-regions:
-    type: int
-    description: number of MPU regions supported by hardware

--- a/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv7m-mpu.yaml
@@ -9,6 +9,5 @@ properties:
     required: true
 
   arm,num-mpu-regions:
-    required: true
     type: int
     description: number of MPU regions supported by hardware

--- a/dts/bindings/mmu_mpu/arm,armv8.1m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv8.1m-mpu.yaml
@@ -7,7 +7,3 @@ include: base.yaml
 properties:
   reg:
     required: true
-
-  arm,num-mpu-regions:
-    type: int
-    description: number of MPU regions supported by hardware

--- a/dts/bindings/mmu_mpu/arm,armv8.1m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv8.1m-mpu.yaml
@@ -9,6 +9,5 @@ properties:
     required: true
 
   arm,num-mpu-regions:
-    required: true
     type: int
     description: number of MPU regions supported by hardware

--- a/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
@@ -7,7 +7,3 @@ include: base.yaml
 properties:
   reg:
     required: true
-
-  arm,num-mpu-regions:
-    type: int
-    description: number of MPU regions supported by hardware

--- a/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
+++ b/dts/bindings/mmu_mpu/arm,armv8m-mpu.yaml
@@ -9,6 +9,5 @@ properties:
     required: true
 
   arm,num-mpu-regions:
-    required: true
     type: int
     description: number of MPU regions supported by hardware


### PR DESCRIPTION
The C code does not required this parameter to be defined and falls back to the MPU_TYPE's register to return the appropriate value.

This change enables the tail gating of a fix for the board mps2_an521.

The SSE-200 implementation on AN521 only has 8 regions. Although the AN521 FPGA image implements the documented value, qemu-system-arm currently shows in MPU_TYPE the incorrect value of 16.

Removing the property definition allows the code to rely on the register read value and work on both qemu-system-arm & the physical board.
