### PR TITLE
pm: device_runtime: allow calling pm_device_runtime_get from ISRs

### DIFF
--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -81,12 +81,16 @@ int pm_device_runtime_disable(const struct device *dev);
  * pm_device_runtime_put_async(), this function will wait for the operation to
  * finish to then resume the device.
  *
+ * @note It is safe to use this function in contexts where blocking is not
+ * allowed, e.g. ISR, provided the device PM implementation does not block.
+ *
  * @funcprops \pre_kernel_ok
  *
  * @param dev Device instance.
  *
  * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
  * available this function will be a no-op and will also return 0.
+ * @retval -EWOUDBLOCK If call would block but it is not allowed (e.g. in ISR).
  * @retval -errno Other negative errno, result of the PM action callback.
  */
 int pm_device_runtime_get(const struct device *dev);


### PR DESCRIPTION
pm_device_runtime_get() uses a semaphore to protect resources.
pm_device_runtime_get() blocked forever until obtaining the lock, making
it unusable from contexts where blocking is not allowed, e.g. ISRs. With
this patch, we give the chance to use the function from an ISR by not
waiting on the lock and returning -EWOULDBLOCK instead. If device is
suspending (from a previous put_async() operation) the same value is
returned as we can't wait either.

Fixes #60784