### PR TITLE
Bluetooth: Mesh: Keep Composition Data Page 128 if RPR Server is present

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -61,7 +61,8 @@ static int dev_comp_data_get(struct bt_mesh_model *model,
 
 	page = net_buf_simple_pull_u8(buf);
 
-	if (page >= 128U && atomic_test_bit(bt_mesh.flags, BT_MESH_COMP_DIRTY)) {
+	if (page >= 128U && (atomic_test_bit(bt_mesh.flags, BT_MESH_COMP_DIRTY) ||
+			     IS_ENABLED(CONFIG_BT_MESH_RPR_SRV))) {
 		page = 128U;
 	} else if (page >= 1U && IS_ENABLED(CONFIG_BT_MESH_COMP_PAGE_1)) {
 		page = 1U;
@@ -80,7 +81,7 @@ static int dev_comp_data_get(struct bt_mesh_model *model,
 			LOG_ERR("Unable to get composition page 1");
 			return err;
 		}
-	} else if (atomic_test_bit(bt_mesh.flags, BT_MESH_COMP_DIRTY) == (page == 0U)) {
+	} else if (atomic_test_bit(bt_mesh.flags, BT_MESH_COMP_DIRTY) && (page == 0U)) {
 		sdu.size -= BT_MESH_MIC_SHORT;
 		err = bt_mesh_comp_read(&sdu);
 		if (err) {

--- a/subsys/bluetooth/mesh/rpr_srv.c
+++ b/subsys/bluetooth/mesh/rpr_srv.c
@@ -874,7 +874,7 @@ static int handle_link_open(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *c
 
 		if (refresh == BT_MESH_RPR_NODE_REFRESH_COMPOSITION &&
 		    !atomic_test_bit(bt_mesh.flags, BT_MESH_COMP_DIRTY)) {
-			LOG_WRN("Composition data page 128 missing");
+			LOG_WRN("Composition data page 128 is equal to page 0");
 			status = BT_MESH_RPR_ERR_LINK_CANNOT_OPEN;
 			goto rsp;
 		}

--- a/tests/bsim/bluetooth/mesh/src/test_provision.c
+++ b/tests/bsim/bluetooth/mesh/src/test_provision.c
@@ -1365,7 +1365,7 @@ static void test_provisioner_pb_remote_client_ncrp(void)
 	ASSERT_OK(bt_mesh_reprovision_remote(&rpr_cli, &srv, pb_remote_server_addr, true));
 	ASSERT_OK(k_sem_take(&reprov_sem, K_SECONDS(20)));
 
-	/* Check that Composition Data Page 128 is now Page 0. */
+	/* Check that Composition Data Page 128 still exists and is now equal to Page 0. */
 	net_buf_simple_reset(&dev_comp_p0);
 	ASSERT_OK(bt_mesh_cfg_cli_comp_data_get(0, pb_remote_server_addr, 0, &page, &dev_comp_p0));
 	ASSERT_EQUAL(0, page);
@@ -1377,7 +1377,7 @@ static void test_provisioner_pb_remote_client_ncrp(void)
 	net_buf_simple_reset(&dev_comp_p128);
 	ASSERT_OK(bt_mesh_cfg_cli_comp_data_get(0, pb_remote_server_addr, 128, &page,
 						&dev_comp_p128));
-	ASSERT_EQUAL(0, page);
+	ASSERT_EQUAL(128, page);
 	ASSERT_EQUAL(dev_comp_p0.len, dev_comp_p128.len);
 	if (memcmp(dev_comp_p0.data, dev_comp_p128.data, dev_comp_p0.len)) {
 		FAIL("Wrong composition data page 128");
@@ -1387,7 +1387,7 @@ static void test_provisioner_pb_remote_client_ncrp(void)
 }
 
 /** @brief Test Node Composition Refresh procedure on Remote Provisioning client:
- * - verify that Composition Data Page 0 is updated after reboot.
+ * - verify that Composition Data Page 0 is now equal to Page 128 after reboot.
  */
 static void test_provisioner_pb_remote_client_ncrp_second_time(void)
 {
@@ -1407,7 +1407,7 @@ static void test_provisioner_pb_remote_client_ncrp_second_time(void)
 	ASSERT_EQUAL(0, page);
 	ASSERT_OK(bt_mesh_cfg_cli_comp_data_get(0, pb_remote_server_addr, 128, &page,
 						&dev_comp_p128));
-	ASSERT_EQUAL(0, page);
+	ASSERT_EQUAL(128, page);
 	ASSERT_TRUE(dev_comp_p0.len == dev_comp_p128.len);
 
 	LOG_INF("Start Node Composition Refresh procedure...\n");
@@ -1457,7 +1457,8 @@ static void test_device_pb_remote_server_ncrp(void)
 }
 
 /** @brief Test Node Composition Refresh procedure on Remote Provisioning server:
- * - verify that Composition Data Page 128 is erased after being re-provisioned and rebooted.
+ * - verify that Composition Data Page 0 is replaced by Page 128 after being re-provisioned and
+ *   rebooted.
  */
 static void test_device_pb_remote_server_ncrp_second_time(void)
 {


### PR DESCRIPTION
According to section 4.2.2.4, Compositiion Data page 128 shall be present if the node supports Remote Provisioning Server (section 4.2.2.4).