### PR TITLE
modules: uoscore-uedhoc: Update to the latest version 

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -117,7 +117,6 @@ zephyr_interface_library_named(mbedTLS)
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_mac.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_rsa.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_se.c
-        ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_slot_management.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_storage.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_its_file.c
       )
@@ -127,6 +126,7 @@ zephyr_interface_library_named(mbedTLS)
       list(APPEND crypto_source
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto.c
         ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_client.c
+        ${ZEPHYR_CURRENT_MODULE_DIR}/library/psa_crypto_slot_management.c
       )
     endif()
 

--- a/modules/mbedtls/Kconfig.tls-generic
+++ b/modules/mbedtls/Kconfig.tls-generic
@@ -422,6 +422,7 @@ config MBEDTLS_SERVER_NAME_INDICATION
 
 config MBEDTLS_PK_WRITE_C
 	bool "The generic public (asymmetric) key writer"
+	default y if MBEDTLS_PSA_CRYPTO_C
 	help
 	  Enable generic public key write functions.
 

--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -394,15 +394,6 @@
 #define MBEDTLS_X509_USE_C
 #endif
 
-#if defined(MBEDTLS_X509_USE_C) || \
-    defined(MBEDTLS_ECDSA_C)
-#define MBEDTLS_ASN1_PARSE_C
-#endif
-
-#if defined(MBEDTLS_ECDSA_C)
-#define MBEDTLS_ASN1_WRITE_C
-#endif
-
 #if defined(MBEDTLS_DHM_C) || \
     defined(MBEDTLS_ECP_C) || \
     defined(MBEDTLS_RSA_C) || \
@@ -426,6 +417,14 @@
 
 #if defined(MBEDTLS_PK_PARSE_C) || defined(MBEDTLS_PK_WRITE_C)
 #define MBEDTLS_PK_C
+#endif
+
+#if defined(MBEDTLS_X509_USE_C) || defined(MBEDTLS_ECDSA_C)
+#define MBEDTLS_ASN1_PARSE_C
+#endif
+
+#if defined(MBEDTLS_ECDSA_C) || defined(MBEDTLS_PK_WRITE_C)
+#define MBEDTLS_ASN1_WRITE_C
 #endif
 
 #if defined(CONFIG_MBEDTLS_PKCS5_C)

--- a/modules/uoscore-uedhoc/CMakeLists.txt
+++ b/modules/uoscore-uedhoc/CMakeLists.txt
@@ -27,6 +27,12 @@ if (CONFIG_UOSCORE OR CONFIG_UEDHOC)
 
   zephyr_library_link_libraries(mbedTLS)
 
+  if (CONFIG_BUILD_WITH_TFM)
+    zephyr_library_include_directories(
+      $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include
+    )
+  endif()
+
 # UOSCORE
 
   if (CONFIG_UOSCORE)

--- a/modules/uoscore-uedhoc/CMakeLists.txt
+++ b/modules/uoscore-uedhoc/CMakeLists.txt
@@ -43,11 +43,14 @@ if (CONFIG_UOSCORE OR CONFIG_UEDHOC)
       ${UOSCORE_UEDHOC_SRC_DIR}/oscore/aad.c
       ${UOSCORE_UEDHOC_SRC_DIR}/oscore/coap2oscore.c
       ${UOSCORE_UEDHOC_SRC_DIR}/oscore/nonce.c
+      ${UOSCORE_UEDHOC_SRC_DIR}/oscore/nvm.c
       ${UOSCORE_UEDHOC_SRC_DIR}/oscore/option.c
-      ${UOSCORE_UEDHOC_SRC_DIR}/oscore/oscore2coap.c
       ${UOSCORE_UEDHOC_SRC_DIR}/oscore/oscore_coap.c
       ${UOSCORE_UEDHOC_SRC_DIR}/oscore/oscore_cose.c
       ${UOSCORE_UEDHOC_SRC_DIR}/oscore/oscore_hkdf_info.c
+      ${UOSCORE_UEDHOC_SRC_DIR}/oscore/oscore_interactions.c
+      ${UOSCORE_UEDHOC_SRC_DIR}/oscore/oscore2coap.c
+      ${UOSCORE_UEDHOC_SRC_DIR}/oscore/replay_protection.c
       ${UOSCORE_UEDHOC_SRC_DIR}/oscore/security_context.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/oscore_aad_array.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/oscore_enc_structure.c
@@ -72,14 +75,15 @@ if (CONFIG_UOSCORE OR CONFIG_UEDHOC)
 
     zephyr_library_sources(
       ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/associated_data_encode.c
+      ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/bstr_encode_decode.c
       ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/cert.c
       ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/ciphertext.c
-      ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/c_x.c
       ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/edhoc_cose.c
       ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/edhoc_exporter.c
       ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/edhoc_method_type.c
       ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/hkdf_info.c
       ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/initiator.c
+      ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/int_encode_decode.c
       ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/okm.c
       ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/plaintext_decode.c
       ${UOSCORE_UEDHOC_SRC_DIR}/edhoc/plaintext_encode.c
@@ -93,6 +97,7 @@ if (CONFIG_UOSCORE OR CONFIG_UEDHOC)
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_bstr_type.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_cert.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_id_cred_x.c
+      ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_int_type.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_message_1.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_message_2.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_decode_message_3.c
@@ -109,8 +114,6 @@ if (CONFIG_UOSCORE OR CONFIG_UEDHOC)
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_encode_message_error.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_encode_sig_structure.c
       ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_encode_th2.c
-      ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_encode_th3.c
-      ${UOSCORE_UEDHOC_SRC_DIR}/cbor/edhoc_encode_th4.c
     )
 
     zephyr_library_link_libraries(mbedTLS)

--- a/tests/lib/uoscore/src/oscore_testvector_tests/oscore_tests.c
+++ b/tests/lib/uoscore/src/oscore_testvector_tests/oscore_tests.c
@@ -21,7 +21,6 @@ ZTEST(oscore_tests, oscore_client_test1)
 	enum err r;
 	struct context c_client;
 	struct oscore_init_params params = {
-		.dev_type = CLIENT,
 		.master_secret.ptr = (uint8_t *)T1__MASTER_SECRET,
 		.master_secret.len = T1__MASTER_SECRET_LEN,
 		.sender_id.ptr = (uint8_t *)T1__SENDER_ID,
@@ -34,6 +33,7 @@ ZTEST(oscore_tests, oscore_client_test1)
 		.id_context.len = T1__ID_CONTEXT_LEN,
 		.aead_alg = OSCORE_AES_CCM_16_64_128,
 		.hkdf = OSCORE_SHA_256,
+		.fresh_master_secret_salt = true,
 	};
 
 	r = oscore_context_init(&params, &c_client);
@@ -45,7 +45,7 @@ ZTEST(oscore_tests, oscore_client_test1)
 	 * during normal operation the sender sequence number is
 	 * increased automatically after every sending
 	 */
-	c_client.sc.sender_seq_num = 20;
+	c_client.sc.ssn = 20;
 
 	uint8_t buf_oscore[256];
 	uint32_t buf_oscore_len = sizeof(buf_oscore);
@@ -80,7 +80,6 @@ ZTEST(oscore_tests, oscore_client_test3)
 	enum err r;
 	struct context c_client;
 	struct oscore_init_params params = {
-		.dev_type = CLIENT,
 		.master_secret.ptr = (uint8_t *)T3__MASTER_SECRET,
 		.master_secret.len = T3__MASTER_SECRET_LEN,
 		.sender_id.ptr = (uint8_t *)T3__SENDER_ID,
@@ -93,6 +92,7 @@ ZTEST(oscore_tests, oscore_client_test3)
 		.id_context.len = T3__ID_CONTEXT_LEN,
 		.aead_alg = OSCORE_AES_CCM_16_64_128,
 		.hkdf = OSCORE_SHA_256,
+		.fresh_master_secret_salt = true,
 	};
 
 	r = oscore_context_init(&params, &c_client);
@@ -104,7 +104,7 @@ ZTEST(oscore_tests, oscore_client_test3)
 	 * during normal operation the sender sequence number is
 	 * increased automatically after every sending
 	 */
-	c_client.sc.sender_seq_num = 20;
+	c_client.sc.ssn = 20;
 
 	uint8_t buf_oscore[256];
 	uint32_t buf_oscore_len = sizeof(buf_oscore);
@@ -128,7 +128,6 @@ ZTEST(oscore_tests, oscore_client_test5)
 	enum err r;
 	struct context c_client;
 	struct oscore_init_params params = {
-		.dev_type = CLIENT,
 		.master_secret.ptr = (uint8_t *)T5__MASTER_SECRET,
 		.master_secret.len = T5__MASTER_SECRET_LEN,
 		.sender_id.ptr = (uint8_t *)T5__SENDER_ID,
@@ -141,6 +140,7 @@ ZTEST(oscore_tests, oscore_client_test5)
 		.id_context.len = T5__ID_CONTEXT_LEN,
 		.aead_alg = OSCORE_AES_CCM_16_64_128,
 		.hkdf = OSCORE_SHA_256,
+		.fresh_master_secret_salt = true,
 	};
 
 	r = oscore_context_init(&params, &c_client);
@@ -152,7 +152,7 @@ ZTEST(oscore_tests, oscore_client_test5)
 	 * during normal operation the sender sequence number is
 	 * increased automatically after every sending
 	 */
-	c_client.sc.sender_seq_num = 20;
+	c_client.sc.ssn = 20;
 
 	uint8_t buf_oscore[256];
 	uint32_t buf_oscore_len = sizeof(buf_oscore);
@@ -176,7 +176,6 @@ ZTEST(oscore_tests, oscore_server_test2)
 	enum err r;
 	struct context c_server;
 	struct oscore_init_params params_server = {
-		.dev_type = SERVER,
 		.master_secret.ptr = (uint8_t *)T2__MASTER_SECRET,
 		.master_secret.len = T2__MASTER_SECRET_LEN,
 		.sender_id.ptr = (uint8_t *)T2__SENDER_ID,
@@ -189,6 +188,7 @@ ZTEST(oscore_tests, oscore_server_test2)
 		.id_context.len = T2__ID_CONTEXT_LEN,
 		.aead_alg = OSCORE_AES_CCM_16_64_128,
 		.hkdf = OSCORE_SHA_256,
+		.fresh_master_secret_salt = true,
 	};
 
 	r = oscore_context_init(&params_server, &c_server);
@@ -198,13 +198,11 @@ ZTEST(oscore_tests, oscore_server_test2)
 	/* Test decrypting of an incoming request */
 	uint8_t buf_coap[256];
 	uint32_t buf_coap_len = sizeof(buf_coap);
-	bool oscore_present_flag = false;
 
 	r = oscore2coap((uint8_t *)T2__OSCORE_REQ, T2__OSCORE_REQ_LEN, buf_coap,
-			&buf_coap_len, &oscore_present_flag, &c_server);
+			&buf_coap_len, &c_server);
 
 	zassert_equal(r, ok, "Error in oscore2coap!");
-	zassert_true(oscore_present_flag, "The packet is not OSCORE packet");
 	zassert_mem_equal__(&buf_coap, T2__COAP_REQ, buf_coap_len,
 			    "oscore2coap failed");
 
@@ -226,7 +224,6 @@ ZTEST(oscore_tests, oscore_server_test4)
 	enum err r;
 	struct context c_server;
 	struct oscore_init_params params_server = {
-		.dev_type = SERVER,
 		.master_secret.ptr = (uint8_t *)T4__MASTER_SECRET,
 		.master_secret.len = T4__MASTER_SECRET_LEN,
 		.sender_id.ptr = (uint8_t *)T4__SENDER_ID,
@@ -239,6 +236,7 @@ ZTEST(oscore_tests, oscore_server_test4)
 		.id_context.len = T4__ID_CONTEXT_LEN,
 		.aead_alg = OSCORE_AES_CCM_16_64_128,
 		.hkdf = OSCORE_SHA_256,
+		.fresh_master_secret_salt = true,
 	};
 
 	r = oscore_context_init(&params_server, &c_server);
@@ -267,7 +265,6 @@ ZTEST(oscore_tests, oscore_server_test6)
 	enum err r;
 	struct context c_server;
 	struct oscore_init_params params_server = {
-		.dev_type = SERVER,
 		.master_secret.ptr = (uint8_t *)T6__MASTER_SECRET,
 		.master_secret.len = T6__MASTER_SECRET_LEN,
 		.sender_id.ptr = (uint8_t *)T6__SENDER_ID,
@@ -280,6 +277,7 @@ ZTEST(oscore_tests, oscore_server_test6)
 		.id_context.len = T6__ID_CONTEXT_LEN,
 		.aead_alg = OSCORE_AES_CCM_16_64_128,
 		.hkdf = OSCORE_SHA_256,
+		.fresh_master_secret_salt = true,
 	};
 
 	r = oscore_context_init(&params_server, &c_server);
@@ -309,7 +307,6 @@ ZTEST(oscore_tests, oscore_misc_test8)
 	enum err r;
 	struct context c;
 	struct oscore_init_params params = {
-		.dev_type = SERVER,
 		.master_secret.ptr = (uint8_t *)T7__MASTER_SECRET,
 		.master_secret.len = T7__MASTER_SECRET_LEN,
 		.sender_id.ptr = (uint8_t *)T7__SENDER_ID,
@@ -322,6 +319,7 @@ ZTEST(oscore_tests, oscore_misc_test8)
 		.id_context.len = T7__ID_CONTEXT_LEN,
 		.aead_alg = OSCORE_AES_CCM_16_64_128,
 		.hkdf = OSCORE_SHA_256,
+		.fresh_master_secret_salt = true,
 	};
 
 	r = oscore_context_init(&params, &c);

--- a/tests/lib/uoscore/testcase.yaml
+++ b/tests/lib/uoscore/testcase.yaml
@@ -1,0 +1,6 @@
+tests:
+  libraries.uoscore:
+    min_flash: 240
+    tags: net crypto uoscore
+    integration_platforms:
+      - qemu_x86

--- a/west.yml
+++ b/west.yml
@@ -341,7 +341,7 @@ manifest:
       groups:
         - tee
     - name: uoscore-uedhoc
-      revision: e8920192b66db4f909eb9cd3f155d5245c1ae825
+      revision: 5fe2cb613bd7e4590bd1b00c2adf181ac0229379
       path: modules/lib/uoscore-uedhoc
     - name: zcbor
       revision: 67fd8bb88d3136738661fa8bb5f9989103f4599e


### PR DESCRIPTION
Update `uoscore-uedhoc` to the latest revision. Additionally, fix two issues encountered with the integration:
* mbed TLS dependencies broken after update to v3.3.0
* `testcase.yaml` missing from `oscore` tests (hence, above was not caught)

Fixes #60235