### PR TITLE
boards: up_squared: override CPU devicetree node to have 2 CPUs

### DIFF
--- a/boards/x86/up_squared/up_squared.dts
+++ b/boards/x86/up_squared/up_squared.dts
@@ -29,6 +29,25 @@
 		zephyr,uart-pipe = &uart1;
 		zephyr,bt-mon-uart = &uart1;
 	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "intel,apollo_lake";
+			d-cache-line-size = <64>;
+			reg = <0>;
+		};
+
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "intel,apollo_lake";
+			d-cache-line-size = <64>;
+			reg = <1>;
+		};
+	};
 };
 
 &hpet {


### PR DESCRIPTION
The device tree file for up_squared includes the base dts file for Apollo Lake which only defines 1 CPU. UP Squared have different SKUs with different CPUs, and overall has a minimal of 2 CPUs. So amend the up_squared device tree overlay to have 2 CPU nodes.