### PR TITLE
 MAINTAINERS: fix path for xtensa/riscv esp32 soc 

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2479,9 +2479,9 @@ Espressif Platforms:
   files:
     - drivers/*/*esp32*.c
     - boards/xtensa/esp32*/
-    - soc/xtensa/esp32*/
+    - soc/xtensa/espressif_esp32*/
     - boards/riscv/esp32*/
-    - soc/riscv/esp32*/
+    - soc/riscv/espressif_esp32*/
     - dts/xtensa/espressif/
     - dts/riscv/espressif/
     - dts/bindings/*/*esp32*


### PR DESCRIPTION
The correct paths are soc/xtensa/espressif_esp32 and soc/riscv/espressif_esp32, not soc/xtensa/esp32 and soc/riscv/esp32.