### PR TITLE
ztest: fix type-limits warning of test_status

### DIFF
--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -675,10 +675,6 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite)
 	int fail = 0;
 	int tc_result = TC_PASS;
 
-	if (test_status < 0) {
-		return test_status;
-	}
-
 	if (suite == NULL) {
 		test_status = ZTEST_STATUS_CRITICAL_ERROR;
 		return -1;


### PR DESCRIPTION
test_status is enum with values all greater than 0, there is an if statement that checks if it is less than 0. This statement is always false due to the limited range of the data type.

The error message
```
zephyr/subsys/testsuite/ztest/src/ztest_new.c:695:25: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  695 |         if (test_status < 0) {
      |                         ^
```