### PR TITLE
toolchain: xcc/xt-clang: include llvm.h for xt-clang...

### DIFF
--- a/include/zephyr/toolchain/xcc.h
+++ b/include/zephyr/toolchain/xcc.h
@@ -19,21 +19,10 @@
 #endif
 
 #ifdef __clang__
-#if __clang_major__ >= 10
-#define __fallthrough __attribute__((fallthrough))
-#endif
-
-#define TOOLCHAIN_CLANG_VERSION \
-	((__clang_major__ * 10000) + (__clang_minor__ * 100) + \
-	__clang_patchlevel__)
-
-#if TOOLCHAIN_CLANG_VERSION >= 30800
-#define TOOLCHAIN_HAS_C_GENERIC 1
-#define TOOLCHAIN_HAS_C_AUTO_TYPE 1
-#endif
-#endif
-
+#include <zephyr/toolchain/llvm.h>
+#else
 #include <zephyr/toolchain/gcc.h>
+#endif
 
 #ifndef __clang__
 #undef __BYTE_ORDER__


### PR DESCRIPTION
...and removed the copied macros. This allows xt-clang to inherit macros from llvm.h to align with any LLVM related additions.