### PR TITLE
Bluetooth: Host: Add LE Power Control Procedure APIs

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -560,6 +560,64 @@ struct bt_hci_rp_read_tx_power_level {
 	int8_t   tx_power_level;
 } __packed;
 
+#define BT_HCI_LE_TX_POWER_PHY_1M               0x01
+#define BT_HCI_LE_TX_POWER_PHY_2M               0x02
+#define BT_HCI_LE_TX_POWER_PHY_CODED_S8         0x03
+#define BT_HCI_LE_TX_POWER_PHY_CODED_S2         0x04
+#define BT_HCI_OP_LE_ENH_READ_TX_POWER_LEVEL    BT_OP(BT_OGF_LE, 0x0076)
+struct bt_hci_cp_le_read_tx_power_level {
+	uint16_t handle;
+	uint8_t  phy;
+} __packed;
+
+struct bt_hci_rp_le_read_tx_power_level {
+	uint8_t  status;
+	uint16_t handle;
+	uint8_t  phy;
+	int8_t   current_tx_power_level;
+	int8_t   max_tx_power_level;
+} __packed;
+
+#define BT_HCI_OP_LE_READ_REMOTE_TX_POWER_LEVEL	BT_OP(BT_OGF_LE, 0x0077)
+
+#define BT_HCI_LE_TX_POWER_REPORT_DISABLE       0x00
+#define BT_HCI_LE_TX_POWER_REPORT_ENABLE        0x01
+#define BT_HCI_OP_LE_SET_TX_POWER_REPORT_ENABLE BT_OP(BT_OGF_LE, 0x007A)
+struct bt_hci_cp_le_set_tx_power_report_enable {
+	uint16_t handle;
+	uint8_t  local_enable;
+	uint8_t  remote_enable;
+} __packed;
+
+#define BT_HCI_OP_VS_WRITE_REMOTE_TX_POWER	BT_OP(BT_OGF_VS, 0x010A)
+
+struct bt_hci_cp_vs_write_tx_power {
+	uint16_t handle;
+	uint8_t  phy;
+	int8_t	 delta;
+} __packed;
+
+#define BT_HCI_OP_VS_SET_AUTO_POWER_CONTROL_REQUEST_PARAM	BT_OP(BT_OGF_VS, 0x010B)
+
+struct bt_hci_cp_vs_set_auto_power_control_request_param {
+	uint16_t handle;
+	uint8_t enable;
+	uint16_t beta;
+	int8_t lower_limit;
+	int8_t upper_limit;
+	int8_t lower_target_rssi;
+	int8_t upper_target_rssi;
+	uint8_t wait_period;
+} __packed;
+
+#define BT_HCI_OP_VS_SET_POWER_CONTROL_APR_HANDLING	BT_OP(BT_OGF_VS, 0x010F)
+
+struct bt_hci_cp_vs_set_power_control_apr_handling {
+	uint16_t handle;
+	int8_t enable;
+	int8_t margin;
+} __packed;
+
 #define BT_HCI_CTL_TO_HOST_FLOW_DISABLE         0x00
 #define BT_HCI_CTL_TO_HOST_FLOW_ENABLE          0x01
 #define BT_HCI_OP_SET_CTL_TO_HOST_FLOW          BT_OP(BT_OGF_BASEBAND, 0x0031)
@@ -2890,6 +2948,17 @@ struct bt_hci_evt_le_req_peer_sca_complete {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  sca;
+} __packed;
+
+#define BT_HCI_EVT_LE_TRANSMIT_POWER_REPORT     0x21
+struct bt_hci_evt_le_transmit_power_report {
+	uint8_t	 status;
+	uint16_t handle;
+	uint8_t  reason;
+	uint8_t  phy;
+	int8_t   tx_power_level;
+	int8_t   tx_power_level_flag;
+	int8_t   delta;
 } __packed;
 
 #define BT_HCI_EVT_LE_BIGINFO_ADV_REPORT        0x22

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -101,6 +101,9 @@ config BT_CTLR_READ_ISO_LINK_QUALITY_SUPPORT
 		   BT_CTLR_PERIPHERAL_ISO_SUPPORT
 	bool
 
+config BT_CTLR_LE_POWER_CONTROL_SUPPORT
+	bool
+
 config BT_CTLR
 	bool "Bluetooth Controller"
 	help

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -727,6 +727,15 @@ config BT_CONN_PARAM_RETRY_TIMEOUT
 	  The value is a timeout used by peripheral device to wait until retry
 	  to attempt requesting again the preferred connection parameters.
 
+config BT_TRANSMIT_POWER_CONTROL
+	bool "Transmit Power Control [EXPERIMENTAL]"
+	depends on !BT_CTLR || BT_CTLR_LE_POWER_CONTROL_SUPPORT
+	select EXPERIMENTAL
+	help
+	  Enable support for controlling transmit power. The controller shall
+	  support LE Power Control Request feature that defined in the Bluetooth
+	  Core specification, Version 5.3 | Vol 6, Part B, Section 4.6.31.
+
 endif # BT_CONN
 
 if BT_OBSERVER

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2636,16 +2636,53 @@ static int bt_conn_get_tx_power_level(struct bt_conn *conn, uint8_t type,
 	return 0;
 }
 
+int bt_conn_le_enhanced_get_tx_power_level(struct bt_conn *conn,
+					   struct bt_conn_le_tx_power *tx_power)
+{
+	int err;
+	struct bt_hci_rp_le_read_tx_power_level *rp;
+	struct net_buf *rsp;
+	struct bt_hci_cp_le_read_tx_power_level *cp;
+	struct net_buf *buf;
+
+	if (!tx_power->phy) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_ENH_READ_TX_POWER_LEVEL, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->phy = tx_power->phy;
+
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_ENH_READ_TX_POWER_LEVEL, buf, &rsp);
+	if (err) {
+		return err;
+	}
+
+	rp = (void *) rsp->data;
+	tx_power->phy = rp->phy;
+	tx_power->current_level = rp->current_tx_power_level;
+	tx_power->max_level = rp->max_tx_power_level;
+	net_buf_unref(rsp);
+
+	return 0;
+}
+
 int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
 				  struct bt_conn_le_tx_power *tx_power_level)
 {
 	int err;
 
 	if (tx_power_level->phy != 0) {
-		/* Extend the implementation when LE Enhanced Read Transmit
-		 * Power Level HCI command is available for use.
-		 */
-		return -ENOTSUP;
+		if (IS_ENABLED(CONFIG_BT_TRANSMIT_POWER_CONTROL)) {
+			return bt_conn_le_enhanced_get_tx_power_level(conn, tx_power_level);
+		} else {
+			return -ENOTSUP;
+		}
 	}
 
 	err = bt_conn_get_tx_power_level(conn, BT_TX_POWER_LEVEL_CURRENT,
@@ -2657,6 +2694,122 @@ int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
 	err = bt_conn_get_tx_power_level(conn, BT_TX_POWER_LEVEL_MAX,
 					 &tx_power_level->max_level);
 	return err;
+}
+
+int bt_conn_le_get_remote_tx_power_level(struct bt_conn *conn,
+					 enum bt_conn_le_tx_power_phy phy)
+{
+	struct bt_hci_cp_le_read_tx_power_level *cp;
+	struct net_buf *buf;
+
+	if (!phy) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_READ_REMOTE_TX_POWER_LEVEL, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->phy = phy;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_REMOTE_TX_POWER_LEVEL, buf, NULL);
+}
+
+int bt_conn_le_set_tx_power_report_enable(struct bt_conn *conn,
+					  bool local_enable,
+					  bool remote_enable)
+{
+	struct bt_hci_cp_le_set_tx_power_report_enable *cp;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_TX_POWER_REPORT_ENABLE, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->local_enable = local_enable ? BT_HCI_LE_TX_POWER_REPORT_ENABLE :
+		BT_HCI_LE_TX_POWER_REPORT_DISABLE;
+	cp->remote_enable = remote_enable ? BT_HCI_LE_TX_POWER_REPORT_ENABLE :
+		BT_HCI_LE_TX_POWER_REPORT_DISABLE;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_TX_POWER_REPORT_ENABLE, buf, NULL);
+}
+
+int bt_conn_vs_write_remote_tx_power(struct bt_conn *conn,
+					 enum bt_conn_le_tx_power_phy phy, int8_t delta)
+{
+	struct bt_hci_cp_vs_write_tx_power *cp;
+	struct net_buf *buf;
+
+	if (!phy) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_VS_WRITE_REMOTE_TX_POWER, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->phy = phy;
+	cp->delta = delta;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_VS_WRITE_REMOTE_TX_POWER, buf, NULL);
+}
+
+int bt_conn_vs_set_auto_power_control_request_param(struct bt_conn *conn,
+					 uint8_t enable, uint16_t beta, int8_t lower_limit,
+					 int8_t upper_limit, int8_t lower_target_rssi,
+					 int8_t upper_target_rssi, uint8_t wait_period)
+{
+	struct bt_hci_cp_vs_set_auto_power_control_request_param *cp;
+	struct net_buf *buf;
+
+	if (!wait_period) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_VS_SET_AUTO_POWER_CONTROL_REQUEST_PARAM, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->enable = enable;
+	cp->beta = beta;
+	cp->lower_limit = lower_limit;
+	cp->upper_limit = upper_limit;
+	cp->lower_target_rssi = lower_target_rssi;
+	cp->upper_target_rssi = upper_target_rssi;
+	cp->wait_period = wait_period;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_VS_SET_AUTO_POWER_CONTROL_REQUEST_PARAM, buf, NULL);
+}
+
+int bt_conn_vs_set_power_control_apr_handling(struct bt_conn *conn,
+					 uint8_t enable, uint8_t margin)
+{
+	struct bt_hci_cp_vs_set_power_control_apr_handling *cp;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_VS_SET_POWER_CONTROL_APR_HANDLING, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->enable = enable;
+	cp->margin = enable;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_VS_SET_POWER_CONTROL_APR_HANDLING, buf, NULL);
 }
 
 int bt_conn_le_param_update(struct bt_conn *conn,
@@ -3440,5 +3593,28 @@ void bt_hci_le_df_cte_req_failed(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 #endif /* CONFIG_BT_DF_CONNECTION_CTE_REQ */
+
+#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
+void notify_tx_power_report(struct bt_conn *conn,
+			    struct bt_conn_le_tx_power_report report)
+{
+	struct bt_conn_cb *cb;
+
+	for (cb = callback_list; cb; cb = cb->_next) {
+		if (cb->tx_power_report) {
+			cb->tx_power_report(conn, &report);
+		}
+	}
+
+	STRUCT_SECTION_FOREACH(bt_conn_cb, cb)
+	{
+		if (cb->tx_power_report) {
+			cb->tx_power_report(conn, &report);
+		}
+	}
+
+	bt_conn_unref(conn);
+}
+#endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
 
 #endif /* CONFIG_BT_CONN */

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -364,6 +364,9 @@ void notify_le_phy_updated(struct bt_conn *conn);
 
 bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param);
 
+void notify_tx_power_report(struct bt_conn *conn,
+			    struct bt_conn_le_tx_power_report report);
+
 #if defined(CONFIG_BT_SMP)
 /* If role specific LTK is present */
 bool bt_conn_ltk_present(const struct bt_conn *conn);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2384,6 +2384,33 @@ int bt_hci_register_vnd_evt_cb(bt_hci_vnd_evt_cb_t cb)
 }
 #endif /* CONFIG_BT_HCI_VS_EVT_USER */
 
+#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
+void bt_hci_le_transmit_power_report(struct net_buf *buf)
+{
+	struct bt_hci_evt_le_transmit_power_report *evt;
+	struct bt_conn_le_tx_power_report report;
+	struct bt_conn *conn;
+
+	evt = net_buf_pull_mem(buf, sizeof(*evt));
+	conn = bt_conn_lookup_handle(sys_le16_to_cpu(evt->handle));
+	if (!conn) {
+		BT_ERR("Unknown conn handle 0x%04X for transmit power report",
+		       sys_le16_to_cpu(evt->handle));
+		return;
+	}
+
+	report.reason = evt->reason;
+	report.phy = evt->phy;
+	report.tx_power_level = evt->tx_power_level;
+	report.tx_power_level_flag = evt->tx_power_level_flag;
+	report.delta = evt->delta;
+
+	notify_tx_power_report(conn, report);
+
+	bt_conn_unref(conn);
+}
+#endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
+
 static const struct event_handler vs_events[] = {
 #if defined(CONFIG_BT_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES)
 	EVENT_HANDLER(BT_HCI_EVT_VS_LE_CONNECTIONLESS_IQ_REPORT,
@@ -2529,6 +2556,10 @@ static const struct event_handler meta_events[] = {
 	EVENT_HANDLER(BT_HCI_EVT_LE_CTE_REQUEST_FAILED, bt_hci_le_df_cte_req_failed,
 		      sizeof(struct bt_hci_evt_le_cte_req_failed)),
 #endif /* CONFIG_BT_DF_CONNECTION_CTE_REQ */
+#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
+	EVENT_HANDLER(BT_HCI_EVT_LE_TRANSMIT_POWER_REPORT, bt_hci_le_transmit_power_report,
+		      sizeof(struct bt_hci_evt_le_transmit_power_report)),
+#endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
 #if defined(CONFIG_BT_PER_ADV_SYNC_RSP)
 	EVENT_HANDLER(BT_HCI_EVT_LE_PER_ADVERTISING_REPORT_V2, bt_hci_le_per_adv_report_v2,
 		      sizeof(struct bt_hci_evt_le_per_advertising_report_v2)),


### PR DESCRIPTION
This PR aims to define host APIs, events and configs for LE Power Control Feature. The support of feature is provided with controller-based feature selection with BT_CTLR_LE_POWER_CONTROL_SUPPORT. If the feature is supported, then BT_TRANSMIT_POWER_CONTROL feature will be selectable.

With the new APIs, the applications will:

get improved reading of local and remote tx power
be aware of changes in remote or local tx power
be able to request a tx power change on remote device
be able to set automatic Power Control Request when leaving golden range of RSSI
be able to set APR handling of remote apr to use in local tx power setting

Defined HCI commands in Core Spec v5.3:

7.8.117 LE Enhanced Read Transmit Power Level command: improvement to existing local tx power reading.
7.8.118 LE Read Remote Transmit Power Level command: Remote tx power is read through an event (LE Transmit Power Reporting)
7.8.121 LE Set Transmit Power Reporting Enable command: Enables local or remote tx power reporting to monitor changes in tx power
7.7.65.33 LE Transmit Power Reporting event:

Vendor-specific HCI commands:
Write remote transmit power level
Set Autonomous LE Power Control Request parameters
Set APR handling within LE Power Control Request