### PR TITLE
drivers: i3c: fix cdns-i3c builds with I3C_USE_IBI=n

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -612,30 +612,6 @@ static int cdns_i3c_read_rx_fifo(const struct cdns_i3c_config *config, void *buf
 	return 0;
 }
 
-static int cdns_i3c_read_ibi_fifo(const struct cdns_i3c_config *config, void *buf, uint32_t len)
-{
-	uint32_t *ptr = buf;
-	uint32_t remain, val;
-
-	for (remain = len; remain >= 4; remain -= 4) {
-		if (cdns_i3c_ibi_fifo_empty(config)) {
-			return -EIO;
-		}
-		val = sys_le32_to_cpu(sys_read32(config->base + IBI_DATA_FIFO));
-		*ptr++ = val;
-	}
-
-	if (remain > 0) {
-		if (cdns_i3c_ibi_fifo_empty(config)) {
-			return -EIO;
-		}
-		val = sys_le32_to_cpu(sys_read32(config->base + IBI_DATA_FIFO));
-		memcpy(ptr, &val, remain);
-	}
-
-	return 0;
-}
-
 static void cdns_i3c_set_prescalers(const struct device *dev)
 {
 	struct cdns_i3c_data *data = dev->data;
@@ -875,8 +851,9 @@ static void cdns_i3c_cancel_transfer(const struct device *dev)
 	sys_write32(MST_INT_CMDD_EMP, config->base + MST_IDR);
 
 	/* Ignore if no pending transfer */
-	if (data->xfer.num_cmds == 0)
+	if (data->xfer.num_cmds == 0) {
 		return;
+	}
 
 	data->xfer.num_cmds = 0;
 
@@ -1433,8 +1410,9 @@ static int cdns_i3c_master_get_rr_slot(const struct device *dev, uint8_t dyn_add
 	const struct cdns_i3c_config *config = dev->config;
 
 	if (dyn_addr == 0) {
-		if (!data->free_rr_slots)
+		if (!data->free_rr_slots) {
 			return -ENOSPC;
+		}
 
 		return find_lsb_set(data->free_rr_slots) - 1;
 	}
@@ -1721,6 +1699,31 @@ static int cdns_i3c_transfer(const struct device *dev, struct i3c_device_desc *t
 	return ret;
 }
 
+#ifdef CONFIG_I3C_USE_IBI
+static int cdns_i3c_read_ibi_fifo(const struct cdns_i3c_config *config, void *buf, uint32_t len)
+{
+	uint32_t *ptr = buf;
+	uint32_t remain, val;
+
+	for (remain = len; remain >= 4; remain -= 4) {
+		if (cdns_i3c_ibi_fifo_empty(config)) {
+			return -EIO;
+		}
+		val = sys_le32_to_cpu(sys_read32(config->base + IBI_DATA_FIFO));
+		*ptr++ = val;
+	}
+
+	if (remain > 0) {
+		if (cdns_i3c_ibi_fifo_empty(config)) {
+			return -EIO;
+		}
+		val = sys_le32_to_cpu(sys_read32(config->base + IBI_DATA_FIFO));
+		memcpy(ptr, &val, remain);
+	}
+
+	return 0;
+}
+
 static void cdns_i3c_handle_ibi(const struct device *dev, uint32_t ibir)
 {
 	const struct cdns_i3c_config *config = dev->config;
@@ -1815,6 +1818,7 @@ static void cdns_i3c_target_ibi_hj_complete(const struct device *dev)
 
 	k_sem_give(&data->ibi_hj_complete);
 }
+#endif
 
 static void cdns_i3c_irq_handler(const struct device *dev)
 {
@@ -1853,7 +1857,12 @@ static void cdns_i3c_irq_handler(const struct device *dev)
 		/* In-band interrupt */
 		if (int_st & MST_INT_IBIR_THR) {
 			sys_write32(MST_INT_IBIR_THR, config->base + MST_ICR);
+#ifdef CONFIG_I3C_USE_IBI
 			cnds_i3c_master_demux_ibis(dev);
+#else
+			LOG_ERR("%s: IBI received - Kconfig for using IBIs is not enabled",
+				dev->name);
+#endif
 		}
 
 		/* In-band interrupt data */
@@ -1948,7 +1957,9 @@ static void cdns_i3c_irq_handler(const struct device *dev)
 			/* HJ could send a DISEC which would trigger the SLV_INT_EVENT_UP bit,
 			 * but it's still expected to eventually send a DAA
 			 */
+#ifdef CONFIG_I3C_USE_IBI
 			cdns_i3c_target_ibi_hj_complete(dev);
+#endif
 		}
 
 		/* HJ complete and DA has been assigned */
@@ -2406,8 +2417,10 @@ static int cdns_i3c_bus_init(const struct device *dev)
 	if (!ctrl_config->is_secondary) {
 		/* Perform bus initialization */
 		ret = i3c_bus_init(dev, &config->common.dev_list);
+#ifdef CONFIG_I3C_USE_IBI
 		/* Bus Initialization Complete, allow HJ ACKs */
 		sys_write32(CTRL_HJ_ACK | sys_read32(config->base + CTRL), config->base + CTRL);
+#endif
 	}
 
 	return 0;


### PR DESCRIPTION
The Cadence I3C was not building with CONFIG_I3C_USE_IBI, this fixes the build and will give a small code size reduction when enabled.