### PR TITLE
ethernet: esp32: make phy a phandle of the ethernet device

### DIFF
--- a/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit.dts
+++ b/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit.dts
@@ -115,7 +115,10 @@
 	};
 };
 
-&eth {
+&mdio {
+	pinctrl-0 = <&mdio_default>;
+	pinctrl-names = "default";
+
 	phy: phy {
 		compatible = "ethernet-phy";
 		status = "disabled";
@@ -124,7 +127,6 @@
 	};
 };
 
-&mdio {
-	pinctrl-0 = <&mdio_default>;
-	pinctrl-names = "default";
+&eth {
+	phy-handle = <&phy>;
 };

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -47,6 +47,9 @@ struct eth_esp32_dev_data {
 	struct k_thread rx_thread;
 };
 
+static const struct device *eth_esp32_phy_dev = DEVICE_DT_GET(
+		DT_INST_PHANDLE(0, phy_handle));
+
 static enum ethernet_hw_caps eth_esp32_caps(const struct device *dev)
 {
 	ARG_UNUSED(dev);
@@ -278,7 +281,6 @@ static void eth_esp32_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_esp32_dev_data *dev_data = dev->data;
-	const struct device *phy_dev = DEVICE_DT_GET(DT_INST_CHILD(0, phy));
 
 	dev_data->iface = iface;
 
@@ -288,8 +290,9 @@ static void eth_esp32_iface_init(struct net_if *iface)
 
 	ethernet_init(iface);
 
-	if (device_is_ready(phy_dev)) {
-		phy_link_callback_set(phy_dev, phy_link_state_changed, (void *)dev);
+	if (device_is_ready(eth_esp32_phy_dev)) {
+		phy_link_callback_set(eth_esp32_phy_dev, phy_link_state_changed,
+				      (void *)dev);
 	} else {
 		LOG_ERR("PHY device not ready");
 	}

--- a/dts/bindings/ethernet/espressif,esp32-eth.yaml
+++ b/dts/bindings/ethernet/espressif,esp32-eth.yaml
@@ -19,3 +19,5 @@ properties:
       Phy connection type define the physical interface connection between
       PHY and MAC.  The default value uses Reduced Media-Independent
       Interface (RMII) mode.
+  phy-handle:
+    required: true


### PR DESCRIPTION
Change the eth-phy definition so that the phy is pointed by a phandle rather than a child node, make the phy device a child of mdio. This makes more sense from a devicetree hirearchy where the phandles have to be initialized before the device itself, allows keeping the priorities in check with CHECK_INIT_PRIORITIES.