### PR TITLE
ethernet: sam-gmac: make phy a phandle of the ethernet device

### DIFF
--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -121,13 +121,7 @@ zephyr_udc0: &usb0 {
 	pinctrl-names = "default";
 
 	mac-eeprom = <&eeprom>;
-
-	phy: phy {
-		compatible = "ethernet-phy";
-		status = "okay";
-		address = <0>;
-		mdio = <&mdio>;
-	};
+	phy-handle = <&phy>;
 };
 
 &mdio {
@@ -135,4 +129,11 @@ zephyr_udc0: &usb0 {
 
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
+
+	phy: phy {
+		compatible = "ethernet-phy";
+		status = "okay";
+		address = <0>;
+		mdio = <&mdio>;
+	};
 };

--- a/boards/arm/sam4e_xpro/sam4e_xpro.dts
+++ b/boards/arm/sam4e_xpro/sam4e_xpro.dts
@@ -187,12 +187,7 @@
 
 	zephyr,random-mac-address;
 
-	phy: phy {
-		compatible = "ethernet-phy";
-		status = "okay";
-		address = <0>;
-		mdio = <&mdio>;
-	};
+	phy-handle = <&phy>;
 };
 
 &mdio {
@@ -200,6 +195,13 @@
 
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
+
+	phy: phy {
+		compatible = "ethernet-phy";
+		status = "okay";
+		address = <0>;
+		mdio = <&mdio>;
+	};
 };
 
 &pwm0 {

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -125,13 +125,7 @@ zephyr_udc0: &usbhs {
 	pinctrl-names = "default";
 
 	mac-eeprom = <&eeprom>;
-
-	phy: phy {
-		compatible = "ethernet-phy";
-		status = "okay";
-		address = <0>;
-		mdio = <&mdio>;
-	};
+	phy-handle = <&phy>;
 };
 
 &mdio {
@@ -139,6 +133,13 @@ zephyr_udc0: &usbhs {
 
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
+
+	phy: phy {
+		compatible = "ethernet-phy";
+		status = "okay";
+		address = <0>;
+		mdio = <&mdio>;
+	};
 };
 
 &pwm0 {

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -233,13 +233,7 @@ zephyr_udc0: &usbhs {
 	pinctrl-names = "default";
 
 	mac-eeprom = <&eeprom>;
-
-	phy: phy {
-		compatible = "ethernet-phy";
-		status = "okay";
-		address = <0>;
-		mdio = <&mdio>;
-	};
+	phy-handle = <&phy>;
 };
 
 &mdio {
@@ -247,6 +241,13 @@ zephyr_udc0: &usbhs {
 
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
+
+	phy: phy {
+		compatible = "ethernet-phy";
+		status = "okay";
+		address = <0>;
+		mdio = <&mdio>;
+	};
 };
 
 &pwm0 {

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2222,11 +2222,7 @@ static const struct eth_sam_dev_cfg eth0_config = {
 	.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(0),
 #endif
 	.config_func = eth0_irq_config,
-#if DT_NODE_EXISTS(DT_INST_CHILD(0, phy))
-	.phy_dev = DEVICE_DT_GET(DT_INST_CHILD(0, phy))
-#else
-#error "No PHY driver specified"
-#endif
+	.phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, phy_handle))
 };
 
 static struct eth_sam_dev_data eth0_data = {

--- a/drivers/mdio/mdio_sam.c
+++ b/drivers/mdio/mdio_sam.c
@@ -132,7 +132,7 @@ static const struct mdio_driver_api mdio_sam_driver_api = {
 
 #define MDIO_SAM_CONFIG(n)						\
 static const struct mdio_sam_dev_config mdio_sam_dev_config_##n = {	\
-	.regs = (Gmac *)DT_REG_ADDR(DT_INST_PARENT(n)),			\
+	.regs = (Gmac *)DT_INST_REG_ADDR(n),				\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
 	.protocol = DT_INST_ENUM_IDX(n, protocol),			\
 };

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -166,11 +166,12 @@
 			num-queues = <1>;
 			phy-connection-type = "mii";
 			status = "disabled";
+		};
 
-			mdio: mdio {
-				compatible = "atmel,sam-mdio";
-				status = "disabled";
-			};
+		mdio: mdio@40034000 {
+			compatible = "atmel,sam-mdio";
+			reg = <0x40034000 0x4000>;
+			status = "disabled";
 		};
 
 		pinctrl: pinctrl@400e0e00 {

--- a/dts/arm/atmel/same5x.dtsi
+++ b/dts/arm/atmel/same5x.dtsi
@@ -16,11 +16,12 @@
 			num-queues = <1>;
 			local-mac-address = [00 00 00 00 00 00];
 			status = "disabled";
+		};
 
-			mdio: mdio {
-				compatible = "atmel,sam-mdio";
-				status = "disabled";
-			};
+		mdio: mdio@42000800 {
+			compatible = "atmel,sam-mdio";
+			reg = <0x42000800 0x400>;
+			status = "disabled";
 		};
 	};
 };

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -328,11 +328,12 @@
 			num-queues = <3>;
 			local-mac-address = [00 00 00 00 00 00];
 			status = "disabled";
+		};
 
-			mdio: mdio {
-				compatible = "atmel,sam-mdio";
-				status = "disabled";
-			};
+		mdio: mdio@40050000 {
+			compatible = "atmel,sam-mdio";
+			reg = <0x40050000 0x4000>;
+			status = "disabled";
 		};
 
 		tc0: tc@4000c000 {

--- a/dts/bindings/ethernet/atmel,gmac-common.yaml
+++ b/dts/bindings/ethernet/atmel,gmac-common.yaml
@@ -10,6 +10,9 @@ properties:
   reg:
     required: true
 
+  phy-handle:
+    required: true
+
   num-queues:
     type: int
     required: true


### PR DESCRIPTION
Make ethernet phys childs of the mdio device and move the mdio device up a level on the tree. That makes the device hierarchy coherent with the required initialization priority and allows keeping the sequence in check with CHECK_INIT_PRIORITIES.