### PR TITLE
boards: arm: stm32f412g_disco: Fix LED LD4 pin

### DIFF
--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -35,7 +35,7 @@
 			label = "User LD3";
 		};
 		blue_led_4: led_4 {
-			gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioe 3 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
 		};
 	};


### PR DESCRIPTION
On the stm32f412g_disco board, the LED LD4 (blue LED) is actually on the pin 3 of GPIOE and not on the pin 4:

![image](https://github.com/zephyrproject-rtos/zephyr/assets/30344/3a2683ab-92d3-455a-93e7-cde4736684d7)

I tested with the following `app.overlay` and it works (the current DT does not work).

```
/ {
    leds {
        led_4 { gpios = <&gpioe 0x3 0x0>; };
    };
};
```

Signed-off-by: Jacques Supcik <jacques.supcik@hefr.ch>
