### PR TITLE
driver: wifi: esp32: increase default stack values

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -22,6 +22,15 @@ menuconfig WIFI_ESP32
 
 if WIFI_ESP32
 
+config NET_TCP_WORKQ_STACK_SIZE
+	default 2048
+
+config NET_RX_STACK_SIZE
+	default 2048
+
+config NET_MGMT_EVENT_STACK_SIZE
+	default 2048
+
 config ESP32_WIFI_STA_AUTO_DHCPV4
 	bool "Automatically starts DHCP4 negotiation"
 	depends on NET_DHCPV4


### PR DESCRIPTION
When testing Wi-Fi with MQTT/HTTP/Socket features, network stacks can be full very fast, causing network issues and eventual crash.

By analyzing used stacks, increasing the stack size described in this PR fixes most use cases related above.

Related to #60629 and #60819