### PR TITLE
build_system: Cleanup access to ".intList" section

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1239,20 +1239,11 @@ if(CONFIG_GEN_ISR_TABLES)
   # isr_tables.c is generated from ${ZEPHYR_LINK_STAGE_EXECUTABLE} by
   # gen_isr_tables.py
   add_custom_command(
-    OUTPUT isr_tables.c isrList.bin
-    COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
-            $<TARGET_PROPERTY:bintools,elfconvert_flag>
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_intarget>${OUTPUT_FORMAT}
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>binary
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_section_only>.intList
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>$<TARGET_FILE:${ZEPHYR_LINK_STAGE_EXECUTABLE}>
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>isrList.bin
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+    OUTPUT isr_tables.c
     COMMAND ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/build/gen_isr_tables.py
     --output-source isr_tables.c
     --kernel $<TARGET_FILE:${ZEPHYR_LINK_STAGE_EXECUTABLE}>
-    --intlist isrList.bin
     $<$<BOOL:${CONFIG_BIG_ENDIAN}>:--big-endian>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--debug>
     ${GEN_ISR_TABLE_EXTRA_ARG}

--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -32,7 +32,7 @@ zephyr_linker_sources_ifdef(CONFIG_GEN_IRQ_VECTOR_TABLE
 )
 
 if(CONFIG_GEN_ISR_TABLES)
-  zephyr_linker_section(NAME .intList VMA IDT_LIST LMA IDT_LIST NOINPUT PASS NOT LINKER_ZEPHYR_FINAL)
+  zephyr_linker_section(NAME .intList NOINPUT TYPE INFO PASS NOT LINKER_ZEPHYR_FINAL)
   zephyr_linker_section_configure(SECTION .intList KEEP INPUT ".irq_info" FIRST)
   zephyr_linker_section_configure(SECTION .intList KEEP INPUT ".intList")
 

--- a/boards/x86/qemu_x86/qemu_x86_tiny.ld
+++ b/boards/x86/qemu_x86/qemu_x86_tiny.ld
@@ -63,16 +63,6 @@ MEMORY
 #if defined(CONFIG_DEMAND_PAGING) && !defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
     FLASH (rw)      : ORIGIN = FLASH_ROM_ADDR, LENGTH = FLASH_ROM_SIZE
 #endif
-
-    /*
-     * On 32-bit x86, fake memory area for build-time IDT generation data.
-     *
-     * It doesn't matter where this region goes as it is stripped from the
-     * final ELF image. The address doesn't even have to be valid on the
-     * target. However, it shouldn't overlap any other regions.
-     */
-
-    IDT_LIST        : ORIGIN = 0xFFFF1000, LENGTH = 2K
     }
 
 #if defined(Z_VM_KERNEL)
@@ -792,26 +782,14 @@ SECTIONS
 
 	z_mapped_size = z_mapped_end - z_mapped_start;
 
-#ifndef LINKER_ZEPHYR_FINAL
 	/* static interrupts */
-	SECTION_PROLOGUE(intList,,)
-	{
-	KEEP(*(.spurIsr))
-	KEEP(*(.spurNoErrIsr))
-	KEEP(*(.intList))
-	KEEP(*(.gnu.linkonce.intList.*))
-	} > IDT_LIST
-#else
-	/DISCARD/ :
+	SECTION_PROLOGUE(intList, 0 (INFO),)
 	{
 	KEEP(*(.spurIsr))
 	KEEP(*(.spurNoErrIsr))
 	KEEP(*(.intList))
 	KEEP(*(.gnu.linkonce.intList.*))
 	}
-#endif
-
-
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.

--- a/cmake/linker/ld/ld_script.cmake
+++ b/cmake/linker/ld/ld_script.cmake
@@ -191,6 +191,7 @@ function(section_to_string)
 
   set(SECTION_TYPE_NOLOAD NOLOAD)
   set(SECTION_TYPE_BSS    NOLOAD)
+  set(SECTION_TYPE_INFO   INFO)
   if(DEFINED type)
     set(type " (${SECTION_TYPE_${type}})")
   endif()

--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -32,7 +32,6 @@ zephyr_linker(ENTRY ${CONFIG_KERNEL_ENTRY})
 
 zephyr_linker_memory(NAME FLASH    FLAGS rx START ${FLASH_ADDR} SIZE ${FLASH_SIZE})
 zephyr_linker_memory(NAME RAM      FLAGS wx START ${RAM_ADDR}   SIZE ${RAM_SIZE})
-zephyr_linker_memory(NAME IDT_LIST FLAGS wx START ${IDT_ADDR}   SIZE 2K)
 
 # Only use 'rw' as FLAGS. It's not used anyway.
 dt_comp_path(paths COMPATIBLE "zephyr,memory-region")

--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -73,8 +73,6 @@ MEMORY {
 #ifdef YCCM_START
 	YCCM  (rw)  : ORIGIN = YCCM_START,  LENGTH = YCCM_SIZE
 #endif
-	/* Used by and documented in include/linker/intlist.ld */
-	IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
 SECTIONS {

--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -80,8 +80,6 @@ MEMORY
     FLASH    (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     RAM      (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
     LINKER_DT_REGIONS()
-    /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -80,8 +80,6 @@ MEMORY
     FLASH (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     RAM   (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
     LINKER_DT_REGIONS()
-    /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
     }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -60,8 +60,6 @@ MEMORY
 {
     FLASH     (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     RAM       (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
-    /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/include/zephyr/arch/mips/linker.ld
+++ b/include/zephyr/arch/mips/linker.ld
@@ -25,8 +25,6 @@
 MEMORY
 {
     RAM (rwx) : ORIGIN = CONFIG_SRAM_BASE_ADDRESS, LENGTH = KB(CONFIG_SRAM_SIZE)
-    /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
 REGION_ALIAS("REGION_TEXT", RAM);

--- a/include/zephyr/arch/nios2/linker.ld
+++ b/include/zephyr/arch/nios2/linker.ld
@@ -56,9 +56,6 @@ MEMORY
     RESET (rx) : ORIGIN = _RESET_VECTOR, LENGTH = 0x20
     FLASH (rx) : ORIGIN = _RESET_VECTOR + 0x20 , LENGTH = (_ROM_SIZE - 0x20)
     RAM   (wx) : ORIGIN = _EXC_VECTOR, LENGTH = _RAM_SIZE - (_EXC_VECTOR - _RAM_ADDR)
-    /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
-
     }
 
 #else
@@ -67,9 +64,6 @@ MEMORY
     {
     RESET (wx) : ORIGIN = _RESET_VECTOR, LENGTH = 0x20
     RAM   (wx) : ORIGIN = _EXC_VECTOR, LENGTH = _RAM_SIZE - (_EXC_VECTOR - _RAM_ADDR)
-
-    /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 #endif
 

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -80,9 +80,6 @@ MEMORY
     RAM (rwx) : ORIGIN = RAM_BASE, LENGTH = RAM_SIZE
 
     LINKER_DT_REGIONS()
-
-    /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/include/zephyr/arch/x86/ia32/linker.ld
+++ b/include/zephyr/arch/x86/ia32/linker.ld
@@ -514,13 +514,13 @@ SECTIONS
 
 #ifndef LINKER_ZEPHYR_FINAL
 	/* static interrupts */
-	SECTION_PROLOGUE(intList,,)
+	SECTION_PROLOGUE(intList, 0 (INFO),)
 	{
 	KEEP(*(.spurIsr))
 	KEEP(*(.spurNoErrIsr))
 	KEEP(*(.intList))
 	KEEP(*(.gnu.linkonce.intList.*))
-	} > IDT_LIST
+	}
 #else
 	/DISCARD/ :
 	{

--- a/include/zephyr/arch/x86/memory.ld
+++ b/include/zephyr/arch/x86/memory.ld
@@ -94,17 +94,6 @@ MEMORY
 #ifdef CONFIG_X86_64
     /* Special low-memory area for bootstrapping other CPUs from real mode */
     LOCORE (wx)     : ORIGIN = LOCORE_BASE, LENGTH = LOCORE_SIZE
-#else
-    /*
-     * On 32-bit x86, fake memory area for build-time IDT generation data.
-     * 64-bit doesn't use this, interrupts are all managed at runtime.
-     *
-     * It doesn't matter where this region goes as it is stripped from the
-     * final ELF image. The address doesn't even have to be valid on the
-     * target. However, it shouldn't overlap any other regions.
-     */
-
-    IDT_LIST        : ORIGIN = 0xFFFF1000, LENGTH = 2K
 #endif /* !CONFIG_X86_64 */
     }
 #endif /* ARCH_X86_MEMORY_LD */

--- a/include/zephyr/linker/intlist.ld
+++ b/include/zephyr/linker/intlist.ld
@@ -18,25 +18,14 @@
  * defined, the total number of IRQ lines in the system, followed by
  * an appropriate number of instances of struct _isr_list. See
  * include/sw_isr_table.h
- *
- * You will need to declare a bogus memory region for IDT_LIST. It doesn't
- * matter where this region goes as it is stripped from the final ELF image.
- * The address doesn't even have to be valid on the target. However, it
- * shouldn't overlap any other regions. On most arches the following should be
- * fine:
- *
- * MEMORY {
- *	.. other regions ..
- *	IDT_LIST        : ORIGIN = 0xfffff7ff, LENGTH = 2K
- * }
  */
 
 #ifndef LINKER_ZEPHYR_FINAL
-SECTION_PROLOGUE(.intList,,)
+SECTION_PROLOGUE(.intList, 0 (INFO),)
 {
 	KEEP(*(.irq_info*))
 	KEEP(*(.intList*))
-} GROUP_ROM_LINK_IN(IDT_LIST, IDT_LIST)
+}
 #else
 /DISCARD/ :
 {

--- a/soc/arm64/nxp_imx/mimx9/linker.ld
+++ b/soc/arm64/nxp_imx/mimx9/linker.ld
@@ -60,8 +60,6 @@ MEMORY
 {
     FLASH     (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     RAM       (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
-    /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/soc/riscv/espressif_esp32/esp32c3/default.ld
+++ b/soc/riscv/espressif_esp32/esp32c3/default.ld
@@ -61,10 +61,6 @@ MEMORY
   dram0_0_seg(RW): org = SRAM_DRAM_ORG, len = I_D_SRAM_SIZE
 
   rtc_iram_seg(RWX): org = 0x50000000, len = 0x2000
-
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
-#endif
 }
 
 

--- a/soc/riscv/espressif_esp32/esp32c3/mcuboot.ld
+++ b/soc/riscv/espressif_esp32/esp32c3/mcuboot.ld
@@ -38,10 +38,6 @@ MEMORY
   iram_seg        (RX) : org = 0x403CA000, len = 0x6000
   iram_loader_seg (RX) : org = 0x403D0000, len = 0x4000
   dram_seg        (RW) : org = 0x3FCD8000, len = 0x8000
-
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
-#endif
 }
 
 /*  Default entry point:  */

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -73,11 +73,6 @@ MEMORY
     VECTORS (rx)  : ORIGIN = VECTOR_BASE, LENGTH = VECTOR_SIZE
 #endif
     RAM (rwx)     : ORIGIN = RAM_BASE,    LENGTH = RAM_SIZE
-    /*
-     * Special section, not included in the final binary, used
-     * to generate interrupt tables. See include/linker/intlist.ld.
-     */
-    IDT_LIST (wx) : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
     }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/soc/riscv/riscv-ite/it8xxx2/linker.ld
+++ b/soc/riscv/riscv-ite/it8xxx2/linker.ld
@@ -77,9 +77,6 @@ MEMORY
     RAM (rwx) : ORIGIN = RAM_BASE, LENGTH = RAM_SIZE
 
     LINKER_DT_REGIONS()
-
-    /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/soc/riscv/riscv-privileged/andes_v5/ae350/linker.ld
+++ b/soc/riscv/riscv-privileged/andes_v5/ae350/linker.ld
@@ -81,9 +81,6 @@ MEMORY
     RAM (rwx) : ORIGIN = RAM_BASE, LENGTH = RAM_SIZE
 
     LINKER_DT_REGIONS()
-
-    /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/soc/sparc/gr716a/linker.ld
+++ b/soc/sparc/gr716a/linker.ld
@@ -26,8 +26,6 @@ MEMORY
   RAM      (rw)  : ORIGIN = 0x30000000, LENGTH = 64K
   SRAM     (x)   : ORIGIN = 0x31000000, LENGTH = 128K
   extram   (rwx) : ORIGIN = 0x40000000, LENGTH = 256M
-  /* refer to include/linker/inlist.ld */
-  IDT_LIST (wx)  : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
 REGION_ALIAS("REGION_TEXT", SRAM);

--- a/soc/sparc/leon3/linker.ld
+++ b/soc/sparc/leon3/linker.ld
@@ -17,8 +17,6 @@ MEMORY
 {
   rom      (rx)  : ORIGIN = 0x00000000, LENGTH = 512M
   RAM      (rwx) : ORIGIN = CONFIG_SRAM_BASE_ADDRESS, LENGTH = KB(CONFIG_SRAM_SIZE)
-  /* refer to include/linker/inlist.ld */
-  IDT_LIST (wx)  : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
 }
 
 REGION_ALIAS("REGION_TEXT", RAM);

--- a/soc/xtensa/espressif_esp32/esp32/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32/default.ld
@@ -93,9 +93,6 @@ MEMORY
 #if defined(CONFIG_ESP_SPIRAM)
   ext_ram_seg(RW): org = 0x3F800000, len = CONFIG_ESP_SPIRAM_SIZE
 #endif
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
-#endif
 }
 
 /*  Default entry point:  */

--- a/soc/xtensa/espressif_esp32/esp32/mcuboot.ld
+++ b/soc/xtensa/espressif_esp32/esp32/mcuboot.ld
@@ -39,10 +39,6 @@ MEMORY
   iram_loader_seg (RWX) : org = 0x40078000, len = 0x4000
   iram_seg        (RWX) : org = 0x4009C000, len = 0x8000
   dram_seg        (RW)  : org = 0x3FFF0000, len = 0x6000
-
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
-#endif
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/soc/xtensa/espressif_esp32/esp32_net/linker.ld
+++ b/soc/xtensa/espressif_esp32/esp32_net/linker.ld
@@ -32,9 +32,6 @@ MEMORY
   dram0_shm0_seg(RW): org = 0x3FFE5230, len = 16K /* shared RAM reserved for IPM */
   dram0_sem0_seg(RW): org = 0x3FFED238, len = 8 /*shared data reserved for IPM data header */
   dram0_1_seg(RW): org = 0x3FFE9238 + CONFIG_ESP32_BT_RESERVE_DRAM, len = 0x17CB0 - 0xEE0 - CONFIG_ESP32_BT_RESERVE_DRAM
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
-#endif
 }
 
 /*  Default entry point:  */

--- a/soc/xtensa/espressif_esp32/esp32s2/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32s2/default.ld
@@ -66,9 +66,6 @@ MEMORY
 #if defined(CONFIG_ESP_SPIRAM)
   ext_ram_seg(RW): org = 0x3f500000, len = CONFIG_ESP_SPIRAM_SIZE
 #endif
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
-#endif
 }
 
 /*  Default entry point:  */

--- a/soc/xtensa/espressif_esp32/esp32s2/mcuboot.ld
+++ b/soc/xtensa/espressif_esp32/esp32s2/mcuboot.ld
@@ -39,11 +39,6 @@ MEMORY
   iram_seg        (RWX) : org = 0x40040000, len = 0x6000
   iram_loader_seg (RWX) : org = 0x40046000, len = 0x2000
   dram_seg        (RW) : org = 0x3FFE6000, len = 0x6000
-
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
-#endif
-
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)

--- a/soc/xtensa/espressif_esp32/esp32s3/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32s3/default.ld
@@ -90,10 +90,6 @@ MEMORY
   /* RTC slow memory (data accessible). Persists over deep sleep.
    */
   rtc_slow_seg(RW): org = 0x50000000, len = 0x2000
-
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
-#endif
 }
 
 /*  Default entry point:  */

--- a/soc/xtensa/espressif_esp32/esp32s3/mcuboot.ld
+++ b/soc/xtensa/espressif_esp32/esp32s3/mcuboot.ld
@@ -39,10 +39,6 @@ MEMORY
   iram_seg(RWX)        : org = 0x403B6000, len = 0x8000
   iram_loader_seg(RWX) : org = 0x403BE000, len = 0x2000
   dram_seg(RW)         : org = 0x3FCD0000, len = 0x6000
-
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST(RW): org = 0x3ebfe010, len = 0x2000
-#endif
 }
 
 /*  Default entry point:  */

--- a/soc/xtensa/intel_adsp/ace/ace-link.ld
+++ b/soc/xtensa/intel_adsp/ace/ace-link.ld
@@ -45,10 +45,6 @@ ENTRY(rom_entry);
 #define ucram ram
 #endif
 
-/* intlist.ld needs an IDT_LIST memory region */
-#define IDT_BASE 0xe0000000
-#define IDT_SIZE 0x2000
-
 /* rimage module sections are C struct data, and thus flagged ALLOC.
  * The xcc linker demands they be in a declared memory region even if
  * the enclosing output section is (NOLOAD).  Put them here.
@@ -112,11 +108,6 @@ MEMORY {
   ucram :
 	org = RPO_SET(RAM_BASE, CONFIG_XTENSA_UNCACHED_REGION),
 	len = RAM_SIZE
-#endif
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST :
-	org = IDT_BASE,
-	len = IDT_SIZE
 #endif
   lpram :
 	org = LP_SRAM_BASE,

--- a/soc/xtensa/intel_adsp/cavs/include/xtensa-cavs-linker.ld
+++ b/soc/xtensa/intel_adsp/cavs/include/xtensa-cavs-linker.ld
@@ -45,10 +45,6 @@ ENTRY(rom_entry);
 #define ucram RAM
 #endif
 
-/* intlist.ld needs an IDT_LIST memory region */
-#define IDT_BASE 0xe0000000
-#define IDT_SIZE 0x2000
-
 /* rimage module sections are C struct data, and thus flagged ALLOC.
  * The xcc linker demands they be in a declared memory region even if
  * the enclosing output section is (NOLOAD).  Put them here.
@@ -124,11 +120,6 @@ MEMORY {
   ucram :
 	org = RPO_SET(RAM_BASE, CONFIG_XTENSA_UNCACHED_REGION),
 	len = RAM_SIZE
-#endif
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST :
-	org = IDT_BASE,
-	len = IDT_SIZE
 #endif
   lpram :
 	org = LP_SRAM_BASE,

--- a/soc/xtensa/nxp_adsp/imx8/linker.ld
+++ b/soc/xtensa/nxp_adsp/imx8/linker.ld
@@ -89,11 +89,6 @@ MEMORY
   sdram1 :
 	org = SDRAM1_BASE + SOF_MAILBOX_SIZE,
         len = SDRAM1_SIZE - SOF_MAILBOX_SIZE
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST :
-	org = IDT_BASE,
-        len = IDT_SIZE
-#endif
 
   static_uuid_entries_seg (!ari) :
         org = UUID_ENTRY_ELF_BASE,

--- a/soc/xtensa/nxp_adsp/imx8m/linker.ld
+++ b/soc/xtensa/nxp_adsp/imx8m/linker.ld
@@ -89,11 +89,6 @@ MEMORY
   sdram1 :
 	org = SDRAM1_BASE + SOF_MAILBOX_SIZE,
         len = SDRAM1_SIZE - SOF_MAILBOX_SIZE
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST :
-	org = IDT_BASE,
-        len = IDT_SIZE
-#endif
 
   static_uuid_entries_seg (!ari) :
         org = UUID_ENTRY_ELF_BASE,

--- a/soc/xtensa/sample_controller/include/xtensa-sample-controller.ld
+++ b/soc/xtensa/sample_controller/include/xtensa-sample-controller.ld
@@ -46,9 +46,6 @@ MEMORY
   srom0_seg :                         	org = 0x50000000, len = 0x300
   srom1_seg :                         	org = 0x50000300, len = 0xFFFD00
   RAM :                         	org = 0x60000000, len = 0x4000000
-#ifdef CONFIG_GEN_ISR_TABLES
-  IDT_LIST : org = 0x3ffbe000, len = 0x2000
-#endif
 }
 
 PHDRS


### PR DESCRIPTION
This is currently proof of concept and idea for discussion.
I was trying to remove the need for dummy IDT_LIST memory definition that provides some limits to the number of supported interrupts. As I am working on solution for interrupt system that would require more fields in _isr_list structure this requirement for dummy memory is even more limiting.

The idea here is to add (INFO) type for the ".intList" section. Such a section is not present in the output and I could not access it via objcopy. But the section is still in elf file - and it can be accessed via pyelftools - and this is how I had used it.

The additional "gain" here is one temporary file less in the build directory.

I have tested it on hello_world sample on nrf52840dk_nrf52840 target. For the full solution it would probably require more cleanups for rest of the linker files around the declaration of the ".intList" section. I wish to get some feedback before I start doing it. If you see any drawbacks for the proposed solution or would you welcome it in zephyr?