### PR TITLE
kernel: Add k_spinlock_init()

### DIFF
--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -262,6 +262,23 @@ static ALWAYS_INLINE void k_spin_unlock(struct k_spinlock *l,
 }
 
 /**
+ * @brief Explicitly initialize the spinlock's locked count
+ *
+ * This routine explicitly initializes the spinlock's locked count to zero.
+ * It is to be used on spinlock's that are allocated from memory regions whose
+ * contents are not guaranteed to be zeroed.
+ *
+ * @param l Pointer to spinlock to initialize
+ */
+static ALWAYS_INLINE void k_spinlock_init(struct k_spinlock *l)
+{
+	ARG_UNUSED(l);
+#ifdef CONFIG_SMP
+	atomic_set(&l->locked, 0);
+#endif
+}
+
+/**
  * @cond INTERNAL_HIDDEN
  */
 


### PR DESCRIPTION
Adds the routine k_spinlock_init() for initializing a spinlock. This routine comes into play when a developer has created a spinlock that resides in a memory region that was not guaranteed to be intitialized to all zeroes.

