### PR TITLE
boards: arm: stm32f746g_disco: Use specified USB serial

### DIFF
--- a/boards/arm/stm32f746g_disco/support/openocd.cfg
+++ b/boards/arm/stm32f746g_disco/support/openocd.cfg
@@ -11,9 +11,13 @@ $_TARGETNAME configure -event gdb-detach {
 	resume
 }
 
+if { [info exists _ZEPHYR_BOARD_SERIAL] } {
+	adapter serial $_ZEPHYR_BOARD_SERIAL
+}
+
 # Event reset-init already uses the maximum speed however adapter speed
 # inherited from stm32f7x.cfg for reset-start defaults to 2000 kHz, so
 # override that speed setting it also to the maximum speed.
 $_TARGETNAME configure -event reset-start {
-        adapter speed 4000
+	adapter speed 4000
 }


### PR DESCRIPTION
The 'west flash' command allows specifying the port where the target is attached via the '--serial' option, allowing users to set the USB serial port for flashing. However, the 'stm32f746g_disco' script file currently ignores the _ZEPHYR_BOARD_SERIAL variable set by this option, preventing effective port specification.

This commit fixes it by correctly setting the openocd adapter serial when _ZEPHYR_BOARD_SERIAL variable is set, enabling proper USB serial port specification during flashing.

For example, if one builds the `hello_world` sample for the board in question with:

`$ west build -p always -b stm32f746g_disco samples/hello_world` 

and have more than one USB serial port available:

```
gromero@gromero6:~/zephyrproject/zephyr$ pyocd list 
  #   Probe/Board      Unique ID                  Target           
-------------------------------------------------------------------
  0   STLINK-V3        000C00284741500320383733   ✖︎ stm32u585aiix  
      B-U585I-IOT02A                                               
                                                                   
  1   STM32 STLink     066CFF485153826687133653   n/a              
gromero@gromero6:~/zephyrproject/zephyr$ 
```

and tries to flash to the specific target attached to port `#1` by using the `Unique ID / serial`, it fails:

```
gromero@gromero6:~/zephyrproject/zephyr$ west flash --serial 066CFF485153826687133653
-- west flash: rebuilding
ninja: no work to do.
-- west flash: using runner openocd
-- runners.openocd: Flashing file: /home/gromero/zephyrproject/zephyr/build/hello_world/zephyr/zephyr.hex
Open On-Chip Debugger 0.11.0+dev-00725-gc5c47943d (2023-03-14-22:08)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
066CFF485153826687133653
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : DEPRECATED target event trace-config; use TPIU events {pre,post}-{enable,disable}
Info : clock speed 2000 kHz
Info : STLINK V3J8M3 (API v3) VID:PID 0483:374E
Info : Target voltage: 3.299800
Warn : UNEXPECTED idcode: 0x0be12477
Error: expected 1 of 1: 0x5ba02477


FATAL ERROR: command exited with status 1: /home/gromero/zephyr-sdk-0.16.0/sysroots/x86_64-pokysdk-linux/usr/bin/openocd -s /home/gromero/zephyrproject/zephyr/boards/arm/stm32f746g_disco/support -s /home/gromero/zephyr-sdk-0.16.0/sysroots/x86_64-pokysdk-linux/usr/share/openocd/scripts '-c set _ZEPHYR_BOARD_SERIAL 066CFF485153826687133653' -f /home/gromero/zephyrproject/zephyr/boards/arm/stm32f746g_disco/support/openocd.cfg '-c init' '-c targets' -c 'reset init' -c 'flash write_image erase /home/gromero/zephyrproject/zephyr/build/hello_world/zephyr/zephyr.hex' -c 'reset run' -c shutdown
gromero@gromero6:~/zephyrproject/zephyr$ 
```

With this patch applied the result is:

```
gromero@gromero6:~/zephyrproject/zephyr$ west flash --serial 066CFF485153826687133653
-- west flash: rebuilding
ninja: no work to do.
-- west flash: using runner openocd
-- runners.openocd: Flashing file: /home/gromero/zephyrproject/zephyr/build/hello_world/zephyr/zephyr.hex
Open On-Chip Debugger 0.11.0+dev-00725-gc5c47943d (2023-03-14-22:08)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
066CFF485153826687133653
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : DEPRECATED target event trace-config; use TPIU events {pre,post}-{enable,disable}
Info : clock speed 2000 kHz
Info : STLINK V2J25M14 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.238421
Info : [stm32f7x.cpu] Cortex-M7 r0p1 processor detected
Warn : [stm32f7x.cpu] Silicon bug: single stepping may enter pending exception handler!
Info : [stm32f7x.cpu] target has 8 breakpoints, 4 watchpoints
Info : starting gdb server for stm32f7x.cpu on 3333
Info : Listening on port 3333 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f7x.cpu       hla_target little stm32f7x.cpu       running

target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x080011e0 msp: 0x20011100
Info : device id = 0x10016449
Info : flash size = 1024 kbytes
auto erase enabled
wrote 32768 bytes from file /home/gromero/zephyrproject/zephyr/build/hello_world/zephyr/zephyr.hex in 1.017129s (31.461 KiB/s)

shutdown command invoked
gromero@gromero6:~/zephyrproject/zephyr$ 
```


