### PR TITLE
emul: sbs_gauge: Return err or unsupported feature

### DIFF
--- a/include/zephyr/drivers/emul_fuel_gauge.h
+++ b/include/zephyr/drivers/emul_fuel_gauge.h
@@ -59,6 +59,10 @@ static inline int emul_fuel_gauge_set_battery_charging(const struct emul *target
 	const struct fuel_gauge_emul_driver_api *backend_api =
 		(const struct fuel_gauge_emul_driver_api *)target->backend_api;
 
+	if (backend_api->set_battery_charging == 0) {
+		return -ENOTSUP;
+	}
+
 	return backend_api->set_battery_charging(target, uV, uA);
 }
 


### PR DESCRIPTION
The fuel gauge emulators will attempt to access a 0 pointer when running a backend emulator function that hasn't been implemented.

Add an explicit runtime check to return -ENOTSUP to signify the emulator feature is not supported. We do not ASSERT here so we can write tests that are generic and can run with various emulators that support a variety of features.