### PR TITLE
tests: sbs_gauge: Factor fixture out of test

### DIFF
--- a/tests/drivers/fuel_gauge/sbs_gauge/CMakeLists.txt
+++ b/tests/drivers/fuel_gauge/sbs_gauge/CMakeLists.txt
@@ -5,4 +5,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(device)
 
 FILE(GLOB app_sources src/test_sbs_gauge.c)
+
+target_include_directories(app PRIVATE include)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/fuel_gauge/sbs_gauge/include/test_sbs_gauge.h
+++ b/tests/drivers/fuel_gauge/sbs_gauge/include/test_sbs_gauge.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/fuel_gauge.h>
+
+struct sbs_gauge_new_api_fixture {
+	const struct device *dev;
+	const struct emul *sbs_fuel_gauge;
+	const struct fuel_gauge_driver_api *api;
+};

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -16,11 +16,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/ztest_assert.h>
 
-struct sbs_gauge_new_api_fixture {
-	const struct device *dev;
-	const struct emul *sbs_fuel_gauge;
-	const struct fuel_gauge_driver_api *api;
-};
+#include "test_sbs_gauge.h"
 
 static void *sbs_gauge_new_api_setup(void)
 {


### PR DESCRIPTION
In the near future we'll be adding SBS tests that are linked in based on configs.

Extract the test fixture as a header that can be shared by multiple tests.