### PR TITLE
devicetree: memory-attr: Add `DT_MEMORY_ATTR_HAS_ATTR`

### DIFF
--- a/include/zephyr/devicetree/memory-attr.h
+++ b/include/zephyr/devicetree/memory-attr.h
@@ -49,6 +49,39 @@
 /** @endcond */
 
 /**
+ * @brief Does the `zephyr,memory-attr` property have the @p attr value?
+ *
+ * If this returns 1, then the `zephyr,memory-attr` property has the value
+ * @p attr, otherwise 0 is returned.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     / {
+ *             soc {
+ *                     res0: memory@20000000 {
+ *                         reg = <0x20000000 0x4000>;
+ *                         zephyr,memory-attr = "RAM_NOCACHE";
+ *                     };
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_MEMORY_ATTR_HAS_ATTR(DT_NODELABEL(res0), RAM)         // 0
+ *     DT_MEMORY_ATTR_HAS_ATTR(DT_NODELABEL(res0), RAM_NOCACHE) // 1
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param attr memory attribute
+ * @return 1 if the `zephyr,memory-attr` property has the value @p attr, 0 otherwise.
+ */
+#define DT_MEMORY_ATTR_HAS_ATTR(node_id, attr) \
+	IS_ENABLED(DT_CAT6(node_id, _P_, zephyr_memory_attr, _ENUM_VAL_, attr, _EXISTS))
+
+/**
  * @brief Invokes @p fn for every node in the tree with property
  *        `zephyr,memory-attr`
  *
@@ -117,7 +150,6 @@
  *                         reg = <0x30000000 0x2000>;
  *                         zephyr,memory-attr = "RAM";
  *                     };
-
  *             };
  *     };
  * @endcode

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -90,6 +90,9 @@
 #define TEST_RANGES_PCIE  DT_NODELABEL(test_ranges_pcie)
 #define TEST_RANGES_OTHER DT_NODELABEL(test_ranges_other)
 
+#define TEST_MEM_ATTR_RAM DT_NODELABEL(test_mem_ram)
+#define TEST_MEM_ATTR_RAM_NOCACHE DT_NODELABEL(test_mem_ram_nocache)
+
 #define ZEPHYR_USER DT_PATH(zephyr_user)
 
 #define TA_HAS_COMPAT(compat) DT_NODE_HAS_COMPAT(TEST_ARRAYS, compat)
@@ -2693,6 +2696,12 @@ ZTEST(devicetree_api, test_mbox)
 
 ZTEST(devicetree_api, test_memory_attr)
 {
+	zassert_true(DT_MEMORY_ATTR_HAS_ATTR(TEST_MEM_ATTR_RAM, RAM), "");
+	zassert_false(DT_MEMORY_ATTR_HAS_ATTR(TEST_MEM_ATTR_RAM, RAM_NOCACHE), "");
+
+	zassert_false(DT_MEMORY_ATTR_HAS_ATTR(TEST_MEM_ATTR_RAM_NOCACHE, RAM), "");
+	zassert_true(DT_MEMORY_ATTR_HAS_ATTR(TEST_MEM_ATTR_RAM_NOCACHE, RAM_NOCACHE), "");
+
 	#define REGION_RAM_ATTR		(0xDEDE)
 	#define REGION_RAM_NOCACHE_ATTR	(0xCACA)
 


### PR DESCRIPTION
Add a new DT helper to check if a node has a specified memory attribute. Kinda suggested by @teburd.