### PR TITLE
net: l2: wifi: Add support for Promiscuous mode

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -536,6 +536,58 @@ static inline const char *get_ps_config_err_code_str(int16_t err_no)
 	return "<unknown>";
 }
 
+/** Promiscuous mode operational settings */
+enum wifi_promiscuous_mode {
+	/** Disable promiscuous mode setting */
+	WIFI_PROMISC_DISABLE = 0,
+	/** Monitor sniffer mode setting enable */
+	WIFI_PROMISC_MONITOR_MODE,
+	/** STA sniffer mode setting enable */
+	WIFI_PROMISC_STA_MODE,
+	/** AP sniffer mode setting enable */
+	WIFI_PROMISC_AP_MODE,
+	/** STA-AP sniffer mode setting enable */
+	WIFI_PROMISC_STA_AP_MODE,
+};
+
+/** Promiscuous mode filter settings */
+enum wifi_promiscuous_filter {
+	/** Support mgmt, data and ctrl packet sniffing */
+	WIFI_PROMISC_ALL = BIT(0),
+	/** Support only sniffing of mgmt packets */
+	WIFI_PROMISC_MGMT = BIT(1),
+	/** Support only sniffing of data packets */
+	WIFI_PROMISC_DATA = BIT(2),
+	/** Support only sniffing of ctrl packets */
+	WIFI_PROMISC_CTRL = BIT(3),
+};
+
+/** Promiscuous mode/filter command operation */
+enum wifi_promiscuous_op {
+	/** Set promiscuous mode */
+	WIFI_PROMISC_MODE = 1,
+	/** Set filter for promiscuous mode */
+	WIFI_PROMISC_FILTER,
+};
+
+static const char * const promiscuous_mode_code_tbl[] = {
+	[WIFI_PROMISC_DISABLE] = "Disabled",
+	[WIFI_PROMISC_MONITOR_MODE] = "Monitor mode",
+	[WIFI_PROMISC_STA_MODE] = "Station Mode",
+	[WIFI_PROMISC_AP_MODE] = "AP mode",
+	[WIFI_PROMISC_STA_AP_MODE] = "AP-STA mode",
+};
+
+/** Helper function to get user-friendly promiscuous mode code name */
+static inline const char *get_promiscuous_mode_str(uint8_t mode)
+{
+	if ((mode) < ARRAY_SIZE(promiscuous_mode_code_tbl)) {
+		return promiscuous_mode_code_tbl[mode];
+	}
+
+	return "<unknown>";
+}
+
 /**
  * @}
  */

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -61,6 +61,8 @@ enum net_request_wifi_cmd {
 	NET_REQUEST_WIFI_CMD_REG_DOMAIN,
 	/** Set power save timeout */
 	NET_REQUEST_WIFI_CMD_PS_TIMEOUT,
+	/** Set or get promiscuous mode/filter settings */
+	NET_REQUEST_WIFI_CMD_PROMISC_SETUP,
 	NET_REQUEST_WIFI_CMD_MAX
 };
 
@@ -122,6 +124,11 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_REG_DOMAIN);
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PS_TIMEOUT)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_TIMEOUT);
+
+#define NET_REQUEST_WIFI_PROMISC_SETUP			\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PROMISC_SETUP)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PROMISC_SETUP);
 
 /** Wi-Fi management events */
 enum net_event_wifi_cmd {
@@ -415,6 +422,21 @@ struct wifi_raw_scan_result {
 	uint8_t data[CONFIG_WIFI_MGMT_RAW_SCAN_RESULT_LENGTH];
 };
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+
+/** Wi-Fi promiscuous mode setup */
+struct wifi_promisc_setup {
+	union {
+		/** Promiscuous mode settings */
+		enum wifi_promiscuous_mode mode;
+		/** Filter setting for a specific promiscuous mode */
+		uint8_t filter;
+	};
+	/** Promiscuous mode/filter operation */
+	enum wifi_promiscuous_op op;
+	/** Get or set operation */
+	enum wifi_mgmt_op oper;
+};
+
 #include <zephyr/net/net_if.h>
 
 /** Scan result callback
@@ -535,6 +557,14 @@ struct wifi_mgmt_ops {
 	 * @return 0 if ok, < 0 if error
 	 */
 	int (*reg_domain)(const struct device *dev, struct wifi_reg_domain *reg_domain);
+	/** Set or get promiscuous mode/filter setting
+	 *
+	 * @param dev Pointer to the device structure for the driver instance.
+	 * @param promisc_setup promiscuous setup data
+	 *
+	 * @return 0 if ok, < 0 if error
+	 */
+	int (*promisc_setup)(const struct device *dev, struct wifi_promisc_setup *promisc_setup);
 };
 
 /** Wi-Fi management offload API */

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -388,6 +388,26 @@ static int wifi_reg_domain(uint32_t mgmt_request, struct net_if *iface,
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_REG_DOMAIN, wifi_reg_domain);
 
+static int wifi_set_promisc_setup(uint32_t mgmt_request, struct net_if *iface,
+				void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_api(iface);
+	struct wifi_promisc_setup *promisc_params = data;
+
+	if (dev == NULL) {
+		return -ENODEV;
+	}
+
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->promisc_setup == NULL) {
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->promisc_setup(dev, promisc_params);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PROMISC_SETUP, wifi_set_promisc_setup);
+
 void wifi_mgmt_raise_twt_sleep_state(struct net_if *iface,
 				     int twt_sleep_state)
 {


### PR DESCRIPTION
This set of changes brings in support for
setting different promiscuous sniffing modes and
filter settings for WiFi

The changes incorporate shell commands and associated wifi_mgmt changes to provide a means to set various sniffing options for a wifi interface