### PR TITLE
gptp: eth_mcux: update driver for gptp

### DIFF
--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -108,6 +108,19 @@ config ETH_MCUX_PTP_CLOCK_INIT_PRIO
 	  a dependency from the network stack that this device
 	  initializes before network stack (NET_INIT_PRIO).
 
+config PTP_UPDATE_THREAD_PRI
+	int
+	default 10
+	help
+	  MCUX need a thread to update the ptp inner counter. This
+	  is a lower priority task.
+
+config ENABLE_HW_TIMER_UPDATE
+	bool "ENABLE ADJUST PTP HW timer"
+	default y
+	help
+	  Enable HW timer update to output pps.
+
 endif # PTP_CLOCK_MCUX
 
 endif # ETH_MCUX


### PR DESCRIPTION
1. do noe use gptp lower api to change the HW clock
2. using sofware to maintain the time drift
3. use a config to enable output pps

Fixing:  [33747](https://github.com/zephyrproject-rtos/zephyr/issues/33747)