### PR TITLE
net: event: provide complete information about the prefix in events

### DIFF
--- a/include/zephyr/net/net_event.h
+++ b/include/zephyr/net/net_event.h
@@ -214,7 +214,6 @@ enum net_event_l4_cmd {
 
 /** @endcond */
 
-#ifdef CONFIG_NET_MGMT_EVENT_INFO
 /**
  * @brief Network Management event information structure
  * Used to pass information on network events like
@@ -236,7 +235,7 @@ struct net_event_ipv6_addr {
  *   NET_EVENT_IPV6_NBR_DEL
  * when CONFIG_NET_MGMT_EVENT_INFO enabled and event generator pass the
  * information.
- * @Note: idx will be '-1' in case of NET_EVENT_IPV6_NBR_DEL event.
+ * @note: idx will be '-1' in case of NET_EVENT_IPV6_NBR_DEL event.
  */
 struct net_event_ipv6_nbr {
 	struct in6_addr addr;
@@ -257,7 +256,19 @@ struct net_event_ipv6_route {
 	uint8_t prefix_len;
 };
 
-#endif /* CONFIG_NET_MGMT_EVENT_INFO */
+/**
+ * @brief Network Management event information structure
+ * Used to pass information on network events like
+ *   NET_EVENT_IPV6_PREFIX_ADD and
+ *   NET_EVENT_IPV6_PREFIX_DEL
+ * when CONFIG_NET_MGMT_EVENT_INFO is enabled and event generator pass the
+ * information.
+ */
+struct net_event_ipv6_prefix {
+	struct in6_addr addr; /* prefix */
+	uint8_t len;
+	uint32_t lifetime;
+};
 
 #ifdef __cplusplus
 }

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -34,9 +34,12 @@ union net_mgmt_events {
 	struct wifi_raw_scan_result raw_scan_result;
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 #endif /* CONFIG_NET_L2_WIFI_MGMT */
-#if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV6_MLD)
+#if defined(CONFIG_NET_IPV6)
+	struct net_event_ipv6_prefix ipv6_prefix;
+#if defined(CONFIG_NET_IPV6_MLD)
 	struct net_event_ipv6_route ipv6_route;
-#endif /* CONFIG_NET_IPV6 && CONFIG_NET_IPV6_MLD */
+#endif /* CONFIG_NET_IPV6_MLD */
+#endif /* CONFIG_NET_IPV6 */
 	char default_event[DEFAULT_NET_EVENT_INFO_SIZE];
 };
 


### PR DESCRIPTION
At the moment, NET_EVENT_IPV6_PREFIX_ADD and NET_EVENT_IPV6_PREFIX_DEL events provide provide information about an address without its length and lifetime.