### PR TITLE
soc: nordic_nrf: nrf52840-qfaa has no USB

### DIFF
--- a/dts/arm/nordic/nrf52840_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52840_qfaa.dtsi
@@ -20,4 +20,6 @@
 		compatible = "nordic,nRF52840-QFAA", "nordic,nRF52840",
 			     "nordic,nRF52", "simple-bus";
 	};
+
+	/delete-node/ &usbd;
 };


### PR DESCRIPTION
The QFN48 version has no USB peripheral, remove it from the Devicetree.