### PR TITLE
soc: nordic: Make all compatibles lower case

### DIFF
--- a/dts/arm/nordic/nrf51822_qfaa.dtsi
+++ b/dts/arm/nordic/nrf51822_qfaa.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF51822-QFAA", "nordic,nRF51822", "nordic,nRF51", "simple-bus";
+		compatible = "nordic,nrf51822-qfaa", "nordic,nrf51822",
+			     "nordic,nrf51", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf51822_qfab.dtsi
+++ b/dts/arm/nordic/nrf51822_qfab.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF51822-QFAB", "nordic,nRF51822", "nordic,nRF51", "simple-bus";
+		compatible = "nordic,nrf51822-qfab", "nordic,nrf51822",
+			     "nordic,nrf51", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf51822_qfac.dtsi
+++ b/dts/arm/nordic/nrf51822_qfac.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF51822-QFAC", "nordic,nRF51822", "nordic,nRF51", "simple-bus";
+		compatible = "nordic,nrf51822-qfac", "nordic,nrf51822",
+			     "nordic,nrf51", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52805_caaa.dtsi
+++ b/dts/arm/nordic/nrf52805_caaa.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF52805-CAAA", "nordic,nRF52805", "nordic,nRF52", "simple-bus";
+		compatible = "nordic,nrf52805-caaa", "nordic,nrf52805",
+			     "nordic,nrf52", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52810_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52810_qfaa.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF52810-QFAA", "nordic,nRF52810", "nordic,nRF52", "simple-bus";
+		compatible = "nordic,nrf52810-qfaa", "nordic,nrf52810",
+			     "nordic,nrf52", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52811_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52811_qfaa.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF52811-QFAA", "nordic,nRF52811", "nordic,nRF52", "simple-bus";
+		compatible = "nordic,nrf52811-qfaa", "nordic,nrf52811",
+			     "nordic,nrf52", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52820_qdaa.dtsi
+++ b/dts/arm/nordic/nrf52820_qdaa.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF52820-QDAA", "nordic,nRF52820", "nordic,nRF52", "simple-bus";
+		compatible = "nordic,nrf52820-qdaa", "nordic,nrf52820",
+			     "nordic,nrf52", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52832_ciaa.dtsi
+++ b/dts/arm/nordic/nrf52832_ciaa.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF52832-CIAA", "nordic,nRF52832", "nordic,nRF52", "simple-bus";
+		compatible = "nordic,nrf52832-ciaa", "nordic,nrf52832",
+			     "nordic,nrf52", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52832_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52832_qfaa.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF52832-QFAA", "nordic,nRF52832", "nordic,nRF52", "simple-bus";
+		compatible = "nordic,nrf52832-qfaa", "nordic,nrf52832",
+			     "nordic,nrf52", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52832_qfab.dtsi
+++ b/dts/arm/nordic/nrf52832_qfab.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF52832-QFAB", "nordic,nRF52832", "nordic,nRF52", "simple-bus";
+		compatible = "nordic,nrf52832-qfab", "nordic,nrf52832",
+			     "nordic,nrf52", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52833_qdaa.dtsi
+++ b/dts/arm/nordic/nrf52833_qdaa.dtsi
@@ -17,7 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF52833-QDAA", "nordic,nRF52833",
-			     "nordic,nRF52", "simple-bus";
+		compatible = "nordic,nrf52833-qdaa", "nordic,nrf52833",
+			     "nordic,nrf52", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52833_qiaa.dtsi
+++ b/dts/arm/nordic/nrf52833_qiaa.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF52833-QIAA", "nordic,nRF52833", "nordic,nRF52", "simple-bus";
+		compatible = "nordic,nrf52833-qiaa", "nordic,nrf52833",
+			     "nordic,nrf52", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52840_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52840_qfaa.dtsi
@@ -17,7 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF52840-QFAA", "nordic,nRF52840",
-			     "nordic,nRF52", "simple-bus";
+		compatible = "nordic,nrf52840-qfaa", "nordic,nrf52840",
+			     "nordic,nrf52", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52840_qiaa.dtsi
+++ b/dts/arm/nordic/nrf52840_qiaa.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF52840-QIAA", "nordic,nRF52840", "nordic,nRF52", "simple-bus";
+		compatible = "nordic,nrf52840-qiaa", "nordic,nrf52840",
+			     "nordic,nrf52", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf5340_cpuapp_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_qkaa.dtsi
@@ -21,6 +21,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF5340-CPUAPP-QKAA", "nordic,nRF5340-CPUAPP", "nordic,nRF53", "simple-bus";
+		compatible = "nordic,nrf5340-cpuapp-qkaa", "nordic,nrf5340-cpuapp",
+			     "nordic,nrf53", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf5340_cpuappns_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns_qkaa.dtsi
@@ -21,6 +21,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF5340-CPUAPP-QKAA", "nordic,nRF5340-CPUAPP", "nordic,nRF53", "simple-bus";
+		compatible = "nordic,nrf5340-cpuapp-qkaa", "nordic,nrf5340-cpuapp",
+			     "nordic,nrf53", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf5340_cpunet_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet_qkaa.dtsi
@@ -25,6 +25,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF5340-CPUNET-QKAA", "nordic,nRF5340-CPUNET", "nordic,nRF53", "simple-bus";
+		compatible = "nordic,nrf5340-cpunet-qkaa", "nordic,nrf5340-cpunet",
+			     "nordic,nrf53", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf9160_sica.dtsi
+++ b/dts/arm/nordic/nrf9160_sica.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF9160-SICA", "nordic,nRF9160", "nordic,nRF91", "simple-bus";
+		compatible = "nordic,nrf9160-sica", "nordic,nrf9160",
+			     "nordic,nrf91", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf9160ns_sica.dtsi
+++ b/dts/arm/nordic/nrf9160ns_sica.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF9160-SICA", "nordic,nRF9160", "nordic,nRF91", "simple-bus";
+		compatible = "nordic,nrf9160-sica", "nordic,nrf9160",
+			     "nordic,nrf91", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf9161_sica.dtsi
+++ b/dts/arm/nordic/nrf9161_sica.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF9161-SICA", "nordic,nRF9120", "nordic,nRF91", "simple-bus";
+		compatible = "nordic,nrf9161-sica", "nordic,nrf9120",
+			     "nordic,nrf91", "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf9161ns_sica.dtsi
+++ b/dts/arm/nordic/nrf9161ns_sica.dtsi
@@ -17,6 +17,7 @@
 
 / {
 	soc {
-		compatible = "nordic,nRF9161-SICA", "nordic,nRF9120", "nordic,nRF91", "simple-bus";
+		compatible = "nordic,nrf9161-sica", "nordic,nrf9120",
+			     "nordic,nrf91", "simple-bus";
 	};
 };


### PR DESCRIPTION
Devicetree specification v0.4, Section 2.3.1:

"The compatible string should consist only of lowercase letters, digits
and dashes, and should start with a letter."
