### PR TITLE
lib: cpp: name the choice group for selecting C++ standard

### DIFF
--- a/lib/cpp/Kconfig
+++ b/lib/cpp/Kconfig
@@ -12,7 +12,7 @@ config CPP
 
 if CPP
 
-choice
+choice STD_CPP
 	prompt "C++ Standard"
 	default STD_CPP11
 	help


### PR DESCRIPTION
Add a name to the choice group for selecting the C++ standard to be able to override the default standard in Kconfig.* files.