### PR TITLE
Configure RTOS Zephyr in west debugserver's openocd runner command

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -356,6 +356,11 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             pre_init_cmd.append("-c")
             pre_init_cmd.append(i)
 
+        if self.thread_info_enabled and self.supports_thread_info():
+            pre_init_cmd.append("-c")
+            rtos_command = '${} configure -rtos Zephyr'.format(self.target_handle)
+            pre_init_cmd.append(rtos_command)
+
         cmd = (self.openocd_cmd + self.cfg_cmd +
                ['-c', 'tcl_port {}'.format(self.tcl_port),
                 '-c', 'telnet_port {}'.format(self.telnet_port),


### PR DESCRIPTION
This enables thread awareness functionality with `gdb` clients. Previously, one had to use the `west debug` command and rely on the spawned `gdb` client or modify `zephyr/boards/arc/iotdk/support/openocd.cfg` and add the following line:

```sh
# Add support for thread awareness
$_TARGETNAME configure -rtos Zephyr
```