### PR TITLE
Make POWER_DOMAIN_GPIO depend on PM_DEVICE

### DIFF
--- a/drivers/power_domain/Kconfig
+++ b/drivers/power_domain/Kconfig
@@ -18,6 +18,7 @@ config POWER_DOMAIN_GPIO
 	depends on DT_HAS_POWER_DOMAIN_GPIO_ENABLED
 	depends on GPIO
 	depends on TIMEOUT_64BIT
+	depends on PM_DEVICE
 
 config POWER_DOMAIN_INTEL_ADSP
 	bool "Use Intel ADSP power gating mechanisms"


### PR DESCRIPTION
The configuration `POWER_DOMAIN_GPIO=y` and `PM_DEVICE=n` results in an compile error since the GPIO device has no `pm` member. To fix this make POWER_DOMAIN_GPIO depend on PM_DEVICE.

---

Not sure if I'm on the wrong path here but it seems this dependency is missing to avoid compile errors.