### PR TITLE
Bluetooth: audio: vocs: Refactor bt_vocs object

### DIFF
--- a/subsys/bluetooth/audio/vocs.c
+++ b/subsys/bluetooth/audio/vocs.c
@@ -287,6 +287,11 @@ void *bt_vocs_svc_decl_get(struct bt_vocs *vocs)
 		return NULL;
 	}
 
+	CHECKIF(vocs->client_instance) {
+		LOG_DBG("vocs pointer shall be server instance");
+		return NULL;
+	}
+
 	return vocs->srv.service_p->attrs;
 }
 
@@ -307,6 +312,11 @@ int bt_vocs_register(struct bt_vocs *vocs,
 
 	CHECKIF(!vocs) {
 		LOG_DBG("Null VOCS pointer");
+		return -EINVAL;
+	}
+
+	CHECKIF(vocs->client_instance) {
+		LOG_DBG("vocs pointer shall be server instance");
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/audio/vocs.c
+++ b/subsys/bluetooth/audio/vocs.c
@@ -38,11 +38,11 @@ static void offset_state_cfg_changed(const struct bt_gatt_attr *attr, uint16_t v
 static ssize_t read_offset_state(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 void *buf, uint16_t len, uint16_t offset)
 {
-	struct bt_vocs *inst = BT_AUDIO_CHRC_USER_DATA(attr);
+	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
 
-	LOG_DBG("offset %d, counter %u", inst->srv.state.offset, inst->srv.state.change_counter);
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, &inst->srv.state,
-				 sizeof(inst->srv.state));
+	LOG_DBG("offset %d, counter %u", inst->state.offset, inst->state.change_counter);
+	return bt_gatt_attr_read(conn, attr, buf, len, offset, &inst->state,
+				 sizeof(inst->state));
 }
 
 static void location_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
@@ -55,14 +55,14 @@ static void location_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value
 static ssize_t write_location(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			      const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
-	struct bt_vocs *inst = BT_AUDIO_CHRC_USER_DATA(attr);
+	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
 	enum bt_audio_location new_location;
 
 	if (offset) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	if (len != sizeof(inst->srv.location)) {
+	if (len != sizeof(inst->location)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	}
 
@@ -74,15 +74,15 @@ static ssize_t write_location(struct bt_conn *conn, const struct bt_gatt_attr *a
 		return BT_GATT_ERR(BT_ATT_ERR_VALUE_NOT_ALLOWED);
 	}
 
-	if (new_location != inst->srv.location) {
-		inst->srv.location = new_location;
+	if (new_location != inst->location) {
+		inst->location = new_location;
 		(void)bt_gatt_notify_uuid(NULL, BT_UUID_VOCS_LOCATION,
-					  inst->srv.service_p->attrs,
-					  &inst->srv.location,
-					  sizeof(inst->srv.location));
+					  inst->service_p->attrs,
+					  &inst->location,
+					  sizeof(inst->location));
 
-		if (inst->srv.cb && inst->srv.cb->location) {
-			inst->srv.cb->location(inst, 0, inst->srv.location);
+		if (inst->cb && inst->cb->location) {
+			inst->cb->location(&inst->vocs, 0, inst->location);
 		}
 	}
 
@@ -93,18 +93,18 @@ static ssize_t write_location(struct bt_conn *conn, const struct bt_gatt_attr *a
 static ssize_t read_location(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			     void *buf, uint16_t len, uint16_t offset)
 {
-	struct bt_vocs *inst = BT_AUDIO_CHRC_USER_DATA(attr);
+	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
 
-	LOG_DBG("0x%08x", inst->srv.location);
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, &inst->srv.location,
-				 sizeof(inst->srv.location));
+	LOG_DBG("0x%08x", inst->location);
+	return bt_gatt_attr_read(conn, attr, buf, len, offset, &inst->location,
+				 sizeof(inst->location));
 }
 #endif /* CONFIG_BT_VOCS */
 
 static ssize_t write_vocs_control(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				  const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
-	struct bt_vocs *inst = BT_AUDIO_CHRC_USER_DATA(attr);
+	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
 	const struct bt_vocs_control *cp = buf;
 	bool notify = false;
 
@@ -129,7 +129,7 @@ static ssize_t write_vocs_control(struct bt_conn *conn, const struct bt_gatt_att
 	LOG_DBG("Opcode %u, counter %u", cp->opcode, cp->counter);
 
 
-	if (cp->counter != inst->srv.state.change_counter) {
+	if (cp->counter != inst->state.change_counter) {
 		return BT_GATT_ERR(BT_VOCS_ERR_INVALID_COUNTER);
 	}
 
@@ -140,8 +140,8 @@ static ssize_t write_vocs_control(struct bt_conn *conn, const struct bt_gatt_att
 			return BT_GATT_ERR(BT_VOCS_ERR_OUT_OF_RANGE);
 		}
 
-		if (inst->srv.state.offset != sys_le16_to_cpu(cp->offset)) {
-			inst->srv.state.offset = sys_le16_to_cpu(cp->offset);
+		if (inst->state.offset != sys_le16_to_cpu(cp->offset)) {
+			inst->state.offset = sys_le16_to_cpu(cp->offset);
 			notify = true;
 		}
 		break;
@@ -150,15 +150,15 @@ static ssize_t write_vocs_control(struct bt_conn *conn, const struct bt_gatt_att
 	}
 
 	if (notify) {
-		inst->srv.state.change_counter++;
-		LOG_DBG("New state: offset %d, counter %u", inst->srv.state.offset,
-			inst->srv.state.change_counter);
+		inst->state.change_counter++;
+		LOG_DBG("New state: offset %d, counter %u", inst->state.offset,
+			inst->state.change_counter);
 		(void)bt_gatt_notify_uuid(NULL, BT_UUID_VOCS_STATE,
-					  inst->srv.service_p->attrs,
-					  &inst->srv.state, sizeof(inst->srv.state));
+					  inst->service_p->attrs,
+					  &inst->state, sizeof(inst->state));
 
-		if (inst->srv.cb && inst->srv.cb->state) {
-			inst->srv.cb->state(inst, 0, inst->srv.state.offset);
+		if (inst->cb && inst->cb->state) {
+			inst->cb->state(&inst->vocs, 0, inst->state.offset);
 		}
 
 	}
@@ -176,39 +176,39 @@ static void output_desc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t va
 static ssize_t write_output_desc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
-	struct bt_vocs *inst = BT_AUDIO_CHRC_USER_DATA(attr);
+	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
 
 	if (offset) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	if (len >= sizeof(inst->srv.output_desc)) {
+	if (len >= sizeof(inst->output_desc)) {
 		LOG_DBG("Output desc was clipped from length %u to %zu", len,
-			sizeof(inst->srv.output_desc) - 1);
+			sizeof(inst->output_desc) - 1);
 		/* We just clip the string value if it's too long */
-		len = (uint16_t)sizeof(inst->srv.output_desc) - 1;
+		len = (uint16_t)sizeof(inst->output_desc) - 1;
 	}
 
-	if (len != strlen(inst->srv.output_desc) || memcmp(buf, inst->srv.output_desc, len)) {
-		memcpy(inst->srv.output_desc, buf, len);
-		inst->srv.output_desc[len] = '\0';
+	if (len != strlen(inst->output_desc) || memcmp(buf, inst->output_desc, len)) {
+		memcpy(inst->output_desc, buf, len);
+		inst->output_desc[len] = '\0';
 
 		(void)bt_gatt_notify_uuid(NULL, BT_UUID_VOCS_DESCRIPTION,
-					  inst->srv.service_p->attrs,
-					  &inst->srv.output_desc,
-					  strlen(inst->srv.output_desc));
+					  inst->service_p->attrs,
+					  &inst->output_desc,
+					  strlen(inst->output_desc));
 
-		if (inst->srv.cb && inst->srv.cb->description) {
-			inst->srv.cb->description(inst, 0, inst->srv.output_desc);
+		if (inst->cb && inst->cb->description) {
+			inst->cb->description(&inst->vocs, 0, inst->output_desc);
 		}
 	}
 
-	LOG_DBG("%s", inst->srv.output_desc);
+	LOG_DBG("%s", inst->output_desc);
 
 	return len;
 }
 
-static int vocs_write(struct bt_vocs *inst,
+static int vocs_write(struct bt_vocs_server *inst,
 		      ssize_t (*write)(struct bt_conn *conn,
 				       const struct bt_gatt_attr *attr,
 				       const void *buf, uint16_t len,
@@ -235,11 +235,11 @@ static int vocs_write(struct bt_vocs *inst,
 static ssize_t read_output_desc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				void *buf, uint16_t len, uint16_t offset)
 {
-	struct bt_vocs *inst = BT_AUDIO_CHRC_USER_DATA(attr);
+	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
 
-	LOG_DBG("%s", inst->srv.output_desc);
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, &inst->srv.output_desc,
-				 strlen(inst->srv.output_desc));
+	LOG_DBG("%s", inst->output_desc);
+	return bt_gatt_attr_read(conn, attr, buf, len, offset, &inst->output_desc,
+				 strlen(inst->output_desc));
 }
 
 #define BT_VOCS_SERVICE_DEFINITION(_vocs) { \
@@ -265,7 +265,7 @@ static ssize_t read_output_desc(struct bt_conn *conn, const struct bt_gatt_attr 
 	BT_AUDIO_CCC(output_desc_cfg_changed) \
 	}
 
-static struct bt_vocs vocs_insts[CONFIG_BT_VOCS_MAX_INSTANCE_COUNT];
+static struct bt_vocs_server vocs_insts[CONFIG_BT_VOCS_MAX_INSTANCE_COUNT];
 BT_GATT_SERVICE_INSTANCE_DEFINE(vocs_service_list, vocs_insts, CONFIG_BT_VOCS_MAX_INSTANCE_COUNT,
 				BT_VOCS_SERVICE_DEFINITION);
 
@@ -277,11 +277,13 @@ struct bt_vocs *bt_vocs_free_instance_get(void)
 		return NULL;
 	}
 
-	return &vocs_insts[instance_cnt++];
+	return &vocs_insts[instance_cnt++].vocs;
 }
 
 void *bt_vocs_svc_decl_get(struct bt_vocs *vocs)
 {
+	struct bt_vocs_server *inst;
+
 	CHECKIF(!vocs) {
 		LOG_DBG("Null VOCS pointer");
 		return NULL;
@@ -292,19 +294,22 @@ void *bt_vocs_svc_decl_get(struct bt_vocs *vocs)
 		return NULL;
 	}
 
-	return vocs->srv.service_p->attrs;
+	inst = CONTAINER_OF(vocs, struct bt_vocs_server, vocs);
+
+	return inst->service_p->attrs;
 }
 
 static void prepare_vocs_instances(void)
 {
 	for (int i = 0; i < ARRAY_SIZE(vocs_insts); i++) {
-		vocs_insts[i].srv.service_p = &vocs_service_list[i];
+		vocs_insts[i].service_p = &vocs_service_list[i];
 	}
 }
 
 int bt_vocs_register(struct bt_vocs *vocs,
 		     const struct bt_vocs_register_param *param)
 {
+	struct bt_vocs_server *inst;
 	int err;
 	struct bt_gatt_attr *attr;
 	struct bt_gatt_chrc *chrc;
@@ -320,6 +325,8 @@ int bt_vocs_register(struct bt_vocs *vocs,
 		return -EINVAL;
 	}
 
+	inst = CONTAINER_OF(vocs, struct bt_vocs_server, vocs);
+
 	CHECKIF(!param) {
 		LOG_DBG("NULL params pointer");
 		return -EINVAL;
@@ -330,7 +337,7 @@ int bt_vocs_register(struct bt_vocs *vocs,
 		instances_prepared = true;
 	}
 
-	CHECKIF(vocs->srv.initialized) {
+	CHECKIF(inst->initialized) {
 		LOG_DBG("Already initialized VOCS instance");
 		return -EALREADY;
 	}
@@ -340,18 +347,18 @@ int bt_vocs_register(struct bt_vocs *vocs,
 		return -EINVAL;
 	}
 
-	vocs->srv.location = param->location;
-	vocs->srv.state.offset = param->offset;
-	vocs->srv.cb = param->cb;
+	inst->location = param->location;
+	inst->state.offset = param->offset;
+	inst->cb = param->cb;
 
 	if (param->output_desc) {
-		strncpy(vocs->srv.output_desc, param->output_desc,
-			sizeof(vocs->srv.output_desc) - 1);
+		strncpy(inst->output_desc, param->output_desc,
+			sizeof(inst->output_desc) - 1);
 		/* strncpy may not always null-terminate */
-		vocs->srv.output_desc[sizeof(vocs->srv.output_desc) - 1] = '\0';
+		inst->output_desc[sizeof(inst->output_desc) - 1] = '\0';
 		if (IS_ENABLED(CONFIG_BT_VOCS_LOG_LEVEL_DBG) &&
-		    strcmp(vocs->srv.output_desc, param->output_desc)) {
-			LOG_DBG("Output desc clipped to %s", vocs->srv.output_desc);
+		    strcmp(inst->output_desc, param->output_desc)) {
+			LOG_DBG("Output desc clipped to %s", inst->output_desc);
 		}
 	}
 
@@ -361,30 +368,30 @@ int bt_vocs_register(struct bt_vocs *vocs,
 	 * also update the characteristic declaration (always found at [i - 1]) with the
 	 * BT_GATT_CHRC_WRITE_WITHOUT_RESP property.
 	 */
-	for (int i = 1; i < vocs->srv.service_p->attr_count; i++) {
-		attr = &vocs->srv.service_p->attrs[i];
+	for (int i = 1; i < inst->service_p->attr_count; i++) {
+		attr = &inst->service_p->attrs[i];
 
 		if (param->location_writable && !bt_uuid_cmp(attr->uuid, BT_UUID_VOCS_LOCATION)) {
 			/* Update attr and chrc to be writable */
-			chrc = vocs->srv.service_p->attrs[i - 1].user_data;
+			chrc = inst->service_p->attrs[i - 1].user_data;
 			attr->perm |= BT_GATT_PERM_WRITE_ENCRYPT;
 			chrc->properties |= BT_GATT_CHRC_WRITE_WITHOUT_RESP;
 		} else if (param->desc_writable &&
 			   !bt_uuid_cmp(attr->uuid, BT_UUID_VOCS_DESCRIPTION)) {
 			/* Update attr and chrc to be writable */
-			chrc = vocs->srv.service_p->attrs[i - 1].user_data;
+			chrc = inst->service_p->attrs[i - 1].user_data;
 			attr->perm |= BT_GATT_PERM_WRITE_ENCRYPT;
 			chrc->properties |= BT_GATT_CHRC_WRITE_WITHOUT_RESP;
 		}
 	}
 
-	err = bt_gatt_service_register(vocs->srv.service_p);
+	err = bt_gatt_service_register(inst->service_p);
 	if (err) {
 		LOG_DBG("Could not register VOCS service");
 		return err;
 	}
 
-	vocs->srv.initialized = true;
+	inst->initialized = true;
 	return 0;
 }
 #endif /* CONFIG_BT_VOCS */
@@ -397,10 +404,14 @@ int bt_vocs_state_get(struct bt_vocs *inst)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VOCS_CLIENT) && inst->client_instance) {
-		return bt_vocs_client_state_get(inst);
+		struct bt_vocs_client *cli = CONTAINER_OF(inst, struct bt_vocs_client, vocs);
+
+		return bt_vocs_client_state_get(cli);
 	} else if (IS_ENABLED(CONFIG_BT_VOCS) && !inst->client_instance) {
-		if (inst->srv.cb && inst->srv.cb->state) {
-			inst->srv.cb->state(inst, 0, inst->srv.state.offset);
+		struct bt_vocs_server *srv = CONTAINER_OF(inst, struct bt_vocs_server, vocs);
+
+		if (srv->cb && srv->cb->state) {
+			srv->cb->state(inst, 0, srv->state.offset);
 		}
 		return 0;
 	}
@@ -416,10 +427,14 @@ int bt_vocs_location_get(struct bt_vocs *inst)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VOCS_CLIENT) && inst->client_instance) {
-		return bt_vocs_client_location_get(inst);
+		struct bt_vocs_client *cli = CONTAINER_OF(inst, struct bt_vocs_client, vocs);
+
+		return bt_vocs_client_location_get(cli);
 	} else if (IS_ENABLED(CONFIG_BT_VOCS) && !inst->client_instance) {
-		if (inst->srv.cb && inst->srv.cb->location) {
-			inst->srv.cb->location(inst, 0, inst->srv.location);
+		struct bt_vocs_server *srv = CONTAINER_OF(inst, struct bt_vocs_server, vocs);
+
+		if (srv->cb && srv->cb->location) {
+			srv->cb->location(inst, 0, srv->location);
 		}
 		return 0;
 	}
@@ -435,9 +450,13 @@ int bt_vocs_location_set(struct bt_vocs *inst, uint32_t location)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VOCS_CLIENT) && inst->client_instance) {
-		return bt_vocs_client_location_set(inst, location);
+		struct bt_vocs_client *cli = CONTAINER_OF(inst, struct bt_vocs_client, vocs);
+
+		return bt_vocs_client_location_set(cli, location);
 	} else if (IS_ENABLED(CONFIG_BT_VOCS) && !inst->client_instance) {
-		return vocs_write(inst, write_location, &location, sizeof(location));
+		struct bt_vocs_server *srv = CONTAINER_OF(inst, struct bt_vocs_server, vocs);
+
+		return vocs_write(srv, write_location, &location, sizeof(location));
 	}
 
 	return -ENOTSUP;
@@ -451,15 +470,18 @@ int bt_vocs_state_set(struct bt_vocs *inst, int16_t offset)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VOCS_CLIENT) && inst->client_instance) {
-		return bt_vocs_client_state_set(inst, offset);
+		struct bt_vocs_client *cli = CONTAINER_OF(inst, struct bt_vocs_client, vocs);
+
+		return bt_vocs_client_state_set(cli, offset);
 	} else if (IS_ENABLED(CONFIG_BT_VOCS) && !inst->client_instance) {
+		struct bt_vocs_server *srv = CONTAINER_OF(inst, struct bt_vocs_server, vocs);
 		struct bt_vocs_control cp;
 
 		cp.opcode = BT_VOCS_OPCODE_SET_OFFSET;
-		cp.counter = inst->srv.state.change_counter;
+		cp.counter = srv->state.change_counter;
 		cp.offset = sys_cpu_to_le16(offset);
 
-		return vocs_write(inst, write_vocs_control, &cp, sizeof(cp));
+		return vocs_write(srv, write_vocs_control, &cp, sizeof(cp));
 	}
 
 	return -ENOTSUP;
@@ -473,10 +495,14 @@ int bt_vocs_description_get(struct bt_vocs *inst)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VOCS_CLIENT) && inst->client_instance) {
-		return bt_vocs_client_description_get(inst);
+		struct bt_vocs_client *cli = CONTAINER_OF(inst, struct bt_vocs_client, vocs);
+
+		return bt_vocs_client_description_get(cli);
 	} else if (IS_ENABLED(CONFIG_BT_VOCS) && !inst->client_instance) {
-		if (inst->srv.cb && inst->srv.cb->description) {
-			inst->srv.cb->description(inst, 0, inst->srv.output_desc);
+		struct bt_vocs_server *srv = CONTAINER_OF(inst, struct bt_vocs_server, vocs);
+
+		if (srv->cb && srv->cb->description) {
+			srv->cb->description(inst, 0, srv->output_desc);
 		}
 		return 0;
 	}
@@ -497,9 +523,13 @@ int bt_vocs_description_set(struct bt_vocs *inst, const char *description)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_VOCS_CLIENT) && inst->client_instance) {
-		return bt_vocs_client_description_set(inst, description);
+		struct bt_vocs_client *cli = CONTAINER_OF(inst, struct bt_vocs_client, vocs);
+
+		return bt_vocs_client_description_set(cli, description);
 	} else if (IS_ENABLED(CONFIG_BT_VOCS) && !inst->client_instance) {
-		return vocs_write(inst, write_output_desc, description, strlen(description));
+		struct bt_vocs_server *srv = CONTAINER_OF(inst, struct bt_vocs_server, vocs);
+
+		return vocs_write(srv, write_output_desc, description, strlen(description));
 	}
 
 	return -ENOTSUP;

--- a/subsys/bluetooth/audio/vocs_client.c
+++ b/subsys/bluetooth/audio/vocs_client.c
@@ -716,6 +716,11 @@ int bt_vocs_discover(struct bt_conn *conn, struct bt_vocs *inst,
 		return -EINVAL;
 	}
 
+	CHECKIF(!inst->client_instance) {
+		LOG_DBG("vocs pointer shall be client instance");
+		return -EINVAL;
+	}
+
 	CHECKIF(param->end_handle < param->start_handle) {
 		LOG_DBG("start_handle (%u) shall be less than end_handle (%u)", param->start_handle,
 			param->end_handle);
@@ -754,6 +759,11 @@ void bt_vocs_client_cb_register(struct bt_vocs *inst, struct bt_vocs_cb *cb)
 {
 	CHECKIF(!inst) {
 		LOG_DBG("inst cannot be NULL");
+		return;
+	}
+
+	CHECKIF(!inst->client_instance) {
+		LOG_DBG("vocs pointer shall be client instance");
 		return;
 	}
 

--- a/subsys/bluetooth/audio/vocs_client.c
+++ b/subsys/bluetooth/audio/vocs_client.c
@@ -26,19 +26,19 @@
 
 LOG_MODULE_REGISTER(bt_vocs_client, CONFIG_BT_VOCS_CLIENT_LOG_LEVEL);
 
-static struct bt_vocs vocs_insts[CONFIG_BT_MAX_CONN * CONFIG_BT_VOCS_CLIENT_MAX_INSTANCE_COUNT];
+static struct bt_vocs_client insts[CONFIG_BT_MAX_CONN * CONFIG_BT_VOCS_CLIENT_MAX_INSTANCE_COUNT];
 
-static struct bt_vocs *lookup_vocs_by_handle(struct bt_conn *conn, uint16_t handle)
+static struct bt_vocs_client *lookup_vocs_by_handle(struct bt_conn *conn, uint16_t handle)
 {
 	__ASSERT(handle != 0, "Handle cannot be 0");
 	__ASSERT(conn, "Conn cannot be NULL");
 
-	for (int i = 0; i < ARRAY_SIZE(vocs_insts); i++) {
-		if (vocs_insts[i].cli.conn == conn &&
-		    vocs_insts[i].cli.active &&
-		    vocs_insts[i].cli.start_handle <= handle &&
-		    vocs_insts[i].cli.end_handle >= handle) {
-			return &vocs_insts[i];
+	for (int i = 0; i < ARRAY_SIZE(insts); i++) {
+		if (insts[i].conn == conn &&
+		    insts[i].active &&
+		    insts[i].start_handle <= handle &&
+		    insts[i].end_handle >= handle) {
+			return &insts[i];
 		}
 	}
 
@@ -50,7 +50,7 @@ uint8_t vocs_client_notify_handler(struct bt_conn *conn, struct bt_gatt_subscrib
 				   const void *data, uint16_t length)
 {
 	uint16_t handle = params->value_handle;
-	struct bt_vocs *inst;
+	struct bt_vocs_client *inst;
 
 	if (conn == NULL) {
 		return BT_GATT_ITER_CONTINUE;
@@ -67,18 +67,18 @@ uint8_t vocs_client_notify_handler(struct bt_conn *conn, struct bt_gatt_subscrib
 		return BT_GATT_ITER_CONTINUE;
 	}
 
-	if (handle == inst->cli.state_handle) {
-		if (length == sizeof(inst->cli.state)) {
-			memcpy(&inst->cli.state, data, length);
-			LOG_DBG("Inst %p: Offset %d, counter %u", inst, inst->cli.state.offset,
-				inst->cli.state.change_counter);
-			if (inst->cli.cb && inst->cli.cb->state) {
-				inst->cli.cb->state(inst, 0, inst->cli.state.offset);
+	if (handle == inst->state_handle) {
+		if (length == sizeof(inst->state)) {
+			memcpy(&inst->state, data, length);
+			LOG_DBG("Inst %p: Offset %d, counter %u", inst, inst->state.offset,
+				inst->state.change_counter);
+			if (inst->cb && inst->cb->state) {
+				inst->cb->state(&inst->vocs, 0, inst->state.offset);
 			}
 		} else {
 			LOG_DBG("Invalid state length %u", length);
 		}
-	} else if (handle == inst->cli.desc_handle) {
+	} else if (handle == inst->desc_handle) {
 		char desc[MIN(BT_L2CAP_RX_MTU, BT_ATT_MAX_ATTRIBUTE_LEN) + 1];
 
 		/* Truncate if too large */
@@ -92,15 +92,15 @@ uint8_t vocs_client_notify_handler(struct bt_conn *conn, struct bt_gatt_subscrib
 		memcpy(desc, data, length);
 		desc[length] = '\0';
 		LOG_DBG("Inst %p: Output description: %s", inst, desc);
-		if (inst->cli.cb && inst->cli.cb->description) {
-			inst->cli.cb->description(inst, 0, desc);
+		if (inst->cb && inst->cb->description) {
+			inst->cb->description(&inst->vocs, 0, desc);
 		}
-	} else if (handle == inst->cli.location_handle) {
-		if (length == sizeof(inst->cli.location)) {
-			memcpy(&inst->cli.location, data, length);
-			LOG_DBG("Inst %p: Location %u", inst, inst->cli.location);
-			if (inst->cli.cb && inst->cli.cb->location) {
-				inst->cli.cb->location(inst, 0, inst->cli.location);
+	} else if (handle == inst->location_handle) {
+		if (length == sizeof(inst->location)) {
+			memcpy(&inst->location, data, length);
+			LOG_DBG("Inst %p: Location %u", inst, inst->location);
+			if (inst->cb && inst->cb->location) {
+				inst->cb->location(&inst->vocs, 0, inst->location);
 			}
 		} else {
 			LOG_DBG("Invalid location length %u", length);
@@ -115,7 +115,7 @@ static uint8_t vocs_client_read_offset_state_cb(struct bt_conn *conn, uint8_t er
 						const void *data, uint16_t length)
 {
 	int cb_err = err;
-	struct bt_vocs *inst = lookup_vocs_by_handle(conn, params->single.handle);
+	struct bt_vocs_client *inst = lookup_vocs_by_handle(conn, params->single.handle);
 
 	memset(params, 0, sizeof(*params));
 
@@ -125,18 +125,18 @@ static uint8_t vocs_client_read_offset_state_cb(struct bt_conn *conn, uint8_t er
 	}
 
 	LOG_DBG("Inst %p: err: 0x%02X", inst, err);
-	inst->cli.busy = false;
+	inst->busy = false;
 
 	if (cb_err) {
 		LOG_DBG("Offset state read failed: %d", err);
 	} else if (data) {
-		if (length == sizeof(inst->cli.state)) {
-			memcpy(&inst->cli.state, data, length);
-			LOG_DBG("Offset %d, counter %u", inst->cli.state.offset,
-				inst->cli.state.change_counter);
+		if (length == sizeof(inst->state)) {
+			memcpy(&inst->state, data, length);
+			LOG_DBG("Offset %d, counter %u", inst->state.offset,
+				inst->state.change_counter);
 		} else {
 			LOG_DBG("Invalid length %u (expected %zu)", length,
-				sizeof(inst->cli.state));
+				sizeof(inst->state));
 			cb_err = BT_ATT_ERR_INVALID_ATTRIBUTE_LEN;
 		}
 	} else {
@@ -144,9 +144,8 @@ static uint8_t vocs_client_read_offset_state_cb(struct bt_conn *conn, uint8_t er
 		cb_err = BT_ATT_ERR_UNLIKELY;
 	}
 
-	if (inst->cli.cb && inst->cli.cb->state) {
-		inst->cli.cb->state(inst, cb_err,
-				    cb_err ? 0 : inst->cli.state.offset);
+	if (inst->cb && inst->cb->state) {
+		inst->cb->state(&inst->vocs, cb_err, cb_err ? 0 : inst->state.offset);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -157,7 +156,7 @@ static uint8_t vocs_client_read_location_cb(struct bt_conn *conn, uint8_t err,
 					    const void *data, uint16_t length)
 {
 	int cb_err = err;
-	struct bt_vocs *inst = lookup_vocs_by_handle(conn, params->single.handle);
+	struct bt_vocs_client *inst = lookup_vocs_by_handle(conn, params->single.handle);
 
 	memset(params, 0, sizeof(*params));
 
@@ -167,17 +166,17 @@ static uint8_t vocs_client_read_location_cb(struct bt_conn *conn, uint8_t err,
 	}
 
 	LOG_DBG("Inst %p: err: 0x%02X", inst, err);
-	inst->cli.busy = false;
+	inst->busy = false;
 
 	if (cb_err) {
 		LOG_DBG("Offset state read failed: %d", err);
 	} else if (data) {
-		if (length == sizeof(inst->cli.location)) {
-			memcpy(&inst->cli.location, data, length);
-			LOG_DBG("Location %u", inst->cli.location);
+		if (length == sizeof(inst->location)) {
+			memcpy(&inst->location, data, length);
+			LOG_DBG("Location %u", inst->location);
 		} else {
 			LOG_DBG("Invalid length %u (expected %zu)", length,
-				sizeof(inst->cli.location));
+				sizeof(inst->location));
 			cb_err = BT_ATT_ERR_INVALID_ATTRIBUTE_LEN;
 		}
 	} else {
@@ -185,9 +184,8 @@ static uint8_t vocs_client_read_location_cb(struct bt_conn *conn, uint8_t err,
 		cb_err = BT_ATT_ERR_UNLIKELY;
 	}
 
-	if (inst->cli.cb && inst->cli.cb->location) {
-		inst->cli.cb->location(inst, cb_err,
-				       cb_err ? 0 : inst->cli.location);
+	if (inst->cb && inst->cb->location) {
+		inst->cb->location(&inst->vocs, cb_err, cb_err ? 0 : inst->location);
 	}
 
 	return BT_GATT_ITER_STOP;
@@ -198,7 +196,7 @@ static uint8_t internal_read_volume_offset_state_cb(struct bt_conn *conn, uint8_
 						    const void *data, uint16_t length)
 {
 	int cb_err = err;
-	struct bt_vocs *inst = lookup_vocs_by_handle(conn, params->single.handle);
+	struct bt_vocs_client *inst = lookup_vocs_by_handle(conn, params->single.handle);
 
 	memset(params, 0, sizeof(*params));
 
@@ -211,22 +209,22 @@ static uint8_t internal_read_volume_offset_state_cb(struct bt_conn *conn, uint8_
 		LOG_WRN("Volume offset state read failed: %d", err);
 		cb_err = BT_ATT_ERR_UNLIKELY;
 	} else if (data) {
-		if (length == sizeof(inst->cli.state)) {
+		if (length == sizeof(inst->state)) {
 			int write_err;
 
-			memcpy(&inst->cli.state, data, length);
-			LOG_DBG("Offset %d, counter %u", inst->cli.state.offset,
-				inst->cli.state.change_counter);
+			memcpy(&inst->state, data, length);
+			LOG_DBG("Offset %d, counter %u", inst->state.offset,
+				inst->state.change_counter);
 
 			/* clear busy flag to reuse function */
-			inst->cli.busy = false;
-			write_err = bt_vocs_client_state_set(inst, inst->cli.cp.offset);
+			inst->busy = false;
+			write_err = bt_vocs_client_state_set(inst, inst->cp.offset);
 			if (write_err) {
 				cb_err = BT_ATT_ERR_UNLIKELY;
 			}
 		} else {
 			LOG_DBG("Invalid length %u (expected %zu)", length,
-				sizeof(inst->cli.state));
+				sizeof(inst->state));
 			cb_err = BT_ATT_ERR_UNLIKELY;
 		}
 	} else {
@@ -235,10 +233,10 @@ static uint8_t internal_read_volume_offset_state_cb(struct bt_conn *conn, uint8_
 	}
 
 	if (cb_err) {
-		inst->cli.busy = false;
+		inst->busy = false;
 
-		if (inst->cli.cb && inst->cli.cb->set_offset) {
-			inst->cli.cb->set_offset(inst, err);
+		if (inst->cb && inst->cb->set_offset) {
+			inst->cb->set_offset(&inst->vocs, err);
 		}
 	}
 
@@ -249,7 +247,7 @@ static void vocs_client_write_vocs_cp_cb(struct bt_conn *conn, uint8_t err,
 					 struct bt_gatt_write_params *params)
 {
 	int cb_err = err;
-	struct bt_vocs *inst = lookup_vocs_by_handle(conn, params->handle);
+	struct bt_vocs_client *inst = lookup_vocs_by_handle(conn, params->handle);
 
 	memset(params, 0, sizeof(*params));
 
@@ -265,30 +263,30 @@ static void vocs_client_write_vocs_cp_cb(struct bt_conn *conn, uint8_t err,
 	 * change counter has been read, we restart the applications write request. If it fails
 	 * the second time, we return an error to the application.
 	 */
-	if (cb_err == BT_VOCS_ERR_INVALID_COUNTER && inst->cli.cp_retried) {
+	if (cb_err == BT_VOCS_ERR_INVALID_COUNTER && inst->cp_retried) {
 		cb_err = BT_ATT_ERR_UNLIKELY;
-	} else if (cb_err == BT_VOCS_ERR_INVALID_COUNTER && inst->cli.state_handle) {
+	} else if (cb_err == BT_VOCS_ERR_INVALID_COUNTER && inst->state_handle) {
 		LOG_DBG("Invalid change counter. Reading volume offset state from server.");
 
-		inst->cli.read_params.func = internal_read_volume_offset_state_cb;
-		inst->cli.read_params.handle_count = 1;
-		inst->cli.read_params.single.handle = inst->cli.state_handle;
+		inst->read_params.func = internal_read_volume_offset_state_cb;
+		inst->read_params.handle_count = 1;
+		inst->read_params.single.handle = inst->state_handle;
 
-		cb_err = bt_gatt_read(conn, &inst->cli.read_params);
+		cb_err = bt_gatt_read(conn, &inst->read_params);
 		if (cb_err) {
 			LOG_WRN("Could not read Volume offset state: %d", cb_err);
 		} else {
-			inst->cli.cp_retried = true;
+			inst->cp_retried = true;
 			/* Wait for read callback */
 			return;
 		}
 	}
 
-	inst->cli.busy = false;
-	inst->cli.cp_retried = false;
+	inst->busy = false;
+	inst->cp_retried = false;
 
-	if (inst->cli.cb && inst->cli.cb->set_offset) {
-		inst->cli.cb->set_offset(inst, cb_err);
+	if (inst->cb && inst->cb->set_offset) {
+		inst->cb->set_offset(&inst->vocs, cb_err);
 	}
 }
 
@@ -297,7 +295,7 @@ static uint8_t vocs_client_read_output_desc_cb(struct bt_conn *conn, uint8_t err
 					       const void *data, uint16_t length)
 {
 	int cb_err = err;
-	struct bt_vocs *inst = lookup_vocs_by_handle(conn, params->single.handle);
+	struct bt_vocs_client *inst = lookup_vocs_by_handle(conn, params->single.handle);
 	char desc[MIN(BT_L2CAP_RX_MTU, BT_ATT_MAX_ATTRIBUTE_LEN) + 1];
 
 	memset(params, 0, sizeof(*params));
@@ -308,7 +306,7 @@ static uint8_t vocs_client_read_output_desc_cb(struct bt_conn *conn, uint8_t err
 	}
 
 	LOG_DBG("Inst %p: err: 0x%02X", inst, err);
-	inst->cli.busy = false;
+	inst->busy = false;
 
 	if (cb_err) {
 		LOG_DBG("Description read failed: %d", err);
@@ -329,38 +327,35 @@ static uint8_t vocs_client_read_output_desc_cb(struct bt_conn *conn, uint8_t err
 		LOG_DBG("Output description: %s", desc);
 	}
 
-	if (inst->cli.cb && inst->cli.cb->description) {
-		inst->cli.cb->description(inst, cb_err, cb_err ? NULL : desc);
+	if (inst->cb && inst->cb->description) {
+		inst->cb->description(&inst->vocs, cb_err, cb_err ? NULL : desc);
 	}
 
 	return BT_GATT_ITER_STOP;
 }
 
-static bool valid_inst_discovered(struct bt_vocs *inst)
+static bool valid_inst_discovered(struct bt_vocs_client *inst)
 {
-	return inst->cli.state_handle &&
-		inst->cli.control_handle &&
-		inst->cli.location_handle &&
-		inst->cli.desc_handle;
+	return inst->state_handle &&
+		inst->control_handle &&
+		inst->location_handle &&
+		inst->desc_handle;
 }
 
 static uint8_t vocs_discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				  struct bt_gatt_discover_params *params)
 {
-	struct bt_vocs_client *client_inst = CONTAINER_OF(params,
-							  struct bt_vocs_client,
-							  discover_params);
-	struct bt_vocs *inst = CONTAINER_OF(client_inst, struct bt_vocs, cli);
+	struct bt_vocs_client *inst = CONTAINER_OF(params, struct bt_vocs_client, discover_params);
 
 	if (!attr) {
 		LOG_DBG("Discovery complete for VOCS %p", inst);
-		inst->cli.busy = false;
+		inst->busy = false;
 		(void)memset(params, 0, sizeof(*params));
 
-		if (inst->cli.cb && inst->cli.cb->discover) {
+		if (inst->cb && inst->cb->discover) {
 			int err = valid_inst_discovered(inst) ? 0 : -ENOENT;
 
-			inst->cli.cb->discover(inst, err);
+			inst->cb->discover(&inst->vocs, err);
 		}
 
 		return BT_GATT_ITER_STOP;
@@ -373,35 +368,35 @@ static uint8_t vocs_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 		struct bt_gatt_chrc *chrc;
 
 		chrc = (struct bt_gatt_chrc *)attr->user_data;
-		if (inst->cli.start_handle == 0) {
-			inst->cli.start_handle = chrc->value_handle;
+		if (inst->start_handle == 0) {
+			inst->start_handle = chrc->value_handle;
 		}
-		inst->cli.end_handle = chrc->value_handle;
+		inst->end_handle = chrc->value_handle;
 
 		if (!bt_uuid_cmp(chrc->uuid, BT_UUID_VOCS_STATE)) {
 			LOG_DBG("Volume offset state");
-			inst->cli.state_handle = chrc->value_handle;
-			sub_params = &inst->cli.state_sub_params;
+			inst->state_handle = chrc->value_handle;
+			sub_params = &inst->state_sub_params;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_VOCS_LOCATION)) {
 			LOG_DBG("Location");
-			inst->cli.location_handle = chrc->value_handle;
+			inst->location_handle = chrc->value_handle;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				sub_params = &inst->cli.location_sub_params;
+				sub_params = &inst->location_sub_params;
 			}
 			if (chrc->properties & BT_GATT_CHRC_WRITE_WITHOUT_RESP) {
-				inst->cli.location_writable = true;
+				inst->location_writable = true;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_VOCS_CONTROL)) {
 			LOG_DBG("Control point");
-			inst->cli.control_handle = chrc->value_handle;
+			inst->control_handle = chrc->value_handle;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_VOCS_DESCRIPTION)) {
 			LOG_DBG("Description");
-			inst->cli.desc_handle = chrc->value_handle;
+			inst->desc_handle = chrc->value_handle;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
-				sub_params = &inst->cli.desc_sub_params;
+				sub_params = &inst->desc_sub_params;
 			}
 			if (chrc->properties & BT_GATT_CHRC_WRITE_WITHOUT_RESP) {
-				inst->cli.desc_writable = true;
+				inst->desc_writable = true;
 			}
 		}
 
@@ -426,7 +421,7 @@ static uint8_t vocs_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 	return BT_GATT_ITER_CONTINUE;
 }
 
-int bt_vocs_client_state_get(struct bt_vocs *inst)
+int bt_vocs_client_state_get(struct bt_vocs_client *inst)
 {
 	int err;
 
@@ -435,43 +430,42 @@ int bt_vocs_client_state_get(struct bt_vocs *inst)
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	CHECKIF(inst->conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
 
-	if (!inst->cli.state_handle) {
+	if (!inst->state_handle) {
 		LOG_DBG("Handle not set");
 		return -EINVAL;
 	}
 
-	if (inst->cli.busy) {
+	if (inst->busy) {
 		LOG_DBG("Handle not set");
 		return -EBUSY;
 	}
 
-	inst->cli.read_params.func = vocs_client_read_offset_state_cb;
-	inst->cli.read_params.handle_count = 1;
-	inst->cli.read_params.single.handle = inst->cli.state_handle;
-	inst->cli.read_params.single.offset = 0U;
+	inst->read_params.func = vocs_client_read_offset_state_cb;
+	inst->read_params.handle_count = 1;
+	inst->read_params.single.handle = inst->state_handle;
+	inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(inst->cli.conn, &inst->cli.read_params);
+	err = bt_gatt_read(inst->conn, &inst->read_params);
 	if (!err) {
-		inst->cli.busy = true;
+		inst->busy = true;
 	}
 
 	return err;
 }
 
-int bt_vocs_client_location_set(struct bt_vocs *inst, uint32_t location)
+int bt_vocs_client_location_set(struct bt_vocs_client *inst, uint32_t location)
 {
-
 	CHECKIF(!inst) {
 		LOG_DBG("NULL instance");
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	CHECKIF(inst->conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -481,23 +475,23 @@ int bt_vocs_client_location_set(struct bt_vocs *inst, uint32_t location)
 		return -EINVAL;
 	}
 
-	if (!inst->cli.location_handle) {
+	if (!inst->location_handle) {
 		LOG_DBG("Handle not set");
 		return -EINVAL;
-	} else if (inst->cli.busy) {
+	} else if (inst->busy) {
 		return -EBUSY;
-	} else if (!inst->cli.location_writable) {
+	} else if (!inst->location_writable) {
 		LOG_DBG("Location is not writable on peer service instance");
 		return -EPERM;
 	}
 
-	return bt_gatt_write_without_response(inst->cli.conn,
-					      inst->cli.location_handle,
+	return bt_gatt_write_without_response(inst->conn,
+					      inst->location_handle,
 					      &location, sizeof(location),
 					      false);
 }
 
-int bt_vocs_client_location_get(struct bt_vocs *inst)
+int bt_vocs_client_location_get(struct bt_vocs_client *inst)
 {
 	int err;
 
@@ -506,32 +500,32 @@ int bt_vocs_client_location_get(struct bt_vocs *inst)
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	CHECKIF(inst->conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
 
-	if (!inst->cli.location_handle) {
+	if (!inst->location_handle) {
 		LOG_DBG("Handle not set");
 		return -EINVAL;
-	} else if (inst->cli.busy) {
+	} else if (inst->busy) {
 		return -EBUSY;
 	}
 
-	inst->cli.read_params.func = vocs_client_read_location_cb;
-	inst->cli.read_params.handle_count = 1;
-	inst->cli.read_params.single.handle = inst->cli.location_handle;
-	inst->cli.read_params.single.offset = 0U;
+	inst->read_params.func = vocs_client_read_location_cb;
+	inst->read_params.handle_count = 1;
+	inst->read_params.single.handle = inst->location_handle;
+	inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(inst->cli.conn, &inst->cli.read_params);
+	err = bt_gatt_read(inst->conn, &inst->read_params);
 	if (!err) {
-		inst->cli.busy = true;
+		inst->busy = true;
 	}
 
 	return err;
 }
 
-int bt_vocs_client_state_set(struct bt_vocs *inst, int16_t offset)
+int bt_vocs_client_state_set(struct bt_vocs_client *inst, int16_t offset)
 {
 	int err;
 
@@ -540,7 +534,7 @@ int bt_vocs_client_state_set(struct bt_vocs *inst, int16_t offset)
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	CHECKIF(inst->conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
@@ -550,32 +544,32 @@ int bt_vocs_client_state_set(struct bt_vocs *inst, int16_t offset)
 		return -EINVAL;
 	}
 
-	if (!inst->cli.control_handle) {
+	if (!inst->control_handle) {
 		LOG_DBG("Handle not set");
 		return -EINVAL;
-	} else if (inst->cli.busy) {
+	} else if (inst->busy) {
 		return -EBUSY;
 	}
 
-	inst->cli.cp.opcode = BT_VOCS_OPCODE_SET_OFFSET;
-	inst->cli.cp.counter = inst->cli.state.change_counter;
-	inst->cli.cp.offset = offset;
+	inst->cp.opcode = BT_VOCS_OPCODE_SET_OFFSET;
+	inst->cp.counter = inst->state.change_counter;
+	inst->cp.offset = offset;
 
-	inst->cli.write_params.offset = 0;
-	inst->cli.write_params.data = &inst->cli.cp;
-	inst->cli.write_params.length = sizeof(inst->cli.cp);
-	inst->cli.write_params.handle = inst->cli.control_handle;
-	inst->cli.write_params.func = vocs_client_write_vocs_cp_cb;
+	inst->write_params.offset = 0;
+	inst->write_params.data = &inst->cp;
+	inst->write_params.length = sizeof(inst->cp);
+	inst->write_params.handle = inst->control_handle;
+	inst->write_params.func = vocs_client_write_vocs_cp_cb;
 
-	err = bt_gatt_write(inst->cli.conn, &inst->cli.write_params);
+	err = bt_gatt_write(inst->conn, &inst->write_params);
 	if (!err) {
-		inst->cli.busy = true;
+		inst->busy = true;
 	}
 
 	return err;
 }
 
-int bt_vocs_client_description_get(struct bt_vocs *inst)
+int bt_vocs_client_description_get(struct bt_vocs_client *inst)
 {
 	int err;
 
@@ -584,32 +578,32 @@ int bt_vocs_client_description_get(struct bt_vocs *inst)
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	CHECKIF(inst->conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
 
-	if (!inst->cli.desc_handle) {
+	if (!inst->desc_handle) {
 		LOG_DBG("Handle not set");
 		return -EINVAL;
-	} else if (inst->cli.busy) {
+	} else if (inst->busy) {
 		return -EBUSY;
 	}
 
-	inst->cli.read_params.func = vocs_client_read_output_desc_cb;
-	inst->cli.read_params.handle_count = 1;
-	inst->cli.read_params.single.handle = inst->cli.desc_handle;
-	inst->cli.read_params.single.offset = 0U;
+	inst->read_params.func = vocs_client_read_output_desc_cb;
+	inst->read_params.handle_count = 1;
+	inst->read_params.single.handle = inst->desc_handle;
+	inst->read_params.single.offset = 0U;
 
-	err = bt_gatt_read(inst->cli.conn, &inst->cli.read_params);
+	err = bt_gatt_read(inst->conn, &inst->read_params);
 	if (!err) {
-		inst->cli.busy = true;
+		inst->busy = true;
 	}
 
 	return err;
 }
 
-int bt_vocs_client_description_set(struct bt_vocs *inst,
+int bt_vocs_client_description_set(struct bt_vocs_client *inst,
 				   const char *description)
 {
 	CHECKIF(!inst) {
@@ -617,34 +611,34 @@ int bt_vocs_client_description_set(struct bt_vocs *inst,
 		return -EINVAL;
 	}
 
-	CHECKIF(inst->cli.conn == NULL) {
+	CHECKIF(inst->conn == NULL) {
 		LOG_DBG("NULL conn");
 		return -EINVAL;
 	}
 
-	if (!inst->cli.desc_handle) {
+	if (!inst->desc_handle) {
 		LOG_DBG("Handle not set");
 		return -EINVAL;
-	} else if (inst->cli.busy) {
+	} else if (inst->busy) {
 		return -EBUSY;
-	} else if (!inst->cli.desc_writable) {
+	} else if (!inst->desc_writable) {
 		LOG_DBG("Description is not writable on peer service instance");
 		return -EPERM;
 	}
 
-	return bt_gatt_write_without_response(inst->cli.conn,
-					      inst->cli.desc_handle,
+	return bt_gatt_write_without_response(inst->conn,
+					      inst->desc_handle,
 					      description,
 					      strlen(description), false);
 }
 
 struct bt_vocs *bt_vocs_client_free_instance_get(void)
 {
-	for (int i = 0; i < ARRAY_SIZE(vocs_insts); i++) {
-		if (!vocs_insts[i].cli.active) {
-			vocs_insts[i].client_instance = true;
-			vocs_insts[i].cli.active = true;
-			return &vocs_insts[i];
+	for (int i = 0; i < ARRAY_SIZE(insts); i++) {
+		if (!insts[i].active) {
+			insts[i].vocs.client_instance = true;
+			insts[i].active = true;
+			return &insts[i].vocs;
 		}
 	}
 
@@ -653,41 +647,45 @@ struct bt_vocs *bt_vocs_client_free_instance_get(void)
 
 int bt_vocs_client_conn_get(const struct bt_vocs *vocs, struct bt_conn **conn)
 {
+	struct bt_vocs_client *inst;
+
 	CHECKIF(vocs == NULL) {
 		LOG_DBG("NULL vocs pointer");
 		return -EINVAL;
 	}
 
-	if (!vocs->client_instance) {
+	CHECKIF(!vocs->client_instance) {
 		LOG_DBG("vocs pointer shall be client instance");
 		return -EINVAL;
 	}
 
-	if (vocs->cli.conn == NULL) {
+	inst = CONTAINER_OF(vocs, struct bt_vocs_client, vocs);
+
+	if (inst->conn == NULL) {
 		LOG_DBG("vocs pointer not associated with a connection. "
 		       "Do discovery first");
 		return -ENOTCONN;
 	}
 
-	*conn = vocs->cli.conn;
+	*conn = inst->conn;
 	return 0;
 }
 
-static void vocs_client_reset(struct bt_vocs *inst)
+static void vocs_client_reset(struct bt_vocs_client *inst)
 {
-	memset(&inst->cli.state, 0, sizeof(inst->cli.state));
-	inst->cli.location_writable = 0;
-	inst->cli.location = 0;
-	inst->cli.desc_writable = 0;
-	inst->cli.start_handle = 0;
-	inst->cli.end_handle = 0;
-	inst->cli.state_handle = 0;
-	inst->cli.location_handle = 0;
-	inst->cli.control_handle = 0;
-	inst->cli.desc_handle = 0;
+	memset(&inst->state, 0, sizeof(inst->state));
+	inst->location_writable = 0;
+	inst->location = 0;
+	inst->desc_writable = 0;
+	inst->start_handle = 0;
+	inst->end_handle = 0;
+	inst->state_handle = 0;
+	inst->location_handle = 0;
+	inst->control_handle = 0;
+	inst->desc_handle = 0;
 
-	if (inst->cli.conn != NULL) {
-		struct bt_conn *conn = inst->cli.conn;
+	if (inst->conn != NULL) {
+		struct bt_conn *conn = inst->conn;
 
 		/* It's okay if these fail. In case of disconnect, we can't
 		 * unsubscribe and they will just fail.
@@ -695,28 +693,29 @@ static void vocs_client_reset(struct bt_vocs *inst)
 		 * function, we will unsubscribe (regardless of bonding state)
 		 * to accommodate the new discovery values.
 		 */
-		(void)bt_gatt_unsubscribe(conn, &inst->cli.state_sub_params);
-		(void)bt_gatt_unsubscribe(conn, &inst->cli.location_sub_params);
-		(void)bt_gatt_unsubscribe(conn, &inst->cli.desc_sub_params);
+		(void)bt_gatt_unsubscribe(conn, &inst->state_sub_params);
+		(void)bt_gatt_unsubscribe(conn, &inst->location_sub_params);
+		(void)bt_gatt_unsubscribe(conn, &inst->desc_sub_params);
 
 		bt_conn_unref(conn);
-		inst->cli.conn = NULL;
+		inst->conn = NULL;
 	}
 }
 
-int bt_vocs_discover(struct bt_conn *conn, struct bt_vocs *inst,
+int bt_vocs_discover(struct bt_conn *conn, struct bt_vocs *vocs,
 		     const struct bt_vocs_discover_param *param)
 {
+	struct bt_vocs_client *inst;
 	int err = 0;
 
-	CHECKIF(!inst || !conn || !param) {
-		LOG_DBG("%s cannot be NULL", inst == NULL   ? "inst"
+	CHECKIF(!vocs || !conn || !param) {
+		LOG_DBG("%s cannot be NULL", vocs == NULL   ? "vocs"
 					     : conn == NULL ? "conn"
 							    : "param");
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst->client_instance) {
+	CHECKIF(!vocs->client_instance) {
 		LOG_DBG("vocs pointer shall be client instance");
 		return -EINVAL;
 	}
@@ -727,45 +726,51 @@ int bt_vocs_discover(struct bt_conn *conn, struct bt_vocs *inst,
 		return -EINVAL;
 	}
 
-	CHECKIF(!inst->cli.active) {
+	inst = CONTAINER_OF(vocs, struct bt_vocs_client, vocs);
+
+	CHECKIF(!inst->active) {
 		LOG_DBG("Inactive instance");
 		return -EINVAL;
 	}
 
-	if (inst->cli.busy) {
+	if (inst->busy) {
 		LOG_DBG("Instance is busy");
 		return -EBUSY;
 	}
 
 	vocs_client_reset(inst);
 
-	inst->cli.conn = bt_conn_ref(conn);
-	inst->cli.discover_params.start_handle = param->start_handle;
-	inst->cli.discover_params.end_handle = param->end_handle;
-	inst->cli.discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
-	inst->cli.discover_params.func = vocs_discover_func;
+	inst->conn = bt_conn_ref(conn);
+	inst->discover_params.start_handle = param->start_handle;
+	inst->discover_params.end_handle = param->end_handle;
+	inst->discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
+	inst->discover_params.func = vocs_discover_func;
 
-	err = bt_gatt_discover(conn, &inst->cli.discover_params);
+	err = bt_gatt_discover(conn, &inst->discover_params);
 	if (err) {
 		LOG_DBG("Discover failed (err %d)", err);
 	} else {
-		inst->cli.busy = true;
+		inst->busy = true;
 	}
 
 	return err;
 }
 
-void bt_vocs_client_cb_register(struct bt_vocs *inst, struct bt_vocs_cb *cb)
+void bt_vocs_client_cb_register(struct bt_vocs *vocs, struct bt_vocs_cb *cb)
 {
-	CHECKIF(!inst) {
+	struct bt_vocs_client *inst;
+
+	CHECKIF(!vocs) {
 		LOG_DBG("inst cannot be NULL");
 		return;
 	}
 
-	CHECKIF(!inst->client_instance) {
+	CHECKIF(!vocs->client_instance) {
 		LOG_DBG("vocs pointer shall be client instance");
 		return;
 	}
 
-	inst->cli.cb = cb;
+	inst = CONTAINER_OF(vocs, struct bt_vocs_client, vocs);
+
+	inst->cb = cb;
 }

--- a/subsys/bluetooth/audio/vocs_internal.h
+++ b/subsys/bluetooth/audio/vocs_internal.h
@@ -30,7 +30,12 @@ struct bt_vocs_state {
 	uint8_t change_counter;
 } __packed;
 
+struct bt_vocs {
+	bool client_instance;
+};
+
 struct bt_vocs_client {
+	struct bt_vocs vocs;
 	struct bt_vocs_state state;
 	bool location_writable;
 	uint32_t location;
@@ -58,6 +63,7 @@ struct bt_vocs_client {
 };
 
 struct bt_vocs_server {
+	struct bt_vocs vocs;
 	struct bt_vocs_state state;
 	uint32_t location;
 	bool initialized;
@@ -67,20 +73,11 @@ struct bt_vocs_server {
 	struct bt_gatt_service *service_p;
 };
 
-struct bt_vocs {
-	bool client_instance;
-	union {
-		struct bt_vocs_server srv;
-		struct bt_vocs_client cli;
-	};
-};
-
-int bt_vocs_client_state_get(struct bt_vocs *inst);
-int bt_vocs_client_state_set(struct bt_vocs *inst, int16_t offset);
-int bt_vocs_client_location_get(struct bt_vocs *inst);
-int bt_vocs_client_location_set(struct bt_vocs *inst, uint32_t location);
-int bt_vocs_client_description_get(struct bt_vocs *inst);
-int bt_vocs_client_description_set(struct bt_vocs *inst,
-				   const char *description);
+int bt_vocs_client_state_get(struct bt_vocs_client *inst);
+int bt_vocs_client_state_set(struct bt_vocs_client *inst, int16_t offset);
+int bt_vocs_client_location_get(struct bt_vocs_client *inst);
+int bt_vocs_client_location_set(struct bt_vocs_client *inst, uint32_t location);
+int bt_vocs_client_description_get(struct bt_vocs_client *inst);
+int bt_vocs_client_description_set(struct bt_vocs_client *inst, const char *description);
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_VOCS_INTERNAL_ */


### PR DESCRIPTION
This adds refactor of bt_vocs object that is common interface for client
and server commands. As the bt_vocs_client is significantly larger than
bt_vocs_server the memory usage is not optimized when bt_vocs has an
union of those. Thus RAM consumption has been minimized by using
CONTAINER_OF macro to reference either to bt_vocs_client or
bt_vocs_server instance that bt_vocs is a member of.