### PR TITLE
net: tcp: Avoid partial ACK canceling retransmission timer

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2343,6 +2343,10 @@ next_state:
 			}
 		}
 #endif
+		NET_ASSERT((conn->send_data_total == 0) ||
+			   k_work_delayable_is_pending(&conn->send_data_timer),
+			   "conn: %p, Missing a subscription "
+				"of the send_data queue timer", conn);
 
 		if (th && (net_tcp_seq_cmp(th_ack(th), conn->seq) > 0)) {
 			uint32_t len_acked = th_ack(th) - conn->seq;
@@ -2383,19 +2387,16 @@ next_state:
 
 			conn_send_data_dump(conn);
 
-			if (!k_work_delayable_remaining_get(
-				    &conn->send_data_timer)) {
-				NET_DBG("conn: %p, Missing a subscription "
-					"of the send_data queue timer", conn);
-				break;
-			}
 			conn->send_data_retries = 0;
-			k_work_cancel_delayable(&conn->send_data_timer);
 			if (conn->data_mode == TCP_DATA_MODE_RESEND) {
 				conn->unacked_len = 0;
 				tcp_derive_rto(conn);
 			}
 			conn->data_mode = TCP_DATA_MODE_SEND;
+			if (conn->send_data_total > 0) {
+				k_work_reschedule_for_queue(&tcp_work_q, &conn->send_data_timer,
+					    K_MSEC(TCP_RTO_MS));
+			}
 
 			/* We are closing the connection, send a FIN to peer */
 			if (conn->in_close && conn->send_data_total == 0) {
@@ -2457,6 +2458,20 @@ next_state:
 				verdict = NET_OK;
 			}
 		}
+
+		/* Check if there is any data left to retransmit possibly*/
+		if (conn->send_data_total == 0) {
+			conn->send_data_retries = 0;
+			k_work_cancel_delayable(&conn->send_data_timer);
+		}
+
+		/* A lot could have happened to the transmission window check the situation here */
+		if (tcp_window_full(conn)) {
+			(void)k_sem_take(&conn->tx_sem, K_NO_WAIT);
+		} else {
+			k_sem_give(&conn->tx_sem);
+		}
+
 		break;
 	case TCP_CLOSE_WAIT:
 		tcp_out(conn, FIN);


### PR DESCRIPTION
At any ack, the retransmission timer was cancelled. This means when an ACK is only partially acknowledging pending data, followed by a packet loss, the connection ended in a deadlock eventually timing out. By checking if there is any pending data for transmission before canceling the retransmission timer, there is no risk of this lock-up any more.