### PR TITLE
devicetree: memory-attr: Introduce `DT_MEMORY_ATTR_FOREACH_STATUS_OKAY_NODE`

### DIFF
--- a/include/zephyr/devicetree/memory-attr.h
+++ b/include/zephyr/devicetree/memory-attr.h
@@ -49,6 +49,21 @@
 /** @endcond */
 
 /**
+ * @brief Invokes @p fn for every status `okay` node in the tree with property
+ *	  `zephyr,memory-attr`
+ *
+ * The macro @p fn must take one parameter, which will be a node identifier
+ * with the `zephyr,memory-attr` property. The macro is expanded once for each
+ * node in the tree with status `okay`. The order that nodes are visited in is
+ * not specified.
+ *
+ * @param fn macro to invoke
+ */
+#define DT_MEMORY_ATTR_FOREACH_STATUS_OKAY_NODE(fn) \
+	DT_FOREACH_STATUS_OKAY_NODE_VARGS(_FILTER, fn)
+
+
+/**
  * @brief Invokes @p fn for every node in the tree with property
  *        `zephyr,memory-attr`
  *
@@ -59,14 +74,15 @@
  * @param fn macro to invoke
  */
 #define DT_MEMORY_ATTR_FOREACH_NODE(fn) \
-	DT_FOREACH_STATUS_OKAY_NODE_VARGS(_FILTER, fn)
+	DT_FOREACH_NODE_VARGS(_FILTER, fn)
 
 /**
  * @brief Invokes @p fn for MPU/MMU regions generation from the device tree
  *	  nodes with `zephyr,memory-attr` property.
  *
  * Helper macro to invoke a @p fn macro on all the memory regions declared
- * using the `zephyr,memory-attr` property
+ * using the `zephyr,memory-attr` property. The macro is expanded once for each
+ * node in the tree with status `okay`.
  *
  * The macro @p fn must take the form:
  *

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -649,6 +649,13 @@
 			zephyr,memory-attr = "RAM_NOCACHE";
 		};
 
+		test_mem_disabled: memory@11223344 {
+			compatible = "vnd,memory-attr";
+			reg = < 0x11223344 0x1000 >;
+			zephyr,memory-attr = "FLASH";
+			status = "disabled";
+		};
+
 	};
 
 	test_64 {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2753,6 +2753,16 @@ ZTEST(devicetree_api, test_memory_attr)
 	zassert_equal(val_filt[0], 0x44332211, "");
 
 	#undef TEST_FUNC
+
+	#define TEST_FUNC(node_id) DT_REG_SIZE(node_id),
+
+	size_t val_status_ok[] = {
+		DT_MEMORY_ATTR_FOREACH_STATUS_OKAY_NODE(TEST_FUNC)
+	};
+
+	zassert_equal(ARRAY_SIZE(val_status_ok), 2, "");
+
+	#undef TEST_FUNC
 }
 
 ZTEST(devicetree_api, test_string_token)


### PR DESCRIPTION
Introduce a new `DT_MEMORY_ATTR_FOREACH_STATUS_OKAY_NODE()` macro and make the `DT_MEMORY_ATTR_FOREACH_NODE()` macro visiting disabled nodes as well.