### PR TITLE
doc: bin blobs: State that blobs will not be fetched in CI

### DIFF
--- a/doc/contribute/bin_blobs.rst
+++ b/doc/contribute/bin_blobs.rst
@@ -217,6 +217,12 @@ over bit-rot, security issues, etc.
 The submitter of the proposal to integrate a binary blob must commit to maintain
 the integration of such blob for the foreseeable future.
 
+Regarding Continuous Integration, binary blobs will **not** be fetched in the
+project's CI infrastructure that builds and optionally executes tests and samples
+to prevent regressions and issues from entering the codebase. This includes
+both CI ran when a new GitHub Pull Request is opened as well as any other
+regularly scheduled execution of the CI infrastructure.
+
 .. _blobs-process:
 
 Submission and review process


### PR DESCRIPTION
As a follow-up to a recent discussion in the PR below: 
https://github.com/zephyrproject-rtos/zephyr/pull/59991

document that binary blobs will not be fetched in CI.