### PR TITLE
runners: harmonize misc-flasher template with the other runners

### DIFF
--- a/boards/arm/beagle_bcf/board.cmake
+++ b/boards/arm/beagle_bcf/board.cmake
@@ -5,5 +5,6 @@
 
 # Download cc2538-bsl.py from https://git.beagleboard.org/beagleconnect/zephyr/cc2538-bsl/-/tags/2.1-bcf
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher $ENV{ZEPHYR_BASE}/boards/arm/beagle_bcf/cc2538-bsl.py -w)
+board_runner_args(misc-flasher $ENV{ZEPHYR_BASE}/boards/arm/beagle_bcf/cc2538-bsl.py -w)
+
+include(${ZEPHYR_BASE}/boards/common/misc-flasher.board.cmake)

--- a/boards/arm/mec172xevb_assy6906/board.cmake
+++ b/boards/arm/mec172xevb_assy6906/board.cmake
@@ -11,4 +11,4 @@ board_finalize_runner_args(dediprog
 )
 
 # This allows a custom script to be used for flashing the SPI chip.
-include(${ZEPHYR_BASE}/boards/common/misc.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/misc-flasher.board.cmake)

--- a/boards/common/misc-flasher.board.cmake
+++ b/boards/common/misc-flasher.board.cmake
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Please use this sparingly and only when if your setup is exotic and
+# you're willing to handle requests for help. E.g. your "board" is a
+# core on a special-purpose SoC which requires a complicated script to
+# network boot.
+
+board_set_flasher_ifnset(misc-flasher)
+board_finalize_runner_args(misc-flasher)

--- a/boards/riscv/it8xxx2_evb/board.cmake
+++ b/boards/riscv/it8xxx2_evb/board.cmake
@@ -1,4 +1,3 @@
 set(SUPPORTED_EMU_PLATFORMS renode)
 set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/it8xxx2_evb.resc)
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+include(${ZEPHYR_BASE}/boards/common/misc-flasher.board.cmake)

--- a/boards/x86/acrn/board.cmake
+++ b/boards/x86/acrn/board.cmake
@@ -1,4 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+include(${ZEPHYR_BASE}/boards/common/misc-flasher.board.cmake)

--- a/boards/x86/ehl_crb/board.cmake
+++ b/boards/x86/ehl_crb/board.cmake
@@ -1,4 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+include(${ZEPHYR_BASE}/boards/common/misc-flasher.board.cmake)

--- a/boards/x86/rpl_crb/board.cmake
+++ b/boards/x86/rpl_crb/board.cmake
@@ -1,4 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+include(${ZEPHYR_BASE}/boards/common/misc-flasher.board.cmake)

--- a/boards/x86/up_squared/board.cmake
+++ b/boards/x86/up_squared/board.cmake
@@ -1,4 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+include(${ZEPHYR_BASE}/boards/common/misc-flasher.board.cmake)

--- a/boards/xtensa/intel_adsp_cavs25/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs25/board.cmake
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if($ENV{CAVS_OLD_FLASHER})
-  board_set_flasher_ifnset(misc-flasher)
-  board_finalize_runner_args(misc-flasher)
+  include(${ZEPHYR_BASE}/boards/common/misc-flasher.board.cmake)
 endif()
 
 board_set_flasher_ifnset(intel_adsp)

--- a/boards/xtensa/nxp_adsp_imx8/board.cmake
+++ b/boards/xtensa/nxp_adsp_imx8/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+include(${ZEPHYR_BASE}/boards/common/misc-flasher.board.cmake)
 
 board_set_rimage_target(imx8)

--- a/boards/xtensa/nxp_adsp_imx8m/board.cmake
+++ b/boards/xtensa/nxp_adsp_imx8m/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+include(${ZEPHYR_BASE}/boards/common/misc-flasher.board.cmake)
 
 board_set_rimage_target(imx8m)

--- a/boards/xtensa/nxp_adsp_imx8x/board.cmake
+++ b/boards/xtensa/nxp_adsp_imx8x/board.cmake
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+include(${ZEPHYR_BASE}/boards/common/misc-flasher.board.cmake)
 
 board_set_rimage_target(imx8)


### PR DESCRIPTION
Make the misc-flasher template work like all the other runners:

- use board_set_flasher_ifnset so that it's used automatically if specified first
- rename the file to match the runner name so one could use something like:

board_runner_args(misc-flasher "...")
include(${ZEPHYR_BASE}/boards/common/misc-flasher.board.cmake)