### PR TITLE
tests: thrift: check for channel closure before throwing

### DIFF
--- a/modules/thrift/src/thrift/server/TFDServer.cpp
+++ b/modules/thrift/src/thrift/server/TFDServer.cpp
@@ -71,6 +71,11 @@ class xport : public TVirtualTransport<xport>
 
 		r = poll(&pollfds.front(), pollfds.size(), -1);
 		if (r == -1) {
+			if (efd == -1 || fd == -1) {
+				/* channel has been closed */
+				return 0;
+			}
+
 			LOG_ERR("failed to poll fds %d, %d: %d", fd, efd, errno);
 			throw system_error(errno, system_category(), "poll");
 		}


### PR DESCRIPTION
Previously, the binary protocol variant of ThriftTest would fail consistently in CI for `qemu_x86_64` with the message below.

```
E: failed to poll fds -1, -1: 1
```

Note: 1 corresponds to EPERM

The root cause of this is that we do not yet have support for standard synchronization primitives in C++, and there is slightly racey behaviour in thrift until we do have support for standard synchronization primitives.

This change is a temporary workaround but solves the test failure (which would occur even when tests all passed).

Fixes #60895