### PR TITLE
Fix #58408 by always using GCC's full version

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -38,7 +38,7 @@ endif()
 # https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=be9dd80f933480
 # Add check for GCC version >= 13.1
 execute_process(
-    COMMAND ${CMAKE_C_COMPILER} -dumpversion
+    COMMAND ${CMAKE_C_COMPILER} -dumpfullversion
     OUTPUT_VARIABLE temp_compiler_version
     )
 


### PR DESCRIPTION
#58408 fixed compilation for GCC >= 13.1. But -dumpversion's output length depends on compile time configuration. It might only yield the major version. So use -dumpfullversion instead, which is guaranteed to always include major, minor and patch version.