### PR TITLE
intel_adsp: Add option about switch off hpsram

### DIFF
--- a/soc/xtensa/intel_adsp/Kconfig
+++ b/soc/xtensa/intel_adsp/Kconfig
@@ -95,6 +95,13 @@ config ADSP_INIT_HPSRAM
 	help
 	  Need to init HP SRAM.
 
+config ADSP_POWER_DOWN_HPSRAM
+	bool
+	default n if ZTEST
+	default y
+	help
+	 Switch off HP SRAM during power down.
+
 config ADSP_DISABLE_L2CACHE_AT_BOOT
 	bool
 

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -282,9 +282,12 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 					(void *)rom_entry;
 			sys_cache_data_flush_range(imr_layout, sizeof(*imr_layout));
 #endif /* CONFIG_ADSP_IMR_CONTEXT_SAVE */
+			uint32_t hpsram_mask = 0;
+#ifdef CONFIG_ADSP_POWER_DOWN_HPSRAM
 			/* turn off all HPSRAM banks - get a full bitmap */
 			uint32_t ebb_banks = ace_hpsram_get_bank_count();
-			uint32_t hpsram_mask = (1 << ebb_banks) - 1;
+			hpsram_mask = (1 << ebb_banks) - 1;
+#endif /* CONFIG_ADSP_POWER_DOWN_HPSRAM */
 			/* do power down - this function won't return */
 			power_down(true, uncache_to_cache(&hpsram_mask),
 				   true);

--- a/soc/xtensa/intel_adsp/cavs/power.c
+++ b/soc/xtensa/intel_adsp/cavs/power.c
@@ -87,7 +87,7 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 		soc_cpus_active[cpu] = false;
 		sys_cache_data_flush_and_invd_all();
 		if (cpu == 0) {
-			uint32_t hpsram_mask[HPSRAM_SEGMENTS];
+			uint32_t hpsram_mask[HPSRAM_SEGMENTS] = {0};
 
 			struct imr_header hdr = {
 				.adsp_imr_magic = ADSP_IMR_MAGIC_VALUE,
@@ -97,9 +97,11 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 			  arch_xtensa_uncached_ptr((struct imr_layout *)L3_MEM_BASE_ADDR);
 			imr_layout->imr_state.header = hdr;
 
+#ifdef CONFIG_ADSP_POWER_DOWN_HPSRAM
 			/* turn off all HPSRAM banks - get a full bitmap */
 			for (int i = 0; i < HPSRAM_SEGMENTS; i++)
 				hpsram_mask[i] = HPSRAM_MEMMASK(i);
+#endif /* CONFIG_ADSP_POWER_DOWN_HPSRAM */
 			/* do power down - this function won't return */
 			power_down_cavs(true, uncache_to_cache(&hpsram_mask[0]));
 		} else {


### PR DESCRIPTION
Add an option to control whether or not hpsram banks should be switched off during the power down. This is particular useful when running tests because we don't want to lose the contents of the memory window before we capture it.