### PR TITLE
boards: mr_canhubk3: enable GPIO when CAN is enabled

### DIFF
--- a/boards/arm/mr_canhubk3/Kconfig.defconfig
+++ b/boards/arm/mr_canhubk3/Kconfig.defconfig
@@ -13,4 +13,11 @@ config UART_CONSOLE
 
 endif # SERIAL
 
+if CAN
+
+config GPIO
+	default y
+
+endif # CAN
+
 endif # BOARD_MR_CANHUBK3

--- a/boards/arm/mr_canhubk3/mr_canhubk3_defconfig
+++ b/boards/arm/mr_canhubk3/mr_canhubk3_defconfig
@@ -21,7 +21,6 @@ CONFIG_NOCACHE_MEMORY=y
 # Drivers
 CONFIG_PINCTRL=y
 CONFIG_SERIAL=y
-CONFIG_GPIO=y # Enable support for GPIO controlled CAN transceivers
 
 # Serial console
 CONFIG_CONSOLE=y


### PR DESCRIPTION
Currently, mr_canhubk3 is enabling GPIO by default. GPIO will be built even if it is not necessary.
Update to enable it for supporting CAN transceiver when CAN is enabled.