### PR TITLE
mgmt: mcumgr: grp: img_mgmt: Fix not checking image upload size

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -153,6 +153,9 @@ enum img_mgmt_ret_code_t {
 
 	/** The image it too large to fit. */
 	IMG_MGMT_RET_RC_INVALID_IMAGE_TOO_LARGE,
+
+	/** The amount of data sent is larger than the provided image size. */
+	IMG_MGMT_RET_RC_INVALID_IMAGE_DATA_OVERRUN,
 };
 
 /**
@@ -356,6 +359,7 @@ extern const char *img_mgmt_err_str_flash_write_failed;
 extern const char *img_mgmt_err_str_downgrade;
 extern const char *img_mgmt_err_str_image_bad_flash_addr;
 extern const char *img_mgmt_err_str_image_too_large;
+extern const char *img_mgmt_err_str_data_overrun;
 #else
 #define IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, rsn)
 #define IMG_MGMT_UPLOAD_ACTION_RC_RSN(action) NULL

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -150,6 +150,9 @@ enum img_mgmt_ret_code_t {
 
 	/** The image vector table is invalid. */
 	IMG_MGMT_RET_RC_INVALID_IMAGE_VECTOR_TABLE,
+
+	/** The image it too large to fit. */
+	IMG_MGMT_RET_RC_INVALID_IMAGE_TOO_LARGE,
 };
 
 /**
@@ -352,6 +355,7 @@ extern const char *img_mgmt_err_str_flash_erase_failed;
 extern const char *img_mgmt_err_str_flash_write_failed;
 extern const char *img_mgmt_err_str_downgrade;
 extern const char *img_mgmt_err_str_image_bad_flash_addr;
+extern const char *img_mgmt_err_str_image_too_large;
 #else
 #define IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, rsn)
 #define IMG_MGMT_UPLOAD_ACTION_RC_RSN(action) NULL

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -97,6 +97,7 @@ const char *img_mgmt_err_str_flash_write_failed = "fa write fail";
 const char *img_mgmt_err_str_downgrade = "downgrade";
 const char *img_mgmt_err_str_image_bad_flash_addr = "img addr mismatch";
 const char *img_mgmt_err_str_image_too_large = "img too large";
+const char *img_mgmt_err_str_data_overrun = "data overrun";
 #endif
 
 void img_mgmt_take_lock(void)
@@ -813,6 +814,7 @@ static int img_mgmt_translate_error_code(uint16_t ret)
 	case IMG_MGMT_RET_RC_INVALID_IMAGE_HEADER_MAGIC:
 	case IMG_MGMT_RET_RC_INVALID_IMAGE_VECTOR_TABLE:
 	case IMG_MGMT_RET_RC_INVALID_IMAGE_TOO_LARGE:
+	case IMG_MGMT_RET_RC_INVALID_IMAGE_DATA_OVERRUN:
 	case IMG_MGMT_RET_RC_UNKNOWN:
 	default:
 	rc = MGMT_ERR_EUNKNOWN;

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -96,6 +96,7 @@ const char *img_mgmt_err_str_flash_erase_failed = "fa erase fail";
 const char *img_mgmt_err_str_flash_write_failed = "fa write fail";
 const char *img_mgmt_err_str_downgrade = "downgrade";
 const char *img_mgmt_err_str_image_bad_flash_addr = "img addr mismatch";
+const char *img_mgmt_err_str_image_too_large = "img too large";
 #endif
 
 void img_mgmt_take_lock(void)
@@ -811,6 +812,7 @@ static int img_mgmt_translate_error_code(uint16_t ret)
 	case IMG_MGMT_RET_RC_FLASH_AREA_DEVICE_NULL:
 	case IMG_MGMT_RET_RC_INVALID_IMAGE_HEADER_MAGIC:
 	case IMG_MGMT_RET_RC_INVALID_IMAGE_VECTOR_TABLE:
+	case IMG_MGMT_RET_RC_INVALID_IMAGE_TOO_LARGE:
 	case IMG_MGMT_RET_RC_UNKNOWN:
 	default:
 	rc = MGMT_ERR_EUNKNOWN;

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -682,6 +682,14 @@ int img_mgmt_upload_inspect(const struct img_mgmt_upload_req *req,
 			 */
 			return IMG_MGMT_RET_RC_OK;
 		}
+
+		if ((req->off + req->img_data.len) > action->size) {
+			/* Data overrun, the amount of data written would be more than the size
+			 * of the image that the client originally sent
+			 */
+			IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, img_mgmt_err_str_data_overrun);
+			return IMG_MGMT_RET_RC_INVALID_IMAGE_DATA_OVERRUN;
+		}
 	}
 
 	action->write_bytes = req->img_data.len;


### PR DESCRIPTION
Fixes an issue whereby upload image size would not be checked in the first packet of an upload, which would allow an image to be uploaded until it reached the point of it being too large to fit anymore.

and

    mgmt: mcumgr: grp: img_mgmt: Fix not checking write bounds
    
    Fixes an issue whereby the data packets were not checked to ensure
    that the client has not attempted to write more data than the size
    that was provided in the original upload packet.

Fixes #60899