### PR TITLE
boards: adafruit_feather_m0_basic_proto: add zephyr_udc0 nodelabel

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
+++ b/boards/arm/adafruit_feather_m0_basic_proto/adafruit_feather_m0_basic_proto.dts
@@ -104,7 +104,7 @@
 	};
 };
 
-&usb0 {
+zephyr_udc0: &usb0 {
 	status = "okay";
 
 	pinctrl-0 = <&usb_dc_default>;


### PR DESCRIPTION
Add zephyr_udc0 nodelabel to allow building all USB device samples for adafruit_feather_m0_basic_proto board out of the box.

Resolves: #60715