### PR TITLE
samples: subsys: nvs on nucleo_g474re requires 6kB for storage partition

### DIFF
--- a/samples/subsys/nvs/boards/nucleo_g474re.overlay
+++ b/samples/subsys/nvs/boards/nucleo_g474re.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		/* Set 6KB of storage at the end of 512KB flash */
+		storage_partition: partition@7e800 {
+			label = "storage";
+			reg = <0x0007e800 DT_SIZE_K(6)>;
+		};
+	};
+};


### PR DESCRIPTION
Add the overlay for running the samples/subsys/nvs/ application on the nucleo_g474re. Define a 6kB storage_partition at the end of the 512kB flash.
(as done on other target boards like nucleo_g071)

Fixes the error on flash when running the sample
$ west build -p auto -b nucleo_g474re samples/subsys/nvs/

```
...
Error, no Reboot counter                                                       
Rebooting in ...5...4...3...2...1                                               
[00:00:00.652,000] <err> flash_stm32: Read range invalid. Offset: 526328, len: *
```



