### PR TITLE
npcx: Update erase function to allow 0x1000 byte erase size

### DIFF
--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -110,5 +110,7 @@
 /* Test whether offset is aligned to a given number of bits. */
 #define SPI_NOR_IS_ALIGNED(_ofs, _bits) (((_ofs) & BIT_MASK(_bits)) == 0)
 #define SPI_NOR_IS_SECTOR_ALIGNED(_ofs) SPI_NOR_IS_ALIGNED(_ofs, 12)
+#define SPI_NOR_IS_32K_ALIGNED(_ofs) SPI_NOR_IS_ALIGNED(_ofs, 15)
+#define SPI_NOR_IS_64K_ALIGNED(_ofs) SPI_NOR_IS_ALIGNED(_ofs, 16)
 
 #endif /*__SPI_NOR_H__*/

--- a/dts/bindings/flash_controller/nuvoton,npcx-fiu-nor.yaml
+++ b/dts/bindings/flash_controller/nuvoton,npcx-fiu-nor.yaml
@@ -28,13 +28,6 @@ properties:
     type: int
     required: true
     description: Mapped memory address of direct read access for spi nor flash.
-  min-erase-size:
-    type: int
-    default: 0x10000
-    description: Minimum erase size of spi nor flash.
-    enum:
-      - 0x1000  # 4KB (Sector Erase)
-      - 0x10000 # 64KB (Block Erase)
   max-timeout:
     type: int
     default: 10000


### PR DESCRIPTION
Modify the NPCX driver erase method to allow 0x1000 byte size erases along with 0x10000 byte size erases based on input parameters