### PR TITLE
ethernet: nxp_s32: initialize after PHY

### DIFF
--- a/drivers/ethernet/Kconfig.nxp_s32
+++ b/drivers/ethernet/Kconfig.nxp_s32
@@ -94,13 +94,13 @@ config ETH_NXP_S32_MAC_FILTER_TABLE_SIZE
 
 config ETH_NXP_S32_PSI_INIT_PRIORITY
 	int
-	default 60
+	default 81
 	help
 	  PSI initialization priority. It must be lower than VSI priority.
 
 config ETH_NXP_S32_VSI_INIT_PRIORITY
 	int
-	default 61
+	default 82
 	help
 	  VSI initialization priority. It must be bigger than PSI priority
 	  and lower than CONFIG_NET_INIT_PRIO, so that it can start after the PSI


### PR DESCRIPTION
Change the nxp_s32 initialization priority so that it happens after the ethernet phy, which makes sense from a devicetree hierarchy point of view since the ethernet device has a phandle to the phy.