### PR TITLE
drivers: i2c: mcux_lpi2c: Introduce startup delay

### DIFF
--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -39,6 +39,7 @@ struct mcux_lpi2c_config {
 	void (*irq_config_func)(const struct device *dev);
 	uint32_t bitrate;
 	uint32_t bus_idle_timeout_ns;
+	uint32_t startup_delay;
 	const struct pinctrl_dev_config *pincfg;
 #ifdef CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY
 	struct gpio_dt_spec scl;
@@ -520,6 +521,8 @@ static int mcux_lpi2c_init(const struct device *dev)
 
 	config->irq_config_func(dev);
 
+	k_busy_wait(config->startup_delay);
+
 	return 0;
 }
 
@@ -555,6 +558,7 @@ static const struct i2c_driver_api mcux_lpi2c_driver_api = {
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
 		.irq_config_func = mcux_lpi2c_config_func_##n,		\
 		.bitrate = DT_INST_PROP(n, clock_frequency),		\
+		.startup_delay = DT_INST_PROP(n, startup_delay_us),	\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
 		I2C_MCUX_LPI2C_SCL_INIT(n)				\
 		I2C_MCUX_LPI2C_SDA_INIT(n)				\

--- a/dts/bindings/i2c/i2c-controller.yaml
+++ b/dts/bindings/i2c/i2c-controller.yaml
@@ -17,3 +17,7 @@ properties:
   clock-frequency:
     type: int
     description: Initial clock frequency in Hz
+  startup-delay-us:
+    type: int
+    default: 0
+    description: Startup time, in microseconds


### PR DESCRIPTION
Introduce a startup delay after the init routine so the system doesn't start to use the bus right away although the levels on the SDA/SCL lines aren't yet good.

---

I considered using a power domain or regulator to introduce delay but that all had its downsides. So now introducing it via a dedicated parameter. Consider this as a basis for discussion.

In my case, with adding a 500 us Delay, the communication looks like this. Without it, the communication seems to start right at where the line gets pulled high and therefore fails.

![image](https://github.com/zephyrproject-rtos/zephyr/assets/6226629/c6341d1f-64c6-4eb9-930b-15fca048bcd6)

My testing is based on a test-cases. It might be that in real applications this never occured before since the communication is delayed due to the system doing other work before the first communication?!
