### PR TITLE
soc: raptor_lake: Disable watchdog by default

### DIFF
--- a/dts/x86/intel/raptor_lake.dtsi
+++ b/dts/x86/intel/raptor_lake.dtsi
@@ -528,6 +528,8 @@
 		tco_wdt: tco_wdt@400 {
 			compatible = "intel,tco-wdt";
 			reg = <0x0400 0x20>;
+
+			status = "disabled";
 		};
 	};
 };


### PR DESCRIPTION
Without status line, watchdog is enabled by default. The desired behavior is to have it disabled and enable only when watchdog is used with overlay files, the same way how it is done for samples/drivers/watchdog and tests/drivers/watchdog/wdt_basic_api.

See for example:
https://github.com/zephyrproject-rtos/zephyr/blob/3191d0813003fd5c44646382c4948a16f7f60505/tests/drivers/watchdog/wdt_basic_api/boards/rpl_crb.overlay#L7-L9
or
https://github.com/zephyrproject-rtos/zephyr/blob/3191d0813003fd5c44646382c4948a16f7f60505/samples/drivers/watchdog/boards/rpl_crb.overlay#L7-L9

we can also leave it "enabled" (it would be included only when watchdog is selected), then I will remove overlays.