### PR TITLE
usb: device_next: add few more string descriptor helpers

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -446,6 +446,24 @@ int usbd_add_descriptor(struct usbd_contex *uds_ctx,
 			struct usbd_desc_node *dn);
 
 /**
+ * @brief Get USB string descriptor index from descriptor node
+ *
+ * @param[in] desc_nd Pointer to USB descriptor node
+ *
+ * @return Descriptor index, 0 if descriptor is not part of any device
+ */
+uint8_t usbd_get_descriptor_idx(const struct usbd_desc_node *const desc_nd);
+
+/**
+ * @brief Remove USB string descriptor
+ *
+ * Remove linked USB string descriptor from any list.
+ *
+ * @param[in] desc_nd Pointer to USB descriptor node
+ */
+void usbd_remove_descriptor(struct usbd_desc_node *const desc_nd);
+
+/**
  * @brief Add a USB device configuration
  *
  * @param[in] uds_ctx Pointer to USB device support context

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -412,7 +412,7 @@ static int usbd_cdc_ecm_init(struct usbd_class_node *const c_nd)
 	if (usbd_add_descriptor(c_nd->data->uds_ctx, data->mac_desc_nd)) {
 		LOG_ERR("Failed to add iMACAddress string descriptor");
 	} else {
-		desc->if0_ecm.iMACAddress = data->mac_desc_nd->idx;
+		desc->if0_ecm.iMACAddress = usbd_get_descriptor_idx(data->mac_desc_nd);
 	}
 
 	return 0;
@@ -425,7 +425,7 @@ static void usbd_cdc_ecm_shutdown(struct usbd_class_node *const c_nd)
 	struct cdc_ecm_eth_data *const data = dev->data;
 
 	desc->if0_ecm.iMACAddress = 0;
-	sys_dlist_remove(&data->mac_desc_nd->node);
+	usbd_remove_descriptor(data->mac_desc_nd);
 }
 
 static int cdc_ecm_send(const struct device *dev, struct net_pkt *const pkt)

--- a/subsys/usb/device_next/usbd_desc.c
+++ b/subsys/usb/device_next/usbd_desc.c
@@ -263,3 +263,20 @@ add_descriptor_error:
 	usbd_device_unlock(uds_ctx);
 	return ret;
 }
+
+uint8_t usbd_get_descriptor_idx(const struct usbd_desc_node *const desc_nd)
+{
+	if (sys_dnode_is_linked(&desc_nd->node)) {
+		return desc_nd->idx;
+	}
+
+	return 0;
+}
+
+void usbd_remove_descriptor(struct usbd_desc_node *const desc_nd)
+{
+	if (sys_dnode_is_linked(&desc_nd->node)) {
+		sys_dlist_remove(&desc_nd->node);
+		desc_nd->idx = 0;
+	}
+}


### PR DESCRIPTION
usb: device_next: add few more string descriptor helpers

Add function to get string descriptor index and function
to remove linked descriptor from a device. This abstracts
it a bit so that the user does not need to know how it is
handled internally.



usb: device_next: add string descriptor for CDC ACM

Add a string descriptor whose index is used for IAD and interface
descriptors. The string is derived from the virtual CDC ACM UART
nodelabel, which allows the user to accurately identify the UART
interface on the device side.
It can probably be further improved by converting the string to
upper case and replacing the underline with a space.