### PR TITLE
sensor: dht: return error if channel not supported

### DIFF
--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -184,7 +184,7 @@ static int dht_channel_get(const struct device *dev,
 				+ drv_data->sample[1];
 			val->val1 = raw_val / 10;
 			val->val2 = (raw_val % 10) * 100000;
-		} else { /* chan == SENSOR_CHAN_AMBIENT_TEMP */
+		} else if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 			raw_val = (drv_data->sample[2] << 8)
 				+ drv_data->sample[3];
 
@@ -199,15 +199,19 @@ static int dht_channel_get(const struct device *dev,
 				val->val1 = -val->val1;
 				val->val2 = -val->val2;
 			}
+		} else {
+			return -ENOTSUP;
 		}
 	} else {
 		/* use only integral data byte */
 		if (chan == SENSOR_CHAN_HUMIDITY) {
 			val->val1 = drv_data->sample[0];
 			val->val2 = 0;
-		} else { /* chan == SENSOR_CHAN_AMBIENT_TEMP */
+		} else if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 			val->val1 = drv_data->sample[2];
 			val->val2 = 0;
+		} else {
+			return -ENOTSUP;
 		}
 	}
 


### PR DESCRIPTION
The driver would return the temperature for all channels requested except relative humidity. Instead, ENOTSUP should be returned for unsupported channels.