### PR TITLE
arch: arm: aarch32: introduce CONFIG_BUILD_ALIGN_LMA

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -675,6 +675,15 @@ config BUILD_OUTPUT_INFO_HEADER
 	  - VMA address of each segment
 	  - Size of each segment
 
+config BUILD_ALIGN_LMA
+	bool "Align LMA in output image"
+	default y if BUILD_OUTPUT_ADJUST_LMA!=""
+	help
+	  Ensure that the LMA for each section in the output image respects
+	  the alignment requirements of that section. This is required for
+	  some tooling, such as objcopy, to be able to adjust the LMA of the
+	  ELF file.
+
 config APPLICATION_DEFINED_SYSCALL
 	bool "Scan application folder for any syscall definition"
 	help

--- a/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -206,8 +206,21 @@ SECTIONS
 
 #include <zephyr/linker/cplusplus-rom.ld>
 
+#if defined(CONFIG_BUILD_ALIGN_LMA)
+    /*
+     * Include a padding section here to make sure that the LMA address
+     * of the sections in the RAMABLE_REGION are aligned with those
+     * section's VMA alignment requirements.
+     */
+    SECTION_PROLOGUE(padding_section,,)
+	{
 	__rodata_region_end = .;
 	MPU_ALIGN(__rodata_region_end - ADDR(rom_start));
+	} GROUP_LINK_IN(ROMABLE_REGION)
+#else
+	__rodata_region_end = .;
+	MPU_ALIGN(__rodata_region_end - ADDR(rom_start));
+#endif
 	__rom_region_end = __rom_region_start + . - ADDR(rom_start);
 
     GROUP_END(ROMABLE_REGION)


### PR DESCRIPTION
Introduce CONFIG_BUILD_ALIGN_LMA. When enabled, this symbol will add a
padding section after the final read only data section in the image.
This padding section will ensure that the LMA of the data sections
follows the same alignment restrictions as the VMA does. This LMA alignment
is needed for objcopy to adjust the LMA address of the output ELF file


This change is intended to work around the issue described by @stephanosio in #58080. Another alternative would be to try to fix the limitation that exists in objcopy, rather than changing the alignment of our image in Zephyr