### PR TITLE
drivers: can: stm32h7: fix message RAM address calculations

### DIFF
--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(can_stm32h7, CONFIG_CAN_LOG_LEVEL);
 
 struct can_stm32h7_config {
 	mm_reg_t base;
+	mem_addr_t mrba;
 	mem_addr_t mram;
 	void (*config_irq)(void);
 	const struct pinctrl_dev_config *pcfg;
@@ -132,7 +133,7 @@ static int can_stm32h7_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = can_mcan_configure_mram(dev, stm32h7_cfg->mram, stm32h7_cfg->mram);
+	ret = can_mcan_configure_mram(dev, stm32h7_cfg->mrba, stm32h7_cfg->mram);
 	if (ret != 0) {
 		return ret;
 	}
@@ -205,6 +206,7 @@ static const struct can_mcan_ops can_stm32h7_ops = {
 									    \
 	static const struct can_stm32h7_config can_stm32h7_cfg_##n = {	    \
 		.base = CAN_MCAN_DT_INST_MCAN_ADDR(n),			    \
+		.mrba = CAN_MCAN_DT_INST_MRBA(n),			    \
 		.mram = CAN_MCAN_DT_INST_MRAM_ADDR(n),			    \
 		.config_irq = stm32h7_mcan_irq_config_##n,		    \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		    \

--- a/include/zephyr/drivers/can/can_mcan.h
+++ b/include/zephyr/drivers/can/can_mcan.h
@@ -573,13 +573,25 @@
  * @brief Get the Bosch M_CAN Message RAM base address
  *
  * For devicetree nodes with dedicated Message RAM area defined via devicetree, this macro returns
- * the base address of the Message RAM, taking in the Message RAM offset into account.
+ * the base address of the Message RAM.
  *
  * @param node_id node identifier
- * @return the Bosch M_CAN Message RAM base address
+ * @return the Bosch M_CAN Message RAM base address (MRBA)
+ */
+#define CAN_MCAN_DT_MRBA(node_id)                                                                  \
+	(mem_addr_t)DT_REG_ADDR_BY_NAME(node_id, message_ram)
+
+/**
+ * @brief Get the Bosch M_CAN Message RAM address
+ *
+ * For devicetree nodes with dedicated Message RAM area defined via devicetree, this macro returns
+ * the address of the Message RAM, taking in the Message RAM offset into account.
+ *
+ * @param node_id node identifier
+ * @return the Bosch M_CAN Message RAM address
  */
 #define CAN_MCAN_DT_MRAM_ADDR(node_id)                                                             \
-	(mem_addr_t)(DT_REG_ADDR_BY_NAME(node_id, message_ram) + CAN_MCAN_DT_MRAM_OFFSET(node_id))
+	(mem_addr_t)(CAN_MCAN_DT_MRBA(node_id) + CAN_MCAN_DT_MRAM_OFFSET(node_id))
 
 /**
  * @brief Get the Bosch M_CAN Message RAM size
@@ -783,9 +795,17 @@
 #define CAN_MCAN_DT_INST_MCAN_ADDR(inst) CAN_MCAN_DT_MCAN_ADDR(DT_DRV_INST(inst))
 
 /**
+ * @brief Equivalent to CAN_MCAN_DT_MRBA(DT_DRV_INST(inst))
+ * @param inst DT_DRV_COMPAT instance number
+ * @return the Bosch M_CAN Message RAM Base Address (MRBA)
+ * @see CAN_MCAN_DT_MRBA()
+ */
+#define CAN_MCAN_DT_INST_MRBA(inst) CAN_MCAN_DT_MRBA(DT_DRV_INST(inst))
+
+/**
  * @brief Equivalent to CAN_MCAN_DT_MRAM_ADDR(DT_DRV_INST(inst))
  * @param inst DT_DRV_COMPAT instance number
- * @return the Bosch M_CAN Message RAM base address
+ * @return the Bosch M_CAN Message RAM address
  * @see CAN_MCAN_DT_MRAM_ADDR()
  */
 #define CAN_MCAN_DT_INST_MRAM_ADDR(inst) CAN_MCAN_DT_MRAM_ADDR(DT_DRV_INST(inst))


### PR DESCRIPTION
Calculate the Bosch M_CAN Message RAM addresses relative to the Message RAM Base Address (MRBA), not the offset. Add `CAN_MCAN_DT_MRBA()` and `CAN_MCAN_DT_INST_MRBA()` helper macros.
    
Fixes: #59624