### PR TITLE
boards: shields: rk055hdmipi4ma0: add probe address to RT595-EVK

### DIFF
--- a/boards/shields/rk055hdmipi4ma0/boards/mimxrt595_evk_cm33.overlay
+++ b/boards/shields/rk055hdmipi4ma0/boards/mimxrt595_evk_cm33.overlay
@@ -12,7 +12,8 @@
 	rx-buffer-config = <1 7 11 1024>;
 };
 
-/* GT911 IRQ GPIO is active low on this board */
+/* GT911 IRQ GPIO is active low on this board, and needs probing mode */
 &touch_controller_rk055hdmipi4ma0 {
 	irq-gpios = <&nxp_mipi_connector 29 GPIO_ACTIVE_LOW>;
+	alt-addr = <0x14>;
 };


### PR DESCRIPTION
Add probe address setting to RT595-EVK, to work around board issue with routing of INT GPIO that prevents GPIO from being set to output mode.