### PR TITLE
thrift: add temporary mutex implementation

### DIFF
--- a/modules/thrift/src/thrift/concurrency/Mutex.cpp
+++ b/modules/thrift/src/thrift/concurrency/Mutex.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
+
 #include <thrift/concurrency/Mutex.h>
 
 namespace apache
@@ -13,31 +15,52 @@ namespace thrift
 namespace concurrency
 {
 
+class Mutex::impl
+{
+public:
+	k_spinlock_key_t key;
+	struct k_spinlock lock;
+};
+
 Mutex::Mutex()
 {
+	impl_ = std::make_shared<Mutex::impl>();
 }
 
 void Mutex::lock() const
 {
+	while (!trylock()) {
+		k_msleep(1);
+	}
 }
 
 bool Mutex::trylock() const
 {
-	return false;
+	return k_spin_trylock(&impl_->lock, &impl_->key) == 0;
 }
 
 bool Mutex::timedlock(int64_t milliseconds) const
 {
+	k_timepoint_t end = sys_timepoint_calc(K_MSEC(milliseconds));
+
+	do {
+		if (trylock()) {
+			return true;
+		}
+		k_msleep(5);
+	} while(!sys_timepoint_expired(end));
+
 	return false;
 }
 
 void Mutex::unlock() const
 {
+	k_spin_unlock(&impl_->lock, impl_->key);
 }
 
 void *Mutex::getUnderlyingImpl() const
 {
-	return nullptr;
+	return &impl_->lock;
 }
 } // namespace concurrency
 } // namespace thrift

--- a/tests/lib/thrift/ThriftTest/src/main.cpp
+++ b/tests/lib/thrift/ThriftTest/src/main.cpp
@@ -148,11 +148,10 @@ static void thrift_test_before(void *data)
 static void thrift_test_after(void *data)
 {
 	ARG_UNUSED(data);
-	void *unused;
 
 	context.server->stop();
 
-	pthread_join(context.server_thread, &unused);
+	pthread_join(context.server_thread, NULL);
 
 	context.server.reset();
 	context.client.reset();


### PR DESCRIPTION
The Thrift library has its own abstraction for mutexes, which normally just a wrapper around `std::mutex` using the PIMPL idiom (pointer-to-impl).

Since Zephyr does not yet support `std::mutex`, a workaround was added in Zephyr that was essentially no-op.

We cannot yet use a `struct k_mutex` due to some additional userspace requirements, but for now we can fake a mutex interface with a spinlock.

We hope to eventually drop this workaround entirely and just support `std::mutex`.

Fixes #60941 

Tested-with:  [run-thrift-trials.sh.txt](https://github.com/zephyrproject-rtos/zephyr/files/12202588/run-thrift-trials.sh.txt)

```
west build -p auto -b qemu_x86_64 tests/lib/thrift/ThriftTest
ninja: no work to do.

real    0m0.166s
user    0m0.134s
sys     0m0.032s
done
********************************************************************************
Job 0/100                                       [ OK ] Pass Rate: 100 %
********************************************************************************
Job 1/100                                       [ OK ] Pass Rate: 100 %
********************************************************************************
Job 2/100                                       [ OK ] Pass Rate: 100 %
********************************************************************************
Job 3/100                                       [ OK ] Pass Rate: 100 %
********************************************************************************
Job 4/100                                       [ OK ] Pass Rate: 100 %
..
********************************************************************************
Job 93/100                                      [ OK ] Pass Rate: 100 %
********************************************************************************
Job 94/100                                      [ OK ] Pass Rate: 100 %
********************************************************************************
Job 95/100                                      [ OK ] Pass Rate: 100 %
********************************************************************************
Job 96/100                                      [ OK ] Pass Rate: 100 %
********************************************************************************
Job 97/100                                      [ OK ] Pass Rate: 100 %
********************************************************************************
Job 98/100                                      [ OK ] Pass Rate: 100 %
********************************************************************************
Job 99/100                                      [ OK ] Pass Rate: 100 %
RESULT: 100/100
```