### PR TITLE
drivers: flash: spi_nor: select largest valid erase operation

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -775,7 +775,7 @@ static int spi_nor_erase(const struct device *dev, off_t addr, size_t size)
 
 				if ((etp->exp != 0)
 				    && SPI_NOR_IS_ALIGNED(addr, etp->exp)
-				    && SPI_NOR_IS_ALIGNED(size, etp->exp)
+				    && (size >= BIT(etp->exp))
 				    && ((bet == NULL)
 					|| (etp->exp > bet->exp))) {
 					bet = etp;


### PR DESCRIPTION
The spi_nor erase op selection was based on the alignment of the end of the region to be erased. This prevented larger erase operations being selected in many cases

Closes https://github.com/zephyrproject-rtos/zephyr/issues/60904