### PR TITLE
posix: signal: extend strsignal buf to cover entire INT range

### DIFF
--- a/lib/posix/signal.c
+++ b/lib/posix/signal.c
@@ -77,7 +77,8 @@ int sigismember(const sigset_t *set, int signo)
 
 char *strsignal(int signum)
 {
-	static char buf[sizeof("RT signal " STRINGIFY(SIGRTMAX))];
+	/* Using -INT_MAX here because compiler resolves INT_MIN to (-2147483647 - 1) */
+	static char buf[sizeof("RT signal -" STRINGIFY(INT_MAX))];
 
 	if (!signo_valid(signum)) {
 		errno = EINVAL;

--- a/tests/posix/common/src/signal.c
+++ b/tests/posix/common/src/signal.c
@@ -196,7 +196,8 @@ ZTEST(posix_apis, test_signal_ismember)
 
 ZTEST(posix_apis, test_signal_strsignal)
 {
-	char buf[sizeof("RT signal " STRINGIFY(SIGRTMAX))] = {0};
+	/* Using -INT_MAX here because compiler resolves INT_MIN to (-2147483647 - 1) */
+	char buf[sizeof("RT signal -" STRINGIFY(INT_MAX))] = {0};
 
 	zassert_mem_equal(strsignal(-1), "Invalid signal", sizeof("Invalid signal"));
 	zassert_mem_equal(strsignal(0), "Invalid signal", sizeof("Invalid signal"));


### PR DESCRIPTION
extend the char buffer in the strsignal function to cover the entire range of `int`, fixes the following warnings when building the Thrift test:

```
/home/user/zephyrproject/zephyr/lib/posix/signal.c: In function 'strsignal':
/home/user/zephyrproject/zephyr/lib/posix/signal.c:88:55: warning: '%d' directive output may be truncated writing between 1 and 11 bytes into a region of size 10 [-Wformat-truncation=]
   88 |                 snprintf(buf, sizeof(buf), "RT signal %d", signum - SIGRTMIN);
      |                                                       ^~
/home/user/zephyrproject/zephyr/lib/posix/signal.c:88:44: note: directive argument in the range [-2147483648, 2147483615]
   88 |                 snprintf(buf, sizeof(buf), "RT signal %d", signum - SIGRTMIN);
      |                                            ^~~~~~~~~~~~~~
/home/user/zephyrproject/zephyr/lib/posix/signal.c:88:17: note: 'snprintf' output between 12 and 22 bytes into a destination of size 20
   88 |                 snprintf(buf, sizeof(buf), "RT signal %d", signum - SIGRTMIN);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```