### PR TITLE
tests: thrift: re-order shared_ptr reset to prevent fd leak

### DIFF
--- a/tests/lib/thrift/ThriftTest/overlay-tls.conf
+++ b/tests/lib/thrift/ThriftTest/overlay-tls.conf
@@ -1,5 +1,21 @@
 CONFIG_THRIFT_SSL_SOCKET=y
 
+# Currenty, in Zephyr's MBedTLS IPPROTO_TLS_1_0 implementation, 2 sockets are
+# needed for every connection.
+#
+# Additionally, upstream Apache Thrift uses socketpair for cancellation rather
+# than eventfd, since the latter is not portable to some operating systems.
+#
+# File Descriptor Usage
+# ---------------------
+# stdin, stdout, stderr: 3
+# tcp socket (accept): 1
+# tls socket (accept): 1
+# tcp sockets (client, server): 2
+# tls sockets (client, server): 2
+# socketpairs for cancellation (accept, client, server): 6
+CONFIG_POSIX_MAX_FDS=15
+
 # TLS configuration
 CONFIG_MBEDTLS=y
 CONFIG_MBEDTLS_PEM_CERTIFICATE_FORMAT=y

--- a/tests/lib/thrift/ThriftTest/prj.conf
+++ b/tests/lib/thrift/ThriftTest/prj.conf
@@ -39,7 +39,19 @@ CONFIG_NET_BUF_TX_COUNT=20
 CONFIG_NET_PKT_TX_COUNT=20
 CONFIG_NET_BUF_RX_COUNT=20
 CONFIG_NET_PKT_RX_COUNT=20
-CONFIG_POSIX_MAX_FDS=16
+
+# We can get away with using fewer sockets in the non-TLS tests because we use
+# TFDServer.cpp for our server and socketpair() for our channel. We do not
+# need an accept socket for the server (in contrast to TCP), it only needs 1
+# eventfd for server cancellation, and there are no cancellation sockets
+# required because we close them in the testsuite.
+#
+# File Descriptor Usage
+# ---------------------
+# stdin, stdout, stderr: 3
+# socketpair for channel: 2
+# eventfd for cancellation: 1
+CONFIG_POSIX_MAX_FDS=6
 
 # Network address config
 CONFIG_NET_IPV4=y

--- a/tests/lib/thrift/ThriftTest/src/main.cpp
+++ b/tests/lib/thrift/ThriftTest/src/main.cpp
@@ -153,13 +153,13 @@ static void thrift_test_after(void *data)
 
 	pthread_join(context.server_thread, NULL);
 
-	context.server.reset();
-	context.client.reset();
-
 	for (auto &fd : context.fds) {
 		close(fd);
 		fd = -1;
 	}
+
+	context.client.reset();
+	context.server.reset();
 }
 
 ZTEST_SUITE(thrift, NULL, thrift_test_setup, thrift_test_before, thrift_test_after, NULL);


### PR DESCRIPTION
This change fixes a file descriptor leak that snuck-in undetected in the original `gsoc-2022-thrift` project.

Additional details in the linked issue.

Fixes #60947