### PR TITLE
tests: drivers: build_all: sensor: do not run build-only testsuite

### DIFF
--- a/tests/drivers/build_all/sensor/testcase.yaml
+++ b/tests/drivers/build_all/sensor/testcase.yaml
@@ -27,4 +27,3 @@ tests:
       - CONFIG_EMUL=y
       - CONFIG_NATIVE_UART_0_ON_STDINOUT=y
       - CONFIG_SENSOR_ASYNC_API=y
-    build_only: false


### PR DESCRIPTION
A recent modification to the `build_all/sensor` testsuite changed `build-only` to `false` in `testcase.yaml`, which is causing CI to go bonkers.

https://bit.ly/3rSe0Te

Please do not run build-only testsuites.

Fixes #60958