### PR TITLE
posix: pthread: pthread_join should fail to join detached threads

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -658,7 +658,7 @@ int pthread_join(pthread_t pthread, void **status)
 		__ASSERT_NO_MSG(err == 0);
 	}
 
-	return 0;
+	return ret;
 }
 
 /**


### PR DESCRIPTION
A thread that has been previously detached using `pthread_detach()` should not be able to be joined.

A recent change made it so that `pthread_join()` would always report success (0), even when `ret` (return value) had an error.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/60962