### PR TITLE
drivers: gpio: gpio_intel: Corrected offset to check PMODE

### DIFF
--- a/drivers/gpio/gpio_intel.c
+++ b/drivers/gpio/gpio_intel.c
@@ -157,7 +157,7 @@ static bool check_perm(const struct device *dev, uint32_t raw_pin)
 	}
 
 	/* Also need to make sure the function of pad is GPIO */
-	offset = data->pad_base + (raw_pin << 3);
+	offset = data->pad_base + (raw_pin << 4);
 	val = sys_read32(regs(dev) + offset);
 	if (val & PAD_CFG0_PMODE_MASK) {
 		/* mode is not zero => not functioning as GPIO */


### PR DESCRIPTION
Corrected offset to read PMODE to check function number.

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>