### PR TITLE
boards: nucleo_l552ze_q: Fix green led port/pin definition

### DIFF
--- a/boards/arm/nucleo_l552ze_q/doc/nucleol552ze_q.rst
+++ b/boards/arm/nucleo_l552ze_q/doc/nucleol552ze_q.rst
@@ -261,7 +261,7 @@ Default Zephyr Peripheral Mapping:
 - SPI_3_MOSI : PC12
 - PWM_2_CH1 : PA0
 - USER_PB : PC13
-- LD2 : PA5
+- LD2 : PB7
 - DAC1 : PA4
 - ADC1 : PC0
 

--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
@@ -12,7 +12,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
-			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
 		blue_led_1: led_2 {


### PR DESCRIPTION
This commit fixes the definition of the green led pin on the nucleo-L552ZE-Q board.
The new port/pin for this led (LED1) can be confirmed using [docs from os.mbed.com](https://os.mbed.com/platforms/ST-Nucleo-L552ZE-Q/) for this board.
Additionally I tested it on my own hardware.