### PR TITLE
ethernet: eth_stm32_hal: fix unused variable build warning

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1098,9 +1098,6 @@ void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth_handle)
 
 static void generate_mac(uint8_t *mac_addr)
 {
-	uint8_t unique_device_ID_12_bytes[12];
-	uint32_t result_mac_32_bits;
-
 #if defined(ETH_STM32_RANDOM_MAC)
 	/* Either CONFIG_ETH_STM32_HAL_RANDOM_MAC or device tree property */
 	/* "zephyr,random-mac-address" is set, generate a random mac address */
@@ -1118,6 +1115,9 @@ static void generate_mac(uint8_t *mac_addr)
 	mac_addr[4] = CONFIG_ETH_STM32_HAL_MAC4;
 	mac_addr[5] = CONFIG_ETH_STM32_HAL_MAC5;
 #else
+	uint8_t unique_device_ID_12_bytes[12];
+	uint32_t result_mac_32_bits;
+
 	/* Nothing defined by the user, use device id */
 	hwinfo_get_device_id(unique_device_ID_12_bytes, 12);
 	result_mac_32_bits = crc32_ieee((uint8_t *)unique_device_ID_12_bytes, 12);


### PR DESCRIPTION
Hi, spotted this in the weekly build test: https://github.com/zephyrproject-rtos/zephyr/runs/15459346533

---

Fix an unused variable build warning that was happening in certain configurations. Move the variables in the only condition where they are actually used.

```
west build -p -b nucleo_f429zi \
	-T samples/net/cloud/aws_iot_mqtt/sample.net.cloud.aws_iot_mqtt
```