### PR TITLE
add NXP orphaned files to its area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2326,13 +2326,19 @@ NXP Platforms:
     - boards/arm/frdm_k*/
     - boards/arm/lpcxpress*/
     - boards/arm/twr_*/
+    - boards/arm/s32*/
+    - boards/arm/mr_canhubk3/
     - soc/arm/nxp_*/
     - drivers/*/*imx*
     - drivers/*/*lpc*.c
     - drivers/*/*mcux*.c
+    - drivers/*/*nxp*
     - dts/arm/nxp/
     - dts/bindings/*/nxp*
     - soc/xtensa/nxp_adsp/
+    - samples/boards/nxp*/
+    - include/zephyr/dt-bindings/*/nxp*
+    - include/zephyr/drivers/*/*nxp*
   labels:
     - "platform: NXP"
 


### PR DESCRIPTION
~Assign me as codeowner of files related to NXP S32 support.
`/drivers/*/*nxp_s32*` moved after all `drivers` entries to avoid adding an entry for each driver subdirectory.~

Assign NXP related orphaned files related its area.