### PR TITLE
net: tcp: Remove trigger of send_data_timer when window full

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2775,41 +2775,11 @@ int net_tcp_queue_data(struct net_context *context, struct net_pkt *pkt)
 
 	k_mutex_lock(&conn->lock, K_FOREVER);
 
+	/* If there is no space to transmit, try at a later time.
+	 * The ZWP will make sure the window becomes available at
+	 * some point in time.
+	 */
 	if (tcp_window_full(conn)) {
-		if (conn->send_win == 0) {
-			/* No point retransmiting if the current TX window size
-			 * is 0.
-			 */
-			ret = -EAGAIN;
-			goto out;
-		}
-
-		/* Trigger resend if the timer is not active */
-		/* TODO: use k_work_delayable for send_data_timer so we don't
-		 * have to directly access the internals of the legacy object.
-		 *
-		 * NOTE: It is not permitted to access any fields of k_work or
-		 * k_work_delayable directly.  This replacement does so, but
-		 * only as a temporary workaround until the legacy
-		 * k_delayed_work structure is replaced with k_work_delayable;
-		 * at that point k_work_schedule() can be invoked to cause the
-		 * work to be scheduled if it is not already scheduled.
-		 *
-		 * This solution diverges from the original, which would
-		 * invoke the retransmit function directly here.  Because that
-		 * function is given a k_work pointer, again this cannot be
-		 * done without accessing the internal data of the
-		 * k_work_delayable structure.
-		 *
-		 * The original inline retransmission could be supported by
-		 * refactoring the work_handler to delegate to a function that
-		 * takes conn directly, rather than the work item in which
-		 * conn is embedded, and calling that function directly here
-		 * and in the work handler.
-		 */
-		(void)k_work_schedule_for_queue(&tcp_work_q,
-						&conn->send_data_timer,
-						K_NO_WAIT);
 		ret = -EAGAIN;
 		goto out;
 	}


### PR DESCRIPTION
Likely this trigger of the send_data_timer was an alternative for the function that has been filled in by the ZWP transmission. At the moment this timer has the potential to cause spurious retransmissions that can degrade the throughput of the network stack. Second to that it can accelerate the retransmission process, quickly running to the number of retransmissions, causing a connection failure.

Requires merging of https://github.com/zephyrproject-rtos/zephyr/pull/60880 to work properly.