### PR TITLE
ethernet: smsc91x: rework the device node hierarchy

### DIFF
--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
@@ -132,22 +132,27 @@
 			clocks = <&uartclk>;
 		};
 
-		eth: ethernet@1a000000 {
-			compatible = "smsc,lan91c111";
+		ethernet@1a000000 {
 			reg = <0x1a000000 0x1000>;
-			interrupts = <GIC_SPI 15 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			status = "disabled";
 
-			phy: phy {
-				compatible = "ethernet-phy";
+			eth: ethernet {
+				compatible = "smsc,lan91c111";
+				interrupts = <GIC_SPI 15 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				status = "disabled";
-				address = <0>;
-				mdio = <&mdio>;
+
+				phy-handle = <&phy>;
 			};
 
 			mdio: mdio {
 				compatible = "smsc,lan91c111-mdio";
 				status = "disabled";
+
+				phy: phy {
+					compatible = "ethernet-phy";
+					status = "disabled";
+					address = <0>;
+					mdio = <&mdio>;
+				};
 			};
 		};
 

--- a/drivers/ethernet/Kconfig.smsc91x
+++ b/drivers/ethernet/Kconfig.smsc91x
@@ -5,5 +5,6 @@ config ETH_SMSC91X
 	bool "SMSC91x Ethernet driver"
 	default y
 	depends on DT_HAS_SMSC_LAN91C111_ENABLED
+	select MDIO
 	help
 	  Enable driver for SMSC/LAN91x family of chips.

--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -821,8 +821,8 @@ int eth_init(const struct device *dev)
 static struct eth_context eth_0_context;
 
 static struct eth_config eth_0_config = {
-	DEVICE_MMIO_ROM_INIT(DT_DRV_INST(0)),
-	.phy_dev = DEVICE_DT_GET(DT_INST_CHILD(0, phy)),
+	DEVICE_MMIO_ROM_INIT(DT_PARENT(DT_DRV_INST(0))),
+	.phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, phy_handle)),
 };
 
 ETH_NET_DEVICE_DT_INST_DEFINE(0,
@@ -879,7 +879,7 @@ static const struct mdio_driver_api mdio_smsc_api = {
 };
 
 const struct mdio_smsc_config mdio_smsc_config_0 = {
-	.eth_dev = DEVICE_DT_GET(DT_INST_PARENT(0)),
+	.eth_dev = DEVICE_DT_GET(DT_CHILD(DT_INST_PARENT(0), ethernet)),
 };
 
 DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, &mdio_smsc_config_0, POST_KERNEL,

--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -707,16 +707,15 @@ static int eth_smsc_set_config(const struct device *dev,
 			       enum ethernet_config_type type,
 			       const struct ethernet_config *config)
 {
-	struct eth_context *data = dev->data;
-	struct smsc_data *sc = &data->sc;
-	uint8_t reg_val;
 	int ret = 0;
-
-	(void) reg_val;
 
 	switch (type) {
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
+		struct eth_context *data = dev->data;
+		struct smsc_data *sc = &data->sc;
+		uint8_t reg_val;
+
 		SMSC_LOCK(sc);
 		smsc_select_bank(sc, 0);
 		reg_val = smsc_read_1(sc, RCR);

--- a/drivers/mdio/mdio_shell.c
+++ b/drivers/mdio/mdio_shell.c
@@ -22,6 +22,8 @@ LOG_MODULE_REGISTER(mdio_shell, CONFIG_LOG_DEFAULT_LEVEL);
 #define DT_DRV_COMPAT nxp_s32_netc_emdio
 #elif DT_HAS_COMPAT_STATUS_OKAY(adi_adin2111_mdio)
 #define DT_DRV_COMPAT adi_adin2111_mdio
+#elif DT_HAS_COMPAT_STATUS_OKAY(smsc_lan91c111_mdio)
+#define DT_DRV_COMPAT smsc_lan91c111_mdio
 #else
 #error "No known devicetree compatible match for MDIO shell"
 #endif

--- a/dts/arm64/fvp/fvp-aemv8r.dtsi
+++ b/dts/arm64/fvp/fvp-aemv8r.dtsi
@@ -104,22 +104,27 @@
 			clocks = <&uartclk>;
 		};
 
-		eth: ethernet@9a000000 {
-			compatible = "smsc,lan91c111";
+		ethernet@9a000000 {
 			reg = <0x9a000000 0x1000>;
-			interrupts = <GIC_SPI 15 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
-			status = "disabled";
 
-			phy: phy {
-				compatible = "ethernet-phy";
+			eth: ethernet {
+				compatible = "smsc,lan91c111";
+				interrupts = <GIC_SPI 15 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				status = "disabled";
-				address = <0>;
-				mdio = <&mdio>;
+
+				phy-handle = <&phy>;
 			};
 
 			mdio: mdio {
 				compatible = "smsc,lan91c111-mdio";
 				status = "disabled";
+
+				phy: phy {
+					compatible = "ethernet-phy";
+					status = "disabled";
+					address = <0>;
+					mdio = <&mdio>;
+				};
 			};
 		};
 	};

--- a/dts/bindings/ethernet/smsc,lan91c111.yaml
+++ b/dts/bindings/ethernet/smsc,lan91c111.yaml
@@ -5,10 +5,10 @@ description: SMSC (now Microchip) LAN91C111 Ethernet controller
 
 compatible: "smsc,lan91c111"
 
-include: base.yaml
+include: [ethernet-controller.yaml, base.yaml]
 
 properties:
-  reg:
+  phy-handle:
     required: true
 
   interrupts:


### PR DESCRIPTION
Hi, various cleanups on the smsc91x driver, mainly reworking the mdio/phy hierarchy so that we can match up the init sequence but also various cleanups I bumped into.

Note that I had to hack some `enabled = "okay"` to test this, it does not look like it's being build in CI so that's alsomething that should e looked into.