### PR TITLE
boards: arm: nucleo_stm32f410rb partitioning 128KB of flash

### DIFF
--- a/boards/arm/nucleo_f410rb/nucleo_f410rb.dts
+++ b/boards/arm/nucleo_f410rb/nucleo_f410rb.dts
@@ -126,31 +126,29 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(64)>;
+			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
 		};
 
 		/*
-		 * The flash starting at 0x00010000 and ending at
-		 * 0x0001ffff (sectors 16-31) is reserved for use
-		 * by the application.
+		 * The flash sectors 2&3 at 0x00008000 and ending at
+		 * 0x0000ffff
 		 */
-		storage_partition: partition@10000 {
-			label = "storage";
-			reg = <0x00010000 DT_SIZE_K(64)>;
-		};
-
-		slot0_partition: partition@20000 {
+		slot0_partition: partition@8000 {
 			label = "image-0";
-			reg = <0x00020000 DT_SIZE_K(128)>;
+			reg = <0x00008000 DT_SIZE_K(32)>;
 		};
-		slot1_partition: partition@40000 {
+		/*
+		 * The flash sectors 4 at 0x00010000 and ending at
+		 * 0x001ffff
+		 */
+		slot1_partition: partition@10000 {
 			label = "image-1";
-			reg = <0x00040000 DT_SIZE_K(128)>;
+			reg = <0x00010000 DT_SIZE_K(32)>;
 		};
-		scratch_partition: partition@60000 {
+		scratch_partition: partition@18000 {
 			label = "image-scratch";
-			reg = <0x00060000 DT_SIZE_K(128)>;
+			reg = <0x00018000 DT_SIZE_K(32)>;
 		};
 	};
 };


### PR DESCRIPTION
The flash is organized in 4 partitions of 32KB each, 
to fit the 128KB made of 4 sectors of 16KB plus one sector of 64KB.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/59096

