### PR TITLE
treewide: mgmt: mcumgr: Change "ret" to "err" for SMP version 2

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -47,6 +47,14 @@ Deprecated in this release
 Stable API changes in this release
 ==================================
 
+* MCUmgr SMP version 2 error codes entry has changed due to a collision with an
+  existing response in shell_mgmt. Previously, these errors had the entry ``ret``
+  but now have the entry ``err``. ``smp_add_cmd_ret()`` is now deprecated and
+  :c:func:`smp_add_cmd_err` should be used instead, ``MGMT_CB_ERROR_RET`` is
+  now deprecated and :c:enumerator:`MGMT_CB_ERROR_ERR` should be used instead.
+  SMP version 2 error code defines for in-tree modules have been updated to
+  replace the ``*_RET_RC_*`` parts with ``*_ERR_*``.
+
 New APIs in this release
 ========================
 

--- a/doc/services/device_mgmt/mcumgr_callbacks.rst
+++ b/doc/services/device_mgmt/mcumgr_callbacks.rst
@@ -193,7 +193,7 @@ Two types of errors can be returned, the ``rc`` parameter can be set to an
 :c:enumerator:`mcumgr_err_t` error code and :c:enumerator:`MGMT_CB_ERROR_RC`
 can be returned, or a group error code (introduced with version 2 of the MCUmgr
 protocol) can be set by setting the ``group`` value to the group and ``rc``
-value to the group error code and returning :c:enumerator:`MGMT_CB_ERROR_RET`.
+value to the group error code and returning :c:enumerator:`MGMT_CB_ERROR_ERR`.
 
 MCUmgr Command Callback Usage/Adding New Event Types
 ====================================================
@@ -234,8 +234,8 @@ An example MCUmgr command handler:
     static int test_command(struct mgmt_ctxt *ctxt)
     {
         int rc;
-        int ret_rc;
-        uint16_t ret_group;
+        int err_rc;
+        uint16_t err_group;
         zcbor_state_t *zse = ctxt->cnbe->zs;
         bool ok;
         struct test_struct test_data = {
@@ -243,17 +243,17 @@ An example MCUmgr command handler:
         };
 
         rc = mgmt_callback_notify(MGMT_EVT_OP_USER_ONE_FIRST, &test_data,
-                                  sizeof(test_data), &ret_rc, &ret_group);
+                                  sizeof(test_data), &err_rc, &err_group);
 
         if (rc != MGMT_CB_OK) {
             /* A handler returned a failure code */
             if (rc == MGMT_CB_ERROR_RC) {
                 /* The failure code is the RC value */
-                return ret_rc;
+                return err_rc;
             }
 
             /* The failure is a group and ID error value */
-            ok = smp_add_cmd_ret(zse, ret_group, (uint16_t)ret_rc);
+            ok = smp_add_cmd_err(zse, err_group, (uint16_t)err_rc);
             goto end;
         }
 

--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
@@ -25,39 +25,39 @@ extern "C" {
 /**
  * Command result codes for file system management group.
  */
-enum fs_mgmt_ret_code_t {
+enum fs_mgmt_err_code_t {
 	/** No error, this is implied if there is no ret value in the response */
-	FS_MGMT_RET_RC_OK = 0,
+	FS_MGMT_ERR_OK = 0,
 
 	/** Unknown error occurred. */
-	FS_MGMT_RET_RC_UNKNOWN,
+	FS_MGMT_ERR_UNKNOWN,
 
 	/** The specified file name is not valid. */
-	FS_MGMT_RET_RC_FILE_INVALID_NAME,
+	FS_MGMT_ERR_FILE_INVALID_NAME,
 
 	/** The specified file does not exist. */
-	FS_MGMT_RET_RC_FILE_NOT_FOUND,
+	FS_MGMT_ERR_FILE_NOT_FOUND,
 
 	/** The specified file is a directory, not a file. */
-	FS_MGMT_RET_RC_FILE_IS_DIRECTORY,
+	FS_MGMT_ERR_FILE_IS_DIRECTORY,
 
 	/** Error occurred whilst attempting to open a file. */
-	FS_MGMT_RET_RC_FILE_OPEN_FAILED,
+	FS_MGMT_ERR_FILE_OPEN_FAILED,
 
 	/** Error occurred whilst attempting to seek to an offset in a file. */
-	FS_MGMT_RET_RC_FILE_SEEK_FAILED,
+	FS_MGMT_ERR_FILE_SEEK_FAILED,
 
 	/** Error occurred whilst attempting to read data from a file. */
-	FS_MGMT_RET_RC_FILE_READ_FAILED,
+	FS_MGMT_ERR_FILE_READ_FAILED,
 
 	/** Error occurred whilst trying to truncate file. */
-	FS_MGMT_RET_RC_FILE_TRUNCATE_FAILED,
+	FS_MGMT_ERR_FILE_TRUNCATE_FAILED,
 
 	/** Error occurred whilst trying to delete file. */
-	FS_MGMT_RET_RC_FILE_DELETE_FAILED,
+	FS_MGMT_ERR_FILE_DELETE_FAILED,
 
 	/** Error occurred whilst attempting to write data to a file. */
-	FS_MGMT_RET_RC_FILE_WRITE_FAILED,
+	FS_MGMT_ERR_FILE_WRITE_FAILED,
 
 	/**
 	 * The specified data offset is not valid, this could indicate that the file on the device
@@ -66,13 +66,13 @@ enum fs_mgmt_ret_code_t {
 	 * hash of the file could be requested and compared with the hash of the length of the
 	 * file being uploaded to see if they match or not).
 	 */
-	FS_MGMT_RET_RC_FILE_OFFSET_NOT_VALID,
+	FS_MGMT_ERR_FILE_OFFSET_NOT_VALID,
 
 	/** The requested offset is larger than the size of the file on the device. */
-	FS_MGMT_RET_RC_FILE_OFFSET_LARGER_THAN_FILE,
+	FS_MGMT_ERR_FILE_OFFSET_LARGER_THAN_FILE,
 
 	/** The requested checksum or hash type was not found or is not supported by this build. */
-	FS_MGMT_RET_RC_CHECKSUM_HASH_NOT_FOUND,
+	FS_MGMT_ERR_CHECKSUM_HASH_NOT_FOUND,
 };
 
 #ifdef __cplusplus

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -60,102 +60,102 @@ extern "C" {
 /**
  * Command result codes for image management group.
  */
-enum img_mgmt_ret_code_t {
+enum img_mgmt_err_code_t {
 	/** No error, this is implied if there is no ret value in the response */
-	IMG_MGMT_RET_RC_OK = 0,
+	IMG_MGMT_ERR_OK = 0,
 
 	/** Unknown error occurred. */
-	IMG_MGMT_RET_RC_UNKNOWN,
+	IMG_MGMT_ERR_UNKNOWN,
 
 	/** Failed to query flash area configuration. */
-	IMG_MGMT_RET_RC_FLASH_CONFIG_QUERY_FAIL,
+	IMG_MGMT_ERR_FLASH_CONFIG_QUERY_FAIL,
 
 	/** There is no image in the slot. */
-	IMG_MGMT_RET_RC_NO_IMAGE,
+	IMG_MGMT_ERR_NO_IMAGE,
 
 	/** The image in the slot has no TLVs (tag, length, value). */
-	IMG_MGMT_RET_RC_NO_TLVS,
+	IMG_MGMT_ERR_NO_TLVS,
 
 	/** The image in the slot has an invalid TLV type and/or length. */
-	IMG_MGMT_RET_RC_INVALID_TLV,
+	IMG_MGMT_ERR_INVALID_TLV,
 
 	/** The image in the slot has multiple hash TLVs, which is invalid. */
-	IMG_MGMT_RET_RC_TLV_MULTIPLE_HASHES_FOUND,
+	IMG_MGMT_ERR_TLV_MULTIPLE_HASHES_FOUND,
 
 	/** The image in the slot has an invalid TLV size. */
-	IMG_MGMT_RET_RC_TLV_INVALID_SIZE,
+	IMG_MGMT_ERR_TLV_INVALID_SIZE,
 
 	/** The image in the slot does not have a hash TLV, which is required.  */
-	IMG_MGMT_RET_RC_HASH_NOT_FOUND,
+	IMG_MGMT_ERR_HASH_NOT_FOUND,
 
 	/** There is no free slot to place the image. */
-	IMG_MGMT_RET_RC_NO_FREE_SLOT,
+	IMG_MGMT_ERR_NO_FREE_SLOT,
 
 	/** Flash area opening failed. */
-	IMG_MGMT_RET_RC_FLASH_OPEN_FAILED,
+	IMG_MGMT_ERR_FLASH_OPEN_FAILED,
 
 	/** Flash area reading failed. */
-	IMG_MGMT_RET_RC_FLASH_READ_FAILED,
+	IMG_MGMT_ERR_FLASH_READ_FAILED,
 
 	/** Flash area writing failed. */
-	IMG_MGMT_RET_RC_FLASH_WRITE_FAILED,
+	IMG_MGMT_ERR_FLASH_WRITE_FAILED,
 
 	/** Flash area erase failed. */
-	IMG_MGMT_RET_RC_FLASH_ERASE_FAILED,
+	IMG_MGMT_ERR_FLASH_ERASE_FAILED,
 
 	/** The provided slot is not valid. */
-	IMG_MGMT_RET_RC_INVALID_SLOT,
+	IMG_MGMT_ERR_INVALID_SLOT,
 
 	/** Insufficient heap memory (malloc failed). */
-	IMG_MGMT_RET_RC_NO_FREE_MEMORY,
+	IMG_MGMT_ERR_NO_FREE_MEMORY,
 
 	/** The flash context is already set. */
-	IMG_MGMT_RET_RC_FLASH_CONTEXT_ALREADY_SET,
+	IMG_MGMT_ERR_FLASH_CONTEXT_ALREADY_SET,
 
 	/** The flash context is not set. */
-	IMG_MGMT_RET_RC_FLASH_CONTEXT_NOT_SET,
+	IMG_MGMT_ERR_FLASH_CONTEXT_NOT_SET,
 
 	/** The device for the flash area is NULL. */
-	IMG_MGMT_RET_RC_FLASH_AREA_DEVICE_NULL,
+	IMG_MGMT_ERR_FLASH_AREA_DEVICE_NULL,
 
 	/** The offset for a page number is invalid. */
-	IMG_MGMT_RET_RC_INVALID_PAGE_OFFSET,
+	IMG_MGMT_ERR_INVALID_PAGE_OFFSET,
 
 	/** The offset parameter was not provided and is required. */
-	IMG_MGMT_RET_RC_INVALID_OFFSET,
+	IMG_MGMT_ERR_INVALID_OFFSET,
 
 	/** The length parameter was not provided and is required. */
-	IMG_MGMT_RET_RC_INVALID_LENGTH,
+	IMG_MGMT_ERR_INVALID_LENGTH,
 
 	/** The image length is smaller than the size of an image header. */
-	IMG_MGMT_RET_RC_INVALID_IMAGE_HEADER,
+	IMG_MGMT_ERR_INVALID_IMAGE_HEADER,
 
 	/** The image header magic value does not match the expected value. */
-	IMG_MGMT_RET_RC_INVALID_IMAGE_HEADER_MAGIC,
+	IMG_MGMT_ERR_INVALID_IMAGE_HEADER_MAGIC,
 
 	/** The hash parameter provided is not valid. */
-	IMG_MGMT_RET_RC_INVALID_HASH,
+	IMG_MGMT_ERR_INVALID_HASH,
 
 	/** The image load address does not match the address of the flash area. */
-	IMG_MGMT_RET_RC_INVALID_FLASH_ADDRESS,
+	IMG_MGMT_ERR_INVALID_FLASH_ADDRESS,
 
 	/** Failed to get version of currently running application. */
-	IMG_MGMT_RET_RC_VERSION_GET_FAILED,
+	IMG_MGMT_ERR_VERSION_GET_FAILED,
 
 	/** The currently running application is newer than the version being uploaded. */
-	IMG_MGMT_RET_RC_CURRENT_VERSION_IS_NEWER,
+	IMG_MGMT_ERR_CURRENT_VERSION_IS_NEWER,
 
 	/** There is already an image operating pending. */
-	IMG_MGMT_RET_RC_IMAGE_ALREADY_PENDING,
+	IMG_MGMT_ERR_IMAGE_ALREADY_PENDING,
 
 	/** The image vector table is invalid. */
-	IMG_MGMT_RET_RC_INVALID_IMAGE_VECTOR_TABLE,
+	IMG_MGMT_ERR_INVALID_IMAGE_VECTOR_TABLE,
 
 	/** The image it too large to fit. */
-	IMG_MGMT_RET_RC_INVALID_IMAGE_TOO_LARGE,
+	IMG_MGMT_ERR_INVALID_IMAGE_TOO_LARGE,
 
 	/** The amount of data sent is larger than the provided image size. */
-	IMG_MGMT_RET_RC_INVALID_IMAGE_DATA_OVERRUN,
+	IMG_MGMT_ERR_INVALID_IMAGE_DATA_OVERRUN,
 };
 
 /**

--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
@@ -28,15 +28,15 @@ extern "C" {
 /**
  * Command result codes for OS management group.
  */
-enum os_mgmt_ret_code_t {
+enum os_mgmt_err_code_t {
 	/** No error, this is implied if there is no ret value in the response */
-	OS_MGMT_RET_RC_OK = 0,
+	OS_MGMT_ERR_OK = 0,
 
 	/** Unknown error occurred. */
-	OS_MGMT_RET_RC_UNKNOWN,
+	OS_MGMT_ERR_UNKNOWN,
 
 	/** The provided format value is not valid. */
-	OS_MGMT_RET_RC_INVALID_FORMAT,
+	OS_MGMT_ERR_INVALID_FORMAT,
 };
 
 /* Bitmask values used by the os info command handler. Note that the width of this variable is

--- a/include/zephyr/mgmt/mcumgr/grp/shell_mgmt/shell_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/shell_mgmt/shell_mgmt.h
@@ -20,18 +20,18 @@ extern "C" {
 /**
  * Command result codes for shell management group.
  */
-enum shell_mgmt_ret_code_t {
+enum shell_mgmt_err_code_t {
 	/** No error, this is implied if there is no ret value in the response */
-	SHELL_MGMT_RET_RC_OK = 0,
+	SHELL_MGMT_ERR_OK = 0,
 
 	/** Unknown error occurred. */
-	SHELL_MGMT_RET_RC_UNKNOWN,
+	SHELL_MGMT_ERR_UNKNOWN,
 
 	/** The provided command to execute is too long. */
-	SHELL_MGMT_RET_RC_COMMAND_TOO_LONG,
+	SHELL_MGMT_ERR_COMMAND_TOO_LONG,
 
 	/** No command to execute was provided. */
-	SHELL_MGMT_RET_RC_EMPTY_COMMAND,
+	SHELL_MGMT_ERR_EMPTY_COMMAND,
 };
 
 #ifdef __cplusplus

--- a/include/zephyr/mgmt/mcumgr/grp/stat_mgmt/stat_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/stat_mgmt/stat_mgmt.h
@@ -21,24 +21,24 @@ extern "C" {
 /**
  * Command result codes for statistics management group.
  */
-enum stat_mgmt_ret_code_t {
+enum stat_mgmt_err_code_t {
 	/** No error, this is implied if there is no ret value in the response */
-	STAT_MGMT_RET_RC_OK = 0,
+	STAT_MGMT_ERR_OK = 0,
 
 	/** Unknown error occurred. */
-	STAT_MGMT_RET_RC_UNKNOWN,
+	STAT_MGMT_ERR_UNKNOWN,
 
 	/** The provided statistic group name was not found. */
-	STAT_MGMT_RET_RC_INVALID_GROUP,
+	STAT_MGMT_ERR_INVALID_GROUP,
 
 	/** The provided statistic name was not found. */
-	STAT_MGMT_RET_RC_INVALID_STAT_NAME,
+	STAT_MGMT_ERR_INVALID_STAT_NAME,
 
 	/** The size of the statistic cannot be handled. */
-	STAT_MGMT_RET_RC_INVALID_STAT_SIZE,
+	STAT_MGMT_ERR_INVALID_STAT_SIZE,
 
 	/** Walk through of statistics was aborted. */
-	STAT_MGMT_RET_RC_WALK_ABORTED,
+	STAT_MGMT_ERR_WALK_ABORTED,
 };
 
 /**

--- a/include/zephyr/mgmt/mcumgr/grp/zephyr/zephyr_basic.h
+++ b/include/zephyr/mgmt/mcumgr/grp/zephyr/zephyr_basic.h
@@ -18,21 +18,21 @@ extern "C" {
 /**
  * Command result codes for statistics management group.
  */
-enum zephyr_basic_group_ret_code_t {
+enum zephyr_basic_group_err_code_t {
 	/** No error, this is implied if there is no ret value in the response */
-	ZEPHYR_MGMT_GRP_CMD_RC_OK = 0,
+	ZEPHYRBASIC_MGMT_ERR_OK = 0,
 
 	/** Unknown error occurred. */
-	ZEPHYR_MGMT_RET_RC_UNKNOWN,
+	ZEPHYRBASIC_MGMT_ERR_UNKNOWN,
 
 	/** Opening of the flash area has failed. */
-	ZEPHYR_MGMT_GRP_CMD_RC_FLASH_OPEN_FAILED,
+	ZEPHYRBASIC_MGMT_ERR_FLASH_OPEN_FAILED,
 
 	/** Querying the flash area parameters has failed. */
-	ZEPHYR_MGMT_GRP_CMD_RC_FLASH_CONFIG_QUERY_FAIL,
+	ZEPHYRBASIC_MGMT_ERR_FLASH_CONFIG_QUERY_FAIL,
 
 	/** Erasing the flash area has failed. */
-	ZEPHYR_MGMT_GRP_CMD_RC_FLASH_ERASE_FAILED,
+	ZEPHYRBASIC_MGMT_ERR_FLASH_ERASE_FAILED,
 };
 
 #ifdef __cplusplus

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -58,15 +58,18 @@ enum mgmt_cb_return {
 	/** No error. */
 	MGMT_CB_OK,
 
-	/** SMP protocol error and ``ret_rc`` contains the #mcumgr_err_t error code. */
+	/** SMP protocol error and ``err_rc`` contains the #mcumgr_err_t error code. */
 	MGMT_CB_ERROR_RC,
 
 	/**
-	 * Group (application-level) error and ``ret_group`` contains the group ID that caused
-	 * the error and ``ret_rc`` contians the error code of that group to return.
+	 * Group (application-level) error and ``err_group`` contains the group ID that caused
+	 * the error and ``err_rc`` contians the error code of that group to return.
 	 */
-	MGMT_CB_ERROR_RET,
+	MGMT_CB_ERROR_ERR,
 };
+
+/* Deprecated after Zephyr 3.4, use MGMT_CB_ERROR_ERR instead */
+#define MGMT_CB_ERROR_RET __DEPRECATED_MACRO MGMT_CB_ERROR_ERR
 
 /**
  * @typedef mgmt_cb
@@ -80,16 +83,16 @@ enum mgmt_cb_return {
  *			is being called for a notification only, the return code will be ignored).
  * @param rc		If ``prev_status`` is #MGMT_CB_ERROR_RC then this is the SMP error that
  *			was returned by the first handler that failed. If ``prev_status`` is
- *			#MGMT_CB_ERROR_RET then this will be the group error rc code returned by
+ *			#MGMT_CB_ERROR_ERR then this will be the group error rc code returned by
  *			the first handler that failed. If the handler wishes to raise an SMP
  *			error, this must be set to the #mcumgr_err_t status and #MGMT_CB_ERROR_RC
  *			must be returned by the function, if the handler wishes to raise a ret
- *			error, this must be set to the group ret status and #MGMT_CB_ERROR_RET
+ *			error, this must be set to the group ret status and #MGMT_CB_ERROR_ERR
  *			must be returned by the function.
- * @param group		If ``prev_status`` is #MGMT_CB_ERROR_RET then this is the group of the
+ * @param group		If ``prev_status`` is #MGMT_CB_ERROR_ERR then this is the group of the
  *			ret error that was returned by the first handler that failed. If the
  *			handler wishes to raise a ret error, this must be set to the group ret
- *			status and #MGMT_CB_ERROR_RET must be returned by the function.
+ *			status and #MGMT_CB_ERROR_ERR must be returned by the function.
  * @param abort_more	Set to true to abort further processing by additional handlers.
  * @param data		Optional event argument.
  * @param data_size	Size of optional event argument (0 if no data is provided).
@@ -249,18 +252,18 @@ uint8_t mgmt_evt_get_index(uint32_t event);
  * @param event		#mcumgr_op_t.
  * @param data		Optional event argument.
  * @param data_size	Size of optional event argument (0 if none).
- * @param ret_rc	Pointer to rc value.
- * @param ret_group	Pointer to group value.
+ * @param err_rc	Pointer to rc value.
+ * @param err_group	Pointer to group value.
  *
  * @return		#mgmt_cb_return either #MGMT_CB_OK if all handlers returned it, or
  *			#MGMT_CB_ERROR_RC if the first failed handler returned an SMP error (in
- *			which case ``ret_rc`` will be updated with the SMP error) or
- *			#MGMT_CB_ERROR_RET if the first failed handler returned a ret group and
- *			error (in which case ``ret_group`` will be updated with the failed group
- *			ID and ``ret_rc`` will be updated with the group-specific error code).
+ *			which case ``err_rc`` will be updated with the SMP error) or
+ *			#MGMT_CB_ERROR_ERR if the first failed handler returned a ret group and
+ *			error (in which case ``err_group`` will be updated with the failed group
+ *			ID and ``err_rc`` will be updated with the group-specific error code).
  */
 enum mgmt_cb_return mgmt_callback_notify(uint32_t event, void *data, size_t data_size,
-					 int32_t *ret_rc, uint16_t *ret_group);
+					 int32_t *err_rc, uint16_t *err_group);
 
 /**
  * @brief Register event callback function.

--- a/include/zephyr/mgmt/mcumgr/smp/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp/smp.h
@@ -107,9 +107,9 @@ struct smp_streamer {
 int smp_process_request_packet(struct smp_streamer *streamer, void *req);
 
 /**
- * @brief Appends a "ret" response
+ * @brief Appends an "err" response
  *
- * This appends a ret response to a pending outgoing response which contains a
+ * This appends an err response to a pending outgoing response which contains a
  * result code for a specific group. Note that error codes are specific to the
  * command group they are emitted from).
  *
@@ -119,17 +119,23 @@ int smp_process_request_packet(struct smp_streamer *streamer, void *req);
  *
  * @return true on success, false on failure (memory error).
  */
-bool smp_add_cmd_ret(zcbor_state_t *zse, uint16_t group, uint16_t ret);
+bool smp_add_cmd_err(zcbor_state_t *zse, uint16_t group, uint16_t ret);
+
+/** @deprecated Deprecated after Zephyr 3.4, use smp_add_cmd_err() instead */
+__deprecated inline bool smp_add_cmd_ret(zcbor_state_t *zse, uint16_t group, uint16_t ret)
+{
+	return smp_add_cmd_err(zse, group, ret);
+}
 
 #if IS_ENABLED(CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL)
 /** @typedef	smp_translate_error_fn
  * @brief	Translates a SMP version 2 error response to a legacy SMP version 1 error code.
  *
- * @param ret	The SMP version 2 error ret/rc value.
+ * @param ret	The SMP version 2 group error value.
  *
  * @return	#enum mcumgr_err_t Legacy SMP version 1 error code to return to client.
  */
-typedef int (*smp_translate_error_fn)(uint16_t ret);
+typedef int (*smp_translate_error_fn)(uint16_t err);
 #endif
 
 #ifdef __cplusplus

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -183,7 +183,7 @@ img_mgmt_state_set_pending(int slot, int permanent)
 	 * run if it is a loader in a split image setup.
 	 */
 	if (state_flags & IMG_MGMT_STATE_F_CONFIRMED && slot != 0) {
-		rc = IMG_MGMT_RET_RC_IMAGE_ALREADY_PENDING;
+		rc = IMG_MGMT_ERR_IMAGE_ALREADY_PENDING;
 		goto done;
 	}
 
@@ -204,21 +204,21 @@ img_mgmt_state_confirm(void)
 	int rc;
 
 #if defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS)
-	int32_t ret_rc;
-	uint16_t ret_group;
+	int32_t err_rc;
+	uint16_t err_group;
 #endif
 
 	/* Confirm disallowed if a test is pending. */
 	if (img_mgmt_state_any_pending()) {
-		rc = IMG_MGMT_RET_RC_IMAGE_ALREADY_PENDING;
+		rc = IMG_MGMT_ERR_IMAGE_ALREADY_PENDING;
 		goto err;
 	}
 
 	rc = img_mgmt_write_confirmed();
 
 #if defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS)
-	(void)mgmt_callback_notify(MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED, NULL, 0, &ret_rc,
-				   &ret_group);
+	(void)mgmt_callback_notify(MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED, NULL, 0, &err_rc,
+				   &err_group);
 #endif
 
 err:
@@ -305,8 +305,8 @@ int img_mgmt_set_next_boot_slot(int slot, bool confirm)
 	bool active = (slot == img_mgmt_active_slot(img_mgmt_active_image()));
 
 #if defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS)
-	int32_t ret_rc;
-	uint16_t ret_group;
+	int32_t err_rc;
+	uint16_t err_group;
 #endif
 
 	if (active) {
@@ -320,11 +320,11 @@ int img_mgmt_set_next_boot_slot(int slot, bool confirm)
 
 	/* Confirm disallowed if a test is pending. */
 	if (active && img_mgmt_state_any_pending()) {
-		return IMG_MGMT_RET_RC_IMAGE_ALREADY_PENDING;
+		return IMG_MGMT_ERR_IMAGE_ALREADY_PENDING;
 	}
 
 	if (flash_area_open(area_id, &fa) != 0) {
-		return IMG_MGMT_RET_RC_FLASH_OPEN_FAILED;
+		return IMG_MGMT_ERR_FLASH_OPEN_FAILED;
 	}
 
 	rc = boot_set_next(fa, active, confirm);
@@ -338,13 +338,13 @@ int img_mgmt_set_next_boot_slot(int slot, bool confirm)
 
 		/* Translate from boot util error code to IMG mgmt group error code */
 		if (rc == BOOT_EFLASH) {
-			rc = IMG_MGMT_RET_RC_FLASH_WRITE_FAILED;
+			rc = IMG_MGMT_ERR_FLASH_WRITE_FAILED;
 		} else if (rc == BOOT_EBADVECT) {
-			rc = IMG_MGMT_RET_RC_INVALID_IMAGE_VECTOR_TABLE;
+			rc = IMG_MGMT_ERR_INVALID_IMAGE_VECTOR_TABLE;
 		} else if (rc == BOOT_EBADIMAGE) {
-			rc = IMG_MGMT_RET_RC_INVALID_IMAGE_HEADER_MAGIC;
+			rc = IMG_MGMT_ERR_INVALID_IMAGE_HEADER_MAGIC;
 		} else {
-			rc = IMG_MGMT_RET_RC_UNKNOWN;
+			rc = IMG_MGMT_ERR_UNKNOWN;
 		}
 	}
 	flash_area_close(fa);
@@ -352,8 +352,8 @@ int img_mgmt_set_next_boot_slot(int slot, bool confirm)
 #if defined(CONFIG_MCUMGR_GRP_IMG_STATUS_HOOKS)
 	if (active) {
 		/* Confirm event is only sent for active slot */
-		(void)mgmt_callback_notify(MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED, NULL, 0, &ret_rc,
-					   &ret_group);
+		(void)mgmt_callback_notify(MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED, NULL, 0, &err_rc,
+					   &err_group);
 	}
 #endif
 
@@ -396,15 +396,15 @@ img_mgmt_state_write(struct smp_streamer *ctxt)
 			slot = img_mgmt_active_slot(img_mgmt_active_image());
 		} else {
 			/* A 'test' without a hash is invalid. */
-			ok = smp_add_cmd_ret(zse, MGMT_GROUP_ID_IMAGE,
-					     IMG_MGMT_RET_RC_INVALID_HASH);
+			ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE,
+					     IMG_MGMT_ERR_INVALID_HASH);
 			goto end;
 		}
 	} else if (zhash.len != IMAGE_HASH_LEN) {
 		/* The img_mgmt_find_by_hash does exact length compare
 		 * so just fail here.
 		 */
-		ok = smp_add_cmd_ret(zse, MGMT_GROUP_ID_IMAGE, IMG_MGMT_RET_RC_INVALID_HASH);
+		ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE, IMG_MGMT_ERR_INVALID_HASH);
 		goto end;
 	} else {
 		uint8_t hash[IMAGE_HASH_LEN];
@@ -413,15 +413,15 @@ img_mgmt_state_write(struct smp_streamer *ctxt)
 
 		slot = img_mgmt_find_by_hash(hash, NULL);
 		if (slot < 0) {
-			ok = smp_add_cmd_ret(zse, MGMT_GROUP_ID_IMAGE,
-					     IMG_MGMT_RET_RC_HASH_NOT_FOUND);
+			ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE,
+					     IMG_MGMT_ERR_HASH_NOT_FOUND);
 			goto end;
 		}
 	}
 
 	rc = img_mgmt_set_next_boot_slot(slot, confirm);
 	if (rc != 0) {
-		ok = smp_add_cmd_ret(zse, MGMT_GROUP_ID_IMAGE, rc);
+		ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE, rc);
 		goto end;
 	}
 

--- a/subsys/mgmt/mcumgr/grp/shell_mgmt/src/shell_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/shell_mgmt/src/shell_mgmt.c
@@ -84,8 +84,8 @@ shell_mgmt_exec(struct smp_streamer *ctxt)
 		ok = zcbor_tstr_decode(zsd, &value);
 		if (ok) {
 			if ((len + value.len) >= (ARRAY_SIZE(line) - 1)) {
-				ok = smp_add_cmd_ret(zse, MGMT_GROUP_ID_SHELL,
-						     SHELL_MGMT_RET_RC_COMMAND_TOO_LONG);
+				ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_SHELL,
+						     SHELL_MGMT_ERR_COMMAND_TOO_LONG);
 				goto end;
 			}
 
@@ -104,7 +104,7 @@ shell_mgmt_exec(struct smp_streamer *ctxt)
 	if (len == 0) {
 		/* We do not bother to close decoder */
 		LOG_ERR("Failed to compose command line");
-		ok = smp_add_cmd_ret(zse, MGMT_GROUP_ID_SHELL, SHELL_MGMT_RET_RC_EMPTY_COMMAND);
+		ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_SHELL, SHELL_MGMT_ERR_EMPTY_COMMAND);
 		goto end;
 	}
 
@@ -132,17 +132,17 @@ end:
 /*
  * @brief	Translate shell mgmt group error code into MCUmgr error code
  *
- * @param ret	#shell_mgmt_ret_code_t error code
+ * @param ret	#shell_mgmt_err_code_t error code
  *
  * @return	#mcumgr_err_t error code
  */
-static int shell_mgmt_translate_error_code(uint16_t ret)
+static int shell_mgmt_translate_error_code(uint16_t err)
 {
 	int rc;
 
-	switch (ret) {
-	case SHELL_MGMT_RET_RC_COMMAND_TOO_LONG:
-	case SHELL_MGMT_RET_RC_EMPTY_COMMAND:
+	switch (err) {
+	case SHELL_MGMT_ERR_COMMAND_TOO_LONG:
+	case SHELL_MGMT_ERR_EMPTY_COMMAND:
 		rc = MGMT_ERR_EINVAL;
 		break;
 

--- a/subsys/mgmt/mcumgr/grp/zephyr_basic/src/basic_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/zephyr_basic/src/basic_mgmt.c
@@ -25,17 +25,17 @@ static int storage_erase(void)
 
 	if (rc < 0) {
 		LOG_ERR("Failed to open flash area");
-		rc = ZEPHYR_MGMT_GRP_CMD_RC_FLASH_OPEN_FAILED;
+		rc = ZEPHYRBASIC_MGMT_ERR_FLASH_OPEN_FAILED;
 	} else {
 		if (flash_area_get_device(fa) == NULL) {
 			LOG_ERR("Failed to get flash area device");
-			rc = ZEPHYR_MGMT_GRP_CMD_RC_FLASH_CONFIG_QUERY_FAIL;
+			rc = ZEPHYRBASIC_MGMT_ERR_FLASH_CONFIG_QUERY_FAIL;
 		} else {
 			rc = flash_area_erase(fa, 0, fa->fa_size);
 
 			if (rc < 0) {
 				LOG_ERR("Failed to erase flash area");
-				rc = ZEPHYR_MGMT_GRP_CMD_RC_FLASH_ERASE_FAILED;
+				rc = ZEPHYRBASIC_MGMT_ERR_FLASH_ERASE_FAILED;
 			}
 		}
 
@@ -53,8 +53,8 @@ static int storage_erase_handler(struct smp_streamer *ctxt)
 
 	rc = storage_erase();
 
-	if (rc != ZEPHYR_MGMT_GRP_CMD_RC_OK) {
-		ok = smp_add_cmd_ret(zse, ZEPHYR_MGMT_GRP_BASIC, rc);
+	if (rc != ZEPHYRBASIC_MGMT_ERR_OK) {
+		ok = smp_add_cmd_err(zse, ZEPHYR_MGMT_GRP_BASIC, rc);
 	}
 
 	if (!ok) {
@@ -68,7 +68,7 @@ static int storage_erase_handler(struct smp_streamer *ctxt)
 /*
  * @brief	Translate zephyr basic group error code into MCUmgr error code
  *
- * @param ret	#zephyr_basic_group_ret_code_t error code
+ * @param ret	#zephyr_basic_group_err_code_t error code
  *
  * @return	#mcumgr_err_t error code
  */
@@ -77,12 +77,12 @@ static int zephyr_basic_group_translate_error_code(uint16_t ret)
 	int rc;
 
 	switch (ret) {
-	case ZEPHYR_MGMT_GRP_CMD_RC_FLASH_OPEN_FAILED:
+	case ZEPHYRBASIC_MGMT_ERR_FLASH_OPEN_FAILED:
 		rc = MGMT_ERR_ENOENT;
 		break;
 
-	case ZEPHYR_MGMT_GRP_CMD_RC_FLASH_CONFIG_QUERY_FAIL:
-	case ZEPHYR_MGMT_GRP_CMD_RC_FLASH_ERASE_FAILED:
+	case ZEPHYRBASIC_MGMT_ERR_FLASH_CONFIG_QUERY_FAIL:
+	case ZEPHYRBASIC_MGMT_ERR_FLASH_ERASE_FAILED:
 		rc = MGMT_ERR_EOK;
 		break;
 

--- a/subsys/mgmt/mcumgr/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/mgmt/src/mgmt.c
@@ -111,7 +111,7 @@ void mgmt_callback_unregister(struct mgmt_callback *callback)
 }
 
 enum mgmt_cb_return mgmt_callback_notify(uint32_t event, void *data, size_t data_size,
-					 int32_t *ret_rc, uint16_t *ret_group)
+					 int32_t *err_rc, uint16_t *err_group)
 {
 	sys_snode_t *snp, *sns;
 	bool failed = false;
@@ -119,8 +119,8 @@ enum mgmt_cb_return mgmt_callback_notify(uint32_t event, void *data, size_t data
 	uint16_t group = MGMT_EVT_GET_GROUP(event);
 	enum mgmt_cb_return return_status = MGMT_CB_OK;
 
-	*ret_rc = MGMT_ERR_EOK;
-	*ret_group = 0;
+	*err_rc = MGMT_ERR_EOK;
+	*err_group = 0;
 
 	/*
 	 * Search through the linked list for entries that have registered for this event and
@@ -139,24 +139,24 @@ enum mgmt_cb_return mgmt_callback_notify(uint32_t event, void *data, size_t data
 		    (MGMT_EVT_GET_GROUP(loop_group->event_id) == group &&
 		     (MGMT_EVT_GET_ID(event) & MGMT_EVT_GET_ID(loop_group->event_id)) ==
 		     MGMT_EVT_GET_ID(event))) {
-			int32_t cached_rc = *ret_rc;
-			uint16_t cached_group = *ret_group;
+			int32_t cached_rc = *err_rc;
+			uint16_t cached_group = *err_group;
 			enum mgmt_cb_return status;
 
 			status = loop_group->callback(event, return_status, &cached_rc,
 						      &cached_group, &abort_more, data,
 						      data_size);
 
-			__ASSERT((status <= MGMT_CB_ERROR_RET),
+			__ASSERT((status <= MGMT_CB_ERROR_ERR),
 				 "Invalid status returned by MCUmgr handler: %d", status);
 
 			if (status != MGMT_CB_OK && failed == false) {
 				failed = true;
 				return_status = status;
-				*ret_rc = cached_rc;
+				*err_rc = cached_rc;
 
-				if (status == MGMT_CB_ERROR_RET) {
-					*ret_group = cached_group;
+				if (status == MGMT_CB_ERROR_ERR) {
+					*err_group = cached_group;
 				}
 			}
 

--- a/tests/subsys/mgmt/mcumgr/handler_demo/example_as_module/include/example_mgmt.h
+++ b/tests/subsys/mgmt/mcumgr/handler_demo/example_as_module/include/example_mgmt.h
@@ -24,18 +24,18 @@ extern "C" {
 /**
  * Command result codes for example management group.
  */
-enum example_mgmt_ret_code_t {
+enum example_mgmt_err_code_t {
 	/** No error, this is implied if there is no ret value in the response */
-	EXAMPLE_MGMT_RET_RC_OK = 0,
+	EXAMPLE_MGMT_ERR_OK = 0,
 
 	/** Unknown error occurred. */
-	EXAMPLE_MGMT_RET_RC_UNKNOWN,
+	EXAMPLE_MGMT_ERR_UNKNOWN,
 
 	/** The provided value is not wanted at this time. */
-	EXAMPLE_MGMT_RET_RC_NOT_WANTED,
+	EXAMPLE_MGMT_ERR_NOT_WANTED,
 
 	/** The provided value was rejected by a hook. */
-	EXAMPLE_MGMT_RET_RC_REJECTED_BY_HOOK,
+	EXAMPLE_MGMT_ERR_REJECTED_BY_HOOK,
 };
 
 #ifdef __cplusplus

--- a/tests/subsys/mgmt/mcumgr/handler_demo/example_as_module/src/example_mgmt.c
+++ b/tests/subsys/mgmt/mcumgr/handler_demo/example_as_module/src/example_mgmt.c
@@ -56,7 +56,7 @@ static int example_mgmt_test(struct smp_streamer *ctxt)
 
 	/* If the value of "uint_key" is over 50, return an error of "not wanted" */
 	if (uint_value > 50) {
-		ok = smp_add_cmd_ret(zse, MGMT_GROUP_ID_EXAMPLE, EXAMPLE_MGMT_RET_RC_NOT_WANTED);
+		ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_EXAMPLE, EXAMPLE_MGMT_ERR_NOT_WANTED);
 		goto end;
 	}
 
@@ -86,8 +86,8 @@ static int example_mgmt_other(struct smp_streamer *ctxt)
 #if defined(CONFIG_MCUMGR_GRP_EXAMPLE_OTHER_HOOK)
 	struct example_mgmt_other_data other_data;
 	enum mgmt_cb_return status;
-	int32_t ret_rc;
-	uint16_t ret_group;
+	int32_t err_rc;
+	uint16_t err_group;
 #endif
 
 	LOG_DBG("Example other function called");
@@ -106,17 +106,17 @@ static int example_mgmt_other(struct smp_streamer *ctxt)
 	/* Send request to application to check what to do */
 	other_data.user_value = user_value;
 	status = mgmt_callback_notify(MGMT_EVT_OP_EXAMPLE_OTHER, &other_data, sizeof(other_data),
-				      &ret_rc, &ret_group);
+				      &err_rc, &err_group);
 	if (status != MGMT_CB_OK) {
 		/* If a callback returned an RC error, exit out, if it returned a group error
 		 * code, add the error code to the response and return to the calling function to
 		 * have it sent back to the client
 		 */
 		if (status == MGMT_CB_ERROR_RC) {
-			return ret_rc;
+			return err_rc;
 		}
 
-		ok = smp_add_cmd_ret(zse, ret_group, (uint16_t)ret_rc);
+		ok = smp_add_cmd_err(zse, err_group, (uint16_t)err_rc);
 		goto end;
 	}
 #endif
@@ -140,22 +140,22 @@ end:
  * only for general SMP/MCUmgr errors. The success/OK error code is not used in translation
  * functions as it is automatically handled by the base SMP code.
  */
-static int example_mgmt_translate_error_code(uint16_t ret)
+static int example_mgmt_translate_error_code(uint16_t err)
 {
 	int rc;
 
-	switch (ret) {
-	case EXAMPLE_MGMT_RET_RC_NOT_WANTED:
-	rc = MGMT_ERR_ENOENT;
-	break;
+	switch (err) {
+	case EXAMPLE_MGMT_ERR_NOT_WANTED:
+		rc = MGMT_ERR_ENOENT;
+		break;
 
-	case EXAMPLE_MGMT_RET_RC_REJECTED_BY_HOOK:
-	rc = MGMT_ERR_EBADSTATE;
-	break;
+	case EXAMPLE_MGMT_ERR_REJECTED_BY_HOOK:
+		rc = MGMT_ERR_EBADSTATE;
+		break;
 
-	case EXAMPLE_MGMT_RET_RC_UNKNOWN:
+	case EXAMPLE_MGMT_ERR_UNKNOWN:
 	default:
-	rc = MGMT_ERR_EUNKNOWN;
+		rc = MGMT_ERR_EUNKNOWN;
 	}
 
 	return rc;

--- a/tests/subsys/mgmt/mcumgr/handler_demo/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/handler_demo/src/main.c
@@ -33,10 +33,10 @@ enum mgmt_cb_return test_function(uint32_t event, enum mgmt_cb_return prev_statu
 		if (last_run) {
 			/* Return a dummy error for a demo */
 			*group = MGMT_GROUP_ID_EXAMPLE;
-			*rc = EXAMPLE_MGMT_RET_RC_REJECTED_BY_HOOK;
+			*rc = EXAMPLE_MGMT_ERR_REJECTED_BY_HOOK;
 
 			LOG_INF("Received hook, rejecting!");
-			return MGMT_CB_ERROR_RET;
+			return MGMT_CB_ERROR_ERR;
 		}
 
 		LOG_INF("Received hook, allowing");

--- a/tests/subsys/mgmt/mcumgr/smp_version/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/smp_version/src/main.c
@@ -49,7 +49,7 @@ static const uint8_t response_old[] = {
 /* Response to current packet */
 static const uint8_t response_current[] = {
 	0x09, 0x00, 0x00, 0x13, 0x00, 0x00, 0x01, 0x07,
-	0xbf, 0x63, 0x72, 0x65, 0x74, 0xbf, 0x65, 0x67,
+	0xbf, 0x63, 0x65, 0x72, 0x72, 0xbf, 0x65, 0x67,
 	0x72, 0x6f, 0x75, 0x70, 0x00, 0x62, 0x72, 0x63,
 	0x02, 0xff, 0xff
 };
@@ -115,7 +115,7 @@ ZTEST(smp_version, test_legacy_command)
 	struct zcbor_map_decode_key_val output_decode[] = {
 		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 		ZCBOR_MAP_DECODE_KEY_DECODER("rc", zcbor_int32_decode, &rc),
-		ZCBOR_MAP_DECODE_KEY_DECODER("ret", mcumgr_ret_decode, &group_error),
+		ZCBOR_MAP_DECODE_KEY_DECODER("err", mcumgr_ret_decode, &group_error),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -173,7 +173,7 @@ ZTEST(smp_version, test_legacy_command)
 
 	zassert_equal(
 		zcbor_map_decode_bulk_key_found(output_decode, ARRAY_SIZE(output_decode),
-						"ret"), 0,
+						"err"), 0,
 		"Did not expect to get ret in response");
 
 #ifdef CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL
@@ -202,7 +202,7 @@ ZTEST(smp_version, test_current_command)
 	struct zcbor_map_decode_key_val output_decode[] = {
 		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 		ZCBOR_MAP_DECODE_KEY_DECODER("rc", zcbor_int32_decode, &rc),
-		ZCBOR_MAP_DECODE_KEY_DECODER("ret", mcumgr_ret_decode, &group_error),
+		ZCBOR_MAP_DECODE_KEY_DECODER("err", mcumgr_ret_decode, &group_error),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -260,14 +260,14 @@ ZTEST(smp_version, test_current_command)
 
 	zassert_equal(
 		zcbor_map_decode_bulk_key_found(output_decode, ARRAY_SIZE(output_decode),
-						"ret"), 1,
+						"err"), 1,
 		"Expected to get ret in response");
 
 	zassert_true(group_error.found, "Expected both group and rc in ret to be found");
 	zassert_equal(group_error.group, MGMT_GROUP_ID_OS,
 		      "Expected to get MGMT_GROUP_ID_OS for ret group");
-	zassert_equal(group_error.rc, OS_MGMT_RET_RC_INVALID_FORMAT,
-		      "Expected to get OS_MGMT_RET_RC_INVALID_FORMAT for ret rc");
+	zassert_equal(group_error.rc, OS_MGMT_ERR_INVALID_FORMAT,
+		      "Expected to get OS_MGMT_ERR_INVALID_FORMAT for ret rc");
 }
 
 ZTEST(smp_version, test_new_command)
@@ -288,7 +288,7 @@ ZTEST(smp_version, test_new_command)
 	struct zcbor_map_decode_key_val output_decode[] = {
 		ZCBOR_MAP_DECODE_KEY_DECODER("output", zcbor_tstr_decode, &output),
 		ZCBOR_MAP_DECODE_KEY_DECODER("rc", zcbor_int32_decode, &rc),
-		ZCBOR_MAP_DECODE_KEY_DECODER("ret", mcumgr_ret_decode, &group_error),
+		ZCBOR_MAP_DECODE_KEY_DECODER("err", mcumgr_ret_decode, &group_error),
 	};
 
 	memset(buffer, 0, sizeof(buffer));
@@ -346,7 +346,7 @@ ZTEST(smp_version, test_new_command)
 
 	zassert_equal(
 		zcbor_map_decode_bulk_key_found(output_decode, ARRAY_SIZE(output_decode),
-						"ret"), 0,
+						"err"), 0,
 		"Did not expect to get ret in response");
 
 	zassert_equal(rc, MGMT_ERR_UNSUPPORTED_TOO_NEW,


### PR DESCRIPTION
This is a stable API treewide change changing the newly introduced "ret" response to "err" as it was overlooked that the shell_mgmt group already used "ret" to return the exit code of the command and this created a collision. Since SMP version 2 was only recently introduced, there should not be any public implementations of it as of yet.

Fixes #60980

Note: Not a treewide change as in touching lots of files, but a single commit making all needed changes so that it doesn't break a bisect