### PR TITLE
ipc: fix icmsg-me maybe-uninitialized compile warning

### DIFF
--- a/subsys/ipc/ipc_service/lib/icmsg_me.c
+++ b/subsys/ipc/ipc_service/lib/icmsg_me.c
@@ -168,7 +168,7 @@ int icmsg_me_send(const struct icmsg_config_t *conf,
 		  const void *msg, size_t len)
 {
 	int r;
-	int sent_bytes;
+	int sent_bytes = 0;
 
 	if (user_buffer_len_to_icmsg_buffer_len(len) >= SEND_BUF_SIZE) {
 		return -EBADMSG;


### PR DESCRIPTION
The sent_bytes variable was not initialized in all possible execution branches before return.