### PR TITLE
drivers: spi_nrfx_*: Add support for optional WAKE line

### DIFF
--- a/drivers/spi/CMakeLists.txt
+++ b/drivers/spi/CMakeLists.txt
@@ -16,8 +16,10 @@ zephyr_library_sources_ifdef(CONFIG_SPI_SAM		spi_sam.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_SAM0		spi_sam0.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_SIFIVE		spi_sifive.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_RV32M1_LPSPI	spi_rv32m1_lpspi.c)
-zephyr_library_sources_ifdef(CONFIG_SPI_NRFX_SPI	spi_nrfx_spi.c)
-zephyr_library_sources_ifdef(CONFIG_SPI_NRFX_SPIM	spi_nrfx_spim.c)
+zephyr_library_sources_ifdef(CONFIG_SPI_NRFX_SPI	spi_nrfx_spi.c
+							spi_nrfx_common.c)
+zephyr_library_sources_ifdef(CONFIG_SPI_NRFX_SPIM	spi_nrfx_spim.c
+							spi_nrfx_common.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_NRFX_SPIS	spi_nrfx_spis.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_LITESPI		spi_litespi.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_OC_SIMPLE	spi_oc_simple.c)

--- a/drivers/spi/Kconfig.nrfx
+++ b/drivers/spi/Kconfig.nrfx
@@ -66,4 +66,13 @@ config SPI_NRFX_RAM_BUFFER_SIZE
 	  supplying buffers located in flash to the driver, otherwise such
 	  transfers will fail.
 
+config SPI_NRFX_WAKE_TIMEOUT_US
+	int "Maximum time to wait for SPI slave to wake up"
+	default 200
+	help
+	  Maximum amount of time (in microseconds) that SPI master should wait
+	  for SPI slave to wake up after the WAKE line is asserted. Used only
+	  by instances that have the WAKE line configured (see the wake-gpios
+	  devicetree property).
+
 endif # SPI_NRFX

--- a/drivers/spi/spi_nrfx_common.c
+++ b/drivers/spi/spi_nrfx_common.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "spi_nrfx_common.h"
+#include <zephyr/kernel.h>
+#include <nrfx_gpiote.h>
+
+int spi_nrfx_wake_init(uint32_t wake_pin)
+{
+	nrfx_gpiote_input_config_t input_config = {
+		.pull = NRF_GPIO_PIN_PULLDOWN,
+	};
+	uint8_t ch;
+	nrfx_gpiote_trigger_config_t trigger_config = {
+		.trigger = NRFX_GPIOTE_TRIGGER_HITOLO,
+		.p_in_channel = &ch,
+	};
+	nrfx_err_t res;
+
+	res = nrfx_gpiote_channel_alloc(&ch);
+	if (res != NRFX_SUCCESS) {
+		return -ENODEV;
+	}
+
+	res = nrfx_gpiote_input_configure(wake_pin,
+					  &input_config,
+					  &trigger_config,
+					  NULL);
+	if (res != NRFX_SUCCESS) {
+		nrfx_gpiote_channel_free(ch);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+int spi_nrfx_wake_request(uint32_t wake_pin)
+{
+	nrf_gpiote_event_t trigger_event = nrfx_gpiote_in_event_get(wake_pin);
+	uint32_t start_cycles;
+	uint32_t max_wait_cycles =
+		DIV_ROUND_UP(CONFIG_SPI_NRFX_WAKE_TIMEOUT_US *
+				 CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
+			     1000000);
+	int err = 0;
+
+	/* Enable the trigger (a high-to-low transition) without its interrupt.
+	 * The expected time to wait is quite short so it is not worth paying
+	 * the overhead of context switching to handle the interrupt.
+	 */
+	nrfx_gpiote_trigger_enable(wake_pin, false);
+	/* Enable pull-up on the WAKE line. After the slave device sees the
+	 * WAKE line going high, it will force the line to go low. This will
+	 * be caught by the enabled trigger and the loop below waits for that.
+	 */
+	nrf_gpio_cfg_input(wake_pin, NRF_GPIO_PIN_PULLUP);
+
+	start_cycles = k_cycle_get_32();
+	while (!nrf_gpiote_event_check(NRF_GPIOTE, trigger_event)) {
+		uint32_t elapsed_cycles = k_cycle_get_32() - start_cycles;
+
+		if (elapsed_cycles >= max_wait_cycles) {
+			err = -ETIMEDOUT;
+			break;
+		}
+	}
+
+	nrfx_gpiote_trigger_disable(wake_pin);
+	nrf_gpio_cfg_input(wake_pin, NRF_GPIO_PIN_PULLDOWN);
+
+	return err;
+}

--- a/drivers/spi/spi_nrfx_common.h
+++ b/drivers/spi/spi_nrfx_common.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023, Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SPI_NRFX_COMMON_H_
+#define ZEPHYR_DRIVERS_SPI_NRFX_COMMON_H_
+
+#include <stdint.h>
+
+#define WAKE_PIN_NOT_USED UINT32_MAX
+
+int spi_nrfx_wake_init(uint32_t wake_pin);
+int spi_nrfx_wake_request(uint32_t wake_pin);
+
+#endif /* ZEPHYR_DRIVERS_SPI_NRFX_COMMON_H_ */

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -15,6 +15,7 @@
 LOG_MODULE_REGISTER(spi_nrfx_spi, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
+#include "spi_nrfx_common.h"
 
 struct spi_nrfx_data {
 	struct spi_context ctx;
@@ -29,6 +30,7 @@ struct spi_nrfx_config {
 	nrfx_spi_config_t def_config;
 	void (*irq_connect)(void);
 	const struct pinctrl_dev_config *pcfg;
+	uint32_t wake_pin;
 };
 
 static void event_handler(const nrfx_spi_evt_t *p_event, void *p_context);
@@ -231,6 +233,18 @@ static int transceive(const struct device *dev,
 	if (error == 0) {
 		dev_data->busy = true;
 
+		if (dev_config->wake_pin != WAKE_PIN_NOT_USED) {
+			error = spi_nrfx_wake_request(dev_config->wake_pin);
+			if (error == -ETIMEDOUT) {
+				LOG_WRN("Waiting for WAKE acknowledgment timed out");
+				/* If timeout occurs, try to perform the transfer
+				 * anyway, just in case the slave device was unable
+				 * to signal that it was already awaken and prepared
+				 * for the transfer.
+				 */
+			}
+		}
+
 		spi_context_buffers_setup(&dev_data->ctx, tx_bufs, rx_bufs, 1);
 		spi_context_cs_control(&dev_data->ctx, true);
 
@@ -363,6 +377,18 @@ static int spi_nrfx_init(const struct device *dev)
 		return err;
 	}
 
+	if (dev_config->wake_pin != WAKE_PIN_NOT_USED) {
+		err = spi_nrfx_wake_init(dev_config->wake_pin);
+		if (err == -ENODEV) {
+			LOG_ERR("Failed to allocate GPIOTE channel for WAKE");
+			return err;
+		}
+		if (err == -EIO) {
+			LOG_ERR("Failed to configure WAKE pin");
+			return err;
+		}
+	}
+
 	dev_config->irq_connect();
 
 	err = spi_context_cs_configure_all(&dev_data->ctx);
@@ -413,7 +439,12 @@ static int spi_nrfx_init(const struct device *dev)
 		},							       \
 		.irq_connect = irq_connect##idx,			       \
 		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(SPI(idx)),		       \
+		.wake_pin = NRF_DT_GPIOS_TO_PSEL_OR(SPI(idx), wake_gpios,      \
+						    WAKE_PIN_NOT_USED),	       \
 	};								       \
+	BUILD_ASSERT(!DT_NODE_HAS_PROP(SPI(idx), wake_gpios) ||		       \
+		     !(DT_GPIO_FLAGS(SPI(idx), wake_gpios) & GPIO_ACTIVE_LOW), \
+		     "WAKE line must be configured as active high");	       \
 	PM_DEVICE_DT_DEFINE(SPI(idx), spi_nrfx_pm_action);		       \
 	DEVICE_DT_DEFINE(SPI(idx),					       \
 		      spi_nrfx_init,					       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -22,6 +22,7 @@
 LOG_MODULE_REGISTER(spi_nrfx_spim, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
+#include "spi_nrfx_common.h"
 
 #if defined(CONFIG_SOC_NRF52832) && !defined(CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58)
 #error  This driver is not available by default for nRF52832 because of Product Anomaly 58 \
@@ -59,6 +60,7 @@ struct spi_nrfx_config {
 #ifdef CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58
 	bool anomaly_58_workaround;
 #endif
+	uint32_t wake_pin;
 };
 
 static void event_handler(const nrfx_spim_evt_t *p_event, void *p_context);
@@ -393,6 +395,18 @@ static int transceive(const struct device *dev,
 	if (error == 0) {
 		dev_data->busy = true;
 
+		if (dev_config->wake_pin != WAKE_PIN_NOT_USED) {
+			error = spi_nrfx_wake_request(dev_config->wake_pin);
+			if (error == -ETIMEDOUT) {
+				LOG_WRN("Waiting for WAKE acknowledgment timed out");
+				/* If timeout occurs, try to perform the transfer
+				 * anyway, just in case the slave device was unable
+				 * to signal that it was already awaken and prepared
+				 * for the transfer.
+				 */
+			}
+		}
+
 		spi_context_buffers_setup(&dev_data->ctx, tx_bufs, rx_bufs, 1);
 		spi_context_cs_control(&dev_data->ctx, true);
 
@@ -529,6 +543,18 @@ static int spi_nrfx_init(const struct device *dev)
 		return err;
 	}
 
+	if (dev_config->wake_pin != WAKE_PIN_NOT_USED) {
+		err = spi_nrfx_wake_init(dev_config->wake_pin);
+		if (err == -ENODEV) {
+			LOG_ERR("Failed to allocate GPIOTE channel for WAKE");
+			return err;
+		}
+		if (err == -EIO) {
+			LOG_ERR("Failed to configure WAKE pin");
+			return err;
+		}
+	}
+
 	dev_config->irq_connect();
 
 	err = spi_context_cs_configure_all(&dev_data->ctx);
@@ -603,7 +629,12 @@ static int spi_nrfx_init(const struct device *dev)
 			(.anomaly_58_workaround =			       \
 				SPIM_PROP(idx, anomaly_58_workaround),),       \
 			())						       \
+		.wake_pin = NRF_DT_GPIOS_TO_PSEL_OR(SPIM(idx), wake_gpios,     \
+						    WAKE_PIN_NOT_USED),	       \
 	};								       \
+	BUILD_ASSERT(!DT_NODE_HAS_PROP(SPIM(idx), wake_gpios) ||	       \
+		     !(DT_GPIO_FLAGS(SPIM(idx), wake_gpios) & GPIO_ACTIVE_LOW),\
+		     "WAKE line must be configured as active high");	       \
 	PM_DEVICE_DT_DEFINE(SPIM(idx), spim_nrfx_pm_action);		       \
 	DEVICE_DT_DEFINE(SPIM(idx),					       \
 		      spi_nrfx_init,					       \

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -106,35 +106,29 @@ static int configure(const struct device *dev,
 	return 0;
 }
 
-static void prepare_for_transfer(const struct device *dev,
-				 const uint8_t *tx_buf, size_t tx_buf_len,
-				 uint8_t *rx_buf, size_t rx_buf_len)
+static int prepare_for_transfer(const struct device *dev,
+				const uint8_t *tx_buf, size_t tx_buf_len,
+				uint8_t *rx_buf, size_t rx_buf_len)
 {
-	struct spi_nrfx_data *dev_data = dev->data;
 	const struct spi_nrfx_config *dev_config = dev->config;
-	int status;
+	nrfx_err_t result;
 
 	if (tx_buf_len > dev_config->max_buf_len ||
 	    rx_buf_len > dev_config->max_buf_len) {
 		LOG_ERR("Invalid buffer sizes: Tx %d/Rx %d",
 			tx_buf_len, rx_buf_len);
-		status = -EINVAL;
-	} else {
-		nrfx_err_t result;
-
-		result = nrfx_spis_buffers_set(&dev_config->spis,
-					       tx_buf, tx_buf_len,
-					       rx_buf, rx_buf_len);
-		if (result == NRFX_SUCCESS) {
-			return;
-		}
-
-		status = -EIO;
+		return -EINVAL;
 	}
 
-	spi_context_complete(&dev_data->ctx, dev, status);
-}
+	result = nrfx_spis_buffers_set(&dev_config->spis,
+				       tx_buf, tx_buf_len,
+				       rx_buf, rx_buf_len);
+	if (result != NRFX_SUCCESS) {
+		return -EIO;
+	}
 
+	return 0;
+}
 
 static int transceive(const struct device *dev,
 		      const struct spi_config *spi_cfg,
@@ -161,13 +155,14 @@ static int transceive(const struct device *dev,
 		LOG_ERR("Only buffers located in RAM are supported");
 		error = -ENOTSUP;
 	} else {
-		prepare_for_transfer(dev,
-				     tx_bufs ? tx_bufs->buffers[0].buf : NULL,
-				     tx_bufs ? tx_bufs->buffers[0].len : 0,
-				     rx_bufs ? rx_bufs->buffers[0].buf : NULL,
-				     rx_bufs ? rx_bufs->buffers[0].len : 0);
-
-		error = spi_context_wait_for_completion(&dev_data->ctx);
+		error = prepare_for_transfer(dev,
+				tx_bufs ? tx_bufs->buffers[0].buf : NULL,
+				tx_bufs ? tx_bufs->buffers[0].len : 0,
+				rx_bufs ? rx_bufs->buffers[0].buf : NULL,
+				rx_bufs ? rx_bufs->buffers[0].len : 0);
+		if (error == 0) {
+			error = spi_context_wait_for_completion(&dev_data->ctx);
+		}
 	}
 
 	spi_context_release(&dev_data->ctx, error);

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -36,3 +36,27 @@ properties:
     description: |
       Maximum number of bits available in the EasyDMA MAXCNT register. This
       property must be set at SoC level DTS files.
+
+  wake-gpios:
+    type: phandle-array
+    description: |
+      Optional bi-directional line that allows SPI master to indicate to SPI
+      slave (by setting the line high) that a transfer is to occur, so that
+      the latter can prepare (and indicate its readiness) for handling that
+      transfer when it is actually needed, and stay in any desired low-power
+      state otherwise.
+      The protocol is as follows:
+      - initially, SPI slave configures its WAKE line pin as an input and SPI
+        master keeps the line in the low state
+      - when a transfer is to be performed, SPI master configures its WAKE
+        line pin as an input with pull-up; this changes the line state to
+        high but allows SPI slave to override that state
+      - when SPI slave detects the high state of the WAKE line, it prepares
+        for the transfer and when everything is ready, it drives the WAKE
+        line low by configuring its pin as an output
+      - the generated high-to-low transition on the WAKE line is a signal
+        to SPI master that it can proceed with the transfer
+      - SPI slave releases the line by configuring its pin back to be an input
+        and SPI master again keeps the line in the low state
+      Please note that the line must be configured and properly handled on
+      both sides for the mechanism to work correctly.


### PR DESCRIPTION
Add option to use (by defining the `wake-gpios` devicetree properties) an additional signal line between SPI master and SPI slave that allows the latter to stay in low-power state and wake up only when a transfer is to occur.