### PR TITLE
pm: Refactor pm_notifier to work on a per-power-state basis

### DIFF
--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -205,6 +205,18 @@ struct pm_state_info {
 	COND_CODE_1(DT_NODE_HAS_STATUS(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i), okay),    \
 		    (PM_STATE_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i)),), ())
 
+/**
+ * @brief Call a function for an enabled power-state phandle list item
+ *
+ * @param node_id zephyr,power-state node identifier
+ * @param prop Property holding power-state phandle(s)
+ * @param idx Index within the phandle list
+ * @param fn Function taking a power-state node_id
+ */
+#define Z_PM_STATE_DT_PHANDLE_GEN(node_id, prop, idx, fn)					 \
+	COND_CODE_1(DT_NODE_HAS_STATUS(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, idx), okay), \
+		    (fn(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, idx))), ())
+
 /** @endcond */
 
 /**

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -156,6 +156,16 @@ struct pm_state_info {
 	uint32_t exit_latency_us;
 };
 
+/**
+ * @brief PM state transition direction: state entry bit field value
+ */
+#define PM_STATE_ENTRY        BIT(0)
+
+/**
+ * @brief PM state transition direction: state exit bit field value
+ */
+#define PM_STATE_EXIT         BIT(1)
+
 /** @cond INTERNAL_HIDDEN */
 
 /**

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -350,6 +350,16 @@ struct pm_state_info {
 uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states);
 
 /**
+ * Retrieve the index of a DT power-states array element.
+ *
+ * @param state pm_state state.
+ * @param substate_id pm_state substate ID.
+ *
+ * @return Index of the PM state, or -1.
+ */
+int8_t pm_state_get_index(enum pm_state state, uint8_t substate_id);
+
+/**
  * @}
  */
 

--- a/samples/boards/mec15xxevb_assy6853/power_management/src/power_mgmt.c
+++ b/samples/boards/mec15xxevb_assy6853/power_management/src/power_mgmt.c
@@ -90,44 +90,43 @@ static void pm_latency_check(void)
 }
 
 /* Hooks to count entry/exit */
-static void notify_pm_state_entry(enum pm_state state)
+static void notify_pm_state(uint8_t direction, void *ctx)
 {
+	ARG_UNUSED(ctx);
+
+	const struct pm_state_info *pm_state = pm_state_next_get(0u);
+
 	if (!checks_enabled) {
 		return;
 	}
 
-	switch (state) {
-	case PM_STATE_SUSPEND_TO_IDLE:
-		GPIO_CTRL_REGS->CTRL_0012 = 0x240ul;
-		pm_counters[0].entry_cnt++;
-		break;
-	case PM_STATE_SUSPEND_TO_RAM:
-		GPIO_CTRL_REGS->CTRL_0013 = 0x240ul;
-		pm_counters[1].entry_cnt++;
-		pm_latency_check();
-		break;
-	default:
-		break;
-	}
-}
+	if (direction & PM_STATE_ENTRY) {
+		pm_counters[pm_state->state].entry_cnt++;
 
-static void notify_pm_state_exit(enum pm_state state)
-{
-	if (!checks_enabled) {
-		return;
-	}
+		switch (pm_state->state) {
+		case PM_STATE_SUSPEND_TO_IDLE:
+			GPIO_CTRL_REGS->CTRL_0012 = 0x240ul;
+			break;
+		case PM_STATE_SUSPEND_TO_RAM:
+			GPIO_CTRL_REGS->CTRL_0013 = 0x240ul;
+			pm_latency_check();
+			break;
+		default:
+			break;
+		}
+	} else {
+		pm_counters[pm_state->state].exit_cnt++;
 
-	switch (state) {
-	case PM_STATE_SUSPEND_TO_IDLE:
-		GPIO_CTRL_REGS->CTRL_0012 = 0x10240ul;
-		pm_counters[0].exit_cnt++;
-		break;
-	case PM_STATE_SUSPEND_TO_RAM:
-		GPIO_CTRL_REGS->CTRL_0013 = 0x10240ul;
-		pm_counters[1].exit_cnt++;
-		break;
-	default:
-		break;
+		switch (pm_state->state) {
+		case PM_STATE_SUSPEND_TO_IDLE:
+			GPIO_CTRL_REGS->CTRL_0012 = 0x10240ul;
+			break;
+		case PM_STATE_SUSPEND_TO_RAM:
+			GPIO_CTRL_REGS->CTRL_0013 = 0x10240ul;
+			break;
+		default:
+			break;
+		}
 	}
 }
 
@@ -256,21 +255,24 @@ static void resume_all_tasks(void)
 	k_thread_resume(&thread_b_id);
 }
 
-static struct pm_notifier notifier = {
-	.state_entry = notify_pm_state_entry,
-	.state_exit = notify_pm_state_exit,
-};
+PM_NOTIFIER_DEFINE(notifier_light_sleep, (PM_STATE_ENTRY|PM_STATE_EXIT), notify_pm_state, NULL);
+PM_NOTIFIER_DEFINE(notifier_deep_sleep, (PM_STATE_ENTRY|PM_STATE_EXIT), notify_pm_state, NULL);
 
 int test_pwr_mgmt_multithread(bool use_logging, uint8_t cycles)
 {
 	uint8_t iterations = cycles;
+	const struct pm_state_info *light_sleep = &residency_info[0];
+	const struct pm_state_info *deep_sleep = &residency_info[residency_info_len - 1];
 	/* Ensure we can enter deep sleep when stopping threads
 	 * No UART output should occur when threads are suspended
 	 * Test to verify Zephyr RTOS issue #20033
 	 * https://github.com/zephyrproject-rtos/zephyr/issues/20033
 	 */
 
-	pm_notifier_register(&notifier);
+	pm_notifier_register(&PM_NOTIFIER(notifier_light_sleep), light_sleep->state,
+			     light_sleep->substate_id);
+	pm_notifier_register(&PM_NOTIFIER(notifier_deep_sleep), deep_sleep->state,
+			     deep_sleep->substate_id);
 	create_tasks();
 
 	LOG_WRN("PM multi-thread test started for cycles: %d, logging: %d",
@@ -283,7 +285,7 @@ int test_pwr_mgmt_multithread(bool use_logging, uint8_t cycles)
 		LOG_INF("Suspend...");
 		suspend_all_tasks();
 		LOG_INF("About to enter light sleep");
-		k_msleep((residency_info[0].min_residency_us / 1000U) +
+		k_msleep((light_sleep->min_residency_us / 1000U) +
 			 LT_EXTRA_SLP_TIME);
 		k_busy_wait(100);
 
@@ -304,7 +306,7 @@ int test_pwr_mgmt_multithread(bool use_logging, uint8_t cycles)
 		/* GPIO toggle to measure latency for deep sleep */
 		pm_trigger_marker();
 		k_msleep(
-		   (residency_info[residency_info_len - 1].min_residency_us /
+		   (deep_sleep->min_residency_us /
 		    1000U) + DP_EXTRA_SLP_TIME);
 		k_busy_wait(100);
 
@@ -324,7 +326,10 @@ int test_pwr_mgmt_multithread(bool use_logging, uint8_t cycles)
 	LOG_INF("PM multi-thread completed");
 	pm_check_counters(cycles);
 	pm_reset_counters();
-	pm_notifier_unregister(&notifier);
+	pm_notifier_unregister(&PM_NOTIFIER(notifier_light_sleep), light_sleep->state,
+			       light_sleep->substate_id);
+	pm_notifier_unregister(&PM_NOTIFIER(notifier_deep_sleep), deep_sleep->state,
+			       deep_sleep->substate_id);
 
 	return 0;
 }
@@ -332,17 +337,22 @@ int test_pwr_mgmt_multithread(bool use_logging, uint8_t cycles)
 int test_pwr_mgmt_singlethread(bool use_logging, uint8_t cycles)
 {
 	uint8_t iterations = cycles;
+	const struct pm_state_info *light_sleep = &residency_info[0];
+	const struct pm_state_info *deep_sleep = &residency_info[residency_info_len - 1];
 
 	LOG_WRN("PM single-thread test started for cycles: %d, logging: %d",
 		cycles, use_logging);
 
-	pm_notifier_register(&notifier);
+	pm_notifier_register(&PM_NOTIFIER(notifier_light_sleep), light_sleep->state,
+			     light_sleep->substate_id);
+	pm_notifier_register(&PM_NOTIFIER(notifier_deep_sleep), deep_sleep->state,
+			     deep_sleep->substate_id);
 	checks_enabled = true;
 	while (iterations-- > 0) {
 
 		/* Trigger Light Sleep 1 state. 48MHz PLL stays on */
 		LOG_INF("About to enter light sleep");
-		k_msleep((residency_info[0].min_residency_us / 1000U) +
+		k_msleep((light_sleep->min_residency_us / 1000U) +
 			 LT_EXTRA_SLP_TIME);
 		k_busy_wait(100);
 
@@ -358,7 +368,7 @@ int test_pwr_mgmt_singlethread(bool use_logging, uint8_t cycles)
 		/* GPIO toggle to measure latency */
 		pm_trigger_marker();
 		k_msleep(
-		   (residency_info[residency_info_len - 1].min_residency_us /
+		   (deep_sleep->min_residency_us /
 		    1000U) + DP_EXTRA_SLP_TIME);
 		k_busy_wait(100);
 
@@ -374,7 +384,10 @@ int test_pwr_mgmt_singlethread(bool use_logging, uint8_t cycles)
 	LOG_INF("PM single-thread completed");
 	pm_check_counters(cycles);
 	pm_reset_counters();
-	pm_notifier_unregister(&notifier);
+	pm_notifier_unregister(&PM_NOTIFIER(notifier_light_sleep), light_sleep->state,
+			       light_sleep->substate_id);
+	pm_notifier_unregister(&PM_NOTIFIER(notifier_deep_sleep), deep_sleep->state,
+			       deep_sleep->substate_id);
 
 	return 0;
 }

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -26,7 +26,27 @@ LOG_MODULE_REGISTER(pm, CONFIG_PM_LOG_LEVEL);
 	(COND_CODE_1(CONFIG_SMP, (arch_curr_cpu()->id), (_current_cpu->id)))
 
 static ATOMIC_DEFINE(z_post_ops_required, CONFIG_MP_MAX_NUM_CPUS);
-static sys_slist_t pm_notifiers = SYS_SLIST_STATIC_INIT(&pm_notifiers);
+
+/* Active state notifiers list */
+static sys_slist_t pm_notifiers_active = SYS_SLIST_STATIC_INIT(&pm_notifiers_active);
+
+#if CONFIG_MP_NUM_CPUS > 1 && DT_NODE_EXISTS(DT_PATH(cpus, power_states))
+/* Generate a notifier list for each DT power-state */
+DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus, power_states), Z_PM_NOTIFIERS_CREATE_DT_STATES, (;));
+
+static sys_slist_t *pm_notifiers_array[] = {
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus, power_states), Z_PM_NOTIFIERS_DT_STATES, (,))
+};
+#elif DT_NODE_HAS_PROP(DT_PATH(cpus, cpu_0), cpu_power_states)
+/* Generate a notifier list for each DT cpu-power-state */
+DT_FOREACH_PROP_ELEM_SEP_VARGS(DT_PATH(cpus, cpu_0), cpu_power_states, Z_PM_STATE_DT_PHANDLE_GEN,
+			       (;), Z_PM_NOTIFIERS_CREATE_DT_STATES);
+
+static sys_slist_t *pm_notifiers_array[] = {
+	DT_FOREACH_PROP_ELEM_SEP_VARGS(DT_PATH(cpus, cpu_0), cpu_power_states,
+				       Z_PM_STATE_DT_PHANDLE_GEN, (,), Z_PM_NOTIFIERS_DT_STATES)
+};
+#endif
 
 /*
  * Properly initialize cpu power states. Do not make assumptions that
@@ -110,22 +130,28 @@ static void pm_resume_devices(void)
  * Function called to notify when the system is entering / exiting a
  * power state
  */
-static inline void pm_state_notify(uint8_t direction)
+static void pm_state_notify(uint8_t direction)
 {
 	struct pm_notifier *notifier;
+	static sys_slist_t *notifiers;
 	k_spinlock_key_t pm_notifier_key;
-	void (*callback)(enum pm_state state);
+
+	if (z_cpus_pm_state[CURRENT_CPU].state == PM_STATE_ACTIVE) {
+		notifiers = &pm_notifiers_active;
+	} else {
+		int8_t state_idx = pm_state_get_index(z_cpus_pm_state[CURRENT_CPU].state,
+						       z_cpus_pm_state[CURRENT_CPU].substate_id);
+		if (state_idx < 0) {
+			LOG_ERR("Sub/state passed didn't match any enabled system states");
+			return;
+		}
+		notifiers = pm_notifiers_array[state_idx];
+	}
 
 	pm_notifier_key = k_spin_lock(&pm_notifier_lock);
-	SYS_SLIST_FOR_EACH_CONTAINER(&pm_notifiers, notifier, _node) {
-		if (direction & PM_STATE_ENTRY) {
-			callback = notifier->state_entry;
-		} else {
-			callback = notifier->state_exit;
-		}
-
-		if (callback) {
-			callback(z_cpus_pm_state[_current_cpu->id].state);
+	SYS_SLIST_FOR_EACH_CONTAINER(notifiers, notifier, _node) {
+		if ((direction & notifier->direction) && notifier->callback) {
+			notifier->callback(direction, (void *)notifier->ctx);
 		}
 	}
 	k_spin_unlock(&pm_notifier_lock, pm_notifier_key);
@@ -260,21 +286,50 @@ bool pm_system_suspend(int32_t ticks)
 	return true;
 }
 
-void pm_notifier_register(struct pm_notifier *notifier)
+int pm_notifier_register(struct pm_notifier *notifier, enum pm_state state, uint8_t substate_id)
 {
-	k_spinlock_key_t pm_notifier_key = k_spin_lock(&pm_notifier_lock);
-
-	sys_slist_append(&pm_notifiers, &notifier->_node);
-	k_spin_unlock(&pm_notifier_lock, pm_notifier_key);
-}
-
-int pm_notifier_unregister(struct pm_notifier *notifier)
-{
-	int ret = -EINVAL;
+	static sys_slist_t *notifiers;
 	k_spinlock_key_t pm_notifier_key;
 
+	if (state == PM_STATE_ACTIVE) {
+		notifiers = &pm_notifiers_active;
+	} else {
+		int8_t state_idx = pm_state_get_index(state, substate_id);
+
+		if (state_idx < 0) {
+			LOG_ERR("Sub/state passed didn't match any enabled system states");
+			return -EINVAL;
+		}
+		notifiers = pm_notifiers_array[state_idx];
+	}
+
 	pm_notifier_key = k_spin_lock(&pm_notifier_lock);
-	if (sys_slist_find_and_remove(&pm_notifiers, &(notifier->_node))) {
+	sys_slist_append(notifiers, &notifier->_node);
+	k_spin_unlock(&pm_notifier_lock, pm_notifier_key);
+
+	return 0;
+}
+
+int pm_notifier_unregister(struct pm_notifier *notifier, enum pm_state state, uint8_t substate_id)
+{
+	int ret = -EINVAL;
+	static sys_slist_t *notifiers;
+	k_spinlock_key_t pm_notifier_key;
+
+	if (state == PM_STATE_ACTIVE) {
+		notifiers = &pm_notifiers_active;
+	} else {
+		int8_t state_idx = pm_state_get_index(state, substate_id);
+
+		if (state_idx < 0) {
+			LOG_ERR("Sub/state passed didn't match any enabled system states");
+			return -EINVAL;
+		}
+		notifiers = pm_notifiers_array[state_idx];
+	}
+
+	pm_notifier_key = k_spin_lock(&pm_notifier_lock);
+	if (sys_slist_find_and_remove(notifiers, &(notifier->_node))) {
 		ret = 0;
 	}
 	k_spin_unlock(&pm_notifier_lock, pm_notifier_key);

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -110,7 +110,7 @@ static void pm_resume_devices(void)
  * Function called to notify when the system is entering / exiting a
  * power state
  */
-static inline void pm_state_notify(bool entering_state)
+static inline void pm_state_notify(uint8_t direction)
 {
 	struct pm_notifier *notifier;
 	k_spinlock_key_t pm_notifier_key;
@@ -118,7 +118,7 @@ static inline void pm_state_notify(bool entering_state)
 
 	pm_notifier_key = k_spin_lock(&pm_notifier_lock);
 	SYS_SLIST_FOR_EACH_CONTAINER(&pm_notifiers, notifier, _node) {
-		if (entering_state) {
+		if (direction & PM_STATE_ENTRY) {
 			callback = notifier->state_entry;
 		} else {
 			callback = notifier->state_exit;
@@ -149,9 +149,12 @@ void pm_system_resume(void)
 	 */
 	if (atomic_test_and_clear_bit(z_post_ops_required, id)) {
 		pm_state_exit_post_ops(z_cpus_pm_state[id].state, z_cpus_pm_state[id].substate_id);
-		pm_state_notify(false);
+		/* Exiting low-power state */
+		pm_state_notify(PM_STATE_EXIT);
 		z_cpus_pm_state[id] = (struct pm_state_info){PM_STATE_ACTIVE,
 			0, 0};
+		/* Entering active state */
+		pm_state_notify(PM_STATE_ENTRY);
 	}
 }
 
@@ -175,6 +178,9 @@ bool pm_system_suspend(int32_t ticks)
 	k_spinlock_key_t key;
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, system_suspend, ticks);
+
+	/* Exiting active state */
+	pm_state_notify(PM_STATE_EXIT);
 
 	key = k_spin_lock(&pm_forced_state_lock);
 	if (z_cpus_pm_forced_state[id].state != PM_STATE_ACTIVE) {
@@ -233,8 +239,8 @@ bool pm_system_suspend(int32_t ticks)
 	 */
 	k_sched_lock();
 	pm_stats_start();
-	/* Enter power state */
-	pm_state_notify(true);
+	/* Entering low-power state */
+	pm_state_notify(PM_STATE_ENTRY);
 	atomic_set_bit(z_post_ops_required, id);
 	pm_state_set(z_cpus_pm_state[id].state, z_cpus_pm_state[id].substate_id);
 	pm_stats_stop();

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -40,11 +40,19 @@ BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
 DT_FOREACH_CHILD(DT_PATH(cpus), CHECK_POWER_STATES_CONSISTENCY)
 
 #define DEFINE_CPU_STATES(n) \
-	static const struct pm_state_info pmstates_##n[] \
+	static const struct pm_state_info pmstates_cpu##n[] \
 		= PM_STATE_INFO_LIST_FROM_DT_CPU(n);
-#define CPU_STATE_REF(n) pmstates_##n
+#define CPU_STATE_REF(n) pmstates_cpu##n
 
 DT_FOREACH_CHILD(DT_PATH(cpus), DEFINE_CPU_STATES);
+
+#if CONFIG_MP_NUM_CPUS > 1 && DT_NODE_EXISTS(DT_PATH(cpus, power_states))
+/** General power-states list on SMP platforms, as individual per-CPU states may vary */
+static const struct pm_state_info pmstates_all[] = {
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus, power_states),
+					 PM_STATE_INFO_DT_INIT, (,)),
+};
+#endif
 
 /** CPU power states information for each CPU */
 static const struct pm_state_info *cpus_states[] = {
@@ -66,3 +74,34 @@ uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states)
 
 	return states_per_cpu[cpu];
 }
+
+#if CONFIG_MP_NUM_CPUS > 1
+int8_t pm_state_get_index(enum pm_state state, uint8_t substate_id)
+{
+	for (uint8_t i = 0; i < ARRAY_SIZE(pmstates_all); i++) {
+		if (pmstates_all[i].state == state &&
+		    pmstates_all[i].substate_id == substate_id) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+#else
+static inline int8_t pm_state_cpu_get_index(uint8_t cpu, enum pm_state state, uint8_t substate_id)
+{
+	for (uint8_t i = 0; i < states_per_cpu[cpu]; i++) {
+		if (cpus_states[cpu][i].state == state &&
+		    cpus_states[cpu][i].substate_id == substate_id) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+int8_t pm_state_get_index(enum pm_state state, uint8_t substate_id)
+{
+	return pm_state_cpu_get_index(0U, state, substate_id);
+}
+#endif

--- a/tests/subsys/pm/device_wakeup_api/boards/native_posix.overlay
+++ b/tests/subsys/pm/device_wakeup_api/boards/native_posix.overlay
@@ -9,3 +9,18 @@
 	gpio-controller;
 	wakeup-source;
 };
+
+/ {
+	cpus {
+		power-states {
+			s2ram: s2ram {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-ram";
+			};
+		};
+	};
+};
+
+&cpu0 {
+	cpu-power-states = <&s2ram>;
+};

--- a/tests/subsys/pm/power_mgmt/boards/native_posix.overlay
+++ b/tests/subsys/pm/power_mgmt/boards/native_posix.overlay
@@ -5,6 +5,15 @@
  */
 
 / {
+	cpus {
+		power-states {
+			suspend: suspend {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+			};
+		};
+	};
+
 	device_a: device_a {
 		compatible = "test-device-pm";
 	};
@@ -20,4 +29,8 @@
 	device_d: device_d {
 		compatible = "test-device-pm";
 	};
+};
+
+&cpu0 {
+	cpu-power-states = <&suspend>;
 };

--- a/tests/subsys/pm/power_mgmt_multicore/boards/qemu_x86_64.overlay
+++ b/tests/subsys/pm/power_mgmt_multicore/boards/qemu_x86_64.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Kenneth J. Miller <ken@miller.ec>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	cpus {
+		cpu@0 {
+			cpu-power-states = <&idle &s2idle &stdby>;
+		};
+
+		power-states {
+			idle: idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "runtime-idle";
+			};
+
+			s2idle: s2idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+			};
+
+			stdby: stdby {
+				compatible = "zephyr,power-state";
+				power-state-name = "standby";
+			};
+		};
+	};
+};


### PR DESCRIPTION
The changes in this PR creates separate `pm_notifier` lists for each DT power state.
This allows more efficient traversal during power state transitions when many notifiers are needed, e.g. for driver-specific actions such as device reinitialization (see #59194 #60369).

The callback has also been refactored to no longer accept the (superficial) state that triggered it as an argument, but a transition indicator bit field and a void context pointer that can be used for a variety of purposes, such as passing a device driver instance.

#### Closes

-  #59194