### PR TITLE
build: relocation: Fix long command-line invocations

### DIFF
--- a/cmake/linker/ld/target_relocation.cmake
+++ b/cmake/linker/ld/target_relocation.cmake
@@ -10,6 +10,14 @@ macro(toolchain_ld_relocation)
        "${PROJECT_BINARY_DIR}/include/generated/linker_sram_bss_relocate.ld")
   set(MEM_RELOCATION_CODE "${PROJECT_BINARY_DIR}/code_relocation.c")
   set(MEM_REGION_DEFAULT_RAM RAM)
+  set(DICT_FILE "${PROJECT_BINARY_DIR}/relocation_dict.txt")
+
+  file(GENERATE
+  OUTPUT
+    ${DICT_FILE}
+  CONTENT
+    $<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>
+  )
 
   add_custom_command(
     OUTPUT ${MEM_RELOCATION_CODE} ${MEM_RELOCATION_LD}
@@ -18,7 +26,7 @@ macro(toolchain_ld_relocation)
     ${ZEPHYR_BASE}/scripts/build/gen_relocate_app.py
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
     -d ${APPLICATION_BINARY_DIR}
-    -i \"$<TARGET_PROPERTY:code_data_relocation_target,COMPILE_DEFINITIONS>\"
+    -i ${DICT_FILE}
     -o ${MEM_RELOCATION_LD}
     -s ${MEM_RELOCATION_SRAM_DATA_LD}
     -b ${MEM_RELOCATION_SRAM_BSS_LD}

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -456,8 +456,8 @@ def parse_args():
         formatter_class=argparse.RawDescriptionHelpFormatter, allow_abbrev=False)
     parser.add_argument("-d", "--directory", required=True,
                         help="obj file's directory")
-    parser.add_argument("-i", "--input_rel_dict", required=True,
-                        help="input src:memory type(sram2 or ccm or aon etc) string")
+    parser.add_argument("-i", "--input_rel_dict", required=True, type=argparse.FileType('r'),
+                        help="input file with dict src:memory type(sram2 or ccm or aon etc)")
     parser.add_argument("-o", "--output", required=False, help="Output ld file")
     parser.add_argument("-s", "--output_sram_data", required=False,
                         help="Output sram data ld file")
@@ -490,7 +490,7 @@ def get_obj_filename(searchpath, filename):
 # Returns a 4-tuple with them: (mem_region, program_header, flag, file_name)
 # If no `program_header` is defined, returns an empty string
 def parse_input_string(line):
-    line = line.replace('\\ :', ':')
+    line = line.replace(' :', ':')
 
     flag_sep = ':NOCOPY:' if ':NOCOPY' in line else ':COPY:'
     mem_region_phdr, copy_flag, file_name = line.partition(flag_sep)
@@ -508,9 +508,10 @@ def create_dict_wrt_mem():
     rel_dict = dict()
     phdrs = dict()
 
-    if args.input_rel_dict == '':
+    input_rel_dict = args.input_rel_dict.read()
+    if input_rel_dict == '':
         sys.exit("Disable CONFIG_CODE_DATA_RELOCATION if no file needs relocation")
-    for line in args.input_rel_dict.split('|'):
+    for line in input_rel_dict.split('|'):
         if ':' not in line:
             continue
 


### PR DESCRIPTION
For applications relocating big parts of the code with many sections, builds were failing on Windows due to hitting the max command-line length on that platform.
Fix this by using a file to store the dictionary passed to the python script.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/60994.