### PR TITLE
drivers: interrupt_controller: multilevel: extend second tier interrupts

### DIFF
--- a/drivers/interrupt_controller/Kconfig.multilevel
+++ b/drivers/interrupt_controller/Kconfig.multilevel
@@ -52,6 +52,13 @@ config NUM_2ND_LEVEL_AGGREGATORS
 	  aggregator can manage at most MAX_IRQ_PER_AGGREGATOR level 2
 	  interrupts.
 
+config EXTEND_2ND_LEVEL_INTERRUPTS
+	bool "Support more than 255 level 2 interrupts"
+	depends on 2ND_LEVEL_INTERRUPTS
+	help
+	  Allow more than 255 level 2 interrupts by folding the lebel 3 field
+	  into level 2.
+
 prev-level-num = 1
 cur-level-num = 2
 cur-level = 2ND
@@ -74,7 +81,7 @@ rsource "Kconfig.multilevel.aggregator_template"
 
 config 3RD_LEVEL_INTERRUPTS
 	bool "Third-level interrupt support"
-	depends on 2ND_LEVEL_INTERRUPTS
+	depends on 2ND_LEVEL_INTERRUPTS && !EXTEND_2ND_LEVEL_INTERRUPTS
 	help
 	  Third level interrupts are used to increase the number of
 	  addressable interrupts in a system.

--- a/scripts/build/gen_isr_tables.py
+++ b/scripts/build/gen_isr_tables.py
@@ -311,6 +311,12 @@ def main():
             else:
                 # Figure out third level interrupt position
                 debug('IRQ = ' + hex(irq))
+                if "CONFIG_EXTENDED_2ND_LEVEL_INTERRUPTS" in syms:
+                    global SECND_LVL_INTERRUPTS
+                    global THIRD_LVL_INTERRUPTS
+                    SECND_LVL_INTERRUPTS = 0x00FFFF00
+                    THIRD_LVL_INTERRUPTS = 0
+
                 irq3 = (irq & THIRD_LVL_INTERRUPTS) >> 16
                 irq2 = (irq & SECND_LVL_INTERRUPTS) >> 8
                 irq1 = irq & FIRST_LVL_INTERRUPTS


### PR DESCRIPTION
Some controllers support more than 255 second tier interrupts. This diff adds support to extend the second tier by folding it into the third tier.