### PR TITLE
Add macro to detect pointer overflow in buffer accesses

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -25,6 +25,7 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
+#include <stdint.h>
 
 /** @brief Number of bits that make up a type */
 #define NUM_BITS(t) (sizeof(t) * 8)
@@ -587,6 +588,22 @@ char *utf8_lcpy(char *dst, const char *src, size_t n);
  * @return 2^ceil(log2(x)) or 0 if 2^ceil(log2(x)) would saturate 64-bits
  */
 #define NHPOT(x) ((x) < 1 ? 1 : ((x) > (1ULL<<63) ? 0 : 1ULL << LOG2CEIL(x)))
+
+/**
+ * @brief Determine if a buffer exceeds highest address
+ *
+ * This macro determines if a buffer identified by a starting address @a addr
+ * and length @a buflen spans a region of memory that goes beond the highest
+ * possible address (thereby resulting in a pointer overflow).
+ *
+ * @param addr Buffer starting address
+ * @param buflen Length of the buffer
+ *
+ * @return true if pointer overflow detected, false otherwise
+ */
+#define Z_DETECT_POINTER_OVERFLOW(addr, buflen)  \
+	(((buflen) != 0) &&                        \
+	((UINTPTR_MAX - (uintptr_t)(addr)) <= ((uintptr_t)((buflen) - 1))))
 
 #ifdef __cplusplus
 }

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -204,7 +204,7 @@ static inline void z_mem_assert_virtual_region(uint8_t *addr, size_t size)
 		 "unaligned addr %p", addr);
 	__ASSERT(size % CONFIG_MMU_PAGE_SIZE == 0U,
 		 "unaligned size %zu", size);
-	__ASSERT(addr + size > addr,
+	__ASSERT(!Z_DETECT_POINTER_OVERFLOW(addr, size),
 		 "region %p size %zu zero or wraps around", addr, size);
 	__ASSERT(addr >= Z_VIRT_RAM_START && addr + size < Z_VIRT_RAM_END,
 		 "invalid virtual address region %p (%zu)", addr, size);


### PR DESCRIPTION
Adds the macro Z_DETECT_POINTER_OVERFLOW() to serve as a common method to detect pointer overflows in buffers.

Fixes #61010

Historically, a common approach to test for pointer overflow has been to do something like ...

```
     if (addr + buflen < addr) {
        /* Buffer overflow detected */
     }

```
At least with GCC, such a check gets silently ignored. In an effort to help avoid such things in the future, a new macro has been created (Z_DETECT_POINTER_OVERFLOW) that can be used to detect pointer overflow on a buffer that is defined by a start address and length.