### PR TITLE
drivers: sensor: Fix return value for unsupported channels

### DIFF
--- a/drivers/sensor/ak8975/ak8975.c
+++ b/drivers/sensor/ak8975/ak8975.c
@@ -77,8 +77,10 @@ static int ak8975_channel_get(const struct device *dev,
 		ak8975_convert(val, drv_data->x_sample, drv_data->x_adj);
 	} else if (chan == SENSOR_CHAN_MAGN_Y) {
 		ak8975_convert(val, drv_data->y_sample, drv_data->y_adj);
-	} else { /* chan == SENSOR_CHAN_MAGN_Z */
+	} else if (chan == SENSOR_CHAN_MAGN_Z) {
 		ak8975_convert(val, drv_data->z_sample, drv_data->z_adj);
+	} else {
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/akm09918c/akm09918c.c
+++ b/drivers/sensor/akm09918c/akm09918c.c
@@ -86,7 +86,7 @@ static int akm09918c_channel_get(const struct device *dev, enum sensor_channel c
 		akm09918c_convert(val, data->z_sample);
 	} else {
 		LOG_WRN("Invalid channel %d", chan);
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/bmc150_magn/bmc150_magn.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn.c
@@ -347,7 +347,7 @@ static int bmc150_magn_channel_get(const struct device *dev,
 		bmc150_magn_convert(val + 2, data->sample_z);
 		break;
 	default:
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -291,7 +291,7 @@ static int bme680_channel_get(const struct device *dev,
 		val->val2 = 0;
 		break;
 	default:
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/bmi323/bmi323.c
+++ b/drivers/sensor/bmi323/bmi323.c
@@ -1096,7 +1096,7 @@ static int bosch_bmi323_driver_api_channel_get(const struct device *dev, enum se
 		break;
 
 	default:
-		ret = -ENODEV;
+		ret = -ENOTSUP;
 
 		break;
 	}

--- a/drivers/sensor/bmm150/bmm150.c
+++ b/drivers/sensor/bmm150/bmm150.c
@@ -371,7 +371,7 @@ static int bmm150_channel_get(const struct device *dev,
 		bmm150_convert(val + 2, drv_data->sample_z);
 		break;
 	default:
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -184,7 +184,7 @@ static int dht_channel_get(const struct device *dev,
 				+ drv_data->sample[1];
 			val->val1 = raw_val / 10;
 			val->val2 = (raw_val % 10) * 100000;
-		} else { /* chan == SENSOR_CHAN_AMBIENT_TEMP */
+		} else if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 			raw_val = (drv_data->sample[2] << 8)
 				+ drv_data->sample[3];
 
@@ -199,15 +199,19 @@ static int dht_channel_get(const struct device *dev,
 				val->val1 = -val->val1;
 				val->val2 = -val->val2;
 			}
+		} else {
+			return -ENOTSUP;
 		}
 	} else {
 		/* use only integral data byte */
 		if (chan == SENSOR_CHAN_HUMIDITY) {
 			val->val1 = drv_data->sample[0];
 			val->val2 = 0;
-		} else { /* chan == SENSOR_CHAN_AMBIENT_TEMP */
+		} else if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 			val->val1 = drv_data->sample[2];
 			val->val2 = 0;
+		} else {
+			return -ENOTSUP;
 		}
 	}
 

--- a/drivers/sensor/dps310/dps310.c
+++ b/drivers/sensor/dps310/dps310.c
@@ -703,7 +703,7 @@ static int dps310_channel_get(const struct device *dev,
 		val->val2 = data->psr_val2;
 		break;
 	default:
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/grow_r502a/grow_r502a.c
+++ b/drivers/sensor/grow_r502a/grow_r502a.c
@@ -634,7 +634,7 @@ static int grow_r502a_channel_get(const struct device *dev, enum sensor_channel 
 		val->val1 = drv_data->template_count;
 	} else {
 		LOG_ERR("Invalid channel");
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/hmc5883l/hmc5883l.c
+++ b/drivers/sensor/hmc5883l/hmc5883l.c
@@ -41,13 +41,15 @@ static int hmc5883l_channel_get(const struct device *dev,
 	} else if (chan == SENSOR_CHAN_MAGN_Z) {
 		hmc5883l_convert(val, drv_data->z_sample,
 				 hmc5883l_gain[drv_data->gain_idx]);
-	} else { /* chan == SENSOR_CHAN_MAGN_XYZ */
+	} else if (chan == SENSOR_CHAN_MAGN_XYZ) {
 		hmc5883l_convert(val, drv_data->x_sample,
 				 hmc5883l_gain[drv_data->gain_idx]);
 		hmc5883l_convert(val + 1, drv_data->y_sample,
 				 hmc5883l_gain[drv_data->gain_idx]);
 		hmc5883l_convert(val + 2, drv_data->z_sample,
 				 hmc5883l_gain[drv_data->gain_idx]);
+	} else {
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/max31855/max31855.c
+++ b/drivers/sensor/max31855/max31855.c
@@ -97,7 +97,7 @@ static int max31855_channel_get(const struct device *dev, enum sensor_channel ch
 		break;
 
 	default:
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/max31865/max31865.c
+++ b/drivers/sensor/max31865/max31865.c
@@ -270,7 +270,7 @@ static int max31865_channel_get(const struct device *dev, enum sensor_channel ch
 	case SENSOR_CHAN_AMBIENT_TEMP:
 		return sensor_value_from_double(val, data->temperature);
 	default:
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 }
 

--- a/drivers/sensor/mcp9808/mcp9808.c
+++ b/drivers/sensor/mcp9808/mcp9808.c
@@ -83,6 +83,10 @@ static int mcp9808_channel_get(const struct device *dev,
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_AMBIENT_TEMP);
 
+	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
+		return -ENOTSUP;
+	}
+
 	val->val1 = temp / MCP9808_TEMP_SCALE_CEL;
 	temp -= val->val1 * MCP9808_TEMP_SCALE_CEL;
 	val->val2 = (temp * 1000000) / MCP9808_TEMP_SCALE_CEL;

--- a/drivers/sensor/mpr/mpr.c
+++ b/drivers/sensor/mpr/mpr.c
@@ -113,6 +113,10 @@ static int mpr_channel_get(const struct device *dev,
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_PRESS);
 
+	if (chan != SENSOR_CHAN_PRESS) {
+		return -ENOTSUP;
+	}
+
 	uint64_t value;
 
 	mpr_convert_reg(&data->reg_val, &value);

--- a/drivers/sensor/mpu6050/mpu6050.c
+++ b/drivers/sensor/mpu6050/mpu6050.c
@@ -102,8 +102,10 @@ static int mpu6050_channel_get(const struct device *dev,
 		mpu6050_convert_gyro(val, drv_data->gyro_z,
 				     drv_data->gyro_sensitivity_x10);
 		break;
-	default: /* chan == SENSOR_CHAN_DIE_TEMP */
+	case SENSOR_CHAN_DIE_TEMP:
 		mpu6050_convert_temp(val, drv_data->temp);
+	default:
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/ms5607/ms5607.c
+++ b/drivers/sensor/ms5607/ms5607.c
@@ -155,7 +155,7 @@ static int ms5607_channel_get(const struct device *dev,
 		val->val2 = data->pressure % 100 * 10000;
 		break;
 	default:
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/ms5837/ms5837.c
+++ b/drivers/sensor/ms5837/ms5837.c
@@ -184,7 +184,7 @@ static int ms5837_channel_get(const struct device *dev,
 		val->val2 = data->pressure % 1000 * 1000;
 		break;
 	default:
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/pms7003/pms7003.c
+++ b/drivers/sensor/pms7003/pms7003.c
@@ -162,7 +162,7 @@ static int pms7003_channel_get(const struct device *dev,
 		val->val1 = drv_data->pm_10;
 		val->val2 = 0;
 	} else {
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 	return 0;
 }

--- a/drivers/sensor/si7210/si7210.c
+++ b/drivers/sensor/si7210/si7210.c
@@ -414,7 +414,7 @@ static int si7210_channel_get(const struct device *dev,
 		val->val2 = tmp % 1000000;
 		break;
 	default:
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/sx9500/sx9500.c
+++ b/drivers/sensor/sx9500/sx9500.c
@@ -64,6 +64,10 @@ static int sx9500_channel_get(const struct device *dev,
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_PROX);
 
+	if (chan != SENSOR_CHAN_PROX) {
+		return -ENOTSUP;
+	}
+
 	val->val1 = !!(data->prox_stat &
 		       (1 << (4 + CONFIG_SX9500_PROX_CHANNEL)));
 	val->val2 = 0;

--- a/drivers/sensor/ti_hdc20xx/ti_hdc20xx.c
+++ b/drivers/sensor/ti_hdc20xx/ti_hdc20xx.c
@@ -128,7 +128,7 @@ static int ti_hdc20xx_channel_get(const struct device *dev,
 		val->val2 = ((tmp & 0xFFFF) * 15625U) >> 10;
 		break;
 	default:
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	return 0;

--- a/drivers/sensor/vl53l1x/vl53l1.c
+++ b/drivers/sensor/vl53l1x/vl53l1.c
@@ -342,6 +342,10 @@ static int vl53l1x_channel_get(const struct device *dev,
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_DISTANCE);
 
+	if (chan != SENSOR_CHAN_DISTANCE) {
+		return -ENOTSUP;
+	}
+
 	/* Calling VL53L1_WaitMeasurementDataReady regardless of using interrupt or
 	 * polling method ensures user does not have to consider the time between
 	 * calling fetch and get.


### PR DESCRIPTION
Fixes sensor drivers to consistently return -ENOTSUP when an unsupported channel argument is passed to the sensor_channel_get function.

Follow up to discussion in https://github.com/zephyrproject-rtos/zephyr/pull/60697#pullrequestreview-1544280793

cc: @joseppc 