### PR TITLE
pm: add pm service support for ish

### DIFF
--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -13,6 +13,36 @@
 	chosen {
 	};
 
+	power-states {
+		d0i0: d0i0 {
+			compatible = "zephyr,power-state";
+			power-state-name = "runtime-idle";
+			min-residency-us = <500>;
+			substate-id = <1>;
+		};
+
+		d0i1: d0i1 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			min-residency-us = <2000>;
+			substate-id = <2>;
+		};
+
+		d0i2: d0i2 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			min-residency-us = <4000>;
+			substate-id = <3>;
+		};
+
+		d0i3: d0i3 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-disk";
+			min-residency-us = <3000000>;
+			substate-id = <4>;
+		};
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -21,6 +51,7 @@
 			device_type = "cpu";
 			compatible = "intel,ish";
 			reg = <0>;
+			cpu-power-states = <&d0i0 &d0i1 &d0i2 &d0i3>;
 		};
 	};
 

--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -68,6 +68,13 @@
 		reg = <0xff200000 DT_SIZE_K(640)>;
 	};
 
+	aon: memory@ff800000 {
+		device_type = "memory";
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0xff800000 DT_SIZE_K(8)>;
+		zephyr,memory-region = "AON";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/include/zephyr/arch/x86/ia32/linker.ld
+++ b/include/zephyr/arch/x86/ia32/linker.ld
@@ -87,6 +87,10 @@ SECTIONS
 	*(.iplt)
 	}
 
+#if defined(CONFIG_SOC_FAMILY_INTEL_ISH) && defined(CONFIG_PM)
+#include <zephyr/arch/x86/ia32/scripts/ish_aon.ld>
+#endif
+
 #ifdef CONFIG_LINKER_USE_BOOT_SECTION
 
 	SECTION_PROLOGUE(boot.text,,)

--- a/include/zephyr/arch/x86/ia32/scripts/ish_aon.ld
+++ b/include/zephyr/arch/x86/ia32/scripts/ish_aon.ld
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define AON_C_OBJECT_FILE_IN_SECT(lsect, objfile)			\
+        KEEP(*_intel_hal.a:objfile.c.obj(.##lsect))		\
+        KEEP(*_intel_hal.a:objfile.c.obj(.##lsect##.*))
+
+#define AON_S_OBJECT_FILE_IN_SECT(lsect, objfile)			\
+        KEEP(*_intel_hal.a:objfile.S.obj(.##lsect))		\
+        KEEP(*_intel_hal.a:objfile.S.obj(.##lsect##.*))
+
+#define AON_IN_SECT(lsect)						\
+        AON_C_OBJECT_FILE_IN_SECT(lsect, aon_task)			\
+        AON_C_OBJECT_FILE_IN_SECT(lsect, ish_dma)			\
+        AON_S_OBJECT_FILE_IN_SECT(lsect, ipapg)
+
+GROUP_START(AON)
+
+	SECTION_PROLOGUE(aon,,)
+	{
+		aon_start = .;
+		KEEP(*(.data.aon_share))
+		AON_IN_SECT(data)
+		AON_IN_SECT(text)
+		AON_IN_SECT(bss)
+		aon_end = .;
+	} GROUP_LINK_IN(AON)
+
+GROUP_END(AON)

--- a/include/zephyr/arch/x86/memory.ld
+++ b/include/zephyr/arch/x86/memory.ld
@@ -28,6 +28,7 @@
 #define ARCH_X86_MEMORY_LD
 
 #include <zephyr/devicetree.h>
+#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/sys/mem_manage.h>
 
 /* Bounds of physical RAM from DTS */
@@ -88,6 +89,7 @@ MEMORY
      * physical ROM locations
      */
     RAM (wx)        : ORIGIN = KERNEL_BASE_ADDR, LENGTH = KERNEL_RAM_SIZE
+    LINKER_DT_REGIONS()
 
 #ifdef CONFIG_X86_64
     /* Special low-memory area for bootstrapping other CPUs from real mode */

--- a/soc/x86/intel_ish/Kconfig
+++ b/soc/x86/intel_ish/Kconfig
@@ -12,3 +12,4 @@ config SOC_FAMILY_INTEL_ISH
 	select LOAPIC
 	select CPU_HAS_FPU
 	select INTEL_HAL
+	select HAS_PM

--- a/soc/x86/intel_ish/intel_ish5/CMakeLists.txt
+++ b/soc/x86/intel_ish/intel_ish5/CMakeLists.txt
@@ -6,5 +6,6 @@
 zephyr_cc_option(-march=pentium -mtune=i486)
 
 zephyr_sources(soc.c)
+add_subdirectory_ifdef(CONFIG_PM pm)
 
 include(../utils/build_ish_firmware.cmake)

--- a/soc/x86/intel_ish/intel_ish5/Kconfig.defconfig.series
+++ b/soc/x86/intel_ish/intel_ish5/Kconfig.defconfig.series
@@ -16,3 +16,5 @@ config SOC
 	default "intel_ish_5_8_0" if SOC_INTEL_ISH_5_8_0
 
 endif # SOC_SERIES_INTEL_ISH5
+
+rsource "pm/Kconfig.pm"

--- a/soc/x86/intel_ish/intel_ish5/pm/CMakeLists.txt
+++ b/soc/x86/intel_ish/intel_ish5/pm/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_sources(power.c)

--- a/soc/x86/intel_ish/intel_ish5/pm/Kconfig.pm
+++ b/soc/x86/intel_ish/intel_ish5/pm/Kconfig.pm
@@ -1,0 +1,21 @@
+# Intel ISH family PM default configuration options
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if PM
+
+config GDT_DYNAMIC
+	default y
+
+config PM_DEVICE
+	default y
+
+config GDT_RESERVED_NUM_ENTRIES
+	default 3
+
+config REBOOT
+	default y
+
+endif

--- a/soc/x86/intel_ish/intel_ish5/pm/power.c
+++ b/soc/x86/intel_ish/intel_ish5/pm/power.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/device.h>
+#include <zephyr/timeout_q.h>
+#include <zephyr/init.h>
+#include <zephyr/irq.h>
+#include <zephyr/logging/log_core.h>
+#include <stdio.h>
+#include <zephyr/drivers/interrupt_controller/ioapic.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(pm_service, CONFIG_PM_LOG_LEVEL);
+
+/* low power modes */
+#define FW_D0		0
+#define FW_D0i0		1
+#define FW_D0i1		2
+#define FW_D0i2		3
+#define	FW_D0i3		4
+
+extern void sedi_pm_enter_power_state(int state);
+
+void pm_state_set(enum pm_state state, uint8_t substate_id)
+{
+	LOG_DBG(" -> SoC D0i%u, idle=%u ms", substate_id,
+				k_ticks_to_ms_floor32(_kernel.idle));
+
+	switch (state) {
+	case PM_STATE_RUNTIME_IDLE:
+		sedi_pm_enter_power_state(FW_D0i0);
+		break;
+	case PM_STATE_SUSPEND_TO_IDLE:
+		sedi_pm_enter_power_state(FW_D0i1);
+		break;
+	case PM_STATE_SUSPEND_TO_RAM:
+		sedi_pm_enter_power_state(FW_D0i2);
+		break;
+	case PM_STATE_SUSPEND_TO_DISK:
+		sedi_pm_enter_power_state(FW_D0i3);
+		break;
+	default:
+		LOG_DBG("Unsupported power state %u", state);
+		break;
+	}
+
+	LOG_DBG("SoC D0i%u ->", substate_id);
+}
+
+/* Handle SOC specific activity after Low Power Mode Exit */
+void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+	__asm__ volatile ("sti" ::: "memory");
+}
+
+#if defined(CONFIG_REBOOT) && !defined(CONFIG_REBOOT_RST_CNT)
+extern void sedi_pm_reset(void);
+
+void sys_arch_reboot(int type)
+{
+	ARG_UNUSED(type);
+	sedi_pm_reset();
+}
+#endif
+
+extern void sedi_pm_init(void);
+
+static int ish_sedi_pm_init(void)
+{
+	sedi_pm_init();
+
+	return 0;
+}
+
+SYS_INIT(ish_sedi_pm_init, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/x86/intel_ish/utils/build_ish_firmware.cmake
+++ b/soc/x86/intel_ish/utils/build_ish_firmware.cmake
@@ -3,8 +3,23 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+if(CONFIG_PM)
+set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+  COMMAND ${CMAKE_OBJCOPY} -O binary --remove-section=aon
+      ${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME} ${PROJECT_BINARY_DIR}/ish_kernel.bin
+
+  COMMAND ${CMAKE_OBJCOPY} -O binary --only-section=aon
+      ${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME} ${PROJECT_BINARY_DIR}/ish_aon.bin
+
+  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/build_ish_firmware.py
+  -k ${PROJECT_BINARY_DIR}/ish_kernel.bin
+  -a ${PROJECT_BINARY_DIR}/ish_aon.bin
+  -o ${PROJECT_BINARY_DIR}/ish_fw.bin
+)
+else()
 set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/build_ish_firmware.py
   ARGS -k ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.bin
   -o ${PROJECT_BINARY_DIR}/ish_fw.bin
 )
+endif()

--- a/west.yml
+++ b/west.yml
@@ -173,7 +173,7 @@ manifest:
       groups:
         - hal
     - name: hal_intel
-      revision: b04f13d58bd7b5b9349d6fc2e248679ce1b5579d
+      revision: 3d4d4a6195710595e4e5028e687f37525febcf60
       path: modules/hal/intel
       groups:
         - hal


### PR DESCRIPTION
This enables the power management for Intel ISH. It supports D0i0, D0i1,
D0i2, D0i3 power saving modes for ISH.