### PR TITLE
driver:flash:spi_nor: provide api to reset the flash registers

### DIFF
--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -8,6 +8,7 @@ menuconfig SPI_NOR
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_JESD216
+	select FLASH_HAS_EX_OP
 	select SPI
 
 if SPI_NOR

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -702,6 +702,34 @@ static int spi_nor_read(const struct device *dev, off_t addr, void *dest,
 	return ret;
 }
 
+#if defined(CONFIG_FLASH_EX_OP_ENABLED)
+static int flash_spi_nor_ex_op(const struct device *dev, uint16_t code,
+			const uintptr_t in, void *out)
+{
+	int ret;
+
+	ARG_UNUSED(in);
+	ARG_UNUSED(out);
+
+	acquire_device(dev);
+
+	switch (code) {
+	case FLASH_EX_OP_RESET:
+		ret = spi_nor_cmd_write(dev, SPI_NOR_CMD_RESET_EN);
+		if (ret == 0) {
+			ret = spi_nor_cmd_write(dev, SPI_NOR_CMD_RESET_MEM);
+		}
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
+	}
+
+	release_device(dev);
+	return ret;
+}
+#endif
+
 static int spi_nor_write(const struct device *dev, off_t addr,
 			 const void *src,
 			 size_t size)
@@ -1425,6 +1453,9 @@ static const struct flash_driver_api spi_nor_api = {
 #if defined(CONFIG_FLASH_JESD216_API)
 	.sfdp_read = spi_nor_sfdp_read,
 	.read_jedec_id = spi_nor_read_jedec_id,
+#endif
+#if defined(CONFIG_FLASH_EX_OP_ENABLED)
+	.ex_op = flash_spi_nor_ex_op,
 #endif
 };
 

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -471,6 +471,16 @@ __syscall int flash_ex_op(const struct device *dev, uint16_t code,
 #define FLASH_EX_OP_VENDOR_BASE 0x8000
 #define FLASH_EX_OP_IS_VENDOR(c) ((c) & FLASH_EX_OP_VENDOR_BASE)
 
+/**
+ *  @brief Enumeration for extra flash operations
+ */
+enum flash_ex_op_types {
+	/*
+	 * Reset flash device.
+	 */
+	FLASH_EX_OP_RESET = 0,
+};
+
 static inline int z_impl_flash_ex_op(const struct device *dev, uint16_t code,
 				     const uintptr_t in, void *out)
 {


### PR DESCRIPTION
changes enables flash driver to provides api interface to send reset memory spi command to the spi flash. The reset memory command would bring the SPI flash to its default power-on state and loose all the volatile register settings.
Flash reset is needed when more than one masters accessing the flash chip in a shared mode.