### PR TITLE
Build system: disable `OUTPUT_DISASSEMBLY` by default

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -507,7 +507,6 @@ config OUTPUT_SYMBOLS
 
 config OUTPUT_DISASSEMBLY
 	bool "Create a disassembly file"
-	default y
 	help
 	  Create an .lst file with the assembly listing of the firmware.
 


### PR DESCRIPTION
This on-by-default option takes the majority of "link" time. If people need the disassembly, they can turn it on.

Incremental builds of the bluetooth tester app:

```bash
west build -b nrf52840dk_nrf52840 zephyr/tests/bluetooth/shell
touch zephyr/subsys/bluetooth/shell/bt.c
time west build -b nrf52840dk_nrf52840
```

```
Before:
real    0m6,621s
user    0m6,430s
sys     0m0,175s

After:
real    0m1,011s
user    0m0,840s
sys     0m0,170s
```

```bash
rm -rf build
time west build -p -b nrf52840dk_nrf52840 zephyr/tests/bluetooth/shell
```

```
Before:
real    0m9,726s
user    0m11,735s
sys     0m2,665s

After:
real    0m4,545s
user    0m8,006s
sys     0m2,723s
```