### PR TITLE
net: coap: Use 64bit timestamps

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -260,6 +260,18 @@ Drivers and Sensors
 Networking
 **********
 
+* CoAP:
+
+  * Use 64 bit timer values for calculating transmission timeouts. This fixes potential problems for
+    devices that stay on for more than 49 days when the 32 bit uptime counter might roll over and
+    cause CoAP packets to not timeout at all on this event.
+
+* LwM2M:
+
+  * Added support for tickless mode. This removes the 500 ms timeout from the socket loop
+    so the engine does not constantly wake up the CPU. This can be enabled by
+    :kconfig:option:`CONFIG_LWM2M_TICKLESS`.
+
 * Wi-Fi
   * Added Passive scan support.
   * The Wi-Fi scan API updated with Wi-Fi scan parameter to allow scan mode selection.

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -269,7 +269,7 @@ typedef int (*coap_reply_t)(const struct coap_packet *response,
  */
 struct coap_pending {
 	struct sockaddr addr;
-	uint32_t t0;
+	int64_t t0;
 	uint32_t timeout;
 	uint16_t id;
 	uint8_t *data;

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -954,8 +954,8 @@ end:
 static void schedule_next_retransmission(void)
 {
 	struct coap_pending *pending;
-	int32_t remaining;
-	uint32_t now = k_uptime_get_32();
+	int64_t remaining;
+	int64_t now = k_uptime_get();
 
 	/* Get the first pending retransmission to expire after cycling. */
 	pending = coap_pending_next_to_expire(pendings, NUM_PENDINGS);

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1287,7 +1287,7 @@ int coap_pending_init(struct coap_pending *pending,
 
 	pending->data = request->data;
 	pending->len = request->offset;
-	pending->t0 = k_uptime_get_32();
+	pending->t0 = k_uptime_get();
 	pending->retries = retries;
 
 	return 0;
@@ -1382,7 +1382,7 @@ struct coap_pending *coap_pending_next_to_expire(
 {
 	struct coap_pending *p, *found = NULL;
 	size_t i;
-	uint32_t expiry, min_expiry;
+	int64_t expiry, min_expiry = INT64_MAX;
 
 	for (i = 0, p = pendings; i < len; i++, p++) {
 		if (!p->timeout) {
@@ -1391,7 +1391,7 @@ struct coap_pending *coap_pending_next_to_expire(
 
 		expiry = p->t0 + p->timeout;
 
-		if (!found || (int32_t)(expiry - min_expiry) < 0) {
+		if (expiry < min_expiry) {
 			min_expiry = expiry;
 			found = p;
 		}

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -368,7 +368,6 @@ static int64_t retransmit_request(struct lwm2m_ctx *client_ctx, const int64_t ti
 			continue;
 		}
 
-		/* TODO: will roll over in 47 days */
 		remaining = p->t0 + p->timeout;
 		if (remaining < timestamp) {
 			msg = find_msg(p, NULL);


### PR DESCRIPTION
Use 64bit timestamps from k_uptime_get() so they don't roll over during the expected device lifetime.

Fixes #60826