### PR TITLE
ITE: drivers/i2c: Channel C/i2c2 cannot use FIFO mode

### DIFF
--- a/drivers/i2c/Kconfig.it8xxx2
+++ b/drivers/i2c/Kconfig.it8xxx2
@@ -19,8 +19,8 @@ config I2C_IT8XXX2_FIFO_MODE
 	  This is an option to enable FIFO mode which can reduce
 	  the time between each byte to improve the I2C bus clock
 	  stretching during I2C transaction.
-	  The I2C controller supports two 32-bytes FIFOs, FIFO2
-	  only supports one channel of B or C.
+	  The I2C controller supports two 32-bytes FIFOs,
+	  FIFO1 supports channel A. FIFO2 supports channel B.
 	  I2C FIFO mode of it8xxx2 can support I2C APIs including:
 	  i2c_write(), i2c_read(), i2c_burst_read.
 

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -1232,9 +1232,18 @@ static const struct i2c_driver_api i2c_it8xxx2_driver_api = {
 };
 
 #ifdef CONFIG_I2C_IT8XXX2_FIFO_MODE
-BUILD_ASSERT(!((DT_INST_PROP(SMB_CHANNEL_B, fifo_enable) == true) &&
-	     (DT_INST_PROP(SMB_CHANNEL_C, fifo_enable) == true)),
-	     "Channel B and C cannot support FIFO mode at the same time.");
+/*
+ * Sometimes, channel C may write wrong register to the target device.
+ * This issue occurs when FIFO2 is enabled on channel C. The problem
+ * arises because FIFO2 is shared between channel B and channel C.
+ * FIFO2 will be disabled when data access is completed, at which point
+ * FIFO2 is set to the default configuration for channel B.
+ * The byte counter of FIFO2 may be affected by channel B. There is a chance
+ * that channel C may encounter wrong register being written due to FIFO2
+ * byte counter wrong write after channel B's write operation.
+ */
+BUILD_ASSERT((DT_INST_PROP(SMB_CHANNEL_C, fifo_enable) == false),
+	     "Channel C cannot use FIFO mode.");
 #endif
 
 #define I2C_ITE_IT8XXX2_INIT(inst)                                              \

--- a/dts/bindings/i2c/ite,it8xxx2-i2c.yaml
+++ b/dts/bindings/i2c/ite,it8xxx2-i2c.yaml
@@ -12,4 +12,4 @@ properties:
     type: boolean
     description: |
       FIFO1 supports channel A.
-      FIFO2 only supports one channel of B or C.
+      FIFO2 supports channel B.

--- a/dts/riscv/ite/it81xx2.dtsi
+++ b/dts/riscv/ite/it81xx2.dtsi
@@ -362,7 +362,7 @@
 			scl-gpios = <&gpioc 1 0>;
 			sda-gpios = <&gpioc 2 0>;
 			clock-gate-offset = <CGC_OFFSET_SMBB>;
-			/delete-property/ fifo-enable;   /* FIFO2 */
+			fifo-enable;   /* FIFO2 */
 		};
 
 		i2c2: i2c@f01cc0 {
@@ -378,7 +378,7 @@
 			scl-gpios = <&gpiof 6 0>;
 			sda-gpios = <&gpiof 7 0>;
 			clock-gate-offset = <CGC_OFFSET_SMBC>;
-			fifo-enable;   /* FIFO2 */
+			/delete-property/ fifo-enable;   /* FIFO2 */
 		};
 
 		i2c3: i2c@f03680 {


### PR DESCRIPTION
Sometimes, channel C may write wrong register to the target device. This issue occurs when FIFO2 is enabled on channel C. The problem arises because FIFO2 is shared between channel B and channel C. 
FIFO2 will be disabled when data access is completed, at which point FIFO2 is set to the default configuration for channel B. 
The byte counter of FIFO2 may be affected by channel B. There is a chance that channel C may encounter wrong register being written due to the FIFO2 byte counter wrong write after channel B's write operation.

The current workaround is that channel C cannot use FIFO mode.