### PR TITLE
tests: build_all: sensors: drop a bunch of redundant status = okay

### DIFF
--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -14,20 +14,17 @@ test_i2c_adt7420: adt7420@0 {
 	compatible = "adi,adt7420";
 	reg = <0x0>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_adxl345: adxl345@1 {
 	compatible = "adi,adxl345";
 	reg = <0x1>;
-	status = "okay";
 };
 
 test_i2c_adxl372: adxl372@2 {
 	compatible = "adi,adxl372";
 	reg = <0x2>;
 	int1-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_ccs811: ccs811@3 {
@@ -36,32 +33,27 @@ test_i2c_ccs811: ccs811@3 {
 	wake-gpios = <&test_gpio 0 0>;
 	reset-gpios = <&test_gpio 0 0>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_ens210: ens210@4 {
 	compatible = "ams,ens210";
 	reg = <0x4>;
-	status = "okay";
 };
 
 test_i2c_iaqcore: iaqcore@5 {
 	compatible = "ams,iaqcore";
 	reg = <0x5>;
-	status = "okay";
 };
 
 test_i2c_bme280: bme280@6 {
 	compatible = "bosch,bme280";
 	reg = <0x6>;
-	status = "okay";
 };
 
 test_i2c_apds9960: apds9960@7 {
 	compatible = "avago,apds9960";
 	reg = <0x7>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_bma280: bma280@8 {
@@ -69,65 +61,55 @@ test_i2c_bma280: bma280@8 {
 	reg = <0x8>;
 	int1-gpios = <&test_gpio 0 0>;
 	/* is-bmc150; */
-	status = "okay";
 };
 
 test_i2c_bmc150_magn: bmc150_magn@9 {
 	compatible = "bosch,bmc150_magn";
 	reg = <0x9>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_ak8975: ak8975@a {
 	compatible = "asahi-kasei,ak8975";
 	reg = <0xa>;
-	status = "okay";
 };
 
 test_i2c_bme680: bme680@b {
 	compatible = "bosch,bme680";
 	reg = <0xb>;
-	status = "okay";
 };
 
 test_i2c_bmg160: bmg160@c {
 	compatible = "bosch,bmg160";
 	reg = <0xc>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_bmm150: bmm150@d {
 	compatible = "bosch,bmm150";
 	reg = <0xd>;
-	status = "okay";
 };
 
 test_i2c_hmc5883l: hmc5883l@e {
 	compatible = "honeywell,hmc5883l";
 	reg = <0xe>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_hp206c: hp206c@f {
 	compatible = "hoperf,hp206c";
 	reg = <0xf>;
-	status = "okay";
 };
 
 test_i2c_th02: th02@10 {
 	compatible = "hoperf,th02";
 	reg = <0x10>;
-	status = "okay";
 };
 
 test_i2c_mpu6050: mpu6050@11 {
 	compatible = "invensense,mpu6050";
 	reg = <0x11>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_mpu9250: mpu9250@12 {
@@ -139,7 +121,6 @@ test_i2c_mpu9250: mpu9250@12 {
 	gyro-fs = <250>;
 	accel-fs = <2>;
 	accel-dlpf="5.05";
-	status = "okay";
 };
 
 test_i2c_ina219: ina219@13 {
@@ -151,46 +132,39 @@ test_i2c_ina219: ina219@13 {
 	badc = <13>;
 	shunt-milliohm = <100>;
 	lsb-microamp = <10>;
-	status = "okay";
 };
 
 test_i2c_isl29035: isl29035@14 {
 	compatible = "isil,isl29035";
 	reg = <0x14>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_max30101: max30101@15 {
 	compatible = "maxim,max30101";
 	reg = <0x15>;
-	status = "okay";
 };
 
 test_i2c_max44009: max44009@16 {
 	compatible = "maxim,max44009";
 	reg = <0x16>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_ms5607: ms5607@17 {
 	compatible = "meas,ms5607";
 	reg = <0x17>;
-	status = "okay";
 };
 
 test_i2c_ms5837: ms5837@18 {
 	compatible = "meas,ms5837";
 	reg = <0x18>;
-	status = "okay";
 };
 
 test_i2c_mcp9808: mcp9808@19 {
 	compatible = "microchip,mcp9808";
 	reg = <0x19>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_fxas21002: fxas21002@1a {
@@ -198,7 +172,6 @@ test_i2c_fxas21002: fxas21002@1a {
 	reg = <0x1a>;
 	int1-gpios = <&test_gpio 0 0>;
 	int2-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_fxos8700: fxos8700@1b {
@@ -207,42 +180,36 @@ test_i2c_fxos8700: fxos8700@1b {
 	reset-gpios = <&test_gpio 0 0>;
 	int1-gpios = <&test_gpio 0 0>;
 	int2-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_amg88xx: amg88xx@1c {
 	compatible = "panasonic,amg88xx";
 	reg = <0x1c>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_sx9500: sx9500@1d {
 	compatible = "semtech,sx9500";
 	reg = <0x1d>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_sgp40: sgp40@1e {
 	compatible = "sensirion,sgp40";
 	reg = <0x1e>;
 	enable-selftest;
-	status = "okay";
 };
 
 test_i2c_sht3xd: sht3xd@1f {
 	compatible = "sensirion,sht3xd";
 	reg = <0x1f>;
 	alert-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_sht4xd: sht4x@20 {
 	compatible = "sensirion,sht4x";
 	reg = <0x20>;
 	repeatability = <2>;
-	status = "okay";
 };
 
 test_i2c_shtc3: SHTC3@21 {
@@ -251,59 +218,50 @@ test_i2c_shtc3: SHTC3@21 {
 	chip = "shtc3";
 	measure-mode = "normal";
 	clock-stretching;
-	status = "okay";
 };
 
 test_i2c_si7006: si7006@22 {
 	compatible = "silabs,si7006";
 	reg = <0x22>;
-	status = "okay";
 };
 
 test_i2c_si7055: si7055@23 {
 	compatible = "silabs,si7055";
 	reg = <0x23>;
-	status = "okay";
 };
 
 test_i2c_si7060: si7060@24 {
 	compatible = "silabs,si7060";
 	reg = <0x24>;
-	status = "okay";
 };
 
 test_i2c_si7210: si7010@25 {
 	compatible = "silabs,si7210";
 	reg = <0x25>;
-	status = "okay";
 };
 
 test_i2c_hts221: hts221@26 {
 	compatible = "st,hts221";
 	reg = <0x26>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_iis2dlpc: iis2dlpc@27 {
 	compatible = "st,iis2dlpc";
 	reg = <0x27>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_iis2mdc: iis2mdc@28 {
 	compatible = "st,iis2mdc";
 	reg = <0x28>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_ism330dhcx: ism330dhcx@29 {
 	compatible = "st,ism330dhcx";
 	reg = <0x29>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_lis2dh: lis2dh@2a {
@@ -311,7 +269,6 @@ test_i2c_lis2dh: lis2dh@2a {
 	reg = <0x2a>;
 	irq-gpios = <&test_gpio 0 0>;
 	/* disconnect-sdo-sa0-pull-up; */
-	status = "okay";
 };
 
 test_i2c_lis2dh12: lis2dh12@2b {
@@ -325,21 +282,18 @@ test_i2c_lis2ds12: lis2ds12@2c {
 	compatible = "st,lis2ds12";
 	reg = <0x2c>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_lis2dw12: lis2dw12@2d {
 	compatible = "st,lis2dw12";
 	reg = <0x2d>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_lis2mdl: lis2mdl@2e {
 	compatible = "st,lis2mdl";
 	reg = <0x2e>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_lis3dh: lis3dh@2f {
@@ -353,26 +307,22 @@ test_i2c_lis3mdl_magn: lis3mdl-magn@30 {
 	compatible = "st,lis3mdl-magn";
 	reg = <0x30>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_lps22hb_press: lps22hb-press@31 {
 	compatible = "st,lps22hb-press";
 	reg = <0x31>;
-	status = "okay";
 };
 
 test_i2c_lps22hh: lps22hh@32 {
 	compatible = "st,lps22hh";
 	reg = <0x32>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_lps25hb_press: lps25hb-press@33 {
 	compatible = "st,lps25hb-press";
 	reg = <0x33>;
-	status = "okay";
 };
 
 test_i2c_lsm303agr_accel: lsm303agr-accel@34 {
@@ -394,118 +344,100 @@ test_i2c_lsm303dlhc_accel: lsm303dlhc-accel@35 {
 test_i2c_lsm303dlhc_magn: lsm303dlhc-magn@36 {
 	compatible = "st,lsm303dlhc-magn";
 	reg = <0x36>;
-	status = "okay";
 };
 
 test_i2c_lsm6ds0: lsm6ds0@37 {
 	compatible = "st,lsm6ds0";
 	reg = <0x37>;
-	status = "okay";
 };
 
 test_i2c_lsm6dsl: lsm6dsl@38 {
 	compatible = "st,lsm6dsl";
 	reg = <0x38>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_lsm6dso: lsm6dso@39 {
 	compatible = "st,lsm6dso";
 	reg = <0x39>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_lsm9ds0_gyro: lsm9ds0-gyro@3a {
 	compatible = "st,lsm9ds0-gyro";
 	reg = <0x3a>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_lsm9ds0_mfd: lsm9ds0-mfd@3b {
 	compatible = "st,lsm9ds0-mfd";
 	reg = <0x3b>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_stts751: stts751@3c {
 	compatible = "st,stts751";
 	reg = <0x3c>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_vl53l0x: vl53l0x@3d {
 	compatible = "st,vl53l0x";
 	reg = <0x3d>;
 	xshut-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_hdc: hdc@3e {
 	compatible = "ti,hdc";
 	reg = <0x3e>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_hdc2010: hdc2010@3f {
 	compatible = "ti,hdc2010";
 	reg = <0x3f>;
-	status = "okay";
 };
 
 test_i2c_hdc2021: hdc2021@40 {
 	compatible = "ti,hdc2021";
 	reg = <0x40>;
-	status = "okay";
 };
 
 test_i2c_hdc2022: hdc2022@41 {
 	compatible = "ti,hdc2022";
 	reg = <0x41>;
-	status = "okay";
 };
 
 test_i2c_hdc2080: hdc2080@42 {
 	compatible = "ti,hdc2080";
 	reg = <0x42>;
-	status = "okay";
 };
 
 test_i2c_opt3001: opt3001@43 {
 	compatible = "ti,opt3001";
 	reg = <0x43>;
-	status = "okay";
 };
 
 test_i2c_tmp007: tmp007@44 {
 	compatible = "ti,tmp007";
 	reg = <0x44>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_tmp108: tmp108@45 {
 	compatible = "ti,tmp108";
 	reg = <0x45>;
 	alert-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_tmp112: tmp112@46 {
 	compatible = "ti,tmp112";
 	reg = <0x46>;
-	status = "okay";
 };
 
 test_i2c_tmp116: tmp116@47 {
 	compatible = "ti,tmp116";
 	reg = <0x47>;
-	status = "okay";
 };
 
 test_i2c_bq274xx: bq27xx@48 {
@@ -516,26 +448,22 @@ test_i2c_bq274xx: bq27xx@48 {
 	taper-current = <45>;
 	terminate-voltage = <3000>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_mpr: mpr@49 {
 	compatible = "honeywell,mpr";
 	reg = <0x49>;
-	status = "okay";
 };
 
 test_i2c_dps310: dps310@4a {
 	compatible = "infineon,dps310";
 	reg = <0x4a>;
-	status = "okay";
 };
 
 test_i2c_iis2dh: iis2dh@4b {
 	compatible = "st,iis2dh";
 	reg = <0x4b>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_iis2iclx: iis2iclx@4c {
@@ -543,7 +471,6 @@ test_i2c_iis2iclx: iis2iclx@4c {
 	reg = <0x4c>;
 	drdy-gpios = <&test_gpio 0 0>;
 	int-pin = <1>;
-	status = "okay";
 };
 
 test_i2c_wsen_hids: wsen_hids@4d {
@@ -551,7 +478,6 @@ test_i2c_wsen_hids: wsen_hids@4d {
 	reg = <0x4d>;
 	drdy-gpios = <&test_gpio 0 0>;
 	odr = "1";
-	status = "okay";
 };
 
 test_i2c_itds: itds@4e {
@@ -560,7 +486,6 @@ test_i2c_itds: itds@4e {
 	int-gpios = <&test_gpio 0 0>;
 	odr = "800";
 	op-mode = "high-perf";
-	status = "okay";
 };
 
 test_i2c_max17055: max17055@4f {
@@ -573,7 +498,6 @@ test_i2c_max17055: max17055@4f {
 	i-chg-term = <100>;
 	rsense-mohms = <5>;
 	v-empty = <3300>;
-	status = "okay";
 };
 
 test_i2c_max17262: max17262@50 {
@@ -586,27 +510,23 @@ test_i2c_max17262: max17262@50 {
 	empty-voltage = <3300>;
 	recovery-voltage = <3880>;
 	charge-voltage = <3600>;
-	status = "okay";
 };
 
 test_i2c_vcnl4040: vcnl4040@51 {
 	compatible = "vishay,vcnl4040";
 	reg = <0x51>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_bmi160: bmi160@52 {
 	compatible = "bosch,bmi160";
 	reg = <0x52>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_bmi270: bmi270@53 {
 	compatible = "bosch,bmi270";
 	reg = <0x53>;
-	status = "okay";
 };
 
 test_i2c_fdc2x1x: fdc2x1x@54 {
@@ -624,20 +544,17 @@ test_i2c_fdc2x1x: fdc2x1x@54 {
 		fin-sel = <2>;
 		inductance = <18>;
 	};
-	status = "okay";
 };
 
 test_i2c_bmp388: bmp388@55 {
 	compatible = "bosch,bmp388";
 	reg = <0x55>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_lm75: lm75@56 {
 	compatible = "lm75";
 	reg = <0x56>;
-	status = "okay";
 };
 
 test_i2c_ina230: ina230@57 {
@@ -649,14 +566,12 @@ test_i2c_ina230: ina230@57 {
 	mask = <0>;
 	alert-limit = <0>;
 	alert-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_lm77: lm77@58 {
 	compatible = "lm77";
 	reg = <0x58>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_ina231: ina231@59 {
@@ -668,7 +583,6 @@ test_i2c_ina231: ina231@59 {
 	mask = <0>;
 	alert-limit = <0>;
 	alert-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_ina237: ina237@5a {
@@ -680,13 +594,11 @@ test_i2c_ina237: ina237@5a {
 	rshunt-micro-ohms = <1000>;
 	alert-config = <0>;
 	alert-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_max31875: max31875@5b {
 	compatible = "maxim,max31875";
 	reg = <0x5b>;
-	status = "okay";
 };
 
 test_i2c_icp10125: icp10125@5c {
@@ -694,25 +606,21 @@ test_i2c_icp10125: icp10125@5c {
 	reg = <0x5c>;
 	temperature-measurement-mode = "normal";
 	pressure-measurement-mode = "normal";
-	status = "okay";
 };
 
 test_i2c_as5600: as5600@5d {
 	compatible = "ams,as5600";
 	reg = <0x5d>;
-	status = "okay";
 };
 
 test_i2c_bh1750: bh1750@5e {
 	compatible = "rohm,bh1750";
 	reg = <0x5e>;
-	status = "okay";
 };
 
 test_i2c_akm09918c: akm09918c@5f {
 	compatible = "asahi-kasei,akm09918c";
 	reg = <0x5f>;
-	status = "okay";
 };
 
 test_i2c_wsen_tids: wsen_tids@60 {
@@ -722,7 +630,6 @@ test_i2c_wsen_tids: wsen_tids@60 {
 	odr = <25>;
 	temp-high-threshold = <0>;
 	temp-low-threshold = <0>;
-	status = "okay";
 };
 
 test_i2c_vl53l1x: vl53l1x@61 {
@@ -730,7 +637,6 @@ test_i2c_vl53l1x: vl53l1x@61 {
 	reg = <0x61>;
 	int-gpios = <&test_gpio 0 0>;
 	xshut-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_tmd2620: tmd2620@62 {
@@ -745,7 +651,6 @@ test_i2c_tmd2620: tmd2620@62 {
 	proximity-led-drive-strength = <4>;
 	proximity-interrupt-filter = <0>;
 	wait-time-factor = <0>;
-	status = "okay";
 };
 
 test_i2c_wsen_pads: wsen_pads@63 {
@@ -753,28 +658,24 @@ test_i2c_wsen_pads: wsen_pads@63 {
 	reg = <0x63>;
 	drdy-gpios = <&test_gpio 0 0>;
 	odr = <1>;
-	status = "okay";
 };
 
 test_i2c_s11059: s11059@64 {
 	compatible = "hamamatsu,s11059";
 	reg = <0x64>;
 	integration-time = <546000>;
-	status = "okay";
 };
 
 test_i2c_wsen_pdus: wsen_pdus@65 {
 	compatible = "we,wsen-pdus";
 	reg = <0x65>;
 	sensor-type = <3>;
-	status = "okay";
 };
 
 test_i2c_veml7700: veml7700@66 {
 	compatible = "vishay,veml7700";
 	reg = <0x66>;
 	psm-mode = <0x03>;
-	status = "okay";
 };
 
 test_i2c_ina3221: ina3221@67 {
@@ -785,41 +686,35 @@ test_i2c_ina3221: ina3221@67 {
 	conv-time-bus = <7>;
 	conv-time-shunt = <7>;
 	avg-mode = <2>;
-	status = "okay";
 };
 
 test_i2c_lsm6dso16is: lsm6dso16is@68 {
 	compatible = "st,lsm6dso16is";
 	reg = <0x68>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_lsm6dsv16x: lsm6dsv16x@69 {
 	compatible = "st,lsm6dsv16x";
 	reg = <0x69>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_mcp9600: mcp9600@6a {
 	compatible = "microchip,mcp9600";
 	reg = <0x6a>;
-	status = "okay";
 };
 
 test_i2c_tcs3400: tcs3400@6b {
 	compatible = "ams,tcs3400";
 	reg = <0x6b>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_tcn75a: tcn75a@6c {
 	compatible = "microchip,tcn75a";
 	reg = <0x6c>;
 	alert-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_i2c_bmi08x_accel: bmi08x@6d {

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -15,7 +15,6 @@ test_spi_adxl362: adxl362@0 {
 	reg = <0x0>;
 	spi-max-frequency = <0>;
 	int1-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_adxl372: adxl372@1 {
@@ -23,14 +22,12 @@ test_spi_adxl372: adxl372@1 {
 	reg = <0x1>;
 	spi-max-frequency = <0>;
 	int1-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_bme280: bme280@2 {
 	compatible = "bosch,bme280";
 	reg = <0x2>;
 	spi-max-frequency = <0>;
-	status = "okay";
 };
 
 test_spi_bmi160: bmi160@3 {
@@ -38,14 +35,12 @@ test_spi_bmi160: bmi160@3 {
 	reg = <0x3>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_ms5607: ms5607@4 {
 	compatible = "meas,ms5607";
 	reg = <0x4>;
 	spi-max-frequency = <0>;
-	status = "okay";
 };
 
 test_spi_iis2dlpc: iis2dlpc@5 {
@@ -53,7 +48,6 @@ test_spi_iis2dlpc: iis2dlpc@5 {
 	reg = <0x5>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_iis2mdc: iis2mdc@6 {
@@ -61,7 +55,6 @@ test_spi_iis2mdc: iis2mdc@6 {
 	reg = <0x6>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_iis3dhhc: iis3dhhc@7 {
@@ -69,7 +62,6 @@ test_spi_iis3dhhc: iis3dhhc@7 {
 	reg = <0x7>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_ism330dhcx: ism330dhcx@8 {
@@ -77,7 +69,6 @@ test_spi_ism330dhcx: ism330dhcx@8 {
 	reg = <0x8>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_lis2dh: lis2dh@9 {
@@ -86,7 +77,6 @@ test_spi_lis2dh: lis2dh@9 {
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
 	/* disconnect-sdo-sa0-pull-up; */
-	status = "okay";
 };
 
 test_spi_lis2ds12: lis2ds12@a {
@@ -94,7 +84,6 @@ test_spi_lis2ds12: lis2ds12@a {
 	reg = <0xa>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_lis2dw12: lis2dw12@b {
@@ -102,7 +91,6 @@ test_spi_lis2dw12: lis2dw12@b {
 	reg = <0xb>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_lis2mdl: lis2mdl@c {
@@ -110,7 +98,6 @@ test_spi_lis2mdl: lis2mdl@c {
 	reg = <0xc>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_lps22hh: lps22hh@d {
@@ -118,7 +105,6 @@ test_spi_lps22hh: lps22hh@d {
 	reg = <0xd>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_lsm303agr_accel: lsm303agr-accel@e {
@@ -135,7 +121,6 @@ test_spi_lsm6dsl: lsm6dsl@f {
 	reg = <0xf>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_lsm6dso: lsm6dso@10 {
@@ -143,7 +128,6 @@ test_spi_lsm6dso: lsm6dso@10 {
 	reg = <0x10>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_iis2dh: iis2dh@11 {
@@ -151,7 +135,6 @@ test_spi_iis2dh: iis2dh@11 {
 	reg = <0x11>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_iis2iclx: iis2iclx@12 {
@@ -160,7 +143,6 @@ test_spi_iis2iclx: iis2iclx@12 {
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
 	int-pin = <1>;
-	status = "okay";
 };
 
 test_spi_icm42605: icm42605@13 {
@@ -168,21 +150,18 @@ test_spi_icm42605: icm42605@13 {
 	reg = <0x13>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_max6675: max6675@14 {
 	compatible = "maxim,max6675";
 	reg = <0x14>;
 	spi-max-frequency = <0>;
-	status = "okay";
 };
 
 test_spi_bmi270: bmi270@15 {
 	compatible = "bosch,bmi270";
 	reg = <0x15>;
 	spi-max-frequency = <0>;
-	status = "okay";
 };
 
 test_spi_bmp388: bmp388@16 {
@@ -190,14 +169,12 @@ test_spi_bmp388: bmp388@16 {
 	reg = <0x16>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_i3g4250d: i3g4250d@17 {
 	compatible = "st,i3g4250d";
 	reg = <0x17>;
 	spi-max-frequency = <0>;
-	status = "okay";
 };
 
 test_spi_icm42670: icm42670@18 {
@@ -209,14 +186,12 @@ test_spi_icm42670: icm42670@18 {
 	accel-fs = <16>;
 	gyro-hz = <800>;
 	gyro-fs = <2000>;
-	status = "okay";
 };
 
 test_spi_bme680: bme680@19 {
 	compatible = "bosch,bme680";
 	reg = <0x19>;
 	spi-max-frequency = <0>;
-	status = "okay";
 };
 
 test_spi_icm426888: icm42688@1a {
@@ -227,14 +202,12 @@ test_spi_icm426888: icm42688@1a {
 	accel-fs = <16>;
 	gyro-hz = <32000>;
 	gyro-fs = <2000>;
-	status = "okay";
 };
 
 test_spi_max31855: max31855@1b {
 	compatible = "maxim,max31855";
 	reg = <0x1b>;
 	spi-max-frequency = <0>;
-	status = "okay";
 };
 
 test_spi_max31865: max31865@1c {
@@ -246,14 +219,12 @@ test_spi_max31865: max31865@1c {
 	low-threshold = <6579>;
 	high-threshold = <32767>;
 	filter-50hz;
-	status = "okay";
 };
 
 test_spi_bmm150: bmm150@1d {
 	compatible = "bosch,bmm150";
 	reg = <0x1d>;
 	spi-max-frequency = <0>;
-	status = "okay";
 };
 
 test_spi_hts221: hts221@1e {
@@ -261,7 +232,6 @@ test_spi_hts221: hts221@1e {
 	reg = <0x1e>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_adt7310: adt7310@1f {
@@ -269,7 +239,6 @@ test_spi_adt7310: adt7310@1f {
 	reg = <0x1f>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_bmi323: bmi323@20 {
@@ -277,7 +246,6 @@ test_spi_bmi323: bmi323@20 {
 	reg = <0x20>;
 	spi-max-frequency = <8000000>;
 	int-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_lsm6dso16is: lsm6dso16is@21 {
@@ -285,7 +253,6 @@ test_spi_lsm6dso16is: lsm6dso16is@21 {
 	reg = <0x21>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_lsm6dsv16x: lsm6dsv16x@22 {
@@ -293,7 +260,6 @@ test_spi_lsm6dsv16x: lsm6dsv16x@22 {
 	reg = <0x22>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
-	status = "okay";
 };
 
 test_spi_bmi08x_accel: bmi08x@23 {


### PR DESCRIPTION
Drop a bunch of redundant `status = "okay"` entries. These have been added in 613c32b03f together with few other tweaks, but are not really needed as nodes are enabled by default.