### PR TITLE
bluetooth: host: convert conn address on identity resolution

### DIFF
--- a/tests/bsim/bluetooth/host/compile.sh
+++ b/tests/bsim/bluetooth/host/compile.sh
@@ -69,6 +69,7 @@ app=tests/bsim/bluetooth/host/security/bond_overwrite_denied compile
 app=tests/bsim/bluetooth/host/security/bond_per_connection compile
 app=tests/bsim/bluetooth/host/security/ccc_update compile
 app=tests/bsim/bluetooth/host/security/ccc_update conf_file=prj_2.conf compile
+app=tests/bsim/bluetooth/host/security/id_addr_update compile
 
 app=tests/bsim/bluetooth/host/id/settings compile
 

--- a/tests/bsim/bluetooth/host/security/id_addr_update/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(bsim_test_id_addr_update)
+
+target_sources(app PRIVATE
+	src/bs_bt_utils.c
+	src/central.c
+	src/main.c
+	src/peripheral.c
+)
+
+zephyr_include_directories(
+  ${BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  ${BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+  )

--- a/tests/bsim/bluetooth/host/security/id_addr_update/prj.conf
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/prj.conf
@@ -1,0 +1,26 @@
+CONFIG_BT=y
+CONFIG_BT_PERIPHERAL=y
+CONFIG_BT_CENTRAL=y
+CONFIG_BT_GATT_CLIENT=y
+
+# Both BT_SMP and BT_SETTINGS options need to be enabled to trigger
+# code execution of the bt_gatt_identity_resolved function.
+CONFIG_BT_SMP=y
+CONFIG_BT_SETTINGS=y
+
+# Enabled the dependencies of the BT_SETTINGS option.
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_NVS=y
+CONFIG_SETTINGS_NVS=y
+CONFIG_SETTINGS=y
+
+CONFIG_ASSERT=y
+CONFIG_BT_TESTING=y
+CONFIG_LOG=y
+
+CONFIG_BT_ID_MAX=3
+CONFIG_BT_MAX_PAIRED=2
+CONFIG_BT_MAX_CONN=2
+
+CONFIG_BT_PRIVACY=y

--- a/tests/bsim/bluetooth/host/security/id_addr_update/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/src/bs_bt_utils.c
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bs_bt_utils.h"
+
+BUILD_ASSERT(CONFIG_BT_MAX_PAIRED >= 2, "CONFIG_BT_MAX_PAIRED is too small.");
+BUILD_ASSERT(CONFIG_BT_ID_MAX >= 3, "CONFIG_BT_ID_MAX is too small.");
+BUILD_ASSERT(CONFIG_BT_MAX_CONN == 2, "CONFIG_BT_MAX_CONN should be equal to two.");
+BUILD_ASSERT(CONFIG_BT_GATT_CLIENT, "CONFIG_BT_GATT_CLIENT is disabled.");
+
+#define BS_SECONDS(dur_sec)    ((bs_time_t)dur_sec * 1000000)
+#define TEST_TIMEOUT_SIMULATED BS_SECONDS(60)
+
+void test_tick(bs_time_t HW_device_time)
+{
+	bs_trace_debug_time(0, "Simulation ends now.\n");
+	if (bst_result != Passed) {
+		bst_result = Failed;
+		bs_trace_error("Test did not pass before simulation ended.\n");
+	}
+}
+
+void test_init(void)
+{
+	bst_ticker_set_next_tick_absolute(TEST_TIMEOUT_SIMULATED);
+	bst_result = In_progress;
+}
+
+DEFINE_FLAG(flag_has_new_conn);
+struct bt_conn *new_conn;
+
+DEFINE_FLAG(flag_has_disconnected);
+
+void clear_conn(struct bt_conn *conn)
+{
+	if (new_conn == conn) {
+		new_conn = NULL;
+	}
+
+	ASSERT(conn, "Test error: No new_conn!\n");
+	bt_conn_unref(conn);
+}
+
+void wait_connected(struct bt_conn **conn)
+{
+	WAIT_FOR_FLAG(flag_has_new_conn);
+	UNSET_FLAG(flag_has_new_conn);
+
+	ASSERT(new_conn, "connection unpopulated.");
+	*conn = new_conn;
+	new_conn = NULL;
+}
+
+void wait_disconnected(void)
+{
+	WAIT_FOR_FLAG(flag_has_disconnected);
+	UNSET_FLAG(flag_has_disconnected);
+}
+
+static void print_conn_state_transition(const char *prefix, struct bt_conn *conn)
+{
+	int err;
+	struct bt_conn_info info;
+	char addr_str[BT_ADDR_LE_STR_LEN];
+
+	err = bt_conn_get_info(conn, &info);
+	ASSERT(!err, "Unexpected conn info result.");
+
+	bt_addr_le_to_str(info.le.dst, addr_str, sizeof(addr_str));
+	printk("%s: %s\n", prefix, addr_str);
+}
+
+static void disconnected(struct bt_conn *conn, uint8_t reason)
+{
+	print_conn_state_transition("Disonnected", conn);
+	SET_FLAG(flag_has_disconnected);
+}
+
+static void connected(struct bt_conn *conn, uint8_t err)
+{
+	ASSERT((!new_conn || (conn == new_conn)), "Unexpected new connection.");
+
+	if (!new_conn) {
+		new_conn = bt_conn_ref(conn);
+	}
+
+	if (err != 0) {
+		clear_conn(conn);
+		return;
+	}
+
+	print_conn_state_transition("Connected", conn);
+	SET_FLAG(flag_has_new_conn);
+}
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+	.connected = connected,
+	.disconnected = disconnected,
+};
+
+DEFINE_FLAG(flag_pairing_completed);
+
+static void pairing_complete(struct bt_conn *conn, bool bonded)
+{
+	print_conn_state_transition("Paired", conn);
+	SET_FLAG(flag_pairing_completed);
+}
+
+static struct bt_conn_auth_info_cb bt_conn_auth_info_cb = {
+	.pairing_complete = pairing_complete,
+};
+
+void set_security(struct bt_conn *conn, bt_security_t sec)
+{
+	int err;
+
+	err = bt_conn_set_security(conn, sec);
+	ASSERT(!err, "Err bt_conn_set_security %d", err);
+}
+
+void wait_pairing_completed(void)
+{
+	WAIT_FOR_FLAG(flag_pairing_completed);
+	UNSET_FLAG(flag_pairing_completed);
+}
+
+void bs_bt_utils_setup(void)
+{
+	int err;
+
+	err = bt_enable(NULL);
+	ASSERT(!err, "bt_enable failed.\n");
+	err = bt_conn_auth_info_cb_register(&bt_conn_auth_info_cb);
+	ASSERT(!err, "bt_conn_auth_info_cb_register failed.\n");
+
+	err = settings_load();
+	ASSERT(!err, "settings_load failed.\n");
+}
+
+static void scan_connect_to_first_result__device_found(const bt_addr_le_t *addr, int8_t rssi,
+						       uint8_t type, struct net_buf_simple *ad)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	int err;
+
+	/* We're only interested in connectable events */
+	if (type != BT_HCI_ADV_IND && type != BT_HCI_ADV_DIRECT_IND) {
+		FAIL("Unexpected advertisement type.");
+	}
+
+	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	printk("Got scan result, connecting.. dst %s, RSSI %d\n", addr_str, rssi);
+
+	err = bt_le_scan_stop();
+	ASSERT(!err, "Err bt_le_scan_stop %d", err);
+
+	err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, BT_LE_CONN_PARAM_DEFAULT, &new_conn);
+	ASSERT(!err, "Err bt_conn_le_create %d", err);
+}
+
+void scan_connect_to_first_result(void)
+{
+	int err;
+
+	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, scan_connect_to_first_result__device_found);
+	ASSERT(!err, "Err bt_le_scan_start %d", err);
+}
+
+void disconnect(struct bt_conn *conn)
+{
+	int err;
+
+	err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	ASSERT(!err, "Err bt_conn_disconnect %d", err);
+}
+
+void advertise_connectable(int id)
+{
+	int err;
+	struct bt_le_adv_param param = {};
+
+	param.id = id;
+	param.interval_min = 0x0020;
+	param.interval_max = 0x4000;
+	param.options |= BT_LE_ADV_OPT_ONE_TIME;
+	param.options |= BT_LE_ADV_OPT_CONNECTABLE;
+
+	err = bt_le_adv_start(&param, NULL, 0, NULL, 0);
+	ASSERT(!err, "Advertising failed to start (err %d)\n", err);
+}
+
+DEFINE_FLAG(flag_bas_ccc_subscribed);
+static uint8_t bas_level = 50;
+
+static void bas_ccc_cfg_changed(const struct bt_gatt_attr *attr,
+				uint16_t value)
+{
+	ARG_UNUSED(attr);
+
+	if (value == BT_GATT_CCC_NOTIFY) {
+		printk("BAS CCCD: notification enabled\n");
+		SET_FLAG(flag_bas_ccc_subscribed);
+	}
+}
+
+void wait_bas_ccc_subscription(void)
+{
+	WAIT_FOR_FLAG(flag_bas_ccc_subscribed);
+	UNSET_FLAG(flag_bas_ccc_subscribed);
+}
+
+static ssize_t bas_read(struct bt_conn *conn,
+			const struct bt_gatt_attr *attr, void *buf,
+			uint16_t len, uint16_t offset)
+{
+	uint8_t lvl8 = bas_level;
+
+	return bt_gatt_attr_read(conn, attr, buf, len, offset, &lvl8,
+				 sizeof(lvl8));
+}
+
+BT_GATT_SERVICE_DEFINE(bas,
+	BT_GATT_PRIMARY_SERVICE(BT_UUID_BAS),
+	BT_GATT_CHARACTERISTIC(BT_UUID_BAS_BATTERY_LEVEL,
+			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
+			       BT_GATT_PERM_READ, bas_read, NULL, &bas_level),
+	BT_GATT_CCC(bas_ccc_cfg_changed,
+		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
+);
+
+void bas_notify(struct bt_conn *conn)
+{
+	int err;
+
+	err = bt_gatt_notify(conn, &bas.attrs[2], &bas_level, sizeof(bas_level));
+	ASSERT(!err, "bt_gatt_notify failed (err %d)\n", err);
+}
+
+DEFINE_FLAG(flag_bas_has_notification);
+
+static uint8_t bas_notify_func(struct bt_conn *conn,
+			       struct bt_gatt_subscribe_params *params,
+			       const void *data, uint16_t length)
+{
+	const uint8_t *lvl8 = data;
+
+	if ((length == 1) && (*lvl8 == bas_level)) {
+		printk("BAS notification\n");
+		SET_FLAG(flag_bas_has_notification);
+	}
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+void wait_bas_notification(void)
+{
+	WAIT_FOR_FLAG(flag_bas_has_notification);
+	UNSET_FLAG(flag_bas_has_notification);
+}
+
+void bas_subscribe(struct bt_conn *conn)
+{
+	int err;
+	static struct bt_gatt_subscribe_params subscribe_params = {0};
+
+	subscribe_params.ccc_handle = bt_gatt_attr_get_handle(&bas.attrs[3]);
+	subscribe_params.value_handle = bt_gatt_attr_get_handle(&bas.attrs[2]);
+	subscribe_params.value = BT_GATT_CCC_NOTIFY;
+	subscribe_params.notify = bas_notify_func;
+
+	err = bt_gatt_subscribe(conn, &subscribe_params);
+	ASSERT(!err, "bt_gatt_subscribe failed (err %d)\n", err);
+}

--- a/tests/bsim/bluetooth/host/security/id_addr_update/src/bs_bt_utils.h
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/src/bs_bt_utils.h
@@ -1,0 +1,86 @@
+/**
+ * Common functions and helpers for BSIM GATT tests
+ *
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bs_tracing.h"
+#include "bs_types.h"
+#include "bstests.h"
+#include "time_machine.h"
+#include "zephyr/sys/__assert.h"
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/types.h>
+
+extern enum bst_result_t bst_result;
+
+#define DECLARE_FLAG(flag) extern atomic_t flag
+#define DEFINE_FLAG(flag)  atomic_t flag = (atomic_t) false
+#define SET_FLAG(flag)	   (void)atomic_set(&flag, (atomic_t) true)
+#define UNSET_FLAG(flag)   (void)atomic_set(&flag, (atomic_t) false)
+#define WAIT_FOR_FLAG(flag)                                                                        \
+	while (!(bool)atomic_get(&flag)) {                                                         \
+		(void)k_sleep(K_MSEC(1));                                                          \
+	}
+#define WAIT_FOR_FLAG_UNSET(flag)                                                                  \
+	while ((bool)atomic_get(&flag)) {                                                          \
+		(void)k_sleep(K_MSEC(1));                                                          \
+	}
+#define TAKE_FLAG(flag)                                                                            \
+	while (!(bool)atomic_cas(&flag, true, false)) {                                            \
+		(void)k_sleep(K_MSEC(1));                                                          \
+	}
+#define GET_FLAG(flag)                                                                             \
+	(bool)atomic_get(&flag)
+
+#define ASSERT(expr, ...)                                                                          \
+	do {                                                                                       \
+		if (!(expr)) {                                                                     \
+			FAIL(__VA_ARGS__);                                                         \
+		}                                                                                  \
+	} while (0)
+
+#define FAIL(...)                                                                                  \
+	do {                                                                                       \
+		bst_result = Failed;                                                               \
+		bs_trace_error_time_line(__VA_ARGS__);                                             \
+	} while (0)
+
+#define PASS(...)                                                                                  \
+	do {                                                                                       \
+		bst_result = Passed;                                                               \
+		bs_trace_info_time(1, __VA_ARGS__);                                                \
+	} while (0)
+
+void test_tick(bs_time_t HW_device_time);
+void test_init(void);
+
+void bs_bt_utils_setup(void);
+
+void clear_conn(struct bt_conn *conn);
+void wait_connected(struct bt_conn **conn);
+void wait_disconnected(void);
+void disconnect(struct bt_conn *conn);
+void scan_connect_to_first_result(void);
+void advertise_connectable(int id);
+
+void set_security(struct bt_conn *conn, bt_security_t sec);
+void wait_pairing_completed(void);
+
+void bas_subscribe(struct bt_conn *conn);
+void wait_bas_ccc_subscription(void);
+void bas_notify(struct bt_conn *conn);
+void wait_bas_notification(void);

--- a/tests/bsim/bluetooth/host/security/id_addr_update/src/central.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/src/central.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bs_bt_utils.h"
+#include "zephyr/bluetooth/addr.h"
+#include "zephyr/bluetooth/conn.h"
+
+#include <stdint.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+
+void central(void)
+{
+	bs_bt_utils_setup();
+
+	struct bt_conn *conn_a;
+	struct bt_conn *conn_b;
+
+	/* Connect to the first identity of the peripheral. */
+	scan_connect_to_first_result();
+	wait_connected(&conn_a);
+
+	/* Subscribe to battery notifications and wait on the first one. */
+	bas_subscribe(conn_a);
+	wait_bas_notification();
+
+	/* Connect to the second identity of the peripheral. */
+	scan_connect_to_first_result();
+	wait_connected(&conn_b);
+
+	/* Establish security with the second identity and resolve identity address. */
+	set_security(conn_b, BT_SECURITY_L2);
+	wait_pairing_completed();
+
+	/* Wait for notification from the first connection after identity address resolution. */
+	wait_bas_notification();
+
+	/* Disconnect the first identity of the peripheral. */
+	disconnect(conn_a);
+	wait_disconnected();
+	clear_conn(conn_a);
+
+	/* Disconnect the second identity of the peripheral. */
+	disconnect(conn_b);
+	wait_disconnected();
+	clear_conn(conn_b);
+
+	PASS("PASS\n");
+}

--- a/tests/bsim/bluetooth/host/security/id_addr_update/src/main.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/src/main.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bs_bt_utils.h"
+#include "bstests.h"
+
+void central(void);
+void peripheral(void);
+
+static const struct bst_test_instance test_to_add[] = {
+	{
+		.test_id = "central",
+		.test_post_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = central,
+	},
+	{
+		.test_id = "peripheral",
+		.test_post_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = peripheral,
+	},
+	BSTEST_END_MARKER,
+};
+
+static struct bst_test_list *install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_to_add);
+};
+
+bst_test_install_t test_installers[] = {install, NULL};
+
+int main(void)
+{
+	bst_main();
+	return 0;
+}

--- a/tests/bsim/bluetooth/host/security/id_addr_update/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/src/peripheral.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bs_bt_utils.h"
+#include "zephyr/bluetooth/addr.h"
+#include "zephyr/bluetooth/bluetooth.h"
+#include "zephyr/bluetooth/conn.h"
+#include "zephyr/toolchain/gcc.h"
+
+#include <stdint.h>
+#include <string.h>
+
+static void verify_equal_address(struct bt_conn *conn_a, struct bt_conn *conn_b)
+{
+	int err;
+	struct bt_conn_info info_a;
+	struct bt_conn_info info_b;
+
+	err = bt_conn_get_info(conn_a, &info_a);
+	ASSERT(!err, "Unexpected info_a result.");
+
+	err = bt_conn_get_info(conn_b, &info_b);
+	ASSERT(!err, "Unexpected info_b result.");
+
+	ASSERT(bt_addr_le_eq(info_a.le.dst, info_b.le.dst),
+	       "Conn A address is not equal with the conn B address");
+}
+
+void peripheral(void)
+{
+	bs_bt_utils_setup();
+
+	int id_a;
+	int id_b;
+
+	struct bt_conn *conn_a;
+	struct bt_conn *conn_b;
+
+	/* Create two identities that will simultaneously connect with the same central peer. */
+	id_a = bt_id_create(NULL, NULL);
+	ASSERT(id_a >= 0, "bt_id_create id_a failed (err %d)\n", id_a);
+
+	id_b = bt_id_create(NULL, NULL);
+	ASSERT(id_b >= 0, "bt_id_create id_b failed (err %d)\n", id_b);
+
+	/* Connect with the first identity. */
+	advertise_connectable(id_a);
+	wait_connected(&conn_a);
+
+	/* Send battery notification on the first connection. */
+	wait_bas_ccc_subscription();
+	bas_notify(conn_a);
+
+	/* Connect with the second identity. */
+	advertise_connectable(id_b);
+	wait_connected(&conn_b);
+
+	/* Wait for the pairing completed callback on the second identity. */
+	wait_pairing_completed();
+
+	/* Both connections should relate to the identity address of the same Central peer. */
+	verify_equal_address(conn_a, conn_b);
+
+	/* Send notification after identity address resolution to the first connection object. */
+	bas_notify(conn_a);
+
+	/* Disconnect the first identity. */
+	wait_disconnected();
+	clear_conn(conn_a);
+
+	/* Disconnect the second identity. */
+	wait_disconnected();
+	clear_conn(conn_b);
+
+	PASS("PASS\n");
+}

--- a/tests/bsim/bluetooth/host/security/id_addr_update/test_scripts/_compile.sh
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/test_scripts/_compile.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+
+# Read variable definitions output by _env.sh
+source "${bash_source_dir}/_env.sh"
+
+: "${BSIM_COMPONENTS_PATH:?BSIM_COMPONENTS_PATH must be defined}"
+: "${ZEPHYR_BASE:?ZEPHYR_BASE must be defined}"
+
+WORK_DIR="${WORK_DIR:-${ZEPHYR_BASE}/bsim_out}"
+BOARD="${BOARD:-nrf52_bsim}"
+BOARD_ROOT="${BOARD_ROOT:-${ZEPHYR_BASE}}"
+INCR_BUILD=1
+mkdir -p ${WORK_DIR}
+source ${ZEPHYR_BASE}/tests/bsim/compile.source
+app="tests/bsim/bluetooth/host/security/$test_name" compile

--- a/tests/bsim/bluetooth/host/security/id_addr_update/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/test_scripts/_env.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+
+: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+
+test_name="id_addr_update"
+bsim_bin="${BSIM_OUT_PATH}/bin"
+verbosity_level=2
+BOARD="${BOARD:-nrf52_bsim}"
+simulation_id="$test_name"
+central_exe="${bsim_bin}/bs_${BOARD}_tests_bsim_bluetooth_host_security_${test_name}_prj_conf"
+peripheral_exe="${central_exe}"
+
+function print_var {
+	# Print a shell-sourceable variable definition.
+	local var_name="$1"
+	local var_repr="${!var_name@Q}"
+	echo "$var_name=$var_repr"
+}
+
+print_var test_name
+print_var bsim_bin
+print_var verbosity_level
+print_var BOARD
+print_var simulation_id
+print_var central_exe
+print_var peripheral_exe

--- a/tests/bsim/bluetooth/host/security/id_addr_update/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/test_scripts/run_test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+
+# Read variable definitions output by _env.sh
+source "${bash_source_dir}/_env.sh"
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+EXECUTE_TIMEOUT=30
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute "$central_exe" \
+    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -RealEncryption=1
+
+Execute "$peripheral_exe" \
+    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -RealEncryption=1
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+    -D=2 -sim_length=60e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/61028

Fix an issue in the CCC configuration when the Peripheral device maintains two or more distinct connections on different identities with the same peer. The issue occurs when the local device performs the pairing and the bonding procedure on a connection associated with one of the Bluetooth identities. During the identity resolution, the peer address field in the CCC descriptor is converted from the RPA-type address to the Identity Address. However, the destination address on the remaining connection objects associated with other Bluetooth identities is not converted. Due to this, their CCC configuration is reset and GATT indications and notification fail to be sent even if the Central device subscribed to them.

Added necessary code to iterate over all connection objects during the identity resolution phase and aligned their destination address from the RPA-type to the Identity Address.