### PR TITLE
Avoid using of set/way cache instructions for ARM64

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -729,6 +729,13 @@ static inline void add_arm_mmu_region(struct arm_mmu_ptables *ptables,
 	}
 }
 
+static inline void inv_dcache_after_map_helper(void *virt, size_t size, uint32_t attrs)
+{
+	if (MT_TYPE(attrs) == MT_NORMAL || MT_TYPE(attrs) == MT_NORMAL_WT) {
+		sys_cache_data_invd_range(virt, size);
+	}
+}
+
 static void setup_page_tables(struct arm_mmu_ptables *ptables)
 {
 	unsigned int index;
@@ -767,6 +774,20 @@ static void setup_page_tables(struct arm_mmu_ptables *ptables)
 	}
 
 	invalidate_tlb_all();
+
+	for (index = 0U; index < ARRAY_SIZE(mmu_zephyr_ranges); index++) {
+		size_t size;
+
+		range = &mmu_zephyr_ranges[index];
+		size = POINTER_TO_UINT(range->end) - POINTER_TO_UINT(range->start);
+		inv_dcache_after_map_helper(range->start, size, range->attrs);
+	}
+
+	for (index = 0U; index < mmu_config.num_regions; index++) {
+		region = &mmu_config.mmu_regions[index];
+		inv_dcache_after_map_helper(UINT_TO_POINTER(region->base_va), region->size,
+					    region->attrs);
+	}
 }
 
 /* Translation table control register settings */
@@ -814,9 +835,6 @@ static void enable_mmu_el1(struct arm_mmu_ptables *ptables, unsigned int flags)
 
 	/* Ensure these changes are seen before MMU is enabled */
 	barrier_isync_fence_full();
-
-	/* Invalidate all data caches before enable them */
-	sys_cache_data_invd_all();
 
 	/* Enable the MMU and data cache */
 	val = read_sctlr_el1();
@@ -955,8 +973,19 @@ void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 		LOG_ERR("__arch_mem_map() returned %d", ret);
 		k_panic();
 	} else {
+		uint32_t mem_flags = flags & K_MEM_CACHE_MASK;
+
 		sync_domains((uintptr_t)virt, size);
 		invalidate_tlb_all();
+
+		switch (mem_flags) {
+		case K_MEM_CACHE_WB:
+		case K_MEM_CACHE_WT:
+			mem_flags = (mem_flags == K_MEM_CACHE_WB) ? MT_NORMAL : MT_NORMAL_WT;
+			inv_dcache_after_map_helper(virt, size, mem_flags);
+		default:
+			break;
+		}
 	}
 }
 
@@ -1077,6 +1106,7 @@ static int private_map(struct arm_mmu_ptables *ptables, const char *name,
 	__ASSERT(ret == 0, "add_map() returned %d", ret);
 	invalidate_tlb_all();
 
+	inv_dcache_after_map_helper(UINT_TO_POINTER(virt), size, attrs);
 	return ret;
 }
 

--- a/include/zephyr/arch/arm64/cache.h
+++ b/include/zephyr/arch/arm64/cache.h
@@ -139,96 +139,19 @@ done:
 	return 0;
 }
 
-/*
- * operation for all data cache
- * ops:  K_CACHE_INVD: invalidate
- *	 K_CACHE_WB: clean
- *	 K_CACHE_WB_INVD: clean and invalidate
- */
-static ALWAYS_INLINE int arm64_dcache_all(int op)
-{
-	uint32_t clidr_el1, csselr_el1, ccsidr_el1;
-	uint8_t loc, ctype, cache_level, line_size, way_pos;
-	uint32_t max_ways, max_sets, dc_val, set, way;
-
-	if (op != K_CACHE_INVD && op != K_CACHE_WB && op != K_CACHE_WB_INVD) {
-		return -ENOTSUP;
-	}
-
-	/* Data barrier before start */
-	barrier_dsync_fence_full();
-
-	clidr_el1 = read_clidr_el1();
-
-	loc = (clidr_el1 >> CLIDR_EL1_LOC_SHIFT) & CLIDR_EL1_LOC_MASK;
-	if (!loc) {
-		return 0;
-	}
-
-	for (cache_level = 0; cache_level < loc; cache_level++) {
-		ctype = (clidr_el1 >> CLIDR_EL1_CTYPE_SHIFT(cache_level))
-				& CLIDR_EL1_CTYPE_MASK;
-		/* No data cache, continue */
-		if (ctype < 2) {
-			continue;
-		}
-
-		/* select cache level */
-		csselr_el1 = cache_level << 1;
-		write_csselr_el1(csselr_el1);
-		barrier_isync_fence_full();
-
-		ccsidr_el1 = read_ccsidr_el1();
-		line_size = (ccsidr_el1 >> CCSIDR_EL1_LN_SZ_SHIFT
-				& CCSIDR_EL1_LN_SZ_MASK) + 4;
-		max_ways = (ccsidr_el1 >> CCSIDR_EL1_WAYS_SHIFT)
-				& CCSIDR_EL1_WAYS_MASK;
-		max_sets = (ccsidr_el1 >> CCSIDR_EL1_SETS_SHIFT)
-				& CCSIDR_EL1_SETS_MASK;
-		/* 32-log2(ways), bit position of way in DC operand */
-		way_pos = __builtin_clz(max_ways);
-
-		for (set = 0; set <= max_sets; set++) {
-			for (way = 0; way <= max_ways; way++) {
-				/* way number, aligned to pos in DC operand */
-				dc_val = way << way_pos;
-				/* cache level, aligned to pos in DC operand */
-				dc_val |= csselr_el1;
-				/* set number, aligned to pos in DC operand */
-				dc_val |= set << line_size;
-
-				if (op == K_CACHE_INVD) {
-					dc_ops("isw", dc_val);
-				} else if (op == K_CACHE_WB_INVD) {
-					dc_ops("cisw", dc_val);
-				} else if (op == K_CACHE_WB) {
-					dc_ops("csw", dc_val);
-				}
-			}
-		}
-	}
-
-	/* Restore csselr_el1 to level 0 */
-	write_csselr_el1(0);
-	barrier_dsync_fence_full();
-	barrier_isync_fence_full();
-
-	return 0;
-}
-
 static ALWAYS_INLINE int arch_dcache_flush_all(void)
 {
-	return arm64_dcache_all(K_CACHE_WB);
+	return -ENOTSUP;
 }
 
 static ALWAYS_INLINE int arch_dcache_invd_all(void)
 {
-	return arm64_dcache_all(K_CACHE_INVD);
+	return -ENOTSUP;
 }
 
 static ALWAYS_INLINE int arch_dcache_flush_and_invd_all(void)
 {
-	return arm64_dcache_all(K_CACHE_WB_INVD);
+	return -ENOTSUP;
 }
 
 static ALWAYS_INLINE int arch_dcache_flush_range(void *addr, size_t size)


### PR DESCRIPTION
Architecturally, Set/Way operations are not guaranteed to affect all caches prior to the PoC, and may require other IMPLEMENTATION DEFINED maintenance (e.g. MMIO control of system-level caches).

First of all this patch was designed for Xen domain Zephyr build, set/way ops are not easily virtualized by Xen. S/W emulation is disabled, because IP-MMU is active for Dom0. IP-MMU is a IO-MMU made by Renesas, as any good IO-MMU, it shares page-tables with CPU. Trying to emulate S/W with IP-MMU active will lead to IO-MMU faults. So if we build Zephyr as a Xen Initial domain, it won't work with cache management support enabled.
    
Exposing set/way cache maintenance to a virtual machine is unsafe, not least because the instructions are not permission-checked, but also because they are not broadcast between CPUs.

VA data invalidate invoked after every mapping instead of using set/way instructions on init MMU. So, it was easy to delete sys_cache_data_invd_all from enable MMU function, becase every adding of a new memory region to xlat tabes will cause invalidating of this memory and in this way we sure that there are not any stale data inside.

-----
Set/way operations are not guaranteed to affect all caches prior to the PoC, and may require other IMPLEMENTATION DEFINED maintenance.

Delete arm64_dcache_all function, because it is unused and in order to avoid future usage of set/way cache maintenance instructions. It isn't safe to use them.