### PR TITLE
Introduce comparison for timepoint and timeout values

### DIFF
--- a/include/zephyr/sys_clock.h
+++ b/include/zephyr/sys_clock.h
@@ -252,6 +252,24 @@ static inline uint64_t sys_clock_timeout_end_calc(k_timeout_t timeout)
 	return tp.tick;
 }
 
+/**
+ * @brief Compare two timepoint values.
+ *
+ * This function is used to compare two timepoint values.
+ *
+ * @param a Timepoint to compare
+ * @param b Timepoint to compare against.
+ * @return zero if both timepoints are the same. Negative value if timepoint @a a is before
+ * timepoint @a b, positive otherwise.
+ */
+static inline int sys_timepoint_cmp(k_timepoint_t a, k_timepoint_t b)
+{
+	if (a.tick == b.tick) {
+		return 0;
+	}
+	return a.tick < b.tick ? -1 : 1;
+}
+
 #else
 
 /*
@@ -274,6 +292,14 @@ static inline k_timeout_t sys_timepoint_timeout(k_timepoint_t timepoint)
 	return timepoint.wait ? Z_FOREVER : Z_TIMEOUT_NO_WAIT;
 }
 
+static inline int sys_timepoint_cmp(k_timepoint_t a, k_timepoint_t b)
+{
+	if (a.wait == b.wait) {
+		return 0;
+	}
+	return b.wait ? -1 : 1;
+}
+
 #endif
 
 /**
@@ -288,6 +314,7 @@ static inline bool sys_timepoint_expired(k_timepoint_t timepoint)
 {
 	return K_TIMEOUT_EQ(sys_timepoint_timeout(timepoint), Z_TIMEOUT_NO_WAIT);
 }
+
 
 #ifdef __cplusplus
 }

--- a/tests/kernel/timer/timepoints/src/main.c
+++ b/tests/kernel/timer/timepoints/src/main.c
@@ -35,4 +35,44 @@ ZTEST(timepoints, test_timepoint_api)
 	zassert_true(K_TIMEOUT_EQ(remaining, K_NO_WAIT));
 }
 
+ZTEST(timepoints, test_comparison)
+{
+	k_timepoint_t a, b;
+
+	a = sys_timepoint_calc(K_NO_WAIT);
+	b = a;
+	zassert_true(sys_timepoint_cmp(a, b) == 0);
+	zassert_true(sys_timepoint_cmp(b, a) == 0);
+
+	a = sys_timepoint_calc(K_FOREVER);
+	b = a;
+	zassert_true(sys_timepoint_cmp(a, b) == 0);
+	zassert_true(sys_timepoint_cmp(b, a) == 0);
+
+	a = sys_timepoint_calc(K_NO_WAIT);
+	b = sys_timepoint_calc(K_MSEC(1));
+	zassert_true(sys_timepoint_cmp(a, b) < 0);
+	zassert_true(sys_timepoint_cmp(b, a) > 0);
+
+	a = sys_timepoint_calc(K_MSEC(1));
+	b = sys_timepoint_calc(K_FOREVER);
+	zassert_true(sys_timepoint_cmp(a, b) < 0);
+	zassert_true(sys_timepoint_cmp(b, a) > 0);
+
+	a = sys_timepoint_calc(K_MSEC(1));
+	b = a;
+	zassert_true(sys_timepoint_cmp(a, b) == 0);
+	zassert_true(sys_timepoint_cmp(b, a) == 0);
+
+	a = sys_timepoint_calc(K_MSEC(100));
+	b = sys_timepoint_calc(K_MSEC(200));
+	zassert_true(sys_timepoint_cmp(a, b) < 0);
+	zassert_true(sys_timepoint_cmp(b, a) > 0);
+
+	a = sys_timepoint_calc(K_NO_WAIT);
+	b = sys_timepoint_calc(K_FOREVER);
+	zassert_true(sys_timepoint_cmp(a, b) < 0);
+	zassert_true(sys_timepoint_cmp(b, a) > 0);
+}
+
 ZTEST_SUITE(timepoints, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Introduce new API to compare two timepoint values.

As I was proposed to convert CoAP library to use the new Timepoint API I immediately noticed that it does not have any function to compare two timepoint values to distinct which one is going to expire sooner.

I believe at least LwM2M and CoAP engines (and probably many others) hold list of multiple packets (events) that each have some expiration time in the future. The engine needs to go through this list, find the timestamp/timepoint that is going to expire soon, and sleep until the expiration is going to happen.

I believe with this new functions I'm able to convert then engine to use the timepoint.

```c
/**
 * @brief Compare two timepoint values.
 *
 * This function is used to compare two timepoint values.
 *
 * @param a Timepoint to compare
 * @param b Timepoint to compare against.
 * @return zero if both timepoints are the same. Negative value if timepoint @a a is before
 * timepoint @a b, positive otherwise.
 */
static inline int sys_timepoint_cmp(k_timepoint_t a, k_timepoint_t b)
```

As this is completely out of my field, I create this PR as a draft so you can provide any feedback and we can work out the idea or drop it, if this does not fit.
