### PR TITLE
sensor: max17055: support fetching individual channels + other fixes

### DIFF
--- a/drivers/sensor/max17055/max17055.c
+++ b/drivers/sensor/max17055/max17055.c
@@ -27,7 +27,7 @@ LOG_MODULE_REGISTER(max17055, CONFIG_SENSOR_LOG_LEVEL);
  * @param valp Place to put the value on success
  * @return 0 if successful, or negative error code from I2C API
  */
-static int max17055_reg_read(const struct device *dev, int reg_addr,
+static int max17055_reg_read(const struct device *dev, uint8_t reg_addr,
 			     int16_t *valp)
 {
 	const struct max17055_config *config = dev->config;
@@ -44,13 +44,13 @@ static int max17055_reg_read(const struct device *dev, int reg_addr,
 	return 0;
 }
 
-static int max17055_reg_write(const struct device *dev, int reg_addr,
+static int max17055_reg_write(const struct device *dev, uint8_t reg_addr,
 			      uint16_t val)
 {
 	const struct max17055_config *config = dev->config;
 	uint8_t buf[3];
 
-	buf[0] = (uint8_t)reg_addr;
+	buf[0] = reg_addr;
 	sys_put_le16(val, &buf[1]);
 
 	return i2c_write_dt(&config->i2c, buf, sizeof(buf));

--- a/drivers/sensor/max17055/max17055.c
+++ b/drivers/sensor/max17055/max17055.c
@@ -39,7 +39,7 @@ static int max17055_reg_read(const struct device *dev, int reg_addr,
 		LOG_ERR("Unable to read register");
 		return rc;
 	}
-	*valp = (i2c_data[1] << 8) | i2c_data[0];
+	*valp = sys_get_le16(i2c_data);
 
 	return 0;
 }

--- a/drivers/sensor/max17055/max17055.c
+++ b/drivers/sensor/max17055/max17055.c
@@ -63,9 +63,9 @@ static int max17055_reg_write(const struct device *dev, uint8_t reg_addr,
  * @param val Value to convert (taken from a MAX17055 register)
  * @return corresponding value in milliamps
  */
-static int current_to_ma(unsigned int rsense_mohms, int16_t val)
+static int current_to_ma(uint16_t rsense_mohms, int16_t val)
 {
-	return (val * 1.5625) / rsense_mohms;
+	return (int32_t)val * 25 / rsense_mohms / 16; /* * 1.5625 */
 }
 
 /**
@@ -75,9 +75,9 @@ static int current_to_ma(unsigned int rsense_mohms, int16_t val)
  * @param val Value in mA to convert
  * @return corresponding value in MAX17055 units, ready to write to a register
  */
-static int current_ma_to_max17055(unsigned int rsense_mohms, uint16_t val)
+static int current_ma_to_max17055(uint16_t rsense_mohms, uint16_t val)
 {
-	return val * rsense_mohms / 1.5625;
+	return (int32_t)val * rsense_mohms * 16 / 25; /* / 1.5625 */
 }
 
 /**
@@ -119,7 +119,7 @@ static int capacity_to_max17055(unsigned int rsense_mohms, uint16_t val_mha)
  */
 static int voltage_mV_to_max17055(uint16_t val_mv)
 {
-	return val_mv * 16 / 1.25;
+	return (val_mv * 16) * 10 / 8; /* * 1.25 */
 }
 
 static void set_millis(struct sensor_value *val, int val_millis)

--- a/drivers/sensor/max17055/max17055.c
+++ b/drivers/sensor/max17055/max17055.c
@@ -229,36 +229,87 @@ static int max17055_sample_fetch(const struct device *dev,
 				 enum sensor_channel chan)
 {
 	struct max17055_data *priv = dev->data;
+	int ret = -ENOTSUP;
 
-	struct {
-		int reg_addr;
-		int16_t *dest;
-	} regs[] = {
-		{ VCELL, &priv->voltage },
-		{ VFOCV, &priv->ocv },
-		{ AVG_CURRENT, &priv->avg_current },
-		{ REP_SOC, &priv->state_of_charge },
-		{ INT_TEMP, &priv->internal_temp },
-		{ REP_CAP, &priv->remaining_cap },
-		{ FULL_CAP_REP, &priv->full_cap },
-		{ TTE, &priv->time_to_empty },
-		{ TTF, &priv->time_to_full },
-		{ CYCLES, &priv->cycle_count },
-		{ DESIGN_CAP, &priv->design_cap },
-	};
-
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
-	for (size_t i = 0; i < ARRAY_SIZE(regs); i++) {
-		int rc;
-
-		rc = max17055_reg_read(dev, regs[i].reg_addr, regs[i].dest);
-		if (rc != 0) {
-			LOG_ERR("Failed to read channel %d", chan);
-			return rc;
+	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_GAUGE_VOLTAGE) {
+		ret = max17055_reg_read(dev, VCELL, &priv->voltage);
+		if (ret < 0) {
+			return ret;
 		}
 	}
 
-	return 0;
+	if (chan == SENSOR_CHAN_ALL ||
+	    (enum sensor_channel_max17055)chan == SENSOR_CHAN_MAX17055_VFOCV) {
+		ret = max17055_reg_read(dev, VFOCV, &priv->ocv);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_GAUGE_AVG_CURRENT) {
+		ret = max17055_reg_read(dev, AVG_CURRENT, &priv->avg_current);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_GAUGE_STATE_OF_CHARGE) {
+		ret = max17055_reg_read(dev, REP_SOC, &priv->state_of_charge);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_GAUGE_TEMP) {
+		ret = max17055_reg_read(dev, INT_TEMP, &priv->internal_temp);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY) {
+		ret = max17055_reg_read(dev, REP_CAP, &priv->remaining_cap);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY) {
+		ret = max17055_reg_read(dev, FULL_CAP_REP, &priv->full_cap);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_GAUGE_TIME_TO_EMPTY) {
+		ret = max17055_reg_read(dev, TTE, &priv->time_to_empty);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_GAUGE_TIME_TO_FULL) {
+		ret = max17055_reg_read(dev, TTF, &priv->time_to_full);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_GAUGE_CYCLE_COUNT) {
+		ret = max17055_reg_read(dev, CYCLES, &priv->cycle_count);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY) {
+		ret = max17055_reg_read(dev, DESIGN_CAP, &priv->design_cap);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	return ret;
 }
 
 static int max17055_exit_hibernate(const struct device *dev)


### PR DESCRIPTION
Hi, few improvements on the max17055 driver

- use the byte swap APIs
- get rid of floating point ops
- support fetching individual channels
