### PR TITLE
libc/picolibc: Remove unused read_stdin/write_stdout hooks

### DIFF
--- a/include/zephyr/sys/libc-hooks.h
+++ b/include/zephyr/sys/libc-hooks.h
@@ -21,7 +21,7 @@ extern "C" {
  * that need to call into the kernel as system calls
  */
 
-#if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_ARCMWDT_LIBC) || defined(CONFIG_PICOLIBC)
+#if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_ARCMWDT_LIBC)
 
 /* syscall generation ignores preprocessor, ensure this is defined to ensure
  * we don't have compile errors
@@ -31,12 +31,17 @@ __syscall int zephyr_read_stdin(char *buf, int nbytes);
 __syscall int zephyr_write_stdout(const void *buf, int nbytes);
 
 #else
-/* Minimal libc */
+/* Minimal libc and picolibc */
 
 __syscall int zephyr_fputc(int c, FILE * stream);
 
+#ifdef CONFIG_MINIMAL_LIBC
+/* Minimal libc only */
+
 __syscall size_t zephyr_fwrite(const void *ZRESTRICT ptr, size_t size,
 				size_t nitems, FILE *ZRESTRICT stream);
+#endif
+
 #endif /* CONFIG_NEWLIB_LIBC */
 
 /* Handle deprecated malloc arena size configuration values */

--- a/lib/libc/picolibc/libc-hooks.c
+++ b/lib/libc/picolibc/libc-hooks.c
@@ -73,34 +73,6 @@ void __stdin_hook_install(unsigned char (*hook)(void))
 	__stdin.flags |= _FDEV_SETUP_READ;
 }
 
-int z_impl_zephyr_read_stdin(char *buf, int nbytes)
-{
-	int i = 0;
-
-	for (i = 0; i < nbytes; i++) {
-		*(buf + i) = getchar();
-		if ((*(buf + i) == '\n') || (*(buf + i) == '\r')) {
-			i++;
-			break;
-		}
-	}
-	return i;
-}
-
-int z_impl_zephyr_write_stdout(const void *buffer, int nbytes)
-{
-	const char *buf = buffer;
-	int i;
-
-	for (i = 0; i < nbytes; i++) {
-		if (*(buf + i) == '\n') {
-			putchar('\r');
-		}
-		putchar(*(buf + i));
-	}
-	return nbytes;
-}
-
 #include <zephyr/sys/cbprintf.h>
 
 struct cb_bits {


### PR DESCRIPTION
Picolibc doesn't need these two syscall implementations as it uses zephyr_fputc instead. Make sure that zephyr_putc is declared correctly.

Fixes: #59550.