### PR TITLE
drivers: counter: Infineon Cat1fixes

### DIFF
--- a/drivers/counter/counter_ifx_cat1.c
+++ b/drivers/counter/counter_ifx_cat1.c
@@ -396,15 +396,16 @@ static int ifx_cat1_counter_set_alarm(const struct device *dev, uint8_t chan_id,
 	uint32_t curr = cyhal_timer_read(&data->counter_obj);
 	uint32_t diff = ifx_cat1_counter_ticks_sub((val - 1), curr, top_val);
 
-	/* Interrupt is triggered always for relative alarm and for absolute depending
-	 * on the flag.
-	 */
-	if (irq_on_late) {
-		data->alarm_irq_flag = true;
-		ifx_cat1_counter_set_int_pending(dev);
-	}
-
 	if ((absolute && (val < curr)) || (diff > max_rel_val)) {
+
+		/* Interrupt is triggered always for relative alarm and for absolute depending
+		 * on the flag.
+		 */
+		if (irq_on_late) {
+			data->alarm_irq_flag = true;
+			ifx_cat1_counter_set_int_pending(dev);
+		}
+
 		if (absolute) {
 			return -ETIME;
 		}

--- a/samples/drivers/counter/alarm/boards/cy8cproto_063_ble.overlay
+++ b/samples/drivers/counter/alarm/boards/cy8cproto_063_ble.overlay
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation
+ */
+
+counter0_0: &counter0_0 {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/boards/cy8cproto_063_ble.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/cy8cproto_063_ble.overlay
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation
+ */
+
+counter0_0: &counter0_0 {
+	status = "okay";
+};


### PR DESCRIPTION
TC "test_single_shot_alarm_notop" is failing because there were 2 ISR
callbacks instead of one. this is because of invoking
ifx_cat1_counter_set_int_pending incorrectly. Updated
ifx_cat1_counter_set_alarm to fix this