### PR TITLE
kernel: canaries: Enable stack canaries on thread local storage

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -92,6 +92,7 @@ config X86
 	select NEED_LIBC_MEM_PARTITION if USERSPACE && TIMING_FUNCTIONS \
 					  && !BOARD_HAS_TIMING_FUNCTIONS \
 					  && !SOC_HAS_TIMING_FUNCTIONS
+	select ARCH_HAS_STACK_CANARIES_TLS
 	help
 	  x86 architecture
 
@@ -599,6 +600,9 @@ config ARCH_HAS_SUSPEND_TO_RAM
 	bool
 	help
 	  When selected, the architecture supports suspend-to-RAM (S2RAM).
+
+config ARCH_HAS_STACK_CANARIES_TLS
+	bool
 
 #
 # Other architecture related options

--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -44,6 +44,10 @@
 	GDATA(_sse_mxcsr_default_value)
 #endif
 
+#if defined(CONFIG_THREAD_LOCAL_STORAGE)
+	GTEXT(z_x86_early_tls_update_gdt)
+#endif
+
 	GDATA(x86_cpu_boot_arg)
 
 .macro install_page_tables
@@ -252,6 +256,11 @@ __csSet:
 #endif
 #endif /* Z_VM_KERNEL */
 
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
+	pushl %esp
+	call z_x86_early_tls_update_gdt
+	popl %esp
+#endif
 	/* Clear BSS */
 #ifdef CONFIG_LINKER_USE_BOOT_SECTION
 	call	z_bss_zero_boot

--- a/arch/x86/core/ia32/tls.c
+++ b/arch/x86/core/ia32/tls.c
@@ -28,3 +28,29 @@ void z_x86_tls_update_gdt(struct k_thread *thread)
 	sd->base_mid = (thread->tls >> 16) & 0xFFU;
 	sd->base_hi = (thread->tls >> 24) & 0xFFU;
 }
+
+FUNC_NO_STACK_PROTECTOR
+void z_x86_early_tls_update_gdt(char *stack_ptr)
+{
+	uintptr_t *self_ptr;
+	uintptr_t tls_seg = GS_TLS_SEG;
+	struct segment_descriptor *sd = &_gdt.entries[ENTRY_NUM];
+
+	/*
+	 * Since we are populating things backwards, store
+	 * the pointer to the TLS area at top of stack.
+	 */
+	stack_ptr -= sizeof(uintptr_t);
+	self_ptr = (void *)stack_ptr;
+	*self_ptr = POINTER_TO_UINT(stack_ptr);
+
+	sd->base_low = POINTER_TO_UINT(self_ptr) & 0xFFFFU;
+	sd->base_mid = (POINTER_TO_UINT(self_ptr) >> 16) & 0xFFU;
+	sd->base_hi = (POINTER_TO_UINT(self_ptr) >> 24) & 0xFFU;
+
+	__asm__ volatile(
+		"movl %0, %%eax;\n\t"
+		"movl %%eax, %%gs;\n\t"
+		:
+		: "r"(tls_seg));
+}

--- a/arch/x86/core/intel64.cmake
+++ b/arch/x86/core/intel64.cmake
@@ -17,5 +17,5 @@ zephyr_library_sources(
 )
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE	intel64/userspace.S)
-
+zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE	intel64/tls.c)
 zephyr_library_sources_ifdef(CONFIG_DEBUG_COREDUMP	intel64/coredump.c)

--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -261,6 +261,11 @@ enter_code64:
 
 	/* Enter C domain now that we have a stack set up, never to return */
 	movq %rbp, %rdi
+#ifdef CONFIG_STACK_CANARIES_TLS
+	pushq %rsp
+	call z_x86_early_tls_update_gdt
+	popq %rsp
+#endif
 	call z_x86_cpu_init
 
 	/* 64 bit OS entry point, used by EFI support.  UEFI

--- a/arch/x86/core/intel64/tls.c
+++ b/arch/x86/core/intel64/tls.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel_internal.h>
+
+FUNC_NO_STACK_PROTECTOR
+void z_x86_early_tls_update_gdt(char *stack_ptr)
+{
+	uintptr_t *self_ptr;
+	uint32_t fs_base = X86_FS_BASE;
+
+	/*
+	 * Since we are populating things backwards, store
+	 * the pointer to the TLS area at top of stack.
+	 */
+	stack_ptr -= sizeof(uintptr_t);
+	self_ptr = (void *)stack_ptr;
+	*self_ptr = POINTER_TO_UINT(stack_ptr);
+
+	__asm__ volatile(
+		"movl %0, %%ecx;\n\t"
+		"movq %1, %%rax;\n\t"
+		"movq %1, %%rdx;\n\t"
+		"shrq $32, %%rdx;\n\t"
+		"wrmsr;\n\t"
+		:
+		: "r"(fs_base), "r"(POINTER_TO_UINT(self_ptr)));
+}

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -160,7 +160,12 @@ set_compiler_property(PROPERTY coverage -fprofile-arcs -ftest-coverage -fno-inli
 set_compiler_property(PROPERTY security_canaries -fstack-protector-all)
 
 # Only a valid option with GCC 7.x and above, so let's do check and set.
-check_set_compiler_property(APPEND PROPERTY security_canaries -mstack-protector-guard=global)
+if(CONFIG_STACK_CANARIES_TLS)
+  check_set_compiler_property(APPEND PROPERTY security_canaries -mstack-protector-guard=tls)
+else()
+  check_set_compiler_property(APPEND PROPERTY security_canaries -mstack-protector-guard=global)
+endif()
+
 
 if(NOT CONFIG_NO_OPTIMIZATIONS)
   # _FORTIFY_SOURCE: Detect common-case buffer overflows for certain functions

--- a/include/zephyr/sys/libc-hooks.h
+++ b/include/zephyr/sys/libc-hooks.h
@@ -87,7 +87,8 @@ __syscall size_t zephyr_fwrite(const void *ZRESTRICT ptr, size_t size,
 extern struct k_mem_partition z_malloc_partition;
 #endif
 
-#if defined(CONFIG_NEWLIB_LIBC) || defined(CONFIG_STACK_CANARIES) || \
+#if defined(CONFIG_NEWLIB_LIBC) || (defined(CONFIG_STACK_CANARIES) && \
+			    !defined(CONFIG_STACK_CANARIES_TLS)) || \
 defined(CONFIG_PICOLIBC) || defined(CONFIG_NEED_LIBC_MEM_PARTITION)
 /* - All newlib globals will be placed into z_libc_partition.
  * - Minimal C library globals, if any, will be placed into

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -829,6 +829,24 @@ config STACK_CANARIES
 	  If stack canaries are not supported by the compiler an error
 	  will occur at build time.
 
+if STACK_CANARIES
+
+config STACK_CANARIES_TLS
+	bool "Stack canaries using thread local storage"
+	depends on THREAD_LOCAL_STORAGE
+	depends on ARCH_HAS_STACK_CANARIES_TLS
+	help
+	  This option enables compiler stack canaries on TLS.
+
+	  Stack canaries will leave in the thread local storage and
+	  each thread will have its own canary. This makes harder
+	  to predict the canary location and value.
+
+	  When enabled this causes an additional performance penalty
+	  during thread creations because it needs a new random value
+	  per thread.
+endif
+
 config EXECUTE_XOR_WRITE
 	bool "W^X for memory partitions"
 	depends on USERSPACE

--- a/kernel/compiler_stack_protect.c
+++ b/kernel/compiler_stack_protect.c
@@ -46,7 +46,9 @@ void _StackCheckHandler(void)
  * Symbol referenced by GCC compiler generated code for canary value.
  * The canary value gets initialized in z_cstart().
  */
-#ifdef CONFIG_USERSPACE
+#ifdef CONFIG_STACK_CANARIES_TLS
+__thread uintptr_t __stack_chk_guard;
+#elif CONFIG_USERSPACE
 K_APP_DMEM(z_libc_partition) uintptr_t __stack_chk_guard;
 #else
 __noinit uintptr_t __stack_chk_guard;

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -217,7 +217,11 @@ void z_bss_zero_pinned(void)
 #endif /* CONFIG_LINKER_USE_PINNED_SECTION */
 
 #ifdef CONFIG_STACK_CANARIES
+#ifdef CONFIG_STACK_CANARIES_TLS
+extern __thread volatile uintptr_t __stack_chk_guard;
+#else
 extern volatile uintptr_t __stack_chk_guard;
+#endif
 #endif /* CONFIG_STACK_CANARIES */
 
 /* LCOV_EXCL_STOP */

--- a/kernel/xip.c
+++ b/kernel/xip.c
@@ -11,7 +11,11 @@
 #include <zephyr/linker/linker-defs.h>
 
 #ifdef CONFIG_STACK_CANARIES
+#ifdef CONFIG_STACK_CANARIES_TLS
+extern __thread volatile uintptr_t __stack_chk_guard;
+#else
 extern volatile uintptr_t __stack_chk_guard;
+#endif /* CONFIG_STACK_CANARIES_TLS */
 #endif /* CONFIG_STACK_CANARIES */
 
 /**

--- a/tests/kernel/mem_protect/stackprot/testcase.yaml
+++ b/tests/kernel/mem_protect/stackprot/testcase.yaml
@@ -9,3 +9,12 @@ tests:
       - kernel
       - userspace
     ignore_faults: true
+  kernel.memory_protection.stackprot_tls:
+    filter: CONFIG_ARCH_HAS_STACK_CANARIES_TLS and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE
+    tags:
+      - kernel
+      - userspace
+    ignore_faults: true
+    extra_configs:
+      - CONFIG_THREAD_LOCAL_STORAGE=y
+      - CONFIG_STACK_CANARIES_TLS=y


### PR DESCRIPTION
- Add an optional that allows using the thread local storage for the stack canaries, instead of a global.
- ~~Some targets may need similar early tls initialization. This was tested for now only in x86, will work on other targets after this one. I may make this option available only for that target for now though.~~
- Stack canaries using TLS is not available in all architectures, some architectures have different options like on ARM that sysreg can be used. This PR enables stack canaries in TLS for x86 and x86-64