### PR TITLE
drivers: regulator: implement active discharge api

### DIFF
--- a/drivers/regulator/regulator_common.c
+++ b/drivers/regulator/regulator_common.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Nordic Semiconductor ASA
+ * Copyright 2023 Meta Platforms
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,6 +38,15 @@ int regulator_common_init(const struct device *dev, bool is_enabled)
 
 	if (config->initial_mode != REGULATOR_INITIAL_MODE_UNKNOWN) {
 		ret = regulator_set_mode(dev, config->initial_mode);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (REGULATOR_ACTIVE_DISCHARGE_GET_BITS(config->flags) !=
+	    REGULATOR_ACTIVE_DISCHARGE_DEFAULT) {
+		ret = regulator_set_active_discharge(dev,
+		    (bool)REGULATOR_ACTIVE_DISCHARGE_GET_BITS(config->flags));
 		if (ret < 0) {
 			return ret;
 		}

--- a/drivers/regulator/regulator_fake.c
+++ b/drivers/regulator/regulator_fake.c
@@ -39,6 +39,10 @@ DEFINE_FAKE_VALUE_FUNC(int, regulator_fake_set_mode, const struct device *,
 		       regulator_mode_t);
 DEFINE_FAKE_VALUE_FUNC(int, regulator_fake_get_mode, const struct device *,
 		       regulator_mode_t *);
+DEFINE_FAKE_VALUE_FUNC(int, regulator_fake_set_active_discharge, const struct device *,
+		       bool);
+DEFINE_FAKE_VALUE_FUNC(int, regulator_fake_get_active_discharge, const struct device *,
+		       bool *);
 DEFINE_FAKE_VALUE_FUNC(int, regulator_fake_get_error_flags,
 		       const struct device *, regulator_error_flags_t *);
 
@@ -53,6 +57,8 @@ static struct regulator_driver_api api = {
 	.get_current_limit = regulator_fake_get_current_limit,
 	.set_mode = regulator_fake_set_mode,
 	.get_mode = regulator_fake_get_mode,
+	.set_active_discharge = regulator_fake_set_active_discharge,
+	.get_active_discharge = regulator_fake_get_active_discharge,
 	.get_error_flags = regulator_fake_get_error_flags,
 };
 

--- a/drivers/regulator/regulator_shell.c
+++ b/drivers/regulator/regulator_shell.c
@@ -364,6 +364,63 @@ static int cmd_modeget(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static int cmd_adset(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	bool ad;
+	int ret;
+
+	ARG_UNUSED(argc);
+
+	dev = device_get_binding(argv[1]);
+	if (dev == NULL) {
+		shell_error(sh, "Regulator device %s not available", argv[1]);
+		return -ENODEV;
+	}
+
+	if (strcmp(argv[2], "enable")) {
+		ad = true;
+	} else if (strcmp(argv[2], "disable")) {
+		ad = false;
+	} else {
+		shell_error(sh, "Invalid parameter");
+		return -EINVAL;
+	}
+
+	ret = regulator_set_active_discharge(dev, ad);
+	if (ret < 0) {
+		shell_error(sh, "Could not set mode (%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int cmd_adget(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	bool ad;
+	int ret;
+
+	ARG_UNUSED(argc);
+
+	dev = device_get_binding(argv[1]);
+	if (dev == NULL) {
+		shell_error(sh, "Regulator device %s not available", argv[1]);
+		return -ENODEV;
+	}
+
+	ret = regulator_get_active_discharge(dev, &ad);
+	if (ret < 0) {
+		shell_error(sh, "Could not get active discharge (%d)", ret);
+		return ret;
+	}
+
+	shell_print(sh, "Active Discharge: %s", ad ? "enabled" : "disabled");
+
+	return 0;
+}
+
 static int cmd_errors(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
@@ -503,6 +560,14 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "Get regulator mode\n"
 		      "Usage: modeget <device>",
 		      cmd_modeget, 2, 0),
+	SHELL_CMD_ARG(adset, NULL,
+		      "Set active discharge\n"
+		      "Usage: adset <device> <enable/disable>",
+		      cmd_adset, 3, 0),
+	SHELL_CMD_ARG(adget, NULL,
+		      "Get active discharge\n"
+		      "Usage: adset <device>",
+		      cmd_adget, 2, 0),
 	SHELL_CMD_ARG(errors, &dsub_device_name,
 		      "Get errors\n"
 		      "Usage: errors <device>",

--- a/include/zephyr/drivers/regulator/fake.h
+++ b/include/zephyr/drivers/regulator/fake.h
@@ -31,6 +31,10 @@ DECLARE_FAKE_VALUE_FUNC(int, regulator_fake_set_mode, const struct device *,
 			regulator_mode_t);
 DECLARE_FAKE_VALUE_FUNC(int, regulator_fake_get_mode, const struct device *,
 			regulator_mode_t *);
+DECLARE_FAKE_VALUE_FUNC(int, regulator_fake_set_active_discharge, const struct device *,
+			bool);
+DECLARE_FAKE_VALUE_FUNC(int, regulator_fake_get_active_discharge, const struct device *,
+			bool *);
 DECLARE_FAKE_VALUE_FUNC(int, regulator_fake_get_error_flags,
 			const struct device *, regulator_error_flags_t *);
 

--- a/tests/drivers/regulator/api/app.overlay
+++ b/tests/drivers/regulator/api/app.overlay
@@ -24,6 +24,7 @@
 			regulator-max-microamp = <200>;
 			regulator-allowed-modes = <1 10>;
 			regulator-initial-mode = <1>;
+			regulator-active-discharge = <1>;
 		};
 	};
 };


### PR DESCRIPTION
Add an active discharge api for regulators. This uses the already existing but previously unused regulator-active-discharge property.

This implements it within the pca9420.

_I am currently working on my own PMIC where I need this api but I do not have the pca9420 to test with and verify it... but this seems like a trivial addition_

TODO:
- [x] Add test cases
- [x] Add shell cmd
- [x] only allow bool param