### PR TITLE
dts: bindings: adc-controller: Add zephyr,differential property

### DIFF
--- a/dts/bindings/adc/adc-controller.yaml
+++ b/dts/bindings/adc/adc-controller.yaml
@@ -121,6 +121,13 @@ child-binding:
         hardware (e.g. when the hardware does not allow to configure the
         acquisition time).
 
+    zephyr,differential:
+      type: boolean
+      description: |
+        When set, selects differential input mode for the channel. Otherwise,
+        single-ended mode is used unless the zephyr,input-negative property is
+        specified, in which case the differential mode is selected implicitly.
+
     zephyr,input-positive:
       type: int
       description: |
@@ -132,8 +139,7 @@ child-binding:
       description: |
         Negative ADC input. Used only for drivers that select
         the ADC_CONFIGURABLE_INPUTS Kconfig option.
-        When specified, the channel is to be used in differential input mode,
-        otherwise, single-ended mode is used.
+        When specified, implies the differential input mode for the channel.
 
     zephyr,resolution:
       type: int

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -231,6 +231,8 @@ IF_ENABLED(CONFIG_ADC_CONFIGURABLE_INPUTS, \
 	(.differential    = DT_NODE_HAS_PROP(node_id, zephyr_input_negative), \
 	 .input_positive  = DT_PROP_OR(node_id, zephyr_input_positive, 0), \
 	 .input_negative  = DT_PROP_OR(node_id, zephyr_input_negative, 0),)) \
+IF_ENABLED(DT_PROP(node_id, zephyr_differential), \
+	(.differential    = true,)) \
 IF_ENABLED(CONFIG_ADC_CONFIGURABLE_EXCITATION_CURRENT_SOURCE_PIN, \
 	(.current_source_pin_set = DT_NODE_HAS_PROP(node_id, zephyr_current_source_pin), \
 	 .current_source_pin = DT_PROP_OR(node_id, zephyr_current_source_pin, {0}),)) \


### PR DESCRIPTION
Add a property that allows explicit selection of the differential input mode for ADC channels in DTS. This is useful for controllers that do not have configurable inputs, so the zephyr,negative-input property that implicitly selects the differential mode is not specified for them.

See https://github.com/zephyrproject-rtos/zephyr/pull/59379#discussion_r1265105077.