### PR TITLE
mgmt: mcumgr: grp: os_mgmt: Add force parameter to reset command

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_MCUMGR_OS_MGMT_CALLBACKS_
+#define H_MCUMGR_OS_MGMT_CALLBACKS_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MCUmgr os_mgmt callback API
+ * @defgroup mcumgr_callback_api_os_mgmt MCUmgr os_mgmt callback API
+ * @ingroup mcumgr_callback_api
+ * @{
+ */
+
+/**
+ * Structure provided in the #MGMT_EVT_OP_OS_MGMT_RESET notification callback: This callback
+ * function is used to notify the application about a pending device reboot request and to
+ * authorise or deny it.
+ */
+struct os_mgmt_reset_data {
+	/** Contains the value of the force parameter. */
+	bool force;
+};
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -19,6 +19,10 @@
 #include <zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h>
 #endif
 
+#ifdef CONFIG_MCUMGR_GRP_OS
+#include <zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -176,7 +180,7 @@ enum img_mgmt_group_events {
  * MGMT event opcodes for operating system management group.
  */
 enum os_mgmt_group_events {
-	/** Callback when a reset command has been received. */
+	/** Callback when a reset command has been received, data is os_mgmt_reset_data. */
 	MGMT_EVT_OP_OS_MGMT_RESET		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 0),
 
 	/** Callback when an info command is processed, data is os_mgmt_info_check. */


### PR DESCRIPTION
    Adds the force parameter to the reset command which is now
    provided to the callback hook (if enabled).

Fixes #60979