### PR TITLE
tests: mgmt: mcumgr: cb_notifications: Fix SMP sync issue

### DIFF
--- a/tests/subsys/mgmt/mcumgr/cb_notifications/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/cb_notifications/src/main.c
@@ -83,6 +83,17 @@ static void destroy_callbacks(void *p)
 	mgmt_callback_unregister(&mgmt_event_callback);
 }
 
+static inline void wait_for_sync(void)
+{
+#ifdef CONFIG_SMP
+	/* For SMP systems, it is possible that a dummy response is fully received and processed
+	 * prior to the callback code being executed, therefore implement a dummy wait to wait
+	 * for callback synchronisation to take place.
+	 */
+	k_sleep(K_MSEC(1));
+#endif
+}
+
 ZTEST(callback_disabled, test_notifications_disabled)
 {
 	uint8_t buffer[ZCBOR_BUFFER_SIZE];
@@ -122,6 +133,7 @@ ZTEST(callback_disabled, test_notifications_disabled)
 	smp_dummy_disable();
 
 	/* Check events */
+	wait_for_sync();
 	zassert_false(cmd_recv_got, "Did not expect received command callback\n");
 	zassert_false(cmd_status_got, "Did not expect IMG status callback\n");
 	zassert_false(cmd_done_got, "Did not expect done command callback\n");
@@ -167,6 +179,7 @@ ZTEST(callback_enabled, test_notifications_enabled)
 	smp_dummy_disable();
 
 	/* Check events */
+	wait_for_sync();
 	zassert_true(cmd_recv_got, "Expected received command callback\n");
 	zassert_false(cmd_status_got, "Did not expect IMG status callback\n");
 	zassert_true(cmd_done_got, "Expected done command callback\n");
@@ -212,6 +225,7 @@ ZTEST(callback_disabled_verify, test_notifications_disabled_verify)
 	smp_dummy_disable();
 
 	/* Check events */
+	wait_for_sync();
 	zassert_false(cmd_recv_got, "Did not expect received command callback\n");
 	zassert_false(cmd_status_got, "Did not expect IMG status callback\n");
 	zassert_false(cmd_done_got, "Did not expect done command callback\n");


### PR DESCRIPTION
Fixes an issue with a test whereby the reponse on the dummy device can be fully send and processed prior to a callback being ran which updates a variable, add a delay in the test to wait for the sync to finish.