### PR TITLE
Bluetooth: audio: ascs: Fix ASE state transition due to CIS link loss

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -892,12 +892,6 @@ static void ascs_ep_iso_disconnected(struct bt_bap_ep *ep, uint8_t reason)
 
 	LOG_DBG("stream %p ep %p reason 0x%02x", stream, stream->ep, reason);
 
-	if (ep->status.state == BT_BAP_EP_STATE_ENABLING &&
-	    reason == BT_HCI_ERR_CONN_FAIL_TO_ESTAB) {
-		LOG_DBG("Waiting for retry");
-		return;
-	}
-
 	/* Cancel ASE disconnect work if pending */
 	(void)k_work_cancel_delayable(&ase->disconnect_work);
 	ep->reason = reason;

--- a/tests/bluetooth/audio/ascs/include/test_common.h
+++ b/tests/bluetooth/audio/ascs/include/test_common.h
@@ -65,4 +65,4 @@ void test_preamble_state_streaming(struct bt_conn *conn, uint8_t ase_id,
 				   struct bt_bap_stream *stream, struct bt_iso_chan **chan,
 				   bool source);
 void test_preamble_state_disabling(struct bt_conn *conn, uint8_t ase_id,
-				   struct bt_bap_stream *stream);
+				   struct bt_bap_stream *stream, struct bt_iso_chan **chan);

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -244,10 +244,10 @@ ZTEST_F(ascs_test_suite, test_release_ase_on_acl_disconnection_client_terminates
 				      !IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK));
 
 	/* Mock ACL disconnection */
-	mock_bt_conn_disconnected(conn, BT_HCI_ERR_CONN_TIMEOUT);
+	mock_bt_conn_disconnected(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
 	/* Mock CIS disconnection */
-	mock_bt_iso_disconnect(chan);
+	mock_bt_iso_disconnected(chan, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
 	/* Expected to notify the upper layers */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
@@ -342,10 +342,10 @@ ZTEST_F(ascs_test_suite, test_release_stream_pair_on_acl_disconnection_client_te
 	test_mocks_reset();
 
 	/* Mock ACL disconnection */
-	mock_bt_conn_disconnected(conn, BT_HCI_ERR_CONN_TIMEOUT);
+	mock_bt_conn_disconnected(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
 	/* Mock CIS disconnection */
-	mock_bt_iso_disconnect(chan);
+	mock_bt_iso_disconnected(chan, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
 	/* Expected to notify the upper layers */
 	const struct bt_bap_stream *streams[2] = { &snk_stream, &src_stream };

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -605,3 +605,50 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state)
 
 	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
 }
+
+ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state_client_retries)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	const struct bt_gatt_attr *ase;
+	struct bt_iso_chan *chan;
+	uint8_t ase_id;
+	int err;
+
+	if (IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK)) {
+		ase = fixture->ase_snk.attr;
+		ase_id = fixture->ase_snk.id;
+	} else {
+		ase = fixture->ase_src.attr;
+		ase_id = fixture->ase_src.id;
+	}
+	zexpect_not_null(ase);
+	zexpect_true(ase_id != 0x00);
+
+	bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
+	zassert_equal(0, err, "Failed to connect iso: err %d", err);
+
+	/* Mock CIS disconnection */
+	mock_bt_iso_disconnected(chan, BT_HCI_ERR_CONN_FAIL_TO_ESTAB);
+
+	/* Expected to not notify the upper layers */
+	expect_bt_bap_stream_ops_qos_set_not_called();
+	expect_bt_bap_stream_ops_released_not_called();
+
+	/* Client retries to establish CIS */
+	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
+	zassert_equal(0, err, "Failed to connect iso: err %d", err);
+	if (!IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK)) {
+		test_ase_control_client_receiver_start_ready(conn, ase_id);
+	} else {
+		err = bt_bap_stream_start(stream);
+		zassert_equal(0, err, "bt_bap_stream_start err %d", err);
+	}
+
+	expect_bt_bap_stream_ops_started_called_once(stream);
+
+	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
+}

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -475,3 +475,133 @@ ZTEST_F(ascs_test_suite, test_recv_in_enabling_state)
 
 	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
 }
+
+ZTEST_F(ascs_test_suite, test_cis_link_loss_in_streaming_state)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	const struct bt_gatt_attr *ase;
+	struct bt_iso_chan *chan;
+	uint8_t ase_id;
+
+	if (IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK)) {
+		ase = fixture->ase_snk.attr;
+		ase_id = fixture->ase_snk.id;
+	} else {
+		ase = fixture->ase_src.attr;
+		ase_id = fixture->ase_src.id;
+	}
+	zexpect_not_null(ase);
+	zexpect_true(ase_id != 0x00);
+
+	bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
+
+	test_preamble_state_streaming(conn, ase_id, stream, &chan,
+				      !IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK));
+
+	/* Mock CIS disconnection */
+	mock_bt_iso_disconnected(chan, BT_HCI_ERR_CONN_TIMEOUT);
+
+	/* Expected to notify the upper layers */
+	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_released_not_called();
+
+	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
+}
+
+static void test_cis_link_loss_in_disabling_state(struct ascs_test_suite_fixture *fixture,
+						  bool streaming)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	const struct bt_gatt_attr *ase;
+	struct bt_iso_chan *chan;
+	uint8_t ase_id;
+	int err;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
+
+	ase = fixture->ase_src.attr;
+	ase_id = fixture->ase_src.id;
+	zexpect_not_null(ase);
+	zexpect_true(ase_id != 0x00);
+
+	bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
+	zassert_equal(0, err, "Failed to connect iso: err %d", err);
+
+	if (streaming) {
+		test_ase_control_client_receiver_start_ready(conn, ase_id);
+	}
+
+	test_ase_control_client_disable(conn, ase_id);
+	test_mocks_reset();
+
+	/* Mock CIS disconnection */
+	mock_bt_iso_disconnected(chan, BT_HCI_ERR_CONN_TIMEOUT);
+
+	/* Expected to notify the upper layers */
+	expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	expect_bt_bap_stream_ops_released_not_called();
+
+	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
+}
+
+ZTEST_F(ascs_test_suite, test_cis_link_loss_in_disabling_state_v1)
+{
+	/* Enabling -> Streaming -> Disabling */
+	test_cis_link_loss_in_disabling_state(fixture, true);
+}
+
+ZTEST_F(ascs_test_suite, test_cis_link_loss_in_disabling_state_v2)
+{
+	/* Enabling -> Disabling */
+	test_cis_link_loss_in_disabling_state(fixture, false);
+}
+
+ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state)
+{
+	struct bt_bap_stream *stream = &fixture->stream;
+	struct bt_conn *conn = &fixture->conn;
+	const struct bt_gatt_attr *ase;
+	struct bt_iso_chan *chan;
+	uint8_t ase_id;
+	int err;
+
+	if (IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK)) {
+		ase = fixture->ase_snk.attr;
+		ase_id = fixture->ase_snk.id;
+	} else {
+		ase = fixture->ase_src.attr;
+		ase_id = fixture->ase_src.id;
+	}
+	zexpect_not_null(ase);
+	zexpect_true(ase_id != 0x00);
+
+	bt_bap_unicast_server_register_cb(&mock_bap_unicast_server_cb);
+
+	test_preamble_state_enabling(conn, ase_id, stream);
+	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
+	zassert_equal(0, err, "Failed to connect iso: err %d", err);
+
+	/* Mock CIS disconnection */
+	mock_bt_iso_disconnected(chan, BT_HCI_ERR_CONN_TIMEOUT);
+
+	/* Expected no change in ASE state */
+	expect_bt_bap_stream_ops_qos_set_not_called();
+	expect_bt_bap_stream_ops_released_not_called();
+
+	err = bt_bap_unicast_server_disable(stream);
+	zassert_equal(0, err, "Failed to disable stream: err %d", err);
+
+	if (IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK)) {
+		expect_bt_bap_stream_ops_qos_set_called_once(stream);
+	} else {
+		/* Server-initiated disable operation that shall not cause transition to QoS */
+		expect_bt_bap_stream_ops_qos_set_not_called();
+	}
+
+	bt_bap_unicast_server_unregister_cb(&mock_bap_unicast_server_cb);
+}

--- a/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
@@ -830,8 +830,9 @@ static void test_receiver_stop_ready_expect_invalid_length(struct bt_conn *conn,
 		0x02,           /* Response_Code[0] = Invalid Length */
 		0x00,           /* Reason[0] */
 	};
+	struct bt_iso_chan *chan;
 
-	test_preamble_state_disabling(conn, ase_id, stream);
+	test_preamble_state_disabling(conn, ase_id, stream, &chan);
 
 	ase_cp->write(conn, ase_cp, buf, len, 0, 0);
 

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -276,7 +276,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_releasing)
 	test_ase_control_client_release(conn, ase_id);
 
 	/* Client disconnects the ISO */
-	mock_bt_iso_disconnect(chan);
+	mock_bt_iso_disconnected(chan, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
@@ -566,7 +566,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_releasing)
 	zassert_false(err < 0, "bt_bap_stream_release returned err %d", err);
 
 	/* Client disconnects the ISO */
-	mock_bt_iso_disconnect(chan);
+	mock_bt_iso_disconnected(chan, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
@@ -814,8 +814,9 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_releasing)
 	test_preamble_state_streaming(conn, ase_id, stream, &chan, true);
 
 	test_ase_control_client_release(conn, ase_id);
+
 	/* Client disconnects the ISO */
-	mock_bt_iso_disconnect(chan);
+	mock_bt_iso_disconnected(chan, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);
@@ -1125,7 +1126,7 @@ ZTEST_F(test_source_ase_state_transition, test_server_streaming_to_releasing)
 	zassert_false(err < 0, "bt_bap_stream_release returned err %d", err);
 
 	/* Client disconnects the ISO */
-	mock_bt_iso_disconnect(chan);
+	mock_bt_iso_disconnected(chan, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
 	/* Verification */
 	expect_bt_bap_unicast_server_cb_release_called_once(stream);

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
@@ -432,12 +432,13 @@ ZTEST_F(test_ase_state_transition_invalid, test_client_source_state_disabling)
 	const struct bt_gatt_attr *ase_cp = fixture->ase_cp;
 	struct bt_bap_stream *stream = &fixture->stream;
 	struct bt_conn *conn = &fixture->conn;
+	struct bt_iso_chan *chan;
 	uint8_t ase_id;
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
 
 	ase_id = test_ase_id_get(fixture->ase_src);
-	test_preamble_state_disabling(conn, ase_id, stream);
+	test_preamble_state_disabling(conn, ase_id, stream, &chan);
 
 	test_client_config_codec_expect_transition_error(conn, ase_id, ase_cp);
 	test_client_config_qos_expect_transition_error(conn, ase_id, ase_cp);
@@ -679,12 +680,13 @@ ZTEST_F(test_ase_state_transition_invalid, test_server_source_state_disabling)
 {
 	struct bt_bap_stream *stream = &fixture->stream;
 	struct bt_conn *conn = &fixture->conn;
+	struct bt_iso_chan *chan;
 	uint8_t ase_id;
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SRC);
 
 	ase_id = test_ase_id_get(fixture->ase_src);
-	test_preamble_state_disabling(conn, ase_id, stream);
+	test_preamble_state_disabling(conn, ase_id, stream, &chan);
 
 	test_server_config_codec_expect_error(stream);
 	test_server_config_qos_expect_error(stream);

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -330,16 +330,15 @@ void test_preamble_state_streaming(struct bt_conn *conn, uint8_t ase_id,
 }
 
 void test_preamble_state_disabling(struct bt_conn *conn, uint8_t ase_id,
-				   struct bt_bap_stream *stream)
+				   struct bt_bap_stream *stream, struct bt_iso_chan **chan)
 {
-	struct bt_iso_chan *chan;
 	int err;
 
 	test_ase_control_client_config_codec(conn, ase_id, stream);
 	test_ase_control_client_config_qos(conn, ase_id);
 	test_ase_control_client_enable(conn, ase_id);
 
-	err = mock_bt_iso_accept(conn, 0x01, 0x01, &chan);
+	err = mock_bt_iso_accept(conn, 0x01, 0x01, chan);
 	zassert_equal(0, err, "Failed to connect iso: err %d", err);
 
 	test_ase_control_client_receiver_start_ready(conn, ase_id);

--- a/tests/bluetooth/audio/mocks/include/iso.h
+++ b/tests/bluetooth/audio/mocks/include/iso.h
@@ -14,7 +14,7 @@ void mock_bt_iso_init(void);
 void mock_bt_iso_cleanup(void);
 int mock_bt_iso_accept(struct bt_conn *conn, uint8_t cig_id, uint8_t cis_id,
 		       struct bt_iso_chan **chan);
-int mock_bt_iso_disconnect(struct bt_iso_chan *chan);
+int mock_bt_iso_disconnected(struct bt_iso_chan *chan, uint8_t err);
 
 DECLARE_FAKE_VALUE_FUNC(int, bt_iso_chan_send, struct bt_iso_chan *, struct net_buf *, uint16_t,
 			uint32_t);

--- a/tests/bluetooth/audio/mocks/src/iso.c
+++ b/tests/bluetooth/audio/mocks/src/iso.c
@@ -42,11 +42,7 @@ int bt_iso_server_unregister(struct bt_iso_server *server)
 
 int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 {
-	chan->state = BT_ISO_STATE_DISCONNECTED;
-	chan->ops->disconnected(chan, 0x13);
-	free(chan->iso);
-
-	return 0;
+	return mock_bt_iso_disconnected(chan, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 }
 
 void mock_bt_iso_init(void)
@@ -87,7 +83,12 @@ int mock_bt_iso_accept(struct bt_conn *conn, uint8_t cig_id, uint8_t cis_id,
 	return 0;
 }
 
-int mock_bt_iso_disconnect(struct bt_iso_chan *chan)
+int mock_bt_iso_disconnected(struct bt_iso_chan *chan, uint8_t err)
 {
-	return bt_iso_chan_disconnect(chan);
+	chan->state = BT_ISO_STATE_DISCONNECTED;
+	chan->ops->disconnected(chan, err);
+	free(chan->iso);
+	chan->iso = NULL;
+
+	return 0;
 }


### PR DESCRIPTION
This fixes ASE state transition to QoS Configured state that shall be
done autononously when CIS has been terminated due to link loss.

As per ASCS v1.0:
"If the server detects link loss of a CIS for an ASE in the Streaming
state or the Disabling state, the server shall immediately transition
that ASE to the QoS Configured state. Link loss of a CIS for an ASE in
any state other than Streaming or Disabling shall not cause a
transition of the ASE state machine."

The PR adds test cases testing the changes made:
test_cis_link_loss_in_streaming_state
test_cis_link_loss_in_disabling_state
test_cis_link_loss_in_enabling_state
test_cis_estab_failed_in_enabling_state

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/60669