### PR TITLE
Bluetooth: Controller: Remove separate done memq

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -15,11 +15,6 @@
 #define TICKER_USER_ID_THREAD   MAYFLY_CALL_ID_PROGRAM
 
 #define EVENT_PIPELINE_MAX 7
-#if defined(CONFIG_BT_CTLR_LOW_LAT_ULL)
-#define EVENT_DONE_LINK_CNT 0
-#else
-#define EVENT_DONE_LINK_CNT 1
-#endif /* CONFIG_BT_CTLR_LOW_LAT_ULL */
 
 #define ADV_INT_UNIT_US      625U
 #define SCAN_INT_UNIT_US     625U
@@ -598,9 +593,7 @@ void *ull_pdu_rx_alloc(void);
 void *ull_iso_pdu_rx_alloc_peek(uint8_t count);
 void *ull_iso_pdu_rx_alloc(void);
 void ull_rx_put(memq_link_t *link, void *rx);
-void ull_rx_put_done(memq_link_t *link, void *done);
 void ull_rx_sched(void);
-void ull_rx_sched_done(void);
 void ull_rx_put_sched(memq_link_t *link, void *rx);
 void ull_iso_rx_put(memq_link_t *link, void *rx);
 void ull_iso_rx_sched(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -803,7 +803,7 @@ void ull_conn_setup(memq_link_t *rx_link, struct node_rx_hdr *rx)
 	}
 }
 
-int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
+void ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
 {
 	struct pdu_data *pdu_rx;
 	struct ll_conn *conn;
@@ -813,7 +813,7 @@ int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
 		/* Mark for buffer for release */
 		(*rx)->hdr.type = NODE_RX_TYPE_RELEASE;
 
-		return 0;
+		return;
 	}
 
 	ull_cp_tx_ntf(conn);
@@ -828,7 +828,7 @@ int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
 
 		ull_cp_rx(conn, link, *rx);
 
-		return 0;
+		return;
 	}
 
 	case PDU_DATA_LLID_DATA_CONTINUE:
@@ -860,9 +860,6 @@ int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx)
 
 		break;
 	}
-
-
-	return 0;
 }
 
 int ull_conn_llcp(struct ll_conn *conn, uint32_t ticks_at_expire,

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -22,7 +22,7 @@ bool ull_conn_peer_connected(uint8_t const own_id_addr_type,
 			     uint8_t const peer_id_addr_type,
 			     uint8_t const *const peer_id_addr);
 void ull_conn_setup(memq_link_t *rx_link, struct node_rx_hdr *rx);
-int ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx);
+void ull_conn_rx(memq_link_t *link, struct node_rx_pdu **rx);
 int ull_conn_llcp(struct ll_conn *conn, uint32_t ticks_at_expire,
 		  uint32_t remainder, uint16_t lazy);
 void ull_conn_done(struct node_rx_event_done *done);


### PR DESCRIPTION
The separate done memq was introduced to handle the old LLCP stalling processing of the rx queue; This is no longer an issue with the new LLCP, so we can remove it