### PR TITLE
posix: mutex: return ETIMEDOUT from pthread_mutex_timedlock()

### DIFF
--- a/lib/posix/mutex.c
+++ b/lib/posix/mutex.c
@@ -147,6 +147,13 @@ static int acquire_mutex(pthread_mutex_t *mu, k_timeout_t timeout)
 
 	if (ret == 0) {
 		ret = k_mutex_lock(m, timeout);
+		if (ret == -EAGAIN) {
+			/*
+			 * special quirk - k_mutex_lock() returns EAGAIN if a timeout occurs, but
+			 * for pthreads, that means something different
+			 */
+			ret = -ETIMEDOUT;
+		}
 	}
 
 	if (ret < 0) {


### PR DESCRIPTION
The normative spec for `pthread_mutex_timedlock()` says that it should return `ETIMEDOUT` when a timeout occurs. However, currently it returns `EAGAIN`, which reflects what is returned by `k_mutex_lock()`.

Inspect and update the return value to account for this slight difference.

Fixes #61079