### PR TITLE
manifest: Update nRF HW models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -292,7 +292,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 0a7f846b0ad38dd7355e5728e7ba77af91c5f848
+      revision: 23bc852e3e4eaf64caa415b47e365ac1685ed91d
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 42b7c577714b8f22ce82a901e19c1814af4609a8


### PR DESCRIPTION
The nRF HW models have been updated to include the following fixes and improvements:

* TIMER: Add missing HAL function override
* TIMER: Added notes about minor differences

------

Fixes this failure: https://github.com/zephyrproject-rtos/zephyr/actions/runs/5738478848/job/15553662150