### PR TITLE
Devicetree: edtlib: clarify the possibly confusing content of _VENDOR_PREFIX_ALLOWED

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2247,8 +2247,7 @@ class EDT:
 
                     # As an exception, the root node can have whatever
                     # compatibles it wants. Other nodes get checked.
-                    elif node.path != '/' and \
-                       vendor not in _VENDOR_PREFIX_ALLOWED:
+                    elif node.path != '/':
                         if self._werror:
                             handler_fn: Any = _err
                         else:
@@ -3213,14 +3212,3 @@ _DEFAULT_PROP_SPECS: Dict[str, PropertySpec] = {
     name: PropertySpec(name, _DEFAULT_PROP_BINDING)
     for name in _DEFAULT_PROP_TYPES
 }
-
-# A set of vendor prefixes which are grandfathered in by Linux,
-# and therefore by us as well.
-_VENDOR_PREFIX_ALLOWED: Set[str] = set([
-    "at25", "bm", "devbus", "dmacap", "dsa",
-    "exynos", "fsia", "fsib", "gpio-fan", "gpio-key", "gpio", "gpmc",
-    "hdmi", "i2c-gpio", "keypad", "m25p", "max8952", "max8997",
-    "max8998", "mpmc", "pinctrl-single", "#pinctrl-single", "PowerPC",
-    "pl022", "pxa-mmc", "rcar_sound", "rotary-encoder", "s5m8767",
-    "sdhci", "simple-audio-card", "st-plgpio", "st-spics", "ts",
-])


### PR DESCRIPTION
This PR groups a few commits related to the vendor prefixes support in the edtlib API, one of which may be a bug fix.

### Fix typo in vendor prefixes

This one should be straightforward: there's a typo where the compatible string `gpio-keys` is misspelled `gpio-key` in the *grandfathered in by Linux* compatible strings set.

Reference: [gpio-keys.txt](https://www.kernel.org/doc/Documentation/devicetree/bindings/input/gpio-keys.txt) 

### Complement allowed vendor prefixes

Add a few vendor prefixes *grandfathered in by Linux*:

- `fixed-partitions` ([fixed-partitions.yaml](https://www.kernel.org/doc/Documentation/devicetree/bindings/mtd/partitions/fixed-partitions.yaml))
- `leds-gpio.txt` ([leds-gpio.txt](https://www.kernel.org/doc/Documentation/devicetree/bindings/leds/leds-gpio.txt))
- `mmio-sram` ([sram.txt](https://www.kernel.org/doc/Documentation/devicetree/bindings/sram/sram.txt))
- `pwm-leds` ([leds-pwm.txt](https://www.kernel.org/doc/Documentation/devicetree/bindings/leds/leds-pwm.txt))
 
### Fix *vendor prefixes validation*

When initialized with a vendor prefixes dictionary, an EDT model will permit to retrieve vendor descriptions with the public `EDT.compat2vendor` property.

Additionally, when this vendors support is enabled, the `EDT._init_luts()` function seems to validate compatible strings: for all nodes but the devicetree root, compatible strings should either include a vendor defined in the `vendor-prefixes.txt` dictionary in use, or be *grandfathered in by Linux*.

The issue is that:
- a compatible string is "grandfathered in by Linux" if present in the `_VENDOR_PREFIX_ALLOWED` set, which indeed contains compatible values, **NOT** vendor prefixes
- the validation happens **ONLY** when the compatible string starts with a vendor prefix followed by a comma, and there `_VENDOR_PREFIX_ALLOWED` would be searched for a vendor prefix it definitely cannot contain

IIUC the intent, `EDT._init_luts()` should:
- validate compatible strings whenever the vendors support is enabled (`EDT._vendor_prefixes` is not `None`)
- search the `EDT._vendor_prefixes` dictionary (aka `vendor-prefixes.txt`) for vendors when the compatible string actually starts with a vendor prefix
- search the *grandfathered in by Linux* set to validate compatible strings that do not start with a vendor prefix

Hope this helps.
Thanks.


--
chris
