### PR TITLE
test lwm2m/engine: Fix build warning

### DIFF
--- a/tests/net/lib/lwm2m/engine/src/lwm2m_observation.c
+++ b/tests/net/lib/lwm2m/engine/src/lwm2m_observation.c
@@ -228,7 +228,6 @@ static void run_insertion_test(char const *insert_path_str[], int insertions_cou
 
 	/* WHEN: inserting each path */
 	struct lwm2m_obj_path insert_path;
-	char name[20];
 
 	for (int i = 0; i < insertions_count; ++i) {
 		ret = lwm2m_string_to_path(insert_path_str[i], &insert_path, '/');
@@ -237,7 +236,6 @@ static void run_insertion_test(char const *insert_path_str[], int insertions_cou
 		ret = lwm2m_engine_add_path_to_list(&lwm2m_path_list, &lwm2m_path_free_list,
 							&insert_path);
 
-		sprintf(name, "Insertion: %d", i);
 		zassert_true(ret >= 0, "Insertion #%d failed", i);
 		/* THEN: path order is maintained */
 		assert_path_list_order(&lwm2m_path_list);


### PR DESCRIPTION
Fix a build warning that is generated by new enough compilers,
as it detects the sprintf() may overflow the destination buffer length.

The code which was generating the warning was actually not used, so we just remove it.

The build warning would cause a twister run to fail as warnings are treated as errors.

```
[57/215] Building C object CMakeFiles/app.dir/src/lwm2m_observation.c.obj
tests/net/lib/lwm2m/engine/src/lwm2m_observation.c: In function ‘run_insertion_test’:
tests/net/lib/lwm2m/engine/src/lwm2m_observation.c:240:43: warning: ‘%d’ directive writing between 1 and 10 bytes into a region of size 9 [-Wformat-overflow=]
  240 |                 sprintf(name, "Insertion: %d", i);
      |                                           ^~
tests/net/lib/lwm2m/engine/src/lwm2m_observation.c:240:31: note: directive argument in the range [0, 1073741823]
  240 |                 sprintf(name, "Insertion: %d", i);
      |                               ^~~~~~~~~~~~~~~
tests/net/lib/lwm2m/engine/src/lwm2m_observation.c:240:17: note: ‘sprintf’ output between 13 and 22 bytes into a destination of size 20
  240 |                 sprintf(name, "Insertion: %d", i);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```