### PR TITLE
drivers: modem: Remove unnecessary MODEM_SHELL dependency

### DIFF
--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -176,7 +176,6 @@ config MODEM_SHELL
 
 config MODEM_SIM_NUMBERS
 	bool "Query the SIM for IMSI and ICCID"
-	depends on MODEM_SHELL
 	default y
 	help
 	  Query the SIM card for the IMSI and ICCID identifiers. This
@@ -184,7 +183,6 @@ config MODEM_SIM_NUMBERS
 
 config MODEM_CELL_INFO
 	bool "Query for operator and cell info"
-	depends on MODEM_SHELL
 	help
 	  Query for numerical operator id, location area code and cell id.
 


### PR DESCRIPTION
MODEM_SIM_NUMBERS and MODEM_CELL_INFO don't depend on MODEM_SHELL.
These values should be as easy to access as the IMEI, without the need to enable shell for that.