### PR TITLE
tests: Re-enable the generic sensor test

### DIFF
--- a/tests/drivers/build_all/sensor/testcase.yaml
+++ b/tests/drivers/build_all/sensor/testcase.yaml
@@ -20,6 +20,7 @@ tests:
       - CONFIG_PM=y
       - CONFIG_PM_DEVICE=y
   sensors.generic_test:
+    build_only: false
     extra_configs:
       - CONFIG_GENERIC_SENSOR_TEST=y
       - CONFIG_ZTEST=y


### PR DESCRIPTION
This test was turned off last weekend when a sensor misbehaved and broke the CI, but that issue was resolved in #61016. This PR turns the test back on.

For more info on what this test does, please see #60394.

For more context see also the comments under #60959