### PR TITLE
drivers: can: mcan: Manually track available TX buffers

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -912,7 +912,7 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 				  &tx_hdr, sizeof(struct can_mcan_tx_buffer_hdr));
 	if (err != 0) {
 		LOG_ERR("failed to write Tx Buffer header (err %d)", err);
-		goto unlock;
+		goto err_unlock;
 	}
 
 	err = can_mcan_write_mram(dev, config->mram_offsets[CAN_MCAN_MRAM_CFG_TX_BUFFER] + put_idx *
@@ -921,7 +921,7 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 				  &frame->data_32, ROUND_UP(data_length, sizeof(uint32_t)));
 	if (err != 0) {
 		LOG_ERR("failed to write Tx Buffer data (err %d)", err);
-		goto unlock;
+		goto err_unlock;
 	}
 
 	__ASSERT_NO_MSG(put_idx <= cbs->num_tx);
@@ -930,11 +930,15 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 
 	err = can_mcan_write_reg(dev, CAN_MCAN_TXBAR, BIT(put_idx));
 	if (err != 0) {
-		goto unlock;
+		goto err_unlock;
 	}
 
-unlock:
 	k_mutex_unlock(&data->tx_mtx);
+	return 0;
+
+err_unlock:
+	k_mutex_unlock(&data->tx_mtx);
+	k_sem_give(&data->tx_sem);
 
 	return err;
 }

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -924,7 +924,7 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 		goto err_unlock;
 	}
 
-	__ASSERT_NO_MSG(put_idx <= cbs->num_tx);
+	__ASSERT_NO_MSG(put_idx < cbs->num_tx);
 	cbs->tx[put_idx].function = callback;
 	cbs->tx[put_idx].user_data = user_data;
 

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -930,12 +930,14 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 
 	err = can_mcan_write_reg(dev, CAN_MCAN_TXBAR, BIT(put_idx));
 	if (err != 0) {
-		goto err_unlock;
+		goto err_free_tx_cb;
 	}
 
 	k_mutex_unlock(&data->tx_mtx);
 	return 0;
 
+err_free_tx_cb:
+	cbs->tx[put_idx].function = NULL;
 err_unlock:
 	k_mutex_unlock(&data->tx_mtx);
 	k_sem_give(&data->tx_sem);

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -477,6 +477,7 @@ static void can_mcan_tx_event_handler(const struct device *dev)
 	struct can_mcan_data *data = dev->data;
 	struct can_mcan_tx_event_fifo tx_event;
 	can_tx_callback_t tx_cb;
+	void *user_data;
 	uint32_t event_idx;
 	uint32_t tx_idx;
 	uint32_t txefs;
@@ -507,12 +508,14 @@ static void can_mcan_tx_event_handler(const struct device *dev)
 			return;
 		}
 
-		k_sem_give(&data->tx_sem);
-
 		__ASSERT_NO_MSG(tx_idx <= cbs->num_tx);
 		tx_cb = cbs->tx[tx_idx].function;
+		user_data = cbs->tx[tx_idx].user_data;
 		cbs->tx[tx_idx].function = NULL;
-		tx_cb(dev, 0, cbs->tx[tx_idx].user_data);
+
+		k_sem_give(&data->tx_sem);
+
+		tx_cb(dev, 0, user_data);
 
 		err = can_mcan_read_reg(dev, CAN_MCAN_TXEFS, &txefs);
 		if (err != 0) {

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -829,7 +829,7 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 	uint32_t reg;
 	int err;
 
-	LOG_DBG("Sending %d bytes. Id: 0x%x, ID type: %s %s %s %s", data_length, frame->id,
+	LOG_DBG("Sending %zu bytes. Id: 0x%x, ID type: %s %s %s %s", data_length, frame->id,
 		(frame->flags & CAN_FRAME_IDE) != 0U ? "extended" : "standard",
 		(frame->flags & CAN_FRAME_RTR) != 0U ? "RTR" : "",
 		(frame->flags & CAN_FRAME_FDF) != 0U ? "FD frame" : "",

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -912,7 +912,7 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 				  &tx_hdr, sizeof(struct can_mcan_tx_buffer_hdr));
 	if (err != 0) {
 		LOG_ERR("failed to write Tx Buffer header (err %d)", err);
-		return err;
+		goto unlock;
 	}
 
 	err = can_mcan_write_mram(dev, config->mram_offsets[CAN_MCAN_MRAM_CFG_TX_BUFFER] + put_idx *
@@ -921,7 +921,7 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 				  &frame->data_32, ROUND_UP(data_length, sizeof(uint32_t)));
 	if (err != 0) {
 		LOG_ERR("failed to write Tx Buffer data (err %d)", err);
-		return err;
+		goto unlock;
 	}
 
 	__ASSERT_NO_MSG(put_idx <= cbs->num_tx);


### PR DESCRIPTION
The MCAN driver operates in TX queue mode (`TXBC.TFQM = 1`).
In this mode `TXFQS.TFQPI` returns the first available buffer (usually buffer zero).

Hardware is free to re-use a buffer as soon as TX completes, it does not have to wait for the matching TX event to be processed.

If a TX completes and that TX buffer is re-used before processing the TX event, two TX events for the same buffer occur.
The first event calls the second events TX callback, and the second event results in a NULL pointer exception.

In a "normal" configuration, the TX event ISR will always preempt the queuing of a TX frame to the same TX buffer.
However, this issue could occur if:

 * Sending a message with ISRs temporarily disabled
 * The ISR is processed on a different core to the TX call

The fix is to manually track which TX buffers are available, only freeing a buffer after the TX event has been processed.

The MCAN user manual states that this is allowed:

> The application may use register TXBRP instead of the Put Index and may place messages to any Tx Buffer without pending transmission request

Here is an example to demonstrate the issue:

    #include <zephyr/drivers/can.h>

    static void tx_callback(const struct device *dev, int error, void *user_data)
    {
    }

    FUNC_NORETURN void main(void)
    {
        const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
        struct can_frame tx_frame = { };

        can_set_mode(dev, CAN_MODE_LOOPBACK);
        can_start(dev);

        struct k_spinlock spinlock;
        k_spinlock_key_t key = k_spin_lock(&spinlock);

        can_send(dev, &tx_frame, K_NO_WAIT, tx_callback, NULL);

        /* Wait long enough for the first TX to complete */
        k_busy_wait(10000);

        can_send(dev, &tx_frame, K_NO_WAIT, tx_callback, NULL);

        k_spin_unlock(&spinlock, key);
        
        /* Crash */

        while (true) { k_sleep(K_FOREVER); }
    }

There's a couple other minor tidy ups in this PR, happy to split into separate PRs if requested

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/61245