### PR TITLE
drivers: nxp_s32_netc: fix init priorities

### DIFF
--- a/drivers/ethernet/Kconfig.nxp_s32_netc
+++ b/drivers/ethernet/Kconfig.nxp_s32_netc
@@ -92,18 +92,12 @@ config ETH_NXP_S32_MAC_FILTER_TABLE_SIZE
 	help
 	  Maximum number of entries supported in the MAC filter hash table.
 
-config ETH_NXP_S32_PSI_INIT_PRIORITY
-	int
-	default 60
-	help
-	  PSI initialization priority. It must be lower than VSI priority.
-
 config ETH_NXP_S32_VSI_INIT_PRIORITY
 	int
-	default 61
+	default 81
 	help
-	  VSI initialization priority. It must be bigger than PSI priority
-	  and lower than CONFIG_NET_INIT_PRIO, so that it can start after the PSI
-	  but before the networking sub-system.
+	  VSI initialization priority. It must be bigger than PSI init priority
+	  (CONFIG_ETH_INIT_PRIORITY) and lower than CONFIG_NET_INIT_PRIO, so
+	  that it can start after the PSI but before the networking sub-system.
 
 endif # ETH_NXP_S32_NETC

--- a/drivers/ethernet/eth_nxp_s32_netc_priv.h
+++ b/drivers/ethernet/eth_nxp_s32_netc_priv.h
@@ -99,8 +99,6 @@ struct nxp_s32_eth_msix {
 struct nxp_s32_eth_config {
 	const Netc_Eth_Ip_ConfigType netc_cfg;
 
-	const Netc_EthSwt_Ip_ConfigType switch_cfg;
-
 	Netc_Eth_Ip_MACFilterHashTableEntryType *mac_filter_hash_table;
 
 	uint8_t si_idx;

--- a/drivers/ethernet/eth_nxp_s32_netc_psi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_psi.c
@@ -135,7 +135,6 @@ static int nxp_s32_eth_configure_cgm(uint8_t port_idx)
 static int nxp_s32_eth_initialize(const struct device *dev)
 {
 	const struct nxp_s32_eth_config *cfg = dev->config;
-	Std_ReturnType swt_status;
 	int err;
 
 	err = pinctrl_apply_state(cfg->pincfg, PINCTRL_STATE_DEFAULT);
@@ -146,14 +145,6 @@ static int nxp_s32_eth_initialize(const struct device *dev)
 	err = nxp_s32_eth_configure_cgm(cfg->port_idx);
 	if (err != 0) {
 		LOG_ERR("Failed to configure NETC Switch CGM");
-		return -EIO;
-	}
-
-	/* NETC Switch driver must be initialized before PSI */
-	swt_status = Netc_EthSwt_Ip_Init(NETC_SWITCH_IDX, &cfg->switch_cfg);
-	if (swt_status != E_OK) {
-		LOG_ERR("Failed to initialize NETC Switch %d (%d)",
-			NETC_SWITCH_IDX, swt_status);
 		return -EIO;
 	}
 
@@ -369,6 +360,15 @@ static Netc_EthSwt_Ip_PortType nxp_s32_eth0_switch_ports_cfg[NETC_ETHSWT_NUMBER_
 	LISTIFY(NETC_ETHSWT_NUMBER_OF_PORTS, NETC_SWITCH_PORT_CFG, (,))
 };
 
+static const Netc_EthSwt_Ip_ConfigType nxp_s32_eth0_switch_cfg = {
+	.port = &nxp_s32_eth0_switch_ports_cfg,
+	.EthSwtArlTableEntryTimeout = NETC_SWITCH_PORT_AGING,
+	.netcClockFrequency = DT_PROP(PSI_NODE, clock_frequency),
+	.MacLearningOption = ETHSWT_MACLEARNINGOPTION_HWDISABLED,
+	.MacForwardingOption = ETHSWT_NO_FDB_LOOKUP_FLOOD_FRAME,
+	.Timer1588ClkSrc = ETHSWT_REFERENCE_CLOCK_DISABLED,
+};
+
 PINCTRL_DT_DEFINE(PSI_NODE);
 
 NETC_GENERATE_MAC_ADDRESS(PSI_NODE, 0)
@@ -381,14 +381,6 @@ static const struct nxp_s32_eth_config nxp_s32_eth0_config = {
 		.stateStructure = &nxp_s32_eth0_state,
 		.paCtrlRxRingConfig = &nxp_s32_eth0_rxring_cfg,
 		.paCtrlTxRingConfig = &nxp_s32_eth0_txring_cfg,
-	},
-	.switch_cfg = {
-		.port = &nxp_s32_eth0_switch_ports_cfg,
-		.EthSwtArlTableEntryTimeout = NETC_SWITCH_PORT_AGING,
-		.netcClockFrequency = DT_PROP(PSI_NODE, clock_frequency),
-		.MacLearningOption = ETHSWT_MACLEARNINGOPTION_HWDISABLED,
-		.MacForwardingOption = ETHSWT_NO_FDB_LOOKUP_FLOOD_FRAME,
-		.Timer1588ClkSrc = ETHSWT_REFERENCE_CLOCK_DISABLED,
 	},
 	.si_idx = NETC_ETH_IP_PSI_INDEX,
 	.port_idx = NETC_SWITCH_PORT_IDX,
@@ -415,6 +407,28 @@ ETH_NET_DEVICE_DT_DEFINE(PSI_NODE,
 			NULL,
 			&nxp_s32_eth0_data,
 			&nxp_s32_eth0_config,
-			CONFIG_ETH_NXP_S32_PSI_INIT_PRIORITY,
+			CONFIG_ETH_INIT_PRIORITY,
 			&nxp_s32_eth_api,
 			NET_ETH_MTU);
+
+static int nxp_s32_eth_switch_init(void)
+{
+	Std_ReturnType swt_status;
+
+	swt_status = Netc_EthSwt_Ip_Init(NETC_SWITCH_IDX, &nxp_s32_eth0_switch_cfg);
+	if (swt_status != E_OK) {
+		LOG_ERR("Failed to initialize NETC Switch %d (%d)",
+			NETC_SWITCH_IDX, swt_status);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+/*
+ * NETC Switch driver must be initialized before any other NETC component.
+ * This is because Netc_EthSwt_Ip_Init() will not only initialize the Switch,
+ * but also perform global initialization, enable the PCIe functions for MDIO
+ * and ENETC, and initialize MDIO with a fixed configuration.
+ */
+SYS_INIT(nxp_s32_eth_switch_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/arm/nxp_s32/s32ze/Kconfig.defconfig.series
+++ b/soc/arm/nxp_s32/s32ze/Kconfig.defconfig.series
@@ -29,15 +29,7 @@ config FLASH_BASE_ADDRESS
 	default 0
 endif # !XIP
 
-# Ethernet driver must init first because it initializes the
-# NETC which is needed for EMDIO functionality
 if NET_L2_ETHERNET
-
-config MDIO_INIT_PRIORITY
-	default 70
-
-config PHY_INIT_PRIORITY
-	default 80
 
 # NETC drops TCP/UDP packets with invalid checksum
 config NET_TCP_CHECKSUM


### PR DESCRIPTION
So far the init priorities were `enetc_psi0=60 < enetc_vsin=61 < emdio=70 < ethernet-phy=80` because the Ethernet PSI driver was doing global initialization for the whole NETC complex, including enabling MDIO function (due to the way the HAL works).

Change to use the default init priorities `mdio=60 < phy=70 < eth=enetc_psi0=80 < enetc_vsin=81` by executing at an early stage the NETC global initialization. This allows to match the DT hierarchy representation of NETC with the effective priorities assigned and keeping the priorities in check with CHECK_INIT_PRIORITIES.

Relates to #58388 