### PR TITLE
drivers: sensor: correct scale in WSEN_ITDS driver

### DIFF
--- a/drivers/sensor/wsen_itds/itds.c
+++ b/drivers/sensor/wsen_itds/itds.c
@@ -25,7 +25,7 @@ static const struct itds_odr itds_odr_map[ITDS_ODR_MAX] = {
 	{400}, {800}, {1600}
 };
 
-static const unsigned int itds_sensitivity_scale[][ITDS_ACCL_RANGE_END] = {
+static const int16_t itds_sensitivity_scale[][ITDS_ACCL_RANGE_END] = {
 	{976, 1952, 3904, 7808},
 
 	/* high performance mode */

--- a/drivers/sensor/wsen_itds/itds.h
+++ b/drivers/sensor/wsen_itds/itds.h
@@ -107,7 +107,7 @@ struct itds_device_data {
 #endif
 	int16_t samples[ITDS_SAMPLE_SIZE];
 	int16_t temperature;
-	uint16_t scale;
+	int16_t scale;
 	enum operation_mode op_mode;
 	const struct device *dev;
 


### PR DESCRIPTION
correct scale in WSEN_ITDS driver to overcome sign extension issues

Fixes #58565