### PR TITLE
debug: arc: expose thread relinquish cause

### DIFF
--- a/subsys/debug/thread_info.c
+++ b/subsys/debug/thread_info.c
@@ -24,6 +24,7 @@ enum {
 	THREAD_INFO_OFFSET_T_PREEMPT_FLOAT,
 	THREAD_INFO_OFFSET_T_COOP_FLOAT,
 	THREAD_INFO_OFFSET_T_ARM_EXC_RETURN,
+	THREAD_INFO_OFFSET_T_ARC_RELINQUISH_CAUSE,
 };
 
 #if CONFIG_MP_MAX_NUM_CPUS > 1
@@ -137,7 +138,14 @@ size_t _kernel_thread_info_offsets[] = {
 #else
 	[THREAD_INFO_OFFSET_T_ARM_EXC_RETURN] = THREAD_INFO_UNIMPLEMENTED,
 #endif /* CONFIG_ARM_STORE_EXC_RETURN */
+#if defined(CONFIG_ARC)
+	[THREAD_INFO_OFFSET_T_ARC_RELINQUISH_CAUSE] = offsetof(struct _thread_arch,
+						relinquish_cause),
+#else
+	[THREAD_INFO_OFFSET_T_ARC_RELINQUISH_CAUSE] = THREAD_INFO_UNIMPLEMENTED,
+#endif /* CONFIG_ARC */
 };
+
 extern size_t __attribute__((alias("_kernel_thread_info_offsets")))
 		_kernel_openocd_offsets;
 


### PR DESCRIPTION
When a thread is preempted on ARC, caller-saved registers are saved on the stack automatically (RIRQ) or manually by the kernel ISR (FIRQ). Exposing the thread's relinquish cause hints the debugger that it can read more or less register values.