### PR TITLE
hal_silabs: Add support for librail for 1x devices

### DIFF
--- a/boards/arm/efr32_radio/Kconfig.defconfig
+++ b/boards/arm/efr32_radio/Kconfig.defconfig
@@ -33,6 +33,7 @@ config LOG_BACKEND_SWO_FREQ_HZ
 if SOC_GECKO_USE_RAIL
 
 config FPU
+	default n if SOC_GECKO_SERIES1
 	default y
 
 endif # SOC_GECKO_USE_RAIL

--- a/boards/arm/efr32_radio/efr32_radio_brd4250b.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4250b.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <silabs/efr32fg1p133f256gm48.dtsi>
+#include <silabs/efr32xg1p-pinctrl.dtsi>
 #include "efr32_radio.dtsi"
 
 / {
@@ -78,4 +79,11 @@
 		};
 
 	};
+};
+
+&usart0 {
+	current-speed = <115200>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+	status = "okay";
 };

--- a/boards/arm/efr32_radio/efr32_radio_brd4255a.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4255a.dts
@@ -7,6 +7,7 @@
 
 /dts-v1/;
 #include <silabs/efr32fg13p233f512gm48.dtsi>
+#include <silabs/efr32xg13p-pinctrl.dtsi>
 #include "efr32_radio.dtsi"
 
 / {
@@ -56,4 +57,11 @@
 		};
 
 	};
+};
+
+&usart0 {
+	current-speed = <115200>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+	status = "okay";
 };

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <silabs/efr32mg12p332f1024gl125.dtsi>
+#include <silabs/efr32xg13p-pinctrl.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -74,8 +75,8 @@
 
 &usart0 {
 	current-speed = <115200>;
-	location-rx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(1)>;
-	location-tx = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(0)>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -172,6 +172,14 @@
 		};
 
 	};
+
+	pinctrl: pin-controller {
+		/* Pin controller is a "virtual" device since SiLabs SoCs do pin
+		 * control in a distributed way (GPIO registers and PSEL
+		 * registers on each peripheral).
+		 */
+		compatible = "silabs,gecko-pinctrl";
+	};
 };
 
 &nvic {

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -233,6 +233,14 @@
 			status = "disabled";
 		};
 	};
+
+	pinctrl: pin-controller {
+		/* Pin controller is a "virtual" device since SiLabs SoCs do pin
+		 * control in a distributed way (GPIO registers and PSEL
+		 * registers on each peripheral).
+		 */
+		compatible = "silabs,gecko-pinctrl";
+	};
 };
 
 &nvic {

--- a/dts/arm/silabs/efr32xg12p-pinctrl.dtsi
+++ b/dts/arm/silabs/efr32xg12p-pinctrl.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Silicon Labs
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+
+&pinctrl {
+	/* configuration for uart0 device, default state */
+	usart0_default: usart0_default {
+		group1 {
+			/* configure PA.1 as UART_RX */
+			psels = <GECKO_PSEL(UART_RX, A, 1)>,
+				<GECKO_LOC(UART_RX, 0)>;
+		};
+		group2 {
+			/* configure PA.0 as UART_TX */
+			psels = <GECKO_PSEL(UART_TX, A, 0)>,
+				<GECKO_LOC(UART_TX, 0)>;
+		};
+	};
+};

--- a/dts/arm/silabs/efr32xg13p-pinctrl.dtsi
+++ b/dts/arm/silabs/efr32xg13p-pinctrl.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Silicon Labs
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+
+&pinctrl {
+	/* configuration for uart0 device, default state */
+	usart0_default: usart0_default {
+		group1 {
+			/* configure PA.1 as UART_RX */
+			psels = <GECKO_PSEL(UART_RX, A, 1)>,
+				<GECKO_LOC(UART_RX, 0)>;
+		};
+		group2 {
+			/* configure PA.0 as UART_TX */
+			psels = <GECKO_PSEL(UART_TX, A, 0)>,
+				<GECKO_LOC(UART_TX, 0)>;
+		};
+	};
+};

--- a/dts/arm/silabs/efr32xg13p.dtsi
+++ b/dts/arm/silabs/efr32xg13p.dtsi
@@ -180,6 +180,14 @@
 			status = "disabled";
 		};
 	};
+
+	pinctrl: pin-controller {
+		/* Pin controller is a "virtual" device since SiLabs SoCs do pin
+		 * control in a distributed way (GPIO registers and PSEL
+		 * registers on each peripheral).
+		 */
+		compatible = "silabs,gecko-pinctrl";
+	};
 };
 
 &nvic {

--- a/dts/arm/silabs/efr32xg1p-pinctrl.dtsi
+++ b/dts/arm/silabs/efr32xg1p-pinctrl.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Silicon Labs
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+
+&pinctrl {
+	/* configuration for uart0 device, default state */
+	usart0_default: usart0_default {
+		group1 {
+			/* configure PA.1 as UART_RX */
+			psels = <GECKO_PSEL(UART_RX, A, 1)>,
+				<GECKO_LOC(UART_RX, 0)>;
+		};
+		group2 {
+			/* configure PA.0 as UART_TX */
+			psels = <GECKO_PSEL(UART_TX, A, 0)>,
+				<GECKO_LOC(UART_TX, 0)>;
+		};
+	};
+};

--- a/soc/arm/silabs_exx32/efm32gg11b/Kconfig.series
+++ b/soc/arm/silabs_exx32/efm32gg11b/Kconfig.series
@@ -18,5 +18,6 @@ config SOC_SERIES_EFM32GG11B
 	select SOC_GECKO_EMU
 	select SOC_GECKO_GPIO
 	select SOC_GECKO_TRNG
+	select SOC_GECKO_SERIES1
 	help
 	  Enable support for EFM32 GiantGecko MCU series

--- a/soc/arm/silabs_exx32/efm32gg12b/Kconfig.series
+++ b/soc/arm/silabs_exx32/efm32gg12b/Kconfig.series
@@ -17,5 +17,6 @@ config SOC_SERIES_EFM32GG12B
 	select SOC_GECKO_EMU
 	select SOC_GECKO_GPIO
 	select SOC_GECKO_TRNG
+	select SOC_GECKO_SERIES1
 	help
 	  Enable support for EFM32 GiantGecko MCU series

--- a/soc/arm/silabs_exx32/efr32bg13p/Kconfig.series
+++ b/soc/arm/silabs_exx32/efr32bg13p/Kconfig.series
@@ -18,5 +18,6 @@ config SOC_SERIES_EFR32BG13P
 	select SOC_GECKO_EMU
 	select SOC_GECKO_GPIO
 	select HAS_PM
+	select SOC_GECKO_SERIES1
 	help
 	  Enable support for EFR32BG13P Blue Gecko MCU series

--- a/soc/arm/silabs_exx32/efr32fg13p/Kconfig.series
+++ b/soc/arm/silabs_exx32/efr32fg13p/Kconfig.series
@@ -19,5 +19,6 @@ config SOC_SERIES_EFR32FG13P
 	select SOC_GECKO_GPIO
 	select SOC_GECKO_HAS_ERRATA_RTCC_E201
 	select HAS_PM
+	select SOC_GECKO_SERIES1
 	help
 	  Enable support for EFR32 FlexGecko MCU series

--- a/soc/arm/silabs_exx32/efr32fg1p/Kconfig.series
+++ b/soc/arm/silabs_exx32/efr32fg1p/Kconfig.series
@@ -19,5 +19,6 @@ config SOC_SERIES_EFR32FG1P
 	select SOC_GECKO_GPIO
 	select SOC_GECKO_HAS_ERRATA_RTCC_E201
 	select HAS_PM
+	select SOC_GECKO_SERIES1
 	help
 	  Enable support for EFR32 FlexGecko MCU series

--- a/soc/arm/silabs_exx32/efr32mg12p/Kconfig.series
+++ b/soc/arm/silabs_exx32/efr32mg12p/Kconfig.series
@@ -20,5 +20,6 @@ config SOC_SERIES_EFR32MG12P
 	select SOC_GECKO_GPIO
 	select SOC_GECKO_TRNG
 	select HAS_PM
+	select SOC_GECKO_SERIES1
 	help
 	  Enable support for EFR32 Mighty Gecko MCU series

--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 20113e9520ce59ee7fa85ba10102d0880822bb3e
+      revision: 267cd0bb17cf3cd431633a40b6d37a981e78dcb7
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Update hal_silabs to support the use of librail for efr32xg1x devices.