### PR TITLE
drivers: dma: intel-adsp-hda: make sure that channels are disabled be…

### DIFF
--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -310,6 +310,14 @@ static void intel_adsp_hda_channels_init(const struct device *dev)
 
 	for (uint32_t i = 0; i < cfg->dma_channels; i++) {
 		intel_adsp_hda_init(cfg->base, cfg->regblock_size, i);
+
+		if (intel_adsp_hda_is_enabled(cfg->base, cfg->regblock_size, i)) {
+			uint32_t size;
+
+			size = intel_adsp_hda_get_buffer_size(cfg->base, cfg->regblock_size, i);
+			intel_adsp_hda_disable(cfg->base, cfg->regblock_size, i);
+			intel_adsp_hda_link_commit(cfg->base, cfg->regblock_size, i, size);
+		}
 	}
 }
 


### PR DESCRIPTION
…fore use

After boot the channel used for loading the basefw might be left enabled by ROM.
Make sure that all channels are in stopped state to have consistency.

On TGL during Zephyr boot one channel is left running: 0:0x0x72800: Channel 0 of host out DMA (used for bassefw loading)
	dgcs: 0x4800100,
	dgbba 0x6000,
	dgbs 32768,
	dgbrp 8192,
	dgbwp 8192,
	dgbsp 0,
	dgmbs 0,
	dgbllpi 0x0,
	dglpibi 0x0