### PR TITLE
boards: bt510, b610: move some gpio-keys entries zephyr,user  [WAS: boards: bt510, b610: remove some gpio-keys entries for non keys device]

### DIFF
--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -42,37 +42,9 @@
 			gpios = <&gpio1 10 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button switch 1 (SW1)";
 		};
-	};
-
-	ids {
-		compatible = "gpio-keys";
-		id0: id_0 {
-			gpios = <&gpio1 2 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-			label = "ID 0";
-		};
-		id1: id_1 {
-			gpios = <&gpio1 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-			label = "ID 1";
-		};
-		id2: id_2 {
-			gpios = <&gpio0 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-			label = "ID 2";
-		};
-	};
-
-	tm {
-		compatible = "gpio-keys";
 		tm0: tm_0 {
 			gpios = <&gpio0 3 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Test mode (TM)";
-		};
-	};
-
-	mag {
-		compatible = "gpio-keys";
-		mag0: mag_0 {
-			compatible = "honeywell,sm351lt";
-			gpios = <&gpio1 14 0>;
 		};
 	};
 
@@ -85,6 +57,11 @@
 		mcuboot-led0 = &led1a;
 		watchdog0 = &wdt0;
 		accel0 = &lis2dh12;
+	};
+
+	mag0: mag_0 {
+		compatible = "honeywell,sm351lt";
+		gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/boards/arm/bt610/bt610.dts
+++ b/boards/arm/bt610/bt610.dts
@@ -60,128 +60,6 @@
 			gpios = <&gpio1 1 GPIO_PULL_UP>;
 			label = "Tamper switch 2 (SW2)";
 		};
-		mag1: mag_1 {
-			compatible = "honeywell,sm351lt";
-			gpios = <&gpio1 15 0>;
-		};
-	};
-
-	gpio_keys {
-		compatible = "gpio-keys";
-		dinenable1: din_enable_1 {
-			label = "Digital Input 1 Enable";
-			gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
-		};
-
-		dinenable2: din_enable_2 {
-			label = "Digital Input 2 Enable";
-			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
-		};
-
-		din1: din_1 {
-			label = "Digital Input 1";
-			gpios = <&gpio0 9 GPIO_PULL_UP>;
-		};
-
-		din2: din_2 {
-			label = "Digital Input 2";
-			gpios = <&gpio1 11 GPIO_PULL_UP>;
-		};
-
-		thermenable: therm_enable {
-			label = "Thermistor Inputs Enable";
-			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
-		};
-
-		analogenable: analog_enable {
-			label = "Analog Inputs Enable";
-			gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
-		};
-
-		highsupplyenable: high_supply_enable {
-			label = "High Voltage Power Supply Enable";
-			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
-		};
-
-		expanderirq: expander_irq {
-			label = "Port Expander Interrupt Request";
-			gpios = <&gpio1 14 GPIO_PULL_UP>;
-		};
-
-		ain1: ain_1 {
-			label = "Analog Input 1";
-			gpios = <&gpio0 2 GPIO_PULL_UP>;
-		};
-
-		ain2: ain_2 {
-			label = "Analog Input 2";
-			gpios = <&gpio0 3 GPIO_PULL_UP>;
-		};
-
-		vref: v_ref {
-			label = "Voltage Reference";
-			gpios = <&gpio0 29 GPIO_PULL_UP>;
-		};
-
-		expanderreset: expander_reset {
-			label = "Port Expander Reset";
-			gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
-		};
-
-		batteryoutputenable: battery_output_enable {
-			label = "Battery Output Enable";
-			gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
-		};
-
-		do1mcu: do_1_mcu {
-			label = "Digital Output 1";
-			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
-		};
-
-		do2mcu: do_2_mcu {
-			label = "Digital Output 2";
-			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
-		};
-
-		ain1sel: ain_1_current_measurement_selection {
-			label = "Analogue Input 1 Current/Voltage measurement select";
-			gpios = <&gpio_exp0 0 GPIO_ACTIVE_HIGH>;
-		};
-
-		ain2sel: ain_2_current_measurement_selection {
-			label = "Analogue Input 2 Current/Voltage measurement select";
-			gpios = <&gpio_exp0 1 GPIO_ACTIVE_HIGH>;
-		};
-
-		ain3sel: ain_3_current_measurement_selection {
-			label = "Analogue Input 3 Current/Voltage measurement select";
-			gpios = <&gpio_exp0 2 GPIO_ACTIVE_HIGH>;
-		};
-
-		ain4sel: ain_4_current_measurement_selection {
-			label = "Analogue Input 4 Current/Voltage measurement select";
-			gpios = <&gpio_exp0 3 GPIO_ACTIVE_HIGH>;
-		};
-
-		aina0: analog_input_selection_0 {
-			label = "Analogue Input Mux 0";
-			gpios = <&gpio_exp0 4 GPIO_ACTIVE_HIGH>;
-		};
-
-		aina1: analog_input_selection_1 {
-			label = "Analogue Input Mux 1";
-			gpios = <&gpio_exp0 5 GPIO_ACTIVE_HIGH>;
-		};
-
-		aux1: aux_input_1 {
-			label = "Aux Input 1";
-			gpios = <&gpio_exp0 6 GPIO_ACTIVE_HIGH>;
-		};
-
-		aux2: aux_input_2 {
-			label = "Aux Input 2";
-			gpios = <&gpio_exp0 7 GPIO_ACTIVE_HIGH>;
-		};
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -196,6 +74,47 @@
 		mcuboot-button0 = &button1;
 		mcuboot-led0 = &led1;
 		watchdog0 = &wdt0;
+	};
+
+	mag1: mag_1 {
+		compatible = "honeywell,sm351lt";
+		gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
+	};
+
+	dinenable1: din_enable_1 {
+		compatible = "regulator-fixed";
+		regulator-name = "din_enable_1";
+		enable-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+	};
+
+	dinenable2: din_enable_2 {
+		compatible = "regulator-fixed";
+		regulator-name = "din_enable_2";
+		enable-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+	};
+
+	thermenable: therm_enable {
+		compatible = "regulator-fixed";
+		regulator-name = "therm_enable";
+		enable-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+	};
+
+	analogenable: analog_enable {
+		compatible = "regulator-fixed";
+		regulator-name = "analog_enable";
+		enable-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+	};
+
+	highsupplyenable: high_supply_enable {
+		compatible = "regulator-fixed";
+		regulator-name = "high_supply_enable";
+		enable-gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+	};
+
+	batteryoutputenable: battery_output_enable {
+		compatible = "regulator-fixed";
+		regulator-name = "battery_output_enable";
+		enable-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
 	};
 };
 


### PR DESCRIPTION
Hi @rerickson1 @greg-leach, bumped into this while going through the current gpio-keys. I'm working on adding key codes to the various boards so they can be used with the input driver and this would get in the way.

Looks like the compatible has been used just as a gpio placeholder, these should either use a `zephyr,user` node like https://github.com/zephyrproject-rtos/zephyr/blob/2af5ac8fbb33e946eb1cfeaff110ab837da5a830/boards/arm/swan_r5/swan_r5.dts#L40-L42 or have a definition in the application.

Could you help me get these off the binding and into something more appropriate? I'm proposing to drop them and you can handle them downstream but feel free to propose an alternative.

---

These two boards have few oddly defined gpio-keys nodes that do not seem to have anything to do with keys, and are just used as a placeholder to define gpios. Drop these from the board file since these should really have their own binding.