### PR TITLE
drivers: serial: cmsdk_apb: fix irq_rx_ready deviation

### DIFF
--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -369,7 +369,7 @@ static int uart_cmsdk_apb_irq_rx_ready(const struct device *dev)
 {
 	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
 
-	return dev_cfg->uart->state & UART_RX_BF;
+	return (dev_cfg->uart->state & UART_RX_BF) == UART_RX_BF;
 }
 
 /**


### PR DESCRIPTION
The docstring for `uart_cmsdk_apb_irq_rx_ready` says "@return 1 if an interrupt is ready, 0 otherwise" but the function actually returns 2 on success. This PR fixes this to conform with serial driver API.