### PR TITLE
input: add zephyr/ prefix to the event code sample and docs

### DIFF
--- a/dts/bindings/input/gpio-qdec.yaml
+++ b/dts/bindings/input/gpio-qdec.yaml
@@ -12,7 +12,7 @@ description: |
 
   Example configuration:
 
-  #include <dt-bindings/input/input-event-codes.h>
+  #include <zephyr/dt-bindings/input/input-event-codes.h>
 
   qdec {
           compatible = "gpio-qdec";

--- a/dts/bindings/input/zephyr,gpio-keys.yaml
+++ b/dts/bindings/input/zephyr,gpio-keys.yaml
@@ -10,7 +10,7 @@ description: |
 
   For example:
 
-  #include <dt-bindings/input/input-event-codes.h>
+  #include <zephyr/dt-bindings/input/input-event-codes.h>
 
   / {
          buttons {

--- a/dts/bindings/input/zephyr,input-longpress.yaml
+++ b/dts/bindings/input/zephyr,input-longpress.yaml
@@ -10,7 +10,7 @@ description: |
   Can be optionally be associated to a specific device to listen for events
   only from that device. Example configuration:
 
-  #include <dt-bindings/input/input-event-codes.h>
+  #include <zephyr/dt-bindings/input/input-event-codes.h>
 
   longpress {
           input = <&buttons>;

--- a/samples/subsys/input/input_dump/boards/nrf52dk_nrf52832.overlay
+++ b/samples/subsys/input/input_dump/boards/nrf52dk_nrf52832.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	buttons {

--- a/tests/subsys/input/input_longpress/boards/native_posix.overlay
+++ b/tests/subsys/input/input_longpress/boards/native_posix.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	fake_input_device: fake-device {


### PR DESCRIPTION
The system still takes both prefixed and unprefixed dt-bindings files, but let's use zephyr/ prefixed in the examples and documentation.