### PR TITLE
lib/cbprintf: CONFIG_CBPRINTF_LIBC_SUBSTS should be optional

### DIFF
--- a/lib/os/Kconfig.cbprintf
+++ b/lib/os/Kconfig.cbprintf
@@ -16,7 +16,7 @@ config CBPRINTF_COMPLETE
 config CBPRINTF_NANO
 	bool "Space-optimized but feature-limited"
 	# nano needs to count characters if it's the formatter for libc
-	select CBPRINTF_LIBC_SUBSTS if MINIMAL_LIBC
+	imply CBPRINTF_LIBC_SUBSTS if MINIMAL_LIBC
 	help
 	  If selected a completely different implementation of the core
 	  formatting capability is substituted.  This has a much smaller code


### PR DESCRIPTION
When aiming for the smallest build result, it is desirable to
use CONFIG_CBPRINTF_NANO together with CONFIG_MINIMAL_LIBC. However
that doesn't mean we need all the functions enabled by having
CONFIG_CBPRINTF_LIBC_SUBSTS=y which increases the binary size even if
those functions are not used and not linked in.

When CONFIG_CBPRINTF_LIBC_SUBSTS=n such functions are not defined
anyway so z_cbvprintf_impl() won't be invoked with missing
functionalities.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
