### PR TITLE
tests: newlib/thread_safety: exclude acrn_ehl_crb

### DIFF
--- a/tests/lib/newlib/thread_safety/testcase.yaml
+++ b/tests/lib/newlib/thread_safety/testcase.yaml
@@ -63,3 +63,4 @@ tests:
       - userspace
     min_ram: 192
     timeout: 120
+    platform_exclude: acrn_ehl_crb  # See #61129


### PR DESCRIPTION
This seems to be failing fairly persistently in CI runs. Filed an issue for having it checked, let's exclude it from the test run until it's fixed.