### PR TITLE
soc: arm: stm32h5: support SWO

### DIFF
--- a/soc/arm/st_stm32/common/soc_config.c
+++ b/soc/arm/st_stm32/common/soc_config.c
@@ -27,9 +27,10 @@ static int st_stm32_common_config(void)
 {
 #ifdef CONFIG_LOG_BACKEND_SWO
 	/* Enable SWO trace asynchronous mode */
-#if defined(CONFIG_SOC_SERIES_STM32WBX)
+#if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32H5X)
 	LL_DBGMCU_EnableTraceClock();
-#else
+#endif
+#if !defined(CONFIG_SOC_SERIES_STM32WBX)
 	LL_DBGMCU_SetTracePinAssignment(LL_DBGMCU_TRACE_ASYNCH);
 #endif
 #endif /* CONFIG_LOG_BACKEND_SWO */

--- a/soc/arm/st_stm32/stm32h5/Kconfig.series
+++ b/soc/arm/st_stm32/stm32h5/Kconfig.series
@@ -15,5 +15,6 @@ config SOC_SERIES_STM32H5X
 	select ARMV8_M_DSP
 	select CPU_CORTEX_M_HAS_DWT
 	select HAS_STM32CUBE
+	select HAS_SWO
 	help
 	  Enable support for STM32H5 MCU series


### PR DESCRIPTION
In case of stm32h5 both `LL_DBGMCU_EnableTraceClock()` and
`LL_DBGMCU_SetTracePinAssignment()` need to be called in order to properly
configure SWO output.

Select `HAS_SWO`, so that logging over SWO can be enabled.

Tested with ST's fork of openocd [1].

[1] https://github.com/STMicroelectronics/OpenOCD