### PR TITLE
logging: swo: add Kconfig option for SWO reference frequency

### DIFF
--- a/soc/arm/st_stm32/common/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/common/Kconfig.defconfig.series
@@ -16,6 +16,13 @@ DT_STM32_RCC_CLOCK_FREQ := $(dt_node_int_prop_int,$(DT_STM32_RCC_PATH),clock-fre
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default "$(DT_STM32_RCC_CLOCK_FREQ)" if "$(dt_nodelabel_enabled,rcc)"
 
+if LOG_BACKEND_SWO
+
+config LOG_BACKEND_SWO_REF_FREQ_HZ
+	default "$(DT_STM32_RCC_CLOCK_FREQ)" if "$(dt_nodelabel_enabled,rcc)"
+
+endif # LOG_BACKEND_SWO
+
 # set the tick per sec as a divider of the LPTIM clock source
 config SYS_CLOCK_TICKS_PER_SEC
 	default 4096 if STM32_LPTIM_TIMER && STM32_LPTIM_CLOCK_LSE

--- a/subsys/logging/backends/Kconfig.swo
+++ b/subsys/logging/backends/Kconfig.swo
@@ -9,6 +9,16 @@ config LOG_BACKEND_SWO
 	  When enabled, backend will use SWO for logging.
 
 if LOG_BACKEND_SWO
+
+config LOG_BACKEND_SWO_REF_FREQ_HZ
+	int "SWO reference clock frequency"
+	default $(dt_node_int_prop_int,$(dt_nodelabel_path,itm),swo-ref-frequency) if $(dt_nodelabel_enabled,itm)
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if $(dt_node_has_prop,/cpus/cpu@0,clock-frequency)
+	default 0
+	help
+	  Set SWO reference frequency. In most cases it is equal to CPU
+	  frequency.
+
 config LOG_BACKEND_SWO_FREQ_HZ
 	int "Set SWO output frequency"
 	default 0

--- a/subsys/logging/backends/log_backend_swo.c
+++ b/subsys/logging/backends/log_backend_swo.c
@@ -42,17 +42,12 @@ PINCTRL_DT_DEFINE(DT_NODELABEL(itm));
 #define SWO_FREQ_DIV  1
 #else
 
-/* Set reference frequency which can be custom or cpu frequency. */
-#if DT_NODE_HAS_PROP(DT_NODELABEL(itm), swo_ref_frequency)
-#define SWO_REF_FREQ DT_PROP(DT_NODELABEL(itm), swo_ref_frequency)
-#elif DT_NODE_HAS_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
-#define SWO_REF_FREQ DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
-#else
-#error "Missing DT 'clock-frequency' property on cpu@0 node"
+#if CONFIG_LOG_BACKEND_SWO_REF_FREQ_HZ == 0
+#error "SWO reference frequency is not configured"
 #endif
 
 #define SWO_FREQ_DIV \
-	((SWO_REF_FREQ + (CONFIG_LOG_BACKEND_SWO_FREQ_HZ / 2)) / \
+	((CONFIG_LOG_BACKEND_SWO_REF_FREQ_HZ + (CONFIG_LOG_BACKEND_SWO_FREQ_HZ / 2)) / \
 		CONFIG_LOG_BACKEND_SWO_FREQ_HZ)
 
 #if SWO_FREQ_DIV > 0xFFFF


### PR DESCRIPTION
SWO reference frequency was set based on `swo-ref-frequency` under `itm`
nodelabel or `/cpus/cpu@0/clock-frequency` property. Not all platforms
configure those.

All ST devices configure CPU frequency in `clock-frequency` under `rcc`
nodelabel. Configuring the same value for each board in
`/cpus/cpu@0/clock-frequency` would be one way to make SWO work out of the
box. There is lots of copy-pasting involved in this, which makes this very
error-prone.

Introduce Kconfig option, which will default to values configured in `itm`
or `/cpus/cpu@0`. The main advantage will be for platforms like ST, where
CPU clock frequency is already configured in another place. Thsoe could
override default value in SoC, board or any other platform specific layer.

Configure SWO reference frequency to be the same as
`CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC`. This should make all ST boards ready to
be used with SWO, without configuring any other devicetree property.

Tested with NUCLEO-L476RG and NUCLEO-H563ZI.