### PR TITLE
doc: Fix a typo

### DIFF
--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -46,7 +46,7 @@ API Changes
 
 * The :c:func:`lwm2m_rd_client_start` function now accepts an additional
   ``flags`` parameter, which allows to configure current LwM2M client session,
-  for instance enable bootstrap procedure in the curent session.
+  for instance enable bootstrap procedure in the current session.
 
 * LwM2M execute now supports arguments. The execute callback
   :c:type:`lwm2m_engine_execute_cb_t` is extended with an ``args`` parameter

--- a/doc/services/rtio/index.rst
+++ b/doc/services/rtio/index.rst
@@ -210,7 +210,7 @@ Many requests to the same SPI peripheral for example might be translated to hard
 descriptors entirely. Meaning the hardware can potentially do more than ever.
 
 There is a small cost to each RTIO context and iodev. This cost could be weighed
-against using a thread for each concurent I/O operation or custom queues and
+against using a thread for each concurrent I/O operation or custom queues and
 threads per peripheral. RTIO is much lower cost than that.
 
 Examples

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -2954,6 +2954,7 @@ sub process {
 
 # Check for various typo / spelling mistakes
 		if (defined($misspellings) &&
+		    ($spelling_file !~ /$realfile/) &&
 		    ($in_commit_log || $line =~ /^(?:\+|Subject:)/i)) {
 			while ($rawline =~ /(?:^|[^a-z@])($misspellings)(?:\b|$|[^a-z@])/gi) {
 				my $typo = $1;

--- a/scripts/spelling.txt
+++ b/scripts/spelling.txt
@@ -274,6 +274,7 @@ compresion||compression
 comression||compression
 comunication||communication
 conbination||combination
+concurent||concurrent
 conditionaly||conditionally
 conected||connected
 connecetd||connected
@@ -319,6 +320,7 @@ couter||counter
 coutner||counter
 cryptocraphic||cryptographic
 cunter||counter
+curent||current
 curently||currently
 cylic||cyclic
 dafault||default

--- a/subsys/bluetooth/audio/shell/mcc.c
+++ b/subsys/bluetooth/audio/shell/mcc.c
@@ -1794,7 +1794,7 @@ static int cmd_mcc_otc_read_track_segments_object(const struct shell *sh,
 static int cmd_mcc_otc_read_current_track_object(const struct shell *sh,
 						 size_t argc, char *argv[])
 {
-	/* Assumes the Curent Track Object has already been selected by ID */
+	/* Assumes the Current Track Object has already been selected by ID */
 
 	int result;
 


### PR DESCRIPTION
Fix a typo in the spelling of "current".
Add "current" to spelling.txt.