### PR TITLE
MEC17/MEC15 GPIO interrupt fixes

### DIFF
--- a/soc/arm/microchip_mec/mec1501/Kconfig.soc
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.soc
@@ -85,3 +85,13 @@ choice
 		  JTAG port in SWD mode and SWV as tracing method.
 		  UART2 cannot be used. ADC00-03 can be used.
 endchoice
+
+# GPIO initialization depends on SOC initialization, which happen at
+# CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, so GPIO_INIT_PRIORITY needs to be
+# higher than that.
+if GPIO
+
+config GPIO_INIT_PRIORITY
+	default 41
+
+endif # GPIO

--- a/soc/arm/microchip_mec/mec172x/Kconfig.soc
+++ b/soc/arm/microchip_mec/mec172x/Kconfig.soc
@@ -72,3 +72,13 @@ choice
 		  JTAG port in SWD mode and SWV as tracing method.
 		  I2C09 cannot be used. ADC00-03 can be used.
 endchoice
+
+# GPIO initialization depends on ECIA initialization, which happen at
+# CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, so GPIO_INIT_PRIORITY needs to be
+# higher than that.
+if GPIO
+
+config GPIO_INIT_PRIORITY
+	default 41
+
+endif # GPIO


### PR DESCRIPTION
Since bb590b5b6e2e, which enforces a more consistent ordering of initialisation for devices, the interrupt controllers initialisation was happening after GPIO initialisation. This caused interrupts to stop working on GPIO input.

These patches fix that by increasing GPIO_INIT_PRIORITY. For MEC15, this makes it happen after `soc_init`, which does some interrupt initialisation. And for MEC17, this makes it happen after the EC interrupt aggregator (ECIA) initialisation.