### PR TITLE
github workflow: Bump checkout action to latest version

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -8,7 +8,7 @@ jobs:
     name: Scan code for licenses
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Scan the code
       id: scancode
       uses: zephyrproject-rtos/action_scancode@v4


### PR DESCRIPTION
This PR bumps the `checkout` action in the license check workflow to its latest version.