### PR TITLE
Bluetooth: host: fix deadlock when `CONFIG_BT_RECV_WORKQ_BT=y`

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -182,7 +182,7 @@ static struct bt_att_tx_meta_data *tx_meta_data_alloc(k_timeout_t timeout)
 	 * so if we're in the same workqueue but there are no immediate
 	 * contexts available, there's no chance we'll get one by waiting.
 	 */
-	if (k_current_get() == &k_sys_work_q.thread) {
+	if (bt_is_wq()) {
 		return k_fifo_get(&free_att_tx_meta_data, K_NO_WAIT);
 	}
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3934,6 +3934,16 @@ static void rx_work_handler(struct k_work *work)
 }
 #endif /* !CONFIG_BT_RECV_BLOCKING */
 
+bool bt_is_wq(void)
+{
+#if defined(CONFIG_BT_RECV_WORKQ_BT)
+	return ((k_current_get() == &k_sys_work_q.thread) ||
+		(k_current_get() == &bt_workq.thread));
+#else
+	return (k_current_get() == &k_sys_work_q.thread);
+#endif
+}
+
 int bt_enable(bt_ready_cb_t cb)
 {
 	int err;

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -445,6 +445,9 @@ const bt_addr_le_t *bt_lookup_id_addr(uint8_t id, const bt_addr_le_t *addr);
 
 int bt_send(struct net_buf *buf);
 
+/* Returns true if current context is Bluetooth RX context. */
+bool bt_is_wq(void);
+
 /* Don't require everyone to include keys.h */
 struct bt_keys;
 void bt_id_add(struct bt_keys *keys);


### PR DESCRIPTION
A deadlock can occur in that situation:
- bt wq handles an HCI buffer that is an ATT REQ
- handling it involves sending a RSP
- sending a RSP involves waiting for a conn TX context
- bt wq waits forever
- the HCI buffer is freed _after_ the l2cap .chan cb
- in that case, that is att_recv, which is currently stuck -> buffer is held up

- hci thread waits on a data buffer -> last buffer is held by bt wq

The bug doesn't manifest itself when using the syswq for bt_recv. This is infortunate as using the BT WQ is the default option.

To work around it, apply the same rule as the syswq: don't wait for a TX context or ATT metadata when sending from the workqueue that bt_recv is called from.