### PR TITLE
net: l2: ppp: ppp uart usage fixes

### DIFF
--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -1046,7 +1046,7 @@ static int ppp_start(const struct device *dev)
 	}
 #endif /* !CONFIG_NET_TEST */
 
-	ARG_UNUSED(context);
+	net_if_carrier_on(context->iface);
 	return 0;
 }
 
@@ -1054,6 +1054,7 @@ static int ppp_stop(const struct device *dev)
 {
 	struct ppp_driver_context *context = dev->data;
 
+	net_if_carrier_off(context->iface);
 	context->modem_init_done = false;
 	return 0;
 }

--- a/include/zephyr/net/ppp.h
+++ b/include/zephyr/net/ppp.h
@@ -489,6 +489,9 @@ struct ppp_context {
 	/** Is PPP ready to receive packets */
 	uint16_t is_ready_to_serve : 1;
 
+	/** Is PPP L2 enabled or not */
+	uint16_t is_enabled : 1;
+
 	/** PPP enable pending */
 	uint16_t is_enable_done : 1;
 

--- a/subsys/net/l2/ppp/ppp_internal.h
+++ b/subsys/net/l2/ppp/ppp_internal.h
@@ -213,5 +213,3 @@ static inline bool ppp_my_option_is_acked(struct ppp_fsm *fsm,
 {
 	return ppp_my_option_flags(fsm, code) & PPP_MY_OPTION_ACKED;
 }
-
-void ppp_if_carrier_down(struct net_if *iface);


### PR DESCRIPTION
This fixes 3 issues that came within PR #59124 for ppp uart usage.

Earlier start/stop of ppp was done at enable() but that was removed in PR #59124. 
Now putting enable/disable() back and putting start/stop there.

Additionally, there was a double ppp carrier ON when NET_EVENT_IF_DOWN. For that net_if_carrier_on/off is set in uart ppp.c driver. Also, worth to be mentioned that after PR #59124 there is no ppp carrier off when lcp is disconnected, for workaround that change, application that needs that information: should use ppp dead/running events instead.
