### PR TITLE
net: lwm2m: Don't report CoAP code "continue" as error

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -3209,6 +3209,9 @@ static int do_send_reply_cb(const struct coap_packet *response, struct coap_repl
 			msg->send_status_cb(LWM2M_SEND_STATUS_SUCCESS);
 		}
 		return 0;
+	} else if (code == COAP_RESPONSE_CODE_CONTINUE) {
+		/* Continue sending */
+		return 0;
 	}
 
 	LOG_ERR("Failed with code %u.%u. Not Retrying.", COAP_RESPONSE_CODE_CLASS(code),


### PR DESCRIPTION
When doing LwM2M SEND using CoAP block-wise mode, the callback errorneously reported CoAP code 2.31 (Continue) as an error. This code should be ignored.

Otherwise the blockwise SEND seem to work OK
![Screenshot from 2023-08-04 10-54-34](https://github.com/zephyrproject-rtos/zephyr/assets/3104794/afd66ebe-d1f1-4c00-b322-5efa705c21a6)
