### PR TITLE
net: lwm2m: Restructure LwM2M Kconfig menu

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -2,19 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig LWM2M
-	bool "OMA LWM2M protocol stack"
+	bool "OMA LwM2M protocol stack"
 	select COAP
 	select HTTP_PARSER_URL
 	select NET_SOCKETS
 	help
-	  This option adds logic for managing OMA LWM2M data
+	  This option adds logic for managing OMA LwM2M data
 
 if LWM2M
 
 module = LWM2M
 module-dep = LOG
-module-str = Log level for LWM2M library
+module-str = Log level for LwM2M library
 source "subsys/net/Kconfig.template.log_config.net"
+
+menu "Protocol versions"
 
 choice
 	prompt "LwM2M protocol version"
@@ -31,17 +33,7 @@ config LWM2M_VERSION_1_1
 	imply LWM2M_RW_CBOR_SUPPORT
 	imply ZCBOR
 
-endchoice
-
-config LWM2M_SHELL
-	bool "LwM2M shell utilities"
-	select SHELL
-	help
-	  Activate shell module that provides LwM2M commands like
-	  send to the console.
-
-config LWM2M_DTLS_SUPPORT
-	bool "DTLS support in the LwM2M client"
+endchoice # "LwM2M protocol version"
 
 choice
 	prompt "LwM2M Security object version"
@@ -56,7 +48,7 @@ config LWM2M_SECURITY_OBJECT_VERSION_1_0
 config LWM2M_SECURITY_OBJECT_VERSION_1_1
 	bool "Security object version 1.1"
 
-endchoice
+endchoice # "LwM2M Security object version"
 
 choice
 	prompt "LwM2M Server object version"
@@ -71,61 +63,19 @@ config LWM2M_SERVER_OBJECT_VERSION_1_0
 config LWM2M_SERVER_OBJECT_VERSION_1_1
 	bool "Server object version 1.1"
 
-endchoice
+endchoice # "LwM2M Server object version"
+
+endmenu # "Protocol versions"
+
+menu "Engine features"
+
+config LWM2M_DTLS_SUPPORT
+	bool "DTLS support in the LwM2M client"
+
 
 config LWM2M_DNS_SUPPORT
-	bool "DNS support in the LWM2M client"
+	bool "DNS support in the LwM2M client"
 	default y if DNS_RESOLVER
-
-choice
-	prompt "LwM2M Engine operation mode"
-	default LWM2M_TICKLESS if NET_SOCKETPAIR
-	default LWM2M_INTERVAL if !NET_SOCKETPAIR
-
-config LWM2M_TICKLESS
-	bool "Tickless operation mode"
-	depends on NET_SOCKETPAIR
-
-config LWM2M_INTERVAL
-	bool "Interval based polling mode"
-
-endchoice
-
-config LWM2M_ENGINE_STACK_SIZE
-	int "LWM2M engine stack size"
-	default 2560 if NET_LOG
-	default 2048
-	help
-	  Set the stack size for the LWM2M library engine (used for handling
-	  OBSERVE and NOTIFY events)
-
-config LWM2M_ENGINE_MAX_MESSAGES
-	int "LWM2M engine max. message object"
-	default 10
-	help
-	  Set the maximum message objects for the LWM2M library client
-
-config LWM2M_COAP_BLOCK_SIZE
-	int "LWM2M CoAP block-wise transfer size"
-	default 256
-	range 64 1024
-	help
-	  CoAP block size used by LWM2M when performing block-wise
-	  transfers. Possible values: 64, 128, 256, 512 and 1024.
-
-config LWM2M_ENGINE_MESSAGE_HEADER_SIZE
-	int "Room for CoAP header data"
-	default 48
-	range 24 128
-	help
-	  Extra room allocated to handle CoAP header data
-
-config LWM2M_COAP_MAX_MSG_SIZE
-	int "LWM2M CoAP maximum message size"
-	default LWM2M_COAP_BLOCK_SIZE
-	help
-	  CoAP message size used by LWM2M. Minimum is the block size used
-	  in blockwise transfers.
 
 config LWM2M_COAP_BLOCK_TRANSFER
 	bool "CoAP block transfer support for big outgoing LwM2M messages [EXPERIMENTAL]"
@@ -133,62 +83,6 @@ config LWM2M_COAP_BLOCK_TRANSFER
 	help
 	  LwM2M messages with a big body that exceed the block size will be split
 	  into blocks for sending.
-
-if LWM2M_COAP_BLOCK_TRANSFER
-config LWM2M_COAP_ENCODE_BUFFER_SIZE
-	int "LwM2M CoAP buffer size for encoding the full message for block-wise transfer"
-	default 1024
-	help
-	  Size of buffers for serializing big LwM2M CoAP messages that need to be
-	  split into blocks for sending.
-
-config LWM2M_NUM_OUTPUT_BLOCK_CONTEXT
-	int "Maximum # of LWM2M block contexts used for outgoing messages"
-	default 3
-	help
-	  Maximum number of CoAP block contexts needed to split messages into blocks for
-	  sending. This limits the numer of messages that need block transfer that can be
-	  handled at the same time.
-
-config LWM2M_LOG_ENCODE_BUFFER_ALLOCATIONS
-	bool "Log allocations of encode buffers for block wise transfer"
-	select MEM_SLAB_TRACE_MAX_UTILIZATION
-	help
-	  The allocation of encode buffers can be tracked to analyse the usage and
-	  to optimize the configuration of number of block contexts and indirectly
-	  the number of available encode buffers.
-endif # LWM2M_COAP_BLOCK_TRANSFER
-
-config LWM2M_ENGINE_VALIDATION_BUFFER_SIZE
-	int "Size of the validation buffer for the incoming data"
-	default 64
-	help
-	  LwM2M will use the validation buffer during the write operation, to
-	  decode the resource value before validating it (applies for resources
-	  for which validation callback has been registered). Set this value to
-	  the maximum expected size of the resources that need to be validated
-	  (and thus have validation callback registered).
-	  Setting the validation buffer size to 0 disables validation support.
-
-config LWM2M_ENGINE_MAX_PENDING
-	int "LWM2M engine max. pending objects"
-	default 5
-	help
-	  Set the maximum pending objects for the LWM2M library client
-
-config LWM2M_ENGINE_MAX_REPLIES
-	int "LWM2M engine max. reply objects"
-	default 5
-	help
-	  Set the maximum reply objects for the LWM2M library client
-
-config LWM2M_ENGINE_MAX_OBSERVER
-	int "Maximum # of observable LWM2M resources"
-	default 10
-	range 5 200
-	help
-	  This value sets the maximum number of resources which can be
-	  added to the observe notification list.
 
 config LWM2M_CANCEL_OBSERVE_BY_PATH
 	bool "Use path matching as fallback for cancel-observe"
@@ -199,36 +93,17 @@ config LWM2M_CANCEL_OBSERVE_BY_PATH
 	  this option, cancel-observe may not work properly when connecting to
 	  those servers.
 
-config LWM2M_ENGINE_DEFAULT_LIFETIME
-	int "LWM2M engine default server connection lifetime"
-	default 30
-	range 15 4294967295
-	help
-	  Set the default lifetime (in seconds) for the LWM2M library engine.
-	  This is also a minimum lifetime that client accepts. If server sets lifetime
-	  less than this value, client automatically raises it.
-
-config LWM2M_SECONDS_TO_UPDATE_EARLY
-	int "LWM2M Registration Update transmission time before timeout"
-	default 6
-	range 1 4294967295
-	help
-	  Time in seconds before the registration timeout, when the LWM2M
-	  Registration Update is sent by the engine. In networks with large
-	  round trip times (like NB-IoT), it might be needed to set this value
-	  higher, in order to allow the response to arrive before timeout.
-
 config LWM2M_QUEUE_MODE_ENABLED
 	bool "Queue Mode UDP binding"
 	help
 	  Set the transport binding to UDP with Queue Mode (UQ).
 
 config LWM2M_QUEUE_MODE_UPTIME
-	int "Specify time the LWM2M client should stay online in queue mode."
+	int "Specify time the LwM2M client should stay online in queue mode." if LWM2M_QUEUE_MODE_ENABLED
 	default 93
 	help
 	  This config specifies time (in seconds) the device should stay online
-	  after sending a message to the server. Note, that LWM2M specification
+	  after sending a message to the server. Note, that LwM2M specification
 	  recommends this to be CoAP MAX_TRANSMIT_WAIT parameter (which
 	  defaults to 93 seconds, see RFC 7252), it does not forbid other
 	  values though.
@@ -237,6 +112,11 @@ config LWM2M_TLS_SESSION_CACHING
 	bool "TLS session caching"
 	help
 	  Enabling this only when feature is supported in TLS library.
+
+config LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP
+	bool "Bootstrap support"
+	help
+	  Enabling this setting allows the RD client to support bootstrap mode.
 
 choice
 prompt "Socket handling at idle state"
@@ -255,44 +135,19 @@ config  LWM2M_RD_CLIENT_LISTEN_AT_IDLE
 
 endchoice
 
-config LWM2M_RD_CLIENT_SUPPORT
-	bool "support for LWM2M client bootstrap/registration state machine"
-	select DEPRECATED
-	help
-	  Deprecated flag. RD state machine is always part of engine. It cannot be disabled.
+choice
+	prompt "LwM2M Engine operation mode"
+	default LWM2M_TICKLESS if NET_SOCKETPAIR
+	default LWM2M_INTERVAL if !NET_SOCKETPAIR
 
-config LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP
-	bool "Bootstrap support"
-	help
-	  Enabling this setting allows the RD client to support bootstrap mode.
+config LWM2M_TICKLESS
+	bool "Tickless operation mode"
+	depends on NET_SOCKETPAIR
 
-config LWM2M_RD_CLIENT_ENDPOINT_NAME_MAX_LENGTH
-	int "Maximum length of client endpoint name"
-	default 33
-	help
-	  Default: room for 32 hexadecimal digits (UUID) + NULL
+config LWM2M_INTERVAL
+	bool "Interval based polling mode"
 
-config LWM2M_RD_CLIENT_MAX_RETRIES
-	int "Specify maximum number of registration retries"
-	default 5
-	help
-	  Specify maximum number of registration retries, before the application
-	  is notified about the network failure. Once application is notified,
-	  it's up to the application to handle this situation in a way
-	  appropriate for the specific use-case (for instance by waiting for
-	  LTE link to be re-established).
-
-config LWM2M_ACCESS_CONTROL_ENABLE
-	bool "Access control support"
-	help
-	  Enabling this setting registers the access control object (obj_id 2).
-
-config LWM2M_ACCESS_CONTROL_INSTANCE_COUNT
-	int "Maximum # of LWM2M Access Control object instances"
-	default 50
-	help
-	  This setting establishes the total count of LWM2M Access Control instances
-	  available to the client.
+endchoice
 
 config LWM2M_SERVER_DEFAULT_SSID
 	int "Default server ssid when using the lwm2m-client. (used for access control)"
@@ -304,7 +159,7 @@ config LWM2M_PEER_PORT
 	int "LWM2M server port"
 	default 5683
 	help
-	  This is the default server port to connect to for LWM2M communication.
+	  This is the default server port to connect to for LwM2M communication.
 
 config LWM2M_FIRMWARE_PORT_NONSECURE
 	int "LWM2M firmware server port non-secure"
@@ -317,32 +172,6 @@ config LWM2M_FIRMWARE_PORT_SECURE
 	default 5684
 	help
 	  This is the default server port to connect to for LwM2M firmware downloads over coaps.
-
-config LWM2M_SECURITY_INSTANCE_COUNT
-	int "Maximum # of LWM2M Security object instances"
-	default 2 if LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP
-	default 1
-	range 1 10
-	help
-	  This setting establishes the total count of LWM2M Security instances
-	  available to the client.
-
-config LWM2M_SECURITY_KEY_SIZE
-	int "Buffer size of the security key resources"
-	default 16
-	help
-	  This setting establishes the size of the key (pre-shared / public)
-	  resources in the security object instances.
-
-config LWM2M_SECURITY_DTLS_TLS_CIPHERSUITE_MAX
-	int "Maximum # of DTLS/TLS ciphersuite resource instances"
-	default 5
-	range 0 20
-	depends on LWM2M_SECURITY_OBJECT_VERSION_1_1
-	help
-	  This setting sets the maximum number of the resource instances of
-	  a security object defined in LWM2M version 1.1. Affects the resource
-	  0/X/16, where X is the object instance number.
 
 config LWM2M_SERVER_DEFAULT_PMIN
 	int "Default server record PMIN"
@@ -361,178 +190,15 @@ config LWM2M_SERVER_DEFAULT_PMAX
 	  between notifications.  When this time period expires a notification
 	  must be sent.
 
-config LWM2M_SERVER_INSTANCE_COUNT
-	int "Maximum # of LWM2M Server object instances"
-	default 2 if LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP
-	default 1
-	range 1 10
+config LWM2M_RD_CLIENT_MAX_RETRIES
+	int "Specify maximum number of registration retries"
+	default 5
 	help
-	  This setting establishes the total count of LWM2M Server instances
-	  available to the client (including: bootstrap and regular servers).
-
-config LWM2M_CONN_MON_OBJ_SUPPORT
-	bool "Connectivity Monitoring object support"
-	help
-	  Include support for LWM2M Connectivity Monitoring Object (ID 4)
-
-choice
-	prompt "LwM2M Connectivity Monitor object version"
-	default LWM2M_CONNMON_OBJECT_VERSION_1_0 if LWM2M_VERSION_1_0
-	default LWM2M_CONNMON_OBJECT_VERSION_1_2 if LWM2M_VERSION_1_1
-	depends on LWM2M_CONN_MON_OBJ_SUPPORT
-	help
-	  Select Which version of the Connectivity Monitor object should be used.
-
-config LWM2M_CONNMON_OBJECT_VERSION_1_0
-	bool "Connectivity monitor object version 1.0"
-
-config LWM2M_CONNMON_OBJECT_VERSION_1_2
-	bool "Connectivity monitor object version 1.2"
-
-endchoice
-
-config LWM2M_CONN_MON_BEARER_MAX
-	int "Maximum # of available network bearer resource instances"
-	depends on LWM2M_CONN_MON_OBJ_SUPPORT
-	default 1
-	help
-	  This value sets the maximum number of available network bearer
-	  resource instances.  These are displayed via the
-	  "Connection Monitoring" object /4/0/1.
-
-config LWM2M_CONN_MON_APN_MAX
-	int "Maximum # of APN resource instances"
-	depends on LWM2M_CONN_MON_OBJ_SUPPORT
-	default 1
-	help
-	  This value sets the maximum number of APN resource instances.
-	  These are displayed via the "Connection Monitoring" object /4/0/7.
-
-config LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT
-	bool "Firmware Update object support"
-	default y
-	help
-	  Include support for LWM2M Firmware Update Object (ID 5)
-
-config LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT_MULTIPLE
-	bool "Support multiple firmware update objects [EXPERIMENTAL]"
-	depends on LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT
-	select EXPERIMENTAL
-	help
-	  Support multiple instances of LWM2M Firmware Update Object (ID 5)
-
-config LWM2M_FIRMWARE_UPDATE_OBJ_INSTANCE_COUNT
-	int "Maximum # of LWM2M Firmware update object instances"
-	default 1
-	depends on LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT_MULTIPLE
-	help
-	  This setting establishes the total count of LWM2M Firmware update
-	  object instances available to the client.
-
-config LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
-	bool "Firmware Update object pull support"
-	default y
-	depends on LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT
-	depends on (HTTP_PARSER || HTTP_PARSER_URL)
-	help
-	  Include support for pulling a file from a remote server via
-	  block transfer and "FIRMWARE PACKAGE URI" resource.  This option
-	  adds another UDP context and packet handling.
-
-config LWM2M_SWMGMT_OBJ_SUPPORT
-	bool "Software management object support"
-	help
-	  Include support for LWM2M Software Management Object (ID 9)
-
-config LWM2M_PORTFOLIO_OBJ_SUPPORT
-	bool "LwM2M Portfolio object ID support for Conformance test"
-	help
-	  Include support for LWM2M Portfolio Object (ID 16).
-
-config LWM2M_SWMGMT_MAX_INSTANCE_COUNT
-	int "Maximum # of object instances"
-	depends on LWM2M_SWMGMT_OBJ_SUPPORT
-	default 1
-
-config LWM2M_SWMGMT_PACKAGE_NAME_LEN
-	int "Maximum size of the software management object's name string"
-	depends on LWM2M_SWMGMT_OBJ_SUPPORT
-	default 64
-
-config LWM2M_SWMGMT_PACKAGE_VERSION_LEN
-	int "Maximum size of the software management object's version string"
-	depends on LWM2M_SWMGMT_OBJ_SUPPORT
-	default 64
-
-config LWM2M_SWMGMT_PACKAGE_URI_LEN
-	int "Maximum size of the software management object's download URI string"
-	depends on (LWM2M_SWMGMT_OBJ_SUPPORT || LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)
-	default 128
-
-config LWM2M_NUM_BLOCK1_CONTEXT
-	int "Maximum # of LWM2M block1 contexts"
-	default 3
-	help
-	  This value sets up the maximum number of block1 contexts for
-	  CoAP block-wise transfer we can handle at the same time.
-
-config LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT
-	bool "Firmware Update object pull via CoAP-CoAP/HTTP proxy support"
-	depends on LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
-	help
-	  Include support for pulling firmware file via a CoAP-CoAP/HTTP proxy.
-
-config LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_ADDR
-	string "CoAP proxy network address"
-	depends on LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT
-	help
-	  Network address of the CoAP proxy server.
-
-config LWM2M_RW_OMA_TLV_SUPPORT
-	bool "TLV data format"
-	help
-	  Include support for write / parse TLV data
-
-config LWM2M_RW_JSON_SUPPORT
-	bool "support for JSON writer"
-	depends on JSON_LIBRARY
-	help
-	  Include support for writing JSON data
-
-
-config LWM2M_RW_SENML_JSON_SUPPORT
-	bool "SENML JSON data format"
-	depends on BASE64
-	depends on JSON_LIBRARY
-	help
-	  Include support for write / parse SENML JSON data
-
-config LWM2M_COMPOSITE_PATH_LIST_SIZE
-	int "Maximum # of composite read and send operation URL path"
-	default 6
-	help
-	  Define path list size for Composite Read and send operation.
-
-config LWM2M_RW_CBOR_SUPPORT
-	bool "support for CBOR writer"
-	depends on ZCBOR
-	help
-	  Include support for writing CBOR data
-
-config LWM2M_RW_SENML_CBOR_SUPPORT
-	bool "support for SenML CBOR writer"
-	depends on ZCBOR
-	depends on ZCBOR_CANONICAL
-	help
-	  Include support for writing SenML CBOR data
-
-config LWM2M_RW_SENML_CBOR_RECORDS
-	int "Maximum # of SenML records packed into a CBOR binary"
-	depends on LWM2M_RW_SENML_CBOR_SUPPORT
-	default 30
-	help
-	  The CBOR library requires you to set an upper limit for the records when encoder
-	  and decoder do get generated.
+	  Specify maximum number of registration retries, before the application
+	  is notified about the network failure. Once application is notified,
+	  it's up to the application to handle this situation in a way
+	  appropriate for the specific use-case (for instance by waiting for
+	  LTE link to be re-established).
 
 config LWM2M_RESOURCE_DATA_CACHE_SUPPORT
 	bool "Resource Time series data cache support"
@@ -563,6 +229,160 @@ endchoice
 
 endif # LWM2M_RESOURCE_DATA_CACHE_SUPPORT
 
+endmenu # "Engine features"
+
+menu "Memory and buffer size configuration"
+
+config LWM2M_ENGINE_STACK_SIZE
+	int "LWM2M engine stack size"
+	default 2560 if NET_LOG
+	default 2048
+	help
+	  Set the stack size for the LwM2M library engine (used for handling
+	  OBSERVE and NOTIFY events)
+
+config LWM2M_ENGINE_MAX_MESSAGES
+	int "LWM2M engine max. message object"
+	default 10
+	help
+	  Set the maximum message objects for the LwM2M library client
+
+config LWM2M_COAP_BLOCK_SIZE
+	int "LWM2M CoAP block-wise transfer size"
+	default 256
+	range 64 1024
+	help
+	  CoAP block size used by LwM2M when performing block-wise
+	  transfers. Possible values: 64, 128, 256, 512 and 1024.
+
+config LWM2M_ENGINE_MESSAGE_HEADER_SIZE
+	int "Room for CoAP header data"
+	default 48
+	range 24 128
+	help
+	  Extra room allocated to handle CoAP header data
+
+config LWM2M_COAP_MAX_MSG_SIZE
+	int "LWM2M CoAP maximum message size"
+	default LWM2M_COAP_BLOCK_SIZE
+	help
+	  CoAP message size used by LWM2M. Minimum is the block size used
+	  in blockwise transfers.
+
+config LWM2M_ENGINE_VALIDATION_BUFFER_SIZE
+	int "Size of the validation buffer for the incoming data"
+	default 64
+	help
+	  LwM2M will use the validation buffer during the write operation, to
+	  decode the resource value before validating it (applies for resources
+	  for which validation callback has been registered). Set this value to
+	  the maximum expected size of the resources that need to be validated
+	  (and thus have validation callback registered).
+	  Setting the validation buffer size to 0 disables validation support.
+
+config LWM2M_ENGINE_MAX_PENDING
+	int "LWM2M engine max. pending objects"
+	default 5
+	help
+	  Set the maximum pending objects for the LwM2M library client
+
+config LWM2M_ENGINE_MAX_REPLIES
+	int "LWM2M engine max. reply objects"
+	default 5
+	help
+	  Set the maximum reply objects for the LwM2M library client
+
+config LWM2M_ENGINE_MAX_OBSERVER
+	int "Maximum # of observable LwM2M resources"
+	default 10
+	range 5 200
+	help
+	  This value sets the maximum number of resources which can be
+	  added to the observe notification list.
+
+config LWM2M_RD_CLIENT_ENDPOINT_NAME_MAX_LENGTH
+	int "Maximum length of client endpoint name"
+	default 33
+	help
+	  Default: room for 32 hexadecimal digits (UUID) + NULL
+
+config LWM2M_SECURITY_KEY_SIZE
+	int "Buffer size of the security key resources"
+	default 16
+	help
+	  This setting establishes the size of the key (pre-shared / public)
+	  resources in the security object instances.
+
+config LWM2M_SECURITY_DTLS_TLS_CIPHERSUITE_MAX
+	int "Maximum # of DTLS/TLS ciphersuite resource instances"
+	default 5
+	range 0 20
+	depends on LWM2M_SECURITY_OBJECT_VERSION_1_1
+	help
+	  This setting sets the maximum number of the resource instances of
+	  a security object defined in LwM2M version 1.1. Affects the resource
+	  0/X/16, where X is the object instance number.
+
+config LWM2M_SECURITY_INSTANCE_COUNT
+	int "Maximum # of LwM2M Security object instances"
+	default 2 if LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP
+	default 1
+	range 1 10
+	help
+	  This setting establishes the total count of LwM2M Security instances
+	  available to the client.
+
+config LWM2M_SERVER_INSTANCE_COUNT
+	int "Maximum # of LwM2M Server object instances"
+	default 2 if LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP
+	default 1
+	range 1 10
+	help
+	  This setting establishes the total count of LwM2M Server instances
+	  available to the client (including: bootstrap and regular servers).
+
+if LWM2M_COAP_BLOCK_TRANSFER
+config LWM2M_COAP_ENCODE_BUFFER_SIZE
+	int "LwM2M CoAP buffer size for encoding the full message for block-wise transfer"
+	default 1024
+	help
+	  Size of buffers for serializing big LwM2M CoAP messages that need to be
+	  split into blocks for sending.
+
+config LWM2M_NUM_OUTPUT_BLOCK_CONTEXT
+	int "Maximum # of LwM2M block contexts used for outgoing messages"
+	default 3
+	help
+	  Maximum number of CoAP block contexts needed to split messages into blocks for
+	  sending. This limits the numer of messages that need block transfer that can be
+	  handled at the same time.
+
+config LWM2M_LOG_ENCODE_BUFFER_ALLOCATIONS
+	bool "Log allocations of encode buffers for block wise transfer"
+	select MEM_SLAB_TRACE_MAX_UTILIZATION
+	help
+	  The allocation of encode buffers can be tracked to analyse the usage and
+	  to optimize the configuration of number of block contexts and indirectly
+	  the number of available encode buffers.
+endif # LWM2M_COAP_BLOCK_TRANSFER
+
+config LWM2M_NUM_BLOCK1_CONTEXT
+	int "Maximum # of LwM2M block1 contexts"
+	default 3
+	help
+	  This value sets up the maximum number of block1 contexts for
+	  CoAP block-wise transfer we can handle at the same time.
+
+config LWM2M_SWMGMT_PACKAGE_URI_LEN
+	int "Maximum size of the software management object's download URI string"
+	default 128
+
+config LWM2M_COMPOSITE_PATH_LIST_SIZE
+	int "Maximum # of composite read and send operation URL path"
+	default 6
+	help
+	  Define path list size for Composite Read and send operation.
+
 config LWM2M_DEVICE_PWRSRC_MAX
 	int "Maximum # of device power source records"
 	default 5
@@ -589,30 +409,220 @@ config LWM2M_DEVICE_EXT_DEV_INFO_MAX
 	  device object will store before ignoring new values.
 
 config LWM2M_NUM_ATTR
-	int "Maximum # of LWM2M attributes"
+	int "Maximum # of LwM2M attributes"
 	default 20
 	help
 	  This value sets up the maximum number of LwM2M attributes that
 	  we can handle at the same time.
 
-config LWM2M_LOCATION_OBJ_SUPPORT
-	bool "Location object support"
-	help
-	  Include support for LWM2M Location Object (ID 6)
+endmenu # "Memory and buffer size configuration"
 
-config LWM2M_GATEWAY_OBJ_SUPPORT
-	bool "LwM2M Gateway Object (25) [EXPERIMENTAL]"
+menu "Content format supports"
+config LWM2M_RW_OMA_TLV_SUPPORT
+	bool "TLV data format"
+	help
+	  Include support for write / parse TLV data
+
+config LWM2M_RW_JSON_SUPPORT
+	bool "support for JSON writer"
+	depends on JSON_LIBRARY
+	help
+	  Include support for writing JSON data
+
+
+config LWM2M_RW_SENML_JSON_SUPPORT
+	bool "SENML JSON data format"
+	depends on BASE64
+	depends on JSON_LIBRARY
+	help
+	  Include support for write / parse SENML JSON data
+
+config LWM2M_RW_CBOR_SUPPORT
+	bool "support for CBOR writer"
+	depends on ZCBOR
+	help
+	  Include support for writing CBOR data
+
+config LWM2M_RW_SENML_CBOR_SUPPORT
+	bool "support for SenML CBOR writer"
+	depends on ZCBOR
+	depends on ZCBOR_CANONICAL
+	help
+	  Include support for writing SenML CBOR data
+
+config LWM2M_RW_SENML_CBOR_RECORDS
+	int "Maximum # of SenML records packed into a CBOR binary"
+	depends on LWM2M_RW_SENML_CBOR_SUPPORT
+	default 30
+	help
+	  The CBOR library requires you to set an upper limit for the records when encoder
+	  and decoder do get generated.
+
+endmenu # "Content format supports"
+
+config LWM2M_ENGINE_DEFAULT_LIFETIME
+	int "LWM2M engine default server connection lifetime"
+	default 30
+	range 15 4294967295
+	help
+	  Set the default lifetime (in seconds) for the LwM2M library engine.
+	  This is also a minimum lifetime that client accepts. If server sets lifetime
+	  less than this value, client automatically raises it.
+
+config LWM2M_SECONDS_TO_UPDATE_EARLY
+	int "LWM2M Registration Update transmission time before timeout"
+	default 6
+	range 1 4294967295
+	help
+	  Time in seconds before the registration timeout, when the LWM2M
+	  Registration Update is sent by the engine. In networks with large
+	  round trip times (like NB-IoT), it might be needed to set this value
+	  higher, in order to allow the response to arrive before timeout.
+
+config LWM2M_SHELL
+	bool "LwM2M shell utilities"
+	select SHELL
+	help
+	  Activate shell module that provides LwM2M commands like
+	  send to the console.
+
+config LWM2M_ACCESS_CONTROL_ENABLE
+	bool "Access control support (ID 2)"
+	help
+	  Enabling this setting registers the access control object.
+
+config LWM2M_ACCESS_CONTROL_INSTANCE_COUNT
+	int "Maximum # of LwM2M Access Control object instances" if LWM2M_ACCESS_CONTROL_ENABLE
+	default 50
+	help
+	  This setting establishes the total count of LwM2M Access Control instances
+	  available to the client.
+
+config LWM2M_CONN_MON_OBJ_SUPPORT
+	bool "Connectivity Monitoring object support (ID 4)"
+	help
+	  Include support for LwM2M Connectivity Monitoring Object
+
+if LWM2M_CONN_MON_OBJ_SUPPORT
+choice
+	prompt "LwM2M Connectivity Monitor object version"
+	default LWM2M_CONNMON_OBJECT_VERSION_1_0 if LWM2M_VERSION_1_0
+	default LWM2M_CONNMON_OBJECT_VERSION_1_2 if LWM2M_VERSION_1_1
+	help
+	  Select Which version of the Connectivity Monitor object should be used.
+
+config LWM2M_CONNMON_OBJECT_VERSION_1_0
+	bool "Connectivity monitor object version 1.0"
+
+config LWM2M_CONNMON_OBJECT_VERSION_1_2
+	bool "Connectivity monitor object version 1.2"
+
+endchoice
+
+config LWM2M_CONN_MON_BEARER_MAX
+	int "Maximum # of available network bearer resource instances"
+	default 1
+	help
+	  This value sets the maximum number of available network bearer
+	  resource instances.  These are displayed via the
+	  "Connection Monitoring" object /4/0/1.
+
+config LWM2M_CONN_MON_APN_MAX
+	int "Maximum # of APN resource instances"
+	default 1
+	help
+	  This value sets the maximum number of APN resource instances.
+	  These are displayed via the "Connection Monitoring" object /4/0/7.
+endif # LWM2M_CONN_MON_OBJ_SUPPORT
+
+config LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT
+	bool "Firmware Update object support (ID 5)"
+	default y
+	help
+	  Include support for LwM2M Firmware Update Object
+
+if LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT
+config LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT_MULTIPLE
+	bool "Support multiple firmware update objects [EXPERIMENTAL]"
 	select EXPERIMENTAL
-
-config LWM2M_EVENT_LOG_OBJ_SUPPORT
-	bool "LwM2M Event Log Object (20)"
 	help
-	  Include support for LWM2M Event Log Object (ID 20)
+	  Support multiple instances of LwM2M Firmware Update Object
+
+config LWM2M_FIRMWARE_UPDATE_OBJ_INSTANCE_COUNT
+	int "Maximum # of LwM2M Firmware update object instances"
+	default 1
+	help
+	  This setting establishes the total count of LwM2M Firmware update
+	  object instances available to the client.
+
+config LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
+	bool "Firmware Update object pull support"
+	default y
+	depends on (HTTP_PARSER || HTTP_PARSER_URL)
+	help
+	  Include support for pulling a file from a remote server via
+	  block transfer and "FIRMWARE PACKAGE URI" resource.  This option
+	  adds another UDP context and packet handling.
+
+config LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT
+	bool "Firmware Update object pull via CoAP-CoAP/HTTP proxy support"
+	depends on LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
+	help
+	  Include support for pulling firmware file via a CoAP-CoAP/HTTP proxy.
+
+config LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_ADDR
+	string "CoAP proxy network address"
+	depends on LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT
+	help
+	  Network address of the CoAP proxy server.
+
+endif # LWM2M_FIRMWARE_UPDATE_OBJ_SUPPORT
+
+config LWM2M_LOCATION_OBJ_SUPPORT
+	bool "Location object support (ID 6)"
+	help
+	  Include support for LwM2M Location Object
+
+config LWM2M_SWMGMT_OBJ_SUPPORT
+	bool "Software management object support (ID 9)"
+	help
+	  Include support for LwM2M Software Management Object.
+
+if LWM2M_SWMGMT_OBJ_SUPPORT
+config LWM2M_SWMGMT_MAX_INSTANCE_COUNT
+	int "Maximum # of object instances"
+	depends on LWM2M_SWMGMT_OBJ_SUPPORT
+	default 1
+
+config LWM2M_SWMGMT_PACKAGE_NAME_LEN
+	int "Maximum size of the software management object's name string"
+	depends on LWM2M_SWMGMT_OBJ_SUPPORT
+	default 64
+
+config LWM2M_SWMGMT_PACKAGE_VERSION_LEN
+	int "Maximum size of the software management object's version string"
+	depends on LWM2M_SWMGMT_OBJ_SUPPORT
+	default 64
+endif # LWM2M_SWMGMT_OBJ_SUPPORT
+
+config LWM2M_PORTFOLIO_OBJ_SUPPORT
+	bool "LwM2M Portfolio object ID support (ID 16)"
+	help
+	  Include support for LwM2M Portfolio Object.
 
 config LWM2M_BINARYAPPDATA_OBJ_SUPPORT
-	bool "LwM2M BinaryAppDataContainer Object (19)"
+	bool "LwM2M BinaryAppDataContainer Object (ID 19)"
 	help
-	  Include support for LWM2M BinaryAppDataContainer Object (ID 19)
+	  Include support for LwM2M BinaryAppDataContainer Object
+
+config LWM2M_EVENT_LOG_OBJ_SUPPORT
+	bool "LwM2M Event Log Object (ID 20)"
+	help
+	  Include support for LwM2M Event Log Object
+
+config LWM2M_GATEWAY_OBJ_SUPPORT
+	bool "LwM2M Gateway Object (ID 25) [EXPERIMENTAL]"
+	select EXPERIMENTAL
 
 if LWM2M_GATEWAY_OBJ_SUPPORT
 
@@ -621,7 +631,7 @@ config LWM2M_GATEWAY_MAX_INSTANCES
 	default 1
 	help
 	  This setting establishes the total count of LwM2M Gateway
-	  instances available to the LWM2M client.
+	  instances available to the LwM2M client.
 
 config LWM2M_GATEWAY_DEFAULT_DEVICE_ID
 	string "Identifies the IoT Device bridged to the LwM2M Gateway"
@@ -657,16 +667,16 @@ config LWM2M_GATEWAY_IOT_DEVICE_OBJECTS_MAX_STR_SIZE
 
 endif # LWM2M_GATEWAY_OBJ_SUPPORT
 
-menu "IPSO Alliance Smart Object Support"
-
 source "subsys/net/lib/lwm2m/Kconfig.ipso"
-
-endmenu
-
-menu "uCIFI Alliance Object Support"
 
 source "subsys/net/lib/lwm2m/Kconfig.ucifi"
 
-endmenu
+menu "Deprecated flags"
+config LWM2M_RD_CLIENT_SUPPORT
+	bool "DEPRECATED: client bootstrap/registration state machine"
+	select DEPRECATED
+	help
+	  Deprecated flag. RD state machine is always part of engine. It cannot be disabled.
+endmenu # "Deprecated flags"
 
 endif # LWM2M


### PR DESCRIPTION
* Create submenu for protocol versions. Like LwM2M 1.0 vs 1.1. Object versions.
* Create submenu for engine features. Containing all engine tweaks that are not directly from protocol specification.
* Create submenu for all memory tuning options. For example maximum number of certain objects, buffer sizes, etc.
* Order all objects by object ID and show the ID in title.
* When multiple options depend on same feature, group them under if <option> ... endif. Preferably directly after the selection itself.
* Move IPSO and uCIFI menuentries one sublevel up.
* Drop deprecated entries to bottom.

No functional changes, just clean up of Kconfig menu.

## Main LwM2M menu
![Screenshot from 2023-08-04 12-15-58](https://github.com/zephyrproject-rtos/zephyr/assets/3104794/8d8c5783-92d6-4341-b815-254284940633)

## Protocol versions
![Screenshot from 2023-08-04 12-16-13](https://github.com/zephyrproject-rtos/zephyr/assets/3104794/7b2d42ee-0f80-46a0-8645-4612962a277b)

## Engine features
![Screenshot from 2023-08-04 12-16-29](https://github.com/zephyrproject-rtos/zephyr/assets/3104794/162e2a00-0904-4e20-9306-18fe6dcbe8f8)
