### PR TITLE
usb: device: Fix transfer slot leak without callback

### DIFF
--- a/subsys/usb/device/usb_transfer.c
+++ b/subsys/usb/device/usb_transfer.c
@@ -131,7 +131,7 @@ static void usb_transfer_work(struct k_work *item)
 	}
 
 done:
-	if (trans->status != -EBUSY && trans->cb) { /* Transfer complete */
+	if (trans->status != -EBUSY) { /* Transfer complete */
 		usb_transfer_callback cb = trans->cb;
 		int tsize = trans->tsize;
 		void *priv = trans->priv;
@@ -149,7 +149,9 @@ done:
 		k_sem_give(&trans->sem);
 
 		/* Transfer completion callback */
-		cb(ep, tsize, priv);
+		if (cb) {
+			cb(ep, tsize, priv);
+		}
 	}
 }
 


### PR DESCRIPTION
Log transfer status and release transfer semaphore regardless if user provided transfer completion callback or not. This fixes transfer slot leak when transfer without callback completes.