### PR TITLE
drivers: counter: Add Ambiq counter driver

### DIFF
--- a/boards/arm/apollo4p_evb/apollo4p_evb.dts
+++ b/boards/arm/apollo4p_evb/apollo4p_evb.dts
@@ -21,3 +21,7 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&counter0 {
+	status = "okay";
+};

--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -11,6 +11,7 @@ zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_TIMER_TMR_CMSDK_APB         timer_tmr_cmsdk_apb.c)
 zephyr_library_sources_ifdef(CONFIG_TIMER_DTMR_CMSDK_APB        timer_dtmr_cmsdk_apb.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_AMBIQ               counter_ambiq_timer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_GECKO_RTCC          counter_gecko_rtcc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_GECKO_STIMER        counter_gecko_stimer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_IMX_EPIT            counter_imx_epit.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -20,6 +20,8 @@ module = COUNTER
 module-str = counter
 source "subsys/logging/Kconfig.template.log_config"
 
+source "drivers/counter/Kconfig.ambiq"
+
 source "drivers/counter/Kconfig.gecko"
 
 source "drivers/counter/Kconfig.tmr_cmsdk_apb"

--- a/drivers/counter/Kconfig.ambiq
+++ b/drivers/counter/Kconfig.ambiq
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+
+
+config COUNTER_AMBIQ
+	bool "Ambiq Counter Driver"
+	default y
+	depends on DT_HAS_AMBIQ_COUNTER_ENABLED
+	select AMBIQ_HAL
+	select AMBIQ_HAL_USE_TIMER
+	help
+	  Enables the Counter driver for Ambiq devices.

--- a/drivers/counter/counter_ambiq_timer.c
+++ b/drivers/counter/counter_ambiq_timer.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2023 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ambiq_counter
+
+#include <zephyr/drivers/counter.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+/* ambiq-sdk includes */
+#include <am_mcu_apollo.h>
+
+LOG_MODULE_REGISTER(ambiq_counter, CONFIG_COUNTER_LOG_LEVEL);
+
+static void counter_ambiq_isr(void *arg);
+
+#define TIMER_IRQ (DT_INST_IRQN(0))
+
+struct counter_ambiq_config {
+	struct counter_config_info counter_info;
+};
+
+struct counter_ambiq_data {
+	counter_alarm_callback_t callback;
+	void *user_data;
+};
+
+static struct k_spinlock lock;
+
+static int counter_ambiq_init(const struct device *dev)
+{
+	am_hal_timer_config_t tc;
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	am_hal_timer_default_config_set(&tc);
+	tc.eInputClock = AM_HAL_TIMER_CLOCK_HFRC_DIV16;
+	tc.eFunction = AM_HAL_TIMER_FN_UPCOUNT;
+	tc.ui32PatternLimit = 0;
+
+	am_hal_timer_config(0, &tc);
+	am_hal_timer_interrupt_enable(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
+
+	k_spin_unlock(&lock, key);
+
+	NVIC_ClearPendingIRQ(TIMER_IRQ);
+	IRQ_CONNECT(TIMER_IRQ, 0, counter_ambiq_isr, DEVICE_DT_INST_GET(0), 0);
+	irq_enable(TIMER_IRQ);
+
+	return 0;
+}
+
+static int counter_ambiq_start(const struct device *dev)
+{
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	am_hal_timer_start(0);
+
+	k_spin_unlock(&lock, key);
+
+	return 0;
+}
+
+static int counter_ambiq_stop(const struct device *dev)
+{
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	am_hal_timer_stop(0);
+
+	k_spin_unlock(&lock, key);
+
+	return 0;
+}
+
+static int counter_ambiq_get_value(const struct device *dev, uint32_t *ticks)
+{
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	*ticks = am_hal_timer_read(0);
+
+	k_spin_unlock(&lock, key);
+
+	return 0;
+}
+
+static int counter_ambiq_set_alarm(const struct device *dev, uint8_t chan_id,
+				   const struct counter_alarm_cfg *alarm_cfg)
+{
+	ARG_UNUSED(chan_id);
+	struct counter_ambiq_data *data = dev->data;
+	uint32_t now;
+
+	counter_ambiq_get_value(dev, &now);
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
+		am_hal_timer_compare1_set(0, now + alarm_cfg->ticks);
+	} else {
+		am_hal_timer_compare1_set(0, alarm_cfg->ticks);
+	}
+
+	data->user_data = alarm_cfg->user_data;
+	data->callback = alarm_cfg->callback;
+
+	k_spin_unlock(&lock, key);
+
+	return 0;
+}
+
+static int counter_ambiq_cancel_alarm(const struct device *dev, uint8_t chan_id)
+{
+	ARG_UNUSED(chan_id);
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	am_hal_timer_interrupt_disable(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
+	k_spin_unlock(&lock, key);
+
+	return 0;
+}
+
+static int counter_ambiq_set_top_value(const struct device *dev, const struct counter_top_cfg *cfg)
+{
+	const struct counter_ambiq_config *config = dev->config;
+
+	if (cfg->ticks != config->counter_info.max_top_value) {
+		return -ENOTSUP;
+	} else {
+		return 0;
+	}
+}
+
+static uint32_t counter_ambiq_get_pending_int(const struct device *dev)
+{
+	return 0;
+}
+
+static uint32_t counter_ambiq_get_top_value(const struct device *dev)
+{
+	const struct counter_ambiq_config *config = dev->config;
+
+	return config->counter_info.max_top_value;
+}
+
+static const struct counter_driver_api counter_api = {
+	.start = counter_ambiq_start,
+	.stop = counter_ambiq_stop,
+	.get_value = counter_ambiq_get_value,
+	.set_alarm = counter_ambiq_set_alarm,
+	.cancel_alarm = counter_ambiq_cancel_alarm,
+	.set_top_value = counter_ambiq_set_top_value,
+	.get_pending_int = counter_ambiq_get_pending_int,
+	.get_top_value = counter_ambiq_get_top_value,
+};
+
+static void counter_ambiq_isr(void *arg)
+{
+	const struct device *dev = (const struct device *)arg;
+	struct counter_ambiq_data *data = dev->data;
+	uint32_t now = 0;
+
+	am_hal_timer_interrupt_clear(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
+	counter_ambiq_get_value(dev, &now);
+
+	if (data->callback) {
+		data->callback(dev, 0, now, data->user_data);
+	}
+}
+
+#define AMBIQ_COUNTER_INIT(idx)                                                                    \
+                                                                                                   \
+	static struct counter_ambiq_data counter_data_##idx;                                       \
+                                                                                                   \
+	static const struct counter_ambiq_config counter_config_##idx = {                          \
+		.counter_info = {.max_top_value = UINT32_MAX,                                      \
+				 .freq = 6000000,                                                  \
+				 .flags = COUNTER_CONFIG_INFO_COUNT_UP,                            \
+				 .channels = 1},                                                   \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(idx, counter_ambiq_init, NULL, &counter_data_##idx,                  \
+			      &counter_config_##idx, PRE_KERNEL_1, CONFIG_COUNTER_INIT_PRIORITY,   \
+			      &counter_api);
+
+DT_INST_FOREACH_STATUS_OKAY(AMBIQ_COUNTER_INIT);

--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -48,6 +48,13 @@
 			status = "okay";
 		};
 
+		counter0: counter@40008000 {
+			compatible = "ambiq,counter";
+			reg = <0x40008000 0x80>;
+			interrupts = <67 0>;
+			status = "disabled";
+		};
+
 		uart0: uart@4001c000 {
 			compatible = "ambiq,uart", "arm,pl011";
 			reg = <0x4001c000 0x1000>;

--- a/dts/bindings/counter/ambiq,counter.yaml
+++ b/dts/bindings/counter/ambiq,counter.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: Ambiq Timer/Counter
+
+compatible: "ambiq,counter"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true

--- a/modules/hal_ambiq/Kconfig
+++ b/modules/hal_ambiq/Kconfig
@@ -20,4 +20,9 @@ config AMBIQ_HAL_USE_STIMER
 	help
 	  Use the STIMER driver from Ambiq HAL
 
+config AMBIQ_HAL_USE_TIMER
+	bool
+	help
+	  Use the TIMER driver from Ambiq HAL
+
 endif # AMBIQ_HAL

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -47,6 +47,8 @@ struct counter_alarm_cfg alarm_cfg;
 #define TIMER DT_NODELABEL(stimer0)
 #elif defined(CONFIG_COUNTER_INFINEON_CAT1)
 #define TIMER DT_NODELABEL(counter0_0)
+#elif defined(CONFIG_COUNTER_AMBIQ)
+#define TIMER DT_NODELABEL(counter0)
 #endif
 
 static void test_counter_interrupt_fn(const struct device *counter_dev,

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: c8203b6fc752e51fb3cb1e98441f392cc4493623
+      revision: 5079b0096479a5630b91d38a891c2db1693faa2a
       path: modules/hal/ambiq
       groups:
         - hal


### PR DESCRIPTION
This PR adds the Ambiq counter driver, as well as instances in the SoC dtsi file, enabling it on the apollo4p_evb board.

It should be merged after https://github.com/zephyrproject-rtos/hal_ambiq/pull/2 is merged.