### PR TITLE
boards: arm: nucleo: Add leds label

### DIFF
--- a/boards/arm/nucleo_c031c6/nucleo_c031c6.dts
+++ b/boards/arm/nucleo_c031c6/nucleo_c031c6.dts
@@ -20,7 +20,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_4: led_4 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f031k6/nucleo_f031k6.dts
+++ b/boards/arm/nucleo_f031k6/nucleo_f031k6.dts
@@ -19,7 +19,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_3: led_3 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f042k6/nucleo_f042k6.dts
+++ b/boards/arm/nucleo_f042k6/nucleo_f042k6.dts
@@ -19,7 +19,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_3: led_3 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -20,7 +20,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/arm/nucleo_f302r8/nucleo_f302r8.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
+++ b/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
@@ -20,7 +20,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_3: green_led_3 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/arm/nucleo_f303re/nucleo_f303re.dts
@@ -22,7 +22,7 @@
 		zephyr,canbus = &can1;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -23,7 +23,7 @@
 		zephyr,code-partition = &slot0_partition;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f410rb/nucleo_f410rb.dts
+++ b/boards/arm/nucleo_f410rb/nucleo_f410rb.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/arm/nucleo_f411re/nucleo_f411re.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/arm/nucleo_f412zg/nucleo_f412zg.dts
@@ -20,7 +20,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/arm/nucleo_f413zh/nucleo_f413zh.dts
@@ -20,7 +20,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -22,7 +22,7 @@
 		zephyr,code-partition = &slot0_partition;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -22,7 +22,7 @@
 		zephyr,canbus = &can2;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/arm/nucleo_f446ze/nucleo_f446ze.dts
@@ -21,7 +21,7 @@
 		zephyr,canbus = &can1;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -29,7 +29,7 @@
 		zephyr,canbus = &can1;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/arm/nucleo_f756zg/nucleo_f756zg.dts
@@ -29,7 +29,7 @@
 		zephyr,dtcm = &dtcm;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -30,7 +30,7 @@
 		zephyr,canbus = &can1;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_g031k8/nucleo_g031k8.dts
+++ b/boards/arm/nucleo_g031k8/nucleo_g031k8.dts
@@ -20,7 +20,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_3: led_3 {
 			gpios = <&gpioc 6 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_g070rb/nucleo_g070rb.dts
+++ b/boards/arm/nucleo_g070rb/nucleo_g070rb.dts
@@ -21,7 +21,7 @@
 	};
 
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_4 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -22,7 +22,7 @@
 	};
 
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_4 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -23,7 +23,7 @@
 		zephyr,canbus = &can1;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_4 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -21,7 +21,7 @@
 		zephyr,canbus = &can1;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/arm/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -11,7 +11,7 @@
 #include "st_morpho_connector.dtsi"
 
 / {
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
@@ -25,7 +25,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -23,7 +23,7 @@
 		zephyr,canbus = &can1;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q.dtsi
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q.dtsi
@@ -8,7 +8,7 @@
 #include "arduino_r3_connector.dtsi"
 
 / {
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
@@ -23,7 +23,7 @@
 		zephyr,canbus = &can1;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
+++ b/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
@@ -22,7 +22,7 @@
 		zephyr,itcm = &itcm;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l011k4/nucleo_l011k4.dts
+++ b/boards/arm/nucleo_l011k4/nucleo_l011k4.dts
@@ -19,7 +19,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l031k6/nucleo_l031k6.dts
+++ b/boards/arm/nucleo_l031k6/nucleo_l031k6.dts
@@ -20,7 +20,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/arm/nucleo_l053r8/nucleo_l053r8.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_0: led_0 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_LOW>;

--- a/boards/arm/nucleo_l412rb_p/nucleo_l412rb_p.dts
+++ b/boards/arm/nucleo_l412rb_p/nucleo_l412rb_p.dts
@@ -20,7 +20,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -20,7 +20,7 @@
 		zephyr,canbus = &can1;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l433rc_p/nucleo_l433rc_p.dts
+++ b/boards/arm/nucleo_l433rc_p/nucleo_l433rc_p.dts
@@ -21,7 +21,7 @@
 		zephyr,canbus = &can1;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l452re/nucleo_l452re.dts
+++ b/boards/arm/nucleo_l452re/nucleo_l452re.dts
@@ -15,7 +15,7 @@
 	model = "STMicroelectronics STM32L452RE-NUCLEO board";
 	compatible = "st,stm32l452re-nucleo";
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l452re/nucleo_l452re_p.dts
+++ b/boards/arm/nucleo_l452re/nucleo_l452re_p.dts
@@ -14,7 +14,7 @@
 	model = "STMicroelectronics STM32L452RE-P-NUCLEO board";
 	compatible = "st,stm32l452re-nucleo";
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led: led_0 {
 			gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/arm/nucleo_l476rg/nucleo_l476rg.dts
@@ -21,7 +21,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
+++ b/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
@@ -20,7 +20,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
 			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l4a6zg/nucleo_l4a6zg.dts
+++ b/boards/arm/nucleo_l4a6zg/nucleo_l4a6zg.dts
@@ -20,7 +20,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
 			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -20,7 +20,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_0: led_0 {
 			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
@@ -9,7 +9,7 @@
 #include "arduino_r3_connector.dtsi"
 
 / {
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
 			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -9,7 +9,7 @@
 #include "arduino_r3_connector.dtsi"
 
 / {
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		green_led_1: led_1 {
 			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -23,7 +23,7 @@
 		zephyr,code-partition = &slot0_partition;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		blue_led_1: led_0 {
 			gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/nucleo_wba52cg/nucleo_wba52cg.dts
+++ b/boards/arm/nucleo_wba52cg/nucleo_wba52cg.dts
@@ -23,7 +23,7 @@
 		zephyr,flash = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		blue_led_1: led_1 {
 			gpios = <&gpiob 4 GPIO_ACTIVE_LOW>;

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -21,7 +21,7 @@
 		zephyr,code-partition = &flash0;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 		blue_led_1: led_0 {
 			gpios = <&gpiob 15 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
The nucleo evaluation boards can be enhanced with shields for additional functionality. Flat device tree overlays can be used to configure and support these shields. Regrettably leds can not be simply added due to a missing label. Tag leds with a label.
