### PR TITLE
ARC: scripts: twister: fix toolchain filtering

### DIFF
--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -75,7 +75,11 @@ class Platform:
             self.supported_toolchains = []
 
         support_toolchain_variants = {
-          "arc": ["zephyr", "cross-compile", "xtools", "arcmwdt"],
+          # we don't provide defaults for 'arc' intentionally: some targets can't be built with GNU
+          # toolchain ("zephyr", "cross-compile", "xtools" options) and for some targets we haven't
+          # provided MWDT compiler / linker options in corresponding SoC file in Zephyr, so these
+          # targets can't be built with ARC MWDT toolchain ("arcmwdt" option) by Zephyr build system
+          # Instead for 'arc' we rely on 'toolchain' option in board yaml configuration.
           "arm": ["zephyr", "gnuarmemb", "xtools", "armclang", "llvm"],
           "arm64": ["zephyr", "cross-compile"],
           "mips": ["zephyr", "xtools"],


### PR DESCRIPTION
Let's not provide default toolchains for `arc`: some targets can't be built with GNU toolchain (`zephyr`, `cross-compile`, `xtools` options) and for some targets we haven't provided MWDT compiler / linker options in corresponding SoC file in Zephyr, so these targets can't be built with ARC MWDT toolchain (`arcmwdt` option) by Zephyr build system.

Instead for `arc` we rely on 'toolchain' option in board yaml configuration.

Fixes: https://github.com/zephyrproject-rtos/zephyr/pull/56737