### PR TITLE
modbus: use macro for function code for input register

### DIFF
--- a/subsys/modbus/modbus_client.c
+++ b/subsys/modbus/modbus_client.c
@@ -412,7 +412,7 @@ int modbus_read_input_regs(const int iface,
 	sys_put_be16(start_addr, &ctx->tx_adu.data[0]);
 	sys_put_be16(num_regs, &ctx->tx_adu.data[2]);
 
-	err = mbc_send_cmd(ctx, unit_id, 4, reg_buf);
+	err = mbc_send_cmd(ctx, unit_id, MODBUS_FC04_IN_REG_RD, reg_buf);
 	k_mutex_unlock(&ctx->iface_lock);
 
 	return err;


### PR DESCRIPTION
use MODBUS_FC04_IN_REG_RD for input register reading function code 4.