### PR TITLE
drivers: i3c: cdns: fix transfers while not idle and reading error upon completion

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -1302,7 +1302,7 @@ static void cdns_i3c_complete_transfer(const struct device *dev)
 	}
 
 	for (int i = 0; i < data->xfer.num_cmds; i++) {
-		switch (data->xfer.cmds->error) {
+		switch (data->xfer.cmds[i].error) {
 		case CMDR_NO_ERROR:
 			break;
 


### PR DESCRIPTION
If a transfer happen in rapid sucession. It was possible for
the core to not be ready to accept another command. Poll on
the idle status bit until the core is ready to accept new data.

Due to a bug, after a completed transfer happen. Only the first
command response error was read. This fixes the issue so all
commands are read for if an error occurred.