### PR TITLE
boards: arm: xiao_ble: Fix mismatched spi peripheral

### DIFF
--- a/boards/arm/xiao_ble/seeed_xiao_connector.dtsi
+++ b/boards/arm/xiao_ble/seeed_xiao_connector.dtsi
@@ -27,6 +27,6 @@
 	};
 };
 
-xiao_spi: &spi0 {};
+xiao_spi: &spi2 {};
 xiao_i2c: &i2c1 {};
 xiao_serial: &uart0 {};


### PR DESCRIPTION
As per #54658, spi2 is configured to be used on XIAO BLE (Sense) board. This commit updates its connector devicetree to use this configured spi peripheral accordingly.