### PR TITLE
drivers: sensor: lis3mdl: always use continuous mode

### DIFF
--- a/drivers/sensor/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/lis3mdl/lis3mdl.c
@@ -140,8 +140,7 @@ int lis3mdl_init(const struct device *dev)
 	chip_cfg[0] = LIS3MDL_REG_CTRL1;
 	chip_cfg[1] = LIS3MDL_TEMP_EN_MASK | lis3mdl_odr_bits[idx];
 	chip_cfg[2] = LIS3MDL_FS_IDX << LIS3MDL_FS_SHIFT;
-	chip_cfg[3] = lis3mdl_odr_bits[idx] & LIS3MDL_FAST_ODR_MASK ?
-		      LIS3MDL_MD_SINGLE : LIS3MDL_MD_CONTINUOUS;
+	chip_cfg[3] = LIS3MDL_MD_CONTINUOUS;
 	chip_cfg[4] = ((lis3mdl_odr_bits[idx] & LIS3MDL_OM_MASK) >>
 		       LIS3MDL_OM_SHIFT) << LIS3MDL_OMZ_SHIFT;
 	chip_cfg[5] = LIS3MDL_BDU_EN;


### PR DESCRIPTION
The LIS3MDL driver misunderstands the MD[1:0] bits in CTRL_REG3. Correct this so that all ODR settings are functional.

Currently, single-conversion mode is enabled when fast ODR is set, resulting in only one measurement being taken before the device immediately returns to power-down mode. The result is that all fast-ODR rates (155 and higher) are not usable when assigned to CONFIG_LIS3MDL_ODR.

Continuous mode is the only mode truly supported by this driver and should always be used.