### PR TITLE
uart_sam0: don't consume CONFIG_UART_ASYNC_API directly.

### DIFF
--- a/boards/arm/atsamc21n_xpro/atsamc21n_xpro.yaml
+++ b/boards/arm/atsamc21n_xpro/atsamc21n_xpro.yaml
@@ -18,4 +18,4 @@ supported:
   - i2c
   - pwm
   - spi
-  - can
+  - uart

--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.yaml
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.yaml
@@ -13,4 +13,5 @@ supported:
   - gpio
   - i2c
   - spi
+  - uart
   - watchdog

--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.yaml
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.yaml
@@ -18,6 +18,7 @@ supported:
   - i2c
   - pwm
   - spi
+  - uart
   - usb_cdc
   - usb_device
   - watchdog

--- a/boards/arm/atsame54_xpro/atsame54_xpro.yaml
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.yaml
@@ -16,5 +16,6 @@ supported:
   - pwm
   - spi
   - i2c
+  - uart
   - usb_device
   - netif:eth

--- a/boards/arm/atsaml21_xpro/atsaml21_xpro.yaml
+++ b/boards/arm/atsaml21_xpro/atsaml21_xpro.yaml
@@ -18,6 +18,7 @@ supported:
   - i2c
   - pwm
   - spi
+  - uart
   - usb_cdc
   - usb_device
   - watchdog

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.yaml
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.yaml
@@ -18,6 +18,7 @@ supported:
   - netif
   - pwm
   - spi
+  - uart
   - usb_device
   - xpro_gpio
   - xpro_i2c

--- a/boards/arm/atsamr34_xpro/atsamr34_xpro.yaml
+++ b/boards/arm/atsamr34_xpro/atsamr34_xpro.yaml
@@ -18,6 +18,7 @@ supported:
   - i2c
   - pwm
   - spi
+  - uart
   - usb_cdc
   - usb_device
   - watchdog

--- a/drivers/serial/Kconfig.sam0
+++ b/drivers/serial/Kconfig.sam0
@@ -9,8 +9,12 @@ config UART_SAM0
 	depends on DT_HAS_ATMEL_SAM0_UART_ENABLED
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
-	# the ASYNC implementation requires a DMA controller
 	select SERIAL_SUPPORT_ASYNC if DT_HAS_ATMEL_SAM0_DMAC_ENABLED
-	select DMA if UART_ASYNC_API
 	help
 	  This option enables the SERCOMx USART driver for Atmel SAM0 MCUs.
+
+config UART_SAM0_ASYNC
+	bool "Async UART support for Atmel SAM0 series."
+	depends on DMA_SAM0
+	depends on UART_SAM0
+	depends on UART_ASYNC_API

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -43,10 +43,10 @@ struct uart_sam0_dev_cfg {
 	uint32_t pm_apbcmask;
 	uint16_t gclk_clkctrl_id;
 #endif
-#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
+#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_SAM0_ASYNC
 	void (*irq_config_func)(const struct device *dev);
 #endif
-#if CONFIG_UART_ASYNC_API
+#if CONFIG_UART_SAM0_ASYNC
 	const struct device *dma_dev;
 	uint8_t tx_dma_request;
 	uint8_t tx_dma_channel;
@@ -64,7 +64,7 @@ struct uart_sam0_dev_data {
 	void *cb_data;
 	uint8_t txc_cache;
 #endif
-#if CONFIG_UART_ASYNC_API
+#if CONFIG_UART_SAM0_ASYNC
 	const struct device *dev;
 	const struct uart_sam0_dev_cfg *cfg;
 
@@ -126,7 +126,7 @@ static int uart_sam0_set_baudrate(SercomUsart *const usart, uint32_t baudrate,
 }
 
 
-#if CONFIG_UART_ASYNC_API
+#if CONFIG_UART_SAM0_ASYNC
 
 static void uart_sam0_dma_tx_done(const struct device *dma_dev, void *arg,
 				  uint32_t id, int error_code)
@@ -565,11 +565,11 @@ static int uart_sam0_init(const struct device *dev)
 	}
 	dev_data->config_cache.baudrate = cfg->baudrate;
 
-#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
+#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_SAM0_ASYNC
 	cfg->irq_config_func(dev);
 #endif
 
-#ifdef CONFIG_UART_ASYNC_API
+#ifdef CONFIG_UART_SAM0_ASYNC
 	dev_data->dev = dev;
 	dev_data->cfg = cfg;
 	if (!device_is_ready(cfg->dma_dev)) {
@@ -705,7 +705,7 @@ static int uart_sam0_err_check(const struct device *dev)
 	return err;
 }
 
-#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
+#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_SAM0_ASYNC
 
 static void uart_sam0_isr(const struct device *dev)
 {
@@ -717,7 +717,7 @@ static void uart_sam0_isr(const struct device *dev)
 	}
 #endif
 
-#if CONFIG_UART_ASYNC_API
+#if CONFIG_UART_SAM0_ASYNC
 	const struct uart_sam0_dev_cfg *const cfg = dev->config;
 	SercomUsart * const regs = cfg->regs;
 
@@ -936,14 +936,14 @@ static void uart_sam0_irq_callback_set(const struct device *dev,
 	dev_data->cb = cb;
 	dev_data->cb_data = cb_data;
 
-#if defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS)
+#if defined(CONFIG_UART_SAM0_ASYNC) && defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS)
 	dev_data->async_cb = NULL;
 	dev_data->async_cb_data = NULL;
 #endif
 }
 #endif
 
-#ifdef CONFIG_UART_ASYNC_API
+#ifdef CONFIG_UART_SAM0_ASYNC
 
 static int uart_sam0_callback_set(const struct device *dev,
 				  uart_callback_t callback,
@@ -1205,7 +1205,7 @@ static const struct uart_driver_api uart_sam0_driver_api = {
 	.irq_update = uart_sam0_irq_update,
 	.irq_callback_set = uart_sam0_irq_callback_set,
 #endif
-#if CONFIG_UART_ASYNC_API
+#if CONFIG_UART_SAM0_ASYNC
 	.callback_set = uart_sam0_callback_set,
 	.tx = uart_sam0_tx,
 	.tx_abort = uart_sam0_tx_abort,
@@ -1215,7 +1215,7 @@ static const struct uart_driver_api uart_sam0_driver_api = {
 #endif
 };
 
-#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
+#if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_SAM0_ASYNC
 
 #define SAM0_UART_IRQ_CONNECT(n, m)					\
 	do {								\
@@ -1253,7 +1253,7 @@ static void uart_sam0_irq_config_##n(const struct device *dev)		\
 #define UART_SAM0_IRQ_HANDLER(n)
 #endif
 
-#if CONFIG_UART_ASYNC_API
+#if CONFIG_UART_SAM0_ASYNC
 #define UART_SAM0_DMA_CHANNELS(n)					\
 	.dma_dev = DEVICE_DT_GET(ATMEL_SAM0_DT_INST_DMA_CTLR(n, tx)),	\
 	.tx_dma_request = ATMEL_SAM0_DT_INST_DMA_TRIGSRC(n, tx),	\

--- a/tests/drivers/uart/uart_async_api/boards/atsamc21n_xpro.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/atsamc21n_xpro.overlay
@@ -18,10 +18,6 @@ dut: &sercom0 {
 	status = "disabled";
 };
 
-&sercom3 {
-	status = "disabled";
-};
-
 &sercom4 {
 	/* configure DMA channels for async operation */
 	dmas = <&dmac 10 0x0A>, <&dmac 11 0x0B>;

--- a/tests/drivers/uart/uart_async_api/boards/atsamd21_xpro.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/atsamd21_xpro.overlay
@@ -1,5 +1,13 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+&dmac {
+	status = "okay";
+};
+
+&sercom0 {
+	status = "disabled";
+};
+
 dut: &sercom1 {
 	/* Internally loop-back TX and RX on PAD0 */
 	rxpo = <0>;
@@ -7,5 +15,11 @@ dut: &sercom1 {
 
 	/* Configure DMA channels for async operation */
 	dmas = <&dmac 0 3>, <&dmac 1 4>;
+	dma-names = "rx", "tx";
+};
+
+&sercom3 {
+	/* configure DMA channels for async operation */
+	dmas = <&dmac 10 7>, <&dmac 11 8>;
 	dma-names = "rx", "tx";
 };

--- a/tests/drivers/uart/uart_async_api/boards/atsame54_xpro.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/atsame54_xpro.overlay
@@ -1,5 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+&dmac {
+	status = "okay";
+};
+
 dut: &sercom1 {
 	status = "okay";
 	compatible = "atmel,sam0-uart";
@@ -13,5 +17,11 @@ dut: &sercom1 {
 
 	/* Configure DMA channels for async operation */
 	dmas = <&dmac 0 6>, <&dmac 1 7>;
+	dma-names = "rx", "tx";
+};
+
+&sercom2 {
+	/* configure DMA channels for async operation */
+	dmas = <&dmac 30 8>, <&dmac 31 9>;
 	dma-names = "rx", "tx";
 };

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -40,3 +40,16 @@ tests:
     filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_UART_MCUX_LPUART
     harness: ztest
     depends_on: dma
+  drivers.uart.async_api.sam0:
+    filter: CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_SOC_FAMILY_SAM0
+    platform_allow:
+      - atsamc21n_xpro
+      - atsamd21_xpro
+      - atsaml21_xpro
+      - atsamr21_xpro
+      - atsamr34_xpro
+      - atsame54_xpro
+    extra_configs:
+      - CONFIG_UART_SAM0_ASYNC=y
+      - CONFIG_DMA=y
+    build_only: true

--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -1,26 +1,8 @@
 common:
   platform_exclude:
-    - seeeduino_xiao
-    - serpente
-    - arduino_nano_33_iot
-    - atsamr21_xpro
-    - adafruit_itsybitsy_m4_express
-    - atsame54_xpro
-    - atsamc21n_xpro
-    - adafruit_trinket_m0
-    - arduino_nano_33_iot
-    - arduino_zero
-    - atsamd21_xpro
-    - adafruit_feather_m0_basic_proto
-    - adafruit_feather_m0_lora
-    - arduino_mkrzero
-    - atsaml21_xpro
-    - atsamr34_xpro
     - stamp_c3
     - wio_terminal
     - xiao_esp32c3
-    - atsamd20_xpro
-    - ev11l78a
   tags:
     - drivers
     - uart


### PR DESCRIPTION
uart_sam0: don't consume CONFIG_UART_ASYNC_API directly.


There are situations in which the async API for uart can be provided
by another driver (case in point, uart_rtt), and thus there is no valid
DMA controller for the uart_sam0 driver to talk with.

By separating the configuration, there's no need to exclude samd20-based
boards (that have no DMA peripheral) from the uart_async_api tests.

Signed-off-by: Diego Elio Pettenò <flameeyes@meta.com>
