### PR TITLE
espi: mchp_xec: Fix possible buffer overflow

### DIFF
--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -647,6 +647,11 @@ static int espi_xec_flash_write(const struct device *dev,
 
 	LOG_DBG("%s", __func__);
 
+	if (sizeof(target_mem) < pckt->len) {
+		LOG_ERR("Packet length is too big");
+		return -ENOMEM;
+	}
+
 	if (!(ESPI_FC_REGS->STS & MCHP_ESPI_FC_STS_CHAN_EN)) {
 		LOG_ERR("Flash channel is disabled");
 		return -EIO;

--- a/drivers/espi/espi_mchp_xec_v2.c
+++ b/drivers/espi/espi_mchp_xec_v2.c
@@ -524,6 +524,11 @@ static int espi_xec_flash_write(const struct device *dev,
 
 	LOG_DBG("%s", __func__);
 
+	if (sizeof(target_mem) < pckt->len) {
+		LOG_ERR("Packet length is too big");
+		return -ENOMEM;
+	}
+
 	if (!(regs->FCSTS & MCHP_ESPI_FC_STS_CHAN_EN)) {
 		LOG_ERR("Flash channel is disabled");
 		return -EIO;


### PR DESCRIPTION
Check the packet lenght in flash_write operation before
copying it to an internal buffer.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>