### PR TITLE
[RFC] boards: remove redundant build and flashing instructions

### DIFF
--- a/boards/arm/96b_aerocore2/doc/index.rst
+++ b/boards/arm/96b_aerocore2/doc/index.rst
@@ -311,31 +311,8 @@ You should see following confirmation on your Linux host:
    usb 1-2.1: Manufacturer: STMicroelectronics
    usb 1-2.1: SerialNumber: 3574364C3034
 
-Then build and flash an application. Here is an example for the
-:ref:`hello_world` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: 96b_aerocore2
-   :goals: build flash
-
 Connect a USB-TTL dongle to the UART_7 header port and to your computer.
 Run your favorite terminal program to listen for output.
-
-.. code-block:: console
-
-   $ minicom -D <tty_device> -b 115200
-
-Replace :code:`<tty_device>` with the port where the board 96Boards Aerocore2
-can be found. For example, under Linux, :code:`/dev/ttyUSB0`.
-The ``-b`` option sets baud rate ignoring the value from config.
-
-Press the Reset button and you should see the the following message in your
-terminal:
-
-.. code-block:: console
-
-   Hello World! arm
 
 .. _96Boards website:
    https://www.96boards.org/product/aerocore2/

--- a/boards/arm/96b_carbon/doc/index.rst
+++ b/boards/arm/96b_carbon/doc/index.rst
@@ -299,31 +299,8 @@ You should see following confirmation on your Linux host:
    usb 1-2.1: Manufacturer: STMicroelectronics
    usb 1-2.1: SerialNumber: 3574364C3034
 
-Then build and flash an application. Here is an example for the
-:ref:`hello_world` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: 96b_carbon
-   :goals: build flash
-
 Connect the micro-USB cable to the USB UART (FTDI) port and to your computer.
 Run your favorite terminal program to listen for output.
-
-.. code-block:: console
-
-   $ minicom -D <tty_device> -b 115200
-
-Replace :code:`<tty_device>` with the port where the board 96Boards Carbon
-can be found. For example, under Linux, :code:`/dev/ttyUSB0`.
-The ``-b`` option sets baud rate ignoring the value from config.
-
-Press the Reset button and you should see the the following message in your
-terminal:
-
-.. code-block:: console
-
-   Hello World! arm
 
 .. _96b_carbon_verify_bluetooth:
 

--- a/boards/arm/96b_nitrogen/doc/index.rst
+++ b/boards/arm/96b_nitrogen/doc/index.rst
@@ -271,46 +271,6 @@ pyOCD as root (e.g. sudo).
 To fix the above error, add the udev rule shown in the previous section
 and install a more recent version of pyOCD.
 
-Flashing an Application to 96Boards Nitrogen
-============================================
-
-Here is an example for the :ref:`hello_world` application. This
-requires installing the :ref:`pyocd-debug-host-tools`.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: 96b_nitrogen
-   :goals: build flash
-
-Run your favorite terminal program to listen for output.
-
-.. code-block:: console
-
-   $ minicom -D <tty_device> -b 115200
-
-Replace :code:`<tty_device>` with the port where the board 96Boards Nitrogen
-can be found. For example, under Linux, :code:`/dev/ttyACM0`.
-The ``-b`` option sets baud rate ignoring the value from config.
-
-Press the Reset button and you should see the the following message in your
-terminal:
-
-.. code-block:: console
-
-   Hello World! arm
-
-Debugging with GDB
-==================
-
-You can debug an application in the usual way.  Here is an example for the
-:ref:`hello_world` application. This also requires pyOCD.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: 96b_nitrogen
-   :maybe-skip-config:
-   :goals: debug
-
 .. _pyOCD:
     https://github.com/mbedmicro/pyOCD
 

--- a/boards/arm/96b_stm32_sensor_mez/doc/index.rst
+++ b/boards/arm/96b_stm32_sensor_mez/doc/index.rst
@@ -179,59 +179,12 @@ to the on-board ST MP34DT01 DMIC. The default I2S mapping is:
 Programming and Debugging
 *************************
 
-Building
-========
-
-Here is an example for building the :ref:`hello_world` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: 96b_stm32_sensor_mez
-   :goals: build
-
 Flashing
 ========
 
 96Boards STM32 Sensor Mezzanine board includes an ST-LINK/V2-1 embedded
 debug tool interface. This interface is supported by the openocd version
 included in the Zephyr SDK.
-
-Flashing an application to 96Boards STM32 Sensor Mezzanine
-----------------------------------------------------------
-
-Here is an example for the :ref:`hello_world` application.
-
-Run a serial host program to connect with your 96Boards STM32 Sensor Mezzanine
-board.
-
-.. code-block:: console
-
-   $ minicom -b 115200 -D /dev/ttyACM0
-
-Build and flash the application:
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: 96b_stm32_sensor_mez
-   :goals: build flash
-
-You should see the following message on the console:
-
-.. code-block:: console
-
-   $ Hello World! 96b_stm32_sensor_mez
-
-Debugging
-=========
-
-You can debug an application in the usual way.  Here is an example for the
-:ref:`hello_world` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: 96b_stm32_sensor_mez
-   :maybe-skip-config:
-   :goals: debug
 
 References
 **********

--- a/boards/arm/adafruit_feather_m0_basic_proto/doc/index.rst
+++ b/boards/arm/adafruit_feather_m0_basic_proto/doc/index.rst
@@ -107,51 +107,6 @@ The Adafruit Feather M0 Basic Proto ships with a BOSSA compatible
 SAM-BA bootloader.  The bootloader can be entered by quickly tapping
 the reset button twice.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the :ref:`hello_world` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: adafruit_feather_m0_basic_proto
-      :goals: build
-      :compact:
-
-#. Connect the Adafruit Feather M0 Basic Proto to your host computer
-   using USB
-
-#. Connect a 3.3 V USB to serial adapter to the board and to the
-   host.  See the `Serial Port`_ section above for the board's pin
-   connections.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyACM0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. Tap the reset button twice quickly to enter bootloader mode
-
-#. Flash the image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: adafruit_feather_m0_basic_proto
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! adafruit_feather_m0_basic_proto" in your terminal.
-
 References
 **********
 

--- a/boards/arm/adafruit_feather_m0_lora/doc/index.rst
+++ b/boards/arm/adafruit_feather_m0_lora/doc/index.rst
@@ -116,51 +116,6 @@ The Adafruit Feather M0 with LoRa ships with a BOSSA compatible
 SAM-BA bootloader.  The bootloader can be entered by quickly tapping
 the reset button twice.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the :ref:`hello_world` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: adafruit_feather_m0_lora
-      :goals: build
-      :compact:
-
-#. Connect the Adafruit Feather M0 with LoRa to your host computer
-   using USB
-
-#. Connect a 3.3 V USB to serial adapter to the board and to the
-   host.  See the `Serial Port`_ section above for the board's pin
-   connections.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyACM0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. Tap the reset button twice quickly to enter bootloader mode
-
-#. Flash the image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: adafruit_feather_m0_lora
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! adafruit_feather_m0_lora" in your terminal.
-
 References
 **********
 

--- a/boards/arm/adafruit_itsybitsy_m4_express/doc/index.rst
+++ b/boards/arm/adafruit_itsybitsy_m4_express/doc/index.rst
@@ -119,76 +119,11 @@ bootloader can be entered by quickly tapping the reset button twice.
 Additionally, if :code:`CONFIG_USB_CDC_ACM` is enabled then the bootloader
 will be entered automatically when you run :code:`west flash`.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the :ref:`hello_world` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: adafruit_itsybitsy_m4_express
-      :goals: build
-      :compact:
-
-#. Connect the ItsyBitsy to your host computer using USB
-
-#. Connect a 3.3 V USB to serial adapter to the board and to the
-   host.  See the `Serial Port`_ section above for the board's pin
-   connections.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyUSB0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyUSB0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. Tap the reset button twice quickly to enter bootloader mode
-
-#. Flash the image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: adafruit_itsybitsy_m4_express
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! adafruit_itsybitsy_m4_express" in your terminal.
-
 Debugging
 =========
 
 In addition to the built-in bootloader, the ItsyBitsy can be flashed and
 debugged using a SWD probe such as the Segger J-Link.
-
-#. Connect the board to the probe by connecting the :code:`SWCLK`,
-   :code:`SWDIO`, :code:`RESET`, :code:`GND`, and :code:`3V3` pins on the
-   ItsyBitsy to the :code:`SWCLK`, :code:`SWDIO`, :code:`RESET`, :code:`GND`,
-   and :code:`VTref` pins on the `J-Link`_.
-
-#. Flash the image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: adafruit_itsybitsy_m4_express
-      :goals: flash -r openocd
-      :compact:
-
-#. Start debugging:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: adafruit_itsybitsy_m4_express
-      :goals: debug
-      :compact:
 
 References
 **********

--- a/boards/arm/adafruit_trinket_m0/doc/index.rst
+++ b/boards/arm/adafruit_trinket_m0/doc/index.rst
@@ -111,50 +111,6 @@ bootloader can be entered by quickly tapping the reset button twice.
 Additionally, if :code:`CONFIG_USB_CDC_ACM` is enabled then the bootloader
 will be entered automatically when you run :code:`west flash`.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the :ref:`hello_world` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: adafruit_trinket_m0
-      :goals: build
-      :compact:
-
-#. Connect the Trinket M0 to your host computer using USB
-
-#. Connect a 3.3 V USB to serial adapter to the board and to the
-   host.  See the `Serial Port`_ section above for the board's pin
-   connections.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyACM0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. Tap the reset button twice quickly to enter bootloader mode
-
-#. Flash the image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: adafruit_trinket_m0
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! adafruit_trinket_m0" in your terminal.
-
 References
 **********
 

--- a/boards/arm/apollo4p_evb/doc/index.rst
+++ b/boards/arm/apollo4p_evb/doc/index.rst
@@ -50,39 +50,6 @@ The Apollo4P EVB board configuration supports the following hardware features:
 The default configuration can be found in the defconfig file:
 ``boards/arm/apollo4p_evb/apollo4p_evb_defconfig``.
 
-Programming and Debugging
-=========================
-
-Flashing an application
------------------------
-
-Connect your device to your host computer using the JLINK USB port.
-The sample application :ref:`hello_world` is used for this example.
-Build the Zephyr kernel and application, then flash it to the device:
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: apollo4p_evb
-   :goals: flash
-
-.. note::
-   `west flash` requires `SEGGER J-Link software`_ and `pylink`_ Python module
-   to be installed on you host computer.
-
-Open a serial terminal (minicom, putty, etc.) with the following settings:
-
-- Speed: 115200
-- Data: 8 bits
-- Parity: None
-- Stop bits: 1
-
-Reset the board and you should be able to see on the corresponding Serial Port
-the following message:
-
-.. code-block:: console
-
-   Hello World! apollo4p_evb
-
 .. _Apollo4 Plus Website:
    https://ambiq.com/apollo4-plus/
 

--- a/boards/arm/arduino_due/doc/index.rst
+++ b/boards/arm/arduino_due/doc/index.rst
@@ -171,36 +171,9 @@ To build the bossa tool, follow these steps:
 Flashing an Application to Arduino Due
 --------------------------------------
 
-Applications for the ``arduino_due`` board configuration can be built
-and flashed in the usual way (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
-
-Here is an example for the :ref:`hello_world` application. After
-building the application, press the Reset button before running the
+After building the application, press the Reset button before running the
 flash command, so the board will boot into the SAM-BA bootloader and
 be prepared to receive the new program.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: arduino_due
-   :goals: build flash
-
-After flashing the application, run your favorite terminal program to
-listen for output. For example, under Linux, the terminal should be
-:code:`/dev/ttyACM0`. For example:
-
-.. code-block:: console
-
-   $ sudo minicom -D /dev/ttyACM0 -o
-
-The -o option tells minicom not to send the modem initialization
-string.
-
-Now press the Reset button and you should see "Hello World! arduino_due" in your terminal.
-
-.. note::
-   Make sure your terminal program is closed before flashing the binary image,
-   or it will interfere with the flashing process.
 
 References
 **********

--- a/boards/arm/arduino_giga_r1/doc/index.rst
+++ b/boards/arm/arduino_giga_r1/doc/index.rst
@@ -130,42 +130,12 @@ First, connect the Arduino GIGA R1 board to your host computer using the USB
 port to prepare it for flashing. Double click the ``RST`` button to put the
 board into the Arduino Bootloader mode. Then build and flash your application.
 
-Here is an example for the :ref:`hello_world` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: arduino_giga_r1_m7
-   :goals: build flash
-
-Run a serial host program to connect with your board:
-
-.. code-block:: console
-
-   $ minicom -D /dev/ttyACM0
-
-You should see the following message on the console:
-
-.. code-block:: console
-
-   Hello World! arduino_giga_r1_m7
-
-Similarly, you can build and flash samples on the M4 target.
-
-Here is an example for the :ref:`blinky-sample` application on M4 core.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/blinky
-   :board: arduino_giga_r1_m4
-   :goals: build flash
-
 Debugging
 =========
 
 Debugging is supported by using ``west debug`` with an external probe such as a
 J-Link or Black Magic Probe, connected to the on board MIPI-10 SWD port marked
-as "JTAG". For example::
-
-  west debug -r jlink
+as "JTAG".
 
 .. _Arduino GIGA website:
    https://docs.arduino.cc/hardware/giga-r1-wifi

--- a/boards/arm/arduino_mkrzero/doc/index.rst
+++ b/boards/arm/arduino_mkrzero/doc/index.rst
@@ -127,50 +127,6 @@ Programming and Debugging
 The Arduino MKR Zero ships the BOSSA compatible bootloader.  The
 bootloader can be entered by quickly tapping the reset button twice.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the :ref:`hello_world` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: arduino_mkrzero
-      :goals: build
-      :compact:
-
-#. Connect the MKR Zero to your host computer using USB
-
-#. Connect a 3.3 V USB to serial adapter to the board and to the
-   host.  See the `Serial Port`_ section above for the board's pin
-   connections.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyACM0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. Tap the reset button twice quickly to enter bootloader mode
-
-#. Flash the image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: arduino_mkrzero
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! arduino_mkrzero" in your terminal.
-
 References
 **********
 

--- a/boards/arm/arduino_nano_33_iot/doc/index.rst
+++ b/boards/arm/arduino_nano_33_iot/doc/index.rst
@@ -115,50 +115,6 @@ bootloader can be entered by quickly tapping the reset button twice.
 Additionally, if :code:`CONFIG_USB_CDC_ACM` is enabled then the bootloader
 will be entered automatically when you run :code:`west flash`.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the :ref:`hello_world` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: arduino_nano_33_iot
-      :goals: build
-      :compact:
-
-#. Connect the Nano 33 IOT to your host computer using USB
-
-#. Connect a 3.3 V USB to serial adapter to the board and to the
-   host.  See the `Serial Port`_ section above for the board's pin
-   connections.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyACM0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. Tap the reset button twice quickly to enter bootloader mode
-
-#. Flash the image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: arduino_nano_33_iot
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! arduino_nano_33_iot" in your terminal.
-
 References
 **********
 

--- a/boards/arm/arduino_nicla_sense_me/doc/index.rst
+++ b/boards/arm/arduino_nicla_sense_me/doc/index.rst
@@ -82,49 +82,6 @@ Available pins:
 
 For more details please refer to the `datasheet`_, `full pinout`_ and the `schematics`_.
 
-Programming and Debugging
-*************************
-
-Applications for the ``arduino_nicla_sense_me`` board configuration can be built and
-flashed in the usual way (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
-
-Flashing
-========
-
-First, connect the Arduino Nicla Sense ME board to your host computer using
-the USB port to prepare it for flashing. Then build and flash your application.
-
-Here is an example for the :ref:`hello_world` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: arduino_nicla_sense_me
-   :goals: build flash
-
-Run a serial host program to connect with your board:
-
-.. code-block:: console
-
-   $ minicom -D /dev/ttyACM0
-
-You should see the following message on the console:
-
-.. code-block:: console
-
-   Hello World! arduino_nicla_sense_me
-
-Debugging
-=========
-
-You can debug an application in the usual way.  Here is an example for the
-:ref:`hello_world` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: arduino_nicla_sense_me
-   :goals: debug
-
 References
 **********
 

--- a/boards/arm/arduino_portenta_h7/doc/index.rst
+++ b/boards/arm/arduino_portenta_h7/doc/index.rst
@@ -99,35 +99,6 @@ First, connect the Arduino Portenta H7 board to your host computer using
 the USB port to prepare it for flashing. Double tap the button to put the board
 into the Arduino Bootloader mode. Then build and flash your application.
 
-Here is an example for the :ref:`hello_world` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: arduino_portenta_h7_m7
-   :goals: build flash
-
-Run a serial host program to connect with your board:
-
-.. code-block:: console
-
-   $ minicom -D /dev/ttyACM0
-
-You should see the following message on the console:
-
-.. code-block:: console
-
-   Hello World! arduino_portenta_m7
-
-Similarly, you can build and flash samples on the M4 target. For this, please
-take care of the resource sharing (UART port used for console for instance).
-
-Here is an example for the :ref:`blinky-sample` application on M4 core.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/blinky
-   :board: arduino_portenta_h7_m4
-   :goals: build flash
-
 .. _ARDUINO_PORTENTA_H7 website:
    https://docs.arduino.cc/hardware/portenta-h7
 

--- a/boards/arm/arduino_zero/doc/index.rst
+++ b/boards/arm/arduino_zero/doc/index.rst
@@ -115,45 +115,6 @@ The Arduino Zero comes with a Atmel Embedded Debugger (EDBG).  This
 provides a debug interface to the SAMD21 chip and is supported by
 OpenOCD.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the :ref:`hello_world` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: arduino_zero
-      :goals: build
-      :compact:
-
-#. Connect the Arduino Zero to your host computer using the USB debug
-   port.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyACM0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. To flash an image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: arduino_zero
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! arduino_zero" in your terminal.
-
 References
 **********
 

--- a/boards/arm/arty/doc/index.rst
+++ b/boards/arm/arty/doc/index.rst
@@ -148,38 +148,12 @@ The UART console is available via the on-board JTAG on USB connector
 ``J10``. The on-board JTAG will enumerate as two USB serial ports. The UART is
 typically available on the second serial port.
 
-Use the following settings with your serial terminal of choice (minicom, putty,
-etc.):
-
-- Speed: 115200
-- Data: 8 bits
-- Parity: None
-- Stop bits: 1
-
 Flashing
 ========
 
-Here is an example for building and flashing the :ref:`hello_world` application
-for the Cortex-M1 reference design:
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: arty_a7_arm_designstart_m1
-   :goals: flash
-
-After flashing, you should see message similar to the following in the terminal:
-
-.. code-block:: console
-
-   *** Booting Zephyr OS build zephyr-v2.3.99  ***
-   Hello World! arty_a7_arm_designstart_m1
-
-The same procedure can be used for the Cortex-M3 reference design.
-
-Note, however, that the application was not persisted in flash memory by the
-above steps. It was merely written to internal block RAM in the FPGA. It will
-revert to the application stored in the block RAM within the FPGA bitstream
-the next time the FPGA is configured.
+The application is not persisted in flash memory. It is merely written to
+internal block RAM in the FPGA. It will revert to the application stored in the
+block RAM within the FPGA bitstream the next time the FPGA is configured.
 
 The steps to persist the application within the FPGA bitstream are covered by
 the ARM Cortex-M1/M3 DesignStart FPGA Xilinx edition user guide. If the
@@ -187,24 +161,6 @@ the ARM Cortex-M1/M3 DesignStart FPGA Xilinx edition user guide. If the
 is available, the build system will automatically generate a Verilog memory hex
 dump :file:`zephyr.mem` file suitable for initialising the block RAM using
 `Xilinx Vivado`_.
-
-Debugging
-=========
-
-Here is an example for the :ref:`hello_world` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: arty_a7_arm_designstart_m1
-   :goals: debug
-
-Step through the application in your debugger, and you should see a message
-similar to the following in the terminal:
-
-.. code-block:: console
-
-   *** Booting Zephyr OS build zephyr-v2.3.99  ***
-   Hello World! arty_a7_arm_designstart_m1
 
 .. _Digilent Arty:
    https://store.digilentinc.com/arty

--- a/boards/arm/atsamc21n_xpro/doc/index.rst
+++ b/boards/arm/atsamc21n_xpro/doc/index.rst
@@ -140,45 +140,6 @@ The SAM C21N Xplained Pro comes with a Atmel Embedded Debugger (EDBG). This
 provides a debug interface to the SAMC21 chip and is supported by
 OpenOCD.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the ``hello_world`` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: atsamc21n_xpro
-      :goals: build
-      :compact:
-
-#. Connect the SAM C21N Xplained Pro to your host computer using the USB debug
-   port.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyACM0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. To flash an image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: atsamc21n_xpro
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! atsamc21n_xpro" in your terminal.
-
 References
 **********
 

--- a/boards/arm/atsamd20_xpro/doc/index.rst
+++ b/boards/arm/atsamd20_xpro/doc/index.rst
@@ -88,45 +88,6 @@ The SAM D20 Xplained Pro comes with a Atmel Embedded Debugger (EDBG).  This
 provides a debug interface to the SAMD20 chip and is supported by
 OpenOCD.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the :ref:`hello_world` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: atsamd20_xpro
-      :goals: build
-      :compact:
-
-#. Connect the SAM D20 Xplained Pro to your host computer using the USB debug
-   port.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyACM0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. To flash an image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: atsamd20_xpro
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! atsamd20_xpro" in your terminal.
-
 References
 **********
 

--- a/boards/arm/atsamd21_xpro/doc/index.rst
+++ b/boards/arm/atsamd21_xpro/doc/index.rst
@@ -129,45 +129,6 @@ The SAM D21 Xplained Pro comes with a Atmel Embedded Debugger (EDBG).  This
 provides a debug interface to the SAMD21 chip and is supported by
 OpenOCD.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the ``hello_world`` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: atsamd21_xpro
-      :goals: build
-      :compact:
-
-#. Connect the SAM D21 Xplained Pro to your host computer using the USB debug
-   port.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyACM0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. To flash an image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: atsamd21_xpro
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! atsamd21_xpro" in your terminal.
-
 References
 **********
 

--- a/boards/arm/atsame54_xpro/doc/index.rst
+++ b/boards/arm/atsame54_xpro/doc/index.rst
@@ -176,45 +176,6 @@ The SAM E54 Xplained Pro comes with a Atmel Embedded Debugger (EDBG).  This
 provides a debug interface to the SAME54 chip and is supported by
 OpenOCD.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the ``hello_world`` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: atsame54_xpro
-      :goals: build
-      :compact:
-
-#. Connect the SAM E54 Xplained Pro to your host computer using the USB debug
-   port.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyACM0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. To flash an image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: atsame54_xpro
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! atsame54_xpro" in your terminal.
-
 References
 **********
 

--- a/boards/arm/atsaml21_xpro/doc/index.rst
+++ b/boards/arm/atsaml21_xpro/doc/index.rst
@@ -147,42 +147,6 @@ The SAM L21 Xplained Pro comes with a Atmel Embedded Debugger (EDBG).  This
 provides a debug interface to the SAML21 chip and is supported by
 OpenOCD.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the ``hello_world`` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: atsaml21_xpro
-      :goals: build
-      :compact:
-
-#. Connect the SAM L21 Xplained Pro to your host computer using the USB debug
-   port.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ picocom -b 115200 /dev/ttyACM0
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. To flash an image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: atsaml21_xpro
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! atsaml21_xpro" in your terminal.
-
 References
 **********
 

--- a/boards/arm/atsamr21_xpro/doc/index.rst
+++ b/boards/arm/atsamr21_xpro/doc/index.rst
@@ -171,45 +171,6 @@ The SAM R21 Xplained Pro comes with a Atmel Embedded Debugger (EDBG).  This
 provides a debug interface to the SAMR21 chip and is supported by
 OpenOCD.
 
-Flashing
-========
-
-#. Build the Zephyr kernel and the :ref:`hello_world` sample application:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: atsamr21_xpro
-      :goals: build
-      :compact:
-
-#. Connect the SAM R21 Xplained Pro to your host computer using the USB debug
-   port.
-
-#. Run your favorite terminal program to listen for output. Under Linux the
-   terminal should be :code:`/dev/ttyACM0`. For example:
-
-   .. code-block:: console
-
-      $ minicom -D /dev/ttyACM0 -o
-
-   The -o option tells minicom not to send the modem initialization
-   string. Connection should be configured as follows:
-
-   - Speed: 115200
-   - Data: 8 bits
-   - Parity: None
-   - Stop bits: 1
-
-#. To flash an image:
-
-   .. zephyr-app-commands::
-      :zephyr-app: samples/hello_world
-      :board: atsamr21_xpro
-      :goals: flash
-      :compact:
-
-   You should see "Hello World! atsamr21_xpro" in your terminal.
-
 References
 **********
 

--- a/boards/riscv/xiao_esp32c3/doc/index.rst
+++ b/boards/riscv/xiao_esp32c3/doc/index.rst
@@ -161,27 +161,12 @@ The only difference is the structure of the build directory.
 
    Remember that bootloader (MCUboot) needs to be flash at least once.
 
-For the :code:`Hello, world!` application, follow the instructions below.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/hello_world
-   :board: xiao_esp32c3
-   :goals: build flash
-
-Since the Zephyr console is by default on the `usb_serial` device, we use
-the espressif monitor to view.
+You can try the :ref:`hello_world` application. Since the Zephyr console is by
+default on the `usb_serial` device, we use the espressif monitor to view.
 
 .. code-block:: console
 
    $ west espressif monitor
-
-After the board has automatically reset and booted, you should see the following
-message in the monitor:
-
-.. code-block:: console
-
-   ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
-   Hello World! xiao_esp32c3
 
 Debugging
 *********


### PR DESCRIPTION
Almost every Zephyr board page contains how to build and flash the hello world sample. Often, instructions on using minicom are also present. This leads to tons of duplicated information, often out of date.

This RFC proposes to delete all common details because they are already found in samples or other places in the documentation. We should have a dedicated short, simple section that explains how to build and flash samples in a generic way. Board docs should only contain specific quirks. This change could also benefit samples, since the situation is somewhat similar.

Note: just changed a few boards as an example