### PR TITLE
logging: return actual filter level when runtime filter is disabled

### DIFF
--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -417,7 +417,7 @@ uint32_t z_impl_log_filter_set(struct log_backend const *const backend,
 			       uint32_t level)
 {
 	if (!IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) {
-		return level;
+		return log_compiled_level_get(domain_id, source_id);
 	}
 
 	__ASSERT_NO_MSG(source_id < log_src_cnt_get(domain_id));


### PR DESCRIPTION
`log_filter_set()` is defined to return the actual level that was set by the call. In case runtime filtering is disabled, this is always the compiled-in log level, not the level passed by the user.