### PR TITLE
bindings: gpio-qdec use INPUT_REL_WHEEL as example

### DIFF
--- a/dts/bindings/input/gpio-qdec.yaml
+++ b/dts/bindings/input/gpio-qdec.yaml
@@ -19,7 +19,7 @@ description: |
           gpios = <&gpio0 14 (GPIO_PULL_UP | GPIO_ACTIVE_HIGH)>,
                   <&gpio0 13 (GPIO_PULL_UP | GPIO_ACTIVE_HIGH)>;
           steps-per-period = <4>;
-          zephyr,axis = <INPUT_REL_Y>;
+          zephyr,axis = <INPUT_REL_WHEEL>;
           sample-time-us = <2000>;
           idle-timeout-ms = <200>;
   };


### PR DESCRIPTION
INPUT_REL_WHEEL is the code that normally refer to scroller wheel, which probably makes a bit more sense in this context, use that instead of INPUT_REL_Y.