### PR TITLE
net: iface: Allow NULL pointer to be handled in net_if_is_ip_offloaded

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -756,10 +756,8 @@ void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt);
 static inline bool net_if_is_ip_offloaded(struct net_if *iface)
 {
 #if defined(CONFIG_NET_OFFLOAD)
-	NET_ASSERT(iface);
-	NET_ASSERT(iface->if_dev);
-
-	return (iface->if_dev->offload != NULL);
+	return (iface != NULL && iface->if_dev != NULL &&
+		iface->if_dev->offload != NULL);
 #else
 	ARG_UNUSED(iface);
 


### PR DESCRIPTION
In case native interface is used with NET_OFFLOAD enabled, the net_if_is_ip_offloaded() could lead to a crash, if called on unbound net_context (i.e. with no iface assigned to net_context yet).

As since commit 40d224022608a3e5d68e95cc4d6f7606f1d48fb2 the net_context allocated on offloaded interface is always assigned with the iface pointer during its creation, it can be safely assumed that in case of NULL pointer is provided we deal with a native interface. Therefore instead of asserting on the iface pointer, indicate that the interface is native when NULL pointer is provided.

Fixes #61173