### PR TITLE
[Backport v2.7-branch] drivers: ieee802154_nrf5: Add payload length check on TX

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -494,6 +494,11 @@ static int nrf5_tx(const struct device *dev,
 	uint8_t *payload = frag->data;
 	bool ret = true;
 
+	if (payload_len > NRF5_PSDU_LENGTH) {
+		LOG_ERR("Payload too large: %d", payload_len);
+		return -EMSGSIZE;
+	}
+
 	LOG_DBG("%p (%u)", payload, payload_len);
 
 	nrf5_radio->tx_psdu[0] = payload_len + NRF5_FCS_LENGTH;


### PR DESCRIPTION
In case upper layer does not follow the convention, and the net_pkt provided to the nRF 15.4 driver had a payload larger than the maximum payload size of an individual 15.4 frame, the driver would end up with buffer overflow.

Fix this by adding an extra payload_len check before attempting to copy the payload to the internal buffer.

Fixes #61544