### PR TITLE
init: fix sub-priority for named init functions

### DIFF
--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -178,6 +178,9 @@ struct init_entry {
  *
  * @note This macro can be used for cases where the multiple init calls use the
  * same init function.
+ * The sub-priority must be kept of same length as _ORD_STR_SORTABLE so that
+ * it takes precedence over other devices with same level and priority when
+ * sorted by the linker.
  *
  * @param name Unique name for SYS_INIT entry.
  * @param init_fn_ See SYS_INIT().
@@ -188,7 +191,7 @@ struct init_entry {
  */
 #define SYS_INIT_NAMED(name, init_fn_, level, prio)                            \
 	static const Z_DECL_ALIGN(struct init_entry)                           \
-		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan           \
+		Z_INIT_ENTRY_SECTION(level, prio, 00000) __used __noasan       \
 		Z_INIT_ENTRY_NAME(name) = {                                    \
 			.init_fn = {.sys = (init_fn_)},                        \
 			.dev = NULL,                                           \


### PR DESCRIPTION
The sub-priority must be kept of same length as `_ORD_STR_SORTABLE` so that it takes precedence over other devices with same level and priority, when sorted by the linker.

Take for example `west build -p auto -b s32z270dc2_rtu0_r52 tests/drivers/gpio/gpio_api_1pin`
```
*(SORT_BY_NAME(SORT_BY_ALIGNMENT(.z_init_PRE_KERNEL_1??_*)))
.z_init_PRE_KERNEL_140_00019_
            0x000000003178e700        0x8 zephyr/drivers/interrupt_controller/libdrivers__interrupt_controller.a(intc_eirq_nxp_s32.c.obj)
.z_init_PRE_KERNEL_140_0_
            0x000000003178e708        0x8 zephyr/libzephyr.a(soc.c.obj)
.z_init_PRE_KERNEL_140_0_
            0x000000003178e710        0x8 zephyr/drivers/interrupt_controller/libdrivers__interrupt_controller.a(intc_gicv3.c.obj)
```

And after the change:
```
*(SORT_BY_NAME(SORT_BY_ALIGNMENT(.z_init_PRE_KERNEL_1??_*)))
.z_init_PRE_KERNEL_140_00000_
            0x000000003178e700        0x8 zephyr/libzephyr.a(soc.c.obj)
.z_init_PRE_KERNEL_140_00000_
            0x000000003178e708        0x8 zephyr/drivers/interrupt_controller/libdrivers__interrupt_controller.a(intc_gicv3.c.obj)
.z_init_PRE_KERNEL_140_00019_
            0x000000003178e710        0x8 zephyr/drivers/interrupt_controller/libdrivers__interrupt_controller.a(intc_eirq_nxp_s32.c.obj)
```

Fixes #61218