### PR TITLE
dts: arm: stm32f412 has a spi3 node

### DIFF
--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -50,6 +50,16 @@
 			status = "disabled";
 		};
 
+		spi3: spi@40003c00 {
+			compatible = "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
+			interrupts = <51 5>;
+			status = "disabled";
+		};
+
 		spi4: spi@40013400 {
 			compatible = "st,stm32-spi";
 			#address-cells = <1>;


### PR DESCRIPTION
Add the SPI3 node to the stm32f412 device which is also present in the stm32f413


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/55026
