### PR TITLE
Rename shadow variables (part 1)

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -56,7 +56,7 @@ LOG_MODULE_REGISTER(mpu);
 
 #define PMP_NONE 0
 
-static void print_pmp_entries(unsigned int start, unsigned int end,
+static void print_pmp_entries(unsigned int pmp_start, unsigned int pmp_end,
 			      unsigned long *pmp_addr, unsigned long *pmp_cfg,
 			      const char *banner)
 {
@@ -64,7 +64,7 @@ static void print_pmp_entries(unsigned int start, unsigned int end,
 	unsigned int index;
 
 	LOG_DBG("PMP %s:", banner);
-	for (index = start; index < end; index++) {
+	for (index = pmp_start; index < pmp_end; index++) {
 		unsigned long start, end, tmp;
 
 		switch (pmp_n_cfg[index] & PMP_A) {

--- a/boards/posix/native_posix/irq_ctrl.c
+++ b/boards/posix/native_posix/irq_ctrl.c
@@ -94,14 +94,14 @@ int hw_irq_ctrl_get_highest_prio_irq(void)
 		return -1;
 	}
 
-	uint64_t irq_status = hw_irq_ctrl_get_irq_status();
+	uint64_t hw_irq_status = hw_irq_ctrl_get_irq_status();
 	int winner = -1;
 	int winner_prio = 256;
 
-	while (irq_status != 0U) {
-		int irq_nbr = find_lsb_set(irq_status) - 1;
+	while (hw_irq_status != 0U) {
+		int irq_nbr = find_lsb_set(hw_irq_status) - 1;
 
-		irq_status &= ~((uint64_t) 1 << irq_nbr);
+		hw_irq_status &= ~((uint64_t) 1 << irq_nbr);
 		if ((winner_prio > (int)irq_prio[irq_nbr])
 		   && (currently_running_prio > (int)irq_prio[irq_nbr])) {
 			winner = irq_nbr;

--- a/boards/posix/nrf52_bsim/time_machine.c
+++ b/boards/posix/nrf52_bsim/time_machine.c
@@ -159,14 +159,16 @@ void tm_update_last_phy_sync_time(bs_time_t abs_time)
 
 /**
  * Advance the internal time values of this device
- * until the HW time reaches hw_time
+ * until the HW time reaches time @a t.
+ *
+ * @param t Time to advance to.
  */
-static void tm_sleep_until_hw_time(bs_time_t hw_time)
+static void tm_sleep_until_hw_time(bs_time_t t)
 {
 	bs_time_t next_time = TIME_NEVER;
 
-	if (hw_time != TIME_NEVER) {
-		next_time = hw_time + hw_time_delta;
+	if (t != TIME_NEVER) {
+		next_time = t + hw_time_delta;
 	}
 	tm_sleep_until_abs_time(next_time);
 }

--- a/drivers/clock_control/clock_control_litex.c
+++ b/drivers/clock_control/clock_control_litex.c
@@ -975,8 +975,6 @@ static int litex_clk_set_duty_cycle(struct litex_clk_clkout *lcko,
 	   *low_time = &lcko->div.low_time;
 
 	if (lcko->frac.frac == 0) {
-		int ret;
-
 		lcko->ts_config.duty = *duty;
 		LOG_DBG("CLKOUT%d: setting duty: %u/%u",
 			lcko->id, duty->num, duty->den);

--- a/drivers/clock_control/nrf_clock_calibration.c
+++ b/drivers/clock_control/nrf_clock_calibration.c
@@ -44,7 +44,7 @@ static void cal_lf_callback(struct onoff_manager *mgr,
 			    struct onoff_client *cli,
 			    uint32_t state, int res);
 
-static struct onoff_client cli;
+static struct onoff_client client;
 static struct onoff_manager *mgrs;
 
 /* Temperature sensor is only needed if
@@ -87,12 +87,12 @@ static void clk_release(struct onoff_manager *mgr)
 
 static void hf_request(void)
 {
-	clk_request(&mgrs[CLOCK_CONTROL_NRF_TYPE_HFCLK], &cli, cal_hf_callback);
+	clk_request(&mgrs[CLOCK_CONTROL_NRF_TYPE_HFCLK], &client, cal_hf_callback);
 }
 
 static void lf_request(void)
 {
-	clk_request(&mgrs[CLOCK_CONTROL_NRF_TYPE_LFCLK], &cli, cal_lf_callback);
+	clk_request(&mgrs[CLOCK_CONTROL_NRF_TYPE_LFCLK], &client, cal_lf_callback);
 }
 
 static void hf_release(void)

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -25,7 +25,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <dmic_regs.h>
 
 /* Base addresses (in PDM scope) of 2ch PDM controllers and coefficient RAM. */
-static const uint32_t base[4] = {PDM0, PDM1, PDM2, PDM3};
+static const uint32_t dmic_base[4] = {PDM0, PDM1, PDM2, PDM3};
 
 /* global data shared between all dmic instances */
 struct dai_dmic_global_shared dai_dmic_global;
@@ -513,17 +513,17 @@ static void dai_dmic_gain_ramp(struct dai_intel_dmic *dmic)
 			continue;
 
 		if (dmic->startcount == DMIC_UNMUTE_CIC)
-			dai_dmic_update_bits(dmic, base[i] + CIC_CONTROL,
+			dai_dmic_update_bits(dmic, dmic_base[i] + CIC_CONTROL,
 					     CIC_CONTROL_MIC_MUTE, 0);
 
 		if (dmic->startcount == DMIC_UNMUTE_FIR) {
 			switch (dmic->dai_config_params.dai_index) {
 			case 0:
-				dai_dmic_update_bits(dmic, base[i] + FIR_CONTROL_A,
+				dai_dmic_update_bits(dmic, dmic_base[i] + FIR_CONTROL_A,
 						     FIR_CONTROL_MUTE, 0);
 				break;
 			case 1:
-				dai_dmic_update_bits(dmic, base[i] + FIR_CONTROL_B,
+				dai_dmic_update_bits(dmic, dmic_base[i] + FIR_CONTROL_B,
 						     FIR_CONTROL_MUTE, 0);
 				break;
 			}
@@ -531,13 +531,13 @@ static void dai_dmic_gain_ramp(struct dai_intel_dmic *dmic)
 		switch (dmic->dai_config_params.dai_index) {
 		case 0:
 			val = FIELD_PREP(OUT_GAIN, gval);
-			dai_dmic_write(dmic, base[i] + OUT_GAIN_LEFT_A, val);
-			dai_dmic_write(dmic, base[i] + OUT_GAIN_RIGHT_A, val);
+			dai_dmic_write(dmic, dmic_base[i] + OUT_GAIN_LEFT_A, val);
+			dai_dmic_write(dmic, dmic_base[i] + OUT_GAIN_RIGHT_A, val);
 			break;
 		case 1:
 			val = FIELD_PREP(OUT_GAIN, gval);
-			dai_dmic_write(dmic, base[i] + OUT_GAIN_LEFT_B, val);
-			dai_dmic_write(dmic, base[i] + OUT_GAIN_RIGHT_B, val);
+			dai_dmic_write(dmic, dmic_base[i] + OUT_GAIN_LEFT_B, val);
+			dai_dmic_write(dmic, dmic_base[i] + OUT_GAIN_RIGHT_B, val);
 			break;
 		}
 	}
@@ -591,11 +591,11 @@ static void dai_dmic_start(struct dai_intel_dmic *dmic)
 
 	for (i = 0; i < CONFIG_DAI_DMIC_HW_CONTROLLERS; i++) {
 #ifdef CONFIG_SOC_SERIES_INTEL_ACE
-		dai_dmic_update_bits(dmic, base[i] + CIC_CONTROL,
+		dai_dmic_update_bits(dmic, dmic_base[i] + CIC_CONTROL,
 				     CIC_CONTROL_SOFT_RESET, 0);
 
 		LOG_INF("dmic_start(), cic 0x%08x",
-			dai_dmic_read(dmic, base[i] + CIC_CONTROL));
+			dai_dmic_read(dmic, dmic_base[i] + CIC_CONTROL));
 #endif
 
 		mic_a = dmic->enable[i] & 1;
@@ -610,40 +610,40 @@ static void dai_dmic_start(struct dai_intel_dmic *dmic)
 		 * This makes sure we do not clear start/en for another DAI.
 		 */
 		if (mic_a && mic_b) {
-			dai_dmic_update_bits(dmic, base[i] + CIC_CONTROL,
+			dai_dmic_update_bits(dmic, dmic_base[i] + CIC_CONTROL,
 					     CIC_CONTROL_CIC_START_A |
 					     CIC_CONTROL_CIC_START_B,
 					     FIELD_PREP(CIC_CONTROL_CIC_START_A, 1) |
 					     FIELD_PREP(CIC_CONTROL_CIC_START_B, 1));
-			dai_dmic_update_bits(dmic, base[i] + MIC_CONTROL,
+			dai_dmic_update_bits(dmic, dmic_base[i] + MIC_CONTROL,
 					     MIC_CONTROL_PDM_EN_A |
 					     MIC_CONTROL_PDM_EN_B,
 					     FIELD_PREP(MIC_CONTROL_PDM_EN_A, 1) |
 					     FIELD_PREP(MIC_CONTROL_PDM_EN_B, 1));
 		} else if (mic_a) {
-			dai_dmic_update_bits(dmic, base[i] + CIC_CONTROL,
+			dai_dmic_update_bits(dmic, dmic_base[i] + CIC_CONTROL,
 					     CIC_CONTROL_CIC_START_A,
 					     FIELD_PREP(CIC_CONTROL_CIC_START_A, 1));
-			dai_dmic_update_bits(dmic, base[i] + MIC_CONTROL,
+			dai_dmic_update_bits(dmic, dmic_base[i] + MIC_CONTROL,
 					     MIC_CONTROL_PDM_EN_A,
 					     FIELD_PREP(MIC_CONTROL_PDM_EN_A, 1));
 		} else if (mic_b) {
-			dai_dmic_update_bits(dmic, base[i] + CIC_CONTROL,
+			dai_dmic_update_bits(dmic, dmic_base[i] + CIC_CONTROL,
 					     CIC_CONTROL_CIC_START_B,
 					     FIELD_PREP(CIC_CONTROL_CIC_START_B, 1));
-			dai_dmic_update_bits(dmic, base[i] + MIC_CONTROL,
+			dai_dmic_update_bits(dmic, dmic_base[i] + MIC_CONTROL,
 					     MIC_CONTROL_PDM_EN_B,
 					     FIELD_PREP(MIC_CONTROL_PDM_EN_B, 1));
 		}
 
 		switch (dmic->dai_config_params.dai_index) {
 		case 0:
-			dai_dmic_update_bits(dmic, base[i] + FIR_CONTROL_A,
+			dai_dmic_update_bits(dmic, dmic_base[i] + FIR_CONTROL_A,
 					     FIR_CONTROL_START,
 					     FIELD_PREP(FIR_CONTROL_START, fir_a));
 			break;
 		case 1:
-			dai_dmic_update_bits(dmic, base[i] + FIR_CONTROL_B,
+			dai_dmic_update_bits(dmic, dmic_base[i] + FIR_CONTROL_B,
 					     FIR_CONTROL_START,
 					     FIELD_PREP(FIR_CONTROL_START, fir_b));
 			break;
@@ -655,11 +655,11 @@ static void dai_dmic_start(struct dai_intel_dmic *dmic)
 	 * start capture in sync.
 	 */
 	for (i = 0; i < CONFIG_DAI_DMIC_HW_CONTROLLERS; i++) {
-		dai_dmic_update_bits(dmic, base[i] + CIC_CONTROL,
+		dai_dmic_update_bits(dmic, dmic_base[i] + CIC_CONTROL,
 				     CIC_CONTROL_SOFT_RESET, 0);
 
 		LOG_INF("dmic_start(), cic 0x%08x",
-			dai_dmic_read(dmic, base[i] + CIC_CONTROL));
+			dai_dmic_read(dmic, dmic_base[i] + CIC_CONTROL));
 	}
 #endif
 
@@ -703,7 +703,7 @@ static void dai_dmic_stop(struct dai_intel_dmic *dmic, bool stop_is_pause)
 	for (i = 0; i < CONFIG_DAI_DMIC_HW_CONTROLLERS; i++) {
 		/* Don't stop CIC yet if one FIFO remains active */
 		if (dai_dmic_global.active_fifos_mask == 0) {
-			dai_dmic_update_bits(dmic, base[i] + CIC_CONTROL,
+			dai_dmic_update_bits(dmic, dmic_base[i] + CIC_CONTROL,
 					     CIC_CONTROL_SOFT_RESET |
 					     CIC_CONTROL_MIC_MUTE,
 					     CIC_CONTROL_SOFT_RESET |
@@ -711,12 +711,12 @@ static void dai_dmic_stop(struct dai_intel_dmic *dmic, bool stop_is_pause)
 		}
 		switch (dmic->dai_config_params.dai_index) {
 		case 0:
-			dai_dmic_update_bits(dmic, base[i] + FIR_CONTROL_A,
+			dai_dmic_update_bits(dmic, dmic_base[i] + FIR_CONTROL_A,
 					     FIR_CONTROL_MUTE,
 					     FIR_CONTROL_MUTE);
 			break;
 		case 1:
-			dai_dmic_update_bits(dmic, base[i] + FIR_CONTROL_B,
+			dai_dmic_update_bits(dmic, dmic_base[i] + FIR_CONTROL_B,
 					     FIR_CONTROL_MUTE,
 					     FIR_CONTROL_MUTE);
 			break;

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -2205,11 +2205,11 @@ static int flash_stm32_ospi_init(const struct device *dev)
 			union {
 				uint32_t dw[MIN(php->len_dw, 20)];
 				struct jesd216_bfp bfp;
-			} u;
-			const struct jesd216_bfp *bfp = &u.bfp;
+			} u2;
+			const struct jesd216_bfp *bfp = &u2.bfp;
 
 			ret = ospi_read_sfdp(dev, jesd216_param_addr(php),
-					     (uint8_t *)u.dw, sizeof(u.dw));
+					     (uint8_t *)u2.dw, sizeof(u2.dw));
 			if (ret == 0) {
 				ret = spi_nor_process_bfp(dev, php, bfp);
 			}

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1311,11 +1311,11 @@ static int flash_stm32_qspi_init(const struct device *dev)
 			union {
 				uint32_t dw[MIN(php->len_dw, 20)];
 				struct jesd216_bfp bfp;
-			} u;
-			const struct jesd216_bfp *bfp = &u.bfp;
+			} u2;
+			const struct jesd216_bfp *bfp = &u2.bfp;
 
 			ret = qspi_read_sfdp(dev, jesd216_param_addr(php),
-					     (uint8_t *)u.dw, sizeof(u.dw));
+					     (uint8_t *)u2.dw, sizeof(u2.dw));
 			if (ret == 0) {
 				ret = spi_nor_process_bfp(dev, php, bfp);
 			}

--- a/drivers/pinctrl/pinctrl_gd32_afio.c
+++ b/drivers/pinctrl/pinctrl_gd32_afio.c
@@ -144,17 +144,17 @@ static void configure_pin(pinctrl_soc_pin_t pin)
 	reg_val &= ~GPIO_MODE_MASK(pin_num);
 
 	if (mode == GD32_MODE_ALTERNATE) {
-		uint8_t mode;
+		uint8_t new_mode;
 
-		mode = configure_spd(port, pin_bit, GD32_OSPEED_GET(pin));
+		new_mode = configure_spd(port, pin_bit, GD32_OSPEED_GET(pin));
 
 		if (GD32_OTYPE_GET(pin) == GD32_OTYPE_PP) {
-			mode |= GPIO_MODE_ALT_PP;
+			new_mode |= GPIO_MODE_ALT_PP;
 		} else {
-			mode |= GPIO_MODE_ALT_OD;
+			new_mode |= GPIO_MODE_ALT_OD;
 		}
 
-		reg_val |= GPIO_MODE_SET(pin_num, mode);
+		reg_val |= GPIO_MODE_SET(pin_num, new_mode);
 	} else if (mode == GD32_MODE_GPIO_IN) {
 		uint8_t pupd = GD32_PUPD_GET(pin);
 

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -495,10 +495,10 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 #ifdef CONFIG_PM
 #define UART_CC13XX_CC26XX_POWER_UART(n)				\
 	do {								\
-		struct uart_cc13xx_cc26xx_data *data = dev->data;	\
+		struct uart_cc13xx_cc26xx_data *dev_data = dev->data;	\
 									\
-		data->rx_constrained = false;				\
-		data->tx_constrained = false;				\
+		dev_data->rx_constrained = false;			\
+		dev_data->tx_constrained = false;			\
 									\
 		/* Set Power dependencies */				\
 		if (DT_INST_REG_ADDR(n) == 0x40001000) {		\
@@ -508,7 +508,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 		}							\
 									\
 		/* Register notification function */			\
-		Power_registerNotify(&data->postNotify,			\
+		Power_registerNotify(&dev_data->postNotify,		\
 			PowerCC26XX_AWAKE_STANDBY,			\
 			postNotifyFxn, (uintptr_t)dev);			\
 	} while (false)

--- a/drivers/serial/uart_hvc_xen.c
+++ b/drivers/serial/uart_hvc_xen.c
@@ -21,7 +21,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uart_hvc_xen, CONFIG_UART_LOG_LEVEL);
 
-static struct hvc_xen_data hvc_data = {0};
+static struct hvc_xen_data xen_hvc_data = {0};
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void hvc_uart_evtchn_cb(void *priv);
@@ -262,7 +262,7 @@ int xen_console_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_DEFINE(DT_NODELABEL(xen_hvc), xen_console_init, NULL, &hvc_data,
+DEVICE_DT_DEFINE(DT_NODELABEL(xen_hvc), xen_console_init, NULL, &xen_hvc_data,
 		NULL, PRE_KERNEL_1, CONFIG_XEN_HVC_INIT_PRIORITY,
 		&xen_hvc_api);
 

--- a/drivers/spi/spi_pl022.c
+++ b/drivers/spi/spi_pl022.c
@@ -786,13 +786,13 @@ static int spi_pl022_transceive_impl(const struct device *dev,
 	if (cfg->dma_enabled) {
 #if defined(CONFIG_SPI_PL022_DMA)
 		for (size_t i = 0; i < ARRAY_SIZE(data->dma); i++) {
-			const struct spi_pl022_cfg *cfg = dev->config;
 			struct dma_status stat = {.busy = true};
 
 			dma_stop(cfg->dma[i].dev, cfg->dma[i].channel);
 
 			while (stat.busy) {
-				dma_get_status(cfg->dma[i].dev, cfg->dma[i].channel, &stat);
+				dma_get_status(cfg->dma[i].dev,
+					       cfg->dma[i].channel, &stat);
 			}
 
 			data->dma[i].count = 0;

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1046,7 +1046,6 @@ static void usbd_event_transfer_data(nrfx_usbd_evt_t const *const p_event)
  */
 static void usbd_event_handler(nrfx_usbd_evt_t const *const p_event)
 {
-	struct nrf_usbd_ep_ctx *ep_ctx;
 	struct usbd_event evt = {0};
 	bool put_evt = false;
 
@@ -1080,7 +1079,9 @@ static void usbd_event_handler(nrfx_usbd_evt_t const *const p_event)
 		}
 		break;
 
-	case NRFX_USBD_EVT_EPTRANSFER:
+	case NRFX_USBD_EVT_EPTRANSFER: {
+		struct nrf_usbd_ep_ctx *ep_ctx;
+
 		ep_ctx = endpoint_ctx(p_event->data.eptransfer.ep);
 		switch (ep_ctx->cfg.type) {
 		case USB_DC_EP_CONTROL:
@@ -1097,6 +1098,7 @@ static void usbd_event_handler(nrfx_usbd_evt_t const *const p_event)
 			break;
 		}
 		break;
+	}
 
 	case NRFX_USBD_EVT_SETUP: {
 		nrfx_usbd_setup_t drv_setup;

--- a/include/zephyr/arch/arm64/lib_helpers.h
+++ b/include/zephyr/arch/arm64/lib_helpers.h
@@ -16,10 +16,10 @@
 
 #define read_sysreg(reg)						\
 ({									\
-	uint64_t val;							\
+	uint64_t reg_val;						\
 	__asm__ volatile ("mrs %0, " STRINGIFY(reg)			\
-			  : "=r" (val) :: "memory");			\
-	val;								\
+			  : "=r" (reg_val) :: "memory");		\
+	reg_val;							\
 })
 
 #define write_sysreg(val, reg)						\

--- a/include/zephyr/arch/riscv/csr.h
+++ b/include/zephyr/arch/riscv/csr.h
@@ -184,52 +184,52 @@
 
 #define csr_read(csr)						\
 ({								\
-	register unsigned long __v;				\
+	register unsigned long __rv;				\
 	__asm__ volatile ("csrr %0, " STRINGIFY(csr)		\
-				: "=r" (__v));			\
-	__v;							\
+				: "=r" (__rv));			\
+	__rv;							\
 })
 
 #define csr_write(csr, val)					\
 ({								\
-	unsigned long __v = (unsigned long)(val);		\
+	unsigned long __wv = (unsigned long)(val);		\
 	__asm__ volatile ("csrw " STRINGIFY(csr) ", %0"		\
-				: : "rK" (__v)			\
+				: : "rK" (__wv)			\
 				: "memory");			\
 })
 
 
 #define csr_read_set(csr, val)					\
 ({								\
-	unsigned long __v = (unsigned long)(val);		\
+	unsigned long __rsv = (unsigned long)(val);		\
 	__asm__ volatile ("csrrs %0, " STRINGIFY(csr) ", %1"	\
-				: "=r" (__v) : "rK" (__v)	\
+				: "=r" (__rsv) : "rK" (__rsv)	\
 				: "memory");			\
-	__v;							\
+	__rsv;							\
 })
 
 #define csr_set(csr, val)					\
 ({								\
-	unsigned long __v = (unsigned long)(val);		\
+	unsigned long __sv = (unsigned long)(val);		\
 	__asm__ volatile ("csrs " STRINGIFY(csr) ", %0"		\
-				: : "rK" (__v)			\
+				: : "rK" (__sv)			\
 				: "memory");			\
 })
 
 #define csr_read_clear(csr, val)				\
 ({								\
-	unsigned long __v = (unsigned long)(val);		\
+	unsigned long __rcv = (unsigned long)(val);		\
 	__asm__ volatile ("csrrc %0, " STRINGIFY(csr) ", %1"	\
-				: "=r" (__v) : "rK" (__v)	\
+				: "=r" (__rcv) : "rK" (__rcv)	\
 				: "memory");			\
-	__v;							\
+	__rcv;							\
 })
 
 #define csr_clear(csr, val)					\
 ({								\
-	unsigned long __v = (unsigned long)(val);		\
+	unsigned long __cv = (unsigned long)(val);		\
 	__asm__ volatile ("csrc " STRINGIFY(csr) ", %0"		\
-				: : "rK" (__v)			\
+				: : "rK" (__cv)			\
 				: "memory");			\
 })
 

--- a/include/zephyr/debug/stack.h
+++ b/include/zephyr/debug/stack.h
@@ -13,6 +13,7 @@
 #define ZEPHYR_INCLUDE_DEBUG_STACK_H_
 
 #include <zephyr/logging/log.h>
+#include <zephyr/toolchain.h>
 #include <stdbool.h>
 
 static inline void log_stack_usage(const struct k_thread *thread)
@@ -20,7 +21,9 @@ static inline void log_stack_usage(const struct k_thread *thread)
 #if defined(CONFIG_INIT_STACKS) && defined(CONFIG_THREAD_STACK_INFO)
 	size_t unused, size = thread->stack_info.size;
 
+	TOOLCHAIN_IGNORE_WSHADOW_BEGIN;
 	LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
+	TOOLCHAIN_IGNORE_WSHADOW_END;
 
 	if (k_thread_stack_space_get(thread, &unused) == 0) {
 		unsigned int pcnt = ((size - unused) * 100U) / size;

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2450,9 +2450,9 @@ struct k_fifo {
 #define k_fifo_alloc_put(fifo, data) \
 	({ \
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_fifo, alloc_put, fifo, data); \
-	int ret = k_queue_alloc_append(&(fifo)->_queue, data); \
-	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, alloc_put, fifo, data, ret); \
-	ret; \
+	int fap_ret = k_queue_alloc_append(&(fifo)->_queue, data); \
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, alloc_put, fifo, data, fap_ret); \
+	fap_ret; \
 	})
 
 /**
@@ -2516,9 +2516,9 @@ struct k_fifo {
 #define k_fifo_get(fifo, timeout) \
 	({ \
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_fifo, get, fifo, timeout); \
-	void *ret = k_queue_get(&(fifo)->_queue, timeout); \
-	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, get, fifo, timeout, ret); \
-	ret; \
+	void *fg_ret = k_queue_get(&(fifo)->_queue, timeout); \
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, get, fifo, timeout, fg_ret); \
+	fg_ret; \
 	})
 
 /**
@@ -2553,9 +2553,9 @@ struct k_fifo {
 #define k_fifo_peek_head(fifo) \
 	({ \
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_fifo, peek_head, fifo); \
-	void *ret = k_queue_peek_head(&(fifo)->_queue); \
-	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, peek_head, fifo, ret); \
-	ret; \
+	void *fph_ret = k_queue_peek_head(&(fifo)->_queue); \
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, peek_head, fifo, fph_ret); \
+	fph_ret; \
 	})
 
 /**
@@ -2572,9 +2572,9 @@ struct k_fifo {
 #define k_fifo_peek_tail(fifo) \
 	({ \
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_fifo, peek_tail, fifo); \
-	void *ret = k_queue_peek_tail(&(fifo)->_queue); \
-	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, peek_tail, fifo, ret); \
-	ret; \
+	void *fpt_ret = k_queue_peek_tail(&(fifo)->_queue); \
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, peek_tail, fifo, fpt_ret); \
+	fpt_ret; \
 	})
 
 /**
@@ -2667,9 +2667,9 @@ struct k_lifo {
 #define k_lifo_alloc_put(lifo, data) \
 	({ \
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_lifo, alloc_put, lifo, data); \
-	int ret = k_queue_alloc_prepend(&(lifo)->_queue, data); \
-	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_lifo, alloc_put, lifo, data, ret); \
-	ret; \
+	int lap_ret = k_queue_alloc_prepend(&(lifo)->_queue, data); \
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_lifo, alloc_put, lifo, data, lap_ret); \
+	lap_ret; \
 	})
 
 /**
@@ -2692,9 +2692,9 @@ struct k_lifo {
 #define k_lifo_get(lifo, timeout) \
 	({ \
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_lifo, get, lifo, timeout); \
-	void *ret = k_queue_get(&(lifo)->_queue, timeout); \
-	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_lifo, get, lifo, timeout, ret); \
-	ret; \
+	void *lg_ret = k_queue_get(&(lifo)->_queue, timeout); \
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_lifo, get, lifo, timeout, lg_ret); \
+	lg_ret; \
 	})
 
 /**

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -235,7 +235,9 @@ do { \
 		CBPRINTF_STATIC_PACKAGE(NULL, 0, _plen, Z_LOG_MSG_ALIGN_OFFSET, _options, \
 					__VA_ARGS__); \
 	} \
+	TOOLCHAIN_IGNORE_WSHADOW_BEGIN \
 	struct log_msg *_msg; \
+	TOOLCHAIN_IGNORE_WSHADOW_END \
 	Z_LOG_MSG_ON_STACK_ALLOC(_msg, Z_LOG_MSG_LEN(_plen, 0)); \
 	Z_LOG_ARM64_VLA_PROTECT(); \
 	if (_plen != 0) { \

--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -471,18 +471,18 @@ do { \
 	if (_pbuf != NULL) { \
 		/* Append string locations. */ \
 		uint8_t *_pbuf_loc = &_pbuf[_pkg_len]; \
-		for (size_t i = 0; i < _ros_cnt; i++) { \
-			*_pbuf_loc++ = _ros_pos_buf[i]; \
+		for (size_t _ros_idx = 0; _ros_idx < _ros_cnt; _ros_idx++) { \
+			*_pbuf_loc++ = _ros_pos_buf[_ros_idx]; \
 		} \
-		for (size_t i = 0; i < (2 * _rws_cnt); i++) { \
-			*_pbuf_loc++ = _rws_buffer[i]; \
+		for (size_t _rws_idx = 0; _rws_idx < (2 * _rws_cnt); _rws_idx++) { \
+			*_pbuf_loc++ = _rws_buffer[_rws_idx]; \
 		} \
 	} \
 	/* Store length */ \
 	_outlen = (_total_len > (int)_pmax) ? -ENOSPC : _total_len; \
 	/* Store length in the header, set number of dumped strings to 0 */ \
 	if (_pbuf != NULL) { \
-		union cbprintf_package_hdr hdr = { \
+		union cbprintf_package_hdr pkg_hdr = { \
 			.desc = { \
 				.len = (uint8_t)(_pkg_len / sizeof(int)), \
 				.str_cnt = 0, \
@@ -491,8 +491,8 @@ do { \
 			} \
 		}; \
 		IF_ENABLED(CONFIG_CBPRINTF_PACKAGE_HEADER_STORE_CREATION_FLAGS, \
-			   (hdr.desc.pkg_flags = flags)); \
-		*_len_loc = hdr; \
+			   (pkg_hdr.desc.pkg_flags = flags)); \
+		*_len_loc = pkg_hdr; \
 	} \
 	_Pragma("GCC diagnostic pop") \
 } while (false)

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -668,9 +668,9 @@ char *utf8_lcpy(char *dst, const char *src, size_t n);
  */
 #define WAIT_FOR(expr, timeout, delay_stmt)                                                        \
 	({                                                                                         \
-		uint32_t cycle_count = k_us_to_cyc_ceil32(timeout);                                \
-		uint32_t start = k_cycle_get_32();                                                 \
-		while (!(expr) && (cycle_count > (k_cycle_get_32() - start))) {                    \
+		uint32_t _wf_cycle_count = k_us_to_cyc_ceil32(timeout);                            \
+		uint32_t _wf_start = k_cycle_get_32();                                             \
+		while (!(expr) && (_wf_cycle_count > (k_cycle_get_32() - _wf_start))) {            \
 			delay_stmt;                                                                \
 			Z_SPIN_DELAY(10);                                                          \
 		}                                                                                  \

--- a/include/zephyr/syscall_handler.h
+++ b/include/zephyr/syscall_handler.h
@@ -311,7 +311,9 @@ extern int z_user_string_copy(char *dst, const char *src, size_t maxlen);
 #define Z_SYSCALL_VERIFY_MSG(expr, fmt, ...) ({ \
 	bool expr_copy = !(expr); \
 	if (expr_copy) { \
+		TOOLCHAIN_IGNORE_WSHADOW_BEGIN \
 		LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL); \
+		TOOLCHAIN_IGNORE_WSHADOW_END \
 		LOG_ERR("syscall %s failed check: " fmt, \
 			__func__, ##__VA_ARGS__); \
 	} \

--- a/include/zephyr/toolchain.h
+++ b/include/zephyr/toolchain.h
@@ -115,6 +115,28 @@
 #define TOOLCHAIN_HAS_C_AUTO_TYPE 0
 #endif
 
+/**
+ * @def TOOLCHAIN_IGNORE_WSHADOW_BEGIN
+ * @brief Begin of block to ignore -Wshadow.
+ *
+ * To be used inside another macro.
+ * Only for toolchain supporting _Pragma("GCC diagnostic ...").
+ */
+#ifndef TOOLCHAIN_IGNORE_WSHADOW_BEGIN
+#define TOOLCHAIN_IGNORE_WSHADOW_BEGIN
+#endif
+
+/**
+ * @def TOOLCHAIN_IGNORE_WSHADOW_END
+ * @brief End of block to ignore -Wshadow.
+ *
+ * To be used inside another macro.
+ * Only for toolchain supporting _Pragma("GCC diagnostic ...").
+ */
+#ifndef TOOLCHAIN_IGNORE_WSHADOW_END
+#define TOOLCHAIN_IGNORE_WSHADOW_END
+#endif
+
 /*
  * Ensure that __BYTE_ORDER__ and related preprocessor definitions are defined,
  * and that they match the Kconfig option that is used in the code itself to

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -639,5 +639,12 @@ do {                                                                    \
 #define FUNC_NO_STACK_PROTECTOR
 #endif
 
+#define TOOLCHAIN_IGNORE_WSHADOW_BEGIN \
+	_Pragma("GCC diagnostic push") \
+	_Pragma("GCC diagnostic ignored \"-Wshadow\"")
+
+#define TOOLCHAIN_IGNORE_WSHADOW_END \
+	_Pragma("GCC diagnostic pop")
+
 #endif /* !_LINKER */
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_GCC_H_ */

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -123,12 +123,12 @@
 #endif
 
 /* Unaligned access */
-#define UNALIGNED_GET(p)						\
+#define UNALIGNED_GET(g)						\
 __extension__ ({							\
 	struct  __attribute__((__packed__)) {				\
-		__typeof__(*(p)) __v;					\
-	} *__p = (__typeof__(__p)) (p);					\
-	__p->__v;							\
+		__typeof__(*(g)) __v;					\
+	} *__g = (__typeof__(__g)) (g);					\
+	__g->__v;							\
 })
 
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -493,11 +493,11 @@ void k_sched_time_slice_set(int32_t slice, int prio)
 }
 
 #ifdef CONFIG_TIMESLICE_PER_THREAD
-void k_thread_time_slice_set(struct k_thread *th, int32_t slice_ticks,
+void k_thread_time_slice_set(struct k_thread *th, int32_t thread_slice_ticks,
 			     k_thread_timeslice_fn_t expired, void *data)
 {
 	K_SPINLOCK(&sched_spinlock) {
-		th->base.slice_ticks = slice_ticks;
+		th->base.slice_ticks = thread_slice_ticks;
 		th->base.slice_expired = expired;
 		th->base.slice_data = data;
 	}

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -9,7 +9,7 @@
 #include <kernel_internal.h>
 
 static atomic_t global_lock;
-static atomic_t start_flag;
+static atomic_t cpu_start_flag;
 static atomic_t ready_flag;
 
 unsigned int z_smp_global_lock(void)
@@ -56,10 +56,10 @@ static inline void local_delay(void)
 	}
 }
 
-static void wait_for_start_signal(atomic_t *cpu_start_flag)
+static void wait_for_start_signal(atomic_t *start_flag)
 {
 	/* Wait for the signal to begin scheduling */
-	while (!atomic_get(cpu_start_flag)) {
+	while (!atomic_get(start_flag)) {
 		local_delay();
 	}
 }
@@ -107,20 +107,20 @@ static void start_cpu(int id, atomic_t *start_flag)
 
 void z_smp_start_cpu(int id)
 {
-	(void)atomic_set(&start_flag, 1); /* async, don't care */
-	start_cpu(id, &start_flag);
+	(void)atomic_set(&cpu_start_flag, 1); /* async, don't care */
+	start_cpu(id, &cpu_start_flag);
 }
 
 void z_smp_init(void)
 {
-	(void)atomic_clear(&start_flag);
+	(void)atomic_clear(&cpu_start_flag);
 
 	unsigned int num_cpus = arch_num_cpus();
 
 	for (int i = 1; i < num_cpus; i++) {
-		start_cpu(i, &start_flag);
+		start_cpu(i, &cpu_start_flag);
 	}
-	(void)atomic_set(&start_flag, 1);
+	(void)atomic_set(&cpu_start_flag, 1);
 }
 
 bool z_smp_cpu_mobile(void)

--- a/lib/acpi/acpi.c
+++ b/lib/acpi/acpi.c
@@ -26,7 +26,7 @@ static struct acpi bus_ctx = {
 	.status = AE_NOT_CONFIGURED,
 };
 
-static ACPI_TABLE_DESC acpi_table[CONFIG_ACPI_MAX_INIT_TABLES];
+static ACPI_TABLE_DESC acpi_tables[CONFIG_ACPI_MAX_INIT_TABLES];
 
 static int acpi_init(void);
 
@@ -380,7 +380,7 @@ static int acpi_early_init(void)
 		return 0;
 	}
 
-	status = AcpiInitializeTables(acpi_table, CONFIG_ACPI_MAX_INIT_TABLES, TRUE);
+	status = AcpiInitializeTables(acpi_tables, CONFIG_ACPI_MAX_INIT_TABLES, TRUE);
 	if (ACPI_FAILURE(status)) {
 		LOG_ERR("Error in acpi table init:%d", status);
 		return -EIO;

--- a/subsys/shell/modules/devmem_service.c
+++ b/subsys/shell/modules/devmem_service.c
@@ -42,7 +42,7 @@ static int memory_dump(const struct shell *sh, mem_addr_t phys_addr, size_t size
 	size_t data_offset;
 	mm_reg_t addr;
 	const size_t vsize = width / BITS_PER_BYTE;
-	uint8_t data[SHELL_HEXDUMP_BYTES_IN_LINE];
+	uint8_t hex_data[SHELL_HEXDUMP_BYTES_IN_LINE];
 
 #if defined(CONFIG_MMU) || defined(CONFIG_PCIE)
 	device_map((mm_reg_t *)&addr, phys_addr, size, K_MEM_CACHE_NONE);
@@ -60,7 +60,7 @@ static int memory_dump(const struct shell *sh, mem_addr_t phys_addr, size_t size
 			switch (width) {
 			case 8:
 				value = sys_read8(addr + data_offset);
-				data[data_offset] = value;
+				hex_data[data_offset] = value;
 				break;
 			case 16:
 				value = sys_read16(addr + data_offset);
@@ -68,9 +68,9 @@ static int memory_dump(const struct shell *sh, mem_addr_t phys_addr, size_t size
 					value = __bswap_16(value);
 				}
 
-				data[data_offset] = (uint8_t)value;
+				hex_data[data_offset] = (uint8_t)value;
 				value >>= 8;
-				data[data_offset + 1] = (uint8_t)value;
+				hex_data[data_offset + 1] = (uint8_t)value;
 				break;
 			case 32:
 				value = sys_read32(addr + data_offset);
@@ -78,13 +78,13 @@ static int memory_dump(const struct shell *sh, mem_addr_t phys_addr, size_t size
 					value = __bswap_32(value);
 				}
 
-				data[data_offset] = (uint8_t)value;
+				hex_data[data_offset] = (uint8_t)value;
 				value >>= 8;
-				data[data_offset + 1] = (uint8_t)value;
+				hex_data[data_offset + 1] = (uint8_t)value;
 				value >>= 8;
-				data[data_offset + 2] = (uint8_t)value;
+				hex_data[data_offset + 2] = (uint8_t)value;
 				value >>= 8;
-				data[data_offset + 3] = (uint8_t)value;
+				hex_data[data_offset + 3] = (uint8_t)value;
 				break;
 			default:
 				shell_fprintf(sh, SHELL_NORMAL, "Incorrect data width\n");
@@ -92,7 +92,7 @@ static int memory_dump(const struct shell *sh, mem_addr_t phys_addr, size_t size
 			}
 		}
 
-		shell_hexdump_line(sh, addr, data, MIN(size, SHELL_HEXDUMP_BYTES_IN_LINE));
+		shell_hexdump_line(sh, addr, hex_data, MIN(size, SHELL_HEXDUMP_BYTES_IN_LINE));
 	}
 
 	return 0;

--- a/subsys/testsuite/busy_sim/busy_sim.c
+++ b/subsys/testsuite/busy_sim/busy_sim.c
@@ -22,7 +22,7 @@ struct busy_sim_data {
 	busy_sim_cb_t cb;
 };
 
-static struct k_work work;
+static struct k_work sim_work;
 static struct ring_buf rnd_rbuf;
 static uint8_t rnd_buf[BUFFER_SIZE];
 
@@ -84,7 +84,7 @@ static uint32_t get_timeout(bool idle)
 				   (uint8_t *)&rand_val,
 				   sizeof(rand_val));
 		if (len < sizeof(rand_val)) {
-			k_work_submit(&work);
+			k_work_submit(&sim_work);
 			rand_val = 0;
 		}
 	}
@@ -141,7 +141,7 @@ void busy_sim_start(uint32_t active_avg, uint32_t active_delta,
 	data->idle_delta = idle_delta;
 
 	if (!IS_ENABLED(CONFIG_XOSHIRO_RANDOM_GENERATOR)) {
-		err = k_work_submit(&work);
+		err = k_work_submit(&sim_work);
 		__ASSERT_NO_MSG(err >= 0);
 	}
 
@@ -159,7 +159,7 @@ void busy_sim_stop(void)
 	const struct busy_sim_config *config = busy_sim_dev->config;
 
 	if (!IS_ENABLED(CONFIG_XOSHIRO_RANDOM_GENERATOR)) {
-		k_work_cancel(&work);
+		k_work_cancel(&sim_work);
 	}
 
 	err = counter_stop(config->counter);
@@ -191,7 +191,7 @@ static int busy_sim_init(const struct device *dev)
 	}
 
 	if (!IS_ENABLED(CONFIG_XOSHIRO_RANDOM_GENERATOR)) {
-		k_work_init(&work, rng_pool_work_handler);
+		k_work_init(&sim_work, rng_pool_work_handler);
 		ring_buf_init(&rnd_rbuf, BUFFER_SIZE, rnd_buf);
 	}
 

--- a/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
@@ -393,10 +393,10 @@ void ztest_skip_failed_assumption(void);
 		.thread_options = t_options,                                                       \
 		.stats = &z_ztest_unit_test_stats_##suite##_##fn                                   \
 	};                                                                                         \
-	static void _##suite##_##fn##_wrapper(void *data)                                          \
+	static void _##suite##_##fn##_wrapper(void *wrapper_data)                                  \
 	{                                                                                          \
-		COND_CODE_1(use_fixture, (suite##_##fn((struct suite##_fixture *)data);),          \
-			    (ARG_UNUSED(data); suite##_##fn();))                                   \
+		COND_CODE_1(use_fixture, (suite##_##fn((struct suite##_fixture *)wrapper_data);),  \
+			    (ARG_UNUSED(wrapper_data); suite##_##fn();))                           \
 	}                                                                                          \
 	static inline void suite##_##fn(                                                           \
 		COND_CODE_1(use_fixture, (struct suite##_fixture *fixture), (void)))

--- a/subsys/testsuite/ztest/include/zephyr/ztress.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztress.h
@@ -176,17 +176,18 @@ struct ztress_context_data {
 #define ZTRESS_EXECUTE(...) do {							\
 	Z_ZTRESS_TIMER_CONTEXT_VALIDATE(__VA_ARGS__);					\
 	int has_timer = Z_ZTRESS_HAS_TIMER(__VA_ARGS__);				\
-	struct ztress_context_data data1[] = {						\
+	struct ztress_context_data _ctx_data1[] = {					\
 		FOR_EACH(Z_ZTRESS_GET_HANDLER_DATA, (,), __VA_ARGS__)			\
 	};										\
-	size_t cnt = ARRAY_SIZE(data1) - has_timer;					\
-	static struct ztress_context_data data[ARRAY_SIZE(data1)];                      \
-	for (size_t i = 0; i < ARRAY_SIZE(data1); i++) {                                \
-		data[i] = data1[i];                                                     \
+	size_t cnt = ARRAY_SIZE(_ctx_data1) - has_timer;				\
+	static struct ztress_context_data _ctx_data[ARRAY_SIZE(_ctx_data1)];		\
+	for (size_t i = 0; i < ARRAY_SIZE(_ctx_data1); i++) {				\
+		_ctx_data[i] = _ctx_data1[i];						\
 	}	                                                                        \
-	int err = ztress_execute(has_timer ? &data[0] : NULL, &data[has_timer], cnt);	\
+	int exec_err = ztress_execute(has_timer ? &_ctx_data[0] : NULL,			\
+				 &_ctx_data[has_timer], cnt);				\
 											\
-	zassert_equal(err, 0, "ztress_execute failed (err: %d)", err);			\
+	zassert_equal(exec_err, 0, "ztress_execute failed (err: %d)", exec_err);	\
 } while (0)
 
 /** Execute contexts.

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -44,7 +44,7 @@ enum ztest_status {
 /**
  * @brief Tracks the current phase that ztest is operating in.
  */
-ZTEST_DMEM enum ztest_phase phase = TEST_PHASE_FRAMEWORK;
+ZTEST_DMEM enum ztest_phase cur_phase = TEST_PHASE_FRAMEWORK;
 
 static ZTEST_BMEM enum ztest_status test_status = ZTEST_STATUS_OK;
 
@@ -303,43 +303,43 @@ static jmp_buf test_suite_fail;
 
 void ztest_test_fail(void)
 {
-	switch (phase) {
+	switch (cur_phase) {
 	case TEST_PHASE_SETUP:
-		PRINT(" at %s function\n", get_friendly_phase_name(phase));
+		PRINT(" at %s function\n", get_friendly_phase_name(cur_phase));
 		longjmp(test_suite_fail, 1);
 	case TEST_PHASE_BEFORE:
 	case TEST_PHASE_TEST:
-		PRINT(" at %s function\n", get_friendly_phase_name(phase));
+		PRINT(" at %s function\n", get_friendly_phase_name(cur_phase));
 		longjmp(test_fail, 1);
 	case TEST_PHASE_AFTER:
 	case TEST_PHASE_TEARDOWN:
 	case TEST_PHASE_FRAMEWORK:
 		PRINT(" ERROR: cannot fail in test phase '%s()', bailing\n",
-		      get_friendly_phase_name(phase));
+		      get_friendly_phase_name(cur_phase));
 		longjmp(stack_fail, 1);
 	}
 }
 
 void ztest_test_pass(void)
 {
-	if (phase == TEST_PHASE_TEST) {
+	if (cur_phase == TEST_PHASE_TEST) {
 		longjmp(test_pass, 1);
 	}
 	PRINT(" ERROR: cannot pass in test phase '%s()', bailing\n",
-	      get_friendly_phase_name(phase));
+	      get_friendly_phase_name(cur_phase));
 	longjmp(stack_fail, 1);
 }
 
 void ztest_test_skip(void)
 {
-	switch (phase) {
+	switch (cur_phase) {
 	case TEST_PHASE_SETUP:
 	case TEST_PHASE_BEFORE:
 	case TEST_PHASE_TEST:
 		longjmp(test_skip, 1);
 	default:
 		PRINT(" ERROR: cannot skip in test phase '%s()', bailing\n",
-		      get_friendly_phase_name(phase));
+		      get_friendly_phase_name(cur_phase));
 		longjmp(stack_fail, 1);
 	}
 }
@@ -348,19 +348,19 @@ void ztest_test_expect_fail(void)
 {
 	failed_expectation = true;
 
-	switch (phase) {
+	switch (cur_phase) {
 	case TEST_PHASE_SETUP:
-		PRINT(" at %s function\n", get_friendly_phase_name(phase));
+		PRINT(" at %s function\n", get_friendly_phase_name(cur_phase));
 		break;
 	case TEST_PHASE_BEFORE:
 	case TEST_PHASE_TEST:
-		PRINT(" at %s function\n", get_friendly_phase_name(phase));
+		PRINT(" at %s function\n", get_friendly_phase_name(cur_phase));
 		break;
 	case TEST_PHASE_AFTER:
 	case TEST_PHASE_TEARDOWN:
 	case TEST_PHASE_FRAMEWORK:
 		PRINT(" ERROR: cannot fail in test phase '%s()', bailing\n",
-		      get_friendly_phase_name(phase));
+		      get_friendly_phase_name(cur_phase));
 		longjmp(stack_fail, 1);
 	}
 }
@@ -445,7 +445,7 @@ static void test_finalize(void)
 
 void ztest_test_fail(void)
 {
-	switch (phase) {
+	switch (cur_phase) {
 	case TEST_PHASE_SETUP:
 		__ztest_set_test_result(ZTEST_RESULT_SUITE_FAIL);
 		break;
@@ -456,7 +456,7 @@ void ztest_test_fail(void)
 		break;
 	default:
 		PRINT(" ERROR: cannot fail in test phase '%s()', bailing\n",
-		      get_friendly_phase_name(phase));
+		      get_friendly_phase_name(cur_phase));
 		test_status = ZTEST_STATUS_CRITICAL_ERROR;
 		break;
 	}
@@ -464,16 +464,16 @@ void ztest_test_fail(void)
 
 void ztest_test_pass(void)
 {
-	switch (phase) {
+	switch (cur_phase) {
 	case TEST_PHASE_TEST:
 		__ztest_set_test_result(ZTEST_RESULT_PASS);
 		test_finalize();
 		break;
 	default:
 		PRINT(" ERROR: cannot pass in test phase '%s()', bailing\n",
-		      get_friendly_phase_name(phase));
+		      get_friendly_phase_name(cur_phase));
 		test_status = ZTEST_STATUS_CRITICAL_ERROR;
-		if (phase == TEST_PHASE_BEFORE) {
+		if (cur_phase == TEST_PHASE_BEFORE) {
 			test_finalize();
 		}
 	}
@@ -481,7 +481,7 @@ void ztest_test_pass(void)
 
 void ztest_test_skip(void)
 {
-	switch (phase) {
+	switch (cur_phase) {
 	case TEST_PHASE_SETUP:
 		__ztest_set_test_result(ZTEST_RESULT_SUITE_SKIP);
 		break;
@@ -492,7 +492,7 @@ void ztest_test_skip(void)
 		break;
 	default:
 		PRINT(" ERROR: cannot skip in test phase '%s()', bailing\n",
-		      get_friendly_phase_name(phase));
+		      get_friendly_phase_name(cur_phase));
 		test_status = ZTEST_STATUS_CRITICAL_ERROR;
 		break;
 	}
@@ -717,8 +717,8 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite)
 		memset(tests_to_run, 0, ZTEST_TEST_COUNT * sizeof(struct ztest_unit_test *));
 		z_ztest_shuffle((void **)tests_to_run, (intptr_t)_ztest_unit_test_list_start,
 				ZTEST_TEST_COUNT, sizeof(struct ztest_unit_test));
-		for (size_t i = 0; i < ZTEST_TEST_COUNT; ++i) {
-			test = tests_to_run[i];
+		for (size_t j = 0; j < ZTEST_TEST_COUNT; ++j) {
+			test = tests_to_run[j];
 			/* Make sure that the test belongs to this suite */
 			if (strcmp(suite->name, test->test_suite_name) != 0) {
 				continue;
@@ -992,7 +992,7 @@ void z_impl___ztest_set_test_result(enum ztest_result new_result)
 
 void z_impl___ztest_set_test_phase(enum ztest_phase new_phase)
 {
-	phase = new_phase;
+	cur_phase = new_phase;
 }
 
 #ifdef CONFIG_USERSPACE

--- a/tests/benchmarks/data_structure_perf/rbtree_perf/src/rbtree_perf.c
+++ b/tests/benchmarks/data_structure_perf/rbtree_perf/src/rbtree_perf.c
@@ -19,7 +19,7 @@ struct container_node {
 	int value;
 };
 static struct rbnode nodes[TREE_SIZE];
-static struct rbtree tree;
+static struct rbtree test_rbtree;
 
 /* Our "lessthan" is just the location of the struct */
 bool node_lessthan(struct rbnode *a, struct rbnode *b)
@@ -126,7 +126,7 @@ static int search_height_recurse(struct rbnode *node, struct rbnode
 
 	current_height++;
 	struct rbnode *ch = z_rb_child(node,
-			!tree.lessthan_fn(final_node, node));
+			!test_rbtree.lessthan_fn(final_node, node));
 
 	return search_height_recurse(ch, final_node, current_height);
 }
@@ -188,14 +188,14 @@ static void verify_rbtree_perf(struct rbnode *root, struct rbnode *test)
  */
 ZTEST(rbtree_perf, test_rbtree_perf)
 {
-	init_tree(&tree, TREE_SIZE);
-	struct rbnode *root = tree.root;
+	init_tree(&test_rbtree, TREE_SIZE);
+	struct rbnode *root = test_rbtree.root;
 	struct rbnode *test = NULL;
 
-	test = rb_get_min(&tree);
+	test = rb_get_min(&test_rbtree);
 	verify_rbtree_perf(root, test);
 
-	test = rb_get_max(&tree);
+	test = rb_get_max(&test_rbtree);
 	verify_rbtree_perf(root, test);
 
 	/* insert and remove a same node with same height.Assume that

--- a/tests/benchmarks/sys_kernel/src/lifo.c
+++ b/tests/benchmarks/sys_kernel/src/lifo.c
@@ -224,13 +224,13 @@ int lifo_test(void)
 			 NULL, INT_TO_POINTER(number_of_loops), NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	for (i = 0; i < number_of_loops / 2U; i++) {
-		intptr_t element[2];
+		intptr_t more_element[2];
 		intptr_t *pelement;
 
-		element[1] = 2 * i;
-		k_lifo_put(&lifo1, element);
-		element[1] = 2 * i + 1;
-		k_lifo_put(&lifo1, element);
+		more_element[1] = 2 * i;
+		k_lifo_put(&lifo1, more_element);
+		more_element[1] = 2 * i + 1;
+		k_lifo_put(&lifo1, more_element);
 
 		pelement = k_lifo_get(&lifo2, K_FOREVER);
 		if (pelement[1] != 2 * i + 1) {

--- a/tests/benchmarks/sys_kernel/src/mwfifo.c
+++ b/tests/benchmarks/sys_kernel/src/mwfifo.c
@@ -225,13 +225,13 @@ int fifo_test(void)
 			 NULL, INT_TO_POINTER(number_of_loops / 2U), NULL,
 			 K_PRIO_COOP(3), 0, K_NO_WAIT);
 	for (i = 0; i < number_of_loops / 2U; i++) {
-		intptr_t element[2];
+		intptr_t more_element[2];
 		intptr_t *pelement;
 
-		element[1] = i;
-		k_fifo_put(&fifo1, element);
-		element[1] = i;
-		k_fifo_put(&fifo1, element);
+		more_element[1] = i;
+		k_fifo_put(&fifo1, more_element);
+		more_element[1] = i;
+		k_fifo_put(&fifo1, more_element);
 
 		pelement = k_fifo_get(&fifo2, K_FOREVER);
 		if (pelement[1] != i) {

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -49,7 +49,7 @@ static void init_adc(void)
 
 	zassert_true(adc_is_ready_dt(&adc_channels[0]), "ADC device is not ready");
 
-	for (int i = 0; i < adc_channels_count; i++) {
+	for (i = 0; i < adc_channels_count; i++) {
 		ret = adc_channel_setup_dt(&adc_channels[i]);
 		zassert_equal(ret, 0, "Setting up of channel %d failed with code %d", i, ret);
 	}

--- a/tests/drivers/clock_control/nrf_lf_clock_start/src/main.c
+++ b/tests/drivers/clock_control/nrf_lf_clock_start/src/main.c
@@ -7,8 +7,8 @@
 #include <hal/nrf_clock.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 
-static nrf_clock_lfclk_t type;
-static bool on;
+static nrf_clock_lfclk_t clk_type;
+static bool clk_on;
 static uint32_t rtc_cnt;
 
 static void xtal_check(bool on, nrf_clock_lfclk_t type)
@@ -58,11 +58,11 @@ ZTEST(nrf_lf_clock_start, test_clock_check)
 		IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_EXT_FULL_SWING);
 
 	if (xtal) {
-		xtal_check(on, type);
+		xtal_check(clk_on, clk_type);
 	} else if (IS_ENABLED(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC)) {
-		rc_check(on, type);
+		rc_check(clk_on, clk_type);
 	} else {
-		synth_check(on, type);
+		synth_check(clk_on, clk_type);
 	}
 }
 
@@ -121,7 +121,7 @@ static int get_lfclk_state(void)
 	 * not valid, in that case read system clock to check if it has
 	 * progressed.
 	 */
-	on = nrf_clock_is_running(NRF_CLOCK, NRF_CLOCK_DOMAIN_LFCLK, &type);
+	clk_on = nrf_clock_is_running(NRF_CLOCK, NRF_CLOCK_DOMAIN_LFCLK, &clk_type);
 	k_busy_wait(100);
 	rtc_cnt = k_cycle_get_32();
 

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -19,8 +19,8 @@ static void top_handler(const struct device *dev, void *user_data);
 
 void *exp_user_data = (void *)199;
 
-struct counter_alarm_cfg alarm_cfg;
-struct counter_alarm_cfg alarm_cfg2;
+struct counter_alarm_cfg cntr_alarm_cfg;
+struct counter_alarm_cfg cntr_alarm_cfg2;
 
 #define DEVICE_DT_GET_AND_COMMA(node_id) DEVICE_DT_GET(node_id),
 /* Generate a list of devices for all instances of the "compat" */
@@ -340,7 +340,7 @@ static void alarm_handler(const struct device *dev, uint8_t chan_id,
 			counter, now, top, processing_limit_us);
 
 	if (user_data) {
-		zassert_true(&alarm_cfg == user_data,
+		zassert_true(&cntr_alarm_cfg == user_data,
 			"%s: Unexpected callback", dev->name);
 	}
 
@@ -369,9 +369,9 @@ static void test_single_shot_alarm_instance(const struct device *dev, bool set_t
 	ticks = counter_us_to_ticks(dev, counter_period_us);
 	top_cfg.ticks = ticks;
 
-	alarm_cfg.flags = 0;
-	alarm_cfg.callback = alarm_handler;
-	alarm_cfg.user_data = &alarm_cfg;
+	cntr_alarm_cfg.flags = 0;
+	cntr_alarm_cfg.callback = alarm_handler;
+	cntr_alarm_cfg.user_data = &cntr_alarm_cfg;
 
 	k_sem_reset(&alarm_cnt_sem);
 	alarm_cnt = 0;
@@ -390,16 +390,16 @@ static void test_single_shot_alarm_instance(const struct device *dev, bool set_t
 		zassert_equal(0, err,
 			     "%s: Counter failed to set top value", dev->name);
 
-		alarm_cfg.ticks = ticks + 1;
-		err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
+		cntr_alarm_cfg.ticks = ticks + 1;
+		err = counter_set_channel_alarm(dev, 0, &cntr_alarm_cfg);
 		zassert_equal(-EINVAL, err,
 			      "%s: Counter should return error because ticks"
 			      " exceeded the limit set alarm", dev->name);
-		alarm_cfg.ticks = ticks - 1;
+		cntr_alarm_cfg.ticks = ticks - 1;
 	}
 
-	alarm_cfg.ticks = ticks;
-	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
+	cntr_alarm_cfg.ticks = ticks;
+	err = counter_set_channel_alarm(dev, 0, &cntr_alarm_cfg);
 	zassert_equal(0, err, "%s: Counter set alarm failed (err: %d)",
 			dev->name, err);
 
@@ -509,15 +509,15 @@ static void test_multiple_alarms_instance(const struct device *dev)
 	zassert_equal(0, err, "%s: Counter get value failed", dev->name);
 	top_cfg.ticks += ticks;
 
-	alarm_cfg.flags = COUNTER_ALARM_CFG_ABSOLUTE;
-	alarm_cfg.ticks = counter_us_to_ticks(dev, 2000);
-	alarm_cfg.callback = alarm_handler2;
-	alarm_cfg.user_data = &alarm_cfg;
+	cntr_alarm_cfg.flags = COUNTER_ALARM_CFG_ABSOLUTE;
+	cntr_alarm_cfg.ticks = counter_us_to_ticks(dev, 2000);
+	cntr_alarm_cfg.callback = alarm_handler2;
+	cntr_alarm_cfg.user_data = &cntr_alarm_cfg;
 
-	alarm_cfg2.flags = 0;
-	alarm_cfg2.ticks = counter_us_to_ticks(dev, 2000);
-	alarm_cfg2.callback = alarm_handler2;
-	alarm_cfg2.user_data = &alarm_cfg2;
+	cntr_alarm_cfg2.flags = 0;
+	cntr_alarm_cfg2.ticks = counter_us_to_ticks(dev, 2000);
+	cntr_alarm_cfg2.callback = alarm_handler2;
+	cntr_alarm_cfg2.user_data = &cntr_alarm_cfg2;
 
 	k_sem_reset(&alarm_cnt_sem);
 	alarm_cnt = 0;
@@ -541,12 +541,12 @@ static void test_multiple_alarms_instance(const struct device *dev)
 		return;
 	}
 
-	k_busy_wait(3*(uint32_t)counter_ticks_to_us(dev, alarm_cfg.ticks));
+	k_busy_wait(3*(uint32_t)counter_ticks_to_us(dev, cntr_alarm_cfg.ticks));
 
-	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
+	err = counter_set_channel_alarm(dev, 0, &cntr_alarm_cfg);
 	zassert_equal(0, err, "%s: Counter set alarm failed", dev->name);
 
-	err = counter_set_channel_alarm(dev, 1, &alarm_cfg2);
+	err = counter_set_channel_alarm(dev, 1, &cntr_alarm_cfg2);
 	zassert_equal(0, err, "%s: Counter set alarm failed", dev->name);
 
 	k_busy_wait(1.2 * counter_ticks_to_us(dev, ticks * 2U));
@@ -557,10 +557,10 @@ static void test_multiple_alarms_instance(const struct device *dev)
 			"%s: Invalid number of callbacks %d (expected: %d)",
 			dev->name, cnt, 2);
 
-	zassert_equal(&alarm_cfg2, clbk_data[0],
+	zassert_equal(&cntr_alarm_cfg2, clbk_data[0],
 			"%s: Expected different order or callbacks",
 			dev->name);
-	zassert_equal(&alarm_cfg, clbk_data[1],
+	zassert_equal(&cntr_alarm_cfg, clbk_data[1],
 			"%s: Expected different order or callbacks",
 			dev->name);
 

--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -27,9 +27,9 @@
 
 #ifdef CONFIG_RANDOM_BUFFER_NOCACHED
 __attribute__((__section__(".nocache")))
-static uint8_t buffer[BUFFER_LENGTH] = {0};
+static uint8_t entropy_buffer[BUFFER_LENGTH] = {0};
 #else
-static uint8_t buffer[BUFFER_LENGTH] = {0};
+static uint8_t entropy_buffer[BUFFER_LENGTH] = {0};
 #endif
 
 static int random_entropy(const struct device *dev, char *buffer, char num)
@@ -86,7 +86,7 @@ static int get_entropy(void)
 	TC_PRINT("random device is %p, name is %s\n",
 		 dev, dev->name);
 
-	ret = random_entropy(dev, buffer, 0);
+	ret = random_entropy(dev, entropy_buffer, 0);
 
 	/* Check whether 20% or more of buffer still filled with default
 	 * value(0), if yes then recheck again by filling nonzero value(0xa5)
@@ -94,7 +94,7 @@ static int get_entropy(void)
 	 * of buffer filled with value(0xa5) or not.
 	 */
 	if (ret == RECHECK_RANDOM_ENTROPY) {
-		ret = random_entropy(dev, buffer, 0xa5);
+		ret = random_entropy(dev, entropy_buffer, 0xa5);
 		if (ret == RECHECK_RANDOM_ENTROPY) {
 			return TC_FAIL;
 		} else {

--- a/tests/drivers/flash/stm32/src/main.c
+++ b/tests/drivers/flash/stm32/src/main.c
@@ -25,7 +25,7 @@ static uint32_t sector_mask;
 static uint8_t __aligned(4) expected[EXPECTED_SIZE];
 
 static int sector_mask_from_offset(const struct device *dev, off_t offset,
-				   size_t size, uint32_t *sector_mask)
+				   size_t size, uint32_t *mask)
 {
 	struct flash_pages_info start_page, end_page;
 
@@ -34,8 +34,8 @@ static int sector_mask_from_offset(const struct device *dev, off_t offset,
 		return -EINVAL;
 	}
 
-	*sector_mask = ((1UL << (end_page.index + 1)) - 1) &
-		       ~((1UL << start_page.index) - 1);
+	*mask = ((1UL << (end_page.index + 1)) - 1) &
+		~((1UL << start_page.index) - 1);
 
 	return 0;
 }

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -433,7 +433,7 @@ static K_SEM_DEFINE(caller, 0, 1);
 K_THREAD_STACK_DEFINE(spi_async_stack, STACK_SIZE);
 static int result = 1;
 
-static void spi_async_call_cb(struct k_poll_event *async_evt,
+static void spi_async_call_cb(struct k_poll_event *evt,
 			      struct k_sem *caller_sem,
 			      void *unused)
 {
@@ -442,15 +442,15 @@ static void spi_async_call_cb(struct k_poll_event *async_evt,
 	LOG_DBG("Polling...");
 
 	while (1) {
-		ret = k_poll(async_evt, 1, K_MSEC(200));
+		ret = k_poll(evt, 1, K_MSEC(200));
 		zassert_false(ret, "one or more events are not ready");
 
-		result = async_evt->signal->result;
+		result = evt->signal->result;
 		k_sem_give(caller_sem);
 
 		/* Reinitializing for next call */
-		async_evt->signal->signaled = 0U;
-		async_evt->state = K_POLL_STATE_NOT_READY;
+		evt->signal->signaled = 0U;
+		evt->state = K_POLL_STATE_NOT_READY;
 	}
 }
 

--- a/tests/drivers/uart/uart_pm/src/main.c
+++ b/tests/drivers/uart/uart_pm/src/main.c
@@ -112,8 +112,8 @@ static void communication_verify(const struct device *dev, bool active)
 
 #define state_verify(dev, exp_state) do {\
 	enum pm_device_state power_state; \
-	int err = pm_device_state_get(dev, &power_state); \
-	zassert_equal(err, 0, "Unexpected err: %d", err); \
+	int error = pm_device_state_get(dev, &power_state); \
+	zassert_equal(error, 0, "Unexpected err: %d", error); \
 	zassert_equal(power_state, exp_state); \
 } while (0)
 

--- a/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
+++ b/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
@@ -26,7 +26,7 @@
 struct k_thread usr_fp_thread;
 K_THREAD_STACK_DEFINE(usr_fp_thread_stack, STACKSIZE);
 
-ZTEST_BMEM static volatile int ret = TC_PASS;
+ZTEST_BMEM static volatile int test_ret = TC_PASS;
 
 static void usr_fp_thread_entry_1(void)
 {
@@ -48,13 +48,13 @@ static void usr_fp_thread_entry_2(void)
 
 		TC_ERROR("k_float_disable() fail - should never see this\n");
 
-		ret = TC_FAIL;
+		test_ret = TC_FAIL;
 	}
 }
 
 ZTEST(k_float_disable, test_k_float_disable_common)
 {
-	ret = TC_PASS;
+	test_ret = TC_PASS;
 
 	/* Set thread priority level to the one used
 	 * in this test suite for cooperative threads.
@@ -105,7 +105,7 @@ ZTEST(k_float_disable, test_k_float_disable_common)
 
 ZTEST(k_float_disable, test_k_float_disable_syscall)
 {
-	ret = TC_PASS;
+	test_ret = TC_PASS;
 
 	k_thread_priority_set(k_current_get(), PRIORITY);
 
@@ -138,8 +138,8 @@ ZTEST(k_float_disable, test_k_float_disable_syscall)
 		"usr_fp_thread FP options not clear (0x%0x)",
 		usr_fp_thread.base.user_options);
 
-	/* ret is volatile, static analysis says we can't use in assert */
-	bool ok = ret == TC_PASS;
+	/* test_ret is volatile, static analysis says we can't use in assert */
+	bool ok = test_ret == TC_PASS;
 
 	zassert_true(ok, "");
 #else
@@ -167,7 +167,7 @@ void arm_test_isr_handler(const void *args)
 
 		TC_ERROR("k_float_disable() successful in ISR\n");
 
-		ret = TC_FAIL;
+		test_ret = TC_FAIL;
 	}
 }
 
@@ -177,7 +177,7 @@ static void sup_fp_thread_entry(void)
 	if ((sup_fp_thread.base.user_options & K_FP_REGS) == 0) {
 
 		TC_ERROR("sup_fp_thread FP options cleared\n");
-		ret = TC_FAIL;
+		test_ret = TC_FAIL;
 	}
 
 	/* Determine an NVIC IRQ line that is not currently in use. */
@@ -234,13 +234,13 @@ static void sup_fp_thread_entry(void)
 	if ((sup_fp_thread.base.user_options & K_FP_REGS) == 0) {
 
 		TC_ERROR("sup_fp_thread FP options cleared\n");
-		ret = TC_FAIL;
+		test_ret = TC_FAIL;
 	}
 }
 
 ZTEST(k_float_disable, test_k_float_disable_irq)
 {
-	ret = TC_PASS;
+	test_ret = TC_PASS;
 
 	k_thread_priority_set(k_current_get(), PRIORITY);
 
@@ -256,8 +256,8 @@ ZTEST(k_float_disable, test_k_float_disable_irq)
 	/* Yield will swap-in sup_fp_thread */
 	k_yield();
 
-	/* ret is volatile, static analysis says we can't use in assert */
-	bool ok = ret == TC_PASS;
+	/* test_ret is volatile, static analysis says we can't use in assert */
+	bool ok = test_ret == TC_PASS;
 
 	zassert_true(ok, "");
 }

--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
@@ -14,7 +14,7 @@
 struct k_sem sync_sema;
 static K_THREAD_STACK_ARRAY_DEFINE(tstack, THREAD_NUM, STACK_SIZE);
 static struct k_thread tdata[THREAD_NUM];
-static void *block[BLK_NUM_MAX];
+static void *pool_blocks[BLK_NUM_MAX];
 
 /*test cases*/
 
@@ -55,9 +55,9 @@ static void tmheap_handler(void *p1, void *p2, void *p3)
 {
 	int thread_id = POINTER_TO_INT(p1);
 
-	block[thread_id] = k_malloc(BLOCK_SIZE);
+	pool_blocks[thread_id] = k_malloc(BLOCK_SIZE);
 
-	zassert_not_null(block[thread_id], "memory is not allocated");
+	zassert_not_null(pool_blocks[thread_id], "memory is not allocated");
 
 	k_sem_give(&sync_sema);
 }
@@ -95,7 +95,7 @@ ZTEST(mheap_api, test_mheap_threadsafe)
 
 	for (int i = 0; i < THREAD_NUM; i++) {
 		/* verify free mheap in main thread */
-		k_free(block[i]);
+		k_free(pool_blocks[i]);
 		k_thread_abort(tid[i]);
 	}
 }

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -1328,7 +1328,7 @@ struct k_thread t;
 struct k_timer timer;
 struct z_thread_stack_element zs;
 struct k_futex f;
-struct k_condvar c;
+struct k_condvar condvar;
 
 static void entry_error_perm(void *p1, void *p2, void *p3)
 {
@@ -1364,7 +1364,7 @@ ZTEST(mem_protect_kobj, test_kobject_perm_error)
 	kobj[9] = &timer;
 	kobj[10] = &zs;
 	kobj[11] = &f;
-	kobj[12] = &c;
+	kobj[12] = &condvar;
 
 	for (int i = 0; i < 12 ; i++) {
 

--- a/tests/kernel/msgq/msgq_usage/src/main.c
+++ b/tests/kernel/msgq/msgq_usage/src/main.c
@@ -28,7 +28,7 @@ K_SEM_DEFINE(test_continue, 0, 1);
 struct k_thread service_manager;
 struct k_thread service1;
 struct k_thread service2;
-struct k_thread client;
+struct k_thread client_thread;
 static ZTEST_DMEM unsigned long __aligned(4) service1_buf[MSGQ_LEN];
 static ZTEST_DMEM unsigned long __aligned(4) service2_buf[MSGQ_LEN];
 static ZTEST_DMEM unsigned long __aligned(4) client_buf[MSGQ_LEN * 2];
@@ -254,7 +254,7 @@ static void start_client(void)
 
 	int pri = k_thread_priority_get(k_current_get());
 
-	tclient = k_thread_create(&client, client_stack, STACK_SIZE,
+	tclient = k_thread_create(&client_thread, client_stack, STACK_SIZE,
 				  client_entry, NULL, NULL, NULL, pri,
 				  0, K_NO_WAIT);
 }

--- a/tests/kernel/pending/src/main.c
+++ b/tests/kernel/pending/src/main.c
@@ -87,14 +87,14 @@ static int __noinit task_low_state;
 
 static int __noinit counter;
 
-static inline void *my_fifo_get(struct k_fifo *fifo, int32_t timeout)
+static inline void *my_fifo_get(struct k_fifo *my_fifo, int32_t timeout)
 {
-	return k_fifo_get(fifo, K_MSEC(timeout));
+	return k_fifo_get(my_fifo, K_MSEC(timeout));
 }
 
-static inline void *my_lifo_get(struct k_lifo *lifo, int32_t timeout)
+static inline void *my_lifo_get(struct k_lifo *my_lifo, int32_t timeout)
 {
-	return k_lifo_get(lifo, K_MSEC(timeout));
+	return k_lifo_get(my_lifo, K_MSEC(timeout));
 }
 
 static int increment_counter(void)

--- a/tests/kernel/sched/preempt/src/main.c
+++ b/tests/kernel/sched/preempt/src/main.c
@@ -50,7 +50,7 @@ const enum { METAIRQ, COOP, PREEMPTIBLE } worker_priorities[] = {
 
 #define STACK_SIZE (640 + CONFIG_TEST_EXTRA_STACK_SIZE)
 
-k_tid_t last_thread;
+k_tid_t last_wakeup_thread;
 
 struct k_thread manager_thread;
 
@@ -65,7 +65,7 @@ struct k_thread manager_thread;
 struct k_sem worker_sems[NUM_THREADS];
 
 /* Command to worker: who to wake up */
-int target;
+int wakeup_target;
 
 /* Command to worker: use a sched_lock()? */
 volatile int do_lock;
@@ -96,7 +96,7 @@ void wakeup_src_thread(int id)
 		return;
 	}
 
-	last_thread = NULL;
+	last_wakeup_thread = NULL;
 
 	/* A little bit of white-box inspection: check that all the
 	 * worker threads are pending.
@@ -112,7 +112,7 @@ void wakeup_src_thread(int id)
 	}
 
 	/* Wake the src worker up */
-	last_thread = NULL;
+	last_wakeup_thread = NULL;
 	k_sem_give(&worker_sems[id]);
 
 	while (do_sleep && !(src_thread->base.thread_state & _THREAD_PENDING)) {
@@ -121,15 +121,15 @@ void wakeup_src_thread(int id)
 	}
 
 	/* We are lowest priority, SOMEONE must have run */
-	zassert_true(!!last_thread, "");
+	zassert_true(!!last_wakeup_thread, "");
 }
 
 void manager(void *p1, void *p2, void *p3)
 {
 	for (int src = 0; src < NUM_THREADS; src++) {
-		for (target = 0; target < NUM_THREADS; target++) {
+		for (wakeup_target = 0; wakeup_target < NUM_THREADS; wakeup_target++) {
 
-			if (src == target) {
+			if (src == wakeup_target) {
 				continue;
 			}
 
@@ -157,7 +157,7 @@ void manager(void *p1, void *p2, void *p3)
 void irq_waker(const void *p)
 {
 	ARG_UNUSED(p);
-	k_sem_give(&worker_sems[target]);
+	k_sem_give(&worker_sems[wakeup_target]);
 }
 
 #define PRI(n) (worker_priorities[n])
@@ -244,12 +244,12 @@ void worker(void *p1, void *p2, void *p3)
 		 */
 		k_sem_take(&worker_sems[id], K_FOREVER);
 
-		last_thread = curr;
+		last_wakeup_thread = curr;
 
-		/* If we're the wakeup target, setting last_thread is
+		/* If we're the wakeup target, setting last_wakeup_thread is
 		 * all we do
 		 */
-		if (id == target) {
+		if (id == wakeup_target) {
 			continue;
 		}
 
@@ -262,14 +262,14 @@ void worker(void *p1, void *p2, void *p3)
 			 * ISR return does the right thing
 			 */
 			irq_offload(irq_waker, NULL);
-			prev = last_thread;
+			prev = last_wakeup_thread;
 		} else {
 			/* Do the sem_give() directly to validate that
 			 * the synchronous scheduling does the right
 			 * thing
 			 */
-			k_sem_give(&worker_sems[target]);
-			prev = last_thread;
+			k_sem_give(&worker_sems[wakeup_target]);
+			prev = last_wakeup_thread;
 		}
 
 		if (do_lock) {
@@ -278,7 +278,7 @@ void worker(void *p1, void *p2, void *p3)
 
 		if (do_yield) {
 			k_yield();
-			prev = last_thread;
+			prev = last_wakeup_thread;
 		}
 
 		if (do_sleep) {
@@ -288,10 +288,10 @@ void worker(void *p1, void *p2, void *p3)
 
 			zassert_true(k_uptime_get() - start > 0,
 				     "didn't sleep");
-			prev = last_thread;
+			prev = last_wakeup_thread;
 		}
 
-		validate_wakeup(id, target, prev);
+		validate_wakeup(id, wakeup_target, prev);
 	}
 }
 

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -18,7 +18,7 @@ struct k_thread t;
 
 K_SEM_DEFINE(pend_sema, 0, 1);
 K_SEM_DEFINE(timer_sema, 0, 1);
-struct k_timer timer;
+struct k_timer th_wakeup_timer;
 
 static void thread_entry(void *p1, void *p2, void *p3)
 {
@@ -80,8 +80,8 @@ static void timer_handler(struct k_timer *timer)
 
 static void thread_handler(void *p1, void *p2, void *p3)
 {
-	k_timer_init(&timer, timer_handler, NULL);
-	k_timer_start(&timer, DURATION, K_NO_WAIT);
+	k_timer_init(&th_wakeup_timer, timer_handler, NULL);
+	k_timer_start(&th_wakeup_timer, DURATION, K_NO_WAIT);
 }
 
 /* test cases */

--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -79,7 +79,7 @@ struct k_thread sem_tid_1, sem_tid_2, sem_tid_3, sem_tid_4;
 struct k_thread multiple_tid[TOTAL_THREADS_WAITING];
 
 K_SEM_DEFINE(ksema, SEM_INIT_VAL, SEM_MAX_VAL);
-struct k_sem sema, mut_sem;
+struct k_sem msg_sema, mut_sem;
 static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
 struct k_thread tdata;
 
@@ -247,9 +247,9 @@ ZTEST_USER(semaphore, test_k_sem_define)
 ZTEST_USER(semaphore, test_sem_thread2thread)
 {
 	/**TESTPOINT: test k_sem_init sema*/
-	expect_k_sem_init_nomsg(&sema, SEM_INIT_VAL, SEM_MAX_VAL, 0);
+	expect_k_sem_init_nomsg(&msg_sema, SEM_INIT_VAL, SEM_MAX_VAL, 0);
 
-	tsema_thread_thread(&sema);
+	tsema_thread_thread(&msg_sema);
 
 	/**TESTPOINT: test K_SEM_DEFINE sema*/
 	tsema_thread_thread(&ksema);
@@ -262,9 +262,9 @@ ZTEST_USER(semaphore, test_sem_thread2thread)
 ZTEST(semaphore, test_sem_thread2isr)
 {
 	/**TESTPOINT: test k_sem_init sema*/
-	expect_k_sem_init_nomsg(&sema, SEM_INIT_VAL, SEM_MAX_VAL, 0);
+	expect_k_sem_init_nomsg(&msg_sema, SEM_INIT_VAL, SEM_MAX_VAL, 0);
 
-	tsema_thread_isr(&sema);
+	tsema_thread_isr(&msg_sema);
 
 	/**TESTPOINT: test K_SEM_DEFINE sema*/
 	tsema_thread_isr(&ksema);
@@ -281,15 +281,15 @@ ZTEST(semaphore, test_sem_thread2isr)
 ZTEST_USER(semaphore, test_k_sem_init)
 {
 	/* initialize a semaphore with valid count and max limit */
-	expect_k_sem_init_nomsg(&sema, SEM_INIT_VAL, SEM_MAX_VAL, 0);
+	expect_k_sem_init_nomsg(&msg_sema, SEM_INIT_VAL, SEM_MAX_VAL, 0);
 
-	k_sem_reset(&sema);
+	k_sem_reset(&msg_sema);
 
 	/* initialize a semaphore with invalid max limit */
-	expect_k_sem_init_nomsg(&sema, SEM_INIT_VAL, 0, -EINVAL);
+	expect_k_sem_init_nomsg(&msg_sema, SEM_INIT_VAL, 0, -EINVAL);
 
 	/* initialize a semaphore with invalid count */
-	expect_k_sem_init_nomsg(&sema, SEM_MAX_VAL + 1, SEM_MAX_VAL, -EINVAL);
+	expect_k_sem_init_nomsg(&msg_sema, SEM_MAX_VAL + 1, SEM_MAX_VAL, -EINVAL);
 }
 
 
@@ -299,27 +299,27 @@ ZTEST_USER(semaphore, test_k_sem_init)
  */
 ZTEST_USER(semaphore, test_sem_reset)
 {
-	expect_k_sem_init_nomsg(&sema, SEM_INIT_VAL, SEM_MAX_VAL, 0);
-	expect_k_sem_count_get_nomsg(&sema, 0);
+	expect_k_sem_init_nomsg(&msg_sema, SEM_INIT_VAL, SEM_MAX_VAL, 0);
+	expect_k_sem_count_get_nomsg(&msg_sema, 0);
 
-	k_sem_give(&sema);
-	expect_k_sem_count_get_nomsg(&sema, 1);
-	k_sem_reset(&sema);
-	expect_k_sem_count_get_nomsg(&sema, 0);
+	k_sem_give(&msg_sema);
+	expect_k_sem_count_get_nomsg(&msg_sema, 1);
+	k_sem_reset(&msg_sema);
+	expect_k_sem_count_get_nomsg(&msg_sema, 0);
 
 	/**TESTPOINT: semaphore take return -EBUSY*/
-	expect_k_sem_take_nomsg(&sema, K_NO_WAIT, -EBUSY);
-	expect_k_sem_count_get_nomsg(&sema, 0);
+	expect_k_sem_take_nomsg(&msg_sema, K_NO_WAIT, -EBUSY);
+	expect_k_sem_count_get_nomsg(&msg_sema, 0);
 
 	/**TESTPOINT: semaphore take return -EAGAIN*/
-	expect_k_sem_take_nomsg(&sema, SEM_TIMEOUT, -EAGAIN);
-	expect_k_sem_count_get_nomsg(&sema, 0);
+	expect_k_sem_take_nomsg(&msg_sema, SEM_TIMEOUT, -EAGAIN);
+	expect_k_sem_count_get_nomsg(&msg_sema, 0);
 
-	k_sem_give(&sema);
-	expect_k_sem_count_get_nomsg(&sema, 1);
+	k_sem_give(&msg_sema);
+	expect_k_sem_count_get_nomsg(&msg_sema, 1);
 
-	expect_k_sem_take_nomsg(&sema, K_FOREVER, 0);
-	expect_k_sem_count_get_nomsg(&sema, 0);
+	expect_k_sem_take_nomsg(&msg_sema, K_FOREVER, 0);
+	expect_k_sem_count_get_nomsg(&msg_sema, 0);
 }
 
 ZTEST_USER(semaphore, test_sem_reset_waiting)
@@ -353,22 +353,22 @@ ZTEST_USER(semaphore, test_sem_reset_waiting)
  */
 ZTEST_USER(semaphore, test_sem_count_get)
 {
-	expect_k_sem_init_nomsg(&sema, SEM_INIT_VAL, SEM_MAX_VAL, 0);
+	expect_k_sem_init_nomsg(&msg_sema, SEM_INIT_VAL, SEM_MAX_VAL, 0);
 
 	/**TESTPOINT: semaphore count get upon init*/
-	expect_k_sem_count_get_nomsg(&sema, SEM_INIT_VAL);
-	k_sem_give(&sema);
+	expect_k_sem_count_get_nomsg(&msg_sema, SEM_INIT_VAL);
+	k_sem_give(&msg_sema);
 	/**TESTPOINT: sem count get after give*/
-	expect_k_sem_count_get_nomsg(&sema, SEM_INIT_VAL + 1);
-	expect_k_sem_take_nomsg(&sema, K_FOREVER, 0);
+	expect_k_sem_count_get_nomsg(&msg_sema, SEM_INIT_VAL + 1);
+	expect_k_sem_take_nomsg(&msg_sema, K_FOREVER, 0);
 	/**TESTPOINT: sem count get after take*/
 	for (int i = 0; i < SEM_MAX_VAL; i++) {
-		expect_k_sem_count_get_nomsg(&sema, SEM_INIT_VAL + i);
-		k_sem_give(&sema);
+		expect_k_sem_count_get_nomsg(&msg_sema, SEM_INIT_VAL + i);
+		k_sem_give(&msg_sema);
 	}
 	/**TESTPOINT: semaphore give above limit*/
-	k_sem_give(&sema);
-	expect_k_sem_count_get_nomsg(&sema, SEM_MAX_VAL);
+	k_sem_give(&msg_sema);
+	expect_k_sem_count_get_nomsg(&msg_sema, SEM_MAX_VAL);
 }
 
 
@@ -1307,7 +1307,7 @@ void *test_init(void)
 #ifdef CONFIG_USERSPACE
 	k_thread_access_grant(k_current_get(),
 			      &simple_sem, &multiple_thread_sem, &low_prio_sem,
-				  &mid_prio_sem, &high_prio_sem, &ksema, &sema,
+				  &mid_prio_sem, &high_prio_sem, &ksema, &msg_sema,
 				  &high_prio_long_sem, &stack_1, &stack_2,
 				  &stack_3, &stack_4, &timeout_info_pipe,
 				  &sem_tid_1, &sem_tid_2, &sem_tid_3,

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -198,7 +198,7 @@ ZTEST(smp, test_cpu_id_threads)
 	k_thread_join(tid, K_FOREVER);
 }
 
-static void thread_entry(void *p1, void *p2, void *p3)
+static void thread_entry_fn(void *p1, void *p2, void *p3)
 {
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
@@ -373,7 +373,7 @@ ZTEST(smp, test_coop_resched_threads)
 	 * will not get scheduled
 	 */
 	spawn_threads(K_PRIO_COOP(10), num_threads, !EQUAL_PRIORITY,
-		      &thread_entry, THREAD_DELAY);
+		      &thread_entry_fn, THREAD_DELAY);
 
 	/* Wait for some time to let other core's thread run */
 	k_busy_wait(DELAY_US);
@@ -414,7 +414,7 @@ ZTEST(smp, test_preempt_resched_threads)
 	 * be preempted by higher ones
 	 */
 	spawn_threads(K_PRIO_PREEMPT(10), num_threads, !EQUAL_PRIORITY,
-		      &thread_entry, THREAD_DELAY);
+		      &thread_entry_fn, THREAD_DELAY);
 
 	spin_for_threads_exit();
 
@@ -447,7 +447,7 @@ ZTEST(smp, test_yield_threads)
 	 * pending.
 	 */
 	spawn_threads(K_PRIO_COOP(10), num_threads, !EQUAL_PRIORITY,
-		      &thread_entry, !THREAD_DELAY);
+		      &thread_entry_fn, !THREAD_DELAY);
 
 	k_yield();
 	k_busy_wait(DELAY_US);
@@ -476,7 +476,7 @@ ZTEST(smp, test_sleep_threads)
 	unsigned int num_threads = arch_num_cpus();
 
 	spawn_threads(K_PRIO_COOP(10), num_threads, !EQUAL_PRIORITY,
-		      &thread_entry, !THREAD_DELAY);
+		      &thread_entry_fn, !THREAD_DELAY);
 
 	k_msleep(TIMEOUT);
 

--- a/tests/kernel/stack/stack/src/test_stack_contexts.c
+++ b/tests/kernel/stack/stack/src/test_stack_contexts.c
@@ -130,13 +130,13 @@ ZTEST(stack_contexts, test_stack_thread2thread)
  */
 ZTEST_USER(stack_contexts, test_stack_user_thread2thread)
 {
-	struct k_stack *stack = k_object_alloc(K_OBJ_STACK);
+	struct k_stack *th_stack = k_object_alloc(K_OBJ_STACK);
 
-	zassert_not_null(stack, "couldn't allocate stack object");
-	zassert_false(k_stack_alloc_init(stack, STACK_LEN),
+	zassert_not_null(th_stack, "couldn't allocate stack object");
+	zassert_false(k_stack_alloc_init(th_stack, STACK_LEN),
 		      "stack init failed");
 
-	tstack_thread_thread(stack);
+	tstack_thread_thread(th_stack);
 }
 #endif
 

--- a/tests/kernel/stack/stack/src/test_stack_fail.c
+++ b/tests/kernel/stack/stack/src/test_stack_fail.c
@@ -17,14 +17,14 @@ extern struct k_stack stack;
 K_THREAD_STACK_DEFINE(threadstack2, STACK_SIZE);
 struct k_thread thread_data2;
 
-static void stack_pop_fail(struct k_stack *stack)
+static void stack_pop_fail(struct k_stack *rx_data_stack)
 {
 	stack_data_t rx_data;
 
 	/**TESTPOINT: stack pop returns -EBUSY*/
-	zassert_equal(k_stack_pop(stack, &rx_data, K_NO_WAIT), -EBUSY);
+	zassert_equal(k_stack_pop(rx_data_stack, &rx_data, K_NO_WAIT), -EBUSY);
 	/**TESTPOINT: stack pop returns -EAGAIN*/
-	zassert_equal(k_stack_pop(stack, &rx_data, TIMEOUT), -EAGAIN);
+	zassert_equal(k_stack_pop(rx_data_stack, &rx_data, TIMEOUT), -EAGAIN);
 }
 
 /**

--- a/tests/kernel/threads/dynamic_thread_stack/src/main.c
+++ b/tests/kernel/threads/dynamic_thread_stack/src/main.c
@@ -17,7 +17,7 @@
 
 #define MAX_HEAP_STACKS (CONFIG_HEAP_MEM_POOL_SIZE / STACK_OBJ_SIZE)
 
-ZTEST_DMEM bool flag[MAX(CONFIG_DYNAMIC_THREAD_POOL_SIZE, MAX_HEAP_STACKS)];
+ZTEST_DMEM bool tflag[MAX(CONFIG_DYNAMIC_THREAD_POOL_SIZE, MAX_HEAP_STACKS)];
 
 static void func(void *arg1, void *arg2, void *arg3)
 {
@@ -63,17 +63,17 @@ ZTEST(dynamic_thread_stack, test_dynamic_thread_stack_pool)
 
 	/* spawn our threads */
 	for (size_t i = 0; i < CONFIG_DYNAMIC_THREAD_POOL_SIZE; ++i) {
-		flag[i] = false;
+		tflag[i] = false;
 		tid[i] = k_thread_create(&th[i], stack[i],
 				CONFIG_DYNAMIC_THREAD_STACK_SIZE, func,
-				&flag[i], NULL, NULL, 0,
+				&tflag[i], NULL, NULL, 0,
 				K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 	}
 
 	/* join all threads and check that flags have been set */
 	for (size_t i = 0; i < CONFIG_DYNAMIC_THREAD_POOL_SIZE; ++i) {
 		zassert_ok(k_thread_join(tid[i], K_MSEC(TIMEOUT_MS)));
-		zassert_true(flag[i]);
+		zassert_true(tflag[i]);
 	}
 
 	/* clean up stacks allocated from the pool */
@@ -109,17 +109,17 @@ ZTEST(dynamic_thread_stack, test_dynamic_thread_stack_alloc)
 
 	/* spwan our threads */
 	for (size_t i = 0; i < N; ++i) {
-		flag[i] = false;
+		tflag[i] = false;
 		tid[i] = k_thread_create(&th[i], stack[i],
 					 CONFIG_DYNAMIC_THREAD_STACK_SIZE, func,
-					 &flag[i], NULL, NULL, 0,
+					 &tflag[i], NULL, NULL, 0,
 					 K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 	}
 
 	/* join all threads and check that flags have been set */
 	for (size_t i = 0; i < N; ++i) {
 		zassert_ok(k_thread_join(tid[i], K_MSEC(TIMEOUT_MS)));
-		zassert_true(flag[i]);
+		zassert_true(tflag[i]);
 	}
 
 	/* clean up stacks allocated from the heap */

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -45,8 +45,8 @@ static struct k_sem rel_sem;
 /* Common work structures, to avoid dead references to stack objects
  * if a test fails.
  */
-static struct k_work work;
-static struct k_work work1;
+static struct k_work common_work;
+static struct k_work common_work1;
 static struct k_work_delayable dwork;
 
 /* Work synchronization objects must be in cache-coherent memory,
@@ -214,10 +214,10 @@ ZTEST(work, test_unstarted)
 {
 	int rc;
 
-	k_work_init(&work, counter_handler);
-	zassert_equal(k_work_busy_get(&work), 0);
+	k_work_init(&common_work, counter_handler);
+	zassert_equal(k_work_busy_get(&common_work), 0);
 
-	rc = k_work_submit_to_queue(&not_start_queue, &work);
+	rc = k_work_submit_to_queue(&not_start_queue, &common_work);
 	zassert_equal(rc, -ENODEV);
 }
 
@@ -274,10 +274,10 @@ ZTEST(work, test_null_queue)
 {
 	int rc;
 
-	k_work_init(&work, counter_handler);
-	zassert_equal(k_work_busy_get(&work), 0);
+	k_work_init(&common_work, counter_handler);
+	zassert_equal(k_work_busy_get(&common_work), 0);
 
-	rc = k_work_submit_to_queue(NULL, &work);
+	rc = k_work_submit_to_queue(NULL, &common_work);
 	zassert_equal(rc, -EINVAL);
 }
 
@@ -288,15 +288,15 @@ ZTEST(work_1cpu, test_1cpu_simple_queue)
 
 	/* Reset state and use the non-blocking handler */
 	reset_counters();
-	k_work_init(&work, counter_handler);
-	zassert_equal(k_work_busy_get(&work), 0);
-	zassert_equal(k_work_is_pending(&work), false);
+	k_work_init(&common_work, counter_handler);
+	zassert_equal(k_work_busy_get(&common_work), 0);
+	zassert_equal(k_work_is_pending(&common_work), false);
 
 	/* Submit to the cooperative queue */
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, 1);
-	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED);
-	zassert_equal(k_work_is_pending(&work), true);
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_QUEUED);
+	zassert_equal(k_work_is_pending(&common_work), true);
 
 	/* Shouldn't have been started since test thread is
 	 * cooperative.
@@ -306,7 +306,7 @@ ZTEST(work_1cpu, test_1cpu_simple_queue)
 	/* Let it run, then check it finished. */
 	k_sleep(K_TICKS(1));
 	zassert_equal(coophi_counter(), 1);
-	zassert_equal(k_work_busy_get(&work), 0);
+	zassert_equal(k_work_busy_get(&common_work), 0);
 
 	/* Flush the sync state from completion */
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
@@ -325,12 +325,12 @@ ZTEST(work, test_smp_simple_queue)
 
 	/* Reset state and use the non-blocking handler */
 	reset_counters();
-	k_work_init(&work, counter_handler);
-	zassert_equal(k_work_busy_get(&work), 0);
-	zassert_equal(k_work_is_pending(&work), false);
+	k_work_init(&common_work, counter_handler);
+	zassert_equal(k_work_busy_get(&common_work), 0);
+	zassert_equal(k_work_is_pending(&common_work), false);
 
 	/* Submit to the cooperative queue */
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, 1);
 
 	/* It should run and finish without this thread yielding. */
@@ -339,9 +339,9 @@ ZTEST(work, test_smp_simple_queue)
 
 	do {
 		delay = k_ticks_to_ms_floor32(k_uptime_ticks() - ts0);
-	} while (k_work_is_pending(&work) && (delay < DELAY_MS));
+	} while (k_work_is_pending(&common_work) && (delay < DELAY_MS));
 
-	zassert_equal(k_work_busy_get(&work), 0);
+	zassert_equal(k_work_busy_get(&common_work), 0);
 	zassert_equal(coophi_counter(), 1);
 
 	/* Flush the sync state from completion */
@@ -356,13 +356,13 @@ ZTEST(work_1cpu, test_1cpu_sync_queue)
 
 	/* Reset state and use the blocking handler */
 	reset_counters();
-	k_work_init(&work, rel_handler);
-	zassert_equal(k_work_busy_get(&work), 0);
+	k_work_init(&common_work, rel_handler);
+	zassert_equal(k_work_busy_get(&common_work), 0);
 
 	/* Submit to the cooperative queue */
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, 1);
-	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED);
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_QUEUED);
 
 	/* Shouldn't have been started since test thread is
 	 * cooperative.
@@ -372,7 +372,7 @@ ZTEST(work_1cpu, test_1cpu_sync_queue)
 	/* Let it run, then check it didn't finish. */
 	k_sleep(K_TICKS(1));
 	zassert_equal(coophi_counter(), 0);
-	zassert_equal(k_work_busy_get(&work), K_WORK_RUNNING);
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_RUNNING);
 
 	/* Make it ready so it can finish when this thread yields. */
 	handler_release();
@@ -394,10 +394,10 @@ ZTEST(work_1cpu, test_1cpu_reentrant_queue)
 
 	/* Reset state and use the blocking handler */
 	reset_counters();
-	k_work_init(&work, rel_handler);
+	k_work_init(&common_work, rel_handler);
 
 	/* Submit to the cooperative queue. */
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, 1);
 	zassert_equal(coophi_counter(), 0);
 
@@ -406,7 +406,7 @@ ZTEST(work_1cpu, test_1cpu_reentrant_queue)
 	zassert_equal(coophi_counter(), 0);
 
 	/* Resubmit to a different queue. */
-	rc = k_work_submit_to_queue(&preempt_queue, &work);
+	rc = k_work_submit_to_queue(&preempt_queue, &common_work);
 	zassert_equal(rc, 2);
 
 	/* Release the first submission. */
@@ -433,34 +433,34 @@ ZTEST(work_1cpu, test_1cpu_queued_flush)
 
 	/* Reset state and use the delaying handler */
 	reset_counters();
-	k_work_init(&work, delay_handler);
-	k_work_init(&work1, delay_handler);
+	k_work_init(&common_work, delay_handler);
+	k_work_init(&common_work1, delay_handler);
 
 	/* Submit to the cooperative queue. */
-	rc = k_work_submit_to_queue(&coophi_queue, &work1);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work1);
 	zassert_equal(rc, 1);
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, 1);
 	zassert_equal(coophi_counter(), 0);
 
 	/* Confirm that it's still in the queue, then wait for completion.
 	 * This should wait.
 	 */
-	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED);
-	zassert_equal(k_work_busy_get(&work1), K_WORK_QUEUED);
-	zassert_true(k_work_flush(&work, &work_sync));
-	zassert_false(k_work_flush(&work1, &work_sync));
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_QUEUED);
+	zassert_equal(k_work_busy_get(&common_work1), K_WORK_QUEUED);
+	zassert_true(k_work_flush(&common_work, &work_sync));
+	zassert_false(k_work_flush(&common_work1, &work_sync));
 
 	/* Verify completion. */
 	zassert_equal(coophi_counter(), 2);
-	zassert_true(!k_work_is_pending(&work));
-	zassert_true(!k_work_is_pending(&work1));
+	zassert_true(!k_work_is_pending(&common_work));
+	zassert_true(!k_work_is_pending(&common_work1));
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
 	zassert_equal(rc, 0);
 
 	/* After completion flush should be a no-op */
-	zassert_false(k_work_flush(&work, &work_sync));
-	zassert_false(k_work_flush(&work1, &work_sync));
+	zassert_false(k_work_flush(&common_work, &work_sync));
+	zassert_false(k_work_flush(&common_work1, &work_sync));
 }
 
 /* Single CPU submit a work item and wait for flush after it's started.
@@ -471,23 +471,23 @@ ZTEST(work_1cpu, test_1cpu_running_flush)
 
 	/* Reset state and use the delaying handler */
 	reset_counters();
-	k_work_init(&work, delay_handler);
+	k_work_init(&common_work, delay_handler);
 
 	/* Submit to the cooperative queue. */
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, 1);
 	zassert_equal(coophi_counter(), 0);
-	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED);
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_QUEUED);
 
 	/* Release it so it's running. */
 	k_sleep(K_TICKS(1));
-	zassert_equal(k_work_busy_get(&work), K_WORK_RUNNING);
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_RUNNING);
 	zassert_equal(coophi_counter(), 0);
 
 	/* Wait for completion.  This should be released by the delay
 	 * handler.
 	 */
-	zassert_true(k_work_flush(&work, &work_sync));
+	zassert_true(k_work_flush(&common_work, &work_sync));
 
 	/* Verify completion. */
 	zassert_equal(coophi_counter(), 1);
@@ -536,15 +536,15 @@ ZTEST(work_1cpu, test_1cpu_queued_cancel)
 
 	/* Reset state and use the blocking handler */
 	reset_counters();
-	k_work_init(&work, rel_handler);
+	k_work_init(&common_work, rel_handler);
 
 	/* Submit to the cooperative queue. */
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, 1);
 	zassert_equal(coophi_counter(), 0);
 
 	/* Cancellation should complete immediately. */
-	zassert_equal(k_work_cancel(&work), 0);
+	zassert_equal(k_work_cancel(&common_work), 0);
 
 	/* Shouldn't have run. */
 	zassert_equal(coophi_counter(), 0);
@@ -557,22 +557,22 @@ ZTEST(work_1cpu, test_1cpu_queued_cancel_sync)
 
 	/* Reset state and use the blocking handler */
 	reset_counters();
-	k_work_init(&work, rel_handler);
+	k_work_init(&common_work, rel_handler);
 
 	/* Cancel an unqueued work item should not affect the work
 	 * and return false.
 	 */
-	zassert_false(k_work_cancel_sync(&work, &work_sync));
+	zassert_false(k_work_cancel_sync(&common_work, &work_sync));
 
 	/* Submit to the cooperative queue. */
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, 1);
 	zassert_equal(coophi_counter(), 0);
 
 	/* Cancellation should complete immediately, indicating that
 	 * work was pending.
 	 */
-	zassert_true(k_work_cancel_sync(&work, &work_sync));
+	zassert_true(k_work_cancel_sync(&common_work, &work_sync));
 
 	/* Shouldn't have run. */
 	zassert_equal(coophi_counter(), 0);
@@ -816,10 +816,10 @@ ZTEST(work, test_smp_running_cancel)
 
 	/* Reset state and use the delaying handler */
 	reset_counters();
-	k_work_init(&work, delay_handler);
+	k_work_init(&common_work, delay_handler);
 
 	/* Submit to the cooperative queue. */
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, 1);
 
 	/* It should advance to running without this thread yielding. */
@@ -828,17 +828,17 @@ ZTEST(work, test_smp_running_cancel)
 
 	do {
 		delay = k_ticks_to_ms_floor32(k_uptime_ticks() - ts0);
-	} while ((k_work_busy_get(&work) != K_WORK_RUNNING)
+	} while ((k_work_busy_get(&common_work) != K_WORK_RUNNING)
 		 && (delay < DELAY_MS));
 
 	/* Cancellation should not succeed immediately because the
 	 * work is running.
 	 */
-	rc = k_work_cancel(&work);
+	rc = k_work_cancel(&common_work);
 	zassert_equal(rc, K_WORK_RUNNING | K_WORK_CANCELING, "rc %x", rc);
 
 	/* Sync should wait. */
-	zassert_equal(k_work_cancel_sync(&work, &work_sync), true);
+	zassert_equal(k_work_cancel_sync(&common_work, &work_sync), true);
 
 	/* Should have completed. */
 	zassert_equal(coophi_counter(), 1);
@@ -882,10 +882,10 @@ ZTEST(work_1cpu, test_1cpu_drain_wait)
 	 */
 	reset_counters();
 	atomic_set(&resubmits_left, 1);
-	k_work_init(&work, delay_handler);
+	k_work_init(&common_work, delay_handler);
 
 	/* Submit to the cooperative queue. */
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, 1);
 	zassert_equal(coophi_counter(), 0);
 
@@ -921,10 +921,10 @@ ZTEST(work_1cpu, test_1cpu_plugged_drain)
 
 	/* Reset state and use the delaying handler. */
 	reset_counters();
-	k_work_init(&work, delay_handler);
+	k_work_init(&common_work, delay_handler);
 
 	/* Submit to the cooperative queue */
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, 1);
 
 	/* Wait to drain, and plug. */
@@ -944,10 +944,10 @@ ZTEST(work_1cpu, test_1cpu_plugged_drain)
 		      NULL);
 
 	/* Switch to the non-blocking handler. */
-	k_work_init(&work, counter_handler);
+	k_work_init(&common_work, counter_handler);
 
 	/* Resubmission should fail because queue is plugged */
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, -EBUSY);
 
 	/* Unplug the queue */
@@ -962,7 +962,7 @@ ZTEST(work_1cpu, test_1cpu_plugged_drain)
 		      NULL);
 
 	/* Resubmission should succeed and complete */
-	rc = k_work_submit_to_queue(&coophi_queue, &work);
+	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
 	zassert_equal(rc, 1);
 
 	/* Flush the sync state and verify completion */
@@ -1027,9 +1027,9 @@ struct state_1cpu_basic_schedule_running {
 
 static void handle_1cpu_basic_schedule_running(struct k_work *work)
 {
-	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct k_work_delayable *one_dwork = k_work_delayable_from_work(work);
 	struct state_1cpu_basic_schedule_running *state
-		= CONTAINER_OF(dwork, struct state_1cpu_basic_schedule_running,
+		= CONTAINER_OF(one_dwork, struct state_1cpu_basic_schedule_running,
 			       dwork);
 
 	/* Co-opt the resubmits so we can test the schedule API
@@ -1037,7 +1037,7 @@ static void handle_1cpu_basic_schedule_running(struct k_work *work)
 	 */
 	if (atomic_dec(&resubmits_left) > 0) {
 		/* Schedule again on current queue */
-		state->schedule_res = k_work_schedule_for_queue(NULL, dwork,
+		state->schedule_res = k_work_schedule_for_queue(NULL, one_dwork,
 								K_MSEC(DELAY_MS));
 	} else {
 		/* Flag that it didn't schedule */
@@ -1277,16 +1277,16 @@ static bool try_queue_no_yield(struct k_work_q *wq)
 
 	/* Submit two work items directly to the cooperative queue. */
 
-	k_work_init(&work, counter_handler);
+	k_work_init(&common_work, counter_handler);
 	k_work_init_delayable(&dwork, counter_handler);
 
-	rc = k_work_submit_to_queue(wq, &work);
+	rc = k_work_submit_to_queue(wq, &common_work);
 	zassert_equal(rc, 1);
 	rc = k_work_schedule_for_queue(wq, &dwork, K_NO_WAIT);
 	zassert_equal(rc, 1);
 
 	/* Wait for completion */
-	zassert_equal(k_work_is_pending(&work), true);
+	zassert_equal(k_work_is_pending(&common_work), true);
 	zassert_equal(k_work_delayable_is_pending(&dwork), true);
 	rc = k_sem_take(&sync_sem, K_FOREVER);
 	zassert_equal(rc, 0);
@@ -1295,7 +1295,7 @@ static bool try_queue_no_yield(struct k_work_q *wq)
 	 * another yield won't cause anything to happen.
 	 */
 	zassert_equal(coop_counter(wq), 2);
-	zassert_equal(k_work_is_pending(&work), false);
+	zassert_equal(k_work_is_pending(&common_work), false);
 	zassert_equal(k_work_delayable_is_pending(&dwork), false);
 
 	/* The first give unblocked this thread; we need to consume
@@ -1325,13 +1325,13 @@ ZTEST(work_1cpu, test_1cpu_system_queue)
 
 	/* Reset state and use the non-blocking handler */
 	reset_counters();
-	k_work_init(&work, counter_handler);
-	zassert_equal(k_work_busy_get(&work), 0);
+	k_work_init(&common_work, counter_handler);
+	zassert_equal(k_work_busy_get(&common_work), 0);
 
 	/* Submit to the system queue */
-	rc = k_work_submit(&work);
+	rc = k_work_submit(&common_work);
 	zassert_equal(rc, 1);
-	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED);
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_QUEUED);
 
 	/* Shouldn't have been started since test thread is
 	 * cooperative.
@@ -1341,7 +1341,7 @@ ZTEST(work_1cpu, test_1cpu_system_queue)
 	/* Let it run, then check it didn't finish. */
 	k_sleep(K_TICKS(1));
 	zassert_equal(system_counter(), 1);
-	zassert_equal(k_work_busy_get(&work), 0);
+	zassert_equal(k_work_busy_get(&common_work), 0);
 
 	/* Flush the sync state from completion */
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);

--- a/tests/lib/hash_map/src/load_factor.c
+++ b/tests/lib/hash_map/src/load_factor.c
@@ -35,23 +35,23 @@ ZTEST(hash_map, test_load_factor_custom)
 {
 	int ret;
 	uint32_t load_factor;
-	struct sys_hashmap *const map = &custom_load_factor_map;
+	struct sys_hashmap *const hmap = &custom_load_factor_map;
 
-	zassert_equal(map->config->load_factor, CUSTOM_LOAD_FACTOR);
+	zassert_equal(hmap->config->load_factor, CUSTOM_LOAD_FACTOR);
 
-	zassert_true(sys_hashmap_is_empty(map));
-	zassert_equal(0, sys_hashmap_load_factor(map));
+	zassert_true(sys_hashmap_is_empty(hmap));
+	zassert_equal(0, sys_hashmap_load_factor(hmap));
 
 	for (size_t i = 0; i < MANY; ++i) {
-		ret = sys_hashmap_insert(map, i, i, NULL);
+		ret = sys_hashmap_insert(hmap, i, i, NULL);
 		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
-		load_factor = sys_hashmap_load_factor(map);
+		load_factor = sys_hashmap_load_factor(hmap);
 		zassert_true(load_factor > 0 && load_factor <= CUSTOM_LOAD_FACTOR);
 	}
 
 	for (size_t i = MANY; i > 0; --i) {
-		zassert_equal(true, sys_hashmap_remove(map, i - 1, NULL));
-		load_factor = sys_hashmap_load_factor(map);
+		zassert_equal(true, sys_hashmap_remove(hmap, i - 1, NULL));
+		load_factor = sys_hashmap_load_factor(hmap);
 		zassert_true(load_factor <= CUSTOM_LOAD_FACTOR);
 	}
 }

--- a/tests/lib/mpsc_pbuf/src/concurrent.c
+++ b/tests/lib/mpsc_pbuf/src/concurrent.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(test);
 #define DBG(...) COND_CODE_1(DEBUG, (printk(__VA_ARGS__)), ())
 
 static uint32_t buf32[128];
-static struct mpsc_pbuf_buffer buffer;
+static struct mpsc_pbuf_buffer mpsc_buffer;
 volatile int test_microdelay_cnt;
 static struct k_spinlock lock;
 
@@ -248,24 +248,24 @@ static void stress_test(bool overwrite,
 	memset(track_base_idx, 0, sizeof(track_base_idx));
 	memset(track_mask, 0, sizeof(track_mask));
 	memset(&data, 0, sizeof(data));
-	memset(&buffer, 0, sizeof(buffer));
-	mpsc_pbuf_init(&buffer, &config);
+	memset(&mpsc_buffer, 0, sizeof(mpsc_buffer));
+	mpsc_pbuf_init(&mpsc_buffer, &config);
 
 	ztress_set_timeout(K_MSEC(10000));
 
 	if (h4 == NULL) {
 		ZTRESS_EXECUTE(
-				/*ZTRESS_TIMER(h1,  &buffer, 0, t),*/
-			       ZTRESS_THREAD(h1,  &buffer, 0, 0, t),
-			       ZTRESS_THREAD(h2, &buffer, 0, preempt_max, t),
-			       ZTRESS_THREAD(h3, &buffer, 0, preempt_max, t));
+				/*ZTRESS_TIMER(h1,  &mpsc_buffer, 0, t),*/
+			       ZTRESS_THREAD(h1,  &mpsc_buffer, 0, 0, t),
+			       ZTRESS_THREAD(h2, &mpsc_buffer, 0, preempt_max, t),
+			       ZTRESS_THREAD(h3, &mpsc_buffer, 0, preempt_max, t));
 	} else {
 		ZTRESS_EXECUTE(
-				/*ZTRESS_TIMER(h1,  &buffer, 0, t),*/
-			       ZTRESS_THREAD(h1, &buffer, 0, 0, t),
-			       ZTRESS_THREAD(h2, &buffer, 0, preempt_max, t),
-			       ZTRESS_THREAD(h3, &buffer, 0, preempt_max, t),
-			       ZTRESS_THREAD(h4, &buffer, 0, preempt_max, t)
+				/*ZTRESS_TIMER(h1,  &mpsc_buffer, 0, t),*/
+			       ZTRESS_THREAD(h1, &mpsc_buffer, 0, 0, t),
+			       ZTRESS_THREAD(h2, &mpsc_buffer, 0, preempt_max, t),
+			       ZTRESS_THREAD(h3, &mpsc_buffer, 0, preempt_max, t),
+			       ZTRESS_THREAD(h4, &mpsc_buffer, 0, preempt_max, t)
 			       );
 	}
 

--- a/tests/lib/ringbuffer/src/concurrent.c
+++ b/tests/lib/ringbuffer/src/concurrent.c
@@ -26,7 +26,7 @@
 
 static ZTEST_BMEM SYS_MUTEX_DEFINE(mutex);
 RING_BUF_ITEM_DECLARE(ringbuf, RINGBUFFER);
-static uint32_t output[LENGTH];
+static uint32_t data_output[LENGTH];
 static uint32_t databuffer1[LENGTH];
 static uint32_t databuffer2[LENGTH];
 
@@ -74,7 +74,7 @@ static bool user_handler(void *user_data, uint32_t iter_cnt, bool last, int prio
 	/* Try to write data into the ringbuffer */
 	data_write(buffer);
 	/* Try to get data from the ringbuffer and check */
-	data_read(output);
+	data_read(data_output);
 
 	return true;
 }

--- a/tests/lib/ringbuffer/src/main.c
+++ b/tests/lib/ringbuffer/src/main.c
@@ -168,7 +168,7 @@ static struct {
 	uint8_t value;
 	uint16_t type;
 	uint32_t buffer[DATA_MAX_SIZE];
-} data[] = {
+} static_data[] = {
 	{ 0, 32, 1, {} },
 	{ 1, 76, 54, { 0x89ab } },
 	{ 3, 0xff, 0xffff, { 0x0f0f, 0xf0f0, 0xff00 } }
@@ -179,8 +179,8 @@ static void tringbuf_put(const void *p)
 {
 	int index = POINTER_TO_INT(p);
 	/**TESTPOINT: ring buffer put*/
-	int ret = ring_buf_item_put(pbuf, data[index].type, data[index].value,
-				   data[index].buffer, data[index].length);
+	int ret = ring_buf_item_put(pbuf, static_data[index].type, static_data[index].value,
+				    static_data[index].buffer, static_data[index].length);
 
 	zassert_equal(ret, 0);
 }
@@ -195,10 +195,10 @@ static void tringbuf_get(const void *p)
 	/**TESTPOINT: ring buffer get*/
 	ret = ring_buf_item_get(pbuf, &type, &value, rx_data, &size32);
 	zassert_equal(ret, 0);
-	zassert_equal(type, data[index].type);
-	zassert_equal(value, data[index].value);
-	zassert_equal(size32, data[index].length);
-	zassert_equal(memcmp(rx_data, data[index].buffer, size32), 0);
+	zassert_equal(type, static_data[index].type);
+	zassert_equal(value, static_data[index].value);
+	zassert_equal(size32, static_data[index].length);
+	zassert_equal(memcmp(rx_data, static_data[index].buffer, size32), 0);
 }
 
 static void tringbuf_get_discard(const void *p)
@@ -210,9 +210,9 @@ static void tringbuf_get_discard(const void *p)
 	/**TESTPOINT: ring buffer get*/
 	ret = ring_buf_item_get(pbuf, &type, &value, NULL, &size32);
 	zassert_equal(ret, 0);
-	zassert_equal(type, data[index].type);
-	zassert_equal(value, data[index].value);
-	zassert_equal(size32, data[index].length);
+	zassert_equal(type, static_data[index].type);
+	zassert_equal(value, static_data[index].value);
+	zassert_equal(size32, static_data[index].length);
 }
 
 /*test cases*/

--- a/tests/posix/common/src/sleep.c
+++ b/tests/posix/common/src/sleep.c
@@ -12,7 +12,7 @@ struct waker_work {
 	k_tid_t tid;
 	struct k_work_delayable dwork;
 };
-static struct waker_work ww;
+static struct waker_work wake_work;
 
 static void waker_func(struct k_work *work)
 {
@@ -49,9 +49,9 @@ ZTEST(posix_apis, test_sleep)
 	zassert_true((now - then) >= 2 * MSEC_PER_SEC);
 
 	/* test that sleep reports the remainder */
-	ww.tid = k_current_get();
-	k_work_init_delayable(&ww.dwork, waker_func);
-	zassert_equal(1, k_work_schedule(&ww.dwork, K_SECONDS(sleep_min_s)));
+	wake_work.tid = k_current_get();
+	k_work_init_delayable(&wake_work.dwork, waker_func);
+	zassert_equal(1, k_work_schedule(&wake_work.dwork, K_SECONDS(sleep_min_s)));
 	zassert_true(sleep(sleep_max_s) >= sleep_rem_s);
 }
 
@@ -80,9 +80,9 @@ ZTEST(posix_apis, test_usleep)
 	zassert_equal(errno, EINVAL);
 
 	/* test that sleep reports errno = EINTR when woken up */
-	ww.tid = k_current_get();
-	k_work_init_delayable(&ww.dwork, waker_func);
-	zassert_equal(1, k_work_schedule(&ww.dwork, K_USEC(USEC_PER_SEC / 2)));
+	wake_work.tid = k_current_get();
+	k_work_init_delayable(&wake_work.dwork, waker_func);
+	zassert_equal(1, k_work_schedule(&wake_work.dwork, K_USEC(USEC_PER_SEC / 2)));
 	zassert_equal(-1, usleep(USEC_PER_SEC - 1));
 	zassert_equal(EINTR, errno);
 }

--- a/tests/unit/rbtree/main.c
+++ b/tests/unit/rbtree/main.c
@@ -13,7 +13,7 @@
 
 #define MAX_NODES 256
 
-static struct rbtree tree;
+static struct rbtree test_rbtree;
 
 static struct rbnode nodes[MAX_NODES];
 
@@ -123,10 +123,10 @@ void check_rb(void)
 {
 	last_black_height = 0;
 
-	_CHECK(tree.root);
-	_CHECK(z_rb_is_black(tree.root));
+	_CHECK(test_rbtree.root);
+	_CHECK(z_rb_is_black(test_rbtree.root));
 
-	check_rbnode(tree.root, 0);
+	check_rbnode(test_rbtree.root, 0);
 }
 
 /* First validates the external API behavior via a walk, then checks
@@ -140,11 +140,11 @@ void _check_tree(int size, int use_foreach)
 	(void)memset(walked_nodes, 0, sizeof(walked_nodes));
 
 	if (use_foreach) {
-		RB_FOR_EACH(&tree, n) {
+		RB_FOR_EACH(&test_rbtree, n) {
 			visit_node(n, &nwalked);
 		}
 	} else {
-		rb_walk(&tree, visit_node, &nwalked);
+		rb_walk(&test_rbtree, visit_node, &nwalked);
 	}
 
 	/* Make sure all found nodes are in-order and marked in the tree */
@@ -164,7 +164,7 @@ void _check_tree(int size, int use_foreach)
 	/* Make sure all tree bits properly reflect the set of nodes we found */
 	ni = 0;
 	for (i = 0; i < MAX_NODES; i++) {
-		_CHECK(get_node_mask(i) == rb_contains(&tree, &nodes[i]));
+		_CHECK(get_node_mask(i) == rb_contains(&test_rbtree, &nodes[i]));
 
 		if (get_node_mask(i)) {
 			_CHECK(node_index(walked_nodes[ni]) == i);
@@ -174,7 +174,7 @@ void _check_tree(int size, int use_foreach)
 
 	_CHECK(ni == nwalked);
 
-	if (tree.root) {
+	if (test_rbtree.root) {
 		check_rb();
 	}
 }
@@ -200,8 +200,8 @@ void test_tree(int size)
 	/* Small trees get checked after every op, big trees less often */
 	int small_tree = size <= 32;
 
-	(void)memset(&tree, 0, sizeof(tree));
-	tree.lessthan_fn = node_lessthan;
+	(void)memset(&test_rbtree, 0, sizeof(test_rbtree));
+	test_rbtree.lessthan_fn = node_lessthan;
 	(void)memset(nodes, 0, sizeof(nodes));
 	(void)memset(node_mask, 0, sizeof(node_mask));
 
@@ -210,10 +210,10 @@ void test_tree(int size)
 			int node = next_rand_mod(size);
 
 			if (!get_node_mask(node)) {
-				rb_insert(&tree, &nodes[node]);
+				rb_insert(&test_rbtree, &nodes[node]);
 				set_node_mask(node, 1);
 			} else {
-				rb_remove(&tree, &nodes[node]);
+				rb_remove(&test_rbtree, &nodes[node]);
 				set_node_mask(node, 0);
 			}
 
@@ -260,21 +260,21 @@ ZTEST(rbtree_api, test_rb_get_minmax)
 	struct rbnode temp = {0};
 
 	/* Initialize a tree and insert it */
-	(void)memset(&tree, 0, sizeof(tree));
-	tree.lessthan_fn = node_lessthan;
+	(void)memset(&test_rbtree, 0, sizeof(test_rbtree));
+	test_rbtree.lessthan_fn = node_lessthan;
 	(void)memset(nodes, 0, sizeof(nodes));
 
-	zassert_true(rb_get_min(&tree) == NULL, "the tree is invalid");
+	zassert_true(rb_get_min(&test_rbtree) == NULL, "the tree is invalid");
 
 	for (int i = 0; i < 8; i++) {
-		rb_insert(&tree, &nodes[i]);
+		rb_insert(&test_rbtree, &nodes[i]);
 	}
 
-	rb_remove(&tree, &temp);
+	rb_remove(&test_rbtree, &temp);
 
 	/* Check if tree's max and min node are expected */
-	zassert_true(rb_get_min(&tree) == &nodes[0], "the tree is invalid");
-	zassert_true(rb_get_max(&tree) == &nodes[7], "the tree is invalid");
+	zassert_true(rb_get_min(&test_rbtree) == &nodes[0], "the tree is invalid");
+	zassert_true(rb_get_max(&test_rbtree) == &nodes[7], "the tree is invalid");
 }
 
 ZTEST_SUITE(rbtree_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
This is an attempt to rename shadow variables found by enabling -Wshadow manually via twister. Note that this does not enable -Wshadow by default, and that requires more work to be done not only in tree but also in various modules.

This covers various parts of the tree where changes per commit are small. Changes for networking and bluetooth are much bigger and will be submitted separately to ease review effort.

Relates to #5450