### PR TITLE
networking: rename shadow variables

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1381,9 +1381,9 @@ static void eth_rx(struct gmac_queue *queue)
 		 * the used VLAN tag.
 		 */
 		{
-			struct net_eth_hdr *hdr = NET_ETH_HDR(rx_frame);
+			struct net_eth_hdr *p_hdr = NET_ETH_HDR(rx_frame);
 
-			if (ntohs(hdr->type) == NET_ETH_PTYPE_VLAN) {
+			if (ntohs(p_hdr->type) == NET_ETH_PTYPE_VLAN) {
 				struct net_eth_vlan_hdr *hdr_vlan =
 					(struct net_eth_vlan_hdr *)
 					NET_ETH_HDR(rx_frame);

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -547,7 +547,7 @@ const static struct hl7800_config hl7800_cfg = {
 		GPIO_DT_SPEC_INST_GET(0, mdm_gpio6_gpios),
 	},
 };
-static struct hl7800_iface_ctx ictx;
+static struct hl7800_iface_ctx iface_ctx;
 
 static size_t hl7800_read_rx(struct net_buf **buf);
 static char *get_network_state_string(enum mdm_hl7800_network_state state);
@@ -587,8 +587,8 @@ static struct stale_socket *alloc_stale_socket(void)
 	struct stale_socket *sock = NULL;
 
 	for (int i = 0; i < MDM_MAX_SOCKETS; i++) {
-		if (!ictx.stale_sockets[i].allocated) {
-			sock = &ictx.stale_sockets[i];
+		if (!iface_ctx.stale_sockets[i].allocated) {
+			sock = &iface_ctx.stale_sockets[i];
 			sock->allocated = true;
 			break;
 		}
@@ -613,7 +613,7 @@ static int queue_stale_socket(enum net_sock_type type, uint8_t id)
 	if (sock != NULL) {
 		sock->type = type;
 		sock->id = id;
-		k_queue_append(&ictx.stale_socket_queue, (void *)sock);
+		k_queue_append(&iface_ctx.stale_socket_queue, (void *)sock);
 	} else {
 		LOG_ERR("Could not alloc stale socket");
 		ret = -ENOMEM;
@@ -626,7 +626,7 @@ static struct stale_socket *dequeue_stale_socket(void)
 {
 	struct stale_socket *sock = NULL;
 
-	sock = (struct stale_socket *)k_queue_get(&ictx.stale_socket_queue, K_NO_WAIT);
+	sock = (struct stale_socket *)k_queue_get(&iface_ctx.stale_socket_queue, K_NO_WAIT);
 
 	return sock;
 }
@@ -651,13 +651,13 @@ static int read_pin(int default_state, const struct gpio_dt_spec *spec)
 #ifdef CONFIG_MODEM_HL7800_LOW_POWER_MODE
 static bool is_cmd_ready(void)
 {
-	ictx.vgpio_state = read_pin(0, &hl7800_cfg.gpio[MDM_VGPIO]);
+	iface_ctx.vgpio_state = read_pin(0, &hl7800_cfg.gpio[MDM_VGPIO]);
 
-	ictx.gpio6_state = read_pin(0, &hl7800_cfg.gpio[MDM_GPIO6]);
+	iface_ctx.gpio6_state = read_pin(0, &hl7800_cfg.gpio[MDM_GPIO6]);
 
-	ictx.cts_state = read_pin(1, &hl7800_cfg.gpio[MDM_UART_CTS]);
+	iface_ctx.cts_state = read_pin(1, &hl7800_cfg.gpio[MDM_UART_CTS]);
 
-	return ictx.vgpio_state && ictx.gpio6_state && !ictx.cts_state;
+	return iface_ctx.vgpio_state && iface_ctx.gpio6_state && !iface_ctx.cts_state;
 }
 #endif
 
@@ -670,27 +670,27 @@ static void check_hl7800_awake(void)
 #ifdef CONFIG_MODEM_HL7800_LOW_POWER_MODE
 	bool is_cmd_rdy = is_cmd_ready();
 
-	if (is_cmd_rdy && (ictx.sleep_state != HL7800_SLEEP_AWAKE) &&
-	    !ictx.allow_sleep && !ictx.wait_for_KSUP) {
+	if (is_cmd_rdy && (iface_ctx.sleep_state != HL7800_SLEEP_AWAKE) &&
+	    !iface_ctx.allow_sleep && !iface_ctx.wait_for_KSUP) {
 		PRINT_AWAKE_MSG;
 		set_sleep_state(HL7800_SLEEP_AWAKE);
-		k_sem_give(&ictx.mdm_awake);
-	} else if (!is_cmd_rdy && ictx.sleep_state == HL7800_SLEEP_AWAKE &&
-		   ictx.allow_sleep) {
+		k_sem_give(&iface_ctx.mdm_awake);
+	} else if (!is_cmd_rdy && iface_ctx.sleep_state == HL7800_SLEEP_AWAKE &&
+		   iface_ctx.allow_sleep) {
 		PRINT_NOT_AWAKE_MSG;
 
-		if (ictx.desired_sleep_level == HL7800_SLEEP_HIBERNATE ||
-		    ictx.desired_sleep_level == HL7800_SLEEP_LITE_HIBERNATE) {
+		if (iface_ctx.desired_sleep_level == HL7800_SLEEP_HIBERNATE ||
+		    iface_ctx.desired_sleep_level == HL7800_SLEEP_LITE_HIBERNATE) {
 			/* If the device is sleeping (not ready to receive commands)
 			 * then the device may send +KSUP when waking up.
 			 * We should wait for it.
 			 */
-			ictx.wait_for_KSUP = true;
-			ictx.wait_for_KSUP_tries = 0;
+			iface_ctx.wait_for_KSUP = true;
+			iface_ctx.wait_for_KSUP_tries = 0;
 
-			set_sleep_state(ictx.desired_sleep_level);
+			set_sleep_state(iface_ctx.desired_sleep_level);
 
-		} else if (ictx.desired_sleep_level == HL7800_SLEEP_SLEEP) {
+		} else if (iface_ctx.desired_sleep_level == HL7800_SLEEP_SLEEP) {
 			set_sleep_state(HL7800_SLEEP_SLEEP);
 		}
 	}
@@ -775,8 +775,8 @@ static struct hl7800_socket *socket_get(void)
 	struct hl7800_socket *sock = NULL;
 
 	for (i = 0; i < MDM_MAX_SOCKETS; i++) {
-		if (!ictx.sockets[i].context) {
-			sock = &ictx.sockets[i];
+		if (!iface_ctx.sockets[i].context) {
+			sock = &iface_ctx.sockets[i];
 			break;
 		}
 	}
@@ -794,8 +794,8 @@ static struct hl7800_socket *socket_from_id(int socket_id)
 	}
 
 	for (i = 0; i < MDM_MAX_SOCKETS; i++) {
-		if (ictx.sockets[i].socket_id == socket_id) {
-			sock = &ictx.sockets[i];
+		if (iface_ctx.sockets[i].socket_id == socket_id) {
+			sock = &iface_ctx.sockets[i];
 			break;
 		}
 	}
@@ -844,17 +844,17 @@ char *hl7800_sprint_ip_addr(const struct sockaddr *addr)
 
 void mdm_hl7800_register_wake_test_point_callback(void (*func)(int state))
 {
-	ictx.wake_up_callback = func;
+	iface_ctx.wake_up_callback = func;
 }
 
 void mdm_hl7800_register_gpio6_callback(void (*func)(int state))
 {
-	ictx.gpio6_callback = func;
+	iface_ctx.gpio6_callback = func;
 }
 
 void mdm_hl7800_register_cts_callback(void (*func)(int state))
 {
-	ictx.cts_callback = func;
+	iface_ctx.cts_callback = func;
 }
 
 static void modem_assert_wake(bool assert)
@@ -871,8 +871,8 @@ static void modem_assert_wake(bool assert)
 
 	gpio_pin_set_dt(&hl7800_cfg.gpio[MDM_WAKE], state);
 
-	if (ictx.wake_up_callback != NULL) {
-		ictx.wake_up_callback(state);
+	if (iface_ctx.wake_up_callback != NULL) {
+		iface_ctx.wake_up_callback(state);
 	}
 }
 
@@ -902,8 +902,8 @@ static void allow_sleep_work_callback(struct k_work *item)
 {
 	ARG_UNUSED(item);
 	LOG_DBG("Allow sleep");
-	ictx.allow_sleep = true;
-	set_sleep_state(ictx.desired_sleep_level);
+	iface_ctx.allow_sleep = true;
+	set_sleep_state(iface_ctx.desired_sleep_level);
 	modem_assert_wake(false);
 }
 
@@ -912,12 +912,12 @@ static void allow_sleep(bool allow)
 #ifdef CONFIG_MODEM_HL7800_LOW_POWER_MODE
 	if (allow) {
 		k_work_reschedule_for_queue(&hl7800_workq,
-					    &ictx.allow_sleep_work,
+					    &iface_ctx.allow_sleep_work,
 					    K_MSEC(CONFIG_MODEM_HL7800_ALLOW_SLEEP_DELAY_MS));
 	} else {
 		LOG_DBG("Keep awake");
-		k_work_cancel_delayable(&ictx.allow_sleep_work);
-		ictx.allow_sleep = false;
+		k_work_cancel_delayable(&iface_ctx.allow_sleep_work);
+		iface_ctx.allow_sleep = false;
 		modem_assert_wake(true);
 	}
 #endif
@@ -944,8 +944,8 @@ void mdm_hl7800_get_signal_quality(int *rsrp, int *sinr)
 		rssi_query();
 	}
 
-	*rsrp = ictx.mdm_rssi;
-	*sinr = ictx.mdm_sinr;
+	*rsrp = iface_ctx.mdm_rssi;
+	*sinr = iface_ctx.mdm_sinr;
 }
 
 void mdm_hl7800_wakeup(bool wakeup)
@@ -959,33 +959,33 @@ static int send_at_cmd(struct hl7800_socket *sock, const uint8_t *data,
 {
 	int ret = 0;
 
-	ictx.last_error = 0;
+	iface_ctx.last_error = 0;
 
 	do {
 		if (!sock) {
-			k_sem_reset(&ictx.response_sem);
-			ictx.last_socket_id = 0;
+			k_sem_reset(&iface_ctx.response_sem);
+			iface_ctx.last_socket_id = 0;
 		} else {
 			sock->error = 0;
 			k_sem_reset(&sock->sock_send_sem);
-			ictx.last_socket_id = sock->socket_id;
+			iface_ctx.last_socket_id = sock->socket_id;
 		}
 		if (no_id_resp) {
-			strncpy(ictx.no_id_resp_cmd, data,
-				sizeof(ictx.no_id_resp_cmd) - 1);
-			ictx.search_no_id_resp = true;
+			strncpy(iface_ctx.no_id_resp_cmd, data,
+				sizeof(iface_ctx.no_id_resp_cmd) - 1);
+			iface_ctx.search_no_id_resp = true;
 		}
 
 		LOG_DBG("OUT: [%s]", (char *)data);
-		mdm_receiver_send(&ictx.mdm_ctx, data, strlen(data));
-		mdm_receiver_send(&ictx.mdm_ctx, "\r", 1);
+		mdm_receiver_send(&iface_ctx.mdm_ctx, data, strlen(data));
+		mdm_receiver_send(&iface_ctx.mdm_ctx, "\r", 1);
 
 		if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
 			goto done;
 		}
 
 		if (!sock) {
-			ret = k_sem_take(&ictx.response_sem, timeout);
+			ret = k_sem_take(&iface_ctx.response_sem, timeout);
 		} else {
 			ret = k_sem_take(&sock->sock_send_sem, timeout);
 		}
@@ -994,7 +994,7 @@ static int send_at_cmd(struct hl7800_socket *sock, const uint8_t *data,
 			if (sock) {
 				ret = sock->error;
 			} else {
-				ret = ictx.last_error;
+				ret = iface_ctx.last_error;
 			}
 		} else if (ret == -EAGAIN) {
 			ret = -ETIMEDOUT;
@@ -1006,7 +1006,7 @@ static int send_at_cmd(struct hl7800_socket *sock, const uint8_t *data,
 		}
 	} while (ret != 0 && retries > 0);
 done:
-	ictx.search_no_id_resp = false;
+	iface_ctx.search_no_id_resp = false;
 	return ret;
 }
 
@@ -1020,13 +1020,13 @@ static int wakeup_hl7800(void)
 	/* If modem is in sleep mode (not hibernate),
 	 * then it can respond in ~10 ms.
 	 */
-	if (ictx.desired_sleep_level == HL7800_SLEEP_SLEEP) {
+	if (iface_ctx.desired_sleep_level == HL7800_SLEEP_SLEEP) {
 		k_sleep(MDM_WAKE_TO_CHECK_CTS_DELAY_MS);
 	}
 
 	if (!is_cmd_ready()) {
 		LOG_DBG("Waiting to wakeup");
-		ret = k_sem_take(&ictx.mdm_awake, MDM_WAKEUP_TIME);
+		ret = k_sem_take(&iface_ctx.mdm_awake, MDM_WAKEUP_TIME);
 		if (ret) {
 			LOG_DBG("Err waiting for wakeup: %d", ret);
 		}
@@ -1045,7 +1045,7 @@ int32_t mdm_hl7800_send_at_cmd(const uint8_t *data)
 
 	hl7800_lock();
 	wakeup_hl7800();
-	ictx.last_socket_id = 0;
+	iface_ctx.last_socket_id = 0;
 	ret = send_at_cmd(NULL, data, MDM_CMD_SEND_TIMEOUT, 0, false);
 	allow_sleep(true);
 	hl7800_unlock();
@@ -1061,7 +1061,7 @@ int32_t mdm_hl7800_update_apn(char *access_point_name)
 
 	hl7800_lock();
 	wakeup_hl7800();
-	ictx.last_socket_id = 0;
+	iface_ctx.last_socket_id = 0;
 	ret = write_apn(access_point_name);
 	allow_sleep(true);
 	hl7800_unlock();
@@ -1070,7 +1070,7 @@ int32_t mdm_hl7800_update_apn(char *access_point_name)
 		/* After a reset the APN will be re-read from the modem
 		 * and an event will be generated.
 		 */
-		k_work_reschedule_for_queue(&hl7800_workq, &ictx.mdm_reset_work,
+		k_work_reschedule_for_queue(&hl7800_workq, &iface_ctx.mdm_reset_work,
 					    K_NO_WAIT);
 	}
 	return ret;
@@ -1088,7 +1088,7 @@ int32_t mdm_hl7800_update_rat(enum mdm_hl7800_radio_mode value)
 {
 	int ret = -EINVAL;
 
-	if (value == ictx.mdm_rat) {
+	if (value == iface_ctx.mdm_rat) {
 		/* The set command will fail (in the modem)
 		 * if the RAT isn't different.
 		 */
@@ -1099,16 +1099,16 @@ int32_t mdm_hl7800_update_rat(enum mdm_hl7800_radio_mode value)
 
 	hl7800_lock();
 	wakeup_hl7800();
-	ictx.last_socket_id = 0;
+	iface_ctx.last_socket_id = 0;
 
 	if (value == MDM_RAT_CAT_M1) {
-		if (ictx.new_rat_cmd_support) {
+		if (iface_ctx.new_rat_cmd_support) {
 			SEND_AT_CMD_ONCE_EXPECT_OK(SET_RAT_M1_CMD);
 		} else {
 			SEND_AT_CMD_ONCE_EXPECT_OK(SET_RAT_M1_CMD_LEGACY);
 		}
 	} else { /* MDM_RAT_CAT_NB1 */
-		if (ictx.new_rat_cmd_support) {
+		if (iface_ctx.new_rat_cmd_support) {
 			SEND_AT_CMD_ONCE_EXPECT_OK(SET_RAT_NB1_CMD);
 		} else {
 			SEND_AT_CMD_ONCE_EXPECT_OK(SET_RAT_NB1_CMD_LEGACY);
@@ -1125,7 +1125,7 @@ error:
 	 * state are valid.
 	 */
 	if (ret >= 0) {
-		k_work_reschedule_for_queue(&hl7800_workq, &ictx.mdm_reset_work, K_NO_WAIT);
+		k_work_reschedule_for_queue(&hl7800_workq, &iface_ctx.mdm_reset_work, K_NO_WAIT);
 	}
 
 	return ret;
@@ -1135,16 +1135,16 @@ int32_t mdm_hl7800_get_local_time(struct tm *tm, int32_t *offset)
 {
 	int ret;
 
-	ictx.local_time_valid = false;
+	iface_ctx.local_time_valid = false;
 
 	hl7800_lock();
 	wakeup_hl7800();
-	ictx.last_socket_id = 0;
+	iface_ctx.last_socket_id = 0;
 	ret = send_at_cmd(NULL, "AT+CCLK?", MDM_CMD_SEND_TIMEOUT, 0, false);
 	allow_sleep(true);
-	if (ictx.local_time_valid) {
-		memcpy(tm, &ictx.local_time, sizeof(struct tm));
-		memcpy(offset, &ictx.local_time_offset, sizeof(*offset));
+	if (iface_ctx.local_time_valid) {
+		memcpy(tm, &iface_ctx.local_time, sizeof(struct tm));
+		memcpy(offset, &iface_ctx.local_time_offset, sizeof(*offset));
 	} else {
 		ret = -EIO;
 	}
@@ -1158,7 +1158,7 @@ int32_t mdm_hl7800_get_operator_index(void)
 
 	hl7800_lock();
 	wakeup_hl7800();
-	ictx.last_socket_id = 0;
+	iface_ctx.last_socket_id = 0;
 	ret = send_at_cmd(NULL, "AT+KCARRIERCFG?", MDM_CMD_SEND_TIMEOUT, 0,
 			  false);
 	allow_sleep(true);
@@ -1166,7 +1166,7 @@ int32_t mdm_hl7800_get_operator_index(void)
 	if (ret < 0) {
 		return ret;
 	} else {
-		return ictx.operator_index;
+		return iface_ctx.operator_index;
 	}
 }
 
@@ -1176,7 +1176,7 @@ int32_t mdm_hl7800_get_functionality(void)
 
 	hl7800_lock();
 	wakeup_hl7800();
-	ictx.last_socket_id = 0;
+	iface_ctx.last_socket_id = 0;
 	ret = send_at_cmd(NULL, "AT+CFUN?", MDM_CMD_SEND_TIMEOUT, 0, false);
 	allow_sleep(true);
 	hl7800_unlock();
@@ -1184,7 +1184,7 @@ int32_t mdm_hl7800_get_functionality(void)
 	if (ret < 0) {
 		return ret;
 	} else {
-		return ictx.functionality;
+		return iface_ctx.functionality;
 	}
 }
 
@@ -1196,7 +1196,7 @@ int32_t mdm_hl7800_set_functionality(enum mdm_hl7800_functionality mode)
 	hl7800_lock();
 	wakeup_hl7800();
 	snprintk(buf, sizeof(buf), "AT+CFUN=%u,0", mode);
-	ictx.last_socket_id = 0;
+	iface_ctx.last_socket_id = 0;
 	ret = send_at_cmd(NULL, buf, MDM_CMD_SEND_TIMEOUT,
 			  MDM_DEFAULT_AT_CMD_RETRIES, false);
 	allow_sleep(true);
@@ -1212,7 +1212,7 @@ int32_t mdm_hl7800_set_gps_rate(uint32_t rate)
 
 	hl7800_lock();
 	wakeup_hl7800();
-	ictx.gps_query_location_rate_seconds = rate;
+	iface_ctx.gps_query_location_rate_seconds = rate;
 
 	/* Stopping first allows changing the rate between two non-zero values.
 	 * Ignore error if GNSS isn't running.
@@ -1238,10 +1238,10 @@ int32_t mdm_hl7800_set_gps_rate(uint32_t rate)
 
 error:
 	if (rate && ret == 0) {
-		k_work_reschedule_for_queue(&hl7800_workq, &ictx.gps_work,
-					    K_SECONDS(ictx.gps_query_location_rate_seconds));
+		k_work_reschedule_for_queue(&hl7800_workq, &iface_ctx.gps_work,
+					    K_SECONDS(iface_ctx.gps_query_location_rate_seconds));
 	} else {
-		k_work_cancel_delayable(&ictx.gps_work);
+		k_work_cancel_delayable(&iface_ctx.gps_work);
 	}
 	LOG_DBG("GPS status: %d rate: %u", ret, rate);
 
@@ -1334,13 +1334,13 @@ void mdm_hl7800_generate_status_events(void)
 #ifdef CONFIG_MODEM_HL7800_FW_UPDATE
 	generate_fota_state_event();
 #endif
-	event_handler(HL7800_EVENT_RSSI, &ictx.mdm_rssi);
-	event_handler(HL7800_EVENT_SINR, &ictx.mdm_sinr);
-	event_handler(HL7800_EVENT_APN_UPDATE, &ictx.mdm_apn);
-	event_handler(HL7800_EVENT_RAT, &ictx.mdm_rat);
-	event_handler(HL7800_EVENT_BANDS, ictx.mdm_bands_string);
-	event_handler(HL7800_EVENT_ACTIVE_BANDS, ictx.mdm_active_bands_string);
-	event_handler(HL7800_EVENT_REVISION, ictx.mdm_revision);
+	event_handler(HL7800_EVENT_RSSI, &iface_ctx.mdm_rssi);
+	event_handler(HL7800_EVENT_SINR, &iface_ctx.mdm_sinr);
+	event_handler(HL7800_EVENT_APN_UPDATE, &iface_ctx.mdm_apn);
+	event_handler(HL7800_EVENT_RAT, &iface_ctx.mdm_rat);
+	event_handler(HL7800_EVENT_BANDS, iface_ctx.mdm_bands_string);
+	event_handler(HL7800_EVENT_ACTIVE_BANDS, iface_ctx.mdm_active_bands_string);
+	event_handler(HL7800_EVENT_REVISION, iface_ctx.mdm_revision);
 	hl7800_unlock();
 }
 
@@ -1410,7 +1410,7 @@ static int send_data(struct hl7800_socket *sock, struct net_pkt *pkt)
 	/* Loop through packet data and send */
 	while (frag) {
 		actual_send_len += frag->len;
-		mdm_receiver_send(&ictx.mdm_ctx, frag->data, frag->len);
+		mdm_receiver_send(&iface_ctx.mdm_ctx, frag->data, frag->len);
 		frag = frag->frags;
 	}
 	if (actual_send_len != send_len) {
@@ -1421,7 +1421,7 @@ static int send_data(struct hl7800_socket *sock, struct net_pkt *pkt)
 
 	/* Send EOF pattern to terminate data */
 	k_sem_reset(&sock->sock_send_sem);
-	mdm_receiver_send(&ictx.mdm_ctx, EOF_PATTERN, strlen(EOF_PATTERN));
+	mdm_receiver_send(&iface_ctx.mdm_ctx, EOF_PATTERN, strlen(EOF_PATTERN));
 	ret = k_sem_take(&sock->sock_send_sem, MDM_IP_SEND_RX_TIMEOUT);
 	if (ret == 0) {
 		ret = sock->error;
@@ -1645,11 +1645,11 @@ static bool on_cmd_atcmdinfo_manufacturer(struct net_buf **buf, uint16_t len)
 		len = MDM_MANUFACTURER_LENGTH;
 	}
 
-	out_len = net_buf_linearize(ictx.mdm_manufacturer,
-				    sizeof(ictx.mdm_manufacturer) - 1, *buf, 0,
+	out_len = net_buf_linearize(iface_ctx.mdm_manufacturer,
+				    sizeof(iface_ctx.mdm_manufacturer) - 1, *buf, 0,
 				    len);
-	ictx.mdm_manufacturer[out_len] = 0;
-	LOG_INF("Manufacturer: %s", ictx.mdm_manufacturer);
+	iface_ctx.mdm_manufacturer[out_len] = 0;
+	LOG_INF("Manufacturer: %s", iface_ctx.mdm_manufacturer);
 done:
 	return true;
 }
@@ -1680,10 +1680,10 @@ static bool on_cmd_atcmdinfo_model(struct net_buf **buf, uint16_t len)
 		len = MDM_MODEL_LENGTH;
 	}
 
-	out_len = net_buf_linearize(ictx.mdm_model, sizeof(ictx.mdm_model) - 1,
+	out_len = net_buf_linearize(iface_ctx.mdm_model, sizeof(iface_ctx.mdm_model) - 1,
 				    *buf, 0, len);
-	ictx.mdm_model[out_len] = 0;
-	LOG_INF("Model: %s", ictx.mdm_model);
+	iface_ctx.mdm_model[out_len] = 0;
+	LOG_INF("Model: %s", iface_ctx.mdm_model);
 done:
 	return true;
 }
@@ -1714,10 +1714,10 @@ static bool on_cmd_atcmdinfo_revision(struct net_buf **buf, uint16_t len)
 	}
 
 	out_len = net_buf_linearize(
-		ictx.mdm_revision, sizeof(ictx.mdm_revision) - 1, *buf, 0, len);
-	ictx.mdm_revision[out_len] = 0;
-	LOG_INF("Revision: %s", ictx.mdm_revision);
-	event_handler(HL7800_EVENT_REVISION, ictx.mdm_revision);
+		iface_ctx.mdm_revision, sizeof(iface_ctx.mdm_revision) - 1, *buf, 0, len);
+	iface_ctx.mdm_revision[out_len] = 0;
+	LOG_INF("Revision: %s", iface_ctx.mdm_revision);
+	event_handler(HL7800_EVENT_REVISION, iface_ctx.mdm_revision);
 done:
 	return true;
 }
@@ -1747,11 +1747,11 @@ static bool on_cmd_atcmdinfo_imei(struct net_buf **buf, uint16_t len)
 		len = MDM_HL7800_IMEI_STRLEN;
 	}
 
-	out_len = net_buf_linearize(ictx.mdm_imei, sizeof(ictx.mdm_imei) - 1,
+	out_len = net_buf_linearize(iface_ctx.mdm_imei, sizeof(iface_ctx.mdm_imei) - 1,
 				    *buf, 0, len);
-	ictx.mdm_imei[out_len] = 0;
+	iface_ctx.mdm_imei[out_len] = 0;
 
-	LOG_INF("IMEI: %s", ictx.mdm_imei);
+	LOG_INF("IMEI: %s", iface_ctx.mdm_imei);
 done:
 	return true;
 }
@@ -1782,12 +1782,12 @@ static bool on_cmd_atcmdinfo_iccid(struct net_buf **buf, uint16_t len)
 		LOG_INF("EID: %s", delim + 1);
 	}
 
-	ret = snprintk(ictx.mdm_iccid, sizeof(ictx.mdm_iccid), "%s", value);
+	ret = snprintk(iface_ctx.mdm_iccid, sizeof(iface_ctx.mdm_iccid), "%s", value);
 	if (ret > MDM_HL7800_ICCID_MAX_STRLEN) {
 		LOG_WRN("ICCID too long: %d", ret);
 	}
 
-	LOG_INF("ICCID: %s", ictx.mdm_iccid);
+	LOG_INF("ICCID: %s", iface_ctx.mdm_iccid);
 
 	return true;
 }
@@ -1814,16 +1814,16 @@ static bool on_cmd_atcmdinfo_imsi(struct net_buf **buf, uint16_t len)
 		len = MDM_HL7800_IMSI_MAX_STRLEN;
 	}
 
-	out_len = net_buf_linearize(ictx.mdm_imsi, MDM_HL7800_IMSI_MAX_STR_SIZE,
+	out_len = net_buf_linearize(iface_ctx.mdm_imsi, MDM_HL7800_IMSI_MAX_STR_SIZE,
 				    *buf, 0, len);
-	ictx.mdm_imsi[out_len] = 0;
+	iface_ctx.mdm_imsi[out_len] = 0;
 
-	if (strstr(ictx.mdm_imsi, "ERROR") != NULL) {
+	if (strstr(iface_ctx.mdm_imsi, "ERROR") != NULL) {
 		LOG_ERR("Unable to read IMSI");
-		memset(ictx.mdm_imsi, 0, sizeof(ictx.mdm_imsi));
+		memset(iface_ctx.mdm_imsi, 0, sizeof(iface_ctx.mdm_imsi));
 	}
 
-	LOG_INF("IMSI: %s", ictx.mdm_imsi);
+	LOG_INF("IMSI: %s", iface_ctx.mdm_imsi);
 done:
 	return true;
 }
@@ -1837,30 +1837,34 @@ static void dns_work_cb(struct k_work *work)
 	bool valid_address = false;
 	static const char *const dns_servers_str[] = {
 #ifdef CONFIG_NET_IPV6
-		ictx.dns_v6_string,
+		iface_ctx.dns_v6_string,
 #endif
 #ifdef CONFIG_NET_IPV4
-		ictx.dns_v4_string,
+		iface_ctx.dns_v4_string,
 #endif
 		NULL};
 
 #ifdef CONFIG_NET_IPV6
 	valid_address =
-		net_ipaddr_parse(ictx.dns_v6_string, strlen(ictx.dns_v6_string), &temp_addr);
+		net_ipaddr_parse(iface_ctx.dns_v6_string, strlen(iface_ctx.dns_v6_string),
+				 &temp_addr);
 	if (!valid_address && IS_ENABLED(CONFIG_NET_IPV4)) {
 		/* IPv6 DNS string is not valid, replace it with IPv4 address and recheck */
-		strncpy(ictx.dns_v6_string, ictx.dns_v4_string, strlen(ictx.dns_v4_string));
-		valid_address = net_ipaddr_parse(ictx.dns_v6_string, strlen(ictx.dns_v6_string),
+		strncpy(iface_ctx.dns_v6_string, iface_ctx.dns_v4_string,
+			strlen(iface_ctx.dns_v4_string));
+		valid_address = net_ipaddr_parse(iface_ctx.dns_v6_string,
+						 strlen(iface_ctx.dns_v6_string),
 						 &temp_addr);
 	}
 #else
 	valid_address =
-		net_ipaddr_parse(ictx.dns_v4_string, strlen(ictx.dns_v4_string), &temp_addr);
+		net_ipaddr_parse(iface_ctx.dns_v4_string, strlen(iface_ctx.dns_v4_string),
+				 &temp_addr);
 #endif
 
 	if (!valid_address) {
 		LOG_WRN("No valid DNS address!");
-	} else if (ictx.iface && net_if_is_up(ictx.iface) && !ictx.dns_ready) {
+	} else if (iface_ctx.iface && net_if_is_up(iface_ctx.iface) && !iface_ctx.dns_ready) {
 		/* set new DNS addr in DNS resolver */
 		LOG_DBG("Refresh DNS resolver");
 		dnsCtx = dns_resolve_get_default();
@@ -1869,34 +1873,34 @@ static void dns_work_cb(struct k_work *work)
 			LOG_ERR("dns_resolve_init fail (%d)", ret);
 			return;
 		}
-		ictx.dns_ready = true;
+		iface_ctx.dns_ready = true;
 	}
 #endif
 }
 
 char *mdm_hl7800_get_iccid(void)
 {
-	return ictx.mdm_iccid;
+	return iface_ctx.mdm_iccid;
 }
 
 char *mdm_hl7800_get_sn(void)
 {
-	return ictx.mdm_sn;
+	return iface_ctx.mdm_sn;
 }
 
 char *mdm_hl7800_get_imei(void)
 {
-	return ictx.mdm_imei;
+	return iface_ctx.mdm_imei;
 }
 
 char *mdm_hl7800_get_fw_version(void)
 {
-	return ictx.mdm_revision;
+	return iface_ctx.mdm_revision;
 }
 
 char *mdm_hl7800_get_imsi(void)
 {
-	return ictx.mdm_imsi;
+	return iface_ctx.mdm_imsi;
 }
 
 /* Convert HL7800 IPv6 address string in format
@@ -2029,7 +2033,7 @@ static bool on_cmd_atcmdinfo_ipaddr(struct net_buf **buf, uint16_t len)
 		addr_len = delims[3] - sm_start;
 		strncpy(temp_addr_str, sm_start, addr_len);
 		temp_addr_str[addr_len] = 0;
-		ret = net_addr_pton(AF_INET, temp_addr_str, &ictx.subnet);
+		ret = net_addr_pton(AF_INET, temp_addr_str, &iface_ctx.subnet);
 		if (ret < 0) {
 			LOG_ERR("Invalid subnet");
 			return true;
@@ -2040,7 +2044,7 @@ static bool on_cmd_atcmdinfo_ipaddr(struct net_buf **buf, uint16_t len)
 		addr_len = delims[4] - addr_start;
 		strncpy(temp_addr_str, addr_start, addr_len);
 		temp_addr_str[addr_len] = 0;
-		ret = net_addr_pton(AF_INET, temp_addr_str, &ictx.gateway);
+		ret = net_addr_pton(AF_INET, temp_addr_str, &iface_ctx.gateway);
 		if (ret < 0) {
 			LOG_ERR("Invalid gateway");
 			return true;
@@ -2053,28 +2057,28 @@ static bool on_cmd_atcmdinfo_ipaddr(struct net_buf **buf, uint16_t len)
 	strncpy(temp_addr_str, addr_start, addr_len);
 	temp_addr_str[addr_len] = 0;
 	if (is_ipv4) {
-		ret = strncmp(temp_addr_str, ictx.dns_v4_string, addr_len);
+		ret = strncmp(temp_addr_str, iface_ctx.dns_v4_string, addr_len);
 		if (ret != 0) {
-			ictx.dns_ready = false;
+			iface_ctx.dns_ready = false;
 		}
-		strncpy(ictx.dns_v4_string, addr_start, addr_len);
-		ictx.dns_v4_string[addr_len] = 0;
-		ret = net_addr_pton(AF_INET, ictx.dns_v4_string, &ictx.dns_v4);
-		LOG_DBG("IPv4 DNS addr: %s", ictx.dns_v4_string);
+		strncpy(iface_ctx.dns_v4_string, addr_start, addr_len);
+		iface_ctx.dns_v4_string[addr_len] = 0;
+		ret = net_addr_pton(AF_INET, iface_ctx.dns_v4_string, &iface_ctx.dns_v4);
+		LOG_DBG("IPv4 DNS addr: %s", iface_ctx.dns_v4_string);
 	}
 #ifdef CONFIG_NET_IPV6
 	else {
-		ret = strncmp(temp_addr_str, ictx.dns_v6_string, addr_len);
+		ret = strncmp(temp_addr_str, iface_ctx.dns_v6_string, addr_len);
 		if (ret != 0) {
-			ictx.dns_ready = false;
+			iface_ctx.dns_ready = false;
 		}
 		/* store HL7800 formatted IPv6 DNS string temporarily */
-		strncpy(ictx.dns_v6_string, addr_start, addr_len);
+		strncpy(iface_ctx.dns_v6_string, addr_start, addr_len);
 
-		ret = hl7800_net_addr6_pton(ictx.dns_v6_string, &ictx.dns_v6);
-		net_addr_ntop(AF_INET6, &ictx.dns_v6, ictx.dns_v6_string,
-			      sizeof(ictx.dns_v6_string));
-		LOG_DBG("IPv6 DNS addr: %s", ictx.dns_v6_string);
+		ret = hl7800_net_addr6_pton(iface_ctx.dns_v6_string, &iface_ctx.dns_v6);
+		net_addr_ntop(AF_INET6, &iface_ctx.dns_v6, iface_ctx.dns_v6_string,
+			      sizeof(iface_ctx.dns_v6_string));
+		LOG_DBG("IPv6 DNS addr: %s", iface_ctx.dns_v6_string);
 	}
 #endif
 	if (ret < 0) {
@@ -2082,28 +2086,29 @@ static bool on_cmd_atcmdinfo_ipaddr(struct net_buf **buf, uint16_t len)
 		return true;
 	}
 
-	if (ictx.iface) {
+	if (iface_ctx.iface) {
 		if (is_ipv4) {
 #ifdef CONFIG_NET_IPV4
 			/* remove the current IPv4 addr before adding a new one.
 			 * We dont care if it is successful or not.
 			 */
-			net_if_ipv4_addr_rm(ictx.iface, &ictx.ipv4Addr);
+			net_if_ipv4_addr_rm(iface_ctx.iface, &iface_ctx.ipv4Addr);
 
-			if (!net_if_ipv4_addr_add(ictx.iface, &new_ipv4_addr, NET_ADDR_DHCP, 0)) {
+			if (!net_if_ipv4_addr_add(iface_ctx.iface, &new_ipv4_addr,
+						  NET_ADDR_DHCP, 0)) {
 				LOG_ERR("Cannot set iface IPv4 addr");
 			}
 
-			net_if_ipv4_set_netmask(ictx.iface, &ictx.subnet);
-			net_if_ipv4_set_gw(ictx.iface, &ictx.gateway);
+			net_if_ipv4_set_netmask(iface_ctx.iface, &iface_ctx.subnet);
+			net_if_ipv4_set_gw(iface_ctx.iface, &iface_ctx.gateway);
 #endif
 			/* store the new IP addr */
-			net_ipaddr_copy(&ictx.ipv4Addr, &new_ipv4_addr);
+			net_ipaddr_copy(&iface_ctx.ipv4Addr, &new_ipv4_addr);
 		} else {
 #if CONFIG_NET_IPV6
-			net_if_ipv6_addr_rm(ictx.iface, &ictx.ipv6Addr);
-			if (!net_if_ipv6_addr_add(ictx.iface, &new_ipv6_addr, NET_ADDR_AUTOCONF,
-						  0)) {
+			net_if_ipv6_addr_rm(iface_ctx.iface, &iface_ctx.ipv6Addr);
+			if (!net_if_ipv6_addr_add(iface_ctx.iface, &new_ipv6_addr,
+						  NET_ADDR_AUTOCONF, 0)) {
 				LOG_ERR("Cannot set iface IPv6 addr");
 			}
 #endif
@@ -2111,13 +2116,13 @@ static bool on_cmd_atcmdinfo_ipaddr(struct net_buf **buf, uint16_t len)
 
 		/* start DNS update work */
 		delay = K_NO_WAIT;
-		if (!ictx.initialized) {
+		if (!iface_ctx.initialized) {
 			/* Delay this in case the network
 			 * stack is still starting up
 			 */
 			delay = K_SECONDS(DNS_WORK_DELAY_SECS);
 		}
-		k_work_reschedule_for_queue(&hl7800_workq, &ictx.dns_work,
+		k_work_reschedule_for_queue(&hl7800_workq, &iface_ctx.dns_work,
 					    delay);
 	} else {
 		LOG_ERR("iface NULL");
@@ -2156,7 +2161,7 @@ static bool on_cmd_atcmdinfo_operator_status(struct net_buf **buf, uint16_t len)
 	/* Process AT+COPS? */
 	if (len == 1) {
 		/* only mode was returned, there is no operator info */
-		ictx.operator_status = NO_OPERATOR;
+		iface_ctx.operator_status = NO_OPERATOR;
 		goto done;
 	}
 
@@ -2174,7 +2179,7 @@ static bool on_cmd_atcmdinfo_operator_status(struct net_buf **buf, uint16_t len)
 	}
 
 	/* we found both delimiters, that means we have an operator */
-	ictx.operator_status = REGISTERED;
+	iface_ctx.operator_status = REGISTERED;
 done:
 	return true;
 }
@@ -2222,9 +2227,9 @@ static bool on_cmd_atcmdinfo_serial_number(struct net_buf **buf, uint16_t len)
 		sn_len = MDM_HL7800_SERIAL_NUMBER_STRLEN;
 	}
 
-	strncpy(ictx.mdm_sn, val_start, sn_len);
-	ictx.mdm_sn[sn_len] = 0;
-	LOG_INF("Serial #: %s", ictx.mdm_sn);
+	strncpy(iface_ctx.mdm_sn, val_start, sn_len);
+	iface_ctx.mdm_sn[sn_len] = 0;
+	LOG_INF("Serial #: %s", iface_ctx.mdm_sn);
 done:
 	return true;
 }
@@ -2237,9 +2242,9 @@ static bool on_cmd_radio_tech_status(struct net_buf **buf, uint16_t len)
 
 	out_len = net_buf_linearize(value, sizeof(value), *buf, 0, len);
 	value[out_len] = 0;
-	ictx.mdm_rat = strtol(value, NULL, 10);
-	LOG_INF("+KSRAT: %d", ictx.mdm_rat);
-	event_handler(HL7800_EVENT_RAT, &ictx.mdm_rat);
+	iface_ctx.mdm_rat = strtol(value, NULL, 10);
+	LOG_INF("+KSRAT: %d", iface_ctx.mdm_rat);
+	event_handler(HL7800_EVENT_RAT, &iface_ctx.mdm_rat);
 
 	return true;
 }
@@ -2254,7 +2259,7 @@ static bool on_cmd_radio_band_configuration(struct net_buf **buf, uint16_t len)
 	out_len = net_buf_linearize(value, sizeof(value), *buf, 0, len);
 	value[out_len] = 0;
 
-	if (value[0] != (ictx.mdm_rat == MDM_RAT_CAT_M1 ? '0' : '1')) {
+	if (value[0] != (iface_ctx.mdm_rat == MDM_RAT_CAT_M1 ? '0' : '1')) {
 		/* Invalid RAT */
 		return true;
 	} else if (strlen(value) < sizeof("#,###################")) {
@@ -2262,28 +2267,28 @@ static bool on_cmd_radio_band_configuration(struct net_buf **buf, uint16_t len)
 		return true;
 	}
 
-	memcpy(ictx.mdm_bands_string, &value[MDM_TOP_BAND_START_POSITION],
+	memcpy(iface_ctx.mdm_bands_string, &value[MDM_TOP_BAND_START_POSITION],
 	       MDM_HL7800_LTE_BAND_STRLEN);
 
 	memcpy(n_tmp, &value[MDM_TOP_BAND_START_POSITION], MDM_TOP_BAND_SIZE);
 	n_tmp[MDM_TOP_BAND_SIZE] = 0;
-	ictx.mdm_bands_top = strtoul(n_tmp, NULL, 16);
+	iface_ctx.mdm_bands_top = strtoul(n_tmp, NULL, 16);
 
 	memcpy(n_tmp, &value[MDM_MIDDLE_BAND_START_POSITION],
 	       MDM_MIDDLE_BAND_SIZE);
 	n_tmp[MDM_MIDDLE_BAND_SIZE] = 0;
-	ictx.mdm_bands_middle = strtoul(n_tmp, NULL, 16);
+	iface_ctx.mdm_bands_middle = strtoul(n_tmp, NULL, 16);
 
 	memcpy(n_tmp, &value[MDM_BOTTOM_BAND_START_POSITION],
 	       MDM_BOTTOM_BAND_SIZE);
 	n_tmp[MDM_BOTTOM_BAND_SIZE] = 0;
-	ictx.mdm_bands_bottom = strtoul(n_tmp, NULL, 16);
+	iface_ctx.mdm_bands_bottom = strtoul(n_tmp, NULL, 16);
 
 	LOG_INF("Current band configuration: %04x %08x %08x",
-		ictx.mdm_bands_top, ictx.mdm_bands_middle,
-		ictx.mdm_bands_bottom);
+		iface_ctx.mdm_bands_top, iface_ctx.mdm_bands_middle,
+		iface_ctx.mdm_bands_bottom);
 
-	event_handler(HL7800_EVENT_BANDS, ictx.mdm_bands_string);
+	event_handler(HL7800_EVENT_BANDS, iface_ctx.mdm_bands_string);
 
 	return true;
 }
@@ -2302,9 +2307,9 @@ static bool on_cmd_radio_active_bands(struct net_buf **buf, uint16_t len)
 		return true;
 	}
 
-	memcpy(ictx.mdm_active_bands_string,
+	memcpy(iface_ctx.mdm_active_bands_string,
 	       &value[MDM_TOP_BAND_START_POSITION], MDM_HL7800_LTE_BAND_STRLEN);
-	event_handler(HL7800_EVENT_ACTIVE_BANDS, ictx.mdm_active_bands_string);
+	event_handler(HL7800_EVENT_ACTIVE_BANDS, iface_ctx.mdm_active_bands_string);
 
 	return true;
 }
@@ -2328,7 +2333,7 @@ static char *get_startup_state_string(enum mdm_hl7800_startup_state state)
 
 static void set_startup_state(enum mdm_hl7800_startup_state state)
 {
-	ictx.mdm_startup_state = state;
+	iface_ctx.mdm_startup_state = state;
 	generate_startup_state_event();
 }
 
@@ -2336,8 +2341,8 @@ static void generate_startup_state_event(void)
 {
 	struct mdm_hl7800_compound_event event;
 
-	event.code = ictx.mdm_startup_state;
-	event.string = get_startup_state_string(ictx.mdm_startup_state);
+	event.code = iface_ctx.mdm_startup_state;
+	event.string = get_startup_state_string(iface_ctx.mdm_startup_state);
 	LOG_INF("Startup State: %s", event.string);
 	event_handler(HL7800_EVENT_STARTUP_STATE_CHANGE, &event);
 }
@@ -2352,7 +2357,7 @@ int mdm_hl7800_set_desired_sleep_level(enum mdm_hl7800_sleep level)
 	case HL7800_SLEEP_HIBERNATE:
 	case HL7800_SLEEP_LITE_HIBERNATE:
 	case HL7800_SLEEP_SLEEP:
-		ictx.desired_sleep_level = level;
+		iface_ctx.desired_sleep_level = level;
 		r = 0;
 		break;
 	default:
@@ -2375,15 +2380,15 @@ int mdm_hl7800_set_desired_sleep_level(enum mdm_hl7800_sleep level)
 
 static void initialize_sleep_level(void)
 {
-	if (ictx.desired_sleep_level == HL7800_SLEEP_UNINITIALIZED) {
+	if (iface_ctx.desired_sleep_level == HL7800_SLEEP_UNINITIALIZED) {
 		if (IS_ENABLED(CONFIG_MODEM_HL7800_SLEEP_LEVEL_HIBERNATE)) {
-			ictx.desired_sleep_level = HL7800_SLEEP_HIBERNATE;
+			iface_ctx.desired_sleep_level = HL7800_SLEEP_HIBERNATE;
 		} else if (IS_ENABLED(CONFIG_MODEM_HL7800_SLEEP_LEVEL_LITE_HIBERNATE)) {
-			ictx.desired_sleep_level = HL7800_SLEEP_LITE_HIBERNATE;
+			iface_ctx.desired_sleep_level = HL7800_SLEEP_LITE_HIBERNATE;
 		} else if (IS_ENABLED(CONFIG_MODEM_HL7800_SLEEP_LEVEL_SLEEP)) {
-			ictx.desired_sleep_level = HL7800_SLEEP_SLEEP;
+			iface_ctx.desired_sleep_level = HL7800_SLEEP_SLEEP;
 		} else {
-			ictx.desired_sleep_level = HL7800_SLEEP_AWAKE;
+			iface_ctx.desired_sleep_level = HL7800_SLEEP_AWAKE;
 		}
 	}
 }
@@ -2398,7 +2403,7 @@ static int set_sleep_level(void)
 	/* AT+KSLEEP= <management>[,<level>[,<delay to sleep after reboot>]]
 	 * management 1 means the HL7800 decides when it enters sleep mode
 	 */
-	switch (ictx.desired_sleep_level) {
+	switch (iface_ctx.desired_sleep_level) {
 	case HL7800_SLEEP_HIBERNATE:
 		snprintk(cmd, sizeof(cmd), SLEEP_CMD_FMT, 1, 2, delay);
 		break;
@@ -2439,9 +2444,9 @@ static char *get_sleep_state_string(enum mdm_hl7800_sleep state)
 
 static void set_sleep_state(enum mdm_hl7800_sleep state)
 {
-	ictx.sleep_state = state;
-	if (ictx.sleep_state != HL7800_SLEEP_AWAKE) {
-		k_sem_reset(&ictx.mdm_awake);
+	iface_ctx.sleep_state = state;
+	if (iface_ctx.sleep_state != HL7800_SLEEP_AWAKE) {
+		k_sem_reset(&iface_ctx.mdm_awake);
 	}
 	generate_sleep_state_event();
 }
@@ -2450,8 +2455,8 @@ static void generate_sleep_state_event(void)
 {
 	struct mdm_hl7800_compound_event event;
 
-	event.code = ictx.sleep_state;
-	event.string = get_sleep_state_string(ictx.sleep_state);
+	event.code = iface_ctx.sleep_state;
+	event.string = get_sleep_state_string(iface_ctx.sleep_state);
 	LOG_INF("Sleep State: %s", event.string);
 	event_handler(HL7800_EVENT_SLEEP_STATE_CHANGE, &event);
 }
@@ -2479,9 +2484,9 @@ static char *get_fota_state_string(enum mdm_hl7800_fota_state state)
 static void set_fota_state(enum mdm_hl7800_fota_state state)
 {
 	LOG_INF("FOTA state: %s->%s",
-		get_fota_state_string(ictx.fw_update_state),
+		get_fota_state_string(iface_ctx.fw_update_state),
 		get_fota_state_string(state));
-	ictx.fw_update_state = state;
+	iface_ctx.fw_update_state = state;
 	generate_fota_state_event();
 }
 
@@ -2489,14 +2494,14 @@ static void generate_fota_state_event(void)
 {
 	struct mdm_hl7800_compound_event event;
 
-	event.code = ictx.fw_update_state;
-	event.string = get_fota_state_string(ictx.fw_update_state);
+	event.code = iface_ctx.fw_update_state;
+	event.string = get_fota_state_string(iface_ctx.fw_update_state);
 	event_handler(HL7800_EVENT_FOTA_STATE, &event);
 }
 
 static void generate_fota_count_event(void)
 {
-	uint32_t count = ictx.fw_packet_count * XMODEM_DATA_SIZE;
+	uint32_t count = iface_ctx.fw_packet_count * XMODEM_DATA_SIZE;
 
 	event_handler(HL7800_EVENT_FOTA_COUNT, &count);
 }
@@ -2517,24 +2522,24 @@ static bool on_cmd_startup_report(struct net_buf **buf, uint16_t len)
 	}
 
 #ifdef CONFIG_MODEM_HL7800_FW_UPDATE
-	if (ictx.fw_updated) {
-		ictx.fw_updated = false;
+	if (iface_ctx.fw_updated) {
+		iface_ctx.fw_updated = false;
 		set_fota_state(HL7800_FOTA_REBOOT_AND_RECONFIGURE);
 		/* issue reset after a firmware update to reconfigure modem state */
-		k_work_reschedule_for_queue(&hl7800_workq, &ictx.mdm_reset_work,
+		k_work_reschedule_for_queue(&hl7800_workq, &iface_ctx.mdm_reset_work,
 					    K_NO_WAIT);
 	} else
 #endif
 	{
 		PRINT_AWAKE_MSG;
-		ictx.wait_for_KSUP = false;
-		ictx.mdm_startup_reporting_on = true;
-		ictx.reconfig_IP_connection = true;
+		iface_ctx.wait_for_KSUP = false;
+		iface_ctx.mdm_startup_reporting_on = true;
+		iface_ctx.reconfig_IP_connection = true;
 #ifdef CONFIG_MODEM_HL7800_LOW_POWER_MODE
 		mark_sockets_for_reconfig();
 #endif
 		set_sleep_state(HL7800_SLEEP_AWAKE);
-		k_sem_give(&ictx.mdm_awake);
+		k_sem_give(&iface_ctx.mdm_awake);
 	}
 
 	return true;
@@ -2576,7 +2581,7 @@ static bool profile_handler(struct net_buf **buf, uint16_t len,
 	net_buf_skipcrlf(buf);
 
 	if (active_profile) {
-		ictx.mdm_echo_is_on = (echo_state != 0);
+		iface_ctx.mdm_echo_is_on = (echo_state != 0);
 	}
 
 	/* Discard next line.  This waits for the longest possible response even
@@ -2627,10 +2632,10 @@ static bool on_cmd_atcmdinfo_pdp_authentication_cfg(struct net_buf **buf,
 						  *buf, 0, line_length);
 		LOG_DBG("length: %u: %s", line_length, line);
 		if (output_length > 0) {
-			memset(ictx.mdm_apn.username, 0,
-			       sizeof(ictx.mdm_apn.username));
-			memset(ictx.mdm_apn.password, 0,
-			       sizeof(ictx.mdm_apn.password));
+			memset(iface_ctx.mdm_apn.username, 0,
+			       sizeof(iface_ctx.mdm_apn.username));
+			memset(iface_ctx.mdm_apn.password, 0,
+			       sizeof(iface_ctx.mdm_apn.password));
 
 			i = 0;
 			p = strchr(line, '"');
@@ -2640,11 +2645,11 @@ static bool on_cmd_atcmdinfo_pdp_authentication_cfg(struct net_buf **buf,
 				while ((p != NULL) && (*p != '"') &&
 				       (i <
 					MDM_HL7800_APN_USERNAME_MAX_STRLEN)) {
-					ictx.mdm_apn.username[i++] = *p++;
+					iface_ctx.mdm_apn.username[i++] = *p++;
 				}
 			}
 			LOG_INF("APN Username: %s",
-				ictx.mdm_apn.username);
+				iface_ctx.mdm_apn.username);
 
 			p = strchr(p + 1, '"');
 			if (p != NULL) {
@@ -2653,11 +2658,11 @@ static bool on_cmd_atcmdinfo_pdp_authentication_cfg(struct net_buf **buf,
 				while ((p != NULL) && (*p != '"') &&
 				       (i <
 					MDM_HL7800_APN_PASSWORD_MAX_STRLEN)) {
-					ictx.mdm_apn.password[i++] = *p++;
+					iface_ctx.mdm_apn.password[i++] = *p++;
 				}
 			}
 			LOG_INF("APN Password: %s",
-				ictx.mdm_apn.password);
+				iface_ctx.mdm_apn.password);
 		}
 	}
 	net_buf_remove(buf, line_length);
@@ -2689,8 +2694,8 @@ static bool on_cmd_atcmdinfo_pdp_context(struct net_buf **buf, uint16_t len)
 						  *buf, 0, line_length);
 		LOG_DBG("length: %u: %s", line_length, line);
 		if (output_length > 0) {
-			memset(ictx.mdm_apn.value, 0, sizeof(ictx.mdm_apn.value));
-			memset(ictx.mdm_pdp_addr_fam, 0, MDM_ADDR_FAM_MAX_LEN);
+			memset(iface_ctx.mdm_apn.value, 0, sizeof(iface_ctx.mdm_apn.value));
+			memset(iface_ctx.mdm_pdp_addr_fam, 0, MDM_ADDR_FAM_MAX_LEN);
 
 			/* Address family after first , */
 			p = strchr(line, ',');
@@ -2701,9 +2706,9 @@ static bool on_cmd_atcmdinfo_pdp_context(struct net_buf **buf, uint16_t len)
 			p += 2;
 			i = 0;
 			while ((p != NULL) && (*p != '"') && (i < MDM_ADDR_FAM_MAX_LEN)) {
-				ictx.mdm_pdp_addr_fam[i++] = *p++;
+				iface_ctx.mdm_pdp_addr_fam[i++] = *p++;
 			}
-			LOG_DBG("PDP address family: %s", ictx.mdm_pdp_addr_fam);
+			LOG_DBG("PDP address family: %s", iface_ctx.mdm_pdp_addr_fam);
 
 			/* APN after second , " */
 			p = strchr(p, ',');
@@ -2721,11 +2726,11 @@ static bool on_cmd_atcmdinfo_pdp_context(struct net_buf **buf, uint16_t len)
 				i = 0;
 				while ((p != NULL) && (*p != '"') &&
 				       (i < MDM_HL7800_APN_MAX_STRLEN)) {
-					ictx.mdm_apn.value[i++] = *p++;
+					iface_ctx.mdm_apn.value[i++] = *p++;
 				}
 			}
 
-			LOG_INF("APN: %s", ictx.mdm_apn.value);
+			LOG_INF("APN: %s", iface_ctx.mdm_apn.value);
 		}
 	}
 done:
@@ -2752,7 +2757,7 @@ static void hl7800_start_rssi_work(void)
 	/* Rate is not checked here to allow one reading
 	 * when going from network down->up
 	 */
-	k_work_reschedule_for_queue(&hl7800_workq, &ictx.rssi_query_work,
+	k_work_reschedule_for_queue(&hl7800_workq, &iface_ctx.rssi_query_work,
 				    K_NO_WAIT);
 }
 
@@ -2760,7 +2765,7 @@ static void hl7800_stop_rssi_work(void)
 {
 	int rc;
 
-	rc = k_work_cancel_delayable(&ictx.rssi_query_work);
+	rc = k_work_cancel_delayable(&iface_ctx.rssi_query_work);
 	if (rc != 0) {
 		LOG_ERR("Could not cancel RSSI work [%d]", rc);
 	}
@@ -2781,7 +2786,7 @@ static void hl7800_rssi_query_work(struct k_work *work)
 
 	/* re-start RSSI query work */
 	if (CONFIG_MODEM_HL7800_RSSI_RATE_SECONDS > 0) {
-		k_work_reschedule_for_queue(&hl7800_workq, &ictx.rssi_query_work,
+		k_work_reschedule_for_queue(&hl7800_workq, &iface_ctx.rssi_query_work,
 					    K_SECONDS(CONFIG_MODEM_HL7800_RSSI_RATE_SECONDS));
 	}
 }
@@ -2832,9 +2837,9 @@ static void gps_work_callback(struct k_work *work)
 
 	LOG_DBG("GPS location request status: %d", r);
 
-	if (ictx.gps_query_location_rate_seconds) {
-		k_work_reschedule_for_queue(&hl7800_workq, &ictx.gps_work,
-					    K_SECONDS(ictx.gps_query_location_rate_seconds));
+	if (iface_ctx.gps_query_location_rate_seconds) {
+		k_work_reschedule_for_queue(&hl7800_workq, &iface_ctx.gps_work,
+					    K_SECONDS(iface_ctx.gps_query_location_rate_seconds));
 	}
 }
 
@@ -3186,7 +3191,7 @@ static void notify_all_tcp_sockets_closed(void)
 	struct hl7800_socket *sock = NULL;
 
 	for (i = 0; i < MDM_MAX_SOCKETS; i++) {
-		sock = &ictx.sockets[i];
+		sock = &iface_ctx.sockets[i];
 		if ((sock->context != NULL) && (sock->type == SOCK_STREAM)) {
 			LOG_DBG("Sock %d closed", sock->socket_id);
 			/* signal RX callback with null packet */
@@ -3205,27 +3210,29 @@ static void iface_status_work_cb(struct k_work *work)
 	hl7800_lock();
 	enum mdm_hl7800_network_state state;
 
-	if (ictx.off) {
+	if (iface_ctx.off) {
 		goto done;
-	} else if (!ictx.initialized && ictx.restarting) {
+	} else if (!iface_ctx.initialized && iface_ctx.restarting) {
 		LOG_DBG("Wait for driver init, process network state later");
 		/* we are not ready to process this yet, try again later */
 		k_work_reschedule_for_queue(&hl7800_workq,
-					    &ictx.iface_status_work,
+					    &iface_ctx.iface_status_work,
 					    IFACE_WORK_DELAY);
 		goto done;
-	} else if (ictx.wait_for_KSUP && ictx.wait_for_KSUP_tries < WAIT_FOR_KSUP_RETRIES) {
+	} else if (iface_ctx.wait_for_KSUP &&
+		   iface_ctx.wait_for_KSUP_tries < WAIT_FOR_KSUP_RETRIES) {
 		LOG_DBG("Wait for +KSUP before updating network state");
-		ictx.wait_for_KSUP_tries++;
+		iface_ctx.wait_for_KSUP_tries++;
 		/* we have not received +KSUP yet, lets wait more time to receive +KSUP */
 		k_work_reschedule_for_queue(&hl7800_workq,
-					    &ictx.iface_status_work,
+					    &iface_ctx.iface_status_work,
 					    IFACE_WORK_DELAY);
 		goto done;
-	} else if (ictx.wait_for_KSUP && ictx.wait_for_KSUP_tries >= WAIT_FOR_KSUP_RETRIES) {
+	} else if (iface_ctx.wait_for_KSUP &&
+		   iface_ctx.wait_for_KSUP_tries >= WAIT_FOR_KSUP_RETRIES) {
 		/* give up waiting for KSUP */
 		LOG_DBG("Give up waiting for");
-		ictx.wait_for_KSUP = false;
+		iface_ctx.wait_for_KSUP = false;
 		check_hl7800_awake();
 	}
 
@@ -3233,12 +3240,12 @@ static void iface_status_work_cb(struct k_work *work)
 
 	LOG_DBG("Updating network state...");
 
-	state = ictx.network_state;
+	state = iface_ctx.network_state;
 	/* Ensure we bring the network interface down and then re-check the current state */
-	if (ictx.network_dropped) {
-		ictx.network_dropped = false;
+	if (iface_ctx.network_dropped) {
+		iface_ctx.network_dropped = false;
 		state = HL7800_OUT_OF_COVERAGE;
-		k_work_reschedule_for_queue(&hl7800_workq, &ictx.iface_status_work,
+		k_work_reschedule_for_queue(&hl7800_workq, &iface_ctx.iface_status_work,
 					    IFACE_WORK_DELAY);
 	}
 
@@ -3252,26 +3259,26 @@ static void iface_status_work_cb(struct k_work *work)
 	switch (state) {
 	case HL7800_HOME_NETWORK:
 	case HL7800_ROAMING:
-		if (ictx.iface) {
+		if (iface_ctx.iface) {
 			LOG_DBG("HL7800 iface UP");
-			net_if_carrier_on(ictx.iface);
+			net_if_carrier_on(iface_ctx.iface);
 		}
 		break;
 	case HL7800_OUT_OF_COVERAGE:
 	default:
-		if (ictx.iface && (ictx.low_power_mode != HL7800_LPM_PSM)) {
+		if (iface_ctx.iface && (iface_ctx.low_power_mode != HL7800_LPM_PSM)) {
 			LOG_DBG("HL7800 iface DOWN");
-			ictx.dns_ready = false;
-			net_if_carrier_off(ictx.iface);
+			iface_ctx.dns_ready = false;
+			net_if_carrier_off(iface_ctx.iface);
 		}
 		break;
 	}
 
-	if ((ictx.iface && !net_if_is_up(ictx.iface)) ||
-	    (ictx.low_power_mode == HL7800_LPM_PSM && state == HL7800_OUT_OF_COVERAGE)) {
+	if ((iface_ctx.iface && !net_if_is_up(iface_ctx.iface)) ||
+	    (iface_ctx.low_power_mode == HL7800_LPM_PSM && state == HL7800_OUT_OF_COVERAGE)) {
 		hl7800_stop_rssi_work();
 		notify_all_tcp_sockets_closed();
-	} else if (ictx.iface && net_if_is_up(ictx.iface)) {
+	} else if (iface_ctx.iface && net_if_is_up(iface_ctx.iface)) {
 		hl7800_start_rssi_work();
 		/* get IP address info */
 		(void)send_at_cmd(NULL, "AT+CGCONTRDP=1", MDM_CMD_SEND_TIMEOUT,
@@ -3303,7 +3310,7 @@ static char *get_network_state_string(enum mdm_hl7800_network_state state)
 
 static void set_network_state(enum mdm_hl7800_network_state state)
 {
-	ictx.network_state = state;
+	iface_ctx.network_state = state;
 	generate_network_state_event();
 }
 
@@ -3311,9 +3318,9 @@ static void generate_network_state_event(void)
 {
 	struct mdm_hl7800_compound_event event;
 
-	event.code = ictx.network_state;
-	event.string = get_network_state_string(ictx.network_state);
-	LOG_INF("Network State: %d %s", ictx.network_state, event.string);
+	event.code = iface_ctx.network_state;
+	event.string = get_network_state_string(iface_ctx.network_state);
+	LOG_INF("Network State: %d %s", iface_ctx.network_state, event.string);
 	event_handler(HL7800_EVENT_NETWORK_STATE_CHANGE, &event);
 }
 
@@ -3338,7 +3345,7 @@ static bool on_cmd_network_report_query(struct net_buf **buf, uint16_t len)
 
 		/* start work to adjust iface */
 		k_work_reschedule_for_queue(&hl7800_workq,
-					    &ictx.iface_status_work,
+					    &iface_ctx.iface_status_work,
 					    IFACE_WORK_DELAY);
 	}
 
@@ -3364,9 +3371,9 @@ static bool on_cmd_operator_index_query(struct net_buf **buf, uint16_t len)
 	out_len = net_buf_linearize(carrier, MDM_HL7800_OPERATOR_INDEX_STRLEN,
 				    *buf, 0, len);
 	carrier[out_len] = 0;
-	ictx.operator_index = (uint8_t)strtol(carrier, NULL, 10);
+	iface_ctx.operator_index = (uint8_t)strtol(carrier, NULL, 10);
 
-	LOG_INF("Operator Index: %u", ictx.operator_index);
+	LOG_INF("Operator Index: %u", iface_ctx.operator_index);
 done:
 	return true;
 }
@@ -3390,9 +3397,9 @@ static bool on_cmd_modem_functionality(struct net_buf **buf, uint16_t len)
 	out_len = net_buf_linearize(rsp, MDM_HL7800_MODEM_FUNCTIONALITY_STRLEN,
 				    *buf, 0, len);
 	rsp[out_len] = 0;
-	ictx.functionality = strtol(rsp, NULL, 10);
+	iface_ctx.functionality = strtol(rsp, NULL, 10);
 
-	LOG_INF("Modem Functionality: %u", ictx.functionality);
+	LOG_INF("Modem Functionality: %u", iface_ctx.functionality);
 done:
 	return true;
 }
@@ -3473,7 +3480,7 @@ static bool on_cmd_rtc_query(struct net_buf **buf, uint16_t len)
 	char rtc_string[sizeof(TIME_STRING_FORMAT)];
 
 	memset(rtc_string, 0, sizeof(rtc_string));
-	ictx.local_time_valid = false;
+	iface_ctx.local_time_valid = false;
 
 	wait_for_modem_data_and_newline(buf, net_buf_frags_len(*buf),
 					sizeof(TIME_STRING_FORMAT));
@@ -3489,8 +3496,8 @@ static bool on_cmd_rtc_query(struct net_buf **buf, uint16_t len)
 	} else {
 		net_buf_linearize(rtc_string, str_len, *buf, 0, str_len);
 		LOG_INF("RTC string: '%s'", rtc_string);
-		ictx.local_time_valid = convert_time_string_to_struct(
-			&ictx.local_time, &ictx.local_time_offset, rtc_string);
+		iface_ctx.local_time_valid = convert_time_string_to_struct(
+			&iface_ctx.local_time, &iface_ctx.local_time_offset, rtc_string);
 	}
 done:
 	return true;
@@ -3578,25 +3585,25 @@ static bool on_cmd_network_report(struct net_buf **buf, uint16_t len)
 	int l;
 	char val[MDM_MAX_RESP_SIZE];
 
-	out_len = net_buf_linearize(ictx.mdm_network_status,
-				    sizeof(ictx.mdm_network_status) - 1, *buf,
+	out_len = net_buf_linearize(iface_ctx.mdm_network_status,
+				    sizeof(iface_ctx.mdm_network_status) - 1, *buf,
 				    0, len);
-	ictx.mdm_network_status[out_len] = 0;
-	LOG_DBG("Network status: %s", ictx.mdm_network_status);
-	pos = strchr(ictx.mdm_network_status, ',');
+	iface_ctx.mdm_network_status[out_len] = 0;
+	LOG_DBG("Network status: %s", iface_ctx.mdm_network_status);
+	pos = strchr(iface_ctx.mdm_network_status, ',');
 	if (pos) {
-		l = pos - ictx.mdm_network_status;
-		strncpy(val, ictx.mdm_network_status, l);
+		l = pos - iface_ctx.mdm_network_status;
+		strncpy(val, iface_ctx.mdm_network_status, l);
 		val[l] = 0;
 		set_network_state(strtol(val, NULL, 0));
 	} else {
-		set_network_state(strtol(ictx.mdm_network_status, NULL, 0));
+		set_network_state(strtol(iface_ctx.mdm_network_status, NULL, 0));
 	}
 
 	/* keep HL7800 awake because we want to process the network state soon */
 	allow_sleep(false);
 	/* start work to adjust iface */
-	k_work_reschedule_for_queue(&hl7800_workq, &ictx.iface_status_work,
+	k_work_reschedule_for_queue(&hl7800_workq, &iface_ctx.iface_status_work,
 				    IFACE_WORK_DELAY);
 
 	return true;
@@ -3631,19 +3638,19 @@ static bool on_cmd_atcmdinfo_rssi(struct net_buf **buf, uint16_t len)
 		search_start = delims[i] + 1;
 	}
 	/* the first value in the message is the RSRP */
-	ictx.mdm_rssi = strtol(value, NULL, 10);
+	iface_ctx.mdm_rssi = strtol(value, NULL, 10);
 	/* the 4th ',' (last in the msg) is the start of the SINR */
-	ictx.mdm_sinr = strtol(delims[3] + 1, NULL, 10);
+	iface_ctx.mdm_sinr = strtol(delims[3] + 1, NULL, 10);
 	if ((delims[1] - delims[0]) == 1) {
 		/* there is no value between the first and second
 		 *  delimiter, signal is unknown
 		 */
 		LOG_INF("RSSI (RSRP): UNKNOWN");
 	} else {
-		LOG_INF("RSSI (RSRP): %d SINR: %d", ictx.mdm_rssi,
-			ictx.mdm_sinr);
-		event_handler(HL7800_EVENT_RSSI, &ictx.mdm_rssi);
-		event_handler(HL7800_EVENT_SINR, &ictx.mdm_sinr);
+		LOG_INF("RSSI (RSRP): %d SINR: %d", iface_ctx.mdm_rssi,
+			iface_ctx.mdm_sinr);
+		event_handler(HL7800_EVENT_RSSI, &iface_ctx.mdm_rssi);
+		event_handler(HL7800_EVENT_SINR, &iface_ctx.mdm_sinr);
 	}
 done:
 	return true;
@@ -3654,10 +3661,10 @@ static bool on_cmd_sockok(struct net_buf **buf, uint16_t len)
 {
 	struct hl7800_socket *sock = NULL;
 
-	sock = socket_from_id(ictx.last_socket_id);
+	sock = socket_from_id(iface_ctx.last_socket_id);
 	if (!sock) {
-		ictx.last_error = 0;
-		k_sem_give(&ictx.response_sem);
+		iface_ctx.last_error = 0;
+		k_sem_give(&iface_ctx.response_sem);
 	} else {
 		sock->error = 0;
 		k_sem_give(&sock->sock_send_sem);
@@ -3674,7 +3681,7 @@ static bool on_cmd_sock_ind(struct net_buf **buf, uint16_t len, const char *cons
 	size_t out_len;
 	int id;
 
-	ictx.last_error = 0;
+	iface_ctx.last_error = 0;
 
 	out_len = net_buf_linearize(value, sizeof(value), *buf, 0, len);
 	value[out_len] = 0;
@@ -3721,10 +3728,10 @@ static bool on_cmd_sockerror(struct net_buf **buf, uint16_t len)
 		LOG_ERR("'%s'", string);
 	}
 
-	sock = socket_from_id(ictx.last_socket_id);
+	sock = socket_from_id(iface_ctx.last_socket_id);
 	if (!sock) {
-		ictx.last_error = -EIO;
-		k_sem_give(&ictx.response_sem);
+		iface_ctx.last_error = -EIO;
+		k_sem_give(&iface_ctx.response_sem);
 	} else {
 		sock->error = -EIO;
 		k_sem_give(&sock->sock_send_sem);
@@ -3745,10 +3752,10 @@ static bool on_cmd_sock_error_code(struct net_buf **buf, uint16_t len)
 
 	LOG_ERR("Error code: %s", value);
 
-	sock = socket_from_id(ictx.last_socket_id);
+	sock = socket_from_id(iface_ctx.last_socket_id);
 	if (!sock) {
-		ictx.last_error = -EIO;
-		k_sem_give(&ictx.response_sem);
+		iface_ctx.last_error = -EIO;
+		k_sem_give(&iface_ctx.response_sem);
 	} else {
 		sock->error = -EIO;
 		k_sem_give(&sock->sock_send_sem);
@@ -3827,7 +3834,7 @@ static bool on_cmd_sock_notif(struct net_buf **buf, uint16_t len)
 		sock->error = -ENOTCONN;
 		break;
 	default:
-		ictx.network_dropped = true;
+		iface_ctx.network_dropped = true;
 		err = true;
 		sock->error = -EIO;
 		break;
@@ -3845,8 +3852,8 @@ static bool on_cmd_sock_notif(struct net_buf **buf, uint16_t len)
 			k_sem_give(&sock->sock_send_sem);
 		}
 
-		if (ictx.network_dropped) {
-			k_work_reschedule_for_queue(&hl7800_workq, &ictx.iface_status_work,
+		if (iface_ctx.network_dropped) {
+			k_work_reschedule_for_queue(&hl7800_workq, &iface_ctx.iface_status_work,
 						    IFACE_WORK_DELAY);
 		}
 	}
@@ -3889,32 +3896,32 @@ static bool on_cmd_sockcreate(enum net_sock_type type, struct net_buf **buf, uin
 
 	out_len = net_buf_linearize(value, sizeof(value), *buf, 0, len);
 	value[out_len] = 0;
-	ictx.last_socket_id = strtol(value, NULL, 10);
+	iface_ctx.last_socket_id = strtol(value, NULL, 10);
 	if (type == SOCK_STREAM) {
-		LOG_DBG("+KTCPCFG: %d", ictx.last_socket_id);
+		LOG_DBG("+KTCPCFG: %d", iface_ctx.last_socket_id);
 	} else if (type == SOCK_DGRAM) {
-		LOG_DBG("+KUDPCFG: %d", ictx.last_socket_id);
+		LOG_DBG("+KUDPCFG: %d", iface_ctx.last_socket_id);
 	}
 
 	/* check if the socket has been created already */
-	sock = socket_from_id(ictx.last_socket_id);
+	sock = socket_from_id(iface_ctx.last_socket_id);
 	if (!sock) {
 		LOG_DBG("look up new socket by creation id");
 		sock = socket_from_id(MDM_CREATE_SOCKET_ID);
 		if (!sock) {
-			if (queue_stale_socket(type, ictx.last_socket_id) == 0) {
+			if (queue_stale_socket(type, iface_ctx.last_socket_id) == 0) {
 				/* delay some time before socket cleanup in case there
 				 * are multiple sockets to cleanup
 				 */
 				k_work_reschedule_for_queue(&hl7800_workq,
-							    &ictx.delete_untracked_socket_work,
+							    &iface_ctx.delete_untracked_socket_work,
 							    SOCKET_CLEANUP_WORK_DELAY);
 			}
 			goto done;
 		}
 	}
 
-	sock->socket_id = ictx.last_socket_id;
+	sock->socket_id = iface_ctx.last_socket_id;
 	sock->created = true;
 	sock->reconfig = false;
 	/* don't give back semaphore -- OK to follow */
@@ -3964,9 +3971,9 @@ static void sock_read(struct net_buf **buf, uint16_t len)
 	char eof[sizeof(EOF_PATTERN)];
 	size_t out_len;
 
-	sock = socket_from_id(ictx.last_socket_id);
+	sock = socket_from_id(iface_ctx.last_socket_id);
 	if (!sock) {
-		LOG_ERR("Socket not found! (%d)", ictx.last_socket_id);
+		LOG_ERR("Socket not found! (%d)", iface_ctx.last_socket_id);
 		goto exit;
 	}
 
@@ -4115,9 +4122,9 @@ static bool on_cmd_connect(struct net_buf **buf, uint16_t len)
 	bool remove_data_from_buffer = true;
 	struct hl7800_socket *sock = NULL;
 
-	sock = socket_from_id(ictx.last_socket_id);
+	sock = socket_from_id(iface_ctx.last_socket_id);
 	if (!sock) {
-		LOG_ERR("Sock (%d) not found", ictx.last_socket_id);
+		LOG_ERR("Sock (%d) not found", iface_ctx.last_socket_id);
 		goto done;
 	}
 
@@ -4146,30 +4153,30 @@ static int start_socket_rx(struct hl7800_socket *sock, uint16_t rx_size)
 	sock->state = SOCK_RX;
 	if (sock->type == SOCK_DGRAM) {
 #if defined(CONFIG_NET_IPV4)
-		if (rx_size > (net_if_get_mtu(ictx.iface) - NET_IPV4UDPH_LEN)) {
+		if (rx_size > (net_if_get_mtu(iface_ctx.iface) - NET_IPV4UDPH_LEN)) {
 			sock->rx_size =
-				net_if_get_mtu(ictx.iface) - NET_IPV4UDPH_LEN;
+				net_if_get_mtu(iface_ctx.iface) - NET_IPV4UDPH_LEN;
 		}
 #endif
 #if defined(CONFIG_NET_IPV6)
-		if (rx_size > (net_if_get_mtu(ictx.iface) - NET_IPV6UDPH_LEN)) {
+		if (rx_size > (net_if_get_mtu(iface_ctx.iface) - NET_IPV6UDPH_LEN)) {
 			sock->rx_size =
-				net_if_get_mtu(ictx.iface) - NET_IPV6UDPH_LEN;
+				net_if_get_mtu(iface_ctx.iface) - NET_IPV6UDPH_LEN;
 		}
 #endif
 		snprintk(sendbuf, sizeof(sendbuf), "AT+KUDPRCV=%d,%u",
 			 sock->socket_id, rx_size);
 	} else {
 #if defined(CONFIG_NET_IPV4)
-		if (rx_size > (net_if_get_mtu(ictx.iface) - NET_IPV4TCPH_LEN)) {
+		if (rx_size > (net_if_get_mtu(iface_ctx.iface) - NET_IPV4TCPH_LEN)) {
 			sock->rx_size =
-				net_if_get_mtu(ictx.iface) - NET_IPV4TCPH_LEN;
+				net_if_get_mtu(iface_ctx.iface) - NET_IPV4TCPH_LEN;
 		}
 #endif
 #if defined(CONFIG_NET_IPV6)
-		if (rx_size > (net_if_get_mtu(ictx.iface) - NET_IPV6TCPH_LEN)) {
+		if (rx_size > (net_if_get_mtu(iface_ctx.iface) - NET_IPV6TCPH_LEN)) {
 			sock->rx_size =
-				net_if_get_mtu(ictx.iface) - NET_IPV6TCPH_LEN;
+				net_if_get_mtu(iface_ctx.iface) - NET_IPV6TCPH_LEN;
 		}
 #endif
 		snprintk(sendbuf, sizeof(sendbuf), "AT+KTCPRCV=%d,%u",
@@ -4281,14 +4288,14 @@ static bool on_cmd_device_service_ind(struct net_buf **buf, uint16_t len)
 	memset(value, 0, sizeof(value));
 	out_len = net_buf_linearize(value, sizeof(value), *buf, 0, len);
 	if (out_len > 0) {
-		ictx.device_services_ind = strtol(value, NULL, 10);
+		iface_ctx.device_services_ind = strtol(value, NULL, 10);
 	}
-	LOG_INF("+WDSI: %d", ictx.device_services_ind);
+	LOG_INF("+WDSI: %d", iface_ctx.device_services_ind);
 
 #ifdef CONFIG_MODEM_HL7800_FW_UPDATE
-	if (ictx.device_services_ind == WDSI_PKG_DOWNLOADED) {
+	if (iface_ctx.device_services_ind == WDSI_PKG_DOWNLOADED) {
 		k_work_submit_to_queue(&hl7800_workq,
-				       &ictx.finish_fw_update_work);
+				       &iface_ctx.finish_fw_update_work);
 	}
 #endif
 
@@ -4312,7 +4319,7 @@ static size_t hl7800_read_rx(struct net_buf **buf)
 
 	/* read all of the data from mdm_receiver */
 	while (true) {
-		ret = mdm_receiver_recv(&ictx.mdm_ctx, uart_buffer,
+		ret = mdm_receiver_recv(&iface_ctx.mdm_ctx, uart_buffer,
 					sizeof(uart_buffer), &bytes_read);
 		if (ret < 0 || bytes_read == 0) {
 			/* mdm_receiver buffer is empty */
@@ -4353,7 +4360,7 @@ static void finish_fw_update_work_callback(struct k_work *item)
 	ARG_UNUSED(item);
 
 	send_at_cmd(NULL, "AT+WDSR=4", MDM_CMD_SEND_TIMEOUT, 0, false);
-	ictx.fw_updated = true;
+	iface_ctx.fw_updated = true;
 	set_fota_state(HL7800_FOTA_INSTALL);
 	hl7800_unlock();
 }
@@ -4377,8 +4384,8 @@ static uint8_t calc_fw_update_crc(uint8_t *ptr, int count)
 static int send_fw_update_packet(struct xmodem_packet *pkt)
 {
 	generate_fota_count_event();
-	LOG_DBG("Send FW update packet %d,%d", pkt->id, ictx.fw_packet_count);
-	return mdm_receiver_send(&ictx.mdm_ctx, (const uint8_t *)pkt,
+	LOG_DBG("Send FW update packet %d,%d", pkt->id, iface_ctx.fw_packet_count);
+	return mdm_receiver_send(&iface_ctx.mdm_ctx, (const uint8_t *)pkt,
 				 XMODEM_PACKET_SIZE);
 }
 
@@ -4387,16 +4394,16 @@ static int prepare_and_send_fw_packet(void)
 	int ret = 0;
 	int read_res;
 
-	ictx.fw_packet.id_complement = 0xFF - ictx.fw_packet.id;
+	iface_ctx.fw_packet.id_complement = 0xFF - iface_ctx.fw_packet.id;
 
-	ret = fs_seek(&ictx.fw_update_file, ictx.file_pos, FS_SEEK_SET);
+	ret = fs_seek(&iface_ctx.fw_update_file, iface_ctx.file_pos, FS_SEEK_SET);
 	if (ret < 0) {
 		set_fota_state(HL7800_FOTA_FILE_ERROR);
-		LOG_ERR("Could not seek to offset %d of file", ictx.file_pos);
+		LOG_ERR("Could not seek to offset %d of file", iface_ctx.file_pos);
 		return ret;
 	}
 
-	read_res = fs_read(&ictx.fw_update_file, ictx.fw_packet.data,
+	read_res = fs_read(&iface_ctx.fw_update_file, iface_ctx.fw_packet.data,
 			   XMODEM_DATA_SIZE);
 	if (read_res < 0) {
 		set_fota_state(HL7800_FOTA_FILE_ERROR);
@@ -4404,21 +4411,21 @@ static int prepare_and_send_fw_packet(void)
 		return ret;
 	} else if (read_res < XMODEM_DATA_SIZE) {
 		set_fota_state(HL7800_FOTA_PAD);
-		fs_close(&ictx.fw_update_file);
+		fs_close(&iface_ctx.fw_update_file);
 		/* pad rest of data */
 		for (int i = read_res; i < XMODEM_DATA_SIZE; i++) {
-			ictx.fw_packet.data[i] = XMODEM_PAD_VALUE;
+			iface_ctx.fw_packet.data[i] = XMODEM_PAD_VALUE;
 		}
 	}
 
-	ictx.fw_packet.crc =
-		calc_fw_update_crc(ictx.fw_packet.data, XMODEM_DATA_SIZE);
+	iface_ctx.fw_packet.crc =
+		calc_fw_update_crc(iface_ctx.fw_packet.data, XMODEM_DATA_SIZE);
 
-	send_fw_update_packet(&ictx.fw_packet);
+	send_fw_update_packet(&iface_ctx.fw_packet);
 
-	ictx.file_pos += read_res;
-	ictx.fw_packet_count++;
-	ictx.fw_packet.id++;
+	iface_ctx.file_pos += read_res;
+	iface_ctx.fw_packet_count++;
+	iface_ctx.fw_packet.id++;
 
 	return ret;
 }
@@ -4431,28 +4438,28 @@ static void process_fw_update_rx(struct net_buf **rx_buf)
 	xm_msg = net_buf_get_u8(rx_buf);
 
 	if (xm_msg == XM_NACK) {
-		if (ictx.fw_update_state == HL7800_FOTA_START) {
+		if (iface_ctx.fw_update_state == HL7800_FOTA_START) {
 			/* send first FW update packet */
 			set_fota_state(HL7800_FOTA_WIP);
-			ictx.file_pos = 0;
-			ictx.fw_packet_count = 1;
-			ictx.fw_packet.id = 1;
-			ictx.fw_packet.preamble = XM_SOH_1K;
+			iface_ctx.file_pos = 0;
+			iface_ctx.fw_packet_count = 1;
+			iface_ctx.fw_packet.id = 1;
+			iface_ctx.fw_packet.preamble = XM_SOH_1K;
 
 			prepare_and_send_fw_packet();
-		} else if (ictx.fw_update_state == HL7800_FOTA_WIP) {
+		} else if (iface_ctx.fw_update_state == HL7800_FOTA_WIP) {
 			LOG_DBG("RX FW update NACK");
 			/* resend last packet */
-			send_fw_update_packet(&ictx.fw_packet);
+			send_fw_update_packet(&iface_ctx.fw_packet);
 		}
 	} else if (xm_msg == XM_ACK) {
 		LOG_DBG("RX FW update ACK");
-		if (ictx.fw_update_state == HL7800_FOTA_WIP) {
+		if (iface_ctx.fw_update_state == HL7800_FOTA_WIP) {
 			/* send next FW update packet */
 			prepare_and_send_fw_packet();
-		} else if (ictx.fw_update_state == HL7800_FOTA_PAD) {
+		} else if (iface_ctx.fw_update_state == HL7800_FOTA_PAD) {
 			set_fota_state(HL7800_FOTA_SEND_EOT);
-			mdm_receiver_send(&ictx.mdm_ctx, &eot, sizeof(eot));
+			mdm_receiver_send(&iface_ctx.mdm_ctx, &eot, sizeof(eot));
 		}
 	} else {
 		LOG_WRN("RX unhandled FW update value: %02x", xm_msg);
@@ -4556,7 +4563,7 @@ static void hl7800_rx(void)
 
 	while (true) {
 		/* wait for incoming data */
-		(void)k_sem_take(&ictx.mdm_ctx.rx_sem, K_FOREVER);
+		(void)k_sem_take(&iface_ctx.mdm_ctx.rx_sem, K_FOREVER);
 
 		hl7800_read_rx(&rx_buf);
 		/* If an external module hasn't locked the command processor,
@@ -4574,9 +4581,9 @@ static void hl7800_rx(void)
 			cmd_handled = false;
 
 #ifdef CONFIG_MODEM_HL7800_FW_UPDATE
-			if ((ictx.fw_update_state == HL7800_FOTA_START) ||
-			    (ictx.fw_update_state == HL7800_FOTA_WIP) ||
-			    (ictx.fw_update_state == HL7800_FOTA_PAD)) {
+			if ((iface_ctx.fw_update_state == HL7800_FOTA_START) ||
+			    (iface_ctx.fw_update_state == HL7800_FOTA_WIP) ||
+			    (iface_ctx.fw_update_state == HL7800_FOTA_PAD)) {
 				process_fw_update_rx(&rx_buf);
 				if (!rx_buf) {
 					break;
@@ -4601,8 +4608,8 @@ static void hl7800_rx(void)
 			/* look for matching data handlers */
 			i = -1;
 			for (i = 0; i < ARRAY_SIZE(handlers); i++) {
-				if (ictx.search_no_id_resp) {
-					cmp_res = strncmp(ictx.no_id_resp_cmd,
+				if (iface_ctx.search_no_id_resp) {
+					cmp_res = strncmp(iface_ctx.no_id_resp_cmd,
 							  handlers[i].cmd,
 							  handlers[i].cmd_len);
 				} else {
@@ -4615,7 +4622,7 @@ static void hl7800_rx(void)
 					/* found a matching handler */
 
 					/* skip cmd_len */
-					if (!ictx.search_no_id_resp) {
+					if (!iface_ctx.search_no_id_resp) {
 						rx_buf = net_buf_skip(
 							rx_buf,
 							handlers[i].cmd_len);
@@ -4637,7 +4644,7 @@ static void hl7800_rx(void)
 								&rx_buf, len);
 					}
 					cmd_handled = true;
-					ictx.search_no_id_resp = false;
+					iface_ctx.search_no_id_resp = false;
 					frag = NULL;
 					/* make sure buf still has data */
 					if (!rx_buf) {
@@ -4685,15 +4692,15 @@ static void shutdown_uart(void)
 #ifdef CONFIG_PM_DEVICE
 	int rc;
 
-	if (ictx.uart_on) {
+	if (iface_ctx.uart_on) {
 		HL7800_IO_DBG_LOG("Power OFF the UART");
-		uart_irq_rx_disable(ictx.mdm_ctx.uart_dev);
-		rc = pm_device_action_run(ictx.mdm_ctx.uart_dev, PM_DEVICE_ACTION_SUSPEND);
+		uart_irq_rx_disable(iface_ctx.mdm_ctx.uart_dev);
+		rc = pm_device_action_run(iface_ctx.mdm_ctx.uart_dev, PM_DEVICE_ACTION_SUSPEND);
 		if (rc) {
 			LOG_ERR("Error disabling UART peripheral (%d)", rc);
-			uart_irq_rx_enable(ictx.mdm_ctx.uart_dev);
+			uart_irq_rx_enable(iface_ctx.mdm_ctx.uart_dev);
 		} else {
-			ictx.uart_on = false;
+			iface_ctx.uart_on = false;
 		}
 	}
 #endif
@@ -4704,15 +4711,15 @@ static void power_on_uart(void)
 #ifdef CONFIG_PM_DEVICE
 	int rc;
 
-	if (!ictx.uart_on) {
+	if (!iface_ctx.uart_on) {
 		HL7800_IO_DBG_LOG("Power ON the UART");
-		rc = pm_device_action_run(ictx.mdm_ctx.uart_dev, PM_DEVICE_ACTION_RESUME);
+		rc = pm_device_action_run(iface_ctx.mdm_ctx.uart_dev, PM_DEVICE_ACTION_RESUME);
 		if (rc) {
 			LOG_ERR("Error enabling UART peripheral (%d)", rc);
-			uart_irq_rx_disable(ictx.mdm_ctx.uart_dev);
+			uart_irq_rx_disable(iface_ctx.mdm_ctx.uart_dev);
 		} else {
-			uart_irq_rx_enable(ictx.mdm_ctx.uart_dev);
-			ictx.uart_on = true;
+			uart_irq_rx_enable(iface_ctx.mdm_ctx.uart_dev);
+			iface_ctx.uart_on = true;
 		}
 	}
 #endif
@@ -4726,8 +4733,8 @@ static void prepare_io_for_reset(void)
 	modem_assert_wake(false);
 	modem_assert_pwr_on(false);
 	modem_assert_fast_shutd(false);
-	ictx.wait_for_KSUP = true;
-	ictx.wait_for_KSUP_tries = 0;
+	iface_ctx.wait_for_KSUP = true;
+	iface_ctx.wait_for_KSUP_tries = 0;
 }
 
 static void mdm_vgpio_work_cb(struct k_work *item)
@@ -4735,16 +4742,16 @@ static void mdm_vgpio_work_cb(struct k_work *item)
 	ARG_UNUSED(item);
 
 	hl7800_lock();
-	if (!ictx.vgpio_state) {
-		if (ictx.desired_sleep_level == HL7800_SLEEP_HIBERNATE ||
-		    ictx.desired_sleep_level == HL7800_SLEEP_LITE_HIBERNATE) {
-			if (ictx.sleep_state != ictx.desired_sleep_level) {
-				set_sleep_state(ictx.desired_sleep_level);
+	if (!iface_ctx.vgpio_state) {
+		if (iface_ctx.desired_sleep_level == HL7800_SLEEP_HIBERNATE ||
+		    iface_ctx.desired_sleep_level == HL7800_SLEEP_LITE_HIBERNATE) {
+			if (iface_ctx.sleep_state != iface_ctx.desired_sleep_level) {
+				set_sleep_state(iface_ctx.desired_sleep_level);
 			}
 		}
-		if (ictx.iface && ictx.initialized &&
-		    ictx.low_power_mode != HL7800_LPM_PSM) {
-			net_if_carrier_off(ictx.iface);
+		if (iface_ctx.iface && iface_ctx.initialized &&
+		    iface_ctx.low_power_mode != HL7800_LPM_PSM) {
+			net_if_carrier_off(iface_ctx.iface);
 		}
 	}
 	hl7800_unlock();
@@ -4753,16 +4760,16 @@ static void mdm_vgpio_work_cb(struct k_work *item)
 void mdm_vgpio_callback_isr(const struct device *port, struct gpio_callback *cb,
 			    uint32_t pins)
 {
-	ictx.vgpio_state = read_pin(1, &hl7800_cfg.gpio[MDM_VGPIO]);
-	HL7800_IO_DBG_LOG("VGPIO:%d", ictx.vgpio_state);
-	if (!ictx.vgpio_state) {
+	iface_ctx.vgpio_state = read_pin(1, &hl7800_cfg.gpio[MDM_VGPIO]);
+	HL7800_IO_DBG_LOG("VGPIO:%d", iface_ctx.vgpio_state);
+	if (!iface_ctx.vgpio_state) {
 		prepare_io_for_reset();
-		if (!ictx.restarting && ictx.initialized) {
-			ictx.reconfig_IP_connection = true;
+		if (!iface_ctx.restarting && iface_ctx.initialized) {
+			iface_ctx.reconfig_IP_connection = true;
 		}
 		check_hl7800_awake();
 	} else {
-		if (ictx.off) {
+		if (iface_ctx.off) {
 			return;
 		}
 		/* The peripheral must be enabled in ISR context
@@ -4782,14 +4789,14 @@ void mdm_vgpio_callback_isr(const struct device *port, struct gpio_callback *cb,
 	/* When the network state changes a semaphore must be taken.
 	 * This can't be done in interrupt context because the wait time != 0.
 	 */
-	k_work_submit_to_queue(&hl7800_workq, &ictx.mdm_vgpio_work);
+	k_work_submit_to_queue(&hl7800_workq, &iface_ctx.mdm_vgpio_work);
 }
 
 void mdm_uart_dsr_callback_isr(const struct device *port,
 			       struct gpio_callback *cb, uint32_t pins)
 {
-	ictx.dsr_state = read_pin(1, &hl7800_cfg.gpio[MDM_UART_DSR]);
-	HL7800_IO_DBG_LOG("MDM_UART_DSR:%d", ictx.dsr_state);
+	iface_ctx.dsr_state = read_pin(1, &hl7800_cfg.gpio[MDM_UART_DSR]);
+	HL7800_IO_DBG_LOG("MDM_UART_DSR:%d", iface_ctx.dsr_state);
 }
 
 #ifdef CONFIG_MODEM_HL7800_LOW_POWER_MODE
@@ -4799,7 +4806,7 @@ static void mark_sockets_for_reconfig(void)
 	struct hl7800_socket *sock = NULL;
 
 	for (i = 0; i < MDM_MAX_SOCKETS; i++) {
-		sock = &ictx.sockets[i];
+		sock = &iface_ctx.sockets[i];
 		if ((sock->context != NULL) && (sock->created)) {
 			/* mark socket as possibly needing re-configuration */
 			sock->reconfig = true;
@@ -4812,27 +4819,27 @@ void mdm_gpio6_callback_isr(const struct device *port, struct gpio_callback *cb,
 			    uint32_t pins)
 {
 #ifdef CONFIG_MODEM_HL7800_LOW_POWER_MODE
-	ictx.gpio6_state = read_pin(1, &hl7800_cfg.gpio[MDM_GPIO6]);
-	HL7800_IO_DBG_LOG("MDM_GPIO6:%d", ictx.gpio6_state);
-	if (!ictx.gpio6_state) {
+	iface_ctx.gpio6_state = read_pin(1, &hl7800_cfg.gpio[MDM_GPIO6]);
+	HL7800_IO_DBG_LOG("MDM_GPIO6:%d", iface_ctx.gpio6_state);
+	if (!iface_ctx.gpio6_state) {
 		/* HL7800 is not awake, shut down UART to save power */
 		shutdown_uart();
-		ictx.wait_for_KSUP = true;
-		ictx.wait_for_KSUP_tries = 0;
-		ictx.reconfig_IP_connection = true;
+		iface_ctx.wait_for_KSUP = true;
+		iface_ctx.wait_for_KSUP_tries = 0;
+		iface_ctx.reconfig_IP_connection = true;
 		mark_sockets_for_reconfig();
 		/* TODO: may need to indicate all TCP connections lost here */
 	} else {
-		if (ictx.off) {
+		if (iface_ctx.off) {
 			return;
 		}
 		power_on_uart();
 	}
 
-	if ((ictx.gpio6_callback != NULL) &&
-	    ((ictx.desired_sleep_level == HL7800_SLEEP_HIBERNATE) ||
-	     (ictx.desired_sleep_level == HL7800_SLEEP_LITE_HIBERNATE))) {
-		ictx.gpio6_callback(ictx.gpio6_state);
+	if ((iface_ctx.gpio6_callback != NULL) &&
+	    ((iface_ctx.desired_sleep_level == HL7800_SLEEP_HIBERNATE) ||
+	     (iface_ctx.desired_sleep_level == HL7800_SLEEP_LITE_HIBERNATE))) {
+		iface_ctx.gpio6_callback(iface_ctx.gpio6_state);
 	}
 
 	check_hl7800_awake();
@@ -4878,7 +4885,7 @@ void mdm_uart_cts_callback(const struct device *port, struct gpio_callback *cb, 
 	ARG_UNUSED(cb);
 	ARG_UNUSED(pins);
 
-	ictx.cts_state =
+	iface_ctx.cts_state =
 		glitch_filter(0, &hl7800_cfg.gpio[MDM_UART_CTS],
 			      CONFIG_MODEM_HL7800_CTS_FILTER_US,
 			      CONFIG_MODEM_HL7800_CTS_FILTER_MAX_ITERATIONS);
@@ -4886,25 +4893,26 @@ void mdm_uart_cts_callback(const struct device *port, struct gpio_callback *cb, 
 	/* CTS toggles A LOT,
 	 * comment out the debug print unless we really need it.
 	 */
-	/* HL7800_IO_DBG_LOG("MDM_UART_CTS:%d", ictx.cts_state); */
+	/* HL7800_IO_DBG_LOG("MDM_UART_CTS:%d", iface_ctx.cts_state); */
 
-	if ((ictx.cts_callback != NULL) && (ictx.desired_sleep_level == HL7800_SLEEP_SLEEP)) {
-		ictx.cts_callback(ictx.cts_state);
+	if ((iface_ctx.cts_callback != NULL) &&
+	    (iface_ctx.desired_sleep_level == HL7800_SLEEP_SLEEP)) {
+		iface_ctx.cts_callback(iface_ctx.cts_state);
 	}
 
 #ifdef CONFIG_MODEM_HL7800_LOW_POWER_MODE
-	if (ictx.cts_state) {
+	if (iface_ctx.cts_state) {
 		/* HL7800 is not awake, shut down UART to save power */
-		if (ictx.allow_sleep) {
+		if (iface_ctx.allow_sleep) {
 			shutdown_uart();
 		}
 	} else {
-		if (ictx.off) {
+		if (iface_ctx.off) {
 			return;
 		}
-		if (ictx.desired_sleep_level != HL7800_SLEEP_HIBERNATE) {
+		if (iface_ctx.desired_sleep_level != HL7800_SLEEP_HIBERNATE) {
 			power_on_uart();
-			if (ictx.sleep_state == HL7800_SLEEP_SLEEP) {
+			if (iface_ctx.sleep_state == HL7800_SLEEP_SLEEP) {
 				/* Wake up the modem to see if it has anything to send to us. */
 				allow_sleep(false);
 				/* Allow the modem to go back to sleep if it was the one who
@@ -4929,20 +4937,20 @@ static void modem_reset(void)
 	/* >20 milliseconds required for reset low */
 	k_sleep(MDM_RESET_LOW_TIME);
 
-	ictx.mdm_startup_reporting_on = false;
+	iface_ctx.mdm_startup_reporting_on = false;
 	set_sleep_state(HL7800_SLEEP_UNINITIALIZED);
 	check_hl7800_awake();
 	set_network_state(HL7800_NOT_REGISTERED);
 	set_startup_state(HL7800_STARTUP_STATE_UNKNOWN);
 #ifdef CONFIG_MODEM_HL7800_FW_UPDATE
-	if (ictx.fw_update_state == HL7800_FOTA_REBOOT_AND_RECONFIGURE) {
+	if (iface_ctx.fw_update_state == HL7800_FOTA_REBOOT_AND_RECONFIGURE) {
 		set_fota_state(HL7800_FOTA_COMPLETE);
 	} else {
 		set_fota_state(HL7800_FOTA_IDLE);
 	}
 #endif
-	k_sem_reset(&ictx.mdm_awake);
-	ictx.off = true;
+	k_sem_reset(&iface_ctx.mdm_awake);
+	iface_ctx.off = true;
 }
 
 static void modem_run(void)
@@ -4950,7 +4958,7 @@ static void modem_run(void)
 	LOG_INF("Modem Run");
 	gpio_pin_set_dt(&hl7800_cfg.gpio[MDM_RESET], 0);
 	k_sleep(MDM_RESET_HIGH_TIME);
-	ictx.off = false;
+	iface_ctx.off = false;
 	allow_sleep(false);
 }
 
@@ -4959,10 +4967,10 @@ static int modem_boot_handler(char *reason)
 	int ret;
 
 	LOG_DBG("%s", reason);
-	ret = k_sem_take(&ictx.mdm_awake, MDM_BOOT_TIME);
+	ret = k_sem_take(&iface_ctx.mdm_awake, MDM_BOOT_TIME);
 	if (ret) {
 		LOG_ERR("Err waiting for boot: %d, DSR: %u", ret,
-			ictx.dsr_state);
+			iface_ctx.dsr_state);
 		return -1;
 	} else {
 		LOG_INF("Modem booted!");
@@ -4977,10 +4985,10 @@ static int modem_boot_handler(char *reason)
 	 * note: It wasn't clear how to read the
 	 * active profile so all 3 are read.
 	 */
-	ictx.mdm_echo_is_on = true;
+	iface_ctx.mdm_echo_is_on = true;
 	SEND_AT_CMD_EXPECT_OK("AT&V");
 
-	if (ictx.mdm_echo_is_on) {
+	if (iface_ctx.mdm_echo_is_on) {
 		/* Turn OFF echo (after boot/reset) because a profile
 		 * hasn't been saved yet
 		 */
@@ -4993,7 +5001,7 @@ static int modem_boot_handler(char *reason)
 		SEND_AT_CMD_EXPECT_OK("AT&V");
 	}
 
-	__ASSERT(!ictx.mdm_echo_is_on, "Echo should be off");
+	__ASSERT(!iface_ctx.mdm_echo_is_on, "Echo should be off");
 
 	return 0;
 
@@ -5069,7 +5077,7 @@ static int set_bands(const char *bands, bool full_reboot)
 	int ret;
 	char cmd[sizeof("AT+KBNDCFG=#,####################")];
 
-	snprintk(cmd, sizeof(cmd), "AT+KBNDCFG=%d,%s", ictx.mdm_rat, bands);
+	snprintk(cmd, sizeof(cmd), "AT+KBNDCFG=%d,%s", iface_ctx.mdm_rat, bands);
 	ret = send_at_cmd(NULL, cmd, MDM_CMD_SEND_TIMEOUT, MDM_DEFAULT_AT_CMD_RETRIES, false);
 	if (ret < 0) {
 		return ret;
@@ -5084,7 +5092,7 @@ static int set_bands(const char *bands, bool full_reboot)
 
 		ret = modem_boot_handler("LTE bands were just set");
 	} else {
-		k_work_reschedule_for_queue(&hl7800_workq, &ictx.mdm_reset_work, K_NO_WAIT);
+		k_work_reschedule_for_queue(&hl7800_workq, &iface_ctx.mdm_reset_work, K_NO_WAIT);
 	}
 	return ret;
 }
@@ -5113,7 +5121,7 @@ int32_t mdm_hl7800_set_bands(const char *bands)
 	}
 
 	/* no need to set bands if settings match */
-	if (strncmp(temp_bands, ictx.mdm_bands_string, sizeof(temp_bands)) == 0) {
+	if (strncmp(temp_bands, iface_ctx.mdm_bands_string, sizeof(temp_bands)) == 0) {
 		return 0;
 	}
 
@@ -5145,10 +5153,10 @@ static int modem_reset_and_configure(void)
 		"\",\"" CONFIG_MODEM_HL7800_PSM_ACTIVE_TIME "\"";
 #endif
 
-	ictx.restarting = true;
-	ictx.dns_ready = false;
-	if (ictx.iface) {
-		net_if_carrier_off(ictx.iface);
+	iface_ctx.restarting = true;
+	iface_ctx.dns_ready = false;
+	if (iface_ctx.iface) {
+		net_if_carrier_off(iface_ctx.iface);
 	}
 
 	hl7800_stop_rssi_work();
@@ -5157,7 +5165,7 @@ reboot:
 	modem_reset();
 	modem_run();
 	ret = modem_boot_handler("Initialization");
-	if (!ictx.mdm_startup_reporting_on) {
+	if (!iface_ctx.mdm_startup_reporting_on) {
 		/* Turn on mobile start-up reporting for next reset.
 		 * It will indicate if SIM is present.
 		 * Its value is saved in non-volatile memory on the HL7800.
@@ -5175,11 +5183,11 @@ reboot:
 	SEND_COMPLEX_AT_CMD("AT+CGMR");
 
 	/* determine RAT command support */
-	ret = compare_versions(ictx.mdm_revision, NEW_RAT_CMD_MIN_VERSION);
+	ret = compare_versions(iface_ctx.mdm_revision, NEW_RAT_CMD_MIN_VERSION);
 	if (ret < 0) {
-		ictx.new_rat_cmd_support = false;
+		iface_ctx.new_rat_cmd_support = false;
 	} else {
-		ictx.new_rat_cmd_support = true;
+		iface_ctx.new_rat_cmd_support = true;
 	}
 
 	/* Query current Radio Access Technology (RAT) */
@@ -5187,14 +5195,14 @@ reboot:
 
 	/* If CONFIG_MODEM_HL7800_RAT_M1 or CONFIG_MODEM_HL7800_RAT_NB1, then
 	 * set the radio mode. This is only done here if the driver has not been
-	 * initialized (!ictx.configured) yet because the public API also
+	 * initialized (!iface_ctx.configured) yet because the public API also
 	 * allows the RAT to be changed (and will reset the modem).
 	 */
 #ifndef CONFIG_MODEM_HL7800_RAT_NO_CHANGE
-	if (!ictx.configured) {
+	if (!iface_ctx.configured) {
 #if CONFIG_MODEM_HL7800_RAT_M1
-		if (ictx.mdm_rat != MDM_RAT_CAT_M1) {
-			if (ictx.new_rat_cmd_support) {
+		if (iface_ctx.mdm_rat != MDM_RAT_CAT_M1) {
+			if (iface_ctx.new_rat_cmd_support) {
 				SEND_AT_CMD_ONCE_EXPECT_OK(SET_RAT_M1_CMD);
 			} else {
 				SEND_AT_CMD_ONCE_EXPECT_OK(
@@ -5205,8 +5213,8 @@ reboot:
 			}
 		}
 #elif CONFIG_MODEM_HL7800_RAT_NB1
-		if (ictx.mdm_rat != MDM_RAT_CAT_NB1) {
-			if (ictx.new_rat_cmd_support) {
+		if (iface_ctx.mdm_rat != MDM_RAT_CAT_NB1) {
+			if (iface_ctx.new_rat_cmd_support) {
 				SEND_AT_CMD_ONCE_EXPECT_OK(SET_RAT_NB1_CMD);
 			} else {
 				SEND_AT_CMD_ONCE_EXPECT_OK(
@@ -5294,20 +5302,20 @@ reboot:
 #endif
 
 	/* Check if bands are configured correctly */
-	if (ictx.mdm_bands_top != bands_top ||
-	    ictx.mdm_bands_middle != bands_middle ||
-	    ictx.mdm_bands_bottom != bands_bottom) {
-		if (ictx.mdm_bands_top != bands_top) {
+	if (iface_ctx.mdm_bands_top != bands_top ||
+	    iface_ctx.mdm_bands_middle != bands_middle ||
+	    iface_ctx.mdm_bands_bottom != bands_bottom) {
+		if (iface_ctx.mdm_bands_top != bands_top) {
 			LOG_INF("Top band mismatch, want %04x got %04x",
-				bands_top, ictx.mdm_bands_top);
+				bands_top, iface_ctx.mdm_bands_top);
 		}
-		if (ictx.mdm_bands_middle != bands_middle) {
+		if (iface_ctx.mdm_bands_middle != bands_middle) {
 			LOG_INF("Middle band mismatch, want %08x got %08x",
-				bands_middle, ictx.mdm_bands_middle);
+				bands_middle, iface_ctx.mdm_bands_middle);
 		}
-		if (ictx.mdm_bands_bottom != bands_bottom) {
+		if (iface_ctx.mdm_bands_bottom != bands_bottom) {
 			LOG_INF("Bottom band mismatch, want %08x got %08x",
-				bands_bottom, ictx.mdm_bands_bottom);
+				bands_bottom, iface_ctx.mdm_bands_bottom);
 		}
 
 		snprintk(new_bands, sizeof(new_bands),
@@ -5322,7 +5330,7 @@ reboot:
 	}
 #endif
 
-	ictx.low_power_mode = HL7800_LPM_NONE;
+	iface_ctx.low_power_mode = HL7800_LPM_NONE;
 #ifdef CONFIG_MODEM_HL7800_LOW_POWER_MODE
 	/* enable GPIO6 low power monitoring */
 	SEND_AT_CMD_EXPECT_OK("AT+KHWIOCFG=3,1,6");
@@ -5334,18 +5342,18 @@ reboot:
 	}
 
 #if CONFIG_MODEM_HL7800_PSM
-	ictx.low_power_mode = HL7800_LPM_PSM;
+	iface_ctx.low_power_mode = HL7800_LPM_PSM;
 	/* Turn off eDRX */
 	SEND_AT_CMD_EXPECT_OK("AT+CEDRXS=0");
 
 	SEND_AT_CMD_EXPECT_OK(TURN_ON_PSM);
 #elif CONFIG_MODEM_HL7800_EDRX
-	ictx.low_power_mode = HL7800_LPM_EDRX;
+	iface_ctx.low_power_mode = HL7800_LPM_EDRX;
 	/* Turn off PSM */
 	SEND_AT_CMD_EXPECT_OK("AT+CPSMS=0");
 
 	/* turn on eDRX */
-	if (ictx.mdm_rat == MDM_RAT_CAT_NB1) {
+	if (iface_ctx.mdm_rat == MDM_RAT_CAT_NB1) {
 		edrx_act_type = 5;
 	} else {
 		edrx_act_type = 4;
@@ -5378,7 +5386,7 @@ reboot:
 	/* query modem serial number */
 	SEND_COMPLEX_AT_CMD("AT+KGSN=3");
 
-	if (ictx.mdm_startup_state != HL7800_STARTUP_STATE_SIM_NOT_PRESENT) {
+	if (iface_ctx.mdm_startup_state != HL7800_STARTUP_STATE_SIM_NOT_PRESENT) {
 		/* query SIM ICCID */
 		SEND_AT_CMD_IGNORE_ERROR("AT+CCID?");
 
@@ -5389,15 +5397,15 @@ reboot:
 
 	/* Query PDP context to get APN */
 	SEND_AT_CMD_EXPECT_OK("AT+CGDCONT?");
-	if (strcmp(ictx.mdm_pdp_addr_fam, MODEM_HL7800_ADDRESS_FAMILY)) {
+	if (strcmp(iface_ctx.mdm_pdp_addr_fam, MODEM_HL7800_ADDRESS_FAMILY)) {
 		/* set PDP context address family along with current APN */
-		ret = write_apn(ictx.mdm_apn.value);
+		ret = write_apn(iface_ctx.mdm_apn.value);
 		if (ret < 0) {
 			goto error;
 		}
 	}
 
-	ret = setup_gprs_connection(ictx.mdm_apn.value);
+	ret = setup_gprs_connection(iface_ctx.mdm_apn.value);
 	if (ret < 0) {
 		goto error;
 	}
@@ -5409,8 +5417,8 @@ reboot:
 	SEND_AT_CMD_IGNORE_ERROR("AT+WPPP?");
 
 #if CONFIG_MODEM_HL7800_SET_APN_NAME_ON_STARTUP
-	if (!ictx.configured) {
-		if (strncmp(ictx.mdm_apn.value, CONFIG_MODEM_HL7800_APN_NAME,
+	if (!iface_ctx.configured) {
+		if (strncmp(iface_ctx.mdm_apn.value, CONFIG_MODEM_HL7800_APN_NAME,
 			    MDM_HL7800_APN_MAX_STRLEN) != 0) {
 			ret = write_apn(CONFIG_MODEM_HL7800_APN_NAME);
 			if (ret < 0) {
@@ -5438,20 +5446,20 @@ reboot:
 	 * started in the CEREG message handler.
 	 */
 	LOG_INF("Modem ready!");
-	ictx.restarting = false;
-	ictx.configured = true;
+	iface_ctx.restarting = false;
+	iface_ctx.configured = true;
 	allow_sleep(sleep);
 	/* trigger APN update event */
-	event_handler(HL7800_EVENT_APN_UPDATE, &ictx.mdm_apn);
+	event_handler(HL7800_EVENT_APN_UPDATE, &iface_ctx.mdm_apn);
 
 #ifdef CONFIG_MODEM_HL7800_BOOT_DELAY
-	if (!ictx.initialized) {
-		if (ictx.iface != NULL) {
-			hl7800_build_mac(&ictx);
-			net_if_set_link_addr(ictx.iface, ictx.mac_addr,
-					     sizeof(ictx.mac_addr),
+	if (!iface_ctx.initialized) {
+		if (iface_ctx.iface != NULL) {
+			hl7800_build_mac(&iface_ctx);
+			net_if_set_link_addr(iface_ctx.iface, iface_ctx.mac_addr,
+					     sizeof(iface_ctx.mac_addr),
 					     NET_LINK_ETHERNET);
-			ictx.initialized = true;
+			iface_ctx.initialized = true;
 		}
 	}
 #endif
@@ -5460,7 +5468,7 @@ reboot:
 
 error:
 	LOG_ERR("Unable to configure modem");
-	ictx.configured = false;
+	iface_ctx.configured = false;
 	set_network_state(HL7800_UNABLE_TO_CONFIGURE);
 	/* Kernel will fault with non-zero return value.
 	 * Allow other parts of application to run when modem cannot be configured.
@@ -5527,12 +5535,12 @@ static void mdm_power_off_work_callback(struct k_work *item)
 		return;
 	}
 	prepare_io_for_reset();
-	ictx.dns_ready = false;
-	ictx.configured = false;
-	ictx.off = true;
+	iface_ctx.dns_ready = false;
+	iface_ctx.configured = false;
+	iface_ctx.off = true;
 	/* bring the iface down */
-	if (ictx.iface) {
-		net_if_carrier_off(ictx.iface);
+	if (iface_ctx.iface) {
+		net_if_carrier_off(iface_ctx.iface);
 	}
 	LOG_INF("Modem powered off");
 
@@ -5544,12 +5552,12 @@ static int hl7800_power_off(void)
 	LOG_INF("Powering off modem");
 	wakeup_hl7800();
 	hl7800_stop_rssi_work();
-	k_work_cancel_delayable(&ictx.iface_status_work);
-	k_work_cancel_delayable(&ictx.dns_work);
-	k_work_cancel_delayable(&ictx.mdm_reset_work);
-	k_work_cancel_delayable(&ictx.allow_sleep_work);
-	k_work_cancel_delayable(&ictx.delete_untracked_socket_work);
-	(void)k_work_submit_to_queue(&hl7800_workq, &ictx.mdm_pwr_off_work);
+	k_work_cancel_delayable(&iface_ctx.iface_status_work);
+	k_work_cancel_delayable(&iface_ctx.dns_work);
+	k_work_cancel_delayable(&iface_ctx.mdm_reset_work);
+	k_work_cancel_delayable(&iface_ctx.allow_sleep_work);
+	k_work_cancel_delayable(&iface_ctx.delete_untracked_socket_work);
+	(void)k_work_submit_to_queue(&hl7800_workq, &iface_ctx.mdm_pwr_off_work);
 
 	return 0;
 }
@@ -5721,11 +5729,11 @@ static int reconfigure_IP_connection(void)
 {
 	int ret = 0;
 
-	if (ictx.reconfig_IP_connection) {
-		ictx.reconfig_IP_connection = false;
+	if (iface_ctx.reconfig_IP_connection) {
+		iface_ctx.reconfig_IP_connection = false;
 
 		/* reconfigure GPRS connection so sockets can be used */
-		ret = setup_gprs_connection(ictx.mdm_apn.value);
+		ret = setup_gprs_connection(iface_ctx.mdm_apn.value);
 		if (ret < 0) {
 			LOG_ERR("AT+KCNXCFG= ret:%d", ret);
 			goto done;
@@ -5761,7 +5769,7 @@ static int offload_get(sa_family_t family, enum net_sock_type type,
 
 	(*context)->offload_context = sock;
 	/* set the context iface index to our iface */
-	(*context)->iface = net_if_get_by_iface(ictx.iface);
+	(*context)->iface = net_if_get_by_iface(iface_ctx.iface);
 	sock->family = family;
 	sock->type = type;
 	sock->ip_proto = ip_proto;
@@ -6133,7 +6141,7 @@ int32_t mdm_hl7800_update_fw(char *file_path)
 		goto err;
 	}
 
-	ret = fs_open(&ictx.fw_update_file, file_path, FS_O_READ);
+	ret = fs_open(&iface_ctx.fw_update_file, file_path, FS_O_READ);
 	if (ret < 0) {
 		LOG_ERR("%s open err: %d", file_path, ret);
 		goto err;
@@ -6147,15 +6155,15 @@ int32_t mdm_hl7800_update_fw(char *file_path)
 
 	notify_all_tcp_sockets_closed();
 	hl7800_stop_rssi_work();
-	k_work_cancel_delayable(&ictx.iface_status_work);
-	k_work_cancel_delayable(&ictx.dns_work);
-	k_work_cancel_delayable(&ictx.mdm_reset_work);
-	k_work_cancel_delayable(&ictx.allow_sleep_work);
-	k_work_cancel_delayable(&ictx.delete_untracked_socket_work);
-	ictx.dns_ready = false;
-	if (ictx.iface) {
+	k_work_cancel_delayable(&iface_ctx.iface_status_work);
+	k_work_cancel_delayable(&iface_ctx.dns_work);
+	k_work_cancel_delayable(&iface_ctx.mdm_reset_work);
+	k_work_cancel_delayable(&iface_ctx.allow_sleep_work);
+	k_work_cancel_delayable(&iface_ctx.delete_untracked_socket_work);
+	iface_ctx.dns_ready = false;
+	if (iface_ctx.iface) {
 		LOG_DBG("HL7800 iface DOWN");
-		net_if_carrier_off(ictx.iface);
+		net_if_carrier_off(iface_ctx.iface);
 	}
 
 	/* HL7800 will stay locked for the duration of the FW update */
@@ -6187,27 +6195,27 @@ static int hl7800_init(const struct device *dev)
 	 * the modem has been initialized
 	 * because the modem may not have a valid SIM card.
 	 */
-	ictx.iface = net_if_get_default();
-	if (ictx.iface == NULL) {
+	iface_ctx.iface = net_if_get_default();
+	if (iface_ctx.iface == NULL) {
 		return -EIO;
 	}
 
-	net_if_carrier_off(ictx.iface);
+	net_if_carrier_off(iface_ctx.iface);
 
 	/* init sockets */
 	for (i = 0; i < MDM_MAX_SOCKETS; i++) {
-		ictx.sockets[i].socket_id = -1;
-		k_work_init(&ictx.sockets[i].recv_cb_work,
+		iface_ctx.sockets[i].socket_id = -1;
+		k_work_init(&iface_ctx.sockets[i].recv_cb_work,
 			    sockreadrecv_cb_work);
-		k_work_init(&ictx.sockets[i].rx_data_work,
+		k_work_init(&iface_ctx.sockets[i].rx_data_work,
 			    sock_rx_data_cb_work);
-		k_work_init_delayable(&ictx.sockets[i].notif_work,
+		k_work_init_delayable(&iface_ctx.sockets[i].notif_work,
 				      sock_notif_cb_work);
-		k_sem_init(&ictx.sockets[i].sock_send_sem, 0, 1);
+		k_sem_init(&iface_ctx.sockets[i].sock_send_sem, 0, 1);
 	}
-	ictx.last_socket_id = 0;
-	k_sem_init(&ictx.response_sem, 0, 1);
-	k_sem_init(&ictx.mdm_awake, 0, 1);
+	iface_ctx.last_socket_id = 0;
+	k_sem_init(&iface_ctx.response_sem, 0, 1);
+	k_sem_init(&iface_ctx.mdm_awake, 0, 1);
 
 	/* initialize the work queue */
 	k_work_queue_start(&hl7800_workq, hl7800_workq_stack,
@@ -6215,24 +6223,25 @@ static int hl7800_init(const struct device *dev)
 			   WORKQ_PRIORITY, &cfg);
 
 	/* init work tasks */
-	k_work_init_delayable(&ictx.rssi_query_work, hl7800_rssi_query_work);
-	k_work_init_delayable(&ictx.iface_status_work, iface_status_work_cb);
-	k_work_init_delayable(&ictx.dns_work, dns_work_cb);
-	k_work_init(&ictx.mdm_vgpio_work, mdm_vgpio_work_cb);
-	k_work_init_delayable(&ictx.mdm_reset_work, mdm_reset_work_callback);
-	k_work_init_delayable(&ictx.allow_sleep_work,
+	k_work_init_delayable(&iface_ctx.rssi_query_work, hl7800_rssi_query_work);
+	k_work_init_delayable(&iface_ctx.iface_status_work, iface_status_work_cb);
+	k_work_init_delayable(&iface_ctx.dns_work, dns_work_cb);
+	k_work_init(&iface_ctx.mdm_vgpio_work, mdm_vgpio_work_cb);
+	k_work_init_delayable(&iface_ctx.mdm_reset_work, mdm_reset_work_callback);
+	k_work_init_delayable(&iface_ctx.allow_sleep_work,
 			      allow_sleep_work_callback);
-	k_work_init_delayable(&ictx.delete_untracked_socket_work, delete_untracked_socket_work_cb);
-	k_work_init(&ictx.mdm_pwr_off_work, mdm_power_off_work_callback);
+	k_work_init_delayable(&iface_ctx.delete_untracked_socket_work,
+			      delete_untracked_socket_work_cb);
+	k_work_init(&iface_ctx.mdm_pwr_off_work, mdm_power_off_work_callback);
 
 #ifdef CONFIG_MODEM_HL7800_GPS
-	k_work_init_delayable(&ictx.gps_work, gps_work_callback);
+	k_work_init_delayable(&iface_ctx.gps_work, gps_work_callback);
 #endif
 
 #ifdef CONFIG_MODEM_HL7800_FW_UPDATE
-	k_work_init(&ictx.finish_fw_update_work,
+	k_work_init(&iface_ctx.finish_fw_update_work,
 		    finish_fw_update_work_callback);
-	ictx.fw_updated = false;
+	iface_ctx.fw_updated = false;
 #endif
 
 	/* setup port devices and pin directions */
@@ -6301,7 +6310,7 @@ static int hl7800_init(const struct device *dev)
 	}
 
 	/* when this driver starts, the UART peripheral is already enabled */
-	ictx.uart_on = true;
+	iface_ctx.uart_on = true;
 
 	modem_assert_wake(false);
 	modem_assert_pwr_on(false);
@@ -6315,10 +6324,10 @@ static int hl7800_init(const struct device *dev)
 
 	/* setup input pin callbacks */
 	/* VGPIO */
-	gpio_init_callback(&ictx.mdm_vgpio_cb, mdm_vgpio_callback_isr,
+	gpio_init_callback(&iface_ctx.mdm_vgpio_cb, mdm_vgpio_callback_isr,
 			   BIT(hl7800_cfg.gpio[MDM_VGPIO].pin));
 	ret = gpio_add_callback(hl7800_cfg.gpio[MDM_VGPIO].port,
-				&ictx.mdm_vgpio_cb);
+				&iface_ctx.mdm_vgpio_cb);
 	if (ret) {
 		LOG_ERR("Cannot setup vgpio callback! (%d)", ret);
 		return ret;
@@ -6330,10 +6339,10 @@ static int hl7800_init(const struct device *dev)
 	}
 
 	/* UART DSR */
-	gpio_init_callback(&ictx.mdm_uart_dsr_cb, mdm_uart_dsr_callback_isr,
+	gpio_init_callback(&iface_ctx.mdm_uart_dsr_cb, mdm_uart_dsr_callback_isr,
 			   BIT(hl7800_cfg.gpio[MDM_UART_DSR].pin));
 	ret = gpio_add_callback(hl7800_cfg.gpio[MDM_UART_DSR].port,
-				&ictx.mdm_uart_dsr_cb);
+				&iface_ctx.mdm_uart_dsr_cb);
 	if (ret) {
 		LOG_ERR("Cannot setup uart dsr callback! (%d)", ret);
 		return ret;
@@ -6345,10 +6354,10 @@ static int hl7800_init(const struct device *dev)
 	}
 
 	/* GPIO6 */
-	gpio_init_callback(&ictx.mdm_gpio6_cb, mdm_gpio6_callback_isr,
+	gpio_init_callback(&iface_ctx.mdm_gpio6_cb, mdm_gpio6_callback_isr,
 			   BIT(hl7800_cfg.gpio[MDM_GPIO6].pin));
 	ret = gpio_add_callback(hl7800_cfg.gpio[MDM_GPIO6].port,
-				&ictx.mdm_gpio6_cb);
+				&iface_ctx.mdm_gpio6_cb);
 	if (ret) {
 		LOG_ERR("Cannot setup gpio6 callback! (%d)", ret);
 		return ret;
@@ -6360,10 +6369,10 @@ static int hl7800_init(const struct device *dev)
 	}
 
 	/* UART CTS */
-	gpio_init_callback(&ictx.mdm_uart_cts_cb, mdm_uart_cts_callback,
+	gpio_init_callback(&iface_ctx.mdm_uart_cts_cb, mdm_uart_cts_callback,
 			   BIT(hl7800_cfg.gpio[MDM_UART_CTS].pin));
 	ret = gpio_add_callback(hl7800_cfg.gpio[MDM_UART_CTS].port,
-				&ictx.mdm_uart_cts_cb);
+				&iface_ctx.mdm_uart_cts_cb);
 	if (ret) {
 		LOG_ERR("Cannot setup uart cts callback! (%d)", ret);
 		return ret;
@@ -6375,22 +6384,22 @@ static int hl7800_init(const struct device *dev)
 	}
 
 	/* Set modem data storage */
-	ictx.mdm_ctx.data_manufacturer = ictx.mdm_manufacturer;
-	ictx.mdm_ctx.data_model = ictx.mdm_model;
-	ictx.mdm_ctx.data_revision = ictx.mdm_revision;
+	iface_ctx.mdm_ctx.data_manufacturer = iface_ctx.mdm_manufacturer;
+	iface_ctx.mdm_ctx.data_model = iface_ctx.mdm_model;
+	iface_ctx.mdm_ctx.data_revision = iface_ctx.mdm_revision;
 #ifdef CONFIG_MODEM_SIM_NUMBERS
-	ictx.mdm_ctx.data_imei = ictx.mdm_imei;
+	iface_ctx.mdm_ctx.data_imei = iface_ctx.mdm_imei;
 #endif
-	ictx.mdm_ctx.data_rssi = &ictx.mdm_rssi;
+	iface_ctx.mdm_ctx.data_rssi = &iface_ctx.mdm_rssi;
 
-	ret = mdm_receiver_register(&ictx.mdm_ctx, MDM_UART_DEV,
+	ret = mdm_receiver_register(&iface_ctx.mdm_ctx, MDM_UART_DEV,
 				    mdm_recv_buf, sizeof(mdm_recv_buf));
 	if (ret < 0) {
 		LOG_ERR("Error registering modem receiver (%d)!", ret);
 		return ret;
 	}
 
-	k_queue_init(&ictx.stale_socket_queue);
+	k_queue_init(&iface_ctx.stale_socket_queue);
 
 	/* start RX thread */
 	k_thread_name_set(
@@ -6418,10 +6427,10 @@ static void offload_iface_init(struct net_if *iface)
 	ctx->iface = iface;
 
 	if (!IS_ENABLED(CONFIG_MODEM_HL7800_BOOT_DELAY)) {
-		hl7800_build_mac(&ictx);
-		net_if_set_link_addr(iface, ictx.mac_addr, sizeof(ictx.mac_addr),
+		hl7800_build_mac(&iface_ctx);
+		net_if_set_link_addr(iface, iface_ctx.mac_addr, sizeof(iface_ctx.mac_addr),
 				     NET_LINK_ETHERNET);
-		ictx.initialized = true;
+		iface_ctx.initialized = true;
 	}
 }
 
@@ -6429,6 +6438,6 @@ static struct offloaded_if_api api_funcs = {
 	.iface_api.init = offload_iface_init,
 };
 
-NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, hl7800_init, NULL, &ictx,
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, hl7800_init, NULL, &iface_ctx,
 				  &hl7800_cfg, CONFIG_MODEM_HL7800_INIT_PRIORITY,
 				  &api_funcs, MDM_MTU);

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -1413,39 +1413,39 @@ static int create_socket(struct modem_socket *sock, const struct sockaddr *addr)
 	}
 
 	if (sock->ip_proto == IPPROTO_TLS_1_2) {
-		char buf[sizeof("AT+USECPRF=#,#,#######\r")];
+		char atbuf[sizeof("AT+USECPRF=#,#,#######\r")];
 
 		/* Enable socket security */
-		snprintk(buf, sizeof(buf), "AT+USOSEC=%d,1,%d", sock->id, sock->id);
-		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0U, buf,
+		snprintk(atbuf, sizeof(atbuf), "AT+USOSEC=%d,1,%d", sock->id, sock->id);
+		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0U, atbuf,
 				     &mdata.sem_response, MDM_CMD_TIMEOUT);
 		if (ret < 0) {
 			goto error;
 		}
 		/* Reset the security profile */
-		snprintk(buf, sizeof(buf), "AT+USECPRF=%d", sock->id);
-		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0U, buf,
+		snprintk(atbuf, sizeof(atbuf), "AT+USECPRF=%d", sock->id);
+		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0U, atbuf,
 				     &mdata.sem_response, MDM_CMD_TIMEOUT);
 		if (ret < 0) {
 			goto error;
 		}
 		/* Validate server cert against the CA.  */
-		snprintk(buf, sizeof(buf), "AT+USECPRF=%d,0,1", sock->id);
-		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0U, buf,
+		snprintk(atbuf, sizeof(atbuf), "AT+USECPRF=%d,0,1", sock->id);
+		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0U, atbuf,
 				     &mdata.sem_response, MDM_CMD_TIMEOUT);
 		if (ret < 0) {
 			goto error;
 		}
 		/* Use TLSv1.2 only */
-		snprintk(buf, sizeof(buf), "AT+USECPRF=%d,1,3", sock->id);
-		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0U, buf,
+		snprintk(atbuf, sizeof(atbuf), "AT+USECPRF=%d,1,3", sock->id);
+		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0U, atbuf,
 				     &mdata.sem_response, MDM_CMD_TIMEOUT);
 		if (ret < 0) {
 			goto error;
 		}
 		/* Set root CA filename */
-		snprintk(buf, sizeof(buf), "AT+USECPRF=%d,3,\"ca\"", sock->id);
-		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0U, buf,
+		snprintk(atbuf, sizeof(atbuf), "AT+USECPRF=%d,3,\"ca\"", sock->id);
+		ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0U, atbuf,
 				     &mdata.sem_response, MDM_CMD_TIMEOUT);
 		if (ret < 0) {
 			goto error;

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -314,20 +314,20 @@ static uint8_t *recv_cb(uint8_t *buf, size_t *off)
 		if (slip_input_byte(slip, buf[i])) {
 
 			if (LOG_LEVEL >= LOG_LEVEL_DBG) {
-				struct net_buf *buf = slip->rx->buffer;
-				int bytes = net_buf_frags_len(buf);
+				struct net_buf *rx_buf = slip->rx->buffer;
+				int bytes = net_buf_frags_len(rx_buf);
 				int count = 0;
 
-				while (bytes && buf) {
+				while (bytes && rx_buf) {
 					char msg[6 + 10 + 1];
 
 					snprintk(msg, sizeof(msg),
 						 ">slip %2d", count);
 
-					LOG_HEXDUMP_DBG(buf->data, buf->len,
+					LOG_HEXDUMP_DBG(rx_buf->data, rx_buf->len,
 							msg);
 
-					buf = buf->frags;
+					rx_buf = rx_buf->frags;
 					count++;
 				}
 

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3256,8 +3256,8 @@ bool net_if_ipv4_is_addr_bcast(struct net_if *iface,
 		goto out;
 	}
 
-	STRUCT_SECTION_FOREACH(net_if, iface) {
-		ret = ipv4_is_broadcast_address(iface, addr);
+	STRUCT_SECTION_FOREACH(net_if, one_iface) {
+		ret = ipv4_is_broadcast_address(one_iface, addr);
 		if (ret) {
 			goto out;
 		}

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -2974,14 +2974,14 @@ static void gptp_print_port_info(const struct shell *sh, int port)
 	struct gptp_port_bmca_data *port_bmca_data;
 	struct gptp_port_param_ds *port_param_ds;
 	struct gptp_port_states *port_state;
-	struct gptp_domain *gptp_domain;
+	struct gptp_domain *domain;
 	struct gptp_port_ds *port_ds;
 	struct net_if *iface;
 	int ret, i;
 
-	gptp_domain = gptp_get_domain();
+	domain = gptp_get_domain();
 
-	ret = gptp_get_port_data(gptp_domain,
+	ret = gptp_get_port_data(domain,
 				 port,
 				 &port_ds,
 				 &port_param_ds,
@@ -3080,10 +3080,10 @@ static void gptp_print_port_info(const struct shell *sh, int port)
 					(NSEC_PER_USEC * USEC_PER_MSEC));
 	PR("BMCA %s %s%d%s: %d\n", "default", "priority", 1,
 	   "                                        ",
-	   gptp_domain->default_ds.priority1);
+	   domain->default_ds.priority1);
 	PR("BMCA %s %s%d%s: %d\n", "default", "priority", 2,
 	   "                                        ",
-	   gptp_domain->default_ds.priority2);
+	   domain->default_ds.priority2);
 
 	PR("\nRuntime status:\n");
 	PR("Current global port state                          "

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -411,18 +411,18 @@ struct net_route_entry *net_route_add(struct net_if *iface,
 				     node);
 
 		if (CONFIG_NET_ROUTE_LOG_LEVEL >= LOG_LEVEL_DBG) {
-			struct in6_addr *tmp;
+			struct in6_addr *in6_addr_tmp;
 			struct net_linkaddr_storage *llstorage;
 
-			tmp = net_route_get_nexthop(route);
-			nbr = net_ipv6_nbr_lookup(iface, tmp);
+			in6_addr_tmp = net_route_get_nexthop(route);
+			nbr = net_ipv6_nbr_lookup(iface, in6_addr_tmp);
 			if (nbr) {
 				llstorage = net_nbr_get_lladdr(nbr->idx);
 
 				NET_DBG("Removing the oldest route %s "
 					"via %s [%s]",
 					net_sprint_ipv6_addr(&route->addr),
-					net_sprint_ipv6_addr(tmp),
+					net_sprint_ipv6_addr(in6_addr_tmp),
 					net_sprint_ll_addr(llstorage->addr,
 							   llstorage->len));
 			}

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -445,13 +445,13 @@ static bool eir_found(uint8_t type, const uint8_t *data, uint8_t data_len,
 	return false;
 }
 
-static bool ad_parse(struct net_buf_simple *ad,
+static bool ad_parse(struct net_buf_simple *ad_buf,
 		     bool (*func)(uint8_t type, const uint8_t *data,
 				  uint8_t data_len, void *user_data),
 		     void *user_data)
 {
-	while (ad->len > 1) {
-		uint8_t len = net_buf_simple_pull_u8(ad);
+	while (ad_buf->len > 1) {
+		uint8_t len = net_buf_simple_pull_u8(ad_buf);
 		uint8_t type;
 
 		/* Check for early termination */
@@ -459,30 +459,30 @@ static bool ad_parse(struct net_buf_simple *ad,
 			return false;
 		}
 
-		if (len > ad->len) {
+		if (len > ad_buf->len) {
 			NET_ERR("AD malformed\n");
 			return false;
 		}
 
-		type = net_buf_simple_pull_u8(ad);
+		type = net_buf_simple_pull_u8(ad_buf);
 
-		if (func(type, ad->data, len - 1, user_data)) {
+		if (func(type, ad_buf->data, len - 1, user_data)) {
 			return true;
 		}
 
-		net_buf_simple_pull(ad, len - 1);
+		net_buf_simple_pull(ad_buf, len - 1);
 	}
 
 	return false;
 }
 
 static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
-			 struct net_buf_simple *ad)
+			 struct net_buf_simple *ad_buf)
 {
 	/* We're only interested in connectable events */
 	if (type == BT_GAP_ADV_TYPE_ADV_IND ||
 	    type == BT_GAP_ADV_TYPE_ADV_DIRECT_IND) {
-		ad_parse(ad, eir_found, (void *)addr);
+		ad_parse(ad_buf, eir_found, (void *)addr);
 	}
 }
 

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -478,28 +478,28 @@ static void arp_update(struct net_if *iface,
 
 		if (force) {
 			sys_snode_t *prev = NULL;
-			struct arp_entry *entry;
+			struct arp_entry *arp_ent;
 
-			entry = arp_entry_find(&arp_table, iface, src, &prev);
-			if (entry) {
-				memcpy(&entry->eth, hwaddr,
+			arp_ent = arp_entry_find(&arp_table, iface, src, &prev);
+			if (arp_ent) {
+				memcpy(&arp_ent->eth, hwaddr,
 				       sizeof(struct net_eth_addr));
 			} else {
 				/* Add new entry as it was not found and force
 				 * was set.
 				 */
-				entry = arp_entry_get_free();
-				if (!entry) {
+				arp_ent = arp_entry_get_free();
+				if (!arp_ent) {
 					/* Then let's take one from table? */
-					entry = arp_entry_get_last_from_table();
+					arp_ent = arp_entry_get_last_from_table();
 				}
 
-				if (entry) {
-					entry->req_start = k_uptime_get_32();
-					entry->iface = iface;
-					net_ipaddr_copy(&entry->ip, src);
-					memcpy(&entry->eth, hwaddr, sizeof(entry->eth));
-					sys_slist_prepend(&arp_table, &entry->node);
+				if (arp_ent) {
+					arp_ent->req_start = k_uptime_get_32();
+					arp_ent->iface = iface;
+					net_ipaddr_copy(&arp_ent->ip, src);
+					memcpy(&arp_ent->eth, hwaddr, sizeof(arp_ent->eth));
+					sys_slist_prepend(&arp_table, &arp_ent->node);
 				}
 			}
 		}

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -941,15 +941,15 @@ static void disable_port(int port)
 
 static void vlan_enabled(struct k_work *work)
 {
-	struct vlan_work *vlan = CONTAINER_OF(work,
-					      struct vlan_work,
-					      work);
+	struct vlan_work *one_vlan = CONTAINER_OF(work,
+						  struct vlan_work,
+						  work);
 	if (tid) {
 		int port;
 
-		port = gptp_get_port_number(vlan->iface);
+		port = gptp_get_port_number(one_vlan->iface);
 		if (port < 0) {
-			NET_DBG("No port found for iface %p", vlan->iface);
+			NET_DBG("No port found for iface %p", one_vlan->iface);
 			return;
 		}
 
@@ -963,14 +963,14 @@ static void vlan_enabled(struct k_work *work)
 
 static void vlan_disabled(struct k_work *work)
 {
-	struct vlan_work *vlan = CONTAINER_OF(work,
-					      struct vlan_work,
-					      work);
+	struct vlan_work *one_vlan = CONTAINER_OF(work,
+						  struct vlan_work,
+						  work);
 	int port;
 
-	port = gptp_get_port_number(vlan->iface);
+	port = gptp_get_port_number(one_vlan->iface);
 	if (port < 0) {
-		NET_DBG("No port found for iface %p", vlan->iface);
+		NET_DBG("No port found for iface %p", one_vlan->iface);
 		return;
 	}
 

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -26,9 +26,9 @@ static const struct net_eth_addr gptp_multicast_eth_addr = {
 
 #define NET_GPTP_INFO(msg, pkt)						\
 	if (CONFIG_NET_GPTP_LOG_LEVEL >= LOG_LEVEL_DBG) {		\
-		struct gptp_hdr *hdr = GPTP_HDR(pkt);			\
+		struct gptp_hdr *one_hdr = GPTP_HDR(pkt);		\
 									\
-		if (hdr->message_type == GPTP_ANNOUNCE_MESSAGE) {	\
+		if (one_hdr->message_type == GPTP_ANNOUNCE_MESSAGE) {	\
 			struct gptp_announce *ann = GPTP_ANNOUNCE(pkt);	\
 			char output[sizeof("xx:xx:xx:xx:xx:xx:xx:xx")];	\
 									\
@@ -39,7 +39,7 @@ static const struct net_eth_addr gptp_multicast_eth_addr = {
 									\
 			NET_DBG("Sending %s seq %d pkt %p",		\
 				msg,					\
-				ntohs(hdr->sequence_id), pkt);		\
+				ntohs(one_hdr->sequence_id), pkt);	\
 									\
 			NET_DBG("  GM %d/%d/0x%x/%d/%s",\
 				ann->root_system_id.grand_master_prio1, \
@@ -50,7 +50,7 @@ static const struct net_eth_addr gptp_multicast_eth_addr = {
 		} else {						\
 			NET_DBG("Sending %s seq %d pkt %p",		\
 				msg,					\
-				ntohs(hdr->sequence_id), pkt);		\
+				ntohs(one_hdr->sequence_id), pkt);	\
 		}							\
 	}
 

--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -267,7 +267,7 @@ static int lldp_start(struct net_if *iface, uint32_t mgmt_event)
 enum net_verdict net_lldp_recv(struct net_if *iface, struct net_pkt *pkt)
 {
 	struct ethernet_context *ctx;
-	net_lldp_recv_cb_t cb;
+	net_lldp_recv_cb_t recv_cb;
 	int ret;
 
 	ret = lldp_check_iface(iface);
@@ -282,15 +282,15 @@ enum net_verdict net_lldp_recv(struct net_if *iface, struct net_pkt *pkt)
 		return NET_DROP;
 	}
 
-	cb = ctx->lldp[ret].cb;
-	if (cb) {
-		return cb(iface, pkt);
+	recv_cb = ctx->lldp[ret].cb;
+	if (recv_cb) {
+		return recv_cb(iface, pkt);
 	}
 
 	return NET_DROP;
 }
 
-int net_lldp_register_callback(struct net_if *iface, net_lldp_recv_cb_t cb)
+int net_lldp_register_callback(struct net_if *iface, net_lldp_recv_cb_t recv_cb)
 {
 	struct ethernet_context *ctx;
 	int ret;
@@ -307,12 +307,12 @@ int net_lldp_register_callback(struct net_if *iface, net_lldp_recv_cb_t cb)
 		return ret;
 	}
 
-	ctx->lldp[ret].cb = cb;
+	ctx->lldp[ret].cb = recv_cb;
 
 	return 0;
 }
 
-static void iface_event_handler(struct net_mgmt_event_callback *cb,
+static void iface_event_handler(struct net_mgmt_event_callback *evt_cb,
 				uint32_t mgmt_event, struct net_if *iface)
 {
 	lldp_start(iface, mgmt_event);

--- a/subsys/net/l2/ppp/network.c
+++ b/subsys/net/l2/ppp/network.c
@@ -45,10 +45,10 @@ void ppp_network_done(struct ppp_context *ctx, int proto)
 {
 	ctx->network_protos_up--;
 	if (ctx->network_protos_up <= 0) {
-		const struct ppp_protocol_handler *proto = ppp_lcp_get();
+		const struct ppp_protocol_handler *ppp_proto = ppp_lcp_get();
 
-		if (proto) {
-			proto->close(ctx, "All networks down");
+		if (ppp_proto) {
+			ppp_proto->close(ctx, "All networks down");
 		}
 	}
 }

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -322,7 +322,6 @@ static void send_sd_response(struct net_context *ctx,
 			     struct net_buf *result)
 {
 	int ret;
-	const struct dns_sd_rec *record;
 	/* filter must be zero-initialized for "wildcard" port */
 	struct dns_sd_rec filter = {0};
 	struct sockaddr dst;
@@ -353,9 +352,6 @@ static void send_sd_response(struct net_context *ctx,
 	label[1] = service_buf;
 	label[2] = proto_buf;
 	label[3] = domain_buf;
-
-	/* This actually is used but the compiler doesn't see that */
-	ARG_UNUSED(record);
 
 	ret = setup_dst_addr(ctx, family, &dst, &dst_len);
 	if (ret < 0) {

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1075,7 +1075,7 @@ static void query_timeout(struct k_work *work)
 	 */
 	ret = k_mutex_lock(&pending_query->ctx->lock, K_NO_WAIT);
 	if (ret != 0) {
-		struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+		struct k_work_delayable *dwork2 = k_work_delayable_from_work(work);
 
 		/*
 		 * Reschedule query timeout handler with some delay, so that all
@@ -1085,7 +1085,7 @@ static void query_timeout(struct k_work *work)
 		 * Timeout value was arbitrarily chosen and can be updated in
 		 * future if needed.
 		 */
-		k_work_reschedule(dwork, K_MSEC(10));
+		k_work_reschedule(dwork2, K_MSEC(10));
 		return;
 	}
 

--- a/subsys/net/lib/lwm2m/ipso_buzzer.c
+++ b/subsys/net/lib/lwm2m/ipso_buzzer.c
@@ -58,7 +58,7 @@ struct ipso_buzzer_data {
 
 static struct ipso_buzzer_data buzzer_data[MAX_INSTANCE_COUNT];
 
-static struct lwm2m_engine_obj buzzer;
+static struct lwm2m_engine_obj ipso_buzzer;
 static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(ON_OFF_RID, RW, BOOL),
 	OBJ_FIELD_DATA(LEVEL_RID, RW_OPT, FLOAT),
@@ -169,8 +169,8 @@ static void buzzer_work_cb(struct k_work *work)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct ipso_buzzer_data *buzzer = CONTAINER_OF(dwork,
-						      struct ipso_buzzer_data,
-						      buzzer_work);
+						       struct ipso_buzzer_data,
+						       buzzer_work);
 	stop_buzzer(buzzer, false);
 }
 
@@ -245,15 +245,15 @@ static struct lwm2m_engine_obj_inst *buzzer_create(uint16_t obj_inst_id)
 
 static int ipso_buzzer_init(void)
 {
-	buzzer.obj_id = IPSO_OBJECT_BUZZER_ID;
-	buzzer.version_major = BUZZER_VERSION_MAJOR;
-	buzzer.version_minor = BUZZER_VERSION_MINOR;
-	buzzer.is_core = false;
-	buzzer.fields = fields;
-	buzzer.field_count = ARRAY_SIZE(fields);
-	buzzer.max_instance_count = ARRAY_SIZE(inst);
-	buzzer.create_cb = buzzer_create;
-	lwm2m_register_obj(&buzzer);
+	ipso_buzzer.obj_id = IPSO_OBJECT_BUZZER_ID;
+	ipso_buzzer.version_major = BUZZER_VERSION_MAJOR;
+	ipso_buzzer.version_minor = BUZZER_VERSION_MINOR;
+	ipso_buzzer.is_core = false;
+	ipso_buzzer.fields = fields;
+	ipso_buzzer.field_count = ARRAY_SIZE(fields);
+	ipso_buzzer.max_instance_count = ARRAY_SIZE(inst);
+	ipso_buzzer.create_cb = buzzer_create;
+	lwm2m_register_obj(&ipso_buzzer);
 
 	return 0;
 }

--- a/subsys/net/lib/lwm2m/ipso_timer.c
+++ b/subsys/net/lib/lwm2m/ipso_timer.c
@@ -65,7 +65,7 @@ struct ipso_timer_data {
 
 static struct ipso_timer_data timer_data[MAX_INSTANCE_COUNT];
 
-static struct lwm2m_engine_obj timer;
+static struct lwm2m_engine_obj ipso_timer;
 static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(DELAY_DURATION_RID, RW, FLOAT),
 	OBJ_FIELD_DATA(REMAINING_TIME_RID, R_OPT, FLOAT),
@@ -353,15 +353,15 @@ static struct lwm2m_engine_obj_inst *timer_inst_create(uint16_t obj_inst_id)
 
 static int ipso_timer_init(void)
 {
-	timer.obj_id = IPSO_OBJECT_TIMER_ID;
-	timer.version_major = TIMER_VERSION_MAJOR;
-	timer.version_minor = TIMER_VERSION_MINOR;
-	timer.is_core = false;
-	timer.fields = fields;
-	timer.field_count = ARRAY_SIZE(fields);
-	timer.max_instance_count = MAX_INSTANCE_COUNT;
-	timer.create_cb = timer_inst_create;
-	lwm2m_register_obj(&timer);
+	ipso_timer.obj_id = IPSO_OBJECT_TIMER_ID;
+	ipso_timer.version_major = TIMER_VERSION_MAJOR;
+	ipso_timer.version_minor = TIMER_VERSION_MINOR;
+	ipso_timer.is_core = false;
+	ipso_timer.fields = fields;
+	ipso_timer.field_count = ARRAY_SIZE(fields);
+	ipso_timer.max_instance_count = MAX_INSTANCE_COUNT;
+	ipso_timer.create_cb = timer_inst_create;
+	lwm2m_register_obj(&ipso_timer);
 
 	return 0;
 }

--- a/subsys/net/lib/mqtt_sn/mqtt_sn.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn.c
@@ -37,7 +37,7 @@ struct mqtt_sn_publish {
 	bool retain;
 };
 
-static struct mqtt_sn_publish pubs[CONFIG_MQTT_SN_LIB_MAX_PUBLISH];
+static struct mqtt_sn_publish mqtt_sn_pubs[CONFIG_MQTT_SN_LIB_MAX_PUBLISH];
 
 enum mqtt_sn_topic_state {
 	MQTT_SN_TOPIC_STATE_REGISTERING,
@@ -150,9 +150,9 @@ static struct mqtt_sn_publish *mqtt_sn_publish_find_empty(void)
 {
 	size_t i;
 
-	for (i = 0; i < ARRAY_SIZE(pubs); i++) {
-		if (!pubs[i].con.in_use) {
-			return &pubs[i];
+	for (i = 0; i < ARRAY_SIZE(mqtt_sn_pubs); i++) {
+		if (!mqtt_sn_pubs[i].con.in_use) {
+			return &mqtt_sn_pubs[i];
 		}
 	}
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -3151,12 +3151,12 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 	case F_SETFL: {
 		const struct fd_op_vtable *vtable;
 		struct k_mutex *lock;
-		void *obj;
+		void *fd_obj;
 		int ret;
 
-		obj = z_get_fd_obj_and_vtable(ctx->sock,
+		fd_obj = z_get_fd_obj_and_vtable(ctx->sock,
 				(const struct fd_op_vtable **)&vtable, &lock);
-		if (obj == NULL) {
+		if (fd_obj == NULL) {
 			errno = EBADF;
 			return -1;
 		}
@@ -3164,7 +3164,7 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 		(void)k_mutex_lock(lock, K_FOREVER);
 
 		/* Pass the call to the core socket implementation. */
-		ret = vtable->ioctl(obj, request, args);
+		ret = vtable->ioctl(fd_obj, request, args);
 
 		k_mutex_unlock(lock);
 

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -41,7 +41,7 @@ static struct net_eth_addr *expected_hwaddr;
 
 static struct net_pkt *pending_pkt;
 
-static struct net_eth_addr hwaddr = { { 0x42, 0x11, 0x69, 0xde, 0xfa, 0xec } };
+static struct net_eth_addr eth_hwaddr = { { 0x42, 0x11, 0x69, 0xde, 0xfa, 0xec } };
 
 static int send_status = -EINVAL;
 
@@ -107,7 +107,7 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 				return -EINVAL;
 			}
 
-			if (!req_test && memcmp(&hdr->dst, &hwaddr,
+			if (!req_test && memcmp(&hdr->dst, &eth_hwaddr,
 						sizeof(struct net_eth_addr))) {
 				char out[sizeof("xx:xx:xx:xx:xx:xx")];
 
@@ -118,14 +118,14 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 				printk("Invalid dst hwaddr %s, should be %s\n",
 				       out,
 				       net_sprint_ll_addr(
-					       (uint8_t *)&hwaddr,
+					       (uint8_t *)&eth_hwaddr,
 					       sizeof(struct net_eth_addr)));
 				send_status = -EINVAL;
 				return send_status;
 			}
 
 		} else if (ntohs(arp_hdr->opcode) == NET_ARP_REQUEST) {
-			if (memcmp(&hdr->src, &hwaddr,
+			if (memcmp(&hdr->src, &eth_hwaddr,
 				   sizeof(struct net_eth_addr))) {
 				char out[sizeof("xx:xx:xx:xx:xx:xx")];
 
@@ -136,7 +136,7 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 				printk("Invalid src hwaddr %s, should be %s\n",
 				       out,
 				       net_sprint_ll_addr(
-					       (uint8_t *)&hwaddr,
+					       (uint8_t *)&eth_hwaddr,
 					       sizeof(struct net_eth_addr)));
 				send_status = -EINVAL;
 				return send_status;
@@ -529,7 +529,7 @@ ZTEST(arp_fn_tests, test_arp)
 	net_ipv4_addr_copy_raw(arp_hdr->dst_ipaddr, (uint8_t *)&dst);
 	net_ipv4_addr_copy_raw(arp_hdr->src_ipaddr, (uint8_t *)&src);
 
-	pkt2 = prepare_arp_reply(iface, pkt, &hwaddr, &eth_hdr);
+	pkt2 = prepare_arp_reply(iface, pkt, &eth_hwaddr, &eth_hdr);
 
 	zassert_not_null(pkt2, "ARP reply generation failed.");
 
@@ -561,7 +561,7 @@ ZTEST(arp_fn_tests, test_arp)
 
 	send_status = -EINVAL;
 
-	setup_eth_header(iface, pkt, &hwaddr, NET_ETH_PTYPE_ARP);
+	setup_eth_header(iface, pkt, &eth_hwaddr, NET_ETH_PTYPE_ARP);
 
 	arp_hdr = (struct net_arp_hdr *)(pkt->buffer->data +
 					 (sizeof(struct net_eth_hdr)));
@@ -570,7 +570,7 @@ ZTEST(arp_fn_tests, test_arp)
 	net_ipv4_addr_copy_raw(arp_hdr->dst_ipaddr, (uint8_t *)&src);
 	net_ipv4_addr_copy_raw(arp_hdr->src_ipaddr, (uint8_t *)&dst);
 
-	pkt2 = prepare_arp_request(iface, pkt, &hwaddr, &eth_hdr);
+	pkt2 = prepare_arp_request(iface, pkt, &eth_hwaddr, &eth_hdr);
 
 	/**TESTPOINT: Check if ARP request generation failed*/
 	zassert_not_null(pkt2, "ARP request generation failed.");
@@ -602,7 +602,7 @@ ZTEST(arp_fn_tests, test_arp)
 
 		/* First make sure that we have an entry in cache */
 		entry_found = false;
-		expected_hwaddr = &hwaddr;
+		expected_hwaddr = &eth_hwaddr;
 		net_arp_foreach(arp_cb, &dst);
 		zassert_true(entry_found, "Entry not found");
 

--- a/tests/net/buf/src/main.c
+++ b/tests/net/buf/src/main.c
@@ -270,10 +270,10 @@ ZTEST(net_buf_tests, test_net_buf_4)
 	removed = 0;
 
 	while (buf->frags) {
-		struct net_buf *frag = buf->frags;
+		struct net_buf *frag2 = buf->frags;
 
-		net_buf_frag_del(buf, frag);
-		net_buf_unref(frag);
+		net_buf_frag_del(buf, frag2);
+		net_buf_unref(frag2);
 		removed++;
 	}
 

--- a/tests/net/icmpv4/src/main.c
+++ b/tests/net/icmpv4/src/main.c
@@ -112,7 +112,7 @@ static const unsigned char icmpv4_echo_req_opt_bad[] = {
 
 static uint8_t current = TEST_ICMPV4_UNKNOWN;
 static struct in_addr my_addr  = { { { 192, 0, 2, 1 } } };
-static struct net_if *iface;
+static struct net_if *net_iface;
 
 static enum net_verdict handle_reply_msg(struct net_pkt *pkt,
 					 struct net_ipv4_hdr *ip_hdr,
@@ -418,12 +418,12 @@ static void *icmpv4_setup(void)
 {
 	struct net_if_addr *ifaddr;
 
-	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
-	if (!iface) {
+	net_iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
+	if (!net_iface) {
 		zassert_true(false, "Interface not available");
 	}
 
-	ifaddr = net_if_ipv4_addr_add(iface, &my_addr, NET_ADDR_MANUAL, 0);
+	ifaddr = net_if_ipv4_addr_add(net_iface, &my_addr, NET_ADDR_MANUAL, 0);
 	if (!ifaddr) {
 		zassert_true(false, "Failed to add address");
 	}
@@ -434,9 +434,9 @@ static void icmpv4_teardown(void *dummy)
 {
 	ARG_UNUSED(dummy);
 
-	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
+	net_iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
 
-	net_if_ipv4_addr_rm(iface, &my_addr);
+	net_if_ipv4_addr_rm(net_iface, &my_addr);
 }
 
 static void icmpv4_send_echo_req(void)
@@ -445,7 +445,7 @@ static void icmpv4_send_echo_req(void)
 
 	current = TEST_ICMPV4_ECHO_REQ;
 
-	pkt = prepare_echo_request(iface);
+	pkt = prepare_echo_request(net_iface);
 	if (!pkt) {
 		zassert_true(false, "EchoRequest packet prep failed");
 	}
@@ -462,7 +462,7 @@ static void icmpv4_send_echo_rep(void)
 
 	net_icmpv4_register_handler(&echo_rep_handler);
 
-	pkt = prepare_echo_reply(iface);
+	pkt = prepare_echo_reply(net_iface);
 	if (!pkt) {
 		zassert_true(false, "EchoReply packet prep failed");
 	}
@@ -480,7 +480,7 @@ ZTEST(net_icmpv4, test_icmpv4_send_echo_req_opt)
 
 	current = TEST_ICMPV4_ECHO_REQ_OPTS;
 
-	pkt = prepare_echo_request_with_options(iface);
+	pkt = prepare_echo_request_with_options(net_iface);
 	if (!pkt) {
 		zassert_true(false, "EchoRequest with opts packet prep failed");
 	}
@@ -495,7 +495,7 @@ ZTEST(net_icmpv4, test_send_echo_req_bad_opt)
 {
 	struct net_pkt *pkt;
 
-	pkt = prepare_echo_request_with_bad_options(iface);
+	pkt = prepare_echo_request_with_bad_options(net_iface);
 	if (!pkt) {
 		zassert_true(false,
 			     "EchoRequest with bad opts packet prep failed");

--- a/tests/net/igmp/src/main.c
+++ b/tests/net/igmp/src/main.c
@@ -46,7 +46,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_IPV4_LOG_LEVEL);
 static struct in_addr my_addr = { { { 192, 0, 2, 1 } } };
 static struct in_addr mcast_addr = { { { 224, 0, 2, 63 } } };
 
-static struct net_if *iface;
+static struct net_if *net_iface;
 static bool is_group_joined;
 static bool is_group_left;
 static bool is_join_msg_ok;
@@ -206,11 +206,11 @@ static void *igmp_setup(void)
 
 	setup_mgmt_events();
 
-	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
+	net_iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
 
-	zassert_not_null(iface, "Interface is NULL");
+	zassert_not_null(net_iface, "Interface is NULL");
 
-	ifaddr = net_if_ipv4_addr_add(iface, &my_addr, NET_ADDR_MANUAL, 0);
+	ifaddr = net_if_ipv4_addr_add(net_iface, &my_addr, NET_ADDR_MANUAL, 0);
 
 	zassert_not_null(ifaddr, "Cannot add IPv4 address");
 
@@ -227,16 +227,16 @@ static void igmp_teardown(void *dummy)
 		net_mgmt_del_event_callback(&mgmt_events[i].cb);
 	}
 
-	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
+	net_iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
 
-	net_if_ipv4_addr_rm(iface, &my_addr);
+	net_if_ipv4_addr_rm(net_iface, &my_addr);
 }
 
 static void join_group(void)
 {
 	int ret;
 
-	ret = net_ipv4_igmp_join(iface, &mcast_addr);
+	ret = net_ipv4_igmp_join(net_iface, &mcast_addr);
 
 	if (ignore_already) {
 		zassert_true(ret == 0 || ret == -EALREADY,
@@ -253,7 +253,7 @@ static void leave_group(void)
 {
 	int ret;
 
-	ret = net_ipv4_igmp_leave(iface, &mcast_addr);
+	ret = net_ipv4_igmp_leave(net_iface, &mcast_addr);
 
 	zassert_equal(ret, 0, "Cannot leave IPv4 multicast group");
 

--- a/tests/net/ipv4_fragment/src/main.c
+++ b/tests/net/ipv4_fragment/src/main.c
@@ -147,7 +147,7 @@ static uint8_t upper_layer_packet_count;
 static uint16_t lower_layer_total_size;
 static uint16_t upper_layer_total_size;
 
-static uint8_t tmp_buf[256];
+static uint8_t test_tmp_buf[256];
 static uint8_t net_iface_dummy_data;
 
 static void net_iface_init(struct net_if *iface);
@@ -590,7 +590,7 @@ static void *test_setup(void)
 	setup_tcp_handler(&my_addr1, &my_addr2, 4092, 19551);
 
 	/* Generate test data */
-	generate_dummy_data(tmp_buf, sizeof(tmp_buf));
+	generate_dummy_data(test_tmp_buf, sizeof(test_tmp_buf));
 
 	return NULL;
 }
@@ -618,9 +618,9 @@ ZTEST(net_ipv4_fragment, test_udp)
 	/* Add enough data until we have 4 packets */
 	i = 0;
 	while (i < IPV4_TEST_PACKET_SIZE) {
-		ret = net_pkt_write(pkt, tmp_buf, sizeof(tmp_buf));
+		ret = net_pkt_write(pkt, test_tmp_buf, sizeof(test_tmp_buf));
 		zassert_equal(ret, 0, "IPv4 data append failed");
-		i += sizeof(tmp_buf);
+		i += sizeof(test_tmp_buf);
 	}
 
 	/* Setup packet for insertion */

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -42,7 +42,7 @@ static struct in6_addr my_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 				       0, 0, 0, 0, 0, 0, 0, 0x1 } } };
 static struct in6_addr peer_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 					 0, 0, 0, 0, 0, 0, 0, 0x2 } } };
-static struct in6_addr mcast_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+static struct in6_addr multicast_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 					  0, 0, 0, 0, 0, 0, 0, 0x1 } } };
 
 /* ICMPv6 NS frame (74 bytes) */
@@ -501,11 +501,11 @@ static void *ipv6_setup(void)
 	ifaddr2 = net_if_ipv6_addr_lookup(&my_addr, &iface2);
 	zassert_true(ifaddr2 == ifaddr, "Invalid ifaddr (%p vs %p)\n", ifaddr, ifaddr2);
 
-	net_ipv6_addr_create(&mcast_addr, 0xff02, 0, 0, 0, 0, 0, 0, 0x0001);
+	net_ipv6_addr_create(&multicast_addr, 0xff02, 0, 0, 0, 0, 0, 0, 0x0001);
 
-	maddr = net_if_ipv6_maddr_add(iface, &mcast_addr);
+	maddr = net_if_ipv6_maddr_add(iface, &multicast_addr);
 	zassert_not_null(maddr, "Cannot add multicast IPv6 address %s\n",
-			 net_sprint_ipv6_addr(&mcast_addr));
+			 net_sprint_ipv6_addr(&multicast_addr));
 
 	/* The semaphore is there to wait the data to be received. */
 	k_sem_init(&wait_data, 0, UINT_MAX);
@@ -528,8 +528,8 @@ static void ipv6_teardown(void *dummy)
 	rm_max_neighbors();
 	rm_neighbor();
 
-	net_ipv6_addr_create(&mcast_addr, 0xff02, 0, 0, 0, 0, 0, 0, 0x0001);
-	net_if_ipv6_maddr_rm(iface, &mcast_addr);
+	net_ipv6_addr_create(&multicast_addr, 0xff02, 0, 0, 0, 0, 0, 0, 0x0001);
+	net_if_ipv6_maddr_rm(iface, &multicast_addr);
 	ifaddr_record->is_used = false;
 }
 

--- a/tests/net/lib/dns_packet/src/main.c
+++ b/tests/net/lib/dns_packet/src/main.c
@@ -14,8 +14,8 @@
 /* RFC 1035, 4.1.1. Header section format */
 #define DNS_HEADER_SIZE	12
 
-static uint8_t buf[MAX_BUF_SIZE];
-static uint16_t buf_len;
+static uint8_t dns_buf[MAX_BUF_SIZE];
+static uint16_t dns_buf_len;
 
 static uint8_t qname[MAX_BUF_SIZE];
 static uint16_t qname_len;
@@ -61,90 +61,90 @@ static int eval_query(const char *dname, uint16_t tid, enum dns_rr_type type,
 		goto lb_exit;
 	}
 
-	rc = dns_msg_pack_query(buf, &buf_len, MAX_BUF_SIZE, qname, qname_len,
+	rc = dns_msg_pack_query(dns_buf, &dns_buf_len, MAX_BUF_SIZE, qname, qname_len,
 				tid, type);
 	if (rc != 0) {
 		goto lb_exit;
 	}
 
-	if (dns_unpack_header_id(buf) != tid) {
+	if (dns_unpack_header_id(dns_buf) != tid) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
 	/* This is a query */
-	if (dns_header_qr(buf) != DNS_QUERY) {
+	if (dns_header_qr(dns_buf) != DNS_QUERY) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
 	/* This is a query (standard query) */
-	if (dns_header_opcode(buf) != DNS_QUERY) {
+	if (dns_header_opcode(dns_buf) != DNS_QUERY) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
 	/* Authoritative Answer must be 0 for a Query */
-	if (dns_header_aa(buf) != 0) {
+	if (dns_header_aa(dns_buf) != 0) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
 	/* TrunCation is always 0 */
-	if (dns_header_tc(buf) != 0) {
+	if (dns_header_tc(dns_buf) != 0) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
 	/* Recursion Desired is always 1 */
-	if (dns_header_rd(buf) != 1) {
+	if (dns_header_rd(dns_buf) != 1) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
 	/* Recursion Available is always 0 */
-	if (dns_header_ra(buf) != 0) {
+	if (dns_header_ra(dns_buf) != 0) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
 	/* Z is always 0 */
-	if (dns_header_z(buf) != 0) {
+	if (dns_header_z(dns_buf) != 0) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
 	/* Response code must be 0 (no error) */
-	if (dns_header_rcode(buf) != DNS_HEADER_NOERROR) {
+	if (dns_header_rcode(dns_buf) != DNS_HEADER_NOERROR) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
 	/* Question counter must be 1 */
-	if (dns_header_qdcount(buf) != 1) {
+	if (dns_header_qdcount(dns_buf) != 1) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
 	/* Answer counter must be 0 */
-	if (dns_header_ancount(buf) != 0) {
+	if (dns_header_ancount(dns_buf) != 0) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
 	/* Name server resource records counter must be 0 */
-	if (dns_header_nscount(buf) != 0) {
+	if (dns_header_nscount(dns_buf) != 0) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
 	/* Additional records counter must be 0 */
-	if (dns_header_arcount(buf) != 0) {
+	if (dns_header_arcount(dns_buf) != 0) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
-	question = buf + DNS_HEADER_SIZE;
+	question = dns_buf + DNS_HEADER_SIZE;
 
 	/* QClass */
 	if (dns_unpack_query_qclass(question + qname_len) != DNS_CLASS_IN) {
@@ -159,12 +159,12 @@ static int eval_query(const char *dname, uint16_t tid, enum dns_rr_type type,
 	}
 
 	/* compare with the expected result */
-	if (buf_len != expected_len) {
+	if (dns_buf_len != expected_len) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}
 
-	if (memcmp(expected, buf, buf_len) != 0) {
+	if (memcmp(expected, dns_buf, dns_buf_len) != 0) {
 		rc = -EINVAL;
 		goto lb_exit;
 	}

--- a/tests/net/lib/lwm2m/content_plain_text/src/main.c
+++ b/tests/net/lib/lwm2m/content_plain_text/src/main.c
@@ -473,19 +473,19 @@ ZTEST(net_content_plain_text_nodata, test_get_bool_nodata)
 ZTEST(net_content_plain_text, test_get_opaque)
 {
 	int ret;
-	const char *test_payload = "test_payload";
+	const char *payload = "test_payload";
 	uint8_t buf[16];
 	bool last_block;
 	struct lwm2m_opaque_context ctx = { 0 };
 
-	test_payload_set(test_payload);
+	test_payload_set(payload);
 
 	ret = plain_text_reader.get_opaque(&test_in, buf, sizeof(buf),
 					   &ctx, &last_block);
-	zassert_equal(ret, strlen(test_payload), "Invalid length returned");
-	zassert_mem_equal(buf, test_payload, strlen(test_payload),
+	zassert_equal(ret, strlen(payload), "Invalid length returned");
+	zassert_mem_equal(buf, payload, strlen(payload),
 			  "Invalid value parsed");
-	zassert_equal(test_in.offset, strlen(test_payload) + 1,
+	zassert_equal(test_in.offset, strlen(payload) + 1,
 		      "Invalid packet offset");
 }
 

--- a/tests/net/lib/mqtt_sn_client/src/mqtt_sn_client.c
+++ b/tests/net/lib/mqtt_sn_client/src/mqtt_sn_client.c
@@ -84,15 +84,15 @@ int tp_poll(struct mqtt_sn_client *client)
 	return recv_data.sz;
 }
 
-static ZTEST_BMEM struct mqtt_sn_client clients[3];
-static ZTEST_BMEM struct mqtt_sn_client *client;
+static ZTEST_BMEM struct mqtt_sn_client mqtt_clients[3];
+static ZTEST_BMEM struct mqtt_sn_client *mqtt_client;
 
 static void setup(void *f)
 {
 	ARG_UNUSED(f);
 	static ZTEST_BMEM size_t i;
 
-	client = &clients[i++];
+	mqtt_client = &mqtt_clients[i++];
 
 	transport = (struct mqtt_sn_transport){
 		.init = tp_init, .msg_send = msg_send, .recv = tp_recv, .poll = tp_poll};
@@ -139,7 +139,7 @@ static void mqtt_sn_connect_no_will(struct mqtt_sn_client *client)
 static ZTEST(mqtt_sn_client, test_mqtt_sn_connect_no_will)
 {
 
-	mqtt_sn_connect_no_will(client);
+	mqtt_sn_connect_no_will(mqtt_client);
 }
 
 static ZTEST(mqtt_sn_client, test_mqtt_sn_connect_will)
@@ -150,32 +150,32 @@ static ZTEST(mqtt_sn_client, test_mqtt_sn_connect_will)
 
 	int err;
 
-	err = mqtt_sn_client_init(client, &client_id, &transport, evt_cb, tx, sizeof(tx), rx,
+	err = mqtt_sn_client_init(mqtt_client, &client_id, &transport, evt_cb, tx, sizeof(tx), rx,
 				  sizeof(rx));
 	zassert_equal(err, 0, "unexpected error %d");
 
-	client->will_topic = MQTT_SN_DATA_STRING_LITERAL("topic");
-	client->will_msg = MQTT_SN_DATA_STRING_LITERAL("msg");
+	mqtt_client->will_topic = MQTT_SN_DATA_STRING_LITERAL("topic");
+	mqtt_client->will_msg = MQTT_SN_DATA_STRING_LITERAL("msg");
 
-	err = mqtt_sn_connect(client, true, false);
+	err = mqtt_sn_connect(mqtt_client, true, false);
 	zassert_equal(err, 0, "unexpected error %d");
 	assert_msg_send(1, 12);
-	zassert_equal(client->state, 0, "Wrong state");
+	zassert_equal(mqtt_client->state, 0, "Wrong state");
 
-	err = input(client, willtopicreq, sizeof(willtopicreq));
+	err = input(mqtt_client, willtopicreq, sizeof(willtopicreq));
 	zassert_equal(err, 0, "unexpected error %d");
-	zassert_equal(client->state, 0, "Wrong state");
+	zassert_equal(mqtt_client->state, 0, "Wrong state");
 	assert_msg_send(1, 8);
 
-	err = input(client, willmsgreq, sizeof(willmsgreq));
+	err = input(mqtt_client, willmsgreq, sizeof(willmsgreq));
 	zassert_equal(err, 0, "unexpected error %d");
-	zassert_equal(client->state, 0, "Wrong state");
+	zassert_equal(mqtt_client->state, 0, "Wrong state");
 	zassert_equal(evt_cb_data.called, 0, "Unexpected event");
 	assert_msg_send(1, 5);
 
-	err = input(client, connack, sizeof(connack));
+	err = input(mqtt_client, connack, sizeof(connack));
 	zassert_equal(err, 0, "unexpected error %d");
-	zassert_equal(client->state, 1, "Wrong state");
+	zassert_equal(mqtt_client->state, 1, "Wrong state");
 	zassert_equal(evt_cb_data.called, 1, "NO event");
 	zassert_equal(evt_cb_data.last_evt.type, MQTT_SN_EVT_CONNECTED, "Wrong event");
 	k_sleep(K_MSEC(10));
@@ -189,22 +189,22 @@ static ZTEST(mqtt_sn_client, test_mqtt_sn_publish_qos0)
 	uint8_t regack[] = {7, 0x0B, 0x1A, 0x1B, 0x00, 0x01, 0};
 	int err;
 
-	mqtt_sn_connect_no_will(client);
-	err = mqtt_sn_publish(client, MQTT_SN_QOS_0, &topic, false, &data);
+	mqtt_sn_connect_no_will(mqtt_client);
+	err = mqtt_sn_publish(mqtt_client, MQTT_SN_QOS_0, &topic, false, &data);
 	zassert_equal(err, 0, "Unexpected error %d", err);
 
 	assert_msg_send(0, 0);
 	k_sleep(K_MSEC(10));
 	/* Expect a REGISTER to be sent */
 	assert_msg_send(1, 12);
-	err = input(client, regack, sizeof(regack));
+	err = input(mqtt_client, regack, sizeof(regack));
 	zassert_equal(err, 0, "unexpected error %d");
 	assert_msg_send(0, 0);
 	k_sleep(K_MSEC(10));
 	assert_msg_send(1, 20);
 
-	zassert_true(sys_slist_is_empty(&client->publish), "Publish not empty");
-	zassert_false(sys_slist_is_empty(&client->topic), "Topic empty");
+	zassert_true(sys_slist_is_empty(&mqtt_client->publish), "Publish not empty");
+	zassert_false(sys_slist_is_empty(&mqtt_client->topic), "Topic empty");
 }
 
 ZTEST_SUITE(mqtt_sn_client, NULL, NULL, setup, NULL, NULL);

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -50,7 +50,7 @@ static struct in6_addr peer_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 static struct in6_addr mcast_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 					  0, 0, 0, 0, 0, 0, 0, 0x1 } } };
 
-static struct net_if *iface;
+static struct net_if *net_iface;
 static bool is_group_joined;
 static bool is_group_left;
 static bool is_join_msg_ok;
@@ -206,11 +206,11 @@ static void *test_mld_setup(void)
 
 	setup_mgmt_events();
 
-	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
+	net_iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
 
-	zassert_not_null(iface, "Interface is NULL");
+	zassert_not_null(net_iface, "Interface is NULL");
 
-	ifaddr = net_if_ipv6_addr_add(iface, &my_addr,
+	ifaddr = net_if_ipv6_addr_add(net_iface, &my_addr,
 				      NET_ADDR_MANUAL, 0);
 
 	zassert_not_null(ifaddr, "Cannot add IPv6 address");
@@ -225,7 +225,7 @@ static void test_join_group(void)
 	/* Using adhoc multicast group outside standard range */
 	net_ipv6_addr_create(&mcast_addr, 0xff10, 0, 0, 0, 0, 0, 0, 0x0001);
 
-	ret = net_ipv6_mld_join(iface, &mcast_addr);
+	ret = net_ipv6_mld_join(net_iface, &mcast_addr);
 
 	if (ignore_already) {
 		zassert_true(ret == 0 || ret == -EALREADY,
@@ -244,7 +244,7 @@ static void test_leave_group(void)
 
 	net_ipv6_addr_create(&mcast_addr, 0xff10, 0, 0, 0, 0, 0, 0, 0x0001);
 
-	ret = net_ipv6_mld_leave(iface, &mcast_addr);
+	ret = net_ipv6_mld_leave(net_iface, &mcast_addr);
 
 	zassert_equal(ret, 0, "Cannot leave IPv6 multicast group");
 
@@ -557,12 +557,12 @@ ZTEST(net_mld_test_suite, test_no_mld_flag)
 	is_join_msg_ok = false;
 	is_leave_msg_ok = false;
 
-	net_if_flag_set(iface, NET_IF_IPV6_NO_MLD);
+	net_if_flag_set(net_iface, NET_IF_IPV6_NO_MLD);
 
 	/* Using adhoc multicast group outside standard range */
 	net_ipv6_addr_create(&mcast_addr, 0xff10, 0, 0, 0, 0, 0, 0, 0x0001);
 
-	ret = net_ipv6_mld_join(iface, &mcast_addr);
+	ret = net_ipv6_mld_join(net_iface, &mcast_addr);
 	zassert_equal(ret, 0, "Cannot add multicast address");
 
 	/* Let the network stack to proceed */
@@ -570,7 +570,7 @@ ZTEST(net_mld_test_suite, test_no_mld_flag)
 
 	zassert_false(is_join_msg_ok, "Received join message when not expected");
 
-	ret = net_ipv6_mld_leave(iface, &mcast_addr);
+	ret = net_ipv6_mld_leave(net_iface, &mcast_addr);
 	zassert_equal(ret, 0, "Cannot remove multicast address");
 
 	/* Let the network stack to proceed */
@@ -578,7 +578,7 @@ ZTEST(net_mld_test_suite, test_no_mld_flag)
 
 	zassert_false(is_leave_msg_ok, "Received leave message when not expected");
 
-	net_if_flag_clear(iface, NET_IF_IPV6_NO_MLD);
+	net_if_flag_clear(net_iface, NET_IF_IPV6_NO_MLD);
 }
 
 ZTEST_SUITE(net_mld_test_suite, NULL, test_mld_setup, NULL, NULL, NULL);

--- a/tests/net/ppp/driver/src/main.c
+++ b/tests/net/ppp/driver/src/main.c
@@ -35,7 +35,7 @@ typedef enum net_verdict (*ppp_l2_callback_t)(struct net_if *iface,
 void ppp_l2_register_pkt_cb(ppp_l2_callback_t cb); /* found in ppp_l2.c */
 void ppp_driver_feed_data(uint8_t *data, int data_len);
 
-static struct net_if *iface;
+static struct net_if *net_iface;
 
 static bool test_failed;
 static bool test_started;
@@ -208,15 +208,15 @@ static enum net_verdict ppp_l2_recv(struct net_if *iface, struct net_pkt *pkt)
 
 static void test_iface_setup(void)
 {
-	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(PPP));
-	zassert_not_null(iface, "PPP interface not found!");
+	net_iface = net_if_get_first_by_type(&NET_L2_GET_NAME(PPP));
+	zassert_not_null(net_iface, "PPP interface not found!");
 
 	/* The semaphore is there to wait the data to be received. */
 	k_sem_init(&wait_data, 0, UINT_MAX);
 
 	ppp_l2_register_pkt_cb(ppp_l2_recv);
 
-	net_if_up(iface);
+	net_if_up(net_iface);
 
 	test_failed = false;
 	test_started = true;
@@ -245,9 +245,9 @@ static void test_send_ppp_pkt_with_escapes(void)
 {
 	bool ret;
 
-	NET_DBG("Sending data to iface %p", iface);
+	NET_DBG("Sending data to iface %p", net_iface);
 
-	ret = send_iface(iface, ppp_recv_data1, sizeof(ppp_recv_data1),
+	ret = send_iface(net_iface, ppp_recv_data1, sizeof(ppp_recv_data1),
 			 ppp_expect_data1, sizeof(ppp_expect_data1));
 
 	zassert_true(ret, "iface");
@@ -257,9 +257,9 @@ static void test_send_ppp_pkt_with_full_and_partial(void)
 {
 	bool ret;
 
-	NET_DBG("Sending data to iface %p", iface);
+	NET_DBG("Sending data to iface %p", net_iface);
 
-	ret = send_iface(iface, ppp_recv_data2, sizeof(ppp_recv_data2),
+	ret = send_iface(net_iface, ppp_recv_data2, sizeof(ppp_recv_data2),
 			 ppp_expect_data1, sizeof(ppp_expect_data1));
 
 	zassert_true(ret, "iface");
@@ -320,7 +320,7 @@ static void ppp_verify_fcs(uint8_t *buf, int len)
 	uint8_t *ptr;
 	bool ret;
 
-	pkt = net_pkt_alloc_with_buffer(iface, len, AF_UNSPEC, 0, K_NO_WAIT);
+	pkt = net_pkt_alloc_with_buffer(net_iface, len, AF_UNSPEC, 0, K_NO_WAIT);
 	zassert_not_null(pkt, "Cannot create pkt");
 
 	ptr = buf;
@@ -391,7 +391,7 @@ static void ppp_calc_fcs(uint8_t *buf, int len)
 	uint8_t *ptr;
 	bool ret;
 
-	pkt = net_pkt_alloc_with_buffer(iface, len, AF_UNSPEC, 0, K_NO_WAIT);
+	pkt = net_pkt_alloc_with_buffer(net_iface, len, AF_UNSPEC, 0, K_NO_WAIT);
 	zassert_not_null(pkt, "Cannot create pkt");
 
 	ptr = buf;
@@ -445,9 +445,9 @@ static void test_send_ppp_3(void)
 {
 	bool ret;
 
-	NET_DBG("Sending data to iface %p", iface);
+	NET_DBG("Sending data to iface %p", net_iface);
 
-	ret = send_iface(iface, ppp_recv_data3, sizeof(ppp_recv_data3),
+	ret = send_iface(net_iface, ppp_recv_data3, sizeof(ppp_recv_data3),
 			 ppp_expect_data3, sizeof(ppp_expect_data3));
 
 	zassert_true(ret, "iface");
@@ -461,9 +461,9 @@ static void test_send_ppp_4(void)
 {
 	bool ret;
 
-	NET_DBG("Sending data to iface %p", iface);
+	NET_DBG("Sending data to iface %p", net_iface);
 
-	ret = send_iface(iface, ppp_recv_data4, sizeof(ppp_recv_data4),
+	ret = send_iface(net_iface, ppp_recv_data4, sizeof(ppp_recv_data4),
 			 ppp_expect_data4, sizeof(ppp_expect_data4));
 
 	zassert_true(ret, "iface");
@@ -477,9 +477,9 @@ static void test_send_ppp_5(void)
 {
 	bool ret;
 
-	NET_DBG("Sending data to iface %p", iface);
+	NET_DBG("Sending data to iface %p", net_iface);
 
-	ret = send_iface(iface, ppp_recv_data5, sizeof(ppp_recv_data5),
+	ret = send_iface(net_iface, ppp_recv_data5, sizeof(ppp_recv_data5),
 			 ppp_expect_data5, sizeof(ppp_expect_data5));
 
 	zassert_true(ret, "iface");
@@ -493,9 +493,9 @@ static void test_send_ppp_6(void)
 {
 	bool ret;
 
-	NET_DBG("Sending data to iface %p", iface);
+	NET_DBG("Sending data to iface %p", net_iface);
 
-	ret = send_iface(iface, ppp_recv_data6, sizeof(ppp_recv_data6),
+	ret = send_iface(net_iface, ppp_recv_data6, sizeof(ppp_recv_data6),
 			 ppp_expect_data6, sizeof(ppp_expect_data6));
 
 	zassert_true(ret, "iface");
@@ -509,9 +509,9 @@ static void test_send_ppp_7(void)
 {
 	bool ret;
 
-	NET_DBG("Sending data to iface %p", iface);
+	NET_DBG("Sending data to iface %p", net_iface);
 
-	ret = send_iface(iface, ppp_recv_data7, sizeof(ppp_recv_data7),
+	ret = send_iface(net_iface, ppp_recv_data7, sizeof(ppp_recv_data7),
 			 ppp_expect_data7, sizeof(ppp_expect_data7));
 
 	zassert_true(ret, "iface");
@@ -525,9 +525,9 @@ static void test_send_ppp_8(void)
 {
 	bool ret;
 
-	NET_DBG("Sending data to iface %p", iface);
+	NET_DBG("Sending data to iface %p", net_iface);
 
-	ret = send_iface(iface, ppp_recv_data8, sizeof(ppp_recv_data8),
+	ret = send_iface(net_iface, ppp_recv_data8, sizeof(ppp_recv_data8),
 			 ppp_expect_data8, sizeof(ppp_expect_data8));
 
 	zassert_true(ret, "iface");

--- a/tests/net/route/src/main.c
+++ b/tests/net/route/src/main.c
@@ -75,7 +75,7 @@ static struct net_if *recipient;
 static struct net_if *my_iface;
 static struct net_if *peer_iface;
 
-static struct net_route_entry *entry;
+static struct net_route_entry *route_entry;
 
 #define MAX_ROUTES CONFIG_NET_MAX_ROUTES
 static const int max_routes = MAX_ROUTES;
@@ -374,13 +374,13 @@ static void test_populate_nbr_cache(void)
 
 static void test_route_add(void)
 {
-	entry = net_route_add(my_iface,
-			      &dest_addr, 128,
-			      &peer_addr,
-			      NET_IPV6_ND_INFINITE_LIFETIME,
-			      NET_ROUTE_PREFERENCE_LOW);
+	route_entry = net_route_add(my_iface,
+				    &dest_addr, 128,
+				    &peer_addr,
+				    NET_IPV6_ND_INFINITE_LIFETIME,
+				    NET_ROUTE_PREFERENCE_LOW);
 
-	zassert_not_null(entry, "Route add failed");
+	zassert_not_null(route_entry, "Route add failed");
 }
 
 static void test_route_update(void)
@@ -392,7 +392,7 @@ static void test_route_update(void)
 				     &peer_addr,
 				     NET_IPV6_ND_INFINITE_LIFETIME,
 				     NET_ROUTE_PREFERENCE_LOW);
-	zassert_equal_ptr(update_entry, entry,
+	zassert_equal_ptr(update_entry, route_entry,
 			  "Route add again failed");
 }
 
@@ -400,7 +400,7 @@ static void test_route_del(void)
 {
 	int ret;
 
-	ret = net_route_del(entry);
+	ret = net_route_del(route_entry);
 	if (ret < 0) {
 		zassert_true(0, "Route del failed");
 	}
@@ -410,7 +410,7 @@ static void test_route_del_again(void)
 {
 	int ret;
 
-	ret = net_route_del(entry);
+	ret = net_route_del(route_entry);
 	if (ret >= 0) {
 		zassert_true(0, "Route del again failed");
 	}
@@ -420,7 +420,7 @@ static void test_route_get_nexthop(void)
 {
 	struct in6_addr *nexthop;
 
-	nexthop = net_route_get_nexthop(entry);
+	nexthop = net_route_get_nexthop(route_entry);
 
 	zassert_not_null(nexthop, "Route get nexthop failed");
 
@@ -494,23 +494,23 @@ static void test_route_del_many(void)
 
 static void test_route_lifetime(void)
 {
-	entry = net_route_add(my_iface,
-			      &dest_addr, 128,
-			      &peer_addr,
-			      NET_IPV6_ND_INFINITE_LIFETIME,
-			      NET_ROUTE_PREFERENCE_LOW);
+	route_entry = net_route_add(my_iface,
+				    &dest_addr, 128,
+				    &peer_addr,
+				    NET_IPV6_ND_INFINITE_LIFETIME,
+				    NET_ROUTE_PREFERENCE_LOW);
 
-	zassert_not_null(entry, "Route add failed");
+	zassert_not_null(route_entry, "Route add failed");
 
-	entry = net_route_lookup(my_iface, &dest_addr);
-	zassert_not_null(entry, "Route not found");
+	route_entry = net_route_lookup(my_iface, &dest_addr);
+	zassert_not_null(route_entry, "Route not found");
 
-	net_route_update_lifetime(entry, 1);
+	net_route_update_lifetime(route_entry, 1);
 
 	k_sleep(K_MSEC(1200));
 
-	entry = net_route_lookup(my_iface, &dest_addr);
-	zassert_is_null(entry, "Route did not expire");
+	route_entry = net_route_lookup(my_iface, &dest_addr);
+	zassert_is_null(route_entry, "Route did not expire");
 
 }
 
@@ -518,19 +518,19 @@ static void test_route_preference(void)
 {
 	struct net_route_entry *update_entry;
 
-	entry = net_route_add(my_iface,
-			      &dest_addr, 128,
-			      &peer_addr,
-			      NET_IPV6_ND_INFINITE_LIFETIME,
-			      NET_ROUTE_PREFERENCE_LOW);
-	zassert_not_null(entry, "Route add failed");
+	route_entry = net_route_add(my_iface,
+				    &dest_addr, 128,
+				    &peer_addr,
+				    NET_IPV6_ND_INFINITE_LIFETIME,
+				    NET_ROUTE_PREFERENCE_LOW);
+	zassert_not_null(route_entry, "Route add failed");
 
 	update_entry = net_route_add(my_iface,
 				     &dest_addr, 128,
 				     &peer_addr_alt,
 				     NET_IPV6_ND_INFINITE_LIFETIME,
 				     NET_ROUTE_PREFERENCE_MEDIUM);
-	zassert_equal_ptr(update_entry, entry,
+	zassert_equal_ptr(update_entry, route_entry,
 			  "Route add again failed");
 
 	update_entry = net_route_add(my_iface,
@@ -541,7 +541,7 @@ static void test_route_preference(void)
 	zassert_is_null(update_entry,
 			"Low preference route overwritten medium one");
 
-	net_route_del(entry);
+	net_route_del(route_entry);
 }
 
 

--- a/tests/net/shell/src/main.c
+++ b/tests/net/shell/src/main.c
@@ -147,7 +147,7 @@ static void *test_setup(void)
 	struct net_if_addr *ifaddr;
 
 	struct sockaddr_in6 any_addr6;
-	const struct in6_addr in6addr_any = IN6ADDR_ANY_INIT;
+	const struct in6_addr in6addr_anyaddr = IN6ADDR_ANY_INIT;
 
 	struct sockaddr_in6 my_addr6;
 	struct in6_addr in6addr_my = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
@@ -169,7 +169,7 @@ static void *test_setup(void)
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
 	test_failed = false;
 
-	net_ipaddr_copy(&any_addr6.sin6_addr, &in6addr_any);
+	net_ipaddr_copy(&any_addr6.sin6_addr, &in6addr_anyaddr);
 	any_addr6.sin6_family = AF_INET6;
 
 	net_ipaddr_copy(&my_addr6.sin6_addr, &in6addr_my);

--- a/tests/net/socket/socketpair/src/block.c
+++ b/tests/net/socket/socketpair/src/block.c
@@ -17,10 +17,12 @@ struct ctx {
 static ZTEST_BMEM struct ctx ctx;
 static ZTEST_BMEM struct k_work work;
 
-static void work_handler(struct k_work *work)
+static void work_handler(struct k_work *w)
 {
 	int res;
 	char c = '\0';
+
+	(void)w;
 
 	LOG_DBG("doing work");
 

--- a/tests/net/socket/socketpair/src/poll.c
+++ b/tests/net/socket/socketpair/src/poll.c
@@ -80,9 +80,9 @@ ZTEST_USER(net_socketpair, test_poll_timeout_nonblocking)
 	test_socketpair_poll_timeout_common(sv);
 }
 
-static void close_fun(struct k_work *work)
+static void close_fun(struct k_work *w)
 {
-	(void)work;
+	(void)w;
 
 	if (!(K_TIMEOUT_EQ(ctx.delay, K_NO_WAIT)
 		|| K_TIMEOUT_EQ(ctx.delay, K_FOREVER))) {
@@ -233,9 +233,9 @@ ZTEST_USER(net_socketpair, test_poll_immediate_data)
 	close(sv[1]);
 }
 
-static void rw_fun(struct k_work *work)
+static void rw_fun(struct k_work *w)
 {
-	(void)work;
+	(void)w;
 
 	int res;
 	char c;

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -921,7 +921,7 @@ struct eth_fake_context {
 };
 
 static struct eth_fake_context eth_fake_data;
-static ZTEST_BMEM struct sockaddr_in6 server_addr;
+static ZTEST_BMEM struct sockaddr_in6 udp_server_addr;
 
 /* The semaphore is there to wait the data to be received. */
 static ZTEST_BMEM SYS_MUTEX_DEFINE(wait_data);
@@ -1016,14 +1016,14 @@ ZTEST(net_socket_udp, test_17_setup_eth)
 
 	net_if_up(eth_iface);
 
-	(void)memset(&server_addr, 0, sizeof(server_addr));
-	server_addr.sin6_family = AF_INET6;
-	server_addr.sin6_port = htons(1234);
-	ret = inet_pton(AF_INET6, PEER_IPV6_ADDR_ETH, &server_addr.sin6_addr);
+	(void)memset(&udp_server_addr, 0, sizeof(udp_server_addr));
+	udp_server_addr.sin6_family = AF_INET6;
+	udp_server_addr.sin6_port = htons(1234);
+	ret = inet_pton(AF_INET6, PEER_IPV6_ADDR_ETH, &udp_server_addr.sin6_addr);
 	zassert_equal(ret, 1, "inet_pton failed");
 
 	/* In order to avoid neighbor discovery, populate neighbor cache */
-	net_ipv6_nbr_add(eth_iface, &server_addr.sin6_addr, &server_link_addr,
+	net_ipv6_nbr_add(eth_iface, &udp_server_addr.sin6_addr, &server_link_addr,
 			 true, NET_IPV6_NBR_STATE_REACHABLE);
 }
 
@@ -1057,8 +1057,8 @@ ZTEST_USER(net_socket_udp, test_18_v6_sendmsg_with_txtime)
 	msg.msg_controllen = sizeof(cmsgbuf.buf);
 	msg.msg_iov = io_vector;
 	msg.msg_iovlen = 1;
-	msg.msg_name = &server_addr;
-	msg.msg_namelen = sizeof(server_addr);
+	msg.msg_name = &udp_server_addr;
+	msg.msg_namelen = sizeof(udp_server_addr);
 
 	txtime = TEST_TXTIME;
 
@@ -1096,7 +1096,7 @@ void test_msg_trunc(int sock_c, int sock_s, struct sockaddr *addr_c,
 		    socklen_t addrlen_s)
 {
 	int rv;
-	uint8_t rx_buf[sizeof(TEST_STR_SMALL) - 1];
+	uint8_t str_buf[sizeof(TEST_STR_SMALL) - 1];
 
 	rv = bind(sock_s, addr_s, addrlen_s);
 	zassert_equal(rv, 0, "server bind failed");
@@ -1112,14 +1112,14 @@ void test_msg_trunc(int sock_c, int sock_s, struct sockaddr *addr_c,
 	rv = send(sock_c, BUF_AND_SIZE(TEST_STR_SMALL), 0);
 	zassert_equal(rv, sizeof(TEST_STR_SMALL) - 1, "send failed");
 
-	memset(rx_buf, 0, sizeof(rx_buf));
-	rv = recv(sock_s, rx_buf, 2, ZSOCK_MSG_TRUNC);
+	memset(str_buf, 0, sizeof(str_buf));
+	rv = recv(sock_s, str_buf, 2, ZSOCK_MSG_TRUNC);
 	zassert_equal(rv, sizeof(TEST_STR_SMALL) - 1, "MSG_TRUNC flag failed");
-	zassert_mem_equal(rx_buf, TEST_STR_SMALL, 2, "invalid rx data");
-	zassert_equal(rx_buf[2], 0, "received more than requested");
+	zassert_mem_equal(str_buf, TEST_STR_SMALL, 2, "invalid rx data");
+	zassert_equal(str_buf[2], 0, "received more than requested");
 
 	/* The remaining data should've been discarded */
-	rv = recv(sock_s, rx_buf, sizeof(rx_buf), ZSOCK_MSG_DONTWAIT);
+	rv = recv(sock_s, str_buf, sizeof(str_buf), ZSOCK_MSG_DONTWAIT);
 	zassert_equal(rv, -1, "consecutive recv should've failed");
 	zassert_equal(errno, EAGAIN, "incorrect errno value");
 
@@ -1128,15 +1128,15 @@ void test_msg_trunc(int sock_c, int sock_s, struct sockaddr *addr_c,
 	rv = send(sock_c, BUF_AND_SIZE(TEST_STR_SMALL), 0);
 	zassert_equal(rv, sizeof(TEST_STR_SMALL) - 1, "send failed");
 
-	memset(rx_buf, 0, sizeof(rx_buf));
-	rv = recv(sock_s, rx_buf, 2, ZSOCK_MSG_TRUNC | ZSOCK_MSG_PEEK);
+	memset(str_buf, 0, sizeof(str_buf));
+	rv = recv(sock_s, str_buf, 2, ZSOCK_MSG_TRUNC | ZSOCK_MSG_PEEK);
 	zassert_equal(rv, sizeof(TEST_STR_SMALL) - 1, "MSG_TRUNC flag failed");
 
 	/* The packet should still be available due to MSG_PEEK */
-	rv = recv(sock_s, rx_buf, sizeof(rx_buf), ZSOCK_MSG_TRUNC);
+	rv = recv(sock_s, str_buf, sizeof(str_buf), ZSOCK_MSG_TRUNC);
 	zassert_equal(rv, sizeof(TEST_STR_SMALL) - 1,
 		      "recv after MSG_PEEK failed");
-	zassert_mem_equal(rx_buf, BUF_AND_SIZE(TEST_STR_SMALL),
+	zassert_mem_equal(str_buf, BUF_AND_SIZE(TEST_STR_SMALL),
 			  "invalid rx data");
 
 	rv = close(sock_c);

--- a/tests/net/socket/websocket/src/main.c
+++ b/tests/net/socket/websocket/src/main.c
@@ -64,22 +64,22 @@ static int test_fd_alloc(void *obj)
 	return fd;
 }
 
-static int test_recv_buf(uint8_t *feed_buf, size_t feed_len,
+static int test_recv_buf(uint8_t *input_buf, size_t input_len,
 			 struct websocket_context *ctx,
 			 uint32_t *msg_type, uint64_t *remaining,
-			 uint8_t *recv_buf, size_t recv_len)
+			 uint8_t *recv_buffer, size_t recv_len)
 {
 	static struct test_data test_data;
 	int fd, ret;
 
 	test_data.ctx = ctx;
-	test_data.input_buf = feed_buf;
-	test_data.input_len = feed_len;
+	test_data.input_buf = input_buf;
+	test_data.input_len = input_len;
 	test_data.input_pos = 0;
 
 	fd = test_fd_alloc(&test_data);
 
-	ret = websocket_recv_msg(fd, recv_buf, recv_len,
+	ret = websocket_recv_msg(fd, recv_buffer, recv_len,
 				 msg_type, remaining, 0);
 
 	z_free_fd(fd);

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -438,7 +438,7 @@ ZTEST(udp_fn_tests, test_udp)
 	bool st;
 
 	struct sockaddr_in6 any_addr6;
-	const struct in6_addr in6addr_any = IN6ADDR_ANY_INIT;
+	const struct in6_addr in6addr_anyaddr = IN6ADDR_ANY_INIT;
 
 	struct sockaddr_in6 my_addr6;
 	struct in6_addr in6addr_my = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
@@ -459,7 +459,7 @@ ZTEST(udp_fn_tests, test_udp)
 
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
 
-	net_ipaddr_copy(&any_addr6.sin6_addr, &in6addr_any);
+	net_ipaddr_copy(&any_addr6.sin6_addr, &in6addr_anyaddr);
 	any_addr6.sin6_family = AF_INET6;
 
 	net_ipaddr_copy(&my_addr6.sin6_addr, &in6addr_my);

--- a/tests/posix/eventfd/src/_main.c
+++ b/tests/posix/eventfd/src/_main.c
@@ -81,12 +81,12 @@ void eventfd_poll_set_common(int fd)
 	zassert_equal(ret, 1, "eventfd is not blocked after read");
 }
 
-static struct eventfd_fixture fixture;
+static struct eventfd_fixture efd_fixture;
 
 static void *setup(void)
 {
-	fixture.fd = -1;
-	return &fixture;
+	efd_fixture.fd = -1;
+	return &efd_fixture;
 }
 
 static void before(void *arg)


### PR DESCRIPTION
This is an attempt to rename shadow variables found by enabling -Wshadow manually via twister. Note that this does not enable -Wshadow by default, and that requires more work to be done not only in tree but also in various modules.

This covers mainly networking related code.

Relates to #5450