### PR TITLE
bluetooth: fixes shadow variables

### DIFF
--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -152,14 +152,14 @@ static inline int bt_spi_transceive(void *tx, uint32_t tx_len,
 	return spi_transceive_dt(&bus, &spi_tx, &spi_rx);
 }
 
-static inline uint16_t bt_spi_get_cmd(uint8_t *txmsg)
+static inline uint16_t bt_spi_get_cmd(uint8_t *msg)
 {
-	return (txmsg[CMD_OCF] << 8) | txmsg[CMD_OGF];
+	return (msg[CMD_OCF] << 8) | msg[CMD_OGF];
 }
 
-static inline uint16_t bt_spi_get_evt(uint8_t *rxmsg)
+static inline uint16_t bt_spi_get_evt(uint8_t *msg)
 {
-	return (rxmsg[EVT_VENDOR_CODE_MSB] << 8) | rxmsg[EVT_VENDOR_CODE_LSB];
+	return (msg[EVT_VENDOR_CODE_MSB] << 8) | msg[EVT_VENDOR_CODE_LSB];
 }
 
 static void bt_to_inactive_isr(const struct device *unused1,
@@ -187,11 +187,11 @@ static void bt_to_active_isr(const struct device *unused1,
 	k_sem_give(&sem_request);
 }
 
-static bool bt_spi_handle_vendor_evt(uint8_t *rxmsg)
+static bool bt_spi_handle_vendor_evt(uint8_t *msg)
 {
 	bool handled = false;
 
-	switch (bt_spi_get_evt(rxmsg)) {
+	switch (bt_spi_get_evt(msg)) {
 	case EVT_BLUE_INITIALIZED:
 		k_sem_give(&sem_initialised);
 #if defined(CONFIG_BT_BLUENRG_ACI)

--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -23,7 +23,7 @@ static void start_scan(void);
 
 static struct bt_conn *default_conn;
 
-static struct bt_uuid_16 uuid = BT_UUID_INIT_16(0);
+static struct bt_uuid_16 discover_uuid = BT_UUID_INIT_16(0);
 static struct bt_gatt_discover_params discover_params;
 static struct bt_gatt_subscribe_params subscribe_params;
 
@@ -57,8 +57,8 @@ static uint8_t discover_func(struct bt_conn *conn,
 	printk("[ATTRIBUTE] handle %u\n", attr->handle);
 
 	if (!bt_uuid_cmp(discover_params.uuid, BT_UUID_HRS)) {
-		memcpy(&uuid, BT_UUID_HRS_MEASUREMENT, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		memcpy(&discover_uuid, BT_UUID_HRS_MEASUREMENT, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.start_handle = attr->handle + 1;
 		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 
@@ -68,8 +68,8 @@ static uint8_t discover_func(struct bt_conn *conn,
 		}
 	} else if (!bt_uuid_cmp(discover_params.uuid,
 				BT_UUID_HRS_MEASUREMENT)) {
-		memcpy(&uuid, BT_UUID_GATT_CCC, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		memcpy(&discover_uuid, BT_UUID_GATT_CCC, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.start_handle = attr->handle + 2;
 		discover_params.type = BT_GATT_DISCOVER_DESCRIPTOR;
 		subscribe_params.value_handle = bt_gatt_attr_value_handle(attr);
@@ -202,8 +202,8 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	printk("Connected: %s\n", addr);
 
 	if (conn == default_conn) {
-		memcpy(&uuid, BT_UUID_HRS, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		memcpy(&discover_uuid, BT_UUID_HRS, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.func = discover_func;
 		discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
 		discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;

--- a/samples/bluetooth/central_ht/src/main.c
+++ b/samples/bluetooth/central_ht/src/main.c
@@ -23,7 +23,7 @@
 static int scan_start(void);
 
 static struct bt_conn *default_conn;
-static struct bt_uuid_16 uuid = BT_UUID_INIT_16(0);
+static struct bt_uuid_16 discover_uuid = BT_UUID_INIT_16(0);
 static struct bt_gatt_discover_params discover_params;
 static struct bt_gatt_subscribe_params subscribe_params;
 
@@ -84,8 +84,8 @@ static uint8_t discover_func(struct bt_conn *conn,
 	printk("[ATTRIBUTE] handle %u\n", attr->handle);
 
 	if (!bt_uuid_cmp(discover_params.uuid, BT_UUID_HTS)) {
-		memcpy(&uuid, BT_UUID_HTS_MEASUREMENT, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		memcpy(&discover_uuid, BT_UUID_HTS_MEASUREMENT, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.start_handle = attr->handle + 1;
 		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 
@@ -95,8 +95,8 @@ static uint8_t discover_func(struct bt_conn *conn,
 		}
 	} else if (!bt_uuid_cmp(discover_params.uuid,
 				BT_UUID_HTS_MEASUREMENT)) {
-		memcpy(&uuid, BT_UUID_GATT_CCC, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		memcpy(&discover_uuid, BT_UUID_GATT_CCC, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.start_handle = attr->handle + 2;
 		discover_params.type = BT_GATT_DISCOVER_DESCRIPTOR;
 		subscribe_params.value_handle = bt_gatt_attr_value_handle(attr);
@@ -143,8 +143,8 @@ static void connected(struct bt_conn *conn, uint8_t conn_err)
 	printk("Connected: %s\n", addr);
 
 	if (conn == default_conn) {
-		memcpy(&uuid, BT_UUID_HTS, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		memcpy(&discover_uuid, BT_UUID_HTS, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.func = discover_func;
 		discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
 		discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;

--- a/samples/bluetooth/central_otc/src/main.c
+++ b/samples/bluetooth/central_otc/src/main.c
@@ -45,7 +45,7 @@ static int on_obj_data_read(struct bt_ots_client *ots_inst, struct bt_conn *conn
 			    uint32_t len, uint8_t *data_p, bool is_complete);
 
 static void start_scan(void);
-static struct bt_uuid_16 uuid = BT_UUID_INIT_16(0);
+static struct bt_uuid_16 discover_uuid = BT_UUID_INIT_16(0);
 static struct bt_conn *default_conn;
 static atomic_t discovery_state;
 
@@ -371,8 +371,8 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 	}
 
 	if (bt_uuid_cmp(discover_params.uuid, BT_UUID_OTS) == 0) {
-		(void)memcpy(&uuid, BT_UUID_OTS_FEATURE, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		(void)memcpy(&discover_uuid, BT_UUID_OTS_FEATURE, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.start_handle = attr->handle + 1;
 		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 		err = bt_gatt_discover(conn, &discover_params);
@@ -384,8 +384,8 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 	} else if (bt_uuid_cmp(discover_params.uuid, BT_UUID_OTS_FEATURE) == 0) {
 		atomic_set_bit(&discovery_state, DISC_OTS_FEATURE);
 		otc.feature_handle = bt_gatt_attr_value_handle(attr);
-		(void)memcpy(&uuid, BT_UUID_OTS_NAME, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		(void)memcpy(&discover_uuid, BT_UUID_OTS_NAME, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.start_handle = attr->handle + 1;
 		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 
@@ -397,8 +397,8 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 	} else if (bt_uuid_cmp(discover_params.uuid, BT_UUID_OTS_NAME) == 0) {
 		atomic_set_bit(&discovery_state, DISC_OTS_NAME);
 		otc.obj_name_handle = bt_gatt_attr_value_handle(attr);
-		(void)memcpy(&uuid, BT_UUID_OTS_TYPE, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		(void)memcpy(&discover_uuid, BT_UUID_OTS_TYPE, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.start_handle = attr->handle + 1;
 		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 
@@ -410,8 +410,8 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 	} else if (bt_uuid_cmp(discover_params.uuid, BT_UUID_OTS_TYPE) == 0) {
 		atomic_set_bit(&discovery_state, DISC_OTS_TYPE);
 		otc.obj_type_handle = bt_gatt_attr_value_handle(attr);
-		(void)memcpy(&uuid, BT_UUID_OTS_SIZE, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		(void)memcpy(&discover_uuid, BT_UUID_OTS_SIZE, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.start_handle = attr->handle + 1;
 		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 
@@ -423,8 +423,8 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 	} else if (bt_uuid_cmp(discover_params.uuid, BT_UUID_OTS_SIZE) == 0) {
 		atomic_set_bit(&discovery_state, DISC_OTS_SIZE);
 		otc.obj_size_handle = bt_gatt_attr_value_handle(attr);
-		(void)memcpy(&uuid, BT_UUID_OTS_ID, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		(void)memcpy(&discover_uuid, BT_UUID_OTS_ID, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.start_handle = attr->handle + 1;
 		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 
@@ -436,8 +436,8 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 	} else if (bt_uuid_cmp(discover_params.uuid, BT_UUID_OTS_ID) == 0) {
 		atomic_set_bit(&discovery_state, DISC_OTS_ID);
 		otc.obj_id_handle = bt_gatt_attr_value_handle(attr);
-		(void)memcpy(&uuid, BT_UUID_OTS_PROPERTIES, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		(void)memcpy(&discover_uuid, BT_UUID_OTS_PROPERTIES, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.start_handle = attr->handle + 1;
 		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 
@@ -449,8 +449,8 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 	} else if (bt_uuid_cmp(discover_params.uuid, BT_UUID_OTS_PROPERTIES) == 0) {
 		atomic_set_bit(&discovery_state, DISC_OTS_PROPERTIES);
 		otc.obj_properties_handle = bt_gatt_attr_value_handle(attr);
-		(void)memcpy(&uuid, BT_UUID_OTS_ACTION_CP, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		(void)memcpy(&discover_uuid, BT_UUID_OTS_ACTION_CP, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.start_handle = attr->handle + 1;
 		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 
@@ -461,8 +461,8 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 	} else if (bt_uuid_cmp(discover_params.uuid, BT_UUID_OTS_ACTION_CP) == 0) {
 		atomic_set_bit(&discovery_state, DISC_OTS_ACTION_CP);
 		otc.oacp_handle = bt_gatt_attr_value_handle(attr);
-		(void)memcpy(&uuid, BT_UUID_OTS_LIST_CP, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		(void)memcpy(&discover_uuid, BT_UUID_OTS_LIST_CP, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.start_handle = attr->handle + 1;
 		discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
 
@@ -517,8 +517,8 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	printk("Connected: %s\n", addr);
 
 	if (conn == default_conn) {
-		(void)memcpy(&uuid, BT_UUID_OTS, sizeof(uuid));
-		discover_params.uuid = &uuid.uuid;
+		(void)memcpy(&discover_uuid, BT_UUID_OTS, sizeof(discover_uuid));
+		discover_params.uuid = &discover_uuid.uuid;
 		discover_params.func = discover_func;
 		discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
 		discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;

--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -31,7 +31,7 @@
 #define ADV_DATA_HEX_STR_LEN_MAX (BT_GAP_ADV_MAX_EXT_ADV_DATA_LEN * 2 + 1)
 
 static struct bt_le_per_adv_sync_param sync_create_param;
-static struct bt_le_per_adv_sync *sync;
+static struct bt_le_per_adv_sync *adv_sync;
 static bt_addr_le_t per_addr;
 static bool per_adv_found;
 static bool scan_enabled;
@@ -264,7 +264,7 @@ static void create_sync(void)
 	sync_create_param.sid = per_sid;
 	sync_create_param.skip = 0;
 	sync_create_param.timeout = 0xaa;
-	err = bt_le_per_adv_sync_create(&sync_create_param, &sync);
+	err = bt_le_per_adv_sync_create(&sync_create_param, &adv_sync);
 	if (err != 0) {
 		printk("failed (err %d)\n", err);
 		return;
@@ -277,7 +277,7 @@ static int delete_sync(void)
 	int err;
 
 	printk("Deleting Periodic Advertising Sync...");
-	err = bt_le_per_adv_sync_delete(sync);
+	err = bt_le_per_adv_sync_delete(adv_sync);
 	if (err != 0) {
 		printk("failed (err %d)\n", err);
 		return err;
@@ -304,7 +304,7 @@ static void enable_cte_rx(void)
 	};
 
 	printk("Enable receiving of CTE...\n");
-	err = bt_df_per_adv_sync_cte_rx_enable(sync, &cte_rx_params);
+	err = bt_df_per_adv_sync_cte_rx_enable(adv_sync, &cte_rx_params);
 	if (err != 0) {
 		printk("failed (err %d)\n", err);
 		return;

--- a/samples/bluetooth/hap_ha/src/csip_set_member.c
+++ b/samples/bluetooth/hap_ha/src/csip_set_member.c
@@ -18,14 +18,14 @@
 static struct bt_csip_set_member_svc_inst *svc_inst;
 
 static void csip_lock_changed_cb(struct bt_conn *conn,
-				 struct bt_csip_set_member_svc_inst *svc_inst,
+				 struct bt_csip_set_member_svc_inst *inst,
 				 bool locked)
 {
 	printk("Client %p %s the lock\n", conn, locked ? "locked" : "released");
 }
 
 static uint8_t sirk_read_req_cb(struct bt_conn *conn,
-				struct bt_csip_set_member_svc_inst *svc_inst)
+				struct bt_csip_set_member_svc_inst *inst)
 {
 	return BT_CSIP_READ_SIRK_REQ_RSP_ACCEPT;
 }

--- a/samples/bluetooth/hap_ha/src/main.c
+++ b/samples/bluetooth/hap_ha/src/main.c
@@ -51,7 +51,7 @@ static const struct bt_data ad[] = {
 };
 
 static struct k_work_delayable adv_work;
-static struct bt_le_ext_adv *adv;
+static struct bt_le_ext_adv *ext_adv;
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
@@ -101,14 +101,14 @@ static void adv_work_handler(struct k_work *work)
 {
 	int err;
 
-	if (adv == NULL) {
+	if (ext_adv == NULL) {
 		/* Create a non-connectable non-scannable advertising set */
-		err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, &adv_cb, &adv);
+		err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN_NAME, &adv_cb, &ext_adv);
 		if (err) {
 			printk("Failed to create advertising set (err %d)\n", err);
 		}
 
-		err = bt_le_ext_adv_set_data(adv, ad, ARRAY_SIZE(ad), NULL, 0);
+		err = bt_le_ext_adv_set_data(ext_adv, ad, ARRAY_SIZE(ad), NULL, 0);
 		if (err) {
 			printk("Failed to set advertising data (err %d)\n", err);
 		}
@@ -116,7 +116,7 @@ static void adv_work_handler(struct k_work *work)
 		__ASSERT_NO_MSG(err == 0);
 	}
 
-	err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
+	err = bt_le_ext_adv_start(ext_adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (err) {
 		printk("Failed to start advertising set (err %d)\n", err);
 	} else {

--- a/samples/bluetooth/hci_pwr_ctrl/src/main.c
+++ b/samples/bluetooth/hci_pwr_ctrl/src/main.c
@@ -36,8 +36,8 @@ static const struct bt_data ad[] = {
 static struct k_thread pwr_thread_data;
 static K_THREAD_STACK_DEFINE(pwr_thread_stack, 512);
 
-static const int8_t txp[DEVICE_BEACON_TXPOWER_NUM] = {4, 0, -3, -8,
-						    -15, -18, -23, -30};
+static const int8_t txpower[DEVICE_BEACON_TXPOWER_NUM] = {4, 0, -3, -8,
+							  -15, -18, -23, -30};
 static const struct bt_le_adv_param *param =
 	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_USE_NAME,
 			0x0020, 0x0020, NULL);
@@ -235,9 +235,9 @@ void modulate_tx_power(void *p1, void *p2, void *p3)
 
 	while (1) {
 		if (!default_conn) {
-			printk("Set Tx power level to %d\n", txp[idx]);
+			printk("Set Tx power level to %d\n", txpower[idx]);
 			set_tx_power(BT_HCI_VS_LL_HANDLE_TYPE_ADV,
-				     0, txp[idx]);
+				     0, txpower[idx]);
 
 			k_sleep(K_SECONDS(5));
 

--- a/samples/bluetooth/mesh_provisioner/src/main.c
+++ b/samples/bluetooth/mesh_provisioner/src/main.c
@@ -63,7 +63,7 @@ static struct bt_mesh_elem elements[] = {
 	BT_MESH_ELEM(0, root_models, BT_MESH_MODEL_NONE),
 };
 
-static const struct bt_mesh_comp comp = {
+static const struct bt_mesh_comp mesh_comp = {
 	.cid = BT_COMP_ID_LF,
 	.elem = elements,
 	.elem_count = ARRAY_SIZE(elements),
@@ -243,7 +243,7 @@ static void unprovisioned_beacon(uint8_t uuid[16],
 	k_sem_give(&sem_unprov_beacon);
 }
 
-static void node_added(uint16_t net_idx, uint8_t uuid[16], uint16_t addr, uint8_t num_elem)
+static void node_added(uint16_t idx, uint8_t uuid[16], uint16_t addr, uint8_t num_elem)
 {
 	node_addr = addr;
 	k_sem_give(&sem_node_added);
@@ -260,7 +260,7 @@ static int bt_ready(void)
 	uint8_t net_key[16], dev_key[16];
 	int err;
 
-	err = bt_mesh_init(&prov, &comp);
+	err = bt_mesh_init(&prov, &mesh_comp);
 	if (err) {
 		printk("Initializing mesh failed (err %d)\n", err);
 		return err;

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -77,7 +77,7 @@
 
 /* Cycling Speed and Cadence Service declaration */
 
-static uint32_t cwr; /* Cumulative Wheel Revolutions */
+static uint32_t c_wheel_revs; /* Cumulative Wheel Revolutions */
 static uint8_t supported_locations[] = CSC_SUPPORTED_LOCATIONS;
 static uint8_t sensor_location; /* Current Sensor Location */
 static bool csc_simulate;
@@ -150,7 +150,7 @@ static ssize_t write_ctrl_point(struct bt_conn *conn,
 			break;
 		}
 
-		cwr = sys_le32_to_cpu(req->cwr);
+		c_wheel_revs = sys_le32_to_cpu(req->cwr);
 		status = SC_CP_RSP_SUCCESS;
 		break;
 	case SC_CP_OP_UPDATE_LOC:
@@ -310,7 +310,7 @@ static void csc_simulation(void)
 	/* Measurements don't have to be updated every second */
 	if (!(i % 2)) {
 		lwet += 1050 + rand % 50;
-		cwr += 2U;
+		c_wheel_revs += 2U;
 		nfy_wheel = true;
 	}
 
@@ -326,7 +326,7 @@ static void csc_simulation(void)
 	 * and is determined by the Server and not required to be configurable
 	 * by the Client.
 	 */
-	measurement_nfy(NULL, nfy_wheel ? cwr : 0, nfy_wheel ? lwet : 0,
+	measurement_nfy(NULL, nfy_wheel ? c_wheel_revs : 0, nfy_wheel ? lwet : 0,
 			nfy_crank ? ccr : 0, nfy_crank ? lcet : 0);
 
 	/*

--- a/samples/bluetooth/st_ble_sensor/src/main.c
+++ b/samples/bluetooth/st_ble_sensor/src/main.c
@@ -74,7 +74,7 @@ static const struct bt_data ad[] = {
 };
 
 /* BLE connection */
-struct bt_conn *conn;
+struct bt_conn *ble_conn;
 /* Notification state */
 volatile bool notify_enable;
 
@@ -116,7 +116,7 @@ static void button_callback(const struct device *gpiob, struct gpio_callback *cb
 	int err;
 
 	LOG_INF("Button pressed");
-	if (conn) {
+	if (ble_conn) {
 		if (notify_enable) {
 			err = bt_gatt_notify(NULL, &stsensor_svc.attrs[4],
 					     &but_val, sizeof(but_val));
@@ -157,17 +157,17 @@ static void connected(struct bt_conn *connected, uint8_t err)
 		LOG_ERR("Connection failed (err %u)", err);
 	} else {
 		LOG_INF("Connected");
-		if (!conn) {
-			conn = bt_conn_ref(connected);
+		if (!ble_conn) {
+			ble_conn = bt_conn_ref(connected);
 		}
 	}
 }
 
 static void disconnected(struct bt_conn *disconn, uint8_t reason)
 {
-	if (conn) {
-		bt_conn_unref(conn);
-		conn = NULL;
+	if (ble_conn) {
+		bt_conn_unref(ble_conn);
+		ble_conn = NULL;
 	}
 
 	LOG_INF("Disconnected (reason %u)", reason);

--- a/samples/bluetooth/tmap_bms/src/cap_initiator.c
+++ b/samples/bluetooth/tmap_bms/src/cap_initiator.c
@@ -47,7 +47,7 @@ struct bt_cap_initiator_broadcast_stream_param stream_params;
 struct bt_cap_initiator_broadcast_subgroup_param subgroup_param;
 struct bt_cap_initiator_broadcast_create_param create_param;
 struct bt_cap_broadcast_source *broadcast_source;
-struct bt_le_ext_adv *adv;
+struct bt_le_ext_adv *ext_adv;
 
 static uint8_t tmap_addata[] = {
 	BT_UUID_16_ENCODE(BT_UUID_TMAS_VAL), /* TMAS UUID */
@@ -273,7 +273,7 @@ void cap_initiator_setup(void)
 		}
 		printk("Creating broadcast source\n");
 
-		err = setup_extended_adv(&adv);
+		err = setup_extended_adv(&ext_adv);
 		if (err != 0) {
 			printk("Unable to setup extended advertiser: %d\n", err);
 			return;
@@ -285,19 +285,19 @@ void cap_initiator_setup(void)
 			return;
 		}
 
-		err = bt_cap_initiator_broadcast_audio_start(broadcast_source, adv);
+		err = bt_cap_initiator_broadcast_audio_start(broadcast_source, ext_adv);
 		if (err != 0) {
 			printk("Unable to start broadcast source: %d\n", err);
 			return;
 		}
 
-		err = setup_extended_adv_data(broadcast_source, adv);
+		err = setup_extended_adv_data(broadcast_source, ext_adv);
 		if (err != 0) {
 			printk("Unable to setup extended advertising data: %d\n", err);
 			return;
 		}
 
-		err = start_extended_adv(adv);
+		err = start_extended_adv(ext_adv);
 		if (err != 0) {
 			printk("Unable to start extended advertiser: %d\n", err);
 			return;
@@ -337,7 +337,7 @@ void cap_initiator_setup(void)
 		}
 		broadcast_source = NULL;
 
-		err = stop_and_delete_extended_adv(adv);
+		err = stop_and_delete_extended_adv(ext_adv);
 		if (err != 0) {
 			printk("Failed to stop and delete extended advertising: %d\n", err);
 			return;

--- a/samples/bluetooth/tmap_central/src/vcp_vol_ctlr.c
+++ b/samples/bluetooth/tmap_central/src/vcp_vol_ctlr.c
@@ -8,7 +8,7 @@
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/vcp.h>
 
-static struct bt_vcp_vol_ctlr *vol_ctlr;
+static struct bt_vcp_vol_ctlr *vcp_vol_ctlr;
 
 static void vcs_discover_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
 			    uint8_t vocs_count, uint8_t aics_count)
@@ -66,7 +66,7 @@ static int process_profile_connection(struct bt_conn *conn)
 {
 	int err = 0;
 
-	err = bt_vcp_vol_ctlr_discover(conn, &vol_ctlr);
+	err = bt_vcp_vol_ctlr_discover(conn, &vcp_vol_ctlr);
 
 	if (err != 0) {
 		printk("bt_vcp_vol_ctlr_discover (err %d)\n", err);
@@ -107,8 +107,8 @@ int vcp_vol_ctlr_mute(void)
 {
 	int err;
 
-	if (vol_ctlr != NULL) {
-		err = bt_vcp_vol_ctlr_mute(vol_ctlr);
+	if (vcp_vol_ctlr != NULL) {
+		err = bt_vcp_vol_ctlr_mute(vcp_vol_ctlr);
 	} else {
 		err = -EINVAL;
 	}
@@ -120,8 +120,8 @@ int vcp_vol_ctlr_unmute(void)
 {
 	int err;
 
-	if (vol_ctlr != NULL) {
-		err = bt_vcp_vol_ctlr_unmute(vol_ctlr);
+	if (vcp_vol_ctlr != NULL) {
+		err = bt_vcp_vol_ctlr_unmute(vcp_vol_ctlr);
 	} else {
 		err = -EINVAL;
 	}
@@ -133,8 +133,8 @@ int vcp_vol_ctlr_set_vol(uint8_t volume)
 {
 	int err;
 
-	if (vol_ctlr != NULL) {
-		err = bt_vcp_vol_ctlr_set_vol(vol_ctlr, volume);
+	if (vcp_vol_ctlr != NULL) {
+		err = bt_vcp_vol_ctlr_set_vol(vcp_vol_ctlr, volume);
 	} else {
 		err = -EINVAL;
 	}

--- a/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
+++ b/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
@@ -235,8 +235,8 @@ static int lc3_metadata(struct bt_bap_stream *stream, const struct bt_audio_code
 		}
 
 		if (data->data.type == BT_AUDIO_METADATA_TYPE_CCID_LIST) {
-			for (uint8_t i = 0; i < data->data.data_len; i++) {
-				const uint8_t ccid = data->data.data[i];
+			for (uint8_t j = 0; j < data->data.data_len; j++) {
+				const uint8_t ccid = data->data.data[j];
 
 				if (!(IS_ENABLED(CONFIG_BT_TBS_CLIENT_CCID) &&
 					bt_tbs_client_get_by_ccid(default_conn, ccid) != NULL)) {

--- a/samples/bluetooth/tmap_peripheral/src/csip_set_member.c
+++ b/samples/bluetooth/tmap_peripheral/src/csip_set_member.c
@@ -16,7 +16,7 @@
 static struct bt_csip_set_member_svc_inst *svc_inst;
 
 static void csip_lock_changed_cb(struct bt_conn *conn,
-				 struct bt_csip_set_member_svc_inst *svc_inst,
+				 struct bt_csip_set_member_svc_inst *inst,
 				 bool locked)
 {
 	printk("Client %p %s the lock\n", conn, locked ? "locked" : "released");

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -150,7 +150,6 @@ static void ase_status_changed(struct bt_ascs_ase *ase, uint8_t state)
 			const uint8_t att_ntf_header_size = 3; /* opcode (1) + handle (2) */
 			const uint16_t max_ntf_size = bt_gatt_get_mtu(conn) - att_ntf_header_size;
 			uint16_t ntf_size;
-			int err;
 
 			err = k_sem_take(&ase_buf_sem, ASE_BUF_SEM_TIMEOUT);
 			if (err != 0) {

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -759,9 +759,9 @@ int bt_bap_broadcast_source_create(struct bt_bap_broadcast_source_create_param *
 				     stream_param->data,
 				     stream_param->data_count * sizeof(*stream_param->data));
 			source->stream_data[stream_count].data_count = stream_param->data_count;
-			for (uint8_t i = 0U; i < stream_param->data_count; i++) {
-				source->stream_data[stream_count].data[i].data.data =
-					source->stream_data[stream_count].data[i].value;
+			for (uint8_t k = 0U; k < stream_param->data_count; k++) {
+				source->stream_data[stream_count].data[k].data.data =
+					source->stream_data[stream_count].data[k].value;
 			}
 
 			sys_slist_append(&subgroup->streams, &stream->_node);

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -249,7 +249,7 @@ static void scan_delegator_security_changed(struct bt_conn *conn,
 	/* Notify all receive states after a bonded device reconnects */
 	for (int i = 0; i < ARRAY_SIZE(scan_delegator.recv_states); i++) {
 		struct bass_recv_state_internal *internal_state = &scan_delegator.recv_states[i];
-		int err;
+		int gatt_err;
 
 		if (!internal_state->active) {
 			continue;
@@ -257,12 +257,12 @@ static void scan_delegator_security_changed(struct bt_conn *conn,
 
 		net_buf_put_recv_state(internal_state);
 
-		err = bt_gatt_notify_uuid(conn, BT_UUID_BASS_RECV_STATE,
-					  internal_state->attr, read_buf.data,
-					  read_buf.len);
-		if (err != 0) {
+		gatt_err = bt_gatt_notify_uuid(conn, BT_UUID_BASS_RECV_STATE,
+					       internal_state->attr, read_buf.data,
+					       read_buf.len);
+		if (gatt_err != 0) {
 			LOG_WRN("Could not notify receive state[%d] to reconnecting assistant: %d",
-				i, err);
+				i, gatt_err);
 		}
 	}
 }

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -135,7 +135,7 @@ struct mcs_instance_t {
 #endif /* CONFIG_BT_MCC_OTS */
 };
 
-static struct mcs_instance_t mcs_inst;
+static struct mcs_instance_t mcs_instance;
 static struct bt_uuid_16 uuid = BT_UUID_INIT_16(0);
 
 static struct bt_mcc_cb *mcc_cb;
@@ -168,7 +168,7 @@ static struct mcs_instance_t *lookup_inst_by_conn(struct bt_conn *conn)
 	}
 
 	/* TODO: Expand when supporting more instances */
-	return &mcs_inst;
+	return &mcs_instance;
 }
 
 static void mcc_player_name_cb(struct bt_conn *conn, uint8_t err, const void *data, uint16_t length)

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -225,7 +225,7 @@ static struct mpl_group group_p = {
 	.next	= NULL,
 };
 
-static struct mpl_mediaplayer pl = {
+static struct mpl_mediaplayer media_player = {
 	.name			  = CONFIG_BT_MPL_MEDIA_PLAYER_NAME,
 	.icon_url		  = CONFIG_BT_MPL_ICON_URL,
 	.group			  = &group_1,
@@ -717,29 +717,29 @@ static void on_obj_selected(struct bt_ots *ots, struct bt_conn *conn,
 
 	LOG_DBG_OBJ_ID("Object Id selected: ", id);
 
-	if (id == pl.icon_id) {
+	if (id == media_player.icon_id) {
 		LOG_DBG("Icon Object ID");
 		(void)setup_icon_object();
-	} else if (id == pl.group->track->segments_id) {
+	} else if (id == media_player.group->track->segments_id) {
 		LOG_DBG("Current Track Segments Object ID");
-		(void)setup_segments_object(pl.group->track);
-	} else if (id == pl.group->track->id) {
+		(void)setup_segments_object(media_player.group->track);
+	} else if (id == media_player.group->track->id) {
 		LOG_DBG("Current Track Object ID");
-		(void)setup_track_object(pl.group->track);
-	} else if (pl.next_track_set && id == pl.next.track->id) {
+		(void)setup_track_object(media_player.group->track);
+	} else if (media_player.next_track_set && id == media_player.next.track->id) {
 		/* Next track, if the next track has been explicitly set */
 		LOG_DBG("Next Track Object ID");
-		(void)setup_track_object(pl.next.track);
-	} else if (id == pl.group->track->next->id) {
+		(void)setup_track_object(media_player.next.track);
+	} else if (id == media_player.group->track->next->id) {
 		/* Next track, if next track has not been explicitly set */
 		LOG_DBG("Next Track Object ID");
-		(void)setup_track_object(pl.group->track->next);
-	} else if (id == pl.group->parent->id) {
+		(void)setup_track_object(media_player.group->track->next);
+	} else if (id == media_player.group->parent->id) {
 		LOG_DBG("Parent Group Object ID");
-		(void)setup_parent_group_object(pl.group);
-	} else if (id == pl.group->id) {
+		(void)setup_parent_group_object(media_player.group);
+	} else if (id == media_player.group->id) {
 		LOG_DBG("Current Group Object ID");
-		(void)setup_group_object(pl.group);
+		(void)setup_group_object(media_player.group);
 	} else {
 		LOG_ERR("Unknown Object ID");
 		obj.busy = false;
@@ -762,7 +762,7 @@ static int on_obj_created(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
 		LOG_DBG("Icon Obj Type");
 		if (obj.add_type == MPL_OBJ_ICON) {
 			obj.add_type = MPL_OBJ_NONE;
-			pl.icon_id = id;
+			media_player.icon_id = id;
 		} else {
 			LOG_DBG("Unexpected object creation");
 		}
@@ -772,7 +772,7 @@ static int on_obj_created(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
 		LOG_DBG("Track Segments Obj Type");
 		if (obj.add_type == MPL_OBJ_TRACK_SEGMENTS) {
 			obj.add_type = MPL_OBJ_NONE;
-			pl.group->track->segments_id = id;
+			media_player.group->track->segments_id = id;
 		} else {
 			LOG_DBG("Unexpected object creation");
 		}
@@ -794,7 +794,7 @@ static int on_obj_created(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
 		if (obj.add_type == MPL_OBJ_PARENT_GROUP) {
 			LOG_DBG("Parent group");
 			obj.add_type = MPL_OBJ_NONE;
-			pl.group->parent->id = id;
+			media_player.group->parent->id = id;
 		} else if (obj.add_type == MPL_OBJ_GROUP) {
 			LOG_DBG("Other group");
 			obj.add_type = MPL_OBJ_NONE;
@@ -1419,18 +1419,18 @@ void inactive_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PREV_TRACK:
-		if (do_prev_track(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+		if (do_prev_track(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		} else {
 			/* For previous track, the position is reset to 0 */
 			/* even if we stay at the same track (goto start of */
 			/* track) */
-			pl.track_pos = 0;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = 0;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 		}
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
@@ -1439,68 +1439,68 @@ void inactive_state_command_handler(const struct mpl_cmd *command,
 		 * The case where the next track has been set explicitly breaks somewhat
 		 * with the "next" order hardcoded into the group and track structure
 		 */
-		if (pl.next_track_set) {
+		if (media_player.next_track_set) {
 			LOG_DBG("Next track set");
-			if (do_next_track_next_track_set(&pl)) {
-				do_group_change_notifications(&pl);
+			if (do_next_track_next_track_set(&media_player)) {
+				do_group_change_notifications(&media_player);
 			}
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
-		} else if (do_next_track_normal_order(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
+		} else if (do_next_track_normal_order(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		}
 		/* For next track, the position is kept if the track */
 		/* does not change */
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FIRST_TRACK:
-		if (do_first_track(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+		if (do_first_track(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		} else {
 			/* For first track, the position is reset to 0 even */
 			/* if we stay at the same track (goto start of track) */
-			pl.track_pos = 0;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = 0;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 		}
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_LAST_TRACK:
-		if (do_last_track(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+		if (do_last_track(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		} else {
 			/* For last track, the position is reset to 0 even */
 			/* if we stay at the same track (goto start of track) */
-			pl.track_pos = 0;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = 0;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 		}
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_GOTO_TRACK:
 		if (command->use_param) {
-			if (do_goto_track(&pl, command->param)) {
-				pl.track_pos = 0;
-				do_track_change_notifications(&pl);
+			if (do_goto_track(&media_player, command->param)) {
+				media_player.track_pos = 0;
+				do_track_change_notifications(&media_player);
 			} else {
 				/* For goto track, the position is reset to 0 */
 				/* even if we stay at the same track (goto */
 				/* start of track) */
-				pl.track_pos = 0;
-				media_proxy_pl_track_position_cb(pl.track_pos);
+				media_player.track_pos = 0;
+				media_proxy_pl_track_position_cb(media_player.track_pos);
 			}
-			pl.state = MEDIA_PROXY_STATE_PAUSED;
-			media_proxy_pl_media_state_cb(pl.state);
+			media_player.state = MEDIA_PROXY_STATE_PAUSED;
+			media_proxy_pl_media_state_cb(media_player.state);
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
@@ -1508,38 +1508,38 @@ void inactive_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PREV_GROUP:
-		do_full_prev_group(&pl);
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		do_full_prev_group(&media_player);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_NEXT_GROUP:
-		do_full_next_group(&pl);
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		do_full_next_group(&media_player);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FIRST_GROUP:
-		do_full_first_group(&pl);
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		do_full_first_group(&media_player);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_LAST_GROUP:
-		do_full_last_group(&pl);
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		do_full_last_group(&media_player);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_GOTO_GROUP:
 		if (command->use_param) {
-			do_full_goto_group(&pl, command->param);
-			pl.state = MEDIA_PROXY_STATE_PAUSED;
-			media_proxy_pl_media_state_cb(pl.state);
+			do_full_goto_group(&media_player, command->param);
+			media_player.state = MEDIA_PROXY_STATE_PAUSED;
+			media_proxy_pl_media_state_cb(media_player.state);
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
@@ -1570,34 +1570,34 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PAUSE:
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FAST_REWIND:
 		/* We're in playing state, seeking speed must have been zero */
-		pl.seeking_speed_factor = -MPL_SEEKING_SPEED_FACTOR_STEP;
-		pl.state = MEDIA_PROXY_STATE_SEEKING;
-		media_proxy_pl_media_state_cb(pl.state);
-		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
+		media_player.seeking_speed_factor = -MPL_SEEKING_SPEED_FACTOR_STEP;
+		media_player.state = MEDIA_PROXY_STATE_SEEKING;
+		media_proxy_pl_media_state_cb(media_player.state);
+		media_proxy_pl_seeking_speed_cb(media_player.seeking_speed_factor);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FAST_FORWARD:
 		/* We're in playing state, seeking speed must have been zero */
-		pl.seeking_speed_factor = MPL_SEEKING_SPEED_FACTOR_STEP;
-		pl.state = MEDIA_PROXY_STATE_SEEKING;
-		media_proxy_pl_media_state_cb(pl.state);
-		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
+		media_player.seeking_speed_factor = MPL_SEEKING_SPEED_FACTOR_STEP;
+		media_player.state = MEDIA_PROXY_STATE_SEEKING;
+		media_proxy_pl_media_state_cb(media_player.state);
+		media_proxy_pl_seeking_speed_cb(media_player.seeking_speed_factor);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_STOP:
-		pl.track_pos = 0;
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		media_player.track_pos = 0;
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
@@ -1605,59 +1605,59 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 		if (command->use_param) {
 			/* Keep within track - i.e. in the range 0 - duration */
 			if (command->param >
-			    pl.group->track->duration - pl.track_pos) {
-				pl.track_pos = pl.group->track->duration;
-			} else if (command->param < -pl.track_pos) {
-				pl.track_pos = 0;
+			    media_player.group->track->duration - media_player.track_pos) {
+				media_player.track_pos = media_player.group->track->duration;
+			} else if (command->param < -media_player.track_pos) {
+				media_player.track_pos = 0;
 			} else {
-				pl.track_pos += command->param;
+				media_player.track_pos += command->param;
 			}
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PREV_SEGMENT:
 		/* Switch to previous segment if we are less than <margin> */
 		/* into the segment, otherwise go to start of segment */
-		if (pl.track_pos - PREV_MARGIN <
-		    pl.group->track->segment->pos) {
-			do_prev_segment(&pl);
+		if (media_player.track_pos - PREV_MARGIN <
+		    media_player.group->track->segment->pos) {
+			do_prev_segment(&media_player);
 		}
-		pl.track_pos = pl.group->track->segment->pos;
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		media_player.track_pos = media_player.group->track->segment->pos;
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_NEXT_SEGMENT:
-		do_next_segment(&pl);
-		pl.track_pos = pl.group->track->segment->pos;
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		do_next_segment(&media_player);
+		media_player.track_pos = media_player.group->track->segment->pos;
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FIRST_SEGMENT:
-		do_first_segment(&pl);
-		pl.track_pos = pl.group->track->segment->pos;
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		do_first_segment(&media_player);
+		media_player.track_pos = media_player.group->track->segment->pos;
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_LAST_SEGMENT:
-		do_last_segment(&pl);
-		pl.track_pos = pl.group->track->segment->pos;
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		do_last_segment(&media_player);
+		media_player.track_pos = media_player.group->track->segment->pos;
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_GOTO_SEGMENT:
 		if (command->use_param) {
 			if (command->param != 0) {
-				do_goto_segment(&pl, command->param);
-				pl.track_pos = pl.group->track->segment->pos;
-				media_proxy_pl_track_position_cb(pl.track_pos);
+				do_goto_segment(&media_player, command->param);
+				media_player.track_pos = media_player.group->track->segment->pos;
+				media_proxy_pl_track_position_cb(media_player.track_pos);
 			}
 			/* If the argument to "goto segment" is zero, */
 			/* the segment shall stay the same, and the */
@@ -1669,30 +1669,30 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PREV_TRACK:
-		if (do_prev_track(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+		if (do_prev_track(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		} else {
 			/* For previous track, the position is reset to 0 */
 			/* even if we stay at the same track (goto start of */
 			/* track) */
-			pl.track_pos = 0;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = 0;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 		}
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_NEXT_TRACK:
-		if (pl.next_track_set) {
+		if (media_player.next_track_set) {
 			LOG_DBG("Next track set");
-			if (do_next_track_next_track_set(&pl)) {
-				do_group_change_notifications(&pl);
+			if (do_next_track_next_track_set(&media_player)) {
+				do_group_change_notifications(&media_player);
 			}
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
-		} else if (do_next_track_normal_order(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
+		} else if (do_next_track_normal_order(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		}
 		/* For next track, the position is kept if the track */
 		/* does not change */
@@ -1700,42 +1700,42 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FIRST_TRACK:
-		if (do_first_track(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+		if (do_first_track(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		} else {
 			/* For first track, the position is reset to 0 even */
 			/* if we stay at the same track (goto start of track) */
-			pl.track_pos = 0;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = 0;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 		}
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_LAST_TRACK:
-		if (do_last_track(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+		if (do_last_track(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		} else {
 			/* For last track, the position is reset to 0 even */
 			/* if we stay at the same track (goto start of track) */
-			pl.track_pos = 0;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = 0;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 		}
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_GOTO_TRACK:
 		if (command->use_param) {
-			if (do_goto_track(&pl, command->param)) {
-				pl.track_pos = 0;
-				do_track_change_notifications(&pl);
+			if (do_goto_track(&media_player, command->param)) {
+				media_player.track_pos = 0;
+				do_track_change_notifications(&media_player);
 			} else {
 				/* For goto track, the position is reset to 0 */
 				/* even if we stay at the same track (goto */
 				/* start of track) */
-				pl.track_pos = 0;
-				media_proxy_pl_track_position_cb(pl.track_pos);
+				media_player.track_pos = 0;
+				media_proxy_pl_track_position_cb(media_player.track_pos);
 			}
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
@@ -1744,28 +1744,28 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PREV_GROUP:
-		do_full_prev_group(&pl);
+		do_full_prev_group(&media_player);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_NEXT_GROUP:
-		do_full_next_group(&pl);
+		do_full_next_group(&media_player);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FIRST_GROUP:
-		do_full_first_group(&pl);
+		do_full_first_group(&media_player);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_LAST_GROUP:
-		do_full_last_group(&pl);
+		do_full_last_group(&media_player);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_GOTO_GROUP:
 		if (command->use_param) {
-			do_full_goto_group(&pl, command->param);
+			do_full_goto_group(&media_player, command->param);
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
@@ -1791,8 +1791,8 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 	}
 	switch (command->opcode) {
 	case MEDIA_PROXY_OP_PLAY:
-		pl.state = MEDIA_PROXY_STATE_PLAYING;
-		media_proxy_pl_media_state_cb(pl.state);
+		media_player.state = MEDIA_PROXY_STATE_PLAYING;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
@@ -1803,27 +1803,27 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 		break;
 	case MEDIA_PROXY_OP_FAST_REWIND:
 		/* We're in paused state, seeking speed must have been zero */
-		pl.seeking_speed_factor = -MPL_SEEKING_SPEED_FACTOR_STEP;
-		pl.state = MEDIA_PROXY_STATE_SEEKING;
-		media_proxy_pl_media_state_cb(pl.state);
-		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
+		media_player.seeking_speed_factor = -MPL_SEEKING_SPEED_FACTOR_STEP;
+		media_player.state = MEDIA_PROXY_STATE_SEEKING;
+		media_proxy_pl_media_state_cb(media_player.state);
+		media_proxy_pl_seeking_speed_cb(media_player.seeking_speed_factor);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FAST_FORWARD:
 		/* We're in paused state, seeking speed must have been zero */
-		pl.seeking_speed_factor = MPL_SEEKING_SPEED_FACTOR_STEP;
-		pl.state = MEDIA_PROXY_STATE_SEEKING;
-		media_proxy_pl_media_state_cb(pl.state);
-		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
+		media_player.seeking_speed_factor = MPL_SEEKING_SPEED_FACTOR_STEP;
+		media_player.state = MEDIA_PROXY_STATE_SEEKING;
+		media_proxy_pl_media_state_cb(media_player.state);
+		media_proxy_pl_seeking_speed_cb(media_player.seeking_speed_factor);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_STOP:
-		pl.track_pos = 0;
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		media_player.track_pos = 0;
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
@@ -1831,30 +1831,31 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 		if (command->use_param) {
 			/* Keep within track - i.e. in the range 0 - duration */
 			if (command->param >
-			    pl.group->track->duration - pl.track_pos) {
-				pl.track_pos = pl.group->track->duration;
-			} else if (command->param < -pl.track_pos) {
-				pl.track_pos = 0;
+			    media_player.group->track->duration - media_player.track_pos) {
+				media_player.track_pos = media_player.group->track->duration;
+			} else if (command->param < -media_player.track_pos) {
+				media_player.track_pos = 0;
 			} else {
-				pl.track_pos += command->param;
+				media_player.track_pos += command->param;
 			}
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PREV_SEGMENT:
 		/* Switch to previous segment if we are less than 5 seconds */
 		/* into the segment, otherwise go to start of segment */
-		if (pl.group->track->segment != NULL) {
-			if (pl.track_pos - PREV_MARGIN < pl.group->track->segment->pos) {
-				do_prev_segment(&pl);
+		if (media_player.group->track->segment != NULL) {
+			if (media_player.track_pos - PREV_MARGIN <
+			    media_player.group->track->segment->pos) {
+				do_prev_segment(&media_player);
 			}
 
-			pl.track_pos = pl.group->track->segment->pos;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = media_player.group->track->segment->pos;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
@@ -1863,10 +1864,10 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_NEXT_SEGMENT:
-		if (pl.group->track->segment != NULL) {
-			do_next_segment(&pl);
-			pl.track_pos = pl.group->track->segment->pos;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+		if (media_player.group->track->segment != NULL) {
+			do_next_segment(&media_player);
+			media_player.track_pos = media_player.group->track->segment->pos;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
@@ -1875,10 +1876,10 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FIRST_SEGMENT:
-		if (pl.group->track->segment != NULL) {
-			do_first_segment(&pl);
-			pl.track_pos = pl.group->track->segment->pos;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+		if (media_player.group->track->segment != NULL) {
+			do_first_segment(&media_player);
+			media_player.track_pos = media_player.group->track->segment->pos;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
@@ -1887,10 +1888,10 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_LAST_SEGMENT:
-		if (pl.group->track->segment != NULL) {
-			do_last_segment(&pl);
-			pl.track_pos = pl.group->track->segment->pos;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+		if (media_player.group->track->segment != NULL) {
+			do_last_segment(&media_player);
+			media_player.track_pos = media_player.group->track->segment->pos;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
@@ -1899,11 +1900,11 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_GOTO_SEGMENT:
-		if (command->use_param && pl.group->track->segment != NULL) {
+		if (command->use_param && media_player.group->track->segment != NULL) {
 			if (command->param != 0) {
-				do_goto_segment(&pl, command->param);
-				pl.track_pos = pl.group->track->segment->pos;
-				media_proxy_pl_track_position_cb(pl.track_pos);
+				do_goto_segment(&media_player, command->param);
+				media_player.track_pos = media_player.group->track->segment->pos;
+				media_proxy_pl_track_position_cb(media_player.track_pos);
 			}
 			/* If the argument to "goto segment" is zero, */
 			/* the segment shall stay the same, and the */
@@ -1915,30 +1916,30 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PREV_TRACK:
-		if (do_prev_track(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+		if (do_prev_track(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		} else {
 			/* For previous track, the position is reset to 0 */
 			/* even if we stay at the same track (goto start of */
 			/* track) */
-			pl.track_pos = 0;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = 0;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 		}
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_NEXT_TRACK:
-		if (pl.next_track_set) {
+		if (media_player.next_track_set) {
 			LOG_DBG("Next track set");
-			if (do_next_track_next_track_set(&pl)) {
-				do_group_change_notifications(&pl);
+			if (do_next_track_next_track_set(&media_player)) {
+				do_group_change_notifications(&media_player);
 			}
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
-		} else if (do_next_track_normal_order(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
+		} else if (do_next_track_normal_order(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		}
 		/* For next track, the position is kept if the track */
 		/* does not change */
@@ -1946,42 +1947,42 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FIRST_TRACK:
-		if (do_first_track(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+		if (do_first_track(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		} else {
 			/* For first track, the position is reset to 0 even */
 			/* if we stay at the same track (goto start of track) */
-			pl.track_pos = 0;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = 0;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 		}
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_LAST_TRACK:
-		if (do_last_track(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+		if (do_last_track(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		} else {
 			/* For last track, the position is reset to 0 even */
 			/* if we stay at the same track (goto start of track) */
-			pl.track_pos = 0;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = 0;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 		}
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_GOTO_TRACK:
 		if (command->use_param) {
-			if (do_goto_track(&pl, command->param)) {
-				pl.track_pos = 0;
-				do_track_change_notifications(&pl);
+			if (do_goto_track(&media_player, command->param)) {
+				media_player.track_pos = 0;
+				do_track_change_notifications(&media_player);
 			} else {
 				/* For goto track, the position is reset to 0 */
 				/* even if we stay at the same track (goto */
 				/* start of track) */
-				pl.track_pos = 0;
-				media_proxy_pl_track_position_cb(pl.track_pos);
+				media_player.track_pos = 0;
+				media_proxy_pl_track_position_cb(media_player.track_pos);
 			}
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
@@ -1990,28 +1991,28 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PREV_GROUP:
-		do_full_prev_group(&pl);
+		do_full_prev_group(&media_player);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_NEXT_GROUP:
-		do_full_next_group(&pl);
+		do_full_next_group(&media_player);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FIRST_GROUP:
-		do_full_first_group(&pl);
+		do_full_first_group(&media_player);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_LAST_GROUP:
-		do_full_last_group(&pl);
+		do_full_last_group(&media_player);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_GOTO_GROUP:
 		if (command->use_param) {
-			do_full_goto_group(&pl, command->param);
+			do_full_goto_group(&media_player, command->param);
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
@@ -2037,19 +2038,19 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 	}
 	switch (command->opcode) {
 	case MEDIA_PROXY_OP_PLAY:
-		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
-		pl.state = MEDIA_PROXY_STATE_PLAYING;
-		media_proxy_pl_media_state_cb(pl.state);
-		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
+		media_player.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+		media_player.state = MEDIA_PROXY_STATE_PLAYING;
+		media_proxy_pl_media_state_cb(media_player.state);
+		media_proxy_pl_seeking_speed_cb(media_player.seeking_speed_factor);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PAUSE:
-		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+		media_player.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
 		/* TODO: Set track and track position */
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
-		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
+		media_proxy_pl_seeking_speed_cb(media_player.seeking_speed_factor);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
@@ -2060,31 +2061,31 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 		/* What about FR followed by FF? */
 		/* Currently, the seeking speed may also become	 zero */
 		/* Lowest value allowed by spec is -64, notify on change only */
-		if (pl.seeking_speed_factor >= -(MEDIA_PROXY_SEEKING_SPEED_FACTOR_MAX
+		if (media_player.seeking_speed_factor >= -(MEDIA_PROXY_SEEKING_SPEED_FACTOR_MAX
 						 - MPL_SEEKING_SPEED_FACTOR_STEP)) {
-			pl.seeking_speed_factor -= MPL_SEEKING_SPEED_FACTOR_STEP;
-			media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
+			media_player.seeking_speed_factor -= MPL_SEEKING_SPEED_FACTOR_STEP;
+			media_proxy_pl_seeking_speed_cb(media_player.seeking_speed_factor);
 		}
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FAST_FORWARD:
 		/* Highest value allowed by spec is 64, notify on change only */
-		if (pl.seeking_speed_factor <= (MEDIA_PROXY_SEEKING_SPEED_FACTOR_MAX
+		if (media_player.seeking_speed_factor <= (MEDIA_PROXY_SEEKING_SPEED_FACTOR_MAX
 						- MPL_SEEKING_SPEED_FACTOR_STEP)) {
-			pl.seeking_speed_factor += MPL_SEEKING_SPEED_FACTOR_STEP;
-			media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
+			media_player.seeking_speed_factor += MPL_SEEKING_SPEED_FACTOR_STEP;
+			media_proxy_pl_seeking_speed_cb(media_player.seeking_speed_factor);
 		}
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_STOP:
-		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
-		pl.track_pos = 0;
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
-		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		media_player.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+		media_player.track_pos = 0;
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
+		media_proxy_pl_seeking_speed_cb(media_player.seeking_speed_factor);
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
@@ -2092,59 +2093,59 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 		if (command->use_param) {
 			/* Keep within track - i.e. in the range 0 - duration */
 			if (command->param >
-			    pl.group->track->duration - pl.track_pos) {
-				pl.track_pos = pl.group->track->duration;
-			} else if (command->param < -pl.track_pos) {
-				pl.track_pos = 0;
+			    media_player.group->track->duration - media_player.track_pos) {
+				media_player.track_pos = media_player.group->track->duration;
+			} else if (command->param < -media_player.track_pos) {
+				media_player.track_pos = 0;
 			} else {
-				pl.track_pos += command->param;
+				media_player.track_pos += command->param;
 			}
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PREV_SEGMENT:
 		/* Switch to previous segment if we are less than 5 seconds */
 		/* into the segment, otherwise go to start of segment */
-		if (pl.track_pos - PREV_MARGIN <
-		    pl.group->track->segment->pos) {
-			do_prev_segment(&pl);
+		if (media_player.track_pos - PREV_MARGIN <
+		    media_player.group->track->segment->pos) {
+			do_prev_segment(&media_player);
 		}
-		pl.track_pos = pl.group->track->segment->pos;
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		media_player.track_pos = media_player.group->track->segment->pos;
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_NEXT_SEGMENT:
-		do_next_segment(&pl);
-		pl.track_pos = pl.group->track->segment->pos;
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		do_next_segment(&media_player);
+		media_player.track_pos = media_player.group->track->segment->pos;
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FIRST_SEGMENT:
-		do_first_segment(&pl);
-		pl.track_pos = pl.group->track->segment->pos;
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		do_first_segment(&media_player);
+		media_player.track_pos = media_player.group->track->segment->pos;
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_LAST_SEGMENT:
-		do_last_segment(&pl);
-		pl.track_pos = pl.group->track->segment->pos;
-		media_proxy_pl_track_position_cb(pl.track_pos);
+		do_last_segment(&media_player);
+		media_player.track_pos = media_player.group->track->segment->pos;
+		media_proxy_pl_track_position_cb(media_player.track_pos);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_GOTO_SEGMENT:
 		if (command->use_param) {
 			if (command->param != 0) {
-				do_goto_segment(&pl, command->param);
-				pl.track_pos = pl.group->track->segment->pos;
-				media_proxy_pl_track_position_cb(pl.track_pos);
+				do_goto_segment(&media_player, command->param);
+				media_player.track_pos = media_player.group->track->segment->pos;
+				media_proxy_pl_track_position_cb(media_player.track_pos);
 			}
 			/* If the argument to "goto segment" is zero, */
 			/* the segment shall stay the same, and the */
@@ -2156,89 +2157,89 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PREV_TRACK:
-		if (do_prev_track(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+		if (do_prev_track(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		} else {
 			/* For previous track, the position is reset to 0 */
 			/* even if we stay at the same track (goto start of */
 			/* track) */
-			pl.track_pos = 0;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = 0;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 		}
-		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		media_player.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_NEXT_TRACK:
-		if (pl.next_track_set) {
+		if (media_player.next_track_set) {
 			LOG_DBG("Next track set");
-			if (do_next_track_next_track_set(&pl)) {
-				do_group_change_notifications(&pl);
+			if (do_next_track_next_track_set(&media_player)) {
+				do_group_change_notifications(&media_player);
 			}
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
-		} else if (do_next_track_normal_order(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
+		} else if (do_next_track_normal_order(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		}
 		/* For next track, the position is kept if the track */
 		/* does not change */
-		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		media_player.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FIRST_TRACK:
-		if (do_first_track(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+		if (do_first_track(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		} else {
 			/* For first track, the position is reset to 0 even */
 			/* if we stay at the same track (goto start of track) */
-			pl.track_pos = 0;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = 0;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 		}
-		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		media_player.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_LAST_TRACK:
-		if (do_last_track(&pl)) {
-			pl.track_pos = 0;
-			do_track_change_notifications(&pl);
+		if (do_last_track(&media_player)) {
+			media_player.track_pos = 0;
+			do_track_change_notifications(&media_player);
 		} else {
 			/* For last track, the position is reset to 0 even */
 			/* if we stay at the same track (goto start of track) */
-			pl.track_pos = 0;
-			media_proxy_pl_track_position_cb(pl.track_pos);
+			media_player.track_pos = 0;
+			media_proxy_pl_track_position_cb(media_player.track_pos);
 		}
-		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		media_player.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_GOTO_TRACK:
 		if (command->use_param) {
-			if (do_goto_track(&pl, command->param)) {
-				pl.track_pos = 0;
-				do_track_change_notifications(&pl);
+			if (do_goto_track(&media_player, command->param)) {
+				media_player.track_pos = 0;
+				do_track_change_notifications(&media_player);
 			} else {
 				/* For goto track, the position is reset to 0 */
 				/* even if we stay at the same track (goto */
 				/* start of track) */
-				pl.track_pos = 0;
-				media_proxy_pl_track_position_cb(pl.track_pos);
+				media_player.track_pos = 0;
+				media_proxy_pl_track_position_cb(media_player.track_pos);
 			}
-			pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
-			pl.state = MEDIA_PROXY_STATE_PAUSED;
-			media_proxy_pl_media_state_cb(pl.state);
+			media_player.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+			media_player.state = MEDIA_PROXY_STATE_PAUSED;
+			media_proxy_pl_media_state_cb(media_player.state);
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
@@ -2246,38 +2247,38 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_PREV_GROUP:
-		do_full_prev_group(&pl);
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		do_full_prev_group(&media_player);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_NEXT_GROUP:
-		do_full_next_group(&pl);
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		do_full_next_group(&media_player);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_FIRST_GROUP:
-		do_full_first_group(&pl);
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		do_full_first_group(&media_player);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_LAST_GROUP:
-		do_full_last_group(&pl);
-		pl.state = MEDIA_PROXY_STATE_PAUSED;
-		media_proxy_pl_media_state_cb(pl.state);
+		do_full_last_group(&media_player);
+		media_player.state = MEDIA_PROXY_STATE_PAUSED;
+		media_proxy_pl_media_state_cb(media_player.state);
 		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case MEDIA_PROXY_OP_GOTO_GROUP:
 		if (command->use_param) {
-			do_full_goto_group(&pl, command->param);
-			pl.state = MEDIA_PROXY_STATE_PAUSED;
-			media_proxy_pl_media_state_cb(pl.state);
+			do_full_goto_group(&media_player, command->param);
+			media_player.state = MEDIA_PROXY_STATE_PAUSED;
+			media_proxy_pl_media_state_cb(media_player.state);
 			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
 			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
@@ -2378,97 +2379,97 @@ static bool find_group_by_id(const struct mpl_mediaplayer *pl, uint64_t id,
 
 const char *get_player_name(void)
 {
-	return pl.name;
+	return media_player.name;
 }
 
 #ifdef CONFIG_BT_MPL_OBJECTS
 uint64_t get_icon_id(void)
 {
-	return pl.icon_id;
+	return media_player.icon_id;
 }
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 const char *get_icon_url(void)
 {
-	return pl.icon_url;
+	return media_player.icon_url;
 }
 
 const char *get_track_title(void)
 {
-	return pl.group->track->title;
+	return media_player.group->track->title;
 }
 
 int32_t get_track_duration(void)
 {
-	return pl.group->track->duration;
+	return media_player.group->track->duration;
 }
 
 int32_t get_track_position(void)
 {
-	return pl.track_pos;
+	return media_player.track_pos;
 }
 
 void set_track_position(int32_t position)
 {
-	int32_t old_pos = pl.track_pos;
+	int32_t old_pos = media_player.track_pos;
 	int32_t new_pos;
 
 	if (position >= 0) {
-		if (position > pl.group->track->duration) {
+		if (position > media_player.group->track->duration) {
 			/* Do not go beyond end of track */
-			new_pos = pl.group->track->duration;
+			new_pos = media_player.group->track->duration;
 		} else {
 			new_pos = position;
 		}
 	} else {
 		/* Negative position, handle as offset from _end_ of track */
 		/* (Note minus sign below) */
-		if (position < -pl.group->track->duration) {
+		if (position < -media_player.group->track->duration) {
 			new_pos = 0;
 		} else {
 			/* (Remember position is negative) */
-			new_pos = pl.group->track->duration + position;
+			new_pos = media_player.group->track->duration + position;
 		}
 	}
 
 	LOG_DBG("Pos. given: %d, resulting pos.: %d (duration is %d)", position, new_pos,
-		pl.group->track->duration);
+		media_player.group->track->duration);
 
 	if (new_pos != old_pos) {
 		/* Set new position and notify it */
-		pl.track_pos = new_pos;
+		media_player.track_pos = new_pos;
 		media_proxy_pl_track_position_cb(new_pos);
 	}
 }
 
 int8_t get_playback_speed(void)
 {
-	return pl.playback_speed_param;
+	return media_player.playback_speed_param;
 }
 
 void set_playback_speed(int8_t speed)
 {
 	/* Set new speed parameter and notify, if different from current */
-	if (speed != pl.playback_speed_param) {
-		pl.playback_speed_param = speed;
-		media_proxy_pl_playback_speed_cb(pl.playback_speed_param);
+	if (speed != media_player.playback_speed_param) {
+		media_player.playback_speed_param = speed;
+		media_proxy_pl_playback_speed_cb(media_player.playback_speed_param);
 	}
 }
 
 int8_t get_seeking_speed(void)
 {
-	return pl.seeking_speed_factor;
+	return media_player.seeking_speed_factor;
 }
 
 #ifdef CONFIG_BT_MPL_OBJECTS
 uint64_t get_track_segments_id(void)
 {
-	return pl.group->track->segments_id;
+	return media_player.group->track->segments_id;
 }
 
 uint64_t get_current_track_id(void)
 {
-	return pl.group->track->id;
+	return media_player.group->track->id;
 }
 
 void set_current_track_id(uint64_t id)
@@ -2478,18 +2479,18 @@ void set_current_track_id(uint64_t id)
 
 	LOG_DBG_OBJ_ID("Track ID to set: ", id);
 
-	if (find_track_by_id(&pl, id, &group, &track)) {
-		if (pl.group != group) {
-			pl.group = group;
-			do_group_change_notifications(&pl);
+	if (find_track_by_id(&media_player, id, &group, &track)) {
+		if (media_player.group != group) {
+			media_player.group = group;
+			do_group_change_notifications(&media_player);
 
 			/* Group change implies track change (even if same track in other group) */
-			pl.group->track = track;
-			do_track_change_notifications(&pl);
+			media_player.group->track = track;
+			do_track_change_notifications(&media_player);
 
-		} else if (pl.group->track != track) {
-			pl.group->track = track;
-			do_track_change_notifications(&pl);
+		} else if (media_player.group->track != track) {
+			media_player.group->track = track;
+			do_track_change_notifications(&media_player);
 		}
 		return;
 	}
@@ -2504,13 +2505,13 @@ void set_current_track_id(uint64_t id)
 uint64_t get_next_track_id(void)
 {
 	/* If the next track has been set explicitly */
-	if (pl.next_track_set) {
-		return pl.next.track->id;
+	if (media_player.next_track_set) {
+		return media_player.next.track->id;
 	}
 
 	/* Normal playing order */
-	if (pl.group->track->next) {
-		return pl.group->track->next->id;
+	if (media_player.group->track->next) {
+		return media_player.group->track->next->id;
 	}
 
 	/* Return zero value to indicate that there is no next track */
@@ -2524,11 +2525,11 @@ void set_next_track_id(uint64_t id)
 
 	LOG_DBG_OBJ_ID("Next Track ID to set: ", id);
 
-	if (find_track_by_id(&pl, id, &group, &track)) {
+	if (find_track_by_id(&media_player, id, &group, &track)) {
 
-		pl.next_track_set = true;
-		pl.next.group = group;
-		pl.next.track = track;
+		media_player.next_track_set = true;
+		media_player.next.group = group;
+		media_player.next.track = track;
 		media_proxy_pl_next_track_id_cb(id);
 		return;
 	}
@@ -2538,12 +2539,12 @@ void set_next_track_id(uint64_t id)
 
 uint64_t get_parent_group_id(void)
 {
-	return pl.group->parent->id;
+	return media_player.group->parent->id;
 }
 
 uint64_t get_current_group_id(void)
 {
-	return pl.group->id;
+	return media_player.group->id;
 }
 
 void set_current_group_id(uint64_t id)
@@ -2553,17 +2554,17 @@ void set_current_group_id(uint64_t id)
 
 	LOG_DBG_OBJ_ID("Group ID to set: ", id);
 
-	if (find_group_by_id(&pl, id, &group)) {
+	if (find_group_by_id(&media_player, id, &group)) {
 
-		if (pl.group != group) {
+		if (media_player.group != group) {
 			/* Change to found group */
-			pl.group = group;
-			do_group_change_notifications(&pl);
+			media_player.group = group;
+			do_group_change_notifications(&media_player);
 
 			/* And change to first track in group */
-			track_change = do_first_track(&pl);
+			track_change = do_first_track(&media_player);
 			if (track_change) {
-				do_track_change_notifications(&pl);
+				do_track_change_notifications(&media_player);
 			}
 		}
 		return;
@@ -2575,27 +2576,27 @@ void set_current_group_id(uint64_t id)
 
 uint8_t get_playing_order(void)
 {
-	return pl.playing_order;
+	return media_player.playing_order;
 }
 
 void set_playing_order(uint8_t order)
 {
-	if (order != pl.playing_order) {
-		if (BIT(order - 1) & pl.playing_orders_supported) {
-			pl.playing_order = order;
-			media_proxy_pl_playing_order_cb(pl.playing_order);
+	if (order != media_player.playing_order) {
+		if (BIT(order - 1) & media_player.playing_orders_supported) {
+			media_player.playing_order = order;
+			media_proxy_pl_playing_order_cb(media_player.playing_order);
 		}
 	}
 }
 
 uint16_t get_playing_orders_supported(void)
 {
-	return pl.playing_orders_supported;
+	return media_player.playing_orders_supported;
 }
 
 uint8_t get_media_state(void)
 {
-	return pl.state;
+	return media_player.state;
 }
 
 void send_command(const struct mpl_cmd *command)
@@ -2608,9 +2609,9 @@ void send_command(const struct mpl_cmd *command)
 		LOG_DBG("opcode: %d", command->opcode);
 	}
 
-	if (pl.state < MEDIA_PROXY_STATE_LAST) {
+	if (media_player.state < MEDIA_PROXY_STATE_LAST) {
 		ntf.requested_opcode = command->opcode;
-		command_handlers[pl.state](command, &ntf);
+		command_handlers[media_player.state](command, &ntf);
 	} else {
 		LOG_DBG("INVALID STATE");
 	}
@@ -2618,7 +2619,7 @@ void send_command(const struct mpl_cmd *command)
 
 uint32_t get_commands_supported(void)
 {
-	return pl.opcodes_supported;
+	return media_player.opcodes_supported;
 }
 
 #ifdef CONFIG_BT_MPL_OBJECTS
@@ -2664,15 +2665,15 @@ static void parse_search(const struct mpl_search *search)
 	/* For now, just fake it. */
 
 	if (search_failed) {
-		pl.search_results_id = 0;
+		media_player.search_results_id = 0;
 		media_proxy_pl_search_cb(MEDIA_PROXY_SEARCH_FAILURE);
 	} else {
 		/* Use current group as search result for now */
-		pl.search_results_id = pl.group->id;
+		media_player.search_results_id = media_player.group->id;
 		media_proxy_pl_search_cb(MEDIA_PROXY_SEARCH_SUCCESS);
 	}
 
-	media_proxy_pl_search_results_id_cb(pl.search_results_id);
+	media_proxy_pl_search_results_id_cb(media_player.search_results_id);
 }
 
 void send_search(const struct mpl_search *search)
@@ -2688,13 +2689,13 @@ void send_search(const struct mpl_search *search)
 
 uint64_t get_search_results_id(void)
 {
-	return pl.search_results_id;
+	return media_player.search_results_id;
 }
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 uint8_t get_content_ctrl_id(void)
 {
-	return pl.content_ctrl_id;
+	return media_player.content_ctrl_id;
 }
 
 int media_proxy_pl_init(void)
@@ -2727,21 +2728,21 @@ int media_proxy_pl_init(void)
 #endif /* CONFIG_BT_MCS */
 
 	/* Get a Content Control ID */
-	pl.content_ctrl_id = bt_ccid_get_value();
+	media_player.content_ctrl_id = bt_ccid_get_value();
 
 #ifdef CONFIG_BT_MPL_OBJECTS
 	/* Initialize the object content buffer */
 	net_buf_simple_init(obj.content, 0);
 
 	/* Icon Object */
-	ret = add_icon_object(&pl);
+	ret = add_icon_object(&media_player);
 	if (ret < 0) {
 		LOG_ERR("Unable to add icon object, error %d", ret);
 		return ret;
 	}
 
 	/* Add all tracks and groups to OTS */
-	ret = add_group_and_track_objects(&pl);
+	ret = add_group_and_track_objects(&media_player);
 	if (ret < 0) {
 		LOG_ERR("Error adding tracks and groups to OTS, error %d", ret);
 		return ret;
@@ -2750,7 +2751,7 @@ int media_proxy_pl_init(void)
 	/* Initial setup of Track Segments Object */
 	/* TODO: Later, this should be done when the tracks are added */
 	/* but for no only one of the tracks has segments .*/
-	ret = add_current_track_segments_object(&pl);
+	ret = add_current_track_segments_object(&media_player);
 	if (ret < 0) {
 		LOG_ERR("Error adding Track Segments Object to OTS, error %d", ret);
 		return ret;
@@ -2758,41 +2759,41 @@ int media_proxy_pl_init(void)
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	/* Set up the calls structure */
-	pl.calls.get_player_name              = get_player_name;
+	media_player.calls.get_player_name              = get_player_name;
 #ifdef CONFIG_BT_MPL_OBJECTS
-	pl.calls.get_icon_id                  = get_icon_id;
+	media_player.calls.get_icon_id                  = get_icon_id;
 #endif /* CONFIG_BT_MPL_OBJECTS */
-	pl.calls.get_icon_url                 = get_icon_url;
-	pl.calls.get_track_title              = get_track_title;
-	pl.calls.get_track_duration           = get_track_duration;
-	pl.calls.get_track_position           = get_track_position;
-	pl.calls.set_track_position           = set_track_position;
-	pl.calls.get_playback_speed           = get_playback_speed;
-	pl.calls.set_playback_speed           = set_playback_speed;
-	pl.calls.get_seeking_speed            = get_seeking_speed;
+	media_player.calls.get_icon_url                 = get_icon_url;
+	media_player.calls.get_track_title              = get_track_title;
+	media_player.calls.get_track_duration           = get_track_duration;
+	media_player.calls.get_track_position           = get_track_position;
+	media_player.calls.set_track_position           = set_track_position;
+	media_player.calls.get_playback_speed           = get_playback_speed;
+	media_player.calls.set_playback_speed           = set_playback_speed;
+	media_player.calls.get_seeking_speed            = get_seeking_speed;
 #ifdef CONFIG_BT_MPL_OBJECTS
-	pl.calls.get_track_segments_id        = get_track_segments_id;
-	pl.calls.get_current_track_id         = get_current_track_id;
-	pl.calls.set_current_track_id         = set_current_track_id;
-	pl.calls.get_next_track_id            = get_next_track_id;
-	pl.calls.set_next_track_id            = set_next_track_id;
-	pl.calls.get_parent_group_id          = get_parent_group_id;
-	pl.calls.get_current_group_id         = get_current_group_id;
-	pl.calls.set_current_group_id         = set_current_group_id;
+	media_player.calls.get_track_segments_id        = get_track_segments_id;
+	media_player.calls.get_current_track_id         = get_current_track_id;
+	media_player.calls.set_current_track_id         = set_current_track_id;
+	media_player.calls.get_next_track_id            = get_next_track_id;
+	media_player.calls.set_next_track_id            = set_next_track_id;
+	media_player.calls.get_parent_group_id          = get_parent_group_id;
+	media_player.calls.get_current_group_id         = get_current_group_id;
+	media_player.calls.set_current_group_id         = set_current_group_id;
 #endif /* CONFIG_BT_MPL_OBJECTS */
-	pl.calls.get_playing_order            = get_playing_order;
-	pl.calls.set_playing_order            = set_playing_order;
-	pl.calls.get_playing_orders_supported = get_playing_orders_supported;
-	pl.calls.get_media_state              = get_media_state;
-	pl.calls.send_command                 = send_command;
-	pl.calls.get_commands_supported       = get_commands_supported;
+	media_player.calls.get_playing_order            = get_playing_order;
+	media_player.calls.set_playing_order            = set_playing_order;
+	media_player.calls.get_playing_orders_supported = get_playing_orders_supported;
+	media_player.calls.get_media_state              = get_media_state;
+	media_player.calls.send_command                 = send_command;
+	media_player.calls.get_commands_supported       = get_commands_supported;
 #ifdef CONFIG_BT_MPL_OBJECTS
-	pl.calls.send_search                  = send_search;
-	pl.calls.get_search_results_id        = get_search_results_id;
+	media_player.calls.send_search                  = send_search;
+	media_player.calls.get_search_results_id        = get_search_results_id;
 #endif /* CONFIG_BT_MPL_OBJECTS */
-	pl.calls.get_content_ctrl_id          = get_content_ctrl_id;
+	media_player.calls.get_content_ctrl_id          = get_content_ctrl_id;
 
-	ret = media_proxy_pl_register(&pl.calls);
+	ret = media_proxy_pl_register(&media_player.calls);
 	if (ret < 0) {
 		LOG_ERR("Unable to register player");
 		return ret;
@@ -2812,53 +2813,53 @@ void mpl_debug_dump_state(void)
 	struct mpl_track *track;
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
-	LOG_DBG("Mediaplayer name: %s", pl.name);
+	LOG_DBG("Mediaplayer name: %s", media_player.name);
 
 #if CONFIG_BT_MPL_OBJECTS
-	(void)bt_ots_obj_id_to_str(pl.icon_id, t, sizeof(t));
+	(void)bt_ots_obj_id_to_str(media_player.icon_id, t, sizeof(t));
 	LOG_DBG("Icon ID: %s", t);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
-	LOG_DBG("Icon URL: %s", pl.icon_url);
-	LOG_DBG("Track position: %d", pl.track_pos);
-	LOG_DBG("Media state: %d", pl.state);
-	LOG_DBG("Playback speed parameter: %d", pl.playback_speed_param);
-	LOG_DBG("Seeking speed factor: %d", pl.seeking_speed_factor);
-	LOG_DBG("Playing order: %d", pl.playing_order);
-	LOG_DBG("Playing orders supported: 0x%x", pl.playing_orders_supported);
-	LOG_DBG("Opcodes supported: %d", pl.opcodes_supported);
-	LOG_DBG("Content control ID: %d", pl.content_ctrl_id);
+	LOG_DBG("Icon URL: %s", media_player.icon_url);
+	LOG_DBG("Track position: %d", media_player.track_pos);
+	LOG_DBG("Media state: %d", media_player.state);
+	LOG_DBG("Playback speed parameter: %d", media_player.playback_speed_param);
+	LOG_DBG("Seeking speed factor: %d", media_player.seeking_speed_factor);
+	LOG_DBG("Playing order: %d", media_player.playing_order);
+	LOG_DBG("Playing orders supported: 0x%x", media_player.playing_orders_supported);
+	LOG_DBG("Opcodes supported: %d", media_player.opcodes_supported);
+	LOG_DBG("Content control ID: %d", media_player.content_ctrl_id);
 
 #if CONFIG_BT_MPL_OBJECTS
-	(void)bt_ots_obj_id_to_str(pl.group->parent->id, t, sizeof(t));
+	(void)bt_ots_obj_id_to_str(media_player.group->parent->id, t, sizeof(t));
 	LOG_DBG("Current group's parent: %s", t);
 
-	(void)bt_ots_obj_id_to_str(pl.group->id, t, sizeof(t));
+	(void)bt_ots_obj_id_to_str(media_player.group->id, t, sizeof(t));
 	LOG_DBG("Current group: %s", t);
 
-	(void)bt_ots_obj_id_to_str(pl.group->track->id, t, sizeof(t));
+	(void)bt_ots_obj_id_to_str(media_player.group->track->id, t, sizeof(t));
 	LOG_DBG("Current track: %s", t);
 
-	if (pl.next_track_set) {
-		(void)bt_ots_obj_id_to_str(pl.next.track->id, t, sizeof(t));
+	if (media_player.next_track_set) {
+		(void)bt_ots_obj_id_to_str(media_player.next.track->id, t, sizeof(t));
 		LOG_DBG("Next track: %s", t);
-	} else if (pl.group->track->next) {
-		(void)bt_ots_obj_id_to_str(pl.group->track->next->id, t,
+	} else if (media_player.group->track->next) {
+		(void)bt_ots_obj_id_to_str(media_player.group->track->next->id, t,
 					   sizeof(t));
 		LOG_DBG("Next track: %s", t);
 	} else {
 		LOG_DBG("No next track");
 	}
 
-	if (pl.search_results_id) {
-		(void)bt_ots_obj_id_to_str(pl.search_results_id, t, sizeof(t));
+	if (media_player.search_results_id) {
+		(void)bt_ots_obj_id_to_str(media_player.search_results_id, t, sizeof(t));
 		LOG_DBG("Search results: %s", t);
 	} else {
 		LOG_DBG("No search results");
 	}
 
 	LOG_DBG("Groups and tracks:");
-	group = pl.group;
+	group = media_player.group;
 
 	while (group->prev != NULL) {
 		group = group->prev;
@@ -2895,24 +2896,24 @@ void mpl_debug_dump_state(void)
 void mpl_test_unset_parent_group(void)
 {
 	LOG_DBG("Setting current group to be it's own parent");
-	pl.group->parent = pl.group;
+	media_player.group->parent = media_player.group;
 }
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 void mpl_test_media_state_set(uint8_t state)
 {
-	pl.state = state;
-	media_proxy_pl_media_state_cb(pl.state);
+	media_player.state = state;
+	media_proxy_pl_media_state_cb(media_player.state);
 }
 
 void mpl_test_player_name_changed_cb(void)
 {
-	media_proxy_pl_name_cb(pl.name);
+	media_proxy_pl_name_cb(media_player.name);
 }
 
 void mpl_test_player_icon_url_changed_cb(void)
 {
-	media_proxy_pl_icon_url_cb(pl.icon_url);
+	media_proxy_pl_icon_url_cb(media_player.icon_url);
 }
 
 void mpl_test_track_changed_cb(void)
@@ -2922,70 +2923,70 @@ void mpl_test_track_changed_cb(void)
 
 void mpl_test_title_changed_cb(void)
 {
-	media_proxy_pl_track_title_cb(pl.group->track->title);
+	media_proxy_pl_track_title_cb(media_player.group->track->title);
 }
 
 void mpl_test_duration_changed_cb(void)
 {
-	media_proxy_pl_track_duration_cb(pl.group->track->duration);
+	media_proxy_pl_track_duration_cb(media_player.group->track->duration);
 }
 
 void mpl_test_position_changed_cb(void)
 {
-	media_proxy_pl_track_position_cb(pl.track_pos);
+	media_proxy_pl_track_position_cb(media_player.track_pos);
 }
 
 void mpl_test_playback_speed_changed_cb(void)
 {
-	media_proxy_pl_playback_speed_cb(pl.playback_speed_param);
+	media_proxy_pl_playback_speed_cb(media_player.playback_speed_param);
 }
 
 void mpl_test_seeking_speed_changed_cb(void)
 {
-	media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
+	media_proxy_pl_seeking_speed_cb(media_player.seeking_speed_factor);
 }
 
 #ifdef CONFIG_BT_MPL_OBJECTS
 void mpl_test_current_track_id_changed_cb(void)
 {
-	media_proxy_pl_current_track_id_cb(pl.group->track->id);
+	media_proxy_pl_current_track_id_cb(media_player.group->track->id);
 }
 
 void mpl_test_next_track_id_changed_cb(void)
 {
-	media_proxy_pl_next_track_id_cb(pl.group->track->next->id);
+	media_proxy_pl_next_track_id_cb(media_player.group->track->next->id);
 }
 
 void mpl_test_parent_group_id_changed_cb(void)
 {
-	media_proxy_pl_parent_group_id_cb(pl.group->id);
+	media_proxy_pl_parent_group_id_cb(media_player.group->id);
 }
 
 void mpl_test_current_group_id_changed_cb(void)
 {
-	media_proxy_pl_current_group_id_cb(pl.group->id);
+	media_proxy_pl_current_group_id_cb(media_player.group->id);
 }
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 void mpl_test_playing_order_changed_cb(void)
 {
-	media_proxy_pl_playing_order_cb(pl.playing_order);
+	media_proxy_pl_playing_order_cb(media_player.playing_order);
 }
 
 void mpl_test_media_state_changed_cb(void)
 {
-	media_proxy_pl_media_state_cb(pl.playing_order);
+	media_proxy_pl_media_state_cb(media_player.playing_order);
 }
 
 void mpl_test_opcodes_supported_changed_cb(void)
 {
-	media_proxy_pl_commands_supported_cb(pl.opcodes_supported);
+	media_proxy_pl_commands_supported_cb(media_player.opcodes_supported);
 }
 
 #ifdef CONFIG_BT_MPL_OBJECTS
 void mpl_test_search_results_changed_cb(void)
 {
-	media_proxy_pl_search_cb(pl.search_results_id);
+	media_proxy_pl_search_cb(media_player.search_results_id);
 }
 #endif /* CONFIG_BT_MPL_OBJECTS */
 

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -970,7 +970,7 @@ static int cmd_discover(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (!cbs_registered) {
-		int err = bt_bap_unicast_client_register_cb(&unicast_client_cbs);
+		err = bt_bap_unicast_client_register_cb(&unicast_client_cbs);
 
 		if (err != 0) {
 			shell_error(sh, "Failed to register unicast client callbacks: %d", err);
@@ -1981,12 +1981,13 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 		bool group_can_be_deleted = true;
 
 		for (size_t i = 0U; i < ARRAY_SIZE(unicast_streams); i++) {
-			const struct bt_bap_stream *stream = &unicast_streams[i].stream.bap_stream;
+			const struct bt_bap_stream *bap_stream =
+				&unicast_streams[i].stream.bap_stream;
 
-			if (stream->ep != NULL) {
+			if (bap_stream->ep != NULL) {
 				struct bt_bap_ep_info ep_info;
 
-				bt_bap_ep_get_info(stream->ep, &ep_info);
+				bt_bap_ep_get_info(bap_stream->ep, &ep_info);
 
 				if (ep_info.state != BT_BAP_EP_STATE_CODEC_CONFIGURED &&
 				    ep_info.state != BT_BAP_EP_STATE_IDLE) {
@@ -2285,7 +2286,6 @@ static int cmd_sync_broadcast(const struct shell *sh, size_t argc, char *argv[])
 	stream_cnt = 0U;
 	for (int i = 1; i < argc; i++) {
 		unsigned long val;
-		int err = 0;
 
 		val = shell_strtoul(argv[i], 0, &err);
 		if (err != 0) {

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -234,17 +234,17 @@ static int cmd_cap_initiator_unicast_start(const struct shell *sh, size_t argc,
 
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0
 		conn_snk_cnt = sink_cnt;
-		for (size_t i = 0U; i < sink_cnt; i++) {
+		for (size_t j = 0U; j < sink_cnt; j++) {
 			struct bt_cap_stream *stream =
 				&unicast_streams[start_param.count].stream;
 			struct shell_stream *uni_stream =
 				CONTAINER_OF(stream, struct shell_stream, stream);
-			struct bt_bap_ep *snk_ep = snks[bt_conn_index(conn)][i];
+			struct bt_bap_ep *snk_ep = snks[bt_conn_index(conn)][j];
 
 			if (snk_ep == NULL) {
 				shell_info(sh, "Could only setup %zu/%zu sink endpoints",
-					   i, sink_cnt);
-				conn_snk_cnt = i;
+					   j, sink_cnt);
+				conn_snk_cnt = j;
 				break;
 			}
 
@@ -259,7 +259,7 @@ static int cmd_cap_initiator_unicast_start(const struct shell *sh, size_t argc,
 				stream_param[start_param.count].qos;
 			group_stream_params[start_param.count].stream =
 				&stream_param[start_param.count].stream->bap_stream;
-			pair_params[pair_cnt + i].tx_param =
+			pair_params[pair_cnt + j].tx_param =
 				&group_stream_params[start_param.count];
 
 			start_param.count++;
@@ -268,17 +268,17 @@ static int cmd_cap_initiator_unicast_start(const struct shell *sh, size_t argc,
 
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0
 		conn_src_cnt = source_cnt;
-		for (size_t i = 0U; i < source_cnt; i++) {
+		for (size_t j = 0U; j < source_cnt; j++) {
 			struct bt_cap_stream *stream =
 				&unicast_streams[start_param.count].stream;
 			struct shell_stream *uni_stream =
 				CONTAINER_OF(stream, struct shell_stream, stream);
-			struct bt_bap_ep *src_ep = srcs[bt_conn_index(conn)][i];
+			struct bt_bap_ep *src_ep = srcs[bt_conn_index(conn)][j];
 
 			if (src_ep == NULL) {
 				shell_info(sh, "Could only setup %zu/%zu source endpoints",
-					   i, source_cnt);
-				conn_src_cnt = i;
+					   j, source_cnt);
+				conn_src_cnt = j;
 				break;
 			}
 
@@ -293,7 +293,7 @@ static int cmd_cap_initiator_unicast_start(const struct shell *sh, size_t argc,
 				stream_param[start_param.count].qos;
 			group_stream_params[start_param.count].stream =
 				&stream_param[start_param.count].stream->bap_stream;
-			pair_params[pair_cnt + i].rx_param =
+			pair_params[pair_cnt + j].rx_param =
 				&group_stream_params[start_param.count];
 
 			start_param.count++;

--- a/subsys/bluetooth/audio/shell/csip_set_member.c
+++ b/subsys/bluetooth/audio/shell/csip_set_member.c
@@ -24,7 +24,7 @@ struct bt_csip_set_member_svc_inst *svc_inst;
 static uint8_t sirk_read_rsp = BT_CSIP_READ_SIRK_REQ_RSP_ACCEPT;
 
 static void locked_cb(struct bt_conn *conn,
-		      struct bt_csip_set_member_svc_inst *svc_inst,
+		      struct bt_csip_set_member_svc_inst *inst,
 		      bool locked)
 {
 	if (conn == NULL) {
@@ -41,7 +41,7 @@ static void locked_cb(struct bt_conn *conn,
 }
 
 static uint8_t sirk_read_req_cb(struct bt_conn *conn,
-				struct bt_csip_set_member_svc_inst *svc_inst)
+				struct bt_csip_set_member_svc_inst *inst)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 	static const char *const rsp_strings[] = {

--- a/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
@@ -16,7 +16,7 @@
 
 #include "shell/bt.h"
 
-static struct bt_micp_mic_ctlr *mic_ctlr;
+static struct bt_micp_mic_ctlr *micp_mic_ctlr;
 #if defined(CONFIG_BT_MICP_MIC_CTLR_AICS)
 static struct bt_micp_included micp_included;
 #endif /* CONFIG_BT_MICP_MIC_CTLR_AICS */
@@ -233,7 +233,7 @@ static int cmd_micp_mic_ctlr_discover(const struct shell *sh, size_t argc,
 		return -ENOTCONN;
 	}
 
-	result = bt_micp_mic_ctlr_discover(default_conn, &mic_ctlr);
+	result = bt_micp_mic_ctlr_discover(default_conn, &micp_mic_ctlr);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -246,11 +246,11 @@ static int cmd_micp_mic_ctlr_mute_get(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 
-	result = bt_micp_mic_ctlr_mute_get(mic_ctlr);
+	result = bt_micp_mic_ctlr_mute_get(micp_mic_ctlr);
 
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
@@ -264,11 +264,11 @@ static int cmd_micp_mic_ctlr_mute(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 
-	result = bt_micp_mic_ctlr_mute(mic_ctlr);
+	result = bt_micp_mic_ctlr_mute(micp_mic_ctlr);
 
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
@@ -282,11 +282,11 @@ static int cmd_micp_mic_ctlr_unmute(const struct shell *sh, size_t argc,
 {
 	int result;
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 
-	result = bt_micp_mic_ctlr_unmute(mic_ctlr);
+	result = bt_micp_mic_ctlr_unmute(micp_mic_ctlr);
 
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
@@ -316,7 +316,7 @@ static int cmd_micp_mic_ctlr_aics_input_state_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 
@@ -348,7 +348,7 @@ static int cmd_micp_mic_ctlr_aics_gain_setting_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 
@@ -380,7 +380,7 @@ static int cmd_micp_mic_ctlr_aics_input_type_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 
@@ -412,7 +412,7 @@ static int cmd_micp_mic_ctlr_aics_input_status_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 
@@ -472,7 +472,7 @@ static int cmd_micp_mic_ctlr_aics_input_mute(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 
@@ -504,7 +504,7 @@ static int cmd_micp_mic_ctlr_aics_manual_input_gain_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 
@@ -537,7 +537,7 @@ static int cmd_micp_mic_ctlr_aics_automatic_input_gain_set(const struct shell *s
 		return -ENOEXEC;
 	}
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 
@@ -584,7 +584,7 @@ static int cmd_micp_mic_ctlr_aics_gain_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 
@@ -616,7 +616,7 @@ static int cmd_micp_mic_ctlr_aics_input_description_get(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 
@@ -648,7 +648,7 @@ static int cmd_micp_mic_ctlr_aics_input_description_set(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (mic_ctlr == NULL) {
+	if (micp_mic_ctlr == NULL) {
 		return -ENOENT;
 	}
 

--- a/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
@@ -15,7 +15,7 @@
 
 #include "shell/bt.h"
 
-static struct bt_vcp_vol_ctlr *vol_ctlr;
+static struct bt_vcp_vol_ctlr *vcp_vol_ctlr;
 static struct bt_vcp_included vcp_included;
 
 static void vcs_discover_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err,
@@ -343,7 +343,7 @@ static int cmd_vcp_vol_ctlr_discover(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcp_vol_ctlr_discover(default_conn, &vol_ctlr);
+	result = bt_vcp_vol_ctlr_discover(default_conn, &vcp_vol_ctlr);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -361,7 +361,7 @@ static int cmd_vcp_vol_ctlr_state_get(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcp_vol_ctlr_read_state(vol_ctlr);
+	result = bt_vcp_vol_ctlr_read_state(vcp_vol_ctlr);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -379,7 +379,7 @@ static int cmd_vcp_vol_ctlr_flags_get(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcp_vol_ctlr_read_flags(vol_ctlr);
+	result = bt_vcp_vol_ctlr_read_flags(vcp_vol_ctlr);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -397,7 +397,7 @@ static int cmd_vcp_vol_ctlr_volume_down(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcp_vol_ctlr_vol_down(vol_ctlr);
+	result = bt_vcp_vol_ctlr_vol_down(vcp_vol_ctlr);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -416,7 +416,7 @@ static int cmd_vcp_vol_ctlr_volume_up(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcp_vol_ctlr_vol_up(vol_ctlr);
+	result = bt_vcp_vol_ctlr_vol_up(vcp_vol_ctlr);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -434,7 +434,7 @@ static int cmd_vcp_vol_ctlr_unmute_volume_down(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcp_vol_ctlr_unmute_vol_down(vol_ctlr);
+	result = bt_vcp_vol_ctlr_unmute_vol_down(vcp_vol_ctlr);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -452,7 +452,7 @@ static int cmd_vcp_vol_ctlr_unmute_volume_up(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcp_vol_ctlr_unmute_vol_up(vol_ctlr);
+	result = bt_vcp_vol_ctlr_unmute_vol_up(vcp_vol_ctlr);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -485,7 +485,7 @@ static int cmd_vcp_vol_ctlr_volume_set(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcp_vol_ctlr_set_vol(vol_ctlr, volume);
+	result = bt_vcp_vol_ctlr_set_vol(vcp_vol_ctlr, volume);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -504,7 +504,7 @@ static int cmd_vcp_vol_ctlr_unmute(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcp_vol_ctlr_unmute(vol_ctlr);
+	result = bt_vcp_vol_ctlr_unmute(vcp_vol_ctlr);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -522,7 +522,7 @@ static int cmd_vcp_vol_ctlr_mute(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	result = bt_vcp_vol_ctlr_mute(vol_ctlr);
+	result = bt_vcp_vol_ctlr_mute(vcp_vol_ctlr);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -467,8 +467,6 @@ static uint8_t vcs_discover_func(struct bt_conn *conn,
 		}
 
 		if (sub_params != NULL) {
-			int err;
-
 			sub_params->value = BT_GATT_CCC_NOTIFY;
 			sub_params->value_handle = chrc->value_handle;
 			sub_params->ccc_handle = 0;

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2032,8 +2032,8 @@ static void le_set_cig_parameters(struct net_buf *buf, struct net_buf **evt)
 		status = ll_cig_parameters_commit(cig_id, handles);
 
 		if (status == BT_HCI_ERR_SUCCESS) {
-			for (uint8_t i = 0; i < cis_count; i++) {
-				rp->handle[i] = sys_cpu_to_le16(handles[i]);
+			for (uint8_t j = 0; j < cis_count; j++) {
+				rp->handle[j] = sys_cpu_to_le16(handles[j]);
 			}
 		}
 	}
@@ -2104,8 +2104,8 @@ static void le_set_cig_params_test(struct net_buf *buf, struct net_buf **evt)
 		status = ll_cig_parameters_commit(cig_id, handles);
 
 		if (status == BT_HCI_ERR_SUCCESS) {
-			for (uint8_t i = 0; i < cis_count; i++) {
-				rp->handle[i] = sys_cpu_to_le16(handles[i]);
+			for (uint8_t j = 0; j < cis_count; j++) {
+				rp->handle[j] = sys_cpu_to_le16(handles[j]);
 			}
 		}
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -814,12 +814,12 @@ void lll_conn_pdu_tx_prep(struct lll_conn *lll, struct pdu_data **pdu_data_tx)
 }
 
 #if defined(CONFIG_BT_CTLR_FORCE_MD_AUTO)
-uint8_t lll_conn_force_md_cnt_set(uint8_t force_md_cnt)
+uint8_t lll_conn_force_md_cnt_set(uint8_t reload_cnt)
 {
 	uint8_t previous;
 
 	previous = force_md_cnt_reload;
-	force_md_cnt_reload = force_md_cnt;
+	force_md_cnt_reload = reload_cnt;
 
 	return previous;
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -257,12 +257,12 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	} else if (conn_lll->enc_rx) {
-		uint64_t payload_count;
+		uint64_t payload_cnt;
 		uint8_t pkt_flags;
 
-		payload_count = (cis_lll->event_count * cis_lll->rx.bn) +
-				(cis_lll->rx.bn_curr - 1U);
-		cis_lll->rx.ccm.counter = payload_count;
+		payload_cnt = (cis_lll->event_count * cis_lll->rx.bn) +
+			      (cis_lll->rx.bn_curr - 1U);
+		cis_lll->rx.ccm.counter = payload_cnt;
 
 		pkt_flags = RADIO_PKT_CONF_FLAGS(RADIO_PKT_CONF_PDU_TYPE_DC,
 						 phy,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -1083,18 +1083,18 @@ static void isr_done_cleanup(void *param)
 	}
 
 	if (lll->is_aux_sched) {
-		struct node_rx_pdu *node_rx;
+		struct node_rx_pdu *node_rx2;
 
 		lll->is_aux_sched = 0U;
 
-		node_rx = ull_pdu_rx_alloc();
-		LL_ASSERT(node_rx);
+		node_rx2 = ull_pdu_rx_alloc();
+		LL_ASSERT(node_rx2);
 
-		node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
+		node_rx2->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
-		node_rx->hdr.rx_ftr.param = lll;
+		node_rx2->hdr.rx_ftr.param = lll;
 
-		ull_rx_put_sched(node_rx->hdr.link, node_rx);
+		ull_rx_put_sched(node_rx2->hdr.link, node_rx2);
 	}
 #endif  /* CONFIG_BT_CTLR_ADV_EXT */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -846,12 +846,12 @@ isr_rx_do_close:
 	} else {
 		/* Send message to flush Auxiliary PDU list */
 		if (lll->is_aux_sched && err != -ECANCELED) {
-			struct node_rx_pdu *node_rx;
+			struct node_rx_pdu *node_rx2;
 
-			node_rx = ull_pdu_rx_alloc();
-			LL_ASSERT(node_rx);
+			node_rx2 = ull_pdu_rx_alloc();
+			LL_ASSERT(node_rx2);
 
-			node_rx->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
+			node_rx2->hdr.type = NODE_RX_TYPE_EXT_AUX_RELEASE;
 
 			/* Use LLL scan context pointer which will be resolved
 			 * to LLL aux context in the `ull_scan_aux_release`
@@ -862,9 +862,9 @@ isr_rx_do_close:
 			 * under race, if ULL execution did assign one, it will
 			 * free it.
 			 */
-			node_rx->hdr.rx_ftr.param = lll;
+			node_rx2->hdr.rx_ftr.param = lll;
 
-			ull_rx_put_sched(node_rx->hdr.link, node_rx);
+			ull_rx_put_sched(node_rx2->hdr.link, node_rx2);
 		}
 
 		/* Check if LLL scheduled auxiliary PDU reception by scan
@@ -902,7 +902,6 @@ static int isr_rx_pdu(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 		   lll_scan_ext_tgta_check(lll, false, true, pdu,
 					   rl_idx, NULL)) {
 		struct lll_scan_aux *lll_aux_to_use;
-		struct node_rx_ftr *ftr;
 		struct node_rx_pdu *rx;
 		struct pdu_adv *pdu_tx;
 		uint32_t conn_space_us;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -301,8 +301,6 @@ static int create_prepare_cb(struct lll_prepare_param *p)
 	if (false) {
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX)
 	} else if (cfg->is_enabled) {
-		int err;
-
 		/* In case of call in create_prepare_cb, new sync event starts hence discard
 		 * previous incomplete state.
 		 */
@@ -312,8 +310,8 @@ static int create_prepare_cb(struct lll_prepare_param *p)
 		err = lll_df_iq_report_no_resources_prepare(lll);
 		if (!err) {
 			err = lll_df_conf_cte_rx_enable(cfg->slot_durations, cfg->ant_sw_len,
-							cfg->ant_ids, chan_idx, CTE_INFO_IN_PAYLOAD,
-							lll->phy);
+							cfg->ant_ids, chan_idx,
+							CTE_INFO_IN_PAYLOAD, lll->phy);
 			if (err) {
 				lll->is_cte_incomplete = true;
 			}
@@ -388,8 +386,6 @@ static int prepare_cb(struct lll_prepare_param *p)
 	cfg = lll_df_sync_cfg_latest_get(&lll->df_cfg, NULL);
 
 	if (cfg->is_enabled) {
-		int err;
-
 		/* In case of call in prepare, new sync event starts hence discard previous
 		 * incomplete state.
 		 */
@@ -399,8 +395,8 @@ static int prepare_cb(struct lll_prepare_param *p)
 		err = lll_df_iq_report_no_resources_prepare(lll);
 		if (!err) {
 			err = lll_df_conf_cte_rx_enable(cfg->slot_durations, cfg->ant_sw_len,
-							cfg->ant_ids, chan_idx, CTE_INFO_IN_PAYLOAD,
-							lll->phy);
+							cfg->ant_ids, chan_idx,
+							CTE_INFO_IN_PAYLOAD, lll->phy);
 			if (err) {
 				lll->is_cte_incomplete = true;
 			}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -529,14 +529,14 @@ static void isr_rx(void *param)
 
 	/* Save the AA captured for the first anchor point sync */
 	if (!radio_tmr_aa_restore()) {
-		const struct lll_sync_iso_stream *stream;
+		const struct lll_sync_iso_stream *sync_stream;
 		uint32_t se_offset_us;
 		uint8_t se;
 
 		crc_ok_anchor = crc_ok;
 
-		stream = ull_sync_iso_lll_stream_get(lll->stream_handle[0]);
-		se = ((lll->bis_curr - stream->bis_index) *
+		sync_stream = ull_sync_iso_lll_stream_get(lll->stream_handle[0]);
+		se = ((lll->bis_curr - sync_stream->bis_index) *
 		      ((lll->bn * lll->irc) + lll->ptc)) +
 		     ((lll->irc_curr - 1U) * lll->bn) + (lll->bn_curr - 1U) +
 		     lll->ptc_curr + lll->ctrl;
@@ -553,7 +553,7 @@ static void isr_rx(void *param)
 
 	/* Check CRC and generate ISO Data PDU */
 	if (crc_ok) {
-		struct lll_sync_iso_stream *stream;
+		struct lll_sync_iso_stream *sync_stream;
 		uint16_t stream_handle;
 		struct pdu_bis *pdu;
 
@@ -600,10 +600,10 @@ static void isr_rx(void *param)
 		}
 
 		stream_handle = lll->stream_handle[lll->stream_curr];
-		stream = ull_sync_iso_lll_stream_get(stream_handle);
+		sync_stream = ull_sync_iso_lll_stream_get(stream_handle);
 
 		/* store the received PDU */
-		if ((lll->bis_curr == stream->bis_index) && pdu->len &&
+		if ((lll->bis_curr == sync_stream->bis_index) && pdu->len &&
 		    !lll->payload[bis_idx][payload_index] &&
 		    ((payload_index >= lll->payload_tail) ||
 		     (payload_index < lll->payload_head))) {
@@ -723,18 +723,18 @@ isr_rx_find_subevent:
 	/* Next BIS */
 	if (lll->bis_curr < lll->num_bis) {
 		const uint8_t stream_curr = lll->stream_curr + 1U;
-		struct lll_sync_iso_stream *stream;
+		struct lll_sync_iso_stream *sync_stream;
 		uint16_t stream_handle;
 
 		/* Next selected stream */
 		if (stream_curr < lll->stream_count) {
 			lll->stream_curr = stream_curr;
 			stream_handle = lll->stream_handle[lll->stream_curr];
-			stream = ull_sync_iso_lll_stream_get(stream_handle);
-			if (stream->bis_index <= lll->num_bis) {
+			sync_stream = ull_sync_iso_lll_stream_get(stream_handle);
+			if (sync_stream->bis_index <= lll->num_bis) {
 				uint8_t bis_idx_new;
 
-				lll->bis_curr = stream->bis_index;
+				lll->bis_curr = sync_stream->bis_index;
 				lll->ptc_curr = 0U;
 				lll->irc_curr = 1U;
 				lll->bn_curr = 1U;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -661,7 +661,7 @@ static void ticker_start_next_op_cb(uint32_t status, void *param)
 	LL_ASSERT(status == TICKER_STATUS_SUCCESS);
 }
 
-static uint32_t preempt_ticker_start(struct lll_event *event,
+static uint32_t preempt_ticker_start(struct lll_event *evt,
 				     ticker_op_func op_cb)
 {
 	struct lll_prepare_param *p;
@@ -671,7 +671,7 @@ static uint32_t preempt_ticker_start(struct lll_event *event,
 	uint32_t ret;
 
 	/* Calc the preempt timeout */
-	p = &event->prepare_param;
+	p = &evt->prepare_param;
 	ull = HDR_LLL2ULL(p->param);
 	preempt_anchor = p->ticks_at_expire;
 	preempt_to = MAX(ull->ticks_active_to_start,
@@ -688,8 +688,8 @@ static uint32_t preempt_ticker_start(struct lll_event *event,
 			   TICKER_NULL_REMAINDER,
 			   TICKER_NULL_LAZY,
 			   TICKER_NULL_SLOT,
-			   preempt_ticker_cb, event,
-			   op_cb, event);
+			   preempt_ticker_cb, evt,
+			   op_cb, evt);
 
 	return ret;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1100,11 +1100,11 @@ void ll_rx_dequeue(void)
 
 		LL_ASSERT(!lll_conn->link_tx_free);
 
-		memq_link_t *link = memq_deinit(&lll_conn->memq_tx.head,
-						&lll_conn->memq_tx.tail);
-		LL_ASSERT(link);
+		memq_link_t *memq_link = memq_deinit(&lll_conn->memq_tx.head,
+						     &lll_conn->memq_tx.tail);
+		LL_ASSERT(memq_link);
 
-		lll_conn->link_tx_free = link;
+		lll_conn->link_tx_free = memq_link;
 
 		struct ll_conn *conn = HDR_LLL2ULL(lll_conn);
 
@@ -1144,17 +1144,17 @@ void ll_rx_dequeue(void)
 			if (cc->status == BT_HCI_ERR_ADV_TIMEOUT) {
 				struct lll_conn *conn_lll;
 				struct ll_conn *conn;
-				memq_link_t *link;
+				memq_link_t *memq_link;
 
 				conn_lll = lll->conn;
 				LL_ASSERT(conn_lll);
 				lll->conn = NULL;
 
 				LL_ASSERT(!conn_lll->link_tx_free);
-				link = memq_deinit(&conn_lll->memq_tx.head,
-						   &conn_lll->memq_tx.tail);
-				LL_ASSERT(link);
-				conn_lll->link_tx_free = link;
+				memq_link = memq_deinit(&conn_lll->memq_tx.head,
+							&conn_lll->memq_tx.tail);
+				LL_ASSERT(memq_link);
+				conn_lll->link_tx_free = memq_link;
 
 				conn = HDR_LLL2ULL(conn_lll);
 				ll_conn_release(conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1392,7 +1392,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 			 * started.
 			 */
 			if (sync) {
-				uint32_t ticks_slot_overhead;
+				uint32_t ticks_slot_overhead2;
 				uint32_t ticks_slot_aux;
 
 #if defined(CONFIG_BT_CTLR_ADV_RESERVE_MAX)
@@ -1436,10 +1436,10 @@ uint8_t ll_adv_enable(uint8_t enable)
 
 #endif /* CONFIG_BT_CTLR_ADV_AUX_SYNC_OFFSET */
 
-				ticks_slot_overhead = ull_adv_sync_evt_init(adv, sync, NULL);
+				ticks_slot_overhead2 = ull_adv_sync_evt_init(adv, sync, NULL);
 				ret = ull_adv_sync_start(adv, sync,
 							 ticks_anchor_sync,
-							 ticks_slot_overhead);
+							 ticks_slot_overhead2);
 				if (ret) {
 					goto failure_cleanup;
 				}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -582,7 +582,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 
 	if (adv->is_enabled) {
 		struct ll_adv_aux_set *aux;
-		struct pdu_adv *pdu;
+		struct pdu_adv *chan_res_pdu;
 		uint8_t tmp_idx;
 
 		aux = HDR_LLL2ULL(adv->lll.aux);
@@ -634,8 +634,8 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		}
 
 		/* Update primary channel reservation */
-		pdu = lll_adv_data_alloc(&adv->lll, &tmp_idx);
-		err = ull_adv_time_update(adv, pdu, NULL);
+		chan_res_pdu = lll_adv_data_alloc(&adv->lll, &tmp_idx);
+		err = ull_adv_time_update(adv, chan_res_pdu, NULL);
 		if (err) {
 			return err;
 		}
@@ -3053,7 +3053,6 @@ void ull_adv_aux_lll_auxptr_fill(struct pdu_adv *pdu, struct lll_adv *adv)
 	offset_us = HAL_TICKER_TICKS_TO_US(lll_aux->ticks_pri_pdu_offset) +
 		    lll_aux->us_pri_pdu_offset;
 	if ((offset_us/OFFS_UNIT_30_US)*OFFS_UNIT_30_US < EVENT_MAFS_US + pdu_us) {
-		struct ll_adv_aux_set *aux = HDR_LLL2ULL(lll_aux);
 		uint32_t interval_us;
 
 		/* Offset too small, point to next aux packet instead */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -1383,20 +1383,20 @@ static void tx_lll_flush(void *param)
 		struct lll_adv_iso_stream *stream;
 		struct node_tx_iso *tx;
 		uint16_t stream_handle;
-		memq_link_t *link;
+		memq_link_t *link2;
 		uint16_t handle;
 
 		stream_handle = lll->stream_handle[num_bis];
 		handle = LL_BIS_ADV_HANDLE_FROM_IDX(stream_handle);
 		stream = ull_adv_iso_stream_get(stream_handle);
 
-		link = memq_dequeue(stream->memq_tx.tail, &stream->memq_tx.head,
-				    (void **)&tx);
-		while (link) {
-			tx->next = link;
+		link2 = memq_dequeue(stream->memq_tx.tail, &stream->memq_tx.head,
+				     (void **)&tx);
+		while (link2) {
+			tx->next = link2;
 			ull_iso_lll_ack_enqueue(handle, tx);
 
-			link = memq_dequeue(stream->memq_tx.tail,
+			link2 = memq_dequeue(stream->memq_tx.tail,
 					    &stream->memq_tx.head,
 					    (void **)&tx);
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -99,8 +99,6 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_PARAM_CHECK)) {
-		uint8_t err;
-
 		err = adv_type_check(adv);
 		if (err) {
 			return err;
@@ -112,7 +110,6 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 		struct pdu_adv *ter_pdu;
 		struct lll_adv *lll;
 		uint8_t chm_last;
-		int err;
 
 		sync = sync_acquire();
 		if (!sync) {
@@ -268,8 +265,6 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 
 	/* Check for advertising set type */
 	if (IS_ENABLED(CONFIG_BT_CTLR_PARAM_CHECK)) {
-		uint8_t err;
-
 		err = adv_type_check(adv);
 		if (err) {
 			return err;
@@ -757,8 +752,6 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 
 	/* Check for advertising set type */
 	if (IS_ENABLED(CONFIG_BT_CTLR_PARAM_CHECK)) {
-		uint8_t err;
-
 		err = adv_type_check(adv);
 		if (err) {
 			return BT_HCI_ERR_CMD_DISALLOWED;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1237,7 +1237,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 	    ticks_slot_plus || ticks_slot_minus ||
 	    lazy || force) {
 		uint8_t ticker_id = TICKER_ID_CONN_BASE + lll->handle;
-		struct ll_conn *conn = lll->hdr.parent;
+		struct ll_conn *conn_ll = lll->hdr.parent;
 		uint32_t ticker_status;
 
 		/* Call to ticker_update can fail under the race
@@ -1253,10 +1253,10 @@ void ull_conn_done(struct node_rx_event_done *done)
 					      ticks_slot_plus, ticks_slot_minus,
 					      lazy, force,
 					      ticker_update_conn_op_cb,
-					      conn);
+					      conn_ll);
 		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 			  (ticker_status == TICKER_STATUS_BUSY) ||
-			  ((void *)conn == ull_disable_mark_get()));
+			  ((void *)conn_ll == ull_disable_mark_get()));
 	}
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -341,11 +341,11 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		}
 
 		if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && sync_lll) {
-			struct ll_sync_set *sync;
+			struct ll_sync_set *sync_set;
 
-			sync = HDR_LLL2ULL(sync_lll);
-			ftr->aux_data_len = sync->data_len + data_len;
-			sync->data_len = 0U;
+			sync_set = HDR_LLL2ULL(sync_lll);
+			ftr->aux_data_len = sync_set->data_len + data_len;
+			sync_set->data_len = 0U;
 		} else if (aux) {
 			aux->data_len += data_len;
 			ftr->aux_data_len = aux->data_len;
@@ -469,11 +469,11 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		(!IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED) &&
 		  PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) == EXT_ADV_AUX_PHY_LE_CODED)) {
 		if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && sync_lll) {
-			struct ll_sync_set *sync;
+			struct ll_sync_set *sync_set;
 
-			sync = HDR_LLL2ULL(sync_lll);
-			ftr->aux_data_len = sync->data_len + data_len;
-			sync->data_len = 0U;
+			sync_set = HDR_LLL2ULL(sync_lll);
+			ftr->aux_data_len = sync_set->data_len + data_len;
+			sync_set->data_len = 0U;
 		} else if (aux) {
 			aux->data_len += data_len;
 			ftr->aux_data_len = aux->data_len;
@@ -509,11 +509,11 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 
 			if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) &&
 			    sync_lll) {
-				struct ll_sync_set *sync;
+				struct ll_sync_set *sync_set;
 
-				sync = HDR_LLL2ULL(sync_lll);
-				ftr->aux_data_len = sync->data_len + data_len;
-				sync->data_len = 0U;
+				sync_set = HDR_LLL2ULL(sync_lll);
+				ftr->aux_data_len = sync_set->data_len + data_len;
+				sync_set->data_len = 0U;
 
 			}
 
@@ -547,11 +547,11 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	 * enqueue rx in aux context and will flush them after scan is complete.
 	 */
 	if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && sync_lll) {
-		struct ll_sync_set *sync;
+		struct ll_sync_set *sync_set;
 
-		sync = HDR_LLL2ULL(sync_lll);
-		sync->data_len += data_len;
-		ftr->aux_data_len = sync->data_len;
+		sync_set = HDR_LLL2ULL(sync_lll);
+		sync_set->data_len += data_len;
+		ftr->aux_data_len = sync_set->data_len;
 	} else {
 		if (aux->rx_last) {
 			aux->rx_last->rx_ftr.extra = rx;
@@ -607,14 +607,14 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 		 */
 		lll->lll_aux = NULL;
 	} else {
-		struct ll_sync_set *sync;
+		struct ll_sync_set *sync_set;
 
 		LL_ASSERT(sync_lll &&
 			  (!sync_lll->lll_aux || sync_lll->lll_aux == lll_aux));
 
 		/* Do not ULL schedule if sync terminate requested */
-		sync = HDR_LLL2ULL(sync_lll);
-		if (unlikely(sync->is_stop)) {
+		sync_set = HDR_LLL2ULL(sync_lll);
+		if (unlikely(sync_set->is_stop)) {
 			goto ull_scan_aux_rx_flush;
 		}
 
@@ -758,14 +758,14 @@ ull_scan_aux_rx_flush:
 			aux->rx_last->rx_ftr.extra = rx;
 			aux->rx_last = rx;
 		} else {
-			const struct ll_sync_set *sync;
+			const struct ll_sync_set *sync_set;
 
 			LL_ASSERT(sync_lll);
 
 			ll_rx_put_sched(link, rx);
 
-			sync = HDR_LLL2ULL(sync_lll);
-			if (unlikely(sync->is_stop && sync_lll->lll_aux)) {
+			sync_set = HDR_LLL2ULL(sync_lll);
+			if (unlikely(sync_set->is_stop && sync_lll->lll_aux)) {
 				return;
 			}
 		}
@@ -853,12 +853,12 @@ void *ull_scan_aux_lll_parent_get(struct lll_scan_aux *lll,
 
 	if (is_lll_scan) {
 		struct ll_scan_set *scan;
-		struct lll_scan *lll;
+		struct lll_scan *lllscan;
 
-		lll = aux->parent;
-		LL_ASSERT(lll);
+		lllscan = aux->parent;
+		LL_ASSERT(lllscan);
 
-		scan = HDR_LLL2ULL(lll);
+		scan = HDR_LLL2ULL(lllscan);
 		*is_lll_scan = !!ull_scan_is_valid_get(scan);
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -68,7 +68,7 @@ typedef struct ull_hdr *(*ull_hdr_get_func)(uint8_t ticker_id,
 					    uint32_t *ticks_slot);
 static uint8_t after_match_slot_get(uint8_t user_id, uint32_t ticks_slot_abs,
 				    ticker_op_match_func ticker_match_op_cb,
-				    ull_hdr_get_func ull_hdr_get_cb,
+				    ull_hdr_get_func ull_hdr_get_cb_fn,
 				    uint32_t *ticks_anchor,
 				    uint32_t *ticks_to_expire_match,
 				    uint32_t *remainder_match,
@@ -413,7 +413,7 @@ static int group_free_slot_get(uint8_t user_id, uint32_t ticks_slot_abs,
 
 static uint8_t after_match_slot_get(uint8_t user_id, uint32_t ticks_slot_abs,
 				    ticker_op_match_func ticker_match_op_cb,
-				    ull_hdr_get_func ull_hdr_get_cb,
+				    ull_hdr_get_func ull_hdr_get_cb_fn,
 				    uint32_t *ticks_anchor,
 				    uint32_t *ticks_to_expire_match,
 				    uint32_t *remainder_match,
@@ -518,7 +518,7 @@ static uint8_t after_match_slot_get(uint8_t user_id, uint32_t ticks_slot_abs,
 		}
 #endif /* CONFIG_BT_TICKER_NEXT_SLOT_GET_MATCH */
 
-		hdr = ull_hdr_get_cb(ticker_id, &ticks_slot);
+		hdr = ull_hdr_get_cb_fn(ticker_id, &ticks_slot);
 		if (!hdr) {
 			continue;
 		}

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -609,7 +609,6 @@ static int hci_set_adv_ext_fragmented(struct bt_le_ext_adv *adv, uint16_t hci_op
 		struct net_buf *buf;
 		const size_t data_len = MIN(BT_HCI_LE_EXT_ADV_FRAG_MAX_LEN, stream.remaining_size);
 		const size_t cmd_size = sizeof(*set_data) + data_len;
-		int err;
 
 		buf = bt_hci_cmd_create(hci_op, cmd_size);
 		if (!buf) {
@@ -717,7 +716,6 @@ static int hci_set_per_adv_data(const struct bt_le_ext_adv *adv,
 		struct net_buf *buf;
 		const size_t data_len = MIN(BT_HCI_LE_PER_ADV_FRAG_MAX_LEN, stream.remaining_size);
 		const size_t cmd_size = sizeof(*set_data) + data_len;
-		int err;
 
 		buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PER_ADV_DATA, cmd_size);
 		if (!buf) {

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -303,8 +303,6 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 	}
 
 	if (hdr->code == BT_ATT_OP_SIGNED_WRITE_CMD) {
-		int err;
-
 		err = bt_smp_sign(chan->att->conn, buf);
 		if (err) {
 			LOG_ERR("Error signing data");

--- a/subsys/bluetooth/host/br.c
+++ b/subsys/bluetooth/host/br.c
@@ -598,11 +598,11 @@ void bt_hci_remote_name_request_complete(struct net_buf *buf)
 check_names:
 	/* if still waiting for names */
 	for (i = 0; i < discovery_results_count; i++) {
-		struct discovery_priv *priv;
+		struct discovery_priv *dpriv;
 
-		priv = (struct discovery_priv *)&discovery_results[i]._priv;
+		dpriv = (struct discovery_priv *)&discovery_results[i]._priv;
 
-		if (priv->resolving) {
+		if (dpriv->resolving) {
 			return;
 		}
 	}

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1522,9 +1522,7 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 
 static void notify_connected(struct bt_conn *conn)
 {
-	struct bt_conn_cb *cb;
-
-	for (cb = callback_list; cb; cb = cb->_next) {
+	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
 		if (cb->connected) {
 			cb->connected(conn, conn->err);
 		}
@@ -1539,9 +1537,7 @@ static void notify_connected(struct bt_conn *conn)
 
 static void notify_disconnected(struct bt_conn *conn)
 {
-	struct bt_conn_cb *cb;
-
-	for (cb = callback_list; cb; cb = cb->_next) {
+	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
 		if (cb->disconnected) {
 			cb->disconnected(conn, conn->err);
 		}
@@ -1558,7 +1554,6 @@ static void notify_disconnected(struct bt_conn *conn)
 void notify_remote_info(struct bt_conn *conn)
 {
 	struct bt_conn_remote_info remote_info;
-	struct bt_conn_cb *cb;
 	int err;
 
 	err = bt_conn_get_remote_info(conn, &remote_info);
@@ -1567,7 +1562,7 @@ void notify_remote_info(struct bt_conn *conn)
 		return;
 	}
 
-	for (cb = callback_list; cb; cb = cb->_next) {
+	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
 		if (cb->remote_info_available) {
 			cb->remote_info_available(conn, &remote_info);
 		}
@@ -1583,8 +1578,6 @@ void notify_remote_info(struct bt_conn *conn)
 
 void notify_le_param_updated(struct bt_conn *conn)
 {
-	struct bt_conn_cb *cb;
-
 	/* If new connection parameters meet requirement of pending
 	 * parameters don't send peripheral conn param request anymore on timeout
 	 */
@@ -1596,7 +1589,7 @@ void notify_le_param_updated(struct bt_conn *conn)
 		atomic_clear_bit(conn->flags, BT_CONN_PERIPHERAL_PARAM_SET);
 	}
 
-	for (cb = callback_list; cb; cb = cb->_next) {
+	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
 		if (cb->le_param_updated) {
 			cb->le_param_updated(conn, conn->le.interval,
 					     conn->le.latency,
@@ -1616,9 +1609,7 @@ void notify_le_param_updated(struct bt_conn *conn)
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
 void notify_le_data_len_updated(struct bt_conn *conn)
 {
-	struct bt_conn_cb *cb;
-
-	for (cb = callback_list; cb; cb = cb->_next) {
+	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
 		if (cb->le_data_len_updated) {
 			cb->le_data_len_updated(conn, &conn->le.data_len);
 		}
@@ -1635,9 +1626,7 @@ void notify_le_data_len_updated(struct bt_conn *conn)
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
 void notify_le_phy_updated(struct bt_conn *conn)
 {
-	struct bt_conn_cb *cb;
-
-	for (cb = callback_list; cb; cb = cb->_next) {
+	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
 		if (cb->le_phy_updated) {
 			cb->le_phy_updated(conn, &conn->le.phy);
 		}
@@ -1653,13 +1642,11 @@ void notify_le_phy_updated(struct bt_conn *conn)
 
 bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 {
-	struct bt_conn_cb *cb;
-
 	if (!bt_le_conn_params_valid(param)) {
 		return false;
 	}
 
-	for (cb = callback_list; cb; cb = cb->_next) {
+	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
 		if (!cb->le_param_req) {
 			continue;
 		}
@@ -2149,7 +2136,6 @@ bool bt_conn_ltk_present(const struct bt_conn *conn)
 void bt_conn_identity_resolved(struct bt_conn *conn)
 {
 	const bt_addr_le_t *rpa;
-	struct bt_conn_cb *cb;
 
 	if (conn->role == BT_HCI_ROLE_CENTRAL) {
 		rpa = &conn->le.resp_addr;
@@ -2157,7 +2143,7 @@ void bt_conn_identity_resolved(struct bt_conn *conn)
 		rpa = &conn->le.init_addr;
 	}
 
-	for (cb = callback_list; cb; cb = cb->_next) {
+	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
 		if (cb->identity_resolved) {
 			cb->identity_resolved(conn, rpa, &conn->le.dst);
 		}
@@ -2261,15 +2247,13 @@ static void reset_pairing(struct bt_conn *conn)
 void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
 			      enum bt_security_err err)
 {
-	struct bt_conn_cb *cb;
-
 	reset_pairing(conn);
 	bt_l2cap_security_changed(conn, hci_err);
 	if (IS_ENABLED(CONFIG_BT_ISO_CENTRAL)) {
 		bt_iso_security_changed(conn, hci_err);
 	}
 
-	for (cb = callback_list; cb; cb = cb->_next) {
+	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
 		if (cb->security_changed) {
 			cb->security_changed(conn, conn->sec_level, err);
 		}
@@ -3366,7 +3350,6 @@ void bt_hci_le_df_connection_iq_report_common(uint8_t event, struct net_buf *buf
 {
 	struct bt_df_conn_iq_samples_report iq_report;
 	struct bt_conn *conn;
-	struct bt_conn_cb *cb;
 	int err;
 
 	if (event == BT_HCI_EVT_LE_CONNECTION_IQ_REPORT) {
@@ -3387,7 +3370,7 @@ void bt_hci_le_df_connection_iq_report_common(uint8_t event, struct net_buf *buf
 		return;
 	}
 
-	for (cb = callback_list; cb; cb = cb->_next) {
+	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
 		if (cb->cte_report_cb) {
 			cb->cte_report_cb(conn, &iq_report);
 		}
@@ -3421,7 +3404,6 @@ void bt_hci_le_df_cte_req_failed(struct net_buf *buf)
 {
 	struct bt_df_conn_iq_samples_report iq_report;
 	struct bt_conn *conn;
-	struct bt_conn_cb *cb;
 	int err;
 
 	err = hci_df_prepare_conn_cte_req_failed(buf, &iq_report, &conn);
@@ -3430,7 +3412,7 @@ void bt_hci_le_df_cte_req_failed(struct net_buf *buf)
 		return;
 	}
 
-	for (cb = callback_list; cb; cb = cb->_next) {
+	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
 		if (cb->cte_report_cb) {
 			cb->cte_report_cb(conn, &iq_report);
 		}

--- a/subsys/bluetooth/host/ecc.c
+++ b/subsys/bluetooth/host/ecc.c
@@ -34,9 +34,9 @@ static const uint8_t debug_public_key[BT_PUB_KEY_LEN] = {
 	0x6d, 0xeb, 0x2a, 0x65, 0x49, 0x9c, 0x80, 0xdc
 };
 
-bool bt_pub_key_is_debug(uint8_t *pub_key)
+bool bt_pub_key_is_debug(uint8_t *cmp_pub_key)
 {
-	return memcmp(pub_key, debug_public_key, BT_PUB_KEY_LEN) == 0;
+	return memcmp(cmp_pub_key, debug_public_key, BT_PUB_KEY_LEN) == 0;
 }
 
 int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)

--- a/subsys/bluetooth/host/ecc.h
+++ b/subsys/bluetooth/host/ecc.h
@@ -38,11 +38,11 @@ struct bt_pub_key_cb {
  *  Compare the Public key to the Bluetooth specification defined debug public
  *  key.
  *
- *  @param pub_key The public key to compare.
+ *  @param cmp_pub_key The public key to compare.
  *
  *  @return True if the public key is the debug public key.
  */
-bool bt_pub_key_is_debug(uint8_t *pub_key);
+bool bt_pub_key_is_debug(uint8_t *cmp_pub_key);
 
 /*  @brief Generate a new Public Key.
  *

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3190,10 +3190,10 @@ static void sc_restore_rsp(struct bt_conn *conn,
 #endif /* CONFIG_BT_GATT_CACHING */
 
 	if (!err && IS_ENABLED(CONFIG_BT_GATT_SERVICE_CHANGED)) {
-		struct gatt_sc_cfg *sc_cfg = find_sc_cfg(conn->id, &conn->le.dst);
+		struct gatt_sc_cfg *gsc_cfg = find_sc_cfg(conn->id, &conn->le.dst);
 
-		if (sc_cfg) {
-			sc_reset(sc_cfg);
+		if (gsc_cfg) {
+			sc_reset(gsc_cfg);
 		}
 	}
 }

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -378,7 +378,6 @@ void bt_iso_connected(struct bt_conn *iso)
 		} else if (iso->iso.info.type == BT_ISO_CHAN_TYPE_BROADCASTER ||
 			   iso->iso.info.type == BT_ISO_CHAN_TYPE_SYNC_RECEIVER) {
 			struct bt_iso_big *big;
-			int err;
 
 			big = lookup_big_by_handle(iso->iso.big_handle);
 
@@ -2031,13 +2030,13 @@ int bt_iso_cig_reconfigure(struct bt_iso_cig *cig,
 		return -EINVAL;
 	}
 
-	for (uint8_t i = 0; i < param->num_cis; i++) {
-		struct bt_iso_chan *cis = param->cis_channels[i];
+	for (uint8_t j = 0; j < param->num_cis; j++) {
+		struct bt_iso_chan *param_cis = param->cis_channels[j];
 
-		if (cis->iso != NULL && !cis_is_in_cig(cig, cis)) {
+		if (param_cis->iso != NULL && !cis_is_in_cig(cig, param_cis)) {
 			LOG_DBG("Cannot reconfigure other CIG's (id 0x%02X) CIS "
 			       "with this CIG (id 0x%02X)",
-			       cis->iso->iso.cig_id, cig->id);
+			       param_cis->iso->iso.cig_id, cig->id);
 			return -EINVAL;
 		}
 	}
@@ -3175,24 +3174,24 @@ int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_para
 	}
 
 	for (uint8_t i = 0; i < param->num_bis; i++) {
-		struct bt_iso_chan *bis = param->bis_channels[i];
+		struct bt_iso_chan *param_bis = param->bis_channels[i];
 
-		CHECKIF(bis == NULL) {
+		CHECKIF(param_bis == NULL) {
 			LOG_DBG("bis_channels[%u]: NULL channel", i);
 			return -EINVAL;
 		}
 
-		if (bis->iso) {
+		if (param_bis->iso) {
 			LOG_DBG("bis_channels[%u]: already allocated", i);
 			return -EALREADY;
 		}
 
-		CHECKIF(bis->qos == NULL) {
+		CHECKIF(param_bis->qos == NULL) {
 			LOG_DBG("bis_channels[%u]: qos is NULL", i);
 			return -EINVAL;
 		}
 
-		CHECKIF(bis->qos->rx == NULL) {
+		CHECKIF(param_bis->qos->rx == NULL) {
 			LOG_DBG("bis_channels[%u]: qos->rx is NULL", i);
 			return -EINVAL;
 		}

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -4894,14 +4894,14 @@ static const uint8_t M[] = {
 	0xad, 0x2b, 0x41, 0x7b, 0xe6, 0x6c, 0x37, 0x10
 };
 
-static int aes_test(const char *prefix, const uint8_t *key, const uint8_t *m,
+static int aes_test(const char *prefix, const uint8_t *in_key, const uint8_t *m,
 		    uint16_t len, const uint8_t *mac)
 {
 	uint8_t out[16];
 
 	LOG_DBG("%s: AES CMAC of message with len %u", prefix, len);
 
-	bt_crypto_aes_cmac(key, m, len, out);
+	bt_crypto_aes_cmac(in_key, m, len, out);
 	if (!memcmp(out, mac, 16)) {
 		LOG_DBG("%s: Success", prefix);
 	} else {
@@ -4955,7 +4955,7 @@ static int smp_aes_cmac_test(void)
 	return 0;
 }
 
-static int sign_test(const char *prefix, const uint8_t *key, const uint8_t *m,
+static int sign_test(const char *prefix, const uint8_t *sign_key, const uint8_t *m,
 		     uint16_t len, const uint8_t *sig)
 {
 	uint8_t msg[len + sizeof(uint32_t) + 8];
@@ -4971,7 +4971,7 @@ static int sign_test(const char *prefix, const uint8_t *key, const uint8_t *m,
 
 	memcpy(orig, msg, sizeof(msg));
 
-	err = smp_sign_buf(key, msg, len);
+	err = smp_sign_buf(sign_key, msg, len);
 	if (err) {
 		return err;
 	}

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -670,8 +670,7 @@ static int mod_app_list_handle(struct bt_mesh_msg_ctx *ctx, struct net_buf_simpl
 
 		if (param->member_cnt && param->members) {
 
-			int err =
-				bt_mesh_key_idx_unpack_list(buf, param->members, param->member_cnt);
+			err = bt_mesh_key_idx_unpack_list(buf, param->members, param->member_cnt);
 
 			if (err) {
 				LOG_ERR("The message size for the application opcode is "

--- a/subsys/bluetooth/mesh/dfu_cli.c
+++ b/subsys/bluetooth/mesh/dfu_cli.c
@@ -66,7 +66,7 @@ enum {
 	STATE_SUSPENDED,
 };
 
-static int32_t timeout = (10 * MSEC_PER_SEC);
+static int32_t dfu_cli_timeout = (10 * MSEC_PER_SEC);
 
 static struct bt_mesh_dfu_target *target_get(struct bt_mesh_dfu_cli *cli,
 					     uint16_t addr)
@@ -1079,7 +1079,7 @@ int bt_mesh_dfu_cli_cancel(struct bt_mesh_dfu_cli *cli,
 			return err;
 		}
 
-		return req_wait(cli, K_MSEC(timeout));
+		return req_wait(cli, K_MSEC(dfu_cli_timeout));
 	}
 
 	if (cli->xfer.state == STATE_IDLE) {
@@ -1168,7 +1168,7 @@ int bt_mesh_dfu_cli_imgs_get(struct bt_mesh_dfu_cli *cli,
 		return err;
 	}
 
-	err = req_wait(cli, K_MSEC(timeout));
+	err = req_wait(cli, K_MSEC(dfu_cli_timeout));
 
 	cli->req.img_cb = NULL;
 
@@ -1206,7 +1206,7 @@ int bt_mesh_dfu_cli_metadata_check(struct bt_mesh_dfu_cli *cli,
 		return err;
 	}
 
-	return req_wait(cli, K_MSEC(timeout));
+	return req_wait(cli, K_MSEC(dfu_cli_timeout));
 }
 
 int bt_mesh_dfu_cli_status_get(struct bt_mesh_dfu_cli *cli,
@@ -1229,15 +1229,15 @@ int bt_mesh_dfu_cli_status_get(struct bt_mesh_dfu_cli *cli,
 		return err;
 	}
 
-	return req_wait(cli, K_MSEC(timeout));
+	return req_wait(cli, K_MSEC(dfu_cli_timeout));
 }
 
 int32_t bt_mesh_dfu_cli_timeout_get(void)
 {
-	return timeout;
+	return dfu_cli_timeout;
 }
 
 void bt_mesh_dfu_cli_timeout_set(int32_t t)
 {
-	timeout = t;
+	dfu_cli_timeout = t;
 }

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -171,7 +171,7 @@ static void friend_clear(struct bt_mesh_friend *frnd)
 	/* If cancelling the timer fails, we'll exit early in the work handler. */
 	(void)k_work_cancel_delayable(&frnd->timer);
 
-	for (int i = 0; i < ARRAY_SIZE(frnd->cred); i++) {
+	for (i = 0; i < ARRAY_SIZE(frnd->cred); i++) {
 		if (frnd->subnet->keys[i].valid) {
 			bt_mesh_friend_cred_destroy(&frnd->cred[i]);
 		}

--- a/subsys/bluetooth/mesh/heartbeat.c
+++ b/subsys/bluetooth/mesh/heartbeat.c
@@ -164,7 +164,7 @@ static void hb_publish(struct k_work *work)
 		.start = hb_publish_start_cb,
 		.end = hb_publish_end_cb,
 	};
-	struct bt_mesh_subnet *sub;
+	struct bt_mesh_subnet *subnet;
 	int err;
 
 	LOG_DBG("hb_pub.count: %u", pub.count);
@@ -174,8 +174,8 @@ static void hb_publish(struct k_work *work)
 		return;
 	}
 
-	sub = bt_mesh_subnet_get(pub.net_idx);
-	if (!sub) {
+	subnet = bt_mesh_subnet_get(pub.net_idx);
+	if (!subnet) {
 		LOG_ERR("No matching subnet for idx 0x%02x", pub.net_idx);
 		pub.dst = BT_MESH_ADDR_UNASSIGNED;
 		return;
@@ -412,7 +412,7 @@ void bt_mesh_hb_resume(void)
 static int hb_pub_set(const char *name, size_t len_rd,
 		      settings_read_cb read_cb, void *cb_arg)
 {
-	struct bt_mesh_hb_pub pub;
+	struct bt_mesh_hb_pub hb_pub;
 	struct hb_pub_val hb_val;
 	int err;
 
@@ -422,19 +422,19 @@ static int hb_pub_set(const char *name, size_t len_rd,
 		return err;
 	}
 
-	pub.dst = hb_val.dst;
-	pub.period = bt_mesh_hb_pwr2(hb_val.period);
-	pub.ttl = hb_val.ttl;
-	pub.feat = hb_val.feat;
-	pub.net_idx = hb_val.net_idx;
+	hb_pub.dst = hb_val.dst;
+	hb_pub.period = bt_mesh_hb_pwr2(hb_val.period);
+	hb_pub.ttl = hb_val.ttl;
+	hb_pub.feat = hb_val.feat;
+	hb_pub.net_idx = hb_val.net_idx;
 
 	if (hb_val.indefinite) {
-		pub.count = 0xffff;
+		hb_pub.count = 0xffff;
 	} else {
-		pub.count = 0U;
+		hb_pub.count = 0U;
 	}
 
-	(void)bt_mesh_hb_pub_set(&pub);
+	(void)bt_mesh_hb_pub_set(&hb_pub);
 
 	LOG_DBG("Restored heartbeat publication");
 
@@ -445,20 +445,20 @@ BT_MESH_SETTINGS_DEFINE(pub, "HBPub", hb_pub_set);
 
 void bt_mesh_hb_pub_pending_store(void)
 {
-	struct bt_mesh_hb_pub pub;
+	struct bt_mesh_hb_pub hb_pub;
 	struct hb_pub_val val;
 	int err;
 
-	bt_mesh_hb_pub_get(&pub);
-	if (pub.dst == BT_MESH_ADDR_UNASSIGNED) {
+	bt_mesh_hb_pub_get(&hb_pub);
+	if (hb_pub.dst == BT_MESH_ADDR_UNASSIGNED) {
 		err = settings_delete("bt/mesh/HBPub");
 	} else {
-		val.indefinite = (pub.count == 0xffff);
-		val.dst = pub.dst;
-		val.period = bt_mesh_hb_log(pub.period);
-		val.ttl = pub.ttl;
-		val.feat = pub.feat;
-		val.net_idx = pub.net_idx;
+		val.indefinite = (hb_pub.count == 0xffff);
+		val.dst = hb_pub.dst;
+		val.period = bt_mesh_hb_log(hb_pub.period);
+		val.ttl = hb_pub.ttl;
+		val.feat = hb_pub.feat;
+		val.net_idx = hb_pub.net_idx;
 
 		err = settings_save_one("bt/mesh/HBPub", &val, sizeof(val));
 	}

--- a/subsys/bluetooth/mesh/sar_cfg_cli.c
+++ b/subsys/bluetooth/mesh/sar_cfg_cli.c
@@ -113,11 +113,11 @@ static int bt_mesh_sar_cfg_cli_init(struct bt_mesh_model *model)
 
 static void bt_mesh_sar_cfg_cli_reset(struct bt_mesh_model *model)
 {
-	struct bt_mesh_sar_cfg_cli *cli;
+	struct bt_mesh_sar_cfg_cli *model_cli;
 
-	cli = model->user_data;
+	model_cli = model->user_data;
 
-	bt_mesh_msg_ack_ctx_clear(&cli->ack_ctx);
+	bt_mesh_msg_ack_ctx_clear(&model_cli->ack_ctx);
 }
 
 const struct bt_mesh_model_cb _bt_mesh_sar_cfg_cli_cb = {

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -877,16 +877,16 @@ static int cmd_auth_method_set_output(const struct shell *sh, size_t argc, char 
 static int cmd_auth_method_set_static(const struct shell *sh, size_t argc, char *argv[])
 {
 	size_t len;
-	uint8_t static_val[16];
+	uint8_t static_oob_auth[16];
 	int err = 0;
 
-	len = hex2bin(argv[1], strlen(argv[1]), static_val, sizeof(static_val));
+	len = hex2bin(argv[1], strlen(argv[1]), static_oob_auth, sizeof(static_oob_auth));
 	if (len < 1) {
 		shell_warn(sh, "Unable to parse input string argument");
 		return -EINVAL;
 	}
 
-	err = bt_mesh_auth_method_set_static(static_val, len);
+	err = bt_mesh_auth_method_set_static(static_oob_auth, len);
 	if (err) {
 		shell_error(sh, "Setting static OOB authentication failed (err %d)", err);
 	}

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1515,11 +1515,11 @@ static int cmd_scan_filter_clear_addr(const struct shell *sh, size_t argc,
 
 #if defined(CONFIG_BT_BROADCASTER)
 static ssize_t ad_init(struct bt_data *data_array, const size_t data_array_size,
-		       const atomic_t *adv_opt)
+		       const atomic_t *adv_options)
 {
-	const bool discoverable = atomic_test_bit(adv_opt, SHELL_ADV_OPT_DISCOVERABLE);
-	const bool appearance = atomic_test_bit(adv_opt, SHELL_ADV_OPT_APPEARANCE);
-	const bool adv_ext = atomic_test_bit(adv_opt, SHELL_ADV_OPT_EXT_ADV);
+	const bool discoverable = atomic_test_bit(adv_options, SHELL_ADV_OPT_DISCOVERABLE);
+	const bool appearance = atomic_test_bit(adv_options, SHELL_ADV_OPT_APPEARANCE);
+	const bool adv_ext = atomic_test_bit(adv_options, SHELL_ADV_OPT_EXT_ADV);
 	static uint8_t ad_flags;
 	size_t ad_len = 0;
 
@@ -1548,11 +1548,11 @@ static ssize_t ad_init(struct bt_data *data_array, const size_t data_array_size,
 	}
 
 	if (appearance) {
-		const uint16_t appearance = bt_get_appearance();
-		static uint8_t appearance_data[sizeof(appearance)];
+		const uint16_t appearance2 = bt_get_appearance();
+		static uint8_t appearance_data[sizeof(appearance2)];
 
 		__ASSERT(data_array_size > ad_len, "No space for appearance");
-		sys_put_le16(appearance, appearance_data);
+		sys_put_le16(appearance2, appearance_data);
 		data_array[ad_len].type = BT_DATA_GAP_APPEARANCE;
 		data_array[ad_len].data_len = sizeof(appearance_data);
 		data_array[ad_len].data = appearance_data;
@@ -1573,7 +1573,7 @@ static ssize_t ad_init(struct bt_data *data_array, const size_t data_array_size,
 	}
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO) && IS_ENABLED(CONFIG_BT_EXT_ADV) && adv_ext) {
-		const bool connectable = atomic_test_bit(adv_opt, SHELL_ADV_OPT_CONNECTABLE);
+		const bool connectable = atomic_test_bit(adv_options, SHELL_ADV_OPT_CONNECTABLE);
 		ssize_t audio_ad_len;
 
 		audio_ad_len = audio_ad_data_add(&data_array[ad_len], data_array_size - ad_len,
@@ -2330,30 +2330,30 @@ static int cmd_per_adv_sync_create(const struct shell *sh, size_t argc,
 
 	create_params.sid = strtol(argv[3], NULL, 16);
 
-	for (int i = 4; i < argc; i++) {
-		if (!strcmp(argv[i], "aoa")) {
+	for (int j = 4; j < argc; j++) {
+		if (!strcmp(argv[j], "aoa")) {
 			options |= BT_LE_PER_ADV_SYNC_OPT_DONT_SYNC_AOA;
-		} else if (!strcmp(argv[i], "aod_1us")) {
+		} else if (!strcmp(argv[j], "aod_1us")) {
 			options |= BT_LE_PER_ADV_SYNC_OPT_DONT_SYNC_AOD_1US;
-		} else if (!strcmp(argv[i], "aod_2us")) {
+		} else if (!strcmp(argv[j], "aod_2us")) {
 			options |= BT_LE_PER_ADV_SYNC_OPT_DONT_SYNC_AOD_2US;
-		} else if (!strcmp(argv[i], "only_cte")) {
+		} else if (!strcmp(argv[j], "only_cte")) {
 			options |=
 				BT_LE_PER_ADV_SYNC_OPT_SYNC_ONLY_CONST_TONE_EXT;
-		} else if (!strcmp(argv[i], "timeout")) {
-			if (++i == argc) {
+		} else if (!strcmp(argv[j], "timeout")) {
+			if (++j == argc) {
 				shell_help(sh);
 				return SHELL_CMD_HELP_PRINTED;
 			}
 
-			create_params.timeout = strtoul(argv[i], NULL, 16);
-		} else if (!strcmp(argv[i], "skip")) {
-			if (++i == argc) {
+			create_params.timeout = strtoul(argv[j], NULL, 16);
+		} else if (!strcmp(argv[j], "skip")) {
+			if (++j == argc) {
 				shell_help(sh);
 				return SHELL_CMD_HELP_PRINTED;
 			}
 
-			create_params.skip = strtoul(argv[i], NULL, 16);
+			create_params.skip = strtoul(argv[j], NULL, 16);
 		} else {
 			shell_help(sh);
 			return SHELL_CMD_HELP_PRINTED;
@@ -2446,34 +2446,34 @@ static int cmd_past_subscribe(const struct shell *sh, size_t argc,
 	param.timeout = 1000; /* 10 seconds */
 	param.skip = 10;
 
-	for (int i = 1; i < argc; i++) {
-		if (!strcmp(argv[i], "aoa")) {
+	for (int j = 1; j < argc; j++) {
+		if (!strcmp(argv[j], "aoa")) {
 			param.options |=
 				BT_LE_PER_ADV_SYNC_TRANSFER_OPT_SYNC_NO_AOA;
-		} else if (!strcmp(argv[i], "aod_1us")) {
+		} else if (!strcmp(argv[j], "aod_1us")) {
 			param.options |=
 				BT_LE_PER_ADV_SYNC_TRANSFER_OPT_SYNC_NO_AOD_1US;
-		} else if (!strcmp(argv[i], "aod_2us")) {
+		} else if (!strcmp(argv[j], "aod_2us")) {
 			param.options |=
 				BT_LE_PER_ADV_SYNC_TRANSFER_OPT_SYNC_NO_AOD_2US;
-		} else if (!strcmp(argv[i], "only_cte")) {
+		} else if (!strcmp(argv[j], "only_cte")) {
 			param.options |=
 				BT_LE_PER_ADV_SYNC_TRANSFER_OPT_SYNC_ONLY_CTE;
-		} else if (!strcmp(argv[i], "timeout")) {
-			if (++i == argc) {
+		} else if (!strcmp(argv[j], "timeout")) {
+			if (++j == argc) {
 				shell_help(sh);
 				return SHELL_CMD_HELP_PRINTED;
 			}
 
-			param.timeout = strtoul(argv[i], NULL, 16);
-		} else if (!strcmp(argv[i], "skip")) {
-			if (++i == argc) {
+			param.timeout = strtoul(argv[j], NULL, 16);
+		} else if (!strcmp(argv[j], "skip")) {
+			if (++j == argc) {
 				shell_help(sh);
 				return SHELL_CMD_HELP_PRINTED;
 			}
 
-			param.skip = strtoul(argv[i], NULL, 16);
-		} else if (!strcmp(argv[i], "conn")) {
+			param.skip = strtoul(argv[j], NULL, 16);
+		} else if (!strcmp(argv[j], "conn")) {
 			if (!default_conn) {
 				shell_print(sh, "Not connected");
 				return -EINVAL;

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -717,7 +717,7 @@ static uint8_t print_attr(const struct bt_gatt_attr *attr, uint16_t handle,
 
 static int cmd_show_db(const struct shell *sh, size_t argc, char *argv[])
 {
-	struct bt_uuid_16 uuid;
+	struct bt_uuid_16 uuid16;
 	size_t total_len;
 
 	memset(&stats, 0, sizeof(stats));
@@ -725,14 +725,14 @@ static int cmd_show_db(const struct shell *sh, size_t argc, char *argv[])
 	if (argc > 1) {
 		uint16_t num_matches = 0;
 
-		uuid.uuid.type = BT_UUID_TYPE_16;
-		uuid.val = strtoul(argv[1], NULL, 16);
+		uuid16.uuid.type = BT_UUID_TYPE_16;
+		uuid16.val = strtoul(argv[1], NULL, 16);
 
 		if (argc > 2) {
 			num_matches = strtoul(argv[2], NULL, 10);
 		}
 
-		bt_gatt_foreach_attr_type(0x0001, 0xffff, &uuid.uuid, NULL,
+		bt_gatt_foreach_attr_type(0x0001, 0xffff, &uuid16.uuid, NULL,
 					  num_matches, print_attr,
 					  (void *)sh);
 		return 0;

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -116,11 +116,11 @@ static void le_connected(struct bt_conn *conn, uint8_t err)
 	tester_event(BTP_SERVICE_ID_GAP, BTP_GAP_EV_DEVICE_CONNECTED, &ev, sizeof(ev));
 
 	if (info.role == BT_CONN_ROLE_PERIPHERAL) {
-		struct btp_gap_new_settings_ev ev;
+		struct btp_gap_new_settings_ev sev;
 
 		atomic_clear_bit(&current_settings, BTP_GAP_SETTINGS_ADVERTISING);
-		ev.current_settings = sys_cpu_to_le32(current_settings);
-		tester_event(BTP_SERVICE_ID_GAP, BTP_GAP_EV_NEW_SETTINGS, &ev, sizeof(ev));
+		sev.current_settings = sys_cpu_to_le32(current_settings);
+		tester_event(BTP_SERVICE_ID_GAP, BTP_GAP_EV_NEW_SETTINGS, &sev, sizeof(sev));
 	}
 }
 
@@ -713,25 +713,25 @@ static uint8_t stop_advertising(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-static uint8_t get_ad_flags(struct net_buf_simple *ad)
+static uint8_t get_ad_flags(struct net_buf_simple *buf_ad)
 {
 	uint8_t len, i;
 
 	/* Parse advertisement to get flags */
-	for (i = 0U; i < ad->len; i += len - 1) {
-		len = ad->data[i++];
+	for (i = 0U; i < buf_ad->len; i += len - 1) {
+		len = buf_ad->data[i++];
 		if (!len) {
 			break;
 		}
 
 		/* Check if field length is correct */
-		if (len > (ad->len - i) || (ad->len - i) < 1) {
+		if (len > (buf_ad->len - i) || (buf_ad->len - i) < 1) {
 			break;
 		}
 
-		switch (ad->data[i++]) {
+		switch (buf_ad->data[i++]) {
 		case BT_DATA_FLAGS:
-			return ad->data[i];
+			return buf_ad->data[i];
 		default:
 			break;
 		}
@@ -744,7 +744,7 @@ static uint8_t discovery_flags;
 static struct net_buf_simple *adv_buf = NET_BUF_SIMPLE(ADV_BUF_LEN);
 
 static void store_adv(const bt_addr_le_t *addr, int8_t rssi,
-		      struct net_buf_simple *ad)
+		      struct net_buf_simple *buf_ad)
 {
 	struct btp_gap_device_found_ev *ev;
 
@@ -756,17 +756,17 @@ static void store_adv(const bt_addr_le_t *addr, int8_t rssi,
 	bt_addr_le_copy(&ev->address, addr);
 	ev->rssi = rssi;
 	ev->flags = BTP_GAP_DEVICE_FOUND_FLAG_AD | BTP_GAP_DEVICE_FOUND_FLAG_RSSI;
-	ev->eir_data_len = ad->len;
-	memcpy(net_buf_simple_add(adv_buf, ad->len), ad->data, ad->len);
+	ev->eir_data_len = buf_ad->len;
+	memcpy(net_buf_simple_add(adv_buf, buf_ad->len), buf_ad->data, buf_ad->len);
 }
 
 static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t evtype,
-			 struct net_buf_simple *ad)
+			 struct net_buf_simple *buf_ad)
 {
 	/* if General/Limited Discovery - parse Advertising data to get flags */
 	if (!(discovery_flags & BTP_GAP_DISCOVERY_FLAG_LE_OBSERVE) &&
 	    (evtype != BT_GAP_ADV_TYPE_SCAN_RSP)) {
-		uint8_t flags = get_ad_flags(ad);
+		uint8_t flags = get_ad_flags(buf_ad);
 
 		/* ignore non-discoverable devices */
 		if (!(flags & BT_LE_AD_DISCOV_MASK)) {
@@ -807,10 +807,10 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t evtype,
 			goto done;
 		}
 
-		ev->eir_data_len += ad->len;
+		ev->eir_data_len += buf_ad->len;
 		ev->flags |= BTP_GAP_DEVICE_FOUND_FLAG_SD;
 
-		memcpy(net_buf_simple_add(adv_buf, ad->len), ad->data, ad->len);
+		memcpy(net_buf_simple_add(adv_buf, buf_ad->len), buf_ad->data, buf_ad->len);
 
 		goto done;
 	}
@@ -825,7 +825,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t evtype,
 		net_buf_simple_reset(adv_buf);
 	}
 
-	store_adv(addr, rssi, ad);
+	store_adv(addr, rssi, buf_ad);
 
 	/* if Active Scan and scannable event - wait for Scan Response */
 	if ((discovery_flags & BTP_GAP_DISCOVERY_FLAG_LE_ACTIVE_SCAN) &&

--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -2207,7 +2207,7 @@ static uint8_t get_attrs(const void *cmd, uint16_t cmd_len,
 	struct net_buf_simple *buf = NET_BUF_SIMPLE(BTP_DATA_MAX_SIZE - sizeof(*rp));
 	struct get_attrs_foreach_data foreach;
 	uint16_t start_handle, end_handle;
-	union uuid uuid;
+	union uuid search_uuid;
 
 	if ((cmd_len < sizeof(*cp)) ||
 	    (cmd_len != sizeof(*cp) + cp->type_length)) {
@@ -2220,15 +2220,15 @@ static uint8_t get_attrs(const void *cmd, uint16_t cmd_len,
 	if (cp->type_length) {
 		char uuid_str[BT_UUID_STR_LEN];
 
-		if (btp2bt_uuid(cp->type, cp->type_length, &uuid.uuid)) {
+		if (btp2bt_uuid(cp->type, cp->type_length, &search_uuid.uuid)) {
 			return BTP_STATUS_FAILED;
 		}
 
-		bt_uuid_to_str(&uuid.uuid, uuid_str, sizeof(uuid_str));
+		bt_uuid_to_str(&search_uuid.uuid, uuid_str, sizeof(uuid_str));
 		LOG_DBG("start 0x%04x end 0x%04x, uuid %s", start_handle,
 			end_handle, uuid_str);
 
-		foreach.uuid = &uuid.uuid;
+		foreach.uuid = &search_uuid.uuid;
 	} else {
 		LOG_DBG("start 0x%04x end 0x%04x", start_handle, end_handle);
 


### PR DESCRIPTION
This is an attempt to rename shadow variables found by enabling -Wshadow manually via twister. Note that this does not enable -Wshadow by default, and that requires more work to be done not only in tree but also in various modules.

This covers the bluetooth portion.

Relates to #5450