### PR TITLE
Revert "ztest: Fix test statistics reporting"

### DIFF
--- a/subsys/testsuite/include/zephyr/tc_util.h
+++ b/subsys/testsuite/include/zephyr/tc_util.h
@@ -67,7 +67,6 @@
 #define TC_PASS 0
 #define TC_FAIL 1
 #define TC_SKIP 2
-#define TC_FLAKY 3
 
 #ifndef TC_PASS_STR
 #define TC_PASS_STR "PASS"
@@ -77,9 +76,6 @@
 #endif
 #ifndef TC_SKIP_STR
 #define TC_SKIP_STR "SKIP"
-#endif
-#ifndef TC_FLAKY_STR
-#define TC_FLAKY_STR "FLAKY"
 #endif
 
 static inline const char *TC_RESULT_TO_STR(int result)
@@ -91,8 +87,6 @@ static inline const char *TC_RESULT_TO_STR(int result)
 		return TC_FAIL_STR;
 	case TC_SKIP:
 		return TC_SKIP_STR;
-	case TC_FLAKY:
-		return TC_FLAKY_STR;
 	default:
 		return "?";
 	}


### PR DESCRIPTION
This reverts commit 2af5ac8fbb33e946eb1cfeaff110ab837da5a830.

Failures are not being captured correctly now:

```
 - PASS - [test_c_lib.test_strtoul] duration = 0.001 seconds
 - PASS - [test_c_lib.test_strxspn] duration = 0.001 seconds
 - FAIL - [test_c_lib.test_that_fails] duration = 0.002 seconds
 - PASS - [test_c_lib.test_time] duration = 0.001 seconds
 - PASS - [test_c_lib.test_tolower_toupper] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL

```
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
