### PR TITLE
MAINTAINERS: add samples/boards/google to Google platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1544,6 +1544,7 @@ Google Platforms:
     - keith-zephyr
   files:
     - boards/*/google_*/
+    - samples/boards/google_*/
 
 Hash Utilities:
   status: maintained


### PR DESCRIPTION
Add the board samples path to Google platforms group so PRs there are assigned.