### PR TITLE
drivers: regulator-fixed: extend api of driver (list/count voltages)

### DIFF
--- a/dts/bindings/regulator/regulator-fixed.yaml
+++ b/dts/bindings/regulator/regulator-fixed.yaml
@@ -1,7 +1,8 @@
 # Copyright 2019-2020 Peter Bigot Consulting, LLC
+# Copyright 2023 EPAM Systems
 # SPDX-License-Identifier: Apache-2.0
 
-description: GPIO-controlled regulators
+description: Fixed voltage regulators
 
 include:
   - name: base.yaml
@@ -19,7 +20,6 @@ properties:
 
   enable-gpios:
     type: phandle-array
-    required: true
     description: |
       GPIO to use to enable/disable the regulator.
 

--- a/dts/bindings/regulator/regulator-fixed.yaml
+++ b/dts/bindings/regulator/regulator-fixed.yaml
@@ -11,6 +11,8 @@ include:
       - regulator-name
       - regulator-boot-on
       - regulator-always-on
+      - regulator-min-microvolt
+      - regulator-max-microvolt
 
 compatible: "regulator-fixed"
 

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2019-2020 Peter Bigot Consulting, LLC
  * Copyright (c) 2021 NXP
  * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2023 EPAM Systems
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -240,6 +241,28 @@ static inline bool regulator_common_is_init_enabled(const struct device *dev)
 		(const struct regulator_common_config *)dev->config;
 
 	return (config->flags & REGULATOR_INIT_ENABLED) != 0U;
+}
+
+/**
+ * @brief Get minimum supported voltage.
+ *
+ * @param dev Regulator device instance.
+ * @param min_uv Where minimum voltage will be stored, in microvolts.
+ *
+ * @retval 0 If successful
+ * @retval -ENOENT If minimum voltage is not specified.
+ */
+static inline int regulator_common_get_min_voltage(const struct device *dev, int32_t *min_uv)
+{
+	const struct regulator_common_config *config =
+		(const struct regulator_common_config *)dev->config;
+
+	if (config->min_uv == INT32_MIN) {
+		return -ENOENT;
+	}
+
+	*min_uv = config->min_uv;
+	return 0;
 }
 
 /** @endcond */

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -322,6 +322,7 @@ static inline int regulator_parent_ship_mode(const struct device *dev)
  *
  * @retval 0 If regulator has been successfully enabled.
  * @retval -errno Negative errno in case of failure.
+ * @retval -ENOTSUP If regulator enablement can not be controlled.
  */
 int regulator_enable(const struct device *dev);
 
@@ -349,6 +350,7 @@ bool regulator_is_enabled(const struct device *dev);
  *
  * @retval 0 If regulator has been successfully disabled.
  * @retval -errno Negative errno in case of failure.
+ * @retval -ENOTSUP If regulator disablement can not be controlled.
  */
 int regulator_disable(const struct device *dev);
 


### PR DESCRIPTION
Allow to create fixed-regulator nodes without gpio for en/dis power source.
Allow properties `regulator-min-microvolt` and `regulator-max-microvolt` for fixed regulator, note: they should be equal.
Add simple functions for getting list of allowed and count of voltages.