### PR TITLE
ipc: icmsg: Dedicated workqueue for ICMSG backend

### DIFF
--- a/subsys/ipc/ipc_service/lib/Kconfig.icmsg
+++ b/subsys/ipc/ipc_service/lib/Kconfig.icmsg
@@ -27,11 +27,6 @@ config IPC_SERVICE_ICMSG_SHMEM_ACCESS_TO_MS
 	  Maximum time to wait, in milliseconds, for access to send data with
 	  backends basing on icmsg library. This time should be relatively low.
 
-# The Icmsg library in its simplicity requires the system workqueue to execute
-# at a cooperative priority.
-config SYSTEM_WORKQUEUE_PRIORITY
-	range -256 -1
-
 config IPC_SERVICE_ICMSG_BOND_NOTIFY_REPEAT_TO_MS
 	int "Bond notification timeout in miliseconds"
 	range 1 100
@@ -39,3 +34,46 @@ config IPC_SERVICE_ICMSG_BOND_NOTIFY_REPEAT_TO_MS
 	help
 	  Time to wait for remote bonding notification before the
 	  notification is repeated.
+
+config IPC_SERVICE_BACKEND_ICMSG_WQ_ENABLE
+	bool "Use dedicated workqueue"
+	default y
+	help
+	  Enable dedicated workqueue thread for the ICMsg backend.
+	  Disabling this configuration will cause the ICMsg backend to
+	  process incoming data through the system workqueue context, and
+	  therefore reduces the RAM footprint of the backend.
+	  Disabling this config may result in deadlocks in certain usage
+	  scenarios, such as when synchronous IPC is executed from the system
+	  workqueue context.
+	  The callbacks coming from the backend are executed from the workqueue
+	  context.
+	  When the option is disabled, the user must obey the restrictions
+	  imposed by the system workqueue, such as never performing blocking
+	  operations from within the callback.
+
+if IPC_SERVICE_BACKEND_ICMSG_WQ_ENABLE
+
+config IPC_SERVICE_BACKEND_ICMSG_WQ_STACK_SIZE
+	int "Size of RX work queue stack"
+	default 1024
+	help
+	  Size of stack used by work queue RX thread. This work queue is
+	  created to prevent notifying service users about received data
+	  from the system work queue. The queue is shared among instances.
+
+config IPC_SERVICE_BACKEND_ICMSG_WQ_PRIORITY
+	int "Priority of RX work queue thread"
+	default -1
+	range -256 -1
+	help
+	  Priority of the ICMSG RX work queue thread.
+	  The ICMSG library in its simplicity requires the workqueue to execute
+	  at a cooperative priority.
+
+endif
+
+# The Icmsg library in its simplicity requires the system workqueue to execute
+# at a cooperative priority.
+config SYSTEM_WORKQUEUE_PRIORITY
+	range -256 -1 if !IPC_SERVICE_BACKEND_ICMSG_WQ_ENABLE


### PR DESCRIPTION
The ICMSG backend now has a dedicated workqueue to process incoming IPC messages. The system workqueue is no longer utilized for that purpose.

Testing shows that in certain scenarios substituting a RPMsg backend with ICMsg results in deadlocks.
The deadlocks were a symptom of running a synchronous RPC protocol from the context of the system workqueue and transpired as follows:

1. The RPC protocol sends a request over the ICMsg backend on the system workqueue thread.
2. The RPC protocol puts the thread to sleep until response is received. This puts the system workqueue thread to sleep.
3. The response to the request arrives over ICMsg backend.
4. The backend signals a work item to the system workqueue.
5. The system workqueue is unable to process the response due to being previously pended on the RPC request.

The deadlock was initially observed with the nrf-802154 driver in conjuntion with the IPv6 stack.

To prevent this condition from occurring, the approach was selected to give ICMsg a dedicated workqueue thread.