### PR TITLE
Runner name deprecation + deprecate 'misc-flasher' to prefer 'misc'

### DIFF
--- a/boards/arm/beagle_bcf/board.cmake
+++ b/boards/arm/beagle_bcf/board.cmake
@@ -5,5 +5,5 @@
 
 # Download cc2538-bsl.py from https://git.beagleboard.org/beagleconnect/zephyr/cc2538-bsl/-/tags/2.1-bcf
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher $ENV{ZEPHYR_BASE}/boards/arm/beagle_bcf/cc2538-bsl.py -w)
+board_set_flasher_ifnset(misc)
+board_finalize_runner_args(misc $ENV{ZEPHYR_BASE}/boards/arm/beagle_bcf/cc2538-bsl.py -w)

--- a/boards/arm/mec172xevb_assy6906/support/mec172x_remote_flasher.py
+++ b/boards/arm/mec172xevb_assy6906/support/mec172x_remote_flasher.py
@@ -9,7 +9,7 @@ This script allows flashing a mec172xevb_assy6906 board
 attached to a remote system.
 
 Usage:
-  west flash -r misc-flasher -- mec172x_remote_flasher.py <remote host>
+  west flash -r misc -- mec172x_remote_flasher.py <remote host>
 
 Note:
 1. SSH access to remote host with write access to remote /tmp.
@@ -29,7 +29,7 @@ Here is a sample map file:
     id: mec172xevb_assy6906
     platform: mec172xevb_assy6906
     product: mec172xevb_assy6906
-    runner: misc-flasher
+    runner: misc
     runner_params:
       - <ZEPHYR_BASE>/boards/arm/mec172xevb_assy6906/support/mec172x_remote_flasher.py
       - <remote host>

--- a/boards/common/misc.board.cmake
+++ b/boards/common/misc.board.cmake
@@ -5,4 +5,4 @@
 # core on a special-purpose SoC which requires a complicated script to
 # network boot.
 
-board_finalize_runner_args(misc-flasher)
+board_finalize_runner_args(misc)

--- a/boards/riscv/it8xxx2_evb/board.cmake
+++ b/boards/riscv/it8xxx2_evb/board.cmake
@@ -1,4 +1,4 @@
 set(SUPPORTED_EMU_PLATFORMS renode)
 set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/it8xxx2_evb.resc)
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+board_set_flasher_ifnset(misc)
+board_finalize_runner_args(misc)

--- a/boards/x86/acrn/board.cmake
+++ b/boards/x86/acrn/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+board_set_flasher_ifnset(misc)
+board_finalize_runner_args(misc)

--- a/boards/x86/intel_ehl/board.cmake
+++ b/boards/x86/intel_ehl/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+board_set_flasher_ifnset(misc)
+board_finalize_runner_args(misc)

--- a/boards/x86/intel_rpl/board.cmake
+++ b/boards/x86/intel_rpl/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+board_set_flasher_ifnset(misc)
+board_finalize_runner_args(misc)

--- a/boards/x86/up_squared/board.cmake
+++ b/boards/x86/up_squared/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+board_set_flasher_ifnset(misc)
+board_finalize_runner_args(misc)

--- a/boards/xtensa/intel_adsp_cavs25/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs25/board.cmake
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if($ENV{CAVS_OLD_FLASHER})
-  board_set_flasher_ifnset(misc-flasher)
-  board_finalize_runner_args(misc-flasher)
+  board_set_flasher_ifnset(misc)
+  board_finalize_runner_args(misc)
 endif()
 
 board_set_flasher_ifnset(intel_adsp)

--- a/boards/xtensa/nxp_adsp_imx8/board.cmake
+++ b/boards/xtensa/nxp_adsp_imx8/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+board_set_flasher_ifnset(misc)
+board_finalize_runner_args(misc)
 
 board_set_rimage_target(imx8)

--- a/boards/xtensa/nxp_adsp_imx8m/board.cmake
+++ b/boards/xtensa/nxp_adsp_imx8m/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+board_set_flasher_ifnset(misc)
+board_finalize_runner_args(misc)
 
 board_set_rimage_target(imx8m)

--- a/boards/xtensa/nxp_adsp_imx8x/board.cmake
+++ b/boards/xtensa/nxp_adsp_imx8x/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+board_set_flasher_ifnset(misc)
+board_finalize_runner_args(misc)
 
 board_set_rimage_target(imx8)

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -147,6 +147,13 @@ def do_run_common(command, user_args, user_runner_args, domains=None):
     # This is the main routine for all the "west flash", "west debug",
     # etc. commands.
 
+    # Set up runner logging to delegate to west.log commands.
+    logger = logging.getLogger('runners')
+    logger.setLevel(LOG_LEVEL)
+    if not logger.hasHandlers():
+        # Only add a runners log handler if none has been added already.
+        logger.addHandler(WestLogHandler())
+
     if user_args.context:
         dump_context(command, user_args, user_runner_args)
         return
@@ -190,12 +197,6 @@ def do_run_common_image(command, user_args, user_runner_args, build_dir=None):
                                 cache)
     runner_name = runner_cls.name()
 
-    # Set up runner logging to delegate to west.log commands.
-    logger = logging.getLogger('runners')
-    logger.setLevel(LOG_LEVEL)
-    if not logger.hasHandlers():
-        # Only add a runners log handler if none has been added already.
-        logger.addHandler(WestLogHandler())
 
     # If the user passed -- to force the parent argument parser to stop
     # parsing, it will show up here, and needs to be filtered out.

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -306,7 +306,7 @@ def runners_yaml_path(build_dir, board):
     if not ret.is_file():
         log.die(f'either a pristine build is needed, or board {board} '
                 "doesn't support west flash/debug "
-                '(no ZEPHYR_RUNNERS_YAML in CMake cache)')
+                f'(no zephyr/runners.yaml in build directory {build_dir})')
     return ret
 
 def load_runners_yaml(path):

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -150,9 +150,7 @@ def do_run_common(command, user_args, user_runner_args, domains=None):
     # Set up runner logging to delegate to west.log commands.
     logger = logging.getLogger('runners')
     logger.setLevel(LOG_LEVEL)
-    if not logger.hasHandlers():
-        # Only add a runners log handler if none has been added already.
-        logger.addHandler(WestLogHandler())
+    logger.addHandler(WestLogHandler())
 
     if user_args.context:
         dump_context(command, user_args, user_runner_args)

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -466,7 +466,8 @@ def dump_context(command, args, unknown_args):
         if cls:
             dump_runner_context(command, cls, runners_yaml)
         else:
-            dump_all_runner_context(command, runners_yaml, board, build_dir)
+            dump_all_runner_context(command, yaml_path, runners_yaml,
+                                    board, build_dir)
 
 def dump_context_no_config(command, cls):
     if not cls:
@@ -521,14 +522,13 @@ def dump_runner_args(group, runners_yaml, indent=''):
     else:
         log.inf(f'{msg} (none)', colorize=True)
 
-def dump_all_runner_context(command, runners_yaml, board, build_dir):
+def dump_all_runner_context(command, yaml_path, runners_yaml,
+                            board, build_dir):
     all_cls = {cls.name(): cls for cls in ZephyrBinaryRunner.get_runners() if
                command.name in cls.capabilities().commands}
     available = runners_yaml['runners']
     available_cls = {r: all_cls[r] for r in available if r in all_cls}
     default_runner = runners_yaml[command.runner_key]
-    yaml_path = runners_yaml_path(build_dir, board)
-    runners_yaml = load_runners_yaml(yaml_path)
 
     log.inf(f'zephyr runners which support "west {command.name}":',
             colorize=True)

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -500,30 +500,16 @@ def dump_runner_caps(cls, indent=''):
     log.inf(f'{indent}{cls.name()} capabilities:', colorize=True)
     log.inf(f'{indent}{INDENT}{cls.capabilities()}')
 
-def dump_runner_option_help(cls, indent=''):
+def dump_runner_option_help(cls, indent):
     # Print help text for class-specific command line options for the
     # given runner class.
-
+    sub_indent = indent + INDENT
     dummy_parser = argparse.ArgumentParser(prog='', add_help=False, allow_abbrev=False)
     cls.add_parser(dummy_parser)
-    formatter = dummy_parser._get_formatter()
-    for group in dummy_parser._action_groups:
-        # Break the abstraction to filter out the 'flash', 'debug', etc.
-        # TODO: come up with something cleaner (may require changes
-        # in the runner core).
-        actions = group._group_actions
-        if len(actions) == 1 and actions[0].dest == 'command':
-            # This is the lone positional argument. Skip it.
-            continue
-        formatter.start_section('REMOVE ME')
-        formatter.add_text(group.description)
-        formatter.add_arguments(actions)
-        formatter.end_section()
-    # Get the runner help, with the "REMOVE ME" string gone
-    runner_help = f'\n{indent}'.join(formatter.format_help().splitlines()[1:])
+    runner_help = f'\n{sub_indent}'.join(dummy_parser.format_help().splitlines())
 
     log.inf(f'{indent}{cls.name()} options:', colorize=True)
-    log.inf(indent + runner_help)
+    log.inf(sub_indent + runner_help)
 
 def dump_runner_args(group, runners_yaml, indent=''):
     msg = f'{indent}{group} arguments from runners.yaml:'

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -61,11 +61,17 @@ _names = [
 for _name in _names:
     _import_runner_module(_name)
 
-def get_runner_cls(runner):
+def get_runner_cls(runner_name):
     '''Get a runner's class object, given its name.'''
-    for cls in ZephyrBinaryRunner.get_runners():
-        if cls.name() == runner:
+    all_runners = ZephyrBinaryRunner.get_runners()
+    for cls in all_runners:
+        if cls.name() == runner_name:
             return cls
-    raise ValueError('unknown runner "{}"'.format(runner))
+    for cls in all_runners:
+        if runner_name in cls.deprecated_names():
+            _logger.warning(f'runner name "{runner_name}" is deprecated, '
+                            f'use "{cls.name()}" instead')
+            return cls
+    raise ValueError('unknown runner "{}"'.format(runner_name))
 
 __all__ = ['ZephyrBinaryRunner', 'get_runner_cls']

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -448,6 +448,14 @@ class ZephyrBinaryRunner(abc.ABC):
         the target architecture/board (like xtensa etc.).'''
 
     @classmethod
+    def deprecated_names(cls) -> List[str]:
+        '''Any deprecated names that the runner should be known by.
+
+        Attempts to use the runner by one of these names will work,
+        but will log a warning.'''
+        return []
+
+    @classmethod
     def capabilities(cls) -> RunnerCaps:
         '''Returns a RunnerCaps representing this runner's capabilities.
 

--- a/scripts/west_commands/runners/misc.py
+++ b/scripts/west_commands/runners/misc.py
@@ -27,7 +27,11 @@ class MiscFlasher(ZephyrBinaryRunner):
 
     @classmethod
     def name(cls):
-        return 'misc-flasher'
+        return 'misc'
+
+    @classmethod
+    def deprecated_names(cls):
+        return ['misc-flasher']
 
     @classmethod
     def capabilities(cls):

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -30,7 +30,7 @@ def test_runner_imports():
                     'linkserver',
                     'mdb-nsim',
                     'mdb-hw',
-                    'misc-flasher',
+                    'misc',
                     'native_gdb',
                     'nios2',
                     'nrfjprog',

--- a/scripts/west_commands/tests/test_misc.py
+++ b/scripts/west_commands/tests/test_misc.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2023 Ampere Computing
+# SPDX-License-Identifier: Apache-2.0
+
+from logging import WARNING
+
+from runners import get_runner_cls
+
+def test_deprecated_name(caplog):
+    # The deprecated name should result in the same class,
+    # but a warning should be logged.
+    assert get_runner_cls('misc') is get_runner_cls('misc-flasher')
+    warning = 'runner name "misc-flasher" is deprecated, use "misc" instead'
+    assert ('runners', WARNING, warning) in caplog.record_tuples

--- a/soc/xtensa/intel_adsp/tools/cavstwist.sh
+++ b/soc/xtensa/intel_adsp/tools/cavstwist.sh
@@ -18,7 +18,7 @@ set -e
 #
 # The CAVS_OLD_FLASHER is necessary because now the client-server-based
 # cavstool works by default. This is to tell the build system to use
-# the misc-flasher as the runner. Please remember to do the command
+# the misc runner. Please remember to do the command
 # "unset CAVS_OLD_FLASHER" when you are going to switch to the
 # client-server-based intel_adsp runner.
 #


### PR DESCRIPTION
An alternative to https://github.com/zephyrproject-rtos/zephyr/pull/60894. As pointed out there, the 'misc-flasher' ZephyrBinaryRunner name is inconsistent with the names of these associated files:

- zephyr/boards/common/misc.board.cmake 
- scripts/west_commands/runners/misc.py

The runner probably should have been named 'misc' all along. I added it in a hurry to get an issue report to go away a long time ago, and I wasn't thinking about how it would evolve. Right now it only "flashes", but it would be trivial to extend this to add miscellaneous debug support as well.

Clean things up so that the flasher's name is "misc".

To avoid breaking out of tree boards, though, preserve backwards compatibility by allowing runners to declare deprecated names as well, and keep the old 'misc-flasher' name around, but deprecated.