### PR TITLE
intc: nxp_s32: initialize after core intc

### DIFF
--- a/drivers/interrupt_controller/intc_eirq_nxp_s32.c
+++ b/drivers/interrupt_controller/intc_eirq_nxp_s32.c
@@ -216,7 +216,7 @@ static int eirq_nxp_s32_init(const struct device *dev)
 		NULL,										\
 		&eirq_nxp_s32_data_##n,								\
 		&eirq_nxp_s32_conf_##n,								\
-		PRE_KERNEL_1,									\
+		PRE_KERNEL_2,									\
 		CONFIG_INTC_INIT_PRIORITY,							\
 		NULL);										\
 	static int eirq_nxp_s32_init##n(const struct device *dev)				\


### PR DESCRIPTION
Following #60410, the NXP S32 external interrupt controller device initializes after the core interrupt controller. Bump the NXP S32 intc init level to initialize after the core intc and before the GPIO device driver.

Fixes #61218