### PR TITLE
drivers: i2c: i2c_dw: Added intel lpss dma support for I2C

### DIFF
--- a/boards/x86/intel_rpl/Kconfig.defconfig
+++ b/boards/x86/intel_rpl/Kconfig.defconfig
@@ -29,6 +29,15 @@ endif
 config ACPI
 	default y
 
+if DMA
+config DMA_64BIT
+	default y
+config DMA_DW_HW_LLI
+	default n
+config DMA_DW_CHANNEL_COUNT
+	default 2
+endif
+
 if SHELL
 config SHELL_STACK_SIZE
 	default 320000

--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -809,7 +809,7 @@ int dw_dma_get_status(const struct device *dev, uint32_t channel,
 	const struct dw_dma_dev_cfg *const dev_cfg = dev->config;
 	struct dw_dma_chan_data *chan_data;
 
-	if (channel >= DW_MAX_CHAN) {
+	if (channel >= DW_CHAN_COUNT) {
 		return -EINVAL;
 	}
 

--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -12,3 +12,12 @@ config I2C_DW_CLOCK_SPEED
 	int "Set the clock speed for I2C"
 	depends on I2C_DW
 	default 32
+
+config I2C_DW_LPSS_DMA
+	bool "Use I2C integrated DMA for asynchronous transfer"
+	select DMA
+	select DMA_INTEL_LPSS
+	help
+	  This option enables I2C DMA feature to be used for asynchrounous
+	  data transfers. All Tx operaton are done using dma channel 0 and
+	  all Rx operations are done using dma channel 1.

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -123,6 +123,13 @@ struct i2c_dw_dev_config {
 	uint8_t			request_bytes;
 	uint8_t			xfr_flags;
 	bool			support_hs_mode;
+#ifdef CONFIG_I2C_DW_LPSS_DMA
+	const struct device *dma_dev;
+	uintptr_t phy_addr;
+	uintptr_t base_addr;
+	/* For dma transfer */
+	bool xfr_status;
+#endif
 
 	struct i2c_target_config *slave_cfg;
 };

--- a/drivers/i2c/i2c_dw_registers.h
+++ b/drivers/i2c/i2c_dw_registers.h
@@ -144,13 +144,24 @@ union ic_comp_param_1_register {
 #define DW_IC_REG_STATUS			(0x70)
 #define DW_IC_REG_TXFLR				(0x74)
 #define DW_IC_REG_RXFLR				(0x78)
+#define DW_IC_REG_DMA_CR                        (0x88)
+#define DW_IC_REG_TDLR                          (0x8C)
+#define DW_IC_REG_RDLR                          (0x90)
 #define DW_IC_REG_FS_SPKLEN			(0xA0)
 #define DW_IC_REG_HS_SPKLEN			(0xA4)
 #define DW_IC_REG_COMP_PARAM_1		(0xF4)
 #define DW_IC_REG_COMP_TYPE			(0xFC)
 
+#define IDMA_REG_INTR_STS               0xAE8
+#define IDMA_TX_RX_CHAN_MASK            0x3
+
 /* CON Bit */
 #define DW_IC_CON_MASTER_MODE_BIT		(0)
+
+/* DMA control bits */
+#define DW_IC_DMA_RX_ENABLE                    BIT(0)
+#define DW_IC_DMA_TX_ENABLE                    BIT(1)
+#define DW_IC_DMA_ENABLE                       (BIT(0) | BIT(1))
 
 DEFINE_TEST_BIT_OP(con_master_mode, DW_IC_REG_CON, DW_IC_CON_MASTER_MODE_BIT)
 DEFINE_MM_REG_WRITE(con, DW_IC_REG_CON, 32)
@@ -208,6 +219,14 @@ DEFINE_TEST_BIT_OP(status_rfne, DW_IC_REG_STATUS, DW_IC_STATUS_RFNE_BIT)
 
 DEFINE_MM_REG_READ(txflr, DW_IC_REG_TXFLR, 32)
 DEFINE_MM_REG_READ(rxflr, DW_IC_REG_RXFLR, 32)
+
+DEFINE_MM_REG_READ(dma_cr, DW_IC_REG_DMA_CR, 32)
+DEFINE_MM_REG_WRITE(dma_cr, DW_IC_REG_DMA_CR, 32)
+
+DEFINE_MM_REG_READ(tdlr, DW_IC_REG_TDLR, 32)
+DEFINE_MM_REG_WRITE(tdlr, DW_IC_REG_TDLR, 32)
+DEFINE_MM_REG_READ(rdlr, DW_IC_REG_RDLR, 32)
+DEFINE_MM_REG_WRITE(rdlr, DW_IC_REG_RDLR, 32)
 
 DEFINE_MM_REG_READ(fs_spklen, DW_IC_REG_FS_SPKLEN, 32)
 DEFINE_MM_REG_READ(hs_spklen, DW_IC_REG_HS_SPKLEN, 32)

--- a/dts/x86/intel/raptor_lake.dtsi
+++ b/dts/x86/intel/raptor_lake.dtsi
@@ -75,6 +75,13 @@
 			status = "okay";
 		};
 
+		i2c0_dma: i2c0_dma {
+			compatible = "intel,lpss";
+			dma-parent = <&i2c0>;
+			#dma-cells = <1>;
+			status = "okay";
+		};
+
 		i2c1: i2c1 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -85,7 +92,14 @@
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			status = "okay";
+			status = "disabled";
+		};
+
+		i2c1_dma: i2c1_dma {
+			compatible = "intel,lpss";
+			dma-parent = <&i2c1>;
+			#dma-cells = <1>;
+			status = "disabled";
 		};
 
 		i2c2: i2c2 {
@@ -93,12 +107,21 @@
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			vendor-id = <0x8086>;
 			device-id = <0x7ace>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			status = "okay";
+			status = "disabled";
+		};
+
+		i2c2_dma: i2c2_dma {
+			compatible = "intel,lpss";
+			dma-parent = <&i2c2>;
+			#dma-cells = <1>;
+			status = "disabled";
 		};
 
 		i2c3: i2c3 {
@@ -111,6 +134,13 @@
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
+			status = "disabled";
+		};
+
+		i2c3_dma: i2c3_dma {
+			compatible = "intel,lpss";
+			dma-parent = <&i2c3>;
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 
@@ -127,6 +157,13 @@
 			status = "disabled";
 		};
 
+		i2c4_dma: i2c4_dma {
+			compatible = "intel,lpss";
+			dma-parent = <&i2c4>;
+			#dma-cells = <1>;
+			status = "disabled";
+		};
+
 		i2c5: i2c5 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -137,6 +174,13 @@
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
+			status = "disabled";
+		};
+
+		i2c5_dma: i2c5_dma {
+			compatible = "intel,lpss";
+			dma-parent = <&i2c5>;
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 
@@ -153,6 +197,13 @@
 			status = "disabled";
 		};
 
+		i2c6_dma: i2c6_dma {
+			compatible = "intel,lpss";
+			dma-parent = <&i2c6>;
+			#dma-cells = <1>;
+			status = "disabled";
+		};
+
 		i2c7: i2c7 {
 			compatible = "snps,designware-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -163,6 +214,13 @@
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
+			status = "disabled";
+		};
+
+		i2c7_dma: i2c7_dma {
+			compatible = "intel,lpss";
+			dma-parent = <&i2c7>;
+			#dma-cells = <1>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Enabled intel LPSS DMA interface using dw common to support usage of internal DMA in LPSS I2C to transfer and
receive data.