### PR TITLE
samples: boards: mimxrt595_evk_cm33: system_off: misc cleanups

### DIFF
--- a/boards/arm/mimxrt595_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt595_evk/Kconfig.defconfig
@@ -29,14 +29,13 @@ config HEAP_MEM_POOL_SIZE
 
 endif # DMA_MCUX_LPC
 
-if PM
 # Turn on Device Level Power Management as we wish
 # to reconfigure the FlexSPI pins for power savings
 # when transitioning the SoC to Deep Low Power modes.
 config PM_DEVICE
-	default y
+	default y if PM
+
 config REGULATOR
-	default y
-endif # PM
+	default y if PM || POWEROFF
 
 endif # BOARD_MIMXRT595_EVK

--- a/samples/boards/mimxrt595_evk_cm33/system_off/README.rst
+++ b/samples/boards/mimxrt595_evk_cm33/system_off/README.rst
@@ -44,9 +44,8 @@ MIMXRT595-EVK core output
 
    *** Booting Zephyr OS build zephyr-v3.2.0-1045-g07228f716c78  ***
 
-   mimxrt595_evk_cm33 system off demo
-   RTC Alarm set for 10 seconds to wake from soft-off.
-   Entering system off
+   Wake-up alarm set for 10 seconds
+   Powering off
 
 OTP Fuse setting to wake from Deep Power Down and reset flash
 #############################################################

--- a/samples/boards/mimxrt595_evk_cm33/system_off/src/main.c
+++ b/samples/boards/mimxrt595_evk_cm33/system_off/src/main.c
@@ -5,51 +5,38 @@
  */
 
 #include <stdio.h>
-#include <zephyr/kernel.h>
-#include <zephyr/device.h>
-#include <zephyr/drivers/gpio.h>
+
 #include <zephyr/drivers/counter.h>
 #include <zephyr/sys/poweroff.h>
-
-#define SOFT_OFF_S 10U
-
-#define RTC_NODE DT_NODELABEL(rtc)
-#if !DT_NODE_HAS_STATUS(RTC_NODE, okay)
-#error "Unsupported board: rtc node is not enabled"
-#endif
-
-#define RTC_CHANNEL_ID 0
-
-static const struct device *const rtc_dev = DEVICE_DT_GET(RTC_NODE);
+#include <zephyr/sys_clock.h>
 
 int main(void)
 {
 	int ret;
+	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(rtc));
+	struct counter_alarm_cfg alarm_cfg = { 0 };
 
-	printk("\n%s system off demo\n", CONFIG_BOARD);
-
-	uint32_t sleep_ticks = counter_us_to_ticks(rtc_dev, SOFT_OFF_S * 1000ULL * 1000ULL);
-
-	counter_start(rtc_dev);
-
-	if (sleep_ticks == 0) {
-		/* counter_us_to_ticks will round down the number of ticks to the nearest int. */
-		/* Ensure at least one tick is used in the RTC */
-		sleep_ticks++;
-	}
-	const struct counter_alarm_cfg alarm_cfg = {
-		.ticks = sleep_ticks,
-		.flags = 0,
-	};
-
-	ret = counter_set_channel_alarm(rtc_dev, RTC_CHANNEL_ID, &alarm_cfg);
-	if (ret != 0) {
-		printk("Could not rtc alarm.\n");
+	if (!device_is_ready(dev)) {
+		printf("Counter device not ready\n");
 		return 0;
 	}
-	printk("RTC Alarm set for %llu seconds to wake from soft-off.\n",
-	       counter_ticks_to_us(rtc_dev, alarm_cfg.ticks) / (1000ULL * 1000ULL));
-	printk("Entering system off");
+
+	ret = counter_start(dev);
+	if (ret < 0) {
+		printf("Could not start counter (%d)\n", ret);
+		return 0;
+	}
+
+	alarm_cfg.ticks = counter_us_to_ticks(dev, 10 * USEC_PER_SEC);
+
+	ret = counter_set_channel_alarm(dev, 0, &alarm_cfg);
+	if (ret < 0) {
+		printf("Could not set counter channel alarm (%d)\n", ret);
+		return 0;
+	}
+
+	printf("Wake-up alarm set for 10 seconds\n");
+	printf("Powering off\n");
 
 	sys_poweroff();
 


### PR DESCRIPTION
- Remove unnecessary includes
- Remove redundant definitions (sample is not portable anyway)
- Use printf
- Check for device readiness
- Do not check for zero ticks (not possible for the given timeout/driver), also, driver should likely error for such case anyway
- Check for all error codes