### PR TITLE
soc: arm: silabs_exx32: add support for sys_poweroff

### DIFF
--- a/soc/arm/silabs_exx32/Kconfig
+++ b/soc/arm/silabs_exx32/Kconfig
@@ -6,6 +6,7 @@ config SOC_FAMILY_EXX32
 	bool
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 	select BUILD_OUTPUT_HEX
+	select HAS_POWEROFF
 
 if SOC_FAMILY_EXX32
 config SOC_FAMILY
@@ -138,7 +139,7 @@ config SOC_GECKO_TRNG
 	help
 	  Set if the SoC has a True Random Number Generator (TRNG) module.
 
-if PM
+if PM || POWEROFF
 
 config SOC_GECKO_PM_BACKEND_PMGR
 	bool

--- a/soc/arm/silabs_exx32/common/CMakeLists.txt
+++ b/soc/arm/silabs_exx32/common/CMakeLists.txt
@@ -5,4 +5,6 @@ zephyr_sources(soc.c)
 zephyr_sources_ifdef(CONFIG_SOC_GECKO_PM_BACKEND_EMU    soc_power.c)
 zephyr_sources_ifdef(CONFIG_SOC_GECKO_PM_BACKEND_PMGR   soc_power_pmgr.c)
 
+zephyr_sources_ifdef(CONFIG_POWEROFF poweroff.c)
+
 zephyr_include_directories(.)

--- a/soc/arm/silabs_exx32/common/poweroff.c
+++ b/soc/arm/silabs_exx32/common/poweroff.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/poweroff.h>
+#include <zephyr/toolchain.h>
+
+#if defined(CONFIG_SOC_GECKO_PM_BACKEND_EMU)
+#include <em_emu.h>
+#elif defined(CONFIG_SOC_GECKO_PM_BACKEND_PMGR)
+#include <sl_power_manager.h>
+#endif
+
+void z_sys_poweroff(void)
+{
+#if defined(CONFIG_SOC_GECKO_PM_BACKEND_EMU)
+	EMU_EnterEM4();
+#elif defined(CONFIG_SOC_GECKO_PM_BACKEND_PMGR)
+	sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM4);
+	sl_power_manager_sleep();
+#else
+	#error "No valid power management backend selected"
+#endif
+
+	CODE_UNREACHABLE;
+}

--- a/soc/arm/silabs_exx32/common/soc_power.c
+++ b/soc/arm/silabs_exx32/common/soc_power.c
@@ -16,7 +16,6 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
  * PM_STATE_RUNTIME_IDLE: EM1 Sleep
  * PM_STATE_SUSPEND_TO_IDLE: EM2 Deep Sleep
  * PM_STATE_STANDBY: EM3 Stop
- * PM_STATE_SOFT_OFF: EM4
  */
 
 /* Invoke Low Power/System Off specific Tasks */
@@ -47,9 +46,6 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 		break;
 	case PM_STATE_STANDBY:
 		EMU_EnterEM3(true);
-		break;
-	case PM_STATE_SOFT_OFF:
-		EMU_EnterEM4();
 		break;
 	default:
 		LOG_DBG("Unsupported power state %u", state);

--- a/soc/arm/silabs_exx32/common/soc_power_pmgr.c
+++ b/soc/arm/silabs_exx32/common/soc_power_pmgr.c
@@ -16,7 +16,6 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
  * PM_STATE_RUNTIME_IDLE: EM1 Sleep
  * PM_STATE_SUSPEND_TO_IDLE: EM2 Deep Sleep
  * PM_STATE_STANDBY: EM3 Stop
- * PM_STATE_SOFT_OFF: EM4
  */
 
 
@@ -37,9 +36,6 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 		break;
 	case PM_STATE_STANDBY:
 		energy_mode = SL_POWER_MANAGER_EM3;
-		break;
-	case PM_STATE_SOFT_OFF:
-		energy_mode = SL_POWER_MANAGER_EM4;
 		break;
 	default:
 		LOG_DBG("Unsupported power state %d", state);


### PR DESCRIPTION
Implement the sys_poweroff() hooks based on existing code for SOFT_OFF. Note that the Kconfig structure looks a bit messy, so I've done my best to understand it.