### PR TITLE
drivers: stm32: SPI: SPI nocache buffers can be in CONFIG_NOCACHE_MEMORY

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2023 Graphcore Ltd, All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Graphcore Ltd, All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi1 {
+	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};


### PR DESCRIPTION
The STM32 SPI driver checks buffers are within bounds of nocache memory regions, in case DMA is enabled, so that trying to use a buffer which is not in a nocache region returns an error. The only buffers that are considered nocache at the moment are those that are declared as so in devicetree.

As detected in the issue #60977, there is a problem with this: Zephyr has two different ways of declaring a new cache region. One is declaring such region in devicetree, and the other is using CONFIG_NOCACHE_REGION. Because of this, buffers that are located within these regions must be checked inside the STM32 SPI driver and considered valid.

This PR aims to solve the issue explained above.

Notice that #60977 also remarks another problem: the SPI API states that NULL buffers will be used to send/ignore dummy bytes. In order to pass the `spi_loopback` tests, this needs to be fixed as well.

Fixes the two problems mentioned in #60977 that make the SPI loopback tests to fail, that is, send zeroes if a tx null buffer is provided and consider buffers associated to `CONFIG_NOCACHE_REGION` as valid. However, it would be desirable to have loopback tests for buffers in nocache regions declared in devicetree, as mentioned in the above issue's comments. #61021 achieves this, but it would need to be rebased on top of this PR. 

Note: I believe #52965 has the same problem in `address_in_non_cacheable_sram`

Test plan
=========
Connect an STM32H7 board to the PC with pins D11 and D12 connected.

Open a minicom or equivalent terminal to read the test report.

Execute the following commands:
```
west build -p auto -b nucleo_h753zi tests/drivers/spi/spi_loopback/
west flash
```
And verify all tests pass. Then, do:
```
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma.loopback
west flash
```
And verify all pass again.