### PR TITLE
drivers: wifi: esp32: choose channel 0 by default

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -430,7 +430,8 @@ static int esp32_wifi_ap_enable(const struct device *dev,
 	wifi_config_t wifi_config = {
 		.ap = {
 			.max_connection = 5,
-			.channel = params->channel
+			.channel = params->channel == WIFI_CHANNEL_ANY ?
+				0 : params->channel,
 		},
 	};
 


### PR DESCRIPTION
When channel set to WIFI_CHANNEL_ANY(255), ap will not work. 
because we pass 255 to hal driver.

This patch choose channel 0 when channel is WIFI_CHANNEL_ANY.
