### PR TITLE
net: wifi: shell: fix parameter description error

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -1142,7 +1142,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_cmd_ap,
 	SHELL_CMD(disable, NULL,
 		  "Disable Access Point mode",
 		  cmd_wifi_ap_disable),
-	SHELL_CMD(enable, NULL, "<SSID> <SSID length> [channel] [PSK]",
+	SHELL_CMD(enable, NULL, "<SSID> [channel] [PSK]",
 		  cmd_wifi_ap_enable),
 	SHELL_SUBCMD_SET_END
 );


### PR DESCRIPTION
command `wifi ap enable` not have `SSID LENGTH` parameter, remove it.

---

we use `__wifi_args_to_params` function to parse args,
but argv[1] is channel, there is no parameter for ssid length

```
static int __wifi_args_to_params(size_t argc, char *argv[],
				struct wifi_connect_req_params *params)
{
	char *endptr;
	int idx = 1;

	if (argc < 1) {
		return -EINVAL;
	}

	/* SSID */
	params->ssid = argv[0];
	params->ssid_length = strlen(params->ssid);
	if (params->ssid_length > WIFI_SSID_MAX_LEN) {
		return -EINVAL;
	}

	/* Channel (optional) */
	if ((idx < argc) && (strlen(argv[idx]) <= 3)) {                      <<<<<<< idx == 1, argv[1] is channel
		params->channel = strtol(argv[idx], &endptr, 10);
		if (*endptr != '\0') {
			return -EINVAL;
		}

		if (params->channel == 0U) {
			params->channel = WIFI_CHANNEL_ANY;
		}

		idx++;
	} else {
		params->channel = WIFI_CHANNEL_ANY;
	}

```