### PR TITLE
Misc. fixes for Connected ISO

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -84,13 +84,13 @@ struct bt_hci_acl_hdr {
 #define BT_ISO_DATA_INVALID              0x01
 #define BT_ISO_DATA_NOP                  0x02
 
-#define bt_iso_pkt_len(h)                ((h) & 0x3fff)
+#define bt_iso_pkt_len(h)                ((h) & BIT_MASK(12))
 #define bt_iso_pkt_flags(h)              ((h) >> 14)
-#define bt_iso_pkt_len_pack(h, f)        ((h) | ((f) << 14))
+#define bt_iso_pkt_len_pack(h, f)        (((h) & BIT_MASK(12)) | ((f) << 14))
 
 struct bt_hci_iso_data_hdr {
 	uint16_t sn;
-	uint16_t slen;
+	uint16_t slen; /* 12 bit len, 2 bit RFU, 2 bit packet status */
 } __packed;
 #define BT_HCI_ISO_DATA_HDR_SIZE	4
 

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5666,7 +5666,7 @@ int hci_iso_handle(struct net_buf *buf, struct net_buf **evt)
 
 	iso_hdr = net_buf_pull_mem(buf, sizeof(*iso_hdr));
 	handle = sys_le16_to_cpu(iso_hdr->handle);
-	len = sys_le16_to_cpu(iso_hdr->len);
+	len = bt_iso_hdr_len(sys_le16_to_cpu(iso_hdr->len));
 
 	if (buf->len < len) {
 		LOG_ERR("Invalid HCI ISO packet length");
@@ -5706,7 +5706,8 @@ int hci_iso_handle(struct net_buf *buf, struct net_buf **evt)
 		iso_data_hdr = net_buf_pull_mem(buf, sizeof(*iso_data_hdr));
 		len -= sizeof(*iso_data_hdr);
 		sdu_frag_tx.packet_sn = sys_le16_to_cpu(iso_data_hdr->sn);
-		sdu_frag_tx.iso_sdu_length = sys_le16_to_cpu(iso_data_hdr->slen);
+		sdu_frag_tx.iso_sdu_length =
+			sys_le16_to_cpu(bt_iso_pkt_len(iso_data_hdr->slen));
 	} else {
 		sdu_frag_tx.packet_sn = 0;
 		sdu_frag_tx.iso_sdu_length = 0;

--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define LLL_CIS_FLUSH_NONE      0
+#define LLL_CIS_FLUSH_PENDING   1
+#define LLL_CIS_FLUSH_COMPLETE  2
+
 struct lll_conn_iso_stream_rxtx {
 	uint64_t payload_count:39; /* cisPayloadCounter */
 	uint64_t phy_flags:1;      /* S2 or S8 coding scheme */
@@ -42,7 +46,7 @@ struct lll_conn_iso_stream {
 	uint8_t nesn:1;             /* Next expected sequence number */
 	uint8_t cie:1;              /* Close isochronous event */
 	uint8_t npi:1;              /* 1 if CIS LLL has Tx-ed Null PDU Indicator */
-	uint8_t flushed:1;          /* 1 if CIS LLL has been flushed */
+	uint8_t flush:2;            /* See states LLL_CIS_FLUSH_XXX */
 	uint8_t active:1;           /* 1 if CIS LLL is active */
 	uint8_t datapath_ready_rx:1;/* 1 if datapath for RX is ready */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -637,7 +637,7 @@ void ll_cis_create(uint16_t cis_handle, uint16_t acl_handle)
 	cis->lll.sn = 0;
 	cis->lll.nesn = 0;
 	cis->lll.cie = 0;
-	cis->lll.flushed = 0;
+	cis->lll.flush = LLL_CIS_FLUSH_NONE;
 	cis->lll.active = 0;
 	cis->lll.datapath_ready_rx = 0;
 	cis->lll.tx.bn_curr = 1U;
@@ -816,7 +816,7 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 	cis->lll.nesn = 0U;
 	cis->lll.cie = 0U;
 	cis->lll.npi = 0U;
-	cis->lll.flushed = 0U;
+	cis->lll.flush = LLL_CIS_FLUSH_NONE;
 	cis->lll.active = 0U;
 	cis->lll.datapath_ready_rx = 0U;
 	cis->lll.tx.payload_count = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -216,25 +216,28 @@ struct ll_conn_iso_stream *ll_conn_iso_stream_get_by_acl(struct ll_conn *conn, u
 
 		handle_iter = UINT16_MAX;
 
-		for (cis_idx = 0; cis_idx < cig->lll.num_cis; cis_idx++) {
+		/* Find next connected CIS in the group */
+		for (cis_idx = 0; cis_idx < CONFIG_BT_CTLR_CONN_ISO_STREAMS_PER_GROUP; cis_idx++) {
 			cis = ll_conn_iso_stream_get_by_group(cig, &handle_iter);
-			LL_ASSERT(cis);
+			if (cis) {
+				uint16_t cis_handle = cis->lll.handle;
 
-			uint16_t cis_handle = cis->lll.handle;
-
-			cis = ll_iso_stream_connected_get(cis_handle);
-			if (!cis) {
-				continue;
-			}
-
-			if (!cis_iter_start) {
-				/* Look for iterator start handle */
-				cis_iter_start = cis_handle == (*cis_iter);
-			} else if (cis->lll.acl_handle == conn->lll.handle) {
-				if (cis_iter) {
-					(*cis_iter) = cis_handle;
+				cis = ll_iso_stream_connected_get(cis_handle);
+				if (!cis) {
+					/* CIS is not connected */
+					continue;
 				}
-				return cis;
+
+				if (!cis_iter_start) {
+					/* Look for iterator start handle */
+					cis_iter_start = cis_handle == (*cis_iter);
+				} else if (cis->lll.acl_handle == conn->lll.handle) {
+					if (cis_iter) {
+						(*cis_iter) = cis_handle;
+					}
+
+					return cis;
+				}
 			}
 		}
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -716,7 +716,7 @@ static void lp_comm_st_idle(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t 
 			/* Clear terminate ack flag, used to signal CIS Terminated */
 			conn->llcp.cis.terminate_ack = 0U;
 			llcp_cis_stop_by_id(ctx->data.cis_term.cig_id, ctx->data.cis_term.cis_id,
-					    ctx->data.cis_term.error_code);
+					    BT_HCI_ERR_LOCALHOST_TERM_CONN);
 		}
 #endif /* CONFIG_BT_CTLR_CENTRAL_ISO || CONFIG_BT_CTLR_PERIPHERAL_ISO */
 		lp_comm_send_req(conn, ctx, evt, param);

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -328,7 +328,7 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 	cis->lll.nesn = 0U;
 	cis->lll.cie = 0U;
 	cis->lll.npi = 0U;
-	cis->lll.flushed = 0U;
+	cis->lll.flush = LLL_CIS_FLUSH_NONE;
 	cis->lll.active = 0U;
 	cis->lll.datapath_ready_rx = 0U;
 	cis->lll.tx.payload_count = 0U;


### PR DESCRIPTION
**Bluetooth: controller: Modify reason for local CIS_TERMINATE procedure**
When executing a local CIS_TERMINATE procedure, the reason sent to the
host must be changed to match the perspective of the initiator.

According to BT Core 5.4 Vol 4, Part E, section 7.1.6, the disconnect
reason must be BT_HCI_ERR_LOCALHOST_TERM_CONN for a local disconnect.

**Bluetooth: controller: Prevent assert in ll_conn_iso_stream_get_by_acl**
Do not assert in case of race conditions or asymmetric CIS
create/release. There are cases where ll_conn_iso_stream_get_by_group
legally returns NULL, and this should just cause for-loop continuing to
next iteration.

**Bluetooth: controller: Introduce CIS LLL flush states**
To keep track of requested/pending CIS LLL flushing, change 'flushed'
binary state to 'flush' with states NONE, PENDING and COMPLETE.

This enables CIS teardown to know that a CIS already has a pending LLL
flush, and ULL does not need to initiate it.

**Bluetooth: controller: Fix HCI ISO header RFU bit masking**
Mask out RFU bits in HCI ISO header to prevent set RFU bits leaking into
length values.
