### PR TITLE
drivers: pinctrl: nrf: Add support for setting initial pin state

### DIFF
--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -124,7 +124,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 #if defined(NRF_PSEL_SPIM)
 		case NRF_FUN_SPIM_SCK:
 			NRF_PSEL_SPIM(reg, SCK) = psel;
-			write = 0U;
+			write = NRF_GET_INIT(pins[i]);
 			dir = NRF_GPIO_PIN_DIR_OUTPUT;
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;

--- a/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
@@ -92,6 +92,8 @@ child-binding:
           - bias-pull-down
           - bias-pull-up
           - low-power-enable
+          - output-high
+          - output-low
 
     properties:
       psels:

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -10,7 +10,8 @@
  * The whole nRF pin configuration information is encoded in a 32-bit bitfield
  * organized as follows:
  *
- * - 31..16: Pin function.
+ * - 31      Pin initial state.
+ * - 30..16: Pin function.
  * - 15:     Reserved.
  * - 14:     Pin inversion mode.
  * - 13:     Pin low power mode.
@@ -24,10 +25,14 @@
  * @{
  */
 
+/** Position of the output initial state. */
+#define NRF_INIT_POS 31U
+/** Mask for the output initial state. */
+#define NRF_INIT_MSK 0x1U
 /** Position of the function field. */
 #define NRF_FUN_POS 16U
 /** Mask for the function field. */
-#define NRF_FUN_MSK 0xFFFFU
+#define NRF_FUN_MSK 0x7FFFU
 /** Position of the invert field. */
 #define NRF_INVERT_POS 14U
 /** Mask for the invert field. */
@@ -190,6 +195,18 @@
 
 /** Indicates that a pin is disconnected */
 #define NRF_PIN_DISCONNECTED NRF_PIN_MSK
+
+/** @} */
+
+/**
+ * @name nRF pinctrl init state.
+ * @{
+ */
+
+/** High initial pin state. */
+#define NRF_INIT_HIGH 1U
+/** Low initial pin state. */
+#define NRF_INIT_LOW 0U
 
 /** @} */
 

--- a/soc/arm/nordic_nrf/common/pinctrl_soc.h
+++ b/soc/arm/nordic_nrf/common/pinctrl_soc.h
@@ -38,7 +38,9 @@ typedef uint32_t pinctrl_soc_pin_t;
 	 ((NRF_PULL_UP * DT_PROP(node_id, bias_pull_up)) << NRF_PULL_POS) |    \
 	 (DT_PROP(node_id, nordic_drive_mode) << NRF_DRIVE_POS) |	       \
 	 ((NRF_LP_ENABLE * DT_PROP(node_id, low_power_enable)) << NRF_LP_POS) |\
-	 (DT_PROP(node_id, nordic_invert) << NRF_INVERT_POS)		       \
+	 (DT_PROP(node_id, nordic_invert) << NRF_INVERT_POS) |		       \
+	 ((NRF_INIT_LOW * DT_PROP(node_id, output_low)) << NRF_INIT_POS) |     \
+	 ((NRF_INIT_HIGH * DT_PROP(node_id, output_high)) << NRF_INIT_POS)     \
 	),
 
 /**
@@ -51,6 +53,13 @@ typedef uint32_t pinctrl_soc_pin_t;
 	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop),		       \
 				DT_FOREACH_PROP_ELEM, psels,		       \
 				Z_PINCTRL_STATE_PIN_INIT)}
+
+/**
+ * @brief Utility macro to obtain pin initial state.
+ *
+ * @param pincfg Pin configuration bit field.
+ */
+#define NRF_GET_INIT(pincfg) (((pincfg) >> NRF_INIT_POS) & NRF_INIT_MSK)
 
 /**
  * @brief Utility macro to obtain pin function.


### PR DESCRIPTION
The nRF pinctrl driver did not allow for setting the initial state of the pins. This issue specifically affected the SPI SPIM driver, which caused an invalid SCK state when configured with CPOL (Clock Polarity).

With the introduction of the power-optimized SPIM driver, it disables the peripheral instance once the transfer is completed. As a result, the GPIO takes control over the SCK pin and drive it based on its own configuration. However, the pinctrl configures pins for SPIM incorrectly when CPOL is set. This causes that GPIO sets the SCK pin to 0 instead of the expected 1 when idle after SPI transaction is finished.

To address this issue, a patch was introduced.
Now, when an SPIM instance is configured with CPOL, the pinctrl node must have the 'output-high' property set to ensure the correct initial pin state.

Example devicetree fragment:
```
    spi1_default: spi1_default {
        group1 {
            psels = <NRF_PSEL(SPIM_SCK, 0, 5)>;
            output-high;
        };
        group2 {
            psels = <NRF_PSEL(SPIM_MISO, 0, 6)>,
                    <NRF_PSEL(SPIM_MOSI, 0, 7)>;
        };
    };
```