### PR TITLE
mgmt/MCUmgr/img: Introduce img_mgmt_set_next_boot_slot, and mark img_mgmt_state_confirm and img_mgmt_state_pending as deprecated

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -44,6 +44,10 @@ Deprecated in this release
   The GIC version should now be specified by adding the appropriate compatible, for
   example :dtcompatible:`arm,gic-v2`, to the GIC node in the device tree.
 
+* MCUmgr image management functions :c:func:`img_mgmt_state_set_pending` and
+  :c:func:`img_mgmt_state_set_confirm` have been deprecated and are being replaced
+  by :c:func:`img_mgmt_set_next_boot_slot`.
+
 Stable API changes in this release
 ==================================
 

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -312,7 +312,7 @@ uint8_t img_mgmt_state_flags(int query_slot);
  *
  * @return 0 on success, non-zero on failure
  */
-int img_mgmt_state_set_pending(int slot, int permanent);
+__deprecated int img_mgmt_state_set_pending(int slot, int permanent);
 
 /**
  * @brief Confirms the current image state.

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -325,6 +325,27 @@ __deprecated int img_mgmt_state_set_pending(int slot, int permanent);
 __deprecated int img_mgmt_state_confirm(void);
 
 /**
+ * @brief Sets next boot slot
+ *
+ * Sets next boot slot and marks it for test for confirmed permanent,
+ * depending on the value of @p confirm.
+ * The slot is always selected in a context of an image it is part of,
+ * where each image consists of two slots. This means that it is allowed
+ * to set several slots, or change boot slots, as long as they belong
+ * to different images, in which case, on the next boot, these slots
+ * will be used as boot slots for the images they belong to.
+ *
+ * @param slot		slot number, 0 based in MCUboot notion of slot numbering.
+ * @param confirm	if flase then slot is set for test, unless application
+ *			is already running from that slot in which case
+ *			nothing changes; if true then slot is confirmed
+ *			to be used for each next boot.
+ *
+ * @return #img_mgmt_ret_code_t error code.
+ */
+int img_mgmt_set_next_boot_slot(int slot, bool confirm);
+
+/**
  * Compares two image version numbers in a semver-compatible way.
  *
  * @param a	The first version to compare

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -322,7 +322,7 @@ int img_mgmt_state_set_pending(int slot, int permanent);
  *
  * @return 0 on success, non-zero on failure
  */
-int img_mgmt_state_confirm(void);
+__deprecated int img_mgmt_state_confirm(void);
 
 /**
  * Compares two image version numbers in a semver-compatible way.

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -327,7 +327,7 @@ __deprecated int img_mgmt_state_confirm(void);
 /**
  * @brief Sets next boot slot
  *
- * Sets next boot slot and marks it for test for confirmed permanent,
+ * Sets next boot slot and marks it for test or confirmed (permanent),
  * depending on the value of @p confirm.
  * The slot is always selected in a context of an image it is part of,
  * where each image consists of two slots. This means that it is allowed

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -339,7 +339,7 @@ __deprecated int img_mgmt_state_confirm(void);
  * @param confirm	if flase then slot is set for test, unless application
  *			is already running from that slot in which case
  *			nothing changes; if true then slot is confirmed
- *			to be used for each next boot.
+ *			to be used for each boot hereafter.
  *
  * @return #img_mgmt_ret_code_t error code.
  */


### PR DESCRIPTION
Introduces `img_mgmt_set_next_boot_slot` as the replacement for two other deprecated functions.
The new function is supposed to cover various MCUboot boot algorithms and number of images.