### PR TITLE
soc: arm: nordic_nrf: fix poweroff for nrf53/91

### DIFF
--- a/soc/arm/nordic_nrf/common/poweroff.c
+++ b/soc/arm/nordic_nrf/common/poweroff.c
@@ -6,11 +6,19 @@
 #include <zephyr/sys/poweroff.h>
 #include <zephyr/toolchain.h>
 
+#if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
 #include <hal/nrf_power.h>
+#else
+#include <hal/nrf_regulators.h>
+#endif
 
 void z_sys_poweroff(void)
 {
+#if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
 	nrf_power_system_off(NRF_POWER);
+#else
+	nrf_regulators_system_off(NRF_REGULATORS);
+#endif
 
 	CODE_UNREACHABLE;
 }


### PR DESCRIPTION
nRF53/91 require usage of nrf_regulators_system_off, so the API is not common with nRF51/52. This was an oversight during the conversion.