### PR TITLE
drivers: spi: spi_nrfx_spim: Add CPOL handling on SCK pin

### DIFF
--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -133,6 +133,9 @@ static int configure(const struct device *dev,
 	config.mode      = get_nrf_spi_mode(spi_cfg->operation);
 	config.bit_order = get_nrf_spi_bit_order(spi_cfg->operation);
 
+	nrf_gpio_pin_write(nrf_spi_sck_pin_get(dev_config->spi.p_reg),
+			   spi_cfg->operation & SPI_MODE_CPOL ? 1 : 0);
+
 	if (dev_data->initialized) {
 		nrfx_spi_uninit(&dev_config->spi);
 		dev_data->initialized = false;

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -181,6 +181,9 @@ static int configure(const struct device *dev,
 	config.mode      = get_nrf_spim_mode(spi_cfg->operation);
 	config.bit_order = get_nrf_spim_bit_order(spi_cfg->operation);
 
+	nrfy_gpio_pin_write(nrfy_spim_sck_pin_get(dev_config->spim.p_reg),
+			    spi_cfg->operation & SPI_MODE_CPOL ? 1 : 0);
+
 	if (dev_data->initialized) {
 		nrfx_spim_uninit(&dev_config->spim);
 		dev_data->initialized = false;


### PR DESCRIPTION
Pin state after SPIM deinitialization is based on pinctrl configuration. On the other hand, CPOL is set during runtime. With the introduction of the power-optimized SPIM driver, it disables the peripheral instance once the transfer is completed. As a result, the GPIO takes control over the SCK pin and drives it based on pinctrl configuration which causes an invalid SCK state when the transaction is configured with CPOL (Clock Polarity).

To address this issue, a patch was introduced to the SPIM driver. Now, when a SPIM instance is configured with CPOL, the driver is setting in the runtime the correct state of the SCK pin.

The PR addresses concerns in the comment https://github.com/zephyrproject-rtos/zephyr/pull/61280#issuecomment-1669621931 placed in PR with another solution to CPOL handling on SCK pin.