### PR TITLE
snippets: fix example usage of EXTRA_DTC_OVERLAY_FILE

### DIFF
--- a/scripts/schemas/snippet-schema.yml
+++ b/scripts/schemas/snippet-schema.yml
@@ -27,7 +27,7 @@ mapping:
 
         name: foo
         append:
-          DTC_OVERLAY_FILE: m3.overlay
+          EXTRA_DTC_OVERLAY_FILE: m3.overlay
     include: append-schema
   boards:
     example: |
@@ -37,7 +37,7 @@ mapping:
         boards:
           qemu_cortex_m3:
             append:
-              DTC_OVERLAY_FILE: m3.overlay
+              EXTRA_DTC_OVERLAY_FILE: m3.overlay
     type: map
     mapping:
       regex;(.*):


### PR DESCRIPTION
`DTC_OVERLAY_FILE` was replaced with `EXTRA_DTC_OVERLAY_FILE`. Adjust example
usage in schema file.

Fixes: 1561a0705f76 ("snippets: support for EXTRA_DTC_OVERLAY_FILE and EXTRA_CONF_FILE")