### PR TITLE
subsys: input: rename callback define macro to INPUT_CALLBACK_DEFINE

### DIFF
--- a/doc/services/input/index.rst
+++ b/doc/services/input/index.rst
@@ -38,7 +38,7 @@ Application API
 ***************
 
 An application can register a callback using the
-:c:macro:`INPUT_LISTENER_CB_DEFINE` macro. If a device node is specified, the
+:c:macro:`INPUT_CALLBACK_DEFINE` macro. If a device node is specified, the
 callback is only invoked for events from the specific device, otherwise the
 callback will receive all the events in the system. This is the only type of
 filtering supported, any more complex filtering logic has to be implemented in

--- a/drivers/kscan/kscan_input.c
+++ b/drivers/kscan/kscan_input.c
@@ -105,8 +105,8 @@ static const struct kscan_driver_api kscan_input_driver_api = {
 		kscan_input_cb(DEVICE_DT_GET(DT_INST(index, DT_DRV_COMPAT)),   \
 			       evt);                                           \
 	}                                                                      \
-	INPUT_LISTENER_CB_DEFINE(DEVICE_DT_GET(DT_INST_PARENT(index)),         \
-				 kscan_input_cb_##index);                      \
+	INPUT_CALLBACK_DEFINE(DEVICE_DT_GET(DT_INST_PARENT(index)),            \
+			      kscan_input_cb_##index);                         \
 	static const struct kscan_input_config kscan_input_config_##index = {  \
 		.input_dev = DEVICE_DT_GET(DT_INST_PARENT(index)),             \
 	};                                                                     \

--- a/include/zephyr/input/input.h
+++ b/include/zephyr/input/input.h
@@ -135,7 +135,7 @@ struct input_listener {
  * @param _dev @ref device pointer or NULL.
  * @param _callback The callback function.
  */
-#define INPUT_LISTENER_CB_DEFINE(_dev, _callback)                              \
+#define INPUT_CALLBACK_DEFINE(_dev, _callback)                                 \
 	static const STRUCT_SECTION_ITERABLE(input_listener,                   \
 					     _input_listener__##_callback) = { \
 		.dev = _dev,                                                   \

--- a/subsys/input/input_longpress.c
+++ b/subsys/input/input_longpress.c
@@ -116,8 +116,8 @@ static int longpress_init(const struct device *dev)
 	{                                                                                          \
 		longpress_cb(DEVICE_DT_INST_GET(inst), evt);                                       \
 	}                                                                                          \
-	INPUT_LISTENER_CB_DEFINE(DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, input)),              \
-				 longpress_cb_##inst);                                             \
+	INPUT_CALLBACK_DEFINE(DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, input)),                 \
+			      longpress_cb_##inst);                                                \
 	static const uint16_t longpress_input_codes_##inst[] = DT_INST_PROP(inst, input_codes);    \
 	static const uint16_t longpress_short_codes_##inst[] = DT_INST_PROP(inst, short_codes);    \
 	static const uint16_t longpress_long_codes_##inst[] = DT_INST_PROP(inst, long_codes);      \

--- a/subsys/input/input_utils.c
+++ b/subsys/input/input_utils.c
@@ -60,7 +60,7 @@ static void input_cb(struct input_event *evt)
 		evt->code,
 		evt->value);
 }
-INPUT_LISTENER_CB_DEFINE(NULL, input_cb);
+INPUT_CALLBACK_DEFINE(NULL, input_cb);
 #endif /* CONFIG_INPUT_EVENT_DUMP */
 
 #ifdef CONFIG_INPUT_SHELL

--- a/tests/drivers/input/gpio_keys/src/main.c
+++ b/tests/drivers/input/gpio_keys/src/main.c
@@ -43,7 +43,7 @@ static void test_gpio_keys_cb_handler(struct input_event *evt)
 	last_code = evt->code;
 	last_val = evt->value;
 }
-INPUT_LISTENER_CB_DEFINE(test_gpio_keys_dev, test_gpio_keys_cb_handler);
+INPUT_CALLBACK_DEFINE(test_gpio_keys_dev, test_gpio_keys_cb_handler);
 
 /**
  * @brief TestPurpose: Verify gpio_keys_config pressed raw.

--- a/tests/subsys/input/api/src/main.c
+++ b/tests/subsys/input/api/src/main.c
@@ -29,7 +29,7 @@ static void input_cb_filtered(struct input_event *evt)
 
 	k_sem_give(&cb_start);
 }
-INPUT_LISTENER_CB_DEFINE(&fake_dev, input_cb_filtered);
+INPUT_CALLBACK_DEFINE(&fake_dev, input_cb_filtered);
 
 static void input_cb_unfiltered(struct input_event *evt)
 {
@@ -42,7 +42,7 @@ static void input_cb_unfiltered(struct input_event *evt)
 		k_sem_give(&cb_done);
 	}
 }
-INPUT_LISTENER_CB_DEFINE(NULL, input_cb_unfiltered);
+INPUT_CALLBACK_DEFINE(NULL, input_cb_unfiltered);
 
 ZTEST(input_api, test_sequence_thread)
 {
@@ -91,13 +91,13 @@ static void input_cb_filtered(struct input_event *evt)
 		message_count_filtered++;
 	}
 }
-INPUT_LISTENER_CB_DEFINE(&fake_dev, input_cb_filtered);
+INPUT_CALLBACK_DEFINE(&fake_dev, input_cb_filtered);
 
 static void input_cb_unfiltered(struct input_event *evt)
 {
 	message_count_unfiltered++;
 }
-INPUT_LISTENER_CB_DEFINE(NULL, input_cb_unfiltered);
+INPUT_CALLBACK_DEFINE(NULL, input_cb_unfiltered);
 
 ZTEST(input_api, test_synchronous)
 {
@@ -122,7 +122,7 @@ static void input_cb_last_event(struct input_event *evt)
 {
 	memcpy(&last_event, evt, sizeof(last_event));
 }
-INPUT_LISTENER_CB_DEFINE(NULL, input_cb_last_event);
+INPUT_CALLBACK_DEFINE(NULL, input_cb_last_event);
 
 ZTEST(input_api, test_report_apis)
 {

--- a/tests/subsys/input/input_longpress/src/main.c
+++ b/tests/subsys/input/input_longpress/src/main.c
@@ -28,7 +28,7 @@ static void test_cb(struct input_event *evt)
 	memcpy(&last_events[1], &last_events[0], sizeof(struct input_event));
 	memcpy(&last_events[0], evt, sizeof(struct input_event));
 }
-INPUT_LISTENER_CB_DEFINE(longpress_dev, test_cb);
+INPUT_CALLBACK_DEFINE(longpress_dev, test_cb);
 
 ZTEST(longpress, test_longpress_test)
 {


### PR DESCRIPTION
Hey, had a bit of a look back at the input API and realized that this really feel misnamed. Not sure why I picked something with so many qualifiers at the time but it does not look quite right, figured it should have just be called "INPUT_CALLBACK_DEFINE". Simple.

Feels a bit silly to change it just for the naming, but then I thought, the API is experimental, it just came out and there's plenty of other breaking changes involved with input anyway, if I have a chance to change this it's now or never. LMK what you think.

---

Looking back at the current INPUT_LISTENER_CB_DEFINE api naming, it feels like it's a bit overloaded. Rename it to a simpler INPUT_CALLBACK_DEFINE.