### PR TITLE
driver: wifi: esp32: enable iface when enable ap mode

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -289,6 +289,7 @@ static void esp_wifi_event_task(void)
 			break;
 		case ESP32_WIFI_EVENT_AP_STOP:
 			esp32_data.state = ESP32_AP_STOPPED;
+			net_eth_carrier_off(esp32_wifi_iface);
 			break;
 		case ESP32_WIFI_EVENT_AP_STACONNECTED:
 			esp32_data.state = ESP32_AP_CONNECTED;
@@ -457,6 +458,8 @@ static int esp32_wifi_ap_enable(const struct device *dev,
 		LOG_ERR("Failed to enable Wi-Fi AP mode");
 		return -EAGAIN;
 	}
+
+	net_eth_carrier_on(esp32_wifi_iface);
 
 	return 0;
 };


### PR DESCRIPTION
when ap mode is enable, we don't enable iface by `net_eth_carrier_on` before, this will cause wifi tx error.

this patch fix this issues.