### PR TITLE
board: mimxrt1160_evk: Add missing CANFD fields

### DIFF
--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
@@ -46,7 +46,7 @@
 &flexcan3 {
 	status = "okay";
 	bus-speed = <125000>;
-
+	bus-speed-data = <1000000>;
 	can-transceiver {
 		max-bitrate = <5000000>;
 	};


### PR DESCRIPTION
Add the missing bus-speed-data field to the 1160 evk to fix CI build problems.