### PR TITLE
drivers: gpio: mchp: Twister fix for test_input_output failure

### DIFF
--- a/drivers/gpio/gpio_mchp_xec_v2.c
+++ b/drivers/gpio/gpio_mchp_xec_v2.c
@@ -94,6 +94,11 @@ static int gpio_xec_validate_flags(gpio_flags_t flags)
 		return -ENOTSUP;
 	}
 
+	if ((flags & (GPIO_INPUT | GPIO_OUTPUT))
+	    == (GPIO_INPUT | GPIO_OUTPUT)) {
+		return -ENOTSUP;
+	}
+
 	if ((flags & GPIO_OUTPUT_INIT_LOW) && (flags & GPIO_OUTPUT_INIT_HIGH)) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
Added logic to return ENOTSUP, if input-output GPIO direction requested.

fix #60358