### PR TITLE
modules: hal_ethos_u: ethosu_log depends on stdout console

### DIFF
--- a/modules/hal_ethos_u/Kconfig
+++ b/modules/hal_ethos_u/Kconfig
@@ -40,6 +40,32 @@ config ARM_ETHOS_U_NPU_NAME
 	help
 		Name of the used Arm NPU
 
-module = ARM_ETHOS_U
-module-str = arm_ethos_u
-source "subsys/logging/Kconfig.template.log_config"
+choice "ARM_ETHOS_U_LOG_LEVEL_CHOICE"
+	prompt "Max compiled-in log level for arm_ethos_u"
+	default ARM_ETHOS_U_LOG_LEVEL_WRN
+	depends on STDOUT_CONSOLE
+
+config ARM_ETHOS_U_LOG_LEVEL_ERR
+	bool "Error"
+
+config ARM_ETHOS_U_LOG_LEVEL_WRN
+	bool "Warning"
+
+config ARM_ETHOS_U_LOG_LEVEL_INF
+	bool "Info"
+
+config ARM_ETHOS_U_LOG_LEVEL_DBG
+	bool "Debug"
+
+config ARM_ETHOS_U_LOG_LEVEL_DEFAULT
+	bool "Default"
+
+endchoice
+
+config ARM_ETHOS_U_LOG_LEVEL
+	int
+	depends on STDOUT_CONSOLE
+	default 1 if ARM_ETHOS_U_LOG_LEVEL_ERR
+	default 2 if ARM_ETHOS_U_LOG_LEVEL_WRN
+	default 3 if ARM_ETHOS_U_LOG_LEVEL_INF
+	default 4 if ARM_ETHOS_U_LOG_LEVEL_DBG


### PR DESCRIPTION
ethosu_log.h uses the stdout as it's stream for printf. This could
cause an issue where if CONFIG_LOG=n and CONFIG_CONSOLE=y then there
would be no way to control the log level and it would default to debug
level. There is no NONE option as with the way the ethos-u hal is set
up with no way to go below the err level.

ethosu_log.h can be seen here: https://github.com/zephyrproject-rtos/hal_ethos_u/blob/main/src/ethosu_log.h

Signed-off-by: Ryan McClelland <ryanmcclelland@meta.com>