### PR TITLE
west.yaml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -281,7 +281,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 76d19b3b8885ea7ae25a6f4f5d8501f7ec646447
+      revision: fc658eb5a22b7b1721c3b7d0853a7115fae08939
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  fc658eb5a22b7b1721c3b7d0853a7115fae08939

Brings following Zephyr relevant fixes:
 - c9fa608 boot: boot_serial: Fix issue with encrypted second slot images
 - 25d2f2c zephyr: encryption: Improve Kconfig and key generation
 - 99613c6 bootutil: fix downgrade prevention
 - 5b1d511 boot: bootutil: Add optional boot info shared data saving
 - ea88860 bootutil: Add bootloader info TLV entries
 - 3016d00 bootutil: Add active slot number and max app size to shared data
 - 0540d0f bootutil: Fix for flash_area_id_to_image
 - f17b005 bootutil: Fix boot_set_next passing wrong image number
 - fefc398 fix: update zephyr CONFIG_BOOTLOADER_MCUBOOT
 - 61898da boot: boot_serial: Add updated SMP header
 - 36ae4fd boot: zephyr: split esp32 to esp32_devkitc_{wroom,wrover}
 - 2c86755 boot: zephyr: Fix indication LED not selecting GPIO

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.