### PR TITLE
native boards: IRQ handling: dont swap if kernel is uninitialized

### DIFF
--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -105,7 +105,7 @@ void posix_irq_handler(void)
 	 */
 	if (may_swap
 		&& (hw_irq_ctrl_get_cur_prio() == 256)
-		&& (_kernel.ready_q.cache != _current)) {
+		&& (_kernel.ready_q.cache) && (_kernel.ready_q.cache != _current)) {
 
 		(void)z_swap_irqlock(irq_lock);
 	}

--- a/boards/posix/native_sim/irq_handler.c
+++ b/boards/posix/native_sim/irq_handler.c
@@ -106,7 +106,7 @@ void posix_irq_handler(void)
 	 */
 	if (may_swap
 		&& (hw_irq_ctrl_get_cur_prio() == 256)
-		&& (_kernel.ready_q.cache != _current)) {
+		&& (_kernel.ready_q.cache) && (_kernel.ready_q.cache != _current)) {
 
 		(void)z_swap_irqlock(irq_lock);
 	}

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -126,7 +126,7 @@ void posix_irq_handler(void)
 	if (may_swap
 		&& (hw_irq_ctrl_get_cur_prio() == 256)
 		&& (CPU_will_be_awaken_from_WFE == false)
-		&& (_kernel.ready_q.cache != _current)) {
+		&& (_kernel.ready_q.cache) && (_kernel.ready_q.cache != _current)) {
 
 		z_swap_irqlock(irq_lock);
 	}


### PR DESCRIPTION
After an interrupt, do not attempt to swap
if the kernel is not yet initialized.
    
Otherwise, if an interrupt is raised with interrupts
unlocked while the kernel is not yet fully initialized,
a swap would lead to a crash.
(This could happen if a PREKERNEK1/2 driver enables interrupts
and an interrupt fires before the kernel has swapped to main)
