### PR TITLE
usb_tcpc: fix typo.

### DIFF
--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -106,7 +106,7 @@ struct tcpc_chip_info {
 	/** Device Id */
 	uint16_t device_id;
 	/** Firmware version number */
-	uint64_t fw_verion_number;
+	uint64_t fw_version_number;
 
 	union {
 		/** Minimum Required firmware version string */


### PR DESCRIPTION
This structure is not used anywhere in Zephyr code itself, so it _should_ be safe to change.

On the other hand it might be considered an API breakage, so I'm not quite sure how to proceed.

If this is now definite part of the API (à-la Referer), it should probably be signposted as such.
