### PR TITLE
samples/tests: Fix main return

### DIFF
--- a/samples/drivers/led_is31fl3733/src/main.c
+++ b/samples/drivers/led_is31fl3733/src/main.c
@@ -110,28 +110,28 @@ static int led_on_off(const struct device *led)
 
 const struct device *led_dev = DEVICE_DT_GET_ONE(issi_is31fl3733);
 
-void main(void)
+int main(void)
 {
 	int ret;
 	int current_limit = 0xFF;
 
 	if (!device_is_ready(led_dev)) {
 		printk("Error- LED device is not ready\n");
-		return;
+		return 0;
 	}
 
 	while (1) {
 		ret = led_channel_write(led_dev);
 		if (ret < 0) {
-			return;
+			return 0;
 		}
 		ret = led_brightness(led_dev);
 		if (ret < 0) {
-			return;
+			return 0;
 		}
 		ret = led_on_off(led_dev);
 		if (ret < 0) {
-			return;
+			return 0;
 		}
 		if (current_limit == 0xFF) {
 			/* Select lower current limt */
@@ -140,7 +140,7 @@ void main(void)
 			ret = is31fl3733_current_limit(led_dev, current_limit);
 			if (ret) {
 				printk("Could not set LED current limit (%d)\n", ret);
-				return;
+				return 0;
 			}
 		} else {
 			/* Select higher current limt */
@@ -149,7 +149,7 @@ void main(void)
 			ret = is31fl3733_current_limit(led_dev, current_limit);
 			if (ret) {
 				printk("Could not set LED current limit (%d)\n", ret);
-				return;
+				return 0;
 			}
 		}
 	}

--- a/samples/drivers/led_lp50xx/src/main.c
+++ b/samples/drivers/led_lp50xx/src/main.c
@@ -330,7 +330,7 @@ static int run_test(const struct device *const lp50xx_dev,
 	return 0;
 }
 
-void main(void)
+int main(void)
 {
 	const struct device *lp50xx_dev;
 	bool found = false;
@@ -434,4 +434,5 @@ void main(void)
 	if (!found) {
 		LOG_ERR("No LP50XX LED controller found");
 	}
+	return 0;
 }

--- a/samples/subsys/sensing/simple/src/main.c
+++ b/samples/subsys/sensing/simple/src/main.c
@@ -24,7 +24,7 @@ static void acc_data_event_callback(sensing_sensor_handle_t handle, const void *
 		sample->readings[0].z);
 }
 
-void main(void)
+int main(void)
 {
 	const struct sensing_callback_list base_acc_cb_list = {
 		.on_data_event = &acc_data_event_callback,
@@ -40,7 +40,7 @@ void main(void)
 	ret = sensing_get_sensors(&num, &info);
 	if (ret) {
 		LOG_ERR("sensing_get_sensors error");
-		return;
+		return 0;
 	}
 
 	for (i = 0; i < num; ++i) {
@@ -76,4 +76,5 @@ void main(void)
 	if (ret) {
 		LOG_ERR("sensing_close_sensor:%p error:%d", lid_acc, ret);
 	}
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/src/main.c
@@ -81,7 +81,8 @@ struct bst_test_list *test_ccc_store_install(struct bst_test_list *tests)
 
 bst_test_install_t test_installers[] = {test_ccc_store_install, NULL};
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/id/settings/src/main.c
+++ b/tests/bsim/bluetooth/host/id/settings/src/main.c
@@ -57,7 +57,8 @@ struct bst_test_list *test_id_settings_install(struct bst_test_list *tests)
 
 bst_test_install_t test_installers[] = {test_id_settings_install, NULL};
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/main.c
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/main.c
@@ -94,7 +94,8 @@ struct bst_test_list *test_ccc_update_install(struct bst_test_list *tests)
 
 bst_test_install_t test_installers[] = {test_ccc_update_install, NULL};
 
-void main(void)
+int main(void)
 {
 	bst_main();
+	return 0;
 }


### PR DESCRIPTION
Since 3a197934fca250e456e6fe84ca02309a8b437086
`main()` should be `int main(void)` instead of `void main(void)`

Without these fixes we have CI breaks when these are built as we get a build warning which is treated as an error