### PR TITLE
drivers: i2c: Add Ambiq I2C driver

### DIFF
--- a/boards/arm/apollo4p_evb/apollo4p_evb-pinctrl.dtsi
+++ b/boards/arm/apollo4p_evb/apollo4p_evb-pinctrl.dtsi
@@ -16,4 +16,68 @@
 			input-enable;
 		};
 	};
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <M0SCL_P5>, <M0SDAWIR3_P6>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c1_default: i2c1_default {
+		group1 {
+			pinmux = <M1SCL_P8>, <M1SDAWIR3_P9>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c2_default: i2c2_default {
+		group1 {
+			pinmux = <M2SCL_P25>, <M2SDAWIR3_P26>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c3_default: i2c3_default {
+		group1 {
+			pinmux = <M3SCL_P31>, <M3SDAWIR3_P32>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c4_default: i2c4_default {
+		group1 {
+			pinmux = <M4SCL_P34>, <M4SDAWIR3_P35>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c5_default: i2c5_default {
+		group1 {
+			pinmux = <M5SCL_P47>, <M5SDAWIR3_P48>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c6_default: i2c6_default {
+		group1 {
+			pinmux = <M6SCL_P61>, <M6SDAWIR3_P62>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c7_default: i2c7_default {
+		group1 {
+			pinmux = <M7SCL_P22>, <M7SDAWIR3_P23>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
 };

--- a/boards/arm/apollo4p_evb/apollo4p_evb.dts
+++ b/boards/arm/apollo4p_evb/apollo4p_evb.dts
@@ -33,3 +33,9 @@
 &wdt0 {
 	status = "okay";
 };
+
+&i2c0 {
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -53,6 +53,7 @@ zephyr_library_sources_ifdef(CONFIG_I2C_SMARTBOND	i2c_smartbond.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_XILINX_AXI	i2c_xilinx_axi.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_MCHP_MSS		i2c_mchp_mss.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SEDI		i2c_sedi.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_AMBIQ		i2c_ambiq.c)
 
 zephyr_library_sources_ifdef(CONFIG_I2C_STM32_V1
 	i2c_ll_stm32_v1.c

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -77,6 +77,7 @@ source "drivers/i2c/Kconfig.smartbond"
 source "drivers/i2c/Kconfig.xilinx_axi"
 source "drivers/i2c/Kconfig.mchp_mss"
 source "drivers/i2c/Kconfig.sedi"
+source "drivers/i2c/Kconfig.ambiq"
 
 config I2C_INIT_PRIORITY
 	int "Init priority"

--- a/drivers/i2c/Kconfig.ambiq
+++ b/drivers/i2c/Kconfig.ambiq
@@ -1,0 +1,15 @@
+# Ambiq SDK I2C
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config I2C_AMBIQ
+	bool "AMBIQ I2C driver"
+	default y
+	depends on DT_HAS_AMBIQ_I2C_ENABLED
+	select AMBIQ_HAL
+	select AMBIQ_HAL_USE_I2C
+	help
+	  Enable driver for Ambiq I2C.

--- a/drivers/i2c/i2c_ambiq.c
+++ b/drivers/i2c/i2c_ambiq.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2023 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ambiq_i2c
+
+#include <errno.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/kernel.h>
+
+#include <am_mcu_apollo.h>
+
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/pinctrl.h>
+
+LOG_MODULE_REGISTER(ambiq_i2c, CONFIG_I2C_LOG_LEVEL);
+
+typedef int (*ambiq_i2c_pwr_func_t)(void);
+
+#define PWRCTRL_MAX_WAIT_US 5
+
+#include "i2c-priv.h"
+
+struct i2c_ambiq_config {
+	uint32_t base;
+	int size;
+	uint32_t bitrate;
+	const struct pinctrl_dev_config *pcfg;
+	ambiq_i2c_pwr_func_t pwr_func;
+};
+
+struct i2c_ambiq_data {
+	am_hal_iom_config_t iom_cfg;
+	void *IOMHandle;
+};
+
+static int i2c_ambiq_read(const struct device *dev, struct i2c_msg *msg, uint16_t addr)
+{
+	struct i2c_ambiq_data *data = dev->data;
+
+	int ret = 0;
+
+	am_hal_iom_transfer_t trans = {0};
+
+	trans.ui8Priority = 1;
+	trans.eDirection = AM_HAL_IOM_RX;
+	trans.uPeerInfo.ui32I2CDevAddr = addr;
+	trans.ui32NumBytes = msg->len;
+	trans.pui32RxBuffer = (uint32_t *)msg->buf;
+
+	ret = am_hal_iom_blocking_transfer(data->IOMHandle, &trans);
+
+	return ret;
+}
+
+static int i2c_ambiq_write(const struct device *dev, struct i2c_msg *msg, uint16_t addr)
+{
+	struct i2c_ambiq_data *data = dev->data;
+
+	int ret = 0;
+
+	am_hal_iom_transfer_t trans = {0};
+
+	trans.ui8Priority = 1;
+	trans.eDirection = AM_HAL_IOM_TX;
+	trans.uPeerInfo.ui32I2CDevAddr = addr;
+	trans.ui32NumBytes = msg->len;
+	trans.pui32TxBuffer = (uint32_t *)msg->buf;
+
+	ret = am_hal_iom_blocking_transfer(data->IOMHandle, &trans);
+
+	return ret;
+}
+
+static int i2c_ambiq_configure(const struct device *dev, uint32_t dev_config)
+{
+	struct i2c_ambiq_data *data = dev->data;
+
+	if (!(I2C_MODE_CONTROLLER & dev_config)) {
+		return -EINVAL;
+	}
+
+	switch (I2C_SPEED_GET(dev_config)) {
+	case I2C_SPEED_STANDARD:
+		data->iom_cfg.ui32ClockFreq = AM_HAL_IOM_100KHZ;
+		break;
+	case I2C_SPEED_FAST:
+		data->iom_cfg.ui32ClockFreq = AM_HAL_IOM_400KHZ;
+		break;
+	case I2C_SPEED_FAST_PLUS:
+		data->iom_cfg.ui32ClockFreq = AM_HAL_IOM_1MHZ;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	am_hal_iom_configure(data->IOMHandle, &data->iom_cfg);
+
+	return 0;
+}
+
+static int i2c_ambiq_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
+			      uint16_t addr)
+{
+	int ret = 0;
+
+	if (!num_msgs) {
+		return 0;
+	}
+
+	for (int i = 0; i < num_msgs; i++) {
+		if (msgs[i].flags & I2C_MSG_READ) {
+			ret = i2c_ambiq_read(dev, &(msgs[i]), addr);
+		} else {
+			ret = i2c_ambiq_write(dev, &(msgs[i]), addr);
+		}
+
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static int i2c_ambiq_init(const struct device *dev)
+{
+	struct i2c_ambiq_data *data = dev->data;
+	const struct i2c_ambiq_config *config = dev->config;
+	uint32_t bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
+	int ret = 0;
+
+	data->iom_cfg.eInterfaceMode = AM_HAL_IOM_I2C_MODE;
+
+	ret = am_hal_iom_initialize((config->base - REG_IOM_BASEADDR) / config->size,
+				    &data->IOMHandle);
+
+	ret = config->pwr_func();
+
+	ret = i2c_ambiq_configure(dev, I2C_MODE_CONTROLLER | I2C_SPEED_SET(bitrate_cfg));
+
+	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = am_hal_iom_enable(data->IOMHandle);
+
+	return ret;
+}
+
+static struct i2c_driver_api i2c_ambiq_driver_api = {
+	.configure = i2c_ambiq_configure,
+	.transfer = i2c_ambiq_transfer,
+};
+
+#define AMBIQ_I2C_DEFINE(n)                                                                        \
+	PINCTRL_DT_INST_DEFINE(n);                                                                 \
+	static int pwr_on_ambiq_i2c_##n(void)                                                      \
+	{                                                                                          \
+		uint32_t addr = DT_REG_ADDR(DT_INST_PHANDLE(n, ambiq_pwrcfg)) +                    \
+				DT_INST_PHA(n, ambiq_pwrcfg, offset);                              \
+		sys_write32((sys_read32(addr) | DT_INST_PHA(n, ambiq_pwrcfg, mask)), addr);        \
+		k_busy_wait(PWRCTRL_MAX_WAIT_US);                                                  \
+		return 0;                                                                          \
+	}                                                                                          \
+	static struct i2c_ambiq_data i2c_ambiq_data##n;                                            \
+	static const struct i2c_ambiq_config i2c_ambiq_config##n = {                               \
+		.base = DT_INST_REG_ADDR(n),                                                       \
+		.size = DT_INST_REG_SIZE(n),                                                       \
+		.bitrate = DT_INST_PROP(n, clock_frequency),                                       \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
+		.pwr_func = pwr_on_ambiq_i2c_##n};                                                 \
+	I2C_DEVICE_DT_INST_DEFINE(n, i2c_ambiq_init, NULL, &i2c_ambiq_data##n,                     \
+				  &i2c_ambiq_config##n, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,     \
+				  &i2c_ambiq_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(AMBIQ_I2C_DEFINE)

--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -2,6 +2,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <mem.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	clocks {
@@ -99,6 +100,94 @@
 			status = "disabled";
 			clocks = <&uartclk>;
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x1000>;
+		};
+
+		i2c0: i2c@40050000 {
+			compatible = "ambiq,i2c";
+			reg = <0x40050000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <6 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
+		};
+
+		i2c1: i2c@40051000 {
+			compatible = "ambiq,i2c";
+			reg = <0x40051000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <7 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
+		};
+
+		i2c2: i2c@40052000 {
+			compatible = "ambiq,i2c";
+			reg = <0x40052000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <8 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
+		};
+
+		i2c3: i2c@40053000 {
+			compatible = "ambiq,i2c";
+			reg = <0x40053000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <9 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
+		};
+
+		i2c4: i2c@40054000 {
+			compatible = "ambiq,i2c";
+			reg = <0x40054000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <10 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
+		};
+
+		i2c5: i2c@40055000 {
+			compatible = "ambiq,i2c";
+			reg = <0x40055000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <11 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
+		};
+
+		i2c6: i2c@40056000 {
+			compatible = "ambiq,i2c";
+			reg = <0x40056000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <12 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
+		};
+
+		i2c7: i2c@40057000 {
+			compatible = "ambiq,i2c";
+			reg = <0x40057000 0x1000>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <13 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
 		};
 
 		pinctrl: pin-controller@40010000 {

--- a/dts/bindings/i2c/ambiq,i2c.yaml
+++ b/dts/bindings/i2c/ambiq,i2c.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: Ambiq I2C
+
+compatible: "ambiq,i2c"
+
+include: [i2c-controller.yaml, pinctrl-device.yaml, ambiq-pwrcfg.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  ambiq,pwrcfg:
+    required: true

--- a/modules/hal_ambiq/Kconfig
+++ b/modules/hal_ambiq/Kconfig
@@ -30,4 +30,9 @@ config AMBIQ_HAL_USE_WDT
 	help
 	  Use the WDT driver from Ambiq HAL
 
+config AMBIQ_HAL_USE_I2C
+	bool
+	help
+	  Use the I2C driver from Ambiq HAL
+
 endif # AMBIQ_HAL

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: fe158a4395ba80a9d46c6782e23c277149855a57
+      revision: 446736a1c36199d1c8b9b2c4b3d14bf27006d440
       path: modules/hal/ambiq
       groups:
         - hal


### PR DESCRIPTION
This PR adds the Ambiq IOM I2C driver, as well as instances in SoC.
This PR should be merged after the https://github.com/zephyrproject-rtos/hal_ambiq/pull/3 is merged.
