### PR TITLE
scripts: twister: Fix return value for size

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -745,7 +745,7 @@ def parse_arguments(parser, args, options = None):
         for fn in options.size:
             sc = SizeCalculator(fn, [])
             sc.size_report()
-        sys.exit(1)
+        sys.exit(0)
 
     if len(options.extra_test_args) > 0:
         # extra_test_args is a list of CLI args that Twister did not recognize

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -190,7 +190,7 @@ def test_parse_arguments_errors_size():
         with pytest.raises(SystemExit) as exit_info:
             twisterlib.environment.parse_arguments(parser, args)
 
-    assert exit_info.value.code == 1
+    assert exit_info.value.code == 0
 
     mock_calc_parent.child.assert_has_calls([mock.call(('dummy.elf', []), {})])
     mock_calc_parent.child().size_report.assert_has_calls([mock.call()])


### PR DESCRIPTION
If size is given then twister prnits the size information for the ELF but returns one which if used in automation fails the command.

Return zero as the command is successful.