### PR TITLE
ARC: tests: re-enable cpu_idle test for SMP nSIM platforms

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -361,13 +361,6 @@ ZTEST(context_cpu_idle, test_cpu_idle_atomic)
  */
 ZTEST(context_cpu_idle, test_cpu_idle)
 {
-/*
- * Fixme: remove the skip code when sleep instruction in
- * nsim_hs_smp is fixed.
- */
-#if defined(CONFIG_SOC_NSIM) && defined(CONFIG_SMP)
-	ztest_test_skip();
-#endif
 	_test_kernel_cpu_idle(0);
 }
 


### PR DESCRIPTION
The original issue is fixed some time ago, so re-enable the test.

This reverts commit 52992b065829d8280119fca96ab27d49e9d4b5fc ("tests: skip the cpu_idle test for nsim_hs_smp")