### PR TITLE
Add img_mgmt_get_next_boot_slot  and switch upload and erase logic to use it

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -351,6 +351,14 @@ Libraries / Subsystems
     zephyr settings from a remote device, see :ref:`mcumgr_smp_group_3` for
     details.
 
+  * Added :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_SECONDARY`
+    and :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_ANY`
+    that allow to control whether MCUmgr client will be allowed to confirm
+    non-active images.
+
+  * Added :kconfig:option:`CONFIG_MCUMGR_GRP_IMG_ALLOW_ERASE_PENDING` that allows
+    to erase slots pending for next boot, that are not revert slots.
+
 * File systems
 
   * Added support for ext2 file system.

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -156,6 +156,12 @@ enum img_mgmt_err_code_t {
 
 	/** The amount of data sent is larger than the provided image size. */
 	IMG_MGMT_ERR_INVALID_IMAGE_DATA_OVERRUN,
+
+	/** Confirmation of image has been denied */
+	IMG_MGMT_ERR_IMAGE_CONFIRMATION_DENIED,
+
+	/** Setting test to active slot is not allowed */
+	IMG_MGMT_ERR_IMAGE_SETTING_TEST_TO_ACTIVE_DENIED,
 };
 
 /**

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -82,6 +82,15 @@ config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_ANY
 	  broken and may not boot in other slot; instead application should
 	  have means to test and confirm the image.
 
+if !MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
+config MCUMGR_GRP_IMG_ALLOW_ERASE_PENDING
+	bool "Allow to erase pending slot"
+	help
+	  Allows erasing secondary slot which is marked for test or confirmed; this allows
+	  erasing slots that have been set for next boot but the device has not
+	  reset yet, so has not yet been swapped.
+endif
+
 config MCUMGR_GRP_IMG_DIRECT_UPLOAD
 	bool "Allow direct image upload"
 	help

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -62,6 +62,26 @@ config MCUMGR_GRP_IMG_VERBOSE_ERR
 	  Add additional "rsn" key to SMP responses, where provided, explaining
 	  non-0 "rc" codes.
 
+config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_SECONDARY
+	bool "Allow to confirm secondary slot of non-active image"
+	default y
+	help
+	  Allows to confirm secondary (non-active) slot of non-active image.
+	  Normally it should not be allowed to confirm any slots of non-active
+	  image, via MCUmgr commands, to prevent confirming something that is
+	  broken and may not boot in other slot; instead application should
+	  have means to test and confirm the image.
+
+config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_ANY
+	bool "Allow to confirm slots of non-active image"
+	select MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_SECONDARY
+	help
+	  Allows to confirm any slot of non-active image.
+	  Normally it should not be allowed to confirm any slots of non-active
+	  image, via MCUmgr commands, to prevent confirming something that is
+	  broken and may not boot in other slot; instead application should
+	  have means to test and confirm the image.
+
 config MCUMGR_GRP_IMG_DIRECT_UPLOAD
 	bool "Allow direct image upload"
 	help

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/include/mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/include/mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h
@@ -87,6 +87,55 @@ int img_mgmt_write_image_data(unsigned int offset, const void *data, unsigned in
 int img_mgmt_swap_type(int slot);
 
 /**
+ * @brief Returns image that the given slot belongs to.
+ *
+ * @param slot			A slot number.
+ *
+ * @return 0 based image number.
+ */
+int img_mgmt_slot_to_image(int slot);
+
+/**
+ * @brief Get slot number of alternate (inactive) image pair
+ *
+ * @param slot			A slot number.
+ *
+ * @return Number of other slot in pair
+ */
+static inline int img_mgmt_get_opposite_slot(int slot)
+{
+	__ASSERT(slot >= 0 && slot < (CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER << 1),
+		 "Impossible slot number");
+
+	return (slot ^ 1);
+}
+
+enum img_mgmt_next_boot_type {
+	/** The normal boot to active or non-active slot */
+	NEXT_BOOT_TYPE_NORMAL	=	0,
+	/** The test/non-permanent boot to non-active slot */
+	NEXT_BOOT_TYPE_TEST	=	1,
+	/** Next boot will be revert to already confirmed slot; this
+	 * type of next boot means that active slot is not confirmed
+	 * yet as it has been marked for test in previous boot.
+	 */
+	NEXT_BOOT_TYPE_REVERT	=	2
+};
+
+/**
+ * @brief Get next boot slot number for a given image.
+ *
+ * @param image			An image number.
+ * @param type			Type of next boot
+ *
+ * @return Number of slot, from pair of slots assigned to image, that will
+ * boot on next reset. User needs to compare this slot against active slot
+ * to check whether application image will change for the next boot.
+ * @return -1 in case when next boot slot can not be established.
+ */
+int img_mgmt_get_next_boot_slot(int image, enum img_mgmt_next_boot_type *type);
+
+/**
  * Collects information about the specified image slot.
  *
  * @return Flags of the specified image slot

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/include/mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/include/mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h
@@ -93,7 +93,13 @@ int img_mgmt_swap_type(int slot);
  *
  * @return 0 based image number.
  */
-int img_mgmt_slot_to_image(int slot);
+static inline int img_mgmt_slot_to_image(int slot)
+{
+	__ASSERT(slot >= 0 && slot < (CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER << 1),
+		 "Impossible slot number");
+
+	return (slot >> 1);
+}
 
 /**
  * @brief Get slot number of alternate (inactive) image pair

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -141,16 +141,20 @@ static int img_mgmt_find_tlvs(int slot, size_t *start_off, size_t *end_off, uint
 
 int img_mgmt_active_slot(int image)
 {
-#if CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER == 2
-	if (image == 1) {
-		return 2;
+	int slot = 0;
+
+	/* Multi image does not support DirectXIP currently */
+#if CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER > 1
+	slot = (image << 1);
+#else
+	/* This covers single image, including DirectXiP */
+	if (FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot1_partition)) {
+		slot = 1;
 	}
 #endif
-	/* Image 0 */
-	if (FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot1_partition)) {
-		return 1;
-	}
-	return 0;
+	LOG_DBG("(%d) => %d", image, slot);
+
+	return slot;
 }
 
 int img_mgmt_active_image(void)

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -322,24 +322,6 @@ static void img_mgmt_reset_upload(void)
 	img_mgmt_release_lock();
 }
 
-static int
-img_mgmt_get_other_slot(void)
-{
-	int slot = img_mgmt_active_slot(img_mgmt_active_image());
-
-	switch (slot) {
-	case 1:
-		return 0;
-#if CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER > 2
-	case 2:
-		return 3;
-	case 3:
-		return 2;
-#endif
-	}
-	return 1;
-}
-
 /**
  * Command handler: image erase
  */
@@ -351,7 +333,7 @@ img_mgmt_erase(struct smp_streamer *ctxt)
 	zcbor_state_t *zse = ctxt->writer->zs;
 	zcbor_state_t *zsd = ctxt->reader->zs;
 	bool ok;
-	uint32_t slot = img_mgmt_get_other_slot();
+	uint32_t slot = img_mgmt_get_opposite_slot(img_mgmt_active_slot(img_mgmt_active_image()));
 	size_t decoded = 0;
 
 	struct zcbor_map_decode_key_val image_erase_decode[] = {

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -238,13 +238,15 @@ static int img_mgmt_get_unused_slot_area_id(int slot)
 static int img_mgmt_get_unused_slot_area_id(int image)
 {
 	int area_id = -1;
+	int slot = 0;
 
-	if (image == 0 || image == -1) {
-		if (img_mgmt_slot_in_use(1) == 0) {
-			area_id = img_mgmt_flash_area_id(1);
-		}
-	} else if (image == 1) {
-		area_id = img_mgmt_flash_area_id(3);
+	if (image == -1) {
+		image = 0;
+	}
+	slot = img_mgmt_get_opposite_slot(img_mgmt_active_slot(image));
+
+	if (!img_mgmt_slot_in_use(slot)) {
+		area_id = img_mgmt_flash_area_id(slot);
 	}
 
 	return area_id;

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -32,46 +32,6 @@ BUILD_ASSERT(CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER == 1 ||
 	      FIXED_PARTITION_EXISTS(SLOT3_PARTITION)),
 	     "Missing partitions?");
 
-#if defined(CONFIG_MCUMGR_GRP_IMG_DIRECT_UPLOAD) &&		\
-	!(CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER > 1)
-/* In case when direct upload is enabled, slot2 and slot3 are optional
- * as long as there is support for one application image only.
- */
-#define ADD_SLOT_2_CONDITION FIXED_PARTITION_EXISTS(SLOT2_PARTITION)
-#define ADD_SLOT_3_CONDITION FIXED_PARTITION_EXISTS(SLOT3_PARTITION)
-#elif (CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER > 1)
-/* For more than one application image slot2 and slot3 are required. */
-#define ADD_SLOT_2_CONDITION 1
-#define ADD_SLOT_3_CONDITION 1
-#else
-/* If neither in direct upload mode nor more than one application image
- * is supported, then slot2 and slot3 support is useless.
- */
-#define ADD_SLOT_2_CONDITION 0
-#define ADD_SLOT_3_CONDITION 0
-#endif
-
-int
-img_mgmt_slot_to_image(int slot)
-{
-	switch (slot) {
-	case 0:
-	case 1:
-		return 0;
-#if ADD_SLOT_2_CONDITION
-	case 2:
-		return 1;
-#endif
-#if ADD_SLOT_3_CONDITION
-	case 3:
-		return 1;
-#endif
-	default:
-		assert(0);
-	}
-	return 0;
-}
-
 /**
  * Determines if the specified area of flash is completely unwritten.
  *
@@ -165,13 +125,13 @@ img_mgmt_flash_area_id(int slot)
 		fa_id = FIXED_PARTITION_ID(SLOT1_PARTITION);
 		break;
 
-#if ADD_SLOT_2_CONDITION
+#if FIXED_PARTITION_EXISTS(SLOT2_PARTITION)
 	case 2:
 		fa_id = FIXED_PARTITION_ID(SLOT2_PARTITION);
 		break;
 #endif
 
-#if ADD_SLOT_3_CONDITION
+#if FIXED_PARTITION_EXISTS(SLOT3_PARTITION)
 	case 3:
 		fa_id = FIXED_PARTITION_ID(SLOT3_PARTITION);
 		break;

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -51,7 +51,7 @@ BUILD_ASSERT(CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER == 1 ||
 #define ADD_SLOT_3_CONDITION 0
 #endif
 
-static int
+int
 img_mgmt_slot_to_image(int slot)
 {
 	switch (slot) {


### PR DESCRIPTION
The PR contains series of commits that:
1) Provide img_mgmt_get_next_boot_slot  and img_mgmt_get_opposite_slot functions allowing to  obtain information on next boot slot for given image and type of boot and opposite slot;
2) Switches various function to use the above function for detecting type of next boot;
3) Improves image erase logic;
4) Adds additional Kconfig options to allow better control on setting image flags and erase process;
5) Makes code more image number independent and reduces #ifdefs dedicated to supported number of images.

**Update 2023-08-17 15:00 UTC**
Applied requested changes.
**Update 2023-08-18 17:50 UTC**
Applied set of review comments and fixed problem with `CONFIG_MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_ANY`. There is one additional commit now that reduces `img_mgmt_slot_to_image`.
**Update 2023-08-18 18:20 UTC**
Minor fix in commit message.
**Update 2023-08-24 10:24 UTC**
Review fixes and update from main.
**Update 2023-08-24 12:12 UTC**
Rebase onto main.
**Update 2023-08-24 14:45 UTC**
Added some initialization on output variable to make static analysis happy.