### PR TITLE
scripts: zephyr_module: Tolerate symlinks

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -162,10 +162,10 @@ schema = yaml.safe_load(METADATA_SCHEMA)
 def validate_setting(setting, module_path, filename=None):
     if setting is not None:
         if filename is not None:
-            checkfile = os.path.join(module_path, setting, filename)
+            checkfile = Path(module_path) / setting / filename
         else:
-            checkfile = os.path.join(module_path, setting)
-        if not os.path.isfile(checkfile):
+            checkfile = Path(module_path) / setting
+        if not checkfile.resolve().is_file():
             return False
     return True
 


### PR DESCRIPTION
Currently, this script will blow up when given a symlink for a path (e.g., to a kconfig file).

This is annoying, as when wrapping the build system in a hermetic build system like Bazel, Bazel likes to limit the input file set by creating symlinks.

Resolve the path, if it is a file once resolved, then it's OK.