### PR TITLE
ITE: drivers/i2c/target: Introduce I2C target transfer using PIO mode

### DIFF
--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -1222,11 +1222,9 @@ static int i2c_enhance_target_register(const struct device *dev,
 	/* Software reset */
 	IT8XXX2_I2C_DHTR(base) |= IT8XXX2_I2C_SOFT_RST;
 	IT8XXX2_I2C_DHTR(base) &= ~IT8XXX2_I2C_SOFT_RST;
-	/*
-	 * Set time out register.
-	 * I2C D/E/F clock/data low timeout.
-	 */
-	IT8XXX2_I2C_TOR(base) = I2C_CLK_LOW_TIMEOUT;
+	/* Disable the timeout setting when clock/data are in a low state */
+	IT8XXX2_I2C_TO_ARB_ST(base) &= ~(IT8XXX2_I2C_SCL_TIMEOUT_EN |
+					 IT8XXX2_I2C_SDA_TIMEOUT_EN);
 	/* Bit stretching */
 	IT8XXX2_I2C_TOS(base) |= IT8XXX2_I2C_CLK_STRETCH;
 	/* Peripheral address(8-bit) */

--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -966,10 +966,11 @@ static void target_i2c_isr(const struct device *dev)
 
 	/* Any error */
 	if (target_status & E_TARGET_ANY_ERROR) {
-		/* Hardware reset */
-		IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_HALT;
+		goto end;
+	}
+
 	/* Interrupt pending */
-	} else if (target_status & IT8XXX2_I2C_INT_PEND) {
+	if (target_status & IT8XXX2_I2C_INT_PEND) {
 		uint8_t interrupt_status = IT8XXX2_I2C_IRQ_ST(base);
 
 		/* Byte counter enable */
@@ -1021,14 +1022,13 @@ static void target_i2c_isr(const struct device *dev)
 		if (interrupt_status & IT8XXX2_I2C_P_CLR) {
 			/* Transfer done callback function */
 			target_cb->stop(data->target_cfg);
-			/* Hardware reset */
-			IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_HALT;
 		}
 		/* Write clear the peripheral status */
 		IT8XXX2_I2C_IRQ_ST(base) = interrupt_status;
 	}
-	/* Write clear the target status */
-	IT8XXX2_I2C_STR(base) = target_status;
+end:
+	/* Hardware reset */
+	IT8XXX2_I2C_CTR(base) |= IT8XXX2_I2C_HALT;
 }
 #endif
 

--- a/dts/bindings/i2c/ite,enhance-i2c.yaml
+++ b/dts/bindings/i2c/ite,enhance-i2c.yaml
@@ -24,3 +24,9 @@ properties:
       This option is used when the I2C target is enabled. It is
       necessary to prevent the target port from being configured
       with I2C host related initialization.
+
+  target-pio-mode:
+    type: boolean
+    description: |
+      This option is used when the I2C target is enabled and it can
+      support PIO mode for I2C target transfer.

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1347,6 +1347,9 @@ enum chip_pll_mode {
 /* 0x13: Nack Status */
 #define IT8XXX2_I2C_NST_CNS           BIT(7)
 #define IT8XXX2_I2C_NST_ID_NACK       BIT(3)
+/* 0x18: Timeout and Arbiter Status */
+#define IT8XXX2_I2C_SCL_TIMEOUT_EN    BIT(7)
+#define IT8XXX2_I2C_SDA_TIMEOUT_EN    BIT(6)
 /* 0x19: Error Status */
 #define IT8XXX2_I2C_ERR_ST_DEV1_EIRQ  BIT(0)
 /* 0x1B: Finish Status */

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1321,6 +1321,8 @@ enum chip_pll_mode {
 /* 0x55: Slave A FIFO Control */
 #define IT8XXX2_SMB_HSAPE             BIT(1)
 /* 0x03: Status Register */
+#define IT8XXX2_I2C_BYTE_DONE         BIT(7)
+#define IT8XXX2_I2C_RW                BIT(2)
 #define IT8XXX2_I2C_INT_PEND          BIT(1)
 /* 0x04: Data Hold Time */
 #define IT8XXX2_I2C_SOFT_RST          BIT(7)


### PR DESCRIPTION
This PR includes:
1. Cleanup the initiation and transfer flow of I2C target driver.
2. Introduce I2C target transfer using the PIO mode.

This I2C target transfer using PIO mode is passed the test of test/drivers/i2c/i2c_target_api on it8xxx2_evb board.