### PR TITLE
POSIX arch: Fix literal floating comparison in 32bit targets

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(native_simulator INTERFACE)
 if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/${CMAKE_HOST_SYSTEM_NAME}.${CMAKE_HOST_SYSTEM_PROCESSOR}.cmake)
   # @Intent: Set necessary compiler & linker options for this specific host architecture & OS
   include(${CMAKE_HOST_SYSTEM_NAME}.${CMAKE_HOST_SYSTEM_PROCESSOR}.cmake)
-else()
+else() # Linux.x86_64
   if (CONFIG_64BIT)
     # some gcc versions fail to build without -fPIC
     zephyr_compile_options(-m64 -fPIC)
@@ -44,6 +44,14 @@ else()
 
     target_link_options(native_simulator INTERFACE "-m32")
     target_compile_options(native_simulator INTERFACE "-m32")
+
+    # When building for 32bits x86, gcc defaults to using the old 8087 float arithmetic
+    # which causes some issues with literal float comparisons. So we set it
+    # to use the SSE2 float path instead
+    # (clang defaults to use SSE, but, setting this option for it is safe)
+    check_set_compiler_property(APPEND PROPERTY fpsse2 "SHELL:-msse2 -mfpmath=sse")
+    zephyr_compile_options($<TARGET_PROPERTY:compiler,fpsse2>)
+    target_compile_options(native_simulator INTERFACE "$<TARGET_PROPERTY:compiler,fpsse2>")
   endif ()
 endif()
 


### PR DESCRIPTION
When building the 32bit native board targets variants for x86(-64) hosts, gcc will promote float literals to double (See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92875 )

This can result in unexpected comparison differences.

This is due to the compiler using the 8087 float mode by default.
Instead let's tell the compiler to use the SSE float path, which is the default for 64 bit x86-64 builds.

The assumption that any x86 host used for development will have SSE support should be safe enough.

For more background see
https://github.com/zephyrproject-rtos/zephyr/issues/61345

Fixes #61345