### PR TITLE
Bluetooth: audio: Retry sending notification on error

### DIFF
--- a/subsys/bluetooth/audio/Kconfig
+++ b/subsys/bluetooth/audio/Kconfig
@@ -31,6 +31,15 @@ config BT_AUDIO_TX
 	  This hidden option is enabled when any of the profiles/services
 	  enables support for transmitting of audio data.
 
+config BT_AUDIO_NOTIFY_RETRY_DELAY
+	int "Delay for notification sending retried attempt in 1.25 ms units"
+	range 6 3200
+	default 20
+	help
+	  This option sets the time in 1.25 ms units before the stack will
+	  retry to send notification that failed due to lack of TX buffers
+	  available.
+
 config BT_CCID
 	bool
 	help

--- a/subsys/bluetooth/audio/aics.c
+++ b/subsys/bluetooth/audio/aics.c
@@ -164,6 +164,74 @@ static ssize_t read_input_status(struct bt_conn *conn,
 				 sizeof(inst->srv.status));
 }
 
+static const char *aics_notify_str(enum bt_aics_notify notify)
+{
+	switch (notify) {
+	case AICS_NOTIFY_STATE:
+		return "state";
+	case AICS_NOTIFY_DESCRIPTION:
+		return "description";
+	case AICS_NOTIFY_STATUS:
+		return "status";
+	default:
+		return "unknown";
+	}
+}
+
+static void notify_work_reschedule(struct bt_aics *inst, enum bt_aics_notify notify,
+				   k_timeout_t delay)
+{
+	int err;
+
+	atomic_set_bit(inst->srv.notify, notify);
+
+	err = k_work_reschedule(&inst->srv.notify_work, K_NO_WAIT);
+	if (err < 0) {
+		LOG_ERR("Failed to reschedule %s notification err %d",
+			aics_notify_str(notify), err);
+	}
+}
+
+static void notify(struct bt_aics *inst, enum bt_aics_notify notify, const struct bt_uuid *uuid,
+		   const void *data, uint16_t len)
+{
+	int err;
+
+	err = bt_gatt_notify_uuid(NULL, uuid, inst->srv.service_p->attrs, data, len);
+	if (err == -ENOMEM) {
+		notify_work_reschedule(inst, notify, K_USEC(BT_AUDIO_NOTIFY_RETRY_DELAY_US));
+	} else if (err < 0 && err != -ENOTCONN) {
+		LOG_ERR("Notify %s err %d", aics_notify_str(notify), err);
+	}
+}
+
+static void notify_work_handler(struct k_work *work)
+{
+	struct k_work_delayable *d_work = k_work_delayable_from_work(work);
+	struct bt_aics *inst = CONTAINER_OF(d_work, struct bt_aics, srv.notify_work);
+
+	if (atomic_test_and_clear_bit(inst->srv.notify, AICS_NOTIFY_STATE)) {
+		notify(inst, AICS_NOTIFY_STATE, BT_UUID_AICS_STATE, &inst->srv.state,
+		       sizeof(inst->srv.state));
+	}
+
+	if (atomic_test_and_clear_bit(inst->srv.notify, AICS_NOTIFY_DESCRIPTION)) {
+		notify(inst, AICS_NOTIFY_DESCRIPTION, BT_UUID_AICS_DESCRIPTION,
+		       &inst->srv.description, strlen(inst->srv.description));
+	}
+
+	if (atomic_test_and_clear_bit(inst->srv.notify, AICS_NOTIFY_STATUS)) {
+		notify(inst, AICS_NOTIFY_STATUS, BT_UUID_AICS_INPUT_STATUS, &inst->srv.status,
+		       sizeof(inst->srv.status));
+	}
+}
+
+static void value_changed(struct bt_aics *inst, enum bt_aics_notify notify)
+{
+	notify_work_reschedule(inst, notify, K_NO_WAIT);
+}
+#else
+#define value_changed(...)
 #endif /* CONFIG_BT_AICS */
 
 static ssize_t write_aics_control(struct bt_conn *conn,
@@ -264,9 +332,7 @@ static ssize_t write_aics_control(struct bt_conn *conn,
 			inst->srv.state.gain, inst->srv.state.mute, inst->srv.state.gain_mode,
 			inst->srv.state.change_counter);
 
-		bt_gatt_notify_uuid(NULL, BT_UUID_AICS_STATE,
-				    inst->srv.service_p->attrs, &inst->srv.state,
-				    sizeof(inst->srv.state));
+		value_changed(inst, AICS_NOTIFY_STATE);
 
 		if (inst->srv.cb && inst->srv.cb->state) {
 			inst->srv.cb->state(inst, 0, inst->srv.state.gain,
@@ -306,9 +372,7 @@ static ssize_t write_description(struct bt_conn *conn,
 		memcpy(inst->srv.description, buf, len);
 		inst->srv.description[len] = '\0';
 
-		bt_gatt_notify_uuid(NULL, BT_UUID_AICS_DESCRIPTION,
-				    inst->srv.service_p->attrs, &inst->srv.description,
-				    strlen(inst->srv.description));
+		value_changed(inst, AICS_NOTIFY_DESCRIPTION);
 
 		if (inst->srv.cb && inst->srv.cb->description) {
 			inst->srv.cb->description(inst, 0,
@@ -444,6 +508,9 @@ int bt_aics_register(struct bt_aics *aics, struct bt_aics_register_param *param)
 	aics->srv.status = param->status ? BT_AICS_STATUS_ACTIVE : BT_AICS_STATUS_INACTIVE;
 	aics->srv.cb = param->cb;
 
+	atomic_clear(aics->srv.notify);
+	k_work_init_delayable(&aics->srv.notify_work, notify_work_handler);
+
 	if (param->description) {
 		strncpy(aics->srv.description, param->description,
 			sizeof(aics->srv.description) - 1);
@@ -517,10 +584,7 @@ int bt_aics_deactivate(struct bt_aics *inst)
 		inst->srv.status = BT_AICS_STATUS_INACTIVE;
 		LOG_DBG("Instance %p: Status was set to inactive", inst);
 
-		bt_gatt_notify_uuid(NULL, BT_UUID_AICS_INPUT_STATUS,
-				    inst->srv.service_p->attrs,
-				    &inst->srv.status,
-				    sizeof(inst->srv.status));
+		value_changed(inst, AICS_NOTIFY_STATUS);
 
 		if (inst->srv.cb && inst->srv.cb->status) {
 			inst->srv.cb->status(inst, 0, inst->srv.status);
@@ -547,10 +611,7 @@ int bt_aics_activate(struct bt_aics *inst)
 		inst->srv.status = BT_AICS_STATUS_ACTIVE;
 		LOG_DBG("Instance %p: Status was set to active", inst);
 
-		bt_gatt_notify_uuid(NULL, BT_UUID_AICS_INPUT_STATUS,
-				    inst->srv.service_p->attrs,
-				    &inst->srv.status,
-				    sizeof(inst->srv.status));
+		value_changed(inst, AICS_NOTIFY_STATUS);
 
 		if (inst->srv.cb && inst->srv.cb->status) {
 			inst->srv.cb->status(inst, 0, inst->srv.status);
@@ -572,8 +633,7 @@ int bt_aics_gain_set_manual_only(struct bt_aics *inst)
 
 	inst->srv.state.gain_mode = BT_AICS_MODE_MANUAL_ONLY;
 
-	bt_gatt_notify_uuid(NULL, BT_UUID_AICS_STATE, inst->srv.service_p->attrs,
-			    &inst->srv.state, sizeof(inst->srv.state));
+	value_changed(inst, AICS_NOTIFY_STATE);
 
 	return 0;
 }
@@ -587,8 +647,7 @@ int bt_aics_gain_set_auto_only(struct bt_aics *inst)
 
 	inst->srv.state.gain_mode = BT_AICS_MODE_AUTO_ONLY;
 
-	bt_gatt_notify_uuid(NULL, BT_UUID_AICS_STATE, inst->srv.service_p->attrs,
-			    &inst->srv.state, sizeof(inst->srv.state));
+	value_changed(inst, AICS_NOTIFY_STATE);
 
 	return 0;
 }
@@ -691,8 +750,7 @@ int bt_aics_disable_mute(struct bt_aics *inst)
 
 	inst->srv.state.mute = BT_AICS_STATE_MUTE_DISABLED;
 
-	bt_gatt_notify_uuid(NULL, BT_UUID_AICS_STATE, inst->srv.service_p->attrs,
-			    &inst->srv.state, sizeof(inst->srv.state));
+	value_changed(inst, AICS_NOTIFY_STATE);
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/aics_internal.h
+++ b/subsys/bluetooth/audio/aics_internal.h
@@ -88,6 +88,13 @@ struct bt_aics_gain_settings {
 	int8_t maximum;
 } __packed;
 
+enum bt_aics_notify {
+	AICS_NOTIFY_STATE,
+	AICS_NOTIFY_DESCRIPTION,
+	AICS_NOTIFY_STATUS,
+	AICS_NOTIFY_NUM,
+};
+
 struct bt_aics_server {
 	struct bt_aics_state state;
 	struct bt_aics_gain_settings gain_settings;
@@ -99,6 +106,9 @@ struct bt_aics_server {
 	struct bt_aics_cb *cb;
 
 	struct bt_gatt_service *service_p;
+
+	ATOMIC_DEFINE(notify, AICS_NOTIFY_NUM);
+	struct k_work_delayable notify_work;
 };
 
 /* Struct used as a common type for the api */

--- a/subsys/bluetooth/audio/audio_internal.h
+++ b/subsys/bluetooth/audio/audio_internal.h
@@ -9,6 +9,8 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/audio/audio.h>
 
+#define BT_AUDIO_NOTIFY_RETRY_DELAY_US ((CONFIG_BT_AUDIO_NOTIFY_RETRY_DELAY) * 1250U)
+
 /** @brief LE Audio Attribute User Data. */
 struct bt_audio_attr_user_data {
 	/** Attribute read callback */

--- a/subsys/bluetooth/audio/vocs_internal.h
+++ b/subsys/bluetooth/audio/vocs_internal.h
@@ -62,6 +62,13 @@ struct bt_vocs_client {
 	struct bt_conn *conn;
 };
 
+enum bt_vocs_notify {
+	NOTIFY_STATE,
+	NOTIFY_LOCATION,
+	NOTIFY_OUTPUT_DESC,
+	NOTIFY_NUM,
+};
+
 struct bt_vocs_server {
 	struct bt_vocs vocs;
 	struct bt_vocs_state state;
@@ -71,6 +78,9 @@ struct bt_vocs_server {
 	struct bt_vocs_cb *cb;
 
 	struct bt_gatt_service *service_p;
+
+	ATOMIC_DEFINE(notify, NOTIFY_NUM);
+	struct k_work_delayable notify_work;
 };
 
 int bt_vocs_client_state_get(struct bt_vocs_client *inst);


### PR DESCRIPTION
Retry sending notification was not sent due to e.g. lack of buffers currently available.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/57452
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/57456
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/57455