### PR TITLE
mgmt/MCUmgr/grp: Add missing const in mgmt_handler definitions

### DIFF
--- a/subsys/mgmt/mcumgr/grp/shell_mgmt/src/shell_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/shell_mgmt/src/shell_mgmt.c
@@ -154,7 +154,7 @@ static int shell_mgmt_translate_error_code(uint16_t ret)
 }
 #endif
 
-static struct mgmt_handler shell_mgmt_handlers[] = {
+static const struct mgmt_handler shell_mgmt_handlers[] = {
 	[SHELL_MGMT_ID_EXEC] = { NULL, shell_mgmt_exec },
 };
 

--- a/subsys/mgmt/mcumgr/grp/stat_mgmt/src/stat_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/stat_mgmt/src/stat_mgmt.c
@@ -23,7 +23,7 @@
 
 LOG_MODULE_REGISTER(mcumgr_stat_grp, CONFIG_MCUMGR_GRP_STAT_LOG_LEVEL);
 
-static struct mgmt_handler stat_mgmt_handlers[];
+static const struct mgmt_handler stat_mgmt_handlers[];
 
 typedef int stat_mgmt_foreach_entry_fn(zcbor_state_t *zse, struct stat_mgmt_entry *entry);
 
@@ -257,7 +257,7 @@ static int stat_mgmt_translate_error_code(uint16_t ret)
 }
 #endif
 
-static struct mgmt_handler stat_mgmt_handlers[] = {
+static const struct mgmt_handler stat_mgmt_handlers[] = {
 	[STAT_MGMT_ID_SHOW] = { stat_mgmt_show, NULL },
 	[STAT_MGMT_ID_LIST] = { stat_mgmt_list, NULL },
 };


### PR DESCRIPTION
Make mgmt_handler definitions static const for shell and stat groups.

**Update 2023-08-11 UTC 13:55**
Rebased to remove conflicts.
**Update 2023-08-18 18:20 UTC**
Rebase from main.