### PR TITLE
Bluetooth: vocs: Retry sending notification on error

### DIFF
--- a/subsys/bluetooth/audio/vocs_internal.h
+++ b/subsys/bluetooth/audio/vocs_internal.h
@@ -65,6 +65,13 @@ struct bt_vocs_server {
 	struct bt_vocs_cb *cb;
 
 	struct bt_gatt_service *service_p;
+
+	struct k_work_delayable state_notify_work;
+	uint8_t state_notify_retry_count;
+	struct k_work_delayable location_notify_work;
+	uint8_t location_notify_retry_count;
+	struct k_work_delayable output_desc_notify_work;
+	uint8_t output_desc_notify_retry_count;
 };
 
 struct bt_vocs {


### PR DESCRIPTION
Retry sending notification was not sent due to e.g. lack of buffers currently available.

Fixes: #57456