### PR TITLE
Bluetooth: controller: disregard length field on pdu error in unframed ISO rx

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/isoal.c
+++ b/subsys/bluetooth/controller/ll_sw/isoal.c
@@ -731,7 +731,7 @@ static isoal_status_t isoal_rx_unframed_consume(struct isoal_sink *sink,
 	/* If status is not ISOAL_PDU_STATUS_VALID, length and LLID cannot be trusted */
 	llid = pdu_meta->pdu->ll_id;
 	pdu_err = (pdu_meta->meta->status != ISOAL_PDU_STATUS_VALID);
-	length = pdu_meta->pdu->len;
+	length = pdu_err ? 0U : pdu_meta->pdu->len;
 	/* A zero length PDU with LLID 0b01 (PDU_BIS_LLID_START_CONTINUE) would be a padding PDU.
 	 * However if there are errors in the PDU, it could be an incorrectly receive non-padding
 	 * PDU. Therefore only consider a PDU with errors as padding if received after the end


### PR DESCRIPTION
In case of unframed iso rx with PDU error, length field cannot be trusted and is considered zero