### PR TITLE
drivers: sensor: stm32 Vref sensor calibration on 12bit

### DIFF
--- a/drivers/sensor/stm32_vref/stm32_vref.c
+++ b/drivers/sensor/stm32_vref/stm32_vref.c
@@ -86,7 +86,16 @@ static int stm32_vref_channel_get(const struct device *dev, enum sensor_channel 
 #endif /* CONFIG_SOC_SERIES_STM32H5X */
 
 	/* Calculate VREF+ using VREFINT bandgap voltage and calibration data */
+#if defined(CONFIG_SOC_SERIES_STM32U5X)
+	/*
+	 * The VREF CALIBRATION value is acquired on 14 bits
+	 * and the data acquired is on 12 bits
+	 * since the adc_sequence.resolution is 12
+	 */
+	vref = (cfg->cal_mv * (*cfg->cal_addr) >> 2) / data->raw;
+#else
 	vref = cfg->cal_mv * (*cfg->cal_addr) / data->raw;
+#endif /* CONFIG_SOC_SERIES_STM32H5X */
 	/* millivolt to volt */
 	vref /= 1000;
 


### PR DESCRIPTION
The Calibration value of the VRef on stm32U5 is acquired on 14Bit by ADC1 and should be adjusted on 12bit becasue the resolution is 12bit in this stm32_vref driver.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/61368

Not evaluated against other stm32 series.