### PR TITLE
intel_adsp: hda: fix usage of FIFORDY bit

### DIFF
--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -249,6 +249,7 @@ int intel_adsp_hda_dma_start(const struct device *dev, uint32_t channel)
 {
 	const struct intel_adsp_hda_dma_cfg *const cfg = dev->config;
 	uint32_t size;
+	bool set_fifordy;
 
 	__ASSERT(channel < cfg->dma_channels, "Channel does not exist");
 
@@ -275,7 +276,9 @@ int intel_adsp_hda_dma_start(const struct device *dev, uint32_t channel)
 		return 0;
 	}
 
-	intel_adsp_hda_enable(cfg->base, cfg->regblock_size, channel);
+	set_fifordy = (cfg->direction == HOST_TO_MEMORY || cfg->direction == MEMORY_TO_HOST);
+	intel_adsp_hda_enable(cfg->base, cfg->regblock_size, channel, set_fifordy);
+
 	if (cfg->direction == MEMORY_TO_PERIPHERAL) {
 		size = intel_adsp_hda_get_buffer_size(cfg->base, cfg->regblock_size, channel);
 		intel_adsp_hda_link_commit(cfg->base, cfg->regblock_size, channel, size);

--- a/soc/xtensa/intel_adsp/common/include/intel_adsp_hda.h
+++ b/soc/xtensa/intel_adsp/common/include/intel_adsp_hda.h
@@ -207,9 +207,14 @@ static inline uint32_t intel_adsp_hda_get_buffer_size(uint32_t base,
  * @param regblock_size Register block size
  * @param sid Stream ID
  */
-static inline void intel_adsp_hda_enable(uint32_t base, uint32_t regblock_size, uint32_t sid)
+static inline void intel_adsp_hda_enable(uint32_t base, uint32_t regblock_size,
+					 uint32_t sid, bool set_fifordy)
 {
-	*DGCS(base, regblock_size, sid) |= DGCS_GEN | DGCS_FIFORDY;
+	*DGCS(base, regblock_size, sid) |= DGCS_GEN;
+
+	if (set_fifordy) {
+		*DGCS(base, regblock_size, sid) |= DGCS_FIFORDY;
+	}
 }
 
 /**
@@ -224,7 +229,6 @@ static inline void intel_adsp_hda_disable(uint32_t base, uint32_t regblock_size,
 	*DGCS(base, regblock_size, sid) &= ~(DGCS_GEN | DGCS_FIFORDY);
 }
 
-
 /**
  * @brief Check if stream is enabled
  *
@@ -236,7 +240,6 @@ static inline bool intel_adsp_hda_is_enabled(uint32_t base, uint32_t regblock_si
 {
 	return *DGCS(base, regblock_size, sid) & (DGCS_GEN | DGCS_FIFORDY);
 }
-
 
 /**
  * @brief Determine the number of unused bytes in the buffer

--- a/tests/boards/intel_adsp/hda/src/smoke.c
+++ b/tests/boards/intel_adsp/hda/src/smoke.c
@@ -81,7 +81,7 @@ ZTEST(intel_adsp_hda, test_hda_host_in_smoke)
 	hda_dump_regs(HOST_IN, HDA_REGBLOCK_SIZE, STREAM_ID, "dsp set_buffer");
 	zassert_ok(res, "Expected set buffer to succeed");
 
-	intel_adsp_hda_enable(HDA_HOST_IN_BASE, HDA_REGBLOCK_SIZE, STREAM_ID);
+	intel_adsp_hda_enable(HDA_HOST_IN_BASE, HDA_REGBLOCK_SIZE, STREAM_ID, true);
 	hda_dump_regs(HOST_IN, HDA_REGBLOCK_SIZE, STREAM_ID, "dsp enable");
 
 	hda_ipc_msg(INTEL_ADSP_IPC_HOST_DEV, IPCCMD_HDA_START, STREAM_ID, IPC_TIMEOUT);
@@ -148,7 +148,7 @@ ZTEST(intel_adsp_hda, test_hda_host_out_smoke)
 	hda_ipc_msg(INTEL_ADSP_IPC_HOST_DEV, IPCCMD_HDA_START, (STREAM_ID + 7), IPC_TIMEOUT);
 	hda_dump_regs(HOST_OUT, HDA_REGBLOCK_SIZE, STREAM_ID, "host start");
 
-	intel_adsp_hda_enable(HDA_HOST_OUT_BASE, HDA_REGBLOCK_SIZE, STREAM_ID);
+	intel_adsp_hda_enable(HDA_HOST_OUT_BASE, HDA_REGBLOCK_SIZE, STREAM_ID, true);
 	hda_dump_regs(HOST_OUT, HDA_REGBLOCK_SIZE, STREAM_ID, "dsp enable");
 
 	for (uint32_t i = 0; i < TRANSFER_COUNT; i++) {


### PR DESCRIPTION
Touching FIFORDY bit when enabling HDA Link DMA leads to DMA start issue.
I found this problem in capture scenarios with windows driver.

According to HW specs FIFORDY bit is only available for HDA Host DMA. 
In case of Link DMA this bit is RO.