### PR TITLE
CODEOWNERS, MAINTAINERS: Add entries for Connection Manager

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -683,6 +683,7 @@
 /include/zephyr/net/                             @rlubos @tbursztyka
 /include/zephyr/net/buf.h                        @jhedberg @tbursztyka @rlubos
 /include/zephyr/net/coap*.h                      @rlubos
+/include/zephyr/net/conn_mgr*.h			 @rlubos @glarsennordic
 /include/zephyr/net/lwm2m*.h                     @rlubos
 /include/zephyr/net/mqtt.h                       @rlubos
 /include/zephyr/net/mqtt_sn.h                    @rlubos @BeckmaR
@@ -844,6 +845,7 @@ scripts/build/gen_image_info.py           @tejlmand
 /subsys/mgmt/osdp/                        @sidcha
 /subsys/modbus/                           @jfischer-no
 /subsys/net/buf.c                         @jhedberg @tbursztyka @rlubos
+/subsys/net/conn_mgr/			  @rlubos @glarsennordic
 /subsys/net/ip/                           @rlubos @tbursztyka
 /subsys/net/lib/                          @rlubos @tbursztyka
 /subsys/net/lib/dns/                      @rlubos @tbursztyka @cfriedt
@@ -900,6 +902,8 @@ scripts/build/gen_image_info.py           @tejlmand
 /tests/lib/cmsis_dsp/                     @stephanosio
 /tests/net/                               @rlubos @tbursztyka
 /tests/net/buf/                           @jhedberg @tbursztyka
+/tests/net/conn_mgr/			  @rlubos @glarsennordic
+/tests/net/conn_mgr_conn/		  @rlubos @glarsennordic
 /tests/net/lib/                           @rlubos @tbursztyka
 /tests/net/lib/http_header_fields/        @rlubos @tbursztyka
 /tests/net/lib/mqtt_packet/               @rlubos

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1876,6 +1876,20 @@ Networking:
   labels:
     - "area: Networking"
 
+"Networking: Connection Manager":
+  status: maintained
+  maintainers:
+    - rlubos
+  collaborators:
+    - glarsennordic
+  files:
+    - include/zephyr/net/conn_mgr*.h
+    - subsys/net/conn_mgr/
+    - tests/net/conn_mgr/
+    - tests/net/conn_mgr_conn/
+  labels:
+    - "area: Networking"
+
 "Networking: CoAP":
   status: maintained
   maintainers:


### PR DESCRIPTION
Adding myself as a codeowner and collaborator since I am at this point the author of the bulk of conn_mgr, and actively maintaining it

Adding @rlubos as primary maintainer since he is also heavily involved in the design and maintenance of conn_mgr. Plus this was already his role by default as the maintainer of subsys/net/