### PR TITLE
Samples: Fix XEC clock control sample code for MEC172x using new GPIOs.

### DIFF
--- a/samples/drivers/clock_control_xec/src/main.c
+++ b/samples/drivers/clock_control_xec/src/main.c
@@ -5,9 +5,11 @@
  */
 #include <errno.h>
 #include <zephyr/device.h>
+#include <soc.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
 #include <zephyr/dt-bindings/clock/mchp_xec_pcr.h>
+#include <zephyr/dt-bindings/pinctrl/mchp-xec-pinctrl.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/printk.h>
@@ -179,8 +181,8 @@ static void vbat_power_fail(void)
 }
 #endif
 
-static const struct gpio_ctrl_regs * const gpc =
-	(struct gpio_ctrl_regs *)(DT_REG_ADDR(DT_NODELABEL(gpio_000_036)));
+static const struct gpio_regs * const gpio =
+	(struct gpio_regs *)(DT_REG_ADDR(DT_NODELABEL(gpio_000_036)));
 static const struct device *clkdev = DEVICE_DT_GET(DT_NODELABEL(pcr));
 
 struct sys_clk {
@@ -214,8 +216,8 @@ int main(void)
 	vbat_power_fail();
 
 	LOG_INF("32KHZ_IN is function 1 of GPIO 0165");
-	r = gpc->CTRL_0165;
-	LOG_INF("XEC GPIO 0165 Control = 0x%x", gpc->CTRL_0165);
+	r = gpio->CTRL[MCHP_XEC_PINCTRL_REG_IDX(0165)];
+	LOG_INF("XEC GPIO 0165 Control = 0x%x", r);
 	r = (r & MCHP_GPIO_CTRL_MUX_MASK) >> MCHP_GPIO_CTRL_MUX_POS;
 	LOG_INF("Pin function = %u", r);
 	vbat_clock_regs();

--- a/soc/arm/microchip_mec/common/reg/mec_gpio.h
+++ b/soc/arm/microchip_mec/common/reg/mec_gpio.h
@@ -10,6 +10,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#define MCHP_XEC_PINCTRL_REG_IDX(pin) ((pin >> 5) * 32 + (pin & 0x1f))
+
 /** @brief All GPIO register as arrays of registers */
 struct gpio_regs {
 	volatile uint32_t  CTRL[174];


### PR DESCRIPTION
This commit goes along with pull request #61396 to update the sample code to use simplified GPIO SOC definitions