### PR TITLE
posix: signal: type corrections for sigval, sigevent, notify attr

### DIFF
--- a/drivers/fpga/fpga_ice40.c
+++ b/drivers/fpga/fpga_ice40.c
@@ -18,7 +18,6 @@
 #include <zephyr/drivers/spi.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/posix/time.h>
 #include <zephyr/sys/crc.h>
 
 /*

--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -35,7 +35,6 @@ typedef uint32_t clockid_t;
 typedef unsigned long timer_t;
 #endif
 
-#ifdef CONFIG_PTHREAD_IPC
 /* Thread attributes */
 struct pthread_attr {
 	int priority;
@@ -100,8 +99,6 @@ typedef struct pthread_rwlock_obj {
 	int32_t status;
 	k_tid_t wr_owner;
 } pthread_rwlock_t;
-
-#endif /* CONFIG_PTHREAD_IPC */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -77,20 +77,18 @@ int sigismember(const sigset_t *set, int signo);
 
 typedef int	sig_atomic_t;		/* Atomic entity type (ANSI) */
 
-typedef union sigval {
+union sigval {
 	int sival_int;
 	void *sival_ptr;
-} sigval;
+};
 
-typedef struct sigevent {
+struct sigevent {
 	int sigev_notify;
 	int sigev_signo;
-	sigval sigev_value;
-	void (*sigev_notify_function)(sigval val);
-	#ifdef CONFIG_PTHREAD_IPC
+	union sigval sigev_value;
+	void (*sigev_notify_function)(union sigval val);
 	pthread_attr_t *sigev_notify_attributes;
-	#endif
-} sigevent;
+};
 
 #ifdef __cplusplus
 }

--- a/lib/posix/timer.c
+++ b/lib/posix/timer.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <string.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/posix/signal.h>
 #include <zephyr/posix/time.h>
 
 #define ACTIVE 1
@@ -16,8 +17,8 @@ static void zephyr_timer_wrapper(struct k_timer *ztimer);
 
 struct timer_obj {
 	struct k_timer ztimer;
-	void (*sigev_notify_function)(sigval val);
-	sigval val;
+	void (*sigev_notify_function)(union sigval val);
+	union sigval val;
 	struct timespec interval;	/* Reload value */
 	uint32_t reload;			/* Reload value in ms */
 	uint32_t status;

--- a/subsys/shell/modules/date_service.c
+++ b/subsys/shell/modules/date_service.c
@@ -8,8 +8,14 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/init.h>
 #include <string.h>
-#include <zephyr/posix/time.h>
+
 #include <zephyr/sys/timeutil.h>
+
+#if defined(CONFIG_ARCH_POSIX) && defined(CONFIG_EXTERNAL_LIBC)
+#include <time.h>
+#else
+#include <zephyr/posix/time.h>
+#endif
 
 #define HELP_NONE      "[none]"
 #define HELP_DATE_SET  "[Y-m-d] <H:M:S>"


### PR DESCRIPTION
* `struct sigevent` is not type-defined
* `union sigval` is not type-defined
* `struct sigevent` must include `sigev_notify_attributes`

For more information, see https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html

Fixes #60957