### PR TITLE
dts: arm: npcx: Add dts files for NPCX4 series

### DIFF
--- a/dts/arm/nuvoton/npcx/npcx-lvol-ctrl-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx-lvol-ctrl-map.dtsi
@@ -130,7 +130,7 @@
 		 * low voltage detection.)
 		 */
 		lvol_none: lvol-pseudo {
-			lvols = <&scfg 6 0>;
+			lvols = <&scfg 31 0>;
 		};
 	};
 };

--- a/dts/arm/nuvoton/npcx/npcx-miwus-wui-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx-miwus-wui-map.dtsi
@@ -23,9 +23,6 @@
 		wui_io83: wui0-1-3 {
 			miwus = <&miwu0 0 3>; /* GPIO83 */
 		};
-		wui_cr_sin2: wui0-1-6-2 {
-			miwus = <&miwu0 0 6>; /* CR_SIN2 */
-		};
 		wui_io87: wui0-1-7 {
 			miwus = <&miwu0 0 7>; /* GPIO87 */
 		};

--- a/dts/arm/nuvoton/npcx/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx.dtsi
@@ -517,7 +517,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40020000 0x2000>;
-			clocks = <&pcc NPCX_CLOCK_BUS_FIU NPCX_PWDWN_CTL1 2>;
 		};
 
 		peci0: peci@400d4000 {

--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -1,19 +1,19 @@
 /*
- * Copyright (c) 2021 Nuvoton Technology Corporation.
+ * Copyright (c) 2023 Nuvoton Technology Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* NPCX9 series pinmux mapping table */
-#include "npcx9/npcx9-alts-map.dtsi"
-/* NPCX9 series mapping table between MIWU wui bits and source device */
-#include "npcx9/npcx9-miwus-wui-map.dtsi"
-/* NPCX9 series mapping table between MIWU groups and interrupts */
-#include "npcx9/npcx9-miwus-int-map.dtsi"
-/* NPCX9 series eSPI VW mapping table */
-#include "npcx9/npcx9-espi-vws-map.dtsi"
-/* NPCX9 series low-voltage io controls mapping table */
-#include "npcx9/npcx9-lvol-ctrl-map.dtsi"
+/* npcx4 series pinmux mapping table */
+#include "npcx4/npcx4-alts-map.dtsi"
+/* npcx4 series mapping table between MIWU wui bits and source device */
+#include "npcx4/npcx4-miwus-wui-map.dtsi"
+/* npcx4 series mapping table between MIWU groups and interrupts */
+#include "npcx4/npcx4-miwus-int-map.dtsi"
+/* npcx4 series eSPI VW mapping table */
+#include "npcx4/npcx4-espi-vws-map.dtsi"
+/* npcx4 series low-voltage io controls mapping table */
+#include "npcx4/npcx4-lvol-ctrl-map.dtsi"
 
 /* Device tree declarations of npcx soc family */
 #include "npcx.dtsi"
@@ -21,44 +21,45 @@
 / {
 	def-io-conf-list {
 		pinmux = <&alt0_gpio_no_spip
-			   &alt0_gpio_no_fpip
-			   &alt1_no_pwrgd
-			   &alta_no_peci_en
-			   &altd_npsl_in1_sl
-			   &altd_npsl_in2_sl
-			   &altd_psl_in3_sl
-			   &altd_psl_in4_sl
-			   &alt7_no_ksi0_sl
-			   &alt7_no_ksi1_sl
-			   &alt7_no_ksi2_sl
-			   &alt7_no_ksi3_sl
-			   &alt7_no_ksi4_sl
-			   &alt7_no_ksi5_sl
-			   &alt7_no_ksi6_sl
-			   &alt7_no_ksi7_sl
-			   &alt8_no_kso00_sl
-			   &alt8_no_kso01_sl
-			   &alt8_no_kso02_sl
-			   &alt8_no_kso03_sl
-			   &alt8_no_kso04_sl
-			   &alt8_no_kso05_sl
-			   &alt8_no_kso06_sl
-			   &alt8_no_kso07_sl
-			   &alt9_no_kso08_sl
-			   &alt9_no_kso09_sl
-			   &alt9_no_kso10_sl
-			   &alt9_no_kso11_sl
-			   &alt9_no_kso12_sl
-			   &alt9_no_kso13_sl
-			   &alt9_no_kso14_sl
-			   &alt9_no_kso15_sl
-			   &alta_no_kso16_sl
-			   &alta_no_kso17_sl
-			   &altg_psl_gpo_sl>;
+			  &alt0_gpio_no_fpip
+			  &alt1_no_pwrgd
+			  &alt7_no_ksi0_sl
+			  &alt7_no_ksi1_sl
+			  &alt7_no_ksi2_sl
+			  &alt7_no_ksi3_sl
+			  &alt7_no_ksi4_sl
+			  &alt7_no_ksi5_sl
+			  &alt7_no_ksi6_sl
+			  &alt7_no_ksi7_sl
+			  &alt8_no_kso00_sl
+			  &alt8_no_kso01_sl
+			  &alt8_no_kso02_sl
+			  &alt8_no_kso03_sl
+			  &alt8_no_kso04_sl
+			  &alt8_no_kso05_sl
+			  &alt8_no_kso06_sl
+			  &alt8_no_kso07_sl
+			  &alt9_no_kso08_sl
+			  &alt9_no_kso09_sl
+			  &alt9_no_kso10_sl
+			  &alt9_no_kso11_sl
+			  &alt9_no_kso12_sl
+			  &alt9_no_kso13_sl
+			  &alt9_no_kso14_sl
+			  &alt9_no_kso15_sl
+			  &alta_no_kso16_sl
+			  &alta_no_kso17_sl
+			  &alta_no_peci_en
+			  &altc_gpio97_sl_inv
+			  &altd_npsl_in1_sl
+			  &altd_npsl_in2_sl
+			  &altd_psl_in3_sl
+			  &altd_psl_in4_sl
+			  &altg_psl_gpo_sl>;
 	};
 
 	soc {
-		/* Specific soc devices in npcx9 series */
+		/* Specific soc devices in npcx4 series */
 		itims: timer@400b0000 {
 			compatible = "nuvoton,npcx-itim-timer";
 			reg = <0x400b0000 0x2000
@@ -105,39 +106,39 @@
 			status = "disabled";
 		};
 
-		/* Default clock and power settings in npcx9 series */
+		/* Default clock and power settings in npcx4 series */
 		pcc: clock-controller@4000d000 {
-			clock-frequency = <DT_FREQ_M(90)>; /* OFMCLK runs at 90MHz */
-			core-prescaler = <6>; /* CORE_CLK runs at 15MHz */
-			apb1-prescaler = <6>; /* APB1_CLK runs at 15MHz */
-			apb2-prescaler = <6>; /* APB2_CLK runs at 15MHz */
-			apb3-prescaler = <6>; /* APB3_CLK runs at 15MHz */
-			apb4-prescaler = <6>; /* APB4_CLK runs at 15MHz */
-			ram-pd-depth = <15>; /* Valid bit-depth of RAM_PDn reg */
+			clock-frequency = <DT_FREQ_M(120)>; /* OFMCLK runs at 120MHz */
+			core-prescaler = <8>; /* CORE_CLK runs at 15MHz */
+			apb1-prescaler = <8>; /* APB1_CLK runs at 15MHz */
+			apb2-prescaler = <8>; /* APB2_CLK runs at 15MHz */
+			apb3-prescaler = <8>; /* APB3_CLK runs at 15MHz */
+			apb4-prescaler = <8>; /* APB4_CLK runs at 15MHz */
+			ram-pd-depth = <8>; /* Valid bit-depth of RAM_PDn reg */
 		};
 
-		/* Wake-up input source mapping for GPIOs in npcx9 series */
+		/* Wake-up input source mapping for GPIOs in npcx4 series */
 		gpio0: gpio@40081000 {
 			wui-maps = <&wui_io00 &wui_io01 &wui_io02 &wui_io03
 				    &wui_io04 &wui_io05 &wui_io06 &wui_io07>;
 
-			lvol-maps = <&lvol_io00 &lvol_none &lvol_none &lvol_none
-				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+			lvol-maps = <&lvol_io00 &lvol_io01 &lvol_io02 &lvol_io03
+				     &lvol_io04 &lvol_io05 &lvol_io06 &lvol_io07>;
 		};
 
 		gpio1: gpio@40083000 {
-			wui-maps = <&wui_io10 &wui_io11 &wui_none &wui_none
+			wui-maps = <&wui_io10 &wui_io11 &wui_io12 &wui_io13
 				    &wui_io14 &wui_io15 &wui_io16 &wui_io17>;
 
-			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
-				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+			lvol-maps = <&lvol_io10 &lvol_io11 &lvol_none &lvol_io13
+				     &lvol_io14 &lvol_io15 &lvol_io16 &lvol_io17>;
 		};
 
 		gpio2: gpio@40085000 {
 			wui-maps = <&wui_io20 &wui_io21 &wui_io22 &wui_io23
 				    &wui_io24 &wui_io25 &wui_io26 &wui_io27>;
 
-			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
+			lvol-maps = <&lvol_io20 &lvol_io21 &lvol_io22 &lvol_io23
 				     &lvol_none &lvol_none &lvol_none &lvol_none>;
 		};
 
@@ -153,8 +154,8 @@
 			wui-maps = <&wui_io40 &wui_io41 &wui_io42 &wui_io43
 				    &wui_io44 &wui_io45 &wui_io46 &wui_io47>;
 
-			lvol-maps = <&lvol_io40 &lvol_none &lvol_none &lvol_none
-				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+			lvol-maps = <&lvol_io40 &lvol_io41 &lvol_io42 &lvol_io43
+				     &lvol_io44 &lvol_io45 &lvol_none &lvol_none>;
 		};
 
 		gpio5: gpio@4008b000 {
@@ -169,23 +170,23 @@
 			wui-maps = <&wui_io60 &wui_io61 &wui_io62 &wui_io63
 				    &wui_io64 &wui_none &wui_io66 &wui_io67>;
 
-			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
-				     &lvol_io64 &lvol_none &lvol_io66 &lvol_none>;
+			lvol-maps = <&lvol_io60 &lvol_io61 &lvol_io62 &lvol_io63
+				     &lvol_io64 &lvol_none &lvol_io66 &lvol_io67>;
 		};
 
 		gpio7: gpio@4008f000 {
 			wui-maps = <&wui_io70 &wui_none &wui_io72 &wui_io73
 				    &wui_io74 &wui_io75 &wui_io76 &wui_none>;
 
-			lvol-maps = <&lvol_none &lvol_none &lvol_io72 &lvol_io73
-				     &lvol_io74 &lvol_io75 &lvol_none &lvol_none>;
+			lvol-maps = <&lvol_io70 &lvol_none &lvol_io72 &lvol_io73
+				     &lvol_io74 &lvol_io75 &lvol_io76 &lvol_none>;
 		};
 
 		gpio8: gpio@40091000 {
 			wui-maps = <&wui_io80 &wui_io81 &wui_io82 &wui_io83
 				    &wui_none &wui_none &wui_none &wui_io87>;
 
-			lvol-maps = <&lvol_io80 &lvol_none &lvol_io82 &lvol_none
+			lvol-maps = <&lvol_io80 &lvol_none &lvol_io82 &lvol_io83
 				     &lvol_none &lvol_none &lvol_none &lvol_io87>;
 		};
 
@@ -209,52 +210,61 @@
 			wui-maps = <&wui_iob0 &wui_iob1 &wui_iob2 &wui_iob3
 				    &wui_iob4 &wui_iob5 &wui_iob6 &wui_iob7>;
 
-			lvol-maps = <&lvol_none &lvol_none &lvol_iob2 &lvol_iob3
-				     &lvol_iob4 &lvol_iob5 &lvol_none &lvol_none>;
+			lvol-maps = <&lvol_none &lvol_iob1 &lvol_iob2 &lvol_iob3
+				     &lvol_iob4 &lvol_iob5 &lvol_iob6 &lvol_iob7>;
 		};
 
 		gpioc: gpio@40099000 {
 			wui-maps = <&wui_ioc0 &wui_ioc1 &wui_ioc2 &wui_ioc3
 				    &wui_ioc4 &wui_ioc5 &wui_ioc6 &wui_ioc7>;
 
-			lvol-maps = <&lvol_none &lvol_ioc1 &lvol_ioc2 &lvol_none
-				     &lvol_none &lvol_ioc5 &lvol_ioc6 &lvol_ioc7>;
+			lvol-maps = <&lvol_ioc0 &lvol_ioc1 &lvol_ioc2 &lvol_ioc3
+				     &lvol_ioc4 &lvol_ioc5 &lvol_ioc6 &lvol_ioc7>;
 		};
 
 		gpiod: gpio@4009b000 {
 			wui-maps = <&wui_iod0 &wui_iod1 &wui_iod2 &wui_iod3
-				    &wui_iod4 &wui_iod5 &wui_none &wui_none>;
+				    &wui_iod4 &wui_iod5 &wui_iod6 &wui_none>;
 
-			lvol-maps = <&lvol_iod0 &lvol_iod1 &lvol_none &lvol_none
-				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+			lvol-maps = <&lvol_iod0 &lvol_iod1 &lvol_iod2 &lvol_iod3
+				     &lvol_iod4 &lvol_iod5 &lvol_iod6 &lvol_none>;
 		};
 
 		gpioe: gpio@4009d000 {
 			wui-maps = <&wui_ioe0 &wui_ioe1 &wui_ioe2 &wui_ioe3
-				    &wui_ioe4 &wui_ioe5 &wui_none &wui_none>;
+				    &wui_ioe4 &wui_ioe5 &wui_none &wui_ioe7>;
 
-			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_ioe3
-				     &lvol_ioe4 &lvol_none &lvol_none &lvol_none>;
+			lvol-maps = <&lvol_ioe0 &lvol_ioe1 &lvol_ioe2 &lvol_ioe3
+				     &lvol_ioe4 &lvol_ioe5 &lvol_none &lvol_ioe7>;
 		};
 
 		gpiof: gpio@4009f000 {
 			wui-maps = <&wui_iof0 &wui_iof1 &wui_iof2 &wui_iof3
 				    &wui_iof4 &wui_iof5 &wui_none &wui_none>;
 
-			lvol-maps = <&lvol_none &lvol_none &lvol_iof2 &lvol_iof3
+			lvol-maps = <&lvol_iof0 &lvol_iof1 &lvol_iof2 &lvol_iof3
 				     &lvol_iof4 &lvol_iof5 &lvol_none &lvol_none>;
 		};
 
-		/* ADC0 comparator configuration in npcx9 series */
+		/* ADC0 comparator configuration in npcx4 series */
 		adc0: adc@400d1000 {
-			channel-count = <12>;
-			threshold-reg-offset = <0x60>;
+			channel-count = <26>;
+			threshold-reg-offset = <0x80>;
 			threshold-count = <6>;
 		};
 
-		/* FIU0 configuration in npcx9 series */
+		/* FIU0 configuration in npcx4 series */
 		qspi_fiu0: quadspi@40020000 {
-			clocks = <&pcc NPCX_CLOCK_BUS_FIU NPCX_PWDWN_CTL1 2>;
+			clocks = <&pcc NPCX_CLOCK_BUS_FIU0 NPCX_PWDWN_CTL8 5>;
+		};
+
+		/* FIU1 configuration in npcx4 series */
+		qspi_fiu1: quadspi@40021000 {
+			compatible = "nuvoton,npcx-fiu-qspi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40021000 0x1000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_FIU0 NPCX_PWDWN_CTL8 6>;
 		};
 
 		sha0: sha@13c {
@@ -264,8 +274,28 @@
 		};
 	};
 
+	soc-if {
+		i2c4_0: io_i2c_ctrl4_port0 {
+			compatible = "nuvoton,npcx-i2c-port";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port = <0x40>;
+			controller = <&i2c_ctrl4>;
+			status = "disabled";
+		};
+
+		i2c7_1: io_i2c_ctrl7_port1 {
+			compatible = "nuvoton,npcx-i2c-port";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port = <0x71>;
+			controller = <&i2c_ctrl7>;
+			status = "disabled";
+		};
+	};
+
 	soc-id {
-		chip-id = <0x09>;
+		chip-id = <0x0a>;
 		revision-reg = <0x0000FFFC 4>;
 	};
 };

--- a/dts/arm/nuvoton/npcx/npcx4/npcx4-alts-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4/npcx4-alts-map.dtsi
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2023 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common pin-mux configurations in npcx family */
+#include <nuvoton/npcx/npcx-alts-map.dtsi>
+
+/* Specific pin-mux configurations in npcx4 series */
+/ {
+	npcx-alts-map {
+		compatible = "nuvoton,npcx-pinctrl-conf";
+
+		/* SCFG DEVALT 0 */
+		alt0_f_spi_cs1: alt04 {
+			alts = <&scfg 0x00 0x4 0>;
+		};
+		alt0_f_spi_quad: alt06 {
+			alts = <&scfg 0x00 0x6 0>;
+		};
+
+		/* SCFG DEVALT 2 */
+		alt2_i2c4_0_sl: alt27 {
+			alts = <&scfg 0x02 0x7 0>;
+		};
+
+		/* SCFG DEVALT 5 */
+		alt5_jen_lk: alt51 {
+			alts = <&scfg 0x05 0x1 0>;
+		};
+		alt5_gp_lk: alt57 {
+			alts = <&scfg 0x05 0x7 0>;
+		};
+
+		/* SCFG DEVALT E */
+		alte_cr_sin4_sl: alte6 {
+			alts = <&scfg 0x0E 0x6 0>;
+		};
+		alte_cr_sout4_sl: alte7 {
+			alts = <&scfg 0x0E 0x7 0>;
+		};
+
+		/* SCFG DEVALT F */
+		altf_adc10_sl: altf5 {
+			alts = <&scfg 0x0F 0x5 0>;
+		};
+		altf_adc11_sl: altf6 {
+			alts = <&scfg 0x0F 0x6 0>;
+		};
+
+		/* SCFG DEVALT A */
+		alta_32kclkin_sl: alta3 {
+			alts = <&scfg 0x0A 0x3 0>;
+		};
+
+		/* SCFG DEVALT C */
+		altc_gpio97_sl_inv: altc2-inv {
+			alts = <&scfg 0x0C 0x2 1>;
+		};
+
+		/* SCFG DEVALT F */
+		altf_adc12_sl: altf7 {
+			alts = <&scfg 0x0F 0x7 0>;
+		};
+
+		/* SCFG DEVALT G */
+		altg_vcc1_rst_pud: altg4 {
+			alts = <&scfg 0x10 0x4 0>;
+		};
+		altg_vcc1_rst_pud_lk: altg5 {
+			alts = <&scfg 0x10 0x5 0>;
+		};
+		altg_psl_out_sl: altg6 {
+			alts = <&scfg 0x10 0x6 0>;
+		};
+		altg_psl_gpo_sl: altg7 {
+			alts = <&scfg 0x10 0x7 0>;
+		};
+
+		/* SCFG DEVALT H */
+		alth_fcsi_typ: alth1 {
+			alts = <&scfg 0x11 0x1 0>;
+		};
+		alth_flm_quad: alth5 {
+			alts = <&scfg 0x11 0x5 0>;
+		};
+		alth_flm_mon_md: alth6-inv {
+			alts = <&scfg 0x11 0x6 1>;
+		};
+		alth_flm_sl: alth7 {
+			alts = <&scfg 0x11 0x7 0>;
+		};
+
+		/*
+		 * Note: DEVALT I is skipped in the datasheet, the offset of
+		 * DEVALT J is 0x12 not 0x13.
+		 */
+		/* SCFG DEVALT J */
+		altj_cr_sin1_sl1: altj0 {
+			alts = <&scfg 0x12 0x0 0>;
+		};
+		altj_cr_sout1_sl1: altj1 {
+			alts = <&scfg 0x12 0x1 0>;
+		};
+		altj_cr_sin1_sl2:  altj2 {
+			alts = <&scfg 0x12 0x2 0>;
+		};
+		altj_cr_sout1_sl2: altj3 {
+			alts = <&scfg 0x12 0x3 0>;
+		};
+		altj_cr_sin2_sl: altj4 {
+			alts = <&scfg 0x12 0x4 0>;
+		};
+		altj_cr_sout2_sl: altj5 {
+			alts = <&scfg 0x12 0x5 0>;
+		};
+		altj_cr_sin3_sl: altj6 {
+			alts = <&scfg 0x12 0x6 0>;
+		};
+		altj_cr_sout3_sl: altj7 {
+			alts = <&scfg 0x12 0x7 0>;
+		};
+
+		/* SCFG DEVALT K */
+		altk_i2c7_1_sl: altk7 {
+			alts = <&scfg 0x13 0x7 0>;
+		};
+
+		/* SCFG DEVALT L */
+		altl_adc13_sl: altl0 {
+			alts = <&scfg 0x14 0x0 0>;
+		};
+		altl_adc14_sl: altl1 {
+			alts = <&scfg 0x14 0x1 0>;
+		};
+		altl_adc15_sl:  altl2 {
+			alts = <&scfg 0x14 0x2 0>;
+		};
+		altl_adc16_sl: altl3 {
+			alts = <&scfg 0x14 0x3 0>;
+		};
+		altl_adc17_sl: altl4 {
+			alts = <&scfg 0x14 0x4 0>;
+		};
+		altl_adc18_sl: altl5 {
+			alts = <&scfg 0x14 0x5 0>;
+		};
+		altl_adc19_sl: altl6 {
+			alts = <&scfg 0x14 0x6 0>;
+		};
+		altl_adc20_sl: altl7 {
+			alts = <&scfg 0x14 0x7 0>;
+		};
+
+		/* SCFG DEVALT M */
+		altm_adc21_sl: altm0 {
+			alts = <&scfg 0x15 0x0 0>;
+		};
+		altm_adc22_sl: altm1 {
+			alts = <&scfg 0x15 0x1 0>;
+		};
+		altm_adc23_sl:  altm2 {
+			alts = <&scfg 0x15 0x2 0>;
+		};
+		altm_adc24_sl: altm3 {
+			alts = <&scfg 0x15 0x3 0>;
+		};
+		altm_adc25_sl: altm4 {
+			alts = <&scfg 0x15 0x4 0>;
+		};
+
+		/* SCFG DEVALT N */
+		altn_i3c1_sl: altn0 {
+			alts = <&scfg 0x16 0x0 0>;
+		};
+		altn_i3c2_sl: altn1 {
+			alts = <&scfg 0x16 0x1 0>;
+		};
+		altn_i3c3_sl:  altn2 {
+			alts = <&scfg 0x16 0x2 0>;
+		};
+	};
+};

--- a/dts/arm/nuvoton/npcx/npcx4/npcx4-espi-vws-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4/npcx4-espi-vws-map.dtsi
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2023 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common eSPI Virtual Wire (VW) mapping configurations in npcx family */
+#include <nuvoton/npcx/npcx-espi-vws-map.dtsi>
+
+/* Specific eSPI Virtual Wire (VW) mapping configurations in npcx4 series */

--- a/dts/arm/nuvoton/npcx/npcx4/npcx4-lvol-ctrl-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4/npcx4-lvol-ctrl-map.dtsi
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2023 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common Low-Voltage level configurations in npcx family */
+#include <nuvoton/npcx/npcx-lvol-ctrl-map.dtsi>
+
+/* Specific Low-Voltage level configurations in npcx4 series */
+/ {
+	def-lvol-conf-list {
+		compatible = "nuvoton,npcx-lvolctrl-conf";
+
+		/* Low-Voltage IO Control 1 */
+		lvol_io66: lvol17 {
+			lvols = <&scfg 1 7>;
+		};
+
+		/* Low-Voltage IO Control 2 */
+		lvol_ioe7: lvol26 {
+			lvols = <&scfg 2 6>;
+		};
+
+		/* Low-Voltage IO Control 5 */
+		lvol_io02: lvol54 {
+			lvols = <&scfg 5 4>;
+		};
+		lvol_io01: lvol55 {
+			lvols = <&scfg 5 5>;
+		};
+		lvol_ioe2: lvol56 {
+			lvols = <&scfg 5 6>;
+		};
+		lvol_iod6: lvol57 {
+			lvols = <&scfg 5 7>;
+		};
+
+		/* Low-Voltage IO Control 6 */
+		lvol_io03: lvol60 {
+			lvols = <&scfg 6 0>;
+		};
+		lvol_io05: lvol61 {
+			lvols = <&scfg 6 1>;
+		};
+		lvol_io04: lvol62 {
+			lvols = <&scfg 6 2>;
+		};
+		lvol_io06: lvol63 {
+			lvols = <&scfg 6 3>;
+		};
+		lvol_io07: lvol64 {
+			lvols = <&scfg 6 4>;
+		};
+		lvol_io10: lvol65 {
+			lvols = <&scfg 6 5>;
+		};
+		lvol_io11: lvol66 {
+			lvols = <&scfg 6 6>;
+		};
+		lvol_io13: lvol67 {
+			lvols = <&scfg 6 7>;
+		};
+
+		/* Low-Voltage IO Control 7 */
+		lvol_io14: lvol70 {
+			lvols = <&scfg 7 0>;
+		};
+		lvol_io15: lvol71 {
+			lvols = <&scfg 7 1>;
+		};
+		lvol_io16: lvol72 {
+			lvols = <&scfg 7 2>;
+		};
+		lvol_io17: lvol73 {
+			lvols = <&scfg 7 3>;
+		};
+		lvol_io20: lvol74 {
+			lvols = <&scfg 7 4>;
+		};
+		lvol_io21: lvol75 {
+			lvols = <&scfg 7 5>;
+		};
+		lvol_io22: lvol76 {
+			lvols = <&scfg 7 6>;
+		};
+		lvol_io23: lvol77 {
+			lvols = <&scfg 7 7>;
+		};
+
+		/* Low-Voltage IO Control 8 */
+		lvol_ioe0: lvol80 {
+			lvols = <&scfg 8 0>;
+		};
+		lvol_io41: lvol81 {
+			lvols = <&scfg 8 1>;
+		};
+		lvol_iof0: lvol82 {
+			lvols = <&scfg 8 2>;
+		};
+		lvol_io42: lvol83 {
+			lvols = <&scfg 8 3>;
+		};
+		lvol_io43: lvol84 {
+			lvols = <&scfg 8 4>;
+		};
+		lvol_io44: lvol85 {
+			lvols = <&scfg 8 5>;
+		};
+		lvol_io45: lvol86 {
+			lvols = <&scfg 8 6>;
+		};
+		lvol_ioe1: lvol87 {
+			lvols = <&scfg 8 7>;
+		};
+
+		/* Low-Voltage IO Control 9 */
+		lvol_iof1: lvol90 {
+			lvols = <&scfg 9 0>;
+		};
+		lvol_io61: lvol91 {
+			lvols = <&scfg 9 1>;
+		};
+		lvol_io62: lvol92 {
+			lvols = <&scfg 9 2>;
+		};
+		lvol_io63: lvol93 {
+			lvols = <&scfg 9 3>;
+		};
+		lvol_io67: lvol94 {
+			lvols = <&scfg 9 4>;
+		};
+		lvol_io70: lvol95 {
+			lvols = <&scfg 9 5>;
+		};
+		lvol_io76: lvol96 {
+			lvols = <&scfg 9 6>;
+		};
+		lvol_io83: lvol97 {
+			lvols = <&scfg 9 7>;
+		};
+
+		/* Low-Voltage IO Control A */
+		lvol_iob1: lvola0 {
+			lvols = <&scfg 10 0>;
+		};
+		lvol_iob6: lvola1 {
+			lvols = <&scfg 10 1>;
+		};
+		lvol_iob7: lvola2 {
+			lvols = <&scfg 10 2>;
+		};
+		lvol_ioc0: lvola3 {
+			lvols = <&scfg 10 3>;
+		};
+		lvol_ioc3: lvola4 {
+			lvols = <&scfg 10 4>;
+		};
+		lvol_ioc4: lvola5 {
+			lvols = <&scfg 10 5>;
+		};
+		lvol_iod2: lvola6 {
+			lvols = <&scfg 10 6>;
+		};
+		lvol_iod3: lvola7 {
+			lvols = <&scfg 10 7>;
+		};
+
+		/* Low-Voltage IO Control B */
+		lvol_iod4: lvolb0 {
+			lvols = <&scfg 11 0>;
+		};
+		lvol_iod5: lvolb1 {
+			lvols = <&scfg 11 1>;
+		};
+		lvol_ioe5: lvolb2 {
+			lvols = <&scfg 11 2>;
+		};
+		lvol_io60: lvolb7 {
+			lvols = <&scfg 11 7>;
+		};
+	};
+};

--- a/dts/arm/nuvoton/npcx/npcx4/npcx4-miwus-int-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4/npcx4-miwus-int-map.dtsi
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common MIWU group-interrupt mapping configurations in npcx family */
+#include <nuvoton/npcx/npcx-miwus-int-map.dtsi>
+
+/* Specific MIWU group-interrupt mapping configurations in npcx4 series */
+/ {
+	/* Mapping between MIWU group and interrupts */
+	npcx-miwus-int-map {
+		map_miwu0_groups: map-miwu0-groups {
+			compatible = "nuvoton,npcx-miwu-int-map";
+			parent = <&miwu0>;
+
+			group_a0: group-a0-map {
+				irq        = <7>;
+				irq-prio   = <2>;
+				group-mask = <0x01>;
+			};
+			group_d0: group-d0-map {
+				irq        = <5>;
+				irq-prio   = <2>;
+				group-mask = <0x08>;
+			};
+			group_e0: group-e0-map {
+				irq        = <11>;
+				irq-prio   = <2>;
+				group-mask = <0x10>;
+			};
+			group_f0: group-f0-map {
+				irq        = <35>;
+				irq-prio   = <2>;
+				group-mask = <0x20>;
+			};
+			group_g0: group-g0-map {
+				irq        = <42>;
+				irq-prio   = <2>;
+				group-mask = <0x40>;
+			};
+			group_h0: group-h0-map {
+				irq        = <46>;
+				irq-prio   = <2>;
+				group-mask = <0x80>;
+			};
+		};
+
+		map_miwu2_groups: map-miwu2-groups {
+			compatible = "nuvoton,npcx-miwu-int-map";
+			parent = <&miwu2>;
+
+			group_e2: group-e2-map {
+				irq        = <64>;
+				irq-prio   = <2>;
+				group-mask = <0x10>;
+			};
+			group_f2: group-f2-map {
+				irq        = <59>;
+				irq-prio   = <2>;
+				group-mask = <0x20>;
+			};
+			group_g2: group-g2-map {
+				irq        = <55>;
+				irq-prio   = <2>;
+				group-mask = <0x40>;
+			};
+			group_h2: group-h2-map {
+				irq        = <82>;
+				irq-prio   = <2>;
+				group-mask = <0x80>;
+			};
+		};
+	};
+};

--- a/dts/arm/nuvoton/npcx/npcx4/npcx4-miwus-wui-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4/npcx4-miwus-wui-map.dtsi
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common Wake-Up Unit Input (WUI) mapping configurations in npcx family */
+#include <nuvoton/npcx/npcx-miwus-wui-map.dtsi>
+
+/* Specific Wake-Up Unit Input (WUI) mapping configurations in npcx4 series */
+/ {
+	/* Mapping between MIWU wui bits and source device */
+	npcx-miwus-wui-map {
+		compatible = "nuvoton,npcx-miwu-wui-map";
+
+		/* MIWU table 0 */
+		/* MIWU group H */
+		wui_ioe7: wui0-8-7 {
+			miwus = <&miwu0 7 7>; /* GPIOE7 */
+		};
+
+		/* MIWU table 1 */
+		/* MIWU group B */
+		wui_io13: wui1-2-3 {
+			miwus = <&miwu1 1 3>; /* GPIO13 */
+		};
+
+		/* MIWU group G */
+		wui_io66: wui1-7-6 {
+			miwus = <&miwu1 6 6>; /* GPIO66 */
+		};
+
+		/* MIWU table 2 */
+		/* MIWU group E */
+		wui_slp_msc: wui2-5-0 {
+			miwus = <&miwu2 4 0>; /* SLP_MSC */
+		};
+		wui_z8: wui2-5-1 {
+			miwus = <&miwu2 4 1>; /* Z8 */
+		};
+		wui_z9: wui2-5-2 {
+			miwus = <&miwu2 4 2>; /* Z9 */
+		};
+		wui_z10: wui2-5-3 {
+			miwus = <&miwu2 4 3>; /* Z10 */
+		};
+
+		/* MIWU group F */
+		wui_io12: wui2-6-0 {
+			miwus = <&miwu2 5 0>; /* GPIO12 */
+		};
+		wui_smb2: wui2-6-3 {
+			miwus = <&miwu2 5 3>; /* SMB2 */
+		};
+		wui_smb3: wui2-6-4 {
+			miwus = <&miwu2 5 4>; /* SMB3 */
+		};
+		wui_iod6: wui2-6-5 {
+			miwus = <&miwu2 5 5>; /* GPIOD6 */
+		};
+		wui_iob6: wui2-6-6 {
+			miwus = <&miwu2 5 6>; /* GPIOB6 */
+		};
+		wui_lct: wui2-6-7 {
+			miwus = <&miwu2 5 7>; /* LCT Event */
+		};
+
+		/* MIWU group G */
+		wui_cr_sin2: wui2-7-3 {
+			miwus = <&miwu2 6 3>; /* CR_SIN2 */
+		};
+		wui_cr_sin3: wui2-7-4 {
+			miwus = <&miwu2 6 4>; /* CR_SIN3 */
+		};
+		wui_cr_sin4: wui2-7-5 {
+			miwus = <&miwu2 6 5>; /* CR_SIN4 */
+		};
+		wui_i3c1_addrw: wui2-7-6 {
+			miwus = <&miwu2 6 6>; /* I3C1_ADDRW */
+		};
+		wui_i3c1_rstw: wui2-7-7 {
+			miwus = <&miwu2 6 7>; /* I3C1_RSTW */
+		};
+
+		/* MIWU group G */
+		wui_i3c2_addrw: wui2-8-0 {
+			miwus = <&miwu2 7 0>; /* I3C2_ADDRW */
+		};
+		wui_i3c2_rstw: wui2-8-1 {
+			miwus = <&miwu2 7 1>; /* I3C2_RSTW */
+		};
+		wui_i3c3_addrw: wui2-8-2 {
+			miwus = <&miwu2 7 2>; /* I3C3_ADDRW */
+		};
+		wui_i3c3_rstw: wui2-8-3 {
+			miwus = <&miwu2 7 3>; /* I3C3_RSTW */
+		};
+	};
+};

--- a/dts/arm/nuvoton/npcx/npcx4/npcx4-pinctrl.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4/npcx4-pinctrl.dtsi
@@ -1,0 +1,558 @@
+/*
+ * Copyright (c) 2023 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	/* Prebuild nodes for peripheral device's characteristics (Optional) */
+	/omit-if-no-ref/ vhif_lpc_sl: devctl-vhif-3p3v-lpc {
+		dev-ctl = <0x0 2 2 0x01>;
+	};
+
+	/omit-if-no-ref/ vhif_espi_shi_sl: devctl-vhif-1p8v-espi-shi {
+		dev-ctl = <0x0 2 2 0x02>;
+	};
+
+	/omit-if-no-ref/ vspi_3p3v_sl: devctl-vspi-3p3v {
+		dev-ctl = <0x0 4 2 0x01>;
+	};
+
+	/omit-if-no-ref/ vspi_1p8v_sl: devctl-vspi-1p8v {
+		dev-ctl = <0x0 4 2 0x02>;
+	};
+
+	/omit-if-no-ref/ ext_flash_tris_off: devctl-fiu-ext-tris-off {
+		dev-ctl = <0x0 6 1 0x00>;
+	};
+
+	/omit-if-no-ref/ ext_flash_tris_on: devctl-fiu-ext-tris-on {
+		dev-ctl = <0x0 6 1 0x01>;
+	};
+
+	/* Prebuild nodes for peripheral device's pin-muxing and pad properties */
+	/* Flash Interface Unit (FIU) */
+	/omit-if-no-ref/ fiu_ext_io0_io1_clk_cs_gpa4_96_a2_a0: periph-fiu-ext {
+		pinmux = <&alt0_gpio_no_fpip>;
+	};
+
+	/omit-if-no-ref/ fiu_ext_quad_io2_io3_gp93_a7: periph-fiu-ext-quad {
+		pinmux = <&alt0_f_spi_quad>;
+	};
+
+	/omit-if-no-ref/ ext_flash_cs1_sl: periph-ext-spi-flash-cs1 {
+		pinmux = <&alt0_f_spi_cs1>;
+	};
+
+	/* Host peripheral interfaces */
+	/omit-if-no-ref/ espi_lpc_gp46_47_51_52_53_54_55_57: periph-lpc-espi {
+		pinmux = <&alt1_no_lpc_espi>;
+	};
+
+	/* I2C peripheral interfaces */
+	/omit-if-no-ref/ i2c0_0_sda_scl_gpb4_b5: periph-i2c0-0 {
+		pinmux = <&alt2_i2c0_0_sl>;
+		periph-pupd = <0x00 0>;
+	};
+
+	/omit-if-no-ref/ i2c1_0_sda_scl_gp87_90: periph-i2c1-0 {
+		pinmux = <&alt2_i2c1_0_sl>;
+		periph-pupd = <0x00 2>;
+	};
+
+	/omit-if-no-ref/ i2c2_0_sda_scl_gp91_92: periph-i2c2-0 {
+		pinmux = <&alt2_i2c2_0_sl>;
+		periph-pupd = <0x00 4>;
+	};
+
+	/omit-if-no-ref/ i2c3_0_sda_scl_gpd0_d1: periph-i2c3-0 {
+		pinmux = <&alt2_i2c3_0_sl>;
+		periph-pupd = <0x00 6>;
+	};
+
+	/omit-if-no-ref/ i2c4_0_sda_scl_gp75_86: periph-i2c4-0 {
+		pinmux = <&alt2_i2c4_0_sl>;
+		periph-pupd = <0x00 7>;
+	};
+
+	/omit-if-no-ref/ i2c4_1_sda_scl_gpf2_f3: periph-i2c4-1 {
+		pinmux = <&alt6_i2c4_1_sl>;
+		periph-pupd = <0x01 2>;
+	};
+
+	/omit-if-no-ref/ i2c5_0_sda_scl_gp33_36: periph-i2c5-0 {
+		pinmux = <&alt2_i2c5_0_sl>;
+		periph-pupd = <0x00 5>;
+	};
+
+	/omit-if-no-ref/ i2c5_1_sda_scl_gpf4_f5: periph-i2c5-1 {
+		pinmux = <&alt6_i2c5_1_sl>;
+		periph-pupd = <0x01 1>;
+	};
+
+	/omit-if-no-ref/ i2c6_0_sda_scl_gpc1_c2: periph-i2c6-0 {
+		pinmux = <&alt2_i2c6_0_sl>;
+		periph-pupd = <0x00 3>;
+	};
+
+	/omit-if-no-ref/ i2c6_1_sda_scl_gpe3_e4: periph-i2c6-1 {
+		pinmux = <&alt6_i2c6_1_sl>;
+		periph-pupd = <0x01 0>;
+	};
+
+	/omit-if-no-ref/ i2c7_0_sda_scl_gpb2_b3: periph-i2c7-0 {
+		pinmux = <&alt2_i2c7_0_sl>;
+		periph-pupd = <0x00 1>;
+	};
+
+	/omit-if-no-ref/ i2c7_1_sda_scl_gpb7_c0: periph-i2c7-1 {
+		pinmux = <&altk_i2c7_1_sl>;
+		periph-pupd = <0x01 3>;
+	};
+
+	/* PS2 peripheral interfaces */
+	/omit-if-no-ref/ ps2_0_dat_clk_gp67_70: periph-ps2-0 {
+		pinmux = <&alt3_ps2_0_sl>;
+	};
+
+	/omit-if-no-ref/ ps2_1_dat_clk_gp62_63: periph-ps2-1 {
+		pinmux = <&alt3_ps2_1_sl>;
+	};
+
+	/omit-if-no-ref/ ps2_2_dat_clk_gp34_37: periph-ps2-2 {
+		pinmux = <&alt3_ps2_2_sl>;
+	};
+
+	/omit-if-no-ref/ ps2_3_2_dat_clk_gpa6_a7: periph-ps2-3-2 {
+		pinmux = <&altc_ps2_3_sl2>;
+	};
+
+	/* Tachometer peripheral interfaces */
+	/omit-if-no-ref/ ta1_1_in_gp40: periph-ta1-1 {
+		pinmux = <&alt3_ta1_sl1>;
+	};
+
+	/omit-if-no-ref/ ta1_2_in_gp93: periph-ta1-2 {
+		pinmux = <&altc_ta1_sl2>;
+	};
+
+	/omit-if-no-ref/ ta2_1_in_gp73: periph-ta2-1 {
+		pinmux = <&alt3_ta2_sl1>;
+	};
+
+	/omit-if-no-ref/ ta2_2_in_gpa6: periph-ta2-2 {
+		pinmux = <&altc_ta2_sl2>;
+	};
+
+	/omit-if-no-ref/ tb1_1_in_gpa4: periph-tb1-1 {
+		pinmux = <&alt3_tb1_sl1>;
+	};
+
+	/omit-if-no-ref/ tb1_2_in_gpd3: periph-tb1-2 {
+		pinmux = <&altc_tb1_sl2>;
+	};
+
+	/omit-if-no-ref/ tb2_2_in_gpa7: periph-tb2-2 {
+		pinmux = <&altc_tb2_sl2>;
+	};
+
+	/* PWM peripheral interfaces */
+	/omit-if-no-ref/ pwm0_gpc3: periph-pwm0 {
+		pinmux = <&alt4_pwm0_sl>;
+	};
+
+	/omit-if-no-ref/ pwm1_gpc2: periph-pwm1 {
+		pinmux = <&alt4_pwm1_sl>;
+	};
+
+	/omit-if-no-ref/ pwm2_gpc4: periph-pwm2 {
+		pinmux = <&alt4_pwm2_sl>;
+	};
+
+	/omit-if-no-ref/ pwm3_gp80: periph-pwm3 {
+		pinmux = <&alt4_pwm3_sl>;
+	};
+
+	/omit-if-no-ref/ pwm4_gpb6: periph-pwm4 {
+		pinmux = <&alt4_pwm4_sl>;
+	};
+
+	/omit-if-no-ref/ pwm5_gpb7: periph-pwm5 {
+		pinmux = <&alt4_pwm5_sl>;
+	};
+
+	/omit-if-no-ref/ pwm6_gpc0: periph-pwm6 {
+		pinmux = <&alt4_pwm6_sl>;
+	};
+
+	/omit-if-no-ref/ pwm7_gp60: periph-pwm7 {
+		pinmux = <&alt4_pwm7_sl>;
+	};
+
+	/* Keyboard peripheral interfaces. */
+	/omit-if-no-ref/ ksi0_gp31: periph-kbscan-ksi0 {
+		pinmux = <&alt7_no_ksi0_sl>;
+	};
+
+	/omit-if-no-ref/ ksi1_gp30: periph-kbscan-ksi1 {
+		pinmux = <&alt7_no_ksi1_sl>;
+	};
+
+	/omit-if-no-ref/ ksi2_gp27: periph-kbscan-ksi2 {
+		pinmux = <&alt7_no_ksi2_sl>;
+	};
+
+	/omit-if-no-ref/ ksi3_gp26: periph-kbscan-ksi3 {
+		pinmux = <&alt7_no_ksi3_sl>;
+	};
+
+	/omit-if-no-ref/ ksi4_gp25: periph-kbscan-ksi4 {
+		pinmux = <&alt7_no_ksi4_sl>;
+	};
+
+	/omit-if-no-ref/ ksi5_gp24: periph-kbscan-ksi5 {
+		pinmux = <&alt7_no_ksi5_sl>;
+	};
+
+	/omit-if-no-ref/ ksi6_gp23: periph-kbscan-ksi6 {
+		pinmux = <&alt7_no_ksi6_sl>;
+	};
+
+	/omit-if-no-ref/ ksi7_gp22: periph-kbscan-ksi7 {
+		pinmux = <&alt7_no_ksi7_sl>;
+	};
+
+	/omit-if-no-ref/ kso00_gp21: periph-kbscan-kso00 {
+		pinmux = <&alt8_no_kso00_sl>;
+	};
+
+	/omit-if-no-ref/ kso01_gp20: periph-kbscan-kso01 {
+		pinmux = <&alt8_no_kso01_sl>;
+	};
+
+	/omit-if-no-ref/ kso02_gp17: periph-kbscan-kso02 {
+		pinmux = <&alt8_no_kso02_sl>;
+	};
+
+	/omit-if-no-ref/ kso03_gp16: periph-kbscan-kso03 {
+		pinmux = <&alt8_no_kso03_sl>;
+	};
+
+	/omit-if-no-ref/ kso04_gp15: periph-kbscan-kso04 {
+		pinmux = <&alt8_no_kso04_sl>;
+	};
+
+	/omit-if-no-ref/ kso05_gp14: periph-kbscan-kso05 {
+		pinmux = <&alt8_no_kso05_sl>;
+	};
+
+	/omit-if-no-ref/ kso06_gp13: periph-kbscan-kso06 {
+		pinmux = <&alt8_no_kso06_sl>;
+	};
+
+	/omit-if-no-ref/ kso07_gp12: periph-kbscan-kso07 {
+		pinmux = <&alt8_no_kso07_sl>;
+	};
+
+	/omit-if-no-ref/ kso08_gp11: periph-kbscan-kso08 {
+		pinmux = <&alt9_no_kso08_sl>;
+	};
+
+	/omit-if-no-ref/ kso09_gp10: periph-kbscan-kso09 {
+		pinmux = <&alt9_no_kso09_sl>;
+	};
+
+	/omit-if-no-ref/ kso10_gp07: periph-kbscan-kso10 {
+		pinmux = <&alt9_no_kso10_sl>;
+	};
+
+	/omit-if-no-ref/ kso11_gp06: periph-kbscan-kso11 {
+		pinmux = <&alt9_no_kso11_sl>;
+	};
+
+	/omit-if-no-ref/ kso12_gp05: periph-kbscan-kso12 {
+		pinmux = <&alt9_no_kso12_sl>;
+	};
+
+	/omit-if-no-ref/ kso13_gp04: periph-kbscan-kso13 {
+		pinmux = <&alt9_no_kso13_sl>;
+	};
+
+	/omit-if-no-ref/ kso14_gp82: periph-kbscan-kso14 {
+		pinmux = <&alt9_no_kso14_sl>;
+	};
+
+	/omit-if-no-ref/ kso15_gp83: periph-kbscan-kso15 {
+		pinmux = <&alt9_no_kso15_sl>;
+	};
+
+	/omit-if-no-ref/ kso16_gp03: periph-kbscan-kso16 {
+		pinmux = <&alta_no_kso16_sl>;
+	};
+
+	/omit-if-no-ref/ kso17_gpb1: periph-kbscan-kso17 {
+		pinmux = <&alta_no_kso17_sl>;
+	};
+
+	/* Miscellaneous peripheral interfaces */
+	/omit-if-no-ref/ clk_32k_out_gp75: periph-clk-32k-out {
+		pinmux = <&alta_32k_out_sl>;
+	};
+
+	/omit-if-no-ref/ clk_32k_in_gpe7: periph-clk-32k-in {
+		pinmux = <&alta_32kclkin_sl>;
+	};
+
+	/omit-if-no-ref/ vcc1_rst_gp77: periph-vcc1-rst {
+		pinmux = <&alta_no_vcc1_rst>;
+	};
+
+	/omit-if-no-ref/ peci_dat_gp81: periph-peci-dat {
+		pinmux = <&alta_no_peci_en>;
+	};
+
+	/* Host UART peripheral interfaces */
+	/omit-if-no-ref/ huart_rxd_gp75: periph-host-uart-rxd {
+		pinmux = <&altb_rxd_sl>;
+	};
+
+	/omit-if-no-ref/ huart_txd_gp86: periph-host-uart-txd {
+		pinmux = <&altb_txd_sl>;
+	};
+
+	/omit-if-no-ref/ huart_rts_gp36: periph-host-uart-rts {
+		pinmux = <&altb_rts_sl>;
+	};
+
+	/omit-if-no-ref/ huart_cts_gp33: periph-host-uart-cts {
+		pinmux = <&altb_cts_sl>;
+	};
+
+	/omit-if-no-ref/ huart_ri_gp42: periph-host-uart-ri {
+		pinmux = <&altb_ri_sl>;
+	};
+
+	/omit-if-no-ref/ huart_dtr_bout_gpc7: periph-host-uart-dtr_bout {
+		pinmux = <&altb_dtr_bout_sl>;
+	};
+
+	/omit-if-no-ref/ huart_dcd_gpb3: periph-host-uart-dcd {
+		pinmux = <&altb_dcd_sl>;
+	};
+
+	/omit-if-no-ref/ huart_dsr_gpb2: periph-host-uart-dsr {
+		pinmux = <&altb_dsr_sl>;
+	};
+
+	/* SHI peripheral interfaces */
+	/omit-if-no-ref/ shi_gp46_47_53_55: periph-shi {
+		pinmux = <&altc_shi_sl>;
+		periph-pupd = <0x01 4>;
+	};
+
+	/* FLM peripheral interfaces */
+	/omit-if-no-ref/ flm_gp96_a0_a2_a4: periph-flm {
+		pinmux = <&alth_flm_sl>;
+	};
+
+	/omit-if-no-ref/ flm_quad_gp93_a7: periph-flm-quad {
+		pinmux = <&alth_flm_quad>;
+	};
+
+	/omit-if-no-ref/ flm_mon_md_gpd6: periph-flm-mon-md {
+		pinmux = <&alth_flm_mon_md>;
+	};
+
+
+	/* ADC peripheral interfaces. */
+	/omit-if-no-ref/ adc0_chan0_gp45: periph-adc0-0 {
+		pinmux = <&alt6_adc0_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan1_gp44: periph-adc0-1 {
+		pinmux = <&alt6_adc1_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan2_gp43: periph-adc0-2 {
+		pinmux = <&alt6_adc2_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan3_gp42: periph-adc0-3 {
+		pinmux = <&alt6_adc3_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan4_gp41: periph-adc0-4 {
+		pinmux = <&alt6_adc4_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan5_gp37: periph-adc0-5 {
+		pinmux = <&altf_adc5_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan6_gp34: periph-adc0-6 {
+		pinmux = <&altf_adc6_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan7_gpe1: periph-adc0-7 {
+		pinmux = <&altf_adc7_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan8_gpf1: periph-adc0-8 {
+		pinmux = <&altf_adc8_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan9_gpf0: periph-adc0-9 {
+		pinmux = <&altf_adc9_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan10_gpe0: periph-adc0-10 {
+		pinmux = <&altf_adc10_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan11_gpc7: periph-adc0-11 {
+		pinmux = <&altf_adc11_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan12_gp24: periph-adc0-12 {
+		pinmux = <&altf_adc12_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan13_gp26: periph-adc0-13 {
+		pinmux = <&altl_adc13_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan14_gp27: periph-adc0-14 {
+		pinmux = <&altl_adc14_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan15_gp31: periph-adc0-15 {
+		pinmux = <&altl_adc15_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan16_gp62: periph-adc0-16 {
+		pinmux = <&altl_adc16_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan17_gp63: periph-adc0-17 {
+		pinmux = <&altl_adc17_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan18_gp67: periph-adc0-18 {
+		pinmux = <&altl_adc18_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan19_gp70: periph-adc0-19 {
+		pinmux = <&altl_adc19_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan20_gp22: periph-adc0-20 {
+		pinmux = <&altl_adc20_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan21_gp23: periph-adc0-21 {
+		pinmux = <&altm_adc21_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan22_gpc1: periph-adc0-22 {
+		pinmux = <&altm_adc22_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan23_gp74: periph-adc0-23 {
+		pinmux = <&altm_adc23_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan24_gp25: periph-adc0-24 {
+		pinmux = <&altm_adc24_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan25_gp30: periph-adc0-25 {
+		pinmux = <&altm_adc25_sl>;
+	};
+
+	/* PSL peripheral interfaces */
+	/omit-if-no-ref/ psl_in1_gpd2: periph-psl-in1 {
+		pinmux = <&altd_npsl_in1_sl>;
+		psl-offset = <0>;
+		psl-polarity = <&altd_psl_in1_ahi>;
+	};
+
+	/omit-if-no-ref/ psl_in2_gp00: periph-psl-in2 {
+		pinmux = <&altd_npsl_in2_sl>;
+		psl-offset = <1>;
+		psl-polarity = <&altd_psl_in2_ahi>;
+	};
+
+	/omit-if-no-ref/ psl_in3_gp01: periph-psl-in3 {
+		pinmux = <&altd_psl_in3_sl>;
+		psl-offset = <2>;
+		psl-polarity = <&altd_psl_in3_ahi>;
+	};
+
+	/omit-if-no-ref/ psl_in4_gp02: periph-psl-in4 {
+		pinmux = <&altd_psl_in4_sl>;
+		psl-offset = <3>;
+		psl-polarity = <&altd_psl_in4_ahi>;
+	};
+
+	/omit-if-no-ref/ psl_gpo_gpd7: periph-psl-gpo {
+		pinmux = <&altg_psl_gpo_sl>;
+	};
+
+	/omit-if-no-ref/ psl_out_gp85: periph-psl-out {
+		pinmux = <&altg_psl_out_sl>;
+	};
+
+	/* I3C peripheral interfaces */
+	/omit-if-no-ref/ i3c1_sda_scl_gpe3_e4: periph-i3c1 {
+		pinmux = <&altn_i3c1_sl>;
+	};
+
+	/omit-if-no-ref/ i3c2_sda_scl_gp50_56: periph-i3c2 {
+		pinmux = <&altn_i3c2_sl>;
+	};
+
+	/omit-if-no-ref/ i3c3_sda_scl_gpf4_f5: periph-i3c3 {
+		pinmux = <&altn_i3c3_sl>;
+	};
+
+	/* UART peripheral interfaces */
+	/omit-if-no-ref/ uart1_1_sin_gp10: periph-uart1-1-sin {
+		pinmux = <&altj_cr_sin1_sl1>;
+	};
+
+	/omit-if-no-ref/ uart1_1_sout_gp11: periph-uart1-1-sout {
+		pinmux = <&altj_cr_sout1_sl1>;
+	};
+
+	/omit-if-no-ref/ uart1_2_sin_gp64: periph-uart1-2-sin {
+		pinmux = <&altj_cr_sin1_sl2>;
+	};
+
+	/omit-if-no-ref/ uart1_2_sout_gp65: periph-uart1-2-sout {
+		pinmux = <&altj_cr_sout1_sl2>;
+	};
+
+	/omit-if-no-ref/ uart2_sin_gp75: periph-uart2-sin {
+		pinmux = <&altj_cr_sin2_sl>;
+	};
+
+	/omit-if-no-ref/ uart2_sout_gp86: periph-uart2-sout {
+		pinmux = <&altj_cr_sout2_sl>;
+	};
+
+	/omit-if-no-ref/ uart3_sin_gpd4: periph-uart3-sin {
+		pinmux = <&altj_cr_sin3_sl>;
+	};
+
+	/omit-if-no-ref/ uart3_sout_gpd6: periph-uart3-sout {
+		pinmux = <&altj_cr_sout3_sl>;
+	};
+
+	/omit-if-no-ref/ uart4_sin_gpb1: periph-uart4-sin {
+		pinmux = <&alte_cr_sin4_sl>;
+	};
+
+	/omit-if-no-ref/ uart4_sout_gp35: periph-uart4-sout {
+		pinmux = <&alte_cr_sout4_sl>;
+	};
+};

--- a/dts/arm/nuvoton/npcx/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7.dtsi
@@ -231,6 +231,11 @@
 			threshold-reg-offset = <0x14>;
 			threshold-count = <3>;
 		};
+
+		/* FIU0 configuration in npcx7 series */
+		qspi_fiu0: quadspi@40020000 {
+			clocks = <&pcc NPCX_CLOCK_BUS_FIU NPCX_PWDWN_CTL1 2>;
+		};
 	};
 
 	soc-id {

--- a/dts/arm/nuvoton/npcx/npcx7/npcx7-miwus-wui-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7/npcx7-miwus-wui-map.dtsi
@@ -15,6 +15,11 @@
 
 		/* MIWU table 0 */
 		/* MIWU group A */
+		wui_cr_sin2: wui0-1-6-2 {
+			miwus = <&miwu0 0 6>; /* CR_SIN2 */
+		};
+
+		/* MIWU group A */
 		wui_io86: wui0-1-6 {
 			miwus = <&miwu0 0 6>; /* GPIO86 */
 		};

--- a/dts/arm/nuvoton/npcx/npcx9/npcx9-miwus-wui-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9/npcx9-miwus-wui-map.dtsi
@@ -14,6 +14,11 @@
 		compatible = "nuvoton,npcx-miwu-wui-map";
 
 		/* MIWU table 1 */
+		/* MIWU group A */
+		wui_cr_sin2: wui0-1-6-2 {
+			miwus = <&miwu0 0 6>; /* CR_SIN2 */
+		};
+
 		/* MIWU group G */
 		wui_io66: wui1-7-6 {
 			miwus = <&miwu1 6 6>; /* GPIO66 */

--- a/dts/arm/nuvoton/npcx4m3f.dtsi
+++ b/dts/arm/nuvoton/npcx4m3f.dtsi
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include "npcx/npcx4.dtsi"
+
+/ {
+	flash0: flash@10088000 {
+		reg = <0x10088000 DT_SIZE_K(224)>;
+	};
+
+	flash1: flash@60000000 {
+		reg = <0x60000000 DT_SIZE_K(512)>;
+	};
+
+	sram0: memory@200c0000 {
+		compatible = "mmio-sram";
+		reg = <0x200C0000 DT_SIZE_K(96)>;
+	};
+
+	soc-id {
+		device-id = <0x2d>;
+	};
+};
+
+&qspi_fiu0 {
+	status = "okay";
+
+	int_flash: w25q40@0 {
+		compatible ="nuvoton,npcx-fiu-nor";
+		size = <DT_SIZE_K(512 * 8)>;
+		reg = <0>;
+		status = "okay";
+
+		/* quad spi bus configuration of nor flash device */
+		qspi-flags = <NPCX_QSPI_SW_CS0>;
+		mapped-addr = <0x60000000>;
+	};
+};

--- a/dts/arm/nuvoton/npcx4m8f.dtsi
+++ b/dts/arm/nuvoton/npcx4m8f.dtsi
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include "npcx/npcx4.dtsi"
+
+/ {
+	flash0: flash@10060000 {
+		reg = <0x10060000 DT_SIZE_K(384)>;
+	};
+
+	flash1: flash@60000000 {
+		reg = <0x60000000 DT_SIZE_M(1)>;
+	};
+
+	sram0: memory@200c0000 {
+		compatible = "mmio-sram";
+		reg = <0x200C0000 DT_SIZE_K(114)>;
+	};
+
+	soc-id {
+		device-id = <0x2b>;
+	};
+};
+
+&qspi_fiu0 {
+	status = "okay";
+
+	int_flash: w25q80@0 {
+		compatible ="nuvoton,npcx-fiu-nor";
+		size = <DT_SIZE_M(1 * 8)>;
+		reg = <0>;
+		status = "okay";
+
+		/* quad spi bus configuration of nor flash device */
+		qspi-flags = <NPCX_QSPI_SW_CS0>;
+		mapped-addr = <0x60000000>;
+	};
+};

--- a/dts/arm/nuvoton/npcx7m6fb.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fb.dtsi
@@ -37,7 +37,7 @@
 
 	int_flash: w25q80@0 {
 		compatible ="nuvoton,npcx-fiu-nor";
-		size = <DT_SIZE_K(1024 * 8)>;
+		size = <DT_SIZE_M(1 * 8)>;
 		reg = <0>;
 		status = "okay";
 

--- a/dts/arm/nuvoton/npcx9m7f.dtsi
+++ b/dts/arm/nuvoton/npcx9m7f.dtsi
@@ -29,7 +29,7 @@
 &qspi_fiu0 {
 	int_flash: w25q80@0 {
 		compatible ="nuvoton,npcx-fiu-nor";
-		size = <DT_SIZE_K(1024 * 8)>;
+		size = <DT_SIZE_M(1 * 8)>;
 		reg = <0>;
 		status = "okay";
 


### PR DESCRIPTION
This PR adds the dts source files for NPCX4 series which integrates advanced functions. The new features include:

**Core and Memory Features**:
* Up to 512 Kbytes of on-chip RAM for code and data regions.
* Up to 1 Mbyte On-chip flash memory, accessed via the dedicated Flash Interface unit (FIU)

**Embedded Controller (EC) System Features**:
* FIU - Two FIU modules support for more external nor SPI flashes.
* SHI - New version to simply the SPI Host Interface driver.
* GPIO - Up to 88 GPIOs support low-voltage power supply levels (1.8V).
* CLOCK - Up to 120MHz Core Clock
* ADC: (Will introduce in the following PRs.)
        1. Two Analog-to-Digital Converters (ADC_IREF and ADC_EREF)
        2. Up to 26 channels with 10-bit resolution
        3. External voltage reference (AVCC) for ADC_EREF and internal voltage reference (VREF) for ADC_IREF