### PR TITLE
doc: tfm: Update TFM overview.rst

### DIFF
--- a/doc/services/tfm/overview.rst
+++ b/doc/services/tfm/overview.rst
@@ -196,13 +196,12 @@ within a default Zephyr west workspace.)
 Secure Services
 ---------------
 
-As of TF-M 1.4.1, the following secure services are generally available (although vendor support may vary):
+As of TF-M 1.8.0, the following secure services are generally available (although vendor support may vary):
 
-* Audit Logging (Audit)
-* Crypto (Crypto)
+* Crypto
 * Firmware Update (FWU)
-* Initial Attestation (IAS)
-* Platform (Platform)
+* Initial Attestation
+* Platform
 * Secure Storage, which has two parts:
 
   * Internal Trusted Storage (ITS)


### PR DESCRIPTION
- Updated TFM v1.4 to v1.8
- Delete the TFM "Audit log" service, as it was removed from TFM.
- Delete not used secure service abbreviations.