### PR TITLE
sample: out_of_tree_driver: allow to build this sample blindly

### DIFF
--- a/samples/application_development/out_of_tree_driver/CMakeLists.txt
+++ b/samples/application_development/out_of_tree_driver/CMakeLists.txt
@@ -1,10 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # For the sake of demonstration, we add the driver directory as a zephyr module
-# by hand. If your driver is a project that's managed by west, you can remove this line.
-list(APPEND EXTRA_ZEPHYR_MODULES
-  ${CMAKE_CURRENT_SOURCE_DIR}/hello_world_module
-  )
+# by hand. The sample ensures that it can be blindly built but in your application,
+# please adding all extra modules in a consistently way.
+# If your driver is a project that's managed by west, you can remove those condition checkers.
+if (DEFINED CACHE{EXTRA_ZEPHYR_MODULES})
+  message(WARNING "All extra modules should be consistently added over -DEXTRA_ZEPHYR_MODULES")
+  set(EXTRA_ZEPHYR_MODULES ${EXTRA_ZEPHYR_MODULES} ${CMAKE_CURRENT_SOURCE_DIR}/hello_world_module CACHE INTERNAL "" FORCE)
+elseif(DEFINED ENV{EXTRA_ZEPHYR_MODULES})
+  message(WARNING "All extra modules should be consistently added over environment variable EXTRA_ZEPHYR_MODULES")
+  set(ENV{EXTRA_ZEPHYR_MODULES} "$ENV{EXTRA_ZEPHYR_MODULES};${CMAKE_CURRENT_SOURCE_DIR}/hello_world_module")
+else()
+  list(APPEND EXTRA_ZEPHYR_MODULES ${CMAKE_CURRENT_SOURCE_DIR}/hello_world_module)
+endif()
 
 cmake_minimum_required(VERSION 3.20.0)
 


### PR DESCRIPTION
There are multiple ways to add extra modules but all extra modules should be added by only one of them, so make this sample can be built blindly and warn user to do follow a proper, consistent way.

Honestly, not sure this is the best way but in downstream, we are adding extra modules over -DEXTRA_ZEPHYR_MODULES, then
this sample will build fail because extra module is added over CLI takes precedence over local setting in CMakeLists.txt

Not sure i should change this https://github.com/zephyrproject-rtos/zephyr/blob/main/cmake/modules/zephyr_module.cmake#L39 to use "MERGE" instead 