### PR TITLE
Re-enable and Fix mec15.

### DIFF
--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
@@ -52,6 +52,8 @@
 &uart1 {
 	status = "okay";
 	current-speed = <115200>;
+	pinctrl-0 = <&uart1_tx_gpio170 &uart1_rx_gpio171>;
+	pinctrl-names = "default";
 };
 
 &adc0 {

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -80,6 +80,8 @@
 &uart2 {
 	status = "okay";
 	current-speed = <115200>;
+	pinctrl-0 = <&uart2_tx_gpio146 &uart2_rx_gpio145>;
+	pinctrl-names = "default";
 };
 
 &adc0 {

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -162,30 +162,36 @@
 			pcrs = <1 9>;
 		};
 		uart0: uart@400f2400 {
-			compatible = "ns16550";
+			compatible = "microchip,xec-uart";
 			reg = <0x400f2400 0x400>;
 			interrupts = <40 0>;
 			clock-frequency = <1843200>;
 			current-speed = <38400>;
-			reg-shift = <0>;
+			girqs = <15 0>;
+			pcrs = <2 1>;
+			ldn = <9>;
 			status = "disabled";
 		};
 		uart1: uart@400f2800 {
-			compatible = "ns16550";
+			compatible = "microchip,xec-uart";
 			reg = <0x400f2800 0x400>;
 			interrupts = <41 0>;
 			clock-frequency = <1843200>;
 			current-speed = <38400>;
-			reg-shift = <0>;
+			girqs = <15 1>;
+			pcrs = <2 2>;
+			ldn = <10>;
 			status = "disabled";
 		};
 		uart2: uart@400f2c00 {
-			compatible = "ns16550";
+			compatible = "microchip,xec-uart";
 			reg = <0x400f2c00 0x400>;
 			interrupts = <44 0>;
 			clock-frequency = <1843200>;
 			current-speed = <38400>;
-			reg-shift = <0>;
+			girqs = <15 4>;
+			pcrs = <2 28>;
+			ldn = <11>;
 			status = "disabled";
 		};
 

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -554,9 +554,7 @@ class TestPlan:
 
         toolchain = self.env.toolchain
         platform_filter = self.options.platform
-        # temporary workaround for exclusion of boards. setting twister in
-        # board yaml file to False does not really work. Need a better solution for the future.
-        exclude_platform = ['mec15xxevb_assy6853','mec1501modular_assy6885'] + self.options.exclude_platform
+        exclude_platform = self.options.exclude_platform
         testsuite_filter = self.run_individual_testsuite
         arch_filter = self.options.arch
         tag_filter = self.options.tag


### PR DESCRIPTION
Re-enable mec15 for v3.2-branch.
There are three cherry-picks.
[b2a95831eb ](https://github.com/zephyrproject-rtos/zephyr/commit/b2a95831eb)Revert "twister: temporarily disable mec15xx boards"
[4ce502777b ](https://github.com/zephyrproject-rtos/zephyr/commit/4ce502777b5fa87681529253d5b86410327fadfc) soc: arm: mec1501: add debug interface configuration
[f6e2cb9b84 ](https://github.com/zephyrproject-rtos/zephyr/commit/f6e2cb9b84)drivers: uart: microchip: add support for mec15xx


Fixes: 
- Skipping tests for mec15.
- No console output from mec15.