### PR TITLE
twister: overhaul of statuses and accounting

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -632,6 +632,26 @@ line break instead of white spaces.
 
 Most everyday users will run with no arguments.
 
+Test Statuses
+*************
+
+The following statuses are reported per testcase:
+
+- `passed`: A test is deemed to pass if its actual result matches its expected
+  result.
+- `failed`: A test is deemed to fail if its actual result does not match its
+  expected result.
+- `error`: A test produces the Error result when there is a problem in running
+  the test itself.
+- `skipped`: A test case that was skipped during a test script execution.
+- `blocked`: A test case that is scheduled to run but cannot run because of an
+  error or a crash in the suite or environment.
+- `notrun`: A test case or test suite that is not yet run.
+- `inprogress`: A test case was started and it is currently executing. This is
+  an intermediate and internal status that will ultimately transition to one of
+  the above statuses.
+
+
 Running in Integration Mode
 ***************************
 

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -458,6 +458,10 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
              "The '--clobber-output' option controls what cleaning does.")
 
     parser.add_argument(
+        "--report-summary", action="store_true",
+        help="Show failed/error report from latest run")
+
+    parser.add_argument(
         "-o", "--report-dir",
         help="""Output reports containing results of the test run into the
         specified directory.

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -468,6 +468,8 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
     parser.add_argument("--overflow-as-errors", action="store_true",
                         help="Treat RAM/SRAM overflows as errors.")
 
+    parser.add_argument("--report-filtered", action="store_true",
+                        help="Report filtered tests.")
 
     parser.add_argument("-P", "--exclude-platform", action="append", default=[],
             help="""Exclude platforms and do not build or run any tests

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -20,6 +20,7 @@ import re
 import psutil
 from twisterlib.environment import ZEPHYR_BASE
 from twisterlib.error import TwisterException
+from twisterlib.testsuite import Status
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
 from domains import Domains
 
@@ -116,7 +117,7 @@ class Handler:
         logger.debug(f"Expected suite names:{expected_suite_names}")
         logger.debug(f"Detected suite names:{detected_suite_names}")
         if not expected_suite_names or \
-                not harness_state == "passed":
+                not harness_state == Status.PASS:
             return
         if not detected_suite_names:
             self._missing_suite_name(expected_suite_names, handler_time)
@@ -130,10 +131,10 @@ class Handler:
         Change result of performed test if problem with missing or unpropper
         suite name was occurred.
         """
-        self.instance.status = "failed"
+        self.instance.status = Status.FAIL
         self.instance.execution_time = handler_time
         for tc in self.instance.testcases:
-            tc.status = "failed"
+            tc.status = Status.FAIL
         self.instance.reason = f"Testsuite mismatch"
         logger.debug("Test suite names were not printed or some of them in " \
                      "output do not correspond with expected: %s",
@@ -145,14 +146,14 @@ class Handler:
         harness_class_name = type(harness).__name__
         if self.suite_name_check and harness_class_name == "Test":
             self._verify_ztest_suite_name(harness.state, harness.detected_suite_names, handler_time)
-            if self.instance.status == 'failed':
+            if self.instance.status == Status.FAIL:
                 return
             if not harness.matched_run_id and harness.run_id_exists:
-                self.instance.status = "failed"
+                self.instance.status = Status.FAIL
                 self.instance.execution_time = handler_time
                 self.instance.reason = "RunID mismatch"
                 for tc in self.instance.testcases:
-                    tc.status = "failed"
+                    tc.status = Status.FAIL
 
         self.record(harness)
 
@@ -299,7 +300,7 @@ class BinaryHandler(Handler):
 
         self.instance.execution_time = handler_time
         if not self.terminated and self.returncode != 0:
-            self.instance.status = "failed"
+            self.instance.status = Status.FAIL
             if run_valgrind and self.returncode == 2:
                 self.instance.reason = "Valgrind error"
             else:
@@ -308,12 +309,12 @@ class BinaryHandler(Handler):
                 self.instance.reason = "Failed"
         elif harness.state:
             self.instance.status = harness.state
-            if harness.state == "failed":
+            if harness.state == Status.FAIL:
                 self.instance.reason = "Failed"
         else:
-            self.instance.status = "failed"
+            self.instance.status = Status.FAIL
             self.instance.reason = "Timeout"
-            self.instance.add_missing_case_status("blocked", "Timeout")
+            self.instance.add_missing_case_status(Status.BLOCK, "Timeout")
 
         self._final_handle_actions(harness, handler_time)
 
@@ -459,7 +460,7 @@ class DeviceHandler(Handler):
                 time.sleep(1)
                 hardware = self.device_is_available(self.instance)
         except TwisterException as error:
-            self.instance.status = "failed"
+            self.instance.status = Status.FAIL
             self.instance.reason = str(error)
             logger.error(self.instance.reason)
         return hardware
@@ -558,11 +559,11 @@ class DeviceHandler(Handler):
                 timeout=max(flash_timeout, self.timeout)  # the worst case of no serial input
             )
         except serial.SerialException as e:
-            self.instance.status = "failed"
+            self.instance.status = Status.FAIL
             self.instance.reason = "Serial Device Error"
             logger.error("Serial device error: %s" % (str(e)))
 
-            self.instance.add_missing_case_status("blocked", "Serial Device Error")
+            self.instance.add_missing_case_status(Status.BLOCK, "Serial Device Error")
             if serial_pty and ser_pty_process:
                 ser_pty_process.terminate()
                 outs, errs = ser_pty_process.communicate()
@@ -593,7 +594,7 @@ class DeviceHandler(Handler):
                     logger.debug(stdout.decode(errors = "ignore"))
 
                     if proc.returncode != 0:
-                        self.instance.status = "error"
+                        self.instance.status = Status.ERROR
                         self.instance.reason = "Device issue (Flash error?)"
                         flash_error = True
                         with open(d_log, "w") as dlog_fp:
@@ -603,7 +604,7 @@ class DeviceHandler(Handler):
                     logger.warning("Flash operation timed out.")
                     self.terminate(proc)
                     (stdout, stderr) = proc.communicate()
-                    self.instance.status = "error"
+                    self.instance.status = Status.ERROR
                     self.instance.reason = "Device issue (Timeout)"
                     flash_error = True
 
@@ -612,7 +613,7 @@ class DeviceHandler(Handler):
 
         except subprocess.CalledProcessError:
             halt_monitor_evt.set()
-            self.instance.status = "error"
+            self.instance.status = Status.ERROR
             self.instance.reason = "Device issue (Flash error)"
             flash_error = True
 
@@ -646,14 +647,14 @@ class DeviceHandler(Handler):
         self.instance.execution_time = handler_time
         if harness.state:
             self.instance.status = harness.state
-            if harness.state == "failed":
+            if harness.state == Status.FAIL:
                 self.instance.reason = "Failed"
         elif not flash_error:
-            self.instance.status = "failed"
+            self.instance.status = Status.FAIL
             self.instance.reason = "Timeout"
 
-        if self.instance.status in ["error", "failed"]:
-            self.instance.add_missing_case_status("blocked", self.instance.reason)
+        if self.instance.status in [Status.ERROR, Status.FAIL]:
+            self.instance.add_missing_case_status(Status.BLOCK, self.instance.reason)
 
         self._final_handle_actions(harness, handler_time)
 
@@ -752,7 +753,7 @@ class QEMUHandler(Handler):
                             timeout_time = time.time() + (timeout - cpu_time)
                             continue
                 except ProcessLookupError:
-                    out_state = "failed"
+                    out_state = Status.FAIL
                     break
 
                 if not out_state:
@@ -789,7 +790,7 @@ class QEMUHandler(Handler):
                 # if we have registered a fail make sure the state is not
                 # overridden by a false success message coming from the
                 # testsuite
-                if out_state not in ['failed', 'unexpected eof', 'unexpected byte']:
+                if out_state not in [Status.FAIL, 'unexpected eof', 'unexpected byte']:
                     out_state = harness.state
 
                 # if we get some state, that means test is doing well, we reset
@@ -810,13 +811,13 @@ class QEMUHandler(Handler):
 
         handler.instance.execution_time = handler_time
         if out_state == "timeout":
-            handler.instance.status = "failed"
+            handler.instance.status = Status.FAIL
             handler.instance.reason = "Timeout"
-        elif out_state == "failed":
-            handler.instance.status = "failed"
+        elif out_state == Status.FAIL:
+            handler.instance.status = Status.FAIL
             handler.instance.reason = "Failed"
         elif out_state in ['unexpected eof', 'unexpected byte']:
-            handler.instance.status = "failed"
+            handler.instance.status = Status.FAIL
             handler.instance.reason = out_state
         else:
             handler.instance.status = out_state
@@ -895,7 +896,7 @@ class QEMUHandler(Handler):
 
                 is_timeout = True
                 self.terminate(proc)
-                if harness.state == "passed":
+                if harness.state == Status.PASS:
                     self.returncode = 0
                 else:
                     self.returncode = proc.returncode
@@ -918,13 +919,13 @@ class QEMUHandler(Handler):
         logger.debug(f"return code from QEMU ({qemu_pid}): {self.returncode}")
 
         if (self.returncode != 0 and not self.ignore_qemu_crash) or not harness.state:
-            self.instance.status = "failed"
+            self.instance.status = Status.FAIL
             if is_timeout:
                 self.instance.reason = "Timeout"
             else:
                 if not self.instance.reason:
                     self.instance.reason = "Exited with {}".format(self.returncode)
-            self.instance.add_missing_case_status("blocked")
+            self.instance.add_missing_case_status(Status.BLOCK)
 
         self._final_handle_actions(harness, 0)
 

--- a/scripts/pylib/twister/twisterlib/package.py
+++ b/scripts/pylib/twister/twisterlib/package.py
@@ -7,6 +7,18 @@ import tarfile
 import json
 import os
 
+
+class Status:
+    PASS = 'passed'
+    FAIL = 'failed'
+    ERROR = 'error'
+    SKIP = 'skipped'
+    RERUN = 'rerun'
+    NOTRUN = 'notrun'
+    BLOCK = 'blocked'
+    INPROGRESS = 'inprogress'
+    FILTER = 'filtered'
+
 class Artifacts:
 
     def __init__(self, env):
@@ -25,7 +37,7 @@ class Artifacts:
         with open(os.path.join(self.options.outdir, "twister.json"), "r") as json_test_plan:
             jtp = json.load(json_test_plan)
             for t in jtp['testsuites']:
-                if t['status'] != "filtered":
+                if t['status'] != Status.FILTER:
                     dirs.append(os.path.join(self.options.outdir, t['platform'], t['name']))
 
         dirs.extend(

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -77,9 +77,8 @@ class Reporting:
             else:
                 passes += 1
         else:
-            if not status:
-                logger.debug(f"{name}: No status")
-                ET.SubElement(eleTestcase, 'skipped', type=f"untested", message="No results captured, testsuite misconfiguration?")
+            if status == Status.NOTRUN:
+                ET.SubElement(eleTestcase, 'norun', type=f"untested", message="test was not run.")
             else:
                 logger.error(f"{name}: Unknown status '{status}'")
 
@@ -288,13 +287,8 @@ class Reporting:
                     suite["log"] = self.process_log(device_log)
                 else:
                     suite["log"] = self.process_log(build_log)
-            elif instance.status == Status.FILTER:
-                suite["status"] = Status.FILTER
-                suite["reason"] = instance.reason
-            elif instance.status == Status.PASS:
-                suite["status"] = Status.PASS
-            elif instance.status == Status.SKIP:
-                suite["status"] = Status.SKIP
+            else:
+                suite["status"] = instance.status
                 suite["reason"] = instance.reason
 
             if instance.status != Status.NOTRUN:

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -418,7 +418,7 @@ class Reporting:
             logger.warning("Deltas based on metrics from last %s" %
                            ("release" if not last_metrics else "run"))
 
-    def synopsis(self):
+    def synopsis(self, count=10):
         cnt = 0
         example_instance = None
         for instance in self.instances.values():
@@ -430,7 +430,7 @@ class Reporting:
 
                 logger.info(f"{cnt}) {instance.testsuite.name} on {instance.platform.name} {instance.status} ({instance.reason})")
                 example_instance = instance
-            if cnt == 10:
+            if count != 0 and cnt == count:
                 break
 
         if cnt and example_instance:

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -287,6 +287,8 @@ class Reporting:
                     suite["log"] = self.process_log(device_log)
                 else:
                     suite["log"] = self.process_log(build_log)
+            elif instance.status == Status.PASS:
+                suite["status"] = instance.status
             else:
                 suite["status"] = instance.status
                 suite["reason"] = instance.reason

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -477,15 +477,18 @@ class Reporting:
                 duration))
 
         total_platforms = len(self.platforms)
-        # if we are only building, do not report about tests being executed.
-        if self.platforms and not self.env.options.build_only:
-            logger.info("In total {} test cases were executed, {} skipped on {} out of total {} platforms ({:02.2f}%)".format(
-                results.cases - results.skipped_cases,
-                results.skipped_cases,
-                len(self.filtered_platforms),
-                total_platforms,
-                (100 * len(self.filtered_platforms) / len(self.platforms))
-            ))
+        pass_rate = (float(results.cases_passed) / float(results.cases))
+        logger.info("{} of {} test cases passed ({:.2%}), {} failed, {} not run, {} blocked on {} out of total {} platforms ({:02.2f}%)".format(
+            results.cases_passed,
+            results.cases,
+            pass_rate,
+            results.cases_failed,
+            results.cases_notrun,
+            results.cases_blocked,
+            len(self.filtered_platforms),
+            total_platforms,
+            (100 * len(self.filtered_platforms) / len(self.platforms))
+        ))
 
         run = results.total - built_only - results.skipped_runtime
         logger.info(f"{Fore.GREEN}{run}{Fore.RESET} test configurations executed on platforms, \

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -478,13 +478,14 @@ class Reporting:
 
         total_platforms = len(self.platforms)
         pass_rate = (float(results.cases_passed) / float(results.cases))
-        logger.info("{} of {} test cases passed ({:.2%}), {} failed, {} not run, {} blocked on {} out of total {} platforms ({:02.2f}%)".format(
+        logger.info("{} of {} test cases passed ({:.2%}), {} failed, {} not run, {} blocked, {} skipped on {} out of total {} platforms ({:02.2f}%)".format(
             results.cases_passed,
             results.cases,
             pass_rate,
             results.cases_failed,
             results.cases_notrun,
             results.cases_blocked,
+            results.cases_skipped,
             len(self.filtered_platforms),
             total_platforms,
             (100 * len(self.filtered_platforms) / len(self.platforms))

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -19,7 +19,7 @@ logger.setLevel(logging.DEBUG)
 class Reporting:
 
     def __init__(self, plan, env) -> None:
-        self.plan = plan #FIXME
+        self.plan = plan
         self.instances = plan.instances
         self.platforms = plan.platforms
         self.selected_platforms = plan.selected_platforms
@@ -280,7 +280,7 @@ class Reporting:
             if instance.status in [Status.ERROR, Status.FAIL]:
                 suite['status'] = instance.status
                 suite["reason"] = instance.reason
-                # FIXME
+                # FIXME: move this to a function
                 if os.path.exists(handler_log):
                     suite["log"] = self.process_log(handler_log)
                 elif os.path.exists(device_log):

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -458,7 +458,7 @@ class Reporting:
             pass_rate = 0
 
         logger.info(
-            "{}{} of {}{} test configurations passed ({:.2%}), {}{}{} failed, {}{}{} errored, {}{}{} warnings in {:.2f} seconds".format(
+            "{}{} of {}{} test configurations passed ({:.2%}), {}{}{} failed, {}{}{} errored, {} not run, {}{}{} warnings in {:.2f} seconds".format(
                 Fore.RED if failed else Fore.GREEN,
                 results.passed,
                 results.total - results.skipped_runtime,
@@ -470,6 +470,7 @@ class Reporting:
                 Fore.RED if results.error else Fore.RESET,
                 results.error,
                 Fore.RESET,
+                results.notrun,
                 Fore.YELLOW if self.plan.warnings else Fore.RESET,
                 self.plan.warnings,
                 Fore.RESET,

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -244,6 +244,9 @@ class Reporting:
         suites = []
 
         for instance in self.instances.values():
+            # do not capture filtered tests
+            if instance.status == Status.FILTER and not self.env.options.report_filtered:
+                continue
             suite = {}
             handler_log = os.path.join(instance.build_dir, "handler.log")
             build_log = os.path.join(instance.build_dir, "build.log")

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -454,7 +454,7 @@ class Reporting:
             elif instance.status == Status.NOTRUN:
                 built_only += 1
 
-        if results.total and results.total != results.skipped_configs:
+        if results.total and results.total != results.skipped_runtime:
             pass_rate = (float(results.passed) / float(results.total - results.skipped_runtime))
         else:
             pass_rate = 0
@@ -479,7 +479,9 @@ class Reporting:
                 duration))
 
         total_platforms = len(self.platforms)
-        pass_rate = (float(results.cases_passed) / float(results.cases))
+        pass_rate = 0
+        if results.cases:
+            pass_rate = (float(results.cases_passed) / float(results.cases))
         logger.info("{} of {} test cases passed ({:.2%}), {} failed, {} not run, {} blocked, {} skipped on {} out of total {} platforms ({:02.2f}%)".format(
             results.cases_passed,
             results.cases,

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -938,7 +938,7 @@ class ProjectBuilder(FilterBuilder):
                 else:
                     more_info = "build"
 
-                if ( instance.status in [Status.ERROR, Status.FAIL, "timeout"]
+                if ( instance.status in [Status.ERROR, Status.FAIL]
                      and hasattr(self.instance.handler, 'seed')
                      and self.instance.handler.seed is not None ):
                     more_info += "/seed: " + str(self.options.seed)
@@ -946,7 +946,7 @@ class ProjectBuilder(FilterBuilder):
                 results.done, total_tests_width, total_to_do , instance.platform.name,
                 instance.testsuite.name, status, more_info))
 
-            if instance.status in [Status.ERROR, Status.FAIL, "timeout"]:
+            if instance.status in [Status.ERROR, Status.FAIL]:
                 self.log_info_file(self.options.inline_logs)
         else:
             completed_perc = 0

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -634,6 +634,7 @@ class ProjectBuilder(FilterBuilder):
             if self.instance.run and self.instance.handler.ready:
                 pipeline.put({"op": "run", "test": self.instance})
             else:
+                self.instance.status = Status.NOTRUN
                 pipeline.put({"op": "report", "test": self.instance})
 
         # Run the generated binary using one of the supported handlers
@@ -920,6 +921,8 @@ class ProjectBuilder(FilterBuilder):
                 # test cases skipped at the test case level
                 if case.status == Status.SKIP:
                     results.skipped_cases += 1
+        elif instance.status == Status.NOTRUN:
+            status = Fore.YELLOW + "NOTRUN" + Fore.RESET
         else:
             logger.debug(f"Unknown status = {instance.status}")
             status = Fore.YELLOW + "UNKNOWN" + Fore.RESET

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -90,6 +90,9 @@ class ExecutionCounter(object):
         self._error = Value('i', 0)
         self._failed = Value('i', 0)
 
+        # testsuites that we did not run
+        self._notrun = Value('i', 0)
+
         # initialized to number of test instances
         self._total = Value('i', total)
 
@@ -131,6 +134,16 @@ class ExecutionCounter(object):
     def skipped_cases(self, value):
         with self._skipped_cases.get_lock():
             self._skipped_cases.value = value
+
+    @property
+    def notrun(self):
+        with self._notrun.get_lock():
+            return self._notrun.value
+
+    @notrun.setter
+    def notrun(self, value):
+        with self._notrun.get_lock():
+            self._notrun.value = value
 
     @property
     def error(self):
@@ -640,6 +653,7 @@ class ProjectBuilder(FilterBuilder):
                 pipeline.put({"op": "run", "test": self.instance})
             else:
                 self.instance.status = Status.NOTRUN
+                results.notrun += 1
                 self.instance.reason = "Test was built only"
                 pipeline.put({"op": "report", "test": self.instance})
 

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -640,6 +640,7 @@ class ProjectBuilder(FilterBuilder):
                 pipeline.put({"op": "run", "test": self.instance})
             else:
                 self.instance.status = Status.NOTRUN
+                self.instance.reason = "Test was built only"
                 pipeline.put({"op": "report", "test": self.instance})
 
         # Run the generated binary using one of the supported handlers

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -42,6 +42,7 @@ from twisterlib.log_helper import log_command
 from twisterlib.testinstance import TestInstance
 from twisterlib.testplan import change_skip_to_error_if_integration
 from twisterlib.harness import HarnessImporter, Pytest
+from twisterlib.testsuite import Status
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
@@ -271,9 +272,9 @@ class CMake:
         if p.returncode == 0:
             msg = "Finished building %s for %s" % (self.source_dir, self.platform.name)
 
-            self.instance.status = "passed"
+            self.instance.status = Status.PASS
             if not self.instance.run:
-                self.instance.add_missing_case_status("skipped", "Test was built only")
+                self.instance.add_missing_case_status(Status.SKIP, "Test was built only")
             results = {'msg': msg, "returncode": p.returncode, "instance": self.instance}
 
             if out:
@@ -296,15 +297,15 @@ class CMake:
                 imgtool_overflow_found = re.findall(r"Error: Image size \(.*\) \+ trailer \(.*\) exceeds requested size", log_msg)
                 if overflow_found and not self.options.overflow_as_errors:
                     logger.debug("Test skipped due to {} Overflow".format(overflow_found[0]))
-                    self.instance.status = "skipped"
+                    self.instance.status = Status.SKIP
                     self.instance.reason = "{} overflow".format(overflow_found[0])
                     change_skip_to_error_if_integration(self.options, self.instance)
                 elif imgtool_overflow_found and not self.options.overflow_as_errors:
-                    self.instance.status = "skipped"
+                    self.instance.status = Status.SKIP
                     self.instance.reason = "imgtool overflow"
                     change_skip_to_error_if_integration(self.options, self.instance)
                 else:
-                    self.instance.status = "error"
+                    self.instance.status = Status.ERROR
                     self.instance.reason = "Build failure"
 
             results = {
@@ -390,7 +391,7 @@ class CMake:
             results = {'msg': msg, 'filter': filter_results}
 
         else:
-            self.instance.status = "error"
+            self.instance.status = Status.ERROR
             self.instance.reason = "Cmake build failure"
 
             for tc in self.instance.testcases:
@@ -565,16 +566,16 @@ class ProjectBuilder(FilterBuilder):
 
         if op == "filter":
             res = self.cmake(filter_stages=self.instance.filter_stages)
-            if self.instance.status in ["failed", "error"]:
+            if self.instance.status in [Status.FAIL, Status.ERROR]:
                 pipeline.put({"op": "report", "test": self.instance})
             else:
                 # Here we check the dt/kconfig filter results coming from running cmake
                 if self.instance.name in res['filter'] and res['filter'][self.instance.name]:
                     logger.debug("filtering %s" % self.instance.name)
-                    self.instance.status = "filtered"
+                    self.instance.status = Status.FILTER
                     self.instance.reason = "runtime filter"
                     results.skipped_runtime += 1
-                    self.instance.add_missing_case_status("skipped")
+                    self.instance.add_missing_case_status(Status.SKIP)
                     pipeline.put({"op": "report", "test": self.instance})
                 else:
                     pipeline.put({"op": "cmake", "test": self.instance})
@@ -582,20 +583,20 @@ class ProjectBuilder(FilterBuilder):
         # The build process, call cmake and build with configured generator
         if op == "cmake":
             res = self.cmake()
-            if self.instance.status in ["failed", "error"]:
+            if self.instance.status in [Status.FAIL, Status.ERROR]:
                 pipeline.put({"op": "report", "test": self.instance})
             elif self.options.cmake_only:
-                if self.instance.status is None:
-                    self.instance.status = "passed"
+                if self.instance.status == Status.NOTRUN:
+                    self.instance.status = Status.PASS
                 pipeline.put({"op": "report", "test": self.instance})
             else:
                 # Here we check the runtime filter results coming from running cmake
                 if self.instance.name in res['filter'] and res['filter'][self.instance.name]:
                     logger.debug("filtering %s" % self.instance.name)
-                    self.instance.status = "filtered"
+                    self.instance.status = Status.FILTER
                     self.instance.reason = "runtime filter"
                     results.skipped_runtime += 1
-                    self.instance.add_missing_case_status("skipped")
+                    self.instance.add_missing_case_status(Status.SKIP)
                     pipeline.put({"op": "report", "test": self.instance})
                 else:
                     pipeline.put({"op": "build", "test": self.instance})
@@ -604,18 +605,18 @@ class ProjectBuilder(FilterBuilder):
             logger.debug("build test: %s" % self.instance.name)
             res = self.build()
             if not res:
-                self.instance.status = "error"
+                self.instance.status = Status.ERROR
                 self.instance.reason = "Build Failure"
                 pipeline.put({"op": "report", "test": self.instance})
             else:
                 # Count skipped cases during build, for example
                 # due to ram/rom overflow.
-                if  self.instance.status == "skipped":
+                if  self.instance.status == Status.SKIP:
                     results.skipped_runtime += 1
-                    self.instance.add_missing_case_status("skipped", self.instance.reason)
+                    self.instance.add_missing_case_status(Status.SKIP, self.instance.reason)
 
                 if res.get('returncode', 1) > 0:
-                    self.instance.add_missing_case_status("blocked", self.instance.reason)
+                    self.instance.add_missing_case_status(Status.BLOCK, self.instance.reason)
                     pipeline.put({"op": "report", "test": self.instance})
                 else:
                     logger.debug(f"Determine test cases for test instance: {self.instance.name}")
@@ -624,7 +625,7 @@ class ProjectBuilder(FilterBuilder):
                         pipeline.put({"op": "gather_metrics", "test": self.instance})
                     except BuildError as e:
                         logger.error(str(e))
-                        self.instance.status = "error"
+                        self.instance.status = Status.ERROR
                         self.instance.reason = str(e)
                         pipeline.put({"op": "report", "test": self.instance})
 
@@ -664,8 +665,8 @@ class ProjectBuilder(FilterBuilder):
             if not self.options.coverage:
                 if self.options.prep_artifacts_for_testing:
                     pipeline.put({"op": "cleanup", "mode": "device", "test": self.instance})
-                elif self.options.runtime_artifact_cleanup == "pass" and self.instance.status == "passed":
-                    pipeline.put({"op": "cleanup", "mode": "passed", "test": self.instance})
+                elif self.options.runtime_artifact_cleanup == "pass" and self.instance.status == Status.PASS:
+                    pipeline.put({"op": "cleanup", "mode": Status.PASS, "test": self.instance})
                 elif self.options.runtime_artifact_cleanup == "all":
                     pipeline.put({"op": "cleanup", "mode": "all", "test": self.instance})
 
@@ -673,7 +674,7 @@ class ProjectBuilder(FilterBuilder):
             mode = message.get("mode")
             if mode == "device":
                 self.cleanup_device_testing_artifacts()
-            elif mode == "passed" or (mode == "all" and self.instance.reason != "Cmake build failure"):
+            elif mode == Status.PASS or (mode == "all" and self.instance.reason != "Cmake build failure"):
                 self.cleanup_artifacts()
 
     def determine_testcases(self, results):
@@ -887,8 +888,8 @@ class ProjectBuilder(FilterBuilder):
         if results.iteration == 1:
             results.cases += len(instance.testcases)
 
-        if instance.status in ["error", "failed"]:
-            if instance.status == "error":
+        if instance.status in [Status.ERROR, Status.FAIL]:
+            if instance.status == Status.ERROR:
                 results.error += 1
                 txt = " ERROR "
             else:
@@ -907,17 +908,17 @@ class ProjectBuilder(FilterBuilder):
                         instance.reason))
             if not self.options.verbose:
                 self.log_info_file(self.options.inline_logs)
-        elif instance.status in ["skipped", "filtered"]:
+        elif instance.status in [Status.SKIP, Status.FILTER]:
             status = Fore.YELLOW + "SKIPPED" + Fore.RESET
             results.skipped_configs += 1
             # test cases skipped at the test instance level
             results.skipped_cases += len(instance.testsuite.testcases)
-        elif instance.status == "passed":
+        elif instance.status == Status.PASS:
             status = Fore.GREEN + "PASSED" + Fore.RESET
             results.passed += 1
             for case in instance.testcases:
                 # test cases skipped at the test case level
-                if case.status == 'skipped':
+                if case.status == Status.SKIP:
                     results.skipped_cases += 1
         else:
             logger.debug(f"Unknown status = {instance.status}")
@@ -926,7 +927,7 @@ class ProjectBuilder(FilterBuilder):
         if self.options.verbose:
             if self.options.cmake_only:
                 more_info = "cmake"
-            elif instance.status in ["skipped", "filtered"]:
+            elif instance.status in [Status.SKIP, Status.FILTER]:
                 more_info = instance.reason
             else:
                 if instance.handler.ready and instance.run:
@@ -937,7 +938,7 @@ class ProjectBuilder(FilterBuilder):
                 else:
                     more_info = "build"
 
-                if ( instance.status in ["error", "failed", "timeout", "flash_error"]
+                if ( instance.status in [Status.ERROR, Status.FAIL, "timeout", "flash_error"]
                      and hasattr(self.instance.handler, 'seed')
                      and self.instance.handler.seed is not None ):
                     more_info += "/seed: " + str(self.options.seed)
@@ -945,7 +946,7 @@ class ProjectBuilder(FilterBuilder):
                 results.done, total_tests_width, total_to_do , instance.platform.name,
                 instance.testsuite.name, status, more_info))
 
-            if instance.status in ["error", "failed", "timeout"]:
+            if instance.status in [Status.ERROR, Status.FAIL, "timeout"]:
                 self.log_info_file(self.options.inline_logs)
         else:
             completed_perc = 0
@@ -1058,7 +1059,7 @@ class ProjectBuilder(FilterBuilder):
 
     @staticmethod
     def calc_size(instance: TestInstance, from_buildlog: bool):
-        if instance.status not in ["error", "failed", "skipped"]:
+        if instance.status not in [Status.ERROR, Status.FAIL, Status.SKIP]:
             if not instance.platform.type in ["native", "qemu", "unit"]:
                 generate_warning = bool(instance.platform.type == "mcu")
                 size_calc = instance.calculate_sizes(from_buildlog=from_buildlog, generate_warning=generate_warning)
@@ -1169,12 +1170,12 @@ class TwisterRunner:
         the static filter stats. So need to prepare them before pipline starts.
         '''
         for instance in self.instances.values():
-            if instance.status == 'filtered' and not instance.reason == 'runtime filter':
+            if instance.status == Status.FILTER and not instance.reason == 'runtime filter':
                 self.results.skipped_filter += 1
                 self.results.skipped_configs += 1
                 self.results.skipped_cases += len(instance.testsuite.testcases)
                 self.results.cases += len(instance.testsuite.testcases)
-            elif instance.status == 'error':
+            elif instance.status == Status.ERROR:
                 self.results.error += 1
 
     def show_brief(self):
@@ -1190,15 +1191,15 @@ class TwisterRunner:
             if build_only:
                 instance.run = False
 
-            no_retry_statuses = ['passed', 'skipped', 'filtered']
+            no_retry_statuses = [Status.PASS, Status.SKIP, Status.FILTER]
             if not retry_build_errors:
-                no_retry_statuses.append("error")
+                no_retry_statuses.append(Status.ERROR)
 
             if instance.status not in no_retry_statuses:
                 logger.debug(f"adding {instance.name}")
                 if instance.status:
                     instance.retries += 1
-                instance.status = None
+                instance.status = Status.NOTRUN
 
                 # Check if cmake package_helper script can be run in advance.
                 instance.filter_stages = []

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1276,6 +1276,7 @@ class TwisterRunner:
                 self.results.cases_filtered += len(instance.testsuite.testcases)
                 continue
             elif instance.status == Status.ERROR:
+                logger.error(f"{instance.name}: {instance.reason}")
                 self.results.error += 1
 
             self.results.total += 1

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -964,7 +964,7 @@ class ProjectBuilder(FilterBuilder):
 
     def count_testcase_states(self, instance, results):
         for t in instance.testcases:
-            if t.status == Status.NOTRUN and instance.status == Status.NOTRUN:
+            if t.status == Status.NOTRUN and instance.status in [Status.NOTRUN, Status.ERROR ]:
                 results.cases_notrun +=1
             elif t.status == Status.NOTRUN and instance.status == Status.FAIL:
                 results.cases_blocked +=1

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1362,8 +1362,7 @@ class TwisterRunner:
 
         processes = []
 
-        for job in range(self.jobs):
-            logger.debug(f"Launch process {job}")
+        for _ in range(self.jobs):
             p = Process(target=self.pipeline_mgr, args=(pipeline, done, lock, self.results, ))
             processes.append(p)
             p.start()

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -929,7 +929,7 @@ class ProjectBuilder(FilterBuilder):
                         instance.reason))
             if not self.options.verbose:
                 self.log_info_file(self.options.inline_logs)
-        elif instance.status in [Status.SKIP]:
+        elif instance.status in [Status.FILTER]:
             status = Fore.YELLOW + "FILTERED" + Fore.RESET
             results.skipped_configs += 1
             # test cases skipped at the test instance level

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -112,7 +112,6 @@ class ExecutionCounter(object):
         print("--------------------------------")
         print(f"Total test suites: {self.total}") # actually test instances
         print(f"Total test cases: {self.cases}")
-        print(f"Executed test cases: {self.cases - self.cases_filtered}")
         print(f"Skipped test cases: {self.cases_filtered}")
         print(f"Completed test suites: {self.done}")
         print(f"Passing test suites: {self.passed}")

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -938,7 +938,7 @@ class ProjectBuilder(FilterBuilder):
                 else:
                     more_info = "build"
 
-                if ( instance.status in [Status.ERROR, Status.FAIL, "timeout", "flash_error"]
+                if ( instance.status in [Status.ERROR, Status.FAIL, "timeout"]
                      and hasattr(self.instance.handler, 'seed')
                      and self.instance.handler.seed is not None ):
                     more_info += "/seed: " + str(self.options.seed)

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -24,6 +24,7 @@ from twisterlib.handlers import (
     SUPPORTED_SIMS,
     SUPPORTED_SIMS_IN_PYTEST,
 )
+from twisterlib.testsuite import Status
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
@@ -44,7 +45,7 @@ class TestInstance:
         self.testsuite: TestSuite = testsuite
         self.platform: Platform = platform
 
-        self.status = None
+        self.status = Status.NOTRUN
         self.reason = "Unknown"
         self.metrics = dict()
         self.handler = None
@@ -66,7 +67,7 @@ class TestInstance:
 
     def add_filter(self, reason, filter_type):
         self.filters.append({'type': filter_type, 'reason': reason })
-        self.status = "filtered"
+        self.status = Status.FILTER
         self.reason = reason
         self.filter_type = filter_type
 
@@ -86,8 +87,8 @@ class TestInstance:
 
     def add_missing_case_status(self, status, reason=None):
         for case in self.testcases:
-            if case.status == 'started':
-                case.status = "failed"
+            if case.status == Status.INPROGRESS:
+                case.status = Status.FAIL
             elif not case.status:
                 case.status = status
                 if reason:

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -204,7 +204,7 @@ class TestPlan:
         else:
             last_run = os.path.join(self.options.outdir, "twister.json")
 
-        if self.options.only_failed:
+        if self.options.only_failed or self.options.report_summary:
             self.load_from_file(last_run)
             self.selected_platforms = set(p.platform.name for p in self.instances.values())
         elif self.options.load_tests:
@@ -580,8 +580,8 @@ class TestPlan:
 
                 status = ts.get('status', None)
                 reason = ts.get("reason", "Unknown")
-                if status in [Status.ERROR, Status.FAIL]:
-                    instance.status = None
+                if status in [Status.ERROR, Status.FAIL] and False:
+                    instance.status = Status.NOTRUN
                     instance.reason = None
                     instance.retries += 1
                 # test marked as passed (built only) but can run when

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -18,6 +18,17 @@ from twisterlib.error import TwisterException, TwisterRuntimeError
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
 
+class Status:
+    PASS = 'passed'
+    FAIL = 'failed'
+    ERROR = 'error'
+    SKIP = 'skipped'
+    RERUN = 'rerun'
+    NOTRUN = 'notrun'
+    BLOCK = 'blocked'
+    INPROGRESS = 'inprogress'
+    FILTER = 'filtered'
+
 class ScanPathResult:
     """Result of the scan_tesuite_path function call.
 
@@ -327,8 +338,8 @@ class TestCase(DisablePyTestCollectionMixin):
     def __init__(self, name=None, testsuite=None):
         self.duration = 0
         self.name = name
-        self.status = None
-        self.reason = None
+        self.status = Status.NOTRUN
+        self.reason = ""
         self.testsuite = testsuite
         self.output = ""
         self.freeform = False

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -316,7 +316,6 @@ def scan_testsuite_path(testsuite_path):
             "call to 'ztest_run_registered_test_suites()'"
         logger.error(warning)
         raise TwisterRuntimeError(warning)
-
     return subcases, ztest_suite_names
 
 def _find_src_dir_path(test_dir_path):

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -10,7 +10,7 @@ import logging
 import contextlib
 import mmap
 import glob
-from typing import List
+from typing import List, Dict
 from twisterlib.mixins import DisablePyTestCollectionMixin
 from twisterlib.environment import canonical_zephyr_base
 from twisterlib.error import TwisterException, TwisterRuntimeError
@@ -52,13 +52,15 @@ class ScanPathResult:
                  has_registered_test_suites: bool = False,
                  has_run_registered_test_suites: bool = False,
                  has_test_main: bool = False,
-                 ztest_suite_names: List[str] = []):
+                 ztest_suite_names: List[str] = [],
+                 test_map: Dict[str, List[str]] = None):
         self.matches = matches
         self.warnings = warnings
         self.has_registered_test_suites = has_registered_test_suites
         self.has_run_registered_test_suites = has_run_registered_test_suites
         self.has_test_main = has_test_main
         self.ztest_suite_names = ztest_suite_names
+        self.test_map = test_map
 
     def __eq__(self, other):
         if not isinstance(other, ScanPathResult):
@@ -127,6 +129,7 @@ def scan_file(inf_name):
             new_suite_regex_matches = \
                 [m for m in new_suite_regex.finditer(main_c)]
 
+            tmap = {}
             if registered_suite_regex_matches:
                 has_registered_test_suites = True
             if registered_suite_run_regex.search(main_c):
@@ -137,18 +140,22 @@ def scan_file(inf_name):
             if regular_suite_regex_matches:
                 ztest_suite_names = \
                     _extract_ztest_suite_names(regular_suite_regex_matches)
-                testcase_names, warnings = \
+                tmap, testcase_names, warnings = \
                     _find_regular_ztest_testcases(main_c, regular_suite_regex_matches, has_registered_test_suites)
             elif registered_suite_regex_matches:
                 ztest_suite_names = \
                     _extract_ztest_suite_names(registered_suite_regex_matches)
-                testcase_names, warnings = \
+                tmap, testcase_names, warnings = \
                     _find_regular_ztest_testcases(main_c, registered_suite_regex_matches, has_registered_test_suites)
             elif new_suite_regex_matches or new_suite_testcase_regex_matches:
+                tmap, testcase_names, warnings = \
+                    _find_new_ztest_testcases(main_c)
                 ztest_suite_names = \
                     _extract_ztest_suite_names(new_suite_regex_matches)
-                testcase_names, warnings = \
-                    _find_new_ztest_testcases(main_c)
+                for zt in ztest_suite_names:
+                    if not tmap.get(zt):
+                        tmap[zt] = []
+
             else:
                 # can't find ztest_test_suite, maybe a client, because
                 # it includes ztest.h
@@ -161,7 +168,8 @@ def scan_file(inf_name):
                 has_registered_test_suites=has_registered_test_suites,
                 has_run_registered_test_suites=has_run_registered_test_suites,
                 has_test_main=has_test_main,
-                ztest_suite_names=ztest_suite_names)
+                ztest_suite_names=ztest_suite_names,
+                test_map=tmap)
 
 def _extract_ztest_suite_names(suite_regex_matches):
     ztest_suite_names = \
@@ -201,7 +209,7 @@ def _find_regular_ztest_testcases(search_area, suite_regex_matches, is_registere
     search_start, search_end = \
         _get_search_area_boundary(search_area, suite_regex_matches, is_registered_test_suite)
     limited_search_area = search_area[search_start:search_end]
-    testcase_names, warnings = \
+    tmap, testcase_names, warnings = \
         _find_ztest_testcases(limited_search_area, testcase_regex)
 
     achtung_matches = re.findall(achtung_regex, limited_search_area)
@@ -209,7 +217,7 @@ def _find_regular_ztest_testcases(search_area, suite_regex_matches, is_registere
         achtung = ", ".join(sorted({match.decode() for match in achtung_matches},reverse = True))
         warnings = f"found invalid {achtung} in ztest_test_suite()"
 
-    return testcase_names, warnings
+    return tmap, testcase_names, warnings
 
 
 def _get_search_area_boundary(search_area, suite_regex_matches, is_registered_test_suite):
@@ -255,6 +263,18 @@ def _find_ztest_testcases(search_area, testcase_regex):
     """
     testcase_regex_matches = \
         [m for m in testcase_regex.finditer(search_area)]
+
+    a = {}
+    for m in testcase_regex_matches:
+        try:
+            s = m.group("suite_name")
+        except IndexError:
+            continue
+        tc = m.group("testcase_name").decode("UTF-8").replace("test_", "", 1)
+        tests = a.get(s, [])
+        tests.append(tc)
+        a[s.decode("UTF-8")] = tests
+
     testcase_names = \
         [m.group("testcase_name") for m in testcase_regex_matches]
     testcase_names = [name.decode("UTF-8") for name in testcase_names]
@@ -265,7 +285,7 @@ def _find_ztest_testcases(search_area, testcase_regex):
     testcase_names = \
         [tc_name.replace("test_", "", 1) for tc_name in testcase_names]
 
-    return testcase_names, warnings
+    return a, testcase_names, warnings
 
 
 def scan_testsuite_path(testsuite_path):
@@ -276,6 +296,8 @@ def scan_testsuite_path(testsuite_path):
     ztest_suite_names = []
 
     src_dir_path = _find_src_dir_path(testsuite_path)
+
+    testsuites = {}
     for filename in glob.glob(os.path.join(src_dir_path, "*.c*")):
         try:
             result: ScanPathResult = scan_file(filename)
@@ -293,6 +315,14 @@ def scan_testsuite_path(testsuite_path):
                 has_test_main = True
             if result.ztest_suite_names:
                 ztest_suite_names += result.ztest_suite_names
+
+
+            if result.test_map:
+                for k in result.test_map:
+                    if not testsuites.get(k):
+                        testsuites[k] = result.test_map.get(k)
+                    else:
+                        testsuites[k] += result.test_map.get(k)
 
         except ValueError as e:
             logger.error("%s: can't find: %s" % (filename, e))

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -74,7 +74,7 @@ def main(options):
 
     previous_results = None
     # Cleanup
-    if options.no_clean or options.only_failed or options.test_only:
+    if options.no_clean or options.only_failed or options.test_only or options.report_summary:
         if os.path.exists(options.outdir):
             print("Keeping artifacts untouched")
     elif options.last_metrics:
@@ -181,6 +181,10 @@ def main(options):
 
     if options.short_build_path:
         tplan.create_build_dir_links()
+
+    if options.report_summary:
+        report.synopsis(0)
+        return 0
 
     runner = TwisterRunner(tplan.instances, tplan.testsuites, env)
     runner.duts = hwm.duts

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -19,6 +19,7 @@ from twisterlib.coverage import run_coverage
 from twisterlib.runner import TwisterRunner
 from twisterlib.environment import TwisterEnv
 from twisterlib.package import Artifacts
+from twisterlib.testsuite import Status
 
 logger = logging.getLogger("twister")
 logger.setLevel(logging.DEBUG)
@@ -142,7 +143,7 @@ def main(options):
         # command line
 
         for i in tplan.instances.values():
-            if i.status == "filtered":
+            if i.status == Status.FILTER:
                 if options.platform and i.platform.name not in options.platform:
                     continue
                 logger.debug(

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -12,6 +12,7 @@ from twisterlib.harness import Pytest
 from twisterlib.testsuite import TestSuite
 from twisterlib.testinstance import TestInstance
 from twisterlib.platform import Platform
+from twisterlib.testsuite import Status
 
 
 @pytest.fixture
@@ -102,10 +103,10 @@ def test_if_report_with_error(pytester, testinstance: TestInstance):
     pytest_harness._update_test_status()
 
     assert pytest_harness.state == "failed"
-    assert testinstance.status == "failed"
+    assert testinstance.status == Status.FAIL
     assert len(testinstance.testcases) == 2
     for tc in testinstance.testcases:
-        assert tc.status == "failed"
+        assert tc.status == Status.FAIL
         assert tc.output
         assert tc.reason
 
@@ -136,7 +137,7 @@ def test_if_report_with_skip(pytester, testinstance: TestInstance):
     pytest_harness._update_test_status()
 
     assert pytest_harness.state == "skipped"
-    assert testinstance.status == "skipped"
+    assert testinstance.status == Status.SKIP
     assert len(testinstance.testcases) == 2
     for tc in testinstance.testcases:
-        assert tc.status == "skipped"
+        assert tc.status == Status.SKIP

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
 from twisterlib.harness import Gtest
 from twisterlib.testinstance import TestInstance
+from twisterlib.testsuite import Status
 
 GTEST_START_STATE = " RUN      "
 GTEST_PASS_STATE = "       OK "
@@ -70,7 +71,7 @@ def test_gtest_start_test(gtest):
     assert gtest.detected_suite_names[0] == "suite_name"
     assert gtest.instance.get_case_by_name("id.suite_name.test_name") is not None
     assert (
-        gtest.instance.get_case_by_name("id.suite_name.test_name").status == "started"
+        gtest.instance.get_case_by_name("id.suite_name.test_name").status == Status.INPROGRESS
     )
 
 
@@ -111,7 +112,7 @@ def test_gtest_failed(gtest):
     assert len(gtest.detected_suite_names) == 1
     assert gtest.detected_suite_names[0] == "suite_name"
     assert gtest.instance.get_case_by_name("id.suite_name.test_name") is not None
-    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == "failed"
+    assert gtest.instance.get_case_by_name("id.suite_name.test_name").status == Status.FAIL
 
 
 def test_gtest_all_pass(gtest):
@@ -161,7 +162,7 @@ def test_gtest_one_fail(gtest):
     assert gtest.instance.get_case_by_name("id.suite_name.test0") is not None
     assert gtest.instance.get_case_by_name("id.suite_name.test0").status == "passed"
     assert gtest.instance.get_case_by_name("id.suite_name.test1") is not None
-    assert gtest.instance.get_case_by_name("id.suite_name.test1").status == "failed"
+    assert gtest.instance.get_case_by_name("id.suite_name.test1").status == Status.FAIL
 
 
 def test_gtest_missing_result(gtest):

--- a/scripts/tests/twister/test_testplan_class.py
+++ b/scripts/tests/twister/test_testplan_class.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
 from twisterlib.testplan import TestPlan
 from twisterlib.testinstance import TestInstance
-from twisterlib.testsuite import TestSuite
+from twisterlib.testsuite import TestSuite, Status
 from twisterlib.platform import Platform
 from twisterlib.quarantine import Quarantine
 
@@ -168,7 +168,7 @@ def test_apply_filters_part1(class_testplan, all_testsuites_dict, platforms_list
         plan.apply_filters(exclude_platform=['demo_board_1'],
                                                  platform=['demo_board_2'])
 
-    filtered_instances = list(filter(lambda item:  item.status == "filtered", plan.instances.values()))
+    filtered_instances = list(filter(lambda item:  item.status == Status.FILTER, plan.instances.values()))
     for d in filtered_instances:
         assert d.reason == expected_discards
 
@@ -202,7 +202,7 @@ def test_apply_filters_part2(class_testplan, all_testsuites_dict,
             ]
         }
     class_testplan.apply_filters(**kwargs)
-    filtered_instances = list(filter(lambda item:  item.status == "filtered", class_testplan.instances.values()))
+    filtered_instances = list(filter(lambda item:  item.status == Status.FILTER, class_testplan.instances.values()))
     for d in filtered_instances:
         assert d.reason == expected_discards
 
@@ -233,7 +233,7 @@ def test_apply_filters_part3(class_testplan, all_testsuites_dict, platforms_list
     class_testplan.apply_filters(exclude_platform=['demo_board_1'],
                                              platform=['demo_board_2'])
 
-    filtered_instances = list(filter(lambda item:  item.status == "filtered", class_testplan.instances.values()))
+    filtered_instances = list(filter(lambda item:  item.status == Status.FILTER, class_testplan.instances.values()))
     assert not filtered_instances
 
 def test_add_instances(test_data, class_env, all_testsuites_dict, platforms_list):
@@ -325,14 +325,14 @@ def test_quarantine(class_testplan, platforms_list, test_data,
     for testname, instance in class_testplan.instances.items():
         if quarantine_verify:
             if testname in expected_val:
-                assert not instance.status
+                assert instance.status == Status.NOTRUN
             else:
-                assert instance.status == 'filtered'
+                assert instance.status == Status.FILTER
                 assert instance.reason == "Not under quarantine"
         else:
             print(testname)
             if testname in expected_val:
-                assert instance.status == 'filtered'
+                assert instance.status == Status.FILTER
                 assert instance.reason == "Quarantine: " + expected_val[testname]
             else:
-                assert not instance.status
+                assert instance.status == Status.NOTRUN


### PR DESCRIPTION
Overhaul of twister status and how we count results and report them.

This partial implementation of #58070.


- twister: use class for test status
- twister: remove flash_error as possible status
- twister: remove timeout as a possible status
- twister: mark tests that only build as NOTRUN
- twister: rework stats and reporting
- twister: use NOTRUN as a status
- twister: count not run tests
- twister: fix filtered reporting on screen
- twister: better accounting for testcases
- twister: process status per testcase
- twister: count skipped testcases
- twister: detect ztest suites and their testcases
- twister: improve testcase parsing
- twister: do not set reason for passed to Unknown
- twister: fix passrate calc when cases = 0
- twister: error message on integration platform issues
- twister: do not include filtered scnearios in report
- twister: fix pass rate calculation and avoid div by 0
- twister: error on filtered integration platforms
- twister: do not log launched jobs
- twister: cleanup filter routine
- twister: show synopsis on demand
- twister: remove misleading debug message about executed tests
