### PR TITLE
doc: lwm2m: samples: fix formatting issue

### DIFF
--- a/samples/net/lwm2m_client/README.rst
+++ b/samples/net/lwm2m_client/README.rst
@@ -34,26 +34,28 @@ Building and Running
 There are configuration files for various setups in the
 samples/net/lwm2m_client directory:
 
-- :file:`prj.conf`
-  This is the standard default config.
+.. list-table::
 
-- :file:`overlay-bootstrap.conf`
-  This overlay config can be added to enable LWM2M Bootstrap support.
+    * - :file:`prj.conf`
+      - This is the standard default config.
 
-- :file:`overlay-ot.conf`
-  This overlay config can be added for OpenThread support.
+    * - :file:`overlay-bootstrap.conf`
+      - This overlay config can be added to enable LWM2M Bootstrap support.
 
-- :file:`overlay-dtls.conf`
-  This overlay config can be added for DTLS support via MBEDTLS.
+    * - :file:`overlay-ot.conf`
+      - This overlay config can be added for OpenThread support.
 
-- :file:`overlay-bt.conf`
-  This overlay config can be added to enable Bluetooth networking support.
+    * - :file:`overlay-dtls.conf`
+      - This overlay config can be added for DTLS support via MBEDTLS.
 
-- :file:`overlay-queue.conf`
-  This overlay config can be added to enable LWM2M Queue Mode support.
+    * - :file:`overlay-bt.conf`
+      - This overlay config can be added to enable Bluetooth networking support.
 
-- :file:`overlay-tickless.conf`
-   This overlay config can be used to stop LwM2M engine for periodically interrupting socket polls. It can have significant effect on power usage on certain devices.
+    * - :file:`overlay-queue.conf`
+      - This overlay config can be added to enable LWM2M Queue Mode support.
+
+    * - :file:`overlay-tickless.conf`
+      - This overlay config can be used to stop LwM2M engine for periodically interrupting socket polls. It can have significant effect on power usage on certain devices.
 
 Build the lwm2m-client sample application like this:
 


### PR DESCRIPTION
A sneaky whitespace was causing inconsistent rendering in the list of available overlays for the recently added overlay-tickless entry.
Fixed by switching to a list table which is arguably now even easier to read.

before:

<img width="639" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/128251/5380b3a8-0d3f-4feb-aabe-fd5237928e46">

after: 

<img width="634" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/128251/b6045b21-0f78-4669-a787-a5f6f471da3b">
