### PR TITLE
Bluetooth: Shell: Fix the command bt adv-data

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1961,6 +1961,8 @@ static int cmd_adv_data(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
+	ad_len += *data_len;
+
 	err = bt_le_ext_adv_set_data(adv, ad_len > 0 ? ad : NULL, ad_len,
 					  sd_len > 0 ? sd : NULL, sd_len);
 	if (err) {


### PR DESCRIPTION
The command did no longer set the user specified data if the user specified more than 1 AD field.

We were using the return value of ad_init() to set the number of AD fields. This did not take into account the number of existing data fields. By chance this usually returned 1.