### PR TITLE
west.yml: update modules/hal/st with new sensor/vl53l1x version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -224,7 +224,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: 9b128caf3e7b2e750169b880e83f210ea2213473
+      revision: fb8e79d1a261fd02aadff7c142729f1954163cf3
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
Update the ../modules/hal/st/sensor/vl53l1x to version 2.4.5

Requires https://github.com/zephyrproject-rtos/hal_st/pull/17

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/61320
