### PR TITLE
samples: hello_world: use printf

### DIFF
--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
+#include <stdio.h>
 
 int main(void)
 {
-	printk("Hello World! %s\n", CONFIG_BOARD);
+	printf("Hello World! %s\n", CONFIG_BOARD);
 	return 0;
 }


### PR DESCRIPTION
Instead of printk. This change aligns the sample a bit more to the canonical "hello world" sample in C. Also, samples should, in general, be as portable as possible.