### PR TITLE
drivers: spi_nrfx_spis: Enable required SPI_SLAVE option in Kconfig

### DIFF
--- a/drivers/spi/Kconfig.nrfx
+++ b/drivers/spi/Kconfig.nrfx
@@ -30,6 +30,7 @@ config SPI_NRFX_SPIM
 config SPI_NRFX_SPIS
 	def_bool y
 	depends on DT_HAS_NORDIC_NRF_SPIS_ENABLED
+	select SPI_SLAVE
 	select NRFX_SPIS0 if HAS_HW_NRF_SPIS0
 	select NRFX_SPIS1 if HAS_HW_NRF_SPIS1
 	select NRFX_SPIS2 if HAS_HW_NRF_SPIS2


### PR DESCRIPTION
This is a follow-up to commit fa609e58449392ffd2b60e5bb9b59ef8e959762a.

This driver implements SPI slave operations only and cannot be used without the corresponding Kconfig option enabled.