### PR TITLE
boards: nxp_adsp_imx8m: add tag for openamp_rsc_table sample test

### DIFF
--- a/boards/xtensa/nxp_adsp_imx8m/nxp_adsp_imx8m.yaml
+++ b/boards/xtensa/nxp_adsp_imx8m/nxp_adsp_imx8m.yaml
@@ -8,5 +8,6 @@ testing:
   only_tags:
     - kernel
     - sof
+    - ipm
 supported:
   - uart


### PR DESCRIPTION
Add ipm tag for testing openamp_rsc_table sample for nxp_adsp_imx8m platform.