### PR TITLE
tests: Fix app_kernel benchmark to run on cavs25

### DIFF
--- a/tests/benchmarks/app_kernel/src/fifo_b.c
+++ b/tests/benchmarks/app_kernel/src/fifo_b.c
@@ -20,15 +20,15 @@ void queue_test(void)
 	uint32_t et; /* elapsed time */
 	int i;
 
-	PRINT_STRING(dashline, output_file);
+	PRINT_STRING(dashline);
 	et = BENCH_START();
 	for (i = 0; i < NR_OF_FIFO_RUNS; i++) {
 		k_msgq_put(&DEMOQX1, data_bench, K_FOREVER);
 	}
 	et = TIME_STAMP_DELTA_GET(et);
 
-	PRINT_F(output_file, FORMAT, "enqueue 1 byte msg in FIFO",
-			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_FIFO_RUNS));
+	PRINT_F(FORMAT, "enqueue 1 byte msg in FIFO",
+		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_FIFO_RUNS));
 
 	et = BENCH_START();
 	for (i = 0; i < NR_OF_FIFO_RUNS; i++) {
@@ -37,8 +37,8 @@ void queue_test(void)
 	et = TIME_STAMP_DELTA_GET(et);
 	check_result();
 
-	PRINT_F(output_file, FORMAT, "dequeue 1 byte msg in FIFO",
-			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_FIFO_RUNS));
+	PRINT_F(FORMAT, "dequeue 1 byte msg in FIFO",
+		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_FIFO_RUNS));
 
 	et = BENCH_START();
 	for (i = 0; i < NR_OF_FIFO_RUNS; i++) {
@@ -47,8 +47,8 @@ void queue_test(void)
 	et = TIME_STAMP_DELTA_GET(et);
 	check_result();
 
-	PRINT_F(output_file, FORMAT, "enqueue 4 bytes msg in FIFO",
-			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_FIFO_RUNS));
+	PRINT_F(FORMAT, "enqueue 4 bytes msg in FIFO",
+		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_FIFO_RUNS));
 
 	et = BENCH_START();
 	for (i = 0; i < NR_OF_FIFO_RUNS; i++) {
@@ -57,8 +57,8 @@ void queue_test(void)
 	et = TIME_STAMP_DELTA_GET(et);
 	check_result();
 
-	PRINT_F(output_file, FORMAT, "dequeue 4 bytes msg in FIFO",
-			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_FIFO_RUNS));
+	PRINT_F(FORMAT, "dequeue 4 bytes msg in FIFO",
+		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_FIFO_RUNS));
 
 	k_sem_give(&STARTRCV);
 
@@ -69,9 +69,9 @@ void queue_test(void)
 	et = TIME_STAMP_DELTA_GET(et);
 	check_result();
 
-	PRINT_F(output_file, FORMAT,
-			"enqueue 1 byte msg in FIFO to a waiting higher priority task",
-			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_FIFO_RUNS));
+	PRINT_F(FORMAT,
+		"enqueue 1 byte msg in FIFO to a waiting higher priority task",
+		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_FIFO_RUNS));
 
 	et = BENCH_START();
 	for (i = 0; i < NR_OF_FIFO_RUNS; i++) {
@@ -80,9 +80,9 @@ void queue_test(void)
 	et = TIME_STAMP_DELTA_GET(et);
 	check_result();
 
-	PRINT_F(output_file, FORMAT,
-			"enqueue 4 bytes in FIFO to a waiting higher priority task",
-			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_FIFO_RUNS));
+	PRINT_F(FORMAT,
+		"enqueue 4 bytes in FIFO to a waiting higher priority task",
+		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_FIFO_RUNS));
 }
 
 #endif /* FIFO_BENCH */

--- a/tests/benchmarks/app_kernel/src/mailbox_b.c
+++ b/tests/benchmarks/app_kernel/src/mailbox_b.c
@@ -14,46 +14,44 @@ static struct k_mbox_msg message;
 
 #ifdef FLOAT
 #define PRINT_HEADER()                                                       \
-	(PRINT_STRING                                         \
+	(PRINT_STRING                                                        \
 	   ("|   size(B) |       time/packet (usec)       |          MB/sec" \
-	    "                |\n", output_file))
+	    "                |\n"))
 #define PRINT_ONE_RESULT()                                                   \
-	PRINT_F(output_file, "|%11u|%32.3f|%32f|\n", putsize, puttime / 1000.0,\
-	     (1000.0 * putsize) / SAFE_DIVISOR(puttime))
+	PRINT_F("|%11u|%32.3f|%32f|\n", putsize, puttime / 1000.0,           \
+		(1000.0 * putsize) / SAFE_DIVISOR(puttime))
 
 #define PRINT_OVERHEAD()                                                     \
-	PRINT_F(output_file,						\
-	     "| message overhead:  %10.3f     usec/packet                   "\
-	     "            |\n", empty_msg_put_time / 1000.0)
+	PRINT_F("| message overhead:  %10.3f     usec/packet               " \
+		"                |\n", empty_msg_put_time / 1000.0)
 
 #define PRINT_XFER_RATE()                                                     \
 	double netto_transfer_rate;                                           \
 	netto_transfer_rate = 1000.0 * \
 		(putsize >> 1) / SAFE_DIVISOR(puttime - empty_msg_put_time);  \
-	PRINT_F(output_file,						\
-	     "| raw transfer rate:     %10.3f MB/sec (without"		\
-	     " overhead)                 |\n", netto_transfer_rate)
+	PRINT_F("| raw transfer rate:     %10.3f MB/sec (without"             \
+		" overhead)                 |\n", netto_transfer_rate)
 
 #else
 #define PRINT_HEADER()                                                       \
-	(PRINT_STRING                                                         \
+	(PRINT_STRING                                                        \
 	   ("|   size(B) |       time/packet (nsec)       |          KB/sec" \
-	    "                |\n", output_file))
+	    "                |\n"))
 
 #define PRINT_ONE_RESULT()                                                   \
-	PRINT_F(output_file, "|%11u|%32u|%32u|\n", putsize, puttime,	     \
-	     (uint32_t)(((uint64_t)putsize * 1000000U) / SAFE_DIVISOR(puttime)))
+	PRINT_F("|%11u|%32u|%32u|\n", putsize, puttime,	                     \
+		(uint32_t)                                                   \
+		(((uint64_t)putsize * 1000000U) / SAFE_DIVISOR(puttime)))
 
 #define PRINT_OVERHEAD()                                                     \
-	PRINT_F(output_file,						\
-	     "| message overhead:  %10u     nsec/packet                     "\
-	     "          |\n", empty_msg_put_time)
+	PRINT_F("| message overhead:  %10u     nsec/packet                 " \
+	     "              |\n", empty_msg_put_time)
 
 #define PRINT_XFER_RATE()                                                    \
-	PRINT_F(output_file, "| raw transfer rate:     %10u KB/sec (without" \
-	     " overhead)                 |\n",                               \
-	     (uint32_t)((uint64_t)(putsize >> 1) * 1000000U                   \
-	     / SAFE_DIVISOR(puttime - empty_msg_put_time)))
+	PRINT_F("| raw transfer rate:     %10u KB/sec (without"              \
+		" overhead)                 |\n",                            \
+		(uint32_t)((uint64_t)(putsize >> 1) * 1000000U /             \
+			   SAFE_DIVISOR(puttime - empty_msg_put_time)))
 
 #endif
 
@@ -80,19 +78,19 @@ void mailbox_test(void)
 	unsigned int empty_msg_put_time;
 	struct getinfo getinfo;
 
-	PRINT_STRING(dashline, output_file);
+	PRINT_STRING(dashline);
 	PRINT_STRING("|                "
-				 "M A I L B O X   M E A S U R E M E N T S"
-				 "                      |\n", output_file);
-	PRINT_STRING(dashline, output_file);
+		     "M A I L B O X   M E A S U R E M E N T S"
+		     "                      |\n");
+	PRINT_STRING(dashline);
 	PRINT_STRING("| Send mailbox message to waiting high "
-		 "priority task and wait                 |\n", output_file);
-	PRINT_F(output_file, "| repeat for %4d times and take the "
-			"average                                  |\n",
-			NR_OF_MBOX_RUNS);
-	PRINT_STRING(dashline, output_file);
+		     "priority task and wait                 |\n");
+	PRINT_F("| repeat for %4d times and take the "
+		"average                                  |\n",
+		NR_OF_MBOX_RUNS);
+	PRINT_STRING(dashline);
 	PRINT_HEADER();
-	PRINT_STRING(dashline, output_file);
+	PRINT_STRING(dashline);
 	k_sem_reset(&SEM0);
 	k_sem_give(&STARTRCV);
 
@@ -110,7 +108,7 @@ void mailbox_test(void)
 		k_msgq_get(&MB_COMM, &getinfo, K_FOREVER);
 		PRINT_ONE_RESULT();
 	}
-	PRINT_STRING(dashline, output_file);
+	PRINT_STRING(dashline);
 	PRINT_OVERHEAD();
 	PRINT_XFER_RATE();
 }

--- a/tests/benchmarks/app_kernel/src/master.c
+++ b/tests/benchmarks/app_kernel/src/master.c
@@ -26,8 +26,6 @@ struct k_pipe *test_pipes[] = {&PIPE_NOBUFF, &PIPE_SMALLBUFF, &PIPE_BIGBUFF};
 char sline[SLINE_LEN + 1];
 const char newline[] = "\n";
 
-FILE *output_file;
-
 /*
  * Time in timer cycles necessary to read time.
  * Used for correction in time measurements.
@@ -72,26 +70,6 @@ int kbhit(void)
 	return 0;
 }
 
-
-/**
- *
- * @brief Prepares the test output
- *
- * @param continuously   Run test till the user presses the key.
- * @param autorun        Expect user input.
- *
- */
-void init_output(int *continuously, int *autorun)
-{
-	ARG_UNUSED(continuously);
-	ARG_UNUSED(autorun);
-
-	/*
-	 * send all printf and fprintf to console
-	 */
-	output_file = stdout;
-}
-
 /**
  *
  * @brief Close output for the test
@@ -113,18 +91,16 @@ void output_close(void)
  */
 int main(void)
 {
-	int autorun = 0, continuously = 0;
+	int continuously = 0;
 
-	init_output(&continuously, &autorun);
 	bench_test_init();
 
-	PRINT_STRING(newline, output_file);
+	PRINT_STRING(newline);
 	do {
-		PRINT_STRING(dashline, output_file);
+		PRINT_STRING(dashline);
 		PRINT_STRING("|          S I M P L E   S E R V I C E    "
-					 "M E A S U R E M E N T S  |  nsec    |\n",
-					 output_file);
-		PRINT_STRING(dashline, output_file);
+			     "M E A S U R E M E N T S  |  nsec    |\n");
+		PRINT_STRING(dashline);
 		queue_test();
 		sema_test();
 		mutex_test();
@@ -132,10 +108,9 @@ int main(void)
 		mailbox_test();
 		pipe_test();
 		PRINT_STRING("|         END OF TESTS                     "
-					 "                                   |\n",
-					 output_file);
-		PRINT_STRING(dashline, output_file);
-		PRINT_STRING("PROJECT EXECUTION SUCCESSFUL\n", output_file);
+			     "                                   |\n");
+		PRINT_STRING(dashline);
+		PRINT_STRING("PROJECT EXECUTION SUCCESSFUL\n");
 		TC_PRINT_RUNID;
 	} while (continuously && !kbhit());
 

--- a/tests/benchmarks/app_kernel/src/master.h
+++ b/tests/benchmarks/app_kernel/src/master.h
@@ -50,7 +50,6 @@
 extern char msg[MAX_MSG];
 extern char data_bench[MESSAGE_SIZE];
 extern struct k_pipe *test_pipes[];
-extern FILE *output_file;
 extern const char newline[];
 extern char sline[];
 
@@ -150,25 +149,24 @@ extern struct k_mem_slab MAP1;
 
 
 /* PRINT_STRING
- * Macro to print an ASCII NULL terminated string. fprintf is used
- * so output can go to console.
+ * Macro to print an ASCII NULL terminated string.
  */
-#define PRINT_STRING(string, stream)  fputs(string, stream)
+#define PRINT_STRING(string)  printk("%s", string)
 
 /* PRINT_F
- * Macro to print a formatted output string. fprintf is used when
+ * Macro to print a formatted output string.
  * Assumed that sline character array of SLINE_LEN + 1 characters
  * is defined in the main file
  */
 
-#define PRINT_F(stream, fmt, ...)					\
+#define PRINT_F(fmt, ...)					        \
 {									\
-	snprintf(sline, SLINE_LEN, fmt, ##__VA_ARGS__);	\
-	PRINT_STRING(sline, stream);					\
+	snprintf(sline, SLINE_LEN, fmt, ##__VA_ARGS__);                 \
+	PRINT_STRING(sline);					        \
 }
 
 #define PRINT_OVERFLOW_ERROR()						\
-	PRINT_F(output_file, __FILE__":%d Error: tick occurred\n", __LINE__)
+	PRINT_F(__FILE__":%d Error: tick occurred\n", __LINE__)
 
 static inline uint32_t BENCH_START(void)
 {
@@ -186,6 +184,5 @@ static inline void check_result(void)
 		return; /* error */
 	}
 }
-
 
 #endif /* _MASTER_H */

--- a/tests/benchmarks/app_kernel/src/memmap_b.c
+++ b/tests/benchmarks/app_kernel/src/memmap_b.c
@@ -24,12 +24,12 @@ void memorymap_test(void)
 	void *p;
 	int alloc_status;
 
-	PRINT_STRING(dashline, output_file);
+	PRINT_STRING(dashline);
 	et = BENCH_START();
 	for (i = 0; i < NR_OF_MAP_RUNS; i++) {
 		alloc_status = k_mem_slab_alloc(&MAP1, &p, K_FOREVER);
 		if (alloc_status != 0) {
-			PRINT_F(output_file, FORMAT,
+			PRINT_F(FORMAT,
 				"Error: Slab allocation failed.", alloc_status);
 			break;
 		}
@@ -38,7 +38,7 @@ void memorymap_test(void)
 	et = TIME_STAMP_DELTA_GET(et);
 	check_result();
 
-	PRINT_F(output_file, FORMAT, "average alloc and dealloc memory page",
+	PRINT_F(FORMAT, "average alloc and dealloc memory page",
 		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, (2 * NR_OF_MAP_RUNS)));
 }
 

--- a/tests/benchmarks/app_kernel/src/mutex_b.c
+++ b/tests/benchmarks/app_kernel/src/mutex_b.c
@@ -20,7 +20,7 @@ void mutex_test(void)
 	uint32_t et; /* elapsed time */
 	int i;
 
-	PRINT_STRING(dashline, output_file);
+	PRINT_STRING(dashline);
 	et = BENCH_START();
 	for (i = 0; i < NR_OF_MUTEX_RUNS; i++) {
 		k_mutex_lock(&DEMO_MUTEX, K_FOREVER);
@@ -29,7 +29,7 @@ void mutex_test(void)
 	et = TIME_STAMP_DELTA_GET(et);
 	check_result();
 
-	PRINT_F(output_file, FORMAT, "average lock and unlock mutex",
+	PRINT_F(FORMAT, "average lock and unlock mutex",
 		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, (2 * NR_OF_MUTEX_RUNS)));
 }
 

--- a/tests/benchmarks/app_kernel/src/pipe_b.c
+++ b/tests/benchmarks/app_kernel/src/pipe_b.c
@@ -12,69 +12,68 @@
 
 #ifdef FLOAT
 #define PRINT_ALL_TO_N_HEADER_UNIT()                                       \
-	PRINT_STRING("|   size(B) |       time/packet (usec)       |         "\
-		  " MB/sec                |\n", output_file)
+	PRINT_STRING("|   size(B) |       time/packet (usec)       |     " \
+		     "     MB/sec                |\n")
 
 #define PRINT_ALL_TO_N() \
-	PRINT_F(output_file,						\
-	     "|%5u|%5u|%10.3f|%10.3f|%10.3f|%10.3f|%10.3f|%10.3f|\n",     \
-	     putsize, putsize, puttime[0] / 1000.0, puttime[1] / 1000.0,  \
-	     puttime[2] / 1000.0,                                         \
-	     (1000.0 * putsize) / SAFE_DIVISOR(puttime[0]),               \
-	     (1000.0 * putsize) / SAFE_DIVISOR(puttime[1]),               \
-	     (1000.0 * putsize) / SAFE_DIVISOR(puttime[2]))
+	PRINT_F("|%5u|%5u|%10.3f|%10.3f|%10.3f|%10.3f|%10.3f|%10.3f|\n",     \
+		putsize, putsize, puttime[0] / 1000.0, puttime[1] / 1000.0,  \
+		puttime[2] / 1000.0,                                         \
+		(1000.0 * putsize) / SAFE_DIVISOR(puttime[0]),               \
+		(1000.0 * putsize) / SAFE_DIVISOR(puttime[1]),               \
+		(1000.0 * putsize) / SAFE_DIVISOR(puttime[2]))
 
-#define PRINT_1_TO_N_HEADER()                                             \
-	do { \
-	PRINT_STRING("|   size(B) |       time/packet (usec)       |        "\
-		  "  MB/sec                |\n", output_file);            \
-	PRINT_STRING(dashline, output_file);\
+#define PRINT_1_TO_N_HEADER()                                                 \
+	do {                                                                  \
+		PRINT_STRING("|   size(B) |       time/packet (usec)       |" \
+			     "          MB/sec                |\n");          \
+		PRINT_STRING(dashline);                                       \
 	} while (0)
 
-#define  PRINT_1_TO_N()                                               \
-	PRINT_F(output_file,						\
-	     "|%5u|%5d|%10.3f|%10.3f|%10.3f|%10.3f|%10.3f|%10.3f|\n", \
-	     putsize,                                                 \
-	     getsize,                                                 \
-	     puttime[0] / 1000.0,                                     \
-	     puttime[1] / 1000.0,                                     \
-	     puttime[2] / 1000.0,                                     \
-	     (1000.0 * putsize) / SAFE_DIVISOR(puttime[0]),           \
-	     (1000.0 * putsize) / SAFE_DIVISOR(puttime[1]),           \
-	     (1000.0 * putsize) / SAFE_DIVISOR(puttime[2]))
+#define  PRINT_1_TO_N()                                                  \
+	PRINT_F("|%5u|%5d|%10.3f|%10.3f|%10.3f|%10.3f|%10.3f|%10.3f|\n", \
+		putsize,                                                 \
+		getsize,                                                 \
+		puttime[0] / 1000.0,                                     \
+		puttime[1] / 1000.0,                                     \
+		puttime[2] / 1000.0,                                     \
+		(1000.0 * putsize) / SAFE_DIVISOR(puttime[0]),           \
+		(1000.0 * putsize) / SAFE_DIVISOR(puttime[1]),           \
+		(1000.0 * putsize) / SAFE_DIVISOR(puttime[2]))
 
 #else
 #define PRINT_ALL_TO_N_HEADER_UNIT()                                       \
-	PRINT_STRING("|   size(B) |       time/packet (nsec)       |         "\
-		  " KB/sec                |\n", output_file)
+	PRINT_STRING("|   size(B) |       time/packet (nsec)       |     " \
+		     "     KB/sec                |\n")
 
 #define PRINT_ALL_TO_N() \
-	PRINT_F(output_file,                                                 \
-	     "|%5u|%5u|%10u|%10u|%10u|%10u|%10u|%10u|\n",                 \
-	     putsize, putsize, puttime[0], puttime[1],                    \
-	     puttime[2],                                                  \
-	     (1000000 * putsize) / SAFE_DIVISOR(puttime[0]),              \
-	     (1000000 * putsize) / SAFE_DIVISOR(puttime[1]),              \
-	     (1000000 * putsize) / SAFE_DIVISOR(puttime[2]))
+	PRINT_F("|%5u|%5u|%10u|%10u|%10u|%10u|%10u|%10u|\n",                 \
+		putsize, putsize, puttime[0], puttime[1],                    \
+		puttime[2],                                                  \
+		(1000000 * putsize) / SAFE_DIVISOR(puttime[0]),              \
+		(1000000 * putsize) / SAFE_DIVISOR(puttime[1]),              \
+		(1000000 * putsize) / SAFE_DIVISOR(puttime[2]))
 
-#define PRINT_1_TO_N_HEADER()                                             \
-	do { \
-	PRINT_STRING("|   size(B) |       time/packet (nsec)       |        "\
-		  "  KB/sec                |\n", output_file);            \
-	PRINT_STRING(dashline, output_file); \
+#define PRINT_1_TO_N_HEADER()                                                 \
+	do {                                                                  \
+		PRINT_STRING("|   size(B) |       time/packet (nsec)       |" \
+			     "          KB/sec                |\n");          \
+		PRINT_STRING(dashline);                                       \
 	} while (0)
 
-#define  PRINT_1_TO_N()                                              \
-	PRINT_F(output_file,                                            \
-	     "|%5u|%5d|%10u|%10u|%10u|%10u|%10u|%10u|\n",	     \
-	     putsize,                                                \
-	     getsize,                                                \
-	     puttime[0],                                             \
-	     puttime[1],                                             \
-	     puttime[2],                                             \
-	     (uint32_t)(((uint64_t)putsize * 1000000U) / SAFE_DIVISOR(puttime[0])), \
-	     (uint32_t)(((uint64_t)putsize * 1000000U) / SAFE_DIVISOR(puttime[1])), \
-	     (uint32_t)(((uint64_t)putsize * 1000000U) / SAFE_DIVISOR(puttime[2])))
+#define  PRINT_1_TO_N()                                                 \
+	PRINT_F("|%5u|%5d|%10u|%10u|%10u|%10u|%10u|%10u|\n",	        \
+		putsize,                                                \
+		getsize,                                                \
+		puttime[0],                                             \
+		puttime[1],                                             \
+		puttime[2],                                             \
+		(uint32_t)(((uint64_t)putsize * 1000000U) /             \
+			   SAFE_DIVISOR(puttime[0])),                   \
+		(uint32_t)(((uint64_t)putsize * 1000000U) /             \
+			   SAFE_DIVISOR(puttime[1])),                   \
+		(uint32_t)(((uint64_t)putsize * 1000000U) /             \
+			   SAFE_DIVISOR(puttime[2])))
 #endif /* FLOAT */
 
 /*
@@ -109,24 +108,23 @@ void pipe_test(void)
 	/* action: */
 
 	/* non-buffered operation, matching (ALL_N) */
-	PRINT_STRING(dashline, output_file);
+	PRINT_STRING(dashline);
 	PRINT_STRING("|                   "
-				 "P I P E   M E A S U R E M E N T S"
-				 "                         |\n", output_file);
-	PRINT_STRING(dashline, output_file);
+		     "P I P E   M E A S U R E M E N T S"
+		     "                         |\n");
+	PRINT_STRING(dashline);
 	PRINT_STRING("| Send data into a pipe towards a "
-			 "receiving high priority task and wait       |\n",
-				 output_file);
-	PRINT_STRING(dashline, output_file);
+		     "receiving high priority task and wait       |\n");
+	PRINT_STRING(dashline);
 	PRINT_STRING("|                          "
-				 "matching sizes (_ALL_N)"
-			 "                            |\n", output_file);
-	PRINT_STRING(dashline, output_file);
+		     "matching sizes (_ALL_N)"
+		     "                            |\n");
+	PRINT_STRING(dashline);
 	PRINT_ALL_TO_N_HEADER_UNIT();
-	PRINT_STRING(dashline, output_file);
+	PRINT_STRING(dashline);
 	PRINT_STRING("| put | get |  no buf  | small buf| big buf  |"
-			 "  no buf  | small buf| big buf  |\n", output_file);
-	PRINT_STRING(dashline, output_file);
+		     "  no buf  | small buf| big buf  |\n");
+	PRINT_STRING(dashline);
 
 	for (putsize = 8U; putsize <= MESSAGE_SIZE_PIPE; putsize <<= 1) {
 		for (pipe = 0; pipe < 3; pipe++) {
@@ -139,7 +137,7 @@ void pipe_test(void)
 		}
 		PRINT_ALL_TO_N();
 	}
-	PRINT_STRING(dashline, output_file);
+	PRINT_STRING(dashline);
 
 	/* Test with two different sender priorities */
 	for (prio = 0; prio < 2; prio++) {
@@ -147,20 +145,20 @@ void pipe_test(void)
 		if (prio == 0) {
 			PRINT_STRING("|                      "
 			 "non-matching sizes (1_TO_N) to higher priority"
-						 "         |\n", output_file);
+						 "         |\n");
 			TaskPrio = k_thread_priority_get(k_current_get());
 		}
 		if (prio == 1) {
 			PRINT_STRING("|                      "
 				 "non-matching sizes (1_TO_N) to lower priority"
-						 "          |\n", output_file);
+						 "          |\n");
 			k_thread_priority_set(k_current_get(), TaskPrio - 2);
 		}
-		PRINT_STRING(dashline, output_file);
+		PRINT_STRING(dashline);
 		PRINT_1_TO_N_HEADER();
 		PRINT_STRING("| put | get |  no buf  | small buf| big buf  |  "
-			 "no buf  | small buf| big buf  |\n", output_file);
-		PRINT_STRING(dashline, output_file);
+			     "no buf  | small buf| big buf  |\n");
+		PRINT_STRING(dashline);
 
 	for (putsize = 8U; putsize <= (MESSAGE_SIZE_PIPE); putsize <<= 1) {
 		putcount = MESSAGE_SIZE_PIPE / putsize;
@@ -174,7 +172,7 @@ void pipe_test(void)
 		}
 		PRINT_1_TO_N();
 	}
-		PRINT_STRING(dashline, output_file);
+		PRINT_STRING(dashline);
 		k_thread_priority_set(k_current_get(), TaskPrio);
 	}
 }
@@ -239,14 +237,11 @@ int pipeput(struct k_pipe *pipe,
 	*time = SYS_CLOCK_HW_CYCLES_TO_NS_AVG(t, count);
 	if (bench_test_end() < 0) {
 		if (high_timer_overflow()) {
-			PRINT_STRING("| Timer overflow."
-					"Results are invalid            ",
-						 output_file);
+			PRINT_STRING("| Timer overflow. Results are invalid            ");
 		} else {
-	PRINT_STRING("| Tick occurred. Results may be inaccurate       ",
-						 output_file);
+			PRINT_STRING("| Tick occurred. Results may be inaccurate       ");
 		}
-		PRINT_STRING("                             |\n", output_file);
+		PRINT_STRING("                             |\n");
 	}
 	return 0;
 }

--- a/tests/benchmarks/app_kernel/src/pipe_r.c
+++ b/tests/benchmarks/app_kernel/src/pipe_r.c
@@ -127,15 +127,12 @@ int pipeget(struct k_pipe *pipe, enum pipe_options option, int size, int count,
 	if (bench_test_end() < 0) {
 		if (high_timer_overflow()) {
 			PRINT_STRING("| Timer overflow. "
-			"Results are invalid            ",
-						 output_file);
+				     "Results are invalid            ");
 		} else {
 			PRINT_STRING("| Tick occurred. "
-			"Results may be inaccurate       ",
-						 output_file);
+				     "Results may be inaccurate       ");
 		}
-		PRINT_STRING("                             |\n",
-					 output_file);
+		PRINT_STRING("                             |\n");
 	}
 	return 0;
 }

--- a/tests/benchmarks/app_kernel/src/sema_b.c
+++ b/tests/benchmarks/app_kernel/src/sema_b.c
@@ -21,7 +21,7 @@ void sema_test(void)
 	uint32_t et; /* elapsed Time */
 	int i;
 
-	PRINT_STRING(dashline, output_file);
+	PRINT_STRING(dashline);
 	et = BENCH_START();
 	for (i = 0; i < NR_OF_SEMA_RUNS; i++) {
 	  k_sem_give(&SEM0);
@@ -29,8 +29,8 @@ void sema_test(void)
 	et = TIME_STAMP_DELTA_GET(et);
 	check_result();
 
-	PRINT_F(output_file, FORMAT, "signal semaphore",
-			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_SEMA_RUNS));
+	PRINT_F(FORMAT, "signal semaphore",
+		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_SEMA_RUNS));
 
 	k_sem_reset(&SEM1);
 	k_sem_give(&STARTRCV);
@@ -42,8 +42,8 @@ void sema_test(void)
 	et = TIME_STAMP_DELTA_GET(et);
 	check_result();
 
-	PRINT_F(output_file, FORMAT, "signal to waiting high pri task",
-			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_SEMA_RUNS));
+	PRINT_F(FORMAT, "signal to waiting high pri task",
+		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_SEMA_RUNS));
 
 	et = BENCH_START();
 	for (i = 0; i < NR_OF_SEMA_RUNS; i++) {
@@ -52,9 +52,8 @@ void sema_test(void)
 	et = TIME_STAMP_DELTA_GET(et);
 	check_result();
 
-	PRINT_F(output_file, FORMAT,
-			"signal to waiting high pri task, with timeout",
-			SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_SEMA_RUNS));
+	PRINT_F(FORMAT, "signal to waiting high pri task, with timeout",
+		SYS_CLOCK_HW_CYCLES_TO_NS_AVG(et, NR_OF_SEMA_RUNS));
 
 }
 


### PR DESCRIPTION
Instead of sending output strings to stdout via fputs(), just print them using printk(). This allows the output to be detected by twister.

Fixes #60676