### PR TITLE
fuel_gauge: Add battery cutoff support

### DIFF
--- a/doc/hardware/peripherals/fuel_gauge.rst
+++ b/doc/hardware/peripherals/fuel_gauge.rst
@@ -23,6 +23,15 @@ or present-time current/voltage.
 Properties are fetched using a client allocated array of :c:struct:`fuel_gauge_get_property`.  This
 array is then populated by values as according to its `property_type` field.
 
+Battery Cutoff
+==============
+
+Many fuel gauges embedded within battery packs expose a register address that when written to with a
+specific payload will do a battery cutoff. This battery cutoff is often referred to as ship, shelf,
+or sleep mode due to its utility in reducing battery drain while devices are stored or shipped.
+
+The fuel gauge API exposes battery cutoff with the :c:func:`fuel_gauge_battery_cutoff` function.
+
 Caching
 =======
 

--- a/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
+++ b/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
@@ -70,3 +70,12 @@ static inline int z_vrfy_fuel_gauge_get_buffer_prop(const struct device *dev,
 }
 
 #include <syscalls/fuel_gauge_get_buffer_prop_mrsh.c>
+
+static inline int z_vrfy_fuel_gauge_battery_cutoff(const struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, battery_cutoff));
+
+	return z_impl_fuel_gauge_battery_cutoff(dev);
+}
+
+#include <syscalls/fuel_gauge_battery_cutoff_mrsh.c>

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.h
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.h
@@ -47,8 +47,33 @@
 
 #define SBS_GAUGE_DELAY                     1000
 
+/*
+ * Nearly all cutoff payloads are actually a singular value that must be written twice to the fuel
+ * gauge. For the case where it's a singular value that must only be written to the fuel gauge only
+ * once, retransmitting the duplicate write has no significant negative consequences.
+ *
+ * Why not devicetree: Finding the maximum length of all the battery cutoff payloads in a devicetree
+ * at compile-time would require labyrinthine amount of macro-batics.
+ *
+ * Why not compute at runtime: It's not worth the memory given having more than a single fuel gauge
+ * is rare, and most will have a payload size of 2.
+ *
+ * This is validated as a BUILD_ASSERT in the driver.
+ */
+#define SBS_GAUGE_CUTOFF_PAYLOAD_MAX_SIZE 2
+
+struct sbs_gauge_battery_cutoff_config {
+	/* Size of the payload array */
+	size_t payload_size;
+	/* Array SMBus word values to write to cut off the battery */
+	uint32_t payload[SBS_GAUGE_CUTOFF_PAYLOAD_MAX_SIZE];
+	/* Register to write cutoff payload */
+	uint8_t reg;
+};
+
 struct sbs_gauge_config {
 	struct i2c_dt_spec i2c;
+	const struct sbs_gauge_battery_cutoff_config *cutoff_cfg;
 };
 
 #endif

--- a/dts/bindings/fuel-gauge/battery-cutoff.yaml
+++ b/dts/bindings/fuel-gauge/battery-cutoff.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright 2023 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+description: |
+
+  Properties for fuel-gauges that may control battery cutoff, this is common in SBS-compliant or
+  similarly smart battery fuel gauges.
+
+  Note: These properties are to be used with meaningful defaults in fuel gauge ICs that can cut off
+  their associated battery from the system. See the default fuel gauge SBS Gauge compatible as an
+  example.
+
+properties:
+  battery-cutoff-support:
+    description: |
+      Helper prop that indicates whether this device can cutoff the battery; this is also often
+      referred to as ship or sleep mode.
+    type: boolean
+  battery-cutoff-reg-addr:
+    description: |
+       Address of register to receive cutoff payload for battery cutoff.
+    type: int
+  battery-cutoff-payload:
+    description: |
+       Payload to write to cutoff battery register. This must be array of maximum 2 integers.
+    type: array

--- a/dts/bindings/fuel-gauge/sbs,default-sbs-gauge.yaml
+++ b/dts/bindings/fuel-gauge/sbs,default-sbs-gauge.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright 2023 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+compatible: "sbs,default-sbs-gauge"
+
+include: ["sbs,sbs-gauge-new-api.yaml", "battery-cutoff.yaml"]
+
+description: |
+  Default generic smart battery fuel gauge driver. Includes support for battery cutoff if enabled.
+
+  This compatible is intended to be used with the abstract SBS Gauge compatible because it is
+  actuated by the SBS driver for SBS compliant fuel gauge ICs.
+
+properties:
+  battery-cutoff-reg-addr:
+    # For SBS compliant fuel gauges this is usually "ManufactuerAccess"
+    default: 0x0
+  battery-cutoff-payload:
+    default: [0x0010, 0x0010]

--- a/include/zephyr/drivers/emul_fuel_gauge.h
+++ b/include/zephyr/drivers/emul_fuel_gauge.h
@@ -34,6 +34,7 @@ extern "C" {
  */
 __subsystem struct fuel_gauge_emul_driver_api {
 	int (*set_battery_charging)(const struct emul *emul, uint32_t uV, int uA);
+	int (*is_battery_cutoff)(const struct emul *emul, bool *cutoff);
 };
 /**
  * @endcond
@@ -64,6 +65,26 @@ static inline int emul_fuel_gauge_set_battery_charging(const struct emul *target
 	}
 
 	return backend_api->set_battery_charging(target, uV, uA);
+}
+
+/**
+ * @brief Check if the battery has been cut off.
+ *
+ * @param target Pointer to the emulator structure for the fuel gauge emulator instance.
+ * @param cutoff Pointer to bool storing variable.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOTSUP if not supported by emulator.
+ */
+static inline int emul_fuel_gauge_is_battery_cutoff(const struct emul *target, bool *cutoff)
+{
+	const struct fuel_gauge_emul_driver_api *backend_api =
+		(const struct fuel_gauge_emul_driver_api *)target->backend_api;
+
+	if (backend_api->is_battery_cutoff == 0) {
+		return -ENOTSUP;
+	}
+	return backend_api->is_battery_cutoff(target, cutoff);
 }
 
 #ifdef __cplusplus

--- a/tests/drivers/fuel_gauge/sbs_gauge/CMakeLists.txt
+++ b/tests/drivers/fuel_gauge/sbs_gauge/CMakeLists.txt
@@ -4,7 +4,8 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(device)
 
-FILE(GLOB app_sources src/test_sbs_gauge.c)
+target_sources(app PRIVATE src/test_sbs_gauge.c)
+target_sources_ifndef(CONFIG_TEST_SBS_CUTOFF_EXTENSION app PRIVATE src/test_cutoff_disabled.c)
+target_sources_ifdef(CONFIG_TEST_SBS_CUTOFF_EXTENSION app PRIVATE src/test_cutoff.c)
 
 target_include_directories(app PRIVATE include)
-target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/fuel_gauge/sbs_gauge/Kconfig
+++ b/tests/drivers/fuel_gauge/sbs_gauge/Kconfig
@@ -1,0 +1,11 @@
+# Copyright 2023 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config TEST_SBS_CUTOFF_EXTENSION
+	bool "Test Battery Cutoff"
+	help
+	  Enabling this option adds test sources that verify if the battery cutoff extension to the
+	  SBS driver are functional.

--- a/tests/drivers/fuel_gauge/sbs_gauge/boards/emulated_board_cutoff.overlay
+++ b/tests/drivers/fuel_gauge/sbs_gauge/boards/emulated_board_cutoff.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/i2c/i2c.h>
+
+/ {
+	fake_i2c_bus: i2c@100 {
+		status = "okay";
+		compatible = "zephyr,i2c-emul-controller";
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x100 4>;
+	};
+};
+
+&fake_i2c_bus {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	compatible = "zephyr,i2c-emul-controller";
+	smartbattery0: smartbattery@b {
+		compatible =  "sbs,default-sbs-gauge","sbs,sbs-gauge-new-api";
+		reg = <0x0b>;
+		status = "okay";
+		battery-cutoff-support;
+		battery-cutoff-payload = <0x0010 0x0020>;
+	};
+};

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_cutoff.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_cutoff.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/fuel_gauge.h>
+#include <zephyr/drivers/emul_fuel_gauge.h>
+#include <zephyr/ztest.h>
+#include <zephyr/ztest_assert.h>
+
+#include "test_sbs_gauge.h"
+
+ZTEST_F(sbs_gauge_new_api, test_cutoff)
+{
+	bool is_cutoff;
+
+	/* Initially there should be no cutoff */
+	zassert_ok(emul_fuel_gauge_is_battery_cutoff(fixture->sbs_fuel_gauge, &is_cutoff));
+	zassert_false(is_cutoff);
+
+	zassert_ok(fuel_gauge_battery_cutoff(fixture->dev));
+
+	/* Now we should've cutoff */
+	zassert_ok(emul_fuel_gauge_is_battery_cutoff(fixture->sbs_fuel_gauge, &is_cutoff));
+	zassert_true(is_cutoff);
+}

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_cutoff_disabled.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_cutoff_disabled.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/fuel_gauge.h>
+#include <zephyr/drivers/emul_fuel_gauge.h>
+#include <zephyr/ztest.h>
+#include <zephyr/ztest_assert.h>
+
+#include "test_sbs_gauge.h"
+
+ZTEST_F(sbs_gauge_new_api, test_cutoff_disabled)
+{
+	bool is_cutoff;
+
+	/* Initially there should be no cutoff */
+	zassert_ok(emul_fuel_gauge_is_battery_cutoff(fixture->sbs_fuel_gauge, &is_cutoff));
+	zassert_false(is_cutoff);
+
+	zassert_not_equal(fuel_gauge_battery_cutoff(fixture->dev), 0);
+
+	/* We confirm there was no cutoff */
+	zassert_ok(emul_fuel_gauge_is_battery_cutoff(fixture->sbs_fuel_gauge, &is_cutoff));
+	zassert_false(is_cutoff);
+}

--- a/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
+++ b/tests/drivers/fuel_gauge/sbs_gauge/testcase.yaml
@@ -40,3 +40,17 @@ tests:
     extra_args:
       - CONF_FILE="prj.conf;boards/qemu_cortex_a53.conf"
       - DTC_OVERLAY_FILE="boards/qemu_cortex_a53.overlay"
+  drivers.sbs_gauge_new_api.emulated.cutoff:
+    tags:
+      - drivers
+      - fuel_gauge
+    filter: dt_compat_enabled("sbs,sbs-gauge-new-api")
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/emulated_board_cutoff.overlay"
+    extra_configs:
+      - CONFIG_EMUL=y
+      - CONFIG_TEST_SBS_CUTOFF_EXTENSION=y
+      - CONFIG_USERSPACE=y
+    platform_allow:
+      - native_posix
+      - qemu_x86


### PR DESCRIPTION
Many fuel gauge ICs offer a battery cutoff/shipping mode functionality that cutoff charge from the battery. This is often useful for preserving battery charge on devices while in storage.

Add battery cutoff support to the fuel gauge API with a generic default SBS driver showing an example of support in tests.

Please see  https://github.com/zephyrproject-rtos/zephyr/issues/61434 for more information on motivation and a graphic to gain some quick context on this PR.