### PR TITLE
atsamd2x_xpro: follow best practices.

### DIFF
--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.dts
@@ -5,6 +5,7 @@
  */
 
 /dts-v1/;
+#include <freq.h>
 #include <atmel/samd20.dtsi>
 #include "atsamd20_xpro-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
@@ -13,17 +14,18 @@
 	model = "SAM D20 Xplained Pro";
 	compatible = "atsamd20,xpro", "atmel,samd20j18", "atmel,samd20";
 
-	aliases {
-		led0 = &yellow_led;
-		sw0 = &user_button;
-		i2c-0 = &sercom2;
-	};
-
 	chosen {
 		zephyr,console = &sercom3;
 		zephyr,shell-uart = &sercom3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		led0 = &yellow_led;
+		sw0 = &user_button;
+		i2c-0 = &sercom2;
 	};
 
 	leds {
@@ -45,7 +47,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <48000000>;
+	clock-frequency = <DT_FREQ_M(48)>;
 };
 
 &sercom0 {

--- a/boards/arm/atsamd20_xpro/atsamd20_xpro.yaml
+++ b/boards/arm/atsamd20_xpro/atsamd20_xpro.yaml
@@ -8,3 +8,9 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
+supported:
+  - adc
+  - gpio
+  - i2c
+  - spi
+  - watchdog

--- a/boards/arm/atsamd20_xpro/doc/index.rst
+++ b/boards/arm/atsamd20_xpro/doc/index.rst
@@ -12,9 +12,12 @@ microcontrollers. The kit includes Atmel’s Embedded Debugger (EDBG),
 which provides a full debug interface without the need for additional
 hardware.
 
-.. image:: img/atsamd20_xpro.jpg
-     :align: center
-     :alt: ATSAMD20-XPRO
+.. figure:: img/atsamd20_xpro.jpg
+    :width: 500px
+    :align: center
+    :alt: ATSAMD20-XPRO
+
+    ATSAMD20-XPRO (Credit: `Microchip Technology`_)
 
 Hardware
 ********
@@ -44,9 +47,13 @@ features:
 +-----------+------------+------------------------------------------+
 | WDT       | on-chip    | Watchdog                                 |
 +-----------+------------+------------------------------------------+
+| ADC       | on-chip    | Analog to Digital Converter              |
++-----------+------------+------------------------------------------+
 | GPIO      | on-chip    | I/O ports                                |
 +-----------+------------+------------------------------------------+
 | USART     | on-chip    | Serial ports                             |
++-----------+------------+------------------------------------------+
+| I2C       | on-chip    | I2C ports                                |
 +-----------+------------+------------------------------------------+
 | SPI       | on-chip    | Serial Peripheral Interface ports        |
 +-----------+------------+------------------------------------------+
@@ -131,6 +138,9 @@ References
 **********
 
 .. target-notes::
+
+.. _Microchip Technology:
+    https://www.microchip.com/DevelopmentTools/ProductDetails.aspx?PartNO=ATSAMD20-XPRO
 
 .. _Microchip website:
     https://www.microchip.com/DevelopmentTools/ProductDetails.aspx?PartNO=ATSAMD20-XPRO

--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
@@ -5,6 +5,7 @@
  */
 
 /dts-v1/;
+#include <freq.h>
 #include <atmel/samd21.dtsi>
 #include "atsamd21_xpro-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
@@ -54,7 +55,7 @@
 };
 
 &cpu0 {
-	clock-frequency = <48000000>;
+	clock-frequency = <DT_FREQ_M(48)>;
 };
 
 &tcc0 {

--- a/boards/arm/atsamd21_xpro/doc/index.rst
+++ b/boards/arm/atsamd21_xpro/doc/index.rst
@@ -8,13 +8,16 @@ Overview
 
 The SAM D21 Xplained Pro evaluation kit is ideal for evaluation and
 prototyping with the SAM D21 Cortex®-M0+ processor-based
-microcontrollers. The kit includes Atmel’s Embedded Debugger (EDBG),
+microcontrollers. The kit includes Atmel's Embedded Debugger (EDBG),
 which provides a full debug interface without the need for additional
 hardware.
 
-.. image:: img/atsamd21_xpro.jpg
-     :align: center
-     :alt: ATSAMD21-XPRO
+.. figure:: img/atsamd21_xpro.jpg
+    :width: 500px
+    :align: center
+    :alt: ATSAMD21-XPRO
+
+    ATSAMD21-XPRO (Credit: `Microchip Technology`_)
 
 Hardware
 ********
@@ -43,6 +46,8 @@ features:
 | SYSTICK   | on-chip    | systick                                  |
 +-----------+------------+------------------------------------------+
 | WDT       | on-chip    | Watchdog                                 |
++-----------+------------+------------------------------------------+
+| ADC       | on-chip    | Analog to Digital Converter              |
 +-----------+------------+------------------------------------------+
 | GPIO      | on-chip    | I/O ports                                |
 +-----------+------------+------------------------------------------+
@@ -173,7 +178,7 @@ References
 
 .. target-notes::
 
-.. _Microchip website:
+.. _Microchip Technology:
     http://www.microchip.com/DevelopmentTools/ProductDetails.aspx?PartNO=ATSAMD21-XPRO
 
 .. _SAM D21 Family Datasheet:

--- a/tests/drivers/adc/adc_api/boards/atsamd20_xpro.overlay
+++ b/tests/drivers/adc/adc_api/boards/atsamd20_xpro.overlay
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
+ */
+
+#define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val 0x1BU
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val>;
+	};
+};


### PR DESCRIPTION
atsamd2x_xpro: follow best practices.

This updates the configurations for these two boars to match the expected
best practices for new boards, as discussed in #61140.

Signed-off-by: Diego Elio Pettenò <flameeyes@meta.com>

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zephyrproject-rtos/zephyr/pull/61437).
* #61529
* __->__ #61437