### PR TITLE
boards: s32z270dc2_r52: support board revision D

### DIFF
--- a/boards/arm/s32z270dc2_r52/doc/index.rst
+++ b/boards/arm/s32z270dc2_r52/doc/index.rst
@@ -111,9 +111,8 @@ The Cortex-R52 cores are configured to run at 800 MHz.
 Serial Port
 ===========
 
-The SoC has 12 LINFlexD instances that can be used in UART mode. Instance 0
-(defined as ``uart0`` in devicetree) is configured for the console and the
-remaining are disabled and not configured.
+The SoC has 12 LINFlexD instances that can be used in UART mode. The console can
+be accessed by default on the USB micro-B connector `J119`.
 
 Watchdog
 ========
@@ -188,6 +187,14 @@ For example, you can build and run the :ref:`hello_world` sample for the board
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: s32z270dc2_rtu0_r52
+   :goals: build flash
+
+In case you are using a newer PCB revision, you have to use an adapted board
+definition as the default PCB revision is B. For example, if using revision D:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: s32z270dc2_rtu0_r52@D
    :goals: build flash
 
 You should see the following message in the terminal:

--- a/boards/arm/s32z270dc2_r52/revision.cmake
+++ b/boards/arm/s32z270dc2_r52/revision.cmake
@@ -1,0 +1,8 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+board_check_revision(
+  FORMAT LETTER
+  DEFAULT_REVISION B
+  VALID_REVISIONS B D
+)

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52-pinctrl-common.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52-pinctrl-common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,6 +14,17 @@
 		};
 		group2 {
 			pinmux = <PB11_LIN_0_RX>;
+			input-enable;
+		};
+	};
+
+	uart9_default: uart9_default {
+		group1 {
+			pinmux = <PM6_LIN_9_TX>;
+			output-enable;
+		};
+		group2 {
+			pinmux = <PM7_LIN_9_RX>;
 			input-enable;
 		};
 	};

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
@@ -1,17 +1,11 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <arm/nxp/nxp_s32z27x_r52.dtsi>
-#include "s32z270dc2_r52-pinctrl.dtsi"
-
-&uart0 {
-	pinctrl-0 = <&uart0_default>;
-	pinctrl-names = "default";
-	status = "okay";
-};
+#include "s32z270dc2_r52-pinctrl-common.dtsi"
 
 &spi0 {
 	clock-frequency = <100000000>;

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
@@ -14,8 +14,6 @@
 
 	chosen {
 		zephyr,sram = &sram0;
-		zephyr,console = &uart0;
-		zephyr,shell-uart = &uart0;
 		zephyr,canbus = &can0;
 	};
 

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_B.overlay
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_B.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+	};
+};
+
+&uart0 {
+	pinctrl-0 = <&uart0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_D.overlay
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_D.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &uart9;
+		zephyr,shell-uart = &uart9;
+	};
+};
+
+&uart9 {
+	pinctrl-0 = <&uart9_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_D.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52_D.yaml
@@ -1,0 +1,16 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: s32z270dc2_rtu0_r52@D
+name: NXP X-S32Z270-DC (DC2) on RTU0 Cortex-R52 cores
+type: mcu
+arch: arm
+ram: 1024
+toolchain:
+  - zephyr
+supported:
+  - uart
+  - gpio
+  - watchdog
+  - netif:eth
+  - can

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_B.overlay
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_B.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+	};
+};
+
+&uart0 {
+	pinctrl-0 = <&uart0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_D.overlay
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_D.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &uart9;
+		zephyr,shell-uart = &uart9;
+	};
+};
+
+&uart9 {
+	pinctrl-0 = <&uart9_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_D.yaml
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52_D.yaml
@@ -1,0 +1,16 @@
+# Copyright 2022 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: s32z270dc2_rtu1_r52@D
+name: NXP X-S32Z270-DC (DC2) on RTU1 Cortex-R52 cores
+type: mcu
+arch: arm
+ram: 1024
+toolchain:
+  - zephyr
+supported:
+  - uart
+  - gpio
+  - watchdog
+  - netif:eth
+  - can


### PR DESCRIPTION
Add a board revision `D` for the `s32z270dc2_r52` boards and make the existing revision `B` the default. The main difference between these revisions affecting current Zephyr port is the USB/UART port that was moved from LINFlexD instance 0 to 9.