### PR TITLE
drivers: can: mcux: flexcan: can_set_mode supports triple sampling

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -431,7 +431,7 @@ static int mcux_flexcan_stop(const struct device *dev)
 
 static int mcux_flexcan_set_mode(const struct device *dev, can_mode_t mode)
 {
-	can_mode_t supported = CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY;
+	can_mode_t supported = CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY | CAN_MODE_3_SAMPLES;
 	const struct mcux_flexcan_config *config = dev->config;
 	struct mcux_flexcan_data *data = dev->data;
 	uint32_t ctrl1;


### PR DESCRIPTION
In case CAN-FD mode is not enabled the mcux flexcan driver supports triple sampling.
 This has been removed inadvertently while adding can-fd support.

Fixes #61450 