### PR TITLE
drivers: can: stm32: correct timing_max parameters

### DIFF
--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -1069,10 +1069,10 @@ static const struct can_driver_api can_api_funcs = {
 		.prescaler = 0x01
 	},
 	.timing_max = {
-		.sjw = 0x07,
+		.sjw = 0x04,
 		.prop_seg = 0x00,
-		.phase_seg1 = 0x0F,
-		.phase_seg2 = 0x07,
+		.phase_seg1 = 0x10,
+		.phase_seg2 = 0x08,
 		.prescaler = 0x400
 	}
 };


### PR DESCRIPTION
The timing_max parameters defined in the stm32 bxCAN driver don't match the register description in the reference manuals.
- sjw does have only 2 bits representing 1 to 4 tq.
- phase_seg1 and phase_seg2 max is one tq higher.

I have checked the following reference manuals and all match:
- RM0090: STM32F405, F415, F407, F417, F427, F437 AND F429
- RM0008: STM32F101, F102, F103, F105, F107 advanced arm-based mcus
- RM0351, RM0394: all STM32L4
- RM0091: all STM32F0 with CAN support

Fixes #61451 