### PR TITLE
boards: arm: stm32f4i_disc1: Fix LED color

### DIFF
--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -32,11 +32,11 @@
 
 	leds {
 		compatible = "gpio-leds";
-		orange_led_3: led_3 {
+		green_led_3: led_3 {
 			gpios = <&gpiog 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
-		green_led_4: led_4 {
+		red_led_4: led_4 {
 			gpios = <&gpiog 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
 		};
@@ -52,7 +52,7 @@
 	};
 
 	aliases {
-		led0 = &green_led_4;
+		led0 = &green_led_3;
 		sw0 = &user_button;
 	};
 };


### PR DESCRIPTION
Fix wrong LED color in STM32F4I_DISC1 devicetree.

Signed-off-by: Thien Nguyen <nguyenmthien@live.com>