### PR TITLE
kernel: sched: Disable FPU context when thread ends

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1714,6 +1714,10 @@ static void end_thread(struct k_thread *thread)
 		unpend_all(&thread->join_queue);
 		update_cache(1);
 
+#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
+		arch_float_disable(thread);
+#endif
+
 		SYS_PORT_TRACING_FUNC(k_thread, sched_abort, thread);
 
 		z_thread_monitor_exit(thread);


### PR DESCRIPTION
The following is with respect to ARM64, although this issue likely exists on other architectures too.

When `CONFIG_FPU_SHARING` is enabled each `k_thread` struct has a saved floating point context (`saved_fp_context`).
During a context switch, the current FPU owner's (`_current_cpu->arch.fpu_owner`) registers are saved to its `saved_fp_context`, and the destination threads FPU registers are loaded from its `saved_fp_context`.

When a thread ends, it does not release ownership of the FPU (`_current_cpu->arch.fpu_owner`).
This is problematic if the `k_thread` struct was allocated on the stack.
The next context switch will save the FPU registers into `k_thread -> saved_fp_context` which may now be out of scope.
This will likely (but not always) result in a crash.

Adding `arch_float_disable(thread);` when a thread ends disables preservation of floating point context information, fixing this issue

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/61454
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/60678