### PR TITLE
boards: fix typos in cy8ckit_062s4 docs and config

### DIFF
--- a/boards/arm/cy8ckit_062s4/board.cmake
+++ b/boards/arm/cy8ckit_062s4/board.cmake
@@ -1,5 +1,5 @@
 # Copyright (c) 2023 David Ullmann
-# spdx-license-identifier: apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=cy8c6xxa")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/cy8ckit_062s4/cy8ckit_062s4_m4_defconfig
+++ b/boards/arm/cy8ckit_062s4/cy8ckit_062s4_m4_defconfig
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2023 David Ullmann
+# SPDX-License-Identifier: Apache-2.0
 
 CONFIG_SOC_SERIES_PSOC_62=y
 CONFIG_BOARD_CY8CKIT_062S4_M4=y

--- a/boards/arm/cy8ckit_062s4/doc/index.rst
+++ b/boards/arm/cy8ckit_062s4/doc/index.rst
@@ -5,7 +5,7 @@
 
 Overview
 ********
-The PSOC 62S$ Pioneer kit has a CY8C62x4 MCU, which is an ultra-low-power PSoC device specifically designed for battery-operated analog
+The PSOC 62S4 Pioneer kit has a CY8C62x4 MCU, which is an ultra-low-power PSoC device specifically designed for battery-operated analog
 sensing applications. It includes a 150-MHz Arm® Cortex®-M4 CPU as the primary application processor, a 100-MHz Arm® Cortex®-M0+ CPU that
 supports low-power operations, up to 256 KB Flash and 128 KB SRAM, programmable analog sensing,
 CapSense™ touch-sensing, and programmable digital peripherals.


### PR DESCRIPTION
fix misc typos
Signed-off-by: David Ullmann <davidl.ullmann@gmail.com>