### PR TITLE
bluetooth:micp Wrong error response for invalid Mute Value.

### DIFF
--- a/include/zephyr/bluetooth/audio/micp.h
+++ b/include/zephyr/bluetooth/audio/micp.h
@@ -35,7 +35,6 @@ extern "C" {
 
 /** Application error codes */
 #define BT_MICP_ERR_MUTE_DISABLED                  0x80
-#define BT_MICP_ERR_VAL_OUT_OF_RANGE               0x81
 
 /** Microphone Control Profile mute states */
 #define BT_MICP_MUTE_UNMUTED                       0x00

--- a/subsys/bluetooth/audio/micp_mic_dev.c
+++ b/subsys/bluetooth/audio/micp_mic_dev.c
@@ -65,7 +65,7 @@ static ssize_t write_mute(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 
 	if ((conn != NULL && *val == BT_MICP_MUTE_DISABLED) ||
 	    *val > BT_MICP_MUTE_DISABLED) {
-		return BT_GATT_ERR(BT_MICP_ERR_VAL_OUT_OF_RANGE);
+		return BT_GATT_ERR(BT_ATT_ERR_VALUE_NOT_ALLOWED);
 	}
 
 	if (conn != NULL && micp_inst.mute == BT_MICP_MUTE_DISABLED) {


### PR DESCRIPTION
Qualification test MICS/SR/SPE/BI-01-C [Invalid Mute Value]

Specification: Microphone Control Service Revision v1.0 Section 3.1.1

If the client writes a value of Disabled or RFU to the Mute characteristic, the server shall return an ATT Error Response with the ATT error code Value Not Allowed (0x13) as defined in Assigned Numbers.