### PR TITLE
bluetooth:csip Only Unlock Non-bonded devices immediately at disconnect.

### DIFF
--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -525,8 +525,10 @@ static void csip_disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	LOG_DBG("Disconnected: %s (reason %u)", bt_addr_le_str(bt_conn_get_dst(conn)), reason);
 
-	for (int i = 0; i < ARRAY_SIZE(svc_insts); i++) {
-		handle_csip_disconnect(&svc_insts[i], conn);
+	if (!bt_addr_le_is_bonded(conn->id, &conn->le.dst)) {
+		for (int i = 0; i < ARRAY_SIZE(svc_insts); i++) {
+			handle_csip_disconnect(&svc_insts[i], conn);
+		}
 	}
 }
 


### PR DESCRIPTION
Qualification test CSIS/SR/SP/BV-03-C [Lock Timeout]

Specification: Coordinated Set Identification Service Revision v1.0.1 Section 5.3.1.1.

When the server and the client are not bonded and they disconnect when the value of the Set Member Lock characteristic is set to Locked, the server shall set the value of the Set Member Lock characteristic to Unlocked immediately after the disconnection.