### PR TITLE
native_sim: Update native simulator to latest and align with it

### DIFF
--- a/boards/posix/native_sim/CMakeLists.txt
+++ b/boards/posix/native_sim/CMakeLists.txt
@@ -40,6 +40,7 @@ set(nsi_config_content
   "NSI_EXTRA_SRCS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_SOURCES>,\ >"
   "NSI_LINK_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_LINK_OPTIONS>,\ >"
   "NSI_PATH:=${NSI_DIR}/"
+  "NSI_NATIVE=1"
 )
 
 string(REPLACE ";" "\n" nsi_config_content "${nsi_config_content}")

--- a/boards/posix/native_sim/nsi_if.c
+++ b/boards/posix/native_sim/nsi_if.c
@@ -25,9 +25,14 @@ void nsif_cpu0_boot(void)
 	run_native_tasks(_NATIVE_FIRST_SLEEP_LEVEL);
 }
 
-void nsif_cpu0_cleanup(void)
+int nsif_cpu0_cleanup(void)
 {
+	/*
+	 * Note posix_soc_clean_up() may not return, but in that case,
+	 * nsif_cpu0_cleanup() will be called again
+	 */
 	posix_soc_clean_up();
+	return 0;
 }
 
 void nsif_cpu0_irq_raised(void)

--- a/scripts/native_simulator/Makefile
+++ b/scripts/native_simulator/Makefile
@@ -7,52 +7,84 @@
 
 # By default all the build output is placed under the _build folder, but the user can override it
 # setting the NSI_BUILD_PATH
+#
+# The caller can provide an optional configuration file and point to it with NSI_CONFIG_FILE
+# See "Configurable/user overridible variables" below.
+#
+# By default only the core of the runner will be built, but the caller can set NSI_NATIVE
+# to also build the components in native/src/
 
 NSI_CONFIG_FILE?=nsi_config
 -include ${NSI_CONFIG_FILE}
 #If the file does not exist, we don't use it as a build dependency
 NSI_CONFIG_FILE:=$(wildcard ${NSI_CONFIG_FILE})
 
+# Configurable/user overridible variables:
+#  Path to the native_simulator (this folder):
 NSI_PATH?=./
+#  Folder where the build output will be placed
 NSI_BUILD_PATH?=$(abspath _build/)
 EXE_NAME?=native_simulator.exe
+#  Final executable path/file_name which will be produced
 NSI_EXE?=${NSI_BUILD_PATH}/${EXE_NAME}
+#  Path to the embedded SW which will be linked with the final executable
 NSI_EMBEDDED_CPU_SW?=
+#  Host architecture configuration switch
 NSI_ARCH?=-m32
+#  Coverage switch (GCOV coverage is enabled by default)
 NSI_COVERAGE?=--coverage
 NSI_BUILD_OPTIONS?=${NSI_ARCH} ${NSI_COVERAGE}
 NSI_LINK_OPTIONS?=${NSI_ARCH} ${NSI_COVERAGE}
+#  Extra source files to be built in the runner context
 NSI_EXTRA_SRCS?=
+#  Extra include directories to be used while building in the runner context
+NSI_EXTRA_INCLUDES?=
+#  Extra libraries to be linked to the final executable
 NSI_EXTRA_LIBS?=
 
 SHELL?=bash
+#  Compiler
 NSI_CC?=gcc
+#  Archive program (it is unlikely you'll need to change this)
 NSI_AR?=ar
+#  Objcopy program (it is unlikely you'll need to change this)
 NSI_OBJCOPY?=objcopy
 
-no_default:
-	@echo "There is no default rule, please specify what you want to build,\
- or run make help for more info"
-
+#  Build debug switch (by default enabled)
 NSI_DEBUG?=-g
+#  Build optimization level (by default disabled to ease debugging)
 NSI_OPT?=-O0
+#  Warnings swtiches (for the runner itself)
 NSI_WARNINGS?=-Wall -Wpedantic
+#  Preprocessor flags
 NSI_CPPFLAGS?=-D_POSIX_C_SOURCE=200809 -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED
+
 NO_PIE_CO:=-fno-pie -fno-pic
 DEPENDFLAGS:=-MMD -MP
 CFLAGS:=${NSI_DEBUG} ${NSI_WARNINGS} ${NSI_OPT} ${NO_PIE_CO} \
   -ffunction-sections -fdata-sections ${DEPENDFLAGS} -std=c11 ${NSI_BUILD_OPTIONS}
 FINALLINK_FLAGS:=${NO_PIE_CO} -no-pie  ${NSI_WARNINGS} \
-  -Wl,--gc-sections -lm -ldl -pthread \
-  ${NSI_LINK_OPTIONS}
+  -Wl,--gc-sections -ldl -pthread \
+  ${NSI_LINK_OPTIONS} -lm
+
+no_default:
+	@echo "There is no default rule, please specify what you want to build,\
+ or run make help for more info"
 
 RUNNER_LIB:=runner.a
 
-SRCS:=$(shell ls ${NSI_PATH}common/src/*.c ${NSI_PATH}native/src/*.c )
+SRCS:=$(shell ls ${NSI_PATH}common/src/*.c)
+ifdef NSI_NATIVE
+  SRCS+=$(shell ls ${NSI_PATH}native/src/*.c)
+endif
 
 INCLUDES:=-I${NSI_PATH}common/src/include/ \
- -I${NSI_PATH}native/src/include/ \
- -I${NSI_PATH}common/src
+ -I${NSI_PATH}common/src \
+ ${NSI_EXTRA_INCLUDES}
+
+ifdef NSI_NATIVE
+  INCLUDES+=-I${NSI_PATH}native/src/include/
+endif
 
 EXTRA_OBJS:=$(abspath $(addprefix $(NSI_BUILD_PATH)/,$(sort ${NSI_EXTRA_SRCS:%.c=%.o})))
 OBJS:=$(abspath $(addprefix $(NSI_BUILD_PATH)/,${SRCS:${NSI_PATH}%.c=%.o})) ${EXTRA_OBJS}

--- a/scripts/native_simulator/common/other/linker_script.pre.ld
+++ b/scripts/native_simulator/common/other/linker_script.pre.ld
@@ -32,16 +32,11 @@ SECTIONS
 
 	nsi_hw_events :
 	{
-		__nsi_hw_events_callbacks_start = .;
-		KEEP(*(SORT(.nsi_hw_event[0-9]_callback)));		\
-		KEEP(*(SORT(.nsi_hw_event[1-9][0-9]_callback)));	\
-		KEEP(*(SORT(.nsi_hw_event[1-9][0-9][0-9]_callback)));
-		__nsi_hw_events_callbacks_end = .;
-		__nsi_hw_events_timers_start = .;
-		KEEP(*(SORT(.nsi_hw_event[0-9]_timer)));		\
-		KEEP(*(SORT(.nsi_hw_event[1-9][0-9]_timer)));		\
-		KEEP(*(SORT(.nsi_hw_event[1-9][0-9][0-9]_timer)));
-		__nsi_hw_events_timers_end = .;
+		__nsi_hw_events_start = .;
+		KEEP(*(SORT(.nsi_hw_event_[0-9])));		\
+		KEEP(*(SORT(.nsi_hw_event_[1-9][0-9])));	\
+		KEEP(*(SORT(.nsi_hw_event_[1-9][0-9][0-9])));
+		__nsi_hw_events_end = .;
 	}
  } INSERT AFTER .data;
 

--- a/scripts/native_simulator/common/src/include/nsi_cmdline_main_if.h
+++ b/scripts/native_simulator/common/src/include/nsi_cmdline_main_if.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief API to the native simulator expects any integrating program has for handling
+ *        command line argument parsing
+ */
+
+#ifndef NATIVE_SIMULATOR_COMMON_SRC_NSI_CMDLINE_MAIN_IF_H
+#define NATIVE_SIMULATOR_COMMON_SRC_NSI_CMDLINE_MAIN_IF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void nsi_handle_cmd_line(int argc, char *argv[]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NATIVE_SIMULATOR_COMMON_SRC_NSI_CMDLINE_MAIN_IF_H */

--- a/scripts/native_simulator/common/src/include/nsi_cpu_if.h
+++ b/scripts/native_simulator/common/src/include/nsi_cpu_if.h
@@ -74,7 +74,7 @@ NATIVE_SIMULATOR_IF void nsif_cpu0_boot(void);
  * The embedded SW library may provide this function.
  * to do any cleanup it needs.
  */
-NATIVE_SIMULATOR_IF void nsif_cpu0_cleanup(void);
+NATIVE_SIMULATOR_IF int nsif_cpu0_cleanup(void);
 
 /*
  * Called by the runner each time an interrupt is raised by the HW

--- a/scripts/native_simulator/common/src/include/nsi_hw_scheduler.h
+++ b/scripts/native_simulator/common/src/include/nsi_hw_scheduler.h
@@ -24,6 +24,7 @@ void nsi_hws_cleanup(void);
 void nsi_hws_one_event(void);
 void nsi_hws_set_end_of_time(uint64_t new_end_of_time);
 void nsi_hws_find_next_event(void);
+uint64_t nsi_hws_get_next_event_time(void);
 
 #ifdef __cplusplus
 }

--- a/scripts/native_simulator/common/src/include/nsi_main.h
+++ b/scripts/native_simulator/common/src/include/nsi_main.h
@@ -12,9 +12,22 @@ extern "C" {
 #endif
 
 /**
+ * @brief Like nsi_exit(), do all cleanup required to terminate the
+ *        execution of the native_simulator, but instead of exiting,
+ *        return to the caller what would have been passed to exit()
+ *
+ * @param[in] exit_code: Requested exit code to the shell
+ *            Note that other components may have requested a different
+ *            exit code which may have precedence if it was !=0
+ *
+ * @returns Code which would have been passed to exit()
+ */
+int nsi_exit_inner(int exit_code);
+
+/**
  * @brief Terminate the execution of the native simulator
  *
- * exit_code: Requested exit code to the shell
+ * @param[in] exit_code: Requested exit code to the shell
  *            Note that other components may have requested a different
  *            exit code which may have precedence if it was !=0
  */

--- a/scripts/native_simulator/common/src/nsi_tasks.h
+++ b/scripts/native_simulator/common/src/nsi_tasks.h
@@ -13,6 +13,14 @@
 extern "C" {
 #endif
 
+#define NSITASK_PRE_BOOT_1_LEVEL	0
+#define NSITASK_PRE_BOOT_2_LEVEL	1
+#define NSITASK_HW_INIT_LEVEL		2
+#define NSITASK_PRE_BOOT_3_LEVEL	3
+#define NSITASK_FIRST_SLEEP_LEVEL	4
+#define NSITASK_ON_EXIT_PRE_LEVEL	5
+#define NSITASK_ON_EXIT_POST_LEVEL	6
+
 /**
  * NSI_TASK
  *
@@ -45,15 +53,10 @@ extern "C" {
 	static void (* const NSI_CONCAT(__nsi_task_, fn))(void) \
 	__attribute__((__used__)) \
 	__attribute__((__section__(".nsi_" #level NSI_STRINGIFY(prio) "_task")))\
-	= fn
-
-#define NSITASK_PRE_BOOT_1_LEVEL	0
-#define NSITASK_PRE_BOOT_2_LEVEL	1
-#define NSITASK_HW_INIT_LEVEL		2
-#define NSITASK_PRE_BOOT_3_LEVEL	3
-#define NSITASK_FIRST_SLEEP_LEVEL	4
-#define NSITASK_ON_EXIT_PRE_LEVEL	5
-#define NSITASK_ON_EXIT_POST_LEVEL	6
+	= fn; \
+	/* Let's cross-check the macro level is a valid one, so we don't silently drop it */ \
+	_Static_assert(NSITASK_##level##_LEVEL >= 0, \
+			"Using a non pre-defined level, it will be dropped")
 
 /**
  * @brief Run the set of special native tasks corresponding to the given level

--- a/scripts/native_simulator/native/src/include/nsi_cmdline.h
+++ b/scripts/native_simulator/native/src/include/nsi_cmdline.h
@@ -19,6 +19,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include "nsi_cmdline_main_if.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,11 +69,9 @@ struct args_struct_t {
 #define ARG_TABLE_ENDMARKER \
 	{false, false, false, NULL, NULL, 0, NULL, NULL, NULL}
 
-void nsi_handle_cmd_line(int argc, char *argv[]);
 void nsi_get_cmd_line_args(int *argc, char ***argv);
 void nsi_get_test_cmd_line_args(int *argc, char ***argv);
 void nsi_add_command_line_opts(struct args_struct_t *args);
-void nsi_cleanup_cmd_line(void);
 
 #ifdef __cplusplus
 }

--- a/scripts/native_simulator/native/src/nsi_cmdline.c
+++ b/scripts/native_simulator/native/src/nsi_cmdline.c
@@ -13,6 +13,7 @@
 #include "nsi_tracing.h"
 #include "nsi_timer_model.h"
 #include "nsi_hw_scheduler.h"
+#include "nsi_tasks.h"
 
 static int s_argc, test_argc;
 static char **s_argv, **test_argv;
@@ -22,13 +23,15 @@ static int used_args;
 static int args_aval;
 #define ARGS_ALLOC_CHUNK_SIZE 20
 
-void nsi_cleanup_cmd_line(void)
+static void nsi_cleanup_cmd_line(void)
 {
 	if (args_struct != NULL) { /* LCOV_EXCL_BR_LINE */
 		free(args_struct);
 		args_struct = NULL;
 	}
 }
+
+NSI_TASK(nsi_cleanup_cmd_line, ON_EXIT_POST, 0);
 
 /**
  * Add a set of command line options to the program.


### PR DESCRIPTION
Align with the latest [upstream native simulator](https://github.com/BabbleSim/native_simulator/)
4c595794588f9d7f67fcf0fe05c3db02892a00f9
including:

    * 4c59579 Makefile: Add option to build native part
    * 910f934 Makefile: NSI_EXTRA_INCLUDES option and lots of commentary
    * d9bf489 cmd line parsin: Minor header refactoring
    * 02f3555 cmd line cleanup: Run as NSI_TASK instead of calling expl.
    * 2c88173 Split exit call in two
    * 2b989b4 CPU IF change: nsif_cpu0_cleanup() to return int
    * e696228 HW scheduler: Add API to get next event time
    * ae0e9e8 native irq ctrl: Miscellaneous fixes and improvements
    * 3fd84cd NSI_TASK: Add compile check of valid priority
    * 7e09fb8 HW events: Change internal storage
    
And two minor updates to the native_sim board, to align with this updated version:

* nsif_cpu0_cleanup(void) now must return an int
* We need to explicitly tell the native simul

------

All changes to scripts/native_simulator/ are a direct merge from the native simulator upstream.
Only the 2 minor changes to the native_sim board (boards/posix/native_sim ) are the changes done in Zephyr itself (beyond that merge)