### PR TITLE
hci: Make the disc. complete event NOT prioritized

### DIFF
--- a/include/zephyr/drivers/bluetooth/hci_driver.h
+++ b/include/zephyr/drivers/bluetooth/hci_driver.h
@@ -61,7 +61,8 @@ static inline uint8_t bt_hci_evt_get_flags(uint8_t evt)
 {
 	switch (evt) {
 	case BT_HCI_EVT_DISCONN_COMPLETE:
-		return BT_HCI_EVT_FLAG_RECV | BT_HCI_EVT_FLAG_RECV_PRIO;
+		/* return BT_HCI_EVT_FLAG_RECV | BT_HCI_EVT_FLAG_RECV_PRIO; */
+		return BT_HCI_EVT_FLAG_RECV;
 		/* fallthrough */
 #if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_ISO)
 	case BT_HCI_EVT_NUM_COMPLETED_PACKETS:


### PR DESCRIPTION
Fixes issue #61465.

Prioritizing the disconnect complete event causes out of order handling of the disconnect event which in turn causes a successful pairing to fail the device that initiates the pairing disconnects shortly after the pairing has successfully completed.