### PR TITLE
ztest: Document ZTEST_DMEM & ZTEST_BMEM

### DIFF
--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -111,6 +111,11 @@ This is achieved via fixtures in the following way:
    	zassert_equal(256, fixture->max_size);
    }
 
+Using memory allocated by a test fixture in a userspace thread, such as during execution of
+:c:macro:`ZTEST_USER` or :c:macro:`ZTEST_USER_F`, requires that memory to be declared userspace
+accessible. This is because the fixture memory is owned and initialized by kernel space. The Ztest
+framework provides the :c:macro:`ZTEST_DMEM` and :c:macro:`ZTEST_BMEM` macros for use of such
+user/kernel space shared memory.
 
 Advanced features
 *****************


### PR DESCRIPTION
We use ZTEST_DMEM and ZTEST_BMEM for running tests with memory shared between userspace and kernelspace. This ought to be documented.

Document ZTEST_DMEM and ZTEST_BMEM.