### PR TITLE
net: socket: Make the send timeout configurable

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -64,6 +64,13 @@ config NET_SOCKETS_DNS_TIMEOUT
 	  query is considered timeout. Minimum timeout is 1 second and
 	  maximum timeout is 5 min.
 
+config NET_SOCKET_MAX_SEND_WAIT
+	int "Max time in milliseconds waiting for a send command"
+	default 10000
+	help
+	  The maximum time a socket is waiting for a blocked connection before
+	  returning an ENOBUFS error.
+
 config NET_SOCKETS_SOCKOPT_TLS
 	bool "TCP TLS socket option support [EXPERIMENTAL]"
 	imply TLS_CREDENTIALS

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -689,7 +689,7 @@ static inline int z_vrfy_zsock_accept(int sock, struct sockaddr *addr,
 
 #define WAIT_BUFS_INITIAL_MS 10
 #define WAIT_BUFS_MAX_MS 100
-#define MAX_WAIT_BUFS K_SECONDS(10)
+#define MAX_WAIT_BUFS K_MSEC(CONFIG_NET_SOCKET_MAX_SEND_WAIT)
 
 static int send_check_and_wait(struct net_context *ctx, int status,
 			       k_timepoint_t buf_timeout, k_timeout_t timeout,


### PR DESCRIPTION
When the protocol layer like TCP is blocking transmission, the socket layer will attempt and wait for a maximum amount of time before returning with an ENOBUFS error.
This change allows to set the maximum waiting time from the configuration file instead of using a fixed 10 second value.

I used the value in milliseconds, as the other values are also in milliseconds.