### PR TITLE
Bluetooth: Shell: Add value handle to notification print

### DIFF
--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -562,7 +562,8 @@ static uint8_t notify_func(struct bt_conn *conn,
 		return BT_GATT_ITER_STOP;
 	}
 
-	shell_print(ctx_shell, "Notification: length %u", length);
+	shell_print(ctx_shell, "Notification: value_handle %u, length %u",
+		    params->value_handle, length);
 	shell_hexdump(ctx_shell, data, length);
 
 	return BT_GATT_ITER_CONTINUE;


### PR DESCRIPTION
This makes it possible to see what service the notification corresponds to.