### PR TITLE
doc: release process: link to milestone dates on wiki

### DIFF
--- a/doc/project/release_process.rst
+++ b/doc/project/release_process.rst
@@ -45,6 +45,12 @@ The Zephyr release model was loosely based on the Linux kernel model:
 
     Release Cycle
 
+.. note::
+
+    The milestones for the current major version can be found on the
+    `Official GitHub Wiki <https://github.com/zephyrproject-rtos/zephyr/wiki/Release-Management>`_.
+    Information on previous releases can be found :ref:`here <zephyr_release_notes>`.
+
 Development Phase
 *****************
 


### PR DESCRIPTION
This adds a link for convenience. Many times before I struggled to find the date for the next feature freeze. This is to help others, and myself, to find it easier in the future.