### PR TITLE
fs: ext2: Remove comparing unsigned < 0 and other fixes

### DIFF
--- a/subsys/fs/ext2/ext2_diskops.c
+++ b/subsys/fs/ext2/ext2_diskops.c
@@ -615,10 +615,6 @@ static int get_level_offsets(struct ext2_data *fs, uint32_t block, uint32_t offs
 	const uint32_t lvl2_blks = B * B;
 	const uint32_t lvl3_blks = B * B * B;
 
-	if (block < 0) {
-		return -EINVAL;
-	}
-
 	/* Level 0 */
 	if (block < lvl0_blks) {
 		offsets[0] = block;

--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -823,12 +823,12 @@ int ext2_get_direntry(struct ext2_file *dir, struct fs_dirent *ent)
 		EXT2_DISK_DIRENTRY_BY_OFFSET(inode_current_block_mem(dir->f_inode), block_off);
 	struct ext2_direntry *de = ext2_fetch_direntry(disk_de);
 
-	LOG_DBG("inode=%d name_len=%d rec_len=%d", de->de_inode, de->de_name_len, de->de_rec_len);
-
 	if (de == NULL) {
 		LOG_ERR("Read directory entry name too long");
 		return -EINVAL;
 	}
+
+	LOG_DBG("inode=%d name_len=%d rec_len=%d", de->de_inode, de->de_name_len, de->de_rec_len);
 
 	len = de->de_name_len;
 	if (de->de_name_len > MAX_FILE_NAME) {

--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -1501,7 +1501,7 @@ int ext2_inode_drop(struct ext2_inode *inode)
 		/* find entry */
 		uint32_t offset = 0;
 
-		while (fs->inode_pool[offset] != inode && offset < MAX_INODES) {
+		while (offset < MAX_INODES && fs->inode_pool[offset] != inode) {
 			offset++;
 		}
 

--- a/subsys/fs/ext2/ext2_ops.c
+++ b/subsys/fs/ext2/ext2_ops.c
@@ -245,9 +245,9 @@ static int ext2_mkdir(struct fs_mount_t *mountp, const char *name)
 
 	const char *path = fs_impl_strip_prefix(name, mountp);
 	struct ext2_lookup_args args = {
-		args.path = path,
-		args.inode = NULL,
-		args.parent = NULL,
+		.path = path,
+		.inode = NULL,
+		.parent = NULL,
 	};
 
 	args.flags = LOOKUP_ARG_CREATE;
@@ -503,9 +503,9 @@ static int ext2_unlink(struct fs_mount_t *mountp, const char *name)
 
 	const char *path = fs_impl_strip_prefix(name, mountp);
 	struct ext2_lookup_args args = {
-		args.path = path,
-		args.inode = NULL,
-		args.parent = NULL,
+		.path = path,
+		.inode = NULL,
+		.parent = NULL,
 	};
 
 	args.flags = LOOKUP_ARG_UNLINK;

--- a/subsys/fs/ext2/ext2_ops.c
+++ b/subsys/fs/ext2/ext2_ops.c
@@ -174,8 +174,7 @@ static ssize_t ext2_write(struct fs_file_t *filp, const void *src, size_t nbytes
 static int ext2_lseek(struct fs_file_t *filp, off_t off, int whence)
 {
 	struct ext2_file *f = filp->filep;
-
-	uint32_t new_off = 0;
+	off_t new_off = 0;
 
 	switch (whence) {
 	case FS_SEEK_SET:


### PR DESCRIPTION
Remove never true comparisons for ext2, buffer overrun and de-reference before NULL check.