### PR TITLE
mgmt: mcumgr: transport: udp: Fix non-automatic start

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/smp_udp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_udp.c
@@ -93,9 +93,7 @@ static struct configs configs = {
 #endif
 };
 
-#ifdef CONFIG_MCUMGR_TRANSPORT_UDP_AUTOMATIC_INIT
 static struct net_mgmt_event_callback smp_udp_mgmt_cb;
-#endif
 
 static const char *smp_udp_proto_to_name(enum proto_type proto)
 {


### PR DESCRIPTION
Fixes a stray ifdef which causes a build failure if the automatic UDP start Kconfig is not enabled.

Fixes #61492