### PR TITLE
tests: ztest: zexpect: include directly main.c instead of symlink

### DIFF
--- a/tests/ztest/zexpect/CMakeLists.txt
+++ b/tests/ztest/zexpect/CMakeLists.txt
@@ -15,7 +15,5 @@ else()
     target_sources(app PRIVATE src/main.cpp)
   else()
     target_sources(app PRIVATE src/main.c)
-
-    target_sources_ifdef(CONFIG_USERSPACE app PRIVATE src/main_userspace.c)
   endif()
 endif()

--- a/tests/ztest/zexpect/src/main.cpp
+++ b/tests/ztest/zexpect/src/main.cpp
@@ -1,1 +1,1 @@
-main.c
+#include "main.c"


### PR DESCRIPTION
The main.cpp was introduced as a symbolic link (look like on Ubuntu machine or the like) of main.c but this makes the test build failure on Windows, so just include directly main.c in cpp source instead
Also there is no _src/main_userspace.c_ so just remove the line