### PR TITLE
scripts: compliance: add a check for missing west area maintainer enties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ Kconfig.txt
 KconfigBasic.txt
 KconfigBasicNoModules.txt
 MaintainersFormat.txt
+ModulesMaintainers.txt
 Nits.txt
 Pylint.txt
 YAMLLint.txt

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -22,6 +22,9 @@ from yamllint import config, linter
 from junitparser import TestCase, TestSuite, JUnitXml, Skipped, Error, Failure
 import magic
 
+from west.manifest import Manifest
+from west.manifest import ManifestProject
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from get_maintainer import Maintainers, MaintainersError
 
@@ -1083,6 +1086,40 @@ class MaintainersFormat(ComplianceTest):
                 Maintainers(file)
             except MaintainersError as ex:
                 self.failure(f"Error parsing {file}: {ex}")
+
+class ModulesMaintainers(ComplianceTest):
+    """
+    Check that all modules have a MAINTAINERS entry.
+    """
+    name = "ModulesMaintainers"
+    doc = "Check that all modules have a MAINTAINERS entry."
+    path_hint = "<git-top>"
+
+    def run(self):
+        MAINTAINERS_FILES = ["MAINTAINERS.yml", "MAINTAINERS.yaml"]
+
+        manifest = Manifest.from_file()
+
+        maintainers_file = None
+        for file in MAINTAINERS_FILES:
+            if os.path.exists(file):
+                maintainers_file = file
+                break
+        if not maintainers_file:
+            return
+
+        maintainers = Maintainers(maintainers_file)
+
+        for project in manifest.get_projects([]):
+            if not manifest.is_active(project):
+                continue
+
+            if isinstance(project, ManifestProject):
+                continue
+
+            area = f"West project: {project.name}"
+            if area not in maintainers.areas:
+                self.failure(f"Missing {maintainers_file} entry for: \"{area}\"")
 
 
 class YAMLLint(ComplianceTest):


### PR DESCRIPTION
Add a compliance check to ensure all modules have a matching maintainer entry, add the two missing ones (added in https://github.com/zephyrproject-rtos/zephyr/pull/42580 and https://github.com/zephyrproject-rtos/zephyr/pull/56347)

@kristofer-jonsson-arm @najumon1980