### PR TITLE
ci: bsim workflow: nice down test images build

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -129,7 +129,7 @@ jobs:
         if: steps.check-bluetooth-files.outputs.any_changed == 'true' || steps.check-common-files.outputs.any_changed == 'true'
         run: |
           export ZEPHYR_BASE=${PWD}
-          WORK_DIR=${ZEPHYR_BASE}/bsim_bluetooth tests/bsim/bluetooth/compile.sh
+          WORK_DIR=${ZEPHYR_BASE}/bsim_bluetooth nice tests/bsim/bluetooth/compile.sh
           RESULTS_FILE=${ZEPHYR_BASE}/${bsim_bluetooth_test_results_file} \
           SEARCH_PATH=tests/bsim/bluetooth/ tests/bsim/run_parallel.sh
 
@@ -137,7 +137,7 @@ jobs:
         if: steps.check-networking-files.outputs.any_changed == 'true' || steps.check-common-files.outputs.any_changed == 'true'
         run: |
           export ZEPHYR_BASE=${PWD}
-          WORK_DIR=${ZEPHYR_BASE}/bsim_net tests/bsim/net/compile.sh
+          WORK_DIR=${ZEPHYR_BASE}/bsim_net nice tests/bsim/net/compile.sh
           RESULTS_FILE=${ZEPHYR_BASE}/${bsim_networking_test_results_file} \
           SEARCH_PATH=tests/bsim/net/ tests/bsim/run_parallel.sh
 


### PR DESCRIPTION
The compile script was modified to fully parallelize all bsim test images builds (https://github.com/zephyrproject-rtos/zephyr/pull/52484).
This speed up the build time, but as we are
building ~80 images, the average load on the system will skyrocket to over 200.
For CI systems we are seeing in quite many cases,
the CI server loosing connection with the CI runner, while this part of the job is run, and suspect it is due to this load.

Nice the job down (by the default +10),
as this should alleviate this problem without slowing down the job.

---

An example run where connection is lost:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/5854017481/attempts/1?pr=61467