### PR TITLE
manifest: move optional modules to a submanifest and make them optional

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -58,6 +58,7 @@ jobs:
           git log  --pretty=oneline | head -n 10
           west init -l . || true
           west config --global update.narrow true
+          west config manifest.group-filter -- +ci,+optional
           # In some cases modules are left in a state where they can't be
           # updated (i.e. when we cancel a job and the builder is killed),
           # So first retry to update, if that does not work, remove all modules

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -44,6 +44,7 @@ jobs:
         # debug
         git log  --pretty=oneline | head -n 10
         west init -l . || true
+        west config manifest.group-filter -- +ci,+optional
         west update 2>&1 1> west.update.log || west update 2>&1 1> west.update2.log
 
     - name: Run Compliance Tests

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -75,7 +75,7 @@ jobs:
           git rebase origin/${BASE_REF}
           git log  --pretty=oneline | head -n 10
           west init -l . || true
-          west config manifest.group-filter -- +ci
+          west config manifest.group-filter -- +ci,+optional
           west config --global update.narrow true
           west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
           west forall -c 'git reset --hard HEAD'
@@ -174,6 +174,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
           west init -l . || true
+          west config manifest.group-filter -- +ci,+optional
           west config --global update.narrow true
           west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
           west forall -c 'git reset --hard HEAD'

--- a/doc/_extensions/zephyr/manifest_projects_table.py
+++ b/doc/_extensions/zephyr/manifest_projects_table.py
@@ -1,0 +1,141 @@
+"""
+Manifest Revisions Table
+========================
+
+This extension allows to render a table containing the revisions of the projects
+present in a manifest file.
+
+Usage
+*****
+
+This extension introduces a new directive: ``manifest-projects-table``. It can
+be used in the code as::
+
+    .. manifest-projects-table::
+        :filter: active
+
+where the ``:filter:`` option can have the following values: active, inactive, all.
+
+Options
+*******
+
+- ``manifest_projects_table_manifest``: Path to the manifest file.
+
+Copyright (c) Nordic Semiconductor ASA 2022
+Copyright (c) Intel Corp 2023
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import re
+from typing import Any, Dict, List
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.application import Sphinx
+from sphinx.util.docutils import SphinxDirective
+from west.manifest import Manifest
+
+
+__version__ = "0.1.0"
+
+
+class ManifestProjectsTable(SphinxDirective):
+    """Manifest revisions table."""
+
+    option_spec = {
+        "filter": directives.unchanged,
+    }
+
+    @staticmethod
+    def rev_url(base_url: str, rev: str) -> str:
+        """Return URL for a revision.
+
+        Notes:
+            Revision format is assumed to be a git hash or a tag. URL is
+            formatted assuming a GitHub base URL.
+
+        Args:
+            base_url: Base URL of the repository.
+            rev: Revision.
+
+        Returns:
+            URL for the revision.
+        """
+
+        if re.match(r"^[0-9a-f]{40}$", rev):
+            return f"{base_url}/commit/{rev}"
+
+        return f"{base_url}/releases/tag/{rev}"
+
+    def run(self) -> List[nodes.Element]:
+        active_filter = self.options.get("filter", None)
+
+        manifest = Manifest.from_file(self.env.config.manifest_projects_table_manifest)
+        projects = []
+        for project in manifest.projects:
+            if project.name == "manifest":
+                continue
+            if active_filter == 'active' and manifest.is_active(project):
+                projects.append(project)
+            elif active_filter == 'inactive' and not manifest.is_active(project):
+                projects.append(project)
+            elif active_filter == 'all' or active_filter is None:
+                projects.append(project)
+
+        # build table
+        table = nodes.table()
+
+        tgroup = nodes.tgroup(cols=2)
+        tgroup += nodes.colspec(colwidth=1)
+        tgroup += nodes.colspec(colwidth=1)
+        table += tgroup
+
+        thead = nodes.thead()
+        tgroup += thead
+
+        row = nodes.row()
+        thead.append(row)
+
+        entry = nodes.entry()
+        entry += nodes.paragraph(text="Project")
+        row += entry
+        entry = nodes.entry()
+        entry += nodes.paragraph(text="Revision")
+        row += entry
+
+        rows = []
+        for project in projects:
+            row = nodes.row()
+            rows.append(row)
+
+            entry = nodes.entry()
+            entry += nodes.paragraph(text=project.name)
+            row += entry
+            entry = nodes.entry()
+            par = nodes.paragraph()
+            par += nodes.reference(
+                project.revision,
+                project.revision,
+                internal=False,
+                refuri=ManifestProjectsTable.rev_url(project.url, project.revision),
+            )
+            entry += par
+            row += entry
+
+        tbody = nodes.tbody()
+        tbody.extend(rows)
+        tgroup += tbody
+
+        return [table]
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    app.add_config_value("manifest_projects_table_manifest", None, "env")
+
+    directives.register_directive("manifest-projects-table", ManifestProjectsTable)
+
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -82,6 +82,7 @@ extensions = [
     "zephyr.warnings_filter",
     "zephyr.doxyrunner",
     "zephyr.vcs_link",
+    "zephyr.manifest_projects_table",
     "notfound.extension",
     "sphinx_copybutton",
     "sphinx_togglebutton",
@@ -171,6 +172,7 @@ html_context = {
         "API": f"{reference_prefix}/doxygen/html/index.html",
         "Kconfig Options": f"{reference_prefix}/kconfig.html",
         "Devicetree Bindings": f"{reference_prefix}/build/dts/api/bindings.html",
+        "West Projects": f"{reference_prefix}/develop/projects/index.html",
     }
 }
 
@@ -292,6 +294,7 @@ external_content_contents = [
 ]
 external_content_keep = [
     "reference/kconfig/*",
+    "develop/manifest/index.rst",
     "build/dts/api/bindings.rst",
     "build/dts/api/bindings/**/*",
     "build/dts/api/compatibles/**/*",

--- a/doc/contribute/external.rst
+++ b/doc/contribute/external.rst
@@ -103,6 +103,47 @@ With this approach the code is considered as being developed externally, and
 thus it is not automatically subject to the requirements of the previous
 section.
 
+Integration in main manifest file (west.yaml)
++++++++++++++++++++++++++++++++++++++++++++++
+
+Integrating external code into the main :file:`west.yml` manifest file is
+limited to code that is used by a Zephyr subsystem (libraries), by a platform,
+drivers (HAL) or tooling needed to test or build Zephyr components.
+
+The integration of modules in this group is validated by the Zephyr project CI,
+and verified to be working with each Zephyr release.
+
+Integrated modules will not be removed from the tree without a detailed
+migration plan.
+
+Integration as optional modules
++++++++++++++++++++++++++++++++
+
+Standalone or loose integration of modules/projects without any incoming
+dependencies shall be made optional and shall be kept standalone. Optional
+projects that provide value to users directly and through a Zephyr subsystem or
+platform shall be added to an optional manifest file that is filtered by
+default. (:file:`submanifests/optional.yml`).
+
+Such optional projects might include samples and tests in their own repositories.
+
+There shall not be any direct dependency added in the Zephyr code tree (Git
+repository) and all sample or test code shall be maintained as part of the module.
+
+.. note::
+
+   This is valid for all new optional modules. Existing optional modules with
+   samples and test code in the Zephyr Git repository will be transitioned out
+   over time.
+
+Integration as external modules
++++++++++++++++++++++++++++++++
+
+Similar to optional modules, but added to the Zephyr project as an entry in the
+documentation using a pre-defined template. This type of modules exists outside the
+Zephyr project manifest with documentation instructing users and developers how
+to integrate the functionality.
+
 Ongoing maintenance
 ===================
 

--- a/doc/develop/manifest/index.rst
+++ b/doc/develop/manifest/index.rst
@@ -1,0 +1,58 @@
+:orphan:
+
+.. _west_projects_index:
+
+West Projects index
+###################
+
+See :ref:`external-contributions` for more information about
+this contributing and review process for imported components.
+
+Active Projects/Modules
++++++++++++++++++++++++
+
+The projects below are enabled by default and will be downloaded when you
+call `west update`. Many of the projects or modules listed below are
+essential for building generic Zephyr application and include among others
+hardware support for many of the platforms available in Zephyr.
+
+To disable any of the active modules, for example a specific HAL, use the
+following commands::
+
+        west config manifest.project-filter -- -hal_FOO
+        west update
+
+.. manifest-projects-table::
+   :filter: active
+
+Inactive and Optional Projects/Modules
+++++++++++++++++++++++++++++++++++++++
+
+
+The projects below are optional and will not be downloaded when you
+call `west update`. You can add any of the the projects or modules listed below
+and use them to write application code and extend your workspace with the added
+functionality.
+
+To enable any of the modules below, use the following commands::
+
+        west config manifest.project-filter -- +nanopb
+        west update
+
+.. manifest-projects-table::
+   :filter: inactive
+
+External Projects/Modules
+++++++++++++++++++++++++++
+
+
+The projects listed below are external and are not directly imported into the
+default manifest.
+To use any of the projects below, you will need to define your own manifest
+file which includes them.  See :ref:`west-manifest-import` for information on
+recommended ways to do this while still inheriting the mandatory modules from
+Zephyr's :file:`west.yml`.
+
+.. rst-class:: rst-columns
+
+- TBD

--- a/samples/compression/lz4/sample.yaml
+++ b/samples/compression/lz4/sample.yaml
@@ -12,6 +12,8 @@ common:
     type: one_line
     regex:
       - "Validation done. (.*)"
+  modules:
+    - lz4
 tests:
   sample.compression.lz4:
     integration_platforms:

--- a/samples/modules/tflite-micro/tflm_ethosu/sample.yaml
+++ b/samples/modules/tflite-micro/tflm_ethosu/sample.yaml
@@ -3,7 +3,10 @@ sample:
   name: Arm Ethos-U NPU sample
 tests:
   sample.drivers.tflm_ethosu:
-    tags: NPU
+    tags:
+      - NPU
+    modules:
+      - tflite-micro
     filter: dt_compat_enabled("arm,ethos-u")
     build_only: true
     integration_platforms:

--- a/samples/tfm_integration/tfm_psa_test/sample.yaml
+++ b/samples/tfm_integration/tfm_psa_test/sample.yaml
@@ -8,6 +8,9 @@ common:
     - nrf9160dk_nrf9160_ns
     - nrf9161dk_nrf9161_ns
     - v2m_musca_s1_ns
+  modules:
+    - psa-arch-tests
+    - tf-m-tests
   integration_platforms:
     - mps2_an521_ns
   harness: console

--- a/samples/tfm_integration/tfm_regression_test/sample.yaml
+++ b/samples/tfm_integration/tfm_regression_test/sample.yaml
@@ -2,8 +2,9 @@ common:
   tags:
     - trusted-firmware-m
     - mcuboot
+  modules:
+    - psa-arch-tests
   platform_allow:
-
     - nrf5340dk_nrf5340_cpuapp_ns
     - nrf9160dk_nrf9160_ns
     - nrf9161dk_nrf9161_ns

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -64,6 +64,8 @@ class Filters:
     SKIP = 'Skip filter'
     # in case of incompatibility between selected and allowed toolchains.
     TOOLCHAIN = 'Toolchain filter'
+    # in case an optional module is not available
+    MODULE = 'Module filter'
 
 
 class TestLevel:
@@ -743,7 +745,7 @@ class TestPlan:
 
                 if ts.modules and self.modules:
                     if not set(ts.modules).issubset(set(self.modules)):
-                        instance.add_filter(f"one or more required modules not available: {','.join(ts.modules)}", Filters.TESTSUITE)
+                        instance.add_filter(f"one or more required modules not available: {','.join(ts.modules)}", Filters.MODULE)
 
                 if self.options.level:
                     tl = self.get_level(self.options.level)
@@ -1038,7 +1040,7 @@ def change_skip_to_error_if_integration(options, instance):
         # Do not treat this as error if filter type is command line
         filters = {t['type'] for t in instance.filters}
         ignore_filters ={Filters.CMD_LINE, Filters.SKIP, Filters.PLATFORM_KEY,
-                         Filters.TOOLCHAIN}
+                         Filters.TOOLCHAIN, Filters.MODULE}
         if filters.intersection(ignore_filters):
             return
         instance.status = "error"

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -1,0 +1,60 @@
+manifest:
+  remotes:
+    - name: upstream
+      url-base: https://github.com/zephyrproject-rtos
+  projects:
+    - name: chre
+      revision: b7955c27e50485b7dafdc3888d7d6afdc2ac6d96
+      path: modules/lib/chre
+      remote: upstream
+      groups:
+        - optional
+    - name: lz4
+      revision: 8e303c264fc21c2116dc612658003a22e933124d
+      path: modules/lib/lz4
+      remote: upstream
+      groups:
+        - optional
+    - name: nanopb
+      revision: 42fa8b211e946b90b9d968523fce7b1cfe27617e
+      path: modules/lib/nanopb
+      remote: upstream
+      groups:
+        - optional
+    - name: psa-arch-tests
+      revision: 6a17330e0dfb5f319730f974d5b05f7b7f04757b
+      path: modules/tee/tf-m/psa-arch-tests
+      remote: upstream
+      groups:
+        - optional
+    - name: sof
+      revision: c0f20b69daa44e3563f970b366e49ccfcfa1b71c
+      path: modules/audio/sof
+      remote: upstream
+      groups:
+        - optional
+    - name: tf-m-tests
+      revision: a878426da78fbd1486dfc29d6c6b82be4ee79e72
+      path: modules/tee/tf-m/tf-m-tests
+      remote: upstream
+      groups:
+        - optional
+    - name: tflite-micro
+      revision: 1a34dcab41e7e0e667db72d6a40999c1ec9c510c
+      path: optional/modules/lib/tflite-micro
+      repo-path: tflite-micro
+      remote: upstream
+      groups:
+        - optional
+    - name: thrift
+      path: optional/modules/lib/thrift
+      revision: 10023645a0e6cb7ce23fcd7fd3dbac9f18df6234
+      remote: upstream
+      groups:
+        - optional
+    - name: zscilib
+      path: modules/lib/zscilib
+      revision: 34c3432e81085bb717e4871d21ca419ae0058ec5
+      remote: upstream
+      groups:
+        - optional

--- a/west.yml
+++ b/west.yml
@@ -24,7 +24,7 @@ manifest:
     - name: babblesim
       url-base: https://github.com/BabbleSim
 
-  group-filter: [-babblesim]
+  group-filter: [-babblesim, -optional]
 
   #
   # Please add items below based on alphabetical order
@@ -118,9 +118,6 @@ manifest:
     - name: canopennode
       revision: dec12fa3f0d790cafa8414a4c2930ea71ab72ffd
       path: modules/lib/canopennode
-    - name: chre
-      revision: b7955c27e50485b7dafdc3888d7d6afdc2ac6d96
-      path: modules/lib/chre
     - name: cmsis
       revision: 5a00331455dd74e31e80efa383a489faea0590e3
       path: modules/hal/cmsis
@@ -278,9 +275,6 @@ manifest:
     - name: lvgl
       revision: 8a6a2d1d29d17d1e4bdc94c243c146a39d635fdd
       path: modules/lib/gui/lvgl
-    - name: lz4
-      revision: 8e303c264fc21c2116dc612658003a22e933124d
-      path: modules/lib/lz4
     - name: mbedtls
       revision: c38dc78d9a8dcbe43b898cc1171ab33ba3e6fc26
       path: modules/crypto/mbedtls
@@ -294,9 +288,6 @@ manifest:
       groups:
         - debug
       revision: a819419603a2dfcb47f7f39092e1bc112e45d1ef
-    - name: nanopb
-      revision: 42fa8b211e946b90b9d968523fce7b1cfe27617e
-      path: modules/lib/nanopb
     - name: net-tools
       revision: e0828aa9629b533644dc96ff6d1295c939bd713c
       path: tools/net-tools
@@ -324,12 +315,6 @@ manifest:
       path: modules/debug/segger
       groups:
         - debug
-    - name: sof
-      revision: c0f20b69daa44e3563f970b366e49ccfcfa1b71c
-      path: modules/audio/sof
-    - name: tflite-micro
-      revision: 1a34dcab41e7e0e667db72d6a40999c1ec9c510c
-      path: modules/lib/tflite-micro
     - name: tinycrypt
       revision: 3e9a49d2672ec01435ffbf0d788db6d95ef28de0
       path: modules/crypto/tinycrypt
@@ -345,28 +330,12 @@ manifest:
       path: modules/tee/tf-a/trusted-firmware-a
       groups:
         - tee
-    - name: tf-m-tests
-      revision: a878426da78fbd1486dfc29d6c6b82be4ee79e72
-      path: modules/tee/tf-m/tf-m-tests
-      groups:
-        - tee
-    - name: psa-arch-tests
-      revision: 6a17330e0dfb5f319730f974d5b05f7b7f04757b
-      path: modules/tee/tf-m/psa-arch-tests
-      groups:
-        - tee
     - name: uoscore-uedhoc
       revision: 5fe2cb613bd7e4590bd1b00c2adf181ac0229379
       path: modules/lib/uoscore-uedhoc
     - name: zcbor
       revision: 67fd8bb88d3136738661fa8bb5f9989103f4599e
       path: modules/lib/zcbor
-    - name: zscilib
-      path: modules/lib/zscilib
-      revision: 34c3432e81085bb717e4871d21ca419ae0058ec5
-    - name: thrift
-      path: modules/lib/thrift
-      revision: 10023645a0e6cb7ce23fcd7fd3dbac9f18df6234
 
   self:
     path: zephyr


### PR DESCRIPTION
Move optional modules to a submanifest and make them optional by
default.
The idea is to look
at the optional manifest as an area for modules that work with Zephyr,
but not needed directly by zephyr. This could be documented somewhere
for discovery purposes allowing users to enable such modules in their
downstream if desired.

See #54276

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
