### PR TITLE
ignore '.' prefixed directories

### DIFF
--- a/scripts/build/parse_syscalls.py
+++ b/scripts/build/parse_syscalls.py
@@ -90,6 +90,8 @@ def analyze_headers(include_dir, scan_dir, file_list):
     # header files (e.g. for function stubs).
     for base_path in multiple_directories:
         for root, dirs, files in os.walk(base_path, topdown=True):
+            # ignore '.' prefixed directories
+            dirs[:] = [d for d in dirs if not d.startswith(".")]
             dirs.sort()
             files.sort()
             for fn in files:

--- a/scripts/build/parse_syscalls.py
+++ b/scripts/build/parse_syscalls.py
@@ -100,6 +100,7 @@ def analyze_headers(include_dir, scan_dir, file_list):
                 # don't want to trip over
                 path = os.path.join(root, fn)
                 if (not (path.endswith(".h") or path.endswith(".c")) or
+                        fn.startswith(".") or
                         path.endswith(os.path.join(os.sep, 'toolchain',
                                                    'common.h'))):
                     continue


### PR DESCRIPTION
I'm using ccls, and it will generate .ccls-cache under applicaton root, it will be parsed by parse_syscalls.py