### PR TITLE
soc: esp32s3: fix heap_sentry reference

### DIFF
--- a/soc/xtensa/espressif_esp32/esp32s3/default.ld
+++ b/soc/xtensa/espressif_esp32/esp32s3/default.ld
@@ -468,7 +468,6 @@ SECTIONS
 
     . = ALIGN(4);
     _end = ABSOLUTE(.);
-    _heap_sentry = .;
     __data_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
@@ -634,6 +633,8 @@ SECTIONS
 #ifdef CONFIG_GEN_ISR_TABLES
 #include <zephyr/linker/intlist.ld>
 #endif
+
+_heap_sentry = 0x3fceb910;
 
 #include <zephyr/linker/debug-sections.ld>
 


### PR DESCRIPTION
Fix heap_sentry value to point final useful stack area.  

Fixes #61443