### PR TITLE
modem: hl7800: ensure the modem inits with radio on

### DIFF
--- a/drivers/modem/Kconfig.hl7800
+++ b/drivers/modem/Kconfig.hl7800
@@ -321,8 +321,6 @@ config MODEM_HL7800_BOOT_IN_AIRPLANE_MODE
 	help
 	  mdm_hl7800_set_functionality must be used by app to exit
 	  airplane mode.
-	  If bands are reconfigured, then this setting is overridden
-	  because modem is rebooted into full functionality mode.
 
 endchoice
 

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -261,6 +261,7 @@ struct xmodem_packet {
 #define PROFILE_LINE_2                                                         \
 	"S00:255 S01:255 S03:255 S04:255 S05:255 S07:255 S08:255 S10:255\r\n"
 
+#define ADDRESS_FAMILY_IP "IP"
 #define ADDRESS_FAMILY_IPV4 "IPV4"
 #if defined(CONFIG_MODEM_HL7800_ADDRESS_FAMILY_IPV4V6)
 #define MODEM_HL7800_ADDRESS_FAMILY "IPV4V6"
@@ -2708,7 +2709,13 @@ static bool on_cmd_atcmdinfo_pdp_context(struct net_buf **buf, uint16_t len)
 			while ((p != NULL) && (*p != '"') && (i < MDM_ADDR_FAM_MAX_LEN)) {
 				iface_ctx.mdm_pdp_addr_fam[i++] = *p++;
 			}
-			LOG_DBG("PDP address family: %s", iface_ctx.mdm_pdp_addr_fam);
+
+			if (strcmp(ictx.mdm_pdp_addr_fam, ADDRESS_FAMILY_IP) == 0) {
+				snprintk(ictx.mdm_pdp_addr_fam, sizeof(ictx.mdm_pdp_addr_fam), "%s",
+					 ADDRESS_FAMILY_IPV4);
+			}
+
+			LOG_DBG("PDP address family: %s", ictx.mdm_pdp_addr_fam);
 
 			/* APN after second , " */
 			p = strchr(p, ',');
@@ -5138,6 +5145,8 @@ static int modem_reset_and_configure(void)
 {
 	int ret = 0;
 	bool sleep = false;
+	bool config_apn = false;
+	char *apn;
 #ifdef CONFIG_MODEM_HL7800_EDRX
 	int edrx_act_type;
 	char set_edrx_msg[sizeof("AT+CEDRXS=2,4,\"0000\"")];
@@ -5229,15 +5238,7 @@ reboot:
 	}
 #endif
 
-	/* If this isn't defined, then keep the current state.
-	 * If the bands are being reconfigured, this is overridden.
-	 */
-#ifdef CONFIG_MODEM_HL7800_BOOT_IN_AIRPLANE_MODE
-	SEND_AT_CMD_EXPECT_OK("AT+CFUN=4,0");
-#endif
-
 	SEND_AT_CMD_EXPECT_OK("AT+KBNDCFG?");
-
 	/* Configure LTE bands */
 #if CONFIG_MODEM_HL7800_CONFIGURE_BANDS
 #if CONFIG_MODEM_HL7800_BAND_1
@@ -5330,7 +5331,13 @@ reboot:
 	}
 #endif
 
-	iface_ctx.low_power_mode = HL7800_LPM_NONE;
+	/**
+	 * Disable the radio until all config is done.
+	 * This ensures all settings are applied during this session instead of on the next reboot.
+	 */
+	SEND_AT_CMD_EXPECT_OK("AT+CFUN=4,0");
+
+	ictx.low_power_mode = HL7800_LPM_NONE;
 #ifdef CONFIG_MODEM_HL7800_LOW_POWER_MODE
 	/* enable GPIO6 low power monitoring */
 	SEND_AT_CMD_EXPECT_OK("AT+KHWIOCFG=3,1,6");
@@ -5397,17 +5404,9 @@ reboot:
 
 	/* Query PDP context to get APN */
 	SEND_AT_CMD_EXPECT_OK("AT+CGDCONT?");
-	if (strcmp(iface_ctx.mdm_pdp_addr_fam, MODEM_HL7800_ADDRESS_FAMILY)) {
-		/* set PDP context address family along with current APN */
-		ret = write_apn(iface_ctx.mdm_apn.value);
-		if (ret < 0) {
-			goto error;
-		}
-	}
-
-	ret = setup_gprs_connection(iface_ctx.mdm_apn.value);
-	if (ret < 0) {
-		goto error;
+	apn = ictx.mdm_apn.value;
+	if (strcmp(ictx.mdm_pdp_addr_fam, MODEM_HL7800_ADDRESS_FAMILY)) {
+		config_apn = true;
 	}
 
 	/* Query PDP authentication context to get APN username/password.
@@ -5420,15 +5419,25 @@ reboot:
 	if (!iface_ctx.configured) {
 		if (strncmp(iface_ctx.mdm_apn.value, CONFIG_MODEM_HL7800_APN_NAME,
 			    MDM_HL7800_APN_MAX_STRLEN) != 0) {
-			ret = write_apn(CONFIG_MODEM_HL7800_APN_NAME);
-			if (ret < 0) {
-				goto error;
-			} else {
-				goto reboot;
-			}
+			apn = CONFIG_MODEM_HL7800_APN_NAME;
+			config_apn = true;
 		}
 	}
 #endif
+
+	if (config_apn) {
+		/* set PDP context address family along with current APN */
+		ret = write_apn(apn);
+		if (ret < 0) {
+			goto error;
+		}
+		SEND_AT_CMD_EXPECT_OK("AT+CGDCONT?");
+	}
+
+	ret = setup_gprs_connection(ictx.mdm_apn.value);
+	if (ret < 0) {
+		goto error;
+	}
 
 	/* query the network status in case we already registered */
 	SEND_COMPLEX_AT_CMD("AT+CEREG?");
@@ -5441,6 +5450,11 @@ reboot:
 	 */
 	SEND_AT_CMD_EXPECT_OK("AT+KTCPCFG?");
 	SEND_AT_CMD_EXPECT_OK("AT+KUDPCFG?");
+
+	/* Enabled the LTE radio */
+#if !defined(CONFIG_MODEM_HL7800_BOOT_IN_AIRPLANE_MODE)
+	SEND_AT_CMD_EXPECT_OK("AT+CFUN=1,0");
+#endif
 
 	/* The modem has been initialized and now the network interface can be
 	 * started in the CEREG message handler.
@@ -5486,7 +5500,8 @@ static int write_apn(char *access_point_name)
 		strncat(cmd_string, "AT+CGDCONT=1,\"" MODEM_HL7800_ADDRESS_FAMILY "\",\"",
 			MDM_HL7800_APN_CMD_MAX_STRLEN);
 	} else {
-		strncat(cmd_string, "AT+CGDCONT=1,\"IP\",\"", MDM_HL7800_APN_CMD_MAX_STRLEN);
+		strncat(cmd_string, "AT+CGDCONT=1,\"" ADDRESS_FAMILY_IP "\",\"",
+			MDM_HL7800_APN_CMD_MAX_STRLEN);
 	}
 	strncat(cmd_string, access_point_name, MDM_HL7800_APN_CMD_MAX_STRLEN);
 	strncat(cmd_string, "\"", MDM_HL7800_APN_CMD_MAX_STRLEN);


### PR DESCRIPTION
Ensure the driver enables the LTE radio during init unless boot in airplane mode is specified.
To ensure the settings applied during init are used, the LTE radio is turned off during config.
Fix issue where PDP and GPRS connection config could have a mismatched APN.