### PR TITLE
west support simulator flash and debug directly without resort to cmake system

### DIFF
--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -69,7 +69,7 @@ jobs:
     - name: install pytest
       run: |
         pip3 install wheel
-        pip3 install pytest west pyelftools canopen natsort progress mypy intelhex psutil ply pyserial
+        pip3 install pytest west pyelftools canopen natsort progress mypy intelhex psutil ply pyserial types-PyYAML
     - name: run pytest-win
       if: runner.os == 'Windows'
       run: |

--- a/boards/arm/mimxrt595_evk/board.cmake
+++ b/boards/arm/mimxrt595_evk/board.cmake
@@ -9,7 +9,10 @@ board_runner_args(linkserver  "--device=MIMXRT595S:EVK-MIMXRT595")
 board_runner_args(linkserver  "--override=/device/memory/5/flash-driver=MIMXRT500_SFDP_MXIC_OSPI_S.cfx")
 board_runner_args(linkserver  "--override=/device/memory/5/location=0x18000000")
 
+board_runner_args(qemu "--commander=qemu-system-arm_rt595" "--machine=rt595-m33,boot-base-addr=0x18001000")
+set(SUPPORTED_EMU_PLATFORMS qemu)
 
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/arm/mps2_an385/board.cmake
+++ b/boards/arm/mps2_an385/board.cmake
@@ -10,4 +10,6 @@ set(QEMU_FLAGS_${ARCH}
   -vga none
   )
 
-board_set_debugger_ifnset(qemu)
+board_runner_args(qemu "--cpu=cortex-m3" "--machine=mps2-an385")
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/arm/mps2_an521/board.cmake
+++ b/boards/arm/mps2_an521/board.cmake
@@ -10,7 +10,6 @@ set(QEMU_FLAGS_${ARCH}
   -m 16
   -vga none
   )
-board_set_debugger_ifnset(qemu)
 
  # To enable a host tty switch between serial and pty
  #  -chardev serial,path=/dev/ttyS0,id=hostS0
@@ -21,10 +20,30 @@ if (CONFIG_BUILD_WITH_TFM)
   # TF-M (Secure) & Zephyr (Non Secure) image (when running
   # in-tree tests).
   set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/zephyr/tfm_merged.hex")
+
+  FILE(WRITE "${PROJECT_BINARY_DIR}/qemu_runner_variables.conf" "${QEMU_KERNEL_OPTION}"\n)
+  board_runner_args(qemu "--cpu=cortex-m33" "--machine=mps2-an521"
+                  "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/mps2_an521_tfm_option.yml")
 elseif(CONFIG_OPENAMP)
   set(QEMU_EXTRA_FLAGS "-device;loader,file=${REMOTE_ZEPHYR_DIR}/zephyr.elf")
+
+  FILE(WRITE "${PROJECT_BINARY_DIR}/qemu_runner_variables.conf" "${QEMU_EXTRA_FLAGS}"\n)
+
+  board_runner_args(qemu "--cpu=cortex-m33" "--machine=mps2-an521"
+                  "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/mps2_an521_openamp_option.yml")
 elseif (CONFIG_SOC_MPS2_AN521_CPU1)
   set(CPU0_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/zephyr/boards/arm/mps2_an521/empty_cpu0-prefix/src/empty_cpu0-build/zephyr)
   set(QEMU_KERNEL_OPTION "-device;loader,file=${CPU0_BINARY_DIR}/zephyr.elf")
   list(APPEND QEMU_EXTRA_FLAGS "-device;loader,file=${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}")
+
+  FILE(WRITE "${PROJECT_BINARY_DIR}/qemu_runner_variables.conf" "${QEMU_KERNEL_OPTION}"\n)
+  FILE(APPEND "${PROJECT_BINARY_DIR}/qemu_runner_variables.conf" "${QEMU_EXTRA_FLAGS}"\n)
+
+  board_runner_args(qemu "--cpu=cortex-m33" "--machine=mps2-an521"
+                  "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/mps2_an521_cpu1_option.yml")
+else()
+  board_runner_args(qemu "--cpu=cortex-m33" "--machine=mps2-an521"
+                  "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_mps2_an521_option.yml")
 endif()
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/arm/mps2_an521/qemu_mps2_an521_cpu1_option.yml
+++ b/boards/arm/mps2_an521/qemu_mps2_an521_cpu1_option.yml
@@ -1,0 +1,4 @@
+qemu:
+  qemu_option:
+    - "-chardev pty,id=hostS0 -serial chardev:hostS0"
+  variable_options: true

--- a/boards/arm/mps2_an521/qemu_mps2_an521_openamp_option.yml
+++ b/boards/arm/mps2_an521/qemu_mps2_an521_openamp_option.yml
@@ -1,0 +1,4 @@
+qemu:
+  qemu_option:
+    - "-chardev pty,id=hostS0 -serial chardev:hostS0"
+  variable_options: true

--- a/boards/arm/mps2_an521/qemu_mps2_an521_option.yml
+++ b/boards/arm/mps2_an521/qemu_mps2_an521_option.yml
@@ -1,0 +1,3 @@
+qemu:
+  qemu_option:
+    - "-chardev pty,id=hostS0 -serial chardev:hostS0"

--- a/boards/arm/mps2_an521/qemu_mps2_an521_tfm_option.yml
+++ b/boards/arm/mps2_an521/qemu_mps2_an521_tfm_option.yml
@@ -1,0 +1,4 @@
+qemu:
+  qemu_option:
+    - "-chardev pty,id=hostS0 -serial chardev:hostS0"
+  variable_options: true

--- a/boards/arm/mps3_an547/board.cmake
+++ b/boards/arm/mps3_an547/board.cmake
@@ -19,13 +19,18 @@ set(QEMU_FLAGS_${ARCH}
   -nographic
   -vga none
   )
-board_set_debugger_ifnset(qemu)
 
 if (CONFIG_BUILD_WITH_TFM)
   # Override the binary used by qemu, to use the combined
   # TF-M (Secure) & Zephyr (Non Secure) image (when running
   # in-tree tests).
   set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/zephyr/tfm_merged.hex")
+
+  FILE(WRITE "${PROJECT_BINARY_DIR}/qemu_runner_variables.conf" "${QEMU_KERNEL_OPTION}"\n)
+  board_runner_args(qemu "--cpu=cortex-m55" "--machine=mps3-an547"
+                   "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_mps3_an547_option.yml")
+else()
+  board_runner_args(qemu "--cpu=cortex-m55" "--machine=mps3-an547")
 endif()
 
 # FVP settings
@@ -44,3 +49,5 @@ set(ARMFVP_FLAGS
   -C mps3_board.uart2.unbuffered_output=1
   -C mps3_board.visualisation.disable-visualisation=1
   )
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/arm/mps3_an547/qemu_mps3_an547_option.yml
+++ b/boards/arm/mps3_an547/qemu_mps3_an547_option.yml
@@ -1,0 +1,2 @@
+qemu:
+  variable_options: true

--- a/boards/arm/qemu_cortex_a9/board.cmake
+++ b/boards/arm/qemu_cortex_a9/board.cmake
@@ -18,4 +18,8 @@ set(QEMU_KERNEL_OPTION
   "-device;loader,file=\$<TARGET_FILE:\${logical_target_for_zephyr_elf}>,cpu-num=0"
   )
 
-board_set_debugger_ifnset(qemu)
+board_runner_args(qemu "--commander=qemu-system-xilinx-aarch64" "--cpu=cortex-a9" "--machine=arm-generic-fdt-7series"
+                  "--dtb=${CMAKE_CURRENT_LIST_DIR}/fdt-zynq7000s.dtb"
+                  "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_cortex_a9_option.yml")
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/arm/qemu_cortex_a9/qemu_cortex_a9_option.yml
+++ b/boards/arm/qemu_cortex_a9/qemu_cortex_a9_option.yml
@@ -1,0 +1,3 @@
+qemu:
+  qemu_option:
+    - "-device loader,file={self.elf_name},cpu-num=0"

--- a/boards/arm/qemu_cortex_m0/board.cmake
+++ b/boards/arm/qemu_cortex_m0/board.cmake
@@ -12,4 +12,6 @@ set(QEMU_FLAGS_${ARCH}
   -nographic
   -vga none
   )
-board_set_debugger_ifnset(qemu)
+board_runner_args(qemu "--cpu=cortex-m0" "--machine=microbit")
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/arm/qemu_cortex_m3/board.cmake
+++ b/boards/arm/qemu_cortex_m3/board.cmake
@@ -9,4 +9,7 @@ set(QEMU_FLAGS_${ARCH}
   -nographic
   -vga none
   )
-board_set_debugger_ifnset(qemu)
+
+board_runner_args(qemu "--cpu=cortex-m3" "--machine=lm3s6965evb")
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/arm/qemu_cortex_r5/board.cmake
+++ b/boards/arm/qemu_cortex_r5/board.cmake
@@ -18,4 +18,8 @@ set(QEMU_KERNEL_OPTION
   "-device;loader,addr=0xff9a0000,data=0x80000218,data-len=4"
   )
 
-board_set_debugger_ifnset(qemu)
+board_runner_args(qemu "--commander=qemu-system-xilinx-aarch64" "--cpu=cortex-r5" "--machine=arm-generic-fdt"
+             "--dtb=${CMAKE_CURRENT_LIST_DIR}/fdt-single_arch-zcu102-arm.dtb"
+             "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_cortex_r5_option.yml")
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/arm/qemu_cortex_r5/qemu_cortex_r5_option.yml
+++ b/boards/arm/qemu_cortex_r5/qemu_cortex_r5_option.yml
@@ -1,0 +1,8 @@
+qemu:
+  qemu_option:
+    - "-device loader,file={self.elf_name},cpu-num=4"
+    - "-device loader,addr=0xff5e023c,data=0x80008fde,data-len=4"
+    - "-device loader,addr=0xff9a0000,data=0x80000218,data-len=4"
+    - "-net none -pidfile qemu.pid -chardev stdio,id=con,mux=on"
+    - "-serial chardev:con -mon chardev=con,mode=readline"
+    - "-icount shift=3,align=off,sleep=off -rtc clock=vm"

--- a/boards/arm64/qemu_cortex_a53/board.cmake
+++ b/boards/arm64/qemu_cortex_a53/board.cmake
@@ -25,6 +25,10 @@ if(CONFIG_XIP)
   set(QEMU_KERNEL_OPTION
   -bios ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.bin
   )
+  board_runner_args(qemu "--commander=qemu-system-aarch64" "--cpu=cortex-a53" "--machine=${QEMU_MACH}"
+              "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_cortex_a53_xip_option.yml")
+else()
+  board_runner_args(qemu "--commander=qemu-system-aarch64" "--cpu=cortex-a53" "--machine=${QEMU_MACH}")
 endif()
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/arm64/qemu_cortex_a53/qemu_cortex_a53_xip_option.yml
+++ b/boards/arm64/qemu_cortex_a53/qemu_cortex_a53_xip_option.yml
@@ -1,0 +1,3 @@
+qemu:
+  qemu_option:
+    - "-bios {self.bin_name}"

--- a/boards/arm64/qemu_kvm_arm64/board.cmake
+++ b/boards/arm64/qemu_kvm_arm64/board.cmake
@@ -24,6 +24,12 @@ if(CONFIG_XIP)
   set(QEMU_KERNEL_OPTION
   -bios ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.bin
   )
+  board_runner_args(qemu "--commander=qemu-system-aarch64" "--cpu=host"
+    "--machine=${QEMU_MACH}"
+    "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_kvm_arm64_xip_option.yml")
+else()
+  board_runner_args(qemu "--commander=qemu-system-aarch64" "--cpu=host"
+    "--machine=${QEMU_MACH}")
 endif()
 
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/arm64/qemu_kvm_arm64/qemu_kvm_arm64_xip_option.yml
+++ b/boards/arm64/qemu_kvm_arm64/qemu_kvm_arm64_xip_option.yml
@@ -1,0 +1,3 @@
+qemu:
+  qemu_option:
+    - "-bios {self.bin_name}"

--- a/boards/common/qemu.board.cmake
+++ b/boards/common/qemu.board.cmake
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(qemu)
+board_set_debugger_ifnset(qemu)
+board_finalize_runner_args(qemu)

--- a/boards/mips/qemu_malta/board.cmake
+++ b/boards/mips/qemu_malta/board.cmake
@@ -10,4 +10,8 @@ set(QEMU_FLAGS_${ARCH}
   -serial null
   -serial null
   )
-board_set_debugger_ifnset(qemu)
+
+board_runner_args(qemu "--commander=qemu-system-24Kc" "--machine=malta"
+                "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_malta_option.yml")
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/mips/qemu_malta/qemu_malta_option.yml
+++ b/boards/mips/qemu_malta/qemu_malta_option.yml
@@ -1,0 +1,3 @@
+qemu:
+  qemu_option:
+    - "-serial null"

--- a/boards/nios2/qemu_nios2/board.cmake
+++ b/boards/nios2/qemu_nios2/board.cmake
@@ -9,4 +9,6 @@ set(QEMU_FLAGS_${ARCH}
   -nographic
   )
 
-board_set_debugger_ifnset(qemu)
+board_runner_args(qemu "--commander=qemu-system-nios2" "--machine=altera_10m50_zephyr")
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/riscv/qemu_riscv32/board.cmake
+++ b/boards/riscv/qemu_riscv32/board.cmake
@@ -12,12 +12,14 @@ if(CONFIG_BOARD_QEMU_RISCV32 OR CONFIG_BOARD_QEMU_RISCV32_SMP)
     -bios none
     -m 256
     )
+  board_runner_args(qemu "--commander=qemu-system-riscv32" "--machine=virt"
+  "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_riscv32_smp_option.yml")
 else()
   set(QEMU_FLAGS_${ARCH}
     -nographic
     -machine sifive_e
     )
+  board_runner_args(qemu "--commander=qemu-system-riscv32" "--machine=sifive_e")
 endif()
 
-
-board_set_debugger_ifnset(qemu)
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/riscv/qemu_riscv32/qemu_riscv32_smp_option.yml
+++ b/boards/riscv/qemu_riscv32/qemu_riscv32_smp_option.yml
@@ -1,0 +1,4 @@
+qemu:
+  qemu_option:
+    - "-bios none"
+    - "-m 256"

--- a/boards/riscv/qemu_riscv32e/board.cmake
+++ b/boards/riscv/qemu_riscv32e/board.cmake
@@ -13,4 +13,7 @@ set(QEMU_FLAGS_${ARCH}
   -m 256
   )
 
-board_set_debugger_ifnset(qemu)
+board_runner_args(qemu "--commander=qemu-system-riscv32" "--machine=virt"
+              "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_riscv32e_option.yml")
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/riscv/qemu_riscv32e/qemu_riscv32e_option.yml
+++ b/boards/riscv/qemu_riscv32e/qemu_riscv32e_option.yml
@@ -1,0 +1,4 @@
+qemu:
+  qemu_option:
+    - "-bios none"
+    - "-m 256"

--- a/boards/riscv/qemu_riscv64/board.cmake
+++ b/boards/riscv/qemu_riscv64/board.cmake
@@ -11,4 +11,7 @@ set(QEMU_FLAGS_${ARCH}
   -bios none
   -m 256
   )
-board_set_debugger_ifnset(qemu)
+board_runner_args(qemu "--commander=qemu-system-riscv64" "--machine=virt"
+              "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_riscv64_option.yml")
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/riscv/qemu_riscv64/qemu_riscv64_option.yml
+++ b/boards/riscv/qemu_riscv64/qemu_riscv64_option.yml
@@ -1,0 +1,4 @@
+qemu:
+  qemu_option:
+    - "-bios none"
+    - "-m 256"

--- a/boards/sparc/qemu_leon3/board.cmake
+++ b/boards/sparc/qemu_leon3/board.cmake
@@ -10,4 +10,7 @@ set(QEMU_FLAGS_${ARCH}
   -machine leon3_generic
   -icount auto
   )
-board_set_debugger_ifnset(qemu)
+board_runner_args(qemu "--commander=qemu-system-leon3" "--machine=leon3_generic"
+  "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_leon3_option.yml")
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/sparc/qemu_leon3/qemu_leon3_option.yml
+++ b/boards/sparc/qemu_leon3/qemu_leon3_option.yml
@@ -1,0 +1,3 @@
+qemu:
+  qemu_option:
+    - "-icount auto"

--- a/boards/x86/qemu_x86/board.cmake
+++ b/boards/x86/qemu_x86/board.cmake
@@ -16,6 +16,7 @@ if(CONFIG_X86_64)
     list(APPEND QEMU_EXTRA_FLAGS -icount shift=5,align=off,sleep=off -rtc clock=vm)
   endif()
 else()
+  set(QEMU_binary_suffix i386)
   set(QEMU_CPU_TYPE_${ARCH} qemu32,+nx,+pae)
 endif()
 
@@ -82,3 +83,14 @@ if(CONFIG_BOARD_QEMU_X86_TINY AND CONFIG_DEMAND_PAGING
   set(X86_EXTRA_GEN_MMU_ARGUMENTS
       --map ${CONFIG_FLASH_BASE_ADDRESS},${QEMU_FLASH_SIZE_KB},W)
 endif()
+
+# for CMake variables that are not passed in west command
+FILE(WRITE "${PROJECT_BINARY_DIR}/qemu_runner_variables.conf" "") # Empty file
+FILE(APPEND "${PROJECT_BINARY_DIR}/qemu_runner_variables.conf" ${REBOOT_FLAG}\n)
+FILE(APPEND "${PROJECT_BINARY_DIR}/qemu_runner_variables.conf" -m ${QEMU_MEMORY_SIZE_MB}\n)
+
+board_runner_args(qemu "--commander=qemu-system-${QEMU_binary_suffix}"
+  "--machine=q35" "--cpu=${QEMU_CPU_TYPE_${ARCH}}"
+  "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_x86_option.yml")
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/x86/qemu_x86/qemu_x86_option.yml
+++ b/boards/x86/qemu_x86/qemu_x86_option.yml
@@ -1,0 +1,4 @@
+qemu:
+  qemu_option:
+    - "-device isa-debug-exit,iobase=0xf4,iosize=0x04"
+  variable_options: true

--- a/boards/xtensa/qemu_xtensa/board.cmake
+++ b/boards/xtensa/qemu_xtensa/board.cmake
@@ -10,7 +10,7 @@ if(CONFIG_BOARD_QEMU_XTENSA OR CONFIG_BOARD_QEMU_XTENSA_MMU)
   )
 endif()
 
-# TODO: Support debug
-# board_set_debugger_ifnset(qemu)
-# debugserver: QEMU_EXTRA_FLAGS += -s -S
-# debugserver: qemu
+board_runner_args(qemu "--commander=qemu-system-xtensa" "--machine=sim" "--cpu=sample_controller"
+  "--qemu_option=${CMAKE_CURRENT_LIST_DIR}/qemu_xtensa_option.yml")
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/xtensa/qemu_xtensa/qemu_xtensa_option.yml
+++ b/boards/xtensa/qemu_xtensa/qemu_xtensa_option.yml
@@ -1,0 +1,3 @@
+qemu:
+  qemu_option:
+    - "-semihosting"

--- a/cmake/emu/qemu.cmake
+++ b/cmake/emu/qemu.cmake
@@ -449,3 +449,22 @@ foreach(target ${qemu_targets})
     add_dependencies(${target} qemu_nvme_disk qemu_kernel_target)
   endif()
 endforeach()
+
+# Wrap the new `west flash --runner=qemu` target.
+if(WEST_DIR)
+  set(WEST "PYTHONPATH=${WEST_DIR}/src" "${PYTHON_EXECUTABLE};${WEST_DIR}/src/west/app/main.py;--zephyr-base=${ZEPHYR_BASE} ")
+endif()
+
+if(WEST)
+  add_custom_target(run_qemu_west COMMAND
+    COMMAND
+      ${CMAKE_COMMAND} -E env
+      ${WEST}
+      flash --runner=qemu
+    WORKING_DIRECTORY
+      ${APPLICATION_BINARY_DIR}
+    COMMENT
+      ${comment}
+    USES_TERMINAL
+  )
+endif()

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -89,6 +89,7 @@ class Handler:
         self.generator_cmd = None
         self.suite_name_check = True
         self.ready = False
+        self.platform = instance.platform
 
         self.args = []
         self.terminated = False
@@ -749,7 +750,7 @@ class QEMUHandler(Handler):
         self.fifo_fn = os.path.join(instance.build_dir, "qemu-fifo")
 
         self.pid_fn = os.path.join(instance.build_dir, "qemu.pid")
-
+        self.call_west_flash = False
         if instance.testsuite.ignore_qemu_crash:
             self.ignore_qemu_crash = True
             self.ignore_unexpected_eof = True
@@ -992,6 +993,11 @@ class QEMUHandler(Handler):
             subprocess.call(["stty", "sane"], stdin=sys.stdout)
 
         logger.debug("Running %s (%s)" % (self.name, self.type_str))
+        if self.call_west_flash:
+            command = ["west", "flash", "--skip-rebuild",
+                "-d", self.build_dir, "--runner", "qemu",
+                "--pipe", os.path.join(self.build_dir, "qemu-fifo")]
+        logger.info(" ".join(command))
 
         is_timeout = False
         qemu_pid = None

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -160,8 +160,18 @@ class TestInstance:
 
         options = env.options
         handler = Handler(self, "")
+        runner = None
         if options.device_testing:
-            handler = DeviceHandler(self, "device")
+            for dut in env.hwm.duts:
+                if dut.platform == self.platform.name:
+                    runner = dut.runner
+                    break
+            if env.hwm and runner == "qemu":
+                handler = QEMUHandler(self, "qemu")
+                handler.args.append(f"QEMU_PIPE={handler.get_fifo()}")
+                handler.call_west_flash = True
+            else:
+                handler = DeviceHandler(self, "device")
             handler.call_make_run = False
             handler.ready = True
         elif self.platform.simulation != "na":

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -451,7 +451,6 @@ class TestPlan:
 
                                     break
 
-
                 except RuntimeError as e:
                     logger.error("E: %s: can't load: %s" % (file, e))
                     self.load_errors += 1

--- a/scripts/requirements-build-test.txt
+++ b/scripts/requirements-build-test.txt
@@ -16,6 +16,7 @@ coverage
 # used for west-command testing
 pytest
 mypy
+types-PyYAML
 
 # used for mocking functions in pytest
 mock>=4.0.1

--- a/scripts/west_commands/runners/qemu.py
+++ b/scripts/west_commands/runners/qemu.py
@@ -4,11 +4,49 @@
 
 '''Runner stub for QEMU.'''
 
-from runners.core import ZephyrBinaryRunner, RunnerCaps
+import os
+from pathlib import Path
+import shlex
+import sys
 
+import yaml
+
+from runners.core import ZephyrBinaryRunner, RunnerCaps, FileType
+
+DEFAULT_QEMU_EXE = 'qemu-system-arm.exe' if sys.platform == 'win32' else 'qemu-system-arm'
+DEFAULT_QEMU_GDB_PORT = 1234
 
 class QemuBinaryRunner(ZephyrBinaryRunner):
     '''Place-holder for QEMU runner customizations.'''
+
+    def __init__(self, cfg, machine, cpu, dtb, qemu_opts,
+                 commander=DEFAULT_QEMU_EXE,
+                 pipe=None,
+                 gdbserver='',
+                 gdb_host='127.0.0.1',
+                 gdb_port=DEFAULT_QEMU_GDB_PORT,
+                 tui=False, tool_opt=[]):
+        super().__init__(cfg)
+        self.file = cfg.file
+        self.file_type = cfg.file_type
+        self.elf_name = cfg.elf_file
+        self.gdb_cmd = [cfg.gdb] if cfg.gdb else None
+        self.machine = machine
+        self.cpu = cpu
+        self.dtb = dtb
+        self.pipe = pipe
+        self.use_loader = False
+        self.qemu_opts_content = []
+        self.qemu_opts = qemu_opts
+        self.commander = commander
+        self.gdbserver = gdbserver
+        self.gdb_host = gdb_host
+        self.gdb_port = gdb_port
+        self.tui_arg = ['-tui'] if tui else []
+        self.tool_opt = []
+        for opts in [shlex.split(opt) for opt in tool_opt]:
+            self.tool_opt += opts
+
 
     @classmethod
     def name(cls):
@@ -16,16 +54,151 @@ class QemuBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        # This is a stub.
-        return RunnerCaps(commands=set())
+        return RunnerCaps(commands={'flash', 'debug'},
+                          tool_opt=True, file=True)
 
     @classmethod
     def do_add_parser(cls, parser):
-        pass                    # Nothing to do.
+        # Required:
+        parser.add_argument('--machine', required=True, help='machine name')
+
+        # Optional:
+        parser.add_argument('--cpu', required=False, dest='cpu',
+                            help='specifies a cpu type')
+        parser.add_argument('--tui', default=False, action='store_true',
+                            help='if given, GDB uses -tui')
+        parser.add_argument('--gdbserver', default='JLinkGDBServer',
+                            help='GDB server, default is JLinkGDBServer')
+        parser.add_argument('--gdb-host', default='127.0.0.1',
+                            help='custom gdb host, defaults to the empty string '
+                            'and runs a gdb server')
+        parser.add_argument('--gdb-port', default=DEFAULT_QEMU_GDB_PORT,
+                            help='gdb port, defaults to {}'.format(
+                                DEFAULT_QEMU_GDB_PORT))
+        parser.add_argument('--dtb', required=False, dest='dtb',
+                            help='specifies a dtb file')
+        parser.add_argument('--qemu_option', required=False, dest='qemu_opts',
+                            help='specifies qemu opts')
+        parser.add_argument('--commander', default=DEFAULT_QEMU_EXE,
+                            help=f'''QEMU executable, default is
+                            {DEFAULT_QEMU_EXE}''')
+        parser.add_argument('--pipe', default=None,
+                            help='''if given, qemu use pipe''')
 
     @classmethod
     def do_create(cls, cfg, args):
-        return QemuBinaryRunner(cfg)
+        return QemuBinaryRunner(cfg, machine=args.machine,
+                                 cpu=args.cpu,
+                                 dtb=args.dtb,
+                                 qemu_opts=args.qemu_opts,
+                                 commander=args.commander,
+                                 pipe=args.pipe,
+                                 gdbserver=args.gdbserver,
+                                 gdb_host=args.gdb_host,
+                                 gdb_port=args.gdb_port,
+                                 tui=args.tui, tool_opt=args.tool_opt)
 
     def do_run(self, command, **kwargs):
-        pass
+        self.commander = os.fspath(
+            Path(self.require(self.commander)).resolve())
+
+        if command == 'flash':
+            self.flash(**kwargs)
+        elif command == 'debug':
+            self.debug(**kwargs)
+        else:
+            pass
+
+
+    def get_qemu_opts(self):
+
+        def fstr(template):
+            return eval(f"f'{template}'", {'self' : self})
+        if self.qemu_opts:
+            with open(self.qemu_opts, 'r') as stream:
+                try:
+                    _d = yaml.safe_load(stream)
+                    if "qemu" in _d and "qemu_option" in _d["qemu"]:
+                        for _li in _d["qemu"]["qemu_option"]:
+                            li_parsed = fstr(_li).format()
+                            if "loader,file" in _li:
+                                self.use_loader = True
+                            self.qemu_opts_content += li_parsed.split(" ")
+                    elif "qemu" in _d and "variable_options" in _d["qemu"]:
+                        _f = os.path.join(Path(self.cfg.elf_file).parent,
+                                       "qemu_runner_variables.conf")
+                        with open(_f) as __f:
+                            for _li in __f:
+                                if "loader,file" in _li:
+                                    self.use_loader = True
+                                self.qemu_opts_content += fstr(_li).format().split(" ")
+
+                except yaml.YAMLError as _e:
+                    self.logger.error("%s raised", format(_e))
+
+    def flash(self, **kwargs):
+        flash_file = self.cfg.elf_file
+        self.get_qemu_opts()
+
+        if self.file is not None:
+            # use file provided by the user
+            if not os.path.isfile(self.file):
+                err = 'Cannot flash; file ({}) not found'
+                raise ValueError(err.format(self.file))
+            flash_file = self.file
+
+        cmd = ([self.commander] +
+               (['-nographic']) +
+               ['-machine', self.machine] +
+               (['-cpu', f'{self.cpu}'] if self.cpu else []) +
+               (['-dtb', f'{self.dtb}'] if self.dtb else []) +
+               (['-serial', f'pipe:{self.pipe}'] if self.pipe else []) +
+               (['-kernel', flash_file] if not self.use_loader else []) +
+               (self.qemu_opts_content if self.qemu_opts_content else []) +
+                self.tool_opt)
+        kwargs = {}
+        #if not self.logger.isEnabledFor(logging.DEBUG):
+        #    kwargs['stdout'] = subprocess.DEVNULL
+        self.logger.info("flashing with {}".format(" ".join(cmd)))
+        self.logger.info("press ctrl+a x to quit qemu")
+        self.check_call(cmd, **kwargs)
+
+
+    def debug(self, **kwargs):
+        flash_file = self.cfg.elf_file
+        self.get_qemu_opts()
+
+        if self.file is not None:
+            # use file provided by the user
+            if not os.path.isfile(self.file):
+                err = 'Cannot flash; file ({}) not found'
+                raise ValueError(err.format(self.file))
+
+            flash_file = self.cfg.elf_file
+
+            if self.cfg.file_type != FileType.ELF:
+                err = 'Cannot flash; qmue runner only supports elf files'
+                raise ValueError(err)
+
+            server_cmd = ([self.commander] +
+                   (['-nographic']) +
+                   ['-machine', self.machine] +
+                   (['-cpu', f'{self.cpu}'] if self.cpu else []) +
+                   (['-dtb', f'{self.dtb}'] if self.dtb else []) +
+                   (['-kernel', flash_file] if not self.use_loader else []) +
+                   (self.qemu_opts_content if self.qemu_opts_content else []) +
+                   (['-s']) + (['-S']) +
+                   self.tool_opt)
+            client_cmd = (self.gdb_cmd +
+                          self.tui_arg +
+                          [flash_file] +
+                          ['-ex', '\"target remote {}:{}\"'.format(self.gdb_host, self.gdb_port)] +
+                          ['-ex', '\"maintenance packet Qqemu.PhyMemMode:1\"',
+                          ])
+            kwargs = {}
+            self.logger.info("press ctrl+a x to quit qemu")
+            self.logger.info("run below command to debug \r\n %s", format(" ".join(client_cmd)))
+            self.check_call(server_cmd, **kwargs)
+        else:
+            err = 'Cannot flash; qmue runner only supports elf files'
+            raise ValueError(err)


### PR DESCRIPTION
proposal to add qemu simulator support to west command, details are listed in, and then every board can has its simultor runner to test against 

#61509

to run with application
```
west build -b qemu_cortex_m3
west flash --runner=qemu
```

and debug with two steps
step 1:
```
west debug --runner=qemu
```
you will see the command line prompt below

```
-- west debug: rebuilding
ninja: no work to do.
yaml_path is /home/shared/disk/zephyr_project/zephyr_test/zephyr/samples/hello_world/build/zephyr/runners.yaml
{'runners': ['qemu'], 'flash-runner': 'qemu', 'debug-runner': 'qemu', 'config': {'board_dir': '/home/shared/disk/zephyr_project/zephyr_test/zephyr/boards/arm/qemu_cortex_m3', 'elf_file': 'zephyr.elf', 'gdb': '/home/ubuntu/zephyr-sdk/zephyr-sdk-0.16.2-rc1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb-py', 'openocd': '/home/ubuntu/zephyr-sdk/zephyr-sdk-0.16.2-rc1/sysroots/x86_64-pokysdk-linux/usr/bin/openocd', 'openocd_search': ['/home/ubuntu/zephyr-sdk/zephyr-sdk-0.16.2-rc1/sysroots/x86_64-pokysdk-linux/usr/share/openocd/scripts']}, 'args': {'qemu': ['--cpu=cortex-m3', '--machine=lm3s6965evb']}}
-- west debug: using runner qemu
finale_argv is ['--cpu=cortex-m3', '--machine=lm3s6965evb']
-- runners.qemu: press ctrl+a x to quit qemu
-- runners.qemu: run below command to debug
 /home/ubuntu/zephyr-sdk/zephyr-sdk-0.16.2-rc1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb-py /home/shared/disk/zephyr_project/zephyr_test/zephyr/samples/hello_world/build/zephyr/zephyr.elf -ex "target remote 127.0.0.1:1234" -ex "maintenance packet Qqemu.PhyMemMode:1"
Timer with period zero, disabling
```

step 2:
in another console run the prompt 
```
#  /home/ubuntu/zephyr-sdk/zephyr-sdk-0.16.2-rc1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb-py /home/shared/disk/zephyr_project/zephyr_test/zephyr/samples/hello_world/build/zephyr/zephyr.elf -ex "target remote 127.0.0.1:1234" -ex "maintenance packet Qqemu.PhyMemMode:1"
```
![image](https://github.com/zephyrproject-rtos/zephyr/assets/800198/8a43dc0a-e399-4d91-8d65-6b50df17df09)

to run CI with twister
```
scripts/twister -p qemu_cortex_m3  --device-testing --hardware-map ./test_map.yml  -T samples/hello_world/
```

the test_map.yaml only needs to have below

```
- connected: true
  id: "1234"
  product: qemu-simulator
  platform: mimxrt595_evk_cm33
  runner: qemu
  serial: pty-qemu
```
still keep using cmake:

`west build -t run`

with west command:

`west build -t run_qemu_with_west`
