### PR TITLE
scripts: set_assignee: add options to assign module PRs and issues

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -10,6 +10,9 @@ on:
     branches:
     - main
     - v*-branch
+  issues:
+    types:
+    - labeled
 
 jobs:
   assignment:
@@ -21,7 +24,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         sudo pip3 install -U setuptools wheel pip
-        pip3 install -U PyGithub>=1.55
+        pip3 install -U PyGithub>=1.55 west
 
     - name: Check out source code
       uses: actions/checkout@v3
@@ -30,9 +33,19 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.ZB_GITHUB_TOKEN }}
       run: |
-        python3 scripts/set_assignees.py \
-          -v \
-          -o ${{ github.event.repository.owner.login }} \
-          -r ${{ github.event.repository.name }} \
-          -M MAINTAINERS.yml \
-          -P ${{ github.event.pull_request.number }}
+        FLAGS="-v"
+        FLAGS+=" -o ${{ github.event.repository.owner.login }}"
+        FLAGS+=" -r ${{ github.event.repository.name }}"
+        FLAGS+=" -M MAINTAINERS.yml"
+        if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            FLAGS+=" -P ${{ github.event.pull_request.number }}"
+        elif [ "${{ github.event_name }}" = "issues" ]; then
+            FLAGS+=" -I ${{ github.event.issue.number }}"
+        elif [ "${{ github.event_name }}" = "schedule" ]; then
+            FLAGS+=" --modules"
+        else
+          echo "Unknown event: ${{ github.event_name }}"
+          exit 1
+        endif
+
+        python3 scripts/set_assignees.py $FLAGS


### PR DESCRIPTION
Add a -m option to set_assignees to have the script find all unassigned module PRs for areas that have an assignee and set the assignee on those PRs.

This should help avoiding forgotten PRs on modules. It's implemented as a search and meant to run periodically, so we don't have to add a workflow for this on every individual module.