### PR TITLE
drivers/i2c: remove unnecessary includes

### DIFF
--- a/drivers/i2c/i2c_rcar.c
+++ b/drivers/i2c/i2c_rcar.c
@@ -9,7 +9,6 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
-#include <soc.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>


### PR DESCRIPTION
i2c_rcar.c includes soc.h header which doesn't need for this source and exists not for all boards. soc.h header doesn't exist for rcar-gen3 soc based on arm64 core.
soc.h consists soc-depended defenitions and need to be included by soc-depended sources.