### PR TITLE
net: gptp: improve the synchronization accuracy of the slave clock

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -3316,6 +3316,8 @@ static int cmd_net_gptp(const struct shell *sh, size_t argc, char *argv[])
 		PR("\tThe local clock has expired    : %s\n",
 		   domain->state.clk_slave_sync.rcvd_local_clk_tick ?
 							   "yes" : "no");
+		PR("\tTime offset from master        : %lld ns\n",
+		   domain->servo_ds.master_offset_ns);
 
 		PR("PortRoleSelection state machine variables:\n");
 		PR("\tCurrent state                  : %s\n",

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -226,4 +226,41 @@ config NET_GPTP_STATISTICS
 	  Enable this if you need to collect gPTP statistics. The statistics
 	  can be seen in net-shell if needed.
 
+config NET_GPTP_SERVO_STEP_THRESHOLD
+	int "Set slave clock jump threshold (ns)"
+	default 1000000000
+	help
+	  In slave port mode, if the error with the master clock is greater
+	  than the value, time jump is required to prevent the clock from
+	  converging too slowly.
+
+config NET_GPTP_SERVO_MAX_ADJTIME
+	int "Set servo maximum adjust time (ns)"
+	default 25000000
+	help
+	  The maximum offset the servo will correct by adjust the clock
+	  speed, If your device supports higher frequencies, set higher
+	  values to speed up convergence.
+
+config NET_GPTP_SERVO_KP
+	int "Set servo controller proportional value"
+	default 700
+	help
+	  The proportional constant of the PI controller. It is error of
+	  the master and slave clocks is multiplied by the proportionality
+	  constant, If controller converges slowly or oscillates,
+	  recalibration both ki and kp.
+	  The value is the converted in float as follow:
+	  servo_kp = NET_GPTP_SERVO_KP / 1000
+
+config NET_GPTP_SERVO_KI
+	int "Set servo controller integral value"
+	default 300
+	help
+	  The integral constant of the PI controller. It is the integral
+	  of the phase error between master and slave clock, If controller
+	  converges slowly or oscillates, recalibration both ki and kp.
+	  The value is the converted in float as follow:
+	  servo_ki = NET_GPTP_SERVO_KI / 1000
+
 endif # NET_GPTP

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -355,12 +355,14 @@ static void gptp_init_clock_ds(void)
 	struct gptp_current_ds *current_ds;
 	struct gptp_parent_ds *parent_ds;
 	struct gptp_time_prop_ds *prop_ds;
+	struct gptp_servo_ds *servo_ds;
 
 	global_ds = GPTP_GLOBAL_DS();
 	default_ds = GPTP_DEFAULT_DS();
 	current_ds = GPTP_CURRENT_DS();
 	parent_ds = GPTP_PARENT_DS();
 	prop_ds = GPTP_PROPERTIES_DS();
+	servo_ds = GPTP_SERVO_DS();
 
 	/* Initialize global data set. */
 	(void)memset(global_ds, 0, sizeof(struct gptp_global_ds));
@@ -438,6 +440,13 @@ static void gptp_init_clock_ds(void)
 	global_ds->sys_time_source = default_ds->time_source;
 	global_ds->clk_master_sync_itv =
 		NSEC_PER_SEC * GPTP_POW2(CONFIG_NET_GPTP_INIT_LOG_SYNC_ITV);
+
+	/* Initialize servo data set. */
+	(void)memset(servo_ds, 0, sizeof(struct gptp_servo_ds));
+	servo_ds->step_threshold_ns = CONFIG_NET_GPTP_SERVO_STEP_THRESHOLD;
+	servo_ds->max_time_adjust = CONFIG_NET_GPTP_SERVO_MAX_ADJTIME;
+	servo_ds->kp = CONFIG_NET_GPTP_SERVO_KP / 1000.0;
+	servo_ds->ki = CONFIG_NET_GPTP_SERVO_KI / 1000.0;
 }
 
 static void gptp_init_port_ds(int port)

--- a/subsys/net/l2/ethernet/gptp/gptp_data_set.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_data_set.h
@@ -47,6 +47,7 @@ extern "C" {
 #define GPTP_CURRENT_DS() (&gptp_domain.current_ds)
 #define GPTP_PARENT_DS() (&gptp_domain.parent_ds)
 #define GPTP_PROPERTIES_DS() (&gptp_domain.properties_ds)
+#define GPTP_SERVO_DS() (&gptp_domain.servo_ds)
 #define GPTP_STATE() (&gptp_domain.state)
 
 #define GPTP_PORT_DS(port) \
@@ -377,6 +378,26 @@ struct gptp_time_prop_ds {
 };
 
 /**
+ * @brief Servo Controllor Data Set.
+ *
+ * Data Set representing time sync servo controllor.
+ */
+struct gptp_servo_ds {
+	/* Time difference between master clock and slave clock. */
+	int64_t master_offset_ns;
+	/* The value of slave clock jump threshold. */
+	int64_t step_threshold_ns;
+	/* The value of slave clock maximum adjust time. */
+	int32_t max_time_adjust;
+	/* The proportional value of PI controllor. */
+	double kp;
+	/* The integral value of PI controllor. */
+	double ki;
+	/* The observed drift value of PI controllor. */
+	double observed_drift;
+};
+
+/**
  * @brief Port Parameter Data Set.
  *
  * Data Set representing port capabilities.
@@ -549,6 +570,9 @@ struct gptp_domain {
 
 	/** Time Properties Data Set for this gPTP domain. */
 	struct gptp_time_prop_ds properties_ds;
+
+	/** Servo Controllor Data Set for this gPTP domain. */
+	struct gptp_servo_ds servo_ds;
 
 	/** Current State of the MI State Machines for this gPTP domain. */
 	struct gptp_states state;

--- a/subsys/net/l2/ethernet/gptp/gptp_md.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_md.c
@@ -103,19 +103,17 @@ static int gptp_set_md_sync_receive(int port,
 	sync_rcv->precise_orig_ts.nanosecond = ntohl(fup->prec_orig_ts_nsecs);
 
 	/* Compute time when sync was sent by the remote. */
-	sync_rcv->upstream_tx_time = sync_ts->second;
-	sync_rcv->upstream_tx_time *= NSEC_PER_SEC;
-	sync_rcv->upstream_tx_time += sync_ts->nanosecond;
-
 	prop_delay_rated = port_ds->neighbor_prop_delay;
 	prop_delay_rated /= port_ds->neighbor_rate_ratio;
-
-	sync_rcv->upstream_tx_time -= prop_delay_rated;
 
 	delay_asymmetry_rated = port_ds->delay_asymmetry;
 	delay_asymmetry_rated /= port_ds->neighbor_rate_ratio;
 
-	sync_rcv->upstream_tx_time -= delay_asymmetry_rated;
+	sync_rcv->upstream_tx_time = sync_ts->second;
+	sync_rcv->upstream_tx_time *= NSEC_PER_SEC;
+	sync_rcv->upstream_tx_time += sync_ts->nanosecond;
+	sync_rcv->upstream_tx_time -= (int64_t)prop_delay_rated;
+	sync_rcv->upstream_tx_time -= (int64_t)delay_asymmetry_rated;
 
 	sync_rcv->rate_ratio = ntohl(fup->tlv.cumulative_scaled_rate_offset);
 	sync_rcv->rate_ratio /= GPTP_POW2_41;


### PR DESCRIPTION
This PR include gPTP slave clock accuracy optimize and some fix.

1. Add a servo PI controllor, improve the time accuracy from 1580ns to 580ns (accuracy to linuxptp level).
2. Support print time offset from master clock by using shell command `net gptp`.
3. Fix a timestamp precision loss issue.
4. Fix a mcux driver time base jump issue.

Test platform: https://github.com/zephyrproject-rtos/zephyr/pull/60562#issuecomment-1642472371

Selftest report:

- Test time: 39980s
- Test count: 5
- Phase offset: 502~710ns (Because PHY hardware circuit transmission have delay, result have a fixed offset is 580ns)
- STDDev: 31.44ns

![20230806_050653022_iOS](https://github.com/zephyrproject-rtos/zephyr/assets/18113342/c2935aab-316c-47ec-b1a1-f66fd65ecfb7)

- Cable plug out and plug in: Time converged.

![QQ截图20230816014709](https://github.com/zephyrproject-rtos/zephyr/assets/18113342/f3cf1239-68ae-469c-a2be-949a189b8344)

- Master clock time jump simulation: Time converged, print warning.

![QQ截图20230816015321](https://github.com/zephyrproject-rtos/zephyr/assets/18113342/81df276e-6860-4ffc-a82b-a3fd92be0082)

- Master clock time jump forward simulation: Time converged, tell user system maybe unstable.

![QQ截图20230816015234](https://github.com/zephyrproject-rtos/zephyr/assets/18113342/69251453-5c71-4ac2-87e9-7faec9cf42fc)


