### PR TITLE
Rename shadow variables (part 2) and partially enable -Wshadow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,12 +601,7 @@ add_subdirectory(lib)
 # property which is set implicitly for custom command outputs
 include(misc/generated/CMakeLists.txt)
 
-if(EXISTS ${SOC_DIR}/${ARCH}/CMakeLists.txt)
-  add_subdirectory(${SOC_DIR}/${ARCH} soc/${ARCH})
-else()
-  add_subdirectory(${SOC_DIR}/${ARCH}/${SOC_PATH} soc/${ARCH}/${SOC_PATH})
-endif()
-
+add_subdirectory(soc)
 add_subdirectory(boards)
 add_subdirectory(subsys)
 add_subdirectory(drivers)

--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# FIXME: SHADOW_VARS: Remove this once we have enabled -Wshadow globally.
+add_compile_options($<TARGET_PROPERTY:compiler,warning_shadow_variables>)
+
 add_definitions(-D__ZEPHYR_SUPERVISOR__)
 
 include_directories(

--- a/arch/x86/core/ia32/gdbstub.c
+++ b/arch/x86/core/ia32/gdbstub.c
@@ -11,7 +11,7 @@
 #include <zephyr/debug/gdbstub.h>
 
 
-static struct gdb_ctx ctx;
+static struct gdb_ctx debug_ctx;
 
 /**
  * Currently we just handle vectors 1 and 3 but lets keep it generic
@@ -80,55 +80,55 @@ static unsigned int get_exception(unsigned int vector)
  */
 static void z_gdb_interrupt(unsigned int vector, z_arch_esf_t *esf)
 {
-	ctx.exception = get_exception(vector);
+	debug_ctx.exception = get_exception(vector);
 
-	ctx.registers[GDB_EAX] = esf->eax;
-	ctx.registers[GDB_ECX] = esf->ecx;
-	ctx.registers[GDB_EDX] = esf->edx;
-	ctx.registers[GDB_EBX] = esf->ebx;
-	ctx.registers[GDB_ESP] = esf->esp;
-	ctx.registers[GDB_EBP] = esf->ebp;
-	ctx.registers[GDB_ESI] = esf->esi;
-	ctx.registers[GDB_EDI] = esf->edi;
-	ctx.registers[GDB_PC] = esf->eip;
-	ctx.registers[GDB_CS] = esf->cs;
-	ctx.registers[GDB_EFLAGS]  = esf->eflags;
-	ctx.registers[GDB_SS] = esf->ss;
-	ctx.registers[GDB_DS] = esf->ds;
-	ctx.registers[GDB_ES] = esf->es;
-	ctx.registers[GDB_FS] = esf->fs;
-	ctx.registers[GDB_GS] = esf->gs;
+	debug_ctx.registers[GDB_EAX] = esf->eax;
+	debug_ctx.registers[GDB_ECX] = esf->ecx;
+	debug_ctx.registers[GDB_EDX] = esf->edx;
+	debug_ctx.registers[GDB_EBX] = esf->ebx;
+	debug_ctx.registers[GDB_ESP] = esf->esp;
+	debug_ctx.registers[GDB_EBP] = esf->ebp;
+	debug_ctx.registers[GDB_ESI] = esf->esi;
+	debug_ctx.registers[GDB_EDI] = esf->edi;
+	debug_ctx.registers[GDB_PC] = esf->eip;
+	debug_ctx.registers[GDB_CS] = esf->cs;
+	debug_ctx.registers[GDB_EFLAGS]  = esf->eflags;
+	debug_ctx.registers[GDB_SS] = esf->ss;
+	debug_ctx.registers[GDB_DS] = esf->ds;
+	debug_ctx.registers[GDB_ES] = esf->es;
+	debug_ctx.registers[GDB_FS] = esf->fs;
+	debug_ctx.registers[GDB_GS] = esf->gs;
 
-	z_gdb_main_loop(&ctx);
+	z_gdb_main_loop(&debug_ctx);
 
-	esf->eax = ctx.registers[GDB_EAX];
-	esf->ecx = ctx.registers[GDB_ECX];
-	esf->edx = ctx.registers[GDB_EDX];
-	esf->ebx = ctx.registers[GDB_EBX];
-	esf->esp = ctx.registers[GDB_ESP];
-	esf->ebp = ctx.registers[GDB_EBP];
-	esf->esi = ctx.registers[GDB_ESI];
-	esf->edi = ctx.registers[GDB_EDI];
-	esf->eip = ctx.registers[GDB_PC];
-	esf->cs = ctx.registers[GDB_CS];
-	esf->eflags = ctx.registers[GDB_EFLAGS];
-	esf->ss = ctx.registers[GDB_SS];
-	esf->ds = ctx.registers[GDB_DS];
-	esf->es = ctx.registers[GDB_ES];
-	esf->fs = ctx.registers[GDB_FS];
-	esf->gs = ctx.registers[GDB_GS];
+	esf->eax = debug_ctx.registers[GDB_EAX];
+	esf->ecx = debug_ctx.registers[GDB_ECX];
+	esf->edx = debug_ctx.registers[GDB_EDX];
+	esf->ebx = debug_ctx.registers[GDB_EBX];
+	esf->esp = debug_ctx.registers[GDB_ESP];
+	esf->ebp = debug_ctx.registers[GDB_EBP];
+	esf->esi = debug_ctx.registers[GDB_ESI];
+	esf->edi = debug_ctx.registers[GDB_EDI];
+	esf->eip = debug_ctx.registers[GDB_PC];
+	esf->cs = debug_ctx.registers[GDB_CS];
+	esf->eflags = debug_ctx.registers[GDB_EFLAGS];
+	esf->ss = debug_ctx.registers[GDB_SS];
+	esf->ds = debug_ctx.registers[GDB_DS];
+	esf->es = debug_ctx.registers[GDB_ES];
+	esf->fs = debug_ctx.registers[GDB_FS];
+	esf->gs = debug_ctx.registers[GDB_GS];
 }
 
 void arch_gdb_continue(void)
 {
 	/* Clear the TRAP FLAG bit */
-	ctx.registers[GDB_EFLAGS] &= ~BIT(8);
+	debug_ctx.registers[GDB_EFLAGS] &= ~BIT(8);
 }
 
 void arch_gdb_step(void)
 {
 	/* Set the TRAP FLAG bit */
-	ctx.registers[GDB_EFLAGS] |= BIT(8);
+	debug_ctx.registers[GDB_EFLAGS] |= BIT(8);
 }
 
 size_t arch_gdb_reg_readall(struct gdb_ctx *ctx, uint8_t *buf, size_t buflen)

--- a/boards/CMakeLists.txt
+++ b/boards/CMakeLists.txt
@@ -8,6 +8,11 @@ if(EXISTS ${BOARD_DIR}/CMakeLists.txt)
 	set(build_dir boards/${ARCH}/${BOARD})
   else()
 	unset(build_dir)
+
+	# FIXME: SHADOW_VARS: Remove this once we have enabled -Wshadow globally.
+	#
+	# For now, only enable warning for shadow variables for in-tree boards.
+	add_compile_options($<TARGET_PROPERTY:compiler,warning_shadow_variables>)
   endif()
 
   add_subdirectory(${BOARD_DIR} ${build_dir})

--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -203,3 +203,6 @@ if(CONFIG_ARCMWDT_LIBC)
   # to ASM builds (which may use 'stdbool.h').
   set_property(TARGET asm APPEND PROPERTY required "-I${NOSTDINC}")
 endif()
+
+# Remove after testing that -Wshadow works
+set_compiler_property(PROPERTY warning_shadow_variables)

--- a/cmake/compiler/armclang/compiler_flags.cmake
+++ b/cmake/compiler/armclang/compiler_flags.cmake
@@ -7,3 +7,6 @@ set_property(TARGET asm APPEND PROPERTY required "--target=${triple}")
 
 # Only the ARM Compiler C library is currently supported.
 set_compiler_property(PROPERTY nostdinc)
+
+# Remove after testing that -Wshadow works
+set_compiler_property(PROPERTY warning_shadow_variables)

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -130,3 +130,6 @@ set_compiler_property(PROPERTY no_position_independent)
 # gen_kobject_list.py is does not understand it and end up identifying objects as if
 # they had the same address.
 set_compiler_property(PROPERTY no_global_merge)
+
+# Compiler flag for warning about shadow variables
+set_compiler_property(PROPERTY warning_shadow_variables)

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -225,3 +225,5 @@ set_compiler_property(PROPERTY no_position_independent
 )
 
 set_compiler_property(PROPERTY no_global_merge "")
+
+set_compiler_property(PROPERTY warning_shadow_variables -Wshadow)

--- a/cmake/compiler/icx/compiler_flags.cmake
+++ b/cmake/compiler/icx/compiler_flags.cmake
@@ -1,2 +1,5 @@
 
 include(${ZEPHYR_BASE}/cmake/compiler/clang/compiler_flags.cmake)
+
+# Remove after testing that -Wshadow works
+set_compiler_property(PROPERTY warning_shadow_variables)

--- a/cmake/compiler/xcc/compiler_flags.cmake
+++ b/cmake/compiler/xcc/compiler_flags.cmake
@@ -12,3 +12,6 @@ set_compiler_property(PROPERTY warning_error_misra_sane)
 
 # XCC does not support -fno-pic and -fno-pie
 set_compiler_property(PROPERTY no_position_independent "")
+
+# Remove after testing that -Wshadow works
+set_compiler_property(PROPERTY warning_shadow_variables)

--- a/cmake/compiler/xt-clang/compiler_flags.cmake
+++ b/cmake/compiler/xt-clang/compiler_flags.cmake
@@ -31,3 +31,6 @@ endif()
 
 # Clang version used by Xtensa does not support -fno-pic and -fno-pie
 set_compiler_property(PROPERTY no_position_independent "")
+
+# Remove after testing that -Wshadow works
+set_compiler_property(PROPERTY warning_shadow_variables)

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# FIXME: SHADOW_VARS: Remove this once we have enabled -Wshadow globally.
+add_compile_options($<TARGET_PROPERTY:compiler,warning_shadow_variables>)
+
 add_definitions(-D__ZEPHYR_SUPERVISOR__)
 
 add_subdirectory(disk)

--- a/drivers/counter/maxim_ds3231.c
+++ b/drivers/counter/maxim_ds3231.c
@@ -289,7 +289,7 @@ static const uint8_t *decode_time(struct tm *tp,
 	uint8_t reg;
 
 	if (with_sec) {
-		uint8_t reg = *rp++;
+		reg = *rp++;
 
 		tp->tm_sec = bcd2bin(reg & 0x7F);
 	}

--- a/include/zephyr/rtio/rtio_spsc.h
+++ b/include/zephyr/rtio/rtio_spsc.h
@@ -171,11 +171,11 @@ struct rtio_spsc {
 #define rtio_spsc_acquire(spsc)                                                                    \
 	({                                                                                         \
 		unsigned long idx = z_rtio_spsc_in(spsc) + (spsc)->_spsc.acquire;                  \
-		bool acq = (idx - z_rtio_spsc_out(spsc)) < rtio_spsc_size(spsc);                   \
-		if (acq) {                                                                         \
+		bool spsc_acq = (idx - z_rtio_spsc_out(spsc)) < rtio_spsc_size(spsc);              \
+		if (spsc_acq) {                                                                    \
 			(spsc)->_spsc.acquire += 1;                                                \
 		}                                                                                  \
-		acq ? &((spsc)->buffer[z_rtio_spsc_mask(spsc, idx)]) : NULL;                       \
+		spsc_acq ? &((spsc)->buffer[z_rtio_spsc_mask(spsc, idx)]) : NULL;                  \
 	})
 
 /**

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -38,6 +38,9 @@ target_link_libraries(kernel INTERFACE ${libkernel})
 
 else()
 
+# FIXME: SHADOW_VARS: Remove this once we have enabled -Wshadow globally.
+add_compile_options($<TARGET_PROPERTY:compiler,warning_shadow_variables>)
+
 list(APPEND kernel_files
   main_weak.c
   banner.c

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# FIXME: SHADOW_VARS: Remove this once we have enabled -Wshadow globally.
+add_compile_options($<TARGET_PROPERTY:compiler,warning_shadow_variables>)
+
 add_subdirectory(crc)
 if(NOT CONFIG_EXTERNAL_LIBC)
 add_subdirectory(libc)

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -573,14 +573,14 @@ void platformRadioProcess(otInstance *aInstance)
 	bool event_pending = false;
 
 	if (is_pending_event_set(PENDING_EVENT_FRAME_TO_SEND)) {
-		struct net_pkt *tx_pkt;
+		struct net_pkt *evt_pkt;
 
 		reset_pending_event(PENDING_EVENT_FRAME_TO_SEND);
-		while ((tx_pkt = (struct net_pkt *) k_fifo_get(&tx_pkt_fifo, K_NO_WAIT)) != NULL) {
+		while ((evt_pkt = (struct net_pkt *) k_fifo_get(&tx_pkt_fifo, K_NO_WAIT)) != NULL) {
 			if (IS_ENABLED(CONFIG_OPENTHREAD_COPROCESSOR_RCP)) {
-				net_pkt_unref(tx_pkt);
+				net_pkt_unref(evt_pkt);
 			} else {
-				openthread_handle_frame_to_send(aInstance, tx_pkt);
+				openthread_handle_frame_to_send(aInstance, evt_pkt);
 			}
 		}
 	}
@@ -829,7 +829,7 @@ int8_t otPlatRadioGetRssi(otInstance *aInstance)
 {
 	int8_t ret_rssi = INT8_MAX;
 	int error = 0;
-	const uint16_t energy_detection_time = 1;
+	const uint16_t detection_time = 1;
 	enum ieee802154_hw_caps radio_caps;
 	ARG_UNUSED(aInstance);
 
@@ -846,7 +846,7 @@ int8_t otPlatRadioGetRssi(otInstance *aInstance)
 		 * Blocking implementation of get RSSI
 		 * using no-blocking ed_scan
 		 */
-		error = radio_api->ed_scan(radio_dev, energy_detection_time,
+		error = radio_api->ed_scan(radio_dev, detection_time,
 					   get_rssi_energy_detected);
 
 		if (error == 0) {

--- a/samples/arch/smp/pi/src/main.c
+++ b/samples/arch/smp/pi/src/main.c
@@ -27,8 +27,8 @@
 
 static K_THREAD_STACK_ARRAY_DEFINE(tstack, THREADS_NUM, STACK_SIZE);
 static struct k_thread tthread[THREADS_NUM];
-static char buffer[THREADS_NUM][DIGITS_NUM + 1];
-static atomic_t counter = THREADS_NUM;
+static char th_buffer[THREADS_NUM][DIGITS_NUM + 1];
+static atomic_t th_counter = THREADS_NUM;
 
 void test_thread(void *arg1, void *arg2, void *arg3)
 {
@@ -91,12 +91,12 @@ int main(void)
 	for (i = 0; i < THREADS_NUM; i++) {
 		k_thread_create(&tthread[i], tstack[i], STACK_SIZE,
 			       (k_thread_entry_t)test_thread,
-			       (void *)&counter, (void *)buffer[i], NULL,
+			       (void *)&th_counter, (void *)th_buffer[i], NULL,
 			       K_PRIO_COOP(10), 0, K_NO_WAIT);
 	}
 
 	/* Wait for all workers to finish their calculations */
-	while (counter) {
+	while (th_counter) {
 		k_sleep(K_MSEC(1));
 	}
 
@@ -107,7 +107,7 @@ int main(void)
 	nanoseconds_spent = (uint32_t)k_cyc_to_ns_floor64(cycles_spent);
 
 	for (i = 0; i < THREADS_NUM; i++) {
-		printk("Pi value calculated by thread #%d: %s\n", i, buffer[i]);
+		printk("Pi value calculated by thread #%d: %s\n", i, th_buffer[i]);
 	}
 
 	printk("All %d threads executed by %d cores in %d msec\n", THREADS_NUM,

--- a/samples/boards/bbc_microbit/pong/src/ble.c
+++ b/samples/boards/bbc_microbit/pong/src/ble.c
@@ -360,35 +360,35 @@ static void create_conn(const bt_addr_le_t *addr)
 }
 
 static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
-			 struct net_buf_simple *ad)
+			 struct net_buf_simple *ad_buf)
 {
 	if (type != BT_GAP_ADV_TYPE_ADV_IND) {
 		return;
 	}
 
-	while (ad->len > 1) {
-		uint8_t len = net_buf_simple_pull_u8(ad);
-		uint8_t type;
+	while (ad_buf->len > 1) {
+		uint8_t len = net_buf_simple_pull_u8(ad_buf);
+		uint8_t ad_type;
 
 		/* Check for early termination */
 		if (len == 0U) {
 			return;
 		}
 
-		if (len > ad->len) {
+		if (len > ad_buf->len) {
 			printk("AD malformed\n");
 			return;
 		}
 
-		type = net_buf_simple_pull_u8(ad);
-		if (type == BT_DATA_UUID128_ALL &&
-		    pong_uuid_match(ad->data, len - 1)) {
+		ad_type = net_buf_simple_pull_u8(ad_buf);
+		if (ad_type == BT_DATA_UUID128_ALL &&
+		    pong_uuid_match(ad_buf->data, len - 1)) {
 			bt_le_scan_stop();
 			create_conn(addr);
 			return;
 		}
 
-		net_buf_simple_pull(ad, len - 1);
+		net_buf_simple_pull(ad_buf, len - 1);
 	}
 }
 

--- a/samples/boards/nrf/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff-app/src/main.c
@@ -142,7 +142,7 @@ static const struct bt_mesh_model_op gen_onoff_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-struct onoff_state {
+struct led_onoff_state {
 	const struct gpio_dt_spec led_device;
 	uint8_t current;
 	uint8_t previous;
@@ -153,7 +153,7 @@ struct onoff_state {
  * Change to select different GPIO output pins
  */
 
-static struct onoff_state onoff_state[] = {
+static struct led_onoff_state led_onoff_states[] = {
 	{ .led_device = GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios), },
 	{ .led_device = GPIO_DT_SPEC_GET(DT_ALIAS(led1), gpios), },
 	{ .led_device = GPIO_DT_SPEC_GET(DT_ALIAS(led2), gpios), },
@@ -172,9 +172,9 @@ static struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_srv_op,
-		      &gen_onoff_pub_srv, &onoff_state[0]),
+		      &gen_onoff_pub_srv, &led_onoff_states[0]),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, gen_onoff_cli_op,
-		      &gen_onoff_pub_cli, &onoff_state[0]),
+		      &gen_onoff_pub_cli, &led_onoff_states[0]),
 };
 
 /*
@@ -183,9 +183,9 @@ static struct bt_mesh_model root_models[] = {
 
 static struct bt_mesh_model secondary_0_models[] = {
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_srv_op,
-		      &gen_onoff_pub_srv_s_0, &onoff_state[1]),
+		      &gen_onoff_pub_srv_s_0, &led_onoff_states[1]),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, gen_onoff_cli_op,
-		      &gen_onoff_pub_cli_s_0, &onoff_state[1]),
+		      &gen_onoff_pub_cli_s_0, &led_onoff_states[1]),
 };
 
 /*
@@ -194,9 +194,9 @@ static struct bt_mesh_model secondary_0_models[] = {
 
 static struct bt_mesh_model secondary_1_models[] = {
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_srv_op,
-		      &gen_onoff_pub_srv_s_1, &onoff_state[2]),
+		      &gen_onoff_pub_srv_s_1, &led_onoff_states[2]),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, gen_onoff_cli_op,
-		      &gen_onoff_pub_cli_s_1, &onoff_state[2]),
+		      &gen_onoff_pub_cli_s_1, &led_onoff_states[2]),
 };
 
 /*
@@ -205,9 +205,9 @@ static struct bt_mesh_model secondary_1_models[] = {
 
 static struct bt_mesh_model secondary_2_models[] = {
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_srv_op,
-		      &gen_onoff_pub_srv_s_2, &onoff_state[3]),
+		      &gen_onoff_pub_srv_s_2, &led_onoff_states[3]),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, gen_onoff_cli_op,
-		      &gen_onoff_pub_cli_s_2, &onoff_state[3]),
+		      &gen_onoff_pub_cli_s_2, &led_onoff_states[3]),
 };
 
 /*
@@ -256,7 +256,7 @@ static const struct gpio_dt_spec sw_device[4] = {
 	GPIO_DT_SPEC_GET(DT_ALIAS(sw3), gpios),
 };
 
-struct sw {
+struct switch_data {
 	uint8_t sw_num;
 	uint8_t onoff_state;
 	struct k_work button_work;
@@ -265,7 +265,7 @@ struct sw {
 
 
 static uint8_t button_press_cnt;
-static struct sw sw;
+static struct switch_data sw;
 
 static struct gpio_callback button_cb;
 
@@ -286,7 +286,7 @@ static int gen_onoff_get(struct bt_mesh_model *model,
 			 struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, 2 + 1 + 4);
-	struct onoff_state *onoff_state = model->user_data;
+	struct led_onoff_state *onoff_state = model->user_data;
 
 	printk("addr 0x%04x onoff 0x%02x\n",
 	       bt_mesh_model_elem(model)->addr, onoff_state->current);
@@ -305,7 +305,7 @@ static int gen_onoff_set_unack(struct bt_mesh_model *model,
 			       struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = model->pub->msg;
-	struct onoff_state *onoff_state = model->user_data;
+	struct led_onoff_state *onoff_state = model->user_data;
 	int err;
 
 	onoff_state->current = net_buf_simple_pull_u8(buf);
@@ -450,7 +450,7 @@ static void button_pressed(const struct device *dev, struct gpio_callback *cb,
 
 static void button_cnt_timer(struct k_timer *work)
 {
-	struct sw *button_sw = CONTAINER_OF(work, struct sw, button_timer);
+	struct switch_data *button_sw = CONTAINER_OF(work, struct switch_data, button_timer);
 
 	button_sw->onoff_state = button_press_cnt == 1U ? 1 : 0;
 	printk("button_press_cnt 0x%02x onoff_state 0x%02x\n",
@@ -467,9 +467,9 @@ static void button_pressed_worker(struct k_work *work)
 {
 	struct bt_mesh_model *mod_cli, *mod_srv;
 	struct bt_mesh_model_pub *pub_cli, *pub_srv;
-	struct sw *sw = CONTAINER_OF(work, struct sw, button_work);
+	struct switch_data *button_sw = CONTAINER_OF(work, struct switch_data, button_work);
 	int err;
-	uint8_t sw_idx = sw->sw_num;
+	uint8_t sw_idx = button_sw->sw_num;
 
 	mod_cli = mod_cli_sw[sw_idx];
 	pub_cli = mod_cli->pub;
@@ -497,7 +497,7 @@ static void button_pressed_worker(struct k_work *work)
 		 * for the led server
 		 */
 
-		net_buf_simple_add_u8(&msg, sw->onoff_state);
+		net_buf_simple_add_u8(&msg, button_sw->onoff_state);
 		(void)gen_onoff_set_unack(mod_srv, &ctx, &msg);
 		return;
 	}
@@ -507,10 +507,10 @@ static void button_pressed_worker(struct k_work *work)
 	}
 
 	printk("publish to 0x%04x onoff 0x%04x sw_idx 0x%04x\n",
-	       pub_cli->addr, sw->onoff_state, sw_idx);
+	       pub_cli->addr, button_sw->onoff_state, sw_idx);
 	bt_mesh_model_msg_init(pub_cli->msg,
 			       BT_MESH_MODEL_OP_GEN_ONOFF_SET);
-	net_buf_simple_add_u8(pub_cli->msg, sw->onoff_state);
+	net_buf_simple_add_u8(pub_cli->msg, button_sw->onoff_state);
 	net_buf_simple_add_u8(pub_cli->msg, trans_id++);
 	err = bt_mesh_model_publish(mod_cli);
 	if (err) {
@@ -604,12 +604,12 @@ int main(void)
 
 
 	/* Initialize LED's */
-	for (i = 0; i < ARRAY_SIZE(onoff_state); i++) {
-		if (!device_is_ready(onoff_state[i].led_device.port)) {
+	for (i = 0; i < ARRAY_SIZE(led_onoff_states); i++) {
+		if (!device_is_ready(led_onoff_states[i].led_device.port)) {
 			printk("LED%d GPIO controller device is not ready\n", i);
 			return 0;
 		}
-		gpio_pin_configure_dt(&onoff_state[i].led_device, GPIO_OUTPUT_INACTIVE);
+		gpio_pin_configure_dt(&led_onoff_states[i].led_device, GPIO_OUTPUT_INACTIVE);
 	}
 
 	/* Initialize the Bluetooth Subsystem */

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -45,17 +45,17 @@ BT_MESH_MODEL_PUB_DEFINE(gen_level_cli_pub_s0, NULL, 2 + 7);
 /* Definitions of models publication context (End) */
 
 struct lightness light;
-struct temperature temp;
+struct temperature light_temp;
 struct delta_uv duv;
 
-struct light_ctl_state state = {
+struct light_ctl_state light_state = {
 	.light = &light,
-	.temp = &temp,
+	.temp = &light_temp,
 	.duv = &duv,
-	.transition = &transition,
+	.transition = &onoff_transition,
 };
 
-struct light_ctl_state *const ctl = &state;
+struct light_ctl_state *const ctl = &light_state;
 
 /* Definitions of models user data (Start) */
 

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
@@ -87,7 +87,7 @@ struct light_ctl_state {
 	uint16_t last_dst_addr;
 	int64_t last_msg_timestamp;
 
-	struct transition *transition;
+	struct transition_data *transition;
 };
 
 extern struct vendor_state vnd_user_data;

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
@@ -13,11 +13,11 @@
 #include "state_binding.h"
 #include "transition.h"
 
-struct transition transition;
+struct transition_data onoff_transition;
 
 /* Function to calculate Remaining Time (Start) */
 
-void calculate_rt(struct transition *transition)
+void calculate_rt(struct transition_data *transition)
 {
 	uint8_t steps, resolution;
 	int32_t duration_remainder;
@@ -62,7 +62,7 @@ void calculate_rt(struct transition *transition)
 
 /* Function to calculate Remaining Time (End) */
 
-static bool set_transition_counter(struct transition *transition)
+static bool set_transition_counter(struct transition_data *transition)
 {
 	uint8_t steps_multiplier, resolution;
 

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.h
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.h
@@ -18,7 +18,7 @@ enum transition_types {
 	NON_MOVE
 };
 
-struct transition {
+struct transition_data {
 	bool just_started;
 	uint8_t type;
 	uint8_t tt;
@@ -32,11 +32,11 @@ struct transition {
 	struct k_timer timer;
 };
 
-extern struct transition transition;
+extern struct transition_data onoff_transition;
 
 extern struct k_timer dummy_timer;
 
-void calculate_rt(struct transition *transition);
+void calculate_rt(struct transition_data *transition);
 void set_transition_values(uint8_t type);
 
 void onoff_handler(void);

--- a/samples/drivers/audio/dmic/src/main.c
+++ b/samples/drivers/audio/dmic/src/main.c
@@ -52,7 +52,6 @@ static int do_pdm_transfer(const struct device *dmic_dev,
 	for (int i = 0; i < block_count; ++i) {
 		void *buffer;
 		uint32_t size;
-		int ret;
 
 		ret = dmic_read(dmic_dev, 0, &buffer, &size, READ_TIMEOUT);
 		if (ret < 0) {

--- a/samples/drivers/memc/src/main.c
+++ b/samples/drivers/memc/src/main.c
@@ -46,7 +46,7 @@ int main(void)
 	uint32_t i, j;
 
 	/* Initialize write buffer */
-	for (uint32_t i = 0; i < BUF_SIZE; i++) {
+	for (i = 0; i < BUF_SIZE; i++) {
 		memc_write_buffer[i] = (uint8_t)i;
 	}
 	printk("Writing to memory region with base 0x%0x, size 0x%0x\n\n",

--- a/samples/drivers/peci/src/main.c
+++ b/samples/drivers/peci/src/main.c
@@ -25,7 +25,7 @@
 
 static const struct device *const peci_dev = DEVICE_DT_GET(DT_ALIAS(peci_0));
 static bool peci_initialized;
-static uint8_t tjmax;
+static uint8_t cpu_tjmax;
 static uint8_t rx_fcs;
 static void monitor_temperature_func(void *dummy1, void *dummy2, void *dummy3);
 
@@ -135,7 +135,7 @@ int peci_get_temp(int *temperature)
 	}
 
 	raw_cpu_temp = (raw_cpu_temp >> 6) | 0x7E00;
-	*temperature = raw_cpu_temp + tjmax;
+	*temperature = raw_cpu_temp + cpu_tjmax;
 
 	return 0;
 }
@@ -156,11 +156,11 @@ void get_max_temp(void)
 {
 	int ret;
 
-	ret = peci_get_tjmax(&tjmax);
+	ret = peci_get_tjmax(&cpu_tjmax);
 	if (ret) {
 		printk("Fail to obtain maximum temperature: %d\n", ret);
 	} else {
-		printk("Maximum temperature: %u\n", tjmax);
+		printk("Maximum temperature: %u\n", cpu_tjmax);
 	}
 }
 
@@ -197,7 +197,7 @@ int main(void)
 
 	peci_enable(peci_dev);
 
-	tjmax = 100;
+	cpu_tjmax = 100;
 
 	get_max_temp();
 	printk("Start thread...\n");

--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -64,7 +64,7 @@ static sec_tag_t m_sec_tags[] = {
 	APP_CA_CERT_TAG,
 };
 
-static uint8_t topic[] = "devices/" MQTT_CLIENTID "/messages/devicebound/#";
+static uint8_t devbound_topic[] = "devices/" MQTT_CLIENTID "/messages/devicebound/#";
 static struct mqtt_topic subs_topic;
 static struct mqtt_subscription_list subs_list;
 
@@ -274,27 +274,27 @@ static void subscribe(struct mqtt_client *client)
 	int err;
 
 	/* subscribe */
-	subs_topic.topic.utf8 = topic;
-	subs_topic.topic.size = strlen(topic);
+	subs_topic.topic.utf8 = devbound_topic;
+	subs_topic.topic.size = strlen(devbound_topic);
 	subs_list.list = &subs_topic;
 	subs_list.list_count = 1U;
 	subs_list.message_id = 1U;
 
 	err = mqtt_subscribe(client, &subs_list);
 	if (err) {
-		LOG_ERR("Failed on topic %s", topic);
+		LOG_ERR("Failed on topic %s", devbound_topic);
 	}
 }
 
 static int publish(struct mqtt_client *client, enum mqtt_qos qos)
 {
 	char payload[] = "{id=123}";
-	char topic[] = "devices/" MQTT_CLIENTID "/messages/events/";
-	uint8_t len = strlen(topic);
+	char evt_topic[] = "devices/" MQTT_CLIENTID "/messages/events/";
+	uint8_t len = strlen(evt_topic);
 	struct mqtt_publish_param param;
 
 	param.message.topic.qos = qos;
-	param.message.topic.topic.utf8 = (uint8_t *)topic;
+	param.message.topic.topic.utf8 = (uint8_t *)evt_topic;
 	param.message.topic.topic.size = len;
 	param.message.payload.data = payload;
 	param.message.payload.len = strlen(payload);

--- a/samples/net/dsa/src/main.c
+++ b/samples/net/dsa/src/main.c
@@ -90,23 +90,23 @@ int start_slave_port_packet_socket(struct net_if *iface,
 	return 0;
 }
 
-struct ud ifaces;
+struct ud user_data_ifaces;
 static int init_dsa_ports(void)
 {
 	uint8_t tbl_buf[8];
 
-	/* Initialize interfaces - read them to ifaces */
-	(void)memset(&ifaces, 0, sizeof(ifaces));
-	net_if_foreach(iface_cb, &ifaces);
+	/* Initialize interfaces - read them to user_data_ifaces */
+	(void)memset(&user_data_ifaces, 0, sizeof(user_data_ifaces));
+	net_if_foreach(iface_cb, &user_data_ifaces);
 
 	/*
 	 * Set static table to forward LLDP protocol packets
 	 * to master port.
 	 */
-	dsa_switch_set_mac_table_entry(ifaces.lan[0],
+	dsa_switch_set_mac_table_entry(user_data_ifaces.lan[0],
 					      &eth_filter_l2_addr_base[0][0],
 					      BIT(4), 0, 0);
-	dsa_switch_get_mac_table_entry(ifaces.lan[0], tbl_buf, 0);
+	dsa_switch_get_mac_table_entry(user_data_ifaces.lan[0], tbl_buf, 0);
 
 	LOG_INF("DSA static MAC address table entry [%d]:", 0);
 	LOG_INF("0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x",

--- a/samples/net/dsa/src/main.h
+++ b/samples/net/dsa/src/main.h
@@ -27,7 +27,7 @@
 #define ETH_ALEN 6
 #define PACKET_LEN 128
 
-extern struct ud ifaces;
+extern struct ud user_data_ifaces;
 
 struct eth_addr {
 	uint8_t addr[ETH_ALEN]; /* origin hardware address */
@@ -86,7 +86,7 @@ enum net_verdict dsa_ll_addr_switch_cb(struct net_if *iface,
 		struct instance_data data;                                     \
 		struct net_if *iface;                                          \
 									       \
-		iface = ifaces.lan[ID-1];                                      \
+		iface = user_data_ifaces.lan[ID-1];                            \
 									       \
 		data.if_name = "lan"#ID;                                       \
 		ret = start_slave_port_packet_socket(iface, &data);            \

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -40,7 +40,7 @@ static uint8_t bat_status = LWM2M_DEVICE_BATTERY_STATUS_CHARGING;
 static int mem_free = 15;
 static int mem_total = 25;
 
-static struct lwm2m_ctx client;
+static struct lwm2m_ctx client_ctx;
 
 static const char *endpoint =
 	(sizeof(CONFIG_LWM2M_APP_ID) > 1 ? CONFIG_LWM2M_APP_ID : CONFIG_BOARD);
@@ -278,13 +278,13 @@ int main(void)
 		return 0;
 	}
 
-	(void)memset(&client, 0x0, sizeof(client));
+	(void)memset(&client_ctx, 0x0, sizeof(client_ctx));
 #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
-	client.tls_tag = CONFIG_LWM2M_APP_TLS_TAG;
+	client_ctx.tls_tag = CONFIG_LWM2M_APP_TLS_TAG;
 #endif
 
-	/* client.sec_obj_inst is 0 as a starting point */
-	lwm2m_rd_client_start(&client, endpoint, flags, rd_client_event, observe_cb);
+	/* client_ctx.sec_obj_inst is 0 as a starting point */
+	lwm2m_rd_client_start(&client_ctx, endpoint, flags, rd_client_event, observe_cb);
 
 	k_sem_take(&quit_lock, K_FOREVER);
 	return 0;

--- a/samples/net/sockets/can/src/main.c
+++ b/samples/net/sockets/can/src/main.c
@@ -37,7 +37,7 @@ static const struct can_filter zfilter = {
 	.mask = CAN_STD_ID_MASK
 };
 
-static struct socketcan_filter sfilter;
+static struct socketcan_filter sock_filter;
 
 static void tx(int *can_fd)
 {
@@ -169,7 +169,7 @@ static int setup_socket(void)
 	int fd, rx_fd;
 	int ret;
 
-	socketcan_from_can_filter(&zfilter, &sfilter);
+	socketcan_from_can_filter(&zfilter, &sock_filter);
 
 	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(CANBUS_RAW));
 	if (!iface) {
@@ -194,8 +194,8 @@ static int setup_socket(void)
 		goto cleanup;
 	}
 
-	ret = setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, &sfilter,
-			 sizeof(sfilter));
+	ret = setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, &sock_filter,
+			 sizeof(sock_filter));
 	if (ret < 0) {
 		ret = -errno;
 		LOG_ERR("Cannot set CAN sockopt (%d)", ret);
@@ -221,14 +221,14 @@ static int setup_socket(void)
 	rx_fd = fd;
 
 #if CONFIG_NET_SOCKETS_CAN_RECEIVERS == 2
-	fd = create_socket(&sfilter);
+	fd = create_socket(&sock_filter);
 	if (fd >= 0) {
 		rx_tid = k_thread_create(&rx_data, rx_stack,
 					 K_THREAD_STACK_SIZEOF(rx_stack),
 					 (k_thread_entry_t)rx,
 					 INT_TO_POINTER(fd),
 					 INT_TO_POINTER(CLOSE_PERIOD),
-					 &sfilter, PRIORITY, 0, K_NO_WAIT);
+					 &sock_filter, PRIORITY, 0, K_NO_WAIT);
 		if (!rx_tid) {
 			ret = -ENOENT;
 			errno = -ret;

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -1262,7 +1262,7 @@ static const char * const core_2_attributes[] = {
 	"rt=core1",
 	NULL };
 
-static struct coap_resource resources[] = {
+static struct coap_resource coap_resources[] = {
 	{ .get = well_known_core_get,
 	  .path = COAP_WELL_KNOWN_CORE_PATH,
 	},
@@ -1348,7 +1348,7 @@ static void remove_observer(struct sockaddr *addr)
 		return;
 	}
 
-	r = find_resource_by_observer(resources, o);
+	r = find_resource_by_observer(coap_resources, o);
 	if (!r) {
 		LOG_ERR("Observer found but Resource not found\n");
 		return;
@@ -1397,7 +1397,7 @@ static void process_coap_request(uint8_t *data, uint16_t data_len,
 	return;
 
 not_found:
-	r = coap_handle_request(&request, resources, options, opt_num,
+	r = coap_handle_request(&request, coap_resources, options, opt_num,
 				client_addr, client_addr_len);
 	if (r < 0) {
 		LOG_WRN("No handler for such request (%d)\n", r);

--- a/samples/net/sockets/packet/src/packet.c
+++ b/samples/net/sockets/packet/src/packet.c
@@ -34,7 +34,7 @@ struct packet_data {
 	char recv_buffer[RECV_BUFFER_SIZE];
 };
 
-static struct packet_data packet;
+static struct packet_data sock_packet;
 static bool finish;
 static K_SEM_DEFINE(iface_up, 0, 1);
 
@@ -148,13 +148,13 @@ static void recv_packet(void)
 		.tv_usec = 0,
 	};
 
-	ret = start_socket(&packet.recv_sock);
+	ret = start_socket(&sock_packet.recv_sock);
 	if (ret < 0) {
 		quit();
 		return;
 	}
 
-	ret = setsockopt(packet.recv_sock, SOL_SOCKET, SO_RCVTIMEO,
+	ret = setsockopt(sock_packet.recv_sock, SOL_SOCKET, SO_RCVTIMEO,
 			 &timeo_optval, sizeof(timeo_optval));
 	if (ret < 0) {
 		quit();
@@ -162,7 +162,7 @@ static void recv_packet(void)
 	}
 
 	while (ret == 0) {
-		ret = recv_packet_socket(&packet);
+		ret = recv_packet_socket(&sock_packet);
 		if (ret < 0) {
 			quit();
 			return;
@@ -235,14 +235,14 @@ static void send_packet(void)
 {
 	int ret;
 
-	ret = start_socket(&packet.send_sock);
+	ret = start_socket(&sock_packet.send_sock);
 	if (ret < 0) {
 		quit();
 		return;
 	}
 
 	while (ret == 0) {
-		ret = send_packet_socket(&packet);
+		ret = send_packet_socket(&sock_packet);
 		if (ret < 0) {
 			quit();
 			return;
@@ -297,12 +297,12 @@ int main(void)
 	k_thread_join(receiver_thread_id, K_FOREVER);
 	k_thread_join(sender_thread_id, K_FOREVER);
 
-	if (packet.recv_sock >= 0) {
-		(void)close(packet.recv_sock);
+	if (sock_packet.recv_sock >= 0) {
+		(void)close(sock_packet.recv_sock);
 	}
 
-	if (packet.send_sock >= 0) {
-		(void)close(packet.send_sock);
+	if (sock_packet.send_sock >= 0) {
+		(void)close(sock_packet.send_sock);
 	}
 	return 0;
 }

--- a/samples/philosophers/src/main.c
+++ b/samples/philosophers/src/main.c
@@ -142,35 +142,35 @@ void philosopher(void *id, void *unused1, void *unused2)
 	ARG_UNUSED(unused1);
 	ARG_UNUSED(unused2);
 
-	fork_t fork1;
-	fork_t fork2;
+	fork_t my_fork1;
+	fork_t my_fork2;
 
 	int my_id = POINTER_TO_INT(id);
 
 	/* Djkstra's solution: always pick up the lowest numbered fork first */
 	if (is_last_philosopher(my_id)) {
-		fork1 = fork(0);
-		fork2 = fork(my_id);
+		my_fork1 = fork(0);
+		my_fork2 = fork(my_id);
 	} else {
-		fork1 = fork(my_id);
-		fork2 = fork(my_id + 1);
+		my_fork1 = fork(my_id);
+		my_fork2 = fork(my_id + 1);
 	}
 
 	while (1) {
 		int32_t delay;
 
 		print_phil_state(my_id, "       STARVING       ", 0);
-		take(fork1);
+		take(my_fork1);
 		print_phil_state(my_id, "   HOLDING ONE FORK   ", 0);
-		take(fork2);
+		take(my_fork2);
 
 		delay = get_random_delay(my_id, 25);
 		print_phil_state(my_id, "  EATING  [ %s%d ms ] ", delay);
 		k_msleep(delay);
 
-		drop(fork2);
+		drop(my_fork2);
 		print_phil_state(my_id, "   DROPPED ONE FORK   ", 0);
-		drop(fork1);
+		drop(my_fork1);
 
 		delay = get_random_delay(my_id, 25);
 		print_phil_state(my_id, " THINKING [ %s%d ms ] ", delay);

--- a/samples/sensor/adc_cmp_npcx/src/main.c
+++ b/samples/sensor/adc_cmp_npcx/src/main.c
@@ -26,7 +26,7 @@ enum threshold_state {
 
 atomic_val_t stop;
 
-const struct sensor_trigger trigger = {
+const struct sensor_trigger sensor_trig = {
 	.type = SENSOR_TRIG_THRESHOLD,
 	.chan = SENSOR_CHAN_VOLTAGE
 };
@@ -107,7 +107,7 @@ int main(void)
 		return 0;
 	}
 
-	err = sensor_trigger_set(adc_cmp, &trigger,
+	err = sensor_trigger_set(adc_cmp, &sensor_trig,
 		threshold_trigger_handler);
 	if (err) {
 		printf("ADC CMP: Error setting handler");

--- a/samples/sensor/fxos8700-hid/src/main.c
+++ b/samples/sensor/fxos8700-hid/src/main.c
@@ -36,7 +36,7 @@ static const uint8_t hid_report_desc[] = HID_MOUSE_REPORT_DESC(2);
 static uint32_t def_val[4];
 static volatile uint8_t status[4];
 static K_SEM_DEFINE(sem, 0, 1);	/* starts off "not available" */
-static struct gpio_callback callback[4];
+static struct gpio_callback gpio_callbacks[4];
 
 #define MOUSE_BTN_REPORT_POS	0
 #define MOUSE_X_REPORT_POS	1
@@ -185,13 +185,13 @@ int main(void)
 
 	gpio_pin_configure_dt(&led_gpio, GPIO_OUTPUT);
 
-	if (callbacks_configure(&sw0_gpio, &left_button, &callback[0], &def_val[0])) {
+	if (callbacks_configure(&sw0_gpio, &left_button, &gpio_callbacks[0], &def_val[0])) {
 		LOG_ERR("Failed configuring left button callback.");
 		return 0;
 	}
 
 #if DT_NODE_HAS_STATUS(SW1_NODE, okay)
-	if (callbacks_configure(&sw1_gpio, &right_button, &callback[1], &def_val[1])) {
+	if (callbacks_configure(&sw1_gpio, &right_button, &gpio_callbacks[1], &def_val[1])) {
 		LOG_ERR("Failed configuring right button callback.");
 		return 0;
 	}

--- a/samples/sensor/mcp9808/src/main.c
+++ b/samples/sensor/mcp9808/src/main.c
@@ -38,7 +38,7 @@ static const char *now_str(void)
 
 #ifdef CONFIG_MCP9808_TRIGGER
 
-static struct sensor_trigger trig;
+static struct sensor_trigger sensor_trig;
 
 static int set_window(const struct device *dev,
 		      const struct sensor_value *temp)
@@ -121,9 +121,9 @@ int main(void)
 #ifdef CONFIG_MCP9808_TRIGGER
 	rc = set_window_ucel(dev, TEMP_INITIAL_CEL * UCEL_PER_CEL);
 	if (rc == 0) {
-		trig.type = SENSOR_TRIG_THRESHOLD;
-		trig.chan = SENSOR_CHAN_AMBIENT_TEMP;
-		rc = sensor_trigger_set(dev, &trig, trigger_handler);
+		sensor_trig.type = SENSOR_TRIG_THRESHOLD;
+		sensor_trig.chan = SENSOR_CHAN_AMBIENT_TEMP;
+		rc = sensor_trigger_set(dev, &sensor_trig, trigger_handler);
 	}
 
 	if (rc != 0) {

--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -273,7 +273,7 @@ static struct fs_mount_t lfs_storage_mnt = {
 };
 #endif /* PARTITION_NODE */
 
-	struct fs_mount_t *mp =
+	struct fs_mount_t *mountpoint =
 #if DT_NODE_EXISTS(PARTITION_NODE)
 		&FS_FSTAB_ENTRY(PARTITION_NODE)
 #else
@@ -324,7 +324,7 @@ static struct fs_mount_t __mp = {
 	.fs_data = &lfsfs,
 	.flags = FS_MOUNT_FLAG_USE_DISK_ACCESS,
 };
-struct fs_mount_t *mp = &__mp;
+struct fs_mount_t *mountpoint = &__mp;
 
 static int littlefs_mount(struct fs_mount_t *mp)
 {
@@ -347,15 +347,15 @@ int main(void)
 
 	LOG_PRINTK("Sample program to r/w files on littlefs\n");
 
-	rc = littlefs_mount(mp);
+	rc = littlefs_mount(mountpoint);
 	if (rc < 0) {
 		return 0;
 	}
 
-	snprintf(fname1, sizeof(fname1), "%s/boot_count", mp->mnt_point);
-	snprintf(fname2, sizeof(fname2), "%s/pattern.bin", mp->mnt_point);
+	snprintf(fname1, sizeof(fname1), "%s/boot_count", mountpoint->mnt_point);
+	snprintf(fname2, sizeof(fname2), "%s/pattern.bin", mountpoint->mnt_point);
 
-	rc = fs_statvfs(mp->mnt_point, &sbuf);
+	rc = fs_statvfs(mountpoint->mnt_point, &sbuf);
 	if (rc < 0) {
 		LOG_PRINTK("FAIL: statvfs: %d\n", rc);
 		goto out;
@@ -363,13 +363,13 @@ int main(void)
 
 	LOG_PRINTK("%s: bsize = %lu ; frsize = %lu ;"
 		   " blocks = %lu ; bfree = %lu\n",
-		   mp->mnt_point,
+		   mountpoint->mnt_point,
 		   sbuf.f_bsize, sbuf.f_frsize,
 		   sbuf.f_blocks, sbuf.f_bfree);
 
-	rc = lsdir(mp->mnt_point);
+	rc = lsdir(mountpoint->mnt_point);
 	if (rc < 0) {
-		LOG_PRINTK("FAIL: lsdir %s: %d\n", mp->mnt_point, rc);
+		LOG_PRINTK("FAIL: lsdir %s: %d\n", mountpoint->mnt_point, rc);
 		goto out;
 	}
 
@@ -384,7 +384,7 @@ int main(void)
 	}
 
 out:
-	rc = fs_unmount(mp);
-	LOG_PRINTK("%s unmount: %d\n", mp->mnt_point, rc);
+	rc = fs_unmount(mountpoint);
+	LOG_PRINTK("%s unmount: %d\n", mountpoint->mnt_point, rc);
 	return 0;
 }

--- a/samples/subsys/ipc/openamp/remote/src/main.c
+++ b/samples/subsys/ipc/openamp/remote/src/main.c
@@ -60,14 +60,14 @@ static struct virtio_vring_info rvrings[2] = {
 static struct virtio_device vdev;
 static struct rpmsg_virtio_device rvdev;
 static struct metal_io_region *io;
-static struct virtqueue *vq[2];
+static struct virtqueue *vqueue[2];
 
-static unsigned char ipc_virtio_get_status(struct virtio_device *vdev)
+static unsigned char ipc_virtio_get_status(struct virtio_device *dev)
 {
 	return sys_read8(VDEV_STATUS_ADDR);
 }
 
-static uint32_t ipc_virtio_get_features(struct virtio_device *vdev)
+static uint32_t ipc_virtio_get_features(struct virtio_device *dev)
 {
 	return 1 << VIRTIO_RPMSG_F_NS;
 }
@@ -128,7 +128,7 @@ static unsigned int receive_message(void)
 		int status = k_sem_take(&data_sem, K_FOREVER);
 
 		if (status == 0) {
-			virtqueue_notification(vq[1]);
+			virtqueue_notification(vqueue[1]);
 		}
 	}
 	return received_data;
@@ -191,14 +191,14 @@ void app_task(void *arg1, void *arg2, void *arg3)
 	}
 
 	/* setup vdev */
-	vq[0] = virtqueue_allocate(VRING_SIZE);
-	if (vq[0] == NULL) {
-		printk("virtqueue_allocate failed to alloc vq[0]\n");
+	vqueue[0] = virtqueue_allocate(VRING_SIZE);
+	if (vqueue[0] == NULL) {
+		printk("virtqueue_allocate failed to alloc vqueue[0]\n");
 		return;
 	}
-	vq[1] = virtqueue_allocate(VRING_SIZE);
-	if (vq[1] == NULL) {
-		printk("virtqueue_allocate failed to alloc vq[1]\n");
+	vqueue[1] = virtqueue_allocate(VRING_SIZE);
+	if (vqueue[1] == NULL) {
+		printk("virtqueue_allocate failed to alloc vqueue[1]\n");
 		return;
 	}
 
@@ -209,13 +209,13 @@ void app_task(void *arg1, void *arg2, void *arg3)
 	rvrings[0].info.vaddr = (void *)VRING_TX_ADDRESS;
 	rvrings[0].info.num_descs = VRING_SIZE;
 	rvrings[0].info.align = VRING_ALIGNMENT;
-	rvrings[0].vq = vq[0];
+	rvrings[0].vq = vqueue[0];
 
 	rvrings[1].io = io;
 	rvrings[1].info.vaddr = (void *)VRING_RX_ADDRESS;
 	rvrings[1].info.num_descs = VRING_SIZE;
 	rvrings[1].info.align = VRING_ALIGNMENT;
-	rvrings[1].vq = vq[1];
+	rvrings[1].vq = vqueue[1];
 
 	vdev.vrings_info = &rvrings[0];
 

--- a/samples/subsys/ipc/openamp/src/main.c
+++ b/samples/subsys/ipc/openamp/src/main.c
@@ -61,24 +61,24 @@ static struct virtio_vring_info rvrings[2] = {
 static struct virtio_device vdev;
 static struct rpmsg_virtio_device rvdev;
 static struct metal_io_region *io;
-static struct virtqueue *vq[2];
+static struct virtqueue *vqueue[2];
 
-static unsigned char ipc_virtio_get_status(struct virtio_device *vdev)
+static unsigned char ipc_virtio_get_status(struct virtio_device *dev)
 {
 	return VIRTIO_CONFIG_STATUS_DRIVER_OK;
 }
 
-static void ipc_virtio_set_status(struct virtio_device *vdev, unsigned char status)
+static void ipc_virtio_set_status(struct virtio_device *dev, unsigned char status)
 {
 	sys_write8(status, VDEV_STATUS_ADDR);
 }
 
-static uint32_t ipc_virtio_get_features(struct virtio_device *vdev)
+static uint32_t ipc_virtio_get_features(struct virtio_device *dev)
 {
 	return 1 << VIRTIO_RPMSG_F_NS;
 }
 
-static void ipc_virtio_set_features(struct virtio_device *vdev, uint32_t features)
+static void ipc_virtio_set_features(struct virtio_device *dev, uint32_t features)
 {
 }
 
@@ -150,7 +150,7 @@ static unsigned int receive_message(void)
 		int status = k_sem_take(&data_sem, K_FOREVER);
 
 		if (status == 0) {
-			virtqueue_notification(vq[0]);
+			virtqueue_notification(vqueue[0]);
 		}
 	}
 	return received_data;
@@ -214,14 +214,14 @@ void app_task(void *arg1, void *arg2, void *arg3)
 	}
 
 	/* setup vdev */
-	vq[0] = virtqueue_allocate(VRING_SIZE);
-	if (vq[0] == NULL) {
-		printk("virtqueue_allocate failed to alloc vq[0]\n");
+	vqueue[0] = virtqueue_allocate(VRING_SIZE);
+	if (vqueue[0] == NULL) {
+		printk("virtqueue_allocate failed to alloc vqueue[0]\n");
 		return;
 	}
-	vq[1] = virtqueue_allocate(VRING_SIZE);
-	if (vq[1] == NULL) {
-		printk("virtqueue_allocate failed to alloc vq[1]\n");
+	vqueue[1] = virtqueue_allocate(VRING_SIZE);
+	if (vqueue[1] == NULL) {
+		printk("virtqueue_allocate failed to alloc vqueue[1]\n");
 		return;
 	}
 
@@ -232,13 +232,13 @@ void app_task(void *arg1, void *arg2, void *arg3)
 	rvrings[0].info.vaddr = (void *)VRING_TX_ADDRESS;
 	rvrings[0].info.num_descs = VRING_SIZE;
 	rvrings[0].info.align = VRING_ALIGNMENT;
-	rvrings[0].vq = vq[0];
+	rvrings[0].vq = vqueue[0];
 
 	rvrings[1].io = io;
 	rvrings[1].info.vaddr = (void *)VRING_RX_ADDRESS;
 	rvrings[1].info.num_descs = VRING_SIZE;
 	rvrings[1].info.align = VRING_ALIGNMENT;
-	rvrings[1].vq = vq[1];
+	rvrings[1].vq = vqueue[1];
 
 	vdev.vrings_info = &rvrings[0];
 
@@ -254,7 +254,7 @@ void app_task(void *arg1, void *arg2, void *arg3)
 	 * from NS setup and than we need to process it
 	 */
 	k_sem_take(&data_sem, K_FOREVER);
-	virtqueue_notification(vq[0]);
+	virtqueue_notification(vqueue[0]);
 
 	/* Wait til nameservice ep is setup */
 	k_sem_take(&ept_sem, K_FOREVER);

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -106,11 +106,11 @@ static int rpmsg_recv_cs_callback(struct rpmsg_endpoint *ept, void *data,
 static int rpmsg_recv_tty_callback(struct rpmsg_endpoint *ept, void *data,
 				   size_t len, uint32_t src, void *priv)
 {
-	struct rpmsg_rcv_msg *tty_msg = priv;
+	struct rpmsg_rcv_msg *msg = priv;
 
 	rpmsg_hold_rx_buffer(ept, data);
-	tty_msg->data = data;
-	tty_msg->len = len;
+	msg->data = data;
+	msg->len = len;
 	k_sem_give(&data_tty_sem);
 
 	return RPMSG_SUCCESS;

--- a/samples/subsys/lorawan/class_a/src/main.c
+++ b/samples/subsys/lorawan/class_a/src/main.c
@@ -29,11 +29,11 @@ char data[] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd'};
 
 static void dl_callback(uint8_t port, bool data_pending,
 			int16_t rssi, int8_t snr,
-			uint8_t len, const uint8_t *data)
+			uint8_t len, const uint8_t *hex_data)
 {
 	LOG_INF("Port %d, Pending %d, RSSI %ddB, SNR %ddBm", port, data_pending, rssi, snr);
-	if (data) {
-		LOG_HEXDUMP_INF(data, len, "Payload: ");
+	if (hex_data) {
+		LOG_HEXDUMP_INF(hex_data, len, "Payload: ");
 	}
 }
 

--- a/samples/subsys/usb/hid-cdc/src/main.c
+++ b/samples/subsys/usb/hid-cdc/src/main.c
@@ -132,7 +132,7 @@ static const uint8_t hid_kbd_report_desc[] = HID_KEYBOARD_REPORT_DESC();
 
 static K_SEM_DEFINE(evt_sem, 0, 1);	/* starts off "not available" */
 static K_SEM_DEFINE(usb_sem, 1, 1);	/* starts off "available" */
-static struct gpio_callback callback[4];
+static struct gpio_callback gpio_callbacks[4];
 
 static char data_buf_mouse[64], data_buf_kbd[64];
 static char string[64];
@@ -567,27 +567,27 @@ int main(void)
 		}
 	}
 
-	if (callbacks_configure(&sw0_gpio, &btn0, &callback[0])) {
+	if (callbacks_configure(&sw0_gpio, &btn0, &gpio_callbacks[0])) {
 		LOG_ERR("Failed configuring button 0 callback.");
 		return 0;
 	}
 
 #if DT_NODE_HAS_STATUS(SW1_NODE, okay)
-	if (callbacks_configure(&sw1_gpio, &btn1, &callback[1])) {
+	if (callbacks_configure(&sw1_gpio, &btn1, &gpio_callbacks[1])) {
 		LOG_ERR("Failed configuring button 1 callback.");
 		return 0;
 	}
 #endif
 
 #if DT_NODE_HAS_STATUS(SW2_NODE, okay)
-	if (callbacks_configure(&sw2_gpio, &btn2, &callback[2])) {
+	if (callbacks_configure(&sw2_gpio, &btn2, &gpio_callbacks[2])) {
 		LOG_ERR("Failed configuring button 2 callback.");
 		return 0;
 	}
 #endif
 
 #if DT_NODE_HAS_STATUS(SW3_NODE, okay)
-	if (callbacks_configure(&sw3_gpio, &btn3, &callback[3])) {
+	if (callbacks_configure(&sw3_gpio, &btn3, &gpio_callbacks[3])) {
 		LOG_ERR("Failed configuring button 3 callback.");
 		return 0;
 	}
@@ -680,10 +680,10 @@ int main(void)
 				/* Send string on HID keyboard */
 				write_data(cdc_dev[1], gpio2, strlen(gpio2));
 				if (strlen(string) > 0) {
-					struct app_evt_t *ev = app_evt_alloc();
+					struct app_evt_t *ev2 = app_evt_alloc();
 
-					ev->event_type = HID_KBD_STRING,
-					app_evt_put(ev);
+					ev2->event_type = HID_KBD_STRING,
+					app_evt_put(ev2);
 					str_pointer = 0U;
 					k_sem_give(&evt_sem);
 				}
@@ -813,10 +813,10 @@ int main(void)
 				str_pointer++;
 
 				if (strlen(string) > str_pointer) {
-					struct app_evt_t *ev = app_evt_alloc();
+					struct app_evt_t *ev2 = app_evt_alloc();
 
-					ev->event_type = HID_KBD_STRING,
-					app_evt_put(ev);
+					ev2->event_type = HID_KBD_STRING,
+					app_evt_put(ev2);
 					k_sem_give(&evt_sem);
 				} else if (strlen(string) == str_pointer) {
 					clear_kbd_report();

--- a/samples/subsys/usb_c/sink/src/main.c
+++ b/samples/subsys/usb_c/sink/src/main.c
@@ -117,43 +117,43 @@ static void display_pdo(const int idx,
 	}
 	break;
 	case PDO_BATTERY: {
-		union pd_battery_supply_pdo_source pdo;
+		union pd_battery_supply_pdo_source batt_pdo;
 
-		pdo.raw_value = pdo_value;
+		batt_pdo.raw_value = pdo_value;
 		LOG_INF("\tType:              BATTERY");
 		LOG_INF("\tMin Voltage: %d",
-			PD_CONVERT_BATTERY_PDO_VOLTAGE_TO_MV(pdo.min_voltage));
+			PD_CONVERT_BATTERY_PDO_VOLTAGE_TO_MV(batt_pdo.min_voltage));
 		LOG_INF("\tMax Voltage: %d",
-			PD_CONVERT_BATTERY_PDO_VOLTAGE_TO_MV(pdo.max_voltage));
+			PD_CONVERT_BATTERY_PDO_VOLTAGE_TO_MV(batt_pdo.max_voltage));
 		LOG_INF("\tMax Power:   %d",
-			PD_CONVERT_BATTERY_PDO_POWER_TO_MW(pdo.max_power));
+			PD_CONVERT_BATTERY_PDO_POWER_TO_MW(batt_pdo.max_power));
 	}
 	break;
 	case PDO_VARIABLE: {
-		union pd_variable_supply_pdo_source pdo;
+		union pd_variable_supply_pdo_source var_pdo;
 
-		pdo.raw_value = pdo_value;
+		var_pdo.raw_value = pdo_value;
 		LOG_INF("\tType:        VARIABLE");
 		LOG_INF("\tMin Voltage: %d",
-			PD_CONVERT_VARIABLE_PDO_VOLTAGE_TO_MV(pdo.min_voltage));
+			PD_CONVERT_VARIABLE_PDO_VOLTAGE_TO_MV(var_pdo.min_voltage));
 		LOG_INF("\tMax Voltage: %d",
-			PD_CONVERT_VARIABLE_PDO_VOLTAGE_TO_MV(pdo.max_voltage));
+			PD_CONVERT_VARIABLE_PDO_VOLTAGE_TO_MV(var_pdo.max_voltage));
 		LOG_INF("\tMax Current: %d",
-			PD_CONVERT_VARIABLE_PDO_CURRENT_TO_MA(pdo.max_current));
+			PD_CONVERT_VARIABLE_PDO_CURRENT_TO_MA(var_pdo.max_current));
 	}
 	break;
 	case PDO_AUGMENTED: {
-		union pd_augmented_supply_pdo_source pdo;
+		union pd_augmented_supply_pdo_source aug_pdo;
 
-		pdo.raw_value = pdo_value;
+		aug_pdo.raw_value = pdo_value;
 		LOG_INF("\tType:              AUGMENTED");
 		LOG_INF("\tMin Voltage:       %d",
-			PD_CONVERT_AUGMENTED_PDO_VOLTAGE_TO_MV(pdo.min_voltage));
+			PD_CONVERT_AUGMENTED_PDO_VOLTAGE_TO_MV(aug_pdo.min_voltage));
 		LOG_INF("\tMax Voltage:       %d",
-			PD_CONVERT_AUGMENTED_PDO_VOLTAGE_TO_MV(pdo.max_voltage));
+			PD_CONVERT_AUGMENTED_PDO_VOLTAGE_TO_MV(aug_pdo.max_voltage));
 		LOG_INF("\tMax Current:       %d",
-			PD_CONVERT_AUGMENTED_PDO_CURRENT_TO_MA(pdo.max_current));
-		LOG_INF("\tPPS Power Limited: %d", pdo.pps_power_limited);
+			PD_CONVERT_AUGMENTED_PDO_CURRENT_TO_MA(aug_pdo.max_current));
+		LOG_INF("\tPPS Power Limited: %d", aug_pdo.pps_power_limited);
 	}
 	break;
 	}

--- a/soc/CMakeLists.txt
+++ b/soc/CMakeLists.txt
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# FIXME: SHADOW_VARS: Remove this once we have enabled -Wshadow globally.
+#
+# Limit warning of shadow variables to in-tree SoC files for now.
+cmake_path(IS_PREFIX ZEPHYR_BASE "${SOC_DIR}" NORMALIZE _SOC_IS_IN_TREE)
+if(_SOC_IS_IN_TREE)
+  add_compile_options($<TARGET_PROPERTY:compiler,warning_shadow_variables>)
+endif()
+unset(_SOC_IS_IN_TREE)
+
+if(EXISTS ${SOC_DIR}/${ARCH}/CMakeLists.txt)
+  add_subdirectory(${SOC_DIR}/${ARCH} soc/${ARCH})
+else()
+  add_subdirectory(${SOC_DIR}/${ARCH}/${SOC_PATH} soc/${ARCH}/${SOC_PATH})
+endif()

--- a/soc/xtensa/espressif_esp32/esp32/soc.c
+++ b/soc/xtensa/espressif_esp32/esp32/soc.c
@@ -64,8 +64,8 @@ void __attribute__((section(".iram1"))) start_esp32_net_cpu(void)
 			volatile uint32_t *dst =
 				(volatile uint32_t *)segment->load_addr;
 
-			for (int i = 0; i < segment->data_len/4 ; i++) {
-				dst[i] = src[i];
+			for (int j = 0; j < segment->data_len/4 ; j++) {
+				dst[j] = src[j];
 			}
 		} else if (segment->load_addr >= SOC_DRAM_LOW &&
 			segment->load_addr < SOC_DRAM_HIGH) {

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -1,5 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# FIXME: SHADOW_VARS: move this before adding shadow variable warning below.
+# This is because, in some build configurations, the external lorawan module
+# is pulled in as though the source files are in main repo. This results in
+# shadow variable warnings being active on these files. Until the module has
+# fixed those shadow variables, keep this here before add_compile_options()
+# below.
+add_subdirectory_ifdef(CONFIG_LORAWAN lorawan)
+
+# FIXME: SHADOW_VARS: Remove this once we have enabled -Wshadow globally.
+add_compile_options($<TARGET_PROPERTY:compiler,warning_shadow_variables>)
+
 add_subdirectory(canbus)
 add_subdirectory(debug)
 add_subdirectory(fb)
@@ -29,7 +40,6 @@ add_subdirectory_ifdef(CONFIG_EMUL emul)
 add_subdirectory_ifdef(CONFIG_IMG_MANAGER dfu)
 add_subdirectory_ifdef(CONFIG_INPUT input)
 add_subdirectory_ifdef(CONFIG_JWT jwt)
-add_subdirectory_ifdef(CONFIG_LORAWAN lorawan)
 add_subdirectory_ifdef(CONFIG_NET_BUF net)
 add_subdirectory_ifdef(CONFIG_RETENTION retention)
 add_subdirectory_ifdef(CONFIG_SENSING sensing)

--- a/subsys/fs/ext2/ext2_diskops.c
+++ b/subsys/fs/ext2/ext2_diskops.c
@@ -539,12 +539,12 @@ static int64_t delete_blocks(struct ext2_data *fs, uint32_t block_num, int lvl,
 			start_blk = offsets[0];
 
 		} else {
-			uint32_t block_num = sys_le32_to_cpu(list[offsets[0]]);
+			uint32_t block_num2 = sys_le32_to_cpu(list[offsets[0]]);
 
 			/* We don't remove all blocks referenced by current block. We have to use
 			 * offsets to decide which part of next block we want to remove.
 			 */
-			if (block_num == 0) {
+			if (block_num2 == 0) {
 				LOG_ERR("Inode block that references other blocks must be nonzero");
 				fs->flags |= EXT2_DATA_FLAGS_ERR;
 				removed = -EINVAL;
@@ -555,7 +555,7 @@ static int64_t delete_blocks(struct ext2_data *fs, uint32_t block_num, int lvl,
 			start_blk = offsets[0] + 1;
 
 			/* Remove desired part of lower level block. */
-			rem = delete_blocks(fs, block_num, lvl - 1, &offsets[1]);
+			rem = delete_blocks(fs, block_num2, lvl - 1, &offsets[1]);
 			if (rem < 0) {
 				removed = rem;
 				goto out;
@@ -565,12 +565,12 @@ static int64_t delete_blocks(struct ext2_data *fs, uint32_t block_num, int lvl,
 
 		/* Iterate over blocks that will be entirely deleted */
 		for (uint32_t i = start_blk; i < fs->block_size / EXT2_BLOCK_NUM_SIZE; ++i) {
-			uint32_t block_num = sys_le32_to_cpu(list[i]);
+			uint32_t block_num2 = sys_le32_to_cpu(list[i]);
 
-			if (block_num == 0) {
+			if (block_num2 == 0) {
 				continue;
 			}
-			rem = delete_blocks(fs, block_num, lvl - 1, zero_offsets);
+			rem = delete_blocks(fs, block_num2, lvl - 1, zero_offsets);
 			if (rem < 0) {
 				removed = rem;
 				goto out;

--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -1463,11 +1463,11 @@ int ext2_inode_get(struct ext2_data *fs, uint32_t ino, struct ext2_inode **ret)
 	memset(inode, 0, sizeof(struct ext2_inode));
 
 	if (ino != 0) {
-		int rc = ext2_fetch_inode(fs, ino, inode);
+		int rc2 = ext2_fetch_inode(fs, ino, inode);
 
-		if (rc < 0) {
+		if (rc2 < 0) {
 			k_mem_slab_free(&inode_struct_slab, (void **)&inode);
-			return rc;
+			return rc2;
 		}
 	}
 

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -870,7 +870,7 @@ static int nvs_startup(struct nvs_fs *fs)
 		 * So, temporarily, we set the lookup cache to the end of the fs.
 		 * The cache will be rebuilt afterwards
 		 **/
-		for (int i = 0; i < CONFIG_NVS_LOOKUP_CACHE_SIZE; i++) {
+		for (i = 0; i < CONFIG_NVS_LOOKUP_CACHE_SIZE; i++) {
 			fs->lookup_cache[i] = fs->ate_wra;
 		}
 #endif

--- a/subsys/ipc/rpmsg_service/rpmsg_backend.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_backend.c
@@ -88,7 +88,7 @@ static struct virtio_vring_info rvrings[2] = {
 		.info.align = VRING_ALIGNMENT,
 	},
 };
-static struct virtqueue *vq[2];
+static struct virtqueue *vqueue[2];
 
 static struct k_work ipm_work;
 
@@ -151,7 +151,7 @@ const struct virtio_dispatch dispatch = {
 
 static void ipm_callback_process(struct k_work *work)
 {
-	virtqueue_notification(vq[VIRTQUEUE_ID]);
+	virtqueue_notification(vqueue[VIRTQUEUE_ID]);
 }
 
 static void ipm_callback(const struct device *dev,
@@ -246,15 +246,15 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev)
 #endif
 
 	/* Virtqueue setup */
-	vq[0] = virtqueue_allocate(VRING_SIZE);
-	if (!vq[0]) {
-		LOG_ERR("virtqueue_allocate failed to alloc vq[0]");
+	vqueue[0] = virtqueue_allocate(VRING_SIZE);
+	if (!vqueue[0]) {
+		LOG_ERR("virtqueue_allocate failed to alloc vqueue[0]");
 		return -ENOMEM;
 	}
 
-	vq[1] = virtqueue_allocate(VRING_SIZE);
-	if (!vq[1]) {
-		LOG_ERR("virtqueue_allocate failed to alloc vq[1]");
+	vqueue[1] = virtqueue_allocate(VRING_SIZE);
+	if (!vqueue[1]) {
+		LOG_ERR("virtqueue_allocate failed to alloc vqueue[1]");
 		return -ENOMEM;
 	}
 
@@ -262,13 +262,13 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev)
 	rvrings[0].info.vaddr = (void *)VRING_TX_ADDRESS;
 	rvrings[0].info.num_descs = VRING_SIZE;
 	rvrings[0].info.align = VRING_ALIGNMENT;
-	rvrings[0].vq = vq[0];
+	rvrings[0].vq = vqueue[0];
 
 	rvrings[1].io = *io;
 	rvrings[1].info.vaddr = (void *)VRING_RX_ADDRESS;
 	rvrings[1].info.num_descs = VRING_SIZE;
 	rvrings[1].info.align = VRING_ALIGNMENT;
-	rvrings[1].vq = vq[1];
+	rvrings[1].vq = vqueue[1];
 
 	vdev->role = RPMSG_ROLE;
 	vdev->vrings_num = VRING_COUNT;

--- a/subsys/logging/backends/log_backend_fs.c
+++ b/subsys/logging/backends/log_backend_fs.c
@@ -24,7 +24,7 @@ enum backend_fs_state {
 	BACKEND_FS_OK
 };
 
-static struct fs_file_t file;
+static struct fs_file_t fs_file;
 static enum backend_fs_state backend_state = BACKEND_FS_NOT_INITIALIZED;
 static int file_ctr, newest, oldest;
 
@@ -149,7 +149,7 @@ close_dir:
 int write_log_to_file(uint8_t *data, size_t length, void *ctx)
 {
 	int rc;
-	struct fs_file_t *f = &file;
+	struct fs_file_t *f = &fs_file;
 
 	if (backend_state == BACKEND_FS_NOT_INITIALIZED) {
 		if (check_log_volumen_available()) {
@@ -157,7 +157,7 @@ int write_log_to_file(uint8_t *data, size_t length, void *ctx)
 		}
 		rc = create_log_dir(CONFIG_LOG_BACKEND_FS_DIR);
 		if (!rc) {
-			rc = allocate_new_file(&file);
+			rc = allocate_new_file(&fs_file);
 		}
 		backend_state = (rc ? BACKEND_FS_CORRUPTED : BACKEND_FS_OK);
 	}

--- a/subsys/logging/log_output_syst.c
+++ b/subsys/logging/log_output_syst.c
@@ -847,9 +847,9 @@ void log_output_msg_syst_process(const struct log_output *output,
 #endif
 		{
 #ifdef CONFIG_CBPRINTF_PACKAGE_HEADER_STORE_CREATION_FLAGS
-			struct cbprintf_package_desc *pkg_hdr = (void *)data;
+			struct cbprintf_package_desc *pkg_desc = (void *)data;
 
-			CHECKIF((pkg_hdr->pkg_flags & CBPRINTF_PACKAGE_ARGS_ARE_TAGGED) ==
+			CHECKIF((pkg_desc->pkg_flags & CBPRINTF_PACKAGE_ARGS_ARE_TAGGED) ==
 				CBPRINTF_PACKAGE_ARGS_ARE_TAGGED) {
 				/*
 				 * Tagged arguments are to be used with catalog messages,

--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -418,11 +418,11 @@ out:
 		 * responsibility to increase datarates when ADR is enabled.
 		 */
 		if (!lorawan_adr_enable) {
-			MibRequestConfirm_t mib_req;
+			MibRequestConfirm_t mib_req2;
 
-			mib_req.Type = MIB_CHANNELS_DATARATE;
-			mib_req.Param.ChannelsDatarate = default_datarate;
-			LoRaMacMibSetRequestConfirm(&mib_req);
+			mib_req2.Type = MIB_CHANNELS_DATARATE;
+			mib_req2.Param.ChannelsDatarate = default_datarate;
+			LoRaMacMibSetRequestConfirm(&mib_req2);
 		}
 
 		/*

--- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_types.h
+++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_types.h
@@ -57,6 +57,13 @@ struct record_t {
 	int64_t _record_t;
 };
 
+/* The union members and enum members have the same names.
+ * This is intentional so we need to ignore -Wshadow to avoid
+ * compiler complaining about them.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+
 struct record_union_ {
 	union {
 		struct {
@@ -104,6 +111,8 @@ struct value_ {
 		_value_bool,
 	} _value_choice;
 };
+
+#pragma GCC diagnostic pop
 
 struct key_value_pair {
 	int32_t _key_value_pair_key;

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -68,9 +68,9 @@ static struct sockaddr_in in4_addr_my = {
 	.sin_port = htons(MY_SRC_PORT),
 };
 
-static struct in6_addr ipv6;
+static struct in6_addr shell_ipv6;
 
-static struct in_addr ipv4;
+static struct in_addr shell_ipv4;
 
 #define DEVICE_NAME "zperf shell"
 
@@ -189,7 +189,7 @@ static int cmd_setip(const struct shell *sh, size_t argc, char *argv[])
 		}
 
 		if (zperf_get_ipv6_addr(argv[start + 1], argv[start + 2],
-					&ipv6) < 0) {
+					&shell_ipv6) < 0) {
 			shell_fprintf(sh, SHELL_WARNING,
 				      "Unable to set IP\n");
 			return 0;
@@ -197,7 +197,7 @@ static int cmd_setip(const struct shell *sh, size_t argc, char *argv[])
 
 		shell_fprintf(sh, SHELL_NORMAL,
 			      "Setting IP address %s\n",
-			      net_sprint_ipv6_addr(&ipv6));
+			      net_sprint_ipv6_addr(&shell_ipv6));
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && !IS_ENABLED(CONFIG_NET_IPV6)) {
@@ -206,7 +206,7 @@ static int cmd_setip(const struct shell *sh, size_t argc, char *argv[])
 			return -ENOEXEC;
 		}
 
-		if (zperf_get_ipv4_addr(argv[start + 1], &ipv4) < 0) {
+		if (zperf_get_ipv4_addr(argv[start + 1], &shell_ipv4) < 0) {
 			shell_fprintf(sh, SHELL_WARNING,
 				      "Unable to set IP\n");
 			return -ENOEXEC;
@@ -214,18 +214,18 @@ static int cmd_setip(const struct shell *sh, size_t argc, char *argv[])
 
 		shell_fprintf(sh, SHELL_NORMAL,
 			      "Setting IP address %s\n",
-			      net_sprint_ipv4_addr(&ipv4));
+			      net_sprint_ipv4_addr(&shell_ipv4));
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) && IS_ENABLED(CONFIG_NET_IPV4)) {
-		if (net_addr_pton(AF_INET6, argv[start + 1], &ipv6) < 0) {
+		if (net_addr_pton(AF_INET6, argv[start + 1], &shell_ipv6) < 0) {
 			if (argc != 2) {
 				shell_help(sh);
 				return -ENOEXEC;
 			}
 
 			if (zperf_get_ipv4_addr(argv[start + 1],
-						&ipv4) < 0) {
+						&shell_ipv4) < 0) {
 				shell_fprintf(sh, SHELL_WARNING,
 					      "Unable to set IP\n");
 				return -ENOEXEC;
@@ -233,7 +233,7 @@ static int cmd_setip(const struct shell *sh, size_t argc, char *argv[])
 
 			shell_fprintf(sh, SHELL_NORMAL,
 				      "Setting IP address %s\n",
-				      net_sprint_ipv4_addr(&ipv4));
+				      net_sprint_ipv4_addr(&shell_ipv4));
 		} else {
 			if (argc != 3) {
 				shell_help(sh);
@@ -241,7 +241,7 @@ static int cmd_setip(const struct shell *sh, size_t argc, char *argv[])
 			}
 
 			if (zperf_get_ipv6_addr(argv[start + 1],
-						argv[start + 2], &ipv6) < 0) {
+						argv[start + 2], &shell_ipv6) < 0) {
 				shell_fprintf(sh, SHELL_WARNING,
 					      "Unable to set IP\n");
 				return -ENOEXEC;
@@ -249,7 +249,7 @@ static int cmd_setip(const struct shell *sh, size_t argc, char *argv[])
 
 			shell_fprintf(sh, SHELL_NORMAL,
 				      "Setting IP address %s\n",
-				      net_sprint_ipv6_addr(&ipv6));
+				      net_sprint_ipv6_addr(&shell_ipv6));
 		}
 	}
 

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -158,13 +158,13 @@ static int settings_fcb_load_priv(struct settings_store *cs,
 	while ((rc = fcb_getnext(&cf->cf_fcb, &entry_ctx.loc)) == 0) {
 		char name[SETTINGS_MAX_NAME_LEN + SETTINGS_EXTRA_LEN + 1];
 		size_t name_len;
-		int rc;
+		int rc2;
 		bool pass_entry = true;
 
-		rc = settings_line_name_read(name, sizeof(name), &name_len,
+		rc2 = settings_line_name_read(name, sizeof(name), &name_len,
 					     (void *)&entry_ctx);
-		if (rc) {
-			LOG_ERR("Failed to load line name: %d", rc);
+		if (rc2) {
+			LOG_ERR("Failed to load line name: %d", rc2);
 			continue;
 		}
 		name[name_len] = '\0';

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -28,12 +28,12 @@ static int settings_direct_loader(const char *key, size_t len,
 	/* Handle the subtree if it is an exact key match. */
 	if (settings_name_next(key, NULL) == 0) {
 		size_t bytes_written = 0;
-		ssize_t len = read_cb(cb_arg, &bytes_written,
+		ssize_t cb_len = read_cb(cb_arg, &bytes_written,
 				      sizeof(bytes_written));
 
-		if (len != sizeof(ctx->bytes_written)) {
+		if (cb_len != sizeof(ctx->bytes_written)) {
 			LOG_ERR("Unable to read bytes_written from storage");
-			return len;
+			return cb_len;
 		}
 
 		/* Check that loaded progress is not outdated. */

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -133,35 +133,35 @@ static int bazfoo_request(struct usbh_contex *const ctx,
 	return uhc_xfer_free(dev, xfer);
 }
 
-static int bazfoo_connected(struct usbh_contex *const uhs_ctx)
+static int bazfoo_connected(struct usbh_contex *const ctx)
 {
 	shell_info(ctx_shell, "host: USB device connected");
 
 	return 0;
 }
 
-static int bazfoo_removed(struct usbh_contex *const uhs_ctx)
+static int bazfoo_removed(struct usbh_contex *const ctx)
 {
 	shell_info(ctx_shell, "host: USB device removed");
 
 	return 0;
 }
 
-static int bazfoo_rwup(struct usbh_contex *const uhs_ctx)
+static int bazfoo_rwup(struct usbh_contex *const ctx)
 {
 	shell_info(ctx_shell, "host: Bus remote wakeup event");
 
 	return 0;
 }
 
-static int bazfoo_suspended(struct usbh_contex *const uhs_ctx)
+static int bazfoo_suspended(struct usbh_contex *const ctx)
 {
 	shell_info(ctx_shell, "host: Bus suspended");
 
 	return 0;
 }
 
-static int bazfoo_resumed(struct usbh_contex *const uhs_ctx)
+static int bazfoo_resumed(struct usbh_contex *const ctx)
 {
 	shell_info(ctx_shell, "host: Bus resumed");
 

--- a/tests/drivers/rtc/rtc_api/src/test_alarm.c
+++ b/tests/drivers/rtc/rtc_api/src/test_alarm.c
@@ -96,7 +96,7 @@ ZTEST(rtc_api, test_alarm)
 	time_set.tm_isdst = -1;
 	time_set.tm_nsec = 0;
 
-	for (uint8_t i = 0; i < 2; i++) {
+	for (uint8_t k = 0; k < 2; k++) {
 		/* Set RTC time */
 		ret = rtc_set_time(rtc, &time_set);
 

--- a/tests/drivers/rtc/rtc_api/src/test_alarm_callback.c
+++ b/tests/drivers/rtc/rtc_api/src/test_alarm_callback.c
@@ -137,10 +137,10 @@ ZTEST(rtc_api, test_alarm_callback)
 		k_sleep(K_SECONDS(RTC_TEST_ALARM_TEST_CALLED_DELAY));
 
 		/* Validate alarm callback called */
-		for (uint16_t i = 0; i < alarms_count; i++) {
+		for (uint16_t j = 0; j < alarms_count; j++) {
 			callback_called_status =
-				(i % 2) ? atomic_test_bit(&callback_called_mask_odd, i)
-					: atomic_test_bit(&callback_called_mask_even, i);
+				(j % 2) ? atomic_test_bit(&callback_called_mask_odd, j)
+					: atomic_test_bit(&callback_called_mask_even, j);
 
 			zassert_equal(callback_called_status, true,
 				      "Alarm callback should have been called");

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -112,7 +112,7 @@ const struct isotp_msg_id tx_addr_fixed = {
 };
 
 const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
-struct isotp_recv_ctx recv_ctx;
+struct isotp_recv_ctx conform_recv_ctx;
 struct isotp_send_ctx send_ctx;
 uint8_t data_buf[128];
 CAN_MSGQ_DEFINE(frame_msgq, 10);
@@ -354,13 +354,13 @@ ZTEST(isotp_conformance, test_receive_sf)
 	memcpy(&single_frame.data[1], random_data, DATA_SIZE_SF);
 	single_frame.length  = DATA_SIZE_SF + 1;
 
-	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
+	ret = isotp_bind(&conform_recv_ctx, can_dev, &rx_addr, &tx_addr,
 			 &fc_opts_single, K_NO_WAIT);
 	zassert_equal(ret, ISOTP_N_OK, "Binding failed [%d]", ret);
 
 	send_frame_series(&single_frame, 1, rx_addr.std_id);
 
-	get_sf(&recv_ctx, DATA_SIZE_SF);
+	get_sf(&conform_recv_ctx, DATA_SIZE_SF);
 
 	single_frame.data[0] = SF_PCI_BYTE_LEN_8;
 	send_frame_series(&single_frame, 1, rx_addr.std_id);
@@ -370,10 +370,10 @@ ZTEST(isotp_conformance, test_receive_sf)
 	single_frame.length = 7;
 	send_frame_series(&single_frame, 1, rx_addr.std_id);
 
-	get_sf_ignore(&recv_ctx);
+	get_sf_ignore(&conform_recv_ctx);
 #endif
 
-	isotp_unbind(&recv_ctx);
+	isotp_unbind(&conform_recv_ctx);
 }
 
 ZTEST(isotp_conformance, test_send_sf_ext)
@@ -410,13 +410,13 @@ ZTEST(isotp_conformance, test_receive_sf_ext)
 	memcpy(&single_frame.data[2], random_data, DATA_SIZE_SF_EXT);
 	single_frame.length  = DATA_SIZE_SF_EXT + 2;
 
-	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr_ext, &tx_addr,
+	ret = isotp_bind(&conform_recv_ctx, can_dev, &rx_addr_ext, &tx_addr,
 			 &fc_opts_single, K_NO_WAIT);
 	zassert_equal(ret, ISOTP_N_OK, "Binding failed [%d]", ret);
 
 	send_frame_series(&single_frame, 1, rx_addr.std_id);
 
-	get_sf(&recv_ctx, DATA_SIZE_SF_EXT);
+	get_sf(&conform_recv_ctx, DATA_SIZE_SF_EXT);
 
 	single_frame.data[1] = SF_PCI_BYTE_1;
 	send_frame_series(&single_frame, 1, rx_addr.std_id);
@@ -426,10 +426,10 @@ ZTEST(isotp_conformance, test_receive_sf_ext)
 	single_frame.length = 7;
 	send_frame_series(&single_frame, 1, rx_addr.std_id);
 
-	get_sf_ignore(&recv_ctx);
+	get_sf_ignore(&conform_recv_ctx);
 #endif
 
-	isotp_unbind(&recv_ctx);
+	isotp_unbind(&conform_recv_ctx);
 }
 
 ZTEST(isotp_conformance, test_send_sf_fixed)
@@ -465,27 +465,27 @@ ZTEST(isotp_conformance, test_receive_sf_fixed)
 	memcpy(&single_frame.data[1], random_data, DATA_SIZE_SF);
 	single_frame.length  = DATA_SIZE_SF + 1;
 
-	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr_fixed, &tx_addr_fixed,
+	ret = isotp_bind(&conform_recv_ctx, can_dev, &rx_addr_fixed, &tx_addr_fixed,
 			 &fc_opts_single, K_NO_WAIT);
 	zassert_equal(ret, ISOTP_N_OK, "Binding failed [%d]", ret);
 
 	/* default source address */
 	send_frame_series(&single_frame, 1, rx_addr_fixed.ext_id);
-	get_sf(&recv_ctx, DATA_SIZE_SF);
+	get_sf(&conform_recv_ctx, DATA_SIZE_SF);
 
 	/* different source address */
 	send_frame_series(&single_frame, 1, rx_addr_fixed.ext_id | 0xFF);
-	get_sf(&recv_ctx, DATA_SIZE_SF);
+	get_sf(&conform_recv_ctx, DATA_SIZE_SF);
 
 	/* different priority */
 	send_frame_series(&single_frame, 1, rx_addr_fixed.ext_id | (7U << 26));
-	get_sf(&recv_ctx, DATA_SIZE_SF);
+	get_sf(&conform_recv_ctx, DATA_SIZE_SF);
 
 	/* different target address (should fail) */
 	send_frame_series(&single_frame, 1, rx_addr_fixed.ext_id | 0xFF00);
-	get_sf_ignore(&recv_ctx);
+	get_sf_ignore(&conform_recv_ctx);
 
-	isotp_unbind(&recv_ctx);
+	isotp_unbind(&conform_recv_ctx);
 }
 
 ZTEST(isotp_conformance, test_send_data)
@@ -606,7 +606,7 @@ ZTEST(isotp_conformance, test_receive_data)
 
 	filter_id = add_rx_msgq(tx_addr.std_id, CAN_STD_ID_MASK);
 
-	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
+	ret = isotp_bind(&conform_recv_ctx, can_dev, &rx_addr, &tx_addr,
 			 &fc_opts_single, K_NO_WAIT);
 	zassert_equal(ret, ISOTP_N_OK, "Binding failed [%d]", ret);
 
@@ -616,10 +616,10 @@ ZTEST(isotp_conformance, test_receive_data)
 
 	send_frame_series(des_frames, ARRAY_SIZE(des_frames), rx_addr.std_id);
 
-	receive_test_data(&recv_ctx, random_data, DATA_SEND_LENGTH, 0);
+	receive_test_data(&conform_recv_ctx, random_data, DATA_SEND_LENGTH, 0);
 
 	can_remove_rx_filter(can_dev, filter_id);
-	isotp_unbind(&recv_ctx);
+	isotp_unbind(&conform_recv_ctx);
 }
 
 ZTEST(isotp_conformance, test_receive_data_blocks)
@@ -651,7 +651,7 @@ ZTEST(isotp_conformance, test_receive_data_blocks)
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 
-	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
+	ret = isotp_bind(&conform_recv_ctx, can_dev, &rx_addr, &tx_addr,
 			 &fc_opts, K_NO_WAIT);
 	zassert_equal(ret, ISOTP_N_OK, "Binding failed [%d]", ret);
 
@@ -676,10 +676,10 @@ ZTEST(isotp_conformance, test_receive_data_blocks)
 	ret = k_msgq_get(&frame_msgq, &dummy_frame, K_MSEC(50));
 	zassert_equal(ret, -EAGAIN, "Expected timeout but got %d", ret);
 
-	receive_test_data(&recv_ctx, random_data, DATA_SEND_LENGTH, 0);
+	receive_test_data(&conform_recv_ctx, random_data, DATA_SEND_LENGTH, 0);
 
 	can_remove_rx_filter(can_dev, filter_id);
-	isotp_unbind(&recv_ctx);
+	isotp_unbind(&conform_recv_ctx);
 }
 
 ZTEST(isotp_conformance, test_send_timeouts)
@@ -751,17 +751,17 @@ ZTEST(isotp_conformance, test_receive_timeouts)
 	memcpy(&ff_frame.data[2], random_data, DATA_SIZE_FF);
 	ff_frame.length = DATA_SIZE_FF + 2;
 
-	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
+	ret = isotp_bind(&conform_recv_ctx, can_dev, &rx_addr, &tx_addr,
 			 &fc_opts, K_NO_WAIT);
 	zassert_equal(ret, ISOTP_N_OK, "Binding failed [%d]", ret);
 
 	send_frame_series(&ff_frame, 1, rx_addr.std_id);
 	start_time = k_uptime_get_32();
 
-	ret = isotp_recv(&recv_ctx, data_buf, sizeof(data_buf), K_FOREVER);
+	ret = isotp_recv(&conform_recv_ctx, data_buf, sizeof(data_buf), K_FOREVER);
 	zassert_equal(ret, DATA_SIZE_FF,
 		      "Expected FF data length but got %d", ret);
-	ret = isotp_recv(&recv_ctx, data_buf, sizeof(data_buf), K_FOREVER);
+	ret = isotp_recv(&conform_recv_ctx, data_buf, sizeof(data_buf), K_FOREVER);
 	zassert_equal(ret, ISOTP_N_TIMEOUT_CR,
 		      "Expected timeout but got %d", ret);
 
@@ -771,7 +771,7 @@ ZTEST(isotp_conformance, test_receive_timeouts)
 	zassert_true(time_diff <= BS_TIMEOUT_UPPER_MS,
 		     "Timeout too slow (%dms)", time_diff);
 
-	isotp_unbind(&recv_ctx);
+	isotp_unbind(&conform_recv_ctx);
 }
 
 ZTEST(isotp_conformance, test_stmin)
@@ -852,7 +852,7 @@ ZTEST(isotp_conformance, test_receiver_fc_errors)
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 
-	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
+	ret = isotp_bind(&conform_recv_ctx, can_dev, &rx_addr, &tx_addr,
 			 &fc_opts, K_NO_WAIT);
 	zassert_equal(ret, ISOTP_N_OK, "Binding failed [%d]", ret);
 
@@ -866,10 +866,10 @@ ZTEST(isotp_conformance, test_receiver_fc_errors)
 	des_frames[1].data[0] = CF_PCI_BYTE_1 | (3 & 0x0F);
 	send_frame_series(des_frames, fc_opts.bs, rx_addr.std_id);
 
-	ret = isotp_recv(&recv_ctx, data_buf, sizeof(data_buf), K_MSEC(200));
+	ret = isotp_recv(&conform_recv_ctx, data_buf, sizeof(data_buf), K_MSEC(200));
 	zassert_equal(ret, DATA_SIZE_FF,
 		      "Expected FF data length but got %d", ret);
-	ret = isotp_recv(&recv_ctx, data_buf, sizeof(data_buf), K_MSEC(200));
+	ret = isotp_recv(&conform_recv_ctx, data_buf, sizeof(data_buf), K_MSEC(200));
 	zassert_equal(ret, ISOTP_N_WRONG_SN,
 		      "Expected wrong SN but got %d", ret);
 
@@ -881,8 +881,8 @@ ZTEST(isotp_conformance, test_receiver_fc_errors)
 	fc_frame.data[1] = FC_PCI_BYTE_2(0);
 	fc_frame.data[2] = FC_PCI_BYTE_3(0);
 
-	isotp_unbind(&recv_ctx);
-	ret = isotp_bind(&recv_ctx, can_dev, &rx_addr, &tx_addr,
+	isotp_unbind(&conform_recv_ctx);
+	ret = isotp_bind(&conform_recv_ctx, can_dev, &rx_addr, &tx_addr,
 			 &fc_opts_single, K_NO_WAIT);
 	zassert_equal(ret, ISOTP_N_OK, "Binding failed [%d]", ret);
 
@@ -891,7 +891,7 @@ ZTEST(isotp_conformance, test_receiver_fc_errors)
 
 	can_remove_rx_filter(can_dev, filter_id);
 	k_msgq_cleanup(&frame_msgq);
-	isotp_unbind(&recv_ctx);
+	isotp_unbind(&conform_recv_ctx);
 }
 
 ZTEST(isotp_conformance, test_sender_fc_errors)

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -362,7 +362,7 @@ static size_t get_long_hexdump(void)
  * there is no room. However, if after discarding all messages there is still no
  * room then current log is discarded.
  */
-static uint8_t data[CONFIG_LOG_BUFFER_SIZE];
+static uint8_t log_buf[CONFIG_LOG_BUFFER_SIZE];
 
 ZTEST(test_log_api, test_log_overflow)
 {
@@ -379,7 +379,7 @@ ZTEST(test_log_api, test_log_overflow)
 	}
 
 	for (int i = 0; i < CONFIG_LOG_BUFFER_SIZE; i++) {
-		data[i] = i;
+		log_buf[i] = i;
 	}
 
 	uint32_t hexdump_len = get_long_hexdump();
@@ -388,19 +388,19 @@ ZTEST(test_log_api, test_log_overflow)
 	exp_timestamp++;
 	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, "test 100 100");
 	mock_log_frontend_generic_record(LOG_CURRENT_MODULE_ID(), Z_LOG_LOCAL_DOMAIN_ID,
-					 LOG_LEVEL_INF, "hexdump", data, hexdump_len);
+					 LOG_LEVEL_INF, "hexdump", log_buf, hexdump_len);
 	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, "test2");
 	mock_log_backend_generic_record(&backend1, LOG_CURRENT_MODULE_ID(),
 					Z_LOG_LOCAL_DOMAIN_ID, LOG_LEVEL_INF,
 					exp_timestamp++, "hexdump",
-					data, hexdump_len);
+					log_buf, hexdump_len);
 	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				Z_LOG_LOCAL_DOMAIN_ID, LOG_LEVEL_INF,
 				exp_timestamp++, "test2");
 	mock_log_backend_drop_record(&backend1, 1);
 
 	LOG_INF("test %d %d", 100, 100);
-	LOG_HEXDUMP_INF(data, hexdump_len, "hexdump");
+	LOG_HEXDUMP_INF(log_buf, hexdump_len, "hexdump");
 	LOG_INF("test2");
 
 	process_and_validate(false, false);
@@ -414,7 +414,7 @@ ZTEST(test_log_api, test_log_overflow)
 
 	mock_log_frontend_record(LOG_CURRENT_MODULE_ID(), LOG_LEVEL_INF, "test");
 	mock_log_frontend_generic_record(LOG_CURRENT_MODULE_ID(), Z_LOG_LOCAL_DOMAIN_ID,
-					 LOG_LEVEL_INF, "test", data, hexdump_len + 1);
+					 LOG_LEVEL_INF, "test", log_buf, hexdump_len + 1);
 	/* Log2 allocation is not destructive if request exceeds the
 	 * capacity.
 	 */
@@ -424,7 +424,7 @@ ZTEST(test_log_api, test_log_overflow)
 	mock_log_backend_drop_record(&backend1, 1);
 
 	LOG_INF("test");
-	LOG_HEXDUMP_INF(data, hexdump_len + 1, "test");
+	LOG_HEXDUMP_INF(log_buf, hexdump_len + 1, "test");
 
 	process_and_validate(false, false);
 

--- a/tests/subsys/mgmt/mcumgr/smp_reassembly/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/smp_reassembly/src/main.c
@@ -25,7 +25,7 @@ static struct net_buf *backup;
  * buffer the pointer to allow a test case to free it with use of the mcumgr net_buf
  * management.
  */
-void smp_rx_req(struct smp_transport *smpt, struct net_buf *nb)
+void smp_rx_req(struct smp_transport *transport, struct net_buf *nb)
 {
 	backup = nb;
 }

--- a/tests/subsys/pm/device_driver_init/src/main.c
+++ b/tests/subsys/pm/device_driver_init/src/main.c
@@ -17,8 +17,8 @@
 	{\
 		const struct gpio_dt_spec gpio = GPIO_DT_SPEC_GET(node_id, enable_gpios);\
 		gpio_flags_t gpio_config; \
-		int rc = gpio_pin_get_config_dt(&gpio, &gpio_config); \
-		zassert_equal(rc, 0, "GPIO config retrieval failed"); \
+		int gpio_ret = gpio_pin_get_config_dt(&gpio, &gpio_config); \
+		zassert_equal(gpio_ret, 0, "GPIO config retrieval failed"); \
 		zassert_equal(gpio_config, config, "Unexpected config");\
 	}
 

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -10,7 +10,7 @@
 
 #include "test_driver.h"
 
-static const struct device *dev;
+static const struct device *test_dev;
 static struct k_thread get_runner_td;
 K_THREAD_STACK_DEFINE(get_runner_stack, 1024);
 
@@ -24,11 +24,11 @@ static void get_runner(void *arg1, void *arg2, void *arg3)
 	ARG_UNUSED(arg3);
 
 	/* make sure we test blocking path (suspend is ongoing) */
-	ongoing = test_driver_pm_ongoing(dev);
+	ongoing = test_driver_pm_ongoing(test_dev);
 	zassert_equal(ongoing, true);
 
 	/* usage: 0, +1, resume: yes */
-	ret = pm_device_runtime_get(dev);
+	ret = pm_device_runtime_get(test_dev);
 	zassert_equal(ret, 0);
 }
 
@@ -38,22 +38,22 @@ void test_api_setup(void *data)
 	enum pm_device_state state;
 
 	/* check API always returns 0 when runtime PM is disabled */
-	ret = pm_device_runtime_get(dev);
+	ret = pm_device_runtime_get(test_dev);
 	zassert_equal(ret, 0);
-	ret = pm_device_runtime_put(dev);
+	ret = pm_device_runtime_put(test_dev);
 	zassert_equal(ret, 0);
-	ret = pm_device_runtime_put_async(dev);
+	ret = pm_device_runtime_put_async(test_dev);
 	zassert_equal(ret, 0);
 
 	/* enable runtime PM */
-	ret = pm_device_runtime_enable(dev);
+	ret = pm_device_runtime_enable(test_dev);
 	zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(dev, &state);
+	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	/* enabling again should succeed (no-op) */
-	ret = pm_device_runtime_enable(dev);
+	ret = pm_device_runtime_enable(test_dev);
 	zassert_equal(ret, 0);
 }
 
@@ -65,15 +65,15 @@ static void test_api_teardown(void *data)
 	/* let test driver finish async PM (in case it was left pending due to
 	 * a failure)
 	 */
-	if (test_driver_pm_ongoing(dev)) {
-		test_driver_pm_done(dev);
+	if (test_driver_pm_ongoing(test_dev)) {
+		test_driver_pm_done(test_dev);
 	}
 
 	/* disable runtime PM, make sure device is left into active state */
-	ret = pm_device_runtime_disable(dev);
+	ret = pm_device_runtime_disable(test_dev);
 	zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(dev, &state);
+	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 }
 
@@ -92,89 +92,89 @@ ZTEST(device_runtime_api, test_api)
 	enum pm_device_state state;
 
 	/* device is initially suspended */
-	(void)pm_device_state_get(dev, &state);
+	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	/*** get + put ***/
 
 	/* usage: 0, +1, resume: yes */
-	ret = pm_device_runtime_get(dev);
+	ret = pm_device_runtime_get(test_dev);
 	zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(dev, &state);
+	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
 	/* usage: 1, +1, resume: no */
-	ret = pm_device_runtime_get(dev);
+	ret = pm_device_runtime_get(test_dev);
 	zassert_equal(ret, 0);
 
 	/* usage: 2, -1, suspend: no */
-	ret = pm_device_runtime_put(dev);
+	ret = pm_device_runtime_put(test_dev);
 	zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(dev, &state);
+	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
 	/* usage: 1, -1, suspend: yes */
-	ret = pm_device_runtime_put(dev);
+	ret = pm_device_runtime_put(test_dev);
 	zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(dev, &state);
+	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	/* usage: 0, -1, suspend: no (unbalanced call) */
-	ret = pm_device_runtime_put(dev);
+	ret = pm_device_runtime_put(test_dev);
 	zassert_equal(ret, -EALREADY);
 
 	/*** get + asynchronous put until suspended ***/
 
 	/* usage: 0, +1, resume: yes */
-	ret = pm_device_runtime_get(dev);
+	ret = pm_device_runtime_get(test_dev);
 	zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(dev, &state);
+	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
-	test_driver_pm_async(dev);
+	test_driver_pm_async(test_dev);
 
 	/* usage: 1, -1, suspend: yes (queued) */
-	ret = pm_device_runtime_put_async(dev);
+	ret = pm_device_runtime_put_async(test_dev);
 	zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(dev, &state);
+	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
 
 	/* usage: 0, -1, suspend: no (unbalanced call) */
-	ret = pm_device_runtime_put(dev);
+	ret = pm_device_runtime_put(test_dev);
 	zassert_equal(ret, -EALREADY);
 
 	/* usage: 0, -1, suspend: no (unbalanced call) */
-	ret = pm_device_runtime_put_async(dev);
+	ret = pm_device_runtime_put_async(test_dev);
 	zassert_equal(ret, -EALREADY);
 
 	/* unblock test driver and let it finish */
-	test_driver_pm_done(dev);
+	test_driver_pm_done(test_dev);
 	k_yield();
 
-	(void)pm_device_state_get(dev, &state);
+	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	/*** get + asynchronous put + get (while suspend still ongoing) ***/
 
 	/* usage: 0, +1, resume: yes */
-	ret = pm_device_runtime_get(dev);
+	ret = pm_device_runtime_get(test_dev);
 	zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(dev, &state);
+	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
-	test_driver_pm_async(dev);
+	test_driver_pm_async(test_dev);
 
 	/* usage: 1, -1, suspend: yes (queued) */
-	ret = pm_device_runtime_put_async(dev);
+	ret = pm_device_runtime_put_async(test_dev);
 	zassert_equal(ret, 0);
 
-	(void)pm_device_state_get(dev, &state);
+	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
 
 	/* let suspension start */
@@ -194,26 +194,26 @@ ZTEST(device_runtime_api, test_api)
 	/* let driver suspend to finish and wait until get_runner finishes
 	 * resuming the driver
 	 */
-	test_driver_pm_done(dev);
+	test_driver_pm_done(test_dev);
 	k_thread_join(&get_runner_td, K_FOREVER);
 
-	(void)pm_device_state_get(dev, &state);
+	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
 	/* Put operation should fail due the state be locked. */
-	ret = pm_device_runtime_disable(dev);
+	ret = pm_device_runtime_disable(test_dev);
 	zassert_equal(ret, 0);
 
-	pm_device_state_lock(dev);
+	pm_device_state_lock(test_dev);
 
 	/* This operation should not succeed.  */
-	ret = pm_device_runtime_enable(dev);
+	ret = pm_device_runtime_enable(test_dev);
 	zassert_equal(ret, -EPERM);
 
 	/* After unlock the state, enable runtime should work. */
-	pm_device_state_unlock(dev);
+	pm_device_state_unlock(test_dev);
 
-	ret = pm_device_runtime_enable(dev);
+	ret = pm_device_runtime_enable(test_dev);
 	zassert_equal(ret, 0);
 }
 
@@ -254,8 +254,8 @@ ZTEST(device_runtime_api, test_pm_device_runtime_auto)
 
 void *device_runtime_api_setup(void)
 {
-	dev = device_get_binding("test_driver");
-	zassert_not_null(dev, NULL);
+	test_dev = device_get_binding("test_driver");
+	zassert_not_null(test_dev, NULL);
 	return NULL;
 }
 

--- a/tests/subsys/pm/power_domain/src/main.c
+++ b/tests/subsys/pm/power_domain/src/main.c
@@ -243,17 +243,17 @@ DEVICE_DT_DEFINE(TEST_DEV_BALANCED, NULL, PM_DEVICE_DT_GET(TEST_DEV_BALANCED),
  */
 ZTEST(power_domain_1cpu, test_power_domain_device_balanced)
 {
-	const struct device *domain = DEVICE_DT_GET(TEST_DOMAIN_BALANCED);
+	const struct device *balanced_domain = DEVICE_DT_GET(TEST_DOMAIN_BALANCED);
 	const struct device *dev = DEVICE_DT_GET(TEST_DEV_BALANCED);
 	enum pm_device_state state;
 	int ret;
 
 	/* Init domain */
-	pm_device_init_suspended(domain);
-	pm_device_runtime_enable(domain);
+	pm_device_init_suspended(balanced_domain);
+	pm_device_runtime_enable(balanced_domain);
 
 	/* At this point domain should be SUSPENDED */
-	pm_device_state_get(domain, &state);
+	pm_device_state_get(balanced_domain, &state);
 	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	/* Get and put the device without PM enabled should not change the domain */
@@ -262,13 +262,13 @@ ZTEST(power_domain_1cpu, test_power_domain_device_balanced)
 	ret = pm_device_runtime_put(dev);
 	zassert_equal(ret, 0);
 
-	pm_device_state_get(domain, &state);
+	pm_device_state_get(balanced_domain, &state);
 	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	/* Same thing with the domain in active state */
-	ret = pm_device_runtime_get(domain);
+	ret = pm_device_runtime_get(balanced_domain);
 	zassert_equal(ret, 0);
-	pm_device_state_get(domain, &state);
+	pm_device_state_get(balanced_domain, &state);
 	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
 	ret = pm_device_runtime_get(dev);
@@ -276,7 +276,7 @@ ZTEST(power_domain_1cpu, test_power_domain_device_balanced)
 	ret = pm_device_runtime_put(dev);
 	zassert_equal(ret, 0);
 
-	pm_device_state_get(domain, &state);
+	pm_device_state_get(balanced_domain, &state);
 	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 }
 

--- a/tests/subsys/portability/cmsis_rtos_v2/src/thread_apis.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/thread_apis.c
@@ -15,7 +15,7 @@ static int thread_yield_check;
 static int thread_yield_check_dynamic;
 
 static K_THREAD_STACK_DEFINE(test_stack1, STACKSZ);
-static osThreadAttr_t thread1_attr = {
+static osThreadAttr_t os_thread1_attr = {
 	.name = "Thread1",
 	.stack_mem = &test_stack1,
 	.stack_size = STACKSZ,
@@ -23,7 +23,7 @@ static osThreadAttr_t thread1_attr = {
 };
 
 static K_THREAD_STACK_DEFINE(test_stack2, STACKSZ);
-static osThreadAttr_t thread2_attr = {
+static osThreadAttr_t os_thread2_attr = {
 	.name = "Thread2",
 	.stack_mem = &test_stack2,
 	.stack_size = STACKSZ,
@@ -144,8 +144,8 @@ ZTEST(cmsis_thread_apis, test_thread_apis_dynamic)
 
 ZTEST(cmsis_thread_apis, test_thread_apis)
 {
-	thread_apis_common(&thread_yield_check, thread1_attr.name,
-			   &thread1_attr, &thread2_attr);
+	thread_apis_common(&thread_yield_check, os_thread1_attr.name,
+			   &os_thread1_attr, &os_thread2_attr);
 }
 
 static osPriority_t OsPriorityInvalid = 60;

--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -37,7 +37,7 @@ static int cb_ret;
 
 static const char progress_key[] = "sf-test/progress";
 
-static uint8_t buf[BUF_LEN];
+static uint8_t generic_buf[BUF_LEN];
 static uint8_t read_buf[TESTBUF_SIZE];
 const static uint8_t write_buf[TESTBUF_SIZE] = {[0 ... TESTBUF_SIZE - 1] = 0xaa};
 static uint8_t written_pattern[TESTBUF_SIZE] = {[0 ... TESTBUF_SIZE - 1] = 0xaa};
@@ -83,7 +83,7 @@ static void init_target(void)
 
 	/* Ensure that target is clean */
 	memset(&ctx, 0, sizeof(ctx));
-	memset(buf, 0, BUF_LEN);
+	memset(generic_buf, 0, BUF_LEN);
 
 	/* Disable callback tests */
 	cb_len = 0;
@@ -93,7 +93,7 @@ static void init_target(void)
 
 	erase_flash();
 
-	rc = stream_flash_init(&ctx, fdev, buf, BUF_LEN, FLASH_BASE, 0,
+	rc = stream_flash_init(&ctx, fdev, generic_buf, BUF_LEN, FLASH_BASE, 0,
 			       stream_flash_callback);
 	zassert_equal(rc, 0, "expected success");
 }
@@ -105,21 +105,21 @@ ZTEST(lib_stream_flash, test_stream_flash_init)
 	init_target();
 
 	/* End address out of range */
-	rc = stream_flash_init(&ctx, fdev, buf, BUF_LEN, FLASH_BASE,
+	rc = stream_flash_init(&ctx, fdev, generic_buf, BUF_LEN, FLASH_BASE,
 		      FLASH_AVAILABLE + 4, NULL);
 	zassert_true(rc < 0, "should fail as size is more than available");
 
-	rc = stream_flash_init(NULL, fdev, buf, BUF_LEN, FLASH_BASE, 0, NULL);
+	rc = stream_flash_init(NULL, fdev, generic_buf, BUF_LEN, FLASH_BASE, 0, NULL);
 	zassert_true(rc < 0, "should fail as ctx is NULL");
 
-	rc = stream_flash_init(&ctx, NULL, buf, BUF_LEN, FLASH_BASE, 0, NULL);
+	rc = stream_flash_init(&ctx, NULL, generic_buf, BUF_LEN, FLASH_BASE, 0, NULL);
 	zassert_true(rc < 0, "should fail as fdev is NULL");
 
 	rc = stream_flash_init(&ctx, fdev, NULL, BUF_LEN, FLASH_BASE, 0, NULL);
 	zassert_true(rc < 0, "should fail as buffer is NULL");
 
 	/* Entering '0' as flash size uses rest of flash. */
-	rc = stream_flash_init(&ctx, fdev, buf, BUF_LEN, FLASH_BASE, 0, NULL);
+	rc = stream_flash_init(&ctx, fdev, generic_buf, BUF_LEN, FLASH_BASE, 0, NULL);
 	zassert_equal(rc, 0, "should succeed");
 	zassert_equal(FLASH_AVAILABLE, ctx.available, "Wrong size");
 }
@@ -191,12 +191,12 @@ ZTEST(lib_stream_flash, test_stream_flash_buffered_write_unaligned)
 	/* 1 byte should be dumped to flash */
 	VERIFY_WRITTEN(0, 1);
 
-	rc = stream_flash_init(&ctx, fdev, buf, BUF_LEN, FLASH_BASE + BUF_LEN,
+	rc = stream_flash_init(&ctx, fdev, generic_buf, BUF_LEN, FLASH_BASE + BUF_LEN,
 			       0, stream_flash_callback);
 	zassert_equal(rc, 0, "expected success");
 
 	/* Trigger verification in callback */
-	cb_buf = buf;
+	cb_buf = generic_buf;
 	cb_len = BUF_LEN - 1;
 	cb_offset = FLASH_BASE + BUF_LEN;
 
@@ -263,11 +263,11 @@ ZTEST(lib_stream_flash, test_stream_flash_buf_size_greater_than_page_size)
 	int rc;
 
 	/* To illustrate that other params does not trigger error */
-	rc = stream_flash_init(&ctx, fdev, buf, 0x10, 0, 0, NULL);
+	rc = stream_flash_init(&ctx, fdev, generic_buf, 0x10, 0, 0, NULL);
 	zassert_equal(rc, 0, "expected success");
 
 	/* Only change buf_len param */
-	rc = stream_flash_init(&ctx, fdev, buf, 0x10000, 0, 0, NULL);
+	rc = stream_flash_init(&ctx, fdev, generic_buf, 0x10000, 0, 0, NULL);
 	zassert_true(rc < 0, "expected failure");
 }
 
@@ -293,7 +293,7 @@ ZTEST(lib_stream_flash, test_stream_flash_buffered_write_callback)
 	init_target();
 
 	/* Trigger verification in callback */
-	cb_buf = buf;
+	cb_buf = generic_buf;
 	cb_len = BUF_LEN;
 	cb_offset = FLASH_BASE;
 
@@ -394,8 +394,8 @@ ZTEST(lib_stream_flash, test_stream_flash_buffered_write_whole_page)
 
 	/* Reset stream_flash context */
 	memset(&ctx, 0, sizeof(ctx));
-	memset(buf, 0, BUF_LEN);
-	rc = stream_flash_init(&ctx, fdev, buf, BUF_LEN, FLASH_BASE, 0,
+	memset(generic_buf, 0, BUF_LEN);
+	rc = stream_flash_init(&ctx, fdev, generic_buf, BUF_LEN, FLASH_BASE, 0,
 			       stream_flash_callback);
 	zassert_equal(rc, 0, "expected success");
 


### PR DESCRIPTION
Here are a few more commits on renaming shadow variables, and also partially enable -Wshadow (see last commit).