### PR TITLE
Add esp32_devkitc_wrover to some tests and samples

### DIFF
--- a/samples/boards/esp32/flash_encryption/sample.yaml
+++ b/samples/boards/esp32/flash_encryption/sample.yaml
@@ -5,5 +5,6 @@ tests:
   sample.board.esp32:
     platform_allow:
       - esp32_devkitc_wroom
+      - esp32_devkitc_wrover
       - yd_esp32
     tags: esp32

--- a/samples/drivers/adc/boards/esp32_devkitc_wrover.overlay
+++ b/samples/drivers/adc/boards/esp32_devkitc_wrover.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Wolter HV <wolterhv@gmx.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels =
+			<&adc0 0>,
+			<&adc1 0>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};
+
+&adc1 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -19,6 +19,7 @@ tests:
       - gd32vf103v_eval
       - gd32f403z_eval
       - esp32_devkitc_wroom
+      - esp32_devkitc_wrover
       - esp32s2_saola
       - esp32c3_devkitm
       - gd32l233r_eval

--- a/samples/drivers/dac/boards/esp32_devkitc_wrover.overlay
+++ b/samples/drivers/dac/boards/esp32_devkitc_wrover.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 Espressif (Shanghai)
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		dac = <&dac>;
+		dac-channel-id = <0>;
+		dac-resolution = <8>;
+	};
+};
+
+&dac {
+	status = "okay";
+};

--- a/samples/drivers/dac/sample.yaml
+++ b/samples/drivers/dac/sample.yaml
@@ -12,6 +12,7 @@ tests:
       - bl5340_dvk_cpuapp
       - disco_l475_iot1
       - esp32_devkitc_wroom
+      - esp32_devkitc_wrover
       - esp32s2_saola
       - frdm_k22f
       - frdm_k64f

--- a/samples/drivers/ipm/ipm_esp32/sample.yaml
+++ b/samples/drivers/ipm/ipm_esp32/sample.yaml
@@ -2,7 +2,7 @@ sample:
   name: ESP32 IPM Sample
 tests:
   sample.ipm.ipm_esp32:
-    platform_allow: esp32_devkitc_wroom
+    platform_allow: esp32_devkitc_wroom esp32_devkitc_wrover
     tags:
       - samples
       - ipm

--- a/tests/drivers/can/api/testcase.yaml
+++ b/tests/drivers/can/api/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     filter: dt_compat_enabled("espressif,esp32-twai")
     platform_allow:
       - esp32_devkitc_wroom
+      - esp32_devkitc_wrover
       - esp32c3_devkitm
       - esp32s2_saola
       - esp32s3_devkitm

--- a/tests/drivers/counter/counter_basic_api/boards/esp32_devkitc_wrover.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/esp32_devkitc_wrover.overlay
@@ -1,0 +1,3 @@
+&timer0 {
+	status = "okay";
+};


### PR DESCRIPTION
Add esp32_devkitc_wrover boards to supported platforms:

tests/drivers/can/api
samples/drivers/ipm/ipm_esp32
samples/drivers/dac 
samples/drivers/adc
samples/boards/esp32/flash_encryption