### PR TITLE
hal: nxp: manifest update to reflect a change in the NXP HAL

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 4364ed701eb20af90ed1756414015c4db4416318
+      revision: 6f11dd49e7fab534a6925d7103e573622effdaef
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
The change is to update the location of the NXP HAL license file (BSD-3) to the root of the NXP HAL repo.

Fixes #61514