### PR TITLE
boards: mg100: fix SD card operation

### DIFF
--- a/boards/arm/mg100/Kconfig.defconfig
+++ b/boards/arm/mg100/Kconfig.defconfig
@@ -18,6 +18,9 @@ config NORDIC_QSPI_NOR
 config NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 	default 4096 if NORDIC_QSPI_NOR
 
+config REGULATOR
+	default DISK_DRIVER_SDMMC
+
 config BT_CTLR
 	default BT
 

--- a/boards/arm/mg100/mg100.dts
+++ b/boards/arm/mg100/mg100.dts
@@ -49,6 +49,13 @@
 		};
 	};
 
+	en-sd-switch {
+		compatible = "regulator-fixed";
+		regulator-name = "en_sd_switch";
+		enable-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
+	};
+
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led1;


### PR DESCRIPTION
Add regulator to the board to enable SD card communication.
In samples/fs_sample, the regulator needs to be enabled to allow SD card communication