### PR TITLE
atsamd2x_xpro/ev11l78a: update RST table format.

### DIFF
--- a/boards/arm/atsamd20_xpro/doc/index.rst
+++ b/boards/arm/atsamd20_xpro/doc/index.rst
@@ -36,27 +36,39 @@ Supported Features
 The atsamd20_xpro board configuration supports the following hardware
 features:
 
-+-----------+------------+------------------------------------------+
-| Interface | Controller | Driver/Component                         |
-+===========+============+==========================================+
-| NVIC      | on-chip    | nested vector interrupt controller       |
-+-----------+------------+------------------------------------------+
-| Flash     | on-chip    | Can be used with LittleFS to store files |
-+-----------+------------+------------------------------------------+
-| SYSTICK   | on-chip    | systick                                  |
-+-----------+------------+------------------------------------------+
-| WDT       | on-chip    | Watchdog                                 |
-+-----------+------------+------------------------------------------+
-| ADC       | on-chip    | Analog to Digital Converter              |
-+-----------+------------+------------------------------------------+
-| GPIO      | on-chip    | I/O ports                                |
-+-----------+------------+------------------------------------------+
-| USART     | on-chip    | Serial ports                             |
-+-----------+------------+------------------------------------------+
-| I2C       | on-chip    | I2C ports                                |
-+-----------+------------+------------------------------------------+
-| SPI       | on-chip    | Serial Peripheral Interface ports        |
-+-----------+------------+------------------------------------------+
+.. list-table::
+    :header-rows: 1
+
+    * - Interface
+      - Controller
+      - Driver / Component
+    * - NVIC
+      - on-chip
+      - nested vector interrupt controller
+    * - Flash
+      - on-chip
+      - Can be used with LittleFS to store files
+    * - SYSTICK
+      - on-chip
+      - systick
+    * - WDT
+      - on-chip
+      - Watchdog
+    * - ADC
+      - on-chip
+      - Analog to Digital Converter
+    * - GPIO
+      - on-chip
+      - I/O ports
+    * - USART
+      - on-chip
+      - Serial ports
+    * - I2C
+      - on-chip
+      - I2C ports
+    * - SPI
+      - on-chip
+      - Serial Peripheral Interface ports
 
 Other hardware features are not currently supported by Zephyr.
 

--- a/boards/arm/atsamd21_xpro/doc/index.rst
+++ b/boards/arm/atsamd21_xpro/doc/index.rst
@@ -36,31 +36,45 @@ Supported Features
 The atsamd21_xpro board configuration supports the following hardware
 features:
 
-+-----------+------------+------------------------------------------+
-| Interface | Controller | Driver/Component                         |
-+===========+============+==========================================+
-| NVIC      | on-chip    | nested vector interrupt controller       |
-+-----------+------------+------------------------------------------+
-| Flash     | on-chip    | Can be used with LittleFS to store files |
-+-----------+------------+------------------------------------------+
-| SYSTICK   | on-chip    | systick                                  |
-+-----------+------------+------------------------------------------+
-| WDT       | on-chip    | Watchdog                                 |
-+-----------+------------+------------------------------------------+
-| ADC       | on-chip    | Analog to Digital Converter              |
-+-----------+------------+------------------------------------------+
-| GPIO      | on-chip    | I/O ports                                |
-+-----------+------------+------------------------------------------+
-| PWM       | on-chip    | Pulse Width Modulation                   |
-+-----------+------------+------------------------------------------+
-| USART     | on-chip    | Serial ports                             |
-+-----------+------------+------------------------------------------+
-| I2C       | on-chip    | I2C ports                                |
-+-----------+------------+------------------------------------------+
-| SPI       | on-chip    | Serial Peripheral Interface ports        |
-+-----------+------------+------------------------------------------+
-| USB       | on-chip    | Universal Serial Bus device ports        |
-+-----------+------------+------------------------------------------+
+.. list-table::
+    :header-rows: 1
+
+    * - Interface
+      - Controller
+      - Driver / Component
+    * - NVIC
+      - on-chip
+      - nested vector interrupt controller
+    * - Flash
+      - on-chip
+      - Can be used with LittleFS to store files
+    * - SYSTICK
+      - on-chip
+      - systick
+    * - WDT
+      - on-chip
+      - Watchdog
+    * - ADC
+      - on-chip
+      - Analog to Digital Converter
+    * - GPIO
+      - on-chip
+      - I/O ports
+    * - PWM
+      - on-chip
+      - Pulse Width Modulation
+    * - USART
+      - on-chip
+      - Serial ports
+    * - I2C
+      - on-chip
+      - I2C ports
+    * - SPI
+      - on-chip
+      - Serial Peripheral Interface ports
+    * - USB
+      - on-chip
+      - Universal Serial Bus device ports
 
 Other hardware features are not currently supported by Zephyr.
 

--- a/boards/arm/ev11l78a/doc/index.rst
+++ b/boards/arm/ev11l78a/doc/index.rst
@@ -33,27 +33,40 @@ Supported Features
 The ev11l78a board configuration supports the following hardware
 features:
 
-+-----------+------------+------------------------------------------+
-| Interface | Controller | Driver/Component                         |
-+===========+============+==========================================+
-| NVIC      | on-chip    | nested vector interrupt controller       |
-+-----------+------------+------------------------------------------+
-| Flash     | on-chip    | Can be used with LittleFS to store files |
-+-----------+------------+------------------------------------------+
-| SYSTICK   | on-chip    | systick                                  |
-+-----------+------------+------------------------------------------+
-| WDT       | on-chip    | Watchdog                                 |
-+-----------+------------+------------------------------------------+
-| GPIO      | on-chip    | I/O ports                                |
-+-----------+------------+------------------------------------------+
-| USART     | on-chip    | Serial ports                             |
-+-----------+------------+------------------------------------------+
-| SPI       | on-chip    | Serial Peripheral Interface ports        |
-+-----------+------------+------------------------------------------+
-| I2C       | on-chip    | I²C ports                                |
-+-----------+------------+------------------------------------------+
-| ADC       | on-chip    | Analog-to-Digital Converter              |
-+-----------+------------+------------------------------------------+
+
+.. list-table::
+    :header-rows: 1
+
+    * - Interface
+      - Controller
+      - Driver / Component
+    * - NVIC
+      - on-chip
+      - nested vector interrupt controller
+    * - Flash
+      - on-chip
+      - Can be used with LittleFS to store files
+    * - SYSTICK
+      - on-chip
+      - systick
+    * - WDT
+      - on-chip
+      - Watchdog
+    * - ADC
+      - on-chip
+      - Analog to Digital Converter
+    * - GPIO
+      - on-chip
+      - I/O ports
+    * - USART
+      - on-chip
+      - Serial ports
+    * - I2C
+      - on-chip
+      - I2C ports
+    * - SPI
+      - on-chip
+      - Serial Peripheral Interface ports
 
 Other hardware features are not currently supported by Zephyr.
 


### PR DESCRIPTION
atsamd2x_xpro/ev11l78a: update RST table format.

This follows the same template as the atsamc21n_xpro and other boards by
using the list-table extension, and the same device descriptions where
applicable.

Signed-off-by: Diego Elio Pettenò <flameeyes@meta.com>
