### PR TITLE
Bluetooth: controller: Fixes for CIS Central error handling

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -416,8 +416,52 @@ uint8_t ll_terminate_ind_send(uint16_t handle, uint8_t reason)
 #if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO) || defined(CONFIG_BT_CTLR_CENTRAL_ISO)
 	if (IS_CIS_HANDLE(handle)) {
 		cis = ll_iso_stream_connected_get(handle);
-		/* Disallow if CIS is not connected */
 		if (!cis) {
+#if defined(CONFIG_BT_CTLR_CENTRAL_ISO)
+			/* CIS is not connected - get the unconnected instance */
+			cis = ll_conn_iso_stream_get(handle);
+
+			/* Sanity-check instance to make sure it's created but not connected */
+			if (cis->group && cis->lll.handle == handle && !cis->established) {
+				if (cis->group->state == CIG_STATE_CONFIGURABLE) {
+					/* Disallow if CIG is still in configurable state */
+					return BT_HCI_ERR_CMD_DISALLOWED;
+
+				} else if (cis->group->state == CIG_STATE_INITIATING) {
+					conn = ll_connected_get(cis->lll.acl_handle);
+
+					/* CIS is not yet established - try to cancel procedure */
+					if (ull_cp_cc_cancel(conn)) {
+						/* Successfully canceled - complete disconnect */
+						struct node_rx_pdu *node_terminate;
+
+						node_terminate = ull_pdu_rx_alloc();
+						LL_ASSERT(node_terminate);
+
+						node_terminate->hdr.handle = handle;
+						node_terminate->hdr.type = NODE_RX_TYPE_TERMINATE;
+						*((uint8_t *)node_terminate->pdu) =
+							BT_HCI_ERR_LOCALHOST_TERM_CONN;
+
+						ll_rx_put_sched(node_terminate->hdr.link,
+							node_terminate);
+
+						/* We're no longer initiating a connection */
+						cis->group->state = CIG_STATE_CONFIGURABLE;
+
+						/* This is now a successful disconnection */
+						return BT_HCI_ERR_SUCCESS;
+					}
+
+					/* Procedure could not be canceled in the current
+					 * state - let it run its course and enqueue a
+					 * terminate procedure.
+					 */
+					return ull_cp_cis_terminate(conn, cis, reason);
+				}
+			}
+#endif /* CONFIG_BT_CTLR_CENTRAL_ISO */
+			/* Disallow if CIS is not connected */
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -10,8 +10,9 @@ typedef void (*ll_iso_stream_released_cb_t)(struct ll_conn *conn);
 
 #define CIG_STATE_NO_CIG       0
 #define CIG_STATE_CONFIGURABLE 1 /* Central only */
-#define CIG_STATE_ACTIVE       2
-#define CIG_STATE_INACTIVE     3
+#define CIG_STATE_INITIATING   2 /* Central only */
+#define CIG_STATE_ACTIVE       3
+#define CIG_STATE_INACTIVE     4
 
 struct ll_conn_iso_stream {
 	struct ll_iso_stream_hdr hdr;
@@ -71,8 +72,9 @@ struct ll_conn_iso_group {
 	uint16_t iso_interval;
 	uint8_t  cig_id;
 
-	uint8_t  state:2;       /* CIG_STATE_NO_CIG, CIG_STATE_CONFIGURABLE (central only),
-				 * CIG_STATE_ACTIVE or CIG_STATE_INACTIVE.
+	uint8_t  state:3;       /* CIG_STATE_NO_CIG, CIG_STATE_CONFIGURABLE (central only),
+				 * CIG_STATE_INITIATING (central only), CIG_STATE_ACTIVE or
+				 * CIG_STATE_INACTIVE.
 				 */
 	uint8_t  sca_update:4;  /* (new SCA)+1 to trigger restart of ticker */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1398,6 +1398,20 @@ bool ull_cp_cc_awaiting_established(struct ll_conn *conn)
 	return false;
 }
 
+#if defined(CONFIG_BT_CTLR_CENTRAL_ISO)
+bool ull_cp_cc_cancel(struct ll_conn *conn)
+{
+	struct proc_ctx *ctx;
+
+	ctx = llcp_lr_peek(conn);
+	if (ctx && ctx->proc == PROC_CIS_CREATE) {
+		return llcp_lp_cc_cancel(conn, ctx);
+	}
+
+	return false;
+}
+#endif /* CONFIG_BT_CTLR_CENTRAL_ISO */
+
 void ull_cp_cc_established(struct ll_conn *conn, uint8_t error_code)
 {
 	struct proc_ctx *ctx;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -200,6 +200,11 @@ bool ull_cp_cc_awaiting_reply(struct ll_conn *conn);
 bool ull_cp_cc_awaiting_established(struct ll_conn *conn);
 
 /**
+ * @brief Cancel ongoing create cis procedure
+ */
+bool ull_cp_cc_cancel(struct ll_conn *conn);
+
+/**
  * @brief Get handle of ongoing create cis procedure.
  * @return 0xFFFF if none
  */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -738,6 +738,7 @@ void llcp_lp_cc_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 bool llcp_lp_cc_is_active(struct proc_ctx *ctx);
 bool llcp_lp_cc_awaiting_established(struct proc_ctx *ctx);
 void llcp_lp_cc_established(struct ll_conn *conn, struct proc_ctx *ctx);
+bool llcp_lp_cc_cancel(struct ll_conn *conn, struct proc_ctx *ctx);
 
 void llcp_rp_cc_init_proc(struct proc_ctx *ctx);
 void llcp_rp_cc_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);

--- a/tests/bluetooth/controller/mock_ctrl/src/ull.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull.c
@@ -263,6 +263,11 @@ int ull_disable(void *lll)
 	return 0;
 }
 
+void *ull_pdu_rx_alloc(void)
+{
+	return NULL;
+}
+
 void ull_rx_put(memq_link_t *link, void *rx)
 {
 }


### PR DESCRIPTION
- Fix masking for no coded phy
- Allow ISO_Interval < SDU_Interval for framed mode
- Change BT_HCI_ERR_INSUFFICIENT_RESOURCES to BT_HCI_ERR_CONN_LIMIT_EXCEEDED.
- Prevent starting same CIS twice
- Cancel an initiated CIS creation procedure if terminated before sending CIS_IND.
- Implement canceling of local CC procedure. Respond to CIS_RSP with REJECT, if canceled after CIS_REQ was sent.
- Introduce state CIG_STATE_INITIATING for central, to keep track of initiating CIS connection, in transition between CONFIGURABLE and ACTIVE.

Fixes EBQ test /HCI/CIS/BC-03-C.