### PR TITLE
drivers: spi: Add Ambiq SPI driver 

### DIFF
--- a/boards/arm/apollo4p_evb/apollo4p_evb-pinctrl.dtsi
+++ b/boards/arm/apollo4p_evb/apollo4p_evb-pinctrl.dtsi
@@ -80,4 +80,85 @@
 			bias-pull-up;
 		};
 	};
+
+	spi0_default: spi0_default {
+		group1 {
+			pinmux = <M0SCK_P5>, <M0MISO_P7>, <M0MOSI_P6>;
+		};
+		group2 {
+			pinmux = <NCE72_P72>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <0>;
+		};
+	};
+	spi1_default: spi1_default {
+		group1 {
+			pinmux = <M1SCK_P8>, <M1MISO_P10>, <M1MOSI_P9>;
+		};
+		group2 {
+			pinmux = <NCE11_P11>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <4>;
+		};
+	};
+	spi2_default: spi2_default {
+		group1 {
+			pinmux = <M2SCK_P25>, <M2MISO_P27>, <M2MOSI_P26>;
+		};
+		group2 {
+			pinmux = <NCE37_P37>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <8>;
+		};
+	};
+	spi3_default: spi3_default {
+		group1 {
+			pinmux = <M3SCK_P31>, <M3MISO_P33>, <M3MOSI_P32>;
+		};
+		group2 {
+			pinmux = <NCE85_P85>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <12>;
+		};
+	};
+	spi4_default: spi4_default {
+		group1 {
+			pinmux = <M4SCK_P34>, <M4MISO_P36>, <M4MOSI_P35>;
+		};
+		group2 {
+			pinmux = <NCE79_P79>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <16>;
+		};
+	};
+	spi5_default: spi5_default {
+		group1 {
+			pinmux = <M5SCK_P47>, <M5MISO_P49>, <M5MOSI_P48>;
+		};
+		group2 {
+			pinmux = <NCE60_P60>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <20>;
+		};
+	};
+	spi6_default: spi6_default {
+		group1 {
+			pinmux = <M6SCK_P61>, <M6MISO_P63>, <M6MOSI_P62>;
+		};
+		group2 {
+			pinmux = <NCE30_P30>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <24>;
+		};
+	};
+	spi7_default: spi7_default {
+		group1 {
+			pinmux = <M7SCK_P22>, <M7MISO_P24>, <M7MOSI_P23>;
+		};
+		group2 {
+			pinmux = <NCE88_P88>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <28>;
+		};
+	};
 };

--- a/boards/arm/apollo4p_evb/apollo4p_evb.dts
+++ b/boards/arm/apollo4p_evb/apollo4p_evb.dts
@@ -34,8 +34,18 @@
 	status = "okay";
 };
 
-&i2c0 {
+&iom0 {
+	compatible = "ambiq,i2c";
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
+};
+
+&iom1 {
+	compatible = "ambiq,spi";
+	pinctrl-0 = <&spi1_default>;
+	pinctrl-names = "default";
+	clock-frequency = <1000000>;
 	status = "okay";
 };

--- a/drivers/pinctrl/pinctrl_ambiq_apollo4.c
+++ b/drivers/pinctrl/pinctrl_ambiq_apollo4.c
@@ -22,6 +22,7 @@ static void pinctrl_configure_pin(const pinctrl_soc_pin_t *pin)
 							  : AM_HAL_GPIO_PIN_OUTCFG_DISABLE;
 	pin_config.GP.cfg_b.eDriveStrength = pin->drive_strength;
 	pin_config.GP.cfg_b.uSlewRate = pin->slew_rate;
+	pin_config.GP.cfg_b.uNCE = pin->iom_nce;
 
 	if (pin->bias_pull_up) {
 		pin_config.GP.cfg_b.ePullup = pin->ambiq_pull_up_ohms + AM_HAL_GPIO_PIN_PULLUP_1_5K;

--- a/drivers/spi/CMakeLists.txt
+++ b/drivers/spi/CMakeLists.txt
@@ -41,6 +41,7 @@ zephyr_library_sources_ifdef(CONFIG_SPI_PW		spi_pw.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_SMARTBOND   spi_smartbond.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_OPENTITAN	spi_opentitan.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_NUMAKER		spi_numaker.c)
+zephyr_library_sources_ifdef(CONFIG_SPI_AMBIQ		spi_ambiq.c)
 
 zephyr_library_sources_ifdef(CONFIG_SPI_RTIO spi_rtio.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_ASYNC spi_signal.c)

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -129,4 +129,6 @@ source "drivers/spi/Kconfig.opentitan"
 
 source "drivers/spi/Kconfig.numaker"
 
+source "drivers/spi/Kconfig.ambiq"
+
 endif # SPI

--- a/drivers/spi/Kconfig.ambiq
+++ b/drivers/spi/Kconfig.ambiq
@@ -1,0 +1,15 @@
+# Ambiq SDK SPI
+#
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config SPI_AMBIQ
+	bool "AMBIQ SPI driver"
+	default y
+	depends on DT_HAS_AMBIQ_SPI_ENABLED
+	select AMBIQ_HAL
+	select AMBIQ_HAL_USE_SPI
+	help
+	  Enable driver for Ambiq SPI.

--- a/drivers/spi/spi_ambiq.c
+++ b/drivers/spi/spi_ambiq.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2023 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ambiq_spi
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(spi_ambiq);
+
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/byteorder.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "spi_context.h"
+#include <am_mcu_apollo.h>
+
+#define PWRCTRL_MAX_WAIT_US 5
+
+typedef int (*ambiq_spi_pwr_func_t)(void);
+
+struct spi_ambiq_config {
+	uint32_t base;
+	int size;
+	uint32_t clock_freq;
+	const struct pinctrl_dev_config *pcfg;
+	ambiq_spi_pwr_func_t pwr_func;
+};
+
+struct spi_ambiq_data {
+	struct spi_context ctx;
+	am_hal_iom_config_t iom_cfg;
+	void *IOMHandle;
+};
+
+#define SPI_BASE      (((const struct spi_ambiq_config *)(dev)->config)->base)
+#define REG_STAT      0x248
+#define IDLE_STAT     0x4
+#define SPI_STAT(dev) (SPI_BASE + REG_STAT)
+#define SPI_WORD_SIZE 8
+
+static int spi_config(const struct device *dev, const struct spi_config *config)
+{
+	struct spi_ambiq_data *data = dev->data;
+	const struct spi_ambiq_config *cfg = dev->config;
+
+	data->iom_cfg.eInterfaceMode = AM_HAL_IOM_SPI_MODE;
+
+	int ret = 0;
+
+	if (config->operation & SPI_HALF_DUPLEX) {
+		LOG_ERR("Half-duplex not supported");
+		return -ENOTSUP;
+	}
+
+	if (SPI_WORD_SIZE_GET(config->operation) != 8) {
+		LOG_ERR("Word size must be %d", SPI_WORD_SIZE);
+		return -ENOTSUP;
+	}
+
+	if ((config->operation & SPI_LINES_MASK) != SPI_LINES_SINGLE) {
+		LOG_ERR("Only supports single mode");
+		return -ENOTSUP;
+	}
+
+	if (config->operation & SPI_LOCK_ON) {
+		LOG_ERR("Lock On not supported");
+		return -ENOTSUP;
+	}
+
+	if (config->operation & SPI_TRANSFER_LSB) {
+		LOG_ERR("LSB first not supported");
+		return -ENOTSUP;
+	}
+
+	if (config->operation & (SPI_MODE_CPOL | SPI_MODE_CPHA)) {
+		if (config->operation & (SPI_MODE_CPOL && SPI_MODE_CPHA)) {
+			data->iom_cfg.eSpiMode = AM_HAL_IOM_SPI_MODE_3;
+		} else if (config->operation & SPI_MODE_CPOL) {
+			data->iom_cfg.eSpiMode = AM_HAL_IOM_SPI_MODE_2;
+		} else if (config->operation & SPI_MODE_CPHA) {
+			data->iom_cfg.eSpiMode = AM_HAL_IOM_SPI_MODE_1;
+		} else {
+			data->iom_cfg.eSpiMode = AM_HAL_IOM_SPI_MODE_0;
+		}
+	}
+
+	if (config->operation & SPI_OP_MODE_SLAVE) {
+		LOG_ERR("Slave mode not supported");
+		return -ENOTSUP;
+	}
+	if (config->operation & SPI_MODE_LOOP) {
+		LOG_ERR("Loopback mode not supported");
+		return -ENOTSUP;
+	}
+
+	if (cfg->clock_freq > AM_HAL_IOM_MAX_FREQ) {
+		LOG_ERR("Clock frequency too high");
+		return -ENOTSUP;
+	}
+
+	data->iom_cfg.ui32ClockFreq = cfg->clock_freq;
+
+	/* Disable IOM instance as it cannot be configured when enabled*/
+	ret = am_hal_iom_disable(data->IOMHandle);
+
+	ret = am_hal_iom_configure(data->IOMHandle, &data->iom_cfg);
+
+	ret = am_hal_iom_enable(data->IOMHandle);
+
+	return ret;
+}
+
+static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *config)
+{
+	struct spi_ambiq_data *data = dev->data;
+	struct spi_context *ctx = &data->ctx;
+	int ret = 0;
+
+	am_hal_iom_transfer_t trans = {0};
+	uint8_t *buf3;
+
+	trans.eDirection = AM_HAL_IOM_FULLDUPLEX;
+
+	uint16_t cmd = *ctx->tx_buf;
+
+	trans.ui32InstrLen = ctx->tx_len;
+	spi_context_update_tx(ctx, 1, 1);
+	cmd = __bswap_16(cmd | *ctx->tx_buf << 8);
+	trans.ui64Instr = cmd;
+
+	if (ctx->rx_buf != NULL) {
+		trans.pui32TxBuffer = (uint32_t *)ctx->tx_buf;
+		spi_context_update_rx(ctx, 1, ctx->rx_len);
+		buf3 = (uint8_t *)malloc(sizeof(uint8_t) * ctx->rx_len);
+		trans.ui32NumBytes = ctx->rx_len;
+		trans.pui32RxBuffer = (uint32_t *)&buf3;
+		ret = am_hal_iom_spi_blocking_fullduplex(data->IOMHandle, &trans);
+
+		memcpy(ctx->rx_buf, &buf3, (ctx->rx_len * sizeof(uint8_t)));
+
+	} else if (ctx->tx_buf != NULL) {
+		spi_context_update_tx(ctx, 1, 1);
+		trans.ui32NumBytes = ctx->tx_len;
+		trans.pui32TxBuffer = (uint32_t *)ctx->tx_buf;
+		trans.pui32RxBuffer = (uint32_t *)ctx->tx_buf;
+		ret = am_hal_iom_spi_blocking_fullduplex(data->IOMHandle, &trans);
+	}
+
+	spi_context_complete(ctx, dev, 0);
+
+	return ret;
+}
+
+static int spi_ambiq_transceive(const struct device *dev, const struct spi_config *config,
+				const struct spi_buf_set *tx_bufs,
+				const struct spi_buf_set *rx_bufs)
+{
+	struct spi_ambiq_data *data = dev->data;
+	int ret;
+
+	ret = spi_config(dev, config);
+
+	if (ret) {
+		return ret;
+	}
+
+	if (!tx_bufs && !rx_bufs) {
+		return 0;
+	}
+
+	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
+
+	ret = spi_ambiq_xfer(dev, config);
+
+	return ret;
+}
+
+static int spi_ambiq_release(const struct device *dev, const struct spi_config *config)
+{
+	struct spi_ambiq_data *data = dev->data;
+
+	if (!sys_read32(SPI_STAT(dev))) {
+		return -EBUSY;
+	}
+
+	spi_context_unlock_unconditionally(&data->ctx);
+
+	return 0;
+}
+
+static struct spi_driver_api spi_ambiq_driver_api = {
+	.transceive = spi_ambiq_transceive,
+	.release = spi_ambiq_release,
+};
+
+static int spi_ambiq_init(const struct device *dev)
+{
+	struct spi_ambiq_data *data = dev->data;
+	const struct spi_ambiq_config *cfg = dev->config;
+	int ret;
+
+	ret = am_hal_iom_initialize((cfg->base - REG_IOM_BASEADDR) / cfg->size, &data->IOMHandle);
+
+	ret = cfg->pwr_func();
+
+	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+
+	return ret;
+}
+
+#define AMBIQ_SPI_INIT(n)                                                                          \
+	PINCTRL_DT_INST_DEFINE(n);                                                                 \
+	static int pwr_on_ambiq_spi_##n(void)                                                      \
+	{                                                                                          \
+		uint32_t addr = DT_REG_ADDR(DT_INST_PHANDLE(n, ambiq_pwrcfg)) +                    \
+				DT_INST_PHA(n, ambiq_pwrcfg, offset);                              \
+		sys_write32((sys_read32(addr) | DT_INST_PHA(n, ambiq_pwrcfg, mask)), addr);        \
+		k_busy_wait(PWRCTRL_MAX_WAIT_US);                                                  \
+		return 0;                                                                          \
+	}                                                                                          \
+	static struct spi_ambiq_data spi_ambiq_data##n = {                                         \
+		SPI_CONTEXT_INIT_LOCK(spi_ambiq_data##n, ctx),                                     \
+		SPI_CONTEXT_INIT_SYNC(spi_ambiq_data##n, ctx)};                                    \
+	static const struct spi_ambiq_config spi_ambiq_config##n = {                               \
+		.base = DT_INST_REG_ADDR(n),                                                       \
+		.size = DT_INST_REG_SIZE(n),                                                       \
+		.clock_freq = DT_INST_PROP(n, clock_frequency),                                    \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
+		.pwr_func = pwr_on_ambiq_spi_##n};                                                 \
+	DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, NULL, &spi_ambiq_data##n, &spi_ambiq_config##n,   \
+			      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY, &spi_ambiq_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(AMBIQ_SPI_INIT)

--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -102,10 +102,8 @@
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x1000>;
 		};
 
-		i2c0: i2c@40050000 {
-			compatible = "ambiq,i2c";
+		iom0: iom@40050000 {
 			reg = <0x40050000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			interrupts = <6 0>;
@@ -113,10 +111,8 @@
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
 		};
 
-		i2c1: i2c@40051000 {
-			compatible = "ambiq,i2c";
+		iom1: iom@40051000 {
 			reg = <0x40051000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			interrupts = <7 0>;
@@ -124,10 +120,8 @@
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
 		};
 
-		i2c2: i2c@40052000 {
-			compatible = "ambiq,i2c";
+		iom2: iom@40052000 {
 			reg = <0x40052000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			interrupts = <8 0>;
@@ -135,21 +129,16 @@
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
 		};
 
-		i2c3: i2c@40053000 {
-			compatible = "ambiq,i2c";
+		iom3: iom@40053000 {
 			reg = <0x40053000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			interrupts = <9 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
 		};
-
-		i2c4: i2c@40054000 {
-			compatible = "ambiq,i2c";
+		iom4: iom@40054000 {
 			reg = <0x40054000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			interrupts = <10 0>;
@@ -157,10 +146,8 @@
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
 		};
 
-		i2c5: i2c@40055000 {
-			compatible = "ambiq,i2c";
+		iom5: iom@40055000 {
 			reg = <0x40055000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			interrupts = <11 0>;
@@ -168,10 +155,8 @@
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
 		};
 
-		i2c6: i2c@40056000 {
-			compatible = "ambiq,i2c";
+		iom6: iom@40056000 {
 			reg = <0x40056000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			interrupts = <12 0>;
@@ -179,10 +164,8 @@
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
 		};
 
-		i2c7: i2c@40057000 {
-			compatible = "ambiq,i2c";
+		iom7: iom@40057000 {
 			reg = <0x40057000 0x1000>;
-			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			interrupts = <13 0>;

--- a/dts/bindings/pinctrl/ambiq,apollo4-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ambiq,apollo4-pinctrl.yaml
@@ -104,3 +104,8 @@ child-binding:
         default: 1500
         description: |
           The pullup resistor value. The default value is 1500 ohms.
+      ambiq,iom-nce-module:
+        type: int
+        default: 0
+        description: |
+          IOM nCE module select. The default value is reset value.

--- a/dts/bindings/spi/ambiq,spi.yaml
+++ b/dts/bindings/spi/ambiq,spi.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: Ambiq SPI
+
+compatible: "ambiq,spi"
+
+include: [spi-controller.yaml, pinctrl-device.yaml, ambiq-pwrcfg.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  clock-frequency:
+    required: true
+
+  ambiq,pwrcfg:
+    required: true

--- a/modules/hal_ambiq/Kconfig
+++ b/modules/hal_ambiq/Kconfig
@@ -35,4 +35,9 @@ config AMBIQ_HAL_USE_I2C
 	help
 	  Use the I2C driver from Ambiq HAL
 
+config AMBIQ_HAL_USE_SPI
+	bool
+	help
+	  Use the SPI driver from Ambiq HAL
+
 endif # AMBIQ_HAL

--- a/soc/arm/ambiq/apollo4x/pinctrl_soc.h
+++ b/soc/arm/ambiq/apollo4x/pinctrl_soc.h
@@ -35,6 +35,8 @@ struct apollo4_pinctrl_soc_pin {
 	uint32_t bias_pull_down : 1;
 	/** pullup resistor value */
 	uint32_t ambiq_pull_up_ohms : 3;
+	/** IOM nCE module select */
+	uint32_t iom_nce : 6;
 };
 
 typedef struct apollo4_pinctrl_soc_pin pinctrl_soc_pin_t;
@@ -59,6 +61,7 @@ typedef struct apollo4_pinctrl_soc_pin pinctrl_soc_pin_t;
 		DT_PROP(node_id, bias_pull_up),					\
 		DT_PROP(node_id, bias_pull_down),				\
 		DT_ENUM_IDX(node_id, ambiq_pull_up_ohms),			\
+		DT_PROP(node_id, ambiq_iom_nce_module),				\
 	},
 
 /**

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: 446736a1c36199d1c8b9b2c4b3d14bf27006d440
+      revision: fbb1618df8b0946cc2abea817309dc85fe051c21
       path: modules/hal/ambiq
       groups:
         - hal


### PR DESCRIPTION
This PR adds the Ambiq IOM SPI driver. It creates an instance of this peripheral in the SoC and enables it in the board dts file.

It should be merged after merging https://github.com/zephyrproject-rtos/hal_ambiq/pull/5.

Also Ambiq IOM I2C and SPI are using the same peripherals. The change will be needed after SPI or I2C (https://github.com/zephyrproject-rtos/zephyr/pull/61330) driver will be merged.