### PR TITLE
npcx: espi: move DT nodes to specific files which support them

### DIFF
--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -163,6 +163,8 @@ static const struct npcx_vw_out_config vw_out_tbl[] = {
 
 /*  Virtual wire GPIOs for platform level usage (High at Reset state) */
 static const struct npcx_vw_out_config vw_out_gpio_tbl1[] = {
+/* Only NPCX9 and later series support this feature */
+#if !defined(CONFIG_SOC_SERIES_NPCX7)
 	/* index 50h (Out) */
 	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SLV_GPIO_0, vw_slv_gpio_0),
 	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SLV_GPIO_1, vw_slv_gpio_1),
@@ -173,6 +175,7 @@ static const struct npcx_vw_out_config vw_out_gpio_tbl1[] = {
 	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SLV_GPIO_5, vw_slv_gpio_5),
 	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SLV_GPIO_6, vw_slv_gpio_6),
 	NPCX_DT_VW_OUT_CONF(ESPI_VWIRE_SIGNAL_SLV_GPIO_7, vw_slv_gpio_7),
+#endif
 };
 
 /* Callbacks for eSPI bus reset and Virtual Wire signals. */

--- a/dts/arm/nuvoton/npcx/npcx-espi-vws-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx-espi-vws-map.dtsi
@@ -7,7 +7,7 @@
 #include <zephyr/dt-bindings/espi/npcx_espi.h>
 
 /*
- *                Nuvoton NPCX7 eSPI Virtual Wires Mapping Table
+ *                Nuvoton NPCX eSPI Virtual Wires Mapping Table
  * |--------------------------------------------------------------------------|
  * | VW idx | SLV reg | Wire Bit 3   | Wire Bit 2   | Wire Bit 1| Wire Bit 0  |
  * |--------------------------------------------------------------------------|
@@ -25,11 +25,6 @@
  * | 05h[S] | VWEVSM1 | SLV_BOOT_STS | ERR_NONFATAL | ERR_FATAL | SLV_BT_DONE |
  * | 06h[S] | VWEVSM2 | HOST_RST_ACK | Reserved     | SMI#      | SCI#        |
  * | 40h[P] | VWEVSM3 | Reserved     | Reserved     | Reserved  | SUS_ACK#    |
- * |--------------------------------------------------------------------------|
- * |       Output (Slave-to-Master) Virtual Wires (High at reset state)       |
- * |--------------------------------------------------------------------------|
- * | 50h[P] | VWGPSM0 | SLV_GPIO_3   | SLV_GPIO_2   | SLV_GPIO_1| SLV_GPIO_0  |
- * | 51h[P] | VWGPSM1 | SLV_GPIO_7   | SLV_GPIO_6   | SLV_GPIO_5| SLV_GPIO_4  |
  * |--------------------------------------------------------------------------|
  *  [S] System-/[P] Platform-Specific Virtual Wires
  */
@@ -141,37 +136,6 @@
 		/* index 40h (Out) */
 		vw-sus-ack {
 			vw-reg = <NPCX_VWEVSM3 0x01>;
-		};
-
-		/*
-		 * Virtual wires for platform level usage (High at Reset state)
-		 */
-		/* index 50h (Out) */
-		vw_slv_gpio_0 {
-			vw-reg = <NPCX_VWGPSM0 0x01>;
-		};
-		vw_slv_gpio_1 {
-			vw-reg = <NPCX_VWGPSM0 0x02>;
-		};
-		vw_slv_gpio_2 {
-			vw-reg = <NPCX_VWGPSM0 0x04>;
-		};
-		vw_slv_gpio_3 {
-			vw-reg = <NPCX_VWGPSM0 0x08>;
-		};
-
-		/* index 51h (Out) */
-		vw_slv_gpio_4 {
-			vw-reg = <NPCX_VWGPSM1 0x01>;
-		};
-		vw_slv_gpio_5 {
-			vw-reg = <NPCX_VWGPSM1 0x02>;
-		};
-		vw_slv_gpio_6 {
-			vw-reg = <NPCX_VWGPSM1 0x04>;
-		};
-		vw_slv_gpio_7 {
-			vw-reg = <NPCX_VWGPSM1 0x08>;
 		};
 	};
 };

--- a/dts/arm/nuvoton/npcx/npcx4/npcx4-espi-vws-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4/npcx4-espi-vws-map.dtsi
@@ -7,4 +7,52 @@
 /* Common eSPI Virtual Wire (VW) mapping configurations in npcx family */
 #include <nuvoton/npcx/npcx-espi-vws-map.dtsi>
 
-/* Specific eSPI Virtual Wire (VW) mapping configurations in npcx4 series */
+/*
+ *   Specific eSPI Virtual Wire (VW) mapping configurations in npcx4 series
+ * |--------------------------------------------------------------------------|
+ * | VW idx | SLV reg | Wire Bit 3   | Wire Bit 2   | Wire Bit 1| Wire Bit 0  |
+ * |--------------------------------------------------------------------------|
+ * |       Output (Slave-to-Master) Virtual Wires (High at reset state)       |
+ * |--------------------------------------------------------------------------|
+ * | 50h[P] | VWGPSM0 | SLV_GPIO_3   | SLV_GPIO_2   | SLV_GPIO_1| SLV_GPIO_0  |
+ * | 51h[P] | VWGPSM1 | SLV_GPIO_7   | SLV_GPIO_6   | SLV_GPIO_5| SLV_GPIO_4  |
+ * |--------------------------------------------------------------------------|
+ *  [S] System-/[P] Platform-Specific Virtual Wires
+ */
+
+/ {
+	npcx-espi-vws-map {
+		compatible = "nuvoton,npcx-espi-vw-conf";
+
+		/*
+		 * Virtual wires for platform level usage (High at Reset state)
+		 */
+		/* index 50h (Out) */
+		vw_slv_gpio_0 {
+			vw-reg = <NPCX_VWGPSM0 0x01>;
+		};
+		vw_slv_gpio_1 {
+			vw-reg = <NPCX_VWGPSM0 0x02>;
+		};
+		vw_slv_gpio_2 {
+			vw-reg = <NPCX_VWGPSM0 0x04>;
+		};
+		vw_slv_gpio_3 {
+			vw-reg = <NPCX_VWGPSM0 0x08>;
+		};
+
+		/* index 51h (Out) */
+		vw_slv_gpio_4 {
+			vw-reg = <NPCX_VWGPSM1 0x01>;
+		};
+		vw_slv_gpio_5 {
+			vw-reg = <NPCX_VWGPSM1 0x02>;
+		};
+		vw_slv_gpio_6 {
+			vw-reg = <NPCX_VWGPSM1 0x04>;
+		};
+		vw_slv_gpio_7 {
+			vw-reg = <NPCX_VWGPSM1 0x08>;
+		};
+	};
+};

--- a/dts/arm/nuvoton/npcx/npcx9/npcx9-espi-vws-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9/npcx9-espi-vws-map.dtsi
@@ -7,4 +7,52 @@
 /* Common eSPI Virtual Wire (VW) mapping configurations in npcx family */
 #include <nuvoton/npcx/npcx-espi-vws-map.dtsi>
 
-/* Specific eSPI Virtual Wire (VW) mapping configurations in npcx9 series */
+/*
+ *   Specific eSPI Virtual Wire (VW) mapping configurations in npcx9 series
+ * |--------------------------------------------------------------------------|
+ * | VW idx | SLV reg | Wire Bit 3   | Wire Bit 2   | Wire Bit 1| Wire Bit 0  |
+ * |--------------------------------------------------------------------------|
+ * |       Output (Slave-to-Master) Virtual Wires (High at reset state)       |
+ * |--------------------------------------------------------------------------|
+ * | 50h[P] | VWGPSM0 | SLV_GPIO_3   | SLV_GPIO_2   | SLV_GPIO_1| SLV_GPIO_0  |
+ * | 51h[P] | VWGPSM1 | SLV_GPIO_7   | SLV_GPIO_6   | SLV_GPIO_5| SLV_GPIO_4  |
+ * |--------------------------------------------------------------------------|
+ *  [S] System-/[P] Platform-Specific Virtual Wires
+ */
+
+/ {
+	npcx-espi-vws-map {
+		compatible = "nuvoton,npcx-espi-vw-conf";
+
+		/*
+		 * Virtual wires for platform level usage (High at Reset state)
+		 */
+		/* index 50h (Out) */
+		vw_slv_gpio_0 {
+			vw-reg = <NPCX_VWGPSM0 0x01>;
+		};
+		vw_slv_gpio_1 {
+			vw-reg = <NPCX_VWGPSM0 0x02>;
+		};
+		vw_slv_gpio_2 {
+			vw-reg = <NPCX_VWGPSM0 0x04>;
+		};
+		vw_slv_gpio_3 {
+			vw-reg = <NPCX_VWGPSM0 0x08>;
+		};
+
+		/* index 51h (Out) */
+		vw_slv_gpio_4 {
+			vw-reg = <NPCX_VWGPSM1 0x01>;
+		};
+		vw_slv_gpio_5 {
+			vw-reg = <NPCX_VWGPSM1 0x02>;
+		};
+		vw_slv_gpio_6 {
+			vw-reg = <NPCX_VWGPSM1 0x04>;
+		};
+		vw_slv_gpio_7 {
+			vw-reg = <NPCX_VWGPSM1 0x08>;
+		};
+	};
+};


### PR DESCRIPTION
Since VWGPSMx (Virtual Wire GPIO Target-to-Controller) registers are introduced in npcx9 and later series only, this PR moves the related DT nodes from npcx-espi-vws-map.dtsi (Used for all npcx series) to the specific dtsi files which chip series support this feature. (ex. npcx9 and npcx4 series)