### PR TITLE
dts: bindings: add detect property to zephyr,sdmmc-disk

### DIFF
--- a/dts/bindings/sdhc/zephyr,sdhc-spi-slot.yaml
+++ b/dts/bindings/sdhc/zephyr,sdhc-spi-slot.yaml
@@ -34,4 +34,11 @@ properties:
       This pin defaults to active high when consumed by the SPI SDHC driver.
       It can be used to toggle card power via an external control circuit
 
+  detect-gpios:
+    type: phandle-array
+    description: |
+      This pin is used to detect the physical presence of a card. It is
+      common that SD-cards slot have a dedicated pin/mechanical switch
+      that either connects or disconnects the card's detect pin to ground.
+
 bus: sd


### PR DESCRIPTION
Add a GPIO-property to the zephyr,sdmmc-disk binding to allow the driver to detect the presence of a card in the slot. Most SD-card slots have a dedicated pin/mechanical switch that either connects or disconnects the card's detect pin to ground, but there's no standardised way to access this yet. I propose to add a GPIO pin property that allows users to define the pin there, along with if it is active high or low. The driver or user can then read this pin out in their code.

Signed-off-by: Ivan Herrera Olivares <ivan.herreraolivares@gmail.com>