### PR TITLE
drivers: flash: flash_stm32h7x: Fix STM32H7 unaligned read access

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -343,7 +343,8 @@ static int write_ndwords(const struct device *dev,
 
 	/* Perform the data write operation at the desired memory address */
 	for (i = 0; i < n; ++i) {
-		flash[i] = data[i];
+		/* Source dword may be unaligned, so take extra care when dereferencing it */
+		flash[i] = UNALIGNED_GET(data + i);
 
 		/* Flush the data write */
 		barrier_dsync_fence_full();


### PR DESCRIPTION
Due to source data pointer having no alignment constraint, extra care needs to be taken when reading source data as dword (in case source data was not dword-aligned, misaligned access exception would occur).

The same approach with `UNALIGNED_GET` macro for reading source buffer is already used in flash drivers for STM32G0, STM32L4 and STM32WB series.

Fixes #59029 

This PR is a continuation on discussion in PR #59098 
The same exception could occur on other STM32 series, but I only have devkits with H7 and L4 MCUs, so cannot verify for others.