### PR TITLE
drivers: wdt_tco: Use DT_DRV_COMPAT interface 

### DIFF
--- a/drivers/watchdog/wdt_tco.c
+++ b/drivers/watchdog/wdt_tco.c
@@ -11,8 +11,6 @@
 
 LOG_MODULE_REGISTER(wdt_tco, CONFIG_WDT_LOG_LEVEL);
 
-#define TCO_WDT_NODE           DT_NODELABEL(tco_wdt)
-
 #define BASE(d)                ((struct tco_config *)(d)->config)->base
 
 #define TCO_RLD(d)             (BASE(d) + 0x00) /* TCO Timer Reload/Curr. Value */
@@ -267,9 +265,9 @@ static struct tco_data wdt_data = {
 };
 
 static const struct tco_config wdt_config = {
-	.base = DT_REG_ADDR(TCO_WDT_NODE),
+	.base = DT_INST_REG_ADDR(0),
 };
 
-DEVICE_DT_DEFINE(TCO_WDT_NODE, wdt_init, NULL, &wdt_data, &wdt_config,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		 &tco_driver_api);
+DEVICE_DT_INST_DEFINE(0, wdt_init, NULL, &wdt_data, &wdt_config,
+		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		      &tco_driver_api);


### PR DESCRIPTION
DT_DRV_COMPAT is unused for this driver. To get a node identifier DT_NODELABEL() macro is used.