### PR TITLE
Adding Central CIS Create unittest and fix a couple of feature related errors in the process

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -921,14 +921,14 @@ static void lp_cc_st_wait_rx_cis_rsp(struct ll_conn *conn, struct proc_ctx *ctx,
 		break;
 	case LP_CC_EVT_UNKNOWN:
 		/* Unsupported in peer, so disable locally for this connection */
-		feature_unmask_features(conn, LL_FEAT_BIT_CIS_PERIPHERAL);
+		feature_unmask_peer_features(conn, LL_FEAT_BIT_CIS_PERIPHERAL);
 		ctx->data.cis_create.error = BT_HCI_ERR_UNSUPP_REMOTE_FEATURE;
 		lp_cc_complete(conn, ctx, evt, param);
 		break;
 	case LP_CC_EVT_REJECT:
 		if (pdu->llctrl.reject_ext_ind.error_code == BT_HCI_ERR_UNSUPP_REMOTE_FEATURE) {
 			/* Unsupported in peer, so disable locally for this connection */
-			feature_unmask_features(conn, LL_FEAT_BIT_CIS_PERIPHERAL);
+			feature_unmask_peer_features(conn, LL_FEAT_BIT_CIS_PERIPHERAL);
 		}
 		ctx->data.cis_create.error = pdu->llctrl.reject_ext_ind.error_code;
 		lp_cc_complete(conn, ctx, evt, param);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_features.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_features.h
@@ -9,6 +9,11 @@ static inline void feature_unmask_features(struct ll_conn *conn, uint64_t ll_fea
 	conn->llcp.fex.features_used &= ~ll_feat_mask;
 }
 
+static inline void feature_unmask_peer_features(struct ll_conn *conn, uint64_t ll_feat_mask)
+{
+	conn->llcp.fex.features_peer &= ~ll_feat_mask;
+}
+
 static inline bool feature_le_encryption(struct ll_conn *conn)
 {
 #if defined(CONFIG_BT_CTLR_LE_ENC)

--- a/tests/bluetooth/controller/common/src/helper_pdu.c
+++ b/tests/bluetooth/controller/common/src/helper_pdu.c
@@ -1213,8 +1213,8 @@ void helper_pdu_verify_cis_ind(const char *file, uint32_t line, struct pdu_data 
 	zassert_mem_equal(pdu->llctrl.cis_ind.cis_sync_delay, p->cis_sync_delay,
 			  sizeof(p->cis_sync_delay),
 			  "cis_sync_delay mismatch.\nCalled at %s:%d\n", file, line);
-
-	pdu->llctrl.cis_ind.conn_event_count = p->conn_event_count;
+	zassert_equal(pdu->llctrl.cis_ind.conn_event_count, p->conn_event_count,
+		      "conn_event_count mismatch.\nCalled at %s:%d\n", file, line);
 }
 
 void helper_pdu_verify_cis_terminate_ind(const char *file, uint32_t line, struct pdu_data *pdu,

--- a/tests/bluetooth/controller/ctrl_cis_create/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cis_create/src/main.c
@@ -39,6 +39,7 @@ DEFINE_FFF_GLOBALS;
 #include "ull_iso_types.h"
 #include "ull_conn_types.h"
 #include "ull_conn_iso_types.h"
+#include "ull_conn_iso_internal.h"
 #include "ull_llcp.h"
 #include "ull_conn_internal.h"
 #include "ull_llcp_internal.h"
@@ -47,6 +48,9 @@ DEFINE_FFF_GLOBALS;
 #include "helper_util.h"
 
 static struct ll_conn conn;
+
+static struct ll_conn_iso_group cig_mock = { 0 };
+static struct ll_conn_iso_stream cis_mock = { .established = 1, .group = &cig_mock };
 
 /* struct ll_conn_iso_stream *ll_conn_iso_stream_get(uint16_t handle); */
 FAKE_VALUE_FUNC(struct ll_conn_iso_stream *, ll_conn_iso_stream_get, uint16_t);
@@ -63,15 +67,16 @@ static bool is_instant_reached(struct ll_conn *conn, uint16_t instant)
 	return ((event_counter(conn) - instant) & 0xFFFF) <= 0x7FFF;
 }
 
+#define MAX_xDU 160
 static struct pdu_data_llctrl_cis_req remote_cis_req = {
 	.cig_id           =   0x01,
 	.cis_id           =   0x02,
 	.c_phy            =   0x01,
 	.p_phy            =   0x01,
-	.c_max_sdu_packed =   { 0, 160},
-	.p_max_sdu        =   { 0, 160},
-	.c_max_pdu        =   160,
-	.p_max_pdu        =   160,
+	.c_max_sdu_packed =   { MAX_xDU, 0 },
+	.p_max_sdu        =   { MAX_xDU, 0 },
+	.c_max_pdu        =   MAX_xDU,
+	.p_max_pdu        =   MAX_xDU,
 	.nse              =   2,
 	.p_bn             =   1,
 	.c_bn             =   1,
@@ -92,6 +97,37 @@ static struct pdu_data_llctrl_cis_ind remote_cis_ind = {
 	.cis_offset = { 0, 0, 0},
 	.cis_sync_delay = { 0, 0, 0},
 	.conn_event_count = 12
+};
+
+static struct pdu_data_llctrl_cis_req local_cis_req = {
+	.cig_id           =   0x00,
+	.cis_id           =   0x02,
+	.c_phy            =   0x01,
+	.p_phy            =   0x01,
+	.c_max_sdu_packed =   { MAX_xDU, 0 },
+	.p_max_sdu        =   { MAX_xDU, 0 },
+	.c_max_pdu        =   MAX_xDU,
+	.p_max_pdu        =   MAX_xDU,
+	.nse              =   2,
+	.p_bn             =   1,
+	.c_bn             =   1,
+	.c_ft             =   1,
+	.p_ft             =   1,
+	.iso_interval     =   6,
+	.conn_event_count =   0,
+	.c_sdu_interval   =   { 0, 0, 0},
+	.p_sdu_interval   =   { 0, 0, 0},
+	.sub_interval     =   { 0, 0, 0},
+	.cis_offset_min   =   { 0, 0, 0},
+	.cis_offset_max   =   { 0, 0, 0}
+};
+
+static struct pdu_data_llctrl_cis_ind local_cis_ind = {
+	.aa = { 0, 0, 0, 0},
+	.cig_sync_delay = { 0, 0, 0},
+	.cis_offset = { 0, 0, 0},
+	.cis_sync_delay = { 0, 0, 0},
+	.conn_event_count = 13
 };
 
 #define ERROR_CODE 0x17
@@ -141,10 +177,9 @@ ZTEST(cis_create, test_cc_create_periph_rem_host_accept)
 		.cis_handle = 0x00,
 		.status = 0x00
 	};
-	struct ll_conn_iso_stream cis = { 0 };
 
 	/* Prepare mocked call to ll_conn_iso_stream_get() */
-	ll_conn_iso_stream_get_fake.return_val = &cis;
+	ll_conn_iso_stream_get_fake.return_val = &cis_mock;
 
 	/* Role */
 	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
@@ -237,7 +272,7 @@ ZTEST(cis_create, test_cc_create_periph_rem_host_accept)
 	event_done(&conn);
 
 	/* NODE_CIS_ESTABLISHED carry extra information in header rx footer param field */
-	zassert_equal_ptr(ntf->hdr.rx_ftr.param, &cis);
+	zassert_equal_ptr(ntf->hdr.rx_ftr.param, &cis_mock);
 
 	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
 		      "Free CTX buffers %d", llcp_ctx_buffers_free());
@@ -438,10 +473,10 @@ ZTEST(cis_create, test_cc_create_periph_rem_invalid_phy)
 		.cis_id           =   0x02,
 		.c_phy            =   0x03,
 		.p_phy            =   0x01,
-		.c_max_sdu_packed =   { 0, 160},
-		.p_max_sdu        =   { 0, 160},
-		.c_max_pdu        =   160,
-		.p_max_pdu        =   160,
+		.c_max_sdu_packed =   { MAX_xDU, 0 },
+		.p_max_sdu        =   { MAX_xDU, 0 },
+		.c_max_pdu        =   MAX_xDU,
+		.p_max_pdu        =   MAX_xDU,
 		.nse              =   2,
 		.p_bn             =   1,
 		.c_bn             =   1,
@@ -489,5 +524,340 @@ ZTEST(cis_create, test_cc_create_periph_rem_invalid_phy)
 	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
 		      "Free CTX buffers %d", llcp_ctx_buffers_free());
 }
+
+/*
+ * Central-initiated CIS Create procedure.
+ * Host requests CIS, LL replies with 'remote feature unsupported'
+ *
+ * +-----+                    +-------+                    +-----+
+ * | UT  |                    | LL_C  |                    | LT  |
+ * +-----+                    +-------+                    +-----+
+ *    |                           |                           |
+ *    | LE CIS Create             |                           |
+ *    |-------------------------->|                           |
+ *    |                           |                           |
+ *    |                           | (FEAT unsupported)        |
+ *    |                           |                           |
+ *    |                           |                           |
+ *    |    LE CIS ESTABLISHED     |                           |
+ *    |    (rem feat unsupported) |                           |
+ *    |<--------------------------|                           |
+ */
+ZTEST(cis_create, test_cc_create_central_rem_unsupported)
+{
+	struct ll_conn_iso_stream *cis;
+	struct node_rx_pdu *ntf;
+	uint8_t err;
+
+	struct node_rx_conn_iso_estab cis_estab = {
+		.cis_handle = 0x00,
+		.status = BT_HCI_ERR_UNSUPP_REMOTE_FEATURE
+	};
+
+	/* Prepare mocked call to ll_conn_iso_stream_get() */
+	ll_conn_iso_stream_get_fake.return_val = &cis_mock;
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	conn.llcp.fex.valid = 1;
+
+	cis = ll_conn_iso_stream_get(LL_CIS_HANDLE_BASE);
+	cis->lll.acl_handle = conn.lll.handle;
+
+	err = ull_cp_cis_create(&conn, cis);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* There should be excactly one host notification
+	 * with status BT_HCI_ERR_UNSUPP_REMOTE_FEATURE
+	 */
+	ut_rx_node(NODE_CIS_ESTABLISHED, &ntf, &cis_estab);
+	ut_rx_q_is_empty();
+
+	/* Done */
+	event_done(&conn);
+
+	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", llcp_ctx_buffers_free());
+}
+
+/*
+ * Central-initiated CIS Create procedure.
+ * Central requests CIS, peripheral accepts
+ *
+ * +-----+                    +-------+                    +-----+
+ * | UT  |                    | LL_C  |                    | LT  |
+ * +-----+                    +-------+                    +-----+
+ *    |                           |                           |
+ *    | LE CIS Create             |                           |
+ *    |-------------------------->|                           |
+ *    |                           |   LL_CIS_REQ              |
+ *    |                           |-------------------------->|
+ *    |                           |                           |
+ *    |                           | LL_CIS_RSP                |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    |                           |                           |
+ *    |                           |   LL_CIS_IND              |
+ *    |                           |-------------------------->|
+ *    |                           |                           |
+ *    |                           |                           |
+ *    |                           |                           |
+ *    |                           |                           |
+ *    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *    |                           |                           |
+ *    |      LE CIS ESTABLISHED   |                           |
+ *    |<--------------------------|                           |
+ */
+ZTEST(cis_create, test_cc_create_central_rem_accept)
+{
+	struct pdu_data_llctrl_cis_rsp remote_cis_rsp = {
+		.cis_offset_max = { 0, 0, 0},
+		.cis_offset_min = { 0, 0, 0},
+		.conn_event_count = 13
+	};
+	struct node_rx_conn_iso_estab cis_estab = {
+		.cis_handle = 0x00,
+		.status = BT_HCI_ERR_SUCCESS
+	};
+	struct ll_conn_iso_stream *cis;
+	struct node_rx_pdu *ntf;
+	struct node_tx *tx;
+	uint8_t err;
+
+	/* Prepare mocked call to ll_conn_iso_stream_get() */
+	ll_conn_iso_stream_get_fake.return_val = &cis_mock;
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	conn.llcp.fex.valid = 1;
+	conn.llcp.fex.features_peer |= BIT64(BT_LE_FEAT_BIT_CIS_PERIPHERAL);
+
+	/* Setup default CIS/CIG parameters */
+	cis = ll_conn_iso_stream_get(LL_CIS_HANDLE_BASE);
+	cis->lll.acl_handle = conn.lll.handle;
+	cis->group->cig_id = local_cis_req.cig_id;
+	cis->cis_id = local_cis_req.cis_id;
+	cis->lll.tx.phy = local_cis_req.c_phy;
+	cis->lll.rx.phy = local_cis_req.p_phy;
+	cis->group->c_sdu_interval = 0;
+	cis->group->p_sdu_interval = 0;
+	cis->lll.tx.max_pdu = MAX_xDU;
+	cis->lll.rx.max_pdu = MAX_xDU;
+	cis->c_max_sdu = MAX_xDU;
+	cis->p_max_sdu = MAX_xDU;
+	cis->group->iso_interval = local_cis_req.iso_interval;
+	cis->framed = 0;
+	cis->lll.nse = local_cis_req.nse;
+	cis->lll.sub_interval = 0;
+	cis->lll.tx.bn = local_cis_req.c_bn;
+	cis->lll.rx.bn = local_cis_req.p_bn;
+	cis->lll.tx.ft = local_cis_req.c_ft;
+	cis->lll.rx.ft = local_cis_req.p_ft;
+
+	err = ull_cp_cis_create(&conn, cis);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_CIS_REQ, &conn, &tx, &local_cis_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx */
+	lt_tx(LL_CIS_RSP, &conn, &remote_cis_rsp);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_CIS_IND, &conn, &tx, &local_cis_ind);
+	lt_rx_q_is_empty(&conn);
+
+	/* Done */
+	event_done(&conn);
+
+	/* */
+	while (!is_instant_reached(&conn, remote_cis_rsp.conn_event_count)) {
+		/* Prepare */
+		event_prepare(&conn);
+
+		/* Tx Queue should NOT have a LL Control PDU */
+		lt_rx_q_is_empty(&conn);
+
+		/* Done */
+		event_done(&conn);
+
+		/* There should NOT be a host notification */
+		ut_rx_q_is_empty();
+	}
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Emulate CIS becoming established */
+	ull_cp_cc_established(&conn, 0);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should NOT have a LL Control PDU */
+	lt_rx_q_is_empty(&conn);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* There should be excactly one host notification */
+	ut_rx_node(NODE_CIS_ESTABLISHED, &ntf, &cis_estab);
+	ut_rx_q_is_empty();
+
+	/* Done */
+	event_done(&conn);
+
+	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", llcp_ctx_buffers_free());
+}
+
+/*
+ * Central-initiated CIS Create procedure.
+ * Central requests CIS, peripheral rejects with 'unsupported remote feature'
+ *
+ * +-----+                    +-------+                    +-----+
+ * | UT  |                    | LL_C  |                    | LT  |
+ * +-----+                    +-------+                    +-----+
+ *    |                           |                           |
+ *    | LE CIS Create             |                           |
+ *    |-------------------------->|                           |
+ *    |                           |   LL_CIS_REQ              |
+ *    |                           |-------------------------->|
+ *    |                           |                           |
+ *    |                           | LL_REJECT_EXT_IND         |
+ *    |                           | (unsupported remote feat) |
+ *    |                           |<--------------------------|
+ *    |                           |                           |
+ *    |                           |                           |
+ *    |                           |                           |
+ *    |                           |                           |
+ *    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *    |                           |                           |
+ *    |      LE CIS ESTABLISHED   |                           |
+ *    |<--------------------------|                           |
+ */
+ZTEST(cis_create, test_cc_create_central_rem_reject)
+{
+	struct node_rx_conn_iso_estab cis_estab = {
+		.cis_handle = 0x00,
+		.status = BT_HCI_ERR_UNSUPP_REMOTE_FEATURE
+	};
+	struct pdu_data_llctrl_reject_ext_ind remote_reject = {
+		.error_code = BT_HCI_ERR_UNSUPP_REMOTE_FEATURE,
+		.reject_opcode = PDU_DATA_LLCTRL_TYPE_CIS_REQ
+	};
+	struct ll_conn_iso_stream *cis;
+	struct node_rx_pdu *ntf;
+	struct node_tx *tx;
+	uint8_t err;
+
+	/* Prepare mocked call to ll_conn_iso_stream_get() */
+	ll_conn_iso_stream_get_fake.return_val = &cis_mock;
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	conn.llcp.fex.valid = 1;
+	conn.llcp.fex.features_peer |= BIT64(BT_LE_FEAT_BIT_CIS_PERIPHERAL);
+
+	/* Setup default CIS/CIG parameters */
+	cis = ll_conn_iso_stream_get(LL_CIS_HANDLE_BASE);
+	cis->lll.acl_handle = conn.lll.handle;
+	cis->group->cig_id = local_cis_req.cig_id;
+	cis->cis_id = local_cis_req.cis_id;
+	cis->lll.tx.phy = local_cis_req.c_phy;
+	cis->lll.rx.phy = local_cis_req.p_phy;
+	cis->group->c_sdu_interval = 0;
+	cis->group->p_sdu_interval = 0;
+	cis->lll.tx.max_pdu = MAX_xDU;
+	cis->lll.rx.max_pdu = MAX_xDU;
+	cis->c_max_sdu = MAX_xDU;
+	cis->p_max_sdu = MAX_xDU;
+	cis->group->iso_interval = local_cis_req.iso_interval;
+	cis->framed = 0;
+	cis->lll.nse = local_cis_req.nse;
+	cis->lll.sub_interval = 0;
+	cis->lll.tx.bn = local_cis_req.c_bn;
+	cis->lll.rx.bn = local_cis_req.p_bn;
+	cis->lll.tx.ft = local_cis_req.c_ft;
+	cis->lll.rx.ft = local_cis_req.p_ft;
+
+	err = ull_cp_cis_create(&conn, cis);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_CIS_REQ, &conn, &tx, &local_cis_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx */
+	lt_tx(LL_REJECT_EXT_IND, &conn, &remote_reject);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* There should be excactly one host notification */
+	ut_rx_node(NODE_CIS_ESTABLISHED, &ntf, &cis_estab);
+	ut_rx_q_is_empty();
+
+	zassert_equal(conn.llcp.fex.features_peer & BIT64(BT_LE_FEAT_BIT_CIS_PERIPHERAL), 0);
+
+	/* Done */
+	event_done(&conn);
+
+	zassert_equal(llcp_ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", llcp_ctx_buffers_free());
+}
+
 
 ZTEST_SUITE(cis_create, NULL, NULL, cis_create_setup, NULL, NULL);

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_central.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_central.c
@@ -42,7 +42,7 @@ int ull_central_reset(void)
 }
 
 uint16_t ull_central_iso_cis_offset_get(uint16_t cis_handle, uint32_t *cis_offset_min,
-					uint32_t *cis_offset_max)
+					uint32_t *cis_offset_max, uint16_t *conn_event_count)
 {
 	return 0;
 }

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_conn_iso.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_conn_iso.c
@@ -42,7 +42,7 @@
 #include "hal/debug.h"
 
 static struct ll_conn_iso_group cig = { 0 };
-static struct ll_conn_iso_stream cis = { 0 };
+static struct ll_conn_iso_stream cis = { .established = 1, .group = &cig };
 
 __weak struct ll_conn_iso_stream *ll_conn_iso_stream_get_by_acl(struct ll_conn *conn,
 								uint16_t *cis_iter)


### PR DESCRIPTION
Adding basic unittest for Central CIS Create.

Fix issue re. hitting ASSERT in case of non supported feature in peripheral. 

Adding API to allow unmasking peer feature, for asymmetrical features.

Fix issue re. unmasking of peer feature support in case of non support for CIS peripheral 