### PR TITLE
dt-bindings: use dt-bindings/dt-util.h instead of sys/util_macro.h

### DIFF
--- a/include/zephyr/dt-bindings/dt-util.h
+++ b/include/zephyr/dt-bindings/dt-util.h
@@ -9,8 +9,8 @@
 
 /*
  * This file exists to keep in-tree DTS clean.  This means, only
- * #include <dt-bindings/foo.h> form should be included.  The
- * <dt-bindings/dt-util.h> wraps <sys/util_macro.h> file exposing
+ * #include <zephyr/dt-bindings/foo.h> form should be included.  The
+ * <zephyr/dt-bindings/dt-util.h> wraps <zephyr/sys/util_macro.h> file exposing
  * all macro base definitions to DTS preprocessor.  It provides
  * necessary background to elaborate complex constructions like
  * variable length macros with zero or more elements.

--- a/include/zephyr/dt-bindings/interrupt-controller/arm-gic.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/arm-gic.h
@@ -6,7 +6,7 @@
 #ifndef __DT_BINDING_ARM_GIC_H
 #define __DT_BINDING_ARM_GIC_H
 
-#include <zephyr/sys/util_macro.h>
+#include <zephyr/dt-bindings/dt-util.h>
 
 /* CPU Interrupt numbers */
 #define	GIC_INT_VIRT_MAINT		25

--- a/include/zephyr/dt-bindings/ipc_service/static_vrings.h
+++ b/include/zephyr/dt-bindings/ipc_service/static_vrings.h
@@ -6,7 +6,7 @@
 #ifndef __DT_BINDING_IPC_SERVICE_STATIC_VRINGS_H
 #define __DT_BINDING_IPC_SERVICE_STATIC_VRINGS_H
 
-#include <zephyr/sys/util_macro.h>
+#include <zephyr/dt-bindings/dt-util.h>
 
 #define	PRIO_COOP	BIT(0)
 #define	PRIO_PREEMPT	BIT(1)

--- a/include/zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP_PINCTRL_COMMON_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ESP_PINCTRL_COMMON_H_
 
-#include <zephyr/sys/util_macro.h>
+#include <zephyr/dt-bindings/dt-util.h>
 
 #define ESP32_PIN_NUM_SHIFT      0U
 #define ESP32_PIN_NUM_MASK       0x3FU

--- a/include/zephyr/dt-bindings/pinctrl/nxp-s32-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nxp-s32-pinctrl.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_NXP_S32_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_NXP_S32_PINCTRL_H_
 
-#include <zephyr/sys/util_macro.h>
+#include <zephyr/dt-bindings/dt-util.h>
 
 /*
  * The NXP S32 pinmux configuration is encoded in a 32-bit field value as follows:

--- a/include/zephyr/dt-bindings/pinctrl/quicklogic-eos-s3-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/quicklogic-eos-s3-pinctrl.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_QUICKLOGIC_EOS_S3_PINCTRL_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_QUICKLOGIC_EOS_S3_PINCTRL_H_
 
-#include <zephyr/sys/util_macro.h>
+#include <zephyr/dt-bindings/dt-util.h>
 
 #define IO_MUX_REG_MAX_OFFSET	107
 #define IO_MUX_MAX_PAD_NR	45


### PR DESCRIPTION
Replaces some usages of `<zephyr/sys/util_macro.h>` with `<zephyr/dt-bindings/dt-util.h>` such that this is done in a uniform way for all files in the `include/zephyr/dt-bindings` path.

The latter being a wrapper around the former, which was introduced in PR #28779 with the intention to be able to retain the pattern of only including `<zephyr/dt-bindings/foo.h>` files in in-tree dts files.