### PR TITLE
ethernet: phy_mii: get the MDIO bus with DT_INST_BUS

### DIFF
--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -136,6 +136,5 @@ zephyr_udc0: &usb0 {
 		compatible = "ethernet-phy";
 		status = "okay";
 		address = <0>;
-		mdio = <&mdio>;
 	};
 };

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
@@ -99,7 +99,6 @@
 	phy0: ethernet-phy {
 		compatible = "ethernet-phy";
 		address = <0x7>;
-		mdio = <&emdio>;
 		status = "okay";
 	};
 };

--- a/boards/arm/sam4e_xpro/sam4e_xpro.dts
+++ b/boards/arm/sam4e_xpro/sam4e_xpro.dts
@@ -201,7 +201,6 @@
 		compatible = "ethernet-phy";
 		status = "okay";
 		address = <0>;
-		mdio = <&mdio>;
 	};
 };
 

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -140,7 +140,6 @@ zephyr_udc0: &usbhs {
 		compatible = "ethernet-phy";
 		status = "okay";
 		address = <0>;
-		mdio = <&mdio>;
 	};
 };
 

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -249,7 +249,6 @@ zephyr_udc0: &usbhs {
 		compatible = "ethernet-phy";
 		status = "okay";
 		address = <0>;
-		mdio = <&mdio>;
 	};
 };
 

--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
@@ -151,7 +151,6 @@
 					compatible = "ethernet-phy";
 					status = "disabled";
 					address = <0>;
-					mdio = <&mdio>;
 				};
 			};
 		};

--- a/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit.dts
+++ b/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit.dts
@@ -123,7 +123,6 @@
 		compatible = "ethernet-phy";
 		status = "disabled";
 		address = <1>;
-		mdio = <&mdio>;
 	};
 };
 

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -481,7 +481,7 @@ static const struct phy_mii_dev_config phy_mii_dev_config_##n = {	 \
 	.fixed = IS_FIXED_LINK(n),					 \
 	.fixed_speed = DT_INST_ENUM_IDX_OR(n, fixed_link, 0),		 \
 	.mdio = UTIL_AND(UTIL_NOT(IS_FIXED_LINK(n)),			 \
-			 DEVICE_DT_GET(DT_INST_PHANDLE(n, mdio)))	 \
+			 DEVICE_DT_GET(DT_INST_BUS(n)))			 \
 };
 
 #define PHY_MII_DEVICE(n)						\

--- a/dts/arm64/fvp/fvp-aemv8r.dtsi
+++ b/dts/arm64/fvp/fvp-aemv8r.dtsi
@@ -123,7 +123,6 @@
 					compatible = "ethernet-phy";
 					status = "disabled";
 					address = <0>;
-					mdio = <&mdio>;
 				};
 			};
 		};

--- a/dts/bindings/ethernet/ethernet-phy.yaml
+++ b/dts/bindings/ethernet/ethernet-phy.yaml
@@ -14,10 +14,6 @@ properties:
     type: int
     required: true
     description: PHY address
-  mdio:
-    type: phandle
-    required: true
-    description: MDIO driver node
   no-reset:
     type: boolean
     description: Do not reset the PHY during initialization


### PR DESCRIPTION
Now that all in-tree phys are declared under their mdio bus, drop the `mdio` property and use DT_INST_BUS to find the bus.