### PR TITLE
winc1500: fix undefined declarations

### DIFF
--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -158,11 +158,11 @@ struct winc1500_data {
 static struct winc1500_data w1500_data;
 
 #if LOG_LEVEL > LOG_LEVEL_OFF
-
 static void stack_stats(void)
 {
 	log_stack_usage(&winc1500_thread_data);
 }
+#endif /* LOG_LEVEL > LOG_LEVEL_OFF */
 
 static char *socket_error_string(int8_t err)
 {
@@ -284,8 +284,6 @@ static char *socket_message_to_string(uint8_t message)
 		return "UNKNOWN.";
 	}
 }
-
-#endif /* LOG_LEVEL > LOG_LEVEL_OFF */
 
 /**
  * This function is called when the socket is to be opened.
@@ -773,8 +771,9 @@ static void winc1500_wifi_cb(uint8_t message_type, void *pvMsg)
 	default:
 		break;
 	}
-
+#if LOG_LEVEL > LOG_LEVEL_OFF
 	stack_stats();
+#endif /* LOG_LEVEL > LOG_LEVEL_OFF */
 }
 
 static void handle_socket_msg_connect(struct socket_data *sd, void *pvMsg)
@@ -962,8 +961,9 @@ static void winc1500_socket_cb(SOCKET sock, uint8 message, void *pvMsg)
 
 		break;
 	}
-
+#if LOG_LEVEL > LOG_LEVEL_OFF
 	stack_stats();
+#endif /* LOG_LEVEL > LOG_LEVEL_OFF */
 }
 
 static void winc1500_thread(void)


### PR DESCRIPTION
LOG_LEVEL > LOG_LEVEL_OFF guards were protecting a couple of function declarations. These functions were being used without taking this fact into consideration. These guards are now applied around the stack_stats() function only.