### PR TITLE
boards: arduino_portenta_h7: fix can1 device name

### DIFF
--- a/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
+++ b/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
@@ -20,7 +20,7 @@
 		zephyr,bt-uart = &uart7;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,canbus = &can2;
+		zephyr,canbus = &fdcan2;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -134,7 +134,7 @@
 	pinctrl-names = "default";
 };
 
-&can2 {
+&fdcan2 {
 	status = "okay";
 	pinctrl-0 = <&fdcan2_tx_pb13 &fdcan2_rx_pb5>;
 	pinctrl-names = "default";

--- a/boards/arm/arduino_portenta_h7/arduino_portenta_h7-common.dtsi
+++ b/boards/arm/arduino_portenta_h7/arduino_portenta_h7-common.dtsi
@@ -102,7 +102,7 @@
 	pinctrl-names = "default";
 };
 
-&can1 {
+&fdcan1 {
 	pinctrl-0 = <&fdcan1_rx_pb8 &fdcan1_tx_ph13>;
 	pinctrl-names = "default";
 };


### PR DESCRIPTION
CI hotfix

---

This has been renamed to fdcan1 in 03f20698ae but this board was left out somehow.