### PR TITLE
dts: Fix arduino_giga_r1_m7.dts

### DIFF
--- a/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
+++ b/boards/arm/arduino_giga_r1/arduino_giga_r1_m7.dts
@@ -20,7 +20,7 @@
 		zephyr,bt-uart = &uart7;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,canbus = &can2;
+		zephyr,canbus = &fdcan2;
 		zephyr,code-partition = &slot0_partition;
 	};
 
@@ -134,7 +134,7 @@
 	pinctrl-names = "default";
 };
 
-&can2 {
+&fdcan2 {
 	status = "okay";
 	pinctrl-0 = <&fdcan2_tx_pb13 &fdcan2_rx_pb5>;
 	pinctrl-names = "default";


### PR DESCRIPTION
A previous commit updated various canX labels to fdcanX, but the can2 label in the arduino_giga_r1 was missed.

Fixes #61569