### PR TITLE
doc: security: Add information about backports

### DIFF
--- a/doc/security/reporting.rst
+++ b/doc/security/reporting.rst
@@ -107,6 +107,8 @@ within the Zephyr project to fix the issues, and 60 days for external
 parties building products using Zephyr to be able to apply and
 distribute these fixes.
 
+.. _vulnerability_fix_recommendations:
+
 Fixes to the code shall be made through pull requests PR in the Zephyr
 project github.  Developers shall make an attempt to not reveal the
 sensitive nature of what is being fixed, and shall not refer to CVE
@@ -180,7 +182,12 @@ following releases:
 The developer of the fix shall be responsible for any necessary
 backports, and apply them to any of the above listed release branches,
 unless the fix does not apply (the vulnerability was introduced after
-this release was made).
+this release was made). All recommendations for
+:ref:`vulnerability fixes <vulnerability_fix_recommendations>` apply
+for backport pull requests (and associated issues). Additionally, it is
+recommended that the developer privately informs the responsible
+release manager that the backport pull request and issue are addressing
+a vulnerability.
 
 Backports will be tracked on the security advisory.
 


### PR DESCRIPTION
Clarify about how to proceed with backports for vulnerabilities.