### PR TITLE
arch: arm: mpu: Make XN bit conditional on CONFIG_XIP for RAM region

### DIFF
--- a/include/zephyr/arch/arm/aarch32/mpu/arm_mpu_v7m.h
+++ b/include/zephyr/arch/arm/aarch32/mpu/arm_mpu_v7m.h
@@ -112,10 +112,15 @@
 #define REGION_4G       REGION_SIZE(4GB)
 
 /* Some helper defines for common regions */
+
+/* On Cortex-M, we can only set the XN bit when CONFIG_XIP=y. When
+ * CONFIG_XIP=n, the entire image will be linked to SRAM, so we need to keep
+ * the SRAM region XN bit clear or the application code will not be executable.
+ */
 #define REGION_RAM_ATTR(size) \
 { \
 	(NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE | \
-	 MPU_RASR_XN_Msk | size | P_RW_U_NA_Msk) \
+	 IF_ENABLED(CONFIG_XIP, (MPU_RASR_XN_Msk |)) size | P_RW_U_NA_Msk) \
 }
 #define REGION_RAM_NOCACHE_ATTR(size) \
 { \

--- a/include/zephyr/arch/arm/aarch32/mpu/arm_mpu_v8.h
+++ b/include/zephyr/arch/arm/aarch32/mpu/arm_mpu_v8.h
@@ -245,9 +245,14 @@
 		.r_limit = limit - 1,				      \
 	}
 #else
+
+/* On Cortex-M, we can only set the XN bit when CONFIG_XIP=y. When
+ * CONFIG_XIP=n, the entire image will be linked to SRAM, so we need to keep
+ * the SRAM region XN bit clear or the application code will not be executable.
+ */
 #define REGION_RAM_ATTR(base, size) \
 	{\
-		.rbar = NOT_EXEC | \
+		.rbar = IF_ENABLED(CONFIG_XIP, (NOT_EXEC |)) \
 			P_RW_U_NA_Msk | NON_SHAREABLE_Msk, /* AP, XN, SH */ \
 		/* Cache-ability */ \
 		.mair_idx = MPU_MAIR_INDEX_SRAM, \


### PR DESCRIPTION
Make the execute never (XN) bit conditonal on CONFIG_XIP for the RAM MPU region attribute. This is required because when CONFIG_XIP is not set, the entire image will be linked into SRAM. In this case, SRAM must be executable.

The alternative to this would be to configure two MPU regions within the SRAM region (one with the XN bit set, and the other with it clear). However, trying to use linker symbols in order to initialize the ARM MPU regions needed for this setup results in the build failing with the error: `initializer element is not computable at load time`.

I'm open to any ideas for a better approach for how to handle `CONFIG_XIP=n` on ARM Cortex M platforms, since currently the MPU must be disabled to run an image built with `CONFIG_XIP=n` on this architecture.