### PR TITLE
Revert "test: Exclude qemu_cortex_a53_smp from portability.posix.eventfd"

### DIFF
--- a/tests/posix/eventfd/testcase.yaml
+++ b/tests/posix/eventfd/testcase.yaml
@@ -5,8 +5,5 @@ common:
     - eventfd
   integration_platforms:
     - qemu_x86
-  # See issue #60678
-  platform_exclude:
-    - qemu_cortex_a53_smp
 tests:
   portability.posix.eventfd: {}


### PR DESCRIPTION
Reverts zephyrproject-rtos/zephyr#60675

It should be ok to re-enable this test now that the fix is merged: https://github.com/zephyrproject-rtos/zephyr/pull/61455