### PR TITLE
retention: Drop prefix/checksum code if not used

### DIFF
--- a/subsys/retention/retention.c
+++ b/subsys/retention/retention.c
@@ -21,6 +21,18 @@ LOG_MODULE_REGISTER(retention, CONFIG_RETENTION_LOG_LEVEL);
 
 #define DATA_VALID_VALUE 1
 
+#define INST_HAS_CHECKSUM(n) DT_INST_PROP(n, checksum) ||
+
+#define INST_HAS_PREFIX(n) COND_CODE_1(DT_INST_NODE_HAS_PROP(n, prefix), (1), (0)) ||
+
+#if (DT_INST_FOREACH_STATUS_OKAY(INST_HAS_CHECKSUM) 0)
+#define ANY_HAS_CHECKSUM
+#endif
+
+#if (DT_INST_FOREACH_STATUS_OKAY(INST_HAS_PREFIX) 0)
+#define ANY_HAS_PREFIX
+#endif
+
 enum {
 	CHECKSUM_NONE = 0,
 	CHECKSUM_CRC8,
@@ -68,6 +80,7 @@ static inline void retention_lock_release(const struct device *dev)
 #endif
 }
 
+#ifdef ANY_HAS_CHECKSUM
 static int retention_checksum(const struct device *dev, uint32_t *output)
 {
 	const struct retention_config *config = dev->config;
@@ -108,6 +121,7 @@ static int retention_checksum(const struct device *dev, uint32_t *output)
 finish:
 	return rc;
 }
+#endif
 
 static int retention_init(const struct device *dev)
 {
@@ -156,10 +170,7 @@ ssize_t retention_size(const struct device *dev)
 int retention_is_valid(const struct device *dev)
 {
 	const struct retention_config *config = dev->config;
-	struct retention_data *data = dev->data;
 	int rc = 0;
-	uint8_t buffer[CONFIG_RETENTION_BUFFER_SIZE];
-	off_t pos;
 
 	retention_lock_take(dev);
 
@@ -169,9 +180,12 @@ int retention_is_valid(const struct device *dev)
 		goto finish;
 	}
 
+#ifdef ANY_HAS_PREFIX
 	if (config->prefix_len != 0) {
 		/* Check magic header is present at the start of the section */
-		pos = 0;
+		struct retention_data *data = dev->data;
+		uint8_t buffer[CONFIG_RETENTION_BUFFER_SIZE];
+		off_t pos = 0;
 
 		while (pos < config->prefix_len) {
 			uint8_t read_size = MIN((config->prefix_len - pos), sizeof(buffer));
@@ -198,7 +212,9 @@ int retention_is_valid(const struct device *dev)
 		/* Header already exists so no need to re-write it again */
 		data->header_written = true;
 	}
+#endif
 
+#ifdef ANY_HAS_CHECKSUM
 	if (config->checksum_size != 0) {
 		/* Check the checksum validity, for this all the data must be read out */
 		uint32_t checksum = 0;
@@ -237,6 +253,7 @@ int retention_is_valid(const struct device *dev)
 			goto finish;
 		}
 	}
+#endif
 
 	/* At this point, checks have passed (if enabled), mark data as being valid */
 	rc = DATA_VALID_VALUE;
@@ -270,8 +287,11 @@ int retention_read(const struct device *dev, off_t offset, uint8_t *buffer, size
 int retention_write(const struct device *dev, off_t offset, const uint8_t *buffer, size_t size)
 {
 	const struct retention_config *config = dev->config;
-	struct retention_data *data = dev->data;
 	int rc;
+
+#ifdef ANY_HAS_PREFIX
+	struct retention_data *data = dev->data;
+#endif
 
 	retention_lock_take(dev);
 
@@ -288,6 +308,7 @@ int retention_write(const struct device *dev, off_t offset, const uint8_t *buffe
 		goto finish;
 	}
 
+#ifdef ANY_HAS_PREFIX
 	/* Write optional header and footer information, these are done last to ensure data
 	 * validity before marking it as being valid
 	 */
@@ -301,7 +322,9 @@ int retention_write(const struct device *dev, off_t offset, const uint8_t *buffe
 
 		data->header_written = true;
 	}
+#endif
 
+#ifdef ANY_HAS_CHECKSUM
 	if (config->checksum_size != 0) {
 		/* Generating a checksum requires reading out all the data in the region */
 		uint32_t checksum = 0;
@@ -330,6 +353,7 @@ int retention_write(const struct device *dev, off_t offset, const uint8_t *buffe
 					(void *)&checksum, sizeof(checksum));
 		}
 	}
+#endif
 
 finish:
 	retention_lock_release(dev);


### PR DESCRIPTION
Will exclude the code for prefix and checksum functionality if none of the entries on a device make use of these features, saves ~816 bytes when both features are excluded.