### PR TITLE
cmake: extend zephyr_file(CONF_FILES <paths>) to allow a list of paths

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -2291,26 +2291,27 @@ endfunction()
 #
 # returns an updated list of absolute paths
 #
-# CONF_FILES <path>: Find all configuration files in path and return them in a
-#                    list. Configuration files will be:
-#                    - DTS:       Overlay files (.overlay)
-#                    - Kconfig:   Config fragments (.conf)
-#                    The conf file search will return existing configuration
-#                    files for the current board.
-#                    CONF_FILES takes the following additional arguments:
-#                    BOARD <board>:             Find configuration files for specified board.
-#                    BOARD_REVISION <revision>: Find configuration files for specified board
-#                                               revision. Requires BOARD to be specified.
+# CONF_FILES <paths>: Find all configuration files in the list of paths and
+#                     return them in a list. If paths is empty then no configuration
+#                     files are returned. Configuration files will be:
+#                     - DTS:       Overlay files (.overlay)
+#                     - Kconfig:   Config fragments (.conf)
+#                     The conf file search will return existing configuration
+#                     files for the current board.
+#                     CONF_FILES takes the following additional arguments:
+#                     BOARD <board>:             Find configuration files for specified board.
+#                     BOARD_REVISION <revision>: Find configuration files for specified board
+#                                                revision. Requires BOARD to be specified.
 #
-#                                               If no board is given the current BOARD and
-#                                               BOARD_REVISION will be used.
+#                                                If no board is given the current BOARD and
+#                                                BOARD_REVISION will be used.
 #
-#                    DTS <list>:   List to append DTS overlay files in <path> to
-#                    KCONF <list>: List to append Kconfig fragment files in <path> to
-#                    BUILD <type>: Build type to include for search.
-#                                  For example:
-#                                  BUILD debug, will look for <board>_debug.conf
-#                                  and <board>_debug.overlay, instead of <board>.conf
+#                     DTS <list>:   List to append DTS overlay files in <path> to
+#                     KCONF <list>: List to append Kconfig fragment files in <path> to
+#                     BUILD <type>: Build type to include for search.
+#                                   For example:
+#                                   BUILD debug, will look for <board>_debug.conf
+#                                   and <board>_debug.overlay, instead of <board>.conf
 #
 function(zephyr_file)
   set(file_options APPLICATION_ROOT CONF_FILES)
@@ -2322,10 +2323,11 @@ Please provide one of following: APPLICATION_ROOT, CONF_FILES")
   if(${ARGV0} STREQUAL APPLICATION_ROOT)
     set(single_args APPLICATION_ROOT)
   elseif(${ARGV0} STREQUAL CONF_FILES)
-    set(single_args CONF_FILES BOARD BOARD_REVISION DTS KCONF BUILD)
+    set(single_args BOARD BOARD_REVISION DTS KCONF BUILD)
+    set(multi_args CONF_FILES)
   endif()
 
-  cmake_parse_arguments(FILE "" "${single_args}" "" ${ARGN})
+  cmake_parse_arguments(FILE "" "${single_args}" "${multi_args}" ${ARGN})
   if(FILE_UNPARSED_ARGUMENTS)
       message(FATAL_ERROR "zephyr_file(${ARGV0} <val> ...) given unknown arguments: ${FILE_UNPARSED_ARGUMENTS}")
   endif()
@@ -2397,10 +2399,12 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
     list(REMOVE_DUPLICATES filename_list)
 
     if(FILE_DTS)
-      foreach(filename ${filename_list})
-        if(EXISTS ${FILE_CONF_FILES}/${filename}.overlay)
-          list(APPEND ${FILE_DTS} ${FILE_CONF_FILES}/${filename}.overlay)
-        endif()
+      foreach(path ${FILE_CONF_FILES})
+        foreach(filename ${filename_list})
+          if(EXISTS ${path}/${filename}.overlay)
+            list(APPEND ${FILE_DTS} ${path}/${filename}.overlay)
+          endif()
+        endforeach()
       endforeach()
 
       # This updates the provided list in parent scope (callers scope)
@@ -2408,10 +2412,12 @@ Relative paths are only allowed with `-D${ARGV1}=<path>`")
     endif()
 
     if(FILE_KCONF)
-      foreach(filename ${filename_list})
-        if(EXISTS ${FILE_CONF_FILES}/${filename}.conf)
-          list(APPEND ${FILE_KCONF} ${FILE_CONF_FILES}/${filename}.conf)
-        endif()
+      foreach(path ${FILE_CONF_FILES})
+        foreach(filename ${filename_list})
+          if(EXISTS ${path}/${filename}.conf)
+            list(APPEND ${FILE_KCONF} ${path}/${filename}.conf)
+          endif()
+        endforeach()
       endforeach()
 
       # This updates the provided list in parent scope (callers scope)


### PR DESCRIPTION
Extend zephyr_file(CONF_FILES <paths>) to take a list of paths to lookup instead of a single path.

This remove the need of callers to do:
```
foreach(p ${paths})
  zephyr_file(CONF_FILES ${p})
  ...
endforeach()
```
and instead allow them to just pass the list directly to
```
zephyr_file(CONF_FILES ${paths})
```
In addition the help text is updated with the detail that CONF_FILES can be given an empty list. This has always been possible, but not described.