### PR TITLE
Implement get config/direction GPIO APIs for NXP S32

### DIFF
--- a/tests/drivers/gpio/gpio_get_direction/boards/s32z270dc2_rtu0_r52.overlay
+++ b/tests/drivers/gpio/gpio_get_direction/boards/s32z270dc2_rtu0_r52.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		led0 = &led_A3;
+	};
+
+	gpio-led {
+		compatible = "gpio-leds";
+		led_A3: led_A3 {
+			gpios = <&gpioa 3 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpioa {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_get_direction/boards/s32z270dc2_rtu1_r52.overlay
+++ b/tests/drivers/gpio/gpio_get_direction/boards/s32z270dc2_rtu1_r52.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		led0 = &led_A3;
+	};
+
+	gpio-led {
+		compatible = "gpio-leds";
+		led_A3: led_A3 {
+			gpios = <&gpioa 3 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpioa {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_hogs/boards/mr_canhubk3.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/mr_canhubk3.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	zephyr,user {
+		output-high-gpios = <&gpioa_h 0 GPIO_ACTIVE_LOW>;
+		output-low-gpios = <&gpioa_h 3 GPIO_ACTIVE_HIGH>;
+		input-gpios = <&gpioa_h 1 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpioa_h {
+	hog1 {
+		gpio-hog;
+		gpios = <0 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+
+	hog2 {
+		gpio-hog;
+		gpios = <1 GPIO_ACTIVE_HIGH>;
+		input;
+	};
+
+	hog3 {
+		gpio-hog;
+		gpios = <3 GPIO_ACTIVE_HIGH>;
+		output-low;
+	};
+};

--- a/tests/drivers/gpio/gpio_hogs/boards/s32z270dc2_rtu0_r52.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/s32z270dc2_rtu0_r52.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	zephyr,user {
+		output-high-gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
+		output-low-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
+		input-gpios = <&gpioa 1 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpioa {
+	status = "okay";
+
+	hog1 {
+		gpio-hog;
+		gpios = <0 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+
+	hog2 {
+		gpio-hog;
+		gpios = <1 GPIO_ACTIVE_HIGH>;
+		input;
+	};
+
+	hog3 {
+		gpio-hog;
+		gpios = <2 GPIO_ACTIVE_HIGH>;
+		output-low;
+	};
+};

--- a/tests/drivers/gpio/gpio_hogs/boards/s32z270dc2_rtu1_r52.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/s32z270dc2_rtu1_r52.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	zephyr,user {
+		output-high-gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
+		output-low-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
+		input-gpios = <&gpioa 1 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpioa {
+	status = "okay";
+
+	hog1 {
+		gpio-hog;
+		gpios = <0 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+
+	hog2 {
+		gpio-hog;
+		gpios = <1 GPIO_ACTIVE_HIGH>;
+		input;
+	};
+
+	hog3 {
+		gpio-hog;
+		gpios = <2 GPIO_ACTIVE_HIGH>;
+		output-low;
+	};
+};

--- a/tests/drivers/gpio/gpio_hogs/testcase.yaml
+++ b/tests/drivers/gpio/gpio_hogs/testcase.yaml
@@ -11,6 +11,9 @@ tests:
       - nrf52840dk_nrf52840
       - nucleo_g474re
       - nrf52_bsim
+      - mr_canhubk3
+      - s32z270dc2_rtu0_r52
+      - s32z270dc2_rtu1_r52
     integration_platforms:
       - native_posix
       - native_posix_64


### PR DESCRIPTION
Implement `pin_get_config()` and `port_get_direction()` GPIO APIs and enable related tests on NXP S32 boards.