### PR TITLE
Bluetooth: controller: created ll_types for common LL type definitions

### DIFF
--- a/subsys/bluetooth/controller/include/ll_types.h
+++ b/subsys/bluetooth/controller/include/ll_types.h
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2023 Demant
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define TRUE         1U
+#define FALSE        0U


### PR DESCRIPTION
Created new LL type definition header.

Based on review suggestion from PR https://github.com/zephyrproject-rtos/zephyr/pull/61473 (https://github.com/zephyrproject-rtos/zephyr/pull/61473#discussion_r1295862285).