### PR TITLE
Revert   linker command file fixes: .bss/.noinit sections, z_mapped_start marker 

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -61,32 +61,9 @@ Kernel
 Architectures
 *************
 
-* ARC
-
 * ARM
 
-  * Fixed the Cortex-A/-R linker command file:
-
-    * The sections for zero-initialized (.bss) and uninitialized (.noinit) data
-      are now the last sections within the binary. This allows the linker to just
-      account for the required memory, but not having to actually include large
-      empty spaces within the binary. With the .bss and .noinit sections placed
-      somewhere in the middle of the resulting binary, as was the case with
-      previous releases, the linker had to pad the space for zero-/uninitialized
-      data due to subsequent sections containing initialized data. The inclusion
-      of large zero-initialized arrays or statically defined heaps reflected
-      directly in the size of the resulting binary, resulting in unnecessarily
-      large binaries, even when stripped.
-    * Fixed the location of the z_mapped_start address marker to point to the
-      base of RAM instead of to the start of the .text section. Therefore, the
-      single 4k page .vectors section, which is located right at the base of RAM
-      before the .text section and which was previously not included in the
-      mapped memory range, is now considered mapped and unavailable for dynamic
-      memory mapping via the MMU at run-time. This prevents the 4k page containing
-      the exception vectors data being mapped as regular memory at run-time, with
-      any subsequently mapped pages being located beyond the permanently mapped
-      memory regions (beyond z_mapped_end), resulting in non-contiguous memory
-      allocation for any first memory request greater than 4k.
+* ARM
 
 * ARM64
 

--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -133,6 +133,9 @@ SECTIONS
     {
         . = ALIGN(_region_min_align);
         __text_region_start = .;
+#ifndef CONFIG_XIP
+        z_mapped_start = .;
+#endif
 
 #include <zephyr/linker/kobject-text.ld>
 
@@ -244,7 +247,9 @@ SECTIONS
      */
     . = ALIGN(_region_min_align);
     _image_ram_start = .;
+#ifdef CONFIG_XIP
     z_mapped_start = .;
+#endif
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.

--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -26,13 +26,6 @@
 #endif
 #define RAMABLE_REGION RAM
 
-/* section alignment directive, valid only if not running in XIP mode */
-#ifndef CONFIG_XIP
-  #define SECTION_ALIGN ALIGN(_region_min_align)
-#else
-  #define SECTION_ALIGN
-#endif
-
 #if !defined(CONFIG_XIP) && (CONFIG_FLASH_SIZE == 0)
   #define ROM_ADDR RAM_ADDR
 #else
@@ -79,6 +72,8 @@ _region_min_align = 4;
   #define MPU_ALIGN(region_size) \
     . = ALIGN(_region_min_align)
 #endif
+
+#define BSS_ALIGN ALIGN(_region_min_align)
 
 MEMORY
 {
@@ -266,10 +261,35 @@ SECTIONS
     _app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
 #endif  /* CONFIG_USERSPACE */
 
-    . = ALIGN(_region_min_align);
-    __kernel_ram_start = .;
+    SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD), BSS_ALIGN)
+    {
+        /*
+         * For performance, BSS section is assumed to be 4 byte aligned and
+         * a multiple of 4 bytes
+         */
+        . = ALIGN(4);
+        __bss_start = .;
+        __kernel_ram_start = .;
 
-    SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,SECTION_ALIGN)
+        *(.bss)
+        *(".bss.*")
+        *(COMMON)
+        *(".kernel_bss.*")
+
+#ifdef CONFIG_CODE_DATA_RELOCATION
+#include <linker_sram_bss_relocate.ld>
+#endif
+
+        /*
+         * As memory is cleared in words only, it is simpler to ensure the BSS
+         * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
+         */
+        __bss_end = ALIGN(4);
+    } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+
+#include <zephyr/linker/common-noinit.ld>
+
+    SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
     {
         __data_region_start = .;
         __data_start = .;
@@ -303,29 +323,7 @@ SECTIONS
 #include <snippets-data-sections.ld>
 
     __data_region_end = .;
-    . = ALIGN(_region_min_align);
 
-    SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD), SECTION_ALIGN)
-    {
-        __bss_start = .;
-
-        *(.bss)
-        *(".bss.*")
-        *(COMMON)
-        *(".kernel_bss.*")
-
-#ifdef CONFIG_CODE_DATA_RELOCATION
-#include <linker_sram_bss_relocate.ld>
-#endif
-
-        /*
-         * As memory is cleared in words only, it is simpler to ensure the BSS
-         * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
-         */
-        __bss_end = ALIGN(4);
-    } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
-
-#include <zephyr/linker/common-noinit.ld>
 
     /* Define linker symbols */
 


### PR DESCRIPTION
Revert https://github.com/zephyrproject-rtos/zephyr/pull/60368 as it's breaking few tests, see https://github.com/zephyrproject-rtos/zephyr/issues/61572.