### PR TITLE
Bluetooth: Mesh: Add ext timeout in PB for OOB I/O

### DIFF
--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -282,7 +282,7 @@ static void prov_failed(uint8_t err)
 
 static void prov_msg_recv(void)
 {
-	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
+	k_work_reschedule(&link.prot_timer, bt_mesh_prov_protocol_timeout_get());
 
 	if (!bt_mesh_fcs_check(link.rx.buf, link.rx.fcs)) {
 		LOG_ERR("Incorrect FCS");
@@ -654,7 +654,7 @@ static int bearer_ctl_send(struct net_buf *buf)
 	}
 
 	prov_clear_tx();
-	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
+	k_work_reschedule(&link.prot_timer, bt_mesh_prov_protocol_timeout_get());
 
 	link.tx.start = k_uptime_get();
 	link.tx.buf[0] = buf;
@@ -670,7 +670,7 @@ static int bearer_ctl_send_unacked(struct net_buf *buf, void *user_data)
 	}
 
 	prov_clear_tx();
-	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
+	k_work_reschedule(&link.prot_timer, bt_mesh_prov_protocol_timeout_get());
 
 	bt_mesh_adv_send(buf, &buf_sent_cb, user_data);
 	net_buf_unref(buf);
@@ -685,7 +685,7 @@ static int prov_send_adv(struct net_buf_simple *msg,
 	uint8_t seg_len, seg_id;
 
 	prov_clear_tx();
-	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
+	k_work_reschedule(&link.prot_timer, bt_mesh_prov_protocol_timeout_get());
 
 	start = adv_buf_create(RETRANSMITS_RELIABLE);
 	if (!start) {

--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -95,7 +95,7 @@ int bt_mesh_pb_gatt_recv(struct bt_conn *conn, struct net_buf_simple *buf)
 		return -EINVAL;
 	}
 
-	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
+	k_work_reschedule(&link.prot_timer, bt_mesh_prov_protocol_timeout_get());
 
 	link.cb->recv(&bt_mesh_pb_gatt, link.cb_data, buf);
 
@@ -111,7 +111,7 @@ int bt_mesh_pb_gatt_start(struct bt_conn *conn)
 	}
 
 	link.conn = bt_conn_ref(conn);
-	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
+	k_work_reschedule(&link.prot_timer, bt_mesh_prov_protocol_timeout_get());
 
 	link.cb->link_opened(&bt_mesh_pb_gatt, link.cb_data);
 
@@ -142,7 +142,7 @@ int bt_mesh_pb_gatt_cli_start(struct bt_conn *conn)
 	}
 
 	link.conn = bt_conn_ref(conn);
-	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
+	k_work_reschedule(&link.prot_timer, bt_mesh_prov_protocol_timeout_get());
 
 	return 0;
 }
@@ -218,7 +218,7 @@ static int buf_send(struct net_buf_simple *buf, prov_bearer_send_complete_t cb,
 	link.comp.cb = cb;
 	link.comp.cb_data = cb_data;
 
-	k_work_reschedule(&link.prot_timer, PROTOCOL_TIMEOUT);
+	k_work_reschedule(&link.prot_timer, bt_mesh_prov_protocol_timeout_get());
 
 	return bt_mesh_proxy_msg_send(link.conn, BT_MESH_PROXY_PROV,
 				      buf, buf_send_end, NULL);

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -38,7 +38,7 @@ BUILD_ASSERT(sizeof(bt_mesh_prov_link.conf_inputs) == 145,
 int bt_mesh_prov_reset_state(void)
 {
 	int err;
-	const size_t offset = offsetof(struct bt_mesh_prov_link, auth);
+	const size_t offset = offsetof(struct bt_mesh_prov_link, addr);
 
 	atomic_clear(bt_mesh_prov_link.flags);
 	(void)memset((uint8_t *)&bt_mesh_prov_link + offset, 0,

--- a/subsys/bluetooth/mesh/prov.h
+++ b/subsys/bluetooth/mesh/prov.h
@@ -170,6 +170,14 @@ static inline uint8_t bt_mesh_prov_auth_size_get(void)
 	return bt_mesh_prov_link.algorithm == BT_MESH_PROV_AUTH_CMAC_AES128_AES_CCM ? 16 : 32;
 }
 
+static inline k_timeout_t bt_mesh_prov_protocol_timeout_get(void)
+{
+	return (bt_mesh_prov_link.oob_method == AUTH_METHOD_INPUT ||
+		bt_mesh_prov_link.oob_method == AUTH_METHOD_OUTPUT)
+		       ? PROTOCOL_TIMEOUT_EXT
+		       : PROTOCOL_TIMEOUT;
+}
+
 int bt_mesh_prov_reset_state(void);
 
 bool bt_mesh_prov_active(void);

--- a/subsys/bluetooth/mesh/prov_bearer.h
+++ b/subsys/bluetooth/mesh/prov_bearer.h
@@ -5,10 +5,12 @@
  */
 
 /** Provisioning protocol timeout in seconds. */
-#define PROTOCOL_TIMEOUT_SEC  60
+#define PROTOCOL_TIMEOUT_SEC     60
+#define PROTOCOL_TIMEOUT_EXT_SEC 120
 
 /** Provisioning protocol timeout. */
 #define PROTOCOL_TIMEOUT     K_SECONDS(PROTOCOL_TIMEOUT_SEC)
+#define PROTOCOL_TIMEOUT_EXT K_SECONDS(PROTOCOL_TIMEOUT_EXT_SEC)
 
 /** @def PROV_BEARER_BUF_HEADROOM
  *


### PR DESCRIPTION
Adds separate extended protocol timeout of 120 sec in provisioning implementation when OOB method Input or Output is used. This complies with recommendation in the mesh 1.1 protocol spec (5.4.4).