### PR TITLE
Bluetooth: CAP: Remove qos from start_stream_param

### DIFF
--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -221,9 +221,6 @@ struct bt_cap_unicast_audio_start_stream_param {
 	 * stream context (@ref BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT) bitfield.
 	 */
 	struct bt_audio_codec_cfg *codec_cfg;
-
-	/** Quality of Service configuration. */
-	struct bt_audio_codec_qos *qos;
 };
 
 struct bt_cap_unicast_audio_start_param {

--- a/samples/bluetooth/tmap_central/src/cap_initiator.c
+++ b/samples/bluetooth/tmap_central/src/cap_initiator.c
@@ -356,7 +356,6 @@ static int unicast_audio_start(struct bt_conn *conn, struct bt_bap_unicast_group
 	stream_param.stream = &unicast_streams[0];
 	stream_param.ep = unicast_sink_eps[0];
 	stream_param.codec_cfg = &unicast_preset_48_2_1.codec_cfg;
-	stream_param.qos = &unicast_preset_48_2_1.qos;
 
 	err = bt_cap_initiator_unicast_audio_start(&param, unicast_group);
 	if (err != 0) {

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -671,11 +671,6 @@ static bool valid_unicast_audio_start_param(const struct bt_cap_unicast_audio_st
 			return false;
 		}
 
-		CHECKIF(stream_param->qos == NULL) {
-			LOG_DBG("param->stream_params[%zu].qos is NULL", i);
-			return false;
-		}
-
 		CHECKIF(member == NULL) {
 			LOG_DBG("param->stream_params[%zu].member is NULL", i);
 			return false;

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -252,11 +252,8 @@ static int cmd_cap_initiator_unicast_start(const struct shell *sh, size_t argc,
 			stream_param[start_param.count].stream = stream;
 			stream_param[start_param.count].ep = snk_ep;
 			copy_unicast_stream_preset(uni_stream, default_sink_preset);
-			stream_param[start_param.count].codec_cfg  = &uni_stream->codec_cfg;
-			stream_param[start_param.count].qos = &uni_stream->qos;
+			stream_param[start_param.count].codec_cfg = &uni_stream->codec_cfg;
 
-			group_stream_params[start_param.count].qos =
-				stream_param[start_param.count].qos;
 			group_stream_params[start_param.count].stream =
 				&stream_param[start_param.count].stream->bap_stream;
 			pair_params[pair_cnt + j].tx_param =
@@ -286,11 +283,7 @@ static int cmd_cap_initiator_unicast_start(const struct shell *sh, size_t argc,
 			stream_param[start_param.count].stream = stream;
 			stream_param[start_param.count].ep = src_ep;
 			copy_unicast_stream_preset(uni_stream, default_source_preset);
-			stream_param[start_param.count].codec_cfg  = &uni_stream->codec_cfg;
-			stream_param[start_param.count].qos = &uni_stream->qos;
-
-			group_stream_params[start_param.count].qos =
-				stream_param[start_param.count].qos;
+			stream_param[start_param.count].codec_cfg = &uni_stream->codec_cfg;
 			group_stream_params[start_param.count].stream =
 				&stream_param[start_param.count].stream->bap_stream;
 			pair_params[pair_cnt + j].rx_param =
@@ -501,8 +494,6 @@ static int cap_ac_unicast_start(const struct bap_unicast_ac_param *param,
 	struct bt_audio_codec_cfg *src_codec_cfgs[BAP_UNICAST_AC_MAX_SRC] = {0};
 	struct bt_cap_stream *snk_cap_streams[BAP_UNICAST_AC_MAX_SNK] = {0};
 	struct bt_cap_stream *src_cap_streams[BAP_UNICAST_AC_MAX_SRC] = {0};
-	struct bt_audio_codec_qos *snk_qos[BAP_UNICAST_AC_MAX_SNK] = {0};
-	struct bt_audio_codec_qos *src_qos[BAP_UNICAST_AC_MAX_SRC] = {0};
 	struct bt_cap_unicast_audio_start_param start_param = {0};
 	struct bt_bap_ep *snk_eps[BAP_UNICAST_AC_MAX_SNK] = {0};
 	struct bt_bap_ep *src_eps[BAP_UNICAST_AC_MAX_SRC] = {0};
@@ -559,13 +550,11 @@ static int cap_ac_unicast_start(const struct bap_unicast_ac_param *param,
 	 */
 	for (size_t i = 0U; i < snk_cnt; i++) {
 		snk_cap_streams[i] = &snk_uni_streams[i]->stream;
-		snk_qos[i] = &snk_uni_streams[i]->qos;
 		snk_codec_cfgs[i] = &snk_uni_streams[i]->codec_cfg;
 	}
 
 	for (size_t i = 0U; i < src_cnt; i++) {
 		src_cap_streams[i] = &src_uni_streams[i]->stream;
-		src_qos[i] = &src_uni_streams[i]->qos;
 		src_codec_cfgs[i] = &src_uni_streams[i]->codec_cfg;
 	}
 
@@ -578,7 +567,6 @@ static int cap_ac_unicast_start(const struct bap_unicast_ac_param *param,
 			stream_param->member.member = connected_conns[i];
 			stream_param->codec_cfg = snk_codec_cfgs[snk_stream_cnt];
 			stream_param->ep = snk_eps[snk_stream_cnt];
-			stream_param->qos = snk_qos[snk_stream_cnt];
 			stream_param->stream = snk_cap_streams[snk_stream_cnt];
 
 			snk_stream_cnt++;
@@ -606,7 +594,6 @@ static int cap_ac_unicast_start(const struct bap_unicast_ac_param *param,
 			stream_param->member.member = connected_conns[i];
 			stream_param->codec_cfg = src_codec_cfgs[src_stream_cnt];
 			stream_param->ep = src_eps[src_stream_cnt];
-			stream_param->qos = src_qos[src_stream_cnt];
 			stream_param->stream = src_cap_streams[src_stream_cnt];
 
 			src_stream_cnt++;

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -545,7 +545,6 @@ static void unicast_audio_start_inval(struct bt_bap_unicast_group *unicast_group
 	valid_stream_param.stream = &unicast_client_streams[0];
 	valid_stream_param.ep = unicast_sink_eps[bt_conn_index(default_conn)][0];
 	valid_stream_param.codec_cfg = &unicast_preset_16_2_1.codec_cfg;
-	valid_stream_param.qos = &unicast_preset_16_2_1.qos;
 
 	/* Test NULL parameters */
 	err = bt_cap_initiator_unicast_audio_start(NULL, unicast_group);
@@ -625,16 +624,6 @@ static void unicast_audio_start_inval(struct bt_bap_unicast_group *unicast_group
 		return;
 	}
 
-	memcpy(&invalid_stream_param, &valid_stream_param, sizeof(valid_stream_param));
-
-	invalid_stream_param.qos = NULL;
-	err = bt_cap_initiator_unicast_audio_start(&invalid_start_param, unicast_group);
-	if (err == 0) {
-		FAIL("bt_cap_initiator_unicast_audio_start with NULL stream params qos did not "
-		     "fail\n");
-		return;
-	}
-
 	/* Clear metadata so that it does not contain the mandatory stream context */
 	memcpy(&invalid_stream_param, &valid_stream_param, sizeof(valid_stream_param));
 	memset(&invalid_codec.meta, 0, sizeof(invalid_codec.meta));
@@ -661,7 +650,6 @@ static void unicast_audio_start(struct bt_bap_unicast_group *unicast_group, bool
 	stream_param[0].stream = &unicast_client_streams[0];
 	stream_param[0].ep = unicast_sink_eps[bt_conn_index(default_conn)][0];
 	stream_param[0].codec_cfg = &unicast_preset_16_2_1.codec_cfg;
-	stream_param[0].qos = &unicast_preset_16_2_1.qos;
 
 	UNSET_FLAG(flag_started);
 
@@ -1058,8 +1046,6 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 	struct bt_cap_stream *snk_cap_streams[CAP_AC_MAX_SNK] = {0};
 	struct bt_cap_stream *src_cap_streams[CAP_AC_MAX_SRC] = {0};
 	struct bt_cap_unicast_audio_start_param start_param = {0};
-	struct bt_audio_codec_qos *snk_qos[CAP_AC_MAX_SNK] = {0};
-	struct bt_audio_codec_qos *src_qos[CAP_AC_MAX_SRC] = {0};
 	struct bt_bap_ep *snk_eps[CAP_AC_MAX_SNK] = {0};
 	struct bt_bap_ep *src_eps[CAP_AC_MAX_SRC] = {0};
 	size_t snk_stream_cnt = 0U;
@@ -1113,13 +1099,11 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 	 */
 	for (size_t i = 0U; i < snk_cnt; i++) {
 		snk_cap_streams[i] = &snk_uni_streams[i]->stream;
-		snk_qos[i] = &snk_uni_streams[i]->qos;
 		snk_codec_cfgs[i] = &snk_uni_streams[i]->codec_cfg;
 	}
 
 	for (size_t i = 0U; i < src_cnt; i++) {
 		src_cap_streams[i] = &src_uni_streams[i]->stream;
-		src_qos[i] = &src_uni_streams[i]->qos;
 		src_codec_cfgs[i] = &src_uni_streams[i]->codec_cfg;
 	}
 
@@ -1132,7 +1116,6 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 			stream_param->member.member = connected_conns[i];
 			stream_param->codec_cfg = snk_codec_cfgs[snk_stream_cnt];
 			stream_param->ep = snk_eps[snk_stream_cnt];
-			stream_param->qos = snk_qos[snk_stream_cnt];
 			stream_param->stream = snk_cap_streams[snk_stream_cnt];
 
 			snk_stream_cnt++;
@@ -1150,7 +1133,6 @@ static int cap_initiator_ac_cap_unicast_start(const struct cap_initiator_ac_para
 			stream_param->member.member = connected_conns[i];
 			stream_param->codec_cfg = src_codec_cfgs[src_stream_cnt];
 			stream_param->ep = src_eps[src_stream_cnt];
-			stream_param->qos = src_qos[src_stream_cnt];
 			stream_param->stream = src_cap_streams[src_stream_cnt];
 
 			src_stream_cnt++;


### PR DESCRIPTION
Remove the qos field from
bt_cap_unicast_audio_start_stream_param as it was not used.

The QOS values are set when creating the unicast group, and not when starting the streams.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/60101