### PR TITLE
boards: intel: Fix Missing #address-cells warning

### DIFF
--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -30,9 +30,10 @@
 
 	intc: ioapic@fec00000  {
 		compatible = "intel,ioapic";
+		#address-cells = <1>;
+		#interrupt-cells = <3>;
 		reg = <0xfec00000 0x1000>;
 		interrupt-controller;
-		#interrupt-cells = <3>;
 	};
 
 	pcie0: pcie0 {

--- a/dts/x86/intel/apollo_lake.dtsi
+++ b/dts/x86/intel/apollo_lake.dtsi
@@ -30,9 +30,10 @@
 
 	intc: ioapic@fec00000  {
 		compatible = "intel,ioapic";
+		#address-cells = <1>;
+		#interrupt-cells = <3>;
 		reg = <0xfec00000 0x1000>;
 		interrupt-controller;
-		#interrupt-cells = <3>;
 	};
 
 	pcie0: pcie0 {

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -35,9 +35,10 @@
 
 	intc: ioapic@fec00000  {
 		compatible = "intel,ioapic";
+		#address-cells = <1>;
+		#interrupt-cells = <3>;
 		reg = <0xfec00000 0x1000>;
 		interrupt-controller;
-		#interrupt-cells = <3>;
 	};
 
 	pcie0: pcie0 {

--- a/dts/x86/intel/ia32.dtsi
+++ b/dts/x86/intel/ia32.dtsi
@@ -23,9 +23,10 @@
 
 	intc: ioapic@fec00000  {
 		compatible = "intel,ioapic";
+		#address-cells = <1>;
+		#interrupt-cells = <3>;
 		reg = <0xfec00000 0x1000>;
 		interrupt-controller;
-		#interrupt-cells = <3>;
 	};
 
 	dram0: memory@0 {

--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -26,9 +26,10 @@
 
 	intc: ioapic@fec00000  {
 		compatible = "intel,ioapic";
+		#address-cells = <1>;
+		#interrupt-cells = <3>;
 		reg = <0xfec00000 0x100000>;
 		interrupt-controller;
-		#interrupt-cells = <3>;
 	};
 
 	sram: memory@ff200000 {

--- a/dts/x86/intel/raptor_lake.dtsi
+++ b/dts/x86/intel/raptor_lake.dtsi
@@ -30,9 +30,10 @@
 
 	intc: ioapic@fec00000  {
 		compatible = "intel,ioapic";
+		#address-cells = <1>;
+		#interrupt-cells = <3>;
 		reg = <0xfec00000 0x1000>;
 		interrupt-controller;
-		#interrupt-cells = <3>;
 	};
 
 	pcie0: pcie0 {


### PR DESCRIPTION
Specify properties to fix compile warning:

Warning (interrupt_provider): /ioapic@fec00000: Missing #address-cells in interrupt provider