### PR TITLE
Microchip MEC172X: Make PM debug helper board specific

### DIFF
--- a/boards/arm/mec172xevb_assy6906/CMakeLists.txt
+++ b/boards/arm/mec172xevb_assy6906/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+add_subdirectory(debug)
+
 if(DEFINED ENV{MEC172X_SPI_GEN})
   # Grab it from environment variable if defined
   set(MEC172X_SPI_GEN $ENV{MEC172X_SPI_GEN})

--- a/boards/arm/mec172xevb_assy6906/debug/CMakeLists.txt
+++ b/boards/arm/mec172xevb_assy6906/debug/CMakeLists.txt
@@ -1,0 +1,3 @@
+zephyr_include_directories(${ZEPHYR_BASE})
+zephyr_library()
+zephyr_library_sources_ifdef(CONFIG_SOC_SLEEP_STATE_DEBUG_FUNCTION power_debug.c)

--- a/boards/arm/mec172xevb_assy6906/debug/power_debug.c
+++ b/boards/arm/mec172xevb_assy6906/debug/power_debug.c
@@ -1,0 +1,15 @@
+#include <zephyr/device.h>
+#include <zephyr/drivers/led.h>
+#include <soc/arm/microchip_mec/mec172x/soc_power_debug.h>
+
+const struct device *led = DEVICE_DT_GET(DT_ALIAS(led0));
+
+void pm_debug_function(uint32_t debug)
+{
+
+	if (debug == PM_DEBUG_ENTER) {
+		led_on(led, 0);
+	} else if (debug == PM_DEBUG_EXIT) {
+		led_off(led, 0);
+	}
+}

--- a/soc/arm/microchip_mec/mec172x/Kconfig.soc
+++ b/soc/arm/microchip_mec/mec172x/Kconfig.soc
@@ -82,3 +82,10 @@ config GPIO_INIT_PRIORITY
 	default 41
 
 endif # GPIO
+
+config SOC_SLEEP_STATE_DEBUG_FUNCTION
+	bool "Platform provides a debug indicator for sleep modes"
+	depends on PM
+	help
+	  Platform may provide an indication of entering/exiting sleep modes by
+	  defining board-specific void function pm_debug_function(uint32_t).

--- a/soc/arm/microchip_mec/mec172x/soc_power_debug.h
+++ b/soc/arm/microchip_mec/mec172x/soc_power_debug.h
@@ -7,34 +7,19 @@
 #ifndef __SOC_POWER_DEBUG_H__
 #define __SOC_POWER_DEBUG_H__
 
-/* #define SOC_SLEEP_STATE_GPIO_MARKER_DEBUG */
+#ifdef CONFIG_SOC_SLEEP_STATE_DEBUG_FUNCTION
 
-#ifdef SOC_SLEEP_STATE_GPIO_MARKER_DEBUG
+#define PM_DEBUG_ENTER	1
+#define PM_DEBUG_EXIT	0
 
-/* Select a gpio not used. LED4 on EVB. High = ON */
-#define DP_GPIO_ID		MCHP_GPIO_0241_ID
+#define PM_DP_ENTER()	pm_debug_function(PM_DEBUG_ENTER)
+#define PM_DP_EXIT()	pm_debug_function(PM_DEBUG_EXIT)
 
-/* output drive high */
-#define PM_DP_ENTER_GPIO_VAL	0x10240U
-/* output drive low */
-#define PM_DP_EXIT_GPIO_VAL	0x0240U
-
-static inline void pm_dp_gpio(uint32_t gpio_ctrl_val)
-{
-	struct gpio_regs * const regs =
-		(struct gpio_regs * const)(DT_REG_ADDR(DT_NODELABEL(gpio_000_036)));
-
-	regs->CTRL[DP_GPIO_ID] = gpio_ctrl_val;
-}
-
-#endif
-
-#ifdef DP_GPIO_ID
-#define PM_DP_ENTER()	pm_dp_gpio(PM_DP_ENTER_GPIO_VAL)
-#define PM_DP_EXIT()	pm_dp_gpio(PM_DP_EXIT_GPIO_VAL)
 #else
+
 #define PM_DP_ENTER()
 #define PM_DP_EXIT()
+
 #endif
 
 #endif /* __SOC_POWER_DEBUG_H__ */


### PR DESCRIPTION
PM debug for MEC172X was initially implemented as SoC-specific code, with the changes to the GPIO control this commit makes it possible to make debug support code board-specific.