### PR TITLE
boards: doc: Include only index documents to toctree

### DIFF
--- a/boards/x86/common/efi_boot.rst
+++ b/boards/x86/common/efi_boot.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Preparing the Boot Device
 -------------------------
 

--- a/boards/x86/common/net_boot.rst
+++ b/boards/x86/common/net_boot.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Prepare Linux host
 ------------------
 

--- a/boards/x86/index.rst
+++ b/boards/x86/index.rst
@@ -7,4 +7,4 @@ x86 Boards
    :maxdepth: 1
    :glob:
 
-   **/*
+   **/index


### PR DESCRIPTION
Use correct glob pattern to exclude common rst helpers from toctree.

Fixes current issues with RST helpers added to TOC here: https://docs.zephyrproject.org/latest/boards/x86/index.html