### PR TITLE
soc: arm: nxp_imx: introduce ROM ramloader feature

### DIFF
--- a/dts/arm/nxp/nxp_rt5xx.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx.dtsi
@@ -8,8 +8,9 @@
 
 / {
 	soc {
-		sram: sram@30018000 {
-			ranges = <0x20180000 0x30180000 0x300000>;
+		sram: sram@30000000 {
+			ranges = <0x0 0x10000000 0x500000
+				0x20000000 0x30000000 0x500000>;
 		};
 
 		peripheral: peripheral@50000000 {

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -69,6 +69,20 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	/* RT5XX SRAM partitions are shared
+	 * between code and data. Boards can
+	 * override the reg properties of either sram0 or sram_code nodes to
+	 * change the balance of SRAM allocation.
+	 *
+	 * Note that the sram code region starts at an offset of 0x1B000,
+	 * as the boot ROM will not load code before 0x1C000. The first
+	 * 0x1000 of the image will contain the boot header.
+	 */
+	sram_code: memory@1b000 {
+		compatible = "mmio-sram";
+		reg = <0x1b000 DT_SIZE_K(1428)>;
+	};
+
 	sram0: memory@20180000 {
 		compatible = "mmio-sram";
 		reg = <0x20180000 DT_SIZE_K(3072)>;

--- a/dts/arm/nxp/nxp_rt5xx_ns.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_ns.dtsi
@@ -8,8 +8,9 @@
 
 / {
 	soc {
-		sram: sram@20180000 {
-			ranges = <0x20180000 0x20180000 0x300000>;
+		sram: sram@20000000 {
+			ranges = <0x0 0x0 0x500000
+				0x20000000 0x20000000 0x500000>;
 		};
 
 		peripheral: peripheral@40000000 {

--- a/dts/arm/nxp/nxp_rt6xx.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx.dtsi
@@ -8,8 +8,9 @@
 
 / {
 	soc {
-		sram: sram@30018000 {
-			ranges = <0x20180000 0x30180000 0x300000>;
+		sram: sram@30000000 {
+			ranges = <0x0 0x10000000 0x500000
+				0x20000000 0x30000000 0x500000>;
 		};
 
 		peripheral: peripheral@50000000 {

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -53,6 +53,20 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	/* RT6XX SRAM partitions are shared
+	 * between code and data. Boards can
+	 * override the reg properties of either sram0 or sram_code nodes to
+	 * change the balance of SRAM allocation.
+	 *
+	 * Note that the sram code region starts at an offset of 0x1B000,
+	 * as the boot ROM will not load code before 0x1C000. The first
+	 * 0x1000 of the image will contain the boot header.
+	 */
+	sram_code: memory@1b000 {
+		compatible = "mmio-sram";
+		reg = <0x1b000 DT_SIZE_K(1428)>;
+	};
+
 	sram0: memory@20180000 {
 		compatible = "mmio-sram";
 		reg = <0x20180000 DT_SIZE_K(3072)>;

--- a/dts/arm/nxp/nxp_rt6xx_ns.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_ns.dtsi
@@ -8,8 +8,9 @@
 
 / {
 	soc {
-		sram: sram@20180000 {
-			ranges = <0x20180000 0x20180000 0x300000>;
+		sram: sram@20000000 {
+			ranges = <0x0 0x0 0x500000
+				0x20000000 0x20000000 0x500000>;
 		};
 
 		peripheral: peripheral@40000000 {

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -795,6 +795,23 @@ config NXP_IMX_EXTERNAL_SDRAM
 	  an MPU region will be defined to disable cached access to the
 	  SDRAM memory space.
 
+config NXP_IMX_RT_ROM_RAMLOADER
+	depends on !FLASH_MCUX_FLEXSPI_XIP && NXP_IMX_RT_BOOT_HEADER
+	# Required so that debugger will load image to correct offset
+	select BUILD_OUTPUT_HEX
+	bool "Create output image that IMX RT ROM can load from FlexSPI to ram"
+	help
+	  Builds an output image that the IMX RT BootROM can load from the
+	  FlexSPI boot device into RAM region. The image will be loaded
+	  from FLEXSPI into the region specified by `zephyr,flash` node.
+
+# Setup LMA adjustment if using the RAMLOADER feature of ROM
+FLASH_CHOSEN := zephyr,flash
+FLASH_BASE := $(dt_chosen_reg_addr_hex,$(FLASH_CHOSEN))
+FLEXSPI_BASE := $(dt_node_reg_addr_hex,/soc/spi@402a8000,1)
+config BUILD_OUTPUT_ADJUST_LMA
+	default "$(FLEXSPI_BASE) - $(FLASH_BASE)" if NXP_IMX_RT_ROM_RAMLOADER
+
 config SECOND_CORE_MCUX
 	bool "Dual core operation on the RT11xx series"
 	depends on SOC_SERIES_IMX_RT11XX

--- a/soc/arm/nxp_imx/rt5xx/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt5xx/Kconfig.soc
@@ -101,7 +101,26 @@ config IMAGE_VECTOR_TABLE_OFFSET
 	  the application entry point and device configuration data. The boot
 	  ROM requires a fixed IVT offset for each type of boot device.
 
+config NXP_IMX_RT_ROM_RAMLOADER
+	depends on !FLASH_MCUX_FLEXSPI_XIP
+	# Required so that debugger will load image to correct offset
+	select BUILD_OUTPUT_HEX
+	bool "Create output image that IMX RT ROM can load from FlexSPI to ram"
+	help
+	  Builds an output image that the IMX RT BootROM can load from the
+	  FlexSPI boot device into RAM region. The image will be loaded
+	  from FLEXSPI0 into the region specified by `zephyr,flash` node.
+
+# Setup LMA adjustment if using the RAMLOADER feature of ROM
+FLASH_CHOSEN := zephyr,flash
+FLASH_BASE := $(dt_chosen_reg_addr_hex,$(FLASH_CHOSEN))
+FLEXSPI_BASE := $(dt_node_reg_addr_hex,/soc/spi@134000,1)
+config BUILD_OUTPUT_ADJUST_LMA
+	default "$(FLEXSPI_BASE) - $(FLASH_BASE)" if NXP_IMX_RT_ROM_RAMLOADER
+
 endif # NXP_IMX_RT5XX_BOOT_HEADER
+
+
 
 config IMXRT5XX_CODE_CACHE
 	bool "Code cache"

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.soc
@@ -107,6 +107,23 @@ config IMAGE_VECTOR_TABLE_OFFSET
 	  the application entry point and device configuration data. The boot
 	  ROM requires a fixed IVT offset for each type of boot device.
 
+config NXP_IMX_RT_ROM_RAMLOADER
+	depends on !FLASH_MCUX_FLEXSPI_XIP
+	# Required so that debugger will load image to correct offset
+	select BUILD_OUTPUT_HEX
+	bool "Create output image that IMX RT ROM can load from FlexSPI to ram"
+	help
+	  Builds an output image that the IMX RT BootROM can load from the
+	  FlexSPI boot device into RAM region. The image will be loaded
+	  from FLEXSPI into the region specified by `zephyr,flash` node.
+
+# Setup LMA adjustment if using the RAMLOADER feature of ROM
+FLASH_CHOSEN := zephyr,flash
+FLASH_BASE := $(dt_chosen_reg_addr_hex,$(FLASH_CHOSEN))
+FLEXSPI_BASE := $(dt_node_reg_addr_hex,/soc/spi@134000,1)
+config BUILD_OUTPUT_ADJUST_LMA
+	default "$(FLEXSPI_BASE) - $(FLASH_BASE)" if NXP_IMX_RT_ROM_RAMLOADER
+
 endif # NXP_IMX_RT6XX_BOOT_HEADER
 
 config IMXRT6XX_CODE_CACHE


### PR DESCRIPTION
The iMX RT bootrom allows the user to transparently load images into
RAM regions from flash at boot time by providing a correctly configured
boot header. In particular, if the boot header contains a load address within
RAM, the bootroom will automatically copy the image to the load address
before executing it.

Introduce CONFIG_NXP_IMX_RT_ROM_RAMLOADER to enable this feature. This
Kconfig will shift the LMA of a image built to run in a RAM region to
reside in the default FlexSPI boot region, which allows the image to be
loaded to the FlexSPI region using west. This is intended to simplify
development of applications executing from RAM on iMX RT based systems.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>