### PR TITLE
MAINTAINERS: storage: Mention eMMC support in doc pages and add decsny as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -564,6 +564,7 @@ Disk:
     - danieldegrasse
   collaborators:
     - jfischer-no
+    - decsny
   files:
     - include/zephyr/storage/disk_access.h
     - include/zephyr/drivers/disk.h

--- a/doc/hardware/peripherals/sdhc.rst
+++ b/doc/hardware/peripherals/sdhc.rst
@@ -16,7 +16,8 @@ SD Host Controller
 
 An SD host controller is a device capable of sending SD commands to an attached
 SD card. These commands can be sent using the native SD protocol, or over SPI.
-the SDHC api is designed to provide a generic way to send commands to and
+Some SD host controllers are also capable of communicating with MMC devices.
+The SDHC api is designed to provide a generic way to send commands to and
 interact with attached SD devices.
 
 Requests

--- a/doc/services/storage/disk/access.rst
+++ b/doc/services/storage/disk/access.rst
@@ -65,6 +65,14 @@ To read and write files and directories, see the :ref:`file_system_api` in
 :zephyr_file:`include/zephyr/fs/fs.h` such as :c:func:`fs_open()`,
 :c:func:`fs_read()`, and :c:func:`fs_write()`.
 
+eMMC Device Support
+*******************
+
+Zephyr also has support for eMMC devices using the Disk Access API.
+MMC in zephyr is implemented using the SD subsystem because the MMC bus
+shares a lot of similarity with the SD bus. MMC controllers also use the
+SDHC device driver API.
+
 Emulated block device on flash partition support
 ************************************************
 


### PR DESCRIPTION
- Add a mention of eMMC support to the disk and SDHC doc pages alongside SD (same api used)

- Add myself as collaborator of storage/disk subsystem to help maintain eMMC which I added last year