### PR TITLE
drivers: sensor: vl53l1x: Allow for SENSOR_CHAN_ALL channel to be used

### DIFF
--- a/drivers/sensor/vl53l1x/vl53l1.c
+++ b/drivers/sensor/vl53l1x/vl53l1.c
@@ -307,7 +307,8 @@ static int vl53l1x_sample_fetch(const struct device *dev,
 	const struct vl53l1x_config *config = dev->config;
 	VL53L1_Error ret;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_DISTANCE);
+	__ASSERT_NO_MSG((chan == SENSOR_CHAN_ALL)
+			|| (chan == SENSOR_CHAN_DISTANCE));
 
 	/* Will immediately stop current measurement */
 	ret = VL53L1_StopMeasurement(&drv_data->vl53l1x);
@@ -339,8 +340,6 @@ static int vl53l1x_channel_get(const struct device *dev,
 {
 	struct vl53l1x_data *drv_data = dev->data;
 	VL53L1_Error ret;
-
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_DISTANCE);
 
 	if (chan != SENSOR_CHAN_DISTANCE) {
 		return -ENOTSUP;


### PR DESCRIPTION
It mirrors the functionality of the vl53l0x driver. Also removes an assert not needed, as the channel is checked.