### PR TITLE
dts: vendor-prefixes: deprecate facebook and add meta

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -202,7 +202,7 @@ evervision	Evervision Electronics Co. Ltd.
 exar	Exar Corporation
 excito	Excito
 ezchip	EZchip Semiconductor
-facebook	Facebook
+facebook	Facebook (deprecated, use meta)
 fairphone	Fairphone B.V.
 faraday	Faraday Technology Corporation
 fastrax	Fastrax Oy
@@ -371,6 +371,7 @@ menlo	Menlo Systems GmbH
 mentor	Mentor Graphics
 meraki	Cisco Meraki, LLC
 merrii	Merrii Technology Co., Ltd.
+meta	Meta Platforms, Inc.
 micrel	Micrel Inc.
 microbit	Micro:bit Educational Foundation
 microchip	Microchip Technology Inc.


### PR DESCRIPTION
Although there are no in-tree users, we will deprecate the `facebook` vendor prefix and add `meta`.

Fixes #61337