### PR TITLE
drivers: memc: rework FlexSPI memc API to better support multiple flash devices

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -504,34 +504,22 @@ static int flash_flexspi_nor_init(const struct device *dev)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
 	uint8_t vendor_id;
-	uint32_t temp_lut[sizeof(flash_flexspi_nor_lut) / sizeof(uint32_t)];
 
 	if (!device_is_ready(data->controller)) {
 		LOG_ERR("Controller device not ready");
 		return -ENODEV;
 	}
 
-	if (!memc_flexspi_is_running_xip(data->controller) &&
-	    memc_flexspi_set_device_config(data->controller, &data->config,
-					   data->port)) {
-		LOG_ERR("Could not set device configuration");
-		return -EINVAL;
+	if (memc_flexspi_is_running_xip(data->controller)) {
+		/* Wait for bus idle before configuring */
+		memc_flexspi_wait_bus_idle(data->controller);
 	}
 
-	/*
-	 * Using the LUT stored in the FlexSPI directly when updating
-	 * the FlexSPI can result in an invalid LUT entry being stored,
-	 * as the LUT itself describes how the FlexSPI should access the flash.
-	 * To resolve this, copy the LUT to a array placed in RAM before
-	 * updating the FlexSPI.
-	 */
-	memcpy(temp_lut, flash_flexspi_nor_lut,
-		sizeof(flash_flexspi_nor_lut));
-
-	if (memc_flexspi_update_lut(data->controller, 0,
-				   (const uint32_t *) temp_lut,
-				   sizeof(temp_lut) / sizeof(uint32_t))) {
-		LOG_ERR("Could not update lut");
+	if (memc_flexspi_set_device_config(data->controller, &data->config,
+	    (const uint32_t *)flash_flexspi_nor_lut,
+	    sizeof(flash_flexspi_nor_lut) / MEMC_FLEXSPI_CMD_SIZE,
+	    data->port)) {
+		LOG_ERR("Could not set device configuration");
 		return -EINVAL;
 	}
 

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -506,34 +506,21 @@ static int flash_flexspi_nor_init(const struct device *dev)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
 	uint8_t vendor_id;
-	uint32_t temp_lut[sizeof(flash_flexspi_nor_lut) / sizeof(uint32_t)];
 
 	if (!device_is_ready(data->controller)) {
 		LOG_ERR("Controller device is not ready");
 		return -ENODEV;
 	}
 
-	if (!memc_flexspi_is_running_xip(data->controller) &&
-	    memc_flexspi_set_device_config(data->controller, &data->config,
-					   data->port)) {
-		LOG_ERR("Could not set device configuration");
-		return -EINVAL;
+	if (memc_flexspi_is_running_xip(data->controller)) {
+		/* Wait for bus idle before configuring */
+		memc_flexspi_wait_bus_idle(data->controller);
 	}
-
-	/*
-	 * Using the LUT stored in the FlexSPI directly when updating
-	 * the FlexSPI can result in an invalid LUT entry being stored,
-	 * as the LUT itself describes how the FlexSPI should access the flash.
-	 * To resolve this, copy the LUT to a array placed in RAM before
-	 * updating the FlexSPI.
-	 */
-	memcpy(temp_lut, flash_flexspi_nor_lut,
-		sizeof(flash_flexspi_nor_lut));
-
-	if (memc_flexspi_update_lut(data->controller, 0,
-				   (const uint32_t *) temp_lut,
-				   sizeof(temp_lut) / sizeof(uint32_t))) {
-		LOG_ERR("Could not update lut");
+	if (memc_flexspi_set_device_config(data->controller, &data->config,
+	    (const uint32_t *)flash_flexspi_nor_lut,
+	    sizeof(flash_flexspi_nor_lut) / MEMC_FLEXSPI_CMD_SIZE,
+	    data->port)) {
+		LOG_ERR("Could not set device configuration");
 		return -EINVAL;
 	}
 

--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -252,12 +252,13 @@ static int memc_flexspi_pm_action(const struct device *dev, enum pm_device_actio
 }
 #endif
 
-#if defined(CONFIG_XIP) && defined(CONFIG_CODE_FLEXSPI)
-#define MEMC_FLEXSPI_CFG_XIP(node_id) DT_SAME_NODE(node_id, DT_NODELABEL(flexspi))
-#elif defined(CONFIG_XIP) && defined(CONFIG_CODE_FLEXSPI2)
-#define MEMC_FLEXSPI_CFG_XIP(node_id) DT_SAME_NODE(node_id, DT_NODELABEL(flexspi2))
-#elif defined(CONFIG_SOC_SERIES_IMX_RT6XX) || defined(CONFIG_SOC_SERIES_IMX_RT5XX)
-#define MEMC_FLEXSPI_CFG_XIP(node_id) DT_SAME_NODE(node_id, DT_NODELABEL(flexspi))
+#if defined(CONFIG_XIP) && defined(CONFIG_FLASH_MCUX_FLEXSPI_XIP)
+/* Checks if image flash base address is in the FlexSPI AHB base region */
+#define MEMC_FLEXSPI_CFG_XIP(node_id)						\
+	((CONFIG_FLASH_BASE_ADDRESS) >= DT_REG_ADDR_BY_IDX(node_id, 1)) &&	\
+	((CONFIG_FLASH_BASE_ADDRESS) < (DT_REG_ADDR_BY_IDX(node_id, 1) +	\
+					DT_REG_SIZE_BY_IDX(node_id, 1)))
+
 #else
 #define MEMC_FLEXSPI_CFG_XIP(node_id) false
 #endif

--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -26,6 +26,8 @@
 	read-while-write hazards. This configuration is not recommended."
 #endif
 
+#define FLEXSPI_MAX_LUT 64U
+
 LOG_MODULE_REGISTER(memc_flexspi, CONFIG_MEMC_LOG_LEVEL);
 
 struct memc_flexspi_buf_cfg {
@@ -34,6 +36,12 @@ struct memc_flexspi_buf_cfg {
 	uint16_t master_id;
 	uint16_t buf_size;
 } __packed;
+
+/* Structure tracking LUT offset and usage per each port */
+struct port_lut {
+	uint8_t lut_offset;
+	uint8_t lut_used;
+};
 
 /* flexspi device data should be stored in RAM to avoid read-while-write hazards */
 struct memc_flexspi_data {
@@ -49,6 +57,7 @@ struct memc_flexspi_data {
 	flexspi_read_sample_clock_t rx_sample_clock;
 	const struct pinctrl_dev_config *pincfg;
 	size_t size[kFLEXSPI_PortCount];
+	struct port_lut port_luts[kFLEXSPI_PortCount];
 	struct memc_flexspi_buf_cfg *buf_cfg;
 	uint8_t buf_cfg_cnt;
 };
@@ -66,16 +75,6 @@ bool memc_flexspi_is_running_xip(const struct device *dev)
 	struct memc_flexspi_data *data = dev->data;
 
 	return data->xip;
-}
-
-int memc_flexspi_update_lut(const struct device *dev, uint32_t index,
-		const uint32_t *cmd, uint32_t count)
-{
-	struct memc_flexspi_data *data = dev->data;
-
-	FLEXSPI_UpdateLUT(data->base, index, cmd, count);
-
-	return 0;
 }
 
 int memc_flexspi_update_clock(const struct device *dev,
@@ -108,20 +107,65 @@ int memc_flexspi_update_clock(const struct device *dev,
 
 int memc_flexspi_set_device_config(const struct device *dev,
 		const flexspi_device_config_t *device_config,
+		const uint32_t *lut_array,
+		uint8_t lut_count,
 		flexspi_port_t port)
 {
+	flexspi_device_config_t tmp_config;
+	uint32_t tmp_lut[FLEXSPI_MAX_LUT];
 	struct memc_flexspi_data *data = dev->data;
+	const uint32_t *lut_ptr = lut_array;
+	uint8_t lut_used = 0U;
+	unsigned int key = 0;
 
 	if (port >= kFLEXSPI_PortCount) {
 		LOG_ERR("Invalid port number");
 		return -EINVAL;
 	}
 
+	if (data->port_luts[port].lut_used < lut_count) {
+		/* We cannot reuse the existing LUT slot,
+		 * Check if the LUT table will fit into the remaining LUT slots
+		 */
+		for (uint8_t i = 0; i < kFLEXSPI_PortCount; i++) {
+			lut_used += data->port_luts[i].lut_used;
+		}
+
+		if ((lut_used + lut_count) > FLEXSPI_MAX_LUT) {
+			return -ENOBUFS;
+		}
+	}
+
 	data->size[port] = device_config->flashSize * KB(1);
 
-	FLEXSPI_SetFlashConfig(data->base,
-			       (flexspi_device_config_t *) device_config,
-			       port);
+	if (memc_flexspi_is_running_xip(dev)) {
+		/* We need to avoid flash access while configuring the FlexSPI.
+		 * To do this, we will copy the LUT array into stack-allocated
+		 * temporary memory
+		 */
+		memcpy(tmp_lut, lut_array, lut_count * MEMC_FLEXSPI_CMD_SIZE);
+		lut_ptr = tmp_lut;
+	}
+
+	memcpy(&tmp_config, device_config, sizeof(tmp_config));
+	/* Update FlexSPI AWRSEQID and ARDSEQID values based on where the LUT
+	 * array will actually be loaded.
+	 */
+	if (data->port_luts[port].lut_used < lut_count) {
+		/* Update lut offset with new value */
+		data->port_luts[port].lut_offset = lut_used;
+	}
+	data->port_luts[port].lut_used = lut_count;
+	tmp_config.ARDSeqIndex += data->port_luts[port].lut_offset;
+	tmp_config.AWRSeqIndex += data->port_luts[port].lut_offset;
+
+	/* Lock IRQs before reconfiguring FlexSPI, to prevent XIP */
+	key = irq_lock();
+
+	FLEXSPI_SetFlashConfig(data->base, &tmp_config, port);
+	FLEXSPI_UpdateLUT(data->base, data->port_luts[port].lut_offset,
+			  lut_ptr, lut_count);
+	irq_unlock(key);
 
 	return 0;
 }
@@ -139,7 +183,11 @@ int memc_flexspi_transfer(const struct device *dev,
 		flexspi_transfer_t *transfer)
 {
 	struct memc_flexspi_data *data = dev->data;
-	status_t status = FLEXSPI_TransferBlocking(data->base, transfer);
+	status_t status;
+
+	/* Adjust transfer LUT index based on port */
+	transfer->seqIndex += data->port_luts[transfer->port].lut_offset;
+	status = FLEXSPI_TransferBlocking(data->base, transfer);
 
 	if (status != kStatus_Success) {
 		LOG_ERR("Transfer error: %d", status);
@@ -161,7 +209,7 @@ void *memc_flexspi_get_ahb_address(const struct device *dev,
 	}
 
 	for (i = 0; i < port; i++) {
-		offset += data->size[port];
+		offset += data->size[i];
 	}
 
 	return data->ahb_base + offset;

--- a/drivers/memc/memc_mcux_flexspi.h
+++ b/drivers/memc/memc_mcux_flexspi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 NXP
+ * Copyright 2020,2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,25 +15,94 @@ enum memc_flexspi_clock_t {
 	MEMC_FLEXSPI_CLOCK_42M,
 };
 
+/* Size of a command in the LUT table */
+#define MEMC_FLEXSPI_CMD_SIZE 4U
+
+/**
+ * @brief Wait for the FlexSPI bus to be idle
+ *
+ * Waits for the FlexSPI bus to be idle. Can be used when reconfiguring
+ * the FlexSPI to make sure no flash access is occurring before changing
+ * settings.
+ *
+ * @param dev: FlexSPI device
+ */
 void memc_flexspi_wait_bus_idle(const struct device *dev);
 
+/**
+ * @brief Check if FlexSPI is being used in XIP mode.
+ *
+ * Checks if the FlexSPI is being used for code execution in the current
+ * application.
+ *
+ * @param dev: FlexSPI device
+ * @retval true if FlexSPI being used for XIP
+ */
 bool memc_flexspi_is_running_xip(const struct device *dev);
 
-int memc_flexspi_update_lut(const struct device *dev, uint32_t index,
-		const uint32_t *cmd, uint32_t count);
-
+/**
+ * @brief Update clock selection of the FlexSPI device
+ *
+ * Updates clock selection of the FlexSPI device to a new clock speed.
+ *
+ * @param dev: FlexSPI device
+ * @param device_config: External device configuration.
+ * @param port: FlexSPI port to use for this external device
+ * @param clock: new clock selection to apply
+ * @return 0 on success, negative value on failure
+ */
 int memc_flexspi_update_clock(const struct device *dev,
 		flexspi_device_config_t *device_config,
 		flexspi_port_t port, enum memc_flexspi_clock_t clock);
 
+/**
+ * @brief configure new FlexSPI device
+ *
+ * Configures new device on the FlexSPI bus.
+ * @param dev: FlexSPI device
+ * @param device_config: External device configuration.
+ * @param lut_array: Lookup table of FlexSPI flash commands for device
+ * @param lut_count: number of command entries (16 bytes each) in LUT
+ * @param port: FlexSPI port to use for this external device
+ * @return 0 on success, negative value on failure
+ */
 int memc_flexspi_set_device_config(const struct device *dev,
 		const flexspi_device_config_t *device_config,
+		const uint32_t *lut_array,
+		uint8_t lut_count,
 		flexspi_port_t port);
 
+
+/**
+ * @brief Perform software reset of FlexSPI
+ *
+ * Software reset of FlexSPI. Does not clear configuration registers.
+ * @param dev: FlexSPI device
+ * @return 0 on success, negative value on failure
+ */
 int memc_flexspi_reset(const struct device *dev);
 
+/**
+ * @brief Send blocking IP transfer
+ *
+ * Send blocking IP transfer using FlexSPI.
+ * @param dev: FlexSPI device
+ * @param transfer: FlexSPI transfer. seqIndex should be set  as though the
+ *                  LUT array was loaded at offset 0.
+ * @return 0 on success, negative value on failure
+ */
 int memc_flexspi_transfer(const struct device *dev,
 		flexspi_transfer_t *transfer);
 
+/**
+ * @brief Get AHB address for FlexSPI port
+ *
+ * Get AHB address for FlexSPI port. This address is memory mapped, and can be
+ * read from (and written to, for PSRAM) as though it were internal memory.
+ * @param dev: FlexSPI device
+ * @param port: FlexSPI port external device is on
+ * @param offset: byte offset from start of device to get AHB address for
+ * @return 0 on success, negative value on failure
+ */
 void *memc_flexspi_get_ahb_address(const struct device *dev,
 		flexspi_port_t port, off_t offset);

--- a/drivers/memc/memc_mcux_flexspi_aps6408l.c
+++ b/drivers/memc/memc_mcux_flexspi_aps6408l.c
@@ -215,15 +215,10 @@ static int memc_flexspi_aps6408l_init(const struct device *dev)
 	}
 
 	if (memc_flexspi_set_device_config(data->controller, &config->config,
-					   config->port)) {
+	    (const uint32_t *) memc_flexspi_aps6408l_lut,
+	    sizeof(memc_flexspi_aps6408l_lut) / MEMC_FLEXSPI_CMD_SIZE,
+	    config->port)) {
 		LOG_ERR("Could not set device configuration");
-		return -EINVAL;
-	}
-
-	if (memc_flexspi_update_lut(data->controller, 0,
-				    (const uint32_t *) memc_flexspi_aps6408l_lut,
-				    sizeof(memc_flexspi_aps6408l_lut) / 4)) {
-		LOG_ERR("Could not update lut");
 		return -EINVAL;
 	}
 

--- a/drivers/memc/memc_mcux_flexspi_s27ks0641.c
+++ b/drivers/memc/memc_mcux_flexspi_s27ks0641.c
@@ -122,15 +122,10 @@ static int memc_flexspi_s27ks0641_init(const struct device *dev)
 	}
 
 	if (memc_flexspi_set_device_config(data->controller, &config->config,
-					   config->port)) {
+	    (const uint32_t *) memc_flexspi_s27ks0641_lut,
+	    sizeof(memc_flexspi_s27ks0641_lut) / MEMC_FLEXSPI_CMD_SIZE,
+	    config->port)) {
 		LOG_ERR("Could not set device configuration");
-		return -EINVAL;
-	}
-
-	if (memc_flexspi_update_lut(data->controller, 0,
-				    (const uint32_t *) memc_flexspi_s27ks0641_lut,
-				    sizeof(memc_flexspi_s27ks0641_lut) / 4)) {
-		LOG_ERR("Could not update lut");
 		return -EINVAL;
 	}
 

--- a/drivers/memc/memc_mcux_flexspi_w956a8mbya.c
+++ b/drivers/memc/memc_mcux_flexspi_w956a8mbya.c
@@ -114,15 +114,10 @@ static int memc_flexspi_w956a8mbya_init(const struct device *dev)
 	}
 
 	if (memc_flexspi_set_device_config(data->controller, &config->config,
-					   config->port)) {
+	    (const uint32_t *) memc_flexspi_w956a8mbya_lut,
+	    sizeof(memc_flexspi_w956a8mbya_lut) / MEMC_FLEXSPI_CMD_SIZE,
+	    config->port)) {
 		LOG_ERR("Could not set device configuration");
-		return -EINVAL;
-	}
-
-	if (memc_flexspi_update_lut(data->controller, 0,
-				    (const uint32_t *) memc_flexspi_w956a8mbya_lut,
-				    sizeof(memc_flexspi_w956a8mbya_lut) / 4)) {
-		LOG_ERR("Could not update lut");
 		return -EINVAL;
 	}
 

--- a/samples/drivers/memc/CMakeLists.txt
+++ b/samples/drivers/memc/CMakeLists.txt
@@ -5,4 +5,9 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(memc)
 
+
+if(CONFIG_MEMC_MCUX_FLEXSPI)
+  target_include_directories(app PRIVATE ${ZEPHYR_BASE}/drivers/memc)
+endif()
+
 target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/memc/src/main.c
+++ b/samples/drivers/memc/src/main.c
@@ -7,8 +7,11 @@
 #include <zephyr/kernel.h>
 
 #if DT_HAS_COMPAT_STATUS_OKAY(nxp_imx_flexspi)
-/* FlexSPI memory mapped region is second register property of parent dev */
-#define MEMC_BASE DT_REG_ADDR_BY_IDX(DT_PARENT(DT_ALIAS(sram_ext)), 1)
+/* Use memc API to get AHB base address for the device */
+#include "memc_mcux_flexspi.h"
+#define FLEXSPI_DEV DEVICE_DT_GET(DT_PARENT(DT_ALIAS(sram_ext)))
+#define MEMC_PORT DT_REG_ADDR(DT_ALIAS(sram_ext))
+#define MEMC_BASE memc_flexspi_get_ahb_address(FLEXSPI_DEV, MEMC_PORT, 0)
 #define MEMC_SIZE (DT_PROP(DT_ALIAS(sram_ext), size) / 8)
 #endif
 
@@ -49,7 +52,7 @@ int main(void)
 	for (uint32_t i = 0; i < BUF_SIZE; i++) {
 		memc_write_buffer[i] = (uint8_t)i;
 	}
-	printk("Writing to memory region with base 0x%0x, size 0x%0x\n\n",
+	printk("Writing to memory region with base %p, size 0x%0x\n\n",
 		MEMC_BASE, MEMC_SIZE);
 	/* Copy write buffer into memc region */
 	for (i = 0, j = 0; j < (MEMC_SIZE / BUF_SIZE); i += BUF_SIZE, j++) {


### PR DESCRIPTION
Rework the FlexSPI MEMC API in order to better support multiple flash devices. This change requires that the flash chip's port and LUT table be configured in one API call, so that the memc driver can dynamically select the LUT offset to use for a given port

The advantage to this approach is that multiple devices on a FlexSPI bus no longer need to dynamically set their LUT sequence indices when setting up transfers. Instead, all devices can initiate transfers as though their LUT starts at offset 0, and the memc driver will select the correct LUT offset for the transfer based on the port.

This change has been verified on the following boards:

- RT1060: validated with MCUBoot (flash_mcux_flexspi_nor.c)
- RT1050: validated with MCUBoot (flash_mcux_flexspi_hyperflash.)
- RT685: validated with MCUBoot (flash_mcux_flexspi_mx25um51345g.c)
- RT595: validated with memc sample (memc_mcux_flexspi_aps6408l.c)