### PR TITLE
soc: arm: npcx: introduce npcx4 soc driver

### DIFF
--- a/drivers/flash/flash_npcx_fiu_qspi.h
+++ b/drivers/flash/flash_npcx_fiu_qspi.h
@@ -19,6 +19,12 @@ extern "C" {
 #define NPCX_UMA_ACCESS_READ  BIT(1)
 #define NPCX_UMA_ACCESS_ADDR  BIT(2)
 
+/* Valid value of Dn_NADDRB that sets the number of address bytes in a transaction */
+#define NPCX_DEV_NUM_ADDR_1BYTE 1
+#define NPCX_DEV_NUM_ADDR_2BYTE 2
+#define NPCX_DEV_NUM_ADDR_3BYTE 3
+#define NPCX_DEV_NUM_ADDR_4BYTE 4
+
 /* UMA operation configuration for a SPI device */
 struct npcx_uma_cfg {
 	uint8_t opcode;

--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -115,6 +115,14 @@
 			apb3-prescaler = <8>; /* APB3_CLK runs at 15MHz */
 			apb4-prescaler = <8>; /* APB4_CLK runs at 15MHz */
 			ram-pd-depth = <8>; /* Valid bit-depth of RAM_PDn reg */
+			pwdwn-ctl-val = <0xfb
+					 0xff
+					 0x1f /* No GDMA1_PD/GDMA2_PD */
+					 0xff
+					 0xfa
+					 0x7f /* No ESPI_PD */
+					 0xff
+					 0xcf>; /* No FIU_PD */
 		};
 
 		/* Wake-up input source mapping for GPIOs in npcx4 series */

--- a/dts/arm/nuvoton/npcx/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7.dtsi
@@ -94,6 +94,13 @@
 			apb2-prescaler = <6>; /* APB2_CLK runs at 15MHz */
 			apb3-prescaler = <6>; /* APB3_CLK runs at 15MHz */
 			ram-pd-depth = <12>; /* Valid bit-depth of RAM_PDn reg */
+			pwdwn-ctl-val = <0xfb /* No FIU_PD */
+					 0xff
+					 0x1f /* No GDMA_PD */
+					 0xff
+					 0xfa
+					 0x7f /* No ESPI_PD */
+					 0xe7>;
 		};
 
 		/* Wake-up input source mapping for GPIOs in npcx7 series */

--- a/dts/arm/nuvoton/npcx/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9.dtsi
@@ -114,6 +114,14 @@
 			apb3-prescaler = <6>; /* APB3_CLK runs at 15MHz */
 			apb4-prescaler = <6>; /* APB4_CLK runs at 15MHz */
 			ram-pd-depth = <15>; /* Valid bit-depth of RAM_PDn reg */
+			pwdwn-ctl-val = <0xfb /* No FIU_PD */
+					 0xff
+					 0x1f /* No GDMA_PD */
+					 0xff
+					 0xfa
+					 0x7f /* No ESPI_PD */
+					 0xff
+					 0x31>;
 		};
 
 		/* Wake-up input source mapping for GPIOs in npcx9 series */

--- a/dts/bindings/clock/nuvoton,npcx-pcc.yaml
+++ b/dts/bindings/clock/nuvoton,npcx-pcc.yaml
@@ -32,6 +32,7 @@ properties:
     description: |
       Default frequency in Hz for HFCG output clock (OFMCLK). Currently,
       only the following values are allowed:
+        120000000, 120 MHz
         100000000, 100 MHz
         96000000, 96 MHz
         90000000, 90 MHz
@@ -39,9 +40,8 @@ properties:
         66000000, 66 MHz
         50000000, 50 MHz
         48000000, 48 MHz
-        40000000, 40 MHz (default value after reset)
-        33000000, 33 MHz
     enum:
+      - 120000000
       - 100000000
       - 96000000
       - 90000000
@@ -49,8 +49,6 @@ properties:
       - 66000000
       - 50000000
       - 48000000
-      - 40000000
-      - 33000000
 
   core-prescaler:
     type: int
@@ -208,6 +206,7 @@ properties:
   ram-pd-depth:
     type: int
     enum:
+      - 8
       - 12
       - 15
     description: |
@@ -215,6 +214,13 @@ properties:
       Each bit in RAM_PDn can power down the relevant RAM block by setting
       itself to 1 for better power consumption and this valid bit-depth
       varies in different NPCX series.
+
+  pwdwn-ctl-val:
+    type: array
+    required: true
+    description: |
+      Power-down (turn off clock) the modules during system initialization for
+      better power consumption.
 
 clock-cells:
   - bus

--- a/include/zephyr/dt-bindings/clock/npcx_clock.h
+++ b/include/zephyr/dt-bindings/clock/npcx_clock.h
@@ -18,6 +18,8 @@
 #define NPCX_CLOCK_BUS_APB4        8
 #define NPCX_CLOCK_BUS_AHB6        9
 #define NPCX_CLOCK_BUS_FMCLK       10
+#define NPCX_CLOCK_BUS_FIU0        NPCX_CLOCK_BUS_FIU
+#define NPCX_CLOCK_BUS_FIU1        11
 
 /* clock enable/disable references */
 #define NPCX_PWDWN_CTL1            0

--- a/soc/arm/nuvoton_npcx/Kconfig
+++ b/soc/arm/nuvoton_npcx/Kconfig
@@ -42,6 +42,8 @@ config NPCX_HEADER_CHIP
 	default "npcx9m3" if SOC_NPCX9M3F
 	default "npcx9m6" if SOC_NPCX9M6F
 	default "npcx9m7" if SOC_NPCX9M7F
+	default "npcx4m3" if SOC_NPCX4M3F
+	default "npcx4m8" if SOC_NPCX4M8F
 
 choice NPCX_HEADER_SPI_MAX_CLOCK_CHOICE
 	prompt "Clock rate to use for SPI flash"

--- a/soc/arm/nuvoton_npcx/common/ecst/ecst.py
+++ b/soc/arm/nuvoton_npcx/common/ecst/ecst.py
@@ -213,8 +213,8 @@ def _check_chip(output, ecst_args):
 
     if ecst_args.chip_name == INVALID_INPUT:
         message = f'Invalid chip name, '
-        message += "should be npcx9m8, npcx9m7, npcx9m6, npcx7m7," \
-                   " npcx7m6, npcx7m5, npcx5m5 or npcx5m6."
+        message += "should be npcx4m3, npcx4m8, npcx9m8, npcx9m7, npcx9m6, " \
+                   "npcx7m7, npcx7m6, npcx7m5."
         _exit_with_failure_delete_file(output, message)
 
 def _set_anchor(output, ecst_args):
@@ -924,7 +924,7 @@ def _crc_update(cur, crc, table):
     :param crc
     :param table
     """
-    l_crc = (0x000000ff & cur)
+    l_crc = 0x000000ff & cur
 
     tmp = crc ^ l_crc
     crc = (crc >> 8) ^ table[(tmp & 0xff)]

--- a/soc/arm/nuvoton_npcx/common/ecst/ecst_args.py
+++ b/soc/arm/nuvoton_npcx/common/ecst/ecst_args.py
@@ -53,6 +53,8 @@ CHIPS_INFO = {
     'npcx9m3': {'ram_address': 0x10080000, 'ram_size': 0x50000},
     'npcx9m6': {'ram_address': 0x10090000, 'ram_size': 0x40000},
     'npcx9m7': {'ram_address': 0x10070000, 'ram_size': 0x60000},
+    'npcx4m3': {'ram_address': 0x10088000, 'ram_size': 0x50000},
+    'npcx4m8': {'ram_address': 0x10060000, 'ram_size': 0x7c800},
 }
 DEFAULT_CHIP = 'npcx7m6'
 

--- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
+++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
@@ -241,15 +241,23 @@ static inline uint32_t npcx_devalt_lk_offset(uint32_t alt_lk_no)
 
 static inline uint32_t npcx_pupd_en_offset(uint32_t pupd_en_no)
 {
-	return 0x28 + pupd_en_no;
+	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7) || IS_ENABLED(CONFIG_SOC_SERIES_NPCX9)) {
+		return 0x28 + pupd_en_no;
+	} else { /* NPCX4 and later series */
+		return 0x2b + pupd_en_no;
+	}
 }
 
 static inline uint32_t npcx_lv_gpio_ctl_offset(uint32_t ctl_no)
 {
-	if (ctl_no < 5) {
-		return 0x02a + ctl_no;
-	} else {
-		return 0x026 + ctl_no - 5;
+	if (IS_ENABLED(CONFIG_SOC_SERIES_NPCX7) || IS_ENABLED(CONFIG_SOC_SERIES_NPCX9)) {
+		if (ctl_no < 5) {
+			return 0x02a + ctl_no;
+		} else {
+			return 0x026 + ctl_no - 5;
+		}
+	} else { /* NPCX4 and later series */
+		return 0x150 + ctl_no;
 	}
 }
 

--- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
+++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
@@ -1533,10 +1533,24 @@ struct fiu_reg {
 	volatile uint8_t SPI1_DEV;
 	/* 0x03E-0x3F */
 	volatile uint8_t reserved9[2];
+#elif defined(CONFIG_SOC_SERIES_NPCX4)
+	/* 0x034: UMA address byte 0-3 */
+	volatile uint32_t UMA_AB0_3;
+	/* 0x038-0x3B */
+	volatile uint8_t reserved8[4];
+	/* 0x03C: SPI Device */
+	volatile uint8_t SPI_DEV;
+	/* 0x03D */
+	volatile uint8_t reserved9;
+	/* 0x03E */
+	volatile uint8_t SPI_DEV_SIZE;
+	/* 0x03F */
+	volatile uint8_t reserved10;
 #endif
 };
 
 /* FIU register fields */
+#define NPCX_BURST_CFG_SPI_DEV_SEL       FIELD(4, 2)
 #define NPCX_RESP_CFG_IAD_EN             0
 #define NPCX_RESP_CFG_DEV_SIZE_EX        2
 #define NPCX_RESP_CFG_QUAD_EN            3
@@ -1550,12 +1564,20 @@ struct fiu_reg {
 #define NPCX_UMA_ECTS_SW_CS1             1
 #define NPCX_UMA_ECTS_SEC_CS             2
 #define NPCX_UMA_ECTS_UMA_LOCK           3
+#define NPCX_UMA_ECTS_UMA_ADDR_SIZE      FIELD(4, 3)
 #define NPCX_SPI1_DEV_FOUR_BADDR_CS10    6
 #define NPCX_SPI1_DEV_FOUR_BADDR_CS11    7
 #define NPCX_SPI1_DEV_SPI1_LO_DEV_SIZE   FIELD(0, 4)
+#if defined(CONFIG_SOC_SERIES_NPCX9)
 #define NPCX_FIU_EXT_CFG_SPI1_2DEV       7
+#else
+#define NPCX_FIU_EXT_CFG_SPI1_2DEV       6
+#endif
 #define NPCX_FIU_EXT_CFG_SET_DMM_EN      2
 #define NPCX_FIU_EXT_CFG_SET_CMD_EN      1
+#define NPCX_SPI_DEV_NADDRB              FIELD(5, 3)
+
+#define NPCX_MSR_IE_CFG_UMA_BLOCK        3
 
 /* UMA fields selections */
 #define UMA_FLD_ADDR     BIT(NPCX_UMA_CTS_A_SIZE)  /* 3-bytes ADR field */

--- a/soc/arm/nuvoton_npcx/common/registers.c
+++ b/soc/arm/nuvoton_npcx/common/registers.c
@@ -162,7 +162,7 @@ NPCX_REG_OFFSET_CHECK(ps2_reg, PSISIG, 0x008);
 NPCX_REG_OFFSET_CHECK(ps2_reg, PSIEN, 0x00a);
 
 /* FIU register structure check */
-#if defined(CONFIG_SOC_SERIES_NPCX9)
+#if defined(CONFIG_SOC_SERIES_NPCX9) || defined(CONFIG_SOC_SERIES_NPCX4)
 NPCX_REG_SIZE_CHECK(fiu_reg, 0x040);
 #else
 NPCX_REG_SIZE_CHECK(fiu_reg, 0x034);

--- a/soc/arm/nuvoton_npcx/common/soc_clock.h
+++ b/soc/arm/nuvoton_npcx/common/soc_clock.h
@@ -51,15 +51,28 @@ struct npcx_clk_cfg {
 #endif /* !CONFIG_SOC_SERIES_NPCX7 */
 #endif
 
+/* Construct a uint8_t array from 'pwdwn-ctl-val' prop for PWDWN_CTL initialization. */
+#define NPCX_PWDWN_CTL_ITEMS_INIT(node, prop, idx) DT_PROP_BY_IDX(node, prop, idx),
+#define NPCX_PWDWN_CTL_INIT DT_FOREACH_PROP_ELEM(DT_NODELABEL(pcc), \
+				pwdwn_ctl_val, NPCX_PWDWN_CTL_ITEMS_INIT)
+
 /*
  * NPCX7 and later series clock tree macros:
  * (Please refer Figure 58. for more information.)
  *
- * Suggestion:
- * - OFMCLK > 50MHz, XF_RANGE should be 1, else 0.
- * - CORE_CLK > 50MHz, AHB6DIV should be 1, else 0.
- * - CORE_CLK > 50MHz, FIUDIV should be 1, else 0.
+ * Maximum OFMCLK in npcx7/9 series is 100MHz,
+ * Maximum OFMCLK in npcx4 series is 120MHz,
+ *
+ * Suggestion for npcx series:
+ * - OFMCLK   > MAX_OFMCLK/2, XF_RANGE should be 1, else 0.
+ * - CORE_CLK > MAX_OFMCLK/2, AHB6DIV should be 1, else 0.
+ * - CORE_CLK > MAX_OFMCLK/2, FIUDIV should be 1, else 0.
  */
+#if defined(CONFIG_SOC_SERIES_NPCX4)
+#define MAX_OFMCLK 120000000
+#else
+#define MAX_OFMCLK 100000000
+#endif /* CONFIG_SOC_SERIES_NPCX4 */
 
 /* Core domain clock */
 #define CORE_CLK (OFMCLK / DT_PROP(DT_NODELABEL(pcc), core_prescaler))
@@ -67,8 +80,8 @@ struct npcx_clk_cfg {
 #define LFCLK 32768
 
 /* FMUL clock */
-#if (OFMCLK > 50000000)
-#define FMCLK (OFMCLK / 2) /* FMUL clock = OFMCLK/2 if OFMCLK > 50MHz */
+#if (OFMCLK > (MAX_OFMCLK / 2))
+#define FMCLK (OFMCLK / 2) /* FMUL clock = OFMCLK/2 */
 #else
 #define FMCLK OFMCLK /* FMUL clock = OFMCLK */
 #endif
@@ -77,17 +90,26 @@ struct npcx_clk_cfg {
 #define APBSRC_CLK OFMCLK
 
 /* AHB6 clock */
-#if (CORE_CLK > 50000000)
-#define AHB6DIV_VAL 1 /* AHB6_CLK = CORE_CLK/2 if CORE_CLK > 50MHz */
+#if (CORE_CLK > (MAX_OFMCLK / 2))
+#define AHB6DIV_VAL 1 /* AHB6_CLK = CORE_CLK/2 */
 #else
 #define AHB6DIV_VAL 0 /* AHB6_CLK = CORE_CLK */
 #endif
+
 /* FIU clock divider */
-#if (CORE_CLK > 50000000)
+#if (CORE_CLK > (MAX_OFMCLK / 2))
 #define FIUDIV_VAL 1 /* FIU_CLK = CORE_CLK/2 */
 #else
 #define FIUDIV_VAL 0 /* FIU_CLK = CORE_CLK */
 #endif
+
+#if defined(CONFIG_SOC_SERIES_NPCX4)
+#if (CORE_CLK > (MAX_OFMCLK / 2))
+#define FIU1DIV_VAL 1 /* FIU1_CLK = CORE_CLK/2 */
+#else
+#define FIU1DIV_VAL 0 /* FIU1_CLK = CORE_CLK */
+#endif
+#endif /* CONFIG_SOC_SERIES_NPCX4 */
 
 /* Get APB clock freq */
 #define NPCX_APB_CLOCK(no) (APBSRC_CLK / (APB##no##DIV_VAL + 1))
@@ -96,8 +118,8 @@ struct npcx_clk_cfg {
  * Frequency multiplier M/N value definitions according to the requested
  * OFMCLK (Unit:Hz).
  */
-#if (OFMCLK > 50000000)
-#define HFCGN_VAL    0x82 /* Set XF_RANGE as 1 if OFMCLK > 50MHz */
+#if (OFMCLK > (MAX_OFMCLK / 2))
+#define HFCGN_VAL    0x82 /* Set XF_RANGE as 1 */
 #else
 #define HFCGN_VAL    0x02
 #endif
@@ -125,15 +147,23 @@ struct npcx_clk_cfg {
 #elif (OFMCLK == 48000000)
 #define HFCGMH_VAL   0x0B
 #define HFCGML_VAL   0x72
-#elif (OFMCLK == 40000000)
-#define HFCGMH_VAL   0x09
-#define HFCGML_VAL   0x89
-#elif (OFMCLK == 33000000)
-#define HFCGMH_VAL   0x07
-#define HFCGML_VAL   0xDE
 #else
 #error "Unsupported OFMCLK Frequency"
 #endif
+
+/* Clock prescaler configurations in different series */
+#define VAL_HFCGP   ((FPRED_VAL << 4) | AHB6DIV_VAL)
+#if defined(FIU1DIV_VAL)
+#define VAL_HFCBCD  ((FIU1DIV_VAL << 4) | (FIUDIV_VAL << 2))
+#else
+#define VAL_HFCBCD  (FIUDIV_VAL << 4)
+#endif /* FIU1DIV_VAL */
+#define VAL_HFCBCD1 (APB1DIV_VAL | (APB2DIV_VAL << 4))
+#if defined(APB4DIV_VAL)
+#define VAL_HFCBCD2 (APB3DIV_VAL | (APB4DIV_VAL << 4))
+#else
+#define VAL_HFCBCD2 APB3DIV_VAL
+#endif /* APB4DIV_VAL */
 
 /**
  * @brief Function to notify clock driver that backup the counter value of

--- a/soc/arm/nuvoton_npcx/common/soc_clock.h
+++ b/soc/arm/nuvoton_npcx/common/soc_clock.h
@@ -44,11 +44,11 @@ struct npcx_clk_cfg {
 #define APB3DIV_VAL (DT_PROP(DT_NODELABEL(pcc), apb3_prescaler) - 1)
 /* APB4 clock divider if supported */
 #if DT_NODE_HAS_PROP(DT_NODELABEL(pcc), apb4_prescaler)
-#if defined(CONFIG_SOC_SERIES_NPCX9)
+#if !defined(CONFIG_SOC_SERIES_NPCX7) /* Supported in NPCX9 and later series */
 #define APB4DIV_VAL (DT_PROP(DT_NODELABEL(pcc), apb4_prescaler) - 1)
 #else
 #error "APB4 clock divider is not supported but defined in pcc node!"
-#endif
+#endif /* !CONFIG_SOC_SERIES_NPCX7 */
 #endif
 
 /*
@@ -101,7 +101,10 @@ struct npcx_clk_cfg {
 #else
 #define HFCGN_VAL    0x02
 #endif
-#if   (OFMCLK == 100000000)
+#if   (OFMCLK == 120000000)
+#define HFCGMH_VAL   0x0E
+#define HFCGML_VAL   0x4E
+#elif (OFMCLK == 100000000)
 #define HFCGMH_VAL   0x0B
 #define HFCGML_VAL   0xEC
 #elif (OFMCLK == 96000000)

--- a/soc/arm/nuvoton_npcx/npcx4/CMakeLists.txt
+++ b/soc/arm/nuvoton_npcx/npcx4/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_include_directories(${ZEPHYR_BASE}/drivers)
+
+zephyr_sources(
+  soc.c
+)

--- a/soc/arm/nuvoton_npcx/npcx4/Kconfig.defconfig.npcx4m3f
+++ b/soc/arm/nuvoton_npcx/npcx4/Kconfig.defconfig.npcx4m3f
@@ -1,0 +1,11 @@
+# Nuvoton Cortex-M4 Embedded Controller
+
+# Copyright (c) 2023 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NPCX4M3F
+
+config SOC
+	default "npcx4m3f"
+
+endif # SOC_NPCX4M3F

--- a/soc/arm/nuvoton_npcx/npcx4/Kconfig.defconfig.npcx4m8f
+++ b/soc/arm/nuvoton_npcx/npcx4/Kconfig.defconfig.npcx4m8f
@@ -1,0 +1,11 @@
+# Nuvoton Cortex-M4 Embedded Controller
+
+# Copyright (c) 2023 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NPCX4M8F
+
+config SOC
+	default "npcx4m8f"
+
+endif # SOC_NPCX4M8F

--- a/soc/arm/nuvoton_npcx/npcx4/Kconfig.defconfig.series
+++ b/soc/arm/nuvoton_npcx/npcx4/Kconfig.defconfig.series
@@ -1,0 +1,23 @@
+# Nuvoton Cortex-M4 Embedded Controller
+
+# Copyright (c) 2023 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_NPCX4
+
+config SOC_SERIES
+	default "npcx4"
+
+config NUM_IRQS
+	default 128
+
+config CORTEX_M_SYSTICK
+	default !NPCX_ITIM_TIMER
+
+config ESPI_NPCX
+	default y
+	depends on ESPI
+
+source "soc/arm/nuvoton_npcx/npcx4/Kconfig.defconfig.npcx4*"
+
+endif # SOC_SERIES_NPCX4

--- a/soc/arm/nuvoton_npcx/npcx4/Kconfig.series
+++ b/soc/arm/nuvoton_npcx/npcx4/Kconfig.series
@@ -1,0 +1,15 @@
+# Nuvoton Cortex-M4 Embedded Controller NPCX4 series
+
+# Copyright (c) 2023 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_NPCX4
+	bool "Nuvoton NPCX4 Series"
+	select ARM
+	select CPU_CORTEX_M4
+	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_FPU
+	select CPU_HAS_ARM_MPU
+	select SOC_FAMILY_NPCX
+	help
+	  Enable support for Nuvoton NPCX4 series

--- a/soc/arm/nuvoton_npcx/npcx4/Kconfig.soc
+++ b/soc/arm/nuvoton_npcx/npcx4/Kconfig.soc
@@ -1,0 +1,16 @@
+# Nuvoton NPCX4 EC series
+
+# Copyright (c) 2023 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+choice
+	prompt "NPCX4 Selection"
+	depends on SOC_SERIES_NPCX4
+
+config SOC_NPCX4M3F
+	bool "NPCX4M3F"
+
+config SOC_NPCX4M8F
+	bool "NPCX4M8F"
+
+endchoice

--- a/soc/arm/nuvoton_npcx/npcx4/linker.ld
+++ b/soc/arm/nuvoton_npcx/npcx4/linker.ld
@@ -1,0 +1,9 @@
+/* linker.ld - Linker command/script file */
+
+/*
+ * Copyright (c) 2023 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/nuvoton_npcx/npcx4/soc.c
+++ b/soc/arm/nuvoton_npcx/npcx4/soc.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <soc.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
+
+static int soc_init(void)
+{
+
+	return 0;
+}
+
+SYS_INIT(soc_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/arm/nuvoton_npcx/npcx4/soc.h
+++ b/soc/arm/nuvoton_npcx/npcx4/soc.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _NUVOTON_NPCX_SOC_H_
+#define _NUVOTON_NPCX_SOC_H_
+
+/* CMSIS required definitions */
+#define __FPU_PRESENT  CONFIG_CPU_HAS_FPU
+#define __MPU_PRESENT  CONFIG_CPU_HAS_ARM_MPU
+
+
+#include <reg/reg_access.h>
+#include <reg/reg_def.h>
+#include <soc_dt.h>
+#include <soc_clock.h>
+#include <soc_pins.h>
+#include <soc_power.h>
+
+#endif /* _NUVOTON_NPCX_SOC_H_ */


### PR DESCRIPTION
This PR adds the drivers for npcx4m3f and npcx4m8f SoCs. Besides maintaining different register offsets of LV_GPIO_CTL and PUPD_EN, It also includes slight changes of clock_control and flash drivers for npcx4 series.

* clock_control driver
 The maximum freq. is up to 120MHz in npcx4. The CL includes:
    - Introduce MAX_OFMCLK for valid clock frequency check
    - Wraps `PWDWN_CTLx` reg initialization based on `pwdwn-ctl-val` prop.
* flash driver
The Flash Interface Unit (FIU) module in npcx4 has significant changes for some advanced applications. We will introduce them later. In this CL, it adds the changes for the following functions that already exist:
    - Configure 3-Byte/4-Byte address mode
    - Add secondary flash selection for Direct-Read-Access mode