### PR TITLE
mm: intel_adsp_tlb: Handle address space conversion warnings with __s…

### DIFF
--- a/drivers/mm/mm_drv_intel_adsp_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_tlb.c
@@ -29,6 +29,7 @@
 #include <zephyr/sys/check.h>
 #include <zephyr/sys/mem_manage.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/debug/sparse.h>
 #include <zephyr/cache.h>
 
 #include <soc.h>
@@ -144,7 +145,7 @@ out:
 int sys_mm_drv_map_region(void *virt, uintptr_t phys,
 			  size_t size, uint32_t flags)
 {
-	void *va = z_soc_cached_ptr(virt);
+	void *va = (__sparse_force void *)z_soc_cached_ptr(virt);
 
 	return sys_mm_drv_simple_map_region(va, phys, size, flags);
 }
@@ -152,7 +153,7 @@ int sys_mm_drv_map_region(void *virt, uintptr_t phys,
 int sys_mm_drv_map_array(void *virt, uintptr_t *phys,
 			 size_t cnt, uint32_t flags)
 {
-	void *va = z_soc_cached_ptr(virt);
+	void *va = (__sparse_force void *)z_soc_cached_ptr(virt);
 
 	return sys_mm_drv_simple_map_array(va, phys, cnt, flags);
 }
@@ -201,7 +202,7 @@ out:
 
 int sys_mm_drv_unmap_region(void *virt, size_t size)
 {
-	void *va = z_soc_cached_ptr(virt);
+	void *va = (__sparse_force void *)z_soc_cached_ptr(virt);
 
 	return sys_mm_drv_simple_unmap_region(va, size);
 }
@@ -273,7 +274,7 @@ int sys_mm_drv_update_page_flags(void *virt, uint32_t flags)
 int sys_mm_drv_update_region_flags(void *virt, size_t size,
 				   uint32_t flags)
 {
-	void *va = z_soc_cached_ptr(virt);
+	void *va = (__sparse_force void *)z_soc_cached_ptr(virt);
 
 	return sys_mm_drv_simple_update_region_flags(va, size, flags);
 }
@@ -282,8 +283,8 @@ int sys_mm_drv_update_region_flags(void *virt, size_t size,
 int sys_mm_drv_remap_region(void *virt_old, size_t size,
 			    void *virt_new)
 {
-	void *va_new = z_soc_cached_ptr(virt_new);
-	void *va_old = z_soc_cached_ptr(virt_old);
+	void *va_new = (__sparse_force void *)z_soc_cached_ptr(virt_new);
+	void *va_old = (__sparse_force void *)z_soc_cached_ptr(virt_old);
 
 	return sys_mm_drv_simple_remap_region(va_old, size, va_new);
 }
@@ -293,8 +294,8 @@ int sys_mm_drv_move_region(void *virt_old, size_t size, void *virt_new,
 {
 	int ret;
 
-	void *va_new = z_soc_cached_ptr(virt_new);
-	void *va_old = z_soc_cached_ptr(virt_old);
+	void *va_new = (__sparse_force void *)z_soc_cached_ptr(virt_new);
+	void *va_old = (__sparse_force void *)z_soc_cached_ptr(virt_old);
 
 	ret = sys_mm_drv_simple_move_region(va_old, size, va_new, phys_new);
 
@@ -313,8 +314,8 @@ int sys_mm_drv_move_array(void *virt_old, size_t size, void *virt_new,
 {
 	int ret;
 
-	void *va_new = z_soc_cached_ptr(virt_new);
-	void *va_old = z_soc_cached_ptr(virt_old);
+	void *va_new = (__sparse_force void *)z_soc_cached_ptr(virt_new);
+	void *va_old = (__sparse_force void *)z_soc_cached_ptr(virt_old);
 
 	ret = sys_mm_drv_simple_move_array(va_old, size, va_new,
 					    phys_new, phys_cnt);


### PR DESCRIPTION
…parse_force

There are various call to z_soc_cached_ptr() which returns values in the cached address space and are stored in temporary variables that are not marked as in the cached address space. This results in sparse complaining about discarding the cached address space attribute. These temporary variables are then passed to other internal memory management related functions which do not have the concept of cached address space (as it is currently Xtensa specific). Because of this, we cannot change the signature of these functions. Instead, we force a change of address space when those temporary variables are being assigned to suppress sparse warnings.

Reported-by: Guennadi Liakhovetski <guennadi.liakhovetski@linux.intel.com>