### PR TITLE
drivers: dai: alh: fix refcount logic for ALH ownership

### DIFF
--- a/drivers/dai/intel/alh/alh.h
+++ b/drivers/dai/intel/alh/alh.h
@@ -107,10 +107,14 @@ struct dai_intel_alh_pdata {
 
 struct dai_intel_alh {
 	uint32_t index;		/**< index */
-	struct k_spinlock lock;	/**< locking mechanism */
-	int sref;		/**< simple ref counter, guarded by lock */
 	struct dai_intel_alh_plat_data plat_data;
 	struct dai_intel_alh_pdata priv_data;
+};
+
+/* Common data for all ALH DAI instances */
+struct dai_alh_global_shared {
+	struct k_spinlock lock;	/**< locking mechanism */
+	int sref;		/**< simple ref counter, guarded by lock */
 };
 
 #endif


### PR DESCRIPTION
Refcounting is used to track ALH block usage and to call alh_claim_ownership()/alh_release_ownership() accordingly. This is however incorrectly done on ALH instance basis, which means when one instance is released, ownership can be released even though one ALH instance is still active.

Fix the logic by tracking ALH usage as a global property which matches the alh_claim_ownership/alh_release_ownership semantics.

Link: https://github.com/thesofproject/sof/issues/7759