### PR TITLE
Bluetooth: ISO: Reject disconnecting pending CIS as peripheral

### DIFF
--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -808,10 +808,17 @@ int bt_iso_cig_terminate(struct bt_iso_cig *cig);
  */
 int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count);
 
-/** @brief Disconnect ISO channel
+/** @brief Disconnect connected ISO channel
  *
- *  Disconnect ISO channel, if the connection is pending it will be
- *  canceled and as a result the channel disconnected() callback is called.
+ *  Disconnect connected ISO channel.
+ *
+ *  If the device is a central and the connection is pending it will be
+ *  canceled and as a result the channel bt_iso_chan_ops.disconnected() callback is called.
+ *
+ *  If the device is a peripheral and the connection is pending it will be rejected, as a peripheral
+ *  shall wait for a CIS Established event (which may trigger a bt_iso_chan_ops.disconnected()
+ *  callback in case of an error).
+ *
  *  Regarding to input parameter, to get details see reference description
  *  to bt_iso_chan_connect() API above.
  *

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -970,6 +970,14 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan)
 		return -EALREADY;
 	}
 
+	if (IS_ENABLED(CONFIG_BT_ISO_PERIPHERAL) && chan->iso->role == BT_HCI_ROLE_PERIPHERAL &&
+	    chan->state == BT_ISO_STATE_CONNECTING) {
+		/* A CIS peripheral is not allowed to disconnect a CIS in the connecting state - It
+		 * has to wait for a CIS Established event
+		 */
+		return -EAGAIN;
+	}
+
 	err = bt_conn_disconnect(chan->iso, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	if (err == 0) {
 		bt_iso_chan_set_state(chan, BT_ISO_STATE_DISCONNECTING);


### PR DESCRIPTION
As per the core spec, the CIS is not allowed to disconnect a CIS if it is pending (i.e. in the connecting state).

Partially fixes https://github.com/zephyrproject-rtos/zephyr/issues/61603 