### PR TITLE
net: sockets: Fix getsockname() fucntion and add tests to cover it

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -2478,13 +2478,12 @@ int zsock_getsockname_ctx(struct net_context *ctx, struct sockaddr *addr,
 {
 	socklen_t newlen = 0;
 
-	/* If we don't have a connection handler, the socket is not bound */
-	if (!ctx->conn_handler) {
-		SET_ERRNO(-EINVAL);
-	}
-
 	if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.family == AF_INET) {
 		struct sockaddr_in addr4 = { 0 };
+
+		if (net_sin_ptr(&ctx->local)->sin_addr == NULL) {
+			SET_ERRNO(-EINVAL);
+		}
 
 		addr4.sin_family = AF_INET;
 		addr4.sin_port = net_sin_ptr(&ctx->local)->sin_port;
@@ -2496,6 +2495,10 @@ int zsock_getsockname_ctx(struct net_context *ctx, struct sockaddr *addr,
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		   ctx->local.family == AF_INET6) {
 		struct sockaddr_in6 addr6 = { 0 };
+
+		if (net_sin6_ptr(&ctx->local)->sin6_addr == NULL) {
+			SET_ERRNO(-EINVAL);
+		}
 
 		addr6.sin6_family = AF_INET6;
 		addr6.sin6_port = net_sin6_ptr(&ctx->local)->sin6_port;

--- a/tests/net/socket/misc/prj.conf
+++ b/tests/net/socket/misc/prj.conf
@@ -34,6 +34,9 @@ CONFIG_ZTEST_NEW_API=y
 # TCP handshake requires more packets
 CONFIG_NET_PKT_TX_COUNT=10
 
+# Lower the TIME_WAIT delay to speed up the test
+CONFIG_NET_TCP_TIME_WAIT_DELAY=100
+
 # User mode requirements
 CONFIG_TEST_USERSPACE=y
 CONFIG_HEAP_MEM_POOL_SIZE=128


### PR DESCRIPTION
This PR relies on FIN handling being fixed in https://github.com/zephyrproject-rtos/zephyr/pull/61353, as this interferes with the tests (the issue (context leak) was already present in the test suite, but it did not manifest itself until new tests involving TCP were added). So DNM for now.

This PR fixes `getsockname()` function operation, and adds tests to cover its functionality. 

Additionally, the PR fixes a corner case encountered in the TCP implementation which prevented the tests from running properly (i. e. tests were leaking net/TCP context, interfering with each other.

Fixes #61545