### PR TITLE
board: riscv: litex_vexriscv: add flash XIP support

### DIFF
--- a/boards/riscv/litex_vexriscv/litex_vexriscv.dts
+++ b/boards/riscv/litex_vexriscv/litex_vexriscv.dts
@@ -15,11 +15,17 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &ram0;
+		zephyr,flash = &flash0;
 	};
 
 	ram0: memory@40000000 {
 		device_type = "memory";
 		reg = <0x40000000 0x10000000>;
+	};
+
+	flash0: flash@20000000 {
+		reg = <0x20000000 0x100000>;
+		compatible = "soc-nv-flash";
 	};
 };
 


### PR DESCRIPTION
Add support for XIP in the LiteX VexRiscv.

This goes along with adding the `--with-spi-flash` to the `make.py` script from https://github.com/litex-hub/zephyr-on-litex-vexriscv

```
$ cd ~/zephyr-on-litex-vexriscv
$ ./make.py --board=lattice_crosslink_nx_evn --build --toolchain=oxide --csr-json=csr.json --with-spi-flash $ litex_json2dts_zephyr --dts=overlay.dts --config=overlay.config csr.json $ cd ~/zephyr-workspace/zephyr
$ xargs <overlay.config west build -p -b litex_vexriscv zephyr/samples/subsys/shell/shell_module -- -DDTC_OVERLAY_FILE="$PWD/overlay.dts"
```

This requires several LiteX pull requests to be merged first:
https://github.com/litex-hub/zephyr-on-litex-vexriscv/pull/13
https://github.com/enjoy-digital/litex/pull/1748