### PR TITLE
C++ support: arch/arm: remove anonymous struct from struct _thread_arch

### DIFF
--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -126,7 +126,7 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #if defined(CONFIG_ARM_STORE_EXC_RETURN) || defined(CONFIG_USERSPACE)
 	thread->arch.mode = 0;
 #if defined(CONFIG_ARM_STORE_EXC_RETURN)
-	thread->arch.mode_exc_return = DEFAULT_EXC_RETURN;
+	thread->arch.s.mode_exc_return = DEFAULT_EXC_RETURN;
 #endif
 #if FP_GUARD_EXTRA_SIZE > 0
 	if ((thread->base.user_options & K_FP_REGS) != 0) {
@@ -202,7 +202,7 @@ static inline void z_arm_thread_stack_info_adjust(struct k_thread *thread,
 uint32_t z_arm_mpu_stack_guard_and_fpu_adjust(struct k_thread *thread)
 {
 	if (((thread->base.user_options & K_FP_REGS) != 0) ||
-		((thread->arch.mode_exc_return & EXC_RETURN_FTYPE) == 0)) {
+		((thread->arch.s.mode_exc_return & EXC_RETURN_FTYPE) == 0)) {
 		/* The thread has been pre-tagged (at creation or later) with
 		 * K_FP_REGS, i.e. it is expected to be using the FPU registers
 		 * (if not already). Activate lazy stacking and program a large

--- a/arch/arm/core/offsets/offsets_aarch32.c
+++ b/arch/arm/core/offsets/offsets_aarch32.c
@@ -36,7 +36,7 @@ GEN_OFFSET_SYM(_thread_arch_t, swap_return_value);
 GEN_OFFSET_SYM(_thread_arch_t, mode);
 #endif
 #if defined(CONFIG_ARM_STORE_EXC_RETURN)
-GEN_OFFSET_SYM(_thread_arch_t, mode_exc_return);
+GEN_NAMED_OFFSET_SYM(_thread_arch_t, s.mode_exc_return, mode_exc_return);
 #endif
 #if defined(CONFIG_USERSPACE)
 GEN_OFFSET_SYM(_thread_arch_t, priv_stack_start);

--- a/include/zephyr/arch/arm/aarch32/thread.h
+++ b/include/zephyr/arch/arm/aarch32/thread.h
@@ -115,7 +115,7 @@ struct _thread_arch {
 			uint8_t mode_bits;
 			uint8_t mode_exc_return;
 			uint16_t mode_reserved2;
-		};
+		} s;
 #endif
 	};
 

--- a/subsys/debug/thread_info.c
+++ b/subsys/debug/thread_info.c
@@ -134,7 +134,7 @@ size_t _kernel_thread_info_offsets[] = {
 	 * then the LSB needs to be restored from mode_exc_return.
 	 */
 	[THREAD_INFO_OFFSET_T_ARM_EXC_RETURN] = offsetof(struct _thread_arch,
-							 mode_exc_return),
+							 s.mode_exc_return),
 #else
 	[THREAD_INFO_OFFSET_T_ARM_EXC_RETURN] = THREAD_INFO_UNIMPLEMENTED,
 #endif /* CONFIG_ARM_STORE_EXC_RETURN */

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -274,7 +274,7 @@ static void alt_thread_entry(void)
 	/* Verify that the _current_ (alt) thread is
 	 * initialized with EXC_RETURN.Ftype set
 	 */
-	zassert_true((_current->arch.mode_exc_return & EXC_RETURN_FTYPE) != 0,
+	zassert_true((_current->arch.s.mode_exc_return & EXC_RETURN_FTYPE) != 0,
 		"Alt thread FPCA flag not clear at initialization\n");
 #if defined(CONFIG_MPU_STACK_GUARD)
 	/* Alt thread is created with K_FP_REGS set, so we
@@ -294,7 +294,7 @@ static void alt_thread_entry(void)
 	zassert_true((__get_FPSCR() & FPSCR_MASK) == 0,
 		"(Alt thread) FPSCR is not cleared at initialization: 0x%x\n", __get_FPSCR());
 
-	zassert_true((p_ztest_thread->arch.mode_exc_return & EXC_RETURN_FTYPE) == 0,
+	zassert_true((p_ztest_thread->arch.s.mode_exc_return & EXC_RETURN_FTYPE) == 0,
 		"ztest thread mode Ftype flag not updated at swap-out: 0x%0x\n",
 		p_ztest_thread->arch.mode);
 
@@ -484,7 +484,7 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	/* The main test thread is not (yet) actively using the FP registers */
-	zassert_true((_current->arch.mode_exc_return & EXC_RETURN_FTYPE) != 0,
+	zassert_true((_current->arch.s.mode_exc_return & EXC_RETURN_FTYPE) != 0,
 		"Thread Ftype flag not set at initialization 0x%0x\n",
 		_current->arch.mode);
 
@@ -513,7 +513,7 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 	/* The main test thread is using the FP registers, but the .mode
 	 * flag is not updated until the next context switch.
 	 */
-	zassert_true((_current->arch.mode_exc_return & EXC_RETURN_FTYPE) != 0,
+	zassert_true((_current->arch.s.mode_exc_return & EXC_RETURN_FTYPE) != 0,
 		"Thread Ftype flag not set at initialization\n");
 #if defined(CONFIG_MPU_STACK_GUARD)
 	zassert_true((_current->arch.mode &
@@ -737,7 +737,7 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 	/* The main test thread is using the FP registers, and the .mode
 	 * flag and MPU GUARD flag are now updated.
 	 */
-	zassert_true((_current->arch.mode_exc_return & EXC_RETURN_FTYPE) == 0,
+	zassert_true((_current->arch.s.mode_exc_return & EXC_RETURN_FTYPE) == 0,
 		"Thread Ftype flag not cleared after main returned back\n");
 #if defined(CONFIG_MPU_STACK_GUARD)
 	zassert_true((_current->arch.mode &

--- a/tests/arch/arm/arm_thread_swap_tz/src/main.c
+++ b/tests/arch/arm/arm_thread_swap_tz/src/main.c
@@ -38,13 +38,13 @@ static void work_func(struct k_work *work)
 {
 #ifdef CONFIG_ARM_NONSECURE_PREEMPTIBLE_SECURE_CALLS
 	/* Check that the main thread was executing in secure mode. */
-	zassert_true(main_thread->arch.mode_exc_return & EXC_RETURN_S,
-		"EXC_RETURN not secure: 0x%x\n", main_thread->arch.mode_exc_return);
+	zassert_true(main_thread->arch.s.mode_exc_return & EXC_RETURN_S,
+		"EXC_RETURN not secure: 0x%x\n", main_thread->arch.s.mode_exc_return);
 
 #else
 	/* Check that the main thread was executing in nonsecure mode. */
-	zassert_false(main_thread->arch.mode_exc_return & EXC_RETURN_S,
-		"EXC_RETURN not nonsecure: 0x%x\n", main_thread->arch.mode_exc_return);
+	zassert_false(main_thread->arch.s.mode_exc_return & EXC_RETURN_S,
+		"EXC_RETURN not nonsecure: 0x%x\n", main_thread->arch.s.mode_exc_return);
 #endif
 
 	work_done = true;


### PR DESCRIPTION
When CONFIG_ARM_STORE_EXC_RETURN or CONFIG_USERSPACE were enabled, then _thread_arch contained anonymous struct, which is not allowed by C++ standard. GCC generates a warning about this when using pedantic flag:

.../thread.h:114:24: error: ISO C++ prohibits anonymous structs [-Werror=pedantic]

thread.h get included by zephyr/kernel.h. Avoiding to include it on C++ application might be hard.

Fix this by giving the name to the struct.