### PR TITLE
Bluetooth: Mesh: Revert increase of mesh scan window

### DIFF
--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -13,14 +13,8 @@
 #define BT_MESH_ADV(buf) (*(struct bt_mesh_adv **)net_buf_user_data(buf))
 
 #define BT_MESH_ADV_SCAN_UNIT(_ms) ((_ms) * 8 / 5)
-
-#if defined(CONFIG_BT_EXT_ADV) && !defined(CONFIG_BT_LL_SW_SPLIT)
-#define BT_MESH_SCAN_INTERVAL_MS 3000
-#define BT_MESH_SCAN_WINDOW_MS   3000
-#else
 #define BT_MESH_SCAN_INTERVAL_MS 30
 #define BT_MESH_SCAN_WINDOW_MS   30
-#endif
 
 enum bt_mesh_adv_type {
 	BT_MESH_ADV_PROV,


### PR DESCRIPTION
This reverts commit dbb0b30bdd8d3aa1a32faf2aabee441a0c749794.

Shorter scan windows allow devices to hop from one ADV channel to next in quick succession which allows mesh node to capture next retransmission of the same packet on another channel,  if one mesh packet is lost on one channel due to ambient noise.