### PR TITLE
boards: arm: nucleo_l152re: add support for spi

### DIFF
--- a/boards/arm/nucleo_l152re/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_l152re/arduino_r3_connector.dtsi
@@ -37,3 +37,4 @@
 
 arduino_i2c: &i2c1 {};
 arduino_serial: &usart2 {};
+arduino_spi: &spi1 {};

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -83,6 +83,28 @@
 	status = "okay";
 };
 
+&spi1 {
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpiob 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+	status = "okay";
+};
+
+&spi2 {
+	pinctrl-0 = <&spi2_nss_pb12 &spi2_sck_pb13
+		     &spi2_miso_pb14 &spi2_mosi_pb15>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&spi3 {
+	/* SPI3 on the ST Morpho Connector CN7 pins 17, 1, 2, 3*/
+	pinctrl-0 = <&spi3_nss_pa15 &spi3_sck_pc10
+		     &spi3_miso_pc11 &spi3_mosi_pc12>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &eeprom {
 	status = "okay";
 };

--- a/boards/arm/nucleo_l152re/nucleo_l152re.yaml
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.yaml
@@ -10,8 +10,10 @@ flash: 512
 supported:
   - arduino_gpio
   - arduino_i2c
+  - arduino_spi
   - eeprom
   - gpio
+  - spi
   - i2c
   - uart
   - watchdog

--- a/dts/arm/st/l1/stm32l151Xc.dtsi
+++ b/dts/arm/st/l1/stm32l151Xc.dtsi
@@ -36,6 +36,16 @@
 			};
 		};
 
+		spi3: spi@40003c00 {
+			compatible = "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
+			interrupts = <47 0>;
+			status = "disabled";
+		};
+
 		eeprom: eeprom@8080000{
 			reg = <0x08080000 DT_SIZE_K(8)>;
 		};

--- a/dts/arm/st/l1/stm32l152Xc.dtsi
+++ b/dts/arm/st/l1/stm32l152Xc.dtsi
@@ -36,6 +36,16 @@
 			};
 		};
 
+		spi3: spi@40003c00 {
+			compatible = "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
+			interrupts = <47 0>;
+			status = "disabled";
+		};
+
 		eeprom: eeprom@8080000{
 			reg = <0x08080000 DT_SIZE_K(8)>;
 		};

--- a/dts/arm/st/l1/stm32l152Xe.dtsi
+++ b/dts/arm/st/l1/stm32l152Xe.dtsi
@@ -36,6 +36,16 @@
 			};
 		};
 
+		spi3: spi@40003c00 {
+			compatible = "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
+			interrupts = <47 0>;
+			status = "disabled";
+		};
+
 		eeprom: eeprom@8080000{
 			reg = <0x08080000 DT_SIZE_K(16)>;
 		};


### PR DESCRIPTION
Defined SPI1, SPI2, and SPI3 pin controls for Nucleo-L152RE.
Defined arduino_spi.
Add definition of SPI3 for STM32L1 series.