### PR TITLE
sd: clean up sizes of some SD data fields

### DIFF
--- a/include/zephyr/sd/sd.h
+++ b/include/zephyr/sd/sd.h
@@ -55,15 +55,15 @@ struct sd_card {
 	struct sdhc_host_props host_props; /*!< SDHC host properties */
 	uint32_t ocr; /*!< Raw card OCR content */
 	struct sd_switch_caps switch_caps; /*!< SD switch capabilities */
-	uint32_t num_io; /*!< I/O function count. 0 for SD cards */
-	uint32_t relative_addr; /*!< Card relative address */
+	unsigned int num_io: 3; /*!< I/O function count. 0 for SD cards */
+	uint16_t relative_addr; /*!< Card relative address */
 	uint32_t block_count; /*!< Number of blocks in SD card */
-	uint32_t block_size; /*!< SD block size */
-	uint32_t sd_version; /*!< SD specification version */
-	uint32_t card_speed; /*!< Card timing mode */
+	uint16_t block_size; /*!< SD block size */
+	uint8_t sd_version; /*!< SD specification version */
+	uint8_t card_speed; /*!< Card timing mode */
 	enum card_status status; /*!< Card status */
 	enum card_type type; /*!< Card type */
-	uint32_t flags; /*!< Card flags */
+	uint16_t flags; /*!< Card flags */
 	uint8_t card_buffer[CONFIG_SD_BUFFER_SIZE]
 		__aligned(CONFIG_SDHC_BUFFER_ALIGNMENT); /* Card internal buffer */
 };

--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -81,9 +81,10 @@ int sdmmc_wait_ready(struct sd_card *card)
 }
 
 static inline void sdmmc_decode_csd(struct sd_csd *csd, uint32_t *raw_csd, uint32_t *blk_count,
-				    uint32_t *blk_size)
+				    uint16_t *blk_size)
 {
-	uint32_t tmp_blk_count, tmp_blk_size;
+	uint32_t tmp_blk_count;
+	uint16_t tmp_blk_size;
 
 	csd->csd_structure = (uint8_t)((raw_csd[3U] & 0xC0000000U) >> 30U);
 	csd->read_time1 = (uint8_t)((raw_csd[3U] & 0xFF0000U) >> 16U);

--- a/subsys/sd/sdmmc.c
+++ b/subsys/sd/sdmmc.c
@@ -19,7 +19,7 @@
 LOG_MODULE_DECLARE(sd, CONFIG_SD_LOG_LEVEL);
 
 static inline void sdmmc_decode_scr(struct sd_scr *scr,
-	uint32_t *raw_scr, uint32_t *version)
+	uint32_t *raw_scr, uint8_t *version)
 {
 	uint32_t tmp_version = 0;
 


### PR DESCRIPTION
Clean up sizes of some SD data fields, as the max value of these fields is limited by the SD specification

Specifically, the limits are as follows:
num_io: 0-7, 3 bits (SDIO only)
relative_addr: 16 bits (SDMMC/MMC)
block_size: 12 bits (Max of 2KB, uint16_t used)
sd_version: 8 bits (currently at version 3)
card_speed: 8 bits (could potentially be reduced in size)