### PR TITLE
xtensa: sample_controller: smaller intermediate build artifacts

### DIFF
--- a/soc/xtensa/sample_controller/include/xtensa-sample-controller.ld
+++ b/soc/xtensa/sample_controller/include/xtensa-sample-controller.ld
@@ -177,6 +177,10 @@ SECTIONS
 
 #include <zephyr/linker/rel-sections.ld>
 
+#ifdef CONFIG_GEN_ISR_TABLES
+#include <zephyr/linker/intlist.ld>
+#endif
+
   .dram1.rodata : ALIGN(4)
   {
     _dram1_rodata_start = ABSOLUTE(.);
@@ -635,7 +639,4 @@ SECTIONS
   {
     KEEP (*(.debug.xt.callgraph .debug.xt.callgraph.* .gnu.linkonce.xt.callgraph.*))
   }
-#ifdef CONFIG_GEN_ISR_TABLES
-#include <zephyr/linker/intlist.ld>
-#endif
 }


### PR DESCRIPTION
For some weird reasons, if the sections in linker script are not in memory address order, there are lots of padding involved in zephyr_pre0.elf. This moves the .intList section to its memory ordered location. When building hello_world, this shrinks zephyr_pre0.elf from 512MB to 339KB.