### PR TITLE
arch: arm64: Reserved Cores

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -159,6 +159,15 @@ config ARM64_SAFE_EXCEPTION_STACK_SIZE
 	  The stack size of the safe exception stack. The safe exception stack
 	  requires to be enough to do the stack overflow check.
 
+config ARM64_FALLBACK_ON_RESERVED_CORES
+	bool "To enable fallback on reserved cores"
+	help
+	  Give the ability to define more cores in the device tree than required
+	  via CONFIG_MP_MAX_NUM_CPUS.  The extra cores in the device tree
+	  become reserved.  If there is an issue powering on a core during boot
+	  then that core will be skipped and the next core in the device tree
+	  will be used.
+
 if CPU_CORTEX_A
 
 config ARMV8_A_NS


### PR DESCRIPTION
Enhanced arch_start_cpu so if a core is not available based on pm_cpu_on return value, booting does not halt.  Instead the next core in cpu_node_list will be tried.  If the number of CPU nodes described in the device tree is greater than CONFIG_MP_MAX_NUM_CPUS then the extra cores will be reserved and used if any previous cores in the cpu_node_list fail to power on.  If the number of cores described in the device tree matches CONFIG_MP_MAX_NUM_CPUS then no cores are in reserve and booting will behave as previous, it will halt.