### PR TITLE
twister: increase resilience when running outside of git.

### DIFF
--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -1152,7 +1152,7 @@ static int uart_sam0_rx_disable(const struct device *dev)
 	}
 
 	if (dev_data->rx_next_len) {
-		struct uart_event evt = {
+		struct uart_event next_evt = {
 			.type = UART_RX_BUF_RELEASED,
 			.data.rx_buf = {
 				.buf = dev_data->rx_next_buf,
@@ -1163,7 +1163,7 @@ static int uart_sam0_rx_disable(const struct device *dev)
 		dev_data->rx_next_len = 0U;
 
 		if (dev_data->async_cb) {
-			dev_data->async_cb(dev, &evt, dev_data->async_cb_data);
+			dev_data->async_cb(dev, &next_evt, dev_data->async_cb_data);
 		}
 	}
 

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -786,9 +786,9 @@ def parse_arguments(parser, args, options = None):
 class TwisterEnv:
 
     def __init__(self, options=None) -> None:
-        self.version = None
+        self.version = "Unknown"
         self.toolchain = None
-        self.commit_date = None
+        self.commit_date = "Unknown"
         self.run_date = None
         self.options = options
 
@@ -834,20 +834,21 @@ class TwisterEnv:
                 if _version:
                     self.version = _version
                     logger.info(f"Zephyr version: {self.version}")
-                else:
-                    self.version = "Unknown"
-                    logger.error("Could not determine version")
         except OSError:
-            logger.info("Cannot read zephyr version.")
+            logger.exception("Failure while reading Zephyr version.")
 
-        subproc = subprocess.run(["git", "show", "-s", "--format=%cI", "HEAD"],
-                                     stdout=subprocess.PIPE,
-                                     universal_newlines=True,
-                                     cwd=ZEPHYR_BASE)
-        if subproc.returncode == 0:
-            self.commit_date = subproc.stdout.strip()
-        else:
-            self.commit_date = "Unknown"
+        if self.version == "Unknown":
+            logger.warning("Could not determine version")
+
+        try:
+            subproc = subprocess.run(["git", "show", "-s", "--format=%cI", "HEAD"],
+                                        stdout=subprocess.PIPE,
+                                        universal_newlines=True,
+                                        cwd=ZEPHYR_BASE)
+            if subproc.returncode == 0:
+                self.commit_date = subproc.stdout.strip()
+        except OSError:
+            logger.exception("Failure while reading head commit date.")
 
     @staticmethod
     def run_cmake_script(args=[]):

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -369,10 +369,17 @@ TESTDATA_4 = [
         'dummy stdout date'
     ),
     (
+        mock.Mock(returncode=1, stdout='dummy stdout version'),
+        mock.Mock(returncode=0, stdout='dummy stdout date'),
+        ['Could not determine version'],
+        'Unknown',
+        'dummy stdout date'
+    ),
+    (
         OSError,
         mock.Mock(returncode=1),
-        ['Cannot read zephyr version.'],
-        None,
+        ['Could not determine version'],
+        'Unknown',
         'Unknown'
     ),
 ]
@@ -382,7 +389,12 @@ TESTDATA_4 = [
     'git_describe_return, git_show_return, expected_logs,' \
     ' expected_version, expected_commit_date',
     TESTDATA_4,
-    ids=['valid', 'no zephyr version on describe', 'error on git describe']
+    ids=[
+        'valid',
+        'no zephyr version on describe',
+        'error on git describe',
+        'execution error on git describe',
+    ]
 )
 def test_twisterenv_check_zephyr_version(
     caplog,


### PR DESCRIPTION
twister: increase resilience when running outside of git.



While the code already includes some provisions to allow running outside
of a git checkout, attempting that right now causes a failure to generate
the XML report, as the JSON report creates a null `zephyr_version` field.

The reason for that is that the original code doesn't set `self.version`
when the subprocess returns a non-zero status (and also doesn't log.)

Instead of having to set `self.version` for all failure cases, initialize
it to the failure state, and log if it hasn't changed from that.

Signed-off-by: Diego Elio Pettenò <flameeyes@meta.com>

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zephyrproject-rtos/zephyr/pull/61668).
* #61728
* __->__ #61668
* #61736