### PR TITLE
Bluetooth: ISO: Fix invalid conn type check

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1029,11 +1029,6 @@ void hci_le_cis_established(struct net_buf *buf)
 	iso = bt_conn_lookup_handle(handle, BT_CONN_TYPE_ISO);
 	if (!iso) {
 		LOG_ERR("No connection found for handle %u", handle);
-		return;
-	}
-
-	CHECKIF(iso->type != BT_CONN_TYPE_ISO) {
-		LOG_DBG("Invalid connection type %u", iso->type);
 		bt_conn_unref(iso);
 		return;
 	}


### PR DESCRIPTION
The bt_conn_lookup_handle will check ISO type, if check failed, the iso will be NULL and return.