### PR TITLE
arch: xtensa: Implement arch_float_enable&disable

### DIFF
--- a/arch/xtensa/core/xtensa-asm2.c
+++ b/arch/xtensa/core/xtensa-asm2.c
@@ -210,6 +210,20 @@ static inline void *return_to(void *interrupted)
 	return z_arch_get_next_switch_handle(interrupted);
 }
 
+#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
+int arch_float_disable(struct k_thread *thread)
+{
+	/* xtensa always has FPU enabled so cannot be disabled */
+	return -ENOTSUP;
+}
+
+int arch_float_enable(struct k_thread *thread, unsigned int options)
+{
+	/* xtensa always has FPU enabled so nothing to do here */
+	return 0;
+}
+#endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
+
 /* The wrapper code lives here instead of in the python script that
  * generates _xtensa_handle_one_int*().  Seems cleaner, still kind of
  * ugly.


### PR DESCRIPTION
If `CONFIG_FPU` and `CONFIG_FPU_SHARING` are specified,   
the `arch_float_disable` and `arch_float_enable` functions must be implemented.

These functions were used in #61455 and currently cause the pipeline to fail (#61420 ).

I believe that the Xtensa architecture does not provide a way to enable/disable the FPU,   
so I implemented this PR with reference to the x86 architecture(#38178 )