### PR TITLE
regulator: shell: add device name completion

### DIFF
--- a/drivers/regulator/regulator_shell.c
+++ b/drivers/regulator/regulator_shell.c
@@ -413,57 +413,69 @@ static int cmd_shipmode(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static void device_name_get(size_t idx, struct shell_static_entry *entry)
+{
+	const struct device *dev = shell_device_lookup(idx, NULL);
+
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+}
+
+SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_regulator_cmds,
-	SHELL_CMD_ARG(enable, NULL,
+	SHELL_CMD_ARG(enable, &dsub_device_name,
 		      "Enable regulator\n"
 		      "Usage: enable <device>",
 		      cmd_enable, 2, 0),
-	SHELL_CMD_ARG(disable, NULL,
+	SHELL_CMD_ARG(disable, &dsub_device_name,
 		      "Disable regulator\n"
 		      "Usage: disable <device>",
 		      cmd_disable, 2, 0),
-	SHELL_CMD_ARG(vlist, NULL,
+	SHELL_CMD_ARG(vlist, &dsub_device_name,
 		      "List all supported voltages\n"
 		      "Usage: vlist <device>",
 		      cmd_vlist, 2, 0),
-	SHELL_CMD_ARG(vset, NULL,
+	SHELL_CMD_ARG(vset, &dsub_device_name,
 		      "Set voltage\n"
 		      "Input requires units, e.g. 200mv, 20.5mv, 10uv, 1v...\n"
 		      "Usage: vset <device> <minimum> [<maximum>]\n"
 		      "If maximum is not set, exact voltage will be requested",
 		      cmd_vset, 3, 1),
-	SHELL_CMD_ARG(vget, NULL,
+	SHELL_CMD_ARG(vget, &dsub_device_name,
 		      "Get voltage\n"
 		      "Usage: vget <device>",
 		      cmd_vget, 2, 0),
-	SHELL_CMD_ARG(iset, NULL,
+	SHELL_CMD_ARG(iset, &dsub_device_name,
 		      "Set current limit\n"
 		      "Input requires units, e.g. 200ma, 20.5ma, 10ua, 1a...\n"
 		      "Usage: iset <device> <minimum> [<maximum>]"
 		      "If maximum is not set, exact current will be requested",
 		      cmd_iset, 3, 1),
-	SHELL_CMD_ARG(iget, NULL,
+	SHELL_CMD_ARG(iget, &dsub_device_name,
 		      "Get current limit\n"
 		      "Usage: iget <device>",
 		      cmd_iget, 2, 0),
-	SHELL_CMD_ARG(modeset, NULL,
+	SHELL_CMD_ARG(modeset, &dsub_device_name,
 		      "Set regulator mode\n"
 		      "Usage: modeset <device> <mode identifier>",
 		      cmd_modeset, 3, 0),
-	SHELL_CMD_ARG(modeget, NULL,
+	SHELL_CMD_ARG(modeget, &dsub_device_name,
 		      "Get regulator mode\n"
 		      "Usage: modeget <device>",
 		      cmd_modeget, 2, 0),
-	SHELL_CMD_ARG(errors, NULL,
+	SHELL_CMD_ARG(errors, &dsub_device_name,
 		      "Get errors\n"
 		      "Usage: errors <device>",
 		      cmd_errors, 2, 0),
-	SHELL_CMD_ARG(dvsset, NULL,
+	SHELL_CMD_ARG(dvsset, &dsub_device_name,
 		      "Set regulator dynamic voltage scaling state\n"
 		      "Usage: dvsset <device> <state identifier>",
 		      cmd_dvsset, 3, 0),
-	SHELL_CMD_ARG(shipmode, NULL,
+	SHELL_CMD_ARG(shipmode, &dsub_device_name,
 		      "Enable regulator ship mode\n"
 		      "Usage: shipmode <device>",
 		      cmd_shipmode, 2, 0),


### PR DESCRIPTION
Add the code for the shell to complete the device name in the regulator commands.