### PR TITLE
tests: crc: fix crc library location

### DIFF
--- a/tests/unit/crc/main.c
+++ b/tests/unit/crc/main.c
@@ -6,11 +6,11 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/sys/crc.h>
-#include "../../../lib/os/crc8_sw.c"
-#include "../../../lib/os/crc16_sw.c"
-#include "../../../lib/os/crc32_sw.c"
-#include "../../../lib/os/crc32c_sw.c"
-#include "../../../lib/os/crc7_sw.c"
+#include "../../../lib/crc/crc8_sw.c"
+#include "../../../lib/crc/crc16_sw.c"
+#include "../../../lib/crc/crc32_sw.c"
+#include "../../../lib/crc/crc32c_sw.c"
+#include "../../../lib/crc/crc7_sw.c"
 
 ZTEST(crc, test_crc32c)
 {


### PR DESCRIPTION
These files have been moved in:

e6885a4515 lib: crc: move from lib/os to lib/crc

Adjust the path to the new location.