### PR TITLE
scripts: pin `Pillow` version

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -16,7 +16,7 @@ clang-format>=15.0.0
 lpc_checksum
 
 # used by scripts/build/gen_cfb_font_header.py - helper script for user
-Pillow
+Pillow==9.5.*
 
 # can be used to sign a Zephyr application binary for consumption by a bootloader
 imgtool>=1.9


### PR DESCRIPTION
The latest (v10.0) version doesn't work with the cfb script.

```
(zephyr) [john@420blz ~]$ ${ZEPHYR_BASE}/scripts/build/gen_cfb_font_header.py -i ~/Downloads/creep2.ttf -x 10 -y 16 -s 11 --center-x -o cfbv_creep
Traceback (most recent call last):
  File "/home/john/Software/zephyrproject/zephyr/scripts/build/gen_cfb_font_header.py", line 263, in <module>
    main()
  File "/home/john/Software/zephyrproject/zephyr/scripts/build/gen_cfb_font_header.py", line 260, in main
    generate_header()
  File "/home/john/Software/zephyrproject/zephyr/scripts/build/gen_cfb_font_header.py", line 174, in generate_header
    extract_font_glyphs()
  File "/home/john/Software/zephyrproject/zephyr/scripts/build/gen_cfb_font_header.py", line 79, in extract_font_glyphs
    fw, fh = font.getsize(chr(i))
             ^^^^^^^^^^^^
AttributeError: 'FreeTypeFont' object has no attribute 'getsize'

```

Got the hint from googling:
https://github.com/ultralytics/yolov5/issues/11838

The alternative is to update the generator script.