### PR TITLE
pm: Add cooperative workqueue for executing blocking logic

### DIFF
--- a/include/zephyr/pm/pm.h
+++ b/include/zephyr/pm/pm.h
@@ -72,6 +72,16 @@ struct pm_notifier {
 	 */
 	void (*callback)(uint8_t direction, void *ctx);
 
+#ifdef CONFIG_PM
+	/**
+	 * Workqueue item to be called in place of above callback. Runs via dedicated PM workqueue.
+	 * Used for logic that needs to block.
+	 *
+	 * @note State direction comparison is not supported in PM workqueue handler.
+	 */
+	struct k_work work;
+#endif
+
 	/**
 	 * Optional callback context
 	 */

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -350,6 +350,27 @@ struct pm_state_info {
 uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states);
 
 /**
+ * Retrieve the index of a CPU's DT cpu-power-states array element.
+ *
+ * @param cpu CPU index.
+ * @param state pm_state state.
+ * @param substate_id pm_state substate ID.
+ *
+ * @return Index of the PM state, or -1.
+ */
+uint8_t pm_state_cpu_get_index(uint8_t cpu, enum pm_state state, uint8_t substate_id);
+
+/**
+ * Retrieve the index of a DT power-states array element.
+ *
+ * @param state pm_state state.
+ * @param substate_id pm_state substate ID.
+ *
+ * @return Index of the PM state, or -1.
+ */
+uint8_t pm_state_get_index(enum pm_state state, uint8_t substate_id);
+
+/**
  * @}
  */
 

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -205,6 +205,18 @@ struct pm_state_info {
 	COND_CODE_1(DT_NODE_HAS_STATUS(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i), okay),    \
 		    (PM_STATE_DT_INIT(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, i)),), ())
 
+/**
+ * @brief Call a function for an enabled power-state phandle list item
+ *
+ * @param node_id zephyr,power-state node identifier
+ * @param prop Property holding power-state phandle(s)
+ * @param idx Index within the phandle list
+ * @param fn Function taking a power-state node_id
+ */
+#define Z_PM_STATE_DT_PHANDLE_GEN(node_id, prop, idx, fn)					 \
+	COND_CODE_1(DT_NODE_HAS_STATUS(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, idx), okay), \
+		    (fn(DT_PHANDLE_BY_IDX(node_id, cpu_power_states, idx))), ())
+
 /** @endcond */
 
 /**

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -156,6 +156,16 @@ struct pm_state_info {
 	uint32_t exit_latency_us;
 };
 
+/**
+ * @brief PM state transition direction: state entry bit field value
+ */
+#define PM_STATE_ENTRY        BIT(0)
+
+/**
+ * @brief PM state transition direction: state exit bit field value
+ */
+#define PM_STATE_EXIT         BIT(1)
+
 /** @cond INTERNAL_HIDDEN */
 
 /**

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -40,11 +40,19 @@ BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
 DT_FOREACH_CHILD(DT_PATH(cpus), CHECK_POWER_STATES_CONSISTENCY)
 
 #define DEFINE_CPU_STATES(n) \
-	static const struct pm_state_info pmstates_##n[] \
+	static const struct pm_state_info pmstates_cpu##n[] \
 		= PM_STATE_INFO_LIST_FROM_DT_CPU(n);
-#define CPU_STATE_REF(n) pmstates_##n
+#define CPU_STATE_REF(n) pmstates_cpu##n
 
 DT_FOREACH_CHILD(DT_PATH(cpus), DEFINE_CPU_STATES);
+
+#if CONFIG_MP_NUM_CPUS > 1 && DT_NODE_EXISTS(DT_PATH(cpus, power_states))
+/** General power-states list on SMP platforms, as individual per-CPU states may vary */
+static const struct pm_state_info pmstates_all[] = {
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus, power_states),
+					 PM_STATE_INFO_DT_INIT, (,)),
+};
+#endif
 
 /** CPU power states information for each CPU */
 static const struct pm_state_info *cpus_states[] = {
@@ -66,3 +74,34 @@ uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states)
 
 	return states_per_cpu[cpu];
 }
+
+inline uint8_t pm_state_cpu_get_index(uint8_t cpu, enum pm_state state, uint8_t substate_id)
+{
+	for (uint8_t i = 0; i < states_per_cpu[cpu]; i++) {
+		if (cpus_states[cpu][i].state == state &&
+		    cpus_states[cpu][i].substate_id == substate_id) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+#if CONFIG_MP_NUM_CPUS > 1
+inline uint8_t pm_state_get_index(enum pm_state state, uint8_t substate_id)
+{
+	for (uint8_t i = 0; i < ARRAY_SIZE(pmstates_all); i++) {
+		if (pmstates_all[i].state == state &&
+		    pmstates_all[i].substate_id == substate_id) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+#else
+inline uint8_t pm_state_get_index(enum pm_state state, uint8_t substate_id)
+{
+	return pm_state_cpu_get_index(0U, state, substate_id);
+}
+#endif

--- a/tests/subsys/pm/device_wakeup_api/boards/native_posix.overlay
+++ b/tests/subsys/pm/device_wakeup_api/boards/native_posix.overlay
@@ -9,3 +9,18 @@
 	gpio-controller;
 	wakeup-source;
 };
+
+/ {
+	cpus {
+		power-states {
+			s2ram: s2ram {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-ram";
+			};
+		};
+	};
+};
+
+&cpu0 {
+	cpu-power-states = <&s2ram>;
+};

--- a/tests/subsys/pm/power_mgmt/boards/native_posix.overlay
+++ b/tests/subsys/pm/power_mgmt/boards/native_posix.overlay
@@ -5,6 +5,15 @@
  */
 
 / {
+	cpus {
+		power-states {
+			suspend: suspend {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+			};
+		};
+	};
+
 	device_a: device_a {
 		compatible = "test-device-pm";
 	};
@@ -20,4 +29,8 @@
 	device_d: device_d {
 		compatible = "test-device-pm";
 	};
+};
+
+&cpu0 {
+	cpu-power-states = <&suspend>;
 };

--- a/tests/subsys/pm/power_mgmt_multicore/boards/qemu_x86_64.overlay
+++ b/tests/subsys/pm/power_mgmt_multicore/boards/qemu_x86_64.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Kenneth J. Miller <ken@miller.ec>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	cpus {
+		cpu@0 {
+			cpu-power-states = <&idle &s2idle &stdby>;
+		};
+
+		power-states {
+			idle: idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "runtime-idle";
+			};
+
+			s2idle: s2idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+			};
+
+			stdby: stdby {
+				compatible = "zephyr,power-state";
+				power-state-name = "standby";
+			};
+		};
+	};
+};


### PR DESCRIPTION
###### *NOTE: This proposal depends on and includes commits from #60998*

This proposal adds a workqueue with highest cooperative thread priority, in order to allow PM logic to execute blocking code on demand.

It also extends the refactored `pm_notifier` logic, allowing definition of a workqueue handler in place of the callback function, which would be called from the idle thread or an ISR where it isn't allowed to block.

Use case discussed in https://github.com/zephyrproject-rtos/zephyr/pull/60939#issuecomment-1680796061