### PR TITLE
usb: hid: Call the report proto callback function when the reset occurs

### DIFF
--- a/subsys/usb/device/class/hid/core.c
+++ b/subsys/usb/device/class/hid/core.c
@@ -354,13 +354,22 @@ static void hid_do_status_cb(struct hid_device_info *dev_data,
 	case USB_DC_ERROR:
 		LOG_INF("Device error");
 		break;
-	case USB_DC_RESET:
+	case USB_DC_RESET: {
 		LOG_INF("Device reset detected");
 		dev_data->configured = false;
 		dev_data->suspended = false;
 #ifdef CONFIG_USB_HID_BOOT_PROTOCOL
+		const struct device *dev = dev_data->common.dev;
+		uint8_t prev = dev_data->protocol;
+
 		dev_data->protocol = HID_PROTOCOL_REPORT;
+		if (prev != HID_PROTOCOL_REPORT) {
+			if (dev_data->ops && dev_data->ops->protocol_change) {
+				dev_data->ops->protocol_change(dev, dev_data->protocol);
+			}
+		}
 #endif
+	}
 #ifdef CONFIG_USB_DEVICE_SOF
 		hid_clear_idle_ctx(dev_data);
 #endif


### PR DESCRIPTION
This commit changes the protocol callback function is invoked if the HID protocol changed due to reset.