### PR TITLE
LVGL: Fix FS memory leaks

### DIFF
--- a/modules/lvgl/lvgl_fs.c
+++ b/modules/lvgl/lvgl_fs.c
@@ -7,8 +7,9 @@
 #include <lvgl.h>
 #include <zephyr/kernel.h>
 #include <zephyr/fs/fs.h>
-#include <stdlib.h>
 #include "lvgl_fs.h"
+#include "lv_conf.h"
+#include LV_MEM_CUSTOM_INCLUDE
 
 static bool lvgl_fs_ready(struct _lv_fs_drv_t *drv)
 {
@@ -63,7 +64,7 @@ static void *lvgl_fs_open(struct _lv_fs_drv_t *drv, const char *path, lv_fs_mode
 	zmode |= (mode & LV_FS_MODE_WR) ? FS_O_WRITE : 0;
 	zmode |= (mode & LV_FS_MODE_RD) ? FS_O_READ : 0;
 
-	file = malloc(sizeof(struct fs_file_t));
+	file = LV_MEM_CUSTOM_ALLOC(sizeof(struct fs_file_t));
 	if (!file) {
 		return NULL;
 	}
@@ -72,6 +73,7 @@ static void *lvgl_fs_open(struct _lv_fs_drv_t *drv, const char *path, lv_fs_mode
 
 	err = fs_open((struct fs_file_t *)file, path, zmode);
 	if (err) {
+		LV_MEM_CUSTOM_FREE(file);
 		return NULL;
 	}
 
@@ -165,7 +167,7 @@ static void *lvgl_fs_dir_open(struct _lv_fs_drv_t *drv, const char *path)
 	 */
 	path--;
 
-	dir = malloc(sizeof(struct fs_dir_t));
+	dir = LV_MEM_CUSTOM_ALLOC(sizeof(struct fs_dir_t));
 	if (!dir) {
 		return NULL;
 	}
@@ -173,6 +175,7 @@ static void *lvgl_fs_dir_open(struct _lv_fs_drv_t *drv, const char *path)
 	fs_dir_t_init((struct fs_dir_t *)dir);
 	err = fs_opendir((struct fs_dir_t *)dir, path);
 	if (err) {
+		LV_MEM_CUSTOM_FREE(dir);
 		return NULL;
 	}
 
@@ -192,7 +195,7 @@ static lv_fs_res_t lvgl_fs_dir_close(struct _lv_fs_drv_t *drv, void *dir)
 	int err;
 
 	err = fs_closedir((struct fs_dir_t *)dir);
-	free(dir);
+	LV_MEM_CUSTOM_FREE(dir);
 	return errno_to_lv_fs_res(err);
 }
 

--- a/modules/lvgl/lvgl_fs.c
+++ b/modules/lvgl/lvgl_fs.c
@@ -45,6 +45,9 @@ static lv_fs_res_t errno_to_lv_fs_res(int err)
 	case -EINVAL:
 		/*Invalid parameter among arguments*/
 		return LV_FS_RES_INV_PARAM;
+	case -ENOTSUP:
+		/*Not supported by the filesystem*/
+		return LV_FS_RES_NOT_IMP;
 	default:
 		return LV_FS_RES_UNKNOWN;
 	}
@@ -153,7 +156,14 @@ static lv_fs_res_t lvgl_fs_seek(struct _lv_fs_drv_t *drv, void *file, uint32_t p
 
 static lv_fs_res_t lvgl_fs_tell(struct _lv_fs_drv_t *drv, void *file, uint32_t *pos_p)
 {
-	*pos_p = fs_tell((struct fs_file_t *)file);
+	off_t pos;
+
+	pos = fs_tell((struct fs_file_t *)file);
+	if (pos < 0) {
+		return errno_to_lv_fs_res(pos);
+	}
+
+	*pos_p = pos;
 	return LV_FS_RES_OK;
 }
 


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/54713.

Also it changes the allocation to use the memory management selected by the kconfig symbol, similar to how its done for the dynamic allocation of the display buffers. While looking over the wrapper code I also fixed the shortcoming of error propagation of the `fs_tell` wrapper that lvgl expects.