### PR TITLE
doc: release: 3.5: Add CodeChecker entry

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -148,6 +148,10 @@ Boards & SoC Support
 Build system and infrastructure
 *******************************
 
+* SCA (Static Code Analysis)
+
+  * Added support for CodeChecker
+
 Drivers and Sensors
 *******************
 


### PR DESCRIPTION
Add a release note entry for CodeChecker SCA support.

~I used an implicit link to the section title, not sure if this is correct/preferred way?~