### PR TITLE
docs: mem: slabs: fix for mem_slab docs snippets

### DIFF
--- a/doc/kernel/memory_management/slabs.rst
+++ b/doc/kernel/memory_management/slabs.rst
@@ -109,7 +109,7 @@ A warning is printed if a suitable block is not obtained.
 
     char *block_ptr;
 
-    if (k_mem_slab_alloc(&my_slab, &block_ptr, 100) == 0) {
+    if (k_mem_slab_alloc(&my_slab, (void **)&block_ptr, K_MSEC(100)) == 0) {
         memset(block_ptr, 0, 400);
 	...
     } else {
@@ -128,9 +128,9 @@ then releases it once it is no longer needed.
 
     char *block_ptr;
 
-    k_mem_slab_alloc(&my_slab, &block_ptr, K_FOREVER);
+    k_mem_slab_alloc(&my_slab, (void **)&block_ptr, K_FOREVER);
     ... /* use memory block pointed at by block_ptr */
-    k_mem_slab_free(&my_slab, block_ptr);
+    k_mem_slab_free(&my_slab, (void *)block_ptr);
 
 Suggested Uses
 **************


### PR DESCRIPTION
Attempting to run the memory slab docs snippets will result in build issues. This PR is an attempt to fix those.