### PR TITLE
cmake: sca: codechecker: Support storing results

### DIFF
--- a/cmake/sca/codechecker/sca.cmake
+++ b/cmake/sca/codechecker/sca.cmake
@@ -23,6 +23,7 @@ add_custom_target(codechecker ALL
     --keep-gcc-include-fixed
     --keep-gcc-intrin
     --output ${output_dir}/codechecker.plist
+    --name zephyr # Set a default metadata name
     ${CODECHECKER_ANALYZE_OPTS}
     ${CMAKE_BINARY_DIR}/compile_commands.json
   DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json ${output_dir}/codechecker.ready
@@ -66,6 +67,18 @@ else()
       ${output_dir}/codechecker.plist
       ${CODECHECKER_PARSE_OPTS}
       || ${CMAKE_COMMAND} -E true # parse has exit code 2 if a report is emitted by an analyzer
+    VERBATIM
+    USES_TERMINAL
+    COMMAND_EXPAND_LISTS
+  )
+endif()
+
+if(CODECHECKER_STORE OR CODECHECKER_STORE_OPTS)
+  add_custom_command(
+    TARGET codechecker POST_BUILD
+    COMMAND ${CODECHECKER_EXE} store
+      ${CODECHECKER_STORE_OPTS}
+      ${output_dir}/codechecker.plist
     VERBATIM
     USES_TERMINAL
     COMMAND_EXPAND_LISTS

--- a/doc/develop/sca/codechecker.rst
+++ b/doc/develop/sca/codechecker.rst
@@ -42,6 +42,24 @@ To configure CodeChecker or analyzers used, arguments can be passed using the
     -DCODECHECKER_ANALYZE_OPTS="--config;$CODECHECKER_CONFIG_FILE;--timeout;60"
 
 
+Storing CodeChecker results
+***************************
+
+If a CodeChecker server is active the results can be uploaded and stored for tracking purposes.
+Storing is done using the optional ``CODECHECKER_STORE=y`` or ``CODECHECKER_STORE_OPTS="arg;list"``
+parameters, e.g.
+
+.. code-block:: shell
+
+    west build -b mimxrt1064_evk samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker \
+    -DCODECHECKER_STORE_OPTS="--name;build;--url;localhost:8001/Default"
+
+.. note::
+
+    If ``--name`` isn't passed to either ``CODECHECKER_ANALYZE_OPTS`` or ``CODECHECKER_STORE_OPTS``,
+    the default ``zephyr`` is used.
+
+
 Exporting CodeChecker reports
 *****************************
 

--- a/doc/develop/sca/codechecker.rst
+++ b/doc/develop/sca/codechecker.rst
@@ -27,7 +27,7 @@ called with a ``-DZEPHYR_SCA_VARIANT=codechecker`` parameter, e.g.
 
 .. code-block:: shell
 
-    west build -b mimxrt1064_evk -s samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker
+    west build -b mimxrt1064_evk samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker
 
 
 Configuring CodeChecker
@@ -38,7 +38,7 @@ To configure CodeChecker or analyzers used, arguments can be passed using the
 
 .. code-block:: shell
 
-    west build -b mimxrt1064_evk -s samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker \
+    west build -b mimxrt1064_evk samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker \
     -DCODECHECKER_ANALYZE_OPTS="--config;$CODECHECKER_CONFIG_FILE;--timeout;60"
 
 
@@ -54,5 +54,5 @@ Optional parser configuration arguments can be passed using the
 
 .. code-block:: shell
 
-    west build -b mimxrt1064_evk -s samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker \
+    west build -b mimxrt1064_evk samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker \
     -DCODECHECKER_EXPORT=html,json -DCODECHECKER_PARSE_OPTS="--trim-path-prefix;$PWD"


### PR DESCRIPTION
Introduce `CODECHECKER_STORE` parameters to upload results to an active CodeChecker server.

Closes #61633 