### PR TITLE
cmake: Support EXTRA_*FLAGS in sysbuild

### DIFF
--- a/cmake/extra_flags.cmake
+++ b/cmake/extra_flags.cmake
@@ -1,36 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 foreach(extra_flags EXTRA_CPPFLAGS EXTRA_LDFLAGS EXTRA_CFLAGS EXTRA_CXXFLAGS EXTRA_AFLAGS)
-  list(LENGTH ${extra_flags} flags_length)
-  if(flags_length LESS_EQUAL 1)
-    # A length of zero means no argument.
-    # A length of one means a single argument or a space separated list was provided.
-    # In both cases, it is safe to do a separate_arguments on the argument.
-    separate_arguments(${extra_flags}_AS_LIST UNIX_COMMAND ${${extra_flags}})
-  else()
-    # Already a proper list, no conversion needed.
-    set(${extra_flags}_AS_LIST "${${extra_flags}}")
-  endif()
+  zephyr_get(${extra_flags} MERGE ARGLIST SYSBUILD GLOBAL)
 endforeach()
 
 if(EXTRA_CPPFLAGS)
-  zephyr_compile_options(${EXTRA_CPPFLAGS_AS_LIST})
+  zephyr_compile_options(${EXTRA_CPPFLAGS})
 endif()
 if(EXTRA_LDFLAGS)
-  zephyr_link_libraries(${EXTRA_LDFLAGS_AS_LIST})
+  zephyr_link_libraries(${EXTRA_LDFLAGS})
 endif()
 if(EXTRA_CFLAGS)
-  foreach(F ${EXTRA_CFLAGS_AS_LIST})
+  foreach(F ${EXTRA_CFLAGS})
     zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:${F}>)
   endforeach()
 endif()
 if(EXTRA_CXXFLAGS)
-  foreach(F ${EXTRA_CXXFLAGS_AS_LIST})
+  foreach(F ${EXTRA_CXXFLAGS})
     zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:${F}>)
   endforeach()
 endif()
 if(EXTRA_AFLAGS)
-  foreach(F ${EXTRA_AFLAGS_AS_LIST})
+  foreach(F ${EXTRA_AFLAGS})
     zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:${F}>)
   endforeach()
 endif()

--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -19,16 +19,7 @@ include(${ZEPHYR_BASE}/cmake/target_toolchain_flags.cmake)
 #   INCLUDE: list of additional include paths relative to ZEPHYR_BASE
 
 foreach(extra_flags EXTRA_CPPFLAGS EXTRA_LDFLAGS EXTRA_CFLAGS EXTRA_CXXFLAGS EXTRA_AFLAGS)
-  list(LENGTH ${extra_flags} flags_length)
-  if(flags_length LESS_EQUAL 1)
-    # A length of zero means no argument.
-    # A length of one means a single argument or a space separated list was provided.
-    # In both cases, it is safe to do a separate_arguments on the argument.
-    separate_arguments(${extra_flags}_AS_LIST UNIX_COMMAND ${${extra_flags}})
-  else()
-    # Already a proper list, no conversion needed.
-    set(${extra_flags}_AS_LIST "${${extra_flags}}")
-  endif()
+  zephyr_get(${extra_flags}_AS_LIST ARGLIST VAR ${extra_flags})
 endforeach()
 
 set(ENV_ZEPHYR_BASE $ENV{ZEPHYR_BASE})

--- a/tests/cmake/zephyr_get/CMakeLists.txt
+++ b/tests/cmake/zephyr_get/CMakeLists.txt
@@ -600,6 +600,101 @@ function(test_snippets_scope)
   assert_equal(VARIABLE_1 "snippet 1")
 endfunction()
 
+
+function(test_arglist)
+  if(NOT TARGET snippets_scope)
+    zephyr_create_scope(snippets)
+  endif()
+
+  foreach(var VARIABLE_1 VARIABLE_2 TESTCASE_VARIABLE)
+    zephyr_set(${var} SCOPE snippets)
+    unset(ENV{${var}})
+    unset(${var} CACHE)
+    unset(${var})
+  endforeach()
+
+  # String values are handled by separate_arguments().
+  set(ENV{VARIABLE_1} "--environment value --environment \"value with spaces\"")
+  zephyr_get(VARIABLE_1 ARGLIST)
+  assert_equal(VARIABLE_1 "--environment;value;--environment;value with spaces")
+
+  unset(VARIABLE_1 CACHE)
+  zephyr_set(VARIABLE_1 "--snippet value -- -a 1 -b=2 -c '3' -d='4' -e \"5\" -f=\"6\"" SCOPE snippets)
+
+  zephyr_get(VARIABLE_1 ARGLIST)
+  assert_equal(VARIABLE_1 "--snippet;value;--;-a;1;-b=2;-c;3;-d=4;-e;5;-f=6")
+
+  # List values are kept as is, including quotes.
+  set(VARIABLE_1 --cmake-cache value --cmake-cache "value with spaces" CACHE INTERNAL "")
+  zephyr_get(VARIABLE_1 ARGLIST)
+  assert_equal(VARIABLE_1 "--cmake-cache;value;--cmake-cache;value with spaces")
+
+  zephyr_set(VARIABLE_1 SCOPE snippets)
+  unset(ENV{VARIABLE_1})
+  unset(VARIABLE_1 CACHE)
+  set(VARIABLE_1 --local value -- -a 1 -b=2 -c '3' -d='4' -e \"5\" -f=\"6\")
+
+  zephyr_get(VARIABLE_1 ARGLIST)
+  assert_equal(VARIABLE_1 "--local;value;--;-a;1;-b=2;-c;'3';-d='4';-e;\"5\";-f=\"6\"")
+
+  # Duplicates (here: -I) are *not* removed, even with MERGE ARGLIST.
+  set(ENV{VARIABLE_1} "-I /path/1/env")
+  set(ENV{VARIABLE_2} "-I /path/2/env")
+  zephyr_set(VARIABLE_1 "-I /path/1/snippet" SCOPE snippets)
+  zephyr_set(VARIABLE_2 "-I /path/2/snippet" SCOPE snippets)
+  set(VARIABLE_1 "-I /path/1/cache" CACHE INTERNAL "")
+  set(VARIABLE_2 "-I /path/2/cache" CACHE INTERNAL "")
+  set(VARIABLE_1 "-I /path/1/local")
+  set(VARIABLE_2 "-I /path/2/local")
+
+  zephyr_get(RESULT MERGE ARGLIST VAR VARIABLE_1 VARIABLE_2)
+  assert_equal(RESULT "-I;/path/1/cache;-I;/path/2/cache;-I;/path/1/snippet;-I;/path/2/snippet;-I;/path/1/env;-I;/path/2/env;-I;/path/1/local;-I;/path/2/local")
+
+  zephyr_set(VARIABLE_2 SCOPE snippets)
+  unset(ENV{VARIABLE_2})
+  unset(VARIABLE_2)
+
+  # A cache-only value, not defined in current scope, should only appear once.
+  set(VARIABLE_2 "same value" CACHE INTERNAL "")
+  set(VARIABLE_2 "same value")
+
+  zephyr_get(VARIABLE_2 MERGE ARGLIST)
+  assert_equal(VARIABLE_2 "same;value;same;value")
+
+  unset(VARIABLE_2)
+  zephyr_get(VARIABLE_2 MERGE ARGLIST)
+  assert_equal(VARIABLE_2 "same;value")
+
+  # Both space-separated strings and CMake lists can be found in different scopes.
+  set(TESTCASE_VARIABLE "-arg3 \"cmake cache\"" CACHE INTERNAL "")
+  zephyr_set(TESTCASE_VARIABLE "-arg2;snippet" SCOPE snippets)
+  set(ENV{TESTCASE_VARIABLE} "-arg1 environment")
+  set(TESTCASE_VARIABLE "-arg0" "local")
+
+  zephyr_get(TESTCASE_VARIABLE MERGE REVERSE SYSBUILD LOCAL ARGLIST)
+  assert_equal(TESTCASE_VARIABLE
+    IMAGE no_sysbuild    "-arg0;local;-arg1;environment;-arg2;snippet;-arg3;cmake cache"
+    IMAGE zephyr_get     "-arg0;local;-arg1;environment;-arg2;snippet;-arg3;cmake cache;sysbuild.main"
+    IMAGE zephyr_get_2nd "-arg0;local;-arg1;environment;-arg2;snippet;-arg3;cmake cache;sysbuild.2nd"
+    IMAGE zephyr_get_3rd "-arg0;local;-arg1;environment;-arg2;snippet;-arg3;cmake cache"
+    IMAGE zephyr_get_4th "-arg0;local;-arg1;environment;-arg2;snippet;-arg3;cmake cache;sysbuild.main"
+  )
+  unset(TESTCASE_VARIABLE)
+  zephyr_get(TESTCASE_VARIABLE MERGE REVERSE SYSBUILD GLOBAL ARGLIST)
+  assert_equal(TESTCASE_VARIABLE
+    IMAGE no_sysbuild    "-arg1;environment;-arg2;snippet;-arg3;cmake cache"
+    # This image's LOCAL and GLOBAL are identical, and the value appears once,
+    # taken only from -DTESTCASE_VARIABLE=<...>.
+    IMAGE zephyr_get     "-arg1;environment;-arg2;snippet;-arg3;cmake cache;sysbuild.main"
+    IMAGE zephyr_get_2nd "-arg1;environment;-arg2;snippet;-arg3;cmake cache;sysbuild.main;sysbuild.2nd"
+    IMAGE zephyr_get_3rd "-arg1;environment;-arg2;snippet;-arg3;cmake cache;sysbuild.main"
+    # This image's LOCAL and GLOBAL are identical, and the value appears twice,
+    # taken from -DTESTCASE_VARIABLE=<...> and -Dzephyr_get_4th_TESTCASE_VARIABLE=<...>.
+    IMAGE zephyr_get_4th "-arg1;environment;-arg2;snippet;-arg3;cmake cache;sysbuild.main;sysbuild.main"
+  )
+endfunction()
+
+
 run_suite(
   test_precedence
   test_precedence_with_sysbuild
@@ -607,4 +702,5 @@ run_suite(
   test_multivar
   test_merge_reverse
   test_snippets_scope
+  test_arglist
 )

--- a/tests/cmake/zephyr_get/CMakeLists.txt
+++ b/tests/cmake/zephyr_get/CMakeLists.txt
@@ -137,6 +137,9 @@ function(test_precedence_with_sysbuild)
     # GLOBAL sysbuild-defined value for this tertiary image;
     # it has no LOCAL value of its own.
     IMAGE zephyr_get_3rd "sysbuild.main"
+    # Provided -Dzephyr_get_4th_TESTCASE_VARIABLE=<...> serves as
+    # the LOCAL sysbuild-defined value for this quaternary image.
+    IMAGE zephyr_get_4th "sysbuild.main"
   )
 
   unset(TESTCASE_VARIABLE CACHE)
@@ -149,12 +152,14 @@ function(test_precedence_with_sysbuild)
     IMAGE zephyr_get_2nd "sysbuild.2nd"
     # This image has no LOCAL sysbuild-defined value.
     IMAGE zephyr_get_3rd "environment"
+    IMAGE zephyr_get_4th "sysbuild.main"
   )
   assert_equal(CACHE{TESTCASE_VARIABLE}
     IMAGE no_sysbuild    "environment"
     IMAGE zephyr_get     ""
     IMAGE zephyr_get_2nd ""
     IMAGE zephyr_get_3rd "environment"
+    IMAGE zephyr_get_4th ""
   )
 
   unset(TESTCASE_VARIABLE CACHE)
@@ -168,6 +173,7 @@ function(test_precedence_with_sysbuild)
     IMAGE zephyr_get     "sysbuild.main"
     IMAGE zephyr_get_2nd "sysbuild.2nd"
     IMAGE zephyr_get_3rd "sysbuild.main"
+    IMAGE zephyr_get_4th "sysbuild.main"
   )
 endfunction()
 
@@ -220,6 +226,7 @@ function(test_merge)
     IMAGE zephyr_get_2nd "sysbuild.2nd"
     # This image has no LOCAL sysbuild-defined value.
     IMAGE zephyr_get_3rd ""
+    IMAGE zephyr_get_4th "sysbuild.main"
   )
 
   unset(TESTCASE_VARIABLE)
@@ -232,6 +239,8 @@ function(test_merge)
     IMAGE zephyr_get     "sysbuild.main"
     IMAGE zephyr_get_2nd "sysbuild.2nd;sysbuild.main"
     IMAGE zephyr_get_3rd "sysbuild.main"
+    # This image's LOCAL and GLOBAL are identical; duplicates are removed.
+    IMAGE zephyr_get_4th "sysbuild.main"
   )
 
   # Add more variable scopes.
@@ -245,6 +254,7 @@ function(test_merge)
     IMAGE zephyr_get     "sysbuild.main;cmake cache;environment;local"
     IMAGE zephyr_get_2nd "sysbuild.2nd;sysbuild.main;cmake cache;environment;local"
     IMAGE zephyr_get_3rd "sysbuild.main;cmake cache;environment;local"
+    IMAGE zephyr_get_4th "sysbuild.main;cmake cache;environment;local"
   )
 
   unset(TESTCASE_VARIABLE)
@@ -254,6 +264,7 @@ function(test_merge)
     IMAGE zephyr_get     "sysbuild.main;cmake cache;environment"
     IMAGE zephyr_get_2nd "sysbuild.2nd;cmake cache;environment"
     IMAGE zephyr_get_3rd "cmake cache;environment"
+    IMAGE zephyr_get_4th "sysbuild.main;cmake cache;environment"
   )
 
   unset(TESTCASE_VARIABLE)
@@ -266,6 +277,7 @@ function(test_merge)
     IMAGE zephyr_get     "sysbuild.main;environment"
     IMAGE zephyr_get_2nd "sysbuild.2nd;sysbuild.main;environment"
     IMAGE zephyr_get_3rd "sysbuild.main;environment"
+    IMAGE zephyr_get_4th "sysbuild.main;environment"
   )
   assert_equal(CACHE{TESTCASE_VARIABLE} "")
 endfunction()
@@ -363,6 +375,7 @@ function(test_multivar)
     IMAGE zephyr_get     "sysbuild.main"
     IMAGE zephyr_get_2nd "sysbuild.2nd"
     IMAGE zephyr_get_3rd "sysbuild.main"
+    IMAGE zephyr_get_4th "sysbuild.main"
   )
   zephyr_get(RESULT SYSBUILD LOCAL VAR TESTCASE_VARIABLE VARIABLE_1 VARIABLE_2 VARIABLE_3)
   assert_equal(RESULT
@@ -370,6 +383,7 @@ function(test_multivar)
     IMAGE zephyr_get     "sysbuild.main"
     IMAGE zephyr_get_2nd "sysbuild.2nd"
     IMAGE zephyr_get_3rd "cmake cache s"
+    IMAGE zephyr_get_4th "sysbuild.main"
   )
 
   unset(RESULT)
@@ -379,6 +393,7 @@ function(test_multivar)
     IMAGE zephyr_get     "sysbuild.main;cmake cache s;cmake cache 2;environment s;environment 1;environment 3;local s;local 2;local 3"
     IMAGE zephyr_get_2nd "sysbuild.2nd;sysbuild.main;cmake cache s;cmake cache 2;environment s;environment 1;environment 3;local s;local 2;local 3"
     IMAGE zephyr_get_3rd "sysbuild.main;cmake cache s;cmake cache 2;environment s;environment 1;environment 3;local s;local 2;local 3"
+    IMAGE zephyr_get_4th "sysbuild.main;cmake cache s;cmake cache 2;environment s;environment 1;environment 3;local s;local 2;local 3"
   )
   unset(RESULT)
   zephyr_get(RESULT SYSBUILD LOCAL MERGE VAR TESTCASE_VARIABLE VARIABLE_1 VARIABLE_2 VARIABLE_3)
@@ -387,6 +402,7 @@ function(test_multivar)
     IMAGE zephyr_get     "sysbuild.main;cmake cache s;cmake cache 2;environment s;environment 1;environment 3;local s;local 2;local 3"
     IMAGE zephyr_get_2nd "sysbuild.2nd;cmake cache s;cmake cache 2;environment s;environment 1;environment 3;local s;local 2;local 3"
     IMAGE zephyr_get_3rd "cmake cache s;cmake cache 2;environment s;environment 1;environment 3;local s;local 2;local 3"
+    IMAGE zephyr_get_4th "sysbuild.main;cmake cache s;cmake cache 2;environment s;environment 1;environment 3;local s;local 2;local 3"
   )
   unset(RESULT)
   zephyr_get(RESULT SYSBUILD GLOBAL MERGE VAR VARIABLE_3 VARIABLE_2 VARIABLE_1 TESTCASE_VARIABLE)
@@ -395,6 +411,7 @@ function(test_multivar)
     IMAGE zephyr_get     "sysbuild.main;cmake cache 2;cmake cache s;environment 3;environment 1;environment s;local 3;local 2;local s"
     IMAGE zephyr_get_2nd "sysbuild.2nd;sysbuild.main;cmake cache 2;cmake cache s;environment 3;environment 1;environment s;local 3;local 2;local s"
     IMAGE zephyr_get_3rd "sysbuild.main;cmake cache 2;cmake cache s;environment 3;environment 1;environment s;local 3;local 2;local s"
+    IMAGE zephyr_get_4th "sysbuild.main;cmake cache 2;cmake cache s;environment 3;environment 1;environment s;local 3;local 2;local s"
   )
   unset(RESULT)
   zephyr_get(RESULT SYSBUILD LOCAL MERGE VAR VARIABLE_3 VARIABLE_2 VARIABLE_1 TESTCASE_VARIABLE)
@@ -403,6 +420,7 @@ function(test_multivar)
     IMAGE zephyr_get     "sysbuild.main;cmake cache 2;cmake cache s;environment 3;environment 1;environment s;local 3;local 2;local s"
     IMAGE zephyr_get_2nd "sysbuild.2nd;cmake cache 2;cmake cache s;environment 3;environment 1;environment s;local 3;local 2;local s"
     IMAGE zephyr_get_3rd "cmake cache 2;cmake cache s;environment 3;environment 1;environment s;local 3;local 2;local s"
+    IMAGE zephyr_get_4th "sysbuild.main;cmake cache 2;cmake cache s;environment 3;environment 1;environment s;local 3;local 2;local s"
   )
 endfunction()
 
@@ -451,6 +469,7 @@ function(test_merge_reverse)
     IMAGE zephyr_get     "sysbuild.main"
     IMAGE zephyr_get_2nd "sysbuild.main;sysbuild.2nd"
     IMAGE zephyr_get_3rd "sysbuild.main"
+    IMAGE zephyr_get_4th "sysbuild.main"
   )
 
   # Add more variable scopes.
@@ -464,6 +483,7 @@ function(test_merge_reverse)
     IMAGE zephyr_get     "local s;environment s;cmake cache s;sysbuild.main"
     IMAGE zephyr_get_2nd "local s;environment s;cmake cache s;sysbuild.main;sysbuild.2nd"
     IMAGE zephyr_get_3rd "local s;environment s;cmake cache s;sysbuild.main"
+    IMAGE zephyr_get_4th "local s;environment s;cmake cache s;sysbuild.main"
   )
 
   unset(TESTCASE_VARIABLE)
@@ -473,6 +493,7 @@ function(test_merge_reverse)
     IMAGE zephyr_get     "environment s;cmake cache s;sysbuild.main"
     IMAGE zephyr_get_2nd "environment s;cmake cache s;sysbuild.2nd"
     IMAGE zephyr_get_3rd "environment s;cmake cache s"
+    IMAGE zephyr_get_4th "environment s;cmake cache s;sysbuild.main"
   )
 
   unset(RESULT)
@@ -485,6 +506,7 @@ function(test_merge_reverse)
     IMAGE zephyr_get     "local s;local 1;local 2;environment s;environment 1;environment 2;cmake cache s;cmake cache 1;cmake cache 2;sysbuild.main"
     IMAGE zephyr_get_2nd "local s;local 1;local 2;environment s;environment 1;environment 2;cmake cache s;cmake cache 1;cmake cache 2;sysbuild.main;sysbuild.2nd"
     IMAGE zephyr_get_3rd "local s;local 1;local 2;environment s;environment 1;environment 2;cmake cache s;cmake cache 1;cmake cache 2;sysbuild.main"
+    IMAGE zephyr_get_4th "local s;local 1;local 2;environment s;environment 1;environment 2;cmake cache s;cmake cache 1;cmake cache 2;sysbuild.main"
   )
 endfunction()
 
@@ -543,6 +565,7 @@ function(test_snippets_scope)
     IMAGE zephyr_get     "sysbuild.main"
     IMAGE zephyr_get_2nd "sysbuild.2nd"
     IMAGE zephyr_get_3rd "sysbuild.main"
+    IMAGE zephyr_get_4th "sysbuild.main"
   )
   zephyr_get(TESTCASE_VARIABLE SYSBUILD LOCAL)
   assert_equal(TESTCASE_VARIABLE
@@ -550,6 +573,7 @@ function(test_snippets_scope)
     IMAGE zephyr_get     "sysbuild.main"
     IMAGE zephyr_get_2nd "sysbuild.2nd"
     IMAGE zephyr_get_3rd "snippet s"
+    IMAGE zephyr_get_4th "sysbuild.main"
   )
   unset(TESTCASE_VARIABLE)
   zephyr_get(TESTCASE_VARIABLE MERGE SYSBUILD GLOBAL)
@@ -558,6 +582,7 @@ function(test_snippets_scope)
     IMAGE zephyr_get     "sysbuild.main;snippet s"
     IMAGE zephyr_get_2nd "sysbuild.2nd;sysbuild.main;snippet s"
     IMAGE zephyr_get_3rd "sysbuild.main;snippet s"
+    IMAGE zephyr_get_4th "sysbuild.main;snippet s"
   )
 
   # If an environment value wins, it gets cached and promoted above snippets.

--- a/tests/cmake/zephyr_get/sysbuild.cmake
+++ b/tests/cmake/zephyr_get/sysbuild.cmake
@@ -3,7 +3,7 @@
 # Add a few copies of the same image, so that we can configure
 # multiple instances of the same test suite with minor tweaks,
 # including different arguments given to them via testcase.yaml.
-foreach(suffix "2nd" "3rd")
+foreach(suffix "2nd" "3rd" "4th")
   set(image ${DEFAULT_IMAGE}_${suffix})
   if(NOT TARGET ${image})
     ExternalZephyrProject_Add(

--- a/tests/cmake/zephyr_get/testcase.yaml
+++ b/tests/cmake/zephyr_get/testcase.yaml
@@ -9,3 +9,4 @@ tests:
     sysbuild: true
     extra_args: TESTCASE_VARIABLE="sysbuild.main"
       zephyr_get_2nd_TESTCASE_VARIABLE="sysbuild.2nd"
+      zephyr_get_4th_TESTCASE_VARIABLE="sysbuild.main"


### PR DESCRIPTION
This requires using `zephyr_get()`, but the story doesn't end there. Users are allowed to specify these extra flags in one of two ways:

  * `-DEXTRA_CFLAGS="--flag1 --flag2"` (space-separated string)
  * `-DEXTRA_CFLAGS="--flag1;--flag2"` (CMake list)

In this example, `EXTRA_CFLAGS` must either be interpreted as a list, or converted to a list using `separate_arguments()`. The principle for this was established in commit b066ae906b7e44c50c5233129db921081aa2e4b0:

> To allow the use of CMake lists, the length of the argument as a CMake
  list is tested. This ensures that when the argument contains a
  single `;` then the length is >1 and no conversion is needed.

The challenge is that in sysbuild, `EXTRA_CFLAGS` can be passed multiple times, e.g., to set a global value for all images, then local values for individual images. It would be reasonable to handle both representations when parsing each value separately:

  * `-DEXTRA_CFLAGS="--flag1 --flag2 --flag3"`
  * `-Dimage1_EXTRA_CFLAGS="--flag4;--flag5;--flag6"`
  * `-Dimage2_EXTRA_CFLAGS="--flag7 --flag8 --flag9"`

Then, the flags for each image should sum up to:

  * `image1: --flag1 --flag2 --flag3 --flag4 --flag5 --flag6`
  * `image2: --flag1 --flag2 --flag3 --flag7 --flag8 --flag9`

To that end, `zephyr_get()` is extended with `ARGLIST` option, which takes the conversion logic from `extra_flags.cmake` and allows it to be reused for similar variables. The above example can then be realized by calling:

`zephyr_get(EXTRA_CFLAGS MERGE ARGLIST)`.