### PR TITLE
cmake: Enable unit_testing board in sysbuild

### DIFF
--- a/cmake/modules/root.cmake
+++ b/cmake/modules/root.cmake
@@ -34,10 +34,3 @@ zephyr_file(APPLICATION_ROOT BOARD_ROOT)
 zephyr_file(APPLICATION_ROOT SOC_ROOT)
 zephyr_file(APPLICATION_ROOT ARCH_ROOT)
 zephyr_file(APPLICATION_ROOT SCA_ROOT)
-
-if(unittest IN_LIST Zephyr_FIND_COMPONENTS)
-  # Zephyr used in unittest mode, use dedicated unittest root.
-  set(BOARD_ROOT ${ZEPHYR_BASE}/subsys/testsuite)
-  set(ARCH_ROOT  ${ZEPHYR_BASE}/subsys/testsuite)
-  set(SOC_ROOT   ${ZEPHYR_BASE}/subsys/testsuite)
-endif()

--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -2,7 +2,10 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
+include(extensions)
+include(basic_settings)
 include(root)
+include(unittest_root)
 include(boards)
 include(arch)
 include(configuration_files)

--- a/cmake/modules/unittest_root.cmake
+++ b/cmake/modules/unittest_root.cmake
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2023, Nordic Semiconductor ASA
+
+# Set Zephyr roots to support unittest mode. This is an optional CMake module,
+# which allows the build system to locate the dedicated unit testing board.
+#
+# Outcome:
+# The following variables will be defined when this CMake module completes:
+#
+# - BOARD_ROOT: Board root containing the unit_testing board
+# - ARCH_ROOT:  Arch root containing the unit_testing arch
+# - SOC_ROOT:   SoC root containing the unit_testing SoC
+#
+# Note:
+# This module will override previous values of the ROOT variables named above.
+# The root.cmake module may be loaded next, to add more items to each ROOT list.
+
+set(BOARD_ROOT ${ZEPHYR_BASE}/subsys/testsuite)
+set(ARCH_ROOT  ${ZEPHYR_BASE}/subsys/testsuite)
+set(SOC_ROOT   ${ZEPHYR_BASE}/subsys/testsuite)

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -22,7 +22,6 @@ from typing import List
 from packaging import version
 
 from colorama import Fore
-from domains import Domains
 from twisterlib.cmakecache import CMakeCache
 from twisterlib.environment import canonical_zephyr_base
 from twisterlib.error import BuildError
@@ -421,12 +420,7 @@ class FilterBuilder(CMake):
             return {}
 
         if self.testsuite.sysbuild and not filter_stages:
-            # Load domain yaml to get default domain build directory
-            domain_path = os.path.join(self.build_dir, "domains.yaml")
-            domains = Domains.from_file(domain_path)
-            logger.debug("Loaded sysbuild domain data from %s" % (domain_path))
-            self.instance.domains = domains
-            domain_build = domains.get_default_domain().build_dir
+            domain_build = self.instance.domains.get_default_domain().build_dir
             cmake_cache_path = os.path.join(domain_build, "CMakeCache.txt")
             defconfig_path = os.path.join(domain_build, "zephyr", ".config")
             edt_pickle = os.path.join(domain_build, "zephyr", "edt.pickle")

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -4,6 +4,7 @@
 # Copyright 2022 NXP
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+from functools import cached_property
 import os
 import hashlib
 import random
@@ -24,6 +25,7 @@ from twisterlib.handlers import (
     SUPPORTED_SIMS,
     SUPPORTED_SIMS_IN_PYTEST,
 )
+from domains import Domains
 
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
@@ -57,13 +59,22 @@ class TestInstance:
         self.dut = None
         self.build_dir = os.path.join(outdir, platform.name, testsuite.name)
 
-        self.domains = None
-
         self.run = False
         self.testcases: list[TestCase] = []
         self.init_cases()
         self.filters = []
         self.filter_type = None
+
+    @cached_property
+    def domains(self):
+        if not self.testsuite.sysbuild:
+            return None
+
+        # Load domain yaml to get default domain build directory
+        domain_path = os.path.join(self.build_dir, "domains.yaml")
+        domains = Domains.from_file(domain_path)
+        logger.debug("Loaded sysbuild domain data from %s" % (domain_path))
+        return domains
 
     def add_filter(self, reason, filter_type):
         self.filters.append({'type': filter_type, 'reason': reason })

--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -18,7 +18,7 @@ set(APP_DIR ${APP_DIR} CACHE PATH "Main Application Source Directory")
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/modules)
 # List of Zephyr and sysbuild CMake modules we need for sysbuild.
 # Note: sysbuild_kconfig will internally load kconfig CMake module.
-set(zephyr_modules extensions sysbuild_extensions python west root zephyr_module boards shields sysbuild_kconfig)
+set(zephyr_modules extensions sysbuild_extensions python west unittest_root root zephyr_module boards shields sysbuild_kconfig)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS ${zephyr_modules})
 

--- a/tests/cmake/zephyr_get/CMakeLists.txt
+++ b/tests/cmake/zephyr_get/CMakeLists.txt
@@ -2,9 +2,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS unittest)
 project(zephyr_get_test)
-target_sources(app PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c)
 
 if(SYSBUILD)
   get_property(IMAGE_NAME TARGET sysbuild_cache PROPERTY SYSBUILD_NAME)

--- a/tests/cmake/zephyr_get/testcase.yaml
+++ b/tests/cmake/zephyr_get/testcase.yaml
@@ -1,11 +1,11 @@
 common:
   tags: cmake
+  type: unit
   build_only: true
-  platform_allow: native_posix
 tests:
-  zephyr_get.no_sysbuild:
+  cmake.zephyr_get.no_sysbuild:
     sysbuild: false
-  zephyr_get.sysbuild:
+  cmake.zephyr_get.sysbuild:
     sysbuild: true
     extra_args: TESTCASE_VARIABLE="sysbuild.main"
       zephyr_get_2nd_TESTCASE_VARIABLE="sysbuild.2nd"


### PR DESCRIPTION
Allow sysbuild to build Zephyr applications in unittest mode.

`zephyr_get()` tests are updated to use the `unit_testing` platform to speed up build times.

Twister changes are included.