### PR TITLE
ci: consolidate workflows and run in sequence

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   twister-build-prep:
+    name: Check what needs to be run based on changes
     if: github.repository_owner == 'zephyrproject-rtos'
     runs-on: zephyr-runner-linux-x64-4xlarge
     container:
@@ -299,6 +300,134 @@ jobs:
           path: |
             frozen-requirements.txt
 
+  clang-build:
+    needs: [twister-build-prep]
+    if: |
+      github.repository_owner == 'zephyrproject-rtos' &&
+      needs.twister-build-prep.outputs.size != 0 &&
+      github.event_name == 'pull_request_target'
+    runs-on: zephyr-runner-linux-x64-4xlarge
+    container:
+      image: ghcr.io/zephyrproject-rtos/ci:v0.26.7
+      options: '--entrypoint /bin/bash'
+      volumes:
+        - /repo-cache/zephyrproject:/github/cache/zephyrproject
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ["native_sim"]
+    env:
+      LLVM_TOOLCHAIN_PATH: /usr/lib/llvm-16
+      COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+      BASE_REF: ${{ github.base_ref }}
+    outputs:
+      report_needed: ${{ steps.twister.outputs.report_needed }}
+    steps:
+      - name: Apply container owner mismatch workaround
+        run: |
+          # FIXME: The owner UID of the GITHUB_WORKSPACE directory may not
+          #        match the container user UID because of the way GitHub
+          #        Actions runner is implemented. Remove this workaround when
+          #        GitHub comes up with a fundamental fix for this problem.
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+      - name: Clone cached Zephyr repository
+        continue-on-error: true
+        run: |
+          git clone --shared /github/cache/zephyrproject/zephyr .
+          git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Environment Setup
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          git config --global user.email "bot@zephyrproject.org"
+          git config --global user.name "Zephyr Bot"
+          rm -fr ".git/rebase-apply"
+          git rebase origin/${BASE_REF}
+          git log  --pretty=oneline | head -n 10
+          west init -l . || true
+          west config --global update.narrow true
+          west config manifest.group-filter -- +ci,+optional
+          # In some cases modules are left in a state where they can't be
+          # updated (i.e. when we cancel a job and the builder is killed),
+          # So first retry to update, if that does not work, remove all modules
+          # and start over. (Workaround until we implement more robust module
+          # west caching).
+          west update --path-cache /github/cache/zephyrproject 2>&1 1> west.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west2.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
+
+          echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
+
+      - name: Check Environment
+        run: |
+          cmake --version
+          ${LLVM_TOOLCHAIN_PATH}/bin/clang --version
+          gcc --version
+          ls -la
+
+      - name: Prepare ccache timestamp/data
+        id: ccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          string(REPLACE "/" "_" repo ${{github.repository}})
+          string(REPLACE "-" "_" repo2 ${repo})
+          file(APPEND $ENV{GITHUB_OUTPUT} "repo=${repo2}\n")
+
+      - name: use cache
+        id: cache-ccache
+        uses: zephyrproject-rtos/action-s3-cache@v1.2.0
+        with:
+          key: ${{ steps.ccache_cache_timestamp.outputs.repo }}-${{ github.ref_name }}-clang-${{ matrix.platform }}-ccache
+          path: /github/home/.cache/ccache
+          aws-s3-bucket: ccache.zephyrproject.org
+          aws-access-key-id: ${{ vars.AWS_CCACHE_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_CCACHE_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: ccache stats initial
+        run: |
+          mkdir -p /github/home/.cache
+          test -d github/home/.cache/ccache && rm -rf /github/home/.cache/ccache && mv github/home/.cache/ccache /github/home/.cache/ccache
+          ccache -M 10G -s
+
+      - name: Run Tests with Twister
+        id: twister
+        run: |
+          export ZEPHYR_BASE=${PWD}
+          export ZEPHYR_TOOLCHAIN_VARIANT=llvm
+
+          # check if we need to run a full twister or not based on files changed
+          python3 ./scripts/ci/test_plan.py --platform ${{ matrix.platform }} -c origin/${BASE_REF}..
+
+          # We can limit scope to just what has changed
+          if [ -s testplan.json ]; then
+            echo "report_needed=1" >> $GITHUB_OUTPUT
+            # Full twister but with options based on changes
+            ./scripts/twister --force-color --inline-logs -M -N -v --load-tests testplan.json --retry-failed 2
+          else
+            # if nothing is run, skip reporting step
+            echo "report_needed=0" >> $GITHUB_OUTPUT
+          fi
+
+      - name: ccache stats post
+        run: |
+          ccache -s
+          ccache -p
+
+      - name: Upload Unit Test Results
+        if: always() && steps.twister.outputs.report_needed != 0
+        uses: actions/upload-artifact@v4
+        with:
+          name: Unit Test Results (Subset ${{ matrix.platform }})
+          path: twister-out/twister.xml
+
   twister-test-results:
     name: "Publish Unit Tests Results"
     env:
@@ -354,6 +483,39 @@ jobs:
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          check_name: Unit Test Results
+          files: "**/twister.xml"
+          comment_mode: off
+
+  clang-build-results:
+    name: "Publish Unit Tests Results"
+    needs: clang-build
+    runs-on: ubuntu-22.04
+    if: (success() || failure() ) && needs.clang-build.outputs.report_needed != 0
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Merge Test Results
+        run: |
+          pip3 install junitparser junit2html
+          junitparser merge artifacts/*/twister.xml junit.xml
+          junit2html junit.xml junit-clang.html
+
+      - name: Upload Unit Test Results in HTML
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: HTML Unit Test Results
+          if-no-files-found: ignore
+          path: |
+            junit-clang.html
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
         with:
           check_name: Unit Test Results
           files: "**/twister.xml"


### PR DESCRIPTION
Run workflows in sequence and stop if we fail a long the way. If
compliance check fails, do not run tests, first get compliance passing
to allow for full test run.


Why are we doing this?

Our CI costs are skyrocketing and we need as much as possible to avoid useless CI builds. When someone is clearly struggling to pass the basic compliance checks, i.e. commit messages or formatting and keeps updating the PR to fix issues in compliance we still run twister on the code, EVERY time. This change will require the Compliance check to pass first before we go any further, reducing the CI time and load significanlty. 

First step:

- [x] Merge clang workflow
- [ ] Merge Compliance workflow


Signed-off-by: Anas Nashif <anas.nashif@intel.com>
