### PR TITLE
Fix leftover dependency to the CONFIG_SOC flag.

### DIFF
--- a/soc/xtensa/espressif_esp32/esp32s3/loader.c
+++ b/soc/xtensa/espressif_esp32/esp32s3/loader.c
@@ -20,7 +20,7 @@
 #ifdef CONFIG_BOOTLOADER_MCUBOOT
 
 #define BOOT_LOG_INF(_fmt, ...) \
-	ets_printf("[" CONFIG_SOC "] [INF] " _fmt "\n\r", ##__VA_ARGS__)
+	ets_printf("[" CONFIG_SOC_SERIES "] [INF] " _fmt "\n\r", ##__VA_ARGS__)
 
 #define HDR_ATTR __attribute__((section(".entry_addr"))) __attribute__((used))
 


### PR DESCRIPTION
After the latest esp32 refactoring this instance of the CONFIG_SOC flag was not renamed to CONFIG_SOC_SERIES.