### PR TITLE
kernel: Fix unused-parameter warnings

### DIFF
--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -88,6 +88,9 @@ static inline void handle_poll_events(struct k_queue *queue, uint32_t state)
 {
 #ifdef CONFIG_POLL
 	z_handle_obj_poll_events(&queue->poll_events, state);
+#else
+	ARG_UNUSED(queue);
+	ARG_UNUSED(state);
 #endif
 }
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -72,6 +72,7 @@ static inline int is_metairq(struct k_thread *thread)
 	return (thread->base.prio - K_HIGHEST_THREAD_PRIO)
 		< CONFIG_NUM_METAIRQ_PRIORITIES;
 #else
+	ARG_UNUSED(thread);
 	return 0;
 #endif
 }
@@ -214,6 +215,7 @@ static ALWAYS_INLINE void *thread_runq(struct k_thread *thread)
 
 	return &_kernel.cpus[cpu].ready_q.runq;
 #else
+	ARG_UNUSED(thread);
 	return &_kernel.ready_q.runq;
 #endif
 }
@@ -437,6 +439,8 @@ static inline int slice_time(struct k_thread *thread)
 	if (thread->base.slice_ticks != 0) {
 		ret = thread->base.slice_ticks;
 	}
+#else
+	ARG_UNUSED(thread);
 #endif
 	return ret;
 }
@@ -551,6 +555,8 @@ static void update_metairq_preempt(struct k_thread *thread)
 		/* Returning from existing preemption */
 		_current_cpu->metairq_preempted = NULL;
 	}
+#else
+	ARG_UNUSED(thread);
 #endif
 }
 
@@ -600,6 +606,7 @@ static bool thread_active_elsewhere(struct k_thread *thread)
 		}
 	}
 #endif
+	ARG_UNUSED(thread);
 	return false;
 }
 
@@ -1146,6 +1153,8 @@ void *z_get_next_switch_handle(void *interrupted)
 
 void z_priq_dumb_remove(sys_dlist_t *pq, struct k_thread *thread)
 {
+	ARG_UNUSED(pq);
+
 	__ASSERT_NO_MSG(!z_is_idle_thread_object(thread));
 
 	sys_dlist_remove(&thread->base.qnode_dlist);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -69,6 +69,9 @@ void k_thread_foreach(k_thread_user_cb_t user_cb, void *user_data)
 	SYS_PORT_TRACING_FUNC_EXIT(k_thread, foreach);
 
 	k_spin_unlock(&z_thread_monitor_lock, key);
+#else
+	ARG_UNUSED(user_cb);
+	ARG_UNUSED(user_data);
 #endif
 }
 
@@ -93,6 +96,9 @@ void k_thread_foreach_unlocked(k_thread_user_cb_t user_cb, void *user_data)
 	SYS_PORT_TRACING_FUNC_EXIT(k_thread, foreach_unlocked);
 
 	k_spin_unlock(&z_thread_monitor_lock, key);
+#else
+	ARG_UNUSED(user_cb);
+	ARG_UNUSED(user_data);
 #endif
 }
 
@@ -895,6 +901,7 @@ int z_impl_k_float_disable(struct k_thread *thread)
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	return arch_float_disable(thread);
 #else
+	ARG_UNUSED(thread);
 	return -ENOTSUP;
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 }
@@ -904,6 +911,8 @@ int z_impl_k_float_enable(struct k_thread *thread, unsigned int options)
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	return arch_float_enable(thread, options);
 #else
+	ARG_UNUSED(thread);
+	ARG_UNUSED(options);
 	return -ENOTSUP;
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 }

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -598,6 +598,9 @@ bool k_work_cancel_sync(struct k_work *work,
  */
 static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 {
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	struct k_work_q *queue = (struct k_work_q *)workq_ptr;
 
 	while (true) {


### PR DESCRIPTION
Add missing ARG_UNUSED where needed.