### PR TITLE
Align ST sensor drivers to stmemsc HAL i/f v2.3

### DIFF
--- a/drivers/sensor/lsm6dso/lsm6dso_shub.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_shub.c
@@ -485,7 +485,7 @@ static int lsm6dso_shub_read_target_reg(const struct device *dev,
 	trgt_cfg.slv_subadd = trgt_reg;
 	trgt_cfg.slv_len = len;
 
-	lsm6dso_sh_slv0_cfg_read(ctx, &trgt_cfg);
+	lsm6dso_sh_slv_cfg_read(ctx, 0, &trgt_cfg);
 
 	/* turn SH on, wait for shub i2c read to finish */
 	lsm6dso_shub_enable(dev, 1);
@@ -565,12 +565,6 @@ static int lsm6dso_shub_set_data_channel(const struct device *dev)
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	uint8_t n;
 	struct lsm6dso_shub_slist *sp;
-	int32_t (*sh_chan_cfg[LSM6DSO_SHUB_MAX_NUM_TARGETS])
-			(stmdev_ctx_t *ctx, lsm6dso_sh_cfg_read_t *val) = {
-		lsm6dso_sh_slv1_cfg_read,
-		lsm6dso_sh_slv2_cfg_read,
-		lsm6dso_sh_slv3_cfg_read,
-	};
 	lsm6dso_sh_cfg_read_t trgt_cfg;
 
 	/* Configure shub data channels to access external targets */
@@ -581,7 +575,7 @@ static int lsm6dso_shub_set_data_channel(const struct device *dev)
 		trgt_cfg.slv_subadd = sp->out_data_addr;
 		trgt_cfg.slv_len = sp->out_data_len;
 
-		if (sh_chan_cfg[n](ctx, &trgt_cfg) < 0) {
+		if (lsm6dso_sh_slv_cfg_read(ctx, n + 1, &trgt_cfg) < 0) {
 			LOG_DBG("shub: error configuring shub for ext targets");
 			return -EIO;
 		}

--- a/drivers/sensor/lsm6dso16is/lsm6dso16is_shub.c
+++ b/drivers/sensor/lsm6dso16is/lsm6dso16is_shub.c
@@ -580,14 +580,14 @@ static int lsm6dso16is_shub_read_target_reg(const struct device *dev,
 	trgt_cfg.slv_subadd = trgt_reg;
 	trgt_cfg.slv_len = len;
 
-	lsm6dso16is_sh_slv0_cfg_read(ctx, &trgt_cfg);
+	lsm6dso16is_sh_slv_cfg_read(ctx, 0, &trgt_cfg);
 
 	/* turn SH on, wait for shub i2c read to finish */
 	lsm6dso16is_shub_enable(dev, 1);
 	lsm6dso16is_shub_wait_completed(ctx);
 
 	/* read data from external target */
-	if (lsm6dso16is_sh_read_data_raw_get(ctx, (lsm6dso16is_emb_sh_read_t *)value, len) < 0) {
+	if (lsm6dso16is_sh_read_data_raw_get(ctx, value, len) < 0) {
 		LOG_DBG("shub: error reading sensor data");
 		return -EIO;
 	}
@@ -662,13 +662,6 @@ static int lsm6dso16is_shub_set_data_channel(const struct device *dev)
 	struct lsm6dso16is_shub_slist *sp;
 	lsm6dso16is_sh_cfg_read_t trgt_cfg;
 
-	int32_t (*sh_chan_cfg[LSM6DSO16IS_SHUB_MAX_NUM_TARGETS])
-			(stmdev_ctx_t *ctx, lsm6dso16is_sh_cfg_read_t *val) = {
-		lsm6dso16is_sh_slv1_cfg_read,
-		lsm6dso16is_sh_slv2_cfg_read,
-		lsm6dso16is_sh_slv3_cfg_read,
-	};
-
 	/* Configure shub data channels to access external targets */
 	for (n = 0; n < data->num_ext_dev; n++) {
 		sp = &lsm6dso16is_shub_slist[data->shub_ext[n]];
@@ -677,7 +670,7 @@ static int lsm6dso16is_shub_set_data_channel(const struct device *dev)
 		trgt_cfg.slv_subadd = sp->out_data_addr;
 		trgt_cfg.slv_len = sp->out_data_len;
 
-		if (sh_chan_cfg[n](ctx, &trgt_cfg) < 0) {
+		if (lsm6dso16is_sh_slv_cfg_read(ctx, n + 1, &trgt_cfg) < 0) {
 			LOG_DBG("shub: error configuring shub for ext targets");
 			return -EIO;
 		}

--- a/drivers/sensor/lsm6dsv16x/lsm6dsv16x_shub.c
+++ b/drivers/sensor/lsm6dsv16x/lsm6dsv16x_shub.c
@@ -580,14 +580,14 @@ static int lsm6dsv16x_shub_read_target_reg(const struct device *dev,
 	trgt_cfg.slv_subadd = trgt_reg;
 	trgt_cfg.slv_len = len;
 
-	lsm6dsv16x_sh_slv0_cfg_read(ctx, &trgt_cfg);
+	lsm6dsv16x_sh_slv_cfg_read(ctx, 0, &trgt_cfg);
 
 	/* turn SH on, wait for shub i2c read to finish */
 	lsm6dsv16x_shub_enable(dev, 1);
 	lsm6dsv16x_shub_wait_completed(ctx);
 
 	/* read data from external target */
-	if (lsm6dsv16x_sh_read_data_raw_get(ctx, (lsm6dsv16x_emb_sh_read_t *)value, len) < 0) {
+	if (lsm6dsv16x_sh_read_data_raw_get(ctx, value, len) < 0) {
 		LOG_DBG("shub: error reading sensor data");
 		return -EIO;
 	}
@@ -662,13 +662,6 @@ static int lsm6dsv16x_shub_set_data_channel(const struct device *dev)
 	struct lsm6dsv16x_shub_slist *sp;
 	lsm6dsv16x_sh_cfg_read_t trgt_cfg;
 
-	int32_t (*sh_chan_cfg[LSM6DSV16X_SHUB_MAX_NUM_TARGETS])
-			(stmdev_ctx_t *ctx, lsm6dsv16x_sh_cfg_read_t *val) = {
-		lsm6dsv16x_sh_slv1_cfg_read,
-		lsm6dsv16x_sh_slv2_cfg_read,
-		lsm6dsv16x_sh_slv3_cfg_read,
-	};
-
 	/* Configure shub data channels to access external targets */
 	for (n = 0; n < data->num_ext_dev; n++) {
 		sp = &lsm6dsv16x_shub_slist[data->shub_ext[n]];
@@ -677,7 +670,7 @@ static int lsm6dsv16x_shub_set_data_channel(const struct device *dev)
 		trgt_cfg.slv_subadd = sp->out_data_addr;
 		trgt_cfg.slv_len = sp->out_data_len;
 
-		if (sh_chan_cfg[n](ctx, &trgt_cfg) < 0) {
+		if (lsm6dsv16x_sh_slv_cfg_read(ctx, n + 1, &trgt_cfg) < 0) {
 			LOG_DBG("shub: error configuring shub for ext targets");
 			return -EIO;
 		}

--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: 5948f7b3304f1628a45ee928cd607619a7f53bbb
+      revision: 9b128caf3e7b2e750169b880e83f210ea2213473
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
Align all sensor drivers that are using stmemsc (STdC) HAL i/f to new APIs of stmemsc v2.3

Requires https://github.com/zephyrproject-rtos/hal_st/pull/16
(Merged with commit https://github.com/zephyrproject-rtos/hal_st/commit/9b128caf3e7b2e750169b880e83f210ea2213473)