### PR TITLE
Microchip: MEC172X: DTS: Fix symcr binding

### DIFF
--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -1043,9 +1043,9 @@
 			};
 		};
 
-		symcr: symcr@40100000 {
+		symcr: symcr@40108000 {
 			compatible = "microchip,xec-symcr";
-			reg = <0x40100000 0x1000>;
+			reg = <0x40108000 0x2000>;
 			interrupts = <68 1>;
 			clocks = <&pcr 3 26 MCHP_XEC_PCR_CLK_PERIPH>;
 			girqs = <16 3>;


### PR DESCRIPTION
The MEC172X Cryptographic memory is an 8K block that starts at address 0x40108000 according to the latest datasheet.