### PR TITLE
winc1500: WIFI_DISCONNECT request doesn't raise DISCONNECT_RESULT event

### DIFF
--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -641,6 +641,7 @@ static void handle_wifi_con_state_changed(void *pvMsg)
 		LOG_DBG("Connected (%u)", pstrWifiState->u8ErrCode);
 
 		w1500_data.connected = true;
+		w1500_data.connecting = false;
 		wifi_mgmt_raise_connect_result_event(w1500_data.iface, 0);
 
 		break;


### PR DESCRIPTION
Internal flag (w1500_data.connecting) was not being set to false after connection. This made the interface to raise a NET_EVENT_WIFI_CONNECT_RESULT event with an error status instead of a NET_EVENT_WIFI_DISCONNECT_RESULT when disconnection was manually requested (NET_REQUEST_WIFI_DISCONNECT).