### PR TITLE
linker: add _image_ram_size symbol to linker symbol definitions

### DIFF
--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -133,6 +133,7 @@ extern char _flash_used[];
 /* datas, bss, noinit */
 extern char _image_ram_start[];
 extern char _image_ram_end[];
+extern char _image_ram_size[];
 
 extern char __text_region_start[];
 extern char __text_region_end[];

--- a/include/zephyr/linker/ram-end.ld
+++ b/include/zephyr/linker/ram-end.ld
@@ -9,6 +9,7 @@
 	LAST_RAM_ALIGN
 #endif
 	_image_ram_end = .;
+	_image_ram_size = _image_ram_end - _image_ram_start;
 	_end = .; /* end of image */
 	z_mapped_end = .;
     } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -91,8 +91,13 @@ const clock_video_pll_config_t videoPllConfig = {
 
 #ifdef CONFIG_NXP_IMX_RT_BOOT_HEADER
 const __imx_boot_data_section BOOT_DATA_T boot_data = {
+#ifdef CONFIG_XIP
 	.start = CONFIG_FLASH_BASE_ADDRESS,
-	.size = KB(CONFIG_FLASH_SIZE),
+	.size = (uint32_t)&_flash_used,
+#else
+	.start = CONFIG_SRAM_BASE_ADDRESS,
+	.size = (uint32_t)&_image_ram_size,
+#endif
 	.plugin = PLUGIN_FLAG,
 	.placeholder = 0xFFFFFFFF,
 };

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -119,8 +119,13 @@ static const clock_video_pll_config_t videoPllConfig = {
 
 #ifdef CONFIG_NXP_IMX_RT_BOOT_HEADER
 const __imx_boot_data_section BOOT_DATA_T boot_data = {
+#ifdef CONFIG_XIP
 	.start = CONFIG_FLASH_BASE_ADDRESS,
-	.size = KB(CONFIG_FLASH_SIZE),
+	.size = (uint32_t)&_flash_used,
+#else
+	.start = CONFIG_SRAM_BASE_ADDRESS,
+	.size = (uint32_t)&_image_ram_size,
+#endif
 	.plugin = PLUGIN_FLAG,
 	.placeholder = 0xFFFFFFFF,
 };


### PR DESCRIPTION
Add _image_ram_size symbol to linker definitions. This symbol
corresponds to the total RAM used by the image.

This PR also adds a usage of `_image_ram_size`. The reason this symbol is introduced is because GCC will not compile the expression `((uint32_t)&_image_ram_end) - ((uint32_t)&_image_ram_start)`, with the error `error: initializer element is not constant`.