### PR TITLE
tests/kernel/interrupt: Enable 'icount' for qemu_cortex_m0

### DIFF
--- a/tests/kernel/interrupt/testcase.yaml
+++ b/tests/kernel/interrupt/testcase.yaml
@@ -2,7 +2,16 @@ tests:
   arch.interrupt:
     # nios2 excluded, see #22956
     arch_exclude: nios2
+    platform_exclude: qemu_cortex_m0
     tags:
       - kernel
       - interrupt
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
+  arch.interrupt.qemu_cortex_m0:
+    platform_allow: qemu_cortex_m0
+    tags:
+      - kernel
+      - interrupt
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
+    extra_configs:
+      - CONFIG_QEMU_ICOUNT=y


### PR DESCRIPTION
This test fails when icount is disabled, so enable it

See 7bdc621ba9e8b2ab9db8a5931676b542a648802c which disabled icount by default for this platform.

See also #58753 and #58990