### PR TITLE
drivers: sensor: expanding driver for STM32 quadrature encoder

### DIFF
--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -34,6 +34,10 @@ Required changes
   SMP version 2 error code defines for in-tree modules have been updated to
   replace the ``*_RET_RC_*`` parts with ``*_ERR_*``.
 
+* Quadrature decoder STM32 driver (:dtcompatible:`st,stm32-qdec` ) now has a
+  new property :dtcompatible:`st,encoder-mode` which is required.
+  The old behavior is the same as setting the property as :c:enumerator:`MODE_X2_TI1`.
+
 Recommended Changes
 *******************
 

--- a/drivers/sensor/qdec_stm32/qdec_stm32.c
+++ b/drivers/sensor/qdec_stm32/qdec_stm32.c
@@ -20,6 +20,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 #include <stm32_ll_tim.h>
 
@@ -32,6 +33,7 @@ struct qdec_stm32_dev_cfg {
 	TIM_TypeDef *timer_inst;
 	bool is_input_polarity_inverted;
 	uint8_t input_filtering_level;
+	uint8_t encoder_mode;
 	uint32_t counts_per_revolution;
 };
 
@@ -123,6 +125,18 @@ static int qdec_stm32_initialize(const struct device *dev)
 	}
 	LL_TIM_SetAutoReload(dev_cfg->timer_inst, max_counter_value);
 
+	switch (dev_cfg->encoder_mode) {
+	case MODE_X2_TI1:
+		init_props.EncoderMode = LL_TIM_ENCODERMODE_X2_TI1;
+		break;
+	case MODE_X2_TI2:
+		init_props.EncoderMode = LL_TIM_ENCODERMODE_X2_TI2;
+		break;
+	case MODE_X4_TI12:
+		init_props.EncoderMode = LL_TIM_ENCODERMODE_X4_TI12;
+		break;
+	}
+
 	if (LL_TIM_ENCODER_Init(dev_cfg->timer_inst, &init_props) != SUCCESS) {
 		LOG_ERR("Initalization failed");
 		return -EIO;
@@ -150,6 +164,7 @@ static const struct sensor_driver_api qdec_stm32_driver_api = {
 		.is_input_polarity_inverted = DT_INST_PROP(n, st_input_polarity_inverted),	\
 		.input_filtering_level = DT_INST_PROP(n, st_input_filter_level),		\
 		.counts_per_revolution = DT_INST_PROP(n, st_counts_per_revolution),		\
+		.encoder_mode = DT_INST_PROP(n, st_encoder_mode),				\
 	};										\
 											\
 	static struct qdec_stm32_dev_data qdec##n##_stm32_data;				\

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/reset/stm32f0_1_3_reset.h>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <freq.h>
 
 / {
@@ -282,6 +283,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				status = "disabled";
+				st,input-filter-level = <NO_FILTER>;
+			};
 		};
 
 		timers3: timers@40000400 {
@@ -303,6 +310,12 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				status = "disabled";
+				st,input-filter-level = <NO_FILTER>;
 			};
 		};
 

--- a/dts/bindings/sensor/st,stm32-qdec.yaml
+++ b/dts/bindings/sensor/st,stm32-qdec.yaml
@@ -70,3 +70,17 @@ properties:
     description: |
       This is a number >= 1 that is used to determine how many revolutions
       were done based on the current counter's value.
+
+  st,encoder-mode:
+    type: int
+    description: |
+      Encoder counting mode
+      MODE_X2_TI1 Counter counts up/down on TI2FP2 edge depending on TI1FP1 level
+      MODE_X2_TI2  Counter counts up/down on TI1FP1 edge depending on TI2FP2 level
+      MODE_X4_TI12 Counter counts up/down on both TI1FP1 and TI2FP2 edges
+      depending on the level of the other input
+    default: 0
+    enum:
+      - 0 # MODE_X2_TI1
+      - 1 # MODE_X2_TI2
+      - 2 # MODE_X4_TI1

--- a/dts/bindings/sensor/st,stm32-qdec.yaml
+++ b/dts/bindings/sensor/st,stm32-qdec.yaml
@@ -79,7 +79,7 @@ properties:
       MODE_X2_TI2  Counter counts up/down on TI1FP1 edge depending on TI2FP2 level
       MODE_X4_TI12 Counter counts up/down on both TI1FP1 and TI2FP2 edges
       depending on the level of the other input
-    default: 0
+    required: true
     enum:
       - 0 # MODE_X2_TI1
       - 1 # MODE_X2_TI2

--- a/include/zephyr/dt-bindings/sensor/qdec_stm32.h
+++ b/include/zephyr/dt-bindings/sensor/qdec_stm32.h
@@ -23,4 +23,9 @@
 #define FDIV32_N6	14
 #define FDIV32_N8	15
 
+
+#define MODE_X2_TI1	0
+#define MODE_X2_TI2	1
+#define MODE_X4_TI12	2
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_QDEC_STM32_H_ */

--- a/samples/sensor/qdec/boards/nucleo_f303re.overlay
+++ b/samples/sensor/qdec/boards/nucleo_f303re.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Giuseppe Iellamo <giuseppe.iellamo@altorobotics.ai>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+    aliases {
+        qdec0 = &qdec;
+    };
+};
+
+&timers3 {
+    status = "okay";
+
+    qdec: qdec {
+        status = "okay";
+        pinctrl-0 = <&tim3_ch1_pb4 &tim3_ch2_pb5>;
+        pinctrl-names = "default";
+        st,encoder-mode = <MODE_X4_TI12>;
+        st,input-filter-level = <FDIV1_N2>;
+        st,counts-per-revolution = <16>;
+    };
+};

--- a/samples/sensor/qdec/boards/nucleo_f401re.overlay
+++ b/samples/sensor/qdec/boards/nucleo_f401re.overlay
@@ -19,6 +19,7 @@
 		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
 		pinctrl-names = "default";
+		st,encoder-mode = <MODE_X2_TI1>;
 		st,input-polarity-inverted;
 		st,input-filter-level = <FDIV32_N8>;
 		st,counts-per-revolution = <16>;


### PR DESCRIPTION
Added a mode node to the qdec bindings.
And enable qdec for TIM2 and TIM3 of STM32F3.