### PR TITLE
soc: arm: nordic_nrf: nrf91: add nRF9131 LACA

### DIFF
--- a/dts/arm/nordic/nrf9131_laca.dtsi
+++ b/dts/arm/nordic/nrf9131_laca.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <nordic/nrf91.dtsi>
+
+&flash0 {
+	reg = <0x00000000 DT_SIZE_K(1024)>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+};
+
+/ {
+	soc {
+		compatible = "nordic,nrf9131-laca", "nordic,nrf9120",
+			     "nordic,nrf91", "simple-bus";
+	};
+};

--- a/dts/arm/nordic/nrf9131ns_laca.dtsi
+++ b/dts/arm/nordic/nrf9131ns_laca.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <nordic/nrf91ns.dtsi>
+
+&flash0 {
+	reg = <0x00000000 DT_SIZE_K(1024)>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+};
+
+/ {
+	soc {
+		compatible = "nordic,nrf9131-laca", "nordic,nrf9120",
+			     "nordic,nrf91", "simple-bus";
+	};
+};

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9131_LACA
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.defconfig.nrf9131_LACA
@@ -1,0 +1,14 @@
+# Nordic Semiconductor nRF9131 MCU
+
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF9131_LACA
+
+config SOC
+	default "nRF9131_LACA"
+
+config NUM_IRQS
+	default 65
+
+endif # SOC_NRF9131_LACA

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.soc
@@ -30,6 +30,10 @@ config SOC_NRF9161_SICA
 	bool "NRF9161_SICA"
 	select SOC_NRF9120
 
+config SOC_NRF9131_LACA
+	bool "NRF9131_LACA"
+	select SOC_NRF9120
+
 endchoice
 
 config NRF_ENABLE_ICACHE


### PR DESCRIPTION
This patch adds definitions for the nRF9131,
which is software-compatible with nRF9161.