### PR TITLE
subsys: pm: add check for device busy in policy

### DIFF
--- a/soc/x86/intel_ish/intel_ish5/pm/Kconfig.pm
+++ b/soc/x86/intel_ish/intel_ish5/pm/Kconfig.pm
@@ -18,4 +18,7 @@ config GDT_RESERVED_NUM_ENTRIES
 config REBOOT
 	default y
 
+config PM_NEED_ALL_DEVICES_IDLE
+	default y
+
 endif

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -37,6 +37,13 @@ config PM_S2RAM
 	help
 	  This option enables suspend-to-RAM (S2RAM).
 
+config PM_NEED_ALL_DEVICES_IDLE
+	bool "System Low Power Mode Needs All Devices Idle"
+	depends on PM_DEVICE && !SMP
+	help
+	  When this option is enabled, check that no devices are busy before
+	  entering into system low power mode.
+
 choice PM_POLICY
 	prompt "Idle State Power Management Policy"
 	default PM_POLICY_DEFAULT

--- a/subsys/pm/policy.c
+++ b/subsys/pm/policy.c
@@ -14,6 +14,7 @@
 #include <zephyr/sys/time_units.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/toolchain.h>
+#include <zephyr/pm/device.h>
 
 #if DT_HAS_COMPAT_STATUS_OKAY(zephyr_power_state)
 
@@ -135,6 +136,12 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 	int64_t cyc = -1;
 	uint8_t num_cpu_states;
 	const struct pm_state_info *cpu_states;
+
+#ifdef CONFIG_PM_NEED_ALL_DEVICES_IDLE
+	if (pm_device_is_any_busy()) {
+		return NULL;
+	}
+#endif
 
 	if (ticks != K_TICKS_FOREVER) {
 		cyc = k_ticks_to_cyc_ceil32(ticks);


### PR DESCRIPTION
Should add check for device busy here because one or more devices may still in busy, otherwise problem may happen due to system go into low power mode with some devices still in busy. Issue is observed in Intel ISH platform.