### PR TITLE
drivers: watchdog_shell: fix compiler error

### DIFF
--- a/drivers/watchdog/wdt_shell.c
+++ b/drivers/watchdog/wdt_shell.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdlib.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/drivers/watchdog.h>
 


### PR DESCRIPTION
Fix wdt_shell.c:54:13: error: implicit declaration of function 'strtoul'

Tested with west build -p -b nrf52dk_nrf52832 samples/drivers/watchdog -DCONFIG_SHELL=y.