### PR TITLE
usbc_vbus: make all APIs besides check_level optional.

### DIFF
--- a/include/zephyr/drivers/usb_c/usbc_vbus.h
+++ b/include/zephyr/drivers/usb_c/usbc_vbus.h
@@ -61,10 +61,15 @@ static inline bool usbc_vbus_check_level(const struct device *dev, enum tc_vbus_
  *
  * @retval 0 on success
  * @retval -EIO on failure
+ * @retval -ENOTSUP if the driver doesn't implement the request
  */
 static inline int usbc_vbus_measure(const struct device *dev, int *meas)
 {
 	const struct usbc_vbus_driver_api *api = (const struct usbc_vbus_driver_api *)dev->api;
+
+	if (api->measure == NULL) {
+		return -ENOTSUP;
+	}
 
 	return api->measure(dev, meas);
 }
@@ -78,10 +83,15 @@ static inline int usbc_vbus_measure(const struct device *dev, int *meas)
  * @retval 0 on success
  * @retval -EIO on failure
  * @retval -ENOENT if discharge pin isn't defined
+ * @retval -ENOTSUP if the driver doesn't implement the request
  */
 static inline int usbc_vbus_discharge(const struct device *dev, bool enable)
 {
 	const struct usbc_vbus_driver_api *api = (const struct usbc_vbus_driver_api *)dev->api;
+
+	if (api->discharge == NULL) {
+		return -ENOTSUP;
+	}
 
 	return api->discharge(dev, enable);
 }
@@ -95,10 +105,15 @@ static inline int usbc_vbus_discharge(const struct device *dev, bool enable)
  * @retval 0 on success
  * @retval -EIO on failure
  * @retval -ENOENT if enable pin isn't defined
+ * @retval -ENOTSUP if the driver doesn't implement the request
  */
 static inline int usbc_vbus_enable(const struct device *dev, bool enable)
 {
 	const struct usbc_vbus_driver_api *api = (const struct usbc_vbus_driver_api *)dev->api;
+
+	if (api->enable == NULL) {
+		return -ENOTSUP;
+	}
 
 	return api->enable(dev, enable);
 }


### PR DESCRIPTION
usbc_vbus: make all APIs besides check_level optional.


Even in the usb_c subsys samples, the only API that is always called is
check_level. Everything else appears closer to a quirk of how it is
implemented with the ADC driver.

For UPD350, these other APIs cannot be implemented, as it includes its
own comparator. Instead of returning -ENOTSUP on the driver itself,
make it generic enough as other controllers are likely lacking the
ability to take a raw measurement as well.

Signed-off-by: Diego Elio Pettenò <flameeyes@meta.com>
