### PR TITLE
samples: canbus: isotp: increase stack size and make it configurable, exit if RX thread creation failed, name threads

### DIFF
--- a/samples/subsys/canbus/isotp/Kconfig
+++ b/samples/subsys/canbus/isotp/Kconfig
@@ -10,4 +10,16 @@ config SAMPLE_LOOPBACK_MODE
 	help
 	  Set the CAN controller to loopback mode. This allows testing without a second board.
 
+config SAMPLE_RX_THREAD_STACK_SIZE
+	int "RX threads stack size"
+	default 1024
+	help
+	  Stack size (in bytes) used for the RX threads.
+
+config SAMPLE_RX_THREAD_PRIORITY
+	int "RX threads priority"
+	default 2
+	help
+	  Priority used for the RX threads.
+
 source "Kconfig.zephyr"

--- a/samples/subsys/canbus/isotp/src/main.c
+++ b/samples/subsys/canbus/isotp/src/main.c
@@ -7,10 +7,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/canbus/isotp.h>
 
-
-#define RX_THREAD_STACK_SIZE 512
-#define RX_THREAD_PRIORITY 2
-
 const struct isotp_fc_opts fc_opts_8_0 = {.bs = 8, .stmin = 0};
 const struct isotp_fc_opts fc_opts_0_5 = {.bs = 0, .stmin = 5};
 
@@ -39,8 +35,8 @@ const struct device *can_dev;
 struct isotp_recv_ctx recv_ctx_8_0;
 struct isotp_recv_ctx recv_ctx_0_5;
 
-K_THREAD_STACK_DEFINE(rx_8_0_thread_stack, RX_THREAD_STACK_SIZE);
-K_THREAD_STACK_DEFINE(rx_0_5_thread_stack, RX_THREAD_STACK_SIZE);
+K_THREAD_STACK_DEFINE(rx_8_0_thread_stack, CONFIG_SAMPLE_RX_THREAD_STACK_SIZE);
+K_THREAD_STACK_DEFINE(rx_0_5_thread_stack, CONFIG_SAMPLE_RX_THREAD_STACK_SIZE);
 struct k_thread rx_8_0_thread_data;
 struct k_thread rx_0_5_thread_data;
 
@@ -171,7 +167,7 @@ int main(void)
 	tid = k_thread_create(&rx_8_0_thread_data, rx_8_0_thread_stack,
 			      K_THREAD_STACK_SIZEOF(rx_8_0_thread_stack),
 			      rx_8_0_thread, NULL, NULL, NULL,
-			      RX_THREAD_PRIORITY, 0, K_NO_WAIT);
+			      CONFIG_SAMPLE_RX_THREAD_PRIORITY, 0, K_NO_WAIT);
 	if (!tid) {
 		printk("ERROR spawning rx thread\n");
 	}
@@ -179,7 +175,7 @@ int main(void)
 	tid = k_thread_create(&rx_0_5_thread_data, rx_0_5_thread_stack,
 			      K_THREAD_STACK_SIZEOF(rx_0_5_thread_stack),
 			      rx_0_5_thread, NULL, NULL, NULL,
-			      RX_THREAD_PRIORITY, 0, K_NO_WAIT);
+			      CONFIG_SAMPLE_RX_THREAD_PRIORITY, 0, K_NO_WAIT);
 	if (!tid) {
 		printk("ERROR spawning rx thread\n");
 	}

--- a/samples/subsys/canbus/isotp/src/main.c
+++ b/samples/subsys/canbus/isotp/src/main.c
@@ -170,7 +170,9 @@ int main(void)
 			      CONFIG_SAMPLE_RX_THREAD_PRIORITY, 0, K_NO_WAIT);
 	if (!tid) {
 		printk("ERROR spawning rx thread\n");
+		return 0;
 	}
+	k_thread_name_set(tid, "rx_8_0");
 
 	tid = k_thread_create(&rx_0_5_thread_data, rx_0_5_thread_stack,
 			      K_THREAD_STACK_SIZEOF(rx_0_5_thread_stack),
@@ -178,7 +180,9 @@ int main(void)
 			      CONFIG_SAMPLE_RX_THREAD_PRIORITY, 0, K_NO_WAIT);
 	if (!tid) {
 		printk("ERROR spawning rx thread\n");
+		return 0;
 	}
+	k_thread_name_set(tid, "rx_0_5");
 
 	printk("Start sending data\n");
 


### PR DESCRIPTION
Increase the stack size of the two RX threads used in the ISO-TP sample from 512 to 1024 bytes as the former is too small for some CAN controller/SoC combinations. Make both the RX thread stack size and priority configurable via Kconfig.

Exit the sample if creation of any of the RX threads failed. Name the threads to aid in debugging and monitoring of this sample.
