### PR TITLE
flash: correct missing erase handler

### DIFF
--- a/drivers/flash/flash_handlers.c
+++ b/drivers/flash/flash_handlers.c
@@ -28,6 +28,14 @@ static inline int z_vrfy_flash_write(const struct device *dev, off_t offset,
 }
 #include <syscalls/flash_write_mrsh.c>
 
+static inline int z_vrfy_flash_erase(const struct device *dev, off_t offset,
+				     size_t size)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_FLASH(dev, erase));
+	return z_impl_flash_erase((const struct device *)dev, offset, size);
+}
+#include <syscalls/flash_erase_mrsh.c>
+
 static inline size_t z_vrfy_flash_get_write_block_size(const struct device *dev)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_FLASH));


### PR DESCRIPTION
flash_handlers was missing the required z_vrfy_flash_erase function