### PR TITLE
GPIO instances for Alderlake Platform

### DIFF
--- a/boards/x86/intel_adl/intel_adl_crb.yaml
+++ b/boards/x86/intel_adl/intel_adl_crb.yaml
@@ -8,6 +8,7 @@ ram: 2048
 supported:
   - watchdog
   - pwm
+  - gpio
 testing:
   timeout_multiplier: 4
   ignore_tags:

--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -8,6 +8,7 @@
 #include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pcie/pcie.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	cpus {
@@ -107,6 +108,167 @@
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 			reg-shift = <0>;
+			status = "okay";
+		};
+
+		gpio_0_b: gpio@fd6e0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6e0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_0_a: gpio@fd6e09a0 {
+			compatible = "intel,gpio";
+			reg = <0xfd6e09a0 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <41>;
+
+			status = "okay";
+		};
+
+		gpio_1_s: gpio@fd6d0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <8>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_1_i: gpio@fd6d0780 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0780 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <19>;
+			pin-offset = <8>;
+
+			status = "okay";
+		};
+
+
+		gpio_1_h: gpio@fd6d08c0 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d08c0 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <25>;
+
+			status = "okay";
+		};
+
+		gpio_1_d: gpio@fd6d0a40 {
+			compatible = "intel,gpio";
+			reg = <0xfd6d0a40 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <20>;
+			pin-offset = <49>;
+
+			status = "okay";
+		};
+
+		gpio_4_c: gpio@fd6a0700 {
+			compatible = "intel,gpio";
+			reg = <0xfd6a0700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <8>;
+			pin-offset = <0>;
+
+			status = "okay";
+		};
+
+		gpio_4_f: gpio@fd6a0880 {
+			compatible = "intel,gpio";
+			reg = <0xfd6a0880 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x1>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <24>;
+
+			status = "okay";
+		};
+
+		gpio_4_e: gpio@fd6a0a70 {
+			compatible = "intel,gpio";
+			reg = <0xfd6a0a70 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x3>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <24>;
+			pin-offset = <57>;
+
+			status = "okay";
+		};
+
+		gpio_5_r: gpio@fd690700 {
+			compatible = "intel,gpio";
+			reg = <0xfd690700 0x1000>;
+			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+
+			group-index = <0x0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			ngpios = <8>;
+			pin-offset = <0>;
+
 			status = "okay";
 		};
 

--- a/soc/x86/alder_lake/soc_gpio.h
+++ b/soc/x86/alder_lake/soc_gpio.h
@@ -15,7 +15,7 @@
 #ifndef __SOC_GPIO_H_
 #define __SOC_GPIO_H_
 
-#define GPIO_INTEL_NR_SUBDEVS		15
+#define GPIO_INTEL_NR_SUBDEVS		10
 
 #define REG_PAD_OWNER_BASE              0x0020
 #define REG_GPI_INT_STS_BASE            0x0100

--- a/tests/drivers/gpio/gpio_basic_api/boards/intel_adl_crb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/intel_adl_crb.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Connect loopback between GPP_B_14 and GPP_B_15.
+ * BIOS settings to mark these two pins as GPIO
+ * Under Intel Advanced Menu > PCH-IO Configuration
+ * Enable Timed GPIO0 > Disable
+ * Enable Timed GPIO1 > Disable
+ * ISH Configuration > GP_6 > Unchecked [ ]
+ * ISH Configuration > GP_7 > Unchecked [ ]
+ */
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+
+		out-gpios = <&gpio_0_b 14 0>;
+		in-gpios  = <&gpio_0_b 15 0>;
+	};
+};


### PR DESCRIPTION
Added GPIO instances supported on Alderlake platform and enabled GPIO tests for same board.