### PR TITLE
drivers: eth: native_posix: Add Kconfig to Configure RX Timeout

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -195,6 +195,8 @@ Drivers and Sensors
 
 * Ethernet
 
+  * Added :kconfig:option:`CONFIG_ETH_NATIVE_POSIX_RX_TIMEOUT` to set rx timeout for native posix.
+
 * Flash
 
   * Introduce npcx flash driver that supports two or more spi nor flashes via a

--- a/drivers/ethernet/Kconfig.native_posix
+++ b/drivers/ethernet/Kconfig.native_posix
@@ -125,4 +125,14 @@ config ETH_NATIVE_POSIX_MAC_ADDR
 	  means the code will make 00:00:5E:00:53:XX, where XX will be
 	  random.
 
+config ETH_NATIVE_POSIX_RX_TIMEOUT
+	int "Ethernet RX timeout"
+	default 1 if NET_GPTP
+	default 50
+	range 1 100
+	help
+	  Native posix ethernet driver repeatedly checks for new data.
+	  Specify how long the thread sleeps between these checks if no new data
+	  available.
+
 endif # ETH_NATIVE_POSIX

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -376,11 +376,7 @@ static void eth_rx(struct eth_context *ctx)
 			}
 		}
 
-		if (IS_ENABLED(CONFIG_NET_GPTP)) {
-			k_sleep(K_MSEC(1));
-		} else {
-			k_sleep(K_MSEC(50));
-		}
+		k_sleep(K_MSEC(CONFIG_ETH_NATIVE_POSIX_RX_TIMEOUT));
 	}
 }
 


### PR DESCRIPTION
Add Kconfig to set sleep timeout between empty read attempts in rx thread
for ethernet native posix driver.

Signed-off-by: Nicola Ochsenbein <Nicola.Ochsenbein@husqvarnagroup.com>