### PR TITLE
west.yaml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -281,7 +281,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 010019e0f934d0d1288ad522c86600cd066920ae
+      revision: 11ecbf639d826c084973beed709a63d51d9b684e
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  11ecbf639d826c084973beed709a63d51d9b684e

Brings following Zephyr relevant changes and fixes:
 - 11ecbf63 zephyr: use cmsis_core.h header
 - da65db00 zephyr: Provide slot definitions for three images
 - 2c61caf6 bootutil: Move flash_area_id_to_image under ifdef
 - 904d0c46 bootutil: Add DirectXIP version of boot_set_next
 - 2a874b6e zephyr: Do not build in debug mode
 - 258a6c7d bootutil: Fix support for more than 2 flash areas
 
Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.