### PR TITLE
Bluetooth: audio: tbs_client: Fix missing discovery complete event

### DIFF
--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -520,11 +520,10 @@ struct bt_tbs_client_cb {
  * discover and setup handles and subscriptions.
  *
  * @param conn          The connection to discover TBS for.
- * @param subscribe     Whether to subscribe to all handles.
  *
  * @return int          0 on success, GATT error value on fail.
  */
-int bt_tbs_client_discover(struct bt_conn *conn, bool subscribe);
+int bt_tbs_client_discover(struct bt_conn *conn);
 
 /**
  * @brief Set the outgoing URI for a TBS instance on the peer device.

--- a/samples/bluetooth/hap_ha/src/ccp_call_ctrl.c
+++ b/samples/bluetooth/hap_ha/src/ccp_call_ctrl.c
@@ -32,7 +32,7 @@ static int process_profile_connection(struct bt_conn *conn)
 	int err = 0;
 
 	if (!atomic_test_and_set_bit(flags_for_conn, CCP_FLAG_GTBS_DISCOVER)) {
-		err = bt_tbs_client_discover(conn, true);
+		err = bt_tbs_client_discover(conn);
 		if (err != 0) {
 			printk("bt_tbs_client_discover (err %d)\n", err);
 		}

--- a/samples/bluetooth/tmap_peripheral/src/ccp_call_ctrl.c
+++ b/samples/bluetooth/tmap_peripheral/src/ccp_call_ctrl.c
@@ -125,7 +125,7 @@ int ccp_call_ctrl_init(struct bt_conn *conn)
 
 	default_conn = bt_conn_ref(conn);
 	bt_tbs_client_register_cb(&tbs_client_cb);
-	err = bt_tbs_client_discover(conn, true);
+	err = bt_tbs_client_discover(conn);
 	if (err != 0) {
 		return err;
 	}

--- a/subsys/bluetooth/audio/shell/tbs_client.c
+++ b/subsys/bluetooth/audio/shell/tbs_client.c
@@ -27,20 +27,9 @@
 static int cmd_tbs_client_discover(const struct shell *sh, size_t argc,
 				   char *argv[])
 {
-	bool subscribe = true;
 	int result = 0;
 
-	if (argc > 1) {
-		subscribe = shell_strtobool(argv[1], 0, &result);
-		if (result != 0) {
-			shell_error(sh, "Could not parse subscribe: %d",
-				    result);
-
-			return -ENOEXEC;
-		}
-	}
-
-	result = bt_tbs_client_discover(default_conn, (bool)subscribe);
+	result = bt_tbs_client_discover(default_conn);
 	if (result != 0) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -1001,8 +990,8 @@ static int cmd_tbs_client(const struct shell *sh, size_t argc, char **argv)
 
 SHELL_STATIC_SUBCMD_SET_CREATE(tbs_client_cmds,
 	SHELL_CMD_ARG(discover, NULL,
-		      "Discover TBS [subscribe]",
-		      cmd_tbs_client_discover, 1, 1),
+		      "Discover TBS",
+		      cmd_tbs_client_discover, 1, 0),
 
 #if defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL)
 	SHELL_CMD_ARG(set_signal_reporting_interval, NULL,

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -55,7 +55,6 @@ struct bt_tbs_server_inst {
 #endif /* IS_ENABLED(CONFIG_BT_TBS_CLIENT_GTBS) */
 	struct bt_gatt_discover_params discover_params;
 	struct bt_tbs_instance *current_inst;
-	bool subscribe_all;
 };
 
 static const struct bt_tbs_client_cb *tbs_client_cbs;
@@ -1537,7 +1536,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 #endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL) */
 		}
 
-		if (srv_insts[conn_index].subscribe_all && sub_params != NULL) {
+		if (sub_params != NULL) {
 			sub_params->value = 0;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				sub_params->value = BT_GATT_CCC_NOTIFY;
@@ -2220,7 +2219,7 @@ int bt_tbs_client_read_friendly_name(struct bt_conn *conn, uint8_t inst_index)
 }
 #endif /* defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME) */
 
-int bt_tbs_client_discover(struct bt_conn *conn, bool subscribe)
+int bt_tbs_client_discover(struct bt_conn *conn)
 {
 	uint8_t conn_index;
 	struct bt_tbs_server_inst *srv_inst;
@@ -2240,8 +2239,6 @@ int bt_tbs_client_discover(struct bt_conn *conn, bool subscribe)
 	(void)memset(srv_inst->tbs_insts, 0, sizeof(srv_inst->tbs_insts)); /* reset data */
 	srv_inst->inst_cnt = 0;
 #endif /* CONFIG_BT_TBS_CLIENT_TBS */
-	/* Discover TBS on peer, setup handles and notify/indicate */
-	srv_inst->subscribe_all = subscribe;
 #if defined(CONFIG_BT_TBS_CLIENT_GTBS)
 	(void)memset(&srv_inst->gtbs_inst, 0, sizeof(srv_inst->gtbs_inst)); /* reset data */
 	return primary_discover_gtbs(conn);

--- a/tests/bsim/bluetooth/audio/src/tbs_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_client_test.c
@@ -490,7 +490,7 @@ static void test_main(void)
 
 	WAIT_FOR_COND(is_connected);
 
-	tbs_client_err = bt_tbs_client_discover(default_conn, true);
+	tbs_client_err = bt_tbs_client_discover(default_conn);
 	if (tbs_client_err) {
 		FAIL("Failed to discover TBS_CLIENT for connection %d", tbs_client_err);
 	}


### PR DESCRIPTION
This fixes missing Fix bt_tbs_client_cb.discover call that has been
observed when CONFIG_BT_TBS_CLIENT_CCID was disabled. In such case the
discovery proces was not finished from application point of view,
as the callback was not called.
`subscribe` parameter has been removed from bt_tbs_client_discover
function parameters list. As the API user enables specific
CONFIG_BT_TBS_CLIENT_* option, the client implementation should
subscribe to the characteristic notifications so that the user receives
the value updates.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/42488