### PR TITLE
west: sign: do not make rimage configuration and platform name mandatory

### DIFF
--- a/doc/develop/west/sign.rst
+++ b/doc/develop/west/sign.rst
@@ -5,7 +5,9 @@ Signing Binaries
 
 The ``west sign`` :ref:`extension <west-extensions>` command can be used to
 sign a Zephyr application binary for consumption by a bootloader using an
-external tool. Run ``west sign -h`` for command line help.
+external tool. In some configurations, ``west sign`` is also used to invoke
+an external, post-processing tool that "stitches" the final components of
+the image together. Run ``west sign -h`` for command line help.
 
 MCUboot / imgtool
 *****************

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -133,7 +133,8 @@ class Sign(Forceable):
         group.add_argument('-D', '--tool-data', default=None,
                            help='''path to a tool-specific data/configuration directory, if needed''')
         group.add_argument('--if-tool-available', action='store_true',
-                           help='''Do not fail if rimage is missing, just warn.''')
+                           help='''Do not fail if the rimage tool is not found or the rimage signing
+schema (rimage "target") is not defined in board.cmake.''')
         group.add_argument('tool_args', nargs='*', metavar='tool_opt',
                            help='extra option(s) to pass to the signing tool')
 
@@ -425,12 +426,19 @@ class RimageSigner(Signer):
         b = pathlib.Path(build_dir)
         cache = CMakeCache.from_build_dir(build_dir)
 
-        # warning: RIMAGE_TARGET is a duplicate of CONFIG_RIMAGE_SIGNING_SCHEMA
+        # Warning: RIMAGE_TARGET in Zephyr is a duplicate of
+        # CONFIG_RIMAGE_SIGNING_SCHEMA in SOF.
         target = cache.get('RIMAGE_TARGET')
-        kernel_name = build_conf.get('CONFIG_KERNEL_BIN_NAME', 'zephyr')
 
         if not target:
-            log.die('rimage target not defined')
+            msg = 'rimage target not defined in board.cmake'
+            if args.if_tool_available:
+                log.inf(msg)
+                sys.exit(0)
+            else:
+                log.die(msg)
+
+        kernel_name = build_conf.get('CONFIG_KERNEL_BIN_NAME', 'zephyr')
 
         # TODO: make this a new sign.py --bootloader option.
         if target in ('imx8', 'imx8m'):


### PR DESCRIPTION
Now, if the rimage target (meaning rimage configuration and platform name)
is not defined in board.cmake the sign script returns fatal error.
Change this to a warning since there are configurations that are
not using 'west sign' or is used just to glue the headers of the
final image.

Also, update the documentation accordingly.