### PR TITLE
arm64: core/prep_c.c func prototype before function itself

### DIFF
--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -17,9 +17,9 @@
 #include <kernel_internal.h>
 #include <zephyr/linker/linker-defs.h>
 
-__weak void z_arm64_mm_init(bool is_primary_core) { }
-
 extern void z_arm64_mm_init(bool is_primary_core);
+
+__weak void z_arm64_mm_init(bool is_primary_core) { }
 
 /*
  * These simple memset/memcpy alternatives are necessary as the optimized


### PR DESCRIPTION
Move the function prototype before declaration of the function itself. Maybe the prototype could be removed altogether?