### PR TITLE
style: move ALWAYS_INLINE to the beginning to resolve compiler warnings

### DIFF
--- a/arch/arm/core/aarch32/cortex_a_r/fault.c
+++ b/arch/arm/core/aarch32/cortex_a_r/fault.c
@@ -110,7 +110,7 @@ static uint32_t dump_fault(uint32_t status, uint32_t addr)
 
 #if defined(CONFIG_FPU_SHARING)
 
-static void ALWAYS_INLINE z_arm_fpu_caller_save(struct __fpu_sf *fpu)
+static ALWAYS_INLINE void z_arm_fpu_caller_save(struct __fpu_sf *fpu)
 {
 	__asm__ volatile (
 		"vstmia %0, {s0-s15};\n"

--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -177,7 +177,7 @@ static ALWAYS_INLINE int max3421e_hien_disable(const struct device *dev,
 }
 
 /* Set peripheral (device) address to be used in next transfer */
-static int ALWAYS_INLINE max3421e_peraddr(const struct device *dev,
+static ALWAYS_INLINE int max3421e_peraddr(const struct device *dev,
 					  const uint8_t addr)
 {
 	struct max3421e_data *priv = uhc_get_private(dev);

--- a/samples/subsys/usb/hid-mouse/src/main.c
+++ b/samples/subsys/usb/hid-mouse/src/main.c
@@ -42,7 +42,7 @@ static void status_cb(enum usb_dc_status_code status, const uint8_t *param)
 	usb_status = status;
 }
 
-static void ALWAYS_INLINE rwup_if_suspended(void)
+static ALWAYS_INLINE void rwup_if_suspended(void)
 {
 	if (IS_ENABLED(CONFIG_USB_DEVICE_REMOTE_WAKEUP)) {
 		if (usb_status == USB_DC_SUSPEND) {

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -193,7 +193,7 @@ __asm__(".align 4\n\t"
 	"  call0 power_gate_exit\n\t");
 
 #ifdef CONFIG_ADSP_IMR_CONTEXT_SAVE
-static void ALWAYS_INLINE power_off_exit(void)
+static ALWAYS_INLINE void power_off_exit(void)
 {
 	__asm__(
 		"  movi  a0, 0\n\t"

--- a/subsys/usb/device_next/usbd_core.c
+++ b/subsys/usb/device_next/usbd_core.c
@@ -120,7 +120,7 @@ static int event_handler_bus_reset(struct usbd_contex *const uds_ctx)
 }
 
 /* TODO: Add event broadcaster to user application */
-static int ALWAYS_INLINE usbd_event_handler(struct usbd_contex *const uds_ctx,
+static ALWAYS_INLINE int usbd_event_handler(struct usbd_contex *const uds_ctx,
 					    struct udc_event *const event)
 {
 	int ret = 0;

--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -51,7 +51,7 @@ static int event_ep_request(struct usbh_contex *const ctx,
 	return uhc_xfer_free(dev, xfer);
 }
 
-static int ALWAYS_INLINE usbh_event_handler(struct usbh_contex *const ctx,
+static ALWAYS_INLINE int usbh_event_handler(struct usbh_contex *const ctx,
 					    struct uhc_event *const event)
 {
 	int ret = 0;


### PR DESCRIPTION
To resolve the following gcc compiler warning:
zephyr/arch/arm/core/aarch32/cortex_a_r/fault.c:101:1: warning: 'inline' is not at beginning of declaration [-Wold-style-declaration]
  101 | static void ALWAYS_INLINE z_arm_fpu_caller_save(struct __fpu_sf *fpu)
      | ^~~~~~

I searched to all of the source code to find these further occurances where inline is not at the beginning of a function declaration.