### PR TITLE
samples/basic: print_sys_memory_stats() removed from hash_map, static

### DIFF
--- a/samples/basic/hash_map/src/main.c
+++ b/samples/basic/hash_map/src/main.c
@@ -13,8 +13,6 @@ LOG_MODULE_REGISTER(hashmap_sample);
 
 SYS_HASHMAP_DEFINE_STATIC(map);
 
-void print_sys_memory_stats(void);
-
 struct _stats {
 	uint64_t n_insert;
 	uint64_t n_remove;

--- a/samples/basic/sys_heap/src/main.c
+++ b/samples/basic/sys_heap/src/main.c
@@ -12,7 +12,7 @@
 static char heap_mem[HEAP_SIZE];
 static struct sys_heap heap;
 
-void print_sys_memory_stats(void);
+static void print_sys_memory_stats(void);
 
 int main(void)
 {
@@ -34,7 +34,7 @@ int main(void)
 	return 0;
 }
 
-void print_sys_memory_stats(void)
+static void print_sys_memory_stats(void)
 {
 	struct sys_memory_stats stats;
 


### PR DESCRIPTION
Remove print_sys_memory_stats() from hash_map example as it is not used there at all. For sys_heap make this a static function.