### PR TITLE
Add syscall support to the fuel gauge emulator backend

### DIFF
--- a/drivers/fuel_gauge/CMakeLists.txt
+++ b/drivers/fuel_gauge/CMakeLists.txt
@@ -6,3 +6,8 @@ add_subdirectory_ifdef(CONFIG_SBS_GAUGE_NEW_API		sbs_gauge)
 add_subdirectory_ifdef(CONFIG_MAX17048		max17048)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE fuel_gauge_syscall_handlers.c)
+
+if (CONFIG_EMUL AND CONFIG_USERSPACE)
+  zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/emul_fuel_gauge.h)
+  zephyr_library_sources(emul_fuel_gauge_syscall_handlers.c)
+endif()

--- a/drivers/fuel_gauge/emul_fuel_gauge_syscall_handlers.c
+++ b/drivers/fuel_gauge/emul_fuel_gauge_syscall_handlers.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/syscall_handler.h>
+#include <zephyr/drivers/emul_fuel_gauge.h>
+
+/* Emulator syscalls just need to exist as stubs as these are only called by tests. */
+
+static inline int z_vrfy_emul_fuel_gauge_is_battery_cutoff(const struct emul *target, bool *cutoff)
+{
+	return z_impl_emul_fuel_gauge_is_battery_cutoff(target, cutoff);
+}
+
+#include <syscalls/emul_fuel_gauge_is_battery_cutoff_mrsh.c>
+
+static inline int z_vrfy_emul_fuel_gauge_set_battery_charging(const struct emul *target,
+							      uint32_t uV, int uA)
+{
+	return z_impl_emul_fuel_gauge_set_battery_charging(target, uV, uA);
+}
+
+#include <syscalls/emul_fuel_gauge_set_battery_charging_mrsh.c>

--- a/drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c
@@ -342,9 +342,6 @@ static void emul_sbs_gauge_reset_rule_after(const struct ztest_unit_test *test, 
 	DT_INST_FOREACH_STATUS_OKAY(SBS_GAUGE_EMUL_RESET_RULE_BEFORE)
 }
 ZTEST_RULE(emul_sbs_gauge_reset, NULL, emul_sbs_gauge_reset_rule_after);
-#else /* !CONFIG_ZTEST */
-/* Stub ZTEST_DMEM in case emulator is not used in a testing environment. */
-#define ZTEST_DMEM
 #endif /* CONFIG_ZTEST */
 
 /**

--- a/include/zephyr/drivers/emul_fuel_gauge.h
+++ b/include/zephyr/drivers/emul_fuel_gauge.h
@@ -54,8 +54,9 @@ __subsystem struct fuel_gauge_emul_driver_api {
  * @retval 0 If successful.
  * @retval -EINVAL if mV or mA are 0.
  */
-static inline int emul_fuel_gauge_set_battery_charging(const struct emul *target, uint32_t uV,
-						       int uA)
+__syscall int emul_fuel_gauge_set_battery_charging(const struct emul *target, uint32_t uV, int uA);
+static inline int z_impl_emul_fuel_gauge_set_battery_charging(const struct emul *target,
+							      uint32_t uV, int uA)
 {
 	const struct fuel_gauge_emul_driver_api *backend_api =
 		(const struct fuel_gauge_emul_driver_api *)target->backend_api;
@@ -76,7 +77,8 @@ static inline int emul_fuel_gauge_set_battery_charging(const struct emul *target
  * @retval 0 If successful.
  * @retval -ENOTSUP if not supported by emulator.
  */
-static inline int emul_fuel_gauge_is_battery_cutoff(const struct emul *target, bool *cutoff)
+__syscall int emul_fuel_gauge_is_battery_cutoff(const struct emul *target, bool *cutoff);
+static inline int z_impl_emul_fuel_gauge_is_battery_cutoff(const struct emul *target, bool *cutoff)
 {
 	const struct fuel_gauge_emul_driver_api *backend_api =
 		(const struct fuel_gauge_emul_driver_api *)target->backend_api;
@@ -90,6 +92,8 @@ static inline int emul_fuel_gauge_is_battery_cutoff(const struct emul *target, b
 #ifdef __cplusplus
 }
 #endif
+
+#include <syscalls/emul_fuel_gauge.h>
 
 /**
  * @}

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -344,7 +344,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_buffer_props__returns_ok)
 	zassert_ok(ret);
 }
 
-ZTEST_F(sbs_gauge_new_api, test_charging_5v_3a)
+ZTEST_USER_F(sbs_gauge_new_api, test_charging_5v_3a)
 {
 	/* Validate what props are supported by the driver */
 	uint32_t expected_uV = 5000 * 1000;


### PR DESCRIPTION
We ought to have syscall support for the fuel gauge backend emulator. This makes is considerably easier to write userspace tests with them.

These are just stub system calls because the syscalls are for functions that will only be invoked by *tests only*.