### PR TITLE
scripts: Update CFB font generator

### DIFF
--- a/scripts/build/gen_cfb_font_header.py
+++ b/scripts/build/gen_cfb_font_header.py
@@ -76,7 +76,13 @@ def extract_font_glyphs():
     fw_max = 0
     fh_max = 0
     for i in range(args.first, args.last + 1):
-        fw, fh = font.getsize(chr(i))
+        # returns (left, top, right, bottom) bounding box
+        size = font.getbbox(chr(i))
+
+        # calculate width + height
+        fw = size[2] - size[0]  # right - left
+        fh = size[3] - size[1]  # bottom - top
+
         if fw > fw_max:
             fw_max = fw
         if fh > fh_max:
@@ -100,7 +106,12 @@ def extract_font_glyphs():
         image = Image.new('1', (width, height), 'white')
         draw = ImageDraw.Draw(image)
 
-        fw, fh = draw.textsize(chr(i), font=font)
+        # returns (left, top, right, bottom) bounding box
+        size = draw.textbbox((0, 0), chr(i), font=font)
+
+        # calculate width + height
+        fw = size[2] - size[0]  # right - left
+        fh = size[3] - size[1]  # bottom - top
 
         xpos = 0
         if args.center_x:

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -16,7 +16,7 @@ clang-format>=15.0.0
 lpc_checksum
 
 # used by scripts/build/gen_cfb_font_header.py - helper script for user
-Pillow
+Pillow>=10.0
 
 # can be used to sign a Zephyr application binary for consumption by a bootloader
 imgtool>=1.9


### PR DESCRIPTION
Update CFB font generator so it works with Pillow version 10. They
deprecated some methods, with no direct replacements, so the generated
fonts might be slightly different.
