### PR TITLE
fuel_gauge: sbs_gauge: fix uninitialized variable warning

### DIFF
--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -179,7 +179,7 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 
 static int sbs_gauge_do_battery_cutoff(const struct device *dev)
 {
-	int rc;
+	int rc = -ENOTSUP;
 	const struct sbs_gauge_config *cfg = dev->config;
 
 	if (cfg->cutoff_cfg == NULL) {


### PR DESCRIPTION
The return variable rc in sbs_gauge_do_battery_cutoff() needs to be initialized, or else it would return random value if the for loop is never entered.