### PR TITLE
tests: lib: cmsis_dsp: matrix: fix double-promotion warning

### DIFF
--- a/tests/lib/cmsis_dsp/matrix/src/binary_f64.c
+++ b/tests/lib/cmsis_dsp/matrix/src/binary_f64.c
@@ -13,7 +13,7 @@
 
 #include "binary_f64.pat"
 
-#define SNR_ERROR_THRESH	((float32_t)120)
+#define SNR_ERROR_THRESH	((float64_t)120)
 #define REL_ERROR_THRESH	(1.0e-6)
 #define ABS_ERROR_THRESH	(1.0e-5)
 

--- a/tests/lib/cmsis_dsp/matrix/src/unary_f64.c
+++ b/tests/lib/cmsis_dsp/matrix/src/unary_f64.c
@@ -13,11 +13,11 @@
 
 #include "unary_f64.pat"
 
-#define SNR_ERROR_THRESH	((float32_t)120)
+#define SNR_ERROR_THRESH	((float64_t)120)
 #define REL_ERROR_THRESH	(1.0e-6)
 #define ABS_ERROR_THRESH	(1.0e-5)
 
-#define SNR_ERROR_THRESH_CHOL	((float32_t)270)
+#define SNR_ERROR_THRESH_CHOL	((float64_t)270)
 #define REL_ERROR_THRESH_CHOL	(1.0e-9)
 #define ABS_ERROR_THRESH_CHOL	(1.0e-9)
 


### PR DESCRIPTION
Double promotion warnings are generated with the flag -Wdouble-promotion