### PR TITLE
drivers: sensor: ina3221: fix double-promotion

### DIFF
--- a/drivers/sensor/ina3221/ina3221.c
+++ b/drivers/sensor/ina3221/ina3221.c
@@ -225,7 +225,7 @@ static int ina3221_channel_get(const struct device *dev, enum sensor_channel cha
 {
 	const struct ina3221_config *cfg = dev->config;
 	struct ina3221_data *data = dev->data;
-	double result;
+	float result;
 
 	switch (chan) {
 	case SENSOR_CHAN_VOLTAGE:
@@ -245,7 +245,7 @@ static int ina3221_channel_get(const struct device *dev, enum sensor_channel cha
 		return -ENOTSUP;
 	}
 
-	return sensor_value_from_double(val, result);
+	return sensor_value_from_float(val, result);
 }
 
 static int ina3221_attr_set(const struct device *dev, enum sensor_channel chan,


### PR DESCRIPTION
channel_get was doing using floating point constants with it's calculation. The result is changed to be a float as this was generating a double promotion warning.