### PR TITLE
dts: x86: intel: alder_lake: Added UART2 instance

### DIFF
--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -80,6 +80,18 @@
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
+
+		uart2: uart2 {
+			compatible = "ns16550";
+			vendor-id = <0x8086>;
+			device-id = <0x54C7>;
+			clock-frequency = <1843200>;
+			current-speed = <115200>;
+			reg-shift = <2>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupt-parent = <&intc>;
+			status = "disabled";
+		};
 	};
 
 	soc {


### PR DESCRIPTION
Added UART2 instance support for ADL platform.