### PR TITLE
Bluetooth: CAP: bt_cap_initiator_started called without unicast suppo…

### DIFF
--- a/subsys/bluetooth/audio/cap_stream.c
+++ b/subsys/bluetooth/audio/cap_stream.c
@@ -130,7 +130,7 @@ static void cap_stream_started_cb(struct bt_bap_stream *bap_stream)
 
 	LOG_DBG("%p", cap_stream);
 
-	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR)) {
+	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST)) {
 		bt_cap_initiator_started(cap_stream);
 	}
 


### PR DESCRIPTION
…rt fix

The bt_cap_initiator_started may be called in cap_stream_started_cb, even if there is no unicast support. Added a guard for CONFIG_BT_BAP_UNICAST to avoid calling an unlinked function.