### PR TITLE
STM32WBA: add watchdog support

### DIFF
--- a/boards/arm/nucleo_wba52cg/doc/nucleo_wba52cg.rst
+++ b/boards/arm/nucleo_wba52cg/doc/nucleo_wba52cg.rst
@@ -175,6 +175,8 @@ The Zephyr nucleo_wba52cg board configuration supports the following hardware fe
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | adc                                 |
 +-----------+------------+-------------------------------------+
+| WATCHDOG  | on-chip    | independent watchdog                |
++-----------+------------+-------------------------------------+
 | RNG       | on-chip    | True Random number generator        |
 +-----------+------------+-------------------------------------+
 

--- a/boards/arm/nucleo_wba52cg/nucleo_wba52cg.dts
+++ b/boards/arm/nucleo_wba52cg/nucleo_wba52cg.dts
@@ -47,6 +47,10 @@
 	};
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &clk_lse {
 	status = "okay";
 };
@@ -72,6 +76,10 @@
 	apb1-prescaler = <1>;
 	apb2-prescaler = <1>;
 	apb7-prescaler = <1>;
+};
+
+&iwdg {
+	status = "okay";
 };
 
 &usart1 {

--- a/boards/arm/nucleo_wba52cg/nucleo_wba52cg.yaml
+++ b/boards/arm/nucleo_wba52cg/nucleo_wba52cg.yaml
@@ -10,6 +10,7 @@ supported:
   - i2c
   - spi
   - adc
+  - watchdog
   - rng
   - arduino_gpio
   - arduino_i2c

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -188,6 +188,20 @@
 			};
 		};
 
+		iwdg: watchdog@40003000 {
+			compatible = "st,stm32-watchdog";
+			reg = <0x40003000 0x400>;
+			status = "disabled";
+		};
+
+		wwdg: watchdog@40002c00 {
+			compatible = "st,stm32-window-watchdog";
+			reg = <0x40002C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000800>;
+			interrupts = <0 7>;
+			status = "disabled";
+		};
+
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -36,6 +36,7 @@ tests:
       - nucleo_u575zi_q
       - nucleo_c031c6
       - stm32h573i_dk
+      - nucleo_wba52cg
     integration_platforms:
       - nucleo_f091rc
   drivers.watchdog.stm32wwdg_h7:
@@ -68,6 +69,7 @@ tests:
       - nucleo_h743zi
       - nucleo_c031c6
       - nucleo_h753zi
+      - nucleo_wba52cg
     integration_platforms:
       - nucleo_f091rc
   drivers.watchdog.mec15xxevb_assy6853:


### PR DESCRIPTION
- Add watchdog support for STM32WBA
- Enable watchdog for Nucleo WBA52CG
- Add Nucleo WBA52CG to the wdt_basic_api test