### PR TITLE
llvm: use proper syntax for --config option

### DIFF
--- a/cmake/toolchain/llvm/target.cmake
+++ b/cmake/toolchain/llvm/target.cmake
@@ -49,7 +49,9 @@ elseif(CONFIG_COMPILER_RT_RTLIB)
   set(runtime_lib "compiler_rt")
 endif()
 
-list(APPEND TOOLCHAIN_C_FLAGS --config
-	${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg)
-list(APPEND TOOLCHAIN_LD_FLAGS --config
-	${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg)
+list(APPEND TOOLCHAIN_C_FLAGS
+  "--config=${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg"
+  )
+list(APPEND TOOLCHAIN_LD_FLAGS
+  "--config=${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg"
+  )


### PR DESCRIPTION
Use proper `--config=` syntax instead of `--config ` as the latter can cause issues in some situations.