### PR TITLE
net: wifi: shell: remove duplicate ap item in wifi menu

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -1197,7 +1197,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 	SHELL_CMD(statistics, NULL, "Wi-Fi interface statistics", cmd_wifi_stats),
 	SHELL_CMD(status, NULL, "Status of the Wi-Fi interface", cmd_wifi_status),
 	SHELL_CMD(twt, &wifi_twt_ops, "Manage TWT flows", NULL),
-	SHELL_CMD(ap, &wifi_cmd_ap, "Access Point mode commands", NULL),
 	SHELL_CMD(reg_domain, NULL,
 		"Set or Get Wi-Fi regulatory domain\n"
 		"Usage: wifi reg_domain [ISO/IEC 3166-1 alpha2] [-f]\n"


### PR DESCRIPTION
Remove two duplicate ap in wifi menu

``` shell
*** Booting Zephyr OS build zephyr-v3.4.0-2697-gce6c520629e3 ***
uart:~$ wifi
wifi - Wi-Fi commands
Subcommands:
  ap                  :Access Point mode commands  <-------------------------------------First one
  connect             :Connect to a Wi-Fi AP
                       "<SSID>"
                       <channel number (optional), 0 means all>
                       <PSK (optional: valid only for secure SSIDs)>
                       <Security type (optional: valid only for secure SSIDs)>
                       0:None, 1:PSK, 2:PSK-256, 3:SAE
                       <MFP (optional: needs security type to be specified)>
                       : 0:Disable, 1:Optional, 2:Required
  disconnect          :Disconnect from the Wi-Fi AP
  ps                  :Configure Wi-F PS on/off, no arguments will dump config
  ps_mode             :<legacy>
                       <wmm>
  scan                :Scan for Wi-Fi APs
                       <scan type (optional): <active> : <passive>>

  statistics          :Wi-Fi interface statistics
  status              :Status of the Wi-Fi interface
  twt                 :Manage TWT flows
  ap                  :Access Point mode commands   <--------------------------------Remove this
  reg_domain          :Set or Get Wi-Fi regulatory domain
                       Usage: wifi reg_domain [ISO/IEC 3166-1 alpha2] [-f]
                       -f: Force to use this regulatory hint over any other
                       regulatory hints
                       Note: This may cause regulatory compliance issues, use it
                       at your own risk.
  ps_timeout          :<val> - PS inactivity timer(in ms)
  ps_listen_interval  :<val> - Listen interval in the range of <0-65535>
  ps_wakeup_mode      :<dtim> : Set PS wake up mode to DTIM interval
                       <listen_interval> : Set PS wake up mode to listen
                       interval
uart:~$

```