### PR TITLE
ev11l78a: minimize memory usage in the default config.

### DIFF
--- a/boards/arm/ev11l78a/ev11l78a_defconfig
+++ b/boards/arm/ev11l78a/ev11l78a_defconfig
@@ -11,3 +11,16 @@ CONFIG_GPIO=y
 CONFIG_SERIAL=y
 CONFIG_UART_CONSOLE=y
 CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# Kernel Options due to Low Memory (4k)
+CONFIG_LOG_BUFFER_SIZE=256
+CONFIG_MAIN_STACK_SIZE=640
+CONFIG_IDLE_STACK_SIZE=200
+CONFIG_ISR_STACK_SIZE=512
+CONFIG_USBC_STACK_SIZE=512
+# Prevent Interrupt Vector Table in RAM
+CONFIG_SRAM_VECTOR_TABLE=n
+
+# This board only supports the sink role, so
+# no need to ever implement source for it.
+CONFIG_USBC_CSM_SINK_ONLY=y


### PR DESCRIPTION
ev11l78a: minimize memory usage in the default config.

The ATSAMD20E16 used in this board only has 8KiB SRAM, so the defaults
are not really suitable for anything close to useful, particularly the
sink sample that most closely resembles the original demo for the board.

This should also allow more tests not to be skipped for this board as
otherwise they overflow RAM usage.

Signed-off-by: Diego Elio Pettenò <flameeyes@meta.com>

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/zephyrproject-rtos/zephyr/pull/61797).
* #61740
* #62478
* __->__ #61797