### PR TITLE
scripts: size_report: fix encoding issue

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -737,6 +737,8 @@ def main():
     """
     parse_args()
 
+    sys.stdout.reconfigure(encoding='utf-8')
+
     # Init colorama
     init()
 


### PR DESCRIPTION
Force default stdout encoding to utf-8 as otherwise ram_report/rom_report may fail to render due to UnicodeEncodeError being thrown by Anytree library (ex. in CLion IDE built-in terminal).