### PR TITLE
drivers: i2c: stm32: Support wakeup from STOP

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -17,6 +17,8 @@
 #include <stm32_ll_i2c.h>
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 #include "i2c_ll_stm32.h"
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
@@ -220,6 +222,16 @@ int i2c_stm32_target_register(const struct device *dev,
 		return ret;
 	}
 
+#if defined(CONFIG_PM_DEVICE_RUNTIME)
+	if (pm_device_wakeup_is_capable(dev)) {
+		/* Mark device as active */
+		(void)pm_device_runtime_get(dev);
+		/* Enable wake-up from stop */
+		LOG_DBG("i2c: enabling wakeup from stop");
+		LL_I2C_EnableWakeUpFromStop(cfg->i2c);
+	}
+#endif /* defined(CONFIG_PM_DEVICE_RUNTIME) */
+
 	LL_I2C_Enable(i2c);
 
 	if (!data->slave_cfg) {
@@ -298,6 +310,16 @@ int i2c_stm32_target_unregister(const struct device *dev,
 	LL_I2C_ClearFlag_ADDR(i2c);
 
 	LL_I2C_Disable(i2c);
+
+#if defined(CONFIG_PM_DEVICE_RUNTIME)
+	if (pm_device_wakeup_is_capable(dev)) {
+		/* Disable wake-up from STOP */
+		LOG_DBG("i2c: disabling wakeup from stop");
+		LL_I2C_DisableWakeUpFromStop(i2c);
+		/* Release the device */
+		(void)pm_device_runtime_put(dev);
+	}
+#endif /* defined(CONFIG_PM_DEVICE_RUNTIME) */
 
 	data->slave_attached = false;
 


### PR DESCRIPTION
Support for wakeup from STOP mode on STM32 when the i2c device is configured as a target.