### PR TITLE
footprint: ci: ehl_crb board has been renamed.

### DIFF
--- a/scripts/footprint/plan.txt
+++ b/scripts/footprint/plan.txt
@@ -6,8 +6,8 @@ footprints,default,nrf5340dk_nrf5340_cpuapp,tests/benchmarks/footprints,
 footprints,default,nrf51dk_nrf51422,tests/benchmarks/footprints,
 footprints,default,altera_max10,tests/benchmarks/footprints,
 footprints,default,hifive1_revb,tests/benchmarks/footprints,
-footprints,default,ehl_crb,tests/benchmarks/footprints,
-footprints,userspace,ehl_crb,tests/benchmarks/footprints,-DCONF_FILE=prj_userspace.conf
+footprints,default,intel_ehl_crb,tests/benchmarks/footprints,
+footprints,userspace,intel_ehl_crb,tests/benchmarks/footprints,-DCONF_FILE=prj_userspace.conf
 footprints,power-management,frdm_k64f,tests/benchmarks/footprints,-DCONF_FILE=prj_pm.conf
 footprints,power-management,disco_l475_iot1,tests/benchmarks/footprints,-DCONF_FILE=prj_pm.conf
 footprints,power-management,it8xxx2_evb,tests/benchmarks/footprints,-DCONF_FILE=prj_pm.conf


### PR DESCRIPTION
Following PR #61471, ehl_crb board is now intel_ehl_crb. Update the footprint test plan accordingly.
I have confirmed that the full plan now completes successfuly.

@nashif not sure if there is anything we want to do to make sure there is continuity in the [historical dashboard](https://stats.zephyrproject.org/testing/d/SSxr5P6Gk/footprint-tracking?orgId=1&var-board=ehl_crb&var-application=footprints&var-feature=default&var-type=ram) when data will start showing up for the "new" board? 