### PR TITLE
samples: logging: dictionary: fix double-promotion warning

### DIFF
--- a/samples/subsys/logging/dictionary/src/main.c
+++ b/samples/subsys/logging/dictionary/src/main.c
@@ -65,7 +65,7 @@ int main(void)
 
 	LOG_DBG("float %f, double %f", (double)f, d);
 #ifdef CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE
-	long double ld = 70.71;
+	long double ld = 70.71L;
 
 	LOG_DBG("long double %Lf", ld);
 #endif


### PR DESCRIPTION
Double promotion warnings are generated with the flag -Wdouble-promotion