### PR TITLE
drivers: sensor: bmi08x: fix fs prop for gyro

### DIFF
--- a/drivers/sensor/bmi08x/bmi08x.h
+++ b/drivers/sensor/bmi08x/bmi08x.h
@@ -496,7 +496,7 @@ struct bmi08x_gyro_config {
 	uint8_t int3_4_conf_io;
 #endif
 	uint8_t gyro_hz;
-	uint8_t gyro_fs;
+	uint16_t gyro_fs;
 };
 
 struct bmi08x_accel_data {

--- a/drivers/sensor/bmi08x/bmi08x_gyro.c
+++ b/drivers/sensor/bmi08x/bmi08x_gyro.c
@@ -472,7 +472,7 @@ BUILD_ASSERT(CONFIG_BMI08X_GYRO_TRIGGER_NONE,
 		IF_ENABLED(CONFIG_BMI08X_GYRO_TRIGGER,                                             \
 			   (.int_gpio = GPIO_DT_SPEC_INST_GET(inst, int_gpios),))                  \
 			.gyro_hz = DT_INST_ENUM_IDX(inst, gyro_hz),                                \
-		BMI08X_GYRO_TRIGGER_PINS(inst).gyro_fs = DT_INST_ENUM_IDX(inst, gyro_fs),          \
+		BMI08X_GYRO_TRIGGER_PINS(inst).gyro_fs = DT_INST_PROP(inst, gyro_fs),              \
 	};                                                                                         \
                                                                                                    \
 	PM_DEVICE_DT_INST_DEFINE(inst, bmi08x_gyro_pm_action);                                     \


### PR DESCRIPTION
The full scale prop was incorrectly using the enum idx which was then to be used with a look up table which used the actual range number. This changes it to use the int directly from the dts.