### PR TITLE
soc: nordic_nrf: fix usb delete statement location

### DIFF
--- a/dts/arm/nordic/nrf52840_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52840_qfaa.dtsi
@@ -21,5 +21,6 @@
 			     "nordic,nrf52", "simple-bus";
 	};
 
-	/delete-node/ &usbd;
 };
+
+/delete-node/ &usbd;


### PR DESCRIPTION
/delete-node/ pointing at node labels needs to be out of the the tree hierarchy, fixes the error:

`devicetree error: zephyr/dts/arm/nordic/nrf52840_qfaa.dtsi:24 (column 16): parse error: expected node name`