### PR TITLE
net: lib: coap: fix path and query options init

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -372,6 +372,17 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 		      struct coap_option *options, uint8_t opt_num);
 
 /**
+ * @brief Parses provided coap path (with/without query) or query and appends
+ * that as options to the @a cpkt.
+ *
+ * @param cpkt Packet to append path and query options for.
+ * @param path Null-terminated string of coap path, query or both.
+ *
+ * @retval 0 in case of success or negative in case of error.
+ */
+int coap_packet_set_path(struct coap_packet *cpkt, const char *path);
+
+/**
  * @brief Creates a new CoAP Packet from input data.
  *
  * @param cpkt New packet to be initialized using the storage from @a data.

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -198,7 +198,7 @@ static int coap_client_init_path_options(struct coap_packet *pckt, const char *p
 		}
 	}
 
-	if (path_start < path_end) {
+	if (path_start < path_length) {
 		if (contains_query) {
 			ret = coap_packet_append_option(pckt, COAP_OPTION_URI_QUERY,
 							path + path_start,


### PR DESCRIPTION
Fix options initialization for path and query when a final segment is one character long.

For example, `"a/b"` inits path as `["a"]` instead of expected `["a", "b"]`.
The same applies to the query option. The `"a/abc?a&b"` query options won't contain `"b"`.