### PR TITLE
ci: test_plan: also filter on platforms when manifest changes

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -159,6 +159,10 @@ class Filters:
             for p in projs_names:
                 _options.extend(["-t", p ])
 
+            if self.platforms:
+                for platform in self.platforms:
+                    _options.extend(["-p", platform])
+
             self.get_plan(_options, True)
 
 


### PR DESCRIPTION
Add platform filtering when generating tests for manifest modules.
In the clang workflow, we do select to run only on one platform, so this
needs to be applied as well or we end up building unwanted tests using
the wrong toolchain.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
