### PR TITLE
Test_plan script update

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -86,7 +86,7 @@ class Tag:
         return "<Tag {}>".format(self.name)
 
 class Filters:
-    def __init__(self, modified_files, pull_request=False, platforms=[], no_path_name = False, ignore_path=None):
+    def __init__(self, modified_files, pull_request=False, platforms=[], no_path_name = False, ignore_path=None, alt_tags=None):
         self.modified_files = modified_files
         self.twister_options = []
         self.full_twister = False
@@ -96,6 +96,9 @@ class Filters:
         self.platforms = platforms
         self.default_run = False
         self.no_path_name = no_path_name
+        self.tag_cfg_file = os.path.join(zephyr_base, 'scripts', 'ci', 'tags.yaml')
+        if alt_tags:
+            self.tag_cfg_file = alt_tags
         self.ignore_path = f"{zephyr_base}/scripts/ci/twister_ignore.txt"
         if ignore_path:
             self.ignore_path = ignore_path
@@ -271,8 +274,7 @@ class Filters:
 
     def find_tags(self):
 
-        tag_cfg_file = os.path.join(zephyr_base, 'scripts', 'ci', 'tags.yaml')
-        with open(tag_cfg_file, 'r') as ymlfile:
+        with open(self.tag_cfg_file, 'r') as ymlfile:
             tags_config = yaml.safe_load(ymlfile)
 
         tags = {}
@@ -365,6 +367,8 @@ def parse_args():
             help="Don't put paths into test suites' names ")
     parser.add_argument('--ignore-path', default=None,
             help="Path to a text file with patterns of files to be matched against changed files")
+    parser.add_argument('--alt-tags', default=None,
+            help="Path to a file describing relations between directories and tags")
 
     return parser.parse_args()
 
@@ -390,7 +394,7 @@ if __name__ == "__main__":
         print("\n".join(files))
         print("=========")
 
-    f = Filters(files, args.pull_request, args.platform, args.no_path_name, args.ignore_path)
+    f = Filters(files, args.pull_request, args.platform, args.no_path_name, args.ignore_path, args.alt_tags)
     f.process()
 
     # remove dupes and filtered cases

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -12,6 +12,7 @@ import subprocess
 import json
 import logging
 import sys
+import glob
 from pathlib import Path
 from git import Repo
 from west.manifest import Manifest
@@ -256,13 +257,25 @@ class Filters:
             if f.endswith(".rst"):
                 continue
             d = os.path.dirname(f)
-            while d:
+            scope_found = False
+            while not scope_found and d:
+                head, tail = os.path.split(d)
                 if os.path.exists(os.path.join(d, "testcase.yaml")) or \
                     os.path.exists(os.path.join(d, "sample.yaml")):
                     tests.add(d)
                     # Modified file is treated as resolved, since a matching scope was found
                     self.resolved_files.append(f)
-                    break
+                    scope_found = True
+                elif tail == "common":
+                    # Look for yamls in directories collocated with common
+
+                    yamls_found = [yaml for yaml in glob.iglob(head + '/**/testcase.yaml', recursive=True)]
+                    yamls_found.extend([yaml for yaml in glob.iglob(head + '/**/sample.yaml', recursive=True)])
+                    if yamls_found:
+                        for yaml in yamls_found:
+                            tests.add(os.path.dirname(yaml))
+                        self.resolved_files.append(f)
+                        scope_found = True
                 else:
                     d = os.path.dirname(d)
 

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -86,7 +86,7 @@ class Tag:
         return "<Tag {}>".format(self.name)
 
 class Filters:
-    def __init__(self, modified_files, pull_request=False, platforms=[], no_path_name = False):
+    def __init__(self, modified_files, pull_request=False, platforms=[], no_path_name = False, ignore_path=None):
         self.modified_files = modified_files
         self.twister_options = []
         self.full_twister = False
@@ -96,6 +96,9 @@ class Filters:
         self.platforms = platforms
         self.default_run = False
         self.no_path_name = no_path_name
+        self.ignore_path = f"{zephyr_base}/scripts/ci/twister_ignore.txt"
+        if ignore_path:
+            self.ignore_path = ignore_path
 
     def process(self):
         self.find_modules()
@@ -306,7 +309,7 @@ class Filters:
             logging.info(f'Potential tag based filters: {exclude_tags}')
 
     def find_excludes(self, skip=[]):
-        with open("scripts/ci/twister_ignore.txt", "r") as twister_ignore:
+        with open(self.ignore_path, "r") as twister_ignore:
             ignores = twister_ignore.read().splitlines()
             ignores = filter(lambda x: not x.startswith("#"), ignores)
 
@@ -360,6 +363,8 @@ def parse_args():
                         help="Repo to scan")
     parser.add_argument('--no-path-name', action="store_true",
             help="Don't put paths into test suites' names ")
+    parser.add_argument('--ignore-path', default=None,
+            help="Path to a text file with patterns of files to be matched against changed files")
 
     return parser.parse_args()
 
@@ -385,7 +390,7 @@ if __name__ == "__main__":
         print("\n".join(files))
         print("=========")
 
-    f = Filters(files, args.pull_request, args.platform, args.no_path_name)
+    f = Filters(files, args.pull_request, args.platform, args.no_path_name, args.ignore_path)
     f.process()
 
     # remove dupes and filtered cases

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -19,10 +19,10 @@ from west.manifest import Manifest
 if "ZEPHYR_BASE" not in os.environ:
     exit("$ZEPHYR_BASE environment variable undefined.")
 
-repository_path = Path(os.environ['ZEPHYR_BASE'])
+zephyr_base = Path(os.environ['ZEPHYR_BASE'])
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
 
-sys.path.append(os.path.join(repository_path, 'scripts'))
+sys.path.append(os.path.join(zephyr_base, 'scripts'))
 import list_boards
 
 def _get_match_fn(globs, regexes):
@@ -112,7 +112,7 @@ class Filters:
 
     def get_plan(self, options, integration=False):
         fname = "_test_plan_partial.json"
-        cmd = ["scripts/twister", "-c"] + options + ["--save-tests", fname ]
+        cmd = [f"{zephyr_base}/scripts/twister", "-c"] + options + ["--save-tests", fname ]
         if self.no_path_name:
             cmd += ["--no-path-name"]
         if integration:
@@ -131,7 +131,7 @@ class Filters:
         if 'west.yml' in self.modified_files:
             print(f"Manifest file 'west.yml' changed")
             print("=========")
-            old_manifest_content = repo.git.show(f"{args.commits[:-2]}:west.yml")
+            old_manifest_content = repo_to_scan.git.show(f"{args.commits[:-2]}:west.yml")
             with open("west_old.yml", "w") as manifest:
                 manifest.write(old_manifest_content)
             old_manifest = Manifest.from_file("west_old.yml")
@@ -208,8 +208,12 @@ class Filters:
             if p and p.groups():
                 boards.add(p.group(1))
 
-        # Limit search to $ZEPHYR_BASE since this is where the changed files are
-        lb_args = argparse.Namespace(**{ 'arch_roots': [repository_path], 'board_roots': [repository_path] })
+        roots = [zephyr_base]
+        if repository_path != zephyr_base:
+            roots.append(repository_path)
+
+        # Look for boards in monitored repositories
+        lb_args = argparse.Namespace(**{ 'arch_roots': roots, 'board_roots': roots})
         known_boards = list_boards.find_boards(lb_args)
         for b in boards:
             name_re = re.compile(b)
@@ -264,7 +268,7 @@ class Filters:
 
     def find_tags(self):
 
-        tag_cfg_file = os.path.join(repository_path, 'scripts', 'ci', 'tags.yaml')
+        tag_cfg_file = os.path.join(zephyr_base, 'scripts', 'ci', 'tags.yaml')
         with open(tag_cfg_file, 'r') as ymlfile:
             tags_config = yaml.safe_load(ymlfile)
 
@@ -352,6 +356,8 @@ def parse_args():
             help="Number of tests per builder")
     parser.add_argument('-n', '--default-matrix', default=10, type=int,
             help="Number of tests per builder")
+    parser.add_argument('-r', '--repo-to-scan', default=None,
+                        help="Repo to scan")
     parser.add_argument('--no-path-name', action="store_true",
             help="Don't put paths into test suites' names ")
 
@@ -363,9 +369,12 @@ if __name__ == "__main__":
     args = parse_args()
     files = []
     errors = 0
+    repository_path = zephyr_base
+    if args.repo_to_scan:
+        repository_path = Path(args.repo_to_scan)
     if args.commits:
-        repo = Repo(repository_path)
-        commit = repo.git.diff("--name-only", args.commits)
+        repo_to_scan = Repo(repository_path)
+        commit = repo_to_scan.git.diff("--name-only", args.commits)
         files = commit.split("\n")
     elif args.modified_files:
         with open(args.modified_files, "r") as fp:

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -86,7 +86,7 @@ class Tag:
         return "<Tag {}>".format(self.name)
 
 class Filters:
-    def __init__(self, modified_files, pull_request=False, platforms=[]):
+    def __init__(self, modified_files, pull_request=False, platforms=[], no_path_name = False):
         self.modified_files = modified_files
         self.twister_options = []
         self.full_twister = False
@@ -95,6 +95,7 @@ class Filters:
         self.pull_request = pull_request
         self.platforms = platforms
         self.default_run = False
+        self.no_path_name = no_path_name
 
     def process(self):
         self.find_modules()
@@ -112,6 +113,8 @@ class Filters:
     def get_plan(self, options, integration=False):
         fname = "_test_plan_partial.json"
         cmd = ["scripts/twister", "-c"] + options + ["--save-tests", fname ]
+        if self.no_path_name:
+            cmd += ["--no-path-name"]
         if integration:
             cmd.append("--integration")
 
@@ -349,6 +352,8 @@ def parse_args():
             help="Number of tests per builder")
     parser.add_argument('-n', '--default-matrix', default=10, type=int,
             help="Number of tests per builder")
+    parser.add_argument('--no-path-name', action="store_true",
+            help="Don't put paths into test suites' names ")
 
     return parser.parse_args()
 
@@ -371,8 +376,7 @@ if __name__ == "__main__":
         print("\n".join(files))
         print("=========")
 
-
-    f = Filters(files, args.pull_request, args.platform)
+    f = Filters(files, args.pull_request, args.platform, args.no_path_name)
     f.process()
 
     # remove dupes and filtered cases

--- a/scripts/ci/twister_ignore.txt
+++ b/scripts/ci/twister_ignore.txt
@@ -17,25 +17,6 @@ CODEOWNERS
 MAINTAINERS.yml
 LICENSE
 Makefile
-tests/*
-samples/*
-boards/*/*/*
-arch/xtensa/*
-arch/x86/*
-arch/posix/*
-arch/arc/*
-arch/sparc/*
-arch/arm/*
-arch/nios2/*
-arch/riscv/*
-include/arch/xtensa/*
-include/arch/x86/*
-include/arch/posix/*
-include/arch/arc/*
-include/arch/sparc/*
-include/arch/arm/*
-include/arch/nios2/*
-include/arch/riscv/*
 doc/*
 # GH action have no impact on code
 .github/*

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -437,6 +437,10 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         help="Re-use the outdir before building. Will result in "
              "faster compilation since builds will be incremental.")
 
+    parser.add_argument(
+        "--no-path-name", action="store_true",
+        help="Don't put paths into test suites' names ")
+
     # To be removed in favor of --detailed-skipped-report
     parser.add_argument(
         "--no-skipped-report", action="store_true",

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -522,7 +522,7 @@ class TestPlan:
 
                     for name in parsed_data.scenarios.keys():
                         suite_dict = parsed_data.get_scenario(name)
-                        suite = TestSuite(root, suite_path, name, data=suite_dict)
+                        suite = TestSuite(root, suite_path, name, data=suite_dict, no_path_name=self.options.no_path_name)
                         suite.add_subcases(suite_dict, subcases, ztest_suite_names)
                         if testsuite_filter:
                             if suite.name and suite.name in testsuite_filter:

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -348,7 +348,7 @@ class TestSuite(DisablePyTestCollectionMixin):
     """Class representing a test application
     """
 
-    def __init__(self, suite_root, suite_path, name, data=None):
+    def __init__(self, suite_root, suite_path, name, data=None, no_path_name=False):
         """TestSuite constructor.
 
         This gets called by TestPlan as it finds and reads test yaml files.
@@ -369,7 +369,9 @@ class TestSuite(DisablePyTestCollectionMixin):
         """
 
         workdir = os.path.relpath(suite_path, suite_root)
-        self.name = self.get_unique(suite_root, workdir, name)
+
+        assert self.check_suite_name(name, suite_root, workdir)
+        self.name = name if no_path_name else self.get_unique(suite_root, workdir, name)
         self.id = name
 
         self.source_dir = suite_path
@@ -425,10 +427,14 @@ class TestSuite(DisablePyTestCollectionMixin):
 
         # workdir can be "."
         unique = os.path.normpath(os.path.join(relative_ts_root, workdir, name))
+        return unique
+
+    @staticmethod
+    def check_suite_name(name, testsuite_root, workdir):
         check = name.split(".")
         if len(check) < 2:
             raise TwisterException(f"""bad test name '{name}' in {testsuite_root}/{workdir}. \
 Tests should reference the category and subsystem with a dot as a separator.
                     """
                     )
-        return unique
+        return True

--- a/scripts/tests/twister/test_testsuite.py
+++ b/scripts/tests/twister/test_testsuite.py
@@ -110,3 +110,42 @@ def test_get_unique(testsuite_root, suite_path, name, expected):
     '''Test to check if the unique name is given for each testsuite root and workdir'''
     suite = TestSuite(testsuite_root, suite_path, name)
     assert suite.name == expected
+
+TESTDATA_2 = [
+        (
+            ZEPHYR_BASE + '/scripts/tests/twister/test_data/testsuites',
+            ZEPHYR_BASE + '/scripts/tests/twister/test_data/testsuites/tests/test_a',
+            'test_a.check_1',
+            'test_a.check_1'
+        ),
+        (
+            ZEPHYR_BASE,
+            ZEPHYR_BASE,
+            'test_a.check_1',
+            'test_a.check_1'
+        ),
+        (
+            ZEPHYR_BASE,
+            ZEPHYR_BASE + '/scripts/tests/twister/test_data/testsuites/test_b',
+            'test_b.check_1',
+            'test_b.check_1'
+        ),
+        (
+            os.path.join(ZEPHYR_BASE, 'scripts/tests'),
+            os.path.join(ZEPHYR_BASE, 'scripts/tests'),
+            'test_b.check_1',
+            'test_b.check_1'
+        ),
+        (
+            ZEPHYR_BASE,
+            ZEPHYR_BASE,
+            'test_a.check_1.check_2',
+            'test_a.check_1.check_2'
+        ),
+]
+@pytest.mark.parametrize("testsuite_root, suite_path, name, expected", TESTDATA_2)
+def test_get_no_path_name(testsuite_root, suite_path, name, expected):
+    '''Test to check if the name without path is given for each testsuite'''
+    suite = TestSuite(testsuite_root, suite_path, name, no_path_name=True)
+    print(suite.name)
+    assert suite.name == expected


### PR DESCRIPTION
A series of commits to upgrade test_plan.py script. My main goal was to adopt the script so it can be used in other projects (we want to use it in our nRF Connect SDK main repository). During the process I found couple of issues creating blind spots in the script and proposed a solution to make sure that no modified file went unresolved. Also to improve the workflow to find tests when "common" folder is modified, with no yamls inside nor in its parents (those were blind spots before resulting in an empty test scope). 
Each commit should be atomic and described, hence I recommend reviewing commit by commit