### PR TITLE
drivers: gpio: Smartbond: Improve GPIO compatibility

### DIFF
--- a/drivers/gpio/gpio_smartbond.c
+++ b/drivers/gpio/gpio_smartbond.c
@@ -283,7 +283,7 @@ static const struct gpio_driver_api gpio_smartbond_drv_api_funcs = {
 			      NULL,							\
 			      &gpio_smartbond_p##id##_data,				\
 			      &gpio_smartbond_p##id##_config,				\
-			      POST_KERNEL,						\
+			      PRE_KERNEL_1,						\
 			      CONFIG_GPIO_INIT_PRIORITY,				\
 			      &gpio_smartbond_drv_api_funcs);
 


### PR DESCRIPTION
This PR improves GPIO compatibility with other platforms and drivers.

- Init level for GPIO drivers is set PRE_KERNEL_1. Smartbond(tm) driver had it set to POST_KERNEL by accident. while it worked it could  be problem when other drivers (like UART that initializes in PRE_KERNEL_1, would try to configure GPIO)
- Both edges trigger for interrupt added so application does not have to do it by itself. Hardware supports only one edge for given GPIO pin but with minimal changes active edge is reconfigured when interrupt occurs.
- When platform is configured with CONFIG_PM it can enter sleep mode where GPIO changes would not wake up CPU. GPIO interrupts would be handled when platform wakes for other reason. Which could be to late. To handle this for each active GPIO interrupt PDC controller is configured along with WAKEUP controller.

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>