### PR TITLE
Bluetooth: Mesh: Remove bt_mesh_beacon_priv_random_get as unused

### DIFF
--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -41,6 +41,7 @@ LOG_MODULE_REGISTER(bt_mesh_beacon);
 #define PROV_XMIT                  BT_MESH_TRANSMIT(0, 20)
 
 static struct k_work_delayable beacon_timer;
+#if defined(CONFIG_BT_MESH_PRIV_BEACONS)
 static struct {
 	/**
 	 * Identifier for the current Private beacon random-value.
@@ -54,6 +55,7 @@ static struct {
 	uint8_t val[13];
 	uint64_t timestamp;
 } priv_random;
+#endif
 
 struct beacon_params {
 	bool private;

--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -794,9 +794,3 @@ void bt_mesh_beacon_disable(void)
 	/* If this fails, we'll do an early exit in the work handler. */
 	(void)k_work_cancel_delayable(&beacon_timer);
 }
-
-void bt_mesh_beacon_priv_random_get(uint8_t *random, size_t size)
-{
-	__ASSERT(size <= sizeof(priv_random.val), "Invalid random value size %u", size);
-	memcpy(random, priv_random.val, size);
-}

--- a/subsys/bluetooth/mesh/beacon.h
+++ b/subsys/bluetooth/mesh/beacon.h
@@ -15,4 +15,3 @@ int bt_mesh_beacon_create(struct bt_mesh_subnet *sub, struct net_buf_simple *buf
 
 void bt_mesh_beacon_init(void);
 void bt_mesh_beacon_update(struct bt_mesh_subnet *sub);
-void bt_mesh_beacon_priv_random_get(uint8_t *random, size_t size);


### PR DESCRIPTION
This function is not used anywhere.