### PR TITLE
native boards: miscelaneous build improvements

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -19,6 +19,9 @@ endif()
 #      For ex. target_sources(native_simulator INTERFACE silly.c)
 #      Note that these are built with the host libC and the include directories
 #      the runner is built with.
+#  RUNNER_LINK_LIBRARIES:
+#      Extra libraries to link with the runner
+#      For ex. set_property(TARGET native_simulator APPEND PROPERTY RUNNER_LINK_LIBRARIES "mylib.a")
 #  Note: target_link_libraries() cannot be used on this library at this point.
 #        target_link_libraries() updates INTERFACE_LINK_LIBRARIES but wrapping it with extra
 #        information. This means we cannot directly pass it to the native_simulator runner build.
@@ -26,6 +29,7 @@ endif()
 #        info.
 #        We use target_link_options() instead
 add_library(native_simulator INTERFACE)
+set_property(TARGET native_simulator PROPERTY RUNNER_LINK_LIBRARIES "")
 
 set(NSI_DIR ${ZEPHYR_BASE}/scripts/native_simulator CACHE PATH "Path to the native simulator")
 

--- a/boards/posix/common/natsim_config.cmake
+++ b/boards/posix/common/natsim_config.cmake
@@ -14,6 +14,7 @@ set(nsi_config_content
   "NSI_EXE:=${zephyr_build_path}/${KERNEL_EXE_NAME}"
   "NSI_EXTRA_SRCS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_SOURCES>,\ >"
   "NSI_LINK_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_LINK_OPTIONS>,\ >"
+  "NSI_EXTRA_LIBS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,RUNNER_LINK_LIBRARIES>,\ >"
   "NSI_PATH:=${NSI_DIR}/"
 )
 

--- a/boards/posix/common/natsim_config.cmake
+++ b/boards/posix/common/natsim_config.cmake
@@ -1,0 +1,22 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set(zephyr_build_path ${CMAKE_BINARY_DIR}/zephyr)
+
+set(nsi_config_content
+  ${nsi_config_content}
+  "NSI_BUILD_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_COMPILE_OPTIONS>,\ >"
+  "NSI_BUILD_PATH:=${zephyr_build_path}/NSI"
+  "NSI_CC:=${CMAKE_C_COMPILER}"
+  "NSI_EMBEDDED_CPU_SW:=${zephyr_build_path}/${KERNEL_ELF_NAME}"
+  "NSI_EXE:=${zephyr_build_path}/${KERNEL_EXE_NAME}"
+  "NSI_EXTRA_SRCS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_SOURCES>,\ >"
+  "NSI_LINK_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_LINK_OPTIONS>,\ >"
+  "NSI_PATH:=${NSI_DIR}/"
+)
+
+string(REPLACE ";" "\n" nsi_config_content "${nsi_config_content}")
+
+file(GENERATE OUTPUT "${zephyr_build_path}/NSI/nsi_config"
+  CONTENT "${nsi_config_content}"
+)

--- a/boards/posix/common/natsim_config.cmake
+++ b/boards/posix/common/natsim_config.cmake
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set(zephyr_build_path ${CMAKE_BINARY_DIR}/zephyr)
+get_property(CCACHE GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
 
 set(nsi_config_content
   ${nsi_config_content}
   "NSI_BUILD_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_COMPILE_OPTIONS>,\ >"
   "NSI_BUILD_PATH:=${zephyr_build_path}/NSI"
-  "NSI_CC:=${CMAKE_C_COMPILER}"
+  "NSI_CC:=${CCACHE} ${CMAKE_C_COMPILER}"
   "NSI_EMBEDDED_CPU_SW:=${zephyr_build_path}/${KERNEL_ELF_NAME}"
   "NSI_EXE:=${zephyr_build_path}/${KERNEL_EXE_NAME}"
   "NSI_EXTRA_SRCS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_SOURCES>,\ >"

--- a/boards/posix/common/natsim_config.cmake
+++ b/boards/posix/common/natsim_config.cmake
@@ -9,6 +9,7 @@ set(nsi_config_content
   "NSI_BUILD_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_COMPILE_OPTIONS>,\ >"
   "NSI_BUILD_PATH:=${zephyr_build_path}/NSI"
   "NSI_CC:=${CCACHE} ${CMAKE_C_COMPILER}"
+  "NSI_OBJCOPY:=${CMAKE_OBJCOPY}"
   "NSI_EMBEDDED_CPU_SW:=${zephyr_build_path}/${KERNEL_ELF_NAME}"
   "NSI_EXE:=${zephyr_build_path}/${KERNEL_EXE_NAME}"
   "NSI_EXTRA_SRCS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_SOURCES>,\ >"

--- a/boards/posix/native_sim/CMakeLists.txt
+++ b/boards/posix/native_sim/CMakeLists.txt
@@ -27,22 +27,9 @@ if(CONFIG_HAS_SDL)
   add_subdirectory(${ZEPHYR_BASE}/boards/${ARCH}/common/sdl/ ${CMAKE_CURRENT_BINARY_DIR}/sdl)
 endif()
 
-set(zephyr_build_path ${CMAKE_BINARY_DIR}/zephyr)
-
 set(nsi_config_content
-  "NSI_BUILD_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_COMPILE_OPTIONS>,\ >"
-  "NSI_BUILD_PATH:=${zephyr_build_path}/NSI"
-  "NSI_CC:=${CMAKE_C_COMPILER}"
-  "NSI_EMBEDDED_CPU_SW:=${zephyr_build_path}/${KERNEL_ELF_NAME}"
-  "NSI_EXE:=${zephyr_build_path}/${KERNEL_EXE_NAME}"
-  "NSI_EXTRA_SRCS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_SOURCES>,\ >"
-  "NSI_LINK_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_LINK_OPTIONS>,\ >"
-  "NSI_PATH:=${NSI_DIR}/"
+  ${nsi_config_content}
   "NSI_NATIVE=1"
 )
 
-string(REPLACE ";" "\n" nsi_config_content "${nsi_config_content}")
-
-file(GENERATE OUTPUT "${zephyr_build_path}/NSI/nsi_config"
-  CONTENT "${nsi_config_content}"
-)
+include(../common/natsim_config.cmake)

--- a/boards/posix/nrf52_bsim/CMakeLists.txt
+++ b/boards/posix/nrf52_bsim/CMakeLists.txt
@@ -50,7 +50,7 @@ zephyr_library_include_directories(
 )
 
 set(libpath ${BSIM_OUT_PATH}/lib)
-target_link_options(native_simulator INTERFACE
+set_property(TARGET native_simulator APPEND PROPERTY RUNNER_LINK_LIBRARIES
 	${libpath}/libUtilv1.32.a
 	${libpath}/libPhyComv1.32.a
 	${libpath}/lib2G4PhyComv1.32.a

--- a/boards/posix/nrf52_bsim/CMakeLists.txt
+++ b/boards/posix/nrf52_bsim/CMakeLists.txt
@@ -57,21 +57,4 @@ target_link_options(native_simulator INTERFACE
 	${libpath}/libRandv2.32.a
 )
 
-set(zephyr_build_path ${CMAKE_BINARY_DIR}/zephyr)
-
-set(nsi_config_content
-  "NSI_BUILD_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_COMPILE_OPTIONS>,\ >"
-  "NSI_BUILD_PATH:=${zephyr_build_path}/NSI"
-  "NSI_CC:=${CMAKE_C_COMPILER}"
-  "NSI_EMBEDDED_CPU_SW:=${zephyr_build_path}/${KERNEL_ELF_NAME}"
-  "NSI_EXE:=${zephyr_build_path}/${KERNEL_EXE_NAME}"
-  "NSI_EXTRA_SRCS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_SOURCES>,\ >"
-  "NSI_LINK_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_LINK_OPTIONS>,\ >"
-  "NSI_PATH:=${NSI_DIR}/"
-)
-
-string(REPLACE ";" "\n" nsi_config_content "${nsi_config_content}")
-
-file(GENERATE OUTPUT "${zephyr_build_path}/NSI/nsi_config"
-  CONTENT "${nsi_config_content}"
-)
+include(../common/natsim_config.cmake)


### PR DESCRIPTION
    nrf52_bsim: Pass bsim libraries the runner needs using new property
    
    Instead of abusing the INTERFACE_LINK_OPTIONS for this,
    let's use the new RUNNER_LINK_LIBRARIES.
    
 -------

    native simulator: Add property to collect libraries to link w runner
    
    Add a property to the native_simulator target, to collect
    the libraries we want to link with the runner, instead of
    abusing the link options to pass them.
    
 -------

    native boards: Use compiler provided objcopy
    
    Instead of defaulting to use the gnu objcopy, use the
    compiler specific one when building the native simulator
    runner.
    This fixes a link issue when using llvm and ASAN.
    
-------

    boards native: Build the native simulator runner with ccache
    
    If the Zephyr build is using ccache, have the native simulator
    runner build also use it.
    
-------

    native boards: cmake: Move nsi_config generation to shared file
    
    Move the generation of the native simulator build
    configuration into its own file, shared between
    the native simulator boards.
 
 ----
 
 Fixes #60134