### PR TITLE
net: lwm2m: Add support for blockwise GET and FETCH

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -714,6 +714,20 @@ int coap_get_option_int(const struct coap_packet *cpkt, uint16_t code);
 int coap_get_block1_option(const struct coap_packet *cpkt, bool *has_more, uint8_t *block_number);
 
 /**
+ * @brief Get values from CoAP block2 option.
+ *
+ * Decode block number and block size from option. Ignore the has_more flag
+ * as it should always be zero on queries.
+ *
+ * @param cpkt Packet to be inspected
+ * @param block_number Is set to the number of the block
+ *
+ * @return Integer value of the block size in case of success
+ * or negative in case of error.
+ */
+int coap_get_block2_option(const struct coap_packet *cpkt, uint8_t *block_number);
+
+/**
  * @brief Retrieves BLOCK{1,2} and SIZE{1,2} from @a cpkt and updates
  * @a ctx accordingly.
  *

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1303,6 +1303,19 @@ int coap_get_block1_option(const struct coap_packet *cpkt, bool *has_more, uint8
 	return ret;
 }
 
+int coap_get_block2_option(const struct coap_packet *cpkt, uint8_t *block_number)
+{
+	int ret = coap_get_option_int(cpkt, COAP_OPTION_BLOCK2);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	*block_number = GET_NUM(ret);
+	ret = 1 << (GET_BLOCK_SIZE(ret) + 4);
+	return ret;
+}
+
 int insert_option(struct coap_packet *cpkt, uint16_t code, const uint8_t *value, uint16_t len)
 {
 	uint16_t offset = cpkt->hdr_len;

--- a/subsys/net/lib/lwm2m/CMakeLists.txt
+++ b/subsys/net/lib/lwm2m/CMakeLists.txt
@@ -14,6 +14,7 @@ zephyr_library_sources(
     lwm2m_obj_device.c
     lwm2m_rw_link_format.c
     lwm2m_rw_plain_text.c
+    lwm2m_rw_opaque.c
     lwm2m_util.c
     lwm2m_rd_client.c
     )

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -83,6 +83,8 @@ config LWM2M_COAP_BLOCK_TRANSFER
 	help
 	  LwM2M messages with a big body that exceed the block size will be split
 	  into blocks for sending.
+	  To append CoAP ETag option into outgoing block transfers, CONFIG_SYS_HASH_FUNC32 should
+	  be enabled.
 
 config LWM2M_CANCEL_OBSERVE_BY_PATH
 	bool "Use path matching as fallback for cancel-observe"

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -675,7 +675,9 @@ static int socket_send_message(struct lwm2m_ctx *client_ctx)
 	}
 
 	if (msg->type != COAP_TYPE_CON) {
-		lwm2m_reset_message(msg, true);
+		if (!lwm2m_outgoing_is_part_of_blockwise(msg)) {
+			lwm2m_reset_message(msg, true);
+		}
 	}
 
 	return rc;

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -642,7 +642,7 @@ static int socket_recv_message(struct lwm2m_ctx *client_ctx)
 	}
 
 	in_buf[len] = 0U;
-	lwm2m_udp_receive(client_ctx, in_buf, len, &from_addr, handle_request);
+	lwm2m_udp_receive(client_ctx, in_buf, len, &from_addr);
 
 	return 0;
 }

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -307,12 +307,13 @@ STATIC int build_msg_block_for_send(struct lwm2m_message *msg, uint16_t block_nu
 		/* reuse message for next block. Copy token from the new query to allow
 		 * CoAP clients to use new token for every query of ongoing transaction
 		 */
-		tkl = coap_header_get_token(msg->in.in_cpkt, token);
 		lwm2m_reset_message(msg, false);
 		if (msg->type == COAP_TYPE_ACK) {
 			msg->mid = coap_header_get_id(msg->in.in_cpkt);
+			tkl = coap_header_get_token(msg->in.in_cpkt, token);
 		} else {
 			msg->mid = coap_next_id();
+			tkl = LWM2M_MSG_TOKEN_GENERATE_NEW;
 		}
 		msg->token = token;
 		msg->tkl = tkl;

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -47,6 +47,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "lwm2m_rw_link_format.h"
 #include "lwm2m_rw_oma_tlv.h"
 #include "lwm2m_rw_plain_text.h"
+#include "lwm2m_rw_opaque.h"
 #include "lwm2m_util.h"
 #include "lwm2m_rd_client.h"
 #if defined(CONFIG_LWM2M_RW_SENML_JSON_SUPPORT)
@@ -807,6 +808,10 @@ static int select_writer(struct lwm2m_output_context *out, uint16_t accept)
 		out->writer = &link_format_writer;
 		break;
 
+	case LWM2M_FORMAT_APP_OCTET_STREAM:
+		out->writer = &opaque_writer;
+		break;
+
 	case LWM2M_FORMAT_PLAIN_TEXT:
 	case LWM2M_FORMAT_OMA_PLAIN_TEXT:
 		out->writer = &plain_text_writer;
@@ -857,6 +862,9 @@ static int select_reader(struct lwm2m_input_context *in, uint16_t format)
 	switch (format) {
 
 	case LWM2M_FORMAT_APP_OCTET_STREAM:
+		in->reader = &opaque_reader;
+		break;
+
 	case LWM2M_FORMAT_PLAIN_TEXT:
 	case LWM2M_FORMAT_OMA_PLAIN_TEXT:
 		in->reader = &plain_text_reader;
@@ -1537,6 +1545,8 @@ static int do_read_op(struct lwm2m_message *msg, uint16_t content_format)
 	switch (content_format) {
 
 	case LWM2M_FORMAT_APP_OCTET_STREAM:
+		return do_read_op_opaque(msg, content_format);
+
 	case LWM2M_FORMAT_PLAIN_TEXT:
 	case LWM2M_FORMAT_OMA_PLAIN_TEXT:
 		return do_read_op_plain_text(msg, content_format);
@@ -1919,6 +1929,8 @@ static int do_write_op(struct lwm2m_message *msg, uint16_t format)
 	switch (format) {
 
 	case LWM2M_FORMAT_APP_OCTET_STREAM:
+		return do_write_op_opaque(msg);
+
 	case LWM2M_FORMAT_PLAIN_TEXT:
 	case LWM2M_FORMAT_OMA_PLAIN_TEXT:
 		return do_write_op_plain_text(msg);

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -417,12 +417,6 @@ STATIC int prepare_msg_for_send(struct lwm2m_message *msg)
 
 #endif
 
-bool lwm2m_outgoing_is_part_of_blockwise(struct lwm2m_message *msg)
-{
-	return msg->block_send;
-}
-
-
 void lwm2m_engine_context_close(struct lwm2m_ctx *client_ctx)
 {
 	struct lwm2m_message *msg;

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.h
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.h
@@ -39,8 +39,6 @@
 #define NUM_OUTPUT_BLOCK_CONTEXT CONFIG_LWM2M_NUM_OUTPUT_BLOCK_CONTEXT
 #endif
 
-/* Establish a request handler callback type */
-typedef int (*udp_request_handler_cb_t)(struct coap_packet *request, struct lwm2m_message *msg);
 /* LwM2M message functions */
 struct lwm2m_message *lwm2m_get_message(struct lwm2m_ctx *client_ctx);
 struct lwm2m_message *find_msg(struct coap_pending *pending, struct coap_reply *reply);
@@ -49,10 +47,8 @@ void lm2m_message_clear_allocations(struct lwm2m_message *msg);
 int lwm2m_init_message(struct lwm2m_message *msg);
 int lwm2m_send_message_async(struct lwm2m_message *msg);
 
-int handle_request(struct coap_packet *request, struct lwm2m_message *msg);
-
 void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_len,
-		       struct sockaddr *from_addr, udp_request_handler_cb_t udp_request_handler);
+		       struct sockaddr *from_addr);
 
 int generate_notify_message(struct lwm2m_ctx *ctx, struct observe_node *obs, void *user_data);
 /* Notification and Send operation */

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.h
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.h
@@ -75,5 +75,6 @@ enum coap_block_size lwm2m_default_block_size(void);
 
 int lwm2m_parse_peerinfo(char *url, struct lwm2m_ctx *client_ctx, bool is_firmware_uri);
 void lwm2m_clear_block_contexts(void);
+bool lwm2m_outgoing_is_part_of_blockwise(struct lwm2m_message *msg);
 
 #endif /* LWM2M_MESSAGE_HANDLING_H */

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.h
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.h
@@ -75,6 +75,10 @@ enum coap_block_size lwm2m_default_block_size(void);
 
 int lwm2m_parse_peerinfo(char *url, struct lwm2m_ctx *client_ctx, bool is_firmware_uri);
 void lwm2m_clear_block_contexts(void);
-bool lwm2m_outgoing_is_part_of_blockwise(struct lwm2m_message *msg);
+
+static inline bool lwm2m_outgoing_is_part_of_blockwise(struct lwm2m_message *msg)
+{
+	return msg->block_send;
+}
 
 #endif /* LWM2M_MESSAGE_HANDLING_H */

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -705,71 +705,95 @@ static inline int engine_put_end_ri(struct lwm2m_output_context *out,
 	return 0;
 }
 
-static inline int engine_put_s8(struct lwm2m_output_context *out,
-				struct lwm2m_obj_path *path, int8_t value)
+static inline int engine_put_s8(struct lwm2m_output_context *out, struct lwm2m_obj_path *path,
+				int8_t value)
 {
-	return out->writer->put_s8(out, path, value);
+	if (out->writer->put_s8) {
+		return out->writer->put_s8(out, path, value);
+	}
+	return -ENOTSUP;
 }
 
-static inline int engine_put_s16(struct lwm2m_output_context *out,
-				 struct lwm2m_obj_path *path, int16_t value)
+static inline int engine_put_s16(struct lwm2m_output_context *out, struct lwm2m_obj_path *path,
+				 int16_t value)
 {
-	return out->writer->put_s16(out, path, value);
+	if (out->writer->put_s16) {
+		return out->writer->put_s16(out, path, value);
+	}
+	return -ENOTSUP;
 }
 
-static inline int engine_put_s32(struct lwm2m_output_context *out,
-				 struct lwm2m_obj_path *path, int32_t value)
+static inline int engine_put_s32(struct lwm2m_output_context *out, struct lwm2m_obj_path *path,
+				 int32_t value)
 {
-	return out->writer->put_s32(out, path, value);
+	if (out->writer->put_s32) {
+		return out->writer->put_s32(out, path, value);
+	}
+	return -ENOTSUP;
 }
 
-static inline int engine_put_s64(struct lwm2m_output_context *out,
-				 struct lwm2m_obj_path *path, int64_t value)
+static inline int engine_put_s64(struct lwm2m_output_context *out, struct lwm2m_obj_path *path,
+				 int64_t value)
 {
-	return out->writer->put_s64(out, path, value);
+	if (out->writer->put_s64) {
+		return out->writer->put_s64(out, path, value);
+	}
+	return -ENOTSUP;
 }
 
-static inline int engine_put_string(struct lwm2m_output_context *out,
-				    struct lwm2m_obj_path *path, char *buf,
-				    size_t buflen)
+static inline int engine_put_string(struct lwm2m_output_context *out, struct lwm2m_obj_path *path,
+				    char *buf, size_t buflen)
 {
-	return out->writer->put_string(out, path, buf, buflen);
+	if (out->writer->put_string) {
+		return out->writer->put_string(out, path, buf, buflen);
+	}
+	return -ENOTSUP;
 }
 
-static inline int engine_put_float(struct lwm2m_output_context *out,
-				   struct lwm2m_obj_path *path, double *value)
+static inline int engine_put_float(struct lwm2m_output_context *out, struct lwm2m_obj_path *path,
+				   double *value)
 {
-	return out->writer->put_float(out, path, value);
+	if (out->writer->put_float) {
+		return out->writer->put_float(out, path, value);
+	}
+	return -ENOTSUP;
 }
 
-static inline int engine_put_time(struct lwm2m_output_context *out,
-				  struct lwm2m_obj_path *path, time_t value)
+static inline int engine_put_time(struct lwm2m_output_context *out, struct lwm2m_obj_path *path,
+				  time_t value)
 {
-	return out->writer->put_time(out, path, value);
+	if (out->writer->put_time) {
+		return out->writer->put_time(out, path, value);
+	}
+	return -ENOTSUP;
 }
 
-static inline int engine_put_bool(struct lwm2m_output_context *out,
-				  struct lwm2m_obj_path *path, bool value)
+static inline int engine_put_bool(struct lwm2m_output_context *out, struct lwm2m_obj_path *path,
+				  bool value)
 {
-	return out->writer->put_bool(out, path, value);
+	if (out->writer->put_bool) {
+		return out->writer->put_bool(out, path, value);
+	}
+	return -ENOTSUP;
 }
 
-static inline int engine_put_opaque(struct lwm2m_output_context *out,
-				    struct lwm2m_obj_path *path, char *buf,
-				    size_t buflen)
+static inline int engine_put_opaque(struct lwm2m_output_context *out, struct lwm2m_obj_path *path,
+				    char *buf, size_t buflen)
 {
 	if (out->writer->put_opaque) {
 		return out->writer->put_opaque(out, path, buf, buflen);
 	}
 
-	return 0;
+	return -ENOTSUP;
 }
 
-static inline int engine_put_objlnk(struct lwm2m_output_context *out,
-				    struct lwm2m_obj_path *path,
+static inline int engine_put_objlnk(struct lwm2m_output_context *out, struct lwm2m_obj_path *path,
 				    struct lwm2m_objlnk *value)
 {
-	return out->writer->put_objlnk(out, path, value);
+	if (out->writer->put_objlnk) {
+		return out->writer->put_objlnk(out, path, value);
+	}
+	return -ENOTSUP;
 }
 
 static inline int engine_put_corelink(struct lwm2m_output_context *out,
@@ -793,53 +817,68 @@ static inline int engine_put_timestamp(struct lwm2m_output_context *out, time_t 
 
 static inline int engine_get_s32(struct lwm2m_input_context *in, int32_t *value)
 {
-	return in->reader->get_s32(in, value);
+	if (in->reader->get_s32) {
+		return in->reader->get_s32(in, value);
+	}
+	return -ENOTSUP;
 }
 
 static inline int engine_get_s64(struct lwm2m_input_context *in, int64_t *value)
 {
-	return in->reader->get_s64(in, value);
+	if (in->reader->get_s64) {
+		return in->reader->get_s64(in, value);
+	}
+	return -ENOTSUP;
 }
 
-static inline int engine_get_string(struct lwm2m_input_context *in,
-				    uint8_t *buf, size_t buflen)
+static inline int engine_get_string(struct lwm2m_input_context *in, uint8_t *buf, size_t buflen)
 {
-	return in->reader->get_string(in, buf, buflen);
+	if (in->reader->get_string) {
+		return in->reader->get_string(in, buf, buflen);
+	}
+	return -ENOTSUP;
 }
 
 static inline int engine_get_time(struct lwm2m_input_context *in, time_t *value)
 {
-	return in->reader->get_time(in, value);
+	if (in->reader->get_time) {
+		return in->reader->get_time(in, value);
+	}
+	return -ENOTSUP;
 }
 
-static inline int engine_get_float(struct lwm2m_input_context *in,
-				   double *value)
+static inline int engine_get_float(struct lwm2m_input_context *in, double *value)
 {
-	return in->reader->get_float(in, value);
+	if (in->reader->get_float) {
+		return in->reader->get_float(in, value);
+	}
+	return -ENOTSUP;
 }
 
 static inline int engine_get_bool(struct lwm2m_input_context *in, bool *value)
 {
-	return in->reader->get_bool(in, value);
+	if (in->reader->get_bool) {
+		return in->reader->get_bool(in, value);
+	}
+	return -ENOTSUP;
 }
 
-static inline int engine_get_opaque(struct lwm2m_input_context *in,
-				    uint8_t *buf, size_t buflen,
-				    struct lwm2m_opaque_context *opaque,
-				    bool *last_block)
+static inline int engine_get_opaque(struct lwm2m_input_context *in, uint8_t *buf, size_t buflen,
+				    struct lwm2m_opaque_context *opaque, bool *last_block)
 {
 	if (in->reader->get_opaque) {
-		return in->reader->get_opaque(in, buf, buflen,
-					      opaque, last_block);
+		return in->reader->get_opaque(in, buf, buflen, opaque, last_block);
 	}
 
-	return 0;
+	return -ENOTSUP;
 }
 
-static inline int engine_get_objlnk(struct lwm2m_input_context *in,
-				    struct lwm2m_objlnk *value)
+static inline int engine_get_objlnk(struct lwm2m_input_context *in, struct lwm2m_objlnk *value)
 {
-	return in->reader->get_objlnk(in, value);
+	if (in->reader->get_objlnk) {
+		return in->reader->get_objlnk(in, value);
+	}
+	return -ENOTSUP;
 }
 
 #endif /* LWM2M_OBJECT_H_ */

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -521,8 +521,11 @@ struct lwm2m_message {
 	/** Incoming message action */
 	uint8_t operation;
 
-	/* Information whether the message was acknowledged. */
+	/** Information whether the message was acknowledged. */
 	bool acknowledged : 1;
+
+	/** Indicate that this is part of outgoing block transfer. */
+	bool block_send : 1;
 };
 
 /* LWM2M format writer for the various formats supported */

--- a/subsys/net/lib/lwm2m/lwm2m_rw_opaque.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_opaque.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Copyright (c) 2015, Yanzi Networks AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define LOG_MODULE_NAME net_lwm2m_opaque
+#define LOG_LEVEL	CONFIG_LWM2M_LOG_LEVEL
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "lwm2m_object.h"
+#include "lwm2m_rw_opaque.h"
+#include "lwm2m_engine.h"
+#include "lwm2m_util.h"
+
+static int get_opaque(struct lwm2m_input_context *in, uint8_t *value,
+		      size_t buflen, struct lwm2m_opaque_context *opaque,
+		      bool *last_block)
+{
+	uint16_t in_len;
+
+	if (opaque->remaining == 0) {
+		coap_packet_get_payload(in->in_cpkt, &in_len);
+
+		if (in_len == 0) {
+			return -ENODATA;
+		}
+
+		if (in->block_ctx != NULL) {
+			uint32_t block_num =
+				in->block_ctx->ctx.current /
+				coap_block_size_to_bytes(
+					in->block_ctx->ctx.block_size);
+
+			if (block_num == 0) {
+				opaque->len = in->block_ctx->ctx.total_size;
+			}
+
+			if (opaque->len == 0) {
+				/* No size1 option provided, use current
+				 * payload size. This will reset on next packet
+				 * received.
+				 */
+				opaque->remaining = in_len;
+			} else {
+				opaque->remaining = opaque->len;
+			}
+
+		} else {
+			opaque->len = in_len;
+			opaque->remaining = in_len;
+		}
+	}
+
+	return lwm2m_engine_get_opaque_more(in, value, buflen,
+					    opaque, last_block);
+}
+
+static int put_opaque(struct lwm2m_output_context *out,
+			  struct lwm2m_obj_path *path, char *buf,
+			  size_t buflen)
+{
+	int ret;
+
+	ret = buf_append(CPKT_BUF_WRITE(out->out_cpkt), buf, buflen);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return buflen;
+}
+
+
+const struct lwm2m_writer opaque_writer = {
+	.put_opaque = put_opaque,
+};
+
+const struct lwm2m_reader opaque_reader = {
+	.get_opaque = get_opaque,
+};
+
+int do_read_op_opaque(struct lwm2m_message *msg, int content_format)
+{
+	/* Opaque can only return single resource (instance) */
+	if (msg->path.level < LWM2M_PATH_LEVEL_RESOURCE) {
+		return -EPERM;
+	} else if (msg->path.level > LWM2M_PATH_LEVEL_RESOURCE) {
+		if (!IS_ENABLED(CONFIG_LWM2M_VERSION_1_1)) {
+			return -ENOENT;
+		} else if (msg->path.level > LWM2M_PATH_LEVEL_RESOURCE_INST) {
+			return -ENOENT;
+		}
+	}
+
+	return lwm2m_perform_read_op(msg, content_format);
+}
+
+int do_write_op_opaque(struct lwm2m_message *msg)
+{
+	struct lwm2m_engine_obj_inst *obj_inst = NULL;
+	struct lwm2m_engine_obj_field *obj_field;
+	struct lwm2m_engine_res *res = NULL;
+	struct lwm2m_engine_res_inst *res_inst = NULL;
+	int ret;
+	uint8_t created = 0U;
+
+	ret = lwm2m_get_or_create_engine_obj(msg, &obj_inst, &created);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = lwm2m_engine_validate_write_access(msg, obj_inst, &obj_field);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = lwm2m_engine_get_create_res_inst(&msg->path, &res, &res_inst);
+	if (ret < 0) {
+		return -ENOENT;
+	}
+
+	if (msg->path.level < LWM2M_PATH_LEVEL_RESOURCE) {
+		msg->path.level = LWM2M_PATH_LEVEL_RESOURCE;
+	}
+
+	return lwm2m_write_handler(obj_inst, res, res_inst, obj_field, msg);
+}

--- a/subsys/net/lib/lwm2m/lwm2m_rw_opaque.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_opaque.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LWM2M_RW_OPAQUE_H_
+#define LWM2M_RW_OPAQUE_H_
+
+#include "lwm2m_object.h"
+
+extern const struct lwm2m_writer opaque_writer;
+extern const struct lwm2m_reader opaque_reader;
+
+int do_read_op_opaque(struct lwm2m_message *msg, int content_format);
+int do_write_op_opaque(struct lwm2m_message *msg);
+
+#endif /* LWM2M_RW_OPAQUE_H_ */

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -341,49 +341,6 @@ static int get_bool(struct lwm2m_input_context *in, bool *value)
 	return sizeof(uint8_t);
 }
 
-static int get_opaque(struct lwm2m_input_context *in, uint8_t *value,
-		      size_t buflen, struct lwm2m_opaque_context *opaque,
-		      bool *last_block)
-{
-	uint16_t in_len;
-
-	if (opaque->remaining == 0) {
-		coap_packet_get_payload(in->in_cpkt, &in_len);
-
-		if (in_len == 0) {
-			return -ENODATA;
-		}
-
-		if (in->block_ctx != NULL) {
-			uint32_t block_num =
-				in->block_ctx->ctx.current /
-				coap_block_size_to_bytes(
-					in->block_ctx->ctx.block_size);
-
-			if (block_num == 0) {
-				opaque->len = in->block_ctx->ctx.total_size;
-			}
-
-			if (opaque->len == 0) {
-				/* No size1 option provided, use current
-				 * payload size. This will reset on next packet
-				 * received.
-				 */
-				opaque->remaining = in_len;
-			} else {
-				opaque->remaining = opaque->len;
-			}
-
-		} else {
-			opaque->len = in_len;
-			opaque->remaining = in_len;
-		}
-	}
-
-	return lwm2m_engine_get_opaque_more(in, value, buflen,
-					    opaque, last_block);
-}
-
 static int get_objlnk(struct lwm2m_input_context *in,
 		      struct lwm2m_objlnk *value)
 {
@@ -432,7 +389,6 @@ const struct lwm2m_reader plain_text_reader = {
 	.get_time = get_time,
 	.get_float = get_float,
 	.get_bool = get_bool,
-	.get_opaque = get_opaque,
 	.get_objlnk = get_objlnk,
 };
 

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
@@ -836,12 +836,15 @@ static uint8_t parse_composite_read_paths(struct lwm2m_message *msg,
 	uint_fast8_t dret;
 	int len;
 	int ret;
+	char *payload;
+	uint16_t in_len;
 
 	setup_in_fmt_data(msg);
 
 	fd = engine_get_in_user_data(&msg->in);
+	payload = (char *)coap_packet_get_payload(msg->in.in_cpkt, &in_len);
 
-	dret = cbor_decode_lwm2m_senml(ICTX_BUF_R_REGION(&msg->in), &fd->dcd, &isize);
+	dret = cbor_decode_lwm2m_senml(payload, in_len, &fd->dcd, &isize);
 
 	if (dret != ZCBOR_SUCCESS) {
 		__ASSERT_NO_MSG(false);

--- a/tests/net/lib/lwm2m/content_plain_text/src/main.c
+++ b/tests/net/lib/lwm2m/content_plain_text/src/main.c
@@ -470,37 +470,6 @@ ZTEST(net_content_plain_text_nodata, test_get_bool_nodata)
 	zassert_equal(ret, -ENODATA, "Invalid error code returned");
 }
 
-ZTEST(net_content_plain_text, test_get_opaque)
-{
-	int ret;
-	const char *payload = "test_payload";
-	uint8_t buf[16];
-	bool last_block;
-	struct lwm2m_opaque_context ctx = { 0 };
-
-	test_payload_set(payload);
-
-	ret = plain_text_reader.get_opaque(&test_in, buf, sizeof(buf),
-					   &ctx, &last_block);
-	zassert_equal(ret, strlen(payload), "Invalid length returned");
-	zassert_mem_equal(buf, payload, strlen(payload),
-			  "Invalid value parsed");
-	zassert_equal(test_in.offset, strlen(payload) + 1,
-		      "Invalid packet offset");
-}
-
-ZTEST(net_content_plain_text_nodata, test_get_opaque_nodata)
-{
-	int ret;
-	uint8_t value[4];
-	bool last_block;
-	struct lwm2m_opaque_context ctx = { 0 };
-
-	ret = plain_text_reader.get_opaque(&test_in, value, sizeof(value),
-					   &ctx, &last_block);
-	zassert_equal(ret, 0, "Invalid error code returned");
-}
-
 ZTEST(net_content_plain_text, test_get_objlnk)
 {
 	int ret;

--- a/tests/net/lib/lwm2m/lwm2m_engine/src/stubs.c
+++ b/tests/net/lib/lwm2m/lwm2m_engine/src/stubs.c
@@ -24,8 +24,8 @@ DEFINE_FAKE_VALUE_FUNC(int, generate_notify_message, struct lwm2m_ctx *, struct 
 DEFINE_FAKE_VALUE_FUNC(int64_t, engine_observe_shedule_next_event, struct observe_node *, uint16_t,
 		       const int64_t);
 DEFINE_FAKE_VALUE_FUNC(int, handle_request, struct coap_packet *, struct lwm2m_message *);
-DEFINE_FAKE_VOID_FUNC(lwm2m_udp_receive, struct lwm2m_ctx *, uint8_t *, uint16_t, struct sockaddr *,
-		      udp_request_handler_cb_t);
+DEFINE_FAKE_VOID_FUNC(lwm2m_udp_receive, struct lwm2m_ctx *, uint8_t *, uint16_t,
+		      struct sockaddr *);
 DEFINE_FAKE_VALUE_FUNC(bool, lwm2m_rd_client_is_registred, struct lwm2m_ctx *);
 DEFINE_FAKE_VOID_FUNC(lwm2m_engine_context_close, struct lwm2m_ctx *);
 DEFINE_FAKE_VALUE_FUNC(int, lwm2m_get_res_buf, const struct lwm2m_obj_path *, void **, uint16_t *,

--- a/tests/net/lib/lwm2m/lwm2m_engine/src/stubs.h
+++ b/tests/net/lib/lwm2m/lwm2m_engine/src/stubs.h
@@ -39,7 +39,7 @@ DECLARE_FAKE_VALUE_FUNC(int64_t, engine_observe_shedule_next_event, struct obser
 			const int64_t);
 DECLARE_FAKE_VALUE_FUNC(int, handle_request, struct coap_packet *, struct lwm2m_message *);
 DECLARE_FAKE_VOID_FUNC(lwm2m_udp_receive, struct lwm2m_ctx *, uint8_t *, uint16_t,
-		       struct sockaddr *, udp_request_handler_cb_t);
+		       struct sockaddr *);
 DECLARE_FAKE_VALUE_FUNC(bool, lwm2m_rd_client_is_registred, struct lwm2m_ctx *);
 DECLARE_FAKE_VOID_FUNC(lwm2m_engine_context_close, struct lwm2m_ctx *);
 DECLARE_FAKE_VALUE_FUNC(int, lwm2m_get_res_buf, const struct lwm2m_obj_path *, void **, uint16_t *,


### PR DESCRIPTION
This PR contains chain of changes to allow CoAP blockwise support for GET and FETCH messages using mechanisms introduced in https://github.com/zephyrproject-rtos/zephyr/pull/54761.

However, the PR mentioned was only working for LwM2M SEND and registration messages. Both which are initiated by LwM2M client and are CoAP queries (CoAP CON).

To support GET and FETCH (Composite READ) I need to add mechanism not to free the response packet until last block is send out, or any other query starts.

I also found a bug in SenML-CBOR content format that did not parse Composite-GET path correctly.

Opaque payload format is now separated onto its own, and not considered as a part of Plain-Text format. This allows follow up development where we can support stateless Blockwise-GET into single binary resources without keeping the full content in the memory. I did not implement this yet, is it would require API changes into the read-callback.

Also, it is notable that I use CoAP Token to find an ongoing blockwise-transfer. This seem to work OK with AVSystem Coiote server. For Leshan this requires `COAP.BLOCKWISE_REUSE_TOKEN=true` option to work.
There seem to be discussion regarding Leshan/Californium choice of using different token:
* https://github.com/eclipse-leshan/leshan/issues/1422
* https://github.com/eclipse-californium/californium/pull/2088
 which seem to refer to https://core-wg.github.io/attacks-on-coap/draft-ietf-core-attacks-on-coap.html#name-the-response-delay-and-mism
I don't totally agree their choice. If GET comes with different Token, we could generate a new content for it, but how do you ensure that content is the same than from previous query? In my opinion they have introduced a bug into Californium.

### Working GET query using the same Token against Coiote:
![Screenshot from 2023-08-24 17-16-18](https://github.com/zephyrproject-rtos/zephyr/assets/3104794/06ceb1d5-f33c-48a9-9f0b-e377afbc6b80)
