### PR TITLE
boards: arm: stm32f469i_disco: add sdmmc1

### DIFF
--- a/boards/arm/stm32f469i_disco/doc/index.rst
+++ b/boards/arm/stm32f469i_disco/doc/index.rst
@@ -97,6 +97,8 @@ The Zephyr stm32f469i_disco board configuration supports the following hardware 
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| SDIO      | on-chip    | SD-card controller                  |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 
@@ -119,6 +121,7 @@ Default Zephyr Peripheral Mapping:
 - UART_6 TX/RX : PG14/PG9 (Arduino Serial)
 - I2C1 SCL/SDA : PB8/PB9 (Arduino I2C)
 - SPI2 NSS/SCK/MISO/MOSI : PH6/PD3/PB14/PB15 (Arduino SPI)
+- SDIO D0/D1/D2/D3/CLK/Detect : PC8/PC9/PC10/PC11/PC12/PG2
 - USB DM : PA11
 - USB DP : PA12
 - USER_PB : PA0

--- a/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/arm/stm32f469i_disco/stm32f469i_disco.dts
@@ -124,3 +124,17 @@ zephyr_udc0: &usbotg_fs {
 		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
 };
+
+&sdmmc1 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>,
+		 <&rcc STM32_SRC_PLL_Q CLK48M_SEL(0)>;
+	status = "okay";
+	pinctrl-0 = <&sdio_d0_pc8
+		     &sdio_d1_pc9
+		     &sdio_d2_pc10
+		     &sdio_d3_pc11
+		     &sdio_ck_pc12
+		     &sdio_cmd_pd2>;
+	pinctrl-names = "default";
+	cd-gpios = <&gpiog 2 GPIO_ACTIVE_LOW>;
+};


### PR DESCRIPTION
adds sdmmc1 node on stm32f469i_disco board
to use SDIO bus for SD card access
the mandatory clock is 48 Mhz.