### PR TITLE
net: icmpv6: check for type < 128 rather than code < 128

### DIFF
--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -217,7 +217,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 
 		icmp_hdr = (struct net_icmp_hdr *)net_pkt_get_data(
 							orig, &icmpv6_access);
-		if (!icmp_hdr || icmp_hdr->code < 128) {
+		if (!icmp_hdr || icmp_hdr->type < 128) {
 			/* We must not send ICMP errors back */
 			err = -EINVAL;
 			goto drop_no_pkt;


### PR DESCRIPTION
ICMPv6 messages with type < 128 are error messages, where we should not send back another error. The meaning of the code depends on the type.