### PR TITLE
bbram: add support from user threads

### DIFF
--- a/drivers/bbram/CMakeLists.txt
+++ b/drivers/bbram/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_BBRAM_SHELL bbram_shell.c)
 
+zephyr_library_sources_ifdef(CONFIG_USERSPACE bbram_handlers.c)
 zephyr_library_sources_ifdef(CONFIG_BBRAM_NPCX bbram_npcx.c)
 zephyr_library_sources_ifdef(CONFIG_BBRAM_IT8XXX2 bbram_it8xxx2.c)
 zephyr_library_sources_ifdef(CONFIG_BBRAM_EMUL bbram_emul.c)

--- a/drivers/bbram/bbram_handlers.c
+++ b/drivers/bbram/bbram_handlers.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/bbram.h>
+#include <zephyr/syscall_handler.h>
+
+static inline int z_vrfy_bbram_check_invalid(const struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_BBRAM));
+	return z_impl_bbram_check_invalid(dev);
+}
+#include <syscalls/bbram_check_invalid_mrsh.c>
+
+static inline int z_vrfy_bbram_check_standby_power(const struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_BBRAM));
+	return z_impl_bbram_check_standby_power(dev);
+}
+#include <syscalls/bbram_check_standby_power_mrsh.c>
+
+static inline int z_vrfy_bbram_check_power(const struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_BBRAM));
+	return z_impl_bbram_check_power(dev);
+}
+#include <syscalls/bbram_check_power_mrsh.c>
+
+static inline int z_vrfy_bbram_get_size(const struct device *dev, size_t *size)
+{
+	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_BBRAM));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(size, sizeof(size_t)));
+	return z_impl_bbram_get_size(dev, size);
+}
+#include <syscalls/bbram_get_size_mrsh.c>
+
+static inline int z_vrfy_bbram_read(const struct device *dev, size_t offset,
+				    size_t size, uint8_t *data)
+{
+	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_BBRAM));
+	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(data, size));
+	return z_impl_bbram_read(dev, offset, size, data);
+}
+#include <syscalls/bbram_read_mrsh.c>
+
+static inline int z_vrfy_bbram_write(const struct device *dev, size_t offset,
+				     size_t size, const uint8_t *data)
+{
+	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_BBRAM));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(data, size));
+	return z_impl_bbram_write(dev, offset, size, data);
+}
+#include <syscalls/bbram_write_mrsh.c>


### PR DESCRIPTION
Provide the necessary handlers to support bbram access from userthreads.
fixes #61868.