### PR TITLE
canbus: isotp: group CAN ISO-TP doxygen documentation under connectivity

### DIFF
--- a/include/zephyr/canbus/isotp.h
+++ b/include/zephyr/canbus/isotp.h
@@ -15,9 +15,9 @@
 #define ZEPHYR_INCLUDE_ISOTP_H_
 
 /**
- * @brief CAN ISO-TP Interface
- * @defgroup can_isotp CAN ISO-TP Interface
- * @ingroup CAN
+ * @brief CAN ISO-TP Protocol
+ * @defgroup can_isotp CAN ISO-TP Protocol
+ * @ingroup connectivity
  * @{
  */
 


### PR DESCRIPTION
Move the CAN ISO-TP protocol API documentation from having its own top-level module to being grouped with the other connectivity APIs.

Change the API documentation header to reflect that this is a protocol.