### PR TITLE
Enabled RTC support for ADL platform

### DIFF
--- a/boards/x86/intel_adl/intel_adl_crb.dts
+++ b/boards/x86/intel_adl/intel_adl_crb.dts
@@ -11,6 +11,10 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 	};
+
+	aliases {
+		rtc = &rtc;
+	};
 };
 
 &uart0 {

--- a/boards/x86/intel_adl/intel_adl_crb.yaml
+++ b/boards/x86/intel_adl/intel_adl_crb.yaml
@@ -9,6 +9,7 @@ supported:
   - watchdog
   - pwm
   - gpio
+  - rtc
 testing:
   timeout_multiplier: 4
   ignore_tags:

--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -281,9 +281,12 @@
 			status = "okay";
 		};
 
-		counter: counter@70 {
+		rtc: counter: rtc@70 {
 			compatible = "motorola,mc146818";
 			reg = <0x70 0x0D 0x71 0x0D>;
+			interrupts = <8 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
+			interrupt-parent = <&intc>;
+			alarms-count = <1>;
 
 			status = "okay";
 		};


### PR DESCRIPTION
Enabled RTC support by modifying counter instance to support RTC and counter on ADL platform.