### PR TITLE
Add support for network interface user friendly name

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -424,6 +424,14 @@ struct net_if_config {
 	 */
 	sys_slist_t virtual_interfaces;
 #endif /* CONFIG_NET_L2_VIRTUAL */
+
+#if defined(CONFIG_NET_INTERFACE_NAME)
+	/**
+	 * Network interface can have a name and it is possible
+	 * to search a network interface using this name.
+	 */
+	char name[CONFIG_NET_INTERFACE_NAME_LEN + 1];
+#endif
 };
 
 /**
@@ -2575,6 +2583,46 @@ bool net_if_is_wifi(struct net_if *iface);
  */
 struct net_if *net_if_get_first_wifi(void);
 
+/**
+ * @brief Get network interface name.
+ *
+ * @details If interface name support is not enabled, empty string is returned.
+ *
+ * @param iface Pointer to network interface
+ * @param buf User supplied buffer
+ * @param len Length of the user supplied buffer
+ *
+ * @return Length of the interface name copied to buf,
+ *         -EINVAL if invalid parameters,
+ *         -ERANGE if name cannot be copied to the user supplied buffer,
+ *         -ENOTSUP if interface name support is disabled,
+ */
+int net_if_get_name(struct net_if *iface, char *buf, int len);
+
+/**
+ * @brief Set network interface name.
+ *
+ * @details Normally this function is not needed to call as the system
+ *          will automatically assign a name to the network interface.
+ *
+ * @param iface Pointer to network interface
+ * @param buf User supplied name
+ *
+ * @return 0 name is set correctly
+ *         -ENOTSUP interface name support is disabled
+ *         -EINVAL if invalid parameters are given,
+ *         -ENAMETOOLONG if name is too long
+ */
+int net_if_set_name(struct net_if *iface, const char *buf);
+
+/**
+ * @brief Get interface index according to its name
+ *
+ * @param name Name of the network interface
+ *
+ * @return Interface index
+ */
+int net_if_get_by_name(const char *name);
 
 /** @cond INTERNAL_HIDDEN */
 struct net_if_api {

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -859,6 +859,21 @@ config NET_DEFAULT_IF_WIFI
 
 endchoice
 
+config NET_INTERFACE_NAME
+	bool "Allow setting a name to a network interface"
+	default y
+	help
+	  Allow application to set a name to the network interface in order
+	  to simplify network interface management.
+
+config NET_INTERFACE_NAME_LEN
+	int "Network interface max name length"
+	default 8
+	range 1 15
+	depends on NET_INTERFACE_NAME
+	help
+	  Maximum length of the network interface name.
+
 config NET_PKT_TIMESTAMP
 	bool "Network packet timestamp support"
 	help

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -378,8 +379,21 @@ static void iface_cb(struct net_if *iface, void *user_data)
 		return;
 	}
 
+#if defined(CONFIG_NET_INTERFACE_NAME)
+	char ifname[CONFIG_NET_INTERFACE_NAME_LEN + 1] = { 0 };
+	int ret_name;
+
+	ret_name = net_if_get_name(iface, ifname, sizeof(ifname) - 1);
+	if (ret_name < 1 || ifname[0] == '\0') {
+		snprintk(ifname, sizeof(ifname), "?");
+	}
+
+	PR("\nInterface %s (%p) (%s) [%d]\n", ifname, iface, iface2str(iface, &extra),
+	   net_if_get_by_iface(iface));
+#else
 	PR("\nInterface %p (%s) [%d]\n", iface, iface2str(iface, &extra),
 	   net_if_get_by_iface(iface));
+#endif
 	PR("===========================%s\n", extra);
 
 	if (!net_if_is_up(iface)) {

--- a/subsys/net/lib/sockets/socket_dispatcher.c
+++ b/subsys/net/lib/sockets/socket_dispatcher.c
@@ -318,7 +318,6 @@ static int sock_dispatch_setsockopt_vmeth(void *obj, int level, int optname,
 
 	if ((level == SOL_SOCKET) && (optname == SO_BINDTODEVICE)) {
 		struct net_if *iface;
-		const struct device *dev;
 		const struct ifreq *ifreq = optval;
 
 		if ((ifreq == NULL) || (optlen != sizeof(*ifreq))) {
@@ -326,16 +325,34 @@ static int sock_dispatch_setsockopt_vmeth(void *obj, int level, int optname,
 			return -1;
 		}
 
-		dev = device_get_binding(ifreq->ifr_name);
-		if (dev == NULL) {
-			errno = ENODEV;
-			return -1;
-		}
+		if (IS_ENABLED(CONFIG_NET_INTERFACE_NAME)) {
+			int ret;
 
-		iface = net_if_lookup_by_dev(dev);
-		if (iface == NULL) {
-			errno = ENODEV;
-			return -1;
+			ret = net_if_get_by_name(ifreq->ifr_name);
+			if (ret < 0) {
+				errno = -ret;
+				return -1;
+			}
+
+			iface = net_if_get_by_index(ret);
+			if (iface == NULL) {
+				errno = ENODEV;
+				return -1;
+			}
+		} else {
+			const struct device *dev;
+
+			dev = device_get_binding(ifreq->ifr_name);
+			if (dev == NULL) {
+				errno = ENODEV;
+				return -1;
+			}
+
+			iface = net_if_lookup_by_dev(dev);
+			if (iface == NULL) {
+				errno = ENODEV;
+				return -1;
+			}
 		}
 
 		if (net_if_socket_offload(iface) != NULL) {

--- a/tests/net/socket/misc/src/main.c
+++ b/tests/net/socket/misc/src/main.c
@@ -143,8 +143,13 @@ static struct dummy_api dummy_api_funcs = {
 	.send = dummy_send,
 };
 
+#if defined(CONFIG_NET_INTERFACE_NAME)
+#define DEV1_NAME "dummy0"
+#define DEV2_NAME "dummy1"
+#else
 #define DEV1_NAME "dummy_1"
 #define DEV2_NAME "dummy_2"
+#endif
 
 NET_DEVICE_INIT(dummy_1, DEV1_NAME, NULL, NULL, &dummy_data1, NULL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &dummy_api_funcs,
@@ -164,8 +169,11 @@ void test_so_bindtodevice(int sock_c, int sock_s, struct sockaddr *peer_addr,
 {
 	int ret;
 	struct ifreq ifreq = { 0 };
+
+#if !defined(CONFIG_NET_INTERFACE_NAME)
 	const struct device *dev1 = device_get_binding(DEV1_NAME);
 	const struct device *dev2 = device_get_binding(DEV2_NAME);
+#endif
 
 	uint8_t send_buf[32];
 	uint8_t recv_buf[sizeof(send_buf)] = { 0 };
@@ -198,8 +206,10 @@ void test_so_bindtodevice(int sock_c, int sock_s, struct sockaddr *peer_addr,
 	ret = sys_sem_take(&send_sem, K_MSEC(100));
 	zassert_equal(ret, 0, "iface did not receive packet");
 
+#if !defined(CONFIG_NET_INTERFACE_NAME)
 	zassert_equal_ptr(dev1, current_dev, "invalid interface used (%p vs %p)",
 			  dev1, current_dev);
+#endif
 
 	k_msleep(10);
 
@@ -221,8 +231,10 @@ void test_so_bindtodevice(int sock_c, int sock_s, struct sockaddr *peer_addr,
 	ret = sys_sem_take(&send_sem, K_MSEC(100));
 	zassert_equal(ret, 0, "iface did not receive packet");
 
+#if !defined(CONFIG_NET_INTERFACE_NAME)
 	zassert_equal_ptr(dev2, current_dev, "invalid interface used (%p vs %p)",
 			  dev2, current_dev);
+#endif
 
 	/* Server socket should only receive data from the bound interface. */
 
@@ -257,7 +269,9 @@ void test_so_bindtodevice(int sock_c, int sock_s, struct sockaddr *peer_addr,
 	ret = sys_sem_take(&send_sem, K_MSEC(100));
 	zassert_equal(ret, 0, "iface did not receive packet");
 
+#if !defined(CONFIG_NET_INTERFACE_NAME)
 	zassert_equal_ptr(dev1, current_dev, "invalid interface used");
+#endif
 
 	/* Server socket should now receive data from interface 1 as well. */
 

--- a/tests/net/socket/offload_dispatcher/src/main.c
+++ b/tests/net/socket/offload_dispatcher/src/main.c
@@ -688,7 +688,11 @@ ZTEST(net_socket_offload_udp, test_so_bindtodevice_iface_offloaded)
 	int ret;
 	uint8_t dummy_data = 0;
 	struct ifreq ifreq = {
+#if defined(CONFIG_NET_INTERFACE_NAME)
+		.ifr_name = "net1"
+#else
 		.ifr_name = "offloaded_2"
+#endif
 	};
 	struct sockaddr_in addr = {
 		.sin_family = AF_INET
@@ -719,7 +723,11 @@ ZTEST(net_socket_offload_udp, test_so_bindtodevice_iface_native)
 	int ret;
 	uint8_t dummy_data = 0;
 	struct ifreq ifreq = {
+#if defined(CONFIG_NET_INTERFACE_NAME)
+		.ifr_name = "dummy0"
+#else
 		.ifr_name = "dummy_native"
+#endif
 	};
 	struct sockaddr_in addr = test_peer_addr;
 
@@ -750,7 +758,11 @@ ZTEST(net_socket_offload_tls, test_tls_native_iface_offloaded)
 	const struct fd_op_vtable *vtable;
 	void *obj;
 	struct ifreq ifreq = {
+#if defined(CONFIG_NET_INTERFACE_NAME)
+		.ifr_name = "net1"
+#else
 		.ifr_name = "offloaded_2"
+#endif
 	};
 	int tls_native = 1;
 	struct sockaddr_in addr = test_peer_addr;
@@ -793,7 +805,11 @@ ZTEST(net_socket_offload_tls, test_tls_native_iface_native)
 	const struct fd_op_vtable *vtable;
 	void *obj;
 	struct ifreq ifreq = {
+#if defined(CONFIG_NET_INTERFACE_NAME)
+		.ifr_name = "dummy0"
+#else
 		.ifr_name = "dummy_native"
+#endif
 	};
 	int tls_native = 1;
 	struct sockaddr_in addr = test_peer_addr;


### PR DESCRIPTION
If `CONFIG_NET_INTERFACE_NAME` is enabled (default is y), then the system will automatically set a user friendly name to the network interface like eth0, wlan0 etc. Application can change the interface name if needed.

This is useful so that applications do not need to try to use the device name for figuring out the desired network interface. 
