### PR TITLE
mgmt: ec_host_cmd: add missing declaration

### DIFF
--- a/include/zephyr/mgmt/ec_host_cmd/backend.h
+++ b/include/zephyr/mgmt/ec_host_cmd/backend.h
@@ -14,6 +14,7 @@
 
 #include <zephyr/sys/__assert.h>
 #include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 
@@ -141,6 +142,18 @@ struct ec_host_cmd_backend *ec_host_cmd_backend_get_shi_ite(void);
  * @retval The UART backend pointer.
  */
 struct ec_host_cmd_backend *ec_host_cmd_backend_get_uart(const struct device *dev);
+
+/**
+ * @brief Get the SPI Host Command backend pointer
+ *
+ * Get the SPI pointer backend and pass a chip select pin that will be used for the Host Command
+ * communication.
+ *
+ * @param cs Chip select pin..
+ *
+ * @retval The SPI backend pointer.
+ */
+struct ec_host_cmd_backend *ec_host_cmd_backend_get_spi(struct gpio_dt_spec *cs);
 
 /**
  * @}


### PR DESCRIPTION
Add missing declaration of a function to get the SPI backend.