### PR TITLE
doc: extensions: Show Kconfig options in search

### DIFF
--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -28,14 +28,11 @@ Options
   ${BASE_PATH}/modules/${MODULE_NAME}/Kconfig.
 """
 
-from distutils.command.build import build
-from itertools import chain
 import json
-from operator import mod
 import os
-from pathlib import Path
-import re
 import sys
+from itertools import chain
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
@@ -51,7 +48,6 @@ from sphinx.util import progress_message
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import make_refnode
 
-
 __version__ = "0.1.0"
 
 
@@ -64,8 +60,8 @@ sys.path.insert(0, str(SCRIPTS))
 KCONFIGLIB = SCRIPTS / "kconfig"
 sys.path.insert(0, str(KCONFIGLIB))
 
-import zephyr_module
 import kconfiglib
+import zephyr_module
 
 
 def kconfig_load(app: Sphinx) -> Tuple[kconfiglib.Kconfig, Dict[str, str]]:

--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -225,7 +225,7 @@ class KconfigDomain(Domain):
         """Register a new Kconfig option to the domain."""
 
         self.data["options"].append(
-            (option, option, "option", self.env.docname, option, -1)
+            (option, option, "option", self.env.docname, option, 1)
         )
 
 


### PR DESCRIPTION
Show Kconfig options in search results, since that's how some people would expect to be able to find more details about
them.

@gmarull please let me know if there was a good reason for you to have excluded them (-1) back when you worked on this. Thanks!