### PR TITLE
net: icmpv6: allow multiple handlers

### DIFF
--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -429,6 +429,7 @@ enum net_verdict net_icmpv6_input(struct net_pkt *pkt,
 					      struct net_icmp_hdr);
 	struct net_icmp_hdr *icmp_hdr;
 	struct net_icmpv6_handler *cb;
+	enum net_verdict res;
 
 	icmp_hdr = (struct net_icmp_hdr *)net_pkt_get_data(pkt, &icmp_access);
 	if (!icmp_hdr) {
@@ -455,7 +456,12 @@ enum net_verdict net_icmpv6_input(struct net_pkt *pkt,
 	SYS_SLIST_FOR_EACH_CONTAINER(&handlers, cb, node) {
 		if (cb->type == icmp_hdr->type &&
 		    (cb->code == icmp_hdr->code || cb->code == 0U)) {
-			return cb->handler(pkt, ip_hdr, icmp_hdr);
+			res = cb->handler(pkt, ip_hdr, icmp_hdr);
+			if (res == NET_CONTINUE) {
+				continue;
+			} else {
+				return res;
+			}
 		}
 	}
 drop:


### PR DESCRIPTION
This change allows to register additional handlers for ICMPv6 so the user can handle some of the messages between they are handled by the ICMPv6 module in Zephyr by returning NET_CONTINUE.