### PR TITLE
MAINTAINERS: add a few missing paths to the CAN area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -709,16 +709,18 @@ Release Notes:
     - martinjaeger
     - str4t0m
   files:
+    - boards/shields/mcp2515/
     - doc/hardware/peripherals/canbus/
     - drivers/can/
     - drivers/net/canbus.c
     - dts/bindings/can/
+    - dts/bindings/phy/can-transceiver*
     - include/zephyr/canbus/
     - include/zephyr/devicetree/can.h
     - include/zephyr/drivers/can.h
     - include/zephyr/drivers/can/
     - include/zephyr/net/canbus.h
-    - include/zephyr/net/socketcan.h
+    - include/zephyr/net/socketcan*.h
     - samples/drivers/can/
     - samples/modules/canopennode/
     - samples/net/sockets/can/


### PR DESCRIPTION
Add a few missing paths to the CAN area in the MAINTAINERS.yml file.