### PR TITLE
Add LLVM source profiling/coverage mode for native boards

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -15,7 +15,11 @@ set_compiler_property(PROPERTY no_printf_return_value)
 check_set_compiler_property(PROPERTY hosted)
 
 # clang flags for coverage generation
-set_property(TARGET compiler PROPERTY coverage --coverage -fno-inline)
+if (CONFIG_COVERAGE_NATIVE_SOURCE)
+  set_compiler_property(PROPERTY coverage -fprofile-instr-generate -fcoverage-mapping)
+else()
+  set_compiler_property(PROPERTY coverage --coverage -fno-inline)
+endif()
 
 # clang flag for colourful diagnostic messages
 set_compiler_property(PROPERTY diagnostic -fcolor-diagnostics)

--- a/cmake/linker/ld/clang/linker_flags.cmake
+++ b/cmake/linker/ld/clang/linker_flags.cmake
@@ -1,6 +1,8 @@
 # The coverage linker flag is specific for clang.
-if (NOT CONFIG_COVERAGE_GCOV)
+if (CONFIG_COVERAGE_NATIVE_GCOV)
   set_property(TARGET linker PROPERTY coverage --coverage)
+elseif(CONFIG_COVERAGE_NATIVE_SOURCE)
+  set_property(TARGET linker PROPERTY coverage -fprofile-instr-generate -fcoverage-mapping)
 endif()
 
 # Extra warnings options for twister run

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -40,16 +40,37 @@ config COVERAGE
 	  For more information see
 	  https://docs.zephyrproject.org/latest/guides/coverage.html
 
+choice
+	prompt "Coverage mode"
+	default COVERAGE_NATIVE_GCOV if NATIVE_BUILD
+	default COVERAGE_GCOV if !NATIVE_BUILD
+	depends on COVERAGE
+
+config COVERAGE_NATIVE_GCOV
+	bool "Host compiler gcov based code coverage"
+	depends on NATIVE_BUILD
+	help
+	  Build natively with the compiler standard `--coverage` options,
+	  that is with gcov/GCC-compatible coverage
+
+config COVERAGE_NATIVE_SOURCE
+	bool "Host compiler source based code coverage"
+	depends on NATIVE_BUILD
+	depends on "${ZEPHYR_TOOLCHAIN_VARIANT}" = "llvm"
+	help
+	  Build natively with the compiler source based coverage options.
+	  Today this is only supported with LLVM
+
 config COVERAGE_GCOV
 	bool "Create Coverage data from hardware platform"
-	default y
-	depends on COVERAGE
 	depends on !NATIVE_BUILD
 	help
 	  This option will select the custom gcov library. The reports will
 	  be available over serial. This serial dump can be passed to
 	  gen_gcov_files.py which creates the required .gcda files. These
 	  can be read by gcov utility. For more details see gcovr.com .
+
+endchoice
 
 config COVERAGE_GCOV_HEAP_SIZE
 	int "Size of heap allocated for gcov coverage data dump"


### PR DESCRIPTION
Add a a new source coverage for native builds
and new kconfig choice of COVERAGE mode to select which:
* COVERAGE_NATIVE_GCOV: what we had until now with native builds
* COVERAGE_NATIVE_SOURCE: a new LLVM source coverage mode
* COVERAGE_GCOV: the old COVERAGE_GCOV (embedded gcov data generation).

----

Note:
- https://github.com/zephyrproject-rtos/zephyr/pull/61341

cleaned up the missuses of CONFIG_COVERAGE in the tree. The only thing CONFIG_COVERAGE toggles now, is the COMPILER_OPTIMIZATIONS default, and disabling forced inlines.

@andyross do you want this in, now that the CONFIG_COVERAGE  has been cleaned up? (If you feel strongly about having a option to only toggle the build switches and nothing else you can add an extra commit adding a helper kconfig option that does only that)

---

Alternative to #59632, to try to unblock it.