### PR TITLE
Ambiq add simobuck init

### DIFF
--- a/soc/arm/ambiq/apollo4x/soc.c
+++ b/soc/arm/ambiq/apollo4x/soc.c
@@ -10,8 +10,20 @@
 
 static int arm_apollo4_init(void)
 {
-	am_hal_pwrctrl_low_power_init();
-	am_hal_rtc_osc_disable();
+    //
+    // Initialize for low power in the power control block
+    //
+    am_hal_pwrctrl_low_power_init();
+
+    //
+    // Enable SIMOBUCK for this board
+    //
+    am_hal_pwrctrl_control(AM_HAL_PWRCTRL_CONTROL_SIMOBUCK_INIT, 0);
+
+    //
+    // Disable the RTC.
+    //
+    am_hal_rtc_osc_disable();
 
 	return 0;
 }

--- a/soc/arm/ambiq/apollo4x/soc.c
+++ b/soc/arm/ambiq/apollo4x/soc.c
@@ -10,19 +10,13 @@
 
 static int arm_apollo4_init(void)
 {
-    //
-    // Initialize for low power in the power control block
-    //
+    /* Initialize for low power in the power control block */
     am_hal_pwrctrl_low_power_init();
 
-    //
-    // Enable SIMOBUCK for this board
-    //
+    /* Enable SIMOBUCK for this board */
     am_hal_pwrctrl_control(AM_HAL_PWRCTRL_CONTROL_SIMOBUCK_INIT, 0);
 
-    //
-    // Disable the RTC.
-    //
+    /* Disable the RTC. */
     am_hal_rtc_osc_disable();
 
 	return 0;


### PR DESCRIPTION
This allows the Ambiq apollo4 to enter the lowest power by switching from LDO to simobuck upon initialization.
Signed-off-by: Richard Wheatley richardswheatley@gmail.com