### PR TITLE
ci: assigner: fix the main operation selector check

### DIFF
--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -327,7 +327,7 @@ def main():
 
     if args.pull_request:
         process_pr(gh, maintainer_file, args.pull_request)
-    if args.issue:
+    elif args.issue:
         process_issue(gh, maintainer_file, args.issue)
     elif args.modules:
         process_modules(gh, maintainer_file)


### PR DESCRIPTION
Not sure what was wrong with me and "if"s that day...

---

Fix an "if" that should have been an "elif". This is currently causing the script to fallback into the "do all unassigned PRs of the day" path when a PR is specified.