### PR TITLE
kernel: Modify the signature of `k_mem_slab_free` via stable API change

### DIFF
--- a/doc/kernel/memory_management/slabs.rst
+++ b/doc/kernel/memory_management/slabs.rst
@@ -130,7 +130,7 @@ then releases it once it is no longer needed.
 
     k_mem_slab_alloc(&my_slab, &block_ptr, K_FOREVER);
     ... /* use memory block pointed at by block_ptr */
-    k_mem_slab_free(&my_slab, &block_ptr);
+    k_mem_slab_free(&my_slab, block_ptr);
 
 Suggested Uses
 **************

--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -11,6 +11,14 @@ application from Zephyr v3.4.0 to Zephyr v3.5.0.
 Required changes
 ****************
 
+* The kernel :c:func:`k_mem_slab_free` function has changed its signature, now
+  taking a ``void *mem`` pointer instead of a ``void **mem`` double-pointer.
+  The new signature will not immediately trigger a compiler error or warning,
+  instead likely causing a invalid memory access at runtime. A new ``_ASSERT``
+  statement, that you can enable with :kconfig:option:`CONFIG_ASSERT`, will
+  detect if you pass the function memory not belonging to the memory blocks in
+  the slab.
+
 * The :kconfig:option:`CONFIG_BOOTLOADER_SRAM_SIZE` default value is now ``0`` (was
   ``16``). Bootloaders that use a part of the SRAM should set this value to an
   appropriate size. :github:`60371`

--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -39,7 +39,7 @@ struct dmic_nrfx_pdm_drv_cfg {
 
 static void free_buffer(struct dmic_nrfx_pdm_drv_data *drv_data, void *buffer)
 {
-	k_mem_slab_free(drv_data->mem_slab, &buffer);
+	k_mem_slab_free(drv_data->mem_slab, buffer);
 	LOG_DBG("Freed buffer %p", buffer);
 }
 

--- a/drivers/audio/mpxxdtyy-i2s.c
+++ b/drivers/audio/mpxxdtyy-i2s.c
@@ -44,7 +44,7 @@ int mpxxdtyy_i2s_read(const struct device *dev, uint8_t stream, void **buffer,
 
 	sw_filter_lib_run(pdm_filter, pdm_block, pcm_block, pdm_size,
 			  data->pcm_mem_size);
-	k_mem_slab_free(&rx_pdm_i2s_mslab, &pdm_block);
+	k_mem_slab_free(&rx_pdm_i2s_mslab, pdm_block);
 
 	*buffer = pcm_block;
 	*size = data->pcm_mem_size;

--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -61,7 +61,7 @@ void uart_mcumgr_free_rx_buf(struct uart_mcumgr_rx_buf *rx_buf)
 	void *block;
 
 	block = rx_buf;
-	k_mem_slab_free(&uart_mcumgr_slab, &block);
+	k_mem_slab_free(&uart_mcumgr_slab, block);
 }
 
 #if !defined(CONFIG_MCUMGR_TRANSPORT_UART_ASYNC)

--- a/drivers/i2s/i2s_common.c
+++ b/drivers/i2s/i2s_common.c
@@ -21,7 +21,7 @@ int z_impl_i2s_buf_read(const struct device *dev, void *buf, size_t *size)
 		rx_cfg = i2s_config_get((const struct device *)dev, I2S_DIR_RX);
 
 		memcpy(buf, mem_block, *size);
-		k_mem_slab_free(rx_cfg->mem_slab, &mem_block);
+		k_mem_slab_free(rx_cfg->mem_slab, mem_block);
 	}
 
 	return ret;
@@ -51,7 +51,7 @@ int z_impl_i2s_buf_write(const struct device *dev, void *buf, size_t size)
 
 	ret = i2s_write((const struct device *)dev, mem_block, size);
 	if (ret != 0) {
-		k_mem_slab_free(tx_cfg->mem_slab, &mem_block);
+		k_mem_slab_free(tx_cfg->mem_slab, mem_block);
 	}
 
 	return ret;

--- a/drivers/i2s/i2s_handlers.c
+++ b/drivers/i2s/i2s_handlers.c
@@ -66,7 +66,7 @@ static inline int z_vrfy_i2s_buf_read(const struct device *dev,
 		copy_success = z_user_to_copy((void *)buf, mem_block,
 					      data_size);
 
-		k_mem_slab_free(rx_cfg->mem_slab, &mem_block);
+		k_mem_slab_free(rx_cfg->mem_slab, mem_block);
 		Z_OOPS(copy_success);
 		Z_OOPS(z_user_to_copy((void *)size, &data_size,
 				      sizeof(data_size)));
@@ -100,13 +100,13 @@ static inline int z_vrfy_i2s_buf_write(const struct device *dev,
 
 	ret = z_user_from_copy(mem_block, (void *)buf, size);
 	if (ret) {
-		k_mem_slab_free(tx_cfg->mem_slab, &mem_block);
+		k_mem_slab_free(tx_cfg->mem_slab, mem_block);
 		Z_OOPS(ret);
 	}
 
 	ret = i2s_write((const struct device *)dev, mem_block, size);
 	if (ret != 0) {
-		k_mem_slab_free(tx_cfg->mem_slab, &mem_block);
+		k_mem_slab_free(tx_cfg->mem_slab, mem_block);
 	}
 
 	return ret;

--- a/drivers/i2s/i2s_litex.c
+++ b/drivers/i2s/i2s_litex.c
@@ -588,7 +588,7 @@ static void i2s_litex_isr_tx(void *arg)
 			 stream->cfg.word_size, stream->cfg.channels);
 	i2s_clear_pending_irq(cfg->base);
 
-	k_mem_slab_free(stream->cfg.mem_slab, &stream->mem_block);
+	k_mem_slab_free(stream->cfg.mem_slab, stream->mem_block);
 }
 
 static const struct i2s_driver_api i2s_litex_driver_api = {

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -600,7 +600,7 @@ static void dma_tx_callback(const struct device *dma_dev, void *arg,
 	__ASSERT_NO_MSG(stream->mem_block != NULL);
 
 	/* All block data sent */
-	k_mem_slab_free(stream->cfg.mem_slab, &stream->mem_block);
+	k_mem_slab_free(stream->cfg.mem_slab, stream->mem_block);
 	stream->mem_block = NULL;
 
 	/* Stop transmission if there was an error */
@@ -806,7 +806,7 @@ static void rx_stream_disable(struct stream *stream, const struct device *dev)
 
 	dma_stop(stream->dev_dma, stream->dma_channel);
 	if (stream->mem_block != NULL) {
-		k_mem_slab_free(stream->cfg.mem_slab, &stream->mem_block);
+		k_mem_slab_free(stream->cfg.mem_slab, stream->mem_block);
 		stream->mem_block = NULL;
 	}
 
@@ -824,7 +824,7 @@ static void tx_stream_disable(struct stream *stream, const struct device *dev)
 
 	dma_stop(stream->dev_dma, stream->dma_channel);
 	if (stream->mem_block != NULL) {
-		k_mem_slab_free(stream->cfg.mem_slab, &stream->mem_block);
+		k_mem_slab_free(stream->cfg.mem_slab, stream->mem_block);
 		stream->mem_block = NULL;
 	}
 
@@ -839,7 +839,7 @@ static void rx_queue_drop(struct stream *stream)
 	void *mem_block;
 
 	while (queue_get(&stream->mem_block_queue, &mem_block, &size) == 0) {
-		k_mem_slab_free(stream->cfg.mem_slab, &mem_block);
+		k_mem_slab_free(stream->cfg.mem_slab, mem_block);
 	}
 
 	k_sem_reset(&stream->sem);
@@ -852,7 +852,7 @@ static void tx_queue_drop(struct stream *stream)
 	unsigned int n = 0U;
 
 	while (queue_get(&stream->mem_block_queue, &mem_block, &size) == 0) {
-		k_mem_slab_free(stream->cfg.mem_slab, &mem_block);
+		k_mem_slab_free(stream->cfg.mem_slab, mem_block);
 		n++;
 	}
 

--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -300,15 +300,15 @@ static inline void i2s_purge_stream_buffers(struct stream *stream,
 		struct i2s_txq_entry queue_entry;
 
 		while (k_msgq_get(&stream->in_queue, &queue_entry, K_NO_WAIT) == 0) {
-			k_mem_slab_free(mem_slab, &queue_entry.mem_block);
+			k_mem_slab_free(mem_slab, queue_entry.mem_block);
 		}
 	} else {
 		while (k_msgq_get(&stream->in_queue, &buffer, K_NO_WAIT) == 0) {
-			k_mem_slab_free(mem_slab, &buffer);
+			k_mem_slab_free(mem_slab, buffer);
 		}
 	}
 	while (k_msgq_get(&stream->out_queue, &buffer, K_NO_WAIT) == 0) {
-		k_mem_slab_free(mem_slab, &buffer);
+		k_mem_slab_free(mem_slab, buffer);
 	}
 }
 
@@ -457,7 +457,7 @@ static void i2s_mcux_dma_tx_callback(const struct device *dma_dev, void *arg,
 	ret = k_msgq_get(&stream->out_queue, &queue_entry.mem_block, K_NO_WAIT);
 	if (ret == 0) {
 		/* transmission complete. free the buffer */
-		k_mem_slab_free(stream->cfg.mem_slab, &queue_entry.mem_block);
+		k_mem_slab_free(stream->cfg.mem_slab, queue_entry.mem_block);
 	} else {
 		LOG_ERR("no buffer in output queue for channel %u", channel);
 	}

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -124,13 +124,13 @@ static inline void i2s_purge_stream_buffers(struct stream *strm,
 
 	if (in_drop) {
 		while (k_msgq_get(&strm->in_queue, &buffer, K_NO_WAIT) == 0) {
-			k_mem_slab_free(mem_slab, &buffer);
+			k_mem_slab_free(mem_slab, buffer);
 		}
 	}
 
 	if (out_drop) {
 		while (k_msgq_get(&strm->out_queue, &buffer, K_NO_WAIT) == 0) {
-			k_mem_slab_free(mem_slab, &buffer);
+			k_mem_slab_free(mem_slab, buffer);
 		}
 	}
 }
@@ -277,7 +277,7 @@ static void i2s_dma_tx_callback(const struct device *dma_dev,
 	ret = k_msgq_get(&strm->out_queue, &buffer, K_NO_WAIT);
 	if (ret == 0) {
 		/* transmission complete. free the buffer */
-		k_mem_slab_free(strm->cfg.mem_slab, &buffer);
+		k_mem_slab_free(strm->cfg.mem_slab, buffer);
 		(strm->free_tx_dma_blocks)++;
 	} else {
 		LOG_ERR("no buf in out_queue for channel %u", channel);

--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -213,13 +213,13 @@ static bool get_next_rx_buffer(struct i2s_nrfx_drv_data *drv_data,
 static void free_tx_buffer(struct i2s_nrfx_drv_data *drv_data,
 			   const void *buffer)
 {
-	k_mem_slab_free(drv_data->tx.cfg.mem_slab, (void **)&buffer);
+	k_mem_slab_free(drv_data->tx.cfg.mem_slab, (void *)buffer);
 	LOG_DBG("Freed TX %p", buffer);
 }
 
 static void free_rx_buffer(struct i2s_nrfx_drv_data *drv_data, void *buffer)
 {
-	k_mem_slab_free(drv_data->rx.cfg.mem_slab, &buffer);
+	k_mem_slab_free(drv_data->rx.cfg.mem_slab, buffer);
 	LOG_DBG("Freed RX %p", buffer);
 }
 

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -277,7 +277,7 @@ static void dma_tx_callback(const struct device *dma_dev, void *user_data,
 	__ASSERT_NO_MSG(stream->mem_block != NULL);
 
 	/* All block data sent */
-	k_mem_slab_free(stream->cfg.mem_slab, &stream->mem_block);
+	k_mem_slab_free(stream->cfg.mem_slab, stream->mem_block);
 	stream->mem_block = NULL;
 
 	/* Stop transmission if there was an error */
@@ -736,7 +736,7 @@ static void rx_stream_disable(struct stream *stream, Ssc *const ssc,
 	ssc->SSC_IDR = SSC_IDR_OVRUN;
 	dma_stop(dev_dma, stream->dma_channel);
 	if (stream->mem_block != NULL) {
-		k_mem_slab_free(stream->cfg.mem_slab, &stream->mem_block);
+		k_mem_slab_free(stream->cfg.mem_slab, stream->mem_block);
 		stream->mem_block = NULL;
 	}
 }
@@ -748,7 +748,7 @@ static void tx_stream_disable(struct stream *stream, Ssc *const ssc,
 	ssc->SSC_IDR = SSC_IDR_TXEMPTY;
 	dma_stop(dev_dma, stream->dma_channel);
 	if (stream->mem_block != NULL) {
-		k_mem_slab_free(stream->cfg.mem_slab, &stream->mem_block);
+		k_mem_slab_free(stream->cfg.mem_slab, stream->mem_block);
 		stream->mem_block = NULL;
 	}
 }
@@ -759,7 +759,7 @@ static void rx_queue_drop(struct stream *stream)
 	void *mem_block;
 
 	while (queue_get(&stream->mem_block_queue, &mem_block, &size) == 0) {
-		k_mem_slab_free(stream->cfg.mem_slab, &mem_block);
+		k_mem_slab_free(stream->cfg.mem_slab, mem_block);
 	}
 
 	k_sem_reset(&stream->sem);
@@ -772,7 +772,7 @@ static void tx_queue_drop(struct stream *stream)
 	unsigned int n = 0U;
 
 	while (queue_get(&stream->mem_block_queue, &mem_block, &size) == 0) {
-		k_mem_slab_free(stream->cfg.mem_slab, &mem_block);
+		k_mem_slab_free(stream->cfg.mem_slab, mem_block);
 		n++;
 	}
 

--- a/drivers/led_strip/ws2812_i2s.c
+++ b/drivers/led_strip/ws2812_i2s.c
@@ -139,7 +139,7 @@ static int ws2812_strip_update_rgb(const struct device *dev, struct led_rgb *pix
 	/* Flush the buffer on the wire. */
 	ret = i2s_write(cfg->dev, mem_block, cfg->tx_buf_bytes);
 	if (ret < 0) {
-		k_mem_slab_free(cfg->mem_slab, &mem_block);
+		k_mem_slab_free(cfg->mem_slab, mem_block);
 		LOG_ERR("Failed to write data: %d", ret);
 		return ret;
 	}

--- a/drivers/modem/modem_iface_uart_async.c
+++ b/drivers/modem/modem_iface_uart_async.c
@@ -48,7 +48,7 @@ static void iface_uart_async_callback(const struct device *dev,
 		break;
 	case UART_RX_BUF_RELEASED:
 		/* UART driver is done with memory, free it */
-		k_mem_slab_free(&uart_modem_async_rx_slab, (void **)&evt->data.rx_buf.buf);
+		k_mem_slab_free(&uart_modem_async_rx_slab, (void *)evt->data.rx_buf.buf);
 		break;
 	case UART_RX_RDY:
 		/* Place received data on the ring buffer */

--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -392,7 +392,7 @@ static int intel_gna_deregister_model(const struct device *dev,
 
 	gna_model = (struct intel_gna_model *)model_handle;
 	gna_model->registered = false;
-	k_mem_slab_free(&gna->model_slab, &model_handle);
+	k_mem_slab_free(&gna->model_slab, model_handle);
 
 	return 0;
 }

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -387,7 +387,7 @@ static inline void usbd_work_schedule(void)
  */
 static inline void usbd_evt_free(struct usbd_event *ev)
 {
-	k_mem_slab_free(&fifo_elem_slab, (void **)&ev->block.data);
+	k_mem_slab_free(&fifo_elem_slab, (void *)ev->block.data);
 }
 
 /**

--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -506,7 +506,7 @@ static void xfer_work_handler(struct k_work *item)
 		}
 
 xfer_work_error:
-		k_mem_slab_free(&usbfsotg_ee_slab, (void **)&ev);
+		k_mem_slab_free(&usbfsotg_ee_slab, (void *)ev);
 	}
 }
 

--- a/drivers/usb/udc/udc_virtual.c
+++ b/drivers/usb/udc/udc_virtual.c
@@ -332,7 +332,7 @@ static ALWAYS_INLINE void udc_vrt_thread_handler(void *arg)
 			udc_submit_event(dev, UDC_EVT_ERROR, err);
 		}
 
-		k_mem_slab_free(&udc_vrt_slab, (void **)&vrt_ev);
+		k_mem_slab_free(&udc_vrt_slab, (void *)vrt_ev);
 	}
 }
 

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -139,7 +139,7 @@ int uhc_xfer_free(const struct device *dev, struct uhc_transfer *const xfer)
 		uhc_xfer_buf_free(dev, buf);
 	}
 
-	k_mem_slab_free(&uhc_xfer_pool, (void **)&xfer);
+	k_mem_slab_free(&uhc_xfer_pool, (void *)xfer);
 
 xfer_free_error:
 	api->unlock(dev);

--- a/drivers/usb/uhc/uhc_virtual.c
+++ b/drivers/usb/uhc/uhc_virtual.c
@@ -378,7 +378,7 @@ static void xfer_work_handler(struct k_work *work)
 			}
 		}
 
-		k_mem_slab_free(&uhc_vrt_slab, (void **)&ev);
+		k_mem_slab_free(&uhc_vrt_slab, (void *)ev);
 	}
 }
 

--- a/drivers/usb/uvb/uvb.c
+++ b/drivers/usb/uvb/uvb.c
@@ -72,7 +72,7 @@ struct uvb_packet *uvb_alloc_pkt(const enum uvb_request request,
 
 void uvb_free_pkt(struct uvb_packet *const pkt)
 {
-	k_mem_slab_free(&uvb_pkt_slab, (void **)&pkt);
+	k_mem_slab_free(&uvb_pkt_slab, (void *)pkt);
 }
 
 static ALWAYS_INLINE int submit_new_work(struct uvb_msg *const msg)
@@ -311,7 +311,7 @@ static void uvb_work_handler(struct k_work *work)
 		break;
 	}
 
-	k_mem_slab_free(&uvb_msg_slab, (void **)&msg);
+	k_mem_slab_free(&uvb_msg_slab, (void *)msg);
 	if (!k_fifo_is_empty(&uvb_queue)) {
 		(void)k_work_submit(work);
 	}

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5151,9 +5151,9 @@ extern int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem,
  * associated memory slab.
  *
  * @param slab Address of the memory slab.
- * @param mem Pointer to block address area (as set by k_mem_slab_alloc()).
+ * @param mem Pointer to the memory block (as returned by k_mem_slab_alloc()).
  */
-extern void k_mem_slab_free(struct k_mem_slab *slab, void **mem);
+extern void k_mem_slab_free(struct k_mem_slab *slab, void *mem);
 
 /**
  * @brief Get the number of used blocks in a memory slab.

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -149,6 +149,11 @@ void k_mem_slab_free(struct k_mem_slab *slab, void *mem)
 {
 	k_spinlock_key_t key = k_spin_lock(&slab->lock);
 
+	__ASSERT(((char *)mem >= slab->buffer) &&
+		 ((((char *)mem - slab->buffer) % slab->block_size) == 0) &&
+		 ((char *)mem <= (slab->buffer + (slab->block_size * (slab->num_blocks - 1)))),
+		 "Invalid memory pointer provided");
+
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_mem_slab, free, slab);
 	if (slab->free_list == NULL && IS_ENABLED(CONFIG_MULTITHREADING)) {
 		struct k_thread *pending_thread = z_unpend_first_thread(&slab->wait_q);

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -145,7 +145,7 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, k_timeout_t timeout)
 	return result;
 }
 
-void k_mem_slab_free(struct k_mem_slab *slab, void **mem)
+void k_mem_slab_free(struct k_mem_slab *slab, void *mem)
 {
 	k_spinlock_key_t key = k_spin_lock(&slab->lock);
 
@@ -156,14 +156,14 @@ void k_mem_slab_free(struct k_mem_slab *slab, void **mem)
 		if (pending_thread != NULL) {
 			SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mem_slab, free, slab);
 
-			z_thread_return_value_set_with_data(pending_thread, 0, *mem);
+			z_thread_return_value_set_with_data(pending_thread, 0, mem);
 			z_ready_thread(pending_thread);
 			z_reschedule(&slab->lock, key);
 			return;
 		}
 	}
-	**(char ***) mem = slab->free_list;
-	slab->free_list = *(char **) mem;
+	*(char **) mem = slab->free_list;
+	slab->free_list = (char *) mem;
 	slab->num_used--;
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mem_slab, free, slab);

--- a/lib/libc/arcmwdt/threading.c
+++ b/lib/libc/arcmwdt/threading.c
@@ -46,7 +46,7 @@ void _mwmutex_delete(_lock_t *mutex_ptr)
 #ifdef CONFIG_USERSPACE
 	k_object_release(mutex_ptr);
 #else
-	k_mem_slab_free(&z_arcmwdt_lock_slab, mutex_ptr);
+	k_mem_slab_free(&z_arcmwdt_lock_slab, *mutex_ptr);
 #endif /* CONFIG_USERSPACE */
 }
 

--- a/lib/posix/timer.c
+++ b/lib/posix/timer.c
@@ -222,7 +222,7 @@ int timer_delete(timer_t timerid)
 		k_timer_stop(&timer->ztimer);
 	}
 
-	k_mem_slab_free(&posix_timer_slab, (void *) &timer);
+	k_mem_slab_free(&posix_timer_slab, (void *)timer);
 
 	return 0;
 }

--- a/samples/boards/litex/i2s/src/main.c
+++ b/samples/boards/litex/i2s/src/main.c
@@ -110,7 +110,7 @@ int main(void)
 		i2s_read(host_i2s_rx_dev, &rx_mem_block, &size);
 		memcpy(tx_mem_block, rx_mem_block, size);
 		i2s_write(host_i2s_tx_dev, tx_mem_block, size);
-		k_mem_slab_free(&i2s_rx_mem_slab, &rx_mem_block);
+		k_mem_slab_free(&i2s_rx_mem_slab, rx_mem_block);
 	}
 	return 0;
 }

--- a/samples/drivers/audio/dmic/src/main.c
+++ b/samples/drivers/audio/dmic/src/main.c
@@ -61,7 +61,7 @@ static int do_pdm_transfer(const struct device *dmic_dev,
 
 		LOG_INF("%d - got buffer %p of %u bytes", i, buffer, size);
 
-		k_mem_slab_free(&mem_slab, &buffer);
+		k_mem_slab_free(&mem_slab, buffer);
 	}
 
 	ret = dmic_trigger(dmic_dev, DMIC_TRIGGER_STOP);

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3052,7 +3052,7 @@ static void att_reset(struct bt_att *att)
 	 * and `bt_conn_unref` to follow convention.
 	 */
 	att->conn = NULL;
-	k_mem_slab_free(&att_slab, (void **)&att);
+	k_mem_slab_free(&att_slab, (void *)att);
 }
 
 static void att_chan_detach(struct bt_att_chan *chan)
@@ -3288,7 +3288,7 @@ static void bt_att_released(struct bt_l2cap_chan *ch)
 
 	LOG_DBG("chan %p", chan);
 
-	k_mem_slab_free(&chan_slab, (void **)&chan);
+	k_mem_slab_free(&chan_slab, (void *)chan);
 }
 
 #if defined(CONFIG_BT_EATT)
@@ -3862,7 +3862,7 @@ void bt_att_req_free(struct bt_att_req *req)
 		req->buf = NULL;
 	}
 
-	k_mem_slab_free(&req_slab, (void **)&req);
+	k_mem_slab_free(&req_slab, (void *)req);
 }
 
 int bt_att_send(struct bt_conn *conn, struct net_buf *buf)

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -427,7 +427,7 @@ static void bt_mesh_net_local(struct k_work *work)
 
 		net_buf_simple_init_with_data(&sbuf, buf->data, buf->len);
 		(void)bt_mesh_trans_recv(&sbuf, &rx);
-		k_mem_slab_free(&loopback_buf_pool, (void **)&buf);
+		k_mem_slab_free(&loopback_buf_pool, (void *)buf);
 	}
 }
 
@@ -609,7 +609,7 @@ void bt_mesh_net_loopback_clear(uint16_t net_idx)
 
 		if (net_idx == BT_MESH_KEY_ANY || net_idx == buf->sub->net_idx) {
 			LOG_DBG("Dropped 0x%06x", SEQ(buf->data));
-			k_mem_slab_free(&loopback_buf_pool, (void **)&buf);
+			k_mem_slab_free(&loopback_buf_pool, (void *)buf);
 		} else {
 			sys_slist_append(&new_list, &buf->node);
 		}

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -197,7 +197,7 @@ bool bt_mesh_tx_in_progress(void)
 
 static void seg_tx_done(struct seg_tx *tx, uint8_t seg_idx)
 {
-	k_mem_slab_free(&segs, (void **)&tx->seg[seg_idx]);
+	k_mem_slab_free(&segs, (void *)tx->seg[seg_idx]);
 	tx->seg[seg_idx] = NULL;
 	tx->nack_count--;
 }
@@ -590,7 +590,7 @@ static int send_seg(struct bt_mesh_net_tx *net_tx, struct net_buf_simple *sdu,
 				/* PDUs for a specific Friend should only go
 				 * out through the Friend Queue.
 				 */
-				k_mem_slab_free(&segs, &buf);
+				k_mem_slab_free(&segs, buf);
 				tx->seg[seg_o] = NULL;
 			}
 
@@ -1161,7 +1161,7 @@ static void seg_rx_reset(struct seg_rx *rx, bool full_reset)
 			continue;
 		}
 
-		k_mem_slab_free(&segs, &rx->seg[i]);
+		k_mem_slab_free(&segs, rx->seg[i]);
 		rx->seg[i] = NULL;
 	}
 

--- a/subsys/bluetooth/mesh/transport_legacy.c
+++ b/subsys/bluetooth/mesh/transport_legacy.c
@@ -204,7 +204,7 @@ bool bt_mesh_tx_in_progress(void)
 
 static void seg_tx_done(struct seg_tx *tx, uint8_t seg_idx)
 {
-	k_mem_slab_free(&segs, (void **)&tx->seg[seg_idx]);
+	k_mem_slab_free(&segs, (void *)tx->seg[seg_idx]);
 	tx->seg[seg_idx] = NULL;
 	tx->nack_count--;
 }
@@ -550,7 +550,7 @@ static int send_seg(struct bt_mesh_net_tx *net_tx, struct net_buf_simple *sdu,
 				/* PDUs for a specific Friend should only go
 				 * out through the Friend Queue.
 				 */
-				k_mem_slab_free(&segs, &buf);
+				k_mem_slab_free(&segs, buf);
 				tx->seg[seg_o] = NULL;
 			}
 
@@ -1116,7 +1116,7 @@ static void seg_rx_reset(struct seg_rx *rx, bool full_reset)
 			continue;
 		}
 
-		k_mem_slab_free(&segs, &rx->seg[i]);
+		k_mem_slab_free(&segs, rx->seg[i]);
 		rx->seg[i] = NULL;
 	}
 

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -988,7 +988,7 @@ static inline void free_send_ctx(struct isotp_send_ctx **ctx)
 	}
 
 	if ((*ctx)->is_ctx_slab) {
-		k_mem_slab_free(&ctx_slab, (void **)ctx);
+		k_mem_slab_free(&ctx_slab, (void *)*ctx);
 	}
 }
 
@@ -1280,7 +1280,7 @@ int isotp_send_buf(const struct device *can_dev,
 
 	buf = net_buf_alloc_len(&isotp_tx_pool, len, timeout);
 	if (!buf) {
-		k_mem_slab_free(&ctx_slab, (void **)&ctx);
+		k_mem_slab_free(&ctx_slab, (void *)ctx);
 		return ISOTP_NO_BUF_DATA_LEFT;
 	}
 

--- a/subsys/demand_paging/backing_store/ram.c
+++ b/subsys/demand_paging/backing_store/ram.c
@@ -105,7 +105,7 @@ void k_mem_paging_backing_store_location_free(uintptr_t location)
 {
 	void *slab = location_to_slab(location);
 
-	k_mem_slab_free(&backing_slabs, &slab);
+	k_mem_slab_free(&backing_slabs, slab);
 	free_slabs++;
 }
 

--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -80,7 +80,7 @@ static struct ext2_block *get_block_struct(void)
 	ret = k_mem_slab_alloc(&ext2_block_memory_slab, (void **)&b->data, K_NO_WAIT);
 	if (ret < 0) {
 		LOG_ERR("get block: alloc block memory error %d", ret);
-		k_mem_slab_free(&ext2_block_struct_slab, (void **)&b);
+		k_mem_slab_free(&ext2_block_struct_slab, (void *)b);
 		return NULL;
 	}
 	return b;
@@ -140,8 +140,8 @@ void ext2_drop_block(struct ext2_block *b)
 	}
 
 	if (b != NULL && b->data != NULL) {
-		k_mem_slab_free(&ext2_block_memory_slab, (void **)&b->data);
-		k_mem_slab_free(&ext2_block_struct_slab, (void **)&b);
+		k_mem_slab_free(&ext2_block_memory_slab, (void *)b->data);
+		k_mem_slab_free(&ext2_block_struct_slab, (void *)b);
 	}
 }
 
@@ -1466,7 +1466,7 @@ int ext2_inode_get(struct ext2_data *fs, uint32_t ino, struct ext2_inode **ret)
 		int rc2 = ext2_fetch_inode(fs, ino, inode);
 
 		if (rc2 < 0) {
-			k_mem_slab_free(&inode_struct_slab, (void **)&inode);
+			k_mem_slab_free(&inode_struct_slab, (void *)inode);
 			return rc2;
 		}
 	}
@@ -1523,7 +1523,7 @@ int ext2_inode_drop(struct ext2_inode *inode)
 			}
 		}
 
-		k_mem_slab_free(&inode_struct_slab, (void **)&inode);
+		k_mem_slab_free(&inode_struct_slab, (void *)inode);
 
 		/* copy last open in place of freed inode */
 		uint32_t last = fs->open_inodes - 1;

--- a/subsys/fs/ext2/ext2_ops.c
+++ b/subsys/fs/ext2/ext2_ops.c
@@ -126,7 +126,7 @@ static int ext2_close(struct fs_file_t *filp)
 		goto out;
 	}
 
-	k_mem_slab_free(&file_struct_slab, (void **)&f);
+	k_mem_slab_free(&file_struct_slab, (void *)f);
 	filp->filep = NULL;
 out:
 	return rc;
@@ -349,7 +349,7 @@ static int ext2_closedir(struct fs_dir_t *dirp)
 	struct ext2_file *dir = dirp->dirp;
 
 	ext2_inode_drop(dir->f_inode);
-	k_mem_slab_free(&file_struct_slab, (void **)&dir);
+	k_mem_slab_free(&file_struct_slab, (void *)dir);
 	return 0;
 }
 

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -111,7 +111,7 @@ static int fatfs_open(struct fs_file_t *zfp, const char *file_name,
 	res = f_open(zfp->filep, translate_path(file_name), fs_mode);
 
 	if (res != FR_OK) {
-		k_mem_slab_free(&fatfs_filep_pool, &ptr);
+		k_mem_slab_free(&fatfs_filep_pool, ptr);
 		zfp->filep = NULL;
 	}
 
@@ -125,7 +125,7 @@ static int fatfs_close(struct fs_file_t *zfp)
 	res = f_close(zfp->filep);
 
 	/* Free file ptr memory */
-	k_mem_slab_free(&fatfs_filep_pool, &zfp->filep);
+	k_mem_slab_free(&fatfs_filep_pool, zfp->filep);
 	zfp->filep = NULL;
 
 	return translate_error(res);
@@ -334,7 +334,7 @@ static int fatfs_opendir(struct fs_dir_t *zdp, const char *path)
 	res = f_opendir(zdp->dirp, translate_path(path));
 
 	if (res != FR_OK) {
-		k_mem_slab_free(&fatfs_dirp_pool, &ptr);
+		k_mem_slab_free(&fatfs_dirp_pool, ptr);
 		zdp->dirp = NULL;
 	}
 
@@ -366,7 +366,7 @@ static int fatfs_closedir(struct fs_dir_t *zdp)
 	res = f_closedir(zdp->dirp);
 
 	/* Free file ptr memory */
-	k_mem_slab_free(&fatfs_dirp_pool, &zdp->dirp);
+	k_mem_slab_free(&fatfs_dirp_pool, zdp->dirp);
 
 	return translate_error(res);
 }

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -264,7 +264,7 @@ static void release_file_data(struct fs_file_t *fp)
 		fc_release(fdp->cache_block);
 	}
 
-	k_mem_slab_free(&file_data_pool, &fp->filep);
+	k_mem_slab_free(&file_data_pool, fp->filep);
 	fp->filep = NULL;
 }
 
@@ -480,7 +480,7 @@ static int littlefs_opendir(struct fs_dir_t *dp, const char *path)
 	fs_unlock(fs);
 
 	if (ret < 0) {
-		k_mem_slab_free(&lfs_dir_pool, &dp->dirp);
+		k_mem_slab_free(&lfs_dir_pool, dp->dirp);
 	}
 
 	return lfs_to_errno(ret);
@@ -526,7 +526,7 @@ static int littlefs_closedir(struct fs_dir_t *dp)
 
 	fs_unlock(fs);
 
-	k_mem_slab_free(&lfs_dir_pool, &dp->dirp);
+	k_mem_slab_free(&lfs_dir_pool, dp->dirp);
 
 	return lfs_to_errno(ret);
 }

--- a/subsys/mgmt/mcumgr/transport/src/smp_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_dummy.c
@@ -226,7 +226,7 @@ static void dummy_mcumgr_free_rx_buf(struct uart_mcumgr_rx_buf *rx_buf)
 	void *block;
 
 	block = rx_buf;
-	k_mem_slab_free(&dummy_mcumgr_slab, &block);
+	k_mem_slab_free(&dummy_mcumgr_slab, block);
 }
 
 /**

--- a/subsys/mgmt/osdp/src/osdp_cp.c
+++ b/subsys/mgmt/osdp/src/osdp_cp.c
@@ -72,7 +72,7 @@ static struct osdp_cmd *cp_cmd_alloc(struct osdp_pd *pd)
 
 static void cp_cmd_free(struct osdp_pd *pd, struct osdp_cmd *cmd)
 {
-	k_mem_slab_free(&pd->cmd.slab, (void **)&cmd);
+	k_mem_slab_free(&pd->cmd.slab, (void *)cmd);
 }
 
 static void cp_cmd_enqueue(struct osdp_pd *pd, struct osdp_cmd *cmd)

--- a/subsys/mgmt/osdp/src/osdp_pd.c
+++ b/subsys/mgmt/osdp/src/osdp_pd.c
@@ -127,7 +127,7 @@ static struct osdp_event *pd_event_alloc(struct osdp_pd *pd)
 
 static void pd_event_free(struct osdp_pd *pd, struct osdp_event *event)
 {
-	k_mem_slab_free(&pd->event.slab, (void **)&event);
+	k_mem_slab_free(&pd->event.slab, (void *)event);
 }
 
 static void pd_event_enqueue(struct osdp_pd *pd, struct osdp_event *event)

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -602,7 +602,7 @@ done:
 		net_pkt_cursor_init(pkt);
 	}
 
-	k_mem_slab_free(pkt->slab, (void **)&pkt);
+	k_mem_slab_free(pkt->slab, (void *)pkt);
 }
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -585,7 +585,7 @@ static int tcp_conn_unref(struct tcp *conn)
 
 	memset(conn, 0, sizeof(*conn));
 
-	k_mem_slab_free(&tcp_conns_slab, (void **)&conn);
+	k_mem_slab_free(&tcp_conns_slab, (void *)conn);
 
 	k_mutex_unlock(&tcp_lock);
 
@@ -1656,7 +1656,7 @@ fail:
 		conn->queue_recv_data = NULL;
 	}
 
-	k_mem_slab_free(&tcp_conns_slab, (void **)&conn);
+	k_mem_slab_free(&tcp_conns_slab, (void *)conn);
 	return NULL;
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -265,7 +265,7 @@ static inline int request_body_encode_buffer(uint8_t **buffer)
 static inline void release_body_encode_buffer(uint8_t **buffer)
 {
 	if (buffer && *buffer) {
-		k_mem_slab_free(&body_encode_buffer_slab, (void **)buffer);
+		k_mem_slab_free(&body_encode_buffer_slab, (void *)*buffer);
 		log_buffer_usage();
 	}
 }

--- a/subsys/net/lib/sockets/socketpair.c
+++ b/subsys/net/lib/sockets/socketpair.c
@@ -194,7 +194,7 @@ static void spair_delete(struct spair *spair)
 	/* ensure no private information is released to the memory pool */
 	memset(spair, 0, sizeof(*spair));
 #ifdef CONFIG_NET_SOCKETPAIR_STATIC
-	k_mem_slab_free(&spair_slab, (void **) &spair);
+	k_mem_slab_free(&spair_slab, (void *)spair);
 #elif CONFIG_USERSPACE
 	k_object_free(spair);
 #else

--- a/subsys/portability/cmsis_rtos_v1/cmsis_mailq.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_mailq.c
@@ -170,7 +170,7 @@ osStatus osMailFree(osMailQId queue_id, void *mail)
 {
 	osMailQDef_t *queue_def = (osMailQDef_t *)queue_id;
 
-	k_mem_slab_free((struct k_mem_slab *)(queue_def->pool), (void *) &mail);
+	k_mem_slab_free((struct k_mem_slab *)(queue_def->pool), (void *)mail);
 
 	return osOK;
 }

--- a/subsys/portability/cmsis_rtos_v1/cmsis_mempool.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_mempool.c
@@ -68,7 +68,7 @@ osStatus osPoolFree(osPoolId pool_id, void *block)
 	 *                         permitted range.
 	 */
 
-	k_mem_slab_free((struct k_mem_slab *)(osPool->pool), (void *)&block);
+	k_mem_slab_free((struct k_mem_slab *)(osPool->pool), (void *)block);
 
 	return osOK;
 }

--- a/subsys/portability/cmsis_rtos_v1/cmsis_mutex.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_mutex.c
@@ -111,7 +111,7 @@ osStatus osMutexDelete(osMutexId mutex_id)
 	 * not be deleted) is not supported in Zephyr.
 	 */
 
-	k_mem_slab_free(&cmsis_mutex_slab, (void *) &mutex);
+	k_mem_slab_free(&cmsis_mutex_slab, (void *)mutex);
 
 	return osOK;
 }

--- a/subsys/portability/cmsis_rtos_v1/cmsis_semaphore.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_semaphore.c
@@ -116,7 +116,7 @@ osStatus osSemaphoreDelete(osSemaphoreId semaphore_id)
 	 * could not be deleted) is not supported in Zephyr.
 	 */
 
-	k_mem_slab_free(&cmsis_semaphore_slab, (void *) &semaphore);
+	k_mem_slab_free(&cmsis_semaphore_slab, (void *)semaphore);
 
 	return osOK;
 }

--- a/subsys/portability/cmsis_rtos_v1/cmsis_timer.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_timer.c
@@ -134,6 +134,6 @@ osStatus osTimerDelete(osTimerId timer_id)
 		timer->status = NOT_ACTIVE;
 	}
 
-	k_mem_slab_free(&cmsis_timer_slab, (void *) &timer);
+	k_mem_slab_free(&cmsis_timer_slab, (void *)timer);
 	return osOK;
 }

--- a/subsys/portability/cmsis_rtos_v2/event_flags.c
+++ b/subsys/portability/cmsis_rtos_v2/event_flags.c
@@ -252,7 +252,7 @@ osStatus_t osEventFlagsDelete(osEventFlagsId_t ef_id)
 	 * ef_id is incorrect) is not supported in Zephyr.
 	 */
 
-	k_mem_slab_free(&cv2_event_flags_slab, (void *)&events);
+	k_mem_slab_free(&cv2_event_flags_slab, (void *)events);
 
 	return osOK;
 }

--- a/subsys/portability/cmsis_rtos_v2/mempool.c
+++ b/subsys/portability/cmsis_rtos_v2/mempool.c
@@ -59,7 +59,7 @@ osMemoryPoolId_t osMemoryPoolNew(uint32_t block_count, uint32_t block_size,
 
 		mslab->pool = k_calloc(block_count, block_size);
 		if (mslab->pool == NULL) {
-			k_mem_slab_free(&cv2_mem_slab, (void *) &mslab);
+			k_mem_slab_free(&cv2_mem_slab, (void *)mslab);
 			return NULL;
 		}
 		mslab->is_dynamic_allocation = TRUE;
@@ -71,7 +71,7 @@ osMemoryPoolId_t osMemoryPoolNew(uint32_t block_count, uint32_t block_size,
 	int rc = k_mem_slab_init(&mslab->z_mslab, mslab->pool, block_size, block_count);
 
 	if (rc != 0) {
-		k_mem_slab_free(&cv2_mem_slab, (void *) &mslab);
+		k_mem_slab_free(&cv2_mem_slab, (void *)mslab);
 		if (attr->mp_mem == NULL) {
 			k_free(mslab->pool);
 		}
@@ -143,7 +143,7 @@ osStatus_t osMemoryPoolFree(osMemoryPoolId_t mp_id, void *block)
 	 *       is in an invalid memory pool state.
 	 */
 
-	k_mem_slab_free((struct k_mem_slab *)(&mslab->z_mslab), (void *)&block);
+	k_mem_slab_free((struct k_mem_slab *)(&mslab->z_mslab), (void *)block);
 
 	return osOK;
 }
@@ -241,7 +241,7 @@ osStatus_t osMemoryPoolDelete(osMemoryPoolId_t mp_id)
 	if (mslab->is_dynamic_allocation) {
 		k_free(mslab->pool);
 	}
-	k_mem_slab_free(&cv2_mem_slab, (void *)&mslab);
+	k_mem_slab_free(&cv2_mem_slab, (void *)mslab);
 
 	return osOK;
 }

--- a/subsys/portability/cmsis_rtos_v2/msgq.c
+++ b/subsys/portability/cmsis_rtos_v2/msgq.c
@@ -57,7 +57,7 @@ osMessageQueueId_t osMessageQueueNew(uint32_t msg_count, uint32_t msg_size,
 
 		msgq->pool = k_calloc(msg_count, msg_size);
 		if (msgq->pool == NULL) {
-			k_mem_slab_free(&cv2_msgq_slab, (void *) &msgq);
+			k_mem_slab_free(&cv2_msgq_slab, (void *)msgq);
 			return NULL;
 		}
 		msgq->is_dynamic_allocation = TRUE;
@@ -274,7 +274,7 @@ osStatus_t osMessageQueueDelete(osMessageQueueId_t msgq_id)
 	if (msgq->is_dynamic_allocation) {
 		k_free(msgq->pool);
 	}
-	k_mem_slab_free(&cv2_msgq_slab, (void *)&msgq);
+	k_mem_slab_free(&cv2_msgq_slab, (void *)msgq);
 
 	return osOK;
 }

--- a/subsys/portability/cmsis_rtos_v2/mutex.c
+++ b/subsys/portability/cmsis_rtos_v2/mutex.c
@@ -133,7 +133,7 @@ osStatus_t osMutexDelete(osMutexId_t mutex_id)
 	 * mutex_id is in an invalid mutex state) is not supported in Zephyr.
 	 */
 
-	k_mem_slab_free(&cv2_mutex_slab, (void *) &mutex);
+	k_mem_slab_free(&cv2_mutex_slab, (void *)mutex);
 
 	return osOK;
 }

--- a/subsys/portability/cmsis_rtos_v2/semaphore.c
+++ b/subsys/portability/cmsis_rtos_v2/semaphore.c
@@ -142,7 +142,7 @@ osStatus_t osSemaphoreDelete(osSemaphoreId_t semaphore_id)
 	 * supported in Zephyr.
 	 */
 
-	k_mem_slab_free(&cv2_semaphore_slab, (void *) &semaphore);
+	k_mem_slab_free(&cv2_semaphore_slab, (void *)semaphore);
 
 	return osOK;
 }

--- a/subsys/portability/cmsis_rtos_v2/timer.c
+++ b/subsys/portability/cmsis_rtos_v2/timer.c
@@ -144,7 +144,7 @@ osStatus_t osTimerDelete(osTimerId_t timer_id)
 		timer->status = NOT_ACTIVE;
 	}
 
-	k_mem_slab_free(&cv2_timer_slab, (void *) &timer);
+	k_mem_slab_free(&cv2_timer_slab, (void *)timer);
 	return osOK;
 }
 

--- a/subsys/tracing/test/tracing_string_format_test.c
+++ b/subsys/tracing/test/tracing_string_format_test.c
@@ -474,12 +474,12 @@ void sys_trace_k_mem_slab_alloc_exit(struct k_mem_slab *slab, void **mem, k_time
 	TRACING_STRING("%s: %p\n", __func__, slab);
 }
 
-void sys_trace_k_mem_slab_free_enter(struct k_mem_slab *slab, void **mem)
+void sys_trace_k_mem_slab_free_enter(struct k_mem_slab *slab, void *mem)
 {
 	TRACING_STRING("%s: %p\n", __func__, slab);
 }
 
-void sys_trace_k_mem_slab_free_exit(struct k_mem_slab *slab, void **mem)
+void sys_trace_k_mem_slab_free_exit(struct k_mem_slab *slab, void *mem)
 {
 	TRACING_STRING("%s: %p\n", __func__, slab);
 }

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -678,7 +678,7 @@ void sys_trace_k_mem_slab_alloc_enter(struct k_mem_slab *slab, void **mem, k_tim
 void sys_trace_k_mem_slab_alloc_blocking(struct k_mem_slab *slab, void **mem, k_timeout_t timeout);
 void sys_trace_k_mem_slab_alloc_exit(struct k_mem_slab *slab, void **mem, k_timeout_t timeout,
 				     int ret);
-void sys_trace_k_mem_slab_free_exit(struct k_mem_slab *slab, void **mem);
+void sys_trace_k_mem_slab_free_exit(struct k_mem_slab *slab, void *mem);
 
 void sys_trace_k_timer_init(struct k_timer *timer, k_timer_expiry_t expiry_fn,
 			    k_timer_expiry_t stop_fn);

--- a/tests/benchmarks/app_kernel/src/memmap_b.c
+++ b/tests/benchmarks/app_kernel/src/memmap_b.c
@@ -33,7 +33,7 @@ void memorymap_test(void)
 				"Error: Slab allocation failed.", alloc_status);
 			break;
 		}
-		k_mem_slab_free(&MAP1, &p);
+		k_mem_slab_free(&MAP1, p);
 	}
 	et = TIME_STAMP_DELTA_GET(et);
 	check_result();

--- a/tests/benchmarks/sys_kernel/src/mem_slab.c
+++ b/tests/benchmarks/sys_kernel/src/mem_slab.c
@@ -60,7 +60,7 @@ static int mem_slab_free_test(int no_of_loops)
 	int i;
 
 	for (i = 0; i < no_of_loops; i++) {
-		k_mem_slab_free(&my_slab, &slab_array[i]);
+		k_mem_slab_free(&my_slab, slab_array[i]);
 	}
 
 	return i;

--- a/tests/bluetooth/audio/mocks/src/mem_slab.c
+++ b/tests/bluetooth/audio/mocks/src/mem_slab.c
@@ -21,8 +21,8 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, k_timeout_t timeout)
 	return 0;
 }
 
-void k_mem_slab_free(struct k_mem_slab *slab, void **mem)
+void k_mem_slab_free(struct k_mem_slab *slab, void *mem)
 {
-	free(*mem);
+	free(mem);
 	slab->num_used--;
 }

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -337,7 +337,7 @@ int bt_mesh_test_recv(uint16_t len, uint16_t dst, const uint8_t *uuid, k_timeout
 		return -EINVAL;
 	}
 
-	k_mem_slab_free(&msg_pool, (void **)&msg);
+	k_mem_slab_free(&msg_pool, (void *)msg);
 
 	return 0;
 }
@@ -352,7 +352,7 @@ int bt_mesh_test_recv_msg(struct bt_mesh_test_msg *msg, k_timeout_t timeout)
 
 	*msg = *queued;
 
-	k_mem_slab_free(&msg_pool, (void **)&queued);
+	k_mem_slab_free(&msg_pool, (void *)queued);
 
 	return 0;
 }
@@ -363,7 +363,7 @@ int bt_mesh_test_recv_clear(void)
 	int count = 0;
 
 	while ((queued = k_queue_get(&recv, K_NO_WAIT))) {
-		k_mem_slab_free(&msg_pool, (void **)&queued);
+		k_mem_slab_free(&msg_pool, (void *)queued);
 		count++;
 	}
 

--- a/tests/drivers/i2s/i2s_speed/src/test_i2s_speed.c
+++ b/tests/drivers/i2s/i2s_speed/src/test_i2s_speed.c
@@ -244,17 +244,17 @@ ZTEST(drivers_i2s_speed, test_i2s_transfer_short)
 	/* Verify received data */
 	ret = verify_buf((uint16_t *)rx_block[0], 0);
 	zassert_equal(ret, 0);
-	k_mem_slab_free(&rx_0_mem_slab, &rx_block[0]);
+	k_mem_slab_free(&rx_0_mem_slab, rx_block[0]);
 	TC_PRINT("%d<-OK\n", 1);
 
 	ret = verify_buf((uint16_t *)rx_block[1], 1);
 	zassert_equal(ret, 0);
-	k_mem_slab_free(&rx_0_mem_slab, &rx_block[1]);
+	k_mem_slab_free(&rx_0_mem_slab, rx_block[1]);
 	TC_PRINT("%d<-OK\n", 2);
 
 	ret = verify_buf((uint16_t *)rx_block[2], 2);
 	zassert_equal(ret, 0);
-	k_mem_slab_free(&rx_0_mem_slab, &rx_block[2]);
+	k_mem_slab_free(&rx_0_mem_slab, rx_block[2]);
 	TC_PRINT("%d<-OK\n", 3);
 }
 
@@ -344,7 +344,7 @@ ZTEST(drivers_i2s_speed, test_i2s_transfer_long)
 		} else {
 			num_verified++;
 		}
-		k_mem_slab_free(&rx_0_mem_slab, &rx_block[rx_idx]);
+		k_mem_slab_free(&rx_0_mem_slab, rx_block[rx_idx]);
 	}
 	zassert_equal(num_verified, NUM_BLOCKS, "Invalid RX blocks received");
 }
@@ -403,17 +403,17 @@ ZTEST(drivers_i2s_speed_both_rxtx, test_i2s_dir_both_transfer_short)
 	/* Verify received data */
 	ret = verify_buf((uint16_t *)rx_block[0], 0);
 	zassert_equal(ret, 0);
-	k_mem_slab_free(&rx_0_mem_slab, &rx_block[0]);
+	k_mem_slab_free(&rx_0_mem_slab, rx_block[0]);
 	TC_PRINT("%d<-OK\n", 1);
 
 	ret = verify_buf((uint16_t *)rx_block[1], 1);
 	zassert_equal(ret, 0);
-	k_mem_slab_free(&rx_0_mem_slab, &rx_block[1]);
+	k_mem_slab_free(&rx_0_mem_slab, rx_block[1]);
 	TC_PRINT("%d<-OK\n", 2);
 
 	ret = verify_buf((uint16_t *)rx_block[2], 2);
 	zassert_equal(ret, 0);
-	k_mem_slab_free(&rx_0_mem_slab, &rx_block[2]);
+	k_mem_slab_free(&rx_0_mem_slab, rx_block[2]);
 	TC_PRINT("%d<-OK\n", 3);
 }
 
@@ -492,7 +492,7 @@ ZTEST(drivers_i2s_speed_both_rxtx, test_i2s_dir_both_transfer_long)
 		} else {
 			num_verified++;
 		}
-		k_mem_slab_free(&rx_0_mem_slab, &rx_block[rx_idx]);
+		k_mem_slab_free(&rx_0_mem_slab, rx_block[rx_idx]);
 	}
 	zassert_equal(num_verified, NUM_BLOCKS, "Invalid RX blocks received");
 }

--- a/tests/kernel/mem_slab/mslab/src/main.c
+++ b/tests/kernel/mem_slab/mslab/src/main.c
@@ -85,20 +85,20 @@ void helper_thread(void)
 		 "from alloc timeout\n", __func__);
 
 	TC_PRINT("%s: About to free a memory block\n", __func__);
-	k_mem_slab_free(&map_lgblks, &ptr[0]);
+	k_mem_slab_free(&map_lgblks, ptr[0]);
 	k_sem_give(&SEM_HELPERDONE);
 
 	/* Part 5 of test */
 	k_sem_take(&SEM_REGRESSDONE, K_FOREVER);
 	TC_PRINT("(5) <%s> freeing the next block\n", __func__);
 	TC_PRINT("%s: About to free another memory block\n", __func__);
-	k_mem_slab_free(&map_lgblks, &ptr[1]);
+	k_mem_slab_free(&map_lgblks, ptr[1]);
 
 	/*
 	 * Free all the other blocks.  The first 2 blocks are freed by this task
 	 */
 	for (int i = 2; i < NUMBLOCKS; i++) {
-		k_mem_slab_free(&map_lgblks, &ptr[i]);
+		k_mem_slab_free(&map_lgblks, ptr[i]);
 	}
 	TC_PRINT("%s: freed all blocks allocated by this task\n", __func__);
 
@@ -174,7 +174,7 @@ void test_slab_free_all_blocks(void **p)
 
 		TC_PRINT("  block ptr to free p[%d] = %p\n", i, p[i]);
 		/* Free memory block */
-		k_mem_slab_free(&map_lgblks, &p[i]);
+		k_mem_slab_free(&map_lgblks, p[i]);
 
 		TC_PRINT("map_lgblks freed %d block\n", i + 1);
 
@@ -267,7 +267,7 @@ ZTEST(memory_slab_1cpu, test_mslab)
 	/* Free memory block */
 	TC_PRINT("%s: Used %d block\n", __func__,
 		 k_mem_slab_num_used_get(&map_lgblks));
-	k_mem_slab_free(&map_lgblks, &b);
+	k_mem_slab_free(&map_lgblks, b);
 	TC_PRINT("%s: 1 block freed, used %d block\n",
 		 __func__,  k_mem_slab_num_used_get(&map_lgblks));
 }

--- a/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
+++ b/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
@@ -46,7 +46,7 @@ void tmslab_alloc_free(void *data)
 	}
 	for (int i = 0; i < BLK_NUM; i++) {
 		/* TESTPOINT: Free memory allocated from a memory slab.*/
-		k_mem_slab_free(pslab, &block[i]);
+		k_mem_slab_free(pslab, block[i]);
 	}
 }
 
@@ -65,7 +65,7 @@ static void tmslab_alloc_align(void *data)
 		zassert_true((uintptr_t)block[i] % BLK_ALIGN == 0U);
 	}
 	for (int i = 0; i < BLK_NUM; i++) {
-		k_mem_slab_free(pslab, &block[i]);
+		k_mem_slab_free(pslab, block[i]);
 	}
 }
 
@@ -102,7 +102,7 @@ static void tmslab_alloc_timeout(void *data)
 	}
 
 	for (int i = 0; i < BLK_NUM; i++) {
-		k_mem_slab_free(pslab, &block[i]);
+		k_mem_slab_free(pslab, block[i]);
 	}
 }
 
@@ -136,7 +136,7 @@ static void tmslab_used_get(void *data)
 	zassert_equal(k_mem_slab_num_used_get(pslab), BLK_NUM);
 
 	for (int i = 0; i < BLK_NUM; i++) {
-		k_mem_slab_free(pslab, &block[i]);
+		k_mem_slab_free(pslab, block[i]);
 		zassert_equal(k_mem_slab_num_free_get(pslab), i + 1);
 		zassert_equal(k_mem_slab_num_used_get(pslab), BLK_NUM - 1 - i);
 	}
@@ -168,14 +168,14 @@ static void helper_thread(void *p0, void *p1, void *p2)
 	k_sem_give(&SEM_HELPERDONE);
 
 	k_sem_take(&SEM_REGRESSDONE, K_FOREVER);
-	k_mem_slab_free(&kmslab, &ptr[0]);
+	k_mem_slab_free(&kmslab, ptr[0]);
 
 
 	k_sem_take(&SEM_REGRESSDONE, K_FOREVER);
 
 	/* Free all the other blocks.  The first block are freed by this task */
 	for (int i = 1; i < BLK_NUM; i++) {
-		k_mem_slab_free(&kmslab, &ptr[i]);
+		k_mem_slab_free(&kmslab, ptr[i]);
 	}
 
 	k_sem_give(&SEM_HELPERDONE);
@@ -336,5 +336,5 @@ ZTEST(mslab_api, test_mslab_pending)
 	k_sem_take(&SEM_HELPERDONE, K_FOREVER);
 
 	/* Free memory block */
-	k_mem_slab_free(&kmslab, &b);
+	k_mem_slab_free(&kmslab, b);
 }

--- a/tests/kernel/mem_slab/mslab_concept/src/test_mslab_alloc_wait.c
+++ b/tests/kernel/mem_slab/mslab_concept/src/test_mslab_alloc_wait.c
@@ -84,7 +84,7 @@ ZTEST(mslab_concept, test_mslab_alloc_wait_prio)
 	/*relinquish CPU for above threads to start */
 	k_msleep(30);
 	/*free one block, expected to unblock thread "tid[1]"*/
-	k_mem_slab_free(&mslab1, &block[0]);
+	k_mem_slab_free(&mslab1, block[0]);
 	/*wait for all threads exit*/
 	for (int i = 0; i < THREAD_NUM; i++) {
 		k_sem_take(&sync_sema, K_FOREVER);
@@ -94,8 +94,8 @@ ZTEST(mslab_concept, test_mslab_alloc_wait_prio)
 	for (int i = 0; i < THREAD_NUM; i++) {
 		k_thread_abort(tid[i]);
 	}
-	k_mem_slab_free(&mslab1, &block_ok);
+	k_mem_slab_free(&mslab1, block_ok);
 	for (int i = 1; i < BLK_NUM; i++) {
-		k_mem_slab_free(&mslab1, &block[i]);
+		k_mem_slab_free(&mslab1, block[i]);
 	}
 }

--- a/tests/kernel/mem_slab/mslab_stats/src/main.c
+++ b/tests/kernel/mem_slab/mslab_stats/src/main.c
@@ -87,8 +87,8 @@ ZTEST(lib_mem_slab_stats_test, test_mem_slab_runtime_stats)
 
 	/* Free blocks 1 and 2, and then verify the stats. */
 
-	k_mem_slab_free(&kmslab, &memory[2]);
-	k_mem_slab_free(&kmslab, &memory[1]);
+	k_mem_slab_free(&kmslab, memory[2]);
+	k_mem_slab_free(&kmslab, memory[1]);
 
 	status = k_mem_slab_runtime_stats_get(&kmslab, &stats);
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);
@@ -142,8 +142,8 @@ ZTEST(lib_mem_slab_stats_test, test_mem_slab_runtime_stats)
 
 	/* Free the last two blocks; verify stats results */
 
-	k_mem_slab_free(&kmslab, &memory[0]);
-	k_mem_slab_free(&kmslab, &memory[1]);
+	k_mem_slab_free(&kmslab, memory[0]);
+	k_mem_slab_free(&kmslab, memory[1]);
 
 	status = k_mem_slab_runtime_stats_get(&kmslab, &stats);
 	zassert_equal(status, 0, "Routine failed with status %d\n", status);

--- a/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
+++ b/tests/kernel/mem_slab/mslab_threadsafe/src/test_mslab_threadsafe.c
@@ -53,7 +53,7 @@ static void tmslab_api(void *p1, void *p2, void *p3)
 		}
 		for (int i = 0; i < BLK_NUM; i++) {
 			if (block[i]) {
-				k_mem_slab_free(slab, &block[i]);
+				k_mem_slab_free(slab, block[i]);
 				block[i] = NULL;
 			}
 		}


### PR DESCRIPTION
kernel: Modify the signature of `k_mem_slab_free()` via the [Stable API Change procedure](https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#introducing-incompatible-changes)

Modify the signature of the `k_mem_slab_free()` function with a new one,
replacing the old `void **mem` with `void *mem` as a parameter.

Fixes #61888.

Stable API change RFC: #61937

Alternative to https://github.com/zephyrproject-rtos/zephyr/pull/61897
