### PR TITLE
ARC: Fix STR macro for ST* asm instructions

### DIFF
--- a/include/zephyr/arch/arc/asm-compat/asm-macro-64-bit-gnu.h
+++ b/include/zephyr/arch/arc/asm-compat/asm-macro-64-bit-gnu.h
@@ -34,7 +34,7 @@
 	.if \off == 0
 		stl \d, [\s]
 	.else
-		.if \off > 256
+		.if \off > 255
 			STR.as \d, \s, \off / 8
 		.else
 			stl    \d, [\s, \off]


### PR DESCRIPTION
For case of 64-bit arc_v3 architecture "str" macro handles large offsets in incorrrect way. For stl instruction limm swhoud not exceed 255.