### PR TITLE
stm32h7: spi: Add SPI loopback tests for 16 bits frames

### DIFF
--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -44,6 +44,7 @@ tests:
       - nucleo_l152re
       - nucleo_wl55jc
       - nucleo_h743zi
+      - nucleo_h753zi
       - stm32h573i_dk
     integration_platforms:
       - nucleo_g474re


### PR DESCRIPTION
Description
===========
This is a proposal to add some test cases to the spi_loopback test suite to test SPI transmissions with 16 bits frames. These tests cases are run only for STM32H7 SPI as this is the only platform I have access to.

I have run these tests for DMA (adding `STM32_DMA_MEM_16BITS | STM32_DMA_PERIPH_16BITS` to the `dmamux` devicetree configuration) and they don't pass. I have inspected the code and I believe it is due to the fact that the SPI DMA transceive doesn't take into account the existence of 16 bits frames. I have a change that makes all tests except the last one to pass, but this PR does not intend to solve this problem; I mention it as a proof of the value these test cases can provide.

As a consequence of the above, these tests cases are disabled as well in case DMA is enabled.

Test plan
=========
Connect an STM32H7 board to the PC with pins D11 and D12 connected.

Open a minicom or equivalent terminal to read the test report.

Execute the following commands:

```
west build -p auto -b nucleo_h753zi tests/drivers/spi/spi_loopback/
west flash
```

And verify all tests pass. Then, do:

```
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma.loopback
west flash
```

And verify all pass again.