### PR TITLE
MAINTAINERS: Add ADI Platforms section

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2212,6 +2212,28 @@ State machine framework:
   labels:
     - "area: State Machine Framework"
 
+ADI Platforms:
+  status: maintained
+  maintainers:
+    - MaureenHelm
+  collaborators:
+    - galak
+    - microbuilder
+  files:
+    - drivers/*/max*
+    - drivers/*/*max*/
+    - drivers/dac/dac_ltc*
+    - drivers/ethernet/eth_adin*
+    - drivers/mdio/mdio_adin*
+    - drivers/regulator/regulator_adp5360*
+    - drivers/sensor/adt*/
+    - drivers/sensor/adxl*/
+    - dts/bindings/*/adi,*
+    - dts/bindings/*/lltc,*
+    - dts/bindings/*/maxim,*
+  labels:
+    - "platform: ADI"
+
 GD32 Platforms:
   status: maintained
   maintainers:


### PR DESCRIPTION
Adds new ADI Platforms section covering device drivers and bindings for Analog Devices, Maxim Integrated, and Linear Technology.