### PR TITLE
cmake: modules/FindGnuLd: cache variable GNULD_VERSION_STRING

### DIFF
--- a/cmake/modules/FindGnuLd.cmake
+++ b/cmake/modules/FindGnuLd.cmake
@@ -79,7 +79,6 @@ if(GNULD_LINKER)
     RESULT_VARIABLE gnuld_status
     )
 
-  set(GNULD_VERSION_STRING)
   if(${gnuld_status} EQUAL 0)
     # Extract GNU ld version. Different distros have their
     # own version scheme so we need to account for that.
@@ -90,7 +89,7 @@ if(GNULD_LINKER)
     string(REGEX MATCH
            "GNU ld \\(.+\\) ([0-9]+[.][0-9]+[.]?[0-9]*).*"
            out_var ${gnuld_version_output})
-    set(GNULD_VERSION_STRING ${CMAKE_MATCH_1})
+    set(GNULD_VERSION_STRING ${CMAKE_MATCH_1} CACHE STRING "GNU ld version" FORCE)
   endif()
 endif()
 


### PR DESCRIPTION
This changes to cache variable GNULD_VERSION_STRING across cmake runs. This variable is used to determine whether -Wl,-no-pie is being passed to linker. However, if cmake is run multiple times without clearing the build directory, GNULD_VERSION_STRING was lost and the script falsely assumed the linker could not take this argument, and thus omitting it during linking. Depending on the host, it would warn on something like this:

  /usr/bin/ld.bfd: app/libapp.a(main.c.obj): warning: relocation in read-only section `.text._posix_zephyr_main'
  /usr/bin/ld.bfd: warning: creating DT_TEXTREL in a PIE

To fix this, simply caches GNULD_VERSION_STRING so it can be used during subsequent cmake runs.

Fixes #61725