### PR TITLE
boards: arm: xmc45_relax_kit: Add memory regions to linker

### DIFF
--- a/boards/arm/xmc45_relax_kit/xmc45_relax_kit.dts
+++ b/boards/arm/xmc45_relax_kit/xmc45_relax_kit.dts
@@ -57,6 +57,16 @@
 	};
 };
 
+&psram1 {
+	compatible = "zephyr,memory-region", "mmio-sram";
+	zephyr,memory-region = "PSRAM1";
+};
+
+&dsram2 {
+	compatible = "zephyr,memory-region", "mmio-sram";
+	zephyr,memory-region = "DSRAM2";
+};
+
 &flash_controller {
 	status = "okay";
 };

--- a/dts/arm/infineon/xmc4500_F100x1024.dtsi
+++ b/dts/arm/infineon/xmc4500_F100x1024.dtsi
@@ -9,7 +9,6 @@
 #include <infineon/xmc4xxx.dtsi>
 
 / {
-	/* TODO: Add psram1 & dsram2 to MEMORY layout of linker */
 	psram1: memory@10000000 {
 		compatible = "mmio-sram";
 		reg = <0x10000000 DT_SIZE_K(64)>;


### PR DESCRIPTION
Adds psram1 and dsram2 to devicetree with "zephyr,memory-region" compatible so that they will be added to the linker.

I'm splitting this commit out from https://github.com/zephyrproject-rtos/zephyr/pull/51285.