### PR TITLE
Update input_gt911.c to handle touch events on esp32

### DIFF
--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -118,7 +118,7 @@ static int gt911_process(const struct device *dev)
 
 	points = status & TOUCH_POINTS_MSK;
 	if (points != 0U && points != 1U && (0 != (status & TOUCH_STATUS_MSK))) {
-		return 0;
+		points = 1;
 	}
 
 	if (!(status & TOUCH_STATUS_MSK)) {


### PR DESCRIPTION
This fix properly ignores a multitouch event on esp32 board

[Driver: Goodix, GT911 touch controller stops working/responding if there are multiple touch inputs #60668](https://github.com/zephyrproject-rtos/zephyr/issues/60668)