### PR TITLE
soc: arm: ambiq: apollo4: add simobuck init to apollo4 init

### DIFF
--- a/soc/arm/ambiq/apollo4x/soc.c
+++ b/soc/arm/ambiq/apollo4x/soc.c
@@ -10,7 +10,14 @@
 
 static int arm_apollo4_init(void)
 {
+
+	/* Initialize for low power in the power control block */
 	am_hal_pwrctrl_low_power_init();
+
+	/* Enable SIMOBUCK for the Apollo4 Family */
+	am_hal_pwrctrl_control(AM_HAL_PWRCTRL_CONTROL_SIMOBUCK_INIT, 0);
+
+	/* Disable the RTC. */
 	am_hal_rtc_osc_disable();
 
 	return 0;


### PR DESCRIPTION
Adds comments and simobuck init function for low power.

Signed-off-by: Richard Wheatley <richard.wheatley@ambiq.com>