### PR TITLE
boards: arm: vmu_rt1170: correct bmi088 max spi freq to 10MHz

### DIFF
--- a/boards/arm/vmu_rt1170/vmu_rt1170.dts
+++ b/boards/arm/vmu_rt1170/vmu_rt1170.dts
@@ -261,7 +261,7 @@
 		compatible = "bosch,bmi08x-accel";
 		reg = <0>;
 		int-gpios = <&gpio3 20 GPIO_ACTIVE_HIGH>;
-		spi-max-frequency = <24000000>;
+		spi-max-frequency = <10000000>;
 		int1-map-io = <0x01>;
 		int2-map-io = <0x00>;
 		int1-conf-io = <0x04>;
@@ -274,7 +274,7 @@
 		compatible = "bosch,bmi08x-gyro";
 		reg = <1>;
 		int-gpios = <&gpio2 28 GPIO_ACTIVE_HIGH>;
-		spi-max-frequency = <24000000>;
+		spi-max-frequency = <10000000>;
 		int3-4-map-io = <0x01>;
 		int3-4-conf-io = <0x02>;
 		gyro-hz = "1000_116";


### PR DESCRIPTION
The max SPI clock frequency supported by the bmi088 according to the bmi088 data sheet is 10MHz. Correct the vmu_rt1170 to reflect this.

Image from spec sheet from here: https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi088-ds001.pdf
![image](https://github.com/zephyrproject-rtos/zephyr/assets/6809037/3c88f582-b2a6-4916-9413-5de0ad17a4eb)
