### PR TITLE
POSIX: Implement pthread_condattr functions

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -75,6 +75,7 @@ BUILD_ASSERT(sizeof(pthread_mutexattr_t) >= sizeof(struct pthread_mutexattr));
 typedef uint32_t pthread_cond_t;
 
 struct pthread_condattr {
+	clockid_t clock;
 };
 
 #if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -110,26 +110,34 @@ int pthread_cond_timedwait(pthread_cond_t *cv, pthread_mutex_t *mut,
  *
  * See IEEE 1003.1.
  *
- * Note that pthread attribute structs are currently noops in Zephyr.
  */
-static inline int pthread_condattr_init(pthread_condattr_t *att)
-{
-	ARG_UNUSED(att);
-	return 0;
-}
+int pthread_condattr_init(pthread_condattr_t *att);
 
 /**
  * @brief POSIX threading compatibility API
  *
  * See IEEE 1003.1
  *
- * Note that pthread attribute structs are currently noops in Zephyr.
  */
-static inline int pthread_condattr_destroy(pthread_condattr_t *att)
-{
-	ARG_UNUSED(att);
-	return 0;
-}
+int pthread_condattr_destroy(pthread_condattr_t *att);
+
+/**
+ * @brief POSIX threading comatibility API
+ *
+ * See IEEE 1003.1
+ *
+ */
+int pthread_condattr_getclock(const pthread_condattr_t *ZRESTRICT att,
+		clockid_t *ZRESTRICT clock_id);
+
+/**
+ * @brief POSIX threading compatibility API
+ *
+ * See IEEE 1003.1
+ *
+ */
+
+int pthread_condattr_setclock(pthread_condattr_t *att, clockid_t clock_id);
 
 /**
  * @brief Declare a mutex as initialized
@@ -364,9 +372,7 @@ int pthread_barrierattr_getpshared(const pthread_barrierattr_t *ZRESTRICT attr,
  * Unix code.  Leave the declarations here so they can be easily
  * uncommented and implemented as needed.
 
-int pthread_condattr_getclock(const pthread_condattr_t * clockid_t *);
 int pthread_condattr_getpshared(const pthread_condattr_t * int *);
-int pthread_condattr_setclock(pthread_condattr_t *, clockid_t);
 int pthread_condattr_setpshared(pthread_condattr_t *, int);
 int pthread_mutex_consistent(pthread_mutex_t *);
 int pthread_mutex_getprioceiling(const pthread_mutex_t * int *);

--- a/lib/posix/cond.c
+++ b/lib/posix/cond.c
@@ -202,4 +202,39 @@ static int pthread_cond_pool_init(void)
 
 	return 0;
 }
+
+int pthread_condattr_init(pthread_condattr_t *att)
+{
+	__ASSERT_NO_MSG(att != NULL);
+
+	att->clock = CLOCK_MONOTONIC;
+
+	return 0;
+}
+
+int pthread_condattr_destroy(pthread_condattr_t *att)
+{
+	ARG_UNUSED(att);
+
+	return 0;
+}
+
+int pthread_condattr_getclock(const pthread_condattr_t *ZRESTRICT att,
+		clockid_t *ZRESTRICT clock_id)
+{
+	*clock_id = att->clock;
+
+	return 0;
+}
+
+int pthread_condattr_setclock(pthread_condattr_t *att, clockid_t clock_id)
+{
+	if (clock_id != CLOCK_REALTIME && clock_id != CLOCK_MONOTONIC) {
+		return -EINVAL;
+	}
+
+	att->clock = clock_id;
+
+	return 0;
+}
 SYS_INIT(pthread_cond_pool_init, PRE_KERNEL_1, 0);

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -233,6 +233,28 @@ void *thread_top_term(void *p1)
 	return NULL;
 }
 
+ZTEST(posix_apis, test_pthread_condattr)
+{
+	clockid_t clock_id;
+	pthread_condattr_t att;
+
+	zassert_ok(pthread_condattr_init(&att), "pthread_condattr_init failed");
+
+	zassert_ok(pthread_condattr_getclock(&att, &clock_id), "pthread_condattr_getclock failed");
+	zassert_equal(clock_id, CLOCK_MONOTONIC, "clock attribute not set correctly");
+
+	zassert_ok(pthread_condattr_setclock(&att, CLOCK_REALTIME),
+		   "pthread_condattr_setclock failed");
+
+	zassert_ok(pthread_condattr_getclock(&att, &clock_id), "pthread_condattr_setclock failed");
+	zassert_equal(clock_id, CLOCK_REALTIME, "clock attribute not set correctly");
+
+	zassert_equal(pthread_condattr_setclock(&att, 42),
+		      -EINVAL, "pthread_condattr_setclock did not return EINVAL");
+
+	zassert_ok(pthread_condattr_destroy(&att), "pthread_condattr_destroy failed");
+}
+
 ZTEST(posix_apis, test_pthread_execution)
 {
 	int i, ret, min_prio, max_prio;


### PR DESCRIPTION
Added:
pthread_condattr_init
pthread_condattr_destroy
pthread_condattr_getclock
pthread_condattr_setclock

Fixes #59948
Fixes #59947