### PR TITLE
drivers,subsys: fix few missing k_work_delayable_from_work

### DIFF
--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -622,8 +622,9 @@ static void eth_mcux_phy_work(struct k_work *item)
 
 static void eth_mcux_delayed_phy_work(struct k_work *item)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(item);
 	struct eth_context *context =
-		CONTAINER_OF(item, struct eth_context, delayed_phy_work);
+		CONTAINER_OF(dwork, struct eth_context, delayed_phy_work);
 
 	eth_mcux_phy_event(context);
 }

--- a/drivers/input/input_gpio_keys.c
+++ b/drivers/input/input_gpio_keys.c
@@ -79,8 +79,10 @@ static void gpio_keys_interrupt(const struct device *dev, struct gpio_callback *
 	ARG_UNUSED(dev); /* This is a pointer to GPIO device, use dev pointer in
 			  * cbdata for pointer to gpio_debounce device node
 			  */
-	struct gpio_keys_pin_data *pin_data =
-		CONTAINER_OF(cbdata, struct gpio_keys_pin_data, cb_data);
+	struct gpio_keys_callback *keys_cb = CONTAINER_OF(
+			cbdata, struct gpio_keys_callback, gpio_cb);
+	struct gpio_keys_pin_data *pin_data = CONTAINER_OF(
+			keys_cb, struct gpio_keys_pin_data, cb_data);
 	const struct gpio_keys_config *cfg = pin_data->dev->config;
 
 	for (int i = 0; i < cfg->num_keys; i++) {

--- a/drivers/input/input_gpio_keys.c
+++ b/drivers/input/input_gpio_keys.c
@@ -45,7 +45,8 @@ struct gpio_keys_pin_data {
  */
 static void gpio_keys_change_deferred(struct k_work *work)
 {
-	struct gpio_keys_pin_data *pin_data = CONTAINER_OF(work, struct gpio_keys_pin_data, work);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct gpio_keys_pin_data *pin_data = CONTAINER_OF(dwork, struct gpio_keys_pin_data, work);
 	const struct device *dev = pin_data->dev;
 	int key_index = pin_data - (struct gpio_keys_pin_data *)dev->data;
 	const struct gpio_keys_config *cfg = dev->config;

--- a/drivers/input/input_gpio_qdec.c
+++ b/drivers/input/input_gpio_qdec.c
@@ -147,8 +147,9 @@ static void gpio_qdec_irq_setup(const struct device *dev, bool enable)
 
 static void gpio_qdec_idle_worker(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct gpio_qdec_data *data = CONTAINER_OF(
-			work, struct gpio_qdec_data, idle_work);
+			dwork, struct gpio_qdec_data, idle_work);
 	const struct device *dev = data->dev;
 
 	k_timer_stop(&data->sample_timer);

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -232,8 +232,9 @@ static int ppp_async_uart_rx_enable(struct ppp_driver_context *context)
 
 static void uart_recovery(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct ppp_driver_context *ppp =
-		CONTAINER_OF(work, struct ppp_driver_context, uart_recovery_work);
+		CONTAINER_OF(dwork, struct ppp_driver_context, uart_recovery_work);
 	int ret;
 
 	ret = ring_buf_space_get(&ppp->rx_ringbuf);

--- a/drivers/sensor/tmp108/tmp108_trigger.c
+++ b/drivers/sensor/tmp108/tmp108_trigger.c
@@ -16,10 +16,7 @@ LOG_MODULE_DECLARE(TMP108, CONFIG_SENSOR_LOG_LEVEL);
 
 void tmp108_trigger_handle_one_shot(struct k_work *work)
 {
-	struct k_work_delayable *delayable_work = CONTAINER_OF(work,
-							       struct k_work_delayable,
-							       work);
-
+	struct k_work_delayable *delayable_work = k_work_delayable_from_work(work);
 	struct tmp108_data *drv_data = CONTAINER_OF(delayable_work,
 						    struct tmp108_data,
 						    scheduled_work);

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -820,7 +820,8 @@ static int mcux_lpuart_rx_buf_rsp(const struct device *dev, uint8_t *buf, size_t
 
 static void mcux_lpuart_async_rx_timeout(struct k_work *work)
 {
-	struct mcux_lpuart_rx_dma_params *rx_params = CONTAINER_OF(work,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct mcux_lpuart_rx_dma_params *rx_params = CONTAINER_OF(dwork,
 								   struct mcux_lpuart_rx_dma_params,
 								   timeout_work);
 	struct mcux_lpuart_async_data *async_data = CONTAINER_OF(rx_params,
@@ -834,7 +835,8 @@ static void mcux_lpuart_async_rx_timeout(struct k_work *work)
 
 static void mcux_lpuart_async_tx_timeout(struct k_work *work)
 {
-	struct mcux_lpuart_tx_dma_params *tx_params = CONTAINER_OF(work,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct mcux_lpuart_tx_dma_params *tx_params = CONTAINER_OF(dwork,
 								   struct mcux_lpuart_tx_dma_params,
 								   timeout_work);
 	struct mcux_lpuart_async_data *async_data = CONTAINER_OF(tx_params,

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -424,8 +424,9 @@ static __unused void uart_npcx_rx_wk_isr(const struct device *dev, struct npcx_w
 #ifdef CONFIG_UART_CONSOLE_INPUT_EXPIRED
 static void uart_npcx_rx_refresh_timeout(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct uart_npcx_data *data =
-		CONTAINER_OF(work, struct uart_npcx_data, rx_refresh_timeout_work);
+		CONTAINER_OF(dwork, struct uart_npcx_data, rx_refresh_timeout_work);
 
 	uart_npcx_pm_policy_state_lock_put(data, UART_PM_POLICY_STATE_RX_FLAG);
 }

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -303,7 +303,8 @@ static void uart_sam0_dma_rx_done(const struct device *dma_dev, void *arg,
 
 static void uart_sam0_rx_timeout(struct k_work *work)
 {
-	struct uart_sam0_dev_data *dev_data = CONTAINER_OF(work,
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct uart_sam0_dev_data *dev_data = CONTAINER_OF(dwork,
 							   struct uart_sam0_dev_data, rx_timeout_work);
 	const struct uart_sam0_dev_cfg *const cfg = dev_data->cfg;
 	SercomUsart * const regs = cfg->regs;

--- a/drivers/usb/device/usb_dc_it82xx2.c
+++ b/drivers/usb/device/usb_dc_it82xx2.c
@@ -821,8 +821,9 @@ static void it82xx2_usb_dc_isr(void)
 
 static void suspended_check_handler(struct k_work *item)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(item);
 	struct usb_it82xx2_data *udata =
-		CONTAINER_OF(item, struct usb_it82xx2_data, check_suspended_work);
+		CONTAINER_OF(dwork, struct usb_it82xx2_data, check_suspended_work);
 
 	struct usb_it82xx2_regs *const usb_regs =
 		(struct usb_it82xx2_regs *)it82xx2_get_usb_regs();

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -445,7 +445,7 @@ static void set_lock_timer_handler(struct k_work *work)
 	struct k_work_delayable *delayable;
 	struct bt_csip_set_member_svc_inst *svc_inst;
 
-	delayable = CONTAINER_OF(work, struct k_work_delayable, work);
+	delayable = k_work_delayable_from_work(work);
 	svc_inst = CONTAINER_OF(delayable, struct bt_csip_set_member_svc_inst,
 				set_lock_timer);
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1732,7 +1732,8 @@ static void smp_pairing_complete(struct bt_smp *smp, uint8_t status)
 
 static void smp_timeout(struct k_work *work)
 {
-	struct bt_smp *smp = CONTAINER_OF(work, struct bt_smp, work);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct bt_smp *smp = CONTAINER_OF(dwork, struct bt_smp, work);
 
 	LOG_ERR("SMP Timeout");
 

--- a/subsys/input/input_longpress.c
+++ b/subsys/input/input_longpress.c
@@ -36,8 +36,9 @@ struct longpress_data {
 
 static void longpress_deferred(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct longpress_data_entry *entry = CONTAINER_OF(
-			work, struct longpress_data_entry, work);
+			dwork, struct longpress_data_entry, work);
 	const struct device *dev = entry->dev;
 	const struct longpress_config *cfg = dev->config;
 	uint16_t code;

--- a/subsys/mgmt/mcumgr/transport/src/smp_bt.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_bt.c
@@ -195,7 +195,8 @@ static void conn_param_set(struct bt_conn *conn, struct bt_le_conn_param *param)
 /* Work handler function for restoring the preferred connection parameters for the connection. */
 static void conn_param_on_pref_restore(struct k_work *work)
 {
-	struct conn_param_data *cpd = CONTAINER_OF(work, struct conn_param_data, dwork);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct conn_param_data *cpd = CONTAINER_OF(dwork, struct conn_param_data, dwork);
 
 	if (cpd != NULL) {
 		conn_param_set(cpd->conn, CONN_PARAM_PREF);
@@ -206,7 +207,8 @@ static void conn_param_on_pref_restore(struct k_work *work)
 /* Work handler function for retrying on conn negotiation API error. */
 static void conn_param_on_error_retry(struct k_work *work)
 {
-	struct conn_param_data *cpd = CONTAINER_OF(work, struct conn_param_data, ework);
+	struct k_work_delayable *ework = k_work_delayable_from_work(work);
+	struct conn_param_data *cpd = CONTAINER_OF(ework, struct conn_param_data, ework);
 	struct bt_le_conn_param *param = (cpd->state & CONN_PARAM_SMP_REQUESTED) ?
 		CONN_PARAM_SMP : CONN_PARAM_PREF;
 

--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -229,8 +229,9 @@ static void cdc_acm_write_cb(uint8_t ep, int size, void *priv)
 
 static void tx_work_handler(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct cdc_acm_dev_data_t *dev_data =
-		CONTAINER_OF(work, struct cdc_acm_dev_data_t, tx_work);
+		CONTAINER_OF(dwork, struct cdc_acm_dev_data_t, tx_work);
 	const struct device *dev = dev_data->common.dev;
 	struct usb_cfg_data *cfg = (void *)dev->config;
 	uint8_t ep = cfg->endpoint[ACM_IN_EP_IDX].ep_addr;

--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -89,8 +89,9 @@ static struct triggered_from_msgq_test_item triggered_from_msgq_test;
 
 static void work_handler(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct delayed_test_item *ti =
-			CONTAINER_OF(work, struct delayed_test_item, work);
+			CONTAINER_OF(dwork, struct delayed_test_item, work);
 
 	TC_PRINT(" - Running test item %d\n", ti->key);
 	k_msleep(WORK_ITEM_WAIT);
@@ -202,8 +203,9 @@ static void test_sequence(void)
 
 static void resubmit_work_handler(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct delayed_test_item *ti =
-			CONTAINER_OF(work, struct delayed_test_item, work);
+			CONTAINER_OF(dwork, struct delayed_test_item, work);
 
 	k_msleep(WORK_ITEM_WAIT);
 
@@ -242,8 +244,9 @@ ZTEST(workqueue_triggered, test_resubmit)
 
 static void delayed_work_handler(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct delayed_test_item *ti =
-			CONTAINER_OF(work, struct delayed_test_item, work);
+			CONTAINER_OF(dwork, struct delayed_test_item, work);
 
 	TC_PRINT(" - Running delayed test item %d\n", ti->key);
 


### PR DESCRIPTION
Fix few instances of delayable work handlers using the k_work pointer directly in a CONTAINER_OF pointing to a k_work_delayable.

This is harmless since the k_work is the first element in k_work_delayable, but using k_work_delayable_from_work is the right way of handling it.

Change a couple of explicit CONTAINER_OF doing the same work as the macro in the process.

---

Fix another unrelated CONTAINER_OF in input gpio keys.