### PR TITLE
Enable test spi_loopback for LPSPI + DMA for S32K3

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/mr_canhubk3.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mr_canhubk3.conf
@@ -1,0 +1,5 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_MCUX_LPSPI_DMA=y
+CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mr_canhubk3.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mr_canhubk3.overlay
@@ -6,6 +6,9 @@
 
 &lpspi1 {
 	status = "okay";
+	/* DMA channels 10 and 12, muxed to LPSPI1 TX and RX */
+	dmas = <&edma0 10 45>, <&edma0 12 46>;
+	dma-names = "tx", "rx";
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";


### PR DESCRIPTION
Enable test spi_loopback for LPSPI + DMA for S32K3. The test only passes when https://github.com/zephyrproject-rtos/zephyr/pull/61311 merged

Update: https://github.com/zephyrproject-rtos/zephyr/pull/61311 merged already