### PR TITLE
Enable support for LPUART + DMA for S32K3

### DIFF
--- a/boards/arm/mr_canhubk3/mr_canhubk3.dts
+++ b/boards/arm/mr_canhubk3/mr_canhubk3.dts
@@ -197,38 +197,62 @@
 &lpuart0 {
 	pinctrl-0 = <&lpuart0_default>;
 	pinctrl-names = "default";
+	dmas = <&edma0 0 37>, <&edma0 1 38>;
+	dma-names = "tx", "rx";
 };
 
 &lpuart1 {
 	pinctrl-0 = <&lpuart1_default>;
 	pinctrl-names = "default";
+	dmas = <&edma0 2 39>, <&edma0 3 40>;
+	dma-names = "tx", "rx";
 };
 
 &lpuart2 {
 	pinctrl-0 = <&lpuart2_default>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	dmas = <&edma0 16 38>, <&edma0 17 39>;
+	dma-names = "tx", "rx";
 	status = "okay";
 };
 
 &lpuart9 {
 	pinctrl-0 = <&lpuart9_default>;
 	pinctrl-names = "default";
+	/*
+	 * LPUART 1 and 9 share the same DMA source for TX
+	 * and RX, using UART async API for both instances
+	 * should be careful.
+	 */
+	dmas = <&edma0 4 39>, <&edma0 5 40>;
+	dma-names = "tx", "rx";
 };
 
 &lpuart10 {
 	pinctrl-0 = <&lpuart10_default>;
 	pinctrl-names = "default";
+	/*
+	 * LPUART 2 and 10 share the same DMA source for TX
+	 * and RX, using UART async API for both instances
+	 * should be careful.
+	 */
+	dmas = <&edma0 18 38>, <&edma0 19 39>;
+	dma-names = "tx", "rx";
 };
 
 &lpuart13 {
 	pinctrl-0 = <&lpuart13_default>;
 	pinctrl-names = "default";
+	dmas = <&edma0 20 44>, <&edma0 21 45>;
+	dma-names = "tx", "rx";
 };
 
 &lpuart14 {
 	pinctrl-0 = <&lpuart14_default>;
 	pinctrl-names = "default";
+	dmas = <&edma0 22 46>, <&edma0 23 47>;
+	dma-names = "tx", "rx";
 };
 
 &qspi0 {

--- a/boards/arm/mr_canhubk3/mr_canhubk3.yaml
+++ b/boards/arm/mr_canhubk3/mr_canhubk3.yaml
@@ -19,4 +19,5 @@ supported:
   - watchdog
   - netif:eth
   - pwm
+  - dma
 vendor: nxp

--- a/tests/drivers/uart/uart_async_api/boards/mr_canhubk3.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mr_canhubk3.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/ {
+	chosen {
+		zephyr,sram = &dtcm;
+	};
+};
+
+dut: &lpuart10 {
+	current-speed = <115200>;
+	nxp,loopback;
+	status = "okay";
+};


### PR DESCRIPTION
This adds support for LPUART + DMA, leverages DMA mcux drivers, this depends on https://github.com/zephyrproject-rtos/zephyr/pull/61311

Update: https://github.com/zephyrproject-rtos/zephyr/pull/61311 was merged

Tested on `mr_canhubk3` board. All exist LPUART instances on the boards were tested manually over `tests\drivers\uart\uart_async_api` with internal loopback. After this got merged, LPUART 10 will be tested automatically