### PR TITLE
arm64: mmu: add Non-cacheable normal memory mapping support

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -924,6 +924,8 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 	 *			(Device memory nGnRE)
 	 * K_MEM_ARM_DEVICE_GRE => MT_DEVICE_GRE
 	 *			(Device memory GRE)
+	 * K_MEM_ARM_NORMAL_NC   => MT_NORMAL_NC
+	 *			(Normal memory Non-cacheable)
 	 * K_MEM_CACHE_WB   => MT_NORMAL
 	 *			(Normal memory Outer WB + Inner WB)
 	 * K_MEM_CACHE_WT   => MT_NORMAL_WT
@@ -939,6 +941,9 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 		break;
 	case K_MEM_ARM_DEVICE_GRE:
 		entry_flags |= MT_DEVICE_GRE;
+		break;
+	case K_MEM_ARM_NORMAL_NC:
+		entry_flags |= MT_NORMAL_NC;
 		break;
 	case K_MEM_CACHE_WT:
 		entry_flags |= MT_NORMAL_WT;

--- a/include/zephyr/arch/arm64/arm_mem.h
+++ b/include/zephyr/arch/arm64/arm_mem.h
@@ -19,4 +19,7 @@
 /** ARM64 Specific flags: device memory with GRE */
 #define K_MEM_ARM_DEVICE_GRE	4
 
+/** ARM64 Specific flags: normal memory with Non-cacheable */
+#define K_MEM_ARM_NORMAL_NC	5
+
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM64_ARM_MEM_H_ */


### PR DESCRIPTION
In some shared-memory use cases between Zephyr and other parallel running OS, for data coherent, the non-cacheable normal memory mapping is needed.