### PR TITLE
manifest: update loramac-node

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -267,7 +267,7 @@ manifest:
         - fs
       revision: ca583fd297ceb48bced3c2548600dc615d67af24
     - name: loramac-node
-      revision: ce57712f3e426bbbb13acaec97b45369f716f43a
+      revision: 3029c9f304bf46a6e5205f3c8455dbc23108efec
       path: modules/lib/loramac-node
     - name: lvgl
       revision: 8a6a2d1d29d17d1e4bdc94c243c146a39d635fdd


### PR DESCRIPTION
Update loramac-node to point back to the zephyr branch and include a shadow variable fix.

Fixes few `west build -p -b ronoth_lodev -T samples/drivers/lora/send/sample.driver.lora.send`