### PR TITLE
drivers: gpio: xlnx_ps: fix up initialization priorities

### DIFF
--- a/drivers/gpio/gpio_xlnx_ps.c
+++ b/drivers/gpio/gpio_xlnx_ps.c
@@ -129,7 +129,7 @@ static void gpio_xlnx_ps##idx##_irq_config(const struct device *dev)\
 #define GPIO_XLNX_PS_DEV_DEFINE(idx)\
 DEVICE_DT_INST_DEFINE(idx, gpio_xlnx_ps_init, NULL,\
 	&gpio_xlnx_ps##idx##_data, &gpio_xlnx_ps##idx##_cfg,\
-	PRE_KERNEL_2, CONFIG_GPIO_INIT_PRIORITY, &gpio_xlnx_ps_default_apis);
+	PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY, &gpio_xlnx_ps_default_apis);
 
 /*
  * Top-level device initialization macro, executed for each PS GPIO


### PR DESCRIPTION
Reproducible with `west build -p -b zybo  -T samples/basic/blinky/sample.basic.blinky`, failed in the weekly run.

---

Current setup tries to initialize the bank driver before the parent one, which is the inverse of what the devicetree hierarchy implies and causes a bunch of:

ERROR: /soc/gpio@e000a000/psgpio_bank@3 PRE_KERNEL_1 40 32 < /soc/gpio@e000a000 PRE_KERNEL_2 40 10

Change the bank driver to initialize at PRE_KERNEL_1 as the parent drivers so that ordinals take care of priority between these two.