### PR TITLE
drivers: crypto: it8xxx2_evb: fix a shadow variable error

### DIFF
--- a/drivers/crypto/crypto_it8xxx2_sha.c
+++ b/drivers/crypto/crypto_it8xxx2_sha.c
@@ -96,7 +96,7 @@ static void it8xxx2_sha256_init(bool init_k)
 	}
 	/* Initialize array of round constants */
 	if (init_k) {
-		for (int i = 0; i < ARRAY_SIZE(sha256_k); i++) {
+		for (i = 0; i < ARRAY_SIZE(sha256_k); i++) {
 			chip_ctx.k[i] = sha256_k[i];
 		}
 	}


### PR DESCRIPTION
Repro with `west build -p -b it8xxx2_evb  -T samples/drivers/crypto/sample.drivers.crypto.mbedtls`, hit the weekly build.

---

Fix a build error:

crypto_it8xxx2_sha.c:99:26: warning: declaration of 'i' shadows a previous local [-Wshadow]
   99 |                 for (int i = 0; i < ARRAY_SIZE(sha256_k); i++) {
      |                          ^ crypto_it8xxx2_sha.c:88:13: note:
shadowed declaration is here
   88 |         int i;