### PR TITLE
boards: em_starterkit: stop overriding GPIO_INIT_PRIORITY

### DIFF
--- a/boards/arc/em_starterkit/Kconfig.defconfig
+++ b/boards/arc/em_starterkit/Kconfig.defconfig
@@ -5,13 +5,6 @@ if BOARD_EM_STARTERKIT
 config BOARD
 	default "em_starterkit"
 
-if GPIO
-
-config GPIO_INIT_PRIORITY
-	default 70
-
-endif # GPIO
-
 if I2C_DW
 
 config I2C_DW_CLOCK_SPEED

--- a/boards/arc/emsdp/Kconfig.defconfig
+++ b/boards/arc/emsdp/Kconfig.defconfig
@@ -8,14 +8,6 @@ if BOARD_EMSDP
 config BOARD
 	default "emsdp"
 
-
-if GPIO
-
-config GPIO_INIT_PRIORITY
-	default 70
-
-endif # GPIO
-
 if SPI
 
 config SPI_DW

--- a/boards/arc/hsdk/Kconfig.defconfig
+++ b/boards/arc/hsdk/Kconfig.defconfig
@@ -6,16 +6,6 @@ if BOARD_HSDK
 config BOARD
 	default "hsdk"
 
-if GPIO
-
-config GPIO_INIT_PRIORITY
-	default 60
-
-config I2C
-	default y
-
-endif # GPIO
-
 if SPI_DW
 
 config SPI_DW_ACCESS_WORD_ONLY


### PR DESCRIPTION
Repro with `west build -p -b em_starterkit_em11d  -T tests/drivers/build_all/gpio/drivers.gpio.build`

---

This was introduced long time ago during a big priority refactoring, with the current priority changes it should not be necesary anymore, the current value is causing some build fail in the weekly test.

Fixes the following breakage:
```
$ west build -p -b em_starterkit_em11d -T tests/drivers/build_all/gpio/drivers.gpio.build
...
ERROR: /test/nct3807_alert_1 POST_KERNEL 52 51 < /test/gpio@deadbeef POST_KERNEL 70 47
ninja: build stopped: subcommand failed.
```