### PR TITLE
power_domain: intel_adsp: initialize after DMA

### DIFF
--- a/drivers/power_domain/power_domain_intel_adsp.c
+++ b/drivers/power_domain/power_domain_intel_adsp.c
@@ -80,6 +80,7 @@ static int pd_intel_adsp_init(const struct device *dev)
 	};									\
 	PM_DEVICE_DT_INST_DEFINE(id, pd_intel_adsp_pm_action);			\
 	DEVICE_DT_INST_DEFINE(id, pd_intel_adsp_init, PM_DEVICE_DT_INST_GET(id),\
-			      &pd_pg_reg##id, NULL, POST_KERNEL, 75, NULL);
+			      &pd_pg_reg##id, NULL, POST_KERNEL,                \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(POWER_DOMAIN_DEVICE)


### PR DESCRIPTION
Repro with `west build -p -b intel_adsp_ace15_mtpm -T tests/drivers/dma/loop_transfer/drivers.dma.loop_transfer`, found in the weekly build.

---

Change the power_domain_intel_adsp initialization priority so that it initializes after the DMA driver that it depends on.

Fixes a few:

ERROR: /soc/dma@72c00 POST_KERNEL 40 69 <
	/soc/dfpmccu@71b00/hst_domain POST_KERNEL 75 65
ERROR: /soc/dma@72400 POST_KERNEL 40 66 <
	/soc/dfpmccu@71b00/hst_domain POST_KERNEL 75 65
...