### PR TITLE
stm32h7: spi: Use TXC instead of EOT

### DIFF
--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -177,7 +177,11 @@ static inline void ll_func_disable_int_errors(SPI_TypeDef *spi)
 static inline uint32_t ll_func_spi_is_busy(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	return LL_SPI_IsActiveFlag_EOT(spi);
+	if (LL_SPI_GetTransferSize(spi) == 0) {
+		return LL_SPI_IsActiveFlag_TXC(spi) == 0;
+	} else {
+		return LL_SPI_IsActiveFlag_EOT(spi) == 0;
+	}
 #else
 	return LL_SPI_IsActiveFlag_BSY(spi);
 #endif /* st_stm32h7_spi */


### PR DESCRIPTION
This is a proposal to fix what seems to be a problem in the stm32 SPI driver, in particular for H7 devices. In the `spi_stm32_complete` function, the SPI master calls `ll_func_spi_is_busy` to wait for the SPI transaction to finish; this is correct. However, this function does the following:

```
static inline uint32_t ll_func_spi_is_busy(SPI_TypeDef *spi)
{
#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
	return LL_SPI_IsActiveFlag_EOT(spi);
#else
	return LL_SPI_IsActiveFlag_BSY(spi);
#endif /* st_stm32h7_spi */
}
```

As you can see, for the case of H7, it waits for `EOT` to be set. This seems wrong in 2 ways:

 * `EOT` is set when the transfer ends, so `ll_func_spi_is_busy` should actually do `return LL_SPI_IsActiveFlag_EOT(spi) == 0;` so it waits while `EOT` is not set, that is, while the transfer is still ongoing.
 * `EOT` flag will never be set as this driver doesn't set the transfer size during configuration, by accessing the register `SPI_CR2` (`TSIZE`) or, in other words, by calling `LL_SPI_SetTransferSize`

You can find the description of `EOT` and `TSIZE` below:

![tsize](https://github.com/zephyrproject-rtos/zephyr/assets/127399215/c896f673-3e16-41dd-853a-64e3d7bffc25)

![eot](https://github.com/zephyrproject-rtos/zephyr/assets/127399215/6b514d3f-5d66-46d2-9faa-fd8367df5a99)


This PR proposes to use the `TXC` flag instead, since `EOT` is always 0, which defines an 'endless transaction'. See the description of `TXC` below:

![txc](https://github.com/zephyrproject-rtos/zephyr/assets/127399215/129cee66-4225-47dc-818a-cd5529230259)


The driver currently works because the `ll_func_spi_is_busy` has a negated logic for H7, which happens to work as `EOT` is always 0.

Test plan
=======
Connect an STM32H7 board to the PC with pins D11 and D12 connected.

Open a minicom or equivalent terminal to read the test report.

Execute the following commands:
```
west build -p auto -b nucleo_h753zi tests/drivers/spi/spi_loopback/
west flash
```
And verify all tests pass. Then, do:
```
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma.loopback
west flash
```
And verify all pass again.