### PR TITLE
doc: Fix bad use of Sphinx roles within Doxygen comments

### DIFF
--- a/include/zephyr/drivers/bbram.h
+++ b/include/zephyr/drivers/bbram.h
@@ -223,7 +223,7 @@ static inline int z_impl_bbram_write(const struct device *dev, size_t offset,
 /**
  * @brief Set the emulated BBRAM driver's invalid state
  *
- * Calling this will affect the emulated behavior of :c:func:`bbram_check_invalid`
+ * Calling this will affect the emulated behavior of bbram_check_invalid().
  *
  * @param[in] dev The emulated device to modify
  * @param[in] is_invalid The new invalid state
@@ -234,7 +234,7 @@ int bbram_emul_set_invalid(const struct device *dev, bool is_invalid);
 /**
  * @brief Set the emulated BBRAM driver's standby power state
  *
- * Calling this will affect the emulated behavior of :c:func:`bbram_check_standby_power`
+ * Calling this will affect the emulated behavior of bbram_check_standby_power().
  *
  * @param[in] dev The emulated device to modify
  * @param[in] failure Whether or not standby power failure should be emulated
@@ -245,7 +245,7 @@ int bbram_emul_set_standby_power_state(const struct device *dev, bool failure);
 /**
  * @brief Set the emulated BBRAM driver's  power state
  *
- * Calling this will affect the emulated behavior of :c:func:`bbram_check_power`
+ * Calling this will affect the emulated behavior of bbram_check_power().
  *
  * @param[in] dev The emulated device to modify
  * @param[in] failure Whether or not a power failure should be emulated

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -495,7 +495,9 @@ struct sensor_decoder_api {
 	 * @param[out]    channels The channels that were decoded
 	 * @param[out]    values The scaled data that was decoded
 	 * @param[in]     max_count The maximum number of channels to decode.
-	 * @return
+	 * @retval        > 0 The number of decoded values
+	 * @retval        0 Nothing else to decode on the @p buffer
+	 * @retval        < 0 Error
 	 */
 	int (*decode)(const uint8_t *buffer, sensor_frame_iterator_t *fit,
 		      sensor_channel_iterator_t *cit, enum sensor_channel *channels, q31_t *values,

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -401,7 +401,7 @@ typedef int (*sensor_channel_get_t)(const struct device *dev,
 
 /**
  * @typedef sensor_frame_iterator_t
- * @brief Used for iterating over the data frames via the :c:struct:`sensor_decoder_api`
+ * @brief Used for iterating over the data frames via the sensor_decoder_api.
  *
  * Example usage:
  *
@@ -435,21 +435,21 @@ typedef uint32_t sensor_frame_iterator_t;
 
 /**
  * @typedef sensor_channel_iterator_t
- * @brief Used for iterating over data channels in the same frame via :c:struct:`sensor_decoder_api`
+ * @brief Used for iterating over data channels in the same frame via sensor_decoder_api
  */
 typedef uint32_t sensor_channel_iterator_t;
 
 /**
  * @brief Decodes a single raw data buffer
  *
- * Data buffers are provided on the :c:struct:`rtio` context that's supplied to
+ * Data buffers are provided on the @ref rtio context that's supplied to
  * c:func:`sensor_read`.
  */
 struct sensor_decoder_api {
 	/**
 	 * @brief Get the number of frames in the current buffer.
 	 *
-	 * @param[in]  buffer The buffer provided on the :c:struct:`rtio` context.
+	 * @param[in]  buffer The buffer provided on the @ref rtio context.
 	 * @param[out] frame_count The number of frames on the buffer (at least 1)
 	 * @return 0 on success
 	 * @return <0 on error
@@ -459,9 +459,9 @@ struct sensor_decoder_api {
 	/**
 	 * @brief Get the timestamp associated with the first frame.
 	 *
-	 * @param[in]  buffer The buffer provided on the :c:struct:`rtio` context.
+	 * @param[in]  buffer The buffer provided on the @ref rtio context.
 	 * @param[out] timestamp_ns The closest timestamp for when the first frame was generated
-	 *             as attained by :c:func:`k_uptime_ticks`.
+	 *             as attained by k_uptime_ticks().
 	 * @return 0 on success
 	 * @return <0 on error
 	 */
@@ -473,7 +473,7 @@ struct sensor_decoder_api {
 	 * This value can be used by shifting the q31_t value resulting in the SI unit of the
 	 * reading. It is guaranteed that the shift for a channel will not change between frames.
 	 *
-	 * @param[in]  buffer The buffer provided on the :c:struct:`rtio` context.
+	 * @param[in]  buffer The buffer provided on the @ref rtio context.
 	 * @param[in]  channel_type The c:enum:`sensor_channel` to query
 	 * @param[out] shift The bit shift of the channel for this data buffer.
 	 * @return 0 on success
@@ -489,7 +489,7 @@ struct sensor_decoder_api {
 	 * @p max_count is 2, only 1 channel will be decoded and the frame iterator will be modified
 	 * so that the next call to decode will begin at the next frame.
 	 *
-	 * @param[in]     buffer The buffer provided on the :c:struct:`rtio` context
+	 * @param[in]     buffer The buffer provided on the @ref rtio context
 	 * @param[in,out] fit The current frame iterator
 	 * @param[in,out] cit The current channel iterator
 	 * @param[out]    channels The channels that were decoded
@@ -525,7 +525,7 @@ struct sensor_read_config {
 /**
  * @brief Define a reading instance of a sensor
  *
- * Use this macro to generate a :c:struct:`rtio_iodev` for reading specific channels. Example:
+ * Use this macro to generate a @ref rtio_iodev for reading specific channels. Example:
  *
  * @code(.c)
  * SENSOR_DT_READ_IODEV(icm42688_accelgyro, DT_NODELABEL(icm42688),
@@ -787,10 +787,9 @@ struct __attribute__((__packed__)) sensor_data_generic_header {
  * @brief checks if a given channel is a 3-axis channel
  *
  * @param[in] chan The channel to check
- * @return true if @p chan is :c:enum:`SENSOR_CHAN_ACCEL_XYZ`
- * @return true if @p chan is :c:enum:`SENSOR_CHAN_GYRO_XYZ`
- * @return true if @p chan is :c:enum:`SENSOR_CHAN_MAGN_XYZ`
- * @return false otherwise
+ * @retval true if @p chan is any of @ref SENSOR_CHAN_ACCEL_XYZ, @ref SENSOR_CHAN_GYRO_XYZ, or
+ *         @ref SENSOR_CHAN_MAGN_XYZ
+ * @retval false otherwise
  */
 #define SENSOR_CHANNEL_3_AXIS(chan)                                                                \
 	((chan) == SENSOR_CHAN_ACCEL_XYZ || (chan) == SENSOR_CHAN_GYRO_XYZ ||                      \
@@ -831,7 +830,7 @@ static inline int z_impl_sensor_get_decoder(const struct device *dev,
  * invalid. Please be sure the flush or wait for all pending operations to complete before using the
  * data after a configuration change.
  *
- * It is also important that the `data` field of the iodev is a :c:struct:`sensor_read_config`.
+ * It is also important that the `data` field of the iodev is a @ref sensor_read_config.
  *
  * @param[in] iodev The iodev to reconfigure
  * @param[in] sensor The sensor to read from
@@ -866,10 +865,10 @@ static inline int z_impl_sensor_reconfigure_read_iodev(struct rtio_iodev *iodev,
  * @brief Read data from a sensor.
  *
  * Using @p cfg, read one snapshot of data from the device by using the provided RTIO context
- * @p ctx. This call will generate a :c:struct:`rtio_sqe` that will leverage the RTIO's internal
+ * @p ctx. This call will generate a @ref rtio_sqe that will leverage the RTIO's internal
  * mempool when the time comes to service the read.
  *
- * @param[in] iodev The iodev created by :c:macro:`SENSOR_DT_READ_IODEV`
+ * @param[in] iodev The iodev created by @ref SENSOR_DT_READ_IODEV
  * @param[in] ctx The RTIO context to service the read
  * @param[in] userdata Optional userdata that will be available when the read is complete
  * @return 0 on success
@@ -903,7 +902,7 @@ static inline int sensor_read(struct rtio_iodev *iodev, struct rtio *ctx, void *
  * @param[in] result The result code of the read (0 being success)
  * @param[in] buf The data buffer holding the sensor data
  * @param[in] buf_len The length (in bytes) of the @p buf
- * @param[in] userdata The optional userdata passed to :c:func:`sensor_read`
+ * @param[in] userdata The optional userdata passed to sensor_read()
  */
 typedef void (*sensor_processing_callback_t)(int result, uint8_t *buf, uint32_t buf_len,
 					     void *userdata);
@@ -911,7 +910,7 @@ typedef void (*sensor_processing_callback_t)(int result, uint8_t *buf, uint32_t 
 /**
  * @brief Helper function for common processing of sensor data.
  *
- * This function can be called in a blocking manner after :c:func:`sensor_read` or in a standalone
+ * This function can be called in a blocking manner after sensor_read() or in a standalone
  * thread dedicated to processing. It will wait for a cqe from the RTIO context, once received, it
  * will decode the userdata and call the @p cb. Once the @p cb returns, the buffer will be released
  * back into @p ctx's mempool if available.

--- a/include/zephyr/fs/littlefs.h
+++ b/include/zephyr/fs/littlefs.h
@@ -45,14 +45,13 @@ struct fs_littlefs {
  * This defines static arrays required for caches, and initializes the
  * littlefs configuration structure to use the provided values instead
  * of the global Kconfig defaults.  A pointer to the named object must
- * be stored in the ``.fs_data`` field of a :c:type:`struct fs_mount`
- * object.
+ * be stored in the @ref fs_mount_t.fs_data field of a @ref fs_mount_t object.
  *
  * To define an instance for the Kconfig defaults, use
- * :c:macro:`FS_LITTLEFS_DECLARE_DEFAULT_CONFIG`.
+ * @ref FS_LITTLEFS_DECLARE_DEFAULT_CONFIG.
  *
  * To completely control file system configuration the application can
- * directly define and initialize a :c:type:`struct fs_littlefs`
+ * directly define and initialize a @ref fs_littlefs
  * object.  The application is responsible for ensuring the configured
  * values are consistent with littlefs requirements.
  *

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -1326,10 +1326,10 @@ static inline bool net_pkt_filter_local_in_recv_ok(struct net_pkt *pkt)
  *
  * A net_pkt slab is used to store meta-information about
  * network packets. It must be coupled with a data fragment pool
- * (:c:macro:`NET_PKT_DATA_POOL_DEFINE`) used to store the actual
+ * (@ref NET_PKT_DATA_POOL_DEFINE) used to store the actual
  * packet data. The macro can be used by an application to define
  * additional custom per-context TX packet slabs (see
- * :c:func:`net_context_setup_pools`).
+ * net_context_setup_pools()).
  *
  * @param name Name of the slab.
  * @param count Number of net_pkt in this slab.
@@ -1345,10 +1345,10 @@ static inline bool net_pkt_filter_local_in_recv_ok(struct net_pkt *pkt)
  *
  * A net_buf pool is used to store actual data for
  * network packets. It must be coupled with a net_pkt slab
- * (:c:macro:`NET_PKT_SLAB_DEFINE`) used to store the packet
+ * (@ref NET_PKT_SLAB_DEFINE) used to store the packet
  * meta-information. The macro can be used by an application to
  * define additional custom per-context TX packet pools (see
- * :c:func:`net_context_setup_pools`).
+ * net_context_setup_pools()).
  *
  * @param name Name of the pool.
  * @param count Number of net_buf in this pool.

--- a/include/zephyr/net/socket_select.h
+++ b/include/zephyr/net/socket_select.h
@@ -35,7 +35,7 @@ typedef struct zsock_fd_set {
  * <http://pubs.opengroup.org/onlinepubs/9699919799/functions/select.html>`__
  * for normative description. This function is provided to ease porting of
  * existing code and not recommended for usage due to its inefficiency,
- * use :c:func:`zsock_poll()` instead. In Zephyr this function works only with
+ * use zsock_poll() instead. In Zephyr this function works only with
  * sockets, not arbitrary file descriptors.
  * This function is also exposed as ``select()``
  * if :kconfig:option:`CONFIG_NET_SOCKETS_POSIX_NAMES` is defined (in which case

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -128,7 +128,7 @@ extern "C" {
 /**
  * @brief The SQE should continue producing CQEs until canceled
  *
- * This flag must exist along :c:macro:`RTIO_SQE_MEMPOOL_BUFFER` and signals that when a read is
+ * This flag must exist along @ref RTIO_SQE_MEMPOOL_BUFFER and signals that when a read is
  * complete. It should be placed back in queue until canceled.
  */
 #define RTIO_SQE_MULTISHOT BIT(4)
@@ -326,7 +326,7 @@ struct rtio_block_pool {
  * The rtio executor along with any objects implementing the rtio_iodev interface are
  * the consumers of submissions and producers of completions.
  *
- * No work is started until rtio_submit is called.
+ * No work is started until rtio_submit() is called.
  */
 struct rtio {
 #ifdef CONFIG_RTIO_SUBMIT_SEM
@@ -378,7 +378,7 @@ extern struct k_mem_partition rtio_partition;
 /**
  * @brief Compute the mempool block index for a given pointer
  *
- * @param[in] r RTIO contex
+ * @param[in] r RTIO context
  * @param[in] ptr Memory pointer in the mempool
  * @return Index of the mempool block associated with the pointer. Or UINT16_MAX if invalid.
  */
@@ -1274,11 +1274,11 @@ static inline int z_impl_rtio_sqe_cancel(struct rtio_sqe *sqe)
  * @brief Copy an array of SQEs into the queue and get resulting handles back
  *
  * Copies one or more SQEs into the RTIO context and optionally returns their generated SQE handles.
- * Handles can be used to cancel events via the :c:func:`rtio_sqe_cancel` call.
+ * Handles can be used to cancel events via the rtio_sqe_cancel() call.
  *
  * @param[in]  r RTIO context
  * @param[in]  sqes Pointer to an array of SQEs
- * @param[out] handle Optional pointer to :c:struct:`rtio_sqe` pointer to store the handle of the
+ * @param[out] handle Optional pointer to @ref rtio_sqe pointer to store the handle of the
  *             first generated SQE. Use NULL to ignore.
  * @param[in]  sqe_count Count of sqes in array
  *


### PR DESCRIPTION
Spotted a few places where Sphinx directive were used within Doxygen comments. Replaced them with proper Doxygen style references.