### PR TITLE
drivers: watchdog: wdt_mcux_imx_wdog: add pinctrl support

### DIFF
--- a/drivers/watchdog/Kconfig.mcux_imx
+++ b/drivers/watchdog/Kconfig.mcux_imx
@@ -7,5 +7,6 @@ config WDT_MCUX_IMX_WDOG
 	bool "MCUX IMX WDOG driver"
 	default y
 	depends on DT_HAS_NXP_IMX_WDOG_ENABLED
+	select PINCTRL
 	help
 	  Enable the mcux imx wdog driver.

--- a/drivers/watchdog/wdt_mcux_imx_wdog.c
+++ b/drivers/watchdog/wdt_mcux_imx_wdog.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT nxp_imx_wdog
 
+#include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/sys_clock.h>
 #include <fsl_wdog.h>
@@ -20,6 +21,7 @@ LOG_MODULE_REGISTER(wdt_mcux_wdog);
 struct mcux_wdog_config {
 	WDOG_Type *base;
 	void (*irq_config_func)(const struct device *dev);
+	const struct pinctrl_dev_config *pcfg;
 };
 
 struct mcux_wdog_data {
@@ -135,8 +137,14 @@ static void mcux_wdog_isr(const struct device *dev)
 static int mcux_wdog_init(const struct device *dev)
 {
 	const struct mcux_wdog_config *config = dev->config;
+	int ret;
 
 	config->irq_config_func(dev);
+
+	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0 && ret != -ENOENT) {
+		return ret;
+	}
 
 	return 0;
 }
@@ -150,9 +158,12 @@ static const struct wdt_driver_api mcux_wdog_api = {
 
 static void mcux_wdog_config_func(const struct device *dev);
 
+PINCTRL_DT_INST_DEFINE(0);
+
 static const struct mcux_wdog_config mcux_wdog_config = {
 	.base = (WDOG_Type *) DT_INST_REG_ADDR(0),
 	.irq_config_func = mcux_wdog_config_func,
+	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };
 
 static struct mcux_wdog_data mcux_wdog_data;

--- a/dts/bindings/watchdog/nxp,imx-wdog.yaml
+++ b/dts/bindings/watchdog/nxp,imx-wdog.yaml
@@ -5,7 +5,7 @@ description: imxRT watchdog
 
 compatible: "nxp,imx-wdog"
 
-include: base.yaml
+include: [base.yaml, pinctrl-device.yaml]
 
 properties:
   reg:


### PR DESCRIPTION
i.MX RT SoC have some pins related to the watchdog. For example, iomuxc_gpio_ad_b0_15_wdog1_rst_b_deb allows WDOG1_RST_B_DEB signal to be used as reset source for i.MX RT10xx boards.