### PR TITLE
drivers: max17048: add alarm triggers

### DIFF
--- a/drivers/fuel_gauge/max17048/CMakeLists.txt
+++ b/drivers/fuel_gauge/max17048/CMakeLists.txt
@@ -6,3 +6,5 @@ zephyr_library_sources(max17048.c)
 
 zephyr_include_directories_ifdef(CONFIG_EMUL_MAX17048 .)
 zephyr_library_sources_ifdef(CONFIG_EMUL_MAX17048 ./emul_max17048.c)
+
+zephyr_library_sources_ifdef(CONFIG_MAX17048_TRIGGER ./max17048_trigger.c)

--- a/drivers/fuel_gauge/max17048/Kconfig
+++ b/drivers/fuel_gauge/max17048/Kconfig
@@ -20,3 +20,8 @@ config EMUL_MAX17048
 	help
 	  It provides readings which follow a simple sequence, thus allowing
 	  test code to check that things are working as expected.
+
+if MAX17048
+	config MAX17048_TRIGGER
+		bool "MAX17048 trigger"
+endif # MAX17048

--- a/drivers/fuel_gauge/max17048/max17048.h
+++ b/drivers/fuel_gauge/max17048/max17048.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Alvaro Garcia Gomez <maxpowel@gmail.com>
+ * Copyright (c) 2023 Fraunhofer AICOS
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +10,8 @@
 #define ZEPHYR_DRIVERS_SENSOR_MAX17048_MAX17048_H_
 
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/fuel_gauge/max17048.h>
 
 #define REGISTER_VCELL      0x02
 #define REGISTER_SOC        0x04
@@ -27,8 +30,61 @@
 #define RESET_COMMAND       0x5400
 #define QUICKSTART_MODE     0x4000
 
+/* CONFIG register */
+#define MAX17048_CONFIG_ALRT  BIT(5)
+
+/* STATUS register */
+#define MAX17048_STATUS_RI   BIT(8)
+#define MAX17048_STATUS_VH   BIT(9)
+#define MAX17048_STATUS_VL   BIT(10)
+#define MAX17048_STATUS_VR   BIT(11)
+#define MAX17048_STATUS_HD   BIT(12)
+#define MAX17048_STATUS_SC   BIT(13)
+#define MAX17048_STATUS_EnVr BIT(14)
+
+#define MAX17048_OVERVOLTAGE_THRESHOLD_MAX (0xFF * 20) /* 1LSB = 20mV */
+#define MAX17048_SOC_THRESHOLD_MAX 32
+#define MAX17048_SOC_THRESHOLD_POR 4
+
+/**
+ * Storage for the fuel gauge private data
+ */
+struct max17048_data {
+	/* Charge as percentage */
+	uint8_t charge;
+	/* Voltage as mV */
+	uint16_t voltage;
+
+	/* Time in minutes */
+	uint16_t time_to_full;
+	uint16_t time_to_empty;
+	/* True if battery chargin, false if discharging */
+	bool charging;
+
+#ifdef CONFIG_MAX17048_TRIGGER
+	const struct device *dev;
+	struct gpio_callback gpio_cb;
+	struct k_work work;
+	max17048_trigger_handler_t trigger_overvoltage_handler;
+	max17048_trigger_handler_t trigger_undervoltage_handler;
+	max17048_trigger_handler_t trigger_low_soc_handler;
+#endif
+};
+
+/**
+ * Storage for the fuel gauge configuration
+ */
 struct max17048_config {
 	struct i2c_dt_spec i2c;
+	struct gpio_dt_spec int_gpio;
+	/* Under-voltage threshold in mV */
+	uint16_t undervoltage_threshold;
+	/* Over-voltage threshold in mV */
+	uint16_t overvoltage_threshold;
+	/* Low SoC value in % */
+	uint8_t low_soc_threshold;
 };
+
+int max17048_trigger_init(const struct device *dev);
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_MAX17048_MAX17048_H_ */

--- a/drivers/fuel_gauge/max17048/max17048_trigger.c
+++ b/drivers/fuel_gauge/max17048/max17048_trigger.c
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2023 Fraunhofer AICOS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <zephyr/drivers/fuel_gauge/max17048.h>
+#include "max17048.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(MAX17048);
+
+/* Forward declaration of internal functions */
+static int max17048_read_register(const struct device *dev, uint8_t registerId, uint16_t *response);
+static int max17048_update_register(const struct device *dev, uint8_t reg, uint16_t mask,
+				    uint16_t val);
+
+static int max17048_clear_alert(const struct device *dev);
+static void max17048_int_callback(const struct device *port, struct gpio_callback *cb,
+				  uint32_t pin);
+static void max17048_int_work(struct k_work *work);
+
+static int max17048_undervoltage_threshold_set(const struct device *dev, const uint16_t voltage);
+static int max17048_overvoltage_threshold_set(const struct device *dev, const uint16_t voltage);
+static int max17048_low_soc_threshold_set(const struct device *dev, const uint8_t soc);
+
+/* Public interface */
+int max17048_trigger_set(const struct device *dev, const enum max17048_trigger_type trigger_type,
+			 max17048_trigger_handler_t handler)
+{
+	struct max17048_data *drv_data = dev->data;
+	const struct max17048_config *drv_config = dev->config;
+	int rc = 0;
+
+	if (dev == NULL || handler == NULL) {
+		return -EINVAL;
+	}
+	switch (trigger_type) {
+	case MAX17048_TRIGGER_UNDERVOLTAGE:
+		rc = max17048_undervoltage_threshold_set(dev, drv_config->undervoltage_threshold);
+		if (rc < 0) {
+			LOG_ERR("Failed to set under-voltage value.");
+		};
+		drv_data->trigger_undervoltage_handler = handler;
+		break;
+	case MAX17048_TRIGGER_OVERVOLTAGE:
+		rc = max17048_overvoltage_threshold_set(dev, drv_config->overvoltage_threshold);
+		if (rc < 0) {
+			LOG_ERR("Failed to set under-voltage value.");
+		};
+		drv_data->trigger_overvoltage_handler = handler;
+		break;
+	case MAX17048_TRIGGER_LOW_SOC:
+		rc = max17048_low_soc_threshold_set(dev, drv_config->low_soc_threshold);
+		if (rc < 0) {
+			LOG_ERR("Failed to set under-voltage value.");
+		};
+		drv_data->trigger_low_soc_handler = handler;
+		break;
+	default:
+		break;
+	}
+	return 0;
+}
+
+int max17048_trigger_init(const struct device *dev)
+{
+	const struct max17048_config *drv_cfg = dev->config;
+	struct max17048_data *drv_data = dev->data;
+	int rc;
+
+	if (dev == NULL) {
+		return -EINVAL;
+	}
+
+	drv_data->dev = dev;
+	drv_data->work.handler = max17048_int_work;
+
+	if (!gpio_is_ready_dt(&drv_cfg->int_gpio)) {
+		LOG_ERR("Interrupt pin is not ready.");
+		return -EIO;
+	}
+
+	if (gpio_pin_configure_dt(&drv_cfg->int_gpio, GPIO_INPUT) < 0) {
+		LOG_ERR("Failed to configure %s pin %d", drv_cfg->int_gpio.port->name,
+			drv_cfg->int_gpio.pin);
+		return -EIO;
+	}
+
+	gpio_init_callback((struct gpio_callback *)&drv_data->gpio_cb, max17048_int_callback,
+			   BIT(drv_cfg->int_gpio.pin));
+
+	rc = gpio_add_callback_dt(&drv_cfg->int_gpio, (struct gpio_callback *)&drv_data->gpio_cb);
+
+	if (rc < 0) {
+		LOG_ERR("Failed to initialize interrupt on %s pin %d", drv_cfg->int_gpio.port->name,
+			drv_cfg->int_gpio.pin);
+		return -EIO;
+	}
+
+	if (gpio_pin_interrupt_configure_dt(&drv_cfg->int_gpio, GPIO_INT_EDGE_TO_ACTIVE) < 0) {
+		LOG_ERR("Failed to configure interrupt on %s pin %d", drv_cfg->int_gpio.port->name,
+			drv_cfg->int_gpio.pin);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+/* Internal functions */
+static void max17048_int_callback(const struct device *port, struct gpio_callback *cb, uint32_t pin)
+{
+	const struct max17048_data *drv_data = CONTAINER_OF(cb, struct max17048_data, gpio_cb);
+
+	/* Temporarily disables interrupt until CONFIG.ALRT is cleared */
+	gpio_pin_interrupt_configure(port, pin, GPIO_INT_DISABLE);
+	k_work_submit((struct k_work *)&drv_data->work);
+}
+
+static void max17048_process_interrupt(const struct device *dev)
+{
+	const struct max17048_data *drv_data = dev->data;
+	uint16_t status;
+
+	max17048_read_register(dev, REGISTER_STATUS, &status);
+
+	if (status & MAX17048_STATUS_VH) {
+		/* Disables over-voltage alarm by setting maximum value. */
+		max17048_overvoltage_threshold_set(dev, MAX17048_OVERVOLTAGE_THRESHOLD_MAX);
+		if (drv_data->trigger_overvoltage_handler) {
+			drv_data->trigger_overvoltage_handler(dev, MAX17048_TRIGGER_OVERVOLTAGE);
+		} else {
+			LOG_WRN("Over-voltage was detected. But, no handler found.");
+		}
+	}
+	if (status & MAX17048_STATUS_VL) {
+		/* Disables under-voltage alarm by setting minimum value. */
+		max17048_undervoltage_threshold_set(dev, 0);
+		if (drv_data->trigger_undervoltage_handler) {
+			drv_data->trigger_undervoltage_handler(dev, MAX17048_TRIGGER_UNDERVOLTAGE);
+		} else {
+			LOG_WRN("Under-voltage was detected. But, no handler found.");
+		}
+	}
+	if (status & MAX17048_STATUS_HD) {
+		if (drv_data->trigger_low_soc_handler) {
+			drv_data->trigger_low_soc_handler(dev, MAX17048_TRIGGER_LOW_SOC);
+		} else {
+			LOG_WRN("Low SoC was detected. But, no handler found.");
+		}
+	}
+}
+
+static void max17048_int_work(struct k_work *work)
+{
+	const struct max17048_data *drv_data =
+		(struct max17048_data *)CONTAINER_OF(work, struct max17048_data, work);
+	const struct device *dev = drv_data->dev;
+	const struct max17048_config *drv_cfg = dev->config;
+
+	max17048_process_interrupt(dev);
+	max17048_clear_alert(dev);
+	/* Sets all bits in STATUS register to 0 */
+	i2c_reg_write_byte_dt(&drv_cfg->i2c, REGISTER_STATUS, 0x00);
+	gpio_pin_interrupt_configure_dt(&drv_cfg->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+}
+
+static int max17048_clear_alert(const struct device *dev)
+{
+	return max17048_update_register(dev, REGISTER_CONFIG, MAX17048_CONFIG_ALRT, 0x0000);
+}
+
+static int max17048_read_register(const struct device *dev, uint8_t registerId, uint16_t *response)
+{
+	uint8_t max17048_buffer[2];
+	const struct max17048_config *cfg = dev->config;
+	int rc = i2c_write_read_dt(&cfg->i2c, &registerId, sizeof(registerId), max17048_buffer,
+				   sizeof(max17048_buffer));
+
+	if (rc != 0) {
+		LOG_ERR("Unable to read register, error %d", rc);
+		return rc;
+	}
+
+	*response = sys_get_be16(max17048_buffer);
+	return 0;
+}
+
+static int max17048_update_register(const struct device *dev, uint8_t reg, uint16_t mask,
+				    uint16_t val)
+{
+	int ret;
+	const struct max17048_config *drv_config = dev->config;
+	uint16_t old_val, verification;
+	uint8_t buf[2];
+
+	max17048_read_register(dev, reg, &old_val);
+	val = (old_val & ~mask) | (val & mask);
+	buf[0] = (uint8_t)(val >> 8);
+	buf[1] = (uint8_t)(val);
+	ret = i2c_burst_write_dt(&drv_config->i2c, reg, buf, 2);
+	max17048_read_register(dev, reg, &verification);
+	if (verification != val) {
+		return -1;
+	}
+	return ret;
+}
+
+static int max17048_undervoltage_threshold_set(const struct device *dev, const uint16_t voltage)
+{
+	const struct max17048_config *drv_config = dev->config;
+	uint16_t converted_val;
+	uint8_t new_reg_val;
+
+	if (dev == NULL || voltage > MAX17048_OVERVOLTAGE_THRESHOLD_MAX) {
+		return -EINVAL;
+	}
+
+	/* 1LSB = 20mV */
+	converted_val = voltage / 20;
+	new_reg_val = converted_val;
+
+	return i2c_reg_write_byte_dt(&drv_config->i2c, REGISTER_VALRT, converted_val);
+}
+
+static int max17048_overvoltage_threshold_set(const struct device *dev, const uint16_t voltage)
+{
+	const struct max17048_config *drv_config = dev->config;
+	uint16_t converted_val;
+	uint8_t new_reg_val;
+
+	if (dev == NULL || voltage > MAX17048_OVERVOLTAGE_THRESHOLD_MAX) {
+		return -EINVAL;
+	}
+
+	/* 1LSB = 20mV */
+	converted_val = voltage / 20;
+	new_reg_val = converted_val;
+
+	return i2c_reg_write_byte_dt(&drv_config->i2c, REGISTER_VALRT + 1, converted_val);
+}
+
+static int max17048_low_soc_threshold_set(const struct device *dev, const uint8_t soc)
+{
+	uint8_t reg_val;
+
+	if (dev == NULL || soc > MAX17048_SOC_THRESHOLD_MAX || soc < 1) {
+		return -EINVAL;
+	}
+
+	reg_val = MAX17048_SOC_THRESHOLD_MAX - soc;
+
+	return max17048_update_register(dev, REGISTER_CONFIG, 0x001F, reg_val);
+}

--- a/dts/bindings/fuel-gauge/maxim,max17048.yaml
+++ b/dts/bindings/fuel-gauge/maxim,max17048.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2023 Alvaro Garcia Gomez <maxpowel@gmail.com>
+# Copyright (c) 2023 Fraunhofer AICOS
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -8,3 +9,22 @@ description: |
 compatible: "maxim,max17048"
 
 include: [i2c-device.yaml, fuel-gauge.yaml]
+
+properties:
+  int-gpios:
+    type: phandle-array
+  overvoltage-threshold:
+    description: |
+      Overvoltage in mV. If triggers are enabled, an interrupt is triggered upon
+      this value is reached.
+    type: int
+  undervoltage-threshold:
+    description: |
+      Undervoltage in mV. If triggers are enabled, an interrupt is triggered upon
+      this value is reached.
+    type: int
+  low-soc-threshold:
+    description: |
+      Empty alert threshold in %. If triggers are enabled, an interrupt is
+      triggered when this SOC value is crossed.
+    type: int

--- a/include/zephyr/drivers/fuel_gauge/max17048.h
+++ b/include/zephyr/drivers/fuel_gauge/max17048.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 Fraunhofer AICOS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_MAX17048_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_MAX17048_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Type of event triggers on MAX17048
+ */
+enum max17048_trigger_type {
+	/*!< Voltage is above over-voltage threshold (single trigger) */
+	MAX17048_TRIGGER_OVERVOLTAGE,
+	/*!< Voltage is under under-voltage threshold (single trigger) */
+	MAX17048_TRIGGER_UNDERVOLTAGE,
+	/*!< Voltage is under low-soc threshold */
+	MAX17048_TRIGGER_LOW_SOC,
+};
+
+typedef void (*max17048_trigger_handler_t)(const struct device *dev,
+					   const enum max17048_trigger_type evt_type);
+
+/**
+ * @brief Enables alarm for specified MAX17048 trigger event.
+ *
+ * This function enables the trigger for \p trigger_type events and sets \p handler as a callback
+ * function. Be aware that some events are single triggered (MAX17048_TRIGGER_OVERVOLTAGE and
+ * MAX17048_TRIGGER_UNDERVOLTAGE) and require you to call this function after the alarm is triggered
+ * to reactivate the alarm for such events.
+ *
+ * @param dev Pointer to the max17048 device.
+ * @param trigger_type Type of trigger to be enabled by the function.
+ * @param handler Event handler to be called uppon \p trigger_event event occurs.
+ */
+int max17048_trigger_set(const struct device *dev, const enum max17048_trigger_type trigger_type,
+			 max17048_trigger_handler_t handler);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_MAX17048_H_ */


### PR DESCRIPTION
	* Change location of max17048_data structure declaration to header file
	* Add int-gpio, overvoltage-threshold, undervoltage-threshold and low-soc-threshold properties to max17048 dt binding;
	* Add interrupt pin to driver cofiguration structure
	* Add MAX17048_TRIGGER Kconfig
	* Add max17048_trigger_type to identify different alarm triggers
	* Add max17048_trigger_set() to enable triggers and set callbacks