### PR TITLE
subsys: canbus: isotp: replace internal z_timeout with k_timer

### DIFF
--- a/include/zephyr/canbus/isotp.h
+++ b/include/zephyr/canbus/isotp.h
@@ -391,7 +391,7 @@ struct isotp_send_ctx {
 		};
 	};
 	struct k_work work;
-	struct _timeout timeout;
+	struct k_timer timer;
 	union {
 		struct isotp_callback fin_cb;
 		struct k_sem fin_sem;
@@ -421,7 +421,7 @@ struct isotp_recv_ctx {
 	uint32_t length;
 	int error_nr;
 	struct k_work work;
-	struct _timeout timeout;
+	struct k_timer timer;
 	struct k_fifo fifo;
 	struct isotp_msg_id rx_addr;
 	struct isotp_msg_id tx_addr;


### PR DESCRIPTION
The use of private APIs `z_add_timeout()` and friends is not recommended.

With this commit, usual kernel timer APIs are used.

This is the most straightforward fix, as the previous implementation essentially bypassed the `k_timer` APIs, potentially to avoid some overhead introduced by the official kernel APIs.

I will revisit the state machine and consider using work queues in upcoming ISO-TP subsystem revamp (see #59896).

Fixes #61738