### PR TITLE
ipc_service: static_vrings: Fix buffer sizing

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.h
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.h
@@ -163,5 +163,5 @@ static inline unsigned int optimal_num_desc(size_t mem_size, unsigned int buf_si
 		num_desc++;
 	}
 
-	return (1 << (find_msb_set(num_desc) - 1));
+	return (1 << (find_msb_set(--num_desc) - 1));
 }


### PR DESCRIPTION
How many times can I possibly make mistakes on the same function?

Fix this function once again, hoping it is the last time. We are returning an optimal number of buffers that is off-by-one. In some cases this leads to memory corruption. Fix this.