### PR TITLE
[RFC] Partially decouple devices from SYS_INIT

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -51,9 +51,7 @@ extern "C" {
  * than a pointer. The device.h API mainly uses handles to store lists of
  * multiple devices in a compact way.
  *
- * The extreme values and zero have special significance. Negative values
- * identify functionality that does not correspond to a Zephyr device, such as
- * the system clock or a SYS_INIT() function.
+ * The negative, extreme values and zero have special significance.
  *
  * @see device_handle_get()
  * @see device_from_handle()

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -42,80 +42,13 @@ extern "C" {
  *   SMP.
  *
  * Initialization priority can take a value in the range of 0 to 99.
- *
- * @note The same infrastructure is used by devices.
  * @{
  */
 
-struct device;
-
-/**
- * @brief Initialization function for init entries.
- *
- * Init entries support both the system initialization and the device
- * APIs. Each API has its own init function signature; hence, we have a
- * union to cover both.
- */
-union init_function {
-	/**
-	 * System initialization function.
-	 *
-	 * @retval 0 On success
-	 * @retval -errno If init fails.
-	 */
-	int (*sys)(void);
-	/**
-	 * Device initialization function.
-	 *
-	 * @param dev Device instance.
-	 *
-	 * @retval 0 On success
-	 * @retval -errno If device initialization fails.
-	 */
-	int (*dev)(const struct device *dev);
-};
-
-/**
- * @brief Structure to store initialization entry information.
- *
- * @internal
- * Init entries need to be defined following these rules:
- *
- * - Their name must be set using Z_INIT_ENTRY_NAME().
- * - They must be placed in a special init section, given by
- *   Z_INIT_ENTRY_SECTION().
- * - They must be aligned, e.g. using Z_DECL_ALIGN().
- *
- * See SYS_INIT_NAMED() for an example.
- * @endinternal
- */
-struct init_entry {
-	/** Initialization function. */
-	union init_function init_fn;
-	/**
-	 * If the init entry belongs to a device, this fields stores a
-	 * reference to it, otherwise it is set to NULL.
-	 */
-	const struct device *dev;
-};
+/** System initialization function. */
+typedef int (*sys_init_fn_t)(void);
 
 /** @cond INTERNAL_HIDDEN */
-
-/* Helper definitions to evaluate level equality */
-#define Z_INIT_EARLY_EARLY		 1
-#define Z_INIT_PRE_KERNEL_1_PRE_KERNEL_1 1
-#define Z_INIT_PRE_KERNEL_2_PRE_KERNEL_2 1
-#define Z_INIT_POST_KERNEL_POST_KERNEL	 1
-#define Z_INIT_APPLICATION_APPLICATION	 1
-#define Z_INIT_SMP_SMP			 1
-
-/* Init level ordinals */
-#define Z_INIT_ORD_EARLY	0
-#define Z_INIT_ORD_PRE_KERNEL_1 1
-#define Z_INIT_ORD_PRE_KERNEL_2 2
-#define Z_INIT_ORD_POST_KERNEL	3
-#define Z_INIT_ORD_APPLICATION	4
-#define Z_INIT_ORD_SMP		5
 
 /**
  * @brief Obtain init entry name.
@@ -131,28 +64,11 @@ struct init_entry {
  * linker scripts to sort them according to the specified
  * level/priority/sub-priority.
  */
-#define Z_INIT_ENTRY_SECTION(level, prio, sub_prio)                           \
-	__attribute__((__section__(                                           \
-		".z_init_" #level STRINGIFY(prio)"_" STRINGIFY(sub_prio)"_")))
+#define Z_INIT_ENTRY_SECTION(level, prio)                                      \
+	__attribute__(                                                         \
+		(__section__(".z_init_" #level STRINGIFY(prio)"_")))
 
 /** @endcond */
-
-/**
- * @brief Obtain the ordinal for an init level.
- *
- * @param level Init level (EARLY, PRE_KERNEL_1, PRE_KERNEL_2, POST_KERNEL,
- * APPLICATION, SMP).
- *
- * @return Init level ordinal.
- */
-#define INIT_LEVEL_ORD(level)                                                  \
-	COND_CODE_1(Z_INIT_EARLY_##level, (Z_INIT_ORD_EARLY),                  \
-	(COND_CODE_1(Z_INIT_PRE_KERNEL_1_##level, (Z_INIT_ORD_PRE_KERNEL_1),   \
-	(COND_CODE_1(Z_INIT_PRE_KERNEL_2_##level, (Z_INIT_ORD_PRE_KERNEL_2),   \
-	(COND_CODE_1(Z_INIT_POST_KERNEL_##level, (Z_INIT_ORD_POST_KERNEL),     \
-	(COND_CODE_1(Z_INIT_APPLICATION_##level, (Z_INIT_ORD_APPLICATION),     \
-	(COND_CODE_1(Z_INIT_SMP_##level, (Z_INIT_ORD_SMP),                     \
-	(ZERO_OR_COMPILE_ERROR(0)))))))))))))
 
 /**
  * @brief Register an initialization function.
@@ -180,19 +96,16 @@ struct init_entry {
  * same init function.
  *
  * @param name Unique name for SYS_INIT entry.
- * @param init_fn_ See SYS_INIT().
+ * @param init_fn See SYS_INIT().
  * @param level See SYS_INIT().
  * @param prio See SYS_INIT().
  *
  * @see SYS_INIT()
  */
-#define SYS_INIT_NAMED(name, init_fn_, level, prio)                            \
-	static const Z_DECL_ALIGN(struct init_entry)                           \
-		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan           \
-		Z_INIT_ENTRY_NAME(name) = {                                    \
-			.init_fn = {.sys = (init_fn_)},                        \
-			.dev = NULL,                                           \
-	}
+#define SYS_INIT_NAMED(name, init_fn, level, prio)                             \
+	static const Z_DECL_ALIGN(sys_init_fn_t)                               \
+		Z_INIT_ENTRY_SECTION(level, prio) __used __noasan              \
+		Z_INIT_ENTRY_NAME(name) = init_fn
 
 /** @} */
 

--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -20,7 +20,30 @@
 		__init_end = .;
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-	ITERABLE_SECTION_ROM_NUMERIC(device, 4)
+	/* HACK: needs a new iterable "sub-section" API */
+	SECTION_PROLOGUE(device_area,,)
+	{
+		_device_list_start = .;
+		_device_list_EARLY_start = .;
+		KEEP(*(SORT(._device.static.EARLY_?_*)));
+		KEEP(*(SORT(._device.static.EARLY_??_*)));
+		_device_list_PRE_KERNEL_1_start = .;
+		KEEP(*(SORT(._device.static.PRE_KERNEL_1_?_*)));
+		KEEP(*(SORT(._device.static.PRE_KERNEL_1_??_*)));
+		_device_list_PRE_KERNEL_2_start = .;
+		KEEP(*(SORT(._device.static.PRE_KERNEL_2_?_*)));
+		KEEP(*(SORT(._device.static.PRE_KERNEL_2_??_*)));
+		_device_list_POST_KERNEL_start = .;
+		KEEP(*(SORT(._device.static.POST_KERNEL_?_*)));
+		KEEP(*(SORT(._device.static.POST_KERNEL_??_*)));
+		_device_list_APPLICATION_start = .;
+		KEEP(*(SORT(._device.static.APPLICATION_?_*)));
+		KEEP(*(SORT(._device.static.APPLICATION_??_*)));
+		_device_list_SMP_start = .;
+		KEEP(*(SORT(._device.static.SMP_?_*)));
+		KEEP(*(SORT(._device.static.SMP_??_*)));
+		_device_list_end = .;
+	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 #if defined(CONFIG_GEN_SW_ISR_TABLE) && !defined(CONFIG_DYNAMIC_INTERRUPTS)
 	SECTION_PROLOGUE(sw_isr_table,,)

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -61,13 +61,13 @@ static K_KERNEL_PINNED_STACK_ARRAY_DEFINE(z_idle_stacks,
 					  CONFIG_IDLE_STACK_SIZE);
 #endif /* CONFIG_MULTITHREADING */
 
-extern const struct init_entry __init_start[];
-extern const struct init_entry __init_EARLY_start[];
-extern const struct init_entry __init_PRE_KERNEL_1_start[];
-extern const struct init_entry __init_PRE_KERNEL_2_start[];
-extern const struct init_entry __init_POST_KERNEL_start[];
-extern const struct init_entry __init_APPLICATION_start[];
-extern const struct init_entry __init_end[];
+extern const sys_init_fn_t __init_start[];
+extern const sys_init_fn_t __init_EARLY_start[];
+extern const sys_init_fn_t __init_PRE_KERNEL_1_start[];
+extern const sys_init_fn_t __init_PRE_KERNEL_2_start[];
+extern const sys_init_fn_t __init_POST_KERNEL_start[];
+extern const sys_init_fn_t __init_APPLICATION_start[];
+extern const sys_init_fn_t __init_end[];
 
 extern const struct device _device_list_EARLY_start[];
 extern const struct device _device_list_PRE_KERNEL_1_start[];
@@ -89,7 +89,7 @@ enum init_level {
 };
 
 #ifdef CONFIG_SMP
-extern const struct init_entry __init_SMP_start[];
+extern const sys_init_fn_t __init_SMP_start[];
 
 extern const struct device _device_list_SMP_start[];
 #endif
@@ -266,7 +266,7 @@ static void z_sys_init_run_level(enum init_level level)
 		_device_list_end,
 	};
 
-	static const struct init_entry *levels[] = {
+	static const sys_init_fn_t *levels[] = {
 		__init_EARLY_start,
 		__init_PRE_KERNEL_1_start,
 		__init_PRE_KERNEL_2_start,
@@ -306,8 +306,8 @@ static void z_sys_init_run_level(enum init_level level)
 		}
 	}
 
-	for (const struct init_entry *entry = levels[level]; entry < levels[level+1]; entry++) {
-		(void)entry->init_fn.sys();
+	for (const sys_init_fn_t *entry = levels[level]; entry < levels[level+1]; entry++) {
+		(void)(*entry)();
 	}
 }
 

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -62,43 +62,6 @@ DEVICE_DT_DEFINE(TEST_NOLABEL, dev_init, NULL,
 #define DEV_HDL(node_id) device_handle_get(DEVICE_DT_GET(node_id))
 #define DEV_HDL_NAME(name) device_handle_get(DEVICE_GET(name))
 
-ZTEST(devicetree_devices, test_init_get)
-{
-	/* Check device pointers */
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->dev,
-		      DEVICE_DT_GET(TEST_GPIO), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->dev,
-		      DEVICE_DT_GET(TEST_I2C), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->dev,
-		      DEVICE_DT_GET(TEST_DEVA), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->dev,
-		      DEVICE_DT_GET(TEST_DEVB), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->dev,
-		      DEVICE_DT_GET(TEST_GPIOX), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->dev,
-		      DEVICE_DT_GET(TEST_DEVC), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->dev,
-		      DEVICE_DT_GET(TEST_PARTITION), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->dev,
-		      DEVICE_DT_GET(TEST_GPIO_INJECTED), NULL);
-	zassert_equal(DEVICE_INIT_GET(manual_dev)->dev,
-		      DEVICE_GET(manual_dev), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->dev,
-		      DEVICE_DT_GET(TEST_NOLABEL), NULL);
-
-	/* Check init functions */
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_GET(manual_dev)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->init_fn.dev, dev_init);
-}
-
 ZTEST(devicetree_devices, test_init_order)
 {
 	zassert_equal(init_order[0], DEV_HDL(TEST_GPIO));

--- a/tests/misc/check_init_priorities/CMakeLists.txt
+++ b/tests/misc/check_init_priorities/CMakeLists.txt
@@ -5,8 +5,9 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 set(output_file ${PROJECT_BINARY_DIR}/check_init_priorities_output.txt)
 
-add_custom_target(
-	check_init_priorities_output
+add_custom_command(
+  TARGET app
+  POST_BUILD
 	COMMENT "Running check_init_priorities.py"
 	COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/check_init_priorities.py
 	  --verbose
@@ -15,11 +16,7 @@ add_custom_target(
 	  --always-succeed
 	COMMAND ${PYTHON_EXECUTABLE} ${APPLICATION_SOURCE_DIR}/validate_check_init_priorities_output.py
 	  ${output_file}
-	DEPENDS zephyr_pre0
 )
-if (TARGET zephyr_pre1)
-  add_dependencies(zephyr_pre1 check_init_priorities_output)
-endif()
 
 project(check_init_priorities)
 

--- a/tests/misc/check_init_priorities/prj.conf
+++ b/tests/misc/check_init_priorities/prj.conf
@@ -1,4 +1,1 @@
-# Required to force 2 stage linking
-CONFIG_DEVICE_DEPS=y
-
 CONFIG_CHECK_INIT_PRIORITIES=n


### PR DESCRIPTION
## Background

Nowadays, devices rely on the `init.h` (i.e. `SYS_INIT`) infrastructure to get initialized automatically. The `init.h` infrastructure is a basic mechanism that allows to register an init function when the system is initialized (before `main`). It provides with multiple initialization levels: `PRE_KERNEL_*`, `POST_KERNEL`, etc., and within each level a numeric priority (0-99). Using this information, each registered init entry is sorted by the linker so that the Kernel can later iterate
over them in the correct order. This all sounds nice and simple, but when it comes to devices, this mechanism has proven to be insufficient.

Before starting with the changes proposed in this patch, let's first dig into the implementation details of the current model. When devices are defined, using any of the `DEVICE_*DEFINE` macros, they also create an init entry using the internal `init.h` APIs (see `Z_DEVICE_INIT_ENTRY_DEFINE`). This entry, stores a pointer to the device init call and to the device itself. As the reader can imagine, this implies a coupling between `init.h` and `device.h`. The only link between a device and an init entry is the device pointer stored in the init entry. This allows the Kernel init machinery to call the init
function with the right device pointer. However, there is no direct relationship between a device and its init function, that is, `struct device` does not keep the device init function reference. This is not a problem nowadays, but it could be a problem if features like deferred initialization or init/de-init have to be implemented. However, in reality, this is a _secondary_ problem. The most problematic issue we have today is that devices are mixed with `SYS_INIT` calls. They are all part of the same init block, and are treated equally. So for example, one can theoretically have a system where the init sequence can be like:

```
- PRE_KERNEL_1
  - init call 1
  - device 0
  - init call 2
  - init call 3
  - device 1
  - device 2
  - init call 4
- PRE_KERNEL_2
  - init call 5
  - device 3
  ...
```

This is problematic because:

(1) Init calls can depend on devices, but dependency is not tracked anywhere. So the user must check that init priorities are correct to avoid runtime failures.
(2) Device drivers can have multiple instances, and each instance may require a different set of priorities, while `SYS_INIT` calls are singletons.
(3) Devices don't likely need so many init priorities (`SMP`?  `APPLICATION`?)

(1) is particularly important because init calls do not have a specific purpose. They usage ranges from SoC init code, to system services. So it's _unpredictable_ what can happen in there. (2) is a tangential topic, actually not fixed by this patch, even though it helps. (3) is more of a post-patch cleanup we need.

## So, what does this patch propose...?

**First, this patch is still a HACK, so please, focus on the description rather than with the implementation**

So it's about providing devices with their own init infrastructure,
minimizing the coupling with init.h. This patch groups devices in a
separate section, but, keeps the same init levels as before. Therefore, the list
above would look like:

```
/* devices */
- PRE_KERNEL_1
  - device 0
  - device 1
  - device 2
- PRE_KERNEL_2
  - device 3
  ...

/* init calls */
- PRE_KERNEL_1
  - init call 1
  - init call 2
  - init call 3
  - init call 4
- PRE_KERNEL_2
  - init call 5
  ...
```

This means that **it is no longer possible** to mix init calls and devices within the same level. So how does it work now? Within each level, devices are initialized first, then init calls. It is done this way because I believe it is init calls who depend on devices and not vice versa. I may be wrong, and so the whole proposal would need a rework. So the init order would look like:

```
- PRE_KERNEL_1
  - device 0
  - device 1
  - device 2
  - init call 1
  - init call 2
  - init call 3
  - init call 4
- PRE_KERNEL_2
  - device 3
  - init call 5
  ...
```

## Why does this matter for future development?

First, we have devices grouped at least on a level basis. This means that we could likely start using devicetree ordinals, by reducing the source of problems to the init level only. We can also re-think device init levels (probably init levels as well, hey `PRE_KERNEL_1/2`). For example, there could be pre-kernel and post-kernel devices only. The other side effect of this change is that `struct device` stores the device init call, so we can potentially do things like defer device initialization or implement things like init/de-init. They all come with their own complexity, of course, but this patch could be a step forward.

## Problems

This is a breaking change. Sorry, guys, another one to the list. The API does not change, so builds should continue to work. However, the system changes its behavior, so if anyone was relying on mixed init call/device sequences, things will break. This is why it is important to analyze lots of use cases before moving forward with this proposal.