### PR TITLE
drivers: adc: adc_sam0: fix c20 and c21 reference not setting

### DIFF
--- a/soc/arm/atmel_sam0/samc20/soc.h
+++ b/soc/arm/atmel_sam0/samc20/soc.h
@@ -52,6 +52,8 @@
 
 #endif /* _ASMLANGUAGE */
 
+#define ADC_SAM0_REFERENCE_ENABLE_PROTECTED
+
 #include "adc_fixup_sam0.h"
 #include "../common/soc_port.h"
 #include "../common/atmel_sam0_dt.h"

--- a/soc/arm/atmel_sam0/samc21/soc.h
+++ b/soc/arm/atmel_sam0/samc21/soc.h
@@ -52,6 +52,8 @@
 
 #endif /* _ASMLANGUAGE */
 
+#define ADC_SAM0_REFERENCE_ENABLE_PROTECTED
+
 #include "adc_fixup_sam0.h"
 #include "../common/soc_port.h"
 #include "../common/atmel_sam0_dt.h"


### PR DESCRIPTION
drivers: adc: adc_sam0: fix c20 and c21 reference not setting

On c20 and c21 variants, the adc_sam0 driver is failing to honor the enable-protected status of the REFCTRL register when writing the channel config's reference into it. This causes the reference to never be set when adc_sam0_channel_setup is called since the ADC is not disabled prior to the write. Fix it by adding the ADC_SAM0_REFERENCE_ENABLE_PROTECTED definition to the c20 and c21 soc.h files. This effectively disables the ADC during writes to the REFCTRL register, thus honoring the enable-protected behavior of this register. I'm assuming ADC_SAM0_REFERENCE_ENABLE_PROTECTED exists for this type of situation and therefore this was the approach taken. After making the change, I was able to verify proper ADC readings by measuring voltage on an ADC pin and observing correct values. Reverting back prior to this change, running the same test yields reading 0's.

Fixes: #61975