### PR TITLE
Automatically generate API overview documentation

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -68,6 +68,8 @@
 
 @brief Modem APIs
 @defgroup modem Modem APIs
+@since 3.5
+@version 0.1.0
 @{
 @}
 

--- a/doc/_extensions/zephyr/api_overview.py
+++ b/doc/_extensions/zephyr/api_overview.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import doxmlparser
+
+from docutils import nodes
+from doxmlparser.compound import DoxCompoundKind
+from pathlib import Path
+from sphinx.application import Sphinx
+from sphinx.util.docutils import SphinxDirective
+from typing import Any, Dict
+
+
+class ApiOverview(SphinxDirective):
+    """
+    This is a Zephyr directive to generate a table containing an overview
+    of all APIs. This table will show the API name, version and since which
+    version it is present - all information extracted from Doxygen XML output.
+
+    It is exclusively used by the doc/develop/api/overview.rst page.
+
+    Configuration options:
+
+    api_overview_doxygen_xml_dir: Doxygen xml output directory
+    api_overview_doxygen_base_url: Doxygen base html directory
+    """
+
+    def run(self):
+        return [self.env.api_overview_table]
+
+
+def get_group(innergroup, all_groups):
+    try:
+        return [
+            g
+            for g in all_groups
+            if g.get_compounddef()[0].get_id() == innergroup.get_refid()
+        ][0]
+    except IndexError as e:
+        raise Exception(f"Unexpected group {innergroup.get_refid()}") from e
+
+
+def visit_group(app, group, all_groups, rows, indent=0):
+    version = since = ""
+    github_uri = "https://github.com/zephyrproject-rtos/zephyr/releases/tag/"
+    cdef = group.get_compounddef()[0]
+
+    ssects = [
+        s for p in cdef.get_detaileddescription().get_para() for s in p.get_simplesect()
+    ]
+    for sect in ssects:
+        if sect.get_kind() == "since":
+            since = sect.get_para()[0].get_valueOf_()
+        elif sect.get_kind() == "version":
+            version = sect.get_para()[0].get_valueOf_()
+
+    if since:
+        since_url = nodes.inline()
+        reference = nodes.reference(text=f"v{since.strip()}.0", refuri=f"{github_uri}/v{since.strip()}.0")
+        reference.attributes["internal"] = True
+        since_url += reference
+    else:
+        since_url = nodes.Text("")
+
+    url_base = Path(app.config.api_overview_doxygen_base_url)
+    url = url_base / f"{cdef.get_id()}.html"
+
+    title = cdef.get_title()
+
+    row_node = nodes.row()
+
+    # Next entry will contain the spacer and the link with API name
+    entry = nodes.entry()
+    span = nodes.Text("".join(["\U000000A0"] * indent))
+    entry += span
+
+    # API name with link
+    inline = nodes.inline()
+    reference = nodes.reference(text=title, refuri=str(url))
+    reference.attributes["internal"] = True
+    inline += reference
+    entry += inline
+    row_node += entry
+
+    version_node = nodes.Text(version)
+    # Finally, add version and since
+    for cell in [version_node, since_url]:
+        entry = nodes.entry()
+        entry += cell
+        row_node += entry
+    rows.append(row_node)
+
+    for innergroup in cdef.get_innergroup():
+        visit_group(
+            app, get_group(innergroup, all_groups), all_groups, rows, indent + 6
+        )
+
+
+def parse_xml_dir(dir_name):
+    groups = []
+    root = doxmlparser.index.parse(Path(dir_name) / "index.xml", True)
+    for compound in root.get_compound():
+        if compound.get_kind() == DoxCompoundKind.GROUP:
+            file_name = Path(dir_name) / f"{compound.get_refid()}.xml"
+            groups.append(doxmlparser.compound.parse(file_name, True))
+
+    return groups
+
+
+def generate_table(app, toplevel, groups):
+    table = nodes.table()
+    tgroup = nodes.tgroup()
+
+    thead = nodes.thead()
+    thead_row = nodes.row()
+    for header_name in ["API", "Version", "Available in Zephyr Since"]:
+        colspec = nodes.colspec()
+        tgroup += colspec
+
+        entry = nodes.entry()
+        entry += nodes.Text(header_name)
+        thead_row += entry
+    thead += thead_row
+    tgroup += thead
+
+    rows = []
+    tbody = nodes.tbody()
+    for t in toplevel:
+        visit_group(app, t, groups, rows)
+    tbody.extend(rows)
+    tgroup += tbody
+
+    table += tgroup
+
+    return table
+
+
+def sync_contents(app: Sphinx) -> None:
+    if app.config.doxyrunner_outdir:
+        doxygen_out_dir = Path(app.config.doxyrunner_outdir)
+    else:
+        doxygen_out_dir = Path(app.outdir) / "_doxygen"
+
+    doxygen_xml_dir = doxygen_out_dir / "xml"
+    groups = parse_xml_dir(doxygen_xml_dir)
+
+    toplevel = [
+        g
+        for g in groups
+        if g.get_compounddef()[0].get_id()
+        not in [
+            i.get_refid()
+            for h in [j.get_compounddef()[0].get_innergroup() for j in groups]
+            for i in h
+        ]
+    ]
+
+    app.builder.env.api_overview_table = generate_table(app, toplevel, groups)
+
+
+def setup(app) -> Dict[str, Any]:
+    app.add_config_value("api_overview_doxygen_xml_dir", "html/doxygen/xml", "env")
+    app.add_config_value("api_overview_doxygen_base_url", "../../doxygen/html", "env")
+
+    app.add_directive("api-overview-table", ApiOverview)
+
+    app.connect("builder-inited", sync_contents)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -95,6 +95,7 @@ extensions = [
     "sphinx_togglebutton",
     "zephyr.external_content",
     "zephyr.domain",
+    "zephyr.api_overview",
 ]
 
 # Only use SVG converter when it is really needed, e.g. LaTeX.
@@ -364,6 +365,9 @@ linkcheck_timeout = 30
 linkcheck_workers = 10
 linkcheck_anchors = False
 
+# -- Options for zephyr.api_overview --------------------------------------
+
+api_overview_doxygen_base_url = "../../doxygen/html"
 
 def setup(app):
     # theme customizations

--- a/doc/develop/api/api_lifecycle.rst
+++ b/doc/develop/api/api_lifecycle.rst
@@ -20,6 +20,9 @@ no longer optimal or supported by the underlying platforms.
 An up-to-date table of all APIs and their maturity level can be found in the
 :ref:`api_overview` page.
 
+
+.. _api_lifecycle_experimental:
+
 Experimental
 *************
 
@@ -36,6 +39,10 @@ The following requirements apply to all new APIs:
   of said API (in the case of peripheral APIs, this corresponds to one driver)
 - At least one sample using the new API (may only build on one single board)
 
+When introducing a new and experimental API, mark the API version in the headers
+where the API is defined. An experimental API shall have a version where the minor
+version is up to one (0.1.z). (see `api overview <api_overview>`)
+
 Peripheral APIs (Hardware Related)
 ==================================
 
@@ -46,12 +53,18 @@ the Architecture working group consisting of representatives from different vend
 The API shall be promoted to ``unstable`` when it has at least two
 implementations on different hardware platforms.
 
+.. _api_lifecycle_unstable:
+
 Unstable
 ********
 
 The API is in the process of settling, but has not yet had sufficient real-world
 testing to be considered stable. The API is considered generic in nature and can
 be used on different hardware platforms.
+
+When the API changes status to unstable API, mark the API version in the headers
+where the API is defined. Unstable APIs shall have a version where the minor
+version is larger than one (0.y.z | y > 1 ). (see `api overview <api_overview>`)
 
 .. note::
 
@@ -68,6 +81,8 @@ Hardware Agnostic APIs
 
 For hardware agnostic APIs, multiple applications using it are required to
 promote an API from ``experimental`` to ``unstable``.
+
+.. _api_lifecycle_stable:
 
 Stable
 *******
@@ -93,6 +108,11 @@ In order to declare an API ``stable``, the following steps need to be followed:
 #. The Pull Request must be submitted for discussion in the next
    `Zephyr Architecture meeting`_ where, barring any objections, the Pull Request
    will be merged
+
+
+When the API changes status to stable API, mark the API version in the headers
+where the API is defined. Stable APIs shall have a version where the major
+version is one or larger (x.y.z | x >= 1 ). (see `api overview <api_overview>`)
 
 .. _breaking_api_changes:
 
@@ -174,6 +194,11 @@ for it to be discussed and ultimately even voted on in the `Zephyr TSC meeting`_
 
 If the Pull Request is merged then an email must be sent to the ``devel`` and
 ``user`` mailing lists informing them of the change.
+
+The API version shall be changed to signal backward incompatible changes. This
+is achieved by incrementing the major version (X.y.z | X > 1).  It MAY also
+include minor and patch level changes. Patch and minor versions MUST be reset to
+0 when major version is incremented. (see `api overview <api_overview>`)
 
 .. note::
 

--- a/doc/develop/api/overview.rst
+++ b/doc/develop/api/overview.rst
@@ -7,388 +7,49 @@ The table lists Zephyr's APIs and information about them, including their
 current :ref:`stability level <api_lifecycle>`.  More details about API changes
 between major releases are available in the :ref:`zephyr_release_notes`.
 
-.. Keep this list sorted by the name of the API as it appears
-   in the HTML, *NOT* the :ref: label
+The version column uses `semantic version <https://semver.org/>`_, and has the
+following expectations:
 
-.. list-table::
-   :header-rows: 1
+ * Major version zero (0.y.z) is for initial development. Anything MAY
+   change at any time. The public API SHOULD NOT be considered stable.
 
-   * - API
-     - Status
-     - Version Introduced
+   * If minor version is up to one (0.1.z), API is considered
+     :ref:`experimental <api_lifecycle_experimental>`.
+   * If minor version is larger than one (0.y.z | y > 1), API is considered
+     :ref:`unstable <api_lifecycle_unstable>`.
 
-   * - :ref:`adc_api`
-     - Stable
-     - 1.0
+ * Version 1.0.0 defines the public API. The way in which the version number
+   is incremented after this release is dependent on this public API and how it
+   changes.
 
-   * - :ref:`audio_codec_api`
-     - Experimental
-     - 1.13
+   * APIs with major versions equal or larger than one (x.y.z | x >= 1 ) are
+     considered :ref:`stable <api_lifecycle_stable>`.
+   * All existing stable APIs in Zephyr will be start with version 1.0.0.
 
-   * - :ref:`audio_dmic_api`
-     - Experimental
-     - 1.13
+ * Patch version Z (x.y.Z | x > 0) MUST be incremented if only backwards
+   compatible bug fixes are introduced. A bug fix is defined as an internal
+   change that fixes incorrect behavior.
 
-   * - :ref:`auxdisplay_api`
-     - Experimental
-     - 3.4
+ * Minor version Y (x.Y.z | x > 0) MUST be incremented if new, backwards
+   compatible functionality is introduced to the public API. It MUST be
+   incremented if any public API functionality is marked as deprecated. It MAY
+   be incremented if substantial new functionality or improvements are
+   introduced within the private code. It MAY include patch level changes.
+   Patch version MUST be reset to 0 when minor version is incremented.
 
-   * - :ref:`barriers_api`
-     - Experimental
-     - 3.4
+ * Major version X (x.Y.z | x > 0) MUST be incremented if a compatibility
+   breaking change was made to the API.
 
-   * - :ref:`blinfo_api`
-     - Experimental
-     - 3.5
+.. note::
+   Version for existing APIs are initially set based on the current state of the
+   APIs:
 
-   * - :ref:`bluetooth_api`
-     - Stable
-     - 1.0
+    - 0.1.0 denotes an :ref:`experimental <api_lifecycle_experimental>` API
+    - 0.8.0 denote an :ref:`unstable <api_lifecycle_unstable>` API,
+    - and finally 1.0.0 indicates a :ref:`stable <api_lifecycle_stable>` APIs.
 
-   * - :ref:`clock_control_api`
-     - Stable
-     - 1.0
+   Changes to APIs in the future will require adapting the version following the
+   guidelines above.
 
-   * - :ref:`coap_sock_interface`
-     - Unstable
-     - 1.10
 
-   * - :ref:`conn_mgr_docs`
-     - Experimental
-     - 3.4.0
-
-   * - :ref:`can_api`
-     - Stable
-     - 1.14
-
-   * - :ref:`can_transceiver_api`
-     - Experimental
-     - 3.1
-
-   * - :ref:`charger_api`
-     - Experimental
-     - 3.5
-
-   * - :ref:`counter_api`
-     - Unstable
-     - 1.14
-
-   * - :ref:`crypto_api`
-     - Stable
-     - 1.7
-
-   * - :ref:`dac_api`
-     - Unstable
-     - 2.3
-
-   * - :ref:`dai_api`
-     - Experimental
-     - 3.1
-
-   * - :ref:`dma_api`
-     - Stable
-     - 1.5
-
-   * - :ref:`device_model_api`
-     - Stable
-     - 1.0
-
-   * - :ref:`devicetree_api`
-     - Stable
-     - 2.2
-
-   * - :ref:`disk_access_api`
-     - Stable
-     - 1.6
-
-   * - :ref:`display_api`
-     - Unstable
-     - 1.14
-
-   * - :ref:`ec_host_cmd_backend_api`
-     - Experimental
-     - 2.4
-
-   * - :ref:`edac_api`
-     - Unstable
-     - 2.5
-
-   * - :ref:`eeprom_api`
-     - Stable
-     - 2.1
-
-   * - :ref:`entropy_api`
-     - Stable
-     - 1.10
-
-   * - :ref:`file_system_api`
-     - Stable
-     - 1.5
-
-   * - :ref:`flash_api`
-     - Stable
-     - 1.2
-
-   * - :ref:`fcb_api`
-     - Stable
-     - 1.11
-
-   * - :ref:`fuel_gauge_api`
-     - Experimental
-     - 3.3
-
-   * - :ref:`flash_map_api`
-     - Stable
-     - 1.11
-
-   * - :ref:`gnss_api`
-     - Experimental
-     - 3.6
-
-   * - :ref:`gpio_api`
-     - Stable
-     - 1.0
-
-   * - :ref:`hwinfo_api`
-     - Stable
-     - 1.14
-
-   * - :ref:`i2c_eeprom_target_api`
-     - Stable
-     - 1.13
-
-   * - :ref:`i2c_api`
-     - Stable
-     - 1.0
-
-   * - :ref:`i2c-target-api`
-     - Experimental
-     - 1.12
-
-   * - :ref:`i2s_api`
-     - Stable
-     - 1.9
-
-   * - :ref:`i3c_api`
-     - Experimental
-     - 3.2
-
-   * - :ref:`ieee802154_driver_api`
-     - Unstable
-     - 1.0
-
-   * - :ref:`ieee802154_l2_api`
-     - Unstable
-     - 1.0
-
-   * - :ref:`ieee802154_mgmt_api`
-     - Unstable
-     - 1.0
-
-   * - :ref:`input`
-     - Experimental
-     - 3.4
-
-   * - :ref:`ipm_api`
-     - Stable
-     - 1.0
-
-   * - :ref:`kscan_api`
-     - Stable
-     - 2.1
-
-   * - :ref:`kernel_api`
-     - Stable
-     - 1.0
-
-   * - :ref:`led_api`
-     - Stable
-     - 1.12
-
-   * - :ref:`lwm2m_interface`
-     - Unstable
-     - 1.9
-
-   * - :ref:`llext`
-     - Experimental
-     - 3.5
-
-   * - :ref:`logging_api`
-     - Stable
-     - 1.13
-
-   * - :ref:`lora_api`
-     - Experimental
-     - 2.2
-
-   * - :ref:`lorawan_api`
-     - Experimental
-     - 2.5
-
-   * - :ref:`mbox_api`
-     - Experimental
-     - 1.0
-
-   * - :ref:`mcu_mgr`
-     - Stable
-     - 1.11
-
-   * - :ref:`modem`
-     - Experimental
-     - 3.5
-
-   * - :ref:`mqtt_socket_interface`
-     - Unstable
-     - 1.14
-
-   * - :ref:`mipi_dbi_api`
-     - Experimental
-     - 3.6
-
-   * - :ref:`mipi_dsi_api`
-     - Experimental
-     - 3.1
-
-   * - :ref:`misc_api`
-     - Stable
-     - 1.0
-
-   * - :ref:`networking_api`
-     - Stable
-     - 1.0
-
-   * - :ref:`nvs_api`
-     - Stable
-     - 1.12
-
-   * - :ref:`peci_api`
-     - Stable
-     - 2.1
-
-   * - :ref:`ps2_api`
-     - Stable
-     - 2.1
-
-   * - :ref:`pwm_api`
-     - Stable
-     - 1.0
-
-   * - :ref:`pinctrl_api`
-     - Experimental
-     - 3.0
-
-   * - :ref:`pm_api`
-     - Experimental
-     - 1.2
-
-   * - :ref:`random_api`
-     - Stable
-     - 1.0
-
-   * - :ref:`regulator_api`
-     - Experimental
-     - 2.4
-
-   * - :ref:`reset_api`
-     - Experimental
-     - 3.1
-
-   * - :ref:`retained_mem_api`
-     - Unstable
-     - 3.4
-
-   * - :ref:`retention_api`
-     - Experimental
-     - 3.4
-
-   * - :ref:`rtc_api`
-     - Experimental
-     - 3.4
-
-   * - :ref:`rtio_api`
-     - Experimental
-     - 3.2
-
-   * - :ref:`smbus_api`
-     - Experimental
-     - 3.4
-
-   * - :ref:`spi_api`
-     - Stable
-     - 1.0
-
-   * - :ref:`sensor_api`
-     - Stable
-     - 1.2
-
-   * - :ref:`settings_api`
-     - Stable
-     - 1.12
-
-   * - :ref:`shell_api`
-     - Stable
-     - 1.14
-
-   * - :ref:`stream_flash`
-     - Experimental
-     - 2.3
-
-   * - :ref:`sdhc_api`
-     - Experimental
-     - 3.1
-
-   * - :ref:`task_wdt_api`
-     - Unstable
-     - 2.5
-
-   * - :ref:`tcpc_api`
-     - Experimental
-     - 3.1
-
-   * - :ref:`tgpio_api`
-     - Experimental
-     - 3.5
-
-   * - :ref:`uart_api`
-     - Stable
-     - 1.0
-
-   * - :ref:`UART async <uart_api>`
-     - Unstable
-     - 1.14
-
-   * - :ref:`usb_api`
-     - Stable
-     - 1.5
-
-   * - :ref:`usbc_api`
-     - Experimental
-     - 3.3
-
-   * - :ref:`usermode_api`
-     - Stable
-     - 1.11
-
-   * - :ref:`usbc_vbus_api`
-     - Experimental
-     - 3.3
-
-   * - :ref:`util_api`
-     - Experimental
-     - 2.4
-
-   * - :ref:`video_api`
-     - Stable
-     - 2.1
-
-   * - :ref:`w1_api`
-     - Experimental
-     - 3.2
-
-   * - :ref:`watchdog_api`
-     - Stable
-     - 1.0
-
-   * - :ref:`zdsp_api`
-     - Experimental
-     - 3.3
+.. api-overview-table::

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -16,3 +16,6 @@ pykwalify
 
 # Used by pytest-twister-harness plugin
 pytest
+
+# Doxygen doxmlparser
+doxmlparser

--- a/include/zephyr/audio/codec.h
+++ b/include/zephyr/audio/codec.h
@@ -18,6 +18,8 @@
  * @brief Abstraction for audio codecs
  *
  * @defgroup audio_codec_interface Audio Codec Interface
+ * @since 1.13
+ * @version 0.1.0
  * @ingroup audio_interface
  * @{
  */

--- a/include/zephyr/audio/dmic.h
+++ b/include/zephyr/audio/dmic.h
@@ -28,6 +28,8 @@
  * @brief Abstraction for digital microphones
  *
  * @defgroup audio_dmic_interface Digital Microphone Interface
+ * @since 1.13
+ * @version 0.1.0
  * @ingroup audio_interface
  * @{
  */

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -34,6 +34,8 @@ extern "C" {
 /**
  * @brief Generic Access Profile (GAP)
  * @defgroup bt_gap Generic Access Profile (GAP)
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup bluetooth
  * @{
  */

--- a/include/zephyr/crypto/crypto.h
+++ b/include/zephyr/crypto/crypto.h
@@ -27,6 +27,8 @@
 /**
  * @brief Crypto APIs
  * @defgroup crypto Crypto
+ * @since 1.7
+ * @version 1.0.0
  * @ingroup os_services
  * @{
  */

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -24,6 +24,8 @@ extern "C" {
 /**
  * @brief Device Model
  * @defgroup device_model Device Model
+ * @since 1.0
+ * @version 1.0.0
  * @{
  */
 

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -28,6 +28,8 @@
 /**
  * @brief devicetree.h API
  * @defgroup devicetree Devicetree
+ * @since 2.2
+ * @version 1.0.0
  * @{
  * @}
  */

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -24,6 +24,8 @@ extern "C" {
 /**
  * @brief ADC driver APIs
  * @defgroup adc_interface ADC driver APIs
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/auxdisplay.h
+++ b/include/zephyr/drivers/auxdisplay.h
@@ -15,6 +15,8 @@
 /**
  * @brief Auxiliary (Text) Display Interface
  * @defgroup auxdisplay_interface Text Display Interface
+ * @since 3.4
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -30,6 +30,8 @@ extern "C" {
 /**
  * @brief CAN Interface
  * @defgroup can_interface CAN Interface
+ * @since 1.12
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/can/transceiver.h
+++ b/include/zephyr/drivers/can/transceiver.h
@@ -17,6 +17,8 @@ extern "C" {
 /**
  * @brief CAN Transceiver Driver APIs
  * @defgroup can_transceiver CAN Transceiver
+ * @since 3.1
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -17,6 +17,8 @@
 /**
  * @brief Clock Control Interface
  * @defgroup clock_control_interface Clock Control Interface
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -16,6 +16,8 @@
 /**
  * @brief Counter Interface
  * @defgroup counter_interface Counter Interface
+ * @since 1.14
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -21,6 +21,8 @@ extern "C" {
 /**
  * @brief DAC driver APIs
  * @defgroup dac_interface DAC driver APIs
+ * @since 2.3
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -14,6 +14,8 @@
 
 /**
  * @defgroup dai_interface DAI Interface
+ * @since 3.1
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @brief DAI Interface
  *

--- a/include/zephyr/drivers/disk.h
+++ b/include/zephyr/drivers/disk.h
@@ -21,6 +21,8 @@
 /**
  * @brief Disk Driver Interface
  * @defgroup disk_driver_interface Disk Driver Interface
+ * @since 1.6
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -15,6 +15,8 @@
 /**
  * @brief Display Interface
  * @defgroup display_interface Display Interface
+ * @since 1.14
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -24,6 +24,8 @@ extern "C" {
 /**
  * @brief DMA Interface
  * @defgroup dma_interface DMA Interface
+ * @since 1.5
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/edac.h
+++ b/include/zephyr/drivers/edac.h
@@ -18,6 +18,8 @@
 
 /**
  * @defgroup edac EDAC API
+ * @since 2.5
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/eeprom.h
+++ b/include/zephyr/drivers/eeprom.h
@@ -19,6 +19,8 @@
 /**
  * @brief EEPROM Interface
  * @defgroup eeprom_interface EEPROM Interface
+ * @since 2.1
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -16,6 +16,8 @@
 /**
  * @brief Entropy Interface
  * @defgroup entropy_interface Entropy Interface
+ * @since 1.10
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -45,6 +45,8 @@ struct flash_pages_layout {
 /**
  * @brief FLASH Interface
  * @defgroup flash_interface FLASH Interface
+ * @since 1.2
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -11,6 +11,8 @@
 /**
  * @brief Fuel Gauge Interface
  * @defgroup fuel_gauge_interface Fuel Gauge Interface
+ * @since 3.3
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -15,6 +15,8 @@
 /**
  * @brief GNSS Interface
  * @defgroup gnss_interface GNSS Interface
+ * @since 3.6
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -32,6 +32,8 @@ extern "C" {
 /**
  * @brief GPIO Driver APIs
  * @defgroup gpio_interface GPIO Driver APIs
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/hwinfo.h
+++ b/include/zephyr/drivers/hwinfo.h
@@ -16,6 +16,8 @@
 /**
  * @brief Hardware Information Interface
  * @defgroup hwinfo_interface Hardware Info Interface
+ * @since 1.14
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -15,6 +15,8 @@
 /**
  * @brief I2C Interface
  * @defgroup i2c_interface I2C Interface
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/i2c/target/eeprom.h
+++ b/include/zephyr/drivers/i2c/target/eeprom.h
@@ -15,6 +15,8 @@
 /**
  * @brief I2C EEPROM Target Driver API
  * @defgroup i2c_eeprom_target_api I2C EEPROM Target Driver API
+ * @since 1.13
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -14,6 +14,8 @@
 
 /**
  * @defgroup i2s_interface I2S Interface
+ * @since 1.9
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @brief I2S (Inter-IC Sound) Interface
  *

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -11,6 +11,8 @@
 /**
  * @brief I3C Interface
  * @defgroup i3c_interface I3C Interface
+ * @since 3.2
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/ipm.h
+++ b/include/zephyr/drivers/ipm.h
@@ -16,6 +16,8 @@
 /**
  * @brief IPM Interface
  * @defgroup ipm_interface IPM Interface
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/kscan.h
+++ b/include/zephyr/drivers/kscan.h
@@ -28,6 +28,8 @@ extern "C" {
 /**
  * @brief KSCAN APIs
  * @defgroup kscan_interface Keyboard Scan Driver APIs
+ * @since 2.1
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -15,6 +15,8 @@
 /**
  * @brief LED Interface
  * @defgroup led_interface LED Interface
+ * @since 1.12
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -15,6 +15,8 @@
  * @file
  * @brief Public LoRa APIs
  * @defgroup lora_api LoRa APIs
+ * @since 2.2
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -20,6 +20,8 @@ extern "C" {
 /**
  * @brief MBOX Interface
  * @defgroup mbox_interface MBOX Interface
+ * @since 1.0
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  *

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -24,6 +24,8 @@
 /**
  * @brief MIPI-DBI driver APIs
  * @defgroup mipi_dbi_interface MIPI-DBI driver APIs
+ * @since 3.6
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/mipi_dsi.h
+++ b/include/zephyr/drivers/mipi_dsi.h
@@ -15,6 +15,8 @@
 /**
  * @brief MIPI-DSI driver APIs
  * @defgroup mipi_dsi_interface MIPI-DSI driver APIs
+ * @since 3.1
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
+++ b/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
@@ -14,6 +14,8 @@
 /**
  * @brief Time-aware GPIO Interface
  * @defgroup tgpio_interface Time-aware GPIO Interface
+ * @since 3.5
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -15,6 +15,8 @@
 /**
  * @brief PECI Interface 3.0
  * @defgroup peci_interface PECI Interface
+ * @since 2.1
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -14,6 +14,8 @@
 /**
  * @brief Pin Controller Interface
  * @defgroup pinctrl_interface Pin Controller Interface
+ * @since 3.0
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -16,6 +16,8 @@
 /**
  * @brief PWM Interface
  * @defgroup pwm_interface PWM Interface
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -13,6 +13,8 @@
 /**
  * @brief Regulator Interface
  * @defgroup regulator_interface Regulator Interface
+ * @since 2.4
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -15,6 +15,8 @@
 /**
  * @brief Reset Controller Interface
  * @defgroup reset_controller_interface Reset Controller Interface
+ * @since 3.1
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/retained_mem.h
+++ b/include/zephyr/drivers/retained_mem.h
@@ -30,6 +30,8 @@ BUILD_ASSERT(!(sizeof(off_t) > sizeof(size_t)),
 /**
  * @brief Retained memory driver interface
  * @defgroup retained_mem_interface Retained memory driver interface
+ * @since 3.4
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/rtc.h
+++ b/include/zephyr/drivers/rtc.h
@@ -16,6 +16,8 @@
 /**
  * @brief RTC Interface
  * @defgroup rtc_interface RTC Interface
+ * @since 3.4
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -19,6 +19,8 @@
 /**
  * @brief SDHC interface
  * @defgroup sdhc_interface SDHC interface
+ * @since 3.1
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -15,6 +15,8 @@
 /**
  * @brief Sensor Interface
  * @defgroup sensor_interface Sensor Interface
+ * @since 1.2
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -15,6 +15,8 @@
 /**
  * @brief SMBus Interface
  * @defgroup smbus_interface SMBus Interface
+ * @since 3.4
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -15,6 +15,8 @@
 /**
  * @brief SPI Interface
  * @defgroup spi_interface SPI Interface
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -16,6 +16,8 @@
 /**
  * @brief UART Interface
  * @defgroup uart_interface UART Interface
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */
@@ -150,6 +152,8 @@ typedef void (*uart_irq_config_func_t)(const struct device *dev);
  * @}
  *
  * @defgroup uart_async Async UART API
+ * @since 1.14
+ * @version 0.8.0
  * @{
  */
 

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -18,6 +18,8 @@
 /**
  * @brief USB Type-C Port Controller API
  * @defgroup usb_type_c_port_controller_api USB Type-C Port Controller API
+ * @since 3.1
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/usb_c/usbc_vbus.h
+++ b/include/zephyr/drivers/usb_c/usbc_vbus.h
@@ -18,6 +18,8 @@
 /**
  * @brief USB-C VBUS API
  * @defgroup usbc_vbus_api USB-C VBUS API
+ * @since 3.3
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -15,6 +15,8 @@
 /**
  * @brief Video Interface
  * @defgroup video_interface Video Interface
+ * @since 2.1
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/w1.h
+++ b/include/zephyr/drivers/w1.h
@@ -26,6 +26,8 @@ extern "C" {
 /**
  * @brief 1-Wire Interface
  * @defgroup w1_interface 1-Wire Interface
+ * @since 3.2
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/watchdog.h
+++ b/include/zephyr/drivers/watchdog.h
@@ -11,6 +11,8 @@
 /**
  * @brief Watchdog Interface
  * @defgroup watchdog_interface Watchdog Interface
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/dsp/dsp.h
+++ b/include/zephyr/dsp/dsp.h
@@ -32,6 +32,8 @@
 /**
  * @brief DSP Interface
  * @defgroup math_dsp DSP Interface
+ * @since 3.3
+ * @version 0.1.0
  */
 
 #include <zephyr/dsp/types.h>

--- a/include/zephyr/fs/fcb.h
+++ b/include/zephyr/fs/fcb.h
@@ -24,6 +24,8 @@ extern "C" {
 
 /**
  * @defgroup fcb Flash Circular Buffer (FCB)
+ * @since 1.11
+ * @version 1.0.0
  * @ingroup file_system_storage
  * @{
  * @}

--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -20,6 +20,8 @@ extern "C" {
 /**
  * @brief File System APIs
  * @defgroup file_system_api File System APIs
+ * @since 1.5
+ * @version 1.0.0
  * @ingroup os_services
  * @{
  */

--- a/include/zephyr/fs/nvs.h
+++ b/include/zephyr/fs/nvs.h
@@ -19,6 +19,8 @@ extern "C" {
 /**
  * @brief Non-volatile Storage (NVS)
  * @defgroup nvs Non-volatile Storage (NVS)
+ * @since 1.12
+ * @version 1.0.0
  * @ingroup file_system_storage
  * @{
  * @}

--- a/include/zephyr/input/input.h
+++ b/include/zephyr/input/input.h
@@ -10,6 +10,8 @@
 /**
  * @brief Input Interface
  * @defgroup input_interface Input Interface
+ * @since 3.4
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -38,6 +38,8 @@ BUILD_ASSERT(sizeof(intptr_t) == sizeof(long));
 /**
  * @brief Kernel APIs
  * @defgroup kernel_apis Kernel APIs
+ * @since 1.0
+ * @version 1.0.0
  * @{
  * @}
  */

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -21,6 +21,8 @@ extern "C" {
 /**
  * @brief Linkable loadable extensions
  * @defgroup llext Linkable loadable extensions
+ * @since 3.5
+ * @version 0.1.0
  * @ingroup os_services
  * @{
  */

--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -18,6 +18,8 @@ extern "C" {
 /**
  * @brief Logging
  * @defgroup logging Logging
+ * @since 1.13
+ * @version 1.0.0
  * @ingroup os_services
  * @{
  * @}

--- a/include/zephyr/logging/log_ctrl.h
+++ b/include/zephyr/logging/log_ctrl.h
@@ -18,6 +18,7 @@ extern "C" {
 /**
  * @brief Logger
  * @defgroup logger Logger system
+ * @since 1.13
  * @ingroup logging
  * @{
  * @}
@@ -26,6 +27,7 @@ extern "C" {
 /**
  * @brief Logger control API
  * @defgroup log_ctrl Logger control API
+ * @since 1.13
  * @ingroup logger
  * @{
  */

--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -11,6 +11,8 @@
  * @file
  * @brief Public LoRaWAN APIs
  * @defgroup lorawan_api LoRaWAN APIs
+ * @since 2.5
+ * @version 0.1.0
  * @ingroup connectivity
  * @{
  */

--- a/include/zephyr/mgmt/ec_host_cmd/ec_host_cmd.h
+++ b/include/zephyr/mgmt/ec_host_cmd/ec_host_cmd.h
@@ -10,6 +10,8 @@
 /**
  * @brief EC Host Command Interface
  * @defgroup ec_host_cmd_interface EC Host Command Interface
+ * @since 2.4
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/mgmt/mcumgr/mgmt/mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/mgmt.h
@@ -20,6 +20,8 @@ extern "C" {
 /**
  * @brief MCUmgr mgmt API
  * @defgroup mcumgr_mgmt_api MCUmgr mgmt API
+ * @since 1.11
+ * @version 1.0.0
  * @ingroup mcumgr
  * @{
  */

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -17,6 +17,8 @@
 /**
  * @brief COAP library
  * @defgroup coap COAP Library
+ * @since 1.10
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/conn_mgr_connectivity.h
+++ b/include/zephyr/net/conn_mgr_connectivity.h
@@ -25,6 +25,8 @@ extern "C" {
 /**
  * @brief Connection Manager Connectivity API
  * @defgroup conn_mgr_connectivity Connection Manager Connectivity API
+ * @since 3.4
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/ieee802154.h
+++ b/include/zephyr/net/ieee802154.h
@@ -26,6 +26,8 @@ extern "C" {
 
 /**
  * @defgroup ieee802154 IEEE 802.15.4 and Thread APIs
+ * @since 1.0
+ * @version 0.8.0
  * @ingroup connectivity
  *
  * @brief IEEE 802.15.4 native and OpenThread L2, configuration, management and
@@ -76,6 +78,8 @@ extern "C" {
 
 /**
  * @defgroup ieee802154_l2 IEEE 802.15.4 L2
+ * @since 1.0
+ * @version 0.8.0
  * @ingroup ieee802154
  *
  * @brief IEEE 802.15.4 L2 APIs

--- a/include/zephyr/net/ieee802154_mgmt.h
+++ b/include/zephyr/net/ieee802154_mgmt.h
@@ -23,6 +23,8 @@ extern "C" {
 
 /**
  * @defgroup ieee802154_mgmt IEEE 802.15.4 Net Management
+ * @since 1.0
+ * @version 0.8.0
  * @ingroup ieee802154
  *
  * @brief IEEE 802.15.4 net management library

--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -29,6 +29,8 @@ extern "C" {
 
 /**
  * @defgroup ieee802154_driver IEEE 802.15.4 Drivers
+ * @since 1.0
+ * @version 0.8.0
  * @ingroup ieee802154
  *
  * @brief IEEE 802.15.4 driver API

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -8,6 +8,8 @@
 /** @file lwm2m.h
  *
  * @defgroup lwm2m_api LwM2M high-level API
+ * @since 1.9
+ * @version 0.8.0
  * @ingroup networking
  * @{
  * @brief LwM2M high-level API

--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -7,6 +7,8 @@
 /** @file mqtt.h
  *
  * @defgroup mqtt_socket MQTT Client library
+ * @since 1.14
+ * @version 0.8.0
  * @ingroup networking
  * @{
  * @brief MQTT Client Implementation

--- a/include/zephyr/net/net_core.h
+++ b/include/zephyr/net/net_core.h
@@ -29,6 +29,8 @@ extern "C" {
 /**
  * @brief Networking
  * @defgroup networking Networking
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup connectivity
  * @{
  * @}

--- a/include/zephyr/pm/pm.h
+++ b/include/zephyr/pm/pm.h
@@ -21,6 +21,7 @@ extern "C" {
 /**
  * @brief System and device power management
  * @defgroup subsys_pm Power Management (PM)
+ * @since 1.2
  * @ingroup os_services
  * @{
  * @}
@@ -29,6 +30,7 @@ extern "C" {
 /**
  * @brief System Power Management API
  * @defgroup subsys_pm_sys System
+ * @since 1.2
  * @ingroup subsys_pm
  * @{
  */

--- a/include/zephyr/random/random.h
+++ b/include/zephyr/random/random.h
@@ -28,6 +28,8 @@
 /**
  * @brief Random Function APIs
  * @defgroup random_api Random Function APIs
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup crypto
  * @{
  */

--- a/include/zephyr/retention/blinfo.h
+++ b/include/zephyr/retention/blinfo.h
@@ -27,6 +27,8 @@ extern "C" {
 /**
  * @brief Bootloader info interface
  * @defgroup bootloader_info_interface Bootloader info interface
+ * @since 3.5
+ * @version 0.1.0
  * @ingroup retention_api
  * @{
  */

--- a/include/zephyr/retention/retention.h
+++ b/include/zephyr/retention/retention.h
@@ -26,6 +26,8 @@ extern "C" {
 /**
  * @brief Retention API
  * @defgroup retention_api Retention API
+ * @since 3.4
+ * @version 0.1.0
  * @ingroup os_services
  * @{
  */

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -46,6 +46,8 @@ extern "C" {
 /**
  * @brief RTIO
  * @defgroup rtio RTIO
+ * @since 3.2
+ * @version 0.1.0
  * @ingroup os_services
  * @{
  */

--- a/include/zephyr/settings/settings.h
+++ b/include/zephyr/settings/settings.h
@@ -28,6 +28,8 @@ extern "C" {
 
 /**
  * @defgroup settings Settings
+ * @since 1.12
+ * @version 1.0.0
  * @ingroup file_system_storage
  * @{
  */

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -69,6 +69,8 @@ extern "C" {
 /**
  * @brief Shell API
  * @defgroup shell_api Shell API
+ * @since 1.14
+ * @version 1.0.0
  * @ingroup os_services
  * @{
  */

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -18,6 +18,8 @@
  * @brief Abstraction over flash partitions/areas and their drivers
  *
  * @defgroup flash_area_api flash area Interface
+ * @since 1.11
+ * @version 1.0.0
  * @ingroup storage_apis
  * @{
  */

--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -17,6 +17,8 @@
  * @brief Abstraction over stream writes to flash
  *
  * @defgroup stream_flash Stream to flash interface
+ * @since 2.3
+ * @version 0.1.0
  * @ingroup storage_apis
  * @{
  */

--- a/include/zephyr/sys/barrier.h
+++ b/include/zephyr/sys/barrier.h
@@ -25,6 +25,8 @@ extern "C" {
 
 /**
  * @addtogroup barrier_apis Barrier Services APIs
+ * @since 3.4
+ * @version 0.1.0
  * @ingroup kernel_apis
  * @{
  */

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -38,6 +38,8 @@ extern "C" {
 
 /**
  * @defgroup sys-util Utility Functions
+ * @since 2.4
+ * @version 0.1.0
  * @ingroup utilities
  * @{
  */

--- a/include/zephyr/task_wdt/task_wdt.h
+++ b/include/zephyr/task_wdt/task_wdt.h
@@ -24,6 +24,8 @@
 /**
  * @brief Task Watchdog APIs
  * @defgroup task_wdt_api Task Watchdog APIs
+ * @since 2.5
+ * @version 0.8.0
  * @ingroup os_services
  * @{
  */

--- a/include/zephyr/usb_c/usbc.h
+++ b/include/zephyr/usb_c/usbc.h
@@ -25,6 +25,8 @@ extern "C" {
 /**
  * @brief USB-C Device APIs
  * @defgroup _usbc_device_api USB-C Device API
+ * @since 3.3
+ * @version 0.1.0
  * @{
  */
 


### PR DESCRIPTION
This PR should address #50922. It basically:

- ~~Generate \since tags from doxgen and git (it may not be perfect, but it's a fairly comprehensive start);~~
- Manually ~~fix~~ add some based on current information from doc/develop/api.overview.rst;
- Add \version (showing stability level) based on information from doc/develop/api.overview.rst;
- Use all new info (\since and \version) to generate the new API overview page, which is basically an improved version of doxygen own "Modules index" page.

More details of each step are on the commit messages. Two things that still stand out:
 - To parse the doxygen XML info, I've used its own "doxmlparser" Python lib, but it needs to be installed from the sources, as there's no package on PyPi. There's an open issue at doxygen repo about it: https://github.com/doxygen/doxygen/issues/8848
 - The new API overview page points to the doxygen documentation, not for any RST that may exist for it. Since the page now comes from doxygen, we could a) add a new `xrefitem` tag to reference it, but then we'd have doxygen pointing to RST and RST pointing to doxygen, which could be an issue; or b) have another file to map RST pages for some doxygen groups, but it would be another burden to maintain. Any thoughts about this?

Fixes #50922 