### PR TITLE
net: wifi: Properly namespace public APIs

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Texas Instruments, Incorporated
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -455,7 +456,7 @@ enum wifi_twt_fail_reason {
 };
 
 /** @cond INTERNAL_HIDDEN */
-static const char * const twt_err_code_tbl[] = {
+static const char * const wifi_twt_err_code_tbl[] = {
 	[WIFI_TWT_FAIL_UNSPECIFIED] = "Unspecified",
 	[WIFI_TWT_FAIL_CMD_EXEC_FAIL] = "Command Execution failed",
 	[WIFI_TWT_FAIL_OPERATION_NOT_SUPPORTED] =
@@ -478,17 +479,17 @@ static const char * const twt_err_code_tbl[] = {
 /** @endcond */
 
 /** Helper function to get user-friendly TWT error code name. */
-static inline const char *get_twt_err_code_str(int16_t err_no)
+static inline const char *wifi_twt_get_err_code_str(int16_t err_no)
 {
-	if ((err_no) < (int16_t)ARRAY_SIZE(twt_err_code_tbl)) {
-		return twt_err_code_tbl[err_no];
+	if ((err_no) < (int16_t)ARRAY_SIZE(wifi_twt_err_code_tbl)) {
+		return wifi_twt_err_code_tbl[err_no];
 	}
 
 	return "<unknown>";
 }
 
 /** Wi-Fi power save parameters. */
-enum ps_param_type {
+enum wifi_ps_param_type {
 	/** Power save state. */
 	WIFI_PS_PARAM_STATE,
 	/** Power save listen interval. */
@@ -535,7 +536,7 @@ enum wifi_config_ps_param_fail_reason {
 };
 
 /** @cond INTERNAL_HIDDEN */
-static const char * const ps_param_config_err_code_tbl[] = {
+static const char * const wifi_ps_param_config_err_code_tbl[] = {
 	[WIFI_PS_PARAM_FAIL_UNSPECIFIED] = "Unspecified",
 	[WIFI_PS_PARAM_FAIL_CMD_EXEC_FAIL] = "Command Execution failed",
 	[WIFI_PS_PARAM_FAIL_OPERATION_NOT_SUPPORTED] =
@@ -552,10 +553,10 @@ static const char * const ps_param_config_err_code_tbl[] = {
 /** @endcond */
 
 /** Helper function to get user-friendly power save error code name. */
-static inline const char *get_ps_config_err_code_str(int16_t err_no)
+static inline const char *wifi_ps_get_config_err_code_str(int16_t err_no)
 {
-	if ((err_no) < (int16_t)ARRAY_SIZE(ps_param_config_err_code_tbl)) {
-		return ps_param_config_err_code_tbl[err_no];
+	if ((err_no) < (int16_t)ARRAY_SIZE(wifi_ps_param_config_err_code_tbl)) {
+		return wifi_ps_param_config_err_code_tbl[err_no];
 	}
 
 	return "<unknown>";

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -339,7 +339,7 @@ struct wifi_ps_params {
 	 */
 	unsigned int timeout_ms;
 	/** Wi-Fi power save type */
-	enum ps_param_type type;
+	enum wifi_ps_param_type type;
 	/** Wi-Fi power save fail reason */
 	enum wifi_config_ps_param_fail_reason fail_reason;
 };

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -782,7 +782,7 @@ static int cmd_wifi_ps(const struct shell *sh, size_t argc, char *argv[])
 		shell_fprintf(sh, SHELL_WARNING,
 			      "PS %s failed. Reason: %s\n",
 			      params.enabled ? "enable" : "disable",
-			      get_ps_config_err_code_str(params.fail_reason));
+			      wifi_ps_get_config_err_code_str(params.fail_reason));
 		return -ENOEXEC;
 	}
 
@@ -812,7 +812,7 @@ static int cmd_wifi_ps_mode(const struct shell *sh, size_t argc, char *argv[])
 	if (net_mgmt(NET_REQUEST_WIFI_PS, iface, &params, sizeof(params))) {
 		shell_fprintf(sh, SHELL_WARNING, "%s failed Reason : %s\n",
 			      wifi_ps_mode2str[params.mode],
-			      get_ps_config_err_code_str(params.fail_reason));
+			      wifi_ps_get_config_err_code_str(params.fail_reason));
 		return -ENOEXEC;
 	}
 
@@ -843,7 +843,7 @@ static int cmd_wifi_ps_timeout(const struct shell *sh, size_t argc, char *argv[]
 	if (net_mgmt(NET_REQUEST_WIFI_PS, iface, &params, sizeof(params))) {
 		shell_fprintf(sh, SHELL_WARNING,
 			      "Setting PS timeout failed. Reason : %s\n",
-			      get_ps_config_err_code_str(params.fail_reason));
+			      wifi_ps_get_config_err_code_str(params.fail_reason));
 		return -ENOEXEC;
 	}
 
@@ -897,7 +897,7 @@ static int cmd_wifi_twt_setup_quick(const struct shell *sh, size_t argc,
 		shell_fprintf(sh, SHELL_WARNING, "%s with %s failed, reason : %s\n",
 			wifi_twt_operation2str[params.operation],
 			wifi_twt_negotiation_type2str[params.negotiation_type],
-			get_twt_err_code_str(params.fail_reason));
+			wifi_twt_get_err_code_str(params.fail_reason));
 
 		return -ENOEXEC;
 	}
@@ -984,7 +984,7 @@ static int cmd_wifi_twt_setup(const struct shell *sh, size_t argc,
 		shell_fprintf(sh, SHELL_WARNING, "%s with %s failed. reason : %s\n",
 			wifi_twt_operation2str[params.operation],
 			wifi_twt_negotiation_type2str[params.negotiation_type],
-			get_twt_err_code_str(params.fail_reason));
+			wifi_twt_get_err_code_str(params.fail_reason));
 
 		return -ENOEXEC;
 	}
@@ -1040,7 +1040,7 @@ static int cmd_wifi_twt_teardown(const struct shell *sh, size_t argc,
 		shell_fprintf(sh, SHELL_WARNING, "%s with %s failed, reason : %s\n",
 			wifi_twt_operation2str[params.operation],
 			wifi_twt_negotiation_type2str[params.negotiation_type],
-			get_twt_err_code_str(params.fail_reason));
+			wifi_twt_get_err_code_str(params.fail_reason));
 
 		return -ENOEXEC;
 	}
@@ -1067,7 +1067,7 @@ static int cmd_wifi_twt_teardown_all(const struct shell *sh, size_t argc,
 		shell_fprintf(sh, SHELL_WARNING, "%s with %s failed, reason : %s\n",
 			wifi_twt_operation2str[params.operation],
 			wifi_twt_negotiation_type2str[params.negotiation_type],
-			get_twt_err_code_str(params.fail_reason));
+			wifi_twt_get_err_code_str(params.fail_reason));
 
 		return -ENOEXEC;
 	}
@@ -1204,13 +1204,13 @@ static int cmd_wifi_listen_interval(const struct shell *sh, size_t argc, char *a
 		    WIFI_PS_PARAM_LISTEN_INTERVAL_RANGE_INVALID) {
 			shell_fprintf(sh, SHELL_WARNING,
 			      "Setting listen interval failed. Reason :%s\n",
-			      get_ps_config_err_code_str(params.fail_reason));
+			      wifi_ps_get_config_err_code_str(params.fail_reason));
 			shell_fprintf(sh, SHELL_WARNING,
 				"Hardware support valid range : 3 - 65535\n");
 		} else  {
 			shell_fprintf(sh, SHELL_WARNING,
 				"Setting listen interval failed. Reason :%s\n",
-				get_ps_config_err_code_str(params.fail_reason));
+				wifi_ps_get_config_err_code_str(params.fail_reason));
 		}
 		return -ENOEXEC;
 	}
@@ -1245,7 +1245,7 @@ static int cmd_wifi_ps_wakeup_mode(const struct shell *sh, size_t argc, char *ar
 		shell_fprintf(sh, SHELL_WARNING,
 			      "Setting PS wake up mode to %s failed..Reason :%s\n",
 			      params.wakeup_mode ? "Listen interval" : "DTIM interval",
-			      get_ps_config_err_code_str(params.fail_reason));
+			      wifi_ps_get_config_err_code_str(params.fail_reason));
 		return -ENOEXEC;
 	}
 


### PR DESCRIPTION
The twt and ps helper functions were not namespaced (were missing wifi_ prefix).

Also change wifi_get_twt_... to more logical wifi_twt_get... like the other twt based functions.