### PR TITLE
Bluetooth: controller: Add memory barrier to ticker transactions

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -11,6 +11,7 @@
 
 #include "hal/cntr.h"
 #include "hal/ticker.h"
+#include "hal/cpu.h"
 
 #include "ticker.h"
 
@@ -3449,6 +3450,8 @@ uint8_t ticker_start_us(uint8_t instance_index, uint8_t user_id,
 	user_op->fp_op_func = fp_op_func;
 	user_op->op_context = op_context;
 
+	/* Make sure transaction is completed before committing */
+	cpu_dmb();
 	user->last = last;
 
 	instance->sched_cb(instance->caller_id_get_cb(user_id),
@@ -3569,6 +3572,8 @@ uint8_t ticker_update_ext(uint8_t instance_index, uint8_t user_id,
 	user_op->fp_op_func = fp_op_func;
 	user_op->op_context = op_context;
 
+	/* Make sure transaction is completed before committing */
+	cpu_dmb();
 	user->last = last;
 
 	instance->sched_cb(instance->caller_id_get_cb(user_id),
@@ -3625,6 +3630,8 @@ uint8_t ticker_yield_abs(uint8_t instance_index, uint8_t user_id,
 	user_op->fp_op_func = fp_op_func;
 	user_op->op_context = op_context;
 
+	/* Make sure transaction is completed before committing */
+	cpu_dmb();
 	user->last = last;
 
 	instance->sched_cb(instance->caller_id_get_cb(user_id),
@@ -3677,6 +3684,8 @@ uint8_t ticker_stop(uint8_t instance_index, uint8_t user_id, uint8_t ticker_id,
 	user_op->fp_op_func = fp_op_func;
 	user_op->op_context = op_context;
 
+	/* Make sure transaction is completed before committing */
+	cpu_dmb();
 	user->last = last;
 
 	instance->sched_cb(instance->caller_id_get_cb(user_id),
@@ -3732,6 +3741,8 @@ uint8_t ticker_stop_abs(uint8_t instance_index, uint8_t user_id,
 	user_op->fp_op_func = fp_op_func;
 	user_op->op_context = op_context;
 
+	/* Make sure transaction is completed before committing */
+	cpu_dmb();
 	user->last = last;
 
 	instance->sched_cb(instance->caller_id_get_cb(user_id),
@@ -3826,6 +3837,8 @@ uint8_t ticker_next_slot_get_ext(uint8_t instance_index, uint8_t user_id,
 	user_op->fp_op_func = fp_op_func;
 	user_op->op_context = op_context;
 
+	/* Make sure transaction is completed before committing */
+	cpu_dmb();
 	user->last = last;
 
 	instance->sched_cb(instance->caller_id_get_cb(user_id),
@@ -3880,6 +3893,8 @@ uint8_t ticker_job_idle_get(uint8_t instance_index, uint8_t user_id,
 	user_op->fp_op_func = fp_op_func;
 	user_op->op_context = op_context;
 
+	/* Make sure transaction is completed before committing */
+	cpu_dmb();
 	user->last = last;
 
 	instance->sched_cb(instance->caller_id_get_cb(user_id),
@@ -3941,6 +3956,8 @@ uint8_t ticker_priority_set(uint8_t instance_index, uint8_t user_id, uint8_t tic
 	user_op->fp_op_func = fp_op_func;
 	user_op->op_context = op_context;
 
+	/* Make sure transaction is completed before committing */
+	cpu_dmb();
 	user->last = last;
 
 	instance->sched_cb(instance->caller_id_get_cb(user_id),


### PR DESCRIPTION
Prevent compiler optimizations from changing the order of assignments in the ticker API transactions. This could cause lost operation requests and unexpected behavior under certain race conditions.