### PR TITLE
rtio: add missing init.h include

### DIFF
--- a/subsys/rtio/rtio_init.c
+++ b/subsys/rtio/rtio_init.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/init.h>
 #include <zephyr/rtio/rtio.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/app_memory/app_memdomain.h>


### PR DESCRIPTION
File was using init.h API without directly including the header.