### PR TITLE
mgmt: ec_host_cmd: simulator: s/device.h/init.h

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_simulator.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_simulator.c
@@ -6,7 +6,7 @@
 
 #include <errno.h>
 
-#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <zephyr/mgmt/ec_host_cmd/backend.h>
 #include <zephyr/mgmt/ec_host_cmd/ec_host_cmd.h>
 #include <string.h>


### PR DESCRIPTION
File is not using any device.h API, but init.h (SYS_INIT).