### PR TITLE
net: lib: zperf: add missing init.h

### DIFF
--- a/subsys/net/lib/zperf/zperf_common.c
+++ b/subsys/net/lib/zperf/zperf_common.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net/socket.h>
 


### PR DESCRIPTION
File was using SYS_INIT without including init.h.