### PR TITLE
drivers: pinctrl: pfc_rcar: add missing init.h

### DIFF
--- a/drivers/pinctrl/pfc_rcar.c
+++ b/drivers/pinctrl/pfc_rcar.c
@@ -10,6 +10,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/init.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/device_mmio.h>
 


### PR DESCRIPTION
File uses SYS_INIT API, from init.h.