### PR TITLE
drivers: pinctrl: imx: add missing init.h

### DIFF
--- a/drivers/pinctrl/pinctrl_imx.c
+++ b/drivers/pinctrl/pinctrl_imx.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/arch/cpu.h>
+#include <zephyr/init.h>
 #include <zephyr/drivers/pinctrl.h>
 
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,


### PR DESCRIPTION
File used SYS_INIT API from init.h.