### PR TITLE
drivers: usb: device: nrfx: add missing init.h

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -16,6 +16,7 @@
 #include <soc.h>
 #include <string.h>
 #include <stdio.h>
+#include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/usb/usb_dc.h>
 #include <zephyr/usb/usb_device.h>


### PR DESCRIPTION
File was using SYS_INIT, from init.h.