### PR TITLE
drivers: fix few mismatched CONTAINER_OF

### DIFF
--- a/drivers/disk/nvme/nvme_disk.c
+++ b/drivers/disk/nvme/nvme_disk.c
@@ -27,7 +27,7 @@ static int nvme_disk_read(struct disk_info *disk,
 			  uint32_t num_sector)
 {
 	struct nvme_namespace *ns = CONTAINER_OF(disk->name,
-						 struct nvme_namespace, name);
+						 struct nvme_namespace, name[0]);
 	struct nvme_completion_poll_status status =
 		NVME_CPL_STATUS_POLL_INIT(status);
 	struct nvme_request *request;
@@ -70,7 +70,7 @@ static int nvme_disk_write(struct disk_info *disk,
 			   uint32_t num_sector)
 {
 	struct nvme_namespace *ns = CONTAINER_OF(disk->name,
-						 struct nvme_namespace, name);
+						 struct nvme_namespace, name[0]);
 	struct nvme_completion_poll_status status =
 		NVME_CPL_STATUS_POLL_INIT(status);
 	struct nvme_request *request;
@@ -137,7 +137,7 @@ static int nvme_disk_flush(struct nvme_namespace *ns)
 static int nvme_disk_ioctl(struct disk_info *disk, uint8_t cmd, void *buff)
 {
 	struct nvme_namespace *ns = CONTAINER_OF(disk->name,
-						 struct nvme_namespace, name);
+						 struct nvme_namespace, name[0]);
 	int ret = 0;
 
 	nvme_lock(disk->dev);

--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -712,8 +712,9 @@ int dsa_hw_init(struct ksz8xxx_data *pdev)
 
 static void dsa_delayed_work(struct k_work *item)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(item);
 	struct dsa_context *context =
-		CONTAINER_OF(item, struct dsa_context, dsa_work);
+		CONTAINER_OF(dwork, struct dsa_context, dsa_work);
 	struct ksz8xxx_data *pdev = PRV_DATA(context);
 	bool link_state;
 	uint8_t i;

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -610,7 +610,7 @@ static void ppp_process_msg(struct ppp_driver_context *ppp)
 static uint8_t *ppp_recv_cb(uint8_t *buf, size_t *off)
 {
 	struct ppp_driver_context *ppp =
-		CONTAINER_OF(buf, struct ppp_driver_context, buf);
+		CONTAINER_OF(buf, struct ppp_driver_context, buf[0]);
 	size_t i, len = *off;
 
 	for (i = 0; i < *off; i++) {

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -302,7 +302,7 @@ static inline int slip_input_byte(struct slip_context *slip,
 static uint8_t *recv_cb(uint8_t *buf, size_t *off)
 {
 	struct slip_context *slip =
-		CONTAINER_OF(buf, struct slip_context, buf);
+		CONTAINER_OF(buf, struct slip_context, buf[0]);
 	size_t i;
 
 	if (!slip->init_done) {

--- a/drivers/wifi/esp_at/esp.h
+++ b/drivers/wifi/esp_at/esp.h
@@ -344,7 +344,7 @@ static inline atomic_val_t esp_socket_flags(struct esp_socket *sock)
 
 static inline struct esp_data *esp_socket_to_dev(struct esp_socket *sock)
 {
-	return CONTAINER_OF(sock - sock->idx, struct esp_data, sockets);
+	return CONTAINER_OF(sock - sock->idx, struct esp_data, sockets[0]);
 }
 
 static inline void __esp_socket_work_submit(struct esp_socket *sock,

--- a/drivers/wifi/eswifi/eswifi.h
+++ b/drivers/wifi/eswifi/eswifi.h
@@ -121,7 +121,7 @@ static inline int __select_socket(struct eswifi_dev *eswifi, uint8_t idx)
 static inline
 struct eswifi_dev *eswifi_socket_to_dev(struct eswifi_off_socket *socket)
 {
-	return CONTAINER_OF(socket - socket->index, struct eswifi_dev, socket);
+	return CONTAINER_OF(socket - socket->index, struct eswifi_dev, socket[0]);
 }
 
 struct eswifi_bus_ops *eswifi_get_bus(void);


### PR DESCRIPTION
Fix few mismatched CONTAINER_OF, one missing k_work_delayable_from_work conversion and few cases where the target should be pointing at the first element explicitly.