### PR TITLE
net: fix few mismatched CONTAINER_OF

### DIFF
--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -121,8 +121,9 @@ static void reassembly_info(char *str, struct net_ipv4_reassembly *reass)
 
 static void reassembly_timeout(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct net_ipv4_reassembly *reass =
-		CONTAINER_OF(work, struct net_ipv4_reassembly, timer);
+		CONTAINER_OF(dwork, struct net_ipv4_reassembly, timer);
 
 	reassembly_info("Reassembly cancelled", reass);
 

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -213,8 +213,9 @@ static void reassembly_info(char *str, struct net_ipv6_reassembly *reass)
 
 static void reassembly_timeout(struct k_work *work)
 {
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct net_ipv6_reassembly *reass =
-		CONTAINER_OF(work, struct net_ipv6_reassembly, timer);
+		CONTAINER_OF(dwork, struct net_ipv6_reassembly, timer);
 
 	reassembly_info("Reassembly cancelled", reass);
 

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -76,7 +76,7 @@ static inline struct net_nbr *get_nexthop_nbr(struct net_nbr *start, int idx)
 
 static void release_nexthop_route(struct net_route_nexthop *route_nexthop)
 {
-	struct net_nbr *nbr = CONTAINER_OF(route_nexthop, struct net_nbr, __nbr);
+	struct net_nbr *nbr = CONTAINER_OF((uint8_t *)route_nexthop, struct net_nbr, __nbr[0]);
 
 	net_nbr_unref(nbr);
 }


### PR DESCRIPTION
Fix few mismatched CONTAINER_OF, few missing k_work_delayable_from_work and a missing reference to the array first element.