### PR TITLE
logging: fix few mismatched CONTAINER_OF

### DIFF
--- a/subsys/logging/log_cache.c
+++ b/subsys/logging/log_cache.c
@@ -89,7 +89,7 @@ bool log_cache_get(struct log_cache *cache, uintptr_t id, uint8_t **data)
 
 void log_cache_put(struct log_cache *cache, uint8_t *data)
 {
-	struct log_cache_entry *entry = CONTAINER_OF(data, struct log_cache_entry, data);
+	struct log_cache_entry *entry = CONTAINER_OF(data, struct log_cache_entry, data[0]);
 
 	LOG_CACHE_DBG_ENTRY("cache_put", entry);
 	sys_slist_prepend(&cache->active, &entry->node);
@@ -97,7 +97,7 @@ void log_cache_put(struct log_cache *cache, uint8_t *data)
 
 void log_cache_release(struct log_cache *cache, uint8_t *data)
 {
-	struct log_cache_entry *entry = CONTAINER_OF(data, struct log_cache_entry, data);
+	struct log_cache_entry *entry = CONTAINER_OF(data, struct log_cache_entry, data[0]);
 
 	LOG_CACHE_DBG_ENTRY("cache_release", entry);
 	sys_slist_prepend(&cache->idle, &entry->node);

--- a/subsys/logging/log_frontend_dict_uart.c
+++ b/subsys/logging/log_frontend_dict_uart.c
@@ -157,9 +157,10 @@ static void uart_callback(const struct device *dev,
 	case UART_TX_DONE:
 	{
 		union log_frontend_pkt generic_pkt;
+		struct log_frontend_uart_pkt_hdr *hdr;
 
-		generic_pkt.generic = CONTAINER_OF(evt->data.tx.buf,
-						   struct log_frontend_uart_generic_pkt, hdr);
+		hdr = (struct log_frontend_uart_pkt_hdr *)evt->data.tx.buf;
+		generic_pkt.generic = CONTAINER_OF(hdr, struct log_frontend_uart_generic_pkt, hdr);
 
 		mpsc_pbuf_free(&buf, generic_pkt.ro_pkt);
 		atomic_val_t rem_pkts = atomic_dec(&active_cnt);


### PR DESCRIPTION
Fix few mismatched CONTAINER_OF, few missing pointers to the first element, one explicit casting.