### PR TITLE
soc: arm: nordic_nrf: nrf53: sync_rtc: add missing init.h

### DIFF
--- a/soc/arm/nordic_nrf/nrf53/sync_rtc.c
+++ b/soc/arm/nordic_nrf/nrf53/sync_rtc.c
@@ -8,6 +8,7 @@
 #include <helpers/nrfx_gppi.h>
 #include <zephyr/drivers/timer/nrf_rtc_timer.h>
 #include <zephyr/drivers/mbox.h>
+#include <zephyr/init.h>
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sync_rtc, CONFIG_SYNC_RTC_LOG_LEVEL);


### PR DESCRIPTION
File was using SYS_INIT, from init.h.