### PR TITLE
boards: arm: add missing stm32 adc properties

### DIFF
--- a/boards/arm/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/arm/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -141,6 +141,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_inp3_pa6 &adc1_inp15_pa3>; /* Zio A0, Zio D35 */
 	pinctrl-names = "default";
+	st,adc-clock-source = <ASYNC>;
+	st,adc-prescaler = <6>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
@@ -82,6 +82,8 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pc0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -128,12 +128,16 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in1_pc0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <ASYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 
 &adc4 {
 	pinctrl-0 = <&adc4_in18_pb0>;
 	pinctrl-names = "default";
+	st,adc-clock-source = <ASYNC>;
+	st,adc-prescaler = <4>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Clock source and prescaler properties were missing for Nucleo H563ZI, L552ZE and U575ZI

Fixes CI issues in #61901