### PR TITLE
ivshmem: Documentation and shell fixes

### DIFF
--- a/doc/services/virtualization/ivshmem.rst
+++ b/doc/services/virtualization/ivshmem.rst
@@ -16,7 +16,7 @@ it might be necessary to make VMs aware of each other, or aware of the host.
 This is made possible by exposing a shared memory among parties via a feature
 called ivshmem, which stands for inter-VM Shared Memory.
 
-The Two types are supported: a plain shared memory (ivshmem-plain) or a shared
+The two types are supported: a plain shared memory (ivshmem-plain) or a shared
 memory with the ability for a VM to generate an interruption on another, and
 thus to be interrupted as well itself (ivshmem-doorbell).
 
@@ -26,13 +26,13 @@ Please refer to the official `Qemu ivshmem documentation
 Support
 *******
 
-Zephyr supports both version: plain and doorbell. Ivshmem driver can be build
+Zephyr supports both versions: plain and doorbell. Ivshmem driver can be built
 by enabling :kconfig:option:`CONFIG_IVSHMEM`. By default, this will expose the plain
 version. :kconfig:option:`CONFIG_IVSHMEM_DOORBELL` needs to be enabled to get the
 doorbell version.
 
 Because the doorbell version uses MSI-X vectors to support notification vectors,
-the :kconfig:option:`CONFIG_IVSHMEM_MSI_X_VECTORS` has to be tweaked to the amount of
+the :kconfig:option:`CONFIG_IVSHMEM_MSI_X_VECTORS` has to be tweaked to the number of
 vectors that will be needed.
 
 Note that a tiny shell module can be exposed to test the ivshmem feature by

--- a/drivers/virtualization/virt_ivshmem_shell.c
+++ b/drivers/virtualization/virt_ivshmem_shell.c
@@ -212,15 +212,3 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_ivshmem_cmds,
 
 SHELL_CMD_REGISTER(ivshmem, &sub_ivshmem_cmds,
 		   "IVshmem information", cmd_ivshmem_shmem);
-
-SHELL_CMD_ARG_REGISTER(ivshmem_dump, &sub_ivshmem_cmds,
-		       "Dump shared memory content",
-		       cmd_ivshmem_dump, 3, 0);
-
-SHELL_CMD_ARG_REGISTER(ivshmem_int, &sub_ivshmem_cmds,
-		       "Notify a vector on an ivshmem peer",
-		       cmd_ivshmem_int, 3, 0);
-
-SHELL_CMD_ARG_REGISTER(ivshmem_get_notified, &sub_ivshmem_cmds,
-		       "Get notification on vector",
-		       cmd_ivshmem_get_notified, 2, 0);

--- a/drivers/virtualization/virt_ivshmem_shell.c
+++ b/drivers/virtualization/virt_ivshmem_shell.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <zephyr/drivers/virtualization/ivshmem.h>
 
-static const struct device *ivshmem;
+static const struct device *ivshmem = DEVICE_DT_GET_ONE(qemu_ivshmem);
 
 #ifdef CONFIG_IVSHMEM_DOORBELL
 
@@ -48,14 +48,12 @@ static void doorbell_notification_thread(const struct shell *sh)
 
 static bool get_ivshmem(const struct shell *sh)
 {
-	if (ivshmem == NULL) {
-		ivshmem = DEVICE_DT_GET_ONE(qemu_ivshmem);
-		if (!device_is_ready(ivshmem)) {
-			shell_error(sh, "IVshmem device is not ready");
-		}
+	if (!device_is_ready(ivshmem)) {
+		shell_error(sh, "IVshmem device is not ready");
+		return false;
 	}
 
-	return ivshmem != NULL ? true : false;
+	return true;
 }
 
 static int cmd_ivshmem_shmem(const struct shell *sh,


### PR DESCRIPTION
Correct documentation and fixes crash when ivshmem device is not ready.