### PR TITLE
mgmt: mcumgr: smp_dummy: Add missing conditional end bracket

### DIFF
--- a/include/zephyr/mgmt/mcumgr/transport/smp_dummy.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp_dummy.h
@@ -98,4 +98,8 @@ void smp_dummy_disable(void);
  */
 bool smp_dummy_get_status(void);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* ZEPHYR_INCLUDE_MGMT_MCUMGR_TRANSPORT_DUMMY_H_ */


### PR DESCRIPTION
Compiling smp_dummy.c for C++ is currently
not possible due to a missing end curly bracket in the header file.

This commit adds the missing end bracket on the same condition as the start bracket is included.