### PR TITLE
boards: arm: qemu_cortex_m0: add missing init.h

### DIFF
--- a/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
+++ b/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
@@ -6,6 +6,7 @@
  */
 
 #include <soc.h>
+#include <zephyr/init.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #include <zephyr/drivers/timer/system_timer.h>


### PR DESCRIPTION
Timer driver was using SYS_INIT without including init.h.