### PR TITLE
usb: host: core: add missing init.h

### DIFF
--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -8,6 +8,7 @@
 #include <zephyr/device.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/init.h>
 #include "usbh_internal.h"
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
File was using SYS_INIT without including init.h.