### PR TITLE
board: mimxrt1170_evk

### DIFF
--- a/boards/arm/mimxrt1170_evk/doc/index.rst
+++ b/boards/arm/mimxrt1170_evk/doc/index.rst
@@ -349,6 +349,11 @@ Use the ``-r linkserver`` option with West to use the LinkServer runner.
 
    west flash -r linkserver
 
+Alternatively, pyOCD can be used to flash and debug the board by using the
+``-r pyocd`` option with West. pyOCD is installed when you complete the
+:ref:`gs_python_deps` step in the Getting Started Guide. The runners supported
+by NXP are LinkServer and JLink. pyOCD is another potential option, but NXP
+does not test or support the pyOCD runner.
 
 Configuring a Console
 =====================


### PR DESCRIPTION
Hi there,

I have been using this board for some other work and wanted to test out Zephyr with it, seeing as it is a supported board. However, I do not have a J-Link debugger to hand so the flash and debugging instructions weren't working. Looking more closely at the instructions, I was able to use `pyocd` to flash and debug the elf file directly. The MIMXRT1176 processor on this board is now supported by `pyocd` where perhaps it wasn't before: https://pyocd.io/docs/builtin-targets.html, https://github.com/pyocd/pyOCD/blob/main/pyocd/target/builtin/target_MIMXRT1176xxxxx.py.

It should also be noted that most of the MIMXRT1xxx family now appear to be supported by `pyocd` yet the docs all include similar language about flash support not being ready yet. I don't have any of the other boards/processors so cannot confirm this.

Seeing as the `pyocd` runner doesn't require any extra hardware, I think it is easier for getting started and therefore makes a better default. So I have reordered the includes in `board.cmake` which seems to have done the trick, although I couldn't see any explicit documentation on this. I will include at the bottom of this message the terminal output I see when running the commands with this change.

This is my first Zephyr contribution, so I have tried to make minimal changes and keep docs information in line with what is already there. Please feel free to refer me to other examples where `pyocd` and `J-Link` are supported so I can copy their style/information. Or if I have missed anything with regards to contributing guidelines.

Thanks 😃 

Tim

P.S Terminal output following this change:

```bash
>west --verbose flash
-- west flash: rebuilding
cmake version 3.26.3 is OK; minimum version is 3.13.1
Running CMake: 'C:\Program Files\CMake\bin\cmake.EXE' --build 'C:\Users\tim\zephyr_project\build'
ninja: no work to do.
-- west flash: using runner pyocd
WARNING: runners.pyocd: hex file (None) does not exist; falling back on .bin (C:\Users\tim\zephyr_project\build\zephyr\zephyr.bin). Consider enabling CONFIG_BUILD_OUTPUT_HEX.
-- runners.pyocd: Flashing file: C:\Users\tim\zephyr_project\build\zephyr\zephyr.bin
runners.pyocd: pyocd flash -e sector -a 0x30000000 -t mimxrt1170_cm7 'C:\Users\tim\zephyr_project\build\zephyr\zephyr.bin'
0001998 I Loading C:\Users\tim\zephyr_project\build\zephyr\zephyr.bin at 0x30000000 [load_cmd]
[==================================================] 100%
0008938 I Erased 36864 bytes (9 sectors), programmed 35584 bytes (139 pages), skipped 4096 bytes (16 pages) at 5.65 kB/s [loader]

>west --verbose debug
-- west debug: rebuilding
cmake version 3.26.3 is OK; minimum version is 3.13.1
Running CMake: 'C:\Program Files\CMake\bin\cmake.EXE' --build 'C:\Users\tim\zephyr_project\build'
ninja: no work to do.
-- west debug: using runner pyocd
-- runners.pyocd: pyOCD GDB server running on port 3333
runners.pyocd: pyocd gdbserver -p 3333 -T 4444 -t mimxrt1170_cm7
runners.pyocd: C:/Users/tim/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb.exe 'C:\Users\tim\zephyr_project\build\zephyr\zephyr.elf' -ex 'target remote :3333' -ex 'monitor halt' -ex 'monitor reset' -ex load
GNU gdb (Zephyr SDK 0.16.1) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=x86_64-host_w64-mingw32 --target=arm-zephyr-eabi".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://github.com/zephyrproject-rtos/sdk-ng/issues>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from C:\Users\tim\zephyr_project\build\zephyr\zephyr.elf...
0001337 I Target type is mimxrt1170_cm7 [board]
0001378 I DP IDR = 0x6ba02477 (v2 rev6) [dap]
0001443 I AHB-AP#0 IDR = 0x84770001 (AHB-AP var0 rev8) [discovery]
0001490 I AHB-AP#1 IDR = 0x24770011 (AHB-AP var1 rev2) [discovery]
0001507 I APB-AP#2 IDR = 0x54770002 (APB-AP var0 rev5) [discovery]
0001560 I AHB-AP#0 Class 0x1 ROM table #0 @ 0xe00fd000 (designer=00e:NXP part=88c) [rom_table]
0001567 I [0]<e00fe000:ROM class=1 designer=43b:Arm part=4c8> [rom_table]
0001570 I   AHB-AP#0 Class 0x1 ROM table #1 @ 0xe00fe000 (designer=43b:Arm part=4c8) [rom_table]
0001580 I   [0]<e00ff000:ROM class=1 designer=43b:Arm part=4c7> [rom_table]
0001581 I     AHB-AP#0 Class 0x1 ROM table #2 @ 0xe00ff000 (designer=43b:Arm part=4c7) [rom_table]
0001640 I     [0]<e000e000:SCS v7-M class=14 designer=43b:Arm part=00c> [rom_table]
0001644 I     [1]<e0001000:DWT v7-M class=14 designer=43b:Arm part=002> [rom_table]
0001648 I     [2]<e0002000:FPB v7-M class=14 designer=43b:Arm part=00e> [rom_table]
0001660 I     [3]<e0000000:ITM v7-M class=14 designer=43b:Arm part=001> [rom_table]
0001727 I   [1]<e0041000:ETM M7 class=9 designer=43b:Arm part=975 devtype=13 archid=4a13 devid=0:0:0> [rom_table]
0001732 I   [2]<e0042000:CTI CS-400 class=9 designer=43b:Arm part=906 devtype=14 archid=0000 devid=40800:0:0> [rom_table]
0001738 I [1]<e0043000:Trace Funnel CS-400 class=9 designer=43b:Arm part=908 devtype=12 archid=0000 devid=28:0:0> [rom_table]
0001756 I AHB-AP#1 Class 0x1 ROM table #0 @ 0xe00ff000 (designer=43b:Arm part=4c4) [rom_table]
0001830 I [0]<e000e000:SCS v7-M class=14 designer=43b:Arm part=00c> [rom_table]
0001834 I [1]<e0001000:DWT v7-M class=14 designer=43b:Arm part=002> [rom_table]
0001840 I [2]<e0002000:FPB v7-M class=14 designer=43b:Arm part=003> [rom_table]
0001844 I [3]<e0000000:ITM v7-M class=14 designer=43b:Arm part=001> [rom_table]
0001856 I [5]<e0041000:ETM M4 class=9 designer=43b:Arm part=925 devtype=13 archid=0000 devid=0:0:0> [rom_table]
0001862 I [7]<e0043000:Trace Funnel CS-400 class=9 designer=43b:Arm part=908 devtype=12 archid=0000 devid=28:0:0> [rom_table]
0001868 I [8]<e0042000:CTI CS-400 class=9 designer=43b:Arm part=906 devtype=14 archid=0000 devid=40800:0:0> [rom_table]
0001878 I CPU core #0 is Cortex-M7 r1p2 [cortex_m]
0001885 I FPU present: FPv5-D16-M [cortex_m]
0001982 I 4 hardware watchpoints [dwt]
0002016 I 8 hardware breakpoints, 1 literal comparators [fpb]
0002143 I 4 hardware watchpoints [dwt]
0002175 I 6 hardware breakpoints, 4 literal comparators [fpb]
0002400 I Semihost server started on port 4444 (core 0) [server]
Remote debugging using :3333
0002710 I GDB server started on port 3333 (core 0) [gdbserver]
0002713 I Client connected to port 3333! [gdbserver]
0x002230e8 in ?? ()
0002745 I Attempting to load RTOS plugins [gdbserver]
Successfully halted device
Resetting target
Loading section rom_start, size 0x23a8 lma 0x30000000
Loading section text, size 0x45ac lma 0x300023a8
Loading section .ARM.exidx, size 0x8 lma 0x30006954
Loading section initlevel, size 0xa8 lma 0x3000695c
Loading section device_area, size 0x154 lma 0x30006a04
Loading section sw_isr_table, size 0x6d0 lma 0x30006b58
Loading section log_const_area, size 0x28 lma 0x30007228
Loading section rodata, size 0x2828 lma 0x30007250
Loading section datas, size 0x10 lma 0x30009a78
Loading section device_states, size 0x22 lma 0x30009a88
Loading section .last_section, size 0x4 lma 0x30009aaa
[==================================================] 100%
0005688 I Erased 0 bytes (0 sectors), programmed 0 bytes (0 pages), skipped 39680 bytes (155 pages) at 13.87 kB/s [loader]
--Type <RET> for more, q to quit, c to continue without paging
```