### PR TITLE
drivers: ieee802154: cc13xx_cc26xx{_subg}: fix reversed extended address

### DIFF
--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -527,7 +527,7 @@ static void ieee802154_cc13xx_cc26xx_data_init(const struct device *dev)
 		mac = (uint8_t *)(FCFG1_BASE + FCFG1_O_MAC_15_4_0);
 	}
 
-	memcpy(&drv_data->mac, mac, sizeof(drv_data->mac));
+	sys_memcpy_swap(&drv_data->mac, mac, sizeof(drv_data->mac));
 
 	/* Setup circular RX queue (TRM 25.3.2.7) */
 	memset(&drv_data->rx_entry[0], 0, sizeof(drv_data->rx_entry[0]));

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.h
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.h
@@ -65,7 +65,7 @@ struct ieee802154_cc13xx_cc26xx_data {
 
 	struct net_if *iface;
 
-	uint8_t mac[8];
+	uint8_t mac[8]; /* in big endian */
 
 	struct k_mutex tx_mutex;
 

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -757,7 +757,7 @@ static void ieee802154_cc13xx_cc26xx_subg_data_init(
 		mac = (uint8_t *)(FCFG1_BASE + FCFG1_O_MAC_15_4_0);
 	}
 
-	memcpy(&drv_data->mac, mac, sizeof(drv_data->mac));
+	sys_memcpy_swap(&drv_data->mac, mac, sizeof(drv_data->mac));
 
 	/* Setup circular RX queue (TRM 25.3.2.7) */
 	ieee802154_cc13xx_cc26xx_subg_setup_rx_buffers(drv_data);

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.h
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.h
@@ -36,7 +36,7 @@ struct ieee802154_cc13xx_cc26xx_subg_data {
 	RF_Object rf_object;
 
 	struct net_if *iface;
-	uint8_t mac[8];
+	uint8_t mac[8]; /* in big endian */
 
 	struct k_mutex tx_mutex;
 


### PR DESCRIPTION
Based on the [Technical Reference Manual](https://www.ti.com/lit/pdf/SWCU185) for CC13x2/CC26x2 SimpleLink MCU family, the device contains factory pre-programmed 64-bit IEEE MAC address for 802.15.4 radio inside two `FCFG` 32-bit registers:

1. `MAC_15_4_0`: first 32-bit of the 64-bit IEEE MAC address
2. `MAC_15_4_1`: last 32-bit of the 64-bit IEEE MAC address

The way current version of the driver setups the address results in incorrect bytes order (the address is reversed):
```
uart:~$ ieee802154 get_ext_addr
Extended address: AF:03:B7:25:00:4B:12:00
```
This fixes the problem in both drivers (also in the Sub-GHz version) which results in use of proper EUI-64 address:
```
uart:~$ ieee802154 get_ext_addr
Extended address: 00:12:4B:00:25:B7:03:AF
```
IEEE MAC address was confirmed with `UniFlash`:
![obraz](https://github.com/zephyrproject-rtos/zephyr/assets/2934612/4cac889d-398d-4172-802b-d14c4d6523d3)
nRF Sniffer for 802.15.4:
![obraz](https://github.com/zephyrproject-rtos/zephyr/assets/2934612/a57c66da-06c5-42c6-92d6-6b602ea25819)
and [IEEE OUI](https://standards-oui.ieee.org/) database (`00:12:4B` is one of registered OUI for `Texas Instruments`).

To prevent confusion in future, short notice about bytes order for `mac` field in driver's data structures was also included.