### PR TITLE
display: ssd1306: add some init delay

### DIFF
--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -56,6 +56,7 @@ struct ssd1306_config {
 	struct gpio_dt_spec data_cmd;
 #endif
 	struct gpio_dt_spec reset;
+	int ready_time_ms;
 };
 
 struct ssd1306_data {
@@ -403,6 +404,8 @@ static int ssd1306_init(const struct device *dev)
 
 	LOG_DBG("");
 
+	k_sleep(K_TIMEOUT_ABS_MS(config->ready_time_ms));
+
 	if (!ssd1306_bus_ready(dev)) {
 		LOG_ERR("Bus device %s not ready!", config->bus.bus->name);
 		return -EINVAL;
@@ -434,7 +437,8 @@ static const struct ssd1306_config ssd1306_config = {
 		0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8), 0),
 	.data_cmd = GPIO_DT_SPEC_INST_GET(0, data_cmd_gpios),
 #endif
-	.reset = GPIO_DT_SPEC_INST_GET_OR(0, reset_gpios, { 0 })
+	.reset = GPIO_DT_SPEC_INST_GET_OR(0, reset_gpios, { 0 }),
+	.ready_time_ms = DT_INST_PROP(0, ready_time_ms),
 };
 
 static struct ssd1306_data ssd1306_driver;

--- a/dts/bindings/display/solomon,ssd1306fb-common.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb-common.yaml
@@ -48,3 +48,11 @@ properties:
       The RESET pin of SSD1306 is active low.
       If connected directly the MCU pin should be configured
       as active low.
+
+  ready-time-ms:
+    type: int
+    default: 10
+    description: |
+      Time it takes for the device from power up to become responsive and
+      accepting commands. Defaults to 10ms (found by trial and error) if not
+      provided.


### PR DESCRIPTION
Seems like the SSD1306 controller needs a bit of time after power up before it can take i2c commands. This causes problems with microcontrollers that have no other delays in the startup sequence, like rpi_pico.

There's currently no good way of modeling this in Zephyr right now, and there's also no clear indication of how much time the device needs in the datasheet that I could find, but it seems like 10ms is enough for that to start reliably so add a delay in the ssd1306 init function to ensure that at least that time has passed from system power up.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/53800