### PR TITLE
boards: update ina230 instances

### DIFF
--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -151,10 +151,10 @@
 	vbat_sensor: ina231@44 {
 		compatible = "ti,ina230";
 		reg = <0x44>;
-		config = <INA230_CONFIG(INA230_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT,
-					INA230_CONV_TIME_4156,
-					INA230_CONV_TIME_4156,
-					INA230_AVG_MODE_1024)>;
+		adc-mode = "Bus and shunt voltage continuous";
+		vbus-conversion-time-us = <4156>;
+		vshunt-conversion-time-us = <4156>;
+		avg-count = <1024>;
 		current-lsb-microamps = <1>;
 		rshunt-micro-ohms = <510000>;
 	};
@@ -162,10 +162,10 @@
 	vdd1_codec_sensor: ina231@45 {
 		compatible = "ti,ina230";
 		reg = <0x45>;
-		config = <INA230_CONFIG(INA230_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT,
-					INA230_CONV_TIME_4156,
-					INA230_CONV_TIME_4156,
-					INA230_AVG_MODE_1024)>;
+		adc-mode = "Bus and shunt voltage continuous";
+		vbus-conversion-time-us = <4156>;
+		vshunt-conversion-time-us = <4156>;
+		avg-count = <1024>;
 		current-lsb-microamps = <1>;
 		rshunt-micro-ohms = <2200000>;
 	};
@@ -173,10 +173,10 @@
 	vdd2_codec_sensor: ina231@41 {
 		compatible = "ti,ina230";
 		reg = <0x41>;
-		config = <INA230_CONFIG(INA230_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT,
-					INA230_CONV_TIME_4156,
-					INA230_CONV_TIME_4156,
-					INA230_AVG_MODE_1024)>;
+		adc-mode = "Bus and shunt voltage continuous";
+		vbus-conversion-time-us = <4156>;
+		vshunt-conversion-time-us = <4156>;
+		avg-count = <1024>;
 		current-lsb-microamps = <1>;
 		rshunt-micro-ohms = <2200000>;
 	};
@@ -184,10 +184,10 @@
 	vdd2_nrf_sensor: ina231@40 {
 		compatible = "ti,ina230";
 		reg = <0x40>;
-		config = <INA230_CONFIG(INA230_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT,
-					INA230_CONV_TIME_4156,
-					INA230_CONV_TIME_4156,
-					INA230_AVG_MODE_1024)>;
+		adc-mode = "Bus and shunt voltage continuous";
+		vbus-conversion-time-us = <4156>;
+		vshunt-conversion-time-us = <4156>;
+		avg-count = <1024>;
 		current-lsb-microamps = <1>;
 		rshunt-micro-ohms = <1000000>;
 	};

--- a/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
+++ b/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
@@ -144,11 +144,10 @@
 		status = "okay";
 		compatible = "ti,ina230";
 		reg = <0x40>;
-		config = <INA230_CONFIG(
-			INA230_OPER_MODE_BUS_VOLTAGE_CONT,
-			INA230_CONV_TIME_1100,
-			INA230_CONV_TIME_1100,
-			INA230_AVG_MODE_1)>;
+		adc-mode = "Bus voltage continuous";
+		vbus-conversion-time-us = <1100>;
+		vshunt-conversion-time-us = <1100>;
+		avg-count = <1>;
 		current-lsb-microamps = <1000>;
 		rshunt-micro-ohms = <15000>;
 	};


### PR DESCRIPTION
The configuration definition for the ina230 has been changed in f0f7f8b146 and now the old config option is marked as deprecated, which is failing two boards in CI, nrf5340_audio_dk_nrf5340 and stm32g071b_disco.

Update the ina230 config format to the new one for both boards.

---

Should fix these https://github.com/zephyrproject-rtos/zephyr/runs/16317999807