### PR TITLE
board: arm: openocd support for nucleo_g0b1re

### DIFF
--- a/boards/arm/nucleo_g0b1re/support/openocd.cfg
+++ b/boards/arm/nucleo_g0b1re/support/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32g0x.cfg]
+
+reset_config srst_only


### PR DESCRIPTION
This change adds the openocd support for nucleo-g0b1re board.