### PR TITLE
arm: stm32f7: add support for the stm32f765xx soc

### DIFF
--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Rahul Arasikere
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/f7/stm32f7.dtsi>
+
+/ {
+	/* 128KB DTCM @ 20000000, 368KB SRAM1 @ 20020000,
+	 * 16KB SRAM2 @ 2007C000
+	 */
+
+	sram0: memory@20020000 {
+		compatible = "mmio-sram";
+		reg = <0x20020000 DT_SIZE_K(384)>;
+	};
+
+	dtcm: memory@20000000 {
+		compatible = "zephyr,memory-region", "arm,dtcm";
+		reg = <0x20000000 DT_SIZE_K(128)>;
+		zephyr,memory-region = "DTCM";
+	};
+
+	soc {
+		compatible = "st,stm32f765", "st,stm32f7", "simple-bus";
+
+		pinctrl: pin-controller@40020000 {
+			reg = <0x40020000 0x2C00>;
+
+			gpioj: gpio@40022400 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x40022400 0x400>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000200>;
+			};
+
+			gpiok: gpio@40022800 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x40022800 0x400>;
+				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000400>;
+			};
+		};
+
+		i2c4: i2c@40006000 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40006000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x01000000>;
+			interrupts = <95 0>, <96 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+		};
+
+		spi6: spi@40015400 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40015400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00200000>;
+			interrupts = <86 5>;
+			status = "disabled";
+		};
+
+		mac: ethernet@40028000 {
+			compatible = "st,stm32-ethernet";
+			reg = <0x40028000 0x8000>;
+			interrupts = <61 0>;
+			clock-names = "stmmaceth", "mac-clk-tx",
+				      "mac-clk-rx", "mac-clk-ptp";
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x02000000>,
+				 <&rcc STM32_CLOCK_BUS_AHB1 0x04000000>,
+				 <&rcc STM32_CLOCK_BUS_AHB1 0x08000000>,
+				 <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
+			status = "disabled";
+		};
+
+		sdmmc2: sdmmc@40011c00 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x40011c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>,
+				 <&rcc STM32_SRC_PLL_Q SDMMC2_SEL(0)>;
+			resets = <&rctl STM32_RESET(APB2, 7U)>;
+			interrupts = <103 0>;
+			status = "disabled";
+		};
+
+	};
+};

--- a/dts/arm/st/f7/stm32f765Xg.dtsi
+++ b/dts/arm/st/f7/stm32f765Xg.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Rahul Arasikere
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/f7/stm32f765.dtsi>
+
+/ {
+	soc {
+		flash-controller@40023c00 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(1024)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/f7/stm32f765Xi.dtsi
+++ b/dts/arm/st/f7/stm32f765Xi.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Rahul Arasikere
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/f7/stm32f765.dtsi>
+
+/ {
+	soc {
+		flash-controller@40023c00 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(2048)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -1,95 +1,16 @@
 /*
  * Copyright (c) 2019 Roland Ma
+ * Copyright (c) 2023 Rahul Arasikere
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/f7/stm32f7.dtsi>
+#include <st/f7/stm32f765.dtsi>
 #include <zephyr/dt-bindings/display/panel.h>
 
 / {
-	/* 128KB DTCM @ 20000000, 368KB SRAM1 @ 20020000,
-	 * 16KB SRAM2 @ 2007C000
-	 */
-
-	sram0: memory@20020000 {
-		compatible = "mmio-sram";
-		reg = <0x20020000 DT_SIZE_K(384)>;
-	};
-
-	dtcm: memory@20000000 {
-		compatible = "zephyr,memory-region", "arm,dtcm";
-		reg = <0x20000000 DT_SIZE_K(128)>;
-		zephyr,memory-region = "DTCM";
-	};
-
 	soc {
 		compatible = "st,stm32f767", "st,stm32f7", "simple-bus";
-
-		pinctrl: pin-controller@40020000 {
-			reg = <0x40020000 0x2C00>;
-
-			gpioj: gpio@40022400 {
-				compatible = "st,stm32-gpio";
-				gpio-controller;
-				#gpio-cells = <2>;
-				reg = <0x40022400 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000200>;
-			};
-
-			gpiok: gpio@40022800 {
-				compatible = "st,stm32-gpio";
-				gpio-controller;
-				#gpio-cells = <2>;
-				reg = <0x40022800 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00000400>;
-			};
-		};
-
-		i2c4: i2c@40006000 {
-			compatible = "st,stm32-i2c-v2";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40006000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x01000000>;
-			interrupts = <95 0>, <96 0>;
-			interrupt-names = "event", "error";
-			status = "disabled";
-		};
-
-		spi6: spi@40015400 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40015400 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00200000>;
-			interrupts = <86 5>;
-			status = "disabled";
-		};
-
-		mac: ethernet@40028000 {
-			compatible = "st,stm32-ethernet";
-			reg = <0x40028000 0x8000>;
-			interrupts = <61 0>;
-			clock-names = "stmmaceth", "mac-clk-tx",
-				      "mac-clk-rx", "mac-clk-ptp";
-			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x02000000>,
-				 <&rcc STM32_CLOCK_BUS_AHB1 0x04000000>,
-				 <&rcc STM32_CLOCK_BUS_AHB1 0x08000000>,
-				 <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
-			status = "disabled";
-		};
-
-		sdmmc2: sdmmc@40011c00 {
-			compatible = "st,stm32-sdmmc";
-			reg = <0x40011c00 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>,
-				 <&rcc STM32_SRC_PLL_Q SDMMC2_SEL(0)>;
-			resets = <&rctl STM32_RESET(APB2, 7U)>;
-			interrupts = <103 0>;
-			status = "disabled";
-		};
 
 		ltdc: display-controller@40016800 {
 			compatible = "st,stm32-ltdc";

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f765xx
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f765xx
@@ -1,0 +1,14 @@
+# ST STM32F765XX MCU configuration options
+
+# Copyright (c) 2023 Rahul Arasikere
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32F765XX
+
+config SOC
+	default "stm32f765xx"
+
+config NUM_IRQS
+	default 110
+
+endif # SOC_STM32F765XX

--- a/soc/arm/st_stm32/stm32f7/Kconfig.soc
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.soc
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2018 Yurii Hamann
 # Copyright (c) 2022, Rtone.
+# Copyright (c) 2023, Rahul Arasikere.
 # SPDX-License-Identifier: Apache-2.0
 
 choice
@@ -22,6 +23,10 @@ config SOC_STM32F756XX
 
 config SOC_STM32F750XX
 	bool "STM32F750XX"
+
+config SOC_STM32F765XX
+	bool "STM32F765XX"
+	select CPU_HAS_FPU_DOUBLE_PRECISION
 
 config SOC_STM32F767XX
 	bool "STM32F767XX"


### PR DESCRIPTION
The stm32f765xx series is similar to stm32f767xx series but doesn't include an LCD-TFT peripheral. I have updated the device tree files to have a separate one for the stm32f765 which is then included by the stm32f767 to add lcd-tft display controller node.