### PR TITLE
Some platforms are not default test platforms

### DIFF
--- a/boards/arm/numaker_pfm_m467/numaker_pfm_m467.yaml
+++ b/boards/arm/numaker_pfm_m467/numaker_pfm_m467.yaml
@@ -13,5 +13,3 @@ ram: 512
 flash: 1024
 supported:
   - gpio
-testing:
-  default: true

--- a/boards/arm64/rcar_h3ulcb_ca57/rcar_h3ulcb_ca57.yaml
+++ b/boards/arm64/rcar_h3ulcb_ca57/rcar_h3ulcb_ca57.yaml
@@ -10,7 +10,6 @@ supported:
   - clock_control
   - uart
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth


### PR DESCRIPTION
- boards: numaker_pfm_m467: not a default platform
- boards: rcar_h3ulcb_ca57: not a default platform
