### PR TITLE
boards: arm: Fix deprecated ina230 sensor devicetree properties

### DIFF
--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -151,10 +151,10 @@
 	vbat_sensor: ina231@44 {
 		compatible = "ti,ina230";
 		reg = <0x44>;
-		config = <INA230_CONFIG(INA230_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT,
-					INA230_CONV_TIME_4156,
-					INA230_CONV_TIME_4156,
-					INA230_AVG_MODE_1024)>;
+		adc-mode = "Bus and shunt voltage continuous";
+		vbus-conversion-time-us = <4156>;
+		vshunt-conversion-time-us = <4156>;
+		avg-count = <1024>;
 		current-lsb-microamps = <1>;
 		rshunt-micro-ohms = <510000>;
 	};
@@ -162,10 +162,10 @@
 	vdd1_codec_sensor: ina231@45 {
 		compatible = "ti,ina230";
 		reg = <0x45>;
-		config = <INA230_CONFIG(INA230_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT,
-					INA230_CONV_TIME_4156,
-					INA230_CONV_TIME_4156,
-					INA230_AVG_MODE_1024)>;
+		adc-mode = "Bus and shunt voltage continuous";
+		vbus-conversion-time-us = <4156>;
+		vshunt-conversion-time-us = <4156>;
+		avg-count = <1024>;
 		current-lsb-microamps = <1>;
 		rshunt-micro-ohms = <2200000>;
 	};
@@ -173,10 +173,10 @@
 	vdd2_codec_sensor: ina231@41 {
 		compatible = "ti,ina230";
 		reg = <0x41>;
-		config = <INA230_CONFIG(INA230_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT,
-					INA230_CONV_TIME_4156,
-					INA230_CONV_TIME_4156,
-					INA230_AVG_MODE_1024)>;
+		adc-mode = "Bus and shunt voltage continuous";
+		vbus-conversion-time-us = <4156>;
+		vshunt-conversion-time-us = <4156>;
+		avg-count = <1024>;
 		current-lsb-microamps = <1>;
 		rshunt-micro-ohms = <2200000>;
 	};
@@ -184,10 +184,10 @@
 	vdd2_nrf_sensor: ina231@40 {
 		compatible = "ti,ina230";
 		reg = <0x40>;
-		config = <INA230_CONFIG(INA230_OPER_MODE_SHUNT_BUS_VOLTAGE_CONT,
-					INA230_CONV_TIME_4156,
-					INA230_CONV_TIME_4156,
-					INA230_AVG_MODE_1024)>;
+		adc-mode = "Bus and shunt voltage continuous";
+		vbus-conversion-time-us = <4156>;
+		vshunt-conversion-time-us = <4156>;
+		avg-count = <1024>;
 		current-lsb-microamps = <1>;
 		rshunt-micro-ohms = <1000000>;
 	};

--- a/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
+++ b/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
@@ -144,11 +144,10 @@
 		status = "okay";
 		compatible = "ti,ina230";
 		reg = <0x40>;
-		config = <INA230_CONFIG(
-			INA230_OPER_MODE_BUS_VOLTAGE_CONT,
-			INA230_CONV_TIME_1100,
-			INA230_CONV_TIME_1100,
-			INA230_AVG_MODE_1)>;
+		adc-mode = "Bus and shunt voltage continuous";
+		vbus-conversion-time-us = <1100>;
+		vshunt-conversion-time-us = <1100>;
+		avg-count = <1>;
 		current-lsb-microamps = <1000>;
 		rshunt-micro-ohms = <15000>;
 	};


### PR DESCRIPTION
The ina230 sensor devicetree properties were modified in commit f0f7f8b146805358d15a3c7cad0782bb99ee446f, replacing the combined "config" register property with separate properties for each register field. However, in-tree boards were not updated to use the new properties and their use of the deprecated property caused cmake warnings, which get promoted to failures in CI.

cc: @EricNRS

