### PR TITLE
bt: fix l2cap_chan_le_send_sdu to return total number of bytes sent

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2087,7 +2087,7 @@ static int l2cap_chan_le_send_sdu(struct bt_l2cap_le_chan *ch,
 
 	net_buf_unref(frag);
 
-	return ret;
+	return sent;
 }
 
 static void le_credits(struct bt_l2cap *l2cap, uint8_t ident,

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
@@ -40,7 +40,7 @@ static void chan_connected_cb(struct bt_l2cap_chan *l2cap_chan)
 
 	/* Try to send data */
 	err = bt_l2cap_chan_send(l2cap_chan, buf);
-	if (err) {
+	if (err < 0) {
 		FAIL("Could not send data, error %d\n", err);
 	}
 


### PR DESCRIPTION
Fixes #61578 .

Previously `l2cap_chan_le_send_sdu `returned the number of bytes sent in the last sent sdu `buf` fragment or 0 if the `buf` has only one fragment. It now returns the total number of bytes sent across all `buf` fragments.

This PR also fixes a bsim bluetooth test to only fail when the return value from `l2cap_chan_le_send_sdu` is negative.