### PR TITLE
driver: wifi: eswifi: Fix spi buffer length

### DIFF
--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -66,7 +66,7 @@ static int eswifi_spi_write(struct eswifi_dev *eswifi, char *data, size_t dlen)
 	int status;
 
 	spi_tx_buf[0].buf = data;
-	spi_tx_buf[0].len = dlen / 2; /* 16-bit words */
+	spi_tx_buf[0].len = dlen;
 	spi_tx.buffers = spi_tx_buf;
 	spi_tx.count = ARRAY_SIZE(spi_tx_buf);
 
@@ -88,7 +88,7 @@ static int eswifi_spi_read(struct eswifi_dev *eswifi, char *data, size_t dlen)
 	int status;
 
 	spi_rx_buf[0].buf = data;
-	spi_rx_buf[0].len = dlen / 2; /* 16-bit words */
+	spi_rx_buf[0].len = dlen;
 	spi_rx.buffers = spi_rx_buf;
 	spi_rx.count = ARRAY_SIZE(spi_rx_buf);
 


### PR DESCRIPTION
The eswifi spi driver sets up spi buffer length as number of frames, but the length shall be number of bytes. Because eswifi use 16 bit as frame size, so this turns out reading and writing half of data and fails to sending any at command request and getting any responds from eswifi module.

Fix it by setting up length as number of bytes.

Fixes #62056