### PR TITLE
manifest: hal_intel: update to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -173,7 +173,7 @@ manifest:
       groups:
         - hal
     - name: hal_intel
-      revision: 3d4d4a6195710595e4e5028e687f37525febcf60
+      revision: c72eea412d2563463043a2a6cfe41dc46e845d47
       path: modules/hal/intel
       groups:
         - hal


### PR DESCRIPTION
- fix i2c hang issue
- switch hpet/i2c/uart/gpio to use osxml generated header files for IP registers
- spi dma support