### PR TITLE
mr_canhubk3: add missing pinmux settings for SW2

### DIFF
--- a/boards/arm/mr_canhubk3/mr_canhubk3-pinctrl.dtsi
+++ b/boards/arm/mr_canhubk3/mr_canhubk3-pinctrl.dtsi
@@ -9,7 +9,7 @@
 &pinctrl {
 	eirq0_default: eirq0_default {
 		group1 {
-			pinmux = <PTD15_EIRQ31>, <PTA18_EIRQ0>;
+			pinmux = <PTD15_EIRQ31>, <PTA18_EIRQ0>, <PTA25_EIRQ5>;
 			input-enable;
 		};
 	};


### PR DESCRIPTION
Configure GPIO pin for `sw2` as input for external interrupts.