### PR TITLE
tests: driver: flash_default limited on tier one boards

### DIFF
--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -34,20 +34,18 @@ tests:
       and dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions"))
     integration_platforms:
       - qemu_x86
+      - mimxrt1060_evk
+    platform_allow:
+      - mimxrt1060_evk
+      - it8xxx2_evb
+      - mimxrt685_evk_cm33
+      - mimxrt595_evk_cm33
   drivers.flash.common.tfm_ns:
     build_only: true
     filter: (CONFIG_FLASH_HAS_DRIVER_ENABLED and CONFIG_TRUSTED_EXECUTION_NONSECURE
       and dt_label_with_parent_compat_enabled("slot1_ns_partition", "fixed-partitions"))
     integration_platforms:
       - nrf9161dk_nrf9161_ns
-  drivers.flash.mcux:
-    platform_allow:
-      - mimxrt1060_evk
-      - it8xxx2_evb
-      - mimxrt685_evk_cm33
-      - mimxrt595_evk_cm33
-    integration_platforms:
-      - mimxrt1060_evk
   drivers.flash.common.stm32:
     platform_allow:
       - nucleo_f103rb


### PR DESCRIPTION
remove mcux test scenario, which is overlapped with default limit test to boards listed in the boards list

fixing: #62067