### PR TITLE
boards: xtensa: esp32_ethernet_kit: add missing init.h

### DIFF
--- a/boards/xtensa/esp32_ethernet_kit/board_init.c
+++ b/boards/xtensa/esp32_ethernet_kit/board_init.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 
 #define IP101GRI_RESET_N_PIN	5


### PR DESCRIPTION
File uses SYS_INIT, from init.h.