### PR TITLE
drivers: usb: device: kinetis: s/device.h/init.h

### DIFF
--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -14,7 +14,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/usb/usb_device.h>
-#include <zephyr/device.h>
+#include <zephyr/init.h>
 
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
File was not using any device.h API, but SYS_INIT from init.h.