### PR TITLE
drivers: usb: udc: common: add missing init.h

### DIFF
--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net/buf.h>
 #include <zephyr/sys/byteorder.h>


### PR DESCRIPTION
File was using SYS_INIT, from init.h.