### PR TITLE
drivers: pinctrl: gd32_afio: add missing init.h

### DIFF
--- a/drivers/pinctrl/pinctrl_gd32_afio.c
+++ b/drivers/pinctrl/pinctrl_gd32_afio.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/init.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/gd32.h>
 #include <zephyr/drivers/pinctrl.h>


### PR DESCRIPTION
File was using SYS_INIT, from init.h.