### PR TITLE
ipc_service: static_vrings: fix num_desc return value

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.h
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.h
@@ -163,5 +163,6 @@ static inline unsigned int optimal_num_desc(size_t mem_size, unsigned int buf_si
 		num_desc++;
 	}
 
-	return (1 << (find_msb_set(--num_desc) - 1));
+	/* if num_desc == 1 there is not enough memory */
+	return (--num_desc == 0) ? 0 : (1 << LOG2(num_desc));
 }


### PR DESCRIPTION
currently when no enough memory is found a (1 << (-1)) value is returned instead of 0.
Fix this by returning 0 and simplify log2 computation