### PR TITLE
boards: xtensa: heltec_wifi_lora32_v2: add missing init.h, device.h

### DIFF
--- a/boards/xtensa/heltec_wifi_lora32_v2/board_init.c
+++ b/boards/xtensa/heltec_wifi_lora32_v2/board_init.c
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/init.h>
 
 #define VEXT_PIN  DT_GPIO_PIN(DT_NODELABEL(vext), gpios)
 #define OLED_RST  DT_GPIO_PIN(DT_NODELABEL(oledrst), gpios)


### PR DESCRIPTION
File was using SYS_INIT (init.h) and DEVICE_DT_GET (device.h).