### PR TITLE
soc: xtensa: intel_adsp: common: add missing init.h

### DIFF
--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/check.h>
 #include <zephyr/arch/cpu.h>

--- a/soc/xtensa/intel_adsp/common/boot_complete.c
+++ b/soc/xtensa/intel_adsp/common/boot_complete.c
@@ -5,6 +5,7 @@
 #include <zephyr/arch/xtensa/arch.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/init.h>
 #include <errno.h>
 #include <soc.h>
 

--- a/soc/xtensa/intel_adsp/common/soc.c
+++ b/soc/xtensa/intel_adsp/common/soc.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/device.h>
+#include <zephyr/linker/section_tags.h>
 
 extern void power_init(void);
 extern void adsp_clock_init(void);

--- a/soc/xtensa/intel_adsp/common/soc.c
+++ b/soc/xtensa/intel_adsp/common/soc.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <zephyr/linker/section_tags.h>
 
 extern void power_init(void);


### PR DESCRIPTION
SYS_INIT was used without including init.h.