### PR TITLE
logging: backends: adsp_hda: add missing init.h, device.h

### DIFF
--- a/subsys/logging/backends/log_backend_adsp_hda.c
+++ b/subsys/logging/backends/log_backend_adsp_hda.c
@@ -5,6 +5,8 @@
  */
 
 #include <zephyr/cache.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <zephyr/logging/log_backend.h>
 #include <zephyr/logging/log_core.h>
 #include <zephyr/logging/log_output.h>


### PR DESCRIPTION
File was using device.h/init.h API without including respective headers.