### PR TITLE
drivers: intc: nxp_pint: s/device.h/init.h

### DIFF
--- a/drivers/interrupt_controller/intc_nxp_pint.c
+++ b/drivers/interrupt_controller/intc_nxp_pint.c
@@ -6,7 +6,7 @@
 
 /* Based on STM32 EXTI driver, which is (c) 2016 Open-RnD Sp. z o.o. */
 
-#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <zephyr/irq.h>
 #include <errno.h>
 #include <zephyr/drivers/interrupt_controller/nxp_pint.h>


### PR DESCRIPTION
File is just using APIs from init.h (SYS_INIT).