### PR TITLE
drivers: pinctrl: lpc_iocon: add missing init.h

### DIFF
--- a/drivers/pinctrl/pinctrl_lpc_iocon.c
+++ b/drivers/pinctrl/pinctrl_lpc_iocon.c
@@ -5,6 +5,8 @@
  */
 
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/init.h>
+
 #if !defined(CONFIG_SOC_SERIES_LPC11U6X)
 #include <fsl_clock.h>
 #endif


### PR DESCRIPTION
File was using SYS_INIT without including init.h.