### PR TITLE
soc: arm: nxp_imx: rt10xx: s/device.h/init.h

### DIFF
--- a/soc/arm/nxp_imx/rt/power_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/power_rt10xx.c
@@ -7,7 +7,7 @@
  * sleep mode must be defined within this file, or linked to RAM.
  */
 #include <zephyr/kernel.h>
-#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <zephyr/pm/pm.h>
 #include <fsl_dcdc.h>
 #include <fsl_pmu.h>


### PR DESCRIPTION
File was not using any device.h API, but init.h.