### PR TITLE
soc: arm: nuvoton_npcx: common: s/device.h/init.h

### DIFF
--- a/soc/arm/nuvoton_npcx/common/scfg.c
+++ b/soc/arm/nuvoton_npcx/common/scfg.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/pinctrl/npcx-pinctrl.h>
 #include <zephyr/kernel.h>


### PR DESCRIPTION
File was not using any device.h API, but init.h (SYS_INIT).