### PR TITLE
samples: boards: nrf: dynamic_pinctrl: s/device.h/init.h

### DIFF
--- a/samples/boards/nrf/dynamic_pinctrl/src/remap.c
+++ b/samples/boards/nrf/dynamic_pinctrl/src/remap.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>
 


### PR DESCRIPTION
File was not using any device.h API, but init.h (SYS_INIT).