### PR TITLE
logging: frontend_dict_uart: add missing init.h

### DIFF
--- a/subsys/logging/log_frontend_dict_uart.c
+++ b/subsys/logging/log_frontend_dict_uart.c
@@ -9,6 +9,7 @@
 #include <zephyr/sys/mpsc_pbuf.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/init.h>
 
 static uint32_t dbuf[CONFIG_LOG_FRONTEND_DICT_UART_BUFFER_SIZE / sizeof(uint32_t)];
 


### PR DESCRIPTION
File is using SYS_INIT, from init.h.