### PR TITLE
ipc: ipc_service: backends: rpmsg_static_vrings: add missing init.h

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -8,6 +8,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/cache.h>
 #include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <zephyr/sys/atomic.h>
 
 #include <zephyr/ipc/ipc_service_backend.h>


### PR DESCRIPTION
SYS_INIT was used without including init.h.