### PR TITLE
lorawan: services: add missing init.h

### DIFF
--- a/subsys/lorawan/services/lorawan_services.c
+++ b/subsys/lorawan/services/lorawan_services.c
@@ -7,6 +7,7 @@
 
 #include "lorawan_services.h"
 
+#include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 


### PR DESCRIPTION
File was using SYS_INIT, from init.h.