### PR TITLE
debug: gdbstub: s/device.h/init.h

### DIFF
--- a/subsys/debug/gdbstub.c
+++ b/subsys/debug/gdbstub.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <zephyr/kernel.h>
 
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
File was not using any device.h API, but init.h (SYS_INIT).