### PR TITLE
drivers: pinctrl: stm32: add missing init.h

### DIFF
--- a/drivers/pinctrl/pinctrl_stm32.c
+++ b/drivers/pinctrl/pinctrl_stm32.c
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/init.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <gpio/gpio_stm32.h>


### PR DESCRIPTION
File was using SYS_INIT, from init.h.