### PR TITLE
samples: usb_c: source: power_ctrl: add missing init.h

### DIFF
--- a/samples/subsys/usb_c/source/src/power_ctrl.c
+++ b/samples/subsys/usb_c/source/src/power_ctrl.c
@@ -9,6 +9,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/init.h>
 #include <zephyr/usb_c/usbc.h>
 #include <zephyr/drivers/pwm.h>
 


### PR DESCRIPTION
File was using SYS_INIT without including init.h.