### PR TITLE
boards: thingy53_nrf5340: s/device.h/init.h

### DIFF
--- a/boards/arm/thingy53_nrf5340/board.c
+++ b/boards/arm/thingy53_nrf5340/board.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <soc.h>


### PR DESCRIPTION
File was not using any device.h API, but init.h (SYS_INIT).