### PR TITLE
soc: riscv: telink_b91: add missing init.h, devicetree.h

### DIFF
--- a/soc/riscv/riscv-privileged/telink_b91/soc.c
+++ b/soc/riscv/riscv-privileged/telink_b91/soc.c
@@ -6,7 +6,8 @@
 
 #include "sys.h"
 #include "clock.h"
-#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/devicetree.h>
 
 /* Software reset defines */
 #define reg_reset                   REG_ADDR8(0x1401ef)


### PR DESCRIPTION
File was including device.h for nothing, it needs init.h and devicetree.h instead.