### PR TITLE
drivers: pinctrl: b91: add missing init.h

### DIFF
--- a/drivers/pinctrl/pinctrl_b91.c
+++ b/drivers/pinctrl/pinctrl_b91.c
@@ -7,6 +7,7 @@
 #include "analog.h"
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/b91-pinctrl.h>
+#include <zephyr/init.h>
 
 #define DT_DRV_COMPAT telink_b91_pinctrl
 


### PR DESCRIPTION
File was using SYS_INIT, from init.h.