### PR TITLE
drivers: sensor: lis2dw12: Add Power Domain Handling

### DIFF
--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -108,8 +108,7 @@ static int lis2dw12_set_range(const struct device *dev, uint8_t fs)
 
 	if (!err) {
 		/* save internally gain for optimization */
-		lis2dw12->gain =
-			LIS2DW12_FS_TO_GAIN(fs, shift_gain);
+		lis2dw12->gain = LIS2DW12_FS_TO_GAIN(fs, shift_gain);
 	}
 
 	return err;
@@ -132,7 +131,7 @@ static int lis2dw12_set_odr(const struct device *dev, uint16_t odr)
 		return lis2dw12_data_rate_set(ctx, LIS2DW12_XL_ODR_OFF);
 	}
 
-	val =  LIS2DW12_ODR_TO_REG(odr);
+	val = LIS2DW12_ODR_TO_REG(odr);
 	if (val > LIS2DW12_XL_ODR_1k6Hz) {
 		LOG_ERR("ODR too high");
 		return -ENOTSUP;
@@ -141,8 +140,7 @@ static int lis2dw12_set_odr(const struct device *dev, uint16_t odr)
 	return lis2dw12_data_rate_set(ctx, val);
 }
 
-static inline void lis2dw12_convert(struct sensor_value *val, int raw_val,
-				    float gain)
+static inline void lis2dw12_convert(struct sensor_value *val, int raw_val, float gain)
 {
 	int64_t dval;
 
@@ -153,9 +151,8 @@ static inline void lis2dw12_convert(struct sensor_value *val, int raw_val,
 	val->val2 = dval % 1000000LL;
 }
 
-static inline void lis2dw12_channel_get_acc(const struct device *dev,
-					     enum sensor_channel chan,
-					     struct sensor_value *val)
+static inline void lis2dw12_channel_get_acc(const struct device *dev, enum sensor_channel chan,
+					    struct sensor_value *val)
 {
 	int i;
 	uint8_t ofs_start, ofs_stop;
@@ -173,18 +170,18 @@ static inline void lis2dw12_channel_get_acc(const struct device *dev,
 		ofs_start = ofs_stop = 2U;
 		break;
 	default:
-		ofs_start = 0U; ofs_stop = 2U;
+		ofs_start = 0U;
+		ofs_stop = 2U;
 		break;
 	}
 
-	for (i = ofs_start; i <= ofs_stop ; i++) {
+	for (i = ofs_start; i <= ofs_stop; i++) {
 		lis2dw12_convert(pval++, lis2dw12->acc[i], lis2dw12->gain);
 	}
 }
 
-static int lis2dw12_channel_get(const struct device *dev,
-				 enum sensor_channel chan,
-				 struct sensor_value *val)
+static int lis2dw12_channel_get(const struct device *dev, enum sensor_channel chan,
+				struct sensor_value *val)
 {
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_X:
@@ -202,13 +199,11 @@ static int lis2dw12_channel_get(const struct device *dev,
 }
 
 static int lis2dw12_config(const struct device *dev, enum sensor_channel chan,
-			    enum sensor_attribute attr,
-			    const struct sensor_value *val)
+			   enum sensor_attribute attr, const struct sensor_value *val)
 {
 	switch (attr) {
 	case SENSOR_ATTR_FULL_SCALE:
-		return lis2dw12_set_range(dev,
-				LIS2DW12_FS_TO_REG(sensor_ms2_to_g(val)));
+		return lis2dw12_set_range(dev, LIS2DW12_FS_TO_REG(sensor_ms2_to_g(val)));
 	case SENSOR_ATTR_SAMPLING_FREQUENCY:
 		return lis2dw12_set_odr(dev, val->val1);
 	default:
@@ -218,7 +213,6 @@ static int lis2dw12_config(const struct device *dev, enum sensor_channel chan,
 
 	return -ENOTSUP;
 }
-
 
 static inline int32_t sensor_ms2_to_mg(const struct sensor_value *ms2)
 {
@@ -236,25 +230,22 @@ static inline int32_t sensor_ms2_to_mg(const struct sensor_value *ms2)
 /* Converts a lis2dw12_fs_t range to its value in milli-g
  * Range can be 2/4/8/16G
  */
-#define FS_RANGE_TO_MG(fs_range)	((2U << fs_range) * 1000U)
+#define FS_RANGE_TO_MG(fs_range) ((2U << fs_range) * 1000U)
 
 /* Converts a range in mg to the lsb value for the WK_THS register
  * For the reg value: 1 LSB = 1/64 of FS
  * Range can be 2/4/8/16G
  */
-#define MG_TO_WK_THS_LSB(range_mg)	(range_mg / 64)
+#define MG_TO_WK_THS_LSB(range_mg) (range_mg / 64)
 
 /* Calculates the WK_THS reg value
  * from the threshold in mg and the lsb value in mg
  * with correct integer rounding
  */
-#define THRESHOLD_MG_TO_WK_THS_REG(thr_mg, lsb_mg) \
-	((thr_mg + (lsb_mg / 2)) / lsb_mg)
+#define THRESHOLD_MG_TO_WK_THS_REG(thr_mg, lsb_mg) ((thr_mg + (lsb_mg / 2)) / lsb_mg)
 
-static int lis2dw12_attr_set_thresh(const struct device *dev,
-					enum sensor_channel chan,
-					enum sensor_attribute attr,
-					const struct sensor_value *val)
+static int lis2dw12_attr_set_thresh(const struct device *dev, enum sensor_channel chan,
+				    enum sensor_attribute attr, const struct sensor_value *val)
 {
 	uint8_t reg;
 	size_t ret;
@@ -291,19 +282,17 @@ static int lis2dw12_attr_set_thresh(const struct device *dev,
 	lsb_mg = MG_TO_WK_THS_LSB(FS_RANGE_TO_MG(range));
 	reg = THRESHOLD_MG_TO_WK_THS_REG(thr_mg, lsb_mg);
 
-	LOG_DBG("Threshold %d mg -> fs: %u mg -> reg = %d LSBs",
-			thr_mg, FS_RANGE_TO_MG(range), reg);
+	LOG_DBG("Threshold %d mg -> fs: %u mg -> reg = %d LSBs", thr_mg, FS_RANGE_TO_MG(range),
+		reg);
 	ret = 0;
 
 	return lis2dw12_wkup_threshold_set(ctx, reg);
 }
-#endif
+#endif /* CONFIG_LIS2DW12_THRESHOLD */
 
 #ifdef CONFIG_LIS2DW12_FREEFALL
-static int lis2dw12_attr_set_ff_dur(const struct device *dev,
-					enum sensor_channel chan,
-					enum sensor_attribute attr,
-					const struct sensor_value *val)
+static int lis2dw12_attr_set_ff_dur(const struct device *dev, enum sensor_channel chan,
+				    enum sensor_attribute attr, const struct sensor_value *val)
 {
 	int rc;
 	uint16_t duration;
@@ -332,12 +321,10 @@ static int lis2dw12_attr_set_ff_dur(const struct device *dev,
 	}
 	return rc;
 }
-#endif
+#endif /* CONFIG_LIS2DW12_FREEFALL */
 
-static int lis2dw12_attr_set(const struct device *dev,
-			      enum sensor_channel chan,
-			      enum sensor_attribute attr,
-			      const struct sensor_value *val)
+static int lis2dw12_attr_set(const struct device *dev, enum sensor_channel chan,
+			     enum sensor_attribute attr, const struct sensor_value *val)
 {
 	struct lis2dw12_data *lis2dw12 = dev->data;
 
@@ -373,7 +360,7 @@ static int lis2dw12_attr_set(const struct device *dev,
 	if (attr == SENSOR_ATTR_FF_DUR) {
 		return lis2dw12_attr_set_ff_dur(dev, chan, attr, val);
 	}
-#endif
+#endif /* CONFIG_LIS2DW12_FREEFALL */
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_X:
@@ -389,8 +376,7 @@ static int lis2dw12_attr_set(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static int lis2dw12_sample_fetch(const struct device *dev,
-				 enum sensor_channel chan)
+static int lis2dw12_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct lis2dw12_data *lis2dw12 = dev->data;
 	const struct lis2dw12_device_config *cfg = dev->config;
@@ -446,8 +432,7 @@ static const struct sensor_driver_api lis2dw12_driver_api = {
 	.channel_get = lis2dw12_channel_get,
 };
 
-static int lis2dw12_set_power_mode(const struct device *dev,
-				    lis2dw12_mode_t pm)
+static int lis2dw12_set_power_mode(const struct device *dev, lis2dw12_mode_t pm)
 {
 	const struct lis2dw12_device_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
@@ -468,8 +453,7 @@ static int lis2dw12_set_power_mode(const struct device *dev,
 	return lis2dw12_write_reg(ctx, LIS2DW12_CTRL1, &regval, 1);
 }
 
-static int lis2dw12_set_low_noise(const struct device *dev,
-				  bool low_noise)
+static int lis2dw12_set_low_noise(const struct device *dev, bool low_noise)
 {
 	const struct lis2dw12_device_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
@@ -566,8 +550,7 @@ static int lis2dw12_init(const struct device *dev)
 	}
 
 	LOG_DBG("high pass filter path is %d", (int)cfg->hp_filter_path);
-	lis2dw12_fds_t fds = cfg->hp_filter_path ?
-		LIS2DW12_HIGH_PASS_ON_OUT : LIS2DW12_LPF_ON_OUT;
+	lis2dw12_fds_t fds = cfg->hp_filter_path ? LIS2DW12_HIGH_PASS_ON_OUT : LIS2DW12_LPF_ON_OUT;
 	ret = lis2dw12_filter_path_set(ctx, fds);
 	if (ret < 0) {
 		LOG_ERR("filter path config error %d", (int)cfg->hp_filter_path);
@@ -636,36 +619,35 @@ static int lis2dw12_pm_device_init(const struct device *dev)
  */
 
 #ifdef CONFIG_LIS2DW12_TAP
-#define LIS2DW12_CONFIG_TAP(inst)					\
-	.tap_mode = DT_INST_PROP(inst, tap_mode),			\
-	.tap_threshold = DT_INST_PROP(inst, tap_threshold),		\
-	.tap_shock = DT_INST_PROP(inst, tap_shock),			\
-	.tap_latency = DT_INST_PROP(inst, tap_latency),			\
+#define LIS2DW12_CONFIG_TAP(inst)                                                                  \
+	.tap_mode = DT_INST_PROP(inst, tap_mode),                                                  \
+	.tap_threshold = DT_INST_PROP(inst, tap_threshold),                                        \
+	.tap_shock = DT_INST_PROP(inst, tap_shock),                                                \
+	.tap_latency = DT_INST_PROP(inst, tap_latency),                                            \
 	.tap_quiet = DT_INST_PROP(inst, tap_quiet),
 #else
 #define LIS2DW12_CONFIG_TAP(inst)
 #endif /* CONFIG_LIS2DW12_TAP */
 
 #ifdef CONFIG_LIS2DW12_FREEFALL
-#define LIS2DW12_CONFIG_FREEFALL(inst)					\
-	.freefall_duration = DT_INST_PROP(inst, ff_duration),	\
+#define LIS2DW12_CONFIG_FREEFALL(inst)                                                             \
+	.freefall_duration = DT_INST_PROP(inst, ff_duration),                                      \
 	.freefall_threshold = DT_INST_PROP(inst, ff_threshold),
 #else
 #define LIS2DW12_CONFIG_FREEFALL(inst)
 #endif /* CONFIG_LIS2DW12_FREEFALL */
 
 #ifdef CONFIG_LIS2DW12_TRIGGER
-#define LIS2DW12_CFG_IRQ(inst) \
-	.gpio_int = GPIO_DT_SPEC_INST_GET(inst, irq_gpios),		\
-	.int_pin = DT_INST_PROP(inst, int_pin),
+#define LIS2DW12_CFG_IRQ(inst)                                                                     \
+	.gpio_int = GPIO_DT_SPEC_INST_GET(inst, irq_gpios), .int_pin = DT_INST_PROP(inst, int_pin),
 #else
 #define LIS2DW12_CFG_IRQ(inst)
 #endif /* CONFIG_LIS2DW12_TRIGGER */
 
 #define LIS2DW12_CONFIG_COMMON(inst)                                                               \
-	.pm = DT_INST_PROP(inst, power_mode),                                                      \
-	.odr = DT_INST_PROP_OR(inst, odr, 12), .range = DT_INST_PROP(inst, range),                 \
-	.bw_filt = DT_INST_PROP(inst, bw_filt), .low_noise = DT_INST_PROP(inst, low_noise),        \
+	.pm = DT_INST_PROP(inst, power_mode), .odr = DT_INST_PROP_OR(inst, odr, 12),               \
+	.range = DT_INST_PROP(inst, range), .bw_filt = DT_INST_PROP(inst, bw_filt),                \
+	.low_noise = DT_INST_PROP(inst, low_noise),                                                \
 	.hp_filter_path = DT_INST_PROP(inst, hp_filter_path),                                      \
 	.hp_ref_mode = DT_INST_PROP(inst, hp_ref_mode),                                            \
 	.drdy_pulsed = DT_INST_PROP(inst, drdy_pulsed),                                            \
@@ -690,13 +672,14 @@ static int lis2dw12_pm_device_init(const struct device *dev)
  * Instantiation macros used when a device is on an I2C bus.
  */
 
-#define LIS2DW12_CONFIG_I2C(inst)					\
-	{								\
-		STMEMSC_CTX_I2C(&lis2dw12_config_##inst.stmemsc_cfg),	\
-		.stmemsc_cfg = {					\
-			.i2c = I2C_DT_SPEC_INST_GET(inst),		\
-		},							\
-		LIS2DW12_CONFIG_COMMON(inst)				\
+#define LIS2DW12_CONFIG_I2C(inst)                                                                  \
+	{                                                                                          \
+		STMEMSC_CTX_I2C(&lis2dw12_config_##inst.stmemsc_cfg),                              \
+			.stmemsc_cfg =                                                             \
+				{                                                                  \
+					.i2c = I2C_DT_SPEC_INST_GET(inst),                         \
+				},                                                                 \
+			LIS2DW12_CONFIG_COMMON(inst)                                               \
 	}
 
 /*
@@ -704,12 +687,11 @@ static int lis2dw12_pm_device_init(const struct device *dev)
  * bus-specific macro at preprocessor time.
  */
 
-#define LIS2DW12_DEFINE(inst)						\
-	static struct lis2dw12_data lis2dw12_data_##inst;		\
-	static const struct lis2dw12_device_config lis2dw12_config_##inst =	\
-	COND_CODE_1(DT_INST_ON_BUS(inst, spi),				\
-		    (LIS2DW12_CONFIG_SPI(inst)),			\
-		    (LIS2DW12_CONFIG_I2C(inst)));			\
+#define LIS2DW12_DEFINE(inst)                                                                      \
+	static struct lis2dw12_data lis2dw12_data_##inst;                                          \
+	static const struct lis2dw12_device_config lis2dw12_config_##inst =                        \
+		COND_CODE_1(DT_INST_ON_BUS(inst, spi), (LIS2DW12_CONFIG_SPI(inst)),                \
+			    (LIS2DW12_CONFIG_I2C(inst)));                                          \
 	LIS2DW12_DEVICE_INIT(inst)
 
 DT_INST_FOREACH_STATUS_OKAY(LIS2DW12_DEFINE)

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -27,36 +27,35 @@
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
 
 /* Return ODR reg value based on data rate set */
-#define LIS2DW12_ODR_TO_REG(_odr) \
-	((_odr <= 1) ? LIS2DW12_XL_ODR_1Hz6_LP_ONLY : \
-	 (_odr <= 12) ? LIS2DW12_XL_ODR_12Hz5 : \
-	 ((31 - __builtin_clz(_odr / 25))) + 3)
+#define LIS2DW12_ODR_TO_REG(_odr)                                                                  \
+	((_odr <= 1)    ? LIS2DW12_XL_ODR_1Hz6_LP_ONLY                                             \
+	 : (_odr <= 12) ? LIS2DW12_XL_ODR_12Hz5                                                    \
+			: ((31 - __builtin_clz(_odr / 25))) + 3)
 
 /* Return data rate in Hz for given register value */
-#define LIS2DW12_REG_TO_ODR(_reg) \
-	((_reg == 0) ? 0 : \
-	(_reg == 1) ? 1 : \
-	(_reg == 2) ? 12 : \
-	(_reg > 9) ? 1600 : \
-	(1 << (_reg - 3)) * 25)
+#define LIS2DW12_REG_TO_ODR(_reg)                                                                  \
+	((_reg == 0)   ? 0                                                                         \
+	 : (_reg == 1) ? 1                                                                         \
+	 : (_reg == 2) ? 12                                                                        \
+	 : (_reg > 9)  ? 1600                                                                      \
+		       : (1 << (_reg - 3)) * 25)
 
 /* FS reg value from Full Scale */
-#define LIS2DW12_FS_TO_REG(_fs)	(30 - __builtin_clz(_fs))
+#define LIS2DW12_FS_TO_REG(_fs) (30 - __builtin_clz(_fs))
 
 /* Acc Gain value in ug/LSB in High Perf mode */
-#define LIS2DW12_FS_2G_GAIN		244
-#define LIS2DW12_FS_4G_GAIN		488
-#define LIS2DW12_FS_8G_GAIN		976
-#define LIS2DW12_FS_16G_GAIN		1952
+#define LIS2DW12_FS_2G_GAIN  244
+#define LIS2DW12_FS_4G_GAIN  488
+#define LIS2DW12_FS_8G_GAIN  976
+#define LIS2DW12_FS_16G_GAIN 1952
 
-#define LIS2DW12_SHFT_GAIN_NOLP1	2
+#define LIS2DW12_SHFT_GAIN_NOLP1        2
 #define LIS2DW12_ACCEL_GAIN_DEFAULT_VAL LIS2DW12_FS_2G_GAIN
-#define LIS2DW12_FS_TO_GAIN(_fs, _lp1) \
-		(LIS2DW12_FS_2G_GAIN << ((_fs) + (_lp1)))
+#define LIS2DW12_FS_TO_GAIN(_fs, _lp1)  (LIS2DW12_FS_2G_GAIN << ((_fs) + (_lp1)))
 
 /* shift value for power mode */
-#define LIS2DW12_SHIFT_PM1		4
-#define LIS2DW12_SHIFT_PMOTHER		2
+#define LIS2DW12_SHIFT_PM1     4
+#define LIS2DW12_SHIFT_PMOTHER 2
 
 /**
  * struct lis2dw12_device_config - lis2dw12 hw configuration
@@ -103,9 +102,9 @@ struct lis2dw12_device_config {
 struct lis2dw12_data {
 	int16_t acc[3];
 
-	 /* save sensitivity */
+	/* save sensitivity */
 	uint16_t gain;
-	 /* output data rate */
+	/* output data rate */
 	uint16_t odr;
 	bool continuous_mode_enabled;
 	bool power_domain_claimed;
@@ -143,9 +142,8 @@ struct lis2dw12_data {
 
 #ifdef CONFIG_LIS2DW12_TRIGGER
 int lis2dw12_init_interrupt(const struct device *dev);
-int lis2dw12_trigger_set(const struct device *dev,
-			  const struct sensor_trigger *trig,
-			  sensor_trigger_handler_t handler);
+int lis2dw12_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+			 sensor_trigger_handler_t handler);
 
 /**
  * @brief	This function gets the power domain for the device

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -107,8 +107,11 @@ struct lis2dw12_data {
 	uint16_t gain;
 	 /* output data rate */
 	uint16_t odr;
+	bool continuous_mode_enabled;
+	bool power_domain_claimed;
 
 #ifdef CONFIG_LIS2DW12_TRIGGER
+	bool trigger_callback_enabled;
 	const struct device *dev;
 
 	struct gpio_callback gpio_cb;
@@ -143,6 +146,27 @@ int lis2dw12_init_interrupt(const struct device *dev);
 int lis2dw12_trigger_set(const struct device *dev,
 			  const struct sensor_trigger *trig,
 			  sensor_trigger_handler_t handler);
-#endif /* CONFIG_LIS2DW12_TRIGGER */
 
+/**
+ * @brief	This function gets the power domain for the device
+ *			if CONFIG_PM_DEVICE is enabled, otherwise will set
+ *			the device to busy.
+ * @param	dev [in]. the pointer to the device for which
+ *			we wish to turn the power domain on.
+ * @note	This function should be called AFTER setting
+ *			the respective flags for requesting power
+ */
+void lis2dw12_pm_device_handler_get(const struct device *dev);
+
+/**
+ * @brief	This function puts the power domain for the device
+ *			if CONFIG_PM_DEVICE is enabled, otherwise will clear
+ *			the device's busy status.
+ * @param	dev [in]. the pointer to the device for which
+ *			we wish to turn the power domain off.
+ * @note	This function should be called AFTER clearing
+ *			the respective flags for requesting power
+ */
+void lis2dw12_pm_device_handler_put(const struct device *dev);
+#endif /* CONFIG_LIS2DW12_TRIGGER */
 #endif /* ZEPHYR_DRIVERS_SENSOR_LIS2DW12_LIS2DW12_H_ */

--- a/drivers/sensor/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_trigger.c
@@ -22,8 +22,7 @@ LOG_MODULE_DECLARE(LIS2DW12, CONFIG_SENSOR_LOG_LEVEL);
 /**
  * lis2dw12_enable_int - enable selected int pin to generate interrupt
  */
-static int lis2dw12_enable_int(const struct device *dev,
-			       enum sensor_trigger_type type, int enable)
+static int lis2dw12_enable_int(const struct device *dev, enum sensor_trigger_type type, int enable)
 {
 	const struct lis2dw12_device_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
@@ -33,39 +32,31 @@ static int lis2dw12_enable_int(const struct device *dev,
 	case SENSOR_TRIG_DATA_READY:
 		if (cfg->int_pin == 1) {
 			/* set interrupt for pin INT1 */
-			lis2dw12_pin_int1_route_get(ctx,
-					&int_route.ctrl4_int1_pad_ctrl);
+			lis2dw12_pin_int1_route_get(ctx, &int_route.ctrl4_int1_pad_ctrl);
 			int_route.ctrl4_int1_pad_ctrl.int1_drdy = enable;
 
-			return lis2dw12_pin_int1_route_set(ctx,
-					&int_route.ctrl4_int1_pad_ctrl);
+			return lis2dw12_pin_int1_route_set(ctx, &int_route.ctrl4_int1_pad_ctrl);
 		} else {
 			/* set interrupt for pin INT2 */
-			lis2dw12_pin_int2_route_get(ctx,
-					&int_route.ctrl5_int2_pad_ctrl);
+			lis2dw12_pin_int2_route_get(ctx, &int_route.ctrl5_int2_pad_ctrl);
 			int_route.ctrl5_int2_pad_ctrl.int2_drdy = enable;
 
-			return lis2dw12_pin_int2_route_set(ctx,
-					&int_route.ctrl5_int2_pad_ctrl);
+			return lis2dw12_pin_int2_route_set(ctx, &int_route.ctrl5_int2_pad_ctrl);
 		}
 		break;
 #ifdef CONFIG_LIS2DW12_TAP
 	case SENSOR_TRIG_TAP:
 		/* set interrupt for pin INT1 */
-		lis2dw12_pin_int1_route_get(ctx,
-				&int_route.ctrl4_int1_pad_ctrl);
+		lis2dw12_pin_int1_route_get(ctx, &int_route.ctrl4_int1_pad_ctrl);
 		int_route.ctrl4_int1_pad_ctrl.int1_single_tap = enable;
 
-		return lis2dw12_pin_int1_route_set(ctx,
-				&int_route.ctrl4_int1_pad_ctrl);
+		return lis2dw12_pin_int1_route_set(ctx, &int_route.ctrl4_int1_pad_ctrl);
 	case SENSOR_TRIG_DOUBLE_TAP:
 		/* set interrupt for pin INT1 */
-		lis2dw12_pin_int1_route_get(ctx,
-				&int_route.ctrl4_int1_pad_ctrl);
+		lis2dw12_pin_int1_route_get(ctx, &int_route.ctrl4_int1_pad_ctrl);
 		int_route.ctrl4_int1_pad_ctrl.int1_tap = enable;
 
-		return lis2dw12_pin_int1_route_set(ctx,
-				&int_route.ctrl4_int1_pad_ctrl);
+		return lis2dw12_pin_int1_route_set(ctx, &int_route.ctrl4_int1_pad_ctrl);
 #endif /* CONFIG_LIS2DW12_TAP */
 #ifdef CONFIG_LIS2DW12_THRESHOLD
 	/**
@@ -76,12 +67,10 @@ static int lis2dw12_enable_int(const struct device *dev,
 	 */
 	case SENSOR_TRIG_THRESHOLD:
 		LOG_DBG("Setting int1_wu: %d\n", enable);
-		lis2dw12_pin_int1_route_get(ctx,
-				&int_route.ctrl4_int1_pad_ctrl);
+		lis2dw12_pin_int1_route_get(ctx, &int_route.ctrl4_int1_pad_ctrl);
 		int_route.ctrl4_int1_pad_ctrl.int1_wu = enable;
-		return lis2dw12_pin_int1_route_set(ctx,
-						   &int_route.ctrl4_int1_pad_ctrl);
-#endif
+		return lis2dw12_pin_int1_route_set(ctx, &int_route.ctrl4_int1_pad_ctrl);
+#endif /* CONFIG_LIS2DW12_THRESHOLD */
 #ifdef CONFIG_LIS2DW12_FREEFALL
 	/**
 	 * Trigger fires when the readings does not include Earth's
@@ -91,11 +80,9 @@ static int lis2dw12_enable_int(const struct device *dev,
 	 */
 	case SENSOR_TRIG_FREEFALL:
 		LOG_DBG("Setting int1_ff: %d\n", enable);
-		lis2dw12_pin_int1_route_get(ctx,
-				&int_route.ctrl4_int1_pad_ctrl);
+		lis2dw12_pin_int1_route_get(ctx, &int_route.ctrl4_int1_pad_ctrl);
 		int_route.ctrl4_int1_pad_ctrl.int1_ff = enable;
-		return lis2dw12_pin_int1_route_set(ctx,
-				&int_route.ctrl4_int1_pad_ctrl);
+		return lis2dw12_pin_int1_route_set(ctx, &int_route.ctrl4_int1_pad_ctrl);
 #endif /* CONFIG_LIS2DW12_FREEFALL */
 	default:
 		LOG_ERR("Unsupported trigger interrupt route %d", type);
@@ -106,9 +93,8 @@ static int lis2dw12_enable_int(const struct device *dev,
 /**
  * lis2dw12_trigger_set - link external trigger to event data ready
  */
-int lis2dw12_trigger_set(const struct device *dev,
-			  const struct sensor_trigger *trig,
-			  sensor_trigger_handler_t handler)
+int lis2dw12_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
+			 sensor_trigger_handler_t handler)
 {
 	const struct lis2dw12_device_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
@@ -146,8 +132,7 @@ int lis2dw12_trigger_set(const struct device *dev,
 	case SENSOR_TRIG_TAP:
 	case SENSOR_TRIG_DOUBLE_TAP:
 		/* check if tap detection is enabled  */
-		if ((cfg->tap_threshold[0] == 0) &&
-		    (cfg->tap_threshold[1] == 0) &&
+		if ((cfg->tap_threshold[0] == 0) && (cfg->tap_threshold[1] == 0) &&
 		    (cfg->tap_threshold[2] == 0)) {
 			LOG_ERR("Unsupported sensor trigger");
 			local_ret = -ENOTSUP;
@@ -169,18 +154,17 @@ int lis2dw12_trigger_set(const struct device *dev,
 		break;
 #endif /* CONFIG_LIS2DW12_TAP */
 #ifdef CONFIG_LIS2DW12_THRESHOLD
-	case SENSOR_TRIG_THRESHOLD:
-	{
+	case SENSOR_TRIG_THRESHOLD: {
 		LOG_DBG("Set trigger %d (handler: %p)\n", trig->type, handler);
 		lis2dw12->threshold_handler = handler;
 		lis2dw12->threshold_trig = trig;
 		local_ret = lis2dw12_enable_int(dev, SENSOR_TRIG_THRESHOLD, state);
 		break;
 	}
-#endif
+#endif /* CONFIG_LIS2DW12_THRESHOLD */
 #ifdef CONFIG_LIS2DW12_FREEFALL
 	case SENSOR_TRIG_FREEFALL:
-	LOG_DBG("Set freefall %d (handler: %p)\n", trig->type, handler);
+		LOG_DBG("Set freefall %d (handler: %p)\n", trig->type, handler);
 		lis2dw12->freefall_handler = handler;
 		lis2dw12->freefall_trig = trig;
 		local_ret = lis2dw12_enable_int(dev, SENSOR_TRIG_FREEFALL, state);
@@ -265,7 +249,7 @@ static int lis2dw12_handle_wu_ia_int(const struct device *dev)
 
 	return 0;
 }
-#endif
+#endif /* CONFIG_LIS2DW12_THRESHOLD */
 
 #ifdef CONFIG_LIS2DW12_FREEFALL
 static int lis2dw12_handle_ff_ia_int(const struct device *dev)
@@ -308,22 +292,20 @@ static void lis2dw12_handle_interrupt(const struct device *dev)
 	if (sources.all_int_src.wu_ia) {
 		lis2dw12_handle_wu_ia_int(dev);
 	}
-#endif
+#endif /* CONFIG_LIS2DW12_THRESHOLD */
 #ifdef CONFIG_LIS2DW12_FREEFALL
 	if (sources.all_int_src.ff_ia) {
 		lis2dw12_handle_ff_ia_int(dev);
 	}
 #endif /* CONFIG_LIS2DW12_FREEFALL */
 
-	gpio_pin_interrupt_configure_dt(&cfg->gpio_int,
-					GPIO_INT_EDGE_TO_ACTIVE);
+	gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_EDGE_TO_ACTIVE);
 }
 
-static void lis2dw12_gpio_callback(const struct device *dev,
-				    struct gpio_callback *cb, uint32_t pins)
+static void lis2dw12_gpio_callback(const struct device *dev, struct gpio_callback *cb,
+				   uint32_t pins)
 {
-	struct lis2dw12_data *lis2dw12 =
-		CONTAINER_OF(cb, struct lis2dw12_data, gpio_cb);
+	struct lis2dw12_data *lis2dw12 = CONTAINER_OF(cb, struct lis2dw12_data, gpio_cb);
 	const struct lis2dw12_device_config *cfg = lis2dw12->dev->config;
 
 	if ((pins & BIT(cfg->gpio_int.pin)) == 0U) {
@@ -352,8 +334,7 @@ static void lis2dw12_thread(struct lis2dw12_data *lis2dw12)
 #ifdef CONFIG_LIS2DW12_TRIGGER_GLOBAL_THREAD
 static void lis2dw12_work_cb(struct k_work *work)
 {
-	struct lis2dw12_data *lis2dw12 =
-		CONTAINER_OF(work, struct lis2dw12_data, work);
+	struct lis2dw12_data *lis2dw12 = CONTAINER_OF(work, struct lis2dw12_data, work);
 
 	lis2dw12_handle_interrupt(lis2dw12->dev);
 }
@@ -473,8 +454,7 @@ int lis2dw12_init_interrupt(const struct device *dev)
 	/* setup data ready gpio interrupt (INT1 or INT2) */
 	if (!device_is_ready(cfg->gpio_int.port)) {
 		if (cfg->gpio_int.port) {
-			LOG_ERR("%s: device %s is not ready", dev->name,
-						cfg->gpio_int.port->name);
+			LOG_ERR("%s: device %s is not ready", dev->name, cfg->gpio_int.port->name);
 			return -ENODEV;
 		}
 
@@ -489,10 +469,9 @@ int lis2dw12_init_interrupt(const struct device *dev)
 	k_sem_init(&lis2dw12->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&lis2dw12->thread, lis2dw12->thread_stack,
-		       CONFIG_LIS2DW12_THREAD_STACK_SIZE,
-		       (k_thread_entry_t)lis2dw12_thread, lis2dw12,
-		       NULL, NULL, K_PRIO_COOP(CONFIG_LIS2DW12_THREAD_PRIORITY),
-		       0, K_NO_WAIT);
+			CONFIG_LIS2DW12_THREAD_STACK_SIZE, (k_thread_entry_t)lis2dw12_thread,
+			lis2dw12, NULL, NULL, K_PRIO_COOP(CONFIG_LIS2DW12_THREAD_PRIORITY), 0,
+			K_NO_WAIT);
 #elif defined(CONFIG_LIS2DW12_TRIGGER_GLOBAL_THREAD)
 	lis2dw12->work.handler = lis2dw12_work_cb;
 #endif /* CONFIG_LIS2DW12_TRIGGER_OWN_THREAD */
@@ -503,12 +482,9 @@ int lis2dw12_init_interrupt(const struct device *dev)
 		return ret;
 	}
 
-	LOG_INF("%s: int on %s.%02u", dev->name, cfg->gpio_int.port->name,
-				      cfg->gpio_int.pin);
+	LOG_INF("%s: int on %s.%02u", dev->name, cfg->gpio_int.port->name, cfg->gpio_int.pin);
 
-	gpio_init_callback(&lis2dw12->gpio_cb,
-			   lis2dw12_gpio_callback,
-			   BIT(cfg->gpio_int.pin));
+	gpio_init_callback(&lis2dw12->gpio_cb, lis2dw12_gpio_callback, BIT(cfg->gpio_int.pin));
 
 	if (gpio_add_callback(cfg->gpio_int.port, &lis2dw12->gpio_cb) < 0) {
 		LOG_DBG("Could not set gpio callback");
@@ -517,8 +493,8 @@ int lis2dw12_init_interrupt(const struct device *dev)
 
 	/* set data ready mode on int1/int2 */
 	LOG_DBG("drdy_pulsed is %d", (int)cfg->drdy_pulsed);
-	lis2dw12_drdy_pulsed_t mode = cfg->drdy_pulsed ? LIS2DW12_DRDY_PULSED :
-							 LIS2DW12_DRDY_LATCHED;
+	lis2dw12_drdy_pulsed_t mode =
+		cfg->drdy_pulsed ? LIS2DW12_DRDY_PULSED : LIS2DW12_DRDY_LATCHED;
 
 	ret = lis2dw12_data_ready_mode_set(ctx, mode);
 	if (ret < 0) {
@@ -535,11 +511,10 @@ int lis2dw12_init_interrupt(const struct device *dev)
 
 #ifdef CONFIG_LIS2DW12_FREEFALL
 	ret = lis2dw12_ff_init(dev);
-		if (ret < 0) {
-			return ret;
-		}
+	if (ret < 0) {
+		return ret;
+	}
 #endif /* CONFIG_LIS2DW12_FREEFALL */
 
-	return gpio_pin_interrupt_configure_dt(&cfg->gpio_int,
-					       GPIO_INT_EDGE_TO_ACTIVE);
+	return gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_EDGE_TO_ACTIVE);
 }

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -315,6 +315,8 @@ enum sensor_attribute {
 	SENSOR_ATTR_CALIBRATION,
 	/** Enable/disable sensor features */
 	SENSOR_ATTR_FEATURE_MASK,
+	/** Enable/disable continuous mode. */
+	SENSOR_ATTR_CONTINUOUS_MODE,
 	/** Alert threshold or alert enable/disable */
 	SENSOR_ATTR_ALERT,
 	/** Free-fall duration represented in milliseconds.


### PR DESCRIPTION
The lis2dw12 accelerometer driver now supports power domains via CONFIG_PM_DEVICE. If the config is selected, the driver will be required to provide a power-domain and will initialize itself by enabling pm_device_runtime on this domain.

Tap detection can be enabled by setting the sensor_trigger_set callback to a valid callback function - which in turn gets the power domain and keeps it until sensor_trigger_set is called with a NULL callback. This way, interrupt based events can be caught, while the driver stays on a power domain - assuming that the detection is disabled once it is no longer needed.

Similarly, a sensor attribute for continuous measurement mode has been added to allow for an application to continuously fetch data from the sensor without having to power - and reinitialize - only during a fetch call. When set using sensor_value, the driver keeps the power domain and does not put it back until the attribute is reset again.

Additional flags have been introduced to handle any overlap of domain requesting/putting back. The ability to set the default fifo mode has also been added.

Clang formatting has also been introduced for previously incorrectly formatted source files