### PR TITLE
logging: Add option to prefix message with thread ID

### DIFF
--- a/include/zephyr/logging/log_backend_std.h
+++ b/include/zephyr/logging/log_backend_std.h
@@ -33,6 +33,10 @@ static inline uint32_t log_backend_std_get_flags(void)
 		flags |= LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 	}
 
+	if (IS_ENABLED(CONFIG_LOG_THREAD_ID_PREFIX)) {
+		flags |= LOG_OUTPUT_FLAG_THREAD;
+	}
+
 	return flags;
 }
 

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -79,6 +79,9 @@ struct log_msg_hdr {
 	const void *source;
 	log_timestamp_t timestamp;
 #endif
+#if CONFIG_LOG_THREAD_ID_PREFIX
+	void *tid;
+#endif
 };
 
 /* Messages are aligned to alignment required by cbprintf package. */
@@ -653,6 +656,21 @@ static inline const void *log_msg_get_source(struct log_msg *msg)
 static inline log_timestamp_t log_msg_get_timestamp(struct log_msg *msg)
 {
 	return msg->hdr.timestamp;
+}
+
+/** @brief Get Thread ID.
+ *
+ * @param msg Log message.
+ *
+ * @return Thread ID.
+ */
+static inline void *log_msg_get_tid(struct log_msg *msg)
+{
+#if CONFIG_LOG_THREAD_ID_PREFIX
+	return msg->hdr.tid;
+#else
+	return NULL;
+#endif
 }
 
 /** @brief Get data buffer.

--- a/include/zephyr/logging/log_output.h
+++ b/include/zephyr/logging/log_output.h
@@ -10,6 +10,7 @@
 #include <zephyr/sys/util.h>
 #include <stdarg.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,6 +50,9 @@ extern "C" {
 /** @brief Flag forcing syslog format specified in RFC 5424
  */
 #define LOG_OUTPUT_FLAG_FORMAT_SYSLOG		BIT(6)
+
+/** @brief Flag thread id or name prefix. */
+#define LOG_OUTPUT_FLAG_THREAD			BIT(7)
 
 /**@} */
 
@@ -144,6 +148,7 @@ void log_output_msg_process(const struct log_output *log_output,
  * @param timestamp	Timestamp.
  * @param domain	Domain name string. Can be NULL.
  * @param source	Source name string. Can be NULL.
+ * @param tid		Thread ID.
  * @param level		Criticality level.
  * @param package	Cbprintf package with a logging message string.
  * @param data		Data passed to hexdump API. Can bu NULL.
@@ -154,6 +159,7 @@ void log_output_process(const struct log_output *log_output,
 			log_timestamp_t timestamp,
 			const char *domain,
 			const char *source,
+			const k_tid_t tid,
 			uint8_t level,
 			const uint8_t *package,
 			const uint8_t *data,

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -104,6 +104,12 @@ config LOG_DICTIONARY_SUPPORT
 
 	  This should be selected by the backend automatically.
 
+config LOG_THREAD_ID_PREFIX
+	bool "Thread ID prefix"
+	help
+	  Enable support for prefixing log message with thread name or ID.
+	  Thread name is used if THREAD_NAME is enabled.
+
 config LOG_CUSTOM_FORMAT_SUPPORT
 	bool "Custom format support"
 	default n

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -37,6 +37,9 @@ void z_log_msg_finalize(struct log_msg *msg, const void *source,
 
 	msg->hdr.desc = desc;
 	msg->hdr.source = source;
+#if CONFIG_LOG_THREAD_ID_PREFIX
+	msg->hdr.tid = k_is_in_isr() ? NULL : k_current_get();
+#endif
 	z_log_msg_commit(msg);
 }
 

--- a/tests/subsys/logging/log_output/testcase.yaml
+++ b/tests/subsys/logging/log_output/testcase.yaml
@@ -15,3 +15,9 @@ tests:
       - logging
     extra_configs:
       - CONFIG_LOG_TIMESTAMP_64BIT=y
+  logging.log_output.thread_id:
+    tags:
+      - log_output
+      - logging
+    extra_configs:
+      - CONFIG_LOG_THREAD_ID_PREFIX=y

--- a/tests/subsys/logging/log_timestamp/src/log_timestamp_test.c
+++ b/tests/subsys/logging/log_timestamp/src/log_timestamp_test.c
@@ -71,7 +71,7 @@ ZTEST(test_timestamp, test_custom_timestamp)
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
 	zassert_true(err > 0);
 
-	log_output_process(&log_output, 1, DNAME, SNAME, LOG_LEVEL_INF,
+	log_output_process(&log_output, 1, DNAME, SNAME, NULL, LOG_LEVEL_INF,
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';


### PR DESCRIPTION
Added `CONFIG_LOG_THREAD_ID_PREFIX`.
If set then `tid` is stored in the log message and log message formatting can include thread information (name if `CONFIG_THREAD_NAME=y`)

Example output enabling thread prefix in the logging sample:

```
demo_tag [00:00:01.165,204] <err> [log_demo_thread_id] main: Error message example.
demo_tag [00:00:01.165,230] <wrn> [log_demo_thread_id] main: Warning message example.
demo_tag [00:00:01.165,258] <inf> [log_demo_thread_id] main: Info message example.
```

Fixes #61410.