### PR TITLE
dts: arm: nxp: rt11xx: update snvs pin names to align with new pin data

### DIFF
--- a/dts/arm/nxp/nxp_rt11xx_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx_cm4.dtsi
@@ -298,19 +298,19 @@
 };
 
 &gpio13{
-	pinmux = <&iomuxc_snvs_wakeup_gpio13_io00>,
-		<&iomuxc_snvs_pmic_on_req_gpio13_io01>,
-		<&iomuxc_snvs_pmic_stby_req_gpio13_io02>,
-		<&iomuxc_snvs_gpio_snvs_00_gpio13_io03>,
-		<&iomuxc_snvs_gpio_snvs_01_gpio13_io04>,
-		<&iomuxc_snvs_gpio_snvs_02_gpio13_io05>,
-		<&iomuxc_snvs_gpio_snvs_03_gpio13_io06>,
-		<&iomuxc_snvs_gpio_snvs_04_gpio13_io07>,
-		<&iomuxc_snvs_gpio_snvs_05_gpio13_io08>,
-		<&iomuxc_snvs_gpio_snvs_06_gpio13_io09>,
-		<&iomuxc_snvs_gpio_snvs_07_gpio13_io10>,
-		<&iomuxc_snvs_gpio_snvs_08_gpio13_io11>,
-		<&iomuxc_snvs_gpio_snvs_09_gpio13_io12>;
+	pinmux = <&iomuxc_snvs_wakeup_dig_gpio13_io00>,
+		<&iomuxc_snvs_pmic_on_req_dig_gpio13_io01>,
+		<&iomuxc_snvs_pmic_stby_req_dig_gpio13_io02>,
+		<&iomuxc_snvs_gpio_snvs_00_dig_gpio13_io03>,
+		<&iomuxc_snvs_gpio_snvs_01_dig_gpio13_io04>,
+		<&iomuxc_snvs_gpio_snvs_02_dig_gpio13_io05>,
+		<&iomuxc_snvs_gpio_snvs_03_dig_gpio13_io06>,
+		<&iomuxc_snvs_gpio_snvs_04_dig_gpio13_io07>,
+		<&iomuxc_snvs_gpio_snvs_05_dig_gpio13_io08>,
+		<&iomuxc_snvs_gpio_snvs_06_dig_gpio13_io09>,
+		<&iomuxc_snvs_gpio_snvs_07_dig_gpio13_io10>,
+		<&iomuxc_snvs_gpio_snvs_08_dig_gpio13_io11>,
+		<&iomuxc_snvs_gpio_snvs_09_dig_gpio13_io12>;
 };
 
 &gpio2{

--- a/dts/arm/nxp/nxp_rt11xx_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx_cm7.dtsi
@@ -317,19 +317,19 @@
 };
 
 &gpio13{
-	pinmux = <&iomuxc_snvs_wakeup_gpio13_io00>,
-		<&iomuxc_snvs_pmic_on_req_gpio13_io01>,
-		<&iomuxc_snvs_pmic_stby_req_gpio13_io02>,
-		<&iomuxc_snvs_gpio_snvs_00_gpio13_io03>,
-		<&iomuxc_snvs_gpio_snvs_01_gpio13_io04>,
-		<&iomuxc_snvs_gpio_snvs_02_gpio13_io05>,
-		<&iomuxc_snvs_gpio_snvs_03_gpio13_io06>,
-		<&iomuxc_snvs_gpio_snvs_04_gpio13_io07>,
-		<&iomuxc_snvs_gpio_snvs_05_gpio13_io08>,
-		<&iomuxc_snvs_gpio_snvs_06_gpio13_io09>,
-		<&iomuxc_snvs_gpio_snvs_07_gpio13_io10>,
-		<&iomuxc_snvs_gpio_snvs_08_gpio13_io11>,
-		<&iomuxc_snvs_gpio_snvs_09_gpio13_io12>;
+	pinmux = <&iomuxc_snvs_wakeup_dig_gpio13_io00>,
+		<&iomuxc_snvs_pmic_on_req_dig_gpio13_io01>,
+		<&iomuxc_snvs_pmic_stby_req_dig_gpio13_io02>,
+		<&iomuxc_snvs_gpio_snvs_00_dig_gpio13_io03>,
+		<&iomuxc_snvs_gpio_snvs_01_dig_gpio13_io04>,
+		<&iomuxc_snvs_gpio_snvs_02_dig_gpio13_io05>,
+		<&iomuxc_snvs_gpio_snvs_03_dig_gpio13_io06>,
+		<&iomuxc_snvs_gpio_snvs_04_dig_gpio13_io07>,
+		<&iomuxc_snvs_gpio_snvs_05_dig_gpio13_io08>,
+		<&iomuxc_snvs_gpio_snvs_06_dig_gpio13_io09>,
+		<&iomuxc_snvs_gpio_snvs_07_dig_gpio13_io10>,
+		<&iomuxc_snvs_gpio_snvs_08_dig_gpio13_io11>,
+		<&iomuxc_snvs_gpio_snvs_09_dig_gpio13_io12>;
 };
 
 &gpio2{

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 6f11dd49e7fab534a6925d7103e573622effdaef
+      revision: b0274481021b6343740f1970ef167d65ea67d30b
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update SNVS pin names in RT11xx DTSI files to align with new pin data generated for the RT1176 and RT1166 processors. This pin data is stored within the NXP HAL, so the SHA of the HAL is also updated by this commit.