### PR TITLE
manifest: Update TF-M with shared boot data fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -331,7 +331,7 @@ manifest:
       groups:
         - debug
     - name: trusted-firmware-m
-      revision: 8b6146261fe2c0ad61154e20c7e338601eae2208
+      revision: b168d92c7ed3c77c94d7ce3362bdde5dbffe8424
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Update TF-M version with fix for build with shared boot data enabled, i.e. CONFIG_TFM_MCUBOOT_DATA_SHARING=y.

Regression from: 485fa940aacb2ae810dd722366f46386d93839ca

Fixes #61953