### PR TITLE
scripts: build: Fix check_init_priorities for ARCMWDT compatibility

### DIFF
--- a/scripts/build/check_init_priorities.py
+++ b/scripts/build/check_init_priorities.py
@@ -160,6 +160,10 @@ class ZephyrObjectFile:
             if not section.name.startswith(_INIT_SECTION_PREFIX):
                 continue
 
+            sect_name_num_segments = len(section.name.split("."))
+            if sect_name_num_segments > 3:
+                section.name = section.name.rsplit(".", sect_name_num_segments - 3)[0]
+
             prio = Priority(section.name)
 
             for rel in section.iter_relocations():


### PR DESCRIPTION
ARCMWDT linker generates extended section names (ex.: .rela.z_init_POST_KERNEL40_0_.__init_k_sys_work_q_init).

Default script "build/check_init_priorities.py" is unable to parse such format. That's why normalization for extended names was added. It cuts extra part of name.