### PR TITLE
kernel: spinlock: k_spin_is_locked introduction

### DIFF
--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -265,6 +265,20 @@ static ALWAYS_INLINE void k_spin_unlock(struct k_spinlock *l,
  * @cond INTERNAL_HIDDEN
  */
 
+#if defined(CONFIG_SMP) && defined(CONFIG_TEST)
+/*
+ * @brief Checks if spinlock is held by some CPU, including the local CPU.
+ *		This API shouldn't be used outside the tests for spinlock
+ *
+ * @param l A pointer to the spinlock
+ * @retval true - if spinlock is held by some CPU; false - otherwise
+ */
+static ALWAYS_INLINE bool z_spin_is_locked(struct k_spinlock *l)
+{
+	return l->locked;
+}
+#endif
+
 /* Internal function: releases the lock, but leaves local interrupts disabled */
 static ALWAYS_INLINE void k_spin_release(struct k_spinlock *l)
 {

--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -44,15 +44,15 @@ ZTEST(spinlock, test_spinlock_basic)
 	k_spinlock_key_t key;
 	static struct k_spinlock l;
 
-	zassert_true(!l.locked, "Spinlock initialized to locked");
+	zassert_true(!z_spin_is_locked(&l), "Spinlock initialized to locked");
 
 	key = k_spin_lock(&l);
 
-	zassert_true(l.locked, "Spinlock failed to lock");
+	zassert_true(z_spin_is_locked(&l), "Spinlock failed to lock");
 
 	k_spin_unlock(&l, key);
 
-	zassert_true(!l.locked, "Spinlock failed to unlock");
+	zassert_true(!z_spin_is_locked(&l), "Spinlock failed to unlock");
 }
 
 void bounce_once(int id, bool trylock)
@@ -164,7 +164,7 @@ ZTEST(spinlock, test_spinlock_mutual_exclusion)
 
 	key = k_spin_lock(&lock_runtime);
 
-	zassert_true(lock_runtime.locked, "Spinlock failed to lock");
+	zassert_true(z_spin_is_locked(&lock_runtime), "Spinlock failed to lock");
 
 	/* check irq has not locked */
 	zassert_true(arch_irq_unlocked(key.key),
@@ -184,7 +184,7 @@ ZTEST(spinlock, test_spinlock_mutual_exclusion)
 
 	k_spin_unlock(&lock_runtime, key);
 
-	zassert_true(!lock_runtime.locked, "Spinlock failed to unlock");
+	zassert_true(!z_spin_is_locked(&lock_runtime), "Spinlock failed to unlock");
 }
 
 void trylock_fn(void *p1, void *p2, void *p3)


### PR DESCRIPTION
Currently spinlock internals are directly accessed from the tests. This way the test becomes bound to the particular spinlock implementation. To remove this unnecessary dependency the distinct API to check if spinlock is locked is introduced.

k_spin_is_locked should be used for the spinlock testing only, so the scope of this API is intentionally restricted.