### PR TITLE
drivers: serial: uart_pl011_ambiq.h: Remove reserved CLK frequency

### DIFF
--- a/drivers/serial/uart_pl011_ambiq.h
+++ b/drivers/serial/uart_pl011_ambiq.h
@@ -36,9 +36,6 @@ static inline int pl011_ambiq_clk_set(const struct device *dev, uint32_t clk)
 	case 24000000:
 		clksel = PL011_CR_AMBIQ_CLKSEL_24MHZ;
 		break;
-	case 48000000:
-		clksel = PL011_CR_AMBIQ_CLKSEL_48MHZ;
-		break;
 	default:
 		return -EINVAL;
 	}


### PR DESCRIPTION
UART CLK does not support the 48MHz frequency option.

Tested the apollo4p_evb, samples/hello_world