### PR TITLE
Revert "llvm: use proper syntax for --config option"

### DIFF
--- a/cmake/toolchain/llvm/target.cmake
+++ b/cmake/toolchain/llvm/target.cmake
@@ -49,9 +49,7 @@ elseif(CONFIG_COMPILER_RT_RTLIB)
   set(runtime_lib "compiler_rt")
 endif()
 
-list(APPEND TOOLCHAIN_C_FLAGS
-  "--config=${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg"
-  )
-list(APPEND TOOLCHAIN_LD_FLAGS
-  "--config=${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg"
-  )
+list(APPEND TOOLCHAIN_C_FLAGS --config
+	${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg)
+list(APPEND TOOLCHAIN_LD_FLAGS --config
+	${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg)


### PR DESCRIPTION
This reverts commit 577d47f3f1ea6c624b76c0afb1bc3089f79605f2.

The --config= syntax with the equal sign does not work with clang 15 which is less than one year old (https://releases.llvm.org/). It does not work with clang 14 either.

```
clang --verbose
clang version 15.0.7

clang --help | grep config

  -cl-std=<value>         OpenCL language standard to compile for.
  --config   <value>      Specifies configuration file
  --cuda-feature=<value>  Manually specify the CUDA feature to use

clang: error: unsupported option '--config=/home/runner/work/...
```

The reverted commit mentioned "issues in some situations" without providing any example or other information.
This revert fixes the SOF fuzzer build, see more details in #61778.