### PR TITLE
arch: arm64: core: Fix issue related to generate IPI for non-booted core

### DIFF
--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -190,7 +190,7 @@ static void broadcast_ipi(unsigned int ipi)
 		uint64_t target_mpidr = cpu_map[i];
 		uint8_t aff0;
 
-		if (mpidr == target_mpidr || mpidr == INV_MPID) {
+		if (mpidr == target_mpidr || target_mpidr == INV_MPID) {
 			continue;
 		}
 


### PR DESCRIPTION
During Zephyr boot with SMP enabled,
while z_smp_init is not completed yet and only boot core is running, incorrect code in broadcast_ipi API will cause following:
1. Generate IPI even if other cores are not booted.
2. Incorrect setting of sgi1r register.
3. All the affinity(1/2/3) value will be incorrect.

Signed-off-by: Chirag Kochar <chirag.kochar@intel.com>