### PR TITLE
samples: tfm: Run tfm tests when tfm or mcuboot modules change

### DIFF
--- a/samples/tfm_integration/psa_crypto/sample.yaml
+++ b/samples/tfm_integration/psa_crypto/sample.yaml
@@ -5,7 +5,12 @@ sample:
   name: PSA crypto example
 tests:
   sample.psa_crypto:
-    tags: introduction tfm crypto csr
+    tags:
+      - introduction
+      - tfm
+      - trusted-firmware-m
+      - crypto
+      - csr
     platform_allow: mps2_an521_ns v2m_musca_s1_ns
       nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
       stm32l562e_dk_ns bl5340_dvk_cpuapp_ns

--- a/samples/tfm_integration/psa_crypto/sample.yaml
+++ b/samples/tfm_integration/psa_crypto/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - trusted-firmware-m
       - crypto
       - csr
+      - mcuboot
     platform_allow: mps2_an521_ns v2m_musca_s1_ns
       nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
       stm32l562e_dk_ns bl5340_dvk_cpuapp_ns

--- a/samples/tfm_integration/psa_crypto/sample.yaml
+++ b/samples/tfm_integration/psa_crypto/sample.yaml
@@ -7,7 +7,6 @@ tests:
   sample.psa_crypto:
     tags:
       - introduction
-      - tfm
       - trusted-firmware-m
       - crypto
       - csr

--- a/samples/tfm_integration/psa_protected_storage/sample.yaml
+++ b/samples/tfm_integration/psa_protected_storage/sample.yaml
@@ -31,3 +31,4 @@ tests:
     tags:
       - tfm
       - trusted-firmware-m
+      - mcuboot

--- a/samples/tfm_integration/psa_protected_storage/sample.yaml
+++ b/samples/tfm_integration/psa_protected_storage/sample.yaml
@@ -29,6 +29,5 @@ common:
 tests:
   sample.tfm.protected_storage:
     tags:
-      - tfm
       - trusted-firmware-m
       - mcuboot

--- a/samples/tfm_integration/psa_protected_storage/sample.yaml
+++ b/samples/tfm_integration/psa_protected_storage/sample.yaml
@@ -28,4 +28,6 @@ common:
 
 tests:
   sample.tfm.protected_storage:
-    tags: tfm
+    tags:
+      - tfm
+      - trusted-firmware-m

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -6,7 +6,6 @@ tests:
   sample.tfm_ipc:
     tags:
       - introduction
-      - tfm
       - trusted-firmware-m
       - mcuboot
     platform_allow:
@@ -31,7 +30,6 @@ tests:
   sample.tfm_ipc.no_bl2:
     tags:
       - introduction
-      - tfm
       - trusted-firmware-m
     platform_allow: mps2_an521_ns
     extra_configs:

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -8,6 +8,7 @@ tests:
       - introduction
       - tfm
       - trusted-firmware-m
+      - mcuboot
     platform_allow:
       - mps2_an521_ns
       - nrf5340dk_nrf5340_cpuapp_ns

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -7,6 +7,7 @@ tests:
     tags:
       - introduction
       - tfm
+      - trusted-firmware-m
     platform_allow:
       - mps2_an521_ns
       - nrf5340dk_nrf5340_cpuapp_ns
@@ -30,6 +31,7 @@ tests:
     tags:
       - introduction
       - tfm
+      - trusted-firmware-m
     platform_allow: mps2_an521_ns
     extra_configs:
       - CONFIG_TFM_BL2=n

--- a/samples/tfm_integration/tfm_psa_test/sample.yaml
+++ b/samples/tfm_integration/tfm_psa_test/sample.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: tfm
+  tags:
+    - tfm
+    - trusted-firmware-m
   platform_allow:
     - mps2_an521_ns
     - nrf5340dk_nrf5340_cpuapp_ns

--- a/samples/tfm_integration/tfm_psa_test/sample.yaml
+++ b/samples/tfm_integration/tfm_psa_test/sample.yaml
@@ -1,6 +1,5 @@
 common:
   tags:
-    - tfm
     - trusted-firmware-m
     - mcuboot
   platform_allow:

--- a/samples/tfm_integration/tfm_psa_test/sample.yaml
+++ b/samples/tfm_integration/tfm_psa_test/sample.yaml
@@ -2,6 +2,7 @@ common:
   tags:
     - tfm
     - trusted-firmware-m
+    - mcuboot
   platform_allow:
     - mps2_an521_ns
     - nrf5340dk_nrf5340_cpuapp_ns

--- a/samples/tfm_integration/tfm_regression_test/sample.yaml
+++ b/samples/tfm_integration/tfm_regression_test/sample.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: tfm
+  tags:
+    - tfm
+    - trusted-firmware-m
   platform_allow:
 
     - nrf5340dk_nrf5340_cpuapp_ns

--- a/samples/tfm_integration/tfm_regression_test/sample.yaml
+++ b/samples/tfm_integration/tfm_regression_test/sample.yaml
@@ -2,6 +2,7 @@ common:
   tags:
     - tfm
     - trusted-firmware-m
+    - mcuboot
   platform_allow:
 
     - nrf5340dk_nrf5340_cpuapp_ns

--- a/samples/tfm_integration/tfm_regression_test/sample.yaml
+++ b/samples/tfm_integration/tfm_regression_test/sample.yaml
@@ -1,6 +1,5 @@
 common:
   tags:
-    - tfm
     - trusted-firmware-m
     - mcuboot
   platform_allow:

--- a/samples/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/tfm_integration/tfm_secure_partition/sample.yaml
@@ -1,5 +1,7 @@
 common:
-  tags: tfm
+  tags:
+    - tfm
+    - trusted-firmware-m
   platform_allow:
     - mps2_an521_ns
     - v2m_musca_s1_ns
@@ -22,4 +24,6 @@ sample:
 
 tests:
   sample.tfm.secure_partition:
-    tags: tfm
+    tags:
+      - tfm
+      - trusted-firmware-m

--- a/samples/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/tfm_integration/tfm_secure_partition/sample.yaml
@@ -27,3 +27,4 @@ tests:
     tags:
       - tfm
       - trusted-firmware-m
+      - mcuboot

--- a/samples/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/tfm_integration/tfm_secure_partition/sample.yaml
@@ -1,6 +1,5 @@
 common:
   tags:
-    - tfm
     - trusted-firmware-m
   platform_allow:
     - mps2_an521_ns
@@ -25,6 +24,5 @@ sample:
 tests:
   sample.tfm.secure_partition:
     tags:
-      - tfm
       - trusted-firmware-m
       - mcuboot


### PR DESCRIPTION
Now that CI supports running tests, via tag, on changes that modify a module, add the tags necessary to the TF-M tests so that these tests are run in any PR where tfm or mcuboot are modified.  This should reduces the cases where an mcuboot change breaks tfm, and this is not caught.