### PR TITLE
drivers/serial/uart_xlnx_ps.c: uart_xlnx_ps_driver_api is defined twice

### DIFF
--- a/drivers/serial/uart_xlnx_ps.c
+++ b/drivers/serial/uart_xlnx_ps.c
@@ -163,8 +163,6 @@ struct uart_xlnx_ps_dev_data_t {
 #endif
 };
 
-static const struct uart_driver_api uart_xlnx_ps_driver_api;
-
 /**
  * @brief Disables the UART's RX and TX function.
  *


### PR DESCRIPTION
The var "uart_xlnx_ps_driver_api" is defined twice in the source, so remove one definition of it.