### PR TITLE
tests: drivers: clock_control: nrf_lf_clock_start: Clean up

### DIFF
--- a/tests/drivers/clock_control/nrf_lf_clock_start/prj.conf
+++ b/tests/drivers/clock_control/nrf_lf_clock_start/prj.conf
@@ -1,5 +1,2 @@
 CONFIG_ZTEST=y
 CONFIG_ZTEST_NEW_API=y
-
-# Disable boot banner to reduce time between clock start and test execution
-CONFIG_BOOT_BANNER=n


### PR DESCRIPTION
After 31767a0bc there is no need to disable boot banner because initial clock state is read in POST_KERNEL stage before the boot banner is printed.