### PR TITLE
drivers: clock: stm32: overdrive after sysclock

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -723,20 +723,11 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Some clocks would be activated by default */
 	config_enable_default_clocks();
 
-#if defined(STM32_PLL_ENABLED) && defined(CONFIG_SOC_SERIES_STM32F7X)
-	/* Assuming we stay on Power Scale default value: Power Scale 1 */
-	if (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC > 180000000) {
-		/* Set Overdrive if needed before configuring the Flash Latency */
-		LL_PWR_EnableOverDriveMode();
-		while (LL_PWR_IsActiveFlag_OD() != 1) {
-		/* Wait for OverDrive mode ready */
-		}
-		LL_PWR_EnableOverDriveSwitching();
-		while (LL_PWR_IsActiveFlag_ODSW() != 1) {
-		/* Wait for OverDrive switch ready */
-		}
-	}
-#endif /* STM32_PLL_ENABLED && CONFIG_SOC_SERIES_STM32F7X */
+	/* Set up indiviual enabled clocks */
+	set_up_fixed_clock_sources();
+
+	/* Set up PLLs */
+	set_up_plls();
 
 #if defined(FLASH_ACR_LATENCY)
 	uint32_t old_flash_freq;
@@ -753,12 +744,6 @@ int stm32_clock_control_init(const struct device *dev)
 		LL_SetFlashLatency(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
 	}
 #endif /* FLASH_ACR_LATENCY */
-
-	/* Set up indiviual enabled clocks */
-	set_up_fixed_clock_sources();
-
-	/* Set up PLLs */
-	set_up_plls();
 
 	if (DT_PROP(DT_NODELABEL(rcc), undershoot_prevention) &&
 		(STM32_CORE_PRESCALER == LL_RCC_SYSCLK_DIV_1) &&


### PR DESCRIPTION
According to the reference manual the overdrive should be enabled after setup of the sysclock (HSE or HSI) and enabling the PLL (PLLON). The flash latency should be enabled after the PLL has been turned on, but before switching the system clock to the PLL.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/62130