### PR TITLE
Unify soc name

### DIFF
--- a/soc/arm64/nxp_imx/mimx8m/Kconfig.defconfig.mimx8mm
+++ b/soc/arm64/nxp_imx/mimx8m/Kconfig.defconfig.mimx8mm
@@ -1,10 +1,10 @@
-# Copyright 2020-2022 NXP
+# Copyright 2020-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_MIMX8MM_A53
 
 config SOC
-	default "mimx8mm6"
+	default "mimx8mm6_ca53"
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_FLASH := zephyr,flash

--- a/soc/arm64/nxp_imx/mimx8m/Kconfig.defconfig.mimx8mn
+++ b/soc/arm64/nxp_imx/mimx8m/Kconfig.defconfig.mimx8mn
@@ -1,10 +1,10 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_MIMX8MN_A53
 
 config SOC
-	default "mimx8mn6"
+	default "mimx8mn6_ca53"
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_FLASH := zephyr,flash

--- a/soc/arm64/nxp_imx/mimx8m/Kconfig.defconfig.mimx8mp
+++ b/soc/arm64/nxp_imx/mimx8m/Kconfig.defconfig.mimx8mp
@@ -1,10 +1,10 @@
-# Copyright 2021-2022 NXP
+# Copyright 2021-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_MIMX8MP_A53
 
 config SOC
-	default "mimx8ml8"
+	default "mimx8ml8_ca53"
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_FLASH := zephyr,flash

--- a/soc/arm64/nxp_imx/mimx9/Kconfig.defconfig.mimx93
+++ b/soc/arm64/nxp_imx/mimx9/Kconfig.defconfig.mimx93
@@ -1,10 +1,10 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_MIMX93_A55
 
 config SOC
-	default "mimx9352"
+	default "mimx9352_ca55"
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_FLASH := zephyr,flash

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 78d1912dbc2b5f6e114d7fd19a31053716a3b01d
+      revision: 03bd989de4d2de151470e8b6068bc5686f3fc84c
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
In hal_nxp, MCUX_DEVICE is defined according to CONFIG_SOC, and MCUX_DEVICE is followed by CPU Core name in mcux-sdk, so let's unify with MCUX_DEVICE definition with mcux-sdk.

This PR depends on https://github.com/zephyrproject-rtos/hal_nxp/pull/268