### PR TITLE
drivers: gpio: ite_it8xxx2: add missing init.h

### DIFF
--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/ite-it8xxx2-gpio.h>
 #include <zephyr/dt-bindings/interrupt-controller/ite-intc.h>
+#include <zephyr/init.h>
 #include <zephyr/irq.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>


### PR DESCRIPTION
File was using SYS_INIT without including init.h.