### PR TITLE
ipc: rpmsg_service: add missing init.h

### DIFF
--- a/samples/subsys/ipc/rpmsg_service/remote/src/main.c
+++ b/samples/subsys/ipc/rpmsg_service/remote/src/main.c
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/ipm.h>
 #include <zephyr/sys/printk.h>

--- a/subsys/ipc/rpmsg_service/rpmsg_backend.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_backend.c
@@ -9,6 +9,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/ipm.h>
 #include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 
 #include <openamp/open_amp.h>


### PR DESCRIPTION
File was using SYS_INIT without including init.h.