### PR TITLE
scripts: build: elf_parser: _DEVICE_STRUCT_HANDLES_OFFSET is optional

### DIFF
--- a/scripts/build/elf_parser.py
+++ b/scripts/build/elf_parser.py
@@ -100,8 +100,11 @@ class Device(_Symbol):
         # Point to the handles instance associated with the device;
         # assigned by correlating the device struct handles pointer
         # value with the addr of a Handles instance.
-        ordinal_offset = self.elf.ld_consts['_DEVICE_STRUCT_HANDLES_OFFSET']
-        self.obj_ordinals = self._data_native_read(ordinal_offset)
+        self.obj_ordinals = None
+        if '_DEVICE_STRUCT_HANDLES_OFFSET' in self.elf.ld_consts:
+            ordinal_offset = self.elf.ld_consts['_DEVICE_STRUCT_HANDLES_OFFSET']
+            self.obj_ordinals = self._data_native_read(ordinal_offset)
+
         self.obj_pm = None
         if '_DEVICE_STRUCT_PM_OFFSET' in self.elf.ld_consts:
             pm_offset = self.elf.ld_consts['_DEVICE_STRUCT_PM_OFFSET']


### PR DESCRIPTION
It is only available if CONFIG_DEVICE_DEPS=y, so the ZephyrElf class would fail to load if it does not treat _DEVICE_STRUCT_HANDLES_OFFSET as optional.