### PR TITLE
drivers: sensor: bmm150: support pm turn on/off

### DIFF
--- a/drivers/sensor/bmm150/bmm150.h
+++ b/drivers/sensor/bmm150/bmm150.h
@@ -180,10 +180,7 @@ struct bmm150_data {
 	struct k_work work;
 #endif
 
-#if defined(CONFIG_BMM150_TRIGGER_GLOBAL_THREAD) || \
-	defined(CONFIG_BMM150_TRIGGER_DIRECT)
 	const struct device *dev;
-#endif
 
 #ifdef CONFIG_BMM150_TRIGGER
 	const struct sensor_trigger *drdy_trigger;

--- a/drivers/sensor/bmm150/bmm150_trigger.c
+++ b/drivers/sensor/bmm150/bmm150_trigger.c
@@ -67,6 +67,13 @@ static void bmm150_gpio_callback(const struct device *port,
 	ARG_UNUSED(port);
 	ARG_UNUSED(pin);
 
+	enum pm_device_state state;
+
+	(void)pm_device_state_get(data->dev, &state);
+	if (state != PM_DEVICE_STATE_ACTIVE) {
+		return;
+	}
+
 #if defined(CONFIG_BMM150_TRIGGER_OWN_THREAD)
 	k_sem_give(&data->sem);
 #elif defined(CONFIG_BMM150_TRIGGER_GLOBAL_THREAD)
@@ -146,10 +153,7 @@ int bmm150_trigger_mode_init(const struct device *dev)
 	k_work_init(&data->work, bmm150_work_handler);
 #endif
 
-#if defined(CONFIG_BMM150_TRIGGER_GLOBAL_THREAD) || \
-	defined(CONFIG_BMM150_TRIGGER_DIRECT)
 	data->dev = dev;
-#endif
 
 	ret = gpio_pin_configure_dt(&cfg->drdy_int, GPIO_INPUT);
 	if (ret < 0) {


### PR DESCRIPTION
This patch extends PM support for BMM150 driver
to be able to reinitialize the device after it was cut off the power.