### PR TITLE
Bluetooth: Audio: Rename codec qos framing

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -410,9 +410,9 @@ enum bt_audio_dir {
 	}
 
 /** @brief Codec QoS Framing */
-enum {
-	BT_AUDIO_CODEC_QOS_UNFRAMED = 0x00,
-	BT_AUDIO_CODEC_QOS_FRAMED = 0x01,
+enum bt_audio_codec_qos_framing {
+	BT_AUDIO_CODEC_QOS_FRAMING_UNFRAMED = 0x00,
+	BT_AUDIO_CODEC_QOS_FRAMING_FRAMED = 0x01,
 };
 
 /** @brief Codec QoS Preferred PHY */
@@ -432,8 +432,8 @@ enum {
  *  @param _pd Presentation Delay (usec)
  */
 #define BT_AUDIO_CODEC_QOS_UNFRAMED(_interval, _sdu, _rtn, _latency, _pd)                          \
-	BT_AUDIO_CODEC_QOS(_interval, BT_AUDIO_CODEC_QOS_UNFRAMED, BT_AUDIO_CODEC_QOS_2M, _sdu,    \
-			   _rtn, _latency, _pd)
+	BT_AUDIO_CODEC_QOS(_interval, BT_AUDIO_CODEC_QOS_FRAMING_UNFRAMED, BT_AUDIO_CODEC_QOS_2M,  \
+			   _sdu, _rtn, _latency, _pd)
 
 /**
  *  @brief Helper to declare Input Framed bt_audio_codec_qos
@@ -445,8 +445,8 @@ enum {
  *  @param _pd Presentation Delay (usec)
  */
 #define BT_AUDIO_CODEC_QOS_FRAMED(_interval, _sdu, _rtn, _latency, _pd)                            \
-	BT_AUDIO_CODEC_QOS(_interval, BT_AUDIO_CODEC_QOS_FRAMED, BT_AUDIO_CODEC_QOS_2M, _sdu,      \
-			   _rtn, _latency, _pd)
+	BT_AUDIO_CODEC_QOS(_interval, BT_AUDIO_CODEC_QOS_FRAMING_FRAMED, BT_AUDIO_CODEC_QOS_2M,    \
+			   _sdu, _rtn, _latency, _pd)
 
 /** @brief Codec QoS structure. */
 struct bt_audio_codec_qos {
@@ -454,7 +454,7 @@ struct bt_audio_codec_qos {
 	uint8_t  phy;
 
 	/** QoS Framing */
-	uint8_t  framing;
+	enum bt_audio_codec_qos_framing framing;
 
 	/** QoS Retransmission Number */
 	uint8_t rtn;

--- a/include/zephyr/bluetooth/audio/bap_lc3_preset.h
+++ b/include/zephyr/bluetooth/audio/bap_lc3_preset.h
@@ -119,7 +119,7 @@ struct bt_bap_lc3_preset {
  */
 #define BT_BAP_LC3_UNICAST_PRESET_441_1_1(_loc, _stream_context)                                   \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_1(_loc, _stream_context),                  \
-			  BT_AUDIO_CODEC_QOS(8163u, BT_AUDIO_CODEC_QOS_FRAMED,                     \
+			  BT_AUDIO_CODEC_QOS(8163u, BT_AUDIO_CODEC_QOS_FRAMING_FRAMED,             \
 					     BT_AUDIO_CODEC_QOS_2M, 97u, 5u, 24u, 40000u))
 
 /**
@@ -130,7 +130,7 @@ struct bt_bap_lc3_preset {
  */
 #define BT_BAP_LC3_UNICAST_PRESET_441_2_1(_loc, _stream_context)                                   \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                  \
-			  BT_AUDIO_CODEC_QOS(10884u, BT_AUDIO_CODEC_QOS_FRAMED,                    \
+			  BT_AUDIO_CODEC_QOS(10884u, BT_AUDIO_CODEC_QOS_FRAMING_FRAMED,            \
 					     BT_AUDIO_CODEC_QOS_2M, 130u, 5u, 31u, 40000u))
 
 /**
@@ -282,7 +282,7 @@ struct bt_bap_lc3_preset {
  */
 #define BT_BAP_LC3_UNICAST_PRESET_441_1_2(_loc, _stream_context)                                   \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_1(_loc, _stream_context),                  \
-			  BT_AUDIO_CODEC_QOS(8163u, BT_AUDIO_CODEC_QOS_FRAMED,                     \
+			  BT_AUDIO_CODEC_QOS(8163u, BT_AUDIO_CODEC_QOS_FRAMING_FRAMED,             \
 					     BT_AUDIO_CODEC_QOS_2M, 97u, 13u, 80u, 40000u))
 
 /**
@@ -293,7 +293,7 @@ struct bt_bap_lc3_preset {
  */
 #define BT_BAP_LC3_UNICAST_PRESET_441_2_2(_loc, _stream_context)                                   \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                  \
-			  BT_AUDIO_CODEC_QOS(10884u, BT_AUDIO_CODEC_QOS_FRAMED,                    \
+			  BT_AUDIO_CODEC_QOS(10884u, BT_AUDIO_CODEC_QOS_FRAMING_FRAMED,            \
 					     BT_AUDIO_CODEC_QOS_2M, 130u, 13u, 85u, 40000u))
 
 /**
@@ -449,7 +449,7 @@ struct bt_bap_lc3_preset {
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_441_1_1(_loc, _stream_context)                                 \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_1(_loc, _stream_context),                  \
-			  BT_AUDIO_CODEC_QOS(8163u, BT_AUDIO_CODEC_QOS_FRAMED,                     \
+			  BT_AUDIO_CODEC_QOS(8163u, BT_AUDIO_CODEC_QOS_FRAMING_FRAMED,             \
 					     BT_AUDIO_CODEC_QOS_2M, 97u, 4u, 24u, 40000u))
 
 /**
@@ -460,7 +460,7 @@ struct bt_bap_lc3_preset {
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_441_2_1(_loc, _stream_context)                                 \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                  \
-			  BT_AUDIO_CODEC_QOS(10884u, BT_AUDIO_CODEC_QOS_FRAMED,                    \
+			  BT_AUDIO_CODEC_QOS(10884u, BT_AUDIO_CODEC_QOS_FRAMING_FRAMED,            \
 					     BT_AUDIO_CODEC_QOS_2M, 130u, 4u, 31u, 40000u))
 
 /**
@@ -616,7 +616,7 @@ struct bt_bap_lc3_preset {
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_441_1_2(_loc, _stream_context)                                 \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_1(_loc, _stream_context),                  \
-			  BT_AUDIO_CODEC_QOS(8163u, BT_AUDIO_CODEC_QOS_FRAMED,                     \
+			  BT_AUDIO_CODEC_QOS(8163u, BT_AUDIO_CODEC_QOS_FRAMING_FRAMED,             \
 					     BT_AUDIO_CODEC_QOS_2M, 97u, 4u, 54u, 40000u))
 
 /**
@@ -627,7 +627,7 @@ struct bt_bap_lc3_preset {
  */
 #define BT_BAP_LC3_BROADCAST_PRESET_441_2_2(_loc, _stream_context)                                 \
 	BT_BAP_LC3_PRESET(BT_AUDIO_CODEC_LC3_CONFIG_441_2(_loc, _stream_context),                  \
-			  BT_AUDIO_CODEC_QOS(10884u, BT_AUDIO_CODEC_QOS_FRAMED,                    \
+			  BT_AUDIO_CODEC_QOS(10884u, BT_AUDIO_CODEC_QOS_FRAMING_FRAMED,            \
 					     BT_AUDIO_CODEC_QOS_2M, 130u, 4u, 60u, 40000u))
 
 /**

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -155,7 +155,7 @@ enum bt_bap_ascs_reason bt_audio_verify_qos(const struct bt_audio_codec_qos *qos
 		return BT_BAP_ASCS_REASON_INTERVAL;
 	}
 
-	if (qos->framing > BT_AUDIO_CODEC_QOS_FRAMED) {
+	if (qos->framing > BT_AUDIO_CODEC_QOS_FRAMING_FRAMED) {
 		LOG_DBG("Invalid Framing 0x%02x", qos->framing);
 		return BT_BAP_ASCS_REASON_FRAMING;
 	}

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
@@ -421,7 +421,7 @@ static void broadcast_source_create_inval(void)
 
 	memcpy(&qos, &preset_16_2_1.qos, sizeof(preset_16_2_1.qos));
 
-	qos.framing = BT_AUDIO_CODEC_QOS_FRAMED + 1;
+	qos.framing = BT_AUDIO_CODEC_QOS_FRAMING_FRAMED + 1;
 
 	printk("Test bt_bap_broadcast_source_create with qos.framing 0x%02X\n", qos.framing);
 	err = bt_bap_broadcast_source_create(&create_param, &broadcast_sources[0]);
@@ -851,7 +851,7 @@ static void test_broadcast_source_reconfig_inval(struct bt_bap_broadcast_source 
 
 	memcpy(&qos, &preset_16_2_1.qos, sizeof(preset_16_2_1.qos));
 
-	qos.framing = BT_AUDIO_CODEC_QOS_FRAMED + 1;
+	qos.framing = BT_AUDIO_CODEC_QOS_FRAMING_FRAMED + 1;
 
 	printk("Test bt_bap_broadcast_source_reconfig with qos.framing %u\n", qos.framing);
 	err = bt_bap_broadcast_source_reconfig(source, &preset_16_2_1.codec_cfg, &qos);


### PR DESCRIPTION
Rename BT_AUDIO_CODEC_QOS_[UN]FRAMED to
BT_AUDIO_CODEC_QOS_FRAMING_[UN]FRAMED and give a name to the enum, which is then used by the
struct bt_audio_codec_qos.

The rename was needed as we had a codec_qos initializer of the same name, so the values were renamed to avoid duplicated macro names.