### PR TITLE
Fix missuse of internal API in tests/kernel/interrupt/arch.interrupt for POSIX boards

### DIFF
--- a/include/zephyr/arch/posix/posix_soc_if.h
+++ b/include/zephyr/arch/posix/posix_soc_if.h
@@ -31,6 +31,8 @@ unsigned int posix_irq_lock(void);
 void posix_irq_unlock(unsigned int key);
 void posix_irq_full_unlock(void);
 int  posix_get_current_irq(void);
+void posix_sw_set_pending_IRQ(unsigned int IRQn);
+void posix_sw_clear_pending_IRQ(unsigned int IRQn);
 #ifdef CONFIG_IRQ_OFFLOAD
 void posix_irq_offload(void (*routine)(const void *), const void *parameter);
 #endif

--- a/subsys/testsuite/include/zephyr/interrupt_util.h
+++ b/subsys/testsuite/include/zephyr/interrupt_util.h
@@ -158,11 +158,11 @@ static inline void trigger_irq(int vector)
 }
 
 #elif defined(CONFIG_ARCH_POSIX)
-#include "irq_ctrl.h"
+#include <zephyr/arch/posix/posix_soc_if.h>
 
 static inline void trigger_irq(int irq)
 {
-	hw_irq_ctrl_raise_im_from_sw(irq);
+	posix_sw_set_pending_IRQ(irq);
 }
 
 #elif defined(CONFIG_RISCV)


### PR DESCRIPTION
    tests: interrupt util: Fix for native/posix targets
    
    This utility header was accessing directly the interrupt
    controller HW models, but those are not an interface one
    can expect to not change, or to be avaliable in different
    targets.
    Instead we change it to use the APIs we have a contract
    about, that is, the ones all POSIX arch boards are
    expected to provide.
    
-------------

    arch POSIX: Add two missing prototypes to header
    
    The posix_soc_if.h header includes all functions
    one can expect any native board will provide.
    These two functions (to set and clear an interrupt
    from SW) were missing, but they are also required.
    Add them.
