### PR TITLE
nvmp: api for non volatile memory

### DIFF
--- a/dts/bindings/misc/zephyr,nvmp-eeprom.yaml
+++ b/dts/bindings/misc/zephyr,nvmp-eeprom.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 Laczen
+# SPDX-License-Identifier: Apache-2.0
+
+# Compatible used to describe nvmp on eeprom
+
+include: base.yaml

--- a/dts/bindings/misc/zephyr,nvmp-flash.yaml
+++ b/dts/bindings/misc/zephyr,nvmp-flash.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 Laczen
+# SPDX-License-Identifier: Apache-2.0
+
+# Compatible used to describe nvmp on flash
+
+include: base.yaml

--- a/dts/bindings/misc/zephyr,nvmp-partitions.yaml
+++ b/dts/bindings/misc/zephyr,nvmp-partitions.yaml
@@ -1,0 +1,63 @@
+description: |
+  This binding is used to describe partitions on non volatile memory.
+
+  Here is an example:
+
+    &flash0 {
+            nvmp_partitions {
+                    compatible = "zephyr, nvmp-partitions";
+                    #address-cells = <1>;
+                    #size-cells = <1>;
+
+                    partition0: partition@0 {
+                            reg = <0x00000000 0x0000C000>;
+                    };
+                    partition1: partition@c000 {
+                            reg = <0x0000C000 0x00076000>;
+                    };
+            };
+    };
+
+compatible: "zephyr,nvmp-partitions"
+
+properties:
+  "#address-cells":
+    type: int
+    description: |
+      Number of cells required to represent a child node's
+      reg property address. This must be large enough to
+      represent the start offset of each partition.
+
+  "#size-cells":
+    type: int
+    description: |
+      Number of cells required to represent a child node's
+      reg property address. This must be large enough to
+      represent the size of each partition in bytes.
+
+child-binding:
+  description: |
+    Each child node of the fixed-partitions node represents
+    an individual flash partition. These should usually
+    look like this:
+
+      partition_nodelabel: partition@START_OFFSET {
+              label = "human-readable-name";
+              reg = <0xSTART_OFFSET 0xSIZE>;
+      };
+  properties:
+    label:
+      type: string
+      description: |
+        Human readable string describing the flash partition.
+    read-only:
+      type: boolean
+      description: set this property if the partition is read-only
+    reg:
+      type: array
+      description: |
+        This should be in the format <OFFSET SIZE>, where OFFSET
+        is the offset of the flash partition relative to the base
+        address of the parent memory, and SIZE is the size of
+        the partition in bytes.
+      required: true

--- a/dts/bindings/misc/zephyr,nvmp-retained-mem.yaml
+++ b/dts/bindings/misc/zephyr,nvmp-retained-mem.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 Laczen
+# SPDX-License-Identifier: Apache-2.0
+
+# Compatible used to describe nvmp on retained_mem
+
+include: base.yaml

--- a/include/zephyr/storage/nvmp.h
+++ b/include/zephyr/storage/nvmp.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2023 Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Public API for non volatile memory and partitions
+ */
+
+#ifndef ZEPHYR_INCLUDE_NVMP_H_
+#define ZEPHYR_INCLUDE_NVMP_H_
+
+/**
+ * @brief Abstraction over non volatile memory and its partitions on non
+ *	  volatile memory and their drivers
+ *
+ * @defgroup nvmp_part_api nvmp interface
+ * @{
+ */
+
+/*
+ * This API makes it possible to operate on non volatile memory and its
+ * partitions easily and effectively.
+ */
+
+#include <errno.h>
+#include <sys/types.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/drivers/eeprom.h>
+#include <zephyr/drivers/retained_mem.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The nvmp subsystem provide an abstraction layer between non volatile memory
+ * specific drivers and higher-level applications for non volatile memory and
+ * its partitions. On non volatile memory and its partitions 3 routines for
+ * operation are provided: read, write and erase.
+ *
+ */
+
+/**
+ * @brief Retrieve a pointer to the non volatile info struct of non volatile
+ *        memory.
+ *
+ * A non volatile memory or one of its partition with nodelabel "nodelabel" is
+ * retrieved as:
+ * const struct nbmp_info *nvmp = NVMP_GET(nodelabel)
+ *
+ * @param nodelabel of the non volatile memory or one of its partitions.
+ */
+#define NVMP_GET(nodelabel) &UTIL_CAT(nvmp_info_, DT_NODELABEL(nodelabel))
+
+enum nvmp_type {UNKNOWN, FLASH, EEPROM, RETAINED_MEM};
+
+struct nvmp_info;
+
+/**
+ * @brief nvmp_info represents a nvmp item.
+ */
+struct nvmp_info {
+	/** nvmp type */
+	const enum nvmp_type type;
+	/** nvmp size */
+	const size_t size;
+	/** nvmp read-only */
+	const bool read_only;
+	/** nvmp store */
+	const void *store;
+	/** nvmp start on store */
+	const size_t store_start;
+	/** nvmp routines */
+	int (* const read)(const struct nvmp_info *info, size_t start,
+			   void *data, size_t len);
+	int (* const write)(const struct nvmp_info *info, size_t start,
+			    const void *data, size_t len);
+	int (* const erase)(const struct nvmp_info *info, size_t start,
+			    size_t len);
+};
+
+/**
+ * @brief Get the size in byte of a nvmp item.
+ *
+ * @param[in] info nvmp item
+ * @return the size.
+ */
+size_t nvmp_get_size(const struct nvmp_info *info);
+
+/**
+ * @brief Get the type of a nvmp item.
+ *
+ * @param[in] info nvmp item
+ * @return the non volatile memory type.
+ */
+enum nvmp_type nvmp_get_type(const struct nvmp_info *info);
+
+/**
+ * @brief Get the store of a nvmp item.
+ *
+ * @param[in] info nvmp item
+ * @return the store.
+ */
+const void *nvmp_get_store(const struct nvmp_info *info);
+
+/**
+ * @brief Get the start in byte on the store of a nvmp item.
+ *
+ * @param[in] info nvmp item
+ * @return the start on success, negative errno code on fail.
+ */
+ssize_t nvmp_get_store_start(const struct nvmp_info *info);
+
+/**
+ * @brief Read data from nvmp item. Read boundaries are verified before read
+ * request is executed.
+ *
+ * REMARK: start and size are opaque: there meaning can change depending on the
+ * store, e.g. byte on flash, eeprom and retained_mem but sector on disk.
+ *
+ * @param[in] info nvmp item
+ * @param[in] start point relative from beginning of nvmp item
+ * @param[out] data Buffer to store read data
+ * @param[in] len Size to read
+ *
+ * @return  0 on success, negative errno code on fail.
+ */
+int nvmp_read(const struct nvmp_info *info, size_t start, void *data,
+	      size_t len);
+
+/**
+ * @brief Write data to nvmp item. Write boundaries are verified before write
+ * request is executed.
+ *
+ * REMARK: start and size are opaque: there meaning can change depending on the
+ * store, e.g. byte on flash, eeprom and retained_mem but sector on disk.
+ *
+ * @param[in] info nvmp item
+ * @param[in] start point relative from beginning of nvmp item
+ * @param[out] data Buffer with data to be written
+ * @param[in] len Size to read
+ *
+ * @return  0 on success, negative errno code on fail.
+ */
+int nvmp_write(const struct nvmp_info *info, size_t start, const void *data,
+	       size_t len);
+
+/**
+ * @brief Erase range on nvmp item. Erase boundaries are verified before erase
+ * is executed.
+ *
+ * REMARK: start and size are opaque: there meaning can change depending on the
+ * store, e.g. byte on flash, eeprom and retained_mem but sector on disk.
+ *
+ * @param[in] info nvmp item
+ * @param[in] start point relative from beginning of nvmp item
+ * @param[in] len Size to read
+ *
+ * @return  0 on success, negative errno code on fail.
+ */
+int nvmp_erase(const struct nvmp_info *info, size_t start, size_t len);
+
+/**
+ * @brief Helper macro to find out the compatibility of a node, this can be
+ * useful when aiming for minimal code size when multiple types of non
+ * volatile memory are enabled.
+ *
+ * @param node of the non volatile memory.
+ * @param compatible of the non volatile memory
+ */
+#define NVMP_HAS_COMPATIBLE(node, compatible) COND_CODE_1(			\
+	DT_NODE_HAS_COMPAT(node, compatible), (true),				\
+	(COND_CODE_1(DT_NODE_HAS_COMPAT(DT_PARENT(node),			\
+					zephyr_nvmp_partitions),		\
+		(DT_NODE_HAS_COMPAT(DT_GPARENT(node), compatible)), (false))))
+
+/** @cond INTERNAL_HIDDEN */
+
+#define NVMP_DECLARE_ITEM(n) extern const struct nvmp_info nvmp_info_##n;
+
+#define NVMP_PARTITIONS_DECLARE(inst)						\
+	DT_FOREACH_CHILD(inst, NVMP_DECLARE_ITEM)
+
+#define NVMP_DECLARE(inst)							\
+	NVMP_DECLARE_ITEM(inst)							\
+	DT_FOREACH_CHILD_STATUS_OKAY(inst, NVMP_PARTITIONS_DECLARE)
+
+#ifdef CONFIG_NVMP_EEPROM
+DT_FOREACH_STATUS_OKAY(zephyr_nvmp_eeprom, NVMP_DECLARE)
+#endif
+
+#ifdef CONFIG_NVMP_FLASH
+DT_FOREACH_STATUS_OKAY(zephyr_nvmp_flash, NVMP_DECLARE)
+#endif
+
+#ifdef CONFIG_NVMP_RETAINED_MEM
+DT_FOREACH_STATUS_OKAY(zephyr_nvmp_retained_mem, NVMP_DECLARE)
+#endif
+
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_NVMP_H_ */

--- a/subsys/storage/CMakeLists.txt
+++ b/subsys/storage/CMakeLists.txt
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory_ifdef(CONFIG_FLASH_MAP  flash_map)
+add_subdirectory_ifdef(CONFIG_NVMP nvmp)
 add_subdirectory_ifdef(CONFIG_STREAM_FLASH stream)

--- a/subsys/storage/Kconfig
+++ b/subsys/storage/Kconfig
@@ -6,6 +6,7 @@
 menu "Storage"
 
 source "subsys/storage/flash_map/Kconfig"
+source "subsys/storage/nvmp/Kconfig"
 source "subsys/storage/stream/Kconfig"
 
 endmenu

--- a/subsys/storage/nvmp/CMakeLists.txt
+++ b/subsys/storage/nvmp/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(nvmp.c)
+zephyr_library_sources_ifdef(CONFIG_NVMP_FLASH nvmp_flash.c)
+zephyr_library_sources_ifdef(CONFIG_NVMP_EEPROM nvmp_eeprom.c)
+zephyr_library_sources_ifdef(CONFIG_NVMP_RETAINED_MEM nvmp_retained_mem.c)

--- a/subsys/storage/nvmp/Kconfig
+++ b/subsys/storage/nvmp/Kconfig
@@ -1,0 +1,73 @@
+# Copyright (c) 2023, Laczen
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig NVMP
+	bool "nvmp support"
+	help
+	  Enables support for the nvmp system, which enables using unified
+	  routines to read/write and erase non volatile memory. Supported nvmp
+	  backends are flash, eeprom and retained_mem.
+
+if NVMP
+
+config NVMP_FLASH
+	bool "nvmp support for flash devices"
+	default y
+	depends on FLASH
+	help
+	  Enables nvmp support for flash devices.
+
+config NVMP_EEPROM
+	bool "nvmp support for eeprom devices"
+	default y
+	depends on EEPROM
+	help
+	  Enables nvmp support for eeprom devices.
+
+if NVMP_EEPROM
+
+config NVMP_EEPROM_ERASE
+	bool "nvmp eeprom erase support"
+	default y
+	help
+	  Enables nvmp eeprom erase by writing a fixed value
+
+endif #NVMP_EEPROM
+
+config NVMP_RETAINED_MEM
+	bool "nvmp support for retained_mem devices"
+	default y
+	depends on RETAINED_MEM
+	help
+	  Enables nvmp support for retained_mem devices.
+
+if NVMP_RETAINED_MEM
+
+config NVMP_RETAINED_MEM_ERASE
+	bool "nvmp retained_mem erase support"
+	default y
+	help
+	  Enables nvmp retained_mem erase by writing a fixed value
+
+endif #NVMP_RETAINED_MEM
+
+config NVMP_ERASE_BUFSIZE
+	int "nvmp erase bufsize"
+	default 64
+	range 16 256
+	help
+	  Size of the buffer used to erase when nvmp is used on backends that
+	  do not provide an erase function.
+
+config NVMP_ERASE_VALUE
+	hex "nvmp erase value"
+	default 0xff
+	help
+	  Value used to erase when nvmp is used on backends that do not
+	  provide an erase function.
+
+module = NVMP
+module-str = nvmp
+source "subsys/logging/Kconfig.template.log_config"
+
+endif # NVMP

--- a/subsys/storage/nvmp/nvmp.c
+++ b/subsys/storage/nvmp/nvmp.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023, Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/storage/nvmp.h>
+
+size_t nvmp_get_size(const struct nvmp_info *info)
+{
+	if (info == NULL) {
+		return 0U;
+	}
+
+	return info->size;
+}
+
+enum nvmp_type nvmp_get_type(const struct nvmp_info *info)
+{
+	if (info == NULL) {
+		return UNKNOWN;
+	}
+
+	return info->type;
+}
+
+ssize_t nvmp_get_store_start(const struct nvmp_info *info)
+{
+	if (info == NULL) {
+		return -EINVAL;
+	}
+
+	return info->store_start;
+}
+
+const void *nvmp_get_store(const struct nvmp_info *info)
+{
+	if (info == NULL) {
+		return NULL;
+	}
+
+	return info->store;
+}
+
+int nvmp_read(const struct nvmp_info *info, size_t start, void *data,
+	      size_t len)
+{
+	if (info == NULL) {
+		return -EINVAL;
+	}
+
+	return info->read(info, start, data, len);
+}
+
+int nvmp_write(const struct nvmp_info *info, size_t start, const void *data,
+	       size_t len)
+{
+	if (info == NULL) {
+		return -EINVAL;
+	}
+
+	return info->write(info, start, data, len);
+}
+
+int nvmp_erase(const struct nvmp_info *info, size_t start, size_t len)
+{
+	if (info == NULL) {
+		return -EINVAL;
+	}
+
+	return info->erase(info, start, len);
+}

--- a/subsys/storage/nvmp/nvmp_define.h
+++ b/subsys/storage/nvmp/nvmp_define.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NVMP_DEFINE_H_
+#define NVMP_DEFINE_H_
+
+#define NVMP_INFO_DEFINE(inst, _type, _size, _ro, _store, _store_start, _read,	\
+			 _write, _erase)					\
+	const struct nvmp_info nvmp_info_##inst = {				\
+		.type = _type,							\
+		.size = _size,							\
+		.read_only = _ro,						\
+		.store = _store,						\
+		.store_start = _store_start,					\
+		.read = _read,							\
+		.write = _write,						\
+		.erase = _erase,						\
+	}
+
+#define NVMP_RO(inst)								\
+	COND_CODE_1(DT_NODE_HAS_PROP(inst, read_only),				\
+		    (DT_PROP(inst, read_only)), (false))
+
+#define NVMP_PSIZE(inst) DT_REG_SIZE(inst)
+#define NVMP_POFF(inst) DT_REG_ADDR(inst)
+#define NVMP_PRO(inst) NVMP_RO(inst) || NVMP_RO(DT_GPARENT(inst))
+
+#endif /* NVMP_DEFINE_H_ */

--- a/subsys/storage/nvmp/nvmp_eeprom.c
+++ b/subsys/storage/nvmp/nvmp_eeprom.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023, Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/storage/nvmp.h>
+
+LOG_MODULE_REGISTER(nvmp_eeprom, CONFIG_NVMP_LOG_LEVEL);
+
+static int nvmp_eeprom_read(const struct nvmp_info *info, size_t start,
+			    void *data, size_t len)
+{
+	if ((info == NULL) || (info->size < len) ||
+	    ((info->size - len) < start)) {
+		return -EINVAL;
+	}
+
+	const struct device *dev = (const struct device *)info->store;
+
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
+	}
+
+	start += info->store_start;
+	LOG_DBG("read %d byte at 0x%x", len, start);
+	return eeprom_read(dev, (off_t)start, data, len);
+}
+
+static int nvmp_eeprom_write(const struct nvmp_info *info, size_t start,
+			     const void *data, size_t len)
+{
+	if ((info == NULL) || (info->size < len) ||
+	    ((info->size - len) < start)) {
+		return -EINVAL;
+	}
+
+	if (info->read_only) {
+		return -EACCES;
+	}
+
+	const struct device *dev = (const struct device *)info->store;
+
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
+	}
+
+	start += info->store_start;
+	LOG_DBG("write %d byte at 0x%x", len, start);
+	return eeprom_write(dev, (off_t)start, data, len);
+}
+
+#ifdef CONFIG_NVMP_EEPROM_ERASE
+static int nvmp_eeprom_erase(const struct nvmp_info *info, size_t start,
+			     size_t len)
+{
+	if ((info == NULL) || (info->size < len) ||
+	    ((info->size - len) < start)) {
+		return -EINVAL;
+	}
+
+	if (info->read_only) {
+		return -EACCES;
+	}
+
+	int rc;
+	uint8_t buf[CONFIG_NVMP_ERASE_BUFSIZE];
+
+	memset(buf, (char)CONFIG_NVMP_ERASE_VALUE, sizeof(buf));
+	while (len != 0) {
+		size_t wrlen = MIN(len, sizeof(buf));
+
+		rc = info->write(info, start, buf, wrlen);
+		if (rc) {
+			break;
+		}
+
+		len -= wrlen;
+		start += wrlen;
+	}
+
+	return rc;
+}
+#else /* CONFIG_NVMP_EEPROM_ERASE */
+static int nvmp_eeprom_erase(const struct nvmp_info *info, size_t start,
+			     size_t len)
+{
+	return -ENOTSUP;
+}
+#endif /* CONFIG_NVMP_EEPROM_ERASE */
+
+#include "nvmp_define.h"
+
+#define NVMP_EEPROM_DEV(inst) DEVICE_DT_GET(inst)
+#define NVMP_EEPROM_PDEV(inst) NVMP_EEPROM_DEV(DT_GPARENT(inst))
+
+#define NVMP_EEPROM_PARTITION_DEFINE(inst)					\
+	NVMP_INFO_DEFINE(inst, EEPROM, NVMP_PSIZE(inst), NVMP_PRO(inst),	\
+			 (void *)NVMP_EEPROM_PDEV(inst), NVMP_POFF(inst),	\
+			 nvmp_eeprom_read, nvmp_eeprom_write, nvmp_eeprom_erase);
+
+#define NVMP_EEPROM_PARTITIONS_DEFINE(inst)					\
+	DT_FOREACH_CHILD_STATUS_OKAY(inst, NVMP_EEPROM_PARTITION_DEFINE)
+
+#define NVMP_EEPROM_SIZE(inst) DT_PROP(inst, size)
+#define NVMP_EEPROM_OFF(inst) 0U
+#define NVMP_EEPROM_RO(inst) NVMP_RO(inst)
+
+#define NVMP_EEPROM_DEFINE(inst)						\
+	NVMP_INFO_DEFINE(inst, EEPROM, NVMP_EEPROM_SIZE(inst),			\
+			 NVMP_EEPROM_RO(inst), (void *)NVMP_EEPROM_DEV(inst),	\
+			 NVMP_EEPROM_OFF(inst), nvmp_eeprom_read,		\
+			 nvmp_eeprom_write, nvmp_eeprom_erase);			\
+	DT_FOREACH_CHILD(inst, NVMP_EEPROM_PARTITIONS_DEFINE)
+
+DT_FOREACH_STATUS_OKAY(zephyr_nvmp_eeprom, NVMP_EEPROM_DEFINE)

--- a/subsys/storage/nvmp/nvmp_flash.c
+++ b/subsys/storage/nvmp/nvmp_flash.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2023, Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/storage/nvmp.h>
+
+LOG_MODULE_REGISTER(nvmp_flash, CONFIG_NVMP_LOG_LEVEL);
+
+static int nvmp_flash_read(const struct nvmp_info *info, size_t start,
+			   void *data, size_t len)
+{
+	if ((info == NULL) || (info->size < len) ||
+	    ((info->size - len) < start)) {
+		return -EINVAL;
+	}
+
+	const struct device *dev = (const struct device *)info->store;
+
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
+	}
+
+	start += info->store_start;
+	LOG_DBG("read %d byte at 0x%x", len, start);
+	return flash_read(dev, (off_t)start, data, len);
+}
+
+static int nvmp_flash_write(const struct nvmp_info *info, size_t start,
+			    const void *data, size_t len)
+{
+	if ((info == NULL) || (info->size < len) ||
+	    ((info->size - len) < start)) {
+		return -EINVAL;
+	}
+
+	if (info->read_only) {
+		return -EACCES;
+	}
+
+	const struct device *dev = (const struct device *)info->store;
+
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
+	}
+
+	start += info->store_start;
+	LOG_DBG("write %d byte at 0x%x", len, start);
+	return flash_write(dev, (off_t)start, data, len);
+}
+
+static int nvmp_flash_erase(const struct nvmp_info *info, size_t start,
+			    size_t len)
+{
+	if ((info == NULL) || (info->size < len) ||
+	    ((info->size - len) < start)) {
+		return -EINVAL;
+	}
+
+	if (info->read_only) {
+		return -EACCES;
+	}
+
+	const struct device *dev = (const struct device *)info->store;
+
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
+	}
+
+	start += info->store_start;
+	LOG_DBG("erase %d byte at 0x%x", len, start);
+	return flash_erase(dev, (off_t)start, len);
+}
+
+#include "nvmp_define.h"
+
+#define NVMP_FLASH_DEV(inst)							\
+	COND_CODE_1(DT_NODE_HAS_COMPAT(inst, soc_nv_flash),			\
+		    (DEVICE_DT_GET(DT_PARENT(inst))), (DEVICE_DT_GET(inst)))
+#define NVMP_FLASH_PDEV(inst) NVMP_FLASH_DEV(DT_GPARENT(inst))
+
+#define NVMP_FLASH_PARTITION_DEFINE(inst)					\
+	NVMP_INFO_DEFINE(inst, FLASH, NVMP_PSIZE(inst), NVMP_PRO(inst),		\
+			 (void *)NVMP_FLASH_PDEV(inst), NVMP_POFF(inst),	\
+			 nvmp_flash_read, nvmp_flash_write, nvmp_flash_erase);
+
+#define NVMP_FLASH_PARTITIONS_DEFINE(inst)					\
+	DT_FOREACH_CHILD_STATUS_OKAY(inst, NVMP_FLASH_PARTITION_DEFINE)
+
+#define NVMP_FLASH_SIZE(inst)							\
+	COND_CODE_1(DT_NODE_HAS_COMPAT(inst, soc_nv_flash), (DT_REG_SIZE(inst)),\
+		    (DT_PROP_OR(inst, size, 0) / 8))
+#define NVMP_FLASH_OFF(inst) 0U
+#define NVMP_FLASH_RO(inst) NVMP_RO(inst)
+
+#define NVMP_FLASH_DEFINE(inst)							\
+	NVMP_INFO_DEFINE(inst, FLASH, NVMP_FLASH_SIZE(inst),			\
+			 NVMP_FLASH_RO(inst), (void *)NVMP_FLASH_DEV(inst),	\
+			 NVMP_FLASH_OFF(inst), nvmp_flash_read,			\
+			 nvmp_flash_write, nvmp_flash_erase);			\
+	DT_FOREACH_CHILD(inst, NVMP_FLASH_PARTITIONS_DEFINE)
+
+DT_FOREACH_STATUS_OKAY(zephyr_nvmp_flash, NVMP_FLASH_DEFINE)

--- a/subsys/storage/nvmp/nvmp_retained_mem.c
+++ b/subsys/storage/nvmp/nvmp_retained_mem.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023, Laczen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/storage/nvmp.h>
+
+LOG_MODULE_REGISTER(nvmp_retained_mem, CONFIG_NVMP_LOG_LEVEL);
+
+static int nvmp_retained_mem_read(const struct nvmp_info *info, size_t start,
+				  void *data, size_t len)
+{
+	if ((info == NULL) || (info->size < len) ||
+	    ((info->size - len) < start)) {
+		return -EINVAL;
+	}
+
+	const struct device *dev = (const struct device *)info->store;
+
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
+	}
+
+	start += info->store_start;
+	LOG_DBG("read %d byte at 0x%x", len, start);
+	return retained_mem_read(dev, start, data, len);
+}
+
+static int nvmp_retained_mem_write(const struct nvmp_info *info, size_t start,
+				   const void *data, size_t len)
+{
+	if ((info == NULL) || (info->size < len) ||
+	    ((info->size - len) < start)) {
+		return -EINVAL;
+	}
+
+	if (info->read_only) {
+		return -EACCES;
+	}
+
+	const struct device *dev = (const struct device *)info->store;
+
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
+	}
+
+	start += info->store_start;
+	LOG_DBG("write %d byte at 0x%x", len, start);
+	return retained_mem_write(dev, (off_t)start, data, len);
+}
+
+#ifdef CONFIG_NVMP_RETAINED_MEM_ERASE
+static int nvmp_retained_mem_erase(const struct nvmp_info *info, size_t start,
+				   size_t len)
+{
+	if ((info == NULL) || (info->size < len) ||
+	    ((info->size - len) < start)) {
+		return -EINVAL;
+	}
+
+	if (info->read_only) {
+		return -EACCES;
+	}
+
+	int rc;
+	uint8_t buf[CONFIG_NVMP_ERASE_BUFSIZE];
+
+	memset(buf, (char)CONFIG_NVMP_ERASE_VALUE, sizeof(buf));
+	while (len != 0) {
+		size_t wrlen = MIN(len, sizeof(buf));
+
+		rc = info->write(info, start, buf, wrlen);
+		if (rc) {
+			break;
+		}
+
+		len -= wrlen;
+		start += wrlen;
+	}
+
+	return rc;
+}
+#else /* CONFIG_NVMP_RETAINED_MEM_ERASE */
+static int nvmp_retained_mem_erase(const struct nvmp_info *info, size_t start,
+				   size_t len)
+{
+	return -ENOTSUP;
+}
+#endif /* CONFIG_NVMP_RETAINED_MEM_ERASE */
+
+#include "nvmp_define.h"
+
+#define NVMP_RETAINED_MEM_DEV(inst) DEVICE_DT_GET(inst)
+#define NVMP_RETAINED_MEM_PDEV(inst) NVMP_RETAINED_MEM_DEV(DT_GPARENT(inst))
+
+#define NVMP_RETAINED_MEM_PARTITION_DEFINE(inst)				\
+	NVMP_INFO_DEFINE(inst, RETAINED_MEM, NVMP_PSIZE(inst), NVMP_PRO(inst),	\
+			 (void *)NVMP_RETAINED_MEM_PDEV(inst), NVMP_POFF(inst),	\
+			 nvmp_retained_mem_read, nvmp_retained_mem_write,	\
+			 nvmp_retained_mem_erase);
+
+#define NVMP_RETAINED_MEM_PARTITIONS_DEFINE(inst)				\
+	DT_FOREACH_CHILD_STATUS_OKAY(inst, NVMP_RETAINED_MEM_PARTITION_DEFINE)
+
+#define NVMP_RETAINED_MEM_SIZE(inst)						\
+	COND_CODE_1(DT_NODE_HAS_COMPAT(inst, zephyr_retained_ram),		\
+		(DT_REG_SIZE(DT_PARENT(inst))),					\
+		(COND_CODE_1(DT_NODE_HAS_COMPAT(inst, nordic_nrf_gpregret),	\
+			(DT_REG_SIZE(inst)), (0))))
+#define NVMP_RETAINED_MEM_OFF(inst) 0U
+#define NVMP_RETAINED_MEM_RO(inst) NVMP_RO(inst)
+
+#define NVMP_RETAINED_MEM_DEFINE(inst)						\
+	NVMP_INFO_DEFINE(inst, RETAINED_MEM, NVMP_RETAINED_MEM_SIZE(inst),	\
+			 NVMP_RETAINED_MEM_RO(inst),				\
+			 (void *)NVMP_RETAINED_MEM_DEV(inst),			\
+			 NVMP_RETAINED_MEM_OFF(inst), nvmp_retained_mem_read,	\
+			 nvmp_retained_mem_write, nvmp_retained_mem_erase);	\
+	DT_FOREACH_CHILD(inst, NVMP_RETAINED_MEM_PARTITIONS_DEFINE)
+
+DT_FOREACH_STATUS_OKAY(zephyr_nvmp_retained_mem, NVMP_RETAINED_MEM_DEFINE)

--- a/tests/subsys/storage/nvmp/CMakeLists.txt
+++ b/tests/subsys/storage/nvmp/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Laczen
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(nvmp_test)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/storage/nvmp/boards/qemu_cortex_m3.conf
+++ b/tests/subsys/storage/nvmp/boards/qemu_cortex_m3.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2023 Laczen
+# SPDX-License-Identifier: Apache-2.0
+CONFIG_RETAINED_MEM=y
+CONFIG_LOG=y

--- a/tests/subsys/storage/nvmp/boards/qemu_cortex_m3.overlay
+++ b/tests/subsys/storage/nvmp/boards/qemu_cortex_m3.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Laczen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <common/mem.h>
+
+/ {
+	sram_2000FC00: sram@2000FC00 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x2000FC00 0x400>;
+                zephyr,memory-region = "Retention";
+                status = "okay";
+
+		retainedmem0: retainedmem {
+			compatible = "zephyr,retained-ram", "zephyr,nvmp-retained-mem";
+			status = "okay";
+			nvmp_partitions {
+				compatible = "zephyr,nvmp-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				retainedmem0_partition: partition@0 {
+					reg = <0x00000000 0x0000400>;
+				};
+
+			};
+	        };
+        };
+};
+
+&sram0 {
+	reg = <0x20000000 0xFC00>;
+};

--- a/tests/subsys/storage/nvmp/boards/qemu_x86.conf
+++ b/tests/subsys/storage/nvmp/boards/qemu_x86.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 Laczen
+# SPDX-License-Identifier: Apache-2.0
+CONFIG_FLASH=y
+CONFIG_NVMP_FLASH=y
+CONFIG_EEPROM=y
+CONFIG_NVMP_EEPROM=y
+CONFIG_USERSPACE=n

--- a/tests/subsys/storage/nvmp/boards/qemu_x86.overlay
+++ b/tests/subsys/storage/nvmp/boards/qemu_x86.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Laczen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash_sim0 {
+        compatible = "soc-nv-flash", "zephyr,nvmp-flash";
+
+	partitions {
+		compatible = "fixed-partitions", "zephyr,nvmp-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/*
+		 * Storage partition will be used by FCB/LittleFS/NVS
+		 * if enabled.
+		 */
+		storage_partition: partition@1000 {
+			label = "storage";
+			reg = <0x00001000 0x00010000>;
+		};
+
+		slot0_partition: partition@11000 {
+			label = "image-0";
+			reg = <0x00011000 0x00010000>;
+		};
+		slot1_partition: partition@21000 {
+			label = "image-1";
+			reg = <0x00021000 0x00010000>;
+		};
+		eepromemu_partition: partition@31000 {
+			label = "eeprom-emu";
+			reg = <0x00031000 0x00010000>;
+		};
+	};
+};
+
+&eeprom0 {
+        compatible = "zephyr,sim-eeprom", "zephyr,nvmp-eeprom";
+        status = "okay";
+	nvmp_partitions {
+		compatible = "zephyr,nvmp-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		eeprom0_partition: partition@0 {
+			reg = <0x00000000 0x00001000>;
+			status = "okay";
+		};
+
+	};
+};

--- a/tests/subsys/storage/nvmp/prj.conf
+++ b/tests/subsys/storage/nvmp/prj.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 Laczen
+# SPDX-License-Identifier: Apache-2.0
+CONFIG_NVMP=y
+CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y

--- a/tests/subsys/storage/nvmp/src/main.c
+++ b/tests/subsys/storage/nvmp/src/main.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2012-2014 Wind River Systems, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/storage/nvmp.h>
+
+#define NVMP_FLASH_NODE flash_sim0
+#define NVMP_FLASH_PARTITION_NODE storage_partition
+#define NVMP_EEPROM_NODE eeprom0
+#define NVMP_EEPROM_PARTITION_NODE eeprom0_partition
+#define NVMP_RETAINED_MEM_NODE retainedmem0
+#define NVMP_RETAINED_MEM_PARTITION_NODE retainedmem0_partition
+
+ZTEST_BMEM static const struct nvmp_info *nvmp;
+
+static void *nvmp_api_setup(void)
+{
+	return NULL;
+}
+
+ZTEST_USER(nvmp_api, test_read_write_erase)
+{
+	uint8_t *wr = "/a9/9a/a9/9a";
+	uint8_t rd[sizeof(wr)];
+	enum nvmp_type type = nvmp_get_type(nvmp);
+	int rc = 0;
+
+	memset(rd, 0, sizeof(rd));
+
+	zassert_false(type == UNKNOWN, "nvmp has bad type");
+
+	rc = nvmp_read(nvmp, 0, rd, sizeof(rd));
+	zassert_equal(rc, 0, "read returned [%d]", rc);
+
+	rc = nvmp_write(nvmp, 0, wr, sizeof(wr));
+	zassert_equal(rc, 0, "write returned [%d]", rc);
+
+	rc = nvmp_read(nvmp, 0, rd, sizeof(rd));
+	zassert_equal(rc, 0, "read returned [%d]", rc);
+
+	zassert_equal(memcmp(wr, rd, sizeof(rd)), 0, "read/write data differ");
+
+	if ((IS_ENABLED(CONFIG_NVMP_FLASH)) && (type == FLASH)) {
+		const struct device *dev =
+			(const struct device *)nvmp_get_store(nvmp);
+		const struct flash_parameters *flparam =
+			flash_get_parameters(dev);
+
+		rc = nvmp_erase(nvmp, 0, nvmp_get_size(nvmp));
+		zassert_equal(rc, 0, "erase returned [%d]", rc);
+
+		rc = nvmp_read(nvmp, 0, rd, sizeof(rd));
+		zassert_equal(rc, 0, "read returned [%d]", rc);
+
+		for (int i = 0; i < sizeof(rd); i++) {
+			zassert_true(rd[i] == flparam->erase_value,
+				     "erase failed");
+		}
+	}
+
+	if ((IS_ENABLED(CONFIG_NVMP_EEPROM) && (type == EEPROM)) ||
+	    (IS_ENABLED(CONFIG_NVMP_RETAINED_MEM) && (type == RETAINED_MEM))) {
+		rc = nvmp_erase(nvmp, 0, sizeof(rd));
+		zassert_equal(rc, 0, "erase returned [%d]", rc);
+
+		rc = nvmp_read(nvmp, 0, rd, sizeof(rd));
+		zassert_equal(rc, 0, "read returned [%d]", rc);
+
+		for (int i = 0; i < sizeof(rd); i++) {
+			zassert_true(rd[i] == CONFIG_NVMP_ERASE_VALUE,
+				     "erase failed");
+		}
+	}
+}
+
+ZTEST_SUITE(nvmp_api, NULL, nvmp_api_setup, NULL, NULL, NULL);
+
+/* Run all of our tests on the given mtd */
+static void run_tests_on_nvmp(const struct nvmp_info *info)
+{
+	nvmp = info;
+	k_object_access_grant((const struct device *)nvmp_get_store(info),
+			      k_current_get());
+	ztest_run_all(NULL);
+}
+
+void test_main(void)
+{
+#ifdef CONFIG_NVMP_FLASH
+	run_tests_on_nvmp(NVMP_GET(NVMP_FLASH_NODE));
+	run_tests_on_nvmp(NVMP_GET(NVMP_FLASH_PARTITION_NODE));
+#endif
+
+#ifdef CONFIG_NVMP_EEPROM
+	run_tests_on_nvmp(NVMP_GET(NVMP_EEPROM_NODE));
+	run_tests_on_nvmp(NVMP_GET(NVMP_EEPROM_PARTITION_NODE));
+#endif
+
+#ifdef CONFIG_NVMP_RETAINED_MEM
+	run_tests_on_nvmp(NVMP_GET(NVMP_RETAINED_MEM_NODE));
+	run_tests_on_nvmp(NVMP_GET(NVMP_RETAINED_MEM_PARTITION_NODE));
+#endif
+
+	ztest_verify_all_test_suites_ran();
+}

--- a/tests/subsys/storage/nvmp/testcase.yaml
+++ b/tests/subsys/storage/nvmp/testcase.yaml
@@ -1,0 +1,13 @@
+common:
+  depends_on: nvmp
+  tags: nvmp
+  platform_allow:
+    - qemu_cortex_m3
+    - qemu_x86
+tests:
+  mtd.cortex_m3.api:
+    platform_allow: qemu_cortex_m3
+    timeout: 60
+  mtd.qemu_x86.api:
+    platform_allow: qemu_x86
+    timeout: 60


### PR DESCRIPTION
**Renamed the proposal from mtd to nvmp**.

The nvmp system enables support for working with non volatile memory and partitions on non volatile memory. The PR enables support for using non volatile memory on FLASH, EEPROM or RETAINED_MEM devices. Other types (e.g. disks or even files can be added as future extensions).

The nvmp api provides unified read, write and erase methods. When a "backend" has no erase method a write with fixed values is used for erase. A device is declared as non volatile memory by adding the compatible "zephyr, nvmp_flash", "zephyr, nvmp-eeprom", "zephyr,nvmp-retained_mem". All non volatile memories can be partitioned using a "zephyr,nvmp-partition" compatible that is equal to the present "fixed-partition" compatible.

The non volatile memory type can be retrieved and used when needed (e.g. to avoid an erase when it is not needed by the non volatile memory type).

The storage solution (e.g. the device) can be retrieved and all methods available to the storage solution can then be used (e.g. getting the flash "page" info for a flash device).

The proposed api can be used for:
a. Working with images as an alternative to flash_map. This allows images to reside on the different types of non volatile memory. It is extendable to disks an files,
b. Simplify the enabling of fs solutions on different types of non volatile memory,
c. Simplify the coredump backends,
d. Simplify the logging backends,
e. Simplify the "emulated" disks,
f. Share information between a bootloader and an application without forcing the bootloader to use the subsystem.

Fixes #61979,
Could be used to fix #52395,

At the moment a separate compatible is used to define partitions, the proposed solution can be modified to reuse the "fixed-partition" compatible.

*Rationale behind this proposal:*
All types of non volatile memory share properties like read and write methods and some require an erase method. There are several types available but they don't share a method to partition and each have their own method to write/read/(erase). Also they differ on getting basic info like getting the size at build time.
Developing for each type of non volatile memory is tedious and requires knowledge of the type of non volatile memory and the driver. By making a unified solution the users can keep their focus on the problem at hand.
The difficulty of the driver interaction is moved to the nvmp subsystem and this can be done once.
The subsystem also provides support to achieve minimal compile size as is illustrated by `NVMP_HAS_COMPATIBLE(node, compatible)` that allows the code to select the (only) used type of non volatile memory and to remove any unused types.