### PR TITLE
Npm1300 regulator setting pfm mode and voltage errata fix

### DIFF
--- a/include/zephyr/dt-bindings/regulator/npm1300.h
+++ b/include/zephyr/dt-bindings/regulator/npm1300.h
@@ -20,6 +20,7 @@
 /* Buck modes */
 #define NPM1300_BUCK_MODE_AUTO 0x00U
 #define NPM1300_BUCK_MODE_PWM  0x01U
+#define NPM1300_BUCK_MODE_PFM  0x04U
 
 /* LDSW / LDO modes */
 #define NPM1300_LDSW_MODE_LDO  0x02U


### PR DESCRIPTION
Two changes to support workarounds for chip errata.

* Set_mode now supports fixed PFM mode.
* Set voltage now checks existing setting, and does not apply changes if no change is required.