### PR TITLE
samples: ipc: openamp: update build documentation

### DIFF
--- a/samples/subsys/ipc/openamp/README.rst
+++ b/samples/subsys/ipc/openamp/README.rst
@@ -9,7 +9,7 @@ Overview
 This application demonstrates how to use OpenAMP with Zephyr. It is designed to
 demonstrate how to integrate OpenAMP with Zephyr both from a build perspective
 and code. Note that the remote and primary core images can be flashed
-independently, but sysbuild must be used in order to flash them in one step.
+independently, but sysbuild must be used in order to build the images.
 
 Building the application for lpcxpresso54114_m4
 ***********************************************
@@ -18,6 +18,7 @@ Building the application for lpcxpresso54114_m4
    :zephyr-app: samples/subsys/ipc/openamp
    :board: lpcxpresso54114_m4
    :goals: debug
+   :west-args: --sysbuild
 
 Building the application for lpcxpresso55s69_cpu0
 *************************************************
@@ -26,6 +27,7 @@ Building the application for lpcxpresso55s69_cpu0
    :zephyr-app: samples/subsys/ipc/openamp
    :board: lpcxpresso55s69_cpu0
    :goals: debug
+   :west-args: --sysbuild
 
 Building the application for mps2_an521
 ***************************************
@@ -34,6 +36,7 @@ Building the application for mps2_an521
    :zephyr-app: samples/subsys/ipc/openamp
    :board: mps2_an521
    :goals: debug
+   :west-args: --sysbuild
 
 Building the application for v2m_musca_b1
 *****************************************
@@ -42,6 +45,7 @@ Building the application for v2m_musca_b1
    :zephyr-app: samples/subsys/ipc/openamp
    :board: v2m_musca_b1
    :goals: debug
+   :west-args: --sysbuild
 
 Building the application for mimxrt1170_evk_cm7
 ***********************************************
@@ -50,6 +54,7 @@ Building the application for mimxrt1170_evk_cm7
    :zephyr-app: samples/subsys/ipc/openamp
    :board: mimxrt1170_evk_cm7
    :goals: debug
+   :west-args: --sysbuild
 
 Open a serial terminal (minicom, putty, etc.) and connect the board with the
 following settings:


### PR DESCRIPTION
Update build documentation for openamp sample, to reflect that sysbuild is required when building this sample. Sysbuild is needed to build both core images in one step.