### PR TITLE
soc: xtensa: intel_adsp: cavs: fix assert on L3_MEM_BASE_ADDR

### DIFF
--- a/soc/xtensa/intel_adsp/cavs/power.c
+++ b/soc/xtensa/intel_adsp/cavs/power.c
@@ -93,9 +93,10 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 				.adsp_imr_magic = ADSP_IMR_MAGIC_VALUE,
 				.imr_restore_vector = rom_entry,
 			};
-			struct imr_layout *imr_layout = (struct imr_layout *)L3_MEM_BASE_ADDR;
+			struct imr_layout *imr_layout =
+				z_soc_uncached_ptr((__sparse_force void __sparse_cache *)
+						   L3_MEM_BASE_ADDR);
 
-			__ASSERT_NO_MSG(arch_xtensa_is_ptr_uncached((void *)L3_MEM_BASE_ADDR));
 			imr_layout->imr_state.header = hdr;
 
 #ifdef CONFIG_ADSP_POWER_DOWN_HPSRAM


### PR DESCRIPTION
The assert on L3_MEM_BASE_ADDR is incorrect, we need must convert to uncached before use.

Fixes: ffd2121c65d3 ("soc: xtensa: intel_adsp: cavs: fix power_down_cavs() signature")