### PR TITLE
smartbond UART power management

### DIFF
--- a/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
+++ b/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
@@ -119,6 +119,7 @@
 	status = "okay";
 	pinctrl-0 = <&uart_default>;
 	pinctrl-names = "default";
+	rx-wake-gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 };
 
 zephyr_udc0: &usbd {

--- a/drivers/serial/Kconfig.smartbond
+++ b/drivers/serial/Kconfig.smartbond
@@ -7,5 +7,6 @@ config UART_SMARTBOND
 	depends on DT_HAS_RENESAS_SMARTBOND_UART_ENABLED
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	select UART_INTERRUPT_DRIVEN if PM_DEVICE
 	help
 	  Enable UART driver for Renesas SmartBond(tm) DA1469x series MCU.

--- a/dts/arm/renesas/smartbond/da1469x.dtsi
+++ b/dts/arm/renesas/smartbond/da1469x.dtsi
@@ -272,6 +272,7 @@
 			reg = <0x50020100 0x100>;
 			periph-clock-config = <0x02>;
 			interrupts = <6 0>;
+			hw-flow-control-supported;
 			status = "disabled";
 		};
 
@@ -280,6 +281,7 @@
 			reg = <0x50020200 0x100>;
 			periph-clock-config = <0x08>;
 			interrupts = <7 0>;
+			hw-flow-control-supported;
 			status = "disabled";
 		};
 

--- a/dts/bindings/serial/renesas,smartbond-uart.yaml
+++ b/dts/bindings/serial/renesas,smartbond-uart.yaml
@@ -38,3 +38,12 @@ properties:
   hw-flow-control-supported:
     type: boolean
     description: Set to indicate RTS/CTS flow control is supported.
+
+  rx-wake-gpios:
+    type: phandle-array
+    description: GPIO configured as wake source
+
+  rx-wake-timeout:
+    type: int
+    description: |
+      Time to prevent UART entering sleep mode after receiving data (ms)

--- a/dts/bindings/serial/renesas,smartbond-uart.yaml
+++ b/dts/bindings/serial/renesas,smartbond-uart.yaml
@@ -47,3 +47,15 @@ properties:
     type: int
     description: |
       Time to prevent UART entering sleep mode after receiving data (ms)
+
+  dtr-gpios:
+    type: phandle-array
+    description: |
+      DTR pin specification. DTR pin when active tells that the driver that there
+      is active client on the other side of serial line.
+      The device driver does not use DTR for hardware flow control.
+      When device is connected to computer serial converter usually asserts DTR
+      line when serial port is opened and ready for communication.
+      This line can be used in Smartbond(tm) driver to detect remote client presence.
+      If client is not present the device can disable UART, allowing for
+      power system management to enter more efficient power levels.


### PR DESCRIPTION
This adds power management functionality to SmartBond(tm) serial driver.

With this PR:
- UART allows platform to go to sleep handling PM_DEVICE_ACTION_RESUME/PM_DEVICE_ACTION_SUSPEND messages.
- Platform can be woken up on UART RX activity
- Platform can be keep awaken when DTR line is asserted (optional feature of selected GPIO)
- DT now has definition of UART2 and UART3

This change requires #61857 and #61844 and #61941

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>