### PR TITLE
ci: bsim: Improve path triggers for bsim tests

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -12,6 +12,8 @@ on:
       - "boards/posix/**"
       - "soc/posix/**"
       - "arch/posix/**"
+      - "include/zephyr/arch/posix/**"
+      - "scripts/native_simulator/**"
       - "samples/net/sockets/echo_*/**"
       - "modules/openthread/**"
       - "subsys/net/l2/openthread/**"
@@ -86,6 +88,8 @@ jobs:
             boards/posix/**
             soc/posix/**
             arch/posix/**
+            include/zephyr/arch/posix/**
+            scripts/native_simulator/**
             tests/bsim/*
 
       - name: Check if Bluethooth files changed


### PR DESCRIPTION
Let's also run the BabbleSim tests when either
the native simulator or the the include headers
are changed.
The include path was forgotten when creating the filter. The nrf52_bsim was changed to use the native simulator in 3a4bebacb143c036555b8f8c368315690e761c33