### PR TITLE
Documentation on API types and classes

### DIFF
--- a/doc/develop/api/api_conventions.rst
+++ b/doc/develop/api/api_conventions.rst
@@ -1,0 +1,110 @@
+.. _api_conventions:
+
+API Conventions
+###############
+
+Zephyr provides several programming interfaces for application development:
+
+- C programming interface (function prototypes, structures, and macros), provided in C header files
+- Configuration system (Kconfig)
+- Hardware description system (Devicetree)
+
+While other systems like CMake are also user-facing and may be considered as programming interfaces,
+only the areas listed above are formally considered Zephyr APIs.
+
+General API classification
+**************************
+
+The files that define the Zephyr APIs may contain symbols intended for different usage. The intended
+API usage is designated by the API class. Zephyr APIs are classified as:
+
+Private
+    These APIs are intended for use within the boundary of a :term:`software component`. Private
+    APIs defined in the main Zephyr tree are not subject to :ref:`api_lifecycle`. Therefore, they
+    can be changed or removed at any time. Changes to the private APIs may not be documented at all,
+    and are not included in the migration guide.
+
+Internal
+    In general, these APIs are intended for use only between certain software components that are
+    located in the main Zephyr tree. The context where the API is called or implemented is well
+    defined. For example, functions prefixed with ``arch_`` are intended for use by the Zephyr
+    kernel to invoke architecture-specific code. An API is classified as internal on a case by case
+    basis. Internal APIs should not be used by out-of-tree code. Internal APIs are not subject to
+    :ref:`api_lifecycle`. Therefore, they can be changed or removed at any time. However, changes to
+    the internal APIs must be documented in the migration guide.
+
+Public
+    These APIs are intended for use from any :term:`software component`. Public APIs may be used
+    in-tree and out-of-tree. Public APIs are subject to the :ref:`api_lifecycle`. Therefore, changes
+    to an API are introduced and documented according to the rules defined for the API life cycle.
+    This includes documenting any breaking changes in the migration guide.
+
+Note, that only APIs defined in the main Zephyr tree are subject to :ref:`api_lifecycle`. External
+projects used as :ref:`modules` may define their own rules for API lifecycle.
+
+Zephyr is a constantly evolving project and API classification may change over time. A Private or
+Internal API may be promoted to Internal or Public API, respectively. Zephyr users are encouraged to
+follow :ref:`rfcs` process to recommend changes in API classification.
+
+The following sections provide guidelines on how to identify the class of an API depending on its
+type.
+
+Classification by Interface Type
+********************************
+
+The following sections illustrate how to identify the class of an API based on the specific
+interface type (C, Kconfig, or Devicetree).
+
+C header files
+==============
+
+Private
+    Functions and data types declared in header files located in
+    ``include/zephyr/private/``. In addition, private symbols are prefixed with ``z_``.
+    Due to historical reasons some APIs prefixed with ``z_`` are public.
+
+Internal
+    Functions and data types declared :zephyr_file:`include/zephyr/internal`. In addition, Internal
+    APIs must use ``@internal`` doxygen command.
+
+Public
+    Functions and data types declared in header files located in :zephyr_file:`include/zephyr/`.
+
+In addition, the following prefixes are reserved by Zephyr kernel for use in Zephyr Public APIs:
+
+.. list-table:: Prefixes and Descriptions
+   :header-rows: 1
+   :widths: 10 40 40
+   :stub-columns: 1
+
+   * - Prefix
+     - Description
+     - Example
+   * - ``atomic_``
+     - Denotes an atomic operation.
+     - :c:func:`atomic_inc`
+   * - ``device_``
+     - Denotes an API relating to devices and their initialization.
+     - :c:func:`device_get_binding`
+   * - ``irq_``
+     - Denotes an IRQ management operation.
+     - :c:func:`irq_disable`
+   * - ``k_``
+     - Kernel-specific function.
+     - :c:func:`k_malloc`
+   * - ``sys_``
+     - Catch-all for APIs that do not fit into the other namespaces.
+     - :c:func:`sys_write32`
+
+Kconfig symbols
+===============
+
+All Kconfig symbols are considered Public. Their maturity level matches the :term:`software
+component` they belong to. For example, regulator Kconfig symbols share the maturity of the
+:ref:`Regulator <regulator_api>` subsystem.
+
+Devicetree bindings
+===================
+
+All Devicetree bindings are Public. Like Kconfig, a binding's maturity matches its parent
+:term:`software component`.

--- a/doc/develop/api/design_guidelines.rst
+++ b/doc/develop/api/design_guidelines.rst
@@ -3,55 +3,47 @@
 API Design Guidelines
 #####################
 
-Zephyr development and evolution is a group effort, and to simplify
-maintenance and enhancements there are some general policies that should
-be followed when developing a new capability or interface.
+Zephyr development and evolution is a group effort, and to simplify maintenance and enhancements
+there are some general policies that should be followed when developing a new capability or
+interface.
 
 Using Callbacks
 ***************
 
-Many APIs involve passing a callback as a parameter or as a member of a
-configuration structure.  The following policies should be followed when
-specifying the signature of a callback:
+Many APIs involve passing a callback as a parameter or as a member of a configuration structure.
+The following policies should be followed when specifying the signature of a callback:
 
-* The first parameter should be a pointer to the object most closely
-  associated with the callback.  In the case of device drivers this
-  would be ``const struct device *dev``.  For library functions it may be a
-  pointer to another object that was referenced when the callback was
-  provided.
+* The first parameter should be a pointer to the object most closely associated with the callback.
+  In the case of device drivers this would be ``const struct device *dev``.  For library functions
+  it may be a pointer to another object that was referenced when the callback was provided.
 
-* The next parameter(s) should be additional information specific to the
-  callback invocation, such as a channel identifier, new status value,
-  and/or a message pointer followed by the message length.
+* The next parameter(s) should be additional information specific to the callback invocation, such
+  as a channel identifier, new status value, and/or a message pointer followed by the message
+  length.
 
-* The final parameter should be a ``void *user_data`` pointer carrying
-  context that allows a shared callback function to locate additional
-  material necessary to process the callback.
+* The final parameter should be a ``void *user_data`` pointer carrying context that allows a shared
+  callback function to locate additional material necessary to process the callback.
 
-An exception to providing ``user_data`` as the last parameter may be
-allowed when the callback itself was provided through a structure that
-will be embedded in another structure.  An example of such a case is
-:c:struct:`gpio_callback`, normally defined within a data structure
-specific to the code that also defines the callback function.  In those
-cases further context can accessed by the callback indirectly by
-:c:macro:`CONTAINER_OF`.
+An exception to providing ``user_data`` as the last parameter may be allowed when the callback
+itself was provided through a structure that will be embedded in another structure.  An example of
+such a case is :c:type:`gpio_callback`, normally defined within a data structure specific to the
+code that also defines the callback function.  In those cases further context can accessed by the
+callback indirectly by :c:macro:`CONTAINER_OF`.
 
 Examples
 ========
 
-* The requirements of :c:type:`k_timer_expiry_t` invoked when a system
-  timer alarm fires are satisfied by::
+* The requirements of :c:type:`k_timer_expiry_t` invoked when a system timer alarm fires are
+  satisfied by::
 
     void handle_timeout(struct k_timer *timer)
     { ... }
 
-  The assumption here, as with :c:struct:`gpio_callback`, is that the
-  timer is embedded in a structure reachable from
-  :c:macro:`CONTAINER_OF` that can provide additional context to the
-  callback.
+  The assumption here, as with :c:type:`gpio_callback`, is that the timer is embedded in a structure
+  reachable from :c:macro:`CONTAINER_OF` that can provide additional context to the callback.
 
-* The requirements of :c:type:`counter_alarm_callback_t` invoked when a
-  counter device alarm fires are satisfied by::
+* The requirements of :c:type:`counter_alarm_callback_t` invoked when a counter device alarm fires
+  are satisfied by::
 
     void handle_alarm(const struct device *dev,
                       uint8_t chan_id,
@@ -59,64 +51,61 @@ Examples
 		      void *user_data)
     { ... }
 
-  This provides more complete useful information, including which
-  counter channel timed-out and the counter value at which the timeout
-  occurred, as well as user context which may or may not be the
-  :c:struct:`counter_alarm_cfg` used to register the callback, depending
-  on user needs.
+  This provides more complete useful information, including which counter channel timed-out and the
+  counter value at which the timeout occurred, as well as user context which may or may not be the
+  :c:type:`counter_alarm_cfg` used to register the callback, depending on user needs.
 
 Conditional Data and APIs
 *************************
 
-APIs and libraries may provide features that are expensive in RAM or
-code size but are optional in the sense that some applications can be
-implemented without them.  Examples of such feature include
-:kconfig:option:`capturing a timestamp <CONFIG_CAN_RX_TIMESTAMP>` or
-:kconfig:option:`providing an alternative interface <CONFIG_SPI_ASYNC>`.  The
-developer in coordination with the community must determine whether
-enabling the features is to be controllable through a Kconfig option.
+APIs and libraries may provide features that are expensive in RAM or code size but are optional in
+the sense that some applications can be implemented without them.  Examples of such feature include
+:kconfig:option:`capturing a timestamp <CONFIG_CAN_RX_TIMESTAMP>` or :kconfig:option:`providing an
+alternative interface <CONFIG_SPI_ASYNC>`.  The developer in coordination with the community must
+determine whether enabling the features is to be controllable through a Kconfig option.
 
-In the case where a feature is determined to be optional the following
-practices should be followed.
+In the case where a feature is determined to be optional the following practices should be followed.
 
-* Any data that is accessed only when the feature is enabled should be
-  conditionally included via ``#ifdef CONFIG_MYFEATURE`` in the
-  structure or union declaration.  This reduces memory use for
+* Any data that is accessed only when the feature is enabled should be conditionally included via
+  ``#ifdef CONFIG_MYFEATURE`` in the structure or union declaration.  This reduces memory use for
   applications that don't need the capability.
-* Function declarations that are available only when the option is
-  enabled should be provided unconditionally.  Add a note in the
-  description that the function is available only when the specified
-  feature is enabled, referencing the required Kconfig symbol by name.
-  In the cases where the function is used but not enabled the definition
-  of the function shall be excluded from compilation, so references to
-  the unsupported API will result in a link-time error.
-* Where code specific to the feature is isolated in a source file that
-  has no other content that file should be conditionally included in
-  ``CMakeLists.txt``::
+* Function declarations that are available only when the option is enabled should be provided
+  unconditionally.  Add a note in the description that the function is available only when the
+  specified feature is enabled, referencing the required Kconfig symbol by name. In the cases where
+  the function is used but not enabled the definition of the function shall be excluded from
+  compilation, so references to the unsupported API will result in a link-time error.
+* Where code specific to the feature is isolated in a source file that has no other content that
+  file should be conditionally included in ``CMakeLists.txt``::
 
     zephyr_sources_ifdef(CONFIG_MYFEATURE foo_funcs.c)
-* Where code specific to the feature is part of a source file that has
-  other content the feature-specific code should be conditionally
-  processed using ``#ifdef CONFIG_MYFEATURE``.
+* Where code specific to the feature is part of a source file that has other content the
+  feature-specific code should be conditionally processed using ``#ifdef CONFIG_MYFEATURE``.
 
-The Kconfig flag used to enable the feature should be added to the
-``PREDEFINED`` variable in :file:`doc/zephyr.doxyfile.in` to ensure the
-conditional API and functions appear in generated documentation.
+The Kconfig flag used to enable the feature should be added to the ``PREDEFINED`` variable in
+:file:`doc/zephyr.doxyfile.in` to ensure the conditional API and functions appear in generated
+documentation.
+
+Subsystem namespaces
+********************
+A subsystem can define its own naming conventions for symbols as long as the scheme doesn't collide
+with Zephyr naming conventions :ref:`api_conventions`. The naming convention should include a
+namespace prefix (for example, bt\_ for Bluetooth LE, or net\_ for IP). This limits possible
+collisions with symbols defined by an application.
 
 Return Codes
 ************
+Zephyr uses the standard codes in ``errno.h`` for all APIs. As a general rule, 0 indicates success;
+a negative ``errno.h`` code indicates an error condition.
 
-Implementations of an API, for example an API for accessing a peripheral might
-implement only a subset of the functions that is required for minimal operation.
-A distinction is needed between APIs that are not supported and those that are
-not implemented or optional:
+Implementations of an API, for example an API for accessing a peripheral might implement only a
+subset of the functions that is required for minimal operation. A distinction is needed between APIs
+that are not supported and those that are not implemented or optional:
 
 - APIs that are supported but not implemented shall return ``-ENOSYS``.
 
-- Optional APIs that are not supported by the hardware should be implemented and
-  the return code in this case shall be ``-ENOTSUP``.
+- Optional APIs that are not supported by the hardware should be implemented and the return code in
+  this case shall be ``-ENOTSUP``.
 
-- When an API is implemented, but the particular combination of options
-  requested in the call cannot be satisfied by the implementation the call shall
-  return ``-ENOTSUP``. (For example, a request for a level-triggered GPIO interrupt on
-  hardware that supports only edge-triggered interrupts)
+- When an API is implemented but the particular combination of options requested in the call cannot
+  be satisfied by the implementation, the call shall return ``-ENOTSUP``. (For example, a request
+  for a level-triggered GPIO interrupt on hardware that supports only edge-triggered interrupts)

--- a/doc/develop/api/index.rst
+++ b/doc/develop/api/index.rst
@@ -7,6 +7,7 @@ API Status and Guidelines
    :maxdepth: 1
 
    overview.rst
+   api_conventions.rst
    api_lifecycle.rst
    design_guidelines.rst
    terminology.rst


### PR DESCRIPTION
This is a starting point for a documentation of API types and classes.

Resolves #61374 #61588. 