### PR TITLE
Native simulator and  nrf52_bsim update to latest and align with them

### DIFF
--- a/boards/posix/nrf52_bsim/Kconfig.defconfig
+++ b/boards/posix/nrf52_bsim/Kconfig.defconfig
@@ -14,6 +14,9 @@ config OUTPUT_PRINT_MEMORY_USAGE
 config BOARD
 	default "nrf52_bsim"
 
+config NATIVE_SIMULATOR_CPU_N
+	default 0
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768
 

--- a/boards/posix/nrf52_bsim/common/cmsis/cmsis.c
+++ b/boards/posix/nrf52_bsim/common/cmsis/cmsis.c
@@ -17,32 +17,32 @@
  */
 void NVIC_SetPendingIRQ(IRQn_Type IRQn)
 {
-	hw_irq_ctrl_raise_im_from_sw(IRQn);
+	hw_irq_ctrl_raise_im_from_sw(CONFIG_NATIVE_SIMULATOR_CPU_N, IRQn);
 }
 
 void NVIC_ClearPendingIRQ(IRQn_Type IRQn)
 {
-	hw_irq_ctrl_clear_irq(IRQn);
+	hw_irq_ctrl_clear_irq(CONFIG_NATIVE_SIMULATOR_CPU_N, IRQn);
 }
 
 void NVIC_DisableIRQ(IRQn_Type IRQn)
 {
-	hw_irq_ctrl_disable_irq(IRQn);
+	hw_irq_ctrl_disable_irq(CONFIG_NATIVE_SIMULATOR_CPU_N, IRQn);
 }
 
 void NVIC_EnableIRQ(IRQn_Type IRQn)
 {
-	hw_irq_ctrl_enable_irq(IRQn);
+	hw_irq_ctrl_enable_irq(CONFIG_NATIVE_SIMULATOR_CPU_N, IRQn);
 }
 
 void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
 {
-	hw_irq_ctrl_prio_set(IRQn, priority);
+	hw_irq_ctrl_prio_set(CONFIG_NATIVE_SIMULATOR_CPU_N, IRQn, priority);
 }
 
 uint32_t NVIC_GetPriority(IRQn_Type IRQn)
 {
-	return hw_irq_ctrl_get_prio(IRQn);
+	return hw_irq_ctrl_get_prio(CONFIG_NATIVE_SIMULATOR_CPU_N, IRQn);
 }
 
 void NVIC_SystemReset(void)
@@ -55,22 +55,22 @@ void NVIC_SystemReset(void)
  */
 void __enable_irq(void)
 {
-	hw_irq_ctrl_change_lock(false);
+	hw_irq_ctrl_change_lock(CONFIG_NATIVE_SIMULATOR_CPU_N, false);
 }
 
 void __disable_irq(void)
 {
-	hw_irq_ctrl_change_lock(true);
+	hw_irq_ctrl_change_lock(CONFIG_NATIVE_SIMULATOR_CPU_N, true);
 }
 
 uint32_t __get_PRIMASK(void)
 {
-	return hw_irq_ctrl_get_current_lock();
+	return hw_irq_ctrl_get_current_lock(CONFIG_NATIVE_SIMULATOR_CPU_N);
 }
 
 void __set_PRIMASK(uint32_t primask)
 {
-	hw_irq_ctrl_change_lock(primask != 0);
+	hw_irq_ctrl_change_lock(CONFIG_NATIVE_SIMULATOR_CPU_N, primask != 0);
 }
 
 void __WFE(void)

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -25,7 +25,7 @@ static bool CPU_will_be_awaken_from_WFE;
 typedef void (*normal_irq_f_ptr)(const void *);
 typedef int (*direct_irq_f_ptr)(void);
 
-static struct _isr_list irq_vector_table[NRF_HW_NBR_IRQs];
+static struct _isr_list irq_vector_table[NHW_INTCTRL_MAX_INTLINES];
 
 static int currently_running_irq = -1;
 
@@ -43,7 +43,7 @@ static inline void vector_to_irq(int irq_nbr, int *may_swap)
 	}
 
 	bs_trace_raw_time(6, "Vectoring to irq %i (%s)\n", irq_nbr,
-			  hw_irq_ctrl_get_name(irq_nbr));
+			  hw_irq_ctrl_get_name(CONFIG_NATIVE_SIMULATOR_CPU_N, irq_nbr));
 
 	sys_trace_isr_enter();
 
@@ -69,7 +69,8 @@ static inline void vector_to_irq(int irq_nbr, int *may_swap)
 
 	sys_trace_isr_exit();
 
-	bs_trace_raw_time(7, "Irq %i (%s) ended\n", irq_nbr, hw_irq_ctrl_get_name(irq_nbr));
+	bs_trace_raw_time(7, "Irq %i (%s) ended\n", irq_nbr,
+			  hw_irq_ctrl_get_name(CONFIG_NATIVE_SIMULATOR_CPU_N, irq_nbr));
 }
 
 /**
@@ -85,8 +86,9 @@ void posix_irq_handler(void)
 	uint64_t irq_lock;
 	int irq_nbr;
 	static int may_swap;
+	const int cpu_n = CONFIG_NATIVE_SIMULATOR_CPU_N;
 
-	irq_lock = hw_irq_ctrl_get_current_lock();
+	irq_lock = hw_irq_ctrl_get_current_lock(cpu_n);
 
 	if (irq_lock) {
 		/* "spurious" wakes can happen with interrupts locked */
@@ -99,20 +101,20 @@ void posix_irq_handler(void)
 
 	_kernel.cpus[0].nested++;
 
-	while ((irq_nbr = hw_irq_ctrl_get_highest_prio_irq()) != -1) {
-		int last_current_running_prio = hw_irq_ctrl_get_cur_prio();
+	while ((irq_nbr = hw_irq_ctrl_get_highest_prio_irq(cpu_n)) != -1) {
+		int last_current_running_prio = hw_irq_ctrl_get_cur_prio(cpu_n);
 		int last_running_irq = currently_running_irq;
 
-		hw_irq_ctrl_set_cur_prio(hw_irq_ctrl_get_prio(irq_nbr));
-		hw_irq_ctrl_clear_irq(irq_nbr);
+		hw_irq_ctrl_set_cur_prio(cpu_n, hw_irq_ctrl_get_prio(cpu_n, irq_nbr));
+		hw_irq_ctrl_clear_irq(cpu_n, irq_nbr);
 
 		currently_running_irq = irq_nbr;
 		vector_to_irq(irq_nbr, &may_swap);
 		currently_running_irq = last_running_irq;
 
-		hw_irq_ctrl_reeval_level_irq(irq_nbr);
+		hw_irq_ctrl_reeval_level_irq(cpu_n, irq_nbr);
 
-		hw_irq_ctrl_set_cur_prio(last_current_running_prio);
+		hw_irq_ctrl_set_cur_prio(cpu_n, last_current_running_prio);
 	}
 
 	_kernel.cpus[0].nested--;
@@ -124,7 +126,7 @@ void posix_irq_handler(void)
 	 * 4) we are in a irq postfix (not just in a WFE)
 	 */
 	if (may_swap
-		&& (hw_irq_ctrl_get_cur_prio() == 256)
+		&& (hw_irq_ctrl_get_cur_prio(cpu_n) == 256)
 		&& (CPU_will_be_awaken_from_WFE == false)
 		&& (_kernel.ready_q.cache) && (_kernel.ready_q.cache != _current)) {
 
@@ -144,7 +146,7 @@ void posix_irq_handler_im_from_sw(void)
 	 * pending we go immediately into irq_handler() to vector into its
 	 * handler
 	 */
-	if (hw_irq_ctrl_get_highest_prio_irq() != -1) {
+	if (hw_irq_ctrl_get_highest_prio_irq(CONFIG_NATIVE_SIMULATOR_CPU_N) != -1) {
 		if (!posix_is_cpu_running()) { /* LCOV_EXCL_BR_LINE */
 			/* LCOV_EXCL_START */
 			posix_print_error_and_exit("programming error: %s "
@@ -189,7 +191,7 @@ void posix_irq_handler_im_from_sw(void)
  */
 unsigned int posix_irq_lock(void)
 {
-	return hw_irq_ctrl_change_lock(true);
+	return hw_irq_ctrl_change_lock(CONFIG_NATIVE_SIMULATOR_CPU_N, true);
 }
 
 /**
@@ -203,27 +205,27 @@ unsigned int posix_irq_lock(void)
  */
 void posix_irq_unlock(unsigned int key)
 {
-	hw_irq_ctrl_change_lock(key);
+	hw_irq_ctrl_change_lock(CONFIG_NATIVE_SIMULATOR_CPU_N, key);
 }
 
 void posix_irq_full_unlock(void)
 {
-	hw_irq_ctrl_change_lock(false);
+	hw_irq_ctrl_change_lock(CONFIG_NATIVE_SIMULATOR_CPU_N, false);
 }
 
 void posix_irq_enable(unsigned int irq)
 {
-	hw_irq_ctrl_enable_irq(irq);
+	hw_irq_ctrl_enable_irq(CONFIG_NATIVE_SIMULATOR_CPU_N, irq);
 }
 
 void posix_irq_disable(unsigned int irq)
 {
-	hw_irq_ctrl_disable_irq(irq);
+	hw_irq_ctrl_disable_irq(CONFIG_NATIVE_SIMULATOR_CPU_N, irq);
 }
 
 int posix_irq_is_enabled(unsigned int irq)
 {
-	return hw_irq_ctrl_is_irq_enabled(irq);
+	return hw_irq_ctrl_is_irq_enabled(CONFIG_NATIVE_SIMULATOR_CPU_N, irq);
 }
 
 int posix_get_current_irq(void)
@@ -264,7 +266,7 @@ void posix_isr_declare(unsigned int irq_p, int flags, void isr_p(const void *),
  */
 void posix_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
-	hw_irq_ctrl_prio_set(irq, prio);
+	hw_irq_ctrl_prio_set(CONFIG_NATIVE_SIMULATOR_CPU_N, irq, prio);
 }
 
 /**
@@ -277,7 +279,7 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
  */
 void posix_sw_set_pending_IRQ(unsigned int IRQn)
 {
-	hw_irq_ctrl_raise_im_from_sw(IRQn);
+	hw_irq_ctrl_raise_im_from_sw(CONFIG_NATIVE_SIMULATOR_CPU_N, IRQn);
 }
 
 /**
@@ -286,7 +288,7 @@ void posix_sw_set_pending_IRQ(unsigned int IRQn)
  */
 void posix_sw_clear_pending_IRQ(unsigned int IRQn)
 {
-	hw_irq_ctrl_clear_irq(IRQn);
+	hw_irq_ctrl_clear_irq(CONFIG_NATIVE_SIMULATOR_CPU_N, IRQn);
 }
 
 #ifdef CONFIG_IRQ_OFFLOAD

--- a/scripts/native_simulator/Makefile
+++ b/scripts/native_simulator/Makefile
@@ -54,7 +54,7 @@ NSI_OBJCOPY?=objcopy
 NSI_DEBUG?=-g
 #  Build optimization level (by default disabled to ease debugging)
 NSI_OPT?=-O0
-#  Warnings swtiches (for the runner itself)
+#  Warnings switches (for the runner itself)
 NSI_WARNINGS?=-Wall -Wpedantic
 #  Preprocessor flags
 NSI_CPPFLAGS?=-D_POSIX_C_SOURCE=200809 -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED

--- a/scripts/native_simulator/common/src/include/nsi_cpu_if.h
+++ b/scripts/native_simulator/common/src/include/nsi_cpu_if.h
@@ -93,6 +93,32 @@ NATIVE_SIMULATOR_IF void nsif_cpu0_irq_raised(void);
  */
 NATIVE_SIMULATOR_IF void nsif_cpu0_irq_raised_from_sw(void);
 
+#define NSI_CPU_IF_N(i) \
+NATIVE_SIMULATOR_IF void nsif_cpu##i##_pre_cmdline_hooks(void); \
+NATIVE_SIMULATOR_IF void nsif_cpu##i##_pre_hw_init_hooks(void); \
+NATIVE_SIMULATOR_IF void nsif_cpu##i##_boot(void);              \
+NATIVE_SIMULATOR_IF int  nsif_cpu##i##_cleanup(void);           \
+NATIVE_SIMULATOR_IF void nsif_cpu##i##_irq_raised(void);        \
+NATIVE_SIMULATOR_IF void nsif_cpu##i##_irq_raised_from_sw(void);
+
+NSI_CPU_IF_N(1)
+NSI_CPU_IF_N(2)
+NSI_CPU_IF_N(3)
+NSI_CPU_IF_N(4)
+NSI_CPU_IF_N(5)
+NSI_CPU_IF_N(6)
+NSI_CPU_IF_N(7)
+NSI_CPU_IF_N(8)
+NSI_CPU_IF_N(9)
+NSI_CPU_IF_N(10)
+NSI_CPU_IF_N(11)
+NSI_CPU_IF_N(12)
+NSI_CPU_IF_N(13)
+NSI_CPU_IF_N(14)
+NSI_CPU_IF_N(15)
+
+#undef NSI_CPU_IF_N
+
 #ifdef __cplusplus
 }
 #endif

--- a/scripts/native_simulator/common/src/nsi_cpun_if.c
+++ b/scripts/native_simulator/common/src/nsi_cpun_if.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nsi_cpu_if.h"
+
+/*
+ * These trampolines forward a call from the runner into the corresponding embedded CPU hook
+ * for ex., nsif_cpun_boot(4) -> nsif_cpu4_boot()
+ */
+
+#define FUNCT(i, pre, post) \
+	pre##i##post
+
+#define F_TABLE(pre, post)    \
+	FUNCT(0, pre, post), \
+	FUNCT(1, pre, post), \
+	FUNCT(2, pre, post), \
+	FUNCT(3, pre, post), \
+	FUNCT(4, pre, post), \
+	FUNCT(5, pre, post), \
+	FUNCT(6, pre, post), \
+	FUNCT(7, pre, post), \
+	FUNCT(8, pre, post), \
+	FUNCT(9, pre, post), \
+	FUNCT(10, pre, post), \
+	FUNCT(11, pre, post), \
+	FUNCT(12, pre, post), \
+	FUNCT(13, pre, post), \
+	FUNCT(14, pre, post), \
+	FUNCT(15, pre, post)
+
+#define TRAMPOLINES(pre, post)             \
+	void pre ## n ## post(int n)       \
+	{                                  \
+		void(*fptrs[])(void) = {   \
+			F_TABLE(pre, post) \
+		};                         \
+		fptrs[n]();                \
+	}
+
+#define TRAMPOLINES_i(pre, post)             \
+	int pre ## n ## post(int n)          \
+	{                                    \
+		int(*fptrs[])(void) = {      \
+			F_TABLE(pre, post)   \
+		};                           \
+		return fptrs[n]();           \
+	}
+
+TRAMPOLINES(nsif_cpu, _pre_cmdline_hooks)
+TRAMPOLINES(nsif_cpu, _pre_hw_init_hooks)
+TRAMPOLINES(nsif_cpu, _boot)
+TRAMPOLINES_i(nsif_cpu, _cleanup)
+TRAMPOLINES(nsif_cpu, _irq_raised)
+TRAMPOLINES(nsif_cpu, _irq_raised_from_sw)

--- a/scripts/native_simulator/common/src/nsi_cpun_if.h
+++ b/scripts/native_simulator/common/src/nsi_cpun_if.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NSI_COMMON_SRC_NSI_CPUN_IF_H
+#define NSI_COMMON_SRC_NSI_CPUN_IF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Equivalent interfaces to nsi_cpu<n>_* but for the native simulator internal use
+ */
+
+void nsif_cpun_pre_cmdline_hooks(int n);
+void nsif_cpun_pre_hw_init_hooks(int n);
+void nsif_cpun_boot(int n);
+int nsif_cpun_cleanup(int n);
+void nsif_cpun_irq_raised(int n);
+void nsif_cpun_irq_raised_from_sw(int n);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NSI_COMMON_SRC_NSI_CPUN_IF_H */

--- a/scripts/native_simulator/common/src/nsi_weak_stubs.c
+++ b/scripts/native_simulator/common/src/nsi_weak_stubs.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nsi_cpu_if.h"
+#include "nsi_tracing.h"
+
+/*
+ * Stubbed embedded CPU images, which do nothing:
+ *   The CPU does not boot, and interrupts are just ignored
+ * These are all defined as weak, so if an actual image is present for that CPU,
+ * that will be linked against.
+ */
+
+#define NSI_CPU_STUBBED_IMAGE(i)                                          \
+__attribute__((weak)) void nsif_cpu##i##_pre_cmdline_hooks(void) { }      \
+__attribute__((weak)) void nsif_cpu##i##_pre_hw_init_hooks(void) { }      \
+__attribute__((weak)) void nsif_cpu##i##_boot(void)                       \
+	{                                                                 \
+		nsi_print_trace("Attempted boot of CPU %i without image. "\
+				"CPU %i shut down permanently\n", i, i);  \
+	}                                                                 \
+__attribute__((weak)) int nsif_cpu##i##_cleanup(void) { return 0; }       \
+__attribute__((weak)) void nsif_cpu##i##_irq_raised(void) { }             \
+__attribute__((weak)) void nsif_cpu##i##_irq_raised_from_sw(void) { }
+
+NSI_CPU_STUBBED_IMAGE(0)
+NSI_CPU_STUBBED_IMAGE(1)
+NSI_CPU_STUBBED_IMAGE(2)
+NSI_CPU_STUBBED_IMAGE(3)
+NSI_CPU_STUBBED_IMAGE(4)
+NSI_CPU_STUBBED_IMAGE(5)
+NSI_CPU_STUBBED_IMAGE(6)
+NSI_CPU_STUBBED_IMAGE(7)
+NSI_CPU_STUBBED_IMAGE(8)
+NSI_CPU_STUBBED_IMAGE(9)
+NSI_CPU_STUBBED_IMAGE(10)
+NSI_CPU_STUBBED_IMAGE(11)
+NSI_CPU_STUBBED_IMAGE(12)
+NSI_CPU_STUBBED_IMAGE(13)
+NSI_CPU_STUBBED_IMAGE(14)
+NSI_CPU_STUBBED_IMAGE(15)

--- a/soc/posix/inf_clock/Kconfig
+++ b/soc/posix/inf_clock/Kconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config NATIVE_SIMULATOR_CPU_N
+	int "CPU Number this image targets"
+	range 0 15
+	default 0
+	depends on NATIVE_LIBRARY
+	help
+	  Which native simulator embedded CPU number is this image targeting.
+	  This option is only applicable for targets which use the
+	  native simulator as their runner.

--- a/west.yml
+++ b/west.yml
@@ -297,7 +297,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 5993de6656e9c9238e975393c402d2f70339a1b3
+      revision: 57b61a9a2da75c860f15ca79522b24d57992df2c
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 42b7c577714b8f22ce82a901e19c1814af4609a8


### PR DESCRIPTION
As a stepping stone towards adding a simulated nrf5340:

* Update the native simulator to the latest
* Update the nRF HW models to the latest
* Add a new kconfig option for the native targets that use the native simulator to define which embedded CPU (in a AMP system) we are targeting.

---------
    nrf52_bsim: Update HW models to latest and align with them
    
    * In Zephyr: The HW models now include N interrupt controllers
    The interrupt handling code needs to target one controller
    specifically.
    
    * Update the HW models module to
      57b61a9a2da75c860f15ca79522b24d57992df2c
    
      Including the following:
      * 57b61a9 INT CNTRL: Generalize to N controllers
      * 1ea8194 nrf_bsim_redef.h: Add first definitions for nrf5340
      * 5f81ee9 irq_ctrl: Lower a bit HW event priority
      * 0986acc RNG: Add nrf53 variant in model
      * 09345da RNG: Generate level interrupts instead of pulse ones
      * f9b7c7a DPPI: Add first version
      * 62dabd3 HW models: Initial peripheral adaptation for multi-int_cntr
      * f54b59d HW models: Adding initial nrf5340 structure
      * fb1edd9 HW models: Use HW types definitions only where neded
      * 2744f4c Add basic support for variants
      * a5f79cd nrf_bsim_redef.h: Remove unnecessary redefinitions
      * 2c781dd HW_models: Improve includes
      * bdb0a08 minor: Remove non-ASCII characters from source
      * b5e95bd RADIO: Corrected note about MAXLEN and CRCINC behaviour
    
----------

    nrf52_bsim: Set CPU we are targetting
    
    Let's be explicity about which CPU we are targetting.
    
-----------

    native SOC: Add option to select CPU we target
    
    Add a new kconfig option to select which embedded
    CPU we are targetting.
    
-----------

    native simulator: Align with latest upstream version
    
    Align with native_simulator's upstream main
    4888ec241a0e302c98a2a6ebb4e98d0a73596715
    
    Including:
    * 4888ec2 Add default empty embedded images
    * a318045 Add hooks for up to 16 embedded CPUs
    * 0546c59 Makefile: Fix typo
