### PR TITLE
drivers: wifi: Prevent CMake warnings for out-of-tree drivers

### DIFF
--- a/drivers/ethernet/CMakeLists.txt
+++ b/drivers/ethernet/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
+zephyr_library_property(ALLOW_EMPTY TRUE)
 
 zephyr_library_sources_ifdef(CONFIG_ETH_GECKO
 	eth_gecko.c

--- a/drivers/wifi/CMakeLists.txt
+++ b/drivers/wifi/CMakeLists.txt
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
+zephyr_library_property(ALLOW_EMPTY TRUE)
+
 add_subdirectory_ifdef(CONFIG_WIFI_ESP_AT       esp_at)
 add_subdirectory_ifdef(CONFIG_WIFI_ESP32        esp32)
 add_subdirectory_ifdef(CONFIG_WIFI_ESWIFI       eswifi)


### PR DESCRIPTION
When Ethernet or Wi-Fi subsystems are enabled, but no driver source files are provided in the Zephyr source tree (which is the case for out-of-tree drivers), CMake throws warnings about empty libs, for example:

  No SOURCES given to Zephyr library: drivers__ethernet
  No SOURCES given to Zephyr library: drivers__wifi

This commit sets ALLOW_EMPTY property for those libraries, to allow for seamless out-of-tree drivers integration.