### PR TITLE
doc: redirects: Add redirects for renamed Intel boards

### DIFF
--- a/doc/_scripts/redirects.py
+++ b/doc/_scripts/redirects.py
@@ -14,6 +14,8 @@ Notes:
 
 REDIRECTS = [
     ('application/index', 'develop/application/index'),
+    ('boards/x86/ehl_crb/doc/index', 'boards/x86/intel_ehl/doc/index'),
+    ('boards/x86/rpl_crb/doc/index', 'boards/x86/intel_rpl/doc/index'),
     ('development_process/code_flow', 'project/code_flow'),
     ('development_process/index', 'project/index'),
     ('development_process/issues', 'project/issues'),


### PR DESCRIPTION
The ehl_crb and rpl_crb boards directories were renamed to intel_ehl and intel_rpl respectively.