### PR TITLE
tests lwm2m_rd_client: Allow only on native_posix

### DIFF
--- a/tests/net/lib/lwm2m/lwm2m_rd_client/testcase.yaml
+++ b/tests/net/lib/lwm2m/lwm2m_rd_client/testcase.yaml
@@ -4,7 +4,7 @@ common:
   tags:
     - lwm2m
     - net
-  integration_platforms:
+  platform_allow:
     - native_posix
 tests:
   net.lwm2m.lwm2m_rd_client:


### PR DESCRIPTION
This test is too dependent on the exact order of events, and known to fail in most platforms but native_posix. To mitigate the issue and avoid blocking development due to failed CI tests, let's only allow the test in native_posix.

Mitigates #61824
See for ex. an unrelated CI failure in https://github.com/zephyrproject-rtos/zephyr/actions/runs/6048243431/job/16413461922?pr=62200#step:13:3965