### PR TITLE
RFC: net: lwm2m: Add pre request callback

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.h
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.h
@@ -41,6 +41,9 @@
 
 /* Establish a request handler callback type */
 typedef int (*udp_request_handler_cb_t)(struct coap_packet *request, struct lwm2m_message *msg);
+/* Define pre_request_cb type */
+typedef int (*lwm2m_engine_pre_request_cb_t)(struct lwm2m_message *msg);
+
 /* LwM2M message functions */
 struct lwm2m_message *lwm2m_get_message(struct lwm2m_ctx *client_ctx);
 struct lwm2m_message *find_msg(struct coap_pending *pending, struct coap_reply *reply);
@@ -60,6 +63,18 @@ int lwm2m_information_interface_send(struct lwm2m_message *msg);
 int lwm2m_send_empty_ack(struct lwm2m_ctx *client_ctx, uint16_t mid);
 
 int lwm2m_register_payload_handler(struct lwm2m_message *msg);
+
+/**
+ * @brief Registers one callback for every lwm2m request
+ *        Is used to wakeup the device. This callback will
+ *        be called as the first callback for read, write
+ *        and execute
+ *
+ * @param pre_request_cb
+ * @return  0 if successful
+ *          -EBUSY if already registered
+ */
+int lwm2m_register_pre_request_cb(lwm2m_engine_pre_request_cb_t pre_request_cb);
 
 int lwm2m_perform_read_op(struct lwm2m_message *msg, uint16_t content_format);
 


### PR DESCRIPTION
## Introduction
Our product consist of a communication board and a main system. The communication board is always powered and waits for lwm2m requests.  We want one callback for all lwm2m requests to wake up our main system.

### Problem description
We can handle the wake up with the existing read/write/execute callbacks, but that means changes for all existing modules. Further any upcoming lwm2m modules have to handle the wake up separately

### Proposed change
We add a pre_request_callback to solve this problem. The callback can be registered once and will be called from `lwm2m_write_handler()`, `lwm2m_read_handler()` and `lwm2m_exec_handler()`.

## Detailed RFC

### Proposed change (Detailed)
We added the pre_request_handler to the lwm2m_message_handling module. It will be called quite often, but it's the only place to call it from all requests (as I can see)

### Dependencies
None

### Concerns and Unresolved Questions
I open this RFC-PR to discuss about this feature. Is there another way to solve this problem? We can add this callback to your local zephyr branch, but I think we are not the only users with a similar problem
