### PR TITLE
modules: mbedtls: add Kconfig option for HKDF

### DIFF
--- a/modules/mbedtls/Kconfig.tls-generic
+++ b/modules/mbedtls/Kconfig.tls-generic
@@ -481,4 +481,8 @@ config MBEDTLS_SSL_DTLS_CONNECTION_ID
 	  which allows to identify DTLS connections across changes
 	  in the underlying transport.
 
+config MBEDTLS_HKDF_C
+	bool "HMAC-based Extract-and-Expand Key Derivation Function API"
+	depends on MBEDTLS_MD
+
 endmenu

--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -479,6 +479,10 @@
 #define MBEDTLS_SSL_DTLS_CONNECTION_ID
 #endif
 
+#if defined(CONFIG_MBEDTLS_HKDF_C)
+#define MBEDTLS_HKDF_C
+#endif
+
 /* User config file */
 
 #if defined(CONFIG_MBEDTLS_USER_CONFIG_FILE)


### PR DESCRIPTION
Add Kconfig option for `config-tls-generic.h` to enable the HKDF API.