### PR TITLE
Revert "tests: driver: flash_default limited on tier one boards"

### DIFF
--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -34,18 +34,20 @@ tests:
       and dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions"))
     integration_platforms:
       - qemu_x86
-      - mimxrt1060_evk
-    platform_allow:
-      - mimxrt1060_evk
-      - it8xxx2_evb
-      - mimxrt685_evk_cm33
-      - mimxrt595_evk_cm33
   drivers.flash.common.tfm_ns:
     build_only: true
     filter: (CONFIG_FLASH_HAS_DRIVER_ENABLED and CONFIG_TRUSTED_EXECUTION_NONSECURE
       and dt_label_with_parent_compat_enabled("slot1_ns_partition", "fixed-partitions"))
     integration_platforms:
       - nrf9161dk_nrf9161_ns
+  drivers.flash.mcux:
+    platform_allow:
+      - mimxrt1060_evk
+      - it8xxx2_evb
+      - mimxrt685_evk_cm33
+      - mimxrt595_evk_cm33
+    integration_platforms:
+      - mimxrt1060_evk
   drivers.flash.common.stm32:
     platform_allow:
       - nucleo_f103rb


### PR DESCRIPTION
This reverts commit 903a79431aefed48bc1c918a7fca14b7a96444bb.

This commit is breaking CI, in --integration mode.
Also, the above commit is not doing what it is claimingto do and changing unrelated stuff.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>

Fixes #https://github.com/zephyrproject-rtos/zephyr/issues/62215