### PR TITLE
tests drivers.flash.common.default: Fix allow list

### DIFF
--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -36,6 +36,7 @@ tests:
       - qemu_x86
       - mimxrt1060_evk
     platform_allow:
+      - qemu_x86
       - mimxrt1060_evk
       - it8xxx2_evb
       - mimxrt685_evk_cm33


### PR DESCRIPTION
qemu_x86 was listed as an integration platform but not in the allow list causing twister to fail with an error when generating the testplan:

Error found:
tests/drivers/flash/common/drivers.flash.common.default on qemu_x86 (Not in testsuite platform allow list but is one of the integration platforms)

---

Here some examples in CI:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/6049300814/job/16416324340?pr=62200#step:8:58
https://github.com/zephyrproject-rtos/zephyr/actions/runs/6049551554/job/16417045831?pr=62214#step:8:34

Fixes #https://github.com/zephyrproject-rtos/zephyr/issues/62215