### PR TITLE
logging: Minor improvement in instance logging

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -251,13 +251,15 @@ static inline char z_log_minimal_level_to_char(int level)
 #define Z_LOG(_level, ...) \
 	Z_LOG2(_level, 0, __log_current_const_data, __log_current_dynamic_data, __VA_ARGS__)
 
-#define Z_LOG_INSTANCE(_level, _inst, ...) \
+#define Z_LOG_INSTANCE(_level, _inst, ...) do { \
+	(void)_inst; \
 	Z_LOG2(_level, 1, \
 		COND_CODE_1(CONFIG_LOG_RUNTIME_FILTERING, (NULL), (Z_LOG_INST(_inst))), \
 		(struct log_source_dynamic_data *)COND_CODE_1( \
 						CONFIG_LOG_RUNTIME_FILTERING, \
 						(Z_LOG_INST(_inst)), (NULL)), \
-		__VA_ARGS__)
+		__VA_ARGS__); \
+} while (0)
 
 /*****************************************************************************/
 /****************** Macros for hexdump logging *******************************/

--- a/include/zephyr/logging/log_instance.h
+++ b/include/zephyr/logging/log_instance.h
@@ -137,11 +137,16 @@ struct log_source_dynamic_data {
 /**
  * @brief Declare a logger instance pointer in the module structure.
  *
+ * If logging is disabled then element in the structure is still declared to avoid
+ * compilation issues. If compiler supports zero length arrays then it is utilized
+ * to not use any space, else a byte array is created.
+ *
  * @param _name Name of a structure element that will have a pointer to logging
  * instance object.
  */
 #define LOG_INSTANCE_PTR_DECLARE(_name)	\
-	IF_ENABLED(CONFIG_LOG, (Z_LOG_INSTANCE_STRUCT * _name))
+	COND_CODE_1(CONFIG_LOG, (Z_LOG_INSTANCE_STRUCT * _name), \
+				(int _name[TOOLCHAIN_HAS_ZLA ? 0 : 1]))
 
 #define Z_LOG_RUNTIME_INSTANCE_REGISTER(_module_name, _inst_name) \
 	STRUCT_SECTION_ITERABLE_ALTERNATE(log_dynamic, log_source_dynamic_data, \

--- a/include/zephyr/toolchain.h
+++ b/include/zephyr/toolchain.h
@@ -116,6 +116,14 @@
 #endif
 
 /**
+ * @def TOOLCHAIN_HAS_ZLA
+ * @brief Indicate if toolchain supports Zero Length Arrays.
+ */
+#ifndef TOOLCHAIN_HAS_ZLA
+#define TOOLCHAIN_HAS_ZLA 0
+#endif
+
+/**
  * @def TOOLCHAIN_IGNORE_WSHADOW_BEGIN
  * @brief Begin of block to ignore -Wshadow.
  *

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -30,6 +30,8 @@
 #define TOOLCHAIN_HAS_C_AUTO_TYPE 1
 #endif
 
+#define TOOLCHAIN_HAS_ZLA 1
+
 /*
  * Older versions of GCC do not define __BYTE_ORDER__, so it must be manually
  * detected and defined using arch-specific definitions.


### PR DESCRIPTION
When using instance logging (e.g. LOG_INST_INF) first argument is a pointer to the logging object associated with an instance. It is not used if logging is disabled and that can generate 'unused variable' warning when logging is disabled.

Previously logging object was not created when logging was disabled That was done to save memory but because of that object could not be referenced when logging was disabled. Better approach is to create empty array instead of a logging object. It does not increase memory usage but can be referenced and potential compilation warning is suppressed.