### PR TITLE
Bluetooth: Mesh: Fix compilation of Opcode Aggregator server and Solicitation RPL PDU server

### DIFF
--- a/subsys/bluetooth/mesh/op_agg.c
+++ b/subsys/bluetooth/mesh/op_agg.c
@@ -17,10 +17,7 @@ LOG_MODULE_REGISTER(bt_mesh_op_agg);
 #define LENGTH_SHORT_MAX BIT_MASK(7)
 
 NET_BUF_SIMPLE_DEFINE_STATIC(sdu, BT_MESH_TX_SDU_MAX);
-
-#if IS_ENABLED(CONFIG_BT_MESH_OP_AGG_CLI)
 NET_BUF_SIMPLE_DEFINE_STATIC(srcs, BT_MESH_TX_SDU_MAX);
-#endif
 
 static struct op_agg_ctx agg_ctx = {
 	.sdu = &sdu,

--- a/subsys/bluetooth/mesh/solicitation.c
+++ b/subsys/bluetooth/mesh/solicitation.c
@@ -153,12 +153,12 @@ static bool sol_pdu_decrypt(struct bt_mesh_subnet *sub, void *data)
 		net_buf_simple_init(out, 0);
 		net_buf_simple_add_mem(out, in->data, in->len);
 
-		err = bt_mesh_net_obfuscate(out->data, 0, sub->keys[i].msg.privacy);
+		err = bt_mesh_net_obfuscate(out->data, 0, &sub->keys[i].msg.privacy);
 		if (err) {
 			LOG_DBG("obfuscation err %d", err);
 			continue;
 		}
-		err = bt_mesh_net_decrypt(sub->keys[i].msg.enc, out,
+		err = bt_mesh_net_decrypt(&sub->keys[i].msg.enc, out,
 					  0, BT_MESH_NONCE_SOLICITATION);
 		if (!err) {
 			LOG_DBG("Decrypted PDU %s", bt_hex(out->data, out->len));


### PR DESCRIPTION
Fix compilation of Opcode Aggregator server and Solicitation RPL PDU server:
- Remove ifdef around `srcs` and let linker exclude it when Opcode
Aggregator Client model is not enabled

- A pointer to the key struct should be passed after the PSA support has
been added