### PR TITLE
arch: common: Force linker to fill empty spaces in rom_start with 0x00

### DIFF
--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -56,6 +56,10 @@ if (DEFINED CONFIG_ARM OR DEFINED CONFIG_X86 OR DEFINED CONFIG_ARM64
   # Exclamation mark is printable character with lowest number in ASCII table.
   # We are sure that this file will be included as a first.
   zephyr_linker_sources(ROM_START SORT_KEY ! rom_start_address.ld)
+  # Some linkers fill unspecified region with pattern other than 0x00. Include
+  # fill_with_zeros.ld file which forces the linker to use 0x00 pattern. Please
+  # note that the pattern will affect empty spaces created after FILL(0x00).
+  zephyr_linker_sources(ROM_START SORT_KEY $ fill_with_zeros.ld)
   zephyr_linker_sources(ROM_START SORT_KEY 0x0 rom_start_offset.ld)
   # Handled in ld.cmake
 endif()

--- a/arch/common/fill_with_zeros.ld
+++ b/arch/common/fill_with_zeros.ld
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Google, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * LLVM LLD fills empty spaces (created using ALIGN() or moving the location
+ * counter) in executable segments with TrapInstr pattern, e.g. for ARM the
+ * TrapInstr pattern is 0xd4d4d4d4. GNU LD fills empty spaces with 0x00
+ * pattern.
+ *
+ * We may want to have some section (e.g. rom_start) filled with 0x00,
+ * e.g. because MCU can interpret the pattern as a configuration data.
+ */
+FILL(0x00);


### PR DESCRIPTION
LLVM LLD fills empty spaces (created using ALIGN() or moving the location counter) in executable segments with TrapInstr pattern, e.g. for ARM the TrapInstr pattern is 0xd4d4d4d4. GNU LD fills empty spaces with 0x00 pattern.

We may want to have some section (e.g. rom_start) filled with 0x00, e.g. because MCU can interpret the pattern as a configuration data.