### PR TITLE
tests: lib: thrift: temporarily disable tlsTransport

### DIFF
--- a/tests/lib/thrift/ThriftTest/testcase.yaml
+++ b/tests/lib/thrift/ThriftTest/testcase.yaml
@@ -19,5 +19,6 @@ tests:
   thrift.ThriftTest.newlib.compactProtocol:
     extra_configs:
       - CONFIG_THRIFT_COMPACT_PROTOCOL=y
-  thrift.ThriftTest.newlib.tlsTransport:
-    extra_args: OVERLAY_CONFIG="overlay-tls.conf"
+    # Temporarily disabled until #61717 is resolved
+    # thrift.ThriftTest.newlib.tlsTransport:
+    #   extra_args: OVERLAY_CONFIG="overlay-tls.conf"


### PR DESCRIPTION
Issue #61717 details what appears to be a possible race condition in the mbedTLS / Zephyr integration. Disable the thrift tlsTransport test until the issue is resolved to mitigate false positives in other PRs.