### PR TITLE
drivers: sensor: remove LOG_INF from ntc_thermistor_sample_fetch()

### DIFF
--- a/drivers/sensor/ntc_thermistor/ntc_thermistor.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor.c
@@ -65,7 +65,6 @@ static int ntc_thermistor_channel_get(const struct device *dev, enum sensor_chan
 		temp = ntc_get_temp_mc(&cfg->ntc_cfg.type, ohm);
 		val->val1 = temp / 1000;
 		val->val2 = (temp % 1000) * 1000;
-		LOG_INF("ntc temp says %u", val->val1);
 		break;
 	default:
 		return -ENOTSUP;


### PR DESCRIPTION
LOG_INF() inside of a sample_fetch create noise in the logs and is inconsistent with other sensor driver implementations.