### PR TITLE
tests: ARC: update platform lists

### DIFF
--- a/tests/kernel/fatal/no-multithreading/testcase.yaml
+++ b/tests/kernel/fatal/no-multithreading/testcase.yaml
@@ -3,7 +3,10 @@ common:
     - qemu_cortex_m3
     - qemu_arc_em
     - qemu_arc_hs
+    - qemu_arc_hs5x
     - qemu_arc_hs6x
+    - qemu_arc_hs6x
+    - qemu_arc_hs_xip
     - qemu_riscv32
     - qemu_riscv32e
     - qemu_riscv64
@@ -11,6 +14,9 @@ common:
     - nsim_em7d_v22
     - nsim_hs
     - nsim_hs_mpuv6
+    - nsim_hs_sram
+    - nsim_hs_flash_xip
+    - nsim_hs3x_hostlink
     - nsim_hs5x
     - nsim_hs6x
   integration_platforms:

--- a/tests/kernel/fatal/no-multithreading/testcase.yaml
+++ b/tests/kernel/fatal/no-multithreading/testcase.yaml
@@ -15,7 +15,7 @@ common:
     - nsim_hs6x
   integration_platforms:
     - qemu_cortex_m3
-    - nsim_em
+    - qemu_arc_em
   tags:
     - kernel
     - scheduler

--- a/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
+++ b/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
@@ -16,11 +16,17 @@ tests:
       - nsim_em7d_v22
       - nsim_hs
       - nsim_hs_mpuv6
+      - nsim_hs_sram
+      - nsim_hs_flash_xip
+      - nsim_hs3x_hostlink
       - nsim_hs5x
       - nsim_hs6x
       - qemu_arc_em
       - qemu_arc_hs
+      - qemu_arc_hs5x
       - qemu_arc_hs6x
+      - qemu_arc_hs6x
+      - qemu_arc_hs_xip
       - qemu_riscv32
       - qemu_riscv32e
       - qemu_riscv64

--- a/tests/kernel/mem_slab/mslab_api/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_api/testcase.yaml
@@ -14,11 +14,17 @@ tests:
       - nsim_em7d_v22
       - nsim_hs
       - nsim_hs_mpuv6
+      - nsim_hs_sram
+      - nsim_hs_flash_xip
+      - nsim_hs3x_hostlink
       - nsim_hs5x
       - nsim_hs6x
       - qemu_arc_em
       - qemu_arc_hs
+      - qemu_arc_hs5x
       - qemu_arc_hs6x
+      - qemu_arc_hs6x
+      - qemu_arc_hs_xip
       - qemu_riscv32
       - qemu_riscv32e
       - qemu_riscv64

--- a/tests/kernel/threads/no-multithreading/testcase.yaml
+++ b/tests/kernel/threads/no-multithreading/testcase.yaml
@@ -14,11 +14,17 @@ tests:
       - nsim_em7d_v22
       - nsim_hs
       - nsim_hs_mpuv6
+      - nsim_hs_sram
+      - nsim_hs_flash_xip
+      - nsim_hs3x_hostlink
       - nsim_hs5x
       - nsim_hs6x
       - qemu_arc_em
       - qemu_arc_hs
+      - qemu_arc_hs5x
       - qemu_arc_hs6x
+      - qemu_arc_hs6x
+      - qemu_arc_hs_xip
       - qemu_riscv32
       - qemu_riscv32e
       - qemu_riscv64

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -29,11 +29,17 @@ tests:
       - nsim_em7d_v22
       - nsim_hs
       - nsim_hs_mpuv6
+      - nsim_hs_sram
+      - nsim_hs_flash_xip
+      - nsim_hs3x_hostlink
       - nsim_hs5x
       - nsim_hs6x
       - qemu_arc_em
       - qemu_arc_hs
+      - qemu_arc_hs5x
       - qemu_arc_hs6x
+      - qemu_arc_hs6x
+      - qemu_arc_hs_xip
     integration_platforms:
       - qemu_cortex_m3
       - qemu_arc_em

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -36,7 +36,7 @@ tests:
       - qemu_arc_hs6x
     integration_platforms:
       - qemu_cortex_m3
-      - nsim_em
+      - qemu_arc_em
     extra_configs:
       - CONFIG_MULTITHREADING=n
       - CONFIG_TEST_USERSPACE=n


### PR DESCRIPTION
- don't use nSIM as integration platform if QEMU available
- add missing ARC platforms to platform_allow list to no-multithreading tests