### PR TITLE
tests/flash: Fix test assuming erase value to be 0xff

### DIFF
--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -46,11 +46,12 @@
 #endif
 
 #define EXPECTED_SIZE	512
-#define CANARY		0xff
 
 static const struct device *const flash_dev = TEST_AREA_DEVICE;
 static struct flash_pages_info page_info;
 static uint8_t __aligned(4) expected[EXPECTED_SIZE];
+static const struct flash_parameters *flash_params;
+static uint8_t erase_value;
 
 static void *flash_driver_setup(void)
 {
@@ -58,8 +59,8 @@ static void *flash_driver_setup(void)
 
 	zassert_true(device_is_ready(flash_dev));
 
-	const struct flash_parameters *flash_params =
-			flash_get_parameters(flash_dev);
+	flash_params = flash_get_parameters(flash_dev);
+	erase_value = flash_params->erase_value;
 
 	/* For tests purposes use page (in nrf_qspi_nor page = 64 kB) */
 	flash_get_page_info_by_offs(flash_dev, TEST_AREA_OFFSET,
@@ -73,8 +74,12 @@ static void *flash_driver_setup(void)
 	zassert_equal(rc, 0, "Cannot read flash");
 
 	/* Fill test buffer with random data */
-	for (int i = 0; i < EXPECTED_SIZE; i++) {
-		expected[i] = i;
+	for (int i = 0, val = 0; i < EXPECTED_SIZE; i++, val++) {
+		/* Skip erase value */
+		if (val == erase_value) {
+			val++;
+		}
+		expected[i] = val;
 	}
 
 	/* Check if tested region fits in flash */
@@ -85,7 +90,7 @@ static void *flash_driver_setup(void)
 	bool is_buf_clear = true;
 
 	for (off_t i = 0; i < EXPECTED_SIZE; i++) {
-		if (buf[i] != flash_params->erase_value) {
+		if (buf[i] != erase_value) {
 			is_buf_clear = false;
 			break;
 		}
@@ -108,6 +113,7 @@ ZTEST(flash_driver, test_read_unaligned_address)
 {
 	int rc;
 	uint8_t buf[EXPECTED_SIZE];
+	const uint8_t canary = erase_value;
 
 	rc = flash_write(flash_dev,
 			 page_info.start_offset,
@@ -121,8 +127,8 @@ ZTEST(flash_driver, test_read_unaligned_address)
 			/* buffer offset; leave space for buffer guard */
 			for (off_t buf_o = 1; buf_o < 5; buf_o++) {
 				/* buffer overflow protection */
-				buf[buf_o - 1] = CANARY;
-				buf[buf_o + len] = CANARY;
+				buf[buf_o - 1] = canary;
+				buf[buf_o + len] = canary;
 				memset(buf + buf_o, 0, len);
 				rc = flash_read(flash_dev,
 						page_info.start_offset + ad_o,
@@ -134,10 +140,10 @@ ZTEST(flash_driver, test_read_unaligned_address)
 					0, "Flash read failed at len=%d, "
 					"ad_o=%d, buf_o=%d", len, ad_o, buf_o);
 				/* check buffer guards */
-				zassert_equal(buf[buf_o - 1], CANARY,
+				zassert_equal(buf[buf_o - 1], canary,
 					"Buffer underflow at len=%d, "
 					"ad_o=%d, buf_o=%d", len, ad_o, buf_o);
-				zassert_equal(buf[buf_o + len], CANARY,
+				zassert_equal(buf[buf_o + len], canary,
 					"Buffer overflow at len=%d, "
 					"ad_o=%d, buf_o=%d", len, ad_o, buf_o);
 			}


### PR DESCRIPTION
Test assumed non-writen flash to contain 0xff while it is supposed to check for erase_value.