### PR TITLE
drivers/flash: Series of commits enabling use of SPI NOR compativble devices that do not require erase

### DIFF
--- a/drivers/flash/flash_handlers.c
+++ b/drivers/flash/flash_handlers.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -41,6 +42,13 @@ static inline const struct flash_parameters *z_vrfy_flash_get_parameters(const s
 	return z_impl_flash_get_parameters(dev);
 }
 #include <syscalls/flash_get_parameters_mrsh.c>
+
+static inline uint32_t z_vrfy_flash_get_info_word(const struct device *dev)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_FLASH(dev, get_info_word));
+	return z_impl_flash_get_info_word((const struct device *)dev);
+}
+#include <syscalls/flash_write_mrsh.c>
 
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 static inline int z_vrfy_flash_get_page_info_by_offs(const struct device *dev,

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1360,11 +1360,23 @@ flash_nor_get_parameters(const struct device *dev)
 	return &flash_nor_parameters;
 }
 
+static uint32_t spi_nor_get_info_word(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	#if (DT_INST_NODE_HAS_PROP(0, no_erase))
+		return FLASH_INFO_WORD_F_NO_ERASE;
+	#else
+		return 0;
+	#endif
+}
+
 static const struct flash_driver_api spi_nor_api = {
 	.read = spi_nor_read,
 	.write = spi_nor_write,
 	.erase = spi_nor_erase,
 	.get_parameters = flash_nor_get_parameters,
+	.get_info_word = spi_nor_get_info_word,
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 	.page_layout = spi_nor_pages_layout,
 #endif

--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) 2018 Peter Bigot Consulting, LLC
-# Copyright (c) 2019 Nordic Semiconductor ASA
+# Copyright (c) 2019-2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 # Common properties used by nodes describing M25P80-compatible SPI NOR
@@ -89,6 +89,11 @@ properties:
 
       This value, when present, identifies bits in the status register
       that should be cleared when the device is initialized.
+
+  no-erase:
+    type: boolean
+    description:
+      If true, then device does not require erase prior to write.
 
   mxicy,mx25r-power-mode:
     type: string

--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -46,11 +46,12 @@
 #endif
 
 #define EXPECTED_SIZE	512
-#define CANARY		0xff
 
 static const struct device *const flash_dev = TEST_AREA_DEVICE;
 static struct flash_pages_info page_info;
 static uint8_t __aligned(4) expected[EXPECTED_SIZE];
+static const struct flash_parameters *flash_params;
+static uint8_t erase_value;
 
 static void *flash_driver_setup(void)
 {
@@ -58,8 +59,8 @@ static void *flash_driver_setup(void)
 
 	zassert_true(device_is_ready(flash_dev));
 
-	const struct flash_parameters *flash_params =
-			flash_get_parameters(flash_dev);
+	flash_params = flash_get_parameters(flash_dev);
+	erase_value = flash_params->erase_value;
 
 	/* For tests purposes use page (in nrf_qspi_nor page = 64 kB) */
 	flash_get_page_info_by_offs(flash_dev, TEST_AREA_OFFSET,
@@ -73,8 +74,12 @@ static void *flash_driver_setup(void)
 	zassert_equal(rc, 0, "Cannot read flash");
 
 	/* Fill test buffer with random data */
-	for (int i = 0; i < EXPECTED_SIZE; i++) {
-		expected[i] = i;
+	for (int i = 0, val = 0; i < EXPECTED_SIZE; i++, val++) {
+		/* Skip erase value */
+		if (val == erase_value) {
+			val++;
+		}
+		expected[i] = val;
 	}
 
 	/* Check if tested region fits in flash */
@@ -85,7 +90,7 @@ static void *flash_driver_setup(void)
 	bool is_buf_clear = true;
 
 	for (off_t i = 0; i < EXPECTED_SIZE; i++) {
-		if (buf[i] != flash_params->erase_value) {
+		if (buf[i] != erase_value) {
 			is_buf_clear = false;
 			break;
 		}
@@ -108,6 +113,7 @@ ZTEST(flash_driver, test_read_unaligned_address)
 {
 	int rc;
 	uint8_t buf[EXPECTED_SIZE];
+	const uint8_t canary = erase_value;
 
 	rc = flash_write(flash_dev,
 			 page_info.start_offset,
@@ -121,8 +127,8 @@ ZTEST(flash_driver, test_read_unaligned_address)
 			/* buffer offset; leave space for buffer guard */
 			for (off_t buf_o = 1; buf_o < 5; buf_o++) {
 				/* buffer overflow protection */
-				buf[buf_o - 1] = CANARY;
-				buf[buf_o + len] = CANARY;
+				buf[buf_o - 1] = canary;
+				buf[buf_o + len] = canary;
 				memset(buf + buf_o, 0, len);
 				rc = flash_read(flash_dev,
 						page_info.start_offset + ad_o,
@@ -134,10 +140,10 @@ ZTEST(flash_driver, test_read_unaligned_address)
 					0, "Flash read failed at len=%d, "
 					"ad_o=%d, buf_o=%d", len, ad_o, buf_o);
 				/* check buffer guards */
-				zassert_equal(buf[buf_o - 1], CANARY,
+				zassert_equal(buf[buf_o - 1], canary,
 					"Buffer underflow at len=%d, "
 					"ad_o=%d, buf_o=%d", len, ad_o, buf_o);
-				zassert_equal(buf[buf_o + len], CANARY,
+				zassert_equal(buf[buf_o + len], canary,
 					"Buffer overflow at len=%d, "
 					"ad_o=%d, buf_o=%d", len, ad_o, buf_o);
 			}


### PR DESCRIPTION
The PR contains series of commits that allow to use SPI NOR driver to read/write to devices that are SPI NOR compatible in command set and operation, except they do not have erase. Example here is near MX25 compatible Fujitsu ReRAM chip.