### PR TITLE
Asynchronous I2C Driver for STM32 V2

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -95,6 +95,150 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 
 #define OPERATION(msg) (((struct i2c_msg *) msg)->flags & I2C_MSG_RW_MASK)
 
+#if defined(CONFIG_I2C_CALLBACK) && defined(CONFIG_I2C_STM32_V2)
+static void i2c_stm32_async_done(const struct device *dev, int result)
+{
+	struct i2c_stm32_data *data = dev->data;
+	i2c_callback_t cb = data->cb;
+	void *userdata = data->userdata;
+
+	/* Reset all internal transfer data */
+	data->msg = 0;
+	data->msg_buf_pos = 0;
+	data->msgs = NULL;
+	data->num_msgs = 0;
+	data->cb = NULL;
+	data->userdata = NULL;
+	data->addr = 0;
+
+	/* Allow driver to be suspended by PM once I2C transaction is complete */
+	#ifdef CONFIG_PM_DEVICE_RUNTIME
+		(void)pm_device_runtime_put(dev);
+	#else
+		pm_device_busy_clear(dev);
+	#endif
+
+	k_sem_give(&data->bus_mutex);
+
+	cb(dev, result, userdata);
+}
+
+static int i2c_stm32_transfer_cb(const struct device *dev, struct i2c_msg *msgs,
+			      uint8_t num_msgs, uint16_t addr, i2c_callback_t cb, void *userdata)
+{
+	struct i2c_stm32_data *data = dev->data;
+	struct i2c_msg *current, *next;
+	int ret = 0;
+
+	/* Check for validity of all messages, to prevent having to abort
+	 * in the middle of a transfer
+	 */
+	current = msgs;
+
+	/*
+	 * Set I2C_MSG_RESTART flag on first message in order to send start
+	 * condition
+	 */
+	current->flags |= I2C_MSG_RESTART;
+
+	for (uint8_t i = 1; i <= num_msgs; i++) {
+
+		if (i < num_msgs) {
+			next = current + 1;
+
+			/*
+			 * Restart condition between messages
+			 * of different directions is required
+			 */
+			if (OPERATION(current) != OPERATION(next)) {
+				if (!(next->flags & I2C_MSG_RESTART)) {
+					ret = -EINVAL;
+					break;
+				}
+			}
+
+			/* Stop condition is only allowed on last message */
+			if (current->flags & I2C_MSG_STOP) {
+				ret = -EINVAL;
+				break;
+			}
+		} else {
+			/* Stop condition is required for the last message */
+			current->flags |= I2C_MSG_STOP;
+		}
+
+		current++;
+	}
+
+	if (ret) {
+		return ret;
+	}
+
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Cannot start async transfer if bus is busy */
+	if (k_sem_take(&data->bus_mutex, K_NO_WAIT) != 0) {
+		return -EWOULDBLOCK;
+	}
+
+	/* Prevent driver from being suspended by PM until I2C transaction is complete */
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	(void)pm_device_runtime_get(dev);
+#else
+	pm_device_busy_set(dev);
+#endif
+
+	/*
+	 * Begin an asynchronous, non-blocking, I2C transfer.
+	 *
+	 * Here, transfer just the first unit of data. The function i2c_stm32_async_isr()
+	 * will be called by an ISR each time a unit of data has been transferred and
+	 * handles transferring the next unit.
+	 */
+	data->msg = 0;
+	data->msgs = msgs;
+	data->msg_buf_pos = 0;
+	data->num_msgs = num_msgs;
+	data->addr = addr;
+	data->cb = cb;
+	data->userdata = userdata;
+
+	stm32_i2c_transfer_next(dev);
+
+	return ret;
+}
+
+void i2c_stm32_async_isr(void *arg)
+{
+	const struct device *dev = (const struct device *) arg;
+	struct i2c_stm32_data *data = dev->data;
+
+	if (k_sem_take(&data->device_sync_sem, K_NO_WAIT) == 0) {
+		/* data->cb is used to indicate that the current transfer is async.
+		 * It's possible to perform synchronous transfers when async
+		 * transfers are enabled. In this case this function should do nothing
+		 */
+		if (data->cb != NULL) {
+			/* Error occurred - finish with error */
+			if (stm32_i2c_check_error(data, false)) {
+				i2c_stm32_async_done(dev, -EIO);
+			} else {
+				/* Try next transfer. 1 indicates nothing left to send */
+				int ret = stm32_i2c_transfer_next(dev);
+				if(ret == 1) {
+					i2c_stm32_async_done(dev, 0);
+				}
+			}
+		}
+	}
+}
+#else /* CONFIG_I2C_CALLBACK && CONFIG_I2C_STM32_V2 */
+#define i2c_stm32_async_isr(arg)
+#endif /* CONFIG_I2C_CALLBACK && CONFIG_I2C_STM32_V2 */
+
 static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msgs,
 			      uint8_t num_msgs, uint16_t addr)
 {
@@ -181,6 +325,7 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msgs,
 		ret = 0;
 	}
 
+	/* Allow driver to be suspended by PM once I2C transaction is complete */
 #ifdef CONFIG_PM_DEVICE_RUNTIME
 	(void)pm_device_runtime_put(dev);
 #else
@@ -280,16 +425,19 @@ restore:
 void i2c_stm32_combined_isr(void *arg)
 {
 	stm32_i2c_combined_isr(arg);
+	i2c_stm32_async_isr(arg);
 }
 #else
 void i2c_stm32_event_isr(void *arg)
 {
 	stm32_i2c_event_isr(arg);
+	i2c_stm32_async_isr(arg);
 }
 
 void i2c_stm32_error_isr(void *arg)
 {
 	stm32_i2c_error_isr(arg);
+	i2c_stm32_async_isr(arg);
 }
 #endif
 
@@ -299,6 +447,11 @@ static const struct i2c_driver_api api_funcs = {
 #if CONFIG_I2C_STM32_BUS_RECOVERY
 	.recover_bus = i2c_stm32_recover_bus,
 #endif /* CONFIG_I2C_STM32_BUS_RECOVERY */
+/* Restricted to V2 driver for now, TODO: add async support for V1 driver */
+#if defined(CONFIG_I2C_STM32_INTERRUPT) && defined(CONFIG_I2C_CALLBACK) \
+	&& defined(CONFIG_I2C_STM32_V2)
+	.transfer_cb = i2c_stm32_transfer_cb,
+#endif
 #if defined(CONFIG_I2C_TARGET)
 	.target_register = i2c_stm32_target_register,
 	.target_unregister = i2c_stm32_target_unregister,

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -273,6 +273,22 @@ restore:
 }
 #endif /* CONFIG_I2C_STM32_BUS_RECOVERY */
 
+#ifdef CONFIG_I2C_STM32_COMBINED_INTERRUPT
+void i2c_stm32_combined_isr(void *arg)
+{
+	stm32_i2c_combined_isr(arg);
+}
+#else
+void i2c_stm32_event_isr(void *arg)
+{
+	stm32_i2c_event_isr(arg);
+}
+
+void i2c_stm32_error_isr(void *arg)
+{
+	stm32_i2c_error_isr(arg);
+}
+#endif
 
 static const struct i2c_driver_api api_funcs = {
 	.configure = i2c_stm32_runtime_configure,
@@ -435,7 +451,7 @@ static int i2c_stm32_pm_action(const struct device *dev, enum pm_device_action a
 	do {								\
 		IRQ_CONNECT(DT_INST_IRQN(index),			\
 			    DT_INST_IRQ(index, priority),		\
-			    stm32_i2c_combined_isr,			\
+			    i2c_stm32_combined_isr,			\
 			    DEVICE_DT_INST_GET(index), 0);		\
 		irq_enable(DT_INST_IRQN(index));			\
 	} while (false)
@@ -444,13 +460,13 @@ static int i2c_stm32_pm_action(const struct device *dev, enum pm_device_action a
 	do {								\
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, event, irq),	\
 			    DT_INST_IRQ_BY_NAME(index, event, priority),\
-			    stm32_i2c_event_isr,			\
+			    i2c_stm32_event_isr,			\
 			    DEVICE_DT_INST_GET(index), 0);		\
 		irq_enable(DT_INST_IRQ_BY_NAME(index, event, irq));	\
 									\
 		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(index, error, irq),	\
 			    DT_INST_IRQ_BY_NAME(index, error, priority),\
-			    stm32_i2c_error_isr,			\
+			    i2c_stm32_error_isr,			\
 			    DEVICE_DT_INST_GET(index), 0);		\
 		irq_enable(DT_INST_IRQ_BY_NAME(index, error, irq));	\
 	} while (false)

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -62,6 +62,10 @@ struct i2c_stm32_data {
 	uint32_t msg_buf_pos;
 	struct i2c_msg *msgs;
 	uint32_t num_msgs;
+#ifdef CONFIG_I2C_CALLBACK
+	i2c_callback_t cb;
+	void *userdata;
+#endif
 	struct {
 #ifdef CONFIG_I2C_STM32_V1
 		unsigned int is_restart;
@@ -82,6 +86,7 @@ struct i2c_stm32_data {
 #endif
 };
 
+int stm32_i2c_check_error(struct i2c_stm32_data *data, bool is_timeout);
 int32_t stm32_i2c_transfer_next(const struct device *dev);
 int32_t stm32_i2c_configure_timing(const struct device *dev, uint32_t clk);
 int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config);

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -60,15 +60,12 @@ struct i2c_stm32_data {
 	struct {
 #ifdef CONFIG_I2C_STM32_V1
 		unsigned int is_restart;
-		unsigned int flags;
 #endif
 		unsigned int is_write;
 		unsigned int is_arlo;
 		unsigned int is_nack;
 		unsigned int is_err;
-		struct i2c_msg *msg;
-		unsigned int len;
-		uint8_t *buf;
+		struct i2c_msg msg;
 	} current;
 #ifdef CONFIG_I2C_TARGET
 	bool master_active;

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -57,6 +57,11 @@ struct i2c_stm32_data {
 #ifdef CONFIG_I2C_STM32_V1
 	uint16_t slave_address;
 #endif
+	uint16_t addr;
+	uint32_t msg;
+	uint32_t msg_buf_pos;
+	struct i2c_msg *msgs;
+	uint32_t num_msgs;
 	struct {
 #ifdef CONFIG_I2C_STM32_V1
 		unsigned int is_restart;
@@ -77,9 +82,7 @@ struct i2c_stm32_data {
 #endif
 };
 
-int32_t stm32_i2c_transaction(const struct device *dev,
-			    struct i2c_msg msg, uint8_t *next_msg_flags,
-			    uint16_t periph);
+int32_t stm32_i2c_transfer_next(const struct device *dev);
 int32_t stm32_i2c_configure_timing(const struct device *dev, uint32_t clk);
 int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config);
 

--- a/drivers/i2c/i2c_ll_stm32_v1.c
+++ b/drivers/i2c/i2c_ll_stm32_v1.c
@@ -152,15 +152,12 @@ static inline void msg_init(const struct device *dev, struct i2c_msg *msg,
 	k_sem_reset(&data->device_sync_sem);
 #endif
 
-	data->current.len = msg->len;
-	data->current.buf = msg->buf;
-	data->current.flags = msg->flags;
 	data->current.is_restart = 0U;
 	data->current.is_write = (transfer == I2C_REQUEST_WRITE);
 	data->current.is_arlo = 0U;
 	data->current.is_err = 0U;
 	data->current.is_nack = 0U;
-	data->current.msg = msg;
+	data->current.msg = *msg;
 #if defined(CONFIG_I2C_TARGET)
 	data->master_active = true;
 #endif
@@ -250,7 +247,7 @@ static inline void handle_sb(const struct device *dev)
 		LL_I2C_TransmitData8(i2c, slave | I2C_REQUEST_WRITE);
 	} else {
 		LL_I2C_TransmitData8(i2c, slave | I2C_REQUEST_READ);
-		if (data->current.len == 2) {
+		if (data->current.msg.len == 2) {
 			LL_I2C_EnableBitPOS(i2c);
 		}
 	}
@@ -280,16 +277,16 @@ static inline void handle_addr(const struct device *dev)
 	 * specific way.
 	 * Please ref to STM32F10xxC/D/E I2C peripheral Errata sheet 2.14.1
 	 */
-	if (data->current.len == 0U && IS_ENABLED(CONFIG_SOC_SERIES_STM32F1X)) {
+	if (data->current.msg.len == 0U && IS_ENABLED(CONFIG_SOC_SERIES_STM32F1X)) {
 		LL_I2C_GenerateStopCondition(i2c);
-	} else if (data->current.len == 1U) {
+	} else if (data->current.msg.len == 1U) {
 		/* Single byte reception: enable NACK and clear POS */
 		LL_I2C_AcknowledgeNextData(i2c, LL_I2C_NACK);
 #ifdef CONFIG_SOC_SERIES_STM32F1X
 		LL_I2C_ClearFlag_ADDR(i2c);
 		LL_I2C_GenerateStopCondition(i2c);
 #endif
-	} else if (data->current.len == 2U) {
+	} else if (data->current.msg.len == 2U) {
 #ifdef CONFIG_SOC_SERIES_STM32F1X
 		LL_I2C_ClearFlag_ADDR(i2c);
 #endif
@@ -306,19 +303,19 @@ static inline void handle_txe(const struct device *dev)
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
-	if (data->current.len) {
-		data->current.len--;
-		if (data->current.len == 0U) {
+	if (data->current.msg.len) {
+		data->current.msg.len--;
+		if (data->current.msg.len == 0U) {
 			/*
 			 * This is the last byte to transmit disable Buffer
 			 * interrupt and wait for a BTF interrupt
 			 */
 			LL_I2C_DisableIT_BUF(i2c);
 		}
-		LL_I2C_TransmitData8(i2c, *data->current.buf);
-		data->current.buf++;
+		LL_I2C_TransmitData8(i2c, *data->current.msg.buf);
+		data->current.msg.buf++;
 	} else {
-		if (data->current.flags & I2C_MSG_STOP) {
+		if (data->current.msg.flags & I2C_MSG_STOP) {
 			LL_I2C_GenerateStopCondition(i2c);
 		}
 		if (LL_I2C_IsActiveFlag_BTF(i2c)) {
@@ -336,19 +333,19 @@ static inline void handle_rxne(const struct device *dev)
 	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 
-	if (data->current.len > 0) {
-		switch (data->current.len) {
+	if (data->current.msg.len > 0) {
+		switch (data->current.msg.len) {
 		case 1:
 			LL_I2C_AcknowledgeNextData(i2c, LL_I2C_NACK);
 			LL_I2C_DisableBitPOS(i2c);
 			/* Single byte reception */
-			if (data->current.flags & I2C_MSG_STOP) {
+			if (data->current.msg.flags & I2C_MSG_STOP) {
 				LL_I2C_GenerateStopCondition(i2c);
 			}
 			LL_I2C_DisableIT_BUF(i2c);
-			data->current.len--;
-			*data->current.buf = LL_I2C_ReceiveData8(i2c);
-			data->current.buf++;
+			data->current.msg.len--;
+			*data->current.msg.buf = LL_I2C_ReceiveData8(i2c);
+			data->current.msg.buf++;
 
 			k_sem_give(&data->device_sync_sem);
 			break;
@@ -365,13 +362,13 @@ static inline void handle_rxne(const struct device *dev)
 			break;
 		default:
 			/* N byte reception when N > 3 */
-			data->current.len--;
-			*data->current.buf = LL_I2C_ReceiveData8(i2c);
-			data->current.buf++;
+			data->current.msg.len--;
+			*data->current.msg.buf = LL_I2C_ReceiveData8(i2c);
+			data->current.msg.buf++;
 		}
 	} else {
 
-		if (data->current.flags & I2C_MSG_STOP) {
+		if (data->current.msg.flags & I2C_MSG_STOP) {
 			LL_I2C_GenerateStopCondition(i2c);
 		}
 		k_sem_give(&data->device_sync_sem);
@@ -389,29 +386,29 @@ static inline void handle_btf(const struct device *dev)
 	} else {
 		uint32_t counter = 0U;
 
-		switch (data->current.len) {
+		switch (data->current.msg.len) {
 		case 2:
 			/*
 			 * Stop condition must be generated before reading the
 			 * last two bytes.
 			 */
-			if (data->current.flags & I2C_MSG_STOP) {
+			if (data->current.msg.flags & I2C_MSG_STOP) {
 				LL_I2C_GenerateStopCondition(i2c);
 			}
 
 			for (counter = 2U; counter > 0; counter--) {
-				data->current.len--;
-				*data->current.buf = LL_I2C_ReceiveData8(i2c);
-				data->current.buf++;
+				data->current.msg.len--;
+				*data->current.msg.buf = LL_I2C_ReceiveData8(i2c);
+				data->current.msg.buf++;
 			}
 			k_sem_give(&data->device_sync_sem);
 			break;
 		case 3:
 			/* Set NACK before reading N-2 byte*/
 			LL_I2C_AcknowledgeNextData(i2c, LL_I2C_NACK);
-			data->current.len--;
-			*data->current.buf = LL_I2C_ReceiveData8(i2c);
-			data->current.buf++;
+			data->current.msg.len--;
+			*data->current.msg.buf = LL_I2C_ReceiveData8(i2c);
+			data->current.msg.buf++;
 			break;
 		default:
 			handle_rxne(dev);

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -479,6 +479,13 @@ static int stm32_i2c_msg_write(const struct device *dev, struct i2c_msg *msg,
 	stm32_i2c_enable_transfer_interrupts(dev);
 	LL_I2C_EnableIT_TX(i2c);
 
+	/* For async, return immediately without blocking */
+#ifdef CONFIG_I2C_CALLBACK
+	if (data->cb != NULL) {
+		return 0;
+	}
+#endif
+
 	if (k_sem_take(&data->device_sync_sem,
 			K_MSEC(STM32_I2C_TRANSFER_TIMEOUT_MSEC)) != 0) {
 		stm32_i2c_master_mode_end(dev);
@@ -507,6 +514,13 @@ static int stm32_i2c_msg_read(const struct device *dev, struct i2c_msg *msg,
 
 	stm32_i2c_enable_transfer_interrupts(dev);
 	LL_I2C_EnableIT_RX(i2c);
+
+	/* For async, return immediately without blocking */
+#ifdef CONFIG_I2C_CALLBACK
+	if (data->cb != NULL) {
+		return 0;
+	}
+#endif
 
 	if (k_sem_take(&data->device_sync_sem,
 			K_MSEC(STM32_I2C_TRANSFER_TIMEOUT_MSEC)) != 0) {

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -713,51 +713,73 @@ int stm32_i2c_configure_timing(const struct device *dev, uint32_t clock)
 	return 0;
 }
 
-int stm32_i2c_transaction(const struct device *dev,
-						  struct i2c_msg msg, uint8_t *next_msg_flags,
-						  uint16_t periph)
+static int stm32_i2c_transfer_message_chunk(const struct device *dev)
 {
 	/*
-	 * Perform a I2C transaction, while taking into account the STM32 I2C V2
-	 * peripheral has a limited maximum chunk size. Take appropriate action
-	 * if the message to send exceeds that limit.
+	 * Transfer a chunk of an I2C message. The chunk may be a whole message
+	 or part of a message divided to the limited maximum chunk size.
 	 *
-	 * The last chunk of a transmission uses this function's next_msg_flags
-	 * parameter for its backend calls (_write/_read). Any previous chunks
-	 * use a copy of the current message's flags, with the STOP and RESTART
-	 * bits turned off. This will cause the backend to use reload-mode,
-	 * which will make the combination of all chunks to look like one big
-	 * transaction on the wire.
+	 * The last chunk of a transmission uses next_msg_flags for its backend
+	 * calls (_write/_read). Any previous chunks use a copy of the current
+	 * message's flags, with the STOP and RESTART bits turned off. This will
+	 * cause the backend to use reload-mode, which will make the combination
+	 * of all chunks to look like one big transaction on the wire.
 	 */
+	struct i2c_stm32_data *data = dev->data;
+
+	uint8_t *next_msg_flags = NULL;
+
+	if (data->msg < data->num_msgs - 1) {
+		next_msg_flags = &(data->msgs[data->msg + 1].flags);
+	}
+
+	struct i2c_msg msg = data->msgs[data->msg];
 	const uint32_t i2c_stm32_maxchunk = 255U;
 	const uint8_t saved_flags = msg.flags;
 	uint8_t combine_flags =
 		saved_flags & ~(I2C_MSG_STOP | I2C_MSG_RESTART);
 	uint8_t *flagsp = NULL;
-	uint32_t rest = msg.len;
 	int ret = 0;
 
-	do { /* do ... while to allow zero-length transactions */
-		if (msg.len > i2c_stm32_maxchunk) {
-			msg.len = i2c_stm32_maxchunk;
-			msg.flags &= ~I2C_MSG_STOP;
-			flagsp = &combine_flags;
-		} else {
-			msg.flags = saved_flags;
-			flagsp = next_msg_flags;
-		}
-		if ((msg.flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
-			ret = stm32_i2c_msg_write(dev, &msg, flagsp, periph);
-		} else {
-			ret = stm32_i2c_msg_read(dev, &msg, flagsp, periph);
-		}
-		if (ret < 0) {
-			break;
-		}
-		rest -= msg.len;
-		msg.buf += msg.len;
-		msg.len = rest;
-	} while (rest > 0U);
+	if ((msg.len - data->msg_buf_pos) > i2c_stm32_maxchunk) {
+		msg.len = i2c_stm32_maxchunk;
+		msg.flags &= ~I2C_MSG_STOP;
+		flagsp = &combine_flags;
+	} else {
+		msg.len -= data->msg_buf_pos;
+		flagsp = next_msg_flags;
+	}
+	msg.buf += data->msg_buf_pos;
+	data->msg_buf_pos += msg.len;
+	if ((msg.flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
+		ret = stm32_i2c_msg_write(dev, &msg, flagsp, data->addr);
+	} else {
+		ret = stm32_i2c_msg_read(dev, &msg, flagsp, data->addr);
+	}
+	return ret;
+}
+
+int stm32_i2c_transfer_next(const struct device *dev)
+{
+	/* Transfer the next unit of data in a transfer consisting of possibly
+	 * multiple messages, while taking into account the STM32 I2C peripheral
+	 * has a limited maximum chunk size. Take appropriate action if the message
+	 * to send exceeds that limit.
+	 */
+	struct i2c_stm32_data *data = dev->data;
+
+	int ret = 0;
+	/* More data in current message - transfer next chunk */
+	if (data->msg_buf_pos < data->msgs[data->msg].len) {
+		ret = stm32_i2c_transfer_message_chunk(dev);
+	/* Current message done but more messages - transfer next message */
+	} else if (data->msg < data->num_msgs - 1) {
+		data->msg++;
+		data->msg_buf_pos = 0;
+		ret = stm32_i2c_transfer_message_chunk(dev);
+	} else {
+		ret = 1;
+	}
 
 	return ret;
 }


### PR DESCRIPTION
This PR implements an asynchronous I2C driver for the STM32 I2C V2 peripheral, including some cleanup and refactoring to share common logic between synchronous and asynchronous implementations.

The STM32 V1 driver should also be able to implement asynchronous transfers in a similar way but I don't have a device with the V1 peripheral to test with. Perhaps after this PR somebody can add V1 support more easily.

The asynchronous implementation supports the `i2c_transfer_cb` API.

PR is currently draft - most of the work was done a little while ago and has been rebased onto upstream changes, so I need to retest. Opening as draft in case anybody wants to give feedback at this stage.