### PR TITLE
Bluetooth: OTS: Fix memory leak while read/write not finished.

### DIFF
--- a/include/zephyr/bluetooth/services/ots.h
+++ b/include/zephyr/bluetooth/services/ots.h
@@ -937,6 +937,17 @@ struct bt_ots_client_cb {
  */
 int bt_ots_client_register(struct bt_ots_client *ots_inst);
 
+/** @brief Unregister an Object Transfer Service Instance.
+ *
+ *  Unregister an Object Transfer Service instance when disconnect from the peer.
+ *  Call this function when an ACL using OTS instance is disconnected.
+ *
+ *  @param[in]  index	      Index of OTS instance.
+ *
+ *  @return int               0 if success, ERRNO on failure.
+ */
+int bt_ots_client_unregister(uint8_t index);
+
 /** @brief OTS Indicate Handler function.
  *
  *  Set this function as callback for indicate handler when discovering OTS.

--- a/subsys/bluetooth/services/ots/ots_client.c
+++ b/subsys/bluetooth/services/ots/ots_client.c
@@ -230,6 +230,9 @@ static void chan_closed(struct bt_gatt_ots_l2cap *l2cap_ctx,
 			struct bt_conn *conn)
 {
 	LOG_DBG("L2CAP closed, context: %p, conn: %p", l2cap_ctx, (void *)conn);
+	if (cur_inst) {
+		cur_inst = NULL;
+	}
 }
 /* End L2CAP callbacks */
 


### PR DESCRIPTION
    cur_inst is the copy of ots_client instance to prevent duplicate
    call while a read/write procedure is not finished.
    But cur_inst can only be cleared while write_obj_tx_done or read rx_done.
    If ACL is disconnected while read/write is on-going, there is no chance
    for cur_inst being cleared.
    This causes ots client will no longer perform read/write procedure anymore.
    API will always return -EBUSY.

    Let bt_ots_client_unregister assign cur_inst to NULL explicitly.

    Make bt_ots_client_unregister public API.