### PR TITLE
drivers: spi: align dspi and lpspi spi_mcux_transfer_next_packet

### DIFF
--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -195,11 +195,11 @@ static int spi_mcux_transfer_next_packet(const struct device *dev)
 
 	status = DSPI_MasterTransferNonBlocking(base, &data->handle, &transfer);
 	if (status != kStatus_Success) {
-		LOG_ERR("Transfer could not start");
+		LOG_ERR("Transfer could not start on %s: %d", dev->name, status);
+		return status == kDSPI_Busy ? -EBUSY : -EINVAL;
 	}
 
-	return status == kStatus_Success ? 0 :
-	       status == kDSPI_Busy ? -EBUSY : -EINVAL;
+	return 0;
 }
 
 static void spi_mcux_isr(const struct device *dev)

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -67,7 +67,7 @@ struct spi_mcux_data {
 #endif
 };
 
-static void spi_mcux_transfer_next_packet(const struct device *dev)
+static int spi_mcux_transfer_next_packet(const struct device *dev)
 {
 	const struct spi_mcux_config *config = dev->config;
 	struct spi_mcux_data *data = dev->data;
@@ -80,7 +80,7 @@ static void spi_mcux_transfer_next_packet(const struct device *dev)
 		/* nothing left to rx or tx, we're done! */
 		spi_context_cs_control(&data->ctx, false);
 		spi_context_complete(&data->ctx, dev, 0);
-		return;
+		return 0;
 	}
 
 	transfer.configFlags = kLPSPI_MasterPcsContinuous |
@@ -130,8 +130,11 @@ static void spi_mcux_transfer_next_packet(const struct device *dev)
 	status = LPSPI_MasterTransferNonBlocking(base, &data->handle,
 						 &transfer);
 	if (status != kStatus_Success) {
-		LOG_ERR("Transfer could not start");
+		LOG_ERR("Transfer could not start on %s: %d", dev->name, status);
+		return status == kStatus_LPSPI_Busy ? -EBUSY : -EINVAL;
 	}
+
+	return 0;
 }
 
 static void spi_mcux_isr(const struct device *dev)
@@ -496,7 +499,10 @@ static int transceive(const struct device *dev,
 
 	spi_context_cs_control(&data->ctx, true);
 
-	spi_mcux_transfer_next_packet(dev);
+	ret = spi_mcux_transfer_next_packet(dev);
+	if (ret) {
+		goto out;
+	}
 
 	ret = spi_context_wait_for_completion(&data->ctx);
 out:


### PR DESCRIPTION
Add return code to lpspi spi_mcux_transfer_next_packet and print the kStatus_* return code since it information is lost when translated to errno.