### PR TITLE
soc: arm: ti_simplelink: cc13x2_cc26x2: compile power.c if PM_DEVICE=y

### DIFF
--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/CMakeLists.txt
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/CMakeLists.txt
@@ -5,7 +5,7 @@
 zephyr_sources(soc.c)
 zephyr_sources(ccfg.c)
 
-if(CONFIG_PM OR CONFIG_POWEROFF)
+if(CONFIG_PM OR CONFIG_PM_DEVICE OR CONFIG_POWEROFF)
   zephyr_library_sources(power.c)
 endif()
 zephyr_library_sources_ifdef(CONFIG_POWEROFF poweroff.c)


### PR DESCRIPTION
power.c contains some struct definitions required by the HAL when using PM_DEVICE.