### PR TITLE
usb: device: hid: remove CONFIG_USB_HID_PROTOCOL_CODE

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -263,6 +263,9 @@ Networking
 USB
 ***
 
+* USB device HID
+  * Kconfig option USB_HID_PROTOCOL_CODE, deprecated in v2.6, is finally removed.
+
 Devicetree
 **********
 

--- a/subsys/usb/device/class/hid/Kconfig
+++ b/subsys/usb/device/class/hid/Kconfig
@@ -65,13 +65,4 @@ config USB_HID_BOOT_PROTOCOL
 	  See Chapter 4.2 of Device Class Definition for Human Interface Devices 1.11
 	  for more information.
 
-config USB_HID_PROTOCOL_CODE
-	int "HID Boot Interface protocol code (DEPRECATED)"
-	default 0
-	range 0 2
-	depends on USB_HID_BOOT_PROTOCOL
-	help
-	  This option is deprecated.
-	  Please use usb_hid_set_proto_code() instead.
-
 endif # USB_DEVICE_HID

--- a/subsys/usb/device/class/hid/core.c
+++ b/subsys/usb/device/class/hid/core.c
@@ -59,7 +59,7 @@ struct usb_hid_config {
 		.bNumEndpoints = 1,					\
 		.bInterfaceClass = USB_BCC_HID,				\
 		.bInterfaceSubClass = 1,				\
-		.bInterfaceProtocol = CONFIG_USB_HID_PROTOCOL_CODE,	\
+		.bInterfaceProtocol = 0,				\
 		.iInterface = 0,					\
 	}
 #else


### PR DESCRIPTION
Kconfig option USB_HID_PROTOCOL_CODE, deprecated in v2.6, is finally removed.