### PR TITLE
tests: drivers: Improve build_all/sensors test

### DIFF
--- a/tests/drivers/build_all/sensor/adc.dtsi
+++ b/tests/drivers/build_all/sensor/adc.dtsi
@@ -34,7 +34,7 @@ test_current: current_amp {
 	sense-gain-div = <1>;
 };
 
-test_adc_emul: adc {
+test_adc_emul: adc-emul {
 	compatible = "zephyr,adc-emul";
 	nchannels = <2>;
 	ref-internal-mv = <3300>;
@@ -43,7 +43,7 @@ test_adc_emul: adc {
 	status = "okay";
 };
 
-test_ntc_thermistor_generic: ntc-thermistor-generic {
+test_adc_ntc_thermistor_generic: ntc-thermistor-generic {
 	compatible = "ntc-thermistor-generic";
 	io-channels = <&adc0 0>;
 	pullup-uv = <3300000>;
@@ -53,7 +53,7 @@ test_ntc_thermistor_generic: ntc-thermistor-generic {
 	zephyr,compensation-table = <0 0>, <1 1>;
 };
 
-test_epcos_b57861s0103a039: epcos-b57861s0103a039 {
+test_adc_epcos_b57861s0103a039: epcos-b57861s0103a039 {
 	compatible = "epcos,b57861s0103a039";
 	io-channels = <&adc0 0>;
 	pullup-uv = <3300000>;

--- a/tests/drivers/build_all/sensor/app.overlay
+++ b/tests/drivers/build_all/sensor/app.overlay
@@ -141,13 +141,6 @@
 
 			#include "w1.dtsi"
 		};
-
-		dht22 {
-			compatible = "aosong,dht";
-			status = "okay";
-			dio-gpios = <&test_gpio 0 0>;
-			/* dht22; */
-		};
 	};
 };
 

--- a/tests/drivers/build_all/sensor/gpio.dtsi
+++ b/tests/drivers/build_all/sensor/gpio.dtsi
@@ -10,3 +10,10 @@ test_gpio_sm351lt: sm351lt0 {
 	compatible = "honeywell,sm351lt";
 	gpios = <&test_gpio 0 0>;
 };
+
+test_gpio_dht22: dht22 {
+	compatible = "aosong,dht";
+	status = "okay";
+	dio-gpios = <&test_gpio 0 0>;
+	/* dht22; */
+};

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -709,7 +709,7 @@ test_i2c_tcs3400: tcs3400@6b {
 	int-gpios = <&test_gpio 0 0>;
 };
 
-test_tcn75a: tcn75a@6c {
+test_i2c_tcn75a: tcn75a@6c {
 	compatible = "microchip,tcn75a";
 	reg = <0x6c>;
 	alert-gpios = <&test_gpio 0 0>;
@@ -737,7 +737,7 @@ test_i2c_bmi08x_gyro: bmi08x@6e {
 	gyro-fs = <1000>;
 };
 
-test_i2c_ist8310@6f {
+test_i2c_ist8310: ist8310@6f {
 	compatible = "isentek,ist8310";
 	reg = <0x6f>;
 	status = "okay";

--- a/tests/drivers/build_all/sensor/uart.dtsi
+++ b/tests/drivers/build_all/sensor/uart.dtsi
@@ -7,26 +7,26 @@
  * Application overlay for uart devices
  */
 
-test_uart_mhz19b {
+test_uart_mhz19b: mhz19b {
 	compatible = "winsen,mhz19b";
 	maximum-range = <10000>;
 	abc-on;
 };
 
-test_uart_pms7003 {
+test_uart_pms7003: pms7003 {
 	compatible = "plantower,pms7003";
 };
 
-test_uart_grow_r502a {
+grow_r502a {
 	#address-cells=<1>;
 	#size-cells=<0>;
-	grow_r502a@0 {
+	test_uart_grow_r502a: grow_r502a@0 {
 		compatible = "hzgrow,r502a";
 		reg = <0x0>;
 		int-gpios = <&test_gpio 0 0>;
 	};
 };
 
-test_uart_a01nyub {
+test_uart_a01nyub: a01nyub {
 	compatible = "dfrobot,a01nyub";
 };

--- a/tests/drivers/build_all/sensor/w1.dtsi
+++ b/tests/drivers/build_all/sensor/w1.dtsi
@@ -6,7 +6,7 @@
  * Application overlay for w1 devices
  */
 
-test-w1-ds18b20 {
+test_w1_ds18b20: ds18b20 {
 	compatible = "maxim,ds18b20";
 	family-code = <0x28>;
 	resolution = <12>;


### PR DESCRIPTION
Two simple clenups:

1. Move DHT22 sensor to the file which holds GPIO sensors. (It should have more sense than including it in the main `app.overlay`.)
2. Unify labels of all sensors used in the `build_all/sensor` test to follow the same naming scheme.