### PR TITLE
tests: canbus: isotp: implementation: enable for native_posix

### DIFF
--- a/tests/subsys/canbus/isotp/implementation/testcase.yaml
+++ b/tests/subsys/canbus/isotp/implementation/testcase.yaml
@@ -5,6 +5,3 @@ tests:
       - isotp
     depends_on: can
     filter: dt_chosen_enabled("zephyr,canbus") and not dt_compat_enabled("kvaser,pcican")
-    platform_exclude:
-      - native_posix
-      - native_posix_64


### PR DESCRIPTION
The ISO-TP tests were disabled for native_posix in the past because of timing issues.

The implementation test is working well with native_posix now and should also be run in CI.