### PR TITLE
soc: esp32c3: systimer: set clock time using rtc timestamp

### DIFF
--- a/soc/riscv/espressif_esp32/esp32c3/default.ld
+++ b/soc/riscv/espressif_esp32/esp32c3/default.ld
@@ -464,6 +464,7 @@ SECTIONS
   {
     _rtc_data_start = ABSOLUTE(.);
     *(.rtc.data)
+    *(.rtc.data.*)
     *(.rtc.rodata)
     *rtc_wake_stub*.o(.data .rodata .data.* .rodata.* .bss .bss.*)
     _rtc_data_end = ABSOLUTE(.);


### PR DESCRIPTION
During deep-sleep, RTC timer keeps counting, allowing SoC to keep track of time after reset.

This sets clock time during systimer init.

This is just a draft. We got to bring RTC to whole system and also support for all SoCs.

#61811