### PR TITLE
canbus: isotp: use flags for configuration in isotp_msg_id

### DIFF
--- a/include/zephyr/canbus/isotp.h
+++ b/include/zephyr/canbus/isotp.h
@@ -129,6 +129,27 @@ extern "C" {
 #endif
 
 /**
+ * @name ISO-TP message ID flags
+ * @anchor ISOTP_MSG_FLAGS
+ *
+ * @{
+ */
+
+/** Message uses ISO-TP extended addressing (first payload byte of CAN frame) */
+#define ISOTP_MSG_EXT_ADDR BIT(0)
+
+/**
+ * Message uses ISO-TP fixed addressing (according to SAE J1939). Only valid in combination with
+ * ``ISOTP_MSG_IDE``.
+ */
+#define ISOTP_MSG_FIXED_ADDR BIT(1)
+
+/** Message uses extended (29-bit) CAN ID */
+#define ISOTP_MSG_IDE BIT(2)
+
+/** @} */
+
+/**
  * @brief ISO-TP message id struct
  *
  * Used to pass addresses to the bind and send functions.
@@ -146,12 +167,8 @@ struct isotp_msg_id {
 	};
 	/** ISO-TP extended address (if used) */
 	uint8_t ext_addr;
-	/** Indicates the CAN identifier type (0 for standard or 1 for extended) */
-	uint8_t ide : 1;
-	/** Indicates if ISO-TP extended addressing is used */
-	uint8_t use_ext_addr : 1;
-	/** Indicates if ISO-TP fixed addressing (acc. to SAE J1939) is used */
-	uint8_t use_fixed_addr : 1;
+	/** Flags. @see @ref ISOTP_MSG_FLAGS. */
+	uint8_t flags;
 };
 
 /*

--- a/samples/subsys/canbus/isotp/src/main.c
+++ b/samples/subsys/canbus/isotp/src/main.c
@@ -12,23 +12,15 @@ const struct isotp_fc_opts fc_opts_0_5 = {.bs = 0, .stmin = 5};
 
 const struct isotp_msg_id rx_addr_8_0 = {
 	.std_id = 0x80,
-	.ide = 0,
-	.use_ext_addr = 0
 };
 const struct isotp_msg_id tx_addr_8_0 = {
 	.std_id = 0x180,
-	.ide = 0,
-	.use_ext_addr = 0
 };
 const struct isotp_msg_id rx_addr_0_5 = {
 	.std_id = 0x01,
-	.ide = 0,
-	.use_ext_addr = 0
 };
 const struct isotp_msg_id tx_addr_0_5 = {
 	.std_id = 0x101,
-	.ide = 0,
-	.use_ext_addr = 0
 };
 
 const struct device *can_dev;

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -72,43 +72,34 @@ const struct isotp_fc_opts fc_opts_single = {
 	.bs = 0,
 	.stmin = 0
 };
+
 const struct isotp_msg_id rx_addr = {
 	.std_id = 0x10,
-	.ide = 0,
-	.use_ext_addr = 0
 };
 const struct isotp_msg_id tx_addr = {
 	.std_id = 0x11,
-	.ide = 0,
-	.use_ext_addr = 0
 };
 
 const struct isotp_msg_id rx_addr_ext = {
 	.std_id = 0x10,
-	.ide = 0,
-	.use_ext_addr = 1,
-	.ext_addr = EXT_ADDR
+	.ext_addr = EXT_ADDR,
+	.flags = ISOTP_MSG_EXT_ADDR,
 };
 
 const struct isotp_msg_id tx_addr_ext = {
 	.std_id = 0x11,
-	.ide = 0,
-	.use_ext_addr = 1,
-	.ext_addr = EXT_ADDR
+	.ext_addr = EXT_ADDR,
+	.flags = ISOTP_MSG_EXT_ADDR,
 };
 
 const struct isotp_msg_id rx_addr_fixed = {
 	.ext_id = 0x18DA0201,
-	.ide = 1,
-	.use_ext_addr = 0,
-	.use_fixed_addr = 1
+	.flags = ISOTP_MSG_FIXED_ADDR | ISOTP_MSG_IDE,
 };
 
 const struct isotp_msg_id tx_addr_fixed = {
 	.ext_id = 0x18DA0102,
-	.ide = 1,
-	.use_ext_addr = 0,
-	.use_fixed_addr = 1
+	.flags = ISOTP_MSG_FIXED_ADDR | ISOTP_MSG_IDE,
 };
 
 const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));

--- a/tests/subsys/canbus/isotp/implementation/src/main.c
+++ b/tests/subsys/canbus/isotp/implementation/src/main.c
@@ -35,15 +35,12 @@ const struct isotp_fc_opts fc_opts_single = {
 	.bs = 0,
 	.stmin = 1
 };
+
 const struct isotp_msg_id rx_addr = {
 	.std_id = 0x10,
-	.ide = 0,
-	.use_ext_addr = 0
 };
 const struct isotp_msg_id tx_addr = {
 	.std_id = 0x11,
-	.ide = 0,
-	.use_ext_addr = 0
 };
 
 struct isotp_recv_ctx recv_ctx;


### PR DESCRIPTION
The previous design with dedicated bits in the structure required a user to explicitly set each bit.

Using one flags variable allows to extend the features more easily in the future and avoids breaking existing code.

This change is particularly useful for the FDF and BRS flags required for CAN-FD support.

See also previous similar change for the CAN driver in f8a88cdb2791fe40b3021f1275fe250c2c17dcf3