### PR TITLE
twister: handle quotes for all args

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -978,9 +978,15 @@ class ProjectBuilder(FilterBuilder):
         sys.stdout.flush()
 
     @staticmethod
-    def cmake_assemble_args(args, handler, extra_conf_files, extra_overlay_confs,
+    def cmake_assemble_args(extra_args, handler, extra_conf_files, extra_overlay_confs,
                             extra_dtc_overlay_files, cmake_extra_args,
                             build_dir):
+        # Retain quotes around config options
+        config_options = [arg for arg in extra_args if arg.startswith("CONFIG_")]
+        args = [arg for arg in extra_args if not arg.startswith("CONFIG_")]
+
+        args_expanded = ["-D{}".format(a.replace('"', '\"')) for a in config_options]
+
         if handler.ready:
             args.extend(handler.args)
 
@@ -1003,7 +1009,7 @@ class ProjectBuilder(FilterBuilder):
             args.append("OVERLAY_CONFIG=\"%s\"" % (" ".join(overlays)))
 
         # Build the final argument list
-        args_expanded = ["-D{}".format(a.replace('"', '\"')) for a in cmake_extra_args]
+        args_expanded.extend(["-D{}".format(a.replace('"', '\"')) for a in cmake_extra_args])
         args_expanded.extend(["-D{}".format(a.replace('"', '')) for a in args])
 
         return args_expanded

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -90,7 +90,7 @@ def test_projectbuilder_cmake_assemble_args(m):
     handler.ready = True
 
     assert(ProjectBuilder.cmake_assemble_args(
-        ["basearg1"],
+        ["basearg1", "CONFIG_t=\"test\"", "SNIPPET_t=\"test\""],
         handler,
         ["a.conf;b.conf", "c.conf"],
         ["extra_overlay.conf"],
@@ -98,8 +98,9 @@ def test_projectbuilder_cmake_assemble_args(m):
         ["cmake1=foo", "cmake2=bar"],
         "/builddir/",
     ) == [
+        "-DCONFIG_t=\"test\"",
         "-Dcmake1=foo", "-Dcmake2=bar",
-        "-Dbasearg1",
+        "-Dbasearg1", "-DSNIPPET_t=test",
         "-Dhandler_arg1", "-Dhandler_arg2",
         "-DCONF_FILE=a.conf;b.conf;c.conf",
         "-DDTC_OVERLAY_FILE=x.overlay;y.overlay;z.overlay",

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -317,7 +317,11 @@ class Build(Forceable):
                     if data == 'extra_configs':
                         args = ["-D{}".format(arg.replace('"', '\"')) for arg in arg_list]
                     elif data == 'extra_args':
-                        args = ["-D{}".format(arg.replace('"', '')) for arg in arg_list]
+                        # Retain quotes around config options
+                        config_options = [arg for arg in arg_list if arg.startswith("CONFIG_")]
+                        non_config_options = [arg for arg in arg_list if not arg.startswith("CONFIG_")]
+                        args = ["-D{}".format(a.replace('"', '\"')) for a in config_options]
+                        args.extend(["-D{}".format(arg.replace('"', '')) for arg in non_config_options])
                     elif data == 'extra_conf_files':
                         extra_conf_files.extend(arg_list)
                         continue


### PR DESCRIPTION
Instead of only cmake arguments, add support handling quotes for all args by escaping them properly instead of removing the quotes altogether.