### PR TITLE
modules: openthread: fix unused variable during `otPlatCryptoInit`

### DIFF
--- a/modules/openthread/platform/crypto_psa.c
+++ b/modules/openthread/platform/crypto_psa.c
@@ -137,9 +137,8 @@ void otPlatCryptoInit(void)
 	 * PSA with emulated TFM, Settings have to be initialized at the end of otPlatCryptoInit(),
 	 * to be available before storing Network Key.
 	 */
-	int err = settings_subsys_init();
-
-	__ASSERT(!err, "Failed to initialize settings");
+	__ASSERT_EVAL((void) settings_subsys_init(), int err = settings_subsys_init(),
+		      !err, "Failed to initialize settings");
 #endif
 }
 


### PR DESCRIPTION
If asserts are disabled, there is a warning in 'otPlatCryptoInit' regarding unused variable `err`. This commit fixes that.