### PR TITLE
dts/arm/st: add SoC compatible string to stm32wba and stm32mb SoCs

### DIFF
--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -39,6 +39,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32mp157", "st,stm32mp1", "simple-bus";
+
 		rcc: rcc@50000000 {
 			compatible = "st,stm32mp1-rcc";
 			reg = <0x50000000 0x1000>;

--- a/dts/arm/st/wba/stm32wba52Xg.dtsi
+++ b/dts/arm/st/wba/stm32wba52Xg.dtsi
@@ -12,6 +12,8 @@
 	};
 
 	soc {
+		compatible = "st,stm32wba52", "st,stm32wba", "simple-bus";
+
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
 				reg = <0x08000000 DT_SIZE_M(1)>;


### PR DESCRIPTION
While most of the ST family SoCs have the compatible string set, several targets still miss it.