### PR TITLE
doc: release: Migration guide of CONFIG_NET_INTERFACE_NAME option

### DIFF
--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -47,6 +47,16 @@ Required changes
      - "IO"          -> <( DT_MEM_ARM(ATTR_MPU_IO) )>
      - "EXTMEM"      -> <( DT_MEM_ARM(ATTR_MPU_EXTMEM) )>
 
+* A new networking Kconfig option :kconfig:option:`CONFIG_NET_INTERFACE_NAME`
+  defaults to ``y``. The option allows user to set a name to a network interface.
+  During system startup a default name is assigned to the network interface like
+  ``eth0`` to the first Ethernet network interface. The option affects the behavior
+  of ``SO_BINDTODEVICE`` BSD socket option. If the Kconfig option is set to ``n``,
+  which is how the system worked earlier, then the name of the device assigned
+  to the network interface is used by the ``SO_BINDTODEVICE`` socket option.
+  If the Kconfig option is set to ``y`` (current default), then the network
+  interface name is used by the ``SO_BINDTODEVICE`` socket option.
+
 Recommended Changes
 *******************
 


### PR DESCRIPTION
Clarified the impact of CONFIG_NET_INTERFACE_NAME Kconfig option as it can change how SO_BINDTODEVICE BSD socket option behaves.