### PR TITLE
manifest: update sof to pull init.h fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -314,7 +314,7 @@ manifest:
       groups:
         - debug
     - name: sof
-      revision: ee40f61b5725b6615f1abea4a78cc4d90ce144b8
+      revision: pull/30/head
       path: modules/audio/sof
     - name: tflite-micro
       revision: 9156d050927012da87079064db59d07f03b8baf6


### PR DESCRIPTION
Module used SYS_INIT in a few places without including the right headers