### PR TITLE
ipc: rpmsg_service: s/device.h/init.h

### DIFF
--- a/subsys/ipc/rpmsg_service/rpmsg_service.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_service.c
@@ -9,7 +9,7 @@
 #include "rpmsg_backend.h"
 
 #include <zephyr/kernel.h>
-#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 
 #include <openamp/open_amp.h>


### PR DESCRIPTION
Because module uses init.h APIs (SYS_INIT), not device.h.