### PR TITLE
soc: arm: atmel_sam0: common: bossa: add missing init.h

### DIFF
--- a/soc/arm/atmel_sam0/common/bossa.c
+++ b/soc/arm/atmel_sam0/common/bossa.c
@@ -7,6 +7,7 @@
 #include <soc.h>
 #include <zephyr/drivers/uart/cdc_acm.h>
 #include <zephyr/drivers/usb/usb_dc.h>
+#include <zephyr/init.h>
 #include <zephyr/usb/class/usb_cdc.h>
 
 /*


### PR DESCRIPTION
Because modules uses SYS_INIT, from init.h.