### PR TITLE
shields: rk055hdmipi4m: fix touch controller label

### DIFF
--- a/boards/shields/rk055hdmipi4m/boards/mimxrt595_evk_cm33.overlay
+++ b/boards/shields/rk055hdmipi4m/boards/mimxrt595_evk_cm33.overlay
@@ -13,7 +13,7 @@
 };
 
 /* GT911 IRQ GPIO is active low on this board, and needs probing mode */
-&touch_controller {
+&gt911_rk055hdmipi4m {
 	irq-gpios = <&nxp_mipi_connector 29 GPIO_ACTIVE_LOW>;
 	alt-addr = <0x14>;
 };


### PR DESCRIPTION
Repro: `west build -p -b mimxrt595_evk_cm33 -T samples/drivers/display/sample.display.mcux_dcnano_lcdif`

---

This got renamed in 42c6f3311b, use the new label in the board overlay.