### PR TITLE
arch: riscv: Trap handler alignment configuration

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -323,6 +323,15 @@ config CMSIS_V2_THREAD_MAX_STACK_SIZE
 config ARCH_IRQ_VECTOR_TABLE_ALIGN
 	default 256
 
+config RISCV_TRAP_HANDLER_ALIGNMENT
+	int "Alignment of RISC-V trap handler in bytes"
+	default 4
+	help
+	  This value configures the alignment of RISC-V trap handling
+	  code. The requirement for a particular alignment arises from
+	  the format of MTVEC register which is RISC-V platform-specific.
+	  The minimum alignment is 4 bytes according to the Spec.
+
 config GEN_IRQ_VECTOR_TABLE
 	select RISCV_VECTORED_MODE if SOC_FAMILY_RISCV_PRIVILEGED
 

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -103,6 +103,9 @@ GTEXT(_isr_wrapper)
  */
 SECTION_FUNC(exception.entry, _isr_wrapper)
 
+/* Provide requested alignment, which depends e.g. on MTVEC format */
+.balign CONFIG_RISCV_TRAP_HANDLER_ALIGNMENT
+
 #ifdef CONFIG_USERSPACE
 	/* retrieve address of _current_cpu preserving s0 */
 	csrrw s0, mscratch, s0


### PR DESCRIPTION
RISC-V Spec requires minimum alignment of trap handling code to be dependent from MTVEC.BASE field size. Minimum alignment for RISC-V platforms is 4 bytes, but maximum is platform or application-specific.

Currently there is no common approach to align the trap handling code for RISC-V and some platforms use custom wrappers to align _isr_wrapper properly.

This change introduces a generic solution, CONFIG_RISCV_TRAP_HANDLER_ALIGNMENT configuration option which sets the alignment of a RISC-V trap handling code.

The existing custom solutions for some platforms remain operational, since the default alignment is set to minimal possible (4 bytes) and will be overloaded by potentially larger alignment of custom solutions.