### PR TITLE
tests: code_relocation: run setup at earlier stage

### DIFF
--- a/tests/application_development/code_relocation/src/main.c
+++ b/tests/application_development/code_relocation/src/main.c
@@ -72,12 +72,13 @@ void z_early_memset(void *dst, int c, size_t n)
 	return (void)dst;
 }
 
-void *relocate_code_setup(void)
+static int relocate_code_setup(void)
 {
 #if (defined(CONFIG_ARM_MPU) && !defined(CONFIG_CPU_HAS_NXP_MPU))
 	disable_mpu_rasr_xn();
 #endif	/* CONFIG_ARM_MPU */
-	return NULL;
+	return 0;
 }
+SYS_INIT(relocate_code_setup, PRE_KERNEL_1, 0);
 
-ZTEST_SUITE(code_relocation, NULL, relocate_code_setup, NULL, NULL, NULL);
+ZTEST_SUITE(code_relocation, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Some boards like `mr_canhubk3` enable by default peripheral drivers that consume kernel APIs during device initialization. Perform the test setup at an earlier stage to avoid access violation faults on these cases.

The issue is the test is relocating kernel code to RAM, specifically [kernel/sem.c](https://github.com/zephyrproject-rtos/zephyr/blob/ff2f9a2084f1673485c0468c6863081af3804157/tests/application_development/code_relocation/CMakeLists.txt#L41). If a device driver or any other piece of code needs to use the kernel semaphores (which is now in RAM) before relocate_code_setup is executed (i.e. before reaching main()) it will generate an access fault because the MPU configuration does not allow yet to execute from SRAM. By making relocate_code_setup not a ztest setup function that runs in main() but instead a system init routine that runs during boot, we can guarantee that any piece of code that tries to access the kernel semaphore APIs after PRE_KERNEL_1 0 and before main() will not generate an access fault.