### PR TITLE
mr_canhubk3: enable L2 ethernet when dummy L2 is disabled

### DIFF
--- a/boards/arm/mr_canhubk3/Kconfig.defconfig
+++ b/boards/arm/mr_canhubk3/Kconfig.defconfig
@@ -23,7 +23,7 @@ endif # CAN
 if NETWORKING
 
 config NET_L2_ETHERNET
-	default y
+	default y if !NET_LOOPBACK && !NET_TEST
 
 endif # NETWORKING
 


### PR DESCRIPTION
Enable `CONFIG_NET_L2_ETHERNET` only when dummy L2 layer is not used. Otherwise having the two of them enabled will cause failures in some net tests that expect only dummy L2 layer to be enabled and configured.