### PR TITLE
tests: irq_vector_table: support for mr_canhubk3 board

### DIFF
--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -134,7 +134,7 @@ static void spi_mcux_transfer_next_packet(const struct device *dev)
 	}
 }
 
-static void spi_mcux_isr(const struct device *dev)
+void spi_mcux_isr(const struct device *dev)
 {
 	const struct spi_mcux_config *config = dev->config;
 	struct spi_mcux_data *data = dev->data;


### PR DESCRIPTION
`mr_canhubk3` board includes an off-chip watchdog that must be configured during boot to avoid triggering a reset, so add the interrupt handlers for its SPI bus master and external interrupt, besides the test ISRs.