### PR TITLE
Exclude non-supported tests on `mr_canhubk3` board

### DIFF
--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -13,6 +13,8 @@ tests:
     extra_args: CONF_FILE="prj_user.conf"
     integration_platforms:
       - qemu_x86
+    platform_exclude:
+      - mr_canhubk3
     harness_config:
       type: multi_line
       regex:

--- a/tests/kernel/usage/thread_runtime_stats/testcase.yaml
+++ b/tests/kernel/usage/thread_runtime_stats/testcase.yaml
@@ -16,3 +16,5 @@ tests:
     integration_platforms:
       - qemu_x86
       - mps2_an385
+    platform_exclude:
+      - mr_canhubk3


### PR DESCRIPTION
- `samples/subsys/tracing`: the amount of data printed on this test prevents to initialize the on-board watchdog within the expected window, causing a board reset.
- `tests/kernel/usage/thread_runtime_stats`: test_all_stats_usage assumes the CPU was never idle before the test starts but this is not the case for mr_canhubk3 because the off-chip watchdog driver has a thread kicked off during device init that will conflict with the expected usage stats on this test.
