### PR TITLE
scripts: tests: twister: Mixin test

### DIFF
--- a/scripts/tests/twister/test_data/mixins/test_to_ignore.py
+++ b/scripts/tests/twister/test_data/mixins/test_to_ignore.py
@@ -1,0 +1,5 @@
+from twisterlib.mixins import DisablePyTestCollectionMixin
+
+class TestClassToIgnore(DisablePyTestCollectionMixin):
+    def test_to_ignore(self):
+        assert False

--- a/scripts/tests/twister/test_mixins.py
+++ b/scripts/tests/twister/test_mixins.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the mixins class
+"""
+
+import os
+import pytest
+
+
+def test_disable_pytest_test_collection(test_data):
+    test_path = os.path.join(test_data, 'mixins')
+
+    return_code = pytest.main([test_path])
+
+    assert return_code == 5


### PR DESCRIPTION
Simple test explicitly checking whether our method for skipping unwanted test classes for `pytest` works.