### PR TITLE
subsys/net/net_mgmt.c: Fix memory corruption in wait_on_iface

### DIFF
--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -236,29 +236,32 @@ static int mgmt_event_wait_call(struct net_if *iface,
 	net_mgmt_add_event_callback(&sync);
 
 	ret = k_sem_take(sync.sync_call, timeout);
-	if (ret == -EAGAIN) {
-		ret = -ETIMEDOUT;
-	} else {
-		if (!ret) {
-			if (raised_event) {
-				*raised_event = sync.raised_event;
-			}
+	if (ret < 0) {
+		if (ret == -EAGAIN) {
+			ret = -ETIMEDOUT;
+		}
 
-			if (event_iface) {
-				*event_iface = sync_data.iface;
-			}
+		net_mgmt_del_event_callback(&sync);
+		return ret;
+	}
+
+	if (raised_event) {
+		*raised_event = sync.raised_event;
+	}
+
+	if (event_iface) {
+		*event_iface = sync_data.iface;
+	}
 
 #ifdef CONFIG_NET_MGMT_EVENT_INFO
-			if (info) {
-				*info = sync.info;
+	if (info) {
+		*info = sync.info;
 
-				if (info_length) {
-					*info_length = sync.info_length;
-				}
-			}
-#endif /* CONFIG_NET_MGMT_EVENT_INFO */
+		if (info_length) {
+			*info_length = sync.info_length;
 		}
 	}
+#endif /* CONFIG_NET_MGMT_EVENT_INFO */
 
 	return ret;
 }


### PR DESCRIPTION
The net_mgmt subsystem offers a function which waits (blocks) until a specified net event occurs. An event callback is pushed to the stack, then added to the net_mgmt_event_callback list. If the event occurs, the net_mgmt thread calls the callback and deletes the callback from the list. However, if the event does not occur within the timeout specified when invoking mgmt_event_wait_call() the function will return, corrupting the callback structure when the stack is reused.

This PR fixes the issue by deleting the callback before exiting in case the event does not occur.

@rerickson1 I found it! https://github.com/zephyrproject-rtos/zephyr/pull/56692#issuecomment-1636828359 