### PR TITLE
drivers: rtc: stm32: add calibration feature and several fixes/improvements

### DIFF
--- a/drivers/rtc/Kconfig.stm32
+++ b/drivers/rtc/Kconfig.stm32
@@ -5,7 +5,6 @@ config RTC_STM32
 	bool "STM32 RTC driver"
 	default y if !COUNTER
 	depends on DT_HAS_ST_STM32_RTC_ENABLED && !SOC_SERIES_STM32F1X
-	select USE_STM32_LL_RTC
 	select USE_STM32_LL_PWR
 	select USE_STM32_LL_RCC
 	help

--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -298,6 +298,8 @@ static int rtc_stm32_get_time(const struct device *dev, struct rtc_time *timeptr
 }
 
 #ifdef CONFIG_RTC_CALIBRATION
+#if !defined(CONFIG_SOC_SERIES_STM32F2X) && \
+	!(defined(CONFIG_SOC_SERIES_STM32L1X) && !defined(RTC_SMOOTHCALIB_SUPPORT))
 static int rtc_stm32_set_calibration(const struct device *dev, int32_t calibration)
 {
 	ARG_UNUSED(dev);
@@ -362,6 +364,7 @@ static int rtc_stm32_get_calibration(const struct device *dev, int32_t *calibrat
 
 	return 0;
 }
+#endif
 #endif /* CONFIG_RTC_CALIBRATION */
 
 struct rtc_driver_api rtc_stm32_driver_api = {
@@ -370,8 +373,13 @@ struct rtc_driver_api rtc_stm32_driver_api = {
 	/* RTC_ALARM not supported */
 	/* RTC_UPDATE not supported */
 #ifdef CONFIG_RTC_CALIBRATION
+#if !defined(CONFIG_SOC_SERIES_STM32F2X) && \
+	!(defined(CONFIG_SOC_SERIES_STM32L1X) && !defined(RTC_SMOOTHCALIB_SUPPORT))
 	.set_calibration = rtc_stm32_set_calibration,
 	.get_calibration = rtc_stm32_get_calibration,
+#else
+#error RTC calibration for devices without smooth calibration feature is not supported yet
+#endif
 #endif /* CONFIG_RTC_CALIBRATION */
 };
 

--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -138,6 +138,11 @@ static int rtc_stm32_set_time(const struct device *dev, const struct rtc_time *t
 		return -EINVAL;
 	}
 
+	if (timeptr->tm_wday == -1) {
+		/* day of the week is expected */
+		return -EINVAL;
+	}
+
 	LOG_INF("Setting clock");
 	LL_RTC_DisableWriteProtection(RTC);
 

--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -290,6 +290,10 @@ static int rtc_stm32_get_time(const struct device *dev, struct rtc_time *timeptr
 
 	timeptr->tm_nsec = DIV_ROUND_CLOSEST(temp, cfg->sync_prescaler + 1);
 
+	/* unknown values */
+	timeptr->tm_yday  = -1;
+	timeptr->tm_isdst = -1;
+
 	return 0;
 }
 


### PR DESCRIPTION
- Adds set_calibration and get_calibration API functions
- Correctly computes nanosecond value
- Fixes day of the week value
- Fixes potential erroneous values issue due to shadow register being bypassed
- Avoids reset induced time drift
- Remove blocking loops
- Fixes non thread safe operations
- Uses BDC<->bin conversion functions instead of the LL ones
- Sets all the rtc_time fields returned by rtc_stm32_get_time()
- Perform additional checks against arguments received by rtc_stm32_set_time()

This have been tested on an STM32H7