### PR TITLE
net: shell: Add priority to ping

### DIFF
--- a/include/zephyr/net/zperf.h
+++ b/include/zephyr/net/zperf.h
@@ -37,6 +37,7 @@ struct zperf_upload_params {
 	struct {
 		uint8_t tos;
 		int tcp_nodelay;
+		int priority;
 	} options;
 };
 

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -290,6 +290,12 @@ config NET_RX_DEFAULT_PRIORITY
 	  What is the default network RX packet priority if user has not set
 	  one. The value 0 means lowest priority and 7 is the highest.
 
+config NET_ALLOW_ANY_PRIORITY
+	bool "Allow any network packet priority to be used"
+	help
+	  If this is set, then any user given network packet priority can be used. Otherwise
+	  the network packet priorities are limited to 0-7 range.
+
 config NET_IP_ADDR_CHECK
 	bool "Check IP address validity before sending IP packet"
 	default y

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -538,7 +538,8 @@ int net_icmpv4_send_echo_request(struct net_if *iface,
 		return -ENOMEM;
 	}
 
-	if (priority >= NET_MAX_PRIORITIES) {
+	if (!IS_ENABLED(CONFIG_NET_ALLOW_ANY_PRIORITY) &&
+	    priority >= NET_MAX_PRIORITIES) {
 		NET_ERR("Priority %d is too large, maximum allowed is %d",
 			priority, NET_MAX_PRIORITIES - 1);
 		return -EINVAL;

--- a/subsys/net/ip/icmpv4.h
+++ b/subsys/net/ip/icmpv4.h
@@ -82,6 +82,7 @@ int net_icmpv4_send_echo_request(struct net_if *iface,
 				 uint16_t identifier,
 				 uint16_t sequence,
 				 uint8_t tos,
+				 int priority,
 				 const void *data,
 				 size_t data_size);
 #else
@@ -90,6 +91,7 @@ static inline int net_icmpv4_send_echo_request(struct net_if *iface,
 					       uint16_t identifier,
 					       uint16_t sequence,
 					       uint8_t tos,
+					       int priority,
 					       const void *data,
 					       size_t data_size)
 {
@@ -98,6 +100,7 @@ static inline int net_icmpv4_send_echo_request(struct net_if *iface,
 	ARG_UNUSED(identifier);
 	ARG_UNUSED(sequence);
 	ARG_UNUSED(tos);
+	ARG_UNUSED(priority);
 	ARG_UNUSED(data);
 	ARG_UNUSED(data_size);
 

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -363,7 +363,8 @@ int net_icmpv6_send_echo_request(struct net_if *iface,
 		return -ENOMEM;
 	}
 
-	if (priority >= NET_MAX_PRIORITIES) {
+	if (!IS_ENABLED(CONFIG_NET_ALLOW_ANY_PRIORITY) &&
+	    priority >= NET_MAX_PRIORITIES) {
 		NET_ERR("Priority %d is too large, maximum allowed is %d",
 			priority, NET_MAX_PRIORITIES - 1);
 		return -EINVAL;

--- a/subsys/net/ip/icmpv6.h
+++ b/subsys/net/ip/icmpv6.h
@@ -222,6 +222,7 @@ int net_icmpv6_send_echo_request(struct net_if *iface,
 				 uint16_t identifier,
 				 uint16_t sequence,
 				 uint8_t tc,
+				 int priority,
 				 const void *data,
 				 size_t data_size);
 #else
@@ -230,6 +231,7 @@ static inline int net_icmpv6_send_echo_request(struct net_if *iface,
 					       uint16_t identifier,
 					       uint16_t sequence,
 					       uint8_t tc,
+					       int priority,
 					       const void *data,
 					       size_t data_size)
 {
@@ -238,6 +240,7 @@ static inline int net_icmpv6_send_echo_request(struct net_if *iface,
 	ARG_UNUSED(identifier);
 	ARG_UNUSED(sequence);
 	ARG_UNUSED(tc);
+	ARG_UNUSED(priority);
 	ARG_UNUSED(data);
 	ARG_UNUSED(data_size);
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -4279,6 +4279,7 @@ static struct ping_context {
 	uint32_t sequence;
 	uint16_t payload_size;
 	uint8_t tos;
+	int priority;
 } ping_ctx;
 
 static void ping_done(struct ping_context *ctx);
@@ -4504,6 +4505,7 @@ static void ping_work(struct k_work *work)
 						   sys_rand32_get(),
 						   ctx->sequence,
 						   ctx->tos,
+						   ctx->priority,
 						   NULL,
 						   ctx->payload_size);
 	} else {
@@ -4512,6 +4514,7 @@ static void ping_work(struct k_work *work)
 						   sys_rand32_get(),
 						   ctx->sequence,
 						   ctx->tos,
+						   ctx->priority,
 						   NULL,
 						   ctx->payload_size);
 	}
@@ -4612,6 +4615,7 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 	int iface_idx = -1;
 	int tos = 0;
 	int payload_size = 4;
+	int priority = -1;
 
 	for (size_t i = 1; i < argc; ++i) {
 
@@ -4642,6 +4646,14 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 		case 'I':
 			iface_idx = parse_arg(&i, argc, argv);
 			if (iface_idx < 0 || !net_if_get_by_index(iface_idx)) {
+				PR_WARNING("Parse error: %s\n", argv[i]);
+				return -ENOEXEC;
+			}
+			break;
+
+		case 'p':
+			priority = parse_arg(&i, argc, argv);
+			if (priority < 0 || priority > UINT8_MAX) {
 				PR_WARNING("Parse error: %s\n", argv[i]);
 				return -ENOEXEC;
 			}
@@ -4683,6 +4695,7 @@ static int cmd_net_ping(const struct shell *sh, size_t argc, char *argv[])
 	ping_ctx.sh = sh;
 	ping_ctx.count = count;
 	ping_ctx.interval = interval;
+	ping_ctx.priority = priority;
 	ping_ctx.tos = tos;
 	ping_ctx.payload_size = payload_size;
 
@@ -6584,7 +6597,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_vlan,
 SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_ping,
 	SHELL_CMD(--help, NULL,
 		  "'net ping [-c count] [-i interval ms] [-I <iface index>] "
-		  "[-Q tos] [-s payload size] <host>' "
+		  "[-Q tos] [-s payload size] [-p priority] <host>' "
 		  "Send ICMPv4 or ICMPv6 Echo-Request to a network host.",
 		  cmd_net_ping),
 	SHELL_SUBCMD_SET_END

--- a/subsys/net/lib/zperf/zperf_internal.h
+++ b/subsys/net/lib/zperf/zperf_internal.h
@@ -99,7 +99,7 @@ const struct in_addr *zperf_get_default_if_in4_addr(void);
 const struct in6_addr *zperf_get_default_if_in6_addr(void);
 
 int zperf_prepare_upload_sock(const struct sockaddr *peer_addr, int tos,
-			      int proto);
+			      int priority, int proto);
 
 uint32_t zperf_packet_duration(uint32_t packet_size, uint32_t rate_in_kbps);
 

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -526,7 +526,7 @@ static int execute_upload(const struct shell *sh,
 		 * some time and start the test after that.
 		 */
 		net_icmpv6_send_echo_request(net_if_get_default(),
-					     &ipv6->sin6_addr, 0, 0, 0, NULL, 0);
+					     &ipv6->sin6_addr, 0, 0, 0, -1, NULL, 0);
 
 		k_sleep(K_SECONDS(1));
 	}

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -642,6 +642,7 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 	int start = 0;
 	size_t opt_cnt = 0;
 
+	param.options.priority = -1;
 	is_udp = proto == IPPROTO_UDP;
 
 	/* Parse options */
@@ -679,6 +680,19 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 			param.options.tcp_nodelay = 1;
 			opt_cnt += 1;
 			break;
+
+#ifdef CONFIG_NET_CONTEXT_PRIORITY
+		case 'p':
+			param.options.priority = parse_arg(&i, argc, argv);
+			if (param.options.priority < 0 ||
+			    param.options.priority > UINT8_MAX) {
+				shell_fprintf(sh, SHELL_WARNING,
+					      "Parse error: %s\n", argv[i]);
+				return -ENOEXEC;
+			}
+			opt_cnt += 2;
+			break;
+#endif /* CONFIG_NET_CONTEXT_PRIORITY */
 
 		default:
 			shell_fprintf(sh, SHELL_WARNING,
@@ -852,6 +866,19 @@ static int shell_cmd_upload2(const struct shell *sh, size_t argc,
 			param.options.tcp_nodelay = 1;
 			opt_cnt += 1;
 			break;
+
+#ifdef CONFIG_NET_CONTEXT_PRIORITY
+		case 'p':
+			param.options.priority = parse_arg(&i, argc, argv);
+			if (param.options.priority == -1 ||
+			    param.options.priority > UINT8_MAX) {
+				shell_fprintf(sh, SHELL_WARNING,
+					      "Parse error: %s\n", argv[i]);
+				return -ENOEXEC;
+			}
+			opt_cnt += 2;
+			break;
+#endif /* CONFIG_NET_CONTEXT_PRIORITY */
 
 		default:
 			shell_fprintf(sh, SHELL_WARNING,
@@ -1146,6 +1173,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(zperf_cmd_tcp,
 		  "-S tos: Specify IPv4/6 type of service\n"
 		  "-a: Asynchronous call (shell will not block for the upload)\n"
 		  "-n: Disable Nagle's algorithm\n"
+#ifdef CONFIG_NET_CONTEXT_PRIORITY
+		  "-p: Specify custom packet priority\n"
+#endif /* CONFIG_NET_CONTEXT_PRIORITY */
 		  "Example: tcp upload 192.0.2.2 1111 1 1K\n"
 		  "Example: tcp upload 2001:db8::2\n",
 		  cmd_tcp_upload),
@@ -1159,6 +1189,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(zperf_cmd_tcp,
 		  "Available options:\n"
 		  "-S tos: Specify IPv4/6 type of service\n"
 		  "-a: Asynchronous call (shell will not block for the upload)\n"
+#ifdef CONFIG_NET_CONTEXT_PRIORITY
+		  "-p: Specify custom packet priority\n"
+#endif /* CONFIG_NET_CONTEXT_PRIORITY */
 		  "Example: tcp upload2 v6 1 1K\n"
 		  "Example: tcp upload2 v4\n"
 		  "-n: Disable Nagle's algorithm\n"
@@ -1198,6 +1231,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(zperf_cmd_udp,
 		  "Available options:\n"
 		  "-S tos: Specify IPv4/6 type of service\n"
 		  "-a: Asynchronous call (shell will not block for the upload)\n"
+#ifdef CONFIG_NET_CONTEXT_PRIORITY
+		  "-p: Specify custom packet priority\n"
+#endif /* CONFIG_NET_CONTEXT_PRIORITY */
 		  "Example: udp upload 192.0.2.2 1111 1 1K 1M\n"
 		  "Example: udp upload 2001:db8::2\n",
 		  cmd_udp_upload),
@@ -1212,6 +1248,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(zperf_cmd_udp,
 		  "Available options:\n"
 		  "-S tos: Specify IPv4/6 type of service\n"
 		  "-a: Asynchronous call (shell will not block for the upload)\n"
+#ifdef CONFIG_NET_CONTEXT_PRIORITY
+		  "-p: Specify custom packet priority\n"
+#endif /* CONFIG_NET_CONTEXT_PRIORITY */
 		  "Example: udp upload2 v4 1 1K 1M\n"
 		  "Example: udp upload2 v6\n"
 #if defined(CONFIG_NET_IPV6) && defined(MY_IP6ADDR_SET)

--- a/subsys/net/lib/zperf/zperf_tcp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_tcp_uploader.c
@@ -117,7 +117,7 @@ int zperf_tcp_upload(const struct zperf_upload_params *param,
 	}
 
 	sock = zperf_prepare_upload_sock(&param->peer_addr, param->options.tos,
-					 IPPROTO_TCP);
+					 param->options.priority, IPPROTO_TCP);
 	if (sock < 0) {
 		return sock;
 	}

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -284,7 +284,7 @@ int zperf_udp_upload(const struct zperf_upload_params *param,
 	}
 
 	sock = zperf_prepare_upload_sock(&param->peer_addr, param->options.tos,
-					 IPPROTO_UDP);
+					 param->options.priority, IPPROTO_UDP);
 	if (sock < 0) {
 		return sock;
 	}


### PR DESCRIPTION
This is handy in testing of setting priority directly rather than deriving from DSCP. Please note ICMP doesn't use net context.