### PR TITLE
Support CodeChecker with toolchain picolibc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,7 @@ if(CONFIG_COMPILER_FREESTANDING)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:compiler,freestanding>>)
 endif()
 
-if (CONFIG_PICOLIBC AND NOT CONFIG_PICOLIBC_IO_FLOAT)
+if (CONFIG_PICOLIBC AND NOT CONFIG_PICOLIBC_IO_FLOAT AND NOT DEFINED ZEPHYR_SCA_VARIANT)
   # @Intent: Set compiler specific flag to disable printf-related optimizations
   zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,no_printf_return_value>>)
 endif()

--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -22,4 +22,23 @@ if(NOT CONFIG_PICOLIBC_USE_MODULE)
     zephyr_link_libraries(-DPICOLIBC_INTEGER_PRINTF_SCANF)
   endif()
 
+  set(gcctmp "${CMAKE_BINARY_DIR}/gcctmp")
+  file(WRITE "${gcctmp}" "#include <picolibc.h>")
+
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} --specs=picolibc.specs -M -E -
+    INPUT_FILE "${gcctmp}"
+    OUTPUT_VARIABLE PICOLIBC_INCLUDE_DIR
+    )
+  file(REMOVE "${gcctmp}")
+
+  # Extract the pathname to picolibc.h from the makefile-style dependency
+  string(REGEX REPLACE "-: " "" PICOLIBC_INCLUDE_DIR "${PICOLIBC_INCLUDE_DIR}")
+  string(REGEX REPLACE "^\\\\\n *" "" PICOLIBC_INCLUDE_DIR "${PICOLIBC_INCLUDE_DIR}")
+
+  # Trim off the filename
+  cmake_path(REMOVE_FILENAME PICOLIBC_INCLUDE_DIR)
+
+  zephyr_system_include_directories("${PICOLIBC_INCLUDE_DIR}")
+
 endif()


### PR DESCRIPTION
CodeChecker requires complete and correct include path information to work correctly. When using picolibc, that means extracting the relevant paths from the compiler (when using the toolchain picolibc) or hard-coding the relevant path (when using the picolibc module). To make that all work, replace the use of gcc --print-file-name with gcc -M so that we  walk the include path arguments and picolibc.specs bits.

Closes: #62278 