### PR TITLE
Bluetooth: Mesh: Send od priv proxy with devkey

### DIFF
--- a/include/zephyr/bluetooth/mesh/od_priv_proxy_cli.h
+++ b/include/zephyr/bluetooth/mesh/od_priv_proxy_cli.h
@@ -47,7 +47,6 @@ struct bt_mesh_od_priv_proxy_cli {
 			 _bt_mesh_od_priv_proxy_cli_op, NULL, cli_data,            \
 			 &_bt_mesh_od_priv_proxy_cli_cb)
 
-
 /** @brief Get the target's On-Demand Private GATT Proxy state.
  *
  *  This method can be used asynchronously by setting @p val_rsp as NULL.
@@ -57,12 +56,13 @@ struct bt_mesh_od_priv_proxy_cli {
  *  To process the response arguments of an async method, register
  *  the @c od_status callback in @c bt_mesh_od_priv_proxy_cli struct.
  *
- *  @param ctx        Message context for the message.
+ *  @param net_idx    Network index to encrypt with.
+ *  @param addr       Target node address.
  *  @param val_rsp    Response buffer for On-Demand Private GATT Proxy value.
  *
  *  @return 0 on success, or (negative) error code otherwise.
  */
-int bt_mesh_od_priv_proxy_cli_get(struct bt_mesh_msg_ctx *ctx, uint8_t *val_rsp);
+int bt_mesh_od_priv_proxy_cli_get(uint16_t net_idx, uint16_t addr, uint8_t *val_rsp);
 
 /** @brief Set the target's On-Demand Private GATT Proxy state.
  *
@@ -73,13 +73,14 @@ int bt_mesh_od_priv_proxy_cli_get(struct bt_mesh_msg_ctx *ctx, uint8_t *val_rsp)
  *  To process the response arguments of an async method, register
  *  the @c od_status callback in @c bt_mesh_od_priv_proxy_cli struct.
  *
- *  @param ctx        Message context for the message.
+ *  @param net_idx    Network index to encrypt with.
+ *  @param addr       Target node address.
  *  @param val        On-Demand Private GATT Proxy state to be set
  *  @param val_rsp    Response buffer for On-Demand Private GATT Proxy value.
  *
  *  @return 0 on success, or (negative) error code otherwise.
  */
-int bt_mesh_od_priv_proxy_cli_set(struct bt_mesh_msg_ctx *ctx, uint8_t val, uint8_t *val_rsp);
+int bt_mesh_od_priv_proxy_cli_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *val_rsp);
 
 /** @brief Set the transmission timeout value.
  *

--- a/subsys/bluetooth/mesh/od_priv_proxy_cli.c
+++ b/subsys/bluetooth/mesh/od_priv_proxy_cli.c
@@ -54,23 +54,25 @@ const struct bt_mesh_model_op _bt_mesh_od_priv_proxy_cli_op[] = {
 	BT_MESH_MODEL_OP_END
 };
 
-int bt_mesh_od_priv_proxy_cli_get(struct bt_mesh_msg_ctx *ctx, uint8_t *val)
+int bt_mesh_od_priv_proxy_cli_get(uint16_t net_idx, uint16_t addr, uint8_t *val_rsp)
 {
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	const struct bt_mesh_msg_rsp_ctx rsp = {
 		.ack = &cli->ack_ctx,
 		.op = OP_OD_PRIV_PROXY_STATUS,
-		.user_data = val,
+		.user_data = val_rsp,
 		.timeout = msg_timeout,
 	};
 
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_OD_PRIV_PROXY_GET, 0);
 	bt_mesh_model_msg_init(&msg, OP_OD_PRIV_PROXY_GET);
 
-	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, val ? &rsp : NULL);
+	return bt_mesh_msg_ackd_send(cli->model, &ctx, &msg, val_rsp ? &rsp : NULL);
 }
 
-int bt_mesh_od_priv_proxy_cli_set(struct bt_mesh_msg_ctx *ctx, uint8_t val, uint8_t *val_rsp)
+int bt_mesh_od_priv_proxy_cli_set(uint16_t net_idx, uint16_t addr, uint8_t val, uint8_t *val_rsp)
 {
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	const struct bt_mesh_msg_rsp_ctx rsp = {
 		.ack = &cli->ack_ctx,
 		.op = OP_OD_PRIV_PROXY_STATUS,
@@ -83,7 +85,7 @@ int bt_mesh_od_priv_proxy_cli_set(struct bt_mesh_msg_ctx *ctx, uint8_t val, uint
 
 	net_buf_simple_add_u8(&msg, val);
 
-	return bt_mesh_msg_ackd_send(cli->model, ctx, &msg, val_rsp ? &rsp : NULL);
+	return bt_mesh_msg_ackd_send(cli->model, &ctx, &msg, val_rsp ? &rsp : NULL);
 }
 
 void bt_mesh_od_priv_proxy_cli_timeout_set(int32_t timeout)


### PR DESCRIPTION
According to the mesh 1.1 spec, section  4.4.14.1: “. The access layer security on the On-Demand Private Proxy Client model shall use the device key of the node supporting the On-Demand Private Proxy Server model.“

This commit alters the API and implementation to reflect this.