### PR TITLE
Only run the greet first time contributor GitHub Action when the repository is zephyrproject-rtos/zephyr

### DIFF
--- a/.github/workflows/greet_first_time_contributor.yml
+++ b/.github/workflows/greet_first_time_contributor.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   check_for_first_interaction:
     runs-on: ubuntu-22.04
+    if: github.repository == 'zephyrproject-rtos/zephyr'
+
     steps:
       - uses: actions/checkout@v3
       - uses: zephyrproject-rtos/action-first-interaction@v1.1.1-zephyr-3


### PR DESCRIPTION
Only run the greet first time contributor GitHub Action when the repository is zephyrproject-rtos/zephyr. If a contributor forks this repository and wants to run the GitHub Actions, then they are likely not want to have this Action run as part of their checks.

Add a check to greet_first_time_contributor.yml for the GitHub repository being this one.

fixes: https://github.com/zephyrproject-rtos/zephyr/issues/62326