### PR TITLE
scripts: Test_plan.py generalization

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -19,10 +19,17 @@ from west.manifest import Manifest
 if "ZEPHYR_BASE" not in os.environ:
     exit("$ZEPHYR_BASE environment variable undefined.")
 
-repository_path = Path(os.environ['ZEPHYR_BASE'])
+# These are globaly used variables. They are assigned in __main__ and are visible in further methods
+# however, pylint complains that it doesn't recognized them when used (used-before-assignment).
+zephyr_base = Path(os.environ['ZEPHYR_BASE'])
+repository_path = zephyr_base
+repo_to_scan = zephyr_base
+args = None
+
+
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
 
-sys.path.append(os.path.join(repository_path, 'scripts'))
+sys.path.append(os.path.join(zephyr_base, 'scripts'))
 import list_boards
 
 def _get_match_fn(globs, regexes):
@@ -112,7 +119,7 @@ class Filters:
 
     def get_plan(self, options, integration=False):
         fname = "_test_plan_partial.json"
-        cmd = ["scripts/twister", "-c"] + options + ["--save-tests", fname ]
+        cmd = [f"{zephyr_base}/scripts/twister", "-c"] + options + ["--save-tests", fname ]
         if not self.detailed_test_id:
             cmd += ["--no-detailed-test-id"]
         if integration:
@@ -131,7 +138,7 @@ class Filters:
         if 'west.yml' in self.modified_files:
             print(f"Manifest file 'west.yml' changed")
             print("=========")
-            old_manifest_content = repo.git.show(f"{args.commits[:-2]}:west.yml")
+            old_manifest_content = repo_to_scan.git.show(f"{args.commits[:-2]}:west.yml")
             with open("west_old.yml", "w") as manifest:
                 manifest.write(old_manifest_content)
             old_manifest = Manifest.from_file("west_old.yml")
@@ -212,8 +219,12 @@ class Filters:
             if p and p.groups():
                 boards.add(p.group(1))
 
-        # Limit search to $ZEPHYR_BASE since this is where the changed files are
-        lb_args = argparse.Namespace(**{ 'arch_roots': [repository_path], 'board_roots': [repository_path] })
+        roots = [zephyr_base]
+        if repository_path != zephyr_base:
+            roots.append(repository_path)
+
+        # Look for boards in monitored repositories
+        lb_args = argparse.Namespace(**{ 'arch_roots': roots, 'board_roots': roots})
         known_boards = list_boards.find_boards(lb_args)
         for b in boards:
             name_re = re.compile(b)
@@ -268,7 +279,7 @@ class Filters:
 
     def find_tags(self):
 
-        tag_cfg_file = os.path.join(repository_path, 'scripts', 'ci', 'tags.yaml')
+        tag_cfg_file = os.path.join(zephyr_base, 'scripts', 'ci', 'tags.yaml')
         with open(tag_cfg_file, 'r') as ymlfile:
             tags_config = yaml.safe_load(ymlfile)
 
@@ -360,6 +371,8 @@ def parse_args():
             help="Include paths to tests' locations in tests' names.")
     parser.add_argument("--no-detailed-test-id", dest='detailed_test_id', action="store_false",
             help="Don't put paths into tests' names.")
+    parser.add_argument('-r', '--repo-to-scan', default=None,
+            help="Repo to scan")
 
     # Include paths in names by default.
     parser.set_defaults(detailed_test_id=True)
@@ -372,9 +385,11 @@ if __name__ == "__main__":
     args = parse_args()
     files = []
     errors = 0
+    if args.repo_to_scan:
+        repository_path = Path(args.repo_to_scan)
     if args.commits:
-        repo = Repo(repository_path)
-        commit = repo.git.diff("--name-only", args.commits)
+        repo_to_scan = Repo(repository_path)
+        commit = repo_to_scan.git.diff("--name-only", args.commits)
         files = commit.split("\n")
     elif args.modified_files:
         with open(args.modified_files, "r") as fp:

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -86,7 +86,7 @@ class Tag:
         return "<Tag {}>".format(self.name)
 
 class Filters:
-    def __init__(self, modified_files, pull_request=False, platforms=[]):
+    def __init__(self, modified_files, pull_request=False, platforms=[], detailed_test_id=True):
         self.modified_files = modified_files
         self.twister_options = []
         self.full_twister = False
@@ -95,6 +95,7 @@ class Filters:
         self.pull_request = pull_request
         self.platforms = platforms
         self.default_run = False
+        self.detailed_test_id = detailed_test_id
 
     def process(self):
         self.find_modules()
@@ -112,6 +113,8 @@ class Filters:
     def get_plan(self, options, integration=False):
         fname = "_test_plan_partial.json"
         cmd = ["scripts/twister", "-c"] + options + ["--save-tests", fname ]
+        if not self.detailed_test_id:
+            cmd += ["--no-detailed-test-id"]
         if integration:
             cmd.append("--integration")
 
@@ -353,6 +356,13 @@ def parse_args():
             help="Number of tests per builder")
     parser.add_argument('-n', '--default-matrix', default=10, type=int,
             help="Number of tests per builder")
+    parser.add_argument('--detailed-test-id', action='store_true',
+            help="Include paths to tests' locations in tests' names.")
+    parser.add_argument("--no-detailed-test-id", dest='detailed_test_id', action="store_false",
+            help="Don't put paths into tests' names.")
+
+    # Include paths in names by default.
+    parser.set_defaults(detailed_test_id=True)
 
     return parser.parse_args()
 
@@ -375,8 +385,7 @@ if __name__ == "__main__":
         print("\n".join(files))
         print("=========")
 
-
-    f = Filters(files, args.pull_request, args.platform)
+    f = Filters(files, args.pull_request, args.platform, args.detailed_test_id)
     f.process()
 
     # remove dupes and filtered cases

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -93,7 +93,7 @@ class Tag:
         return "<Tag {}>".format(self.name)
 
 class Filters:
-    def __init__(self, modified_files, pull_request=False, platforms=[], detailed_test_id=True):
+    def __init__(self, modified_files, ignore_path, pull_request=False, platforms=[], detailed_test_id=True):
         self.modified_files = modified_files
         self.twister_options = []
         self.full_twister = False
@@ -103,6 +103,7 @@ class Filters:
         self.platforms = platforms
         self.default_run = False
         self.detailed_test_id = detailed_test_id
+        self.ignore_path = ignore_path
 
     def process(self):
         self.find_modules()
@@ -317,7 +318,7 @@ class Filters:
             logging.info(f'Potential tag based filters: {exclude_tags}')
 
     def find_excludes(self, skip=[]):
-        with open("scripts/ci/twister_ignore.txt", "r") as twister_ignore:
+        with open(self.ignore_path, "r") as twister_ignore:
             ignores = twister_ignore.read().splitlines()
             ignores = filter(lambda x: not x.startswith("#"), ignores)
 
@@ -373,6 +374,9 @@ def parse_args():
             help="Don't put paths into tests' names.")
     parser.add_argument('-r', '--repo-to-scan', default=None,
             help="Repo to scan")
+    parser.add_argument('--ignore-path',
+            default=os.path.join(zephyr_base, 'scripts', 'ci', 'twister_ignore.txt'),
+            help="Path to a text file with patterns of files to be matched against changed files")
 
     # Include paths in names by default.
     parser.set_defaults(detailed_test_id=True)
@@ -400,7 +404,7 @@ if __name__ == "__main__":
         print("\n".join(files))
         print("=========")
 
-    f = Filters(files, args.pull_request, args.platform, args.detailed_test_id)
+    f = Filters(files, args.ignore_path, args.pull_request, args.platform, args.detailed_test_id)
     f.process()
 
     # remove dupes and filtered cases

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -93,7 +93,7 @@ class Tag:
         return "<Tag {}>".format(self.name)
 
 class Filters:
-    def __init__(self, modified_files, ignore_path, pull_request=False, platforms=[], detailed_test_id=True):
+    def __init__(self, modified_files, ignore_path, alt_tags, pull_request=False, platforms=[], detailed_test_id=True):
         self.modified_files = modified_files
         self.twister_options = []
         self.full_twister = False
@@ -104,6 +104,7 @@ class Filters:
         self.default_run = False
         self.detailed_test_id = detailed_test_id
         self.ignore_path = ignore_path
+        self.tag_cfg_file = alt_tags
 
     def process(self):
         self.find_modules()
@@ -280,8 +281,7 @@ class Filters:
 
     def find_tags(self):
 
-        tag_cfg_file = os.path.join(zephyr_base, 'scripts', 'ci', 'tags.yaml')
-        with open(tag_cfg_file, 'r') as ymlfile:
+        with open(self.tag_cfg_file, 'r') as ymlfile:
             tags_config = yaml.safe_load(ymlfile)
 
         tags = {}
@@ -377,6 +377,9 @@ def parse_args():
     parser.add_argument('--ignore-path',
             default=os.path.join(zephyr_base, 'scripts', 'ci', 'twister_ignore.txt'),
             help="Path to a text file with patterns of files to be matched against changed files")
+    parser.add_argument('--alt-tags',
+            default=os.path.join(zephyr_base, 'scripts', 'ci', 'tags.yaml'),
+            help="Path to a file describing relations between directories and tags")
 
     # Include paths in names by default.
     parser.set_defaults(detailed_test_id=True)
@@ -404,7 +407,7 @@ if __name__ == "__main__":
         print("\n".join(files))
         print("=========")
 
-    f = Filters(files, args.ignore_path, args.pull_request, args.platform, args.detailed_test_id)
+    f = Filters(files, args.ignore_path, args.alt_tags, args.pull_request, args.platform, args.detailed_test_id)
     f.process()
 
     # remove dupes and filtered cases


### PR DESCRIPTION
I found those changes needed to be able to run test_plan.py script in other then zephyr main repo and customize users own tag/ignore/testsuite-root lists