### PR TITLE
init: deprecate SMP init level

### DIFF
--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -42,3 +42,10 @@ Recommended Changes
   :kconfig:option:`CONFIG_GIC_V3` directly in Kconfig has been deprecated.
   The GIC version should now be specified by adding the appropriate compatible, for
   example :dtcompatible:`arm,gic-v2`, to the GIC node in the device tree.
+
+* ``SMP`` init level (used e.g. in :c:macro:`SYS_INIT`) is deprecated and will
+  be removed in future releases. The ``SMP`` level is the last level to be
+  initialized when :kconfig:option:`CONFIG_SMP` is enabled. Its usage was not
+  well documented, so users of this level are encouraged to analyze their
+  implementations and switch to other existing levels, e.g. ``POST_KERNEL`` or
+  ``APPLICATION``.

--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -75,7 +75,7 @@ static int arc_shared_intc_update_post_smp(void)
 	return 0;
 }
 
-SYS_INIT(arc_shared_intc_update_post_smp, SMP, 0);
+SYS_INIT(arc_shared_intc_update_post_smp, APPLICATION, 99);
 #endif /* CONFIG_ARC_CONNECT */
 
 

--- a/drivers/ipm/ipm_cavs_idc.c
+++ b/drivers/ipm/ipm_cavs_idc.c
@@ -237,6 +237,6 @@ int cavs_idc_smp_init(void)
 }
 
 #ifndef CONFIG_SMP_BOOT_DELAY
-SYS_INIT(cavs_idc_smp_init, SMP, 0);
+SYS_INIT(cavs_idc_smp_init, APPLICATION, 99);
 #endif
 #endif

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -942,6 +942,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * @param prio Initialization priority.
  */
 #define Z_DEVICE_INIT_ENTRY_DEFINE(node_id, dev_id, init_fn_, level, prio)     \
+	Z_INIT_CHECK_DEPRECATED_LEVEL(level)                                   \
 	static const Z_DECL_ALIGN(struct init_entry) __used __noasan           \
 		Z_INIT_ENTRY_SECTION(level, prio,                              \
 				     Z_DEVICE_INIT_SUB_PRIO(node_id))          \


### PR DESCRIPTION
The level meaning has never been clear, ie, how it is related to SMP. It
was the last level to be initialized when enabled. Only a couple of
cases were found upstream. They have been moved to one level below
(APPLICATION) to minimize any potential issues.

Users of SMP level should likely look carefully into their code and use
other levels such as POST_KERNEL or APPLICATION.

This PR also introduces `Z_INIT_CHECK_DEPRECATED_LEVEL` so that other
levels can be easily deprecated in the future.

---

Example output if used:

```
[61/134] Building C object CMakeFiles/app.dir/src/main.c.obj
/home/gmarull/ws/nordic/zephyrproject/zephyr/samples/hello_world/src/main.c:22:13: warning: SMP level is deprecated
   22 | SYS_INIT(cb, SMP, 0);
      |             ^~~~~~~~~  
```