### PR TITLE
doc: samples: fully migrate all basic samples to new custom "code-sample" role&directive 

### DIFF
--- a/boards/arc/nsim/doc/index.rst
+++ b/boards/arc/nsim/doc/index.rst
@@ -107,7 +107,7 @@ The supported toolchains are listed in ``toolchain:`` array in ``.yaml`` file, w
    particular toolchain.
 
 Use this configuration to run basic Zephyr applications and kernel tests in
-nSIM, for example, with the :ref:`synchronization_sample`:
+nSIM, for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/arc/qemu_arc/doc/index.rst
+++ b/boards/arc/qemu_arc/doc/index.rst
@@ -67,7 +67,7 @@ Programming and Debugging
 *************************
 
 Use this configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment, for example, with the :ref:`synchronization_sample`
+emulated environment, for example, with the :zephyr:code-sample:`synchronization` sample
 (note you may use ``qemu_arc_em``, ``qemu_arc_hs``,  ``qemu_arc_hs5x`` or
 ``qemu_arc_hs6x`` depending on target CPU):
 

--- a/boards/arm/adafruit_feather_nrf52840/doc/index.rst
+++ b/boards/arm/adafruit_feather_nrf52840/doc/index.rst
@@ -113,7 +113,7 @@ Flashing
 Flashing Zephyr onto the ``adafruit_feather_nrf52480`` board requires
 an external programmer. The programmer is attached to the SWD header.
 
-Build the Zephyr kernel and the :ref:`blinky-sample` sample application.
+Build the Zephyr kernel and the :zephyr:code-sample:`blinky` sample application.
 
    .. zephyr-app-commands::
       :zephyr-app: samples/basic/blinky

--- a/boards/arm/adafruit_feather_stm32f405/doc/index.rst
+++ b/boards/arm/adafruit_feather_stm32f405/doc/index.rst
@@ -100,7 +100,7 @@ of the built in DFU-Util bootloader is possible by following the
 Flashing
 ========
 
-#. Build the Zephyr kernel and the :ref:`blinky-sample` sample application:
+#. Build the Zephyr kernel and the :zephyr:code-sample:`blinky` sample application:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/basic/blinky

--- a/boards/arm/adafruit_itsybitsy_nrf52840/doc/index.rst
+++ b/boards/arm/adafruit_itsybitsy_nrf52840/doc/index.rst
@@ -119,8 +119,8 @@ or the :ref:`cdc-acm-console` sample applications to see how this works.
 
 Testing LEDs and buttons on the Adafruit ItsyBitsy nRF52840 Express
 *******************************************************************
-The :ref:`button-sample` sample lets you test the buttons (switches) and the red LED.
-The :ref:`blinky-sample` sample lets you test the red LED.
+The :zephyr:code-sample:`button` sample lets you test the buttons (switches) and the red LED.
+The :zephyr:code-sample:`blinky` sample lets you test the red LED.
 
 The DotStar LED has been implemented as a SPI device and can be tested
 with the :ref:`led_apa102_sample` sample application.
@@ -151,7 +151,7 @@ Flashing
 Flashing is done by dragging and dropping the built Zephyr UF2-file
 into the :code:`ITSY840BOOT` drive.
 
-#. Build the Zephyr kernel and the :ref:`blinky-sample`
+#. Build the Zephyr kernel and the :zephyr:code-sample:`blinky`
    sample application:
 
    .. zephyr-app-commands::

--- a/boards/arm/arduino_giga_r1/doc/index.rst
+++ b/boards/arm/arduino_giga_r1/doc/index.rst
@@ -151,7 +151,7 @@ You should see the following message on the console:
 
 Similarly, you can build and flash samples on the M4 target.
 
-Here is an example for the :ref:`blinky-sample` application on M4 core.
+Here is an example for the :zephyr:code-sample:`blinky` application on M4 core.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/arduino_portenta_h7/doc/index.rst
+++ b/boards/arm/arduino_portenta_h7/doc/index.rst
@@ -121,7 +121,7 @@ You should see the following message on the console:
 Similarly, you can build and flash samples on the M4 target. For this, please
 take care of the resource sharing (UART port used for console for instance).
 
-Here is an example for the :ref:`blinky-sample` application on M4 core.
+Here is an example for the :zephyr:code-sample:`blinky` application on M4 core.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/b_g474e_dpow1/doc/index.rst
+++ b/boards/arm/b_g474e_dpow1/doc/index.rst
@@ -120,7 +120,7 @@ The B-G474E-DPOW1 Discovery board includes an ST-LINK/V3E embedded debug tool in
 Flashing an application to the B_G474E_DPOW1
 --------------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/b_u585i_iot02a/doc/index.rst
+++ b/boards/arm/b_u585i_iot02a/doc/index.rst
@@ -327,7 +327,7 @@ Debugging
 =========
 
 Default flasher for this board is openocd. It could be used in the usual way.
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/bl652_dvk/doc/bl652_dvk.rst
+++ b/boards/arm/bl652_dvk/doc/bl652_dvk.rst
@@ -255,8 +255,8 @@ Testing the LEDs and buttons in the BL652 DVK
 There are 2 samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/bl653_dvk/doc/bl653_dvk.rst
+++ b/boards/arm/bl653_dvk/doc/bl653_dvk.rst
@@ -162,8 +162,8 @@ Testing the LEDs and buttons on the BL653 DVK
 There are 2 samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/bl654_dvk/doc/bl654_dvk.rst
+++ b/boards/arm/bl654_dvk/doc/bl654_dvk.rst
@@ -168,8 +168,8 @@ Testing the LEDs and buttons on the BL654 DVK
 There are 2 samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/bl654_sensor_board/doc/bl654_sensor_board.rst
+++ b/boards/arm/bl654_sensor_board/doc/bl654_sensor_board.rst
@@ -233,8 +233,8 @@ Testing the LED and button on the BL654 Sensor Board
 There are 2 samples that allow you to test that the button (switch) and LED on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/bl654_usb/doc/bl654_usb.rst
+++ b/boards/arm/bl654_usb/doc/bl654_usb.rst
@@ -130,7 +130,7 @@ before proceeding. These instructions were tested with version 6.1.0.
    The blue LED should start a fade pattern, signalling the bootloader is
    running.
 
-#. Compile a Zephyr application; we'll use :ref:`blinky <blinky-sample>`.
+#. Compile a Zephyr application; we'll use :zephyr:code-sample:`blinky`.
 
    .. zephyr-app-commands::
       :app: zephyr/samples/basic/blinky
@@ -171,7 +171,7 @@ Testing the LED on the BL654 USB
 There is a sample that allows you to test that the LED on
 the board is working properly with Zephyr:
 
-* :ref:`blinky-sample`
+* :zephyr:code-sample:`blinky`
 
 You can build and flash the example to make sure Zephyr is running correctly on
 your board. The LED definitions can be found in

--- a/boards/arm/black_f407ve/doc/index.rst
+++ b/boards/arm/black_f407ve/doc/index.rst
@@ -202,7 +202,7 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to BLACK_F407VE
 ---------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 Run a serial host program to connect with your board:
 

--- a/boards/arm/black_f407zg_pro/doc/index.rst
+++ b/boards/arm/black_f407zg_pro/doc/index.rst
@@ -184,7 +184,7 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to BLACK_F407ZG_PRO
 -------------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 Run a serial host program to connect with your board:
 

--- a/boards/arm/bt510/doc/bt510.rst
+++ b/boards/arm/bt510/doc/bt510.rst
@@ -239,8 +239,8 @@ Testing the LEDs and buttons on the BT510
 There are 2 samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button, LED and sensor device definitions can be found in

--- a/boards/arm/bt610/doc/bt610.rst
+++ b/boards/arm/bt610/doc/bt610.rst
@@ -593,8 +593,8 @@ Testing the LEDs and buttons on the BT610
 There are 2 samples that allow you to test that the buttons (switches) and LEDs
 on the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly
 on your board. The button, LED and sensor device definitions can be found in

--- a/boards/arm/circuitdojo_feather_nrf9160/doc/index.rst
+++ b/boards/arm/circuitdojo_feather_nrf9160/doc/index.rst
@@ -142,8 +142,8 @@ Testing the LEDs and buttons on the nRF9160 Feather
 There are 2 samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/cy8ckit_062_ble/doc/index.rst
+++ b/boards/arm/cy8ckit_062_ble/doc/index.rst
@@ -190,7 +190,7 @@ Cy_WDT_Disable().
 Running on Dual Core
 ********************
 
-#. Build the Zephyr kernel and the :ref:`button-sample` sample application:
+#. Build the Zephyr kernel and the :zephyr:code-sample:`button` sample application:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/basic/button

--- a/boards/arm/cy8cproto_062_4343w/doc/index.rst
+++ b/boards/arm/cy8cproto_062_4343w/doc/index.rst
@@ -101,7 +101,7 @@ To fetch Binary Blobs:
 Build blinking led sample
 *************************
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. code-block:: console
 

--- a/boards/arm/ebyte_e73_tbb_nrf52832/doc/index.rst
+++ b/boards/arm/ebyte_e73_tbb_nrf52832/doc/index.rst
@@ -206,8 +206,8 @@ the board are working properly with Zephyr:
 
 .. code-block:: console
 
-   :ref:`blinky-sample`
-   :ref:`button-sample`
+   :zephyr:code-sample:`blinky`
+   :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/fvp_baser_aemv8r_aarch32/doc/index.rst
+++ b/boards/arm/fvp_baser_aemv8r_aarch32/doc/index.rst
@@ -77,7 +77,7 @@ Programming
 ===========
 
 Use this configuration to build basic Zephyr applications and kernel tests in the
-Arm FVP emulated environment, for example, with the :ref:`synchronization_sample`:
+Arm FVP emulated environment, for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/arm/holyiot_yj16019/doc/index.rst
+++ b/boards/arm/holyiot_yj16019/doc/index.rst
@@ -109,7 +109,7 @@ found in :ref:`nordic_segger_flashing`. Then build and flash
 applications as usual (see :ref:`build_an_application` and
 :ref:`application_run` for more details).
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/ip_k66f/doc/index.rst
+++ b/boards/arm/ip_k66f/doc/index.rst
@@ -118,7 +118,7 @@ The default flasher is ``jlink`` using the built-in SEGGER Jlink interface.
 Flashing
 ========
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -130,7 +130,7 @@ Red LED0 should blink at 1 second delay.
 Debugging
 =========
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/lora_e5_dev_board/doc/lora_e5_dev_board.rst
+++ b/boards/arm/lora_e5_dev_board/doc/lora_e5_dev_board.rst
@@ -263,7 +263,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nrf51_ble400/doc/index.rst
+++ b/boards/arm/nrf51_ble400/doc/index.rst
@@ -199,10 +199,10 @@ Testing the LEDs and buttons in the nRF51 DK
 There are samples below that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-- :ref:`blinky-sample`
-- :ref:`button-sample`
-- :ref:`fade-led-sample`
-- :ref:`96b_carbon_multi_thread_blinky`
+- :zephyr:code-sample:`blinky`
+- :zephyr:code-sample:`button`
+- :zephyr:code-sample:`fade-led`
+- :zephyr:code-sample:`multi-thread-blinky`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/nrf51_vbluno51/doc/index.rst
+++ b/boards/arm/nrf51_vbluno51/doc/index.rst
@@ -106,7 +106,7 @@ The VBLUno51 board has on-board DAPLink (CMSIS-DAP) interface for flashing and d
 You do not need any other programming device.
 You only need to install pyOCD tool (https://pypi.python.org/pypi/pyOCD)
 
-This tutorial uses the blinky application :ref:`blinky-sample`.
+This tutorial uses the blinky application :zephyr:code-sample:`blinky`.
 
 See the :ref:`getting_started` for general information on setting up
 your development environment. Then build and flash the application in
@@ -121,7 +121,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -136,8 +136,8 @@ Testing the VBLUno51 with Zephyr: buttons, LEDs, UART, BLE
  components on the VBLUno51 board:
 
  * :ref:`hello_world`
- * :ref:`blinky-sample`
- * :ref:`button-sample`
+ * :zephyr:code-sample:`blinky`
+ * :zephyr:code-sample:`button`
  * :ref:`bluetooth-beacon-sample`
  * :ref:`peripheral_hr`
 

--- a/boards/arm/nrf51dongle_nrf51422/doc/index.rst
+++ b/boards/arm/nrf51dongle_nrf51422/doc/index.rst
@@ -132,7 +132,7 @@ Segger IC.
 Testing the LEDs on the nRF51 Dongle
 ************************************
 
-Build and flash the :ref:`blinky-sample` sample to test that the onboard LED
+Build and flash the :zephyr:code-sample:`blinky` sample to test that the onboard LED
 is working properly with Zephyr.
 
 References

--- a/boards/arm/nrf52833dk_nrf52833/doc/index.rst
+++ b/boards/arm/nrf52833dk_nrf52833/doc/index.rst
@@ -150,8 +150,8 @@ Testing the LEDs and buttons in the nRF52833 DK
 There are 2 samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/nrf52840_blip/doc/index.rst
+++ b/boards/arm/nrf52840_blip/doc/index.rst
@@ -175,8 +175,8 @@ Testing the LEDs and buttons in the nRF52840 PDK
 There are 2 samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/nrf52840dongle_nrf52840/doc/index.rst
+++ b/boards/arm/nrf52840dongle_nrf52840/doc/index.rst
@@ -140,7 +140,7 @@ device. Make sure ``nrfutil`` is installed before proceeding.
    The red LED should start a fade pattern, signalling the bootloader is
    running.
 
-#. Compile a Zephyr application; we'll use :ref:`blinky <blinky-sample>`.
+#. Compile a Zephyr application; we'll use :zephyr:code-sample:`blinky`.
 
    .. zephyr-app-commands::
       :app: zephyr/samples/basic/blinky
@@ -298,7 +298,7 @@ flashed with an offset.
 Then build and flash applications as usual (see :ref:`build_an_application` and
 :ref:`application_run` for more details).
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -321,7 +321,7 @@ Testing the LEDs and buttons on the nRF52840 Dongle
 There are 2 samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
+* :zephyr:code-sample:`blinky`
 
 You can build and program the examples to make sure Zephyr is running correctly
 on your board.

--- a/boards/arm/nrf52_adafruit_feather/doc/index.rst
+++ b/boards/arm/nrf52_adafruit_feather/doc/index.rst
@@ -166,11 +166,11 @@ Testing the LEDs and buttons on the nRF52 Adafruit Feather
 There are several samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-- :ref:`blinky-sample`
-- :ref:`button-sample`
-- :ref:`fade-led-sample`
-- :ref:`pwm-blinky-sample`
-- :ref:`96b_carbon_multi_thread_blinky`
+- :zephyr:code-sample:`blinky`
+- :zephyr:code-sample:`button`
+- :zephyr:code-sample:`fade-led`
+- :zephyr:code-sample:`pwm-blinky`
+- :zephyr:code-sample:`multi-thread-blinky`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/nrf52_vbluno52/doc/index.rst
+++ b/boards/arm/nrf52_vbluno52/doc/index.rst
@@ -101,7 +101,7 @@ Here are some sample applications that you can use to test different
 components on the VBLUno52 board:
 
 * :ref:`hello_world`
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 * :ref:`bluetooth-beacon-sample`
 * :ref:`peripheral_hr`

--- a/boards/arm/nrf5340dk_nrf5340/doc/index.rst
+++ b/boards/arm/nrf5340dk_nrf5340/doc/index.rst
@@ -310,8 +310,8 @@ Testing the LEDs and buttons in the nRF5340 DK
 There are 2 samples that allow you to test that the buttons (switches) and
 LEDs on the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/nrf9160dk_nrf9160/doc/index.rst
+++ b/boards/arm/nrf9160dk_nrf9160/doc/index.rst
@@ -245,8 +245,8 @@ Testing the LEDs and buttons in the nRF9160 DK
 There are 2 samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/nrf9161dk_nrf9161/doc/index.rst
+++ b/boards/arm/nrf9161dk_nrf9161/doc/index.rst
@@ -184,8 +184,8 @@ Testing the LEDs and buttons in the nRF9161 DK
 There are 2 samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/nucleo_c031c6/doc/index.rst
+++ b/boards/arm/nucleo_c031c6/doc/index.rst
@@ -127,7 +127,7 @@ Nucleo C031C6 board includes an ST-LINK/V2-1 embedded debug tool interface.
 Flashing an application to Nucleo C031C6
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_f030r8/doc/index.rst
+++ b/boards/arm/nucleo_f030r8/doc/index.rst
@@ -149,7 +149,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo F030R8
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -169,7 +169,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_f031k6/doc/index.rst
+++ b/boards/arm/nucleo_f031k6/doc/index.rst
@@ -116,7 +116,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo F030R8
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -129,7 +129,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_f042k6/doc/index.rst
+++ b/boards/arm/nucleo_f042k6/doc/index.rst
@@ -116,7 +116,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo F042K6
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -129,7 +129,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_f070rb/doc/index.rst
+++ b/boards/arm/nucleo_f070rb/doc/index.rst
@@ -144,7 +144,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo F070RB
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_f091rc/doc/index.rst
+++ b/boards/arm/nucleo_f091rc/doc/index.rst
@@ -158,7 +158,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo F091RC
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_f103rb/doc/index.rst
+++ b/boards/arm/nucleo_f103rb/doc/index.rst
@@ -151,7 +151,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo F103RB
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -164,7 +164,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_f334r8/doc/index.rst
+++ b/boards/arm/nucleo_f334r8/doc/index.rst
@@ -143,7 +143,7 @@ Flashing an application to Nucleo F334R8
 
 Connect the Nucleo F334R8 to your host computer using the USB port,
 then build and flash an application. Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -156,7 +156,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for
-the :ref:`blinky-sample` application.
+the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_g031k8/doc/index.rst
+++ b/boards/arm/nucleo_g031k8/doc/index.rst
@@ -123,7 +123,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo G031K8
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_g070rb/doc/index.rst
+++ b/boards/arm/nucleo_g070rb/doc/index.rst
@@ -155,7 +155,7 @@ Nucleo G070RB board includes an ST-LINK/V2-1 embedded debug tool interface.
 Flashing an application to Nucleo G070RB
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_g071rb/doc/index.rst
+++ b/boards/arm/nucleo_g071rb/doc/index.rst
@@ -159,7 +159,7 @@ Nucleo G071RB board includes an ST-LINK/V3 embedded debug tool interface.
 Flashing an application to Nucleo G071RB
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_g0b1re/doc/index.rst
+++ b/boards/arm/nucleo_g0b1re/doc/index.rst
@@ -168,7 +168,7 @@ following pyocd command:
 Flashing an application to Nucleo G0B1RE
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_h563zi/doc/index.rst
+++ b/boards/arm/nucleo_h563zi/doc/index.rst
@@ -294,7 +294,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_h745zi_q/doc/index.rst
+++ b/boards/arm/nucleo_h745zi_q/doc/index.rst
@@ -240,7 +240,7 @@ You should see the following message on the console:
 Similarly, you can build and flash samples on the M4 target. For this, please
 take care of the resource sharing (UART port used for console for instance).
 
-Here is an example for the :ref:`blinky-sample` application on M4 core.
+Here is an example for the :zephyr:code-sample:`blinky` application on M4 core.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_l011k4/doc/index.rst
+++ b/boards/arm/nucleo_l011k4/doc/index.rst
@@ -131,7 +131,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo L011K4
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_l031k6/doc/index.rst
+++ b/boards/arm/nucleo_l031k6/doc/index.rst
@@ -124,7 +124,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo L031K6
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_l053r8/doc/index.rst
+++ b/boards/arm/nucleo_l053r8/doc/index.rst
@@ -140,7 +140,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo L053R8
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_l073rz/doc/index.rst
+++ b/boards/arm/nucleo_l073rz/doc/index.rst
@@ -154,7 +154,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo L073RZ
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_l152re/doc/index.rst
+++ b/boards/arm/nucleo_l152re/doc/index.rst
@@ -148,7 +148,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo L152RE
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_u575zi_q/doc/index.rst
+++ b/boards/arm/nucleo_u575zi_q/doc/index.rst
@@ -289,7 +289,7 @@ Debugging
 =========
 
 Default flasher for this board is openocd. It could be used in the usual way.
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -288,7 +288,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_wba52cg/doc/nucleo_wba52cg.rst
+++ b/boards/arm/nucleo_wba52cg/doc/nucleo_wba52cg.rst
@@ -232,7 +232,7 @@ as flashing tool by default.
 Flashing an application to Nucleo WBA52CG
 -----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/nucleo_wl55jc/doc/nucleo_wl55jc.rst
+++ b/boards/arm/nucleo_wl55jc/doc/nucleo_wl55jc.rst
@@ -307,7 +307,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/olimex_lora_stm32wl_devkit/doc/olimex_lora_stm32wl_devkit.rst
+++ b/boards/arm/olimex_lora_stm32wl_devkit/doc/olimex_lora_stm32wl_devkit.rst
@@ -136,7 +136,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/olimex_stm32_h103/doc/index.rst
+++ b/boards/arm/olimex_stm32_h103/doc/index.rst
@@ -208,7 +208,7 @@ The ``blackmagicprobe`` can also be used to program the device.
 Flashing
 ========
 
-Here is an example for the :ref:`button-sample` application.
+Here is an example for the :zephyr:code-sample:`button` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/button

--- a/boards/arm/olimexino_stm32/doc/index.rst
+++ b/boards/arm/olimexino_stm32/doc/index.rst
@@ -414,7 +414,7 @@ Flashing an Application to OLIMEXINO-STM32
 
 To upload an application to the OLIMEXINO-STM32 board a TTL(3.3V)
 serial adapter is required. This tutorial uses the
-:ref:`button-sample` sample application.
+:zephyr:code-sample:`button` sample application.
 
 #. Connect the serial cable to the UEXT lines of the UART
    interface (pin #3=TX and pin #4=RX).

--- a/boards/arm/particle_argon/doc/index.rst
+++ b/boards/arm/particle_argon/doc/index.rst
@@ -160,8 +160,8 @@ Testing the LEDs and buttons
 There are 2 samples that allow you to test that the buttons (switches) and
 LEDs on the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board.

--- a/boards/arm/particle_boron/doc/index.rst
+++ b/boards/arm/particle_boron/doc/index.rst
@@ -156,8 +156,8 @@ Testing the LEDs and buttons
 There are 2 samples that allow you to test that the buttons (switches) and
 LEDs on the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board.

--- a/boards/arm/particle_xenon/doc/index.rst
+++ b/boards/arm/particle_xenon/doc/index.rst
@@ -161,8 +161,8 @@ Testing the LEDs and buttons
 There are 2 samples that allow you to test that the buttons (switches) and
 LEDs on the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board.

--- a/boards/arm/qemu_cortex_m0/doc/index.rst
+++ b/boards/arm/qemu_cortex_m0/doc/index.rst
@@ -64,7 +64,7 @@ Programming and Debugging
 *************************
 
 Use this configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment, for example, with the :ref:`synchronization_sample`:
+emulated environment, for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/arm/qemu_cortex_m3/doc/index.rst
+++ b/boards/arm/qemu_cortex_m3/doc/index.rst
@@ -70,7 +70,7 @@ Programming and Debugging
 *************************
 
 Use this configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment, for example, with the :ref:`synchronization_sample`:
+emulated environment, for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/arm/qemu_cortex_r5/doc/index.rst
+++ b/boards/arm/qemu_cortex_r5/doc/index.rst
@@ -64,7 +64,7 @@ Programming and Debugging
 *************************
 
 Use this configuration to run basic Zephyr applications and kernel tests in the
-QEMU emulated environment, for example, with the :ref:`synchronization_sample`:
+QEMU emulated environment, for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/arm/reel_board/doc/index.rst
+++ b/boards/arm/reel_board/doc/index.rst
@@ -544,8 +544,8 @@ Testing the LEDs and buttons
 There are 2 samples that allow you to test that the buttons (switches) and
 LEDs on the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board.

--- a/boards/arm/rpi_pico/doc/index.rst
+++ b/boards/arm/rpi_pico/doc/index.rst
@@ -152,7 +152,7 @@ Using SEGGER JLink
 You can Flash the rpi_pico with a SEGGER JLink debug probe as described in
 :ref:`Building, Flashing and Debugging <west-flashing>`.
 
-Here is an example of building and flashing the :ref:`blinky-sample` application.
+Here is an example of building and flashing the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -187,7 +187,7 @@ Depending on the interface used (such as JLink), you might need to
 checkout to a branch that supports this interface, before proceeding.
 Build and install OpenOCD as described in the README.
 
-Here is an example of building and flashing the :ref:`blinky-sample` application.
+Here is an example of building and flashing the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -247,7 +247,7 @@ Using OpenOCD
 
 Install OpenOCD as described for flashing the board.
 
-Here is an example for debugging the :ref:`blinky-sample` application.
+Here is an example for debugging the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/ruuvi_ruuvitag/doc/index.rst
+++ b/boards/arm/ruuvi_ruuvitag/doc/index.rst
@@ -168,8 +168,8 @@ Testing the LEDs and buttons on the RuuviTag
 There are 2 samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in :file:`boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts`.

--- a/boards/arm/s32z270dc2_r52/doc/index.rst
+++ b/boards/arm/s32z270dc2_r52/doc/index.rst
@@ -99,7 +99,7 @@ using GPIO driver or configuring the pinmuxing for the device drivers.
 +-------------------+-------------+
 
 This board does not include user LED's or switches, which are needed for some
-of the samples such as :ref:`blinky-sample` or :ref:`button-sample`.
+of the samples such as :zephyr:code-sample:`blinky` or :zephyr:code-sample:`button`.
 Follow the steps described in the sample description to enable support for this
 board.
 

--- a/boards/arm/segger_trb_stm32f407/doc/index.rst
+++ b/boards/arm/segger_trb_stm32f407/doc/index.rst
@@ -109,7 +109,7 @@ Flashing an application to the SEGGER-TRB-STM32F407
 Connect the J-Trace/J-Link USB dongle to your host computer and to the JTAG
 port of the SEGGER-TRB-STM32F407 board. Then build and flash an application.
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -121,7 +121,7 @@ After resetting the board, you should see LED0 blink with a 1 second interval.
 Debugging
 =========
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/serpente/doc/index.rst
+++ b/boards/arm/serpente/doc/index.rst
@@ -87,7 +87,7 @@ can be entered by quickly tapping the reset button twice.
 Flashing
 ========
 
-#. Build the Zephyr kernel and the :ref:`blinky-sample` sample application:
+#. Build the Zephyr kernel and the :zephyr:code-sample:`blinky` sample application:
 
    .. zephyr-app-commands::
       :zephyr-app: samples/basic/blinky

--- a/boards/arm/sparkfun_thing_plus_nrf9160/doc/index.rst
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/doc/index.rst
@@ -137,8 +137,8 @@ Testing the LEDs and buttons on the nRF9160 Thing Plus
 There are 2 samples that allow you to test that the buttons (switches) and LEDs on
 the board are working properly with Zephyr:
 
-* :ref:`blinky-sample`
-* :ref:`button-sample`
+* :zephyr:code-sample:`blinky`
+* :zephyr:code-sample:`button`
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/stm3210c_eval/doc/index.rst
+++ b/boards/arm/stm3210c_eval/doc/index.rst
@@ -125,7 +125,7 @@ Flashing an application to STM3210C-EVAL
 Connect the STM3210C-EVAL to your host computer using the USB port, then build
 and flash an application in the usual way.
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32373c_eval/doc/index.rst
+++ b/boards/arm/stm32373c_eval/doc/index.rst
@@ -126,7 +126,7 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to STM32373C-EVAL
 -----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -139,7 +139,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32_min_dev/doc/index.rst
+++ b/boards/arm/stm32_min_dev/doc/index.rst
@@ -161,7 +161,7 @@ built and flashed in the usual way (see :ref:`build_an_application` and
 Flashing
 ========
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32f030_demo/doc/index.rst
+++ b/boards/arm/stm32f030_demo/doc/index.rst
@@ -87,7 +87,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to STM32F030 DEMO BOARD
 -----------------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -100,7 +100,7 @@ Debugging
 =========
 
 You can debug an application in the usual way. Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32f072_eval/doc/index.rst
+++ b/boards/arm/stm32f072_eval/doc/index.rst
@@ -156,7 +156,7 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to STM32F072-EVAL
 -------------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -169,7 +169,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32f0_disco/doc/index.rst
+++ b/boards/arm/stm32f0_disco/doc/index.rst
@@ -107,7 +107,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application to Nucleo F030R8
 ----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -120,7 +120,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32f103_mini/doc/index.rst
+++ b/boards/arm/stm32f103_mini/doc/index.rst
@@ -133,7 +133,7 @@ pattern, which can be triggered by using the BOOT0 pin.
 Flashing an application to stm32f103 mini
 -----------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -146,7 +146,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32f411e_disco/doc/index.rst
+++ b/boards/arm/stm32f411e_disco/doc/index.rst
@@ -141,7 +141,7 @@ Flashing an application to STM32F411E-DISCO
 Connect the STM32F411E-DISCO Discovery kit to your host computer using the
 USB port. Then build and flash an application.
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -162,7 +162,7 @@ Debugging
 =========
 
 You can debug applications in the usual way. Here is an example for
-the :ref:`blinky-sample` application.
+the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32f4_disco/doc/index.rst
+++ b/boards/arm/stm32f4_disco/doc/index.rst
@@ -169,7 +169,7 @@ This interface is supported by the openocd version included in Zephyr SDK.
 Flashing an application to STM32F4DISCOVERY
 -------------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 Run a serial host program to connect with your board:
 

--- a/boards/arm/stm32g0316_disco/doc/index.rst
+++ b/boards/arm/stm32g0316_disco/doc/index.rst
@@ -100,7 +100,7 @@ the following pyocd command:
 Flashing an application to the STM32G0316-DISCO
 -----------------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32g071b_disco/doc/index.rst
+++ b/boards/arm/stm32g071b_disco/doc/index.rst
@@ -130,7 +130,7 @@ The STM32G071B Discovery board includes an ST-LINK/V2-1 embedded debug tool inte
 Flashing an application to the STM32G071B_DISCO
 -----------------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32g081b_eval/doc/index.rst
+++ b/boards/arm/stm32g081b_eval/doc/index.rst
@@ -168,7 +168,7 @@ The STM32G081B Evaluation board includes an ST-LINK/V2-1 embedded debug tool int
 Flashing an application to the STM32G081B_EVAL
 ----------------------------------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32h747i_disco/doc/index.rst
+++ b/boards/arm/stm32h747i_disco/doc/index.rst
@@ -258,7 +258,7 @@ You should see the following message on the console:
 Similarly, you can build and flash samples on the M4 target. For this, please
 take care of the resource sharing (UART port used for console for instance).
 
-Here is an example for the :ref:`blinky-sample` application on M4 core.
+Here is an example for the :zephyr:code-sample:`blinky` application on M4 core.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32l1_disco/doc/index.rst
+++ b/boards/arm/stm32l1_disco/doc/index.rst
@@ -143,7 +143,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application
 -----------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -156,7 +156,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/stm32vl_disco/doc/index.rst
+++ b/boards/arm/stm32vl_disco/doc/index.rst
@@ -137,7 +137,7 @@ This interface is supported by the openocd version included in the Zephyr SDK.
 Flashing an application
 -----------------------
 
-Here is an example for the :ref:`blinky-sample` application.
+Here is an example for the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -150,7 +150,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm/thingy52_nrf52832/doc/index.rst
+++ b/boards/arm/thingy52_nrf52832/doc/index.rst
@@ -362,7 +362,7 @@ debugger. A development board with a Debug out connector such as the
 Testing board features
 **********************
 
-The green lightwell LED can be tested with the :ref:`blinky-sample` example.
+The green lightwell LED can be tested with the :zephyr:code-sample:`blinky` example.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/arm64/fvp_base_revc_2xaemv8a/doc/index.rst
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/doc/index.rst
@@ -72,7 +72,7 @@ Programming
 ===========
 
 Use this configuration to build basic Zephyr applications and kernel tests in the
-ARM FVP emulated environment, for example, with the :ref:`synchronization_sample`:
+ARM FVP emulated environment, for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/arm64/fvp_baser_aemv8r/doc/index.rst
+++ b/boards/arm64/fvp_baser_aemv8r/doc/index.rst
@@ -86,7 +86,7 @@ Programming
 ===========
 
 Use this configuration to build basic Zephyr applications and kernel tests in the
-Arm FVP emulated environment, for example, with the :ref:`synchronization_sample`:
+Arm FVP emulated environment, for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/arm64/mimx8mm_evk/doc/index.rst
+++ b/boards/arm64/mimx8mm_evk/doc/index.rst
@@ -92,7 +92,7 @@ Or kick SMP zephyr.bin:
 
 
 Use this configuration to run basic Zephyr applications and kernel tests,
-for example, with the :ref:`synchronization_sample`:
+for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/arm64/mimx8mn_evk/doc/index.rst
+++ b/boards/arm64/mimx8mn_evk/doc/index.rst
@@ -92,7 +92,7 @@ Or kick SMP zephyr.bin:
 
 
 Use this configuration to run basic Zephyr applications and kernel tests,
-for example, with the :ref:`synchronization_sample`:
+for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/arm64/mimx8mp_evk/doc/index.rst
+++ b/boards/arm64/mimx8mp_evk/doc/index.rst
@@ -91,7 +91,7 @@ Or kick SMP zephyr.bin:
     mw 303d0518 f 1; fatload mmc 1:1 0xc0000000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; cpu 2 release 0xc0000000
 
 Use this configuration to run basic Zephyr applications and kernel tests,
-for example, with the :ref:`synchronization_sample`:
+for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/arm64/mimx93_evk/doc/index.rst
+++ b/boards/arm64/mimx93_evk/doc/index.rst
@@ -97,7 +97,7 @@ Or use the following command to kick zephyr.bin to Cortex-A55 Core0:
 
 
 Use this configuration to run basic Zephyr applications and kernel tests,
-for example, with the :ref:`synchronization_sample`:
+for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/arm64/nxp_ls1046ardb/doc/index.rst
+++ b/boards/arm64/nxp_ls1046ardb/doc/index.rst
@@ -84,7 +84,7 @@ Programming and Debugging
 *************************
 
 Use the following configuration to run basic Zephyr applications and
-kernel tests on LS1046A RDB board. For example, with the :ref:`synchronization_sample`:
+kernel tests on LS1046A RDB board. For example, with the :zephyr:code-sample:`synchronization` sample:
 
 1. Non-SMP mode
 

--- a/boards/arm64/qemu_cortex_a53/doc/index.rst
+++ b/boards/arm64/qemu_cortex_a53/doc/index.rst
@@ -60,7 +60,7 @@ Programming and Debugging
 *************************
 
 Use this configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment, for example, with the :ref:`synchronization_sample`:
+emulated environment, for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/arm64/xenvm/doc/index.rst
+++ b/boards/arm64/xenvm/doc/index.rst
@@ -94,7 +94,7 @@ Building and Running
 ********************
 
 Use this configuration to run basic Zephyr applications and kernel tests as Xen
-guest, for example, with the :ref:`synchronization_sample`:
+guest, for example, with the :zephyr:code-sample:`synchronization` sample:
 
 - if your hardware is based on GICv2:
 

--- a/boards/mips/qemu_malta/doc/index.rst
+++ b/boards/mips/qemu_malta/doc/index.rst
@@ -58,7 +58,7 @@ Programming and Debugging
 *************************
 
 Use this configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment, for example, with the :ref:`synchronization_sample`:
+emulated environment, for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization
@@ -90,7 +90,7 @@ Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
 Big-Endian
 ==========
 
-Use this configuration to run :ref:`synchronization_sample` in big-endian mode:
+Use this configuration to run :zephyr:code-sample:`synchronization` sample in big-endian mode:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/nios2/qemu_nios2/doc/index.rst
+++ b/boards/nios2/qemu_nios2/doc/index.rst
@@ -74,7 +74,7 @@ Programming and Debugging
 *************************
 
 Use this configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment, for example, with the :ref:`synchronization_sample`:
+emulated environment, for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/riscv/longan_nano/doc/index.rst
+++ b/boards/riscv/longan_nano/doc/index.rst
@@ -84,7 +84,7 @@ Programming and debugging
 Building & Flashing
 ===================
 
-Here is an example for building the :ref:`blinky-sample` application.
+Here is an example for building the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
@@ -105,7 +105,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`blinky-sample` application.
+:zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky

--- a/boards/riscv/qemu_riscv32/doc/index.rst
+++ b/boards/riscv/qemu_riscv32/doc/index.rst
@@ -20,7 +20,7 @@ Flashing
 
 While this board is emulated and you can't "flash" it, you can use this
 configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment. For example, with the :ref:`synchronization_sample`:
+emulated environment. For example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/riscv/qemu_riscv32e/doc/index.rst
+++ b/boards/riscv/qemu_riscv32e/doc/index.rst
@@ -20,7 +20,7 @@ Flashing
 
 While this board is emulated and you can't "flash" it, you can use this
 configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment. For example, with the :ref:`synchronization_sample`:
+emulated environment. For example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/riscv/qemu_riscv64/doc/index.rst
+++ b/boards/riscv/qemu_riscv64/doc/index.rst
@@ -29,7 +29,7 @@ Flashing
 
 While this board is emulated and you can't "flash" it, you can use this
 configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment. For example, with the :ref:`synchronization_sample`:
+emulated environment. For example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/sparc/qemu_leon3/doc/index.rst
+++ b/boards/sparc/qemu_leon3/doc/index.rst
@@ -20,7 +20,7 @@ Flashing
 
 While this board is emulated and you can't "flash" it, you can use this
 configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment. For example, with the :ref:`synchronization_sample`:
+emulated environment. For example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/x86/qemu_x86/doc/index.rst
+++ b/boards/x86/qemu_x86/doc/index.rst
@@ -79,7 +79,7 @@ Flashing
 
 While this board is emulated and you can't "flash" it, you can use this
 configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment. For example, with the :ref:`synchronization_sample`:
+emulated environment. For example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/boards/xtensa/qemu_xtensa/doc/index.rst
+++ b/boards/xtensa/qemu_xtensa/doc/index.rst
@@ -13,7 +13,7 @@ Programming and Debugging
 *************************
 
 Use this configuration to run basic Zephyr applications and kernel tests in the QEMU
-emulated environment, for example, with the :ref:`synchronization_sample`:
+emulated environment, for example, with the :zephyr:code-sample:`synchronization` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization

--- a/doc/_extensions/zephyr/domain.py
+++ b/doc/_extensions/zephyr/domain.py
@@ -94,18 +94,6 @@ class ConvertCodeSampleNode(SphinxTransform):
             index = parent.index(node)
             siblings_to_move = parent.children[index + 1 :]
 
-            # TODO remove once all :ref:`sample-xyz` have migrated to :zephyr:code-sample:`xyz`
-            # as this is the recommended way to reference code samples going forward.
-            self.env.app.env.domaindata["std"]["labels"][node["id"]] = (
-                self.env.docname,
-                node["id"],
-                node["name"],
-            )
-            self.env.app.env.domaindata["std"]["anonlabels"][node["id"]] = (
-                self.env.docname,
-                node["id"],
-            )
-
             # Create a new section
             new_section = nodes.section(ids=[node["id"]])
             new_section += nodes.title(text=node["name"])

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -552,6 +552,7 @@ a.internal:visited code.literal {
 
 .rst-content .admonition.toggle button {
     display: inline-flex;
+    color: var(--admonition-note-title-color);
 }
 
 .rst-content .admonition.toggle .tb-icon {

--- a/doc/build/dts/api-usage.rst
+++ b/doc/build/dts/api-usage.rst
@@ -47,7 +47,7 @@ By node label
 By alias
    Use :c:func:`DT_ALIAS()` to get a node identifier for a property of the
    special ``/aliases`` node. This is sometimes done by applications (like
-   :ref:`blinky <blinky-sample>`, which uses the ``led0`` alias) that need to
+   :zephyr:code-sample:`blinky`, which uses the ``led0`` alias) that need to
    refer to *some* device of a particular type ("the board's user LED") but
    don't care which one is used.
 

--- a/doc/build/dts/design.rst
+++ b/doc/build/dts/design.rst
@@ -22,7 +22,7 @@ Examples
 
 - In-tree sample applications shall use :ref:`aliases <dt-alias-chosen>` to
   determine which of multiple possible generic devices of a given type will be
-  used in the current build. For example, the :ref:`blinky-sample` uses this to
+  used in the current build. For example, the :zephyr:code-sample:`blinky` sample uses this to
   determine the LED to blink.
 
 - Boot-time pin muxing and pin control for new SoCs shall be accomplished via a

--- a/doc/build/dts/howtos.rst
+++ b/doc/build/dts/howtos.rst
@@ -630,6 +630,6 @@ Applications that depend on board-specific devices
 
 One way to allow application code to run unmodified on multiple boards is by
 supporting a devicetree alias to specify the hardware specific portions, as is
-done in the :ref:`blinky-sample`. The application can then be configured in
+done in the :zephyr:code-sample:`blinky` sample. The application can then be configured in
 :ref:`BOARD.dts <devicetree-in-out-files>` files or via :ref:`devicetree
 overlays <use-dt-overlays>`.

--- a/doc/build/dts/intro-syntax-structure.rst
+++ b/doc/build/dts/intro-syntax-structure.rst
@@ -468,7 +468,7 @@ Using its node label ``uart0``, the same node is set as the value of the chosen
 
 Zephyr sample applications sometimes use aliases to allow overriding the
 particular hardware device used by the application in a generic way. For
-example, :ref:`blinky-sample` uses this to abstract the LED to blink via the
+example, :zephyr:code-sample:`blinky` uses this to abstract the LED to blink via the
 ``led0`` alias.
 
 The ``/chosen`` node's properties are used to configure system- or

--- a/doc/build/kconfig/tips.rst
+++ b/doc/build/kconfig/tips.rst
@@ -83,7 +83,7 @@ An application-specific devicetree :ref:`binding <dt-bindings>` to identify
 board specific properties may be appropriate. See
 :zephyr_file:`tests/drivers/gpio/gpio_basic_api` for an example.
 
-For applications, see :ref:`blinky-sample` for a devicetree-based alternative.
+For applications, see :zephyr:code-sample:`blinky` for a devicetree-based alternative.
 
 ``select`` statements
 *********************

--- a/doc/develop/beyond-GSG.rst
+++ b/doc/develop/beyond-GSG.rst
@@ -184,7 +184,7 @@ Additional information about building applications can be found in the
 Build Blinky
 ============
 
-Let's build the :ref:`blinky-sample` sample application.
+Let's build the :zephyr:code-sample:`blinky` sample application.
 
 Zephyr applications are built to run on specific hardware, called a
 "board"\ [#board_misnomer]_. We'll use the Phytec :ref:`reel_board

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -650,14 +650,14 @@ Build the Blinky Sample
 
 .. note::
 
-   Blinky is compatible with most, but not all, :ref:`boards`. If your board
+   :zephyr:code-sample:`blinky` is compatible with most, but not all, :ref:`boards`. If your board
    does not meet Blinky's :ref:`blinky-sample-requirements`, then
    :ref:`hello_world` is a good alternative.
 
    If you are unsure what name west uses for your board, ``west boards``
    can be used to obtain a list of all boards Zephyr supports.
 
-Build the :ref:`blinky-sample` with :ref:`west build <west-building>`, changing
+Build the :zephyr:code-sample:`blinky` with :ref:`west build <west-building>`, changing
 ``<your-board-name>`` appropriately for your board:
 
 .. tabs::

--- a/doc/services/tracing/index.rst
+++ b/doc/services/tracing/index.rst
@@ -107,7 +107,7 @@ supported in Zephyr).
 To enable tracing support with `SEGGER SystemView`_ add the configuration option
 :kconfig:option:`CONFIG_SEGGER_SYSTEMVIEW` to your project configuration file and set
 it to *y*. For example, this can be added to the
-:ref:`synchronization_sample` to visualize fast switching between threads.
+:zephyr:code-sample:`synchronization` sample to visualize fast switching between threads.
 SystemView can also be used for post-mortem tracing, which can be enabled with
 `CONFIG_SEGGER_SYSVIEW_POST_MORTEM_MODE`. In this mode, a debugger can
 be attached after the system has crashed using ``west attach`` after which the

--- a/samples/basic/blinky/README.rst
+++ b/samples/basic/blinky/README.rst
@@ -1,4 +1,4 @@
-.. zephyr:code-sample:: blinky-sample
+.. zephyr:code-sample:: blinky
    :name: Blinky
    :relevant-api: gpio_interface
 
@@ -16,7 +16,7 @@ The source code shows how to:
 #. Configure the GPIO pin as an output
 #. Toggle the pin forever
 
-See :zephyr:code-sample:`pwm-blinky-sample` for a similar sample that uses the PWM API instead.
+See :zephyr:code-sample:`pwm-blinky` for a similar sample that uses the PWM API instead.
 
 .. _blinky-sample-requirements:
 

--- a/samples/basic/blinky_pwm/README.rst
+++ b/samples/basic/blinky_pwm/README.rst
@@ -1,4 +1,4 @@
-.. zephyr:code-sample:: pwm-blinky-sample
+.. zephyr:code-sample:: pwm-blinky
    :name: PWM Blinky
    :relevant-api: pwm_interface
 
@@ -8,7 +8,7 @@ Overview
 ********
 
 This application blinks an LED using the :ref:`PWM API <pwm_api>`. See
-:zephyr:code-sample:`blinky-sample` for a GPIO-based sample.
+:zephyr:code-sample:`blinky` for a GPIO-based sample.
 
 The LED starts blinking at a 1 Hz frequency. The frequency doubles every 4
 seconds until it reaches 128 Hz. The frequency will then be halved every 4

--- a/samples/basic/button/README.rst
+++ b/samples/basic/button/README.rst
@@ -1,4 +1,4 @@
-.. zephyr:code-sample:: button-sample
+.. zephyr:code-sample:: button
    :name: Button
    :relevant-api: gpio_interface
 
@@ -28,7 +28,7 @@ You may see additional build errors if the ``sw0`` alias exists, but is not
 properly defined.
 
 The sample additionally supports an optional ``led0`` devicetree alias. This is
-the same alias used by the :zephyr:code-sample:`blinky-sample`. If this is provided, the LED
+the same alias used by the :zephyr:code-sample:`blinky` sample. If this is provided, the LED
 will be turned on when the button is pressed, and turned off off when it is
 released.
 

--- a/samples/basic/custom_dts_binding/README.rst
+++ b/samples/basic/custom_dts_binding/README.rst
@@ -1,7 +1,8 @@
-.. _gpio-custom-dts-binding-sample:
+.. zephyr:code-sample:: gpio-custom-dts-binding
+   :name: GPIO with custom Devicetree binding
+   :relevant-api: gpio_interface devicetree-generic-id devicetree-generic-exist
 
-GPIO with custom devicetree binding
-###################################
+   Use custom Devicetree binding to control a GPIO.
 
 Overview
 ********

--- a/samples/basic/fade_led/README.rst
+++ b/samples/basic/fade_led/README.rst
@@ -1,7 +1,8 @@
-.. _fade-led-sample:
+.. zephyr:code-sample:: fade-led
+   :name: Fade LED
+   :relevant-api: pwm_interface
 
-Fade LED
-########
+   Fade an LED using the PWM API.
 
 Overview
 ********
@@ -18,7 +19,7 @@ Requirements and Wiring
 ***********************
 
 This sample has the same requirements and wiring considerations as the
-:zephyr:code-sample:`pwm-blinky-sample`.
+:zephyr:code-sample:`pwm-blinky` sample.
 
 Building and Running
 ********************

--- a/samples/basic/hash_map/README.rst
+++ b/samples/basic/hash_map/README.rst
@@ -1,5 +1,5 @@
 .. zephyr:code-sample:: system_hashmap
-   :name: System Hashmap
+   :name: System hashmap
    :relevant-api: hashmap_apis
 
    Insert, replace, and remove entries in a hashmap.
@@ -7,7 +7,7 @@
 Overview
 ********
 
-This is a simple example that repeatedly
+This is a simple example that repeatedly:
 
 * inserts up to ``CONFIG_TEST_LIB_HASH_MAP_MAX_ENTRIES``
 * replaces up to the same number that were previously inserted

--- a/samples/basic/minimal/README.rst
+++ b/samples/basic/minimal/README.rst
@@ -1,7 +1,7 @@
-.. _minimal_sample:
+.. zephyr:code-sample:: minimal
+   :name: Minimal footprint
 
-Minimal footprint
-#################
+   Measure Zephyr's minimal ROM footprint in different configurations.
 
 Overview
 ********

--- a/samples/basic/rgb_led/README.rst
+++ b/samples/basic/rgb_led/README.rst
@@ -1,12 +1,13 @@
-.. _rgb-led-sample:
+.. zephyr:code-sample:: rgb-led
+   :name: PWM RGB LED
+   :relevant-api: pwm_interface
 
-PWM: RGB LED
-############
+   Drive an RGB LED using the PWM API.
 
 Overview
 ********
 
-This is a sample app which drives an RGB LED using PWM.
+This is a sample app which drives an RGB LED using the :ref:`PWM API <pwm_api>`.
 
 There are three single-color component LEDs in an RGB LED. Each component LED
 is driven by a PWM port where the pulse width is changed from zero to the period

--- a/samples/basic/servo_motor/README.rst
+++ b/samples/basic/servo_motor/README.rst
@@ -1,12 +1,13 @@
-.. _servo-motor-sample:
+.. zephyr:code-sample:: servo-motor
+   :name: Servomotor
+   :relevant-api: pwm_interface
 
-Servomotor
-##########
+   Drive a servomotor using the PWM API.
 
 Overview
 ********
 
-This is a sample app which drives a servomotor using PWM.
+This is a sample app which drives a servomotor using the :ref:`PWM API <pwm_api>`.
 
 The sample rotates a servomotor back and forth in the 180 degree range with a
 PWM control signal.

--- a/samples/basic/sys_heap/README.rst
+++ b/samples/basic/sys_heap/README.rst
@@ -1,7 +1,7 @@
-.. _system_heap:
+.. zephyr:code-sample:: sys-heap
+   :name: System heap
 
-System heap
-###########
+   Print system heap usage to the console.
 
 Overview
 ********

--- a/samples/basic/threads/README.rst
+++ b/samples/basic/threads/README.rst
@@ -1,7 +1,8 @@
-.. _96b_carbon_multi_thread_blinky:
+.. zephyr:code-sample:: multi-thread-blinky
+   :name: Basic thread manipulation
+   :relevant-api: gpio_interface thread_apis
 
-Basic Thread Example
-####################
+   Spawn multiple threads that blink LEDs and print information to the console.
 
 Overview
 ********

--- a/samples/bluetooth/encrypted_advertising/README.rst
+++ b/samples/bluetooth/encrypted_advertising/README.rst
@@ -25,8 +25,8 @@ Requirements
 ************
 
 * Two boards with Bluetooth Low Energy support
-* Two boards with a push button connected via a GPIO pin, see :zephyr:code-sample:`button-sample`
-  for more details
+* Two boards with a push button connected via a GPIO pin, see the :zephyr:code-sample:`button`
+  sample for more details
 
 Building and Running
 ********************

--- a/samples/synchronization/README.rst
+++ b/samples/synchronization/README.rst
@@ -1,5 +1,5 @@
-.. zephyr:code-sample:: synchronization_sample
-   :name: Synchronization Sample
+.. zephyr:code-sample:: synchronization
+   :name: Basic Synchronization
    :relevant-api: thread_apis semaphore_apis
 
    Manipulate basic kernel synchronization primitives.


### PR DESCRIPTION
See commit messages for more details.
Beyond the pure migration of the samples, this also drops the ability to reference code samples using `:ref:` as `:zephyr:code-sample:` role should be used instead. 
Also fixes a minor styling issue regarding text color in the collapsible admonitions.