### PR TITLE
kernel: Add missing argument to __ASSERT()

### DIFF
--- a/kernel/dynamic.c
+++ b/kernel/dynamic.c
@@ -112,7 +112,8 @@ static void dyn_cb(const struct k_thread *thread, void *user_data)
 	struct dyn_cb_data *const data = (struct dyn_cb_data *)user_data;
 
 	if (data->stack == (k_thread_stack_t *)thread->stack_info.start) {
-		__ASSERT(data->tid == NULL, "stack %p is associated with more than one thread!");
+		__ASSERT(data->tid == NULL, "stack %p is associated with more than one thread!",
+			 data->stack);
 		data->tid = (k_tid_t)thread;
 	}
 }


### PR DESCRIPTION
Fix using __ASSERT() without specified by format argument.