### PR TITLE
ci: bump zephyrproject-rtos/action-first-interaction v1.1.1-zephyr-4

### DIFF
--- a/.github/workflows/greet_first_time_contributor.yml
+++ b/.github/workflows/greet_first_time_contributor.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: zephyrproject-rtos/action-first-interaction@v1.1.1-zephyr-3
+      - uses: zephyrproject-rtos/action-first-interaction@v1.1.1-zephyr-4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
A recent fix in https://github.com/zephyrproject-rtos/action-first-interaction/pull/5 is now making the bot's comments on PR be actual comments, not PR "review comments".