### PR TITLE
boards: arm: nucleo_f091rc: enable CAN support

### DIFF
--- a/boards/arm/nucleo_f091rc/doc/index.rst
+++ b/boards/arm/nucleo_f091rc/doc/index.rst
@@ -98,6 +98,8 @@ The Zephyr nucleo_f091rc board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | SPI controller                      |
 +-----------+------------+-------------------------------------+
+| CAN       | on-chip    | CAN controller                      |
++-----------+------------+-------------------------------------+
 | ADC       | on-chip    | ADC controller                      |
 +-----------+------------+-------------------------------------+
 | DAC       | on-chip    | DAC controller                      |
@@ -132,7 +134,8 @@ Default Zephyr Peripheral Mapping:
 - UART_1 TX/RX : PB6/PB7
 - UART_2 TX/RX : PA2/PA3 (ST-Link Virtual COM Port)
 - I2C1 SCL/SDA : PB8/PB9 (Arduino I2C)
-- I2C2 SCL/SDA : PA11/PA12
+- I2C2 SCL/SDA : PA11/PA12 (disabled by default, uses same pins as CAN)
+- CAN RX/TX : PA11/PA12
 - SPI1 SCK/MISO/MOSI : PA5/PA6/PA7 (Arduino SPI)
 - SPI2 SCK/MISO/MOSI : PB13/PB14/PB15
 - USER_PB : PC13

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -20,6 +20,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,canbus = &can1;
 	};
 
 	leds: leds {
@@ -105,10 +106,18 @@
 };
 
 &i2c2 {
+	/* Pin conflict with can1. Enable only with can1 disabled. */
 	pinctrl-0 = <&i2c2_scl_pa11 &i2c2_sda_pa12>;
 	pinctrl-names = "default";
-	status = "okay";
+	status = "disabled";
 	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&can1 {
+	pinctrl-0 = <&can_rx_pa11 &can_tx_pa12>;
+	pinctrl-names = "default";
+	bus-speed = <125000>;
+	status = "okay";
 };
 
 &spi1 {

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.yaml
@@ -22,6 +22,7 @@ supported:
   - dac
   - dma
   - pwm
+  - can
 testing:
   ignore_tags:
     - net

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
@@ -20,9 +20,16 @@
 
 
 &i2c2 {
+	/* i2c2 is disabled by default because of pin conflict with can1 */
+	status = "okay";
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
 		size = <1024>;
 	};
+};
+
+&can1 {
+	/* can1 shares the pins with i2c2 and must be disabled */
+	status = "disabled";
 };


### PR DESCRIPTION
This MCU has a classical CAN controller, which was previously not enabled.