### PR TITLE
doc: Migrate subsys/ code samples to new Sphinx extension

### DIFF
--- a/boards/arm/adafruit_feather_m0_basic_proto/doc/index.rst
+++ b/boards/arm/adafruit_feather_m0_basic_proto/doc/index.rst
@@ -97,7 +97,7 @@ USB Device Port
 
 The SAMD21 MCU has a USB device port that can be used to communicate
 with a host PC.  See the :ref:`usb-samples` sample applications for
-more, such as the :ref:`usb_cdc-acm` sample which sets up a virtual
+more, such as the :zephyr:code-sample:`usb-cdc-acm` sample which sets up a virtual
 serial port that echos characters back to the host PC.
 
 Programming and Debugging

--- a/boards/arm/adafruit_feather_m0_lora/doc/index.rst
+++ b/boards/arm/adafruit_feather_m0_lora/doc/index.rst
@@ -100,7 +100,7 @@ USB Device Port
 
 The SAMD21 MCU has a USB device port that can be used to communicate
 with a host PC.  See the :ref:`usb-samples` sample applications for
-more, such as the :ref:`usb_cdc-acm` sample which sets up a virtual
+more, such as the :zephyr:code-sample:`usb-cdc-acm` sample which sets up a virtual
 serial port that echos characters back to the host PC.
 
 LoRa Radio

--- a/boards/arm/adafruit_itsybitsy_m4_express/doc/index.rst
+++ b/boards/arm/adafruit_itsybitsy_m4_express/doc/index.rst
@@ -107,7 +107,7 @@ USB Device Port
 
 The SAMD51 MCU has a USB device port that can be used to communicate
 with a host PC.  See the :ref:`usb-samples` sample applications for
-more, such as the :ref:`usb_cdc-acm` sample which sets up a virtual
+more, such as the :zephyr:code-sample:`usb-cdc-acm` sample which sets up a virtual
 serial port that echos characters back to the host PC.
 
 Programming and Debugging

--- a/boards/arm/adafruit_itsybitsy_nrf52840/doc/index.rst
+++ b/boards/arm/adafruit_itsybitsy_nrf52840/doc/index.rst
@@ -114,8 +114,8 @@ Push buttons
 Logging
 -------
 
-Logging is done using the USB-CDC port. See the :ref:`logger_sample`
-or the :ref:`cdc-acm-console` sample applications to see how this works.
+Logging is done using the USB-CDC port. See the :zephyr:code-sample:`logging` sample
+or the :zephyr:code-sample:`usb-cdc-acm-console` sample applications to see how this works.
 
 Testing LEDs and buttons on the Adafruit ItsyBitsy nRF52840 Express
 *******************************************************************

--- a/boards/arm/adafruit_trinket_m0/doc/index.rst
+++ b/boards/arm/adafruit_trinket_m0/doc/index.rst
@@ -99,7 +99,7 @@ USB Device Port
 
 The SAMD21 MCU has a USB device port that can be used to communicate
 with a host PC.  See the :ref:`usb-samples` sample applications for
-more, such as the :ref:`usb_cdc-acm` sample which sets up a virtual
+more, such as the :zephyr:code-sample:`usb-cdc-acm` sample which sets up a virtual
 serial port that echos characters back to the host PC.
 
 Programming and Debugging

--- a/boards/arm/arduino_mkrzero/doc/index.rst
+++ b/boards/arm/arduino_mkrzero/doc/index.rst
@@ -112,7 +112,7 @@ USB Device Port
 
 The SAMD21 MCU has a USB device port that can be used to communicate
 with a host PC.  See the :ref:`usb-samples` sample applications for
-more, such as the :ref:`usb_cdc-acm` sample which sets up a virtual
+more, such as the :zephyr:code-sample:`usb-cdc-acm` sample which sets up a virtual
 serial port that echos characters back to the host PC.
 
 DAC

--- a/boards/arm/arduino_nano_33_iot/doc/index.rst
+++ b/boards/arm/arduino_nano_33_iot/doc/index.rst
@@ -103,7 +103,7 @@ USB Device Port
 
 The SAMD21 MCU has a USB device port that can be used to communicate
 with a host PC.  See the :ref:`usb-samples` sample applications for
-more, such as the :ref:`usb_cdc-acm` sample which sets up a virtual
+more, such as the :zephyr:code-sample:`usb-cdc-acm` sample which sets up a virtual
 serial port that echos characters back to the host PC.
 
 Programming and Debugging

--- a/boards/arm/arduino_zero/doc/index.rst
+++ b/boards/arm/arduino_zero/doc/index.rst
@@ -99,7 +99,7 @@ USB Device Port
 
 The SAMD21 MCU has a USB device port that can be used to communicate
 with a host PC.  See the :ref:`usb-samples` sample applications for
-more, such as the :ref:`usb_cdc-acm` sample which sets up a virtual
+more, such as the :zephyr:code-sample:`usb-cdc-acm` sample which sets up a virtual
 serial port that echos characters back to the host PC.
 
 DAC

--- a/boards/arm/nrf52840dongle_nrf52840/doc/index.rst
+++ b/boards/arm/nrf52840dongle_nrf52840/doc/index.rst
@@ -210,7 +210,7 @@ to the zephyr repository on your computer.
       nrfutil dfu usb-serial -pkg mcuboot.zip -p /dev/ttyACM0
 
 You can now flash a Zephyr application to the board using MCUboot's serial
-recovery mode. We'll use the :ref:`smp_svr_sample` since it's ready to be
+recovery mode. We'll use the :zephyr:code-sample:`smp-svr` sample since it's ready to be
 compiled for chain-loading by MCUboot (and itself supports firmware updates
 over Bluetooth).
 

--- a/boards/arm/seeeduino_xiao/doc/index.rst
+++ b/boards/arm/seeeduino_xiao/doc/index.rst
@@ -99,7 +99,7 @@ USB Device Port
 
 The SAMD21 MCU has a USB device port that can be used to communicate
 with a host PC.  See the :ref:`usb-samples` sample applications for
-more, such as the :ref:`usb_cdc-acm` sample which sets up a virtual
+more, such as the :zephyr:code-sample:`usb-cdc-acm` sample which sets up a virtual
 serial port that echos characters back to the host PC.
 
 DAC

--- a/boards/arm/serpente/doc/index.rst
+++ b/boards/arm/serpente/doc/index.rst
@@ -75,7 +75,7 @@ USB Device Port
 
 The SAMD21 MCU has a USB device port that can be used to communicate
 with a host PC.  See the :ref:`usb-samples` sample applications for
-more, such as the :ref:`usb_cdc-acm` sample which prints "Hello World!"
+more, such as the :zephyr:code-sample:`usb-cdc-acm` sample which prints "Hello World!"
 to the host PC.
 
 Programming and Debugging

--- a/boards/arm/wio_terminal/doc/index.rst
+++ b/boards/arm/wio_terminal/doc/index.rst
@@ -122,7 +122,7 @@ USB Device Port
 
 The SAMD51 MCU has a USB device port that can be used to communicate with a
 host PC.  See the :ref:`usb-samples` sample applications for more, such as the
-:ref:`usb_cdc-acm` sample which sets up a virtual serial port that echos
+:zephyr:code-sample:`usb-cdc-acm` sample which sets up a virtual serial port that echos
 characters back to the host PC.
 
 Programming and Debugging

--- a/boards/xtensa/heltec_wifi_lora32_v2/doc/index.rst
+++ b/boards/xtensa/heltec_wifi_lora32_v2/doc/index.rst
@@ -188,7 +188,7 @@ Onboard OLED display
 
 The onboard OLED display is of type ``ssd1306``, has 128*64 pixels and is
 connected via I2C. It can therefore be used by enabling the
-:ref:`ssd1306_128_shield` as shown in the following for the :ref:`lvgl-sample`:
+:ref:`ssd1306_128_shield` as shown in the following for the :zephyr:code-sample:`lvgl` sample:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/display/lvgl

--- a/doc/connectivity/usb/device/usb_device.rst
+++ b/doc/connectivity/usb/device/usb_device.rst
@@ -39,7 +39,8 @@ Audio
 
 There is an experimental implementation of the Audio class. It follows specification
 version 1.00 (``bcdADC 0x0100``) and supports synchronous synchronisation type only.
-See :ref:`usb_audio_headphones_microphone` and :ref:`usb_audio_headset` for reference.
+See :zephyr:code-sample:`usb-audio-headphones-microphone` and
+:zephyr:code-sample:`usb-audio-headset` samples for reference.
 
 Bluetooth HCI USB transport layer
 =================================
@@ -106,7 +107,7 @@ and looks like this:
 		};
 	};
 
-Samples :ref:`usb_cdc-acm` and :ref:`usb_hid-cdc` have similar overlay files.
+Samples :zephyr:code-sample:`usb-cdc-acm` and :zephyr:code-sample:`usb-hid-cdc` have similar overlay files.
 And since no special properties are present, it may seem overkill to use
 devicetree to describe CDC ACM UART.  The motivation behind using devicetree
 is the easy interchangeability of a real UART controller and CDC ACM UART
@@ -117,7 +118,7 @@ Console over CDC ACM UART
 
 With the CDC ACM UART node from above and ``zephyr,console`` property of the
 chosen node, we can describe that CDC ACM UART is to be used with the console.
-A similar overlay file is used by :ref:`cdc-acm-console`.
+A similar overlay file is used by the :zephyr:code-sample:`usb-cdc-acm-console` sample.
 
 .. code-block:: devicetree
 
@@ -169,7 +170,7 @@ CDC ACM UART as backend for a subsystem or application:
   for example see :zephyr:code-sample:`coprocessor`
 * ``zephyr,shell-uart`` used by shell for serial backend,
   for example see :zephyr_file:`samples/subsys/shell/shell_module`
-* ``zephyr,uart-mcumgr`` used by :ref:`smp_svr_sample`
+* ``zephyr,uart-mcumgr`` used by :zephyr:code-sample:`smp-svr` sample
 
 DFU
 ===
@@ -177,7 +178,7 @@ DFU
 USB DFU class implementation is tightly coupled to :ref:`dfu` and :ref:`mcuboot_api`.
 This means that the target platform must support the :ref:`flash_img_api` API.
 
-See :ref:`usb_dfu` for reference.
+See :zephyr:code-sample:`usb-dfu` sample for reference.
 
 USB Human Interface Devices (HID) support
 =========================================
@@ -276,7 +277,7 @@ The disadvantage of this is that Kconfig options such as
 :kconfig:option:`CONFIG_HID_INTERRUPT_EP_MPS` apply to all instances. This design
 issue will be fixed in the HID class implementation for the new USB support.
 
-See :ref:`usb_hid` or :ref:`usb_hid-mouse` for reference.
+See :zephyr:code-sample:`usb-hid` or :zephyr:code-sample:`usb-hid-mouse` sample for reference.
 
 Mass Storage Class
 ==================
@@ -327,7 +328,7 @@ should be the same as ``disk-name`` property.
 The ``disk-property`` "NAND" may be confusing, but it is simply how some file
 systems identifies the disc. Therefore, if the application also accesses the
 file system on the exposed disc, default names should be used, see
-:ref:`usb_mass` for reference.
+:zephyr:code-sample:`usb-mass` sample for reference.
 
 Networking
 ==========
@@ -355,7 +356,7 @@ The application should register descriptors such as Capability Descriptor
 using :c:func:`usb_bos_register_cap`. Registered descriptors are added to the root
 BOS descriptor and handled by the stack.
 
-See :ref:`webusb-sample` for reference.
+See :zephyr:code-sample:`webusb` sample for reference.
 
 Implementing a non-standard USB class
 *************************************
@@ -473,35 +474,35 @@ and documented requests.
 
 The following Product IDs are currently used:
 
-+-------------------------------------+--------+
-| Sample                              | PID    |
-+=====================================+========+
-| :ref:`usb_cdc-acm`                  | 0x0001 |
-+-------------------------------------+--------+
-| :ref:`usb_cdc-acm_composite`        | 0x0002 |
-+-------------------------------------+--------+
-| :ref:`usb_hid-cdc`                  | 0x0003 |
-+-------------------------------------+--------+
-| :ref:`cdc-acm-console`              | 0x0004 |
-+-------------------------------------+--------+
-| :ref:`usb_dfu`                      | 0x0005 |
-+-------------------------------------+--------+
-| :ref:`usb_hid`                      | 0x0006 |
-+-------------------------------------+--------+
-| :ref:`usb_hid-mouse`                | 0x0007 |
-+-------------------------------------+--------+
-| :ref:`usb_mass`                     | 0x0008 |
-+-------------------------------------+--------+
-| :ref:`testusb-app`                  | 0x0009 |
-+-------------------------------------+--------+
-| :ref:`webusb-sample`                | 0x000A |
-+-------------------------------------+--------+
-| :ref:`bluetooth-hci-usb-sample`     | 0x000B |
-+-------------------------------------+--------+
-| :ref:`bluetooth-hci-usb-h4-sample`  | 0x000C |
-+-------------------------------------+--------+
-| :zephyr:code-sample:`wpan-usb`      | 0x000D |
-+-------------------------------------+--------+
++----------------------------------------------------+--------+
+| Sample                                             | PID    |
++====================================================+========+
+| :zephyr:code-sample:`usb-cdc-acm`                  | 0x0001 |
++----------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-cdc-acm-composite`        | 0x0002 |
++----------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-hid-cdc`                  | 0x0003 |
++----------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-cdc-acm-console`          | 0x0004 |
++----------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-dfu`                      | 0x0005 |
++----------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-hid`                      | 0x0006 |
++----------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-hid-mouse`                | 0x0007 |
++----------------------------------------------------+--------+
+| :zephyr:code-sample:`usb-mass`                     | 0x0008 |
++----------------------------------------------------+--------+
+| :zephyr:code-sample:`testusb-app`                  | 0x0009 |
++----------------------------------------------------+--------+
+| :zephyr:code-sample:`webusb`                       | 0x000A |
++----------------------------------------------------+--------+
+| :ref:`bluetooth-hci-usb-sample`                    | 0x000B |
++----------------------------------------------------+--------+
+| :ref:`bluetooth-hci-usb-h4-sample`                 | 0x000C |
++----------------------------------------------------+--------+
+| :zephyr:code-sample:`wpan-usb`                     | 0x000D |
++----------------------------------------------------+--------+
 
 The USB device descriptor field ``bcdDevice`` (Device Release Number) represents
 the Zephyr kernel major and minor versions as a binary coded decimal value.

--- a/doc/connectivity/usb/device_next/usb_device.rst
+++ b/doc/connectivity/usb/device_next/usb_device.rst
@@ -14,7 +14,7 @@ class API that should be used to implement the functions (classes).
 It will replace :ref:`usb_device_stack`.
 
 If you would like to play around with the new device support, or the new USB
-support in general, please try :ref:`usb_shell-app`. The sample is mainly to help
+support in general, please try :zephyr:code-sample:`usb-shell` sample. The sample is mainly to help
 test the capabilities of the stack and correct implementation of the USB controller
 drivers.
 
@@ -33,14 +33,14 @@ CDC ACM
 
 CDC ACM implementation has support for multiple instances.
 Description from :ref:`usb_device_cdc_acm` also applies to the new implementation.
-See :ref:`usb_cdc-acm` sample for reference.
+See :zephyr:code-sample:`usb-cdc-acm` sample for reference.
 To build the sample for the new device support, set the configuration
 ``-DCONF_FILE=usbd_next_prj.conf`` either directly or via ``west``.
 
 Mass Storage Class
 ==================
 
-See :ref:`usb_mass` sample for reference.
+See :zephyr:code-sample:`usb-mass` sample for reference.
 To build the sample for the new device support, set the configuration
 ``-DCONF_FILE=usbd_next_prj.conf`` either directly or via ``west``.
 

--- a/doc/develop/west/sign.rst
+++ b/doc/develop/west/sign.rst
@@ -42,7 +42,7 @@ Notes on the above commands:
 - The ``CONFIG_MCUBOOT_SIGNATURE_KEY_FILE`` value is the insecure default
   provided and used by by MCUboot for development and testing
 - You can change the ``hello_world`` application directory to any other
-  application that can be loaded by MCUboot, such as the :ref:`smp_svr_sample`
+  application that can be loaded by MCUboot, such as the :zephyr:code-sample:`smp-svr` sample.
 
 For more information on these and other related configuration options, see:
 

--- a/doc/services/device_mgmt/mcumgr.rst
+++ b/doc/services/device_mgmt/mcumgr.rst
@@ -30,7 +30,7 @@ systems.
 The management subsystem is located in :zephyr_file:`subsys/mgmt/` inside of
 the Zephyr tree.
 
-Additionally, there is a :ref:`sample <smp_svr_sample>` that provides
+Additionally, there is a :zephyr:code-sample:`sample <smp-svr>` sample that provides
 management functionality over BLE and serial.
 
 .. _mcumgr_cli:

--- a/doc/services/device_mgmt/ota.rst
+++ b/doc/services/device_mgmt/ota.rst
@@ -44,7 +44,7 @@ REST api to detect firmware updates. When a new update is detected, the binary
 is downloaded and installed. MCUboot can be used to verify the signature before
 upgrading the firmware.
 
-There is a :ref:`hawkbit-api-sample` included in the
+There is a :zephyr:code-sample:`hawkbit-api` sample included in the
 Zephyr :ref:`mgmt-samples` section.
 
 UpdateHub
@@ -55,7 +55,7 @@ be manually triggered or monitored via polling. When a new update is detected,
 the binary is downloaded and installed. MCUboot can be used to verify the
 signature before upgrading the firmware.
 
-There is an :ref:`updatehub_fota_sample` included in the Zephyr
+There is an :zephyr:code-sample:`updatehub-fota` sample included in the Zephyr
 :ref:`mgmt-samples` section.
 
 SMP Server
@@ -66,7 +66,7 @@ Bluetooth Low Energy (BLE) or UDP. :ref:`mcu_mgr` is used to send a signed
 firmware binary to the remote device where it is verified by MCUboot before the
 upgrade occurs.
 
-There is an :ref:`smp_svr_sample` included in the Zephyr :ref:`mgmt-samples`
+There is an :zephyr:code-sample:`smp-svr` sample included in the Zephyr :ref:`mgmt-samples`
 section.
 
 Lightweight M2M (LWM2M)

--- a/doc/services/ipc/ipc_service/backends/ipc_service_icmsg.rst
+++ b/doc/services/ipc/ipc_service/backends/ipc_service_icmsg.rst
@@ -83,4 +83,4 @@ and the backend informs the application by calling
 Samples
 =======
 
- - :ref:`ipc_icmsg_sample`
+ - :zephyr:code-sample:`ipc-icmsg`

--- a/doc/services/logging/index.rst
+++ b/doc/services/logging/index.rst
@@ -734,7 +734,8 @@ hexadecimal characters
 (e.g. when ``CONFIG_LOG_BACKEND_UART_OUTPUT_DICTIONARY_HEX=y``). This tells
 the parser to convert the hexadecimal characters to binary before parsing.
 
-Please refer to :ref:`logging_dictionary_sample` on how to use the log parser.
+Please refer to the :zephyr:code-sample:`logging-dictionary` sample to learn more on how to use
+the log parser.
 
 
 Recommendations

--- a/doc/services/modbus/index.rst
+++ b/doc/services/modbus/index.rst
@@ -25,14 +25,11 @@ More information about Modbus and Modbus RTU can be found on the website
 Samples
 *******
 
-:ref:`modbus-rtu-server-sample` and :ref:`modbus-rtu-client-sample` give
-the possibility to try out RTU server and RTU client implementation with
-an evaluation board.
-
-:ref:`modbus-tcp-server-sample` is a simple Modbus TCP server.
-
-:ref:`modbus-gateway-sample` is an example how to build a TCP to serial line
-gateway with Zephyr OS.
+* :zephyr:code-sample:`modbus-rtu-server` and :zephyr:code-sample:`modbus-rtu-client` samples give
+  the possibility to try out RTU server and RTU client implementation with an evaluation board.
+* :zephyr:code-sample:`modbus-tcp-server` sample is a simple Modbus TCP server.
+* :zephyr:code-sample:`modbus-gateway` sample shows how to build a TCP to serial line
+  gateway with Zephyr OS.
 
 API Reference
 *************

--- a/doc/services/settings/index.rst
+++ b/doc/services/settings/index.rst
@@ -19,8 +19,7 @@ element for the package ``id``.
 Convenience routines are provided for converting a key value to
 and from a string type.
 
-For an example of the settings subsystem refer to
-:ref:`the sample <settings_subsys_sample>`.
+For an example of the settings subsystem refer to :zephyr:code-sample:`settings` sample.
 
 .. note::
 

--- a/samples/subsys/canbus/isotp/README.rst
+++ b/samples/subsys/canbus/isotp/README.rst
@@ -1,14 +1,17 @@
-.. _isotp-sample:
+.. zephyr:code-sample:: isotp
+   :name: ISO-TP library
+   :relevant-api: can_isotp
 
-ISO-TP library
-##############
+   Use ISO-TP library to exchange messages between two boards.
 
 Overview
 ********
-This sample demonstrates how to use the ISO-TP library.
+This sample demonstrates how to use the :ref:`ISO-TP library <can_isotp>`.
+
 Messages are exchanged between two boards. A long message, that is sent with
-a block-size (BS) of eight frames, and a short one that has an minimal
+a block-size (BS) of eight frames, and a short one that has a minimal
 separation-time (STmin) of five milliseconds.
+
 The send function call for the short message is non-blocking, and the send
 function call for the long message is blocking.
 

--- a/samples/subsys/console/getchar/README.rst
+++ b/samples/subsys/console/getchar/README.rst
@@ -1,7 +1,7 @@
-.. _console_getchar_sample:
+.. zephyr:code-sample:: console_getchar
+   :name: console_getchar()
 
-console_getchar() Sample Application
-####################################
+   Use console_getchar() to read an input character from the console.
 
 Overview
 ********
@@ -15,7 +15,7 @@ process console input character by character. The sample also allows to
 see key/character codes as returned by the function.
 
 If you are interested in line by line console input, see
-:ref:`console_getline_sample`.
+:zephyr:code-sample:`console_getline`.
 
 
 Requirements

--- a/samples/subsys/console/getline/README.rst
+++ b/samples/subsys/console/getline/README.rst
@@ -1,7 +1,7 @@
-.. _console_getline_sample:
+.. zephyr:code-sample:: console_getline
+   :name: console_getline()
 
-console_getline() Sample Application
-####################################
+   Use console_getline() to read an input line from the console.
 
 Overview
 ********
@@ -15,7 +15,7 @@ console input line by line. The sample also allows to see details of how
 a line is returned by the function.
 
 If you are interested in character by character console input, see
-:ref:`console_getchar_sample`.
+:zephyr:code-sample:`console_getchar`.
 
 
 Requirements

--- a/samples/subsys/debug/gdbstub/README.rst
+++ b/samples/subsys/debug/gdbstub/README.rst
@@ -1,7 +1,7 @@
-.. _gdb_debug_sample:
+.. zephyr:code-sample:: gdb-debug
+   :name: GDB debug
 
-GDB Debug Sample
-################
+   Use GDB Remote Serial Protocol to debug a Zephyr application running on QEMU.
 
 Overview
 ********

--- a/samples/subsys/display/cfb/README.rst
+++ b/samples/subsys/display/cfb/README.rst
@@ -1,7 +1,8 @@
-.. _character_frame_buffer_sample:
+.. zephyr:code-sample:: character-frame-buffer
+   :name: Character frame buffer
+   :relevant-api: monochrome_character_framebuffer
 
-Character frame buffer
-######################
+   Display character strings using the Character Frame Buffer (CFB).
 
 Overview
 ********

--- a/samples/subsys/display/cfb_custom_font/README.rst
+++ b/samples/subsys/display/cfb_custom_font/README.rst
@@ -1,7 +1,8 @@
-.. _cfb_custom_fonts:
+.. zephyr:code-sample:: cfb-custom-fonts
+   :name: Custom fonts
+   :relevant-api: monochrome_character_framebuffer
 
-Custom Fonts
-############
+   Generate and use a custom font.
 
 Overview
 ********

--- a/samples/subsys/display/cfb_shell/README.rst
+++ b/samples/subsys/display/cfb_shell/README.rst
@@ -1,7 +1,8 @@
-.. _cfb_shell_sample:
+.. zephyr:code-sample:: cfb-shell-sample
+   :name: Character Framebuffer shell module
+   :relevant-api: monochrome_character_framebuffer
 
-Character Framebuffer Shell Module Sample
-#########################################
+   Use the CFB shell module to interact with a monochrome display.
 
 Overview
 ********

--- a/samples/subsys/display/lvgl/README.rst
+++ b/samples/subsys/display/lvgl/README.rst
@@ -1,7 +1,8 @@
-.. _lvgl-sample:
+.. zephyr:code-sample:: lvgl
+   :name: LVGL basic sample
+   :relevant-api: display_interface
 
-LVGL Basic Sample
-#################
+   Display "Hello World" and a dynamic counter using LVGL.
 
 Overview
 ********

--- a/samples/subsys/edac/README.rst
+++ b/samples/subsys/edac/README.rst
@@ -1,13 +1,13 @@
-.. zephyr:code-sample:: edac-sample
+.. zephyr:code-sample:: edac
    :name: EDAC shell
    :relevant-api: edac
 
-   EDAC Shell Sample
+   Test error detection and correction (EDAC) using shell commands.
 
 Overview
 ********
 
-This sample demonstrates the EDAC driver API in a simple EDAC shell sample.
+This sample demonstrates the :ref:`EDAC driver API <edac_api>` in a simple EDAC shell sample.
 
 Building and Running
 ********************

--- a/samples/subsys/fs/format/README.rst
+++ b/samples/subsys/fs/format/README.rst
@@ -1,5 +1,5 @@
 .. zephyr:code-sample:: fs-format
-   :name: Formatting
+   :name: Format filesystem
    :relevant-api: file_system_api
 
    Format different storage devices for different file systems.

--- a/samples/subsys/fs/fs_sample/README.rst
+++ b/samples/subsys/fs/fs_sample/README.rst
@@ -1,8 +1,8 @@
 .. zephyr:code-sample:: fs
-   :name: Filesystem manipulation
+   :name: File system manipulation
    :relevant-api: file_system_api disk_access_interface
 
-   Use filesystem API with various filesystems and storage devices.
+   Use file system API with various filesystems and storage devices.
 
 Overview
 ********

--- a/samples/subsys/input/input_dump/README.rst
+++ b/samples/subsys/input/input_dump/README.rst
@@ -1,7 +1,8 @@
-.. _input-dump-sample:
+.. zephyr:code-sample:: input-dump
+   :name: Input dump
+   :relevant-api: input_events
 
-Input Dump
-##########
+   Print all input events.
 
 Overview
 ********

--- a/samples/subsys/ipc/ipc_service/icmsg/README.rst
+++ b/samples/subsys/ipc/ipc_service/icmsg/README.rst
@@ -1,7 +1,8 @@
-.. _ipc_icmsg_sample:
+.. zephyr:code-sample:: ipc-icmsg
+   :name: IPC service: icmsg backend
+   :relevant-api: ipc
 
-IPC Service - icmsg - Sample Application
-########################################
+   Send messages between two cores using the IPC service and icmsg backend.
 
 Overview
 ********

--- a/samples/subsys/ipc/ipc_service/static_vrings/README.rst
+++ b/samples/subsys/ipc/ipc_service/static_vrings/README.rst
@@ -1,7 +1,8 @@
-.. _static_vrings_sample:
+.. zephyr:code-sample:: ipc-static-vrings
+   :name: IPC service: static vrings backend
+   :relevant-api: ipc
 
-IPC Service - static vrings - Sample Application
-################################################
+   Send messages between two cores using the IPC service and static vrings backend.
 
 Overview
 ********

--- a/samples/subsys/ipc/openamp/README.rst
+++ b/samples/subsys/ipc/openamp/README.rst
@@ -1,7 +1,8 @@
-.. _openAMP_sample:
+.. zephyr:code-sample:: openamp
+   :name: OpenAMP
+   :relevant-api: ipm_interface
 
-OpenAMP Sample Application
-##########################
+   Send messages between two cores using OpenAMP.
 
 Overview
 ********

--- a/samples/subsys/ipc/openamp_rsc_table/README.rst
+++ b/samples/subsys/ipc/openamp_rsc_table/README.rst
@@ -1,7 +1,8 @@
-.. _openAMP_rsc_table_sample:
+.. zephyr:code-sample:: openamp-rsc-table
+   :name: OpenAMP using resource table
+   :relevant-api: ipm_interface
 
-OpenAMP Sample Application using resource table
-###############################################
+   Send messages between two cores using OpenAMP and a resource table.
 
 Overview
 ********

--- a/samples/subsys/ipc/rpmsg_service/README.rst
+++ b/samples/subsys/ipc/rpmsg_service/README.rst
@@ -1,7 +1,8 @@
-.. _RPMsg_Service_sample:
+.. zephyr:code-sample:: rpmsg-service
+   :name: RPMsg service
+   :relevant-api: rpmsg_service_api
 
-RPMsg Service sample Application
-################################
+   Send messages between cores using RPMsg service.
 
 Overview
 ********

--- a/samples/subsys/logging/ble_backend/README.rst
+++ b/samples/subsys/logging/ble_backend/README.rst
@@ -1,7 +1,8 @@
-.. _logger_ble_backend:
+.. zephyr:code-sample:: logging-ble-backend
+   :name: BLE logging backend
+   :relevant-api: log_api log_backend bt_gatt
 
-Logging: BLE Backend
-########################
+   Send log messages over BLE using the BLE logging backend.
 
 Overview
 ********

--- a/samples/subsys/logging/dictionary/README.rst
+++ b/samples/subsys/logging/dictionary/README.rst
@@ -1,9 +1,13 @@
-.. _logging_dictionary_sample:
+.. zephyr:code-sample:: logging-dictionary
+   :name: Dictionary-based logging
+   :relevant-api: log_api
 
-Dictionary-based Logging Sample
-###############################
+   Output binary log data using the dictionary-based logging API.
 
-This is a sample app which utilizes dictionary based logging and
+Overview
+********
+
+This is a sample app which utilizes :ref:`dictionary-based logging <logging_guide_dictionary>` and
 the UART backend. This is configured to output binary log data
 in hexadecimal so it could be run in terminal.
 

--- a/samples/subsys/logging/logger/README.rst
+++ b/samples/subsys/logging/logger/README.rst
@@ -1,7 +1,8 @@
-.. _logger_sample:
+.. zephyr:code-sample:: logging
+   :name: Logging
+   :relevant-api: log_api log_ctrl
 
-Logging
-###########
+   Output log messages to the console using the logging subsystem.
 
 Overview
 ********

--- a/samples/subsys/lorawan/class_a/README.rst
+++ b/samples/subsys/lorawan/class_a/README.rst
@@ -1,12 +1,13 @@
-.. _lorawan_class_a_sample:
+.. zephyr:code-sample:: lorawan-class-a
+   :name: LoRaWAN class A device
+   :relevant-api: lorawan_api
 
-LoRaWAN Class A Sample
-######################
+   Join a LoRaWAN network and send a message periodically.
 
 Overview
 ********
 
-A simple application to demonstrate the LoRaWAN subsystem of Zephyr.
+A simple application to demonstrate the :ref:`LoRaWAN subsystem <lorawan_api>` of Zephyr.
 
 Building and Running
 ********************

--- a/samples/subsys/mgmt/hawkbit/README.rst
+++ b/samples/subsys/mgmt/hawkbit/README.rst
@@ -1,12 +1,13 @@
-.. _hawkbit-api-sample:
+.. zephyr:code-sample:: hawkbit-api
+   :name: Eclipse hawkBit Direct Device Integration API
+   :relevant-api: hawkbit
 
-Hawkbit Direct Device Integration API sample
-############################################
+   Update a device using Eclipse hawkBit DDI API.
 
 Overview
 ********
 
-The hawkbit update server provides REST resources which are consumed by the
+The Eclipse hawkBit update server provides REST resources which are consumed by the
 device to retrieve software update tasks. This API is based on HTTP standards
 and a polling mechanism.
 

--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -1,7 +1,7 @@
-.. _smp_svr_sample:
+.. zephyr:code-sample:: smp-svr
+   :name: SMP server
 
-SMP Server Sample
-#################
+   Implement a Simple Management Protocol (SMP) server.
 
 Overview
 ********

--- a/samples/subsys/mgmt/updatehub/README.rst
+++ b/samples/subsys/mgmt/updatehub/README.rst
@@ -1,7 +1,8 @@
-.. _updatehub_fota_sample:
+.. zephyr:code-sample:: updatehub-fota
+   :name: UpdateHub embedded Firmware Over-The-Air (FOTA) update
+   :relevant-api: updatehub
 
-UpdateHub embedded Firmware Over-The-Air (FOTA) sample
-######################################################
+   Perform Firmware Over-The-Air (FOTA) updates using UpdateHub.
 
 Overview
 ********

--- a/samples/subsys/modbus/rtu_client/README.rst
+++ b/samples/subsys/modbus/rtu_client/README.rst
@@ -1,7 +1,8 @@
-.. _modbus-rtu-client-sample:
+.. zephyr:code-sample:: modbus-rtu-client
+   :name: Modbus RTU client
+   :relevant-api: modbus
 
-Modbus RTU Client Sample
-########################
+   Communicate with a Modbus RTU server.
 
 Overview
 ********
@@ -16,8 +17,7 @@ This sample has been tested with the nRF52840-DK and FRDM-K64F boards,
 but it should work with any board that has a free UART interface.
 
 RTU client example is running on an evaluation board and communicates
-with another board that has been prepared according to the description
-`modbus-rtu-server-sample`.
+with another board running the :zephyr:code-sample:`modbus-rtu-server` sample.
 
 In addition to the evaluation board a RS-485 shield may be used.
 The shield converts UART TX, RX signals to RS-485.

--- a/samples/subsys/modbus/rtu_server/README.rst
+++ b/samples/subsys/modbus/rtu_server/README.rst
@@ -1,7 +1,8 @@
-.. _modbus-rtu-server-sample:
+.. zephyr:code-sample:: modbus-rtu-server
+   :name: Modbus RTU server
+   :relevant-api: modbus
 
-Modbus RTU Server Sample
-########################
+   Implement a Modbus RTU server exposing Modbus commands to control LEDs.
 
 Overview
 ********

--- a/samples/subsys/modbus/tcp_gateway/README.rst
+++ b/samples/subsys/modbus/tcp_gateway/README.rst
@@ -1,7 +1,8 @@
-.. _modbus-gateway-sample:
+.. zephyr:code-sample:: modbus-gateway
+   :name: Modbus TCP-to-serial gateway
+   :relevant-api: modbus bsd_sockets
 
-Modbus TCP to serial line gateway sample
-########################################
+   Implement a gateway between an Ethernet TCP-IP network and a Modbus serial line.
 
 Overview
 ********
@@ -16,8 +17,8 @@ This sample has been tested with FRDM-K64F board,
 but it should work with any board or shield that has a network interface.
 
 Gateway example is running on an evaluation board and communicates
-with another board that has been prepared according to the description
-`modbus-rtu-server-sample`. Client is running on a PC or laptop.
+with another board that has been prepared according to the instructions in
+:zephyr:code-sample:`modbus-rtu-server` sample. Client is running on a PC or laptop.
 
 The description of this sample uses `PyModbus`_ (Pymodbus REPL).
 The user can of course try out other client implementations with this sample.

--- a/samples/subsys/modbus/tcp_server/README.rst
+++ b/samples/subsys/modbus/tcp_server/README.rst
@@ -1,7 +1,8 @@
-.. _modbus-tcp-server-sample:
+.. zephyr:code-sample:: modbus-tcp-server
+   :name: Modbus TCP server
+   :relevant-api: modbus bsd_sockets
 
-Modbus TCP Server Sample
-########################
+   Implement a Modbus TCP server exposing Modbus commands to control LEDs.
 
 Overview
 ********

--- a/samples/subsys/nvs/README.rst
+++ b/samples/subsys/nvs/README.rst
@@ -1,7 +1,8 @@
-.. _nvs-sample:
+.. zephyr:code-sample:: nvs
+   :name: Non-Volatile Storage (NVS)
+   :relevant-api: nvs_high_level_api
 
-NVS: Non-Volatile Storage
-#########################
+   Store and retrieve data from flash using the NVS API.
 
 Overview
 ********

--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/README.rst
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/README.rst
@@ -1,7 +1,7 @@
-.. _cmsis_rtos_v1-sample:
+.. zephyr:code-sample:: cmsis-rtos-v1
+   :name: Dining Philosophers (CMSIS RTOS V1 APIs)
 
-Dining Philosophers (CMSIS RTOS V1 APIs)
-########################################
+   Implement a solution to the Dining Philosophers problem using CMSIS RTOS V1.
 
 Overview
 ********

--- a/samples/subsys/portability/cmsis_rtos_v1/timer_synchronization/README.rst
+++ b/samples/subsys/portability/cmsis_rtos_v1/timer_synchronization/README.rst
@@ -1,7 +1,7 @@
-.. _cmsis_rtos_v1-sync_sample:
+.. zephyr:code-sample:: cmsis-rtos-v1-sync
+   :name: Synchronization using CMSIS RTOS V1 APIs
 
-Synchronization using CMSIS RTOS V1 APIs
-########################################
+   Use timers and message queues from CMSIS RTOS v1 API to synchronize threads.
 
 Overview
 ********

--- a/samples/subsys/portability/cmsis_rtos_v2/philosophers/README.rst
+++ b/samples/subsys/portability/cmsis_rtos_v2/philosophers/README.rst
@@ -1,7 +1,7 @@
-.. _cmsis_rtos_v2-sample:
+.. zephyr:code-sample:: cmsis-rtos-v2
+   :name: Dining Philosophers (CMSIS RTOS V2 APIs)
 
-Dining Philosophers (CMSIS RTOS V2 APIs)
-########################################
+   Implement a solution to the Dining Philosophers problem using CMSIS RTOS V2.
 
 Overview
 ********

--- a/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/README.rst
+++ b/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/README.rst
@@ -1,7 +1,7 @@
-.. _cmsis_rtos_v2-sync_sample:
+.. zephyr:code-sample:: cmsis-rtos-v2-sync
+   :name: Synchronization using CMSIS RTOS V2 APIs
 
-Synchronization using CMSIS RTOS V2 APIs
-########################################
+   Use timers and message queues from CMSIS RTOS v2 API to synchronize threads.
 
 Overview
 ********

--- a/samples/subsys/sensing/simple/README.rst
+++ b/samples/subsys/sensing/simple/README.rst
@@ -1,7 +1,8 @@
-.. _sensing subsytem-sample:
+.. zephyr:code-sample:: sensing
+   :name: Sensing subsystem
+   :relevant-api: sensing_api
 
-Sensing subsystem sample
-########################
+   Get high-level sensor data in defined intervals.
 
 Overview
 ********

--- a/samples/subsys/settings/README.rst
+++ b/samples/subsys/settings/README.rst
@@ -1,7 +1,8 @@
-.. _settings_subsys_sample:
+.. zephyr:code-sample:: settings
+   :name: Settings API
+   :relevant-api: settings settings_rt settings_name_proc
 
-Settings sample
-###############
+   Load and save configuration values using the settings API.
 
 Overview
 ********

--- a/samples/subsys/shell/fs/README.rst
+++ b/samples/subsys/shell/fs/README.rst
@@ -1,7 +1,8 @@
-.. _shell-fs-sample:
+.. zephyr:code-sample:: shell-fs
+   :name: File system shell
+   :relevant-api: file_system_api
 
-File system shell example
-#########################
+   Access a LittleFS file system partition in flash using the file system shell.
 
 Overview
 ********

--- a/samples/subsys/task_wdt/README.rst
+++ b/samples/subsys/task_wdt/README.rst
@@ -1,12 +1,13 @@
-.. _task_wdt_sample:
+.. zephyr:code-sample:: task-wdt
+   :name: Task watchdog
+   :relevant-api: task_wdt_api
 
-Task Watchdog Sample
-####################
+   Monitor a thread using a task watchdog.
 
 Overview
 ********
 
-This sample allows to test the task watchdog subsystem.
+This sample allows to test the :ref:`task watchdog <task_wdt_api>` subsystem.
 
 Building and Running
 ********************

--- a/samples/subsys/tracing/README.rst
+++ b/samples/subsys/tracing/README.rst
@@ -1,10 +1,7 @@
-.. _tracing_sample:
+.. zephyr:code-sample:: tracing
+   :name: Tracing
 
-Send Tracing Formatted Packet To The Host With Supported Backends
-#################################################################
-
-Overview
-********
+   Send tracing formatted packet to the host with supported backends.
 
 This application can be used to demonstrate the tracing feature. The tracing
 formatted packet will be sent to the host with the currently supported tracing

--- a/samples/subsys/usb/audio/headphones_microphone/README.rst
+++ b/samples/subsys/usb/audio/headphones_microphone/README.rst
@@ -1,7 +1,8 @@
-.. _usb_audio_headphones_microphone:
+.. zephyr:code-sample:: usb-audio-headphones-microphone
+   :name: USB Audio microphone & headphones
+   :relevant-api: _usb_device_core_api
 
-USB Audio Sample Application
-############################
+   Implement a USB Audio microphone + headphones device with audio IN/OUT loopback.
 
 Overview
 ********

--- a/samples/subsys/usb/audio/headset/README.rst
+++ b/samples/subsys/usb/audio/headset/README.rst
@@ -1,7 +1,8 @@
-.. _usb_audio_headset:
+.. zephyr:code-sample:: usb-audio-headset
+   :name: USB Audio headset
+   :relevant-api: _usb_device_core_api
 
-USB Audio Sample Application
-############################
+   Implement a USB Audio headset device with audio IN/OUT loopback.
 
 Overview
 ********

--- a/samples/subsys/usb/cdc_acm/README.rst
+++ b/samples/subsys/usb/cdc_acm/README.rst
@@ -1,7 +1,8 @@
-.. _usb_cdc-acm:
+.. zephyr:code-sample:: usb-cdc-acm
+   :name: USB CDC-ACM
+   :relevant-api: usbd_api _usb_device_core_api
 
-USB CDC ACM Sample Application
-####################################
+   Use USB CDC-ACM driver to implement a serial port echo.
 
 Overview
 ********

--- a/samples/subsys/usb/cdc_acm_composite/README.rst
+++ b/samples/subsys/usb/cdc_acm_composite/README.rst
@@ -1,7 +1,8 @@
-.. _usb_cdc-acm_composite:
+.. zephyr:code-sample:: usb-cdc-acm-composite
+   :name: USB CDC-ACM composite
+   :relevant-api: usbd_api
 
-USB CDC ACM Sample Composite Application
-########################################
+   Implement a composite USB device exposing two serial ports using USB CDC-ACM driver.
 
 Overview
 ********

--- a/samples/subsys/usb/console/README.rst
+++ b/samples/subsys/usb/console/README.rst
@@ -1,7 +1,8 @@
-.. _cdc-acm-console:
+.. zephyr:code-sample:: usb-cdc-acm-console
+   :name: Console over USB CDC ACM
+   :relevant-api: _usb_device_core_api usbd_api uart_interface
 
-Console over CDC ACM UART Sample
-################################
+   Output "Hello World!" to the console over USB CDC ACM.
 
 Overview
 ********

--- a/samples/subsys/usb/dfu/README.rst
+++ b/samples/subsys/usb/dfu/README.rst
@@ -1,7 +1,8 @@
-.. _usb_dfu:
+.. zephyr:code-sample:: usb-dfu
+   :name: USB DFU (Device Firmware Upgrade)
+   :relevant-api: usbd_api _usb_device_core_api
 
-USB DFU Sample Application
-##########################
+   Implement device firmware upgrade using the USB DFU class driver.
 
 Overview
 ********

--- a/samples/subsys/usb/hid-cdc/README.rst
+++ b/samples/subsys/usb/hid-cdc/README.rst
@@ -1,7 +1,8 @@
-.. _usb_hid-cdc:
+.. zephyr:code-sample:: usb-hid-cdc
+   :name: USB HID and CDC ACM
+   :relevant-api: _usb_device_core_api usb_hid_class input_interface
 
-USB HID CDC ACM Application
-###########################
+   Expose multiple USB HID and CDC ACM instances.
 
 Overview
 ********

--- a/samples/subsys/usb/hid-mouse/README.rst
+++ b/samples/subsys/usb/hid-mouse/README.rst
@@ -1,7 +1,8 @@
-.. _usb_hid-mouse:
+.. zephyr:code-sample:: usb-hid-mouse
+   :name: USB HID mouse
+   :relevant-api: _usb_device_core_api usb_hid_class input_interface
 
-USB HID mouse Sample Application
-################################
+   Implement a basic HID mouse device.
 
 Overview
 ********

--- a/samples/subsys/usb/hid/README.rst
+++ b/samples/subsys/usb/hid/README.rst
@@ -1,7 +1,8 @@
-.. _usb_hid:
+.. zephyr:code-sample:: usb-hid
+   :name: USB HID (Human Interface Device)
+   :relevant-api: usbd_api usb_hid_device_api
 
-USB HID Sample Application
-##########################
+   Use USB HID driver to enumerate as a raw HID device.
 
 Overview
 ********

--- a/samples/subsys/usb/mass/README.rst
+++ b/samples/subsys/usb/mass/README.rst
@@ -1,7 +1,8 @@
-.. _usb_mass:
+.. zephyr:code-sample:: usb-mass
+   :name: USB Mass Storage
+   :relevant-api: usbd_api _usb_device_core_api file_system_api
 
-USB Mass Storage Sample Application
-###################################
+   Expose board's RAM or FLASH as a USB disk using USB Mass Storage driver.
 
 Overview
 ********

--- a/samples/subsys/usb/shell/README.rst
+++ b/samples/subsys/usb/shell/README.rst
@@ -1,13 +1,14 @@
-.. _usb_shell-app:
+.. zephyr:code-sample:: usb-shell
+   :name: USB shell
+   :relevant-api: usbd_api
 
-USB support shell sample
-########################
+   Use shell commands to interact with USB device stack.
 
 Overview
 ********
 
 The sample enables new experimental USB device support and the shell function.
-It is primarily intended to aid in the development and testing of USB constoller
+It is primarily intended to aid in the development and testing of USB controller
 drivers and new USB support.
 
 Building and flashing

--- a/samples/subsys/usb/testusb/README.rst
+++ b/samples/subsys/usb/testusb/README.rst
@@ -1,9 +1,10 @@
-.. _testusb-app:
+.. zephyr:code-sample:: testusb-app
+   :name: USB testing application
+   :relevant-api: _usb_device_core_api
 
-Testusb application sample
-##########################
+   Test USB device drivers using a loopback function.
 
-The testusb sample implements a loopback function. This function can be used
+This sample implements a loopback function that can be used
 to test USB device drivers and the device stack connected to a Linux host
 and has a similar interface to "Gadget Zero" of the Linux kernel.
 The userspace tool ``testusb`` is needed to start the tests.

--- a/samples/subsys/usb/webusb/README.rst
+++ b/samples/subsys/usb/webusb/README.rst
@@ -1,7 +1,8 @@
-.. _webusb-sample:
+.. zephyr:code-sample:: webusb
+   :name: WebUSB
+   :relevant-api: usbd_api
 
-WebUSB sample application
-#########################
+   Receive and echo data from a web page using WebUSB API.
 
 For a deeper dive into the WebUSB, refer to
 https://developers.google.com/web/updates/2016/03/access-usb-devices-on-the-web
@@ -9,8 +10,8 @@ https://developers.google.com/web/updates/2016/03/access-usb-devices-on-the-web
 WebUSB API Specification:
 https://wicg.github.io/webusb/
 
-Sample Overview
-***************
+Overview
+********
 
 This simple echo application demonstrates the WebUSB sample application.
 This application receives the data and echoed back to the WebUSB

--- a/samples/subsys/usb_c/sink/README.rst
+++ b/samples/subsys/usb_c/sink/README.rst
@@ -1,7 +1,8 @@
-.. _usb-c-sink-sample:
+.. zephyr:code-sample:: usb-c-sink
+   :name: Basic USB-C Sink
+   :relevant-api: _usbc_device_api
 
-Basic USB-C SINK
-################
+   Implement a USB-C Power Delivery application in the form of a USB-C Sink.
 
 Overview
 ********

--- a/samples/subsys/usb_c/source/README.rst
+++ b/samples/subsys/usb_c/source/README.rst
@@ -1,7 +1,8 @@
-.. _usb-c-source-sample:
+.. zephyr:code-sample:: usb-c-source
+   :name: Basic USB-C Source
+   :relevant-api: _usbc_device_api
 
-Basic USB-C SOURCE
-##################
+   Implement a USB-C Power Delivery application in the form of a USB-C Source.
 
 Overview
 ********


### PR DESCRIPTION
This migrates the subsys code samples to the new Sphinx code-sample extension, making it easier to find relevant samples when browsing API reference. 

**I would recommend reviewers focus on `samples/subsys/**/*.rst` changes**, as the rest of the changes are either updates of references to the samples (ref --> zephyr:code-sample), or typo/grammar/formatting fixes I caught while working on this.

Live docs: https://builds.zephyrproject.io/zephyr/pr/62352/docs/

>  As a reminder, this change will allow users to discover related code samples more easily when browsing API reference ; ex:
>
> <img width="876" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/128251/0dc54c07-78b7-48f6-b32c-865ba79f550e">
