### PR TITLE
scripts: tests: twister: Sanity Check Loader tests

### DIFF
--- a/scripts/tests/twister/test_scl.py
+++ b/scripts/tests/twister/test_scl.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for scl.py functions
+"""
+
+import logging
+import mock
+import os
+import pytest
+import sys
+
+ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
+
+import scl
+
+from contextlib import nullcontext
+from importlib import reload
+from pykwalify.errors import SchemaError
+from yaml.scanner import ScannerError
+
+
+TESTDATA_1 = [
+    (False),
+    (True),
+]
+
+@pytest.mark.parametrize(
+    'fail_c',
+    TESTDATA_1,
+    ids=['C YAML', 'non-C YAML']
+)
+def test_yaml_imports(fail_c):
+    class ImportRaiser:
+        def find_spec(self, fullname, path, target=None):
+            if fullname == 'yaml.CLoader' and fail_c:
+                raise ImportError()
+            if fullname == 'yaml.CSafeLoader' and fail_c:
+                raise ImportError()
+            if fullname == 'yaml.CDumper' and fail_c:
+                raise ImportError()
+
+    modules_mock = sys.modules.copy()
+
+    if hasattr(modules_mock['yaml'], 'CLoader'):
+        del modules_mock['yaml'].CLoader
+        del modules_mock['yaml'].CSafeLoader
+        del modules_mock['yaml'].CDumper
+
+    cloader_mock = mock.Mock()
+    loader_mock = mock.Mock()
+    csafeloader_mock = mock.Mock()
+    safeloader_mock = mock.Mock()
+    cdumper_mock = mock.Mock()
+    dumper_mock = mock.Mock()
+
+    if not fail_c:
+        modules_mock['yaml'].CLoader = cloader_mock
+        modules_mock['yaml'].CSafeLoader = csafeloader_mock
+        modules_mock['yaml'].CDumper = cdumper_mock
+
+    modules_mock['yaml'].Loader = loader_mock
+    modules_mock['yaml'].SafeLoader = safeloader_mock
+    modules_mock['yaml'].Dumper = dumper_mock
+
+    meta_path_mock = sys.meta_path[:]
+    meta_path_mock.insert(0, ImportRaiser())
+
+    with mock.patch.dict('sys.modules', modules_mock, clear=True), \
+         mock.patch('sys.meta_path', meta_path_mock):
+        reload(scl)
+
+    assert sys.modules['scl'].Loader == loader_mock if fail_c else \
+                                        cloader_mock
+
+    assert sys.modules['scl'].SafeLoader == safeloader_mock if fail_c else \
+                                        csafeloader_mock
+
+    assert sys.modules['scl'].Dumper == dumper_mock if fail_c else \
+                                        cdumper_mock
+
+    import yaml
+    reload(yaml)
+
+
+TESTDATA_2 = [
+    (False, logging.CRITICAL, []),
+    (True, None, ['can\'t import pykwalify; won\'t validate YAML']),
+]
+
+@pytest.mark.parametrize(
+    'fail_pykwalify, log_level, expected_logs',
+    TESTDATA_2,
+    ids=['pykwalify OK', 'no pykwalify']
+)
+def test_pykwalify_import(caplog, fail_pykwalify, log_level, expected_logs):
+    class ImportRaiser:
+        def find_spec(self, fullname, path, target=None):
+            if fullname == 'pykwalify.core' and fail_pykwalify:
+                raise ImportError()
+
+    modules_mock = sys.modules.copy()
+    modules_mock['pykwalify'] = None if fail_pykwalify else \
+                                modules_mock['pykwalify']
+
+    meta_path_mock = sys.meta_path[:]
+    meta_path_mock.insert(0, ImportRaiser())
+
+    with mock.patch.dict('sys.modules', modules_mock, clear=True), \
+         mock.patch('sys.meta_path', meta_path_mock):
+        reload(scl)
+
+    if log_level:
+        assert logging.getLogger('pykwalify.core').level == log_level
+
+    assert all([log in caplog.text for log in expected_logs])
+
+    if fail_pykwalify:
+        assert scl._yaml_validate(None, None) is None
+        assert scl._yaml_validate(mock.Mock(), mock.Mock()) is None
+
+    reload(scl)
+
+
+TESTDATA_3 = [
+    (False),
+    (True),
+]
+
+@pytest.mark.parametrize(
+    'fail_parsing',
+    TESTDATA_3,
+    ids=['ok', 'parsing error']
+)
+def test_yaml_load(caplog, fail_parsing):
+    result_mock = mock.Mock()
+
+    def mock_load(*args, **kwargs):
+        if fail_parsing:
+            context_mark = mock.Mock()
+            problem_mark = mock.Mock()
+            type(context_mark).args = mock.PropertyMock(return_value=[])
+            type(context_mark).name = 'dummy context mark'
+            type(context_mark).line = 0
+            type(context_mark).column = 0
+            type(problem_mark).args = mock.PropertyMock(return_value=[])
+            type(problem_mark).name = 'dummy problem mark'
+            type(problem_mark).line = 0
+            type(problem_mark).column = 0
+            raise ScannerError(context='dummy context',
+                               context_mark=context_mark, problem='dummy problem',
+                               problem_mark=problem_mark, note='Dummy note')
+        return result_mock
+
+    filename = 'dummy/file.yaml'
+
+    with mock.patch('yaml.load', side_effect=mock_load), \
+         mock.patch('builtins.open', mock.mock_open()) as mock_file:
+        with pytest.raises(ScannerError) if fail_parsing else nullcontext():
+            result = scl.yaml_load(filename)
+
+    mock_file.assert_called_with('dummy/file.yaml', 'r')
+
+    if not fail_parsing:
+        assert result == result_mock
+    else:
+        assert 'dummy problem mark:0:0: error: dummy problem' \
+               ' (note Dummy note context @dummy context mark:0:0' \
+               ' dummy context)' in caplog.text
+
+
+
+TESTDATA_4 = [
+    (True, False, None),
+    (False, False, SchemaError),
+    (False, True, ScannerError),
+]
+
+@pytest.mark.parametrize(
+    'validate, fail_load, expected_error',
+    TESTDATA_4,
+    ids=['successful validation', 'failed validation', 'failed load']
+)
+def test_yaml_load_verify(validate, fail_load, expected_error):
+    filename = 'dummy/file.yaml'
+    schema_mock = mock.Mock()
+    data_mock = mock.Mock()
+
+    def mock_load(file_name, *args, **kwargs):
+        assert file_name == filename
+        if fail_load:
+            raise ScannerError
+        return data_mock
+
+    def mock_validate(data, schema, *args, **kwargs):
+        assert data == data_mock
+        assert schema == schema_mock
+        if validate:
+            return True
+        raise SchemaError(u'Schema validation failed.')
+
+    with mock.patch('scl.yaml_load', side_effect=mock_load), \
+         mock.patch('scl._yaml_validate', side_effect=mock_validate), \
+         pytest.raises(expected_error) if expected_error else nullcontext():
+        res = scl.yaml_load_verify(filename, schema_mock)
+
+    if validate:
+        assert res == data_mock
+
+
+TESTDATA_5 = [
+    (True, True, None),
+    (True, False, SchemaError),
+    (False, None, None),
+]
+
+@pytest.mark.parametrize(
+    'schema_exists, validate, expected_error',
+    TESTDATA_5,
+    ids=['successful validation', 'failed validation', 'no schema']
+)
+def test_yaml_validate(schema_exists, validate, expected_error):
+    data_mock = mock.Mock()
+    schema_mock = mock.Mock() if schema_exists else None
+
+    def mock_validate(raise_exception, *args, **kwargs):
+        assert raise_exception
+        if validate:
+            return True
+        raise SchemaError(u'Schema validation failed.')
+
+    def mock_core(source_data, schema_data, *args, **kwargs):
+        assert source_data == data_mock
+        assert schema_data == schema_mock
+        return mock.Mock(validate=mock_validate)
+
+    core_mock = mock.Mock(side_effect=mock_core)
+
+    with mock.patch('pykwalify.core.Core', core_mock), \
+         pytest.raises(expected_error) if expected_error else nullcontext():
+        scl._yaml_validate(data_mock, schema_mock)
+
+    if schema_exists:
+        core_mock.assert_called_once()
+    else:
+        core_mock.assert_not_called()


### PR DESCRIPTION
Adds explicit testing to the Sanity Check Loader utility.
Coverage is equal to 100%.

Shortened coverage report:
```
<user>@<machine>:~/zephyr_github/os.rtos.zephyr.zephyr/scripts$ coverage report -m
Name                                                                             Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------------------------------------
[...tmp files...]
[...usr lib files...]
[...dts files...]
pylib/build_helpers/domains.py                                                      78     48    38%   55-69, 78-92, 98, 101-119, 122, 125, 131-132, 136, 140, 144, 148
pylib/twister/expr_parser.py                                                       182    126    31%   17-18, 52-53, 57-58, 63-64, 92-93, 98, 111, 115, 119, 123, 134, 138, 142-143, 147, 151-152, 156, 160, 164-165, 170, 175, 178-181, 186, 189-191, 194-200, 203-287, 293-301, 311-317, 322-339
pylib/twister/parsetab.py                                                           18      0   100%
pylib/twister/scl.py                                                                34      0   100%
pylib/twister/twisterlib/cmakecache.py                                              90      0   100%
pylib/twister/twisterlib/config_parser.py                                          116     20    83%   22, 27-30, 108, 128, 132, 136, 141, 146, 150, 155, 189, 193, 195, 197, 202, 248, 261-262
pylib/twister/twisterlib/environment.py                                            292      6    98%   28, 237-239, 850-851
pylib/twister/twisterlib/error.py                                                   11      0   100%
pylib/twister/twisterlib/handlers.py                                               618    560     9%   28-29, 33-37, 55-63, 71-94, 97-103, 106-107, 115-126, 133-138, 145-157, 166-171, 174-181, 184, 187-224, 228-318, 327-334, 343, 346-407, 410-433, 436-438, 442-452, 455-465, 468-668, 685-695, 705-707, 712-839, 842-931, 934
pylib/twister/twisterlib/harness.py                                                401    203    49%   85-108, 115-120, 128-130, 134-154, 159-165, 168-216, 234-244, 266, 272, 277-280, 284-320, 323-343, 351-365, 369-374, 381-383, 386, 400, 419, 516-558, 569-574
pylib/twister/twisterlib/jobserver.py                                              132     98    26%   23-25, 28, 31-32, 40, 45, 50, 60-65, 79-96, 103-108, 135-183, 191-202, 206-213, 217-219, 230-236
pylib/twister/twisterlib/log_helper.py                                               9      1    89%   25
pylib/twister/twisterlib/mixins.py                                                   2      0   100%
pylib/twister/twisterlib/platform.py                                                61      7    89%   75, 97-99, 104-105, 108
pylib/twister/twisterlib/quarantine.py                                              80      0   100%
pylib/twister/twisterlib/runner.py                                                 846    612    28%   35, 64-97, 100-112, 116-117, 121-122, 126-127, 131-132, 136-137, 141-142, 146-147, 151-152, 156-157, 161-162, 166-167, 171-172, 176-177, 181-182, 186-187, 191-192, 196-197, 201-202, 206-207, 211-212, 216-217, 242-243, 247-315, 319-412, 424-515, 532-546, 549-562, 566-681, 684-720, 724-756, 759-766, 807, 816, 829-830, 840, 847, 887-978, 1012-1023, 1026-1027, 1031-1053, 1056-1063, 1067-1082, 1087-1095, 1099-1169, 1177-1184, 1187, 1195-1218, 1222-1247, 1250-1270
pylib/twister/twisterlib/size_calc.py                                              208    173    17%   119-130, 133-142, 149, 156, 163-167, 174, 181, 189-191, 195-203, 209-221, 225-286, 291-293, 300-307, 315-330, 339-352, 360, 368-377, 385-397, 405-419, 426-438, 442-460
pylib/twister/twisterlib/testinstance.py                                           200     57    72%   91, 95, 100-101, 104, 107, 110-114, 131, 148, 153-185, 201, 210, 216-217, 280-281, 289, 303-305, 313-316, 319
pylib/twister/twisterlib/testplan.py                                               688    369    46%   27-28, 42, 124, 146-150, 153-165, 168-199, 203-244, 253-298, 303-304, 308-318, 321-330, 333-338, 341-368, 371-378, 382-390, 393-404, 407-408, 411, 416-417, 432-433, 436, 444-446, 465-479, 511-518, 530-531, 535-537, 541, 552-614, 648-650, 653-654, 656, 658, 666-670, 683-685, 710, 720-723, 726, 730, 733-734, 737-740, 743, 746, 749, 752, 755, 758, 761, 764, 769, 772, 775, 778, 781, 786, 789, 792, 795, 801, 804, 808, 811-813, 816, 819, 822, 832-836, 852-855, 872-889, 917-918, 922-923, 925-926, 929-931, 955-960, 972-973, 982-989, 1000-1015, 1023-1027
pylib/twister/twisterlib/testsuite.py                                              211      1    99%   391
snippets.py                                                                        171     76    56%   58, 60-62, 68, 89, 96-98, 103-145, 148-155, 158-168, 171-174, 177-178, 201, 204-215, 221-222, 232-239, 262-264, 290-291, 294, 302-303, 307, 315-319, 330-333, 336-344, 347
tests/twister/conftest.py                                                           67     10    85%   22, 88-96
tests/twister/pytest_integration/test_harness_pytest.py                             83      0   100%
tests/twister/test_cmakecache.py                                                    75      0   100%
tests/twister/test_data/mixins/test_to_ignore.py                                     4      1    75%   5
tests/twister/test_environment.py                                                  131      4    97%   146-151, 416
tests/twister/test_harness.py                                                       83      0   100%
tests/twister/test_mixins.py                                                         7      0   100%
tests/twister/test_quarantine.py                                                    42      0   100%
tests/twister/test_runner.py                                                        93      0   100%
tests/twister/test_scl.py                                                          137      3    98%   42, 44, 103
tests/twister/test_testinstance.py                                                  56      0   100%
tests/twister/test_testplan_class.py                                               209      4    98%   123, 171, 178, 212
tests/twister/test_testsuite.py                                                    126      6    95%   257, 289, 540, 685, 748-750
tests/twister/test_twister.py                                                       46      1    98%   50
zephyr_module.py                                                                   351    286    19%   163-170, 174-202, 206-231, 237-265, 271-283, 287-295, 299-311, 315-329, 333-353, 357-377, 382-399, 414-514, 525-527, 544-550, 553, 585-594, 598-601, 606-617, 622-625, 631-729, 733
--------------------------------------------------------------------------------------------------------------
TOTAL                                                                            14988   8284    45%
```