### PR TITLE
kernel: dynamic: add missing assert argument

### DIFF
--- a/kernel/dynamic.c
+++ b/kernel/dynamic.c
@@ -112,7 +112,8 @@ static void dyn_cb(const struct k_thread *thread, void *user_data)
 	struct dyn_cb_data *const data = (struct dyn_cb_data *)user_data;
 
 	if (data->stack == (k_thread_stack_t *)thread->stack_info.start) {
-		__ASSERT(data->tid == NULL, "stack %p is associated with more than one thread!");
+		__ASSERT(data->tid == NULL, "stack %p is associated with more than one thread!",
+			 (void *)thread->stack_info.start);
 		data->tid = (k_tid_t)thread;
 	}
 }


### PR DESCRIPTION
Repro: `west build -p -b mps2_an385 -T tests/kernel/threads/dynamic_thread_stack/kernel.threads.dynamic_thread.stack.no_pool.alloc.no_user`

---

Add a missing assert argument, fixes:

zephyrproject/zephyr/kernel/dynamic.c: In function 'dyn_cb': zephyrproject/zephyr/include/zephyr/sys/__assert.h:44:52: warning:
	format '%p' expects a matching 'void *' argument [-Wformat=]

That started to break the build since:

d7846de548 assert: check format arguments for correctness