### PR TITLE
samples: philosophers: fix wrong assert type

### DIFF
--- a/samples/philosophers/src/phil_obj_abstract.h
+++ b/samples/philosophers/src/phil_obj_abstract.h
@@ -87,7 +87,7 @@
 	#endif
 	#define take(x) do { \
 		stack_data_t data; k_stack_pop(x, &data, K_FOREVER); \
-		__ASSERT(data == MAGIC, "data was %x\n", data); \
+		__ASSERT(data == MAGIC, "data was %lx\n", data); \
 	} while ((0))
 	#define drop(x) k_stack_push(x, MAGIC)
 	#define fork_type_str "stacks"


### PR DESCRIPTION
One more:

Repro `west build -p -b nrf52dk_nrf52832 -T samples/philosophers/sample.kernel.philosopher.stacks`

---

zephyrproject/zephyr/samples/philosophers/src/main.c: In function 'philosopher':

zephyrproject/zephyr/include/zephyr/sys/__assert.h:44:52: warning: format '%u' expects argument of type 'unsigned int', but argument 2 has type 'stack_data_t' {aka 'long unsigned int'} [-Wformat=]