### PR TITLE
doc: video: samples: Use new Sphinx extension to document samples

### DIFF
--- a/samples/subsys/video/capture/README.rst
+++ b/samples/subsys/video/capture/README.rst
@@ -1,12 +1,13 @@
-.. _video_capture-sample:
+.. zephyr:code-sample:: video-capture
+   :name: Video capture
+   :relevant-api: video_interface
 
-Video Capture
-#############
+   Use the video API to retrieve video frames from a capture device.
 
 Description
 ***********
 
-This sample application uses the Video API to retrieve video frames from the
+This sample application uses the :ref:`Video API <video_api>` to retrieve video frames from the
 video capture device, writes a frame count message to the console, and then
 discards the video frame data.
 

--- a/samples/subsys/video/tcpserversink/README.rst
+++ b/samples/subsys/video/tcpserversink/README.rst
@@ -1,12 +1,13 @@
-.. _video_tcpserversink-sample:
+.. zephyr:code-sample:: video-tcpserversink
+   :name: Video TCP server sink
+   :relevant-api: video_interface bsd_sockets
 
-VIDEO TCP SERVER SINK
-#####################
+   Capture video frames and send them over the network to a TCP client.
 
 Description
 ***********
 
-This sample application gets frames from video capture device and sends
+This sample application gets frames from a video capture device and sends
 them over the network to the connected TCP client.
 
 Requirements


### PR DESCRIPTION
Use the new code-sample directive and roles to document the video capture samples so that they show up as "Related samples" when browsing the API documentation.

See live build: https://builds.zephyrproject.io/zephyr/pr/62362/docs/hardware/peripherals/video.html#api-reference

