### PR TITLE
doc: fs: samples: Use new Sphinx extension to document samples

### DIFF
--- a/samples/subsys/fs/format/README.rst
+++ b/samples/subsys/fs/format/README.rst
@@ -1,7 +1,8 @@
-.. _fs_format_sample:
+.. zephyr:code-sample:: fs-format
+   :name: Formatting
+   :relevant-api: file_system_api
 
-FS Format Sample
-################
+   Format different storage devices for different file systems.
 
 Overview
 ***********

--- a/samples/subsys/fs/fs_sample/README.rst
+++ b/samples/subsys/fs/fs_sample/README.rst
@@ -1,7 +1,8 @@
-.. _fs_sample:
+.. zephyr:code-sample:: fs
+   :name: Filesystem manipulation
+   :relevant-api: file_system_api disk_access_interface
 
-Filesystems Sample Application
-###################################
+   Use filesystem API with various filesystems and storage devices.
 
 Overview
 ********

--- a/samples/subsys/fs/littlefs/README.rst
+++ b/samples/subsys/fs/littlefs/README.rst
@@ -1,7 +1,8 @@
-.. _littlefs-sample:
+.. zephyr:code-sample:: littlefs
+   :name: LittleFS filesystem
+   :relevant-api: file_system_api flash_area_api
 
-littlefs File System Sample Application
-#######################################
+   Use file system API over LittleFS.
 
 Overview
 ********

--- a/samples/subsys/shell/fs/README.rst
+++ b/samples/subsys/shell/fs/README.rst
@@ -48,7 +48,7 @@ Particle Xenon
 ==============
 
 This target is customized to support the same SPI NOR partition table as
-the :ref:`littlefs-sample`.
+the :zephyr:code-sample:`littlefs` sample.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/shell/fs

--- a/samples/subsys/usb/mass/README.rst
+++ b/samples/subsys/usb/mass/README.rst
@@ -157,7 +157,7 @@ LittleFS Example
 
 This board configures to use the external 64 MiBi QSPI flash chip with a
 128 KiBy `littlefs`_ partition compatible with the one produced by the
-:ref:`littlefs-sample`.
+:zephyr:code-sample:`littlefs` sample.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/usb/mass


### PR DESCRIPTION
Use the new code-sample directive and roles to document the filesystem samples so that they show up as "Related samples" when browsing the API documentation.