### PR TITLE
trivial: mqtt: change cipher and sec_tag lists have const data

### DIFF
--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -348,13 +348,13 @@ struct mqtt_sec_config {
 	/** Indicates the list of ciphers to be used for the session.
 	 *  May be NULL to use the default ciphers.
 	 */
-	int *cipher_list;
+	const int *cipher_list;
 
 	/** Indicates the number of entries in the sec tag list. */
 	uint32_t sec_tag_count;
 
 	/** Indicates the list of security tags to be used for the session. */
-	sec_tag_t *sec_tag_list;
+	const sec_tag_t *sec_tag_list;
 
 	/** Peer hostname for ceritificate verification.
 	 *  May be NULL to skip hostname verification.

--- a/samples/net/cloud/aws_iot_mqtt/src/main.c
+++ b/samples/net/cloud/aws_iot_mqtt/src/main.c
@@ -58,7 +58,7 @@ static bool do_subscribe; /* Trigger client to subscribe */
 #define TLS_TAG_DEVICE_PRIVATE_KEY 1
 #define TLS_TAG_AWS_CA_CERTIFICATE 2
 
-static sec_tag_t sec_tls_tags[] = {
+static const sec_tag_t sec_tls_tags[] = {
 	TLS_TAG_DEVICE_CERTIFICATE,
 	TLS_TAG_AWS_CA_CERTIFICATE,
 };

--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -60,7 +60,7 @@ static K_SEM_DEFINE(mqtt_start, 0, 1);
 #define TLS_SNI_HOSTNAME CONFIG_SAMPLE_CLOUD_AZURE_HOSTNAME
 #define APP_CA_CERT_TAG 1
 
-static sec_tag_t m_sec_tags[] = {
+static const sec_tag_t m_sec_tags[] = {
 	APP_CA_CERT_TAG,
 };
 


### PR DESCRIPTION
cipher_list and sec_tag_list are used only with zsock_setsockopt in MQTT. For that use, they can be const (and potentially kept in flash memory).

... Unless there are future plans to do zsock_getsockopt to get info which TLS credentials are really used and reuse the existing sec_tag_list?