### PR TITLE
fuel_gauge: Move SBS specific props

### DIFF
--- a/drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c
@@ -26,6 +26,7 @@ LOG_MODULE_REGISTER(sbs_sbs_gauge);
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/emul_fuel_gauge.h>
 #include <zephyr/drivers/fuel_gauge.h>
+#include <zephyr/drivers/fuel_gauge_sbs.h>
 #include <zephyr/sys/util.h>
 
 #include "sbs_gauge.h"

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/fuel_gauge.h>
+#include <zephyr/drivers/fuel_gauge_sbs.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
@@ -102,7 +103,7 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 		break;
 	case FUEL_GAUGE_SBS_MFR_ACCESS:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_MANUFACTURER_ACCESS, &val);
-		prop->value.sbs_mfr_access_word = val;
+		prop->value.sbs_word = val;
 		break;
 	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ASOC, &val);
@@ -122,7 +123,7 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 		break;
 	case FUEL_GAUGE_SBS_MODE:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_BATTERY_MODE, &val);
-		prop->value.sbs_mode = val;
+		prop->value.sbs_word = val;
 		break;
 	case FUEL_GAUGE_CHARGE_CURRENT:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CHG_CURRENT, &val);
@@ -146,27 +147,27 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_pr
 		break;
 	case FUEL_GAUGE_SBS_ATRATE:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AR, &val);
-		prop->value.sbs_at_rate = val;
+		prop->value.sbs_word = val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ARTTF, &val);
-		prop->value.sbs_at_rate_time_to_full = val;
+		prop->value.sbs_word = val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ARTTE, &val);
-		prop->value.sbs_at_rate_time_to_empty = val;
+		prop->value.sbs_word = val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE_OK:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AROK, &val);
-		prop->value.sbs_at_rate_ok = val;
+		prop->value.sbs_word = val;
 		break;
 	case FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_CAPACITY_ALARM, &val);
-		prop->value.sbs_remaining_capacity_alarm = val;
+		prop->value.sbs_word = val;
 		break;
 	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_TIME_ALARM, &val);
-		prop->value.sbs_remaining_time_alarm = val;
+		prop->value.sbs_word = val;
 		break;
 	default:
 		rc = -ENOTSUP;
@@ -205,26 +206,26 @@ static int sbs_gauge_set_prop(const struct device *dev, struct fuel_gauge_set_pr
 
 	case FUEL_GAUGE_SBS_MFR_ACCESS:
 		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_MANUFACTURER_ACCESS,
-				       prop->value.sbs_mfr_access_word);
-		prop->value.sbs_mfr_access_word = val;
+				       prop->value.sbs_word);
+		prop->value.sbs_word = val;
 		break;
 	case FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM:
 		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_REM_CAPACITY_ALARM,
-				       prop->value.sbs_remaining_capacity_alarm);
-		prop->value.sbs_remaining_capacity_alarm = val;
+				       prop->value.sbs_word);
+		prop->value.sbs_word = val;
 		break;
 	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM:
 		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_REM_TIME_ALARM,
-				       prop->value.sbs_remaining_time_alarm);
-		prop->value.sbs_remaining_time_alarm = val;
+				       prop->value.sbs_word);
+		prop->value.sbs_word = val;
 		break;
 	case FUEL_GAUGE_SBS_MODE:
-		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_BATTERY_MODE, prop->value.sbs_mode);
-		prop->value.sbs_mode = val;
+		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_BATTERY_MODE, prop->value.sbs_word);
+		prop->value.sbs_word = val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE:
-		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_AR, prop->value.sbs_at_rate);
-		prop->value.sbs_at_rate = val;
+		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_AR, prop->value.sbs_word);
+		prop->value.sbs_word = val;
 		break;
 	default:
 		rc = -ENOTSUP;

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -60,8 +60,6 @@ enum fuel_gauge_property {
 	FUEL_GAUGE_RUNTIME_TO_EMPTY,
 	/** Remaining time in minutes until battery reaches full charge */
 	FUEL_GAUGE_RUNTIME_TO_FULL,
-	/** Retrieve word from SBS1.1 ManufactuerAccess */
-	FUEL_GAUGE_SBS_MFR_ACCESS,
 	/** Absolute state of charge (percent, 0-100) - expressed as % of design capacity */
 	FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE,
 	/** Relative state of charge (percent, 0-100) - expressed as % of full charge capacity */
@@ -70,8 +68,6 @@ enum fuel_gauge_property {
 	FUEL_GAUGE_TEMPERATURE,
 	/** Battery voltage (uV) */
 	FUEL_GAUGE_VOLTAGE,
-	/** Battery Mode (flags) */
-	FUEL_GAUGE_SBS_MODE,
 	/** Battery desired Max Charging Current (mA) */
 	FUEL_GAUGE_CHARGE_CURRENT,
 	/** Battery desired Max Charging Voltage (mV) */
@@ -82,24 +78,15 @@ enum fuel_gauge_property {
 	FUEL_GAUGE_DESIGN_CAPACITY,
 	/** Design Voltage (mV) */
 	FUEL_GAUGE_DESIGN_VOLTAGE,
-	/** AtRate (mA or 10 mW) */
-	FUEL_GAUGE_SBS_ATRATE,
-	/** AtRateTimeToFull (minutes) */
-	FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL,
-	/** AtRateTimeToEmpty (minutes) */
-	FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
-	/** AtRateOK (boolean) */
-	FUEL_GAUGE_SBS_ATRATE_OK,
-	/** Remaining Capacity Alarm (mAh or 10mWh) */
-	FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
-	/** Remaining Time Alarm (minutes) */
-	FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
 	/** Manufacturer of pack (1 byte length + 20 bytes data) */
 	FUEL_GAUGE_MANUFACTURER_NAME,
 	/** Name of pack (1 byte length + 20 bytes data) */
 	FUEL_GAUGE_DEVICE_NAME,
 	/** Chemistry (1 byte length + 4 bytes data) */
 	FUEL_GAUGE_DEVICE_CHEMISTRY,
+
+	/** Reserved for start of SBS specific properties. See the fuel_gauge_sbs.h header */
+	_FUEL_GAUGE_SBS_START,
 
 	/** Reserved to demark end of common fuel gauge properties */
 	FUEL_GAUGE_COMMON_COUNT,
@@ -147,8 +134,6 @@ struct fuel_gauge_get_property {
 		uint32_t runtime_to_empty;
 		/** FUEL_GAUGE_RUNTIME_TO_FULL */
 		uint32_t runtime_to_full;
-		/** FUEL_GAUGE_SBS_MFR_ACCESS */
-		uint16_t sbs_mfr_access_word;
 		/** FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE */
 		uint8_t absolute_state_of_charge;
 		/** FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE */
@@ -157,8 +142,6 @@ struct fuel_gauge_get_property {
 		uint16_t temperature;
 		/** FUEL_GAUGE_VOLTAGE */
 		int voltage;
-		/** FUEL_GAUGE_SBS_MODE */
-		uint16_t sbs_mode;
 		/** FUEL_GAUGE_CHARGE_CURRENT */
 		uint16_t chg_current;
 		/** FUEL_GAUGE_CHARGE_VOLTAGE */
@@ -169,18 +152,8 @@ struct fuel_gauge_get_property {
 		uint16_t design_cap;
 		/** FUEL_GAUGE_DESIGN_VOLTAGE */
 		uint16_t design_volt;
-		/** FUEL_GAUGE_SBS_ATRATE */
-		int16_t sbs_at_rate;
-		/** FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL */
-		uint16_t sbs_at_rate_time_to_full;
-		/** FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY	*/
-		uint16_t sbs_at_rate_time_to_empty;
-		/** FUEL_GAUGE_SBS_ATRATE_OK */
-		bool sbs_at_rate_ok;
-		/** FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM */
-		uint16_t sbs_remaining_capacity_alarm;
-		/** FUEL_GAUGE_SBS_REMAINING_TIME_ALARM */
-		uint16_t sbs_remaining_time_alarm;
+		/** See SBS spec for value interpretation */
+		uint16_t sbs_word;
 	} value;
 };
 
@@ -198,16 +171,8 @@ struct fuel_gauge_set_property {
 		/* type property_field; */
 
 		/* Writable Dynamic Battery Info */
-		/** FUEL_GAUGE_SBS_MFR_ACCESS */
-		uint16_t sbs_mfr_access_word;
-		/** FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM */
-		uint16_t sbs_remaining_capacity_alarm;
-		/** FUEL_GAUGE_SBS_REMAINING_TIME_ALARM */
-		uint16_t sbs_remaining_time_alarm;
-		/** FUEL_GAUGE_SBS_MODE */
-		uint16_t sbs_mode;
-		/** FUEL_GAUGE_SBS_ATRATE */
-		int16_t sbs_at_rate;
+		/** See SBS spec for value interpretation */
+		uint16_t sbs_word;
 	} value;
 };
 
@@ -219,28 +184,6 @@ struct fuel_gauge_get_buffer_property {
 	/** Negative error status set by callee e.g. -ENOTSUP for an unsupported property */
 	int status;
 };
-
-/**
- * Data structures for reading SBS buffer properties
- */
-#define SBS_GAUGE_MANUFACTURER_NAME_MAX_SIZE 20
-#define SBS_GAUGE_DEVICE_NAME_MAX_SIZE       20
-#define SBS_GAUGE_DEVICE_CHEMISTRY_MAX_SIZE  4
-
-struct sbs_gauge_manufacturer_name {
-	uint8_t manufacturer_name_length;
-	char manufacturer_name[SBS_GAUGE_MANUFACTURER_NAME_MAX_SIZE];
-} __packed;
-
-struct sbs_gauge_device_name {
-	uint8_t device_name_length;
-	char device_name[SBS_GAUGE_DEVICE_NAME_MAX_SIZE];
-} __packed;
-
-struct sbs_gauge_device_chemistry {
-	uint8_t device_chemistry_length;
-	char device_chemistry[SBS_GAUGE_DEVICE_CHEMISTRY_MAX_SIZE];
-} __packed;
 
 /**
  * @typedef fuel_gauge_get_property_t

--- a/include/zephyr/drivers/fuel_gauge_sbs.h
+++ b/include/zephyr/drivers/fuel_gauge_sbs.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Google LLC
+ * Copyright 2023 Microsoft Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_SBS_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_SBS_H_
+
+/**
+ * @brief Fuel Gauge Interface
+ * @defgroup fuel_gauge_interface Fuel Gauge Interface
+ * @ingroup io_interfaces
+ * @{
+ */
+
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <zephyr/drivers/fuel_gauge.h>
+
+/**
+ * Data structures for reading SBS buffer properties
+ */
+#define SBS_GAUGE_MANUFACTURER_NAME_MAX_SIZE 20
+#define SBS_GAUGE_DEVICE_NAME_MAX_SIZE       20
+#define SBS_GAUGE_DEVICE_CHEMISTRY_MAX_SIZE  4
+
+struct sbs_gauge_manufacturer_name {
+	uint8_t manufacturer_name_length;
+	char manufacturer_name[SBS_GAUGE_MANUFACTURER_NAME_MAX_SIZE];
+} __packed;
+
+struct sbs_gauge_device_name {
+	uint8_t device_name_length;
+	char device_name[SBS_GAUGE_DEVICE_NAME_MAX_SIZE];
+} __packed;
+
+struct sbs_gauge_device_chemistry {
+	uint8_t device_chemistry_length;
+	char device_chemistry[SBS_GAUGE_DEVICE_CHEMISTRY_MAX_SIZE];
+} __packed;
+
+enum fuel_gauge_sbs_property {
+	/** Denotes start of SBS specific properties */
+	FUEL_GAUGE_SBS_PROPS_START = _FUEL_GAUGE_SBS_START,
+	/** Retrieve word from SBS1.1 ManufactuerAccess */
+	FUEL_GAUGE_SBS_MFR_ACCESS,
+	/** Battery Mode (flags) */
+	FUEL_GAUGE_SBS_MODE,
+	/** AtRate (mA or 10 mW) */
+	FUEL_GAUGE_SBS_ATRATE,
+	/** AtRateTimeToFull (minutes) */
+	FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL,
+	/** AtRateTimeToEmpty (minutes) */
+	FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
+	/** AtRateOK (boolean) */
+	FUEL_GAUGE_SBS_ATRATE_OK,
+	/** Remaining Capacity Alarm (mAh or 10mWh) */
+	FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
+	/** Remaining Time Alarm (minutes) */
+	FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
+};
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_SBS_H_ */

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/emul.h>
 #include <zephyr/drivers/emul_fuel_gauge.h>
 #include <zephyr/drivers/fuel_gauge.h>
+#include <zephyr/drivers/fuel_gauge_sbs.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
@@ -113,7 +114,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_some_props_failed_returns_failed_prop_c
 			/* Valid property */
 			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
 			/* Set Manufacturer's Access to arbitrary word */
-			.value.sbs_mfr_access_word = 1,
+			.value.sbs_word = 1,
 		},
 
 	};
@@ -140,23 +141,23 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_prop_can_be_get)
 			/* Valid property */
 			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
 			/* Set Manufacturer's Access to 16 bit word */
-			.value.sbs_mfr_access_word = word,
+			.value.sbs_word = word,
 		},
 		{
 			.property_type = FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
-			.value.sbs_remaining_capacity_alarm = word,
+			.value.sbs_word = word,
 		},
 		{
 			.property_type = FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
-			.value.sbs_remaining_time_alarm = word,
+			.value.sbs_word = word,
 		},
 		{
 			.property_type = FUEL_GAUGE_SBS_MODE,
-			.value.sbs_mode = word,
+			.value.sbs_word = word,
 		},
 		{
 			.property_type = FUEL_GAUGE_SBS_ATRATE,
-			.value.sbs_at_rate = (int16_t)word,
+			.value.sbs_word = word,
 		},
 	};
 
@@ -188,13 +189,10 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_prop_can_be_get)
 	for (int i = 0; i < ARRAY_SIZE(get_props); i++) {
 		zassert_ok(get_props[i].status, "Property %d getting %d has a bad status.", i,
 			   get_props[i].property_type);
+		zassert_equal(get_props[i].value.sbs_word, word,
+			      "Property %d set as %d but was get as %d.", i, word,
+			      get_props[i].value.sbs_word);
 	}
-
-	zassert_equal(get_props[0].value.sbs_mfr_access_word, word);
-	zassert_equal(get_props[1].value.sbs_remaining_capacity_alarm, word);
-	zassert_equal(get_props[2].value.sbs_remaining_time_alarm, word);
-	zassert_equal(get_props[3].value.sbs_mode, word);
-	zassert_equal(get_props[4].value.sbs_at_rate, (int16_t)word);
 }
 
 ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)


### PR DESCRIPTION
Moving SBS specific properties to a separate header.

# Immediate followup changes

* Remove the `fuel_gauge_set/get_property` structs in favor of a single property struct.