### PR TITLE
doc: driver: samples: Update driver samples to use new Sphinx extension

### DIFF
--- a/boards/arm/adafruit_itsybitsy_nrf52840/doc/index.rst
+++ b/boards/arm/adafruit_itsybitsy_nrf52840/doc/index.rst
@@ -123,7 +123,7 @@ The :zephyr:code-sample:`button` sample lets you test the buttons (switches) and
 The :zephyr:code-sample:`blinky` sample lets you test the red LED.
 
 The DotStar LED has been implemented as a SPI device and can be tested
-with the :ref:`led_apa102_sample` sample application.
+with the :zephyr:code-sample:`led-apa102` sample application.
 
 You can build and flash the examples to make sure Zephyr is running correctly on
 your board. The button and LED definitions can be found in

--- a/boards/arm/blueclover_plt_demo_v2_nrf52832/doc/index.rst
+++ b/boards/arm/blueclover_plt_demo_v2_nrf52832/doc/index.rst
@@ -122,7 +122,7 @@ Flashing
 Flashing Zephyr onto the ``blueclover_plt_demo_v2_nrf52832`` board requires
 an external programmer. The programmer is attached to the SWD header.
 
-Build the Zephyr kernel and the :ref:`led_apa102_sample` sample application.
+Build the Zephyr kernel and the :zephyr:code-sample:`led-apa102` sample application.
 
    .. zephyr-app-commands::
       :zephyr-app: samples/drivers/led_apa102

--- a/boards/posix/native_posix/doc/index.rst
+++ b/boards/posix/native_posix/doc/index.rst
@@ -466,7 +466,7 @@ Interaction with serial ports can be configured in several different ways:
 
 Multiple instances of such uart drivers are supported.
 
-The :ref:`sample-uart-native-tty` sample app provides a working example of the
+The :zephyr:code-sample:`uart-native-tty` sample app provides a working example of the
 driver.
 
 This driver only supports poll mode. Interrupt and async mode are not supported.

--- a/boards/shields/ftdi_vm800c/doc/index.rst
+++ b/boards/shields/ftdi_vm800c/doc/index.rst
@@ -70,7 +70,7 @@ Sample usage
 
 You can try use FT800 with the Zephyr FT800 sample, which provides
 out-of-the-box configuration for FT800 Embedded Video engine.
-See :ref:`display-ft800-sample` for details.
+See :zephyr:code-sample:`ft800` sample for details.
 
 Build and Programming
 *********************

--- a/boards/shields/x_nucleo_eeprma2/doc/index.rst
+++ b/boards/shields/x_nucleo_eeprma2/doc/index.rst
@@ -50,7 +50,7 @@ and the X-NUCLEO-EEPRMA2 in particular, see these ST Microelectronics documents:
 Samples
 *******
 
-The :ref:`samples_eeprom` can be used to demonstrate the expansion boards
+The :zephyr:code-sample:`eeprom` sample can be used to demonstrate the expansion boards
 functionality.
 Per default the shield sets an ``eeprom-0`` alias for the M24C02-FMC6TG EEPROM,
 which can be overwritten to use the other EEPROM devices instead.

--- a/boards/xtensa/yd_esp32/doc/index.rst
+++ b/boards/xtensa/yd_esp32/doc/index.rst
@@ -233,7 +233,7 @@ RGB LED
 =======
 
 The board contains an addressable RGB LED (`XL-5050RGBC-WS2812B`_), driven by GPIO16.
-Here is an example of how to test it using the :ref:`led_ws2812_sample` application.
+Here is an example of how to test it using the :zephyr:code-sample:`led-ws2812` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/led_ws2812

--- a/doc/hardware/peripherals/canbus/controller.rst
+++ b/doc/hardware/peripherals/canbus/controller.rst
@@ -332,7 +332,7 @@ Samples
 *******
 
 We have two ready-to-build samples demonstrating use of the Zephyr CAN API:
-:ref:`Zephyr CAN counter sample <can-counter-sample>` and
+:zephyr:code-sample:`Zephyr CAN counter sample <can-counter-sample>` and
 :zephyr:code-sample:`SocketCAN sample <socket-can>`.
 
 

--- a/doc/services/virtualization/ivshmem.rst
+++ b/doc/services/virtualization/ivshmem.rst
@@ -46,7 +46,7 @@ Zephyr also supports ivshmem-v2:
 https://github.com/siemens/jailhouse/blob/master/Documentation/ivshmem-v2-specification.md
 
 This is primarily used for IPC in the Jailhouse hypervisor
-(e.g. :ref:`eth_ivshmem_sample`). It is also possible to use ivshmem-v2 without
+(e.g. :zephyr:code-sample:`eth-ivshmem`). It is also possible to use ivshmem-v2 without
 Jailhouse by building the Siemens fork of QEMU, and modifying the QEMU launch flags:
 
 https://github.com/siemens/qemu/tree/wip/ivshmem2

--- a/samples/boards/stm32/uart/single_wire/README.rst
+++ b/samples/boards/stm32/uart/single_wire/README.rst
@@ -1,7 +1,8 @@
-.. _sample_uart_stm32_single_wire:
+.. zephyr:code-sample:: uart-stm32-single-wire
+   :name: STM32 single-wire UART
+   :relevant-api: uart_interface
 
-STM32 Single Wire UART
-######################
+   Use single-wire/half-duplex UART functionality of STM32 devices.
 
 Overview
 ********

--- a/samples/drivers/adc/README.rst
+++ b/samples/drivers/adc/README.rst
@@ -1,12 +1,13 @@
-.. _adc-sample:
+.. zephyr:code-sample:: adc
+   :name: Analog-to-Digital Converter (ADC)
+   :relevant-api: adc_interface
 
-Analog-to-Digital Converter (ADC)
-#################################
+   Read analog inputs from ADC channels.
 
 Overview
 ********
 
-This sample demonstrates how to use the ADC driver API.
+This sample demonstrates how to use the :ref:`ADC driver API <adc_api>`.
 
 Depending on the target board, it reads ADC samples from one or more channels
 and prints the readings on the console. If voltage of the used reference can

--- a/samples/drivers/audio/dmic/README.rst
+++ b/samples/drivers/audio/dmic/README.rst
@@ -1,13 +1,14 @@
-.. _dmic_sample:
+.. zephyr:code-sample:: dmic
+   :name: Digital Microphone (DMIC)
+   :relevant-api: audio_dmic_interface
 
-DMIC Sample
-###########
+   Perform PDM transfers using different configurations.
 
 Overview
 ********
 
-This is a very simple application intended to show how to use the Audio DMIC
-API and also to be an aid in developing drivers to implement this API.
+This is a very simple application intended to show how to use the :ref:`Audio DMIC
+API <audio_dmic_api>` and also to be an aid in developing drivers to implement this API.
 It performs two PDM transfers with different configurations (using one channel
 and two channels) but does not in any way process the received audio data.
 

--- a/samples/drivers/auxdisplay/README.rst
+++ b/samples/drivers/auxdisplay/README.rst
@@ -1,13 +1,14 @@
-.. _auxdisplay-sample:
+.. zephyr:code-sample:: auxdisplay
+   :name: Auxiliary display
+   :relevant-api: auxdisplay_interface
 
-Auxiliary display sample
-########################
+   Output "Hello  World" to an auxiliary display.
 
 Overview
 ********
 
-This sample shows how to use the auxiliary display drivers by outputting a
-sample "Hello World" text to one.
+This sample shows how to use the :ref:`auxiliary display driver <auxdisplay_api>`
+by outputting a sample "Hello World" text to one.
 
 Building and Running
 ********************

--- a/samples/drivers/can/babbling/README.rst
+++ b/samples/drivers/can/babbling/README.rst
@@ -1,7 +1,8 @@
-.. _can-babbling-sample:
+.. zephyr:code-sample:: can-babbling
+   :name: Controller Area Network (CAN) babbling node
+   :relevant-api: can_interface
 
-Controller Area Network (CAN) Babbling Node
-###########################################
+   Simulate a babbling CAN node.
 
 Overview
 ********

--- a/samples/drivers/can/counter/README.rst
+++ b/samples/drivers/can/counter/README.rst
@@ -1,7 +1,8 @@
-.. _can-counter-sample:
+.. zephyr:code-sample:: can-counter
+   :name: Controller Area Network (CAN) counter
+   :relevant-api: can_interface
 
-Controller Area Network (CAN) Counter
-#####################################
+   Send and receive CAN messages.
 
 Overview
 ********

--- a/samples/drivers/clock_control_litex/README.rst
+++ b/samples/drivers/clock_control_litex/README.rst
@@ -1,7 +1,8 @@
-.. _clock_control_litex_sample:
+.. zephyr:code-sample:: clock-control-litex
+   :name: LiteX clock control driver
+   :relevant-api: clock_control_interface
 
-LiteX Clock Control Driver Sample
-#################################
+   Use LiteX clock control driver to generate multiple clock signals.
 
 Introduction
 ************

--- a/samples/drivers/counter/alarm/README.rst
+++ b/samples/drivers/counter/alarm/README.rst
@@ -1,11 +1,12 @@
-.. _alarm_sample:
+.. zephyr:code-sample:: alarm
+   :name: Counter Alarm
+   :relevant-api: counter_interface
 
-Counter Alarm Sample
-#####################
+   Implement an alarm application using the counter API.
 
 Overview
 ********
-This sample provides an example of alarm application using counter API.
+This sample provides an example of alarm application using :ref:`counter API <counter_api>`.
 It sets an alarm with an initial delay of 2 seconds. At each alarm
 expiry, a new alarm is configured with a delay multiplied by 2.
 

--- a/samples/drivers/counter/maxim_ds3231/README.rst
+++ b/samples/drivers/counter/maxim_ds3231/README.rst
@@ -1,7 +1,8 @@
-.. _maxim-ds3231-sample:
+.. zephyr:code-sample:: ds3231
+   :name: DS3231 TCXO RTC
+   :relevant-api: counter_interface
 
-Maxim DS3231 TCXO RTC Sample Application
-########################################
+   Interact with a DS3231 real-time clock using the counter API and dedicated driver API.
 
 Overview
 ********

--- a/samples/drivers/crypto/README.rst
+++ b/samples/drivers/crypto/README.rst
@@ -1,11 +1,12 @@
-.. _crypto_sample:
+.. zephyr:code-sample:: crypto
+   :name: Crypto
+   :relevant-api: crypto
 
-Crypto
-######
+   Use the crypto APIs to perform various encryption/decryption operations.
 
 Overview
 ********
-An example to illustrate the usage of crypto APIs.
+An example to illustrate the usage of :ref:`crypto APIs <crypto_api>`.
 
 Building and Running
 ********************

--- a/samples/drivers/dac/README.rst
+++ b/samples/drivers/dac/README.rst
@@ -1,12 +1,13 @@
-.. _dac-sample:
+.. zephyr:code-sample:: dac
+   :name: Digital-to-Analog Converter (DAC)
+   :relevant-api: dac_interface
 
-Digital-to-Analog Converter (DAC)
-#################################
+   Generate an analog sawtooth signal using the DAC driver API.
 
 Overview
 ********
 
-This sample demonstrates how to use the DAC driver API.
+This sample demonstrates how to use the `DAC driver API <dac_api>`.
 
 Building and Running
 ********************

--- a/samples/drivers/display/README.rst
+++ b/samples/drivers/display/README.rst
@@ -1,7 +1,8 @@
-.. _display-sample:
+.. zephyr:code-sample:: display
+   :name: Display
+   :relevant-api: display_interface
 
-Display Sample
-##############
+   Draw basic rectangles on a display device.
 
 Overview
 ********

--- a/samples/drivers/eeprom/README.rst
+++ b/samples/drivers/eeprom/README.rst
@@ -1,12 +1,13 @@
-.. _samples_eeprom:
+.. zephyr:code-sample:: eeprom
+   :name: EEPROM
+   :relevant-api: eeprom_interface
 
-EEPROM Sample
-#############
+   Store a boot count value in EEPROM.
 
 Overview
 ********
 
-This sample demonstrates the EEPROM driver API in a simple boot counter
+This sample demonstrates the `EEPROM driver API <eeprom_api>` in a simple boot counter
 application.
 
 Building and Running

--- a/samples/drivers/espi/README.rst
+++ b/samples/drivers/espi/README.rst
@@ -1,13 +1,14 @@
-.. _espi-sample:
+.. zephyr:code-sample:: espi
+   :name: Enhanced Serial Peripheral Interface (eSPI)
+   :relevant-api: espi_interface spi_interface
 
-Enhanced Serial Peripheral Interface
-####################################
+   Use eSPI to connect to a slave device and exchange virtual wire packets.
 
 Overview
 ********
 
-This sample demonstrates how to use the Enhanced Serial Peripheral Interface
-(eSPI) API.
+This sample demonstrates how to use the :ref:`Enhanced Serial Peripheral Interface
+(eSPI) API <espi_api>`.
 It shows how to configure and select eSPI controller capabilities as part of
 a simple eSPI handshake that includes exchanging virtual wire packets.
 

--- a/samples/drivers/ethernet/eth_ivshmem/README.rst
+++ b/samples/drivers/ethernet/eth_ivshmem/README.rst
@@ -1,7 +1,8 @@
-.. _eth_ivshmem_sample:
+.. zephyr:code-sample:: eth-ivshmem
+   :name: Inter-VM Shared Memory (ivshmem) Ethernet
+   :relevant-api: ivshmem ethernet
 
-Inter-VM Shared Memory (ivshmem) Ethernet Sample Application
-############################################################
+   Communicate with another "cell" in the Jailhouse hypervisor using IVSHMEM Ethernet.
 
 Overview
 ********

--- a/samples/drivers/flash_shell/README.rst
+++ b/samples/drivers/flash_shell/README.rst
@@ -1,10 +1,12 @@
-.. _samples_flash_shell:
+.. zephyr:code-sample:: flash-shell
+   :name: Flash shell
+   :relevant-api: flash_interface
 
-Flash Shell Sample
-##################
+   Explore a flash device using shell commands.
 
 Overview
 ********
+
 This is a simple shell module that allows arbitrary boards with flash
 driver support to explore the flash device.
 

--- a/samples/drivers/fpga/fpga_controller/README.rst
+++ b/samples/drivers/fpga/fpga_controller/README.rst
@@ -1,7 +1,7 @@
-.. _samples_fpga_controller:
+.. zephyr:code-sample:: fpga-controller
+   :name: FPGA Controller
 
-Zephyr FPGA controller
-######################
+   Load a bitstream into an FPGA and perform basic operations on it.
 
 Overview
 ********

--- a/samples/drivers/ht16k33/README.rst
+++ b/samples/drivers/ht16k33/README.rst
@@ -1,7 +1,8 @@
-.. _ht16k33:
+.. zephyr:code-sample:: ht16k33
+   :name: HT16K33 LED driver with keyscan
+   :relevant-api: led_interface kscan_interface
 
-HT16K33 LED driver with keyscan
-###############################
+   Control up to 128 LEDs connected to an HT16K33 LED driver and log keyscan events.
 
 Overview
 ********
@@ -23,7 +24,7 @@ Building and Running
 ********************
 
 Build the application for the :ref:`nrf52840dk_nrf52840` board, and
-connect a HT16K33 LED driver at address 0x70 on the I2C-0 bus.
+connect an HT16K33 LED driver at address 0x70 on the I2C-0 bus.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/ht16k33

--- a/samples/drivers/i2s/echo/README.rst
+++ b/samples/drivers/i2s/echo/README.rst
@@ -1,7 +1,8 @@
-.. _i2s_echo_sample:
+.. zephyr:code-sample:: i2s-echo
+   :name: I2S echo
+   :relevant-api: i2s_interface
 
-I2S Echo Sample
-###############
+   Process an audio stream to add an echo effect.
 
 Overview
 ********

--- a/samples/drivers/ipm/ipm_esp32/README.rst
+++ b/samples/drivers/ipm/ipm_esp32/README.rst
@@ -1,7 +1,8 @@
-.. _ipm_esp32:
+.. zephyr:code-sample:: ipm-esp32
+   :name: IPM on ESP32
+   :relevant-api: ipm_interface
 
-ESP32 Soft-IPM example
-######################
+   Implement inter-processor mailbox (IPM) between ESP32 APP and PRO CPUs.
 
 Overview
 ********
@@ -16,7 +17,7 @@ ESP32 intercore messaging has up two four channels, the 0 and 1 are
 reserved for BT and WIFI messages, and channels 2 and 3 is free to
 any application, each channel supports up to 64 bytes of data per
 message, so high level protocol is responsible to fragment larger
-messages in chunks of 64bytes.
+messages in chunks of 64 bytes.
 
 Building and Running the Zephyr Code
 ************************************

--- a/samples/drivers/ipm/ipm_imx/README.rst
+++ b/samples/drivers/ipm/ipm_imx/README.rst
@@ -1,7 +1,8 @@
-.. _ipm_imx:
+.. zephyr:code-sample:: ipm-imx
+   :name: IPM on NXP i.MX
+   :relevant-api: ipm_interface
 
-i.MX IPM example
-################
+   Implement inter-processor mailbox (IPM) on i.MX SoCs containing a Messaging Unit peripheral.
 
 Overview
 ********

--- a/samples/drivers/ipm/ipm_ivshmem/README.rst
+++ b/samples/drivers/ipm/ipm_ivshmem/README.rst
@@ -1,5 +1,8 @@
-IPM over IVSHMEM Driver sample
-################################
+.. zephyr:code-sample:: ipm-ivshmem
+   :name: IPM over IVSHMEM
+   :relevant-api: ipm_interface
+
+   Implement inter-processor mailbox (IPM) over IVSHMEM (Inter-VM shared memory)
 
 Prerequisites
 *************

--- a/samples/drivers/ipm/ipm_mcux/README.rst
+++ b/samples/drivers/ipm/ipm_mcux/README.rst
@@ -1,7 +1,8 @@
-.. _ipm-mcux-sample:
+.. zephyr:code-sample:: ipm-mcux
+   :name: IPM on NXP LPC
+   :relevant-api: ipm_interface
 
-Sample mailbox application
-##########################
+   Implement inter-processor mailbox (IPM) on NXP LPC family.
 
 Overview
 ********

--- a/samples/drivers/ipm/ipm_mhu_dual_core/README.rst
+++ b/samples/drivers/ipm/ipm_mhu_dual_core/README.rst
@@ -1,7 +1,8 @@
-.. _ipm_mhu_dual_core:
+.. zephyr:code-sample:: ipm-mhu-dual-core
+   :name: IPM with ARM MHU
+   :relevant-api: ipm_interface
 
-MHU Dual Core
-#############
+   Implement inter-processor mailbox (IPM) using an MHU (Message Handling Unit)
 
 Overview
 ********

--- a/samples/drivers/jesd216/README.rst
+++ b/samples/drivers/jesd216/README.rst
@@ -1,7 +1,8 @@
-.. _jesd216-sample:
+.. zephyr:code-sample:: jesd216
+   :name: JESD216 flash
+   :relevant-api: flash_interface
 
-JESD216 Sample
-##############
+   Use the JESD216 flash API to extract information from a compatible serial memory device.
 
 Overview
 ********

--- a/samples/drivers/kscan/README.rst
+++ b/samples/drivers/kscan/README.rst
@@ -1,7 +1,8 @@
-.. _kscan-sample:
+.. zephyr:code-sample:: kscan
+   :name: KSCAN
+   :relevant-api: kscan_interface timer_apis
 
-KSCAN Interface
-####################################
+   Use the KSCAN API to read key presses and releases on a keyboard matrix.
 
 Overview
 ********

--- a/samples/drivers/kscan_touch/README.rst
+++ b/samples/drivers/kscan_touch/README.rst
@@ -1,7 +1,8 @@
-.. _kscan-touch-sample:
+.. zephyr:code-sample:: kscan-touch
+   :name: KSCAN touch panel
+   :relevant-api: kscan_interface
 
-KSCAN touch panel example
-####################################
+   Use the KSCAN API to interface with a touch panel.
 
 Overview
 ********

--- a/samples/drivers/lcd_hd44780/README.rst
+++ b/samples/drivers/lcd_hd44780/README.rst
@@ -1,7 +1,8 @@
-.. _samples_lcd_hd44780:
+.. zephyr:code-sample:: lcd-hd44780
+   :name: HD44780 LCD controller
+   :relevant-api: gpio_interface
 
-LCD HD44780 driver sample
-#########################
+   Control an HD44780-based LCD display using GPIO pins.
 
 Overview
 ********

--- a/samples/drivers/led_apa102/README.rst
+++ b/samples/drivers/led_apa102/README.rst
@@ -1,7 +1,8 @@
-.. _led_apa102_sample:
+.. zephyr:code-sample:: led-apa102
+   :name: APA102 LED strip
+   :relevant-api: led_strip_interface
 
-APA102 Sample Application
-#########################
+   Control an LED strip using an APA102, Adafruit DotStar, or compatible driver chip.
 
 Overview
 ********

--- a/samples/drivers/led_is31fl3216a/README.rst
+++ b/samples/drivers/led_is31fl3216a/README.rst
@@ -1,7 +1,8 @@
-.. _is31fl3216a:
+.. zephyr:code-sample:: is31fl3216a
+   :name: IS31FL3216A LED
+   :relevant-api: led_interface
 
-is31fl3216a: 16 channels PWD LEDs controller
-############################################
+   Control up to 16 PWM LEDs connected to an IS31FL3216A driver chip.
 
 Overview
 ********
@@ -12,12 +13,13 @@ Each LED is gradually pulsed until it reach 100% of luminosity and gradually
 turned off again.
 
 Once each LED was pulsed, multiple LEDs are pulse simultaneously using the
-``write_channels`` LED API.
+:c:func:`led_write_channels` API.
 
 Test pattern
 ============
 
 For each LED:
+
 - Increase the luminosity until 100% is reached
 - Decrease the luminosity until completely turned off
 

--- a/samples/drivers/led_is31fl3733/README.rst
+++ b/samples/drivers/led_is31fl3733/README.rst
@@ -1,7 +1,8 @@
-.. _is31fl3733:
+.. zephyr:code-sample:: is31fl3733
+   :name: IS31FL3733 LED Matrix
+   :relevant-api: led_interface
 
-IS31FL3733 LED Matrix Driver Demo Application
-#############################################
+   Control a matrix of up to 192 LEDs connected to an IS31FL3733 driver chip.
 
 Overview
 ********
@@ -9,19 +10,20 @@ Overview
 This sample controls a matrix of up to 192 LEDs. The sample performs the
 following test steps in an infinite loop:
 
-- Set all LEDs to full brightness with `led_write_channels` API
-- Disable upper quadrant of LED array with `led_write_channels` API
-- Dim each LED in sequence using `led_set_brightness` API
-- Toggle each LED in sequency using `led_on` and `led_off` APIs
-- Toggle between low or high current limit using `is31fl3733_current_limit`
+- Set all LEDs to full brightness with :c:func:`led_write_channels` API
+- Disable upper quadrant of LED array with :c:func:`led_write_channels` API
+- Dim each LED in sequence using :c:func:`led_set_brightness` API
+- Toggle each LED in sequency using :c:func:`led_on` and :c:func:`led_of` APIs
+- Toggle between low or high current limit using :c:func:`is31fl3733_current_limit`
   API, and repeat the above tests
 
 Sample Configuration
 ====================
 
 The number of LEDs can be limited using the following sample specific Kconfigs:
-- `CONFIG_LED_ROW_COUNT`
-- `CONFIG_LED_COLUMN_COUNT`
+
+- :kconfig:option:`CONFIG_LED_ROW_COUNT`
+- :kconfig:option:`CONFIG_LED_COLUMN_COUNT`
 
 Building and Running
 ********************

--- a/samples/drivers/led_lp3943/README.rst
+++ b/samples/drivers/led_lp3943/README.rst
@@ -1,7 +1,8 @@
-.. _lp3943:
+.. zephyr:code-sample:: lp3943
+   :name: LP3943 RGBW LED
+   :relevant-api: led_interface
 
-LP3943: 16-Channel RGB, White-LED Driver
-########################################
+   Control up to 16 RGBW LEDs connected to an LP3943 driver chip.
 
 Overview
 ********

--- a/samples/drivers/led_lp50xx/README.rst
+++ b/samples/drivers/led_lp50xx/README.rst
@@ -1,7 +1,8 @@
-.. _lp50xx:
+.. zephyr:code-sample:: lp50xx
+   :name: LP50XX RGB LED
+   :relevant-api: led_interface
 
-LP50XX: up to 12 RGB channels
-###############################
+   Control up to 12 RGB LEDs connected to an LP50xx driver chip.
 
 Overview
 ********
@@ -11,8 +12,8 @@ This sample controls up to 12 LEDs connected to a LP50xx driver.
 First, for each LED information is retrieved using the led_get_info syscall
 and printed in the log messages. Next, from an infinite loop, a test pattern
 (described below) is applied to all the LEDs simultaneously (using the
-led_write_channels syscall) and then to each LED one by one (using the
-led_set_{brightness,color} syscalls).
+:c:func:`led_write_channels` syscall) and then to each LED one by one (using the
+:c:func:`led_set_brightness` and :c:func:`led_set_color` syscalls).
 
 Test pattern
 ============

--- a/samples/drivers/led_lp5562/README.rst
+++ b/samples/drivers/led_lp5562/README.rst
@@ -1,7 +1,8 @@
-.. _lp5562:
+.. zephyr:code-sample:: lp5562
+   :name: LP5562 RGB LED
+   :relevant-api: led_interface
 
-LP5562: 4-Channel RGB
-######################
+   Control 4 RGB LEDs connected to an LP5562 driver chip.
 
 Overview
 ********

--- a/samples/drivers/led_lp5569/README.rst
+++ b/samples/drivers/led_lp5569/README.rst
@@ -1,7 +1,8 @@
-.. _lp5569:
+.. zephyr:code-sample:: lp5569
+   :name: LP5569 9-channel LED controller
+   :relevant-api: led_interface
 
-LP5569: 9-Channel LED Controller
-################################
+   Control 9 LEDs connected to an LP5569 driver chip.
 
 Overview
 ********

--- a/samples/drivers/led_lpd8806/README.rst
+++ b/samples/drivers/led_lpd8806/README.rst
@@ -1,7 +1,8 @@
-.. _led_lpd8806_sample:
+.. zephyr:code-sample:: led-lpd8806
+   :name: LPD880x LED strip
+   :relevant-api: led_strip_interface
 
-LPD880x Sample Application
-##########################
+   Control an LED strip using an LPD880x-compatible driver chip.
 
 Overview
 ********

--- a/samples/drivers/led_pca9633/README.rst
+++ b/samples/drivers/led_pca9633/README.rst
@@ -1,7 +1,8 @@
-.. _pca9633:
+.. zephyr:code-sample:: pca9633
+   :name: PCA9633 LED
+   :relevant-api: led_interface
 
-PCA9633: 4-Channel RGB
-######################
+   Control 4 LEDs connected to a PCA9633 driver chip.
 
 Overview
 ********

--- a/samples/drivers/led_pwm/README.rst
+++ b/samples/drivers/led_pwm/README.rst
@@ -1,7 +1,8 @@
-.. _led_pwm:
+.. zephyr:code-sample:: led-pwm
+   :name: LED PWM
+   :relevant-api: led_interface
 
-LED PWM sample application
-##########################
+   Control PWM LEDs using the LED API.
 
 Overview
 ********

--- a/samples/drivers/led_sx1509b_intensity/README.rst
+++ b/samples/drivers/led_sx1509b_intensity/README.rst
@@ -1,7 +1,8 @@
-.. _sx1509b_intensity:
+.. zephyr:code-sample:: sx1509b
+   :name: SX1509B RGB LED
+   :relevant-api: led_interface
 
-SX1509B LED Intensity
-######################
+   Control an RGB LED connected to an SX1509B driver chip.
 
 Overview
 ********

--- a/samples/drivers/led_ws2812/README.rst
+++ b/samples/drivers/led_ws2812/README.rst
@@ -1,7 +1,8 @@
-.. _led_ws2812_sample:
+.. zephyr:code-sample:: led-ws2812
+   :name: WS2812 LED strip
+   :relevant-api: led_strip_interface
 
-WS2812 Sample Application
-#########################
+   Control an LED strip using a WS2812 (or compatible) driver chip.
 
 Overview
 ********
@@ -96,9 +97,11 @@ Supported drivers
 This sample uses different drivers depending on the selected board:
 
 I2S driver:
+
 - thingy52_nrf52832
 
 SPI driver:
+
 - mimxrt1050_evk
 - mimxrt1050_evk_qspi
 - nrf52dk_nrf52832
@@ -108,6 +111,7 @@ SPI driver:
 - nucleo_l476rg
 
 GPIO driver (cortex-M0 only):
+
 - bbc_microbit
 - nrf51dk_nrf51422
 

--- a/samples/drivers/led_xec/README.rst
+++ b/samples/drivers/led_xec/README.rst
@@ -9,12 +9,16 @@ Overview
 This sample allows to test the Microchip led-xec driver which uses the
 breathing-blinking LED (BBLED) controllers. The SoC design is fixed
 allowing each BBLED control over one specific GPIO.
+
 MEC15xx and MEC172x:
-BBLED controller 0 uses GPIO 0156.
-BBLED controller 1 uses GPIO 0157.
-BBLED controller 2 uses GPIO 0153.
-MEC172x has a fourth instance of BBLED.
-BBLED controller 3 uses GPIO 0035
+
+- BBLED controller 0 uses GPIO 0156.
+- BBLED controller 1 uses GPIO 0157.
+- BBLED controller 2 uses GPIO 0153.
+
+MEC172x has a fourth instance of BBLED:
+
+- BBLED controller 3 uses GPIO 0035
 
 Test pattern
 ============
@@ -27,44 +31,50 @@ For each LEDs (one after the other):
 - Blinking on: 1 sec, off: 1 sec
 
 Board Jumpers
-********************
+*************
 
-EVB: mec172xevb_assy6906
-BBLED0 GPIO 0156.
-Connect GPIO 0156 to board LED4 by placing a wire from JP71-11 to J47-3.
-Make sure there are no jumpers on JP54 1-2 and JP21 4-5
+mec172xevb_assy6906 evaluation board
+====================================
 
-BBLED1 GPIO 0157.
-Connect GPIO 0156 to board LED5 by placing a wire from JP71-12 to J48-3.
-Make sure there are no jumpers on JP54 3-4 and JP21 16-17
+- BBLED0: GPIO 0156.
+       - Connect GPIO 0156 to board LED4 by placing a wire from JP71-11 to J47-3.
+       - Make sure there are no jumpers on JP54 1-2 and JP21 4-5
 
-BBLED2 GPIO 0153.
-Connect GPIO 0153 to board LED7 by placing a wire from JP71-5 to JP146-5.
-JP146-5 is connected to MEC172x VCI_OUT1 without a jumper. Force VCI_OUT1
-high by forcing VCI_IN1 high: install jumper on J55 3-4 which pulls VCI_IN1
-to the VBAT rail via a 100K pull-up. Requires VBAT power rail is connected
-to VTR or some other power source.
+- BBLED1: GPIO 0157.
+       - Connect GPIO 0156 to board LED5 by placing a wire from JP71-12 to J48-3.
+       - Make sure there are no jumpers on JP54 3-4 and JP21 16-17
 
-BBLED3 GPIO 0035.
-Connect GPIO 0035 to board LED7 by placing a wire from JP67-19 to JP146-1.
-Make sure there is no jumper on JP79 17-18.
-JP146-1 is connected to MEC172x VCI_OUT2 without a jumper. Force VCI_OUT2
-high by forcing VCI_IN2 high: install a jumper on J55 5-6 which pulls VCI_IN2
-to the VBAT rail via a 100K pull-up. Requires VBAT power rail is connected
-to VTR or some other power source.
+- BBLED2: GPIO 0153.
+       - Connect GPIO 0153 to board LED7 by placing a wire from JP71-5 to JP146-5.
 
-EVB: mec15xxevb_assy6853
-BBLED0 GPIO 0156.
-Add jumper on JP41 1-2 to connect GPIO 0156 to board LED2
-Remove jumper on JP31 13-14
+         JP146-5 is connected to MEC172x VCI_OUT1 without a jumper. Force VCI_OUT1
+         high by forcing VCI_IN1 high: install jumper on J55 3-4 which pulls VCI_IN1
+         to the VBAT rail via a 100K pull-up. Requires VBAT power rail is connected
+         to VTR or some other power source.
 
-BBLED1 GPIO 0157.
-Add jumper on JP41 3-4 to connect GPIO 0157 to board LED3
-Remove jumper on JP31 15-16
+- BBLED3: GPIO 0035.
+       - Connect GPIO 0035 to board LED7 by placing a wire from JP67-19 to JP146-1.
+       - Make sure there is no jumper on JP79 17-18.
 
-BBLED2 GPIO 0153.
-Add jumper on JP41 3-4 to connect GPIO 0153 to board LED4
-Remove jumper on JP31 17-18
+         JP146-1 is connected to MEC172x VCI_OUT2 without a jumper. Force VCI_OUT2
+         high by forcing VCI_IN2 high: install a jumper on J55 5-6 which pulls VCI_IN2
+         to the VBAT rail via a 100K pull-up. Requires VBAT power rail is connected
+         to VTR or some other power source.
+
+mec15xxevb_assy6853 evaluation board
+====================================
+
+- BBLED0: GPIO 0156.
+       - Add jumper on JP41 1-2 to connect GPIO 0156 to board LED2
+       - Remove jumper on JP31 13-14
+
+- BBLED1: GPIO 0157.
+       - Add jumper on JP41 3-4 to connect GPIO 0157 to board LED3
+       - Remove jumper on JP31 15-16
+
+- BBLED2: GPIO 0153.
+       - Add jumper on JP41 3-4 to connect GPIO 0153 to board LED4
+       - Remove jumper on JP31 17-18
 
 Building and Running
 ********************

--- a/samples/drivers/led_xec/README.rst
+++ b/samples/drivers/led_xec/README.rst
@@ -1,7 +1,8 @@
-.. _led:
+.. zephyr:code-sample:: led-xec
+   :name: Breathing-blinking LED (BBLED)
+   :relevant-api: led_interface
 
-LED sample application
-##########################
+   Control a BBLED (Breathing-Blinking LED) using Microchip XEC driver.
 
 Overview
 ********

--- a/samples/drivers/mbox/README.rst
+++ b/samples/drivers/mbox/README.rst
@@ -1,7 +1,8 @@
-.. _mbox-sample:
+.. zephyr:code-sample:: mbox
+   :name: MBOX
+   :relevant-api: mbox_interface
 
-MBOX Interface
-##############
+   Perform inter-processor mailbox communication using the MBOX API.
 
 Overview
 ********

--- a/samples/drivers/memc/README.rst
+++ b/samples/drivers/memc/README.rst
@@ -1,7 +1,7 @@
-.. _memc:
+.. zephyr:code-sample:: memc
+   :name: Memory controller (MEMC) driver
 
-MEMC Driver Sample
-##################
+   Access memory-mapped external RAM
 
 Overview
 ********

--- a/samples/drivers/misc/ft800/README.rst
+++ b/samples/drivers/misc/ft800/README.rst
@@ -1,7 +1,8 @@
-.. _display-ft800-sample:
+.. zephyr:code-sample:: ft800
+   :name: FT800
+   :relevant-api: ft8xx_interface
 
-FT800
-#####
+   Display various shapes and text using FT800 Embedded Video Engine.
 
 Overview
 ********

--- a/samples/drivers/misc/grove_display/README.rst
+++ b/samples/drivers/misc/grove_display/README.rst
@@ -1,7 +1,8 @@
-.. _grove-lcd-sample:
+.. zephyr:code-sample:: grove-lcd
+   :name: Grove LCD
+   :relevant-api: grove_display
 
-Grove LCD
-#########
+   Display an incrementing counter and change the backlight color.
 
 Overview
 ********

--- a/samples/drivers/peci/README.rst
+++ b/samples/drivers/peci/README.rst
@@ -1,7 +1,8 @@
-.. _peci-sample:
+.. zephyr:code-sample:: peci
+   :name: PECI interface
+   :relevant-api: peci_interface
 
-PECI Interface
-####################################
+   Monitor CPU temperature using PECI.
 
 Overview
 ********

--- a/samples/drivers/ps2/README.rst
+++ b/samples/drivers/ps2/README.rst
@@ -1,7 +1,8 @@
-.. _ps2-sample:
+.. zephyr:code-sample:: ps2
+   :name: PS/2 interface
+   :relevant-api: ps2_interface
 
-PS/2 Interface
-####################################
+   Communicate with a PS/2 mouse.
 
 Overview
 ********

--- a/samples/drivers/smbus/README.rst
+++ b/samples/drivers/smbus/README.rst
@@ -2,7 +2,7 @@
    :name: SMBus shell
    :relevant-api: smbus_interface
 
-   SMBus Shell Sample
+   Interact with SMBus peripherals using shell commands.
 
 Overview
 ********
@@ -33,7 +33,7 @@ Output from console when application started::
    Start SMBUS shell sample qemu_x86_64
    uart:~$
 
-List avaibalbe SMBus shell commands with::
+List available SMBus shell commands with::
 
    uart:~$ smbus
    smbus - smbus commands

--- a/samples/drivers/soc_flash_nrf/README.rst
+++ b/samples/drivers/soc_flash_nrf/README.rst
@@ -1,18 +1,19 @@
-.. _soc-flash-nrf-sample:
+.. zephyr:code-sample:: soc-flash-nrf
+   :name: nRF SoC flash
+   :relevant-api: flash_interface flash_area_api
 
-nRF SoC flash sample
-####################
+   Use the flash API to interact with the SoC flash.
 
 Overview
 ********
 
-This sample demonstrates using the flash API on a SoC internal flash.
-The sample uses :ref:`flash_map_api` to obtain device for flash, using
-DTS node label, and then directly uses :ref:`flash_api` to perform
+This sample demonstrates using the :ref:`Flash API <flash_api>` on an SoC internal flash.
+The sample uses :ref:`Flash map API <flash_map_api>` to obtain device for flash, using
+DTS node label, and then directly uses :ref:`Flash API <flash_api>` to perform
 flash operations.
 
-Within the sample user may observe how read/write/erase operations
-are performed on a device and how to first check whether device is
+Within the sample, user may observe how read/write/erase operations
+are performed on a device, and how to first check whether device is
 ready for operation.
 
 Building and Running

--- a/samples/drivers/spi_bitbang/README.rst
+++ b/samples/drivers/spi_bitbang/README.rst
@@ -1,7 +1,8 @@
-.. _spi-bitbang-sample:
+.. zephyr:code-sample:: spi-bitbang
+   :name: SPI bitbang
+   :relevant-api: spi_interface
 
-SPI-Bitbang Sample
-####################
+   Use the bitbang SPI driver for communicating with a slave.
 
 Overview
 ********

--- a/samples/drivers/spi_flash/README.rst
+++ b/samples/drivers/spi_flash/README.rst
@@ -1,12 +1,13 @@
-.. _spi-nor-sample:
+.. zephyr:code-sample:: spi-nor
+   :name: JEDEC SPI-NOR flash
+   :relevant-api: flash_interface
 
-JEDEC SPI-NOR Sample
-####################
+   Use the flash API to interact with an SPI NOR serial flash memory device.
 
 Overview
 ********
 
-This sample demonstrates using the flash API on a SPI NOR serial flash
+This sample demonstrates using the `flash API <flash_api>` on a SPI NOR serial flash
 memory device.  While trivial it is an example of direct access and
 allows confirmation that the flash is working and that automatic power
 savings is correctly implemented.

--- a/samples/drivers/spi_flash_at45/README.rst
+++ b/samples/drivers/spi_flash_at45/README.rst
@@ -1,7 +1,8 @@
-.. _spi_flash_at45_sample:
+.. zephyr:code-sample:: spi-flash-at45
+   :name: AT45 DataFlash driver
+   :relevant-api: flash_interface
 
-AT45 DataFlash driver sample
-#############################
+   Use the AT45 family DataFlash driver to interact with the flash memory over SPI.
 
 Overview
 ********
@@ -23,7 +24,7 @@ enables the flash page layout API which allow show the flash information.
 In the default configuration, the AT45 flash driver is configured to use
 the Read-Modify-Write functionality of DataFlash chips and does not perform
 page erasing, as it is not needed in this case. This can be modified by
-simply disabling the SPI_FLASH_AT45_USE_READ_MODIFY_WRITE option.
+simply disabling the :kconfig:option:`CONFIG_SPI_FLASH_AT45_USE_READ_MODIFY_WRITE` option.
 
 Requirements
 ************

--- a/samples/drivers/uart/echo_bot/README.rst
+++ b/samples/drivers/uart/echo_bot/README.rst
@@ -1,7 +1,8 @@
-.. _uart_sample:
+.. zephyr:code-sample:: uart
+   :name: UART echo
+   :relevant-api: uart_interface
 
-UART Driver Sample
-##################
+   Read data from the console and echo it back.
 
 Overview
 ********

--- a/samples/drivers/uart/native_tty/README.rst
+++ b/samples/drivers/uart/native_tty/README.rst
@@ -1,7 +1,8 @@
-.. _sample-uart-native-tty:
+.. zephyr:code-sample:: uart-native-tty
+   :name: Native TTY UART
+   :relevant-api: uart_interface
 
-Native TTY UART
-###############
+   Use native TTY driver to send and receive data between two UART-to-USB bridge dongles.
 
 Overview
 ********

--- a/samples/drivers/virtualization/ivshmem/doorbell/README.rst
+++ b/samples/drivers/virtualization/ivshmem/doorbell/README.rst
@@ -1,5 +1,9 @@
-IVSHMEM Doorbell Sample Application
-###################################
+.. zephyr:code-sample:: ivshmem-doorbell
+   :name: IVSHMEM doorbell
+   :relevant-api: ivshmem
+
+   Use Inter-VM Shared Memory to exchange messages between two processes running on different
+   operating systems.
 
 Overview
 ********
@@ -62,7 +66,7 @@ How to
 .. note::
 
    The ivshmem shared memory can be manipulated to crash QEMU and bring down
-   Zephyr. Check `ivshmem_doorbell_sample_security`_ for details.
+   Zephyr. Check :ref:`ivshmem_doorbell_sample_security` section for more details.
 
 .. note::
 

--- a/samples/drivers/w1/scanner/README.rst
+++ b/samples/drivers/w1/scanner/README.rst
@@ -1,7 +1,8 @@
-.. _w1_scanner_sample:
+.. zephyr:code-sample:: w1-scanner
+   :name: 1-Wire scanner
+   :relevant-api: w1_interface
 
-1-Wire Scanner Sample
-#####################
+   Scan for 1-Wire devices and print their family ID and serial number.
 
 Overview
 ********

--- a/samples/drivers/watchdog/README.rst
+++ b/samples/drivers/watchdog/README.rst
@@ -1,7 +1,8 @@
-.. _watchdog-sample:
+.. zephyr:code-sample:: watchdog
+   :name: Watchdog
+   :relevant-api: watchdog_interface
 
-Watchdog Sample
-###############
+   Use the watchdog driver API to reset the board when it gets stuck in an infinite loop.
 
 Overview
 ********


### PR DESCRIPTION
Migrated existing driver samples to use the new code-sample directive and role.
Live docs: https://builds.zephyrproject.io/zephyr/pr/62367/docs/

As a reminder, this allows to easily discover related code samples when browsing the API reference of a driver ; ex:

<img width="655" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/128251/cbadbbbb-ab60-4a15-ac20-44676441f260">
