### PR TITLE
arch: common: create padding section to align ramfunc region

### DIFF
--- a/arch/common/ramfunc.ld
+++ b/arch/common/ramfunc.ld
@@ -7,9 +7,23 @@
 
 /* Copied from linker.ld */
 
-SECTION_DATA_PROLOGUE(.ramfunc,,)
+/* The ramfunc region must have an associated MPU entry added for it, so that
+ * code can be executed in RAM. This means the start of the ramfunc region
+ * must respect MPU alignment requirements. We include a padding section here
+ * in order to make sure the region will be placed at the correct offset
+ * in flash.
+ */
+SECTION_PROLOGUE(ramfunc_padding_section,,)
 {
 	MPU_ALIGN(__ramfunc_size);
+#ifdef CONFIG_BUILD_ALIGN_LMA
+} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#else
+} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+#endif
+
+SECTION_DATA_PROLOGUE(.ramfunc,,)
+{
 	__ramfunc_start = .;
 	*(.ramfunc)
 	*(".ramfunc.*")


### PR DESCRIPTION
The ramfunc region alignment was performed within the section itself, which resulted in padding being added within the output image when the ramfunc region was not the first section in the RAM region. This meant that the memcpy call to copy ramfunc data in z_data_copy was starting the copy from the incorrect offset in flash, since the copy started from the beginning of the padding region.

To resolve this, define a separate padding region prior to the ramfunc section, which will be linked into the output when CONFIG_BUILD_ALIGN_LMA=y (to preserve section alignment). Otherwise, the region will simply exist in RAM to keep __ramfunc_start aligned at an MPU boundary.

Fixes #62368