### PR TITLE
tests: code_relocation: update test filters

### DIFF
--- a/tests/application_development/code_relocation/testcase.yaml
+++ b/tests/application_development/code_relocation/testcase.yaml
@@ -9,16 +9,17 @@ tests:
     platform_allow:
       - mimxrt1060_evk
   application_development.code_relocation_kinetis:
-    filter: CONFIG_CPU_HAS_NXP_MPU and CONFIG_MINIMAL_LIBC
+    filter: CONFIG_CPU_HAS_NXP_MPU
     arch_allow: arm
     extra_configs:
       - CONFIG_MPU_ALLOW_FLASH_WRITE=y
     platform_allow:
       - frdm_k64f
   application_development.code_relocation.nxp_s32:
-    filter: not CONFIG_CPU_HAS_NXP_MPU and CONFIG_MINIMAL_LIBC and dt_chosen_enabled("zephyr,itcm")
+    filter: dt_chosen_enabled("zephyr,itcm")
     arch_allow: arm
     extra_configs:
+      - CONFIG_MINIMAL_LIBC=y
       - CONFIG_RELOCATE_TO_ITCM=y
       - CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
     platform_allow:


### PR DESCRIPTION
ITCM relocation tests depends on MINIMAL_LIBC and when using Zephyr SDK the default is PICOLIBC for mr_canhubk3 board, so explicitly select it. Also the NXP S32 platforms don't have NXP MPU, so remove it.

For frdm_k64f the ITCM relocation test is not executed, so remove the unnecessary filter CONFIG_MINIMAL_LIBC.