### PR TITLE
modules: Add DevAlert (DFM) and move Tracerecorder into percepio module

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3376,6 +3376,16 @@ West:
   labels:
     - "area: OpenThread"
 
+"West project: percepio":
+  status: maintained
+  maintainers:
+    - eriktamlin
+    - aronlander-pe
+  files:
+    - modules/percepio/
+  labels:
+    - "area: Tracing"
+
 "West project: picolibc":
   status: maintained
   maintainers:
@@ -3439,15 +3449,6 @@ West:
     - modules/Kconfig.tinycrypt
   labels:
     - "area: Crypto / RNG"
-
-"West project: TraceRecorderSource":
-  status: maintained
-  maintainers:
-    - eriktamlin
-  files:
-    - modules/TraceRecorder/
-  labels:
-    - "area: Tracing"
 
 "West project: trusted-firmware-m":
   status: maintained

--- a/modules/percepio/CMakeLists.txt
+++ b/modules/percepio/CMakeLists.txt
@@ -2,11 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+if (CONFIG_PERCEPIO_TRACERECORDER OR CONFIG_PERCEPIO_DFM)
+  zephyr_library()
+endif()
+
 if(CONFIG_PERCEPIO_TRACERECORDER)
 
-  set(TRACERECORDER_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
+  set(TRACERECORDER_DIR ${ZEPHYR_CURRENT_MODULE_DIR}/TraceRecorder)
 
-  zephyr_library()
   zephyr_library_sources_ifdef(
     CONFIG_PERCEPIO_TRACERECORDER
     ${TRACERECORDER_DIR}/kernelports/Zephyr/trcKernelPort.c
@@ -81,6 +84,7 @@ if(CONFIG_PERCEPIO_TRACERECORDER)
     )
   endif()
 
+
   zephyr_include_directories(
     ${TRACERECORDER_DIR}/kernelports/Zephyr/include
     ${TRACERECORDER_DIR}/kernelports/Zephyr/config
@@ -88,8 +92,72 @@ if(CONFIG_PERCEPIO_TRACERECORDER)
     ${TRACERECORDER_DIR}/include
     )
 
-    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
       COMMAND python3 ${TRACERECORDER_DIR}/kernelports/Zephyr/scripts/tz_parse_syscalls.py ${CMAKE_BINARY_DIR} ${ZEPHYR_BASE}
+    )
+
+endif()
+
+if(CONFIG_PERCEPIO_DFM)
+
+  set(DFM_DIR ${ZEPHYR_CURRENT_MODULE_DIR}/DFM)
+
+  zephyr_library_sources_ifdef(
+    CONFIG_PERCEPIO_DFM
+    ${DFM_DIR}/dfm.c
+    ${DFM_DIR}/dfmAlert.c
+    ${DFM_DIR}/dfmCloud.c
+    ${DFM_DIR}/dfmEntry.c
+    ${DFM_DIR}/dfmSession.c
+    ${DFM_DIR}/dfmStorage.c
+    ${DFM_DIR}/kernelports/Zephyr/dfmKernelPort.c
+    )
+
+  if(CONFIG_PERCEPIO_DFM_CFG_STORAGEPORT_NONE)
+    zephyr_library_sources(
+      ${DFM_DIR}/storageports/Dummy/dfmStoragePort.c
+    )
+
+    zephyr_include_directories(
+      ${DFM_DIR}/storageports/Dummy/include/
+    )
+  endif()
+
+  if(CONFIG_PERCEPIO_DFM_CFG_STORAGEPORT_FLASH)
+    zephyr_library_sources(
+      ${DFM_DIR}/kernelports/Zephyr/storageports/Flash/dfmStoragePort.c
+    )
+
+    zephyr_include_directories(
+      ${DFM_DIR}/kernelports/Zephyr/storageports/Flash/include/
+    )
+  endif()
+
+  if(CONFIG_PERCEPIO_DFM_CFG_CLOUDPORT_NONE)
+    zephyr_library_sources(
+      ${DFM_DIR}/cloudports/Dummy/dfmCloudPort.c
+    )
+
+    zephyr_include_directories(
+      ${DFM_DIR}/cloudports/Dummy/include/
+    )
+  endif()
+
+  if(CONFIG_PERCEPIO_DFM_CFG_CLOUDPORT_SERIAL)
+    zephyr_library_sources(
+      ${DFM_DIR}/kernelports/Zephyr/cloudports/Serial/dfmCloudPort.c
+    )
+
+    zephyr_include_directories(
+      ${DFM_DIR}/kernelports/Zephyr/cloudports/Serial/config/
+      ${DFM_DIR}/kernelports/Zephyr/cloudports/Serial/include/
+    )
+  endif()
+
+  zephyr_include_directories(
+    ${DFM_DIR}/kernelports/Zephyr/config
+    ${DFM_DIR}/kernelports/Zephyr/include
+    ${DFM_DIR}/include
     )
 
 endif()

--- a/modules/percepio/Kconfig
+++ b/modules/percepio/Kconfig
@@ -1,10 +1,10 @@
-# Zephyr module config for TraceRecorder.
+# Zephyr module config for percepio.
 # The real Kconfig for the module is located in the module repository,
-# this file is to ensure ZEPHYR_TRACERECORDER_MODULE is defined also when the
+# this file is to ensure ZEPHYR_PERCEPIO_MODULE is defined also when the
 # module is unavailable.
 
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-config ZEPHYR_TRACERECORDER_MODULE
+config ZEPHYR_PERCEPIO_MODULE
 	bool

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -37,7 +37,7 @@ config PERCEPIO_TRACERECORDER
 	select THREAD_NAME
 	select INIT_STACKS
 	select THREAD_MONITOR
-	depends on ZEPHYR_TRACERECORDER_MODULE
+	depends on ZEPHYR_PERCEPIO_MODULE
 
 config SEGGER_SYSTEMVIEW
 	bool "Segger SystemView support"

--- a/west.yml
+++ b/west.yml
@@ -307,7 +307,7 @@ manifest:
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio
-      revision: 831f421994b67856970f131295d1a97ca9d1f086
+      revision: 7ba53eb1c22d14a49fa51f4b57fc0614a893fdd7
       groups:
         - debug
     - name: picolibc

--- a/west.yml
+++ b/west.yml
@@ -305,6 +305,11 @@ manifest:
     - name: openthread
       revision: f7690fe7e9d638341921808cba6a3e695ec0131e
       path: modules/lib/openthread
+    - name: percepio
+      path: modules/debug/percepio
+      revision: 831f421994b67856970f131295d1a97ca9d1f086
+      groups:
+        - debug
     - name: picolibc
       path: modules/lib/picolibc
       revision: d07c38ff051386f8e09a143ea0a6c1d6d66dd1d8
@@ -325,11 +330,6 @@ manifest:
       path: modules/crypto/tinycrypt
       groups:
         - crypto
-    - name: TraceRecorderSource
-      revision: 1ede7ce8e7ab226e9a84d95266241ba3f38d91d2
-      path: modules/debug/TraceRecorder
-      groups:
-        - debug
     - name: trusted-firmware-m
       revision: b168d92c7ed3c77c94d7ce3362bdde5dbffe8424
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
This commit adds the DFM (DevAlert target side code) module and moves the TraceRecorder module into the percepio module, which results in the TraceRecorder module definition being removed from the west manufest and module definition within zephyr.