### PR TITLE
Add NXP S32 Debug Probe west runner

### DIFF
--- a/boards/arm/s32z270dc2_r52/board.cmake
+++ b/boards/arm/s32z270dc2_r52/board.cmake
@@ -1,19 +1,24 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
-
-board_set_flasher_ifnset(trace32)
-board_set_debugger_ifnset(trace32)
 
 board_runner_args(trace32
   "--startup-args"
-    "elfFile=${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}"
-    "thumb=no"
+  "elfFile=${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}"
+  "rtu=${CONFIG_NXP_S32_RTU_INDEX}"
 )
 
-if(CONFIG_BOARD_S32Z270DC2_RTU0_R52)
-board_runner_args(trace32 "rtu=0")
-elseif(CONFIG_BOARD_S32Z270DC2_RTU1_R52)
-board_runner_args(trace32 "rtu=1")
+board_runner_args(nxp_s32dbg
+  "--soc-family-name" "s32z2e2"
+  "--soc-name" "S32Z270"
+)
+
+if(CONFIG_DCLS)
+  board_runner_args(trace32 "lockstep=yes")
+  board_runner_args(nxp_s32dbg "--core-name" "R52_${CONFIG_NXP_S32_RTU_INDEX}_0_LS")
+else()
+  board_runner_args(trace32 "lockstep=no")
+  board_runner_args(nxp_s32dbg "--core-name" "R52_${CONFIG_NXP_S32_RTU_INDEX}_0")
 endif()
 
+include(${ZEPHYR_BASE}/boards/common/nxp_s32dbg.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/trace32.board.cmake)

--- a/boards/arm/s32z270dc2_r52/doc/index.rst
+++ b/boards/arm/s32z270dc2_r52/doc/index.rst
@@ -146,26 +146,21 @@ Applications for the ``s32z270dc2_rtu0_r52`` and ``s32z270dc2_rtu1_r52`` boards
 can be built in the usual way as documented in :ref:`build_an_application`.
 
 Currently is only possible to load and execute a Zephyr application binary on
-this board from the internal SRAM, using `Lauterbach TRACE32`_ development
-tools and debuggers.
+this board from the core internal SRAM.
 
-.. note::
-   Currently, the start-up scripts executed with ``west flash`` and
-   ``west debug`` commands perform the same steps to initialize the SoC and
-   load the application to SRAM. The difference is that ``west flash`` hide the
-   Lauterbach TRACE32 interface, executes the application and exits.
+This board supports West runners for the following debug tools:
 
-Install Lauterbach TRACE32 Software
-===================================
+- :ref:`NXP S32 Debug Probe <nxp-s32-debug-probe>` (default)
+- :ref:`Lauterbach TRACE32 <lauterbach-trace32-debug-host-tools>`
 
-Follow the steps described in :ref:`lauterbach-trace32-debug-host-tools` to
-install and set-up Lauterbach TRACE32 software.
+Follow the installation steps of the debug tool you plan to use before loading
+your firmware.
 
 Set-up the Board
 ================
 
-Connect the Lauterbach TRACE32 debugger to the board's JTAG connector (``J134``)
-and to the host computer.
+Connect the external debugger probe to the board's JTAG connector (``J134``)
+and to the host computer via USB or Ethernet, as supported by the probe.
 
 For visualizing the serial output, connect the board's USB/UART port (``J119``) to
 the host computer and run your favorite terminal program to listen for output.
@@ -178,16 +173,16 @@ For example, using the cross-platform `pySerial miniterm`_ terminal:
 Replace ``<port>`` with the port where the board can be found. For example,
 under Linux, ``/dev/ttyUSB0``.
 
-Flashing
-========
+Debugging
+=========
 
-For example, you can build and run the :ref:`hello_world` sample for the board
+You can build and debug the :ref:`hello_world` sample for the board
 ``s32z270dc2_rtu0_r52`` with:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: s32z270dc2_rtu0_r52
-   :goals: build flash
+   :goals: build debug
 
 In case you are using a newer PCB revision, you have to use an adapted board
 definition as the default PCB revision is B. For example, if using revision D:
@@ -195,30 +190,53 @@ definition as the default PCB revision is B. For example, if using revision D:
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: s32z270dc2_rtu0_r52@D
-   :goals: build flash
+   :goals: build debug
+   :compact:
 
-You should see the following message in the terminal:
+At this point you can do your normal debug session. Set breakpoints and then
+:kbd:`c` to continue into the program. You should see the following message in
+the terminal:
 
 .. code-block:: console
 
    Hello World! s32z270dc2_rtu0_r52
 
-Debugging
-=========
-
-To enable debugging using Lauterbach TRACE32 software, run instead:
+To debug with Lauterbach TRACE32 softare run instead:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
    :board: s32z270dc2_rtu0_r52
-   :goals: build debug
+   :goals: build debug -r trace32
+   :compact:
 
-Step through the application in your debugger, and you should see the following
-message in the terminal:
+Flashing
+========
 
-.. code-block:: console
+Follow these steps if you just want to download the application to the board
+SRAM and run.
 
-   Hello World! s32z270dc2_rtu0_r52
+``flash`` command is supported only by the Lauterbach TRACE32 runner:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: s32z270dc2_rtu0_r52
+   :goals: build flash -r trace32
+   :compact:
+
+.. note::
+   Currently, the Lauterbach start-up scripts executed with ``flash`` and
+   ``debug`` commands perform the same steps to initialize the SoC and
+   load the application to SRAM. The difference is that ``flash`` hides the
+   Lauterbach TRACE32 interface, executes the application and exits.
+
+To imitate a similar behavior using NXP S32 Debug Probe runner, you can run the
+``debug`` command with GDB in batch mode:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: s32z270dc2_rtu0_r52
+   :goals: build debug --tool-opt='--batch'
+   :compact:
 
 RTU and Core Configuration
 ==========================
@@ -231,26 +249,29 @@ configuration).
 To build for split-lock mode, the :kconfig:option:`CONFIG_DCLS` must be
 disabled from your application Kconfig file.
 
-Additionally, to run in a different core or with a different core
-configuration than the default, extra parameters must be provided to the runner
-as follows:
+By default the board configuration will set the runner arguments according to
+the build configuration. To debug for a core different than the default use:
 
-.. code-block:: console
+.. tabs::
 
-   west <command> --startup-args elfFile=<elf_path> rtu=<rtu_id> \
-      core=<core_id> lockstep=<yes/no>
+   .. group-tab:: lockstep configuration
+
+      .. code-block:: console
+
+         west debug --core-name='R52_<rtu_id>_<core_id>_LS'
+
+   .. group-tab:: split-lock configuration
+
+      .. code-block:: console
+
+         west debug --core-name='R52_<rtu_id>_<core_id>'
 
 Where:
 
-- ``<command>`` is ``flash`` or ``debug``
-- ``<elf_path>`` is the path to the Zephyr application ELF in the output
-  directory
 - ``<rtu_id>`` is the zero-based RTU index (0 for ``s32z270dc2_rtu0_r52``
   and 1 for ``s32z270dc2_rtu1_r52``)
 - ``<core_id>`` is the zero-based core index relative to the RTU on which to
   run the Zephyr application (0, 1, 2 or 3)
-- ``<yes/no>`` can be ``yes`` to run in lock-step, or ``no`` to run in
-  split-lock.
 
 For example, to build the :ref:`hello_world` sample for the board
 ``s32z270dc2_rtu0_r52`` with split-lock core configuration:
@@ -260,13 +281,23 @@ For example, to build the :ref:`hello_world` sample for the board
    :board: s32z270dc2_rtu0_r52
    :goals: build
    :gen-args: -DCONFIG_DCLS=n
+   :compact:
 
 To execute this sample in the second core of RTU0 in split-lock mode:
 
 .. code-block:: console
 
-   west flash --startup-args elfFile=build/zephyr/zephyr.elf \
-      rtu=0 core=1 lockstep=no
+   west debug --core-name='R52_0_1'
+
+If using Lauterbach TRACE32, all runner parameters must be overridden from command
+line:
+
+.. code-block:: console
+
+   west debug --startup-args elfFile=<elf_path> rtu=<rtu_id> core=<core_id> lockstep=<yes/no>
+
+Where ``<elf_path>`` is the path to the Zephyr application ELF in the output
+directory.
 
 References
 **********
@@ -275,9 +306,6 @@ References
 
 .. _NXP S32Z2 Real-Time Processors website:
    https://www.nxp.com/products/processors-and-microcontrollers/s32-automotive-platform/s32z-and-s32e-real-time-processors/s32z2-safe-and-secure-high-performance-real-time-processors:S32Z2
-
-.. _Lauterbach TRACE32:
-   https://www.lauterbach.com
 
 .. _pySerial miniterm:
    https://pyserial.readthedocs.io/en/latest/tools.html#module-serial.tools.miniterm

--- a/boards/common/nxp_s32dbg.board.cmake
+++ b/boards/common/nxp_s32dbg.board.cmake
@@ -1,0 +1,6 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(nxp_s32dbg)
+board_set_debugger_ifnset(nxp_s32dbg)
+board_finalize_runner_args(nxp_s32dbg)

--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -377,6 +377,68 @@ Zephyr RTOS Awareness
 To enable Zephyr RTOS awareness follow the steps described in
 `Lauterbach TRACE32 Zephyr OS Awareness Manual`_.
 
+.. _nxp-s32-debug-host-tools:
+
+NXP S32 Debug Probe Host Tools
+******************************
+
+:ref:`nxp-s32-debug-probe` is designed to work in conjunction with
+`NXP S32 Design Studio for S32 Platform`_.
+
+Download (registration required) NXP S32 Design Studio for S32 Platform and
+follow the `S32 Design Studio for S32 Platform Installation User Guide`_ to get
+the necessary debug host tools and associated USB device drivers.
+
+Note that Zephyr RTOS-awareness support for the NXP S32 GDB server depends on
+the target device. Consult the product release notes for more information.
+
+Supported west commands:
+
+1. debug
+#. debugserver
+#. attach
+
+Basic usage
+-----------
+
+Before starting, add NXP S32 Design Studio installation directory to the system
+:ref:`PATH environment variable <env_vars>`. Alternatively, it can be passed to
+the runner on each invocation via ``--s32ds-path`` as shown below:
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: console
+
+         west debug --s32ds-path=/opt/NXP/S32DS.3.5
+
+   .. group-tab:: Windows
+
+      .. code-block:: console
+
+         west debug --s32ds-path=C:\NXP\S32DS.3.5
+
+If multiple S32 debug probes are connected to the host via USB, the runner will
+ask the user to select one via command line prompt before continuing. The
+connection string for the probe can be also specified when invoking the runner
+via ``--dev-id=<connection-string>``. Consult NXP S32 debug probe user manual
+for details on how to construct the connection string. For example, if using a
+probe with serial ID ``00:04:9f:00:ca:fe``:
+
+.. code-block:: console
+
+   west debug --dev-id='s32dbg:00:04:9f:00:ca:fe'
+
+It is possible to pass extra options to the debug host tools via ``--tool-opt``.
+When executing ``debug`` or ``attach`` commands, the tool options will be passed
+to the GDB client only. When executing ``debugserver``, the tool options will be
+passed to the GDB server. For example, to load a Zephyr application to SRAM and
+afterwards detach the debug session:
+
+.. code-block:: console
+
+   west debug --tool-opt='--batch'
 
 .. _J-Link Software and Documentation Pack:
    https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack
@@ -416,3 +478,9 @@ To enable Zephyr RTOS awareness follow the steps described in
 
 .. _MCUXpresso Installer:
 	https://www.nxp.com/lgfiles/updates/mcuxpresso/MCUXpressoInstaller.exe
+
+.. _NXP S32 Design Studio for S32 Platform:
+   https://www.nxp.com/design/software/development-software/s32-design-studio-ide/s32-design-studio-for-s32-platform:S32DS-S32PLATFORM
+
+.. _S32 Design Studio for S32 Platform Installation User Guide:
+   https://www.nxp.com/webapp/Download?colCode=S32DSIG

--- a/doc/develop/flash_debug/probes.rst
+++ b/doc/develop/flash_debug/probes.rst
@@ -33,21 +33,23 @@ host tools, or with J-Link firmware to communicate with J-Link debug host
 tools.
 
 
-+---------------------------------------+---------------------------------------------------------------+
-|| *Debug Probes & Host Tools*          |                          Host Tools                           |
-+| *Compatibility Chart*                +--------------------+--------------------+---------------------+
-|                                       |  **J-Link Debug**  |    **OpenOCD**     |      **pyOCD**      |
-+----------------+----------------------+--------------------+--------------------+---------------------+
-|                | **LPC-Link2 J-Link** |           ✓        |                    |                     |
-|                +----------------------+--------------------+--------------------+---------------------+
-|                | **OpenSDA DAPLink**  |                    |          ✓         |          ✓          |
-|                +----------------------+--------------------+--------------------+---------------------+
-|  Debug Probes  | **OpenSDA J-Link**   |           ✓        |                    |                     |
-|                +----------------------+--------------------+--------------------+---------------------+
-|                | **J-Link External**  |           ✓        |          ✓         |                     |
-|                +----------------------+--------------------+--------------------+---------------------+
-|                | **ST-LINK/V2-1**     |           ✓        |          ✓         | *some STM32 boards* |
-+----------------+----------------------+--------------------+--------------------+---------------------+
++------------------------------------------+------------------------------------------------------------------------------------+
+|| *Debug Probes & Host Tools*             |                                     Host Tools                                     |
++| *Compatibility Chart*                   +--------------------+--------------------+---------------------+--------------------+
+|                                          |  **J-Link Debug**  |    **OpenOCD**     |      **pyOCD**      |   **NXP S32DS**    |
++----------------+-------------------------+--------------------+--------------------+---------------------+--------------------+
+|                | **LPC-Link2 J-Link**    |           ✓        |                    |                     |                    |
+|                +-------------------------+--------------------+--------------------+---------------------+--------------------+
+|                | **OpenSDA DAPLink**     |                    |          ✓         |          ✓          |                    |
+|                +-------------------------+--------------------+--------------------+---------------------+--------------------+
+|  Debug Probes  | **OpenSDA J-Link**      |           ✓        |                    |                     |                    |
+|                +-------------------------+--------------------+--------------------+---------------------+--------------------+
+|                | **J-Link External**     |           ✓        |          ✓         |                     |                    |
+|                +-------------------------+--------------------+--------------------+---------------------+--------------------+
+|                | **ST-LINK/V2-1**        |           ✓        |          ✓         | *some STM32 boards* |                    |
+|                +-------------------------+--------------------+--------------------+---------------------+--------------------+
+|                | **NXP S32 Debug Probe** |                    |                    |                     |          ✓         |
++----------------+-------------------------+--------------------+--------------------+---------------------+--------------------+
 
 
 Some supported boards in Zephyr do not include an onboard debug probe and
@@ -373,6 +375,20 @@ Where board_uid can be obtained using twister's generate-hardware-map
 option. For more information about twister and available options, see
 :ref:`twister_script`.
 
+.. _nxp-s32-debug-probe:
+
+NXP S32 Debug Probe
+*******************
+
+`NXP S32 Debug Probe`_ enables NXP S32 target system debugging via a standard
+debug port while connected to a developer's workstation via USB or remotely via
+Ethernet.
+
+NXP S32 Debug Probe is designed to work in conjunction with NXP S32 Design Studio
+(S32DS) and NXP Automotive microcontrollers and processors. Install the debug
+host tools as in indicated in :ref:`nxp-s32-debug-host-tools` before you program
+the firmware.
+
 .. _LPCScrypt:
    https://www.nxp.com/lpcscrypt
 
@@ -402,3 +418,6 @@ option. For more information about twister and available options, see
 
 .. _MCUXpresso Installer:
 	https://www.nxp.com/lgfiles/updates/mcuxpresso/MCUXpressoInstaller.exe
+
+.. _NXP S32 Debug Probe:
+   https://www.nxp.com/design/software/automotive-software-and-tools/s32-debug-probe:S32-DP

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -45,6 +45,7 @@ _names = [
     'nrfjprog',
     'nrfutil',
     'nsim',
+    'nxp_s32dbg',
     'openocd',
     'pyocd',
     'qemu',

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -676,7 +676,7 @@ class ZephyrBinaryRunner(abc.ABC):
             raise MissingProgram(program)
         return ret
 
-    def run_server_and_client(self, server, client):
+    def run_server_and_client(self, server, client, **kwargs):
         '''Run a server that ignores SIGINT, and a client that handles it.
 
         This routine portably:
@@ -685,20 +685,22 @@ class ZephyrBinaryRunner(abc.ABC):
           SIGINT
         - runs ``client`` in a subprocess while temporarily ignoring SIGINT
         - cleans up the server after the client exits.
+        - the keyword arguments, if any, will be passed down to both server and
+          client subprocess calls
 
         It's useful to e.g. open a GDB server and client.'''
-        server_proc = self.popen_ignore_int(server)
+        server_proc = self.popen_ignore_int(server, **kwargs)
         try:
-            self.run_client(client)
+            self.run_client(client, **kwargs)
         finally:
             server_proc.terminate()
             server_proc.wait()
 
-    def run_client(self, client):
+    def run_client(self, client, **kwargs):
         '''Run a client that handles SIGINT.'''
         previous = signal.signal(signal.SIGINT, signal.SIG_IGN)
         try:
-            self.check_call(client)
+            self.check_call(client, **kwargs)
         finally:
             signal.signal(signal.SIGINT, previous)
 

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -657,19 +657,21 @@ class ZephyrBinaryRunner(abc.ABC):
                   in the order they appear on the command line.'''
 
     @staticmethod
-    def require(program: str) -> str:
+    def require(program: str, path: Optional[str] = None) -> str:
         '''Require that a program is installed before proceeding.
 
         :param program: name of the program that is required,
                         or path to a program binary.
+        :param path:    PATH where to search for the program binary.
+                        By default check on the system PATH.
 
         If ``program`` is an absolute path to an existing program
         binary, this call succeeds. Otherwise, try to find the program
-        by name on the system PATH.
+        by name on the system PATH or in the given PATH, if provided.
 
         If the program can be found, its path is returned.
         Otherwise, raises MissingProgram.'''
-        ret = shutil.which(program)
+        ret = shutil.which(program, path=path)
         if ret is None:
             raise MissingProgram(program)
         return ret

--- a/scripts/west_commands/runners/nxp_s32dbg.py
+++ b/scripts/west_commands/runners/nxp_s32dbg.py
@@ -1,0 +1,334 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+"""
+Runner for NXP S32 Debug Probe.
+"""
+
+import argparse
+import os
+import platform
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+from runners.core import (BuildConfiguration, RunnerCaps, RunnerConfig,
+                          ZephyrBinaryRunner)
+
+NXP_S32DBG_USB_CLASS = 'NXP Probes'
+NXP_S32DBG_USB_VID = 0x15a2
+NXP_S32DBG_USB_PID = 0x0067
+
+
+@dataclass
+class NXPS32DebugProbeConfig:
+    """NXP S32 Debug Probe configuration parameters."""
+    conn_str: str = 's32dbg'
+    server_port: int = 45000
+    speed: int = 16000
+    remote_timeout: int = 30
+    reset_type: Optional[str] = 'default'
+    reset_delay: int = 0
+
+
+class NXPS32DebugProbeRunner(ZephyrBinaryRunner):
+    """Runner front-end for NXP S32 Debug Probe."""
+
+    def __init__(self,
+                 runner_cfg: RunnerConfig,
+                 probe_cfg: NXPS32DebugProbeConfig,
+                 core_name: str,
+                 soc_name: str,
+                 soc_family_name: str,
+                 start_all_cores: bool,
+                 s32ds_path: Optional[str] = None,
+                 tool_opt: Optional[List[str]] = None) -> None:
+        super(NXPS32DebugProbeRunner, self).__init__(runner_cfg)
+        self.elf_file: str = runner_cfg.elf_file or ''
+        self.probe_cfg: NXPS32DebugProbeConfig = probe_cfg
+        self.core_name: str = core_name
+        self.soc_name: str = soc_name
+        self.soc_family_name: str = soc_family_name
+        self.start_all_cores: bool = start_all_cores
+        self.s32ds_path_override: Optional[str] = s32ds_path
+
+        self.tool_opt: List[str] = []
+        if tool_opt:
+            for opt in tool_opt:
+                self.tool_opt.extend(shlex.split(opt))
+
+        build_cfg = BuildConfiguration(runner_cfg.build_dir)
+        self.arch = build_cfg.get('CONFIG_ARCH').replace('"', '')
+
+    @classmethod
+    def name(cls) -> str:
+        return 'nxp_s32dbg'
+
+    @classmethod
+    def capabilities(cls) -> RunnerCaps:
+        return RunnerCaps(commands={'debug', 'debugserver', 'attach'},
+                          dev_id=True, tool_opt=True)
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        return '''Debug probe connection string as in "s32dbg[:<address>]"
+                  where <address> can be the IP address if TAP is available via Ethernet,
+                  the serial ID of the probe or empty if TAP is available via USB.'''
+
+    @classmethod
+    def tool_opt_help(cls) -> str:
+        return '''Additional options for GDB client when used with "debug" or "attach" commands
+                  or for GTA server when used with "debugserver" command.'''
+
+    @classmethod
+    def do_add_parser(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument('--core-name',
+                            required=True,
+                            help='Core name as supported by the debug probe (e.g. "R52_0_0")')
+        parser.add_argument('--soc-name',
+                            required=True,
+                            help='SoC name as supported by the debug probe (e.g. "S32Z270")')
+        parser.add_argument('--soc-family-name',
+                            required=True,
+                            help='SoC family name as supported by the debug probe (e.g. "s32z2e2")')
+        parser.add_argument('--start-all-cores',
+                            action='store_true',
+                            help='Start all SoC cores and not just the one being debugged. '
+                                 'Use together with "debug" command.')
+        parser.add_argument('--s32ds-path',
+                            help='Override the path to NXP S32 Design Studio installation. '
+                                 'By default, this runner will try to obtain it from the system '
+                                 'path, if available.')
+        parser.add_argument('--server-port',
+                            default=NXPS32DebugProbeConfig.server_port,
+                            type=int,
+                            help='GTA server port')
+        parser.add_argument('--speed',
+                            default=NXPS32DebugProbeConfig.speed,
+                            type=int,
+                            help='JTAG interface speed')
+        parser.add_argument('--remote-timeout',
+                            default=NXPS32DebugProbeConfig.remote_timeout,
+                            type=int,
+                            help='Number of seconds to wait for the remote target responses')
+
+    @classmethod
+    def do_create(cls, cfg: RunnerConfig, args: argparse.Namespace) -> 'NXPS32DebugProbeRunner':
+        probe_cfg = NXPS32DebugProbeConfig(args.dev_id,
+                                           server_port=args.server_port,
+                                           speed=args.speed,
+                                           remote_timeout=args.remote_timeout)
+
+        return NXPS32DebugProbeRunner(cfg, probe_cfg, args.core_name, args.soc_name,
+                                      args.soc_family_name, args.start_all_cores,
+                                      s32ds_path=args.s32ds_path, tool_opt=args.tool_opt)
+
+    @staticmethod
+    def find_usb_probes() -> List[str]:
+        """Return a list of debug probe serial numbers connected via USB to this host."""
+        # use system's native commands to enumerate and retrieve the USB serial ID
+        # to avoid bloating this runner with third-party dependencies that often
+        # require priviledged permissions to access the device info
+        macaddr_pattern = r'(?:[0-9a-f]{2}[:]){5}[0-9a-f]{2}'
+        if platform.system() == 'Windows':
+            cmd = f'pnputil /enum-devices /connected /class "{NXP_S32DBG_USB_CLASS}"'
+            serialid_pattern = f'instance id: +usb\\\\.*\\\\({macaddr_pattern})'
+        else:
+            cmd = f'lsusb -v -d {NXP_S32DBG_USB_VID:x}:{NXP_S32DBG_USB_PID:x}'
+            serialid_pattern = f'iserial +.*({macaddr_pattern})'
+
+        try:
+            outb = subprocess.check_output(shlex.split(cmd), stderr=subprocess.DEVNULL)
+            out = outb.decode('utf-8').strip().lower()
+        except subprocess.CalledProcessError:
+            raise RuntimeError('error while looking for debug probes connected')
+
+        devices: List[str] = []
+        if out and 'no devices were found' not in out:
+            devices = re.findall(serialid_pattern, out)
+
+        return sorted(devices)
+
+    @classmethod
+    def select_probe(cls) -> str:
+        """
+        Find debugger probes connected and return the serial number of the one selected.
+
+        If there are multiple debugger probes connected and this runner is being executed
+        in a interactive prompt, ask the user to select one of the probes.
+        """
+        probes_snr = cls.find_usb_probes()
+        if not probes_snr:
+            raise RuntimeError('there are no debug probes connected')
+        elif len(probes_snr) == 1:
+            return probes_snr[0]
+        else:
+            if not sys.stdin.isatty():
+                raise RuntimeError(
+                    f'refusing to guess which of {len(probes_snr)} connected probes to use '
+                    '(Interactive prompts disabled since standard input is not a terminal). '
+                    'Please specify a device ID on the command line.')
+
+            print('There are multiple debug probes connected')
+            for i, probe in enumerate(probes_snr, 1):
+                print(f'{i}. {probe}')
+
+            prompt = f'Please select one with desired serial number (1-{len(probes_snr)}): '
+            while True:
+                try:
+                    value: int = int(input(prompt))
+                except EOFError:
+                    sys.exit(0)
+                except ValueError:
+                    continue
+                if 1 <= value <= len(probes_snr):
+                    break
+            return probes_snr[value - 1]
+
+    @property
+    def runtime_environment(self) -> Optional[Dict[str, str]]:
+        """Execution environment used for the client process."""
+        if platform.system() == 'Windows':
+            python_lib = (self.s32ds_path / 'S32DS' / 'build_tools' / 'msys32'
+                        / 'mingw32' / 'lib' / 'python2.7')
+            return {
+                **os.environ,
+                'PYTHONPATH': f'{python_lib}{os.pathsep}{python_lib / "site-packages"}'
+            }
+
+        return None
+
+    @property
+    def script_globals(self) -> Dict[str, Optional[Union[str, int]]]:
+        """Global variables required by the debugger scripts."""
+        return {
+            '_PROBE_IP': self.probe_cfg.conn_str,
+            '_JTAG_SPEED': self.probe_cfg.speed,
+            '_GDB_SERVER_PORT': self.probe_cfg.server_port,
+            '_RESET_TYPE': self.probe_cfg.reset_type,
+            '_RESET_DELAY': self.probe_cfg.reset_delay,
+            '_REMOTE_TIMEOUT': self.probe_cfg.remote_timeout,
+            '_CORE_NAME': f'{self.soc_name}_{self.core_name}',
+            '_SOC_NAME': self.soc_name,
+            '_IS_LOGGING_ENABLED': False,
+            '_FLASH_NAME': None,    # not supported
+            '_SECURE_TYPE': None,   # not supported
+            '_SECURE_KEY': None,    # not supported
+        }
+
+    def server_commands(self) -> List[str]:
+        """Get launch commands to start the GTA server."""
+        server_exec = str(self.s32ds_path / 'S32DS' / 'tools' / 'S32Debugger'
+                          / 'Debugger' / 'Server' / 'gta' / 'gta')
+        cmd = [server_exec, '-p', str(self.probe_cfg.server_port)]
+        return cmd
+
+    def client_commands(self) -> List[str]:
+        """Get launch commands to start the GDB client."""
+        if self.arch == 'arm':
+            client_exec_name = 'arm-none-eabi-gdb-py'
+        elif self.arch == 'arm64':
+            client_exec_name = 'aarch64-none-elf-gdb-py'
+        else:
+            raise RuntimeError(f'architecture {self.arch} not supported')
+
+        client_exec = str(self.s32ds_path / 'S32DS' / 'tools' / 'gdb-arm'
+                          / 'arm32-eabi' / 'bin' / client_exec_name)
+        cmd = [client_exec]
+        return cmd
+
+    def get_script(self, name: str) -> Path:
+        """
+        Get the file path of a debugger script with the given name.
+
+        :param name: name of the script, without the SoC family name prefix
+        :returns: path to the script
+        :raises RuntimeError: if file does not exist
+        """
+        script = (self.s32ds_path / 'S32DS' / 'tools' / 'S32Debugger' / 'Debugger' / 'scripts'
+                  / self.soc_family_name / f'{self.soc_family_name}_{name}.py')
+        if not script.exists():
+            raise RuntimeError(f'script not found: {script}')
+        return script
+
+    def do_run(self, command: str, **kwargs) -> None:
+        """
+        Execute the given command.
+
+        :param command: command name to execute
+        :raises RuntimeError: if target architecture or host OS is not supported
+        :raises MissingProgram: if required tools are not found in the host
+        """
+        if platform.system() not in ('Windows', 'Linux'):
+            raise RuntimeError(f'runner not supported on {platform.system()} systems')
+
+        if self.arch not in ('arm', 'arm64'):
+            raise RuntimeError(f'architecture {self.arch} not supported')
+
+        app_name = 's32ds' if platform.system() == 'Windows' else 's32ds.sh'
+        self.s32ds_path = Path(self.require(app_name, path=self.s32ds_path_override)).parent
+
+        if not self.probe_cfg.conn_str:
+            self.probe_cfg.conn_str = f's32dbg:{self.select_probe()}'
+            self.logger.info(f'using debug probe {self.probe_cfg.conn_str}')
+
+        if command in ('attach', 'debug'):
+            self.ensure_output('elf')
+            self.do_attach_debug(command, **kwargs)
+        else:
+            self.do_debugserver(**kwargs)
+
+    def do_attach_debug(self, command: str, **kwargs) -> None:
+        """
+        Launch the GTA server and GDB client to start a debugging session.
+
+        :param command: command name to execute
+        """
+        gdb_script: List[str] = []
+
+        # setup global variables required for the scripts before sourcing them
+        for name, val in self.script_globals.items():
+            gdb_script.append(f'py {name} = {repr(val)}')
+
+        # load platform-specific debugger script
+        if command == 'debug':
+            if self.start_all_cores:
+                startup_script = self.get_script('generic_bareboard_all_cores')
+            else:
+                startup_script = self.get_script('generic_bareboard')
+        else:
+            startup_script = self.get_script('attach')
+        gdb_script.append(f'source {startup_script}')
+
+        # executes the SoC and board initialization sequence
+        if command == 'debug':
+            gdb_script.append('py board_init()')
+
+        # initializes the debugger connection to the core specified
+        gdb_script.append('py core_init()')
+
+        gdb_script.append(f'file {Path(self.elf_file).as_posix()}')
+        if command == 'debug':
+            gdb_script.append('load')
+
+        with tempfile.TemporaryDirectory(suffix='nxp_s32dbg') as tmpdir:
+            gdb_cmds = Path(tmpdir) / 'runner.nxp_s32dbg'
+            gdb_cmds.write_text('\n'.join(gdb_script), encoding='utf-8')
+            self.logger.debug(gdb_cmds.read_text(encoding='utf-8'))
+
+            server_cmd = self.server_commands()
+            client_cmd = self.client_commands()
+            client_cmd.extend(['-x', gdb_cmds.as_posix()])
+            client_cmd.extend(self.tool_opt)
+
+            self.run_server_and_client(server_cmd, client_cmd, env=self.runtime_environment)
+
+    def do_debugserver(self, **kwargs) -> None:
+        """Start the GTA server on a given port with the given extra parameters from cli."""
+        server_cmd = self.server_commands()
+        server_cmd.extend(self.tool_opt)
+        self.check_call(server_cmd)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -35,6 +35,7 @@ def test_runner_imports():
                     'nios2',
                     'nrfjprog',
                     'nrfutil',
+                    'nxp_s32dbg',
                     'openocd',
                     'pyocd',
                     'qemu',

--- a/scripts/west_commands/tests/test_nxp_s32dbg.py
+++ b/scripts/west_commands/tests/test_nxp_s32dbg.py
@@ -1,0 +1,247 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from conftest import RC_KERNEL_ELF
+from runners.nxp_s32dbg import NXPS32DebugProbeConfig, NXPS32DebugProbeRunner
+
+TEST_DEVICE = 's32dbg'
+TEST_SPEED = 16000
+TEST_SERVER_PORT = 45000
+TEST_REMOTE_TIMEOUT = 30
+TEST_CORE_NAME = 'R52_0_0'
+TEST_SOC_NAME = 'S32Z270'
+TEST_SOC_FAMILY_NAME = 's32e2z2'
+TEST_START_ALL_CORES = True
+TEST_S32DS_PATH_OVERRIDE = None
+TEST_TOOL_OPT = ['--test-opt-1', '--test-opt-2']
+TEST_RESET_TYPE = 'default'
+TEST_RESET_DELAY = 0
+
+TEST_S32DS_CMD = 's32ds'
+TEST_SERVER_CMD = Path('S32DS') / 'tools' / 'S32Debugger' / 'Debugger' / 'Server' / 'gta' / 'gta'
+TEST_ARM_GDB_CMD = Path('S32DS') / 'tools' / 'gdb-arm' / 'arm32-eabi' / 'bin' / 'arm-none-eabi-gdb-py'
+
+TEST_S32DS_PYTHON_LIB = Path('S32DS') / 'build_tools' / 'msys32' / 'mingw32' / 'lib' / 'python2.7'
+TEST_S32DS_RUNTIME_ENV = {
+    'PYTHONPATH': f'{TEST_S32DS_PYTHON_LIB}{os.pathsep}{TEST_S32DS_PYTHON_LIB / "site-packages"}'
+}
+
+TEST_ALL_KWARGS = {
+    'NXPS32DebugProbeConfig': {
+        'conn_str': TEST_DEVICE,
+        'server_port': TEST_SERVER_PORT,
+        'speed': TEST_SPEED,
+        'remote_timeout': TEST_REMOTE_TIMEOUT,
+    },
+    'NXPS32DebugProbeRunner': {
+        'core_name': TEST_CORE_NAME,
+        'soc_name': TEST_SOC_NAME,
+        'soc_family_name': TEST_SOC_FAMILY_NAME,
+        'start_all_cores': TEST_START_ALL_CORES,
+        's32ds_path': TEST_S32DS_PATH_OVERRIDE,
+        'tool_opt': TEST_TOOL_OPT
+    }
+}
+
+TEST_ALL_PARAMS = [
+    # generic
+    '--dev-id', TEST_DEVICE,
+    *[f'--tool-opt={o}' for o in TEST_TOOL_OPT],
+    # from runner
+    '--s32ds-path', TEST_S32DS_PATH_OVERRIDE,
+    '--core-name', TEST_CORE_NAME,
+    '--soc-name', TEST_SOC_NAME,
+    '--soc-family-name', TEST_SOC_FAMILY_NAME,
+    '--server-port', TEST_SERVER_PORT,
+    '--speed', TEST_SPEED,
+    '--remote-timeout', TEST_REMOTE_TIMEOUT,
+    '--start-all-cores',
+]
+
+TEST_ALL_S32DBG_PY_VARS = [
+    f'py _PROBE_IP = {repr(TEST_DEVICE)}',
+    f'py _JTAG_SPEED = {repr(TEST_SPEED)}',
+    f'py _GDB_SERVER_PORT = {repr(TEST_SERVER_PORT)}',
+    f"py _RESET_TYPE = {repr(TEST_RESET_TYPE)}",
+    f'py _RESET_DELAY = {repr(TEST_RESET_DELAY)}',
+    f'py _REMOTE_TIMEOUT = {repr(TEST_REMOTE_TIMEOUT)}',
+    f'py _CORE_NAME = {repr(f"{TEST_SOC_NAME}_{TEST_CORE_NAME}")}',
+    f'py _SOC_NAME = {repr(TEST_SOC_NAME)}',
+    'py _IS_LOGGING_ENABLED = False',
+    'py _FLASH_NAME = None',
+    'py _SECURE_TYPE = None',
+    'py _SECURE_KEY = None',
+]
+
+DEBUGSERVER_ALL_EXPECTED_CALL = [
+    str(TEST_SERVER_CMD),
+    '-p', str(TEST_SERVER_PORT),
+    *TEST_TOOL_OPT,
+]
+
+DEBUG_ALL_EXPECTED_CALL = {
+    'client': [
+        str(TEST_ARM_GDB_CMD),
+        '-x', 'TEST_GDB_SCRIPT',
+        *TEST_TOOL_OPT,
+    ],
+    'server': [
+        str(TEST_SERVER_CMD),
+        '-p', str(TEST_SERVER_PORT),
+    ],
+    'gdb_script': [
+        *TEST_ALL_S32DBG_PY_VARS,
+        f'source generic_bareboard{"_all_cores" if TEST_START_ALL_CORES else ""}.py',
+        'py board_init()',
+        'py core_init()',
+        f'file {RC_KERNEL_ELF}',
+        'load',
+    ]
+}
+
+ATTACH_ALL_EXPECTED_CALL = {
+    **DEBUG_ALL_EXPECTED_CALL,
+    'gdb_script': [
+        *TEST_ALL_S32DBG_PY_VARS,
+        f'source attach.py',
+        'py core_init()',
+        f'file {RC_KERNEL_ELF}',
+    ]
+}
+
+
+@pytest.fixture
+def s32dbg(runner_config, tmp_path):
+    '''NXPS32DebugProbeRunner from constructor kwargs or command line parameters'''
+    def _factory(args):
+        # create empty files to ensure kernel binaries exist
+        (tmp_path / RC_KERNEL_ELF).touch()
+        os.chdir(tmp_path)
+
+        runner_config_patched = fix_up_runner_config(runner_config, tmp_path)
+
+        if isinstance(args, dict):
+            probe_cfg = NXPS32DebugProbeConfig(**args['NXPS32DebugProbeConfig'])
+            return NXPS32DebugProbeRunner(runner_config_patched, probe_cfg,
+                                          **args['NXPS32DebugProbeRunner'])
+        elif isinstance(args, list):
+            parser = argparse.ArgumentParser(allow_abbrev=False)
+            NXPS32DebugProbeRunner.add_parser(parser)
+            arg_namespace = parser.parse_args(str(x) for x in args)
+            return NXPS32DebugProbeRunner.create(runner_config_patched, arg_namespace)
+    return _factory
+
+
+def fix_up_runner_config(runner_config, tmp_path):
+    to_replace = {}
+
+    zephyr = tmp_path / 'zephyr'
+    zephyr.mkdir()
+    dotconfig = zephyr / '.config'
+    dotconfig.write_text('CONFIG_ARCH="arm"')
+    to_replace['build_dir'] = tmp_path
+
+    return runner_config._replace(**to_replace)
+
+
+def require_patch(program, path=None):
+    assert Path(program).stem == TEST_S32DS_CMD
+    return program
+
+
+def s32dbg_get_script(name):
+    return Path(f'{name}.py')
+
+
+@pytest.mark.parametrize('s32dbg_args,expected,osname', [
+    (TEST_ALL_KWARGS, DEBUGSERVER_ALL_EXPECTED_CALL, 'Windows'),
+    (TEST_ALL_PARAMS, DEBUGSERVER_ALL_EXPECTED_CALL, 'Windows'),
+    (TEST_ALL_KWARGS, DEBUGSERVER_ALL_EXPECTED_CALL, 'Linux'),
+    (TEST_ALL_PARAMS, DEBUGSERVER_ALL_EXPECTED_CALL, 'Linux'),
+])
+@patch('platform.system')
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
+def test_debugserver(require, check_call, system,
+                     s32dbg_args, expected, osname, s32dbg):
+    system.return_value = osname
+
+    runner = s32dbg(s32dbg_args)
+    runner.run('debugserver')
+
+    assert require.called
+    check_call.assert_called_once_with(expected)
+
+
+@pytest.mark.parametrize('s32dbg_args,expected,osname', [
+    (TEST_ALL_KWARGS, DEBUG_ALL_EXPECTED_CALL, 'Windows'),
+    (TEST_ALL_PARAMS, DEBUG_ALL_EXPECTED_CALL, 'Windows'),
+    (TEST_ALL_KWARGS, DEBUG_ALL_EXPECTED_CALL, 'Linux'),
+    (TEST_ALL_PARAMS, DEBUG_ALL_EXPECTED_CALL, 'Linux'),
+])
+@patch.dict(os.environ, TEST_S32DS_RUNTIME_ENV, clear=True)
+@patch('platform.system')
+@patch('tempfile.TemporaryDirectory')
+@patch('runners.nxp_s32dbg.NXPS32DebugProbeRunner.get_script', side_effect=s32dbg_get_script)
+@patch('runners.core.ZephyrBinaryRunner.popen_ignore_int')
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
+def test_debug(require, check_call, popen_ignore_int, get_script, temporary_dir, system,
+               s32dbg_args, expected, osname, s32dbg, tmp_path):
+
+    # mock tempfile.TemporaryDirectory to return `tmp_path` and create gdb init script there
+    temporary_dir.return_value.__enter__.return_value = tmp_path
+    gdb_script = tmp_path / 'runner.nxp_s32dbg'
+    expected_client = [e.replace('TEST_GDB_SCRIPT', gdb_script.as_posix())
+                       for e in expected['client']]
+
+    system.return_value = osname
+    expected_env = TEST_S32DS_RUNTIME_ENV if osname == 'Windows' else None
+
+    runner = s32dbg(s32dbg_args)
+    runner.run('debug')
+
+    assert require.called
+    assert gdb_script.read_text().splitlines() == expected['gdb_script']
+    popen_ignore_int.assert_called_once_with(expected['server'], env=expected_env)
+    check_call.assert_called_once_with(expected_client, env=expected_env)
+
+
+@pytest.mark.parametrize('s32dbg_args,expected,osname', [
+    (TEST_ALL_KWARGS, ATTACH_ALL_EXPECTED_CALL, 'Windows'),
+    (TEST_ALL_PARAMS, ATTACH_ALL_EXPECTED_CALL, 'Windows'),
+    (TEST_ALL_KWARGS, ATTACH_ALL_EXPECTED_CALL, 'Linux'),
+    (TEST_ALL_PARAMS, ATTACH_ALL_EXPECTED_CALL, 'Linux'),
+])
+@patch.dict(os.environ, TEST_S32DS_RUNTIME_ENV, clear=True)
+@patch('platform.system')
+@patch('tempfile.TemporaryDirectory')
+@patch('runners.nxp_s32dbg.NXPS32DebugProbeRunner.get_script', side_effect=s32dbg_get_script)
+@patch('runners.core.ZephyrBinaryRunner.popen_ignore_int')
+@patch('runners.core.ZephyrBinaryRunner.check_call')
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
+def test_attach(require, check_call, popen_ignore_int, get_script, temporary_dir, system,
+                s32dbg_args, expected, osname, s32dbg, tmp_path):
+
+    # mock tempfile.TemporaryDirectory to return `tmp_path` and create gdb init script there
+    temporary_dir.return_value.__enter__.return_value = tmp_path
+    gdb_script = tmp_path / 'runner.nxp_s32dbg'
+    expected_client = [e.replace('TEST_GDB_SCRIPT', gdb_script.as_posix())
+                       for e in expected['client']]
+
+    system.return_value = osname
+    expected_env = TEST_S32DS_RUNTIME_ENV if osname == 'Windows' else None
+
+    runner = s32dbg(s32dbg_args)
+    runner.run('attach')
+
+    assert require.called
+    assert gdb_script.read_text().splitlines() == expected['gdb_script']
+    popen_ignore_int.assert_called_once_with(expected['server'], env=expected_env)
+    check_call.assert_called_once_with(expected_client, env=expected_env)

--- a/soc/arm/nxp_s32/s32ze/soc.c
+++ b/soc/arm/nxp_s32/s32ze/soc.c
@@ -21,6 +21,12 @@ void z_arm_platform_init(void)
 	barrier_dsync_fence_full();
 	barrier_isync_fence_full();
 
+	/*
+	 * Take exceptions in Arm mode because Zephyr ASM code for Cortex-R Aarch32
+	 * is written for Arm
+	 */
+	__set_SCTLR(__get_SCTLR() & ~SCTLR_TE_Msk);
+
 	if (IS_ENABLED(CONFIG_ICACHE)) {
 		if (!(__get_SCTLR() & SCTLR_I_Msk)) {
 			L1C_InvalidateICacheAll();


### PR DESCRIPTION
The [NXP S32 Debug Probe](https://www.nxp.com/design/software/automotive-software-and-tools/s32-debug-probe:S32-DP) is a JTAG-based probe that enables debugging on NXP S32 devices. This probe is designed to work in conjunction with NXP S32 Design Studio and this runner allows to launch a GDB debug session from cli.

`flash` command is not implemented at the moment because presently there are no Zephyr boards that can make use of it and test it. The goal is to enable for now the debugging capabilities, specifically for `s32z270dc2_r52` boards.