### PR TITLE
Bluetooth: l2cap: validate `reconfigure` packet length

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1362,6 +1362,12 @@ static void le_ecred_reconf_req(struct bt_l2cap *l2cap, uint8_t ident,
 		goto response;
 	}
 
+	/* The specification only allows up to 5 CIDs in this packet */
+	if (buf->len > (L2CAP_ECRED_CHAN_MAX_PER_REQ * sizeof(scid))) {
+		result = BT_L2CAP_RECONF_OTHER_UNACCEPT;
+		goto response;
+	}
+
 	while (buf->len >= sizeof(scid)) {
 		struct bt_l2cap_chan *chan;
 		scid = net_buf_pull_le16(buf);


### PR DESCRIPTION
The specification only allows up to 5 16-bit CIDs in this PDU. Enforce it.