### PR TITLE
Bluetooth: Mesh: Add missing descriptions, fix fields rendering, fix 3rd-party links

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/dfu.rst
+++ b/doc/connectivity/bluetooth/api/mesh/dfu.rst
@@ -219,6 +219,10 @@ API reference
 
 This section lists the types common to the Device Firmware Update mesh models.
 
+.. doxygengroup:: bt_mesh_dfd
+   :project: Zephyr
+   :members:
+
 .. doxygengroup:: bt_mesh_dfu
    :project: Zephyr
    :members:

--- a/doc/connectivity/bluetooth/api/mesh/provisioning.rst
+++ b/doc/connectivity/bluetooth/api/mesh/provisioning.rst
@@ -53,7 +53,7 @@ The Uniform Resource Identifier shall follow the format specified in the
 Bluetooth Core Specification Supplement. The URI must start with a URI scheme,
 encoded as a single utf-8 data point, or the special ``none`` scheme, encoded
 as ``0x01``. The available schemes are listed on the `Bluetooth website
-<https://www.bluetooth.com/specifications/assigned-numbers/uri-scheme-name-string-mapping/>`_.
+<https://www.bluetooth.com/specifications/assigned-numbers/>`_.
 
 Examples of encoded URIs:
 

--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -893,7 +893,7 @@ struct bt_mesh_model {
 	uint16_t * const groups;
 	const uint16_t groups_cnt;
 
-#if CONFIG_BT_MESH_LABEL_COUNT > 0
+#if (CONFIG_BT_MESH_LABEL_COUNT > 0) || defined(__DOXYGEN__)
 	/** List of Label UUIDs the model is subscribed to. */
 	const uint8_t ** const uuids;
 #endif
@@ -909,7 +909,7 @@ struct bt_mesh_model {
 	struct bt_mesh_model *next;
 #endif
 
-#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
+#if defined(CONFIG_BT_MESH_LARGE_COMP_DATA_SRV) || defined(__DOXYGEN__)
 	/* Pointer to the array of model metadata entries. */
 	struct bt_mesh_models_metadata_entry **metadata;
 #endif

--- a/include/zephyr/bluetooth/mesh/cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/cfg_cli.h
@@ -1690,6 +1690,7 @@ uint16_t bt_mesh_comp_p0_elem_mod(struct bt_mesh_comp_p0_elem *elem, int idx);
  */
 struct bt_mesh_mod_id_vnd bt_mesh_comp_p0_elem_mod_vnd(struct bt_mesh_comp_p0_elem *elem, int idx);
 
+/** Composition data page 1 element representation */
 struct bt_mesh_comp_p1_elem {
 	/** The number of SIG models in this element */
 	size_t nsig;


### PR DESCRIPTION
This PR fixes the following issues:
- Adds missing bt_mesh_dfd group to DFU doc page
- Adds description for bt_mesh_comp_p1_elem struct
- Adds missing description for bt_mesh_comp_p1_elem struct
- Compiles bt_mesh_model fields with Doxygen to enable rendering these fields in the documentation
- Fixes link to Assigned Numbers document as the old link doesn't exist anymore (though redirects to the new page).