### PR TITLE
dts/arm/nuvoton: Add compat strings to NPCX SoCs

### DIFF
--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -59,6 +59,8 @@
 	};
 
 	soc {
+		compatible = "nuvoton,npcx4", "nuvoton,npcx", "simple-bus";
+
 		/* Specific soc devices in npcx4 series */
 		itims: timer@400b0000 {
 			compatible = "nuvoton,npcx-itim-timer";

--- a/dts/arm/nuvoton/npcx/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7.dtsi
@@ -57,6 +57,8 @@
 	};
 
 	soc {
+		compatible = "nuvoton,npcx7", "nuvoton,npcx", "simple-bus";
+
 		/* Specific soc devices in npcx7 series */
 		itims: timer@400bc000 {
 			compatible = "nuvoton,npcx-itim-timer";

--- a/dts/arm/nuvoton/npcx/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9.dtsi
@@ -58,6 +58,8 @@
 	};
 
 	soc {
+		compatible = "nuvoton,npcx9", "nuvoton,npcx", "simple-bus";
+
 		/* Specific soc devices in npcx9 series */
 		itims: timer@400b0000 {
 			compatible = "nuvoton,npcx-itim-timer";


### PR DESCRIPTION
Compat strings in SoCs allow tools to identify hardware described in flattened device trees.