### PR TITLE
samples: tfm: Fix test definition

### DIFF
--- a/samples/tfm_integration/psa_protected_storage/sample.yaml
+++ b/samples/tfm_integration/psa_protected_storage/sample.yaml
@@ -29,5 +29,4 @@ common:
 tests:
   sample.tfm.protected_storage:
     tags:
-      - trusted-firmware-m
       - mcuboot


### PR DESCRIPTION
32a9d13d61eec18cb91209b63552cf597f89d9ec
introduced a new required tag for this test
which the integration platform does not "support"
causing the testplan generation to error out.

Fix it by removing the offending tag from the test.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/62380