### PR TITLE
sensor: f75303: fix i2c_dump_msgs_rw argument

### DIFF
--- a/drivers/sensor/f75303/f75303_emul.c
+++ b/drivers/sensor/f75303/f75303_emul.c
@@ -57,7 +57,7 @@ static int f75303_emul_transfer_i2c(const struct emul *target, struct i2c_msg *m
 
 	__ASSERT_NO_MSG(msgs && num_msgs);
 
-	i2c_dump_msgs_rw("emul", msgs, num_msgs, addr, false);
+	i2c_dump_msgs_rw(target->dev, msgs, num_msgs, addr, false);
 	switch (num_msgs) {
 	case 2:
 		if (msgs->flags & I2C_MSG_READ) {


### PR DESCRIPTION
Repro `west build -p -b native_posix -T tests/drivers/build_all/sensor/sensors.build.sensorhub`

---

i2c_dump_msgs_rw argument should be the device pointer.

Fixes #62386