### PR TITLE
ci: boards: Allow mps2_an521_ns to execute tfm tests

### DIFF
--- a/boards/arm/mps2_an521/mps2_an521_ns.yaml
+++ b/boards/arm/mps2_an521/mps2_an521_ns.yaml
@@ -16,3 +16,4 @@ testing:
     - kernel
     - tfm
     - userspace
+    - trusted-firmware-m

--- a/samples/tfm_integration/psa_protected_storage/sample.yaml
+++ b/samples/tfm_integration/psa_protected_storage/sample.yaml
@@ -29,4 +29,5 @@ common:
 tests:
   sample.tfm.protected_storage:
     tags:
+      - trusted-firmware-m
       - mcuboot


### PR DESCRIPTION
Reverts a quickfix which removed a "trusted-firmware-m" tag.
Allow to run tests with the given tag on mps2_an521_ns

Fixes: #62380