### PR TITLE
drivers: gpio: cleanup usage of IRQ related ops

### DIFF
--- a/drivers/gpio/gpio_ads114s0x.c
+++ b/drivers/gpio/gpio_ads114s0x.c
@@ -106,17 +106,6 @@ static int gpio_ads114s0x_port_toggle_bits(const struct device *dev, gpio_port_p
 	return ads114s0x_gpio_port_toggle_bits(config->parent, pins);
 }
 
-static int gpio_ads114s0x_pin_interrupt_configure(const struct device *dev, gpio_pin_t pin,
-						  enum gpio_int_mode mode, enum gpio_int_trig trig)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(mode);
-	ARG_UNUSED(trig);
-
-	return -ENOTSUP;
-}
-
 static int gpio_ads114s0x_init(const struct device *dev)
 {
 	const struct gpio_ads114s0x_config *config = dev->config;
@@ -135,7 +124,6 @@ static const struct gpio_driver_api gpio_ads114s0x_api = {
 	.port_set_bits_raw = gpio_ads114s0x_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_ads114s0x_port_clear_bits_raw,
 	.port_toggle_bits = gpio_ads114s0x_port_toggle_bits,
-	.pin_interrupt_configure = gpio_ads114s0x_pin_interrupt_configure,
 	.port_get_raw = gpio_ads114s0x_port_get_raw,
 };
 

--- a/drivers/gpio/gpio_axp192.c
+++ b/drivers/gpio/gpio_axp192.c
@@ -159,17 +159,6 @@ static int gpio_axp192_port_toggle_bits(const struct device *dev, gpio_port_pins
 	return ret;
 }
 
-static int gpio_axp192_pin_interrupt_configure(const struct device *dev, gpio_pin_t pin,
-					       enum gpio_int_mode mode, enum gpio_int_trig trig)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(mode);
-	ARG_UNUSED(trig);
-
-	return -ENOTSUP;
-}
-
 #ifdef CONFIG_GPIO_GET_CONFIG
 static int gpio_axp192_get_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t *out_flags)
 {
@@ -276,7 +265,6 @@ static const struct gpio_driver_api gpio_axp192_api = {
 	.port_set_bits_raw = gpio_axp192_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_axp192_port_clear_bits_raw,
 	.port_toggle_bits = gpio_axp192_port_toggle_bits,
-	.pin_interrupt_configure = gpio_axp192_pin_interrupt_configure,
 	.manage_callback = gpio_axp192_manage_callback,
 #ifdef CONFIG_GPIO_GET_DIRECTION
 	.port_get_direction = gpio_axp192_port_get_direction,

--- a/drivers/gpio/gpio_bd8lb600fs.c
+++ b/drivers/gpio/gpio_bd8lb600fs.c
@@ -193,12 +193,6 @@ static int bd8lb600fs_port_toggle_bits(const struct device *dev, uint32_t mask)
 	return result;
 }
 
-static int bd8lb600fs_pin_interrupt_configure(const struct device *dev, gpio_pin_t pin,
-					      enum gpio_int_mode mode, enum gpio_int_trig trig)
-{
-	return -ENOTSUP;
-}
-
 static const struct gpio_driver_api api_table = {
 	.pin_configure = bd8lb600fs_pin_configure,
 	.port_get_raw = bd8lb600fs_port_get_raw,
@@ -206,7 +200,6 @@ static const struct gpio_driver_api api_table = {
 	.port_set_bits_raw = bd8lb600fs_port_set_bits_raw,
 	.port_clear_bits_raw = bd8lb600fs_port_clear_bits_raw,
 	.port_toggle_bits = bd8lb600fs_port_toggle_bits,
-	.pin_interrupt_configure = bd8lb600fs_pin_interrupt_configure,
 };
 
 static int bd8lb600fs_init(const struct device *dev)

--- a/drivers/gpio/gpio_creg_gpio.c
+++ b/drivers/gpio/gpio_creg_gpio.c
@@ -104,14 +104,6 @@ static int port_toggle_bits(const struct device *dev,
 	return port_write(dev, 0, 0, pins);
 }
 
-static int pin_interrupt_configure(const struct device *dev,
-				   gpio_pin_t pin,
-				   enum gpio_int_mode mode,
-				   enum gpio_int_trig trig)
-{
-	return -ENOTSUP;
-}
-
 static int pin_config(const struct device *dev,
 		       gpio_pin_t pin,
 		       gpio_flags_t flags)
@@ -163,7 +155,6 @@ static const struct gpio_driver_api api_table = {
 	.port_set_bits_raw = port_set_bits,
 	.port_clear_bits_raw = port_clear_bits,
 	.port_toggle_bits = port_toggle_bits,
-	.pin_interrupt_configure = pin_interrupt_configure,
 };
 
 static const struct creg_gpio_config creg_gpio_cfg = {

--- a/drivers/gpio/gpio_cy8c95xx.c
+++ b/drivers/gpio/gpio_cy8c95xx.c
@@ -214,14 +214,6 @@ static int port_toggle_bits(const struct device *dev,
 	return port_write(dev, 0, 0, pins);
 }
 
-static int pin_interrupt_configure(const struct device *dev,
-				   gpio_pin_t pin,
-				   enum gpio_int_mode mode,
-				   enum gpio_int_trig trig)
-{
-	return -ENOTSUP;
-}
-
 /**
  * @brief Initialization function of CY8C95XX
  *
@@ -277,7 +269,6 @@ static const struct gpio_driver_api api_table = {
 	.port_set_bits_raw = port_set_bits,
 	.port_clear_bits_raw = port_clear_bits,
 	.port_toggle_bits = port_toggle_bits,
-	.pin_interrupt_configure = pin_interrupt_configure,
 };
 
 static struct k_sem cy8c95xx_lock = Z_SEM_INITIALIZER(cy8c95xx_lock, 1, 1);

--- a/drivers/gpio/gpio_fxl6408.c
+++ b/drivers/gpio/gpio_fxl6408.c
@@ -377,15 +377,6 @@ static int gpio_fxl6408_port_toggle_bits(const struct device *dev,
 	return ret;
 }
 
-static int gpio_fxl6408_pin_interrupt_configure(const struct device *port,
-						gpio_pin_t pin,
-						enum gpio_int_mode mode,
-						enum gpio_int_trig trig)
-{
-	LOG_DBG("Pin interrupts not supported.");
-	return -ENOTSUP;
-}
-
 int gpio_fxl6408_init(const struct device *dev)
 {
 	struct gpio_fxl6408_drv_data *const drv_data =
@@ -409,7 +400,6 @@ static const struct gpio_driver_api gpio_fxl_driver = {
 	.port_set_bits_raw = gpio_fxl6408_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_fxl6408_port_clear_bits_raw,
 	.port_toggle_bits = gpio_fxl6408_port_toggle_bits,
-	.pin_interrupt_configure = gpio_fxl6408_pin_interrupt_configure
 };
 
 #define GPIO_FXL6408_DEVICE_INSTANCE(inst)                                     \

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -122,19 +122,6 @@ static int gpio_lmp90xxx_port_toggle_bits(const struct device *dev,
 	return lmp90xxx_gpio_port_toggle_bits(config->parent, pins);
 }
 
-static int gpio_lmp90xxx_pin_interrupt_configure(const struct device *dev,
-						 gpio_pin_t pin,
-						 enum gpio_int_mode mode,
-						 enum gpio_int_trig trig)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(mode);
-	ARG_UNUSED(trig);
-
-	return -ENOTSUP;
-}
-
 static int gpio_lmp90xxx_init(const struct device *dev)
 {
 	const struct gpio_lmp90xxx_config *config = dev->config;
@@ -154,7 +141,6 @@ static const struct gpio_driver_api gpio_lmp90xxx_api = {
 	.port_set_bits_raw = gpio_lmp90xxx_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_lmp90xxx_port_clear_bits_raw,
 	.port_toggle_bits = gpio_lmp90xxx_port_toggle_bits,
-	.pin_interrupt_configure = gpio_lmp90xxx_pin_interrupt_configure,
 	.port_get_raw = gpio_lmp90xxx_port_get_raw,
 };
 

--- a/drivers/gpio/gpio_mcp23s17.c
+++ b/drivers/gpio/gpio_mcp23s17.c
@@ -340,14 +340,6 @@ static int mcp23s17_port_toggle_bits(const struct device *dev, uint32_t mask)
 	return ret;
 }
 
-static int mcp23s17_pin_interrupt_configure(const struct device *dev,
-					    gpio_pin_t pin,
-					    enum gpio_int_mode mode,
-					    enum gpio_int_trig trig)
-{
-	return -ENOTSUP;
-}
-
 static const struct gpio_driver_api api_table = {
 	.pin_configure = mcp23s17_config,
 	.port_get_raw = mcp23s17_port_get_raw,
@@ -355,7 +347,6 @@ static const struct gpio_driver_api api_table = {
 	.port_set_bits_raw = mcp23s17_port_set_bits_raw,
 	.port_clear_bits_raw = mcp23s17_port_clear_bits_raw,
 	.port_toggle_bits = mcp23s17_port_toggle_bits,
-	.pin_interrupt_configure = mcp23s17_pin_interrupt_configure,
 };
 
 static int mcp23s17_init(const struct device *dev)

--- a/drivers/gpio/gpio_mmio32.c
+++ b/drivers/gpio/gpio_mmio32.c
@@ -147,18 +147,6 @@ static int gpio_mmio32_port_toggle_bits(const struct device *dev,
 	return 0;
 }
 
-static int gpio_mmio32_pin_interrupt_configure(const struct device *dev,
-					       gpio_pin_t pin,
-					       enum gpio_int_mode mode,
-					       enum gpio_int_trig trig)
-{
-	if (mode != GPIO_INT_MODE_DISABLED) {
-		return -ENOTSUP;
-	}
-
-	return 0;
-}
-
 const struct gpio_driver_api gpio_mmio32_api = {
 	.pin_configure = gpio_mmio32_config,
 	.port_get_raw = gpio_mmio32_port_get_raw,
@@ -166,7 +154,6 @@ const struct gpio_driver_api gpio_mmio32_api = {
 	.port_set_bits_raw = gpio_mmio32_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_mmio32_port_clear_bits_raw,
 	.port_toggle_bits = gpio_mmio32_port_toggle_bits,
-	.pin_interrupt_configure = gpio_mmio32_pin_interrupt_configure,
 };
 
 int gpio_mmio32_init(const struct device *dev)

--- a/drivers/gpio/gpio_neorv32.c
+++ b/drivers/gpio/gpio_neorv32.c
@@ -151,19 +151,6 @@ static int neorv32_gpio_port_toggle_bits(const struct device *dev,
 	return 0;
 }
 
-static int neorv32_gpio_pin_interrupt_configure(const struct device *dev,
-						 gpio_pin_t pin,
-						 enum gpio_int_mode mode,
-						 enum gpio_int_trig trig)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(mode);
-	ARG_UNUSED(trig);
-
-	return -ENOTSUP;
-}
-
 static int neorv32_gpio_manage_callback(const struct device *dev,
 					struct gpio_callback *cb,
 					bool set)
@@ -215,7 +202,6 @@ static const struct gpio_driver_api neorv32_gpio_driver_api = {
 	.port_set_bits_raw = neorv32_gpio_port_set_bits_raw,
 	.port_clear_bits_raw = neorv32_gpio_port_clear_bits_raw,
 	.port_toggle_bits = neorv32_gpio_port_toggle_bits,
-	.pin_interrupt_configure = neorv32_gpio_pin_interrupt_configure,
 	.manage_callback = neorv32_gpio_manage_callback,
 	.get_pending_int = neorv32_gpio_get_pending_int,
 };

--- a/drivers/gpio/gpio_npm1300.c
+++ b/drivers/gpio/gpio_npm1300.c
@@ -185,17 +185,6 @@ static int gpio_npm1300_port_toggle_bits(const struct device *dev, gpio_port_pin
 	return gpio_npm1300_port_set_masked_raw(dev, pins, ~value);
 }
 
-static int gpio_npm1300_pin_interrupt_configure(const struct device *dev, gpio_pin_t pin,
-						enum gpio_int_mode mode, enum gpio_int_trig trig)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(mode);
-	ARG_UNUSED(trig);
-
-	return -ENOTSUP;
-}
-
 static const struct gpio_driver_api gpio_npm1300_api = {
 	.pin_configure = gpio_npm1300_configure,
 	.port_get_raw = gpio_npm1300_port_get_raw,
@@ -203,7 +192,6 @@ static const struct gpio_driver_api gpio_npm1300_api = {
 	.port_set_bits_raw = gpio_npm1300_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_npm1300_port_clear_bits_raw,
 	.port_toggle_bits = gpio_npm1300_port_toggle_bits,
-	.pin_interrupt_configure = gpio_npm1300_pin_interrupt_configure,
 };
 
 static int gpio_npm1300_init(const struct device *dev)

--- a/drivers/gpio/gpio_npm6001.c
+++ b/drivers/gpio/gpio_npm6001.c
@@ -192,19 +192,6 @@ static int gpio_npm6001_port_toggle_bits(const struct device *dev,
 						~val & NPM6001_PIN_MSK);
 }
 
-static int gpio_npm6001_pin_interrupt_configure(const struct device *dev,
-						gpio_pin_t pin,
-						enum gpio_int_mode mode,
-						enum gpio_int_trig trig)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(mode);
-	ARG_UNUSED(trig);
-
-	return -ENOTSUP;
-}
-
 static const struct gpio_driver_api gpio_npm6001_api = {
 	.pin_configure = gpio_npm6001_configure,
 	.port_get_raw = gpio_npm6001_port_get_raw,
@@ -212,7 +199,6 @@ static const struct gpio_driver_api gpio_npm6001_api = {
 	.port_set_bits_raw = gpio_npm6001_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_npm6001_port_clear_bits_raw,
 	.port_toggle_bits = gpio_npm6001_port_toggle_bits,
-	.pin_interrupt_configure = gpio_npm6001_pin_interrupt_configure,
 };
 
 static int gpio_npm6001_init(const struct device *dev)

--- a/drivers/gpio/gpio_nxp_s32.c
+++ b/drivers/gpio/gpio_nxp_s32.c
@@ -205,14 +205,12 @@ static void nxp_s32_gpio_isr(uint8_t pin, void *arg)
 
 	gpio_fire_callbacks(&data->callbacks, dev, BIT(pin));
 }
-#endif /* CONFIG_NXP_S32_EIRQ */
 
 static int nxp_s32_gpio_pin_interrupt_configure(const struct device *dev,
 						gpio_pin_t pin,
 						enum gpio_int_mode mode,
 						enum gpio_int_trig trig)
 {
-#ifdef CONFIG_NXP_S32_EIRQ
 	const struct gpio_nxp_s32_config *config = dev->config;
 	const struct eirq_nxp_s32_info *eirq_info = config->eirq_info;
 
@@ -255,35 +253,18 @@ static int nxp_s32_gpio_pin_interrupt_configure(const struct device *dev,
 	}
 
 	return 0;
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(mode);
-	ARG_UNUSED(trig);
-
-	return -ENOTSUP;
-#endif
 }
 
 static int nxp_s32_gpio_manage_callback(const struct device *dev,
 					struct gpio_callback *cb, bool set)
 {
-#ifdef CONFIG_NXP_S32_EIRQ
 	struct gpio_nxp_s32_data *data = dev->data;
 
 	return gpio_manage_callback(&data->callbacks, cb, set);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(cb);
-	ARG_UNUSED(set);
-
-	return -ENOTSUP;
-#endif
 }
 
 static uint32_t nxp_s32_gpio_get_pending_int(const struct device *dev)
 {
-#ifdef CONFIG_NXP_S32_EIRQ
 	const struct gpio_nxp_s32_config *config = dev->config;
 	const struct eirq_nxp_s32_info *eirq_info = config->eirq_info;
 
@@ -300,14 +281,8 @@ static uint32_t nxp_s32_gpio_get_pending_int(const struct device *dev)
 	 * that GPIO port belongs to
 	 */
 	return eirq_nxp_s32_get_pending(eirq_info->eirq_dev);
-
-#else
-	ARG_UNUSED(dev);
-
-	return -ENOTSUP;
-#endif
 }
-
+#endif /* CONFIG_NXP_S32_EIRQ */
 
 #ifdef CONFIG_GPIO_GET_CONFIG
 static int nxp_s32_gpio_pin_get_config(const struct device *dev,
@@ -400,9 +375,11 @@ static const struct gpio_driver_api gpio_nxp_s32_driver_api = {
 	.port_set_bits_raw = nxp_s32_gpio_port_set_bits_raw,
 	.port_clear_bits_raw = nxp_s32_gpio_port_clear_bits_raw,
 	.port_toggle_bits = nxp_s32_gpio_port_toggle_bits,
+#ifdef CONFIG_NXP_S32_EIRQ
 	.pin_interrupt_configure = nxp_s32_gpio_pin_interrupt_configure,
 	.manage_callback = nxp_s32_gpio_manage_callback,
 	.get_pending_int = nxp_s32_gpio_get_pending_int,
+#endif
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = nxp_s32_gpio_pin_get_config,
 #endif

--- a/drivers/gpio/gpio_pca95xx.c
+++ b/drivers/gpio/gpio_pca95xx.c
@@ -644,7 +644,6 @@ static void gpio_pca95xx_interrupt_callback(const struct device *dev,
 	/* Cannot read PCA95xx registers from ISR context, queue worker */
 	k_work_submit(&drv_data->interrupt_worker);
 }
-#endif /* CONFIG_GPIO_PCA95XX_INTERRUPT */
 
 static int gpio_pca95xx_pin_interrupt_configure(const struct device *dev,
 						  gpio_pin_t pin,
@@ -652,13 +651,6 @@ static int gpio_pca95xx_pin_interrupt_configure(const struct device *dev,
 						  enum gpio_int_trig trig)
 {
 	int ret = 0;
-
-	if (!IS_ENABLED(CONFIG_GPIO_PCA95XX_INTERRUPT)
-	    && (mode != GPIO_INT_MODE_DISABLED)) {
-		return -ENOTSUP;
-	}
-
-#ifdef CONFIG_GPIO_PCA95XX_INTERRUPT
 	const struct gpio_pca95xx_config * const config = dev->config;
 	struct gpio_pca95xx_drv_data * const drv_data =
 		(struct gpio_pca95xx_drv_data * const)dev->data;
@@ -742,11 +734,9 @@ static int gpio_pca95xx_pin_interrupt_configure(const struct device *dev,
 
 err:
 	k_sem_give(&drv_data->lock);
-#endif /* CONFIG_GPIO_PCA95XX_INTERRUPT */
 	return ret;
 }
 
-#ifdef CONFIG_GPIO_PCA95XX_INTERRUPT
 static int gpio_pca95xx_manage_callback(const struct device *dev,
 					struct gpio_callback *callback,
 					bool set)
@@ -766,7 +756,7 @@ static int gpio_pca95xx_manage_callback(const struct device *dev,
 	k_sem_give(&drv_data->lock);
 	return 0;
 }
-#endif
+#endif /* CONFIG_GPIO_PCA95XX_INTERRUPT */
 
 static const struct gpio_driver_api gpio_pca95xx_drv_api_funcs = {
 	.pin_configure = gpio_pca95xx_config,
@@ -775,8 +765,8 @@ static const struct gpio_driver_api gpio_pca95xx_drv_api_funcs = {
 	.port_set_bits_raw = gpio_pca95xx_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_pca95xx_port_clear_bits_raw,
 	.port_toggle_bits = gpio_pca95xx_port_toggle_bits,
-	.pin_interrupt_configure = gpio_pca95xx_pin_interrupt_configure,
 #ifdef CONFIG_GPIO_PCA95XX_INTERRUPT
+	.pin_interrupt_configure = gpio_pca95xx_pin_interrupt_configure,
 	.manage_callback = gpio_pca95xx_manage_callback,
 #endif
 };

--- a/drivers/gpio/gpio_sc18im704.c
+++ b/drivers/gpio/gpio_sc18im704.c
@@ -239,17 +239,6 @@ static int gpio_sc18im_port_toggle_bits(const struct device *port, gpio_port_pin
 	return gpio_sc18im_port_set_raw(port, 0, 0, (uint8_t)pins);
 }
 
-static int gpio_sc18im_pin_interrupt_configure(const struct device *port, gpio_pin_t pin,
-					       enum gpio_int_mode mode, enum gpio_int_trig trig)
-{
-	ARG_UNUSED(port);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(mode);
-	ARG_UNUSED(trig);
-
-	return -ENOTSUP;
-}
-
 static int gpio_sc18im_init(const struct device *dev)
 {
 	const struct gpio_sc18im_config *cfg = dev->config;
@@ -272,7 +261,6 @@ static const struct gpio_driver_api gpio_sc18im_driver_api = {
 	.port_set_bits_raw = gpio_sc18im_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_sc18im_port_clear_bits_raw,
 	.port_toggle_bits = gpio_sc18im_port_toggle_bits,
-	.pin_interrupt_configure = gpio_sc18im_pin_interrupt_configure,
 };
 
 #define CHECK_COMPAT(node)									\

--- a/drivers/gpio/gpio_sn74hc595.c
+++ b/drivers/gpio/gpio_sn74hc595.c
@@ -134,16 +134,6 @@ unlock:
 	return ret;
 }
 
-static int gpio_sn74hc595_pin_interrupt_configure(const struct device *dev, gpio_pin_t pin,
-						  enum gpio_int_mode mode, enum gpio_int_trig trig)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(mode);
-	ARG_UNUSED(trig);
-	return -ENOTSUP;
-}
-
 static const struct gpio_driver_api gpio_sn74hc595_drv_api_funcs = {
 	.pin_configure = gpio_sn74hc595_config,
 	.port_get_raw = gpio_sn74hc595_port_get_raw,
@@ -151,7 +141,6 @@ static const struct gpio_driver_api gpio_sn74hc595_drv_api_funcs = {
 	.port_set_bits_raw = gpio_sn74hc595_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_sn74hc595_port_clear_bits_raw,
 	.port_toggle_bits = gpio_sn74hc595_port_toggle_bits,
-	.pin_interrupt_configure = gpio_sn74hc595_pin_interrupt_configure,
 };
 
 /**

--- a/drivers/gpio/gpio_stmpe1600.c
+++ b/drivers/gpio/gpio_stmpe1600.c
@@ -249,14 +249,6 @@ static int stmpe1600_port_toggle_bits(const struct device *dev, uint32_t mask)
 	return ret;
 }
 
-static int stmpe1600_pin_interrupt_configure(const struct device *dev,
-					     gpio_pin_t pin,
-					     enum gpio_int_mode mode,
-					     enum gpio_int_trig trig)
-{
-	return -ENOTSUP;
-}
-
 static int stmpe1600_init(const struct device *dev)
 {
 	const struct stmpe1600_config *const config = dev->config;
@@ -300,7 +292,6 @@ static const struct gpio_driver_api stmpe1600_drv_api = {
 	.port_set_bits_raw = stmpe1600_port_set_bits_raw,
 	.port_clear_bits_raw = stmpe1600_port_clear_bits_raw,
 	.port_toggle_bits = stmpe1600_port_toggle_bits,
-	.pin_interrupt_configure = stmpe1600_pin_interrupt_configure,
 };
 
 #define STMPE1600_INIT(inst)					     \

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -468,6 +468,7 @@ static int port_toggle_bits(const struct device *dev,
 	return port_write(dev, 0, 0, pins);
 }
 
+#ifdef CONFIG_GPIO_SX1509B_INTERRUPT
 static int pin_interrupt_configure(const struct device *dev,
 				   gpio_pin_t pin,
 				   enum gpio_int_mode mode,
@@ -475,12 +476,6 @@ static int pin_interrupt_configure(const struct device *dev,
 {
 	int rc = 0;
 
-	if (!IS_ENABLED(CONFIG_GPIO_SX1509B_INTERRUPT)
-	    && (mode != GPIO_INT_MODE_DISABLED)) {
-		return -ENOTSUP;
-	}
-
-#ifdef CONFIG_GPIO_SX1509B_INTERRUPT
 	/* Device does not support level-triggered interrupts. */
 	if (mode == GPIO_INT_MODE_LEVEL) {
 		return -ENOTSUP;
@@ -531,10 +526,10 @@ static int pin_interrupt_configure(const struct device *dev,
 	rc = i2c_write_dt(&cfg->bus, &irq_buf.reg, sizeof(irq_buf));
 
 	k_sem_give(&drv_data->lock);
-#endif /* CONFIG_GPIO_SX1509B_INTERRUPT */
 
 	return rc;
 }
+#endif /* CONFIG_GPIO_SX1509B_INTERRUPT */
 
 /**
  * @brief Initialization function of SX1509B
@@ -647,8 +642,8 @@ static const struct gpio_driver_api api_table = {
 	.port_set_bits_raw = port_set_bits,
 	.port_clear_bits_raw = port_clear_bits,
 	.port_toggle_bits = port_toggle_bits,
-	.pin_interrupt_configure = pin_interrupt_configure,
 #ifdef CONFIG_GPIO_SX1509B_INTERRUPT
+	.pin_interrupt_configure = pin_interrupt_configure,
 	.manage_callback = gpio_sx1509b_manage_callback,
 #endif
 };

--- a/drivers/gpio/gpio_test.c
+++ b/drivers/gpio/gpio_test.c
@@ -63,26 +63,6 @@ static int vnd_gpio_port_toggle_bits(const struct device *port,
 	return -ENOTSUP;
 }
 
-static int vnd_gpio_pin_interrupt_configure(const struct device *port,
-					    gpio_pin_t pin,
-					    enum gpio_int_mode mode,
-					    enum gpio_int_trig trig)
-{
-	return -ENOTSUP;
-}
-
-static int vnd_gpio_manage_callback(const struct device *port,
-				    struct gpio_callback *cb,
-				    bool set)
-{
-	return -ENOTSUP;
-}
-
-static uint32_t vnd_gpio_get_pending_int(const struct device *dev)
-{
-	return 0;
-}
-
 static const struct gpio_driver_api vnd_gpio_api = {
 	.pin_configure = vnd_gpio_pin_configure,
 	.port_get_raw = vnd_gpio_port_get_raw,
@@ -90,9 +70,6 @@ static const struct gpio_driver_api vnd_gpio_api = {
 	.port_set_bits_raw = vnd_gpio_port_set_bits_raw,
 	.port_clear_bits_raw = vnd_gpio_port_clear_bits_raw,
 	.port_toggle_bits = vnd_gpio_port_toggle_bits,
-	.pin_interrupt_configure = vnd_gpio_pin_interrupt_configure,
-	.manage_callback = vnd_gpio_manage_callback,
-	.get_pending_int = vnd_gpio_get_pending_int
 };
 
 #define VND_GPIO_INIT(n)						\

--- a/drivers/gpio/gpio_xlnx_axi.c
+++ b/drivers/gpio/gpio_xlnx_axi.c
@@ -198,6 +198,7 @@ static int gpio_xlnx_axi_port_toggle_bits(const struct device *dev, gpio_port_pi
 	return 0;
 }
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 /**
  * Enables interrupts for the given pins on the channel
  * The axi gpio can only enable interrupts for an entire port, so we need to track
@@ -206,7 +207,6 @@ static int gpio_xlnx_axi_port_toggle_bits(const struct device *dev, gpio_port_pi
 static int gpio_xlnx_axi_pin_interrupt_configure(const struct device *dev, gpio_pin_t pin,
 						 enum gpio_int_mode mode, enum gpio_int_trig trig)
 {
-#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 	const struct gpio_xlnx_axi_config *config = dev->config;
 	struct gpio_xlnx_axi_data *data = dev->data;
 	const uint32_t pin_mask = BIT(pin);
@@ -390,9 +390,11 @@ static const struct gpio_driver_api gpio_xlnx_axi_driver_api = {
 	.port_set_bits_raw = gpio_xlnx_axi_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_xlnx_axi_port_clear_bits_raw,
 	.port_toggle_bits = gpio_xlnx_axi_port_toggle_bits,
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 	.pin_interrupt_configure = gpio_xlnx_axi_pin_interrupt_configure,
 	.manage_callback = gpio_xlnx_axi_manage_callback,
 	.get_pending_int = gpio_xlnx_axi_get_pending_int,
+#endif
 };
 
 #define GPIO_XLNX_AXI_GPIO2_HAS_COMPAT_STATUS_OKAY(n)                                              \

--- a/drivers/gpio/gpio_xmc4xxx.c
+++ b/drivers/gpio/gpio_xmc4xxx.c
@@ -117,10 +117,10 @@ static void gpio_xmc4xxx_isr(const struct device *dev, int pin)
 }
 #endif
 
+#ifdef CONFIG_XMC4XXX_INTC
 static int gpio_xmc4xxx_pin_interrupt_configure(const struct device *dev, gpio_pin_t pin,
 						enum gpio_int_mode mode, enum gpio_int_trig trig)
 {
-#if defined(CONFIG_XMC4XXX_INTC)
 	const struct gpio_xmc4xxx_config *config = dev->config;
 	int port_id = PORT_TO_PORT_ID(config->port);
 
@@ -132,15 +132,8 @@ static int gpio_xmc4xxx_pin_interrupt_configure(const struct device *dev, gpio_p
 	} else {
 		return -EINVAL;
 	}
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(pin);
-	ARG_UNUSED(mode);
-	ARG_UNUSED(trig);
-
-	return -ENOTSUP;
-#endif
 }
+#endif
 
 static int gpio_xmc4xxx_get_raw(const struct device *dev, gpio_port_value_t *value)
 {
@@ -215,8 +208,10 @@ static const struct gpio_driver_api gpio_xmc4xxx_driver_api = {
 	.port_set_bits_raw = gpio_xmc4xxx_set_bits_raw,
 	.port_clear_bits_raw = gpio_xmc4xxx_clear_bits_raw,
 	.port_toggle_bits = gpio_xmc4xxx_toggle_bits,
+#ifdef CONFIG_XMC4XXX_INTC
 	.pin_interrupt_configure = gpio_xmc4xxx_pin_interrupt_configure,
-	.manage_callback = IS_ENABLED(CONFIG_XMC4XXX_INTC) ? gpio_xmc4xxx_manage_callback : NULL,
+	.manage_callback = gpio_xmc4xxx_manage_callback,
+#endif
 };
 
 #define GPIO_XMC4XXX_INIT(index)                                                                   \

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -1700,7 +1700,9 @@ static inline void gpio_init_callback(struct gpio_callback *callback,
  * @brief Add an application callback.
  * @param port Pointer to the device structure for the driver instance.
  * @param callback A valid Application's callback structure pointer.
- * @return 0 if successful, negative errno code on failure.
+ * @retval 0 If successful
+ * @retval -ENOSYS If driver does not implement the operation
+ * @retval -errno Other negative errno code on failure.
  *
  * @note Callbacks may be added to the device from within a callback
  * handler invocation, but whether they are invoked for the current
@@ -1715,7 +1717,7 @@ static inline int gpio_add_callback(const struct device *port,
 		(const struct gpio_driver_api *)port->api;
 
 	if (api->manage_callback == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->manage_callback(port, callback, true);
@@ -1742,7 +1744,9 @@ static inline int gpio_add_callback_dt(const struct gpio_dt_spec *spec,
  * @brief Remove an application callback.
  * @param port Pointer to the device structure for the driver instance.
  * @param callback A valid application's callback structure pointer.
- * @return 0 if successful, negative errno code on failure.
+ * @retval 0 If successful
+ * @retval -ENOSYS If driver does not implement the operation
+ * @retval -errno Other negative errno code on failure.
  *
  * @warning It is explicitly permitted, within a callback handler, to
  * remove the registration for the callback that is running, i.e. @p
@@ -1761,7 +1765,7 @@ static inline int gpio_remove_callback(const struct device *port,
 		(const struct gpio_driver_api *)port->api;
 
 	if (api->manage_callback == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->manage_callback(port, callback, false);

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -1800,6 +1800,7 @@ static inline int gpio_remove_callback_dt(const struct gpio_dt_spec *spec,
  *
  * @retval status != 0 if at least one gpio interrupt is pending.
  * @retval 0 if no gpio interrupt is pending.
+ * @retval -ENOSYS If driver does not implement the operation
  */
 __syscall int gpio_get_pending_int(const struct device *dev);
 
@@ -1809,7 +1810,7 @@ static inline int z_impl_gpio_get_pending_int(const struct device *dev)
 		(const struct gpio_driver_api *)dev->api;
 
 	if (api->get_pending_int == NULL) {
-		return -ENOTSUP;
+		return -ENOSYS;
 	}
 
 	return api->get_pending_int(dev);

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -846,6 +846,7 @@ static inline bool gpio_is_ready_dt(const struct gpio_dt_spec *spec)
  * @param flags Interrupt configuration flags as defined by GPIO_INT_*.
  *
  * @retval 0 If successful.
+ * @retval -ENOSYS If the operation is not implemented by the driver.
  * @retval -ENOTSUP If any of the configuration options is not supported
  *                  (unless otherwise directed by flag documentation).
  * @retval -EINVAL  Invalid argument.
@@ -870,6 +871,10 @@ static inline int z_impl_gpio_pin_interrupt_configure(const struct device *port,
 		(const struct gpio_driver_data *)port->data;
 	enum gpio_int_trig trig;
 	enum gpio_int_mode mode;
+
+	if (api->pin_interrupt_configure == NULL) {
+		return -ENOSYS;
+	}
 
 	__ASSERT((flags & (GPIO_INT_DISABLE | GPIO_INT_ENABLE))
 		 != (GPIO_INT_DISABLE | GPIO_INT_ENABLE),


### PR DESCRIPTION
Some dodgy patterns have organically grown in the GPIO driver class when it comes to the IRQ related ops, let's clean this up.