### PR TITLE
cmake: Zephyr kernel version.h and app_version.h creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,10 +557,11 @@ add_custom_command(
     -DOUT_FILE=${PROJECT_BINARY_DIR}/include/generated/version.h
     -DVERSION_TYPE=KERNEL
     -DVERSION_FILE=${ZEPHYR_BASE}/VERSION
-    -DKERNEL_VERSION_CUSTOMIZATION="${KERNEL_VERSION_CUSTOMIZATION}"
+    -DKERNEL_VERSION_CUSTOMIZATION="$<TARGET_PROPERTY:version_h,KERNEL_VERSION_CUSTOMIZATION>"
     ${build_version_argument}
     -P ${ZEPHYR_BASE}/cmake/gen_version_h.cmake
   DEPENDS ${ZEPHYR_BASE}/VERSION ${git_dependency}
+  COMMAND_EXPAND_LISTS
 )
 add_custom_target(version_h DEPENDS ${PROJECT_BINARY_DIR}/include/generated/version.h)
 
@@ -571,10 +572,11 @@ if(EXISTS ${APPLICATION_SOURCE_DIR}/VERSION)
       -DOUT_FILE=${PROJECT_BINARY_DIR}/include/generated/app_version.h
       -DVERSION_TYPE=APP
       -DVERSION_FILE=${APPLICATION_SOURCE_DIR}/VERSION
-      -DAPP_VERSION_CUSTOMIZATION="${APP_VERSION_CUSTOMIZATION}"
+      -DAPP_VERSION_CUSTOMIZATION="$<TARGET_PROPERTY:app_version_h,APP_VERSION_CUSTOMIZATION>"
       ${build_version_argument}
       -P ${ZEPHYR_BASE}/cmake/gen_version_h.cmake
     DEPENDS ${APPLICATION_SOURCE_DIR}/VERSION ${git_dependency}
+    COMMAND_EXPAND_LISTS
   )
   add_custom_target(app_version_h DEPENDS ${PROJECT_BINARY_DIR}/include/generated/app_version.h)
   add_dependencies(zephyr_interface app_version_h)


### PR DESCRIPTION
Move the custom commands creating the version.h and app_version.h below the Zephyr modules sourcing.

This allows custom user specific Zephyr modules to adjust the value of KERNEL_VERSION_CUSTOMIZATION and APP_VERSION_CUSTOMIZATION values and thereby make use of the functionality introduced with #61635.

The creation of the version_h and app_version_h targets, which drives the custom commands, are kept at their current location.

This ensure that the targets themselves are still defined when the Zephyr and Zephyr modules CMakeLists trees are sourced.