### PR TITLE
dts/riscv: riscv-wide `riscv,isa` field cleanup

### DIFF
--- a/dts/bindings/cpu/espressif,riscv.yaml
+++ b/dts/bindings/cpu/espressif,riscv.yaml
@@ -5,7 +5,7 @@ description: Espressif RISC-V CPU
 
 compatible: "espressif,riscv"
 
-include: cpu.yaml
+include: riscv,cpus.yaml
 
 properties:
   clock-source:

--- a/dts/bindings/cpu/intel,niosv.yaml
+++ b/dts/bindings/cpu/intel,niosv.yaml
@@ -5,4 +5,4 @@ description: INTEL FPGA NIOSV Softcore Processor
 
 compatible: "intel,niosv"
 
-include: cpu.yaml
+include: riscv,cpus.yaml

--- a/dts/bindings/cpu/ite,riscv-ite.yaml
+++ b/dts/bindings/cpu/ite,riscv-ite.yaml
@@ -5,4 +5,4 @@ description: ITE IT8XXX2 RISC-V CPU
 
 compatible: "ite,riscv-ite"
 
-include: cpu.yaml
+include: riscv,cpus.yaml

--- a/dts/bindings/cpu/neorv32-cpu.yaml
+++ b/dts/bindings/cpu/neorv32-cpu.yaml
@@ -5,4 +5,4 @@ description: NEORV32 RISC-V CPU
 
 compatible: "neorv32-cpu"
 
-include: cpu.yaml
+include: riscv,cpus.yaml

--- a/dts/bindings/cpu/nuclei,bumblebee.yaml
+++ b/dts/bindings/cpu/nuclei,bumblebee.yaml
@@ -5,7 +5,7 @@ description: Nuclei Bumblebee RISC-V Core
 
 compatible: "nuclei,bumblebee"
 
-include: cpu.yaml
+include: riscv,cpus.yaml
 
 properties:
   mcause-exception-mask:

--- a/dts/bindings/cpu/telink,b91.yaml
+++ b/dts/bindings/cpu/telink,b91.yaml
@@ -5,4 +5,4 @@ description: Telink RISC-V CPU
 
 compatible: "telink,b91"
 
-include: cpu.yaml
+include: riscv,cpus.yaml

--- a/dts/bindings/riscv/riscv,cpus.yaml
+++ b/dts/bindings/riscv/riscv,cpus.yaml
@@ -17,10 +17,3 @@ properties:
     description: RISC-V instruction set architecture
     required: true
     type: string
-    enum:
-      - rv32emc
-      - rv32imac
-      - rv32imafc
-      - rv32imafcb
-      - rv64imac
-      - rv64imafdc

--- a/dts/riscv/andes/andes_v5_ae350.dtsi
+++ b/dts/riscv/andes/andes_v5_ae350.dtsi
@@ -21,7 +21,7 @@
 			device_type = "cpu";
 			reg = <0>;
 			status = "okay";
-			riscv,isa = "rv32imafdcxandes";
+			riscv,isa = "rv32gc_xandes";
 			mmu-type = "riscv,sv32";
 			clock-frequency = <60000000>;
 			i-cache-line-size = <32>;
@@ -38,7 +38,7 @@
 			device_type = "cpu";
 			reg = <1>;
 			status = "okay";
-			riscv,isa = "rv32imafdcxandes";
+			riscv,isa = "rv32gc_xandes";
 			mmu-type = "riscv,sv32";
 			clock-frequency = <60000000>;
 			i-cache-line-size = <32>;
@@ -55,7 +55,7 @@
 			device_type = "cpu";
 			reg = <2>;
 			status = "okay";
-			riscv,isa = "rv32imafdcxandes";
+			riscv,isa = "rv32gc_xandes";
 			mmu-type = "riscv,sv32";
 			clock-frequency = <60000000>;
 			i-cache-line-size = <32>;
@@ -72,7 +72,7 @@
 			device_type = "cpu";
 			reg = <3>;
 			status = "okay";
-			riscv,isa = "rv32imafdcxandes";
+			riscv,isa = "rv32gc_xandes";
 			mmu-type = "riscv,sv32";
 			clock-frequency = <60000000>;
 			i-cache-line-size = <32>;
@@ -89,7 +89,7 @@
 			device_type = "cpu";
 			reg = <4>;
 			status = "okay";
-			riscv,isa = "rv32imafdcxandes";
+			riscv,isa = "rv32gc_xandes";
 			mmu-type = "riscv,sv32";
 			clock-frequency = <60000000>;
 			i-cache-line-size = <32>;
@@ -106,7 +106,7 @@
 			device_type = "cpu";
 			reg = <5>;
 			status = "okay";
-			riscv,isa = "rv32imafdcxandes";
+			riscv,isa = "rv32gc_xandes";
 			mmu-type = "riscv,sv32";
 			clock-frequency = <60000000>;
 			i-cache-line-size = <32>;
@@ -123,7 +123,7 @@
 			device_type = "cpu";
 			reg = <6>;
 			status = "okay";
-			riscv,isa = "rv32imafdcxandes";
+			riscv,isa = "rv32gc_xandes";
 			mmu-type = "riscv,sv32";
 			clock-frequency = <60000000>;
 			i-cache-line-size = <32>;
@@ -140,7 +140,7 @@
 			device_type = "cpu";
 			reg = <7>;
 			status = "okay";
-			riscv,isa = "rv32imafdcxandes";
+			riscv,isa = "rv32gc_xandes";
 			mmu-type = "riscv,sv32";
 			clock-frequency = <60000000>;
 			i-cache-line-size = <32>;

--- a/dts/riscv/efinix/sapphire_soc.dtsi
+++ b/dts/riscv/efinix/sapphire_soc.dtsi
@@ -30,7 +30,7 @@
 			compatible = "riscv";
 			device_type = "cpu";
 			reg = <0>;
-			riscv,isa = "rv32imac";
+			riscv,isa = "rv32ima_zicsr_zifencei";
 			status = "okay";
 			timebase-frequency = <100000000>;
 

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -32,6 +32,7 @@
 		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "espressif,riscv";
+			riscv,isa = "rv32imc_zicsr";
 			reg = <0>;
 			cpu-power-states = <&light_sleep &deep_sleep>;
 		};

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -25,6 +25,7 @@
 			clock-frequency = <DT_FREQ_M(108)>;
 			mcause-exception-mask = <0x7ff>;
 			compatible = "nuclei,bumblebee";
+			riscv,isa = "rv32imac_zicsr_zifencei";
 			reg = <0>;
 		};
 	};

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -29,6 +29,7 @@
 		#size-cells = <0>;
 		cpu0: cpu@0 {
 			compatible = "ite,riscv-ite";
+			riscv,isa = "rv32imafc_zifencei";
 			device_type = "cpu";
 			reg = <0>;
 			cpu-power-states = <&standby>;

--- a/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
+++ b/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
@@ -19,7 +19,7 @@
 			reg = <0x00>;
 			status = "okay";
 			compatible = "riscv";
-			riscv,isa = "rv32imc";
+			riscv,isa = "rv32imcb_zicsr_zifencei";
 
 			hlic: interrupt-controller {
 				#interrupt-cells = <0x01>;

--- a/dts/riscv/microchip/microchip-miv.dtsi
+++ b/dts/riscv/microchip/microchip-miv.dtsi
@@ -16,7 +16,7 @@
 			compatible = "microchip,miv", "riscv";
 			device_type = "cpu";
 			reg = <0>;
-			riscv,isa = "rv32imac";
+			riscv,isa = "rv32ima_zicsr_zifencei";
 			hlic: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				#address-cells = <0>;

--- a/dts/riscv/microchip/mpfs-icicle.dtsi
+++ b/dts/riscv/microchip/mpfs-icicle.dtsi
@@ -19,7 +19,7 @@
 			compatible = "riscv";
 			device_type = "cpu";
 			reg = < 0x0 >;
-			riscv,isa = "rv64imac";
+			riscv,isa = "rv64imac_zicsr_zfencei";
 			hlic0: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				#address-cells = <0>;
@@ -33,7 +33,7 @@
 			compatible = "riscv";
 			device_type = "cpu";
 			reg = < 0x1 >;
-			riscv,isa = "rv64imafdc";
+			riscv,isa = "rv64gc";
 			hlic1: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				#address-cells = <0>;
@@ -47,7 +47,7 @@
 			compatible = "riscv";
 			device_type = "cpu";
 			reg = < 0x2 >;
-			riscv,isa = "rv64imafdc";
+			riscv,isa = "rv64gc";
 			hlic2: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				#address-cells = <0>;
@@ -61,7 +61,7 @@
 			compatible = "riscv";
 			device_type = "cpu";
 			reg = < 0x3 >;
-			riscv,isa = "rv64imafdc";
+			riscv,isa = "rv64gc";
 			hlic3: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				#address-cells = <0>;
@@ -75,7 +75,7 @@
 			compatible = "riscv";
 			device_type = "cpu";
 			reg = < 0x4 >;
-			riscv,isa = "rv64imafdc";
+			riscv,isa = "rv64gc";
 			hlic4: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				#address-cells = <0>;

--- a/dts/riscv/neorv32.dtsi
+++ b/dts/riscv/neorv32.dtsi
@@ -20,6 +20,7 @@
 
 		cpu0: cpu@0 {
 			compatible = "neorv32-cpu";
+			riscv,isa = "rv32imc_zicsr";
 			reg = <0>;
 			device_type = "cpu";
 

--- a/dts/riscv/niosv/niosv-g.dtsi
+++ b/dts/riscv/niosv/niosv-g.dtsi
@@ -18,6 +18,7 @@
 		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "intel,niosv";
+			riscv,isa = "rv32ima_zicsr_zifencei";
 			reg = <0>;
 			clock-frequency = <50000000>;
 

--- a/dts/riscv/niosv/niosv-m.dtsi
+++ b/dts/riscv/niosv/niosv-m.dtsi
@@ -18,6 +18,7 @@
 		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "intel,niosv";
+			riscv,isa = "rv32ia_zicsr_zifencei";
 			reg = <0>;
 			clock-frequency = <50000000>;
 

--- a/dts/riscv/openisa/rv32m1.dtsi
+++ b/dts/riscv/openisa/rv32m1.dtsi
@@ -23,12 +23,14 @@
 		cpu@0 {
 			device_type = "cpu";
 			compatible = "riscv";
+			riscv,isa = "rv32ima_zicsr_zifencei";
 			reg = <0>;
 		};
 
 		cpu@1 {
 			device_type = "cpu";
 			compatible = "riscv";
+			riscv,isa = "rv32ima_zicsr_zifencei";
 			reg = <1>;
 		};
 	};

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -23,7 +23,7 @@
 			compatible = "riscv";
 			device_type = "cpu";
 			reg = <0>;
-			riscv,isa = "rv32imac";
+			riscv,isa = "rv32ima_zicsr_zifencei";
 			status = "okay";
 			timebase-frequency = <32768>;
 		};

--- a/dts/riscv/sifive/riscv32-fe310.dtsi
+++ b/dts/riscv/sifive/riscv32-fe310.dtsi
@@ -30,7 +30,7 @@
 			compatible = "sifive,e31";
 			device_type = "cpu";
 			reg = <0>;
-			riscv,isa = "rv32imac";
+			riscv,isa = "rv32imac_zicsr_zifencei";
 			status = "okay";
 			hlic: interrupt-controller {
 				compatible = "riscv,cpu-intc";

--- a/dts/riscv/sifive/riscv64-fu540.dtsi
+++ b/dts/riscv/sifive/riscv64-fu540.dtsi
@@ -36,7 +36,7 @@
 			compatible = "sifive,e51";
 			device_type = "cpu";
 			reg = <0>;
-			riscv,isa = "rv64imac";
+			riscv,isa = "rv64imac_zicsr_zifencei";
 			status = "okay";
 
 			hlic: interrupt-controller {

--- a/dts/riscv/sifive/riscv64-fu740.dtsi
+++ b/dts/riscv/sifive/riscv64-fu740.dtsi
@@ -35,7 +35,7 @@
 			compatible = "sifive,s7";
 			device_type = "cpu";
 			reg = <0>;
-			riscv,isa = "rv64imac";
+			riscv,isa = "rv64imac_zicsr_zifencei";
 			status = "okay";
 
 			hlic: interrupt-controller {
@@ -50,7 +50,7 @@
 			device_type = "cpu";
 			mmu-type = "riscv,sv39";
 			reg = <0x1>;
-			riscv,isa = "rv64imafdc";
+			riscv,isa = "rv64gc";
 
 			cpu1_intc: interrupt-controller {
 				compatible = "riscv,cpu-intc";
@@ -63,7 +63,7 @@
 			device_type = "cpu";
 			mmu-type = "riscv,sv39";
 			reg = <0x2>;
-			riscv,isa = "rv64imafdc";
+			riscv,isa = "rv64gc";
 
 			cpu2_intc: interrupt-controller {
 				compatible = "riscv,cpu-intc";
@@ -76,7 +76,7 @@
 			device_type = "cpu";
 			mmu-type = "riscv,sv39";
 			reg = <0x3>;
-			riscv,isa = "rv64imafdc";
+			riscv,isa = "rv64gc";
 
 			cpu3_intc: interrupt-controller {
 				compatible = "riscv,cpu-intc";
@@ -89,7 +89,7 @@
 			device_type = "cpu";
 			mmu-type = "riscv,sv39";
 			reg = <0x4>;
-			riscv,isa = "rv64imafdc";
+			riscv,isa = "rv64gc";
 
 			cpu4_intc: interrupt-controller {
 				compatible = "riscv,cpu-intc";

--- a/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
+++ b/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
@@ -35,7 +35,7 @@
 			mmu-type = "riscv,sv39";
 			next-level-cache = <&cachectrl>;
 			reg = <0>;
-			riscv,isa = "rv64imafdc";
+			riscv,isa = "rv64gc";
 			starfive,itim = <&itim0>;
 			status = "okay";
 			tlb-split;
@@ -64,7 +64,7 @@
 			mmu-type = "riscv,sv39";
 			next-level-cache = <&cachectrl>;
 			reg = <1>;
-			riscv,isa = "rv64imafdc";
+			riscv,isa = "rv64gc";
 			starfive,itim = <&itim1>;
 			status = "okay";
 			tlb-split;

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -23,6 +23,7 @@
 			reg = <0>;
 			clock-frequency = <24000000>;
 			compatible ="telink,b91", "riscv";
+			riscv,isa = "rv32imac_zicsr_zifencei";
 		};
 	};
 


### PR DESCRIPTION
This PR cleans up the `riscv,isa` field and adds it where it is currently missing, having the following in mind:
* format the ISA string to be lowercase
* the above means that multi-letter extensions (e.g. custom extensions marked with Xfoo) need to be preceded with an underscore mark
* if an extension is implied by another one - drop it from the isa string, e.g. the `d` extension implies the `f` extension, and the `g` extension implies `imad_zifencei`

This PR also removes the enum array which holds valid values for the `riscv,isa` string, because while listing every possible extension combination in an enum array is possible, it's not very practical or readable.

These changes are also useful for external tools/sites that rely on Zephyr having well-structured data, such as [Renodepedia](https://zephyr-dashboard.renode.io/renodepedia/).