### PR TITLE
twister: Add option for generating rom.json and ram.json

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -364,6 +364,11 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
     parser.add_argument("--enable-size-report", action="store_true",
                         help="Enable expensive computation of RAM/ROM segment sizes.")
 
+    parser.add_argument("--create-rom-ram-report", action="store_true",
+                        help="Generate detailed ram/rom json reports for "
+                             "each build, via cmake build calls with the "
+                             "`--target footprint` argument")
+
     parser.add_argument(
         "--filter", choices=['buildable', 'runnable'],
         default='buildable',

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1059,6 +1059,8 @@ class ProjectBuilder(FilterBuilder):
         sys.stdout.flush()
 
     def gather_metrics(self, instance: TestInstance):
+        if self.options.create_rom_ram_report:
+            self.run_build(['--build', self.build_dir, "--target", "footprint"])
         if self.options.enable_size_report and not self.options.cmake_only:
             self.calc_size(instance=instance, from_buildlog=self.options.footprint_from_buildlog)
         else:


### PR DESCRIPTION
Generate the files via the 'footprint' target for each project.