### PR TITLE
twister: Make string stripping consistent across handlers

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -887,7 +887,7 @@ class QEMUHandler(Handler):
             # line contains a full line of data output from QEMU
             log_out_fp.write(line)
             log_out_fp.flush()
-            line = line.strip()
+            line = line.rstrip()
             logger.debug(f"QEMU ({pid}): {line}")
 
             harness.handle(line)


### PR DESCRIPTION
All handlers except QEMU were right-stripping console lines before checking them. In certain cases where the regex is expecting the whitespace, this could make the test fail on qemu when it is passing on something else. Change QEMUHandler to us .rstrip instead of .strip()