### PR TITLE
esp32: samples: Use esp32_devkitc_wroom board instead of esp32

### DIFF
--- a/samples/boards/esp32/deep_sleep/README.rst
+++ b/samples/boards/esp32/deep_sleep/README.rst
@@ -51,7 +51,7 @@ Building, Flashing and Running
 
 .. zephyr-app-commands::
    :zephyr-app: samples/boards/esp32/deep_sleep
-   :board: esp32
+   :board: esp32_devkitc_wroom
    :goals: build flash
    :compact:
 

--- a/samples/boards/esp32/light_sleep/README.rst
+++ b/samples/boards/esp32/light_sleep/README.rst
@@ -31,7 +31,7 @@ Building, Flashing and Running
 
 .. zephyr-app-commands::
    :zephyr-app: samples/boards/esp32/light_sleep
-   :board: esp32
+   :board: esp32_devkitc_wroom
    :goals: build flash
    :compact:
 

--- a/samples/drivers/ipm/ipm_esp32/README.rst
+++ b/samples/drivers/ipm/ipm_esp32/README.rst
@@ -25,7 +25,7 @@ Build the ESP32 IPM sample code as follows:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/ipm/ipm_esp32
-   :board: esp32
+   :board: esp32_devkitc_wroom
    :goals: build
    :compact:
 


### PR DESCRIPTION
Following #58454, fixed a few remaining references to old "virtual" esp32 board.