### PR TITLE
samples: timer_synchronization: exclude qemu_arc_hs5x

### DIFF
--- a/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/sample.yaml
+++ b/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/sample.yaml
@@ -4,6 +4,8 @@ tests:
   sample.portability.cmsis_rtos_v2.timer_synchronization:
     integration_platforms:
       - native_posix
+    platform_exclude:
+      - qemu_arc_hs5x  # See issue #62405
     tags: cmsis_rtos
     min_ram: 32
     min_flash: 34


### PR DESCRIPTION
Repro: `./scripts/twister -T samples/subsys/portability/cmsis_rtos_v2/timer_synchronization`

---

Exclude qemu_arc_hs5x from the test, seems to fail since f0daf90. Other ARC platform works so let's exclude this one while the issue is investigated.

Link: https://github.com/zephyrproject-rtos/zephyr/issues/62405