### PR TITLE
net: socket: Use network interface name length for IFNAMSIZ

### DIFF
--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -995,7 +995,11 @@ static inline char *inet_ntop(sa_family_t family, const void *src, char *dst,
 #define EAI_FAMILY DNS_EAI_FAMILY
 #endif /* defined(CONFIG_NET_SOCKETS_POSIX_NAMES) */
 
+#if defined(CONFIG_NET_INTERFACE_NAME)
+#define IFNAMSIZ CONFIG_NET_INTERFACE_NAME_LEN
+#else
 #define IFNAMSIZ Z_DEVICE_MAX_NAME_LEN
+#endif
 
 /** Interface description structure */
 struct ifreq {


### PR DESCRIPTION
If the network interface naming is enabled, then use the interface name length (CONFIG_NET_INTERFACE_NAME_LEN) for IFNAMSIZ instead of device name length.