### PR TITLE
samples: remove leftovers from current_sensing sample

### DIFF
--- a/samples/drivers/current_sensing/CMakeLists.txt
+++ b/samples/drivers/current_sensing/CMakeLists.txt
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-cmake_minimum_required(VERSION 3.20.0)
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(current_sensing)
-
-FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
Remove leftovers of a code sample that was (only partially) deleted with PR #35538