### PR TITLE
edtlib: link child nodes to parent for nodes with child-bindings

### DIFF
--- a/dts/arm/cypress/psoc6.dtsi
+++ b/dts/arm/cypress/psoc6.dtsi
@@ -71,164 +71,164 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x40310000 0x40310000 0x2024>;
+		};
 
-			hsiom: hsiom@40310000 {
-				compatible = "cypress,psoc6-hsiom";
-				reg = <0x40310000 0x2024>;
-				interrupts = <15 1>, <16 1>;
-				status = "disabled";
-			};
+		hsiom: hsiom@40310000 {
+			compatible = "cypress,psoc6-hsiom";
+			reg = <0x40310000 0x2024>;
+			interrupts = <15 1>, <16 1>;
+			status = "disabled";
+		};
 
-			gpio_prt0: gpio@40320000 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320000 0x80>;
-				interrupts = <0 1>;
-				gpio-controller;
-				ngpios = <6>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt1: gpio@40320080 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320080 0x80>;
-				interrupts = <1 1>;
-				gpio-controller;
-				ngpios = <6>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt2: gpio@40320100 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320100 0x80>;
-				interrupts = <2 1>;
-				gpio-controller;
-				ngpios = <8>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt3: gpio@40320180 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320180 0x80>;
-				interrupts = <3 1>;
-				gpio-controller;
-				ngpios = <6>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt4: gpio@40320200 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320200 0x80>;
-				interrupts = <4 1>;
-				gpio-controller;
-				ngpios = <4>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt5: gpio@40320280 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320280 0x80>;
-				interrupts = <5 1>;
-				gpio-controller;
-				ngpios = <8>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt6: gpio@40320300 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320300 0x80>;
-				interrupts = <6 1>;
-				gpio-controller;
-				ngpios = <8>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt7: gpio@40320380 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320380 0x80>;
-				interrupts = <7 1>;
-				gpio-controller;
-				ngpios = <8>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt8: gpio@40320400 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320400 0x80>;
-				interrupts = <8 1>;
-				gpio-controller;
-				ngpios = <8>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt9: gpio@40320480 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320480 0x80>;
-				interrupts = <9 1>;
-				gpio-controller;
-				ngpios = <8>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt10: gpio@40320500 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320500 0x80>;
-				interrupts = <10 1>;
-				gpio-controller;
-				ngpios = <8>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt11: gpio@40320580 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320580 0x80>;
-				interrupts = <11 1>;
-				gpio-controller;
-				ngpios = <8>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt12: gpio@40320600 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320600 0x80>;
-				interrupts = <12 1>;
-				gpio-controller;
-				ngpios = <8>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt13: gpio@40320680 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320680 0x80>;
-				interrupts = <13 1>;
-				gpio-controller;
-				ngpios = <8>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
-			gpio_prt14: gpio@40320700 {
-				compatible = "cypress,psoc6-gpio";
-				reg = <0x40320700 0x80>;
-				interrupts = <14 1>;
-				gpio-controller;
-				ngpios = <2>;
-				#gpio-cells = <2>;
-				#cypress,pin-cells = <2>;
-				status = "disabled";
-			};
+		gpio_prt0: gpio@40320000 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320000 0x80>;
+			interrupts = <0 1>;
+			gpio-controller;
+			ngpios = <6>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt1: gpio@40320080 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320080 0x80>;
+			interrupts = <1 1>;
+			gpio-controller;
+			ngpios = <6>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt2: gpio@40320100 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320100 0x80>;
+			interrupts = <2 1>;
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt3: gpio@40320180 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320180 0x80>;
+			interrupts = <3 1>;
+			gpio-controller;
+			ngpios = <6>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt4: gpio@40320200 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320200 0x80>;
+			interrupts = <4 1>;
+			gpio-controller;
+			ngpios = <4>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt5: gpio@40320280 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320280 0x80>;
+			interrupts = <5 1>;
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt6: gpio@40320300 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320300 0x80>;
+			interrupts = <6 1>;
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt7: gpio@40320380 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320380 0x80>;
+			interrupts = <7 1>;
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt8: gpio@40320400 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320400 0x80>;
+			interrupts = <8 1>;
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt9: gpio@40320480 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320480 0x80>;
+			interrupts = <9 1>;
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt10: gpio@40320500 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320500 0x80>;
+			interrupts = <10 1>;
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt11: gpio@40320580 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320580 0x80>;
+			interrupts = <11 1>;
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt12: gpio@40320600 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320600 0x80>;
+			interrupts = <12 1>;
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt13: gpio@40320680 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320680 0x80>;
+			interrupts = <13 1>;
+			gpio-controller;
+			ngpios = <8>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
+		};
+		gpio_prt14: gpio@40320700 {
+			compatible = "cypress,psoc6-gpio";
+			reg = <0x40320700 0x80>;
+			interrupts = <14 1>;
+			gpio-controller;
+			ngpios = <2>;
+			#gpio-cells = <2>;
+			#cypress,pin-cells = <2>;
+			status = "disabled";
 		};
 
 		spi0: spi@40610000 {

--- a/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.dtsi
+++ b/dts/arm/infineon/psoc6/psoc6_01/psoc6_01.dtsi
@@ -55,150 +55,151 @@
 			reg = <0x40310000 0x20000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-
-			hsiom: hsiom@40310000 {
-				compatible = "infineon,cat1-hsiom";
-				reg = <0x40310000 0x4000>;
-				interrupts = <15 6>, <16 6>;
-				status = "disabled";
-			};
-
-			gpio_prt0: gpio@40320000 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320000 0x80>;
-				interrupts = <0 6>;
-				gpio-controller;
-				ngpios = <6>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt1: gpio@40320080 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320080 0x80>;
-				interrupts = <1 6>;
-				gpio-controller;
-				ngpios = <6>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt2: gpio@40320100 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320100 0x80>;
-				interrupts = <2 6>;
-				gpio-controller;
-				ngpios = <8>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt3: gpio@40320180 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320180 0x80>;
-				interrupts = <3 6>;
-				gpio-controller;
-				ngpios = <6>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt4: gpio@40320200 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320200 0x80>;
-				interrupts = <4 6>;
-				gpio-controller;
-				ngpios = <2>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt5: gpio@40320280 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320280 0x80>;
-				interrupts = <5 6>;
-				gpio-controller;
-				ngpios = <8>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt6: gpio@40320300 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320300 0x80>;
-				interrupts = <6 6>;
-				gpio-controller;
-				ngpios = <8>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt7: gpio@40320380 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320380 0x80>;
-				interrupts = <7 6>;
-				gpio-controller;
-				ngpios = <8>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt8: gpio@40320400 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320400 0x80>;
-				interrupts = <8 6>;
-				gpio-controller;
-				ngpios = <8>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt9: gpio@40320480 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320480 0x80>;
-				interrupts = <9 6>;
-				gpio-controller;
-				ngpios = <8>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt10: gpio@40320500 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320500 0x80>;
-				interrupts = <10 6>;
-				gpio-controller;
-				ngpios = <8>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt11: gpio@40320580 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320580 0x80>;
-				interrupts = <11 6>;
-				gpio-controller;
-				ngpios = <8>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt12: gpio@40320600 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320600 0x80>;
-				interrupts = <12 6>;
-				gpio-controller;
-				ngpios = <8>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt13: gpio@40320680 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320680 0x80>;
-				interrupts = <13 6>;
-				gpio-controller;
-				ngpios = <8>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
-			gpio_prt14: gpio@40320700 {
-				compatible = "infineon,cat1-gpio";
-				reg = <0x40320700 0x80>;
-				interrupts = <14 6>;
-				gpio-controller;
-				ngpios = <2>;
-				status = "disabled";
-				#gpio-cells = <2>;
-			};
 		};
+
+		hsiom: hsiom@40310000 {
+			compatible = "infineon,cat1-hsiom";
+			reg = <0x40310000 0x4000>;
+			interrupts = <15 6>, <16 6>;
+			status = "disabled";
+		};
+
+		gpio_prt0: gpio@40320000 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320000 0x80>;
+			interrupts = <0 6>;
+			gpio-controller;
+			ngpios = <6>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt1: gpio@40320080 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320080 0x80>;
+			interrupts = <1 6>;
+			gpio-controller;
+			ngpios = <6>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt2: gpio@40320100 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320100 0x80>;
+			interrupts = <2 6>;
+			gpio-controller;
+			ngpios = <8>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt3: gpio@40320180 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320180 0x80>;
+			interrupts = <3 6>;
+			gpio-controller;
+			ngpios = <6>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt4: gpio@40320200 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320200 0x80>;
+			interrupts = <4 6>;
+			gpio-controller;
+			ngpios = <2>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt5: gpio@40320280 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320280 0x80>;
+			interrupts = <5 6>;
+			gpio-controller;
+			ngpios = <8>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt6: gpio@40320300 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320300 0x80>;
+			interrupts = <6 6>;
+			gpio-controller;
+			ngpios = <8>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt7: gpio@40320380 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320380 0x80>;
+			interrupts = <7 6>;
+			gpio-controller;
+			ngpios = <8>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt8: gpio@40320400 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320400 0x80>;
+			interrupts = <8 6>;
+			gpio-controller;
+			ngpios = <8>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt9: gpio@40320480 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320480 0x80>;
+			interrupts = <9 6>;
+			gpio-controller;
+			ngpios = <8>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt10: gpio@40320500 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320500 0x80>;
+			interrupts = <10 6>;
+			gpio-controller;
+			ngpios = <8>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt11: gpio@40320580 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320580 0x80>;
+			interrupts = <11 6>;
+			gpio-controller;
+			ngpios = <8>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt12: gpio@40320600 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320600 0x80>;
+			interrupts = <12 6>;
+			gpio-controller;
+			ngpios = <8>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt13: gpio@40320680 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320680 0x80>;
+			interrupts = <13 6>;
+			gpio-controller;
+			ngpios = <8>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+		gpio_prt14: gpio@40320700 {
+			compatible = "infineon,cat1-gpio";
+			reg = <0x40320700 0x80>;
+			interrupts = <14 6>;
+			gpio-controller;
+			ngpios = <2>;
+			status = "disabled";
+			#gpio-cells = <2>;
+		};
+
 		uid: device_uid@16000600 {
 			compatible = "infineon,cat1-uid";
 			reg = <0x16000600 0xb>;

--- a/dts/riscv/ite/it81xx2.dtsi
+++ b/dts/riscv/ite/it81xx2.dtsi
@@ -57,284 +57,284 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
+		};
 
-			pinctrla: pinctrl@f01610 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01610 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
-						 0xf02032 0xf02032 0xf016f0 0xf016f0>;
-				func3-en-mask = <0        0        0        0
-						 0x02     0x02     0x10     0x0C    >;
-				func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC >;
-				func4-en-mask = <0        0        0        0
-						 0        0        0        0       >;
-				volt-sel =      <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
-						 0xf016e9 0xf016e9 0xf016e9 0xf016e9>;
-				volt-sel-mask = <0        0        0        0
-						 0x1      0x02     0x20     0x40    >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrla: pinctrl@f01610 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01610 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
+					 0xf02032 0xf02032 0xf016f0 0xf016f0>;
+			func3-en-mask = <0        0        0        0
+					 0x02     0x02     0x10     0x0C    >;
+			func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC >;
+			func4-en-mask = <0        0        0        0
+					 0        0        0        0       >;
+			volt-sel =      <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
+					 0xf016e9 0xf016e9 0xf016e9 0xf016e9>;
+			volt-sel-mask = <0        0        0        0
+					 0x1      0x02     0x20     0x40    >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlb: pinctrl@f01618 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01618 8>;   /* GPCR */
-				func3-gcr =     <0xf016f5 0xf016f5 NO_FUNC NO_FUNC
-						 NO_FUNC  NO_FUNC  NO_FUNC 0xf01600>;
-				func3-en-mask = <0x01     0x02     0       0
-						 0        0        0       0x02    >;
-				func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC NO_FUNC
-						 NO_FUNC  NO_FUNC  NO_FUNC 0xf016f1>;
-				func4-en-mask = <0        0        0       0
-						 0        0        0       0x40    >;
-				volt-sel =      <NO_FUNC  NO_FUNC  NO_FUNC  0xf016e7
-						 0xf016e7 0xf016e4 0xf016e4 0xf016e9>;
-				volt-sel-mask = <0        0        0        0x02
-						 0x01     0x80     0x40     0x10    >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlb: pinctrl@f01618 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01618 8>;   /* GPCR */
+			func3-gcr =     <0xf016f5 0xf016f5 NO_FUNC NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC 0xf01600>;
+			func3-en-mask = <0x01     0x02     0       0
+					 0        0        0       0x02    >;
+			func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC 0xf016f1>;
+			func4-en-mask = <0        0        0       0
+					 0        0        0       0x40    >;
+			volt-sel =      <NO_FUNC  NO_FUNC  NO_FUNC  0xf016e7
+					 0xf016e7 0xf016e4 0xf016e4 0xf016e9>;
+			volt-sel-mask = <0        0        0        0x02
+					 0x01     0x80     0x40     0x10    >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlc: pinctrl@f01620 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01620 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC 0xf016f0
-						 NO_FUNC 0xf016f0 NO_FUNC 0xf016f3>;
-				func3-en-mask = <0       0        0       0x10
-						 0       0x10     0       0x02    >;
-				func4-gcr =     <NO_FUNC NO_FUNC  NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC  NO_FUNC 0xf016f6>;
-				func4-en-mask = <0       0        0       0
-						 0       0        0       0x80    >;
-				volt-sel =      <0xf016e7 0xf016e4 0xf016e4 NO_FUNC
-						 0xf016e9 NO_FUNC  0xf016e9 0xf016e4>;
-				volt-sel-mask = <0x80     0x20     0x10     0
-						 0x04     0        0x08     0x08    >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlc: pinctrl@f01620 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01620 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC 0xf016f0
+					 NO_FUNC 0xf016f0 NO_FUNC 0xf016f3>;
+			func3-en-mask = <0       0        0       0x10
+					 0       0x10     0       0x02    >;
+			func4-gcr =     <NO_FUNC NO_FUNC  NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC  NO_FUNC 0xf016f6>;
+			func4-en-mask = <0       0        0       0
+					 0       0        0       0x80    >;
+			volt-sel =      <0xf016e7 0xf016e4 0xf016e4 NO_FUNC
+					 0xf016e9 NO_FUNC  0xf016e9 0xf016e4>;
+			volt-sel-mask = <0x80     0x20     0x10     0
+					 0x04     0        0x08     0x08    >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrld: pinctrl@f01628 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01628 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC NO_FUNC
-						 NO_FUNC 0xf016f0 NO_FUNC NO_FUNC>;
-				func3-en-mask = <0       0        0       0
-						 0       0x02     0       0      >;
-				func4-gcr =     <NO_FUNC NO_FUNC  NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC  NO_FUNC NO_FUNC>;
-				func4-en-mask = <0       0        0       0
-						 0       0        0       0      >;
-				volt-sel =      <0xf016e4 0xf016e4 0xf016e4 0xf016e5
-						 0xf016e5 0xf016e7 0xf016e7 0xf016e7>;
-				volt-sel-mask = <0x04     0x02     0x01     0x80
-						 0x40     0x10     0x20     0x40    >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrld: pinctrl@f01628 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01628 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC NO_FUNC
+					 NO_FUNC 0xf016f0 NO_FUNC NO_FUNC>;
+			func3-en-mask = <0       0        0       0
+					 0       0x02     0       0      >;
+			func4-gcr =     <NO_FUNC NO_FUNC  NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC  NO_FUNC NO_FUNC>;
+			func4-en-mask = <0       0        0       0
+					 0       0        0       0      >;
+			volt-sel =      <0xf016e4 0xf016e4 0xf016e4 0xf016e5
+					 0xf016e5 0xf016e7 0xf016e7 0xf016e7>;
+			volt-sel-mask = <0x04     0x02     0x01     0x80
+					 0x40     0x10     0x20     0x40    >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrle: pinctrl@f01630 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01630 8>;   /* GPCR */
-				func3-gcr =     <0xf02032 NO_FUNC  NO_FUNC NO_FUNC
-						 NO_FUNC  0xf016f0 NO_FUNC 0xf02032>;
-				func3-en-mask = <0x01     0        0       0
-						 0        0x08     0       0x01    >;
-				func4-gcr =     <0xf016f3 NO_FUNC  NO_FUNC NO_FUNC
-						 NO_FUNC  NO_FUNC  NO_FUNC NO_FUNC >;
-				func4-en-mask = <0x01     0        0       0
-						 0        0        0       0       >;
-				volt-sel =      <0xf016e5 0xf016d4 0xf016d4 NO_FUNC
-						 0xf016e7 0xf016e7 0xf016e5 0xf016e5>;
-				volt-sel-mask = <0x20     0x40     0x80     0
-						 0x04     0x08     0x10     0x08    >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrle: pinctrl@f01630 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01630 8>;   /* GPCR */
+			func3-gcr =     <0xf02032 NO_FUNC  NO_FUNC NO_FUNC
+					 NO_FUNC  0xf016f0 NO_FUNC 0xf02032>;
+			func3-en-mask = <0x01     0        0       0
+					 0        0x08     0       0x01    >;
+			func4-gcr =     <0xf016f3 NO_FUNC  NO_FUNC NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC NO_FUNC >;
+			func4-en-mask = <0x01     0        0       0
+					 0        0        0       0       >;
+			volt-sel =      <0xf016e5 0xf016d4 0xf016d4 NO_FUNC
+					 0xf016e7 0xf016e7 0xf016e5 0xf016e5>;
+			volt-sel-mask = <0x20     0x40     0x80     0
+					 0x04     0x08     0x10     0x08    >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlf: pinctrl@f01638 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01638 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC NO_FUNC 0xf016f0 0xf016f0
-						 NO_FUNC NO_FUNC 0xf016f1 0xf016f1>;
-				func3-en-mask = <0       0       0x02     0x02
-						 0       0       0x10     0x10    >;
-				func4-gcr =     <NO_FUNC NO_FUNC 0xf02046 0xf02046
-						 NO_FUNC NO_FUNC NO_FUNC  NO_FUNC >;
-				func4-en-mask = <0       0       0x40     0x40
-						 0       0       0        0       >;
-				volt-sel =      <0xf016d4 0xf016d4 0xf016e5 0xf016e5
-						 0xf016e5 0xf016e6 0xf016e6 0xf016e6>;
-				volt-sel-mask = <0x10     0x20     0x04     0x02
-						 0x01     0x80     0x40     0x20    >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlf: pinctrl@f01638 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01638 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC NO_FUNC 0xf016f0 0xf016f0
+					 NO_FUNC NO_FUNC 0xf016f1 0xf016f1>;
+			func3-en-mask = <0       0       0x02     0x02
+					 0       0       0x10     0x10    >;
+			func4-gcr =     <NO_FUNC NO_FUNC 0xf02046 0xf02046
+					 NO_FUNC NO_FUNC NO_FUNC  NO_FUNC >;
+			func4-en-mask = <0       0       0x40     0x40
+					 0       0       0        0       >;
+			volt-sel =      <0xf016d4 0xf016d4 0xf016e5 0xf016e5
+					 0xf016e5 0xf016e6 0xf016e6 0xf016e6>;
+			volt-sel-mask = <0x10     0x20     0x04     0x02
+					 0x01     0x80     0x40     0x20    >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlg: pinctrl@f01640 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01640 8>;   /* GPCR */
-				func3-gcr =     <0xf016f0 0xf016f0 0xf016f0 NO_FUNC
-						 NO_FUNC  NO_FUNC  0xf016f0 NO_FUNC>;
-				func3-en-mask = <0x20     0x08     0x10     0
-						 0        0        0x02     0      >;
-				func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
-				func4-en-mask = <0        0        0        0
-						 0        0        0        0      >;
-				volt-sel =      <0xf016d4 0xf016e6 0xf016d4 NO_FUNC
-						 NO_FUNC  NO_FUNC  0xf016e6 NO_FUNC>;
-				volt-sel-mask = <0x04     0x10    0x08     0
-						 0        0       0x08     0       >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlg: pinctrl@f01640 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01640 8>;   /* GPCR */
+			func3-gcr =     <0xf016f0 0xf016f0 0xf016f0 NO_FUNC
+					 NO_FUNC  NO_FUNC  0xf016f0 NO_FUNC>;
+			func3-en-mask = <0x20     0x08     0x10     0
+					 0        0        0x02     0      >;
+			func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
+			func4-en-mask = <0        0        0        0
+					 0        0        0        0      >;
+			volt-sel =      <0xf016d4 0xf016e6 0xf016d4 NO_FUNC
+					 NO_FUNC  NO_FUNC  0xf016e6 NO_FUNC>;
+			volt-sel-mask = <0x04     0x10    0x08     0
+					 0        0       0x08     0       >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlh: pinctrl@f01648 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01648 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC 0xf016f1 0xf016f1 NO_FUNC
-						 NO_FUNC 0xf016f5 0xf016f5 NO_FUNC>;
-				func3-en-mask = <0       0x20     0x20     0
-						 0       0x04     0x08     0      >;
-				func3-ext =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC 0xf03a23 0xf03a23 NO_FUNC>;
-				func3-ext-mask = <0      0        0        0
-						  0      0x01     0x01     0      >;
-				func4-gcr =     <NO_FUNC 0xf016f5 0xf016f5 NO_FUNC
-						 NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC>;
-				func4-en-mask = <0       0x04     0x08     0
-						 0       0        0        0      >;
-				volt-sel =      <0xf016e6 0xf016e6 0xf016e6 NO_FUNC
-						 NO_FUNC  0xf016d3 0xf016d4 NO_FUNC>;
-				volt-sel-mask = <0x04     0x02     0x01     0
-						 0        0x80     0x01     0      >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlh: pinctrl@f01648 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01648 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC 0xf016f1 0xf016f1 NO_FUNC
+					 NO_FUNC 0xf016f5 0xf016f5 NO_FUNC>;
+			func3-en-mask = <0       0x20     0x20     0
+					 0       0x04     0x08     0      >;
+			func3-ext =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC 0xf03a23 0xf03a23 NO_FUNC>;
+			func3-ext-mask = <0      0        0        0
+					  0      0x01     0x01     0      >;
+			func4-gcr =     <NO_FUNC 0xf016f5 0xf016f5 NO_FUNC
+					 NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC>;
+			func4-en-mask = <0       0x04     0x08     0
+					 0       0        0        0      >;
+			volt-sel =      <0xf016e6 0xf016e6 0xf016e6 NO_FUNC
+					 NO_FUNC  0xf016d3 0xf016d4 NO_FUNC>;
+			volt-sel-mask = <0x04     0x02     0x01     0
+					 0        0x80     0x01     0      >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrli: pinctrl@f01650 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01650 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC 0xf016f0 0xf016f0 0xf016f0>;
-				func3-en-mask = <0       0        0        0
-						 0       0x08     0x08     0x08    >;
-				func4-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC >;
-				func4-en-mask = <0       0        0        0
-						 0       0        0        0       >;
-				volt-sel =      <0xf016d3 0xf016e8 0xf016e8 0xf016e8
-						 0xf016e8 0xf016d3 0xf016d3 0xf016d3>;
-				volt-sel-mask = <0x08     0x10     0x20     0x40
-						 0x80     0x10     0x20     0x40    >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrli: pinctrl@f01650 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01650 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC 0xf016f0 0xf016f0 0xf016f0>;
+			func3-en-mask = <0       0        0        0
+					 0       0x08     0x08     0x08    >;
+			func4-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC >;
+			func4-en-mask = <0       0        0        0
+					 0       0        0        0       >;
+			volt-sel =      <0xf016d3 0xf016e8 0xf016e8 0xf016e8
+					 0xf016e8 0xf016d3 0xf016d3 0xf016d3>;
+			volt-sel-mask = <0x08     0x10     0x20     0x40
+					 0x80     0x10     0x20     0x40    >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlj: pinctrl@f01658 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01658 8>;   /* GPCR */
-				func3-gcr =     <0xf016f4 NO_FUNC  0xf016f4 0xf016f4
-						 0xf016f0 0xf016f0 NO_FUNC  NO_FUNC>;
-				func3-en-mask = <0x01     0        0x01     0x02
-						 0x02     0x03     0        0      >;
-				func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
-				func4-en-mask = <0        0        0        0
-						 0        0        0        0      >;
-				volt-sel =      <0xf016e8 0xf016e8 0xf016e8 0xf016e8
-						 0xf016d3 0xf016d3 0xf016d3 0xf016d7>;
-				volt-sel-mask = <0x01     0x02     0x04     0x08
-						 0x01     0x02     0x04     0x04    >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlj: pinctrl@f01658 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01658 8>;   /* GPCR */
+			func3-gcr =     <0xf016f4 NO_FUNC  0xf016f4 0xf016f4
+					 0xf016f0 0xf016f0 NO_FUNC  NO_FUNC>;
+			func3-en-mask = <0x01     0        0x01     0x02
+					 0x02     0x03     0        0      >;
+			func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
+			func4-en-mask = <0        0        0        0
+					 0        0        0        0      >;
+			volt-sel =      <0xf016e8 0xf016e8 0xf016e8 0xf016e8
+					 0xf016d3 0xf016d3 0xf016d3 0xf016d7>;
+			volt-sel-mask = <0x01     0x02     0x04     0x08
+					 0x01     0x02     0x04     0x04    >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlk: pinctrl@f01690 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01690 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
-				func3-en-mask = <0       0       0       0
-						 0       0       0       0      >;
-				func4-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
-				func4-en-mask = <0       0       0       0
-						 0       0       0       0      >;
-				volt-sel =      <0xf016d2 0xf016d2 0xf016d2 0xf016d2
-						 0xf016d2 0xf016d2 0xf016d2 0xf016d2>;
-				volt-sel-mask = <0x01     0x02     0x04     0x08
-						 0x10     0x20     0x40     0x80    >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlk: pinctrl@f01690 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01690 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
+			func3-en-mask = <0       0       0       0
+					 0       0       0       0      >;
+			func4-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
+			func4-en-mask = <0       0       0       0
+					 0       0       0       0      >;
+			volt-sel =      <0xf016d2 0xf016d2 0xf016d2 0xf016d2
+					 0xf016d2 0xf016d2 0xf016d2 0xf016d2>;
+			volt-sel-mask = <0x01     0x02     0x04     0x08
+					 0x10     0x20     0x40     0x80    >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrll: pinctrl@f01698 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01698 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
-				func3-en-mask = <0       0       0       0
-						 0       0       0       0      >;
-				func4-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
-				func4-en-mask = <0       0       0       0
-						 0       0       0       0      >;
-				volt-sel =      <0xf016d1 0xf016d1 0xf016d1 0xf016d1
-						 0xf016d1 0xf016d1 0xf016d1 0xf016d1>;
-				volt-sel-mask = <0x01     0x02     0x04     0x08
-						 0x10     0x20     0x40     0x80    >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrll: pinctrl@f01698 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01698 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
+			func3-en-mask = <0       0       0       0
+					 0       0       0       0      >;
+			func4-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
+			func4-en-mask = <0       0       0       0
+					 0       0       0       0      >;
+			volt-sel =      <0xf016d1 0xf016d1 0xf016d1 0xf016d1
+					 0xf016d1 0xf016d1 0xf016d1 0xf016d1>;
+			volt-sel-mask = <0x01     0x02     0x04     0x08
+					 0x10     0x20     0x40     0x80    >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlm: pinctrl@f016a0 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f016a0 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
-				func3-en-mask = <0       0       0       0
-						 0       0       0       0      >;
-				func4-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
-				func4-en-mask = <0       0       0       0
-						 0       0       0       0      >;
-				volt-sel =      <0xf016ed 0xf016ed 0xf016ed 0xf016ed
-						 0xf016ed 0xf016ed 0xf016ed NO_FUNC >;
-				volt-sel-mask = <0x10     0x10     0x10     0x10
-						 0x10     0x10     0x10     0       >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlm: pinctrl@f016a0 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f016a0 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
+			func3-en-mask = <0       0       0       0
+					 0       0       0       0      >;
+			func4-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
+			func4-en-mask = <0       0       0       0
+					 0       0       0       0      >;
+			volt-sel =      <0xf016ed 0xf016ed 0xf016ed 0xf016ed
+					 0xf016ed 0xf016ed 0xf016ed NO_FUNC >;
+			volt-sel-mask = <0x10     0x10     0x10     0x10
+					 0x10     0x10     0x10     0       >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlksi: pinctrl@f01d06 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01d06 1   /* KSIGCTRL */
-				       0x00f01d05 1>; /* KSICTRL */
-				pp-od-mask = <NO_FUNC>;
-				pullup-mask = <BIT(2)>;
-				#pinmux-cells = <2>;
-			};
+		pinctrlksi: pinctrl@f01d06 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01d06 1   /* KSIGCTRL */
+			       0x00f01d05 1>; /* KSICTRL */
+			pp-od-mask = <NO_FUNC>;
+			pullup-mask = <BIT(2)>;
+			#pinmux-cells = <2>;
+		};
 
-			pinctrlksoh: pinctrl@f01d0a {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01d0a 1   /* KSOHGCTRL */
-				       0x00f01d02 1>; /* KSOCTRL */
-				pp-od-mask = <BIT(0)>;
-				pullup-mask = <BIT(2)>;
-				#pinmux-cells = <2>;
-			};
+		pinctrlksoh: pinctrl@f01d0a {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01d0a 1   /* KSOHGCTRL */
+			       0x00f01d02 1>; /* KSOCTRL */
+			pp-od-mask = <BIT(0)>;
+			pullup-mask = <BIT(2)>;
+			#pinmux-cells = <2>;
+		};
 
-			pinctrlksol: pinctrl@f01d0d {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01d0d 1   /* KSOLGCTRL */
-				       0x00f01d02 1>; /* KSOCTRL */
-				pp-od-mask = <BIT(0)>;
-				pullup-mask = <BIT(2)>;
-				#pinmux-cells = <2>;
-			};
+		pinctrlksol: pinctrl@f01d0d {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01d0d 1   /* KSOLGCTRL */
+			       0x00f01d02 1>; /* KSOCTRL */
+			pp-od-mask = <BIT(0)>;
+			pullup-mask = <BIT(2)>;
+			#pinmux-cells = <2>;
 		};
 
 		i2c0: i2c@f01c40 {

--- a/dts/riscv/ite/it82xx2.dtsi
+++ b/dts/riscv/ite/it82xx2.dtsi
@@ -440,280 +440,280 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
+		};
 
-			pinctrla: pinctrl@f01660 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01660 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
-						 0xf02032 0xf02032 0xf03e10 0xf03e10>;
-				func3-en-mask = <0        0        0        0
-						 0x02     0x02     0x10     0x0C    >;
-				func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC >;
-				func4-en-mask = <0        0        0        0
-						 0        0        0        0       >;
-				volt-sel =      <0xf01648 0xf01648 0xf01648 0xf01648
-						 0xf01648 0xf01648 0xf01648 0xf01648>;
-				volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-						 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrla: pinctrl@f01660 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01660 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
+					 0xf02032 0xf02032 0xf03e10 0xf03e10>;
+			func3-en-mask = <0        0        0        0
+					 0x02     0x02     0x10     0x0C    >;
+			func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC >;
+			func4-en-mask = <0        0        0        0
+					 0        0        0        0       >;
+			volt-sel =      <0xf01648 0xf01648 0xf01648 0xf01648
+					 0xf01648 0xf01648 0xf01648 0xf01648>;
+			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
+					 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlb: pinctrl@f01668 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01668 8>;   /* GPCR */
-				func3-gcr =     <0xf03e15 0xf03e15 0xf03e16 NO_FUNC
-						 NO_FUNC  0xf03e16 NO_FUNC  NO_FUNC>;
-				func3-en-mask = <0x01     0x02     0x40     0
-						 0        0x40     0        0      >;
-				func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
-				func4-en-mask = <0        0        0        0
-						 0        0        0        0      >;
-				volt-sel =      <0xf01649 0xf01649 0xf01649 0xf01649
-						 0xf01649 0xf01649 0xf01649 NO_FUNC>;
-				volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-						 BIT(4)   BIT(5)   BIT(6)   0      >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlb: pinctrl@f01668 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01668 8>;   /* GPCR */
+			func3-gcr =     <0xf03e15 0xf03e15 0xf03e16 NO_FUNC
+					 NO_FUNC  0xf03e16 NO_FUNC  NO_FUNC>;
+			func3-en-mask = <0x01     0x02     0x40     0
+					 0        0x40     0        0      >;
+			func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
+			func4-en-mask = <0        0        0        0
+					 0        0        0        0      >;
+			volt-sel =      <0xf01649 0xf01649 0xf01649 0xf01649
+					 0xf01649 0xf01649 0xf01649 NO_FUNC>;
+			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
+					 BIT(4)   BIT(5)   BIT(6)   0      >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlc: pinctrl@f01670 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01670 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC 0xf03e10
-						 NO_FUNC 0xf03e10 NO_FUNC 0xf03e13>;
-				func3-en-mask = <0       0        0       0x10
-						 0       0x10     0       0x02    >;
-				func4-gcr =     <NO_FUNC NO_FUNC  NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC  NO_FUNC 0xf03e16>;
-				func4-en-mask = <0       0        0       0
-						 0       0        0       0x80    >;
-				volt-sel =      <0xf0164a 0xf0164a 0xf0164a 0xf0164a
-						 0xf0164a 0xf0164a 0xf0164a 0xf0164a>;
-				volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-						 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlc: pinctrl@f01670 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01670 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC 0xf03e10
+					 NO_FUNC 0xf03e10 NO_FUNC 0xf03e13>;
+			func3-en-mask = <0       0        0       0x10
+					 0       0x10     0       0x02    >;
+			func4-gcr =     <NO_FUNC NO_FUNC  NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC  NO_FUNC 0xf03e16>;
+			func4-en-mask = <0       0        0       0
+					 0       0        0       0x80    >;
+			volt-sel =      <0xf0164a 0xf0164a 0xf0164a 0xf0164a
+					 0xf0164a 0xf0164a 0xf0164a 0xf0164a>;
+			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
+					 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrld: pinctrl@f01678 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01678 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC NO_FUNC
-						 NO_FUNC  0xf03e10 NO_FUNC NO_FUNC>;
-				func3-en-mask = <0        0        0       0
-						 0        0x02     0       0      >;
-				func4-gcr =     <0xf03e16 NO_FUNC  NO_FUNC NO_FUNC
-						 NO_FUNC  NO_FUNC  NO_FUNC NO_FUNC>;
-				func4-en-mask = <0x80     0        0       0
-						 0        0        0       0      >;
-				volt-sel =      <0xf0164b 0xf0164b 0xf0164b 0xf0164b
-						 0xf0164b 0xf0164b 0xf0164b 0xf0164b>;
-				volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-						 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrld: pinctrl@f01678 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01678 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC NO_FUNC
+					 NO_FUNC  0xf03e10 NO_FUNC NO_FUNC>;
+			func3-en-mask = <0        0        0       0
+					 0        0x02     0       0      >;
+			func4-gcr =     <0xf03e16 NO_FUNC  NO_FUNC NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC NO_FUNC>;
+			func4-en-mask = <0x80     0        0       0
+					 0        0        0       0      >;
+			volt-sel =      <0xf0164b 0xf0164b 0xf0164b 0xf0164b
+					 0xf0164b 0xf0164b 0xf0164b 0xf0164b>;
+			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
+					 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrle: pinctrl@f01680 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01680 8>;   /* GPCR */
-				func3-gcr =     <0xf02032 0xf03e16 0xf03e16 NO_FUNC
-						 NO_FUNC  0xf03e10 NO_FUNC  0xf02032>;
-				func3-en-mask = <0x01     0x20     0x20     0
-						 0        0x08     0        0x01    >;
-				func4-gcr =     <0xf03e13 NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC >;
-				func4-en-mask = <0x01     0        0        0
-						 0        0        0        0       >;
-				volt-sel =      <0xf0164c 0xf0164c 0xf0164c 0xf0164c
-						 0xf0164c 0xf0164c 0xf0164c 0xf0164c>;
-				volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-						 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrle: pinctrl@f01680 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01680 8>;   /* GPCR */
+			func3-gcr =     <0xf02032 0xf03e16 0xf03e16 NO_FUNC
+					 NO_FUNC  0xf03e10 NO_FUNC  0xf02032>;
+			func3-en-mask = <0x01     0x20     0x20     0
+					 0        0x08     0        0x01    >;
+			func4-gcr =     <0xf03e13 NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC >;
+			func4-en-mask = <0x01     0        0        0
+					 0        0        0        0       >;
+			volt-sel =      <0xf0164c 0xf0164c 0xf0164c 0xf0164c
+					 0xf0164c 0xf0164c 0xf0164c 0xf0164c>;
+			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
+					 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlf: pinctrl@f01688 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01688 8>;   /* GPCR */
-				func3-gcr =     <0xf03e15 0xf03e15 0xf03e10 0xf03e10
-						 NO_FUNC  NO_FUNC  0xf03e11 NO_FUNC>;
-				func3-en-mask = <0x04     0x08     0x02     0x02
-						 0        0        0x10     0      >;
-				func4-gcr =     <NO_FUNC NO_FUNC   NO_FUNC  NO_FUNC
-						 NO_FUNC NO_FUNC   NO_FUNC  NO_FUNC>;
-				func4-en-mask = <0       0         0        0
-						 0       0         0        0      >;
-				volt-sel =      <0xf0164d 0xf0164d 0xf0164d 0xf0164d
-						 0xf0164d 0xf0164d 0xf0164d 0xf0164d>;
-				volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-						 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlf: pinctrl@f01688 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01688 8>;   /* GPCR */
+			func3-gcr =     <0xf03e15 0xf03e15 0xf03e10 0xf03e10
+					 NO_FUNC  NO_FUNC  0xf03e11 NO_FUNC>;
+			func3-en-mask = <0x04     0x08     0x02     0x02
+					 0        0        0x10     0      >;
+			func4-gcr =     <NO_FUNC NO_FUNC   NO_FUNC  NO_FUNC
+					 NO_FUNC NO_FUNC   NO_FUNC  NO_FUNC>;
+			func4-en-mask = <0       0         0        0
+					 0       0         0        0      >;
+			volt-sel =      <0xf0164d 0xf0164d 0xf0164d 0xf0164d
+					 0xf0164d 0xf0164d 0xf0164d 0xf0164d>;
+			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
+					 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlg: pinctrl@f01690 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01690 8>;   /* GPCR */
-				func3-gcr =     <0xf03e10 0xf03e10 0xf03e10 NO_FUNC
-						 NO_FUNC  NO_FUNC  0xf03e10 NO_FUNC>;
-				func3-en-mask = <0x20     0x08     0x10     0
-						 0        0        0x02     0      >;
-				func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
-				func4-en-mask = <0        0        0        0
-						 0        0        0        0      >;
-				volt-sel =      <0xf0164e 0xf0164e 0xf0164e NO_FUNC
-						 NO_FUNC  NO_FUNC  0xf0164e NO_FUNC >;
-				volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   0
-						 0        0        BIT(6)   0       >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlg: pinctrl@f01690 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01690 8>;   /* GPCR */
+			func3-gcr =     <0xf03e10 0xf03e10 0xf03e10 NO_FUNC
+					 NO_FUNC  NO_FUNC  0xf03e10 NO_FUNC>;
+			func3-en-mask = <0x20     0x08     0x10     0
+					 0        0        0x02     0      >;
+			func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
+			func4-en-mask = <0        0        0        0
+					 0        0        0        0      >;
+			volt-sel =      <0xf0164e 0xf0164e 0xf0164e NO_FUNC
+					 NO_FUNC  NO_FUNC  0xf0164e NO_FUNC >;
+			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   0
+					 0        0        BIT(6)   0       >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlh: pinctrl@f01698 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01698 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC 0xf03e11 0xf03e11 NO_FUNC
-						 NO_FUNC 0        0        NO_FUNC>;
-				func3-en-mask = <0       0x20     0x20     0
-						 0       0        0        0      >;
-				func4-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC>;
-				func4-en-mask = <0       0        0        0
-						 0       0        0        0      >;
-				volt-sel =      <0xf0164f 0xf0164f 0xf0164f 0xf0164f
-						 0xf0164f 0xf0164f 0xf0164f NO_FUNC>;
-				volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-						 BIT(4)   BIT(5)   BIT(6)   0      >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlh: pinctrl@f01698 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01698 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC 0xf03e11 0xf03e11 NO_FUNC
+					 NO_FUNC 0        0        NO_FUNC>;
+			func3-en-mask = <0       0x20     0x20     0
+					 0       0        0        0      >;
+			func4-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC>;
+			func4-en-mask = <0       0        0        0
+					 0       0        0        0      >;
+			volt-sel =      <0xf0164f 0xf0164f 0xf0164f 0xf0164f
+					 0xf0164f 0xf0164f 0xf0164f NO_FUNC>;
+			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
+					 BIT(4)   BIT(5)   BIT(6)   0      >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrli: pinctrl@f016a0 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f016a0 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC 0xf03e10 0xf03e10 0xf03e10>;
-				func3-en-mask = <0       0        0        0
-						 0       0x08     0x08     0x08    >;
-				func4-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC >;
-				func4-en-mask = <0       0        0        0
-						 0       0        0        0       >;
-				volt-sel =      <0xf01650 0xf01650 0xf01650 0xf01650
-						 0xf01650 0xf01650 0xf01650 0xf01650>;
-				volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-						 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrli: pinctrl@f016a0 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f016a0 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC 0xf03e10 0xf03e10 0xf03e10>;
+			func3-en-mask = <0       0        0        0
+					 0       0x08     0x08     0x08    >;
+			func4-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC >;
+			func4-en-mask = <0       0        0        0
+					 0       0        0        0       >;
+			volt-sel =      <0xf01650 0xf01650 0xf01650 0xf01650
+					 0xf01650 0xf01650 0xf01650 0xf01650>;
+			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
+					 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlj: pinctrl@f016a8 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f016a8 8>;   /* GPCR */
-				func3-gcr =     <0xf03e14 NO_FUNC  0xf03e14 0xf03e14
-						 0xf03e10 0xf03e10 NO_FUNC  NO_FUNC>;
-				func3-en-mask = <0x01     0        0x01     0x02
-						 0x02     0x03     0        0      >;
-				func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
-						 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
-				func4-en-mask = <0        0        0        0
-						 0        0        0        0      >;
-				volt-sel =      <0xf01651 0xf01651 0xf01651 0xf01651
-						 0xf01651 0xf01651 NO_FUNC  NO_FUNC >;
-				volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-						 BIT(4)   BIT(5)   0        0       >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlj: pinctrl@f016a8 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f016a8 8>;   /* GPCR */
+			func3-gcr =     <0xf03e14 NO_FUNC  0xf03e14 0xf03e14
+					 0xf03e10 0xf03e10 NO_FUNC  NO_FUNC>;
+			func3-en-mask = <0x01     0        0x01     0x02
+					 0x02     0x03     0        0      >;
+			func4-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
+					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
+			func4-en-mask = <0        0        0        0
+					 0        0        0        0      >;
+			volt-sel =      <0xf01651 0xf01651 0xf01651 0xf01651
+					 0xf01651 0xf01651 NO_FUNC  NO_FUNC >;
+			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
+					 BIT(4)   BIT(5)   0        0       >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlk: pinctrl@f016b0 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f016b0 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
-				func3-en-mask = <0       0       0       0
-						 0       0       0       0      >;
-				func4-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
-				func4-en-mask = <0       0       0       0
-						 0       0       0       0      >;
-				volt-sel =      <0xf01652 0xf01652 0xf01652 0xf01652
-						 0xf01652 0xf01652 0xf01652 0xf01652>;
-				volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-						 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlk: pinctrl@f016b0 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f016b0 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
+			func3-en-mask = <0       0       0       0
+					 0       0       0       0      >;
+			func4-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
+			func4-en-mask = <0       0       0       0
+					 0       0       0       0      >;
+			volt-sel =      <0xf01652 0xf01652 0xf01652 0xf01652
+					 0xf01652 0xf01652 0xf01652 0xf01652>;
+			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
+					 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrll: pinctrl@f016b8 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f016b8 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
-				func3-en-mask = <0       0       0       0
-						 0       0       0       0      >;
-				func4-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
-				func4-en-mask = <0       0       0       0
-						 0       0       0       0      >;
-				volt-sel =      <0xf01653 0xf01653 0xf01653 0xf01653
-						 0xf01653 0xf01653 0xf01653 0xf01653>;
-				volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-						 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrll: pinctrl@f016b8 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f016b8 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
+			func3-en-mask = <0       0       0       0
+					 0       0       0       0      >;
+			func4-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
+			func4-en-mask = <0       0       0       0
+					 0       0       0       0      >;
+			volt-sel =      <0xf01653 0xf01653 0xf01653 0xf01653
+					 0xf01653 0xf01653 0xf01653 0xf01653>;
+			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
+					 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlm: pinctrl@f016c0 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f016c0 8>;   /* GPCR */
-				func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
-				func3-en-mask = <0       0       0       0
-						 0       0       0       0      >;
-				func4-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
-						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
-				func4-en-mask = <0       0       0       0
-						 0       0       0       0      >;
-				volt-sel =      <0xf03e2d 0xf03e2d 0xf03e2d 0xf03e2d
-						 0xf03e2d 0xf03e2d 0xf03e2d NO_FUNC >;
-				volt-sel-mask = <BIT(4)   BIT(4)   BIT(4)   BIT(4)
-						 BIT(4)   BIT(4)   BIT(4)   0       >;
-				#pinmux-cells = <2>;
-				gpio-group;
-			};
+		pinctrlm: pinctrl@f016c0 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f016c0 8>;   /* GPCR */
+			func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
+			func3-en-mask = <0       0       0       0
+					 0       0       0       0      >;
+			func4-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
+					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
+			func4-en-mask = <0       0       0       0
+					 0       0       0       0      >;
+			volt-sel =      <0xf03e2d 0xf03e2d 0xf03e2d 0xf03e2d
+					 0xf03e2d 0xf03e2d 0xf03e2d NO_FUNC >;
+			volt-sel-mask = <BIT(4)   BIT(4)   BIT(4)   BIT(4)
+					 BIT(4)   BIT(4)   BIT(4)   0       >;
+			#pinmux-cells = <2>;
+			gpio-group;
+		};
 
-			pinctrlksi: pinctrl@f01d40 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01d40 8   /* KSIGCTRL */
-				       0x00f01d05 1>; /* KSICTRL */
-				pp-od-mask = <NO_FUNC>;
-				pullup-mask = <BIT(2)>;
-				#pinmux-cells = <2>;
-			};
+		pinctrlksi: pinctrl@f01d40 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01d40 8   /* KSIGCTRL */
+			       0x00f01d05 1>; /* KSICTRL */
+			pp-od-mask = <NO_FUNC>;
+			pullup-mask = <BIT(2)>;
+			#pinmux-cells = <2>;
+		};
 
-			pinctrlksol: pinctrl@f01d48 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01d48 8   /* KSOLGCTRL */
-				       0x00f01d02 1>; /* KSOCTRL */
-				pp-od-mask = <BIT(0)>;
-				pullup-mask = <BIT(2)>;
-				#pinmux-cells = <2>;
-			};
+		pinctrlksol: pinctrl@f01d48 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01d48 8   /* KSOLGCTRL */
+			       0x00f01d02 1>; /* KSOCTRL */
+			pp-od-mask = <BIT(0)>;
+			pullup-mask = <BIT(2)>;
+			#pinmux-cells = <2>;
+		};
 
-			pinctrlksoh: pinctrl@f01d50 {
-				compatible = "ite,it8xxx2-pinctrl-func";
-				reg = <0x00f01d50 8   /* KSOHGCTRL */
-				       0x00f01d02 1>; /* KSOCTRL */
-				pp-od-mask = <BIT(0)>;
-				pullup-mask = <BIT(2)>;
-				#pinmux-cells = <2>;
-			};
+		pinctrlksoh: pinctrl@f01d50 {
+			compatible = "ite,it8xxx2-pinctrl-func";
+			reg = <0x00f01d50 8   /* KSOHGCTRL */
+			       0x00f01d02 1>; /* KSOCTRL */
+			pp-od-mask = <BIT(0)>;
+			pullup-mask = <BIT(2)>;
+			#pinmux-cells = <2>;
 		};
 
 		wuc1: wakeup-controller@f01b00 {

--- a/scripts/build/check_init_priorities.py
+++ b/scripts/build/check_init_priorities.py
@@ -286,23 +286,12 @@ class Validator():
             self.log.info(
                     f"{dev_node.path} {dev_prio} > {dep_node.path} {dep_prio}")
 
-    def _check_edt_r(self, dev_ord, dev):
-        """Recursively check for dependencies of a device."""
-        for dep in dev.depends_on:
-            self._check_dep(dev_ord, dep.dep_ordinal)
-        if dev._binding and dev._binding.child_binding:
-            for child in dev.children.values():
-                if "compatible" in child.props:
-                    continue
-                if dev._binding.path != child._binding.path:
-                    continue
-                self._check_edt_r(dev_ord, child)
-
     def check_edt(self):
         """Scan through all known devices and validate the init priorities."""
         for dev_ord in self._obj.devices:
             dev = self._ord2node[dev_ord]
-            self._check_edt_r(dev_ord, dev)
+            for dep in dev.depends_on:
+                self._check_dep(dev_ord, dep.dep_ordinal)
 
     def print_initlevels(self):
         for level, calls in self._obj.initlevels.items():

--- a/scripts/build/check_init_priorities_test.py
+++ b/scripts/build/check_init_priorities_test.py
@@ -381,52 +381,32 @@ class testValidator(unittest.TestCase):
 
     @mock.patch("check_init_priorities.Validator._check_dep")
     @mock.patch("check_init_priorities.Validator.__init__", return_value=None)
-    def test_check_edt_r(self, mock_vinit, mock_cd):
-        validator = check_init_priorities.Validator("", "", None)
-
+    def test_check_edt(self, mock_vinit, mock_cd):
         d0 = mock.Mock()
         d0.dep_ordinal = 1
         d1 = mock.Mock()
         d1.dep_ordinal = 2
+        d2 = mock.Mock()
+        d2.dep_ordinal = 3
 
-        c0 = mock.Mock()
-        c0.props = {"compatible": "c"}
-        c1 = mock.Mock()
-        c1.props = {}
-        c1._binding.path = "another-binding-path.yaml"
-        c2 = mock.Mock()
-        c2.props = {}
-        c2._binding.path = "binding-path.yaml"
-        c2._binding.child_binding = None
-        c2.depends_on = [d1]
+        dev0 = mock.Mock()
+        dev0.depends_on = [d0]
+        dev1 = mock.Mock()
+        dev1.depends_on = [d1]
+        dev2 = mock.Mock()
+        dev2.depends_on = [d2]
 
-        dev = mock.Mock()
-        dev.depends_on = [d0]
-        dev._binding.child_binding = "child-binding"
-        dev._binding.path = "binding-path.yaml"
-        dev.children.values.return_value = [c0, c1, c2]
-
-        validator._check_edt_r(0, dev)
-
-        self.assertListEqual(mock_cd.call_args_list, [
-            mock.call(0, 1),
-            mock.call(0, 2),
-            ])
-
-    @mock.patch("check_init_priorities.Validator._check_edt_r")
-    @mock.patch("check_init_priorities.Validator.__init__", return_value=None)
-    def test_check_edt(self, mock_vinit, mock_cer):
         validator = check_init_priorities.Validator("", "", None)
-        validator._ord2node = {1: mock.Mock(), 2: mock.Mock(), 3: mock.Mock()}
+        validator._ord2node = {1: dev0, 2: dev1, 3: dev2}
         validator._obj = mock.Mock()
         validator._obj.devices = {1: 10, 2: 10, 3: 20}
 
         validator.check_edt()
 
-        self.assertListEqual(mock_cer.call_args_list, [
-            mock.call(1, validator._ord2node[1]),
-            mock.call(2, validator._ord2node[2]),
-            mock.call(3, validator._ord2node[3]),
+        self.assertListEqual(mock_cd.call_args_list, [
+            mock.call(1, 1),
+            mock.call(2, 2),
+            mock.call(3, 3),
             ])
 
 if __name__ == "__main__":

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2052,6 +2052,56 @@ class EDT:
         except Exception as e:
             raise EDTError(e)
 
+    def _process_properties_r(self, root_node, props_node):
+        """
+        Process props_node properties for dependencies, and add those as
+        dependencies of root_node. Then walk through all the props_node
+        children and do the same recursively, maintaining the same root_node.
+
+        This ensures that on a node with child nodes, the parent node includes
+        the dependencies of all the child nodes as well as its own.
+        """
+        # A Node depends on any Nodes present in 'phandle',
+        # 'phandles', or 'phandle-array' property values.
+        for prop in props_node.props.values():
+            if prop.type == 'phandle':
+                self._graph.add_edge(root_node, prop.val)
+            elif prop.type == 'phandles':
+                if TYPE_CHECKING:
+                    assert isinstance(prop.val, list)
+                for phandle_node in prop.val:
+                    self._graph.add_edge(root_node, phandle_node)
+            elif prop.type == 'phandle-array':
+                if TYPE_CHECKING:
+                    assert isinstance(prop.val, list)
+                for cd in prop.val:
+                    if cd is None:
+                        continue
+                    if TYPE_CHECKING:
+                        assert isinstance(cd, ControllerAndData)
+                    self._graph.add_edge(root_node, cd.controller)
+
+        # A Node depends on whatever supports the interrupts it
+        # generates.
+        for intr in props_node.interrupts:
+            self._graph.add_edge(root_node, intr.controller)
+
+        # If the binding defines child bindings, link the child properties to
+        # the root_node as well.
+        if props_node._binding and props_node._binding.child_binding:
+            for child in props_node.children.values():
+                if "compatible" in child.props:
+                    # Not a child node, normal node on a different binding.
+                    continue
+                self._process_properties_r(root_node, child)
+
+    def _process_properties(self, node):
+        """
+        Add node dependencies based on own as well as child node properties,
+        start from the node itself.
+        """
+        self._process_properties_r(node, node)
+
     def _init_graph(self) -> None:
         # Constructs a graph of dependencies between Node instances,
         # which is usable for computing a partial order over the dependencies.
@@ -2065,30 +2115,7 @@ class EDT:
             for child in node.children.values():
                 self._graph.add_edge(child, node)
 
-            # A Node depends on any Nodes present in 'phandle',
-            # 'phandles', or 'phandle-array' property values.
-            for prop in node.props.values():
-                if prop.type == 'phandle':
-                    self._graph.add_edge(node, prop.val)
-                elif prop.type == 'phandles':
-                    if TYPE_CHECKING:
-                        assert isinstance(prop.val, list)
-                    for phandle_node in prop.val:
-                        self._graph.add_edge(node, phandle_node)
-                elif prop.type == 'phandle-array':
-                    if TYPE_CHECKING:
-                        assert isinstance(prop.val, list)
-                    for cd in prop.val:
-                        if cd is None:
-                            continue
-                        if TYPE_CHECKING:
-                            assert isinstance(cd, ControllerAndData)
-                        self._graph.add_edge(node, cd.controller)
-
-            # A Node depends on whatever supports the interrupts it
-            # generates.
-            for intr in node.interrupts:
-                self._graph.add_edge(node, intr.controller)
+            self._process_properties(node)
 
     def _init_compat2binding(self) -> None:
         # Creates self._compat2binding, a dictionary that maps

--- a/scripts/dts/python-devicetree/tests/test-bindings/child-binding.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/child-binding.yaml
@@ -10,6 +10,8 @@ child-binding:
     child-prop:
       type: int
       required: true
+    child-ref:
+      type: phandle
 
   child-binding:
     description: grandchild node
@@ -17,3 +19,5 @@ child-binding:
       grandchild-prop:
         type: int
         required: true
+      grandchild-ref:
+        type: phandle

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -470,16 +470,21 @@
 	// 'child-binding:')
 	//
 
+	child-binding-dep {
+	};
+
 	child-binding {
 		compatible = "top-binding";
 		child-1 {
 			child-prop = <1>;
 			grandchild {
 				grandchild-prop = <2>;
+				grandchild-ref = < &{/child-binding-dep} >;
 			};
 		};
 		child-2 {
 			child-prop = <3>;
+			child-ref = < &{/child-binding-dep} >;
 		};
 	};
 

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -627,6 +627,20 @@ def test_dependencies():
     assert edt.get_node("/") in edt.get_node("/in-dir-1").depends_on
     assert edt.get_node("/in-dir-1") in edt.get_node("/").required_by
 
+def test_child_dependencies():
+    '''Test dependencies relashionship with child nodes propagated to parent'''
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    dep_node = edt.get_node("/child-binding-dep")
+
+    assert dep_node in edt.get_node("/child-binding").depends_on
+    assert dep_node in edt.get_node("/child-binding/child-1/grandchild").depends_on
+    assert dep_node in edt.get_node("/child-binding/child-2").depends_on
+    assert edt.get_node("/child-binding") in dep_node.required_by
+    assert edt.get_node("/child-binding/child-1/grandchild") in dep_node.required_by
+    assert edt.get_node("/child-binding/child-2") in dep_node.required_by
+
 def test_slice_errs(tmp_path):
     '''Test error messages from the internal _slice() helper'''
 


### PR DESCRIPTION
Hi, this is pretty much a reiteration of https://github.com/zephyrproject-rtos/zephyr/pull/55657. At the time I did not realize that it was actually fixing an issue and dropped it, but now that we have ordinals in the device init sequence it's pretty clear that not doing this is an issue.

Example of the problem:

Before:

```
$ west build -p -b nrf52840dk_nrf52840 samples/drivers/led_pwm -DCONFIG_LED_INIT_PRIORITY=50
...
ERROR: /pwmleds POST_KERNEL 50 68 < /soc/pwm@4001c000 POST_KERNEL 50 69
```

![b](https://github.com/zephyrproject-rtos/zephyr/assets/891546/9a05f530-a17a-4bcd-984d-4709f49ce4e6)

After:

```
$ west build -p -b nrf52840dk_nrf52840 samples/drivers/led_pwm -DCONFIG_LED_INIT_PRIORITY=50
<builds fine>
$ ./scripts/build/check_init_priorities.py -vv
...
INFO: /pwmleds POST_KERNEL 50 69 > /soc/pwm@4001c000 POST_KERNEL 50 68
```

![a](https://github.com/zephyrproject-rtos/zephyr/assets/891546/40691aac-e6ec-4c40-a50c-71fedeb2935e)

In the first case, the missing dependency is causing the ordinal of `pwmleds` devices to be lower than the `pwm` one that they depend on, that means that if they were set with the same level and priority, they would initialize in the incorrect order.

Also tested on https://github.com/zephyrproject-rtos/zephyr-testing/tree/vfabio-edt-child-branch (two unrelated breakages there that don't show up on the main repo for some reason)