### PR TITLE
drivers: charger: fix i2c_dump_msgs_rw argument

### DIFF
--- a/drivers/charger/emul_sbs_charger.c
+++ b/drivers/charger/emul_sbs_charger.c
@@ -67,7 +67,7 @@ static int sbs_charger_emul_transfer_i2c(const struct emul *target, struct i2c_m
 
 	data = target->data;
 
-	i2c_dump_msgs_rw("emul", msgs, num_msgs, addr, false);
+	i2c_dump_msgs_rw(target->dev, msgs, num_msgs, addr, false);
 	switch (num_msgs) {
 	case 2:
 		if (msgs->flags & I2C_MSG_READ) {


### PR DESCRIPTION
Repro: `west build -t run -p -b native_posix -T tests/drivers/charger/sbs_charger/drivers.sbs_charger.emulated`

---

Fixes:

zephyr/drivers/charger/emul_sbs_charger.c:70:26: warning: passing argument 1 of ‘i2c_dump_msgs_rw’ from incompatible pointer type [-Wincompatible-pointer-types]