### PR TITLE
modules: lvgl: initialize lvgl_heap_init from lvgl_init

### DIFF
--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -11,6 +11,9 @@
 #ifdef CONFIG_LV_Z_USE_FILESYSTEM
 #include "lvgl_fs.h"
 #endif
+#ifdef CONFIG_LV_Z_MEM_POOL_SYS_HEAP
+#include "lvgl_mem.h"
+#endif
 #include LV_MEM_CUSTOM_INCLUDE
 
 #define LOG_LEVEL CONFIG_LV_LOG_LEVEL
@@ -190,7 +193,6 @@ static int lvgl_allocate_rendering_buffers(lv_disp_drv_t *disp_driver)
 
 static int lvgl_init(void)
 {
-
 	const struct device *display_dev = DEVICE_DT_GET(DISPLAY_NODE);
 
 	int err = 0;
@@ -199,6 +201,10 @@ static int lvgl_init(void)
 		LOG_ERR("Display device not ready.");
 		return -ENODEV;
 	}
+
+#ifdef CONFIG_LV_Z_MEM_POOL_SYS_HEAP
+	lvgl_heap_init();
+#endif
 
 #if CONFIG_LV_LOG_LEVEL != 0
 	lv_log_register_print_cb(lvgl_log);

--- a/modules/lvgl/lvgl_mem.c
+++ b/modules/lvgl/lvgl_mem.c
@@ -58,10 +58,7 @@ void lvgl_print_heap_info(bool dump_chunks)
 	k_spin_unlock(&lvgl_heap_lock, key);
 }
 
-static int lvgl_heap_init(void)
+void lvgl_heap_init(void)
 {
 	sys_heap_init(&lvgl_heap, &lvgl_heap_mem[0], HEAP_BYTES);
-	return 0;
 }
-
-SYS_INIT(lvgl_heap_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/modules/lvgl/lvgl_mem.h
+++ b/modules/lvgl/lvgl_mem.h
@@ -22,6 +22,8 @@ void lvgl_free(void *ptr);
 
 void lvgl_print_heap_info(bool dump_chunks);
 
+void lvgl_heap_init(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Call lvgl_heap_init from lvgl_init rather than using two separate SYS_INIT, this sensures that the heap is initialized correctly regardless of the relation between CONFIG_KERNEL_INIT_PRIORITY_DEFAULT and CONFIG_APPLICATION_INIT_PRIORITY.