### PR TITLE
tests: twister: robot: Fix setting testcases status

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -143,10 +143,15 @@ class Robot(Harness):
 
             if cmake_proc.returncode == 0:
                 self.instance.status = "passed"
+                # all tests in one Robot file are treated as a single test case,
+                # so its status should be set accordingly to the instance status
+                # please note that there should be only one testcase in testcases list
+                self.instance.testcases[0].status = "passed"
             else:
                 logger.error("Robot test failure: %s for %s" %
                              (handler.sourcedir, self.instance.platform.name))
                 self.instance.status = "failed"
+                self.instance.testcases[0].status = "failed"
 
             if out:
                 with open(os.path.join(self.instance.build_dir, handler.log), "wt") as log:


### PR DESCRIPTION
Currently, when a Robot test is run, the test case status value is reported as `None`, which causes the XML to contain information about the test being skipped due to misconfiguration.

This commit fixes the value reported in Twister XML test result by assigning the test result to the `status` variable of a testcase instance after the test has finished running.