### PR TITLE
cmake: modules: host tools: Bump minimum version to 0.16

### DIFF
--- a/cmake/modules/FindHostTools.cmake
+++ b/cmake/modules/FindHostTools.cmake
@@ -50,7 +50,7 @@ endif()
 
 find_package(Deprecated COMPONENTS XCC_USE_CLANG CROSS_COMPILE)
 
-find_package(Zephyr-sdk 0.15)
+find_package(Zephyr-sdk 0.16)
 
 # gperf is an optional dependency
 find_program(GPERF gperf)


### PR DESCRIPTION
Some tests require the zephyr toolchain version 0.16 or newer to be able to use picolibc functionality.

Fixes #62396