### PR TITLE
Bluetooth: Mesh: Fix Solicitation Mesh crypto API use

### DIFF
--- a/subsys/bluetooth/mesh/solicitation.c
+++ b/subsys/bluetooth/mesh/solicitation.c
@@ -304,7 +304,7 @@ static int sol_pdu_create(struct bt_mesh_subnet *sub, struct net_buf_simple *pdu
 	/* DST = 0x0000 */
 	net_buf_simple_add_le16(pdu, 0x0000);
 
-	err = bt_mesh_net_encrypt(sub->keys[SUBNET_KEY_TX_IDX(sub)].msg.enc,
+	err = bt_mesh_net_encrypt(&sub->keys[SUBNET_KEY_TX_IDX(sub)].msg.enc,
 				  pdu, 0, BT_MESH_NONCE_SOLICITATION);
 
 	if (err) {
@@ -313,7 +313,7 @@ static int sol_pdu_create(struct bt_mesh_subnet *sub, struct net_buf_simple *pdu
 	}
 
 	err = bt_mesh_net_obfuscate(pdu->data, 0,
-				    sub->keys[SUBNET_KEY_TX_IDX(sub)].msg.privacy);
+				    &sub->keys[SUBNET_KEY_TX_IDX(sub)].msg.privacy);
 	if (err) {
 		LOG_ERR("Obfuscation failed, err=%d", err);
 		return err;


### PR DESCRIPTION
Pointer of the keys should be send to mesh en/decryption APIs.