### PR TITLE
Bluetooth: Mesh: Make bt_mesh_model as rodata

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/blob_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/blob_cli.rst
@@ -23,7 +23,7 @@ The BLOB Transfer Client is instantiated on an element with a set of event handl
          .cb = &blob_cb,
    };
 
-   static struct bt_mesh_model models[] = {
+   static const struct bt_mesh_model models[] = {
          BT_MESH_MODEL_BLOB_CLI(&blob_cli),
    };
 

--- a/doc/connectivity/bluetooth/api/mesh/blob_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/blob_srv.rst
@@ -27,7 +27,7 @@ The BLOB Transfer Server is instantiated on an element with a set of event handl
        .cb = &blob_cb,
    };
 
-   static struct bt_mesh_model models[] = {
+   static const struct bt_mesh_model models[] = {
        BT_MESH_MODEL_BLOB_SRV(&blob_srv),
    };
 

--- a/include/zephyr/bluetooth/mesh/blob_cli.h
+++ b/include/zephyr/bluetooth/mesh/blob_cli.h
@@ -291,7 +291,7 @@ struct bt_mesh_blob_cli {
 	const struct bt_mesh_blob_cli_cb *cb;
 
 	/* Runtime state */
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 
 	struct {
 		struct bt_mesh_blob_target *target;

--- a/include/zephyr/bluetooth/mesh/blob_srv.h
+++ b/include/zephyr/bluetooth/mesh/blob_srv.h
@@ -136,7 +136,7 @@ struct bt_mesh_blob_srv {
 	const struct bt_mesh_blob_io *io;
 	struct k_work_delayable rx_timeout;
 	struct bt_mesh_blob_block block;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	enum bt_mesh_blob_xfer_phase phase;
 
 	struct bt_mesh_blob_srv_state {

--- a/include/zephyr/bluetooth/mesh/cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/cfg_cli.h
@@ -332,7 +332,7 @@ struct bt_mesh_cfg_cli_cb {
 /** Mesh Configuration Client Model Context */
 struct bt_mesh_cfg_cli {
 	/** Composition data model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/** Optional callback for Mesh Configuration Client Status messages. */
 	const struct bt_mesh_cfg_cli_cb *cb;

--- a/include/zephyr/bluetooth/mesh/dfd_srv.h
+++ b/include/zephyr/bluetooth/mesh/dfd_srv.h
@@ -116,7 +116,7 @@ struct bt_mesh_dfd_srv_cb {
 /** Firmware Distribution Server instance. */
 struct bt_mesh_dfd_srv {
 	const struct bt_mesh_dfd_srv_cb *cb;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_dfu_cli dfu;
 	struct bt_mesh_dfu_target targets[CONFIG_BT_MESH_DFD_SRV_TARGETS_MAX];
 	struct bt_mesh_blob_target_pull pull_ctxs[CONFIG_BT_MESH_DFD_SRV_TARGETS_MAX];

--- a/include/zephyr/bluetooth/mesh/dfu_cli.h
+++ b/include/zephyr/bluetooth/mesh/dfu_cli.h
@@ -190,7 +190,7 @@ struct bt_mesh_dfu_cli {
 	/* runtime state */
 
 	uint32_t op;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 
 	struct {
 		const struct bt_mesh_dfu_slot *slot;

--- a/include/zephyr/bluetooth/mesh/dfu_srv.h
+++ b/include/zephyr/bluetooth/mesh/dfu_srv.h
@@ -184,7 +184,7 @@ struct bt_mesh_dfu_srv {
 	size_t img_count;
 
 	/* Runtime state */
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct {
 		/* Effect of transfer, @see bt_mesh_dfu_effect. */
 		uint8_t effect;

--- a/include/zephyr/bluetooth/mesh/health_cli.h
+++ b/include/zephyr/bluetooth/mesh/health_cli.h
@@ -26,7 +26,7 @@ extern "C" {
 /** Health Client Model Context */
 struct bt_mesh_health_cli {
 	/** Composition data model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/** Publication structure instance */
 	struct bt_mesh_model_pub pub;

--- a/include/zephyr/bluetooth/mesh/health_srv.h
+++ b/include/zephyr/bluetooth/mesh/health_srv.h
@@ -53,7 +53,7 @@ struct bt_mesh_health_srv_cb {
 	 *
 	 *  @return 0 on success, or (negative) error code otherwise.
 	 */
-	int (*fault_get_cur)(struct bt_mesh_model *model, uint8_t *test_id,
+	int (*fault_get_cur)(const struct bt_mesh_model *model, uint8_t *test_id,
 			     uint16_t *company_id, uint8_t *faults,
 			     uint8_t *fault_count);
 
@@ -79,7 +79,7 @@ struct bt_mesh_health_srv_cb {
 	 *
 	 *  @return 0 on success, or (negative) error code otherwise.
 	 */
-	int (*fault_get_reg)(struct bt_mesh_model *model, uint16_t company_id,
+	int (*fault_get_reg)(const struct bt_mesh_model *model, uint16_t company_id,
 			     uint8_t *test_id, uint8_t *faults,
 			     uint8_t *fault_count);
 
@@ -91,7 +91,7 @@ struct bt_mesh_health_srv_cb {
 	 *
 	 *  @return 0 on success, or (negative) error code otherwise.
 	 */
-	int (*fault_clear)(struct bt_mesh_model *model, uint16_t company_id);
+	int (*fault_clear)(const struct bt_mesh_model *model, uint16_t company_id);
 
 	/** @brief Run a self-test.
 	 *
@@ -108,7 +108,7 @@ struct bt_mesh_health_srv_cb {
 	 * (negative) error code otherwise. Note that the fault array will not
 	 * be reported back to the client if the test execution didn't start.
 	 */
-	int (*fault_test)(struct bt_mesh_model *model, uint8_t test_id,
+	int (*fault_test)(const struct bt_mesh_model *model, uint8_t test_id,
 			  uint16_t company_id);
 
 	/** @brief Start calling attention to the device.
@@ -125,7 +125,7 @@ struct bt_mesh_health_srv_cb {
 	 *
 	 *  @param model Health Server model to start the attention state of.
 	 */
-	void (*attn_on)(struct bt_mesh_model *model);
+	void (*attn_on)(const struct bt_mesh_model *model);
 
 	/** @brief Stop the attention state.
 	 *
@@ -134,7 +134,7 @@ struct bt_mesh_health_srv_cb {
 	 *
 	 *  @param model
 	 */
-	void (*attn_off)(struct bt_mesh_model *model);
+	void (*attn_off)(const struct bt_mesh_model *model);
 };
 
 /**
@@ -149,7 +149,7 @@ struct bt_mesh_health_srv_cb {
 /** Mesh Health Server Model Context */
 struct bt_mesh_health_srv {
 	/** Composition data model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/** Optional callback struct */
 	const struct bt_mesh_health_srv_cb *cb;

--- a/include/zephyr/bluetooth/mesh/large_comp_data_cli.h
+++ b/include/zephyr/bluetooth/mesh/large_comp_data_cli.h
@@ -69,7 +69,7 @@ struct bt_mesh_large_comp_data_cli_cb {
 /** Large Composition Data Client model context */
 struct bt_mesh_large_comp_data_cli {
 	/** Model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/** Internal parameters for tracking message responses. */
 	struct bt_mesh_msg_ack_ctx ack_ctx;

--- a/include/zephyr/bluetooth/mesh/od_priv_proxy_cli.h
+++ b/include/zephyr/bluetooth/mesh/od_priv_proxy_cli.h
@@ -22,7 +22,7 @@ extern "C" {
 /** On-Demand Private Proxy Client Model Context */
 struct bt_mesh_od_priv_proxy_cli {
 	/** Solicitation PDU RPL model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/* Internal parameters for tracking message responses. */
 	struct bt_mesh_msg_ack_ctx ack_ctx;

--- a/include/zephyr/bluetooth/mesh/priv_beacon_cli.h
+++ b/include/zephyr/bluetooth/mesh/priv_beacon_cli.h
@@ -90,7 +90,7 @@ struct bt_mesh_priv_beacon_cli_cb {
 
 /** Mesh Private Beacon Client model */
 struct bt_mesh_priv_beacon_cli {
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/* Internal parameters for tracking message responses. */
 	struct bt_mesh_msg_ack_ctx ack_ctx;

--- a/include/zephyr/bluetooth/mesh/rpr_cli.h
+++ b/include/zephyr/bluetooth/mesh/rpr_cli.h
@@ -91,7 +91,7 @@ struct bt_mesh_rpr_cli {
 		enum bt_mesh_rpr_link_state state;
 	} link;
 
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 };
 
 /** @brief Get scanning capabilities of Remote Provisioning Server.

--- a/include/zephyr/bluetooth/mesh/sar_cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/sar_cfg_cli.h
@@ -27,7 +27,7 @@ extern "C" {
 /** Mesh SAR Configuration Client Model Context */
 struct bt_mesh_sar_cfg_cli {
 	/** Access model pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/* Publication structure instance */
 	struct bt_mesh_model_pub pub;

--- a/include/zephyr/bluetooth/mesh/sol_pdu_rpl_cli.h
+++ b/include/zephyr/bluetooth/mesh/sol_pdu_rpl_cli.h
@@ -22,7 +22,7 @@ extern "C" {
 /** Solicitation PDU RPL Client Model Context */
 struct bt_mesh_sol_pdu_rpl_cli {
 	/** Solicitation PDU RPL model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/* Internal parameters for tracking message responses. */
 	struct bt_mesh_msg_ack_ctx ack_ctx;

--- a/include/zephyr/bluetooth/testing.h
+++ b/include/zephyr/bluetooth/testing.h
@@ -39,9 +39,9 @@ struct bt_test_cb {
 			      const void *payload, size_t payload_len);
 	void (*mesh_model_recv)(uint16_t src, uint16_t dst, const void *payload,
 				size_t payload_len);
-	void (*mesh_model_bound)(uint16_t addr, struct bt_mesh_model *model,
+	void (*mesh_model_bound)(uint16_t addr, const struct bt_mesh_model *model,
 				 uint16_t key_idx);
-	void (*mesh_model_unbound)(uint16_t addr, struct bt_mesh_model *model,
+	void (*mesh_model_unbound)(uint16_t addr, const struct bt_mesh_model *model,
 				   uint16_t key_idx);
 	void (*mesh_prov_invalid_bearer)(uint8_t opcode);
 	void (*mesh_trans_incomp_timer_exp)(void);

--- a/samples/bluetooth/mesh/src/main.c
+++ b/samples/bluetooth/mesh/src/main.c
@@ -25,12 +25,12 @@
 #define OP_ONOFF_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x03)
 #define OP_ONOFF_STATUS    BT_MESH_MODEL_OP_2(0x82, 0x04)
 
-static void attention_on(struct bt_mesh_model *mod)
+static void attention_on(const struct bt_mesh_model *mod)
 {
 	board_led_set(true);
 }
 
-static void attention_off(struct bt_mesh_model *mod)
+static void attention_off(const struct bt_mesh_model *mod)
 {
 	board_led_set(false);
 }
@@ -102,7 +102,7 @@ static inline uint8_t model_time_encode(int32_t ms)
 	return 0x3f;
 }
 
-static int onoff_status_send(struct bt_mesh_model *model,
+static int onoff_status_send(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx)
 {
 	uint32_t remaining;
@@ -151,7 +151,7 @@ static void onoff_timeout(struct k_work *work)
 
 /* Generic OnOff Server message handlers */
 
-static int gen_onoff_get(struct bt_mesh_model *model,
+static int gen_onoff_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -159,7 +159,7 @@ static int gen_onoff_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set_unack(struct bt_mesh_model *model,
+static int gen_onoff_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -202,7 +202,7 @@ static int gen_onoff_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set(struct bt_mesh_model *model,
+static int gen_onoff_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -221,7 +221,7 @@ static const struct bt_mesh_model_op gen_onoff_srv_op[] = {
 
 /* Generic OnOff Client */
 
-static int gen_onoff_status(struct bt_mesh_model *model,
+static int gen_onoff_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -248,7 +248,7 @@ static const struct bt_mesh_model_op gen_onoff_cli_op[] = {
 };
 
 /* This application only needs one element to contain its models */
-static struct bt_mesh_model models[] = {
+static const struct bt_mesh_model models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_srv_op, NULL,

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -50,14 +50,14 @@ static void heartbeat(const struct bt_mesh_hb_sub *sub, uint8_t hops,
 static struct bt_mesh_cfg_cli cfg_cli = {
 };
 
-static void attention_on(struct bt_mesh_model *model)
+static void attention_on(const struct bt_mesh_model *model)
 {
 	printk("attention_on()\n");
 	board_attention(true);
 	board_play("100H100C100H100C100H100C");
 }
 
-static void attention_off(struct bt_mesh_model *model)
+static void attention_off(const struct bt_mesh_model *model)
 {
 	printk("attention_off()\n");
 	board_attention(false);
@@ -74,13 +74,13 @@ static struct bt_mesh_health_srv health_srv = {
 
 BT_MESH_HEALTH_PUB_DEFINE(health_pub, 0);
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
 };
 
-static int vnd_button_pressed(struct bt_mesh_model *model,
+static int vnd_button_pressed(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -101,7 +101,7 @@ static const struct bt_mesh_model_op vnd_ops[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static struct bt_mesh_model vnd_models[] = {
+static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, MOD_LF, vnd_ops, NULL, NULL),
 };
 

--- a/samples/bluetooth/mesh_provisioner/src/main.c
+++ b/samples/bluetooth/mesh_provisioner/src/main.c
@@ -53,7 +53,7 @@ static struct bt_mesh_health_cli health_cli = {
 	.current_status = health_current_status,
 };
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_CLI(&health_cli),

--- a/samples/boards/nrf/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff-app/src/main.c
@@ -54,19 +54,19 @@
 #define BT_MESH_MODEL_OP_GEN_ONOFF_SET_UNACK	BT_MESH_MODEL_OP_2(0x82, 0x03)
 #define BT_MESH_MODEL_OP_GEN_ONOFF_STATUS	BT_MESH_MODEL_OP_2(0x82, 0x04)
 
-static int gen_onoff_set(struct bt_mesh_model *model,
+static int gen_onoff_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf);
 
-static int gen_onoff_set_unack(struct bt_mesh_model *model,
+static int gen_onoff_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf);
 
-static int gen_onoff_get(struct bt_mesh_model *model,
+static int gen_onoff_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf);
 
-static int gen_onoff_status(struct bt_mesh_model *model,
+static int gen_onoff_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf);
 
@@ -167,7 +167,7 @@ static struct led_onoff_state led_onoff_states[] = {
  * Element 0 Root Models
  */
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
@@ -181,7 +181,7 @@ static struct bt_mesh_model root_models[] = {
  * Element 1 Models
  */
 
-static struct bt_mesh_model secondary_0_models[] = {
+static const struct bt_mesh_model secondary_0_models[] = {
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_srv_op,
 		      &gen_onoff_pub_srv_s_0, &led_onoff_states[1]),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, gen_onoff_cli_op,
@@ -192,7 +192,7 @@ static struct bt_mesh_model secondary_0_models[] = {
  * Element 2 Models
  */
 
-static struct bt_mesh_model secondary_1_models[] = {
+static const struct bt_mesh_model secondary_1_models[] = {
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_srv_op,
 		      &gen_onoff_pub_srv_s_1, &led_onoff_states[2]),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, gen_onoff_cli_op,
@@ -203,7 +203,7 @@ static struct bt_mesh_model secondary_1_models[] = {
  * Element 3 Models
  */
 
-static struct bt_mesh_model secondary_2_models[] = {
+static const struct bt_mesh_model secondary_2_models[] = {
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_srv_op,
 		      &gen_onoff_pub_srv_s_2, &led_onoff_states[3]),
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_ONOFF_CLI, gen_onoff_cli_op,
@@ -214,7 +214,7 @@ static struct bt_mesh_model secondary_2_models[] = {
  * Button to Client Model Assignments
  */
 
-struct bt_mesh_model *mod_cli_sw[] = {
+const struct bt_mesh_model *mod_cli_sw[] = {
 		&root_models[4],
 		&secondary_0_models[1],
 		&secondary_1_models[1],
@@ -225,7 +225,7 @@ struct bt_mesh_model *mod_cli_sw[] = {
  * LED to Server Model Assignments
  */
 
-struct bt_mesh_model *mod_srv_sw[] = {
+const struct bt_mesh_model *mod_srv_sw[] = {
 		&root_models[3],
 		&secondary_0_models[0],
 		&secondary_1_models[0],
@@ -281,7 +281,7 @@ static uint16_t primary_net_idx;
  *
  */
 
-static int gen_onoff_get(struct bt_mesh_model *model,
+static int gen_onoff_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -300,7 +300,7 @@ static int gen_onoff_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set_unack(struct bt_mesh_model *model,
+static int gen_onoff_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -340,7 +340,7 @@ static int gen_onoff_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set(struct bt_mesh_model *model,
+static int gen_onoff_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -352,7 +352,7 @@ static int gen_onoff_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_status(struct bt_mesh_model *model,
+static int gen_onoff_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -465,7 +465,7 @@ static void button_cnt_timer(struct k_timer *work)
 
 static void button_pressed_worker(struct k_work *work)
 {
-	struct bt_mesh_model *mod_cli, *mod_srv;
+	const struct bt_mesh_model *mod_cli, *mod_srv;
 	struct bt_mesh_model_pub *pub_cli, *pub_srv;
 	struct switch_data *button_sw = CONTAINER_OF(work, struct switch_data, button_work);
 	int err;

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -68,7 +68,7 @@ static struct bt_mesh_elem elements[];
 /* message handlers (Start) */
 
 /* Generic OnOff Server message handlers */
-static int gen_onoff_get(struct bt_mesh_model *model,
+static int gen_onoff_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -95,7 +95,7 @@ send:
 	return 0;
 }
 
-void gen_onoff_publish(struct bt_mesh_model *model)
+void gen_onoff_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -119,7 +119,7 @@ void gen_onoff_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int gen_onoff_set_unack(struct bt_mesh_model *model,
+static int gen_onoff_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -188,7 +188,7 @@ static int gen_onoff_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set(struct bt_mesh_model *model,
+static int gen_onoff_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -261,7 +261,7 @@ static int gen_onoff_set(struct bt_mesh_model *model,
 }
 
 /* Generic OnOff Client message handlers */
-static int gen_onoff_status(struct bt_mesh_model *model,
+static int gen_onoff_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -277,7 +277,7 @@ static int gen_onoff_status(struct bt_mesh_model *model,
 }
 
 /* Generic Level (LIGHTNESS) Server message handlers */
-static int gen_level_get(struct bt_mesh_model *model,
+static int gen_level_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -304,7 +304,7 @@ send:
 	return 0;
 }
 
-void gen_level_publish(struct bt_mesh_model *model)
+void gen_level_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -328,7 +328,7 @@ void gen_level_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int gen_level_set_unack(struct bt_mesh_model *model,
+static int gen_level_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -394,7 +394,7 @@ static int gen_level_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_level_set(struct bt_mesh_model *model,
+static int gen_level_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -463,7 +463,7 @@ static int gen_level_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_delta_set_unack(struct bt_mesh_model *model,
+static int gen_delta_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -545,7 +545,7 @@ static int gen_delta_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_delta_set(struct bt_mesh_model *model,
+static int gen_delta_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -630,7 +630,7 @@ static int gen_delta_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_move_set_unack(struct bt_mesh_model *model,
+static int gen_move_set_unack(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -705,7 +705,7 @@ static int gen_move_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_move_set(struct bt_mesh_model *model,
+static int gen_move_set(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
 {
 	uint8_t tid, tt, delay;
@@ -783,7 +783,7 @@ static int gen_move_set(struct bt_mesh_model *model,
 }
 
 /* Generic Level Client message handlers */
-static int gen_level_status(struct bt_mesh_model *model,
+static int gen_level_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -799,7 +799,7 @@ static int gen_level_status(struct bt_mesh_model *model,
 }
 
 /* Generic Default Transition Time Server message handlers */
-static int gen_def_trans_time_get(struct bt_mesh_model *model,
+static int gen_def_trans_time_get(const struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
@@ -815,7 +815,7 @@ static int gen_def_trans_time_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static void gen_def_trans_time_publish(struct bt_mesh_model *model)
+static void gen_def_trans_time_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -833,7 +833,7 @@ static void gen_def_trans_time_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int gen_def_trans_time_set_unack(struct bt_mesh_model *model,
+static int gen_def_trans_time_set_unack(const struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
@@ -855,7 +855,7 @@ static int gen_def_trans_time_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_def_trans_time_set(struct bt_mesh_model *model,
+static int gen_def_trans_time_set(const struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
@@ -881,7 +881,7 @@ static int gen_def_trans_time_set(struct bt_mesh_model *model,
 }
 
 /* Generic Default Transition Time Client message handlers */
-static int gen_def_trans_time_status(struct bt_mesh_model *model,
+static int gen_def_trans_time_status(const struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
@@ -892,7 +892,7 @@ static int gen_def_trans_time_status(struct bt_mesh_model *model,
 }
 
 /* Generic Power OnOff Server message handlers */
-static int gen_onpowerup_get(struct bt_mesh_model *model,
+static int gen_onpowerup_get(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -909,7 +909,7 @@ static int gen_onpowerup_get(struct bt_mesh_model *model,
 }
 
 /* Generic Power OnOff Client message handlers */
-static int gen_onpowerup_status(struct bt_mesh_model *model,
+static int gen_onpowerup_status(const struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
@@ -921,7 +921,7 @@ static int gen_onpowerup_status(struct bt_mesh_model *model,
 
 /* Generic Power OnOff Setup Server message handlers */
 
-static void gen_onpowerup_publish(struct bt_mesh_model *model)
+static void gen_onpowerup_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -939,7 +939,7 @@ static void gen_onpowerup_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int gen_onpowerup_set_unack(struct bt_mesh_model *model,
+static int gen_onpowerup_set_unack(const struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
@@ -961,7 +961,7 @@ static int gen_onpowerup_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onpowerup_set(struct bt_mesh_model *model,
+static int gen_onpowerup_set(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -987,7 +987,7 @@ static int gen_onpowerup_set(struct bt_mesh_model *model,
 }
 
 /* Vendor Model message handlers*/
-static int vnd_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int vnd_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		   struct net_buf_simple *buf)
 {
 	struct net_buf_simple *msg = NET_BUF_SIMPLE(3 + 6 + 4);
@@ -1007,7 +1007,7 @@ static int vnd_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int vnd_set_unack(struct bt_mesh_model *model,
+static int vnd_set_unack(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -1040,7 +1040,7 @@ static int vnd_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int vnd_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int vnd_set(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		   struct net_buf_simple *buf)
 {
 	(void)vnd_set_unack(model, ctx, buf);
@@ -1049,7 +1049,7 @@ static int vnd_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int vnd_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int vnd_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
 	printk("Acknowledgement from Vendor\n");
@@ -1060,7 +1060,7 @@ static int vnd_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 }
 
 /* Light Lightness Server message handlers */
-static int light_lightness_get(struct bt_mesh_model *model,
+static int light_lightness_get(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -1087,7 +1087,7 @@ send:
 	return 0;
 }
 
-void light_lightness_publish(struct bt_mesh_model *model)
+void light_lightness_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -1111,7 +1111,7 @@ void light_lightness_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_lightness_set_unack(struct bt_mesh_model *model,
+static int light_lightness_set_unack(const struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
@@ -1177,7 +1177,7 @@ static int light_lightness_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_set(struct bt_mesh_model *model,
+static int light_lightness_set(const struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
@@ -1246,7 +1246,7 @@ static int light_lightness_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_linear_get(struct bt_mesh_model *model,
+static int light_lightness_linear_get(const struct bt_mesh_model *model,
 				      struct bt_mesh_msg_ctx *ctx,
 				      struct net_buf_simple *buf)
 {
@@ -1274,7 +1274,7 @@ send:
 	return 0;
 }
 
-void light_lightness_linear_publish(struct bt_mesh_model *model)
+void light_lightness_linear_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -1299,7 +1299,7 @@ void light_lightness_linear_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_lightness_linear_set_unack(struct bt_mesh_model *model,
+static int light_lightness_linear_set_unack(const struct bt_mesh_model *model,
 					    struct bt_mesh_msg_ctx *ctx,
 					    struct net_buf_simple *buf)
 {
@@ -1365,7 +1365,7 @@ static int light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_linear_set(struct bt_mesh_model *model,
+static int light_lightness_linear_set(const struct bt_mesh_model *model,
 				      struct bt_mesh_msg_ctx *ctx,
 				      struct net_buf_simple *buf)
 {
@@ -1434,7 +1434,7 @@ static int light_lightness_linear_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_last_get(struct bt_mesh_model *model,
+static int light_lightness_last_get(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -1450,7 +1450,7 @@ static int light_lightness_last_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_default_get(struct bt_mesh_model *model,
+static int light_lightness_default_get(const struct bt_mesh_model *model,
 				       struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
@@ -1467,7 +1467,7 @@ static int light_lightness_default_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_range_get(struct bt_mesh_model *model,
+static int light_lightness_range_get(const struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
@@ -1489,7 +1489,7 @@ static int light_lightness_range_get(struct bt_mesh_model *model,
 
 /* Light Lightness Setup Server message handlers */
 
-static void light_lightness_default_publish(struct bt_mesh_model *model)
+static void light_lightness_default_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -1508,7 +1508,7 @@ static void light_lightness_default_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_lightness_default_set_unack(struct bt_mesh_model *model,
+static int light_lightness_default_set_unack(const struct bt_mesh_model *model,
 					     struct bt_mesh_msg_ctx *ctx,
 					     struct net_buf_simple *buf)
 {
@@ -1527,7 +1527,7 @@ static int light_lightness_default_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_default_set(struct bt_mesh_model *model,
+static int light_lightness_default_set(const struct bt_mesh_model *model,
 				       struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
@@ -1549,7 +1549,7 @@ static int light_lightness_default_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static void light_lightness_range_publish(struct bt_mesh_model *model)
+static void light_lightness_range_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -1569,7 +1569,7 @@ static void light_lightness_range_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_lightness_range_set_unack(struct bt_mesh_model *model,
+static int light_lightness_range_set_unack(const struct bt_mesh_model *model,
 					   struct bt_mesh_msg_ctx *ctx,
 					   struct net_buf_simple *buf)
 {
@@ -1603,7 +1603,7 @@ static int light_lightness_range_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_range_set(struct bt_mesh_model *model,
+static int light_lightness_range_set(const struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
@@ -1641,7 +1641,7 @@ static int light_lightness_range_set(struct bt_mesh_model *model,
 }
 
 /* Light Lightness Client message handlers */
-static int light_lightness_status(struct bt_mesh_model *model,
+static int light_lightness_status(const struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
@@ -1657,7 +1657,7 @@ static int light_lightness_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_linear_status(struct bt_mesh_model *model,
+static int light_lightness_linear_status(const struct bt_mesh_model *model,
 					 struct bt_mesh_msg_ctx *ctx,
 					 struct net_buf_simple *buf)
 {
@@ -1673,7 +1673,7 @@ static int light_lightness_linear_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_last_status(struct bt_mesh_model *model,
+static int light_lightness_last_status(const struct bt_mesh_model *model,
 				       struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
@@ -1683,7 +1683,7 @@ static int light_lightness_last_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_default_status(struct bt_mesh_model *model,
+static int light_lightness_default_status(const struct bt_mesh_model *model,
 					  struct bt_mesh_msg_ctx *ctx,
 					  struct net_buf_simple *buf)
 {
@@ -1693,7 +1693,7 @@ static int light_lightness_default_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_lightness_range_status(struct bt_mesh_model *model,
+static int light_lightness_range_status(const struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
@@ -1706,7 +1706,7 @@ static int light_lightness_range_status(struct bt_mesh_model *model,
 }
 
 /* Light CTL Server message handlers */
-static int light_ctl_get(struct bt_mesh_model *model,
+static int light_ctl_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -1736,7 +1736,7 @@ send:
 	return 0;
 }
 
-void light_ctl_publish(struct bt_mesh_model *model)
+void light_ctl_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -1766,7 +1766,7 @@ void light_ctl_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_ctl_set_unack(struct bt_mesh_model *model,
+static int light_ctl_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -1845,7 +1845,7 @@ static int light_ctl_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_set(struct bt_mesh_model *model,
+static int light_ctl_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -1927,7 +1927,7 @@ static int light_ctl_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_temp_range_get(struct bt_mesh_model *model,
+static int light_ctl_temp_range_get(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -1947,7 +1947,7 @@ static int light_ctl_temp_range_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_default_get(struct bt_mesh_model *model,
+static int light_ctl_default_get(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -1967,7 +1967,7 @@ static int light_ctl_default_get(struct bt_mesh_model *model,
 
 /* Light CTL Setup Server message handlers */
 
-static void light_ctl_default_publish(struct bt_mesh_model *model)
+static void light_ctl_default_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -1987,7 +1987,7 @@ static void light_ctl_default_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_ctl_default_set_unack(struct bt_mesh_model *model,
+static int light_ctl_default_set_unack(const struct bt_mesh_model *model,
 					struct bt_mesh_msg_ctx *ctx,
 					struct net_buf_simple *buf)
 {
@@ -2018,7 +2018,7 @@ static int light_ctl_default_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_default_set(struct bt_mesh_model *model,
+static int light_ctl_default_set(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -2052,7 +2052,7 @@ static int light_ctl_default_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static void light_ctl_temp_range_publish(struct bt_mesh_model *model)
+static void light_ctl_temp_range_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -2072,7 +2072,7 @@ static void light_ctl_temp_range_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_ctl_temp_range_set_unack(struct bt_mesh_model *model,
+static int light_ctl_temp_range_set_unack(const struct bt_mesh_model *model,
 					  struct bt_mesh_msg_ctx *ctx,
 					  struct net_buf_simple *buf)
 {
@@ -2108,7 +2108,7 @@ static int light_ctl_temp_range_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_temp_range_set(struct bt_mesh_model *model,
+static int light_ctl_temp_range_set(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -2148,7 +2148,7 @@ static int light_ctl_temp_range_set(struct bt_mesh_model *model,
 }
 
 /* Light CTL Client message handlers */
-static int light_ctl_status(struct bt_mesh_model *model,
+static int light_ctl_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -2168,7 +2168,7 @@ static int light_ctl_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_temp_range_status(struct bt_mesh_model *model,
+static int light_ctl_temp_range_status(const struct bt_mesh_model *model,
 				       struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
@@ -2180,7 +2180,7 @@ static int light_ctl_temp_range_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_temp_status(struct bt_mesh_model *model,
+static int light_ctl_temp_status(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -2201,7 +2201,7 @@ static int light_ctl_temp_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_default_status(struct bt_mesh_model *model,
+static int light_ctl_default_status(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -2214,7 +2214,7 @@ static int light_ctl_default_status(struct bt_mesh_model *model,
 }
 
 /* Light CTL Temp. Server message handlers */
-static int light_ctl_temp_get(struct bt_mesh_model *model,
+static int light_ctl_temp_get(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2244,7 +2244,7 @@ send:
 	return 0;
 }
 
-void light_ctl_temp_publish(struct bt_mesh_model *model)
+void light_ctl_temp_publish(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -2270,7 +2270,7 @@ void light_ctl_temp_publish(struct bt_mesh_model *model)
 	}
 }
 
-static int light_ctl_temp_set_unack(struct bt_mesh_model *model,
+static int light_ctl_temp_set_unack(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -2345,7 +2345,7 @@ static int light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int light_ctl_temp_set(struct bt_mesh_model *model,
+static int light_ctl_temp_set(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2424,7 +2424,7 @@ static int light_ctl_temp_set(struct bt_mesh_model *model,
 }
 
 /* Generic Level (TEMPERATURE) Server message handlers */
-static int gen_level_get_temp(struct bt_mesh_model *model,
+static int gen_level_get_temp(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2451,7 +2451,7 @@ send:
 	return 0;
 }
 
-void gen_level_publish_temp(struct bt_mesh_model *model)
+void gen_level_publish_temp(const struct bt_mesh_model *model)
 {
 	int err;
 	struct net_buf_simple *msg = model->pub->msg;
@@ -2475,7 +2475,7 @@ void gen_level_publish_temp(struct bt_mesh_model *model)
 	}
 }
 
-static int gen_level_set_unack_temp(struct bt_mesh_model *model,
+static int gen_level_set_unack_temp(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -2541,7 +2541,7 @@ static int gen_level_set_unack_temp(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_level_set_temp(struct bt_mesh_model *model,
+static int gen_level_set_temp(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2610,7 +2610,7 @@ static int gen_level_set_temp(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_delta_set_unack_temp(struct bt_mesh_model *model,
+static int gen_delta_set_unack_temp(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -2692,7 +2692,7 @@ static int gen_delta_set_unack_temp(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_delta_set_temp(struct bt_mesh_model *model,
+static int gen_delta_set_temp(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2777,7 +2777,7 @@ static int gen_delta_set_temp(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_move_set_unack_temp(struct bt_mesh_model *model,
+static int gen_move_set_unack_temp(const struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
@@ -2852,7 +2852,7 @@ static int gen_move_set_unack_temp(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_move_set_temp(struct bt_mesh_model *model,
+static int gen_move_set_temp(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -2931,7 +2931,7 @@ static int gen_move_set_temp(struct bt_mesh_model *model,
 }
 
 /* Generic Level (TEMPERATURE) Client message handlers */
-static int gen_level_status_temp(struct bt_mesh_model *model,
+static int gen_level_status_temp(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -3112,7 +3112,7 @@ static const struct bt_mesh_model_op gen_level_cli_op_temp[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-struct bt_mesh_model root_models[] = {
+const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
 
@@ -3172,12 +3172,12 @@ struct bt_mesh_model root_models[] = {
 		      NULL),
 };
 
-struct bt_mesh_model vnd_models[] = {
+const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(CID_ZEPHYR, 0x4321, vnd_ops,
 			  &vnd_pub, &vnd_user_data),
 };
 
-struct bt_mesh_model s0_models[] = {
+const struct bt_mesh_model s0_models[] = {
 	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_LEVEL_SRV,
 		      gen_level_srv_op_temp, &gen_level_srv_pub_s0,
 		      NULL),

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.h
@@ -93,18 +93,18 @@ struct light_ctl_state {
 extern struct vendor_state vnd_user_data;
 extern struct light_ctl_state *const ctl;
 
-extern struct bt_mesh_model root_models[];
-extern struct bt_mesh_model vnd_models[];
-extern struct bt_mesh_model s0_models[];
+extern const struct bt_mesh_model root_models[];
+extern const struct bt_mesh_model vnd_models[];
+extern const struct bt_mesh_model s0_models[];
 
 extern const struct bt_mesh_comp comp;
 
-void gen_onoff_publish(struct bt_mesh_model *model);
-void gen_level_publish(struct bt_mesh_model *model);
-void light_lightness_publish(struct bt_mesh_model *model);
-void light_lightness_linear_publish(struct bt_mesh_model *model);
-void light_ctl_publish(struct bt_mesh_model *model);
-void light_ctl_temp_publish(struct bt_mesh_model *model);
-void gen_level_publish_temp(struct bt_mesh_model *model);
+void gen_onoff_publish(const struct bt_mesh_model *model);
+void gen_level_publish(const struct bt_mesh_model *model);
+void light_lightness_publish(const struct bt_mesh_model *model);
+void light_lightness_linear_publish(const struct bt_mesh_model *model);
+void light_ctl_publish(const struct bt_mesh_model *model);
+void light_ctl_temp_publish(const struct bt_mesh_model *model);
+void gen_level_publish_temp(const struct bt_mesh_model *model);
 
 #endif

--- a/samples/boards/reel_board/mesh_badge/src/mesh.c
+++ b/samples/boards/reel_board/mesh_badge/src/mesh.c
@@ -159,12 +159,12 @@ static struct bt_mesh_cfg_cli cfg_cli = {
 	.cb = &cfg_cli_cb,
 };
 
-static void attention_on(struct bt_mesh_model *model)
+static void attention_on(const struct bt_mesh_model *model)
 {
 	board_show_text("Attention!", false, K_SECONDS(2));
 }
 
-static void attention_off(struct bt_mesh_model *model)
+static void attention_off(const struct bt_mesh_model *model)
 {
 	board_refresh_display();
 }
@@ -179,7 +179,7 @@ static struct bt_mesh_health_srv health_srv = {
 };
 
 /* Generic OnOff Server message handlers */
-static int gen_onoff_get(struct bt_mesh_model *model,
+static int gen_onoff_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -198,7 +198,7 @@ static int gen_onoff_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set_unack(struct bt_mesh_model *model,
+static int gen_onoff_set_unack(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -263,7 +263,7 @@ static int gen_onoff_set_unack(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gen_onoff_set(struct bt_mesh_model *model,
+static int gen_onoff_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -273,7 +273,7 @@ static int gen_onoff_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int sensor_desc_get(struct bt_mesh_model *model,
+static int sensor_desc_get(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -333,7 +333,7 @@ static void sensor_create_status(uint16_t id, struct net_buf_simple *msg)
 	}
 }
 
-static int sensor_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int sensor_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, 1 + MAX_SENS_STATUS_LEN + 4);
@@ -349,7 +349,7 @@ static int sensor_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int sensor_col_get(struct bt_mesh_model *model,
+static int sensor_col_get(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -357,7 +357,7 @@ static int sensor_col_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int sensor_series_get(struct bt_mesh_model *model,
+static int sensor_series_get(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -385,7 +385,7 @@ static const struct bt_mesh_model_op sensor_srv_op[] = {
 	{ BT_MESH_MODEL_OP_SENS_SERIES_GET, BT_MESH_LEN_EXACT(2), sensor_series_get },
 };
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
@@ -396,7 +396,7 @@ static struct bt_mesh_model root_models[] = {
 		      sensor_srv_op, NULL, NULL),
 };
 
-static int vnd_hello(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int vnd_hello(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		     struct net_buf_simple *buf)
 {
 	char str[32];
@@ -423,7 +423,7 @@ static int vnd_hello(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int vnd_baduser(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int vnd_baduser(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	char str[32];
@@ -448,7 +448,7 @@ static int vnd_baduser(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int vnd_heartbeat(struct bt_mesh_model *model,
+static int vnd_heartbeat(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -477,7 +477,7 @@ static const struct bt_mesh_model_op vnd_ops[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int pub_update(struct bt_mesh_model *mod)
+static int pub_update(const struct bt_mesh_model *mod)
 {
 	struct net_buf_simple *msg = mod->pub->msg;
 
@@ -491,7 +491,7 @@ static int pub_update(struct bt_mesh_model *mod)
 
 BT_MESH_MODEL_PUB_DEFINE(vnd_pub, pub_update, 3 + 1);
 
-static struct bt_mesh_model vnd_models[] = {
+static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, MOD_LF, vnd_ops, &vnd_pub, NULL),
 };
 

--- a/subsys/bluetooth/host/testing.c
+++ b/subsys/bluetooth/host/testing.c
@@ -56,7 +56,7 @@ void bt_test_mesh_model_recv(uint16_t src, uint16_t dst, const void *payload,
 	}
 }
 
-void bt_test_mesh_model_bound(uint16_t addr, struct bt_mesh_model *model,
+void bt_test_mesh_model_bound(uint16_t addr, const struct bt_mesh_model *model,
 			      uint16_t key_idx)
 {
 	struct bt_test_cb *cb;
@@ -68,7 +68,7 @@ void bt_test_mesh_model_bound(uint16_t addr, struct bt_mesh_model *model,
 	}
 }
 
-void bt_test_mesh_model_unbound(uint16_t addr, struct bt_mesh_model *model,
+void bt_test_mesh_model_unbound(uint16_t addr, const struct bt_mesh_model *model,
 				uint16_t key_idx)
 {
 	struct bt_test_cb *cb;

--- a/subsys/bluetooth/host/testing.h
+++ b/subsys/bluetooth/host/testing.h
@@ -14,9 +14,9 @@ void bt_test_mesh_net_recv(uint8_t ttl, uint8_t ctl, uint16_t src, uint16_t dst,
 			   const void *payload, size_t payload_len);
 void bt_test_mesh_model_recv(uint16_t src, uint16_t dst, const void *payload,
 			     size_t payload_len);
-void bt_test_mesh_model_bound(uint16_t addr, struct bt_mesh_model *model,
+void bt_test_mesh_model_bound(uint16_t addr, const struct bt_mesh_model *model,
 			      uint16_t key_idx);
-void bt_test_mesh_model_unbound(uint16_t addr, struct bt_mesh_model *model,
+void bt_test_mesh_model_unbound(uint16_t addr, const struct bt_mesh_model *model,
 				uint16_t key_idx);
 void bt_test_mesh_prov_invalid_bearer(uint8_t opcode);
 void bt_test_mesh_trans_incomp_timer_exp(void);

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -91,16 +91,16 @@ static struct mod_relation mod_rel_list[MOD_REL_LIST_SIZE];
 		 (idx)++)
 
 #define IS_MOD_BASE(mod, idx) \
-	(mod_rel_list[(idx)].elem_base == (mod)->elem_idx && \
-	 mod_rel_list[(idx)].idx_base == (mod)->mod_idx &&   \
-	 !(mod_rel_list[(idx)].elem_ext != (mod)->elem_idx && \
-	   mod_rel_list[(idx)].idx_ext != (mod)->mod_idx))
+	(mod_rel_list[(idx)].elem_base == (mod)->ctx->elem_idx && \
+	 mod_rel_list[(idx)].idx_base == (mod)->ctx->mod_idx &&   \
+	 !(mod_rel_list[(idx)].elem_ext != (mod)->ctx->elem_idx && \
+	   mod_rel_list[(idx)].idx_ext != (mod)->ctx->mod_idx))
 
 #define IS_MOD_EXTENSION(mod, idx) \
-	 (mod_rel_list[(idx)].elem_ext == (mod)->elem_idx && \
-	  mod_rel_list[(idx)].idx_ext == (mod)->mod_idx &&   \
-	  !(mod_rel_list[(idx)].elem_base != (mod)->elem_idx && \
-	    mod_rel_list[(idx)].idx_base != (mod)->mod_idx))
+	 (mod_rel_list[(idx)].elem_ext == (mod)->ctx->elem_idx && \
+	  mod_rel_list[(idx)].idx_ext == (mod)->ctx->mod_idx &&   \
+	  !(mod_rel_list[(idx)].elem_base != (mod)->ctx->elem_idx && \
+	    mod_rel_list[(idx)].idx_base != (mod)->ctx->mod_idx))
 
 #define RELATION_TYPE_EXT 0xFF
 
@@ -114,7 +114,7 @@ static const struct {
 #endif
 };
 
-void bt_mesh_model_foreach(void (*func)(struct bt_mesh_model *mod,
+void bt_mesh_model_foreach(void (*func)(const struct bt_mesh_model *mod,
 					struct bt_mesh_elem *elem,
 					bool vnd, bool primary,
 					void *user_data),
@@ -126,13 +126,13 @@ void bt_mesh_model_foreach(void (*func)(struct bt_mesh_model *mod,
 		struct bt_mesh_elem *elem = &dev_comp->elem[i];
 
 		for (j = 0; j < elem->model_count; j++) {
-			struct bt_mesh_model *model = &elem->models[j];
+			const struct bt_mesh_model *model = &elem->models[j];
 
 			func(model, elem, false, i == 0, user_data);
 		}
 
 		for (j = 0; j < elem->vnd_model_count; j++) {
-			struct bt_mesh_model *model = &elem->vnd_models[j];
+			const struct bt_mesh_model *model = &elem->vnd_models[j];
 
 			func(model, elem, true, i == 0, user_data);
 		}
@@ -169,7 +169,7 @@ static void data_buf_add_le16_offset(struct net_buf_simple *buf,
 	}
 }
 
-static void comp_add_model(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void comp_add_model(const struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 			   bool vnd, void *user_data)
 {
 	struct comp_foreach_model_arg *arg = user_data;
@@ -198,7 +198,7 @@ static void data_buf_add_mem_offset(struct net_buf_simple *buf,
 	}
 }
 
-static size_t metadata_model_size(struct bt_mesh_model *mod,
+static size_t metadata_model_size(const struct bt_mesh_model *mod,
 				  struct bt_mesh_elem *elem, bool vnd)
 {
 	const struct bt_mesh_models_metadata_entry *entry;
@@ -239,13 +239,13 @@ size_t bt_mesh_metadata_page_0_size(void)
 			sizeof(elem->vnd_model_count);
 
 		for (j = 0; j < elem->model_count; j++) {
-			struct bt_mesh_model *model = &elem->models[j];
+			const struct bt_mesh_model *model = &elem->models[j];
 
 			size += metadata_model_size(model, elem, false);
 		}
 
 		for (j = 0; j < elem->vnd_model_count; j++) {
-			struct bt_mesh_model *model = &elem->vnd_models[j];
+			const struct bt_mesh_model *model = &elem->vnd_models[j];
 
 			size += metadata_model_size(model, elem, true);
 		}
@@ -254,7 +254,7 @@ size_t bt_mesh_metadata_page_0_size(void)
 	return size;
 }
 
-static int metadata_add_model(struct bt_mesh_model *mod,
+static int metadata_add_model(const struct bt_mesh_model *mod,
 			      struct bt_mesh_elem *elem, bool vnd,
 			      void *user_data)
 {
@@ -324,7 +324,7 @@ int bt_mesh_metadata_get_page_0(struct net_buf_simple *buf, size_t offset)
 		vnd_count_ptr = data_buf_add_u8_offset(buf, 0, &offset);
 
 		for (j = 0; j < elem->model_count; j++) {
-			struct bt_mesh_model *model = &elem->models[j];
+			const struct bt_mesh_model *model = &elem->models[j];
 
 			if (!model->metadata) {
 				continue;
@@ -341,7 +341,7 @@ int bt_mesh_metadata_get_page_0(struct net_buf_simple *buf, size_t offset)
 		}
 
 		for (j = 0; j < elem->vnd_model_count; j++) {
-			struct bt_mesh_model *model = &elem->vnd_models[j];
+			const struct bt_mesh_model *model = &elem->vnd_models[j];
 
 			if (!model->metadata) {
 				continue;
@@ -415,13 +415,13 @@ static int comp_add_elem(struct net_buf_simple *buf, struct bt_mesh_elem *elem,
 	data_buf_add_u8_offset(buf, elem->vnd_model_count, offset);
 
 	for (i = 0; i < elem->model_count; i++) {
-		struct bt_mesh_model *model = &elem->models[i];
+		const struct bt_mesh_model *model = &elem->models[i];
 
 		comp_add_model(model, elem, false, &arg);
 	}
 
 	for (i = 0; i < elem->vnd_model_count; i++) {
-		struct bt_mesh_model *model = &elem->vnd_models[i];
+		const struct bt_mesh_model *model = &elem->vnd_models[i];
 
 		comp_add_model(model, elem, true, &arg);
 	}
@@ -471,7 +471,7 @@ int bt_mesh_comp_data_get_page_0(struct net_buf_simple *buf, size_t offset)
 	return 0;
 }
 
-static uint8_t count_mod_ext(struct bt_mesh_model *mod, uint8_t *max_offset)
+static uint8_t count_mod_ext(const struct bt_mesh_model *mod, uint8_t *max_offset)
 {
 	int i;
 	uint8_t extensions = 0;
@@ -495,7 +495,7 @@ static uint8_t count_mod_ext(struct bt_mesh_model *mod, uint8_t *max_offset)
 	return extensions;
 }
 
-static bool is_cor_present(struct bt_mesh_model *mod, uint8_t *cor_id)
+static bool is_cor_present(const struct bt_mesh_model *mod, uint8_t *cor_id)
 {
 	int i;
 
@@ -512,7 +512,7 @@ static bool is_cor_present(struct bt_mesh_model *mod, uint8_t *cor_id)
 	return false;
 }
 
-static void prep_model_item_header(struct bt_mesh_model *mod, uint8_t *cor_id,
+static void prep_model_item_header(const struct bt_mesh_model *mod, uint8_t *cor_id,
 			    uint8_t *mod_cnt, struct net_buf_simple *buf)
 {
 	uint8_t ext_mod_cnt;
@@ -540,7 +540,7 @@ static void prep_model_item_header(struct bt_mesh_model *mod, uint8_t *cor_id,
 	memset(mod_cnt, ext_mod_cnt, sizeof(uint8_t));
 }
 
-static void add_items_to_page(struct net_buf_simple *buf, struct bt_mesh_model *mod,
+static void add_items_to_page(struct net_buf_simple *buf, const struct bt_mesh_model *mod,
 		       uint8_t ext_mod_cnt)
 {
 	int i, offset;
@@ -548,7 +548,7 @@ static void add_items_to_page(struct net_buf_simple *buf, struct bt_mesh_model *
 
 	MOD_REL_LIST_FOR_EACH(i) {
 		if (IS_MOD_EXTENSION(mod, i)) {
-			offset = mod->elem_idx - mod_rel_list[i].elem_base;
+			offset = mod->ctx->elem_idx - mod_rel_list[i].elem_base;
 			mod_idx = mod_rel_list[i].idx_base;
 			if (ext_mod_cnt < 32 &&
 				offset < 4 &&
@@ -572,7 +572,7 @@ static void add_items_to_page(struct net_buf_simple *buf, struct bt_mesh_model *
 	}
 }
 
-static size_t mod_items_size(struct bt_mesh_model *mod)
+static size_t mod_items_size(const struct bt_mesh_model *mod)
 {
 	int i, offset;
 	size_t temp_size = 0;
@@ -584,7 +584,7 @@ static size_t mod_items_size(struct bt_mesh_model *mod)
 
 	MOD_REL_LIST_FOR_EACH(i) {
 		if (IS_MOD_EXTENSION(mod, i)) {
-			offset = mod->elem_idx - mod_rel_list[i].elem_base;
+			offset = mod->ctx->elem_idx - mod_rel_list[i].elem_base;
 			temp_size += (ext_mod_cnt < 32 && offset < 4 && offset > -5) ? 1 : 2;
 		}
 	}
@@ -660,7 +660,7 @@ int bt_mesh_comp_data_get_page_1(struct net_buf_simple *buf)
 	return 0;
 }
 
-int32_t bt_mesh_model_pub_period_get(struct bt_mesh_model *mod)
+int32_t bt_mesh_model_pub_period_get(const struct bt_mesh_model *mod)
 {
 	int32_t period;
 
@@ -700,7 +700,7 @@ int32_t bt_mesh_model_pub_period_get(struct bt_mesh_model *mod)
 	}
 }
 
-static int32_t next_period(struct bt_mesh_model *mod)
+static int32_t next_period(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_model_pub *pub = mod->pub;
 	uint32_t period = 0;
@@ -741,7 +741,7 @@ static int32_t next_period(struct bt_mesh_model *mod)
 
 static void publish_sent(int err, void *user_data)
 {
-	struct bt_mesh_model *mod = user_data;
+	const struct bt_mesh_model *mod = user_data;
 	int32_t delay;
 
 	LOG_DBG("err %d, time %u", err, k_uptime_get_32());
@@ -771,7 +771,7 @@ static const struct bt_mesh_send_cb pub_sent_cb = {
 	.end = publish_sent,
 };
 
-static int publish_transmit(struct bt_mesh_model *mod)
+static int publish_transmit(const struct bt_mesh_model *mod)
 {
 	NET_BUF_SIMPLE_DEFINE(sdu, BT_MESH_TX_SDU_MAX);
 	struct bt_mesh_model_pub *pub = mod->pub;
@@ -784,7 +784,7 @@ static int publish_transmit(struct bt_mesh_model *mod)
 
 	net_buf_simple_add_mem(&sdu, pub->msg->data, pub->msg->len);
 
-	return bt_mesh_trans_send(&tx, &sdu, &pub_sent_cb, mod);
+	return bt_mesh_trans_send(&tx, &sdu, &pub_sent_cb, (void *)mod);
 }
 
 static int pub_period_start(struct bt_mesh_model_pub *pub)
@@ -805,7 +805,7 @@ static int pub_period_start(struct bt_mesh_model_pub *pub)
 		/* Skip this publish attempt. */
 		LOG_DBG("Update failed, skipping publish (err: %d)", err);
 		pub->count = 0;
-		publish_sent(err, pub->mod);
+		publish_sent(err, (void *)pub->mod);
 		return err;
 	}
 
@@ -837,7 +837,7 @@ static void mod_publish(struct k_work *work)
 		    bt_mesh_model_pub_is_retransmission(pub->mod)) {
 			err = pub->update(pub->mod);
 			if (err) {
-				publish_sent(err, pub->mod);
+				publish_sent(err, (void *)pub->mod);
 				return;
 			}
 		}
@@ -852,16 +852,16 @@ static void mod_publish(struct k_work *work)
 	err = publish_transmit(pub->mod);
 	if (err) {
 		LOG_ERR("Failed to publish (err %d)", err);
-		publish_sent(err, pub->mod);
+		publish_sent(err, (void *)pub->mod);
 	}
 }
 
-struct bt_mesh_elem *bt_mesh_model_elem(struct bt_mesh_model *mod)
+struct bt_mesh_elem *bt_mesh_model_elem(const struct bt_mesh_model *mod)
 {
-	return &dev_comp->elem[mod->elem_idx];
+	return &dev_comp->elem[mod->ctx->elem_idx];
 }
 
-struct bt_mesh_model *bt_mesh_model_get(bool vnd, uint8_t elem_idx, uint8_t mod_idx)
+const struct bt_mesh_model *bt_mesh_model_get(bool vnd, uint8_t elem_idx, uint8_t mod_idx)
 {
 	struct bt_mesh_elem *elem;
 
@@ -890,7 +890,7 @@ struct bt_mesh_model *bt_mesh_model_get(bool vnd, uint8_t elem_idx, uint8_t mod_
 }
 
 #if defined(CONFIG_BT_MESH_MODEL_VND_MSG_CID_FORCE)
-static int bt_mesh_vnd_mod_msg_cid_check(struct bt_mesh_model *mod)
+static int bt_mesh_vnd_mod_msg_cid_check(const struct bt_mesh_model *mod)
 {
 	uint16_t cid;
 	const struct bt_mesh_model_op *op;
@@ -913,7 +913,7 @@ static int bt_mesh_vnd_mod_msg_cid_check(struct bt_mesh_model *mod)
 }
 #endif
 
-static void mod_init(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void mod_init(const struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 		     bool vnd, bool primary, void *user_data)
 {
 	int i;
@@ -932,9 +932,9 @@ static void mod_init(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 		mod->keys[i] = BT_MESH_KEY_UNUSED;
 	}
 
-	mod->elem_idx = elem - dev_comp->elem;
+	mod->ctx->elem_idx = elem - dev_comp->elem;
 	if (vnd) {
-		mod->mod_idx = mod - elem->vnd_models;
+		mod->ctx->mod_idx = mod - elem->vnd_models;
 
 		if (IS_ENABLED(CONFIG_BT_MESH_MODEL_VND_MSG_CID_FORCE)) {
 			*err = bt_mesh_vnd_mod_msg_cid_check(mod);
@@ -944,7 +944,7 @@ static void mod_init(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 		}
 
 	} else {
-		mod->mod_idx = mod - elem->models;
+		mod->ctx->mod_idx = mod - elem->models;
 	}
 
 	if (mod->cb && mod->cb->init) {
@@ -1030,7 +1030,7 @@ uint16_t bt_mesh_primary_addr(void)
 	return dev_primary_addr;
 }
 
-static uint16_t *model_group_get(struct bt_mesh_model *mod, uint16_t addr)
+static uint16_t *model_group_get(const struct bt_mesh_model *mod, uint16_t addr)
 {
 	int i;
 
@@ -1045,15 +1045,15 @@ static uint16_t *model_group_get(struct bt_mesh_model *mod, uint16_t addr)
 
 struct find_group_visitor_ctx {
 	uint16_t *entry;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	uint16_t addr;
 };
 
-static enum bt_mesh_walk find_group_mod_visitor(struct bt_mesh_model *mod, void *user_data)
+static enum bt_mesh_walk find_group_mod_visitor(const struct bt_mesh_model *mod, void *user_data)
 {
 	struct find_group_visitor_ctx *ctx = user_data;
 
-	if (mod->elem_idx != ctx->mod->elem_idx) {
+	if (mod->ctx->elem_idx != ctx->mod->ctx->elem_idx) {
 		return BT_MESH_WALK_CONTINUE;
 	}
 
@@ -1066,7 +1066,7 @@ static enum bt_mesh_walk find_group_mod_visitor(struct bt_mesh_model *mod, void 
 	return BT_MESH_WALK_CONTINUE;
 }
 
-uint16_t *bt_mesh_model_find_group(struct bt_mesh_model **mod, uint16_t addr)
+uint16_t *bt_mesh_model_find_group(const struct bt_mesh_model **mod, uint16_t addr)
 {
 	struct find_group_visitor_ctx ctx = {
 		.mod = *mod,
@@ -1081,7 +1081,7 @@ uint16_t *bt_mesh_model_find_group(struct bt_mesh_model **mod, uint16_t addr)
 }
 
 #if CONFIG_BT_MESH_LABEL_COUNT > 0
-static const uint8_t **model_uuid_get(struct bt_mesh_model *mod, const uint8_t *uuid)
+static const uint8_t **model_uuid_get(const struct bt_mesh_model *mod, const uint8_t *uuid)
 {
 	int i;
 
@@ -1103,15 +1103,15 @@ static const uint8_t **model_uuid_get(struct bt_mesh_model *mod, const uint8_t *
 
 struct find_uuid_visitor_ctx {
 	const uint8_t **entry;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	const uint8_t *uuid;
 };
 
-static enum bt_mesh_walk find_uuid_mod_visitor(struct bt_mesh_model *mod, void *user_data)
+static enum bt_mesh_walk find_uuid_mod_visitor(const struct bt_mesh_model *mod, void *user_data)
 {
 	struct find_uuid_visitor_ctx *ctx = user_data;
 
-	if (mod->elem_idx != ctx->mod->elem_idx) {
+	if (mod->ctx->elem_idx != ctx->mod->ctx->elem_idx) {
 		return BT_MESH_WALK_CONTINUE;
 	}
 
@@ -1125,7 +1125,7 @@ static enum bt_mesh_walk find_uuid_mod_visitor(struct bt_mesh_model *mod, void *
 }
 #endif /* CONFIG_BT_MESH_LABEL_COUNT > 0 */
 
-const uint8_t **bt_mesh_model_find_uuid(struct bt_mesh_model **mod, const uint8_t *uuid)
+const uint8_t **bt_mesh_model_find_uuid(const struct bt_mesh_model **mod, const uint8_t *uuid)
 {
 #if CONFIG_BT_MESH_LABEL_COUNT > 0
 	struct find_uuid_visitor_ctx ctx = {
@@ -1143,10 +1143,10 @@ const uint8_t **bt_mesh_model_find_uuid(struct bt_mesh_model **mod, const uint8_
 #endif
 }
 
-static struct bt_mesh_model *bt_mesh_elem_find_group(struct bt_mesh_elem *elem,
+static const struct bt_mesh_model *bt_mesh_elem_find_group(struct bt_mesh_elem *elem,
 						     uint16_t group_addr)
 {
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 	uint16_t *match;
 	int i;
 
@@ -1243,7 +1243,7 @@ uint8_t bt_mesh_elem_count(void)
 	return dev_comp->elem_count;
 }
 
-bool bt_mesh_model_has_key(struct bt_mesh_model *mod, uint16_t key)
+bool bt_mesh_model_has_key(const struct bt_mesh_model *mod, uint16_t key)
 {
 	int i;
 
@@ -1258,14 +1258,14 @@ bool bt_mesh_model_has_key(struct bt_mesh_model *mod, uint16_t key)
 	return false;
 }
 
-static bool model_has_dst(struct bt_mesh_model *mod, uint16_t dst, const uint8_t *uuid)
+static bool model_has_dst(const struct bt_mesh_model *mod, uint16_t dst, const uint8_t *uuid)
 {
 	if (BT_MESH_ADDR_IS_UNICAST(dst)) {
-		return (dev_comp->elem[mod->elem_idx].addr == dst);
+		return (dev_comp->elem[mod->ctx->elem_idx].addr == dst);
 	} else if (BT_MESH_ADDR_IS_VIRTUAL(dst)) {
 		return !!bt_mesh_model_find_uuid(&mod, uuid);
 	} else if (BT_MESH_ADDR_IS_GROUP(dst) ||
-		  (BT_MESH_ADDR_IS_FIXED_GROUP(dst) &&  mod->elem_idx != 0)) {
+		  (BT_MESH_ADDR_IS_FIXED_GROUP(dst) &&  mod->ctx->elem_idx != 0)) {
 		return !!bt_mesh_model_find_group(&mod, dst);
 	}
 
@@ -1273,17 +1273,17 @@ static bool model_has_dst(struct bt_mesh_model *mod, uint16_t dst, const uint8_t
 	 * the lower layers have already confirmed that we are subscribing to
 	 * it. All models on the primary element should receive the message.
 	 */
-	return mod->elem_idx == 0;
+	return mod->ctx->elem_idx == 0;
 }
 
 static const struct bt_mesh_model_op *find_op(struct bt_mesh_elem *elem,
-					      uint32_t opcode, struct bt_mesh_model **model)
+					      uint32_t opcode, const struct bt_mesh_model **model)
 {
 	uint8_t i;
 	uint8_t count;
 	/* This value shall not be used in shipping end products. */
 	uint32_t cid = UINT32_MAX;
-	struct bt_mesh_model *models;
+	const struct bt_mesh_model *models;
 
 	/* SIG models cannot contain 3-byte (vendor) OpCodes, and
 	 * vendor models cannot contain SIG (1- or 2-byte) OpCodes, so
@@ -1364,7 +1364,7 @@ static int element_model_recv(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple
 			      struct bt_mesh_elem *elem, uint32_t opcode)
 {
 	const struct bt_mesh_model_op *op;
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 	struct net_buf_simple_state state;
 	int err;
 
@@ -1450,7 +1450,7 @@ int bt_mesh_model_recv(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
 	return err;
 }
 
-int bt_mesh_model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_model_send(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *msg,
 		       const struct bt_mesh_send_cb *cb, void *cb_data)
 {
@@ -1466,7 +1466,7 @@ int bt_mesh_model_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return bt_mesh_access_send(ctx, msg, bt_mesh_model_elem(model)->addr, cb, cb_data);
 }
 
-int bt_mesh_model_publish(struct bt_mesh_model *model)
+int bt_mesh_model_publish(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_model_pub *pub = model->pub;
 
@@ -1506,7 +1506,7 @@ int bt_mesh_model_publish(struct bt_mesh_model *model)
 	return 0;
 }
 
-struct bt_mesh_model *bt_mesh_model_find_vnd(const struct bt_mesh_elem *elem,
+const struct bt_mesh_model *bt_mesh_model_find_vnd(const struct bt_mesh_elem *elem,
 					     uint16_t company, uint16_t id)
 {
 	uint8_t i;
@@ -1521,7 +1521,7 @@ struct bt_mesh_model *bt_mesh_model_find_vnd(const struct bt_mesh_elem *elem,
 	return NULL;
 }
 
-struct bt_mesh_model *bt_mesh_model_find(const struct bt_mesh_elem *elem,
+const struct bt_mesh_model *bt_mesh_model_find(const struct bt_mesh_elem *elem,
 					 uint16_t id)
 {
 	uint8_t i;
@@ -1540,8 +1540,8 @@ const struct bt_mesh_comp *bt_mesh_comp_get(void)
 	return dev_comp;
 }
 
-void bt_mesh_model_extensions_walk(struct bt_mesh_model *model,
-				   enum bt_mesh_walk (*cb)(struct bt_mesh_model *mod,
+void bt_mesh_model_extensions_walk(const struct bt_mesh_model *model,
+				   enum bt_mesh_walk (*cb)(const struct bt_mesh_model *mod,
 							   void *user_data),
 				   void *user_data)
 {
@@ -1549,14 +1549,14 @@ void bt_mesh_model_extensions_walk(struct bt_mesh_model *model,
 	(void)cb(model, user_data);
 	return;
 #else
-	struct bt_mesh_model *it;
+	const struct bt_mesh_model *it;
 
-	if (cb(model, user_data) == BT_MESH_WALK_STOP || !model->next) {
+	if (cb(model, user_data) == BT_MESH_WALK_STOP || !model->ctx->next) {
 		return;
 	}
 
 	/* List is circular. Step through all models until we reach the start: */
-	for (it = model->next; it != model; it = it->next) {
+	for (it = model->ctx->next; it != model; it = it->ctx->next) {
 		if (cb(it, user_data) == BT_MESH_WALK_STOP) {
 			return;
 		}
@@ -1565,16 +1565,16 @@ void bt_mesh_model_extensions_walk(struct bt_mesh_model *model,
 }
 
 #ifdef CONFIG_BT_MESH_MODEL_EXTENSIONS
-static int mod_rel_register(struct bt_mesh_model *base,
-				 struct bt_mesh_model *ext,
+static int mod_rel_register(const struct bt_mesh_model *base,
+				 const struct bt_mesh_model *ext,
 				 uint8_t type)
 {
 	LOG_DBG("");
 	struct mod_relation extension = {
-		base->elem_idx,
-		base->mod_idx,
-		ext->elem_idx,
-		ext->mod_idx,
+		base->ctx->elem_idx,
+		base->ctx->mod_idx,
+		ext->ctx->elem_idx,
+		ext->ctx->mod_idx,
 		type,
 	};
 	int i;
@@ -1593,22 +1593,23 @@ static int mod_rel_register(struct bt_mesh_model *base,
 	return -ENOMEM;
 }
 
-int bt_mesh_model_extend(struct bt_mesh_model *extending_mod, struct bt_mesh_model *base_mod)
+int bt_mesh_model_extend(const struct bt_mesh_model *extending_mod,
+			 const struct bt_mesh_model *base_mod)
 {
-	struct bt_mesh_model *a = extending_mod;
-	struct bt_mesh_model *b = base_mod;
-	struct bt_mesh_model *a_next = a->next;
-	struct bt_mesh_model *b_next = b->next;
-	struct bt_mesh_model *it;
+	const struct bt_mesh_model *a = extending_mod;
+	const struct bt_mesh_model *b = base_mod;
+	const struct bt_mesh_model *a_next = a->ctx->next;
+	const struct bt_mesh_model *b_next = b->ctx->next;
+	const struct bt_mesh_model *it;
 
-	base_mod->flags |= BT_MESH_MOD_EXTENDED;
+	base_mod->ctx->flags |= BT_MESH_MOD_EXTENDED;
 
 	if (a == b) {
 		return 0;
 	}
 
 	/* Check if a's list contains b */
-	for (it = a; (it != NULL) && (it->next != a); it = it->next) {
+	for (it = a; (it != NULL) && (it->ctx->next != a); it = it->ctx->next) {
 		if (it == b) {
 			return 0;
 		}
@@ -1616,15 +1617,15 @@ int bt_mesh_model_extend(struct bt_mesh_model *extending_mod, struct bt_mesh_mod
 
 	/* Merge lists */
 	if (a_next) {
-		b->next = a_next;
+		b->ctx->next = a_next;
 	} else {
-		b->next = a;
+		b->ctx->next = a;
 	}
 
 	if (b_next) {
-		a->next = b_next;
+		a->ctx->next = b_next;
 	} else {
-		a->next = b;
+		a->ctx->next = b;
 	}
 
 
@@ -1635,8 +1636,8 @@ int bt_mesh_model_extend(struct bt_mesh_model *extending_mod, struct bt_mesh_mod
 	return 0;
 }
 
-int bt_mesh_model_correspond(struct bt_mesh_model *corresponding_mod,
-			     struct bt_mesh_model *base_mod)
+int bt_mesh_model_correspond(const struct bt_mesh_model *corresponding_mod,
+			     const struct bt_mesh_model *base_mod)
 {
 	int i, err;
 	uint8_t cor_id = 0;
@@ -1667,12 +1668,12 @@ int bt_mesh_model_correspond(struct bt_mesh_model *corresponding_mod,
 }
 #endif /* CONFIG_BT_MESH_MODEL_EXTENSIONS */
 
-bool bt_mesh_model_is_extended(struct bt_mesh_model *model)
+bool bt_mesh_model_is_extended(const struct bt_mesh_model *model)
 {
-	return model->flags & BT_MESH_MOD_EXTENDED;
+	return model->ctx->flags & BT_MESH_MOD_EXTENDED;
 }
 
-static int mod_set_bind(struct bt_mesh_model *mod, size_t len_rd,
+static int mod_set_bind(const struct bt_mesh_model *mod, size_t len_rd,
 			settings_read_cb read_cb, void *cb_arg)
 {
 	ssize_t len;
@@ -1700,7 +1701,7 @@ static int mod_set_bind(struct bt_mesh_model *mod, size_t len_rd,
 	return 0;
 }
 
-static int mod_set_sub(struct bt_mesh_model *mod, size_t len_rd,
+static int mod_set_sub(const struct bt_mesh_model *mod, size_t len_rd,
 		       settings_read_cb read_cb, void *cb_arg)
 {
 	size_t size = mod->groups_cnt * sizeof(mod->groups[0]);
@@ -1747,7 +1748,7 @@ static int mod_set_sub(struct bt_mesh_model *mod, size_t len_rd,
 	return 0;
 }
 
-static int mod_set_sub_va(struct bt_mesh_model *mod, size_t len_rd,
+static int mod_set_sub_va(const struct bt_mesh_model *mod, size_t len_rd,
 			  settings_read_cb read_cb, void *cb_arg)
 {
 #if CONFIG_BT_MESH_LABEL_COUNT > 0
@@ -1784,7 +1785,7 @@ static int mod_set_sub_va(struct bt_mesh_model *mod, size_t len_rd,
 	return 0;
 }
 
-static int mod_set_pub(struct bt_mesh_model *mod, size_t len_rd,
+static int mod_set_pub(const struct bt_mesh_model *mod, size_t len_rd,
 		       settings_read_cb read_cb, void *cb_arg)
 {
 	struct mod_pub_val pub;
@@ -1854,7 +1855,7 @@ pub_base_set:
 	return 0;
 }
 
-static int mod_data_set(struct bt_mesh_model *mod,
+static int mod_data_set(const struct bt_mesh_model *mod,
 			const char *name, size_t len_rd,
 			settings_read_cb read_cb, void *cb_arg)
 {
@@ -1873,7 +1874,7 @@ static int mod_data_set(struct bt_mesh_model *mod,
 static int mod_set(bool vnd, const char *name, size_t len_rd,
 		   settings_read_cb read_cb, void *cb_arg)
 {
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	uint8_t elem_idx, mod_idx;
 	uint16_t mod_key;
 	int len;
@@ -1962,10 +1963,10 @@ static int comp_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 }
 BT_MESH_SETTINGS_DEFINE(comp, "cmp", comp_set);
 
-static void encode_mod_path(struct bt_mesh_model *mod, bool vnd,
+static void encode_mod_path(const struct bt_mesh_model *mod, bool vnd,
 			    const char *key, char *path, size_t path_len)
 {
-	uint16_t mod_key = (((uint16_t)mod->elem_idx << 8) | mod->mod_idx);
+	uint16_t mod_key = (((uint16_t)mod->ctx->elem_idx << 8) | mod->ctx->mod_idx);
 
 	if (vnd) {
 		snprintk(path, path_len, "bt/mesh/v/%x/%s", mod_key, key);
@@ -1974,7 +1975,7 @@ static void encode_mod_path(struct bt_mesh_model *mod, bool vnd,
 	}
 }
 
-static void store_pending_mod_bind(struct bt_mesh_model *mod, bool vnd)
+static void store_pending_mod_bind(const struct bt_mesh_model *mod, bool vnd)
 {
 	uint16_t keys[CONFIG_BT_MESH_MODEL_KEY_COUNT];
 	char path[20];
@@ -2002,7 +2003,7 @@ static void store_pending_mod_bind(struct bt_mesh_model *mod, bool vnd)
 	}
 }
 
-static void store_pending_mod_sub(struct bt_mesh_model *mod, bool vnd)
+static void store_pending_mod_sub(const struct bt_mesh_model *mod, bool vnd)
 {
 	uint16_t groups[CONFIG_BT_MESH_MODEL_GROUP_COUNT];
 	char path[20];
@@ -2029,7 +2030,7 @@ static void store_pending_mod_sub(struct bt_mesh_model *mod, bool vnd)
 	}
 }
 
-static void store_pending_mod_sub_va(struct bt_mesh_model *mod, bool vnd)
+static void store_pending_mod_sub_va(const struct bt_mesh_model *mod, bool vnd)
 {
 #if CONFIG_BT_MESH_LABEL_COUNT > 0
 	uint16_t uuidxs[CONFIG_BT_MESH_LABEL_COUNT];
@@ -2061,7 +2062,7 @@ static void store_pending_mod_sub_va(struct bt_mesh_model *mod, bool vnd)
 #endif /* CONFIG_BT_MESH_LABEL_COUNT > 0 */
 }
 
-static void store_pending_mod_pub(struct bt_mesh_model *mod, bool vnd)
+static void store_pending_mod_pub(const struct bt_mesh_model *mod, bool vnd)
 {
 	struct mod_pub_val pub = {0};
 	char path[20];
@@ -2094,32 +2095,32 @@ static void store_pending_mod_pub(struct bt_mesh_model *mod, bool vnd)
 	}
 }
 
-static void store_pending_mod(struct bt_mesh_model *mod,
+static void store_pending_mod(const struct bt_mesh_model *mod,
 			      struct bt_mesh_elem *elem, bool vnd,
 			      bool primary, void *user_data)
 {
-	if (!mod->flags) {
+	if (!mod->ctx->flags) {
 		return;
 	}
 
-	if (mod->flags & BT_MESH_MOD_BIND_PENDING) {
-		mod->flags &= ~BT_MESH_MOD_BIND_PENDING;
+	if (mod->ctx->flags & BT_MESH_MOD_BIND_PENDING) {
+		mod->ctx->flags &= ~BT_MESH_MOD_BIND_PENDING;
 		store_pending_mod_bind(mod, vnd);
 	}
 
-	if (mod->flags & BT_MESH_MOD_SUB_PENDING) {
-		mod->flags &= ~BT_MESH_MOD_SUB_PENDING;
+	if (mod->ctx->flags & BT_MESH_MOD_SUB_PENDING) {
+		mod->ctx->flags &= ~BT_MESH_MOD_SUB_PENDING;
 		store_pending_mod_sub(mod, vnd);
 		store_pending_mod_sub_va(mod, vnd);
 	}
 
-	if (mod->flags & BT_MESH_MOD_PUB_PENDING) {
-		mod->flags &= ~BT_MESH_MOD_PUB_PENDING;
+	if (mod->ctx->flags & BT_MESH_MOD_PUB_PENDING) {
+		mod->ctx->flags &= ~BT_MESH_MOD_PUB_PENDING;
 		store_pending_mod_pub(mod, vnd);
 	}
 
-	if (mod->flags & BT_MESH_MOD_DATA_PENDING) {
-		mod->flags &= ~BT_MESH_MOD_DATA_PENDING;
+	if (mod->ctx->flags & BT_MESH_MOD_DATA_PENDING) {
+		mod->ctx->flags &= ~BT_MESH_MOD_DATA_PENDING;
 		mod->cb->pending_store(mod);
 	}
 }
@@ -2129,21 +2130,21 @@ void bt_mesh_model_pending_store(void)
 	bt_mesh_model_foreach(store_pending_mod, NULL);
 }
 
-void bt_mesh_model_bind_store(struct bt_mesh_model *mod)
+void bt_mesh_model_bind_store(const struct bt_mesh_model *mod)
 {
-	mod->flags |= BT_MESH_MOD_BIND_PENDING;
+	mod->ctx->flags |= BT_MESH_MOD_BIND_PENDING;
 	bt_mesh_settings_store_schedule(BT_MESH_SETTINGS_MOD_PENDING);
 }
 
-void bt_mesh_model_sub_store(struct bt_mesh_model *mod)
+void bt_mesh_model_sub_store(const struct bt_mesh_model *mod)
 {
-	mod->flags |= BT_MESH_MOD_SUB_PENDING;
+	mod->ctx->flags |= BT_MESH_MOD_SUB_PENDING;
 	bt_mesh_settings_store_schedule(BT_MESH_SETTINGS_MOD_PENDING);
 }
 
-void bt_mesh_model_pub_store(struct bt_mesh_model *mod)
+void bt_mesh_model_pub_store(const struct bt_mesh_model *mod)
 {
-	mod->flags |= BT_MESH_MOD_PUB_PENDING;
+	mod->ctx->flags |= BT_MESH_MOD_PUB_PENDING;
 	bt_mesh_settings_store_schedule(BT_MESH_SETTINGS_MOD_PENDING);
 }
 
@@ -2257,7 +2258,7 @@ int bt_mesh_comp_read(struct net_buf_simple *buf, uint8_t page)
 	return 0;
 }
 
-int bt_mesh_model_data_store(struct bt_mesh_model *mod, bool vnd,
+int bt_mesh_model_data_store(const struct bt_mesh_model *mod, bool vnd,
 			     const char *name, const void *data,
 			     size_t data_len)
 {
@@ -2406,7 +2407,7 @@ int bt_mesh_models_metadata_change_prepare(void)
 #endif
 }
 
-static void commit_mod(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void commit_mod(const struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 		       bool vnd, bool primary, void *user_data)
 {
 	if (mod->pub && mod->pub->update &&
@@ -2435,8 +2436,8 @@ void bt_mesh_model_settings_commit(void)
 	bt_mesh_model_foreach(commit_mod, NULL);
 }
 
-void bt_mesh_model_data_store_schedule(struct bt_mesh_model *mod)
+void bt_mesh_model_data_store_schedule(const struct bt_mesh_model *mod)
 {
-	mod->flags |= BT_MESH_MOD_DATA_PENDING;
+	mod->ctx->flags |= BT_MESH_MOD_DATA_PENDING;
 	bt_mesh_settings_store_schedule(BT_MESH_SETTINGS_MOD_PENDING);
 }

--- a/subsys/bluetooth/mesh/access.h
+++ b/subsys/bluetooth/mesh/access.h
@@ -33,23 +33,23 @@ int bt_mesh_comp_data_get_page_1(struct net_buf_simple *buf);
 struct bt_mesh_elem *bt_mesh_elem_find(uint16_t addr);
 
 bool bt_mesh_has_addr(uint16_t addr);
-bool bt_mesh_model_has_key(struct bt_mesh_model *mod, uint16_t key);
+bool bt_mesh_model_has_key(const struct bt_mesh_model *mod, uint16_t key);
 
-void bt_mesh_model_extensions_walk(struct bt_mesh_model *root,
-				   enum bt_mesh_walk (*cb)(struct bt_mesh_model *mod,
+void bt_mesh_model_extensions_walk(const struct bt_mesh_model *root,
+				   enum bt_mesh_walk (*cb)(const struct bt_mesh_model *mod,
 							   void *user_data),
 				   void *user_data);
 
-uint16_t *bt_mesh_model_find_group(struct bt_mesh_model **mod, uint16_t addr);
-const uint8_t **bt_mesh_model_find_uuid(struct bt_mesh_model **mod, const uint8_t *uuid);
+uint16_t *bt_mesh_model_find_group(const struct bt_mesh_model **mod, uint16_t addr);
+const uint8_t **bt_mesh_model_find_uuid(const struct bt_mesh_model **mod, const uint8_t *uuid);
 
-void bt_mesh_model_foreach(void (*func)(struct bt_mesh_model *mod,
+void bt_mesh_model_foreach(void (*func)(const struct bt_mesh_model *mod,
 					struct bt_mesh_elem *elem,
 					bool vnd, bool primary,
 					void *user_data),
 			   void *user_data);
 
-int32_t bt_mesh_model_pub_period_get(struct bt_mesh_model *mod);
+int32_t bt_mesh_model_pub_period_get(const struct bt_mesh_model *mod);
 
 void bt_mesh_comp_provision(uint16_t addr);
 void bt_mesh_comp_unprovision(void);
@@ -58,7 +58,7 @@ uint16_t bt_mesh_primary_addr(void);
 
 const struct bt_mesh_comp *bt_mesh_comp_get(void);
 
-struct bt_mesh_model *bt_mesh_model_get(bool vnd, uint8_t elem_idx, uint8_t mod_idx);
+const struct bt_mesh_model *bt_mesh_model_get(bool vnd, uint8_t elem_idx, uint8_t mod_idx);
 
 int bt_mesh_model_recv(struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf);
 
@@ -74,9 +74,9 @@ void bt_mesh_comp_data_clear(void);
 int bt_mesh_comp_data_get_page(struct net_buf_simple *buf, size_t page, size_t offset);
 
 void bt_mesh_model_pending_store(void);
-void bt_mesh_model_bind_store(struct bt_mesh_model *mod);
-void bt_mesh_model_sub_store(struct bt_mesh_model *mod);
-void bt_mesh_model_pub_store(struct bt_mesh_model *mod);
+void bt_mesh_model_bind_store(const struct bt_mesh_model *mod);
+void bt_mesh_model_sub_store(const struct bt_mesh_model *mod);
+void bt_mesh_model_pub_store(const struct bt_mesh_model *mod);
 void bt_mesh_model_settings_commit(void);
 
 /** @brief Register a callback function hook for mesh model messages.

--- a/subsys/bluetooth/mesh/blob_cli.c
+++ b/subsys/bluetooth/mesh/blob_cli.c
@@ -1204,7 +1204,7 @@ static void rx_block_status(struct bt_mesh_blob_cli *cli,
 	blob_cli_broadcast_rsp(cli, target);
 }
 
-static int handle_xfer_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_xfer_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_cli *cli = mod->user_data;
@@ -1276,7 +1276,7 @@ static int handle_xfer_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 	return 0;
 }
 
-static int handle_block_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_block_report(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_cli *cli = mod->user_data;
@@ -1330,7 +1330,7 @@ static int handle_block_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx
 	return 0;
 }
 
-static int handle_block_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_block_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_cli *cli = mod->user_data;
@@ -1401,7 +1401,7 @@ static int handle_block_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx
 	return 0;
 }
 
-static int handle_info_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_info_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_cli *cli = mod->user_data;
@@ -1458,7 +1458,7 @@ const struct bt_mesh_model_op _bt_mesh_blob_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int blob_cli_init(struct bt_mesh_model *mod)
+static int blob_cli_init(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_blob_cli *cli = mod->user_data;
 
@@ -1471,7 +1471,7 @@ static int blob_cli_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void blob_cli_reset(struct bt_mesh_model *mod)
+static void blob_cli_reset(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_blob_cli *cli = mod->user_data;
 

--- a/subsys/bluetooth/mesh/blob_srv.c
+++ b/subsys/bluetooth/mesh/blob_srv.c
@@ -382,7 +382,7 @@ static void block_status_rsp(struct bt_mesh_blob_srv *srv,
 	(void)bt_mesh_model_send(srv->mod, ctx, &buf, NULL, NULL);
 }
 
-static int handle_xfer_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_xfer_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
@@ -393,7 +393,7 @@ static int handle_xfer_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ct
 	return 0;
 }
 
-static int handle_xfer_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_xfer_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
@@ -524,7 +524,7 @@ rsp:
 	return 0;
 }
 
-static int handle_xfer_cancel(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_xfer_cancel(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	enum bt_mesh_blob_status status = BT_MESH_BLOB_SUCCESS;
@@ -552,7 +552,7 @@ rsp:
 	return 0;
 }
 
-static int handle_block_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_block_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
 	enum bt_mesh_blob_status status;
@@ -583,7 +583,7 @@ static int handle_block_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *c
 	return 0;
 }
 
-static int handle_block_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_block_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
@@ -678,7 +678,7 @@ rsp:
 	return 0;
 }
 
-static int handle_chunk(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_chunk(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
@@ -768,7 +768,7 @@ static int handle_chunk(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int handle_info_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_info_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
@@ -805,7 +805,7 @@ const struct bt_mesh_model_op _bt_mesh_blob_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int blob_srv_init(struct bt_mesh_model *mod)
+static int blob_srv_init(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
 
@@ -819,7 +819,7 @@ static int blob_srv_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static int blob_srv_settings_set(struct bt_mesh_model *mod, const char *name,
+static int blob_srv_settings_set(const struct bt_mesh_model *mod, const char *name,
 				 size_t len_rd, settings_read_cb read_cb,
 				 void *cb_arg)
 {
@@ -861,7 +861,7 @@ static int blob_srv_settings_set(struct bt_mesh_model *mod, const char *name,
 	return 0;
 }
 
-static int blob_srv_start(struct bt_mesh_model *mod)
+static int blob_srv_start(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
 	int err = -ENOTSUP;
@@ -889,7 +889,7 @@ static int blob_srv_start(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void blob_srv_reset(struct bt_mesh_model *mod)
+static void blob_srv_reset(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_blob_srv *srv = mod->user_data;
 

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -48,7 +48,7 @@ static int32_t msg_timeout;
 
 static struct bt_mesh_cfg_cli *cli;
 
-static int comp_data_status(struct bt_mesh_model *model,
+static int comp_data_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -85,7 +85,7 @@ static int comp_data_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static uint8_t state_status_u8(struct bt_mesh_model *model,
+static uint8_t state_status_u8(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf,
 			   uint32_t expect_status)
@@ -111,7 +111,7 @@ static uint8_t state_status_u8(struct bt_mesh_model *model,
 	return status;
 }
 
-static int beacon_status(struct bt_mesh_model *model,
+static int beacon_status(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -126,7 +126,7 @@ static int beacon_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int ttl_status(struct bt_mesh_model *model,
+static int ttl_status(const struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
@@ -141,7 +141,7 @@ static int ttl_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int friend_status(struct bt_mesh_model *model,
+static int friend_status(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -156,7 +156,7 @@ static int friend_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gatt_proxy_status(struct bt_mesh_model *model,
+static int gatt_proxy_status(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -178,7 +178,7 @@ struct krp_param {
 	uint8_t *phase;
 };
 
-static int krp_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int krp_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	int err = 0;
@@ -223,7 +223,7 @@ struct relay_param {
 	uint8_t *transmit;
 };
 
-static int relay_status(struct bt_mesh_model *model,
+static int relay_status(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
@@ -257,7 +257,7 @@ static int relay_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int net_transmit_status(struct bt_mesh_model *model,
+static int net_transmit_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -277,7 +277,7 @@ struct net_key_param {
 	uint16_t net_idx;
 };
 
-static int net_key_status(struct bt_mesh_model *model,
+static int net_key_status(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -345,7 +345,7 @@ int bt_mesh_key_idx_unpack_list(struct net_buf_simple *buf, uint16_t *dst_arr,
 	return buf->len > 0 ? -EMSGSIZE : 0;
 }
 
-static int net_key_list(struct bt_mesh_model *model,
+static int net_key_list(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
@@ -381,7 +381,7 @@ done:
 	return err;
 }
 
-static int node_reset_status(struct bt_mesh_model *model,
+static int node_reset_status(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -412,7 +412,7 @@ struct app_key_param {
 	uint16_t app_idx;
 };
 
-static int app_key_status(struct bt_mesh_model *model,
+static int app_key_status(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -461,7 +461,7 @@ struct app_key_list_param {
 	size_t *key_cnt;
 };
 
-static int app_key_list(struct bt_mesh_model *model,
+static int app_key_list(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
@@ -521,7 +521,7 @@ struct mod_app_param {
 	uint16_t cid;
 };
 
-static int mod_app_status(struct bt_mesh_model *model,
+static int mod_app_status(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -695,7 +695,7 @@ done:
 	return err;
 }
 
-static int mod_app_list(struct bt_mesh_model *model,
+static int mod_app_list(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
 {
 	LOG_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s", ctx->net_idx, ctx->app_idx,
@@ -704,7 +704,7 @@ static int mod_app_list(struct bt_mesh_model *model,
 	return mod_app_list_handle(ctx, buf, OP_SIG_MOD_APP_LIST, false);
 }
 
-static int mod_app_list_vnd(struct bt_mesh_model *model,
+static int mod_app_list_vnd(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -722,7 +722,7 @@ struct mod_pub_param {
 	struct bt_mesh_cfg_cli_mod_pub *pub;
 };
 
-static int mod_pub_status(struct bt_mesh_model *model,
+static int mod_pub_status(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -807,7 +807,7 @@ struct mod_sub_param {
 	uint16_t cid;
 };
 
-static int mod_sub_status(struct bt_mesh_model *model,
+static int mod_sub_status(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -866,7 +866,7 @@ done:
 	return err;
 }
 
-static int mod_sub_list(struct bt_mesh_model *model,
+static int mod_sub_list(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
 {
 	LOG_DBG("net_idx 0x%04x app_idx 0x%04x src 0x%04x len %u: %s", ctx->net_idx, ctx->app_idx,
@@ -875,7 +875,7 @@ static int mod_sub_list(struct bt_mesh_model *model,
 	return mod_sub_list_handle(ctx, buf, OP_MOD_SUB_LIST, false);
 }
 
-static int mod_sub_list_vnd(struct bt_mesh_model *model,
+static int mod_sub_list_vnd(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -890,7 +890,7 @@ struct hb_sub_param {
 	struct bt_mesh_cfg_cli_hb_sub *sub;
 };
 
-static int hb_sub_status(struct bt_mesh_model *model,
+static int hb_sub_status(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -934,7 +934,7 @@ struct hb_pub_param {
 	struct bt_mesh_cfg_cli_hb_pub *pub;
 };
 
-static int hb_pub_status(struct bt_mesh_model *model,
+static int hb_pub_status(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -979,7 +979,7 @@ struct node_idt_param {
 	uint8_t *identity;
 };
 
-static int node_identity_status(struct bt_mesh_model *model,
+static int node_identity_status(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -1020,7 +1020,7 @@ struct lpn_timeout_param {
 	int32_t *polltimeout;
 };
 
-static int lpn_timeout_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int lpn_timeout_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct lpn_timeout_param *param;
@@ -1087,7 +1087,7 @@ const struct bt_mesh_model_op bt_mesh_cfg_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int cfg_cli_init(struct bt_mesh_model *model)
+static int cfg_cli_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Configuration Client only allowed in primary element");
@@ -1108,7 +1108,7 @@ static int cfg_cli_init(struct bt_mesh_model *model)
 	 * and remote keys are allowed to access this model.
 	 */
 	model->keys[0] = BT_MESH_KEY_DEV_ANY;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	bt_mesh_msg_ack_ctx_init(&cli->ack_ctx);
 

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -48,7 +48,7 @@ static void node_reset_pending_handler(struct k_work *work)
 
 static K_WORK_DEFINE(node_reset_pending, node_reset_pending_handler);
 
-static int dev_comp_data_get(struct bt_mesh_model *model,
+static int dev_comp_data_get(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -100,7 +100,7 @@ static int dev_comp_data_get(struct bt_mesh_model *model,
 	return err;
 }
 
-static struct bt_mesh_model *get_model(struct bt_mesh_elem *elem,
+static const struct bt_mesh_model *get_model(struct bt_mesh_elem *elem,
 				       struct net_buf_simple *buf, bool *vnd)
 {
 	if (buf->len < 4) {
@@ -127,8 +127,10 @@ static struct bt_mesh_model *get_model(struct bt_mesh_elem *elem,
 	}
 }
 
-static uint8_t _mod_pub_set(struct bt_mesh_model *model, uint16_t pub_addr, const uint8_t *uuid,
-			 uint16_t app_idx, uint8_t cred_flag, uint8_t ttl, uint8_t period,
+static uint8_t _mod_pub_set(const struct bt_mesh_model *model,
+			 uint16_t pub_addr, const uint8_t *uuid,
+			 uint16_t app_idx, uint8_t cred_flag,
+			 uint8_t ttl, uint8_t period,
 			 uint8_t retransmit, bool store)
 {
 	if (!model->pub) {
@@ -213,7 +215,7 @@ static uint8_t _mod_pub_set(struct bt_mesh_model *model, uint16_t pub_addr, cons
 	return STATUS_SUCCESS;
 }
 
-static uint8_t mod_bind(struct bt_mesh_model *model, uint16_t key_idx)
+static uint8_t mod_bind(const struct bt_mesh_model *model, uint16_t key_idx)
 {
 	int i;
 
@@ -246,7 +248,7 @@ static uint8_t mod_bind(struct bt_mesh_model *model, uint16_t key_idx)
 	return STATUS_INSUFF_RESOURCES;
 }
 
-static uint8_t mod_unbind(struct bt_mesh_model *model, uint16_t key_idx, bool store)
+static uint8_t mod_unbind(const struct bt_mesh_model *model, uint16_t key_idx, bool store)
 {
 	int i;
 
@@ -298,7 +300,7 @@ static void key_idx_pack_list(struct net_buf_simple *buf, uint16_t *arr, size_t 
 
 }
 
-static int send_app_key_status(struct bt_mesh_model *model,
+static int send_app_key_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       uint8_t status,
 			       uint16_t app_idx, uint16_t net_idx)
@@ -316,7 +318,7 @@ static int send_app_key_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int app_key_add(struct bt_mesh_model *model,
+static int app_key_add(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
@@ -332,7 +334,7 @@ static int app_key_add(struct bt_mesh_model *model,
 	return send_app_key_status(model, ctx, status, key_app_idx, key_net_idx);
 }
 
-static int app_key_update(struct bt_mesh_model *model,
+static int app_key_update(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -349,7 +351,7 @@ static int app_key_update(struct bt_mesh_model *model,
 	return send_app_key_status(model, ctx, status, key_app_idx, key_net_idx);
 }
 
-static void mod_app_key_del(struct bt_mesh_model *mod,
+static void mod_app_key_del(const struct bt_mesh_model *mod,
 			    struct bt_mesh_elem *elem, bool vnd, bool primary,
 			    void *user_data)
 {
@@ -368,7 +370,7 @@ static void app_key_evt(uint16_t app_idx, uint16_t net_idx,
 
 BT_MESH_APP_KEY_CB_DEFINE(app_key_evt);
 
-static int app_key_del(struct bt_mesh_model *model,
+static int app_key_del(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
@@ -387,7 +389,7 @@ static int app_key_del(struct bt_mesh_model *model,
 /* Index list length: 3 bytes for every pair and 2 bytes for an odd idx */
 #define IDX_LEN(num) (((num) / 2) * 3 + ((num) % 2) * 2)
 
-static int app_key_get(struct bt_mesh_model *model,
+static int app_key_get(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
@@ -436,7 +438,7 @@ send_status:
 	return 0;
 }
 
-static int beacon_get(struct bt_mesh_model *model,
+static int beacon_get(const struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
@@ -455,7 +457,7 @@ static int beacon_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int beacon_set(struct bt_mesh_model *model,
+static int beacon_set(const struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
@@ -481,7 +483,7 @@ static int beacon_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int default_ttl_get(struct bt_mesh_model *model,
+static int default_ttl_get(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -500,7 +502,7 @@ static int default_ttl_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int default_ttl_set(struct bt_mesh_model *model,
+static int default_ttl_set(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -526,7 +528,7 @@ static int default_ttl_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int send_gatt_proxy_status(struct bt_mesh_model *model,
+static int send_gatt_proxy_status(const struct bt_mesh_model *model,
 				  struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_GATT_PROXY_STATUS, 1);
@@ -541,7 +543,7 @@ static int send_gatt_proxy_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int gatt_proxy_get(struct bt_mesh_model *model,
+static int gatt_proxy_get(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -551,7 +553,7 @@ static int gatt_proxy_get(struct bt_mesh_model *model,
 	return send_gatt_proxy_status(model, ctx);
 }
 
-static int gatt_proxy_set(struct bt_mesh_model *model,
+static int gatt_proxy_set(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -575,7 +577,7 @@ static int gatt_proxy_set(struct bt_mesh_model *model,
 	return send_gatt_proxy_status(model, ctx);
 }
 
-static int net_transmit_get(struct bt_mesh_model *model,
+static int net_transmit_get(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -594,7 +596,7 @@ static int net_transmit_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int net_transmit_set(struct bt_mesh_model *model,
+static int net_transmit_set(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -618,7 +620,7 @@ static int net_transmit_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int relay_get(struct bt_mesh_model *model,
+static int relay_get(const struct bt_mesh_model *model,
 		     struct bt_mesh_msg_ctx *ctx,
 		     struct net_buf_simple *buf)
 {
@@ -638,7 +640,7 @@ static int relay_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int relay_set(struct bt_mesh_model *model,
+static int relay_set(const struct bt_mesh_model *model,
 		     struct bt_mesh_msg_ctx *ctx,
 		     struct net_buf_simple *buf)
 {
@@ -665,10 +667,10 @@ static int relay_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int send_mod_pub_status(struct bt_mesh_model *cfg_mod,
+static int send_mod_pub_status(const struct bt_mesh_model *cfg_mod,
 			       struct bt_mesh_msg_ctx *ctx, uint16_t elem_addr,
 			       uint16_t pub_addr, bool vnd,
-			       struct bt_mesh_model *mod, uint8_t status,
+			       const struct bt_mesh_model *mod, uint8_t status,
 			       uint8_t *mod_id)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_PUB_STATUS, 14);
@@ -705,11 +707,11 @@ static int send_mod_pub_status(struct bt_mesh_model *cfg_mod,
 	return 0;
 }
 
-static int mod_pub_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mod_pub_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, pub_addr = 0U;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	bool vnd;
@@ -756,13 +758,13 @@ send_status:
 				   status, mod_id);
 }
 
-static int mod_pub_set(struct bt_mesh_model *model,
+static int mod_pub_set(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	uint8_t retransmit, status, pub_ttl, pub_period, cred_flag;
 	uint16_t elem_addr, pub_addr, pub_app_idx;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	bool vnd;
@@ -821,7 +823,7 @@ send_status:
 				   status, mod_id);
 }
 
-static size_t mod_sub_list_clear(struct bt_mesh_model *mod)
+static size_t mod_sub_list_clear(const struct bt_mesh_model *mod)
 {
 	size_t clear_count;
 	int i;
@@ -852,7 +854,7 @@ static size_t mod_sub_list_clear(struct bt_mesh_model *mod)
 	return clear_count;
 }
 
-static int mod_pub_va_set(struct bt_mesh_model *model,
+static int mod_pub_va_set(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -860,7 +862,7 @@ static int mod_pub_va_set(struct bt_mesh_model *model,
 	uint8_t retransmit, status, pub_ttl, pub_period, cred_flag;
 	uint16_t elem_addr, pub_app_idx;
 	uint16_t pub_addr = 0U;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	const uint8_t *uuid;
 	uint8_t *mod_id;
@@ -929,7 +931,7 @@ send_status:
 				   status, mod_id);
 }
 
-static int send_mod_sub_status(struct bt_mesh_model *model,
+static int send_mod_sub_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx, uint8_t status,
 			       uint16_t elem_addr, uint16_t sub_addr, uint8_t *mod_id,
 			       bool vnd)
@@ -957,12 +959,12 @@ static int send_mod_sub_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int mod_sub_add(struct bt_mesh_model *model,
+static int mod_sub_add(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	uint8_t status;
@@ -1035,12 +1037,12 @@ send_status:
 				   mod_id, vnd);
 }
 
-static int mod_sub_del(struct bt_mesh_model *model,
+static int mod_sub_del(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	uint16_t *match;
@@ -1106,7 +1108,7 @@ send_status:
 				   mod_id, vnd);
 }
 
-static enum bt_mesh_walk mod_sub_clear_visitor(struct bt_mesh_model *mod, void *user_data)
+static enum bt_mesh_walk mod_sub_clear_visitor(const struct bt_mesh_model *mod, void *user_data)
 {
 	if (IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)) {
 		bt_mesh_lpn_group_del(mod->groups, mod->groups_cnt);
@@ -1117,12 +1119,12 @@ static enum bt_mesh_walk mod_sub_clear_visitor(struct bt_mesh_model *mod, void *
 	return BT_MESH_WALK_CONTINUE;
 }
 
-static int mod_sub_overwrite(struct bt_mesh_model *model,
+static int mod_sub_overwrite(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
 	uint16_t elem_addr, sub_addr;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	uint8_t *mod_id;
 	uint8_t status;
@@ -1188,11 +1190,11 @@ send_status:
 				   mod_id, vnd);
 }
 
-static int mod_sub_del_all(struct bt_mesh_model *model,
+static int mod_sub_del_all(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	uint16_t elem_addr;
 	uint8_t *mod_id;
@@ -1246,13 +1248,13 @@ struct mod_sub_list_ctx {
 	struct net_buf_simple *msg;
 };
 
-static enum bt_mesh_walk mod_sub_list_visitor(struct bt_mesh_model *mod, void *ctx)
+static enum bt_mesh_walk mod_sub_list_visitor(const struct bt_mesh_model *mod, void *ctx)
 {
 	struct mod_sub_list_ctx *visit = ctx;
 	int count = 0;
 	int i;
 
-	if (mod->elem_idx != visit->elem_idx) {
+	if (mod->ctx->elem_idx != visit->elem_idx) {
 		return BT_MESH_WALK_CONTINUE;
 	}
 
@@ -1271,18 +1273,18 @@ static enum bt_mesh_walk mod_sub_list_visitor(struct bt_mesh_model *mod, void *c
 		count++;
 	}
 
-	LOG_DBG("sublist: model %u:%x: %u groups", mod->elem_idx, mod->id, count);
+	LOG_DBG("sublist: model %u:%x: %u groups", mod->ctx->elem_idx, mod->id, count);
 
 	return BT_MESH_WALK_CONTINUE;
 }
 
-static int mod_sub_get(struct bt_mesh_model *model,
+static int mod_sub_get(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, BT_MESH_TX_SDU_MAX);
 	struct mod_sub_list_ctx visit_ctx;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	uint16_t addr, id;
 
@@ -1320,7 +1322,7 @@ static int mod_sub_get(struct bt_mesh_model *model,
 	net_buf_simple_add_le16(&msg, id);
 
 	visit_ctx.msg = &msg;
-	visit_ctx.elem_idx = mod->elem_idx;
+	visit_ctx.elem_idx = mod->ctx->elem_idx;
 	bt_mesh_model_extensions_walk(mod, mod_sub_list_visitor, &visit_ctx);
 
 send_list:
@@ -1331,13 +1333,13 @@ send_list:
 	return 0;
 }
 
-static int mod_sub_get_vnd(struct bt_mesh_model *model,
+static int mod_sub_get_vnd(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	NET_BUF_SIMPLE_DEFINE(msg, BT_MESH_TX_SDU_MAX);
 	struct mod_sub_list_ctx visit_ctx;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	uint16_t company, addr, id;
 
@@ -1379,7 +1381,7 @@ static int mod_sub_get_vnd(struct bt_mesh_model *model,
 	net_buf_simple_add_le16(&msg, id);
 
 	visit_ctx.msg = &msg;
-	visit_ctx.elem_idx = mod->elem_idx;
+	visit_ctx.elem_idx = mod->ctx->elem_idx;
 	bt_mesh_model_extensions_walk(mod, mod_sub_list_visitor, &visit_ctx);
 
 send_list:
@@ -1390,13 +1392,13 @@ send_list:
 	return 0;
 }
 
-static int mod_sub_va_add(struct bt_mesh_model *model,
+static int mod_sub_va_add(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
 	const struct bt_mesh_va *va;
 	uint16_t elem_addr, sub_addr = BT_MESH_ADDR_UNASSIGNED;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	const uint8_t *uuid;
 	uint8_t *mod_id;
@@ -1492,13 +1494,13 @@ send_status:
 				   mod_id, vnd);
 }
 
-static int mod_sub_va_del(struct bt_mesh_model *model,
+static int mod_sub_va_del(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
 	const struct bt_mesh_va *va;
 	uint16_t elem_addr, sub_addr = BT_MESH_ADDR_UNASSIGNED;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	const uint8_t *uuid;
 	uint8_t *mod_id;
@@ -1576,13 +1578,13 @@ send_status:
 				   mod_id, vnd);
 }
 
-static int mod_sub_va_overwrite(struct bt_mesh_model *model,
+static int mod_sub_va_overwrite(const struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	const struct bt_mesh_va *va;
 	uint16_t elem_addr, sub_addr = BT_MESH_ADDR_UNASSIGNED;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	const uint8_t *uuid;
 	uint8_t *mod_id;
@@ -1652,7 +1654,7 @@ send_status:
 				   mod_id, vnd);
 }
 
-static int send_net_key_status(struct bt_mesh_model *model,
+static int send_net_key_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx, uint16_t idx,
 			       uint8_t status)
 {
@@ -1670,7 +1672,7 @@ static int send_net_key_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int net_key_add(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int net_key_add(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	uint8_t status;
@@ -1689,7 +1691,7 @@ static int net_key_add(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return send_net_key_status(model, ctx, idx, status);
 }
 
-static int net_key_update(struct bt_mesh_model *model,
+static int net_key_update(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
@@ -1707,7 +1709,7 @@ static int net_key_update(struct bt_mesh_model *model,
 	return send_net_key_status(model, ctx, idx, status);
 }
 
-static int net_key_del(struct bt_mesh_model *model,
+static int net_key_del(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
@@ -1734,7 +1736,7 @@ static int net_key_del(struct bt_mesh_model *model,
 	return send_net_key_status(model, ctx, del_idx, STATUS_SUCCESS);
 }
 
-static int net_key_get(struct bt_mesh_model *model,
+static int net_key_get(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
@@ -1759,7 +1761,7 @@ static int net_key_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int send_node_id_status(struct bt_mesh_model *model,
+static int send_node_id_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       uint8_t status,
 			       uint16_t net_idx, uint8_t node_id)
@@ -1778,7 +1780,7 @@ static int send_node_id_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int node_identity_get(struct bt_mesh_model *model,
+static int node_identity_get(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -1800,7 +1802,7 @@ static int node_identity_get(struct bt_mesh_model *model,
 	return send_node_id_status(model, ctx, status, idx, node_id);
 }
 
-static int node_identity_set(struct bt_mesh_model *model,
+static int node_identity_set(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -1838,7 +1840,7 @@ static int node_identity_set(struct bt_mesh_model *model,
 }
 
 static void create_mod_app_status(struct net_buf_simple *msg,
-				  struct bt_mesh_model *mod, bool vnd,
+				  const struct bt_mesh_model *mod, bool vnd,
 				  uint16_t elem_addr, uint16_t app_idx,
 				  uint8_t status, uint8_t *mod_id)
 {
@@ -1855,13 +1857,13 @@ static void create_mod_app_status(struct net_buf_simple *msg,
 	}
 }
 
-static int mod_app_bind(struct bt_mesh_model *model,
+static int mod_app_bind(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_STATUS, 9);
 	uint16_t elem_addr, key_app_idx;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	bool vnd;
@@ -1895,7 +1897,7 @@ static int mod_app_bind(struct bt_mesh_model *model,
 	}
 
 	/* Some models only allow device key based access */
-	if (mod->flags & BT_MESH_MOD_DEVKEY_ONLY) {
+	if (mod->ctx->flags & BT_MESH_MOD_DEVKEY_ONLY) {
 		LOG_ERR("Client tried to bind AppKey to DevKey based model");
 		status = STATUS_CANNOT_BIND;
 		goto send_status;
@@ -1919,13 +1921,13 @@ send_status:
 	return 0;
 }
 
-static int mod_app_unbind(struct bt_mesh_model *model,
+static int mod_app_unbind(const struct bt_mesh_model *model,
 			  struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_STATUS, 9);
 	uint16_t elem_addr, key_app_idx;
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	bool vnd;
@@ -1978,7 +1980,7 @@ send_status:
 
 #define KEY_LIST_LEN (CONFIG_BT_MESH_MODEL_KEY_COUNT * 2)
 
-static int mod_app_get(struct bt_mesh_model *model,
+static int mod_app_get(const struct bt_mesh_model *model,
 		       struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
@@ -1987,7 +1989,7 @@ static int mod_app_get(struct bt_mesh_model *model,
 							9 + KEY_LIST_LEN),
 				  BT_MESH_MODEL_BUF_LEN(OP_SIG_MOD_APP_LIST,
 							9 + KEY_LIST_LEN)));
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 	struct bt_mesh_elem *elem;
 	uint8_t *mod_id, status;
 	uint16_t elem_addr;
@@ -2064,7 +2066,7 @@ static void reset_send_end(int err, void *cb_data)
 	k_work_submit(&node_reset_pending);
 }
 
-static int node_reset(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int node_reset(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
 	static const struct bt_mesh_send_cb reset_cb = {
@@ -2086,7 +2088,7 @@ static int node_reset(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int send_friend_status(struct bt_mesh_model *model,
+static int send_friend_status(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_FRIEND_STATUS, 1);
@@ -2101,7 +2103,7 @@ static int send_friend_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int friend_get(struct bt_mesh_model *model,
+static int friend_get(const struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
@@ -2111,7 +2113,7 @@ static int friend_get(struct bt_mesh_model *model,
 	return send_friend_status(model, ctx);
 }
 
-static int friend_set(struct bt_mesh_model *model,
+static int friend_set(const struct bt_mesh_model *model,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
@@ -2128,7 +2130,7 @@ static int friend_set(struct bt_mesh_model *model,
 	return send_friend_status(model, ctx);
 }
 
-static int lpn_timeout_get(struct bt_mesh_model *model,
+static int lpn_timeout_get(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -2174,7 +2176,7 @@ send_rsp:
 	return 0;
 }
 
-static int send_krp_status(struct bt_mesh_model *model,
+static int send_krp_status(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx, uint16_t idx,
 			   uint8_t phase, uint8_t status)
 {
@@ -2193,7 +2195,7 @@ static int send_krp_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int krp_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int krp_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		    struct net_buf_simple *buf)
 {
 	uint8_t kr_phase, status;
@@ -2212,7 +2214,7 @@ static int krp_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return send_krp_status(model, ctx, idx, kr_phase, status);
 }
 
-static int krp_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int krp_set(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		   struct net_buf_simple *buf)
 {
 	uint8_t phase, status;
@@ -2268,7 +2270,7 @@ struct hb_pub_param {
 	uint16_t net_idx;
 } __packed;
 
-static int hb_pub_send_status(struct bt_mesh_model *model,
+static int hb_pub_send_status(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx, uint8_t status,
 			      const struct bt_mesh_hb_pub *pub)
 {
@@ -2294,7 +2296,7 @@ static int hb_pub_send_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int heartbeat_pub_get(struct bt_mesh_model *model,
+static int heartbeat_pub_get(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2307,7 +2309,7 @@ static int heartbeat_pub_get(struct bt_mesh_model *model,
 	return hb_pub_send_status(model, ctx, STATUS_SUCCESS, &pub);
 }
 
-static int heartbeat_pub_set(struct bt_mesh_model *model,
+static int heartbeat_pub_set(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -2367,7 +2369,7 @@ rsp:
 	return hb_pub_send_status(model, ctx, status, &pub);
 }
 
-static int hb_sub_send_status(struct bt_mesh_model *model,
+static int hb_sub_send_status(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      const struct bt_mesh_hb_sub *sub)
 {
@@ -2392,7 +2394,7 @@ static int hb_sub_send_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int heartbeat_sub_get(struct bt_mesh_model *model,
+static int heartbeat_sub_get(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -2405,7 +2407,7 @@ static int heartbeat_sub_get(struct bt_mesh_model *model,
 	return hb_sub_send_status(model, ctx, &sub);
 }
 
-static int heartbeat_sub_set(struct bt_mesh_model *model,
+static int heartbeat_sub_set(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -2518,7 +2520,7 @@ const struct bt_mesh_model_op bt_mesh_cfg_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int cfg_srv_init(struct bt_mesh_model *model)
+static int cfg_srv_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Configuration Server only allowed in primary element");
@@ -2530,7 +2532,7 @@ static int cfg_srv_init(struct bt_mesh_model *model)
 	 * device-key is allowed to access this model.
 	 */
 	model->keys[0] = BT_MESH_KEY_DEV_LOCAL;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	return 0;
 }
@@ -2539,7 +2541,7 @@ const struct bt_mesh_model_cb bt_mesh_cfg_srv_cb = {
 	.init = cfg_srv_init,
 };
 
-static void mod_reset(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void mod_reset(const struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 		      bool vnd, bool primary, void *user_data)
 {
 	size_t clear_count;

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -112,7 +112,7 @@ static void receivers_status_rsp(struct bt_mesh_dfd_srv *srv,
 	bt_mesh_model_send(srv->mod, ctx, &buf, NULL, NULL);
 }
 
-static int handle_receivers_add(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_receivers_add(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	enum bt_mesh_dfd_status status = BT_MESH_DFD_SUCCESS;
@@ -143,7 +143,7 @@ static int handle_receivers_add(struct bt_mesh_model *mod, struct bt_mesh_msg_ct
 	return 0;
 }
 
-static int handle_receivers_delete_all(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_receivers_delete_all(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -153,7 +153,7 @@ static int handle_receivers_delete_all(struct bt_mesh_model *mod, struct bt_mesh
 	return 0;
 }
 
-static int handle_receivers_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_receivers_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -206,7 +206,7 @@ static enum bt_mesh_dfu_iter slot_space_cb(const struct bt_mesh_dfu_slot *slot,
 	return BT_MESH_DFU_ITER_CONTINUE;
 }
 
-static int handle_capabilities_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_capabilities_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
 	size_t size = 0;
@@ -256,7 +256,7 @@ static void status_rsp(struct bt_mesh_dfd_srv *srv, struct bt_mesh_msg_ctx *ctx,
 	bt_mesh_model_send(srv->mod, ctx, &rsp, NULL, NULL);
 }
 
-static int handle_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -266,7 +266,7 @@ static int handle_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int handle_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -298,7 +298,7 @@ static int handle_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int handle_suspend(struct bt_mesh_model *mod,
+static int handle_suspend(const struct bt_mesh_model *mod,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -309,7 +309,7 @@ static int handle_suspend(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_cancel(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_cancel(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -319,7 +319,7 @@ static int handle_cancel(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int handle_apply(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_apply(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -354,7 +354,7 @@ static void upload_status_rsp(struct bt_mesh_dfd_srv *srv,
 	bt_mesh_model_send(srv->mod, ctx, &rsp, NULL, NULL);
 }
 
-static int handle_upload_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_upload_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -364,7 +364,7 @@ static int handle_upload_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *
 	return 0;
 }
 
-static int handle_upload_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_upload_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -474,7 +474,7 @@ static int handle_upload_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx
 	return 0;
 }
 
-static int handle_upload_start_oob(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_upload_start_oob(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -486,7 +486,7 @@ static int handle_upload_start_oob(struct bt_mesh_model *mod, struct bt_mesh_msg
 	return 0;
 }
 
-static int handle_upload_cancel(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_upload_cancel(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -518,7 +518,7 @@ static void fw_status_rsp(struct bt_mesh_dfd_srv *srv,
 	bt_mesh_model_send(srv->mod, ctx, &rsp, NULL, NULL);
 }
 
-static int handle_fw_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_fw_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -542,7 +542,7 @@ static int handle_fw_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int handle_fw_get_by_index(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_fw_get_by_index(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -563,7 +563,7 @@ static int handle_fw_get_by_index(struct bt_mesh_model *mod, struct bt_mesh_msg_
 	return 0;
 }
 
-static int handle_fw_delete(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_fw_delete(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -592,7 +592,7 @@ static enum bt_mesh_dfu_iter slot_del_cb(const struct bt_mesh_dfu_slot *slot,
 	return BT_MESH_DFU_ITER_CONTINUE;
 }
 
-static int handle_fw_delete_all(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_fw_delete_all(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
@@ -752,7 +752,7 @@ const struct bt_mesh_blob_srv_cb _bt_mesh_dfd_srv_blob_cb = {
 	.suspended = upload_timeout,
 };
 
-static int dfd_srv_init(struct bt_mesh_model *mod)
+static int dfd_srv_init(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
 
@@ -765,7 +765,7 @@ static int dfd_srv_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void dfd_srv_reset(struct bt_mesh_model *mod)
+static void dfd_srv_reset(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_dfd_srv *srv = mod->user_data;
 

--- a/subsys/bluetooth/mesh/dfu_cli.c
+++ b/subsys/bluetooth/mesh/dfu_cli.c
@@ -681,7 +681,7 @@ static void cancelled(struct bt_mesh_blob_cli *b)
  * Message handlers
  ******************************************************************************/
 
-static int handle_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_cli *cli = mod->user_data;
@@ -807,7 +807,7 @@ static int handle_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int handle_info_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_info_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_cli *cli = mod->user_data;
@@ -906,7 +906,7 @@ static int handle_info_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 	return 0;
 }
 
-static int handle_metadata_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_metadata_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_cli *cli = mod->user_data;
@@ -943,11 +943,11 @@ const struct bt_mesh_model_op _bt_mesh_dfu_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int dfu_cli_init(struct bt_mesh_model *mod)
+static int dfu_cli_init(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_dfu_cli *cli = mod->user_data;
 
-	if (mod->elem_idx != 0) {
+	if (mod->ctx->elem_idx != 0) {
 		LOG_ERR("DFU update client must be instantiated on first elem");
 		return -EINVAL;
 	}
@@ -963,7 +963,7 @@ static int dfu_cli_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static void dfu_cli_reset(struct bt_mesh_model *mod)
+static void dfu_cli_reset(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_dfu_cli *cli = mod->user_data;
 

--- a/subsys/bluetooth/mesh/dfu_srv.c
+++ b/subsys/bluetooth/mesh/dfu_srv.c
@@ -125,7 +125,7 @@ static void verify(struct bt_mesh_dfu_srv *srv)
 	}
 }
 
-static int handle_info_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_info_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
@@ -187,7 +187,7 @@ static int handle_info_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ct
 	return 0;
 }
 
-static int handle_metadata_check(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_metadata_check(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
@@ -239,7 +239,7 @@ static void update_status_rsp(struct bt_mesh_dfu_srv *srv,
 	bt_mesh_model_send(srv->mod, ctx, &buf, send_cb, srv);
 }
 
-static int handle_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
@@ -262,7 +262,7 @@ static inline bool is_active_update(struct bt_mesh_dfu_srv *srv, uint8_t idx,
 		srv->update.meta != meta_checksum);
 }
 
-static int handle_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
@@ -371,7 +371,7 @@ rsp:
 	return 0;
 }
 
-static int handle_cancel(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_cancel(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
@@ -392,7 +392,7 @@ rsp:
 	return 0;
 }
 
-static int handle_apply(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_apply(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
@@ -435,7 +435,7 @@ const struct bt_mesh_model_op _bt_mesh_dfu_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int dfu_srv_init(struct bt_mesh_model *mod)
+static int dfu_srv_init(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
 
@@ -455,7 +455,7 @@ static int dfu_srv_init(struct bt_mesh_model *mod)
 	return 0;
 }
 
-static int dfu_srv_settings_set(struct bt_mesh_model *mod, const char *name,
+static int dfu_srv_settings_set(const struct bt_mesh_model *mod, const char *name,
 				size_t len_rd, settings_read_cb read_cb,
 				void *cb_arg)
 {
@@ -484,7 +484,7 @@ static int dfu_srv_settings_set(struct bt_mesh_model *mod, const char *name,
 	return 0;
 }
 
-static void dfu_srv_reset(struct bt_mesh_model *mod)
+static void dfu_srv_reset(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_dfu_srv *srv = mod->user_data;
 

--- a/subsys/bluetooth/mesh/foundation.h
+++ b/subsys/bluetooth/mesh/foundation.h
@@ -150,7 +150,7 @@
 
 void bt_mesh_model_reset(void);
 
-void bt_mesh_attention(struct bt_mesh_model *model, uint8_t time);
+void bt_mesh_attention(const struct bt_mesh_model *model, uint8_t time);
 
 #include <zephyr/sys/byteorder.h>
 

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -36,7 +36,7 @@ struct health_fault_param {
 	size_t *fault_count;
 };
 
-static int health_fault_status(struct bt_mesh_model *model,
+static int health_fault_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -89,7 +89,7 @@ done:
 	return 0;
 }
 
-static int health_current_status(struct bt_mesh_model *model,
+static int health_current_status(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -117,7 +117,7 @@ struct health_period_param {
 	uint8_t *divisor;
 };
 
-static int health_period_status(struct bt_mesh_model *model,
+static int health_period_status(const struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
@@ -151,7 +151,7 @@ struct health_attention_param {
 	uint8_t *attention;
 };
 
-static int health_attention_status(struct bt_mesh_model *model,
+static int health_attention_status(const struct bt_mesh_model *model,
 				   struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
@@ -402,7 +402,7 @@ void bt_mesh_health_cli_timeout_set(int32_t timeout)
 	msg_timeout = timeout;
 }
 
-static int health_cli_init(struct bt_mesh_model *model)
+static int health_cli_init(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_health_cli *cli = model->user_data;
 
@@ -423,7 +423,7 @@ static int health_cli_init(struct bt_mesh_model *model)
 	return 0;
 }
 
-static void health_cli_reset(struct bt_mesh_model *model)
+static void health_cli_reset(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_health_cli *cli = model->user_data;
 

--- a/subsys/bluetooth/mesh/health_srv.c
+++ b/subsys/bluetooth/mesh/health_srv.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(bt_mesh_health_srv);
 /* Health Server context of the primary element */
 struct bt_mesh_health_srv *health_srv;
 
-static void health_get_registered(struct bt_mesh_model *mod,
+static void health_get_registered(const struct bt_mesh_model *mod,
 				  uint16_t company_id,
 				  struct net_buf_simple *msg)
 {
@@ -64,7 +64,7 @@ static void health_get_registered(struct bt_mesh_model *mod,
 	}
 }
 
-static size_t health_get_current(struct bt_mesh_model *mod,
+static size_t health_get_current(const struct bt_mesh_model *mod,
 				 struct net_buf_simple *msg)
 {
 	struct bt_mesh_health_srv *srv = mod->user_data;
@@ -105,7 +105,7 @@ static size_t health_get_current(struct bt_mesh_model *mod,
 	return fault_count;
 }
 
-static int health_fault_get(struct bt_mesh_model *model,
+static int health_fault_get(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -125,7 +125,7 @@ static int health_fault_get(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int health_fault_clear_unrel(struct bt_mesh_model *model,
+static int health_fault_clear_unrel(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -143,7 +143,7 @@ static int health_fault_clear_unrel(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int health_fault_clear(struct bt_mesh_model *model,
+static int health_fault_clear(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -173,7 +173,7 @@ static int health_fault_clear(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int health_fault_test_unrel(struct bt_mesh_model *model,
+static int health_fault_test_unrel(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -193,7 +193,7 @@ static int health_fault_test_unrel(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int health_fault_test(struct bt_mesh_model *model,
+static int health_fault_test(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -228,7 +228,7 @@ static int health_fault_test(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int send_attention_status(struct bt_mesh_model *model,
+static int send_attention_status(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
@@ -251,7 +251,7 @@ static int send_attention_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int attention_get(struct bt_mesh_model *model,
+static int attention_get(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -260,7 +260,7 @@ static int attention_get(struct bt_mesh_model *model,
 	return send_attention_status(model, ctx);
 }
 
-static int attention_set_unrel(struct bt_mesh_model *model,
+static int attention_set_unrel(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -275,7 +275,7 @@ static int attention_set_unrel(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int attention_set(struct bt_mesh_model *model,
+static int attention_set(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -291,7 +291,7 @@ static int attention_set(struct bt_mesh_model *model,
 	return send_attention_status(model, ctx);
 }
 
-static int send_health_period_status(struct bt_mesh_model *model,
+static int send_health_period_status(const struct bt_mesh_model *model,
 				     struct bt_mesh_msg_ctx *ctx)
 {
 	/* Needed size: opcode (2 bytes) + msg + MIC */
@@ -308,7 +308,7 @@ static int send_health_period_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int health_period_get(struct bt_mesh_model *model,
+static int health_period_get(const struct bt_mesh_model *model,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -317,7 +317,7 @@ static int health_period_get(struct bt_mesh_model *model,
 	return send_health_period_status(model, ctx);
 }
 
-static int health_period_set_unrel(struct bt_mesh_model *model,
+static int health_period_set_unrel(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -336,7 +336,7 @@ static int health_period_set_unrel(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int health_period_set(struct bt_mesh_model *model,
+static int health_period_set(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -367,7 +367,7 @@ const struct bt_mesh_model_op bt_mesh_health_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int health_pub_update(struct bt_mesh_model *mod)
+static int health_pub_update(const struct bt_mesh_model *mod)
 {
 	struct bt_mesh_model_pub *pub = mod->pub;
 	size_t count;
@@ -386,7 +386,7 @@ static int health_pub_update(struct bt_mesh_model *mod)
 
 int bt_mesh_health_srv_fault_update(struct bt_mesh_elem *elem)
 {
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 
 	mod = bt_mesh_model_find(elem, BT_MESH_MODEL_ID_HEALTH_SRV);
 	if (!mod) {
@@ -418,7 +418,7 @@ static void attention_off(struct k_work *work)
 	}
 }
 
-static int health_srv_init(struct bt_mesh_model *model)
+static int health_srv_init(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_health_srv *srv = model->user_data;
 
@@ -449,7 +449,7 @@ const struct bt_mesh_model_cb bt_mesh_health_srv_cb = {
 	.init = health_srv_init,
 };
 
-void bt_mesh_attention(struct bt_mesh_model *model, uint8_t time)
+void bt_mesh_attention(const struct bt_mesh_model *model, uint8_t time)
 {
 	struct bt_mesh_health_srv *srv;
 

--- a/subsys/bluetooth/mesh/large_comp_data_cli.c
+++ b/subsys/bluetooth/mesh/large_comp_data_cli.c
@@ -33,7 +33,7 @@ LOG_MODULE_REGISTER(bt_mesh_large_comp_data_cli);
 static struct bt_mesh_large_comp_data_cli *cli;
 static int32_t msg_timeout;
 
-static int data_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int data_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf, uint32_t op,
 		       void (*cb)(struct bt_mesh_large_comp_data_cli *cli, uint16_t addr,
 				  struct bt_mesh_large_comp_data_rsp *rsp))
@@ -78,7 +78,7 @@ static int data_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int large_comp_data_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int large_comp_data_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
 	return data_status(model, ctx, buf, OP_LARGE_COMP_DATA_STATUS,
@@ -86,7 +86,7 @@ static int large_comp_data_status(struct bt_mesh_model *model, struct bt_mesh_ms
 			    cli->cb->large_comp_data_status : NULL));
 }
 
-static int models_metadata_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int models_metadata_status(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
 	return data_status(model, ctx, buf, OP_MODELS_METADATA_STATUS,
@@ -100,7 +100,7 @@ const struct bt_mesh_model_op _bt_mesh_large_comp_data_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int large_comp_data_cli_init(struct bt_mesh_model *model)
+static int large_comp_data_cli_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Large Comp Data Client only allowed in primary element");
@@ -108,7 +108,7 @@ static int large_comp_data_cli_init(struct bt_mesh_model *model)
 	}
 
 	model->keys[0] = BT_MESH_KEY_DEV_ANY;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	cli = model->user_data;
 	cli->model = model;

--- a/subsys/bluetooth/mesh/large_comp_data_srv.c
+++ b/subsys/bluetooth/mesh/large_comp_data_srv.c
@@ -37,10 +37,11 @@ LOG_MODULE_REGISTER(bt_mesh_large_comp_data_srv);
 /** Mesh Large Composition Data Server Model Context */
 static struct bt_mesh_large_comp_data_srv {
 	/** Composition data model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 } srv;
 
-static int handle_large_comp_data_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int handle_large_comp_data_get(const struct bt_mesh_model *model,
+				      struct bt_mesh_msg_ctx *ctx,
 				      struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(rsp, OP_LARGE_COMP_DATA_STATUS,
@@ -86,7 +87,8 @@ static int handle_large_comp_data_get(struct bt_mesh_model *model, struct bt_mes
 	return 0;
 }
 
-static int handle_models_metadata_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int handle_models_metadata_get(const struct bt_mesh_model *model,
+				      struct bt_mesh_msg_ctx *ctx,
 				      struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(rsp, OP_MODELS_METADATA_STATUS,
@@ -151,7 +153,7 @@ const struct bt_mesh_model_op _bt_mesh_large_comp_data_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int large_comp_data_srv_init(struct bt_mesh_model *model)
+static int large_comp_data_srv_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Large Composition Data Server only allowed in primary element");
@@ -160,7 +162,7 @@ static int large_comp_data_srv_init(struct bt_mesh_model *model)
 
 	/* Large Composition Data Server model shall use the device key */
 	model->keys[0] = BT_MESH_KEY_DEV;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	srv.model = model;
 

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -419,7 +419,7 @@ bool bt_mesh_is_provisioned(void)
 	return atomic_test_bit(bt_mesh.flags, BT_MESH_VALID);
 }
 
-static void model_suspend(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void model_suspend(const struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 			  bool vnd, bool primary, void *user_data)
 {
 	if (mod->pub && mod->pub->update) {
@@ -463,7 +463,7 @@ int bt_mesh_suspend(void)
 	return 0;
 }
 
-static void model_resume(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void model_resume(const struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 			  bool vnd, bool primary, void *user_data)
 {
 	if (mod->pub && mod->pub->update) {
@@ -552,7 +552,7 @@ int bt_mesh_init(const struct bt_mesh_prov *prov,
 	return 0;
 }
 
-static void model_start(struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
+static void model_start(const struct bt_mesh_model *mod, struct bt_mesh_elem *elem,
 			bool vnd, bool primary, void *user_data)
 {
 	if (mod->cb && mod->cb->start) {

--- a/subsys/bluetooth/mesh/msg.c
+++ b/subsys/bluetooth/mesh/msg.c
@@ -87,7 +87,7 @@ bool bt_mesh_msg_ack_ctx_match(const struct bt_mesh_msg_ack_ctx *ack,
 	return true;
 }
 
-int bt_mesh_msg_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_msg_send(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		     struct net_buf_simple *buf)
 {
 	if (!ctx && !model->pub) {
@@ -104,7 +104,7 @@ int bt_mesh_msg_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return bt_mesh_model_publish(model);
 }
 
-int bt_mesh_msg_ackd_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_msg_ackd_send(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf, const struct bt_mesh_msg_rsp_ctx *rsp)
 {
 	int err;

--- a/subsys/bluetooth/mesh/msg.h
+++ b/subsys/bluetooth/mesh/msg.h
@@ -18,7 +18,7 @@
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is not configured.
  * @retval -EAGAIN The device has not been provisioned.
  */
-int bt_mesh_msg_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_msg_send(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		     struct net_buf_simple *buf);
 
 /**
@@ -51,5 +51,5 @@ struct bt_mesh_msg_rsp_ctx {
  * @retval -EAGAIN The device has not been provisioned.
  * @retval -ETIMEDOUT The request timed out without a response.
  */
-int bt_mesh_msg_ackd_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+int bt_mesh_msg_ackd_send(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf, const struct bt_mesh_msg_rsp_ctx *rsp);

--- a/subsys/bluetooth/mesh/od_priv_proxy_cli.c
+++ b/subsys/bluetooth/mesh/od_priv_proxy_cli.c
@@ -20,7 +20,7 @@ static struct bt_mesh_od_priv_proxy_cli *cli;
 
 static int32_t msg_timeout;
 
-static int handle_proxy_status(struct bt_mesh_model *mod,
+static int handle_proxy_status(const struct bt_mesh_model *mod,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -91,7 +91,7 @@ void bt_mesh_od_priv_proxy_cli_timeout_set(int32_t timeout)
 	msg_timeout = timeout;
 }
 
-static int on_demand_proxy_cli_init(struct bt_mesh_model *mod)
+static int on_demand_proxy_cli_init(const struct bt_mesh_model *mod)
 {
 	if (!bt_mesh_model_in_primary(mod)) {
 		LOG_ERR("On-Demand Private Proxy client not in primary element");
@@ -101,7 +101,7 @@ static int on_demand_proxy_cli_init(struct bt_mesh_model *mod)
 	cli = mod->user_data;
 	cli->model = mod;
 	mod->keys[0] = BT_MESH_KEY_DEV_ANY;
-	mod->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	mod->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 	msg_timeout = CONFIG_BT_MESH_OD_PRIV_PROXY_CLI_TIMEOUT;
 
 	bt_mesh_msg_ack_ctx_init(&cli->ack_ctx);

--- a/subsys/bluetooth/mesh/od_priv_proxy_srv.c
+++ b/subsys/bluetooth/mesh/od_priv_proxy_srv.c
@@ -14,7 +14,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_od_priv_proxy_srv);
 
-static int proxy_status_rsp(struct bt_mesh_model *mod,
+static int proxy_status_rsp(const struct bt_mesh_model *mod,
 			    struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(buf, OP_OD_PRIV_PROXY_STATUS, 1);
@@ -27,7 +27,7 @@ static int proxy_status_rsp(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_proxy_get(struct bt_mesh_model *mod,
+static int handle_proxy_get(const struct bt_mesh_model *mod,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -38,7 +38,7 @@ static int handle_proxy_get(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_proxy_set(struct bt_mesh_model *mod,
+static int handle_proxy_set(const struct bt_mesh_model *mod,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -62,11 +62,11 @@ const struct bt_mesh_model_op _bt_mesh_od_priv_proxy_srv_op[] = {
 	BT_MESH_MODEL_OP_END
 };
 
-static int od_priv_proxy_srv_init(struct bt_mesh_model *mod)
+static int od_priv_proxy_srv_init(const struct bt_mesh_model *mod)
 {
-	struct bt_mesh_model *priv_beacon_srv = bt_mesh_model_find(
+	const struct bt_mesh_model *priv_beacon_srv = bt_mesh_model_find(
 		bt_mesh_model_elem(mod), BT_MESH_MODEL_ID_PRIV_BEACON_SRV);
-	struct bt_mesh_model *sol_pdu_rpl_srv = bt_mesh_model_find(
+	const struct bt_mesh_model *sol_pdu_rpl_srv = bt_mesh_model_find(
 		bt_mesh_model_elem(mod), BT_MESH_MODEL_ID_SOL_PDU_RPL_SRV);
 
 	if (priv_beacon_srv == NULL) {
@@ -79,7 +79,7 @@ static int od_priv_proxy_srv_init(struct bt_mesh_model *mod)
 	}
 
 	mod->keys[0] = BT_MESH_KEY_DEV_LOCAL;
-	mod->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	mod->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
 		bt_mesh_model_extend(mod, priv_beacon_srv);

--- a/subsys/bluetooth/mesh/op_agg.c
+++ b/subsys/bluetooth/mesh/op_agg.c
@@ -50,7 +50,7 @@ void bt_mesh_op_agg_ctx_reinit(void)
 	agg_ctx.initialized = true;
 }
 
-int bt_mesh_op_agg_send(struct bt_mesh_model *model,
+int bt_mesh_op_agg_send(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *msg,
 			const struct bt_mesh_send_cb *cb)
 {

--- a/subsys/bluetooth/mesh/op_agg.h
+++ b/subsys/bluetooth/mesh/op_agg.h
@@ -46,6 +46,6 @@ int bt_mesh_op_agg_decode_msg(struct net_buf_simple *msg,
 
 int bt_mesh_op_agg_accept(struct bt_mesh_msg_ctx *ctx);
 
-int bt_mesh_op_agg_send(struct bt_mesh_model *model,
+int bt_mesh_op_agg_send(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *msg,
 			const struct bt_mesh_send_cb *cb);

--- a/subsys/bluetooth/mesh/op_agg_cli.c
+++ b/subsys/bluetooth/mesh/op_agg_cli.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(bt_mesh_op_agg_cli);
 /** Mesh Opcodes Aggregator Client Model Context */
 static struct bt_mesh_op_agg_cli {
 	/** Composition data model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 
 	/* Internal parameters for tracking message responses. */
 	struct bt_mesh_msg_ack_ctx ack_ctx;
@@ -29,7 +29,7 @@ static struct bt_mesh_op_agg_cli {
 
 static int32_t msg_timeout;
 
-static int handle_status(struct bt_mesh_model *model,
+static int handle_status(const struct bt_mesh_model *model,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -93,7 +93,7 @@ const struct bt_mesh_model_op _bt_mesh_op_agg_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int op_agg_cli_init(struct bt_mesh_model *model)
+static int op_agg_cli_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Opcodes Aggregator Client only allowed in primary element");

--- a/subsys/bluetooth/mesh/op_agg_srv.c
+++ b/subsys/bluetooth/mesh/op_agg_srv.c
@@ -20,10 +20,10 @@ LOG_MODULE_REGISTER(bt_mesh_op_agg_srv);
 /** Mesh Opcodes Aggragator Server Model Context */
 static struct bt_mesh_op_agg_srv {
 	/** Composition data model entry pointer. */
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 } srv;
 
-static int handle_sequence(struct bt_mesh_model *model,
+static int handle_sequence(const struct bt_mesh_model *model,
 			   struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
@@ -105,7 +105,7 @@ const struct bt_mesh_model_op _bt_mesh_op_agg_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int op_agg_srv_init(struct bt_mesh_model *model)
+static int op_agg_srv_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Opcodes Aggregator Server only allowed in primary element");

--- a/subsys/bluetooth/mesh/priv_beacon_cli.c
+++ b/subsys/bluetooth/mesh/priv_beacon_cli.c
@@ -18,7 +18,7 @@ static struct bt_mesh_priv_beacon_cli *cli;
 
 static int32_t msg_timeout;
 
-static int handle_beacon_status(struct bt_mesh_model *model,
+static int handle_beacon_status(const struct bt_mesh_model *model,
 				struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
@@ -56,7 +56,7 @@ static int handle_beacon_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int handle_gatt_proxy_status(struct bt_mesh_model *model,
+static int handle_gatt_proxy_status(const struct bt_mesh_model *model,
 				    struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
@@ -86,7 +86,7 @@ static int handle_gatt_proxy_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int handle_node_id_status(struct bt_mesh_model *model,
+static int handle_node_id_status(const struct bt_mesh_model *model,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -134,7 +134,7 @@ const struct bt_mesh_model_op bt_mesh_priv_beacon_cli_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int priv_beacon_cli_init(struct bt_mesh_model *model)
+static int priv_beacon_cli_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Private Beacon Client only allowed in primary element");
@@ -145,7 +145,7 @@ static int priv_beacon_cli_init(struct bt_mesh_model *model)
 	cli->model = model;
 	msg_timeout = 2 * MSEC_PER_SEC;
 	model->keys[0] = BT_MESH_KEY_DEV_ANY;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	bt_mesh_msg_ack_ctx_init(&cli->ack_ctx);
 

--- a/subsys/bluetooth/mesh/priv_beacon_srv.c
+++ b/subsys/bluetooth/mesh/priv_beacon_srv.c
@@ -16,7 +16,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_priv_beacon_srv);
 
-static int beacon_status_rsp(struct bt_mesh_model *mod,
+static int beacon_status_rsp(const struct bt_mesh_model *mod,
 			      struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(buf, OP_PRIV_BEACON_STATUS, 2);
@@ -30,7 +30,7 @@ static int beacon_status_rsp(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_beacon_get(struct bt_mesh_model *mod,
+static int handle_beacon_get(const struct bt_mesh_model *mod,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -41,7 +41,7 @@ static int handle_beacon_get(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_beacon_set(struct bt_mesh_model *mod,
+static int handle_beacon_set(const struct bt_mesh_model *mod,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -68,7 +68,7 @@ static int handle_beacon_set(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static void gatt_proxy_status_rsp(struct bt_mesh_model *mod,
+static void gatt_proxy_status_rsp(const struct bt_mesh_model *mod,
 				  struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(buf, OP_PRIV_GATT_PROXY_STATUS, 1);
@@ -79,7 +79,7 @@ static void gatt_proxy_status_rsp(struct bt_mesh_model *mod,
 	bt_mesh_model_send(mod, ctx, &buf, NULL, NULL);
 }
 
-static int handle_gatt_proxy_get(struct bt_mesh_model *mod,
+static int handle_gatt_proxy_get(const struct bt_mesh_model *mod,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -90,7 +90,7 @@ static int handle_gatt_proxy_get(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_gatt_proxy_set(struct bt_mesh_model *mod,
+static int handle_gatt_proxy_set(const struct bt_mesh_model *mod,
 				 struct bt_mesh_msg_ctx *ctx,
 				 struct net_buf_simple *buf)
 {
@@ -112,7 +112,7 @@ static int handle_gatt_proxy_set(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static void node_id_status_rsp(struct bt_mesh_model *mod,
+static void node_id_status_rsp(const struct bt_mesh_model *mod,
 			       struct bt_mesh_msg_ctx *ctx, uint8_t status,
 			       uint16_t net_idx, uint8_t node_id)
 {
@@ -126,7 +126,7 @@ static void node_id_status_rsp(struct bt_mesh_model *mod,
 	bt_mesh_model_send(mod, ctx, &buf, NULL, NULL);
 }
 
-static int handle_node_id_get(struct bt_mesh_model *mod,
+static int handle_node_id_get(const struct bt_mesh_model *mod,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -141,7 +141,7 @@ static int handle_node_id_get(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_node_id_set(struct bt_mesh_model *mod,
+static int handle_node_id_set(const struct bt_mesh_model *mod,
 			      struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
@@ -172,7 +172,7 @@ const struct bt_mesh_model_op bt_mesh_priv_beacon_srv_op[] = {
 	BT_MESH_MODEL_OP_END
 };
 
-static int priv_beacon_srv_init(struct bt_mesh_model *mod)
+static int priv_beacon_srv_init(const struct bt_mesh_model *mod)
 {
 	if (!bt_mesh_model_in_primary(mod)) {
 		LOG_ERR("Priv beacon server not in primary element");

--- a/subsys/bluetooth/mesh/rpr_cli.c
+++ b/subsys/bluetooth/mesh/rpr_cli.c
@@ -90,7 +90,7 @@ static void tx_complete(struct bt_mesh_rpr_cli *cli, int err, void *cb_data)
 	}
 }
 
-static int handle_extended_scan_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_extended_scan_report(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				       struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_node srv = RPR_NODE(ctx);
@@ -123,7 +123,7 @@ static int handle_extended_scan_report(struct bt_mesh_model *mod, struct bt_mesh
 	return 0;
 }
 
-static int handle_link_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_link_report(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_node srv = RPR_NODE(ctx);
@@ -161,7 +161,7 @@ static int handle_link_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 	return 0;
 }
 
-static int handle_link_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_link_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_cli *cli = mod->user_data;
@@ -195,7 +195,7 @@ static int handle_link_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 	return 0;
 }
 
-static int handle_pdu_outbound_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_pdu_outbound_report(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				      struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_cli *cli = mod->user_data;
@@ -226,7 +226,7 @@ static int handle_pdu_outbound_report(struct bt_mesh_model *mod, struct bt_mesh_
 	return 0;
 }
 
-static int handle_pdu_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_pdu_report(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_cli *cli = mod->user_data;
@@ -257,7 +257,7 @@ static int handle_pdu_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *
 	return 0;
 }
 
-static int handle_scan_caps_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_caps_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				   struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_cli *cli = mod->user_data;
@@ -281,7 +281,7 @@ static int handle_scan_caps_status(struct bt_mesh_model *mod, struct bt_mesh_msg
 	return 0;
 }
 
-static int handle_scan_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_report(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_cli *cli = mod->user_data;
@@ -313,7 +313,7 @@ static int handle_scan_report(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 	return 0;
 }
 
-static int handle_scan_status(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			      struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_cli *cli = mod->user_data;
@@ -361,9 +361,9 @@ static void link_timeout(struct k_work *work)
 	}
 }
 
-static int rpr_cli_init(struct bt_mesh_model *mod)
+static int rpr_cli_init(const struct bt_mesh_model *mod)
 {
-	if (mod->elem_idx) {
+	if (mod->ctx->elem_idx) {
 		LOG_ERR("Remote provisioning client must be initialized "
 			"on first element");
 		return -EINVAL;
@@ -378,7 +378,7 @@ static int rpr_cli_init(struct bt_mesh_model *mod)
 	bt_mesh_msg_ack_ctx_init(&cli->prov_ack_ctx);
 	k_work_init_delayable(&cli->link.timeout, link_timeout);
 	mod->keys[0] = BT_MESH_KEY_DEV_ANY;
-	mod->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	mod->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/rpr_srv.c
+++ b/subsys/bluetooth/mesh/rpr_srv.c
@@ -47,7 +47,7 @@ enum {
 
 /** Remote provisioning server instance. */
 static struct {
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 
 	ATOMIC_DEFINE(flags, RPR_SRV_NUM_FLAGS);
 
@@ -534,7 +534,7 @@ static const struct prov_bearer_cb prov_bearer_cb = {
  * Message handlers
  ******************************************************************************/
 
-static int handle_scan_caps_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_caps_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(rsp, RPR_OP_SCAN_CAPS_STATUS, 2);
@@ -547,7 +547,7 @@ static int handle_scan_caps_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ct
 	return 0;
 }
 
-static int handle_scan_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	scan_status_send(ctx, BT_MESH_RPR_SUCCESS);
@@ -555,7 +555,7 @@ static int handle_scan_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ct
 	return 0;
 }
 
-static int handle_scan_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_node cli = RPR_NODE(ctx);
@@ -619,7 +619,7 @@ rsp:
 	return 0;
 }
 
-static int handle_extended_scan_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_extended_scan_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 				      struct net_buf_simple *buf)
 {
 	BT_MESH_MODEL_BUF_DEFINE(rsp, RPR_OP_EXTENDED_SCAN_REPORT,
@@ -782,7 +782,7 @@ rsp:
 	return 0;
 }
 
-static int handle_scan_stop(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_scan_stop(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
 	if (atomic_test_bit(srv.flags, SCANNING)) {
@@ -795,7 +795,7 @@ static int handle_scan_stop(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *c
 	return 0;
 }
 
-static int handle_link_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_link_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	LOG_DBG("");
@@ -805,7 +805,7 @@ static int handle_link_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ct
 	return 0;
 }
 
-static int handle_link_open(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_link_open(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
 	bool is_refresh_procedure = (buf->len == 1);
@@ -936,7 +936,7 @@ rsp:
 	return 0;
 }
 
-static int handle_link_close(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_link_close(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_node cli = RPR_NODE(ctx);
@@ -973,7 +973,7 @@ static int handle_link_close(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *
 	return 0;
 }
 
-static int handle_pdu_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int handle_pdu_send(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_rpr_node cli = RPR_NODE(ctx);
@@ -1301,9 +1301,9 @@ static struct bt_le_scan_cb scan_cb = {
 	.recv = scan_packet_recv,
 };
 
-static int rpr_srv_init(struct bt_mesh_model *mod)
+static int rpr_srv_init(const struct bt_mesh_model *mod)
 {
-	if (mod->elem_idx || srv.mod) {
+	if (mod->ctx->elem_idx || srv.mod) {
 		LOG_ERR("Remote provisioning server must be initialized "
 			"on first element");
 		return -EINVAL;
@@ -1318,12 +1318,12 @@ static int rpr_srv_init(struct bt_mesh_model *mod)
 	k_work_init(&srv.link.report, link_report_send_and_clear);
 	bt_le_scan_cb_register(&scan_cb);
 	mod->keys[0] = BT_MESH_KEY_DEV_LOCAL;
-	mod->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	mod->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	return 0;
 }
 
-static void rpr_srv_reset(struct bt_mesh_model *mod)
+static void rpr_srv_reset(const struct bt_mesh_model *mod)
 {
 	cli_link_clear();
 	cli_scan_clear();

--- a/subsys/bluetooth/mesh/sar_cfg_cli.c
+++ b/subsys/bluetooth/mesh/sar_cfg_cli.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(bt_mesh_sar_cfg_cli);
 
 static struct bt_mesh_sar_cfg_cli *cli;
 
-static int transmitter_status(struct bt_mesh_model *model,
+static int transmitter_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
@@ -45,7 +45,7 @@ static int transmitter_status(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int receiver_status(struct bt_mesh_model *model,
+static int receiver_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
@@ -87,7 +87,7 @@ void bt_mesh_sar_cfg_cli_timeout_set(int32_t timeout)
 	cli->timeout = timeout;
 }
 
-static int bt_mesh_sar_cfg_cli_init(struct bt_mesh_model *model)
+static int bt_mesh_sar_cfg_cli_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("SAR Configuration Client only allowed in primary element");
@@ -104,14 +104,14 @@ static int bt_mesh_sar_cfg_cli_init(struct bt_mesh_model *model)
 	cli->timeout = 2 * MSEC_PER_SEC;
 
 	model->keys[0] = BT_MESH_KEY_DEV_ANY;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	bt_mesh_msg_ack_ctx_init(&cli->ack_ctx);
 
 	return 0;
 }
 
-static void bt_mesh_sar_cfg_cli_reset(struct bt_mesh_model *model)
+static void bt_mesh_sar_cfg_cli_reset(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_sar_cfg_cli *model_cli;
 

--- a/subsys/bluetooth/mesh/sar_cfg_srv.c
+++ b/subsys/bluetooth/mesh/sar_cfg_srv.c
@@ -27,7 +27,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_sar_cfg_srv);
 
-static int sar_rx_store(struct bt_mesh_model *model, bool delete)
+static int sar_rx_store(const struct bt_mesh_model *model, bool delete)
 {
 	const void *data = delete ? NULL : &bt_mesh.sar_rx;
 	size_t len = delete ? 0 : sizeof(struct bt_mesh_sar_rx);
@@ -35,7 +35,7 @@ static int sar_rx_store(struct bt_mesh_model *model, bool delete)
 	return bt_mesh_model_data_store(model, false, "sar_rx", data, len);
 }
 
-static int sar_tx_store(struct bt_mesh_model *model, bool delete)
+static int sar_tx_store(const struct bt_mesh_model *model, bool delete)
 {
 	const void *data = delete ? NULL : &bt_mesh.sar_tx;
 	size_t len = delete ? 0 : sizeof(struct bt_mesh_sar_tx);
@@ -43,7 +43,7 @@ static int sar_tx_store(struct bt_mesh_model *model, bool delete)
 	return bt_mesh_model_data_store(model, false, "sar_tx", data, len);
 }
 
-static void transmitter_status(struct bt_mesh_model *model,
+static void transmitter_status(const struct bt_mesh_model *model,
 			       struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_SAR_CFG_TX_STATUS, BT_MESH_SAR_TX_LEN);
@@ -63,7 +63,7 @@ static void transmitter_status(struct bt_mesh_model *model,
 	}
 }
 
-static void receiver_status(struct bt_mesh_model *model,
+static void receiver_status(const struct bt_mesh_model *model,
 			    struct bt_mesh_msg_ctx *ctx)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_SAR_CFG_RX_STATUS, BT_MESH_SAR_RX_LEN);
@@ -81,7 +81,7 @@ static void receiver_status(struct bt_mesh_model *model,
 	}
 }
 
-static int transmitter_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int transmitter_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	LOG_DBG("src 0x%04x", ctx->addr);
@@ -91,7 +91,7 @@ static int transmitter_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *
 	return 0;
 }
 
-static int transmitter_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int transmitter_set(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			   struct net_buf_simple *buf)
 {
 	struct bt_mesh_sar_tx *tx = &bt_mesh.sar_tx;
@@ -108,7 +108,7 @@ static int transmitter_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *
 	return 0;
 }
 
-static int receiver_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int receiver_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	LOG_DBG("src 0x%04x", ctx->addr);
@@ -118,7 +118,7 @@ static int receiver_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx
 	return 0;
 }
 
-static int receiver_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int receiver_set(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
 	struct bt_mesh_sar_rx *rx = &bt_mesh.sar_rx;
@@ -143,7 +143,7 @@ const struct bt_mesh_model_op bt_mesh_sar_cfg_srv_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static int sar_cfg_srv_init(struct bt_mesh_model *model)
+static int sar_cfg_srv_init(const struct bt_mesh_model *model)
 {
 	if (!bt_mesh_model_in_primary(model)) {
 		LOG_ERR("Configuration Server only allowed in primary element");
@@ -155,12 +155,12 @@ static int sar_cfg_srv_init(struct bt_mesh_model *model)
 	 * device-key is allowed to access this model.
 	 */
 	model->keys[0] = BT_MESH_KEY_DEV_LOCAL;
-	model->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	model->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	return 0;
 }
 
-static void sar_cfg_srv_reset(struct bt_mesh_model *model)
+static void sar_cfg_srv_reset(const struct bt_mesh_model *model)
 {
 	struct bt_mesh_sar_tx sar_tx = BT_MESH_SAR_TX_INIT;
 	struct bt_mesh_sar_rx sar_rx = BT_MESH_SAR_RX_INIT;
@@ -175,7 +175,8 @@ static void sar_cfg_srv_reset(struct bt_mesh_model *model)
 }
 
 #ifdef CONFIG_BT_SETTINGS
-static int sar_cfg_srv_settings_set(struct bt_mesh_model *model, const char *name, size_t len_rd,
+static int sar_cfg_srv_settings_set(const struct bt_mesh_model *model,
+				    const char *name, size_t len_rd,
 				    settings_read_cb read_cb, void *cb_data)
 {
 	if (!strncmp(name, "sar_rx", 5)) {

--- a/subsys/bluetooth/mesh/shell/blob.c
+++ b/subsys/bluetooth/mesh/shell/blob.c
@@ -271,7 +271,7 @@ static int cmd_flash_stream_unset(const struct shell *sh, size_t argc, char *arg
 
 #if defined(CONFIG_BT_MESH_SHELL_BLOB_CLI)
 
-static struct bt_mesh_model *mod_cli;
+static const struct bt_mesh_model *mod_cli;
 
 static void blob_cli_inputs_prepare(uint16_t group)
 {
@@ -503,7 +503,7 @@ static int cmd_tx_resume(const struct shell *sh, size_t argc, char *argv[])
 
 #if defined(CONFIG_BT_MESH_SHELL_BLOB_SRV)
 
-static struct bt_mesh_model *mod_srv;
+static const struct bt_mesh_model *mod_srv;
 
 static int cmd_rx(const struct shell *sh, size_t argc, char *argv[])
 {

--- a/subsys/bluetooth/mesh/shell/dfd.c
+++ b/subsys/bluetooth/mesh/shell/dfd.c
@@ -14,7 +14,7 @@
 #include "../dfd_srv_internal.h"
 #include "../access.h"
 
-static struct bt_mesh_model *mod;
+static const struct bt_mesh_model *mod;
 
 static void print_receivers_status(const struct shell *sh, struct bt_mesh_dfd_srv *srv,
 				   enum bt_mesh_dfd_status status)

--- a/subsys/bluetooth/mesh/shell/dfu.c
+++ b/subsys/bluetooth/mesh/shell/dfu.c
@@ -516,7 +516,7 @@ static int cmd_dfu_slot_get(const struct shell *sh, size_t argc, char *argv[])
 
 #if defined(CONFIG_BT_MESH_SHELL_DFU_CLI)
 
-static struct bt_mesh_model *mod_cli;
+static const struct bt_mesh_model *mod_cli;
 
 static struct {
 	struct bt_mesh_dfu_target targets[32];
@@ -907,7 +907,7 @@ static int cmd_dfu_tx_progress(const struct shell *sh, size_t argc, char *argv[]
 
 #if defined(CONFIG_BT_MESH_SHELL_DFU_SRV)
 
-static struct bt_mesh_model *mod_srv;
+static const struct bt_mesh_model *mod_srv;
 
 static int cmd_dfu_applied(const struct shell *sh, size_t argc, char *argv[])
 {

--- a/subsys/bluetooth/mesh/shell/health.c
+++ b/subsys/bluetooth/mesh/shell/health.c
@@ -13,7 +13,7 @@
 #include "utils.h"
 #include <zephyr/bluetooth/mesh/shell.h>
 
-static struct bt_mesh_model *mod;
+static const struct bt_mesh_model *mod;
 
 static void show_faults(const struct shell *sh, uint8_t test_id, uint16_t cid, uint8_t *faults,
 			size_t fault_count)

--- a/subsys/bluetooth/mesh/shell/rpr.c
+++ b/subsys/bluetooth/mesh/shell/rpr.c
@@ -11,7 +11,7 @@
 
 #include "utils.h"
 
-static struct bt_mesh_model *mod;
+static const struct bt_mesh_model *mod;
 
 /***************************************************************************************************
  * Implementation of the model's instance

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -68,7 +68,7 @@ static void get_faults(uint8_t *faults, uint8_t faults_size, uint8_t *dst, uint8
 	}
 }
 
-static int fault_get_cur(struct bt_mesh_model *model, uint8_t *test_id,
+static int fault_get_cur(const struct bt_mesh_model *model, uint8_t *test_id,
 			 uint16_t *company_id, uint8_t *faults, uint8_t *fault_count)
 {
 	shell_print_ctx("Sending current faults");
@@ -81,7 +81,7 @@ static int fault_get_cur(struct bt_mesh_model *model, uint8_t *test_id,
 	return 0;
 }
 
-static int fault_get_reg(struct bt_mesh_model *model, uint16_t cid,
+static int fault_get_reg(const struct bt_mesh_model *model, uint16_t cid,
 			 uint8_t *test_id, uint8_t *faults, uint8_t *fault_count)
 {
 	if (cid != CONFIG_BT_COMPANY_ID) {
@@ -99,7 +99,7 @@ static int fault_get_reg(struct bt_mesh_model *model, uint16_t cid,
 	return 0;
 }
 
-static int fault_clear(struct bt_mesh_model *model, uint16_t cid)
+static int fault_clear(const struct bt_mesh_model *model, uint16_t cid)
 {
 	if (cid != CONFIG_BT_COMPANY_ID) {
 		return -EINVAL;
@@ -110,7 +110,7 @@ static int fault_clear(struct bt_mesh_model *model, uint16_t cid)
 	return 0;
 }
 
-static int fault_test(struct bt_mesh_model *model, uint8_t test_id,
+static int fault_test(const struct bt_mesh_model *model, uint8_t test_id,
 		      uint16_t cid)
 {
 	if (cid != CONFIG_BT_COMPANY_ID) {
@@ -124,12 +124,12 @@ static int fault_test(struct bt_mesh_model *model, uint8_t test_id,
 	return 0;
 }
 
-static void attention_on(struct bt_mesh_model *model)
+static void attention_on(const struct bt_mesh_model *model)
 {
 	shell_print_ctx("Attention On");
 }
 
-static void attention_off(struct bt_mesh_model *model)
+static void attention_off(const struct bt_mesh_model *model)
 {
 	shell_print_ctx("Attention Off");
 }

--- a/subsys/bluetooth/mesh/shell/utils.c
+++ b/subsys/bluetooth/mesh/shell/utils.c
@@ -13,7 +13,7 @@
 #include "mesh/access.h"
 #include "utils.h"
 
-bool bt_mesh_shell_mdl_first_get(uint16_t id, struct bt_mesh_model **mod)
+bool bt_mesh_shell_mdl_first_get(uint16_t id, const struct bt_mesh_model **mod)
 {
 	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
 
@@ -27,10 +27,10 @@ bool bt_mesh_shell_mdl_first_get(uint16_t id, struct bt_mesh_model **mod)
 	return false;
 }
 
-int bt_mesh_shell_mdl_instance_set(const struct shell *sh, struct bt_mesh_model **mod,
+int bt_mesh_shell_mdl_instance_set(const struct shell *sh, const struct bt_mesh_model **mod,
 				 uint16_t mod_id, uint8_t elem_idx)
 {
-	struct bt_mesh_model *mod_temp;
+	const struct bt_mesh_model *mod_temp;
 	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
 
 	if (elem_idx >= comp->elem_count) {
@@ -53,14 +53,14 @@ int bt_mesh_shell_mdl_instance_set(const struct shell *sh, struct bt_mesh_model 
 int bt_mesh_shell_mdl_print_all(const struct shell *sh, uint16_t mod_id)
 {
 	const struct bt_mesh_comp *comp = bt_mesh_comp_get();
-	struct bt_mesh_model *mod;
+	const struct bt_mesh_model *mod;
 
 	for (int i = 0; i < comp->elem_count; i++) {
 		mod = bt_mesh_model_find(&comp->elem[i], mod_id);
 		if (mod) {
 			shell_print(sh,
 				    "Client model instance found at addr 0x%.4X. Element index: %d",
-				    comp->elem[i].addr, mod->elem_idx);
+				    comp->elem[i].addr, mod->ctx->elem_idx);
 		}
 	}
 

--- a/subsys/bluetooth/mesh/shell/utils.h
+++ b/subsys/bluetooth/mesh/shell/utils.h
@@ -34,9 +34,9 @@
 					     0), \
 			       SHELL_SUBCMD_SET_END);
 
-bool bt_mesh_shell_mdl_first_get(uint16_t id, struct bt_mesh_model **mod);
+bool bt_mesh_shell_mdl_first_get(uint16_t id, const struct bt_mesh_model **mod);
 
-int bt_mesh_shell_mdl_instance_set(const struct shell *sh, struct bt_mesh_model **mod,
+int bt_mesh_shell_mdl_instance_set(const struct shell *sh, const struct bt_mesh_model **mod,
 			      uint16_t mod_id, uint8_t elem_idx);
 
 int bt_mesh_shell_mdl_print_all(const struct shell *sh, uint16_t mod_id);

--- a/subsys/bluetooth/mesh/sol_pdu_rpl_cli.c
+++ b/subsys/bluetooth/mesh/sol_pdu_rpl_cli.c
@@ -22,7 +22,7 @@ struct sol_rpl_param {
 	uint8_t *len;
 };
 
-static int handle_status(struct bt_mesh_model *mod,
+static int handle_status(const struct bt_mesh_model *mod,
 			 struct bt_mesh_msg_ctx *ctx,
 			 struct net_buf_simple *buf)
 {
@@ -160,7 +160,7 @@ void bt_mesh_sol_pdu_rpl_cli_timeout_set(int32_t timeout)
 	msg_timeout = timeout;
 }
 
-static int sol_pdu_rpl_cli_init(struct bt_mesh_model *mod)
+static int sol_pdu_rpl_cli_init(const struct bt_mesh_model *mod)
 {
 	if (!bt_mesh_model_in_primary(mod)) {
 		LOG_ERR("Solicitation PDU RPL Configuration client not in primary element");

--- a/subsys/bluetooth/mesh/sol_pdu_rpl_srv.c
+++ b/subsys/bluetooth/mesh/sol_pdu_rpl_srv.c
@@ -14,7 +14,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_sol_pdu_rpl_srv);
 
-static void sol_rpl_status_rsp(struct bt_mesh_model *mod,
+static void sol_rpl_status_rsp(const struct bt_mesh_model *mod,
 			       struct bt_mesh_msg_ctx *ctx,
 			       uint16_t range,
 			       uint8_t len)
@@ -32,7 +32,7 @@ static void sol_rpl_status_rsp(struct bt_mesh_model *mod,
 	bt_mesh_model_send(mod, ctx, &buf, NULL, NULL);
 }
 
-static int item_clear(struct bt_mesh_model *mod,
+static int item_clear(const struct bt_mesh_model *mod,
 		      struct bt_mesh_msg_ctx *ctx,
 		      struct net_buf_simple *buf,
 		      bool acked)
@@ -78,14 +78,14 @@ static int item_clear(struct bt_mesh_model *mod,
 	return 0;
 }
 
-static int handle_item_clear(struct bt_mesh_model *mod,
+static int handle_item_clear(const struct bt_mesh_model *mod,
 			    struct bt_mesh_msg_ctx *ctx,
 			    struct net_buf_simple *buf)
 {
 	return item_clear(mod, ctx, buf, true);
 }
 
-static int handle_item_clear_unacked(struct bt_mesh_model *mod,
+static int handle_item_clear_unacked(const struct bt_mesh_model *mod,
 				     struct bt_mesh_msg_ctx *ctx,
 				     struct net_buf_simple *buf)
 {
@@ -99,7 +99,7 @@ const struct bt_mesh_model_op _bt_mesh_sol_pdu_rpl_srv_op[] = {
 	BT_MESH_MODEL_OP_END
 };
 
-static int sol_pdu_rpl_srv_init(struct bt_mesh_model *mod)
+static int sol_pdu_rpl_srv_init(const struct bt_mesh_model *mod)
 {
 	if (!bt_mesh_model_in_primary(mod)) {
 		LOG_ERR("Solicitation PDU RPL Configuration server not in primary element");

--- a/tests/bluetooth/mesh/basic/src/main.c
+++ b/tests/bluetooth/mesh/basic/src/main.c
@@ -15,7 +15,7 @@
 
 static bool has_reg_fault = true;
 
-static int fault_get_cur(struct bt_mesh_model *model, uint8_t *test_id,
+static int fault_get_cur(const struct bt_mesh_model *model, uint8_t *test_id,
 			 uint16_t *company_id, uint8_t *faults, uint8_t *fault_count)
 {
 	uint8_t reg_faults[MAX_FAULT] = { [0 ... (MAX_FAULT - 1)] = 0xff };
@@ -30,7 +30,7 @@ static int fault_get_cur(struct bt_mesh_model *model, uint8_t *test_id,
 	return 0;
 }
 
-static int fault_get_reg(struct bt_mesh_model *model, uint16_t company_id,
+static int fault_get_reg(const struct bt_mesh_model *model, uint16_t company_id,
 			 uint8_t *test_id, uint8_t *faults, uint8_t *fault_count)
 {
 	if (company_id != BT_COMP_ID_LF) {
@@ -53,7 +53,7 @@ static int fault_get_reg(struct bt_mesh_model *model, uint16_t company_id,
 	return 0;
 }
 
-static int fault_clear(struct bt_mesh_model *model, uint16_t company_id)
+static int fault_clear(const struct bt_mesh_model *model, uint16_t company_id)
 {
 	if (company_id != BT_COMP_ID_LF) {
 		return -EINVAL;
@@ -64,7 +64,7 @@ static int fault_clear(struct bt_mesh_model *model, uint16_t company_id)
 	return 0;
 }
 
-static int fault_test(struct bt_mesh_model *model, uint8_t test_id,
+static int fault_test(const struct bt_mesh_model *model, uint8_t test_id,
 		      uint16_t company_id)
 {
 	if (company_id != BT_COMP_ID_LF) {
@@ -90,12 +90,12 @@ static struct bt_mesh_health_srv health_srv = {
 
 BT_MESH_HEALTH_PUB_DEFINE(health_pub, MAX_FAULT);
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
 };
 
-static int vnd_publish(struct bt_mesh_model *mod)
+static int vnd_publish(const struct bt_mesh_model *mod)
 {
 	printk("Vendor publish\n");
 	return 0;
@@ -109,7 +109,7 @@ static const struct bt_mesh_model_op vnd_ops[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-static struct bt_mesh_model vnd_models[] = {
+static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, 0x1234, vnd_ops, &vnd_pub, NULL),
 	BT_MESH_MODEL_VND(BT_COMP_ID_LF, 0x4321, vnd_ops, &vnd_pub2, NULL),
 };

--- a/tests/bluetooth/mesh_shell/src/main.c
+++ b/tests/bluetooth/mesh_shell/src/main.c
@@ -43,7 +43,7 @@ struct bt_mesh_large_comp_data_cli large_comp_data_cli;
 
 BT_MESH_SHELL_HEALTH_PUB_DEFINE(health_pub);
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_SRV(&bt_mesh_shell_health_srv, &health_pub),

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -59,7 +59,7 @@ static uint16_t vnd_app_key_idx = 0x000f;
 #define AUTH_METHOD_INPUT 0x03
 
 static struct model_data {
-	struct bt_mesh_model *model;
+	const struct bt_mesh_model *model;
 	uint16_t addr;
 	uint16_t appkey_idx;
 } model_bound[MODEL_BOUNDS_MAX];
@@ -193,7 +193,7 @@ static void get_faults(uint8_t *faults, uint8_t faults_size, uint8_t *dst, uint8
 	}
 }
 
-static int fault_get_cur(struct bt_mesh_model *model, uint8_t *test_id,
+static int fault_get_cur(const struct bt_mesh_model *model, uint8_t *test_id,
 			 uint16_t *company_id, uint8_t *faults, uint8_t *fault_count)
 {
 	LOG_DBG("");
@@ -206,7 +206,7 @@ static int fault_get_cur(struct bt_mesh_model *model, uint8_t *test_id,
 	return 0;
 }
 
-static int fault_get_reg(struct bt_mesh_model *model, uint16_t company_id,
+static int fault_get_reg(const struct bt_mesh_model *model, uint16_t company_id,
 			 uint8_t *test_id, uint8_t *faults, uint8_t *fault_count)
 {
 	LOG_DBG("company_id 0x%04x", company_id);
@@ -222,7 +222,7 @@ static int fault_get_reg(struct bt_mesh_model *model, uint16_t company_id,
 	return 0;
 }
 
-static int fault_clear(struct bt_mesh_model *model, uint16_t company_id)
+static int fault_clear(const struct bt_mesh_model *model, uint16_t company_id)
 {
 	LOG_DBG("company_id 0x%04x", company_id);
 
@@ -235,7 +235,7 @@ static int fault_clear(struct bt_mesh_model *model, uint16_t company_id)
 	return 0;
 }
 
-static int fault_test(struct bt_mesh_model *model, uint8_t test_id,
+static int fault_test(const struct bt_mesh_model *model, uint8_t test_id,
 		      uint16_t company_id)
 {
 	LOG_DBG("test_id 0x%02x company_id 0x%04x", test_id, company_id);
@@ -293,14 +293,14 @@ static struct bt_mesh_health_cli health_cli = {
 	.current_status = health_current_status,
 };
 
-static struct bt_mesh_model root_models[] = {
+static const struct bt_mesh_model root_models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
 	BT_MESH_MODEL_HEALTH_CLI(&health_cli),
 };
 
-static struct bt_mesh_model vnd_models[] = {
+static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND(CID_LOCAL, VND_MODEL_ID_1, BT_MESH_MODEL_NO_OPS, NULL,
 			  NULL),
 };
@@ -848,7 +848,7 @@ static uint8_t model_send(const void *cmd, uint16_t cmd_len,
 {
 	const struct btp_mesh_model_send_cmd *cp = cmd;
 	NET_BUF_SIMPLE_DEFINE(msg, UINT8_MAX);
-	struct bt_mesh_model *model = NULL;
+	const struct bt_mesh_model *model = NULL;
 	uint16_t src;
 	int err;
 
@@ -2963,7 +2963,7 @@ void net_recv_ev(uint8_t ttl, uint8_t ctl, uint16_t src, uint16_t dst, const voi
 	tester_event(BTP_SERVICE_ID_MESH, BTP_MESH_EV_NET_RECV, buf.data, buf.len);
 }
 
-static void model_bound_cb(uint16_t addr, struct bt_mesh_model *model,
+static void model_bound_cb(uint16_t addr, const struct bt_mesh_model *model,
 			   uint16_t key_idx)
 {
 	int i;
@@ -2984,7 +2984,7 @@ static void model_bound_cb(uint16_t addr, struct bt_mesh_model *model,
 	LOG_ERR("model_bound is full");
 }
 
-static void model_unbound_cb(uint16_t addr, struct bt_mesh_model *model,
+static void model_unbound_cb(uint16_t addr, const struct bt_mesh_model *model,
 			     uint16_t key_idx)
 {
 	int i;

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -27,7 +27,7 @@ struct bt_mesh_test_stats test_stats;
 struct bt_mesh_msg_ctx test_send_ctx;
 static void (*ra_cb)(uint8_t *, size_t);
 
-static int msg_rx(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int msg_rx(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		   struct net_buf_simple *buf)
 {
 	size_t len = buf->len + BT_MESH_MODEL_OP_LEN(TEST_MSG_OP_1);
@@ -75,7 +75,7 @@ static int msg_rx(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 	return 0;
 }
 
-static int ra_rx(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+static int ra_rx(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		 struct net_buf_simple *buf)
 {
 	LOG_INF("\tlen: %d bytes", buf->len);
@@ -97,19 +97,19 @@ static const struct bt_mesh_model_op model_op[] = {
 	BT_MESH_MODEL_OP_END
 };
 
-int __weak test_model_pub_update(struct bt_mesh_model *mod)
+int __weak test_model_pub_update(const struct bt_mesh_model *mod)
 {
 	return -1;
 }
 
-int __weak test_model_settings_set(struct bt_mesh_model *model,
+int __weak test_model_settings_set(const struct bt_mesh_model *model,
 				   const char *name, size_t len_rd,
 				   settings_read_cb read_cb, void *cb_arg)
 {
 	return -1;
 }
 
-void __weak test_model_reset(struct bt_mesh_model *model)
+void __weak test_model_reset(const struct bt_mesh_model *model)
 {
 	/* No-op. */
 }
@@ -128,19 +128,19 @@ static const struct bt_mesh_model_op vnd_model_op[] = {
 	BT_MESH_MODEL_OP_END,
 };
 
-int __weak test_vnd_model_pub_update(struct bt_mesh_model *mod)
+int __weak test_vnd_model_pub_update(const struct bt_mesh_model *mod)
 {
 	return -1;
 }
 
-int __weak test_vnd_model_settings_set(struct bt_mesh_model *model,
+int __weak test_vnd_model_settings_set(const struct bt_mesh_model *model,
 				       const char *name, size_t len_rd,
 				       settings_read_cb read_cb, void *cb_arg)
 {
 	return -1;
 }
 
-void __weak test_vnd_model_reset(struct bt_mesh_model *model)
+void __weak test_vnd_model_reset(const struct bt_mesh_model *model)
 {
 	/* No-op. */
 }
@@ -166,7 +166,7 @@ static struct bt_mesh_model_pub health_pub = {
 static struct bt_mesh_sar_cfg_cli sar_cfg_cli;
 #endif
 
-static struct bt_mesh_model models[] = {
+static const struct bt_mesh_model models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_CB(TEST_MOD_ID, model_op, &pub, NULL, &test_model_cb),
@@ -177,14 +177,14 @@ static struct bt_mesh_model models[] = {
 #endif
 };
 
-struct bt_mesh_model *test_model = &models[2];
+const struct bt_mesh_model *test_model = &models[2];
 
-static struct bt_mesh_model vnd_models[] = {
+static const struct bt_mesh_model vnd_models[] = {
 	BT_MESH_MODEL_VND_CB(TEST_VND_COMPANY_ID, TEST_VND_MOD_ID, vnd_model_op, &vnd_pub,
 			     NULL, &test_vnd_model_cb),
 };
 
-struct bt_mesh_model *test_vnd_model = &vnd_models[0];
+const struct bt_mesh_model *test_vnd_model = &vnd_models[0];
 
 static struct bt_mesh_elem elems[] = {
 	BT_MESH_ELEM(0, models, vnd_models),

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.h
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.h
@@ -31,7 +31,7 @@
 #define TEST_VND_COMPANY_ID 0x1234
 #define TEST_VND_MOD_ID   0x5678
 
-#define MODEL_LIST(...) ((struct bt_mesh_model[]){ __VA_ARGS__ })
+#define MODEL_LIST(...) ((const struct bt_mesh_model[]){ __VA_ARGS__ })
 
 #define FAIL(msg, ...)                                                         \
 	do {                                                                   \
@@ -127,8 +127,8 @@ struct bt_mesh_test_sync_ctx {
 
 extern enum bst_result_t bst_result;
 extern const struct bt_mesh_test_cfg *cfg;
-extern struct bt_mesh_model *test_model;
-extern struct bt_mesh_model *test_vnd_model;
+extern const struct bt_mesh_model *test_model;
+extern const struct bt_mesh_model *test_vnd_model;
 extern const uint8_t test_net_key[16];
 extern const uint8_t test_app_key[16];
 extern const uint8_t test_va_uuid[16];

--- a/tests/bsim/bluetooth/mesh/src/test_access.c
+++ b/tests/bsim/bluetooth/mesh/src/test_access.c
@@ -35,15 +35,15 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL_INF);
 #define RX_JITTER_MAX (10 + CONFIG_BT_MESH_NETWORK_TRANSMIT_COUNT * \
 		       (CONFIG_BT_MESH_NETWORK_TRANSMIT_INTERVAL + 10))
 
-static int model1_init(struct bt_mesh_model *model);
-static int model2_init(struct bt_mesh_model *model);
-static int model3_init(struct bt_mesh_model *model);
-static int model4_init(struct bt_mesh_model *model);
-static int model5_init(struct bt_mesh_model *model);
-static int test_msg_handler(struct bt_mesh_model *model,
+static int model1_init(const struct bt_mesh_model *model);
+static int model2_init(const struct bt_mesh_model *model);
+static int model3_init(const struct bt_mesh_model *model);
+static int model4_init(const struct bt_mesh_model *model);
+static int model5_init(const struct bt_mesh_model *model);
+static int test_msg_handler(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf);
-static int test_msg_ne_handler(struct bt_mesh_model *model,
+static int test_msg_ne_handler(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf);
 
@@ -99,7 +99,7 @@ static const struct {
 static struct k_sem publish_sem;
 static bool publish_allow;
 
-static int model1_update(struct bt_mesh_model *model)
+static int model1_update(const struct bt_mesh_model *model)
 {
 	model->pub->msg->data[1]++;
 
@@ -108,7 +108,7 @@ static int model1_update(struct bt_mesh_model *model)
 	return publish_allow ? k_sem_give(&publish_sem), 0 : -1;
 }
 
-static int test_msgf_handler(struct bt_mesh_model *model,
+static int test_msgf_handler(const struct bt_mesh_model *model,
 			     struct bt_mesh_msg_ctx *ctx,
 			     struct net_buf_simple *buf)
 {
@@ -204,7 +204,7 @@ static const struct bt_mesh_model_op model_ne_op5[] = {
 static struct bt_mesh_cfg_cli cfg_cli;
 
 /* do not change model sequence. it will break pointer arithmetic. */
-static struct bt_mesh_model models[] = {
+static const struct bt_mesh_model models[] = {
 	BT_MESH_MODEL_CFG_SRV,
 	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
 	BT_MESH_MODEL_CB(TEST_MODEL_ID_1, model_op1, &model_pub1, NULL, &test_model1_cb),
@@ -215,7 +215,7 @@ static struct bt_mesh_model models[] = {
 };
 
 /* do not change model sequence. it will break pointer arithmetic. */
-static struct bt_mesh_model models_ne[] = {
+static const struct bt_mesh_model models_ne[] = {
 	BT_MESH_MODEL_CB(TEST_MODEL_ID_1, model_ne_op1, NULL, NULL, &test_model1_cb),
 	BT_MESH_MODEL_CB(TEST_MODEL_ID_2, model_ne_op2, NULL, NULL, &test_model2_cb),
 	BT_MESH_MODEL_CB(TEST_MODEL_ID_3, model_ne_op3, NULL, NULL, &test_model3_cb),
@@ -223,7 +223,7 @@ static struct bt_mesh_model models_ne[] = {
 	BT_MESH_MODEL_CB(TEST_MODEL_ID_5, model_ne_op5, NULL, NULL, &test_model5_cb),
 };
 
-static struct bt_mesh_model vnd_models[] = {};
+static const struct bt_mesh_model vnd_models[] = {};
 
 static struct bt_mesh_elem elems[] = {
 	BT_MESH_ELEM(0, models, vnd_models),
@@ -246,43 +246,43 @@ const struct bt_mesh_comp local_comp = {
  *            m4        mne4
  */
 
-static int model1_init(struct bt_mesh_model *model)
+static int model1_init(const struct bt_mesh_model *model)
 {
 	return 0;
 }
 
-static int model2_init(struct bt_mesh_model *model)
+static int model2_init(const struct bt_mesh_model *model)
 {
 	return 0;
 }
 
-static int model3_init(struct bt_mesh_model *model)
+static int model3_init(const struct bt_mesh_model *model)
 {
 	ASSERT_OK(bt_mesh_model_extend(model, model - 2));
 	ASSERT_OK(bt_mesh_model_extend(model, model - 1));
 
-	if (model->elem_idx == 0) {
+	if (model->ctx->elem_idx == 0) {
 		ASSERT_OK(bt_mesh_model_extend(&models_ne[2], model));
 	}
 
 	return 0;
 }
 
-static int model4_init(struct bt_mesh_model *model)
+static int model4_init(const struct bt_mesh_model *model)
 {
 	ASSERT_OK(bt_mesh_model_extend(model, model - 1));
 
 	return 0;
 }
 
-static int model5_init(struct bt_mesh_model *model)
+static int model5_init(const struct bt_mesh_model *model)
 {
 	ASSERT_OK(bt_mesh_model_extend(model, model - 4));
 
 	return 0;
 }
 
-static int test_msg_handler(struct bt_mesh_model *model,
+static int test_msg_handler(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
@@ -292,7 +292,7 @@ static int test_msg_handler(struct bt_mesh_model *model,
 	return 0;
 }
 
-static int test_msg_ne_handler(struct bt_mesh_model *model,
+static int test_msg_ne_handler(const struct bt_mesh_model *model,
 			struct bt_mesh_msg_ctx *ctx,
 			struct net_buf_simple *buf)
 {
@@ -515,7 +515,7 @@ static void pub_param_set(uint8_t period, uint8_t transmit)
 
 static void msgf_publish(void)
 {
-	struct bt_mesh_model *model = &models[2];
+	const struct bt_mesh_model *model = &models[2];
 
 	bt_mesh_model_msg_init(model->pub->msg, TEST_MESSAGE_OP_F);
 	net_buf_simple_add_u8(model->pub->msg, 1);
@@ -591,7 +591,7 @@ static void recv_jitter_check(int32_t interval, uint8_t count)
  */
 static void test_tx_period(void)
 {
-	struct bt_mesh_model *model = &models[2];
+	const struct bt_mesh_model *model = &models[2];
 
 	bt_mesh_test_cfg_set(NULL, 60);
 	bt_mesh_device_setup(&prov, &local_comp);
@@ -647,7 +647,7 @@ static void test_rx_period(void)
  */
 static void test_tx_transmit(void)
 {
-	struct bt_mesh_model *model = &models[2];
+	const struct bt_mesh_model *model = &models[2];
 	uint8_t status;
 	int err;
 
@@ -719,7 +719,7 @@ static void test_rx_transmit(void)
  */
 static void test_tx_cancel(void)
 {
-	struct bt_mesh_model *model = &models[2];
+	const struct bt_mesh_model *model = &models[2];
 	int err;
 
 	bt_mesh_test_cfg_set(NULL, 20);

--- a/tests/bsim/bluetooth/mesh/src/test_blob.c
+++ b/tests/bsim/bluetooth/mesh/src/test_blob.c
@@ -261,7 +261,7 @@ static const struct bt_mesh_comp cli_comp = {
 
 static struct k_sem info_get_sem;
 
-static int mock_handle_info_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mock_handle_info_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	k_sem_give(&info_get_sem);
@@ -1310,7 +1310,7 @@ static void test_srv_fail_on_block_get(void)
 	PASS();
 }
 
-static int dummy_xfer_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int dummy_xfer_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	return 0;

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -1257,7 +1257,7 @@ static void test_cli_stop(void)
 
 static struct k_sem caps_get_sem;
 
-static int mock_handle_caps_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mock_handle_caps_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	LOG_WRN("Rejecting BLOB Information Get message");
@@ -1288,7 +1288,7 @@ static const struct bt_mesh_comp srv_caps_broken_comp = {
 	.elem_count = 1,
 };
 
-static int mock_handle_chunks(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mock_handle_chunks(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				struct net_buf_simple *buf)
 {
 	LOG_WRN("Skipping receiving block");
@@ -1321,7 +1321,7 @@ static const struct bt_mesh_comp broken_target_comp = {
 
 static struct k_sem update_get_sem;
 
-static int mock_handle_update_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mock_handle_update_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				  struct net_buf_simple *buf)
 {
 	LOG_WRN("Rejecting Firmware Update Get message");
@@ -1354,7 +1354,7 @@ static const struct bt_mesh_comp srv_update_get_broken_comp = {
 
 static struct k_sem update_apply_sem;
 
-static int mock_handle_update_apply(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mock_handle_update_apply(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 				    struct net_buf_simple *buf)
 {
 	LOG_WRN("Rejecting Firmware Update Apply message");

--- a/tests/bsim/bluetooth/mesh/src/test_lcd.c
+++ b/tests/bsim/bluetooth/mesh/src/test_lcd.c
@@ -41,6 +41,7 @@ LOG_MODULE_REGISTER(test_lcd, LOG_LEVEL_INF);
 	.op = _dummy_op,                            \
 	.cb = NULL,                                 \
 	.user_data = NULL,                          \
+	.ctx = &(struct bt_mesh_model_ctx){ 0 },    \
 	.metadata = _metadata,                      \
 }
 

--- a/tests/bsim/bluetooth/mesh/src/test_op_agg.c
+++ b/tests/bsim/bluetooth/mesh/src/test_op_agg.c
@@ -61,7 +61,7 @@ static struct bt_mesh_msg_ctx test_ctx = {
 static struct bt_mesh_prov prov;
 static struct bt_mesh_cfg_cli cfg_cli;
 
-static int get_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int get_handler(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	uint8_t seq = net_buf_simple_pull_u8(buf);
@@ -85,7 +85,7 @@ static int get_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return bt_mesh_model_send(model, ctx, &msg, NULL, NULL);
 }
 
-static int status_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int status_handler(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
 	uint8_t seq = net_buf_simple_pull_u8(buf);
@@ -100,7 +100,8 @@ static int status_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *c
 	return 0;
 }
 
-static int dummy_vnd_mod_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx, uint8_t seq)
+static int dummy_vnd_mod_get(const struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx, uint8_t seq)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_DUMMY_VND_MOD_GET_OP,
 				 BT_MESH_DUMMY_VND_MOD_MSG_MAXLEN);
@@ -170,7 +171,7 @@ static void op_agg_test_prov_and_conf(uint16_t addr)
 
 static void test_cli_max_len_sequence_msg_send(void)
 {
-	struct bt_mesh_model *dummy_vnd_model = &elements[0].vnd_models[0];
+	const struct bt_mesh_model *dummy_vnd_model = &elements[0].vnd_models[0];
 	uint8_t seq;
 
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);

--- a/tests/bsim/bluetooth/mesh/src/test_persistence.c
+++ b/tests/bsim/bluetooth/mesh/src/test_persistence.c
@@ -314,7 +314,7 @@ static void check_mod_pub_params(const struct bt_mesh_cfg_cli_mod_pub *expected,
 	ASSERT_EQUAL(expected->transmit, got->transmit);
 }
 
-int test_model_settings_set(struct bt_mesh_model *model,
+int test_model_settings_set(const struct bt_mesh_model *model,
 			    const char *name, size_t len_rd,
 			    settings_read_cb read_cb, void *cb_arg)
 {
@@ -340,12 +340,12 @@ int test_model_settings_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-void test_model_reset(struct bt_mesh_model *model)
+void test_model_reset(const struct bt_mesh_model *model)
 {
 	ASSERT_OK(bt_mesh_model_data_store(test_model, false, TEST_MOD_DATA_NAME, NULL, 0));
 }
 
-int test_vnd_model_settings_set(struct bt_mesh_model *model,
+int test_vnd_model_settings_set(const struct bt_mesh_model *model,
 				const char *name, size_t len_rd,
 				settings_read_cb read_cb, void *cb_arg)
 {
@@ -371,7 +371,7 @@ int test_vnd_model_settings_set(struct bt_mesh_model *model,
 	return 0;
 }
 
-void test_vnd_model_reset(struct bt_mesh_model *model)
+void test_vnd_model_reset(const struct bt_mesh_model *model)
 {
 	ASSERT_OK(bt_mesh_model_data_store(test_vnd_model, true, TEST_VND_MOD_DATA_NAME, NULL, 0));
 }

--- a/tests/bsim/bluetooth/mesh/src/test_provision.c
+++ b/tests/bsim/bluetooth/mesh/src/test_provision.c
@@ -139,7 +139,7 @@ static const struct bt_mesh_comp rpr_srv_comp = {
 	.elem_count = 1,
 };
 
-static int mock_pdu_send(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int mock_pdu_send(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			       struct net_buf_simple *buf)
 {
 	/* Device becomes unresponsive and doesn't communicate with other nodes anymore */
@@ -155,10 +155,10 @@ static const struct bt_mesh_model_op model_rpr_op1[] = {
 	BT_MESH_MODEL_OP_END
 };
 
-static int mock_model_init(struct bt_mesh_model *mod)
+static int mock_model_init(const struct bt_mesh_model *mod)
 {
 	mod->keys[0] = BT_MESH_KEY_DEV_LOCAL;
-	mod->flags |= BT_MESH_MOD_DEVKEY_ONLY;
+	mod->ctx->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	return 0;
 }

--- a/tests/bsim/bluetooth/mesh/src/test_sar.c
+++ b/tests/bsim/bluetooth/mesh/src/test_sar.c
@@ -91,7 +91,7 @@ static void data_integrity_check(struct net_buf_simple *buf)
 	net_buf_simple_restore(buf, &state);
 }
 
-static int get_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int get_handler(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 		       struct net_buf_simple *buf)
 {
 	data_integrity_check(buf);
@@ -104,7 +104,7 @@ static int get_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 	return bt_mesh_model_send(model, ctx, &msg, NULL, NULL);
 }
 
-static int status_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int status_handler(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			  struct net_buf_simple *buf)
 {
 	data_integrity_check(buf);
@@ -112,7 +112,7 @@ static int status_handler(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *c
 	return 0;
 }
 
-static int dummy_vnd_mod_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+static int dummy_vnd_mod_get(const struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
 			     uint8_t msg[])
 {
 	BT_MESH_MODEL_BUF_DEFINE(buf, DUMMY_VND_MOD_GET_OP, MAX_SDU_MSG_LEN);
@@ -185,7 +185,7 @@ static void array_random_fill(uint8_t array[], uint16_t len, int seed)
 static void cli_max_len_sdu_send(struct bt_mesh_sar_rx *sar_rx_config,
 				 struct bt_mesh_sar_tx *sar_tx_config)
 {
-	struct bt_mesh_model *dummy_vnd_mod = &elements[0].vnd_models[0];
+	const struct bt_mesh_model *dummy_vnd_mod = &elements[0].vnd_models[0];
 
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
 	bt_mesh_device_setup(&prov, &comp);


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/57215

Since model struct most of member should not change at run time, so mark as const will be suitable and safely.