### PR TITLE
doc: Revert "doc: Add more known-warnings"

### DIFF
--- a/doc/known-warnings.txt
+++ b/doc/known-warnings.txt
@@ -22,8 +22,3 @@
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct in_addr.*'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct in6_addr.*'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct net_if.*'.*
-
-# Clash with field of nested anonymous struct
-.*Duplicate C declaration.*\n.*'\.\. c:member:: enum *bt_mesh_dfd_upload_phase bt_mesh_dfd_srv.phase'.*
-.*Duplicate C declaration.*\n.*'\.\. c:member:: struct *bt_mesh_blob_xfer bt_mesh_dfu_cli.blob'.*
-.*Duplicate C declaration.*\n.*'\.\. c:member:: struct *net_if *\* net_if_mcast_monitor.iface'.


### PR DESCRIPTION
This reverts commit 3127d7b54c22449fcc85dd1c59ca294885d5f997 which was forgotten when switching back to breathe from docleaf and  causing unecessary "here's a warning about something that's not actually a warning" :)
