### PR TITLE
Rework STM32 ADC sequencer

### DIFF
--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -140,7 +140,7 @@
 &adc1 {
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1>;
 	pinctrl-names = "default";
-	st,adc-clock-source = <SYNC>;
+	st,adc-clock-source = <ASYNC>;
 	st,adc-prescaler = <4>;
 	status = "okay";
 	vref-mv = <3300>;

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -154,9 +154,6 @@ static const uint32_t table_seq_len[] = {
 };
 #endif /* ANY_ADC_SEQUENCER_TYPE_IS(FULLY_CONFIGURABLE) */
 
-/* External channels (maximum). */
-#define STM32_CHANNEL_COUNT		20
-
 /* Number of different sampling time values */
 #define STM32_NB_SAMPLING_TIME	8
 
@@ -839,11 +836,6 @@ static int start_read(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (data->channels > BIT(STM32_CHANNEL_COUNT) - 1) {
-		LOG_ERR("Channels bitmask uses out of range channel");
-		return -EINVAL;
-	}
-
 #if ANY_ADC_SEQUENCER_TYPE_IS(FULLY_CONFIGURABLE)
 	if (data->channel_count > ARRAY_SIZE(table_seq_len)) {
 		LOG_ERR("Too many channels for sequencer. Max: %d", ARRAY_SIZE(table_seq_len));
@@ -1112,11 +1104,6 @@ static int adc_stm32_channel_setup(const struct device *dev,
 
 	struct adc_stm32_data *data = dev->data;
 	int acq_time_index;
-
-	if (channel_cfg->channel_id >= STM32_CHANNEL_COUNT) {
-		LOG_ERR("Channel %d is not valid", channel_cfg->channel_id);
-		return -EINVAL;
-	}
 
 	acq_time_index = adc_stm32_check_acq_time(dev,
 				channel_cfg->acquisition_time);

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -299,6 +299,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 4 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <2>;
+			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -344,6 +344,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 8 14 29 42 56 72 240>;
 			num-sampling-time-common-channels = <1>;
+			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -341,6 +341,7 @@
 			#io-channel-cells = <1>;
 			resolutions = <STM32F1_ADC_RES(12)>;
 			sampling-times = <2 8 14 29 42 56 72 240>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -372,6 +372,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 58 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -114,6 +114,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 	};
 };

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -153,6 +153,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		adc2: adc@50000100 {
@@ -168,6 +169,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 	};
 };

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -40,6 +40,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 3 5 8 20 62 182 602>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -193,6 +193,7 @@
 			#io-channel-cells = <1>;
 			resolutions = <STM32F1_ADC_RES(12)>;
 			sampling-times = <2 8 14 29 42 56 72 240>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -519,6 +519,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -258,6 +258,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		adc3: adc@40012200 {
@@ -273,6 +274,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -749,6 +749,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		adc2: adc@40012100 {
@@ -764,6 +765,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		adc3: adc@40012200 {
@@ -779,6 +781,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 15 28 56 84 112 144 480>;
 			st,adc-clock-source = <SYNC>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -408,6 +408,7 @@
 			 */
 			sampling-times = <3 5 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <2>;
+			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -114,6 +114,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		adc2: adc@50000100 {
@@ -128,6 +129,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		dac1: dac@50000800 {

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -39,6 +39,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		adc5: adc@50000600 {
@@ -53,6 +54,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		spi4: spi@40013c00 {

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -69,6 +69,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		uart5: serial@40005000 {

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -268,6 +268,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		rtc: rtc@44007800 {

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -178,6 +178,7 @@
 					STM32_ADC_RES(8, 0x02)
 					STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		timers4: timers@40000800 {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -814,6 +814,7 @@
 				       STM32_ADC_RES(10, 0x03)
 				       STM32_ADC_RES(8, 0x07)>;
 			sampling-times = <2 3 9 17 33 65 388 811>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		adc2: adc@40022100 {
@@ -829,6 +830,7 @@
 				       STM32_ADC_RES(10, 0x03)
 				       STM32_ADC_RES(8, 0x07)>;
 			sampling-times = <2 3 9 17 33 65 388 811>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		/* dual mode: adc1 and adc2 coupled */
@@ -845,6 +847,7 @@
 				       STM32_ADC_RES(10, 0x03)
 				       STM32_ADC_RES(8, 0x07)>;
 			sampling-times = <2 3 9 17 33 65 388 811>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		adc3: adc@58026000 {
@@ -860,6 +863,7 @@
 				       STM32_ADC_RES(10, 0x03)
 				       STM32_ADC_RES(8, 0x07)>;
 			sampling-times = <2 3 9 17 33 65 388 811>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -52,6 +52,7 @@
 				       STM32H72X_ADC3_RES(8, 0x02)
 				       STM32H72X_ADC3_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		dmamux1: dmamux@40020800 {

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -315,6 +315,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 4 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <1>;
+			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -222,6 +222,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <4 9 16 24 48 96 192 384>;
 			st,adc-clock-source = <ASYNC>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -395,6 +395,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		adc2: adc@50040100 {
@@ -409,6 +410,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -664,6 +664,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		adc2: adc@42028100 {
@@ -678,6 +679,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		usb: usb@4000d400 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -749,6 +749,7 @@
 				       STM32_ADC_RES(8, 0x03)>;
 			sampling-times = <5 6 12 20 36 68 391 814>;
 			st,adc-clock-source = <ASYNC>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		adc4: adc@46021000 {
@@ -765,6 +766,7 @@
 			sampling-times = <2 4 8 13 20 40 80 815>;
 			num-sampling-time-common-channels = <2>;
 			st,adc-clock-source = <ASYNC>;
+			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
 		};
 
 		fdcan1: can@4000a400 {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -418,6 +418,7 @@
 				       STM32_ADC_RES(8, 0x02)
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <3 7 13 25 48 93 248 641>;
+			st,adc-sequencer = <FULLY_CONFIGURABLE>;
 		};
 
 		iwdg: watchdog@40003000 {

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -395,6 +395,7 @@
 			sampling-times = <2 4 8 13 20 40 80 815>;
 			num-sampling-time-common-channels = <2>;
 			st,adc-clock-source = <ASYNC>;
+			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
 		};
 
 		lptim1: timers@46004400 {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -338,6 +338,7 @@
 				       STM32_ADC_RES(6, 0x03)>;
 			sampling-times = <2 4 8 13 20 40 80 161>;
 			num-sampling-time-common-channels = <2>;
+			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
 		};
 
 		dac1: dac@40007400 {

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -97,5 +97,16 @@ properties:
     description: |
       Number of sampling time common channels for this ADC instance, if any.
 
+  st,adc-sequencer:
+    type: int
+    required: true
+    enum:
+      - 0 # NOT_FULLY_CONFIGURABLE
+      - 1 # FULLY_CONFIGURABLE
+    description: |
+      Type of ADC sequencer:
+      - <NOT_FULLY_CONFIGURABLE>: Not fully configurable sequencer
+      - <FULLY_CONFIGURABLE>: Fully configurable sequencer
+
 io-channel-cells:
   - input

--- a/include/zephyr/dt-bindings/adc/stm32_adc.h
+++ b/include/zephyr/dt-bindings/adc/stm32_adc.h
@@ -74,4 +74,14 @@
 #define ASYNC 2
 /** @} */
 
+/**
+ * @name STM32 ADC sequencer type
+ * This value is to set <st,adc-sequencer>
+ * One or both values may not apply to all series. Refer to the RefMan
+ * @{
+ */
+#define NOT_FULLY_CONFIGURABLE	0
+#define FULLY_CONFIGURABLE	1
+/** @} */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_STM32_ADC_H_ */

--- a/tests/drivers/adc/adc_api/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/adc/adc_api/boards/b_u585i_iot02a.overlay
@@ -7,11 +7,12 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 15>;
+		io-channels = <&adc1 15>, <&adc1 16>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc1_in15_pb0 &adc1_in16_pb1>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -19,7 +20,19 @@
 		reg = <15>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
+
+	channel@10 {
+		reg = <16>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+};
+
+&adc4 {
+	status = "disabled";
 };

--- a/tests/drivers/adc/adc_api/boards/b_u585i_iot02a_adc4.overlay
+++ b/tests/drivers/adc/adc_api/boards/b_u585i_iot02a_adc4.overlay
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 STMicroelectronics
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc4 18>, <&adc4 19>;
+	};
+};
+
+&adc4 {
+	pinctrl-0 = <&adc4_in18_pb0 &adc4_in19_pb1>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@12 {
+		reg = <18>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@13 {
+		reg = <19>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+};
+
+&adc1 {
+	status = "disabled";
+};

--- a/tests/drivers/adc/adc_api/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/adc/adc_api/boards/disco_l475_iot1.overlay
@@ -7,7 +7,7 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 5>;
+		io-channels = <&adc1 4>, <&adc1 5>;
 	};
 };
 
@@ -15,11 +15,19 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
 	channel@5 {
 		reg = <5>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
-		zephyr,resolution = <10>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f091rc.overlay
@@ -7,11 +7,12 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 0>;
+		io-channels = <&adc1 0>, <&adc1 1>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc_in0_pa0 &adc_in1_pa1>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -19,7 +20,15 @@
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_f207zg.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f207zg.overlay
@@ -7,11 +7,12 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 0>;
+		io-channels = <&adc1 0>, <&adc1 3>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc1_in0_pa0 &adc1_in3_pa3>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -19,7 +20,15 @@
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_f401re.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f401re.overlay
@@ -7,11 +7,12 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 0>;
+		io-channels = <&adc1 0>, <&adc1 1>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -19,7 +20,15 @@
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@10 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f429zi.overlay
@@ -7,11 +7,12 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 0>;
+		io-channels = <&adc1 0>, <&adc1 3>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc1_in0_pa0 &adc1_in3_pa3>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -19,7 +20,15 @@
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f746zg.overlay
@@ -7,11 +7,12 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 0>;
+		io-channels = <&adc1 0>, <&adc1 3>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc1_in0_pa0 &adc1_in3_pa3>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -19,7 +20,15 @@
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_g071rb.overlay
@@ -7,7 +7,7 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 0>;
+		io-channels = <&adc1 0>, <&adc1 1>;
 	};
 };
 
@@ -19,7 +19,15 @@
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_g474re.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_g474re.overlay
@@ -7,16 +7,25 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 1>;
+		io-channels = <&adc1 1>, <&adc1 2>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc1_in1_pa0 &adc1_in2_pa1>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
 	channel@1 {
 		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@2 {
+		reg = <2>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;

--- a/tests/drivers/adc/adc_api/boards/nucleo_l073rz.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_l073rz.overlay
@@ -7,11 +7,12 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 0>;
+		io-channels = <&adc1 0>, <&adc1 1>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc_in0_pa0 &adc_in1_pa1>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -19,7 +20,15 @@
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_l152re.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_l152re.overlay
@@ -7,11 +7,12 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 0>;
+		io-channels = <&adc1 0>, <&adc1 1>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc_in0_pa0 &adc_in1_pa1>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -19,7 +20,15 @@
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_l552ze_q.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_l552ze_q.overlay
@@ -7,11 +7,12 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 1>;
+		io-channels = <&adc1 1>, <&adc1 2>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc1_in1_pc0 &adc1_in2_pc1>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -19,7 +20,15 @@
 		reg = <1>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_wb55rg.overlay
@@ -7,19 +7,28 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 1>;
+		io-channels = <&adc1 3>, <&adc1 4>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc1_in3_pc2 &adc1_in4_pc3>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	channel@1 {
-		reg = <1>;
+	channel@3 {
+		reg = <3>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_wba52cg.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_wba52cg.overlay
@@ -7,19 +7,28 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc4 8>;
+		io-channels = <&adc4 7>, <&adc4 8>;
 	};
 };
 
 &adc4 {
+	pinctrl-0 = <&adc4_in7_pa2 &adc4_in8_pa1>;
 	#address-cells = <1>;
 	#size-cells = <0>;
+
+	channel@7 {
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
 
 	channel@8 {
 		reg = <8>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_wl55jc.overlay
@@ -7,19 +7,28 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 0>;
+		io-channels = <&adc1 4>, <&adc1 5>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc_in4_pb2 &adc_in5_pb1>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	channel@0 {
-		reg = <0>;
+	channel@4 {
+		reg = <4>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@5 {
+		reg = <5>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/stm32f3_disco.overlay
+++ b/tests/drivers/adc/adc_api/boards/stm32f3_disco.overlay
@@ -7,19 +7,28 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 0>;
+		io-channels = <&adc1 1>, <&adc1 2>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc1_in1_pa0 &adc1_in2_pa1>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	channel@0 {
-		reg = <0>;
+	channel@1 {
+		reg = <1>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/adc/adc_api/boards/stm32h573i_dk.overlay
@@ -8,16 +8,25 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 1>;
+		io-channels = <&adc1 3>, <&adc1 6>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = < &adc1_inp3_pa6 &adc1_inp6_pf12>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	channel@1 {
-		reg = <1>;
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@6 {
+		reg = <6>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;

--- a/tests/drivers/adc/adc_api/boards/stm32l562e_dk.overlay
+++ b/tests/drivers/adc/adc_api/boards/stm32l562e_dk.overlay
@@ -7,19 +7,28 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&adc1 1>;
+		io-channels = <&adc1 13>, <&adc1 14>;
 	};
 };
 
 &adc1 {
+	pinctrl-0 = <&adc1_in13_pc4 &adc1_in14_pc5>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	channel@1 {
-		reg = <1>;
+	channel@d {
+		reg = <13>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@e {
+		reg = <14>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
 		zephyr,resolution = <12>;
 	};
 };

--- a/tests/drivers/adc/adc_api/testcase.yaml
+++ b/tests/drivers/adc/adc_api/testcase.yaml
@@ -7,3 +7,8 @@ tests:
   drivers.adc:
     depends_on: adc
     min_flash: 40
+  drivers.adc.b_u585i_iot02a_adc4:
+    extra_args:
+      DTC_OVERLAY_FILE="boards/b_u585i_iot02a_adc4.overlay"
+    platform_allow:
+      - b_u585i_iot02a


### PR DESCRIPTION
The ADC sequencer was not supported on all STM32 series.

This PR adds the support of the sequencer for all STM32 series with the exception of STM32F1 that needs DMA for that (and which is not fully supported yet).

Overlays of tests/drivers/adc_api have been updated in order to check the sequencer in automatic daily tests.

Fixes #61100