### PR TITLE
devicetree: fix DT_FOREACH_PROP_ELEM_SEP doxygen example

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2797,7 +2797,6 @@
  *
  * @code{.c}
  *     struct gpio_dt_spec specs[] = {
- *     struct gpio_dt_spec specs[] = {
  *             GPIO_DT_SPEC_GET_BY_IDX(DT_NODELABEL(n), my_gpios, 0),
  *             GPIO_DT_SPEC_GET_BY_IDX(DT_NODELABEL(n), my_gpios, 1)
  *     };


### PR DESCRIPTION
Remove a duplicate line from the code sample.