### PR TITLE
drivers: i2c: i2c_dw: Add capability for handling reset device.

### DIFF
--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -18,6 +18,10 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "DW I2C in DT needs CONFIG_PCIE");
 #include <zephyr/drivers/pcie/pcie.h>
 #endif
 
+#if defined(CONFIG_RESET)
+#include <zephyr/drivers/reset.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -92,6 +96,9 @@ struct i2c_dw_rom_config {
 
 #if defined(CONFIG_PINCTRL)
 	const struct pinctrl_dev_config *pcfg;
+#endif
+#if defined(CONFIG_RESET)
+	const struct reset_dt_spec reset;
 #endif
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)

--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -138,10 +138,11 @@
 		};
 
 		i2c0: i2c@40044000 {
-			compatible = "snps,designware-i2c";
+			compatible = "raspberrypi,pico-i2c", "snps,designware-i2c";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40044000 DT_SIZE_K(4)>;
+			resets = <&reset RPI_PICO_RESETS_RESET_I2C0>;
 			clocks = <&system_clk>;
 			interrupts = <23 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
 			interrupt-names = "i2c0";
@@ -149,10 +150,11 @@
 		};
 
 		i2c1: i2c@40048000 {
-			compatible = "snps,designware-i2c";
+			compatible = "raspberrypi,pico-i2c", "snps,designware-i2c";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40048000 DT_SIZE_K(4)>;
+			resets = <&reset RPI_PICO_RESETS_RESET_I2C0>;
 			clocks = <&system_clk>;
 			interrupts = <24 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
 			interrupt-names = "i2c1";

--- a/dts/bindings/i2c/raspberrypi,pico-i2c.yaml
+++ b/dts/bindings/i2c/raspberrypi,pico-i2c.yaml
@@ -1,0 +1,5 @@
+description: Raspberry Pi Pico I2C
+
+compatible: "raspberrypi,pico-i2c"
+
+include: ["snps,designware-i2c.yaml", "reset-device.yaml"]


### PR DESCRIPTION
Reset the device on initializing if reset-node is available in dts.
`snps,desingware-i2c` does not define reset-node itself.
Add more of an element that inherits `reset-device.yaml` to
the `compatible` section to allow defining the reset-node for using this feature.

For example.

```
compatible = "reset-device-inherit-node", "snps,designware-i2c";
```

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@gmail.com>