### PR TITLE
drivers: flash: nrf_qspi_nor: Add support for XIP at boot

### DIFF
--- a/drivers/flash/Kconfig.nordic_qspi_nor
+++ b/drivers/flash/Kconfig.nordic_qspi_nor
@@ -14,8 +14,8 @@ menuconfig NORDIC_QSPI_NOR
 if NORDIC_QSPI_NOR
 
 config NORDIC_QSPI_NOR_INIT_PRIORITY
-	int
-	default 80
+	int "Init priority"
+	default 41
 	help
 	  Device driver initialization priority.
 
@@ -38,5 +38,15 @@ config NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE
 	  allow the write to proceed. Multiple transfers will be initiated
 	  if the data is larger than the configured size.
 	  Must be a multiple of 4. When set to 0, the feature is disabled.
+
+config NORDIC_QSPI_NOR_XIP
+	bool "XIP (eXecute in place)"
+	depends on SOC_NRF5340_CPUAPP
+	help
+	  Enable setting up the QSPI NOR driver to allow for execution of code
+	  stored in QSPI XIP region. Note that for this functionality to work,
+	  the QSPI NOR init priority must be set so that no XIP code in the
+	  QSPI NOR flash chip is executed until the driver has been setup.
+	  This will also disable power management for the QSPI NOR flash chip.
 
 endif # NORDIC_QSPI_NOR

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -179,6 +179,8 @@ static bool qspi_initialized;
 
 static int qspi_device_init(const struct device *dev);
 static void qspi_device_uninit(const struct device *dev);
+void z_impl_nrf_qspi_nor_xip_enable(const struct device *dev, bool enable);
+void z_vrfy_nrf_qspi_nor_xip_enable(const struct device *dev, bool enable);
 
 #define WORD_SIZE 4
 
@@ -1229,6 +1231,7 @@ static int qspi_nor_configure(const struct device *dev)
  */
 static int qspi_nor_init(const struct device *dev)
 {
+	int rc;
 	const struct qspi_nor_config *dev_config = dev->config;
 	int ret = pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_DEFAULT);
 
@@ -1238,7 +1241,19 @@ static int qspi_nor_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_IRQN(QSPI_NODE), DT_IRQ(QSPI_NODE, priority),
 		    nrfx_isr, nrfx_qspi_irq_handler, 0);
-	return qspi_nor_configure(dev);
+
+	rc = qspi_nor_configure(dev);
+
+#ifdef CONFIG_NORDIC_QSPI_NOR_XIP
+	if (!rc) {
+		/* Enable XIP mode for QSPI NOR flash, this will prevent the
+		 * flash from being powered down
+		 */
+		z_impl_nrf_qspi_nor_xip_enable(dev, true);
+	}
+#endif
+
+	return rc;
 }
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
@@ -1368,6 +1383,10 @@ static int qspi_nor_pm_action(const struct device *dev,
 			return ret;
 		}
 #endif
+
+		if (dev_data->xip_enabled) {
+			return -EBUSY;
+		}
 
 		if (nrfx_qspi_mem_busy_check() != NRFX_SUCCESS) {
 			return -EBUSY;


### PR DESCRIPTION
Adds support for forcing XIP support at boot time, and reduces the init priority of the driver so that it inits earlier.