### PR TITLE
bluetooth: Make long workqueue init priority configurable

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -23,6 +23,13 @@ config BT_LONG_WQ_PRIO
 	int "Long workqueue priority. Should be pre-emptible."
 	default 10
 	range 0 NUM_PREEMPT_PRIORITIES
+
+config BT_LONG_WQ_INIT_PRIO
+	int "Long workqueue init priority"
+	default 50
+	help
+	  Init priority level to setup the long workqueue.
+
 endif # BT_LONG_WQ
 
 config BT_HCI_HOST

--- a/subsys/bluetooth/host/long_wq.c
+++ b/subsys/bluetooth/host/long_wq.c
@@ -40,4 +40,4 @@ static int long_wq_init(void)
 	return 0;
 }
 
-SYS_INIT(long_wq_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(long_wq_init, POST_KERNEL, CONFIG_BT_LONG_WQ_INIT_PRIO);


### PR DESCRIPTION
Makes the long workqueue init priority configurable and sets the default to 50