### PR TITLE
intel_adsp: ace: cpu clock management

### DIFF
--- a/dts/bindings/clock/intel,adsp-shim-clkctl.yaml
+++ b/dts/bindings/clock/intel,adsp-shim-clkctl.yaml
@@ -19,6 +19,10 @@ properties:
     type: int
     description: Index of HPRO clock encoding in the encoding array.
 
+  adsp-clkctl-clk-ipll:
+    type: int
+    description: Index of ACE integrated PLL clock encoding in the encoding array.
+
   adsp-clkctl-freq-enc:
     type: array
     required: true

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -82,7 +82,7 @@
 		compatible = "intel,adsp-shim-clkctl";
 		adsp-clkctl-clk-wovcro = <0>;
 		adsp-clkctl-clk-lpro = <1>;
-		adsp-clkctl-clk-hpro = <2>;
+		adsp-clkctl-clk-ipll = <2>;
 		adsp-clkctl-freq-enc = <0xc 0x0 0x4>;
 		adsp-clkctl-freq-mask = <0x0 0x0 0x0>;
 		adsp-clkctl-freq-default = <2>;

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -81,11 +81,10 @@
 	clkctl: clkctl {
 		compatible = "intel,adsp-shim-clkctl";
 		adsp-clkctl-clk-wovcro = <0>;
-		adsp-clkctl-clk-lpro = <1>;
-		adsp-clkctl-clk-ipll = <2>;
-		adsp-clkctl-freq-enc = <0xc 0x0 0x4>;
-		adsp-clkctl-freq-mask = <0x0 0x0 0x0>;
-		adsp-clkctl-freq-default = <2>;
+		adsp-clkctl-clk-ipll = <1>;
+		adsp-clkctl-freq-enc = <0xc 0x4>;
+		adsp-clkctl-freq-mask = <0x0 0x0>;
+		adsp-clkctl-freq-default = <1>;
 		adsp-clkctl-freq-lowest = <0>;
 		wovcro-supported;
 	};

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -96,7 +96,7 @@
 		compatible = "intel,adsp-shim-clkctl";
 		adsp-clkctl-clk-wovcro = <0>;
 		adsp-clkctl-clk-lpro = <1>;
-		adsp-clkctl-clk-hpro = <2>;
+		adsp-clkctl-clk-ipll = <2>;
 		adsp-clkctl-freq-enc = <0xc 0x0 0x4>;
 		adsp-clkctl-freq-mask = <0x0 0x0 0x0>;
 		adsp-clkctl-freq-default = <2>;

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -95,11 +95,10 @@
 	clkctl: clkctl {
 		compatible = "intel,adsp-shim-clkctl";
 		adsp-clkctl-clk-wovcro = <0>;
-		adsp-clkctl-clk-lpro = <1>;
-		adsp-clkctl-clk-ipll = <2>;
-		adsp-clkctl-freq-enc = <0xc 0x0 0x4>;
-		adsp-clkctl-freq-mask = <0x0 0x0 0x0>;
-		adsp-clkctl-freq-default = <2>;
+		adsp-clkctl-clk-ipll = <1>;
+		adsp-clkctl-freq-enc = <0xc 0x4>;
+		adsp-clkctl-freq-mask = <0x0 0x0>;
+		adsp-clkctl-freq-default = <1>;
 		adsp-clkctl-freq-lowest = <0>;
 		wovcro-supported;
 	};

--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_shim.h
@@ -140,7 +140,7 @@ struct ace_dfpmccu {
 
 #endif /* _ASMLANGUAGE */
 
-#define ACE_CLKCTL_WOVCRO    BIT(4)	  /* Request WOVCRO clock */
+#define ACE_CLKCTL_WOVCRO    BIT(21)	  /* Request WOVCRO clock */
 
 #define SHIM_LDOCTL_HPSRAM_LDO_ON     (3 << 0)
 #define SHIM_LDOCTL_HPSRAM_LDO_BYPASS BIT(0)

--- a/soc/xtensa/intel_adsp/common/clk.c
+++ b/soc/xtensa/intel_adsp/common/clk.c
@@ -84,7 +84,7 @@ void adsp_clock_init(void)
 	if (ACE_DfPMCCU.dfclkctl & ACE_CLKCTL_WOVCRO) {
 		ACE_DfPMCCU.dfclkctl = ACE_DfPMCCU.dfclkctl & ~ACE_CLKCTL_WOVCRO;
 	} else {
-		platform_lowest_freq_idx = ADSP_CPU_CLOCK_FREQ_LPRO;
+		platform_lowest_freq_idx = ADSP_CPU_CLOCK_FREQ_IPLL;
 	}
 #else
 	CAVS_SHIM.clkctl |= CAVS_CLKCTL_WOVCRO;

--- a/soc/xtensa/intel_adsp/common/clk.c
+++ b/soc/xtensa/intel_adsp/common/clk.c
@@ -25,6 +25,15 @@ int adsp_clock_freq_mask[] = ADSP_CPU_CLOCK_FREQ_MASK;
 static void select_cpu_clock_hw(uint32_t freq_idx)
 {
 	uint32_t enc = adsp_clock_freq_enc[freq_idx];
+
+#ifdef CONFIG_SOC_SERIES_INTEL_ACE
+	uint32_t clk_ctl = ADSP_CLKCTL;
+
+	clk_ctl &= ~ADSP_CLKCTL_OSC_SOURCE_MASK;
+	clk_ctl |= (enc & ADSP_CLKCTL_OSC_SOURCE_MASK);
+
+	ADSP_CLKCTL = clk_ctl;
+#else
 	uint32_t status_mask = adsp_clock_freq_mask[freq_idx];
 
 	/* Request clock */
@@ -42,6 +51,7 @@ static void select_cpu_clock_hw(uint32_t freq_idx)
 
 	/* Release other clocks */
 	ADSP_CLKCTL &= ~ADSP_CLKCTL_OSC_REQUEST_MASK | enc;
+#endif
 }
 
 int adsp_clock_set_cpu_freq(uint32_t freq_idx)

--- a/soc/xtensa/intel_adsp/common/include/adsp_clk.h
+++ b/soc/xtensa/intel_adsp/common/include/adsp_clk.h
@@ -59,6 +59,8 @@ struct adsp_cpu_clock_info *adsp_cpu_clocks_get(void);
 #define ADSP_CPU_CLOCK_FREQ_WOVCRO	ADSP_CPU_CLOCK_FREQ(wovcro)
 #endif
 
+#define ADSP_CPU_CLOCK_FREQ_IPLL	ADSP_CPU_CLOCK_FREQ(ipll)
+
 
 /* Clock sources used by dai */
 #define ADSP_CLOCK_SOURCE_XTAL_OSC		0


### PR DESCRIPTION
This PR is fixing DSP clock management for ACE platforms. In current state DSP is always using the highest clock.