### PR TITLE
drivers: bluetooth: slz_hci: Configure Number of Completed Packets threshold

### DIFF
--- a/drivers/bluetooth/hci/slz_hci.c
+++ b/drivers/bluetooth/hci/slz_hci.c
@@ -16,11 +16,12 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_hci_driver_slz);
 
-#define SL_BT_CONFIG_ACCEPT_LIST_SIZE	1
-#define SL_BT_CONFIG_MAX_CONNECTIONS	1
-#define SL_BT_CONFIG_USER_ADVERTISERS	1
-#define SL_BT_CONTROLLER_BUFFER_MEMORY  CONFIG_BT_SILABS_HCI_BUFFER_MEMORY
-#define SL_BT_SILABS_LL_STACK_SIZE	1024
+#define SL_BT_CONFIG_ACCEPT_LIST_SIZE		1
+#define SL_BT_CONFIG_MAX_CONNECTIONS		1
+#define SL_BT_CONFIG_USER_ADVERTISERS		1
+#define SL_BT_CONTROLLER_BUFFER_MEMORY		CONFIG_BT_SILABS_HCI_BUFFER_MEMORY
+#define SL_BT_CONTROLLER_LE_BUFFER_SIZE_MAX	CONFIG_BT_BUF_ACL_TX_COUNT
+#define SL_BT_SILABS_LL_STACK_SIZE		1024
 
 static K_KERNEL_STACK_DEFINE(slz_ll_stack, SL_BT_SILABS_LL_STACK_SIZE);
 static struct k_thread slz_ll_thread;
@@ -134,6 +135,8 @@ static int slz_bt_open(void)
 		LOG_ERR("Failed to allocate memory %d", ret);
 		return -ENOMEM;
 	}
+
+	sl_btctrl_configure_le_buffer_size(SL_BT_CONTROLLER_LE_BUFFER_SIZE_MAX);
 
 	ret = sl_btctrl_init_ll();
 	if (ret) {

--- a/drivers/bluetooth/hci/slz_hci.c
+++ b/drivers/bluetooth/hci/slz_hci.c
@@ -16,12 +16,14 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_hci_driver_slz);
 
-#define SL_BT_CONFIG_ACCEPT_LIST_SIZE		1
-#define SL_BT_CONFIG_MAX_CONNECTIONS		1
-#define SL_BT_CONFIG_USER_ADVERTISERS		1
-#define SL_BT_CONTROLLER_BUFFER_MEMORY		CONFIG_BT_SILABS_HCI_BUFFER_MEMORY
-#define SL_BT_CONTROLLER_LE_BUFFER_SIZE_MAX	CONFIG_BT_BUF_ACL_TX_COUNT
-#define SL_BT_SILABS_LL_STACK_SIZE		1024
+#define SL_BT_CONFIG_ACCEPT_LIST_SIZE				1
+#define SL_BT_CONFIG_MAX_CONNECTIONS				1
+#define SL_BT_CONFIG_USER_ADVERTISERS				1
+#define SL_BT_CONTROLLER_BUFFER_MEMORY				CONFIG_BT_SILABS_HCI_BUFFER_MEMORY
+#define SL_BT_CONTROLLER_LE_BUFFER_SIZE_MAX			CONFIG_BT_BUF_ACL_TX_COUNT
+#define SL_BT_CONTROLLER_COMPLETED_PACKETS_THRESHOLD		1
+#define SL_BT_CONTROLLER_COMPLETED_PACKETS_EVENTS_TIMEOUT	3
+#define SL_BT_SILABS_LL_STACK_SIZE				1024
 
 static K_KERNEL_STACK_DEFINE(slz_ll_stack, SL_BT_SILABS_LL_STACK_SIZE);
 static struct k_thread slz_ll_thread;
@@ -157,6 +159,10 @@ static int slz_bt_open(void)
 		LOG_ERR("Failed to initialize the controller %d", ret);
 		goto deinit;
 	}
+
+	sl_btctrl_configure_completed_packets_reporting(
+		SL_BT_CONTROLLER_COMPLETED_PACKETS_THRESHOLD,
+		SL_BT_CONTROLLER_COMPLETED_PACKETS_EVENTS_TIMEOUT);
 
 	sl_bthci_init_upper();
 	sl_btctrl_hci_parser_init_default();

--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: d184c2ccc0ec5a7189d6d5cb7645c7f9bd38c2b5
+      revision: 20113e9520ce59ee7fa85ba10102d0880822bb3e
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Configure the Number of Completed Packets event threshold to 1, so the SiLabs Bluetooth controller will always send the Number of Completed Packets HCI event to the host, even for small numbers of transmitted packets.

The required function `sl_btctrl_configure_completed_packets_reporting()` was first added to the Gecko SDK in version 4.2, so this patch also updates hal_silabs and adapts the SiLabs HCI driver accordingly.

Fixes #62279