### PR TITLE
twister: pytest: Move fixtures to one file

### DIFF
--- a/samples/subsys/testsuite/pytest/shell/pytest/test_shell.py
+++ b/samples/subsys/testsuite/pytest/shell/pytest/test_shell.py
@@ -4,19 +4,9 @@
 
 import logging
 
-import pytest
-from twister_harness import DeviceAdapter, Shell
+from twister_harness import Shell
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope='function')
-def shell(dut: DeviceAdapter) -> Shell:
-    """Return ready to use shell interface"""
-    shell = Shell(dut, timeout=20.0)
-    logger.info('wait for prompt')
-    assert shell.wait_for_prompt()
-    return shell
 
 
 def test_shell_print_help(shell: Shell):

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/__init__.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/__init__.py
@@ -5,7 +5,7 @@
 # flake8: noqa
 
 from twister_harness.device.device_adapter import DeviceAdapter
-from twister_harness.fixtures.mcumgr import MCUmgr
+from twister_harness.helpers.mcumgr import MCUmgr
 from twister_harness.helpers.shell import Shell
 
 __all__ = ['DeviceAdapter', 'MCUmgr', 'Shell']

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
@@ -10,6 +10,8 @@ import pytest
 from twister_harness.device.device_adapter import DeviceAdapter
 from twister_harness.device.factory import DeviceFactory
 from twister_harness.twister_harness_config import DeviceConfig, TwisterHarnessConfig
+from twister_harness.helpers.shell import Shell
+from twister_harness.helpers.mcumgr import MCUmgr
 
 logger = logging.getLogger(__name__)
 
@@ -44,3 +46,23 @@ def dut(request: pytest.FixtureRequest, device_object: DeviceAdapter) -> Generat
         yield device_object
     finally:  # to make sure we close all running processes execution
         device_object.close()
+
+
+@pytest.fixture(scope='function')
+def shell(dut: DeviceAdapter) -> Shell:
+    """Return ready to use shell interface"""
+    shell = Shell(dut, timeout=20.0)
+    logger.info('Wait for prompt')
+    assert shell.wait_for_prompt()
+    return shell
+
+
+@pytest.fixture(scope='session')
+def is_mcumgr_available() -> None:
+    if not MCUmgr.is_available():
+        pytest.skip('mcumgr not available')
+
+
+@pytest.fixture()
+def mcumgr(is_mcumgr_available: None, dut: DeviceAdapter) -> Generator[MCUmgr, None, None]:
+    yield MCUmgr.create_for_serial(dut.device_config.serial)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures/__init__.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures/__init__.py
@@ -1,8 +1,0 @@
-# Copyright (c) 2023 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: Apache-2.0
-
-import pytest
-
-pytest.register_assert_rewrite('twister_harness.fixtures.dut')
-pytest.register_assert_rewrite('twister_harness.fixtures.mcumgr')

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/mcumgr.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/mcumgr.py
@@ -3,18 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import pytest
 import logging
 import re
 import shlex
 
-from typing import Generator
 from subprocess import check_output, getstatusoutput
 from pathlib import Path
 from dataclasses import dataclass
-
-from twister_harness.device.device_adapter import DeviceAdapter
-
 
 logger = logging.getLogger(__name__)
 
@@ -108,14 +103,3 @@ class MCUmgr:
             image_list = self.get_image_list()
             hash = image_list[0].hash
         self.run_command(f'image confirm {hash}')
-
-
-@pytest.fixture(scope='session')
-def is_mcumgr_available() -> None:
-    if not MCUmgr.is_available():
-        pytest.skip('mcumgr not available')
-
-
-@pytest.fixture()
-def mcumgr(is_mcumgr_available: None, dut: DeviceAdapter) -> Generator[MCUmgr, None, None]:
-    yield MCUmgr.create_for_serial(dut.device_config.serial)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -14,8 +14,7 @@ from twister_harness.twister_harness_config import TwisterHarnessConfig
 logger = logging.getLogger(__name__)
 
 pytest_plugins = (
-    'twister_harness.fixtures.dut',
-    'twister_harness.fixtures.mcumgr'
+    'twister_harness.fixtures'
 )
 
 

--- a/scripts/pylib/pytest-twister-harness/tests/fixtures/mcumgr_fixture_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/fixtures/mcumgr_fixture_test.py
@@ -6,7 +6,7 @@ import pytest
 import textwrap
 
 from unittest import mock
-from twister_harness.fixtures.mcumgr import MCUmgr, MCUmgrException
+from twister_harness.helpers.mcumgr import MCUmgr, MCUmgrException
 
 
 @pytest.fixture(name='mcumgr')
@@ -14,7 +14,7 @@ def fixture_mcumgr() -> MCUmgr:
     return MCUmgr.create_for_serial('SERIAL_PORT')
 
 
-@mock.patch('twister_harness.fixtures.mcumgr.MCUmgr.run_command', return_value='')
+@mock.patch('twister_harness.helpers.mcumgr.MCUmgr.run_command', return_value='')
 def test_if_mcumgr_fixture_generate_proper_command(
     patched_run_command: mock.Mock, mcumgr: MCUmgr
 ) -> None:


### PR DESCRIPTION
Fixtures in pytest-twister-harness plugin are moved to one file to simplify adding new fixtures in the future - no need to add pytest_plugins entry and register asserts. Moved also shell fixture from sample dir, because that fixture can be reused in new tests.