### PR TITLE
drivers: ioapic: declare the device with DEVICE_DT_INST_DEFINE

### DIFF
--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -543,7 +543,7 @@ static void IoApicRedUpdateLo(unsigned int irq,
 	ioApicRedSetLo(irq, (ioApicRedGetLo(irq) & ~mask) | (value & mask));
 }
 
-PM_DEVICE_DEFINE(ioapic, ioapic_pm_action);
+PM_DEVICE_DT_INST_DEFINE(0, ioapic_pm_action);
 
-DEVICE_DEFINE(ioapic, "ioapic", ioapic_init, PM_DEVICE_GET(ioapic), NULL, NULL,
-	      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);
+DEVICE_DT_INST_DEFINE(0, ioapic_init, PM_DEVICE_DT_INST_GET(0), NULL, NULL,
+		      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);


### PR DESCRIPTION
Use DEVICE_DT_INST_DEFINE instead of DEVICE_DEFINE to declare the device structure. This ensures that the device gets an ordinal and is initialized before any device depending on it.