### PR TITLE
subsys: modem: Delegate async UART pipe closed event

### DIFF
--- a/include/zephyr/modem/backend/uart.h
+++ b/include/zephyr/modem/backend/uart.h
@@ -34,6 +34,7 @@ struct modem_backend_uart_async {
 	struct ring_buf receive_rdb[2];
 	uint8_t *transmit_buf;
 	uint32_t transmit_buf_size;
+	struct k_work rx_disabled_work;
 	atomic_t state;
 };
 

--- a/subsys/modem/backends/Kconfig
+++ b/subsys/modem/backends/Kconfig
@@ -9,6 +9,7 @@ config MODEM_BACKEND_TTY
 config MODEM_BACKEND_UART
 	bool "Modem UART backend module"
 	select MODEM_PIPE
+	select RING_BUFFER
 	depends on UART_INTERRUPT_DRIVEN || UART_ASYNC_API
 
 if MODEM_BACKEND_UART


### PR DESCRIPTION
This commit delegates the modem_pipe_notify_closed() call resulting from the UART async API UART_RX_DISABLED event to the workqueue. This is neccesary as the async UART callback may be called from ISR context.

modem_pipe_notify_closed() must be called from outside of the ISR context as it takes a mutex.

The commit also adds a missing break to the async UART callback, and adds a missing dependency to the Kconfig for the UART backends, RING_BUFFER=y