### PR TITLE
scripts: check_init_priorities: use the zephyr executable file  [WAS: scripts: add dump_init_order.py]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1811,8 +1811,7 @@ if(CONFIG_CHECK_INIT_PRIORITIES)
   list(APPEND
     post_build_commands
     COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/check_init_priorities.py
-      --build-dir ${PROJECT_BINARY_DIR}/..
-      --edt-pickle ${EDT_PICKLE}
+      --elf-file=${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
       ${fail_on_warning}
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1816,6 +1816,15 @@ if(CONFIG_CHECK_INIT_PRIORITIES)
     )
 endif()
 
+add_custom_target(
+  initlevels
+  COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/check_init_priorities.py
+    --elf-file=${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
+    --initlevels
+  DEPENDS ${logical_target_for_zephyr_elf}
+  USES_TERMINAL
+)
+
 # Generate and use MCUboot related artifacts as needed.
 if(CONFIG_BOOTLOADER_MCUBOOT)
   get_target_property(signing_script zephyr_property_target SIGNING_SCRIPT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1816,14 +1816,16 @@ if(CONFIG_CHECK_INIT_PRIORITIES)
     )
 endif()
 
-add_custom_target(
-  initlevels
-  COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/check_init_priorities.py
-    --elf-file=${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
-    --initlevels
-  DEPENDS ${logical_target_for_zephyr_elf}
-  USES_TERMINAL
-)
+if(NOT CMAKE_C_COMPILER_ID STREQUAL "ARMClang")
+  add_custom_target(
+    initlevels
+    COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/check_init_priorities.py
+      --elf-file=${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
+      --initlevels
+    DEPENDS ${logical_target_for_zephyr_elf}
+    USES_TERMINAL
+  )
+endif()
 
 # Generate and use MCUboot related artifacts as needed.
 if(CONFIG_BOOTLOADER_MCUBOOT)

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -748,6 +748,7 @@ config CHECK_INIT_PRIORITIES
 	bool "Build time initialization priorities check"
 	default y
 	depends on !NATIVE_LIBRARY
+	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "armclang"
 	help
 	  Check the build for initialization priority issues by comparing the
 	  initialization priority in the build with the device dependency

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -747,6 +747,7 @@ config BUILD_OUTPUT_STRIP_PATHS
 config CHECK_INIT_PRIORITIES
 	bool "Build time initialization priorities check"
 	default y
+	depends on !NATIVE_LIBRARY
 	help
 	  Check the build for initialization priority issues by comparing the
 	  initialization priority in the build with the device dependency

--- a/scripts/build/check_init_priorities_test.py
+++ b/scripts/build/check_init_priorities_test.py
@@ -10,7 +10,7 @@ import mock
 import pathlib
 import unittest
 
-from elftools.elf.relocation import RelocationSection
+from elftools.elf.relocation import Section
 from elftools.elf.sections import SymbolTableSection
 
 import check_init_priorities
@@ -19,191 +19,245 @@ class TestPriority(unittest.TestCase):
     """Tests for the Priority class."""
 
     def test_priority_parsing(self):
-        prio1 = check_init_priorities.Priority(".rel.z_init_POST_KERNEL12_0_")
-        self.assertEqual(prio1._level_priority, (3, 12, 0))
+        prio1 = check_init_priorities.Priority("POST_KERNEL", 12)
+        self.assertEqual(prio1._level_priority, (3, 12))
 
-        prio2 = check_init_priorities.Priority("noisenoise_POST_KERNEL99_00023_")
-        self.assertEqual(prio2._level_priority, (3, 99, 23))
-
-        prio3 = check_init_priorities.Priority("_PRE_KERNEL_10_99999_")
-        self.assertEqual(prio3._level_priority, (1, 0, 99999))
-
-        prio4 = check_init_priorities.Priority("_PRE_KERNEL_110_00001_")
-        self.assertEqual(prio4._level_priority, (1, 10, 1))
+        prio1 = check_init_priorities.Priority("APPLICATION", 9999)
+        self.assertEqual(prio1._level_priority, (4, 9999))
 
         with self.assertRaises(ValueError):
-            check_init_priorities.Priority("i-am-not-a-priority")
-            check_init_priorities.Priority("_DOESNOTEXIST0_")
-            check_init_priorities.Priority(".rel.z_init_POST_KERNEL12_blah")
-            check_init_priorities.Priority(".rel.z_init_2_")
-            check_init_priorities.Priority(".rel.z_init_POST_KERNEL1_")
+            check_init_priorities.Priority("i-am-not-a-priority", 0)
+            check_init_priorities.Priority("_DOESNOTEXIST0_", 0)
 
     def test_priority_levels(self):
         prios = [
-                check_init_priorities.Priority(".rel.z_init_EARLY0_0_"),
-                check_init_priorities.Priority(".rel.z_init_EARLY1_0_"),
-                check_init_priorities.Priority(".rel.z_init_EARLY11_0_"),
-                check_init_priorities.Priority(".rel.z_init_PRE_KERNEL_10_0_"),
-                check_init_priorities.Priority(".rel.z_init_PRE_KERNEL_11_0_"),
-                check_init_priorities.Priority(".rel.z_init_PRE_KERNEL_111_0_"),
-                check_init_priorities.Priority(".rel.z_init_PRE_KERNEL_111_1_"),
-                check_init_priorities.Priority(".rel.z_init_PRE_KERNEL_111_00002_"),
-                check_init_priorities.Priority(".rel.z_init_PRE_KERNEL_111_00010_"),
-                check_init_priorities.Priority(".rel.z_init_PRE_KERNEL_20_0_"),
-                check_init_priorities.Priority(".rel.z_init_PRE_KERNEL_21_0_"),
-                check_init_priorities.Priority(".rel.z_init_PRE_KERNEL_211_0_"),
-                check_init_priorities.Priority(".rel.z_init_POST_KERNEL0_0_"),
-                check_init_priorities.Priority(".rel.z_init_POST_KERNEL1_0_"),
-                check_init_priorities.Priority(".rel.z_init_POST_KERNEL11_0_"),
-                check_init_priorities.Priority(".rel.z_init_APPLICATION0_0_"),
-                check_init_priorities.Priority(".rel.z_init_APPLICATION1_0_"),
-                check_init_priorities.Priority(".rel.z_init_APPLICATION11_0_"),
-                check_init_priorities.Priority(".rel.z_init_SMP0_0_"),
-                check_init_priorities.Priority(".rel.z_init_SMP1_0_"),
-                check_init_priorities.Priority(".rel.z_init_SMP11_0_"),
+                check_init_priorities.Priority("EARLY", 0),
+                check_init_priorities.Priority("EARLY", 1),
+                check_init_priorities.Priority("PRE_KERNEL_1", 0),
+                check_init_priorities.Priority("PRE_KERNEL_1", 1),
+                check_init_priorities.Priority("PRE_KERNEL_2", 0),
+                check_init_priorities.Priority("PRE_KERNEL_2", 1),
+                check_init_priorities.Priority("POST_KERNEL", 0),
+                check_init_priorities.Priority("POST_KERNEL", 1),
+                check_init_priorities.Priority("APPLICATION", 0),
+                check_init_priorities.Priority("APPLICATION", 1),
+                check_init_priorities.Priority("SMP", 0),
+                check_init_priorities.Priority("SMP", 1),
                 ]
 
         self.assertListEqual(prios, sorted(prios))
 
     def test_priority_strings(self):
-        prio = check_init_priorities.Priority(".rel.z_init_POST_KERNEL12_00023_")
-        self.assertEqual(str(prio), "POST_KERNEL 12 23")
-        self.assertEqual(repr(prio), "<Priority POST_KERNEL 12 23>")
+        prio = check_init_priorities.Priority("POST_KERNEL", 12)
+        self.assertEqual(str(prio), "POST_KERNEL 12")
+        self.assertEqual(repr(prio), "<Priority POST_KERNEL 12>")
 
-class testZephyrObjectFile(unittest.TestCase):
-    """Tests for the ZephyrObjectFile class."""
+class testZephyrInitLevels(unittest.TestCase):
+    """Tests for the ZephyrInitLevels class."""
 
-    @mock.patch("check_init_priorities.ZephyrObjectFile.__init__", return_value=None)
-    def test_load_symbols(self, mock_zofinit):
+    @mock.patch("check_init_priorities.ZephyrInitLevels.__init__", return_value=None)
+    def test_load_objects(self, mock_zilinit):
         mock_elf = mock.Mock()
 
         sts = mock.Mock(spec=SymbolTableSection)
-        rel = mock.Mock(spec=RelocationSection)
+        rel = mock.Mock(spec=Section)
         mock_elf.iter_sections.return_value = [sts, rel]
 
         s0 = mock.Mock()
         s0.name = "a"
+        s0.entry.st_info.type = "STT_OBJECT"
+        s0.entry.st_size = 4
+        s0.entry.st_value = 0xaa
+        s0.entry.st_shndx = 1
+
         s1 = mock.Mock()
         s1.name = None
+
         s2 = mock.Mock()
         s2.name = "b"
+        s2.entry.st_info.type = "STT_FUNC"
+        s2.entry.st_size = 8
+        s2.entry.st_value = 0xbb
+        s2.entry.st_shndx = 2
+
         sts.iter_symbols.return_value = [s0, s1, s2]
 
-        obj = check_init_priorities.ZephyrObjectFile("")
+        obj = check_init_priorities.ZephyrInitLevels("")
         obj._elf = mock_elf
-        obj._load_symbols()
+        obj._load_objects()
 
-        self.assertDictEqual(obj._symbols, {0: "a", 2: "b"})
+        self.assertDictEqual(obj._objects, {0xaa: ("a", 4, 1), 0xbb: ("b", 8, 2)})
 
-    @mock.patch("check_init_priorities.Priority")
-    @mock.patch("check_init_priorities.ZephyrObjectFile._device_ord_from_rel")
-    @mock.patch("check_init_priorities.ZephyrObjectFile.__init__", return_value=None)
-    def test_find_defined_devices(self, mock_zofinit, mock_dofr, mock_prio):
+    @mock.patch("check_init_priorities.ZephyrInitLevels.__init__", return_value=None)
+    def test_load_level_addr(self, mock_zilinit):
         mock_elf = mock.Mock()
 
         sts = mock.Mock(spec=SymbolTableSection)
-        rel1 = mock.Mock(spec=RelocationSection)
-        rel1.name = ".rel.z_init_SOMETHING"
-        rel2 = mock.Mock(spec=RelocationSection)
-        rel2.name = ".rel.something_else"
-        mock_elf.iter_sections.return_value = [sts, rel1, rel2]
+        rel = mock.Mock(spec=Section)
+        mock_elf.iter_sections.return_value = [sts, rel]
 
-        r0 = mock.Mock()
-        rel1.iter_relocations.return_value = [r0]
+        s0 = mock.Mock()
+        s0.name = "__init_EARLY_start"
+        s0.entry.st_value = 0x00
 
-        mock_dofr.return_value = 123
+        s1 = mock.Mock()
+        s1.name = "__init_PRE_KERNEL_1_start"
+        s1.entry.st_value = 0x11
 
-        r0_prio = mock.Mock()
-        mock_prio.return_value = r0_prio
+        s2 = mock.Mock()
+        s2.name = "__init_PRE_KERNEL_2_start"
+        s2.entry.st_value = 0x22
 
-        obj = check_init_priorities.ZephyrObjectFile("")
+        s3 = mock.Mock()
+        s3.name = "__init_POST_KERNEL_start"
+        s3.entry.st_value = 0x33
+
+        s4 = mock.Mock()
+        s4.name = "__init_APPLICATION_start"
+        s4.entry.st_value = 0x44
+
+        s5 = mock.Mock()
+        s5.name = "__init_SMP_start"
+        s5.entry.st_value = 0x55
+
+        s6 = mock.Mock()
+        s6.name = "__init_end"
+        s6.entry.st_value = 0x66
+
+        sts.iter_symbols.return_value = [s0, s1, s2, s3, s4, s5, s6]
+
+        obj = check_init_priorities.ZephyrInitLevels("")
         obj._elf = mock_elf
-        obj._find_defined_devices()
+        obj._load_level_addr()
 
-        self.assertDictEqual(obj.defined_devices, {123: r0_prio})
-        mock_dofr.assert_called_once_with(r0)
-        mock_prio.assert_called_once_with(rel1.name)
+        self.assertDictEqual(obj._init_level_addr, {
+            "EARLY": 0x00,
+            "PRE_KERNEL_1": 0x11,
+            "PRE_KERNEL_2": 0x22,
+            "POST_KERNEL": 0x33,
+            "APPLICATION": 0x44,
+            "SMP": 0x55,
+            })
+        self.assertEqual(obj._init_level_end, 0x66)
 
-    @mock.patch("check_init_priorities.ZephyrObjectFile.__init__", return_value=None)
-    def test_device_ord_from_rel(self, mock_zofinit):
-        obj = check_init_priorities.ZephyrObjectFile("")
+    @mock.patch("check_init_priorities.ZephyrInitLevels.__init__", return_value=None)
+    def test_device_ord_from_name(self, mock_zilinit):
+        obj = check_init_priorities.ZephyrInitLevels("")
 
-        obj._symbols = {
-                1: "blah",
-                2: "__device_dts_ord_123",
+        self.assertEqual(obj._device_ord_from_name(None), None)
+        self.assertEqual(obj._device_ord_from_name("hey, hi!"), None)
+        self.assertEqual(obj._device_ord_from_name("__device_dts_ord_123"), 123)
+
+    @mock.patch("check_init_priorities.ZephyrInitLevels.__init__", return_value=None)
+    def test_object_name(self, mock_zilinit):
+        obj = check_init_priorities.ZephyrInitLevels("")
+        obj._objects = {0x123: ("name", 4)}
+
+        self.assertEqual(obj._object_name(0), "NULL")
+        self.assertEqual(obj._object_name(73), "unknown")
+        self.assertEqual(obj._object_name(0x123), "name")
+
+    @mock.patch("check_init_priorities.ZephyrInitLevels.__init__", return_value=None)
+    def test_initlevel_pointer_32(self, mock_zilinit):
+        obj = check_init_priorities.ZephyrInitLevels("")
+        obj._elf = mock.Mock()
+        obj._elf.elfclass = 32
+        mock_section = mock.Mock()
+        obj._elf.get_section.return_value = mock_section
+        mock_section.header.sh_addr = 0x100
+        mock_section.data.return_value = (b"\x01\x00\x00\x00"
+                                          b"\x02\x00\x00\x00"
+                                          b"\x03\x00\x00\x00")
+
+        self.assertEqual(obj._initlevel_pointer(0x100, 0, 0), 1)
+        self.assertEqual(obj._initlevel_pointer(0x100, 1, 0), 2)
+        self.assertEqual(obj._initlevel_pointer(0x104, 0, 0), 2)
+        self.assertEqual(obj._initlevel_pointer(0x104, 1, 0), 3)
+
+    @mock.patch("check_init_priorities.ZephyrInitLevels.__init__", return_value=None)
+    def test_initlevel_pointer_64(self, mock_zilinit):
+        obj = check_init_priorities.ZephyrInitLevels("")
+        obj._elf = mock.Mock()
+        obj._elf.elfclass = 64
+        mock_section = mock.Mock()
+        obj._elf.get_section.return_value = mock_section
+        mock_section.header.sh_addr = 0x100
+        mock_section.data.return_value = (b"\x01\x00\x00\x00\x00\x00\x00\x00"
+                                          b"\x02\x00\x00\x00\x00\x00\x00\x00"
+                                          b"\x03\x00\x00\x00\x00\x00\x00\x00")
+
+        self.assertEqual(obj._initlevel_pointer(0x100, 0, 0), 1)
+        self.assertEqual(obj._initlevel_pointer(0x100, 1, 0), 2)
+        self.assertEqual(obj._initlevel_pointer(0x108, 0, 0), 2)
+        self.assertEqual(obj._initlevel_pointer(0x108, 1, 0), 3)
+
+    @mock.patch("check_init_priorities.ZephyrInitLevels._object_name")
+    @mock.patch("check_init_priorities.ZephyrInitLevels._initlevel_pointer")
+    @mock.patch("check_init_priorities.ZephyrInitLevels.__init__", return_value=None)
+    def test_process_initlevels(self, mock_zilinit, mock_ip, mock_on):
+        obj = check_init_priorities.ZephyrInitLevels("")
+        obj._init_level_addr = {
+            "EARLY": 0x00,
+            "PRE_KERNEL_1": 0x00,
+            "PRE_KERNEL_2": 0x00,
+            "POST_KERNEL": 0x08,
+            "APPLICATION": 0x0c,
+            "SMP": 0x0c,
+            }
+        obj._init_level_end = 0x0c
+        obj._objects = {
+                0x00: ("a", 4, 0),
+                0x04: ("b", 4, 0),
+                0x08: ("c", 4, 0),
                 }
 
-        self.assertEqual(obj._device_ord_from_rel({"r_info_sym": 0}), None)
-        self.assertEqual(obj._device_ord_from_rel({"r_info_sym": 1}), None)
-        self.assertEqual(obj._device_ord_from_rel({"r_info_sym": 2}), 123)
+        mock_ip.side_effect = lambda *args: args
+
+        def mock_obj_name(*args):
+            if args[0] == (0, 0, 0):
+                return "i0"
+            elif args[0] == (0, 1, 0):
+                return "__device_dts_ord_11"
+            elif args[0] == (4, 0, 0):
+                return "i1"
+            elif args[0] == (4, 1, 0):
+                return "__device_dts_ord_22"
+            return f"name_{args[0][0]}_{args[0][1]}"
+        mock_on.side_effect = mock_obj_name
+
+        obj._process_initlevels()
+
+        self.assertDictEqual(obj.initlevels, {
+            "EARLY": [],
+            "PRE_KERNEL_1": [],
+            "PRE_KERNEL_2": ["a: i0(__device_dts_ord_11)", "b: i1(__device_dts_ord_22)"],
+            "POST_KERNEL": ["c: name_8_0(name_8_1)"],
+            "APPLICATION": [],
+            "SMP": [],
+            })
+        self.assertDictEqual(obj.devices, {
+            11: check_init_priorities.Priority("PRE_KERNEL_2", 0),
+            22: check_init_priorities.Priority("PRE_KERNEL_2", 1),
+            })
 
 class testValidator(unittest.TestCase):
     """Tests for the Validator class."""
 
-    @mock.patch("check_init_priorities.ZephyrObjectFile")
-    @mock.patch("check_init_priorities.Validator._find_build_objfiles")
+    @mock.patch("check_init_priorities.ZephyrInitLevels")
     @mock.patch("pickle.load")
-    def test_initialize(self, mock_pl, mock_fbo, mock_zof):
-        mock_fbo.return_value = ["filepath"]
-
+    def test_initialize(self, mock_pl, mock_zil):
         mock_log = mock.Mock()
         mock_prio = mock.Mock()
         mock_obj = mock.Mock()
         mock_obj.defined_devices = {123: mock_prio}
-        mock_zof.return_value = mock_obj
+        mock_zil.return_value = mock_obj
 
         with mock.patch("builtins.open", mock.mock_open()) as mock_open:
             validator = check_init_priorities.Validator("path", "pickle", mock_log)
 
-        self.assertListEqual(validator._objs, [mock_obj])
-        self.assertDictEqual(validator._dev_priorities, {123: mock_prio})
-        mock_fbo.assert_called_once_with("path", is_root=True)
-        mock_zof.assert_called_once_with("filepath")
-        mock_open.assert_called_once_with(pathlib.Path("path/pickle"), "rb")
-
-    @mock.patch("pathlib.Path")
-    @mock.patch("check_init_priorities.Validator.__init__", return_value=None)
-    def test_find_build_objfiles(self, mock_vinit, mock_path):
-        mock_log = mock.Mock()
-
-        validator = check_init_priorities.Validator("", "", mock_log)
-
-        mock_file = mock.Mock()
-        mock_file.is_file.return_value = True
-        mock_file.is_dir.return_value = False
-        mock_file.file.name = "filename.c.obj"
-
-        mock_dir = mock.Mock()
-        mock_dir.is_file.return_value = False
-        mock_dir.is_dir.return_value = True
-        mock_dir.resolve.return_value = "subdir"
-        mock_dir.iterdir.return_value = []
-
-        mock_nosettingsfile = mock.Mock()
-        mock_nosettingsfile.exists.return_value = False
-
-        mock_path_root = mock.Mock()
-        mock_path_root.iterdir.return_value = [mock_file, mock_dir]
-
-        def mock_path_stubs(*args):
-            if args == ("root",):
-                return mock_path_root
-            elif args == ("subdir",):
-                return mock_dir
-            elif args == ("subdir", "CMakeCache.txt"):
-                return mock_nosettingsfile
-            raise ValueError
-        mock_path.side_effect = mock_path_stubs
-
-        ret = list(validator._find_build_objfiles("root", is_root=True))
-        self.assertListEqual(ret, [mock_file])
-
-        mock_nosettingsfile.exists.assert_called_once_with()
-        self.assertListEqual(mock_path.call_args_list, [
-            mock.call("root"),
-            mock.call("subdir", "CMakeCache.txt"),
-            mock.call("subdir")
-            ])
+        self.assertEqual(validator._obj, mock_obj)
+        mock_zil.assert_called_once_with("path")
+        mock_open.assert_called_once_with(pathlib.Path("pickle"), "rb")
 
     @mock.patch("check_init_priorities.Validator.__init__", return_value=None)
     def test_check_dep_same_node(self, mock_vinit):
@@ -220,15 +274,16 @@ class testValidator(unittest.TestCase):
     def test_check_dep_no_prio(self, mock_vinit):
         validator = check_init_priorities.Validator("", "", None)
         validator.log = mock.Mock()
+        validator._obj = mock.Mock()
 
         validator._ord2node = {1: mock.Mock(), 2: mock.Mock()}
         validator._ord2node[1]._binding = None
         validator._ord2node[2]._binding = None
 
-        validator._dev_priorities = {1: 10}
+        validator._obj.devices = {1: 10}
         validator._check_dep(1, 2)
 
-        validator._dev_priorities = {2: 20}
+        validator._obj.devices = {2: 20}
         validator._check_dep(1, 2)
 
         self.assertFalse(validator.log.info.called)
@@ -239,6 +294,7 @@ class testValidator(unittest.TestCase):
     def test_check(self, mock_vinit):
         validator = check_init_priorities.Validator("", "", None)
         validator.log = mock.Mock()
+        validator._obj = mock.Mock()
         validator.warnings = 0
         validator.errors = 0
 
@@ -250,7 +306,7 @@ class testValidator(unittest.TestCase):
         validator._ord2node[3]._binding = None
         validator._ord2node[3].path = "/3"
 
-        validator._dev_priorities = {1: 10, 2: 10, 3: 20}
+        validator._obj.devices = {1: 10, 2: 10, 3: 20}
 
         validator._check_dep(3, 1)
         validator._check_dep(2, 1)
@@ -266,6 +322,7 @@ class testValidator(unittest.TestCase):
     def test_check_swapped(self, mock_vinit):
         validator = check_init_priorities.Validator("", "", None)
         validator.log = mock.Mock()
+        validator._obj = mock.Mock()
         validator.warnings = 0
         validator.errors = 0
 
@@ -279,7 +336,7 @@ class testValidator(unittest.TestCase):
         validator._ord2node[3]._binding.compatible = "compat-3"
         validator._ord2node[3].path = "/3"
 
-        validator._dev_priorities = {1: 20, 3: 10}
+        validator._obj.devices = {1: 20, 3: 10}
 
         validator._check_dep(3, 1)
 
@@ -296,6 +353,7 @@ class testValidator(unittest.TestCase):
     def test_check_ignored(self, mock_vinit):
         validator = check_init_priorities.Validator("", "", None)
         validator.log = mock.Mock()
+        validator._obj = mock.Mock()
         validator.warnings = 0
         validator.errors = 0
 
@@ -309,7 +367,7 @@ class testValidator(unittest.TestCase):
         validator._ord2node[3]._binding.compatible = "compat-3"
         validator._ord2node[3].path = "/3"
 
-        validator._dev_priorities = {1: 20, 3: 10}
+        validator._obj.devices = {1: 20, 3: 10}
 
         validator._check_dep(3, 1)
 
@@ -360,7 +418,8 @@ class testValidator(unittest.TestCase):
     def test_check_edt(self, mock_vinit, mock_cer):
         validator = check_init_priorities.Validator("", "", None)
         validator._ord2node = {1: mock.Mock(), 2: mock.Mock(), 3: mock.Mock()}
-        validator._dev_priorities = {1: 10, 2: 10, 3: 20}
+        validator._obj = mock.Mock()
+        validator._obj.devices = {1: 10, 2: 10, 3: 20}
 
         validator.check_edt()
 

--- a/tests/misc/check_init_priorities/CMakeLists.txt
+++ b/tests/misc/check_init_priorities/CMakeLists.txt
@@ -5,21 +5,20 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 set(output_file ${PROJECT_BINARY_DIR}/check_init_priorities_output.txt)
 
-add_custom_target(
-	check_init_priorities_output
+add_custom_command(
 	COMMENT "Running check_init_priorities.py"
+	OUTPUT ${output_file}
+	DEPENDS ${BYPRODUCT_KERNEL_ELF_NAME}
 	COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/check_init_priorities.py
 	  --verbose
-	  --build-dir ${PROJECT_BINARY_DIR}/..
+	  --elf-file=${ZEPHYR_BINARY_DIR}/${KERNEL_ELF_NAME}
 	  --output ${output_file}
 	  --always-succeed
 	COMMAND ${PYTHON_EXECUTABLE} ${APPLICATION_SOURCE_DIR}/validate_check_init_priorities_output.py
 	  ${output_file}
-	DEPENDS zephyr_pre0
 )
-if (TARGET zephyr_pre1)
-  add_dependencies(zephyr_pre1 check_init_priorities_output)
-endif()
+
+add_custom_target(check_init_priorities_output ALL DEPENDS ${output_file})
 
 project(check_init_priorities)
 

--- a/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
+++ b/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
@@ -8,12 +8,12 @@
 import sys
 
 REFERENCE_OUTPUT = [
-        "ERROR: /i2c@11112222/test-i2c-dev@10 PRE_KERNEL_1 49 31 < /gpio@ffff PRE_KERNEL_1 50 29",
-        "ERROR: /i2c@11112222/test-i2c-dev@10 PRE_KERNEL_1 49 31 < /i2c@11112222 PRE_KERNEL_1 50 30",
-        "INFO: /i2c@11112222/test-i2c-dev@11 PRE_KERNEL_1 50 32 > /gpio@ffff PRE_KERNEL_1 50 29",
-        "INFO: /i2c@11112222/test-i2c-dev@11 PRE_KERNEL_1 50 32 > /i2c@11112222 PRE_KERNEL_1 50 30",
-        "INFO: /i2c@11112222/test-i2c-dev@12 PRE_KERNEL_1 51 33 > /gpio@ffff PRE_KERNEL_1 50 29",
-        "INFO: /i2c@11112222/test-i2c-dev@12 PRE_KERNEL_1 51 33 > /i2c@11112222 PRE_KERNEL_1 50 30"
+        "ERROR: /i2c@11112222/test-i2c-dev@10 PRE_KERNEL_1 0 < /gpio@ffff PRE_KERNEL_1 1",
+        "ERROR: /i2c@11112222/test-i2c-dev@10 PRE_KERNEL_1 0 < /i2c@11112222 PRE_KERNEL_1 2",
+        "INFO: /i2c@11112222/test-i2c-dev@11 PRE_KERNEL_1 3 > /gpio@ffff PRE_KERNEL_1 1",
+        "INFO: /i2c@11112222/test-i2c-dev@11 PRE_KERNEL_1 3 > /i2c@11112222 PRE_KERNEL_1 2",
+        "INFO: /i2c@11112222/test-i2c-dev@12 PRE_KERNEL_1 4 > /gpio@ffff PRE_KERNEL_1 1",
+        "INFO: /i2c@11112222/test-i2c-dev@12 PRE_KERNEL_1 4 > /i2c@11112222 PRE_KERNEL_1 2",
 ]
 
 if len(sys.argv) != 2:
@@ -23,7 +23,7 @@ if len(sys.argv) != 2:
 output = []
 with open(sys.argv[1], "r") as file:
     for line in file:
-        if line.startswith("INFO: check_init_priorities build_dir:"):
+        if line.startswith("INFO: check_init_priorities"):
             continue
         output.append(line.strip())
 


### PR DESCRIPTION
Hi, this is a rework of  device discovery code of `check_init_priorities`. Instead of finding all the individual object files and find the level+piority from the section name, parse back the `initlevel` section from the output elf file. This means that the script is not impacted by stale files in the build directory, but more importantly it makes it work with LTO builds, where somehow the intermediate object fiels sections are completely mangled up.

While doing this, add a feature to print a human readable format of the initialization sections. This is pretty much just a friendlier version of `arm-zephyr-eabi-objdump -j initlevel -j device_area -d build/zephyr/zephyr.elf`. I'm using it to troubleshoot SYS_INIT order breakages, though I'm thinking one may use it in CI to compare the known sequence order of a build and catch unintended changes.

Looks something like this:

```
$ west build -t initlevels -p -b nrf52840dk_nrf52840 samples/drivers/led_pwm
...
EARLY
PRE_KERNEL_1
  __init_nordicsemi_nrf52_init: nordicsemi_nrf52_init(NULL)
  __init___device_dts_ord_74: clk_init(__device_dts_ord_74)
  __init_rtt_init: rtt_init(NULL)
  __init___device_dts_ord_11: gpio_nrfx_init(__device_dts_ord_11)
  __init___device_dts_ord_104: gpio_nrfx_init(__device_dts_ord_104)
  __init___device_dts_ord_112: uarte_0_init(__device_dts_ord_112)
  __init_uart_console_init: uart_console_init(NULL)
PRE_KERNEL_2
  __init_sys_clock_driver_init: sys_clock_driver_init(NULL)
POST_KERNEL
  __init_enable_logger: enable_logger(NULL)
  __init_malloc_prepare: malloc_prepare(NULL)
  __init___device_dts_ord_69: pwm_nrfx_init(__device_dts_ord_69)
  __init___device_dts_ord_19: led_gpio_init(__device_dts_ord_19)
  __init___device_dts_ord_68: led_pwm_init(__device_dts_ord_68)
APPLICATION
SMP
```

Very much inspired by a comment from @bjarki-trackunit on the original proposal, should be fairly easy to adapt to https://github.com/zephyrproject-rtos/zephyr/pull/61986.

Also pushed on https://github.com/zephyrproject-rtos/zephyr-testing/tree/vfabio-testing-branch

Since this now needs to work on a linked library I had to tweak the CMakeFiles a bit, and also it turns out this does not quite work with the elf file when using `NATIVE_LIBRARY`, although it does on the final exe. I could hack around it but I'd rather turn it off in that case right now and look for a proper solution down the road.