### PR TITLE
arch:ax86: Remove unused ACPI include

### DIFF
--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <zephyr/acpi/acpi.h>
 #include <zephyr/arch/x86/multiboot.h>
 #include <zephyr/arch/x86/efi.h>
 #include <x86_mmu.h>


### PR DESCRIPTION
The prep_c.c source doesn't depend on the ACPI library.  As ACPI support now requires the ACPICA module, the extra header breaks projects using x86 without ACPI support.