### PR TITLE
net: wifi: Add toggle for extensions to scan specific channels

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -252,7 +252,9 @@ struct wifi_scan_params {
 	 *  not conforming to regulatory restrictions etc. The invoker of the API should
 	 *  ensure that the channels specified follow regulatory rules.
 	 */
+#ifdef CONFIG_WIFI_MGMT_SCAN_CHAN_SUPPORT
 	uint8_t chan[WIFI_FREQ_BAND_MAX + 1][WIFI_CHANNEL_MAX];
+#endif /* CONFIG_WIFI_MGMT_SCAN_CHAN_SUPPORT */
 };
 
 /** Wi-Fi scan result, each result is provided to the net_mgmt_event_callback

--- a/include/zephyr/net/wifi_utils.h
+++ b/include/zephyr/net/wifi_utils.h
@@ -72,6 +72,7 @@ int wifi_utils_parse_scan_ssids(char *scan_ssids_str,
 				char ssids[][WIFI_SSID_MAX_LEN + 1]);
 
 
+#ifdef CONFIG_WIFI_MGMT_SCAN_CHAN_SUPPORT
 /**
  * @brief Convert a string containing a specification of scan channels to an array.
  *
@@ -102,6 +103,7 @@ int wifi_utils_parse_scan_ssids(char *scan_ssids_str,
 int wifi_utils_parse_scan_chan(char *scan_chan_str,
 			       uint8_t chan[][WIFI_CHANNEL_MAX]);
 
+#endif /* CONFIG_WIFI_MGMT_SCAN_CHAN_SUPPORT */
 /**
  * @}
  */

--- a/subsys/net/l2/wifi/Kconfig
+++ b/subsys/net/l2/wifi/Kconfig
@@ -96,9 +96,15 @@ config WIFI_MGMT_SCAN_MAX_BSS_CNT
 	help
 	  Maximum number of scan results to return. 0 represents unlimited number of BSSes.
 
+config WIFI_MGMT_SCAN_CHAN_SUPPORT
+	bool "Scan on specific channels support"
+	help
+	  Enabling the scanning of individual channels. This option consumes a lot of memory.
+
 config WIFI_MGMT_SCAN_CHAN
 	string "Scan on specific channels"
 	default ""
+	depends on WIFI_MGMT_SCAN_CHAN_SUPPORT
 	help
 	 Formatted string which specifies channels to be scanned. The channel string has to be formatted
 	 using the colon (:), comma(,), hyphen (-) and space ( ) delimiters as follows:

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -104,8 +104,10 @@ static int wifi_scan(uint32_t mgmt_request, struct net_if *iface,
 	const struct device *dev = net_if_get_device(iface);
 	struct wifi_scan_params *params = data;
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_api(iface);
+#ifdef CONFIG_WIFI_MGMT_SCAN_CHAN_SUPPORT
 	bool chan_specified = false;
-	uint8_t i = 0;
+	uint8_t band = 0;
+#endif /* CONFIG_WIFI_MGMT_SCAN_CHAN_SUPPORT */
 
 	if (wifi_mgmt_api == NULL || wifi_mgmt_api->scan == NULL) {
 		return -ENOTSUP;
@@ -145,9 +147,9 @@ static int wifi_scan(uint32_t mgmt_request, struct net_if *iface,
 		if (!params->max_bss_cnt) {
 			params->max_bss_cnt = CONFIG_WIFI_MGMT_SCAN_MAX_BSS_CNT;
 		}
-
-		for (i = 0; i <= WIFI_FREQ_BAND_MAX; i++) {
-			if (params->chan[i][0]) {
+#ifdef CONFIG_WIFI_MGMT_SCAN_CHAN_SUPPORT
+		for (band = 0; band <= WIFI_FREQ_BAND_MAX; band++) {
+			if (params->chan[band][0]) {
 				chan_specified = true;
 				break;
 			}
@@ -161,6 +163,7 @@ static int wifi_scan(uint32_t mgmt_request, struct net_if *iface,
 				return -EINVAL;
 			}
 		}
+#endif /* CONFIG_WIFI_MGMT_SCAN_CHAN_SUPPORT */
 	}
 
 	return wifi_mgmt_api->scan(dev, params, scan_result_cb);

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -556,13 +556,17 @@ static int wifi_scan_args_to_params(const struct shell *sh,
 			opt_num++;
 			break;
 		case 'c':
+#ifdef CONFIG_WIFI_MGMT_SCAN_CHAN_SUPPORT
 			if (wifi_utils_parse_scan_chan(optarg, params->chan)) {
 				shell_fprintf(sh,
 					      SHELL_ERROR,
 					      "Invalid band or channel value(s)\n");
 				return -ENOEXEC;
 			}
-
+#else
+			shell_fprintf(sh, SHELL_ERROR, "This feature isn't enabled\n");
+			return -ENOEXEC;
+#endif /* CONFIG_WIFI_MGMT_SCAN_CHAN_SUPPORT */
 			opt_num++;
 			break;
 		case 'h':
@@ -1653,7 +1657,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 		    "[-p, --dwell_time_passive <val_in_ms>] : Passive scan dwell time (in ms) on a channel. Range 10 ms to 1000 ms.\n"
 		    "[-s, --ssids <Comma separate list of SSIDs>] : SSID list to scan for.\n"
 		    "[-m, --max_bss <val>] : Maximum BSSes to scan for. Range 1 - 65535.\n"
+#ifdef CONFIG_WIFI_MGMT_SCAN_CHAN_SUPPORT
 		    "[-c, --chans <Comma separated list of channel ranges>] : Channels to be scanned. The channels must be specified in the form band1:chan1,chan2_band2:chan3,..etc. band1, band2 must be valid band values and chan1, chan2, chan3 must be specified as a list of comma separated values where each value is either a single channel or a channel range specified as chan_start-chan_end. Each band channel set has to be separated by a _. For example, a valid channel specification can be 2:1,6-11,14_5:36,149-165,44\n"
+#endif /* CONFIG_WIFI_MGMT_SCAN_CHAN_SUPPORT */
 		    "[-h, --help] : Print out the help for the scan command.",
 		  cmd_wifi_scan),
 	SHELL_CMD(statistics, NULL, "Wi-Fi interface statistics", cmd_wifi_stats),


### PR DESCRIPTION
The feature uses lots of RAM and breaks samples/net/wifi on ESP32. Add option to turn off this feature.

Fixes: b572e8216aa258891cb06a17b25b5770637bb337