### PR TITLE
drivers/spi: stm32: fix TX-only mode

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -324,8 +324,10 @@ static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 		spi_context_update_tx(&data->ctx, 2, 1);
 	}
 
-	while (!ll_func_rx_is_not_empty(spi)) {
-		/* NOP */
+	if (spi_context_rx_buf_on(&data->ctx)) {
+		while (!ll_func_rx_is_not_empty(spi)) {
+			/* NOP */
+		}
 	}
 
 	if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 8) {


### PR DESCRIPTION
When doing a TX-only SPI operation, the RX not empty flag will never get set, thus this will just hang forever.

Found/tested on STM32L462 trying to drive some WS2812 RGB LEDs.