### PR TITLE
drivers: display: add ST7735S support to st7735r driver

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -140,6 +140,8 @@ Drivers and Sensors
 
 * Display
 
+  * Added support for ST7735S (in ST7735R driver)
+
 * DMA
 
 * EEPROM

--- a/drivers/display/Kconfig.st7735r
+++ b/drivers/display/Kconfig.st7735r
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config ST7735R
-	bool "ST7735R display driver"
+	bool "ST7735R/ST7735S display driver"
 	default y
 	depends on DT_HAS_SITRONIX_ST7735R_ENABLED
 	select SPI
 	help
-	  Enable driver for ST7735R display driver.
+	  Enable driver for ST7735R/ST7735S display driver.

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -172,10 +172,17 @@ static int st7735r_set_mem_area(const struct device *dev,
 				const uint16_t x, const uint16_t y,
 				const uint16_t w, const uint16_t h)
 {
+	const struct st7735r_config *config = dev->config;
 	struct st7735r_data *data = dev->data;
 	uint16_t spi_data[2];
 
 	int ret;
+
+	/* ST7735S requires repeating COLMOD for each transfer */
+	ret = st7735r_transmit_hold(dev, ST7735R_CMD_COLMOD, &config->colmod, 1);
+	if (ret < 0) {
+		return ret;
+	}
 
 	uint16_t ram_x = x + data->x_offset;
 	uint16_t ram_y = y + data->y_offset;

--- a/dts/bindings/display/sitronix,st7735r.yaml
+++ b/dts/bindings/display/sitronix,st7735r.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Kim Bøndergaard <kim@fam-boendergaard.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-description: ST7735R 160x128 display controller
+description: ST7735R/ST7735S 160x128 (max) display controller
 
 compatible: "sitronix,st7735r"
 


### PR DESCRIPTION
ST7735S has a few peculiarities that make the ST7735R driver "almost-but-not-quite" work. Specifically,

* the entire sequence of `RASET`, `CASET` and `RAMWR` needs to be a continuous transaction with CS held low. Otherwise the row/column address and current position are lost.
* the `COLMOD` command also needs to be issued as part of the transaction, otherwise it will fall back to some default value.

This makes the necessary adjustments to the `st7735r` driver so it also supports ST7735S.

Tested with KD0096FM display. NB: I do not have access to ST7735R displays, I believe they should work just fine with these changes but cannot confirm this. I also have no idea what exact chip the KD0096FM is using, the datasheet does claim "ST7735S", but who knows what clone they found on a yard sale…