### PR TITLE
debug: Set thread_info.c variables to const

### DIFF
--- a/subsys/debug/thread_info.c
+++ b/subsys/debug/thread_info.c
@@ -40,7 +40,7 @@ enum {
  * Only version 1 is backward compatible to version 0.
  */
 __attribute__((used, section(".dbg_thread_info")))
-size_t _kernel_thread_info_offsets[] = {
+const size_t _kernel_thread_info_offsets[] = {
 	/* Version 0 starts */
 	[THREAD_INFO_OFFSET_VERSION] = 1,
 	[THREAD_INFO_OFFSET_K_CURR_THREAD] = offsetof(struct _cpu, current),
@@ -146,15 +146,15 @@ size_t _kernel_thread_info_offsets[] = {
 #endif /* CONFIG_ARC */
 };
 
-extern size_t __attribute__((alias("_kernel_thread_info_offsets")))
+extern const size_t __attribute__((alias("_kernel_thread_info_offsets")))
 		_kernel_openocd_offsets;
 
 __attribute__((used, section(".dbg_thread_info")))
-size_t _kernel_thread_info_num_offsets = ARRAY_SIZE(_kernel_thread_info_offsets);
-extern size_t __attribute__((alias("_kernel_thread_info_num_offsets")))
+const size_t _kernel_thread_info_num_offsets = ARRAY_SIZE(_kernel_thread_info_offsets);
+extern const size_t __attribute__((alias("_kernel_thread_info_num_offsets")))
 		_kernel_openocd_num_offsets;
 
 __attribute__((used, section(".dbg_thread_info")))
-uint8_t _kernel_thread_info_size_t_size = (uint8_t)sizeof(size_t);
-extern uint8_t __attribute__((alias("_kernel_thread_info_size_t_size")))
+const uint8_t _kernel_thread_info_size_t_size = (uint8_t)sizeof(size_t);
+extern const uint8_t __attribute__((alias("_kernel_thread_info_size_t_size")))
 		_kernel_openocd_size_t_size;


### PR DESCRIPTION
The variables are usually placed into an output region located in FLASH memory when linking, but the variables are not marked `const`, so the section ends up with `W` writeable section flag:

```bash
❯ ~/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-readelf --section-headers build/zephyr/zephyr.elf | grep -E '(Section Headers:)|(  \[Nr\])|(zephyr_dbg_info)'
Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [10] zephyr_dbg_info   PROGBITS        60012298 01238c 000040 00  WA  0   0  4
```

Set them as const to set the output section to read-only:

```bash
❯ ~/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-readelf --section-headers build/zephyr/zephyr.elf | grep -E '(Section Headers:)|(  \[Nr\])|(zephyr_dbg_info)'
Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [10] zephyr_dbg_info   PROGBITS        60012298 01238c 000040 00   A  0   0  4
```