### PR TITLE
fix clang format issues for various drivers

### DIFF
--- a/drivers/gpio/gpio_intel.c
+++ b/drivers/gpio/gpio_intel.c
@@ -32,65 +32,62 @@
 
 BUILD_ASSERT(DT_INST_IRQN(0) == 14);
 
-#define REG_MISCCFG			0x0010
-#define MISCCFG_IRQ_ROUTE_POS		3
+#define REG_MISCCFG           0x0010
+#define MISCCFG_IRQ_ROUTE_POS 3
 
-#define PAD_OWN_MASK			0x03
-#define PAD_OWN_HOST			0
-#define PAD_OWN_CSME			1
-#define PAD_OWN_ISH			2
-#define PAD_OWN_IE			3
+#define PAD_OWN_MASK 0x03
+#define PAD_OWN_HOST 0
+#define PAD_OWN_CSME 1
+#define PAD_OWN_ISH  2
+#define PAD_OWN_IE   3
 
-#define PAD_HOST_SW_OWN_GPIO		1
-#define PAD_HOST_SW_OWN_ACPI		0
+#define PAD_HOST_SW_OWN_GPIO 1
+#define PAD_HOST_SW_OWN_ACPI 0
 
+#define PAD_CFG0_RXPADSTSEL BIT(29)
+#define PAD_CFG0_RXRAW1     BIT(28)
 
-#define PAD_CFG0_RXPADSTSEL		BIT(29)
-#define PAD_CFG0_RXRAW1			BIT(28)
+#define PAD_CFG0_RXEVCFG_POS    25
+#define PAD_CFG0_RXEVCFG_MASK   (0x03 << PAD_CFG0_RXEVCFG_POS)
+#define PAD_CFG0_RXEVCFG_LEVEL  (0 << PAD_CFG0_RXEVCFG_POS)
+#define PAD_CFG0_RXEVCFG_EDGE   (1 << PAD_CFG0_RXEVCFG_POS)
+#define PAD_CFG0_RXEVCFG_DRIVE0 (2 << PAD_CFG0_RXEVCFG_POS)
 
+#define PAD_CFG0_PREGFRXSEL BIT(24)
+#define PAD_CFG0_RXINV      BIT(23)
 
-#define PAD_CFG0_RXEVCFG_POS		25
-#define PAD_CFG0_RXEVCFG_MASK		(0x03 << PAD_CFG0_RXEVCFG_POS)
-#define PAD_CFG0_RXEVCFG_LEVEL		(0 << PAD_CFG0_RXEVCFG_POS)
-#define PAD_CFG0_RXEVCFG_EDGE		(1 << PAD_CFG0_RXEVCFG_POS)
-#define PAD_CFG0_RXEVCFG_DRIVE0		(2 << PAD_CFG0_RXEVCFG_POS)
+#define PAD_CFG0_RXDIS       BIT(9)
+#define PAD_CFG0_TXDIS       BIT(8)
+#define PAD_CFG0_RXSTATE     BIT(1)
+#define PAD_CFG0_RXSTATE_POS 1
+#define PAD_CFG0_TXSTATE     BIT(0)
+#define PAD_CFG0_TXSTATE_POS 0
 
-#define PAD_CFG0_PREGFRXSEL		BIT(24)
-#define PAD_CFG0_RXINV			BIT(23)
+#define PAD_CFG1_IOSTERM_POS    8
+#define PAD_CFG1_IOSTERM_MASK   (0x03 << PAD_CFG1_IOSTERM_POS)
+#define PAD_CFG1_IOSTERM_FUNC   (0 << PAD_CFG1_IOSTERM_POS)
+#define PAD_CFG1_IOSTERM_DISPUD (1 << PAD_CFG1_IOSTERM_POS)
+#define PAD_CFG1_IOSTERM_PU     (2 << PAD_CFG1_IOSTERM_POS)
+#define PAD_CFG1_IOSTERM_PD     (3 << PAD_CFG1_IOSTERM_POS)
 
-#define PAD_CFG0_RXDIS			BIT(9)
-#define PAD_CFG0_TXDIS			BIT(8)
-#define PAD_CFG0_RXSTATE		BIT(1)
-#define PAD_CFG0_RXSTATE_POS		1
-#define PAD_CFG0_TXSTATE		BIT(0)
-#define PAD_CFG0_TXSTATE_POS		0
+#define PAD_CFG1_TERM_POS      10
+#define PAD_CFG1_TERM_MASK     (0x0F << PAD_CFG1_TERM_POS)
+#define PAD_CFG1_TERM_NONE     (0x00 << PAD_CFG1_TERM_POS)
+#define PAD_CFG1_TERM_PD_5K    (0x02 << PAD_CFG1_TERM_POS)
+#define PAD_CFG1_TERM_PD_20K   (0x04 << PAD_CFG1_TERM_POS)
+#define PAD_CFG1_TERM_NONE2    (0x08 << PAD_CFG1_TERM_POS)
+#define PAD_CFG1_TERM_PU_1K    (0x09 << PAD_CFG1_TERM_POS)
+#define PAD_CFG1_TERM_PU_5K    (0x0A << PAD_CFG1_TERM_POS)
+#define PAD_CFG1_TERM_PU_2K    (0x0B << PAD_CFG1_TERM_POS)
+#define PAD_CFG1_TERM_PU_20K   (0x0C << PAD_CFG1_TERM_POS)
+#define PAD_CFG1_TERM_PU_1K_2K (0x0D << PAD_CFG1_TERM_POS)
 
-#define PAD_CFG1_IOSTERM_POS		8
-#define PAD_CFG1_IOSTERM_MASK		(0x03 << PAD_CFG1_IOSTERM_POS)
-#define PAD_CFG1_IOSTERM_FUNC		(0 << PAD_CFG1_IOSTERM_POS)
-#define PAD_CFG1_IOSTERM_DISPUD		(1 << PAD_CFG1_IOSTERM_POS)
-#define PAD_CFG1_IOSTERM_PU		(2 << PAD_CFG1_IOSTERM_POS)
-#define PAD_CFG1_IOSTERM_PD		(3 << PAD_CFG1_IOSTERM_POS)
-
-#define PAD_CFG1_TERM_POS		10
-#define PAD_CFG1_TERM_MASK		(0x0F << PAD_CFG1_TERM_POS)
-#define PAD_CFG1_TERM_NONE		(0x00 << PAD_CFG1_TERM_POS)
-#define PAD_CFG1_TERM_PD_5K		(0x02 << PAD_CFG1_TERM_POS)
-#define PAD_CFG1_TERM_PD_20K		(0x04 << PAD_CFG1_TERM_POS)
-#define PAD_CFG1_TERM_NONE2		(0x08 << PAD_CFG1_TERM_POS)
-#define PAD_CFG1_TERM_PU_1K		(0x09 << PAD_CFG1_TERM_POS)
-#define PAD_CFG1_TERM_PU_5K		(0x0A << PAD_CFG1_TERM_POS)
-#define PAD_CFG1_TERM_PU_2K		(0x0B << PAD_CFG1_TERM_POS)
-#define PAD_CFG1_TERM_PU_20K		(0x0C << PAD_CFG1_TERM_POS)
-#define PAD_CFG1_TERM_PU_1K_2K		(0x0D << PAD_CFG1_TERM_POS)
-
-#define PAD_CFG1_IOSSTATE_POS		14
-#define PAD_CFG1_IOSSTATE_MASK		(0x0F << PAD_CFG1_IOSSTATE_POS)
-#define PAD_CFG1_IOSSTATE_IGNORE	(0x0F << PAD_CFG1_IOSSTATE_POS)
+#define PAD_CFG1_IOSSTATE_POS    14
+#define PAD_CFG1_IOSSTATE_MASK   (0x0F << PAD_CFG1_IOSSTATE_POS)
+#define PAD_CFG1_IOSSTATE_IGNORE (0x0F << PAD_CFG1_IOSSTATE_POS)
 
 /* Required by DEVICE_MMIO_NAMED_* macros */
-#define DEV_CFG(_dev) \
-	((const struct gpio_intel_config *)(_dev)->config)
+#define DEV_CFG(_dev)  ((const struct gpio_intel_config *)(_dev)->config)
 #define DEV_DATA(_dev) ((struct gpio_intel_data *)(_dev)->data)
 
 struct gpio_intel_config {
@@ -99,9 +96,9 @@ struct gpio_intel_config {
 
 	DEVICE_MMIO_NAMED_ROM(reg_base);
 
-	uint8_t	pin_offset;
+	uint8_t pin_offset;
 	uint8_t group_index;
-	uint8_t	num_pins;
+	uint8_t num_pins;
 };
 
 struct gpio_intel_data {
@@ -192,8 +189,7 @@ static void gpio_intel_isr(const struct device *dev)
 		cfg = dev->config;
 		data = dev->data;
 
-		reg = regs(dev) + REG_GPI_INT_STS_BASE
-		      + GPIO_INTERRUPT_BASE(cfg);
+		reg = regs(dev) + REG_GPI_INT_STS_BASE + GPIO_INTERRUPT_BASE(cfg);
 		int_sts = sys_read32(reg);
 		acc_mask = 0U;
 
@@ -211,8 +207,7 @@ static void gpio_intel_isr(const struct device *dev)
 	}
 }
 
-static int gpio_intel_config(const struct device *dev,
-			     gpio_pin_t pin, gpio_flags_t flags)
+static int gpio_intel_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct gpio_intel_config *cfg = dev->config;
 	struct gpio_intel_data *data = dev->data;
@@ -285,10 +280,8 @@ static int gpio_intel_config(const struct device *dev,
 	return 0;
 }
 
-static int gpio_intel_pin_interrupt_configure(const struct device *dev,
-					      gpio_pin_t pin,
-					      enum gpio_int_mode mode,
-					      enum gpio_int_trig trig)
+static int gpio_intel_pin_interrupt_configure(const struct device *dev, gpio_pin_t pin,
+					      enum gpio_int_mode mode, enum gpio_int_trig trig)
 {
 	const struct gpio_intel_config *cfg = dev->config;
 	struct gpio_intel_data *data = dev->data;
@@ -377,8 +370,7 @@ static int gpio_intel_pin_interrupt_configure(const struct device *dev,
 	return 0;
 }
 
-static int gpio_intel_manage_callback(const struct device *dev,
-				      struct gpio_callback *callback,
+static int gpio_intel_manage_callback(const struct device *dev, struct gpio_callback *callback,
 				      bool set)
 {
 	struct gpio_intel_data *data = dev->data;
@@ -386,9 +378,7 @@ static int gpio_intel_manage_callback(const struct device *dev,
 	return gpio_manage_callback(&data->cb, callback, set);
 }
 
-static int port_get_raw(const struct device *dev, uint32_t mask,
-			uint32_t *value,
-			bool read_tx)
+static int port_get_raw(const struct device *dev, uint32_t mask, uint32_t *value, bool read_tx)
 {
 	const struct gpio_intel_config *cfg = dev->config;
 	struct gpio_intel_data *data = dev->data;
@@ -427,8 +417,7 @@ static int port_get_raw(const struct device *dev, uint32_t mask,
 	return 0;
 }
 
-static int port_set_raw(const struct device *dev, uint32_t mask,
-			uint32_t value)
+static int port_set_raw(const struct device *dev, uint32_t mask, uint32_t value)
 {
 	const struct gpio_intel_config *cfg = dev->config;
 	struct gpio_intel_data *data = dev->data;
@@ -464,9 +453,7 @@ static int port_set_raw(const struct device *dev, uint32_t mask,
 	return 0;
 }
 
-static int gpio_intel_port_set_masked_raw(const struct device *dev,
-					  uint32_t mask,
-					  uint32_t value)
+static int gpio_intel_port_set_masked_raw(const struct device *dev, uint32_t mask, uint32_t value)
 {
 	uint32_t port_val;
 
@@ -479,20 +466,17 @@ static int gpio_intel_port_set_masked_raw(const struct device *dev,
 	return 0;
 }
 
-static int gpio_intel_port_set_bits_raw(const struct device *dev,
-					uint32_t mask)
+static int gpio_intel_port_set_bits_raw(const struct device *dev, uint32_t mask)
 {
 	return gpio_intel_port_set_masked_raw(dev, mask, mask);
 }
 
-static int gpio_intel_port_clear_bits_raw(const struct device *dev,
-					  uint32_t mask)
+static int gpio_intel_port_clear_bits_raw(const struct device *dev, uint32_t mask)
 {
 	return gpio_intel_port_set_masked_raw(dev, mask, 0);
 }
 
-static int gpio_intel_port_toggle_bits(const struct device *dev,
-				       uint32_t mask)
+static int gpio_intel_port_toggle_bits(const struct device *dev, uint32_t mask)
 {
 	uint32_t port_val;
 
@@ -505,8 +489,7 @@ static int gpio_intel_port_toggle_bits(const struct device *dev,
 	return 0;
 }
 
-static int gpio_intel_port_get_raw(const struct device *dev,
-				   uint32_t *value)
+static int gpio_intel_port_get_raw(const struct device *dev, uint32_t *value)
 {
 	return port_get_raw(dev, 0xFFFFFFFF, value, false);
 }
@@ -542,9 +525,7 @@ int gpio_intel_init(const struct device *dev)
 
 	const struct gpio_intel_config *cfg = dev->config;
 
-	device_map(&data->reg_base,
-		   cfg->reg_base.phys_addr & ~0xFFU,
-		   cfg->reg_base.size,
+	device_map(&data->reg_base, cfg->reg_base.phys_addr & ~0xFFU, cfg->reg_base.size,
 		   K_MEM_CACHE_NONE);
 #else
 	DEVICE_MMIO_NAMED_MAP(dev, reg_base, K_MEM_CACHE_NONE);
@@ -557,9 +538,7 @@ int gpio_intel_init(const struct device *dev)
 		/* Note that all controllers are using the same IRQ line.
 		 * So we can just use the values from the first instance.
 		 */
-		IRQ_CONNECT(DT_INST_IRQN(0),
-			    DT_INST_IRQ(0, priority),
-			    gpio_intel_isr, NULL,
+		IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), gpio_intel_isr, NULL,
 			    DT_INST_IRQ(0, sense));
 
 		irq_enable(DT_INST_IRQN(0));
@@ -569,33 +548,27 @@ int gpio_intel_init(const struct device *dev)
 
 	if (IS_ENABLED(CONFIG_SOC_APOLLO_LAKE)) {
 		/* route to IRQ 14 */
-		sys_bitfield_clear_bit(regs(dev) + REG_MISCCFG,
-				       MISCCFG_IRQ_ROUTE_POS);
+		sys_bitfield_clear_bit(regs(dev) + REG_MISCCFG, MISCCFG_IRQ_ROUTE_POS);
 	}
 	return 0;
 }
 
-#define GPIO_INTEL_DEV_CFG_DATA(n)					       \
-	static const struct gpio_intel_config				       \
-		gpio_intel_cfg_##n = {					       \
-		.common = {						       \
-			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),   \
-		},							       \
-		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)),	       \
-		.pin_offset = DT_INST_PROP(n, pin_offset),		       \
-		.group_index = DT_INST_PROP_OR(n, group_index, 0),	       \
-		.num_pins = DT_INST_PROP(n, ngpios),			       \
-	};								       \
-									       \
-	static struct gpio_intel_data gpio_intel_data_##n;		       \
-									       \
-	DEVICE_DT_INST_DEFINE(n,					       \
-			      gpio_intel_init,				       \
-			      NULL,					       \
-			      &gpio_intel_data_##n,			       \
-			      &gpio_intel_cfg_##n,			       \
-			      POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,	       \
-			      &gpio_intel_api);
+#define GPIO_INTEL_DEV_CFG_DATA(n)                                                                 \
+	static const struct gpio_intel_config gpio_intel_cfg_##n = {                               \
+		.common =                                                                          \
+			{                                                                          \
+				.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),               \
+			},                                                                         \
+		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)),                              \
+		.pin_offset = DT_INST_PROP(n, pin_offset),                                         \
+		.group_index = DT_INST_PROP_OR(n, group_index, 0),                                 \
+		.num_pins = DT_INST_PROP(n, ngpios),                                               \
+	};                                                                                         \
+                                                                                                   \
+	static struct gpio_intel_data gpio_intel_data_##n;                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, gpio_intel_init, NULL, &gpio_intel_data_##n, &gpio_intel_cfg_##n, \
+			      POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY, &gpio_intel_api);
 
 /* "sub" devices.  no more than GPIO_INTEL_NR_SUBDEVS of these! */
 DT_INST_FOREACH_STATUS_OKAY(GPIO_INTEL_DEV_CFG_DATA)

--- a/drivers/interrupt_controller/intc_ioapic_priv.h
+++ b/drivers/interrupt_controller/intc_ioapic_priv.h
@@ -12,30 +12,30 @@
 
 /* IO APIC direct register offsets */
 
-#define IOAPIC_IND 0x00   /* Index Register */
-#define IOAPIC_DATA 0x10  /* IO window (data) - pc.h */
+#define IOAPIC_IND   0x00 /* Index Register */
+#define IOAPIC_DATA  0x10 /* IO window (data) - pc.h */
 #define IOAPIC_IRQPA 0x20 /* IRQ Pin Assertion Register */
-#define IOAPIC_EOI 0x40   /* EOI Register */
+#define IOAPIC_EOI   0x40 /* EOI Register */
 
 /* IO APIC indirect register offset */
 
-#define IOAPIC_ID 0x00     /* IOAPIC ID */
-#define IOAPIC_VERS 0x01   /* IOAPIC Version */
-#define IOAPIC_ARB 0x02    /* IOAPIC Arbitration ID */
-#define IOAPIC_BOOT 0x03   /* IOAPIC Boot Configuration */
+#define IOAPIC_ID     0x00 /* IOAPIC ID */
+#define IOAPIC_VERS   0x01 /* IOAPIC Version */
+#define IOAPIC_ARB    0x02 /* IOAPIC Arbitration ID */
+#define IOAPIC_BOOT   0x03 /* IOAPIC Boot Configuration */
 #define IOAPIC_REDTBL 0x10 /* Redirection Table (24 * 64bit) */
 
 /* Interrupt delivery type */
 
 #define IOAPIC_DT_APIC 0x0 /* APIC serial bus */
-#define IOAPIC_DT_FS 0x1   /* Front side bus message*/
+#define IOAPIC_DT_FS   0x1 /* Front side bus message*/
 
 /* Version register bits */
 
 #define IOAPIC_MRE_MASK 0x00ff0000 /* Max Red. entry mask */
-#define IOAPIC_MRE_POS 16
-#define IOAPIC_PRQ 0x00008000      /* this has IRQ reg */
-#define IOAPIC_VERSION 0x000000ff  /* version number */
+#define IOAPIC_MRE_POS  16
+#define IOAPIC_PRQ      0x00008000 /* this has IRQ reg */
+#define IOAPIC_VERSION  0x000000ff /* version number */
 
 /* Redirection table entry bits: upper 32 bit */
 

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 #define DT_DRV_COMPAT intel_loapic
 
 /*
@@ -29,31 +28,31 @@
 /* Local APIC Version Register Bits */
 
 #define LOAPIC_VERSION_MASK 0x000000ff /* LO APIC Version mask */
-#define LOAPIC_MAXLVT_MASK 0x00ff0000  /* LO APIC Max LVT mask */
-#define LOAPIC_PENTIUM4 0x00000014     /* LO APIC in Pentium4 */
-#define LOAPIC_LVT_PENTIUM4 5	  /* LO APIC LVT - Pentium4 */
-#define LOAPIC_LVT_P6 4		       /* LO APIC LVT - P6 */
-#define LOAPIC_LVT_P5 3		       /* LO APIC LVT - P5 */
+#define LOAPIC_MAXLVT_MASK  0x00ff0000 /* LO APIC Max LVT mask */
+#define LOAPIC_PENTIUM4     0x00000014 /* LO APIC in Pentium4 */
+#define LOAPIC_LVT_PENTIUM4 5          /* LO APIC LVT - Pentium4 */
+#define LOAPIC_LVT_P6       4          /* LO APIC LVT - P6 */
+#define LOAPIC_LVT_P5       3          /* LO APIC LVT - P5 */
 
 /* Local APIC Vector Table Bits */
 
 #define LOAPIC_VECTOR 0x000000ff /* vectorNo */
-#define LOAPIC_MODE 0x00000700   /* delivery mode */
-#define LOAPIC_FIXED 0x00000000  /* delivery mode: FIXED */
-#define LOAPIC_SMI 0x00000200    /* delivery mode: SMI */
-#define LOAPIC_NMI 0x00000400    /* delivery mode: NMI */
-#define LOAPIC_EXT 0x00000700    /* delivery mode: ExtINT */
-#define LOAPIC_IDLE 0x00000000   /* delivery status: Idle */
-#define LOAPIC_PEND 0x00001000   /* delivery status: Pend */
-#define LOAPIC_HIGH 0x00000000   /* polarity: High */
-#define LOAPIC_LOW 0x00002000    /* polarity: Low */
+#define LOAPIC_MODE   0x00000700 /* delivery mode */
+#define LOAPIC_FIXED  0x00000000 /* delivery mode: FIXED */
+#define LOAPIC_SMI    0x00000200 /* delivery mode: SMI */
+#define LOAPIC_NMI    0x00000400 /* delivery mode: NMI */
+#define LOAPIC_EXT    0x00000700 /* delivery mode: ExtINT */
+#define LOAPIC_IDLE   0x00000000 /* delivery status: Idle */
+#define LOAPIC_PEND   0x00001000 /* delivery status: Pend */
+#define LOAPIC_HIGH   0x00000000 /* polarity: High */
+#define LOAPIC_LOW    0x00002000 /* polarity: Low */
 #define LOAPIC_REMOTE 0x00004000 /* remote IRR */
-#define LOAPIC_EDGE 0x00000000   /* trigger mode: Edge */
-#define LOAPIC_LEVEL 0x00008000  /* trigger mode: Level */
+#define LOAPIC_EDGE   0x00000000 /* trigger mode: Edge */
+#define LOAPIC_LEVEL  0x00008000 /* trigger mode: Level */
 
 /* Local APIC Spurious-Interrupt Register Bits */
 
-#define LOAPIC_ENABLE 0x100	/* APIC Enabled */
+#define LOAPIC_ENABLE        0x100 /* APIC Enabled */
 #define LOAPIC_FOCUS_DISABLE 0x200 /* Focus Processor Checking */
 
 #if CONFIG_LOAPIC_SPURIOUS_VECTOR_ID == -1
@@ -62,18 +61,16 @@
 #define LOAPIC_SPURIOUS_VECTOR_ID CONFIG_LOAPIC_SPURIOUS_VECTOR_ID
 #endif
 
-#define LOAPIC_SSPND_BITS_PER_IRQ  1  /* Just the one for enable disable*/
-#define LOAPIC_SUSPEND_BITS_REQD (ROUND_UP((LOAPIC_IRQ_COUNT * LOAPIC_SSPND_BITS_PER_IRQ), 32))
+#define LOAPIC_SSPND_BITS_PER_IRQ 1 /* Just the one for enable disable*/
+#define LOAPIC_SUSPEND_BITS_REQD  (ROUND_UP((LOAPIC_IRQ_COUNT * LOAPIC_SSPND_BITS_PER_IRQ), 32))
 #ifdef CONFIG_PM_DEVICE
 #include <zephyr/pm/device.h>
-__pinned_bss
-uint32_t loapic_suspend_buf[LOAPIC_SUSPEND_BITS_REQD / 32] = {0};
+__pinned_bss uint32_t loapic_suspend_buf[LOAPIC_SUSPEND_BITS_REQD / 32] = {0};
 #endif
 
 DEVICE_MMIO_TOPLEVEL(LOAPIC_REGS_STR, DT_DRV_INST(0));
 
-__pinned_func
-void send_eoi(void)
+__pinned_func void send_eoi(void)
 {
 	x86_write_xapic(LOAPIC_EOI, 0);
 }
@@ -83,10 +80,10 @@ void send_eoi(void)
  *
  * Called from early assembly layer (e.g., crt0.S).
  */
-__pinned_func
-void z_loapic_enable(unsigned char cpu_number)
+__pinned_func void z_loapic_enable(unsigned char cpu_number)
 {
 	int32_t loApicMaxLvt; /* local APIC Max LVT */
+
 	DEVICE_MMIO_TOPLEVEL_MAP(LOAPIC_REGS_STR, K_MEM_CACHE_NONE);
 
 #ifndef CONFIG_X2APIC
@@ -111,8 +108,7 @@ void z_loapic_enable(unsigned char cpu_number)
 	 * x2APIC access is not enabled until the next step (if at all).
 	 */
 
-	x86_write_xapic(LOAPIC_SVR,
-			x86_read_xapic(LOAPIC_SVR) | LOAPIC_ENABLE);
+	x86_write_xapic(LOAPIC_SVR, x86_read_xapic(LOAPIC_SVR) | LOAPIC_ENABLE);
 
 #ifdef CONFIG_X2APIC
 	/*
@@ -121,6 +117,7 @@ void z_loapic_enable(unsigned char cpu_number)
 	 */
 
 	uint64_t msr = z_x86_msr_read(X86_APIC_BASE_MSR);
+
 	msr |= X86_APIC_BASE_MSR_X2APIC;
 	z_x86_msr_write(X86_APIC_BASE_MSR, msr);
 #endif
@@ -131,7 +128,7 @@ void z_loapic_enable(unsigned char cpu_number)
 
 #ifndef CONFIG_X2APIC
 	/* Flat model */
-	x86_write_loapic(LOAPIC_DFR, 0xffffffff);  /* no DFR in x2APIC mode */
+	x86_write_loapic(LOAPIC_DFR, 0xffffffff); /* no DFR in x2APIC mode */
 #endif
 
 	x86_write_loapic(LOAPIC_TPR, 0x0);
@@ -142,17 +139,17 @@ void z_loapic_enable(unsigned char cpu_number)
 
 	/* set LINT0: extInt, high-polarity, edge-trigger, not-masked */
 
-	x86_write_loapic(LOAPIC_LINT0, (x86_read_loapic(LOAPIC_LINT0) &
-		~(LOAPIC_MODE | LOAPIC_LOW |
-		  LOAPIC_LEVEL | LOAPIC_LVT_MASKED)) |
-		(LOAPIC_EXT | LOAPIC_HIGH | LOAPIC_EDGE));
+	x86_write_loapic(LOAPIC_LINT0,
+			 (x86_read_loapic(LOAPIC_LINT0) &
+			  ~(LOAPIC_MODE | LOAPIC_LOW | LOAPIC_LEVEL | LOAPIC_LVT_MASKED)) |
+				 (LOAPIC_EXT | LOAPIC_HIGH | LOAPIC_EDGE));
 
 	/* set LINT1: NMI, high-polarity, edge-trigger, not-masked */
 
-	x86_write_loapic(LOAPIC_LINT1, (x86_read_loapic(LOAPIC_LINT1) &
-		~(LOAPIC_MODE | LOAPIC_LOW |
-		  LOAPIC_LEVEL | LOAPIC_LVT_MASKED)) |
-		(LOAPIC_NMI | LOAPIC_HIGH | LOAPIC_EDGE));
+	x86_write_loapic(LOAPIC_LINT1,
+			 (x86_read_loapic(LOAPIC_LINT1) &
+			  ~(LOAPIC_MODE | LOAPIC_LOW | LOAPIC_LEVEL | LOAPIC_LVT_MASKED)) |
+				 (LOAPIC_NMI | LOAPIC_HIGH | LOAPIC_EDGE));
 
 	/* lock the Local APIC interrupts */
 
@@ -169,7 +166,7 @@ void z_loapic_enable(unsigned char cpu_number)
 
 #if CONFIG_LOAPIC_SPURIOUS_VECTOR
 	x86_write_loapic(LOAPIC_SVR, (x86_read_loapic(LOAPIC_SVR) & 0xFFFFFF00) |
-		     (LOAPIC_SPURIOUS_VECTOR_ID & 0xFF));
+					     (LOAPIC_SPURIOUS_VECTOR_ID & 0xFF));
 #endif
 
 	/* discard a pending interrupt if any */
@@ -182,16 +179,13 @@ void z_loapic_enable(unsigned char cpu_number)
  * The local APIC is initialized via z_loapic_enable() long before the
  * kernel runs through its device initializations, so this is unneeded.
  */
-__boot_func
-static int loapic_init(const struct device *unused)
+__boot_func static int loapic_init(const struct device *unused)
 {
 	ARG_UNUSED(unused);
 	return 0;
 }
 
-
-__pinned_func
-uint32_t z_loapic_irq_base(void)
+__pinned_func uint32_t z_loapic_irq_base(void)
 {
 	return z_ioapic_num_rtes();
 }
@@ -201,12 +195,11 @@ uint32_t z_loapic_irq_base(void)
  *
  * This associates an IRQ with the desired vector in the IDT.
  */
-__boot_func
-void z_loapic_int_vec_set(unsigned int irq, /* IRQ number of the interrupt */
-				  unsigned int vector /* vector to copy into the LVT */
-				  )
+__boot_func void z_loapic_int_vec_set(unsigned int irq,   /* IRQ number of the interrupt */
+				      unsigned int vector /* vector to copy into the LVT */
+)
 {
-	unsigned int oldLevel;   /* previous interrupt lock level */
+	unsigned int oldLevel; /* previous interrupt lock level */
 
 	/*
 	 * The following mappings are used:
@@ -225,8 +218,7 @@ void z_loapic_int_vec_set(unsigned int irq, /* IRQ number of the interrupt */
 
 	oldLevel = irq_lock();
 	x86_write_loapic(LOAPIC_TIMER + (irq * 0x10),
-		     (x86_read_loapic(LOAPIC_TIMER + (irq * 0x10)) &
-		      ~LOAPIC_VECTOR) | vector);
+			 (x86_read_loapic(LOAPIC_TIMER + (irq * 0x10)) & ~LOAPIC_VECTOR) | vector);
 	irq_unlock(oldLevel);
 }
 
@@ -237,10 +229,9 @@ void z_loapic_int_vec_set(unsigned int irq, /* IRQ number of the interrupt */
  *
  * This routine clears the interrupt mask bit in the LVT for the specified IRQ
  */
-__pinned_func
-void z_loapic_irq_enable(unsigned int irq)
+__pinned_func void z_loapic_irq_enable(unsigned int irq)
 {
-	unsigned int oldLevel;   /* previous interrupt lock level */
+	unsigned int oldLevel; /* previous interrupt lock level */
 
 	/*
 	 * See the comments in _LoApicLvtVecSet() regarding IRQ to LVT mappings
@@ -251,8 +242,7 @@ void z_loapic_irq_enable(unsigned int irq)
 
 	oldLevel = irq_lock();
 	x86_write_loapic(LOAPIC_TIMER + (irq * 0x10),
-		     x86_read_loapic(LOAPIC_TIMER + (irq * 0x10)) &
-		     ~LOAPIC_LVT_MASKED);
+			 x86_read_loapic(LOAPIC_TIMER + (irq * 0x10)) & ~LOAPIC_LVT_MASKED);
 	irq_unlock(oldLevel);
 }
 
@@ -263,10 +253,9 @@ void z_loapic_irq_enable(unsigned int irq)
  *
  * This routine clears the interrupt mask bit in the LVT for the specified IRQ
  */
-__pinned_func
-void z_loapic_irq_disable(unsigned int irq)
+__pinned_func void z_loapic_irq_disable(unsigned int irq)
 {
-	unsigned int oldLevel;   /* previous interrupt lock level */
+	unsigned int oldLevel; /* previous interrupt lock level */
 
 	/*
 	 * See the comments in _LoApicLvtVecSet() regarding IRQ to LVT mappings
@@ -277,11 +266,9 @@ void z_loapic_irq_disable(unsigned int irq)
 
 	oldLevel = irq_lock();
 	x86_write_loapic(LOAPIC_TIMER + (irq * 0x10),
-		     x86_read_loapic(LOAPIC_TIMER + (irq * 0x10)) |
-		     LOAPIC_LVT_MASKED);
+			 x86_read_loapic(LOAPIC_TIMER + (irq * 0x10)) | LOAPIC_LVT_MASKED);
 	irq_unlock(oldLevel);
 }
-
 
 /**
  * @brief Find the currently executing interrupt vector, if any
@@ -310,8 +297,7 @@ void z_loapic_irq_disable(unsigned int irq)
  * @return The vector of the interrupt that is currently being processed, or -1
  * if no IRQ is being serviced.
  */
-__pinned_func
-int z_irq_controller_isr_vector_get(void)
+__pinned_func int z_irq_controller_isr_vector_get(void)
 {
 	int pReg, block;
 
@@ -323,14 +309,12 @@ int z_irq_controller_isr_vector_get(void)
 		if (pReg != 0) {
 			return (block * 32) + (find_msb_set(pReg) - 1);
 		}
-
 	}
 	return -1;
 }
 
 #ifdef CONFIG_PM_DEVICE
-__pinned_func
-static int loapic_suspend(const struct device *port)
+__pinned_func static int loapic_suspend(const struct device *port)
 {
 	volatile uint32_t lvt; /* local vector table entry value */
 	int loapic_irq;
@@ -349,8 +333,7 @@ static int loapic_suspend(const struct device *port)
 			lvt = x86_read_loapic(LOAPIC_TIMER + (loapic_irq * 0x10));
 
 			if ((lvt & LOAPIC_LVT_MASKED) == 0U) {
-				sys_bitfield_set_bit((mem_addr_t)loapic_suspend_buf,
-					loapic_irq);
+				sys_bitfield_set_bit((mem_addr_t)loapic_suspend_buf, loapic_irq);
 			}
 		}
 	}
@@ -358,8 +341,7 @@ static int loapic_suspend(const struct device *port)
 	return 0;
 }
 
-__pinned_func
-int loapic_resume(const struct device *port)
+__pinned_func int loapic_resume(const struct device *port)
 {
 	int loapic_irq;
 
@@ -374,12 +356,11 @@ int loapic_resume(const struct device *port)
 
 		if (_irq_to_interrupt_vector[z_loapic_irq_base() + loapic_irq]) {
 			/* Configure vector and enable the required ones*/
-			z_loapic_int_vec_set(loapic_irq,
-				_irq_to_interrupt_vector[z_loapic_irq_base() +
-							 loapic_irq]);
+			z_loapic_int_vec_set(
+				loapic_irq,
+				_irq_to_interrupt_vector[z_loapic_irq_base() + loapic_irq]);
 
-			if (sys_bitfield_test_bit((mem_addr_t) loapic_suspend_buf,
-							loapic_irq)) {
+			if (sys_bitfield_test_bit((mem_addr_t)loapic_suspend_buf, loapic_irq)) {
 				z_loapic_irq_enable(loapic_irq);
 			}
 		}
@@ -389,12 +370,10 @@ int loapic_resume(const struct device *port)
 }
 
 /*
-* Implements the driver control management functionality
-* the *context may include IN data or/and OUT data
-*/
-__pinned_func
-static int loapic_pm_action(const struct device *dev,
-			    enum pm_device_action action)
+ * Implements the driver control management functionality
+ * the *context may include IN data or/and OUT data
+ */
+__pinned_func static int loapic_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	int ret = 0;
 
@@ -415,13 +394,12 @@ static int loapic_pm_action(const struct device *dev,
 
 PM_DEVICE_DEFINE(loapic, loapic_pm_action);
 
-DEVICE_DEFINE(loapic, "loapic", loapic_init, PM_DEVICE_GET(loapic), NULL, NULL,
-	      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);
+DEVICE_DEFINE(loapic, "loapic", loapic_init, PM_DEVICE_GET(loapic), NULL, NULL, PRE_KERNEL_1,
+	      CONFIG_INTC_INIT_PRIORITY, NULL);
 
 #if CONFIG_LOAPIC_SPURIOUS_VECTOR
 extern void z_loapic_spurious_handler(void);
 
-NANO_CPU_INT_REGISTER(z_loapic_spurious_handler, NANO_SOFT_IRQ,
-		      LOAPIC_SPURIOUS_VECTOR_ID >> 4,
+NANO_CPU_INT_REGISTER(z_loapic_spurious_handler, NANO_SOFT_IRQ, LOAPIC_SPURIOUS_VECTOR_ID >> 4,
 		      LOAPIC_SPURIOUS_VECTOR_ID, 0);
 #endif

--- a/drivers/pwm/pwm_intel_blinky.c
+++ b/drivers/pwm/pwm_intel_blinky.c
@@ -15,12 +15,12 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/pwm.h>
 
-#define PWM_ENABLE              0x80000000
-#define PWM_SWUP                0x40000000
-#define PWM_FREQ_INT_SHIFT      8
-#define PWM_BASE_UNIT_FRACTION	14
-#define PWM_FREQ_MAX            0x100
-#define PWM_DUTY_MAX            0x100
+#define PWM_ENABLE             0x80000000
+#define PWM_SWUP               0x40000000
+#define PWM_FREQ_INT_SHIFT     8
+#define PWM_BASE_UNIT_FRACTION 14
+#define PWM_FREQ_MAX           0x100
+#define PWM_DUTY_MAX           0x100
 
 struct bk_intel_config {
 	DEVICE_MMIO_NAMED_ROM(reg_base);
@@ -33,9 +33,8 @@ struct bk_intel_runtime {
 	DEVICE_MMIO_NAMED_RAM(reg_base);
 };
 
-static int bk_intel_set_cycles(const struct device *dev, uint32_t pin,
-			       uint32_t period_cycles, uint32_t pulse_cycles,
-			       pwm_flags_t flags)
+static int bk_intel_set_cycles(const struct device *dev, uint32_t pin, uint32_t period_cycles,
+			       uint32_t pulse_cycles, pwm_flags_t flags)
 {
 	struct bk_intel_runtime *rt = dev->data;
 	const struct bk_intel_config *cfg = dev->config;
@@ -51,9 +50,9 @@ static int bk_intel_set_cycles(const struct device *dev, uint32_t pin,
 		goto err;
 	}
 
-	out_freq = cfg->clock_freq / (float) period_cycles;
+	out_freq = cfg->clock_freq / (float)period_cycles;
 	period = (out_freq * PWM_FREQ_MAX) / cfg->clock_freq;
-	base_unit = (uint32_t) (period * (1 << PWM_BASE_UNIT_FRACTION));
+	base_unit = (uint32_t)(period * (1 << PWM_BASE_UNIT_FRACTION));
 	duty = (pulse_cycles * PWM_DUTY_MAX) / period_cycles;
 
 	if (duty) {
@@ -80,8 +79,7 @@ err:
 	return ret;
 }
 
-static int bk_intel_get_cycles_per_sec(const struct device *dev, uint32_t pin,
-				       uint64_t *cycles)
+static int bk_intel_get_cycles_per_sec(const struct device *dev, uint32_t pin, uint64_t *cycles)
 {
 	const struct bk_intel_config *cfg = dev->config;
 
@@ -104,26 +102,22 @@ static int bk_intel_init(const struct device *dev)
 	struct bk_intel_runtime *runtime = dev->data;
 	const struct bk_intel_config *config = dev->config;
 
-	device_map(&runtime->reg_base,
-		   config->reg_base.phys_addr & ~0xFFU,
-		   config->reg_base.size,
+	device_map(&runtime->reg_base, config->reg_base.phys_addr & ~0xFFU, config->reg_base.size,
 		   K_MEM_CACHE_NONE);
 
 	return 0;
 }
 
-#define BK_INTEL_DEV_CFG(n)						       \
-	static const struct bk_intel_config bk_cfg_##n = {		       \
-		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)),	       \
-		.reg_offset = DT_INST_PROP(n, reg_offset),		       \
-		.max_pins = DT_INST_PROP(n, max_pins),			       \
-		.clock_freq = DT_INST_PROP(n, clock_frequency),		       \
-	};								       \
-									       \
-	static struct bk_intel_runtime bk_rt_##n;			       \
-	DEVICE_DT_INST_DEFINE(n, &bk_intel_init, NULL,			       \
-			      &bk_rt_##n, &bk_cfg_##n,			       \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
-			      &api_funcs);				       \
+#define BK_INTEL_DEV_CFG(n)                                                                        \
+	static const struct bk_intel_config bk_cfg_##n = {                                         \
+		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)),                              \
+		.reg_offset = DT_INST_PROP(n, reg_offset),                                         \
+		.max_pins = DT_INST_PROP(n, max_pins),                                             \
+		.clock_freq = DT_INST_PROP(n, clock_frequency),                                    \
+	};                                                                                         \
+                                                                                                   \
+	static struct bk_intel_runtime bk_rt_##n;                                                  \
+	DEVICE_DT_INST_DEFINE(n, &bk_intel_init, NULL, &bk_rt_##n, &bk_cfg_##n, POST_KERNEL,       \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &api_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(BK_INTEL_DEV_CFG)

--- a/drivers/rtc/rtc_mc146818.c
+++ b/drivers/rtc/rtc_mc146818.c
@@ -16,102 +16,102 @@
 #include <zephyr/drivers/rtc.h>
 #include <zephyr/sys/sys_io.h>
 
-#define RTC_STD_INDEX (DT_INST_REG_ADDR_BY_IDX(0, 0))
+#define RTC_STD_INDEX  (DT_INST_REG_ADDR_BY_IDX(0, 0))
 #define RTC_STD_TARGET (DT_INST_REG_ADDR_BY_IDX(0, 1))
 
 /* Time indices in RTC RAM */
-#define RTC_SEC		0x00
-#define RTC_MIN		0x02
-#define RTC_HOUR	0x04
+#define RTC_SEC  0x00
+#define RTC_MIN  0x02
+#define RTC_HOUR 0x04
 
 /* Day of week index in RTC RAM */
-#define RTC_WDAY	0x06
+#define RTC_WDAY 0x06
 
 /* Day of month index in RTC RAM */
-#define RTC_MDAY	0x07
+#define RTC_MDAY 0x07
 
 /* Month and year index in RTC RAM */
-#define RTC_MONTH	0x08
-#define RTC_YEAR	0x09
+#define RTC_MONTH 0x08
+#define RTC_YEAR  0x09
 
 /* Y2K Bugfix */
-#define RTC_CENTURY	0x32
+#define RTC_CENTURY 0x32
 
 /* Alarm time indices in RTC RAM */
-#define RTC_ALARM_SEC	0x01
-#define RTC_ALARM_MIN	0x03
-#define RTC_ALARM_HOUR	0x05
+#define RTC_ALARM_SEC  0x01
+#define RTC_ALARM_MIN  0x03
+#define RTC_ALARM_HOUR 0x05
 
 /* Registers A-D indeces in RTC RAM */
-#define RTC_REG_A	0x0A
-#define RTC_REG_B	0x0B
-#define RTC_REG_C	0x0C
-#define RTC_REG_D	0x0D
+#define RTC_REG_A 0x0A
+#define RTC_REG_B 0x0B
+#define RTC_REG_C 0x0C
+#define RTC_REG_D 0x0D
 
-#define RTC_UIP		RTC_REG_A
-#define RTC_DATA	RTC_REG_B
-#define RTC_FLAG	RTC_REG_C
+#define RTC_UIP  RTC_REG_A
+#define RTC_DATA RTC_REG_B
+#define RTC_FLAG RTC_REG_C
 
 /* Alarm don't case state */
-#define RTC_ALARM_DC	0xFF
+#define RTC_ALARM_DC 0xFF
 
 /* Update In Progress bit in REG_A */
-#define RTC_UIP_BIT	BIT(7)
+#define RTC_UIP_BIT BIT(7)
 
 /* Update Cycle Inhibit bit in REG_B */
-#define RTC_UCI_BIT	BIT(7)
+#define RTC_UCI_BIT BIT(7)
 
 /* Periodic Interrupt Enable bit in REG_B */
-#define RTC_PIE_BIT	BIT(6)
+#define RTC_PIE_BIT BIT(6)
 
 /* Alarm Interrupt Enable bit in REG_B */
-#define RTC_AIE_BIT	BIT(5)
+#define RTC_AIE_BIT BIT(5)
 
 /* Update-ended Interrupt Enable bit in REG_B */
-#define RTC_UIE_BIT	BIT(4)
+#define RTC_UIE_BIT BIT(4)
 
 /* Data mode bit in  REG_B */
-#define RTC_DMODE_BIT	BIT(2)
+#define RTC_DMODE_BIT BIT(2)
 
 /* Hour Format bit in REG_B */
-#define RTC_HFORMAT_BIT	BIT(1)
+#define RTC_HFORMAT_BIT BIT(1)
 
 /* Daylight Savings Enable Format bit in REG_B */
-#define RTC_DSE_BIT	BIT(0)
+#define RTC_DSE_BIT BIT(0)
 
 /* Interrupt Request Flag bit in REG_C */
-#define RTC_IRF_BIT	BIT(7)
+#define RTC_IRF_BIT BIT(7)
 
 /* Periodic Flag bit in REG_C */
-#define RTC_PF_BIT	BIT(6)
+#define RTC_PF_BIT BIT(6)
 
 /* Alarm Flag bit in REG_C */
-#define RTC_AF_BIT	BIT(5)
+#define RTC_AF_BIT BIT(5)
 
 /* Update-end Flag bit in REG_C */
-#define RTC_UEF_BIT	BIT(4)
+#define RTC_UEF_BIT BIT(4)
 
 /* VRT bit in REG_D */
-#define RTC_VRT_BIT	BIT(7)
+#define RTC_VRT_BIT BIT(7)
 
 /* Month day Alarm bits in REG_D */
-#define RTC_MDAY_ALARM	BIT_MASK(5)
+#define RTC_MDAY_ALARM BIT_MASK(5)
 
 /* Maximum and Minimum values of time */
-#define MIN_SEC		0
-#define MAX_SEC		59
-#define MIN_MIN		0
-#define MAX_MIN		59
-#define MIN_HOUR	0
-#define MAX_HOUR	23
-#define MAX_WDAY	7
-#define MIN_WDAY	1
-#define MAX_MDAY	31
-#define MIN_MDAY	1
-#define MAX_MON		12
-#define MIN_MON		1
-#define MIN_YEAR_DIFF	0 /* YEAR - 1900 */
-#define MAX_YEAR_DIFF	99 /* YEAR - 1999 */
+#define MIN_SEC       0
+#define MAX_SEC       59
+#define MIN_MIN       0
+#define MAX_MIN       59
+#define MIN_HOUR      0
+#define MAX_HOUR      23
+#define MAX_WDAY      7
+#define MIN_WDAY      1
+#define MAX_MDAY      31
+#define MIN_MDAY      1
+#define MAX_MON       12
+#define MIN_MON       1
+#define MIN_YEAR_DIFF 0  /* YEAR - 1900 */
+#define MAX_YEAR_DIFF 99 /* YEAR - 1999 */
 
 /* Input clock frequency mapped to divider bits */
 #define RTC_IN_CLK_DIV_BITS_4194304 (0)
@@ -171,7 +171,7 @@ static bool rtc_mc146818_validate_time(const struct rtc_time *timeptr)
 
 static int rtc_mc146818_set_time(const struct device *dev, const struct rtc_time *timeptr)
 {
-	struct rtc_mc146818_data * const dev_data = dev->data;
+	struct rtc_mc146818_data *const dev_data = dev->data;
 	uint8_t value;
 	int year;
 	int cent;
@@ -213,9 +213,9 @@ out:
 	return ret;
 }
 
-static int rtc_mc146818_get_time(const struct device *dev, struct rtc_time  *timeptr)
+static int rtc_mc146818_get_time(const struct device *dev, struct rtc_time *timeptr)
 {
-	struct rtc_mc146818_data * const dev_data = dev->data;
+	struct rtc_mc146818_data *const dev_data = dev->data;
 	int ret;
 	uint8_t cent;
 	uint8_t year;
@@ -294,9 +294,8 @@ static int rtc_mc146818_alarm_get_supported_fields(const struct device *dev, uin
 		return -EINVAL;
 	}
 
-	(*mask) = (RTC_ALARM_TIME_MASK_SECOND
-		   | RTC_ALARM_TIME_MASK_MINUTE
-		   | RTC_ALARM_TIME_MASK_HOUR);
+	(*mask) = (RTC_ALARM_TIME_MASK_SECOND | RTC_ALARM_TIME_MASK_MINUTE |
+		   RTC_ALARM_TIME_MASK_HOUR);
 
 	return 0;
 }
@@ -304,7 +303,7 @@ static int rtc_mc146818_alarm_get_supported_fields(const struct device *dev, uin
 static int rtc_mc146818_alarm_set_time(const struct device *dev, uint16_t id, uint16_t mask,
 				       const struct rtc_time *timeptr)
 {
-	struct rtc_mc146818_data * const dev_data = dev->data;
+	struct rtc_mc146818_data *const dev_data = dev->data;
 	int ret;
 
 	k_spinlock_key_t key = k_spin_lock(&dev_data->lock);
@@ -350,9 +349,9 @@ out:
 }
 
 static int rtc_mc146818_alarm_get_time(const struct device *dev, uint16_t id, uint16_t *mask,
-				   struct rtc_time *timeptr)
+				       struct rtc_time *timeptr)
 {
-	struct rtc_mc146818_data * const dev_data = dev->data;
+	struct rtc_mc146818_data *const dev_data = dev->data;
 	uint8_t value;
 	int ret;
 
@@ -395,9 +394,9 @@ out:
 }
 
 static int rtc_mc146818_alarm_set_callback(const struct device *dev, uint16_t id,
-				       rtc_alarm_callback callback, void *user_data)
+					   rtc_alarm_callback callback, void *user_data)
 {
-	struct rtc_mc146818_data * const dev_data = dev->data;
+	struct rtc_mc146818_data *const dev_data = dev->data;
 
 	if (id != 0) {
 		return -EINVAL;
@@ -422,7 +421,7 @@ static int rtc_mc146818_alarm_set_callback(const struct device *dev, uint16_t id
 
 static int rtc_mc146818_alarm_is_pending(const struct device *dev, uint16_t id)
 {
-	struct rtc_mc146818_data * const dev_data = dev->data;
+	struct rtc_mc146818_data *const dev_data = dev->data;
 	int ret;
 
 	if (id != 0) {
@@ -440,10 +439,10 @@ static int rtc_mc146818_alarm_is_pending(const struct device *dev, uint16_t id)
 #endif /* CONFIG_RTC_ALARM */
 
 #if defined(CONFIG_RTC_UPDATE)
-static int rtc_mc146818_update_set_callback(const struct device *dev,
-					rtc_update_callback callback, void *user_data)
+static int rtc_mc146818_update_set_callback(const struct device *dev, rtc_update_callback callback,
+					    void *user_data)
 {
-	struct rtc_mc146818_data * const dev_data = dev->data;
+	struct rtc_mc146818_data *const dev_data = dev->data;
 
 	k_spinlock_key_t key = k_spin_lock(&dev_data->lock);
 
@@ -458,7 +457,6 @@ static int rtc_mc146818_update_set_callback(const struct device *dev,
 		rtc_write(RTC_DATA, (rtc_read(RTC_DATA) & (~RTC_UIE_BIT)));
 	}
 
-
 	k_spin_unlock(&dev_data->lock, key);
 	return 0;
 }
@@ -467,7 +465,7 @@ static int rtc_mc146818_update_set_callback(const struct device *dev,
 
 static void rtc_mc146818_isr(const struct device *dev)
 {
-	struct rtc_mc146818_data * const dev_data = dev->data;
+	struct rtc_mc146818_data *const dev_data = dev->data;
 	uint8_t regc;
 
 	ARG_UNUSED(dev_data);
@@ -511,33 +509,29 @@ struct rtc_driver_api rtc_mc146818_driver_api = {
 #endif /* CONFIG_RTC_UPDATE */
 };
 
-#define RTC_MC146818_INIT_FN_DEFINE(n)						\
-	static int rtc_mc146818_init##n(const struct device *dev)		\
-	{									\
-		rtc_write(RTC_REG_A,						\
-			  _CONCAT(RTC_IN_CLK_DIV_BITS_,				\
-				  DT_INST_PROP(n, clock_frequency)));		\
-										\
-		rtc_write(RTC_REG_B, RTC_DMODE_BIT | RTC_HFORMAT_BIT);		\
-										\
-		IRQ_CONNECT(DT_INST_IRQN(0),					\
-				DT_INST_IRQ(0, priority),			\
-				rtc_mc146818_isr, DEVICE_DT_INST_GET(n),	\
-				DT_INST_IRQ(0, sense));				\
-										\
-		irq_enable(DT_INST_IRQN(0));					\
-										\
-		return 0;							\
+#define RTC_MC146818_INIT_FN_DEFINE(n)                                                             \
+	static int rtc_mc146818_init##n(const struct device *dev)                                  \
+	{                                                                                          \
+		rtc_write(RTC_REG_A,                                                               \
+			  _CONCAT(RTC_IN_CLK_DIV_BITS_, DT_INST_PROP(n, clock_frequency)));        \
+                                                                                                   \
+		rtc_write(RTC_REG_B, RTC_DMODE_BIT | RTC_HFORMAT_BIT);                             \
+                                                                                                   \
+		IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), rtc_mc146818_isr,           \
+			    DEVICE_DT_INST_GET(n), DT_INST_IRQ(0, sense));                         \
+                                                                                                   \
+		irq_enable(DT_INST_IRQN(0));                                                       \
+                                                                                                   \
+		return 0;                                                                          \
 	}
 
-#define RTC_MC146818_DEV_CFG(inst)						\
-	struct rtc_mc146818_data rtc_mc146818_data##inst;			\
-										\
-	RTC_MC146818_INIT_FN_DEFINE(inst)					\
-										\
-	DEVICE_DT_INST_DEFINE(inst, &rtc_mc146818_init##inst, NULL,		\
-			      &rtc_mc146818_data##inst, NULL, POST_KERNEL,	\
-			      CONFIG_RTC_INIT_PRIORITY,				\
-			      &rtc_mc146818_driver_api);			\
+#define RTC_MC146818_DEV_CFG(inst)                                                                 \
+	struct rtc_mc146818_data rtc_mc146818_data##inst;                                          \
+                                                                                                   \
+	RTC_MC146818_INIT_FN_DEFINE(inst)                                                          \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, &rtc_mc146818_init##inst, NULL, &rtc_mc146818_data##inst,      \
+			      NULL, POST_KERNEL, CONFIG_RTC_INIT_PRIORITY,                         \
+			      &rtc_mc146818_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(RTC_MC146818_DEV_CFG)

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -46,10 +46,8 @@ LOG_MODULE_REGISTER(uart_ns16550, CONFIG_UART_LOG_LEVEL);
 #define INST_HAS_PCP_HELPER(inst) DT_INST_NODE_HAS_PROP(inst, pcp) ||
 #define INST_HAS_DLF_HELPER(inst) DT_INST_NODE_HAS_PROP(inst, dlf) ||
 
-#define UART_NS16550_PCP_ENABLED \
-	(DT_INST_FOREACH_STATUS_OKAY(INST_HAS_PCP_HELPER) 0)
-#define UART_NS16550_DLF_ENABLED \
-	(DT_INST_FOREACH_STATUS_OKAY(INST_HAS_DLF_HELPER) 0)
+#define UART_NS16550_PCP_ENABLED (DT_INST_FOREACH_STATUS_OKAY(INST_HAS_PCP_HELPER) 0)
+#define UART_NS16550_DLF_ENABLED (DT_INST_FOREACH_STATUS_OKAY(INST_HAS_DLF_HELPER) 0)
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "NS16550(s) in DT need CONFIG_PCIE");
@@ -65,27 +63,27 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "NS16550(s) in DT need CONFIG_PCIE");
 
 /* register definitions */
 
-#define REG_THR 0x00  /* Transmitter holding reg.       */
-#define REG_RDR 0x00  /* Receiver data reg.             */
-#define REG_BRDL 0x00 /* Baud rate divisor (LSB)        */
-#define REG_BRDH 0x01 /* Baud rate divisor (MSB)        */
-#define REG_IER 0x01  /* Interrupt enable reg.          */
-#define REG_IIR 0x02  /* Interrupt ID reg.              */
-#define REG_FCR 0x02  /* FIFO control reg.              */
-#define REG_LCR 0x03  /* Line control reg.              */
-#define REG_MDC 0x04  /* Modem control reg.             */
-#define REG_LSR 0x05  /* Line status reg.               */
-#define REG_MSR 0x06  /* Modem status reg.              */
-#define REG_DLF 0xC0  /* Divisor Latch Fraction         */
-#define REG_PCP 0x200 /* PRV_CLOCK_PARAMS (Apollo Lake) */
-#define REG_MDR1 0x08 /* Mode control reg. (TI_K3) */
+#define REG_THR  0x00  /* Transmitter holding reg.       */
+#define REG_RDR  0x00  /* Receiver data reg.             */
+#define REG_BRDL 0x00  /* Baud rate divisor (LSB)        */
+#define REG_BRDH 0x01  /* Baud rate divisor (MSB)        */
+#define REG_IER  0x01  /* Interrupt enable reg.          */
+#define REG_IIR  0x02  /* Interrupt ID reg.              */
+#define REG_FCR  0x02  /* FIFO control reg.              */
+#define REG_LCR  0x03  /* Line control reg.              */
+#define REG_MDC  0x04  /* Modem control reg.             */
+#define REG_LSR  0x05  /* Line status reg.               */
+#define REG_MSR  0x06  /* Modem status reg.              */
+#define REG_DLF  0xC0  /* Divisor Latch Fraction         */
+#define REG_PCP  0x200 /* PRV_CLOCK_PARAMS (Apollo Lake) */
+#define REG_MDR1 0x08  /* Mode control reg. (TI_K3) */
 
 /* equates for interrupt enable register */
 
 #define IER_RXRDY 0x01 /* receiver data ready */
-#define IER_TBE 0x02   /* transmit bit enable */
-#define IER_LSR 0x04   /* line status interrupts */
-#define IER_MSI 0x08   /* modem status interrupts */
+#define IER_TBE   0x02 /* transmit bit enable */
+#define IER_LSR   0x04 /* line status interrupts */
+#define IER_MSI   0x08 /* modem status interrupts */
 
 /* equates for interrupt identification register */
 
@@ -101,30 +99,30 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "NS16550(s) in DT need CONFIG_PCIE");
 
 /* equates for FIFO control register */
 
-#define FCR_FIFO 0x01    /* enable XMIT and RCVR FIFO */
+#define FCR_FIFO    0x01 /* enable XMIT and RCVR FIFO */
 #define FCR_RCVRCLR 0x02 /* clear RCVR FIFO */
 #define FCR_XMITCLR 0x04 /* clear XMIT FIFO */
 
 /* equates for Apollo Lake clock control register (PRV_CLOCK_PARAMS) */
 
 #define PCP_UPDATE 0x80000000 /* update clock */
-#define PCP_EN 0x00000001     /* enable clock output */
+#define PCP_EN     0x00000001 /* enable clock output */
 
 /* Fields for TI K3 UART module */
 
-#define MDR1_MODE_SELECT_FIELD_MASK		BIT_MASK(3)
-#define MDR1_MODE_SELECT_FIELD_SHIFT		BIT_MASK(0)
+#define MDR1_MODE_SELECT_FIELD_MASK  BIT_MASK(3)
+#define MDR1_MODE_SELECT_FIELD_SHIFT BIT_MASK(0)
 
 /* Modes available for TI K3 UART module */
 
-#define MDR1_STD_MODE					(0)
-#define MDR1_SIR_MODE					(1)
-#define MDR1_UART_16X					(2)
-#define MDR1_UART_13X					(3)
-#define MDR1_MIR_MODE					(4)
-#define MDR1_FIR_MODE					(5)
-#define MDR1_CIR_MODE					(6)
-#define MDR1_DISABLE					(7)
+#define MDR1_STD_MODE (0)
+#define MDR1_SIR_MODE (1)
+#define MDR1_UART_16X (2)
+#define MDR1_UART_13X (3)
+#define MDR1_MIR_MODE (4)
+#define MDR1_FIR_MODE (5)
+#define MDR1_CIR_MODE (6)
+#define MDR1_DISABLE  (7)
 
 /*
  * Per PC16550D (Literature Number: SNLS378B):
@@ -158,9 +156,9 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "NS16550(s) in DT need CONFIG_PCIE");
 #define FCR_MODE1 0x08 /* set receiver in mode 1 */
 
 /* RCVR FIFO interrupt levels: trigger interrupt with this bytes in FIFO */
-#define FCR_FIFO_1 0x00  /* 1 byte in RCVR FIFO */
-#define FCR_FIFO_4 0x40  /* 4 bytes in RCVR FIFO */
-#define FCR_FIFO_8 0x80  /* 8 bytes in RCVR FIFO */
+#define FCR_FIFO_1  0x00 /* 1 byte in RCVR FIFO */
+#define FCR_FIFO_4  0x40 /* 4 bytes in RCVR FIFO */
+#define FCR_FIFO_8  0x80 /* 8 bytes in RCVR FIFO */
 #define FCR_FIFO_14 0xC0 /* 14 bytes in RCVR FIFO */
 
 /*
@@ -171,23 +169,23 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "NS16550(s) in DT need CONFIG_PCIE");
 
 /* constants for line control register */
 
-#define LCR_CS5 0x00   /* 5 bits data size */
-#define LCR_CS6 0x01   /* 6 bits data size */
-#define LCR_CS7 0x02   /* 7 bits data size */
-#define LCR_CS8 0x03   /* 8 bits data size */
+#define LCR_CS5   0x00 /* 5 bits data size */
+#define LCR_CS6   0x01 /* 6 bits data size */
+#define LCR_CS7   0x02 /* 7 bits data size */
+#define LCR_CS8   0x03 /* 8 bits data size */
 #define LCR_2_STB 0x04 /* 2 stop bits */
 #define LCR_1_STB 0x00 /* 1 stop bit */
-#define LCR_PEN 0x08   /* parity enable */
-#define LCR_PDIS 0x00  /* parity disable */
-#define LCR_EPS 0x10   /* even parity select */
-#define LCR_SP 0x20    /* stick parity select */
-#define LCR_SBRK 0x40  /* break control bit */
-#define LCR_DLAB 0x80  /* divisor latch access enable */
+#define LCR_PEN   0x08 /* parity enable */
+#define LCR_PDIS  0x00 /* parity disable */
+#define LCR_EPS   0x10 /* even parity select */
+#define LCR_SP    0x20 /* stick parity select */
+#define LCR_SBRK  0x40 /* break control bit */
+#define LCR_DLAB  0x80 /* divisor latch access enable */
 
 /* constants for the modem control register */
 
-#define MCR_DTR 0x01  /* dtr output */
-#define MCR_RTS 0x02  /* rts output */
+#define MCR_DTR  0x01 /* dtr output */
+#define MCR_RTS  0x02 /* rts output */
 #define MCR_OUT1 0x04 /* output #1 */
 #define MCR_OUT2 0x08 /* output #2 */
 #define MCR_LOOP 0x10 /* loop back */
@@ -195,40 +193,40 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "NS16550(s) in DT need CONFIG_PCIE");
 
 /* constants for line status register */
 
-#define LSR_RXRDY 0x01 /* receiver data available */
-#define LSR_OE 0x02    /* overrun error */
-#define LSR_PE 0x04    /* parity error */
-#define LSR_FE 0x08    /* framing error */
-#define LSR_BI 0x10    /* break interrupt */
+#define LSR_RXRDY    0x01 /* receiver data available */
+#define LSR_OE       0x02 /* overrun error */
+#define LSR_PE       0x04 /* parity error */
+#define LSR_FE       0x08 /* framing error */
+#define LSR_BI       0x10 /* break interrupt */
 #define LSR_EOB_MASK 0x1E /* Error or Break mask */
-#define LSR_THRE 0x20  /* transmit holding register empty */
-#define LSR_TEMT 0x40  /* transmitter empty */
+#define LSR_THRE     0x20 /* transmit holding register empty */
+#define LSR_TEMT     0x40 /* transmitter empty */
 
 /* constants for modem status register */
 
 #define MSR_DCTS 0x01 /* cts change */
 #define MSR_DDSR 0x02 /* dsr change */
-#define MSR_DRI 0x04  /* ring change */
+#define MSR_DRI  0x04 /* ring change */
 #define MSR_DDCD 0x08 /* data carrier change */
-#define MSR_CTS 0x10  /* complement of cts */
-#define MSR_DSR 0x20  /* complement of dsr */
-#define MSR_RI 0x40   /* complement of ring signal */
-#define MSR_DCD 0x80  /* complement of dcd */
+#define MSR_CTS  0x10 /* complement of cts */
+#define MSR_DSR  0x20 /* complement of dsr */
+#define MSR_RI   0x40 /* complement of ring signal */
+#define MSR_DCD  0x80 /* complement of dcd */
 
-#define THR(dev) (get_port(dev) + REG_THR * reg_interval(dev))
-#define RDR(dev) (get_port(dev) + REG_RDR * reg_interval(dev))
+#define THR(dev)  (get_port(dev) + REG_THR * reg_interval(dev))
+#define RDR(dev)  (get_port(dev) + REG_RDR * reg_interval(dev))
 #define BRDL(dev) (get_port(dev) + REG_BRDL * reg_interval(dev))
 #define BRDH(dev) (get_port(dev) + REG_BRDH * reg_interval(dev))
-#define IER(dev) (get_port(dev) + REG_IER * reg_interval(dev))
-#define IIR(dev) (get_port(dev) + REG_IIR * reg_interval(dev))
-#define FCR(dev) (get_port(dev) + REG_FCR * reg_interval(dev))
-#define LCR(dev) (get_port(dev) + REG_LCR * reg_interval(dev))
-#define MDC(dev) (get_port(dev) + REG_MDC * reg_interval(dev))
-#define LSR(dev) (get_port(dev) + REG_LSR * reg_interval(dev))
-#define MSR(dev) (get_port(dev) + REG_MSR * reg_interval(dev))
+#define IER(dev)  (get_port(dev) + REG_IER * reg_interval(dev))
+#define IIR(dev)  (get_port(dev) + REG_IIR * reg_interval(dev))
+#define FCR(dev)  (get_port(dev) + REG_FCR * reg_interval(dev))
+#define LCR(dev)  (get_port(dev) + REG_LCR * reg_interval(dev))
+#define MDC(dev)  (get_port(dev) + REG_MDC * reg_interval(dev))
+#define LSR(dev)  (get_port(dev) + REG_LSR * reg_interval(dev))
+#define MSR(dev)  (get_port(dev) + REG_MSR * reg_interval(dev))
 #define MDR1(dev) (get_port(dev) + REG_MDR1 * reg_interval(dev))
-#define DLF(dev) (get_port(dev) + REG_DLF)
-#define PCP(dev) (get_port(dev) + REG_PCP)
+#define DLF(dev)  (get_port(dev) + REG_DLF)
+#define PCP(dev)  (get_port(dev) + REG_PCP)
 
 #define IIRC(dev) (((struct uart_ns16550_dev_data *)(dev)->data)->iir_cache)
 
@@ -242,7 +240,7 @@ struct uart_ns16550_device_config {
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
-	uart_irq_config_func_t	irq_config_func;
+	uart_irq_config_func_t irq_config_func;
 #endif
 #if UART_NS16550_PCP_ENABLED
 	uint32_t pcp;
@@ -270,13 +268,13 @@ struct uart_ns16550_dev_data {
 	uint8_t fifo_size;
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	uint8_t iir_cache;	/**< cache of IIR since it clears when read */
-	uart_irq_callback_user_data_t cb;  /**< Callback function pointer */
-	void *cb_data;	/**< Callback function arg */
+	uint8_t iir_cache;                /**< cache of IIR since it clears when read */
+	uart_irq_callback_user_data_t cb; /**< Callback function pointer */
+	void *cb_data;                    /**< Callback function arg */
 #endif
 
 #if UART_NS16550_DLF_ENABLED
-	uint8_t dlf;		/**< DLF value */
+	uint8_t dlf; /**< DLF value */
 #endif
 
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) && defined(CONFIG_PM)
@@ -284,8 +282,8 @@ struct uart_ns16550_dev_data {
 #endif
 };
 
-static void ns16550_outbyte(const struct uart_ns16550_device_config *cfg,
-			    uintptr_t port, uint8_t val)
+static void ns16550_outbyte(const struct uart_ns16550_device_config *cfg, uintptr_t port,
+			    uint8_t val)
 {
 #if defined(CONFIG_UART_NS16550_ACCESS_IOPORT) || defined(CONFIG_UART_NS16550_SIMULT_ACCESS)
 	if (cfg->io_map) {
@@ -307,8 +305,7 @@ static void ns16550_outbyte(const struct uart_ns16550_device_config *cfg,
 	}
 }
 
-static uint8_t ns16550_inbyte(const struct uart_ns16550_device_config *cfg,
-			      uintptr_t port)
+static uint8_t ns16550_inbyte(const struct uart_ns16550_device_config *cfg, uintptr_t port)
 {
 #if defined(CONFIG_UART_NS16550_ACCESS_IOPORT) || defined(CONFIG_UART_NS16550_SIMULT_ACCESS)
 	if (cfg->io_map) {
@@ -332,8 +329,8 @@ static uint8_t ns16550_inbyte(const struct uart_ns16550_device_config *cfg,
 }
 
 #if UART_NS16550_PCP_ENABLED
-static void ns16550_outword(const struct uart_ns16550_device_config *cfg,
-			    uintptr_t port, uint32_t val)
+static void ns16550_outword(const struct uart_ns16550_device_config *cfg, uintptr_t port,
+			    uint32_t val)
 {
 #if defined(CONFIG_UART_NS16550_ACCESS_IOPORT) || defined(CONFIG_UART_NS16550_SIMULT_ACCESS)
 	if (cfg->io_map) {
@@ -347,8 +344,7 @@ static void ns16550_outword(const struct uart_ns16550_device_config *cfg,
 	}
 }
 
-static uint32_t ns16550_inword(const struct uart_ns16550_device_config *cfg,
-			      uintptr_t port)
+static uint32_t ns16550_inword(const struct uart_ns16550_device_config *cfg, uintptr_t port)
 {
 #if defined(CONFIG_UART_NS16550_ACCESS_IOPORT) || defined(CONFIG_UART_NS16550_SIMULT_ACCESS)
 	if (cfg->io_map) {
@@ -389,8 +385,8 @@ static inline uintptr_t get_port(const struct device *dev)
 
 static void set_baud_rate(const struct device *dev, uint32_t baud_rate, uint32_t pclk)
 {
-	struct uart_ns16550_dev_data * const dev_data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	struct uart_ns16550_dev_data *const dev_data = dev->data;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	uint32_t divisor; /* baud rate divisor */
 	uint8_t lcr_cache;
 
@@ -399,8 +395,7 @@ static void set_baud_rate(const struct device *dev, uint32_t baud_rate, uint32_t
 		 * calculate baud rate divisor. a variant of
 		 * (uint32_t)(pclk / (16.0 * baud_rate) + 0.5)
 		 */
-		divisor = ((pclk + (baud_rate << 3))
-					/ baud_rate) >> 4;
+		divisor = ((pclk + (baud_rate << 3)) / baud_rate) >> 4;
 
 		/* set the DLAB to access the baud rate divisor registers */
 		lcr_cache = ns16550_inbyte(dev_cfg, LCR(dev));
@@ -415,11 +410,10 @@ static void set_baud_rate(const struct device *dev, uint32_t baud_rate, uint32_t
 	}
 }
 
-static int uart_ns16550_configure(const struct device *dev,
-				  const struct uart_config *cfg)
+static int uart_ns16550_configure(const struct device *dev, const struct uart_config *cfg)
 {
-	struct uart_ns16550_dev_data * const dev_data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	struct uart_ns16550_dev_data *const dev_data = dev->data;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	uint8_t mdc = 0U;
 	uint32_t pclk = 0U;
 
@@ -455,8 +449,8 @@ static int uart_ns16550_configure(const struct device *dev,
 #ifdef CONFIG_UART_NS16550_TI_K3
 	uint32_t mdr = ns16550_inbyte(dev_cfg, MDR1(dev));
 
-	mdr = ((mdr & ~MDR1_MODE_SELECT_FIELD_MASK) | ((((MDR1_STD_MODE) <<
-		MDR1_MODE_SELECT_FIELD_SHIFT)) & MDR1_MODE_SELECT_FIELD_MASK));
+	mdr = ((mdr & ~MDR1_MODE_SELECT_FIELD_MASK) |
+	       ((((MDR1_STD_MODE) << MDR1_MODE_SELECT_FIELD_SHIFT)) & MDR1_MODE_SELECT_FIELD_MASK));
 	ns16550_outbyte(dev_cfg, MDR1(dev), mdr);
 #endif
 	/*
@@ -471,9 +465,7 @@ static int uart_ns16550_configure(const struct device *dev,
 			goto out;
 		}
 
-		if (clock_control_get_rate(dev_cfg->clock_dev,
-					   dev_cfg->clock_subsys,
-					   &pclk) != 0) {
+		if (clock_control_get_rate(dev_cfg->clock_dev, dev_cfg->clock_subsys, &pclk) != 0) {
 			ret = -EINVAL;
 			goto out;
 		}
@@ -533,8 +525,7 @@ static int uart_ns16550_configure(const struct device *dev,
 			uart_cfg.data_bits | uart_cfg.stop_bits | uart_cfg.parity);
 
 	mdc = MCR_OUT2 | MCR_RTS | MCR_DTR;
-#if defined(CONFIG_UART_NS16550_VARIANT_NS16750) || \
-	defined(CONFIG_UART_NS16550_VARIANT_NS16950)
+#if defined(CONFIG_UART_NS16550_VARIANT_NS16750) || defined(CONFIG_UART_NS16550_VARIANT_NS16950)
 	if (cfg->flow_ctrl == UART_CFG_FLOW_CTRL_RTS_CTS) {
 		mdc |= MCR_AFCE;
 	}
@@ -550,9 +541,9 @@ static int uart_ns16550_configure(const struct device *dev,
 	ns16550_outbyte(dev_cfg, FCR(dev),
 			FCR_FIFO | FCR_MODE0 | FCR_FIFO_8 | FCR_RCVRCLR | FCR_XMITCLR
 #ifdef CONFIG_UART_NS16550_VARIANT_NS16750
-			| FCR_FIFO_64
+				| FCR_FIFO_64
 #endif
-			);
+	);
 
 	if ((ns16550_inbyte(dev_cfg, IIR(dev)) & IIR_FE) == IIR_FE) {
 #ifdef CONFIG_UART_NS16550_VARIANT_NS16750
@@ -578,8 +569,7 @@ out:
 };
 
 #ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
-static int uart_ns16550_config_get(const struct device *dev,
-				   struct uart_config *cfg)
+static int uart_ns16550_config_get(const struct device *dev, struct uart_config *cfg)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
 
@@ -660,8 +650,7 @@ static int uart_ns16550_init(const struct device *dev)
 		pcie_probe_mbar(dev_cfg->pcie->bdf, 0, &mbar);
 		pcie_set_cmd(dev_cfg->pcie->bdf, PCIE_CONF_CMDSTAT_MEM, true);
 
-		device_map(DEVICE_MMIO_RAM_PTR(dev), mbar.phys_addr, mbar.size,
-			   K_MEM_CACHE_NONE);
+		device_map(DEVICE_MMIO_RAM_PTR(dev), mbar.phys_addr, mbar.size, K_MEM_CACHE_NONE);
 	} else
 #endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie) */
 	{
@@ -698,7 +687,7 @@ static int uart_ns16550_init(const struct device *dev)
 static int uart_ns16550_poll_in(const struct device *dev, unsigned char *c)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	int ret = -1;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
@@ -725,11 +714,10 @@ static int uart_ns16550_poll_in(const struct device *dev, unsigned char *c)
  * @param dev UART device struct
  * @param c Character to send
  */
-static void uart_ns16550_poll_out(const struct device *dev,
-					   unsigned char c)
+static void uart_ns16550_poll_out(const struct device *dev, unsigned char c)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
 	while ((ns16550_inbyte(dev_cfg, LSR(dev)) & LSR_THRE) == 0) {
@@ -751,7 +739,7 @@ static void uart_ns16550_poll_out(const struct device *dev,
 static int uart_ns16550_err_check(const struct device *dev)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 	int check = (ns16550_inbyte(dev_cfg, LSR(dev)) & LSR_EOB_MASK);
 
@@ -771,12 +759,10 @@ static int uart_ns16550_err_check(const struct device *dev)
  *
  * @return Number of bytes sent
  */
-static int uart_ns16550_fifo_fill(const struct device *dev,
-				  const uint8_t *tx_data,
-				  int size)
+static int uart_ns16550_fifo_fill(const struct device *dev, const uint8_t *tx_data, int size)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	int i;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
@@ -798,11 +784,10 @@ static int uart_ns16550_fifo_fill(const struct device *dev,
  *
  * @return Number of bytes read
  */
-static int uart_ns16550_fifo_read(const struct device *dev, uint8_t *rx_data,
-				  const int size)
+static int uart_ns16550_fifo_read(const struct device *dev, uint8_t *rx_data, const int size)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	int i;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
@@ -823,7 +808,7 @@ static int uart_ns16550_fifo_read(const struct device *dev, uint8_t *rx_data,
 static void uart_ns16550_irq_tx_enable(const struct device *dev)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) && defined(CONFIG_PM)
@@ -859,11 +844,10 @@ static void uart_ns16550_irq_tx_enable(const struct device *dev)
 static void uart_ns16550_irq_tx_disable(const struct device *dev)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	ns16550_outbyte(dev_cfg, IER(dev),
-			ns16550_inbyte(dev_cfg, IER(dev)) & (~IER_TBE));
+	ns16550_outbyte(dev_cfg, IER(dev), ns16550_inbyte(dev_cfg, IER(dev)) & (~IER_TBE));
 
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) && defined(CONFIG_PM)
 	struct uart_ns16550_dev_data *const dev_data = dev->data;
@@ -917,11 +901,13 @@ static int uart_ns16550_irq_tx_ready(const struct device *dev)
 static int uart_ns16550_irq_tx_complete(const struct device *dev)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	int ret = ((ns16550_inbyte(dev_cfg, LSR(dev)) & (LSR_TEMT | LSR_THRE))
-				== (LSR_TEMT | LSR_THRE)) ? 1 : 0;
+	int ret = ((ns16550_inbyte(dev_cfg, LSR(dev)) & (LSR_TEMT | LSR_THRE)) ==
+		   (LSR_TEMT | LSR_THRE))
+			  ? 1
+			  : 0;
 
 	k_spin_unlock(&data->lock, key);
 
@@ -936,7 +922,7 @@ static int uart_ns16550_irq_tx_complete(const struct device *dev)
 static void uart_ns16550_irq_rx_enable(const struct device *dev)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
 	ns16550_outbyte(dev_cfg, IER(dev), ns16550_inbyte(dev_cfg, IER(dev)) | IER_RXRDY);
@@ -952,11 +938,10 @@ static void uart_ns16550_irq_rx_enable(const struct device *dev)
 static void uart_ns16550_irq_rx_disable(const struct device *dev)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	ns16550_outbyte(dev_cfg, IER(dev),
-			ns16550_inbyte(dev_cfg, IER(dev)) & (~IER_RXRDY));
+	ns16550_outbyte(dev_cfg, IER(dev), ns16550_inbyte(dev_cfg, IER(dev)) & (~IER_RXRDY));
 
 	k_spin_unlock(&data->lock, key);
 }
@@ -988,11 +973,10 @@ static int uart_ns16550_irq_rx_ready(const struct device *dev)
 static void uart_ns16550_irq_err_enable(const struct device *dev)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	ns16550_outbyte(dev_cfg, IER(dev),
-			ns16550_inbyte(dev_cfg, IER(dev)) | IER_LSR);
+	ns16550_outbyte(dev_cfg, IER(dev), ns16550_inbyte(dev_cfg, IER(dev)) | IER_LSR);
 
 	k_spin_unlock(&data->lock, key);
 }
@@ -1007,11 +991,10 @@ static void uart_ns16550_irq_err_enable(const struct device *dev)
 static void uart_ns16550_irq_err_disable(const struct device *dev)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	ns16550_outbyte(dev_cfg, IER(dev),
-			ns16550_inbyte(dev_cfg, IER(dev)) & (~IER_LSR));
+	ns16550_outbyte(dev_cfg, IER(dev), ns16550_inbyte(dev_cfg, IER(dev)) & (~IER_LSR));
 
 	k_spin_unlock(&data->lock, key);
 }
@@ -1045,7 +1028,7 @@ static int uart_ns16550_irq_is_pending(const struct device *dev)
 static int uart_ns16550_irq_update(const struct device *dev)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
 	IIRC(dev) = ns16550_inbyte(dev_cfg, IIR(dev));
@@ -1062,10 +1045,9 @@ static int uart_ns16550_irq_update(const struct device *dev)
  * @param cb Callback function pointer.
  */
 static void uart_ns16550_irq_callback_set(const struct device *dev,
-					  uart_irq_callback_user_data_t cb,
-					  void *cb_data)
+					  uart_irq_callback_user_data_t cb, void *cb_data)
 {
-	struct uart_ns16550_dev_data * const dev_data = dev->data;
+	struct uart_ns16550_dev_data *const dev_data = dev->data;
 	k_spinlock_key_t key = k_spin_lock(&dev_data->lock);
 
 	dev_data->cb = cb;
@@ -1083,14 +1065,14 @@ static void uart_ns16550_irq_callback_set(const struct device *dev,
  */
 static void uart_ns16550_isr(const struct device *dev)
 {
-	struct uart_ns16550_dev_data * const dev_data = dev->data;
+	struct uart_ns16550_dev_data *const dev_data = dev->data;
 
 	if (dev_data->cb) {
 		dev_data->cb(dev, dev_data->cb_data);
 	}
 
 #ifdef CONFIG_UART_NS16550_WA_ISR_REENABLE_INTERRUPT
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 	uint8_t cached_ier = ns16550_inbyte(dev_cfg, IER(dev));
 
 	ns16550_outbyte(dev_cfg, IER(dev), 0U);
@@ -1111,8 +1093,7 @@ static void uart_ns16550_isr(const struct device *dev)
  *
  * @return 0 if successful, failed otherwise
  */
-static int uart_ns16550_line_ctrl_set(const struct device *dev,
-				      uint32_t ctrl, uint32_t val)
+static int uart_ns16550_line_ctrl_set(const struct device *dev, uint32_t ctrl, uint32_t val)
 {
 	struct uart_ns16550_dev_data *data = dev->data;
 	const struct uart_ns16550_device_config *const dev_cfg = dev->config;
@@ -1169,13 +1150,12 @@ static int uart_ns16550_line_ctrl_set(const struct device *dev,
  *
  * @return 0 if successful, failed otherwise
  */
-static int uart_ns16550_drv_cmd(const struct device *dev, uint32_t cmd,
-				uint32_t p)
+static int uart_ns16550_drv_cmd(const struct device *dev, uint32_t cmd, uint32_t p)
 {
 #if UART_NS16550_DLF_ENABLED
 	if (cmd == CMD_SET_DLF) {
-		struct uart_ns16550_dev_data * const dev_data = dev->data;
-		const struct uart_ns16550_device_config * const dev_cfg = dev->config;
+		struct uart_ns16550_dev_data *const dev_data = dev->data;
+		const struct uart_ns16550_device_config *const dev_cfg = dev->config;
 		k_spinlock_key_t key = k_spin_lock(&dev_data->lock);
 
 		dev_data->dlf = p;
@@ -1189,7 +1169,6 @@ static int uart_ns16550_drv_cmd(const struct device *dev, uint32_t cmd,
 }
 
 #endif /* CONFIG_UART_NS16550_DRV_CMD */
-
 
 static const struct uart_driver_api uart_ns16550_driver_api = {
 	.poll_in = uart_ns16550_poll_in,
@@ -1229,71 +1208,59 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 
 #define UART_NS16550_IRQ_FLAGS_SENSE0(n) 0
 #define UART_NS16550_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
-#define UART_NS16550_IRQ_FLAGS(n) \
+#define UART_NS16550_IRQ_FLAGS(n)                                                                  \
 	_CONCAT(UART_NS16550_IRQ_FLAGS_SENSE, DT_INST_IRQ_HAS_CELL(n, sense))(n)
 
 /* not PCI(e) */
-#define UART_NS16550_IRQ_CONFIG_PCIE0(n)                                      \
-	static void irq_config_func##n(const struct device *dev)              \
-	{                                                                     \
-		ARG_UNUSED(dev);                                              \
-		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	      \
-			    uart_ns16550_isr, DEVICE_DT_INST_GET(n),	      \
-			    UART_NS16550_IRQ_FLAGS(n));			      \
-		irq_enable(DT_INST_IRQN(n));                                  \
+#define UART_NS16550_IRQ_CONFIG_PCIE0(n)                                                           \
+	static void irq_config_func##n(const struct device *dev)                                   \
+	{                                                                                          \
+		ARG_UNUSED(dev);                                                                   \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), uart_ns16550_isr,           \
+			    DEVICE_DT_INST_GET(n), UART_NS16550_IRQ_FLAGS(n));                     \
+		irq_enable(DT_INST_IRQN(n));                                                       \
 	}
 
 /* PCI(e) with auto IRQ detection */
-#define UART_NS16550_IRQ_CONFIG_PCIE1(n)                                      \
-	static void irq_config_func##n(const struct device *dev)              \
-	{                                                                     \
-		BUILD_ASSERT(DT_INST_IRQN(n) == PCIE_IRQ_DETECT,              \
-			     "Only runtime IRQ configuration is supported");  \
-		BUILD_ASSERT(IS_ENABLED(CONFIG_DYNAMIC_INTERRUPTS),           \
-			     "NS16550 PCIe requires dynamic interrupts");     \
-		const struct uart_ns16550_device_config *dev_cfg = dev->config;\
-		unsigned int irq = pcie_alloc_irq(dev_cfg->pcie->bdf);        \
-		if (irq == PCIE_CONF_INTR_IRQ_NONE) {                         \
-			return;                                               \
-		}                                                             \
-		pcie_connect_dynamic_irq(dev_cfg->pcie->bdf, irq,	      \
-				     DT_INST_IRQ(n, priority),		      \
-				    (void (*)(const void *))uart_ns16550_isr, \
-				    DEVICE_DT_INST_GET(n),                    \
-				    UART_NS16550_IRQ_FLAGS(n));               \
-		pcie_irq_enable(dev_cfg->pcie->bdf, irq);                    \
+#define UART_NS16550_IRQ_CONFIG_PCIE1(n)                                                           \
+	static void irq_config_func##n(const struct device *dev)                                   \
+	{                                                                                          \
+		BUILD_ASSERT(DT_INST_IRQN(n) == PCIE_IRQ_DETECT,                                   \
+			     "Only runtime IRQ configuration is supported");                       \
+		BUILD_ASSERT(IS_ENABLED(CONFIG_DYNAMIC_INTERRUPTS),                                \
+			     "NS16550 PCIe requires dynamic interrupts");                          \
+		const struct uart_ns16550_device_config *dev_cfg = dev->config;                    \
+		unsigned int irq = pcie_alloc_irq(dev_cfg->pcie->bdf);                             \
+		if (irq == PCIE_CONF_INTR_IRQ_NONE) {                                              \
+			return;                                                                    \
+		}                                                                                  \
+		pcie_connect_dynamic_irq(dev_cfg->pcie->bdf, irq, DT_INST_IRQ(n, priority),        \
+					 (void (*)(const void *))uart_ns16550_isr,                 \
+					 DEVICE_DT_INST_GET(n), UART_NS16550_IRQ_FLAGS(n));        \
+		pcie_irq_enable(dev_cfg->pcie->bdf, irq);                                          \
 	}
 
 #ifdef CONFIG_UART_NS16550_ACCESS_IOPORT
-#define REG_INIT(n) \
-	.port = DT_INST_REG_ADDR(n), \
-	.io_map = true,
+#define REG_INIT(n) .port = DT_INST_REG_ADDR(n), .io_map = true,
 #else
 #define REG_INIT_PCIE1(n)
 #define REG_INIT_PCIE0(n) DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),
 
-#define DEV_REG_PORT_IO_1(n) \
-	.port = DT_INST_REG_ADDR(n),
-#define DEV_REG_PORT_IO_0(n) \
-	_CONCAT(REG_INIT_PCIE, DT_INST_ON_BUS(n, pcie))(n)
+#define DEV_REG_PORT_IO_1(n) .port = DT_INST_REG_ADDR(n),
+#define DEV_REG_PORT_IO_0(n) _CONCAT(REG_INIT_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 #ifdef CONFIG_UART_NS16550_SIMULT_ACCESS
-#define DEV_IO_INIT(n) \
-	.io_map = DT_INST_PROP(n, io_mapped),
+#define DEV_IO_INIT(n) .io_map = DT_INST_PROP(n, io_mapped),
 #else
 #define DEV_IO_INIT(n)
 #endif
 
-#define REG_INIT(n) \
-	_CONCAT(DEV_REG_PORT_IO_, DT_INST_PROP(n, io_mapped))(n) \
-	DEV_IO_INIT(n)
+#define REG_INIT(n) _CONCAT(DEV_REG_PORT_IO_, DT_INST_PROP(n, io_mapped))(n) DEV_IO_INIT(n)
 #endif
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-#define DEV_CONFIG_IRQ_FUNC_INIT(n) \
-	.irq_config_func = irq_config_func##n,
-#define UART_NS16550_IRQ_FUNC_DECLARE(n) \
-	static void irq_config_func##n(const struct device *dev);
-#define UART_NS16550_IRQ_FUNC_DEFINE(n) \
+#define DEV_CONFIG_IRQ_FUNC_INIT(n)      .irq_config_func = irq_config_func##n,
+#define UART_NS16550_IRQ_FUNC_DECLARE(n) static void irq_config_func##n(const struct device *dev);
+#define UART_NS16550_IRQ_FUNC_DEFINE(n)                                                            \
 	_CONCAT(UART_NS16550_IRQ_CONFIG_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 #else
 /* !CONFIG_UART_INTERRUPT_DRIVEN */
@@ -1309,76 +1276,57 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 #endif
 
 #define DEV_CONFIG_PCIE0(n)
-#define DEV_CONFIG_PCIE1(n) DEVICE_PCIE_INST_INIT(n, pcie)
-#define DEV_CONFIG_PCIE_INIT(n) \
-	_CONCAT(DEV_CONFIG_PCIE, DT_INST_ON_BUS(n, pcie))(n)
+#define DEV_CONFIG_PCIE1(n)     DEVICE_PCIE_INST_INIT(n, pcie)
+#define DEV_CONFIG_PCIE_INIT(n) _CONCAT(DEV_CONFIG_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 
 #define DEV_DECLARE_PCIE0(n)
 #define DEV_DECLARE_PCIE1(n) DEVICE_PCIE_INST_DECLARE(n)
-#define DEV_PCIE_DECLARE(n) \
-	_CONCAT(DEV_DECLARE_PCIE, DT_INST_ON_BUS(n, pcie))(n)
+#define DEV_PCIE_DECLARE(n)  _CONCAT(DEV_DECLARE_PCIE, DT_INST_ON_BUS(n, pcie))(n)
 
-#define DEV_DATA_FLOW_CTRL0 UART_CFG_FLOW_CTRL_NONE
-#define DEV_DATA_FLOW_CTRL1 UART_CFG_FLOW_CTRL_RTS_CTS
-#define DEV_DATA_FLOW_CTRL(n) \
-	_CONCAT(DEV_DATA_FLOW_CTRL, DT_INST_PROP_OR(n, hw_flow_control, 0))
+#define DEV_DATA_FLOW_CTRL0   UART_CFG_FLOW_CTRL_NONE
+#define DEV_DATA_FLOW_CTRL1   UART_CFG_FLOW_CTRL_RTS_CTS
+#define DEV_DATA_FLOW_CTRL(n) _CONCAT(DEV_DATA_FLOW_CTRL, DT_INST_PROP_OR(n, hw_flow_control, 0))
 
 #define DEV_DATA_DLF0(n)
-#define DEV_DATA_DLF1(n) \
-	.dlf = DT_INST_PROP(n, dlf),
-#define DEV_DATA_DLF_INIT(n) \
-	_CONCAT(DEV_DATA_DLF, DT_INST_NODE_HAS_PROP(n, dlf))(n)
+#define DEV_DATA_DLF1(n)     .dlf = DT_INST_PROP(n, dlf),
+#define DEV_DATA_DLF_INIT(n) _CONCAT(DEV_DATA_DLF, DT_INST_NODE_HAS_PROP(n, dlf))(n)
 
 #ifdef CONFIG_UART_NS16550_PARENT_INIT_LEVEL
 #define NS16550_BOOT_LEVEL0 PRE_KERNEL_1
 #define NS16550_BOOT_LEVEL1 POST_KERNEL
-#define BOOT_LEVEL(n) \
-	_CONCAT(NS16550_BOOT_LEVEL, DT_INST_ON_BUS(n, pcie))
+#define BOOT_LEVEL(n)       _CONCAT(NS16550_BOOT_LEVEL, DT_INST_ON_BUS(n, pcie))
 #else
 #define BOOT_LEVEL(n) PRE_KERNEL_1
 #endif
-#define UART_RESET_FUNC_INIT(n) \
-	.reset_spec = RESET_DT_SPEC_INST_GET(n),
+#define UART_RESET_FUNC_INIT(n) .reset_spec = RESET_DT_SPEC_INST_GET(n),
 
-#define UART_NS16550_DEVICE_INIT(n)                                                  \
-	UART_NS16550_IRQ_FUNC_DECLARE(n);                                            \
-	DEV_PCIE_DECLARE(n);                                                         \
-	IF_ENABLED(DT_INST_NODE_HAS_PROP(n, pinctrl_0),                              \
-		(PINCTRL_DT_INST_DEFINE(n)));                                        \
-	static const struct uart_ns16550_device_config uart_ns16550_dev_cfg_##n = {  \
-		REG_INIT(n)							     \
-		COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clock_frequency), (             \
-				.sys_clk_freq = DT_INST_PROP(n, clock_frequency),    \
-				.clock_dev = NULL,                                   \
-				.clock_subsys = NULL,                                \
-			), (                                                         \
-				.sys_clk_freq = 0,                                   \
-				.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),  \
-				.clock_subsys = (clock_control_subsys_t) DT_INST_PHA(\
-								0, clocks, clkid),   \
-			)                                                            \
-		)                                                                    \
-		DEV_CONFIG_IRQ_FUNC_INIT(n)                                          \
-		DEV_CONFIG_PCP_INIT(n)                                               \
-		.reg_interval = (1 << DT_INST_PROP(n, reg_shift)),                   \
-		DEV_CONFIG_PCIE_INIT(n)                                              \
-		IF_ENABLED(DT_INST_NODE_HAS_PROP(n, pinctrl_0),                      \
-			(.pincfg = PINCTRL_DT_DEV_CONFIG_GET(DT_DRV_INST(n)),))      \
-		IF_ENABLED(DT_INST_NODE_HAS_PROP(n, resets),                         \
-			(UART_RESET_FUNC_INIT(n)))                                   \
-	};                                                                           \
-	static struct uart_ns16550_dev_data uart_ns16550_dev_data_##n = {            \
-		.uart_config.baudrate = DT_INST_PROP_OR(n, current_speed, 0),        \
-		.uart_config.parity = UART_CFG_PARITY_NONE,                          \
-		.uart_config.stop_bits = UART_CFG_STOP_BITS_1,                       \
-		.uart_config.data_bits = UART_CFG_DATA_BITS_8,                       \
-		.uart_config.flow_ctrl = DEV_DATA_FLOW_CTRL(n),                      \
-		DEV_DATA_DLF_INIT(n)                                                 \
-	};                                                                           \
-	DEVICE_DT_INST_DEFINE(n, &uart_ns16550_init, NULL,                           \
-			      &uart_ns16550_dev_data_##n, &uart_ns16550_dev_cfg_##n, \
-			      BOOT_LEVEL(n), CONFIG_SERIAL_INIT_PRIORITY,             \
-			      &uart_ns16550_driver_api);                             \
+#define UART_NS16550_DEVICE_INIT(n)                                                                \
+	UART_NS16550_IRQ_FUNC_DECLARE(n);                                                          \
+	DEV_PCIE_DECLARE(n);                                                                       \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(n, pinctrl_0), (PINCTRL_DT_INST_DEFINE(n)));              \
+	static const struct uart_ns16550_device_config uart_ns16550_dev_cfg_##n = {                \
+		REG_INIT(n) COND_CODE_1(                                                           \
+			DT_INST_NODE_HAS_PROP(n, clock_frequency),                                 \
+			(.sys_clk_freq = DT_INST_PROP(n, clock_frequency), .clock_dev = NULL,      \
+			 .clock_subsys = NULL,),                                                  \
+			(.sys_clk_freq = 0, .clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),    \
+			 .clock_subsys = (clock_control_subsys_t)DT_INST_PHA(0, clocks, clkid),)) \
+			DEV_CONFIG_IRQ_FUNC_INIT(n) DEV_CONFIG_PCP_INIT(n)                         \
+				.reg_interval = (1 << DT_INST_PROP(n, reg_shift)),                 \
+		DEV_CONFIG_PCIE_INIT(n) IF_ENABLED(                                                \
+			DT_INST_NODE_HAS_PROP(n, pinctrl_0),                                       \
+			(.pincfg = PINCTRL_DT_DEV_CONFIG_GET(DT_DRV_INST(n)),))                   \
+			IF_ENABLED(DT_INST_NODE_HAS_PROP(n, resets), (UART_RESET_FUNC_INIT(n)))};  \
+	static struct uart_ns16550_dev_data uart_ns16550_dev_data_##n = {                          \
+		.uart_config.baudrate = DT_INST_PROP_OR(n, current_speed, 0),                      \
+		.uart_config.parity = UART_CFG_PARITY_NONE,                                        \
+		.uart_config.stop_bits = UART_CFG_STOP_BITS_1,                                     \
+		.uart_config.data_bits = UART_CFG_DATA_BITS_8,                                     \
+		.uart_config.flow_ctrl = DEV_DATA_FLOW_CTRL(n),                                    \
+		DEV_DATA_DLF_INIT(n)};                                                             \
+	DEVICE_DT_INST_DEFINE(n, &uart_ns16550_init, NULL, &uart_ns16550_dev_data_##n,             \
+			      &uart_ns16550_dev_cfg_##n, BOOT_LEVEL(n),                            \
+			      CONFIG_SERIAL_INIT_PRIORITY, &uart_ns16550_driver_api);              \
 	UART_NS16550_IRQ_FUNC_DEFINE(n)
 
 DT_INST_FOREACH_STATUS_OKAY(UART_NS16550_DEVICE_INIT)

--- a/drivers/watchdog/wdt_tco.c
+++ b/drivers/watchdog/wdt_tco.c
@@ -11,50 +11,50 @@
 
 LOG_MODULE_REGISTER(wdt_tco, CONFIG_WDT_LOG_LEVEL);
 
-#define TCO_WDT_NODE           DT_NODELABEL(tco_wdt)
+#define TCO_WDT_NODE DT_NODELABEL(tco_wdt)
 
-#define BASE(d)                ((struct tco_config *)(d)->config)->base
+#define BASE(d) ((struct tco_config *)(d)->config)->base
 
-#define TCO_RLD(d)             (BASE(d) + 0x00) /* TCO Timer Reload/Curr. Value */
-#define TCO_DAT_IN(d)          (BASE(d) + 0x02) /* TCO Data In Register */
-#define TCO_DAT_OUT(d)         (BASE(d) + 0x03) /* TCO Data Out Register */
-#define TCO1_STS(d)            (BASE(d) + 0x04) /* TCO1 Status Register */
-#define TCO2_STS(d)            (BASE(d) + 0x06) /* TCO2 Status Register */
-#define TCO1_CNT(d)            (BASE(d) + 0x08) /* TCO1 Control Register */
-#define TCO2_CNT(d)            (BASE(d) + 0x0a) /* TCO2 Control Register */
-#define TCO_MSG(d)             (BASE(d) + 0x0c) /* TCO Message Registers */
-#define TCO_WDSTATUS(d)        (BASE(d) + 0x0e) /* TCO Watchdog Status Register */
-#define TCO_TMR(d)             (BASE(d) + 0x12) /* TCO Timer Register */
+#define TCO_RLD(d)      (BASE(d) + 0x00) /* TCO Timer Reload/Curr. Value */
+#define TCO_DAT_IN(d)   (BASE(d) + 0x02) /* TCO Data In Register */
+#define TCO_DAT_OUT(d)  (BASE(d) + 0x03) /* TCO Data Out Register */
+#define TCO1_STS(d)     (BASE(d) + 0x04) /* TCO1 Status Register */
+#define TCO2_STS(d)     (BASE(d) + 0x06) /* TCO2 Status Register */
+#define TCO1_CNT(d)     (BASE(d) + 0x08) /* TCO1 Control Register */
+#define TCO2_CNT(d)     (BASE(d) + 0x0a) /* TCO2 Control Register */
+#define TCO_MSG(d)      (BASE(d) + 0x0c) /* TCO Message Registers */
+#define TCO_WDSTATUS(d) (BASE(d) + 0x0e) /* TCO Watchdog Status Register */
+#define TCO_TMR(d)      (BASE(d) + 0x12) /* TCO Timer Register */
 
 /* TCO1_STS bits */
-#define STS_NMI2SMI            BIT(0)
-#define STS_OS_TCO_SMI         BIT(1)
-#define STS_TCO_INT            BIT(2)
-#define STS_TIMEOUT            BIT(3)
-#define STS_NEWCENTURY         BIT(7)
-#define STS_BIOSWR             BIT(8)
-#define STS_CPUSCI             BIT(9)
-#define STS_CPUSMI             BIT(10)
-#define STS_CPUSERR            BIT(12)
-#define STS_SLVSEL             BIT(13)
+#define STS_NMI2SMI    BIT(0)
+#define STS_OS_TCO_SMI BIT(1)
+#define STS_TCO_INT    BIT(2)
+#define STS_TIMEOUT    BIT(3)
+#define STS_NEWCENTURY BIT(7)
+#define STS_BIOSWR     BIT(8)
+#define STS_CPUSCI     BIT(9)
+#define STS_CPUSMI     BIT(10)
+#define STS_CPUSERR    BIT(12)
+#define STS_SLVSEL     BIT(13)
 
 /* TCO2_STS bits */
-#define STS_INTRD_DET          BIT(0)
-#define STS_SECOND_TO          BIT(1)
-#define STS_NRSTRAP            BIT(2)
-#define STS_SMLINK_SLAVE_SMI   BIT(3)
+#define STS_INTRD_DET        BIT(0)
+#define STS_SECOND_TO        BIT(1)
+#define STS_NRSTRAP          BIT(2)
+#define STS_SMLINK_SLAVE_SMI BIT(3)
 
 /* TCO1_CNT bits */
-#define CNT_NR_MSUS            BIT(0)
-#define CNT_NMI_NOW            BIT(8)
-#define CNT_NMI2SMI_EN         BIT(9)
-#define CNT_TCO_TMR_HALT       BIT(11)
-#define CNT_TCO_LOCK           BIT(12)
+#define CNT_NR_MSUS      BIT(0)
+#define CNT_NMI_NOW      BIT(8)
+#define CNT_NMI2SMI_EN   BIT(9)
+#define CNT_TCO_TMR_HALT BIT(11)
+#define CNT_TCO_LOCK     BIT(12)
 
 /* TCO_TMR bits */
-#define TMR_TCOTMR             BIT_MASK(10)
-#define TMR_MIN                0x04
-#define TMR_MAX                0x3f
+#define TMR_TCOTMR BIT_MASK(10)
+#define TMR_MIN    0x04
+#define TMR_MAX    0x3f
 
 struct tco_data {
 	struct k_spinlock lock;
@@ -154,8 +154,7 @@ static uint16_t msec_to_ticks(uint32_t msec)
 	return ((msec / MSEC_PER_SEC) * 10) / 6;
 }
 
-static int tco_install_timeout(const struct device *dev,
-			       const struct wdt_timeout_cfg *cfg)
+static int tco_install_timeout(const struct device *dev, const struct wdt_timeout_cfg *cfg)
 {
 	struct tco_data *data = dev->data;
 	k_spinlock_key_t key;
@@ -249,7 +248,7 @@ static int wdt_init(const struct device *dev)
 
 	key = k_spin_lock(&data->lock);
 
-	sys_out16(STS_TIMEOUT, TCO1_STS(dev)); /* Clear the Time Out Status bit */
+	sys_out16(STS_TIMEOUT, TCO1_STS(dev));   /* Clear the Time Out Status bit */
 	sys_out16(STS_SECOND_TO, TCO2_STS(dev)); /* Clear SECOND_TO_STS bit */
 
 	set_no_reboot(dev, data->no_reboot);
@@ -263,13 +262,11 @@ static int wdt_init(const struct device *dev)
 	return 0;
 }
 
-static struct tco_data wdt_data = {
-};
+static struct tco_data wdt_data = {};
 
 static const struct tco_config wdt_config = {
 	.base = DT_REG_ADDR(TCO_WDT_NODE),
 };
 
-DEVICE_DT_DEFINE(TCO_WDT_NODE, wdt_init, NULL, &wdt_data, &wdt_config,
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
-		 &tco_driver_api);
+DEVICE_DT_DEFINE(TCO_WDT_NODE, wdt_init, NULL, &wdt_data, &wdt_config, POST_KERNEL,
+		 CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &tco_driver_api);

--- a/include/zephyr/acpi/acpi.h
+++ b/include/zephyr/acpi/acpi.h
@@ -10,10 +10,10 @@
 
 #define ACPI_RES_INVALID ACPI_RESOURCE_TYPE_MAX
 
-#define ACPI_DRHD_FLAG_INCLUDE_PCI_ALL			BIT(0)
-#define ACPI_DMAR_FLAG_INTR_REMAP				BIT(0)
-#define ACPI_DMAR_FLAG_X2APIC_OPT_OUT			BIT(1)
-#define ACPI_DMAR_FLAG_DMA_CTRL_PLATFORM_OPT_IN	BIT(2)
+#define ACPI_DRHD_FLAG_INCLUDE_PCI_ALL          BIT(0)
+#define ACPI_DMAR_FLAG_INTR_REMAP               BIT(0)
+#define ACPI_DMAR_FLAG_X2APIC_OPT_OUT           BIT(1)
+#define ACPI_DMAR_FLAG_DMA_CTRL_PLATFORM_OPT_IN BIT(2)
 
 struct acpi_dev {
 	ACPI_HANDLE handle;
@@ -158,8 +158,7 @@ int acpi_madt_entry_get(int type, struct acpi_subtable_header **tables, int *num
  * @param tables pointer to the dmar id structure
  * @return return 0 on success or error code
  */
-int acpi_dmar_entry_get(enum AcpiDmarType type,
-	struct acpi_subtable_header **tables);
+int acpi_dmar_entry_get(enum AcpiDmarType type, struct acpi_subtable_header **tables);
 
 /**
  * @brief retrieve acpi DRHD info for the given scope.
@@ -172,7 +171,7 @@ int acpi_dmar_entry_get(enum AcpiDmarType type,
  * @return return 0 on success or error code
  */
 int acpi_drhd_get(enum AcpiDmarScopeType scope, struct acpi_dmar_device_scope *dev_scope,
-	union acpi_dmar_id *dmar_id, int *num_inst, int max_inst);
+		  union acpi_dmar_id *dmar_id, int *num_inst, int max_inst);
 
 /**
  * @brief Retrieve lapic info for a specific cpu.

--- a/include/zephyr/arch/x86/arch_inlines.h
+++ b/include/zephyr/arch/x86/arch_inlines.h
@@ -19,9 +19,7 @@ static inline struct _cpu *arch_curr_cpu(void)
 {
 	struct _cpu *cpu;
 
-	__asm__ volatile("movq %%gs:(%c1), %0"
-			 : "=r" (cpu)
-			 : "i" (offsetof(x86_tss64_t, cpu)));
+	__asm__ volatile("movq %%gs:(%c1), %0" : "=r"(cpu) : "i"(offsetof(x86_tss64_t, cpu)));
 
 	return cpu;
 }

--- a/lib/acpi/acpi.c
+++ b/lib/acpi/acpi.c
@@ -223,8 +223,8 @@ static ACPI_STATUS acpi_enable_pic_mode(void)
 	return status;
 }
 
-static int acpi_get_irq_table(struct acpi *bus, char *bus_name,
-				ACPI_PCI_ROUTING_TABLE *rt_table, uint32_t rt_size)
+static int acpi_get_irq_table(struct acpi *bus, char *bus_name, ACPI_PCI_ROUTING_TABLE *rt_table,
+			      uint32_t rt_size)
 {
 	ACPI_BUFFER rt_buffer;
 	ACPI_NAMESPACE_NODE *node;
@@ -492,8 +492,7 @@ int acpi_current_resource_free(ACPI_RESOURCE *res)
 	return 0;
 }
 
-int acpi_get_irq_routing_table(char *bus_name,
-			       ACPI_PCI_ROUTING_TABLE *rt_table, size_t rt_size)
+int acpi_get_irq_routing_table(char *bus_name, ACPI_PCI_ROUTING_TABLE *rt_table, size_t rt_size)
 {
 	int ret;
 
@@ -721,7 +720,7 @@ int acpi_dmar_entry_get(enum AcpiDmarType type, struct acpi_subtable_header **ta
 }
 
 int acpi_drhd_get(enum AcpiDmarScopeType scope, struct acpi_dmar_device_scope *dev_scope,
-	union acpi_dmar_id *dmar_id, int *num_inst, int max_inst)
+		  union acpi_dmar_id *dmar_id, int *num_inst, int max_inst)
 {
 	uintptr_t offset = sizeof(ACPI_DMAR_HARDWARE_UNIT);
 	uint32_t i = 0;
@@ -755,7 +754,7 @@ int acpi_drhd_get(enum AcpiDmarScopeType scope, struct acpi_dmar_device_scope *d
 		if (scope == subtable->EntryType) {
 			num_path = (subtable->Length - 6u) / 2u;
 			dev_path = ACPI_ADD_PTR(ACPI_DMAR_PCI_PATH, subtable,
-				sizeof(ACPI_DMAR_DEVICE_SCOPE));
+						sizeof(ACPI_DMAR_DEVICE_SCOPE));
 
 			while (num_path--) {
 				if (i >= max_inst) {

--- a/lib/acpi/acpi_shell.c
+++ b/lib/acpi/acpi_shell.c
@@ -35,23 +35,23 @@ static void dump_dev_res(const struct shell *sh, ACPI_RESOURCE *res_lst)
 			shell_print(sh, "\nACPI_RESOURCE_TYPE_IRQ\n\n");
 			ACPI_RESOURCE_IRQ *irq_res = &res->Data.Irq;
 
-			shell_print(sh,
+			shell_print(
+				sh,
 				"DescriptorLength: %x, Triggering:%x, Polarity:%x, Shareable:%x,",
-			       irq_res->DescriptorLength, irq_res->Triggering, irq_res->Polarity,
-			       irq_res->Shareable);
-			shell_print(sh,
-				"InterruptCount:%d, Interrupts[0]:%x\n", irq_res->InterruptCount,
-			       irq_res->Interrupts[0]);
+				irq_res->DescriptorLength, irq_res->Triggering, irq_res->Polarity,
+				irq_res->Shareable);
+			shell_print(sh, "InterruptCount:%d, Interrupts[0]:%x\n",
+				    irq_res->InterruptCount, irq_res->Interrupts[0]);
 			break;
 		case ACPI_RESOURCE_TYPE_IO:
 			ACPI_RESOURCE_IO * io_res = &res->Data.Io;
 
 			shell_print(sh, "\n ACPI_RESOURCE_TYPE_IO\n");
 			shell_print(sh,
-				"IoDecode: %x, Alignment:%x, AddressLength:%x, Minimum:%x,Maximum:%x\n",
-				   io_res->IoDecode, io_res->Alignment,
-				   io_res->AddressLength, io_res->Minimum,
-				   io_res->Maximum);
+				    "IoDecode: %x, Alignment:%x, AddressLength:%x, "
+				    "Minimum:%x,Maximum:%x\n",
+				    io_res->IoDecode, io_res->Alignment, io_res->AddressLength,
+				    io_res->Minimum, io_res->Maximum);
 			break;
 		case ACPI_RESOURCE_TYPE_DMA:
 			shell_print(sh, "ACPI_RESOURCE_TYPE_DMA\n\n");
@@ -75,8 +75,8 @@ static void dump_dev_res(const struct shell *sh, ACPI_RESOURCE *res_lst)
 			ACPI_RESOURCE_MEMORY32 * mem_res = &res->Data.Memory32;
 
 			shell_print(sh, "\nACPI_RESOURCE_TYPE_MEMORY32\n\n");
-			shell_print(sh, "Minimum:%x, Maximum:%x\n",
-				mem_res->Minimum, mem_res->Maximum);
+			shell_print(sh, "Minimum:%x, Maximum:%x\n", mem_res->Minimum,
+				    mem_res->Maximum);
 			break;
 		case ACPI_RESOURCE_TYPE_FIXED_MEMORY32:
 			ACPI_RESOURCE_FIXED_MEMORY32 * fix_mem_res = &res->Data.FixedMemory32;
@@ -92,15 +92,14 @@ static void dump_dev_res(const struct shell *sh, ACPI_RESOURCE *res_lst)
 
 			shell_print(sh, "\nACPI_RESOURCE_TYPE_ADDRESS32\n\n");
 			shell_print(sh, "Minimum:%x, Maximum:%x\n", add_res->Address.Minimum,
-				add_res->Address.Maximum);
+				    add_res->Address.Maximum);
 			break;
 		case ACPI_RESOURCE_TYPE_ADDRESS64:
 			ACPI_RESOURCE_ADDRESS64 * add_res64 = &res->Data.Address64;
 
 			shell_print(sh, "\nACPI_RESOURCE_TYPE_ADDRESS64\n\n");
-			shell_print(sh,
-					"Minimum:%llx, Maximum:%llx\n", add_res64->Address.Minimum,
-						add_res64->Address.Maximum);
+			shell_print(sh, "Minimum:%llx, Maximum:%llx\n", add_res64->Address.Minimum,
+				    add_res64->Address.Maximum);
 			break;
 		case ACPI_RESOURCE_TYPE_EXTENDED_ADDRESS64:
 			shell_print(sh, "ACPI_RESOURCE_TYPE_EXTENDED_ADDRESS64\n\n");
@@ -130,8 +129,7 @@ static void dump_dev_res(const struct shell *sh, ACPI_RESOURCE *res_lst)
 			shell_print(sh, "ACPI_RESOURCE_TYPE_PIN_GROUP\n\n");
 			break;
 		case ACPI_RESOURCE_TYPE_PIN_GROUP_FUNCTION:
-			shell_print(sh,
-					"ACPI_RESOURCE_TYPE_PIN_GROUP_FUNCTION\n\n");
+			shell_print(sh, "ACPI_RESOURCE_TYPE_PIN_GROUP_FUNCTION\n\n");
 			break;
 		case ACPI_RESOURCE_TYPE_PIN_GROUP_CONFIG:
 			shell_print(sh, "ACPI_RESOURCE_TYPE_PIN_GROUP_CONFIG\n\n");
@@ -198,8 +196,7 @@ static int dump_prt(const struct shell *sh, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	status = acpi_get_irq_routing_table(argv[1],
-						irq_prt_table, sizeof(irq_prt_table));
+	status = acpi_get_irq_routing_table(argv[1], irq_prt_table, sizeof(irq_prt_table));
 	if (status) {
 		return status;
 	}
@@ -207,9 +204,8 @@ static int dump_prt(const struct shell *sh, size_t argc, char **argv)
 	prt = irq_prt_table;
 	for (cnt = 0; prt->Length; cnt++) {
 		shell_print(sh, "[%02X] PCI IRQ Routing Table Package\n", cnt);
-		shell_print(sh,
-			"DevNum: %lld Pin:%d IRQ: %d\n", (prt->Address >> 16) & 0xFFFF, prt->Pin,
-		       prt->SourceIndex);
+		shell_print(sh, "DevNum: %lld Pin:%d IRQ: %d\n", (prt->Address >> 16) & 0xFFFF,
+			    prt->Pin, prt->SourceIndex);
 
 		prt = ACPI_ADD_PTR(ACPI_PCI_ROUTING_TABLE, prt, prt->Length);
 	}
@@ -253,8 +249,8 @@ static int read_table(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	shell_print(sh, "ACPI Table Info:\n");
-	shell_print(sh, "Signature: %4s Table Length:%d Revision:%d OemId:%s\n",
-		table->Signature, table->Length, table->Revision, table->OemId);
+	shell_print(sh, "Signature: %4s Table Length:%d Revision:%d OemId:%s\n", table->Signature,
+		    table->Length, table->Revision, table->OemId);
 
 	return 0;
 }
@@ -272,8 +268,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(enum, NULL,
 		  "enumerate device using hid (for enum HPET timer device,eg:acpi enum PNP0103)",
 		  enum_dev),
-	SHELL_CMD(rd_table, NULL,
-		  "read acpi table (for read mad table, eg:acpi read_table APIC)",
+	SHELL_CMD(rd_table, NULL, "read acpi table (for read mad table, eg:acpi read_table APIC)",
 		  read_table),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );


### PR DESCRIPTION
Fixes for error and warning reported by latest clang format tool on various drivers and subsystem such as gpio, wdt, rtc, ioapic, lapic and acpi.