### PR TITLE
[RFC] drivers: intc: plic: multi-instance support - approach 2

### DIFF
--- a/arch/common/sw_isr_common.c
+++ b/arch/common/sw_isr_common.c
@@ -147,4 +147,18 @@ int __weak arch_irq_connect_dynamic(unsigned int irq,
 	return irq;
 }
 
+int __weak arch_irq_intc_connect_dynamic(unsigned int irq,
+					 unsigned int priority,
+					 void (*routine)(const void *),
+					 const void *parameter,
+					 uint32_t flags,
+					 const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	arch_irq_connect_dynamic(irq, priority, routine, parameter, flags);
+
+	return irq;
+}
+
 #endif /* CONFIG_DYNAMIC_INTERRUPTS */

--- a/arch/riscv/core/irq_manage.c
+++ b/arch/riscv/core/irq_manage.c
@@ -24,6 +24,8 @@ FUNC_NORETURN void z_irq_spurious(const void *unused)
 	LOG_ERR("Spurious interrupt detected! IRQ: %ld", mcause);
 #if defined(CONFIG_RISCV_HAS_PLIC)
 	if (mcause == RISCV_MACHINE_EXT_IRQ) {
+		LOG_ERR("PLIC interrupt instance causing the IRQ: %p",
+			riscv_plic_get_dev());
 		LOG_ERR("PLIC interrupt line causing the IRQ: %d",
 			riscv_plic_get_irq());
 	}
@@ -32,23 +34,28 @@ FUNC_NORETURN void z_irq_spurious(const void *unused)
 }
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
+int arch_irq_intc_connect_dynamic(unsigned int irq, unsigned int priority,
+				  void (*routine)(const void *parameter),
+				  const void *parameter, uint32_t flags,
+				  const struct device *dev)
+{
+#if defined(CONFIG_RISCV_HAS_PLIC)
+	z_riscv_plic_isr_intc_install(irq, priority, routine, parameter, dev);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(flags);
+	z_isr_install(irq, routine, parameter);
+	ARG_UNUSED(priority);
+#endif
+	return irq;
+}
+
 int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 			     void (*routine)(const void *parameter),
 			     const void *parameter, uint32_t flags)
 {
-	ARG_UNUSED(flags);
+	arch_irq_intc_connect_dynamic(irq, priority, routine, parameter, flags, NULL);
 
-	z_isr_install(irq, routine, parameter);
-
-#if defined(CONFIG_RISCV_HAS_PLIC)
-	if (irq_get_level(irq) == 2) {
-		irq = irq_from_level_2(irq);
-
-		riscv_plic_set_priority(irq, priority);
-	}
-#else
-	ARG_UNUSED(priority);
-#endif
 	return irq;
 }
 #endif /* CONFIG_DYNAMIC_INTERRUPTS */

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -5,6 +5,15 @@
 
 menu "Interrupt controller drivers"
 
+config MULTI_INSTANCE_INTC
+	bool
+
+config HAS_MUTLI_INSTANCE_INTC
+	bool "placeholder"
+	select MULTI_INSTANCE_INTC
+	help
+	  placeholder
+
 config ARCV2_INTERRUPT_UNIT
 	bool "ARCv2 Interrupt Unit"
 	default y

--- a/drivers/interrupt_controller/Kconfig.plic
+++ b/drivers/interrupt_controller/Kconfig.plic
@@ -10,9 +10,3 @@ config PLIC
 	help
 	  Platform Level Interrupt Controller provides support
 	  for external interrupt lines defined by the RISC-V SoC.
-
-config PLIC_SUPPORTS_EDGE_IRQ
-	bool "The given interrupt controller supports edge interrupts"
-	help
-	  The given interrupt controller supports edge triggered
-	  interrupts.

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -232,6 +232,9 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "NS16550(s) in DT need CONFIG_PCIE");
 
 #define IIRC(dev) (((struct uart_ns16550_dev_data *)(dev)->data)->iir_cache)
 
+#define NS16550_IRQ_CONNECT(n, irq_p, priority_p, isr_p, isr_param_p, flags_p) \
+	IRQ_INTC_CONNECT(DT_INST_INTC_PARENT(n), irq_p, priority_p, isr_p, isr_param_p, flags_p)
+
 /* device config */
 struct uart_ns16550_device_config {
 	union {
@@ -1237,7 +1240,8 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 	static void irq_config_func##n(const struct device *dev)              \
 	{                                                                     \
 		ARG_UNUSED(dev);                                              \
-		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),	      \
+		NS16550_IRQ_CONNECT(DT_INST_INTC_PARENT(n), DT_INST_IRQN(n),  \
+				    DT_INST_IRQ(n, priority),                 \
 			    uart_ns16550_isr, DEVICE_DT_INST_GET(n),	      \
 			    UART_NS16550_IRQ_FLAGS(n));			      \
 		irq_enable(DT_INST_IRQN(n));                                  \

--- a/dts/bindings/interrupt-controller/sifive,plic-1.0.0.yaml
+++ b/dts/bindings/interrupt-controller/sifive,plic-1.0.0.yaml
@@ -12,7 +12,8 @@ properties:
     type: int
     description: Number of external interrupts supported
     required: true
-  riscv,trigger-reg-offset:
-    type: int
-    default: 4224
-    description: Offset of the trigger type register if supported
+
+  support-edge-interrupt:
+    type: boolean
+    description: |
+      Indicates that this controller supports edge interrupt.

--- a/dts/bindings/interrupt-controller/sifive,plic-1.0.0.yaml
+++ b/dts/bindings/interrupt-controller/sifive,plic-1.0.0.yaml
@@ -17,3 +17,10 @@ properties:
     type: boolean
     description: |
       Indicates that this controller supports edge interrupt.
+
+  isr-offset:
+    type: int
+    default: 0
+    description: |
+      Offset for the ISR in multi-instance interrupt controller setup.
+      Increase according to the index in the devicetree.

--- a/dts/riscv/andes/andes_v5_ae350.dtsi
+++ b/dts/riscv/andes/andes_v5_ae350.dtsi
@@ -171,10 +171,7 @@
 			#address-cells = <1>;
 			#interrupt-cells = <2>;
 			interrupt-controller;
-			reg = <	0xe4000000 0x00001000
-				0xe4002000 0x00000800
-				0xe4200000 0x00010000 >;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <	0xe4000000 0x04000000 >;
 			riscv,max-priority = <255>;
 			riscv,ndev = <1023>;
 			interrupts-extended = <&CPU0_intc 11 &CPU1_intc 11

--- a/dts/riscv/efinix/sapphire_soc.dtsi
+++ b/dts/riscv/efinix/sapphire_soc.dtsi
@@ -55,10 +55,7 @@
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = < 0xf8c00000 0x00001000
-					0xf8c02000 0x00000800
-					0xf8e00000 0x00010000 >;
-			reg-names = "prio", "irq_en", "reg";
+			reg = < 0xf8c00000 0x04000000 >;
 			riscv,max-priority = <3>;
 			riscv,ndev = <32>;
 		};

--- a/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
+++ b/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
@@ -75,10 +75,7 @@
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = <0x48000000 0x00001000
-			       0x48002000 0x00001000
-			       0x48200000 0x00000008>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x48000000 0x04000000>;
 			riscv,max-priority = <7>;
 			riscv,ndev = <184>;
 			status = "okay";

--- a/dts/riscv/microchip/microchip-miv.dtsi
+++ b/dts/riscv/microchip/microchip-miv.dtsi
@@ -54,10 +54,7 @@
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = <0x40000000 0x2000
-			       0x40002000 0x1fe000
-			       0x40200000 0x2000000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x40000000 0x04000000>;
 			riscv,max-priority = <1>;
 			riscv,ndev = <31>;
 		};

--- a/dts/riscv/microchip/mpfs-icicle.dtsi
+++ b/dts/riscv/microchip/mpfs-icicle.dtsi
@@ -121,10 +121,7 @@
 			interrupt-controller;
 			interrupts-extended = <&hlic0 11
 						&hlic1 11>;
-			reg = <0x0c000000 0x00002000
-					0x0c002000 0x001fe000
-					0x0c200000 0x3e000000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x0c000000 0x04000000>;
 			riscv,max-priority = <7>;
 			riscv,ndev = <187>;
 		};

--- a/dts/riscv/sifive/riscv32-fe310.dtsi
+++ b/dts/riscv/sifive/riscv32-fe310.dtsi
@@ -123,10 +123,7 @@
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = <0x0c000000 0x00002000
-			       0x0c002000 0x001fe000
-			       0x0c200000 0x03e00000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x0c000000 0x04000000>;
 			riscv,max-priority = <7>;
 			riscv,ndev = <52>;
 		};

--- a/dts/riscv/sifive/riscv64-fu540.dtsi
+++ b/dts/riscv/sifive/riscv64-fu540.dtsi
@@ -120,10 +120,7 @@
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = <0x0c000000 0x00002000
-			       0x0c002000 0x001fe000
-			       0x0c200000 0x03e00000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x0c000000 0x04000000>;
 			riscv,max-priority = <7>;
 			riscv,ndev = <52>;
 		};

--- a/dts/riscv/sifive/riscv64-fu740.dtsi
+++ b/dts/riscv/sifive/riscv64-fu740.dtsi
@@ -142,10 +142,7 @@
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = <0x0 0x0c000000 0x0 0x00002000
-			       0x0 0x0c002000 0x0 0x001fe000
-			       0x0 0x0c200000 0x0 0x03e00000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x0 0x0c000000 0x0 0x04000000>;
 			riscv,max-priority = <7>;
 			riscv,ndev = <52>;
 		};

--- a/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
+++ b/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
@@ -129,10 +129,7 @@
 			interrupt-controller;
 			interrupts-extended = <&cpu0intctrl 11 &cpu0intctrl 9
 					       &cpu1intctrl 11 &cpu1intctrl 9 >;
-			reg = <0x0 0x0c000000 0x0 0x00002000
-			       0x0 0x0c002000 0x0 0x001fe000
-			       0x0 0x0c200000 0x0 0x03e00000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x0 0x0c000000 0x0 0x04000000>;
 			riscv,max-priority = <7>;
 			riscv,ndev = <127>;
 		};

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -132,10 +132,7 @@
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
 			interrupt-parent = <&cpu0>;
-			reg = < 0xe4000000 0x00001000
-					0xe4002000 0x00000800
-					0xe4200000 0x00010000 >;
-			reg-names = "prio", "irq_en", "reg";
+			reg = < 0xe4000000 0x00210000 >;
 			riscv,max-priority = <3>;
 			riscv,ndev = <63>;
 		};

--- a/dts/riscv/virt.dtsi
+++ b/dts/riscv/virt.dtsi
@@ -165,10 +165,7 @@
 		plic: interrupt-controller@c000000 {
 			riscv,max-priority = <7>;
 			riscv,ndev = < 0x35 >;
-			reg = <0x0c000000 0x00002000
-			       0x0c002000 0x001fe000
-			       0x0c200000 0x03e00000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x0c000000 0x04000000>;
 			interrupts-extended = <
 				&hlic0 0x0b &hlic0 0x09
 				&hlic1 0x0b &hlic1 0x09

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -4191,6 +4191,13 @@
 	DT_INST_PHA_HAS_CELL_AT_IDX(inst, pha, 0, cell)
 
 /**
+ * @brief `DT_DRV_COMPAT` instance's interrupt-parent property
+ * @param inst instance number
+ * @return interrupt-parent property if available in @p inst, 0 otherwise.
+ */
+#define DT_INST_INTC_PARENT(inst) DT_INST_PROP_OR(inst, interrupt_parent, 0)
+
+/**
  * @brief is index valid for interrupt property on a `DT_DRV_COMPAT` instance?
  * @param inst instance number
  * @param idx logical index into the interrupt specifier array

--- a/include/zephyr/drivers/interrupt_controller/riscv_plic.h
+++ b/include/zephyr/drivers/interrupt_controller/riscv_plic.h
@@ -15,18 +15,57 @@
 #include <zephyr/device.h>
 
 /**
+ * @brief Install the ISR into the table
+ *
+ * @param irq Interrupt ID
+ * @param routine Pointer to the ISR handler
+ * @param param Pointer to the argument to be passed into the ISR handler
+ */
+void z_riscv_plic_isr_install(unsigned int irq, unsigned int priority,
+			      void (*routine)(const void *), const void *param);
+
+/**
+ * @brief Install the ISR of an interrupt controller into the table
+ *
+ * See @ref z_riscv_plic_isr_install for more info
+ *
+ * @param dev Interrupt controller of the irq, the first instance will be used if this is NULL
+ */
+void z_riscv_plic_isr_intc_install(unsigned int irq,
+				   unsigned int priority, void (*routine)(const void *),
+				   const void *param, const struct device *dev);
+
+/**
  * @brief Enable interrupt
  *
  * @param irq interrupt ID
  */
-void riscv_plic_irq_enable(uint32_t irq);
+void riscv_plic_irq_enable(uint32_t irq, const struct device *dev);
+
+/**
+ * @brief Enable interrupt of an interrupt controller
+ *
+ * See @ref riscv_plic_irq_enable for more info
+ *
+ * @param dev Interrupt controller of the irq, the first instance will be used if this is NULL
+ */
+void riscv_plic_irq_intc_enable(const struct device *dev, uint32_t irq);
 
 /**
  * @brief Disable interrupt
  *
  * @param irq interrupt ID
  */
-void riscv_plic_irq_disable(uint32_t irq);
+void riscv_plic_irq_disable(uint32_t irq, const struct device *dev);
+
+/**
+ * @brief Disable interrupt of an interrupt controller
+ *
+ * See @ref riscv_plic_irq_disable for more info
+ *
+ * @param dev Interrupt controller of the irq, the first instance will be used if this is NULL
+ */
+void riscv_plic_irq_intc_disable(const struct device *dev, uint32_t irq);
 
 /**
  * @brief Check if an interrupt is enabled
@@ -34,7 +73,16 @@ void riscv_plic_irq_disable(uint32_t irq);
  * @param irq interrupt ID
  * @return Returns true if interrupt is enabled, false otherwise
  */
-int riscv_plic_irq_is_enabled(uint32_t irq);
+int riscv_plic_irq_is_enabled(uint32_t irq, const struct device *dev);
+
+/**
+ * @brief Check if an interrupt of an interrupt controller is enabled
+ *
+ * See @ref riscv_plic_irq_is_enabled for more info
+ *
+ * @param dev Interrupt controller of the irq, the first instance will be used if this is NULL
+ */
+int riscv_plic_irq_intc_is_enabled(uint32_t irq, const struct device *dev);
 
 /**
  * @brief Set interrupt priority
@@ -45,10 +93,26 @@ int riscv_plic_irq_is_enabled(uint32_t irq);
 void riscv_plic_set_priority(uint32_t irq, uint32_t prio);
 
 /**
+ * @brief Set interrupt priority of an interrupt controller
+ *
+ * See @ref riscv_plic_set_priority for more info
+ *
+ * @param dev Interrupt controller of the irq, the first instance will be used if this is NULL
+ */
+void riscv_plic_intc_set_priority(uint32_t irq, uint32_t priority, const struct device *dev);
+
+/**
  * @brief Get active interrupt ID
  *
  * @return Returns the ID of an active interrupt
  */
 int riscv_plic_get_irq(void);
+
+/**
+ * @brief Get the interrupt controller of the active interrupt ID
+ *
+ * @return Returns the device struct of the interrupt controller
+ */
+const struct device *riscv_plic_get_dev(void);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_RISCV_PLIC_H_ */

--- a/include/zephyr/drivers/interrupt_controller/riscv_plic.h
+++ b/include/zephyr/drivers/interrupt_controller/riscv_plic.h
@@ -12,6 +12,8 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_RISCV_PLIC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_RISCV_PLIC_H_
 
+#include <zephyr/device.h>
+
 /**
  * @brief Enable interrupt
  *

--- a/include/zephyr/irq.h
+++ b/include/zephyr/irq.h
@@ -48,6 +48,20 @@ extern "C" {
 #define IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 	ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p)
 
+#ifdef CONFIG_MULTI_INSTANCE_INTC
+/**
+ * @brief Initialize an interrupt handler to an interrupt controller
+ *
+ * For more information, see @ref IRQ_CONNECT
+ *
+ * @param intc_p Interrupt controller node id
+ */
+#define IRQ_INTC_CONNECT(intc_p, irq_p, priority_p, isr_p, isr_param_p, flags_p) \
+	ARCH_IRQ_INTC_CONNECT(intc_p, irq_p, priority_p, isr_p, isr_param_p, flags_p)
+#else
+#define IRQ_INTC_CONNECT(_, ...) IRQ_CONNECT(__VA_ARGS__)
+#endif
+
 /**
  * Configure a dynamic interrupt.
  *
@@ -68,6 +82,24 @@ irq_connect_dynamic(unsigned int irq, unsigned int priority,
 {
 	return arch_irq_connect_dynamic(irq, priority, routine, parameter,
 					flags);
+}
+
+/**
+ * Configure a dynamic interrupt for an instance of the interrupt controller.
+ *
+ * See @ref irq_connect_dynamic for more information.
+ *
+ * @param dev Interrupt controller device
+ *
+ * @return See @ref irq_connect_dynamic
+ */
+static inline int
+irq_intc_connect_dynamic(unsigned int irq, unsigned int priority,
+			 void (*routine)(const void *parameter),
+			 const void *parameter, uint32_t flags,
+			 const struct device *dev)
+{
+	return arch_irq_intc_connect_dynamic(irq, priority, routine, parameter, flags, dev);
 }
 
 /**
@@ -439,6 +471,33 @@ static inline unsigned int irq_parent_level_3(unsigned int irq)
  * @return interrupt enable state, true or false
  */
 #define irq_is_enabled(irq) arch_irq_is_enabled(irq)
+
+/**
+ * @brief Enable an interrupt controller's IRQ.
+ *
+ * See @ref irq_enable for more information.
+ *
+ * @param intc Interrupt controller.
+ */
+#define irq_intc_enable(intc, irq) arch_irq_intc_enable(intc, irq)
+
+/**
+ * @brief Disable an interrupt controller's IRQ.
+ *
+ * See @ref irq_disable for more information.
+ *
+ * @param intc Interrupt controller.
+ */
+#define irq_intc_disable(intc, irq) arch_irq_intc_disable(intc, irq)
+
+/**
+ * @brief Get an interrupt controller's IRQ enable state.
+ *
+ * See @ref irq_is_enabled for more information.
+ *
+ * @param intc interrupt controller.
+ */
+#define irq_intc_is_enabled(intc, irq) arch_irq_intc_is_enabled(intc, irq)
 
 /**
  * @}

--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -31,6 +31,7 @@
 #include <stddef.h>
 #include <zephyr/types.h>
 #include <zephyr/arch/cpu.h>
+#include <zephyr/device.h>
 #include <zephyr/irq_offload.h>
 
 #ifdef __cplusplus
@@ -294,6 +295,8 @@ static inline bool arch_irq_unlocked(unsigned int key);
  */
 void arch_irq_disable(unsigned int irq);
 
+void arch_irq_intc_disable(unsigned int irq, const struct device *dev);
+
 /**
  * Enable the specified interrupt line
  *
@@ -301,12 +304,16 @@ void arch_irq_disable(unsigned int irq);
  */
 void arch_irq_enable(unsigned int irq);
 
+void arch_irq_intc_enable(unsigned int irq, const struct device *dev);
+
 /**
  * Test if an interrupt line is enabled
  *
  * @see irq_is_enabled()
  */
 int arch_irq_is_enabled(unsigned int irq);
+
+int arch_irq_intc_is_enabled(unsigned int irq, const struct device *dev);
 
 /**
  * Arch-specific hook to install a dynamic interrupt.
@@ -322,6 +329,17 @@ int arch_irq_is_enabled(unsigned int irq);
 int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 			     void (*routine)(const void *parameter),
 			     const void *parameter, uint32_t flags);
+
+/**
+ * Arch-specific hook to install a dynamic interrupt to an interrupt
+ * controller. See @ref arch_irq_connect_dynamic for more info.
+ *
+ * @param dev Interrupt controller of the IRQ
+ */
+int arch_irq_intc_connect_dynamic(unsigned int irq, unsigned int priority,
+				  void (*routine)(const void *parameter),
+				  const void *parameter, uint32_t flags,
+				  const struct device *dev);
 
 /**
  * Arch-specific hook to dynamically uninstall a shared interrupt.


### PR DESCRIPTION
This PR add multi-instance support to the `intc_plic` driver. As all the IRQs are sharing the same ISR table, 2nd levels and onwards IRQs in one instance of a controller can collide with another in the ISR table.

To avoid this, the ISR should have an offset as large as the sum of the number of IRQs in the previous instances in the devicetree, so they dont get installed to the same index.

The RISCV's `arch_irq_connect_dynamic` then get this offset from the controller to install the ISR accordingly.

This PR aims to get a look and feel of the approach.

___


1. ~~Why dont we just let interrupt controller to install the ISR?~~ practiced in this PR, for RISCV `intc_plic` only
