### PR TITLE
logging: Fix increase of code size when CONFIG_LOG=n

### DIFF
--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -324,10 +324,11 @@ void z_log_vprintk(const char *fmt, va_list ap);
  * is enabled, override level is set or module specific level is set (not off).
  */
 #define Z_DO_LOG_MODULE_REGISTER(...) \
-	Z_LOG_EVAL(CONFIG_LOG_OVERRIDE_LEVEL, \
+	COND_CODE_1(CONFIG_LOG, \
+		(Z_LOG_EVAL(CONFIG_LOG_OVERRIDE_LEVEL, \
 		   (1), \
 		   (Z_LOG_EVAL(_LOG_LEVEL_RESOLVE(__VA_ARGS__), (1), (0))) \
-		  )
+		  )), (0))
 
 /**
  * @brief Create module-specific state and register the module with Logger.


### PR DESCRIPTION
When logging was disabled there was still a code size increase due to log module structure being kept in the memory even though it was unused. When CONFIG_LOG=n there should be nothing in the memory footprint related to the logging.

Fixes #62194.