### PR TITLE
Modem subsys small corrections

### DIFF
--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -144,7 +144,7 @@ struct modem_chat_script {
 };
 
 #define MODEM_CHAT_SCRIPT_DEFINE(_sym, _script_chats, _abort_matches, _callback, _timeout)         \
-	static struct modem_chat_script _sym = {                                                   \
+	const static struct modem_chat_script _sym = {                                             \
 		.name = #_sym,                                                                     \
 		.script_chats = _script_chats,                                                     \
 		.script_chats_size = ARRAY_SIZE(_script_chats),                                    \

--- a/subsys/modem/backends/modem_backend_uart.c
+++ b/subsys/modem/backends/modem_backend_uart.c
@@ -36,18 +36,18 @@ struct modem_pipe *modem_backend_uart_init(struct modem_backend_uart *backend,
 	backend->uart = config->uart;
 	k_work_init(&backend->receive_ready_work, modem_backend_uart_receive_ready_handler);
 
-#ifdef CONFIG_UART_ASYNC_API
+#ifdef CONFIG_MODEM_BACKEND_UART_ASYNC
 	if (modem_backend_uart_async_is_supported(backend)) {
 		modem_backend_uart_async_init(backend, config);
 		return &backend->pipe;
 	}
-#endif /* CONFIG_UART_ASYNC_API */
+#endif /* CONFIG_MODEM_BACKEND_UART_ASYNC */
 
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#ifdef CONFIG_MODEM_BACKEND_UART_ISR
 	modem_backend_uart_isr_init(backend, config);
 
 	return &backend->pipe;
-#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+#endif /* CONFIG_MODEM_BACKEND_UART_ISR */
 
 	__ASSERT(0, "No supported UART API");
 


### PR DESCRIPTION
These changes add some trivial fixes to the modem subsystem.

- make chat scripts const, reduce usage of RAM
- using configs from modem subsys, instead of uart, the previous version can make some linker issues when isr uart is enabled in the driver but disabled in modem subsys