### PR TITLE
tests: twister: print build issues inline

### DIFF
--- a/scripts/tests/twister_blackbox/test_qemu.py
+++ b/scripts/tests/twister_blackbox/test_qemu.py
@@ -85,7 +85,7 @@ class TestQEMU:
         ]
     )
     def test_emulation_only(self, capfd, test_path, test_platforms, expected):
-        args = ['-T', test_path, '--emulation-only'] + \
+        args = ['-i', '-T', test_path, '--emulation-only'] + \
                [val for pair in zip(
                    ['-p'] * len(test_platforms), test_platforms
                ) for val in pair]


### PR DESCRIPTION
Use -i to print errors inline.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
