### PR TITLE
.github: workflows: Black box testing fix

### DIFF
--- a/.github/workflows/blackbox_tests.yml
+++ b/.github/workflows/blackbox_tests.yml
@@ -46,6 +46,15 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Environment Setup
+      run: |
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+        west init -l . || true
+        west config --global update.narrow true
+        west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
+        west forall -c 'git reset --hard HEAD'
+
     - name: Set Up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/scripts/tests/twister_blackbox/test_qemu.py
+++ b/scripts/tests/twister_blackbox/test_qemu.py
@@ -85,7 +85,7 @@ class TestQEMU:
         ]
     )
     def test_emulation_only(self, capfd, test_path, test_platforms, expected):
-        args = ['-T', test_path, '--emulation-only'] + \
+        args = ['-i', '-T', test_path, '--emulation-only'] + \
                [val for pair in zip(
                    ['-p'] * len(test_platforms), test_platforms
                ) for val in pair]


### PR DESCRIPTION
This fix pulls West in black box testing.
Previously changes in West could break it.
Additionally, it adds the `-i` flag, which adds inline bug reporting for qemu, for easier debugging later.