### PR TITLE
zephyr: Kconfig: SOC_GECKO_USE_RAIL_API option for RAIL for proprietary

### DIFF
--- a/soc/arm/silabs_exx32/Kconfig
+++ b/soc/arm/silabs_exx32/Kconfig
@@ -340,4 +340,13 @@ config SOC_GECKO_USE_RAIL
 	  hardware. This option enable the proper set of features to allow to properly compile
 	  with the RAIL blob.
 
+config SOC_GECKO_CUSTOM_RADIO_PHY
+	bool "Use RAIL for custom radio phy packet sending and receiving"
+	depends on SOC_GECKO_HAS_RADIO
+	select SOC_GECKO_USE_RAIL
+	help
+	  If enabled, RAIL can be used for user generated custom radio phy
+	  management, sending and receiving packets on radio phy. User has
+	  to provide the radio_config.c and radio_config.h files for the phy.
+
 endif # SOC_FAMILY_EXX32

--- a/west.yml
+++ b/west.yml
@@ -222,7 +222,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: d191d981c4eb20c0c7445a4061fcdbcfa686113a
+      revision: 72a67203f0b37dc2c12bfae5ddf05c991c0ab0a4
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Currently on zephyr, RAIL library is used only by Bluetooth applications, with this update, it will be able to be used for sample applications, that are using proprietary phys. Other wireless protocols and proprietary wireless communications will be added to zephyr system later.
With this update, the missing files will be also included and added to the source, that are needed for the Radio to be able to use the Radio Configurator generated c and h files for proprietary usage.

Second half of the PR can be found here: silab_hal: https://github.com/zephyrproject-rtos/hal_silabs/pull/39