### PR TITLE
Bluetooth: Mesh: add optional OOB info to ext scan report

### DIFF
--- a/subsys/bluetooth/mesh/rpr_srv.c
+++ b/subsys/bluetooth/mesh/rpr_srv.c
@@ -267,13 +267,15 @@ static void scan_ext_report_send(void)
 	bt_mesh_model_msg_init(&buf, RPR_OP_EXTENDED_SCAN_REPORT);
 	net_buf_simple_add_u8(&buf, BT_MESH_RPR_SUCCESS);
 	net_buf_simple_add_mem(&buf, srv.scan.dev->uuid, 16);
-	if (!(srv.scan.dev->flags & BT_MESH_RPR_UNPROV_FOUND)) {
+
+	if (srv.scan.dev->flags & BT_MESH_RPR_UNPROV_FOUND) {
+		net_buf_simple_add_le16(&buf, srv.scan.dev->oob);
+	} else {
 		LOG_DBG("not found");
 		goto send;
 	}
 
 	if (srv.scan.dev->flags & BT_MESH_RPR_UNPROV_EXT_ADV_RXD) {
-		net_buf_simple_add_le16(&buf, srv.scan.dev->oob);
 		net_buf_simple_add_mem(&buf, srv.scan.adv_data->data,
 				       srv.scan.adv_data->len);
 		LOG_DBG("adv data: %s",


### PR DESCRIPTION
Even though the OOB information is optional we can add it to extended scan report in cases there is detected unprovisoned devices.