### PR TITLE
drivers: spi: stm32h7: Add interrupt tests for H7

### DIFF
--- a/tests/drivers/spi/spi_loopback/overlay-stm32-spi-interrupt.conf
+++ b/tests/drivers/spi/spi_loopback/overlay-stm32-spi-interrupt.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023 Graphcore Ltd, All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI_STM32_INTERRUPT=y

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -78,6 +78,12 @@ tests:
     platform_allow:
       - nucleo_h743zi
       - nucleo_h753zi
+  drivers.spi.stm32_spi_interrupt.loopback:
+    extra_args: OVERLAY_CONFIG="overlay-stm32-spi-interrupt.conf"
+    filter: CONFIG_SOC_FAMILY_STM32
+    platform_allow:
+      - nucleo_h743zi
+      - nucleo_h753zi
   drivers.spi.gd32_spi_interrupt.loopback:
     extra_args: OVERLAY_CONFIG="overlay-gd32-spi-interrupt.conf"
     platform_allow:


### PR DESCRIPTION
This is a proposal to add interrupt tests for SPI STM32H7.

Test plan
=========
Connect an STM32H7 board to the PC with pins D11 and D12 connected.

Open a minicom or equivalent terminal to read the test report.

Execute the following commands:

```
rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_interrupt.loopback
west flash
```

And verify all tests pass.
