### PR TITLE
boards: Add lvgl pointer support on m5stack_core2

### DIFF
--- a/boards/xtensa/m5stack_core2/Kconfig.defconfig
+++ b/boards/xtensa/m5stack_core2/Kconfig.defconfig
@@ -39,11 +39,8 @@ config GPIO_HOGS_INIT_PRIORITY
 config INPUT_FT5336_INTERRUPT
 	default y if INPUT
 
-config KSCAN
-	default y if DISPLAY
-
 config INPUT
-	default y if KSCAN
+	default y
 
 config LV_COLOR_16_SWAP
 	default y if LVGL

--- a/boards/xtensa/m5stack_core2/m5stack_core2.dts
+++ b/boards/xtensa/m5stack_core2/m5stack_core2.dts
@@ -30,7 +30,6 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
 		zephyr,display = &ili9342c;
-		zephyr,keyboard-scan = &kscan_input;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,rtc = &pfc8563_rtc;
 	};
@@ -41,6 +40,11 @@
 			gpios = <&axp192_gpio 1 (GPIO_OPEN_DRAIN | GPIO_ACTIVE_LOW)>;
 			label = "Power LED";
 		};
+	};
+
+	lvgl_pointer {
+		compatible = "zephyr,lvgl-pointer-input";
+		input = <&ft5336_touch>;
 	};
 };
 
@@ -154,14 +158,10 @@
 		};
 	};
 
-	ft5336@38 {
+	ft5336_touch: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
 		int-gpios = <&gpio1 7 0>;
-
-		kscan_input: kscan-input {
-			compatible = "zephyr,kscan-input";
-		};
 	};
 };
 

--- a/boards/xtensa/m5stack_core2/m5stack_core2.dts
+++ b/boards/xtensa/m5stack_core2/m5stack_core2.dts
@@ -85,7 +85,7 @@
 
 &i2c0 {
 	status = "okay";
-	clock-frequency = <I2C_BITRATE_STANDARD>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-gpios = <&gpio0 21 GPIO_OPEN_DRAIN>;
 	scl-gpios = <&gpio0 22 GPIO_OPEN_DRAIN>;
 	pinctrl-0 = <&i2c0_default>;

--- a/samples/subsys/display/lvgl/boards/m5stack_core2.conf
+++ b/samples/subsys/display/lvgl/boards/m5stack_core2.conf
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_MAIN_STACK_SIZE=4096


### PR DESCRIPTION
Added lvgl-pointer definition in devicetree, to enable touch-support in lvgl applications.
Has been tested with latest lvgl hello world sample.