### PR TITLE
drivers: wdt_mcux_wwdt: Fix warning callback

### DIFF
--- a/drivers/watchdog/Kconfig.mcux
+++ b/drivers/watchdog/Kconfig.mcux
@@ -25,3 +25,15 @@ config WDT_MCUX_WWDT
 	depends on DT_HAS_NXP_LPC_WWDT_ENABLED
 	help
 	  Enable the mcux wwdt driver.
+
+if WDT_MCUX_WWDT
+
+config WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG
+	int "WWDT timeout warning interrupt configuration"
+	range 0 1023
+	default 0
+	help
+	  WWDT timeout warning interrupt time. The units are
+	  the number of watchdog counter ticks before timeout.
+
+endif # WDT_MCUX_WWDT


### PR DESCRIPTION
Warning callback by default is configured to happen at the same time as reset, which results in unexpected behavior from the point of view of Zephyr API. Return -ENOTSUP from install_timeout if trying to set up
callback with 0 warning time, and add kconfig to configure the warning time. Also fix macro to calculate WWDT ticks better to avoid rounding errors.