### PR TITLE
Feature add partial match to modem chat

### DIFF
--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -44,7 +44,10 @@ struct modem_chat_match {
 	const uint8_t separators_size;
 
 	/* Set if modem chat instance shall use wildcards when matching */
-	const bool wildcards;
+	const uint8_t wildcards : 1;
+
+	/* Set if script shall not continue to next step in case of match */
+	const uint8_t partial : 1;
 
 	/* Type of modem chat instance */
 	const modem_chat_match_callback callback;
@@ -63,6 +66,17 @@ struct modem_chat_match {
 		.match = (uint8_t *)(_match), .match_size = (uint8_t)(sizeof(_match) - 1),         \
 		.separators = (uint8_t *)(_separators),                                            \
 		.separators_size = (uint8_t)(sizeof(_separators) - 1), .wildcards = true,          \
+		.callback = _callback,                                                             \
+	}
+
+#define MODEM_CHAT_MATCH_INITIALIZER(_match, _separators, _callback, _wildcards, _partial)         \
+	{                                                                                          \
+		.match = (uint8_t *)(_match),                                                      \
+		.match_size = (uint8_t)(sizeof(_match) - 1),                                       \
+		.separators = (uint8_t *)(_separators),                                            \
+		.separators_size = (uint8_t)(sizeof(_separators) - 1),                             \
+		.wildcards = _wildcards,                                                           \
+		.partial = _partial,                                                               \
 		.callback = _callback,                                                             \
 	}
 

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -459,6 +459,11 @@ static void modem_chat_on_command_received_resp(struct modem_chat *chat)
 		chat->parse_match->callback(chat, (char **)chat->argv, chat->argc, chat->user_data);
 	}
 
+	/* Validate response command is not partial */
+	if (chat->parse_match->partial) {
+		return;
+	}
+
 	/* Advance script */
 	modem_chat_script_next(chat, false);
 }


### PR DESCRIPTION
This PR adds support for what is essentially a while loop within
the modem_chat chat scripts.

Requests like AT+CGML return a list (in this case of SMSes),
terminated by a response of "OK" . See example:

```
send: AT+CMGL=4
recv: +CGML: 1,1,,13
recv: 07911326060032F064A9542954
recv: +CGML: 1,2,,13
recv: 07911326060032F064A9542954
recv: +CGML: 1,3,,13
recv: 07911326060032F064A9542954
recv: OK
```

With this feature, called partial matches, a request can list a set
of matches which will parse the responses and call appropriate
callbacks without proceeding to the next script step. See example:
 
```
MODEM_CHAT_MATCHES_DEFINE(
	cmgl_matches,
	MODEM_CHAT_MATCH_INITIALIZER("+CMGL: ", ",", on_cmgl_partial, false, true),
	MODEM_CHAT_MATCH_INITIALIZER("", "", on_cmgl_any_partial, false, true),
	MODEM_CHAT_MATCH_INITIALIZER("OK", "", NULL, false, false)
);

MODEM_CHAT_SCRIPT_CMDS_DEFINE(
	script_partial_cmds,
	MODEM_CHAT_SCRIPT_CMD_RESP_MULT("AT+CGML=4", cmgl_matches),
);

MODEM_CHAT_SCRIPT_DEFINE(script_partial, script_partial_cmds, abort_matches, on_script_result, 4);
```

The first two matches, "+CMGL: " and "", are partial matches, which can be called any number of times without the script
continuing. The last match, "OK", is a normal match, will will resume (and in this case complete) the script.

This is also useful for listing files on the modem if it supports flash file storage like the Quectel modems do :)