### PR TITLE
scripts/pylib/pytest-twister-harness: Do not fail on Unicode garbage

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
@@ -203,7 +203,7 @@ class DeviceAdapter(abc.ABC):
         with open(self.handler_log_path, 'a+') as log_file:
             while self.is_device_running():
                 if self.is_device_connected():
-                    output = self._read_device_output().decode().strip()
+                    output = self._read_device_output().decode(errors='replace').strip()
                     if output:
                         self._device_read_queue.put(output)
                         log_file.write(f'{output}\n')


### PR DESCRIPTION
If pylib twister harness reads bytes that can't be decoded to Unicode, it would raise an exception at a separate "serial reader" process, that would fail without any warning.

This patch uses "errors='ignore'" paramter for Python str.decode() method, so that this doesn't happen.