### PR TITLE
Support for measuring timer behaviour with external tool

### DIFF
--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -41,3 +41,32 @@ config TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT
 	default 10
 	help
 	  A value of 10 means 10%.
+
+config TIMER_EXTERNAL_TEST
+	bool "Perform test using an external tool"
+	help
+	  Toggles a GPIO pin, on every period, that can be used by an external
+	  tool (such as a logic analyzer) to gather timing data. A pytest harness
+	  is used to get the data collected by the tool and evaluate it.
+
+if TIMER_EXTERNAL_TEST
+
+config TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM
+	int "Maximum drift in PPM for tests using external tool"
+	default 4500
+	help
+	  Parts Per Million of allowed drift when using an external tool
+	  connected to a GPIO pin is used to measure time behaviour.
+
+config TIMER_EXTERNAL_TEST_PERIOD_MAX_DRIFT_PPM
+	int "Maximum timer period drift in PPM for tests using external tool"
+	default 100000
+	help
+	  Parts Per Million of allowed period drift when using an external tool
+	  connected to a GPIO pin is used to measure time behaviour.
+
+config TIMER_EXTERNAL_TEST_SYNC_DELAY
+	int "Delay, in seconds, between tests, so that external tool can be ready"
+	default 3
+
+endif # TIMER_EXTERNAL_TEST

--- a/tests/kernel/timer/timer_behavior/README
+++ b/tests/kernel/timer/timer_behavior/README
@@ -46,6 +46,9 @@ Note that the collection may need to go a bit after the "seconds" parameter,
 to account for expected drift in the test and between the DUT and the external
 tool.
 
+One can check `pytest/saleae_logic2.py` file as a sample of external tool
+helper module.
+
 Twister
 
 For Twister execute the external tool testing, the fixture "gpio_timerout"
@@ -53,6 +56,8 @@ must be available on the device. Also, testcase.yaml
 "harness_config/pytest_args" from "kernel.timer.timer_behavior_external" must
 have parameters "tool", with the name of a loadable Python module and
 "tool-options", a string with options passed to the Python module helper.
+
+Check testcase.yaml for an example using the saleae_logic2 module.
 
 Configuration options
 
@@ -69,3 +74,11 @@ for the hardware in question.
 
 Also, CONFIG_TIMER_EXTERNAL_TEST_SYNC_DELAY is used to set a delay before a
 test cycle starts, so that the external tool can be set up.
+
+Dependencies
+
+The external tool interface may have its own dependencies. For instance,
+the saleae_logic2 module ones are listed at pytest/requirements-saleae.txt.
+One can install them with pip (possibly in some virtual environment):
+
+    pip install -r pytest/requirements-saleae.txt

--- a/tests/kernel/timer/timer_behavior/README
+++ b/tests/kernel/timer/timer_behavior/README
@@ -6,3 +6,66 @@ Records and calculates statistical values against a timer validating that.
 2. Periodic timers do not drift in either direction from expected total time.
 
 Timers are meant to be precise and accurate. This test validates an implementation is both.
+
+--------------------------------------------------------------------------------
+
+External tool testing
+
+It's also possible to use an external tool, such as a logic analyzer, to
+collect samples. The "kernel.timer.timer_behavior_external" test will toggle a
+GPIO pin on every cycle - first cycle will be a rising edge. This test expects
+a Python module to interface with the external tool, which will provide the
+necessary statistics that the test will use to assert the test status.
+
+GPIO pin
+
+To enable external tool testing on a board, it must provide the compatible
+"test-kernel-timer-behavior-external", with property "timeout-gpios" being the
+GPIO pin that will be toggled each period.
+
+External tool interface
+
+In order to get data from the external tool, the test expects a Python module,
+named on testcase.yaml, with the following interface:
+
+    run(seconds: float, options: str) -> {}
+
+The `seconds` parameter defines for how long the data collection is expected
+to run; `options` is a string defined on testcase.yaml with options known to
+the external tool helper module. It should return a dictionary with the
+following statistics, in seconds:
+
+    'mean':         Mean time of each period
+    'stddev':       Standard deviation from the mean time
+    'var':          Variance from the mean time
+    'min':          Minimum period registered
+    'max':          Maximum period registered
+    'total_time':   Total time, between first and last period.
+
+Note that the collection may need to go a bit after the "seconds" parameter,
+to account for expected drift in the test and between the DUT and the external
+tool.
+
+Twister
+
+For Twister execute the external tool testing, the fixture "gpio_timerout"
+must be available on the device. Also, testcase.yaml
+"harness_config/pytest_args" from "kernel.timer.timer_behavior_external" must
+have parameters "tool", with the name of a loadable Python module and
+"tool-options", a string with options passed to the Python module helper.
+
+Configuration options
+
+At its heart, the external testing is actually comparing two clocks: one on
+the board under test and one at the external tool (Zephyr implementation of
+the timer also plays a role, and it's the real target of the test, but it
+depends on the board's clock). Different clocks run at different speeds, so
+they tend to drift. To be able to account for this drift, the external test
+doesn't reuse CONFIG_TIMER_TEST_MAX_DRIFT and
+CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT, instead introducing
+CONFIG_TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM and
+CONFIG_TIMER_EXTERNAL_TEST_PERIOD_MAX_DRIFT_PPM, that can be more finely tuned
+for the hardware in question.
+
+Also, CONFIG_TIMER_EXTERNAL_TEST_SYNC_DELAY is used to set a delay before a
+test cycle starts, so that the external tool can be set up.

--- a/tests/kernel/timer/timer_behavior/boards/esp32s3_devkitm.overlay
+++ b/tests/kernel/timer/timer_behavior/boards/esp32s3_devkitm.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+    resources {
+        compatible = "test-kernel-timer-behavior-external";
+
+        timerout-gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+    };
+};

--- a/tests/kernel/timer/timer_behavior/boards/frdm_k64f.overlay
+++ b/tests/kernel/timer/timer_behavior/boards/frdm_k64f.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+    resources {
+        compatible = "test-kernel-timer-behavior-external";
+
+        timerout-gpios = <&gpioc 3 GPIO_ACTIVE_LOW>; /* Arduino D7 */
+    };
+};

--- a/tests/kernel/timer/timer_behavior/boards/mec15xxevb_assy6853.overlay
+++ b/tests/kernel/timer/timer_behavior/boards/mec15xxevb_assy6853.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+    resources {
+        compatible = "test-kernel-timer-behavior-external";
+
+        timerout-gpios = <&gpio_140_176 14 GPIO_ACTIVE_LOW>;
+    };
+};

--- a/tests/kernel/timer/timer_behavior/dts/bindings/timer-behavior-external.yaml
+++ b/tests/kernel/timer/timer_behavior/dts/bindings/timer-behavior-external.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Binding providing resources required to build and run the
+  tests/kernel/timer/timer_behavior/kernel.timer.timer_behavior_external
+  test in Zephyr.
+
+compatible: "test-kernel-timer-behavior-external"
+
+properties:
+  timerout-gpios:
+    type: phandle-array
+    required: true
+    description:
+      GPIO pin that will toggle on each cycle of the test, to be
+      connected to an external tool (such as a logic analyzer)
+      that will collect timing information.

--- a/tests/kernel/timer/timer_behavior/pytest/conftest.py
+++ b/tests/kernel/timer/timer_behavior/pytest/conftest.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from pathlib import Path
+
+def pytest_addoption(parser):
+    parser.addoption('--tool')
+    parser.addoption('--tool-options')
+    parser.addoption('--sys-clock-hw-cycles-per-sec', default=None)
+
+@pytest.fixture()
+def tool(request):
+    return request.config.getoption('--tool')
+
+@pytest.fixture()
+def tool_options(request):
+    return request.config.getoption('--tool-options')
+
+@pytest.fixture()
+def config(request):
+    build_dir = Path(request.config.getoption('--build-dir'))
+    file_name = build_dir / 'zephyr' / '.config'
+
+    cfgs = {}
+    with open(file_name) as fp:
+        for line in fp:
+            if line.startswith('CONFIG_'):
+                k, v = line.split('=', maxsplit=1)
+                cfgs[k[7:]] = v
+
+    return cfgs
+
+@pytest.fixture()
+def sys_clock_hw_cycles_per_sec(request, config):
+    if request.config.getoption('--sys-clock-hw-cycles-per-sec'):
+        return int(request.config.getoption('--sys-clock-hw-cycles-per-sec'))
+
+    return int(config['SYS_CLOCK_HW_CYCLES_PER_SEC'])

--- a/tests/kernel/timer/timer_behavior/pytest/requirements-saleae.txt
+++ b/tests/kernel/timer/timer_behavior/pytest/requirements-saleae.txt
@@ -1,0 +1,2 @@
+numpy
+logic2-automation

--- a/tests/kernel/timer/timer_behavior/pytest/saleae_logic2.py
+++ b/tests/kernel/timer/timer_behavior/pytest/saleae_logic2.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Sample code showing an external tool Python module helper for Saleae Logic 2
+# compatible logic analyzer.
+# To use it, the Saleae Logic 2 Automation server must be enabled. For more
+# information on it, check
+# https://saleae.github.io/logic2-automation/getting_started.html
+
+import numpy as np
+import tempfile
+
+from pathlib import Path
+from saleae import automation
+from saleae.automation import (CaptureConfiguration, LogicDeviceConfiguration,
+DigitalTriggerCaptureMode, DigitalTriggerType)
+
+def do_collection(device_id, port, channel, sample_rate, threshold_volts,
+                  seconds, output_dir):
+    with automation.Manager.connect(port=port) as manager:
+
+        device_configuration = LogicDeviceConfiguration(
+            enabled_digital_channels=[channel],
+            digital_sample_rate=sample_rate,
+            digital_threshold_volts=threshold_volts,
+        )
+
+        capture_mode = DigitalTriggerCaptureMode(DigitalTriggerType.RISING,
+                                                 channel,
+                                                 after_trigger_seconds=seconds)
+        capture_configuration = CaptureConfiguration(capture_mode=capture_mode)
+
+        with manager.start_capture(
+                device_id=device_id,
+                device_configuration=device_configuration,
+                capture_configuration=capture_configuration) as capture:
+
+            capture.wait()
+
+            capture.export_raw_data_csv(directory=output_dir,
+                                        digital_channels=[channel])
+
+def do_analysis(output_dir):
+    file_name = Path(output_dir) / 'digital.csv'
+    all_data = np.loadtxt(file_name, delimiter=',', skiprows=1, usecols=0)
+
+    # Pre trigger data is negative on CSV
+    non_negative = all_data[all_data >= 0]
+
+    # Last sample is just captured at last moment of capture, not related
+    # to gpio toggle. Discard it
+    data = non_negative[:-1]
+
+    diff = np.diff(data)
+
+    mean = np.mean(diff)
+    std = np.std(diff)
+    var = np.var(diff)
+    minimum = np.min(diff)
+    maximum = np.max(diff)
+    total_time = data[-1]
+
+    return {'mean': mean, 'stddev': std, 'var': var, 'min': minimum,
+            'max': maximum, 'total_time': total_time}
+
+
+# options should be a string of the format:
+# [device-id=<device_id>,]port=<saleae_logic2_server_port>,
+# channel=<channel_number>,sample-rate=<sample-rate>,
+# threshold-volts=<threshold-volts>
+def run(seconds, options):
+    options = [i for p in options.split(',') for i in p.split('=')]
+    options = dict(zip(options[::2], options[1::2]))
+
+    device_id = options.get('device-id')
+    port = int(options.get('port'))
+    channel = int(options.get('channel'))
+    sample_rate = int(options.get('sample-rate'))
+    threshold_volts = float(options.get('threshold-volts'))
+
+    with tempfile.TemporaryDirectory() as output_dir:
+        output_dir = tempfile.mkdtemp()
+        # Add one second to ensure all data is captured
+        do_collection(device_id, port, channel, sample_rate, threshold_volts,
+                      seconds + 1, output_dir)
+
+    return do_analysis(output_dir)

--- a/tests/kernel/timer/timer_behavior/pytest/test_timer.py
+++ b/tests/kernel/timer/timer_behavior/pytest/test_timer.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+from math import ceil
+
+from twister_harness import DeviceAdapter
+
+logger = logging.getLogger(__name__)
+
+
+def do_analysys(test, stats, config, sys_clock_hw_cycles_per_sec):
+    logger.info('====================================================')
+    logger.info(f'periodic timer behaviour using {test} mechanism:')
+
+    test_period = int(config['TIMER_TEST_PERIOD'])
+    test_samples = int(config['TIMER_TEST_SAMPLES'])
+
+    seconds = (test_period * test_samples) / 1_000_000
+
+    periods_sec = test_period / 1_000_000
+    ticks_per_sec = int(config['SYS_CLOCK_TICKS_PER_SEC'])
+    periods_tick = ceil(ticks_per_sec * periods_sec)
+
+    expected_period = test_period * sys_clock_hw_cycles_per_sec / 1_000_000
+    cyc_per_tick = sys_clock_hw_cycles_per_sec / ticks_per_sec
+    expected_period_drift = ((periods_tick * cyc_per_tick - expected_period) /
+                             sys_clock_hw_cycles_per_sec * 1_000_000)
+    expected_total_drift = expected_period_drift * test_samples / 1_000_000
+
+    period_max_drift = (int(config['TIMER_EXTERNAL_TEST_PERIOD_MAX_DRIFT_PPM'])
+                        / 1_000_000)
+    min_bound = (test_period - period_max_drift * test_period +
+                 expected_period_drift) / 1_000_000
+    max_bound = (test_period + period_max_drift * test_period +
+                 expected_period_drift) / 1_000_000
+
+    max_stddev = int(config['TIMER_TEST_MAX_STDDEV']) / 1_000_000
+
+    max_drift_ppm = int(config['TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM'])
+    time_diff = stats['total_time'] - seconds - expected_total_drift
+
+    logger.info(f'min:            {stats["min"] * 1_000_000:.6f} us')
+    logger.info(f'max:            {stats["max"] * 1_000_000:.6f} us')
+    logger.info(f'mean:           {stats["mean"] * 1_000_000:.6f} us')
+    logger.info(f'variance:       {stats["var"] * 1_000_000:.6f} us')
+    logger.info(f'stddev:         {stats["stddev"] * 1_000_000:.6f} us')
+    logger.info(f'total time:     {stats["total_time"] * 1_000_000:.6f} us')
+    logger.info(f'expected drift: {seconds * max_drift_ppm} us')
+    logger.info(f'real drift:     {time_diff * 1_000_000:.6f} us')
+    logger.info('====================================================')
+
+    assert stats['stddev'] < max_stddev
+    assert stats['min'] >= min_bound
+    assert stats['max'] <= max_bound
+    assert abs(time_diff) < seconds * max_drift_ppm / 1_000_000
+
+
+def wait_sync_point(dut: DeviceAdapter, point):
+    dut.readlines_until(regex=f"===== {point} =====")
+
+
+def test_flash(dut: DeviceAdapter, tool, tool_options, config,
+               sys_clock_hw_cycles_per_sec):
+    tool = __import__(tool)
+
+    test_period = int(config['TIMER_TEST_PERIOD'])
+    test_samples = int(config['TIMER_TEST_SAMPLES'])
+    seconds = (test_period * test_samples) / 1_000_000
+
+    tests = ["builtin", "startdelay"]
+    for test in tests:
+        wait_sync_point(dut, test)
+        stats = tool.run(seconds, tool_options)
+        do_analysys(test, stats, config, sys_clock_hw_cycles_per_sec)

--- a/tests/kernel/timer/timer_behavior/src/main.c
+++ b/tests/kernel/timer/timer_behavior/src/main.c
@@ -9,5 +9,7 @@
 void test_main(void)
 {
 	ztest_run_test_suite(timer_jitter_drift);
+#ifndef CONFIG_TIMER_EXTERNAL_TEST
 	ztest_run_test_suite(timer_tick_train);
+#endif
 }

--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -17,3 +17,11 @@ tests:
       - hifive_unleashed
       - mps2_an385
       - mps2_an521_ns
+  kernel.timer.timer_behavior_external:
+    filter: dt_compat_enabled("test-kernel-timer-behavior-external")
+    harness: pytest
+    harness_config:
+      fixture: gpio_timerout
+    extra_configs:
+      - CONFIG_TIMER_EXTERNAL_TEST=y
+      - CONFIG_BOOT_DELAY=5000

--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -21,6 +21,8 @@ tests:
     filter: dt_compat_enabled("test-kernel-timer-behavior-external")
     harness: pytest
     harness_config:
+      pytest_args: ['--tool', 'saleae_logic2', '--tool-options',
+                    'port=10430,channel=1,sample-rate=6_250_000,threshold-volts=3.3']
       fixture: gpio_timerout
     extra_configs:
       - CONFIG_TIMER_EXTERNAL_TEST=y


### PR DESCRIPTION
Modifies timer_behavior test to that `jitter_drift.c` tests also toggle a GPIO, that can be connected to an external tool (such as a logic analyzer) to measure timer behaviour.
A pytest test is also added to get the data from the external tool and assert some measurements.
Finally, an example of how to interface with an external tool to get the data is provided. Note that the external tool can change, as long an interface to get the data is there.