### PR TITLE
twister: UTF-8 encoding bug fix for device handler and yaml reading

### DIFF
--- a/samples/sensor/die_temp_polling/sample.yaml
+++ b/samples/sensor/die_temp_polling/sample.yaml
@@ -12,4 +12,4 @@ tests:
     harness_config:
       type: one_line
       regex:
-        - "CPU Die temperature\\[[A-Za-z0-9_]+\\]: [1-9][0-9].[0-9] °C"
+        - "CPU Die temperature\\[[A-Za-z0-9_@]+\\]: [1-9][0-9].[0-9] °C"

--- a/scripts/pylib/twister/scl.py
+++ b/scripts/pylib/twister/scl.py
@@ -36,7 +36,7 @@ def yaml_load(filename):
     :return: dictionary representing the YAML document
     """
     try:
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf-8') as f:
             return yaml.load(f, Loader=SafeLoader)
     except yaml.scanner.ScannerError as e:	# For errors parsing schema.yaml
         mark = e.problem_mark

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -343,7 +343,7 @@ class DeviceHandler(Handler):
         super().__init__(instance, type_str)
 
     def monitor_serial(self, ser, halt_event, harness):
-        log_out_fp = open(self.log, "wt")
+        log_out_fp = open(self.log, "wb")
 
         if self.options.coverage:
             # Set capture_coverage to True to indicate that right after
@@ -395,7 +395,7 @@ class DeviceHandler(Handler):
                 sl = serial_line.decode('utf-8', 'ignore').lstrip()
                 logger.debug("DEVICE: {0}".format(sl.rstrip()))
 
-                log_out_fp.write(sl)
+                log_out_fp.write(sl.encode('utf-8'))
                 log_out_fp.flush()
                 harness.handle(sl.rstrip())
 

--- a/scripts/tests/twister/test_scl.py
+++ b/scripts/tests/twister/test_scl.py
@@ -162,7 +162,7 @@ def test_yaml_load(caplog, fail_parsing):
         with pytest.raises(ScannerError) if fail_parsing else nullcontext():
             result = scl.yaml_load(filename)
 
-    mock_file.assert_called_with('dummy/file.yaml', 'r')
+    mock_file.assert_called_with('dummy/file.yaml', 'r', encoding='utf-8')
 
     if not fail_parsing:
         assert result == result_mock


### PR DESCRIPTION
- Upon trying to run `die_temp_polling` sample through twister I discovered that the yaml file was not being read correctly and instead of reading ° it was reading Â°. This fix was in scl.py
- For handlers.py, the handler.log file was being encoded in ANSI instead of UTF-8 resulting in bytes not being able to be decoded. This error would occur at the end only if twister failed and wanted to generate the report.
```
File "C:\Users\havrylyuk\zephyr\zephyr\scripts\pylib\twister\twisterlib\reports.py", line 287, in json_report
    suite["log"] = self.process_log(handler_log)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\havrylyuk\zephyr\zephyr\scripts\pylib\twister\twisterlib\reports.py", line 35, in process_log
    log = f.read().decode("utf-8")
          ^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb0 in position 112: invalid start byte

```

- Add @ to the regex for die_temp_polling sample for when the the DUT (xmc47_relax_kit) outputs the address. Example:
 `CPU Die temperature[die_temp@5000408c]: 38.0 °C`