### PR TITLE
net: lwm2m: Allow Bootstrap server to close DTLS connection

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -88,12 +88,10 @@ static void set_sm_state(uint8_t sm_state);
 enum sm_engine_state {
 	ENGINE_IDLE,
 	ENGINE_INIT,
-#if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 	ENGINE_DO_BOOTSTRAP_REG,
 	ENGINE_BOOTSTRAP_REG_SENT,
 	ENGINE_BOOTSTRAP_REG_DONE,
 	ENGINE_BOOTSTRAP_TRANS_DONE,
-#endif
 	ENGINE_DO_REGISTRATION,
 	ENGINE_SEND_REGISTRATION,
 	ENGINE_REGISTRATION_SENT,
@@ -351,14 +349,20 @@ static void sm_handle_failure_state(enum sm_engine_state sm_state)
 static void socket_fault_cb(int error)
 {
 	LOG_ERR("RD Client socket error: %d", error);
+	lwm2m_socket_close(client.ctx);
 
-	if (sm_is_bootstrap()) {
+	if (IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP) && sm_is_bootstrap()) {
 		client.ctx->sec_obj_inst = -1;
 		/* force full registration */
 		client.last_update = 0;
-	}
 
-	lwm2m_socket_close(client.ctx);
+		if (get_sm_state() == ENGINE_BOOTSTRAP_TRANS_DONE) {
+			/* Ignore the error, some servers close the connection immediately
+			 * after receiving Ack to Bootstrap-Finish command.
+			 */
+			return;
+		}
+	}
 
 	/* Network error state causes engine to re-register,
 	 * so only trigger that state if we are not stopping the


### PR DESCRIPTION
Allow Bootstrap server to close the DTLS connection immediately after receiving Ack to Bootstrap-Finnish command.
This is not an error as either parties are allowed to tear down the connection.

This behaviour was seen they tried Zephyr's client against IoTerop’s ALASKA server.

![Screenshot from 2023-09-12 11-37-37](https://github.com/zephyrproject-rtos/zephyr/assets/3104794/2e939d6a-f262-428e-8941-2704c75d4749)
