### PR TITLE
boards: arm: stm32f411e_disco: Add flash partitions and defines

### DIFF
--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -159,4 +160,33 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+			read-only;
+		};
+
+		slot0_partition: partition@20000 {
+			label = "image-0";
+			reg = <0x00020000 DT_SIZE_K(128)>;
+		};
+
+		slot1_partition: partition@40000 {
+			label = "image-1";
+			reg = <0x00040000 DT_SIZE_K(128)>;
+		};
+
+		scratch_partition: partition@60000 {
+			label = "image-scratch";
+			reg = <0x00060000 DT_SIZE_K(128)>;
+		};
+	};
 };

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -78,6 +78,8 @@
 		pwm-led3 = &blue_pwm_led;
 		magn0 = &lsm303agr_magn;
 		accel0 = &lsm303agr_accel;
+		mcuboot-button0 = &user_button;
+		mcuboot-led0 = &orange_led_3;
 	};
 };
 

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -62,7 +62,7 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -16,6 +16,7 @@
 	chosen {
 		zephyr,console = &usart2;
 		zephyr,shell-uart = &usart2;
+		zephyr,uart-mcumgr = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;


### PR DESCRIPTION
    Adds flash partitions so that MCUboot can be used with this board

    Adds the user button and orange LED for use with MCUboot to enter
    serial recovery and indicate when in this mode

    Adds a chosen node for MCUmgr UART

    Fixes the button to have the correct polarity for when it is
    pressed.


This allows for half easily checking the board using MCUboot (though since the board doesn't have a connectable UART to a PC, it would optionally be useful to use the USB port with USB CDC mode).

Tested with a B revision board