### PR TITLE
Revert "drivers/spi: stm32: fix TX-only mode"

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -324,10 +324,8 @@ static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 		spi_context_update_tx(&data->ctx, 2, 1);
 	}
 
-	if (spi_context_rx_buf_on(&data->ctx)) {
-		while (!ll_func_rx_is_not_empty(spi)) {
-			/* NOP */
-		}
+	while (!ll_func_rx_is_not_empty(spi)) {
+		/* NOP */
 	}
 
 	if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 8) {


### PR DESCRIPTION
This reverts commit 31cd3b1f61e914ca23a620033e22ec8d33402369.

This change is causing regression in SPI loopback tests.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/62519