### PR TITLE
MAINTAINERS: update esp32 names

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3012,10 +3012,9 @@ West:
   status: maintained
   maintainers:
     - sylvioalves
-    - glaubermaroto
-    - uLipe
   collaborators:
     - LucasTambor
+    - marekmatej
   files: []
   labels:
     - "platform: ESP32"


### PR DESCRIPTION
Keep single maintainer.
Added "marekmatej"
Remove "glaubermaroto" from the list.