### PR TITLE
MAINTAINERS: update GitHub ID for casparfriedrich

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1393,7 +1393,7 @@ Release Notes:
   maintainers:
     - str4t0m
   collaborators:
-    - dp7hgh7
+    - casparfriedrich
   files:
     - doc/hardware/peripherals/w1.rst
     - drivers/w1/


### PR DESCRIPTION
Unless I'm mistaken, GH User @dp7hgh7 is now @casparfriedrich.