### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -281,7 +281,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 9bf7ce8c5fe8152836a6e00bd4444153bd950342
+      revision: 736234caa5ee0b3090cf02e5af0c2dc798aa4beb
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  736234caa5ee0b3090cf02e5af0c2dc798aa4beb

Brings following Zephyr relevant fixes:
 - c7aa2c0 boot_serial: Fix issues with single slot mode/encrypted images
 - 6ba46c0 boot_serial: Fix issue with queued commands
 - 274547c bootutil: PSA Crypto ECDSA enablement
 - 8f8fbf9 zephyr: Fall back to minimal C library
 - 5c5222f boot_serial: Fix include
 - b847a33 espressif: use minimal libc as default for ESP32 boards
 - 480b97f boot_serial: Fix missing point if using snprintf
 - 3790f5f boot: zephyr: use indication LED also in timeout based recovery
 - 0035c33 zephyr: Provide third image cases for direct image upload

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.