### PR TITLE
drivers: intc: plic: fix the calculation of trig register

### DIFF
--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -29,7 +29,7 @@
 #define PLIC_IRQS        (CONFIG_NUM_IRQS - CONFIG_2ND_LVL_ISR_TBL_OFFSET)
 #define PLIC_EN_SIZE     ((PLIC_IRQS >> 5) + 1)
 
-#define PLIC_EDGE_TRIG_TYPE   (PLIC_MAX_PRIO + DT_INST_PROP(0, riscv_trigger_reg_offset))
+#define PLIC_EDGE_TRIG_TYPE (DT_INST_REG_ADDR(0) + DT_INST_PROP(0, riscv_trigger_reg_offset))
 #define PLIC_EDGE_TRIG_SHIFT  5
 
 struct plic_regs_t {

--- a/tests/drivers/build_all/interrupt_controller/CMakeLists.txt
+++ b/tests/drivers/build_all/interrupt_controller/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(build_all)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/build_all/interrupt_controller/boards/qemu_riscv32_trig.overlay
+++ b/tests/drivers/build_all/interrupt_controller/boards/qemu_riscv32_trig.overlay
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+ /{
+	soc {
+		plic: interrupt-controller@c000000 {
+			riscv,trigger-reg-offset = < 0x00001080 >;
+		};
+	};
+};

--- a/tests/drivers/build_all/interrupt_controller/boards/qemu_riscv64_trig.overlay
+++ b/tests/drivers/build_all/interrupt_controller/boards/qemu_riscv64_trig.overlay
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "qemu_riscv32_trig.overlay"

--- a/tests/drivers/build_all/interrupt_controller/prj.conf
+++ b/tests/drivers/build_all/interrupt_controller/prj.conf
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_TEST=y

--- a/tests/drivers/build_all/interrupt_controller/src/main.c
+++ b/tests/drivers/build_all/interrupt_controller/src/main.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/devicetree.h>
+
+#ifdef CONFIG_PLIC_SUPPORTS_EDGE_IRQ
+BUILD_ASSERT(DT_PROP(DT_NODELABEL(plic), riscv_trigger_reg_offset) == 0x00001080,
+	     "the offset should be the value defined in the board dt overlay");
+#else
+BUILD_ASSERT(DT_PROP(DT_NODELABEL(plic), riscv_trigger_reg_offset) == 4224,
+	     "the offset should be the binding default value");
+#endif /* CONFIG_PLIC_SUPPORTS_EDGE_IRQ */
+
+int main(void)
+{
+	return 0;
+}

--- a/tests/drivers/build_all/interrupt_controller/testcase.yaml
+++ b/tests/drivers/build_all/interrupt_controller/testcase.yaml
@@ -1,0 +1,20 @@
+common:
+  build_only: true
+  tags:
+    - drivers
+    - interrupt
+tests:
+  drivers.interrupt_controller.intc_plic.build:
+    platform_allow:
+      - qemu_riscv32
+      - qemu_riscv64
+    tags: plic
+  drivers.interrupt_controller.intc_plic.edge.build:
+    platform_allow:
+      - qemu_riscv32
+      - qemu_riscv64
+    extra_args:
+      DTC_OVERLAY_FILE="./boards/qemu_riscv32_trig.overlay;./boards/qemu_riscv64_trig.overlay"
+    extra_configs:
+      - CONFIG_PLIC_SUPPORTS_EDGE_IRQ=y
+    tags: plic


### PR DESCRIPTION
`trig` register should be independent of the `riscv,max-priority` property.

This register is mentioned in:
- [telink datasheet](http://wiki.telink-semi.cn/doc/ds/DS-TLSR9518-E_Datasheet%20for%20Telink%20Multi-Standard%20Wireless%20SoC%20TLSR9518.pdf#page=107&zoom=100,70,76)
- [andes datasheet](http://www.andestech.com/wp-content/uploads/AX45MP-1C-Rev.-5.0.0-Datasheet.pdf)