### PR TITLE
riscv: telink_b91: add support for multilevel interrupt.

### DIFF
--- a/drivers/gpio/gpio_b91.c
+++ b/drivers/gpio/gpio_b91.c
@@ -78,7 +78,7 @@ struct gpio_b91_t {
 struct gpio_b91_config {
 	struct gpio_driver_config common;
 	uint32_t gpio_base;
-	uint8_t irq_num;
+	uint32_t irq_num;
 	uint8_t irq_priority;
 	void (*pirq_connect)(void);
 };

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -24,6 +24,12 @@
 			clock-frequency = <24000000>;
 			compatible ="telink,b91", "riscv";
 			riscv,isa = "rv32imac_zicsr_zifencei";
+			hlic: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
 		};
 	};
 
@@ -124,6 +130,8 @@
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;
+			interrupts-extended = <&hlic 11>;
+			interrupt-parent = <&cpu0>;
 			reg = < 0xe4000000 0x00001000
 					0xe4002000 0x00000800
 					0xe4200000 0x00010000 >;

--- a/soc/riscv/riscv-privileged/telink_b91/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privileged/telink_b91/Kconfig.defconfig.series
@@ -50,6 +50,9 @@ config TEST_EXTRA_STACK_SIZE
 	int
 	default 1024
 
+config 2ND_LVL_INTR_00_OFFSET
+	default 11
+
 config HAS_FLASH_LOAD_OFFSET
 	default y if BOOTLOADER_MCUBOOT
 


### PR DESCRIPTION
Fix potential compilation failure due to multilevel interrupt.

Refered to https://github.com/zephyrproject-rtos/zephyr/commit/6e887e3f61dba4712db0854d8eaded37a5a3bd6c
Telink's [datasheet](http://wiki.telink-semi.cn/doc/ds/DS-TLSR9518-E_Datasheet%20for%20Telink%20Multi-Standard%20Wireless%20SoC%20TLSR9518.pdf#page=107&zoom=100,70,76)