### PR TITLE
PM: allow custom policy to use default policy code without duplication

### DIFF
--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -81,6 +81,21 @@ struct pm_policy_event {
  */
 const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks);
 
+/**
+ * @brief Function to get the next PM state (Default policy)
+ *
+ * This function is called by the power subsystem when the system is
+ * idle and returns the most appropriate state based on the number of
+ * ticks to the next event.
+ *
+ * @param cpu CPU index.
+ * @param ticks The number of ticks to the next scheduled event.
+ *
+ * @return The power state the system should use for the given cpu. The function
+ * will return NULL if system should remain into PM_STATE_ACTIVE.
+ */
+const struct pm_state_info *pm_policy_default_next_state(uint8_t cpu, int32_t ticks);
+
 /** @endcond */
 
 /** Special value for 'all substates'. */

--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -64,14 +64,16 @@ struct pm_policy_event {
 	uint32_t value_cyc;
 };
 
-/** @cond INTERNAL_HIDDEN */
-
 /**
  * @brief Function to get the next PM state
  *
  * This function is called by the power subsystem when the system is
  * idle and returns the most appropriate state based on the number of
  * ticks to the next event.
+ *
+ * When :kconfig:option:`CONFIG_PM_POLICY_DEFAULT` is not set, the application
+ * or SoC implementation can implement this function to provide a custom
+ * policy.
  *
  * @param cpu CPU index.
  * @param ticks The number of ticks to the next scheduled event.
@@ -95,8 +97,6 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks);
  * will return NULL if system should remain into PM_STATE_ACTIVE.
  */
 const struct pm_state_info *pm_policy_default_next_state(uint8_t cpu, int32_t ticks);
-
-/** @endcond */
 
 /** Special value for 'all substates'. */
 #define PM_ALL_SUBSTATES (UINT8_MAX)

--- a/subsys/pm/policy.c
+++ b/subsys/pm/policy.c
@@ -129,8 +129,7 @@ static void update_next_event(uint32_t cyc)
 	next_event_cyc = new_next_event_cyc;
 }
 
-#ifdef CONFIG_PM_POLICY_DEFAULT
-const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
+const struct pm_state_info *pm_policy_default_next_state(uint8_t cpu, int32_t ticks)
 {
 	int64_t cyc = -1;
 	uint8_t num_cpu_states;
@@ -188,6 +187,13 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 	}
 
 	return NULL;
+}
+
+#ifdef CONFIG_PM_POLICY_DEFAULT
+const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
+{
+
+	return pm_policy_default_next_state(cpu, ticks);
 }
 #endif
 


### PR DESCRIPTION
- pm: split default policy so custom code can call it
- doc: pm: do not hide pm_policy_next_state
