### PR TITLE
ipc: Enable no-copy features in icmsg backend

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_icmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icmsg.c
@@ -43,10 +43,64 @@ static int send(const struct device *instance, void *token,
 	return icmsg_send(conf, dev_data, msg, len);
 }
 
+static int get_tx_buffer(const struct device *instance, void *token,
+			 void **data, uint32_t *user_len, k_timeout_t wait)
+{
+	const struct icmsg_config_t *conf = instance->config;
+	struct icmsg_data_t *dev_data = instance->data;
+
+	return icmsg_get_tx_buffer(conf, dev_data, data,
+				      user_len);
+}
+
+static int drop_tx_buffer(const struct device *instance, void *token,
+			  const void *data)
+{
+	const struct icmsg_config_t *conf = instance->config;
+	struct icmsg_data_t *dev_data = instance->data;
+
+	return icmsg_drop_tx_buffer(conf, dev_data, data);
+}
+
+static int send_nocopy(const struct device *instance, void *token,
+			const void *data, size_t len)
+{
+	const struct icmsg_config_t *conf = instance->config;
+	struct icmsg_data_t *dev_data = instance->data;
+
+	return icmsg_send_nocopy(conf, dev_data,
+				    data, len);
+}
+
+#ifdef CONFIG_IPC_SERVICE_ICMSG_NOCOPY_RX
+int hold_rx_buffer(const struct device *instance, void *token, void *data)
+{
+	const struct icmsg_config_t *conf = instance->config;
+	struct icmsg_data_t *dev_data = instance->data;
+
+	return icmsg_hold_rx_buffer(conf, dev_data, data);
+}
+
+int release_rx_buffer(const struct device *instance, void *token, void *data)
+{
+	const struct icmsg_config_t *conf = instance->config;
+	struct icmsg_data_t *dev_data = instance->data;
+
+	return icmsg_release_rx_buffer(conf, dev_data, data);
+}
+#endif /* CONFIG_IPC_SERVICE_ICMSG_NOCOPY_RX */
+
 const static struct ipc_service_backend backend_ops = {
 	.register_endpoint = register_ept,
 	.deregister_endpoint = deregister_ept,
 	.send = send,
+	.get_tx_buffer = get_tx_buffer,
+	.drop_tx_buffer = drop_tx_buffer,
+	.send_nocopy = send_nocopy,
+#ifdef CONFIG_IPC_SERVICE_ICMSG_NOCOPY_RX
+	.hold_rx_buffer = hold_rx_buffer,
+	.release_rx_buffer = release_rx_buffer,
+#endif /* CONFIG_IPC_SERVICE_ICMSG_NOCOPY_RX */
 };
 
 static int backend_init(const struct device *instance)

--- a/subsys/ipc/ipc_service/lib/Kconfig.icmsg
+++ b/subsys/ipc/ipc_service/lib/Kconfig.icmsg
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config IPC_SERVICE_ICMSG_NOCOPY_RX
-	bool
+	bool "No-copy receiving with the icmsg library"
 	depends on IPC_SERVICE_ICMSG
 	help
 	  Enable nocopy feature for receiving path of the icmsg library that


### PR DESCRIPTION
The icmsg_me (me stands for multi-endpoint) backend has no-copy features that in fact are implemented in icmsg.c. The icmsg backend should be configurable to have these no-copy features, too.

This fixes #62558 .