### PR TITLE
Skip tests for `mr_canhubk3` board due to off-chip watchdog 

### DIFF
--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -13,6 +13,8 @@ tests:
     extra_args: CONF_FILE="prj_user.conf"
     integration_platforms:
       - qemu_x86
+    platform_exclude:
+      - mr_canhubk3
     harness_config:
       type: multi_line
       regex:

--- a/tests/application_development/code_relocation/testcase.yaml
+++ b/tests/application_development/code_relocation/testcase.yaml
@@ -15,15 +15,6 @@ tests:
       - CONFIG_MPU_ALLOW_FLASH_WRITE=y
     platform_allow:
       - frdm_k64f
-  application_development.code_relocation.nxp_s32:
-    filter: dt_chosen_enabled("zephyr,itcm")
-    arch_allow: arm
-    extra_configs:
-      - CONFIG_MINIMAL_LIBC=y
-      - CONFIG_RELOCATE_TO_ITCM=y
-      - CONFIG_NULL_POINTER_EXCEPTION_DETECTION_NONE=y
-    platform_allow:
-      - mr_canhubk3
   application_development.code_relocation.no_itcm:
     filter: not CONFIG_CPU_HAS_NXP_MPU and not dt_chosen_enabled("zephyr,itcm")
     arch_allow: arm

--- a/tests/arch/arm/arm_irq_vector_table/testcase.yaml
+++ b/tests/arch/arm/arm_irq_vector_table/testcase.yaml
@@ -8,3 +8,5 @@ common:
 tests:
   arch.arm.irq_vector_table:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
+    platform_exclude:
+      - mr_canhubk3

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -112,11 +112,12 @@ tests:
       - longan_nano
     integration_platforms:
       - gd32e103v_eval
-  drivers.watchdog.s32z270dc2_r52:
+  drivers.watchdog.nxp_s32:
     build_only: true
     platform_allow:
       - s32z270dc2_rtu0_r52
       - s32z270dc2_rtu1_r52
+      - mr_canhubk3
   drivers.watchdog.mimxrt1050_evk_ti_tps382x:
     filter: dt_compat_enabled("ti,tps382x")
     platform_allow: mimxrt1050_evk

--- a/tests/kernel/usage/thread_runtime_stats/testcase.yaml
+++ b/tests/kernel/usage/thread_runtime_stats/testcase.yaml
@@ -16,3 +16,5 @@ tests:
     integration_platforms:
       - qemu_x86
       - mps2_an385
+    platform_exclude:
+      - mr_canhubk3


### PR DESCRIPTION
The `mr_canhubk3` board enables by default an off-chip watchdog that must be serviced to avoid triggering a reset and cannot be disabled on a per-test basis or disabled in the default configuration (see #62373). So exclude this board for the conflictive tests in order to have a full successful twister run on this board.

Details:
- `samples/subsys/tracing`: the amount of data printed on this test prevents to initialize the on-board watchdog within the expected window, causing a board reset.
- `tests/kernel/usage/thread_runtime_stats`: test_all_stats_usage assumes the CPU was never idle before the test starts but because of the watchdog driver has a thread kicked off during device init, it will conflict with the expected usage stats on this test.
- `tests/arch/arm/arm_irq_vector_table`: To add the needed ISR for this test involve doing modifications to the LPSPI MCUX driver that does not worth the trouble for this test only, so exclude this board.
- `tests/application_development/code_relocation` :The watchdog driver make uses of a semaphore during device init and on this test the relocation of the kernel sources produces a fault. So skip this test for this board.
- `tests/drivers/watchdog/wdt_basic_api`: this test cannot be executed in the board because ECC initialization will clear SRAM contents that are used by this test to persist data across resets (test could be extended to use external flash instead, but not in the scope of this PR; other watchdog samples are working fine with this device).