### PR TITLE
lib/os: When using CBPRINTF_NANO, picolibc long-long printf isn't req…

### DIFF
--- a/lib/os/Kconfig.cbprintf
+++ b/lib/os/Kconfig.cbprintf
@@ -31,7 +31,7 @@ choice CBPRINTF_INTEGRAL_CONV
 # 01: 0% / 0 B (01 / 00)
 config CBPRINTF_FULL_INTEGRAL
 	bool "Convert the full range of integer values"
-	select PICOLIBC_IO_LONG_LONG if PICOLIBC
+	select PICOLIBC_IO_LONG_LONG if PICOLIBC && !CBPRINTF_NANO
 	help
 	  Build cbprintf with buffers sized to support converting the full
 	  range of all integral and pointer values.


### PR DESCRIPTION
…uired

CBPRINTF_FULL_INTEGRAL doesn't happen to explicitly conflict with CBPRINTF_NANO, but when CBPRINTF_NANO is enabled, there's no long long I/O support provided.

Allow picolibc long-long I/O support to also be elided when CBPRINTF_NANO is enabled to save similar amounts of space.