### PR TITLE
MAINTAINERS: add `dts/riscv` to the `RISCV arch` area of maintenance

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2115,6 +2115,7 @@ RISCV arch:
     - arch/riscv/
     - boards/riscv/
     - dts/bindings/riscv/
+    - dts/riscv/
     - include/zephyr/arch/riscv/
     - soc/riscv/
     - tests/arch/riscv/


### PR DESCRIPTION
This PR adds the `dts/riscv` directory to the `RISCV arch` area of maintenance. Right now, RISC-V devicetrees are covered only by platform-specific areas (Espressif, ITE). When other RISC-V platform devicetrees are affected in a PR, it is left unassigned.

An example of an affected PR: https://github.com/zephyrproject-rtos/zephyr/pull/62528.