### PR TITLE
net: promiscuous: Fix crash in promiscuous mode

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4145,12 +4145,15 @@ enum net_verdict net_if_recv_data(struct net_if *iface, struct net_pkt *pkt)
 		/* L2 has modified the buffer starting point, it is easier
 		 * to re-initialize the cursor rather than updating it.
 		 */
-		net_pkt_cursor_init(new_pkt);
+		if (new_pkt) {
+			net_pkt_cursor_init(new_pkt);
 
-		if (net_promisc_mode_input(new_pkt) == NET_DROP) {
-			net_pkt_unref(new_pkt);
+			if (net_promisc_mode_input(new_pkt) == NET_DROP) {
+				net_pkt_unref(new_pkt);
+			}
+		} else {
+			NET_WARN("promiscuous packet dropped, unable to clone packet");
 		}
-
 		net_pkt_unref(pkt);
 
 		return verdict;


### PR DESCRIPTION
When a packet can't be cloned we crash as we try to initialize the cursor on a nullptr. We should check if we have a valid pointer, and if we don't we drop the packet along with a warning.