### PR TITLE
drivers: fuel_gauge: fix i2c_dump_msgs_rw argument

### DIFF
--- a/drivers/fuel_gauge/bq27z746/emul_bq27z746.c
+++ b/drivers/fuel_gauge/bq27z746/emul_bq27z746.c
@@ -279,7 +279,7 @@ static int bq27z746_emul_transfer_i2c(const struct emul *target, struct i2c_msg 
 
 	__ASSERT_NO_MSG(msgs && num_msgs);
 
-	i2c_dump_msgs_rw("emul", msgs, num_msgs, addr, false);
+	i2c_dump_msgs_rw(target->dev, msgs, num_msgs, addr, false);
 	switch (num_msgs) {
 	case 1:
 		if (msgs->flags & I2C_MSG_READ) {


### PR DESCRIPTION
Fix another i2c_dump_msgs_rw:

/drivers/fuel_gauge/bq27z746/emul_bq27z746.c:282:26: warning: passing argument 1 of ‘i2c_dump_msgs_rw’ from incompatible pointer type