### PR TITLE
board nrf52_bsim: Fix build warning with clang

### DIFF
--- a/boards/posix/nrf52_bsim/common/phy_sync_ctrl.c
+++ b/boards/posix/nrf52_bsim/common/phy_sync_ctrl.c
@@ -23,7 +23,7 @@
 
 static struct {
 	double start_offset;
-	double max_resync_offset;
+	bs_time_t max_resync_offset;
 	bool delay_init;
 	bool sync_preinit;
 	bool sync_preboot;


### PR DESCRIPTION
Fix a build warning with clang due to an implicit cast.