### PR TITLE
cmake: armlink: update CMake library to arch__arm__core__cortex_m

### DIFF
--- a/cmake/linker/armlink/target.cmake
+++ b/cmake/linker/armlink/target.cmake
@@ -65,7 +65,7 @@ function(toolchain_ld_link_elf)
   )
 
   foreach(lib ${ZEPHYR_LIBS_PROPERTY})
-    if(NOT ${lib} STREQUAL arch__arm__core__aarch32__cortex_m)
+    if(NOT ${lib} STREQUAL arch__arm__core__cortex_m)
       list(APPEND ZEPHYR_LIBS_OBJECTS $<TARGET_OBJECTS:${lib}>)
       list(APPEND ZEPHYR_LIBS_OBJECTS $<TARGET_PROPERTY:${lib},LINK_LIBRARIES>)
     endif()
@@ -76,7 +76,7 @@ function(toolchain_ld_link_elf)
     ${TOOLCHAIN_LD_LINK_ELF_LIBRARIES_PRE_SCRIPT}
     --scatter=${TOOLCHAIN_LD_LINK_ELF_LINKER_SCRIPT}
     ${TOOLCHAIN_LD_LINK_ELF_LIBRARIES_POST_SCRIPT}
-    $<TARGET_OBJECTS:arch__arm__core__aarch32__cortex_m>
+    $<TARGET_OBJECTS:arch__arm__core__cortex_m>
     --map --list=${TOOLCHAIN_LD_LINK_ELF_OUTPUT_MAP}
     ${ZEPHYR_LIBS_OBJECTS}
     kernel


### PR DESCRIPTION
Fixes: #62589
Follow-up: #60031

The PR #60031 moved CMake code to new folder location causing generated library names to change.
This change impacted the use of those libraries in the Zephyr armlink CMake code, causing CMake failures at configure time.

This PR fixes this failure by updating the armlink CMake code to use the new library names.