### PR TITLE
cmake: armclang version detection

### DIFF
--- a/cmake/modules/Findarmclang.cmake
+++ b/cmake/modules/Findarmclang.cmake
@@ -16,8 +16,16 @@ include(FindPackageHandleStandardArgs)
 
 if(CMAKE_C_COMPILER)
   # Parse the 'clang --version' output to find the installed version.
-  execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${triple} --version OUTPUT_VARIABLE ARMCLANG_VERSION)
-  string(REGEX REPLACE "[^0-9]*([0-9.]+) .*" "\\1" ARMCLANG_VERSION ${ARMCLANG_VERSION})
+  execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${triple} --version OUTPUT_VARIABLE ARMCLANG_VERSION ERROR_QUIET)
+  string(REPLACE "\n" ";" armclang_version_list "${ARMCLANG_VERSION}")
+  set(ARMCLANG_VERSION ARMCLANG_VERSION-NOTFOUND)
+  foreach(line ${armclang_version_list})
+    # Compiler version is either terminated directly, or followed by space and extra build info.
+    if(line MATCHES ".*[aA]rm [cC]ompiler[^0-9]*([0-9.]+)($| .*$)")
+      set(ARMCLANG_VERSION "${CMAKE_MATCH_1}")
+      break()
+    endif()
+  endforeach()
 endif()
 
 find_package_handle_standard_args(armclang


### PR DESCRIPTION
The armclang version detection introduced in #55133 does not correctly detect a valid ARM Compiler (armclang) installation in all situations.

When ARM Compiler for Embedded is installed as part of ARM-DS or Keil, then it may report itself in following output:
> Product: Arm Development Studio ... <year>.<no>
> Component: ARM Compiler x.y(.z)
> Tool: armclang [...]
>
> Target: ...

Correct the version extraction by turning each line into a list of strings which can then be looped to find the ARM compiler component to ensure the correct line is used for retrieving the version information.