### PR TITLE
Bluetooth: Controller: Fix some compiler instruction re-ordering

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -3149,6 +3149,7 @@ void ticker_job(void *param)
 	instance->job_guard = 0U;
 
 	/* trigger worker if deferred */
+	cpu_dmb();
 	if (instance->worker_trigger || compare_trigger) {
 		instance->sched_cb(TICKER_CALL_ID_JOB, TICKER_CALL_ID_WORKER, 1,
 				   instance);

--- a/subsys/bluetooth/controller/util/mayfly.c
+++ b/subsys/bluetooth/controller/util/mayfly.c
@@ -6,8 +6,13 @@
  */
 
 #include <stddef.h>
+
+#include <soc.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/printk.h>
+
+#include "hal/cpu.h"
+
 #include "memq.h"
 #include "mayfly.h"
 
@@ -154,10 +159,12 @@ static void dequeue(uint8_t callee_id, uint8_t caller_id, memq_link_t *link,
 		m->_link = link;
 
 		/* reset mayfly state to idle */
+		cpu_dmb();
 		ack = m->_ack;
 		m->_ack = req;
 
 		/* re-insert, if re-pended by interrupt */
+		cpu_dmb();
 		if (((m->_req - ack) & 0x03) == 1U) {
 #if defined(MAYFLY_UT)
 			printk("%s: RACE\n", __func__);


### PR DESCRIPTION
Fix some compiler instruction re-ordering. Mayfly code with cpu_dmb() help avoid stalled memq_ull_rx processing when rx_demux is to be executed using mayfly.

![image](https://github.com/zephyrproject-rtos/zephyr/assets/6350656/21ec88f4-5e95-4f44-a8b2-d56322bbb587)

Fixes #62661
