### PR TITLE
settings: shell: Add value type and allow for strings to be used

### DIFF
--- a/subsys/settings/src/settings_shell.c
+++ b/subsys/settings/src/settings_shell.c
@@ -56,8 +56,14 @@ static int cmd_list(const struct shell *shell_ptr, size_t argc, char *argv[])
 	return err;
 }
 
+enum settings_value_types {
+	SETTINGS_VALUE_HEX,
+	SETTINGS_VALUE_STRING,
+};
+
 struct settings_read_callback_params {
 	const struct shell *shell_ptr;
+	const enum settings_value_types value_type;
 	bool value_found;
 };
 
@@ -84,7 +90,23 @@ static int settings_read_callback(const char *key,
 		return 0;
 	}
 
-	shell_hexdump(params->shell_ptr, buffer, num_read_bytes);
+	if (num_read_bytes == 0) {
+		shell_warn(params->shell_ptr, "Value is empty");
+		return 0;
+	}
+
+	switch (params->value_type) {
+	case SETTINGS_VALUE_HEX:
+		shell_hexdump(params->shell_ptr, buffer, num_read_bytes);
+		break;
+	case SETTINGS_VALUE_STRING:
+		if (buffer[num_read_bytes - 1] != '\0') {
+			shell_error(params->shell_ptr, "Value is not a string");
+			return 0;
+		}
+		shell_print(params->shell_ptr, "%s", buffer);
+		break;
+	}
 
 	if (len > SETTINGS_MAX_VAL_LEN) {
 		shell_print(params->shell_ptr, "(The output has been truncated)");
@@ -93,17 +115,40 @@ static int settings_read_callback(const char *key,
 	return 0;
 }
 
+static int settings_parse_type(const char *type, enum settings_value_types *value_type)
+{
+	if (strcmp(type, "string") == 0) {
+		*value_type = SETTINGS_VALUE_STRING;
+	} else if (strcmp(type, "hex") == 0) {
+		*value_type = SETTINGS_VALUE_HEX;
+	} else {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static int cmd_read(const struct shell *shell_ptr, size_t argc, char *argv[])
 {
 	int err;
-	const char *name = argv[1];
+
+	enum settings_value_types value_type = SETTINGS_VALUE_HEX;
+
+	if (argc > 2) {
+		err = settings_parse_type(argv[1], &value_type);
+		if (err) {
+			shell_error(shell_ptr, "Invalid type: %s", argv[1]);
+			return err;
+		}
+	}
 
 	struct settings_read_callback_params params = {
 		.shell_ptr = shell_ptr,
+		.value_type = value_type,
 		.value_found = false
 	};
 
-	err = settings_load_subtree_direct(name, settings_read_callback, &params);
+	err = settings_load_subtree_direct(argv[argc - 1], settings_read_callback, &params);
 
 	if (err) {
 		shell_error(shell_ptr, "Failed to load setting: %d", err);
@@ -119,16 +164,34 @@ static int cmd_write(const struct shell *shell_ptr, size_t argc, char *argv[])
 {
 	int err;
 	uint8_t buffer[CONFIG_SHELL_CMD_BUFF_SIZE / 2];
-	size_t buffer_len;
+	size_t buffer_len = 0;
+	enum settings_value_types value_type = SETTINGS_VALUE_HEX;
 
-	buffer_len = hex2bin(argv[2], strlen(argv[2]), buffer, sizeof(buffer));
+	if (argc > 3) {
+		err = settings_parse_type(argv[1], &value_type);
+		if (err) {
+			shell_error(shell_ptr, "Invalid type: %s", argv[1]);
+			return err;
+		}
+	}
+
+	switch (value_type) {
+	case SETTINGS_VALUE_HEX:
+		buffer_len = hex2bin(argv[argc - 1], strlen(argv[argc - 1]),
+			buffer, sizeof(buffer));
+		break;
+	case SETTINGS_VALUE_STRING:
+		buffer_len = strlen(argv[argc - 1]) + 1;
+		memcpy(buffer, argv[argc - 1], buffer_len);
+		break;
+	}
 
 	if (buffer_len == 0) {
-		shell_error(shell_ptr, "Failed to parse hex value");
+		shell_error(shell_ptr, "Failed to parse value");
 		return -EINVAL;
 	}
 
-	err = settings_save_one(argv[1], buffer, buffer_len);
+	err = settings_save_one(argv[argc - 2], buffer, buffer_len);
 
 	if (err) {
 		shell_error(shell_ptr, "Failed to write setting: %d", err);
@@ -151,11 +214,25 @@ static int cmd_delete(const struct shell *shell_ptr, size_t argc, char *argv[])
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(settings_cmds,
-			       SHELL_CMD_ARG(list, NULL, "[<subtree>]", cmd_list, 1, 1),
-			       SHELL_CMD_ARG(read, NULL, "<name>", cmd_read, 2, 0),
-			       SHELL_CMD_ARG(write, NULL, "<name> <hex>", cmd_write, 3, 0),
-			       SHELL_CMD_ARG(delete, NULL, "<name>", cmd_delete, 2, 0),
-			       SHELL_SUBCMD_SET_END);
+	SHELL_CMD_ARG(list, NULL,
+		"List all settings in a subtree (omit to list all)\n"
+		"Usage: settings list [subtree]",
+		cmd_list, 1, 1),
+	SHELL_CMD_ARG(read, NULL,
+		"Read a specific setting\n"
+		"Usage: settings read [type] <name>\n"
+		"type: string or hex (default: hex)",
+		cmd_read, 2, 1),
+	SHELL_CMD_ARG(write, NULL,
+		"Write to a specific setting\n"
+		"Usage: settings write [type] <name> <value>\n"
+		"type: string or hex (default: hex)",
+		cmd_write, 3, 1),
+	SHELL_CMD_ARG(delete, NULL,
+		"Delete a specific setting\n"
+		"Usage: settings delete <name>",
+		cmd_delete, 2, 0),
+	SHELL_SUBCMD_SET_END);
 
 static int cmd_settings(const struct shell *shell_ptr, size_t argc, char **argv)
 {


### PR DESCRIPTION
This can be further extended to support other data types.

It doesn't break the previous syntax, as the value type is optional.
Examples:
`settings write string foo bar`
`settings write hex foo ffff`
`settings write foo ffff`
`settings read string foo`
`settings read hex foo`
`settings read foo`

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/62546