### PR TITLE
can: rework the table lookup code in can_dlc_to_bytes

### DIFF
--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1360,7 +1360,7 @@ static inline uint8_t can_dlc_to_bytes(uint8_t dlc)
 	static const uint8_t dlc_table[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 12,
 					    16, 20, 24, 32, 48, 64};
 
-	return dlc > 0x0F ? 64 : dlc_table[dlc];
+	return dlc_table[MIN(dlc, ARRAY_SIZE(dlc_table) - 1)];
 }
 
 /**


### PR DESCRIPTION
Hi, fixing a warning that popped up with the switch to picolibc, guess that check was not there before for whatever reasons.

What do you think? Not in love with this solution myself to be honest, but adding a bunch of `#pragma GCC diagnostic ignored "-Warray-bounds"` around this does not sound great either.

---

Rework the can_dlc_to_bytes table lookup code in a way that allow the
compiler to guess the resulting output and somehow fix the build
warning:

zephyr/drivers/can/can_nxp_s32_canxl.c:757:9: warning:
'__builtin___memcpy_chk' forming offset [16, 71] is out of the bounds
[0, 16] of object 'frame' with type 'struct can_frame' [-Warray-bounds]
 757 | memcpy(frame->data, msg_data.data, can_dlc_to_bytes(frame->dlc));

where the compiler detects that frame->data is 8 bytes long but
can_dlc_to_bytes could return more than that.

Can be reproduced with:

west build -p -b s32z270dc2_rtu1_r52 \
	-T samples/net/sockets/can/sample.net.sockets.can.one_socket

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/62701