### PR TITLE
drivers: rtc: stm32: fix build for some L1 MCUs and allow RTC driver to work with BBRAM

### DIFF
--- a/drivers/bbram/Kconfig.stm32
+++ b/drivers/bbram/Kconfig.stm32
@@ -5,7 +5,7 @@ config BBRAM_STM32
 	bool "ST STM32 Battery-backed RAM drivers"
 	default y
 	depends on DT_HAS_ST_STM32_BBRAM_ENABLED
-	depends on COUNTER
+	depends on COUNTER_RTC_STM32 || RTC_STM32
 	help
 	  This option enables the BBRAM driver for STM32 family of
 	  processors.

--- a/drivers/rtc/Kconfig.stm32
+++ b/drivers/rtc/Kconfig.stm32
@@ -5,6 +5,7 @@ config RTC_STM32
 	bool "STM32 RTC driver"
 	default y if !COUNTER
 	depends on DT_HAS_ST_STM32_RTC_ENABLED && !SOC_SERIES_STM32F1X
+	select USE_STM32_LL_RTC
 	select USE_STM32_LL_PWR
 	select USE_STM32_LL_RCC
 	help

--- a/tests/drivers/bbram/stm32_rtc.conf
+++ b/tests/drivers/bbram/stm32_rtc.conf
@@ -1,0 +1,1 @@
+CONFIG_RTC=y

--- a/tests/drivers/bbram/testcase.yaml
+++ b/tests/drivers/bbram/testcase.yaml
@@ -22,3 +22,8 @@ tests:
     filter: dt_compat_enabled("st,stm32-bbram")
     integration_platforms:
       - stm32f746g_disco
+  driver.bbram.stm32_rtc:
+    extra_args: OVERLAY_CONFIG="stm32_rtc.conf"
+    filter: dt_compat_enabled("st,stm32-bbram")
+    integration_platforms:
+      - stm32f746g_disco


### PR DESCRIPTION
STM32 BBRAM depends on RTC to work. This changes STM32 RTC init stage to
PRE_KERNEL_1 to allow RTC driver to initialize before BBRAM driver.

Some adjustments are made so that kernel API is not used during the init
procedure.

Also add a test case and fix build for STM32L1 Cat.1 microcontrollers.