### PR TITLE
dts: regulator: Fix reoccurring typo in properties

### DIFF
--- a/dts/bindings/regulator/regulator.yaml
+++ b/dts/bindings/regulator/regulator.yaml
@@ -147,7 +147,7 @@ properties:
     type: int
     description: |
       Set over current error limit. This is a limit where part of the hardware
-      propably is malfunctional and damage prevention is requested. Zero can be
+      probably is malfunctional and damage prevention is requested. Zero can be
       passed to disable error detection and value '1' indicates that detection
       should be enabled but limit setting can be omitted.
 
@@ -172,7 +172,7 @@ properties:
     type: int
     description: |
       Set over voltage error limit. This is a limit where part of the hardware
-      propably is malfunctional and damage prevention is requested Zero can be
+      probably is malfunctional and damage prevention is requested Zero can be
       passed to disable error detection and value '1' indicates that detection
       should be enabled but limit setting can be omitted. Limit is given as
       microvolt offset from voltage set to regulator.
@@ -200,7 +200,7 @@ properties:
     type: int
     description: |
       Set under voltage error limit. This is a limit where part of the hardware
-      propably is malfunctional and damage prevention is requested Zero can be
+      probably is malfunctional and damage prevention is requested Zero can be
       passed to disable error detection and value '1' indicates that detection
       should be enabled but limit setting can be omitted. Limit is given as
       microvolt offset from voltage set to regulator.
@@ -227,7 +227,7 @@ properties:
     type: int
     description: |
       Set over temperature error limit. This is a limit where part of the
-      hardware propably is malfunctional and damage prevention is requested Zero
+      hardware probably is malfunctional and damage prevention is requested Zero
       can be passed to disable error detection and value '1' indicates that
       detection should be enabled but limit setting can be omitted.
 


### PR DESCRIPTION
Corrects 'propably' to 'probably' in the regulator devicetree bindings.