### PR TITLE
drivers: rtc: stm32: fix build warning

### DIFF
--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -349,7 +349,7 @@ static int rtc_stm32_get_calibration(const struct device *dev, int32_t *calibrat
 {
 	ARG_UNUSED(dev);
 
-	uint32_t calr = sys_read32(&RTC->CALR);
+	uint32_t calr = sys_read32((mem_addr_t) &RTC->CALR);
 
 	bool calp_enabled = READ_BIT(calr, RTC_CALR_CALP);
 	uint32_t calm = READ_BIT(calr, RTC_CALR_CALM);


### PR DESCRIPTION
Just add the proper expected cast.