### PR TITLE
modem: pipe: Reinvoke receive ready on attach

### DIFF
--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -53,6 +53,7 @@ struct modem_pipe {
 	enum modem_pipe_state state;
 	struct k_mutex lock;
 	struct k_condvar condvar;
+	bool receive_ready_pending;
 };
 
 /**


### PR DESCRIPTION
This PR makes the modem_pipe instances track if they have data ready to receive, and invoke the RECEIVE_READY event every time they are attached if the backend implementing the pipe has notified that receive is ready, without a complimentary `modem_pipe_receive()` call.

The feature is a response to this observed issue: 
1. A pipe is connected to the modem DLCI channel 1 pipe
2. modem_chat instance releases pipe and is attached to DLCI channel 2 pipe to run a script
3. Modem sends some commands to DLCI channel 1 pipe (registration status for example)
4. modem_chat instance is reattached to DLCI channel 1 pipe
5. The receive ready event is not sent, so the commands stored in the pipe remain unprocessed
6. modem_chat instance sends new script after a while (10 seconds)
7. modem starts responding to first script command
8. modem_chat processes all stored commands, which in the observed instance contained an old registration status (not registered) while the modem is in fact registered with an active PPP session.

This mechanism ensures that modules attaching to a pipe get the async RECEIVE_READY event immediately after attaching to a pipe if there is data ready, instead of having to poll the pipe, or worse, wait until newer data becomes available.

The issue could also be solved by having all modem modules manually poll the pipe when they are attached, but this results in duplicate boilerplate code.

The addition revealed a timing issue in the cmux test
suite. Specifically the CMUX instance now immediately
receives the response to a command which the CMUX
instance has not sent yet, causing it to drop the
response.

The CMUX test suite now uses the transaction
mechanism of the mock_pipe to wait for the command
before sending the response.