### PR TITLE
util.h: #include zephyr/toolchain.h, not zephyr/toolchain/common.h

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -15,7 +15,7 @@
 #define ZEPHYR_INCLUDE_SYS_UTIL_H_
 
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/toolchain/common.h>
+#include <zephyr/toolchain.h>
 
 /* needs to be outside _ASMLANGUAGE so 'true' and 'false' can turn
  * into '1' and '0' for asm or linker scripts


### PR DESCRIPTION
Commit 9c5dafed95ee ("util: add type checking to CONTAINER_OF") made `util.h` #include `toolchain/common.h` in order to get `BUILD_ASSERT()` used by CONTAINER_OF_VALIDATE() when compiling C code.

However `toolchain/common.h` is not supposed to be included directly but indirectly through `toolchain/<your_toolchain>.h` and in a very specific order.

The direct inclusion caused the following warning when compiling C++:

```
toolchain/gcc.h:87: error: "ZRESTRICT" redefined [-Werror]
   87 | #define ZRESTRICT __restrict
      |
In file included from include/zephyr/sys/util.h:18:
note: this is the location of the previous definition:
include/zephyr/toolchain/common.h:33:
   33 | #define ZRESTRICT
```

Fix this issue #62464 by including `zephyr/toolchain.h` instead, as done by 350 other files.

Fixes commit 9c5dafed95ee ("util: add type checking to CONTAINER_OF")