### PR TITLE
west: Fix typo in zsh and fish completion

### DIFF
--- a/scripts/west_commands/completion/west-completion.fish
+++ b/scripts/west_commands/completion/west-completion.fish
@@ -162,7 +162,7 @@ function __zephyr_west_complete_help
                         "list" "print information about projects" \
                         "manifest" "manage the west manifest" \
                         "diff" '"git diff" for one or more projects' \
-                        "statue" '"git status" for one or more projects' \
+                        "status" '"git status" for one or more projects' \
                         "forall" "run a command in one or more local projects" \
                         "config" "get or set config file values" \
                         "topdir" "print the top level directory of the workspace" \

--- a/scripts/west_commands/completion/west-completion.zsh
+++ b/scripts/west_commands/completion/west-completion.zsh
@@ -300,7 +300,7 @@ _west_spdx() {
   '(-i --init)'{-i,--init}'[initialize CMake file-based API]'
   '(-d --build-dir)'{-d,--build-dir}'[build directory to create or use]:build dir:_directories'
   '(-n --namespace-prefix)'{-n,--namespace-prefix}'[namespace prefix]:namespace prefix:'
-  '(-s --spdx-dir)'{-d,--spdx-dir}'[SPDX output directory]:spdx output dir:_directories'
+  '(-s --spdx-dir)'{-s,--spdx-dir}'[SPDX output directory]:spdx output dir:_directories'
   '--analyze-includes[also analyze included header files]'
   '--include-sdk[also generate SPDX document for SDK]'
   )


### PR DESCRIPTION
Following this comment https://github.com/zephyrproject-rtos/zephyr/pull/62477#pullrequestreview-1625336771 on a previous PR.
Fix two typo, one in zsh and one in fish.

See commits message for more details.