### PR TITLE
Enable S32K3 WKPU IP block to pass interrupt trigger through GPIO

### DIFF
--- a/boards/arm/mr_canhubk3/doc/index.rst
+++ b/boards/arm/mr_canhubk3/doc/index.rst
@@ -48,6 +48,7 @@ Interface     Controller  Driver/Component
 SIUL2         on-chip     | pinctrl
                           | gpio
                           | external interrupt controller
+WKPU          on-chip     interrupt controller
 LPUART        on-chip     serial
 QSPI          on-chip     flash
 FLEXCAN       on-chip     can
@@ -69,6 +70,21 @@ Connections and IOs
 Each GPIO port is divided into two banks: low bank, from pin 0 to 15, and high
 bank, from pin 16 to 31. For example, ``PTA2`` is the pin 2 of ``gpioa_l`` (low
 bank), and ``PTA20`` is the pin 4 of ``gpioa_h`` (high bank).
+
+The GPIO controller provides the option to route external input pad interrupts
+to either the SIUL2 EIRQ or WKPU interrupt controllers, as supported by the SoC.
+By default, GPIO interrupts are routed to SIUL2 EIRQ interrupt controller,
+unless they are explicity configured to be directed to the WKPU interrupt
+controller, as outlined in :zephyr_file:`dts/bindings/gpio/nxp,s32-gpio.yaml`.
+
+To find information about which GPIOs are compatible with each interrupt
+controller, refer to the device reference manual.
+
+.. note::
+
+   It is important to highlight that the current board configuration lacks
+   support for wake-up events and power-management features. WKPU functionality
+   is restricted solely to serving as an interrupt controller.
 
 LEDs
 ----

--- a/drivers/gpio/gpio_nxp_s32.c
+++ b/drivers/gpio/gpio_nxp_s32.c
@@ -9,20 +9,27 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/gpio/gpio_utils.h>
+#include <zephyr/logging/log.h>
 
 #include <Siul2_Port_Ip.h>
 #include <Siul2_Dio_Ip.h>
 
+LOG_MODULE_REGISTER(nxp_s32_gpio, CONFIG_GPIO_LOG_LEVEL);
+
 #ifdef CONFIG_NXP_S32_EIRQ
 #include <zephyr/drivers/interrupt_controller/intc_eirq_nxp_s32.h>
 
-struct eirq_nxp_s32_info {
-	const struct device *eirq_dev;
-	uint8_t num_lines;
-	struct gpio_pin_line {
-		uint8_t pin;
-		uint8_t line;
-	} gpio_pin_lines[];
+#define NXP_S32_GPIO_LINE_NOT_FOUND 0xff
+
+struct gpio_nxp_s32_irq_map {
+	uint8_t pin;
+	uint8_t line;
+} __packed;
+
+struct gpio_nxp_s32_irq_config {
+	const struct device *ctrl;
+	uint8_t map_cnt;
+	struct gpio_nxp_s32_irq_map *map;
 };
 #endif
 
@@ -34,7 +41,7 @@ struct gpio_nxp_s32_config {
 	Siul2_Port_Ip_PortType *port_base;
 
 #ifdef CONFIG_NXP_S32_EIRQ
-	struct eirq_nxp_s32_info *eirq_info;
+	struct gpio_nxp_s32_irq_config *eirq_info;
 #endif
 };
 
@@ -155,17 +162,26 @@ static int nxp_s32_gpio_port_toggle_bits(const struct device *port,
 
 #ifdef CONFIG_NXP_S32_EIRQ
 
-static uint8_t nxp_s32_gpio_pin_to_line(const struct eirq_nxp_s32_info *eirq_info, uint8_t pin)
+static uint8_t nxp_s32_gpio_pin_to_line(const struct gpio_nxp_s32_irq_config *irq_cfg,
+					uint8_t pin)
 {
 	uint8_t i;
 
-	for (i = 0; i < eirq_info->num_lines; i++) {
-		if (eirq_info->gpio_pin_lines[i].pin == pin) {
-			return eirq_info->gpio_pin_lines[i].line;
+	for (i = 0; i < irq_cfg->map_cnt; i++) {
+		if (irq_cfg->map[i].pin == pin) {
+			return irq_cfg->map[i].line;
 		}
 	}
 
-	return SIUL2_ICU_IP_NUM_OF_CHANNELS;
+	return NXP_S32_GPIO_LINE_NOT_FOUND;
+}
+
+static void nxp_s32_gpio_isr(uint8_t pin, void *arg)
+{
+	const struct device *dev = (struct device *)arg;
+	struct gpio_nxp_s32_data *data = dev->data;
+
+	gpio_fire_callbacks(&data->callbacks, dev, BIT(pin));
 }
 
 static int nxp_s32_gpio_eirq_get_trigger(Siul2_Icu_Ip_EdgeType *edge_type,
@@ -198,12 +214,48 @@ static int nxp_s32_gpio_eirq_get_trigger(Siul2_Icu_Ip_EdgeType *edge_type,
 	return 0;
 }
 
-static void nxp_s32_gpio_isr(uint8_t pin, void *arg)
+static int nxp_s32_gpio_config_eirq(const struct device *dev,
+				    gpio_pin_t pin,
+				    enum gpio_int_mode mode,
+				    enum gpio_int_trig trig)
 {
-	const struct device *dev = (struct device *)arg;
-	struct gpio_nxp_s32_data *data = dev->data;
+	const struct gpio_nxp_s32_config *config = dev->config;
+	const struct gpio_nxp_s32_irq_config *irq_cfg = config->eirq_info;
+	uint8_t irq_line;
+	Siul2_Icu_Ip_EdgeType edge_type;
 
-	gpio_fire_callbacks(&data->callbacks, dev, BIT(pin));
+	if (irq_cfg == NULL) {
+		LOG_ERR("external interrupt controller not available or enabled");
+		return -ENOTSUP;
+	}
+
+	if (nxp_s32_gpio_eirq_get_trigger(&edge_type, mode, trig)) {
+		LOG_ERR("trigger or mode not supported");
+		return -ENOTSUP;
+	}
+
+	irq_line = nxp_s32_gpio_pin_to_line(irq_cfg, pin);
+	if (irq_line == NXP_S32_GPIO_LINE_NOT_FOUND) {
+		if (edge_type == SIUL2_ICU_DISABLE) {
+			return 0;
+		}
+		LOG_ERR("pin %d cannot be used for external interrupt", pin);
+		return -ENOTSUP;
+	}
+
+	if (edge_type == SIUL2_ICU_DISABLE) {
+		eirq_nxp_s32_disable_interrupt(irq_cfg->ctrl, irq_line);
+		eirq_nxp_s32_unset_callback(irq_cfg->ctrl, irq_line);
+	} else {
+		if (eirq_nxp_s32_set_callback(irq_cfg->ctrl, irq_line,
+					nxp_s32_gpio_isr, pin, (void *)dev)) {
+			LOG_ERR("pin %d is already in use", pin);
+			return -EBUSY;
+		}
+		eirq_nxp_s32_enable_interrupt(irq_cfg->ctrl, irq_line, edge_type);
+	}
+
+	return 0;
 }
 
 static int nxp_s32_gpio_pin_interrupt_configure(const struct device *dev,
@@ -211,48 +263,7 @@ static int nxp_s32_gpio_pin_interrupt_configure(const struct device *dev,
 						enum gpio_int_mode mode,
 						enum gpio_int_trig trig)
 {
-	const struct gpio_nxp_s32_config *config = dev->config;
-	const struct eirq_nxp_s32_info *eirq_info = config->eirq_info;
-
-	uint8_t eirq_line;
-
-	Siul2_Icu_Ip_EdgeType edge_type;
-
-	if (eirq_info == NULL) {
-		/*
-		 * There is no external interrupt device for
-		 * the GPIO port or exists but is not enabled
-		 */
-		return -ENOTSUP;
-	}
-
-	eirq_line = nxp_s32_gpio_pin_to_line(eirq_info, pin);
-
-	if (eirq_line == SIUL2_ICU_IP_NUM_OF_CHANNELS) {
-		/*
-		 * GPIO pin cannot be used for processing
-		 * external interrupt signal
-		 */
-		return -ENOTSUP;
-	}
-
-	if (nxp_s32_gpio_eirq_get_trigger(&edge_type, mode, trig)) {
-		return -ENOTSUP;
-	}
-
-	if (edge_type == SIUL2_ICU_DISABLE) {
-		eirq_nxp_s32_disable_interrupt(eirq_info->eirq_dev, eirq_line);
-		eirq_nxp_s32_unset_callback(eirq_info->eirq_dev, eirq_line);
-	} else {
-		if (eirq_nxp_s32_set_callback(eirq_info->eirq_dev, eirq_line,
-						nxp_s32_gpio_isr, pin, (void *)dev)) {
-			return -EBUSY;
-		}
-
-		eirq_nxp_s32_enable_interrupt(eirq_info->eirq_dev, eirq_line, edge_type);
-	}
-
-	return 0;
+	return nxp_s32_gpio_config_eirq(dev, pin, mode, trig);
 }
 
 static int nxp_s32_gpio_manage_callback(const struct device *dev,
@@ -266,7 +277,7 @@ static int nxp_s32_gpio_manage_callback(const struct device *dev,
 static uint32_t nxp_s32_gpio_get_pending_int(const struct device *dev)
 {
 	const struct gpio_nxp_s32_config *config = dev->config;
-	const struct eirq_nxp_s32_info *eirq_info = config->eirq_info;
+	const struct gpio_nxp_s32_irq_config *eirq_info = config->eirq_info;
 
 	if (eirq_info == NULL) {
 		/*
@@ -280,7 +291,7 @@ static uint32_t nxp_s32_gpio_get_pending_int(const struct device *dev)
 	 * Return all pending lines of the interrupt controller
 	 * that GPIO port belongs to
 	 */
-	return eirq_nxp_s32_get_pending(eirq_info->eirq_dev);
+	return eirq_nxp_s32_get_pending(eirq_info->ctrl);
 }
 #endif /* CONFIG_NXP_S32_EIRQ */
 
@@ -424,30 +435,30 @@ static const struct gpio_driver_api gpio_nxp_s32_driver_api = {
 	DT_INST_PHANDLE(n, interrupt_parent)
 
 #define GPIO_NXP_S32_EIRQ_PIN_LINE(idx, n)					\
-	{									\
-		.pin  = DT_INST_IRQ_BY_IDX(n, idx, gpio_pin),			\
-		.line = DT_INST_IRQ_BY_IDX(n, idx, eirq_line),			\
-	}
+	DT_INST_IRQ_BY_IDX(n, idx, gpio_pin),					\
+	DT_INST_IRQ_BY_IDX(n, idx, eirq_line)					\
 
 #define GPIO_NXP_S32_SET_EIRQ_INFO(n)						\
 	BUILD_ASSERT((DT_NODE_HAS_PROP(DT_DRV_INST(n), interrupt_parent) ==	\
 			DT_NODE_HAS_PROP(DT_DRV_INST(n), interrupts)),		\
-			"interrupts and interrupt-parent must be set when"	\
-			" using external interrupts");				\
-	IF_ENABLED(DT_NODE_HAS_STATUS(GPIO_NXP_S32_EIRQ_NODE(n), okay),		\
-		(static struct eirq_nxp_s32_info eirq_nxp_s32_info_##n = {	\
-			.eirq_dev = DEVICE_DT_GET(GPIO_NXP_S32_EIRQ_NODE(n)),	\
-			.gpio_pin_lines = {					\
-				LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)),		\
-					GPIO_NXP_S32_EIRQ_PIN_LINE, (,), n)	\
-			},							\
-			.num_lines = DT_NUM_IRQS(DT_DRV_INST(n))		\
+			"interrupts and interrupt-parent must be set when "	\
+			"using external interrupts");				\
+	IF_ENABLED(DT_NODE_HAS_STATUS(GPIO_NXP_S32_EIRQ_NODE(n), okay), (	\
+		static uint8_t gpio_nxp_s32_eirq_data_##n[] = {			\
+			LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)),			\
+				GPIO_NXP_S32_EIRQ_PIN_LINE, (,), n)		\
 		};								\
-		))
+		static struct gpio_nxp_s32_irq_config gpio_nxp_s32_eirq_##n = {	\
+			.ctrl = DEVICE_DT_GET(GPIO_NXP_S32_EIRQ_NODE(n)),	\
+			.map_cnt = DT_NUM_IRQS(DT_DRV_INST(n)),			\
+			.map = (struct gpio_nxp_s32_irq_map *)			\
+				gpio_nxp_s32_eirq_data_##n,			\
+		};								\
+	))
 
 #define GPIO_NXP_S32_GET_EIRQ_INFO(n)						\
 	.eirq_info = UTIL_AND(DT_NODE_HAS_STATUS(GPIO_NXP_S32_EIRQ_NODE(n), okay),\
-				&eirq_nxp_s32_info_##n)
+				&gpio_nxp_s32_eirq_##n),
 #else
 #define GPIO_NXP_S32_SET_EIRQ_INFO(n)
 #define GPIO_NXP_S32_GET_EIRQ_INFO(n)

--- a/drivers/gpio/gpio_nxp_s32.c
+++ b/drivers/gpio/gpio_nxp_s32.c
@@ -9,6 +9,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/gpio/gpio_utils.h>
+#include <zephyr/dt-bindings/gpio/nxp-s32-gpio.h>
 #include <zephyr/logging/log.h>
 
 #include <Siul2_Port_Ip.h>
@@ -18,7 +19,12 @@ LOG_MODULE_REGISTER(nxp_s32_gpio, CONFIG_GPIO_LOG_LEVEL);
 
 #ifdef CONFIG_NXP_S32_EIRQ
 #include <zephyr/drivers/interrupt_controller/intc_eirq_nxp_s32.h>
+#endif
+#ifdef CONFIG_NXP_S32_WKPU
+#include <zephyr/drivers/interrupt_controller/intc_wkpu_nxp_s32.h>
+#endif
 
+#if defined(CONFIG_NXP_S32_EIRQ) || defined(CONFIG_NXP_S32_WKPU)
 #define NXP_S32_GPIO_LINE_NOT_FOUND 0xff
 
 struct gpio_nxp_s32_irq_map {
@@ -43,14 +49,20 @@ struct gpio_nxp_s32_config {
 #ifdef CONFIG_NXP_S32_EIRQ
 	struct gpio_nxp_s32_irq_config *eirq_info;
 #endif
+#ifdef CONFIG_NXP_S32_WKPU
+	struct gpio_nxp_s32_irq_config *wkpu_info;
+#endif
 };
 
 struct gpio_nxp_s32_data {
 	/* gpio_driver_data needs to be first */
 	struct gpio_driver_data common;
 
-#ifdef CONFIG_NXP_S32_EIRQ
+#if defined(CONFIG_NXP_S32_EIRQ) || defined(CONFIG_NXP_S32_WKPU)
 	sys_slist_t callbacks;
+#if defined(CONFIG_NXP_S32_WKPU)
+	uint32_t pin_wkpu_mask;
+#endif /* defined(CONFIG_NXP_S32_WKPU) */
 #endif
 };
 
@@ -65,6 +77,16 @@ static int nxp_s32_gpio_configure(const struct device *dev, gpio_pin_t pin,
 	if ((flags & GPIO_SINGLE_ENDED) != 0) {
 		return -ENOTSUP;
 	}
+
+#if defined(CONFIG_NXP_S32_WKPU)
+	struct gpio_nxp_s32_data *data = dev->data;
+
+	WRITE_BIT(data->pin_wkpu_mask, pin, (flags & NXP_S32_GPIO_INT_WKPU));
+#else
+	if (flags & NXP_S32_GPIO_INT_WKPU) {
+		return -ENOTSUP;
+	}
+#endif
 
 	switch (flags & GPIO_DIR_MASK) {
 	case GPIO_INPUT:
@@ -160,7 +182,7 @@ static int nxp_s32_gpio_port_toggle_bits(const struct device *port,
 	return 0;
 }
 
-#ifdef CONFIG_NXP_S32_EIRQ
+#if defined(CONFIG_NXP_S32_EIRQ) || defined(CONFIG_NXP_S32_WKPU)
 
 static uint8_t nxp_s32_gpio_pin_to_line(const struct gpio_nxp_s32_irq_config *irq_cfg,
 					uint8_t pin)
@@ -184,6 +206,7 @@ static void nxp_s32_gpio_isr(uint8_t pin, void *arg)
 	gpio_fire_callbacks(&data->callbacks, dev, BIT(pin));
 }
 
+#if defined(CONFIG_NXP_S32_EIRQ)
 static int nxp_s32_gpio_eirq_get_trigger(Siul2_Icu_Ip_EdgeType *edge_type,
 					 enum gpio_int_mode mode,
 					 enum gpio_int_trig trigger)
@@ -257,13 +280,100 @@ static int nxp_s32_gpio_config_eirq(const struct device *dev,
 
 	return 0;
 }
+#endif /* CONFIG_NXP_S32_EIRQ */
+
+#if defined(CONFIG_NXP_S32_WKPU)
+static int nxp_s32_gpio_wkpu_get_trigger(Wkpu_Ip_EdgeType *edge_type,
+					 enum gpio_int_mode mode,
+					 enum gpio_int_trig trigger)
+{
+	if (mode == GPIO_INT_MODE_DISABLED) {
+		*edge_type = WKPU_IP_NONE_EDGE;
+		return 0;
+	}
+
+	if (mode == GPIO_INT_MODE_LEVEL) {
+		return -ENOTSUP;
+	}
+
+	switch (trigger) {
+	case GPIO_INT_TRIG_LOW:
+		*edge_type = WKPU_IP_FALLING_EDGE;
+		break;
+	case GPIO_INT_TRIG_HIGH:
+		*edge_type = WKPU_IP_RISING_EDGE;
+		break;
+	case GPIO_INT_TRIG_BOTH:
+		*edge_type = WKPU_IP_BOTH_EDGES;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int nxp_s32_gpio_config_wkpu(const struct device *dev,
+				    gpio_pin_t pin,
+				    enum gpio_int_mode mode,
+				    enum gpio_int_trig trig)
+{
+	const struct gpio_nxp_s32_config *config = dev->config;
+	const struct gpio_nxp_s32_irq_config *irq_cfg = config->wkpu_info;
+	uint8_t irq_line;
+	Wkpu_Ip_EdgeType edge_type;
+
+	if (irq_cfg == NULL) {
+		LOG_ERR("WKPU controller not available or enabled");
+		return -ENOTSUP;
+	}
+
+	if (nxp_s32_gpio_wkpu_get_trigger(&edge_type, mode, trig)) {
+		LOG_ERR("trigger or mode not supported");
+		return -ENOTSUP;
+	}
+
+	irq_line = nxp_s32_gpio_pin_to_line(irq_cfg, pin);
+	if (irq_line == NXP_S32_GPIO_LINE_NOT_FOUND) {
+		if (edge_type == WKPU_IP_NONE_EDGE) {
+			return 0;
+		}
+		LOG_ERR("pin %d cannot be used for external interrupt", pin);
+		return -ENOTSUP;
+	}
+
+	if (edge_type == WKPU_IP_NONE_EDGE) {
+		wkpu_nxp_s32_disable_interrupt(irq_cfg->ctrl, irq_line);
+		wkpu_nxp_s32_unset_callback(irq_cfg->ctrl, irq_line);
+	} else {
+		if (wkpu_nxp_s32_set_callback(irq_cfg->ctrl, irq_line,
+					nxp_s32_gpio_isr, pin, (void *)dev)) {
+			LOG_ERR("pin %d is already in use", pin);
+			return -EBUSY;
+		}
+		wkpu_nxp_s32_enable_interrupt(irq_cfg->ctrl, irq_line, edge_type);
+	}
+
+	return 0;
+}
+#endif /* CONFIG_NXP_S32_WKPU */
 
 static int nxp_s32_gpio_pin_interrupt_configure(const struct device *dev,
 						gpio_pin_t pin,
 						enum gpio_int_mode mode,
 						enum gpio_int_trig trig)
 {
+#if defined(CONFIG_NXP_S32_WKPU)
+	struct gpio_nxp_s32_data *data = dev->data;
+
+	if (data->pin_wkpu_mask & BIT(pin)) {
+		return nxp_s32_gpio_config_wkpu(dev, pin, mode, trig);
+	}
+#endif
+
+#if defined(CONFIG_NXP_S32_EIRQ)
 	return nxp_s32_gpio_config_eirq(dev, pin, mode, trig);
+#endif
 }
 
 static int nxp_s32_gpio_manage_callback(const struct device *dev,
@@ -273,27 +383,7 @@ static int nxp_s32_gpio_manage_callback(const struct device *dev,
 
 	return gpio_manage_callback(&data->callbacks, cb, set);
 }
-
-static uint32_t nxp_s32_gpio_get_pending_int(const struct device *dev)
-{
-	const struct gpio_nxp_s32_config *config = dev->config;
-	const struct gpio_nxp_s32_irq_config *eirq_info = config->eirq_info;
-
-	if (eirq_info == NULL) {
-		/*
-		 * There is no external interrupt device for
-		 * the GPIO port or exists but is not enabled
-		 */
-		return 0;
-	}
-
-	/*
-	 * Return all pending lines of the interrupt controller
-	 * that GPIO port belongs to
-	 */
-	return eirq_nxp_s32_get_pending(eirq_info->ctrl);
-}
-#endif /* CONFIG_NXP_S32_EIRQ */
+#endif /* defined(CONFIG_NXP_S32_EIRQ) || defined(CONFIG_NXP_S32_WKPU) */
 
 #ifdef CONFIG_GPIO_GET_CONFIG
 static int nxp_s32_gpio_pin_get_config(const struct device *dev,
@@ -386,10 +476,9 @@ static const struct gpio_driver_api gpio_nxp_s32_driver_api = {
 	.port_set_bits_raw = nxp_s32_gpio_port_set_bits_raw,
 	.port_clear_bits_raw = nxp_s32_gpio_port_clear_bits_raw,
 	.port_toggle_bits = nxp_s32_gpio_port_toggle_bits,
-#ifdef CONFIG_NXP_S32_EIRQ
+#if defined(CONFIG_NXP_S32_EIRQ) || defined(CONFIG_NXP_S32_WKPU)
 	.pin_interrupt_configure = nxp_s32_gpio_pin_interrupt_configure,
 	.manage_callback = nxp_s32_gpio_manage_callback,
-	.get_pending_int = nxp_s32_gpio_get_pending_int,
 #endif
 #ifdef CONFIG_GPIO_GET_CONFIG
 	.pin_get_config = nxp_s32_gpio_pin_get_config,
@@ -464,8 +553,36 @@ static const struct gpio_driver_api gpio_nxp_s32_driver_api = {
 #define GPIO_NXP_S32_GET_EIRQ_INFO(n)
 #endif /* CONFIG_NXP_S32_EIRQ */
 
+#ifdef CONFIG_NXP_S32_WKPU
+#define GPIO_NXP_S32_WKPU_NODE(n) DT_INST_PHANDLE(n, nxp_wkpu)
+
+#define GPIO_NXP_S32_SET_WKPU_INFO(n)						\
+	BUILD_ASSERT((DT_INST_NODE_HAS_PROP(n, nxp_wkpu) ==			\
+			DT_INST_NODE_HAS_PROP(n, nxp_wkpu_interrupts)),		\
+			"nxp,wkpu and nxp,wkpu-interrupts must be provided");	\
+	IF_ENABLED(DT_NODE_HAS_STATUS(GPIO_NXP_S32_WKPU_NODE(n), okay), (	\
+		static uint8_t gpio_nxp_s32_wkpu_data_##n[] =			\
+			DT_INST_PROP(n, nxp_wkpu_interrupts);			\
+		static struct gpio_nxp_s32_irq_config gpio_nxp_s32_wkpu_##n = {	\
+			.ctrl = DEVICE_DT_GET(GPIO_NXP_S32_WKPU_NODE(n)),	\
+			.map_cnt = sizeof(gpio_nxp_s32_wkpu_data_##n) /		\
+				sizeof(struct gpio_nxp_s32_irq_map),		\
+			.map = (struct gpio_nxp_s32_irq_map *)			\
+				gpio_nxp_s32_wkpu_data_##n,			\
+		};								\
+	))
+
+#define GPIO_NXP_S32_GET_WKPU_INFO(n)						\
+	.wkpu_info = UTIL_AND(DT_NODE_HAS_STATUS(GPIO_NXP_S32_WKPU_NODE(n), okay),\
+				&gpio_nxp_s32_wkpu_##n)
+#else
+#define GPIO_NXP_S32_SET_WKPU_INFO(n)
+#define GPIO_NXP_S32_GET_WKPU_INFO(n)
+#endif /* CONFIG_NXP_S32_WKPU */
+
 #define GPIO_NXP_S32_DEVICE_INIT(n)						\
 	GPIO_NXP_S32_SET_EIRQ_INFO(n)						\
+	GPIO_NXP_S32_SET_WKPU_INFO(n)						\
 	static const struct gpio_nxp_s32_config gpio_nxp_s32_config_##n = {	\
 		.common = {							\
 			.port_pin_mask = GPIO_NXP_S32_PORT_PIN_MASK(n),		\
@@ -473,6 +590,7 @@ static const struct gpio_driver_api gpio_nxp_s32_driver_api = {
 		.gpio_base = GPIO_NXP_S32_REG_ADDR(n),				\
 		.port_base = GPIO_NXP_S32_PORT_REG_ADDR(n),			\
 		GPIO_NXP_S32_GET_EIRQ_INFO(n)					\
+		GPIO_NXP_S32_GET_WKPU_INFO(n)					\
 	};									\
 	static struct gpio_nxp_s32_data gpio_nxp_s32_data_##n;			\
 	static int gpio_nxp_s32_init_##n(const struct device *dev)		\

--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -33,6 +33,7 @@ zephyr_library_sources_ifdef(CONFIG_VEXRISCV_LITEX_IRQ      intc_vexriscv_litex.
 zephyr_library_sources_ifdef(CONFIG_VIM                     intc_vim.c)
 zephyr_library_sources_ifdef(CONFIG_NUCLEI_ECLIC            intc_nuclei_eclic.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_S32_EIRQ            intc_eirq_nxp_s32.c)
+zephyr_library_sources_ifdef(CONFIG_NXP_S32_WKPU            intc_wkpu_nxp_s32.c)
 zephyr_library_sources_ifdef(CONFIG_XMC4XXX_INTC            intc_xmc4xxx.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_PINT                intc_nxp_pint.c)
 

--- a/drivers/interrupt_controller/Kconfig.nxp_s32
+++ b/drivers/interrupt_controller/Kconfig.nxp_s32
@@ -1,6 +1,6 @@
 # Configuration for NXP S32 external interrupt controller
 
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config NXP_S32_EIRQ
@@ -10,3 +10,11 @@ config NXP_S32_EIRQ
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	help
 	  External interrupt controller driver for NXP S32 MCUs
+
+config NXP_S32_WKPU
+	bool "Wake-up Unit interrupt controller driver for NXP S32 MCUs"
+	default y
+	depends on DT_HAS_NXP_S32_WKPU_ENABLED
+	select NOCACHE_MEMORY
+	help
+	  Wake-up Unit interrupt controller driver for NXP S32 MCUs

--- a/drivers/interrupt_controller/intc_wkpu_nxp_s32.c
+++ b/drivers/interrupt_controller/intc_wkpu_nxp_s32.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_s32_wkpu
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/irq.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/drivers/interrupt_controller/intc_wkpu_nxp_s32.h>
+
+#include <Wkpu_Ip_Irq.h>
+
+#define NXP_S32_NUM_CHANNELS		WKPU_IP_NUM_OF_CHANNELS
+#define NXP_S32_NUM_CHANNELS_DEBRACKET	__DEBRACKET WKPU_IP_NUM_OF_CHANNELS
+
+struct wkpu_nxp_s32_config {
+	uint8_t instance;
+
+	const WKPU_Type *base;
+
+	const Wkpu_Ip_IrqConfigType *wkpu_cfg;
+};
+
+/* Wrapper callback for each WKPU line, from low level driver callback to GPIO callback */
+struct wkpu_nxp_s32_cb {
+	wkpu_nxp_s32_callback_t cb;
+	uint8_t pin;
+	void *data;
+};
+
+struct wkpu_nxp_s32_data {
+	struct wkpu_nxp_s32_cb *cb;
+};
+
+int wkpu_nxp_s32_set_callback(const struct device *dev, uint8_t line,
+				wkpu_nxp_s32_callback_t cb, uint8_t pin, void *arg)
+{
+	struct wkpu_nxp_s32_data *data = dev->data;
+
+	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+
+	if (data->cb[line].cb) {
+		return -EBUSY;
+	}
+
+	data->cb[line].cb   = cb;
+	data->cb[line].pin  = pin;
+	data->cb[line].data = arg;
+
+	return 0;
+}
+
+void wkpu_nxp_s32_unset_callback(const struct device *dev, uint8_t line)
+{
+	struct wkpu_nxp_s32_data *data = dev->data;
+
+	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+
+	data->cb[line].cb    = NULL;
+	data->cb[line].pin   = 0;
+	data->cb[line].data  = NULL;
+}
+
+void wkpu_nxp_s32_enable_interrupt(const struct device *dev, uint8_t line,
+				   Wkpu_Ip_EdgeType edge_type)
+{
+	const struct wkpu_nxp_s32_config *config = dev->config;
+
+	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+
+	Wkpu_Ip_SetActivationCondition(config->instance, line, edge_type);
+	Wkpu_Ip_EnableNotification(line);
+	Wkpu_Ip_EnableInterrupt(config->instance, line);
+}
+
+void wkpu_nxp_s32_disable_interrupt(const struct device *dev, uint8_t line)
+{
+	const struct wkpu_nxp_s32_config *config = dev->config;
+
+	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+
+	Wkpu_Ip_DisableInterrupt(config->instance, line);
+	Wkpu_Ip_DisableNotification(line);
+	Wkpu_Ip_SetActivationCondition(config->instance, line, WKPU_IP_NONE_EDGE);
+}
+
+uint64_t wkpu_nxp_s32_get_pending(const struct device *dev)
+{
+	const struct wkpu_nxp_s32_config *config = dev->config;
+	uint64_t flags;
+
+	flags = config->base->WISR & config->base->IRER;
+#if defined(WKPU_IP_64_CH_USED) && (WKPU_IP_64_CH_USED == STD_ON)
+	flags |= ((uint64_t)(config->base->WISR_64 & config->base->IRER_64)) << 32U;
+#endif
+
+	return flags;
+}
+
+static void wkpu_nxp_s32_callback(const struct device *dev, uint8 line)
+{
+	const struct wkpu_nxp_s32_data *data = dev->data;
+
+	if (data->cb[line].cb != NULL) {
+		data->cb[line].cb(data->cb[line].pin, data->cb[line].data);
+	}
+}
+
+static int wkpu_nxp_s32_init(const struct device *dev)
+{
+	const struct wkpu_nxp_s32_config *config = dev->config;
+
+	if (Wkpu_Ip_Init(config->instance, config->wkpu_cfg)) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+#define WKPU_NXP_S32_CALLBACK(line, n)								\
+	void nxp_s32_wkpu_##n##wkpu_line_##line##_callback(void)				\
+	{											\
+		const struct device *dev = DEVICE_DT_INST_GET(n);				\
+												\
+		wkpu_nxp_s32_callback(dev, line);						\
+	}
+
+#define WKPU_NXP_S32_CHANNEL_CONFIG(idx, n)							\
+	{											\
+		.hwChannel = idx,								\
+		.filterEn = DT_INST_PROP_OR(DT_INST_CHILD(n, line_##idx), filter_enable, 0),	\
+		.edgeEvent = WKPU_IP_NONE_EDGE,							\
+		.WkpuChannelNotification = nxp_s32_wkpu_##n##wkpu_line_##idx##_callback,	\
+		.callback = NULL,								\
+		.callbackParam = 0U								\
+	}
+
+#define WKPU_NXP_S32_CHANNELS_CONFIG(n)								\
+	static const Wkpu_Ip_ChannelConfigType wkpu_##n##_channel_nxp_s32_cfg[] = {		\
+		LISTIFY(NXP_S32_NUM_CHANNELS_DEBRACKET,	WKPU_NXP_S32_CHANNEL_CONFIG, (,), n)	\
+	}
+
+#define WKPU_NXP_S32_INSTANCE_CONFIG(n)								\
+	static const Wkpu_Ip_IrqConfigType wkpu_##n##_nxp_s32_cfg = {				\
+		.numChannels	 = NXP_S32_NUM_CHANNELS,					\
+		.pChannelsConfig = &wkpu_##n##_channel_nxp_s32_cfg,				\
+	}
+
+#define WKPU_NXP_S32_CONFIG(n)									\
+	LISTIFY(NXP_S32_NUM_CHANNELS_DEBRACKET, WKPU_NXP_S32_CALLBACK, (), n)			\
+	WKPU_NXP_S32_CHANNELS_CONFIG(n);							\
+	WKPU_NXP_S32_INSTANCE_CONFIG(n);
+
+#define WKPU_NXP_S32_INIT_DEVICE(n)								\
+	WKPU_NXP_S32_CONFIG(n)									\
+	static const struct wkpu_nxp_s32_config wkpu_nxp_s32_conf_##n = {			\
+		.instance = n,									\
+		.base = (WKPU_Type *)DT_INST_REG_ADDR(n),					\
+		.wkpu_cfg = (Wkpu_Ip_IrqConfigType *)&wkpu_##n##_nxp_s32_cfg,			\
+	};											\
+	static struct wkpu_nxp_s32_cb wkpu_nxp_s32_cb_##n[NXP_S32_NUM_CHANNELS];		\
+	static struct wkpu_nxp_s32_data wkpu_nxp_s32_data_##n = {				\
+		.cb = wkpu_nxp_s32_cb_##n,							\
+	};											\
+	static int wkpu_nxp_s32_init##n(const struct device *dev)				\
+	{											\
+		int err;									\
+												\
+		err = wkpu_nxp_s32_init(dev);							\
+		if (err) {									\
+			return err;								\
+		}										\
+												\
+		IRQ_CONNECT(DT_INST_IRQ(n, irq), DT_INST_IRQ(n, priority),			\
+			WKPU_EXT_IRQ_SINGLE_ISR, NULL,						\
+			COND_CODE_1(CONFIG_GIC, (DT_INST_IRQ(n, flags)), (0)));			\
+		irq_enable(DT_INST_IRQ(n, irq));						\
+												\
+		return 0;									\
+	}											\
+	DEVICE_DT_INST_DEFINE(n,								\
+		wkpu_nxp_s32_init##n,								\
+		NULL,										\
+		&wkpu_nxp_s32_data_##n,								\
+		&wkpu_nxp_s32_conf_##n,								\
+		PRE_KERNEL_2,									\
+		CONFIG_INTC_INIT_PRIORITY,							\
+		NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(WKPU_NXP_S32_INIT_DEVICE)

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -108,6 +108,9 @@
 					<5 5>, <6 6>, <7 7>, <8 16>, <9 17>,
 					<10 18>, <11 19>, <12 20>, <13 21>,
 					<14 22>, <15 23>;
+				nxp,wkpu = <&wkpu>;
+				nxp,wkpu-interrupts = <1 9>, <2 4>, <6 19>,
+					<8 27>, <9 25>, <13 8>, <15 24>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -121,6 +124,9 @@
 				interrupt-parent = <&eirq0>;
 				interrupts = <0 4>, <2 0>, <3 1>, <4 2>,
 					<5 3>, <9 5>, <12 6>, <14 7>;
+				nxp,wkpu = <&wkpu>;
+				nxp,wkpu-interrupts = <0 35>, <4 63>, <9 38>,
+					<10 39>, <14 41>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -135,6 +141,9 @@
 				interrupts = <0 8>, <1 9>, <2 10>, <3 11>, <4 12>,
 					<5 13>, <8 14>, <9 15>, <10 24>, <11 25>,
 					<12 26>, <13 27>, <14 28>, <15 29>;
+				nxp,wkpu = <&wkpu>;
+				nxp,wkpu-interrupts = <0 11>, <2 12>, <8 29>,
+					<9 21>, <11 20>, <12 16>, <13 15>, <15 37>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -149,6 +158,9 @@
 				interrupt-parent = <&eirq0>;
 				interrupts = <0 30>, <1 31>, <5 8>, <6 9>, <7 10>,
 					<8 11>, <9 12>, <10 13>, <12 14>, <15 15>;
+				nxp,wkpu = <&wkpu>;
+				nxp,wkpu-interrupts = <0 17>, <1 18>, <3 42>,
+					<5 43>, <7 44>, <10 45>, <12 46>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -164,6 +176,8 @@
 					<5 5>, <6 6>, <7 7>, <8 16>, <9 17>,
 					<10 18>, <11 19>, <12 20>, <13 21>,
 					<14 22>, <15 23>;
+				nxp,wkpu = <&wkpu>;
+				nxp,wkpu-interrupts = <6 7>, <7 6>, <9 14>, <11 22>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -177,6 +191,9 @@
 				interrupt-parent = <&eirq0>;
 				interrupts = <4 16>, <5 17>, <7 18>, <8 19>,
 					<9 20>, <10 21>, <11 22>, <13 23>;
+				nxp,wkpu = <&wkpu>;
+				nxp,wkpu-interrupts = <2 40>, <4 47>, <7 48>,
+					<8 50>, <9 49>, <10 52>, <13 51>, <15 53>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -192,6 +209,9 @@
 					<5 13>, <6 14>, <7 15>, <8 24>,
 					<9 25>, <10 26>, <11 27>, <12 28>,
 					<13 29>, <14 30>, <15 31>;
+				nxp,wkpu = <&wkpu>;
+				nxp,wkpu-interrupts = <0 10>, <2 13>, <3 5>,
+					<4 26>, <13 28>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -205,6 +225,9 @@
 				interrupt-parent = <&eirq0>;
 				interrupts = <1 24>, <4 25>, <5 26>, <6 27>,
 					<7 28>, <8 29>, <11 30>, <12 31>;
+				nxp,wkpu = <&wkpu>;
+				nxp,wkpu-interrupts = <4 58>, <7 54>, <11 55>,
+					<13 56>, <15 57>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -220,6 +243,9 @@
 					<4 4>, <5 5>, <6 6>, <8 7>,
 					<9 8>, <10 9>, <11 10>, <12 11>,
 					<13 12>, <14 13>, <15 14>;
+				nxp,wkpu = <&wkpu>;
+				nxp,wkpu-interrupts = <0 30>, <2 31>, <5 36>,
+					<6 33>, <11 32>, <14 34>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -232,6 +258,9 @@
 				reg-names = "pgpdo", "mscr";
 				interrupt-parent = <&eirq0>;
 				interrupts = <0 15>;
+				nxp,wkpu = <&wkpu>;
+				nxp,wkpu-interrupts = <0 23>, <2 59>, <5 60>,
+					<7 61>, <9 62>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -287,6 +316,13 @@
 				ngpios = <16>;
 				status = "disabled";
 			};
+		};
+
+		wkpu: wkpu@402b4000 {
+			compatible = "nxp,s32-wkpu";
+			reg = <0x402b4000 0x4000>;
+			interrupts = <83 0>;
+			status = "disabled";
 		};
 
 		lpuart0: uart@40328000 {

--- a/dts/bindings/gpio/nxp,s32-gpio.yaml
+++ b/dts/bindings/gpio/nxp,s32-gpio.yaml
@@ -1,7 +1,39 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: NXP S32 GPIO node
+description: |
+  NXP S32 GPIO controller.
+
+  The GPIO controller provides the option to route external input pad interrupts
+  to either the SIUL2 EIRQ interrupt controller or, when available on the SoC,
+  the WKPU interrupt controller. By default, GPIO interrupts are routed to the
+  SIUL2 EIRQ interrupt controller.
+
+  To route external interrupts to the WKPU interrupt controller, the GPIO
+  specifier must be supplied with the flag `NXP_S32_GPIO_INT_WKPU`. For example,
+  the following snippet of devicetree source code instructs the GPIO controller
+  to route the interrupt from pin 9 of `gpioa` to the WKPU interrupt controller:
+
+    #include <zephyr/dt-bindings/gpio/nxp-s32-gpio.h>
+
+    &device {
+        gpios = <&gpioa 9 (NXP_S32_GPIO_INT_WKPU | GPIO_ACTIVE_HIGH)>;
+    };
+
+  Explicitly specifying the routing of a GPIO interrupt to a particular
+  interrupt controller allows for the allocation of distinct interrupt
+  priorities according to application-specific requirements. This is owing to
+  the fact that each interrupt controller features its own interrupt vector.
+  To illustrate, it is plausible to allocate the board's button interrupts to
+  the interrupt controller configured with a lower priority compared to the one
+  designated for the data-ready interrupt originating from a sensor. This
+  decision is justified by the potentially higher importance of the latter
+  interrupt to the overall system operation.
+
+  The `NXP_S32_GPIO_INT_WKPU` flag is intended exclusively for specifying WKPU
+  as the interrupt controller for the corresponding GPIO. It's worth noting that
+  despite being named WKPU, the flag is not meant to configure GPIOs as wake-up
+  sources.
 
 compatible: "nxp,s32-gpio"
 
@@ -19,6 +51,17 @@ properties:
       For GPIO ports that have pins can be used for processing
       external interrupt signal, this is a list of GPIO pins and
       respective external interrupt lines (<gpio-pin eirq-line>).
+
+  nxp,wkpu:
+    type: phandle
+    description: |
+      NXP WKPU controller associated to this GPIO port.
+
+  nxp,wkpu-interrupts:
+    type: array
+    description: |
+      Map between WKPU external interrupt sources and pins of this GPIO port,
+      as in a tuple `<gpio-pin wkpu-interrupt-source>`.
 
   "#gpio-cells":
     const: 2

--- a/dts/bindings/interrupt-controller/nxp,s32-wkpu.yaml
+++ b/dts/bindings/interrupt-controller/nxp,s32-wkpu.yaml
@@ -1,0 +1,28 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP S32 Wake-up Unit
+
+compatible: "nxp,s32-wkpu"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+child-binding:
+  description: |
+    NXP S32 WKPU interrupt line configuration. Specific requirements for each
+    interrupt line can be specified by adding children nodes to this controller,
+    labeled `line_<line_number>`. For example:
+
+      line_0: line_0 {
+          filter-enable;
+      };
+
+  properties:
+    filter-enable:
+      type: boolean
+      description: |
+        Enable analog glitch filter on the external interrupt pad input.

--- a/include/zephyr/drivers/interrupt_controller/intc_wkpu_nxp_s32.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_wkpu_nxp_s32.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief Driver for Wake-up interrupt/event controller in NXP S32 MCUs
+ */
+
+#ifndef ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_WKPU_NXP_S32_H_
+#define ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_WKPU_NXP_S32_H_
+
+#include <Wkpu_Ip.h>
+
+/* Wrapper callback for WKPU line */
+typedef void (*wkpu_nxp_s32_callback_t)(uint8_t pin, void *arg);
+
+/**
+ * @brief Unset WKPU callback for line
+ *
+ * @param dev WKPU device
+ * @param line WKPU line
+ */
+void wkpu_nxp_s32_unset_callback(const struct device *dev, uint8_t line);
+
+/**
+ * @brief Set WKPU callback for line
+ *
+ * @param dev  WKPU device
+ * @param line WKPU line
+ * @param cb   Callback
+ * @param pin  GPIO pin
+ * @param arg  Callback data
+ *
+ * @retval 0 on SUCCESS
+ * @retval -EBUSY if callback for the line is already set
+ */
+int wkpu_nxp_s32_set_callback(const struct device *dev, uint8_t line,
+			      wkpu_nxp_s32_callback_t cb, uint8_t pin, void *arg);
+
+/**
+ * @brief Set edge event and enable interrupt for WKPU line
+ *
+ * @param dev  WKPU device
+ * @param line WKPU line
+ * @param edge_type Type of edge event
+ */
+void wkpu_nxp_s32_enable_interrupt(const struct device *dev, uint8_t line,
+				   Wkpu_Ip_EdgeType edge_type);
+
+/**
+ * @brief Disable interrupt for WKPU line
+ *
+ * @param dev  WKPU device
+ * @param line WKPU line
+ */
+void wkpu_nxp_s32_disable_interrupt(const struct device *dev, uint8_t line);
+
+/**
+ * @brief Get pending interrupt for WKPU device
+ *
+ * @param dev WKPU device
+ * @return A mask contains pending flags
+ */
+uint64_t wkpu_nxp_s32_get_pending(const struct device *dev);
+
+#endif /* ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_WKPU_NXP_S32_H_ */

--- a/include/zephyr/dt-bindings/gpio/nxp-s32-gpio.h
+++ b/include/zephyr/dt-bindings/gpio/nxp-s32-gpio.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_NXP_S32_GPIO_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_NXP_S32_GPIO_H_
+
+/**
+ * @brief NXP S32 GPIO specific flags
+ *
+ * The driver flags are encoded in the 8 upper bits of @ref gpio_dt_flags_t as
+ * follows:
+ *
+ * - Bit 8: Interrupt controller to which the respective GPIO interrupt is routed.
+ *
+ * @ingroup gpio_interface
+ * @{
+ */
+
+/** @cond INTERNAL_HIDDEN */
+#define NXP_S32_GPIO_INT_CONTROLLER_POS		8
+#define NXP_S32_GPIO_INT_CONTROLLER_MASK	(0x1U << NXP_S32_GPIO_INT_CONTROLLER_POS)
+/** @endcond */
+
+/**
+ * @name NXP S32 GPIO interrupt controller routing flags
+ * @brief NXP S32 GPIO interrupt controller routing flags
+ * @{
+ */
+
+/** Interrupt routed to the WKPU controller */
+#define NXP_S32_GPIO_INT_WKPU	(0x1U << NXP_S32_GPIO_INT_CONTROLLER_POS)
+
+/** @} */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_NXP_S32_GPIO_H_ */

--- a/tests/drivers/gpio/gpio_basic_api/boards/mr_canhubk3_wkpu.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/mr_canhubk3_wkpu.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/nxp-s32-gpio.h>
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		/* Use LPSPI1 MISO/MOSI pins which are also used for spi_loopback test */
+		out-gpios = <&gpioa_h 13 0>;
+		in-gpios = <&gpioa_h 14 NXP_S32_GPIO_INT_WKPU>;
+	};
+};
+
+&wkpu {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_manage.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_manage.c
@@ -43,12 +43,12 @@ static int init_callback(const struct device *dev,
 	}
 	if (rc == 0) {
 		/* 1. set PIN_OUT */
-		rc = gpio_pin_configure(dev, PIN_OUT, GPIO_OUTPUT_LOW);
+		rc = gpio_pin_configure(dev, PIN_OUT, (GPIO_OUTPUT_LOW | PIN_OUT_FLAGS));
 	}
 
 	if (rc == 0) {
 		/* 2. configure PIN_IN callback, but don't enable */
-		rc = gpio_pin_configure(dev, PIN_IN, GPIO_INPUT);
+		rc = gpio_pin_configure(dev, PIN_IN, (GPIO_INPUT | PIN_IN_FLAGS));
 	}
 
 	if (rc == 0) {

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
@@ -40,7 +40,7 @@ static int test_callback(int mode)
 	gpio_pin_interrupt_configure(dev, PIN_OUT, GPIO_INT_DISABLE);
 
 	/* 1. set PIN_OUT to logical initial state inactive */
-	uint32_t out_flags = GPIO_OUTPUT_LOW;
+	uint32_t out_flags = GPIO_OUTPUT_LOW | PIN_OUT_FLAGS;
 
 	if ((mode & GPIO_INT_LOW_0) != 0) {
 		out_flags = GPIO_OUTPUT_HIGH | GPIO_ACTIVE_LOW;
@@ -54,7 +54,7 @@ static int test_callback(int mode)
 	}
 
 	/* 2. configure PIN_IN callback and trigger condition */
-	rc = gpio_pin_configure(dev, PIN_IN, GPIO_INPUT);
+	rc = gpio_pin_configure(dev, PIN_IN, (GPIO_INPUT | PIN_IN_FLAGS));
 	if (rc != 0) {
 		TC_ERROR("config PIN_IN fail: %d\n", rc);
 		goto err_exit;

--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio.h
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio.h
@@ -25,7 +25,9 @@
 #define DEV_IN DT_GPIO_CTLR(DT_INST(0, test_gpio_basic_api), in_gpios)
 #define DEV DEV_OUT /* DEV_OUT should equal DEV_IN, we test for this */
 #define PIN_OUT DT_GPIO_PIN(DT_INST(0, test_gpio_basic_api), out_gpios)
+#define PIN_OUT_FLAGS DT_GPIO_FLAGS(DT_INST(0, test_gpio_basic_api), out_gpios)
 #define PIN_IN DT_GPIO_PIN(DT_INST(0, test_gpio_basic_api), in_gpios)
+#define PIN_IN_FLAGS DT_GPIO_FLAGS(DT_INST(0, test_gpio_basic_api), in_gpios)
 
 #elif DT_NODE_HAS_STATUS(DT_ALIAS(gpio_0), okay)
 #define DEV DT_GPIO_CTLR(DT_ALIAS(gpio_0))

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -16,3 +16,7 @@ tests:
     platform_allow: nrf52840dk_nrf52840 nrf52_bsim
     extra_args: "DTC_OVERLAY_FILE=boards/nrf52840dk_nrf52840.overlay;\
                  boards/nrf52840dk_nrf52840_sense_edge.overlay"
+
+  drivers.gpio.mr_canhubk3_wkpu:
+    platform_allow: mr_canhubk3
+    extra_args: "DTC_OVERLAY_FILE=boards/mr_canhubk3_wkpu.overlay"


### PR DESCRIPTION
This PR introduces an interrupt controller driver for the NXP S32 WKPU and integrates it with the GPIO driver to extend the number of GPIO pins that can interrupt the core.

GPIO pins that are input-interrupt capable support triggering SIUL2 EIRQ interrupts (existing interrupt controller implementation) and/or WKPU interrupts (introduced in this patch). To configure WKPU to trigger an interrupt from a GPIO pin, a SoC-specific flag must be supplied to the `gpios` specifier to instruct the GPIO driver which interrupt controller to use.

> [!IMPORTANT]
> WKPU supports triggering interrupts from certain input pads that support this function, as well as generating wake-up events to the power management domain. This patch only adds WKPU functionality as an interrupt controller to extend on this SoC the number of input pads that can interrupt the core. Power management functionalities (ie. wake-up events to power management domain) are not supported and are not in the scope of this PR.

Tests:
```
> west twister -p mr_canhubk3 -T .\tests\drivers\gpio\gpio_basic_api --device-testing --device-serial=COM4 --fixture=gpio_loopback
INFO    - Using Ninja..
INFO    - Zephyr version: v3.5.0-rc1-95-g066503e2555a
INFO    - Using 'zephyr' toolchain.
...
INFO    - Total complete:    3/   3  100%  skipped:    1, failed:    0, error:    0
INFO    - 3 test scenarios (3 test instances) selected, 1 configurations skipped (1 by static filter, 0 at runtime).
INFO    - 2 of 3 test configurations passed (100.00%), 0 failed, 0 errored, 1 skipped with 0 warnings in 291.60 seconds
INFO    - In total 10 test cases were executed, 5 skipped on 1 out of total 626 platforms (0.16%)
INFO    - 2 test configurations executed on platforms, 0 test configurations were only built.
```