### PR TITLE
boards: arm: az3166_iotdevkit: Fix defconfig driver options

### DIFF
--- a/boards/arm/az3166_iotdevkit/Kconfig.defconfig
+++ b/boards/arm/az3166_iotdevkit/Kconfig.defconfig
@@ -8,11 +8,19 @@ if BOARD_AZ3166_DEVKIT
 config BOARD
 	default "az3166_devkit"
 
+if HTS221
+
 choice HTS221_TRIGGER_MODE
 	default HTS221_TRIGGER_NONE
 endchoice
 
+endif # HTS221
+
+if SSD1306
+
 config SSD1306_REVERSE_MODE
 	default y
+
+endif # SSD1306
 
 endif # BOARD_AZ3166_DEVKIT


### PR DESCRIPTION
Set driver options from the board defconfig only if the drivers are enabled.

This fixes CI issues such as: https://github.com/zephyrproject-rtos/zephyr/actions/runs/6181947353/job/16780815348?pr=62603