### PR TITLE
board: az3166_iotdevkit: update SSD1306_REVERSE_MODE option

### DIFF
--- a/boards/arm/az3166_iotdevkit/Kconfig.defconfig
+++ b/boards/arm/az3166_iotdevkit/Kconfig.defconfig
@@ -12,7 +12,4 @@ choice HTS221_TRIGGER_MODE
 	default HTS221_TRIGGER_NONE
 endchoice
 
-config SSD1306_REVERSE_MODE
-	default y
-
 endif # BOARD_AZ3166_DEVKIT

--- a/boards/arm/az3166_iotdevkit/az3166_iotdevkit.dts
+++ b/boards/arm/az3166_iotdevkit/az3166_iotdevkit.dts
@@ -172,6 +172,7 @@
 		segment-remap;
 		com-invdir;
 		prechargep = <0x22>;
+		inversion-on;
 
 		reset-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
 	};


### PR DESCRIPTION
The SSD1306_REVERSE_MODE is now a devicetree property.

Update the board config, fix a:

warning: SSD1306_REVERSE_MODE (defined at
boards/arm/az3166_iotdevkit/Kconfig.defconfig:15) defined without a type

compliance warning.