### PR TITLE
drivers: flash: stm32: change undefined variable causing build error

### DIFF
--- a/drivers/flash/flash_stm32g0x.c
+++ b/drivers/flash/flash_stm32g0x.c
@@ -231,7 +231,7 @@ int  flash_stm32_check_configuration(void)
 {
 #if defined(STM32G0_DBANK_SUPPORT) && (CONFIG_FLASH_SIZE == 256)
 	/* Single bank mode not supported on dual bank SoCs with 256kiB flash */
-	if ((regs->OPTR & FLASH_OPTR_DUAL_BANK) == 0) {
+	if ((FLASH->OPTR & FLASH_OPTR_DUAL_BANK) == 0) {
 		LOG_ERR("Single bank configuration not supported by the driver");
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
Following the issue [#62581](https://github.com/zephyrproject-rtos/zephyr/issues/62581).

This PR remove an undefined variable inside the `flash_stm32_check_configuration` function.

The change make this driver coherent with the other stm32 flash drivers.