### PR TITLE
drivers: serial: uart_nrfx_uart: fix NRFX_WAIT_FOR result type

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -285,7 +285,7 @@ static void uart_nrfx_poll_out(const struct device *dev, unsigned char c)
 	nrf_uart_txd_set(uart0_addr, (uint8_t)c);
 
 	/* Wait until the transmitter is ready, i.e. the character is sent. */
-	int res;
+	bool res;
 
 	NRFX_WAIT_FOR(event_txdrdy_check(), 1000, 1, res);
 


### PR DESCRIPTION
This macro expects a bool variable to store the result.

See e.g.: https://infocenter.nordicsemi.com/index.jsp?topic=%2Fsdk_nrf5_v17.0.2%2Fgroup__nrfx__common.html