### PR TITLE
include: always use <> for Zephyr includes

### DIFF
--- a/arch/posix/core/nsi_compat/nsi_compat.c
+++ b/arch/posix/core/nsi_compat/nsi_compat.c
@@ -12,7 +12,7 @@
  * the migration towards the Native simulator.
  */
 
-#include "zephyr/arch/posix/posix_trace.h"
+#include <zephyr/arch/posix/posix_trace.h>
 
 void nsi_print_error_and_exit(const char *format, ...)
 {

--- a/boards/posix/common/irq/board_irq.h
+++ b/boards/posix/common/irq/board_irq.h
@@ -9,7 +9,7 @@
 #define BOARDS_POSIX_COMMON_BOARD_IRQ_H
 
 #include <zephyr/sw_isr_table.h>
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/posix/native_posix/cmdline.c
+++ b/boards/posix/native_posix/cmdline.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "cmdline_common.h"
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 #include "hw_models_top.h"
 #include "timer_model.h"
 #include "cmdline.h"

--- a/boards/posix/native_posix/cmdline_common.c
+++ b/boards/posix/native_posix/cmdline_common.c
@@ -12,7 +12,7 @@
 #include <math.h>
 #include <zephyr/arch/posix/posix_trace.h>
 #include "posix_board_if.h"
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 #include "cmdline_common.h"
 
 /**

--- a/boards/posix/native_posix/hw_models_top.h
+++ b/boards/posix/native_posix/hw_models_top.h
@@ -7,7 +7,7 @@
 #ifndef _NATIVE_POSIX_HW_MODELS_H
 #define _NATIVE_POSIX_HW_MODELS_H
 
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 #include <inttypes.h>
 
 #ifdef __cplusplus

--- a/boards/posix/native_posix/irq_ctrl.c
+++ b/boards/posix/native_posix/irq_ctrl.c
@@ -14,7 +14,7 @@
 #include <zephyr/arch/posix/arch.h> /* for find_lsb_set() */
 #include "board_soc.h"
 #include "posix_soc.h"
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 
 uint64_t irq_ctrl_timer = NEVER;
 

--- a/boards/posix/native_posix/native_rtc.h
+++ b/boards/posix/native_posix/native_rtc.h
@@ -15,7 +15,7 @@
 
 #include "hw_models_top.h"
 #include <stdbool.h>
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/posix/native_posix/timer_model.c
+++ b/boards/posix/native_posix/timer_model.c
@@ -25,7 +25,7 @@
 #include "hw_models_top.h"
 #include "irq_ctrl.h"
 #include "board_soc.h"
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 #include <zephyr/arch/posix/posix_trace.h>
 #include <zephyr/sys/util.h>
 #include "cmdline.h"

--- a/boards/posix/nrf52_bsim/board_irq.h
+++ b/boards/posix/nrf52_bsim/board_irq.h
@@ -7,7 +7,7 @@
 #ifndef BOARDS_POSIX_NRF52_BSIM_BOARD_IRQ_H
 #define BOARDS_POSIX_NRF52_BSIM_BOARD_IRQ_H
 
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 #include "../common/irq/board_irq.h"
 
 #ifdef __cplusplus

--- a/boards/posix/nrf52_bsim/time_machine.h
+++ b/boards/posix/nrf52_bsim/time_machine.h
@@ -8,7 +8,7 @@
 
 #include "bs_types.h"
 #include "time_machine_if.h"
-#include "zephyr/toolchain.h"
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/bluetooth/hci/hci_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_psoc6_bless.c
@@ -21,7 +21,7 @@
 #include <zephyr/init.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
-#include "zephyr/logging/log.h"
+#include <zephyr/logging/log.h>
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_LEVEL      CONFIG_BT_HCI_DRIVER_LOG_LEVEL

--- a/drivers/crypto/crypto_mchp_xec_symcr.c
+++ b/drivers/crypto/crypto_mchp_xec_symcr.c
@@ -12,7 +12,7 @@
 #include <zephyr/crypto/crypto.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/mchp_xec_clock_control.h>
-#include "zephyr/sys/util.h"
+#include <zephyr/sys/util.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(xec_symcr, CONFIG_CRYPTO_LOG_LEVEL);
 

--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -4,7 +4,7 @@
  */
 
 #include <zephyr/net/ethernet.h>
-#include "zephyr/net/phy.h"
+#include <zephyr/net/phy.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/drivers/mdio.h>

--- a/drivers/i2c/i2c_rtio.c
+++ b/drivers/i2c/i2c_rtio.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/rtio/rtio.h"
+#include <zephyr/rtio/rtio.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/rtio/rtio_spsc.h>
 #include <zephyr/sys/__assert.h>

--- a/drivers/i2c/i2c_sam_twihs_rtio.c
+++ b/drivers/i2c/i2c_sam_twihs_rtio.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/spinlock.h"
+#include <zephyr/spinlock.h>
 #define DT_DRV_COMPAT atmel_sam_i2c_twihs
 
 /** @file

--- a/drivers/ipm/ipm_sedi.h
+++ b/drivers/ipm/ipm_sedi.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 #include "sedi_driver_common.h"
 #include "sedi_driver_ipc.h"
-#include "zephyr/sys/atomic.h"
+#include <zephyr/sys/atomic.h>
 
 /*
  * bit 31 indicates whether message is valid, and could generate interrupt

--- a/drivers/sensor/veml7700/veml7700.c
+++ b/drivers/sensor/veml7700/veml7700.c
@@ -14,7 +14,7 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "zephyr/drivers/sensor/veml7700.h"
+#include <zephyr/drivers/sensor/veml7700.h>
 
 LOG_MODULE_REGISTER(VEML7700, CONFIG_SENSOR_LOG_LEVEL);
 

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -10,7 +10,7 @@
  * It also provides a custom k_busy_wait() which can be used with the
  * POSIX arch and InfClock SOC
  */
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 #include <zephyr/irq.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>

--- a/include/zephyr/acpi/acpi_osal.h
+++ b/include/zephyr/acpi/acpi_osal.h
@@ -8,7 +8,7 @@
 #define ZEPHYR_ARCH_X86_INCLUDE_ACPI_OSAL_H_
 
 #if defined(CONFIG_X86 || CONFIG_X86_64)
-#include "zephyr/acpi/x86_acpi_osal.h"
+#include <zephyr/acpi/x86_acpi_osal.h>
 #else
 #error "Currently only x86 Architecture support ACPI !!"
 #endif

--- a/include/zephyr/net/net_time.h
+++ b/include/zephyr/net/net_time.h
@@ -18,7 +18,7 @@
 #define ZEPHYR_INCLUDE_NET_NET_TIME_H_
 
 /* Include required for NSEC_PER_* constants. */
-#include "zephyr/sys_clock.h"
+#include <zephyr/sys_clock.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/posix/inf_clock/posix_board_if.h
+++ b/soc/posix/inf_clock/posix_board_if.h
@@ -6,7 +6,7 @@
 #ifndef _POSIX_CORE_BOARD_PROVIDED_IF_H
 #define _POSIX_CORE_BOARD_PROVIDED_IF_H
 
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 
 /*
  * This file lists the functions the posix "inf_clock" soc

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -15,7 +15,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
-#include "zephyr/bluetooth/iso.h"
+#include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/pacs.h>

--- a/subsys/bluetooth/audio/vocs.c
+++ b/subsys/bluetooth/audio/vocs.c
@@ -19,7 +19,7 @@
 
 #include "audio_internal.h"
 #include "vocs_internal.h"
-#include "zephyr/bluetooth/audio/audio.h"
+#include <zephyr/bluetooth/audio/audio.h>
 
 #define LOG_LEVEL CONFIG_BT_VOCS_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/rtio/rtio_handlers.c
+++ b/subsys/rtio/rtio_handlers.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/kernel.h"
+#include <zephyr/kernel.h>
 #include <stdbool.h>
 #include <zephyr/rtio/rtio.h>
 #include <zephyr/syscall_handler.h>

--- a/tests/arch/arm64/arm64_smc_call/src/main.c
+++ b/tests/arch/arm64/arm64_smc_call/src/main.c
@@ -5,7 +5,7 @@
 
 #include <zephyr/ztest.h>
 
-#include "zephyr/arch/arm64/arm-smccc.h"
+#include <zephyr/arch/arm64/arm-smccc.h>
 
 /* SMC function IDs for Standard Service queries */
 #define ARM_STD_SMC_CALL_COUNT		0x8400ff00UL

--- a/tests/bluetooth/bt_crypto/src/test_bt_crypto.c
+++ b/tests/bluetooth/bt_crypto/src/test_bt_crypto.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/ztest_assert.h"
+#include <zephyr/ztest_assert.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/tests/bluetooth/controller/common/src/helper_pdu.c
+++ b/tests/bluetooth/controller/common/src/helper_pdu.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/types.h"
-#include "zephyr/ztest.h"
+#include <zephyr/types.h>
+#include <zephyr/ztest.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/byteorder.h>

--- a/tests/bluetooth/controller/common/src/helper_util.c
+++ b/tests/bluetooth/controller/common/src/helper_util.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/types.h"
-#include "zephyr/ztest.h"
+#include <zephyr/types.h>
+#include <zephyr/ztest.h>
 #include <stdlib.h>
 
 #include <zephyr/bluetooth/hci.h>

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_central.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_central.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 #include <zephyr/ztest.h>
 #include "util/util.h"
 #include "util/mem.h"

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_peripheral.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_peripheral.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 #include <zephyr/ztest.h>
 #include "util/util.h"
 #include "util/mem.h"

--- a/tests/bluetooth/tester/src/btp/btp_ias.h
+++ b/tests/bluetooth/tester/src/btp/btp_ias.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/bluetooth/services/ias.h"
+#include <zephyr/bluetooth/services/ias.h>
 #include <stdint.h>
 
 /* events */

--- a/tests/bluetooth/tester/src/btp_csis.c
+++ b/tests/bluetooth/tester/src/btp_csis.c
@@ -8,7 +8,7 @@
 #include <zephyr/bluetooth/audio/csip.h>
 
 #include "btp/btp.h"
-#include "zephyr/sys/byteorder.h"
+#include <zephyr/sys/byteorder.h>
 
 #include <zephyr/logging/log.h>
 #define LOG_MODULE_NAME bttester_csis

--- a/tests/bluetooth/tester/src/btp_has.c
+++ b/tests/bluetooth/tester/src/btp_has.c
@@ -8,8 +8,8 @@
 #include <zephyr/bluetooth/audio/has.h>
 
 #include "btp/btp.h"
-#include "zephyr/sys/byteorder.h"
-#include "zephyr/arch/common/ffs.h"
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/arch/common/ffs.h>
 #include <stdint.h>
 
 #include <zephyr/logging/log.h>

--- a/tests/bluetooth/tester/src/btp_ias.c
+++ b/tests/bluetooth/tester/src/btp_ias.c
@@ -8,7 +8,7 @@
 #include <zephyr/bluetooth/services/ias.h>
 
 #include "btp/btp.h"
-#include "zephyr/sys/byteorder.h"
+#include <zephyr/sys/byteorder.h>
 #include <stdint.h>
 
 #include <zephyr/logging/log.h>

--- a/tests/bluetooth/tester/src/btp_vcp.c
+++ b/tests/bluetooth/tester/src/btp_vcp.c
@@ -12,8 +12,8 @@
 #include <zephyr/bluetooth/testing.h>
 #include <zephyr/bluetooth/audio/vcp.h>
 #include <zephyr/bluetooth/audio/aics.h>
-#include "zephyr/bluetooth/audio/vocs.h"
-#include "zephyr/sys/util.h"
+#include <zephyr/bluetooth/audio/vocs.h>
+#include <zephyr/sys/util.h>
 
 #include <../../subsys/bluetooth/audio/micp_internal.h>
 #include <../../subsys/bluetooth/audio/aics_internal.h>

--- a/tests/bsim/bluetooth/audio/src/ias_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/ias_client_test.c
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #ifdef CONFIG_BT_IAS_CLIENT
 
-#include "zephyr/bluetooth/services/ias.h"
+#include <zephyr/bluetooth/services/ias.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/adv/resume/src/bs_bt_utils.h
+++ b/tests/bsim/bluetooth/host/adv/resume/src/bs_bt_utils.h
@@ -10,7 +10,7 @@
 #include "bs_types.h"
 #include "bstests.h"
 #include "time_machine.h"
-#include "zephyr/sys/__assert.h"
+#include <zephyr/sys/__assert.h>
 
 #include <errno.h>
 

--- a/tests/bsim/bluetooth/host/adv/resume/src/dut.c
+++ b/tests/bsim/bluetooth/host/adv/resume/src/dut.c
@@ -5,10 +5,10 @@
  */
 
 #include "bs_bt_utils.h"
-#include "zephyr/bluetooth/addr.h"
-#include "zephyr/bluetooth/bluetooth.h"
-#include "zephyr/bluetooth/conn.h"
-#include "zephyr/toolchain/gcc.h"
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/toolchain/gcc.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/tests/bsim/bluetooth/host/adv/resume/src/tester.c
+++ b/tests/bsim/bluetooth/host/adv/resume/src/tester.c
@@ -5,8 +5,8 @@
  */
 
 #include "bs_bt_utils.h"
-#include "zephyr/bluetooth/addr.h"
-#include "zephyr/bluetooth/conn.h"
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/conn.h>
 
 #include <stdint.h>
 

--- a/tests/bsim/bluetooth/host/gatt/settings/src/settings.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/settings.c
@@ -11,7 +11,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/settings/settings.h>
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 #include "errno.h"
 #include "argparse.h"
 

--- a/tests/bsim/bluetooth/host/privacy/legacy/src/tester.c
+++ b/tests/bsim/bluetooth/host/privacy/legacy/src/tester.c
@@ -5,8 +5,8 @@
  */
 
 #include "bs_bt_utils.h"
-#include "zephyr/bluetooth/addr.h"
-#include "zephyr/bluetooth/conn.h"
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/conn.h>
 #include <stdint.h>
 #include <zephyr/bluetooth/bluetooth.h>
 

--- a/tests/bsim/bluetooth/host/privacy/peripheral/src/tester.c
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/src/tester.c
@@ -5,8 +5,8 @@
  */
 
 #include "bs_bt_utils.h"
-#include "zephyr/bluetooth/addr.h"
-#include "zephyr/bluetooth/conn.h"
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/conn.h>
 #include <stdint.h>
 #include <zephyr/bluetooth/bluetooth.h>
 

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/bs_bt_utils.h
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/bs_bt_utils.h
@@ -10,7 +10,7 @@
 #include "bs_types.h"
 #include "bstests.h"
 #include "time_machine.h"
-#include "zephyr/sys/__assert.h"
+#include <zephyr/sys/__assert.h>
 
 #include <errno.h>
 #include <stddef.h>

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/central.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/central.c
@@ -5,8 +5,8 @@
  */
 
 #include "bs_bt_utils.h"
-#include "zephyr/bluetooth/addr.h"
-#include "zephyr/bluetooth/conn.h"
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/conn.h>
 
 #include <stdint.h>
 

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/peripheral.c
@@ -5,10 +5,10 @@
  */
 
 #include "bs_bt_utils.h"
-#include "zephyr/bluetooth/addr.h"
-#include "zephyr/bluetooth/bluetooth.h"
-#include "zephyr/bluetooth/conn.h"
-#include "zephyr/toolchain/gcc.h"
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/toolchain/gcc.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/bs_bt_utils.h
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/bs_bt_utils.h
@@ -10,7 +10,7 @@
 #include "bs_types.h"
 #include "bstests.h"
 #include "time_machine.h"
-#include "zephyr/sys/__assert.h"
+#include <zephyr/sys/__assert.h>
 
 #include <errno.h>
 #include <stddef.h>

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/central.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/central.c
@@ -5,8 +5,8 @@
  */
 
 #include "bs_bt_utils.h"
-#include "zephyr/bluetooth/addr.h"
-#include "zephyr/bluetooth/conn.h"
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/conn.h>
 
 #include <stdint.h>
 

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/peripheral.c
@@ -5,10 +5,10 @@
  */
 
 #include "bs_bt_utils.h"
-#include "zephyr/bluetooth/addr.h"
-#include "zephyr/bluetooth/bluetooth.h"
-#include "zephyr/bluetooth/conn.h"
-#include "zephyr/toolchain/gcc.h"
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/toolchain/gcc.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/src/bs_bt_utils.h
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/src/bs_bt_utils.h
@@ -10,7 +10,7 @@
 #include "bs_types.h"
 #include "bstests.h"
 #include "time_machine.h"
-#include "zephyr/sys/__assert.h"
+#include <zephyr/sys/__assert.h>
 
 #include <errno.h>
 #include <stddef.h>

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/src/central.c
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/src/central.c
@@ -5,8 +5,8 @@
  */
 
 #include "bs_bt_utils.h"
-#include "zephyr/bluetooth/addr.h"
-#include "zephyr/bluetooth/conn.h"
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/conn.h>
 
 #include <stdint.h>
 

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/src/peripheral.c
@@ -5,10 +5,10 @@
  */
 
 #include "bs_bt_utils.h"
-#include "zephyr/bluetooth/addr.h"
-#include "zephyr/bluetooth/bluetooth.h"
-#include "zephyr/bluetooth/conn.h"
-#include "zephyr/toolchain/gcc.h"
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/toolchain/gcc.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/tests/bsim/bluetooth/host/security/id_addr_update/central/src/central.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/central/src/central.c
@@ -6,8 +6,8 @@
 
 #include "bs_bt_utils.h"
 #include "utils.h"
-#include "zephyr/bluetooth/addr.h"
-#include "zephyr/bluetooth/conn.h"
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/conn.h>
 
 #include <stdint.h>
 

--- a/tests/bsim/bluetooth/host/security/id_addr_update/common/bs_bt_utils.h
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/common/bs_bt_utils.h
@@ -10,7 +10,7 @@
 #include "bs_types.h"
 #include "bstests.h"
 #include "time_machine.h"
-#include "zephyr/sys/__assert.h"
+#include <zephyr/sys/__assert.h>
 
 #include <errno.h>
 #include <stddef.h>

--- a/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/peripheral.c
@@ -6,10 +6,10 @@
 
 #include "bs_bt_utils.h"
 #include "utils.h"
-#include "zephyr/bluetooth/addr.h"
-#include "zephyr/bluetooth/bluetooth.h"
-#include "zephyr/bluetooth/conn.h"
-#include "zephyr/toolchain/gcc.h"
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/toolchain/gcc.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/tests/bsim/bluetooth/ll/edtt/common/edtt_driver.h
+++ b/tests/bsim/bluetooth/ll/edtt/common/edtt_driver.h
@@ -10,7 +10,7 @@
 
 #include <stdlib.h>
 #include <stdbool.h>
-#include "zephyr/types.h"
+#include <zephyr/types.h>
 
 #define EDTTT_NONBLOCK 0
 #define EDTTT_BLOCK 1

--- a/tests/drivers/input/gpio_keys/src/main.c
+++ b/tests/drivers/input/gpio_keys/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/sys/util.h"
+#include <zephyr/sys/util.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio/gpio_emul.h>
 #include <zephyr/kernel.h>

--- a/tests/drivers/spi/spi_loopback/src/spi_rtio.c
+++ b/tests/drivers/spi/spi_loopback/src/spi_rtio.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/devicetree.h"
+#include <zephyr/devicetree.h>
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(spi_rtio_loopback);

--- a/tests/kernel/spinlock/src/spinlock_error_case.c
+++ b/tests/kernel/spinlock/src/spinlock_error_case.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "zephyr/ztest_test_new.h"
+#include <zephyr/ztest_test_new.h>
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <zephyr/spinlock.h>

--- a/tests/subsys/modem/modem_ppp/src/main.c
+++ b/tests/subsys/modem/modem_ppp/src/main.c
@@ -11,8 +11,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
-#include "zephyr/net/net_l2.h"
-#include "zephyr/net/ppp.h"
+#include <zephyr/net/net_l2.h>
+#include <zephyr/net/ppp.h>
 #include <zephyr/sys/crc.h>
 #include <string.h>
 


### PR DESCRIPTION
Double quotes "" should only be used for local headers.