### PR TITLE
Ethernet: gptp doesn't work at all on STM32H5

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1905,11 +1905,11 @@ static int ptp_stm32_init(const struct device *port)
 
 	/* Query ethernet clock rate */
 	ret = clock_control_get_rate(eth_dev_data->clock,
-#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32H5X)
+#if defined(CONFIG_SOC_SERIES_STM32H7X)
 		(clock_control_subsys_t)&eth_cfg->pclken,
 #else
 		(clock_control_subsys_t)&eth_cfg->pclken_ptp,
-#endif /* CONFIG_SOC_SERIES_STM32H7X || CONFIG_SOC_SERIES_STM32H5X */
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 		&ptp_hclk_rate);
 	if (ret) {
 		LOG_ERR("Failed to query ethernet clock");

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -465,10 +465,12 @@
 			compatible = "st,stm32-ethernet";
 			reg = <0x40028000 0x8000>;
 			interrupts = <106 0>;
-			clock-names = "stmmaceth", "mac-clk-tx", "mac-clk-rx";
+			clock-names = "stmmaceth", "mac-clk-tx",
+				      "mac-clk-rx", "mac-clk-ptp";
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00080000>,
 				 <&rcc STM32_CLOCK_BUS_AHB1 0x00100000>,
-				 <&rcc STM32_CLOCK_BUS_AHB1 0x00200000>;
+				 <&rcc STM32_CLOCK_BUS_AHB1 0x00200000>,
+				 <&rcc STM32_CLOCK_BUS_AHB1 0x00400000>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
check for gPTP issue on STM32H5

link to:
stm32h5: samples/net/gptp doesn't work at all #62465