### PR TITLE
toolchain: do not allow including toolchain-specific headers 

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -27,7 +27,7 @@
 #ifdef CONFIG_ADC_STM32_DMA
 #include <zephyr/drivers/dma/dma_stm32.h>
 #include <zephyr/drivers/dma.h>
-#include <zephyr/toolchain/common.h>
+#include <zephyr/toolchain.h>
 #include <stm32_ll_dma.h>
 #endif
 

--- a/include/zephyr/toolchain/armclang.h
+++ b/include/zephyr/toolchain/armclang.h
@@ -7,6 +7,9 @@
 #ifndef ZEPHYR_INCLUDE_TOOLCHAIN_ARMCLANG_H_
 #define ZEPHYR_INCLUDE_TOOLCHAIN_ARMCLANG_H_
 
+#ifndef ZEPHYR_INCLUDE_TOOLCHAIN_H_
+#error Please do not include toolchain-specific headers directly, use <zephyr/toolchain.h> instead
+#endif
 
 #include <zephyr/toolchain/llvm.h>
 

--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -6,6 +6,11 @@
 
 #ifndef ZEPHYR_INCLUDE_TOOLCHAIN_COMMON_H_
 #define ZEPHYR_INCLUDE_TOOLCHAIN_COMMON_H_
+
+#ifndef ZEPHYR_INCLUDE_TOOLCHAIN_H_
+#error Please do not include toolchain-specific headers directly, use <zephyr/toolchain.h> instead
+#endif
+
 /**
  * @file
  * @brief Common toolchain abstraction

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -7,6 +7,10 @@
 #ifndef ZEPHYR_INCLUDE_TOOLCHAIN_GCC_H_
 #define ZEPHYR_INCLUDE_TOOLCHAIN_GCC_H_
 
+#ifndef ZEPHYR_INCLUDE_TOOLCHAIN_H_
+#error Please do not include toolchain-specific headers directly, use <zephyr/toolchain.h> instead
+#endif
+
 /**
  * @file
  * @brief GCC toolchain abstraction

--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -7,6 +7,9 @@
 #ifndef ZEPHYR_INCLUDE_TOOLCHAIN_LLVM_H_
 #define ZEPHYR_INCLUDE_TOOLCHAIN_LLVM_H_
 
+#ifndef ZEPHYR_INCLUDE_TOOLCHAIN_H_
+#error Please do not include toolchain-specific headers directly, use <zephyr/toolchain.h> instead
+#endif
 
 #define __no_optimization __attribute__((optnone))
 

--- a/include/zephyr/toolchain/mwdt.h
+++ b/include/zephyr/toolchain/mwdt.h
@@ -8,6 +8,10 @@
 #ifndef ZEPHYR_INCLUDE_TOOLCHAIN_MWDT_H_
 #define ZEPHYR_INCLUDE_TOOLCHAIN_MWDT_H_
 
+#ifndef ZEPHYR_INCLUDE_TOOLCHAIN_H_
+#error Please do not include toolchain-specific headers directly, use <zephyr/toolchain.h> instead
+#endif
+
 #ifndef _LINKER
 #if defined(_ASMLANGUAGE)
 

--- a/include/zephyr/toolchain/xcc.h
+++ b/include/zephyr/toolchain/xcc.h
@@ -7,6 +7,10 @@
 #ifndef ZEPHYR_INCLUDE_TOOLCHAIN_XCC_H_
 #define ZEPHYR_INCLUDE_TOOLCHAIN_XCC_H_
 
+#ifndef ZEPHYR_INCLUDE_TOOLCHAIN_H_
+#error Please do not include toolchain-specific headers directly, use <zephyr/toolchain.h> instead
+#endif
+
 /* toolchain/gcc.h errors out if __BYTE_ORDER__ cannot be determined
  * there. However, __BYTE_ORDER__ is actually being defined later in
  * this file. So define __BYTE_ORDER__ to skip the check in gcc.h

--- a/soc/arm/aspeed/aspeed_util.h
+++ b/soc/arm/aspeed/aspeed_util.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_SOC_ARM_ASPEED_UTIL_H_
 #include <zephyr/sys/util.h>
 #include <zephyr/devicetree.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 
 /* gcc.h doesn't define __section but checkpatch.pl will complain for this. so
  * temporarily add a macro here.

--- a/soc/riscv/espressif_esp32/esp32c3/soc.c
+++ b/soc/riscv/espressif_esp32/esp32c3/soc.c
@@ -23,7 +23,7 @@
 #include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <string.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 #include <soc.h>
 
 #ifdef CONFIG_MCUBOOT

--- a/soc/riscv/espressif_esp32/esp32c3/soc_irq.c
+++ b/soc/riscv/espressif_esp32/esp32c3/soc_irq.c
@@ -18,7 +18,7 @@
 
 #include <zephyr/kernel_structs.h>
 #include <string.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 #include <soc.h>
 #include <zephyr/arch/riscv/arch.h>
 

--- a/soc/xtensa/espressif_esp32/esp32/soc.c
+++ b/soc/xtensa/espressif_esp32/esp32/soc.c
@@ -14,7 +14,7 @@
 
 #include <zephyr/kernel_structs.h>
 #include <string.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/linker/linker-defs.h>
 #include <kernel_internal.h>

--- a/soc/xtensa/espressif_esp32/esp32_net/soc.c
+++ b/soc/xtensa/espressif_esp32/esp32_net/soc.c
@@ -14,7 +14,7 @@
 
 #include <zephyr/kernel_structs.h>
 #include <string.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/linker/linker-defs.h>
 #include <kernel_internal.h>

--- a/soc/xtensa/espressif_esp32/esp32s2/soc.c
+++ b/soc/xtensa/espressif_esp32/esp32s2/soc.c
@@ -15,7 +15,7 @@
 #include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <string.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #include "esp_private/system_internal.h"

--- a/soc/xtensa/espressif_esp32/esp32s3/soc.c
+++ b/soc/xtensa/espressif_esp32/esp32s3/soc.c
@@ -14,7 +14,7 @@
 
 #include <zephyr/kernel_structs.h>
 #include <string.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/linker/linker-defs.h>
 #include <kernel_internal.h>

--- a/subsys/usb/device_next/usbd_class.c
+++ b/subsys/usb/device_next/usbd_class.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/usb/usbd.h>
-#include <zephyr/toolchain/common.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/drivers/usb/udc.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/iterable_sections.h>

--- a/subsys/usb/device_next/usbd_core.c
+++ b/subsys/usb/device_next/usbd_core.c
@@ -7,7 +7,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
-#include <zephyr/toolchain/common.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/drivers/usb/udc.h>

--- a/tests/bsim/bluetooth/host/adv/resume/src/dut.c
+++ b/tests/bsim/bluetooth/host/adv/resume/src/dut.c
@@ -8,7 +8,7 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/tests/bsim/bluetooth/host/gatt/settings/src/client.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/client.c
@@ -11,7 +11,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/settings/settings.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/tests/bsim/bluetooth/host/gatt/settings/src/server.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/server.c
@@ -12,7 +12,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/settings/settings.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/tests/bsim/bluetooth/host/privacy/central/src/tester.c
+++ b/tests/bsim/bluetooth/host/privacy/central/src/tester.c
@@ -12,7 +12,7 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 
 DEFINE_FLAG(flag_new_address);
 

--- a/tests/bsim/bluetooth/host/privacy/peripheral/src/dut.c
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/src/dut.c
@@ -12,7 +12,7 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 
 #include "common/bt_str.h"
 

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/peripheral.c
@@ -8,7 +8,7 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/peripheral.c
@@ -8,7 +8,7 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/src/peripheral.c
@@ -8,7 +8,7 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/peripheral.c
@@ -9,7 +9,7 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/toolchain/gcc.h>
+#include <zephyr/toolchain.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 06c956741a81eb0fd3c0c31367c3c177bffaaab8
+      revision: 5331fe2ff1310b033bf01cd3a232f1e587726e3b
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Toolchain utilities need to be used through the <zephyr/toolchain.h>
parent header, where the right header is chosen.