### PR TITLE
subsys: settings: move some marco to KCONFIG for user override

### DIFF
--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -1033,7 +1033,7 @@ static inline bool bt_mesh_model_in_primary(const struct bt_mesh_model *mod)
  *  @param mod      Mesh model.
  *  @param vnd      This is a vendor model.
  *  @param name     Name/key of the settings item. Only
- *                  @ref SETTINGS_MAX_DIR_DEPTH bytes will be used at most.
+ *                  @ref CONFIG_SETTINGS_MAX_DIR_DEPTH bytes will be used at most.
  *  @param data     Model data to store, or NULL to delete any model data.
  *  @param data_len Length of the model data.
  *

--- a/include/zephyr/settings/settings.h
+++ b/include/zephyr/settings/settings.h
@@ -32,16 +32,12 @@ extern "C" {
  * @{
  */
 
-#define SETTINGS_MAX_DIR_DEPTH	8	/* max depth of settings tree */
-#define SETTINGS_MAX_NAME_LEN	(8 * SETTINGS_MAX_DIR_DEPTH)
-#define SETTINGS_MAX_VAL_LEN	256
-#define SETTINGS_NAME_SEPARATOR	'/'
-#define SETTINGS_NAME_END '='
+#define SETTINGS_MAX_NAME_LEN          (8 * CONFIG_SETTINGS_MAX_DIR_DEPTH)
 
 /* place for settings additions:
  * up to 7 separators, '=', '\0'
  */
-#define SETTINGS_EXTRA_LEN ((SETTINGS_MAX_DIR_DEPTH - 1) + 2)
+#define SETTINGS_EXTRA_LEN ((CONFIG_SETTINGS_MAX_DIR_DEPTH - 1) + 2)
 
 /**
  * Function used to read the data from the settings storage in

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -30,6 +30,32 @@ config SETTINGS_DYNAMIC_HANDLERS
 config SETTINGS_ENCODE_LEN
 	bool
 
+config SETTINGS_MAX_DIR_DEPTH
+	int "Maximum depth of settings tree"
+	default 8
+	help
+	  Maximum depth of settings tree. This is used to allocate memory
+	  for settings lookup.
+
+config SETTINGS_MAX_VAL_LEN
+	int "Maximum length of settings value"
+	default 128
+	help
+	  Maximum length of settings value. This is used to allocate memory
+	  for settings lookup.
+
+config SETTINGS_NAME_SEPARATOR
+	hex "Settings name separator"
+	default 0x2f
+	help
+	  Separator used in settings name. This is used for settings lookup.
+
+config SETTINGS_NAME_END
+	hex "Settings name end"
+	default 0x2e
+	help
+	  End of settings name. This is used for settings lookup.
+
 choice SETTINGS_BACKEND
 	prompt "Storage back-end"
 	default SETTINGS_NVS if NVS

--- a/subsys/settings/src/settings.c
+++ b/subsys/settings/src/settings.c
@@ -78,8 +78,8 @@ int settings_name_steq(const char *name, const char *key, const char **next)
 	 * limited to what can be read
 	 */
 
-	while ((*key != '\0') && (*key == *name) &&
-	       (*name != '\0') && (*name != SETTINGS_NAME_END)) {
+	while ((*key != '\0') && (*key == *name) && (*name != '\0') &&
+	       (*name != CONFIG_SETTINGS_NAME_END)) {
 		key++;
 		name++;
 	}
@@ -88,14 +88,14 @@ int settings_name_steq(const char *name, const char *key, const char **next)
 		return 0;
 	}
 
-	if (*name == SETTINGS_NAME_SEPARATOR) {
+	if (*name == CONFIG_SETTINGS_NAME_SEPARATOR) {
 		if (next) {
 			*next = name + 1;
 		}
 		return 1;
 	}
 
-	if ((*name == SETTINGS_NAME_END) || (*name == '\0')) {
+	if ((*name == CONFIG_SETTINGS_NAME_END) || (*name == '\0')) {
 		return 1;
 	}
 
@@ -118,13 +118,13 @@ int settings_name_next(const char *name, const char **next)
 	 * with '=' or '\0' depending how storage is done. Flash reading is
 	 * limited to what can be read
 	 */
-	while ((*name != '\0') && (*name != SETTINGS_NAME_END) &&
-	       (*name != SETTINGS_NAME_SEPARATOR)) {
+	while ((*name != '\0') && (*name != CONFIG_SETTINGS_NAME_END) &&
+	       (*name != CONFIG_SETTINGS_NAME_SEPARATOR)) {
 		rc++;
 		name++;
 	}
 
-	if (*name == SETTINGS_NAME_SEPARATOR) {
+	if (*name == CONFIG_SETTINGS_NAME_SEPARATOR) {
 		if (next) {
 			*next = name + 1;
 		}

--- a/subsys/settings/src/settings_shell.c
+++ b/subsys/settings/src/settings_shell.c
@@ -67,8 +67,8 @@ static int settings_read_callback(const char *key,
 				  void            *cb_arg,
 				  void            *param)
 {
-	uint8_t buffer[SETTINGS_MAX_VAL_LEN];
-	ssize_t num_read_bytes = MIN(len, SETTINGS_MAX_VAL_LEN);
+	uint8_t buffer[CONFIG_SETTINGS_MAX_VAL_LEN];
+	ssize_t num_read_bytes = MIN(len, CONFIG_SETTINGS_MAX_VAL_LEN);
 	struct settings_read_callback_params *params = param;
 
 	/* Process only the exact match and ignore descendants of the searched name */
@@ -86,7 +86,7 @@ static int settings_read_callback(const char *key,
 
 	shell_hexdump(params->shell_ptr, buffer, num_read_bytes);
 
-	if (len > SETTINGS_MAX_VAL_LEN) {
+	if (len > CONFIG_SETTINGS_MAX_VAL_LEN) {
 		shell_print(params->shell_ptr, "(The output has been truncated)");
 	}
 

--- a/tests/bsim/bluetooth/host/gatt/settings/src/settings.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/settings.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(settings_backend, 3);
 
 #define ENTRY_LEN_SIZE (4)
 #define ENTRY_NAME_MAX_LEN (SETTINGS_MAX_NAME_LEN + SETTINGS_EXTRA_LEN)
-#define ENTRY_VAL_MAX_LEN (SETTINGS_MAX_VAL_LEN * 2)
+#define ENTRY_VAL_MAX_LEN (CONFIG_SETTINGS_MAX_VAL_LEN * 2)
 #define READ_LEN_MAX (ENTRY_VAL_MAX_LEN + ENTRY_NAME_MAX_LEN + 2)
 
 struct line_read_ctx {
@@ -146,7 +146,7 @@ static int settings_custom_save(struct settings_store *cs, const char *name,
 		return -1;
 	}
 
-	if (strlen(name) > ENTRY_NAME_MAX_LEN || val_len > SETTINGS_MAX_VAL_LEN) {
+	if (strlen(name) > ENTRY_NAME_MAX_LEN || val_len > CONFIG_SETTINGS_MAX_VAL_LEN) {
 		return -1;
 	}
 

--- a/tests/subsys/settings/fcb/src/settings_test.h
+++ b/tests/subsys/settings/fcb/src/settings_test.h
@@ -37,8 +37,8 @@ extern int c2_var_count;
 
 extern struct flash_sector fcb_sectors[SETTINGS_TEST_FCB_FLASH_CNT];
 
-extern char val_string[SETTINGS_TEST_FCB_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN];
-extern char test_ref_value[SETTINGS_TEST_FCB_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN];
+extern char val_string[SETTINGS_TEST_FCB_VAL_STR_CNT][CONFIG_SETTINGS_MAX_VAL_LEN];
+extern char test_ref_value[SETTINGS_TEST_FCB_VAL_STR_CNT][CONFIG_SETTINGS_MAX_VAL_LEN];
 
 extern struct settings_handler c_test_handlers[];
 
@@ -49,8 +49,7 @@ void config_wipe_srcs(void);
 void config_wipe_fcb(struct flash_sector *fs, int cnt);
 
 void test_config_fill_area(
-	char test_value[SETTINGS_TEST_FCB_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN],
-		int iteration);
+	char test_value[SETTINGS_TEST_FCB_VAL_STR_CNT][CONFIG_SETTINGS_MAX_VAL_LEN], int iteration);
 
 void *settings_config_setup(void);
 void settings_config_teardown(void *fixture);

--- a/tests/subsys/settings/fcb/src/settings_test_compress_deleted.c
+++ b/tests/subsys/settings/fcb/src/settings_test_compress_deleted.c
@@ -61,8 +61,7 @@ int c4_handle_export(int (*cb)(const char *name, const void *value, size_t val_l
 
 static int check_compressed_cb(struct fcb_entry_ctx *entry_ctx, void *arg)
 {
-	char buf[SETTINGS_MAX_NAME_LEN + SETTINGS_MAX_VAL_LEN +
-		 SETTINGS_EXTRA_LEN];
+	char buf[SETTINGS_MAX_NAME_LEN + CONFIG_SETTINGS_MAX_VAL_LEN + SETTINGS_EXTRA_LEN];
 	int rc;
 	int len;
 

--- a/tests/subsys/settings/fcb/src/settings_test_compress_reset.c
+++ b/tests/subsys/settings/fcb/src/settings_test_compress_reset.c
@@ -53,8 +53,7 @@ ZTEST(settings_config_fcb, test_config_compress_reset)
 
 		rc = settings_load();
 		zassert_true(rc == 0, "fcb read error");
-		zassert_true(!memcmp(val_string, test_ref_value,
-				     SETTINGS_MAX_VAL_LEN),
+		zassert_true(!memcmp(val_string, test_ref_value, CONFIG_SETTINGS_MAX_VAL_LEN),
 			     "bad value read");
 	}
 

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -69,8 +69,8 @@ struct settings_handler c_test_handlers[] = {
 	}
 };
 
-char val_string[SETTINGS_TEST_FCB_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN];
-char test_ref_value[SETTINGS_TEST_FCB_VAL_STR_CNT][SETTINGS_MAX_VAL_LEN];
+char val_string[SETTINGS_TEST_FCB_VAL_STR_CNT][CONFIG_SETTINGS_MAX_VAL_LEN];
+char test_ref_value[SETTINGS_TEST_FCB_VAL_STR_CNT][CONFIG_SETTINGS_MAX_VAL_LEN];
 
 int c1_handle_get(const char *name, char *val, int val_len_max)
 {
@@ -198,15 +198,13 @@ void config_wipe_fcb(struct flash_sector *fs, int cnt)
 	}
 }
 
-void
-test_config_fill_area(char test_value[SETTINGS_TEST_FCB_VAL_STR_CNT]
-				     [SETTINGS_MAX_VAL_LEN],
-		      int iteration)
+void test_config_fill_area(
+	char test_value[SETTINGS_TEST_FCB_VAL_STR_CNT][CONFIG_SETTINGS_MAX_VAL_LEN], int iteration)
 {
 	int i, j;
 
 	for (j = 0; j < 64; j++) {
-		for (i = 0; i < SETTINGS_MAX_VAL_LEN; i++) {
+		for (i = 0; i < CONFIG_SETTINGS_MAX_VAL_LEN; i++) {
 			test_value[j][i] = ((j * 2) + i + iteration) % 10 + '0';
 		}
 		test_value[j][sizeof(test_value[j]) - 1] = '\0';


### PR DESCRIPTION
In the setting subsystem, the following macros are defined.
``` c
#define SETTINGS_MAX_DIR_DEPTH	8	/* max depth of settings tree */
#define SETTINGS_MAX_VAL_LEN	256
#define SETTINGS_NAME_SEPARATOR	'/'
#define SETTINGS_NAME_END '='
```

This PR move these macros to Kconfig.
so that the application can overrides these configuration.