### PR TITLE
scripts: set_assignee: set reviewers for modules

### DIFF
--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -286,7 +286,10 @@ def process_modules(gh, maintainers_file):
             log(f"No maintainers for: {area}")
             continue
 
-        log(f"Found {area}, maintainers={maintainers}")
+        collaborators = maintainers_file.areas[area].collaborators
+
+        log(f"Found {area}, maintainers={maintainers}, collaborators={collaborators}")
+
         repo_name = f"{args.org}/{project.name}"
         repos[repo_name] = maintainers_file.areas[area]
 
@@ -309,9 +312,15 @@ def process_modules(gh, maintainers_file):
         area = repos[repo_name]
 
         for maintainer in area.maintainers:
-            log(f"Adding {maintainer} to {pull.html_url}")
+            log(f"Assigning {maintainer} to {pull.html_url}")
             if not args.dry_run:
                 pull.add_to_assignees(maintainer)
+                pull.create_review_request(maintainer)
+
+        for collaborator in area.collaborators:
+            log(f"Adding {collaborator} to {pull.html_url}")
+            if not args.dry_run:
+                pull.create_review_request(collaborator)
 
 
 def main():


### PR DESCRIPTION
Example run:

```
$ ./scripts/set_assignees.py -v -y --modules
...
Assigning dleach02 to https://github.com/zephyrproject-rtos/hal_nxp/pull/274
Adding mmahadevan108 to https://github.com/zephyrproject-rtos/hal_nxp/pull/274
Adding danieldegrasse to https://github.com/zephyrproject-rtos/hal_nxp/pull/274
Adding manuargue to https://github.com/zephyrproject-rtos/hal_nxp/pull/274
Adding PetervdPerk-NXP to https://github.com/zephyrproject-rtos/hal_nxp/pull/274
Adding bperseghetti to https://github.com/zephyrproject-rtos/hal_nxp/pull/274
...
Assigning fkokosinski to https://github.com/zephyrproject-rtos/hal_ambiq/pull/7
Adding tgorochowik to https://github.com/zephyrproject-rtos/hal_ambiq/pull/7
Adding msobkowski to https://github.com/zephyrproject-rtos/hal_ambiq/pull/7
...
```

---

Add support for setting reviewers as well for module PRs, in addition to the assignees.

Note that this still only works on repositories with an assignee on record since it does not seem to be possible to query for PRs that have no reviewers.