### PR TITLE
manifest: update hal_ti

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -239,7 +239,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: 9fa5827c44b6a81dced9efafb4095dafabea7421
+      revision: b85f86e51fc4d47c4c383d320d64d52d4d371ae4
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
Update for https://github.com/zephyrproject-rtos/hal_ti/pull/50, see https://github.com/zephyrproject-rtos/zephyr/issues/62612 as well, build error can be reproduced with `west build -p -b cc3220sf_launchxl -T tests/net/lib/mqtt_publisher/net.mqtt`

---

Update hal_ti to include a build error fix.