### PR TITLE
twister: pytest: Allow to pass a list of testpaths to pytest_root 

### DIFF
--- a/doc/develop/test/pytest.rst
+++ b/doc/develop/test/pytest.rst
@@ -49,28 +49,47 @@ How to create a pytest test
 An example of a pytest test is given at :zephyr_file:`samples/subsys/testsuite/pytest/shell/pytest/test_shell.py`.
 Twister calls pytest for each configuration from the .yaml file which uses ``harness: pytest``.
 By default, it points to ``pytest`` directory, located next to a directory with binary sources.
-A keyword ``pytest_root`` placed under ``harness_config`` section can be used to point to another
-location.
+A keyword ``pytest_root`` placed under ``harness_config`` section can be used to point to other
+files, directories or subtests.
 
-Pytest scans the given folder looking for tests, following its default
+Pytest scans the given locations looking for tests, following its default
 `discovery rules <https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#conventions-for-python-test-discovery>`_
 One can also pass some extra arguments to the pytest from yaml file using ``pytest_args`` keyword
 under ``harness_config``, e.g.: ``pytest_args: [‘-k=test_method’, ‘--log-level=DEBUG’]``.
 
-Following import is required to include in .py sources:
+Helpers & fixtures
+==================
+
+dut
+---
+
+Give access to a DeviceAdapter type object, that represents Device Under Test.
+This fixture is the core of pytest harness plugin. It is required to launch
+DUT (initialize logging, flash device, connect serial etc).
+This fixture yields a device prepared according to the requested type
+(native posix, qemu, hardware, etc.). All types of devices share the same API.
+This allows for writing tests which are device-type-agnostic.
 
 .. code-block:: python
 
-   from twister_harness import Device
+   from twister_harness import DeviceAdapter
 
-It is important for type checking and enabling IDE hints for ``dut`` s (objects representing
-Devices Under Test). The ``dut`` fixture is the core of pytest harness plugin. When used as an
-argument of a test function it gives access to a DeviceAbstract type object. The fixture yields a
-device prepared according to the requested type (native posix, qemu, hardware, etc.). All types of
-devices share the same API. This allows for writing tests which are device-type-agnostic.
+   def test_sample(dut: DeviceAdapter):
+      dut.readlines_until('Hello world')
 
-Helpers & fixtures
-==================
+shell
+-----
+
+Provide an object with methods used to interact with shell application.
+It calls `wait_for_promt` method, to not start scenario until DUT is ready.
+Note that it uses `dut` fixture, so `dut` can be skipped when `shell` is used.
+
+.. code-block:: python
+
+   from twister_harness import Shell
+
+   def test_shell(shell: Shell):
+      shell.exec_command('help')
 
 mcumgr
 ------
@@ -82,16 +101,15 @@ More information about MCUmgr can be found here :ref:`mcu_mgr`.
    This fixture requires the ``mcumgr`` available in the system PATH
 
 Only selected functionality of MCUmgr is wrapped by this fixture.
-
 For example, here is a test with a fixture ``mcumgr``
 
 .. code-block:: python
 
-   from twister_harness import Device, McuMgr
+   from twister_harness import DeviceAdapter, Shell, McuMgr
 
-   def test_upgrade(dut: Device, mcumgr: McuMgr):
-      # wait for dut is up
-      time.sleep(2)
+   def test_upgrade(dut: DeviceAdapter, shell: Shell, mcumgr: McuMgr):
+      # free the serial port for mcumgr
+      dut.disconnect()
       # upload the signed image
       mcumgr.image_upload('path/to/zephyr.signed.bin')
       # obtain the hash of uploaded image from the device
@@ -105,7 +123,4 @@ For example, here is a test with a fixture ``mcumgr``
 Limitations
 ***********
 
-* Device adapters in pytest plugin provide `iter_stdout` method to read from devices. In some
-  cases, it is not the most convenient way, and it will be considered how to improve this
-  (for example replace it with a simple read function with a given byte size and timeout arguments).
 * Not every platform type is supported in the plugin (yet).

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -492,10 +492,11 @@ harness_config: <harness configuration options>
         Only one fixture can be defined per testcase and the fixture name has to
         be unique across all tests in the test suite.
 
-    pytest_root: <pytest directory> (default pytest)
-        Specify a pytest directory which need to execute when test case begin to running,
-        default pytest directory name is pytest, after pytest finished, twister will
-        check if this case pass or fail according the pytest report.
+    pytest_root: <list of pytest testpaths> (default pytest)
+        Specify a list of pytest directories, files or subtests that need to be executed
+        when test case begin to running, default pytest directory is pytest.
+        After pytest finished, twister will check if this case pass or fail according
+        to the pytest report.
 
     pytest_args: <list of arguments> (default empty)
         Specify a list of additional arguments to pass to ``pytest``.
@@ -526,15 +527,24 @@ harness_config: <harness configuration options>
 
     The following is an example yaml file with pytest harness_config options,
     default pytest_root name "pytest" will be used if pytest_root not specified.
-    please refer the example in samples/subsys/testsuite/pytest/.
+    please refer the examples in samples/subsys/testsuite/pytest/.
 
     ::
 
+        common:
+          harness: pytest
         tests:
-          pytest.example:
-            harness: pytest
+          pytest.example.directories:
             harness_config:
-              pytest_root: [pytest directory name]
+              pytest_root:
+                - pytest_dir1
+                - $ENV_VAR/samples/test/pytest_dir2
+          pytest.example.files_and_subtests:
+            harness_config:
+              pytest_root:
+                - pytest/test_file_1.py
+                - test_file_2.py::test_A
+                - test_file_2.py::test_B[param_a]
 
     The following is an example yaml file with robot harness_config options.
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -245,19 +245,20 @@ class Pytest(Harness):
 
     def generate_command(self):
         config = self.instance.testsuite.harness_config
-        pytest_root = config.get('pytest_root', 'pytest') if config else 'pytest'
+        pytest_root = config.get('pytest_root', ['pytest']) if config else ['pytest']
         pytest_args = config.get('pytest_args', []) if config else []
         command = [
             'pytest',
             '--twister-harness',
             '-s', '-v',
-            os.path.join(self.source_dir, pytest_root),
             f'--build-dir={self.running_dir}',
             f'--junit-xml={self.report_file}',
             '--log-file-level=DEBUG',
             '--log-file-format=%(asctime)s.%(msecs)d:%(levelname)s:%(name)s: %(message)s',
             f'--log-file={self.pytest_log_file_path}'
         ]
+        command.extend([os.path.normpath(os.path.join(
+            self.source_dir, os.path.expanduser(os.path.expandvars(src)))) for src in pytest_root])
         command.extend(pytest_args)
 
         handler: Handler = self.instance.handler

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -95,8 +95,10 @@ mapping:
             type: int
             required: false
           "pytest_root":
-            type: str
+            type: seq
             required: false
+            sequence:
+              - type: str
           "pytest_args":
             type: seq
             required: false
@@ -293,8 +295,10 @@ mapping:
                 type: int
                 required: false
               "pytest_root":
-                type: str
+                type: seq
                 required: false
+                sequence:
+                  - type: str
               "pytest_args":
                 type: seq
                 required: false

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -48,6 +48,67 @@ def test_pytest_command(testinstance: TestInstance, device_type):
         assert c in command
 
 
+@pytest.mark.parametrize(
+    ('pytest_root', 'expected'),
+    [
+        (
+            ['pytest/test_shell_help.py'],
+            ['samples/hello/pytest/test_shell_help.py']
+        ),
+        (
+            ['pytest/test_shell_help.py', 'pytest/test_shell_version.py', 'test_dir'],
+            ['samples/hello/pytest/test_shell_help.py',
+             'samples/hello/pytest/test_shell_version.py',
+             'samples/hello/test_dir']
+        ),
+        (
+            ['../shell/pytest/test_shell.py'],
+            ['samples/shell/pytest/test_shell.py']
+        ),
+        (
+            ['/tmp/test_temp.py'],
+            ['/tmp/test_temp.py']
+        ),
+        (
+            ['~/tmp/test_temp.py'],
+            ['/home/joe/tmp/test_temp.py']
+        ),
+        (
+            ['$ZEPHYR_BASE/samples/subsys/testsuite/pytest/shell/pytest'],
+            ['/zephyr_base/samples/subsys/testsuite/pytest/shell/pytest']
+        ),
+        (
+            ['pytest/test_shell_help.py::test_A', 'pytest/test_shell_help.py::test_B'],
+            ['samples/hello/pytest/test_shell_help.py::test_A',
+             'samples/hello/pytest/test_shell_help.py::test_B']
+        ),
+        (
+            ['pytest/test_shell_help.py::test_A[param_a]'],
+            ['samples/hello/pytest/test_shell_help.py::test_A[param_a]']
+        )
+    ],
+    ids=[
+        'one_file',
+        'more_files',
+        'relative_path',
+        'absollute_path',
+        'user_dir',
+        'with_env_var',
+        'subtests',
+        'subtest_with_param'
+    ]
+)
+def test_pytest_handle_source_list(testinstance: TestInstance, monkeypatch, pytest_root, expected):
+    monkeypatch.setenv('ZEPHYR_BASE', '/zephyr_base')
+    monkeypatch.setenv('HOME', '/home/joe')
+    testinstance.testsuite.harness_config['pytest_root'] = pytest_root
+    pytest_harness = Pytest()
+    pytest_harness.configure(testinstance)
+    command = pytest_harness.generate_command()
+    for pytest_src in expected:
+        assert pytest_src in command
+
+
 def test_if_report_is_parsed(pytester, testinstance: TestInstance):
     test_file_content = textwrap.dedent("""
         def test_1():


### PR DESCRIPTION
Allow to specify a list of pytest directories, files or subtests with `pytest_root` keyword in test yaml.
By default, when `harness_config:pytest_root` is empty, then folder 'pytest' is used as a testpath.
This location can be changed, but only one entry can be used.
With that PR it is possible to pass a list of directories, files, subtests and parametrized subtest with `pytest_root`.
It is also possible to use the absolute path to test files (not only related to source folder) or to use an environment variable (like $ZEPHYR_BASE).
This change allows to select tests by different configurations, to not rerun all from given dir / file.
E.g.
```
common:
  harness: pytest
tests:
  sample.pytest.shell_test_basic:
    harness: pytest
  sample.pytest.shell_test_select_one_file:
    harness_config:
      pytest_root:
        - "pytest/test_shell_help.py"
  sample.pytest.shell_test_select_two_files:
    harness_config:
      pytest_root:
        - "pytest/test_shell_help.py"
        - "pytest/test_shell_version.py"
  sample.pytest.shell_test_with_ext_scenario:
    harness_config:
      pytest_root: 
        - "pytest"
        - "../shell/pytest/test_shell.py"
  sample.pytest.shell_test_absolute_path:
    harness_config:
      pytest_root:
        - "/tmp/test_shell.py"
  sample.pytest.shell_test_path_with_user:
    harness_config:
      pytest_root:
        - "~/tmp/test_shell.py"
  sample.pytest.shell_test_path_with_env:
    harness_config:
      pytest_root:
        - "$ZEPHYR_BASE/samples/subsys/testsuite/pytest/shell/pytest/test_shell.py"
  sample.pytest.shell_test_select_subtest:
    harness_config:
      pytest_root:
        - "pytest/test_shell_help.py::test_shell2_sample"
  sample.pytest.shell_test_select_subtest_with_param:
    harness_config:
      pytest_root:
        - "pytest/test_shell_help.py::test_shell2_sample[param_a]"
```

Added unittests.
Also updated the documentation - Feel free to correct


