### PR TITLE
Bluetooth: Host: Document required changes for L2CAP accept() callback

### DIFF
--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -139,6 +139,12 @@ Required changes
          };
      };
 
+* The ``accept()`` callback's signature in :c:struct:`bt_l2cap_server` has
+  changed to ``int (*accept)(struct bt_conn *conn, struct bt_l2cap_server
+  *server, struct bt_l2cap_chan **chan)``,
+  adding a new ``server`` parameter pointing to the :c:struct:`bt_l2cap_server`
+  structure instance the callback relates to. :github:`60536`
+
 Recommended Changes
 *******************
 


### PR DESCRIPTION
Add a required change in the migration guide to document the changes to the accept() callback in struct bt_l2cap_server.

Changes introduced in https://github.com/zephyrproject-rtos/zephyr/pull/60536/