### PR TITLE
MAINTAINERS: include the ethos driver in the ethos module

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3023,6 +3023,7 @@ West:
   maintainers:
     - kristofer-jonsson-arm
   files:
+    - drivers/misc/ethos_u/
     - modules/hal_ethos_u/
   labels:
     - manifest-hal_ethos_u


### PR DESCRIPTION
The driver is bound to the module, there's no separate platform, so let's just add the driver path to the module area so that changes for it gets tagged and assigned.