### PR TITLE
drivers: flash: flash_mcux_flexspi_mx25um51325g: fix OPI DTR write

### DIFF
--- a/drivers/flash/Kconfig.mcux
+++ b/drivers/flash/Kconfig.mcux
@@ -77,6 +77,9 @@ config FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_STR
 
 config FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR
 	bool "DTR"
+	# DTR requires writes be aligned to even addresses and even sizes,
+	# so a write buffer is required.
+	select FLASH_MCUX_FLEXSPI_NOR_WRITE_BUFFER
 
 endchoice
 


### PR DESCRIPTION
Per the MX25UM51325G datasheet, all page programs in OPI DTR mode need to start at an even address, and be of even length. In order to ensure this requirement is respected, always enable the NOR write buffer when DTR mode is used, and add logic to shift the offset and pad the size when a request to program the flash is made that does not respect these requirements.