### PR TITLE
fuel_gauge: Join get/set prop structs

### DIFF
--- a/doc/hardware/peripherals/fuel_gauge.rst
+++ b/doc/hardware/peripherals/fuel_gauge.rst
@@ -20,7 +20,7 @@ Fundamentally, a property is a quantity that a fuel gauge device can measure.
 Fuel gauges typically support multiple properties, such as temperature readings of the battery-pack
 or present-time current/voltage.
 
-Properties are fetched using a client allocated array of :c:struct:`fuel_gauge_get_property`.  This
+Properties are fetched using a client allocated array of :c:struct:`fuel_gauge_property`.  This
 array is then populated by values as according to its `property_type` field.
 
 Battery Cutoff

--- a/drivers/fuel_gauge/bq27z746/bq27z746.c
+++ b/drivers/fuel_gauge/bq27z746/bq27z746.c
@@ -109,7 +109,7 @@ static int bq27z746_read_mac(const struct device *dev, uint16_t cmd, uint8_t *da
 	return ret;
 }
 
-static int bq27z746_get_prop(const struct device *dev, struct fuel_gauge_get_property *prop)
+static int bq27z746_get_prop(const struct device *dev, struct fuel_gauge_property *prop)
 {
 	int rc = 0;
 	uint16_t val = 0;
@@ -198,7 +198,7 @@ static int bq27z746_get_prop(const struct device *dev, struct fuel_gauge_get_pro
 }
 
 static int bq27z746_get_buffer_prop(const struct device *dev,
-				    struct fuel_gauge_get_buffer_property *prop, void *dst,
+				    struct fuel_gauge_buffer_property *prop, void *dst,
 				    size_t dst_len)
 {
 	int rc = 0;
@@ -236,7 +236,7 @@ static int bq27z746_get_buffer_prop(const struct device *dev,
 	return rc;
 }
 
-static int bq27z746_set_prop(const struct device *dev, struct fuel_gauge_set_property *prop)
+static int bq27z746_set_prop(const struct device *dev, struct fuel_gauge_property *prop)
 {
 	int rc = 0;
 	uint16_t val = 0;
@@ -260,7 +260,7 @@ static int bq27z746_set_prop(const struct device *dev, struct fuel_gauge_set_pro
 	return rc;
 }
 
-static int bq27z746_get_props(const struct device *dev, struct fuel_gauge_get_property *props,
+static int bq27z746_get_props(const struct device *dev, struct fuel_gauge_property *props,
 			      size_t len)
 {
 	int err_count = 0;
@@ -276,7 +276,7 @@ static int bq27z746_get_props(const struct device *dev, struct fuel_gauge_get_pr
 	return err_count;
 }
 
-static int bq27z746_set_props(const struct device *dev, struct fuel_gauge_set_property *props,
+static int bq27z746_set_props(const struct device *dev, struct fuel_gauge_property *props,
 			      size_t len)
 {
 	int err_count = 0;

--- a/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
+++ b/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
@@ -9,19 +9,19 @@
 #include <zephyr/drivers/fuel_gauge.h>
 
 static inline int z_vrfy_fuel_gauge_get_prop(const struct device *dev,
-					     struct fuel_gauge_get_property *props,
+					     struct fuel_gauge_property *props,
 					     size_t props_len)
 {
-	struct fuel_gauge_get_property k_props[props_len];
+	struct fuel_gauge_property k_props[props_len];
 
 	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, get_property));
 
 	Z_OOPS(z_user_from_copy(k_props, props,
-				props_len * sizeof(struct fuel_gauge_get_property)));
+				props_len * sizeof(struct fuel_gauge_property)));
 
 	int ret = z_impl_fuel_gauge_get_prop(dev, k_props, props_len);
 
-	Z_OOPS(z_user_to_copy(props, k_props, props_len * sizeof(struct fuel_gauge_get_property)));
+	Z_OOPS(z_user_to_copy(props, k_props, props_len * sizeof(struct fuel_gauge_property)));
 
 	return ret;
 }
@@ -29,19 +29,19 @@ static inline int z_vrfy_fuel_gauge_get_prop(const struct device *dev,
 #include <syscalls/fuel_gauge_get_prop_mrsh.c>
 
 static inline int z_vrfy_fuel_gauge_set_prop(const struct device *dev,
-					     struct fuel_gauge_set_property *props,
+					     struct fuel_gauge_property *props,
 					     size_t props_len)
 {
-	struct fuel_gauge_set_property k_props[props_len];
+	struct fuel_gauge_property k_props[props_len];
 
 	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, set_property));
 
 	Z_OOPS(z_user_from_copy(k_props, props,
-				props_len * sizeof(struct fuel_gauge_set_property)));
+				props_len * sizeof(struct fuel_gauge_property)));
 
 	int ret = z_impl_fuel_gauge_set_prop(dev, k_props, props_len);
 
-	Z_OOPS(z_user_to_copy(props, k_props, props_len * sizeof(struct fuel_gauge_set_property)));
+	Z_OOPS(z_user_to_copy(props, k_props, props_len * sizeof(struct fuel_gauge_property)));
 
 	return ret;
 }
@@ -49,22 +49,22 @@ static inline int z_vrfy_fuel_gauge_set_prop(const struct device *dev,
 #include <syscalls/fuel_gauge_set_prop_mrsh.c>
 
 static inline int z_vrfy_fuel_gauge_get_buffer_prop(const struct device *dev,
-						    struct fuel_gauge_get_buffer_property *prop,
+						    struct fuel_gauge_buffer_property *prop,
 						    void *dst, size_t dst_len)
 {
-	struct fuel_gauge_get_buffer_property k_prop;
+	struct fuel_gauge_buffer_property k_prop;
 
 	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, get_buffer_property));
 
 	Z_OOPS(z_user_from_copy(&k_prop, prop,
-				sizeof(struct fuel_gauge_get_buffer_property)));
+				sizeof(struct fuel_gauge_buffer_property)));
 
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(dst, dst_len));
 
 	int ret = z_impl_fuel_gauge_get_buffer_prop(dev, &k_prop, dst, dst_len);
 
 	Z_OOPS(z_user_to_copy(prop, &k_prop,
-			      sizeof(struct fuel_gauge_get_buffer_property)));
+			      sizeof(struct fuel_gauge_buffer_property)));
 
 	return ret;
 }

--- a/drivers/fuel_gauge/max17048/max17048.c
+++ b/drivers/fuel_gauge/max17048/max17048.c
@@ -175,7 +175,7 @@ static int max17048_init(const struct device *dev)
 /**
  * Get a single property from the fuel gauge
  */
-static int max17048_get_prop(const struct device *dev, struct fuel_gauge_get_property *prop)
+static int max17048_get_prop(const struct device *dev, struct fuel_gauge_property *prop)
 {
 	struct max17048_data *data = dev->data;
 	int rc = 0;
@@ -205,7 +205,7 @@ static int max17048_get_prop(const struct device *dev, struct fuel_gauge_get_pro
 /**
  * Get all possible properties from the fuel gague
  */
-static int max17048_get_props(const struct device *dev, struct fuel_gauge_get_property *props,
+static int max17048_get_props(const struct device *dev, struct fuel_gauge_property *props,
 			      size_t len)
 {
 	int err_count = 0;

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -66,7 +66,7 @@ static int sbs_cmd_buffer_read(const struct device *dev, uint8_t reg_addr, char 
 	return 0;
 }
 
-static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_property *prop)
+static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_property *prop)
 {
 	int rc = 0;
 	uint16_t val = 0;
@@ -196,7 +196,7 @@ static int sbs_gauge_do_battery_cutoff(const struct device *dev)
 	return rc;
 }
 
-static int sbs_gauge_set_prop(const struct device *dev, struct fuel_gauge_set_property *prop)
+static int sbs_gauge_set_prop(const struct device *dev, struct fuel_gauge_property *prop)
 {
 	int rc = 0;
 	uint16_t val = 0;
@@ -236,7 +236,7 @@ static int sbs_gauge_set_prop(const struct device *dev, struct fuel_gauge_set_pr
 }
 
 static int sbs_gauge_get_buffer_prop(const struct device *dev,
-				    struct fuel_gauge_get_buffer_property *prop, void *dst,
+				    struct fuel_gauge_buffer_property *prop, void *dst,
 				    size_t dst_len)
 {
 	int rc = 0;
@@ -274,7 +274,7 @@ static int sbs_gauge_get_buffer_prop(const struct device *dev,
 	return rc;
 }
 
-static int sbs_gauge_get_props(const struct device *dev, struct fuel_gauge_get_property *props,
+static int sbs_gauge_get_props(const struct device *dev, struct fuel_gauge_property *props,
 			       size_t len)
 {
 	int err_count = 0;
@@ -290,7 +290,7 @@ static int sbs_gauge_get_props(const struct device *dev, struct fuel_gauge_get_p
 	return err_count;
 }
 
-static int sbs_gauge_set_props(const struct device *dev, struct fuel_gauge_set_property *props,
+static int sbs_gauge_set_props(const struct device *dev, struct fuel_gauge_property *props,
 			       size_t len)
 {
 	int err_count = 0;

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -28,7 +28,7 @@ extern "C" {
 
 /* Keep these alphabetized wrt property name */
 
-enum fuel_gauge_property {
+enum fuel_gauge_prop_type {
 	/** Runtime Dynamic Battery Parameters */
 	/**
 	 * Provide a 1 minute average of the current on the battery.
@@ -115,7 +115,7 @@ enum fuel_gauge_property {
 
 typedef uint16_t fuel_gauge_prop_t;
 
-struct fuel_gauge_get_property {
+struct fuel_gauge_property {
 	/** Battery fuel gauge property to get */
 	fuel_gauge_prop_t property_type;
 
@@ -184,35 +184,8 @@ struct fuel_gauge_get_property {
 	} value;
 };
 
-struct fuel_gauge_set_property {
-	/** Battery fuel gauge property to set */
-	fuel_gauge_prop_t property_type;
-
-	/** Negative error status set by callee e.g. -ENOTSUP for an unsupported property */
-	int status;
-
-	/** Property field for setting */
-	union {
-		/* Fields have the format: */
-		/* FUEL_GAUGE_PROPERTY_FIELD */
-		/* type property_field; */
-
-		/* Writable Dynamic Battery Info */
-		/** FUEL_GAUGE_SBS_MFR_ACCESS */
-		uint16_t sbs_mfr_access_word;
-		/** FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM */
-		uint16_t sbs_remaining_capacity_alarm;
-		/** FUEL_GAUGE_SBS_REMAINING_TIME_ALARM */
-		uint16_t sbs_remaining_time_alarm;
-		/** FUEL_GAUGE_SBS_MODE */
-		uint16_t sbs_mode;
-		/** FUEL_GAUGE_SBS_ATRATE */
-		int16_t sbs_at_rate;
-	} value;
-};
-
 /** Buffer properties are separated due to size */
-struct fuel_gauge_get_buffer_property {
+struct fuel_gauge_buffer_property {
 	/** Battery fuel gauge property to get */
 	fuel_gauge_prop_t property_type;
 
@@ -249,7 +222,7 @@ struct sbs_gauge_device_chemistry {
  * See fuel_gauge_get_property() for argument description
  */
 typedef int (*fuel_gauge_get_property_t)(const struct device *dev,
-					 struct fuel_gauge_get_property *props, size_t props_len);
+					 struct fuel_gauge_property *props, size_t props_len);
 
 /**
  * @typedef fuel_gauge_set_property_t
@@ -258,7 +231,7 @@ typedef int (*fuel_gauge_get_property_t)(const struct device *dev,
  * See fuel_gauge_set_property() for argument description
  */
 typedef int (*fuel_gauge_set_property_t)(const struct device *dev,
-					 struct fuel_gauge_set_property *props, size_t props_len);
+					 struct fuel_gauge_property *props, size_t props_len);
 
 /**
  * @typedef fuel_gauge_get_buffer_property_t
@@ -267,7 +240,7 @@ typedef int (*fuel_gauge_set_property_t)(const struct device *dev,
  * See fuel_gauge_get_buffer_property() for argument description
  */
 typedef int (*fuel_gauge_get_buffer_property_t)(const struct device *dev,
-					       struct fuel_gauge_get_buffer_property *prop,
+					       struct fuel_gauge_buffer_property *prop,
 					       void *dst, size_t dst_len);
 
 /**
@@ -291,20 +264,20 @@ __subsystem struct fuel_gauge_driver_api {
  * @brief Fetch a battery fuel-gauge property
  *
  * @param dev Pointer to the battery fuel-gauge device
- * @param props pointer to array of fuel_gauge_get_property struct where the property struct
+ * @param props pointer to array of fuel_gauge_property struct where the property struct
  * field is set by the caller to determine what property is read from the
- * fuel gauge device into the fuel_gauge_get_property struct's value field. The props array
+ * fuel gauge device into the fuel_gauge_property struct's value field. The props array
  * maintains the same order of properties as it was given.
  * @param props_len number of properties in props array
  *
  * @return return=0 if successful, return < 0 if getting all properties failed, return > 0 if some
  * properties failed where return=number of failing properties.
  */
-__syscall int fuel_gauge_get_prop(const struct device *dev, struct fuel_gauge_get_property *props,
+__syscall int fuel_gauge_get_prop(const struct device *dev, struct fuel_gauge_property *props,
 				  size_t props_len);
 
 static inline int z_impl_fuel_gauge_get_prop(const struct device *dev,
-					     struct fuel_gauge_get_property *props,
+					     struct fuel_gauge_property *props,
 					     size_t props_len)
 {
 	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
@@ -320,19 +293,19 @@ static inline int z_impl_fuel_gauge_get_prop(const struct device *dev,
  * @brief Set a battery fuel-gauge property
  *
  * @param dev Pointer to the battery fuel-gauge device
- * @param props pointer to array of fuel_gauge_set_property struct where the property struct
+ * @param props pointer to array of fuel_gauge_property struct where the property struct
  * field is set by the caller to determine what property is written to the fuel gauge device from
- * the fuel_gauge_get_property struct's value field.
+ * the fuel_gauge_property struct's value field.
  * @param props_len number of properties in props array
  *
  * @return return=0 if successful, return < 0 if setting all properties failed, return > 0 if some
  * properties failed where return=number of failing properties.
  */
-__syscall int fuel_gauge_set_prop(const struct device *dev, struct fuel_gauge_set_property *props,
+__syscall int fuel_gauge_set_prop(const struct device *dev, struct fuel_gauge_property *props,
 				  size_t props_len);
 
 static inline int z_impl_fuel_gauge_set_prop(const struct device *dev,
-					     struct fuel_gauge_set_property *props,
+					     struct fuel_gauge_property *props,
 					     size_t props_len)
 {
 	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
@@ -357,11 +330,11 @@ static inline int z_impl_fuel_gauge_set_prop(const struct device *dev,
  * @return return=0 if successful, return < 0 if getting property failed, return 0 on success
  */
 __syscall int fuel_gauge_get_buffer_prop(const struct device *dev,
-					struct fuel_gauge_get_buffer_property *prop, void *dst,
+					struct fuel_gauge_buffer_property *prop, void *dst,
 					size_t dst_len);
 
 static inline int z_impl_fuel_gauge_get_buffer_prop(const struct device *dev,
-						   struct fuel_gauge_get_buffer_property *prop,
+						   struct fuel_gauge_buffer_property *prop,
 						   void *dst, size_t dst_len)
 {
 	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;

--- a/samples/fuel_gauge/max17048/src/main.c
+++ b/samples/fuel_gauge/max17048/src/main.c
@@ -38,7 +38,7 @@ int main(void)
 
 	while (1) {
 
-		struct fuel_gauge_get_property props[] = {
+		struct fuel_gauge_property props[] = {
 			{
 				.property_type = FUEL_GAUGE_RUNTIME_TO_EMPTY,
 			},

--- a/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
+++ b/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
@@ -33,7 +33,7 @@ static void *bq27z746_setup(void)
 
 ZTEST_USER_F(bq27z746, test_get_all_props_failed_returns_negative)
 {
-	struct fuel_gauge_get_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			/* Invalid property */
 			.property_type = FUEL_GAUGE_PROP_MAX,
@@ -50,7 +50,7 @@ ZTEST_USER_F(bq27z746, test_get_all_props_failed_returns_negative)
 
 ZTEST_USER_F(bq27z746, test_get_some_props_failed_returns_failed_prop_count)
 {
-	struct fuel_gauge_get_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			/* First invalid property */
 			.property_type = FUEL_GAUGE_PROP_MAX,
@@ -82,7 +82,7 @@ ZTEST_USER_F(bq27z746, test_get_some_props_failed_returns_failed_prop_count)
 
 ZTEST_USER_F(bq27z746, test_get_buffer_prop)
 {
-	struct fuel_gauge_get_buffer_property prop;
+	struct fuel_gauge_buffer_property prop;
 	int ret;
 
 	{
@@ -137,7 +137,7 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 {
 	/* Validate what props are supported by the driver */
 
-	struct fuel_gauge_get_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			.property_type = FUEL_GAUGE_AVG_CURRENT,
 		},

--- a/tests/drivers/fuel_gauge/max17048/src/test_max17048.c
+++ b/tests/drivers/fuel_gauge/max17048/src/test_max17048.c
@@ -34,7 +34,7 @@ static void *max17048_setup(void)
 
 ZTEST_USER_F(max17048, test_get_all_props_failed_returns_negative)
 {
-	struct fuel_gauge_get_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			/* Invalid property */
 			.property_type = FUEL_GAUGE_PROP_MAX,
@@ -51,7 +51,7 @@ ZTEST_USER_F(max17048, test_get_all_props_failed_returns_negative)
 
 ZTEST_USER_F(max17048, test_get_some_props_failed_returns_failed_prop_count)
 {
-	struct fuel_gauge_get_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			/* First invalid property */
 			.property_type = FUEL_GAUGE_PROP_MAX,
@@ -86,7 +86,7 @@ ZTEST_USER_F(max17048, test_get_props__returns_ok)
 {
 	/* Validate what props are supported by the driver */
 
-	struct fuel_gauge_get_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			.property_type = FUEL_GAUGE_RUNTIME_TO_EMPTY,
 		},
@@ -115,7 +115,7 @@ ZTEST_USER_F(max17048, test_current_rate_zero)
 {
 	/* Test when crate is 0, which is a special case */
 
-	struct fuel_gauge_get_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			.property_type = FUEL_GAUGE_RUNTIME_TO_EMPTY,
 		},

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -34,7 +34,7 @@ static void *sbs_gauge_new_api_setup(void)
 
 ZTEST_USER_F(sbs_gauge_new_api, test_get_all_props_failed_returns_negative)
 {
-	struct fuel_gauge_get_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			/* Invalid property */
 			.property_type = FUEL_GAUGE_PROP_MAX,
@@ -51,7 +51,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_all_props_failed_returns_negative)
 
 ZTEST_USER_F(sbs_gauge_new_api, test_get_some_props_failed_returns_failed_prop_count)
 {
-	struct fuel_gauge_get_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			/* First invalid property */
 			.property_type = FUEL_GAUGE_PROP_MAX,
@@ -83,7 +83,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_some_props_failed_returns_failed_prop_c
 
 ZTEST_USER_F(sbs_gauge_new_api, test_set_all_props_failed_returns_negative)
 {
-	struct fuel_gauge_set_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			/* Invalid property */
 			.property_type = FUEL_GAUGE_PROP_MAX,
@@ -100,7 +100,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_all_props_failed_returns_negative)
 
 ZTEST_USER_F(sbs_gauge_new_api, test_set_some_props_failed_returns_failed_prop_count)
 {
-	struct fuel_gauge_set_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			/* First invalid property */
 			.property_type = FUEL_GAUGE_PROP_MAX,
@@ -135,7 +135,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_some_props_failed_returns_failed_prop_c
 ZTEST_USER_F(sbs_gauge_new_api, test_set_prop_can_be_get)
 {
 	uint16_t word = BIT(15) | BIT(0);
-	struct fuel_gauge_set_property set_props[] = {
+	struct fuel_gauge_property set_props[] = {
 		{
 			/* Valid property */
 			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
@@ -160,7 +160,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_prop_can_be_get)
 		},
 	};
 
-	struct fuel_gauge_get_property get_props[] = {
+	struct fuel_gauge_property get_props[] = {
 		{
 			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
 		},
@@ -201,7 +201,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)
 {
 	/* Validate what props are supported by the driver */
 
-	struct fuel_gauge_get_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			.property_type = FUEL_GAUGE_VOLTAGE,
 		},
@@ -290,7 +290,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_props__returns_ok)
 {
 	/* Validate what props are supported by the driver */
 
-	struct fuel_gauge_set_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
 		},
@@ -322,7 +322,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_props__returns_ok)
 ZTEST_USER_F(sbs_gauge_new_api, test_get_buffer_props__returns_ok)
 {
 	/* Validate what properties are supported by the driver */
-	struct fuel_gauge_get_buffer_property prop;
+	struct fuel_gauge_buffer_property prop;
 	struct sbs_gauge_manufacturer_name mfg_name;
 	struct sbs_gauge_device_name dev_name;
 	struct sbs_gauge_device_chemistry chem;
@@ -350,7 +350,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_charging_5v_3a)
 	uint32_t expected_uV = 5000 * 1000;
 	uint32_t expected_uA = 3000 * 1000;
 
-	struct fuel_gauge_get_property props[] = {
+	struct fuel_gauge_property props[] = {
 		{
 			.property_type = FUEL_GAUGE_VOLTAGE,
 		},


### PR DESCRIPTION
The fuel gauge API uses separate get/set property structs to indicate what properties are readable or writable. This lead to duplication in property names and potential confusion for new users of the API. See issue #61818. In addition to above, drivers already determine at runtime if a property is supported for read or write actions.

Join the get/set fuel gauge property structs as a single struct.