### PR TITLE
manifest: hal_nordic: fix wrong include in nrfx_pwm

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 9ae7c765985ebdea3d9b98c0d3b154794f0b47cf
+      revision: 03807f75485c97bd7b9094e0c20e40f8044da9f5
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
New nrfx revision fixes issue in the PWM driver causing build errors due to invalid include when workaround for anomaly 109 is enabled.