### PR TITLE
xtensa: dc233c: enable TLS support

### DIFF
--- a/dts/xtensa/dc233c.dtsi
+++ b/dts/xtensa/dc233c.dtsi
@@ -29,13 +29,13 @@
 	};
 
 	/*
-	 * Although ROM is of size 32MB (0x02000000), limit this to 8KB so
+	 * Although ROM is of size 32MB (0x02000000), limit this to 16KB so
 	 * fewer L2 page table entries are needed when MMU is enabled.
 	 */
 	rom0: memory@fe000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0xfe000000 0x00002000>;
+		reg = <0xfe000000 0x00004000>;
 	};
 
 	soc {

--- a/soc/xtensa/dc233c/Kconfig.soc
+++ b/soc/xtensa/dc233c/Kconfig.soc
@@ -6,6 +6,7 @@ config SOC_XTENSA_DC233C
 	bool "Xtensa dc233c core"
 	select XTENSA
 	select XTENSA_HAL
+	select ARCH_HAS_THREAD_LOCAL_STORAGE
 	select CPU_HAS_MMU
 	imply XTENSA_MMU
 	select ARCH_HAS_RESERVED_PAGE_FRAMES if XTENSA_MMU

--- a/soc/xtensa/dc233c/include/xtensa-dc233c.ld
+++ b/soc/xtensa/dc233c/include/xtensa-dc233c.ld
@@ -397,6 +397,8 @@ SECTIONS
 
 #include <zephyr/linker/common-rom.ld>
 
+#include <zephyr/linker/thread-local-storage.ld>
+
 #include <zephyr/linker/cplusplus-rom.ld>
 
 #include <snippets-sections.ld>


### PR DESCRIPTION
Enable thread local storage support for xtensa/dc233c.

This is needed as picolibc under Zephyr SDK requires TLS.