### PR TITLE
logging: Unused arg in log_msg_get_tid

### DIFF
--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -669,6 +669,7 @@ static inline void *log_msg_get_tid(struct log_msg *msg)
 #if CONFIG_LOG_THREAD_ID_PREFIX
 	return msg->hdr.tid;
 #else
+	ARG_UNUSED(msg);
 	return NULL;
 #endif
 }


### PR DESCRIPTION
Resolve unused arg compiler error