### PR TITLE
doc: tracing: fix formatting issue

### DIFF
--- a/doc/services/tracing/index.rst
+++ b/doc/services/tracing/index.rst
@@ -154,23 +154,25 @@ Examples include:
 not be supported by the other tracing systems
 
 The following functions can be defined by the user:
-- ``void sys_trace_thread_create_user(struct k_thread *thread)``
-- ``void sys_trace_thread_abort_user(struct k_thread *thread)``
-- ``void sys_trace_thread_suspend_user(struct k_thread *thread)``
-- ``void sys_trace_thread_resume_user(struct k_thread *thread)``
-- ``void sys_trace_thread_name_set_user(struct k_thread *thread)``
-- ``void sys_trace_thread_switched_in_user(struct k_thread *thread)``
-- ``void sys_trace_thread_switched_out_user(struct k_thread *thread)``
-- ``void sys_trace_thread_info_user(struct k_thread *thread)``
-- ``void sys_trace_thread_sched_ready_user(struct k_thread *thread)``
-- ``void sys_trace_thread_pend_user(struct k_thread *thread)``
-- ``void sys_trace_thread_priority_set_user(struct k_thread *thread, int prio)``
-- ``void sys_trace_isr_enter_user(int nested_interrupts)``
-- ``void sys_trace_isr_exit_user(int nested_interrupts)``
-- ``void sys_trace_idle_user()``
+
+.. code-block:: c
+
+   void sys_trace_thread_create_user(struct k_thread *thread);
+   void sys_trace_thread_abort_user(struct k_thread *thread);
+   void sys_trace_thread_suspend_user(struct k_thread *thread);
+   void sys_trace_thread_resume_user(struct k_thread *thread);
+   void sys_trace_thread_name_set_user(struct k_thread *thread);
+   void sys_trace_thread_switched_in_user(struct k_thread *thread);
+   void sys_trace_thread_switched_out_user(struct k_thread *thread);
+   void sys_trace_thread_info_user(struct k_thread *thread);
+   void sys_trace_thread_sched_ready_user(struct k_thread *thread);
+   void sys_trace_thread_pend_user(struct k_thread *thread);
+   void sys_trace_thread_priority_set_user(struct k_thread *thread, int prio);
+   void sys_trace_isr_enter_user(int nested_interrupts);
+   void sys_trace_isr_exit_user(int nested_interrupts);
+   void sys_trace_idle_user();
 
 Enable this format with the :kconfig:option:`CONFIG_TRACING_USER` option.
-
 
 Transport Backends
 ******************


### PR DESCRIPTION
The list of user-defined functions in "User-Defined Tracing" section was not properly formatted (missing blank line).
Switched the (broken) list to a code block to now provide C syntax highlighting.
