### PR TITLE
xtensa: mark arch_switch() ALWAYS_INLINE and fix pointer cast during stack dump

### DIFF
--- a/arch/xtensa/core/xtensa-asm2.c
+++ b/arch/xtensa/core/xtensa-asm2.c
@@ -122,7 +122,7 @@ void z_xtensa_dump_stack(const z_arch_esf_t *stack)
 
 	LOG_ERR(" **  A0 %p  SP %p  A2 %p  A3 %p",
 		(void *)bsa->a0,
-		((char *)bsa + sizeof(*bsa)),
+		(void *)((char *)bsa + sizeof(*bsa)),
 		(void *)bsa->a2, (void *)bsa->a3);
 
 	if (reg_blks_remaining > 0) {

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -70,7 +70,7 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 
 void xtensa_switch(void *switch_to, void **switched_from);
 
-static inline void arch_switch(void *switch_to, void **switched_from)
+static ALWAYS_INLINE void arch_switch(void *switch_to, void **switched_from)
 {
 	return xtensa_switch(switch_to, switched_from);
 }


### PR DESCRIPTION
* xtensa: cast char* to void* during stack dump with %p
* xtensa: mark arch_switch ALWAYS_INLINE