### PR TITLE
xtensa: dc233c: enable backtrace support

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -46,7 +46,7 @@ config XTENSA_USE_CORE_CRT1
 config XTENSA_ENABLE_BACKTRACE
 	bool "Backtrace on panic exception"
 	default y
-	depends on SOC_SERIES_ESP32 || SOC_FAMILY_INTEL_ADSP
+	depends on SOC_SERIES_ESP32 || SOC_FAMILY_INTEL_ADSP || SOC_XTENSA_DC233C
 	help
 	  Enable this config option to print backtrace on panic exception
 

--- a/arch/xtensa/core/xtensa_backtrace.c
+++ b/arch/xtensa/core/xtensa_backtrace.c
@@ -11,6 +11,8 @@
 #include "soc/soc_memory_layout.h"
 #elif defined(CONFIG_SOC_FAMILY_INTEL_ADSP)
 #include "debug_helpers.h"
+#elif defined(CONFIG_SOC_XTENSA_DC233C)
+#include "backtrace_helpers.h"
 #endif
 static int mask, cause;
 
@@ -38,6 +40,8 @@ static inline bool z_xtensa_stack_ptr_is_sane(uint32_t sp)
 	return esp_stack_ptr_is_sane(sp);
 #elif defined(CONFIG_SOC_FAMILY_INTEL_ADSP)
 	return intel_adsp_ptr_is_sane(sp);
+#elif defined(CONFIG_SOC_XTENSA_DC233C)
+	return xtensa_dc233c_stack_ptr_is_sane(sp);
 #else
 #warning "z_xtensa_stack_ptr_is_sane is not defined for this platform"
 #endif
@@ -49,6 +53,8 @@ static inline bool z_xtensa_ptr_executable(const void *p)
 	return esp_ptr_executable(p);
 #elif defined(CONFIG_SOC_FAMILY_INTEL_ADSP)
 	return intel_adsp_ptr_executable(p);
+#elif defined(CONFIG_SOC_XTENSA_DC233C)
+	return xtensa_dc233c_ptr_executable(p);
 #else
 #warning "z_xtensa_ptr_executable is not defined for this platform"
 #endif

--- a/soc/xtensa/dc233c/include/backtrace_helpers.h
+++ b/soc/xtensa/dc233c/include/backtrace_helpers.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2022, 2023 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#ifndef ZEPHYR_SOC_XTENSA_DC233C_BACKTRACE_HELPERS_H_
+#define ZEPHYR_SOC_XTENSA_DC233C_BACKTRACE_HELPERS_H_
+
+#include <zephyr/linker/linker-defs.h>
+
+#include <xtensa/config/core-isa.h>
+
+static inline bool xtensa_dc233c_ptr_executable(const void *p)
+{
+	bool in_text = ((p >= (void *)__text_region_start) &&
+			(p <= (void *)__text_region_end));
+	bool in_vecbase = ((p >= (void *)XCHAL_VECBASE_RESET_VADDR) &&
+			   (p < (void *)CONFIG_SRAM_OFFSET));
+
+	return (in_text || in_vecbase);
+}
+
+static inline bool xtensa_dc233c_stack_ptr_is_sane(uint32_t sp)
+{
+	return ((char *)sp >= __text_region_start);
+}
+
+#endif /* ZEPHYR_SOC_XTENSA_DC233C_BACKTRACE_HELPERS_H_ */

--- a/soc/xtensa/dc233c/include/xtensa-dc233c.ld
+++ b/soc/xtensa/dc233c/include/xtensa-dc233c.ld
@@ -322,6 +322,12 @@ SECTIONS
 
     *(.text.arch_is_in_isr)
 
+    /* To support backtracing */
+    *libarch__xtensa__core.a:xtensa_backtrace.c.obj(.literal.*)
+    *libarch__xtensa__core.a:xtensa_backtrace.c.obj(.text.*)
+    *libarch__xtensa__core.a:debug_helpers_asm.S.obj(.iram1.literal)
+    *libarch__xtensa__core.a:debug_helpers_asm.S.obj(.iram1)
+
     *libkernel.a:fatal.c.obj(.literal.*)
     *libkernel.a:fatal.c.obj(.text.*)
 


### PR DESCRIPTION
Adds the necessary bits to enable backtrace support for Xtensa DC233C core.