### PR TITLE
drivers: kconfig: revise the default alignment to 4-bytes

### DIFF
--- a/include/zephyr/sd/sd.h
+++ b/include/zephyr/sd/sd.h
@@ -80,8 +80,14 @@ struct sd_card {
 	uint8_t bus_width; /*!< Desired bus width */
 	uint32_t cccr_flags; /*!< SDIO CCCR data */
 	struct sdio_func func0; /*!< Function 0 common card data */
+
+	/* NOTE: The buffer is accessed as a uint32_t* by the SD subsystem, so must be
+	 * aligned to 4 bytes for platforms that don't support unaligned access...
+	 * Systems where the buffer is accessed by DMA may require wider alignment, in
+	 * which case, use CONFIG_SDHC_BUFFER_ALIGNMENT.
+	 */
 	uint8_t card_buffer[CONFIG_SD_BUFFER_SIZE]
-		__aligned(CONFIG_SDHC_BUFFER_ALIGNMENT); /* Card internal buffer */
+		__aligned(MAX(4, CONFIG_SDHC_BUFFER_ALIGNMENT)); /* Card internal buffer */
 };
 
 /**


### PR DESCRIPTION
Since a85ffa8, the sd_card.card_buffer has been at an unaligned offset, meaning that for systems using the default alignment value of 1, a hard fault will present when executing code that casts the buffer to uint32_t, such as sdmmc_spi_read_cxd(), card_query_written(), and possibly others...

Historically, it appears that the alignment of card_buffer was good and operational only by chance.

See #62619 for further details.