### PR TITLE
cmake: fix wrong indication to look at CMakeError.log

### DIFF
--- a/cmake/modules/kernel.cmake
+++ b/cmake/modules/kernel.cmake
@@ -142,7 +142,9 @@ enable_language(C CXX ASM)
 # Verify that the toolchain can compile a dummy file, if it is not we
 # won't be able to test for compatibility with certain C flags.
 zephyr_check_compiler_flag(C "" toolchain_is_ok)
-assert(toolchain_is_ok "The toolchain is unable to build a dummy C file. See CMakeError.log.")
+assert(toolchain_is_ok "The toolchain is unable to build a dummy C file.\
+ Move ${USER_CACHE_DIR}, re-run and look at \
+ ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/CMakeConfigureLog.yaml")
 
 include(${ZEPHYR_BASE}/cmake/target_toolchain_flags.cmake)
 


### PR DESCRIPTION
There is no CMakeError.log file in this case, with cmake version 3.27 it's CMakeFiles/CMakeConfigureLog.yaml.

To make things harder the failure is cached which means the error message is gone after the first time. So tell the user to delete the cache.

Error handling is generally not tested. To make an exception:

```diff
 # Verify that the toolchain can compile a dummy file, if it is not we
 # won't be able to test for compatibility with certain C flags.
-zephyr_check_compiler_flag(C "" toolchain_is_ok)
+zephyr_check_compiler_flag(C "-fubar" toolchain_is_ok)
 assert(toolchain_is_ok "The toolchain is unable to build a dummy C file.\
```