### PR TITLE
twister: platform filtering when test-only

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -216,11 +216,16 @@ class TestPlan:
             # in cases where no platform was specified when running the tests.
             # If the platform does not exist in the hardware map, just skip it.
             connected_list = []
-            if not self.options.platform:
+            if self.options.platform:
+                connected_list = self.options.platform
+            else:
                 for connected in self.hwm.duts:
                     if connected['connected']:
                         connected_list.append(connected['platform'])
-
+            if self.options.exclude_platform:
+                for excluded in self.options.exclude_platform:
+                    if excluded in connected_list:
+                        connected_list.remove(excluded)
             self.load_from_file(last_run, filter_platform=connected_list)
             self.selected_platforms = set(p.platform.name for p in self.instances.values())
         else:


### PR DESCRIPTION
This PR fixes an issue https://github.com/zephyrproject-rtos/zephyr/issues/62560

- If flags -p and -P are not used twister will use the devices in the testplan.json to figure out what platforms it will run on, **same behavior** as before.
- If flag -P is used it will now exclude that platform from running tests. **Changed behavior**.
- If flag -p is used then only the plaforms defined will have tests run on them. **Changed behavior**.