### PR TITLE
nrf_bsim minors

### DIFF
--- a/boards/posix/nrf52_bsim/Kconfig
+++ b/boards/posix/nrf52_bsim/Kconfig
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_NRF52_BSIM
+if SOC_SERIES_BSIM_NRFXX
 
 # The following file is normally parsed only for the ARM architecture, which is
 # used by Nordic SoCs, so to make the symbols defined in this file available for
-# the simulated nrf52_bsim board, which uses the POSIX architecture, the file
+# the simulated nrf5x_bsim boards, which use the POSIX architecture, the file
 # must be read also from here.
 source "soc/arm/nordic_nrf/Kconfig.peripherals"
 
-endif # BOARD_NRF52_BSIM
+endif # SOC_SERIES_BSIM_NRFXX
 
 
 # This would eventually be shared by a possible family of simulated NRF boards

--- a/boards/posix/nrf52_bsim/common/cmsis/cmsis.h
+++ b/boards/posix/nrf52_bsim/common/cmsis/cmsis.h
@@ -14,7 +14,9 @@
 
 #include <stdint.h>
 #include "cmsis_instr.h"
+#if defined(CONFIG_SOC_COMPATIBLE_NRF52833)
 #include "nrf52833.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Two minor and trivial changes in preparation for the upcoming nrf53_bsim boards.
Sending them as their own PR to avoid a massive PR, and as they are proper changes on their own.

-------

[nrf_bsim: Include peripheral kconfig for all simulated nrf bords](https://github.com/zephyrproject-rtos/zephyr/commit/dd28ebd406481684e18d58dcfe218bf8b34e4ea1)

Include the nrf peripheral kconfig definitions for all simulated
nrf boards, not just for the nrf52_bsim.

---

[boards nrf_bsim: Include nrf52833 header only for nrf52_bsim](https://github.com/zephyrproject-rtos/zephyr/commit/c58bba97ecec42975698359968fba9d89227e965)

Include the nrf52833.h header only for nrf52_bsim