### PR TITLE
modem subsys: added net stats

### DIFF
--- a/include/zephyr/modem/ppp.h
+++ b/include/zephyr/modem/ppp.h
@@ -97,6 +97,10 @@ struct modem_ppp {
 	/* Work */
 	struct k_work send_work;
 	struct k_work process_work;
+
+#if defined(CONFIG_NET_STATISTICS_PPP)
+	struct net_stats_ppp stats;
+#endif
 };
 
 /**

--- a/subsys/modem/modem_ppp.c
+++ b/subsys/modem/modem_ppp.c
@@ -285,6 +285,9 @@ static void modem_ppp_process_received_byte(struct modem_ppp *ppp, uint8_t byte)
 			net_pkt_unref(ppp->rx_pkt);
 			ppp->rx_pkt = NULL;
 			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_SOF;
+#if defined(CONFIG_NET_STATISTICS_PPP)
+			ppp->stats.drop++;
+#endif
 		}
 
 		break;
@@ -295,6 +298,9 @@ static void modem_ppp_process_received_byte(struct modem_ppp *ppp, uint8_t byte)
 			net_pkt_unref(ppp->rx_pkt);
 			ppp->rx_pkt = NULL;
 			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_SOF;
+#if defined(CONFIG_NET_STATISTICS_PPP)
+			ppp->stats.drop++;
+#endif
 			break;
 		}
 
@@ -433,11 +439,23 @@ static int modem_ppp_ppp_api_send(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
+#if defined(CONFIG_NET_STATISTICS_PPP)
+static struct net_stats_ppp *modem_ppp_ppp_get_stats(const struct device *dev)
+{
+	struct modem_ppp *ppp = (struct modem_ppp *)dev->data;
+
+	return &ppp->stats;
+}
+#endif
+
 const struct ppp_api modem_ppp_ppp_api = {
 	.iface_api.init = modem_ppp_ppp_api_init,
 	.start = modem_ppp_ppp_api_start,
 	.stop = modem_ppp_ppp_api_stop,
 	.send = modem_ppp_ppp_api_send,
+#if defined(CONFIG_NET_STATISTICS_PPP)
+	.get_stats = modem_ppp_ppp_get_stats,
+#endif
 };
 
 int modem_ppp_attach(struct modem_ppp *ppp, struct modem_pipe *pipe)

--- a/subsys/net/ip/Kconfig.stats
+++ b/subsys/net/ip/Kconfig.stats
@@ -95,7 +95,7 @@ config NET_STATISTICS_IGMP
 
 config NET_STATISTICS_PPP
 	bool "Point-to-point (PPP) statistics"
-	depends on NET_PPP
+	depends on NET_L2_PPP
 	default y
 	help
 	  Keep track of PPP related statistics


### PR DESCRIPTION
Added `struct net_stats_ppp` handling to modem subsys. Right now statistics for ppp connection are available and can be easily printed via shell.

```
Interface 0x20004060 (PPP) [2]
==============================
IPv4 recv      12	sent	18	drop	0	forwarded	0
IP vhlerr      0	hblener	0	lblener	0
IP fragerr     0	chkerr	0	protoer	0
ICMP recv      12	sent	12	drop	0
ICMP typeer    0	chkerr	0
UDP recv       0	sent	6	drop	0
UDP chkerr     0
TCP bytes recv 0	sent	0	resent	0
TCP seg recv   0	sent	0	drop	0
TCP seg resent 0	chkerr	0	ackerr	0
TCP seg rsterr 0	rst	0
TCP conn drop  0	connrst	0
TCP pkt drop   0
Bytes received 510
Bytes sent     1546
Processing err 0
Frames recv    19
Frames sent    24
Frames dropped 0
Bad FCS        0
```