### PR TITLE
arch: x86: fix build with ACPI disabled

### DIFF
--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -11,7 +11,9 @@
 #include <zephyr/arch/x86/multiboot.h>
 #include <x86_mmu.h>
 #include <zephyr/drivers/interrupt_controller/loapic.h>
+#ifdef CONFIG_ACPI
 #include <zephyr/acpi/acpi.h>
+#endif
 
 BUILD_ASSERT(CONFIG_MP_MAX_NUM_CPUS <= 4, "Only supports max 4 CPUs");
 
@@ -142,14 +144,14 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 	uint8_t vector = ((unsigned long) x86_ap_start) >> 12;
 	uint8_t apic_id;
 
-	if (IS_ENABLED(CONFIG_ACPI)) {
-		struct acpi_madt_local_apic *lapic = acpi_local_apic_get(cpu_num);
+#ifdef CONFIG_ACPI
+	struct acpi_madt_local_apic *lapic = acpi_local_apic_get(cpu_num);
 
-		if (lapic != NULL) {
-			/* We update the apic_id, __start will need it. */
-			x86_cpu_loapics[cpu_num] = lapic->Id;
-		}
+	if (lapic != NULL) {
+		/* We update the apic_id, __start will need it. */
+		x86_cpu_loapics[cpu_num] = lapic->Id;
 	}
+#endif /* CONFIG_ACPI */
 
 	apic_id = x86_cpu_loapics[cpu_num];
 


### PR DESCRIPTION
arch/x86/core/intel64/cpu.c has been changed recently to always include zephyr/acpi/acpi.h, but at the same time the acpica module has also been changed to only expose the headers when enabled, so this file does not build anymore if CONFIG_ACPI=n

Fix this by excluding the ACPI code here entirely when ACPI is not enabled.