### PR TITLE
dts: bindings: reset: ast10x0: revise cells' name

### DIFF
--- a/dts/bindings/reset/aspeed,ast10x0-reset.yaml
+++ b/dts/bindings/reset/aspeed,ast10x0-reset.yaml
@@ -11,5 +11,5 @@ properties:
   "#reset-cells":
     const: 1
 
-clock-cells:
-  - reset_id
+reset-cells:
+  - id


### PR DESCRIPTION
Revise property's name & cells' name for further
devicetree reset macro used.

Fixes: 4224732a5783 ("dts: bindings: reset: add binding for Aspeed AST10x0 reset")