### PR TITLE
boards: esp32: M5Stack Core2 has PCF8563 RTC, not PCF8523

### DIFF
--- a/boards/xtensa/m5stack_core2/m5stack_core2.dts
+++ b/boards/xtensa/m5stack_core2/m5stack_core2.dts
@@ -93,10 +93,9 @@
 	pinctrl-names = "default";
 
 	pfc8563_rtc: pfc8563@51 {
-		compatible = "nxp,pcf8523";
+		compatible = "nxp,pcf8563";
 		reg = <0x51>;
 		status = "okay";
-		battery-switch-over = "disabled";
 	};
 
 	axp192_pmic: axp192@34 {


### PR DESCRIPTION
The RTC chip on i2c0 is a PCF8563, not a PCF8523.

RTC _almost_ works when using the latter, but not quite, hence why it probably was missed before.
Fix tested as working using RTC Shell commands.