### PR TITLE
Fix race conditions in poll and condvar

### DIFF
--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Wind River Systems, Inc.
+ * Copyright (c) 2023 Arm Limited (or its affiliates). All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -470,11 +471,14 @@ static int signal_poll_event(struct k_poll_event *event, uint32_t state)
 void z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state)
 {
 	struct k_poll_event *poll_event;
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	poll_event = (struct k_poll_event *)sys_dlist_get(events);
 	if (poll_event != NULL) {
 		(void) signal_poll_event(poll_event, state);
 	}
+
+	k_spin_unlock(&lock, key);
 }
 
 void z_impl_k_poll_signal_init(struct k_poll_signal *sig)

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017 Linaro Limited
  * Copyright (c) 2021 Nordic Semiconductor
+ * Copyright (c) 2023 Arm Limited (or its affiliates). All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -423,12 +424,12 @@ static void zsock_received_cb(struct net_context *ctx,
 	k_fifo_put(&ctx->recv_q, pkt);
 
 unlock:
+	/* Wake reader if it was sleeping */
+	(void)k_condvar_signal(&ctx->cond.recv);
+
 	if (ctx->cond.lock) {
 		(void)k_mutex_unlock(ctx->cond.lock);
 	}
-
-	/* Wake reader if it was sleeping */
-	(void)k_condvar_signal(&ctx->cond.recv);
 }
 
 int zsock_shutdown_ctx(struct net_context *ctx, int how)


### PR DESCRIPTION
In the poll code, `signal_poll_event` is called by 2 functions: `z_impl_k_poll_signal_raise` and `z_handle_obj_poll_events`. The first one correctly takes the poll lock. Fix the second one not taking the lock.

In the sockets code, fix the mutex of the condition variable getting released before signaling for this same condition variable.

Both of those created race conditions which especially appeared on SMP-enabled configurations. The symptom was similar for both of them: a thread pending, waiting on an event, but never getting scheduled again even though the event happened.