### PR TITLE
interrupt-controller: convert SYS_INIT to DEVICE_DT_INST_DEFINE

### DIFF
--- a/drivers/interrupt_controller/intc_arcv2_irq_unit.c
+++ b/drivers/interrupt_controller/intc_arcv2_irq_unit.c
@@ -19,7 +19,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
-#include <zephyr/init.h>
+#include <zephyr/device.h>
+
+#define DT_DRV_COMPAT snps_arcv2_intc
 
 #ifdef CONFIG_ARC_CONNECT
 static void arc_shared_intc_init(void)
@@ -134,7 +136,7 @@ void arc_core_private_intc_init(void)
 #endif /* CONFIG_ARC_CONNECT */
 }
 
-static int arc_irq_init(void)
+static int arc_irq_init(const struct device *dev)
 {
 #ifdef CONFIG_ARC_CONNECT
 	arc_shared_intc_init();
@@ -149,4 +151,5 @@ static int arc_irq_init(void)
 	return 0;
 }
 
-SYS_INIT(arc_irq_init, PRE_KERNEL_1, 0);
+DEVICE_DT_INST_DEFINE(0, arc_irq_init, NULL,  NULL,  NULL,
+		      PRE_KERNEL_1, 0, NULL);

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/init.h>
+#include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/__assert.h>
@@ -16,6 +16,8 @@
 #include "intc_gicv3_priv.h"
 
 #include <string.h>
+
+#define DT_DRV_COMPAT arm_gic_v3
 
 /* Redistributor base addresses for each core */
 mem_addr_t gic_rdists[CONFIG_MP_MAX_NUM_CPUS];
@@ -596,16 +598,16 @@ static void __arm_gic_init(void)
 	gicv3_cpuif_init();
 }
 
-int arm_gic_init(void)
+int arm_gic_init(const struct device *dev)
 {
-
 	gicv3_dist_init();
 
 	__arm_gic_init();
 
 	return 0;
 }
-SYS_INIT(arm_gic_init, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);
+DEVICE_DT_INST_DEFINE(0, arm_gic_init, NULL, NULL, NULL,
+		      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);
 
 #ifdef CONFIG_SMP
 void arm_gic_secondary_init(void)

--- a/drivers/interrupt_controller/intc_irqmp.c
+++ b/drivers/interrupt_controller/intc_irqmp.c
@@ -17,7 +17,7 @@
 #define DT_DRV_COMPAT gaisler_irqmp
 
 #include <zephyr/kernel.h>
-#include <zephyr/init.h>
+#include <zephyr/device.h>
 
 /*
  * Register description for IRQMP and IRQAMP interrupt controllers
@@ -108,7 +108,7 @@ int z_sparc_int_get_source(int irl)
 	return source;
 }
 
-static int irqmp_init(void)
+static int irqmp_init(const struct device *dev)
 {
 	volatile struct irqmp_regs *regs = get_irqmp_regs();
 
@@ -121,4 +121,5 @@ static int irqmp_init(void)
 	return 0;
 }
 
-SYS_INIT(irqmp_init, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);
+DEVICE_DT_INST_DEFINE(0, irqmp_init, NULL, NULL, NULL,
+		      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -413,10 +413,10 @@ static int loapic_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-PM_DEVICE_DEFINE(loapic, loapic_pm_action);
+PM_DEVICE_DT_INST_DEFINE(0, loapic_pm_action);
 
-DEVICE_DEFINE(loapic, "loapic", loapic_init, PM_DEVICE_GET(loapic), NULL, NULL,
-	      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);
+DEVICE_DT_INST_DEFINE(0, loapic_init, PM_DEVICE_DT_INST_GET(0), NULL, NULL,
+		      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);
 
 #if CONFIG_LOAPIC_SPURIOUS_VECTOR
 extern void z_loapic_spurious_handler(void);

--- a/drivers/interrupt_controller/intc_nuclei_eclic.c
+++ b/drivers/interrupt_controller/intc_nuclei_eclic.c
@@ -11,11 +11,13 @@
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/init.h>
+#include <zephyr/device.h>
 #include <soc.h>
 
 #include <zephyr/sw_isr_table.h>
 #include <zephyr/drivers/interrupt_controller/riscv_clic.h>
+
+#define DT_DRV_COMPAT nuclei_eclic
 
 union CLICCFG {
 	struct {
@@ -159,7 +161,7 @@ void riscv_clic_irq_priority_set(uint32_t irq, uint32_t pri, uint32_t flags)
 	ECLIC_CTRL[irq].INTATTR.b.trg = (uint8_t)(flags & CLIC_INTATTR_TRIG_Msk);
 }
 
-static int nuclei_eclic_init(void)
+static int nuclei_eclic_init(const struct device *dev)
 {
 	/* check hardware support required interrupt levels */
 	__ASSERT_NO_MSG(ECLIC_INFO.b.intctlbits >= INTERRUPT_LEVEL);
@@ -182,4 +184,5 @@ static int nuclei_eclic_init(void)
 	return 0;
 }
 
-SYS_INIT(nuclei_eclic_init, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);
+DEVICE_DT_INST_DEFINE(0, nuclei_eclic_init, NULL, NULL, NULL,
+		      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -14,7 +14,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
-#include <zephyr/init.h>
+#include <zephyr/device.h>
 #include <soc.h>
 
 #include <zephyr/sw_isr_table.h>
@@ -210,7 +210,7 @@ static void plic_irq_handler(const void *arg)
  *
  * @retval 0 on success.
  */
-static int plic_init(void)
+static int plic_init(const struct device *dev)
 {
 
 	volatile uint32_t *en = (volatile uint32_t *)PLIC_IRQ_EN;
@@ -247,4 +247,5 @@ static int plic_init(void)
 	return 0;
 }
 
-SYS_INIT(plic_init, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);
+DEVICE_DT_INST_DEFINE(0, plic_init, NULL, NULL, NULL,
+		      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);

--- a/drivers/interrupt_controller/intc_swerv_pic.c
+++ b/drivers/interrupt_controller/intc_swerv_pic.c
@@ -12,7 +12,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
-#include <zephyr/init.h>
+#include <zephyr/device.h>
 #include <zephyr/sw_isr_table.h>
 #include <zephyr/irq.h>
 
@@ -143,7 +143,7 @@ static void swerv_pic_irq_handler(const void *arg)
 	swerv_pic_write(SWERV_PIC_meigwclr(irq), 0);
 }
 
-static int swerv_pic_init(void)
+static int swerv_pic_init(const struct device *dev)
 {
 	int i;
 
@@ -236,4 +236,5 @@ int arch_irq_is_enabled(unsigned int irq)
 	return !!(mie & (1 << irq));
 }
 
-SYS_INIT(swerv_pic_init, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);
+DEVICE_DT_INST_DEFINE(0, swerv_pic_init, NULL,  NULL,  NULL,
+		      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);

--- a/drivers/interrupt_controller/intc_vexriscv_litex.c
+++ b/drivers/interrupt_controller/intc_vexriscv_litex.c
@@ -4,17 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT litex_eth0
+#define DT_DRV_COMPAT vexriscv_intc0
 
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
-#include <zephyr/init.h>
 #include <zephyr/irq.h>
 #include <zephyr/device.h>
 #include <zephyr/types.h>
 
-#define IRQ_MASK		DT_REG_ADDR_BY_NAME(DT_INST(0, vexriscv_intc0), irq_mask)
-#define IRQ_PENDING		DT_REG_ADDR_BY_NAME(DT_INST(0, vexriscv_intc0), irq_pending)
+#define IRQ_MASK		DT_INST_REG_ADDR_BY_NAME(0, irq_mask)
+#define IRQ_PENDING		DT_INST_REG_ADDR_BY_NAME(0, irq_pending)
 
 #define TIMER0_IRQ		DT_IRQN(DT_INST(0, litex_timer0))
 #define UART0_IRQ		DT_IRQN(DT_INST(0, litex_uart0))
@@ -120,7 +119,7 @@ int arch_irq_is_enabled(unsigned int irq)
 	return vexriscv_litex_irq_getmask() & (1 << irq);
 }
 
-static int vexriscv_litex_irq_init(void)
+static int vexriscv_litex_irq_init(const struct device *dev)
 {
 	__asm__ volatile ("csrrs x0, mie, %0"
 			:: "r"(1 << RISCV_MACHINE_EXT_IRQ));
@@ -131,5 +130,5 @@ static int vexriscv_litex_irq_init(void)
 	return 0;
 }
 
-SYS_INIT(vexriscv_litex_irq_init, PRE_KERNEL_2,
-		CONFIG_INTC_INIT_PRIORITY);
+DEVICE_DT_INST_DEFINE(0, vexriscv_litex_irq_init, NULL, NULL, NULL,
+		      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);


### PR DESCRIPTION
Convert a bunch of drivers from SYS_INIT to DEVICE_DT_INST_DEFINE, this allows the build system to track the device dependencies and ensure that the interrupt controller is initialized before other devices using it.

