### PR TITLE
Documentation hotfixes

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -2391,6 +2391,7 @@ PREDEFINED             = __DOXYGEN__ \
                          NET_MGMT_DEFINE_REQUEST_HANDLER(x)= \
                          DEVICE_DEFINE()= \
                          BUILD_ASSERT()= \
+			 XEN_GUEST_HANDLE_64(x)= \
                          _LINKER \
                          __deprecated= \
                          __packed= \

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -206,7 +206,7 @@ extern "C" {
  * @brief Validate if two entities have a compatible type
  *
  * @param a the first entity to be compared
- * @param a the second entity to be compared
+ * @param b the second entity to be compared
  * @return 1 if the two elements are compatible, 0 if they are not
  */
 #define SAME_TYPE(a, b) __builtin_types_compatible_p(__typeof__(a), __typeof__(b))


### PR DESCRIPTION
Two documentation I think the xen one is breaking the CI doc build right now.

```
WARNING: zephyrproject/zephyr/include/zephyr/xen/public/domctl.h:273: no uniquely matching class member found for
WARNING: zephyrproject/zephyr/include/zephyr/xen/public/domctl.h:326: no uniquely matching class member found for
WARNING: zephyrproject/zephyr/include/zephyr/sys/util.h:208: argument 'a' from the argument list of SAME_TYPE has multiple @param documentation sections
WARNING: zephyrproject/zephyr/include/zephyr/sys/util.h:208: The following parameter of SAME_TYPE(a, b) is not documented:
WARNING: zephyrproject/zephyr/include/zephyr/sys/util.h:208: argument 'a' from the argument list of SAME_TYPE has multiple @param documentation sections
WARNING: zephyrproject/zephyr/include/zephyr/sys/util.h:208: The following parameter of SAME_TYPE(a, b) is not documented:
WARNING: zephyrproject/zephyr/include/zephyr/sys/util.h:208: argument 'a' from the argument list of SAME_TYPE has multiple @param documentation sections
WARNING: zephyrproject/zephyr/include/zephyr/sys/util.h:208: The following parameter of SAME_TYPE(a, b) is not documented:
```