### PR TITLE
doc: known-warnings: remove unused warnings

### DIFF
--- a/doc/known-warnings.txt
+++ b/doc/known-warnings.txt
@@ -22,8 +22,3 @@
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct in_addr.*'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct in6_addr.*'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct net_if.*'.*
-
-# Clash with field of nested anonymous struct
-.*Duplicate C declaration.*\n.*'\.\. c:member:: enum *bt_mesh_dfd_upload_phase bt_mesh_dfd_srv.phase'.*
-.*Duplicate C declaration.*\n.*'\.\. c:member:: struct *bt_mesh_blob_xfer bt_mesh_dfu_cli.blob'.*
-.*Duplicate C declaration.*\n.*'\.\. c:member:: struct *net_if *\* net_if_mcast_monitor.iface'.


### PR DESCRIPTION
As part of the (failed) introduction of docleaf, some new warnings were added to the known list. It turns out that breathe does not care about clashes with field of nested anonymous struct, so let's delete them for now.