### PR TITLE
drivers: spi: stm32: LOG_INF should be LOG_DBG to not clutter console

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -1038,7 +1038,7 @@ static int spi_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	LOG_INF(" SPI with DMA transfer");
+	LOG_DBG("SPI with DMA transfer");
 
 #endif /* CONFIG_SPI_STM32_DMA */
 


### PR DESCRIPTION
Drivers should only log extra information during initialization if debug logging is enabled. Otherwise it always clutters the console when not required.

IMO this log is extraneous though, so might even be better to delete it.