### PR TITLE
Add runtime chat script support for modem_chat module

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -591,7 +591,7 @@ static void modem_cellular_run_init_script_event_handler(struct modem_cellular_d
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_BUS_OPENED:
 		modem_chat_attach(&data->chat, data->uart_pipe);
-		modem_chat_script_run(&data->chat, config->init_chat_script);
+		modem_chat_run_script_async(&data->chat, config->init_chat_script);
 		break;
 
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
@@ -740,7 +740,7 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
 		modem_chat_attach(&data->chat, data->dlci1_pipe);
-		modem_chat_script_run(&data->chat, config->dial_chat_script);
+		modem_chat_run_script_async(&data->chat, config->dial_chat_script);
 		break;
 
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -227,6 +227,8 @@ struct modem_chat {
 	struct k_work script_abort_work;
 	uint16_t script_chat_it;
 	atomic_t script_state;
+	enum modem_chat_script_result script_result;
+	struct k_sem script_stopped_sem;
 
 	/* Script sending */
 	uint16_t script_send_request_pos;
@@ -294,6 +296,18 @@ int modem_chat_init(struct modem_chat *chat, const struct modem_chat_config *con
 int modem_chat_attach(struct modem_chat *chat, struct modem_pipe *pipe);
 
 /**
+ * @brief Run script asynchronously
+ * @param chat Chat instance
+ * @param script Script to run
+ * @returns 0 if script successfully started
+ * @returns -EBUSY if a script is currently running
+ * @returns -EPERM if modem pipe is not attached
+ * @returns -EINVAL if arguments or script is invalid
+ * @note Script runs asynchronously until complete or aborted.
+ */
+int modem_chat_run_script_async(struct modem_chat *chat, const struct modem_chat_script *script);
+
+/**
  * @brief Run script
  * @param chat Chat instance
  * @param script Script to run
@@ -301,9 +315,25 @@ int modem_chat_attach(struct modem_chat *chat, struct modem_pipe *pipe);
  * @returns -EBUSY if a script is currently running
  * @returns -EPERM if modem pipe is not attached
  * @returns -EINVAL if arguments or script is invalid
- * @note Script runs asynchronously until complete or aborted.
+ * @note Script runs until complete or aborted.
  */
-int modem_chat_script_run(struct modem_chat *chat, const struct modem_chat_script *script);
+int modem_chat_run_script(struct modem_chat *chat, const struct modem_chat_script *script);
+
+/**
+ * @brief Run script asynchronously
+ * @note Function exists for backwards compatibility and should be deprecated
+ * @param chat Chat instance
+ * @param script Script to run
+ * @returns 0 if script successfully started
+ * @returns -EBUSY if a script is currently running
+ * @returns -EPERM if modem pipe is not attached
+ * @returns -EINVAL if arguments or script is invalid
+ */
+static inline int modem_chat_script_run(struct modem_chat *chat,
+					const struct modem_chat_script *script)
+{
+	return modem_chat_run_script_async(chat, script);
+}
 
 /**
  * @brief Abort script

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -35,21 +35,19 @@ typedef void (*modem_chat_match_callback)(struct modem_chat *chat, char **argv, 
  * @brief Modem chat match
  */
 struct modem_chat_match {
-	/* Match array */
+	/** Match array */
 	const uint8_t *match;
+	/** Size of match */
 	const uint8_t match_size;
-
-	/* Separators array */
+	/** Separators array */
 	const uint8_t *separators;
+	/** Size of separators array */
 	const uint8_t separators_size;
-
-	/* Set if modem chat instance shall use wildcards when matching */
+	/** Set if modem chat instance shall use wildcards when matching */
 	const uint8_t wildcards : 1;
-
-	/* Set if script shall not continue to next step in case of match */
+	/** Set if script shall not continue to next step in case of match */
 	const uint8_t partial : 1;
-
-	/* Type of modem chat instance */
+	/** Type of modem chat instance */
 	const modem_chat_match_callback callback;
 };
 
@@ -90,9 +88,11 @@ struct modem_chat_match {
  * @brief Modem chat script chat
  */
 struct modem_chat_script_chat {
-	/** Request to send to modem formatted as char string */
-	const char *request;
-	/** Expected responses to request */
+	/** Request to send to modem */
+	const uint8_t *request;
+	/** Size of request */
+	uint8_t request_size;
+	/** Array of expected responses to request */
 	const struct modem_chat_match *const response_matches;
 	/** Number of elements in expected responses */
 	const uint16_t response_matches_size;
@@ -102,19 +102,28 @@ struct modem_chat_script_chat {
 
 #define MODEM_CHAT_SCRIPT_CMD_RESP(_request, _response_match)                                      \
 	{                                                                                          \
-		.request = _request, .response_matches = &_response_match,                         \
-		.response_matches_size = 1, .timeout = 0,                                          \
+		.request = (uint8_t *)(_request),                                                  \
+		.request_size = (uint8_t)(sizeof(_request) - 1),                                   \
+		.response_matches = &_response_match,                                              \
+		.response_matches_size = 1,                                                        \
+		.timeout = 0,                                                                      \
 	}
 
 #define MODEM_CHAT_SCRIPT_CMD_RESP_MULT(_request, _response_matches)                               \
 	{                                                                                          \
-		.request = _request, .response_matches = _response_matches,                        \
-		.response_matches_size = ARRAY_SIZE(_response_matches), .timeout = 0,              \
+		.request = (uint8_t *)(_request),                                                  \
+		.request_size = (uint8_t)(sizeof(_request) - 1),                                   \
+		.response_matches = _response_matches,                                             \
+		.response_matches_size = ARRAY_SIZE(_response_matches),                            \
+		.timeout = 0,                                                                      \
 	}
 
 #define MODEM_CHAT_SCRIPT_CMD_RESP_NONE(_request, _timeout)                                        \
 	{                                                                                          \
-		.request = _request, .response_matches = NULL, .response_matches_size = 0,         \
+		.request = (uint8_t *)(_request),                                                  \
+		.request_size = (uint8_t)(sizeof(_request) - 1),                                   \
+		.response_matches = NULL,                                                          \
+		.response_matches_size = 0,                                                        \
 		.timeout = _timeout,                                                               \
 	}
 

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -38,17 +38,17 @@ struct modem_chat_match {
 	/** Match array */
 	const uint8_t *match;
 	/** Size of match */
-	const uint8_t match_size;
+	uint8_t match_size;
 	/** Separators array */
 	const uint8_t *separators;
 	/** Size of separators array */
-	const uint8_t separators_size;
+	uint8_t separators_size;
 	/** Set if modem chat instance shall use wildcards when matching */
-	const uint8_t wildcards : 1;
+	uint8_t wildcards : 1;
 	/** Set if script shall not continue to next step in case of match */
-	const uint8_t partial : 1;
+	uint8_t partial : 1;
 	/** Type of modem chat instance */
-	const modem_chat_match_callback callback;
+	modem_chat_match_callback callback;
 };
 
 #define MODEM_CHAT_MATCH(_match, _separators, _callback)                                           \
@@ -92,10 +92,10 @@ struct modem_chat_script_chat {
 	const uint8_t *request;
 	/** Size of request */
 	uint8_t request_size;
-	/** Array of expected responses to request */
-	const struct modem_chat_match *const response_matches;
+	/** Expected responses to request */
+	const struct modem_chat_match *response_matches;
 	/** Number of elements in expected responses */
-	const uint16_t response_matches_size;
+	uint16_t response_matches_size;
 	/** Timeout before chat script may continue to next step in milliseconds */
 	uint16_t timeout;
 };
@@ -128,7 +128,7 @@ struct modem_chat_script_chat {
 	}
 
 #define MODEM_CHAT_SCRIPT_CMDS_DEFINE(_sym, ...)                                                   \
-	const static struct modem_chat_script_chat _sym[] = {__VA_ARGS__}
+	const struct modem_chat_script_chat _sym[] = {__VA_ARGS__}
 
 enum modem_chat_script_result {
 	MODEM_CHAT_SCRIPT_RESULT_SUCCESS,
@@ -155,15 +155,15 @@ struct modem_chat_script {
 	/** Array of script chats */
 	const struct modem_chat_script_chat *script_chats;
 	/** Elements in array of script chats */
-	const uint16_t script_chats_size;
+	uint16_t script_chats_size;
 	/** Array of abort matches */
-	const struct modem_chat_match *const abort_matches;
+	const struct modem_chat_match *abort_matches;
 	/** Number of elements in array of abort matches */
-	const uint16_t abort_matches_size;
+	uint16_t abort_matches_size;
 	/** Callback called when script execution terminates */
 	modem_chat_script_callback callback;
 	/** Timeout in seconds within which the script execution must terminate */
-	const uint32_t timeout;
+	uint32_t timeout;
 };
 
 #define MODEM_CHAT_SCRIPT_DEFINE(_sym, _script_chats, _abort_matches, _callback, _timeout)         \

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -194,6 +194,34 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 MODEM_CHAT_SCRIPT_DEFINE(script_partial, script_partial_cmds, abort_matches, on_script_result, 4);
 
 /*************************************************************************************************/
+/*                           Small echo script and mock transactions                             */
+/*************************************************************************************************/
+static const uint8_t at_echo_data[] = {'A', 'T', '\r', '\n'};
+static const struct modem_backend_mock_transaction at_echo_transaction = {
+	.get = at_echo_data,
+	.get_size = sizeof(at_echo_data),
+	.put = at_echo_data,
+	.put_size = sizeof(at_echo_data),
+};
+
+static const uint8_t at_echo_error_data[] = {'E', 'R', 'R', 'O', 'R', ' ', '1', '\r', '\n'};
+static const struct modem_backend_mock_transaction at_echo_error_transaction = {
+	.get = at_echo_data,
+	.get_size = sizeof(at_echo_data),
+	.put = at_echo_error_data,
+	.put_size = sizeof(at_echo_error_data),
+};
+
+MODEM_CHAT_MATCH_DEFINE(at_match, "AT", "", NULL);
+
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(
+	script_echo_cmds,
+	MODEM_CHAT_SCRIPT_CMD_RESP("AT", at_match),
+);
+
+MODEM_CHAT_SCRIPT_DEFINE(script_echo, script_echo_cmds, abort_matches, on_script_result, 4);
+
+/*************************************************************************************************/
 /*                                      Script responses                                         */
 /*************************************************************************************************/
 static const char at_response[] = "AT\r\n";
@@ -517,6 +545,25 @@ ZTEST(modem_chat, test_script_with_partial_matches)
 	/* Assert no data was sent except the request */
 	zassert_equal(modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer)), 0,
 		      "Script sent too many requests");
+}
+
+ZTEST(modem_chat, test_script_run_sync_complete)
+{
+	modem_backend_mock_prime(&mock, &at_echo_transaction);
+	zassert_ok(modem_chat_run_script(&cmd, &script_echo), "Failed to run echo script");
+}
+
+ZTEST(modem_chat, test_script_run_sync_timeout)
+{
+	zassert_equal(modem_chat_run_script(&cmd, &script_echo), -EAGAIN,
+		      "Failed to run echo script");
+}
+
+ZTEST(modem_chat, test_script_run_sync_abort)
+{
+	modem_backend_mock_prime(&mock, &at_echo_error_transaction);
+	zassert_equal(modem_chat_run_script(&cmd, &script_echo), -EAGAIN,
+		      "Echo script should time out and return -EAGAIN");
 }
 
 /*************************************************************************************************/

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -566,6 +566,51 @@ ZTEST(modem_chat, test_script_run_sync_abort)
 		      "Echo script should time out and return -EAGAIN");
 }
 
+ZTEST(modem_chat, test_script_run_dynamic_script_sync)
+{
+	char match[] = "AT";
+	char separators[] = ",";
+	char request[] = "AT";
+	char name[] = "Dynamic";
+
+	struct modem_chat_match stack_response_match = {
+		.match = NULL,
+		.match_size = 0,
+		.separators = NULL,
+		.separators_size = 0,
+		.wildcards = false,
+		.partial = false,
+		.callback = NULL,
+	};
+
+	struct modem_chat_script_chat stack_script_chat = {
+		.request = NULL,
+		.response_matches = &stack_response_match,
+		.response_matches_size = 1,
+		.timeout = 0,
+	};
+
+	struct modem_chat_script stack_script = {
+		.name = name,
+		.script_chats = &stack_script_chat,
+		.script_chats_size = 1,
+		.abort_matches = NULL,
+		.abort_matches_size = 0,
+		.callback = NULL,
+		.timeout = 1,
+	};
+
+	stack_response_match.match = match;
+	stack_response_match.match_size = strlen(match);
+	stack_response_match.separators = separators;
+	stack_response_match.separators_size = strlen(match);
+	stack_script_chat.request = request;
+	stack_script_chat.request_size = strlen(request);
+
+	modem_backend_mock_prime(&mock, &at_echo_transaction);
+	zassert_ok(modem_chat_run_script(&cmd, &stack_script), "Failed to run script");
+}
+
 /*************************************************************************************************/
 /*                                         Test suite                                            */
 /*************************************************************************************************/


### PR DESCRIPTION
### Introduction
This PR makes it possible to construct modem chat scripts and modify them at runtime.

### The problem
Some commands require runtime modification, including the response to said commands.

An example is this one for setting the 1PPS configuration of a GNSS modem:
```
send: "$PAIR752,3,200*DA"
receive: "$PAIR001,752,0*3B"
```
The parameters of the commands will change at runtime, so the chat script
needs to be modifiable at runtime.

### The solution
Create a template script in RAM, that is modified before being run by the modem_chat instance.

```
/* Initialize script */
uint8_t match[32];
uint8_t request[32];

struct modem_chat_match match = {
	.match = match,
	.match_size = 0,
	.separators = NULL,
	.separators_size = 0,
	.wildcards = false,
	.partial = false,
	.callback = NULL,
};

struct modem_chat_script_chat script_chat = {
	.request = request,
	.request_size = 0;
	.response_matches = &match,
	.response_matches_size = 1,
	.timeout = 0,
};

struct modem_chat_script script = {
	.name = "config",
	.script_chats = &script_chat,
	.script_chats_size = 1,
	.abort_matches = NULL,
	.abort_matches_size = 0,
	.callback = NULL,
	.timeout = 1,
};

/* Modify script */
int ret = snprintk(match, sizeof(match), "$PAIR752,%u,%u*DA", 3, 200);
match.match_size = ret;
ret = snprintk(request, sizeof(request), "$PAIR001,%03u,0*3B", 752);
script_chat.request_size = ret;

/* Run script */
modem_chat_run_script(&chat, &stack_script);
```

### Additional features
This PR also adds a function to synchronously run a chat script, and updates the naming scheme of the modem_chat module to clearly distinguish between the sync and async variant of the `modem_chat_run_script()` function, `modem_chat_run_script_async()`.

