### PR TITLE
Bluetooth: Audio: Add parsers for getting metadata values

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -659,11 +659,8 @@ int bt_audio_codec_cfg_get_octets_per_frame(const struct bt_audio_codec_cfg *cod
 int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg *codec_cfg,
 						bool fallback_to_default);
 
-/** @brief Lookup a specific value based on type
- *
- *  Depending on context bt_audio_codec_cfg will be either codec capabilities, codec configuration
- *  or meta data.
- *
+/** @brief Lookup a specific codec configuration value based on type
+ * *
  *  Typically types used are:
  *  @ref bt_audio_codec_capability_type
  *  @ref bt_audio_codec_config_type
@@ -679,6 +676,191 @@ uint8_t bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg, u
 
 /** @} */ /* End of bt_audio_codec_cfg */
 
+/**
+ * @brief Audio codec Config APIs
+ * @defgroup bt_audio_codec_meta Metadata parsing APIs
+ *
+ * Functions to parse LTV formatted metadata.
+ *
+ * @{
+ */
+
+/** @brief Lookup a specific metadata value based on type
+ *
+ *  This works for metadata from both @ref bt_audio_codec_cfg meta and @ref bt_audio_codec_cap meta.
+ * *
+ *  @param[in]  meta     The metadata to search in.
+ *  @param[in]  meta_len The length of @p meta.
+ *  @param[in]  type     The type id to look for
+ *  @param[out] data     Pointer to the data-pointer to update when item is found
+ *
+ *  @retval Length of found @p data (may be 0)
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
+ */
+int bt_audio_codec_meta_get_val(const uint8_t meta[], size_t meta_len, uint8_t type,
+				const uint8_t **data);
+
+/** @brief Extract preferred contexts
+ *
+ *  See @ref BT_AUDIO_METADATA_TYPE_PREF_CONTEXT for more information about this value.
+ *
+ *  @param meta     The metadata to get the data from in.
+ *  @param meta_len The length of @p meta.
+ *
+ *  @retval The preferred context type if positive or 0
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
+ *  @retval -EBADMSG if found value has invalid size
+ */
+int bt_audio_codec_meta_get_pref_context(const uint8_t meta[], size_t meta_len);
+
+/** @brief Extract stream contexts
+ *
+ *  See @ref BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT for more information about this value.
+ *
+ *  @param meta     The metadata to get the data from in.
+ *  @param meta_len The length of @p meta.
+ *
+ *  @retval The stream context type if positive or 0
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
+ *  @retval -EBADMSG if found value has invalid size
+ */
+int bt_audio_codec_meta_get_stream_context(const uint8_t meta[], size_t meta_len);
+
+/** @brief Extract program info
+ *
+ *  See @ref BT_AUDIO_METADATA_TYPE_PROGRAM_INFO for more information about this value.
+ *
+ *  @param[in]  meta         The metadata to get the data from in.
+ *  @param[in]  meta_len     The length of @p meta.
+ *  @param[out] program_info Pointer to the UTF-8 formatted program info.
+ *
+ *  @retval The length of the @p program_info (may be 0)
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
+ */
+int bt_audio_codec_meta_get_program_info(const uint8_t meta[], size_t meta_len,
+					 const uint8_t **program_info);
+
+/** @brief Extract stream language
+ *
+ *  See @ref BT_AUDIO_METADATA_TYPE_STREAM_LANG for more information about this value.
+ *
+ *  @param meta     The metadata to get the data from in.
+ *  @param meta_len The length of @p meta.
+ *
+ *  @retval The stream language if positive or 0
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
+ *  @retval -EBADMSG if found value has invalid size
+ */
+int bt_audio_codec_meta_get_stream_lang(const uint8_t meta[], size_t meta_len);
+
+/** @brief Extract CCID list
+ *
+ *  See @ref BT_AUDIO_METADATA_TYPE_CCID_LIST for more information about this value.
+ *
+ *  @param[in]  meta      The metadata to get the data from in.
+ *  @param[in]  meta_len  The length of @p meta.
+ *  @param[out] ccid_list Pointer to the array containing 8-bit CCIDs.
+ *
+ *  @retval The length of the @p ccid_list (may be 0)
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
+ */
+int bt_audio_codec_meta_get_ccid_list(const uint8_t meta[], size_t meta_len,
+				      const uint8_t **ccid_list);
+
+/** @brief Extract parental rating
+ *
+ *  See @ref BT_AUDIO_METADATA_TYPE_PARENTAL_RATING for more information about this value.
+ *
+ *  @param meta     The metadata to get the data from in.
+ *  @param meta_len The length of @p meta.
+ *
+ *  @retval The parental rating if positive or 0
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
+ *  @retval -EBADMSG if found value has invalid size
+ */
+int bt_audio_codec_meta_get_parental_rating(const uint8_t meta[], size_t meta_len);
+
+/** @brief Extract program info URI
+ *
+ *  See @ref BT_AUDIO_METADATA_TYPE_PROGRAM_INFO_URI for more information about this value.
+ *
+ *  @param[in]  meta             The metadata to get the data from in.
+ *  @param[in]  meta_len         The length of @p meta.
+ *  @param[out] program_info_uri Pointer to the UTF-8 formatted program info URI.
+ *
+ *  @retval The length of the @p ccid_list (may be 0)
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
+ */
+int bt_audio_codec_meta_get_program_info_uri(const uint8_t meta[], size_t meta_len,
+					     const uint8_t **program_info_uri);
+
+/** @brief Extract audio active state
+ *
+ *  See @ref BT_AUDIO_METADATA_TYPE_AUDIO_STATE for more information about this value.
+ *
+ *  @param meta     The metadata to get the data from in.
+ *  @param meta_len The length of @p meta.
+ *
+ *  @retval The preferred context type if positive or 0
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
+ *  @retval -EBADMSG if found value has invalid size
+ */
+int bt_audio_codec_meta_get_audio_active_state(const uint8_t meta[], size_t meta_len);
+
+/** @brief Extract broadcast audio immediate rendering flag
+ *
+ *  See @ref BT_AUDIO_METADATA_TYPE_BROADCAST_IMMEDIATE for more information about this value.
+ *
+ *  @param meta     The metadata to get the data from in.
+ *  @param meta_len The length of @p meta.
+ *
+ *  @retval 0 if the flag was found
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not the flag was not found
+ */
+int bt_audio_codec_meta_get_broadcast_audio_immediate_rendering_flag(const uint8_t meta[],
+								     size_t meta_len);
+
+/** @brief Extract extended metadata
+ *
+ *  See @ref BT_AUDIO_METADATA_TYPE_EXTENDED for more information about this value.
+ *
+ *  @param[in]  meta          The metadata to get the data from in.
+ *  @param[in]  meta_len      The length of @p meta.
+ *  @param[out] extended_meta Pointer to the extended metadata.
+ *
+ *  @retval The length of the @p ccid_list (may be 0)
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
+ */
+int bt_audio_codec_meta_get_extended(const uint8_t meta[], size_t meta_len,
+				     const uint8_t **extended_meta);
+
+/** @brief Extract vendor specific metadata
+ *
+ *  See @ref BT_AUDIO_METADATA_TYPE_VENDOR for more information about this value.
+ *
+ *  @param[in]  meta        The metadata to get the data from in.
+ *  @param[in]  meta_len    The length of @p meta.
+ *  @param[out] vendor_meta Pointer to the vendor specific metadata.
+ *
+ *  @retval The length of the @p ccid_list (may be 0)
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
+ */
+int bt_audio_codec_meta_get_vendor(const uint8_t meta[], size_t meta_len,
+				   const uint8_t **vendor_meta);
+
+/** @} */ /* End of bt_audio_codec_meta */
 #ifdef __cplusplus
 }
 #endif

--- a/tests/bluetooth/audio/codec/src/main.c
+++ b/tests/bluetooth/audio/codec/src/main.c
@@ -9,6 +9,7 @@
 #include <zephyr/fff.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
+#include <zephyr/sys/byteorder.h>
 
 DEFINE_FFF_GLOBALS;
 
@@ -70,4 +71,150 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_frame_blocks_per_sdu)
 
 	ret = bt_audio_codec_cfg_get_frame_blocks_per_sdu(&preset.codec_cfg, true);
 	zassert_equal(ret, 1u, "unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_meta_get_pref_context)
+{
+	const uint8_t metadata[] = {
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PREF_CONTEXT,
+				    BT_BYTES_LIST_LE16(BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED |
+						       BT_AUDIO_CONTEXT_TYPE_MEDIA)),
+	};
+	int ret;
+
+	ret = bt_audio_codec_meta_get_pref_context(metadata, ARRAY_SIZE(metadata));
+	zassert_equal(ret, 0x0005, "unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_meta_get_stream_context)
+{
+	const uint8_t metadata[] = {
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT,
+				    BT_BYTES_LIST_LE16(BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED |
+						       BT_AUDIO_CONTEXT_TYPE_MEDIA)),
+	};
+	int ret;
+
+	ret = bt_audio_codec_meta_get_stream_context(metadata, ARRAY_SIZE(metadata));
+	zassert_equal(ret, 0x0005, "Unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_meta_get_program_info)
+{
+	const uint8_t expected_data[] = {'P', 'r', 'o', 'g', 'r', 'a', 'm', ' ',
+					 'I', 'n', 'f', 'o'};
+	const uint8_t metadata[] = {
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO,
+				    'P', 'r', 'o', 'g', 'r', 'a', 'm', ' ', 'I', 'n', 'f', 'o'),
+	};
+	const uint8_t *program_data;
+	int ret;
+
+	ret = bt_audio_codec_meta_get_program_info(metadata, ARRAY_SIZE(metadata), &program_data);
+	zassert_equal(ret, ARRAY_SIZE(expected_data), "Unexpected return value %d", ret);
+	zassert_mem_equal(expected_data, program_data, ARRAY_SIZE(expected_data));
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_meta_get_stream_lang)
+{
+	const uint32_t expected_data = sys_get_le24((uint8_t[]){'e', 'n', 'g'});
+	const uint8_t metadata[] = {
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_LANG, 'e', 'n', 'g'),
+	};
+	int ret;
+
+	ret = bt_audio_codec_meta_get_stream_lang(metadata, ARRAY_SIZE(metadata));
+	zassert_equal(ret, expected_data, "Unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_meta_get_ccid_list)
+{
+	const uint8_t expected_data[] = {0x05, 0x10, 0x15};
+	const uint8_t metadata[] = {
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_CCID_LIST, 0x05, 0x10, 0x15),
+	};
+	const uint8_t *ccid_list;
+	int ret;
+
+	ret = bt_audio_codec_meta_get_ccid_list(metadata, ARRAY_SIZE(metadata), &ccid_list);
+	zassert_equal(ret, ARRAY_SIZE(expected_data), "Unexpected return value %d", ret);
+	zassert_mem_equal(expected_data, ccid_list, ARRAY_SIZE(expected_data));
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_meta_get_parental_rating)
+{
+	const uint8_t metadata[] = {
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PARENTAL_RATING,
+				    BT_AUDIO_PARENTAL_RATING_AGE_10_OR_ABOVE),
+	};
+	int ret;
+
+	ret = bt_audio_codec_meta_get_parental_rating(metadata, ARRAY_SIZE(metadata));
+	zassert_equal(ret, 0x07, "Unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_meta_get_program_info_uri)
+{
+	const uint8_t expected_data[] = {'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm'};
+	const uint8_t metadata[] = {
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PROGRAM_INFO_URI,
+				    'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm'),
+	};
+	const uint8_t *program_info_uri;
+	int ret;
+
+	ret = bt_audio_codec_meta_get_program_info_uri(metadata, ARRAY_SIZE(metadata),
+						       &program_info_uri);
+	zassert_equal(ret, ARRAY_SIZE(expected_data), "Unexpected return value %d", ret);
+	zassert_mem_equal(expected_data, program_info_uri, ARRAY_SIZE(expected_data));
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_meta_get_audio_active_state)
+{
+	const uint8_t metadata[] = {
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_AUDIO_STATE,
+				    BT_AUDIO_ACTIVE_STATE_ENABLED),
+	};
+	int ret;
+
+	ret = bt_audio_codec_meta_get_audio_active_state(metadata, ARRAY_SIZE(metadata));
+	zassert_equal(ret, 0x01, "Unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_meta_get_broadcast_audio_immediate_rendering_flag)
+{
+	const uint8_t metadata[] = {0x01, BT_AUDIO_METADATA_TYPE_BROADCAST_IMMEDIATE};
+	int ret;
+
+	ret = bt_audio_codec_meta_get_broadcast_audio_immediate_rendering_flag(
+		metadata, ARRAY_SIZE(metadata));
+	zassert_equal(ret, 0, "Unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_meta_get_extended)
+{
+	const uint8_t expected_data[] = {0x00, 0x01, 0x02, 0x03};
+	const uint8_t metadata[] = {
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_EXTENDED, 0x00, 0x01, 0x02, 0x03),
+	};
+	const uint8_t *extended_meta;
+	int ret;
+
+	ret = bt_audio_codec_meta_get_extended(metadata, ARRAY_SIZE(metadata), &extended_meta);
+	zassert_equal(ret, ARRAY_SIZE(expected_data), "Unexpected return value %d", ret);
+	zassert_mem_equal(expected_data, extended_meta, ARRAY_SIZE(expected_data));
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_meta_get_vendor)
+{
+	const uint8_t expected_data[] = {0x00, 0x01, 0x02, 0x03};
+	const uint8_t metadata[] = {
+		BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_VENDOR, 0x00, 0x01, 0x02, 0x03),
+	};
+	const uint8_t *vendor_meta;
+	int ret;
+
+	ret = bt_audio_codec_meta_get_vendor(metadata, ARRAY_SIZE(metadata), &vendor_meta);
+	zassert_equal(ret, ARRAY_SIZE(expected_data), "Unexpected return value %d", ret);
+	zassert_mem_equal(expected_data, vendor_meta, ARRAY_SIZE(expected_data));
 }


### PR DESCRIPTION
Add parsers to retrieve metadata values from codec capabilities and codec configuration structs.