### PR TITLE
twister: Allow an empty quarantine file

### DIFF
--- a/scripts/pylib/twister/scl.py
+++ b/scripts/pylib/twister/scl.py
@@ -21,6 +21,11 @@ except ImportError:
 
 log = logging.getLogger("scl")
 
+
+class EmptyYamlFileException(Exception):
+    pass
+
+
 #
 #
 def yaml_load(filename):
@@ -78,5 +83,7 @@ def yaml_load_verify(filename, schema):
     """
     # 'document.yaml' contains a single YAML document.
     y = yaml_load(filename)
+    if not y:
+        raise EmptyYamlFileException('No data in YAML file: %s' % filename)
     _yaml_validate(y, schema)
     return y

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -194,8 +194,11 @@ class TestPlan:
             raise TwisterRuntimeError("No quarantine list given to be verified")
         if ql:
             for quarantine_file in ql:
-                # validate quarantine yaml file against the provided schema
-                scl.yaml_load_verify(quarantine_file, self.quarantine_schema)
+                try:
+                    # validate quarantine yaml file against the provided schema
+                    scl.yaml_load_verify(quarantine_file, self.quarantine_schema)
+                except scl.EmptyYamlFileException:
+                    logger.debug(f'Quarantine file {quarantine_file} is empty')
             self.quarantine = Quarantine(ql)
 
     def load(self):
@@ -449,7 +452,7 @@ class TestPlan:
                     # if there is already an existed <board>_<revision>.yaml, then use it to
                     # load platform directly, otherwise, iterate the directory to
                     # get all valid board revision based on each <board>_<revision>.conf.
-                    if not "@" in platform.name:
+                    if '@' not in platform.name:
                         tmp_dir = os.listdir(os.path.dirname(file))
                         for item in tmp_dir:
                             # Need to make sure the revision matches

--- a/scripts/tests/twister/test_scl.py
+++ b/scripts/tests/twister/test_scl.py
@@ -247,3 +247,10 @@ def test_yaml_validate(schema_exists, validate, expected_error):
         core_mock.assert_called_once()
     else:
         core_mock.assert_not_called()
+
+
+def test_yaml_load_empty_file(tmp_path):
+    quarantine_file = tmp_path / 'empty_quarantine.yml'
+    quarantine_file.write_text("# yaml file without data")
+    with pytest.raises(scl.EmptyYamlFileException):
+        scl.yaml_load_verify(quarantine_file, None)


### PR DESCRIPTION
When trying to load an empty quarantine file, we receive an error:
`<CoreError: error code 3: No source file/data was loaded: Path: '/'>`
This error is from `pykwalify` module, used to validate yaml data against the provided schema.

In the Downstream CI we use quarantine files, that sometimes can be empty (when there is no issues).
For that case we use an extra entry in the quarantine file:
```
# To have an empty list use:
- scenarios:
   - None
```
but it is a workaround, so better to provide a solution here, to avoid errors

The solution:
Added an exception to `scl.py` module, to not process an empty yaml file. New exception is handled when processing quarantine files.
