### PR TITLE
twister: Change skips to errors on platforms from platform_allow

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -40,7 +40,7 @@ if sys.platform == 'linux':
 
 from twisterlib.log_helper import log_command
 from twisterlib.testinstance import TestInstance
-from twisterlib.testplan import change_skip_to_error_if_integration
+from twisterlib.testplan import change_skip_to_error_on_integration_and_allow_platforms
 from twisterlib.harness import HarnessImporter, Pytest
 
 logger = logging.getLogger('twister')
@@ -298,11 +298,11 @@ class CMake:
                     logger.debug("Test skipped due to {} Overflow".format(overflow_found[0]))
                     self.instance.status = "skipped"
                     self.instance.reason = "{} overflow".format(overflow_found[0])
-                    change_skip_to_error_if_integration(self.options, self.instance)
+                    change_skip_to_error_on_integration_and_allow_platforms(self.options, self.instance)
                 elif imgtool_overflow_found and not self.options.overflow_as_errors:
                     self.instance.status = "skipped"
                     self.instance.reason = "imgtool overflow"
-                    change_skip_to_error_if_integration(self.options, self.instance)
+                    change_skip_to_error_on_integration_and_allow_platforms(self.options, self.instance)
                 else:
                     self.instance.status = "error"
                     self.instance.reason = "Build failure"

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -939,7 +939,7 @@ class TestPlan:
 
         filtered_instances = list(filter(lambda item:  item.status == "filtered", self.instances.values()))
         for filtered_instance in filtered_instances:
-            change_skip_to_error_if_integration(self.options, filtered_instance)
+            change_skip_to_error_on_integration_and_allow_platforms(self.options, filtered_instance)
 
             filtered_instance.add_missing_case_status(filtered_instance.status)
 
@@ -1015,9 +1015,10 @@ class TestPlan:
         self.link_dir_counter += 1
 
 
-def change_skip_to_error_if_integration(options, instance):
-    ''' If integration mode is on all skips on integration_platforms are treated as errors.'''
-    if options.integration and instance.platform.name in instance.testsuite.integration_platforms \
+def change_skip_to_error_on_integration_and_allow_platforms(options, instance):
+    ''' All skips on platforms from integration_platforms and platform_allow are treated as errors.'''
+    if (instance.platform.name in instance.testsuite.integration_platforms \
+        or instance.platform.name in instance.testsuite.platform_allow) \
         and "quarantine" not in instance.reason.lower():
         # Do not treat this as error if filter type is command line
         filters = {t['type'] for t in instance.filters}

--- a/west.yml
+++ b/west.yml
@@ -14,6 +14,7 @@
 # new Zephyr installation. See the west documentation for more
 # information.
 
+
 manifest:
   defaults:
     remote: upstream


### PR DESCRIPTION
If a test defines platform_allow in its yaml there is an assumption
that those platforms are supported and a build should pass. This
commit enforces this assumption by turning skips to errors when
happening on platforms from platform_allow. This is the same mechanism
as for platforms from integration_platforms.