### PR TITLE
tests interrupt_offload: Set a proper interrupt for POSIX arch targets

### DIFF
--- a/tests/kernel/interrupt/src/interrupt_offload.c
+++ b/tests/kernel/interrupt/src/interrupt_offload.c
@@ -7,6 +7,9 @@
 #include <zephyr/ztest.h>
 #include <zephyr/irq_offload.h>
 #include <zephyr/interrupt_util.h>
+#if defined(CONFIG_ARCH_POSIX)
+#include <soc.h>
+#endif
 
 #define STACK_SIZE	1024
 #define NUM_WORK	4
@@ -89,7 +92,11 @@ void isr_handler(const void *param)
 #define TEST_IRQ_DYN_LINE 26
 
 #elif defined(CONFIG_ARCH_POSIX)
-#define TEST_IRQ_DYN_LINE 5
+#if defined(OFFLOAD_SW_IRQ)
+#define TEST_IRQ_DYN_LINE OFFLOAD_SW_IRQ
+#else
+#define TEST_IRQ_DYN_LINE 0
+#endif
 
 #else
 #define TEST_IRQ_DYN_LINE 0


### PR DESCRIPTION
The test assumed that interrupt line 5 was up for grabs, but it is not in general. (For ex., on an nrf53_bsim this is the clock interrupt, which cannot be hijacked).

Instead, for boards that define it, let's use the int line used for offloading SW interrupts (which is defined for all posix arch boards in tree)
And if this is not defined, let's skip that part of the test.