### PR TITLE
samples zbus benchmark: Fix twister filter

### DIFF
--- a/samples/subsys/zbus/benchmark/sample.yaml
+++ b/samples/subsys/zbus/benchmark/sample.yaml
@@ -4,7 +4,7 @@ tests:
   sample.zbus.benchmark_async:
     tags: zbus
     min_ram: 16
-    filter: CONFIG_SYS_CLOCK_EXISTS
+    filter: CONFIG_SYS_CLOCK_EXISTS and not (CONFIG_ARCH_POSIX and not CONFIG_BOARD_NATIVE_POSIX)
     harness: console
     harness_config:
       type: multi_line
@@ -21,13 +21,12 @@ tests:
       - CONFIG_BM_ASYNC=y
       - arch:nios2:CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
       - CONFIG_IDLE_STACK_SIZE=1024
-    platform_exclude: nrf52_bsim
     integration_platforms:
       - qemu_x86
   sample.zbus.benchmark_sync:
     tags: zbus
     min_ram: 16
-    filter: CONFIG_SYS_CLOCK_EXISTS
+    filter: CONFIG_SYS_CLOCK_EXISTS and not (CONFIG_ARCH_POSIX and not CONFIG_BOARD_NATIVE_POSIX)
     harness: console
     harness_config:
       type: multi_line
@@ -44,6 +43,5 @@ tests:
       - CONFIG_BM_ASYNC=n
       - arch:nios2:CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
       - CONFIG_IDLE_STACK_SIZE=1024
-    platform_exclude: nrf52_bsim
     integration_platforms:
       - qemu_x86


### PR DESCRIPTION
For the posix arch, this sample only works for native_posix, all others will get a build error:

https://github.com/zephyrproject-rtos/zephyr/blob/main/samples/subsys/zbus/benchmark/src/benchmark.c#L20 

So let's filter them.