### PR TITLE
Minor cleanup to kernel.h

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -440,7 +440,7 @@ __syscall int k_thread_stack_space_get(const struct k_thread *thread,
 /**
  * @brief Assign the system heap as a thread's resource pool
  *
- * Similar to z_thread_heap_assign(), but the thread will use
+ * Similar to k_thread_heap_assign(), but the thread will use
  * the kernel heap to draw memory.
  *
  * Use with caution, as a malicious thread could perform DoS attacks on the

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5817,6 +5817,7 @@ static inline void k_cpu_atomic_idle(unsigned int key)
  */
 
 /**
+ * @cond INTERNAL_HIDDEN
  * @internal
  */
 #ifdef ARCH_EXCEPT
@@ -5843,6 +5844,9 @@ static inline void k_cpu_atomic_idle(unsigned int key)
 	} while (false)
 
 #endif /* _ARCH__EXCEPT */
+/**
+ * INTERNAL_HIDDEN @endcond
+ */
 
 /**
  * @brief Fatally terminate a thread
@@ -5866,6 +5870,10 @@ static inline void k_cpu_atomic_idle(unsigned int key)
  * will be called will reason code K_ERR_KERNEL_PANIC.
  */
 #define k_panic()	z_except_reason(K_ERR_KERNEL_PANIC)
+
+/**
+ * @cond INTERNAL_HIDDEN
+ */
 
 /*
  * private APIs that are utilized by one or more public APIs
@@ -5904,6 +5912,9 @@ void z_smp_thread_swap(void);
  * @internal
  */
 extern void z_timer_expiration_handler(struct _timeout *t);
+/**
+ * INTERNAL_HIDDEN @endcond
+ */
 
 #ifdef CONFIG_PRINTK
 /**

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5770,11 +5770,6 @@ __syscall void k_poll_signal_check(struct k_poll_signal *sig,
 
 __syscall int k_poll_signal_raise(struct k_poll_signal *sig, int result);
 
-/**
- * @internal
- */
-extern void z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state);
-
 /** @} */
 
 /**

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1822,10 +1822,6 @@ static inline uint64_t k_cycle_get_64(void)
  * @}
  */
 
-/**
- * @cond INTERNAL_HIDDEN
- */
-
 struct k_queue {
 	sys_sflist_t data_q;
 	struct k_spinlock lock;
@@ -1835,6 +1831,10 @@ struct k_queue {
 
 	SYS_PORT_TRACING_TRACKING_FIELD(k_queue)
 };
+
+/**
+ * @cond INTERNAL_HIDDEN
+ */
 
 #define Z_QUEUE_INITIALIZER(obj) \
 	{ \

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1844,8 +1844,6 @@ struct k_queue {
 	_POLL_EVENT_OBJ_INIT(obj)		\
 	}
 
-extern void *z_queue_node_peek(sys_sfnode_t *node, bool needs_free);
-
 /**
  * INTERNAL_HIDDEN @endcond
  */

--- a/include/zephyr/kernel_includes.h
+++ b/include/zephyr/kernel_includes.h
@@ -13,6 +13,10 @@
 #ifndef ZEPHYR_INCLUDE_KERNEL_INCLUDES_H_
 #define ZEPHYR_INCLUDE_KERNEL_INCLUDES_H_
 
+#ifndef ZEPHYR_INCLUDE_KERNEL_H_
+#error  Please do not include kernel-specific headers directly, use <zephyr/kernel.h> instead
+#endif
+
 #include <stddef.h>
 #include <zephyr/types.h>
 #include <limits.h>

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -227,6 +227,9 @@ void z_mem_manage_init(void);
  */
 void z_mem_manage_boot_finish(void);
 
+
+void z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state);
+
 #ifdef CONFIG_PM
 
 /* When the kernel is about to go idle, it calls this function to notify the

--- a/tests/kernel/mem_protect/mem_protect/src/inherit.c
+++ b/tests/kernel/mem_protect/mem_protect/src/inherit.c
@@ -169,7 +169,7 @@ void parent_handler(void *p1, void *p2, void *p3)
  *
  * @ingroup kernel_memprotect_tests
  *
- * @see z_thread_heap_assign()
+ * @see k_thread_heap_assign()
  */
 ZTEST(mem_protect, test_inherit_resource_pool)
 {

--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -294,7 +294,7 @@ static void tqueue_alloc(struct k_queue *pqueue)
  * @brief Test queue alloc append and prepend
  * @ingroup kernel_queue_tests
  * @see k_queue_alloc_append(), k_queue_alloc_prepend(),
- * z_thread_heap_assign(), k_queue_is_empty(),
+ * k_thread_heap_assign(), k_queue_is_empty(),
  * k_queue_get(), k_queue_remove()
  */
 ZTEST(queue_api, test_queue_alloc)


### PR DESCRIPTION
- kernel: remove reference to non existing z_thread_heap_assign
- kernel: kernel_includes.h: double guard header
- kernel: k_queue struct should not be hidden
- kernel: z_handle_obj_poll_events is internal not kernel.h material
- kernel: header: remove unused z_queue_node_peek from kernel.h
- kernel: doc: mark sections as internal in kernel.h
