### PR TITLE
cmake: warn the user that the toolchain cache hides errors

### DIFF
--- a/cmake/modules/kernel.cmake
+++ b/cmake/modules/kernel.cmake
@@ -142,7 +142,8 @@ enable_language(C CXX ASM)
 # Verify that the toolchain can compile a dummy file, if it is not we
 # won't be able to test for compatibility with certain C flags.
 zephyr_check_compiler_flag(C "" toolchain_is_ok)
-assert(toolchain_is_ok "The toolchain is unable to build a dummy C file. See CMakeError.log.")
+assert(toolchain_is_ok "The toolchain is unable to build a dummy C file.\
+ Move ${USER_CACHE_DIR}, re-run and look at CMakeError.log")
 
 include(${ZEPHYR_BASE}/cmake/target_toolchain_flags.cmake)
 


### PR DESCRIPTION
When `toolchain_is_ok` fails, the error message points the user at the CMake logs. But those logs will be empty if the user tried to compile more than once (typically: cleans everything and tries again). So tell the user that cleaning the toolchain cache is required to see the error.

Tell the user to "move" the cache instead of removing it in case technical support needs the cache for forensics.

Some finicky toolchains can be "non-deterministic" and fail _sometimes_. For instance a license server can be flaky, or the toolchain can require an "elaborate" set of environment variables triggering some configuration "trial-and-error". In such a non-deterministic case deleting the cache is enough to get rid of the issue and move on! Looking at logs is not even required; even better. Once the toolchain cache believes that the toolchain works, any future toolchain glitch will be obvious at actual compilation time.

To test all this:
```diff
 # Verify that the toolchain can compile a dummy file, if it is not we
 # won't be able to test for compatibility with certain C flags.
-zephyr_check_compiler_flag(C "" toolchain_is_ok)
+zephyr_check_compiler_flag(C "-fubar" toolchain_is_ok)
 assert(toolchain_is_ok "The toolchain is unable to build a dummy C file.\
```