### PR TITLE
xen: add Kconfig option for Zephyr on Dom0less setups

### DIFF
--- a/arch/arm64/core/xen/Kconfig
+++ b/arch/arm64/core/xen/Kconfig
@@ -18,3 +18,10 @@ config XEN_DOM0
 	depends on XEN
 	help
 	  Built binary will be used as Xen privileged domain (Domain 0).
+
+config XEN_DOM0LESS
+	bool "Zephyr for Xen Dom0less setup"
+	depends on XEN && !XEN_DOM0
+	help
+	  Configures Zephyr as DomU, that can be started on Dom0less
+	  setup.

--- a/drivers/serial/Kconfig.xen
+++ b/drivers/serial/Kconfig.xen
@@ -10,19 +10,22 @@ config UART_XEN_HVC
 	depends on DT_HAS_XEN_HVC_UART_ENABLED
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
-	depends on XEN && !XEN_DOM0
+	depends on XEN && !XEN_DOM0 && !XEN_DOM0LESS
 	help
 	  Enable Xen ring buffer based hypervisor console driver. Used
 	  for Zephyr as unprivileged domain.
 
 config UART_XEN_HVC_CONSOLEIO
-	bool "Xen hypervisor Dom0 console UART driver"
+	bool "Xen hypervisor consoleio UART driver"
 	select SERIAL_HAS_DRIVER
-	depends on XEN_DOM0
+	depends on XEN_DOM0 || XEN_DOM0LESS
 	default y
 	help
 	  Enable Xen hypervisor console driver. Used for Zephyr as
-	  privileged domain (Dom0).
+	  privileged domain (Dom0) or for Zephyr DomU in Dom0less
+	  configuration. Dom0less configuration does not have
+	  privileged domain. Thus, there is no console daemon and Xen
+	  manages all domain outputs through the consoleio interface.
 
 config XEN_HVC_INIT_PRIORITY
 	int "Xen hypervisor console init priority"


### PR DESCRIPTION
Dom0less is Xen mode without privileged domain. All guests are created according to hypervisor device tree configuration on boot. Thus, there is no Dom0 with console daemon, that usually manages console output from domains.

Zephyr OS contains 2 serial drivers related to Xen hypervisor: regular with console shared page and consoleio-based. The first one is for setups with console daemon and usually was used for Zephyr DomU guests. The second one previously was used only for Zephyr Dom0 and had corresponding Kconfig options. But consoleio is also used as interface for DomU output on Dom0less setups and should be configurable without XEN_DOM0 option.

Add corresponding XEN_DOM0LESS config to Xen Kconfig files and proper dependencies in serial drivers.