### PR TITLE
posix: pthread: do not assert in pthread_exit() on k_thread

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -601,7 +601,6 @@ void pthread_exit(void *retval)
 	self = to_posix_thread(pthread_self());
 	if (self == NULL) {
 		/* not a valid posix_thread */
-		__ASSERT_NO_MSG(self != NULL);
 		k_thread_abort(k_current_get());
 	}
 


### PR DESCRIPTION
If `pthread_exit()` is called from a `k_thread`, then we currently trigger an assertion. It is a reasonable expectation to have the calling thread exit or abort when calling `pthread_exit()`, so lets do just that, which mirrors the original behaviour.

Detected when the C++ threads PR was rebased, as POSIX is acting as a compatibility layer.

Fixes #62732