### PR TITLE
drivers: sensor: tmp116: Added ability to read configuration register

### DIFF
--- a/drivers/sensor/tmp116/tmp116.c
+++ b/drivers/sensor/tmp116/tmp116.c
@@ -257,8 +257,36 @@ static int tmp116_attr_set(const struct device *dev,
 	}
 }
 
+static int tmp116_attr_get(const struct device *dev, enum sensor_channel chan,
+			   enum sensor_attribute attr, struct sensor_value *val)
+{
+	uint16_t data;
+	int rc;
+
+	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
+		return -ENOTSUP;
+	}
+
+	switch (attr) {
+	case SENSOR_ATTR_CONFIGURATION:
+		rc = tmp116_reg_read(dev, TMP116_REG_CFGR, &data);
+		if (rc < 0) {
+			return rc;
+		}
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	val->val1 = data;
+	val->val2 = 0;
+
+	return 0;
+}
+
 static const struct sensor_driver_api tmp116_driver_api = {
 	.attr_set = tmp116_attr_set,
+	.attr_get = tmp116_attr_get,
 	.sample_fetch = tmp116_sample_fetch,
 	.channel_get = tmp116_channel_get
 };


### PR DESCRIPTION
Added ability to read contents of TMP116 configuration register by adding an attribute get function that supports the SENSOR_ATTR_CONFIGURATION option. Followed the same approach as the TMP108 driver. Interpretation of the returned value is left up to the caller.

Tested using Nucleo-F401RE and Temp-Log 2 (TMP116) click board and confirmed a read of the configuration register returned the expected value.