### PR TITLE
net: l2: wifi_mgmt: remove scan kconfig defaults

### DIFF
--- a/subsys/net/l2/wifi/Kconfig
+++ b/subsys/net/l2/wifi/Kconfig
@@ -39,40 +39,6 @@ config WIFI_MGMT_TWT_CHECK_IP
 	  even when it is awake intervals. Rejecting TWT setup till Wi-Fi
 	  interface has a valid IP address might be desirable in most scenarios.
 
-config WIFI_MGMT_FORCED_PASSIVE_SCAN
-	bool "Force Passive scan"
-	help
-	  Force passive scan (typically used to reduce power consumption),
-	  the scan type is always sent as passive.
-	  This doesn't guarantee that passive scan will be used, it depends
-	  on the underlying chip implementation to support and honour scan type.
-
-config WIFI_MGMT_SCAN_BANDS
-	string "Frequency bands to scan"
-	default ""
-	help
-	  Specifies the frequency bands to scan, as follows:
-	  2 - 2.4 GHz
-	  5 - 5 GHz
-	  6 - 6 GHz
-	  "" - All bands allowed by the regulatory domain.
-	  Multiple bands can be specified as comma separated band values.
-	  Only regulatory domain permitted values are allowed.
-
-config WIFI_MGMT_SCAN_DWELL_TIME_ACTIVE
-	int "Active scan dwell time"
-	default 50
-	range 5 1000
-	help
-	  Active scan dwell time (in ms) per channel.
-
-config WIFI_MGMT_SCAN_DWELL_TIME_PASSIVE
-	int "Passive scan dwell time"
-	default 130
-	range 10 1000
-	help
-	  Passive scan dwell time (in ms) per channel.
-
 config WIFI_MGMT_SCAN_SSID_FILT_MAX
 	int "Maximum number of SSIDs that can be specified for SSID filtering"
 	default 1
@@ -80,39 +46,6 @@ config WIFI_MGMT_SCAN_SSID_FILT_MAX
 	help
 	  Maximum number of SSIDs that can be specified for SSID filtering.
 	  This can be set based on the underlying chipsets limitations.
-
-config WIFI_MGMT_SCAN_SSID_FILT
-	string "Scan for specific SSIDs"
-	default ""
-	help
-	  String of comma separated SSID values to scan for. The number of SSID’s
-	  that can be specified depends on WIFI_MGMT_SCAN_MAX_SSIDS.
-	  Use "" to disable SSID filtering.
-
-config WIFI_MGMT_SCAN_MAX_BSS_CNT
-	int "Maximum number of scan results to return."
-	default 0
-	range 0 65535
-	help
-	  Maximum number of scan results to return. 0 represents unlimited number of BSSes.
-
-config WIFI_MGMT_SCAN_CHAN
-	string "Scan on specific channels"
-	default ""
-	help
-	 Formatted string which specifies channels to be scanned. The channel string has to be formatted
-	 using the colon (:), comma(,), hyphen (-) and space ( ) delimiters as follows:
-	 - A colon identifies the value preceding it as a band. A band value
-	   (2: 2.4 GHz, 5: 5 GHz 6: 6 GHz) has to precede the channels in that band (e.g. 2: etc)
-	 - Hyphens are used to identify channel ranges (e.g. 2-7, 32-48 etc)
-	 - Commas are used to separate channel values within a band. Channels can be specified
-	   as individual values (2,6,48 etc) or channel ranges using hyphens (1-14, 32-48 etc)
-	 - Spaces are used to specify multiple band-channel sets (e.g. 2:1,2 5:36,40 etc)
-	 - No spaces should be used anywhere else, i.e. before/after commas,
-	   before/after hyphens.
-	   An example channel specification specifying channels in the 2.4 GHz and 5 GHz bands is
-	   as below:
-	   2:1,5,7,9-11_5:36-48,100,163-167
 
 config WIFI_NM
 	bool "Wi-Fi Network manager support"

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -13,7 +13,6 @@ LOG_MODULE_REGISTER(net_wifi_mgmt, CONFIG_NET_L2_WIFI_MGMT_LOG_LEVEL);
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/wifi_mgmt.h>
-#include <zephyr/net/wifi_utils.h>
 #ifdef CONFIG_WIFI_NM
 #include <zephyr/net/wifi_nm.h>
 #endif /* CONFIG_WIFI_NM */
@@ -104,63 +103,9 @@ static int wifi_scan(uint32_t mgmt_request, struct net_if *iface,
 	const struct device *dev = net_if_get_device(iface);
 	struct wifi_scan_params *params = data;
 	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_api(iface);
-	bool chan_specified = false;
-	uint8_t i = 0;
 
 	if (wifi_mgmt_api == NULL || wifi_mgmt_api->scan == NULL) {
 		return -ENOTSUP;
-	}
-
-	if (data && (len == sizeof(*params))) {
-#ifdef CONFIG_WIFI_MGMT_FORCED_PASSIVE_SCAN
-		params->scan_type = WIFI_SCAN_TYPE_PASSIVE;
-#endif /* CONFIG_WIFI_MGMT_FORCED_PASSIVE_SCAN */
-
-		if (!params->bands) {
-			if (wifi_utils_parse_scan_bands(CONFIG_WIFI_MGMT_SCAN_BANDS,
-							&params->bands)) {
-				NET_ERR("Incorrect value(s) in CONFIG_WIFI_MGMT_SCAN_BANDS: %s",
-						CONFIG_WIFI_MGMT_SCAN_BANDS);
-				return -EINVAL;
-			}
-		}
-
-		if (!params->dwell_time_active) {
-			params->dwell_time_active = CONFIG_WIFI_MGMT_SCAN_DWELL_TIME_ACTIVE;
-		}
-
-		if (!params->dwell_time_passive) {
-			params->dwell_time_passive = CONFIG_WIFI_MGMT_SCAN_DWELL_TIME_PASSIVE;
-		}
-
-		if (!strlen(params->ssids[0])) {
-			if (wifi_utils_parse_scan_ssids(CONFIG_WIFI_MGMT_SCAN_SSID_FILT,
-							params->ssids)) {
-				NET_ERR("Incorrect value(s) in CONFIG_WIFI_MGMT_SCAN_SSID_FILT: %s",
-						CONFIG_WIFI_MGMT_SCAN_SSID_FILT);
-				return -EINVAL;
-			}
-		}
-
-		if (!params->max_bss_cnt) {
-			params->max_bss_cnt = CONFIG_WIFI_MGMT_SCAN_MAX_BSS_CNT;
-		}
-
-		for (i = 0; i <= WIFI_FREQ_BAND_MAX; i++) {
-			if (params->chan[i][0]) {
-				chan_specified = true;
-				break;
-			}
-		}
-
-		if ((!chan_specified) && strlen(CONFIG_WIFI_MGMT_SCAN_CHAN))  {
-			if (wifi_utils_parse_scan_chan(CONFIG_WIFI_MGMT_SCAN_CHAN,
-						       params->chan)) {
-				NET_ERR("Incorrect value(s) in CONFIG_WIFI_MGMT_SCAN_CHAN: %s",
-					CONFIG_WIFI_MGMT_SCAN_CHAN);
-				return -EINVAL;
-			}
-		}
 	}
 
 	return wifi_mgmt_api->scan(dev, params, scan_result_cb);


### PR DESCRIPTION
Remove the wifi_mgmt interface overriding default values with values from kconfig.

These defaults were only applied when a `params` struct was provided by the application. This is the case when the application is explicitly setting the options it wants, why is the mgmt API changing these. When `params` is NULL and thus modem defaults are requested, these defaults aren't applied. This is the opposite behaviour from what seems reasonable.

In addition, these options are:
 * Undocumented
 * Using non-trivial string parsing functions (strtok)
 * Adding complexity to the API implementation by forcing support for ROM versions of command line arguments.

**Additional comments outside the commit message**

This overriding was started in #59204 and continued in #60686.
Neither PR justified overriding the application request from what I can see.
None of the reviews questioned why it was being added at all as far as I can see.

From my perspective, I see no reason why the management layer ever needs to mess with the scan request. The application is asking for it, if it wants to provide some defaults, do that in the request, not in some kconfig option (which is only applied some of the time).

Apart from being incorrect in my opinion, supporting these defaults is also making cleaning up the massive RAM usage of the new struct problematic because the "defaults" being applied to `struct wifi_params` needs to be created from ROM strings.