### PR TITLE
modules: lvgl: retain last event for button/pointer device

### DIFF
--- a/modules/lvgl/include/lvgl_common_input.h
+++ b/modules/lvgl/include/lvgl_common_input.h
@@ -23,6 +23,7 @@ struct lvgl_common_input_data {
 	lv_indev_drv_t indev_drv;
 	lv_indev_t *indev;
 	lv_indev_data_t pending_event;
+	lv_indev_data_t previous_event;
 };
 
 int lvgl_input_register_driver(lv_indev_type_t indev_type, const struct device *dev);

--- a/modules/lvgl/input/lvgl_common_input.c
+++ b/modules/lvgl/input/lvgl_common_input.c
@@ -26,8 +26,18 @@ static void lvgl_input_read_cb(lv_indev_drv_t *drv, lv_indev_data_t *data)
 {
 	const struct device *dev = drv->user_data;
 	const struct lvgl_common_input_config *cfg = dev->config;
+	struct lvgl_common_input_data *common_data = dev->data;
 
-	k_msgq_get(cfg->event_msgq, data, K_NO_WAIT);
+	if (k_msgq_get(cfg->event_msgq, data, K_NO_WAIT) != 0) {
+		memcpy(data, &common_data->previous_event, sizeof(lv_indev_data_t));
+		if (drv->type == LV_INDEV_TYPE_ENCODER) {
+			data->enc_diff = 0; /* For encoders, clear last movement */
+		}
+		data->continue_reading = false;
+		return;
+	}
+
+	memcpy(&common_data->previous_event, data, sizeof(lv_indev_data_t));
 	data->continue_reading = k_msgq_num_used_get(cfg->event_msgq) > 0;
 }
 


### PR DESCRIPTION
Adds saving of the last lv_indev_data_t for button and pointer type devices. This is needed because there is currently no way to tell LVGL in the read callback that no event is pending. Preservation of the last state is expected to happen in the port layer for the input devices. This resolves issue #62512 (and also: #62754)

The encoder device does not need buffering of the last event, it is expected that the `enc_diff` field on the `lv_indev_data_t` is zero if the encoder was not moved.

**Note**: To sensibly test this first [issues/62753](https://github.com/zephyrproject-rtos/zephyr/issues/62753) needs to be addressed (changing of the init level of the devices).

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/62512
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/62754