### PR TITLE
modules: lvgl: fix initialization order

### DIFF
--- a/modules/lvgl/Kconfig.input
+++ b/modules/lvgl/Kconfig.input
@@ -4,10 +4,6 @@
 
 menu "Input device settings"
 
-config LV_Z_INPUT_INIT_PRIORITY
-	int
-	default 91
-
 config LV_Z_POINTER_KSCAN
 	bool "Keyboard scan pointer input"
 	depends on KSCAN

--- a/modules/lvgl/include/lvgl_button_input.h
+++ b/modules/lvgl/include/lvgl_button_input.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_MODULES_LVGL_LVGL_BUTTON_INPUT_H_
+#define ZEPHYR_MODULES_LVGL_LVGL_BUTTON_INPUT_H_
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int lvgl_button_input_init(const struct device *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_MODULES_LVGL_LVGL_BUTTON_INPUT_H_ */

--- a/modules/lvgl/include/lvgl_common_input.h
+++ b/modules/lvgl/include/lvgl_common_input.h
@@ -26,6 +26,7 @@ struct lvgl_common_input_data {
 };
 
 int lvgl_input_register_driver(lv_indev_type_t indev_type, const struct device *dev);
+int lvgl_init_input_devices(void);
 
 #define LVGL_INPUT_EVENT_MSGQ(inst, type) lvgl_input_msgq_##type##_##inst
 #define LVGL_INPUT_DEVICE(inst)           DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, input))

--- a/modules/lvgl/include/lvgl_encoder_input.h
+++ b/modules/lvgl/include/lvgl_encoder_input.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_MODULES_LVGL_LVGL_ENCODER_INPUT_H_
+#define ZEPHYR_MODULES_LVGL_LVGL_ENCODER_INPUT_H_
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int lvgl_encoder_input_init(const struct device *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_MODULES_LVGL_LVGL_ENCODER_INPUT_H_ */

--- a/modules/lvgl/include/lvgl_pointer_input.h
+++ b/modules/lvgl/include/lvgl_pointer_input.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Fabian Blatz <fabianblatz@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_MODULES_LVGL_LVGL_POINTER_INPUT_H_
+#define ZEPHYR_MODULES_LVGL_LVGL_POINTER_INPUT_H_
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int lvgl_pointer_input_init(const struct device *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_MODULES_LVGL_LVGL_POINTER_INPUT_H_ */

--- a/modules/lvgl/input/lvgl_button_input.c
+++ b/modules/lvgl/input/lvgl_button_input.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT zephyr_lvgl_button_input
 
 #include "lvgl_common_input.h"
+#include "lvgl_button_input.h"
 
 #include <zephyr/logging/log.h>
 
@@ -44,7 +45,7 @@ static void lvgl_button_process_event(const struct device *dev, struct input_eve
 	}
 }
 
-static int lvgl_button_input_init(const struct device *dev)
+int lvgl_button_input_init(const struct device *dev)
 {
 	struct lvgl_common_input_data *data = dev->data;
 	const struct lvgl_button_input_config *cfg = dev->config;
@@ -79,8 +80,8 @@ static int lvgl_button_input_init(const struct device *dev)
 		.coordinates = lvgl_button_coordinates_##inst,                                     \
 	};                                                                                         \
 	static struct lvgl_common_input_data lvgl_common_input_data_##inst;                        \
-	DEVICE_DT_INST_DEFINE(inst, lvgl_button_input_init, NULL, &lvgl_common_input_data_##inst,  \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &lvgl_common_input_data_##inst,                    \
 			      &lvgl_button_input_config_##inst, POST_KERNEL,                       \
-			      CONFIG_LV_Z_INPUT_INIT_PRIORITY, NULL);
+			      CONFIG_INPUT_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(LVGL_BUTTON_INPUT_DEFINE)

--- a/modules/lvgl/input/lvgl_common_input.c
+++ b/modules/lvgl/input/lvgl_common_input.c
@@ -9,6 +9,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <lvgl_input_device.h>
+#include "lvgl_pointer_input.h"
+#include "lvgl_button_input.h"
+#include "lvgl_encoder_input.h"
 
 LOG_MODULE_DECLARE(lvgl);
 
@@ -49,6 +52,33 @@ int lvgl_input_register_driver(lv_indev_type_t indev_type, const struct device *
 	if (common_data->indev == NULL) {
 		return -EINVAL;
 	}
+
+	return 0;
+}
+
+#define LV_DEV_INIT(node_id, init_fn)                                                              \
+	do {                                                                                       \
+		int ret = init_fn(DEVICE_DT_GET(node_id));                                         \
+		if (ret) {                                                                         \
+			return ret;                                                                \
+		}                                                                                  \
+	} while (0)
+
+int lvgl_init_input_devices(void)
+{
+#ifdef CONFIG_LV_Z_POINTER_INPUT
+	DT_FOREACH_STATUS_OKAY_VARGS(zephyr_lvgl_pointer_input, LV_DEV_INIT,
+				     lvgl_pointer_input_init);
+#endif /* CONFIG_LV_Z_POINTER_INPUT */
+
+#ifdef CONFIG_LV_Z_BUTTON_INPUT
+	DT_FOREACH_STATUS_OKAY_VARGS(zephyr_lvgl_button_input, LV_DEV_INIT, lvgl_button_input_init);
+#endif /* CONFIG_LV_Z_BUTTON_INPUT */
+
+#ifdef CONFIG_LV_Z_ENCODER_INPUT
+	DT_FOREACH_STATUS_OKAY_VARGS(zephyr_lvgl_encoder_input, LV_DEV_INIT,
+				     lvgl_encoder_input_init);
+#endif /* CONFIG_LV_Z_ENCODER_INPUT */
 
 	return 0;
 }

--- a/modules/lvgl/input/lvgl_encoder_input.c
+++ b/modules/lvgl/input/lvgl_encoder_input.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT zephyr_lvgl_encoder_input
 
 #include "lvgl_common_input.h"
+#include "lvgl_encoder_input.h"
 
 #include <zephyr/logging/log.h>
 
@@ -37,7 +38,7 @@ static void lvgl_encoder_process_event(const struct device *dev, struct input_ev
 	}
 }
 
-static int lvgl_encoder_input_init(const struct device *dev)
+int lvgl_encoder_input_init(const struct device *dev)
 {
 	return lvgl_input_register_driver(LV_INDEV_TYPE_ENCODER, dev);
 }
@@ -64,8 +65,8 @@ static int lvgl_encoder_input_init(const struct device *dev)
 		.button_input_code = BUTTON_CODE(inst),                                            \
 	};                                                                                         \
 	static struct lvgl_common_input_data lvgl_common_input_data_##inst;                        \
-	DEVICE_DT_INST_DEFINE(inst, lvgl_encoder_input_init, NULL, &lvgl_common_input_data_##inst, \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &lvgl_common_input_data_##inst,                    \
 			      &lvgl_encoder_input_config_##inst, POST_KERNEL,                      \
-			      CONFIG_LV_Z_INPUT_INIT_PRIORITY, NULL);
+			      CONFIG_INPUT_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(LVGL_ENCODER_INPUT_DEFINE)

--- a/modules/lvgl/input/lvgl_pointer_input.c
+++ b/modules/lvgl/input/lvgl_pointer_input.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT zephyr_lvgl_pointer_input
 
 #include "lvgl_common_input.h"
+#include "lvgl_pointer_input.h"
 
 #include <lvgl_display.h>
 #include <zephyr/logging/log.h>
@@ -108,7 +109,7 @@ static void lvgl_pointer_process_event(const struct device *dev, struct input_ev
 	}
 }
 
-static int lvgl_pointer_input_init(const struct device *dev)
+int lvgl_pointer_input_init(const struct device *dev)
 {
 	return lvgl_input_register_driver(LV_INDEV_TYPE_POINTER, dev);
 }
@@ -123,8 +124,8 @@ static int lvgl_pointer_input_init(const struct device *dev)
 		.invert_y = DT_INST_PROP(inst, invert_y),                                          \
 	};                                                                                         \
 	static struct lvgl_common_input_data lvgl_common_input_data_##inst;                        \
-	DEVICE_DT_INST_DEFINE(inst, lvgl_pointer_input_init, NULL, &lvgl_common_input_data_##inst, \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &lvgl_common_input_data_##inst,                    \
 			      &lvgl_pointer_input_config_##inst, POST_KERNEL,                      \
-			      CONFIG_LV_Z_INPUT_INIT_PRIORITY, NULL);
+			      CONFIG_INPUT_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(LVGL_POINTER_INPUT_DEFINE)

--- a/modules/lvgl/input/lvgl_pointer_kscan.c
+++ b/modules/lvgl/input/lvgl_pointer_kscan.c
@@ -146,4 +146,4 @@ static int lvgl_kscan_pointer_init(void)
 	return 0;
 }
 
-SYS_INIT(lvgl_kscan_pointer_init, APPLICATION, CONFIG_LV_Z_INPUT_INIT_PRIORITY);
+SYS_INIT(lvgl_kscan_pointer_init, APPLICATION, CONFIG_INPUT_INIT_PRIORITY);

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -8,6 +8,7 @@
 #include <zephyr/kernel.h>
 #include <lvgl.h>
 #include "lvgl_display.h"
+#include "lvgl_common_input.h"
 #ifdef CONFIG_LV_Z_USE_FILESYSTEM
 #include "lvgl_fs.h"
 #endif
@@ -241,12 +242,13 @@ static int lvgl_init(void)
 		return -EPERM;
 	}
 
+	err = lvgl_init_input_devices();
+	if (err < 0) {
+		LOG_ERR("Failed to initialize input devices.");
+		return err;
+	}
+
 	return 0;
 }
-
-BUILD_ASSERT(CONFIG_APPLICATION_INIT_PRIORITY < CONFIG_LV_Z_INPUT_INIT_PRIORITY);
-#ifdef CONFIG_INPUT
-BUILD_ASSERT(CONFIG_INPUT_INIT_PRIORITY < CONFIG_LV_Z_INPUT_INIT_PRIORITY);
-#endif /* CONFIG_INPUT */
 
 SYS_INIT(lvgl_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
Adds init priority to ensure the following initialization order:
1. Hardware devices (screens, buttons)
2. LVGL prerequisits (heap, rendering setup)
3. Input subsystem
4. LVGL pseudo devices

This resolves #62753.