### PR TITLE
scripts: pytest: Add option to filter the captured shell output

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/shell.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/shell.py
@@ -66,3 +66,15 @@ class Shell:
         # wait for device command execution
         lines.extend(self._device.readlines_until(regex=regex_prompt, timeout=timeout, print_output=print_output))
         return lines
+
+    def get_filtered_output(self, command_lines: list[str]) -> list[str]:
+        regex_filter = re.compile(
+            '|'.join([
+                re.escape(self.prompt),
+                '<dbg>',
+                '<inf>',
+                '<wrn>',
+                '<err>'
+            ])
+        )
+        return list(filter(lambda l: not regex_filter.search(l), command_lines))


### PR DESCRIPTION
Sometimes you might need exec_command() to return an value from running device. If the output contains shell prompts or logger output, it is harder to capture the value.
Filter away the lines we thing belongs to the shell prompt or normal logging output.