### PR TITLE
Bluetooth: Test: Remove dead code

### DIFF
--- a/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
@@ -125,8 +125,6 @@ DEFINE_FLAG(flag_discovered);
 static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			     struct bt_gatt_discover_params *params)
 {
-	int err;
-
 	if (attr == NULL) {
 		for (int i = 0; i < ARRAY_SIZE(gatt_handles); i++) {
 			printk("handle[%d] = 0x%x\n", i, gatt_handles[i]);
@@ -143,20 +141,7 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 		return BT_GATT_ITER_STOP;
 	}
 
-	if (params->type == BT_GATT_DISCOVER_PRIMARY &&
-	    bt_uuid_cmp(params->uuid, &test_svc_uuid.uuid) == 0) {
-		printk("Found test service\n");
-		params->uuid = NULL;
-		params->start_handle = attr->handle + 1;
-		params->type = BT_GATT_DISCOVER_CHARACTERISTIC;
-
-		err = bt_gatt_discover(conn, params);
-		if (err != 0) {
-			FAIL("Discover failed (err %d)\n", err);
-		}
-
-		return BT_GATT_ITER_STOP;
-	} else if (params->type == BT_GATT_DISCOVER_CHARACTERISTIC) {
+	if (params->type == BT_GATT_DISCOVER_CHARACTERISTIC) {
 		const struct bt_gatt_chrc *chrc = (struct bt_gatt_chrc *)attr->user_data;
 
 		if (bt_uuid_cmp(chrc->uuid, BT_UUID_GATT_CLIENT_FEATURES) == 0) {


### PR DESCRIPTION
Remove unused code in `host/gatt/settings` test. The conditional block could never be reached because the type of the discovery parameter is `BT_GATT_DISCOVER_CHARACTERISTIC`.