### PR TITLE
posix: add logging to pthread, pthread_mutex, and pthread_cond

### DIFF
--- a/lib/posix/Kconfig.template.pooled_ipc_type
+++ b/lib/posix/Kconfig.template.pooled_ipc_type
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 source "lib/posix/Kconfig.template.with_url"
+source "lib/posix/Kconfig.template.with_logging"
 
 # Not user configurable (i.e. private for now)
 config $(TYPE)

--- a/lib/posix/Kconfig.template.pooled_type
+++ b/lib/posix/Kconfig.template.pooled_type
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 source "lib/posix/Kconfig.template.with_url"
+source "lib/posix/Kconfig.template.with_logging"
 
 # This is mainly for TIMER currently.
 config $(TYPE)

--- a/lib/posix/Kconfig.template.with_logging
+++ b/lib/posix/Kconfig.template.with_logging
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 Meta
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module = $(TYPE)
+module-str = $(TYPE) logging
+source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
For A Long Time™️ there was zero logging in our pthread implementation. This made it sometimes difficult to know what was happening under the hood with the POSIX library.

Here, we add error logging to the primary paths of interest in POSIX threads - namely to `pthread_t`, `pthread_mutex_t`, and `pthread_cond_t` operations.

Debug-level logging is also implemented when more verbose output is desired.

Logging is also available by default for any of the pooled resources via the Kconfig template, although it has not yet been implemented for less frequently-traveled types like `pthread_barrier_t`, `pthread_rwlock_t`, and `pthread_spinlock_t`. Those can be implemented on an as-needed basis.

For implementing various APIs on top of pthreads, such as ISO C, and ISO C++ threads, this kind of logging is quite helpful.