### PR TITLE
[Backport v2.7-branch] can: rework the table lookup code in can_dlc_to_bytes

### DIFF
--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -420,7 +420,7 @@ static inline uint8_t can_dlc_to_bytes(uint8_t dlc)
 	static const uint8_t dlc_table[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 12,
 					 16, 20, 24, 32, 48, 64};
 
-	return dlc > 0x0F ? 64 : dlc_table[dlc];
+	return dlc_table[MIN(dlc, ARRAY_SIZE(dlc_table) - 1)];
 }
 
 /**


### PR DESCRIPTION
Backport 4856fd4cb6ce13d7218d7993cce658463ef702c0 from #62611.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/62701, https://github.com/zephyrproject-rtos/zephyr/issues/62709