### PR TITLE
Bluetooth: Controller: Fix order of preempt timeout requested flag

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -835,11 +835,17 @@ static void ticker_start_op_cb(uint32_t status, void *param)
 	ARG_UNUSED(param);
 	LL_ASSERT(status == TICKER_STATUS_SUCCESS);
 
-	LL_ASSERT(preempt_start_req != preempt_start_ack);
-	preempt_start_ack++;
-
+	/* Increase preempt requested count before acknowledging that the
+	 * ticker start operation for the preempt timeout has been handled.
+	 */
 	LL_ASSERT(preempt_req == preempt_ack);
 	preempt_req++;
+
+	/* Increase preempt start ack count, to acknowledge that the ticker
+	 * start operation has been handled.
+	 */
+	LL_ASSERT(preempt_start_req != preempt_start_ack);
+	preempt_start_ack++;
 }
 
 static uint32_t preempt_ticker_start(struct lll_event *first,
@@ -854,7 +860,11 @@ static uint32_t preempt_ticker_start(struct lll_event *first,
 	uint32_t preempt_to;
 	uint32_t ret;
 
-	/* Do not request to start preempt timeout if already requested */
+	/* Do not request to start preempt timeout if already requested.
+	 *
+	 * Check if there is pending preempt timeout start requested or if
+	 * preempt timeout ticker has already been scheduled.
+	 */
 	if ((preempt_start_req != preempt_start_ack) ||
 	    (preempt_req != preempt_ack)) {
 		uint32_t diff;


### PR DESCRIPTION
Fix the order of setting the flag that indicates that preempt timeout has been successfully requested versus the request is waiting to be scheduled.

The change required was identified during code inspection related to analysis of https://devzone.nordicsemi.com/f/nordic-q-a/103127/connectless-cte-tx-rx-problem