### PR TITLE
Deprecate MODEM_GSM_PPP driver

### DIFF
--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -78,6 +78,12 @@ Recommended Changes
          gpio-as-nreset;
      };
 
+* The :kconfig:option:`CONFIG_MODEM_GSM_PPP` modem driver is obsolete.
+  Instead the new :kconfig:option:`CONFIG_MODEM_CELLULAR` driver should be used.
+  As part of this :kconfig:option:`CONFIG_GSM_MUX` and :kconfig:option:`CONFIG_UART_MUX` are being
+  marked as deprecated as well. The new modem subsystem :kconfig:option:`CONFIG_MODEM_CMUX`
+  and :kconfig:option:`CONFIG_MODEM_PPP`` should be used instead.
+
 Picolibc-related Changes
 ************************
 

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -256,10 +256,11 @@ source "subsys/logging/Kconfig.template.log_config"
 source "drivers/console/Kconfig.gsm_mux"
 
 config UART_MUX
-	bool "UART muxing (GSM 07.10) support [EXPERIMENTAL]"
+	bool "[DEPRECATED] UART muxing (GSM 07.10) support [EXPERIMENTAL]"
 	depends on SERIAL_SUPPORT_INTERRUPT && GSM_MUX
 	select UART_INTERRUPT_DRIVEN
 	select EXPERIMENTAL
+	select DEPRECATED
 	help
 	  Enable this option to create UART muxer that run over a physical
 	  UART. The GSM 07.10 muxing protocol is used to separate the data

--- a/drivers/console/Kconfig.gsm_mux
+++ b/drivers/console/Kconfig.gsm_mux
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config GSM_MUX
-	bool "GSM 07.10 muxing protocol"
+	bool "[DEPRECATED] GSM 07.10 muxing protocol"
 	select CRC
+	select DEPRECATED
 	help
 	  Enable GSM 07.10 muxing protocol defined in
 	  https://www.etsi.org/deliver/etsi_ts/101300_101399/101369/07.01.00_60/ts_101369v070100p.pdf

--- a/drivers/modem/Kconfig.gsm
+++ b/drivers/modem/Kconfig.gsm
@@ -2,14 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config MODEM_GSM_PPP
-	bool "Support GSM modems"
+	bool "[DEPRECATED] Support GSM modems"
 	select MODEM_CONTEXT
 	select MODEM_CMD_HANDLER
 	select MODEM_IFACE_UART
 	select NET_MGMT
 	select NET_MGMT_EVENT
+	select DEPRECATED
 	help
-	  Enable GSM modems that support standard AT commands and PPP.
+	  This driver is deprecated, use the MODEM_CELLULAR driver instead.
 
 if MODEM_GSM_PPP
 


### PR DESCRIPTION
The MODEM_GSM_PPP driver is now obsolete and is replaced by MODEM_CELLULAR.
The new MODEM_CELLULAR makes use of the new modem subsystem for better reuse and reliability.