### PR TITLE
tracing: remove references to deprecated k_pipe_block_put

### DIFF
--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -1633,20 +1633,6 @@
  */
 #define sys_port_trace_k_pipe_get_exit(pipe, timeout, ret)
 
-/**
- * @brief Trace Pipe block put enter
- * @param pipe Pipe object
- * @param sem Semaphore object
- */
-#define sys_port_trace_k_pipe_block_put_enter(pipe, sem)
-
-/**
- * @brief Trace Pipe block put exit
- * @param pipe Pipe object
- * @param sem Semaphore object
- */
-#define sys_port_trace_k_pipe_block_put_exit(pipe, sem)
-
 /** @} */ /* end of subsys_tracing_apis_pipe */
 
 /**

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -295,8 +295,6 @@ extern "C" {
 #define sys_port_trace_k_pipe_get_enter(pipe, timeout)
 #define sys_port_trace_k_pipe_get_blocking(pipe, timeout)
 #define sys_port_trace_k_pipe_get_exit(pipe, timeout, ret)
-#define sys_port_trace_k_pipe_block_put_enter(pipe, sem)
-#define sys_port_trace_k_pipe_block_put_exit(pipe, sem)
 
 #define sys_port_trace_k_heap_init(heap)
 #define sys_port_trace_k_heap_aligned_alloc_enter(heap, timeout)

--- a/subsys/tracing/sysview/SYSVIEW_Zephyr.txt
+++ b/subsys/tracing/sysview/SYSVIEW_Zephyr.txt
@@ -79,7 +79,6 @@ TaskState 0xBF 1=dummy, 2=Waiting, 4=New, 8=Terminated, 16=Suspended, 32=Termina
 72  k_pipe_cleanup             pipe=%I  | Returns %ErrCodePosix
 73  k_pipe_put                 pipe=%I, data=%p, bytes_to_write=%u, bytes_written=%u, min_xfer=%u, Timeout=%TimeOut            | Returns %ErrCodePosix
 74  k_pipe_get                 pipe=%I, data=%p, bytes_to_read=%u, bytes_read=%u, min_xfer=%u, Timeout=%TimeOut                | Returns %ErrCodePosix
-75  k_pipe_block_put           pipe=%I, block=%p, bytes_to_write=%u, sem=%I |  Returns (void)(%ErrCodePosix)
 
 76  k_heap_init                heap=%I, mem=%p, bytes=%u
 77  k_heap_alloc               heap=%I, bytes=%u, Timeout=%TimeOut | Returns %p

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -530,8 +530,6 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_pipe_get_enter(pipe, timeout)
 #define sys_port_trace_k_pipe_get_blocking(pipe, timeout)
 #define sys_port_trace_k_pipe_get_exit(pipe, timeout, ret)
-#define sys_port_trace_k_pipe_block_put_enter(pipe, sem)
-#define sys_port_trace_k_pipe_block_put_exit(pipe, sem)
 
 #define sys_port_trace_k_event_init(event)
 #define sys_port_trace_k_event_post_enter(event, events, events_mask)

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -366,10 +366,6 @@
 	sys_trace_k_pipe_get_blocking(pipe, data, bytes_to_read, bytes_read, min_xfer, timeout)
 #define sys_port_trace_k_pipe_get_exit(pipe, timeout, ret)                                         \
 	sys_trace_k_pipe_get_exit(pipe, data, bytes_to_read, bytes_read, min_xfer, timeout, ret)
-#define sys_port_trace_k_pipe_block_put_enter(pipe, sem)                                           \
-	sys_trace_k_pipe_block_put_enter(pipe, block, bytes_to_write, sem)
-#define sys_port_trace_k_pipe_block_put_exit(pipe, sem)                                            \
-	sys_trace_k_pipe_block_put_exit(pipe, block, bytes_to_write, sem)
 
 #define sys_port_trace_k_heap_init(h) sys_trace_k_heap_init(h, mem, bytes)
 #define sys_port_trace_k_heap_aligned_alloc_enter(h, timeout)                                      \
@@ -634,10 +630,6 @@ void sys_trace_k_pipe_get_blocking(struct k_pipe *pipe, void *data, size_t bytes
 				   size_t *bytes_read, size_t min_xfer, k_timeout_t timeout);
 void sys_trace_k_pipe_get_exit(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 			       size_t *bytes_read, size_t min_xfer, k_timeout_t timeout, int ret);
-void sys_trace_k_pipe_block_put_enter(struct k_pipe *pipe, struct k_mem_block *block, size_t size,
-				      struct k_sem *sem);
-void sys_trace_k_pipe_block_put_exit(struct k_pipe *pipe, struct k_mem_block *block, size_t size,
-				     struct k_sem *sem);
 
 void sys_trace_k_msgq_init(struct k_msgq *msgq);
 void sys_trace_k_msgq_alloc_init_enter(struct k_msgq *msgq, size_t msg_size, uint32_t max_msgs);

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -280,8 +280,6 @@ void sys_trace_idle(void);
 #define sys_port_trace_k_pipe_get_enter(pipe, timeout)
 #define sys_port_trace_k_pipe_get_blocking(pipe, timeout)
 #define sys_port_trace_k_pipe_get_exit(pipe, timeout, ret)
-#define sys_port_trace_k_pipe_block_put_enter(pipe, sem)
-#define sys_port_trace_k_pipe_block_put_exit(pipe, sem)
 
 #define sys_port_trace_k_heap_init(heap)
 #define sys_port_trace_k_heap_aligned_alloc_enter(heap, timeout)

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
@@ -437,7 +437,6 @@ ZTEST(pipe_api, test_pipe_get_large)
  */
 ZTEST(pipe_api, test_pipe_reader_wait)
 {
-	/**TESTPOINT: test k_pipe_block_put with semaphore*/
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 					thread_handler, &kpipe1, NULL, NULL,
 					K_PRIO_PREEMPT(0), 0, K_NO_WAIT);


### PR DESCRIPTION
k_pipe_block_put was deprecated some time ago.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
