### PR TITLE
maintainers: remove gmarull as a PM subsystem collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2085,7 +2085,6 @@ Power management:
     - ceolin
   collaborators:
     - nashif
-    - gmarull
     - teburd
     - tmleman
     - JordanYates


### PR DESCRIPTION
I disagree on the way the subsystem is maintained. For more context refer to https://github.com/zephyrproject-rtos/zephyr/pull/61726 or https://discord.com/channels/720317445772017664/997527108844798012/1153288380231208960