### PR TITLE
dts: efm32gg12b: add pin-controller binding

### DIFF
--- a/dts/arm/silabs/efm32gg11b.dtsi
+++ b/dts/arm/silabs/efm32gg11b.dtsi
@@ -287,6 +287,14 @@
 			interrupts = <64 0>;
 			status = "disabled";
 		};
+
+		pinctrl: pin-controller {
+			/* Pin controller is a "virtual" device since SiLabs SoCs do pin
+			 * control in a distributed way (GPIO registers and PSEL
+			 * registers on each peripheral).
+			 */
+			compatible = "silabs,gecko-pinctrl";
+		};
 	};
 };
 

--- a/dts/arm/silabs/efm32gg12b.dtsi
+++ b/dts/arm/silabs/efm32gg12b.dtsi
@@ -240,6 +240,14 @@
 			interrupts = <55 0>;
 			status = "disabled";
 		};
+
+		pinctrl: pin-controller {
+			/* Pin controller is a "virtual" device since SiLabs SoCs do pin
+			 * control in a distributed way (GPIO registers and PSEL
+			 * registers on each peripheral).
+			 */
+			compatible = "silabs,gecko-pinctrl";
+		};
 	};
 };
 


### PR DESCRIPTION
repro: `west build -p -b efm32gg_sltb009a samples/basic/blinky` and `west build -p -b efm32gg_slwstk6121a samples/basic/blinky` (probably more).

Notice that some EFM32 board are still failing for other reasons: `west build -p -b efm32wg_stk3800 samples/basic/blinky` is one.

---

The gecko UART driver needs pinctrl support for SOC_GECKO_SERIES1 devices, this has been added to jg and pg 12b series in 40fa96506b but is missing in others, causing some build failurse.

Add the device nodes for the gg11b and gg12b files since they contain gecko-uart references and seems to be under the SERIES1 define.