### PR TITLE
boards: rcar_salvator_xs_m3: not a default test platform

### DIFF
--- a/boards/arm64/rcar_salvator_xs_m3/rcar_salvator_xs_m3.yaml
+++ b/boards/arm64/rcar_salvator_xs_m3/rcar_salvator_xs_m3.yaml
@@ -10,7 +10,6 @@ supported:
   - clock_control
   - uart
 testing:
-  default: true
   ignore_tags:
     - net
     - bluetooth


### PR DESCRIPTION
This is not an emulation platform, so it should not be set as a default.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
