### PR TITLE
[RFC] drivers: intc: plic: multi-instance support - approach 3

### DIFF
--- a/arch/common/isr_tables.c
+++ b/arch/common/isr_tables.c
@@ -86,3 +86,25 @@ struct _isr_table_entry __sw_isr_table _sw_isr_table[IRQ_TABLE_SIZE] = {
 struct z_shared_isr_table_entry __shared_sw_isr_table z_shared_sw_isr_table[IRQ_TABLE_SIZE] = {
 };
 #endif
+
+#ifdef CONFIG_INTC_MULTI_INSTANCE
+
+#define MULTI_INTC_ID_OFFSET(i)                                                                    \
+	.instance_id = i, .isr_offset = UTIL_CAT(UTIL_CAT(CONFIG_INTC_ID_, i), _OFFSET)
+
+#define MULTI_INTC_TBL_ENTRY(node_id)                                                              \
+	{                                                                                          \
+		.dev = DEVICE_DT_GET(node_id),                                                     \
+		MULTI_INTC_ID_OFFSET(DT_PROP(node_id, multi_instance_id)),                         \
+	},
+
+#define MULTI_INTC_TBL_FN(node_id)                                                                 \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, multi_instance_id), (MULTI_INTC_TBL_ENTRY(node_id)), \
+		    ())
+
+const struct z_isr_offset_table_entry z_isr_offset_table[CONFIG_INTC_NUM_INSTANCE] = {
+	// we only interested in interrupt-controllers under /soc/
+	DT_FOREACH_CHILD_STATUS_OKAY(DT_PATH(soc), MULTI_INTC_TBL_FN)
+};
+
+#endif /* CONFIG_INTC_MULTI_INSTANCE */

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -62,6 +62,8 @@ source "subsys/logging/Kconfig.template.log_config"
 
 source "drivers/interrupt_controller/Kconfig.multilevel"
 
+source "drivers/interrupt_controller/Kconfig.multi_instance"
+
 source "drivers/interrupt_controller/Kconfig.loapic"
 
 source "drivers/interrupt_controller/Kconfig.dw"

--- a/drivers/interrupt_controller/Kconfig.multi_instance
+++ b/drivers/interrupt_controller/Kconfig.multi_instance
@@ -1,0 +1,38 @@
+# Copyright (c) 2023 Meta
+# SPDX-License-Identifier: Apache-2.0
+
+config INTC_HAS_MULTI_INSTANCE
+	bool
+
+config INTC_MULTI_INSTANCE
+	bool "Enable multi-instance interrupt controller"
+	depends on INTC_HAS_MULTI_INSTANCE
+	help
+	  Enable the compilation of extra software to support multi-instance
+	  interrupt controller
+
+config INTC_MULTI_INSTANCE_BITS
+	int "Number of bits to represent the interrupt controller"
+	range 1 2
+	depends on INTC_MULTI_INSTANCE
+	help
+	  Number of bits at the end of the `uint32_t` to be used to encode the
+	  index of the interrupt controller instance. 1 bit allows up to 2 controllers,
+	  2 bits allow up to 4 controllers.
+
+config INTC_NUM_INSTANCE
+	int "Number of interrupt controllers"
+	range 1 4
+	depends on INTC_MULTI_INSTANCE
+	help
+	  Number of interrupt controller enabled in the system.
+	  Support up to 4 controllers.
+
+instance-id = 0
+rsource "Kconfig.multi_instance.offset.template"
+instance-id = 1
+rsource "Kconfig.multi_instance.offset.template"
+instance-id = 2
+rsource "Kconfig.multi_instance.offset.template"
+instance-id = 3
+rsource "Kconfig.multi_instance.offset.template"

--- a/drivers/interrupt_controller/Kconfig.multi_instance.offset.template
+++ b/drivers/interrupt_controller/Kconfig.multi_instance.offset.template
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Meta
+# SPDX-License-Identifier: Apache-2.0
+
+config INTC_ID_$(instance-id)_OFFSET
+	int "placeholder"
+	default 0
+	help
+	  placeholder

--- a/drivers/interrupt_controller/Kconfig.multilevel
+++ b/drivers/interrupt_controller/Kconfig.multilevel
@@ -20,6 +20,7 @@ config MULTI_LEVEL_INTERRUPTS
 
 config 1ST_LEVEL_INTERRUPT_BITS
 	int "Total number of first level interrupt bits"
+	range 1 30 if INTC_MULTI_INSTANCE
 	range 1 32
 	default 8
 	help
@@ -63,6 +64,7 @@ config NUM_2ND_LEVEL_AGGREGATORS
 
 config 2ND_LEVEL_INTERRUPT_BITS
 	int "Total number of second level interrupt bits"
+	range 0 29 if INTC_MULTI_INSTANCE
 	range 0 31
 	default 8
 	help
@@ -117,6 +119,7 @@ config 3RD_LVL_ISR_TBL_OFFSET
 
 config 3RD_LEVEL_INTERRUPT_BITS
 	int "Total number of third level interrupt bits"
+	range 0 28 if INTC_MULTI_INSTANCE
 	range 0 30
 	default 8
 	help

--- a/drivers/interrupt_controller/Kconfig.plic
+++ b/drivers/interrupt_controller/Kconfig.plic
@@ -10,9 +10,3 @@ config PLIC
 	help
 	  Platform Level Interrupt Controller provides support
 	  for external interrupt lines defined by the RISC-V SoC.
-
-config PLIC_SUPPORTS_EDGE_IRQ
-	bool "The given interrupt controller supports edge interrupts"
-	help
-	  The given interrupt controller supports edge triggered
-	  interrupts.

--- a/drivers/interrupt_controller/Kconfig.plic
+++ b/drivers/interrupt_controller/Kconfig.plic
@@ -7,6 +7,7 @@ config PLIC
 	depends on DT_HAS_SIFIVE_PLIC_1_0_0_ENABLED
 	select MULTI_LEVEL_INTERRUPTS
 	select 2ND_LEVEL_INTERRUPTS
+	select INTC_HAS_MULTI_INSTANCE
 	help
 	  Platform Level Interrupt Controller provides support
 	  for external interrupt lines defined by the RISC-V SoC.

--- a/dts/bindings/interrupt-controller/interrupt-controller.yaml
+++ b/dts/bindings/interrupt-controller/interrupt-controller.yaml
@@ -12,3 +12,6 @@ properties:
     type: int
     required: true
     description: Number of items to expect in an interrupt specifier
+  "multi-instance-id":
+    type: int
+    description: placeholder

--- a/dts/bindings/interrupt-controller/sifive,plic-1.0.0.yaml
+++ b/dts/bindings/interrupt-controller/sifive,plic-1.0.0.yaml
@@ -12,7 +12,8 @@ properties:
     type: int
     description: Number of external interrupts supported
     required: true
-  riscv,trigger-reg-offset:
-    type: int
-    default: 4224
-    description: Offset of the trigger type register if supported
+
+  support-edge-interrupt:
+    type: boolean
+    description: |
+      Indicates that this controller supports edge interrupt.

--- a/dts/riscv/andes/andes_v5_ae350.dtsi
+++ b/dts/riscv/andes/andes_v5_ae350.dtsi
@@ -171,10 +171,7 @@
 			#address-cells = <1>;
 			#interrupt-cells = <2>;
 			interrupt-controller;
-			reg = <	0xe4000000 0x00001000
-				0xe4002000 0x00000800
-				0xe4200000 0x00010000 >;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <	0xe4000000 0x04000000 >;
 			riscv,max-priority = <255>;
 			riscv,ndev = <1023>;
 			interrupts-extended = <&CPU0_intc 11 &CPU1_intc 11

--- a/dts/riscv/efinix/sapphire_soc.dtsi
+++ b/dts/riscv/efinix/sapphire_soc.dtsi
@@ -55,10 +55,7 @@
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = < 0xf8c00000 0x00001000
-					0xf8c02000 0x00000800
-					0xf8e00000 0x00010000 >;
-			reg-names = "prio", "irq_en", "reg";
+			reg = < 0xf8c00000 0x04000000 >;
 			riscv,max-priority = <3>;
 			riscv,ndev = <32>;
 		};

--- a/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
+++ b/dts/riscv/lowrisc/opentitan_earlgrey.dtsi
@@ -75,10 +75,7 @@
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = <0x48000000 0x00001000
-			       0x48002000 0x00001000
-			       0x48200000 0x00000008>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x48000000 0x04000000>;
 			riscv,max-priority = <7>;
 			riscv,ndev = <184>;
 			status = "okay";

--- a/dts/riscv/microchip/microchip-miv.dtsi
+++ b/dts/riscv/microchip/microchip-miv.dtsi
@@ -54,10 +54,7 @@
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = <0x40000000 0x2000
-			       0x40002000 0x1fe000
-			       0x40200000 0x2000000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x40000000 0x04000000>;
 			riscv,max-priority = <1>;
 			riscv,ndev = <31>;
 		};

--- a/dts/riscv/microchip/mpfs-icicle.dtsi
+++ b/dts/riscv/microchip/mpfs-icicle.dtsi
@@ -121,10 +121,7 @@
 			interrupt-controller;
 			interrupts-extended = <&hlic0 11
 						&hlic1 11>;
-			reg = <0x0c000000 0x00002000
-					0x0c002000 0x001fe000
-					0x0c200000 0x3e000000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x0c000000 0x04000000>;
 			riscv,max-priority = <7>;
 			riscv,ndev = <187>;
 		};

--- a/dts/riscv/sifive/riscv32-fe310.dtsi
+++ b/dts/riscv/sifive/riscv32-fe310.dtsi
@@ -123,10 +123,7 @@
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = <0x0c000000 0x00002000
-			       0x0c002000 0x001fe000
-			       0x0c200000 0x03e00000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x0c000000 0x04000000>;
 			riscv,max-priority = <7>;
 			riscv,ndev = <52>;
 		};

--- a/dts/riscv/sifive/riscv64-fu540.dtsi
+++ b/dts/riscv/sifive/riscv64-fu540.dtsi
@@ -120,10 +120,7 @@
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = <0x0c000000 0x00002000
-			       0x0c002000 0x001fe000
-			       0x0c200000 0x03e00000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x0c000000 0x04000000>;
 			riscv,max-priority = <7>;
 			riscv,ndev = <52>;
 		};

--- a/dts/riscv/sifive/riscv64-fu740.dtsi
+++ b/dts/riscv/sifive/riscv64-fu740.dtsi
@@ -142,10 +142,7 @@
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
-			reg = <0x0 0x0c000000 0x0 0x00002000
-			       0x0 0x0c002000 0x0 0x001fe000
-			       0x0 0x0c200000 0x0 0x03e00000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x0 0x0c000000 0x0 0x04000000>;
 			riscv,max-priority = <7>;
 			riscv,ndev = <52>;
 		};

--- a/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
+++ b/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
@@ -129,10 +129,7 @@
 			interrupt-controller;
 			interrupts-extended = <&cpu0intctrl 11 &cpu0intctrl 9
 					       &cpu1intctrl 11 &cpu1intctrl 9 >;
-			reg = <0x0 0x0c000000 0x0 0x00002000
-			       0x0 0x0c002000 0x0 0x001fe000
-			       0x0 0x0c200000 0x0 0x03e00000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x0 0x0c000000 0x0 0x04000000>;
 			riscv,max-priority = <7>;
 			riscv,ndev = <127>;
 		};

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -132,10 +132,7 @@
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
 			interrupt-parent = <&cpu0>;
-			reg = < 0xe4000000 0x00001000
-					0xe4002000 0x00000800
-					0xe4200000 0x00010000 >;
-			reg-names = "prio", "irq_en", "reg";
+			reg = < 0xe4000000 0x00210000 >;
 			riscv,max-priority = <3>;
 			riscv,ndev = <63>;
 		};

--- a/dts/riscv/virt.dtsi
+++ b/dts/riscv/virt.dtsi
@@ -165,10 +165,7 @@
 		plic: interrupt-controller@c000000 {
 			riscv,max-priority = <7>;
 			riscv,ndev = < 0x35 >;
-			reg = <0x0c000000 0x00002000
-			       0x0c002000 0x001fe000
-			       0x0c200000 0x03e00000>;
-			reg-names = "prio", "irq_en", "reg";
+			reg = <0x0c000000 0x04000000>;
 			interrupts-extended = <
 				&hlic0 0x0b &hlic0 0x09
 				&hlic1 0x0b &hlic1 0x09

--- a/include/zephyr/drivers/interrupt_controller/riscv_plic.h
+++ b/include/zephyr/drivers/interrupt_controller/riscv_plic.h
@@ -12,6 +12,8 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_RISCV_PLIC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_RISCV_PLIC_H_
 
+#include <zephyr/device.h>
+
 /**
  * @brief Enable interrupt
  *

--- a/include/zephyr/irq.h
+++ b/include/zephyr/irq.h
@@ -281,6 +281,76 @@ void z_smp_global_unlock(unsigned int key);
 #endif
 
 /**
+ * @brief Get the instance_id encoded in @a irq
+ *
+ * @param irq IRQ number in its zephyr format
+ *
+ * @return instance id of the @a irq
+ */
+static inline unsigned int irq_get_instance_id(unsigned int irq)
+{
+#ifdef CONFIG_INTC_MULTI_INSTANCE
+	return irq >> (sizeof(irq) * __CHAR_BIT__ - CONFIG_INTC_MULTI_INSTANCE_BITS);
+#else
+	ARG_UNUSED(irq);
+	return 0;
+#endif
+}
+
+/**
+ * @brief Strip the instance_id from in @a irq
+ *
+ * @param irq IRQ number in its zephyr format
+ *
+ * @return Stripped IRQ number without the instance id information
+ */
+static inline unsigned int irq_strip_instance_id(unsigned int irq)
+{
+#ifdef CONFIG_INTC_MULTI_INSTANCE
+	return irq & BIT_MASK(sizeof(irq) * __CHAR_BIT__ - CONFIG_INTC_MULTI_INSTANCE_BITS);
+#else
+	return irq;
+#endif
+}
+
+/**
+ * @brief Encode the @a instance_id to @a irq
+ *
+ * @param irq IRQ number in its zephyr format
+ * @param instance_id Instance ID for the irq
+ *
+ * @return IRQ number with instance-id encoded
+ */
+static inline unsigned int irq_enc_instance_id(unsigned int irq, unsigned int instance_id)
+{
+#ifdef CONFIG_INTC_MULTI_INSTANCE
+	irq = irq_strip_instance_id(irq);
+	instance_id &= BIT_MASK(CONFIG_INTC_MULTI_INSTANCE_BITS);
+	return irq | (instance_id << (sizeof(irq) * __CHAR_BIT__ - CONFIG_INTC_MULTI_INSTANCE_BITS));
+#else
+	ARG_UNUSED(instance_id);
+	return irq;
+#endif
+}
+
+/**
+ * @brief Get the ISR offset for @a irq
+ *
+ * @param irq IRQ number in its zephyr format
+ *
+ * @return ISR offset of @a irq
+ */
+static inline unsigned int irq_get_instance_isr_offset(unsigned int irq)
+{
+#ifdef CONFIG_INTC_MULTI_INSTANCE
+	return arch_irq_get_instance_isr_offset(irq);
+#else
+	ARG_UNUSED(irq);
+	return 0;
+#endif
+}
+
+/**
  * @brief Return IRQ level
  * This routine returns the interrupt level number of the provided interrupt.
  *

--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -15,6 +15,7 @@
 #define ZEPHYR_INCLUDE_SW_ISR_TABLE_H_
 
 #if !defined(_ASMLANGUAGE)
+#include <zephyr/sys/__assert.h>
 #include <zephyr/types.h>
 #include <zephyr/toolchain.h>
 
@@ -61,6 +62,20 @@ struct _isr_list {
 	const void *param;
 };
 
+/**
+ * We need to somehow map the interrupt controller instance_id to its offset
+ * TODO: Populate this LUT somewhere and put into somewhere
+ */
+#ifdef CONFIG_INTC_MULTI_INSTANCE
+struct z_isr_offset_table_entry {
+	const struct device *dev;
+	unsigned int instance_id;
+	unsigned int isr_offset;
+};
+
+extern const struct z_isr_offset_table_entry z_isr_offset_table[];
+#endif /* CONFIG_INTC_MULTI_INSTANCE */
+
 #ifdef CONFIG_SHARED_INTERRUPTS
 struct z_shared_isr_client {
 	void (*isr)(const void *arg);
@@ -86,6 +101,74 @@ extern struct z_shared_isr_table_entry z_shared_sw_isr_table[];
  * @return corresponding index in _sw_isr_table
  */
 unsigned int z_get_sw_isr_table_idx(unsigned int irq);
+
+/**
+ * @brief Get the corresponding interrupt controller for @a instance_id
+ *
+ * @param instance_id Instance ID of the IRQ
+ *
+ * @return corresponding interrupt controller in z_isr_offset_table, NULL if not found
+*/
+static inline const struct device *z_get_instance_dev_from_id(unsigned int instance_id)
+{
+#ifdef CONFIG_INTC_MULTI_INSTANCE
+	for (size_t i = 0; i < CONFIG_INTC_NUM_INSTANCE; i++) {
+		if(instance_id == z_isr_offset_table[i].instance_id) {
+			return z_isr_offset_table[i].dev;
+		}
+	}
+	__ASSERT(false, "entry not found");
+#else
+	ARG_UNUSED(instance_id);
+#endif
+	return NULL;
+}
+
+/**
+ * @brief Get the corresponding instance_id for interrupt controller @a dev
+ *
+ * @param dev Interrupt controller device
+ *
+ * @return corresponding instance ID in z_isr_offset_table, UINT32_MAX if not found
+*/
+static inline unsigned int z_get_instance_id_from_dev(const struct device *dev)
+{
+#ifdef CONFIG_INTC_MULTI_INSTANCE
+	for (size_t i = 0; i < CONFIG_INTC_NUM_INSTANCE; i++) {
+		if(dev == z_isr_offset_table[i].dev) {
+			return z_isr_offset_table[i].instance_id;
+		}
+	}
+	__ASSERT(false, "entry not found");
+	return UINT32_MAX;
+#else
+	ARG_UNUSED(dev);
+	return 0;
+#endif
+}
+
+/**
+ * @brief Get the corresponding offset for interrupt controller @a dev
+ *
+ * @param dev Interrupt controller device
+ *
+ * @return corresponding ISR offset in z_isr_offset_table, UINT32_MAX if not found
+*/
+static inline unsigned int z_get_instance_isr_offset_from_dev(const struct device *dev)
+{
+#ifdef CONFIG_INTC_MULTI_INSTANCE
+	for (size_t i = 0; i < CONFIG_INTC_NUM_INSTANCE; i++) {
+		if(dev == z_isr_offset_table[i].dev) {
+			return z_isr_offset_table[i].isr_offset;
+		}
+	}
+	__ASSERT(false, "entry not found");
+	return UINT32_MAX;
+#else
+	ARG_UNUSED(dev);
+	return 0;
+#endif
+}
 
 /** This interrupt gets put directly in the vector table */
 #define ISR_FLAG_DIRECT BIT(0)

--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -342,6 +342,15 @@ int arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
 				const void *parameter, uint32_t flags);
 
 /**
+ * Arch-specific hook to get the ISR offset for a IRQ
+ *
+ * @param irq IRQ number in its zephyr format
+ *
+ * @return ISR offset for @a irq
+*/
+unsigned int arch_irq_get_instance_isr_offset(unsigned int irq);
+
+/**
  * @def ARCH_IRQ_CONNECT(irq, pri, isr, arg, flags)
  *
  * @see IRQ_CONNECT()

--- a/tests/drivers/build_all/interrupt_controller/boards/qemu_riscv32_trig.overlay
+++ b/tests/drivers/build_all/interrupt_controller/boards/qemu_riscv32_trig.overlay
@@ -3,7 +3,7 @@
  /{
 	soc {
 		plic: interrupt-controller@c000000 {
-			riscv,trigger-reg-offset = < 0x00001080 >;
+			support-edge-interrupt;
 		};
 	};
 };

--- a/tests/drivers/build_all/interrupt_controller/src/main.c
+++ b/tests/drivers/build_all/interrupt_controller/src/main.c
@@ -4,16 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/devicetree.h>
-
-#ifdef CONFIG_PLIC_SUPPORTS_EDGE_IRQ
-BUILD_ASSERT(DT_PROP(DT_NODELABEL(plic), riscv_trigger_reg_offset) == 0x00001080,
-	     "the offset should be the value defined in the board dt overlay");
-#else
-BUILD_ASSERT(DT_PROP(DT_NODELABEL(plic), riscv_trigger_reg_offset) == 4224,
-	     "the offset should be the binding default value");
-#endif /* CONFIG_PLIC_SUPPORTS_EDGE_IRQ */
-
 int main(void)
 {
 	return 0;

--- a/tests/drivers/build_all/interrupt_controller/testcase.yaml
+++ b/tests/drivers/build_all/interrupt_controller/testcase.yaml
@@ -15,6 +15,4 @@ tests:
       - qemu_riscv64
     extra_args:
       DTC_OVERLAY_FILE="./boards/qemu_riscv32_trig.overlay;./boards/qemu_riscv64_trig.overlay"
-    extra_configs:
-      - CONFIG_PLIC_SUPPORTS_EDGE_IRQ=y
     tags: plic


### PR DESCRIPTION
The idea of this implementation is to encode the interrupt controller(`INTC`) instance-id into the of `uint32_t` IRQN, and partition the `sw_isr_table`, so that the ISRs for IRQN of different `INTC` can be installed into different areas.

User needs to specify the instance-id of an `INTC` in the devicetree and the ISR offset for that instance in the Kconfig. Currently, maximum 2 bits of the `uint32_t` IRQN can be used to represent the instance-id, supporting up to 4 `INTC`s.

For statically connected IRQ, the `gen_isr_tables.py` will get the IRQN from the devicetree, extract the instance-id info from it and offset the resulting isr table index by `INTC_ID_{instance-id}_OFFSET`. For dynamically connected IRQ, the work is done in `z_get_sw_isr_table_idx` using a build-time generated LUT in `zephyr/arch/common/isr_tables.c`.

For an `INTC` to support this feature, driver functions that use the Zephyr-defined format of the `irq` number can get the encoded instance-id using `irq_get_instance_index` and the corresponding device using `z_get_instance_device`. The `instance-id` info can be stripped from the `irq` number using `irq_strip_instance_index`, so other existing operations with `irq` number remain the same.

___

- [ ] should we encode the instance-id in the LSB instead? That probably would make the maths simpler and probably more intuitive (`[instance] -> [L1] -> [L2] -> [L3]`)
- [ ] No RISCV QEMU machine has 2 PLIC instances to do runtime test
- [ ] Is there anything that we can do in `gen_defines.py` to encode the instance ID automatically?