### PR TITLE
fix to the HAL_API_V2 to get PTP to work in STM32H5

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 1bc72c299d0365c0ee2575a97918b22df0899e10
+      revision: 89ef0a3383edebf661073073bcdf6e2836fe90ee
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
In the HAL_ETH_ReadData function where it checks for the last descriptor, 
I added a checked if the TSA bit was set in DESC1 If the TSA bit is set then have a 
peak at the context descriptor which should be the one after the last descriptor
If the CTXT bit is set in the context descriptor then extract the timestamps