### PR TITLE
samples: mgmt: mcumgr: smp_svr: Add sysbuild file

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/sysbuild.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sysbuild.conf
@@ -1,0 +1,2 @@
+# Enable MCUboot bootloader support
+SB_CONFIG_BOOTLOADER_MCUBOOT=y


### PR DESCRIPTION
Adds a sysbuild file which includes MCUboot, as the sample is dependent upon it.