### PR TITLE
west: bossac: handle stty from coreutils on macOS

### DIFF
--- a/scripts/west_commands/runners/bossac.py
+++ b/scripts/west_commands/runners/bossac.py
@@ -149,12 +149,19 @@ class BossacBinaryRunner(ZephyrBinaryRunner):
 
         return None
 
+    def is_gnu_coreutils_stty(self):
+        try:
+            result = subprocess.run(['stty', '--version'], capture_output=True, text=True, check=True)
+            return 'coreutils' in result.stdout
+        except subprocess.CalledProcessError:
+            return False
+
     def set_serial_config(self):
         if platform.system() == 'Linux' or platform.system() == 'Darwin':
             self.require('stty')
 
             # GNU coreutils uses a capital F flag for 'file'
-            flag = '-F' if platform.system() == 'Linux' else '-f'
+            flag = '-F' if self.is_gnu_coreutils_stty() else '-f'
 
             if self.is_extended_samba_protocol():
                 self.speed = '1200'


### PR DESCRIPTION
There might be situations where people are running the coreutils version of stty on macOS instead of the Darwin version, hence the need for being smarter at detecting when that might be the case