### PR TITLE
soc/arm/silabs_exx32: select missing `CONFIG_SOC_GECKO_SERIESx`

### DIFF
--- a/soc/arm/silabs_exx32/Kconfig
+++ b/soc/arm/silabs_exx32/Kconfig
@@ -21,11 +21,11 @@ config SOC_PART_NUMBER
 	  that you should not set directly. The part number selection choice defines
 	  the default value for this string.
 
-config SOC_GECKO_SERIES2
+config SOC_GECKO_SERIES0
 	bool
 	help
-	  Set if we're building for Gecko Series 2 SoC.
-	  This is equivalent of _SILICON_LABS_32B_SERIES_2 definition in HAL
+	  Set if we're building for Gecko Series 0 SoC.
+	  This is equivalent of _SILICON_LABS_32B_SERIES_0 definition in HAL
 	  code.
 
 config SOC_GECKO_SERIES1
@@ -33,6 +33,13 @@ config SOC_GECKO_SERIES1
 	help
 	  Set if we're building for Gecko Series 1 SoC.
 	  This is equivalent of _SILICON_LABS_32B_SERIES_1 definition in HAL
+	  code.
+
+config SOC_GECKO_SERIES2
+	bool
+	help
+	  Set if we're building for Gecko Series 2 SoC.
+	  This is equivalent of _SILICON_LABS_32B_SERIES_2 definition in HAL
 	  code.
 
 config SOC_GECKO_BURTC

--- a/soc/arm/silabs_exx32/efm32hg/Kconfig.series
+++ b/soc/arm/silabs_exx32/efm32hg/Kconfig.series
@@ -13,5 +13,6 @@ config SOC_SERIES_EFM32HG
 	select SOC_GECKO_CMU
 	select SOC_GECKO_GPIO
 	select HAS_PM
+	select SOC_GECKO_SERIES0
 	help
 	  Enable support for EFM32 Happy Gecko MCU series

--- a/soc/arm/silabs_exx32/efm32pg1b/Kconfig.series
+++ b/soc/arm/silabs_exx32/efm32pg1b/Kconfig.series
@@ -19,5 +19,6 @@ config SOC_SERIES_EFM32PG1B
 	select SOC_GECKO_EMU
 	select SOC_GECKO_GPIO
 	select HAS_PM
+	select SOC_GECKO_SERIES1
 	help
 	  Enable support for EFM32 PearlGecko MCU series

--- a/soc/arm/silabs_exx32/efm32wg/Kconfig.series
+++ b/soc/arm/silabs_exx32/efm32wg/Kconfig.series
@@ -15,5 +15,6 @@ config SOC_SERIES_EFM32WG
 	select SOC_GECKO_CMU
 	select SOC_GECKO_GPIO
 	select HAS_PM
+	select SOC_GECKO_SERIES0
 	help
 	  Enable support for EFM32 WonderGecko MCU series

--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 267cd0bb17cf3cd431633a40b6d37a981e78dcb7
+      revision: 32f35f1b3763b4d31021c656ff7cd4e7b192a97c
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
This PR:
* adds `CONFIG_SOC_GECKO_SERIES0` Kconfig option for Gecko Series 0 SoCs
* selects the proper `CONFIG_SOC_GECKO_SERIESx` option where it's currently missing