### PR TITLE
libc: malloc: Get SRAM base from linker instead of Kconfig symbol

### DIFF
--- a/lib/libc/common/source/stdlib/malloc.c
+++ b/lib/libc/common/source/stdlib/malloc.c
@@ -105,7 +105,7 @@ extern char _heap_sentry[];
 #    define HEAP_SIZE  ROUND_DOWN((POINTER_TO_UINT(_heap_sentry) - HEAP_BASE), HEAP_ALIGN)
 #   else
 #    define HEAP_SIZE	ROUND_DOWN((KB((size_t) CONFIG_SRAM_SIZE) -	\
-		((size_t) HEAP_BASE - (size_t) CONFIG_SRAM_BASE_ADDRESS)), HEAP_ALIGN)
+		((size_t) HEAP_BASE - (size_t) POINTER_TO_UINT(&_image_ram_start))), HEAP_ALIGN)
 #   endif /* else CONFIG_XTENSA */
 
 #  endif /* else CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE > 0 */


### PR DESCRIPTION
Use _image_ram_start to use the Kconfig CONFIG_SRAM_BASE_ADDRESS symbol to calculate the HEAP size.