### PR TITLE
net: lib: lwm2m: Use int16_t for signal quality

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_connmon.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_connmon.c
@@ -93,7 +93,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 /* resource state variables */
 static int8_t net_bearer;
 static int16_t rss;
-static uint8_t link_quality;
+static int16_t link_quality;
 static uint32_t cellid;
 static uint16_t mnc;
 static uint16_t mcc;
@@ -113,7 +113,7 @@ static struct lwm2m_engine_obj_field fields[] = {
 	OBJ_FIELD_DATA(CONNMON_NETWORK_BEARER_ID, R, U8),
 	OBJ_FIELD_DATA(CONNMON_AVAIL_NETWORK_BEARER_ID, R, U8),
 	OBJ_FIELD_DATA(CONNMON_RADIO_SIGNAL_STRENGTH, R, S16),
-	OBJ_FIELD_DATA(CONNMON_LINK_QUALITY, R, U8),
+	OBJ_FIELD_DATA(CONNMON_LINK_QUALITY, R, S16),
 	OBJ_FIELD_DATA(CONNMON_IP_ADDRESSES, R, STRING),
 	OBJ_FIELD_DATA(CONNMON_ROUTER_IP_ADDRESSES, R_OPT, STRING),
 	OBJ_FIELD_DATA(CONNMON_LINK_UTILIZATION, R_OPT, U8),


### PR DESCRIPTION
RSRQ is the ratio between send and received signal strength and usually understood/expected to be represented as a ratio in dB and as such always has a negative range. So to allow RSRQ to be represented correctly the resource must allow negative values, but currently it's limited to unsigned 8bit integers.

Fixes [#62809](https://github.com/zephyrproject-rtos/zephyr/issues/62809)