### PR TITLE
tests: fix some test depencencies and metadata of boards

### DIFF
--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.yaml
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.yaml
@@ -19,6 +19,7 @@ supported:
   - adc
   - pwm
   - counter
+  - spi
 testing:
   binaries:
     - spi_image.bin

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.yaml
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.yaml
@@ -13,6 +13,7 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_spi
+  - arduino_serial
   - uart
   - gpio
   - i2c

--- a/samples/drivers/w1/scanner/sample.yaml
+++ b/samples/drivers/w1/scanner/sample.yaml
@@ -37,7 +37,8 @@ tests:
         - "Number of devices found on bus: .*"
       fixture: w1_scanner_ds2485
   samples.drivers.w1.scanner.w1_serial:
-    depends_on: arduino_serial
+    depends_on:
+      - arduino_serial
     extra_args: DTC_OVERLAY_FILE=w1_serial.overlay
     platform_allow:
       - nrf52840dk_nrf52840

--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -69,4 +69,4 @@ tests:
     platform_allow: frdm_k64f
     extra_args: CONF_FILE="prj_percepio.conf"
     modules:
-      - TraceRecorderSource
+      - percepio

--- a/tests/drivers/dma/chan_blen_transfer/testcase.yaml
+++ b/tests/drivers/dma/chan_blen_transfer/testcase.yaml
@@ -1,15 +1,17 @@
 tests:
   drivers.dma.chan_blen_transfer:
     min_ram: 16
-    depends_on: dma
+    depends_on:
+      - dma
     tags:
-      - drivers
       - dma
     filter: dt_nodelabel_enabled("test_dma0")
   drivers.dma.chan_blen_transfer.low_footprint:
-    min_ram: 6
-    depends_on: dma
-      - drivers
+    tags:
+      - dma
+    min_ram: 12
+    depends_on:
       - dma
     filter: dt_nodelabel_enabled("test_dma0")
-    platform_allow: nucleo_c031c6
+    platform_allow:
+      - nucleo_c031c6

--- a/tests/drivers/uart/uart_emul/testcase.yaml
+++ b/tests/drivers/uart/uart_emul/testcase.yaml
@@ -3,7 +3,6 @@ common:
     - drivers
     - uart
   harness: ztest
-  depends_on: uart_emul
 tests:
   drivers.uart_emul.polling:
     platform_allow: qemu_x86


### PR DESCRIPTION
- tests: uart_emul: remove hardware dependency
- tests: dma/chan_blen_transfer: fix hardware dependency and syntax
- tests: tracing: TraceRecorderSource was renamed to percepio
- boards: mec172xevb_assy6906: add spi as supported
- boards: nucleo_h753zi: add watchdog as supported
- boards: nucleo_g0b1re: add arduino_serial as supported
