### PR TITLE
dts: bindings: can: deprecate advanced CAN timing properties

### DIFF
--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -13,13 +13,22 @@ properties:
     description: Resynchronization jump width (ISO 11898-1)
   prop-seg:
     type: int
-    description: Time quantums of propagation segment (ISO 11898-1)
+    deprecated: true
+    description: |
+      Time quantums of propagation segment (ISO 11898-1). Deprecated in favor of setting advanced
+      timing parameters from the application.
   phase-seg1:
     type: int
-    description: Time quantums of phase buffer 1 segment (ISO 11898-1)
+    deprecated: true
+    description: |
+      Time quantums of phase buffer 1 segment (ISO 11898-1). Deprecated in favor of setting advanced
+      timing parameters from the application.
   phase-seg2:
     type: int
-    description: Time quantums of phase buffer 2 segment (ISO 11898-1)
+    deprecated: true
+    description: |
+      Time quantums of phase buffer 2 segment (ISO 11898-1). Deprecated in favor of setting advanced
+      timing parameters from the application.
   sample-point:
     type: int
     description: >

--- a/dts/bindings/can/can-fd-controller.yaml
+++ b/dts/bindings/can/can-fd-controller.yaml
@@ -13,13 +13,22 @@ properties:
     description: Resynchronization jump width for the data phase. (ISO11898-1:2015)
   prop-seg-data:
     type: int
-    description: Time quantums of propagation segment for the data phase. (ISO11898-1:2015)
+    deprecated: true
+    description: |
+      Time quantums of propagation segment for the data phase (ISO11898-1:2015). Deprecated in favor
+      of setting advanced timing parameters from the application.
   phase-seg1-data:
     type: int
-    description: Time quantums of phase buffer 1 segment for the data phase. (ISO11898-1:2015)
+    deprecated: true
+    description: |
+      Time quantums of phase buffer 1 segment for the data phase (ISO11898-1:2015). Deprecated in
+      favor of setting advanced timing parameters from the application.
   phase-seg2-data:
     type: int
-    description: Time quantums of phase buffer 2 segment for the data phase. (ISO11898-1:2015)
+    deprecated: true
+    description: |
+      Time quantums of phase buffer 2 segment for the data phase (ISO11898-1:2015). Deprecated in
+      favor of setting advanced timing parameters from the application.
   sample-point-data:
     type: int
     description: >


### PR DESCRIPTION
Deprecate the advanced CAN timing devicetree properties in favor of setting advanced timing parameters from application code.

The advanced timing properties are giving in number of time quanta (Tq) and requires reverse-calculation to find a suitable CAN clock divider. The resulting bitrate error is compared against a threshold in the driver initialization code, but the application is not able to retrieve it.

Forcing applications to use the CAN timing APIs directly instead makes it up to the application to determine if the bitrate error is acceptable or not.

The deprecated properties are:
- prop-seg
- phase-seg1
- phase-seg2
- prop-seg-data
- phase-seg1-data
- phase-seg2-data