### PR TITLE
twister: pytest: Fix problems with no prompt in tests with shell

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -250,6 +250,7 @@ class HardwareAdapter(DeviceAdapter):
         super()._clear_internal_resources()
         self._serial_connection = None
         self._serial_pty_proc = None
+        self._serial_buffer.clear()
 
     @staticmethod
     def _run_custom_script(script_path: str | Path, timeout: float) -> None:

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/shell.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/shell.py
@@ -57,7 +57,7 @@ class Shell:
         timeout = timeout or self.base_timeout
         command_ext = f'{command}\n\n'
         regex_prompt = re.escape(self.prompt)
-        regex_command = f'{regex_prompt}.*{command}'
+        regex_command = f'.*{command}'
         self._device.clear_buffer()
         self._device.write(command_ext.encode())
         lines: list[str] = []


### PR DESCRIPTION
Only impacts on twister-pytest scenarios.
`exec_command` is waiting for the prompt message, but in some cases, e.g. after resetting the DUT, prompt can be followed by another strings. Solution is to clear internal serial buffer and to not request the prompt string before executing a command.