### PR TITLE
dts: efm32_pg_1b: add pin-controller binding

### DIFF
--- a/dts/arm/silabs/efm32_pg_1b.dtsi
+++ b/dts/arm/silabs/efm32_pg_1b.dtsi
@@ -139,6 +139,13 @@
 				#gpio-cells = <2>;
 				status = "disabled";
 			};
+			pinctrl: pin-controller {
+				/* Pin controller is a "virtual" device since SiLabs SoCs do pin
+				 * control in a distributed way (GPIO registers and PSEL
+				 * registers on each peripheral).
+				 */
+				 compatible = "silabs,gecko-pinctrl";
+			};
 		};
 
                 wdog0: wdog@40052000 {


### PR DESCRIPTION
One more EFM fallouts, hopefully it's the last one, ran this:

~$ for b in boards/arm/ef*/*_defconfig; do west build -p -b $( basename $b | sed 's/_defconfig//' ) samples/basic/blinky; done~
`$ for b in $( west boards | grep ef ); do west build -p -b $b samples/basic/blinky; done`

and they all build so hopefully we covered all of them.

---

This platform (SOC_SERIES_EFM32PG1B) is also using SOC_GECKO_SERIES1 and needs a pinctrl device defined to build the gecko-uart driver successfully.