### PR TITLE
usbc: fix conflicting Kconfigs for USB-C related init priority

### DIFF
--- a/drivers/usb_c/tcpc/Kconfig
+++ b/drivers/usb_c/tcpc/Kconfig
@@ -10,8 +10,8 @@ menuconfig USBC_TCPC_DRIVER
 
 if USBC_TCPC_DRIVER
 
-config USBC_INIT_PRIORITY
-	int "USBC driver init priority"
+config USBC_TCPC_INIT_PRIORITY
+	int "USB-C TCPC driver init priority"
 	default 80
 	help
 	  USB-C device driver initialization priority.

--- a/drivers/usb_c/tcpc/ucpd_stm32.c
+++ b/drivers/usb_c/tcpc/ucpd_stm32.c
@@ -1500,7 +1500,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 0,
 			      &drv_data_##inst,						\
 			      &drv_config_##inst,					\
 			      POST_KERNEL,						\
-			      CONFIG_USBC_INIT_PRIORITY,				\
+			      CONFIG_USBC_TCPC_INIT_PRIORITY,				\
 			      &driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(TCPC_DRIVER_INIT)

--- a/drivers/usb_c/vbus/Kconfig
+++ b/drivers/usb_c/vbus/Kconfig
@@ -10,6 +10,12 @@ menuconfig USBC_VBUS_DRIVER
 
 if USBC_VBUS_DRIVER
 
+config USBC_VBUS_INIT_PRIORITY
+	int "USB-C VBUS driver init priority"
+	default 85
+	help
+	  Initialization priority of the USB-C VBUS measurement drivers in POST_KERNEL.
+
 source "drivers/usb_c/vbus/Kconfig.usbc_vbus_adc"
 
 endif # USBC_VBUS_DRIVER

--- a/drivers/usb_c/vbus/usbc_vbus_adc.c
+++ b/drivers/usb_c/vbus/usbc_vbus_adc.c
@@ -218,7 +218,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 0,
 			      &drv_data_##inst,						\
 			      &drv_config_##inst,					\
 			      POST_KERNEL,						\
-			      CONFIG_USBC_INIT_PRIORITY,				\
+			      CONFIG_USBC_VBUS_INIT_PRIORITY,				\
 			      &driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(DRIVER_INIT)

--- a/subsys/usb/usb_c/Kconfig
+++ b/subsys/usb/usb_c/Kconfig
@@ -14,11 +14,13 @@ menuconfig USBC_STACK
 
 if USBC_STACK
 
-config USBC_INIT_PRIORITY
-	int "USB-C initialization priority"
+config USBC_STACK_INIT_PRIORITY
+	int "USB-C stack init priority"
 	default 90
 	help
 	  Initialization priority of the USB-C connector driver in POST_KERNEL.
+	  This driver must be initialized after devices referenced by USB-C connectors
+	  like VBUS and TCPC.
 
 config USBC_THREAD_PRIORITY
 	int "USB-C thread priority"

--- a/subsys/usb/usb_c/usbc_stack.c
+++ b/subsys/usb/usb_c/usbc_stack.c
@@ -83,7 +83,7 @@ static ALWAYS_INLINE void usbc_handler(void *port_dev)
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, &usbc_subsys_init, NULL, &usbc_port_data_##inst,               \
 			      &usbc_port_config_##inst, POST_KERNEL,                               \
-			      CONFIG_USBC_INIT_PRIORITY, NULL);
+			      CONFIG_USBC_STACK_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(USBC_SUBSYS_INIT)
 


### PR DESCRIPTION
There was a new Kconfig for USB-C init priority that is conflicting with currently used Kconfig for init of VBUS and TCPC. This commit changes the names to more specific related to the subsystem they belong to.