### PR TITLE
fuel_gauge: Add fuel_guage_get_prop/s()

### DIFF
--- a/doc/hardware/peripherals/fuel_gauge.rst
+++ b/doc/hardware/peripherals/fuel_gauge.rst
@@ -20,8 +20,9 @@ Fundamentally, a property is a quantity that a fuel gauge device can measure.
 Fuel gauges typically support multiple properties, such as temperature readings of the battery-pack
 or present-time current/voltage.
 
-Properties are fetched using a client allocated array of :c:struct:`fuel_gauge_property`.  This
-array is then populated by values as according to its `property_type` field.
+Properties are fetched one at a time using a client allocated :c:struct:`fuel_gauge_property` or
+fetched all at once using a client allocated array of :c:struct:`fuel_gauge_property`. Each
+:c:struct:`fuel_gauge_property` is populated by values according to its `property_type` field.
 
 Battery Cutoff
 ==============

--- a/doc/hardware/peripherals/fuel_gauge.rst
+++ b/doc/hardware/peripherals/fuel_gauge.rst
@@ -20,9 +20,11 @@ Fundamentally, a property is a quantity that a fuel gauge device can measure.
 Fuel gauges typically support multiple properties, such as temperature readings of the battery-pack
 or present-time current/voltage.
 
-Properties are fetched one at a time using a client allocated :c:struct:`fuel_gauge_property` or
-fetched all at once using a client allocated array of :c:struct:`fuel_gauge_property`. Each
-:c:struct:`fuel_gauge_property` is populated by values according to its `property_type` field.
+Properties are fetched by the client one at a time using :c:func:`fuel_gauge_get_prop`, or fetched
+in a batch using :c:func:`fuel_gauge_get_props`.
+
+Properties are set by the client one at a time using :c:func:`fuel_gauge_set_prop`, or set in a
+batch using :c:func:`fuel_gauge_set_props`.
 
 Battery Cutoff
 ==============

--- a/drivers/fuel_gauge/bq27z746/bq27z746.c
+++ b/drivers/fuel_gauge/bq27z746/bq27z746.c
@@ -260,22 +260,6 @@ static int bq27z746_set_prop(const struct device *dev, struct fuel_gauge_propert
 	return rc;
 }
 
-static int bq27z746_set_props(const struct device *dev, struct fuel_gauge_property *props,
-			      size_t len)
-{
-	int err_count = 0;
-
-	for (int i = 0; i < len; i++) {
-		int ret = bq27z746_set_prop(dev, props + i);
-
-		err_count += ret ? 1 : 0;
-	}
-
-	err_count = (err_count == len) ? -1 : err_count;
-
-	return err_count;
-}
-
 static int bq27z746_init(const struct device *dev)
 {
 	const struct bq27z746_config *cfg;
@@ -292,7 +276,7 @@ static int bq27z746_init(const struct device *dev)
 
 static const struct fuel_gauge_driver_api bq27z746_driver_api = {
 	.get_property = &bq27z746_get_prop,
-	.set_property = &bq27z746_set_props,
+	.set_property = &bq27z746_set_prop,
 	.get_buffer_property = &bq27z746_get_buffer_prop,
 };
 

--- a/drivers/fuel_gauge/bq27z746/bq27z746.c
+++ b/drivers/fuel_gauge/bq27z746/bq27z746.c
@@ -192,8 +192,6 @@ static int bq27z746_get_prop(const struct device *dev, struct fuel_gauge_propert
 		rc = -ENOTSUP;
 	}
 
-	prop->status = rc;
-
 	return rc;
 }
 
@@ -232,7 +230,6 @@ static int bq27z746_get_buffer_prop(const struct device *dev,
 		rc = -ENOTSUP;
 	}
 
-	prop->status = rc;
 	return rc;
 }
 
@@ -254,8 +251,6 @@ static int bq27z746_set_prop(const struct device *dev, struct fuel_gauge_propert
 	default:
 		rc = -ENOTSUP;
 	}
-
-	prop->status = rc;
 
 	return rc;
 }

--- a/drivers/fuel_gauge/bq27z746/bq27z746.c
+++ b/drivers/fuel_gauge/bq27z746/bq27z746.c
@@ -260,22 +260,6 @@ static int bq27z746_set_prop(const struct device *dev, struct fuel_gauge_propert
 	return rc;
 }
 
-static int bq27z746_get_props(const struct device *dev, struct fuel_gauge_property *props,
-			      size_t len)
-{
-	int err_count = 0;
-
-	for (int i = 0; i < len; i++) {
-		int ret = bq27z746_get_prop(dev, props + i);
-
-		err_count += ret ? 1 : 0;
-	}
-
-	err_count = (err_count == len) ? -1 : err_count;
-
-	return err_count;
-}
-
 static int bq27z746_set_props(const struct device *dev, struct fuel_gauge_property *props,
 			      size_t len)
 {
@@ -307,7 +291,7 @@ static int bq27z746_init(const struct device *dev)
 }
 
 static const struct fuel_gauge_driver_api bq27z746_driver_api = {
-	.get_property = &bq27z746_get_props,
+	.get_property = &bq27z746_get_prop,
 	.set_property = &bq27z746_set_props,
 	.get_buffer_property = &bq27z746_get_buffer_prop,
 };

--- a/drivers/fuel_gauge/bq27z746/bq27z746.c
+++ b/drivers/fuel_gauge/bq27z746/bq27z746.c
@@ -109,84 +109,85 @@ static int bq27z746_read_mac(const struct device *dev, uint16_t cmd, uint8_t *da
 	return ret;
 }
 
-static int bq27z746_get_prop(const struct device *dev, struct fuel_gauge_property *prop)
+static int bq27z746_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
+			     union fuel_gauge_prop_val *val)
 {
 	int rc = 0;
-	uint16_t val = 0;
+	uint16_t tmp_val = 0;
 
 	/*
 	 * Possibly negative values must be cast from uint16 to int16 first to
 	 * then correctly end up in the wider datatypes of `prop`.
 	 */
 
-	switch (prop->property_type) {
+	switch (prop) {
 	case FUEL_GAUGE_AVG_CURRENT:
-		rc = bq27z746_read16(dev, BQ27Z746_AVERAGECURRENT, &val);
-		prop->value.avg_current = (int16_t)val * 1000;
+		rc = bq27z746_read16(dev, BQ27Z746_AVERAGECURRENT, &tmp_val);
+		val->avg_current = (int16_t)tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_CYCLE_COUNT:
-		rc = bq27z746_read16(dev, BQ27Z746_CYCLECOUNT, &val);
-		prop->value.cycle_count = val * 100;
+		rc = bq27z746_read16(dev, BQ27Z746_CYCLECOUNT, &tmp_val);
+		val->cycle_count = tmp_val * 100;
 		break;
 	case FUEL_GAUGE_CURRENT:
-		rc = bq27z746_read16(dev, BQ27Z746_CURRENT, &val);
-		prop->value.current = (int16_t)val * 1000;
+		rc = bq27z746_read16(dev, BQ27Z746_CURRENT, &tmp_val);
+		val->current = (int16_t)tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_FULL_CHARGE_CAPACITY:
-		rc = bq27z746_read16(dev, BQ27Z746_FULLCHARGECAPACITY, &val);
-		prop->value.full_charge_capacity = val * 1000;
+		rc = bq27z746_read16(dev, BQ27Z746_FULLCHARGECAPACITY, &tmp_val);
+		val->full_charge_capacity = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_REMAINING_CAPACITY:
-		rc = bq27z746_read16(dev, BQ27Z746_REMAININGCAPACITY, &val);
-		prop->value.remaining_capacity = val * 1000;
+		rc = bq27z746_read16(dev, BQ27Z746_REMAININGCAPACITY, &tmp_val);
+		val->remaining_capacity = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_RUNTIME_TO_EMPTY:
-		rc = bq27z746_read16(dev, BQ27Z746_AVERAGETIMETOEMPTY, &val);
-		prop->value.runtime_to_empty = val;
+		rc = bq27z746_read16(dev, BQ27Z746_AVERAGETIMETOEMPTY, &tmp_val);
+		val->runtime_to_empty = tmp_val;
 		break;
 	case FUEL_GAUGE_RUNTIME_TO_FULL:
-		rc = bq27z746_read16(dev, BQ27Z746_AVERAGETIMETOFULL, &val);
-		prop->value.runtime_to_full = val;
+		rc = bq27z746_read16(dev, BQ27Z746_AVERAGETIMETOFULL, &tmp_val);
+		val->runtime_to_full = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_MFR_ACCESS:
-		rc = bq27z746_read16(dev, BQ27Z746_MANUFACTURERACCESS, &val);
-		prop->value.sbs_mfr_access_word = val;
+		rc = bq27z746_read16(dev, BQ27Z746_MANUFACTURERACCESS, &tmp_val);
+		val->sbs_mfr_access_word = tmp_val;
 		break;
 	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
-		rc = bq27z746_read16(dev, BQ27Z746_RELATIVESTATEOFCHARGE, &val);
-		prop->value.relative_state_of_charge = val;
+		rc = bq27z746_read16(dev, BQ27Z746_RELATIVESTATEOFCHARGE, &tmp_val);
+		val->relative_state_of_charge = tmp_val;
 		break;
 	case FUEL_GAUGE_TEMPERATURE:
-		rc = bq27z746_read16(dev, BQ27Z746_TEMPERATURE, &val);
-		prop->value.temperature = val;
+		rc = bq27z746_read16(dev, BQ27Z746_TEMPERATURE, &tmp_val);
+		val->temperature = tmp_val;
 		break;
 	case FUEL_GAUGE_VOLTAGE:
-		rc = bq27z746_read16(dev, BQ27Z746_VOLTAGE, &val);
-		prop->value.voltage = val * 1000;
+		rc = bq27z746_read16(dev, BQ27Z746_VOLTAGE, &tmp_val);
+		val->voltage = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE:
-		rc = bq27z746_read16(dev, BQ27Z746_ATRATE, &val);
-		prop->value.sbs_at_rate = (int16_t)val;
+		rc = bq27z746_read16(dev, BQ27Z746_ATRATE, &tmp_val);
+		val->sbs_at_rate = (int16_t)tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY:
-		rc = bq27z746_read16(dev, BQ27Z746_ATRATETIMETOEMPTY, &val);
-		prop->value.sbs_at_rate_time_to_empty = val;
+		rc = bq27z746_read16(dev, BQ27Z746_ATRATETIMETOEMPTY, &tmp_val);
+		val->sbs_at_rate_time_to_empty = tmp_val;
 		break;
 	case FUEL_GAUGE_CHARGE_VOLTAGE:
-		rc = bq27z746_read16(dev, BQ27Z746_CHARGINGVOLTAGE, &val);
-		prop->value.chg_voltage = val;
+		rc = bq27z746_read16(dev, BQ27Z746_CHARGINGVOLTAGE, &tmp_val);
+		val->chg_voltage = tmp_val;
 		break;
 	case FUEL_GAUGE_CHARGE_CURRENT:
-		rc = bq27z746_read16(dev, BQ27Z746_CHARGINGCURRENT, &val);
-		prop->value.chg_current = val;
+		rc = bq27z746_read16(dev, BQ27Z746_CHARGINGCURRENT, &tmp_val);
+		val->chg_current = tmp_val;
 		break;
 	case FUEL_GAUGE_STATUS:
-		rc = bq27z746_read16(dev, BQ27Z746_BATTERYSTATUS, &val);
-		prop->value.fg_status = val;
+		rc = bq27z746_read16(dev, BQ27Z746_BATTERYSTATUS, &tmp_val);
+		val->fg_status = tmp_val;
 		break;
 	case FUEL_GAUGE_DESIGN_CAPACITY:
-		rc = bq27z746_read16(dev, BQ27Z746_DESIGNCAPACITY, &val);
-		prop->value.design_cap = val;
+		rc = bq27z746_read16(dev, BQ27Z746_DESIGNCAPACITY, &tmp_val);
+		val->design_cap = tmp_val;
 		break;
 	default:
 		rc = -ENOTSUP;
@@ -196,12 +197,12 @@ static int bq27z746_get_prop(const struct device *dev, struct fuel_gauge_propert
 }
 
 static int bq27z746_get_buffer_prop(const struct device *dev,
-				    struct fuel_gauge_buffer_property *prop, void *dst,
+				    fuel_gauge_prop_t property_type, void *dst,
 				    size_t dst_len)
 {
 	int rc = 0;
 
-	switch (prop->property_type) {
+	switch (property_type) {
 	case FUEL_GAUGE_MANUFACTURER_NAME:
 		if (dst_len == sizeof(struct sbs_gauge_manufacturer_name)) {
 			rc = bq27z746_read_mac(dev, BQ27Z746_MAC_CMD_MANUFACTURER_NAME,
@@ -233,20 +234,20 @@ static int bq27z746_get_buffer_prop(const struct device *dev,
 	return rc;
 }
 
-static int bq27z746_set_prop(const struct device *dev, struct fuel_gauge_property *prop)
+static int bq27z746_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
+			     union fuel_gauge_prop_val val)
 {
 	int rc = 0;
-	uint16_t val = 0;
+	uint16_t tmp_val = 0;
 
-	switch (prop->property_type) {
+	switch (prop) {
 	case FUEL_GAUGE_SBS_MFR_ACCESS:
-		rc = bq27z746_write16(dev, BQ27Z746_MANUFACTURERACCESS,
-				      prop->value.sbs_mfr_access_word);
-		prop->value.sbs_mfr_access_word = val;
+		rc = bq27z746_write16(dev, BQ27Z746_MANUFACTURERACCESS, val.sbs_mfr_access_word);
+		val.sbs_mfr_access_word = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE:
-		rc = bq27z746_write16(dev, BQ27Z746_ATRATE, prop->value.sbs_at_rate);
-		prop->value.sbs_at_rate = val;
+		rc = bq27z746_write16(dev, BQ27Z746_ATRATE, val.sbs_at_rate);
+		val.sbs_at_rate = tmp_val;
 		break;
 	default:
 		rc = -ENOTSUP;

--- a/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
+++ b/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
@@ -8,72 +8,71 @@
 #include <zephyr/syscall_handler.h>
 #include <zephyr/drivers/fuel_gauge.h>
 
-static inline int z_vrfy_fuel_gauge_get_prop(const struct device *dev,
-					     struct fuel_gauge_property *prop)
+static inline int z_vrfy_fuel_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
+					     union fuel_gauge_prop_val *val)
 {
-	struct fuel_gauge_property k_prop;
+	union fuel_gauge_prop_val k_val;
 
 	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, get_property));
 
-	Z_OOPS(z_user_from_copy(&k_prop, prop, sizeof(struct fuel_gauge_property)));
+	Z_OOPS(z_user_from_copy(&k_val, val, sizeof(union fuel_gauge_prop_val)));
 
-	int ret = z_impl_fuel_gauge_get_prop(dev, &k_prop);
+	int ret = z_impl_fuel_gauge_get_prop(dev, prop, &k_val);
 
-	Z_OOPS(z_user_to_copy(prop, &k_prop, sizeof(struct fuel_gauge_property)));
+	Z_OOPS(z_user_to_copy(val, &k_val, sizeof(union fuel_gauge_prop_val)));
 
 	return ret;
 }
 
 #include <syscalls/fuel_gauge_get_prop_mrsh.c>
 
-static inline int z_vrfy_fuel_gauge_get_props(const struct device *dev,
-					      struct fuel_gauge_property *props, size_t props_len)
+static inline int z_vrfy_fuel_gauge_get_props(const struct device *dev, fuel_gauge_prop_t *props,
+					      union fuel_gauge_prop_val *vals, size_t len)
 {
-	struct fuel_gauge_property k_props[props_len];
+	union fuel_gauge_prop_val k_vals[len];
+	fuel_gauge_prop_t k_props[len];
 
 	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, get_property));
 
-	Z_OOPS(z_user_from_copy(k_props, props, props_len * sizeof(struct fuel_gauge_property)));
+	Z_OOPS(z_user_from_copy(k_vals, vals, len * sizeof(union fuel_gauge_prop_val)));
+	Z_OOPS(z_user_from_copy(k_props, props, len * sizeof(fuel_gauge_prop_t)));
 
-	int ret = z_impl_fuel_gauge_get_props(dev, k_props, props_len);
+	int ret = z_impl_fuel_gauge_get_props(dev, k_props, k_vals, len);
 
-	Z_OOPS(z_user_to_copy(props, k_props, props_len * sizeof(struct fuel_gauge_property)));
+	Z_OOPS(z_user_to_copy(vals, k_vals, len * sizeof(union fuel_gauge_prop_val)));
 
 	return ret;
 }
 
 #include <syscalls/fuel_gauge_get_props_mrsh.c>
 
-static inline int z_vrfy_fuel_gauge_set_prop(const struct device *dev,
-					     struct fuel_gauge_property *prop)
+static inline int z_vrfy_fuel_gauge_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
+					     union fuel_gauge_prop_val val)
 {
-	struct fuel_gauge_property k_prop;
-
 	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, set_property));
 
-	Z_OOPS(z_user_from_copy(&k_prop, prop, sizeof(struct fuel_gauge_property)));
-
-	int ret = z_impl_fuel_gauge_set_prop(dev, &k_prop);
-
-	Z_OOPS(z_user_to_copy(prop, &k_prop, sizeof(struct fuel_gauge_property)));
+	int ret = z_impl_fuel_gauge_set_prop(dev, prop, val);
 
 	return ret;
 }
 
 #include <syscalls/fuel_gauge_set_prop_mrsh.c>
 
-static inline int z_vrfy_fuel_gauge_set_props(const struct device *dev,
-					      struct fuel_gauge_property *props, size_t props_len)
+static inline int z_vrfy_fuel_gauge_set_props(const struct device *dev, fuel_gauge_prop_t *props,
+					      union fuel_gauge_prop_val *vals, size_t len)
 {
-	struct fuel_gauge_property k_props[props_len];
+	union fuel_gauge_prop_val k_vals[len];
+	fuel_gauge_prop_t k_props[len];
 
 	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, set_property));
 
-	Z_OOPS(z_user_from_copy(k_props, props, props_len * sizeof(struct fuel_gauge_property)));
+	Z_OOPS(z_user_from_copy(k_vals, vals, len * sizeof(union fuel_gauge_prop_val)));
+	Z_OOPS(z_user_from_copy(k_props, props, len * sizeof(fuel_gauge_prop_t)));
 
-	int ret = z_impl_fuel_gauge_set_props(dev, k_props, props_len);
+	int ret = z_impl_fuel_gauge_set_props(dev, k_props, k_vals, len);
 
-	Z_OOPS(z_user_to_copy(props, k_props, props_len * sizeof(struct fuel_gauge_property)));
+	/* We only copy back vals because props will never be modified */
+	Z_OOPS(z_user_to_copy(vals, k_vals, len * sizeof(union fuel_gauge_prop_val)));
 
 	return ret;
 }
@@ -81,22 +80,14 @@ static inline int z_vrfy_fuel_gauge_set_props(const struct device *dev,
 #include <syscalls/fuel_gauge_set_props_mrsh.c>
 
 static inline int z_vrfy_fuel_gauge_get_buffer_prop(const struct device *dev,
-						    struct fuel_gauge_buffer_property *prop,
-						    void *dst, size_t dst_len)
+						    fuel_gauge_prop_t prop, void *dst,
+						    size_t dst_len)
 {
-	struct fuel_gauge_buffer_property k_prop;
-
 	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, get_buffer_property));
-
-	Z_OOPS(z_user_from_copy(&k_prop, prop,
-				sizeof(struct fuel_gauge_buffer_property)));
 
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(dst, dst_len));
 
-	int ret = z_impl_fuel_gauge_get_buffer_prop(dev, &k_prop, dst, dst_len);
-
-	Z_OOPS(z_user_to_copy(prop, &k_prop,
-			      sizeof(struct fuel_gauge_buffer_property)));
+	int ret = z_impl_fuel_gauge_get_buffer_prop(dev, prop, dst, dst_len);
 
 	return ret;
 }

--- a/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
+++ b/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
@@ -9,24 +9,40 @@
 #include <zephyr/drivers/fuel_gauge.h>
 
 static inline int z_vrfy_fuel_gauge_get_prop(const struct device *dev,
-					     struct fuel_gauge_property *props,
-					     size_t props_len)
+					     struct fuel_gauge_property *prop)
+{
+	struct fuel_gauge_property k_prop;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, get_property));
+
+	Z_OOPS(z_user_from_copy(&k_prop, prop, sizeof(struct fuel_gauge_property)));
+
+	int ret = z_impl_fuel_gauge_get_prop(dev, &k_prop);
+
+	Z_OOPS(z_user_to_copy(prop, &k_prop, sizeof(struct fuel_gauge_property)));
+
+	return ret;
+}
+
+#include <syscalls/fuel_gauge_get_prop_mrsh.c>
+
+static inline int z_vrfy_fuel_gauge_get_props(const struct device *dev,
+					      struct fuel_gauge_property *props, size_t props_len)
 {
 	struct fuel_gauge_property k_props[props_len];
 
 	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, get_property));
 
-	Z_OOPS(z_user_from_copy(k_props, props,
-				props_len * sizeof(struct fuel_gauge_property)));
+	Z_OOPS(z_user_from_copy(k_props, props, props_len * sizeof(struct fuel_gauge_property)));
 
-	int ret = z_impl_fuel_gauge_get_prop(dev, k_props, props_len);
+	int ret = z_impl_fuel_gauge_get_props(dev, k_props, props_len);
 
 	Z_OOPS(z_user_to_copy(props, k_props, props_len * sizeof(struct fuel_gauge_property)));
 
 	return ret;
 }
 
-#include <syscalls/fuel_gauge_get_prop_mrsh.c>
+#include <syscalls/fuel_gauge_get_props_mrsh.c>
 
 static inline int z_vrfy_fuel_gauge_set_prop(const struct device *dev,
 					     struct fuel_gauge_property *props,

--- a/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
+++ b/drivers/fuel_gauge/fuel_gauge_syscall_handlers.c
@@ -45,24 +45,40 @@ static inline int z_vrfy_fuel_gauge_get_props(const struct device *dev,
 #include <syscalls/fuel_gauge_get_props_mrsh.c>
 
 static inline int z_vrfy_fuel_gauge_set_prop(const struct device *dev,
-					     struct fuel_gauge_property *props,
-					     size_t props_len)
+					     struct fuel_gauge_property *prop)
+{
+	struct fuel_gauge_property k_prop;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, set_property));
+
+	Z_OOPS(z_user_from_copy(&k_prop, prop, sizeof(struct fuel_gauge_property)));
+
+	int ret = z_impl_fuel_gauge_set_prop(dev, &k_prop);
+
+	Z_OOPS(z_user_to_copy(prop, &k_prop, sizeof(struct fuel_gauge_property)));
+
+	return ret;
+}
+
+#include <syscalls/fuel_gauge_set_prop_mrsh.c>
+
+static inline int z_vrfy_fuel_gauge_set_props(const struct device *dev,
+					      struct fuel_gauge_property *props, size_t props_len)
 {
 	struct fuel_gauge_property k_props[props_len];
 
 	Z_OOPS(Z_SYSCALL_DRIVER_FUEL_GAUGE(dev, set_property));
 
-	Z_OOPS(z_user_from_copy(k_props, props,
-				props_len * sizeof(struct fuel_gauge_property)));
+	Z_OOPS(z_user_from_copy(k_props, props, props_len * sizeof(struct fuel_gauge_property)));
 
-	int ret = z_impl_fuel_gauge_set_prop(dev, k_props, props_len);
+	int ret = z_impl_fuel_gauge_set_props(dev, k_props, props_len);
 
 	Z_OOPS(z_user_to_copy(props, k_props, props_len * sizeof(struct fuel_gauge_property)));
 
 	return ret;
 }
 
-#include <syscalls/fuel_gauge_set_prop_mrsh.c>
+#include <syscalls/fuel_gauge_set_props_mrsh.c>
 
 static inline int z_vrfy_fuel_gauge_get_buffer_prop(const struct device *dev,
 						    struct fuel_gauge_buffer_property *prop,

--- a/drivers/fuel_gauge/max17048/max17048.c
+++ b/drivers/fuel_gauge/max17048/max17048.c
@@ -175,23 +175,24 @@ static int max17048_init(const struct device *dev)
 /**
  * Get a single property from the fuel gauge
  */
-static int max17048_get_single_prop_impl(const struct device *dev, struct fuel_gauge_property *prop)
+static int max17048_get_single_prop_impl(const struct device *dev, fuel_gauge_prop_t prop,
+					 union fuel_gauge_prop_val *val)
 {
 	struct max17048_data *data = dev->data;
 	int rc = 0;
 
-	switch (prop->property_type) {
+	switch (prop) {
 	case FUEL_GAUGE_RUNTIME_TO_EMPTY:
-		prop->value.runtime_to_empty = data->time_to_empty;
+		val->runtime_to_empty = data->time_to_empty;
 		break;
 	case FUEL_GAUGE_RUNTIME_TO_FULL:
-		prop->value.runtime_to_full = data->time_to_full;
+		val->runtime_to_full = data->time_to_full;
 		break;
 	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
-		prop->value.relative_state_of_charge = data->charge;
+		val->relative_state_of_charge = data->charge;
 		break;
 	case FUEL_GAUGE_VOLTAGE:
-		prop->value.voltage = data->voltage;
+		val->voltage = data->voltage;
 		break;
 	default:
 		rc = -ENOTSUP;
@@ -203,7 +204,8 @@ static int max17048_get_single_prop_impl(const struct device *dev, struct fuel_g
 /**
  * Get properties from the fuel gauge
  */
-static int max17048_get_prop(const struct device *dev, struct fuel_gauge_property *prop)
+static int max17048_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
+			     union fuel_gauge_prop_val *val)
 {
 	struct max17048_data *data = dev->data;
 	int rc = max17048_percent(dev, &data->charge);
@@ -273,7 +275,7 @@ static int max17048_get_prop(const struct device *dev, struct fuel_gauge_propert
 		data->time_to_empty = 0;
 	}
 
-	ret = max17048_get_single_prop_impl(dev, prop);
+	ret = max17048_get_single_prop_impl(dev, prop, val);
 
 	return ret;
 }

--- a/drivers/fuel_gauge/max17048/max17048.c
+++ b/drivers/fuel_gauge/max17048/max17048.c
@@ -197,8 +197,6 @@ static int max17048_get_single_prop_impl(const struct device *dev, struct fuel_g
 		rc = -ENOTSUP;
 	}
 
-	prop->status = rc;
-
 	return rc;
 }
 

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -172,8 +172,6 @@ static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_proper
 		rc = -ENOTSUP;
 	}
 
-	prop->status = rc;
-
 	return rc;
 }
 
@@ -230,8 +228,6 @@ static int sbs_gauge_set_prop(const struct device *dev, struct fuel_gauge_proper
 		rc = -ENOTSUP;
 	}
 
-	prop->status = rc;
-
 	return rc;
 }
 
@@ -270,7 +266,6 @@ static int sbs_gauge_get_buffer_prop(const struct device *dev,
 		rc = -ENOTSUP;
 	}
 
-	prop->status = rc;
 	return rc;
 }
 

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -274,22 +274,6 @@ static int sbs_gauge_get_buffer_prop(const struct device *dev,
 	return rc;
 }
 
-static int sbs_gauge_set_props(const struct device *dev, struct fuel_gauge_property *props,
-			       size_t len)
-{
-	int err_count = 0;
-
-	for (int i = 0; i < len; i++) {
-		int ret = sbs_gauge_set_prop(dev, props + i);
-
-		err_count += ret ? 1 : 0;
-	}
-
-	err_count = (err_count == len) ? -1 : err_count;
-
-	return err_count;
-}
-
 /**
  * @brief initialize the fuel gauge
  *
@@ -311,7 +295,7 @@ static int sbs_gauge_init(const struct device *dev)
 
 static const struct fuel_gauge_driver_api sbs_gauge_driver_api = {
 	.get_property = &sbs_gauge_get_prop,
-	.set_property = &sbs_gauge_set_props,
+	.set_property = &sbs_gauge_set_prop,
 	.get_buffer_property = &sbs_gauge_get_buffer_prop,
 	.battery_cutoff = &sbs_gauge_do_battery_cutoff,
 };

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -274,22 +274,6 @@ static int sbs_gauge_get_buffer_prop(const struct device *dev,
 	return rc;
 }
 
-static int sbs_gauge_get_props(const struct device *dev, struct fuel_gauge_property *props,
-			       size_t len)
-{
-	int err_count = 0;
-
-	for (int i = 0; i < len; i++) {
-		int ret = sbs_gauge_get_prop(dev, props + i);
-
-		err_count += ret ? 1 : 0;
-	}
-
-	err_count = (err_count == len) ? -1 : err_count;
-
-	return err_count;
-}
-
 static int sbs_gauge_set_props(const struct device *dev, struct fuel_gauge_property *props,
 			       size_t len)
 {
@@ -326,7 +310,7 @@ static int sbs_gauge_init(const struct device *dev)
 }
 
 static const struct fuel_gauge_driver_api sbs_gauge_driver_api = {
-	.get_property = &sbs_gauge_get_props,
+	.get_property = &sbs_gauge_get_prop,
 	.set_property = &sbs_gauge_set_props,
 	.get_buffer_property = &sbs_gauge_get_buffer_prop,
 	.battery_cutoff = &sbs_gauge_do_battery_cutoff,

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -66,107 +66,108 @@ static int sbs_cmd_buffer_read(const struct device *dev, uint8_t reg_addr, char 
 	return 0;
 }
 
-static int sbs_gauge_get_prop(const struct device *dev, struct fuel_gauge_property *prop)
+static int sbs_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
+			      union fuel_gauge_prop_val *val)
 {
 	int rc = 0;
-	uint16_t val = 0;
+	uint16_t tmp_val = 0;
 
-	switch (prop->property_type) {
+	switch (prop) {
 	case FUEL_GAUGE_AVG_CURRENT:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AVG_CURRENT, &val);
-		prop->value.avg_current = val * 1000;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AVG_CURRENT, &tmp_val);
+		val->avg_current = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_CYCLE_COUNT:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CYCLE_COUNT, &val);
-		prop->value.cycle_count = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CYCLE_COUNT, &tmp_val);
+		val->cycle_count = tmp_val;
 		break;
 	case FUEL_GAUGE_CURRENT:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CURRENT, &val);
-		prop->value.current = val * 1000;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CURRENT, &tmp_val);
+		val->current = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_FULL_CHARGE_CAPACITY:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_FULL_CAPACITY, &val);
-		prop->value.full_charge_capacity = val * 1000;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_FULL_CAPACITY, &tmp_val);
+		val->full_charge_capacity = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_REMAINING_CAPACITY:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_CAPACITY, &val);
-		prop->value.remaining_capacity = val * 1000;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_CAPACITY, &tmp_val);
+		val->remaining_capacity = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_RUNTIME_TO_EMPTY:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_RUNTIME2EMPTY, &val);
-		prop->value.runtime_to_empty = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_RUNTIME2EMPTY, &tmp_val);
+		val->runtime_to_empty = tmp_val;
 		break;
 	case FUEL_GAUGE_RUNTIME_TO_FULL:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AVG_TIME2FULL, &val);
-		prop->value.runtime_to_full = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AVG_TIME2FULL, &tmp_val);
+		val->runtime_to_full = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_MFR_ACCESS:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_MANUFACTURER_ACCESS, &val);
-		prop->value.sbs_mfr_access_word = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_MANUFACTURER_ACCESS, &tmp_val);
+		val->sbs_mfr_access_word = tmp_val;
 		break;
 	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ASOC, &val);
-		prop->value.absolute_state_of_charge = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ASOC, &tmp_val);
+		val->absolute_state_of_charge = tmp_val;
 		break;
 	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_RSOC, &val);
-		prop->value.relative_state_of_charge = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_RSOC, &tmp_val);
+		val->relative_state_of_charge = tmp_val;
 		break;
 	case FUEL_GAUGE_TEMPERATURE:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_TEMP, &val);
-		prop->value.temperature = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_TEMP, &tmp_val);
+		val->temperature = tmp_val;
 		break;
 	case FUEL_GAUGE_VOLTAGE:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_VOLTAGE, &val);
-		prop->value.voltage = val * 1000;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_VOLTAGE, &tmp_val);
+		val->voltage = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_SBS_MODE:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_BATTERY_MODE, &val);
-		prop->value.sbs_mode = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_BATTERY_MODE, &tmp_val);
+		val->sbs_mode = tmp_val;
 		break;
 	case FUEL_GAUGE_CHARGE_CURRENT:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CHG_CURRENT, &val);
-		prop->value.chg_current = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CHG_CURRENT, &tmp_val);
+		val->chg_current = tmp_val;
 		break;
 	case FUEL_GAUGE_CHARGE_VOLTAGE:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CHG_VOLTAGE, &val);
-		prop->value.chg_voltage = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CHG_VOLTAGE, &tmp_val);
+		val->chg_voltage = tmp_val;
 		break;
 	case FUEL_GAUGE_STATUS:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_FLAGS, &val);
-		prop->value.fg_status = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_FLAGS, &tmp_val);
+		val->fg_status = tmp_val;
 		break;
 	case FUEL_GAUGE_DESIGN_CAPACITY:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_NOM_CAPACITY, &val);
-		prop->value.design_cap = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_NOM_CAPACITY, &tmp_val);
+		val->design_cap = tmp_val;
 		break;
 	case FUEL_GAUGE_DESIGN_VOLTAGE:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_DESIGN_VOLTAGE, &val);
-		prop->value.design_volt = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_DESIGN_VOLTAGE, &tmp_val);
+		val->design_volt = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AR, &val);
-		prop->value.sbs_at_rate = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AR, &tmp_val);
+		val->sbs_at_rate = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ARTTF, &val);
-		prop->value.sbs_at_rate_time_to_full = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ARTTF, &tmp_val);
+		val->sbs_at_rate_time_to_full = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ARTTE, &val);
-		prop->value.sbs_at_rate_time_to_empty = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_ARTTE, &tmp_val);
+		val->sbs_at_rate_time_to_empty = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE_OK:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AROK, &val);
-		prop->value.sbs_at_rate_ok = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AROK, &tmp_val);
+		val->sbs_at_rate_ok = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_CAPACITY_ALARM, &val);
-		prop->value.sbs_remaining_capacity_alarm = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_CAPACITY_ALARM, &tmp_val);
+		val->sbs_remaining_capacity_alarm = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM:
-		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_TIME_ALARM, &val);
-		prop->value.sbs_remaining_time_alarm = val;
+		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_REM_TIME_ALARM, &tmp_val);
+		val->sbs_remaining_time_alarm = tmp_val;
 		break;
 	default:
 		rc = -ENOTSUP;
@@ -194,35 +195,36 @@ static int sbs_gauge_do_battery_cutoff(const struct device *dev)
 	return rc;
 }
 
-static int sbs_gauge_set_prop(const struct device *dev, struct fuel_gauge_property *prop)
+static int sbs_gauge_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
+			      union fuel_gauge_prop_val val)
 {
 	int rc = 0;
-	uint16_t val = 0;
+	uint16_t tmp_val = 0;
 
-	switch (prop->property_type) {
+	switch (prop) {
 
 	case FUEL_GAUGE_SBS_MFR_ACCESS:
 		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_MANUFACTURER_ACCESS,
-				       prop->value.sbs_mfr_access_word);
-		prop->value.sbs_mfr_access_word = val;
+				       val.sbs_mfr_access_word);
+		val.sbs_mfr_access_word = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM:
 		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_REM_CAPACITY_ALARM,
-				       prop->value.sbs_remaining_capacity_alarm);
-		prop->value.sbs_remaining_capacity_alarm = val;
+				       val.sbs_remaining_capacity_alarm);
+		val.sbs_remaining_capacity_alarm = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_REMAINING_TIME_ALARM:
 		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_REM_TIME_ALARM,
-				       prop->value.sbs_remaining_time_alarm);
-		prop->value.sbs_remaining_time_alarm = val;
+				       val.sbs_remaining_time_alarm);
+		val.sbs_remaining_time_alarm = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_MODE:
-		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_BATTERY_MODE, prop->value.sbs_mode);
-		prop->value.sbs_mode = val;
+		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_BATTERY_MODE, val.sbs_mode);
+		val.sbs_mode = tmp_val;
 		break;
 	case FUEL_GAUGE_SBS_ATRATE:
-		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_AR, prop->value.sbs_at_rate);
-		prop->value.sbs_at_rate = val;
+		rc = sbs_cmd_reg_write(dev, SBS_GAUGE_CMD_AR, val.sbs_at_rate);
+		val.sbs_at_rate = tmp_val;
 		break;
 	default:
 		rc = -ENOTSUP;
@@ -232,12 +234,12 @@ static int sbs_gauge_set_prop(const struct device *dev, struct fuel_gauge_proper
 }
 
 static int sbs_gauge_get_buffer_prop(const struct device *dev,
-				    struct fuel_gauge_buffer_property *prop, void *dst,
+				    fuel_gauge_prop_t prop_type, void *dst,
 				    size_t dst_len)
 {
 	int rc = 0;
 
-	switch (prop->property_type) {
+	switch (prop_type) {
 	case FUEL_GAUGE_MANUFACTURER_NAME:
 		if (dst_len == sizeof(struct sbs_gauge_manufacturer_name)) {
 			rc = sbs_cmd_buffer_read(dev, SBS_GAUGE_CMD_MANUFACTURER_NAME, (char *)dst,

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -115,76 +115,65 @@ enum fuel_gauge_prop_type {
 
 typedef uint16_t fuel_gauge_prop_t;
 
-struct fuel_gauge_property {
-	/** Battery fuel gauge property to get */
-	fuel_gauge_prop_t property_type;
+/** Property field to value/type union */
+union fuel_gauge_prop_val {
+	/* Fields have the format: */
+	/* FUEL_GAUGE_PROPERTY_FIELD */
+	/* type property_field; */
 
-	/** Property field for getting */
-	union {
-		/* Fields have the format: */
-		/* FUEL_GAUGE_PROPERTY_FIELD */
-		/* type property_field; */
-
-		/* Dynamic Battery Info */
-		/** FUEL_GAUGE_AVG_CURRENT */
-		int avg_current;
-		/** FUEL_GAUGE_CHARGE_CUTOFF */
-		bool cutoff;
-		/** FUEL_GAUGE_CURRENT */
-		int current;
-		/** FUEL_GAUGE_CYCLE_COUNT */
-		uint32_t cycle_count;
-		/** FUEL_GAUGE_FLAGS */
-		uint32_t flags;
-		/** FUEL_GAUGE_FULL_CHARGE_CAPACITY */
-		uint32_t full_charge_capacity;
-		/** FUEL_GAUGE_REMAINING_CAPACITY */
-		uint32_t remaining_capacity;
-		/** FUEL_GAUGE_RUNTIME_TO_EMPTY */
-		uint32_t runtime_to_empty;
-		/** FUEL_GAUGE_RUNTIME_TO_FULL */
-		uint32_t runtime_to_full;
-		/** FUEL_GAUGE_SBS_MFR_ACCESS */
-		uint16_t sbs_mfr_access_word;
-		/** FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE */
-		uint8_t absolute_state_of_charge;
-		/** FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE */
-		uint8_t relative_state_of_charge;
-		/** FUEL_GAUGE_TEMPERATURE */
-		uint16_t temperature;
-		/** FUEL_GAUGE_VOLTAGE */
-		int voltage;
-		/** FUEL_GAUGE_SBS_MODE */
-		uint16_t sbs_mode;
-		/** FUEL_GAUGE_CHARGE_CURRENT */
-		uint16_t chg_current;
-		/** FUEL_GAUGE_CHARGE_VOLTAGE */
-		uint16_t chg_voltage;
-		/** FUEL_GAUGE_STATUS */
-		uint16_t fg_status;
-		/** FUEL_GAUGE_DESIGN_CAPACITY */
-		uint16_t design_cap;
-		/** FUEL_GAUGE_DESIGN_VOLTAGE */
-		uint16_t design_volt;
-		/** FUEL_GAUGE_SBS_ATRATE */
-		int16_t sbs_at_rate;
-		/** FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL */
-		uint16_t sbs_at_rate_time_to_full;
-		/** FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY	*/
-		uint16_t sbs_at_rate_time_to_empty;
-		/** FUEL_GAUGE_SBS_ATRATE_OK */
-		bool sbs_at_rate_ok;
-		/** FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM */
-		uint16_t sbs_remaining_capacity_alarm;
-		/** FUEL_GAUGE_SBS_REMAINING_TIME_ALARM */
-		uint16_t sbs_remaining_time_alarm;
-	} value;
-};
-
-/** Buffer properties are separated due to size */
-struct fuel_gauge_buffer_property {
-	/** Battery fuel gauge property to get */
-	fuel_gauge_prop_t property_type;
+	/* Dynamic Battery Info */
+	/** FUEL_GAUGE_AVG_CURRENT */
+	int avg_current;
+	/** FUEL_GAUGE_CHARGE_CUTOFF */
+	bool cutoff;
+	/** FUEL_GAUGE_CURRENT */
+	int current;
+	/** FUEL_GAUGE_CYCLE_COUNT */
+	uint32_t cycle_count;
+	/** FUEL_GAUGE_FLAGS */
+	uint32_t flags;
+	/** FUEL_GAUGE_FULL_CHARGE_CAPACITY */
+	uint32_t full_charge_capacity;
+	/** FUEL_GAUGE_REMAINING_CAPACITY */
+	uint32_t remaining_capacity;
+	/** FUEL_GAUGE_RUNTIME_TO_EMPTY */
+	uint32_t runtime_to_empty;
+	/** FUEL_GAUGE_RUNTIME_TO_FULL */
+	uint32_t runtime_to_full;
+	/** FUEL_GAUGE_SBS_MFR_ACCESS */
+	uint16_t sbs_mfr_access_word;
+	/** FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE */
+	uint8_t absolute_state_of_charge;
+	/** FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE */
+	uint8_t relative_state_of_charge;
+	/** FUEL_GAUGE_TEMPERATURE */
+	uint16_t temperature;
+	/** FUEL_GAUGE_VOLTAGE */
+	int voltage;
+	/** FUEL_GAUGE_SBS_MODE */
+	uint16_t sbs_mode;
+	/** FUEL_GAUGE_CHARGE_CURRENT */
+	uint16_t chg_current;
+	/** FUEL_GAUGE_CHARGE_VOLTAGE */
+	uint16_t chg_voltage;
+	/** FUEL_GAUGE_STATUS */
+	uint16_t fg_status;
+	/** FUEL_GAUGE_DESIGN_CAPACITY */
+	uint16_t design_cap;
+	/** FUEL_GAUGE_DESIGN_VOLTAGE */
+	uint16_t design_volt;
+	/** FUEL_GAUGE_SBS_ATRATE */
+	int16_t sbs_at_rate;
+	/** FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL */
+	uint16_t sbs_at_rate_time_to_full;
+	/** FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY	*/
+	uint16_t sbs_at_rate_time_to_empty;
+	/** FUEL_GAUGE_SBS_ATRATE_OK */
+	bool sbs_at_rate_ok;
+	/** FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM */
+	uint16_t sbs_remaining_capacity_alarm;
+	/** FUEL_GAUGE_SBS_REMAINING_TIME_ALARM */
+	uint16_t sbs_remaining_time_alarm;
 };
 
 /**
@@ -215,8 +204,8 @@ struct sbs_gauge_device_chemistry {
  *
  * See fuel_gauge_get_property() for argument description
  */
-typedef int (*fuel_gauge_get_property_t)(const struct device *dev,
-					 struct fuel_gauge_property *prop);
+typedef int (*fuel_gauge_get_property_t)(const struct device *dev, fuel_gauge_prop_t prop,
+					 union fuel_gauge_prop_val *val);
 
 /**
  * @typedef fuel_gauge_set_property_t
@@ -224,8 +213,8 @@ typedef int (*fuel_gauge_get_property_t)(const struct device *dev,
  *
  * See fuel_gauge_set_property() for argument description
  */
-typedef int (*fuel_gauge_set_property_t)(const struct device *dev,
-					 struct fuel_gauge_property *prop);
+typedef int (*fuel_gauge_set_property_t)(const struct device *dev, fuel_gauge_prop_t prop,
+					 union fuel_gauge_prop_val val);
 
 /**
  * @typedef fuel_gauge_get_buffer_property_t
@@ -234,7 +223,7 @@ typedef int (*fuel_gauge_set_property_t)(const struct device *dev,
  * See fuel_gauge_get_buffer_property() for argument description
  */
 typedef int (*fuel_gauge_get_buffer_property_t)(const struct device *dev,
-					       struct fuel_gauge_buffer_property *prop,
+					       fuel_gauge_prop_t prop_type,
 					       void *dst, size_t dst_len);
 
 /**
@@ -264,17 +253,16 @@ __subsystem struct fuel_gauge_driver_api {
  * @brief Fetch a battery fuel-gauge property
  *
  * @param dev Pointer to the battery fuel-gauge device
- * @param prop pointer to a fuel_gauge_property struct where the property struct
- * field is set by the caller to determine what property is read from the
- * fuel gauge device into the fuel_gauge_property struct's value field. The props array
- * maintains the same order of properties as it was given.
- *
+ * @param prop Type of property to be fetched from device
+ * @param val pointer to a union fuel_gauge_prop_val where the property is read into from the
+ * fuel gauge device.
  * @return 0 if successful, negative errno code if failure.
  */
-__syscall int fuel_gauge_get_prop(const struct device *dev, struct fuel_gauge_property *prop);
+__syscall int fuel_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
+				  union fuel_gauge_prop_val *val);
 
-static inline int z_impl_fuel_gauge_get_prop(const struct device *dev,
-					     struct fuel_gauge_property *prop)
+static inline int z_impl_fuel_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
+					     union fuel_gauge_prop_val *val)
 {
 	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
 
@@ -282,7 +270,7 @@ static inline int z_impl_fuel_gauge_get_prop(const struct device *dev,
 		return -ENOSYS;
 	}
 
-	return api->get_property(dev, prop);
+	return api->get_property(dev, prop, val);
 }
 
 /**
@@ -291,23 +279,25 @@ static inline int z_impl_fuel_gauge_get_prop(const struct device *dev,
  * of the fuel gauge driver APIs struct to override this implementation.
  *
  * @param dev Pointer to the battery fuel-gauge device
- * @param props pointer to array of fuel_gauge_property struct where the property struct
- * field is set by the caller to determine what property is read from the
- * fuel gauge device into the fuel_gauge_property struct's value field. The props array
- * maintains the same order of properties as it was given.
- * @param len number of properties in props array
+ * @param props Array of the type of property to be fetched from device, each index corresponds
+ * to the same index of the vals input array.
+ * @param vals Pointer to array of union fuel_gauge_prop_val where the property is read into from
+ * the fuel gauge device. The vals array is not permuted.
+ * @param len number of properties in props & vals array
  *
  * @return 0 if successful, negative errno code of first failing property
  */
-__syscall int fuel_gauge_get_props(const struct device *dev, struct fuel_gauge_property *props,
-				   size_t len);
+
+__syscall int fuel_gauge_get_props(const struct device *dev, fuel_gauge_prop_t *props,
+				   union fuel_gauge_prop_val *vals, size_t len);
 static inline int z_impl_fuel_gauge_get_props(const struct device *dev,
-					      struct fuel_gauge_property *props, size_t len)
+					      fuel_gauge_prop_t *props,
+					      union fuel_gauge_prop_val *vals, size_t len)
 {
 	const struct fuel_gauge_driver_api *api = dev->api;
 
 	for (int i = 0; i < len; i++) {
-		int ret = api->get_property(dev, props + i);
+		int ret = api->get_property(dev, props[i], vals + i);
 
 		if (ret) {
 			return ret;
@@ -321,16 +311,16 @@ static inline int z_impl_fuel_gauge_get_props(const struct device *dev,
  * @brief Set a battery fuel-gauge property
  *
  * @param dev Pointer to the battery fuel-gauge device
- * @param prop pointer to fuel_gauge_property struct where the property struct
- * field is set by the caller to determine what property is written to the fuel gauge device from
- * the fuel_gauge_property struct's value field.
+ * @param prop Type of property that's being set
+ * @param val Value to set associated prop property.
  *
  * @return 0 if successful, negative errno code of first failing property
  */
-__syscall int fuel_gauge_set_prop(const struct device *dev, struct fuel_gauge_property *prop);
+__syscall int fuel_gauge_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
+				  union fuel_gauge_prop_val val);
 
-static inline int z_impl_fuel_gauge_set_prop(const struct device *dev,
-					     struct fuel_gauge_property *prop)
+static inline int z_impl_fuel_gauge_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
+					     union fuel_gauge_prop_val val)
 {
 	const struct fuel_gauge_driver_api *api = dev->api;
 
@@ -338,28 +328,29 @@ static inline int z_impl_fuel_gauge_set_prop(const struct device *dev,
 		return -ENOSYS;
 	}
 
-	return api->set_property(dev, prop);
+	return api->set_property(dev, prop, val);
 }
-
 /**
  * @brief Set a battery fuel-gauge property
  *
  * @param dev Pointer to the battery fuel-gauge device
- * @param props pointer to array of fuel_gauge_property struct where the property struct
- * field is set by the caller to determine what property is written to the fuel gauge device from
- * the fuel_gauge_property struct's value field.
- * @param props_len number of properties in props array
+ * @param props Array of the type of property to be set, each index corresponds
+ * to the same index of the vals input array.
+ * @param vals Pointer to array of union fuel_gauge_prop_val where the property is written
+ * the fuel gauge device. The vals array is not permuted.
+ * @param len number of properties in props array
  *
  * @return return=0 if successful. Otherwise, return array index of failing property.
  */
-__syscall int fuel_gauge_set_props(const struct device *dev, struct fuel_gauge_property *props,
-				   size_t props_len);
+__syscall int fuel_gauge_set_props(const struct device *dev, fuel_gauge_prop_t *props,
+				   union fuel_gauge_prop_val *vals, size_t len);
 
 static inline int z_impl_fuel_gauge_set_props(const struct device *dev,
-					      struct fuel_gauge_property *props, size_t props_len)
+					      fuel_gauge_prop_t *props,
+					      union fuel_gauge_prop_val *vals, size_t len)
 {
-	for (int i = 0; i < props_len; i++) {
-		int ret = fuel_gauge_set_prop(dev, props + i);
+	for (int i = 0; i < len; i++) {
+		int ret = fuel_gauge_set_prop(dev, props[i], vals[i]);
 
 		if (ret) {
 			return ret;
@@ -373,20 +364,18 @@ static inline int z_impl_fuel_gauge_set_props(const struct device *dev,
  * @brief Fetch a battery fuel-gauge buffer property
  *
  * @param dev Pointer to the battery fuel-gauge device
- * @param prop pointer to single fuel_gauge_get_buffer_property struct where the property struct
- * field is set by the caller to determine what property is read from the
- * fuel gauge device into the dst field.
+ * @param prop_type Type of property to be fetched from device
  * @param dst byte array or struct that will hold the buffer data that is read from the fuel gauge
  * @param dst_len the length of the destination array in bytes
  *
  * @return return=0 if successful, return < 0 if getting property failed, return 0 on success
  */
-__syscall int fuel_gauge_get_buffer_prop(const struct device *dev,
-					struct fuel_gauge_buffer_property *prop, void *dst,
-					size_t dst_len);
+
+__syscall int fuel_gauge_get_buffer_prop(const struct device *dev, fuel_gauge_prop_t prop_type,
+					 void *dst, size_t dst_len);
 
 static inline int z_impl_fuel_gauge_get_buffer_prop(const struct device *dev,
-						   struct fuel_gauge_buffer_property *prop,
+						   fuel_gauge_prop_t prop_type,
 						   void *dst, size_t dst_len)
 {
 	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
@@ -395,7 +384,7 @@ static inline int z_impl_fuel_gauge_get_buffer_prop(const struct device *dev,
 		return -ENOSYS;
 	}
 
-	return api->get_buffer_property(dev, prop, dst, dst_len);
+	return api->get_buffer_property(dev, prop_type, dst, dst_len);
 }
 
 /**

--- a/samples/fuel_gauge/max17048/src/main.c
+++ b/samples/fuel_gauge/max17048/src/main.c
@@ -53,7 +53,7 @@ int main(void)
 			}
 		};
 
-		ret = fuel_gauge_get_prop(dev, props, ARRAY_SIZE(props));
+		ret = fuel_gauge_get_props(dev, props, ARRAY_SIZE(props));
 		if (ret < 0) {
 			printk("Error: cannot get properties\n");
 		} else {

--- a/samples/fuel_gauge/max17048/src/main.c
+++ b/samples/fuel_gauge/max17048/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "zephyr/sys/util.h"
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
@@ -38,31 +39,26 @@ int main(void)
 
 	while (1) {
 
-		struct fuel_gauge_property props[] = {
-			{
-				.property_type = FUEL_GAUGE_RUNTIME_TO_EMPTY,
-			},
-			{
-				.property_type = FUEL_GAUGE_RUNTIME_TO_FULL,
-			},
-			{
-				.property_type = FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
-			},
-			{
-				.property_type = FUEL_GAUGE_VOLTAGE,
-			}};
+		fuel_gauge_prop_t props[] = {
+			FUEL_GAUGE_RUNTIME_TO_EMPTY,
+			FUEL_GAUGE_RUNTIME_TO_FULL,
+			FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
+			FUEL_GAUGE_VOLTAGE,
+		};
 
-		ret = fuel_gauge_get_props(dev, props, ARRAY_SIZE(props));
+		union fuel_gauge_prop_val vals[ARRAY_SIZE(props)];
+
+		ret = fuel_gauge_get_props(dev, props, vals, ARRAY_SIZE(props));
 		if (ret < 0) {
 			printk("Error: cannot get properties\n");
 		} else {
-			printk("Time to empty %d\n", props[0].value.runtime_to_empty);
+			printk("Time to empty %d\n", vals[0].runtime_to_empty);
 
-			printk("Time to full %d\n", props[1].value.runtime_to_full);
+			printk("Time to full %d\n", vals[1].runtime_to_full);
 
-			printk("Charge %d%%\n", props[2].value.relative_state_of_charge);
+			printk("Charge %d%%\n", vals[2].relative_state_of_charge);
 
-			printk("Voltage %d\n", props[3].value.voltage);
+			printk("Voltage %d\n", vals[3].voltage);
 		}
 
 		k_sleep(K_MSEC(5000));

--- a/samples/fuel_gauge/max17048/src/main.c
+++ b/samples/fuel_gauge/max17048/src/main.c
@@ -50,54 +50,20 @@ int main(void)
 			},
 			{
 				.property_type = FUEL_GAUGE_VOLTAGE,
-			}
-		};
+			}};
 
 		ret = fuel_gauge_get_props(dev, props, ARRAY_SIZE(props));
 		if (ret < 0) {
 			printk("Error: cannot get properties\n");
 		} else {
-			if (ret != 0) {
-				printk("Warning: Some properties failed\n");
-			}
+			printk("Time to empty %d\n", props[0].value.runtime_to_empty);
 
-			if (props[0].status == 0) {
-				printk("Time to empty %d\n", props[0].value.runtime_to_empty);
-			} else {
-				printk(
-				"Property FUEL_GAUGE_RUNTIME_TO_EMPTY failed with error %d\n",
-				props[0].status
-				);
-			}
+			printk("Time to full %d\n", props[1].value.runtime_to_full);
 
-			if (props[1].status == 0) {
-				printk("Time to full %d\n", props[1].value.runtime_to_full);
-			} else {
-				printk(
-				"Property FUEL_GAUGE_RUNTIME_TO_FULL failed with error %d\n",
-				props[1].status
-				);
-			}
+			printk("Charge %d%%\n", props[2].value.relative_state_of_charge);
 
-			if (props[2].status == 0) {
-				printk("Charge %d%%\n", props[2].value.relative_state_of_charge);
-			} else {
-				printk(
-				"Property FUEL_GAUGE_STATE_OF_CHARGE failed with error %d\n",
-				props[2].status
-				);
-			}
-
-			if (props[3].status == 0) {
-				printk("Voltage %d\n", props[3].value.voltage);
-			} else {
-				printk(
-				"Property FUEL_GAUGE_VOLTAGE failed with error %d\n",
-				props[3].status
-				);
-			}
+			printk("Voltage %d\n", props[3].value.voltage);
 		}
-
 
 		k_sleep(K_MSEC(5000));
 	}

--- a/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
+++ b/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
@@ -40,7 +40,7 @@ ZTEST_USER_F(bq27z746, test_get_all_props_failed_returns_negative)
 		},
 	};
 
-	int ret = fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	zassert_equal(props[0].status, -ENOTSUP, "Getting bad property %d has a good status.",
 		      props[0].property_type);
@@ -66,7 +66,7 @@ ZTEST_USER_F(bq27z746, test_get_some_props_failed_returns_failed_prop_count)
 
 	};
 
-	int ret = fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	zassert_equal(props[0].status, -ENOTSUP, "Getting bad property %d has a good status.",
 		      props[0].property_type);
@@ -191,7 +191,7 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 		},
 	};
 
-	int ret = fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	/* All props shall have a good status */
 	for (int i = 0; i < ARRAY_SIZE(props); i++) {

--- a/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
+++ b/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
@@ -42,10 +42,7 @@ ZTEST_USER_F(bq27z746, test_get_all_props_failed_returns_negative)
 
 	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
-	zassert_equal(props[0].status, -ENOTSUP, "Getting bad property %d has a good status.",
-		      props[0].property_type);
-
-	zassert_true(ret < 0);
+	zassert_equal(ret, -ENOTSUP);
 }
 
 ZTEST_USER_F(bq27z746, test_get_some_props_failed_returns_failed_prop_count)
@@ -68,16 +65,7 @@ ZTEST_USER_F(bq27z746, test_get_some_props_failed_returns_failed_prop_count)
 
 	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
-	zassert_equal(props[0].status, -ENOTSUP, "Getting bad property %d has a good status.",
-		      props[0].property_type);
-
-	zassert_equal(props[1].status, -ENOTSUP, "Getting bad property %d has a good status.",
-		      props[1].property_type);
-
-	zassert_ok(props[2].status, "Property %d getting %d has a bad status.", 2,
-		   props[2].property_type);
-
-	zassert_equal(ret, 2);
+	zassert_equal(ret, -ENOTSUP);
 }
 
 ZTEST_USER_F(bq27z746, test_get_buffer_prop)
@@ -91,7 +79,6 @@ ZTEST_USER_F(bq27z746, test_get_buffer_prop)
 		prop.property_type = FUEL_GAUGE_MANUFACTURER_NAME;
 		ret = fuel_gauge_get_buffer_prop(fixture->dev, &prop, &mfg_name, sizeof(mfg_name));
 		zassert_ok(ret);
-		zassert_ok(prop.status, "Property %d has a bad status.", prop.property_type);
 #if CONFIG_EMUL
 		/* Only test for fixed values in emulation since the real device might be */
 		/* reprogrammed and respond with different values */
@@ -107,7 +94,6 @@ ZTEST_USER_F(bq27z746, test_get_buffer_prop)
 		prop.property_type = FUEL_GAUGE_DEVICE_NAME;
 		ret = fuel_gauge_get_buffer_prop(fixture->dev, &prop, &dev_name, sizeof(dev_name));
 		zassert_ok(ret);
-		zassert_ok(prop.status, "Property %d has a bad status.", prop.property_type);
 #if CONFIG_EMUL
 		/* Only test for fixed values in emulation since the real device might be */
 		/* reprogrammed and respond with different values */
@@ -122,7 +108,6 @@ ZTEST_USER_F(bq27z746, test_get_buffer_prop)
 		ret = fuel_gauge_get_buffer_prop(fixture->dev, &prop, &device_chemistry,
 						 sizeof(device_chemistry));
 		zassert_ok(ret);
-		zassert_ok(prop.status, "Property %d has a bad status.", prop.property_type);
 #if CONFIG_EMUL
 		/* Only test for fixed values in emulation since the real device might be */
 		/* reprogrammed and respond with different values */
@@ -191,13 +176,7 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 		},
 	};
 
-	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
-
-	/* All props shall have a good status */
-	for (int i = 0; i < ARRAY_SIZE(props); i++) {
-		zassert_ok(props[i].status, "Property %d getting %d has a bad status.", i,
-			   props[i].property_type);
-	}
+	zassert_ok(fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props)));
 
 	/* Check properties for valid ranges */
 #if CONFIG_EMUL
@@ -239,8 +218,6 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 	/* Not testing props[15]. This property is the status and only has only status bits */
 	zassert_between_inclusive(props[16].value.design_cap, 0, 32767);
 #endif
-
-	zassert_ok(ret);
 }
 
 ZTEST_SUITE(bq27z746, NULL, bq27z746_setup, NULL, NULL, NULL);

--- a/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
+++ b/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
@@ -31,53 +31,32 @@ static void *bq27z746_setup(void)
 	return &fixture;
 }
 
-ZTEST_USER_F(bq27z746, test_get_all_props_failed_returns_negative)
+ZTEST_USER_F(bq27z746, test_get_some_props_failed_returns_bad_status)
 {
-	struct fuel_gauge_property props[] = {
-		{
-			/* Invalid property */
-			.property_type = FUEL_GAUGE_PROP_MAX,
-		},
+	fuel_gauge_prop_t props[] = {
+		/* First invalid property */
+		FUEL_GAUGE_PROP_MAX,
+		/* Second invalid property */
+		FUEL_GAUGE_PROP_MAX,
+		/* Valid property */
+		FUEL_GAUGE_VOLTAGE,
 	};
+	union fuel_gauge_prop_val vals[ARRAY_SIZE(props)];
 
-	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, props, vals, ARRAY_SIZE(props));
 
-	zassert_equal(ret, -ENOTSUP);
-}
-
-ZTEST_USER_F(bq27z746, test_get_some_props_failed_returns_failed_prop_count)
-{
-	struct fuel_gauge_property props[] = {
-		{
-			/* First invalid property */
-			.property_type = FUEL_GAUGE_PROP_MAX,
-		},
-		{
-			/* Second invalid property */
-			.property_type = FUEL_GAUGE_PROP_MAX,
-		},
-		{
-			/* Valid property */
-			.property_type = FUEL_GAUGE_VOLTAGE,
-		},
-
-	};
-
-	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
-
-	zassert_equal(ret, -ENOTSUP);
+	zassert_equal(ret, -ENOTSUP, "Getting bad property has a good status.");
 }
 
 ZTEST_USER_F(bq27z746, test_get_buffer_prop)
 {
-	struct fuel_gauge_buffer_property prop;
 	int ret;
 
 	{
 		struct sbs_gauge_manufacturer_name mfg_name;
 
-		prop.property_type = FUEL_GAUGE_MANUFACTURER_NAME;
-		ret = fuel_gauge_get_buffer_prop(fixture->dev, &prop, &mfg_name, sizeof(mfg_name));
+		ret = fuel_gauge_get_buffer_prop(fixture->dev, FUEL_GAUGE_MANUFACTURER_NAME,
+						 &mfg_name, sizeof(mfg_name));
 		zassert_ok(ret);
 #if CONFIG_EMUL
 		/* Only test for fixed values in emulation since the real device might be */
@@ -91,8 +70,8 @@ ZTEST_USER_F(bq27z746, test_get_buffer_prop)
 	{
 		struct sbs_gauge_device_name dev_name;
 
-		prop.property_type = FUEL_GAUGE_DEVICE_NAME;
-		ret = fuel_gauge_get_buffer_prop(fixture->dev, &prop, &dev_name, sizeof(dev_name));
+		ret = fuel_gauge_get_buffer_prop(fixture->dev, FUEL_GAUGE_DEVICE_NAME, &dev_name,
+						 sizeof(dev_name));
 		zassert_ok(ret);
 #if CONFIG_EMUL
 		/* Only test for fixed values in emulation since the real device might be */
@@ -104,9 +83,8 @@ ZTEST_USER_F(bq27z746, test_get_buffer_prop)
 	{
 		struct sbs_gauge_device_chemistry device_chemistry;
 
-		prop.property_type = FUEL_GAUGE_DEVICE_CHEMISTRY;
-		ret = fuel_gauge_get_buffer_prop(fixture->dev, &prop, &device_chemistry,
-						 sizeof(device_chemistry));
+		ret = fuel_gauge_get_buffer_prop(fixture->dev, FUEL_GAUGE_DEVICE_CHEMISTRY,
+						 &device_chemistry, sizeof(device_chemistry));
 		zassert_ok(ret);
 #if CONFIG_EMUL
 		/* Only test for fixed values in emulation since the real device might be */
@@ -122,101 +100,68 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 {
 	/* Validate what props are supported by the driver */
 
-	struct fuel_gauge_property props[] = {
-		{
-			.property_type = FUEL_GAUGE_AVG_CURRENT,
-		},
-		{
-			.property_type = FUEL_GAUGE_CYCLE_COUNT,
-		},
-		{
-			.property_type = FUEL_GAUGE_CURRENT,
-		},
-		{
-			.property_type = FUEL_GAUGE_FULL_CHARGE_CAPACITY,
-		},
-		{
-			.property_type = FUEL_GAUGE_REMAINING_CAPACITY,
-		},
-		{
-			.property_type = FUEL_GAUGE_RUNTIME_TO_EMPTY,
-		},
-		{
-			.property_type = FUEL_GAUGE_RUNTIME_TO_FULL,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
-		},
-		{
-			.property_type = FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
-		},
-		{
-			.property_type = FUEL_GAUGE_TEMPERATURE,
-		},
-		{
-			.property_type = FUEL_GAUGE_VOLTAGE,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_ATRATE,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
-		},
-		{
-			.property_type = FUEL_GAUGE_CHARGE_VOLTAGE,
-		},
-		{
-			.property_type = FUEL_GAUGE_CHARGE_CURRENT,
-		},
-		{
-			.property_type = FUEL_GAUGE_STATUS,
-		},
-		{
-			.property_type = FUEL_GAUGE_DESIGN_CAPACITY,
-		},
+	fuel_gauge_prop_t props[] = {
+			FUEL_GAUGE_AVG_CURRENT,
+			FUEL_GAUGE_CYCLE_COUNT,
+			FUEL_GAUGE_CURRENT,
+			FUEL_GAUGE_FULL_CHARGE_CAPACITY,
+			FUEL_GAUGE_REMAINING_CAPACITY,
+			FUEL_GAUGE_RUNTIME_TO_EMPTY,
+			FUEL_GAUGE_RUNTIME_TO_FULL,
+			FUEL_GAUGE_SBS_MFR_ACCESS,
+			FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
+			FUEL_GAUGE_TEMPERATURE,
+			FUEL_GAUGE_VOLTAGE,
+			FUEL_GAUGE_SBS_ATRATE,
+			FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
+			FUEL_GAUGE_CHARGE_VOLTAGE,
+			FUEL_GAUGE_CHARGE_CURRENT,
+			FUEL_GAUGE_STATUS,
+			FUEL_GAUGE_DESIGN_CAPACITY,
 	};
+	union fuel_gauge_prop_val vals[ARRAY_SIZE(props)];
 
-	zassert_ok(fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props)));
+	zassert_ok(fuel_gauge_get_props(fixture->dev, props, vals, ARRAY_SIZE(props)));
 
 	/* Check properties for valid ranges */
 #if CONFIG_EMUL
 	/* When emulating, check for the fixed values coming from the emulator */
-	zassert_equal(props[0].value.avg_current, -2000);
-	zassert_equal(props[1].value.cycle_count, 100);
-	zassert_equal(props[2].value.current, -2000);
-	zassert_equal(props[3].value.full_charge_capacity, 1000);
-	zassert_equal(props[4].value.remaining_capacity, 1000);
-	zassert_equal(props[5].value.runtime_to_empty, 1);
-	zassert_equal(props[6].value.runtime_to_full, 1);
-	zassert_equal(props[7].value.sbs_mfr_access_word, 1);
-	zassert_equal(props[8].value.relative_state_of_charge, 1);
-	zassert_equal(props[9].value.temperature, 1);
-	zassert_equal(props[10].value.voltage, 1000);
-	zassert_equal(props[11].value.sbs_at_rate, -2);
-	zassert_equal(props[12].value.sbs_at_rate_time_to_empty, 1);
-	zassert_equal(props[13].value.chg_voltage, 1);
-	zassert_equal(props[14].value.chg_current, 1);
-	zassert_equal(props[15].value.fg_status, 1);
-	zassert_equal(props[16].value.design_cap, 1);
+	zassert_equal(vals[0].avg_current, -2000);
+	zassert_equal(vals[1].cycle_count, 100);
+	zassert_equal(vals[2].current, -2000);
+	zassert_equal(vals[3].full_charge_capacity, 1000);
+	zassert_equal(vals[4].remaining_capacity, 1000);
+	zassert_equal(vals[5].runtime_to_empty, 1);
+	zassert_equal(vals[6].runtime_to_full, 1);
+	zassert_equal(vals[7].sbs_mfr_access_word, 1);
+	zassert_equal(vals[8].relative_state_of_charge, 1);
+	zassert_equal(vals[9].temperature, 1);
+	zassert_equal(vals[10].voltage, 1000);
+	zassert_equal(vals[11].sbs_at_rate, -2);
+	zassert_equal(vals[12].sbs_at_rate_time_to_empty, 1);
+	zassert_equal(vals[13].chg_voltage, 1);
+	zassert_equal(vals[14].chg_current, 1);
+	zassert_equal(vals[15].fg_status, 1);
+	zassert_equal(vals[16].design_cap, 1);
 #else
 	/* When having a real device, check for the valid ranges */
-	zassert_between_inclusive(props[0].value.avg_current, -32768 * 1000, 32767 * 1000);
-	zassert_between_inclusive(props[1].value.cycle_count, 0, 6553500);
-	zassert_between_inclusive(props[2].value.current, -32768 * 1000, 32767 * 1000);
-	zassert_between_inclusive(props[3].value.full_charge_capacity, 0, 32767 * 1000);
-	zassert_between_inclusive(props[4].value.remaining_capacity, 0, 32767 * 1000);
-	zassert_between_inclusive(props[5].value.runtime_to_empty, 0, 65535);
-	zassert_between_inclusive(props[6].value.runtime_to_full, 0, 65535);
+	zassert_between_inclusive(props[0].avg_current, -32768 * 1000, 32767 * 1000);
+	zassert_between_inclusive(props[1].cycle_count, 0, 6553500);
+	zassert_between_inclusive(props[2].current, -32768 * 1000, 32767 * 1000);
+	zassert_between_inclusive(props[3].full_charge_capacity, 0, 32767 * 1000);
+	zassert_between_inclusive(props[4].remaining_capacity, 0, 32767 * 1000);
+	zassert_between_inclusive(props[5].runtime_to_empty, 0, 65535);
+	zassert_between_inclusive(props[6].runtime_to_full, 0, 65535);
 	/* Not testing props[7]. This is the manufacturer access and has only status bits */
-	zassert_between_inclusive(props[8].value.relative_state_of_charge, 0, 100);
-	zassert_between_inclusive(props[9].value.temperature, 0, 32767);
-	zassert_between_inclusive(props[10].value.voltage, 0, 32767 * 1000);
-	zassert_between_inclusive(props[11].value.sbs_at_rate, -32768, 32767);
-	zassert_between_inclusive(props[12].value.sbs_at_rate_time_to_empty, 0, 65535);
-	zassert_between_inclusive(props[13].value.chg_voltage, 0, 32767);
-	zassert_between_inclusive(props[14].value.chg_current, 0, 32767);
+	zassert_between_inclusive(props[8].relative_state_of_charge, 0, 100);
+	zassert_between_inclusive(props[9].temperature, 0, 32767);
+	zassert_between_inclusive(props[10].voltage, 0, 32767 * 1000);
+	zassert_between_inclusive(props[11].sbs_at_rate, -32768, 32767);
+	zassert_between_inclusive(props[12].sbs_at_rate_time_to_empty, 0, 65535);
+	zassert_between_inclusive(props[13].chg_voltage, 0, 32767);
+	zassert_between_inclusive(props[14].chg_current, 0, 32767);
 	/* Not testing props[15]. This property is the status and only has only status bits */
-	zassert_between_inclusive(props[16].value.design_cap, 0, 32767);
+	zassert_between_inclusive(props[16].design_cap, 0, 32767);
 #endif
 }
 

--- a/tests/drivers/fuel_gauge/max17048/src/test_max17048.c
+++ b/tests/drivers/fuel_gauge/max17048/src/test_max17048.c
@@ -43,13 +43,10 @@ ZTEST_USER_F(max17048, test_get_all_props_failed_returns_negative)
 
 	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
-	zassert_equal(props[0].status, -ENOTSUP, "Getting bad property %d has a good status.",
-		      props[0].property_type);
-
-	zassert_true(ret < 0);
+	zassert_equal(-ENOTSUP, ret);
 }
 
-ZTEST_USER_F(max17048, test_get_some_props_failed_returns_failed_prop_count)
+ZTEST_USER_F(max17048, test_get_some_props_failed_returns_errno)
 {
 	struct fuel_gauge_property props[] = {
 		{
@@ -69,16 +66,7 @@ ZTEST_USER_F(max17048, test_get_some_props_failed_returns_failed_prop_count)
 
 	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
-	zassert_equal(props[0].status, -ENOTSUP, "Getting bad property %d has a good status.",
-		      props[0].property_type);
-
-	zassert_equal(props[1].status, -ENOTSUP, "Getting bad property %d has a good status.",
-		      props[1].property_type);
-
-	zassert_ok(props[2].status, "Property %d getting %d has a bad status.", 2,
-		   props[2].property_type);
-
-	zassert_equal(ret, 2);
+	zassert_equal(ret, -ENOTSUP);
 }
 
 
@@ -101,14 +89,7 @@ ZTEST_USER_F(max17048, test_get_props__returns_ok)
 		}
 	};
 
-	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
-
-	for (int i = 0; i < ARRAY_SIZE(props); i++) {
-		zassert_ok(props[i].status, "Property %d getting %d has a bad status.", i,
-			   props[i].property_type);
-	}
-
-	zassert_ok(ret);
+	zassert_ok(fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props)));
 }
 
 ZTEST_USER_F(max17048, test_current_rate_zero)
@@ -130,10 +111,6 @@ ZTEST_USER_F(max17048, test_current_rate_zero)
 	emul_max17048_set_crate_status(0);
 	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
-	for (int i = 0; i < ARRAY_SIZE(props); i++) {
-		zassert_ok(props[i].status, "Property %d getting %d has a bad status.", i,
-			   props[i].property_type);
-	}
 	zassert_equal(props[0].value.runtime_to_empty, 0,
 		"Runtime to empty is %d but it should be 0.",
 		props[0].value.runtime_to_full

--- a/tests/drivers/fuel_gauge/max17048/src/test_max17048.c
+++ b/tests/drivers/fuel_gauge/max17048/src/test_max17048.c
@@ -41,7 +41,7 @@ ZTEST_USER_F(max17048, test_get_all_props_failed_returns_negative)
 		},
 	};
 
-	int ret = fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	zassert_equal(props[0].status, -ENOTSUP, "Getting bad property %d has a good status.",
 		      props[0].property_type);
@@ -67,7 +67,7 @@ ZTEST_USER_F(max17048, test_get_some_props_failed_returns_failed_prop_count)
 
 	};
 
-	int ret = fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	zassert_equal(props[0].status, -ENOTSUP, "Getting bad property %d has a good status.",
 		      props[0].property_type);
@@ -101,7 +101,7 @@ ZTEST_USER_F(max17048, test_get_props__returns_ok)
 		}
 	};
 
-	int ret = fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	for (int i = 0; i < ARRAY_SIZE(props); i++) {
 		zassert_ok(props[i].status, "Property %d getting %d has a bad status.", i,
@@ -128,7 +128,7 @@ ZTEST_USER_F(max17048, test_current_rate_zero)
 	 * it will cause a division by zero
 	 */
 	emul_max17048_set_crate_status(0);
-	int ret = fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	for (int i = 0; i < ARRAY_SIZE(props); i++) {
 		zassert_ok(props[i].status, "Property %d getting %d has a bad status.", i,

--- a/tests/drivers/fuel_gauge/max17048/src/test_max17048.c
+++ b/tests/drivers/fuel_gauge/max17048/src/test_max17048.c
@@ -32,98 +32,63 @@ static void *max17048_setup(void)
 	return &fixture;
 }
 
-ZTEST_USER_F(max17048, test_get_all_props_failed_returns_negative)
+ZTEST_USER_F(max17048, test_get_some_props_failed_returns_bad_status)
 {
-	struct fuel_gauge_property props[] = {
-		{
-			/* Invalid property */
-			.property_type = FUEL_GAUGE_PROP_MAX,
-		},
+	fuel_gauge_prop_t prop_types[] = {
+		/* First invalid property */
+		FUEL_GAUGE_PROP_MAX,
+		/* Second invalid property */
+		FUEL_GAUGE_PROP_MAX,
+		/* Valid property */
+		FUEL_GAUGE_VOLTAGE,
 	};
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
 
-	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));
 
-	zassert_equal(-ENOTSUP, ret);
+	zassert_equal(ret, -ENOTSUP, "Getting bad property has a good status.");
 }
-
-ZTEST_USER_F(max17048, test_get_some_props_failed_returns_errno)
-{
-	struct fuel_gauge_property props[] = {
-		{
-			/* First invalid property */
-			.property_type = FUEL_GAUGE_PROP_MAX,
-		},
-		{
-			/* Second invalid property */
-			.property_type = FUEL_GAUGE_PROP_MAX,
-		},
-		{
-			/* Valid property */
-			.property_type = FUEL_GAUGE_VOLTAGE,
-		},
-
-	};
-
-	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
-
-	zassert_equal(ret, -ENOTSUP);
-}
-
 
 ZTEST_USER_F(max17048, test_get_props__returns_ok)
 {
 	/* Validate what props are supported by the driver */
 
-	struct fuel_gauge_property props[] = {
-		{
-			.property_type = FUEL_GAUGE_RUNTIME_TO_EMPTY,
-		},
-		{
-			.property_type = FUEL_GAUGE_RUNTIME_TO_FULL,
-		},
-		{
-			.property_type = FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
-		},
-		{
-			.property_type = FUEL_GAUGE_VOLTAGE,
-		}
+	fuel_gauge_prop_t prop_types[] = {
+		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_RUNTIME_TO_EMPTY,
+		FUEL_GAUGE_RUNTIME_TO_FULL,
+		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
 	};
 
-	zassert_ok(fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props)));
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
+
+	zassert_ok(fuel_gauge_get_props(fixture->dev, prop_types, props, ARRAY_SIZE(props)));
 }
 
 ZTEST_USER_F(max17048, test_current_rate_zero)
 {
 	/* Test when crate is 0, which is a special case */
 
-	struct fuel_gauge_property props[] = {
-		{
-			.property_type = FUEL_GAUGE_RUNTIME_TO_EMPTY,
-		},
-		{
-			.property_type = FUEL_GAUGE_RUNTIME_TO_FULL,
-		}
+	fuel_gauge_prop_t prop_types[] = {
+		FUEL_GAUGE_RUNTIME_TO_EMPTY,
+		FUEL_GAUGE_RUNTIME_TO_FULL,
 	};
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
 
 	/** Null value, not charging either discharging. If not handled correctly,
 	 * it will cause a division by zero
 	 */
 	emul_max17048_set_crate_status(0);
-	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));
 
-	zassert_equal(props[0].value.runtime_to_empty, 0,
-		"Runtime to empty is %d but it should be 0.",
-		props[0].value.runtime_to_full
-	);
-	zassert_equal(props[1].value.runtime_to_full, 0,
-		"Runtime to full is %d but it should be 0.",
-		props[1].value.runtime_to_full
-	);
+	zassert_equal(props[0].runtime_to_empty, 0, "Runtime to empty is %d but it should be 0.",
+		      props[0].runtime_to_full);
+	zassert_equal(props[1].runtime_to_full, 0, "Runtime to full is %d but it should be 0.",
+		      props[1].runtime_to_full);
 
 	zassert_ok(ret);
 	/* Return value to the original state */
 	emul_max17048_set_crate_status(0x4000);
 }
-
 
 ZTEST_SUITE(max17048, NULL, max17048_setup, NULL, NULL, NULL);

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -90,7 +90,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_all_props_failed_returns_negative)
 		},
 	};
 
-	int ret = fuel_gauge_set_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_set_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	zassert_equal(props[0].status, -ENOTSUP, "Setting bad property %d has a good status.",
 		      props[0].property_type);
@@ -118,7 +118,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_some_props_failed_returns_failed_prop_c
 
 	};
 
-	int ret = fuel_gauge_set_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_set_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	zassert_equal(props[0].status, -ENOTSUP, "Setting bad property %d has a good status.",
 		      props[0].property_type);
@@ -178,7 +178,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_prop_can_be_get)
 		},
 	};
 
-	zassert_ok(fuel_gauge_set_prop(fixture->dev, set_props, ARRAY_SIZE(set_props)));
+	zassert_ok(fuel_gauge_set_props(fixture->dev, set_props, ARRAY_SIZE(set_props)));
 	for (int i = 0; i < ARRAY_SIZE(set_props); i++) {
 		zassert_ok(set_props[i].status, "Property %d writing %d has a bad status.", i,
 			   set_props[i].property_type);
@@ -308,7 +308,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_props__returns_ok)
 		},
 	};
 
-	int ret = fuel_gauge_set_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_set_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	for (int i = 0; i < ARRAY_SIZE(props); i++) {
 		zassert_ok(props[i].status, "Property %d writing %d has a bad status.", i,
@@ -369,6 +369,25 @@ ZTEST_USER_F(sbs_gauge_new_api, test_charging_5v_3a)
 	zassert_ok(current.status);
 	zassert_equal(current.value.current, expected_uA, "Got %d instead of %d",
 		      current.value.current, expected_uA);
+}
+
+ZTEST_USER_F(sbs_gauge_new_api, test_set_get_single_prop)
+{
+	/* Validate what props are supported by the driver */
+
+	uint16_t test_value = 0x1001;
+
+	struct fuel_gauge_property mfr_acc_set = {
+		.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
+		.value.sbs_mfr_access_word = test_value,
+	};
+	struct fuel_gauge_property mfr_acc_get = {
+		.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
+	};
+
+	zassert_ok(fuel_gauge_set_prop(fixture->dev, &mfr_acc_set));
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, &mfr_acc_get));
+	zassert_equal(mfr_acc_get.value.sbs_mfr_access_word, test_value);
 }
 
 ZTEST_SUITE(sbs_gauge_new_api, NULL, sbs_gauge_new_api_setup, NULL, NULL, NULL);

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -34,62 +34,58 @@ static void *sbs_gauge_new_api_setup(void)
 
 ZTEST_USER_F(sbs_gauge_new_api, test_get_some_props_failed_returns_bad_status)
 {
-	struct fuel_gauge_property props[] = {
-		{
-			/* First invalid property */
-			.property_type = FUEL_GAUGE_PROP_MAX,
-		},
-		{
-			/* Second invalid property */
-			.property_type = FUEL_GAUGE_PROP_MAX,
-		},
-		{
-			/* Valid property */
-			.property_type = FUEL_GAUGE_VOLTAGE,
-		},
-
+	fuel_gauge_prop_t prop_types[] = {
+		/* First invalid property */
+		FUEL_GAUGE_PROP_MAX,
+		/* Second invalid property */
+		FUEL_GAUGE_PROP_MAX,
+		/* Valid property */
+		FUEL_GAUGE_VOLTAGE,
 	};
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
 
-	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));
 
 	zassert_equal(ret, -ENOTSUP, "Getting bad property has a good status.");
 }
 
 ZTEST_USER_F(sbs_gauge_new_api, test_set_all_props_failed_returns_err)
 {
-	struct fuel_gauge_property props[] = {
-		{
-			/* Invalid property */
-			.property_type = FUEL_GAUGE_PROP_MAX,
-		},
+	fuel_gauge_prop_t prop_types[] = {
+		/* Invalid property */
+		FUEL_GAUGE_PROP_MAX,
 	};
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
 
-	int ret = fuel_gauge_set_props(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_set_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));
 
 	zassert_equal(ret, -ENOTSUP);
 }
 
 ZTEST_USER_F(sbs_gauge_new_api, test_set_some_props_failed_returns_err)
 {
-	struct fuel_gauge_property props[] = {
-		{
-			/* First invalid property */
-			.property_type = FUEL_GAUGE_PROP_MAX,
-		},
-		{
-			/* Second invalid property */
-			.property_type = FUEL_GAUGE_PROP_MAX,
-		},
-		{
-			/* Valid property */
-			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
-			/* Set Manufacturer's Access to arbitrary word */
-			.value.sbs_mfr_access_word = 1,
-		},
+	fuel_gauge_prop_t prop_types[] = {
+		/* First invalid property */
+		FUEL_GAUGE_PROP_MAX,
+		/* Second invalid property */
+		FUEL_GAUGE_PROP_MAX,
+		/* Valid property */
+		FUEL_GAUGE_SBS_MFR_ACCESS,
+		/* Set Manufacturer's Access to arbitrary word */
 
 	};
 
-	int ret = fuel_gauge_set_props(fixture->dev, props, ARRAY_SIZE(props));
+	union fuel_gauge_prop_val props[] = {
+		/* First invalid property */
+		{0},
+		/* Second invalid property */
+		{0},
+		/* Valid property */
+		/* Set Manufacturer's Access to arbitrary word */
+		{.sbs_mfr_access_word = 1},
+	};
+
+	int ret = fuel_gauge_set_props(fixture->dev, prop_types, props, ARRAY_SIZE(props));
 
 	zassert_equal(ret, -ENOTSUP);
 }
@@ -97,184 +93,116 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_some_props_failed_returns_err)
 ZTEST_USER_F(sbs_gauge_new_api, test_set_prop_can_be_get)
 {
 	uint16_t word = BIT(15) | BIT(0);
-	struct fuel_gauge_property set_props[] = {
+
+	fuel_gauge_prop_t prop_types[] = {
+		FUEL_GAUGE_SBS_MFR_ACCESS,
+		FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
+		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
+		FUEL_GAUGE_SBS_MODE,
+		FUEL_GAUGE_SBS_ATRATE,
+	};
+
+	union fuel_gauge_prop_val set_props[] = {
 		{
-			/* Valid property */
-			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
-			/* Set Manufacturer's Access to 16 bit word */
-			.value.sbs_mfr_access_word = word,
+			.sbs_mfr_access_word = word,
 		},
 		{
-			.property_type = FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
-			.value.sbs_remaining_capacity_alarm = word,
+			.sbs_remaining_capacity_alarm = word,
 		},
 		{
-			.property_type = FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
-			.value.sbs_remaining_time_alarm = word,
+			.sbs_remaining_time_alarm = word,
 		},
 		{
-			.property_type = FUEL_GAUGE_SBS_MODE,
-			.value.sbs_mode = word,
+			.sbs_mode = word,
 		},
 		{
-			.property_type = FUEL_GAUGE_SBS_ATRATE,
-			.value.sbs_at_rate = (int16_t)word,
+			.sbs_at_rate = (int16_t)word,
 		},
 	};
 
-	struct fuel_gauge_property get_props[] = {
-		{
-			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_MODE,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_ATRATE,
-		},
-	};
+	union fuel_gauge_prop_val get_props[ARRAY_SIZE(prop_types)];
 
-	zassert_ok(fuel_gauge_set_props(fixture->dev, set_props, ARRAY_SIZE(set_props)));
+	zassert_ok(
+		fuel_gauge_set_props(fixture->dev, prop_types, set_props, ARRAY_SIZE(set_props)));
 
-	zassert_ok(fuel_gauge_get_props(fixture->dev, get_props, ARRAY_SIZE(get_props)));
+	zassert_ok(
+		fuel_gauge_get_props(fixture->dev, prop_types, get_props, ARRAY_SIZE(get_props)));
 
-	zassert_equal(get_props[0].value.sbs_mfr_access_word, word);
-	zassert_equal(get_props[1].value.sbs_remaining_capacity_alarm, word);
-	zassert_equal(get_props[2].value.sbs_remaining_time_alarm, word);
-	zassert_equal(get_props[3].value.sbs_mode, word);
-	zassert_equal(get_props[4].value.sbs_at_rate, (int16_t)word);
+	zassert_equal(get_props[0].sbs_mfr_access_word, word);
+	zassert_equal(get_props[1].sbs_remaining_capacity_alarm, word);
+	zassert_equal(get_props[2].sbs_remaining_time_alarm, word);
+	zassert_equal(get_props[3].sbs_mode, word);
+	zassert_equal(get_props[4].sbs_at_rate, (int16_t)word);
 }
 
 ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)
 {
 	/* Validate what props are supported by the driver */
 
-	struct fuel_gauge_property props[] = {
-		{
-			.property_type = FUEL_GAUGE_VOLTAGE,
-		},
-		{
-			.property_type = FUEL_GAUGE_CURRENT,
-		},
-		{
-			.property_type = FUEL_GAUGE_AVG_CURRENT,
-		},
-		{
-			.property_type = FUEL_GAUGE_TEMPERATURE,
-		},
-		{
-			.property_type = FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE,
-		},
-		{
-			.property_type = FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
-		},
-		{
-			.property_type = FUEL_GAUGE_RUNTIME_TO_FULL,
-		},
-		{
-			.property_type = FUEL_GAUGE_RUNTIME_TO_EMPTY,
-		},
-		{
-			.property_type = FUEL_GAUGE_REMAINING_CAPACITY,
-		},
-		{
-			.property_type = FUEL_GAUGE_FULL_CHARGE_CAPACITY,
-		},
-		{
-			.property_type = FUEL_GAUGE_CYCLE_COUNT,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_MODE,
-		},
-		{
-			.property_type = FUEL_GAUGE_CHARGE_CURRENT,
-		},
-		{
-			.property_type = FUEL_GAUGE_CHARGE_VOLTAGE,
-		},
-		{
-			.property_type = FUEL_GAUGE_STATUS,
-		},
-		{
-			.property_type = FUEL_GAUGE_DESIGN_CAPACITY,
-		},
-		{
-			.property_type = FUEL_GAUGE_DESIGN_VOLTAGE,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_ATRATE,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_ATRATE_OK,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
-		},
+	fuel_gauge_prop_t prop_types[] = {
+		FUEL_GAUGE_VOLTAGE,
+		FUEL_GAUGE_CURRENT,
+		FUEL_GAUGE_AVG_CURRENT,
+		FUEL_GAUGE_TEMPERATURE,
+		FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE,
+		FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE,
+		FUEL_GAUGE_RUNTIME_TO_FULL,
+		FUEL_GAUGE_RUNTIME_TO_EMPTY,
+		FUEL_GAUGE_REMAINING_CAPACITY,
+		FUEL_GAUGE_FULL_CHARGE_CAPACITY,
+		FUEL_GAUGE_CYCLE_COUNT,
+		FUEL_GAUGE_SBS_MFR_ACCESS,
+		FUEL_GAUGE_SBS_MODE,
+		FUEL_GAUGE_CHARGE_CURRENT,
+		FUEL_GAUGE_CHARGE_VOLTAGE,
+		FUEL_GAUGE_STATUS,
+		FUEL_GAUGE_DESIGN_CAPACITY,
+		FUEL_GAUGE_DESIGN_VOLTAGE,
+		FUEL_GAUGE_SBS_ATRATE,
+		FUEL_GAUGE_SBS_ATRATE_TIME_TO_FULL,
+		FUEL_GAUGE_SBS_ATRATE_TIME_TO_EMPTY,
+		FUEL_GAUGE_SBS_ATRATE_OK,
+		FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
+		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
 	};
 
-	zassert_ok(fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props)));
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
+
+	zassert_ok(fuel_gauge_get_props(fixture->dev, prop_types, props, ARRAY_SIZE(props)));
 }
 
 ZTEST_USER_F(sbs_gauge_new_api, test_set_props__returns_ok)
 {
 	/* Validate what props are supported by the driver */
 
-	struct fuel_gauge_property props[] = {
-		{
-			.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_MODE,
-		},
-		{
-			.property_type = FUEL_GAUGE_SBS_ATRATE,
-		},
+	fuel_gauge_prop_t prop_types[] = {
+		FUEL_GAUGE_SBS_MFR_ACCESS,
+		FUEL_GAUGE_SBS_MODE,
+		FUEL_GAUGE_SBS_ATRATE,
+		FUEL_GAUGE_SBS_REMAINING_TIME_ALARM,
+		FUEL_GAUGE_SBS_REMAINING_CAPACITY_ALARM,
+
 	};
+	union fuel_gauge_prop_val props[ARRAY_SIZE(prop_types)];
 
-	zassert_ok(fuel_gauge_set_props(fixture->dev, props, ARRAY_SIZE(props)));
+	zassert_ok(fuel_gauge_set_props(fixture->dev, prop_types, props, ARRAY_SIZE(props)));
 }
-
 
 ZTEST_USER_F(sbs_gauge_new_api, test_get_buffer_props__returns_ok)
 {
 	/* Validate what properties are supported by the driver */
-	struct fuel_gauge_buffer_property prop;
 	struct sbs_gauge_manufacturer_name mfg_name;
 	struct sbs_gauge_device_name dev_name;
 	struct sbs_gauge_device_chemistry chem;
 
-	prop.property_type = FUEL_GAUGE_MANUFACTURER_NAME;
-	zassert_ok(fuel_gauge_get_buffer_prop(fixture->dev, &prop, &mfg_name, sizeof(mfg_name)));
+	zassert_ok(fuel_gauge_get_buffer_prop(fixture->dev, FUEL_GAUGE_MANUFACTURER_NAME, &mfg_name,
+					      sizeof(mfg_name)));
 
-	prop.property_type = FUEL_GAUGE_DEVICE_NAME;
-	zassert_ok(fuel_gauge_get_buffer_prop(fixture->dev, &prop, &dev_name, sizeof(dev_name)));
+	zassert_ok(fuel_gauge_get_buffer_prop(fixture->dev, FUEL_GAUGE_DEVICE_NAME, &dev_name,
+					      sizeof(dev_name)));
 
-	prop.property_type = FUEL_GAUGE_DEVICE_CHEMISTRY;
-	zassert_ok(fuel_gauge_get_buffer_prop(fixture->dev, &prop, &chem, sizeof(chem)));
+	zassert_ok(fuel_gauge_get_buffer_prop(fixture->dev, FUEL_GAUGE_DEVICE_CHEMISTRY, &chem,
+					      sizeof(chem)));
 }
 
 ZTEST_USER_F(sbs_gauge_new_api, test_charging_5v_3a)
@@ -283,23 +211,16 @@ ZTEST_USER_F(sbs_gauge_new_api, test_charging_5v_3a)
 	uint32_t expected_uV = 5000 * 1000;
 	uint32_t expected_uA = 3000 * 1000;
 
-	struct fuel_gauge_property voltage = {
-		.property_type = FUEL_GAUGE_VOLTAGE,
-	};
-	struct fuel_gauge_property current = {
-		.property_type = FUEL_GAUGE_CURRENT,
-	};
+	union fuel_gauge_prop_val voltage;
+	union fuel_gauge_prop_val current;
 
 	zassume_ok(emul_fuel_gauge_set_battery_charging(fixture->sbs_fuel_gauge, expected_uV,
 							expected_uA));
-	zassert_ok(fuel_gauge_get_prop(fixture->dev, &voltage));
-	zassert_ok(fuel_gauge_get_prop(fixture->dev, &current));
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_VOLTAGE, &voltage));
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_CURRENT, &current));
 
-	zassert_equal(voltage.value.voltage, expected_uV, "Got %d instead of %d",
-		      voltage.value.voltage, expected_uV);
-
-	zassert_equal(current.value.current, expected_uA, "Got %d instead of %d",
-		      current.value.current, expected_uA);
+	zassert_equal(voltage.voltage, expected_uV, "Got %d instead of %d", voltage, expected_uV);
+	zassert_equal(current.current, expected_uA, "Got %d instead of %d", current, expected_uA);
 }
 
 ZTEST_USER_F(sbs_gauge_new_api, test_set_get_single_prop)
@@ -308,17 +229,14 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_get_single_prop)
 
 	uint16_t test_value = 0x1001;
 
-	struct fuel_gauge_property mfr_acc_set = {
-		.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
-		.value.sbs_mfr_access_word = test_value,
+	union fuel_gauge_prop_val mfr_acc_set = {
+		.sbs_mfr_access_word = test_value,
 	};
-	struct fuel_gauge_property mfr_acc_get = {
-		.property_type = FUEL_GAUGE_SBS_MFR_ACCESS,
-	};
+	union fuel_gauge_prop_val mfr_acc_get;
 
-	zassert_ok(fuel_gauge_set_prop(fixture->dev, &mfr_acc_set));
-	zassert_ok(fuel_gauge_get_prop(fixture->dev, &mfr_acc_get));
-	zassert_equal(mfr_acc_get.value.sbs_mfr_access_word, test_value);
+	zassert_ok(fuel_gauge_set_prop(fixture->dev, FUEL_GAUGE_SBS_MFR_ACCESS, mfr_acc_set));
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, FUEL_GAUGE_SBS_MFR_ACCESS, &mfr_acc_get));
+	zassert_equal(mfr_acc_get.sbs_mfr_access_word, test_value);
 }
 
 ZTEST_SUITE(sbs_gauge_new_api, NULL, sbs_gauge_new_api_setup, NULL, NULL, NULL);

--- a/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/fuel_gauge/sbs_gauge/src/test_sbs_gauge.c
@@ -41,7 +41,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_all_props_failed_returns_negative)
 		},
 	};
 
-	int ret = fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	zassert_equal(props[0].status, -ENOTSUP, "Getting bad property %d has a good status.",
 		      props[0].property_type);
@@ -67,7 +67,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_some_props_failed_returns_failed_prop_c
 
 	};
 
-	int ret = fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	zassert_equal(props[0].status, -ENOTSUP, "Getting bad property %d has a good status.",
 		      props[0].property_type);
@@ -184,7 +184,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_set_prop_can_be_get)
 			   set_props[i].property_type);
 	}
 
-	zassert_ok(fuel_gauge_get_prop(fixture->dev, get_props, ARRAY_SIZE(get_props)));
+	zassert_ok(fuel_gauge_get_props(fixture->dev, get_props, ARRAY_SIZE(get_props)));
 	for (int i = 0; i < ARRAY_SIZE(get_props); i++) {
 		zassert_ok(get_props[i].status, "Property %d getting %d has a bad status.", i,
 			   get_props[i].property_type);
@@ -276,7 +276,7 @@ ZTEST_USER_F(sbs_gauge_new_api, test_get_props__returns_ok)
 		},
 	};
 
-	int ret = fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props));
+	int ret = fuel_gauge_get_props(fixture->dev, props, ARRAY_SIZE(props));
 
 	for (int i = 0; i < ARRAY_SIZE(props); i++) {
 		zassert_ok(props[i].status, "Property %d getting %d has a bad status.", i,
@@ -350,26 +350,25 @@ ZTEST_USER_F(sbs_gauge_new_api, test_charging_5v_3a)
 	uint32_t expected_uV = 5000 * 1000;
 	uint32_t expected_uA = 3000 * 1000;
 
-	struct fuel_gauge_property props[] = {
-		{
-			.property_type = FUEL_GAUGE_VOLTAGE,
-		},
-		{
-			.property_type = FUEL_GAUGE_CURRENT,
-		},
+	struct fuel_gauge_property voltage = {
+		.property_type = FUEL_GAUGE_VOLTAGE,
+	};
+	struct fuel_gauge_property current = {
+		.property_type = FUEL_GAUGE_CURRENT,
 	};
 
 	zassume_ok(emul_fuel_gauge_set_battery_charging(fixture->sbs_fuel_gauge, expected_uV,
 							expected_uA));
-	zassert_ok(fuel_gauge_get_prop(fixture->dev, props, ARRAY_SIZE(props)));
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, &voltage));
+	zassert_ok(fuel_gauge_get_prop(fixture->dev, &current));
 
-	zassert_ok(props[0].status);
-	zassert_equal(props[0].value.voltage, expected_uV, "Got %d instead of %d",
-		      props[0].value.voltage, expected_uV);
+	zassert_ok(voltage.status);
+	zassert_equal(voltage.value.voltage, expected_uV, "Got %d instead of %d",
+		      voltage.value.voltage, expected_uV);
 
-	zassert_ok(props[1].status);
-	zassert_equal(props[1].value.current, expected_uA, "Got %d instead of %d",
-		      props[1].value.current, expected_uA);
+	zassert_ok(current.status);
+	zassert_equal(current.value.current, expected_uA, "Got %d instead of %d",
+		      current.value.current, expected_uA);
 }
 
 ZTEST_SUITE(sbs_gauge_new_api, NULL, sbs_gauge_new_api_setup, NULL, NULL, NULL);


### PR DESCRIPTION
The fuel_gauge_get_prop() function prototype declares a function that retrieves multiple fuel gauge properties at once. The naming suggests it ought to fetch a singular property at a time. Moreso, some clients may just want to fetch properties one at a time and may feel uncomfortable using a prototype for fetching multiple properties when wanting to fetch them one at a time.

Modify fuel_gauge_get_prop() to fetch a single property and add fuel_gauge_get_props() to support fetching multiple properties. Modify existing tests/drivers/samples.

This is part of #61818 work.