### PR TITLE
samples: pm: fix init priority after init level change

### DIFF
--- a/samples/subsys/pm/device_pm/sample.yaml
+++ b/samples/subsys/pm/device_pm/sample.yaml
@@ -5,8 +5,10 @@ tests:
     platform_allow:
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
+      - qemu_x86
+      - mps2_an385
     integration_platforms:
-      - nrf52840dk_nrf52840
+      - qemu_x86
     tags: power
     harness: console
     harness_config:

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -116,4 +116,4 @@ PM_DEVICE_DEFINE(dummy_driver, dummy_device_pm_action);
 
 DEVICE_DEFINE(dummy_driver, DUMMY_DRIVER_NAME, &dummy_init,
 		    PM_DEVICE_GET(dummy_driver), NULL, NULL, POST_KERNEL,
-		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs);
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &funcs);


### PR DESCRIPTION
Moving from APPLICATION level to POST_KERNEL and keeping both parent and
child on the same level is causing problems, so fix this by putting them
on different priorities in POST_KERNEL.

Also, this sample runs fine in qemu, so make it the integration
platform.

Fixes #62772

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
