### PR TITLE
Small ec_host_cmd fixes

### DIFF
--- a/include/zephyr/mgmt/ec_host_cmd/ec_host_cmd.h
+++ b/include/zephyr/mgmt/ec_host_cmd/ec_host_cmd.h
@@ -170,8 +170,8 @@ struct ec_host_cmd_handler {
  */
 #define EC_HOST_CMD_HANDLER(_id, _function, _version_mask, _request_type, _response_type)          \
 	const STRUCT_SECTION_ITERABLE(ec_host_cmd_handler, __cmd##_id) = {                         \
-		.id = _id,                                                                         \
 		.handler = _function,                                                              \
+		.id = _id,                                                                         \
 		.version_mask = _version_mask,                                                     \
 		.min_rqt_size = sizeof(_request_type),                                             \
 		.min_rsp_size = sizeof(_response_type),                                            \
@@ -190,8 +190,8 @@ struct ec_host_cmd_handler {
  */
 #define EC_HOST_CMD_HANDLER_UNBOUND(_id, _function, _version_mask)                                 \
 	const STRUCT_SECTION_ITERABLE(ec_host_cmd_handler, __cmd##_id) = {                         \
-		.id = _id,                                                                         \
 		.handler = _function,                                                              \
+		.id = _id,                                                                         \
 		.version_mask = _version_mask,                                                     \
 		.min_rqt_size = 0,                                                                 \
 		.min_rsp_size = 0,                                                                 \

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_spi_stm32.c
@@ -136,8 +136,8 @@ struct dma_stream {
 struct ec_host_cmd_spi_cfg {
 	SPI_TypeDef *spi;
 	const struct pinctrl_dev_config *pcfg;
-	size_t pclk_len;
 	const struct stm32_pclken *pclken;
+	size_t pclk_len;
 };
 
 struct ec_host_cmd_spi_ctx {
@@ -189,9 +189,9 @@ static int prepare_rx(struct ec_host_cmd_spi_ctx *hc_spi);
                                                                                                    \
 	static struct ec_host_cmd_spi_cfg ec_host_cmd_spi_cfg = {                                  \
 		.spi = (SPI_TypeDef *)DT_REG_ADDR(id),                                             \
+		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(id),                                             \
 		.pclken = pclken,                                                                  \
 		.pclk_len = DT_NUM_CLOCKS(id),                                                     \
-		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(id),                                             \
 	};                                                                                         \
                                                                                                    \
 	static struct dma_stream dma_rx = {SPI_DMA_CHANNEL_INIT(id, rx, RX, PERIPHERAL, MEMORY)};  \

--- a/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
+++ b/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
@@ -15,6 +15,7 @@
 
 LOG_MODULE_REGISTER(host_cmd_handler, CONFIG_EC_HC_LOG_LEVEL);
 
+#ifdef CONFIG_EC_HOST_CMD_INITIALIZE_AT_BOOT
 #define EC_HOST_CMD_CHOSEN_BACKEND_LIST                                                            \
 	zephyr_host_cmd_espi_backend, zephyr_host_cmd_shi_backend, zephyr_host_cmd_uart_backend,   \
 		zephyr_host_cmd_spi_backend
@@ -26,6 +27,7 @@ LOG_MODULE_REGISTER(host_cmd_handler, CONFIG_EC_HC_LOG_LEVEL);
 	+0
 
 BUILD_ASSERT(NUMBER_OF_CHOSEN_BACKENDS < 2, "Number of chosen backends > 1");
+#endif
 
 #define RX_HEADER_SIZE (sizeof(struct ec_host_cmd_request_header))
 #define TX_HEADER_SIZE (sizeof(struct ec_host_cmd_response_header))


### PR DESCRIPTION
2 small fixes:
-check number of backends only if autoinit is enabled
-order init of structures members according to the structure definition 