### PR TITLE
drivers: serial: uart_nrfx_uarte: coexisting async and interrupt API

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -937,11 +937,6 @@ static int uarte_nrfx_callback_set(const struct device *dev,
 	data->async->user_callback = callback;
 	data->async->user_data = user_data;
 
-#if defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS) && defined(UARTE_INTERRUPT_DRIVEN)
-	data->int_driven->cb = NULL;
-	data->int_driven->cb_data = NULL;
-#endif
-
 	return 0;
 }
 
@@ -1680,11 +1675,6 @@ static void uarte_nrfx_irq_callback_set(const struct device *dev,
 
 	data->int_driven->cb = cb;
 	data->int_driven->cb_data = cb_data;
-
-#if defined(UARTE_ANY_ASYNC) && defined(CONFIG_UART_EXCLUSIVE_API_CALLBACKS)
-	data->async->user_callback = NULL;
-	data->async->user_data = NULL;
-#endif
 }
 #endif /* UARTE_INTERRUPT_DRIVEN */
 


### PR DESCRIPTION
This commit fixes an issue with the nrfx uarte driver to allow the async and interrupt driven UART APIs to coexist on different uart instances. As both APIs cannot be used simultaneously for a given instance, there is no need to handle
CONFIG_UART_EXCLUSIVE_API_CALLBACKS in this driver.