### PR TITLE
Bluetooth: Mesh: Fix printing device UUID

### DIFF
--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -675,7 +675,7 @@ int bt_mesh_prov_enable(bt_mesh_prov_bearer_t bearers)
 		return -EALREADY;
 	}
 
-#if IS_ENABLED(CONFIG_BT_MESH_PROV_DEVICE_LOG_LEVEL)
+#if defined(CONFIG_BT_MESH_PROV_DEVICE_LOG_LEVEL)
 	if (CONFIG_BT_MESH_PROV_DEVICE_LOG_LEVEL > 2) {
 		struct bt_uuid_128 uuid = { .uuid = { BT_UUID_TYPE_128 } };
 


### PR DESCRIPTION
IS_ENABLED was incorrectly used here.