### PR TITLE
doc: Issue warnings when a code-sample role points to a sample that does not exist.

### DIFF
--- a/boards/arm/atsamr21_xpro/doc/index.rst
+++ b/boards/arm/atsamr21_xpro/doc/index.rst
@@ -159,7 +159,7 @@ externally connected SPI devices.
 +-------------+------------------------------------------------------------------------------------------+
 
 Zephyr provide several samples that can use this technology. You can check
-:zephyr:code-sample:`wpanusb` and :zephyr:code-sample:`wpan-serial` examples as starting
+:zephyr:code-sample:`wpan-usb` and :zephyr:code-sample:`wpan-serial` examples as starting
 points. Another good test can be done with IPv6 by using the server/client
 echo demo. More information at :zephyr:code-sample:`sockets-echo-server` and
 :zephyr:code-sample:`sockets-echo-client`.

--- a/doc/_extensions/zephyr/domain.py
+++ b/doc/_extensions/zephyr/domain.py
@@ -214,7 +214,7 @@ class ZephyrDomain(Domain):
     label = "Zephyr Project"
 
     roles = {
-        "code-sample": XRefRole(innernodeclass=nodes.inline),
+        "code-sample": XRefRole(innernodeclass=nodes.inline, warn_dangling=True),
     }
 
     directives = {"code-sample": CodeSampleDirective}

--- a/doc/connectivity/networking/api/mqtt_sn.rst
+++ b/doc/connectivity/networking/api/mqtt_sn.rst
@@ -124,7 +124,7 @@ has no effect on the transport, however. If you want to close the transport (e.g
 the socket), call ``mqtt_sn_client_deinit``, which will deinit the transport as well.
 
 Zephyr provides sample code utilizing the MQTT-SN client API. See
-:zephyr:code-sample:`mqtt-sn-publisher-sample` for more information.
+:zephyr:code-sample:`mqtt-sn-publisher` for more information.
 
 Deviations from the standard
 ****************************

--- a/samples/net/sockets/echo/README.rst
+++ b/samples/net/sockets/echo/README.rst
@@ -1,4 +1,4 @@
-.. zephyr:code-sample:: socket-echo
+.. zephyr:code-sample:: sockets-echo
    :name: Echo server (simple)
    :relevant-api: bsd_sockets
 

--- a/samples/net/wpanusb/README.rst
+++ b/samples/net/wpanusb/README.rst
@@ -1,4 +1,4 @@
-.. zephyr:code-sample:: _wpanusb
+.. zephyr:code-sample:: wpan-usb
    :name: 802.15.4 USB
    :relevant-api: ieee802154 _usb_device_core_api
 

--- a/samples/subsys/mgmt/updatehub/README.rst
+++ b/samples/subsys/mgmt/updatehub/README.rst
@@ -203,7 +203,7 @@ Step 4.3: Build for Modem
 
 Modem needs add ``overlay-modem.conf``.  Now, a DTC overlay file is used to
 configure the glue between the modem and an arduino headers.  The modem config
-uses PPP over GSM modem, see :zephyr:code-sample:`gsm-modem-sample` sample application.
+uses PPP over GSM modem, see :zephyr:code-sample:`gsm-modem` sample application.
 
 .. zephyr-app-commands::
     :zephyr-app: zephyr/samples/subsys/mgmt/updatehub


### PR DESCRIPTION
When introducing the new code-sample Sphinx directive and role, I inadvertently missed to enable warnings for dangling references, to prevent folks from creating references to non-existing code samples. 

This pull request fixes this omission, and also fixes a couple dangling references that got silently introduced.