### PR TITLE
native_simulator: Be sure the symbol_to_keep section is kept

### DIFF
--- a/boards/posix/common/natsim_config.cmake
+++ b/boards/posix/common/natsim_config.cmake
@@ -4,6 +4,9 @@
 set(zephyr_build_path ${CMAKE_BINARY_DIR}/zephyr)
 get_property(CCACHE GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
 
+target_link_options(native_simulator INTERFACE
+  "-T ${ZEPHYR_BASE}/boards/posix/common/natsim_linker_script.ld")
+
 set(nsi_config_content
   ${nsi_config_content}
   "NSI_BUILD_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_COMPILE_OPTIONS>,\ >"

--- a/boards/posix/common/natsim_linker_script.ld
+++ b/boards/posix/common/natsim_linker_script.ld
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Extra linker command/script file for the native simulator runner
+ */
+
+SECTIONS
+ {
+	symbol_to_keep :
+	{
+		KEEP(*(symbol_to_keep*));
+	}
+ } INSERT AFTER .data;
+
+/*
+ * Note this script augments the default native simulator linker script
+ */


### PR DESCRIPTION
The native simulator final link can garbage collect unused symbols. So let's ensure the symbol to keep ones are indeed kept even if not used.