### PR TITLE
doc: code-sample: Fix "text" attribute for code sample links.

### DIFF
--- a/doc/_extensions/zephyr/domain.py
+++ b/doc/_extensions/zephyr/domain.py
@@ -267,7 +267,7 @@ class ZephyrDomain(Domain):
                     code_sample_info["docname"],
                     code_sample_info["id"],
                     contnode,
-                    code_sample_info["description"],
+                    code_sample_info["description"].astext(),
                 )
 
     def add_code_sample(self, code_sample):


### PR DESCRIPTION
A link to a code-sample should have its "text" attribute set to the text description of the sample, not the description _node_.

This fixes this kind of bogus tooltip:

<img width="642" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/128251/47f8c992-d55d-4e37-9bc2-3c9b39d18c3b">

Now:

<img width="476" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/128251/45e5e7bf-ef1c-410d-b24b-325251e7e193">

