### PR TITLE
mm_drv: tlb: Fix compile time warning

### DIFF
--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -668,7 +668,7 @@ static int sys_mm_drv_mm_init(const struct device *dev)
 
 		__ASSERT(false,
 			 "unused l2 pointer is outside of l2 sram range %p\n",
-			 UNUSED_L2_START_ALIGNED);
+			 (void *)UNUSED_L2_START_ALIGNED);
 		return -EFAULT;
 	}
 


### PR DESCRIPTION
This fixes the following compile time warning;
```
zephyr/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c: In function 'sys_mm_drv_mm_init': zephyr/include/zephyr/sys/__assert.h:44:52: error: format '%p' expects argument of type 'void *', but argument 2 has type 'long unsigned int' [-Werror=format=]
   44 | #define __ASSERT_MSG_INFO(fmt, ...) __ASSERT_PRINT("\t" fmt "\n", ##__VA_ARGS__)

by specifying the correct type in __ASSERT macro.
```