### PR TITLE
Bluetooth: Controller: Fix CIS assymmetric PHY usage

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -488,14 +488,17 @@ static void isr_tx(void *param)
 	/* Get reference to CIS LLL context */
 	cis_lll = param;
 
+	/* Acquire rx node for reception */
+	node_rx = ull_iso_pdu_rx_alloc_peek(1U);
+	LL_ASSERT(node_rx);
+
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	/* Get reference to ACL context */
 	const struct lll_conn *conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
-	/* Acquire rx node for reception */
-	node_rx = ull_iso_pdu_rx_alloc_peek(1U);
-	LL_ASSERT(node_rx);
+	/* PHY */
+	radio_phy_set(cis_lll->rx.phy, PHY_FLAGS_S8);
 
 	/* Encryption */
 	if (false) {
@@ -1086,6 +1089,9 @@ static void isr_prepare_subevent(void *param)
 	/* Get reference to ACL context */
 	const struct lll_conn *conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
 #endif /* CONFIG_BT_CTLR_LE_ENC */
+
+	/* PHY */
+	radio_phy_set(cis_lll->tx.phy, cis_lll->tx.phy_flags);
 
 	/* Encryption */
 	if (false) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -244,7 +244,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 #endif /* !CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
 
 	phy = cis_lll->rx.phy;
-	radio_phy_set(phy, cis_lll->rx.phy_flags);
+	radio_phy_set(phy, PHY_FLAGS_S8);
 	radio_aa_set(cis_lll->access_addr);
 	radio_crc_configure(PDU_CRC_POLYNOMIAL, sys_get_le24(conn_lll->crc_init));
 	lll_chan_set(data_chan_use);
@@ -738,6 +738,9 @@ static void isr_rx(void *param)
 	pdu_tx->rfu0 = 0U;
 	pdu_tx->rfu1 = 0U;
 
+	/* PHY */
+	radio_phy_set(cis_lll->tx.phy, cis_lll->tx.phy_flags);
+
 	/* Encryption */
 	if (false) {
 
@@ -879,6 +882,9 @@ static void isr_tx(void *param)
 	/* Get reference to ACL context */
 	const struct lll_conn *conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
 #endif /* CONFIG_BT_CTLR_LE_ENC */
+
+	/* PHY */
+	radio_phy_set(cis_lll->rx.phy, PHY_FLAGS_S8);
 
 	/* Encryption */
 	if (false) {
@@ -1093,6 +1099,9 @@ static void isr_prepare_subevent_common(void *param)
 	/* Get reference to ACL context */
 	const struct lll_conn *conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
 #endif /* CONFIG_BT_CTLR_LE_ENC */
+
+	/* PHY */
+	radio_phy_set(cis_lll->rx.phy, PHY_FLAGS_S8);
 
 	/* Encryption */
 	if (false) {

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -136,7 +136,9 @@ uint8_t ll_cis_parameters_set(uint8_t cis_id,
 	ll_iso_setup.stream[cis_idx].c_max_sdu = c_sdu;
 	ll_iso_setup.stream[cis_idx].p_max_sdu = p_sdu;
 	ll_iso_setup.stream[cis_idx].lll.tx.phy = c_phy;
+	ll_iso_setup.stream[cis_idx].lll.tx.phy_flags = PHY_FLAGS_S8;
 	ll_iso_setup.stream[cis_idx].lll.rx.phy = p_phy;
+	ll_iso_setup.stream[cis_idx].lll.rx.phy_flags = PHY_FLAGS_S8;
 	ll_iso_setup.stream[cis_idx].central.c_rtn = c_rtn;
 	ll_iso_setup.stream[cis_idx].central.p_rtn = p_rtn;
 	ll_iso_setup.cis_idx++;
@@ -635,7 +637,9 @@ uint8_t ll_cis_parameters_test_set(uint8_t cis_id, uint8_t nse,
 	ll_iso_setup.stream[cis_idx].lll.tx.max_pdu = c_bn ? c_pdu : 0U;
 	ll_iso_setup.stream[cis_idx].lll.rx.max_pdu = p_bn ? p_pdu : 0U;
 	ll_iso_setup.stream[cis_idx].lll.tx.phy = c_phy;
+	ll_iso_setup.stream[cis_idx].lll.tx.phy_flags = PHY_FLAGS_S8;
 	ll_iso_setup.stream[cis_idx].lll.rx.phy = p_phy;
+	ll_iso_setup.stream[cis_idx].lll.rx.phy_flags = PHY_FLAGS_S8;
 	ll_iso_setup.stream[cis_idx].lll.tx.bn = c_bn;
 	ll_iso_setup.stream[cis_idx].lll.rx.bn = p_bn;
 	ll_iso_setup.cis_idx++;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -256,11 +256,13 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 	cis->lll.nse = req->nse;
 
 	cis->lll.rx.phy = req->c_phy;
+	cis->lll.rx.phy_flags = PHY_FLAGS_S8;
 	cis->lll.rx.bn = req->c_bn;
 	cis->lll.rx.ft = req->c_ft;
 	cis->lll.rx.max_pdu = sys_le16_to_cpu(req->c_max_pdu);
 
 	cis->lll.tx.phy = req->p_phy;
+	cis->lll.tx.phy_flags = PHY_FLAGS_S8;
 	cis->lll.tx.bn = req->p_bn;
 	cis->lll.tx.ft = req->p_ft;
 	cis->lll.tx.max_pdu = sys_le16_to_cpu(req->p_max_pdu);


### PR DESCRIPTION
Fix CIS assymmetric PHY usage by adding implementation to use correct PHY in radio when switching transceiver.