### PR TITLE
Bluetooth: Controller: Miscellaneous fixes to bugs discovered during conformance testing

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -4245,8 +4245,8 @@ static void le_cis_established(struct pdu_data *pdu_data,
 	sys_put_le24(cis->sync_delay, sep->cis_sync_delay);
 	sys_put_le24(cig->c_latency, sep->c_latency);
 	sys_put_le24(cig->p_latency, sep->p_latency);
-	sep->c_phy = lll_cis_c->phy;
-	sep->p_phy = lll_cis_p->phy;
+	sep->c_phy = find_lsb_set(lll_cis_c->phy);
+	sep->p_phy = find_lsb_set(lll_cis_p->phy);
 	sep->nse = lll_cis->nse;
 	sep->c_bn = lll_cis_c->bn;
 	sep->p_bn = lll_cis_p->bn;

--- a/subsys/bluetooth/controller/ll_sw/ll_feat.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_feat.c
@@ -70,6 +70,11 @@ uint8_t ll_set_host_feature(uint8_t bit_number, uint8_t bit_value)
 	return BT_HCI_ERR_SUCCESS;
 }
 
+void ll_feat_reset(void)
+{
+	host_features = 0U;
+}
+
 uint64_t ll_feat_get(void)
 {
 	return LL_FEAT | (host_features & LL_FEAT_HOST_BIT_MASK);

--- a/subsys/bluetooth/controller/ll_sw/ll_feat_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ll_feat_internal.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+void ll_feat_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -44,6 +44,7 @@
 #include "lll_sync_iso.h"
 #include "lll_iso_tx.h"
 #include "lll_conn.h"
+#include "lll_conn_iso.h"
 #include "lll_df.h"
 
 #include "ull_adv_types.h"
@@ -60,6 +61,7 @@
 #endif /* CONFIG_BT_CTLR_USER_EXT */
 
 #include "isoal.h"
+#include "ll_feat_internal.h"
 #include "ull_internal.h"
 #include "ull_iso_internal.h"
 #include "ull_adv_internal.h"
@@ -69,7 +71,6 @@
 #include "ull_central_internal.h"
 #include "ull_iso_types.h"
 #include "ull_conn_internal.h"
-#include "lll_conn_iso.h"
 #include "ull_conn_iso_types.h"
 #include "ull_central_iso_internal.h"
 #include "ull_llcp.h"
@@ -898,6 +899,10 @@ void ll_reset(void)
 	err = ull_df_reset();
 	LL_ASSERT(!err);
 #endif
+
+#if defined(CONFIG_BT_CTLR_SET_HOST_FEATURE)
+	ll_feat_reset();
+#endif /* CONFIG_BT_CTLR_SET_HOST_FEATURE */
 
 	/* clear static random address */
 	(void)ll_addr_set(1U, NULL);

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -250,7 +250,8 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 	cis->p_max_sdu = (uint16_t)(req->p_max_sdu[1] & 0x0F) << 8 |
 				    req->p_max_sdu[0];
 
-	cis->lll.handle = 0xFFFF;
+	cis->lll.active = 0U;
+	cis->lll.handle = LLL_HANDLE_INVALID;
 	cis->lll.acl_handle = acl->lll.handle;
 	cis->lll.sub_interval = sys_get_le24(req->sub_interval);
 	cis->lll.nse = req->nse;
@@ -325,7 +326,6 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 	cis->lll.cie = 0U;
 	cis->lll.npi = 0U;
 	cis->lll.flush = LLL_CIS_FLUSH_NONE;
-	cis->lll.active = 0U;
 	cis->lll.datapath_ready_rx = 0U;
 	cis->lll.tx.payload_count = 0U;
 	cis->lll.rx.payload_count = 0U;


### PR DESCRIPTION
Fix missing host feature reset on HCI reset command.

Fix assertion due to late Peripheral CIS active flag being
initialized. CIS active flag shall be initialized when it is
acquired.

Fix PHY_C_TO_P and PHY_P_TO_C value in HCI LE CIS
Established Event.
