### PR TITLE
Twister uart basic api wide issue

### DIFF
--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -12,6 +12,7 @@ tests:
       - CONFIG_UART_WIDE_DATA=y
     tags: drivers uart
     filter: CONFIG_UART_CONSOLE
+    harness: keyboard
     arch_allow: arm
     platform_allow: nucleo_h743zi
     integration_platforms:


### PR DESCRIPTION
tests: drivers: uart: uart_basic_api: basic_api.wide issue

The test drivers.uart.basic_api.wide
can't work without keyboard
add harness: keyboard for this test

