### PR TITLE
device: only allow PRE_KERNEL_1/2 and POST_KERNEL levels

### DIFF
--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -94,6 +94,13 @@ Recommended Changes
   marked as deprecated as well. The new modem subsystem :kconfig:option:`CONFIG_MODEM_CMUX`
   and :kconfig:option:`CONFIG_MODEM_PPP`` should be used instead.
 
+* Device drivers should now be restricted to ``PRE_KERNEL_1``, ``PRE_KERNEL_2``
+  and ``POST_KERNEL`` initialization levels. Other device initialization levels,
+  including ``EARLY``, ``APPLICATION``, and ``SMP``, have been deprecated and
+  will be removed in future releases. Note that these changes do not apply to
+  initialization levels used in the context of the ``init.h`` API,
+  e.g. :c:macro:`SYS_INIT`.
+
 Picolibc-related Changes
 ************************
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -118,8 +118,8 @@ typedef int16_t device_handle_t;
  * stored in @ref device.data.
  * @param config Pointer to the device's private constant data, which will be
  * stored in @ref device.config.
- * @param level The device's initialization level. See @ref sys_init for
- * details.
+ * @param level The device's initialization level (PRE_KERNEL_1, PRE_KERNEL_2 or
+ * POST_KERNEL).
  * @param prio The device's priority within its initialization level. See
  * SYS_INIT() for details.
  * @param api Pointer to the device's API structure. Can be `NULL`.
@@ -169,7 +169,8 @@ typedef int16_t device_handle_t;
  * stored in @ref device.data.
  * @param config Pointer to the device's private constant data, which will be
  * stored in @ref device.config field.
- * @param level The device's initialization level. See SYS_INIT() for details.
+ * @param level The device's initialization level (PRE_KERNEL_1, PRE_KERNEL_2 or
+ * POST_KERNEL).
  * @param prio The device's priority within its initialization level. See
  * SYS_INIT() for details.
  * @param api Pointer to the device's API structure. Can be `NULL`.
@@ -931,6 +932,25 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 		DEVICE_NAME_GET(dev_id)) =                                     \
 		Z_DEVICE_INIT(name, pm, data, config, api, state, deps)
 
+/* deprecated device initialization levels */
+#define Z_DEVICE_LEVEL_DEPRECATED_EARLY                                        \
+	__WARN("EARLY device driver level is deprecated")
+#define Z_DEVICE_LEVEL_DEPRECATED_PRE_KERNEL_1
+#define Z_DEVICE_LEVEL_DEPRECATED_PRE_KERNEL_2
+#define Z_DEVICE_LEVEL_DEPRECATED_POST_KERNEL
+#define Z_DEVICE_LEVEL_DEPRECATED_APPLICATION                                  \
+	__WARN("APPLICATION device driver level is deprecated")
+#define Z_DEVICE_LEVEL_DEPRECATED_SMP                                          \
+	__WARN("SMP device driver level is deprecated")
+
+/**
+ * @brief Issue a warning if the given init level is deprecated.
+ *
+ * @param level Init level
+ */
+#define Z_DEVICE_LEVEL_CHECK_DEPRECATED_LEVEL(level)                           \
+	Z_DEVICE_LEVEL_DEPRECATED_##level
+
 /**
  * @brief Define the init entry for a device.
  *
@@ -942,6 +962,8 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * @param prio Initialization priority.
  */
 #define Z_DEVICE_INIT_ENTRY_DEFINE(node_id, dev_id, init_fn_, level, prio)     \
+	Z_DEVICE_LEVEL_CHECK_DEPRECATED_LEVEL(level)                           \
+                                                                               \
 	static const Z_DECL_ALIGN(struct init_entry) __used __noasan           \
 		Z_INIT_ENTRY_SECTION(level, prio,                              \
 				     Z_DEVICE_INIT_SUB_PRIO(node_id))          \

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -284,9 +284,9 @@ ZTEST(device, test_device_init_level)
 	bool seq_correct = true;
 
 	/* we check if the stored executing sequence for different level is
-	 * correct, and it should be 1, 2, 3, 4
+	 * correct, and it should be 1, 2, 3
 	 */
-	for (int i = 0; i < 4; i++) {
+	for (int i = 0; i < 3; i++) {
 		if (init_level_sequence[i] != (i + 1)) {
 			seq_correct = false;
 		}

--- a/tests/kernel/device/src/test_driver_init.c
+++ b/tests/kernel/device/src/test_driver_init.c
@@ -19,7 +19,6 @@
 #define MY_DRIVER_LV_1    "my_driver_level_1"
 #define MY_DRIVER_LV_2    "my_driver_level_2"
 #define MY_DRIVER_LV_3    "my_driver_level_3"
-#define MY_DRIVER_LV_4    "my_driver_level_4"
 #define MY_DRIVER_PRI_1    "my_driver_priority_1"
 #define MY_DRIVER_PRI_2    "my_driver_priority_2"
 #define MY_DRIVER_PRI_3    "my_driver_priority_3"
@@ -28,7 +27,6 @@
 #define LEVEL_PRE_KERNEL_1	1
 #define LEVEL_PRE_KERNEL_2	2
 #define LEVEL_POST_KERNEL	3
-#define LEVEL_APPLICATION	4
 
 #define PRIORITY_1	1
 #define PRIORITY_2	2
@@ -37,7 +35,7 @@
 
 
 /* this is for storing sequence during initialization */
-__pinned_bss int init_level_sequence[4] = {0};
+__pinned_bss int init_level_sequence[3] = {0};
 __pinned_bss int init_priority_sequence[4] = {0};
 __pinned_bss int init_sub_priority_sequence[3] = {0};
 __pinned_bss unsigned int seq_level_cnt;
@@ -82,14 +80,6 @@ static int my_driver_lv_2_init(const struct device *dev)
 static int my_driver_lv_3_init(const struct device *dev)
 {
 	init_level_sequence[seq_level_cnt] = LEVEL_POST_KERNEL;
-	seq_level_cnt++;
-
-	return 0;
-}
-
-static int my_driver_lv_4_init(const struct device *dev)
-{
-	init_level_sequence[seq_level_cnt] = LEVEL_APPLICATION;
 	seq_level_cnt++;
 
 	return 0;
@@ -173,10 +163,6 @@ DEVICE_DEFINE(my_driver_level_3, MY_DRIVER_LV_3, &my_driver_lv_3_init,
 		NULL, NULL, NULL, POST_KERNEL,
 		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs_my_drivers);
 
-DEVICE_DEFINE(my_driver_level_4, MY_DRIVER_LV_4, &my_driver_lv_4_init,
-		NULL, NULL, NULL, APPLICATION,
-		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &funcs_my_drivers);
-
 /* We use priority value of 20 to create a possible sorting conflict with
  * priority value of 2.  So if the linker sorting isn't working correctly
  * we'll find out.
@@ -201,8 +187,8 @@ DEVICE_DEFINE(my_driver_priority_3, MY_DRIVER_PRI_3,
  * other in devicetree so that we can validate linker sorting.
  */
 DEVICE_DT_DEFINE(DT_NODELABEL(fakedomain_0), my_driver_sub_pri_0_init,
-		NULL, NULL, NULL, APPLICATION, 33, NULL);
+		NULL, NULL, NULL, POST_KERNEL, 33, NULL);
 DEVICE_DT_DEFINE(DT_NODELABEL(fakedomain_1), my_driver_sub_pri_1_init,
-		NULL, NULL, NULL, APPLICATION, 33, NULL);
+		NULL, NULL, NULL, POST_KERNEL, 33, NULL);
 DEVICE_DT_DEFINE(DT_NODELABEL(fakedomain_2), my_driver_sub_pri_2_init,
-		NULL, NULL, NULL, APPLICATION, 33, NULL);
+		NULL, NULL, NULL, POST_KERNEL, 33, NULL);


### PR DESCRIPTION
Because devices share the same underlying infrastructure with `SYS_INIT`,
the same levels have always been available. However, not all of them are
needed, and some are not even usable. For example, `EARLY` can't be used
because when initialized, `z_device_state_init` has not been called yet.
`SMP` has never been used by device drivers, and it is now in question,
likely to be moved to SMP specific hooks. Finally, `APPLICATION` does
not make much sense in the context of Kernel devices. Note that of the 3
levels just mentioned, only one was actively tested (`APPLICATION`) by
Kernel tests, meaning others were likely never considered in the context
of devices.

This patch leaves `PRE_KERNEL_1`, `PRE_KERNEL_2` and `POST_KERNEL`
available to devices. Others have been deprecated, and will generate a
compiler warning if used.