### PR TITLE
net: lwm2m: Fix build warning on access-control object

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_access_control.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_access_control.c
@@ -432,10 +432,10 @@ static int ac_control_init(void)
 	ac_obj.create_cb = ac_create;
 	lwm2m_register_obj(&ac_obj);
 
-#if !IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
-	/* add the objects/object instances that were created before the ac control object */
-	add_existing_objects();
-#endif /* CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP */
+	if (!IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)) {
+		/* add the objects/object instances that were created before the ac control */
+		add_existing_objects();
+	}
 	return 0;
 }
 


### PR DESCRIPTION
With bootstrap one function is unused. Fix by changing ifdef to if (IS_ENABLED()) so linker can drop it.