### PR TITLE
net: lwm2m: Don't allow operations on security object

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2330,6 +2330,11 @@ int handle_request(struct coap_packet *request, struct lwm2m_message *msg)
 			goto error;
 		}
 #endif
+		if (msg->path.obj_id == LWM2M_OBJECT_SECURITY_ID && !msg->ctx->bootstrap_mode) {
+			r = -EACCES;
+			goto error;
+		}
+
 		switch (msg->operation) {
 
 		case LWM2M_OP_READ:


### PR DESCRIPTION
In spec:
> The LwM2M Client MUST reject any LwM2M Server operation on the Security Object (ID: 0) with an "4.01 Unauthorized" response  code.