### PR TITLE
testsuite: coverage: extend code coverage to include risc-v

### DIFF
--- a/subsys/testsuite/coverage/coverage_ram.ld
+++ b/subsys/testsuite/coverage/coverage_ram.ld
@@ -26,9 +26,6 @@ SECTION_DATA_PROLOGUE(_GCOV_BSS_SECTION_NAME,(NOLOAD),)
 
 	__gcov_bss_end = .;
 } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-__gcov_bss_num_words = ((__gcov_bss_end - __gcov_bss_start) >> 2);
-__gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
 #endif
 
 #ifdef CONFIG_X86_64
@@ -42,9 +39,6 @@ SECTION_PROLOGUE(_GCOV_BSS_SECTION_NAME, (NOLOAD), ALIGN(16))
 	__gcov_bss_end = .;
 }GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
-__gcov_bss_num_words = ((__gcov_bss_end - __gcov_bss_start) >> 2);
-__gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
-
 #elif CONFIG_X86
 SECTION_PROLOGUE(_GCOV_BSS_SECTION_NAME, (NOLOAD),)
 {
@@ -55,9 +49,6 @@ SECTION_PROLOGUE(_GCOV_BSS_SECTION_NAME, (NOLOAD),)
 	MMU_PAGE_ALIGN
 	__gcov_bss_end = .;
 } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-
-__gcov_bss_num_words = ((__gcov_bss_end - __gcov_bss_start) >> 2);
-__gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
 #endif
 
 #ifdef CONFIG_ARC
@@ -73,7 +64,19 @@ SECTION_PROLOGUE(_GCOV_BSS_SECTION_NAME, (NOLOAD),)
 #endif
 	__gcov_bss_end = .;
 } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#endif
+
+#ifdef CONFIG_RISCV
+SECTION_PROLOGUE(_GCOV_BSS_SECTION_NAME, (NOLOAD),)
+{
+	MPU_MIN_SIZE_ALIGN
+	__gcov_bss_start = .;
+	*(".bss.__gcov0.*");
+	. = ALIGN(4);
+	MPU_MIN_SIZE_ALIGN
+	__gcov_bss_end = .;
+} GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#endif
 
 __gcov_bss_num_words = ((__gcov_bss_end - __gcov_bss_start) >> 2);
 __gcov_bss_size = __gcov_bss_end - __gcov_bss_start;
-#endif

--- a/subsys/testsuite/coverage/coverage_rodata.ld
+++ b/subsys/testsuite/coverage/coverage_rodata.ld
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef CONFIG_64BIT
+. = ALIGN(8);
+#else
 . = ALIGN(4);
+#endif
 
 PROVIDE_HIDDEN (__init_array_start = .);
 KEEP (*(SORT(.init_array.*)))


### PR DESCRIPTION
This PR adds regions for gcov symbols in bss to enable gcov functionality for risc-v