### PR TITLE
Bluetooth: BAP: fix bt_bap_broadcast_source_param struct name

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -839,7 +839,6 @@ int bt_bap_broadcast_source_reconfig(struct bt_bap_broadcast_source *source,
 			struct bt_bap_stream *subgroup_stream;
 			struct bt_iso_chan_io_qos *iso_qos;
 			struct bt_bap_stream *stream;
-			bool stream_in_subgroup;
 			size_t stream_idx;
 
 			stream_param = &subgroup_param->params[j];
@@ -848,7 +847,6 @@ int bt_bap_broadcast_source_reconfig(struct bt_bap_broadcast_source *source,
 			stream_idx = 0U;
 			SYS_SLIST_FOR_EACH_CONTAINER(&subgroup->streams, subgroup_stream, _node) {
 				if (subgroup_stream == stream) {
-					stream_in_subgroup = true;
 					break;
 				}
 

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -664,7 +664,6 @@ static void unicast_audio_start(struct bt_bap_unicast_group *unicast_group, bool
 	stream_param[1].stream = &unicast_client_source_streams[0];
 	stream_param[1].ep = unicast_source_eps[bt_conn_index(default_conn)][0];
 	stream_param[1].codec_cfg = &unicast_preset_16_2_1.codec_cfg;
-	stream_param[1].qos = &unicast_preset_16_2_1.qos;
 
 	UNSET_FLAG(flag_started);
 


### PR DESCRIPTION
Fix a couple bluetooth related build errors.

---

Fixes #62911 (together with https://github.com/zephyrproject-rtos/zephyr/pull/62906)
qos field removed in #61601 (got in 3 weeks ago), test that used it came in https://github.com/zephyrproject-rtos/zephyr/pull/60092 which passed CI 3 weeks ago 