### PR TITLE
.gitlint: de-duplicate defaults with zephyr_commit_rules.py

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,4 +1,5 @@
 # All these sections are optional, edit this file as you like.
+# Zephyr-specific defaults are located in scripts/gitlint/zephyr_commit_rules.py
 [general]
 ignore=title-trailing-punctuation, T3, title-max-length, T1, body-hard-tab, B3, B1
 # verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
@@ -16,13 +17,13 @@ debug = false
 extra-path=scripts/gitlint
 
 [title-max-length-no-revert]
-line-length=75
+# line-length=75
 
 [body-min-line-count]
-min-line-count=1
+# min-line-count=1
 
 [body-max-line-count]
-max-line-count=200
+# max-line-count=200
 
 [title-starts-with-subsystem]
 regex = ^(?!subsys:)(([^:]+):)(\s([^:]+):)*\s(.+)$
@@ -42,7 +43,7 @@ words=wip
 
 [max-line-length-with-exceptions]
 # B1 = body-max-line-length
-line-length=75
+# line-length=75
 
 [body-min-length]
 min-length=3

--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -24,8 +24,8 @@ class BodyMinLineCount(CommitRule):
     # A rule MUST have an *unique* id, we recommend starting with UC (for User-defined Commit-rule).
     id = "UC6"
 
-    # A rule MAY have an option_spec if its behavior should be configurable.
-    options_spec = [IntOption('min-line-count', 2, "Minimum body line count excluding Signed-off-by")]
+    # A rule MAY have an options_spec if its behavior should be configurable.
+    options_spec = [IntOption('min-line-count', 1, "Minimum body line count excluding Signed-off-by")]
 
     def validate(self, commit):
         filtered = [x for x in commit.message.body if not x.lower().startswith("signed-off-by") and x != '']
@@ -42,8 +42,8 @@ class BodyMaxLineCount(CommitRule):
     # A rule MUST have an *unique* id, we recommend starting with UC (for User-defined Commit-rule).
     id = "UC1"
 
-    # A rule MAY have an option_spec if its behavior should be configurable.
-    options_spec = [IntOption('max-line-count', 3, "Maximum body line count")]
+    # A rule MAY have an options_spec if its behavior should be configurable.
+    options_spec = [IntOption('max-line-count', 200, "Maximum body line count")]
 
     def validate(self, commit):
         line_count = len(commit.message.body)
@@ -78,7 +78,7 @@ class TitleMaxLengthRevert(LineRule):
     name = "title-max-length-no-revert"
     id = "UC5"
     target = CommitMessageTitle
-    options_spec = [IntOption('line-length', 72, "Max line length")]
+    options_spec = [IntOption('line-length', 75, "Max line length")]
     violation_message = "Commit title exceeds max length ({0}>{1})"
 
     def validate(self, line, _commit):
@@ -103,7 +103,7 @@ class MaxLineLengthExceptions(LineRule):
     name = "max-line-length-with-exceptions"
     id = "UC4"
     target = CommitMessageBody
-    options_spec = [IntOption('line-length', 80, "Max line length")]
+    options_spec = [IntOption('line-length', 75, "Max line length")]
     violation_message = "Commit message body line exceeds max length ({0}>{1})"
 
     def validate(self, line, _commit):


### PR DESCRIPTION
We don't need to have two different sets of Zephyr-specific default values overriding one another, it's confusing.

Note this commit makes NO functional change, the effective defaults stay the same. It does however make it easier to change defaults in the future.