### PR TITLE
wdt: nxp_s32: use clock control APIs

### DIFF
--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
@@ -64,24 +64,7 @@
 };
 
 &swt0 {
-	clock-frequency = <48000000>;
 	status = "okay";
-};
-
-&swt1 {
-	clock-frequency = <48000000>;
-};
-
-&swt2 {
-	clock-frequency = <48000000>;
-};
-
-&swt3 {
-	clock-frequency = <48000000>;
-};
-
-&swt4 {
-	clock-frequency = <48000000>;
 };
 
 &emdio {

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
@@ -5,6 +5,7 @@
  */
 
 /dts-v1/;
+#include <dt-bindings/clock/nxp_s32z2_clock.h>
 #include <arm/nxp/nxp_s32z27x_rtu0_r52.dtsi>
 #include "s32z270dc2_r52.dtsi"
 

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
@@ -5,6 +5,7 @@
  */
 
 /dts-v1/;
+#include <dt-bindings/clock/nxp_s32z2_clock.h>
 #include <arm/nxp/nxp_s32z27x_rtu1_r52.dtsi>
 #include "s32z270dc2_r52.dtsi"
 

--- a/drivers/watchdog/Kconfig.nxp_s32
+++ b/drivers/watchdog/Kconfig.nxp_s32
@@ -1,10 +1,11 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config WDT_NXP_S32
 	bool "NXP S32 SWT driver"
 	default y
 	depends on DT_HAS_NXP_S32_SWT_ENABLED
+	select CLOCK_CONTROL
 	select NOCACHE_MEMORY
 	help
 	  Enable the Software Watchdog Timer (SWT) driver.

--- a/dts/arm/nxp/nxp_s32z27x_rtu0_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_rtu0_r52.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -48,6 +48,7 @@
 			compatible = "nxp,s32-swt";
 			reg = <0x76000000 0x10000>;
 			interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_FIRC_CLK>;
 			status = "disabled";
 		};
 
@@ -55,6 +56,7 @@
 			compatible = "nxp,s32-swt";
 			reg = <0x76010000 0x10000>;
 			interrupts = <GIC_SPI 9 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_FIRC_CLK>;
 			status = "disabled";
 		};
 
@@ -62,6 +64,7 @@
 			compatible = "nxp,s32-swt";
 			reg = <0x76220000 0x10000>;
 			interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_FIRC_CLK>;
 			status = "disabled";
 		};
 
@@ -69,6 +72,7 @@
 			compatible = "nxp,s32-swt";
 			reg = <0x76230000 0x10000>;
 			interrupts = <GIC_SPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_FIRC_CLK>;
 			status = "disabled";
 		};
 
@@ -76,6 +80,7 @@
 			compatible = "nxp,s32-swt";
 			reg = <0x76140000 0x10000>;
 			interrupts = <GIC_SPI 12 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_FIRC_CLK>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nxp/nxp_s32z27x_rtu1_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_rtu1_r52.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -48,6 +48,7 @@
 			compatible = "nxp,s32-swt";
 			reg = <0x76800000 0x10000>;
 			interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_FIRC_CLK>;
 			status = "disabled";
 		};
 
@@ -55,6 +56,7 @@
 			compatible = "nxp,s32-swt";
 			reg = <0x76810000 0x10000>;
 			interrupts = <GIC_SPI 9 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_FIRC_CLK>;
 			status = "disabled";
 		};
 
@@ -62,6 +64,7 @@
 			compatible = "nxp,s32-swt";
 			reg = <0x76a20000 0x10000>;
 			interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_FIRC_CLK>;
 			status = "disabled";
 		};
 
@@ -69,6 +72,7 @@
 			compatible = "nxp,s32-swt";
 			reg = <0x76a30000 0x10000>;
 			interrupts = <GIC_SPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_FIRC_CLK>;
 			status = "disabled";
 		};
 
@@ -76,6 +80,7 @@
 			compatible = "nxp,s32-swt";
 			reg = <0x76940000 0x10000>;
 			interrupts = <GIC_SPI 12 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_FIRC_CLK>;
 			status = "disabled";
 		};
 	};

--- a/dts/bindings/watchdog/nxp,s32-swt.yaml
+++ b/dts/bindings/watchdog/nxp,s32-swt.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: Software Watchdog Timer (SWT)
@@ -14,7 +14,5 @@ properties:
   interrupts:
     required: true
 
-  clock-frequency:
-    type: int
+  clocks:
     required: true
-    description: Software Watchdog Timer module clock frequency, in Hz.


### PR DESCRIPTION
Use clock control API to retrieve the module's frequency and update the boards using it to provide the source clocks.