### PR TITLE
spi: nxp_s32: use clock control APIs

### DIFF
--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
@@ -7,46 +7,6 @@
 #include <arm/nxp/nxp_s32z27x_r52.dtsi>
 #include "s32z270dc2_r52-pinctrl-common.dtsi"
 
-&spi0 {
-	clock-frequency = <100000000>;
-};
-
-&spi1 {
-	clock-frequency = <100000000>;
-};
-
-&spi2 {
-	clock-frequency = <100000000>;
-};
-
-&spi3 {
-	clock-frequency = <120000000>;
-};
-
-&spi4 {
-	clock-frequency = <120000000>;
-};
-
-&spi5 {
-	clock-frequency = <120000000>;
-};
-
-&spi6 {
-	clock-frequency = <120000000>;
-};
-
-&spi7 {
-	clock-frequency = <100000000>;
-};
-
-&spi8 {
-	clock-frequency = <100000000>;
-};
-
-&spi9 {
-	clock-frequency = <100000000>;
-};
-
 &stm0 {
 	clock-frequency = <133333333>;
 };

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
@@ -5,6 +5,7 @@
  */
 
 /dts-v1/;
+#include <dt-bindings/clock/nxp_s32z2_clock.h>
 #include <arm/nxp/nxp_s32z27x_rtu0_r52.dtsi>
 #include "s32z270dc2_r52.dtsi"
 

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
@@ -5,6 +5,7 @@
  */
 
 /dts-v1/;
+#include <dt-bindings/clock/nxp_s32z2_clock.h>
 #include <arm/nxp/nxp_s32z27x_rtu1_r52.dtsi>
 #include "s32z270dc2_r52.dtsi"
 

--- a/drivers/spi/spi_nxp_s32.h
+++ b/drivers/spi/spi_nxp_s32.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -49,7 +49,8 @@ struct spi_nxp_s32_data {
 struct spi_nxp_s32_config {
 	uint8_t instance;
 	uint8_t num_cs;
-	uint32_t clock_frequency;
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
 	uint32_t sck_cs_delay;
 	uint32_t cs_sck_delay;
 	uint32_t cs_cs_delay;

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -457,6 +457,7 @@
 			compatible = "nxp,s32-spi";
 			reg = <0x40130000 0x10000>;
 			interrupts = <GIC_SPI 191 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_SPI0_CLK>;
 			num-cs = <5>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -467,6 +468,7 @@
 			compatible = "nxp,s32-spi";
 			reg = <0x40140000 0x10000>;
 			interrupts = <GIC_SPI 192 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_SPI1_CLK>;
 			num-cs = <5>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -477,6 +479,7 @@
 			compatible = "nxp,s32-spi";
 			reg = <0x40930000 0x10000>;
 			interrupts = <GIC_SPI 193 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_SPI2_CLK>;
 			num-cs = <5>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -487,6 +490,7 @@
 			compatible = "nxp,s32-spi";
 			reg = <0x40940000 0x10000>;
 			interrupts = <GIC_SPI 194 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_SPI3_CLK>;
 			num-cs = <5>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -497,6 +501,7 @@
 			compatible = "nxp,s32-spi";
 			reg = <0x40950000 0x10000>;
 			interrupts = <GIC_SPI 195 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_SPI4_CLK>;
 			num-cs = <5>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -507,6 +512,7 @@
 			compatible = "nxp,s32-spi";
 			reg = <0x42130000 0x10000>;
 			interrupts = <GIC_SPI 196 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_SPI5_CLK>;
 			num-cs = <5>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -517,6 +523,7 @@
 			compatible = "nxp,s32-spi";
 			reg = <0x42140000 0x10000>;
 			interrupts = <GIC_SPI 197 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_SPI6_CLK>;
 			num-cs = <5>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -527,6 +534,7 @@
 			compatible = "nxp,s32-spi";
 			reg = <0x42150000 0x10000>;
 			interrupts = <GIC_SPI 198 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_SPI7_CLK>;
 			num-cs = <5>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -537,6 +545,7 @@
 			compatible = "nxp,s32-spi";
 			reg = <0x42930000 0x10000>;
 			interrupts = <GIC_SPI 199 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_SPI8_CLK>;
 			num-cs = <5>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -547,6 +556,7 @@
 			compatible = "nxp,s32-spi";
 			reg = <0x42940000 0x10000>;
 			interrupts = <GIC_SPI 200 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_SPI9_CLK>;
 			num-cs = <5>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/bindings/spi/nxp,s32-spi.yaml
+++ b/dts/bindings/spi/nxp,s32-spi.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP S32 SPI controller
@@ -20,11 +20,8 @@ properties:
     description: |
       The number of the Chip Select signals.
 
-  clock-frequency:
-    type: int
+  clocks:
     required: true
-    description: |
-      Module clock frequency in Hz.
 
   pinctrl-0:
     required: true


### PR DESCRIPTION
Use clock control API to retrieve the module's frequency and update the boards using it to provide the source clocks.