### PR TITLE
counter: nxp_s32_sys_timer: use clock control APIs

### DIFF
--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
@@ -7,22 +7,6 @@
 #include <arm/nxp/nxp_s32z27x_r52.dtsi>
 #include "s32z270dc2_r52-pinctrl-common.dtsi"
 
-&stm0 {
-	clock-frequency = <133333333>;
-};
-
-&stm1 {
-	clock-frequency = <133333333>;
-};
-
-&stm2 {
-	clock-frequency = <133333333>;
-};
-
-&stm3 {
-	clock-frequency = <133333333>;
-};
-
 &swt0 {
 	status = "okay";
 };

--- a/drivers/counter/Kconfig.nxp_s32
+++ b/drivers/counter/Kconfig.nxp_s32
@@ -1,9 +1,10 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config COUNTER_NXP_S32_SYS_TIMER
 	bool "NXP S32 System Timer Module driver"
 	default y
 	depends on DT_HAS_NXP_S32_SYS_TIMER_ENABLED
+	select CLOCK_CONTROL
 	help
 	  Enable support for NXP S32 System Timer Module (STM) driver.

--- a/dts/arm/nxp/nxp_s32z27x_rtu0_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_rtu0_r52.dtsi
@@ -20,6 +20,7 @@
 			compatible = "nxp,s32-sys-timer";
 			reg = <0x76200000 0x10000>;
 			interrupts = <GIC_SPI 13 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_RTU0_REG_INTF_CLK>;
 			status = "disabled";
 		};
 
@@ -27,6 +28,7 @@
 			compatible = "nxp,s32-sys-timer";
 			reg = <0x76210000 0x10000>;
 			interrupts = <GIC_SPI 14 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_RTU0_REG_INTF_CLK>;
 			status = "disabled";
 		};
 
@@ -34,6 +36,7 @@
 			compatible = "nxp,s32-sys-timer";
 			reg = <0x76020000 0x10000>;
 			interrupts = <GIC_SPI 15 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_RTU0_REG_INTF_CLK>;
 			status = "disabled";
 		};
 
@@ -41,6 +44,7 @@
 			compatible = "nxp,s32-sys-timer";
 			reg = <0x76030000 0x10000>;
 			interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_RTU0_REG_INTF_CLK>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/nxp_s32z27x_rtu1_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_rtu1_r52.dtsi
@@ -20,6 +20,7 @@
 			compatible = "nxp,s32-sys-timer";
 			reg = <0x76a00000 0x10000>;
 			interrupts = <GIC_SPI 13 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_RTU1_REG_INTF_CLK>;
 			status = "disabled";
 		};
 
@@ -27,6 +28,7 @@
 			compatible = "nxp,s32-sys-timer";
 			reg = <0x76a10000 0x10000>;
 			interrupts = <GIC_SPI 14 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_RTU1_REG_INTF_CLK>;
 			status = "disabled";
 		};
 
@@ -34,6 +36,7 @@
 			compatible = "nxp,s32-sys-timer";
 			reg = <0x76820000 0x10000>;
 			interrupts = <GIC_SPI 15 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_RTU1_REG_INTF_CLK>;
 			status = "disabled";
 		};
 
@@ -41,6 +44,7 @@
 			compatible = "nxp,s32-sys-timer";
 			reg = <0x76830000 0x10000>;
 			interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_RTU1_REG_INTF_CLK>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/timer/nxp,s32-sys-timer.yaml
+++ b/dts/bindings/timer/nxp,s32-sys-timer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP S32 System Timer Module (STM)
@@ -14,10 +14,8 @@ properties:
   interrupts:
     required: true
 
-  clock-frequency:
-    type: int
+  clocks:
     required: true
-    description: Module clock frequency in Hz.
 
   prescaler:
     type: int


### PR DESCRIPTION
Use clock control API to retrieve the counter module's frequency and update the boards using it to provide the source clocks.