### PR TITLE
can: nxp_s32_canxl: use clock control APIs

### DIFF
--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
@@ -109,7 +109,6 @@
 &can0 {
 	pinctrl-0 = <&can0_default>;
 	pinctrl-names = "default";
-	clock-frequency = <80000000>;
 	bus-speed = <125000>;
 	sample-point = <875>;
 	sjw = <1>;
@@ -122,7 +121,6 @@
 &can1 {
 	pinctrl-0 = <&can1_default>;
 	pinctrl-names = "default";
-	clock-frequency = <80000000>;
 	bus-speed = <125000>;
 	sample-point = <875>;
 	sjw = <1>;

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
@@ -5,6 +5,7 @@
  */
 
 /dts-v1/;
+#include <dt-bindings/clock/nxp_s32z2_clock.h>
 #include <arm/nxp/nxp_s32z27x_rtu0_r52.dtsi>
 #include "s32z270dc2_r52.dtsi"
 

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
@@ -5,6 +5,7 @@
  */
 
 /dts-v1/;
+#include <dt-bindings/clock/nxp_s32z2_clock.h>
 #include <arm/nxp/nxp_s32z27x_rtu1_r52.dtsi>
 #include "s32z270dc2_r52.dtsi"
 

--- a/drivers/can/Kconfig.nxp_s32
+++ b/drivers/can/Kconfig.nxp_s32
@@ -1,10 +1,11 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config CAN_NXP_S32_CANXL
 	bool "NXP S32 CANXL driver"
 	default y
 	depends on DT_HAS_NXP_S32_CANXL_ENABLED
+	select CLOCK_CONTROL
 	help
 	  Enable support for NXP S32 CANXL driver.
 

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -688,6 +688,7 @@
 			interrupts = <GIC_SPI 224 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 					<GIC_SPI 225 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "RX_TX_DATA_IRQ", "INT_ERROR_IRQ";
+			clocks = <&clock NXP_S32_P5_CANXL_PE_CLK>;
 		};
 
 		can1: can@4751b000 {
@@ -700,6 +701,7 @@
 			interrupts = <GIC_SPI 226 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 					<GIC_SPI 227 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "RX_TX_DATA_IRQ", "INT_ERROR_IRQ";
+			clocks = <&clock NXP_S32_P5_CANXL_PE_CLK>;
 		};
 	};
 };

--- a/dts/bindings/can/nxp,s32-canxl.yaml
+++ b/dts/bindings/can/nxp,s32-canxl.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 NXP
+# Copyright 2022-2023 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -15,10 +15,8 @@ properties:
   interrupts:
     required: true
 
-  clock-frequency:
-    type: int
+  clocks:
     required: true
-    description: Module clock frequency in Hz.
 
   pinctrl-0:
     required: true


### PR DESCRIPTION
Use clock control API to retrieve the module's frequency and update the boards using it to provide the source clocks.