### PR TITLE
drivers: intc: plic: add support for multiple instances

### DIFF
--- a/arch/riscv/core/irq_manage.c
+++ b/arch/riscv/core/irq_manage.c
@@ -25,8 +25,10 @@ FUNC_NORETURN void z_irq_spurious(const void *unused)
 	LOG_ERR("Spurious interrupt detected! IRQ: %ld", mcause);
 #if defined(CONFIG_RISCV_HAS_PLIC)
 	if (mcause == RISCV_MACHINE_EXT_IRQ) {
-		LOG_ERR("PLIC interrupt line causing the IRQ: %d",
-			riscv_plic_get_irq());
+		unsigned int save_irq = riscv_plic_get_irq();
+		const struct device *save_dev = riscv_plic_get_dev();
+
+		LOG_ERR("PLIC interrupt line causing the IRQ: %d (%p)", save_irq, save_dev);
 	}
 #endif
 	z_riscv_fatal_error(K_ERR_SPURIOUS_IRQ, NULL);
@@ -43,8 +45,6 @@ int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 
 #if defined(CONFIG_RISCV_HAS_PLIC)
 	if (irq_get_level(irq) == 2) {
-		irq = irq_from_level_2(irq);
-
 		riscv_plic_set_priority(irq, priority);
 	}
 #else

--- a/drivers/interrupt_controller/CMakeLists.txt
+++ b/drivers/interrupt_controller/CMakeLists.txt
@@ -41,3 +41,5 @@ zephyr_library_sources_ifdef(CONFIG_RENESAS_RA_ICU          intc_ra_icu.c)
 if(CONFIG_INTEL_VTD_ICTL)
   zephyr_library_include_directories(${ZEPHYR_BASE}/arch/x86/include)
 endif()
+
+zephyr_library_include_directories(${ZEPHYR_BASE}/arch/common/include)

--- a/include/zephyr/drivers/interrupt_controller/riscv_plic.h
+++ b/include/zephyr/drivers/interrupt_controller/riscv_plic.h
@@ -12,24 +12,26 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_RISCV_PLIC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_RISCV_PLIC_H_
 
+#include <zephyr/device.h>
+
 /**
  * @brief Enable interrupt
  *
- * @param irq interrupt ID
+ * @param irq Multi-level encoded interrupt ID
  */
 void riscv_plic_irq_enable(uint32_t irq);
 
 /**
  * @brief Disable interrupt
  *
- * @param irq interrupt ID
+ * @param irq Multi-level encoded interrupt ID
  */
 void riscv_plic_irq_disable(uint32_t irq);
 
 /**
  * @brief Check if an interrupt is enabled
  *
- * @param irq interrupt ID
+ * @param irq Multi-level encoded interrupt ID
  * @return Returns true if interrupt is enabled, false otherwise
  */
 int riscv_plic_irq_is_enabled(uint32_t irq);
@@ -37,7 +39,7 @@ int riscv_plic_irq_is_enabled(uint32_t irq);
 /**
  * @brief Set interrupt priority
  *
- * @param irq interrupt ID
+ * @param irq Multi-level encoded interrupt ID
  * @param prio interrupt priority
  */
 void riscv_plic_set_priority(uint32_t irq, uint32_t prio);
@@ -47,6 +49,13 @@ void riscv_plic_set_priority(uint32_t irq, uint32_t prio);
  *
  * @return Returns the ID of an active interrupt
  */
-int riscv_plic_get_irq(void);
+unsigned int riscv_plic_get_irq(void);
+
+/**
+ * @brief Get active interrupt controller device
+ *
+ * @return Returns device pointer of the active interrupt device
+ */
+const struct device *riscv_plic_get_dev(void);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_RISCV_PLIC_H_ */

--- a/soc/riscv/riscv-privileged/common/soc_common_irq.c
+++ b/soc/riscv/riscv-privileged/common/soc_common_irq.c
@@ -47,7 +47,6 @@ void arch_irq_enable(unsigned int irq)
 	unsigned int level = irq_get_level(irq);
 
 	if (level == 2) {
-		irq = irq_from_level_2(irq);
 		riscv_plic_irq_enable(irq);
 		return;
 	}
@@ -68,7 +67,6 @@ void arch_irq_disable(unsigned int irq)
 	unsigned int level = irq_get_level(irq);
 
 	if (level == 2) {
-		irq = irq_from_level_2(irq);
 		riscv_plic_irq_disable(irq);
 		return;
 	}
@@ -89,7 +87,6 @@ int arch_irq_is_enabled(unsigned int irq)
 	unsigned int level = irq_get_level(irq);
 
 	if (level == 2) {
-		irq = irq_from_level_2(irq);
 		return riscv_plic_irq_is_enabled(irq);
 	}
 #endif
@@ -105,7 +102,6 @@ void z_riscv_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flag
 	unsigned int level = irq_get_level(irq);
 
 	if (level == 2) {
-		irq = irq_from_level_2(irq);
 		riscv_plic_set_priority(irq, prio);
 	}
 }

--- a/tests/drivers/build_all/interrupt_controller/intc_plic/Kconfig
+++ b/tests/drivers/build_all/interrupt_controller/intc_plic/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 Meta
+# SPDX-License-Identifier: Apache-2.0
+
+config NUM_IRQS
+	int ""
+
+source "Kconfig"

--- a/tests/drivers/build_all/interrupt_controller/intc_plic/app.multi_instance.overlay
+++ b/tests/drivers/build_all/interrupt_controller/intc_plic/app.multi_instance.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /{
+	soc {
+		plic1: interrupt-controller@8000000 {
+			riscv,max-priority = <7>;
+			riscv,ndev = <0x35>;
+			reg = <0x08000000 0x04000000>;
+			interrupts-extended = <
+				&hlic0 0x03
+				&hlic1 0x03
+				&hlic2 0x03
+				&hlic3 0x03
+				&hlic4 0x03
+				&hlic5 0x03
+				&hlic6 0x03
+				&hlic7 0x03
+			>;
+			interrupt-controller;
+			compatible = "sifive,plic-1.0.0";
+			#address-cells = <0x00>;
+			#interrupt-cells = <0x02>;
+		};
+	};
+
+	uart1: uart@10000100 {
+		interrupts = <0x0a 1>;
+		interrupt-parent = <&plic1>;
+		clock-frequency = <0x384000>;
+		reg = <0x10000100 0x100>;
+		compatible = "ns16550";
+		reg-shift = <0>;
+	};
+};

--- a/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
+++ b/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
@@ -10,3 +10,13 @@ common:
     - plic
 tests:
   drivers.interrupt_controller.intc_plic.build: {}
+  drivers.interrupt_controller.intc_plic.multi_instance.build:
+    extra_args:
+      DTC_OVERLAY_FILE="./app.multi_instance.overlay"
+    extra_configs:
+      - CONFIG_NUM_IRQS=116
+      - CONFIG_MULTI_LEVEL_INTERRUPTS=y
+      - CONFIG_DYNAMIC_INTERRUPTS=y
+      - CONFIG_NUM_2ND_LEVEL_AGGREGATORS=2
+      - CONFIG_2ND_LVL_INTR_01_OFFSET=3
+      - CONFIG_UART_INTERRUPT_DRIVEN=y


### PR DESCRIPTION
1. Refactored the build_all test added in #62541
2. Refactored the `intc_plic` driver to be multi-instance ready
3. Updated the `sw_isr_*` so that it also records the device pointer of the interrupt controllers & provide functions to do a lookup for the controller using the IRQN, as well as getting the ISR table offset for a controller
4. Updated the `intc_plic` driver to use the functions in the `sw_isr` so that it can differentiate parent controller from IRQN, and invoke the correct ISR with the correct offset from `sw_isr_*`
   - Modified some description in the `riscv_plic` header file, previously the driver expects the trimmed IRQN returned by `irq_from_level_2` as there can only be one controller, with multi-instance, we need the full multi-level-encoded IRQN, so that the driver can determine the right controller with `z_get_sw_isr_device` using the 1st level IRQ.
6. Added a build_all test for multi-instance on `qemu_riscv*` as no QEMU machine supports more than one PLIC. Not sure if this is helpful.

fixes #62441
fixes #62956
fixes #63465