### PR TITLE
misc: check_init_priorities: drop CONFIG_DEVICE_DEPS=y

### DIFF
--- a/tests/misc/check_init_priorities/prj.conf
+++ b/tests/misc/check_init_priorities/prj.conf
@@ -1,4 +1,1 @@
-# Required to force 2 stage linking
-CONFIG_DEVICE_DEPS=y
-
 CONFIG_CHECK_INIT_PRIORITIES=n


### PR DESCRIPTION
@gmarull I think this should take care of https://github.com/zephyrproject-rtos/zephyr/pull/61986/commits/00ed0e6d329215c0c53ebaaa60bd33814dbd88bf, tried to use POST_BUILD but that was making it try to run before the elf file was created for whatever reason, but the current setup works fine already apparently.

---

This runs fine without CONFIG_DEVICE_DEPS, let's drop it from here.