### PR TITLE
drivers: i2c: stm32: Fix for i2c PM

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -146,11 +146,6 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 		return ret;
 	}
 
-	ret = pm_device_runtime_get(dev);
-	if (ret < 0) {
-		return ret;
-	}
-
 	/* Send out messages */
 	k_sem_take(&data->bus_mutex, K_FOREVER);
 


### PR DESCRIPTION
Remove unwanted "pm_device_runtime_get" lock which makes i2c power management working incorrectly.

Fixes: #62790

Signed-off-by: Petr Hlineny <development@hlineny.cz>