### PR TITLE
ARC: boards: qemu: define vendor properly

### DIFF
--- a/boards/arc/qemu_arc/qemu_arc_em.dts
+++ b/boards/arc/qemu_arc/qemu_arc_em.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "QEMU ARC EM";
-	compatible = "qemu,arcem";
+	compatible = "snps,qemu-arcem";
 
 	cpus {
 		#address-cells = <1>;

--- a/boards/arc/qemu_arc/qemu_arc_hs.dts
+++ b/boards/arc/qemu_arc/qemu_arc_hs.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "QEMU ARC HS";
-	compatible = "qemu,archs";
+	compatible = "snps,qemu-archs";
 
 	cpus {
 		#address-cells = <1>;

--- a/boards/arc/qemu_arc/qemu_arc_hs5x.dts
+++ b/boards/arc/qemu_arc/qemu_arc_hs5x.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "QEMU ARC HS";
-	compatible = "qemu,archs";
+	compatible = "snps,qemu-archs";
 
 	cpus {
 		#address-cells = <1>;

--- a/boards/arc/qemu_arc/qemu_arc_hs6x.dts
+++ b/boards/arc/qemu_arc/qemu_arc_hs6x.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "QEMU ARC HS";
-	compatible = "qemu,archs";
+	compatible = "snps,qemu-archs";
 
 	cpus {
 		#address-cells = <1>;

--- a/boards/arc/qemu_arc/qemu_arc_hs_xip.dts
+++ b/boards/arc/qemu_arc/qemu_arc_hs_xip.dts
@@ -10,7 +10,7 @@
 
 / {
 	model = "QEMU ARC HS";
-	compatible = "qemu,archs";
+	compatible = "snps,qemu-archs";
 
 	cpus {
 		#address-cells = <1>;


### PR DESCRIPTION
Set vendor to `snps` to be consistent with vendor in board yaml file.