### PR TITLE
memory-attr: Rationalize _MASK and _GET(x) macros

### DIFF
--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -102,7 +102,7 @@ static int mpu_configure_regions_from_dt(uint8_t *reg_index)
 	for (size_t idx = 0; idx < num_regions; idx++) {
 		struct arm_mpu_region region_conf;
 
-		switch (DT_MEM_ARM_MASK(region[idx].dt_attr)) {
+		switch (DT_MEM_ARM_GET(region[idx].dt_attr)) {
 		case DT_MEM_ARM_MPU_RAM:
 			region_conf = _BUILD_REGION_CONF(region[idx], REGION_RAM_ATTR);
 			break;

--- a/arch/arm/core/mpu/nxp_mpu.c
+++ b/arch/arm/core/mpu/nxp_mpu.c
@@ -163,7 +163,7 @@ static int mpu_configure_regions_from_dt(uint8_t *reg_index)
 	for (size_t idx = 0; idx < num_regions; idx++) {
 		struct nxp_mpu_region region_conf;
 
-		switch (DT_MEM_ARM_MASK(region[idx].dt_attr)) {
+		switch (DT_MEM_ARM_GET(region[idx].dt_attr)) {
 		case DT_MEM_ARM_MPU_RAM:
 			region_conf = _BUILD_REGION_CONF(region[idx], REGION_RAM_ATTR);
 			break;

--- a/arch/arm64/core/cortex_r/arm_mpu.c
+++ b/arch/arm64/core/cortex_r/arm_mpu.c
@@ -196,7 +196,7 @@ static int mpu_configure_regions_from_dt(uint8_t *reg_index)
 	for (size_t idx = 0; idx < num_regions; idx++) {
 		struct arm_mpu_region region_conf;
 
-		switch (DT_MEM_ARM_MASK(region[idx].dt_attr)) {
+		switch (DT_MEM_ARM_GET(region[idx].dt_attr)) {
 		case DT_MEM_ARM_MPU_RAM:
 			region_conf = _BUILD_REGION_CONF(region[idx], REGION_RAM_ATTR);
 			break;

--- a/include/zephyr/dt-bindings/memory-attr/memory-attr-arm.h
+++ b/include/zephyr/dt-bindings/memory-attr/memory-attr-arm.h
@@ -18,7 +18,8 @@
  * This is legacy and it should NOT be extended further. If new MPU region
  * types must be added, these must rely on the generic memory attributes.
  */
-#define DT_MEM_ARM_MASK(x)		((x) & DT_MEM_ARCH_ATTR_MASK)
+#define DT_MEM_ARM_MASK			DT_MEM_ARCH_ATTR_MASK
+#define DT_MEM_ARM_GET(x)		((x) & DT_MEM_ARM_MASK)
 #define DT_MEM_ARM(x)			((x) << DT_MEM_ARCH_ATTR_SHIFT)
 
 #define  ATTR_MPU_RAM			BIT(0)

--- a/include/zephyr/dt-bindings/memory-attr/memory-attr-riscv.h
+++ b/include/zephyr/dt-bindings/memory-attr/memory-attr-riscv.h
@@ -12,7 +12,8 @@
 /*
  * Architecture specific RISCV related attributes.
  */
-#define DT_MEM_RISCV_MASK(x)			((x) & DT_MEM_ARCH_ATTR_MASK)
+#define DT_MEM_RISCV_MASK			DT_MEM_ARCH_ATTR_MASK
+#define DT_MEM_RISCV_GET(x)			((x) & DT_MEM_RISCV_MASK)
 #define DT_MEM_RISCV(x)				((x) << DT_MEM_ARCH_ATTR_SHIFT)
 
 #define  ATTR_RISCV_TYPE_MAIN			BIT(0)

--- a/include/zephyr/dt-bindings/memory-attr/memory-attr-xtensa.h
+++ b/include/zephyr/dt-bindings/memory-attr/memory-attr-xtensa.h
@@ -12,7 +12,8 @@
 /*
  * Architecture specific Xtensa related attributes.
  */
-#define DT_MEM_XTENSA_MASK(x)		((x) & DT_MEM_ARCH_ATTR_MASK)
+#define DT_MEM_XTENSA_MASK		DT_MEM_ARCH_ATTR_MASK
+#define DT_MEM_XTENSA_GET(x)		((x) & DT_MEM_XTENSA_MASK)
 #define DT_MEM_XTENSA(x)		((x) << DT_MEM_ARCH_ATTR_SHIFT)
 
 #define  ATTR_XTENSA_INSTR_ROM		BIT(0)

--- a/include/zephyr/dt-bindings/memory-attr/memory-attr.h
+++ b/include/zephyr/dt-bindings/memory-attr/memory-attr.h
@@ -14,6 +14,7 @@
  * Generic memory attributes that should be common to all architectures.
  */
 #define DT_MEM_ATTR_MASK		GENMASK(15, 0)
+#define DT_MEM_ATTR_GET(x)		((x) & DT_MEM_ATTR_MASK)
 #define DT_MEM_ATTR_SHIFT		(0)
 
 #define  DT_MEM_CACHEABLE		BIT(0)  /* cacheable */
@@ -30,6 +31,7 @@
  * provided mask.
  */
 #define DT_MEM_SW_ATTR_MASK		GENMASK(19, 16)
+#define DT_MEM_SW_ATTR_GET(x)		((x) & DT_MEM_SW_ATTR_MASK)
 #define DT_MEM_SW_ATTR_SHIFT		(16)
 #define DT_MEM_SW_ATTR_UNKNOWN		BIT(19)
 
@@ -42,6 +44,7 @@
  * See for example `include/zephyr/dt-bindings/memory-attr/memory-attr-arm.h`
  */
 #define DT_MEM_ARCH_ATTR_MASK		GENMASK(31, 20)
+#define DT_MEM_ARCH_ATTR_GET(x)		((x) & DT_MEM_ARCH_ATTR_MASK)
 #define DT_MEM_ARCH_ATTR_SHIFT		(20)
 #define DT_MEM_ARCH_ATTR_UNKNOWN	BIT(31)
 

--- a/tests/kernel/mem_heap/shared_multi_heap/src/main.c
+++ b/tests/kernel/mem_heap/shared_multi_heap/src/main.c
@@ -83,7 +83,7 @@ static inline enum shared_multi_heap_attr mpu_to_reg_attr(uint32_t dt_attr)
 	 * RAM          -> SMH_REG_ATTR_CACHEABLE
 	 * RAM_NOCACHE  -> SMH_REG_ATTR_NON_CACHEABLE
 	 */
-	switch (DT_MEM_ARM_MASK(dt_attr)) {
+	switch (DT_MEM_ARM_GET(dt_attr)) {
 	case DT_MEM_ARM_MPU_RAM:
 		return SMH_REG_ATTR_CACHEABLE;
 	case DT_MEM_ARM_MPU_RAM_NOCACHE:


### PR DESCRIPTION
Let's make this official: we use the suffix `_MASK` for the define carrying the GENMASK for the attributes, and the suffix `_GET(x)` for the actual macro extracting the attributes.