### PR TITLE
edtlib: add support for pattern properties 

### DIFF
--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -163,6 +163,7 @@ Property entries in ``properties:`` are written in this syntax:
             phandle | phandles | phandle-array | path | compound>
      deprecated: <true | false>
      default: <default>
+     pattern: <true | false>
      description: <description of the property>
      enum:
        - <item1>
@@ -437,6 +438,47 @@ can write this property as follows:
      mboxes:
        type: phandle-array
        specifier-space: mbox
+
+pattern
+=======
+
+A property with ``pattern: true`` indicates that the property name is a regular
+expression. This can be used to match an arbitrary number of properties
+following the same naming convention. For example:
+
+.. code-block:: YAML
+
+   # base.yaml
+
+   properties:
+     ".*-supply$":
+        type: phandle
+        pattern: true
+
+This will match any property name ending in ``-supply``. For example:
+
+.. code-block:: devicetree
+
+   my-node {
+           foo-supply = <&foo_regulator>;
+           bar-supply = <&bar_regulator>;
+   };
+
+Properties with a name matching another pattern property can be used to set
+constraints or override certain options. For example:
+
+.. code-block:: YAML
+
+   include: base.yaml
+
+   properties:
+     # matches '.*-supply$' from base.yaml, will be required.
+     vin-supply:
+       required: true
+
+This is allowed for the ``required``, ``const``, ``enum`` and
+``specifier-space`` options. The ``deprecated`` and ``type`` options will be
+taken from the pattern property, and so they can not be overridden.
 
 .. _dt-bindings-child:
 

--- a/scripts/dts/python-devicetree/tests/test-bindings/pattern-props.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/pattern-props.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+properties:
+  ".*-pattern$":
+    type: string
+    pattern: true

--- a/scripts/dts/python-devicetree/tests/test-bindings/props.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/props.yaml
@@ -4,6 +4,8 @@ description: Device.props test
 
 compatible: "props"
 
+include: pattern-props.yaml
+
 properties:
   nonexistent-boolean:
     type: boolean
@@ -49,3 +51,6 @@ properties:
 
   path:
     type: path
+
+  foo-pattern:
+    required: true

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -359,6 +359,9 @@
 		phandle-array-foos = < &{/ctrl-1} 1 &{/ctrl-2} 2 3 >;
 		foo-gpios = < &{/ctrl-1} 1 >;
 		path = &{/ctrl-1};
+		foo-pattern = "foo";
+		bar-pattern = "bar";
+		baz-pattern = "baz";
 	};
 
 	ctrl-1 {
@@ -376,6 +379,7 @@
 		compatible = "props";
 		phandle-array-foos = < &{/ctrl-0-1} 0 &{/ctrl-0-2} >;
 		phandle-array-foo-names = "a", "missing", "b";
+		foo-pattern = "foo";
 	};
 
 	ctrl-0-1 {

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -471,19 +471,19 @@ def test_props():
                   'array', 'uint8-array',
                   'string', 'string-array',
                   'phandle-ref', 'phandle-refs',
-                  'path'],
+                  'path', 'foo-pattern', 'bar-pattern', 'baz-pattern'],
                  ['int',
                   'boolean', 'boolean',
                   'array', 'uint8-array',
                   'string', 'string-array',
                   'phandle', 'phandles',
-                  'path'],
+                  'path', 'string', 'string'],
                  [1,
                   True, False,
                   [1,2,3], b'\x124',
                   'foo', ['foo','bar','baz'],
                   ctrl_1, [ctrl_1,ctrl_2],
-                  ctrl_1])
+                  ctrl_1, 'foo', 'bar', 'baz'])
 
     verify_phandle_array_prop(props_node,
                               'phandle-array-foos',


### PR DESCRIPTION
It is often useful to define pattern-based properties when writing
generic binding files included by other clients. For example, all
regulator clients are expected to refer to associated regulators using
the `.*-supply` pattern (`vin-supply`, `vdd-supply`, etc.). Until now,
this was not possible and so each client was forced to define its own
properties, making this generalization more difficult and error-prone.

Similar functionality is offered in dt-schema, the bindings language
used by the Linux Kernel and some other projects by using
`patternProperties`. Because it seems that dt-schema in Zephyr
won't happen anytime soon, this patch tries to modify our own language
to offer the same feature.

A new binding property attribute is added: `pattern`. If set to `true`,
the property name will be treated as a regular expression. This allows
user to define an arbitrary number of properties following that pattern.

Example usage:

```yaml
 # base.yaml

properties:
  ...
  ".*-supply$":
    type: phandle;
    pattern: true
  ...
```

```yaml
 # vnd,sensor.yaml

compatible = "vnd,sensor";

include: base.yaml

properties:
  vnd,foo:
    type: int
```

```dts
/* devicetree */
sensors_power: sensors-power {
    compatible = "regulator-fixed";
    ...
};

sensor {
    compatible = "vnd,sensor";
    vin-supply = <&sensors_power>;
    vnd,foo = <123>;
};
```