### PR TITLE
check_init_priorities fixup for 61986

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -51,9 +51,7 @@ extern "C" {
  * than a pointer. The device.h API mainly uses handles to store lists of
  * multiple devices in a compact way.
  *
- * The extreme values and zero have special significance. Negative values
- * identify functionality that does not correspond to a Zephyr device, such as
- * the system clock or a SYS_INIT() function.
+ * The negative, extreme values and zero have special significance.
  *
  * @see device_handle_get()
  * @see device_from_handle()

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -42,80 +42,13 @@ extern "C" {
  *   SMP.
  *
  * Initialization priority can take a value in the range of 0 to 99.
- *
- * @note The same infrastructure is used by devices.
  * @{
  */
 
-struct device;
-
-/**
- * @brief Initialization function for init entries.
- *
- * Init entries support both the system initialization and the device
- * APIs. Each API has its own init function signature; hence, we have a
- * union to cover both.
- */
-union init_function {
-	/**
-	 * System initialization function.
-	 *
-	 * @retval 0 On success
-	 * @retval -errno If init fails.
-	 */
-	int (*sys)(void);
-	/**
-	 * Device initialization function.
-	 *
-	 * @param dev Device instance.
-	 *
-	 * @retval 0 On success
-	 * @retval -errno If device initialization fails.
-	 */
-	int (*dev)(const struct device *dev);
-};
-
-/**
- * @brief Structure to store initialization entry information.
- *
- * @internal
- * Init entries need to be defined following these rules:
- *
- * - Their name must be set using Z_INIT_ENTRY_NAME().
- * - They must be placed in a special init section, given by
- *   Z_INIT_ENTRY_SECTION().
- * - They must be aligned, e.g. using Z_DECL_ALIGN().
- *
- * See SYS_INIT_NAMED() for an example.
- * @endinternal
- */
-struct init_entry {
-	/** Initialization function. */
-	union init_function init_fn;
-	/**
-	 * If the init entry belongs to a device, this fields stores a
-	 * reference to it, otherwise it is set to NULL.
-	 */
-	const struct device *dev;
-};
+/** System initialization function. */
+typedef int (*sys_init_fn_t)(void);
 
 /** @cond INTERNAL_HIDDEN */
-
-/* Helper definitions to evaluate level equality */
-#define Z_INIT_EARLY_EARLY		 1
-#define Z_INIT_PRE_KERNEL_1_PRE_KERNEL_1 1
-#define Z_INIT_PRE_KERNEL_2_PRE_KERNEL_2 1
-#define Z_INIT_POST_KERNEL_POST_KERNEL	 1
-#define Z_INIT_APPLICATION_APPLICATION	 1
-#define Z_INIT_SMP_SMP			 1
-
-/* Init level ordinals */
-#define Z_INIT_ORD_EARLY	0
-#define Z_INIT_ORD_PRE_KERNEL_1 1
-#define Z_INIT_ORD_PRE_KERNEL_2 2
-#define Z_INIT_ORD_POST_KERNEL	3
-#define Z_INIT_ORD_APPLICATION	4
-#define Z_INIT_ORD_SMP		5
 
 /**
  * @brief Obtain init entry name.
@@ -131,28 +64,11 @@ struct init_entry {
  * linker scripts to sort them according to the specified
  * level/priority/sub-priority.
  */
-#define Z_INIT_ENTRY_SECTION(level, prio, sub_prio)                           \
-	__attribute__((__section__(                                           \
-		".z_init_" #level STRINGIFY(prio)"_" STRINGIFY(sub_prio)"_")))
+#define Z_INIT_ENTRY_SECTION(level, prio)                                      \
+	__attribute__(                                                         \
+		(__section__(".z_init_" #level STRINGIFY(prio)"_")))
 
 /** @endcond */
-
-/**
- * @brief Obtain the ordinal for an init level.
- *
- * @param level Init level (EARLY, PRE_KERNEL_1, PRE_KERNEL_2, POST_KERNEL,
- * APPLICATION, SMP).
- *
- * @return Init level ordinal.
- */
-#define INIT_LEVEL_ORD(level)                                                  \
-	COND_CODE_1(Z_INIT_EARLY_##level, (Z_INIT_ORD_EARLY),                  \
-	(COND_CODE_1(Z_INIT_PRE_KERNEL_1_##level, (Z_INIT_ORD_PRE_KERNEL_1),   \
-	(COND_CODE_1(Z_INIT_PRE_KERNEL_2_##level, (Z_INIT_ORD_PRE_KERNEL_2),   \
-	(COND_CODE_1(Z_INIT_POST_KERNEL_##level, (Z_INIT_ORD_POST_KERNEL),     \
-	(COND_CODE_1(Z_INIT_APPLICATION_##level, (Z_INIT_ORD_APPLICATION),     \
-	(COND_CODE_1(Z_INIT_SMP_##level, (Z_INIT_ORD_SMP),                     \
-	(ZERO_OR_COMPILE_ERROR(0)))))))))))))
 
 /**
  * @brief Register an initialization function.
@@ -180,19 +96,16 @@ struct init_entry {
  * same init function.
  *
  * @param name Unique name for SYS_INIT entry.
- * @param init_fn_ See SYS_INIT().
+ * @param init_fn See SYS_INIT().
  * @param level See SYS_INIT().
  * @param prio See SYS_INIT().
  *
  * @see SYS_INIT()
  */
-#define SYS_INIT_NAMED(name, init_fn_, level, prio)                            \
-	static const Z_DECL_ALIGN(struct init_entry)                           \
-		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan           \
-		Z_INIT_ENTRY_NAME(name) = {                                    \
-			.init_fn = {.sys = (init_fn_)},                        \
-			.dev = NULL,                                           \
-	}
+#define SYS_INIT_NAMED(name, init_fn, level, prio)                             \
+	static const Z_DECL_ALIGN(sys_init_fn_t)                               \
+		Z_INIT_ENTRY_SECTION(level, prio) __used __noasan              \
+		Z_INIT_ENTRY_NAME(name) = init_fn
 
 /** @} */
 

--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -20,7 +20,30 @@
 		__init_end = .;
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-	ITERABLE_SECTION_ROM_NUMERIC(device, 4)
+	/* HACK: needs a new iterable "sub-section" API */
+	SECTION_PROLOGUE(device_area,,)
+	{
+		_device_list_start = .;
+		_device_list_EARLY_start = .;
+		KEEP(*(SORT(._device.static.EARLY_?_*)));
+		KEEP(*(SORT(._device.static.EARLY_??_*)));
+		_device_list_PRE_KERNEL_1_start = .;
+		KEEP(*(SORT(._device.static.PRE_KERNEL_1_?_*)));
+		KEEP(*(SORT(._device.static.PRE_KERNEL_1_??_*)));
+		_device_list_PRE_KERNEL_2_start = .;
+		KEEP(*(SORT(._device.static.PRE_KERNEL_2_?_*)));
+		KEEP(*(SORT(._device.static.PRE_KERNEL_2_??_*)));
+		_device_list_POST_KERNEL_start = .;
+		KEEP(*(SORT(._device.static.POST_KERNEL_?_*)));
+		KEEP(*(SORT(._device.static.POST_KERNEL_??_*)));
+		_device_list_APPLICATION_start = .;
+		KEEP(*(SORT(._device.static.APPLICATION_?_*)));
+		KEEP(*(SORT(._device.static.APPLICATION_??_*)));
+		_device_list_SMP_start = .;
+		KEEP(*(SORT(._device.static.SMP_?_*)));
+		KEEP(*(SORT(._device.static.SMP_??_*)));
+		_device_list_end = .;
+	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 #if defined(CONFIG_GEN_SW_ISR_TABLE) && !defined(CONFIG_DYNAMIC_INTERRUPTS)
 	SECTION_PROLOGUE(sw_isr_table,,)

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -61,13 +61,13 @@ static K_KERNEL_PINNED_STACK_ARRAY_DEFINE(z_idle_stacks,
 					  CONFIG_IDLE_STACK_SIZE);
 #endif /* CONFIG_MULTITHREADING */
 
-extern const struct init_entry __init_start[];
-extern const struct init_entry __init_EARLY_start[];
-extern const struct init_entry __init_PRE_KERNEL_1_start[];
-extern const struct init_entry __init_PRE_KERNEL_2_start[];
-extern const struct init_entry __init_POST_KERNEL_start[];
-extern const struct init_entry __init_APPLICATION_start[];
-extern const struct init_entry __init_end[];
+extern const sys_init_fn_t __init_start[];
+extern const sys_init_fn_t __init_EARLY_start[];
+extern const sys_init_fn_t __init_PRE_KERNEL_1_start[];
+extern const sys_init_fn_t __init_PRE_KERNEL_2_start[];
+extern const sys_init_fn_t __init_POST_KERNEL_start[];
+extern const sys_init_fn_t __init_APPLICATION_start[];
+extern const sys_init_fn_t __init_end[];
 
 extern const struct device _device_list_EARLY_start[];
 extern const struct device _device_list_PRE_KERNEL_1_start[];
@@ -89,7 +89,7 @@ enum init_level {
 };
 
 #ifdef CONFIG_SMP
-extern const struct init_entry __init_SMP_start[];
+extern const sys_init_fn_t __init_SMP_start[];
 
 extern const struct device _device_list_SMP_start[];
 #endif
@@ -266,7 +266,7 @@ static void z_sys_init_run_level(enum init_level level)
 		_device_list_end,
 	};
 
-	static const struct init_entry *levels[] = {
+	static const sys_init_fn_t *levels[] = {
 		__init_EARLY_start,
 		__init_PRE_KERNEL_1_start,
 		__init_PRE_KERNEL_2_start,
@@ -306,8 +306,8 @@ static void z_sys_init_run_level(enum init_level level)
 		}
 	}
 
-	for (const struct init_entry *entry = levels[level]; entry < levels[level+1]; entry++) {
-		(void)entry->init_fn.sys();
+	for (const sys_init_fn_t *entry = levels[level]; entry < levels[level+1]; entry++) {
+		(void)(*entry)();
 	}
 }
 

--- a/scripts/build/check_init_priorities.py
+++ b/scripts/build/check_init_priorities.py
@@ -105,8 +105,14 @@ class ZephyrInitLevels:
     def __init__(self, file_path):
         self.file_path = file_path
         self._elf = ELFFile(open(file_path, "rb"))
+
+        self.initlevels = {}
+        for level in _DEVICE_INIT_LEVELS:
+            self.initlevels[level] = []
+
         self._load_objects()
         self._load_level_addr()
+        self._process_devices()
         self._process_initlevels()
 
     def _load_objects(self):
@@ -124,27 +130,37 @@ class ZephyrInitLevels:
                     self._objects[sym.entry.st_value] = (
                             sym.name, sym.entry.st_size, sym.entry.st_shndx)
 
-    def _load_level_addr(self):
+    def _find_level_addr(self, prefix, levels):
         """Find the address associated with known init levels."""
-        self._init_level_addr = {}
+        addrs = {}
+        end = None
 
         for section in self._elf.iter_sections():
             if not isinstance(section, SymbolTableSection):
                 continue
 
             for sym in section.iter_symbols():
-                for level in _DEVICE_INIT_LEVELS:
-                    name = f"__init_{level}_start"
+                for level in levels:
+                    name = f"{prefix}_{level}_start"
                     if sym.name == name:
-                        self._init_level_addr[level] = sym.entry.st_value
-                    elif sym.name == "__init_end":
-                        self._init_level_end = sym.entry.st_value
+                        addrs[level] = sym.entry.st_value
+                    elif sym.name == f"{prefix}_end":
+                        end = sym.entry.st_value
 
-        if len(self._init_level_addr) != len(_DEVICE_INIT_LEVELS):
-            raise ValueError(f"Missing init symbols, found: {self._init_level_addr}")
+        if len(addrs) != len(levels):
+            raise ValueError(f"Missing level symbols, found: {addrs}")
 
-        if not self._init_level_end:
-            raise ValueError(f"Missing init section end symbol")
+        if not end:
+            raise ValueError(f"Missing level section end symbol")
+
+        return addrs, end
+
+    def _load_level_addr(self):
+        """Load the address level for both init and device sections."""
+        self._init_level_addr, self._init_level_end = self._find_level_addr(
+                "__init", _DEVICE_INIT_LEVELS)
+        self._device_level_addr, self._device_level_end = self._find_level_addr(
+                "_device_list", _DEVICE_INIT_LEVELS)
 
     def _device_ord_from_name(self, sym_name):
         """Find a device ordinal from a symbol name."""
@@ -185,19 +201,16 @@ class ZephyrInitLevels:
 
         return int.from_bytes(data[start:stop], byteorder="little")
 
-    def _process_initlevels(self):
-        """Process the init level and find the init functions and devices."""
+    def _process_devices(self):
+        """Process the init level and find the devices."""
         self.devices = {}
-        self.initlevels = {}
 
         for i, level in enumerate(_DEVICE_INIT_LEVELS):
-            start = self._init_level_addr[level]
+            start = self._device_level_addr[level]
             if i + 1 == len(_DEVICE_INIT_LEVELS):
-                stop = self._init_level_end
+                stop = self._device_level_end
             else:
-                stop = self._init_level_addr[_DEVICE_INIT_LEVELS[i + 1]]
-
-            self.initlevels[level] = []
+                stop = self._device_level_addr[_DEVICE_INIT_LEVELS[i + 1]]
 
             priority = 0
             addr = start
@@ -206,18 +219,38 @@ class ZephyrInitLevels:
                     raise ValueError(f"no symbol at addr {addr:08x}")
                 obj, size, shidx = self._objects[addr]
 
-                arg0_name = self._object_name(self._initlevel_pointer(addr, 0, shidx))
-                arg1_name = self._object_name(self._initlevel_pointer(addr, 1, shidx))
+                init_name = self._object_name(self._initlevel_pointer(addr, 5, shidx))
 
-                self.initlevels[level].append(f"{obj}: {arg0_name}({arg1_name})")
+                self.initlevels[level].append(f"DEVICE   {init_name}({obj})")
 
-                ordinal = self._device_ord_from_name(arg1_name)
+                ordinal = self._device_ord_from_name(obj)
                 if ordinal:
                     prio = Priority(level, priority)
                     self.devices[ordinal] = prio
 
                 addr += size
                 priority += 1
+
+    def _process_initlevels(self):
+        """Process the init level and find the init functions."""
+        for i, level in enumerate(_DEVICE_INIT_LEVELS):
+            start = self._init_level_addr[level]
+            if i + 1 == len(_DEVICE_INIT_LEVELS):
+                stop = self._init_level_end
+            else:
+                stop = self._init_level_addr[_DEVICE_INIT_LEVELS[i + 1]]
+
+            addr = start
+            while addr < stop:
+                if addr not in self._objects:
+                    raise ValueError(f"no symbol at addr {addr:08x}")
+                _, size, shidx = self._objects[addr]
+
+                init_name = self._object_name(self._initlevel_pointer(addr, 0, shidx))
+
+                self.initlevels[level].append(f"SYS_INIT {init_name}()")
+
+                addr += size
 
 class Validator():
     """Validates the initialization priorities.

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -62,43 +62,6 @@ DEVICE_DT_DEFINE(TEST_NOLABEL, dev_init, NULL,
 #define DEV_HDL(node_id) device_handle_get(DEVICE_DT_GET(node_id))
 #define DEV_HDL_NAME(name) device_handle_get(DEVICE_GET(name))
 
-ZTEST(devicetree_devices, test_init_get)
-{
-	/* Check device pointers */
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->dev,
-		      DEVICE_DT_GET(TEST_GPIO), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->dev,
-		      DEVICE_DT_GET(TEST_I2C), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->dev,
-		      DEVICE_DT_GET(TEST_DEVA), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->dev,
-		      DEVICE_DT_GET(TEST_DEVB), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->dev,
-		      DEVICE_DT_GET(TEST_GPIOX), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->dev,
-		      DEVICE_DT_GET(TEST_DEVC), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->dev,
-		      DEVICE_DT_GET(TEST_PARTITION), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->dev,
-		      DEVICE_DT_GET(TEST_GPIO_INJECTED), NULL);
-	zassert_equal(DEVICE_INIT_GET(manual_dev)->dev,
-		      DEVICE_GET(manual_dev), NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->dev,
-		      DEVICE_DT_GET(TEST_NOLABEL), NULL);
-
-	/* Check init functions */
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_GET(manual_dev)->init_fn.dev, dev_init);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->init_fn.dev, dev_init);
-}
-
 ZTEST(devicetree_devices, test_init_order)
 {
 	zassert_equal(init_order[0], DEV_HDL(TEST_GPIO));


### PR DESCRIPTION
Hey @gmarull, I've reworked check_init_priorities for #61986, should work fine now:

```
$ pytest scripts/build
...
scripts/build/check_init_priorities_test.py ...................                                                                      [100%]
...
$ west build -p -b native_posix tests/misc/check_init_priorities
...works...
$ west build -p -b nrf52840dk_nrf52840 samples/drivers/led_pwm -DCONFIG_LED_INIT_PRIORITY=50
...
ERROR: /pwmleds POST_KERNEL 1 < /soc/pwm@4001c000 POST_KERNEL 2
ninja: build stopped: subcommand failed.
$ ./scripts/build/check_init_priorities.py -i
EARLY
PRE_KERNEL_1
  DEVICE   clk_init(__device_dts_ord_74)
  DEVICE   gpio_nrfx_init(__device_dts_ord_11)
  DEVICE   gpio_nrfx_init(__device_dts_ord_105)
  DEVICE   uarte_0_init(__device_dts_ord_113)
  SYS_INIT nordicsemi_nrf52_init()
  SYS_INIT rtt_init()
  SYS_INIT uart_console_init()
PRE_KERNEL_2
  SYS_INIT sys_clock_driver_init()
POST_KERNEL
  DEVICE   led_gpio_init(__device_dts_ord_19)
  DEVICE   led_pwm_init(__device_dts_ord_68)
  DEVICE   pwm_nrfx_init(__device_dts_ord_69)
  SYS_INIT enable_logger()
  SYS_INIT malloc_prepare()
APPLICATION
SMP
```

The output is a bit simpler now, dropped the struct name as it's not really useful anymore. Want to replace the patch in your PR? Or push it up to https://github.com/zephyrproject-rtos/zephyr/tree/collab-init, whatever.