### PR TITLE
drivers: can: switch to CAN_DEVICE_DT_INST_DEFINE for remaining drivers

### DIFF
--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -301,8 +301,8 @@ const struct can_driver_api can_esp32_twai_driver_api = {
 	static struct can_sja1000_data can_sja1000_data_##inst =                                   \
 		CAN_SJA1000_DATA_INITIALIZER(NULL);                                                \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, can_esp32_twai_init, NULL, &can_sja1000_data_##inst,           \
-			      &can_sja1000_config_##inst, POST_KERNEL,                             \
-			      CONFIG_CAN_INIT_PRIORITY, &can_esp32_twai_driver_api);
+	CAN_DEVICE_DT_INST_DEFINE(inst, can_esp32_twai_init, NULL, &can_sja1000_data_##inst,       \
+				  &can_sja1000_config_##inst, POST_KERNEL,                         \
+				  CONFIG_CAN_INIT_PRIORITY, &can_esp32_twai_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(CAN_ESP32_TWAI_INIT)

--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -138,9 +138,9 @@ static const struct can_driver_api fake_can_driver_api = {
 #endif /* CONFIG_CAN_FD_MODE */
 };
 
-#define FAKE_CAN_INIT(inst)						\
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, NULL, POST_KERNEL,\
-			      CONFIG_CAN_INIT_PRIORITY,			\
-			      &fake_can_driver_api);
+#define FAKE_CAN_INIT(inst)						     \
+	CAN_DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, NULL, POST_KERNEL, \
+				  CONFIG_CAN_INIT_PRIORITY,                  \
+				  &fake_can_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(FAKE_CAN_INIT)

--- a/drivers/can/can_kvaser_pci.c
+++ b/drivers/can/can_kvaser_pci.c
@@ -176,9 +176,9 @@ const struct can_driver_api can_kvaser_pci_driver_api = {
 	static struct can_sja1000_data can_sja1000_data_##inst =                                   \
 		CAN_SJA1000_DATA_INITIALIZER(&can_kvaser_pci_data_##inst);                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, can_kvaser_pci_init, NULL, &can_sja1000_data_##inst,           \
-			      &can_sja1000_config_##inst, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,   \
-			      &can_kvaser_pci_driver_api);                                         \
+	CAN_DEVICE_DT_INST_DEFINE(inst, can_kvaser_pci_init, NULL, &can_sja1000_data_##inst,       \
+				  &can_sja1000_config_##inst, POST_KERNEL,                         \
+				  CONFIG_CAN_INIT_PRIORITY, &can_kvaser_pci_driver_api);           \
                                                                                                    \
 	static void can_kvaser_pci_config_func_##inst(const struct device *dev)                    \
 	{                                                                                          \

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -460,9 +460,9 @@ static int can_loopback_init(const struct device *dev)
 #define CAN_LOOPBACK_INIT(inst)						\
 	static struct can_loopback_data can_loopback_dev_data_##inst;	\
 									\
-	DEVICE_DT_INST_DEFINE(inst, &can_loopback_init, NULL,		\
-			      &can_loopback_dev_data_##inst, NULL,	\
-			      POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,	\
-			      &can_loopback_driver_api);
+	CAN_DEVICE_DT_INST_DEFINE(inst, can_loopback_init, NULL,	\
+				  &can_loopback_dev_data_##inst, NULL,	\
+				  POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,\
+				  &can_loopback_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(CAN_LOOPBACK_INIT)

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -1057,8 +1057,8 @@ static int mcp2515_init(const struct device *dev)
 		.max_bitrate = DT_INST_CAN_TRANSCEIVER_MAX_BITRATE(inst, 1000000),                 \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, &mcp2515_init, NULL, &mcp2515_data_##inst,                     \
-			      &mcp2515_config_##inst, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,       \
-			      &can_api_funcs);
+	CAN_DEVICE_DT_INST_DEFINE(inst, mcp2515_init, NULL, &mcp2515_data_##inst,                 \
+				  &mcp2515_config_##inst, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,   \
+				  &can_api_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(MCP2515_INIT)

--- a/drivers/can/can_native_posix_linux.c
+++ b/drivers/can/can_native_posix_linux.c
@@ -488,9 +488,9 @@ static const struct can_npl_config can_npl_cfg_##inst = {			\
 										\
 static struct can_npl_data can_npl_data_##inst;					\
 										\
-DEVICE_DT_INST_DEFINE(inst, &can_npl_init, NULL,				\
-		      &can_npl_data_##inst, &can_npl_cfg_##inst,		\
-		      POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,			\
-		      &can_npl_driver_api);
+CAN_DEVICE_DT_INST_DEFINE(inst, can_npl_init, NULL,				\
+			  &can_npl_data_##inst, &can_npl_cfg_##inst,		\
+			  POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,		\
+			  &can_npl_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(CAN_NATIVE_POSIX_LINUX_INIT)

--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -1092,14 +1092,14 @@ static const struct can_driver_api can_nxp_s32_driver_api = {
 	{										\
 		return can_nxp_s32_init(dev);						\
 	}										\
-	DEVICE_DT_DEFINE(CAN_NXP_S32_NODE(n),						\
-			&can_nxp_s32_##n##_init,					\
-			NULL,								\
-			&can_nxp_s32_data_##n,						\
-			&can_nxp_s32_config_##n,					\
-			POST_KERNEL,							\
-			CONFIG_CAN_INIT_PRIORITY,					\
-			&can_nxp_s32_driver_api);
+	CAN_DEVICE_DT_DEFINE(CAN_NXP_S32_NODE(n),					\
+			     can_nxp_s32_##n##_init,					\
+			     NULL,							\
+			     &can_nxp_s32_data_##n,					\
+			     &can_nxp_s32_config_##n,					\
+			     POST_KERNEL,						\
+			     CONFIG_CAN_INIT_PRIORITY,					\
+			     &can_nxp_s32_driver_api);
 
 #if DT_NODE_HAS_STATUS(CAN_NXP_S32_NODE(0), okay)
 CAN_NXP_S32_INIT_DEVICE(0)

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -1189,10 +1189,10 @@ static const struct can_stm32_config can_stm32_cfg_##inst = {            \
 static struct can_stm32_data can_stm32_dev_data_##inst;
 
 #define CAN_STM32_DEFINE_INST(inst)                                      \
-DEVICE_DT_INST_DEFINE(inst, &can_stm32_init, NULL,                       \
-		      &can_stm32_dev_data_##inst, &can_stm32_cfg_##inst, \
-		      POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,             \
-		      &can_api_funcs);
+CAN_DEVICE_DT_INST_DEFINE(inst, can_stm32_init, NULL,                    \
+			  &can_stm32_dev_data_##inst, &can_stm32_cfg_##inst, \
+			  POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,         \
+			  &can_api_funcs);
 
 #define CAN_STM32_INST(inst)      \
 CAN_STM32_IRQ_INST(inst)          \


### PR DESCRIPTION
Switch from using DEVICE_DT_DEFINE()/DEVICE_DT_INST_DEFINE() to using CAN_DEVICE_DT_DEFINE()/CAN_DEVICE_DT_INST_DEFINE() for remaining drivers.

This unifies CAN controller device driver initialization regardless of the driver implementing CAN statistics support or not.