### PR TITLE
manifest: hal_renesas: Update hal with runtime crash fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: 61ea3505a470b4e739cad4359ec1401cc4b85805
+      revision: a6cf2af9140e014fbbc48d2b6deb802231dd369f
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
hal has to simple corrections:
- One of the asserts were obviously checking wrong condition.
  It resulted in crash when asserts were enabled
- pdc module was using calloc in PRE_KERNEL_1 stage which is not allowed. Latest Zephyr changes of default c library triggered crash. Before calloc returned NULL and that was handled, but now it simple returns some random data.
  Now static buffers are utilized instead.