### PR TITLE
boards: wio-terminal: Default to swapped 16-bit colors for LVGL.

### DIFF
--- a/boards/arm/wio_terminal/Kconfig.defconfig
+++ b/boards/arm/wio_terminal/Kconfig.defconfig
@@ -6,3 +6,6 @@
 config BOARD
 	default "wio_terminal"
 	depends on BOARD_WIO_TERMINAL
+
+config LV_COLOR_16_SWAP
+	default y if LVGL


### PR DESCRIPTION
Set default value for LV_COLOR_16_SWAP when LVGL is enabled to get correct colors out-of-the-box.