### PR TITLE
ci: workflows: run twister tests on collab branches

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - v*-branch
+      - collab-*
   pull_request_target:
     branches:
       - main
       - v*-branch
+      - collab-*
   schedule:
     # Run at 03:00 UTC on every Sunday
     - cron: '0 3 * * 0'


### PR DESCRIPTION
Include CI runs to push and pull request against collab- branches so that thay can be used for detecting CI breakages before trying to open PRs against main.