### PR TITLE
doc: Bluetooth: Mesh: Remove "draft" word, fix DFU and MBT specs names

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh.rst
+++ b/doc/connectivity/bluetooth/api/mesh.rst
@@ -7,7 +7,7 @@ The Bluetooth mesh profile adds secure wireless multi-hop communication for
 Bluetooth Low Energy. This module implements the
 `Bluetooth Mesh Profile Specification v1.0.1 <https://www.bluetooth.com/specifications/specs/mesh-profile-1-0-1/>`_.
 
-Implementation of the draft `Bluetooth Mesh Protocol Specification v1.1 <https://www.bluetooth.com/specifications/specs/mesh-protocol-1-1/>`_
+Implementation of the `Bluetooth Mesh Protocol Specification v1.1 <https://www.bluetooth.com/specifications/specs/mesh-protocol-1-1/>`_
 is in experimental state.
 
 Read more about Bluetooth mesh on the

--- a/doc/connectivity/bluetooth/api/mesh/access.rst
+++ b/doc/connectivity/bluetooth/api/mesh/access.rst
@@ -170,12 +170,12 @@ Composition Data
 
 .. note::
 
-  The implementation of the Bluetooth Mesh Protocol Specification version 1.1
-	is currently in an experimental state. For Bluetooth Mesh Profile Specification
-	version 1.0.1, only Composition Data Page 0 is supported. Users that are developing
-	for Bluetooth Mesh Profile Specification version 1.0.1 may therefore disregard all
-	parts of the following section mentioning the :ref:`bluetooth_mesh_lcd_srv`
-	model and Composition Data Pages 1, 2, 128, 129 and 130.
+   The implementation of the Bluetooth Mesh Protocol Specification version 1.1
+   is currently in an experimental state. For Bluetooth Mesh Profile Specification
+   version 1.0.1, only Composition Data Page 0 is supported. Users that are developing
+   for Bluetooth Mesh Profile Specification version 1.0.1 may therefore disregard all
+   parts of the following section mentioning the :ref:`bluetooth_mesh_lcd_srv`
+   model and Composition Data Pages 1, 2, 128, 129 and 130.
 
 The Composition Data provides information about a mesh device.
 A device's Composition Data holds information about the elements on the

--- a/doc/connectivity/bluetooth/api/mesh/blob.rst
+++ b/doc/connectivity/bluetooth/api/mesh/blob.rst
@@ -3,7 +3,7 @@
 BLOB Transfer models
 ####################
 
-The Binary Large Object (BLOB) Transfer models provide functionality for sending large binary objects from a single source to many Target nodes over the Bluetooth mesh network. It is the underlying transport method for the :ref:`bluetooth_mesh_dfu`, but may be used for other object transfer purposes.
+The Binary Large Object (BLOB) Transfer models implement the Bluetooth Mesh Binary Large Object Transfer Model specification version 1.0 and provide functionality for sending large binary objects from a single source to many Target nodes over the Bluetooth mesh network. It is the underlying transport method for the :ref:`bluetooth_mesh_dfu`, but may be used for other object transfer purposes. The implementation is in experimental state.
 
 The BLOB Transfer models support transfers of continuous binary objects of up to 4 GB (2 \ :sup:`32` bytes). The BLOB transfer protocol has built-in recovery procedures for packet losses, and sets up checkpoints to ensure that all targets have received all the data before moving on. Data transfer order is not guaranteed.
 

--- a/doc/connectivity/bluetooth/api/mesh/dfu.rst
+++ b/doc/connectivity/bluetooth/api/mesh/dfu.rst
@@ -3,7 +3,7 @@
 Device Firmware Update (DFU)
 ############################
 
-Bluetooth mesh supports the distribution of firmware images across a mesh network. The Bluetooth mesh DFU subsystem implements the Firmware update section of the Bluetooth Mesh Model Specification v1.1.
+Bluetooth mesh supports the distribution of firmware images across a mesh network. The Bluetooth mesh DFU subsystem implements the Bluetooth Mesh Device Firmware Update Model specification version 1.0. The implementation is in experimental state.
 
 Bluetooth mesh DFU implements a distribution mechanism for firmware images, and does not put any restrictions on the size, format or usage of the images. The primary design goal of the subsystem is to provide the qualifiable parts of the Bluetooth mesh DFU specification, and leave the usage, firmware validation and deployment to the application.
 


### PR DESCRIPTION
Mesh Protocol 1.1 is now adopted so we can remove "draft" word. The other changes fixing rendering of the note in Access layer page and DFU and MBT (BLOB) specification names.