### PR TITLE
doc: samples: Cleanup table of contents

### DIFF
--- a/samples/index.rst
+++ b/samples/index.rst
@@ -5,6 +5,7 @@ Samples and Demos
 
 
 .. toctree::
+   :titlesonly:
    :maxdepth: 2
    :glob:
 

--- a/samples/modules/index.rst
+++ b/samples/modules/index.rst
@@ -4,7 +4,8 @@ External Module Samples
 #######################
 
 .. toctree::
-   :maxdepth: 2
+   :titlesonly:
+   :maxdepth: 1
    :glob:
 
    **/*

--- a/samples/subsys/portability/portability.rst
+++ b/samples/subsys/portability/portability.rst
@@ -4,7 +4,7 @@ Portability Samples
 ###################
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    **/*

--- a/samples/subsys/subsys.rst
+++ b/samples/subsys/subsys.rst
@@ -4,6 +4,7 @@ Various Subsystems Samples
 ##########################
 
 .. toctree::
+   :titlesonly:
    :maxdepth: 2
    :glob:
 

--- a/samples/tfm_integration/tfm_integration.rst
+++ b/samples/tfm_integration/tfm_integration.rst
@@ -9,9 +9,6 @@ TF-M Integration Samples
 
    */*
 
-Trusted Firmware-M (TF-M)
-#########################
-
 Overview
 ********
 These TF-M integration examples can be used with a supported Armv8-M board, and


### PR DESCRIPTION
Cleaned up a bunch of invalid toctree entries in the code samples that was causing https://docs.zephyrproject.org/latest/samples/index.html to show incorrect or redundant entries.