### PR TITLE
samples: shields: Update Nucleo shields to new code-sample extension

### DIFF
--- a/boards/shields/x_nucleo_53l0a1/doc/index.rst
+++ b/boards/shields/x_nucleo_53l0a1/doc/index.rst
@@ -61,7 +61,7 @@ Samples
 The sample :ref:`vl53l0x` demonstrates how to use the ranging sensor VL53L0X
 using the center sensor only.
 
-The sample :ref:`x-nucleo-53l0a1-sample` demonstrates how to use the three
+The sample :zephyr:code-sample:`x-nucleo-53l0a1` sample demonstrates how to use the three
 sensors (soldered + 2 satellites) and the 7 segments display.
 
 Programming

--- a/boards/shields/x_nucleo_iks01a1/doc/index.rst
+++ b/boards/shields/x_nucleo_iks01a1/doc/index.rst
@@ -45,7 +45,7 @@ Programming
 ***********
 
 An example on how to use the ``x-nucleo-iks01a1`` shield is available
-in the :ref:`x-nucleo-iks01a1-sample` application documentation
+in the :zephyr:code-sample:`x-nucleo-iks01a1` sample application documentation
 (see :ref:`shields` for more details).
 
 References

--- a/boards/shields/x_nucleo_iks01a2/doc/index.rst
+++ b/boards/shields/x_nucleo_iks01a2/doc/index.rst
@@ -85,9 +85,9 @@ Programming
 
 Two samples are provided as examples for ``x-nucleo-iks01a2`` shield:
 
-- :ref:`x-nucleo-iks01a2-std-sample` application, to be used when the shield is configured
+- :zephyr:code-sample:`x-nucleo-iks01a2-std` sample application, to be used when the shield is configured
   in Standard Mode
-- :ref:`x-nucleo-iks01a2-shub-sample` application, to be used when the shield is configured
+- :zephyr:code-sample:`x-nucleo-iks01a2-shub` sample application, to be used when the shield is configured
   in SensorHub Mode
 
 See also :ref:`shields` for more details.

--- a/boards/shields/x_nucleo_iks01a3/doc/index.rst
+++ b/boards/shields/x_nucleo_iks01a3/doc/index.rst
@@ -82,9 +82,9 @@ Programming
 
 Two samples are provided as examples for ``x-nucleo-iks01a3`` shield:
 
-- :ref:`x-nucleo-iks01a3-std-sample` application, to be used when the shield is configured
+- :zephyr:code-sample:`x-nucleo-iks01a3-std` sample application, to be used when the shield is configured
   in Standard Mode
-- :ref:`x-nucleo-iks01a3-shub-sample` application, to be used when the shield is configured
+- :zephyr:code-sample:`x-nucleo-iks01a3-shub` sample application, to be used when the shield is configured
   in SensorHub Mode
 
 See also :ref:`shields` for more details.

--- a/boards/shields/x_nucleo_iks02a1/doc/index.rst
+++ b/boards/shields/x_nucleo_iks02a1/doc/index.rst
@@ -82,11 +82,11 @@ Programming
 
 Three samples are provided as examples for ``x-nucleo-iks02a1`` shield:
 
-- :ref:`x-nucleo-iks02a1-std-sample` application, to be used when the shield is configured
+- :zephyr:code-sample:`x-nucleo-iks02a1-std` application, to be used when the shield is configured
   in Standard Mode
-- :ref:`x-nucleo-iks02a1-shub-sample` application, to be used when the shield is configured
+- :zephyr:code-sample:`x-nucleo-iks02a1-shub` application, to be used when the shield is configured
   in SensorHub Mode
-- :ref:`x-nucleo-iks02a1-mic-sample` application, to be used to acquire data through the
+- :zephyr:code-sample:`x-nucleo-iks02a1-mic` application, to be used to acquire data through the
   on-board PDM microphone
 
 See also :ref:`shields` for more details.

--- a/samples/shields/x_nucleo_53l0a1/README.rst
+++ b/samples/shields/x_nucleo_53l0a1/README.rst
@@ -1,7 +1,8 @@
-.. _x-nucleo-53l0a1-sample:
+.. zephyr:code-sample:: x-nucleo-53l0a1
+   :name: X-NUCLEO-53L0A1 shield
+   :relevant-api: sensor_interface gpio_interface
 
-X-NUCLEO-53L0A1 ranging and gesture detection sensor expansion board
-#####################################################################
+   Interact with the 7-segment display and VL53L0X ranging sensor of an X-NUCLEO-53L0A1 shield.
 
 Overview
 ********

--- a/samples/shields/x_nucleo_iks01a1/README.rst
+++ b/samples/shields/x_nucleo_iks01a1/README.rst
@@ -1,7 +1,8 @@
-.. _x-nucleo-iks01a1-sample:
+.. zephyr:code-sample:: x-nucleo-iks01a1
+   :name: X-NUCLEO-IKS01A1 shield
+   :relevant-api: sensor_interface
 
-X-NUCLEO-IKS01A1: MEMS inertial and environmental multi-sensor shield
-#####################################################################
+   Interact with all the sensors of an X-NUCLEO-IKS01A1 shield.
 
 Overview
 ********

--- a/samples/shields/x_nucleo_iks01a2/sensorhub/README.rst
+++ b/samples/shields/x_nucleo_iks01a2/sensorhub/README.rst
@@ -1,7 +1,8 @@
-.. _x-nucleo-iks01a2-shub-sample:
+.. zephyr:code-sample:: x-nucleo-iks01a2-shub
+   :name: X-NUCLEO-IKS01A2 shield - SensorHub (Mode 2)
+   :relevant-api: sensor_interface
 
-X-NUCLEO-IKS01A2: shield SensorHub (Mode 2) sample
-##################################################
+   Interact with all the sensors of an X-NUCLEO-IKS01A2 shield using Sensor Hub mode.
 
 Overview
 ********

--- a/samples/shields/x_nucleo_iks01a2/standard/README.rst
+++ b/samples/shields/x_nucleo_iks01a2/standard/README.rst
@@ -1,7 +1,8 @@
-.. _x-nucleo-iks01a2-std-sample:
+.. zephyr:code-sample:: x-nucleo-iks01a2-std
+   :name: X-NUCLEO-IKS01A2 shield - Standard (Mode 1)
+   :relevant-api: sensor_interface
 
-X-NUCLEO-IKS01A2: shield Standard (Mode 1) sample
-#################################################
+   Interact with all the sensors of an X-NUCLEO-IKS01A2 shield using Standard Mode.
 
 Overview
 ********

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/README.rst
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/README.rst
@@ -1,7 +1,8 @@
-.. _x-nucleo-iks01a3-shub-sample:
+.. zephyr:code-sample:: x-nucleo-iks01a3-shub
+   :name: X-NUCLEO-IKS01A3 shield - SensorHub (Mode 2)
+   :relevant-api: sensor_interface
 
-X-NUCLEO-IKS01A3: shield (Mode 2) sample
-########################################
+   Interact with all the sensors of an X-NUCLEO-IKS01A3 shield using Sensor Hub mode.
 
 Overview
 ********

--- a/samples/shields/x_nucleo_iks01a3/standard/README.rst
+++ b/samples/shields/x_nucleo_iks01a3/standard/README.rst
@@ -1,7 +1,8 @@
-.. _x-nucleo-iks01a3-std-sample:
+.. zephyr:code-sample:: x-nucleo-iks01a3-std
+   :name: X-NUCLEO-IKS01A3 shield - Standard (Mode 1)
+   :relevant-api: sensor_interface
 
-X-NUCLEO-IKS01A3: shield Standard (Mode 1) sample
-#################################################
+   Interact with all the sensors of an X-NUCLEO-IKS01A3 shield using Standard mode.
 
 Overview
 ********

--- a/samples/shields/x_nucleo_iks02a1/microphone/README.rst
+++ b/samples/shields/x_nucleo_iks02a1/microphone/README.rst
@@ -1,7 +1,8 @@
-.. _x-nucleo-iks02a1-mic-sample:
+.. zephyr:code-sample:: x-nucleo-iks02a1-mic
+   :name: X-NUCLEO-IKS02A1 shield - MEMS microphone
+   :relevant-api: audio_dmic_interface
 
-X-NUCLEO-IKS02A1 shield: Acquire MEMS microphones data
-######################################################
+   Acquire audio using the digital MEMS microphone on X-NUCLEO-IKS02A1 shield.
 
 Overview
 ********
@@ -9,7 +10,7 @@ This sample enables the digital MEMS microphone on X-NUCLEO-IKS02A1
 shields
 
 This sample provides an example of how to acquire audio through
-the digital MEMS microphones on X-NUCLEO-IKS02A1 shield.
+the digital MEMS microphone on X-NUCLEO-IKS02A1 shield.
 The microphone generates a PDM stream which is acquired through I2S.
 The PDM stream is then converted to PCM using the OpenPDM2PCM library
 available in zephyrproject/modules/hal/st/audio/microphone.

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/README.rst
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/README.rst
@@ -1,7 +1,8 @@
-.. _x-nucleo-iks02a1-shub-sample:
+.. zephyr:code-sample:: x-nucleo-iks02a1-shub
+   :name: X-NUCLEO-IKS02A1 shield - SensorHub (Mode 2)
+   :relevant-api: sensor_interface
 
-X-NUCLEO-IKS02A1 shield: Sensorhub (Mode 2) sample
-##################################################
+   Interact with all the sensors of an X-NUCLEO-IKS02A1 shield using Sensor Hub mode.
 
 Overview
 ********

--- a/samples/shields/x_nucleo_iks02a1/standard/README.rst
+++ b/samples/shields/x_nucleo_iks02a1/standard/README.rst
@@ -1,7 +1,8 @@
-.. _x-nucleo-iks02a1-std-sample:
+.. zephyr:code-sample:: x-nucleo-iks02a1-std
+   :name: X-NUCLEO-IKS02A1 shield - Standard (Mode 1)
+   :relevant-api: sensor_interface
 
-X-NUCLEO-IKS02A1 shield: Standard (Mode 1) sample
-#################################################
+   Interact with all the sensors of an X-NUCLEO-IKS02A1 shield using Standard mode.
 
 Overview
 ********


### PR DESCRIPTION
Update all Nucleo shield samples and references to them so that they
use the new zephyr:code-sample extension.

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
