### PR TITLE
boards: efr32_radio_brd4170a: Setup console with pinctrl

### DIFF
--- a/boards/arm/efr32_radio/efr32_radio_brd4170a.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4170a.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <silabs/efr32mg12p433f1024gm68.dtsi>
+#include <silabs/efr32xg12p-pinctrl.dtsi>
 #include "efr32_radio.dtsi"
 
 / {
@@ -59,4 +60,11 @@
 		};
 
 	};
+};
+
+&usart0 {
+	current-speed = <115200>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+	status = "okay";
 };


### PR DESCRIPTION
Prior to this patch, the BRD4170A did not enable the UART console using pinctrl, which was recently added for this SoC series.