### PR TITLE
twister: introduce twister-level test timeout management

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -195,6 +195,14 @@ testing:
   only_tags:
     Only execute tests with this list of tags on a specific platform.
 
+  .. _twister_board_timeout_multiplier:
+
+  timeout_multiplier: <float> (default 1)
+    Multiply each test case timeout by specified ratio. This option allows to tune timeouts only
+    for required platform. It can be useful in case naturally slow platform I.e.: HW board with
+    power-efficient but slow CPU or simulation platform which can perform instruction accurate
+    simulation but does it slowly.
+
 Test Cases
 **********
 
@@ -358,6 +366,8 @@ min_ram: <integer>
 min_flash: <integer>
     minimum amount of ROM in KB needed for this test to build and run. This is
     compared with information provided by the board metadata.
+
+.. _twister_test_case_timeout:
 
 timeout: <number of seconds>
     Length of time to run test before automatically killing it.
@@ -659,6 +669,22 @@ To load arguments from a file, write '+' before the file name, e.g.,
 line break instead of white spaces.
 
 Most everyday users will run with no arguments.
+
+Managing tests timeouts
+***********************
+
+There are several parameters which control tests timeouts on various levels:
+
+* ``timeout`` option in each test case. See :ref:`here <twister_test_case_timeout>` for more
+  details.
+* ``timeout_multiplier`` option in board configuration. See
+  :ref:`here <twister_board_timeout_multiplier>` for more details.
+* ``--timeout-multiplier`` twister option which can be used to adjust timeouts in exact twister run.
+  It can be useful in case of simulation platform as simulation time may depend on the host
+  speed & load or we may select different simulation method (i.e. cycle accurate but slower
+  one), etc...
+
+Overall test case timeout is a multiplication of these three parameters.
 
 Running in Integration Mode
 ***************************

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -196,6 +196,11 @@ Artificially long but functional example:
         help="""Only run device tests with current artifacts, do not build
              the code""")
 
+    parser.add_argument("--timeout-multiplier", type=float, default=1,
+        help="""Globally adjust tests timeouts by specified multiplier. The resulting test
+        timeout would be multiplication of test timeout value, board-level timeout multiplier
+        and global timeout multiplier (this parameter)""")
+
     test_xor_subtest.add_argument(
         "-s", "--test", action="append",
         help="Run only the specified testsuite scenario. These are named by "

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1858,7 +1858,7 @@ TESTDATA_25 = [
     ),
     (
         '1\n2\n3\n4\n5\n'.encode('utf-8'),
-        6,
+        60,
         1,
         [None] * 3 + ['success'] * 7,
         (n for n in [100, 100, 10000]),
@@ -1900,14 +1900,12 @@ def test_qemuhandler_thread(
         else:
             raise ProcessLookupError()
 
+    type(mocked_instance.testsuite).timeout = mock.PropertyMock(return_value=timeout)
     handler = QEMUHandler(mocked_instance, 'build')
     handler.results = {}
     handler.ignore_unexpected_eof = False
     handler.pid_fn = 'pid_fn'
     handler.fifo_fn = 'fifo_fn'
-    type(mocked_instance.testsuite).timeout = mock.PropertyMock(
-        return_value=timeout
-    )
 
     def mocked_open(filename, *args, **kwargs):
         if filename == handler.pid_fn:

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -420,6 +420,7 @@ def test_binaryhandler_output_handler(
 
     handler = BinaryHandler(mocked_instance, 'build')
     handler.terminate = mock.Mock()
+    handler.options = mock.Mock(timeout_multiplier=1)
 
     proc = MockProc(1, proc_stdout)
 
@@ -1208,6 +1209,7 @@ def test_devicehandler_create_serial_connection(
     handler.instance.add_missing_case_status = missing_mock
     available_mock = mock.Mock()
     handler.make_device_available = available_mock
+    handler.options = mock.Mock(timeout_multiplier=1)
 
     hardware_baud = 14400
     flash_timeout = 60
@@ -1375,6 +1377,7 @@ def test_devicehandler_handle(
     handler = DeviceHandler(mocked_instance, 'build')
     handler.get_hardware = mock.Mock(return_value=hardware)
     handler.options = mock.Mock(
+        timeout_multiplier=1,
         west_flash=None,
         west_runner=None
     )
@@ -1906,6 +1909,7 @@ def test_qemuhandler_thread(
     handler.ignore_unexpected_eof = False
     handler.pid_fn = 'pid_fn'
     handler.fifo_fn = 'fifo_fn'
+    handler.options = mock.Mock(timeout_multiplier=1)
 
     def mocked_open(filename, *args, **kwargs):
         if filename == handler.pid_fn:
@@ -1956,7 +1960,7 @@ def test_qemuhandler_thread(
                     mock_thread_update_instance_info):
         QEMUHandler._thread(
             handler,
-            handler.timeout,
+            handler.get_test_timeout(),
             handler.build_dir,
             handler.log,
             handler.fifo_fn,
@@ -2035,6 +2039,7 @@ def test_qemuhandler_handle(
     command = ['generator_cmd', '-C', os.path.join('cmd', 'path'), 'run']
 
     handler.options = mock.Mock(
+        timeout_multiplier=1,
         west_flash=handler_options_west_flash,
         west_runner=None
     )


### PR DESCRIPTION
Twister allows us to control maximum execution time for each test with timeout value in test's `.yaml` configuration and platform level timeout multiplier which allows us to tweak timeout value for specific platform.

However, sometimes we want to additionally adjust tests timeouts when running twister. This is especially useful in case of simulation platform as simulation time may depend on the host speed & load, we may select different simulation method (i.e. cycle accurate but slower one), etc...

Let's introduce global (twister-level) timeout multiplier option to handle these cases.