### PR TITLE
drivers: i2c_ll_stm32_v2: add warning about i2c speeds above fast

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -702,6 +702,8 @@ int stm32_i2c_configure_timing(const struct device *dev, uint32_t clock)
 		i2c_setup_time_min = 500U;
 		break;
 	default:
+		LOG_ERR("i2c: speed above \"fast\" requires manual timing configuration, "
+				"see \"timings\" property of st,stm32-i2c-v2 devicetree binding");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The i2c_ll_stm32_v2 driver requires manual timing configuration for "fast mode plus" speed.
This adds an error message linking to the appropriate documentation.