### PR TITLE
bluetooth: hci: enable backends by default

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -7,25 +7,23 @@ comment "Bluetooth HCI Driver Options"
 
 config BT_UART
 	bool
+	select SERIAL
+	select UART_INTERRUPT_DRIVEN
 
 choice BT_HCI_BUS_TYPE
 	prompt "Bluetooth HCI driver"
 
 config BT_H4
 	bool "H:4 UART"
-	select UART_INTERRUPT_DRIVEN
 	select BT_UART
-	depends on SERIAL
 	help
 	  Bluetooth H:4 UART driver. Requires hardware flow control
 	  lines to be available.
 
 config BT_H5
 	bool "H:5 UART [EXPERIMENTAL]"
-	select UART_INTERRUPT_DRIVEN
 	select BT_UART
 	select EXPERIMENTAL
-	depends on SERIAL
 	help
 	  Bluetooth three-wire (H:5) UART driver. Implementation of HCI
 	  Three-Wire UART Transport Layer.
@@ -41,7 +39,7 @@ config BT_RPMSG
 
 config BT_SPI
 	bool "SPI HCI"
-	depends on SPI
+	select SPI
 	help
 	  Supports Bluetooth ICs using SPI as the communication protocol.
 	  HCI packets are sent and received as single Byte transfers,

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -99,6 +99,7 @@ config BT_PSOC6_BLESS
 
 config BT_NO_DRIVER
 	bool "No default HCI driver"
+	select BT_HAS_HCI_VS
 	help
 	  This is intended for unit tests where no internal driver
 	  should be selected.

--- a/subsys/testsuite/boards/unit_testing/unit_testing/Kconfig.defconfig
+++ b/subsys/testsuite/boards/unit_testing/unit_testing/Kconfig.defconfig
@@ -2,4 +2,7 @@
 #
 # Copyright (c) 2022 Nordic Semiconductor
 
-# Intentionally left empty
+# Bluetooth unit tests expect this backend
+choice BT_HCI_BUS_TYPE
+	default BT_NO_DRIVER
+endchoice


### PR DESCRIPTION
Enable backends by default, instead of requiring some other module to turn them on. This aligns with the behaviour of sensor drivers and `BT_RPMSG`.

Default backend for the `unit_testing` board is explicitly set to `BT_NO_DRIVER`, from the previously implicit `BT_RPMSG`.