### PR TITLE
soc: arm: nxp: add MK22F12 definition

### DIFF
--- a/dts/arm/nxp/nxp_k22fx512.dtsi
+++ b/dts/arm/nxp/nxp_k22fx512.dtsi
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Daniel DeGrasse
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_k2x.dtsi>
+
+/ {
+	soc {
+		i2c2: i2c@400e6000 {
+			compatible = "nxp,kinetis-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x400e6000 0x1000>;
+			interrupts = <74 0>;
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1028 6>;
+			status = "disabled";
+		};
+
+		spi2: spi@400ac000 {
+			reg = <0x400ac000 0x88>;
+			interrupts = <65 3>;
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1030 12>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		uart4: uart@400ea000 {
+			compatible = "nxp,kinetis-uart";
+			reg = <0x400ea000 0x1000>;
+			interrupts = <66 0>, <67 0>;
+			interrupt-names = "status", "error";
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1028 10>;
+
+			status = "disabled";
+		};
+
+		uart5: uart@400eb000 {
+			compatible = "nxp,kinetis-uart";
+			reg = <0x400eb000 0x1000>;
+			interrupts = <68 0>, <69 0>;
+			interrupt-names = "status", "error";
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1028 11>;
+
+			status = "disabled";
+		};
+	};
+};

--- a/soc/arm/nxp_kinetis/k2x/CMakeLists.txt
+++ b/soc/arm/nxp_kinetis/k2x/CMakeLists.txt
@@ -9,4 +9,9 @@ zephyr_sources(
   soc.c
   )
 
+if(DEFINED CONFIG_ARM_MPU AND DEFINED CONFIG_CPU_HAS_NXP_MPU)
+  # MK22F12 series MCUs have NXP MPU
+  zephyr_sources(nxp_mpu_regions.c)
+endif()
+
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22f12
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22f12
@@ -11,4 +11,7 @@ config SOC
 config GPIO
 	default y
 
+config NUM_IRQS
+	default 74
+
 endif # SOC_MK22F12

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22fx12
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22fx12
@@ -1,0 +1,17 @@
+# Copyright 2023 Daniel DeGrasse
+# SPDX-License-Identifier: Apache-2.0
+
+# Kinetis MK22FX12 configuration options
+
+if SOC_MK22F12
+
+config SOC
+	default "mk22f12"
+
+config NUM_IRQS
+	default 81
+
+config CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
+	default y
+
+endif # SOC_MK22F12

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.series
@@ -12,9 +12,6 @@ if SOC_SERIES_KINETIS_K2X
 config SOC_SERIES
 	default "k2x"
 
-config NUM_IRQS
-	default 74
-
 source "soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk*"
 
 endif # SOC_SERIES_KINETIS_K2X

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.soc
@@ -26,6 +26,24 @@ config SOC_MK22F51212
 	select HAS_MCUX_DAC
 	select HAS_MCUX_RCM
 
+# Note- the MK22F12 SKU is a legacy SOC, no longer officially supported by
+# NXP's MCUX SDK, and not recommended for new designs.
+config SOC_MK22F12
+	bool "SOC_MK22F12"
+	select HAS_MCUX
+	select HAS_MCUX_SMC
+	select HAS_MCUX_ADC16
+	select HAS_MCUX_FTFX
+	select HAS_MCUX_FTM
+	select HAS_MCUX_RNGA
+	select HAS_MCUX_SIM
+	select HAS_OSC
+	select HAS_MCG
+	select CPU_HAS_FPU
+	select HAS_MCUX_DAC
+	select HAS_MCUX_RCM
+	select CPU_HAS_NXP_MPU
+
 endchoice
 
 if SOC_SERIES_KINETIS_K2X
@@ -36,9 +54,13 @@ config SOC_PART_NUMBER_MK22FN512VLH12
 config SOC_PART_NUMBER_MK22FX512AVLK12
 	bool
 
+config SOC_PART_NUMBER_MK22FX512VLQ12
+	bool
+
 config SOC_PART_NUMBER_KINETIS_K2X
 	string
 	default "MK22FN512VLH12" if SOC_PART_NUMBER_MK22FN512VLH12
+	default "MK22FX512VLQ12" if SOC_PART_NUMBER_MK22FX512VLQ12
 	help
 	  This string holds the full part number of the SoC. It is a hidden option
 	  that you should not set directly. The part number selection choice defines

--- a/soc/arm/nxp_kinetis/k2x/nxp_mpu_regions.c
+++ b/soc/arm/nxp_kinetis/k2x/nxp_mpu_regions.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Daniel DeGrasse
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <soc.h>
+#include <zephyr/arch/arm/mpu/nxp_mpu.h>
+
+static const struct nxp_mpu_region mpu_regions[] = {
+	/* Region 0 */
+	/* Debugger access can't be disabled; ENET and USB devices will not be able
+	 * to access RAM when their regions are dynamically disabled in NXP MPU.
+	 */
+	MPU_REGION_ENTRY("DEBUGGER_0",
+			 0,
+			 0xFFFFFFFF,
+			 REGION_DEBUGGER_AND_DEVICE_ATTR),
+
+	/* The NXP MPU does not give precedence to memory regions like the ARM
+	 * MPU, which means that if one region grants access then another
+	 * region cannot revoke access. If an application enables hardware
+	 * stack protection, we need to disable supervisor writes from the core
+	 * to the stack guard region. As a result, we cannot have a single
+	 * background region that enables supervisor read/write access from the
+	 * core to the entire address space, and instead define two background
+	 * regions that together cover the entire address space except for
+	 * SRAM.
+	 */
+
+	/* Region 1 */
+	MPU_REGION_ENTRY("BACKGROUND_0",
+			 0,
+			 CONFIG_SRAM_BASE_ADDRESS-1,
+			 REGION_BACKGROUND_ATTR),
+	/* Region 2 */
+	MPU_REGION_ENTRY("BACKGROUND_1",
+			 CONFIG_SRAM_BASE_ADDRESS +
+				 (CONFIG_SRAM_SIZE * 1024),
+			 0xFFFFFFFF,
+			 REGION_BACKGROUND_ATTR),
+	/* Region 3 */
+	MPU_REGION_ENTRY("FLASH_0",
+			 CONFIG_FLASH_BASE_ADDRESS,
+			 (CONFIG_FLASH_BASE_ADDRESS +
+				(CONFIG_FLASH_SIZE * 1024) - 1),
+			 REGION_FLASH_ATTR),
+	/* Region 4 */
+	MPU_REGION_ENTRY("RAM_U_0",
+			 CONFIG_SRAM_BASE_ADDRESS,
+			 (CONFIG_SRAM_BASE_ADDRESS +
+				 (CONFIG_SRAM_SIZE * 1024) - 1),
+			 REGION_RAM_ATTR),
+};
+
+const struct nxp_mpu_config mpu_config = {
+	.num_regions = ARRAY_SIZE(mpu_regions),
+	.mpu_regions = mpu_regions,
+	.sram_region = 4,
+};

--- a/soc/arm/nxp_kinetis/k2x/soc.c
+++ b/soc/arm/nxp_kinetis/k2x/soc.c
@@ -49,7 +49,9 @@ static const osc_config_t oscConfig = {
 
 	.oscerConfig = {
 		.enableMode = 0U, /* Disable external reference clock */
+#if FSL_FEATURE_OSC_HAS_EXT_REF_CLOCK_DIVIDER
 		.erclkDiv = 0U,
+#endif
 	},
 };
 


### PR DESCRIPTION
Add SOC definition for MK22F12 series, larger LQFP-144 K22 series parts that feature additional peripheral instances.

Additionally, these parts differ from the standard MK22 in the following ways:
- SYSMPU peripheral is present, so an MPU definition is required
- No external oscillator divider is present