### PR TITLE
MAINTAINERS: LoRa and LoRaWAN: update maintainer and collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1120,24 +1120,6 @@ Release Notes:
   labels:
     - "area: LED"
 
-"Drivers: lora":
-  status: maintained
-  maintainers:
-    - Mani-Sadhasivam
-  collaborators:
-    - mniestroj
-    - JordanYates
-  files:
-    - drivers/lora/
-    - include/zephyr/drivers/lora.h
-    - samples/drivers/lora/
-    - include/zephyr/lorawan/
-    - subsys/lorawan/
-    - samples/subsys/lorawan/
-    - doc/connectivity/lora_lorawan/index.rst
-  labels:
-    - "area: LoRa"
-
 "Drivers: Modem":
   status: maintained
   maintainers:
@@ -1717,6 +1699,24 @@ Logging:
     - doc/services/logging/
   labels:
     - "area: Logging"
+
+LoRa and LoRaWAN:
+  status: maintained
+  maintainers:
+    - Mani-Sadhasivam
+  collaborators:
+    - mniestroj
+    - JordanYates
+  files:
+    - drivers/lora/
+    - include/zephyr/drivers/lora.h
+    - samples/drivers/lora/
+    - include/zephyr/lorawan/
+    - subsys/lorawan/
+    - samples/subsys/lorawan/
+    - doc/connectivity/lora_lorawan/index.rst
+  labels:
+    - "area: LoRa"
 
 MAINTAINERS file:
   status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1706,6 +1706,7 @@ LoRa and LoRaWAN:
     - JordanYates
   collaborators:
     - Mani-Sadhasivam
+    - martinjaeger
     - mniestroj
   files:
     - drivers/lora/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1703,10 +1703,10 @@ Logging:
 LoRa and LoRaWAN:
   status: maintained
   maintainers:
-    - Mani-Sadhasivam
-  collaborators:
-    - mniestroj
     - JordanYates
+  collaborators:
+    - Mani-Sadhasivam
+    - mniestroj
   files:
     - drivers/lora/
     - include/zephyr/drivers/lora.h


### PR DESCRIPTION
I suggest to promote @JordanYates as the new maintainer for LoRa and LoRaWAN. He has reviewed all recent PRs and driven the discussions around LoRa/LoRaWAN.

Some references:

- Discord channel
- #55073
- #62817
- #62086
- #60461
- #58744
- https://github.com/zephyrproject-rtos/loramac-node/pull/13

The previous maintainer @Mani-Sadhasivam is presumably busy with other work and has not been very active in Zephyr recently.
@Mani-Sadhasivam please let us know if I got a wrong impression and if you would like to keep maintainership.

Also adding myself as a collaborator. I have contributed time synchronization services and some bug fixes in
the past and I'm going to work on Class B support in the future.

Some references:

- #43315
- #43324
- #46667
- #46473
- #51328