### PR TITLE
dts: imx8ml_m7: fix mailbox node compatible for NXP i.MX8M Plus SoC

### DIFF
--- a/dts/arm/nxp/nxp_imx8ml_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx8ml_m7.dtsi
@@ -168,7 +168,7 @@
 		};
 
 		mailbox0: mailbox@30ab0000 {
-			compatible = "nxp,imx-mu";
+			compatible = "nxp,imx-mu-rev2";
 			reg = <0x30ab0000 DT_SIZE_K(64)>;
 			interrupts = <97 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\


### PR DESCRIPTION
Commit 7d1f435a2ab4 ("drivers: ipc: Enable messaging unit driver for iMX.RT multicore SOCs") changed the device tree compatible for the NXP i.MX rev2 MU from 'nxp,imx-mu' to 'nxp,imx-mu-rev2'.
To make the mailbox usable again on this SoC, the compatible needs to be adjusted accordingly.