### PR TITLE
drivers: espi: Microchip MEC172x: Fix Port 80 FIFO usage

### DIFF
--- a/drivers/espi/espi_mchp_xec_host_v2.c
+++ b/drivers/espi/espi_mchp_xec_host_v2.c
@@ -830,8 +830,8 @@ static void p80bd0_isr(const struct device *dev)
 
 	while (count--) {
 		/* Excerpt from manual:
-		 *   "Reading from this register byte accepts the value at the top of the FIFO, then advances the FIFO, updating both this"
-		 *   "location and the EC Data Attributes Register."
+		 *   "Reading from this register byte accepts the value at the top of the FIFO, then
+		 *    advances the FIFO, updating both this location and the EC Data Attributes Register."
 		 * -> so ensure the FIFO data is read exactly once on each loop iteration
 		 */
 		/* b[7:0]=8-bit value written, b[15:8]=attributes */


### PR DESCRIPTION
The MEC172x P80 BIOS Debug Port ISR did read FIFO and attributes only once while trying to loop until all FIFO data were processed. So a change in the "Not Empty" bit was never seen.
As a result P80 event callbacks, using only the top-most FIFO entry, were called 8 times regardless how deep the FIFO was.
Now the FIFO and attributes byte are read on each loop iteration.
Tested by using a debugger and saw that it is working as expected now.