### PR TITLE
Support PIT for NXP S32Z27

### DIFF
--- a/dts/arm/nxp/nxp_s32z27x_rtu0_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_rtu0_r52.dtsi
@@ -83,5 +83,14 @@
 			clocks = <&clock NXP_S32_FIRC_CLK>;
 			status = "disabled";
 		};
+
+		pit0: pit@76150000 {
+			compatible = "nxp,kinetis-pit";
+			reg = <0x76150000 0x10000>;
+			interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_P0_REG_INTF_CLK>;
+			max-load-value = <0x00ffffff>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/nxp/nxp_s32z27x_rtu1_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_rtu1_r52.dtsi
@@ -83,5 +83,14 @@
 			clocks = <&clock NXP_S32_FIRC_CLK>;
 			status = "disabled";
 		};
+
+		pit0: pit@76950000 {
+			compatible = "nxp,kinetis-pit";
+			reg = <0x76950000 0x10000>;
+			interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_P1_REG_INTF_CLK>;
+			max-load-value = <0x00ffffff>;
+			status = "disabled";
+		};
 	};
 };

--- a/soc/arm/nxp_s32/s32ze/Kconfig.series
+++ b/soc/arm/nxp_s32/s32ze/Kconfig.series
@@ -15,5 +15,7 @@ config SOC_SERIES_S32ZE_R52
 	select PLATFORM_SPECIFIC_INIT
 	select SOC_FAMILY_NXP_S32
 	select CLOCK_CONTROL
+	select HAS_MCUX
+	select HAS_MCUX_PIT
 	help
 	  Enable support for NXP S32Z/E MCUs family on Cortex-R52 cores.

--- a/tests/drivers/counter/counter_basic_api/boards/s32z270dc2_rtu0_r52.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/s32z270dc2_rtu0_r52.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,5 +21,11 @@
 
 &stm3 {
 	prescaler = <32>;
+	status = "okay";
+};
+
+&pit0 {
+	pit-channel = <0>;
+	pit-period = <1000000>;
 	status = "okay";
 };

--- a/tests/drivers/counter/counter_basic_api/boards/s32z270dc2_rtu1_r52.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/s32z270dc2_rtu1_r52.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,5 +21,11 @@
 
 &stm3 {
 	prescaler = <32>;
+	status = "okay";
+};
+
+&pit0 {
+	pit-channel = <0>;
+	pit-period = <1000000>;
 	status = "okay";
 };

--- a/west.yml
+++ b/west.yml
@@ -199,7 +199,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 6d91c1727dadb170facc48f5370358a12ae36677
+      revision: b4a37865355a6d55cdcdc087b934017212fb0f54
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Add support for Periodic Interrupt Timer (PIT) on `s32z270dc2_r52` boards.