### PR TITLE
doc: can: samples: fix bad reference to can-counter sample

### DIFF
--- a/doc/hardware/peripherals/canbus/controller.rst
+++ b/doc/hardware/peripherals/canbus/controller.rst
@@ -332,7 +332,7 @@ Samples
 *******
 
 We have two ready-to-build samples demonstrating use of the Zephyr CAN API:
-:zephyr:code-sample:`Zephyr CAN counter sample <can-counter-sample>` and
+:zephyr:code-sample:`Zephyr CAN counter sample <can-counter>` and
 :zephyr:code-sample:`SocketCAN sample <socket-can>`.
 
 


### PR DESCRIPTION
Fixed a dangling reference that was silently ignored before.