### PR TITLE
tests: spinlock: Increase time spent in threads for fast CPUs

### DIFF
--- a/boards/x86/intel_adl/intel_adl_crb.yaml
+++ b/boards/x86/intel_adl/intel_adl_crb.yaml
@@ -12,6 +12,7 @@ supported:
   - rtc
   - i2c
   - spi
+  - smp
 testing:
   timeout_multiplier: 4
   ignore_tags:

--- a/boards/x86/intel_adl/intel_adl_rvp.yaml
+++ b/boards/x86/intel_adl/intel_adl_rvp.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
 ram: 2048
 supported:
+  - smp
   - watchdog
 testing:
   timeout_multiplier: 4

--- a/boards/x86/intel_ehl/intel_ehl_crb.yaml
+++ b/boards/x86/intel_ehl/intel_ehl_crb.yaml
@@ -9,6 +9,7 @@ ram: 2048
 supported:
   - gpio
   - smbus
+  - smp
   - rtc
   - watchdog
 testing:

--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -97,8 +97,9 @@ void bounce_once(int id, bool trylock)
 	 */
 	bounce_owner = id;
 
-	for (i = 0; i < 100; i++) {
+	for (i = 0; i < 5; i++) {
 		zassert_true(bounce_owner == id, "Locked data changed");
+		k_busy_wait(1);
 	}
 
 	/* Release the lock */

--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -55,7 +55,7 @@ ZTEST(spinlock, test_spinlock_basic)
 	zassert_true(!z_spin_is_locked(&l), "Spinlock failed to unlock");
 }
 
-void bounce_once(int id, bool trylock)
+static void bounce_once(int id, bool trylock)
 {
 	int ret;
 	int i, locked;
@@ -106,7 +106,7 @@ void bounce_once(int id, bool trylock)
 	k_spin_unlock(&bounce_lock, key);
 }
 
-void cpu1_fn(void *p1, void *p2, void *p3)
+static void cpu1_fn(void *p1, void *p2, void *p3)
 {
 	ARG_UNUSED(p1);
 	ARG_UNUSED(p2);
@@ -188,7 +188,7 @@ ZTEST(spinlock, test_spinlock_mutual_exclusion)
 	zassert_true(!z_spin_is_locked(&lock_runtime), "Spinlock failed to unlock");
 }
 
-void trylock_fn(void *p1, void *p2, void *p3)
+static void trylock_fn(void *p1, void *p2, void *p3)
 {
 	ARG_UNUSED(p1);
 	ARG_UNUSED(p2);


### PR DESCRIPTION
Fixes spinlock tests for intel boards.