### PR TITLE
boards: s32z270dc2_r52: remove duplicated DT include

### DIFF
--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arm/nxp/nxp_s32z27x_r52.dtsi>
 #include "s32z270dc2_r52-pinctrl-common.dtsi"
 
 &stm0 {


### PR DESCRIPTION
This file is already being included on each RTU board DT source.