### PR TITLE
boards: arm: npcx: update flashing information

### DIFF
--- a/boards/arm/npcx7m6fb_evb/doc/index.rst
+++ b/boards/arm/npcx7m6fb_evb/doc/index.rst
@@ -79,10 +79,20 @@ JTAG only sessions.
 Flashing
 ========
 
-Build application as usual for the ``npcx7m6fb_evb`` board, and flash
-using Servo V2, μServo, or Servo V4 (CCD). See the
+If the correct IDC headers are installed, this board supports both J-TAG and
+also the ChromiumOS servo.
+
+To flash using Servo V2, μServo, or Servo V4 (CCD), see the
 `Chromium EC Flashing Documentation`_ for more information.
 
+To flash with J-TAG, install the drivers for your programmer, for example:
+SEGGER J-link's drivers are at https://www.segger.com/downloads/jlink/
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: npcx7m6fb_evb
+   :maybe-skip-config:
+   :goals: build flash
 
 Debugging
 =========

--- a/boards/arm/npcx9m6f_evb/doc/index.rst
+++ b/boards/arm/npcx9m6f_evb/doc/index.rst
@@ -93,8 +93,8 @@ JTAG-only sessions.
 Flashing
 ========
 
-If the correct headers are installed, this board supports both J-TAG and also
-the ChromiumOS servo.
+If the correct IDC headers are installed, this board supports both J-TAG and
+also the ChromiumOS servo.
 
 To flash using Servo V2, μServo, or Servo V4 (CCD), see the
 `Chromium EC Flashing Documentation`_ for more information.
@@ -102,22 +102,11 @@ To flash using Servo V2, μServo, or Servo V4 (CCD), see the
 To flash with J-TAG, install the drivers for your programmer, for example:
 SEGGER J-link's drivers are at https://www.segger.com/downloads/jlink/
 
-The openocd from Zephyr SDK 0.14.2 doesn't include npcx support, so build openocd from source.::
-
-  sudo apt-get install libftdi-dev libusb-1.0.0-dev
-  git clone https://git.code.sf.net/p/openocd/code ~/openocd
-  cd ~/openocd
-  ./bootstrap
-  ./configure --enable-jlink --enable-ftdi
-  make clean
-  make
-  sudo make install
-
-Build and flash the blinky sample.::
-
-  west build -t clean && \
-    west build -c -p auto -b npcx9m6f_evb samples/basic/blinky && \
-    west flash --openocd /usr/local/bin/openocd
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: npcx9m6f_evb
+   :maybe-skip-config:
+   :goals: build flash
 
 Debugging
 =========


### PR DESCRIPTION
Update flashing information for npcx7m6fb_evb and npcx9m6f_evb since current OpenOCD in zephyr-sdk has supported them.