### PR TITLE
Bluetooth: Controller: nRF53: Fix sw switch single timer id regression

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5340.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5340.h
@@ -5,6 +5,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Override EVENT_TIMER_ID from 4 to 0, as nRF5340 does not have 4 timer
+ * instances.
+ */
+#if defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)
+#undef EVENT_TIMER_ID
+#define EVENT_TIMER_ID 0
+
+#undef EVENT_TIMER
+#define EVENT_TIMER    _CONCAT(NRF_TIMER, EVENT_TIMER_ID)
+
+#undef SW_SWITCH_TIMER
+#define SW_SWITCH_TIMER EVENT_TIMER
+#endif /* CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
+
 /* NRF Radio HW timing constants
  * - provided in US and NS (for higher granularity)
  * - based on empirical measurements and sniffer logs

--- a/tests/bluetooth/init/testcase.yaml
+++ b/tests/bluetooth/init/testcase.yaml
@@ -122,6 +122,19 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52dk_nrf52832
+  bluetooth.init.test_ctlr_sw_switch_single_timer:
+    extra_args:
+      - CONF_FILE=prj_ctlr.conf
+      - CONFIG_BT_CTLR_ADVANCED_FEATURES=y
+      - CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER=y
+    platform_allow:
+      - nrf5340dk_nrf5340_cpunet
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
+    integration_platforms:
+      - nrf5340dk_nrf5340_cpunet
+      - nrf52840dk_nrf52840
+      - nrf52dk_nrf52832
   bluetooth.init.test_ctlr_ticker:
     extra_args:
       - CONF_FILE=prj_ctlr_ticker.conf


### PR DESCRIPTION
Fix regression in sw switch single timer id use for nRF53x series SoC.

Regression introduced in commit cfcbe5d68ed3 ("Bluetooth: Controller: Remove redudant header file includes").

Fixes #62970.