### PR TITLE
doc: bluetooth: mesh: note and spec name fix

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/cfg_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/cfg_srv.rst
@@ -8,7 +8,7 @@ specification. The Configuration Server model controls most parameters of the
 mesh node. It does not have an API of its own, but relies on a
 :ref:`bluetooth_mesh_models_cfg_cli` to control it.
 
-..note::
+.. note::
    The :c:struct:`bt_mesh_cfg_srv` structure has been deprecated. The initial
    values of the Relay, Beacon, Friend, Network transmit and Relay retransmit
    should be set through Kconfig, and the Heartbeat feature should be

--- a/doc/connectivity/bluetooth/api/mesh/op_agg_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/op_agg_cli.rst
@@ -6,7 +6,7 @@ Opcodes Aggregator Client
 The Opcodes Aggregator Client model is a foundation model defined by the Bluetooth
 mesh specification. It is an optional model, enabled with the :kconfig:option:`CONFIG_BT_MESH_OP_AGG_CLI` option.
 
-The Opcodes Aggregator Client model is introduced in the Bluetooth Mesh Profile
+The Opcodes Aggregator Client model is introduced in the Bluetooth Mesh Protocol
 Specification version 1.1, and is used to support the functionality of dispatching
 a sequence of access layer messages to nodes supporting the :ref:`bluetooth_mesh_models_op_agg_srv` model.
 

--- a/doc/connectivity/bluetooth/api/mesh/op_agg_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/op_agg_srv.rst
@@ -6,7 +6,7 @@ Opcodes Aggregator Server
 The Opcodes Aggregator Server model is a foundation model defined by the Bluetooth
 mesh specification. It is an optional model, enabled with the :kconfig:option:`CONFIG_BT_MESH_OP_AGG_SRV` option.
 
-The Opcodes Aggregator Server model is introduced in the Bluetooth Mesh Profile
+The Opcodes Aggregator Server model is introduced in the Bluetooth Mesh Protocol
 Specification version 1.1, and is used to support the functionality of processing
 a sequence of access layer messages.
 

--- a/doc/connectivity/bluetooth/api/mesh/priv_beacon_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/priv_beacon_cli.rst
@@ -7,7 +7,7 @@ The Private Beacon Client model is a foundation model defined by the Bluetooth
 mesh specification. It is enabled with the
 :kconfig:option:`CONFIG_BT_MESH_PRIV_BEACON_CLI` option.
 
-The Private Beacon Client model is introduced in the Bluetooth Mesh Profile
+The Private Beacon Client model is introduced in the Bluetooth Mesh Protocol
 Specification version 1.1, and provides functionality for configuring the
 :ref:`bluetooth_mesh_models_priv_beacon_srv` models.
 

--- a/doc/connectivity/bluetooth/api/mesh/priv_beacon_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/priv_beacon_srv.rst
@@ -7,7 +7,7 @@ The Private Beacon Server model is a foundation model defined by the Bluetooth
 mesh specification. It is enabled with
 :kconfig:option:`CONFIG_BT_MESH_PRIV_BEACON_SRV` option.
 
-The Private Beacon Server model is introduced in the Bluetooth Mesh Profile
+The Private Beacon Server model is introduced in the Bluetooth Mesh Protocol
 Specification version 1.1, and controls the mesh node's Private Beacon state,
 Private GATT Proxy state and Private Node Identity state.
 


### PR DESCRIPTION
Fixed a note in Config Server model
and spec name in couple of other models