### PR TITLE
tests: kernel: xip: exclude qemu_riscv32_xip

### DIFF
--- a/tests/kernel/xip/testcase.yaml
+++ b/tests/kernel/xip/testcase.yaml
@@ -7,6 +7,8 @@ tests:
     integration_platforms:
       - qemu_arc_em
       - qemu_x86_xip
+    platform_exclude:
+      - qemu_riscv32_xip # See issue #62975
   arch.common.xip.minimallibc:
     filter: CONFIG_XIP and CONFIG_MINIMAL_LIBC_SUPPORTED
     tags:
@@ -15,5 +17,7 @@ tests:
     integration_platforms:
       - qemu_arc_em
       - qemu_x86_xip
+    platform_exclude:
+      - qemu_riscv32_xip # See issue #62975
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
Hi, feels odd to exclude a xip board from the xip test but I think qemu or the board config are at fault here and may take a bit to investigate. Reverting the patch is an option as well, but it works on other riscv platforms and this should be investiaged anyway. LMK what you think.

See https://github.com/zephyrproject-rtos/zephyr/issues/62975 for details

---

This board seems to have issue with data alignemnt after 843f66f and is failing in CI. Exclude it while the problem is investigated.