### PR TITLE
samples: subsys: usb: cdc_acm: add twister test for st boards

### DIFF
--- a/samples/subsys/usb/cdc_acm/sample.yaml
+++ b/samples/subsys/usb/cdc_acm/sample.yaml
@@ -42,3 +42,19 @@ tests:
     build_only: true
     integration_platforms:
       - native_posix
+  sample.usb.cdc-acm-otg-st:
+    depends_on: usb_device
+    tags: usb
+    platform_allow:
+      - nucleo_f207zg
+      - nucleo_f429zi
+      - nucleo_f746zg
+      - nucleo_h743zi
+      - disco_l475_iot1
+      - b_u585i_iot02a
+      - stm32l562e_dk
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "Device configured"


### PR DESCRIPTION
add one twister test : sample.usb.cdc-acm-otg-st.
if the second usb connector (the other than ST-link) is connect and the link is ok we must read the string: "Device configured"