### PR TITLE
Bluetooth controller: hal for nrf52_bsim target: Fix hal_radio_tx_chain_delay_ns_get() and other minors 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrf52.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrf52.h
@@ -14,7 +14,10 @@
 
 /* NRF Radio HW timing constants
  * - provided in US and NS (for higher granularity)
- * - based on empirical measurements and sniffer logs
+ * - based on the timings configured in the HW models, which are based
+ *   on the product specification
+ * - Note that this timings are approx. the same as in the real HW,
+ *   but tend to be rounded to the nearest microsecond
  */
 
 /* TXEN->TXIDLE + TXIDLE->TX (with fast Radio ramp-up mode)
@@ -361,7 +364,7 @@ static inline uint32_t hal_radio_tx_chain_delay_ns_get(uint8_t phy, uint8_t flag
 	ARG_UNUSED(phy);
 	ARG_UNUSED(flags);
 
-	return HAL_RADIO_NRF52833_TX_CHAIN_DELAY_US;
+	return HAL_RADIO_NRF52833_TX_CHAIN_DELAY_NS;
 }
 
 static inline uint32_t hal_radio_rx_chain_delay_ns_get(uint8_t phy, uint8_t flags)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrf52.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrf52.h
@@ -185,14 +185,10 @@
 
 static inline void hal_radio_reset(void)
 {
-	/* TODO: Add any required setup for each radio event
-	 */
 }
 
 static inline void hal_radio_stop(void)
 {
-	/* TODO: Add any required cleanup of actions taken in hal_radio_reset()
-	 */
 }
 
 static inline void hal_radio_ram_prio_setup(void)
@@ -226,25 +222,39 @@ static inline uint32_t hal_radio_tx_power_min_get(void)
 
 static inline uint32_t hal_radio_tx_power_max_get(void)
 {
-#if defined(RADIO_TXPOWER_TXPOWER_Pos4dBm)
-	return RADIO_TXPOWER_TXPOWER_Pos4dBm;
-#else
-	return RADIO_TXPOWER_TXPOWER_0dBm;
-#endif
+	return RADIO_TXPOWER_TXPOWER_Pos8dBm;
 }
 
 static inline uint32_t hal_radio_tx_power_floor(int8_t tx_power_lvl)
 {
-#if defined(RADIO_TXPOWER_TXPOWER_Pos4dBm)
+	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_Pos8dBm) {
+		return RADIO_TXPOWER_TXPOWER_Pos8dBm;
+	}
+
+	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_Pos7dBm) {
+		return RADIO_TXPOWER_TXPOWER_Pos7dBm;
+	}
+
+	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_Pos6dBm) {
+		return RADIO_TXPOWER_TXPOWER_Pos6dBm;
+	}
+
+	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_Pos5dBm) {
+		return RADIO_TXPOWER_TXPOWER_Pos5dBm;
+	}
+
 	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_Pos4dBm) {
 		return RADIO_TXPOWER_TXPOWER_Pos4dBm;
 	}
-#endif
-#if defined(RADIO_TXPOWER_TXPOWER_Pos3dBm)
+
 	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_Pos3dBm) {
 		return RADIO_TXPOWER_TXPOWER_Pos3dBm;
 	}
-#endif
+
+	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_Pos2dBm) {
+		return RADIO_TXPOWER_TXPOWER_Pos2dBm;
+	}
+
 	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_0dBm) {
 		return RADIO_TXPOWER_TXPOWER_0dBm;
 	}
@@ -269,10 +279,7 @@ static inline uint32_t hal_radio_tx_power_floor(int8_t tx_power_lvl)
 		return RADIO_TXPOWER_TXPOWER_Neg20dBm;
 	}
 
-	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_Neg30dBm) {
-		return RADIO_TXPOWER_TXPOWER_Neg30dBm;
-	}
-
+	/* Note: The -30 dBm power level is deprecated so ignore it! */
 	return RADIO_TXPOWER_TXPOWER_Neg40dBm;
 }
 


### PR DESCRIPTION


    Bluetooth controller nrf: nrf52 bsim radio hal fix
    
    hal_radio_tx_chain_delay_ns_get() was incorrectly
    returning the microsecond value, resulting in a 1us
    error in the timing => Fix it.
   
---------

    Bluetooth controller nrf: nrf52 bsim radio hal header minor updates
    
    Align the header a bit with the one for the real radio,
    adding missing Tx power levels and removing TODOs which did not need doing.
    The old one originated as a copy of the nrf52833 one, and did not
    evolve like the real ones.
