### PR TITLE
drivers: dma: intel_lpss: Added parent phandle

### DIFF
--- a/drivers/dma/Kconfig.intel_lpss
+++ b/drivers/dma/Kconfig.intel_lpss
@@ -5,8 +5,9 @@
 
 config DMA_INTEL_LPSS
 	bool "INTEL LPSS DMA driver"
-	default n
+	default y
 	depends on DT_HAS_INTEL_LPSS_ENABLED
+	select DEVICE_DEPS
 	help
 	  INTEL LPSS DMA driver.
 

--- a/drivers/dma/dma_intel_lpss.c
+++ b/drivers/dma/dma_intel_lpss.c
@@ -82,7 +82,7 @@ static const struct dma_driver_api dma_intel_lpss_driver_api = {
 		.dw_cfg = {						\
 			.base = 0,					\
 		},							\
-		.parent = DEVICE_DT_GET(DT_INST_PARENT(n)),		\
+		.parent = DEVICE_DT_GET(DT_INST_PHANDLE(n, dma_parent)),\
 	};								\
 									\
 	static struct dw_dma_dev_data dma_intel_lpss##n##_data = {	\

--- a/dts/bindings/dma/intel,lpss.yaml
+++ b/dts/bindings/dma/intel,lpss.yaml
@@ -11,5 +11,10 @@ properties:
   "#dma-cells":
     const: 1
 
+  dma-parent:
+    type: phandle
+    description: |
+      Parent device for LPSS DMA to get its base address.
+
 dma-cells:
   - channel


### PR DESCRIPTION
Added a phandle named dma-parent to get base address instead of
adding DMA as child node because it is causing a build warning
(avoid_unnecessary_addr_size) if the parent instance has
"#address-cells/#size-cells" dts properties marked required
and child doesn't have reg property. DMA doesn't have reg
as it gets the base address from parent device.

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>