### PR TITLE
drivers/sensor: lsm6dsv16x: add in DT both INT1 and INT2 pin

### DIFF
--- a/boards/arm/sensortile_box_pro/sensortile_box_pro.dts
+++ b/boards/arm/sensortile_box_pro/sensortile_box_pro.dts
@@ -175,7 +175,9 @@
 		compatible = "st,lsm6dsv16x";
 		spi-max-frequency = <DT_FREQ_M(10)>; /* 10 MHz */
 		reg = <0>;
-		irq-gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
+		int1-gpios = <&gpioa 4 GPIO_ACTIVE_HIGH>;
+		int2-gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
+
 		drdy-pin = <2>;
 	};
 };

--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -35,6 +35,24 @@ enable all optional modules, and then run ``west update`` again.
 Device Drivers and Device Tree
 ==============================
 
+* The :dtcompatible:`st,lsm6dsv16x` sensor driver has been changed to support
+  configuration of both int1 and int2 pins. The DT attribute ``irq-gpios`` has been
+  removed and substituted by two new attributes, ``int1-gpios`` and ``int2-gpios``.
+  These attributes must be configured in the Device Tree similarly to the following
+  example:
+
+  .. code-block:: devicetree
+
+    / {
+        lsm6dsv16x@0 {
+            compatible = "st,lsm6dsv16x";
+
+            int1-gpios = <&gpioa 4 GPIO_ACTIVE_HIGH>;
+            int2-gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
+            drdy-pin = <2>;
+        };
+    };
+
 Power Management
 ================
 

--- a/drivers/sensor/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/lsm6dsv16x/lsm6dsv16x.c
@@ -919,9 +919,10 @@ static int lsm6dsv16x_init(const struct device *dev)
  */
 
 #ifdef CONFIG_LSM6DSV16X_TRIGGER
-#define LSM6DSV16X_CFG_IRQ(inst)						\
+#define LSM6DSV16X_CFG_IRQ(inst)					\
 	.trig_enabled = true,						\
-	.gpio_drdy = GPIO_DT_SPEC_INST_GET(inst, irq_gpios),		\
+	.int1_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int1_gpios, { 0 }),	\
+	.int2_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int2_gpios, { 0 }),	\
 	.drdy_pin = DT_INST_PROP(inst, drdy_pin)
 #else
 #define LSM6DSV16X_CFG_IRQ(inst)
@@ -938,8 +939,7 @@ static int lsm6dsv16x_init(const struct device *dev)
 	.gyro_odr = DT_INST_PROP(inst, gyro_odr),			\
 	.gyro_range = DT_INST_PROP(inst, gyro_range),			\
 	.drdy_pulsed = DT_INST_PROP(inst, drdy_pulsed),                 \
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),		\
-		(LSM6DSV16X_CFG_IRQ(inst)), ())
+	LSM6DSV16X_CFG_IRQ(inst)
 
 #define LSM6DSV16X_CONFIG_SPI(inst)					\
 	{								\

--- a/drivers/sensor/lsm6dsv16x/lsm6dsv16x.h
+++ b/drivers/sensor/lsm6dsv16x/lsm6dsv16x.h
@@ -57,7 +57,8 @@ struct lsm6dsv16x_config {
 	uint8_t gyro_range;
 	uint8_t drdy_pulsed;
 #ifdef CONFIG_LSM6DSV16X_TRIGGER
-	const struct gpio_dt_spec gpio_drdy;
+	const struct gpio_dt_spec int1_gpio;
+	const struct gpio_dt_spec int2_gpio;
 	uint8_t drdy_pin;
 	bool trig_enabled;
 #endif /* CONFIG_LSM6DSV16X_TRIGGER */
@@ -102,6 +103,8 @@ struct lsm6dsv16x_data {
 	uint8_t gyro_fs;
 
 #ifdef CONFIG_LSM6DSV16X_TRIGGER
+	struct gpio_dt_spec *drdy_gpio;
+
 	struct gpio_callback gpio_cb;
 	sensor_trigger_handler_t handler_drdy_acc;
 	const struct sensor_trigger *trig_drdy_acc;

--- a/drivers/sensor/lsm6dsv16x/lsm6dsv16x_trigger.c
+++ b/drivers/sensor/lsm6dsv16x/lsm6dsv16x_trigger.c
@@ -233,7 +233,7 @@ static void lsm6dsv16x_handle_interrupt(const struct device *dev)
 #endif
 	}
 
-	gpio_pin_interrupt_configure_dt(&cfg->gpio_drdy,
+	gpio_pin_interrupt_configure_dt(lsm6dsv16x->drdy_gpio,
 					GPIO_INT_EDGE_TO_ACTIVE);
 }
 
@@ -242,11 +242,10 @@ static void lsm6dsv16x_gpio_callback(const struct device *dev,
 {
 	struct lsm6dsv16x_data *lsm6dsv16x =
 		CONTAINER_OF(cb, struct lsm6dsv16x_data, gpio_cb);
-	const struct lsm6dsv16x_config *cfg = lsm6dsv16x->dev->config;
 
 	ARG_UNUSED(pins);
 
-	gpio_pin_interrupt_configure_dt(&cfg->gpio_drdy, GPIO_INT_DISABLE);
+	gpio_pin_interrupt_configure_dt(lsm6dsv16x->drdy_gpio, GPIO_INT_DISABLE);
 
 #if defined(CONFIG_LSM6DSV16X_TRIGGER_OWN_THREAD)
 	k_sem_give(&lsm6dsv16x->gpio_sem);
@@ -287,8 +286,12 @@ int lsm6dsv16x_init_interrupt(const struct device *dev)
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	int ret;
 
+	lsm6dsv16x->drdy_gpio = (cfg->drdy_pin == 1) ?
+			(struct gpio_dt_spec *)&cfg->int1_gpio :
+			(struct gpio_dt_spec *)&cfg->int2_gpio;
+
 	/* setup data ready gpio interrupt (INT1 or INT2) */
-	if (!gpio_is_ready_dt(&cfg->gpio_drdy)) {
+	if (!gpio_is_ready_dt(lsm6dsv16x->drdy_gpio)) {
 		LOG_ERR("Cannot get pointer to drdy_gpio device");
 		return -EINVAL;
 	}
@@ -306,7 +309,7 @@ int lsm6dsv16x_init_interrupt(const struct device *dev)
 	lsm6dsv16x->work.handler = lsm6dsv16x_work_cb;
 #endif /* CONFIG_LSM6DSV16X_TRIGGER_OWN_THREAD */
 
-	ret = gpio_pin_configure_dt(&cfg->gpio_drdy, GPIO_INPUT);
+	ret = gpio_pin_configure_dt(lsm6dsv16x->drdy_gpio, GPIO_INPUT);
 	if (ret < 0) {
 		LOG_DBG("Could not configure gpio");
 		return ret;
@@ -314,9 +317,9 @@ int lsm6dsv16x_init_interrupt(const struct device *dev)
 
 	gpio_init_callback(&lsm6dsv16x->gpio_cb,
 			   lsm6dsv16x_gpio_callback,
-			   BIT(cfg->gpio_drdy.pin));
+			   BIT(lsm6dsv16x->drdy_gpio->pin));
 
-	if (gpio_add_callback(cfg->gpio_drdy.port, &lsm6dsv16x->gpio_cb) < 0) {
+	if (gpio_add_callback(lsm6dsv16x->drdy_gpio->port, &lsm6dsv16x->gpio_cb) < 0) {
 		LOG_DBG("Could not set gpio callback");
 		return -EIO;
 	}
@@ -333,6 +336,6 @@ int lsm6dsv16x_init_interrupt(const struct device *dev)
 		return ret;
 	}
 
-	return gpio_pin_interrupt_configure_dt(&cfg->gpio_drdy,
+	return gpio_pin_interrupt_configure_dt(lsm6dsv16x->drdy_gpio,
 					       GPIO_INT_EDGE_TO_ACTIVE);
 }

--- a/dts/bindings/sensor/st,lsm6dsv16x-common.yaml
+++ b/dts/bindings/sensor/st,lsm6dsv16x-common.yaml
@@ -4,10 +4,19 @@
 include: sensor-device.yaml
 
 properties:
-  irq-gpios:
+  int1-gpios:
     type: phandle-array
     description: |
-      DRDY pin
+      INT1 pin
+
+      This pin defaults to active high when produced by the sensor.
+      The property value should ensure the flags properly describe
+      the signal that is presented to the driver.
+
+  int2-gpios:
+    type: phandle-array
+    description: |
+      INT2 pin
 
       This pin defaults to active high when produced by the sensor.
       The property value should ensure the flags properly describe

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -695,7 +695,8 @@ test_i2c_lsm6dso16is: lsm6dso16is@68 {
 test_i2c_lsm6dsv16x: lsm6dsv16x@69 {
 	compatible = "st,lsm6dsv16x";
 	reg = <0x69>;
-	irq-gpios = <&test_gpio 0 0>;
+	int1-gpios = <&test_gpio 0 0>;
+	int2-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_mcp9600: mcp9600@6a {

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -261,7 +261,8 @@ test_spi_lsm6dsv16x: lsm6dsv16x@22 {
 	compatible = "st,lsm6dsv16x";
 	reg = <0x22>;
 	spi-max-frequency = <0>;
-	irq-gpios = <&test_gpio 0 0>;
+	int1-gpios = <&test_gpio 0 0>;
+	int2-gpios = <&test_gpio 0 0>;
 };
 
 test_spi_bmi08x_accel: bmi08x@23 {


### PR DESCRIPTION
Add in DT the possibility to configure both INT1 and INT2 pin. The driver will then assign one of the two (either 1 or 2, according to what value drdy_pin is set) to a gpio for receiving drdy interrupts.

The other pin may be used in the future to receive event interrupts.