### PR TITLE
drivers: i2c: i2c_nrfx_twim: fail gracefully on dma max size

### DIFF
--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -99,6 +99,7 @@
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 
@@ -126,6 +127,7 @@
 			reg = <0x40004000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -110,6 +110,7 @@
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <14>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -114,6 +114,7 @@
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <10>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -126,6 +126,7 @@
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <14>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -116,6 +116,7 @@
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <15>;
 			status = "disabled";
 		};
 
@@ -151,6 +152,7 @@
 			reg = <0x40004000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <15>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -114,6 +114,7 @@
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 
@@ -149,6 +150,7 @@
 			reg = <0x40004000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <8>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -121,6 +121,7 @@
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -156,6 +157,7 @@
 			reg = <0x40004000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -116,6 +116,7 @@
 			reg = <0x40003000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 
@@ -151,6 +152,7 @@
 			reg = <0x40004000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -78,6 +78,7 @@ i2c0: i2c@8000 {
 	reg = <0x8000 0x1000>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
+	easydma-maxcnt-bits = <16>;
 	status = "disabled";
 };
 
@@ -118,6 +119,7 @@ i2c1: i2c@9000 {
 	reg = <0x9000 0x1000>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
+	easydma-maxcnt-bits = <16>;
 	status = "disabled";
 };
 
@@ -171,6 +173,7 @@ i2c2: i2c@b000 {
 	reg = <0xb000 0x1000>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
+	easydma-maxcnt-bits = <16>;
 	status = "disabled";
 };
 
@@ -211,6 +214,7 @@ i2c3: i2c@c000 {
 	reg = <0xc000 0x1000>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <12 NRF_DEFAULT_IRQ_PRIORITY>;
+	easydma-maxcnt-bits = <16>;
 	status = "disabled";
 };
 

--- a/dts/arm/nordic/nrf91_peripherals.dtsi
+++ b/dts/arm/nordic/nrf91_peripherals.dtsi
@@ -158,6 +158,7 @@ i2c0: i2c@8000 {
 	reg = <0x8000 0x1000>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
+	easydma-maxcnt-bits = <13>;
 	status = "disabled";
 };
 
@@ -173,6 +174,7 @@ i2c1: i2c@9000 {
 	reg = <0x9000 0x1000>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
+	easydma-maxcnt-bits = <13>;
 	status = "disabled";
 };
 
@@ -188,6 +190,7 @@ i2c2: i2c@a000 {
 	reg = <0xa000 0x1000>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <10 NRF_DEFAULT_IRQ_PRIORITY>;
+	easydma-maxcnt-bits = <13>;
 	status = "disabled";
 };
 
@@ -203,6 +206,7 @@ i2c3: i2c@b000 {
 	reg = <0xb000 0x1000>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
+	easydma-maxcnt-bits = <13>;
 	status = "disabled";
 };
 

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -15,3 +15,10 @@ properties:
 
   pinctrl-0:
     required: true
+
+  easydma-maxcnt-bits:
+    type: int
+    required: true
+    description: |
+      Maximum number of bits available in the EasyDMA MAXCNT register. This
+      property must be set at SoC level DTS files.


### PR DESCRIPTION
Different nRF52 devices have different maximum TWI DMA transfer size, and it's easy to hit the limit with i2c displays on nrf52832 (8 bit) and nrf52810 (10 bit). Currently neither the driver or the hal validate the limit, leading to random NACK errors when trying to transfer more data.

Add a check on the driver to fail gracefully when going over the limit.