### PR TITLE
drivers: console: uart_console: avoid infinite loop in isr

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -446,13 +446,18 @@ static void uart_console_isr(const struct device *unused, void *user_data)
 	ARG_UNUSED(user_data);
 	static uint8_t last_char = '\0';
 
-	while (uart_irq_update(uart_console_dev) &&
-	       uart_irq_is_pending(uart_console_dev)) {
+	while (uart_irq_update(uart_console_dev) > 0 &&
+	       uart_irq_is_pending(uart_console_dev) > 0) {
 		static struct console_input *cmd;
 		uint8_t byte;
 		int rx;
 
-		if (!uart_irq_rx_ready(uart_console_dev)) {
+		rx = uart_irq_rx_ready(uart_console_dev);
+		if (rx < 0) {
+			return;
+		}
+
+		if (rx == 0) {
 			continue;
 		}
 
@@ -561,7 +566,7 @@ static void console_input_init(void)
 	uart_irq_callback_set(uart_console_dev, uart_console_isr);
 
 	/* Drain the fifo */
-	while (uart_irq_rx_ready(uart_console_dev)) {
+	while (uart_irq_rx_ready(uart_console_dev) > 0) {
 		uart_fifo_read(uart_console_dev, &c, 1);
 	}
 


### PR DESCRIPTION
Previously, the `uart_console_isr()` routine assumed that the return value of several uart API functions would only ever return the equivalent of a boolean value. The functions return integers in `[-N,0,1]` representing negative `errno` values, `false`, and `true`.

Since unary operations would either go to `true` or `false` and since any non-zero integer evaluates to `true`, even a return value of something like `-ENODEV` would evaluate to `true`.

Explicitly compare against the integer-equivalent value of the expected boolean output.

With this, in the case of errors, negative return values do not evaluate to `true`, and the infinite loop is avoided.

Fixes #62999