### PR TITLE
ci: doc-build: add a rebase step

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -44,6 +44,20 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+
+    - name: Rebase
+      continue-on-error: true
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        PR_HEAD: ${{ github.event.pull_request.head.sha }}
+      run: |
+        git config --global user.email "actions@zephyrproject.org"
+        git config --global user.name "Github Actions"
+        git rebase origin/${BASE_REF}
+        git log --graph --oneline HEAD...${PR_HEAD}
 
     - name: install-pkgs
       run: |


### PR DESCRIPTION
Add a rebase step after checkout for the documentation build CI run.

This is in line with what pretty much all other workfloww already do, and means that if a PR is opened on a broken tree and the breakage get fixed, the PR run just have to be retried for the test to pass and we don't have to ask the authors to rebase and lose any pending approvals.