### PR TITLE
soc: xtensa/intel_adsp/ace: fix _end location

### DIFF
--- a/soc/xtensa/intel_adsp/ace/ace-link.ld
+++ b/soc/xtensa/intel_adsp/ace/ace-link.ld
@@ -403,10 +403,13 @@ SECTIONS {
     _unused_ram_start_marker = .;
     *(.unused_ram_start_marker)
     *(.unused_ram_start_marker.*)
-    _end = .;
     z_mapped_end = .;
   } >ram
 
+  /* Heap start and end markers. Used with libc malloc code. */
+  . = SEGSTART_UNCACHED;
+  _end = ALIGN(8);
+  . = SEGSTART_CACHED;
   . = L2_SRAM_BASE + L2_SRAM_SIZE;
   . = SEGSTART_UNCACHED;
   _heap_end = .;


### PR DESCRIPTION
The symbol _end is used to indicate the start of heap in the common libc malloc code. On ACE, heap is in uncached area. However, _end was in the cached area while end of heap is in uncached area. This resulted in incorrect calculation of heap size. So move _end into uncached area so correct heap size can be calculated.