### PR TITLE
samples: userspace: exclude cy8cproto boards from sample

### DIFF
--- a/samples/userspace/shared_mem/sample.yaml
+++ b/samples/userspace/shared_mem/sample.yaml
@@ -14,6 +14,9 @@ common:
 tests:
   sample.kernel.memory_protection.shared_mem:
     filter: CONFIG_ARCH_HAS_USERSPACE
-    platform_exclude: twr_ke18f
+    platform_exclude:
+      - twr_ke18f
+      - cy8cproto_062_4343w
+      - cy8cproto_063_ble
     extra_configs:
       - CONFIG_TEST_HW_STACK_PROTECTION=n


### PR DESCRIPTION
Excluded cy8cproto_062_4343w and cy8cproto_063_ble from
samples/userspace/shared_mem sample due to a hardware
limitation with number of available MPU regions.
Sample throws warning:
`num_parts of 4 exceeds maximum allowable partitions (2)`
With the Cortex M4 on the boards only 2 mpu regions are left
and available to be used with the sample.