### PR TITLE
scripts/log_parser: Handle signed and unsigned char length modifier

### DIFF
--- a/scripts/logging/dictionary/dictionary_parser/log_parser_v1.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_parser_v1.py
@@ -79,9 +79,12 @@ def formalize_fmt_string(fmt_str):
     """Replace unsupported formatter"""
     new_str = fmt_str
 
-    # Python doesn't support %lld or %llu so need to remove extra 'l'
-    new_str = new_str.replace("%lld", "%ld")
-    new_str = new_str.replace("%llu", "%lu")
+    for spec in ['d', 'i', 'o', 'u', 'x', 'X']:
+        # Python doesn't support %ll for integer specifiers, so remove extra 'l'
+        new_str = new_str.replace("%ll" + spec, "%l" + spec)
+
+        # Python doesn't support %hh for integer specifiers, so remove extra 'h'
+        new_str = new_str.replace("%hh" + spec, "%h" + spec)
 
     # No %p for pointer either, so use %x
     new_str = new_str.replace("%p", "0x%x")


### PR DESCRIPTION
The C standard specifies 'hh' as a length modifier indicating an integer conversion specifier applies to a signed char or unsigned char argument. Python doesn't do that, so replace relevant %hh with %h.

Also fix the handling of %ll so that it applies to all integer specifiers as well.