### PR TITLE
net: wifi: additional scan size optimisations

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -245,7 +245,7 @@ struct wifi_scan_params {
 	uint16_t dwell_time_passive;
 	/** Array of SSID strings to scan.
 	 */
-	char ssids[WIFI_MGMT_SCAN_SSID_FILT_MAX][WIFI_SSID_MAX_LEN + 1];
+	const char *ssids[WIFI_MGMT_SCAN_SSID_FILT_MAX];
 	/** Specifies the maximum number of scan results to return. These results would be the
 	 * BSSIDS with the best RSSI values, in all the scanned channels. This should only be
 	 * used to limit the number of returned scan results, and cannot be counted upon to limit

--- a/include/zephyr/net/wifi_utils.h
+++ b/include/zephyr/net/wifi_utils.h
@@ -63,13 +63,15 @@ int wifi_utils_parse_scan_bands(char *scan_bands_str, uint8_t *band_map);
  * as a comma separated string and convert it to an array.
  *
  * @param scan_ssids_str List of SSIDs expressed as a comma separated list.
- * @param ssids Pointer to an array where the parsed SSIDs are to be stored.
+ * @param ssids Pointer to an array where the SSIDs pointers are to be stored.
+ * @param num_ssids Maximum number of SSIDs that can be stored.
  *
  * @retval 0 on success.
  * @retval -errno value in case of failure.
  */
 int wifi_utils_parse_scan_ssids(char *scan_ssids_str,
-				char ssids[][WIFI_SSID_MAX_LEN + 1]);
+				const char *ssids[],
+				uint8_t num_ssids);
 
 
 /**

--- a/subsys/net/l2/wifi/Kconfig
+++ b/subsys/net/l2/wifi/Kconfig
@@ -39,6 +39,15 @@ config WIFI_MGMT_TWT_CHECK_IP
 	  even when it is awake intervals. Rejecting TWT setup till Wi-Fi
 	  interface has a valid IP address might be desirable in most scenarios.
 
+config WIFI_MGMT_FORCED_PASSIVE_SCAN
+	bool "Force passive Wi-Fi scanning"
+	help
+	  Always request a passive scan, regardless of the user supplied parameters.
+	  This is typically used when the underlying hardware is not certified for
+	  RF transmissions. This doesn't guarantee that passive scan will be used,
+	  it depends on the underlying chip implementation to support and honour
+	  scan type.
+
 config WIFI_MGMT_SCAN_SSID_FILT_MAX
 	int "Maximum number of SSIDs that can be specified for SSID filtering"
 	default 1

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -108,6 +108,15 @@ static int wifi_scan(uint32_t mgmt_request, struct net_if *iface,
 		return -ENOTSUP;
 	}
 
+#ifdef CONFIG_WIFI_MGMT_FORCED_PASSIVE_SCAN
+	struct wifi_scan_params default_params = {0};
+
+	if (params == NULL) {
+		params = &default_params;
+	}
+	params->scan_type = WIFI_SCAN_TYPE_PASSIVE;
+#endif /* CONFIG_WIFI_MGMT_FORCED_PASSIVE_SCAN */
+
 	return wifi_mgmt_api->scan(dev, params, scan_result_cb);
 }
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -698,7 +698,7 @@ static int wifi_scan_args_to_params(const struct shell *sh,
 					       {"bands", required_argument, 0, 'b'},
 					       {"dwell_time_active", required_argument, 0, 'a'},
 					       {"dwell_time_passive", required_argument, 0, 'p'},
-					       {"ssids", required_argument, 0, 's'},
+					       {"ssid", required_argument, 0, 's'},
 					       {"max_bss", required_argument, 0, 'm'},
 					       {"chans", required_argument, 0, 'c'},
 					       {"help", no_argument, 0, 'h'},
@@ -755,7 +755,9 @@ static int wifi_scan_args_to_params(const struct shell *sh,
 			opt_num++;
 			break;
 		case 's':
-			if (wifi_utils_parse_scan_ssids(optarg, params->ssids)) {
+			if (wifi_utils_parse_scan_ssids(optarg,
+							params->ssids,
+							ARRAY_SIZE(params->ssids))) {
 				shell_fprintf(sh, SHELL_ERROR, "Invalid SSID(s)\n");
 				return -ENOEXEC;
 			}
@@ -1871,7 +1873,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 		    "[-b, --bands <Comma separated list of band values (2/5/6)>] : Bands to be scanned where 2: 2.4 GHz, 5: 5 GHz, 6: 6 GHz.\n"
 		    "[-a, --dwell_time_active <val_in_ms>] : Active scan dwell time (in ms) on a channel. Range 5 ms to 1000 ms.\n"
 		    "[-p, --dwell_time_passive <val_in_ms>] : Passive scan dwell time (in ms) on a channel. Range 10 ms to 1000 ms.\n"
-		    "[-s, --ssids <Comma separate list of SSIDs>] : SSID list to scan for.\n"
+		    "[-s, --ssid : SSID to scan for. Can be provided multiple times.\n"
 		    "[-m, --max_bss <val>] : Maximum BSSes to scan for. Range 1 - 65535.\n"
 		    "[-c, --chans <Comma separated list of channel ranges>] : Channels to be scanned. The channels must be specified in the form band1:chan1,chan2_band2:chan3,..etc. band1, band2 must be valid band values and chan1, chan2, chan3 must be specified as a list of comma separated values where each value is either a single channel or a channel range specified as chan_start-chan_end. Each band channel set has to be separated by a _. For example, a valid channel specification can be 2:1,6-11,14_5:36,149-165,44\n"
 		    "[-h, --help] : Print out the help for the scan command.",

--- a/subsys/net/l2/wifi/wifi_utils.c
+++ b/subsys/net/l2/wifi/wifi_utils.c
@@ -263,12 +263,9 @@ int wifi_utils_parse_scan_bands(char *scan_bands_str, uint8_t *band_map)
 }
 
 int wifi_utils_parse_scan_ssids(char *scan_ssids_str,
-				char ssids[][WIFI_SSID_MAX_LEN + 1])
+				const char *ssids[],
+				uint8_t num_ssids)
 {
-	char parse_str[(WIFI_MGMT_SCAN_SSID_FILT_MAX * (WIFI_SSID_MAX_LEN + 1)) + 1];
-	char *ssid = NULL;
-	char *ctx = NULL;
-	uint8_t i = 0;
 	int len;
 
 	if (!scan_ssids_str) {
@@ -276,41 +273,23 @@ int wifi_utils_parse_scan_ssids(char *scan_ssids_str,
 	}
 
 	len = strlen(scan_ssids_str);
-
-	if (len > (WIFI_MGMT_SCAN_SSID_FILT_MAX * (WIFI_SSID_MAX_LEN + 1))) {
+	if (len > WIFI_SSID_MAX_LEN) {
 		NET_ERR("SSID string (%s) size (%d) exceeds maximum allowed value (%d)",
 			scan_ssids_str,
 			len,
-			(WIFI_MGMT_SCAN_SSID_FILT_MAX * (WIFI_SSID_MAX_LEN + 1)));
+			WIFI_SSID_MAX_LEN);
 		return -EINVAL;
 	}
 
-	strncpy(parse_str, scan_ssids_str, len);
-	parse_str[len] = '\0';
-
-	ssid = strtok_r(parse_str, ",", &ctx);
-
-	while (ssid) {
-		if (strlen(ssid) > WIFI_SSID_MAX_LEN) {
-			NET_ERR("SSID length (%zu) exceeds maximum value (%d) for SSID %s",
-				strlen(ssid),
-				WIFI_SSID_MAX_LEN,
-				ssid);
-			return -EINVAL;
+	for (int i = 0; i < num_ssids; i++) {
+		if (ssids[i] != NULL) {
+			continue;
 		}
-
-		if (i >= WIFI_MGMT_SCAN_SSID_FILT_MAX) {
-			NET_WARN("Exceeded maximum allowed (%d) SSIDs. Ignoring SSIDs %s onwards",
-				 WIFI_MGMT_SCAN_SSID_FILT_MAX,
-				 ssid);
-			break;
-		}
-
-		strcpy(&ssids[i++][0], ssid);
-
-		ssid = strtok_r(NULL, ",", &ctx);
+		ssids[i] = scan_ssids_str;
+		return 0;
 	}
 
+	NET_WARN("Exceeded maximum allowed SSIDs (%d)", num_ssids);
 	return 0;
 }
 


### PR DESCRIPTION
Optimise the last large field in `struct wifi_scan_params`. The struct is now 18 bytes in the default configuration.

With this reduction it is feasible to re-add `WIFI_MGMT_FORCED_PASSIVE_SCAN` with proper behaviour (passive scan is requested even if the user doesn't provide a params struct).