### PR TITLE
Add adc_read_dt()

### DIFF
--- a/drivers/sensor/current_amp/current_amp.c
+++ b/drivers/sensor/current_amp/current_amp.c
@@ -28,7 +28,7 @@ static int fetch(const struct device *dev, enum sensor_channel chan)
 		return -ENOTSUP;
 	}
 
-	ret = adc_read(config->port.dev, &data->sequence);
+	ret = adc_read_dt(&config->port, &data->sequence);
 	if (ret != 0) {
 		LOG_ERR("adc_read: %d", ret);
 	}

--- a/drivers/sensor/mcp970x/mcp970x.c
+++ b/drivers/sensor/mcp970x/mcp970x.c
@@ -46,7 +46,7 @@ static int fetch(const struct device *dev, enum sensor_channel chan)
 		return -ENOTSUP;
 	}
 
-	ret = adc_read(config->adc.dev, &data->sequence);
+	ret = adc_read_dt(&config->adc, &data->sequence);
 	if (ret != 0) {
 		LOG_ERR("adc_read: %d", ret);
 	}

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -682,6 +682,21 @@ static inline int z_impl_adc_read(const struct device *dev,
 }
 
 /**
+ * @brief Set a read request from a struct adc_dt_spec.
+ *
+ * @param spec ADC specification from Devicetree.
+ * @param sequence  Structure specifying requested sequence of samplings.
+ *
+ * @return A value from adc_read().
+ * @see adc_read()
+ */
+static inline int adc_read_dt(const struct adc_dt_spec *spec,
+			      const struct adc_sequence *sequence)
+{
+	return adc_read(spec->dev, sequence);
+}
+
+/**
  * @brief Set an asynchronous read request.
  *
  * @note This function is available only if @kconfig{CONFIG_ADC_ASYNC}

--- a/samples/boards/google_twinkie_v2_pda/src/meas.c
+++ b/samples/boards/google_twinkie_v2_pda/src/meas.c
@@ -33,7 +33,7 @@ int meas_vbus_v(int32_t *v)
 	};
 	adc_sequence_init_dt(&adc_vbus_v.port, &sequence);
 
-	ret = adc_read(adc_vbus_v.port.dev, &sequence);
+	ret = adc_read_dt(&adc_vbus_v.port, &sequence);
 	if (ret != 0) {
 		return ret;
 	}

--- a/samples/drivers/adc/src/main.c
+++ b/samples/drivers/adc/src/main.c
@@ -65,7 +65,7 @@ int main(void)
 
 			(void)adc_sequence_init_dt(&adc_channels[i], &sequence);
 
-			err = adc_read(adc_channels[i].dev, &sequence);
+			err = adc_read_dt(&adc_channels[i], &sequence);
 			if (err < 0) {
 				printk("Could not read (%d)\n", err);
 				continue;

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -93,7 +93,7 @@ static int test_task_one_channel(void)
 	init_adc();
 	(void)adc_sequence_init_dt(&adc_channels[0], &sequence);
 
-	ret = adc_read(adc_channels[0].dev, &sequence);
+	ret = adc_read_dt(&adc_channels[0], &sequence);
 	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
 
 	check_samples(1);
@@ -124,7 +124,7 @@ static int test_task_multiple_channels(void)
 		sequence.channels |= BIT(adc_channels[i].channel_id);
 	}
 
-	ret = adc_read(adc_channels[0].dev, &sequence);
+	ret = adc_read_dt(&adc_channels[0], &sequence);
 	if (ret == -ENOTSUP) {
 		ztest_test_skip();
 	}
@@ -230,7 +230,7 @@ static int test_task_with_interval(void)
 
 	(void)adc_sequence_init_dt(&adc_channels[0], &sequence);
 
-	ret = adc_read(adc_channels[0].dev, &sequence);
+	ret = adc_read_dt(&adc_channels[0], &sequence);
 	if (ret == -ENOTSUP) {
 		ztest_test_skip();
 	}
@@ -310,7 +310,7 @@ static int test_task_repeated_samplings(void)
 		sequence.channels |=  BIT(adc_channels[1].channel_id);
 	}
 
-	ret = adc_read(adc_channels[0].dev, &sequence);
+	ret = adc_read_dt(&adc_channels[0], &sequence);
 	if (ret == -ENOTSUP) {
 		ztest_test_skip();
 	}
@@ -339,7 +339,7 @@ static int test_task_invalid_request(void)
 
 	init_adc();
 
-	ret = adc_read(adc_channels[0].dev, &sequence);
+	ret = adc_read_dt(&adc_channels[0], &sequence);
 	zassert_not_equal(ret, 0, "adc_read() unexpectedly succeeded");
 
 #if defined(CONFIG_ADC_ASYNC)
@@ -352,7 +352,7 @@ static int test_task_invalid_request(void)
 	 */
 	sequence.resolution = adc_channels[0].resolution;
 
-	ret = adc_read(adc_channels[0].dev, &sequence);
+	ret = adc_read_dt(&adc_channels[0], &sequence);
 	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
 
 	check_samples(1);

--- a/tests/drivers/adc/adc_rescale/src/main.c
+++ b/tests/drivers/adc/adc_rescale/src/main.c
@@ -69,7 +69,7 @@ static int test_task_voltage_divider(void)
 	};
 	adc_sequence_init_dt(&adc_node_0.port, &sequence);
 
-	ret = adc_read(adc_node_0.port.dev, &sequence);
+	ret = adc_read_dt(&adc_node_0.port, &sequence);
 	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
 
 	ret = adc_raw_to_millivolts_dt(&adc_node_0.port, &calculated_voltage);
@@ -109,7 +109,7 @@ static int test_task_current_sense_shunt(void)
 	};
 	adc_sequence_init_dt(&adc_node_1.port, &sequence);
 
-	ret = adc_read(adc_node_1.port.dev, &sequence);
+	ret = adc_read_dt(&adc_node_1.port, &sequence);
 	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
 
 	ret = adc_raw_to_millivolts_dt(&adc_node_1.port, &calculated_current);
@@ -149,7 +149,7 @@ static int test_task_current_sense_amplifier(void)
 	};
 	adc_sequence_init_dt(&adc_node_2.port, &sequence);
 
-	ret = adc_read(adc_node_2.port.dev, &sequence);
+	ret = adc_read_dt(&adc_node_2.port, &sequence);
 	zassert_equal(ret, 0, "adc_read() failed with code %d", ret);
 
 	ret = adc_raw_to_millivolts_dt(&adc_node_2.port, &calculated_current);

--- a/tests/drivers/regulator/voltage/src/main.c
+++ b/tests/drivers/regulator/voltage/src/main.c
@@ -83,7 +83,7 @@ ZTEST(regulator_voltage, test_output_voltage)
 			}
 
 			for (unsigned int k = 0U; k < adc_avg_count; k++) {
-				ret = adc_read(adc_chs[i].dev, &sequence);
+				ret = adc_read_dt(&adc_chs[i], &sequence);
 				zassert_equal(ret, 0);
 
 				val_mv += buf;


### PR DESCRIPTION
This was missing from the ADC Devicetree API set.
