### PR TITLE
drivers: gpio: shell: improve usability

### DIFF
--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -149,10 +149,18 @@
 
 &gpio0 {
 	status = "okay";
+	gpio-reserved-ranges = <0 11>, <17 7>, <26 6>;
+	gpio-line-names = "", "", "", "", "", "", "", "",
+		"", "", "", "BUTTON1", "BUTTON2", "LED1", "LED2", "LED3",
+		"LED4", "", "", "", "", "", "", "",
+		"BUTTON3", "BUTTON4", "", "", "", "", "", "";
 };
 
 &gpio1 {
 	status = "okay";
+	gpio-reserved-ranges = <0 1>, <9 1>, <12 4>;
+	gpio-line-names = "", "D0", "D1", "D2", "D3", "D4", "D5", "D6",
+		"D7", "", "D8", "D9", "", "", "", "";
 };
 
 &uart0 {

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -29,6 +29,15 @@ config GPIO_SHELL_INFO_CMD
 	  This command provides a shell user extra information about gpio
 	  controller reserved pins and line names.
 
+config GPIO_SHELL_BLINK_CMD
+	bool "GPIO Shell blink command"
+	default y
+	depends on GPIO_SHELL
+	help
+	  Enable GPIO Shell blink command.
+	  This command provides a shell user the ability to 'blink' a pin
+	  at 1Hz.
+
 config GPIO_INIT_PRIORITY
 	int "GPIO init priority"
 	default KERNEL_INIT_PRIORITY_DEFAULT

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -20,6 +20,15 @@ config GPIO_SHELL
 	help
 	  Enable GPIO Shell for testing.
 
+config GPIO_SHELL_INFO_CMD
+	bool "GPIO Shell info command"
+	default y
+	depends on GPIO_SHELL
+	help
+	  Enable GPIO Shell information command.
+	  This command provides a shell user extra information about gpio
+	  controller reserved pins and line names.
+
 config GPIO_INIT_PRIORITY
 	int "GPIO init priority"
 	default KERNEL_INIT_PRIORITY_DEFAULT

--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -1,187 +1,441 @@
 /*
  * Copyright (c) 2018 Intel Corporation
  * Copyright (c) 2021 Dennis Ruffer <daruffer@gmail.com>
+ * Copyright (c) 2023 Nick Ward <nix.ward@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
- *
- * Use "device list" command for GPIO port names
  */
 
-#include <zephyr/sys/printk.h>
-#include <zephyr/shell/shell.h>
-#include <zephyr/init.h>
-#include <string.h>
-#include <stdio.h>
 #include <zephyr/drivers/gpio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <zephyr/logging/log.h>
+#include <zephyr/shell/shell.h>
 
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
+#include <stdio.h>
 
-LOG_MODULE_REGISTER(gpio_shell);
+#define ARGV_DEV 1
+#define ARGV_PIN 2
+#define ARGV_CONF 3
+#define ARGV_VALUE 3
 
-struct args_index {
-	uint8_t port;
-	uint8_t index;
-	uint8_t mode;
-	uint8_t value;
-};
+#define NGPIOS_UNKNOWN -1
+#define PIN_NOT_FOUND UINT8_MAX
 
-static const struct args_index args_indx = {
-	.port = 1,
-	.index = 2,
-	.mode = 3,
-	.value = 3,
-};
+/* Pin syntax maximum length */
+#define PIN_SYNTAX_MAX 32
+#define PIN_NUM_MAX 4
 
-static int cmd_gpio_conf(const struct shell *sh, size_t argc, char **argv)
-{
-	uint8_t index = 0U;
-	int type = GPIO_OUTPUT;
+struct gpio_ctrl {
 	const struct device *dev;
+	int8_t ngpios;
+	gpio_port_pins_t reserved_mask;
+	const char **line_names;
+	uint8_t line_names_len;
+	const union shell_cmd_entry *subcmd;
+};
 
-	if (isdigit((unsigned char)argv[args_indx.index][0]) != 0 &&
-	    isalpha((unsigned char)argv[args_indx.mode][0]) != 0) {
-		index = (uint8_t)atoi(argv[args_indx.index]);
-		if (!strcmp(argv[args_indx.mode], "in")) {
-			type = GPIO_INPUT;
-		} else if (!strcmp(argv[args_indx.mode], "inu")) {
-			type = GPIO_INPUT | GPIO_PULL_UP;
-		} else if (!strcmp(argv[args_indx.mode], "ind")) {
-			type = GPIO_INPUT | GPIO_PULL_DOWN;
-		} else if (!strcmp(argv[args_indx.mode], "out")) {
-			type = GPIO_OUTPUT;
+struct sh_gpio {
+	const struct device *dev;
+	gpio_pin_t pin;
+};
+
+/*
+ * Find idx-th pin reference from the set of non reserved
+ * pin numbers and provided line names.
+ */
+static void port_pin_get(gpio_port_pins_t reserved_mask, const char **line_names,
+			 uint8_t line_names_len, size_t idx, struct shell_static_entry *entry)
+{
+	static char pin_syntax[PIN_SYNTAX_MAX];
+	static char pin_num[PIN_NUM_MAX];
+	const char *name;
+	gpio_pin_t pin;
+	bool reserved;
+
+	entry->handler = NULL;
+
+	/* Find allowed numeric pin reference */
+	for (pin = 0; pin < GPIO_MAX_PINS_PER_PORT; pin++) {
+		reserved = ((BIT64(pin) & reserved_mask) != 0);
+		if (!reserved) {
+			if (idx == 0) {
+				break;
+			}
+			idx--;
+		}
+	}
+
+	if (pin < GPIO_MAX_PINS_PER_PORT) {
+		sprintf(pin_num, "%u", pin);
+		if ((pin < line_names_len) && (strlen(line_names[pin]) > 0)) {
+			/* pin can be specified by line name */
+			name = line_names[pin];
+			for (int i = 0; i < (sizeof(pin_syntax) - 1); i++) {
+				/*
+				 * For line-name tab completion to work replace any
+				 * space characters with '_'.
+				 */
+				pin_syntax[i] = (name[i] != ' ') ? name[i] : '_';
+				if (name[i] == '\0') {
+					break;
+				}
+			}
+			pin_syntax[sizeof(pin_syntax) - 1] = '\0';
+			entry->syntax = pin_syntax;
+			entry->help = pin_num;
 		} else {
+			/* fallback to pin specified by pin number */
+			entry->syntax = pin_num;
+			entry->help = NULL;
+		}
+	} else {
+		/* No more pins */
+		entry->syntax = NULL;
+		entry->help = NULL;
+	}
+}
+
+#define GPIO_DT_RESERVED_RANGES_NGPIOS_SHELL(node_id)                                              \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, ngpios),                                             \
+		    (GPIO_DT_RESERVED_RANGES_NGPIOS(node_id, DT_PROP(node_id, ngpios))),           \
+		    (GPIO_MAX_PINS_PER_PORT))
+
+#define GPIO_CTRL_PIN_GET_FN(node_id)                                                              \
+	static const char *node_id##line_names[] = DT_PROP_OR(node_id, gpio_line_names, {NULL});   \
+                                                                                                   \
+	static void node_id##cmd_gpio_pin_get(size_t idx, struct shell_static_entry *entry);       \
+                                                                                                   \
+	SHELL_DYNAMIC_CMD_CREATE(node_id##sub_gpio_pin, node_id##cmd_gpio_pin_get);                \
+                                                                                                   \
+	static void node_id##cmd_gpio_pin_get(size_t idx, struct shell_static_entry *entry)        \
+	{                                                                                          \
+		gpio_port_pins_t reserved_mask = GPIO_DT_RESERVED_RANGES_NGPIOS_SHELL(node_id);    \
+		uint8_t line_names_len = DT_PROP_LEN_OR(node_id, gpio_line_names, 0);              \
+                                                                                                   \
+		port_pin_get(reserved_mask, node_id##line_names, line_names_len, idx, entry);      \
+		entry->subcmd = NULL;                                                              \
+	}
+
+#define IS_GPIO_CTRL_PIN_GET(node_id)                                                              \
+	COND_CODE_1(DT_PROP(node_id, gpio_controller), (GPIO_CTRL_PIN_GET_FN(node_id)), ())
+
+DT_FOREACH_STATUS_OKAY_NODE(IS_GPIO_CTRL_PIN_GET)
+
+#define GPIO_CTRL_LIST_ENTRY(node_id)                                                              \
+	{                                                                                          \
+		.dev = DEVICE_DT_GET(node_id),                                                     \
+		.ngpios = DT_PROP_OR(node_id, ngpios, NGPIOS_UNKNOWN),                             \
+		.reserved_mask = GPIO_DT_RESERVED_RANGES_NGPIOS_SHELL(node_id),                    \
+		.line_names = node_id##line_names,                                                 \
+		.line_names_len = DT_PROP_LEN_OR(node_id, gpio_line_names, 0),                     \
+		.subcmd = &node_id##sub_gpio_pin,                                                  \
+	},
+
+#define IS_GPIO_CTRL_LIST(node_id)                                                                 \
+	COND_CODE_1(DT_PROP(node_id, gpio_controller), (GPIO_CTRL_LIST_ENTRY(node_id)), ())
+
+static const struct gpio_ctrl gpio_list[] = {DT_FOREACH_STATUS_OKAY_NODE(IS_GPIO_CTRL_LIST)};
+
+static const struct gpio_ctrl *get_gpio_ctrl(char *name)
+{
+	const struct device *dev = device_get_binding(name);
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(gpio_list); i++) {
+		if (gpio_list[i].dev == dev) {
+			return &gpio_list[i];
+		}
+	}
+	return NULL;
+}
+
+int line_cmp(const char *input, const char *line_name)
+{
+	int i = 0;
+
+	while (true) {
+		if ((input[i] == '_') && (line_name[i] == ' ')) {
+			/* Allow input underscore to match line_name space */
+		} else if (input[i] != line_name[i]) {
+			return (input[i] > line_name[i]) ? 1 : -1;
+		} else if (line_name[i] == '\0') {
 			return 0;
 		}
-	} else {
-		shell_error(sh, "Wrong parameters for conf");
-		return -ENOTSUP;
+		i++;
 	}
-
-	dev = device_get_binding(argv[args_indx.port]);
-
-	if (dev != NULL) {
-		index = (uint8_t)atoi(argv[args_indx.index]);
-		shell_print(sh, "Configuring %s pin %d",
-			    argv[args_indx.port], index);
-		gpio_pin_configure(dev, index, type);
-	}
-
-	return 0;
 }
 
-static int cmd_gpio_get(const struct shell *sh,
-			size_t argc, char **argv)
+static int get_gpio_pin(const struct shell *sh, const struct gpio_ctrl *ctrl, char *line_name)
 {
-	const struct device *dev;
-	uint8_t index = 0U;
-	int rc;
+	gpio_pin_t pin = PIN_NOT_FOUND;
+	gpio_pin_t i;
+	int result;
 
-	if (isdigit((unsigned char)argv[args_indx.index][0]) != 0) {
-		index = (uint8_t)atoi(argv[args_indx.index]);
-	} else {
-		shell_error(sh, "Wrong parameters for get");
-		return -EINVAL;
-	}
-
-	dev = device_get_binding(argv[args_indx.port]);
-
-	if (dev != NULL) {
-		index = (uint8_t)atoi(argv[2]);
-		shell_print(sh, "Reading %s pin %d",
-			    argv[args_indx.port], index);
-		rc = gpio_pin_get(dev, index);
-		if (rc >= 0) {
-			shell_print(sh, "Value %d", rc);
-		} else {
-			shell_error(sh, "Error %d reading value", rc);
-			return -EIO;
+	for (i = 0; i < ctrl->ngpios; i++) {
+		result = line_cmp(line_name, ctrl->line_names[i]);
+		if (result == 0) {
+			if ((BIT64(i) & ctrl->reserved_mask) != 0) {
+				shell_error(sh, "Reserved pin");
+				return -EACCES;
+			} else if (pin == PIN_NOT_FOUND) {
+				pin = i;
+			} else {
+				shell_error(sh, "Line name ambiguous");
+				return -EFAULT;
+			}
 		}
 	}
 
-	return 0;
+	if (pin == PIN_NOT_FOUND) {
+		shell_error(sh, "Line name not found: '%s'", line_name);
+		return -ENOENT;
+	}
+
+	return pin;
 }
 
-static int cmd_gpio_set(const struct shell *sh,
-			size_t argc, char **argv)
+static int get_sh_gpio(const struct shell *sh, char **argv, struct sh_gpio *gpio)
 {
-	const struct device *dev;
-	uint8_t index = 0U;
-	uint8_t value = 0U;
+	const struct gpio_ctrl *ctrl;
+	int ret = 0;
+	int pin;
 
-	if (isdigit((unsigned char)argv[args_indx.index][0]) != 0 &&
-	    isdigit((unsigned char)argv[args_indx.value][0]) != 0) {
-		index = (uint8_t)atoi(argv[args_indx.index]);
-		value = (uint8_t)atoi(argv[args_indx.value]);
-	} else {
-		shell_print(sh, "Wrong parameters for set");
+	ctrl = get_gpio_ctrl(argv[ARGV_DEV]);
+	if (ctrl == NULL) {
+		shell_error(sh, "unknown gpio controller: %s", argv[ARGV_DEV]);
 		return -EINVAL;
 	}
-	dev = device_get_binding(argv[args_indx.port]);
+	gpio->dev = ctrl->dev;
+	pin = shell_strtoul(argv[ARGV_PIN], 0, &ret);
+	if (ret != 0) {
+		pin = get_gpio_pin(sh, ctrl, argv[ARGV_PIN]);
+		if (pin < 0) {
+			return pin;
+		}
+	} else if ((BIT64(pin) & ctrl->reserved_mask) != 0) {
+		shell_error(sh, "Reserved pin");
+		return -EACCES;
+	}
+	gpio->pin = pin;
 
-	if (dev != NULL) {
-		index = (uint8_t)atoi(argv[2]);
-		shell_print(sh, "Writing to %s pin %d",
-			    argv[args_indx.port], index);
-		gpio_pin_set(dev, index, value);
+	return 0;
+}
+
+static int cmd_gpio_conf(const struct shell *sh, size_t argc, char **argv, void *data)
+{
+	gpio_flags_t flags = 0;
+	struct sh_gpio gpio;
+	int ret = 0;
+
+	ret = get_sh_gpio(sh, argv, &gpio);
+	if (ret != 0) {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	for (int i = 0; i < strlen(argv[ARGV_CONF]); i++) {
+		switch (argv[ARGV_CONF][i]) {
+		case 'i':
+			flags |= GPIO_INPUT;
+			break;
+		case 'o':
+			flags |= GPIO_OUTPUT;
+			break;
+		case 'u':
+			flags |= GPIO_PULL_UP;
+			break;
+		case 'd':
+			flags |= GPIO_PULL_DOWN;
+			break;
+		case 'h':
+			flags |= GPIO_ACTIVE_HIGH;
+			break;
+		case 'l':
+			flags |= GPIO_ACTIVE_LOW;
+			break;
+		case '0':
+			flags |= GPIO_OUTPUT_INIT_LOGICAL | GPIO_OUTPUT_INIT_LOW;
+			break;
+		case '1':
+			flags |= GPIO_OUTPUT_INIT_LOGICAL | GPIO_OUTPUT_INIT_HIGH;
+			break;
+		default:
+			shell_error(sh, "Unknown: '%c'", argv[ARGV_CONF][i]);
+			shell_help(sh);
+			return SHELL_CMD_HELP_PRINTED;
+		}
+	}
+
+	if (((flags & GPIO_INPUT) != 0) == ((flags & GPIO_OUTPUT) != 0)) {
+		shell_error(sh, "must be either input or output");
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	if (((flags & GPIO_PULL_UP) != 0) && ((flags & GPIO_PULL_DOWN) != 0)) {
+		shell_error(sh, "cannot be pull up and pull down");
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	if (((flags & GPIO_ACTIVE_LOW) != 0) && ((flags & GPIO_ACTIVE_HIGH) != 0)) {
+		shell_error(sh, "cannot be active low and active high");
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	if ((flags & GPIO_OUTPUT) != 0) {
+		/* Default to active high if not specified */
+		if ((flags & (GPIO_ACTIVE_LOW | GPIO_ACTIVE_HIGH)) == 0) {
+			flags |= GPIO_ACTIVE_HIGH;
+		}
+		/* Default to initialisation to logic 0 if not specified */
+		if ((flags & GPIO_OUTPUT_INIT_LOGICAL) == 0) {
+			flags |= GPIO_OUTPUT_INIT_LOGICAL | GPIO_OUTPUT_INIT_LOW;
+		}
+	}
+
+	if (((flags & GPIO_INPUT) != 0) && ((flags & GPIO_OUTPUT_INIT_LOGICAL) != 0)) {
+		shell_error(sh, "an input cannot be initialised to a logic level");
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	if (((flags & GPIO_OUTPUT_INIT_LOW) != 0) && ((flags & GPIO_OUTPUT_INIT_HIGH) != 0)) {
+		shell_error(sh, "cannot initialise to logic 0 and logic 1");
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	ret = gpio_pin_configure(gpio.dev, gpio.pin, flags);
+	if (ret != 0) {
+		shell_error(sh, "error: %d", ret);
+		return ret;
 	}
 
 	return 0;
 }
 
+static int cmd_gpio_get(const struct shell *sh, size_t argc, char **argv)
+{
+	struct sh_gpio gpio;
+	int value;
+	int ret;
+
+	ret = get_sh_gpio(sh, argv, &gpio);
+	if (ret != 0) {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	value = gpio_pin_get(gpio.dev, gpio.pin);
+	if (value >= 0) {
+		shell_print(sh, "%u", value);
+	} else {
+		shell_error(sh, "error: %d", value);
+		return value;
+	}
+
+	return 0;
+}
+
+static int cmd_gpio_set(const struct shell *sh, size_t argc, char **argv)
+{
+	struct sh_gpio gpio;
+	unsigned long value;
+	int ret = 0;
+
+	ret = get_sh_gpio(sh, argv, &gpio);
+	if (ret != 0) {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	value = shell_strtoul(argv[ARGV_VALUE], 0, &ret);
+	if (ret != 0) {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	ret = gpio_pin_set(gpio.dev, gpio.pin, value != 0);
+	if (ret != 0) {
+		shell_error(sh, "error: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
 
 /* 500 msec = 1/2 sec */
 #define SLEEP_TIME_MS   500
 
-static int cmd_gpio_blink(const struct shell *sh,
-			  size_t argc, char **argv)
+static int cmd_gpio_blink(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev;
-	uint8_t index = 0U;
-	uint8_t value = 0U;
+	struct sh_gpio gpio;
 	size_t count = 0;
+	int value = 0;
 	char data;
+	int ret;
 
-	if (isdigit((unsigned char)argv[args_indx.index][0]) != 0) {
-		index = (uint8_t)atoi(argv[args_indx.index]);
-	} else {
-		shell_error(sh, "Wrong parameters for blink");
-		return -EINVAL;
+	ret = get_sh_gpio(sh, argv, &gpio);
+	if (ret != 0) {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
 	}
-	dev = device_get_binding(argv[args_indx.port]);
 
-	if (dev != NULL) {
-		index = (uint8_t)atoi(argv[2]);
-		shell_fprintf(sh, SHELL_NORMAL, "Blinking port %s index %d.", argv[1], index);
-		shell_fprintf(sh, SHELL_NORMAL, " Hit any key to exit");
+	shell_fprintf(sh, SHELL_NORMAL, "Blinking port %s pin %u.", argv[ARGV_DEV], gpio.pin);
+	shell_fprintf(sh, SHELL_NORMAL, " Hit any key to exit");
 
-		/* dummy read to clear any pending input */
+	/* dummy read to clear any pending input */
+	(void)sh->iface->api->read(sh->iface, &data, sizeof(data), &count);
+
+	while (true) {
 		(void)sh->iface->api->read(sh->iface, &data, sizeof(data), &count);
-
-		while (true) {
-			(void)sh->iface->api->read(sh->iface, &data, sizeof(data), &count);
-			if (count != 0) {
-				break;
-			}
-			gpio_pin_set(dev, index, value);
-			value = !value;
-			k_msleep(SLEEP_TIME_MS);
+		if (count != 0) {
+			break;
 		}
-
-		shell_fprintf(sh, SHELL_NORMAL, "\n");
+		gpio_pin_set(gpio.dev, gpio.pin, value);
+		value = !value;
+		k_msleep(SLEEP_TIME_MS);
 	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
 
 	return 0;
 }
 
+static void device_name_get(size_t idx, struct shell_static_entry *entry)
+{
+	if (idx >= ARRAY_SIZE(gpio_list)) {
+		entry->syntax = NULL;
+		return;
+	}
+
+	entry->syntax = gpio_list[idx].dev->name;
+	entry->handler = NULL;
+	entry->help = "Device";
+	entry->subcmd = gpio_list[idx].subcmd;
+}
+
+SHELL_DYNAMIC_CMD_CREATE(sub_gpio_dev, device_name_get);
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_gpio,
-			       SHELL_CMD_ARG(conf, NULL, "Configure GPIO", cmd_gpio_conf, 4, 0),
-			       SHELL_CMD_ARG(get, NULL, "Get GPIO value", cmd_gpio_get, 3, 0),
-			       SHELL_CMD_ARG(set, NULL, "Set GPIO", cmd_gpio_set, 4, 0),
-			       SHELL_CMD_ARG(blink, NULL, "Blink GPIO", cmd_gpio_blink, 3, 0),
-			       SHELL_SUBCMD_SET_END /* Array terminated. */
-			       );
+	SHELL_CMD_ARG(conf, &sub_gpio_dev,
+		"Configure GPIO pin\n"
+		"Usage: gpio conf <device> <pin> <configuration <i|o>[u|d][h|l][0|1]>\n"
+		"<i|o> - input|output\n"
+		"[u|d] - pull up|pull down, otherwise open\n"
+		"[h|l] - active high|active low, otherwise defaults to active high\n"
+		"[0|1] - initialise to logic 0|logic 1, otherwise defaults to logic 0",
+		cmd_gpio_conf, 4, 0),
+	SHELL_CMD_ARG(get, &sub_gpio_dev,
+		"Get GPIO pin value\n"
+		"Usage: gpio get <device> <pin>", cmd_gpio_get, 3, 0),
+	SHELL_CMD_ARG(set, &sub_gpio_dev,
+		"Set GPIO pin value\n"
+		"Usage: gpio set <device> <pin> <level 0|1>", cmd_gpio_set, 4, 0),
+	SHELL_CMD_ARG(blink, &sub_gpio_dev,
+		"Blink GPIO pin\n"
+		"Usage: gpio blink <device> <pin>", cmd_gpio_blink, 3, 0),
+	SHELL_SUBCMD_SET_END /* Array terminated. */
+);
 
 SHELL_CMD_REGISTER(gpio, &sub_gpio, "GPIO commands", NULL);

--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -574,7 +574,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_gpio,
 	SHELL_CMD_ARG(set, &sub_gpio_dev,
 		"Set GPIO pin value\n"
 		"Usage: gpio set <device> <pin> <level 0|1>", cmd_gpio_set, 4, 0),
-	SHELL_CMD_ARG(blink, &sub_gpio_dev,
+	SHELL_COND_CMD_ARG(CONFIG_GPIO_SHELL_BLINK_CMD, blink, &sub_gpio_dev,
 		"Blink GPIO pin\n"
 		"Usage: gpio blink <device> <pin>", cmd_gpio_blink, 3, 0),
 	SHELL_COND_CMD_ARG(CONFIG_GPIO_SHELL_INFO_CMD, info, &sub_gpio_dev,


### PR DESCRIPTION
This commit implements this enhancement:
https://github.com/zephyrproject-rtos/zephyr/issues/63018

Also adds a 'info' command for ngpios, reversed pin and line
name information.

The forms of the gpio commands are now:

        gpio conf device pin ol0
        gpio set device pin 1
        gpio get device pin
        gpio blink device pin
        gpio info device

Device name, pin, configuration and set level sub commands now
are suggested/completed when tab is used.

Pin names are suggested with numbers and if available from the Devicetree
gpio line names.

GPIO pin control is now limited to pins that are not assigned as reserved.

Fixes #63018