### PR TITLE
drivers: ieee802154: rf2xx: Fix rf231 invalid frame

### DIFF
--- a/drivers/ieee802154/ieee802154_rf2xx_regs.h
+++ b/drivers/ieee802154/ieee802154_rf2xx_regs.h
@@ -131,6 +131,7 @@
 #define RF2XX_RX_CRC_VALID                  7
 #define RF2XX_RND_VALUE                     5
 #define RF2XX_RSSI                          0
+#define RF2XX_RSSI_MASK                     0x1F
 
 /* PHY_CC_CCA */
 #define RF2XX_CCA_REQUEST                   7


### PR DESCRIPTION
The at86rf231 frame buffer access mode read differs from all other transceivers by only transfer one more byte after PSDU data instead three. This difference is not evaluated in the current version of the driver. The current change add the necessary check and read the missing data (EQ, TRAC).