### PR TITLE
net: socket: Allow same port if different address family

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -132,7 +132,8 @@ static int check_used_port(enum net_ip_protocol proto,
 
 		if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		    local_addr->sa_family == AF_INET6) {
-			if (net_sin6_ptr(&contexts[i].local)->sin6_addr == NULL) {
+			if (net_sin6_ptr(&contexts[i].local)->sin6_addr == NULL ||
+			    net_sin6_ptr(&contexts[i].local)->sin6_family != AF_INET6) {
 				continue;
 			}
 
@@ -187,7 +188,8 @@ static int check_used_port(enum net_ip_protocol proto,
 			}
 		} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 			   local_addr->sa_family == AF_INET) {
-			if (net_sin_ptr(&contexts[i].local)->sin_addr == NULL) {
+			if (net_sin_ptr(&contexts[i].local)->sin_addr == NULL ||
+			    net_sin_ptr(&contexts[i].local)->sin_family != AF_INET) {
 				continue;
 			}
 


### PR DESCRIPTION
It is always possible to bind to same port if the sockets are in different address family.