### PR TITLE
Enable I2C/SPI/MSPI peripherals on apollo4p_blue_kxr_evb

### DIFF
--- a/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
+++ b/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
@@ -16,4 +16,60 @@
 			input-enable;
 		};
 	};
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <M0SCL_P5>, <M0SDAWIR3_P6>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c1_default: i2c1_default {
+		group1 {
+			pinmux = <M1SCL_P8>, <M1SDAWIR3_P9>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c2_default: i2c2_default {
+		group1 {
+			pinmux = <M2SCL_P25>, <M2SDAWIR3_P26>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c3_default: i2c3_default {
+		group1 {
+			pinmux = <M3SCL_P31>, <M3SDAWIR3_P32>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c5_default: i2c5_default {
+		group1 {
+			pinmux = <M5SCL_P47>, <M5SDAWIR3_P48>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c6_default: i2c6_default {
+		group1 {
+			pinmux = <M6SCL_P61>, <M6SDAWIR3_P62>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+	i2c7_default: i2c7_default {
+		group1 {
+			pinmux = <M7SCL_P22>, <M7SDAWIR3_P23>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
 };

--- a/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
+++ b/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
@@ -72,4 +72,85 @@
 			bias-pull-up;
 		};
 	};
+
+	spi0_default: spi0_default {
+		group1 {
+			pinmux = <M0SCK_P5>, <M0MISO_P7>, <M0MOSI_P6>;
+		};
+		group2 {
+			pinmux = <NCE72_P72>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <0>;
+		};
+	};
+	spi1_default: spi1_default {
+		group1 {
+			pinmux = <M1SCK_P8>, <M1MISO_P10>, <M1MOSI_P9>;
+		};
+		group2 {
+			pinmux = <NCE11_P11>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <4>;
+		};
+	};
+	spi2_default: spi2_default {
+		group1 {
+			pinmux = <M2SCK_P25>, <M2MISO_P27>, <M2MOSI_P26>;
+		};
+		group2 {
+			pinmux = <NCE37_P37>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <8>;
+		};
+	};
+	spi3_default: spi3_default {
+		group1 {
+			pinmux = <M3SCK_P31>, <M3MISO_P33>, <M3MOSI_P32>;
+		};
+		group2 {
+			pinmux = <NCE85_P85>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <12>;
+		};
+	};
+	spi4_default: spi4_default {
+		group1 {
+			pinmux = <M4SCK_P34>, <M4MISO_P36>, <M4MOSI_P35>;
+		};
+		group2 {
+			pinmux = <NCE54_P54>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <16>;
+		};
+	};
+	spi5_default: spi5_default {
+		group1 {
+			pinmux = <M5SCK_P47>, <M5MISO_P49>, <M5MOSI_P48>;
+		};
+		group2 {
+			pinmux = <NCE60_P60>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <20>;
+		};
+	};
+	spi6_default: spi6_default {
+		group1 {
+			pinmux = <M6SCK_P61>, <M6MISO_P63>, <M6MOSI_P62>;
+		};
+		group2 {
+			pinmux = <NCE30_P30>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <24>;
+		};
+	};
+	spi7_default: spi7_default {
+		group1 {
+			pinmux = <M7SCK_P22>, <M7MISO_P24>, <M7MOSI_P23>;
+		};
+		group2 {
+			pinmux = <NCE88_P88>;
+			drive-push-pull;
+			ambiq,iom-nce-module = <28>;
+		};
+	};
 };

--- a/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
+++ b/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
@@ -153,4 +153,43 @@
 			ambiq,iom-nce-module = <28>;
 		};
 	};
+	mspi0_default: mspi0_default{
+		group1 {
+			pinmux = <MSPI0_0_P64>,
+				 <MSPI0_1_P65>,
+				 <MSPI0_8_P72>;
+		};
+		group2 {
+			pinmux = <NCE57_P57>;
+			drive-push-pull;
+			drive-strength = "0.5";
+			ambiq,iom-nce-module = <32>;
+		};
+	};
+	mspi1_default: mspi1_default{
+		group1 {
+			pinmux = <MSPI1_0_P37>,
+				 <MSPI1_1_P38>,
+				 <MSPI1_8_P45>;
+		};
+		group2 {
+			pinmux = <NCE56_P56>;
+			drive-push-pull;
+			drive-strength = "0.5";
+			ambiq,iom-nce-module = <34>;
+		};
+	};
+	mspi2_default: mspi2_default{
+		group1 {
+			pinmux = <MSPI2_0_P74>,
+				 <MSPI2_1_P75>,
+				 <MSPI2_8_P82>;
+		};
+		group2 {
+			pinmux = <NCE52_P52>;
+			drive-push-pull;
+			drive-strength = "0.5";
+			ambiq,iom-nce-module = <36>;
+		};
+	};
 };

--- a/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
+++ b/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
@@ -42,3 +42,11 @@
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	status = "okay";
 };
+
+&iom1 {
+	compatible = "ambiq,spi";
+	pinctrl-0 = <&spi1_default>;
+	pinctrl-names = "default";
+	clock-frequency = <1000000>;
+	status = "okay";
+};

--- a/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
+++ b/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
@@ -50,3 +50,9 @@
 	clock-frequency = <1000000>;
 	status = "okay";
 };
+
+&mspi0 {
+	pinctrl-0 = <&mspi0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
+++ b/boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts
@@ -34,3 +34,11 @@
 &wdt0 {
 	status = "okay";
 };
+
+&iom0 {
+	compatible = "ambiq,i2c";
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
+};

--- a/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
@@ -174,6 +174,36 @@
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
 		};
 
+		mspi0: spi@40060000 {
+			compatible = "ambiq,mspi";
+			reg = <0x40060000 0x400>;
+			interrupts = <20 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x4000>;
+		};
+
+		mspi1: spi@40061000 {
+			compatible = "ambiq,mspi";
+			reg = <0x40061000 0x400>;
+			interrupts = <21 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x8000>;
+		};
+
+		mspi2: spi@40062000 {
+			compatible = "ambiq,mspi";
+			reg = <0x40062000 0x400>;
+			interrupts = <22 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x10000>;
+		};
+
 		pinctrl: pin-controller@40010000 {
 			compatible = "ambiq,apollo4-pinctrl";
 			reg = <0x40010000 0x800>;

--- a/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
@@ -2,6 +2,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <mem.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	clocks {
@@ -99,6 +100,78 @@
 			status = "disabled";
 			clocks = <&uartclk>;
 			ambiq,pwrcfg = <&pwrcfg 0x4 0x1000>;
+		};
+
+		iom0: iom@40050000 {
+			reg = <0x40050000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <6 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x2>;
+		};
+
+		iom1: iom@40051000 {
+			reg = <0x40051000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <7 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x4>;
+		};
+
+		iom2: iom@40052000 {
+			reg = <0x40052000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <8 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x8>;
+		};
+
+		iom3: iom@40053000 {
+			reg = <0x40053000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <9 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x10>;
+		};
+
+		iom4: iom@40054000 {
+			reg = <0x40054000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <10 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x20>;
+		};
+
+		iom5: iom@40055000 {
+			reg = <0x40055000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <11 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x40>;
+		};
+
+		iom6: iom@40056000 {
+			reg = <0x40056000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <12 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x80>;
+		};
+
+		iom7: iom@40057000 {
+			reg = <0x40057000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <13 0>;
+			status = "disabled";
+			ambiq,pwrcfg = <&pwrcfg 0x4 0x100>;
 		};
 
 		pinctrl: pin-controller@40010000 {


### PR DESCRIPTION
This PR basically enables the I2C/SPI/MSPI peripherals on the Ambiq apollo4p_blue_kxr_evb.
The supported I2C/SPI/MSPI drivers have been implemented and merged to the mainline.

Changed files:
--dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
--boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb-pinctrl.dtsi
--boards/arm/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.dts