### PR TITLE
dmic: add the correct gain values to the dmic registers

### DIFF
--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -527,11 +527,20 @@ static void dai_dmic_gain_ramp(struct dai_intel_dmic *dmic)
 					     FIR_CONTROL_MUTE, 0);
 		}
 
-		val = FIELD_PREP(OUT_GAIN, gval);
-		dai_dmic_write(dmic, dmic_base[i] + FIR_CHANNEL_REGS_SIZE *
-			       dmic->dai_config_params.dai_index + OUT_GAIN_LEFT, val);
-		dai_dmic_write(dmic, dmic_base[i] + FIR_CHANNEL_REGS_SIZE *
-			       dmic->dai_config_params.dai_index + OUT_GAIN_RIGHT, val);
+		if (gval != 0) {
+			val = FIELD_PREP(OUT_GAIN, gval);
+			dai_dmic_write(dmic, dmic_base[i] + FIR_CHANNEL_REGS_SIZE *
+				       dmic->dai_config_params.dai_index + OUT_GAIN_LEFT, val);
+			dai_dmic_write(dmic, dmic_base[i] + FIR_CHANNEL_REGS_SIZE *
+				       dmic->dai_config_params.dai_index + OUT_GAIN_RIGHT, val);
+		} else {
+			dai_dmic_write(dmic, dmic_base[i] + FIR_CHANNEL_REGS_SIZE *
+				       dmic->dai_config_params.dai_index + OUT_GAIN_LEFT,
+				       dmic->gain_left);
+			dai_dmic_write(dmic, dmic_base[i] + FIR_CHANNEL_REGS_SIZE *
+				       dmic->dai_config_params.dai_index + OUT_GAIN_RIGHT,
+				       dmic->gain_right);
+		}
 	}
 
 	k_spin_unlock(&dmic->lock, key);

--- a/drivers/dai/intel/dmic/dmic.h
+++ b/drivers/dai/intel/dmic/dmic.h
@@ -179,6 +179,8 @@ struct dai_intel_dmic {
 #endif
 	int irq;
 	uint32_t flags;
+	uint32_t gain_left;
+	uint32_t gain_right;
 };
 
 static inline int32_t sat_int32(int64_t x)

--- a/drivers/dai/intel/dmic/dmic_nhlt.c
+++ b/drivers/dai/intel/dmic/dmic_nhlt.c
@@ -621,6 +621,9 @@ static void configure_fir(struct dai_intel_dmic *dmic, const uint32_t base,
 	dai_dmic_write(dmic, base + DC_OFFSET_RIGHT, fir_cfg->dc_offset_right);
 	dai_dmic_write(dmic, base + OUT_GAIN_LEFT, fir_cfg->out_gain_left);
 	dai_dmic_write(dmic, base + OUT_GAIN_RIGHT, fir_cfg->out_gain_right);
+
+	dmic->gain_left = fir_cfg->out_gain_left;
+	dmic->gain_right = fir_cfg->out_gain_right;
 }
 
 int dai_dmic_set_config_nhlt(struct dai_intel_dmic *dmic, const void *bespoke_cfg)


### PR DESCRIPTION
Zephyr increments the gain until it reaches the maximum value and then sets the registers to zero which is incorrect. The values set in the DMIC config should be restored.