### PR TITLE
manifest: hal_nordic: update to prevent USBD bad DMA

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 03807f75485c97bd7b9094e0c20e40f8044da9f5
+      revision: 092eb78ed1b1551d8f480019b9c05d7371784578
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
The bad DMA request was observed as SPU FLASHACCERR when building for nrf5340dk_nrf5340_cpuapp_ns target. The bad DMA request would manifest itself as device failing to reconnect after USB cable was reconnected. The issue was especially visible with CDC ACM sample because SET LINE CODING request has 7 bytes payload.