### PR TITLE
manifest: update loramac-node to v4.7.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -267,7 +267,7 @@ manifest:
         - fs
       revision: ca583fd297ceb48bced3c2548600dc615d67af24
     - name: loramac-node
-      revision: 466089c8726397e3fb68ee611d82712f6e14aa55
+      revision: 842413c5fb98707eb5f26e619e8e792453877897
       path: modules/lib/loramac-node
     - name: lvgl
       revision: 8a6a2d1d29d17d1e4bdc94c243c146a39d635fdd


### PR DESCRIPTION
Update loramac-node to release v4.7.0 from v4.6.0. The `v4.7.0-zephyr` branch contains the same 4 additional commits as `v4.6.0-zephyr`.

Fixes #60373