### PR TITLE
drivers: can: calculate a default SJW value if none is specified

### DIFF
--- a/boards/arm/mr_canhubk3/mr_canhubk3.dts
+++ b/boards/arm/mr_canhubk3/mr_canhubk3.dts
@@ -271,10 +271,8 @@
 	phys = <&can_phy0>;
 	bus-speed = <125000>;
 	sample-point = <875>;
-	sjw = <1>;
 	bus-speed-data = <1000000>;
 	sample-point-data = <875>;
-	sjw-data = <1>;
 	status = "okay";
 };
 
@@ -284,10 +282,8 @@
 	phys = <&can_phy1>;
 	bus-speed = <125000>;
 	sample-point = <875>;
-	sjw = <1>;
 	bus-speed-data = <1000000>;
 	sample-point-data = <875>;
-	sjw-data = <1>;
 };
 
 &flexcan2 {
@@ -296,10 +292,8 @@
 	phys = <&can_phy2>;
 	bus-speed = <125000>;
 	sample-point = <875>;
-	sjw = <1>;
 	bus-speed-data = <1000000>;
 	sample-point-data = <875>;
-	sjw-data = <1>;
 };
 
 &flexcan3 {
@@ -308,10 +302,8 @@
 	phys = <&can_phy3>;
 	bus-speed = <125000>;
 	sample-point = <875>;
-	sjw = <1>;
 	bus-speed-data = <1000000>;
 	sample-point-data = <875>;
-	sjw-data = <1>;
 };
 
 &flexcan4 {
@@ -320,10 +312,8 @@
 	phys = <&can_phy4>;
 	bus-speed = <125000>;
 	sample-point = <875>;
-	sjw = <1>;
 	bus-speed-data = <1000000>;
 	sample-point-data = <875>;
-	sjw-data = <1>;
 };
 
 &flexcan5 {
@@ -332,10 +322,8 @@
 	phys = <&can_phy5>;
 	bus-speed = <125000>;
 	sample-point = <875>;
-	sjw = <1>;
 	bus-speed-data = <1000000>;
 	sample-point-data = <875>;
-	sjw-data = <1>;
 };
 
 &lpi2c0 {

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
@@ -53,10 +53,8 @@
 	pinctrl-names = "default";
 	bus-speed = <125000>;
 	sample-point = <875>;
-	sjw = <1>;
 	bus-speed-data = <1000000>;
 	sample-point-data = <875>;
-	sjw-data = <1>;
 	status = "okay";
 };
 
@@ -65,8 +63,6 @@
 	pinctrl-names = "default";
 	bus-speed = <125000>;
 	sample-point = <875>;
-	sjw = <1>;
 	bus-speed-data = <1000000>;
 	sample-point-data = <875>;
-	sjw-data = <1>;
 };

--- a/boards/posix/native_posix/native_posix.dts
+++ b/boards/posix/native_posix/native_posix.dts
@@ -189,7 +189,6 @@
 	can_loopback0: can_loopback0 {
 		status = "okay";
 		compatible = "zephyr,can-loopback";
-		sjw = <1>;
 		sample-point = <875>;
 		bus-speed = <125000>;
 	};
@@ -201,7 +200,6 @@
 		 * name, e.g.: sudo ip link property add dev vcan0 altname zcan0
 		 */
 		host-interface = "zcan0";
-		sjw = <1>;
 		sample-point = <875>;
 		bus-speed = <125000>;
 	};

--- a/boards/shields/mcp2515/adafruit_can_picowbell.overlay
+++ b/boards/shields/mcp2515/adafruit_can_picowbell.overlay
@@ -16,7 +16,6 @@
 		reg = <0x0>;
 		osc-freq = <16000000>;
 		bus-speed = <125000>;
-		sjw = <1>;
 		sample-point = <875>;
 
 		can-transceiver {

--- a/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
+++ b/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
@@ -16,7 +16,6 @@
 		reg = <0x0>;
 		osc-freq = <16000000>;
 		bus-speed = <125000>;
-		sjw = <1>;
 		sample-point = <875>;
 
 		can-transceiver {

--- a/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
+++ b/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
@@ -16,7 +16,6 @@
 		reg = <0x0>;
 		osc-freq = <16000000>;
 		bus-speed = <125000>;
-		sjw = <1>;
 		sample-point = <875>;
 
 		can-transceiver {

--- a/boards/shields/tcan4550evm/tcan4550evm.overlay
+++ b/boards/shields/tcan4550evm/tcan4550evm.overlay
@@ -28,8 +28,6 @@
 		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_HIGH>; /* D8 */
 		int-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; /* D9 */
 		bosch,mram-cfg = <0x0 15 15 7 7 0 10 10>;
-		sjw = <1>;
-		sjw-data = <1>;
 		sample-point = <875>;
 		sample-point-data = <875>;
 		bus-speed = <125000>;

--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -59,7 +59,6 @@
 			device-id = <0x8406>;
 			interrupts = <11 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			sjw = <1>;
 			bus-speed = <125000>;
 			sample-point = <875>;
 

--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -108,6 +108,16 @@ Required changes
     to a smaller, but inexact conversion algorithm. This requires building
     Picolibc as a module.
 
+* The CAN controller timing API functions :c:func:`can_set_timing` and :c:func:`can_set_timing_data`
+  no longer fallback to the (Re-)Synchronization Jump Width (SJW) value set in the devicetree
+  properties for the given CAN controller upon encountering an SJW value corresponding to
+  ``CAN_SJW_NO_CHANGE`` (which is no longer available). The caller will therefore need to fill in
+  the ``sjw`` field in :c:struct:`can_timing`. To aid in this, the :c:func:`can_calc_timing` and
+  :c:func:`can_calc_timing_data` functions now automatically calculate a suitable SJW. The
+  calculated SJW can be overwritten by the caller if needed. The CAN controller API functions
+  :c:func:`can_set_bitrate` and :c:func:`can_set_bitrate_data` now also automatically calculate a
+  suitable SJW, but their SJW cannot be overwritten by the caller.
+
 Recommended Changes
 *******************
 
@@ -151,3 +161,15 @@ Recommended Changes
   will be removed in future releases. Note that these changes do not apply to
   initialization levels used in the context of the ``init.h`` API,
   e.g. :c:macro:`SYS_INIT`.
+
+* The following CAN controller devicetree properties are now deprecated in favor specifying the
+  initial CAN bitrate using the ``bus-speed``, ``sample-point``, ``bus-speed-data``, and
+  ``sample-point-data`` properties:
+  * ``sjw``
+  * ``prop-seg``
+  * ``phase-seg1``
+  * ``phase-seg1``
+  * ``sjw-data``
+  * ``prop-seg-data``
+  * ``phase-seg1-data``
+  * ``phase-seg1-data``

--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -118,10 +118,8 @@ static int can_esp32_twai_set_timing(const struct device *dev, const struct can_
 	struct can_sja1000_data *data = dev->data;
 	uint8_t btr0;
 	uint8_t btr1;
-	uint8_t sjw;
 
-	__ASSERT_NO_MSG(timing->sjw == CAN_SJW_NO_CHANGE ||
-			(timing->sjw >= 0x1 && timing->sjw <= 0x4));
+	__ASSERT_NO_MSG(timing->sjw >= 0x1 && timing->sjw <= 0x4);
 	__ASSERT_NO_MSG(timing->prop_seg == 0);
 	__ASSERT_NO_MSG(timing->phase_seg1 >= 0x1 && timing->phase_seg1 <= 0x10);
 	__ASSERT_NO_MSG(timing->phase_seg2 >= 0x1 && timing->phase_seg2 <= 0x8);
@@ -133,15 +131,8 @@ static int can_esp32_twai_set_timing(const struct device *dev, const struct can_
 
 	k_mutex_lock(&data->mod_lock, K_FOREVER);
 
-	if (timing->sjw == CAN_SJW_NO_CHANGE) {
-		sjw = data->sjw;
-	} else {
-		sjw = timing->sjw;
-		data->sjw = timing->sjw;
-	}
-
 	btr0 = TWAI_BAUD_PRESC_PREP(timing->prescaler - 1) |
-	       TWAI_SYNC_JUMP_WIDTH_PREP(sjw - 1);
+	       TWAI_SYNC_JUMP_WIDTH_PREP(timing->sjw - 1);
 	btr1 = TWAI_TIME_SEG1_PREP(timing->phase_seg1 - 1) |
 	       TWAI_TIME_SEG2_PREP(timing->phase_seg2 - 1);
 

--- a/drivers/can/can_mcp2515.h
+++ b/drivers/can/can_mcp2515.h
@@ -46,7 +46,6 @@ struct mcp2515_data {
 	enum can_state old_state;
 	uint8_t mcp2515_mode;
 	bool started;
-	uint8_t sjw;
 };
 
 struct mcp2515_config {

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -182,7 +182,6 @@ static int mcux_flexcan_set_timing(const struct device *dev,
 				   const struct can_timing *timing)
 {
 	struct mcux_flexcan_data *data = dev->data;
-	uint8_t sjw_backup = data->timing.sjw;
 
 	if (!timing) {
 		return -EINVAL;
@@ -193,9 +192,6 @@ static int mcux_flexcan_set_timing(const struct device *dev,
 	}
 
 	data->timing = *timing;
-	if (timing->sjw == CAN_SJW_NO_CHANGE) {
-		data->timing.sjw = sjw_backup;
-	}
 
 	return 0;
 }
@@ -205,7 +201,6 @@ static int mcux_flexcan_set_timing_data(const struct device *dev,
 					const struct can_timing *timing_data)
 {
 	struct mcux_flexcan_data *data = dev->data;
-	uint8_t sjw_backup = data->timing_data.sjw;
 
 	if (!timing_data) {
 		return -EINVAL;
@@ -216,9 +211,6 @@ static int mcux_flexcan_set_timing_data(const struct device *dev,
 	}
 
 	data->timing_data = *timing_data;
-	if (timing_data->sjw == CAN_SJW_NO_CHANGE) {
-		data->timing_data.sjw = sjw_backup;
-	}
 
 	return 0;
 }
@@ -1203,6 +1195,7 @@ static int mcux_flexcan_init(const struct device *dev)
 			data->timing.phase_seg2);
 		LOG_DBG("Sample-point err : %d", err);
 	} else {
+		data->timing.sjw = config->sjw;
 		data->timing.prop_seg = config->prop_seg;
 		data->timing.phase_seg1 = config->phase_seg1;
 		data->timing.phase_seg2 = config->phase_seg2;
@@ -1227,6 +1220,7 @@ static int mcux_flexcan_init(const struct device *dev)
 				data->timing_data.phase_seg2);
 			LOG_DBG("Sample-point err : %d", err);
 		} else {
+			data->timing_data.sjw = config->sjw_data;
 			data->timing_data.prop_seg = config->prop_seg_data;
 			data->timing_data.phase_seg1 = config->phase_seg1_data;
 			data->timing_data.phase_seg2 = config->phase_seg2_data;

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -987,7 +987,7 @@ static int can_rcar_init(const struct device *dev)
 {
 	const struct can_rcar_cfg *config = dev->config;
 	struct can_rcar_data *data = dev->data;
-	struct can_timing timing;
+	struct can_timing timing = { 0 };
 	int ret;
 	uint16_t ctlr;
 
@@ -1053,7 +1053,6 @@ static int can_rcar_init(const struct device *dev)
 		return ret;
 	}
 
-	timing.sjw = config->sjw;
 	if (config->sample_point) {
 		ret = can_calc_timing(dev, &timing, config->bus_speed,
 				      config->sample_point);
@@ -1065,6 +1064,7 @@ static int can_rcar_init(const struct device *dev)
 			timing.prescaler, timing.phase_seg1, timing.phase_seg2);
 		LOG_DBG("Sample-point err : %d", ret);
 	} else {
+		timing.sjw = config->sjw;
 		timing.prop_seg = config->prop_seg;
 		timing.phase_seg1 = config->phase_seg1;
 		timing.phase_seg2 = config->phase_seg2;
@@ -1074,7 +1074,7 @@ static int can_rcar_init(const struct device *dev)
 		}
 	}
 
-	ret = can_rcar_set_timing(dev, &timing);
+	ret = can_set_timing(dev, &timing);
 	if (ret) {
 		return ret;
 	}

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -368,7 +368,7 @@ static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 static int cmd_can_bitrate_set(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev = device_get_binding(argv[1]);
-	struct can_timing timing;
+	struct can_timing timing = { 0 };
 	uint16_t sample_pnt;
 	uint32_t bitrate;
 	char *endptr;
@@ -392,16 +392,6 @@ static int cmd_can_bitrate_set(const struct shell *sh, size_t argc, char **argv)
 			return -EINVAL;
 		}
 
-		if (argc >= 5) {
-			timing.sjw = (uint16_t)strtoul(argv[4], &endptr, 10);
-			if (*endptr != '\0') {
-				shell_error(sh, "failed to parse SJW");
-				return -EINVAL;
-			}
-		} else {
-			timing.sjw = CAN_SJW_NO_CHANGE;
-		}
-
 		err = can_calc_timing(dev, &timing, bitrate, sample_pnt);
 		if (err < 0) {
 			shell_error(sh, "failed to calculate timing for "
@@ -410,16 +400,19 @@ static int cmd_can_bitrate_set(const struct shell *sh, size_t argc, char **argv)
 			return err;
 		}
 
-		if (timing.sjw == CAN_SJW_NO_CHANGE) {
-			shell_print(sh, "setting bitrate to %d bps, sample point %d.%d%% "
-				    "(+/- %d.%d%%)",
-				    bitrate, sample_pnt / 10, sample_pnt % 10, err / 10, err % 10);
-		} else {
-			shell_print(sh, "setting bitrate to %d bps, sample point %d.%d%% "
-				    "(+/- %d.%d%%), sjw %d",
-				    bitrate, sample_pnt / 10, sample_pnt % 10, err / 10, err % 10,
-				    timing.sjw);
+		if (argc >= 5) {
+			/* Overwrite calculated default SJW with user-provided value */
+			timing.sjw = (uint16_t)strtoul(argv[4], &endptr, 10);
+			if (*endptr != '\0') {
+				shell_error(sh, "failed to parse SJW");
+				return -EINVAL;
+			}
 		}
+
+		shell_print(sh, "setting bitrate to %d bps, sample point %d.%d%% "
+			    "(+/- %d.%d%%), sjw %d",
+			    bitrate, sample_pnt / 10, sample_pnt % 10, err / 10, err % 10,
+			    timing.sjw);
 
 		LOG_DBG("sjw %u, prop_seg %u, phase_seg1 %u, phase_seg2 %u, prescaler %u",
 			timing.sjw, timing.prop_seg, timing.phase_seg1, timing.phase_seg2,
@@ -446,7 +439,7 @@ static int cmd_can_bitrate_set(const struct shell *sh, size_t argc, char **argv)
 static int cmd_can_dbitrate_set(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev = device_get_binding(argv[1]);
-	struct can_timing timing;
+	struct can_timing timing = { 0 };
 	uint16_t sample_pnt;
 	uint32_t bitrate;
 	char *endptr;
@@ -470,16 +463,6 @@ static int cmd_can_dbitrate_set(const struct shell *sh, size_t argc, char **argv
 			return -EINVAL;
 		}
 
-		if (argc >= 5) {
-			timing.sjw = (uint16_t)strtoul(argv[4], &endptr, 10);
-			if (*endptr != '\0') {
-				shell_error(sh, "failed to parse SJW");
-				return -EINVAL;
-			}
-		} else {
-			timing.sjw = CAN_SJW_NO_CHANGE;
-		}
-
 		err = can_calc_timing_data(dev, &timing, bitrate, sample_pnt);
 		if (err < 0) {
 			shell_error(sh, "failed to calculate timing for "
@@ -488,16 +471,19 @@ static int cmd_can_dbitrate_set(const struct shell *sh, size_t argc, char **argv
 			return err;
 		}
 
-		if (timing.sjw == CAN_SJW_NO_CHANGE) {
-			shell_print(sh, "setting data bitrate to %d bps, sample point %d.%d%% "
-				    "(+/- %d.%d%%)",
-				    bitrate, sample_pnt / 10, sample_pnt % 10, err / 10, err % 10);
-		} else {
-			shell_print(sh, "setting data bitrate to %d bps, sample point %d.%d%% "
-				    "(+/- %d.%d%%), sjw %d",
-				    bitrate, sample_pnt / 10, sample_pnt % 10, err / 10, err % 10,
-				    timing.sjw);
+		if (argc >= 5) {
+			/* Overwrite calculated default SJW with user-provided value */
+			timing.sjw = (uint16_t)strtoul(argv[4], &endptr, 10);
+			if (*endptr != '\0') {
+				shell_error(sh, "failed to parse SJW");
+				return -EINVAL;
+			}
 		}
+
+		shell_print(sh, "setting data bitrate to %d bps, sample point %d.%d%% "
+			    "(+/- %d.%d%%), sjw %d",
+			    bitrate, sample_pnt / 10, sample_pnt % 10, err / 10, err % 10,
+			    timing.sjw);
 
 		LOG_DBG("sjw %u, prop_seg %u, phase_seg1 %u, phase_seg2 %u, prescaler %u",
 			timing.sjw, timing.prop_seg, timing.phase_seg1, timing.phase_seg2,

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -107,9 +107,8 @@ int can_sja1000_set_timing(const struct device *dev, const struct can_timing *ti
 	struct can_sja1000_data *data = dev->data;
 	uint8_t btr0;
 	uint8_t btr1;
-	uint8_t sjw;
 
-	__ASSERT_NO_MSG(timing->sjw == CAN_SJW_NO_CHANGE || (timing->sjw >= 1 && timing->sjw <= 4));
+	__ASSERT_NO_MSG(timing->sjw >= 1 && timing->sjw <= 4);
 	__ASSERT_NO_MSG(timing->prop_seg == 0);
 	__ASSERT_NO_MSG(timing->phase_seg1 >= 1 && timing->phase_seg1 <= 16);
 	__ASSERT_NO_MSG(timing->phase_seg2 >= 1 && timing->phase_seg2 <= 8);
@@ -121,15 +120,8 @@ int can_sja1000_set_timing(const struct device *dev, const struct can_timing *ti
 
 	k_mutex_lock(&data->mod_lock, K_FOREVER);
 
-	if (timing->sjw == CAN_SJW_NO_CHANGE) {
-		sjw = data->sjw;
-	} else {
-		sjw = timing->sjw;
-		data->sjw = timing->sjw;
-	}
-
 	btr0 = CAN_SJA1000_BTR0_BRP_PREP(timing->prescaler - 1) |
-	       CAN_SJA1000_BTR0_SJW_PREP(sjw - 1);
+	       CAN_SJA1000_BTR0_SJW_PREP(timing->sjw - 1);
 	btr1 = CAN_SJA1000_BTR1_TSEG1_PREP(timing->phase_seg1 - 1) |
 	       CAN_SJA1000_BTR1_TSEG2_PREP(timing->phase_seg2 - 1);
 
@@ -668,7 +660,7 @@ int can_sja1000_init(const struct device *dev)
 {
 	const struct can_sja1000_config *config = dev->config;
 	struct can_sja1000_data *data = dev->data;
-	struct can_timing timing;
+	struct can_timing timing = { 0 };
 	int err;
 
 	__ASSERT_NO_MSG(config->read_reg != NULL);
@@ -708,10 +700,6 @@ int can_sja1000_init(const struct device *dev)
 	can_sja1000_write_reg(dev, CAN_SJA1000_AMR2, 0xFF);
 	can_sja1000_write_reg(dev, CAN_SJA1000_AMR3, 0xFF);
 
-	/* Calculate initial timing parameters */
-	data->sjw = config->sjw;
-	timing.sjw = CAN_SJW_NO_CHANGE;
-
 	if (config->sample_point != 0) {
 		err = can_calc_timing(dev, &timing, config->bitrate, config->sample_point);
 		if (err == -EINVAL) {
@@ -721,6 +709,7 @@ int can_sja1000_init(const struct device *dev)
 
 		LOG_DBG("initial sample point error: %d", err);
 	} else {
+		timing.sjw = config->sjw;
 		timing.prop_seg = 0;
 		timing.phase_seg1 = config->phase_seg1;
 		timing.phase_seg2 = config->phase_seg2;

--- a/dts/arm/atmel/samc21.dtsi
+++ b/dts/arm/atmel/samc21.dtsi
@@ -53,9 +53,7 @@
 			clock-names = "GCLK", "MCLK";
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
 			divider = <12>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};
@@ -69,9 +67,7 @@
 			clock-names = "GCLK", "MCLK";
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
 			divider = <12>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -417,9 +417,7 @@
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 35>;
 			divider = <6>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};
@@ -432,9 +430,7 @@
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 37>;
 			divider = <6>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_k66.dtsi
+++ b/dts/arm/nxp/nxp_k66.dtsi
@@ -31,7 +31,6 @@
 			    "rx-warning", "wake-up";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1030 4>;
 			clk-source = <1>;
-			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
 		  };

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -504,7 +504,6 @@
 			interrupt-names = "mb-0-15", "bus-off", "error", "tx-warning", "rx-warning", "wake-up";
 			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103C 4>;
 			clk-source = <1>;
-			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -405,7 +405,6 @@
 					  "mb-0-15";
 			clocks = <&scg KINETIS_SCG_BUS_CLK>;
 			clk-source = <1>;
-			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
 		};
@@ -418,7 +417,6 @@
 					  "mb-0-15";
 			clocks = <&scg KINETIS_SCG_BUS_CLK>;
 			clk-source = <1>;
-			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -223,9 +223,7 @@
 		interrupts = <43 0>, <44 0>;
 		clocks = <&syscon MCUX_MCAN_CLK>;
 		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
-		sjw = <1>;
 		sample-point = <875>;
-		sjw-data = <1>;
 		sample-point-data = <875>;
 		status = "disabled";
 	};

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -218,9 +218,7 @@
 		interrupts = <43 0>, <44 0>;
 		clocks = <&syscon MCUX_MCAN_CLK>;
 		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
-		sjw = <1>;
 		sample-point = <875>;
-		sjw-data = <1>;
 		sample-point-data = <875>;
 		status = "disabled";
 	};

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -328,9 +328,7 @@
 		interrupts = <43 0>, <44 0>;
 		clocks = <&syscon MCUX_MCAN_CLK>;
 		bosch,mram-cfg = <0x0 15 15 8 8 0 15 15>;
-		sjw = <1>;
 		sample-point = <875>;
-		sjw-data = <1>;
 		sample-point-data = <875>;
 		status = "disabled";
 	};

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -867,7 +867,6 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 14>;
 			clk-source = <2>;
-			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
 		};
@@ -879,7 +878,6 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x68 18>;
 			clk-source = <2>;
-			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
 		};
@@ -891,8 +889,6 @@
 			interrupt-names = "common";
 			clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
 			clk-source = <2>;
-			sjw = <1>;
-			sjw-data = <1>;
 			sample-point = <875>;
 			sample-point-data = <875>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -808,8 +808,6 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN1_CLK 0x68 14>;
 			clk-source = <0>;
-			sjw = <1>;
-			sjw-data = <1>;
 			sample-point = <875>;
 			sample-point-data = <875>;
 			status = "disabled";
@@ -822,8 +820,6 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN2_CLK 0x68 18>;
 			clk-source = <0>;
-			sjw = <1>;
-			sjw-data = <1>;
 			sample-point = <875>;
 			sample-point-data = <875>;
 			status = "disabled";
@@ -836,8 +832,6 @@
 			interrupt-names = "common", "error";
 			clocks = <&ccm IMX_CCM_CAN3_CLK 0x84 6>;
 			clk-source = <0>;
-			sjw = <1>;
-			sjw-data = <1>;
 			sample-point = <875>;
 			sample-point-data = <875>;
 			status = "disabled";

--- a/dts/arm/renesas/rcar/gen3/rcar_gen3_cr7.dtsi
+++ b/dts/arm/renesas/rcar/gen3/rcar_gen3_cr7.dtsi
@@ -94,7 +94,6 @@
 			interrupt-parent = <&gic>;
 			interrupts = <GIC_SPI 186 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
-			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f0/stm32f042.dtsi
+++ b/dts/arm/st/f0/stm32f042.dtsi
@@ -44,7 +44,6 @@
 			interrupts = <30 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/f0/stm32f072.dtsi
+++ b/dts/arm/st/f0/stm32f072.dtsi
@@ -16,7 +16,6 @@
 			interrupts = <30 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/f0/stm32f091.dtsi
+++ b/dts/arm/st/f0/stm32f091.dtsi
@@ -58,7 +58,6 @@
 			interrupts = <30 0>;
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/f1/stm32f103X8.dtsi
+++ b/dts/arm/st/f1/stm32f103X8.dtsi
@@ -54,7 +54,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 	};

--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -40,7 +40,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 
@@ -52,7 +51,6 @@
 			/* also enabling clock for can1 (master instance) */
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x06000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -420,7 +420,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -212,7 +212,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 
@@ -225,7 +224,6 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x06000000>;
 			master-can-reg = <0x40006400>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -222,7 +222,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 
@@ -235,7 +234,6 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x06000000>;
 			master-can-reg = <0x40006400>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 	};

--- a/dts/arm/st/f4/stm32f413.dtsi
+++ b/dts/arm/st/f4/stm32f413.dtsi
@@ -79,7 +79,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x08000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 	};

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -65,7 +65,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 
@@ -78,7 +77,6 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x06000000>;
 			master-can-reg = <0x40006400>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -404,7 +404,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -72,7 +72,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>;
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -38,9 +38,7 @@
 			interrupt-names = "LINE_0", "LINE_1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00001000>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -390,9 +390,7 @@
 			interrupt-names = "LINE_0", "LINE_1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -103,9 +103,7 @@
 			interrupt-names = "LINE_0", "LINE_1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -17,10 +17,8 @@
 			interrupts = <86 0>, <87 0>;
 			interrupt-names = "LINE_0", "LINE_1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
-			sjw = <1>;
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -442,9 +442,7 @@
 			interrupt-names = "LINE_0", "LINE_1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -303,9 +303,7 @@
 			/* common clock FDCAN 1 & 2 */
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -475,9 +475,7 @@
 			interrupts = <19 0>, <21 0>, <63 0>;
 			interrupt-names = "LINE_0", "LINE_1", "CALIB";
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};
@@ -490,9 +488,7 @@
 			interrupts = <20 0>, <22 0>, <63 0>;
 			interrupt-names = "LINE_0", "LINE_1", "CALIB";
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -123,9 +123,7 @@
 			interrupts = <159 0>, <160 0>, <63 0>;
 			interrupt-names = "LINE_0", "LINE_1", "CALIB";
 			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -107,7 +107,6 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -57,7 +57,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -141,7 +141,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -232,7 +232,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -55,7 +55,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>; //RCC_APB1ENR1_CAN2EN
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -291,7 +291,6 @@
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
-			sjw = <1>;
 			sample-point = <875>;
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -777,9 +777,7 @@
 			interrupt-names = "LINE_0", "LINE_1";
 			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
-			sjw = <1>;
 			sample-point = <875>;
-			sjw-data = <1>;
 			sample-point-data = <875>;
 			status = "disabled";
 		};

--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -9,26 +9,34 @@ properties:
     description: bus speed in Baud/s
   sjw:
     type: int
-    required: true
-    description: Resynchronization jump width (ISO 11898-1)
+    deprecated: true
+    default: 1
+    description: |
+      Initial time quanta of resynchronization jump width (ISO 11898-1).
+
+      Deprecated in favor of automatic calculation of a suitable default SJW based on existing
+      timing parameters. Default of 1 matches the default value previously used for all in-tree CAN
+      controller devicetree instances.
+
+      Applications can still manually set the SJW using the CAN timing APIs.
   prop-seg:
     type: int
     deprecated: true
     description: |
-      Time quantums of propagation segment (ISO 11898-1). Deprecated in favor of setting advanced
-      timing parameters from the application.
+      Initial time quanta of propagation segment (ISO 11898-1). Deprecated in favor of setting
+      advanced timing parameters from the application.
   phase-seg1:
     type: int
     deprecated: true
     description: |
-      Time quantums of phase buffer 1 segment (ISO 11898-1). Deprecated in favor of setting advanced
-      timing parameters from the application.
+      Initial time quanta of phase buffer 1 segment (ISO 11898-1). Deprecated in favor of setting
+      advanced timing parameters from the application.
   phase-seg2:
     type: int
     deprecated: true
     description: |
-      Time quantums of phase buffer 2 segment (ISO 11898-1). Deprecated in favor of setting advanced
-      timing parameters from the application.
+      Initial time quanta of phase buffer 2 segment (ISO 11898-1). Deprecated in favor of setting
+      advanced timing parameters from the application.
   sample-point:
     type: int
     description: >

--- a/dts/bindings/can/can-fd-controller.yaml
+++ b/dts/bindings/can/can-fd-controller.yaml
@@ -9,26 +9,34 @@ properties:
     description: data phase bus speed in Baud/s
   sjw-data:
     type: int
-    required: true
-    description: Resynchronization jump width for the data phase. (ISO11898-1:2015)
+    deprecated: true
+    default: 1
+    description: |
+      Initial time quanta of resynchronization jump width for the data phase (ISO11898-1:2015).
+
+      Deprecated in favor of automatic calculation of a suitable default SJW based on existing
+      timing parameters. Default of 1 matches the default value previously used for all in-tree CAN
+      controller devicetree instances.
+
+      Applications can still manually set the SJW using the CAN timing APIs.
   prop-seg-data:
     type: int
     deprecated: true
     description: |
-      Time quantums of propagation segment for the data phase (ISO11898-1:2015). Deprecated in favor
-      of setting advanced timing parameters from the application.
+      Initial time quanta of propagation segment for the data phase (ISO11898-1:2015). Deprecated in
+      favor of setting advanced timing parameters from the application.
   phase-seg1-data:
     type: int
     deprecated: true
     description: |
-      Time quantums of phase buffer 1 segment for the data phase (ISO11898-1:2015). Deprecated in
-      favor of setting advanced timing parameters from the application.
+      Initial time quanta of phase buffer 1 segment for the data phase (ISO11898-1:2015). Deprecated
+      in favor of setting advanced timing parameters from the application.
   phase-seg2-data:
     type: int
     deprecated: true
     description: |
-      Time quantums of phase buffer 2 segment for the data phase (ISO11898-1:2015). Deprecated in
-      favor of setting advanced timing parameters from the application.
+      Initial time quanta of phase buffer 2 segment for the data phase (ISO11898-1:2015). Deprecated
+      in favor of setting advanced timing parameters from the application.
   sample-point-data:
     type: int
     description: >

--- a/dts/bindings/can/nxp,flexcan-fd.yaml
+++ b/dts/bindings/can/nxp,flexcan-fd.yaml
@@ -15,8 +15,6 @@ description: |
       interrupt-names = "common";
       clocks = <&ccm IMX_CCM_CAN_CLK 0x84 6>;
       clk-source = <2>;
-      sjw = <1>;
-      sjw-data = <1>;
       sample-point = <875>;
       sample-point-data = <875>;
       bus-speed = <125000>;

--- a/dts/bindings/can/nxp,flexcan.yaml
+++ b/dts/bindings/can/nxp,flexcan.yaml
@@ -13,7 +13,6 @@ description: |
       interrupt-names = "warning", "error", "wake-up", "mb-0-15";
       clocks = <&scg KINETIS_SCG_BUS_CLK>;
       clk-source = <1>;
-      sjw = <1>;
       sample-point = <875>;
       bus-speed = <125000>;
       pinctrl-0 = <&pinmux_flexcan0>;

--- a/dts/bindings/can/ti,tcan4x5x.yaml
+++ b/dts/bindings/can/ti,tcan4x5x.yaml
@@ -16,8 +16,6 @@ description: |
         reset-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
         int-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
         bosch,mram-cfg = <0x0 15 15 5 5 0 10 10>;
-        sjw = <1>;
-        sjw-data = <1>;
         sample-point = <875>;
         sample-point-data = <875>;
         bus-speed = <125000>;

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -218,7 +218,6 @@
 			interrupts = <TWAI_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TWAI_MODULE>;
-			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
 		};

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -345,7 +345,6 @@
 			interrupts = <TWAI_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TWAI_MODULE>;
-			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
 		};

--- a/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
@@ -331,7 +331,6 @@
 			interrupts = <TWAI_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TWAI_MODULE>;
-			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
 		};

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -261,7 +261,6 @@
 			interrupts = <TWAI_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TWAI_MODULE>;
-			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
 		};

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -865,8 +865,6 @@ __syscall int can_calc_timing_data(const struct device *dev, struct can_timing *
 /**
  * @brief Configure the bus timing for the data phase of a CAN-FD controller.
  *
- * If the sjw equals CAN_SJW_NO_CHANGE, the sjw parameter is not changed.
- *
  * @note @kconfig{CONFIG_CAN_FD_MODE} must be selected for this function to be
  * available.
  *
@@ -935,8 +933,6 @@ int can_calc_prescaler(const struct device *dev, struct can_timing *timing,
 
 /**
  * @brief Configure the bus timing of a CAN controller.
- *
- * If the sjw equals CAN_SJW_NO_CHANGE, the sjw parameter is not changed.
  *
  * @see can_set_timing_data()
  *

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -234,11 +234,6 @@ struct can_bus_err_cnt {
 	uint8_t rx_err_cnt;
 };
 
-/** Synchronization Jump Width (SJW) value to indicate that the SJW should not
- * be changed by the timing calculation.
- */
-#define CAN_SJW_NO_CHANGE 0
-
 /**
  * @brief CAN bus timing structure
  *

--- a/include/zephyr/drivers/can/can_sja1000.h
+++ b/include/zephyr/drivers/can/can_sja1000.h
@@ -176,7 +176,6 @@ struct can_sja1000_data {
 	struct k_sem tx_idle;
 	can_tx_callback_t tx_callback;
 	void *tx_user_data;
-	uint32_t sjw;
 	void *custom;
 };
 

--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -389,10 +389,8 @@ ZTEST_USER(canfd, test_set_bitrate_data_while_started)
  */
 ZTEST_USER(canfd, test_set_timing_data_while_started)
 {
-	struct can_timing timing;
+	struct can_timing timing = { 0 };
 	int err;
-
-	timing.sjw = CAN_SJW_NO_CHANGE;
 
 	err = can_calc_timing_data(can_dev, &timing, TEST_BITRATE_3, TEST_SAMPLE_POINT);
 	zassert_ok(err, "failed to calculate data timing (err %d)", err);

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -1031,10 +1031,8 @@ ZTEST_USER(can_classic, test_set_bitrate_while_started)
  */
 ZTEST_USER(can_classic, test_set_timing_while_started)
 {
-	struct can_timing timing;
+	struct can_timing timing = { 0 };
 	int err;
-
-	timing.sjw = CAN_SJW_NO_CHANGE;
 
 	err = can_calc_timing(can_dev, &timing, TEST_BITRATE_1, TEST_SAMPLE_POINT);
 	zassert_ok(err, "failed to calculate timing (err %d)", err);

--- a/tests/drivers/can/shell/app.overlay
+++ b/tests/drivers/can/shell/app.overlay
@@ -8,11 +8,9 @@
 	fake_can: fake_can {
 		compatible = "zephyr,fake-can";
 		status = "okay";
-		sjw = <1>;
 		sample-point = <875>;
 		bus-speed = <125000>;
 		sample-point = <875>;
-		sjw-data = <1>;
 		bus-speed-data = <1000000>;
 		sample-point-data = <750>;
 	};

--- a/tests/drivers/can/shell/src/main.c
+++ b/tests/drivers/can/shell/src/main.c
@@ -136,10 +136,8 @@ static void can_shell_test_bitrate(const char *cmd, uint32_t expected_bitrate,
 				   uint16_t expected_sample_pnt)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	struct can_timing expected;
+	struct can_timing expected = { 0 };
 	int err;
-
-	expected.sjw = CAN_SJW_NO_CHANGE;
 
 	err = can_calc_timing(fake_can_dev, &expected, expected_bitrate, expected_sample_pnt);
 	zassert_ok(err, "failed to calculate reference timing (err %d)", err);
@@ -180,12 +178,10 @@ static void can_shell_test_dbitrate(const char *cmd, uint32_t expected_bitrate,
 				    uint16_t expected_sample_pnt)
 {
 	const struct shell *sh = shell_backend_dummy_get_ptr();
-	struct can_timing expected;
+	struct can_timing expected = { 0 };
 	int err;
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_CAN_FD_MODE);
-
-	expected.sjw = CAN_SJW_NO_CHANGE;
 
 	err = can_calc_timing_data(fake_can_dev, &expected, expected_bitrate, expected_sample_pnt);
 	zassert_ok(err, "failed to calculate reference timing (err %d)", err);

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -115,13 +115,13 @@ static void assert_timing_within_bounds(struct can_timing *timing,
 					const struct can_timing *min,
 					const struct can_timing *max)
 {
-	zassert_true(timing->sjw == CAN_SJW_NO_CHANGE, "sjw does not equal CAN_SJW_NO_CHANGE");
-
+	zassert_true(timing->sjw <= max->sjw, "sjw exceeds max");
 	zassert_true(timing->prop_seg <= max->prop_seg, "prop_seg exceeds max");
 	zassert_true(timing->phase_seg1 <= max->phase_seg1, "phase_seg1 exceeds max");
 	zassert_true(timing->phase_seg2 <= max->phase_seg2, "phase_seg2 exceeds max");
 	zassert_true(timing->prescaler <= max->prescaler, "prescaler exceeds max");
 
+	zassert_true(timing->sjw >= min->sjw, "sjw lower than min");
 	zassert_true(timing->prop_seg >= min->prop_seg, "prop_seg lower than min");
 	zassert_true(timing->phase_seg1 >= min->phase_seg1, "phase_seg1 lower than min");
 	zassert_true(timing->phase_seg2 >= min->phase_seg2, "phase_seg2 lower than min");
@@ -169,8 +169,6 @@ static void test_timing_values(const struct device *dev, const struct can_timing
 	printk("testing bitrate %u, sample point %u.%u%% (%s): ",
 		test->bitrate, test->sp / 10, test->sp % 10, test->invalid ? "invalid" : "valid");
 
-	timing.sjw = CAN_SJW_NO_CHANGE;
-
 	if (data_phase) {
 		if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
 			min = can_get_timing_data_min(dev);
@@ -193,8 +191,9 @@ static void test_timing_values(const struct device *dev, const struct can_timing
 		zassert_true(sp_err <= SAMPLE_POINT_MARGIN, "sample point error %d too large",
 			     sp_err);
 
-		printk("prop_seg = %u, phase_seg1 = %u, phase_seg2 = %u, prescaler = %u ",
-			timing.prop_seg, timing.phase_seg1, timing.phase_seg2, timing.prescaler);
+		printk("sjw = %u, prop_seg = %u, phase_seg1 = %u, phase_seg2 = %u, prescaler = %u ",
+			timing.sjw, timing.prop_seg, timing.phase_seg1, timing.phase_seg2,
+			timing.prescaler);
 
 		assert_bitrate_correct(dev, &timing, test->bitrate);
 		assert_timing_within_bounds(&timing, min, max);

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -483,7 +483,6 @@
 		test_can0: can@55553333 {
 			compatible = "vnd,can-controller";
 			reg = < 0x55553333 0x1000 >;
-			sjw = <1>;
 			sample-point = <875>;
 			bus-speed = <125000>;
 			status = "okay";
@@ -493,7 +492,6 @@
 		test_can1: can@55554444 {
 			compatible = "vnd,can-controller";
 			reg = < 0x55554444 0x1000 >;
-			sjw = <1>;
 			sample-point = <875>;
 			bus-speed = <125000>;
 			status = "okay";


### PR DESCRIPTION
Change the CAN timing API to automatically calculate a default (Re-)Synchronization Jump Width (SJW) value if none is set by the caller. This allows automatically scaling the SJW according to the number of Time Quanta (TQ) used for phase segment 2 instead of relying on a compile-time fallback value defined in devicetree.

Update the CAN controller drivers to solely use the `sjw` and `sjw-data` devicetree properties for setting the initial timing when devicetree timing parameters are specified in Time Quanta (TQ). Any timing set via the CAN timing APIs will contain either user-provided or automatically calculated SJW values. This includes any timing parameters calculated from `bus-speed` and `bus-speed-data` devicetree properties.
    
Update the CAN controller driver tests accordingly and remove the `CAN_SJW_NO_CHANGE` definition as it has lost its meaning.

Update the descriptions for the various CAN devicetree timing properties specified in Time Quanta (TQ) to make it clear that these, if present, are only used for the initial timing parameters. Deprecate the (Re-)Synchronization Jump Width (SJW) devicetree properties for both arbitration and data phase timing as these are now only used in combination with the other TQ-based CAN timing properties, which are all deprecated.

Fixes: #63033
