### PR TITLE
doc: samples: eeprom: Fix link typo

### DIFF
--- a/samples/drivers/eeprom/README.rst
+++ b/samples/drivers/eeprom/README.rst
@@ -7,7 +7,7 @@
 Overview
 ********
 
-This sample demonstrates the `EEPROM driver API <eeprom_api>` in a simple boot counter
+This sample demonstrates the :ref:`EEPROM driver API <eeprom_api>` in a simple boot counter
 application.
 
 Building and Running


### PR DESCRIPTION
Fix typo in a reference to the EEPROM doc page.