### PR TITLE
drivers: mm: refine includes of the header

### DIFF
--- a/drivers/mm/mm_drv_ti_rat.c
+++ b/drivers/mm/mm_drv_ti_rat.c
@@ -19,6 +19,7 @@
  * the address space.
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/mm/rat.h>
 #include <zephyr/drivers/mm/system_mm.h>
 #include <zephyr/sys/__assert.h>

--- a/include/zephyr/drivers/mm/system_mm.h
+++ b/include/zephyr/drivers/mm/system_mm.h
@@ -15,7 +15,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SYSTEM_MM_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SYSTEM_MM_H_
 
-#include <zephyr/kernel.h>
+#include <zephyr/types.h>
 
 #ifndef _ASMLANGUAGE
 


### PR DESCRIPTION
Refines the `system_mm.h` to include `zephyr/types.h` instead of `zephyr/kernel.h` as that is all it needs.

Updated the includes of `mm_drv_ti_rat.c` accordingly.