### PR TITLE
net: wifi: Added missing extern "C"

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -27,6 +27,10 @@
 #define WIFI_LISTEN_INTERVAL_MIN 0
 #define WIFI_LISTEN_INTERVAL_MAX 65535
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** IEEE 802.11 security types. */
 enum wifi_security_type {
 	/** No security. */
@@ -443,6 +447,10 @@ static inline const char *wifi_ps_get_config_err_code_str(int16_t err_no)
 
 	return "<unknown>";
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @}


### PR DESCRIPTION
This change allows to include this header directly from cpp file.

Fixing the following linker issue from cpp files:
```
undefined reference to `wifi_security_txt(wifi_security_type)'
```