### PR TITLE
Bluetooth: Audio: Refactor codec_cfg_get_freq

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -566,16 +566,49 @@ struct bt_audio_codec_qos_pref {
  * @{
  */
 
+/**
+ * @brief Convert assigned numbers frequency to frequency value.
+ *
+ * @param freq The assigned numbers frequency to convert.
+ *
+ * @retval -EINVAL if arguments are invalid.
+ * @retval The converted frequency value in Hz.
+ */
+int bt_audio_codec_cfg_freq_to_freq_hz(enum bt_audio_codec_config_freq freq);
+
+/**
+ * @brief Convert frequency value to assigned numbers frequency.
+ *
+ * @param freq_hz The frequency value to convert.
+ *
+ * @retval -EINVAL if arguments are invalid.
+ * @retval The assigned numbers frequency (@ref bt_audio_codec_config_freq).
+ */
+int bt_audio_codec_cfg_freq_hz_to_freq(uint32_t freq_hz);
+
 /**@brief Extract the frequency from a codec configuration.
  *
  * @param codec_cfg The codec configuration to extract data from.
  *
- *  @retval The frequency in Hz
+ *  @retval A @ref bt_audio_codec_config_freq value
  *  @retval -EINVAL if arguments are invalid
  *  @retval -ENODATA if not found
  *  @retval -EBADMSG if found value has invalid size or value
  */
 int bt_audio_codec_cfg_get_freq(const struct bt_audio_codec_cfg *codec_cfg);
+
+/**
+ * @brief Set the frequency of a codec configuration.
+ *
+ * @param codec_cfg The codec configuration to set data for.
+ * @param freq      The assigned numbers frequency to set.
+ *
+ * @retval The data_len of @p codec_cfg on success
+ * @retval -EINVAL if arguments are invalid
+ * @retval -ENOMEM if the new value could not set or added due to memory
+ */
+int bt_audio_codec_cfg_set_freq(struct bt_audio_codec_cfg *codec_cfg,
+				enum bt_audio_codec_config_freq freq);
 
 /** @brief Extract frame duration from BT codec config
  *
@@ -660,6 +693,21 @@ int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg 
  */
 uint8_t bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg, uint8_t type,
 				   const uint8_t **data);
+
+/**
+ * @brief Set or add a specific codec configuration value
+ *
+ * @param codec_cfg  The codec data to set the value in.
+ * @param type       The type id to set
+ * @param data       Pointer to the data-pointer to set
+ * @param data_len   Length of @p data
+ *
+ * @retval The data_len of @p codec_cfg on success
+ * @retval -EINVAL if arguments are invalid
+ * @retval -ENOMEM if the new value could not set or added due to memory
+ */
+int bt_audio_codec_cfg_set_val(struct bt_audio_codec_cfg *codec_cfg, uint8_t type,
+			       const uint8_t *data, size_t data_len);
 
 /** @} */ /* End of bt_audio_codec_cfg */
 

--- a/include/zephyr/bluetooth/audio/lc3.h
+++ b/include/zephyr/bluetooth/audio/lc3.h
@@ -173,73 +173,75 @@ struct bt_audio_codec_octets_per_codec_frame {
 enum bt_audio_codec_config_type {
 
 	/** @brief LC3 Sample Frequency configuration type. */
-	BT_AUDIO_CODEC_CONFIG_LC3_FREQ                 = 0x01,
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ = 0x01,
 
 	/** @brief LC3 Frame Duration configuration type. */
-	BT_AUDIO_CODEC_CONFIG_LC3_DURATION             = 0x02,
+	BT_AUDIO_CODEC_CONFIG_LC3_DURATION = 0x02,
 
 	/** @brief LC3 channel Allocation configuration type. */
-	BT_AUDIO_CODEC_CONFIG_LC3_CHAN_ALLOC           = 0x03,
+	BT_AUDIO_CODEC_CONFIG_LC3_CHAN_ALLOC = 0x03,
 
 	/** @brief LC3 Frame Length configuration type. */
-	BT_AUDIO_CODEC_CONFIG_LC3_FRAME_LEN            = 0x04,
+	BT_AUDIO_CODEC_CONFIG_LC3_FRAME_LEN = 0x04,
 
 	/** @brief Codec frame blocks, per SDU configuration type. */
-	BT_AUDIO_CODEC_CONFIG_LC3_FRAME_BLKS_PER_SDU   = 0x05,
+	BT_AUDIO_CODEC_CONFIG_LC3_FRAME_BLKS_PER_SDU = 0x05,
 };
 
-/**
- *  @brief 8 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_8KHZ    0x01
-/**
- *  @brief 11.025 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_11KHZ   0x02
-/**
- *  @brief 16 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_16KHZ   0x03
-/**
- *  @brief 22.05 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_22KHZ   0x04
-/**
- *  @brief 24 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_24KHZ   0x05
-/**
- *  @brief 32 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_32KHZ   0x06
-/**
- *  @brief 44.1 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_44KHZ   0x07
-/**
- *  @brief 48 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_48KHZ   0x08
-/**
- *  @brief 88.2 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_88KHZ   0x09
-/**
- *  @brief 96 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_96KHZ   0x0a
-/**
- *  @brief 176.4 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_176KHZ   0x0b
-/**
- *  @brief 192 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_192KHZ   0x0c
-/**
- *  @brief 384 Khz codec Sample Frequency configuration
- */
-#define BT_AUDIO_CODEC_CONFIG_LC3_FREQ_384KHZ   0x0d
+enum bt_audio_codec_config_freq {
+	/**
+	 *  @brief 8 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_8KHZ = 0x01,
+	/**
+	 *  @brief 11.025 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_11KHZ = 0x02,
+	/**
+	 *  @brief 16 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_16KHZ = 0x03,
+	/**
+	 *  @brief 22.05 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_22KHZ = 0x04,
+	/**
+	 *  @brief 24 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_24KHZ = 0x05,
+	/**
+	 *  @brief 32 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_32KHZ = 0x06,
+	/**
+	 *  @brief 44.1 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_44KHZ = 0x07,
+	/**
+	 *  @brief 48 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_48KHZ = 0x08,
+	/**
+	 *  @brief 88.2 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_88KHZ = 0x09,
+	/**
+	 *  @brief 96 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_96KHZ = 0x0a,
+	/**
+	 *  @brief 176.4 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_176KHZ = 0x0b,
+	/**
+	 *  @brief 192 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_192KHZ = 0x0c,
+	/**
+	 *  @brief 384 Khz codec Sample Frequency configuration
+	 */
+	BT_AUDIO_CODEC_CONFIG_LC3_FREQ_384KHZ = 0x0d,
+};
 
 /**
  *  @brief LC3 7.5 msec Frame Duration configuration
@@ -249,7 +251,6 @@ enum bt_audio_codec_config_type {
  *  @brief LC3 10 msec Frame Duration configuration
  */
 #define BT_AUDIO_CODEC_CONFIG_LC3_DURATION_10  0x01
-
 
 /**
  *  @brief Helper to declare LC3 codec capability

--- a/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
+++ b/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
@@ -75,13 +75,18 @@ static void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 	       codec_cfg->vid, codec_cfg->data_len);
 
 	if (codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
-		/* LC3 uses the generic LTV format - other codecs might do as well */
-
 		enum bt_audio_location chan_allocation;
+		int ret;
+
+		/* LC3 uses the generic LTV format - other codecs might do as well */
 
 		bt_audio_data_parse(codec_cfg->data, codec_cfg->data_len, print_cb, "data");
 
-		printk("  Frequency: %d Hz\n", bt_audio_codec_cfg_get_freq(codec_cfg));
+		ret = bt_audio_codec_cfg_get_freq(codec_cfg);
+		if (ret > 0) {
+			printk("  Frequency: %d Hz\n", bt_audio_codec_cfg_freq_to_freq_hz(ret));
+		}
+
 		printk("  Frame Duration: %d us\n",
 		       bt_audio_codec_cfg_get_frame_duration_us(codec_cfg));
 		if (bt_audio_codec_cfg_get_chan_allocation_val(codec_cfg, &chan_allocation) == 0) {

--- a/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
+++ b/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
@@ -64,13 +64,18 @@ static void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 	       codec_cfg->vid, codec_cfg->data_len);
 
 	if (codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
-		/* LC3 uses the generic LTV format - other codecs might do as well */
-
 		enum bt_audio_location chan_allocation;
+		int ret;
+
+		/* LC3 uses the generic LTV format - other codecs might do as well */
 
 		bt_audio_data_parse(codec_cfg->data, codec_cfg->data_len, print_cb, "data");
 
-		printk("  Frequency: %d Hz\n", bt_audio_codec_cfg_get_freq(codec_cfg));
+		ret = bt_audio_codec_cfg_get_freq(codec_cfg);
+		if (ret > 0) {
+			printk("  Frequency: %d Hz\n", bt_audio_codec_cfg_freq_to_freq_hz(ret));
+		}
+
 		printk("  Frame Duration: %d us\n",
 		       bt_audio_codec_cfg_get_frame_duration_us(codec_cfg));
 		if (bt_audio_codec_cfg_get_chan_allocation_val(codec_cfg, &chan_allocation) == 0) {

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -135,13 +135,18 @@ static void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 	       codec_cfg->vid, codec_cfg->data_len);
 
 	if (codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
-		/* LC3 uses the generic LTV format - other codecs might do as well */
-
 		enum bt_audio_location chan_allocation;
+		int ret;
+
+		/* LC3 uses the generic LTV format - other codecs might do as well */
 
 		bt_audio_data_parse(codec_cfg->data, codec_cfg->data_len, print_cb, "data");
 
-		printk("  Frequency: %d Hz\n", bt_audio_codec_cfg_get_freq(codec_cfg));
+		ret = bt_audio_codec_cfg_get_freq(codec_cfg);
+		if (ret > 0) {
+			printk("  Frequency: %d Hz\n", bt_audio_codec_cfg_freq_to_freq_hz(ret));
+		}
+
 		printk("  Frame Duration: %d us\n",
 		       bt_audio_codec_cfg_get_frame_duration_us(codec_cfg));
 		if (bt_audio_codec_cfg_get_chan_allocation_val(codec_cfg, &chan_allocation) == 0) {
@@ -349,15 +354,19 @@ static int lc3_enable(struct bt_bap_stream *stream, const uint8_t meta[], size_t
 
 #if defined(CONFIG_LIBLC3)
 	{
-		const int freq = bt_audio_codec_cfg_get_freq(stream->codec_cfg);
 		const int frame_duration_us =
 			bt_audio_codec_cfg_get_frame_duration_us(stream->codec_cfg);
+		int freq;
+		int ret;
 
-		if (freq < 0) {
+		ret = bt_audio_codec_cfg_get_freq(stream->codec_cfg);
+		if (ret > 0) {
+			freq = bt_audio_codec_cfg_freq_to_freq_hz(ret);
+		} else {
 			printk("Error: Codec frequency not set, cannot start codec.");
 			*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_CONF_INVALID,
 					       BT_BAP_ASCS_REASON_CODEC_DATA);
-			return -1;
+			return ret;
 		}
 
 		if (frame_duration_us < 0) {

--- a/tests/bluetooth/audio/codec/src/main.c
+++ b/tests/bluetooth/audio/codec/src/main.c
@@ -15,6 +15,37 @@ DEFINE_FFF_GLOBALS;
 
 ZTEST_SUITE(audio_codec_test_suite, NULL, NULL, NULL, NULL, NULL);
 
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_freq_to_freq_hz)
+{
+	const struct freq_test_input {
+		enum bt_audio_codec_config_freq freq;
+		uint32_t freq_hz;
+	} freq_test_inputs[] = {
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_8KHZ, .freq_hz = 8000U},
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_11KHZ, .freq_hz = 11025U},
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_16KHZ, .freq_hz = 16000U},
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_22KHZ, .freq_hz = 22050U},
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_24KHZ, .freq_hz = 24000U},
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_32KHZ, .freq_hz = 32000U},
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_44KHZ, .freq_hz = 44100U},
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_48KHZ, .freq_hz = 48000U},
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_88KHZ, .freq_hz = 88200U},
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_96KHZ, .freq_hz = 96000U},
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_176KHZ, .freq_hz = 176400U},
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_192KHZ, .freq_hz = 192000U},
+		{.freq = BT_AUDIO_CODEC_CONFIG_LC3_FREQ_384KHZ, .freq_hz = 384000U},
+	};
+
+	for (size_t i = 0U; i < ARRAY_SIZE(freq_test_inputs); i++) {
+		const struct freq_test_input *fti = &freq_test_inputs[i];
+
+		zassert_equal(bt_audio_codec_cfg_freq_to_freq_hz(fti->freq), fti->freq_hz,
+			      "freq %d was not coverted to %u", fti->freq, fti->freq_hz);
+		zassert_equal(bt_audio_codec_cfg_freq_hz_to_freq(fti->freq_hz), fti->freq,
+			      "freq_hz %u was not coverted to %d", fti->freq_hz, fti->freq);
+	}
+}
+
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_freq)
 {
 	const struct bt_bap_lc3_preset preset =
@@ -23,7 +54,23 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_freq)
 	int ret;
 
 	ret = bt_audio_codec_cfg_get_freq(&preset.codec_cfg);
-	zassert_equal(ret, 16000u, "unexpected return value %d", ret);
+	zassert_equal(ret, 0x03, "unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_set_freq)
+{
+	struct bt_bap_lc3_preset preset = BT_BAP_LC3_UNICAST_PRESET_16_2_1(
+		BT_AUDIO_LOCATION_FRONT_LEFT, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	int ret;
+
+	ret = bt_audio_codec_cfg_get_freq(&preset.codec_cfg);
+	zassert_equal(ret, 0x03, "Unexpected return value %d", ret);
+
+	ret = bt_audio_codec_cfg_set_freq(&preset.codec_cfg, BT_AUDIO_CODEC_CONFIG_LC3_FREQ_32KHZ);
+	zassert_true(ret > 0, "Unexpected return value %d", ret);
+
+	ret = bt_audio_codec_cfg_get_freq(&preset.codec_cfg);
+	zassert_equal(ret, 0x06, "Unexpected return value %d", ret);
 }
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_frame_duration_us)
@@ -47,8 +94,8 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_chan_allocation_val)
 
 	err = bt_audio_codec_cfg_get_chan_allocation_val(&preset.codec_cfg, &chan_allocation);
 	zassert_false(err, "unexpected error %d", err);
-	zassert_equal(chan_allocation, BT_AUDIO_LOCATION_FRONT_LEFT,
-		      "unexpected return value %d", chan_allocation);
+	zassert_equal(chan_allocation, BT_AUDIO_LOCATION_FRONT_LEFT, "unexpected return value %d",
+		      chan_allocation);
 }
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_octets_per_frame)

--- a/tests/bluetooth/tester/src/btp_bap.c
+++ b/tests/bluetooth/tester/src/btp_bap.c
@@ -111,13 +111,18 @@ static void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 		codec_cfg->vid, codec_cfg->data_len);
 
 	if (codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
-		/* LC3 uses the generic LTV format - other codecs might do as well */
-
 		enum bt_audio_location chan_allocation;
+		int ret;
+
+		/* LC3 uses the generic LTV format - other codecs might do as well */
 
 		bt_audio_data_parse(codec_cfg->data, codec_cfg->data_len, print_cb, "data");
 
-		LOG_DBG("  Frequency: %d Hz", bt_audio_codec_cfg_get_freq(codec_cfg));
+		ret = bt_audio_codec_cfg_get_freq(codec_cfg);
+		if (ret > 0) {
+			LOG_DBG("  Frequency: %d Hz", bt_audio_codec_cfg_freq_to_freq_hz(ret));
+		}
+
 		LOG_DBG("  Frame Duration: %d us",
 			bt_audio_codec_cfg_get_frame_duration_us(codec_cfg));
 		if (bt_audio_codec_cfg_get_chan_allocation_val(codec_cfg, &chan_allocation) == 0) {
@@ -230,22 +235,22 @@ static void btp_send_ascs_ase_state_changed_ev(struct bt_conn *conn, uint8_t ase
 
 static int validate_codec_parameters(const struct bt_audio_codec_cfg *codec_cfg)
 {
-	int freq_hz;
 	int frame_duration_us;
 	int frames_per_sdu;
 	int octets_per_frame;
 	int chan_allocation_err;
 	enum bt_audio_location chan_allocation;
+	int ret;
 
-	freq_hz = bt_audio_codec_cfg_get_freq(codec_cfg);
 	frame_duration_us = bt_audio_codec_cfg_get_frame_duration_us(codec_cfg);
 	chan_allocation_err =
 		bt_audio_codec_cfg_get_chan_allocation_val(codec_cfg, &chan_allocation);
 	octets_per_frame = bt_audio_codec_cfg_get_octets_per_frame(codec_cfg);
 	frames_per_sdu = bt_audio_codec_cfg_get_frame_blocks_per_sdu(codec_cfg, true);
 
-	if (freq_hz < 0) {
-		LOG_DBG("Error: Invalid codec frequency.");
+	ret = bt_audio_codec_cfg_get_freq(codec_cfg);
+	if (ret < 0) {
+		LOG_DBG("Error: Invalid codec frequency: %d", ret);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Refactor the codec_cfg_get_freq function to return the assigned
numbers value, instead of a converted value, but with
support for converting the value.