### PR TITLE
modem: chat: extend request_size to uint16_t

### DIFF
--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -91,7 +91,7 @@ struct modem_chat_script_chat {
 	/** Request to send to modem */
 	const uint8_t *request;
 	/** Size of request */
-	uint8_t request_size;
+	uint16_t request_size;
 	/** Expected responses to request */
 	const struct modem_chat_match *response_matches;
 	/** Number of elements in expected responses */
@@ -103,7 +103,7 @@ struct modem_chat_script_chat {
 #define MODEM_CHAT_SCRIPT_CMD_RESP(_request, _response_match)                                      \
 	{                                                                                          \
 		.request = (uint8_t *)(_request),                                                  \
-		.request_size = (uint8_t)(sizeof(_request) - 1),                                   \
+		.request_size = (uint16_t)(sizeof(_request) - 1),                                  \
 		.response_matches = &_response_match,                                              \
 		.response_matches_size = 1,                                                        \
 		.timeout = 0,                                                                      \
@@ -112,7 +112,7 @@ struct modem_chat_script_chat {
 #define MODEM_CHAT_SCRIPT_CMD_RESP_MULT(_request, _response_matches)                               \
 	{                                                                                          \
 		.request = (uint8_t *)(_request),                                                  \
-		.request_size = (uint8_t)(sizeof(_request) - 1),                                   \
+		.request_size = (uint16_t)(sizeof(_request) - 1),                                  \
 		.response_matches = _response_matches,                                             \
 		.response_matches_size = ARRAY_SIZE(_response_matches),                            \
 		.timeout = 0,                                                                      \
@@ -121,7 +121,7 @@ struct modem_chat_script_chat {
 #define MODEM_CHAT_SCRIPT_CMD_RESP_NONE(_request, _timeout)                                        \
 	{                                                                                          \
 		.request = (uint8_t *)(_request),                                                  \
-		.request_size = (uint8_t)(sizeof(_request) - 1),                                   \
+		.request_size = (uint16_t)(sizeof(_request) - 1),                                  \
 		.response_matches = NULL,                                                          \
 		.response_matches_size = 0,                                                        \
 		.timeout = _timeout,                                                               \


### PR DESCRIPTION
Some AT commands, are longer than 255 chars.
Also, script_send_request_pos is uint16_t, so with this change, request_size will have the same type.