### PR TITLE
tests BT privacy: Simplify a bit scripts

### DIFF
--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/_env.sh
@@ -5,10 +5,7 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-test_name="$(basename "$(realpath "$bash_source_dir/..")")"
 bsim_bin="${BSIM_OUT_PATH}/bin"
-verbosity_level=2
 BOARD="${BOARD:-nrf52_bsim}"
-simulation_id="$test_name"
 central_exe="${bsim_bin}/bs_${BOARD}_tests_bsim_bluetooth_host_privacy_central_prj_conf"
 peripheral_exe="${central_exe}"

--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test.sh
@@ -8,6 +8,8 @@ bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 source "${bash_source_dir}/_env.sh"
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
+verbosity_level=2
+simulation_id="$(basename "$(realpath "$bash_source_dir/..")")"
 EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/privacy/device/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/privacy/device/test_scripts/_env.sh
@@ -7,9 +7,6 @@ bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
 
-test_name="$(basename "$(realpath "$bash_source_dir/..")")"
 bsim_bin="${BSIM_OUT_PATH}/bin"
-verbosity_level=2
 BOARD="${BOARD:-nrf52_bsim}"
-simulation_id="$test_name"
 test_exe="${bsim_bin}/bs_${BOARD}_tests_bsim_bluetooth_host_privacy_device_prj_conf"

--- a/tests/bsim/bluetooth/host/privacy/device/test_scripts/run_tests.sh
+++ b/tests/bsim/bluetooth/host/privacy/device/test_scripts/run_tests.sh
@@ -8,6 +8,8 @@ bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 source "${bash_source_dir}/_env.sh"
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
+verbosity_level=2
+simulation_id="$(basename "$(realpath "$bash_source_dir/..")")"
 EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/privacy/legacy/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/privacy/legacy/test_scripts/_env.sh
@@ -5,10 +5,7 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-test_name="$(basename "$(realpath "$bash_source_dir/..")")"
 bsim_bin="${BSIM_OUT_PATH}/bin"
-verbosity_level=2
 BOARD="${BOARD:-nrf52_bsim}"
-simulation_id="$test_name"
 central_exe="${bsim_bin}/bs_${BOARD}_tests_bsim_bluetooth_host_privacy_legacy_prj_conf"
 peripheral_exe="${central_exe}"

--- a/tests/bsim/bluetooth/host/privacy/legacy/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/privacy/legacy/test_scripts/run_test.sh
@@ -8,6 +8,8 @@ bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 source "${bash_source_dir}/_env.sh"
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
+verbosity_level=2
+simulation_id="$(basename "$(realpath "$bash_source_dir/..")")"
 EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/_env.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/_env.sh
@@ -5,10 +5,7 @@
 set -eu
 bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-test_name="$(basename "$(realpath "$bash_source_dir/..")")"
 bsim_bin="${BSIM_OUT_PATH}/bin"
-verbosity_level=2
 BOARD="${BOARD:-nrf52_bsim}"
-simulation_id="$test_name"
 central_exe="${bsim_bin}/bs_${BOARD}_tests_bsim_bluetooth_host_privacy_peripheral_prj_conf"
 peripheral_exe="${central_exe}"

--- a/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test.sh
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/test_scripts/run_test.sh
@@ -8,6 +8,8 @@ bash_source_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 source "${bash_source_dir}/_env.sh"
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
+verbosity_level=2
+simulation_id="$(basename "$(realpath "$bash_source_dir/..")")"
 EXECUTE_TIMEOUT=30
 
 cd ${BSIM_OUT_PATH}/bin


### PR DESCRIPTION
Reduce the unnecessary hidding and indirection,
as it makes the scripts more difficult to follow for no benefit.
If somebody wants to debug these tests, they'll want to see the sim_id,
and won't benefit from going around opening files needlessly.