### PR TITLE
doc: samples: Fix typos introduced by f6a4217a

### DIFF
--- a/samples/drivers/dac/README.rst
+++ b/samples/drivers/dac/README.rst
@@ -7,7 +7,7 @@
 Overview
 ********
 
-This sample demonstrates how to use the `DAC driver API <dac_api>`.
+This sample demonstrates how to use the :ref:`DAC driver API <dac_api>`.
 
 Building and Running
 ********************

--- a/samples/drivers/eeprom/README.rst
+++ b/samples/drivers/eeprom/README.rst
@@ -7,7 +7,7 @@
 Overview
 ********
 
-This sample demonstrates the `EEPROM driver API <eeprom_api>` in a simple boot counter
+This sample demonstrates the :ref:`EEPROM driver API <eeprom_api>` in a simple boot counter
 application.
 
 Building and Running

--- a/samples/drivers/spi_flash/README.rst
+++ b/samples/drivers/spi_flash/README.rst
@@ -7,7 +7,7 @@
 Overview
 ********
 
-This sample demonstrates using the `flash API <flash_api>` on a SPI NOR serial flash
+This sample demonstrates using the :ref:`flash API <flash_api>` on a SPI NOR serial flash
 memory device.  While trivial it is an example of direct access and
 allows confirmation that the flash is working and that automatic power
 savings is correctly implemented.


### PR DESCRIPTION
Fixed typos in references to several doc pages introduced with f6a4217a.