### PR TITLE
samples: blinky: Add more verbose output to the blinky sample.

### DIFF
--- a/samples/basic/blinky/README.rst
+++ b/samples/basic/blinky/README.rst
@@ -40,8 +40,9 @@ Build and flash Blinky as follows, changing ``reel_board`` for your board:
    :goals: build flash
    :compact:
 
-After flashing, the LED starts to blink. If a runtime error occurs, the sample
-exits without printing to the console.
+After flashing, the LED starts to blink and messages with the current LED state
+are printed on the console. If a runtime error occurs, the sample exits without
+printing to the console.
 
 Build errors
 ************

--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdio.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 
@@ -22,6 +23,7 @@ static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
 int main(void)
 {
 	int ret;
+	bool led_state = true;
 
 	if (!gpio_is_ready_dt(&led)) {
 		return 0;
@@ -37,6 +39,9 @@ int main(void)
 		if (ret < 0) {
 			return 0;
 		}
+
+		led_state = !led_state;
+		printf("LED state: %s\n", led_state ? "ON" : "OFF");
 		k_msleep(SLEEP_TIME_MS);
 	}
 	return 0;


### PR DESCRIPTION
This patch enables simpler GPIO pin debugging by providing immediate LED state change feedback, highlighting issues like LED malfunction or reversed polarity.

Adding extra console messages doesn't impact sample requirements or size, as a boot banner is already included anyway.

This PR also changes the configuration of the LED pin, replacing `GPIO_OUTPUT_ACTIVE` with `GPIO_OUTPUT_INACTIVE`, as without this the LED would turn on for a very short period of time and turn off immediately.