### PR TITLE
Bluetooth: host: document settings backend requirement

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -204,6 +204,9 @@ config BT_SETTINGS
 	  which case it's more efficient to load all settings in one go,
 	  instead of each subsystem doing it independently.
 
+	  Warning: The Bluetooth host expects a settings backend that loads
+	  settings items in handle order.
+
 if BT_SETTINGS
 config BT_SETTINGS_CCC_LAZY_LOADING
 	bool "Load CCC values from settings when peer connects"


### PR DESCRIPTION
This requirement was implicit as the only backend the host is currently tested with behaves this way.

Fixes #60243