### PR TITLE
Bluetooth: Controller: nrf53: Fix back-to-back Tx Rx implementation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -106,6 +106,8 @@ void radio_switch_complete_and_b2b_tx(uint8_t phy_curr, uint8_t flags_curr,
 				      uint8_t phy_next, uint8_t flags_next);
 void radio_switch_complete_and_b2b_rx(uint8_t phy_curr, uint8_t flags_curr,
 				      uint8_t phy_next, uint8_t flags_next);
+void radio_switch_complete_and_b2b_tx_disable(void);
+void radio_switch_complete_and_b2b_rx_disable(void);
 void radio_switch_complete_and_disable(void);
 
 uint8_t radio_phy_flags_rx_get(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -447,10 +447,7 @@ static inline void hal_sw_switch_timer_clear_ppi_config(void)
 
 #endif /* CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE */
 
-static inline void hal_radio_sw_switch_setup(
-		uint8_t compare_reg,
-		uint8_t radio_enable_ppi,
-		uint8_t ppi_group_index)
+static inline void hal_radio_sw_switch_setup(uint8_t ppi_group_index)
 {
 	/* Set up software switch mechanism for next Radio switch. */
 
@@ -458,7 +455,7 @@ static inline void hal_radio_sw_switch_setup(
 	 * over PPI[<HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI>]
 	 */
 	HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI_REGISTER_EVT =
-	    HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI_EVT;
+		HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI_EVT;
 	nrf_dppi_subscribe_set(NRF_DPPIC,
 		HAL_SW_DPPI_TASK_EN_FROM_IDX(SW_SWITCH_TIMER_TASK_GROUP(ppi_group_index)),
 		HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI);
@@ -468,55 +465,70 @@ static inline void hal_radio_sw_switch_setup(
 
 	nrf_dppi_subscribe_clear(NRF_DPPIC,
 		HAL_SW_DPPI_TASK_EN_FROM_IDX(SW_SWITCH_TIMER_TASK_GROUP(other_grp)));
+}
 
+static inline void hal_radio_txen_on_sw_switch(uint8_t compare_reg_index, uint8_t radio_enable_ppi)
+{
 	/* Wire SW Switch timer event <compare_reg> to the
 	 * PPI[<radio_enable_ppi>] for enabling Radio. Do
 	 * not wire the task; it is done by the caller of
 	 * the function depending on the desired direction
 	 * (TX/RX).
 	 */
-	HAL_SW_SWITCH_RADIO_ENABLE_PPI_REGISTER_EVT(compare_reg) =
+	HAL_SW_SWITCH_RADIO_ENABLE_PPI_REGISTER_EVT(compare_reg_index) =
 		HAL_SW_SWITCH_RADIO_ENABLE_PPI_EVT(radio_enable_ppi);
+
+	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_TXEN, radio_enable_ppi);
 }
 
-static inline void hal_radio_txen_on_sw_switch(uint8_t ppi)
+static inline void hal_radio_b2b_txen_on_sw_switch(uint8_t compare_reg_index,
+						   uint8_t radio_enable_ppi)
 {
-	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_TXEN, ppi);
-}
-
-static inline void hal_radio_b2b_txen_on_sw_switch(uint8_t ppi)
-{
-	/* NOTE: Calling radio_tmr_start/radio_tmr_start_us/radio_tmr_start_now
-	 *       after the radio_switch_complete_and_b2b_tx() call would have
-	 *       changed the PPI channel to HAL_RADIO_ENABLE_ON_TICK_PPI as we
-	 *       cannot double buffer the subscribe buffer. Hence, lets have
-	 *       both DPPI channel enabled (other one was enabled by the DPPI
-	 *       group when the Radio End occurred) so that when both timer
-	 *       trigger one of the DPPI is correct in the radio tx
-	 *       subscription.
+	/* Wire SW Switch timer event <compare_reg> to the
+	 * PPI[<radio_enable_ppi>] for enabling Radio. Do
+	 * not wire the task; it is done by the caller of
+	 * the function depending on the desired direction
+	 * (TX/RX).
 	 */
-	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_TXEN, ppi);
-	nrf_dppi_channels_enable(NRF_DPPIC, BIT(ppi));
+	HAL_SW_SWITCH_RADIO_ENABLE_PPI_REGISTER_EVT(compare_reg_index) =
+		HAL_SW_SWITCH_RADIO_ENABLE_PPI_EVT(radio_enable_ppi);
+
+	uint8_t prev_ppi_idx = (compare_reg_index + 0x01) & 0x01;
+
+	radio_enable_ppi = HAL_SW_SWITCH_RADIO_ENABLE_PPI(prev_ppi_idx);
+	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_TXEN, radio_enable_ppi);
 }
 
-static inline void hal_radio_rxen_on_sw_switch(uint8_t ppi)
+static inline void hal_radio_rxen_on_sw_switch(uint8_t compare_reg_index, uint8_t radio_enable_ppi)
 {
-	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_RXEN, ppi);
-}
-
-static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t ppi)
-{
-	/* NOTE: Calling radio_tmr_start/radio_tmr_start_us/radio_tmr_start_now
-	 *       after the radio_switch_complete_and_b2b_rx() call would have
-	 *       changed the PPI channel to HAL_RADIO_ENABLE_ON_TICK_PPI as we
-	 *       cannot double buffer the subscribe buffer. Hence, lets have
-	 *       both DPPI channel enabled (other one was enabled by the DPPI
-	 *       group when the Radio End occurred) so that when both timer
-	 *       trigger one of the DPPI is correct in the radio rx
-	 *       subscription.
+	/* Wire SW Switch timer event <compare_reg> to the
+	 * PPI[<radio_enable_ppi>] for enabling Radio. Do
+	 * not wire the task; it is done by the caller of
+	 * the function depending on the desired direction
+	 * (TX/RX).
 	 */
-	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_RXEN, ppi);
-	nrf_dppi_channels_enable(NRF_DPPIC, BIT(ppi));
+	HAL_SW_SWITCH_RADIO_ENABLE_PPI_REGISTER_EVT(compare_reg_index) =
+		HAL_SW_SWITCH_RADIO_ENABLE_PPI_EVT(radio_enable_ppi);
+
+	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_RXEN, radio_enable_ppi);
+}
+
+static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t compare_reg_index,
+						   uint8_t radio_enable_ppi)
+{
+	/* Wire SW Switch timer event <compare_reg> to the
+	 * PPI[<radio_enable_ppi>] for enabling Radio. Do
+	 * not wire the task; it is done by the caller of
+	 * the function depending on the desired direction
+	 * (TX/RX).
+	 */
+	HAL_SW_SWITCH_RADIO_ENABLE_PPI_REGISTER_EVT(compare_reg_index) =
+		HAL_SW_SWITCH_RADIO_ENABLE_PPI_EVT(radio_enable_ppi);
+
+	uint8_t prev_ppi_idx = (compare_reg_index + 0x01) & 0x01;
+
+	radio_enable_ppi = HAL_SW_SWITCH_RADIO_ENABLE_PPI(prev_ppi_idx);
+	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_RXEN, radio_enable_ppi);
 }
 
 static inline void hal_radio_sw_switch_disable(void)
@@ -530,6 +542,26 @@ static inline void hal_radio_sw_switch_disable(void)
 		HAL_SW_DPPI_TASK_EN_FROM_IDX(SW_SWITCH_TIMER_TASK_GROUP(0)));
 	nrf_dppi_subscribe_clear(NRF_DPPIC,
 		HAL_SW_DPPI_TASK_EN_FROM_IDX(SW_SWITCH_TIMER_TASK_GROUP(1)));
+}
+
+static inline void hal_radio_sw_switch_b2b_tx_disable(uint8_t compare_reg_index)
+{
+	hal_radio_sw_switch_disable();
+
+	uint8_t prev_ppi_idx = (compare_reg_index + 0x01) & 0x01;
+	uint8_t radio_enable_ppi = HAL_SW_SWITCH_RADIO_ENABLE_PPI(prev_ppi_idx);
+
+	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_TXEN, radio_enable_ppi);
+}
+
+static inline void hal_radio_sw_switch_b2b_rx_disable(uint8_t compare_reg_index)
+{
+	hal_radio_sw_switch_disable();
+
+	uint8_t prev_ppi_idx = (compare_reg_index + 0x01) & 0x01;
+	uint8_t radio_enable_ppi = HAL_SW_SWITCH_RADIO_ENABLE_PPI(prev_ppi_idx);
+
+	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_RXEN, radio_enable_ppi);
 }
 
 static inline void hal_radio_sw_switch_cleanup(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -333,7 +333,7 @@ static inline void hal_sw_switch_timer_clear_ppi_config(void)
 
 /* Wire a SW SWITCH TIMER EVENTS_COMPARE[<cc_offset>] event
  * to a PPI GROUP TASK DISABLE task (PPI group with index <index>).
- * 2 adjacent PPIs (8 & 9) and 2 adjacent PPI groups are used for this wiring;
+ * 2 adjacent PPIs (14 & 15) and 2 adjacent PPI groups are used for this wiring;
  * <index> must be 0 or 1. <offset> must be a valid TIMER CC register offset.
  */
 #define HAL_SW_SWITCH_GROUP_TASK_DISABLE_PPI(index) \
@@ -421,10 +421,10 @@ static inline void hal_sw_switch_timer_clear_ppi_config(void)
 	(SW_SWITCH_TIMER_EVTS_COMP_PHYEND_DELAY_COMPENSATION_BASE + (index))
 #define HAL_SW_SWITCH_RADIO_ENABLE_PHYEND_DELAY_COMPENSATION_PPI(index) \
 	HAL_SW_SWITCH_GROUP_TASK_DISABLE_PPI(index)
+
 /* Cancel the SW switch timer running considering PHYEND delay compensation timing:
  * wire the RADIO EVENTS_CTEPRESENT event to SW_SWITCH_TIMER TASKS_CAPTURE task.
  */
-#define HAL_SW_SWITCH_TIMER_PHYEND_DELAY_COMPENSATION_DISABLE_PPI 16
 #define HAL_SW_SWITCH_TIMER_PHYEND_DELAY_COMPENSATION_DISABLE_PPI_REGISTER_EVT \
 	NRF_RADIO->PUBLISH_CTEPRESENT
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi_resources.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi_resources.h
@@ -98,7 +98,7 @@
 
 /* Wire a SW SWITCH TIMER EVENTS_COMPARE[<cc_offset>] event
  * to a PPI GROUP TASK DISABLE task (PPI group with index <index>).
- * 2 adjacent PPIs (8 & 9) and 2 adjacent PPI groups are used for this wiring;
+ * 2 adjacent PPIs (14 & 15) and 2 adjacent PPI groups are used for this wiring;
  * <index> must be 0 or 1. <offset> must be a valid TIMER CC register offset.
  */
 #define HAL_SW_SWITCH_GROUP_TASK_DISABLE_PPI_BASE 14

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -410,10 +410,7 @@ static inline void hal_sw_switch_timer_clear_ppi_config(void)
 #define HAL_SW_SWITCH_RADIO_ENABLE_PPI_TASK_RX \
 	((uint32_t)&(NRF_RADIO->TASKS_RXEN))
 
-static inline void hal_radio_sw_switch_setup(
-		uint8_t compare_reg,
-		uint8_t radio_enable_ppi,
-		uint8_t ppi_group_index)
+static inline void hal_radio_sw_switch_setup(uint8_t ppi_group_index)
 {
 	/* Set up software switch mechanism for next Radio switch. */
 
@@ -425,53 +422,58 @@ static inline void hal_radio_sw_switch_setup(
 		HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI,
 		HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI_EVT,
 		HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI_TASK(ppi_group_index));
+}
 
+static inline void hal_radio_txen_on_sw_switch(uint8_t compare_reg_index, uint8_t radio_enable_ppi)
+{
 	/* Wire SW Switch timer event <compare_reg> to the
 	 * PPI[<radio_enable_ppi>] for enabling Radio. Do
 	 * not wire the task; it is done by the caller of
 	 * the function depending on the desired direction
 	 * (TX/RX).
 	 */
-	nrf_ppi_event_endpoint_setup(
-		NRF_PPI,
-		radio_enable_ppi,
-		HAL_SW_SWITCH_RADIO_ENABLE_PPI_EVT(compare_reg));
+	nrf_ppi_event_endpoint_setup(NRF_PPI, radio_enable_ppi,
+				     HAL_SW_SWITCH_RADIO_ENABLE_PPI_EVT(compare_reg_index));
+
+	nrf_ppi_task_endpoint_setup(NRF_PPI, radio_enable_ppi,
+				    HAL_SW_SWITCH_RADIO_ENABLE_PPI_TASK_TX);
 }
 
-static inline void hal_radio_txen_on_sw_switch(uint8_t ppi)
-{
-	nrf_ppi_task_endpoint_setup(
-		NRF_PPI,
-		ppi,
-		HAL_SW_SWITCH_RADIO_ENABLE_PPI_TASK_TX);
-}
-
-static inline void hal_radio_b2b_txen_on_sw_switch(uint8_t ppi)
+static inline void hal_radio_b2b_txen_on_sw_switch(uint8_t compare_reg_index,
+						   uint8_t radio_enable_ppi)
 {
 	/* NOTE: As independent PPI are used to trigger the Radio Tx task,
 	 *       double buffers implementation works for sw_switch using PPIs,
 	 *       simply reuse the hal_radio_txen_on_sw_switch() functon to set
 	 *	 the next PPIs task to be Radio Tx enable.
 	 */
-	hal_radio_txen_on_sw_switch(ppi);
+	hal_radio_txen_on_sw_switch(compare_reg_index, radio_enable_ppi);
 }
 
-static inline void hal_radio_rxen_on_sw_switch(uint8_t ppi)
+static inline void hal_radio_rxen_on_sw_switch(uint8_t compare_reg_index, uint8_t radio_enable_ppi)
 {
-	nrf_ppi_task_endpoint_setup(
-		NRF_PPI,
-		ppi,
-		HAL_SW_SWITCH_RADIO_ENABLE_PPI_TASK_RX);
-}
-
-static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t ppi)
-{
-	/* NOTE: As independent PPI are used to trigger the Radio Rx task,
-	 *       double buffers implementation works for sw_switch using PPIs,
-	 *       simply reuse the hal_radio_rxen_on_sw_switch() functon to set
-	 *	 the next PPIs task to be Radio Rx enable.
+	/* Wire SW Switch timer event <compare_reg> to the
+	 * PPI[<radio_enable_ppi>] for enabling Radio. Do
+	 * not wire the task; it is done by the caller of
+	 * the function depending on the desired direction
+	 * (TX/RX).
 	 */
-	hal_radio_rxen_on_sw_switch(ppi);
+	nrf_ppi_event_endpoint_setup(NRF_PPI, radio_enable_ppi,
+				     HAL_SW_SWITCH_RADIO_ENABLE_PPI_EVT(compare_reg_index));
+
+	nrf_ppi_task_endpoint_setup(NRF_PPI, radio_enable_ppi,
+				    HAL_SW_SWITCH_RADIO_ENABLE_PPI_TASK_RX);
+}
+
+static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t compare_reg_index,
+						   uint8_t radio_enable_ppi)
+{
+	/* NOTE: As independent PPI are used to trigger the Radio Tx task,
+	 *       double buffers implementation works for sw_switch using PPIs,
+	 *       simply reuse the hal_radio_txen_on_sw_switch() functon to set
+	 *	 the next PPIs task to be Radio Tx enable.
+	 */
+	hal_radio_rxen_on_sw_switch(compare_reg_index, radio_enable_ppi);
 }
 
 static inline void hal_radio_sw_switch_disable(void)
@@ -484,6 +486,16 @@ static inline void hal_radio_sw_switch_disable(void)
 		NRF_PPI,
 		BIT(HAL_SW_SWITCH_TIMER_CLEAR_PPI) |
 		BIT(HAL_SW_SWITCH_GROUP_TASK_ENABLE_PPI));
+}
+
+static inline void hal_radio_sw_switch_b2b_tx_disable(uint8_t compare_reg_index)
+{
+	hal_radio_sw_switch_disable();
+}
+
+static inline void hal_radio_sw_switch_b2b_rx_disable(uint8_t compare_reg_index)
+{
+	hal_radio_sw_switch_disable();
 }
 
 static inline void hal_radio_sw_switch_cleanup(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi_resources.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi_resources.h
@@ -143,9 +143,6 @@
 #define HAL_SW_SWITCH_RADIO_ENABLE_PPI_BASE 12
 #endif
 
-#if defined(CONFIG_BT_CTLR_PHY_CODED) && \
-	defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
-
 /* Wire the SW SWITCH TIMER EVENTS_COMPARE[<cc_offset>] event
  * to RADIO TASKS_TXEN/RXEN task.
  */
@@ -155,8 +152,6 @@
  * wire the RADIO EVENTS_RATEBOOST event to SW_SWITCH_TIMER TASKS_CAPTURE task.
  */
 #define HAL_SW_SWITCH_TIMER_S8_DISABLE_PPI 19
-
-#endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 
 #if defined(CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE)
 /* Wire the SW SWITCH PHYEND delay compensation TIMER EVENTS_COMPARE[<cc_offset>] event to software

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -717,7 +717,7 @@ static void isr_tx_common(void *param,
 					    pkt_flags);
 		}
 
-		radio_switch_complete_and_disable();
+		radio_switch_complete_and_b2b_tx_disable();
 
 		radio_isr_set(isr_done_term, lll);
 	} else {


### PR DESCRIPTION
Back-to-back Tx Rx implementation was incorrect for nRF53
that uses DPPI. Both current and next DPPI channels where
enabled in the implementation which only worked correctly
to have the right tIFS when current and next PDU length
were same.

Fix ensures that the correct current DPPI is subscribed
to by the radio subscribe.

The implementation has been refactor to be able to use the
current sw_tifs_toggle value in the HAL implementation.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>