### PR TITLE
drivers: ieee802154: rf2xx: Fix rx promiscuous behaviour

### DIFF
--- a/drivers/ieee802154/ieee802154_rf2xx.h
+++ b/drivers/ieee802154/ieee802154_rf2xx.h
@@ -122,6 +122,7 @@ struct rf2xx_context {
 	int8_t trx_rssi_base;
 	uint8_t trx_version;
 	uint8_t rx_phr;
+	bool promiscuous;
 };
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_RF2XX_H_ */


### PR DESCRIPTION
When radio is set to promiscuous mode it is desirable to receive invalid frames. This skip a few checks and allow an invalid and non-standard frames be delivered for diagnose.