### PR TITLE
samples: Bluetooth: Add broadcast sink data validation

### DIFF
--- a/samples/bluetooth/broadcast_audio_sink/src/main.c
+++ b/samples/bluetooth/broadcast_audio_sink/src/main.c
@@ -90,6 +90,16 @@ static void stream_recv_cb(struct bt_bap_stream *stream,
 {
 	static uint32_t recv_cnt;
 
+	if (info->flags & BT_ISO_FLAGS_ERROR) {
+		printk("ISO receive error\n");
+		return;
+	}
+
+	if (info->flags & BT_ISO_FLAGS_LOST) {
+		printk("ISO receive lost\n");
+		return;
+	}
+
 	recv_cnt++;
 	if ((recv_cnt % 1000U) == 0U) {
 		printk("Received %u total ISO packets\n", recv_cnt);


### PR DESCRIPTION
Add validation of incoming ISO data for the broadcast sink sample.