### PR TITLE
Bluetooth: Controller: nRF53: Fix missing NRF_CCM subscribe clear

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1084,6 +1084,8 @@ void radio_tmr_status_reset(void)
 {
 	nrf_rtc_event_disable(NRF_RTC0, RTC_EVTENCLR_COMPARE2_Msk);
 
+	hal_trigger_crypt_ppi_disable();
+
 	hal_radio_nrf_ppi_channels_disable(
 			BIT(HAL_RADIO_ENABLE_TX_ON_TICK_PPI) |
 			BIT(HAL_RADIO_ENABLE_RX_ON_TICK_PPI) |
@@ -1115,6 +1117,8 @@ void radio_tmr_status_reset(void)
 void radio_tmr_tx_status_reset(void)
 {
 	nrf_rtc_event_disable(NRF_RTC0, RTC_EVTENCLR_COMPARE2_Msk);
+
+	hal_trigger_crypt_ppi_disable();
 
 	hal_radio_nrf_ppi_channels_disable(
 #if (HAL_RADIO_ENABLE_TX_ON_TICK_PPI != HAL_RADIO_ENABLE_RX_ON_TICK_PPI) && \
@@ -1151,6 +1155,8 @@ void radio_tmr_tx_status_reset(void)
 void radio_tmr_rx_status_reset(void)
 {
 	nrf_rtc_event_disable(NRF_RTC0, RTC_EVTENCLR_COMPARE2_Msk);
+
+	hal_trigger_crypt_ppi_disable();
 
 	hal_radio_nrf_ppi_channels_disable(
 #if (HAL_RADIO_ENABLE_TX_ON_TICK_PPI != HAL_RADIO_ENABLE_RX_ON_TICK_PPI) && \

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -127,6 +127,14 @@ static inline void hal_trigger_crypt_ppi_config(void)
 	nrf_ccm_subscribe_set(NRF_CCM, NRF_CCM_TASK_CRYPT, HAL_RADIO_RECV_TIMEOUT_CANCEL_PPI);
 }
 
+/*******************************************************************************
+ * Disable trigger encryption task
+ */
+static inline void hal_trigger_crypt_ppi_disable(void)
+{
+	nrf_ccm_subscribe_clear(NRF_CCM, NRF_CCM_TASK_CRYPT);
+}
+
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
 /*******************************************************************************
  * Trigger encryption task on Bit counter match:

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -205,6 +205,16 @@ static inline void hal_trigger_crypt_ppi_config(void)
 	/* No need to configure anything for the pre-programmed channel. */
 }
 
+/*******************************************************************************
+ * Disable trigger encryption task
+ */
+static inline void hal_trigger_crypt_ppi_disable(void)
+{
+	/* No need to disable anything as ppi channel will be disabled in a
+	 * separate disable ppi call by the caller of this function.
+	 */
+}
+
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
 /*******************************************************************************
  * Trigger encryption task on Bit counter match:


### PR DESCRIPTION
Fix missing NRF_CCM subscribe clear which can lead to spurious trigger of TASK_CRYPT in NRF_CCM. This may lead to corruption of Rx PDU buffers.