### PR TITLE
kernel: rename `z_current_get()` and do not expose `z_tls_current` publicly

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -568,14 +568,20 @@ __syscall void k_yield(void);
 __syscall void k_wakeup(k_tid_t thread);
 
 /**
- * @brief Get thread ID of the current thread.
+ * @brief Query thread ID of the current thread.
  *
  * This unconditionally queries the kernel via a system call.
+ *
+ * @note Use k_current_get() unless absolutely sure this is necessary.
+ *       This should only be used directly where the thread local
+ *       variable cannot be used or may contain invalid values
+ *       if thread local storage (TLS) is enabled. If TLS is not
+ *       enabled, this is the same as k_current_get().
  *
  * @return ID of current thread.
  */
 __attribute_const__
-__syscall k_tid_t z_current_get(void);
+__syscall k_tid_t k_sched_current_thread_query(void);
 
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 /* Thread-local cache of current thread ID, set in z_thread_entry() */
@@ -594,7 +600,7 @@ static inline k_tid_t k_current_get(void)
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 	return z_tls_current;
 #else
-	return z_current_get();
+	return k_sched_current_thread_query();
 #endif
 }
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -583,11 +583,6 @@ __syscall void k_wakeup(k_tid_t thread);
 __attribute_const__
 __syscall k_tid_t k_sched_current_thread_query(void);
 
-#ifdef CONFIG_THREAD_LOCAL_STORAGE
-/* Thread-local cache of current thread ID, set in z_thread_entry() */
-extern __thread k_tid_t z_tls_current;
-#endif
-
 /**
  * @brief Get thread ID of the current thread.
  *
@@ -598,6 +593,9 @@ __attribute_const__
 static inline k_tid_t k_current_get(void)
 {
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
+	/* Thread-local cache of current thread ID, set in z_thread_entry() */
+	extern __thread k_tid_t z_tls_current;
+
 	return z_tls_current;
 #else
 	return k_sched_current_thread_query();

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -205,7 +205,7 @@ bool z_smp_cpu_mobile(void);
 
 #define _current_cpu ({ __ASSERT_NO_MSG(!z_smp_cpu_mobile()); \
 			arch_curr_cpu(); })
-#define _current z_current_get()
+#define _current k_sched_current_thread_query()
 
 #else
 #define _current_cpu (&_kernel.cpus[0])

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -248,7 +248,7 @@ static uint32_t k_event_wait_internal(struct k_event *event, uint32_t events,
 	}
 
 	wait_condition = options & K_EVENT_WAIT_MASK;
-	thread = z_current_get();
+	thread = k_sched_current_thread_query();
 
 	k_spinlock_key_t  key = k_spin_lock(&event->lock);
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1580,7 +1580,7 @@ static inline void z_vrfy_k_wakeup(k_tid_t thread)
 #include <syscalls/k_wakeup_mrsh.c>
 #endif
 
-k_tid_t z_impl_z_current_get(void)
+k_tid_t z_impl_k_sched_current_thread_query(void)
 {
 #ifdef CONFIG_SMP
 	/* In SMP, _current is a field read from _current_cpu, which
@@ -1599,11 +1599,11 @@ k_tid_t z_impl_z_current_get(void)
 }
 
 #ifdef CONFIG_USERSPACE
-static inline k_tid_t z_vrfy_z_current_get(void)
+static inline k_tid_t z_vrfy_k_sched_current_thread_query(void)
 {
-	return z_impl_z_current_get();
+	return z_impl_k_sched_current_thread_query();
 }
-#include <syscalls/z_current_get_mrsh.c>
+#include <syscalls/k_sched_current_thread_query_mrsh.c>
 #endif
 
 int z_impl_k_is_preempt_thread(void)

--- a/lib/libc/armstdc/src/threading_weak.c
+++ b/lib/libc/armstdc/src/threading_weak.c
@@ -49,7 +49,7 @@ int __weak z_impl_k_sem_take(struct k_sem *sem, k_timeout_t timeout)
 	return 0;
 }
 
-k_tid_t __weak z_impl_z_current_get(void)
+k_tid_t __weak z_impl_k_sched_current_thread_query(void)
 {
 	return 0;
 }

--- a/lib/os/thread_entry.c
+++ b/lib/os/thread_entry.c
@@ -36,7 +36,7 @@ FUNC_NORETURN void z_thread_entry(k_thread_entry_t entry,
 				 void *p1, void *p2, void *p3)
 {
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
-	z_tls_current = z_current_get();
+	z_tls_current = k_sched_current_thread_query();
 #endif
 #ifdef CONFIG_STACK_CANARIES_TLS
 	uintptr_t stack_guard;

--- a/samples/subsys/tracing/src/tracing_user.c
+++ b/samples/subsys/tracing/src/tracing_user.c
@@ -14,7 +14,7 @@ void sys_trace_thread_switched_in_user(void)
 
 	__ASSERT_NO_MSG(nested_interrupts[_current_cpu->id] == 0);
 	/* Can't use k_current_get as thread base and z_tls_current might be incorrect */
-	printk("%s: %p\n", __func__, z_current_get());
+	printk("%s: %p\n", __func__, k_sched_current_thread_query());
 
 	irq_unlock(key);
 }
@@ -25,7 +25,7 @@ void sys_trace_thread_switched_out_user(void)
 
 	__ASSERT_NO_MSG(nested_interrupts[_current_cpu->id] == 0);
 	/* Can't use k_current_get as thread base and z_tls_current might be incorrect */
-	printk("%s: %p\n", __func__, z_current_get());
+	printk("%s: %p\n", __func__, k_sched_current_thread_query());
 
 	irq_unlock(key);
 }

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -27,7 +27,7 @@ void sys_trace_k_thread_switched_out(void)
 	ctf_bounded_string_t name = { "unknown" };
 	struct k_thread *thread;
 
-	thread = z_current_get();
+	thread = k_sched_current_thread_query();
 	_get_thread_name(thread, &name);
 
 	ctf_top_thread_switched_out((uint32_t)(uintptr_t)thread, name);
@@ -38,7 +38,7 @@ void sys_trace_k_thread_switched_in(void)
 	struct k_thread *thread;
 	ctf_bounded_string_t name = { "unknown" };
 
-	thread = z_current_get();
+	thread = k_sched_current_thread_query();
 	_get_thread_name(thread, &name);
 
 	ctf_top_thread_switched_in((uint32_t)(uintptr_t)thread, name);


### PR DESCRIPTION
* Rename `z_current_get()` to `k_sched_current_thread_query()`.
* Hide `z_tls_current` from public.

(See commit messages for more details.)