### PR TITLE
Enable testing LPSPI with and without DMA

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1010_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1010_evk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021, NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1015_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1015_evk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021, NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1020_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1020_evk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021, NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1024_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1024_evk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021, NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1040_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1040_evk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright 2023 NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1050_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1050_evk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2018, NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021, NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1064_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1064_evk.conf
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2021, NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -22,6 +22,19 @@ tests:
       - OVERLAY_CONFIG="overlay-mcux-dspi-dma.conf"
       - DTC_OVERLAY_FILE="overlay-mcux-dspi-dma.overlay"
     platform_allow: frdm_k64f
+  drivers.spi.mcux_lpspi_dma.loopback:
+    filter: CONFIG_SPI_MCUX_LPSPI
+    extra_configs:
+      - CONFIG_SPI_MCUX_LPSPI_DMA=y
+    platform_allow:
+      - mimxrt1010_evk
+      - mimxrt1015_evk
+      - mimxrt1020_evk
+      - mimxrt1024_evk
+      - mimxrt1040_evk
+      - mimxrt1050_evk
+      - mimxrt1060_evk
+      - mimxrt1064_evk
   drivers.spi.sam_spi_dma.loopback:
     extra_args:
       - OVERLAY_CONFIG="overlay-sam-spi-dma.conf"


### PR DESCRIPTION
Currently, there is only one testcase for LPSPI under test spi_loopback which only can test LPSPI either with or without DMA. This move current boards overlay (for test with DMA) to testcase.yaml, by default LPSPI is tested without DMA