### PR TITLE
dts: bindings: boards: Update Ethernet PHY to use `reg` property

### DIFF
--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -132,7 +132,7 @@ zephyr_udc0: &usb0 {
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
 
-	phy: phy {
+	phy: ethernet-phy {
 		compatible = "ethernet-phy";
 		status = "okay";
 		address = <0>;

--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -132,9 +132,9 @@ zephyr_udc0: &usb0 {
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
 
-	phy: ethernet-phy {
+	phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		status = "okay";
-		address = <0>;
+		reg = <0>;
 	};
 };

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_r52.dtsi
@@ -31,9 +31,9 @@
 	pinctrl-names = "default";
 	status = "okay";
 
-	phy0: ethernet-phy {
+	phy0: ethernet-phy@7 {
 		compatible = "ethernet-phy";
-		address = <0x7>;
+		reg = <0x7>;
 		status = "okay";
 	};
 };

--- a/boards/arm/sam4e_xpro/sam4e_xpro.dts
+++ b/boards/arm/sam4e_xpro/sam4e_xpro.dts
@@ -198,10 +198,10 @@
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
 
-	phy: ethernet-phy {
+	phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		status = "okay";
-		address = <0>;
+		reg = <0>;
 	};
 };
 

--- a/boards/arm/sam4e_xpro/sam4e_xpro.dts
+++ b/boards/arm/sam4e_xpro/sam4e_xpro.dts
@@ -198,7 +198,7 @@
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
 
-	phy: phy {
+	phy: ethernet-phy {
 		compatible = "ethernet-phy";
 		status = "okay";
 		address = <0>;

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -136,7 +136,7 @@ zephyr_udc0: &usbhs {
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
 
-	phy: phy {
+	phy: ethernet-phy {
 		compatible = "ethernet-phy";
 		status = "okay";
 		address = <0>;

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -136,10 +136,10 @@ zephyr_udc0: &usbhs {
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
 
-	phy: ethernet-phy {
+	phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		status = "okay";
-		address = <0>;
+		reg = <0>;
 	};
 };
 

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -245,10 +245,10 @@ zephyr_udc0: &usbhs {
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
 
-	phy: ethernet-phy {
+	phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		status = "okay";
-		address = <0>;
+		reg = <0>;
 	};
 };
 

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -245,7 +245,7 @@ zephyr_udc0: &usbhs {
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
 
-	phy: phy {
+	phy: ethernet-phy {
 		compatible = "ethernet-phy";
 		status = "okay";
 		address = <0>;

--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
@@ -146,11 +146,13 @@
 			mdio: mdio {
 				compatible = "smsc,lan91c111-mdio";
 				status = "disabled";
+				#address-cells = <1>;
+				#size-cells = <0>;
 
-				phy: ethernet-phy {
+				phy: ethernet-phy@0 {
 					compatible = "ethernet-phy";
 					status = "disabled";
-					address = <0>;
+					reg = <0>;
 				};
 			};
 		};

--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
@@ -147,7 +147,7 @@
 				compatible = "smsc,lan91c111-mdio";
 				status = "disabled";
 
-				phy: phy {
+				phy: ethernet-phy {
 					compatible = "ethernet-phy";
 					status = "disabled";
 					address = <0>;

--- a/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit.dts
+++ b/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit.dts
@@ -119,7 +119,7 @@
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
 
-	phy: phy {
+	phy: ethernet-phy {
 		compatible = "ethernet-phy";
 		status = "disabled";
 		address = <1>;

--- a/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit.dts
+++ b/boards/xtensa/esp32_ethernet_kit/esp32_ethernet_kit.dts
@@ -119,10 +119,10 @@
 	pinctrl-0 = <&mdio_default>;
 	pinctrl-names = "default";
 
-	phy: ethernet-phy {
+	phy: ethernet-phy@1 {
 		compatible = "ethernet-phy";
 		status = "disabled";
-		address = <1>;
+		reg = <1>;
 	};
 };
 

--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -118,6 +118,27 @@ Required changes
   :c:func:`can_set_bitrate` and :c:func:`can_set_bitrate_data` now also automatically calculate a
   suitable SJW, but their SJW cannot be overwritten by the caller.
 
+* Ethernet PHY devicetree bindings were updated to use the standard ``reg``
+  property for the PHY address instead of a custom ``address`` property. As a
+  result, MDIO controller nodes now require ``#address-cells`` and
+  ``#size-cells`` properties. Similarly, Ethernet PHY devicetree nodes and
+  corresponding driver were updated to consistently use the node name
+  ``ethernet-phy`` instead of ``phy``. Devicetrees and overlays must be updated
+  accordingly:
+
+  .. code-block:: devicetree
+
+     mdio {
+         compatible = "mdio-controller";
+         #address-cells = <1>;
+         #size-cells = <0>;
+
+         ethernet-phy@0 {
+             compatible = "ethernet-phy";
+             reg = <0>;
+         };
+     };
+
 Recommended Changes
 *******************
 

--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -938,7 +938,7 @@ static const struct ethernet_api adin2111_port_api = {
 #define ADIN2111_XSTR(x)	ADIN2111_STR(x)
 
 #define ADIN2111_MDIO_PHY_BY_ADDR(adin_n, phy_addr)						\
-	DEVICE_DT_GET(DT_CHILD(DT_INST_CHILD(adin_n, mdio), phy_##phy_addr))
+	DEVICE_DT_GET(DT_CHILD(DT_INST_CHILD(adin_n, mdio), ethernet_phy_##phy_addr))
 
 #define ADIN2111_PORT_MAC(adin_n, port_n)							\
 	DT_PROP(DT_CHILD(DT_DRV_INST(adin_n), port##port_n), local_mac_address)

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -477,7 +477,7 @@ static const struct ethphy_driver_api phy_mii_driver_api = {
 
 #define PHY_MII_CONFIG(n)						 \
 static const struct phy_mii_dev_config phy_mii_dev_config_##n = {	 \
-	.phy_addr = DT_INST_PROP(n, address),				 \
+	.phy_addr = DT_INST_REG_ADDR(n),				 \
 	.fixed = IS_FIXED_LINK(n),					 \
 	.fixed_speed = DT_INST_ENUM_IDX_OR(n, fixed_link, 0),		 \
 	.mdio = UTIL_AND(UTIL_NOT(IS_FIXED_LINK(n)),			 \

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -172,6 +172,8 @@
 			compatible = "atmel,sam-mdio";
 			reg = <0x40034000 0x4000>;
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		pinctrl: pinctrl@400e0e00 {

--- a/dts/arm/atmel/same5x.dtsi
+++ b/dts/arm/atmel/same5x.dtsi
@@ -22,6 +22,8 @@
 			compatible = "atmel,sam-mdio";
 			reg = <0x42000800 0x400>;
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 	};
 };

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -334,6 +334,8 @@
 			compatible = "atmel,sam-mdio";
 			reg = <0x40050000 0x4000>;
 			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		tc0: tc@4000c000 {

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -637,6 +637,8 @@
 				compatible = "nxp,s32-netc-emdio";
 				reg = <0x74b60000 0x1c44>;
 				status = "disabled";
+				#address-cells = <1>;
+				#size-cells = <0>;
 			};
 
 			enetc_psi0: ethernet@74b00000 {

--- a/dts/arm64/fvp/fvp-aemv8r.dtsi
+++ b/dts/arm64/fvp/fvp-aemv8r.dtsi
@@ -119,7 +119,7 @@
 				compatible = "smsc,lan91c111-mdio";
 				status = "disabled";
 
-				phy: phy {
+				phy: ethernet-phy {
 					compatible = "ethernet-phy";
 					status = "disabled";
 					address = <0>;

--- a/dts/arm64/fvp/fvp-aemv8r.dtsi
+++ b/dts/arm64/fvp/fvp-aemv8r.dtsi
@@ -118,11 +118,13 @@
 			mdio: mdio {
 				compatible = "smsc,lan91c111-mdio";
 				status = "disabled";
+				#address-cells = <1>;
+				#size-cells = <0>;
 
-				phy: ethernet-phy {
+				phy: ethernet-phy@0 {
 					compatible = "ethernet-phy";
 					status = "disabled";
-					address = <0>;
+					reg = <0>;
 				};
 			};
 		};

--- a/dts/bindings/ethernet/adi,adin1110.yaml
+++ b/dts/bindings/ethernet/adi,adin1110.yaml
@@ -20,7 +20,7 @@ description: |
                   status = "okay";
                   #address-cells = <1>;
                   #size-cells = <0>;
-                  phy@1 {
+                  ethernet-phy@1 {
                     reg = <0x1>;
                     compatible = "adi,adin2111-phy";
                     status = "okay";

--- a/dts/bindings/ethernet/adi,adin2111.yaml
+++ b/dts/bindings/ethernet/adi,adin2111.yaml
@@ -23,12 +23,12 @@ description: |
                   status = "okay";
                   #address-cells = <1>;
                   #size-cells = <0>;
-                  phy@1 {
+                  ethernet-phy@1 {
                     reg = <0x1>;
                     compatible = "adi,adin2111-phy";
                     status = "okay";
                   };
-                  phy@2 {
+                  ethernet-phy@2 {
                     reg = <0x2>;
                     compatible = "adi,adin2111-phy";
                     status = "okay";

--- a/dts/bindings/ethernet/ethernet-phy.yaml
+++ b/dts/bindings/ethernet/ethernet-phy.yaml
@@ -10,8 +10,7 @@ compatible: "ethernet-phy"
 include: phy.yaml
 
 properties:
-  address:
-    type: int
+  reg:
     required: true
     description: PHY address
   no-reset:

--- a/dts/bindings/mdio/adi,adin2111-mdio.yaml
+++ b/dts/bindings/mdio/adi,adin2111-mdio.yaml
@@ -8,12 +8,3 @@ compatible: "adi,adin2111-mdio"
 include: mdio-controller.yaml
 
 on-bus: adin2111
-
-properties:
-  "#address-cells":
-    required: true
-    const: 1
-
-  "#size-cells":
-    required: true
-    const: 0

--- a/dts/bindings/mdio/mdio-controller.yaml
+++ b/dts/bindings/mdio/mdio-controller.yaml
@@ -6,3 +6,12 @@
 include: base.yaml
 
 bus: mdio
+
+properties:
+  "#address-cells":
+    required: true
+    const: 1
+
+  "#size-cells":
+    required: true
+    const: 0

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -71,6 +71,8 @@
 		compatible = "espressif,esp32-mdio";
 		clocks = <&rtc ESP32_EMAC_MODULE>;
 		status = "disabled";
+		#address-cells = <1>;
+		#size-cells = <0>;
 	};
 
 	pinctrl: pin-controller {

--- a/tests/drivers/build_all/mdio/app.overlay
+++ b/tests/drivers/build_all/mdio/app.overlay
@@ -29,6 +29,8 @@
 			mdc-gpios = <&test_gpio 0 0>;
 			mdio-gpios = <&test_gpio 0 0>;
 			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 
 		test_mdio1: mdio@33334444 {
@@ -37,6 +39,8 @@
 			mdc-gpios = <&test_gpio 0 0>;
 			mdio-gpios = <&test_gpio 0 0>;
 			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
 		};
 	};
 };


### PR DESCRIPTION
Updates Ethernet PHY devicetree bindings to be more consistent with
Linux by using the standard `reg` property for the PHY address instead
of a custom `address` property. As a result, MDIO controller bindings
now require standard `#address-cells` and `#size-cells` properties.

Signed-off-by: Maureen Helm <maureen.helm@analog.com>