### PR TITLE
fixes for mmu compilation error & TI headers enhancements

### DIFF
--- a/include/zephyr/sys/mem_manage.h
+++ b/include/zephyr/sys/mem_manage.h
@@ -149,13 +149,19 @@ static inline uintptr_t z_mem_phys_addr(void *virt)
 	uintptr_t addr = (uintptr_t)virt;
 
 #ifdef CONFIG_MMU
-	__ASSERT((addr >= CONFIG_KERNEL_VM_BASE) &&
+	__ASSERT(
+#if CONFIG_KERNEL_VM_BASE != 0
+		 (addr >= CONFIG_KERNEL_VM_BASE) &&
+#endif
 		 (addr < (CONFIG_KERNEL_VM_BASE +
 			  (CONFIG_KERNEL_VM_SIZE))),
 		 "address %p not in permanent mappings", virt);
 #else
 	/* Should be identity-mapped */
-	__ASSERT((addr >= CONFIG_SRAM_BASE_ADDRESS) &&
+	__ASSERT(
+#if CONFIG_SRAM_BASE_ADDRESS != 0
+		 (addr >= CONFIG_SRAM_BASE_ADDRESS) &&
+#endif
 		 (addr < (CONFIG_SRAM_BASE_ADDRESS +
 			  (CONFIG_SRAM_SIZE * 1024UL))),
 		 "physical address 0x%lx not in RAM",
@@ -172,7 +178,10 @@ static inline uintptr_t z_mem_phys_addr(void *virt)
 /* Just like Z_MEM_VIRT_ADDR() but with type safety and assertions */
 static inline void *z_mem_virt_addr(uintptr_t phys)
 {
-	__ASSERT((phys >= CONFIG_SRAM_BASE_ADDRESS) &&
+	__ASSERT(
+#if CONFIG_SRAM_BASE_ADDRESS != 0
+		 (phys >= CONFIG_SRAM_BASE_ADDRESS) &&
+#endif
 		 (phys < (CONFIG_SRAM_BASE_ADDRESS +
 			  (CONFIG_SRAM_SIZE * 1024UL))),
 		 "physical address 0x%lx not in RAM", (unsigned long)phys);

--- a/soc/arm/ti_k3/am62x_m4/soc.h
+++ b/soc/arm/ti_k3/am62x_m4/soc.h
@@ -4,4 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef __SOC_H_
+#define __SOC_H_
+
 #include <zephyr/drivers/mm/rat.h>
+
+#endif /* __SOC_H */

--- a/soc/arm/ti_k3/pinctrl_soc.h
+++ b/soc/arm/ti_k3/pinctrl_soc.h
@@ -7,6 +7,9 @@
 #ifndef ZEPHYR_SOC_ARM_TI_K3_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_TI_K3_PINCTRL_SOC_H_
 
+#include <zephyr/devicetree.h>
+#include <zephyr/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/soc/arm64/ti_k3/pinctrl_soc.h
+++ b/soc/arm64/ti_k3/pinctrl_soc.h
@@ -7,6 +7,9 @@
 #ifndef ZEPHYR_SOC_ARM64_TI_K3_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM64_TI_K3_PINCTRL_SOC_H_
 
+#include <zephyr/devicetree.h>
+#include <zephyr/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Fix mmu-related compilation error when the base address used in the ASSERT is 0 (compared uint against 0), and some minor enhancements to some TI's headers