### PR TITLE
boards: arm: cc1352*/cc26x2* based: add hwinfo as supported

### DIFF
--- a/boards/arm/beagle_bcf/beagleconnect_freedom.yaml
+++ b/boards/arm/beagle_bcf/beagleconnect_freedom.yaml
@@ -13,4 +13,5 @@ supported:
   - i2c
   - spi
   - uart
+  - hwinfo
 vendor: beagle

--- a/boards/arm/beagle_bcf/doc/index.rst
+++ b/boards/arm/beagle_bcf/doc/index.rst
@@ -54,6 +54,8 @@ The board configuration supports the following hardware features:
 +-----------+------------+----------------------+
 | SPI       | on-chip    | spi                  |
 +-----------+------------+----------------------+
+| HWINFO    | on-chip    | hwinfo               |
++-----------+------------+----------------------+
 | I2C       | off-chip   | OPT3001              |
 +-----------+------------+----------------------+
 | I2C       | off-chip   | HDC2010              |

--- a/boards/arm/cc1352p1_launchxl/cc1352p1_launchxl.yaml
+++ b/boards/arm/cc1352p1_launchxl/cc1352p1_launchxl.yaml
@@ -13,4 +13,5 @@ supported:
   - i2c
   - spi
   - watchdog
+  - hwinfo
 vendor: ti

--- a/boards/arm/cc1352p1_launchxl/doc/index.rst
+++ b/boards/arm/cc1352p1_launchxl/doc/index.rst
@@ -58,6 +58,8 @@ features:
 +-----------+------------+----------------------+
 | WDT       | on-chip    | watchdog             |
 +-----------+------------+----------------------+
+| HWINFO    | on-chip    | hwinfo               |
++-----------+------------+----------------------+
 
 Other hardware features have not been enabled yet for this board.
 

--- a/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.yaml
+++ b/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl.yaml
@@ -14,4 +14,5 @@ supported:
   - spi
   - watchdog
   - adc
+  - hwinfo
 vendor: ti

--- a/boards/arm/cc1352r1_launchxl/doc/index.rst
+++ b/boards/arm/cc1352r1_launchxl/doc/index.rst
@@ -57,6 +57,8 @@ features:
 +-----------+------------+----------------------+
 | AUX_ADC   | on-chip    | adc                  |
 +-----------+------------+----------------------+
+| HWINFO    | on-chip    | hwinfo               |
++-----------+------------+----------------------+
 
 Other hardware features have not been enabled yet for this board.
 

--- a/boards/arm/cc1352r_sensortag/cc1352r_sensortag.yaml
+++ b/boards/arm/cc1352r_sensortag/cc1352r_sensortag.yaml
@@ -14,4 +14,5 @@ supported:
   - spi
   - watchdog
   - adc
+  - hwinfo
 vendor: ti

--- a/boards/arm/cc1352r_sensortag/doc/index.rst
+++ b/boards/arm/cc1352r_sensortag/doc/index.rst
@@ -65,6 +65,8 @@ features:
 +-----------+------------+------------------+
 | WDT       | on-chip    | watchdog         |
 +-----------+------------+------------------+
+| HWINFO    | on-chip    | hwinfo           |
++-----------+------------+------------------+
 
 Other hardware features have not been enabled yet for this board.
 

--- a/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.yaml
+++ b/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl.yaml
@@ -14,4 +14,5 @@ supported:
   - spi
   - watchdog
   - adc
+  - hwinfo
 vendor: ti

--- a/boards/arm/cc26x2r1_launchxl/doc/index.rst
+++ b/boards/arm/cc26x2r1_launchxl/doc/index.rst
@@ -57,6 +57,8 @@ features:
 +-----------+------------+----------------------+
 | AUX_ADC   | on-chip    | adc                  |
 +-----------+------------+----------------------+
+| HWINFO    | on-chip    | hwinfo               |
++-----------+------------+----------------------+
 
 Other hardware features have not been enabled yet for this board.
 


### PR DESCRIPTION
Add `hwinfo` to supported features list in CC1352* and CC26x2* based boards yaml and documentation files. Driver for this platform was included in 634416bc49.

This was suggested by @kartben in https://github.com/zephyrproject-rtos/zephyr/pull/62537#issuecomment-1729505127