### PR TITLE
fix: drivers: remove redundant config checks in cmake files

### DIFF
--- a/drivers/sensor/adt7310/CMakeLists.txt
+++ b/drivers/sensor/adt7310/CMakeLists.txt
@@ -2,5 +2,5 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_ADT7310 adt7310.c)
+zephyr_library_sources(adt7310.c)
 zephyr_library_sources_ifdef(CONFIG_ADT7310_TRIGGER adt7310_trigger.c)

--- a/drivers/sensor/bmi08x/CMakeLists.txt
+++ b/drivers/sensor/bmi08x/CMakeLists.txt
@@ -2,8 +2,8 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_BMI08X bmi08x_accel.c)
-zephyr_library_sources_ifdef(CONFIG_BMI08X bmi08x_gyro.c)
-zephyr_library_sources_ifdef(CONFIG_BMI08X bmi08x.c)
+zephyr_library_sources(bmi08x_accel.c)
+zephyr_library_sources(bmi08x_gyro.c)
+zephyr_library_sources(bmi08x.c)
 zephyr_library_sources_ifdef(CONFIG_BMI08X_ACCEL_TRIGGER bmi08x_accel_trigger.c)
 zephyr_library_sources_ifdef(CONFIG_BMI08X_GYRO_TRIGGER bmi08x_gyro_trigger.c)

--- a/drivers/sensor/ds18b20/CMakeLists.txt
+++ b/drivers/sensor/ds18b20/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_DS18B20 ds18b20.c)
+zephyr_library_sources(ds18b20.c)

--- a/drivers/sensor/max31855/CMakeLists.txt
+++ b/drivers/sensor/max31855/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_MAX31855 max31855.c)
+zephyr_library_sources(max31855.c)

--- a/drivers/sensor/pcnt_esp32/CMakeLists.txt
+++ b/drivers/sensor/pcnt_esp32/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_PCNT_ESP32 pcnt_esp32.c)
+zephyr_library_sources(pcnt_esp32.c)


### PR DESCRIPTION
This commit does not introduce any functional change to the codebase. Just removes certain redundant checks from various CMakeLists.txt files in order to bring more coherence in the codebase.

This comment https://github.com/zephyrproject-rtos/zephyr/pull/60842#discussion_r1320076317 is the rationale behind this cleanup.

These config checks are already present in drivers/sensor/CMakeLists.txt as follows:
```
add_subdirectory_ifdef(CONFIG_ADT7310 adt7310)
...
add_subdirectory_ifdef(CONFIG_BMI08X bmi08x)
...
add_subdirectory_ifdef(CONFIG_DS18B20 ds18b20)
...
add_subdirectory_ifdef(CONFIG_MAX31855 max31855)
...
add_subdirectory_ifdef(CONFIG_PCNT_ESP32 pcnt_esp32)
```
