### PR TITLE
tests: kernel: timer behavior tick alignment on the first timer

### DIFF
--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -121,6 +121,11 @@ static void do_test_using(void (*sample_collection_fn)(void))
 
 	periodic_idx = 0;
 	k_sem_init(&periodic_sem, 0, 1);
+	/*
+	 * Align the test case on the first scheduled timer to the tick
+	 * will avoid the one timeout occurring shorter than the rest.
+	 */
+	k_sleep(K_TICKS(2));
 	sample_collection_fn();
 	k_sem_take(&periodic_sem, K_FOREVER);
 


### PR DESCRIPTION
In the testcase we're missing a tick alignment on the first timer. So with this change, Just before starting the test case, the first scheduled timer is aligned to the tick to avoid the one timeout occurring shorter than the rest.

As recommended to fix https://github.com/zephyrproject-rtos/zephyr/issues/57285

thanks to @teburd 

