### PR TITLE
doc: stm32: Update all st.com links to use HTTPS

### DIFF
--- a/boards/arm/96b_aerocore2/doc/index.rst
+++ b/boards/arm/96b_aerocore2/doc/index.rst
@@ -347,4 +347,4 @@ terminal:
    http://dfu-util.sourceforge.net/build.html
 
 .. _AN2606:
-   http://www.st.com/content/ccc/resource/technical/document/application_note/b9/9b/16/3a/12/1e/40/0c/CD00167594.pdf/files/CD00167594.pdf/jcr:content/translations/en.CD00167594.pdf
+   https://www.st.com/content/ccc/resource/technical/document/application_note/b9/9b/16/3a/12/1e/40/0c/CD00167594.pdf/files/CD00167594.pdf/jcr:content/translations/en.CD00167594.pdf

--- a/boards/arm/96b_argonkey/doc/index.rst
+++ b/boards/arm/96b_argonkey/doc/index.rst
@@ -234,7 +234,7 @@ References
    https://sourceforge.net/p/stm32flash/wiki/Home/
 
 .. _ST-LINK/V2:
-   http://www.st.com/en/development-tools/st-link-v2.html
+   https://www.st.com/en/development-tools/st-link-v2.html
 
 .. _TTL-232RG:
    http://www.ftdichip.com/Support/Documents/DataSheets/Cables/DS_TTL-232RG_CABLES.pdf

--- a/boards/arm/96b_carbon/doc/index.rst
+++ b/boards/arm/96b_carbon/doc/index.rst
@@ -369,16 +369,16 @@ STM32F401RET using an SWD scan.
    http://dfu-util.sourceforge.net/build.html
 
 .. _AN2606:
-   http://www.st.com/content/ccc/resource/technical/document/application_note/b9/9b/16/3a/12/1e/40/0c/CD00167594.pdf/files/CD00167594.pdf/jcr:content/translations/en.CD00167594.pdf
+   https://www.st.com/content/ccc/resource/technical/document/application_note/b9/9b/16/3a/12/1e/40/0c/CD00167594.pdf/files/CD00167594.pdf/jcr:content/translations/en.CD00167594.pdf
 
 .. _96Boards website:
    http://www.96boards.org/documentation
 
 .. _STM32F401RE on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f401re.html
+   https://www.st.com/en/microcontrollers/stm32f401re.html
 
 .. _STM32F401 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00096844.pdf
+   https://www.st.com/resource/en/reference_manual/dm00096844.pdf
 
 .. _96Boards IE Specification:
     https://linaro.co/ie-specification

--- a/boards/arm/96b_stm32_sensor_mez/doc/index.rst
+++ b/boards/arm/96b_stm32_sensor_mez/doc/index.rst
@@ -242,7 +242,7 @@ References
    https://www.96boards.org/documentation/mezzanine/stm32/
 
 .. _STM32F446VE on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f446ve.html
+   https://www.st.com/en/microcontrollers/stm32f446ve.html
 
 .. _STM32F446 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00135183.pdf
+   https://www.st.com/resource/en/reference_manual/dm00135183.pdf

--- a/boards/arm/arduino_giga_r1/doc/index.rst
+++ b/boards/arm/arduino_giga_r1/doc/index.rst
@@ -177,7 +177,7 @@ as "JTAG". For example::
    https://www.st.com/content/st_com/en/products/microcontrollers-microprocessors/stm32-32-bit-arm-cortex-mcus/stm32-high-performance-mcus/stm32h7-series/stm32h747-757/stm32h747xi.html
 
 .. _STM32H747xx reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00176879.pdf
+   https://www.st.com/resource/en/reference_manual/dm00176879.pdf
 
 .. _STM32H747xx datasheet:
    https://www.st.com/resource/en/datasheet/stm32h747xi.pdf

--- a/boards/arm/arduino_portenta_h7/doc/index.rst
+++ b/boards/arm/arduino_portenta_h7/doc/index.rst
@@ -135,7 +135,7 @@ Here is an example for the :zephyr:code-sample:`blinky` application on M4 core.
    https://www.st.com/content/st_com/en/products/microcontrollers-microprocessors/stm32-32-bit-arm-cortex-mcus/stm32-high-performance-mcus/stm32h7-series/stm32h747-757/stm32h747xi.html
 
 .. _STM32H747xx reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00176879.pdf
+   https://www.st.com/resource/en/reference_manual/dm00176879.pdf
 
 .. _STM32H747xx datasheet:
    https://www.st.com/resource/en/datasheet/stm32h747xi.pdf

--- a/boards/arm/b_l072z_lrwan1/doc/index.rst
+++ b/boards/arm/b_l072z_lrwan1/doc/index.rst
@@ -244,7 +244,7 @@ You can debug an application in the usual way.  Here is an example for the
    https://www.st.com/en/evaluation-tools/b-l072z-lrwan1.html
 
 .. _STM32L072CZ on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32l072cz.html
+   https://www.st.com/en/microcontrollers/stm32l072cz.html
 
 .. _STM32L0x2 reference manual:
-   http://www.st.com/resource/en/reference_manual/DM00108281.pdf
+   https://www.st.com/resource/en/reference_manual/DM00108281.pdf

--- a/boards/arm/black_f407ve/doc/index.rst
+++ b/boards/arm/black_f407ve/doc/index.rst
@@ -235,7 +235,7 @@ You can debug an application in the usual way.  Here is an example for the
    https://stm32-base.org/boards/STM32F407VET6-STM32-F4VE-V2.0.html
 
 .. _STM32F407VE on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f407ve.html
+   https://www.st.com/en/microcontrollers/stm32f407ve.html
 
 .. _STM32F407VET6 black board:
    https://os.mbed.com/users/hudakz/code/STM32F407VET6_Hello/

--- a/boards/arm/blackpill_f401cc/doc/index.rst
+++ b/boards/arm/blackpill_f401cc/doc/index.rst
@@ -168,7 +168,7 @@ References
    http://dfu-util.sourceforge.net/build.html
 
 .. _STM32F401CC website:
-   http://www.st.com/en/microcontrollers/stm32f401cc.html
+   https://www.st.com/en/microcontrollers/stm32f401cc.html
 
 .. _STM32F401x reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00096844.pdf
+   https://www.st.com/resource/en/reference_manual/dm00096844.pdf

--- a/boards/arm/blackpill_f401ce/doc/index.rst
+++ b/boards/arm/blackpill_f401ce/doc/index.rst
@@ -173,7 +173,7 @@ References
    http://dfu-util.sourceforge.net/build.html
 
 .. _STM32F401CE website:
-   http://www.st.com/en/microcontrollers/stm32f401ce.html
+   https://www.st.com/en/microcontrollers/stm32f401ce.html
 
 .. _STM32F401x reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00096844.pdf
+   https://www.st.com/resource/en/reference_manual/dm00096844.pdf

--- a/boards/arm/blackpill_f411ce/doc/index.rst
+++ b/boards/arm/blackpill_f411ce/doc/index.rst
@@ -173,7 +173,7 @@ References
    http://dfu-util.sourceforge.net/build.html
 
 .. _STM32F411CE website:
-   http://www.st.com/en/microcontrollers/stm32f411ce.html
+   https://www.st.com/en/microcontrollers/stm32f411ce.html
 
 .. _STM32F411x reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00119316.pdf
+   https://www.st.com/resource/en/reference_manual/dm00119316.pdf

--- a/boards/arm/disco_l475_iot1/doc/index.rst
+++ b/boards/arm/disco_l475_iot1/doc/index.rst
@@ -236,13 +236,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Disco L475 IoT1 website:
-   http://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-eval-tools/stm32-mcu-eval-tools/stm32-mcu-discovery-kits/b-l475e-iot01a.html
+   https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-eval-tools/stm32-mcu-eval-tools/stm32-mcu-discovery-kits/b-l475e-iot01a.html
 
 .. _STM32 Disco L475 IoT1 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00347848.pdf
+   https://www.st.com/resource/en/user_manual/dm00347848.pdf
 
 .. _STM32L475VG on www.st.com:
    https://www.st.com/en/microcontrollers-microprocessors/stm32l475vg.html
 
 .. _STM32L475 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00083560.pdf
+   https://www.st.com/resource/en/reference_manual/dm00083560.pdf

--- a/boards/arm/dragino_lsn50/doc/index.rst
+++ b/boards/arm/dragino_lsn50/doc/index.rst
@@ -188,7 +188,7 @@ You can debug an application in the usual way.  Here is an example for the
    https://www.dragino.com/products/lora-lorawan-end-node/item/128-lsn50.html
 
 .. _STM32L072CZ on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32l072cz.html
+   https://www.st.com/en/microcontrollers/stm32l072cz.html
 
 .. _STM32L0x2 reference manual:
-   http://www.st.com/resource/en/reference_manual/DM00108281.pdf
+   https://www.st.com/resource/en/reference_manual/DM00108281.pdf

--- a/boards/arm/dragino_nbsn95/doc/index.rst
+++ b/boards/arm/dragino_nbsn95/doc/index.rst
@@ -187,7 +187,7 @@ You can debug an application in the usual way.  Here is an example for the
    https://www.dragino.com/products/nb-iot/item/163-nbsn95.html
 
 .. _STM32L072CZ on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32l072cz.html
+   https://www.st.com/en/microcontrollers/stm32l072cz.html
 
 .. _STM32L0x2 reference manual:
-   http://www.st.com/resource/en/reference_manual/DM00108281.pdf
+   https://www.st.com/resource/en/reference_manual/DM00108281.pdf

--- a/boards/arm/legend/doc/index.rst
+++ b/boards/arm/legend/doc/index.rst
@@ -136,4 +136,4 @@ References
 - `STM32F070 reference manual`_
 
 .. _STM32F070 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00031936.pdf
+   https://www.st.com/resource/en/reference_manual/dm00031936.pdf

--- a/boards/arm/nucleo_c031c6/doc/index.rst
+++ b/boards/arm/nucleo_c031c6/doc/index.rst
@@ -142,7 +142,7 @@ References
 .. target-notes::
 
 .. _Nucleo C031C6 website:
-   http://www.st.com/en/evaluation-tools/nucleo-c031c6.html
+   https://www.st.com/en/evaluation-tools/nucleo-c031c6.html
 
 .. _STM32C0x1 reference manual:
    https://www.st.com/resource/en/reference_manual/rm0490-stm32c0x1-advanced-armbased-64bit-mcus-stmicroelectronics.pdf

--- a/boards/arm/nucleo_f070rb/doc/index.rst
+++ b/boards/arm/nucleo_f070rb/doc/index.rst
@@ -171,10 +171,10 @@ References
 .. target-notes::
 
 .. _Nucleo F070RB website:
-   http://www.st.com/en/evaluation-tools/nucleo-f070rb.html
+   https://www.st.com/en/evaluation-tools/nucleo-f070rb.html
 
 .. _STM32F070 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00031936.pdf
+   https://www.st.com/resource/en/reference_manual/dm00031936.pdf
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf

--- a/boards/arm/nucleo_f091rc/doc/index.rst
+++ b/boards/arm/nucleo_f091rc/doc/index.rst
@@ -188,10 +188,10 @@ References
 .. target-notes::
 
 .. _Nucleo F091RC website:
-   http://www.st.com/en/evaluation-tools/nucleo-f091rc.html
+   https://www.st.com/en/evaluation-tools/nucleo-f091rc.html
 
 .. _STM32F091 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00031936.pdf
+   https://www.st.com/resource/en/reference_manual/dm00031936.pdf
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf

--- a/boards/arm/nucleo_f103rb/doc/index.rst
+++ b/boards/arm/nucleo_f103rb/doc/index.rst
@@ -178,13 +178,13 @@ References
 .. target-notes::
 
 .. _Nucleo F103RB website:
-   http://www.st.com/en/evaluation-tools/nucleo-f103rb.html
+   https://www.st.com/en/evaluation-tools/nucleo-f103rb.html
 
 .. _STM32F103 reference manual:
-   http://www.st.com/resource/en/reference_manual/cd00171190.pdf
+   https://www.st.com/resource/en/reference_manual/cd00171190.pdf
 
 .. _STM32F103 data sheet:
-   http://www.st.com/resource/en/datasheet/stm32f103rb.pdf
+   https://www.st.com/resource/en/datasheet/stm32f103rb.pdf
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf

--- a/boards/arm/nucleo_f207zg/doc/index.rst
+++ b/boards/arm/nucleo_f207zg/doc/index.rst
@@ -194,13 +194,13 @@ This interface is supported by the openocd version included in Zephyr SDK.
 
 
 .. _Nucleo F207ZG website:
-   http://www.st.com/en/evaluation-tools/nucleo-f207zg.html
+   https://www.st.com/en/evaluation-tools/nucleo-f207zg.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00244518.pdf
+   https://www.st.com/resource/en/user_manual/dm00244518.pdf
 
 .. _STM32F207ZG on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f207zg.html
+   https://www.st.com/en/microcontrollers/stm32f207zg.html
 
 .. _STM32F207 reference manual:
-   http://www.st.com/resource/en/reference_manual/cd00225773.pdf
+   https://www.st.com/resource/en/reference_manual/cd00225773.pdf

--- a/boards/arm/nucleo_f302r8/doc/index.rst
+++ b/boards/arm/nucleo_f302r8/doc/index.rst
@@ -153,16 +153,16 @@ This interface is supported by the openocd version included in Zephyr SDK.
 
 
 .. _Nucleo F302R8 website:
-   http://www.st.com/en/evaluation-tools/nucleo-f302r8.html
+   https://www.st.com/en/evaluation-tools/nucleo-f302r8.html
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf
 
 .. _STM32F302R8 on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f302r8.html
+   https://www.st.com/en/microcontrollers/stm32f302r8.html
 
 .. _STM32F302R8 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00094349.pdf
+   https://www.st.com/resource/en/reference_manual/dm00094349.pdf
 
 .. _STM32F302R8 datasheet:
-   http://www.st.com/resource/en/datasheet/stm32f302r8.pdf
+   https://www.st.com/resource/en/datasheet/stm32f302r8.pdf

--- a/boards/arm/nucleo_f303k8/doc/index.rst
+++ b/boards/arm/nucleo_f303k8/doc/index.rst
@@ -144,13 +144,13 @@ This interface is supported by the openocd version included in Zephyr SDK.
 
 
 .. _Nucleo F303K8 website:
-   http://www.st.com/en/evaluation-tools/nucleo-F303K8.html
+   https://www.st.com/en/evaluation-tools/nucleo-F303K8.html
 
 .. _STM32 Nucleo-32 board User Manual:
    https://www.st.com/resource/en/user_manual/dm00231744-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf
 
 .. _STM32F303K8 on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32F303K8.html
+   https://www.st.com/en/microcontrollers/stm32F303K8.html
 
 .. _STM32F303K8 reference manual:
    https://www.st.com/resource/en/reference_manual/dm00043574-stm32f303xbcde-stm32f303x68-stm32f328x8-stm32f358xc-stm32f398xe-advanced-armbased-mcus-stmicroelectronics.pdf

--- a/boards/arm/nucleo_f303re/doc/index.rst
+++ b/boards/arm/nucleo_f303re/doc/index.rst
@@ -147,16 +147,16 @@ This interface is supported by the openocd version included in Zephyr SDK.
 
 
 .. _Nucleo F303RE website:
-   http://www.st.com/en/evaluation-tools/nucleo-f303re.html
+   https://www.st.com/en/evaluation-tools/nucleo-f303re.html
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf
 
 .. _STM32F303RE on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f303re.html
+   https://www.st.com/en/microcontrollers/stm32f303re.html
 
 .. _STM32F303RE reference manual:
    https://www.st.com/resource/en/reference_manual/dm00043574.pdf
 
 .. _STM32F303RE datasheet:
-   http://www.st.com/resource/en/datasheet/stm32f303re.pdf
+   https://www.st.com/resource/en/datasheet/stm32f303re.pdf

--- a/boards/arm/nucleo_f334r8/doc/index.rst
+++ b/boards/arm/nucleo_f334r8/doc/index.rst
@@ -170,10 +170,10 @@ References
 .. target-notes::
 
 .. _Nucleo F334R8 website:
-   http://www.st.com/en/evaluation-tools/nucleo-f334r8.html
+   https://www.st.com/en/evaluation-tools/nucleo-f334r8.html
 
 .. _STM32F334 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00093941.pdf
+   https://www.st.com/resource/en/reference_manual/dm00093941.pdf
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf

--- a/boards/arm/nucleo_f401re/doc/index.rst
+++ b/boards/arm/nucleo_f401re/doc/index.rst
@@ -194,13 +194,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo F401RE website:
-   http://www.st.com/en/evaluation-tools/nucleo-f401re.html
+   https://www.st.com/en/evaluation-tools/nucleo-f401re.html
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf
 
 .. _STM32F401RE on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f401re.html
+   https://www.st.com/en/microcontrollers/stm32f401re.html
 
 .. _STM32F401 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00096844.pdf
+   https://www.st.com/resource/en/reference_manual/dm00096844.pdf

--- a/boards/arm/nucleo_f410rb/doc/index.rst
+++ b/boards/arm/nucleo_f410rb/doc/index.rst
@@ -200,13 +200,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo F410RB website:
-   http://www.st.com/en/evaluation-tools/nucleo-F410RB.html
+   https://www.st.com/en/evaluation-tools/nucleo-F410RB.html
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf
 
 .. _STM32F410RB on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f410rb.html
+   https://www.st.com/en/microcontrollers/stm32f410rb.html
 
 .. _STM32F410 reference manual:
    https://www.st.com/resource/en/reference_manual/dm00180366.pdf

--- a/boards/arm/nucleo_f411re/doc/index.rst
+++ b/boards/arm/nucleo_f411re/doc/index.rst
@@ -188,13 +188,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo F411RE website:
-   http://www.st.com/en/evaluation-tools/nucleo-f411re.html
+   https://www.st.com/en/evaluation-tools/nucleo-f411re.html
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf
 
 .. _STM32F411RE on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f411re.html
+   https://www.st.com/en/microcontrollers/stm32f411re.html
 
 .. _STM32F411 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00119316.pdf
+   https://www.st.com/resource/en/reference_manual/dm00119316.pdf

--- a/boards/arm/nucleo_f412zg/doc/index.rst
+++ b/boards/arm/nucleo_f412zg/doc/index.rst
@@ -160,13 +160,13 @@ This interface is supported by the openocd version included in Zephyr SDK.
 
 
 .. _Nucleo F412ZG website:
-   http://www.st.com/en/evaluation-tools/nucleo-f412zg.html
+   https://www.st.com/en/evaluation-tools/nucleo-f412zg.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00244518.pdf
+   https://www.st.com/resource/en/user_manual/dm00244518.pdf
 
 .. _STM32F412ZG on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f412zg.html
+   https://www.st.com/en/microcontrollers/stm32f412zg.html
 
 .. _STM32F412 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00180369.pdf
+   https://www.st.com/resource/en/reference_manual/dm00180369.pdf

--- a/boards/arm/nucleo_f413zh/doc/index.rst
+++ b/boards/arm/nucleo_f413zh/doc/index.rst
@@ -162,13 +162,13 @@ This interface is supported by the openocd version included in Zephyr SDK.
 
 
 .. _Nucleo F413ZH website:
-   http://www.st.com/en/evaluation-tools/nucleo-f413zh.html
+   https://www.st.com/en/evaluation-tools/nucleo-f413zh.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00244518.pdf
+   https://www.st.com/resource/en/user_manual/dm00244518.pdf
 
 .. _STM32F413ZH on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f413zh.html
+   https://www.st.com/en/microcontrollers/stm32f413zh.html
 
 .. _STM32F413/423 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00305666.pdf
+   https://www.st.com/resource/en/reference_manual/dm00305666.pdf

--- a/boards/arm/nucleo_f429zi/doc/index.rst
+++ b/boards/arm/nucleo_f429zi/doc/index.rst
@@ -199,19 +199,19 @@ A specific application can adjust each partition size based on its needs.
 
 
 .. _Nucleo F429ZI website:
-   http://www.st.com/en/evaluation-tools/nucleo-f429zi.html
+   https://www.st.com/en/evaluation-tools/nucleo-f429zi.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00244518.pdf
+   https://www.st.com/resource/en/user_manual/dm00244518.pdf
 
 .. _STM32F429ZI on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f429zi.html
+   https://www.st.com/en/microcontrollers/stm32f429zi.html
 
 .. _STM32F429 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00031020.pdf
+   https://www.st.com/resource/en/reference_manual/dm00031020.pdf
 
 .. _STM32F429 datasheet:
-   http://www.st.com/resource/en/datasheet/DM00071990.pdf
+   https://www.st.com/resource/en/datasheet/DM00071990.pdf
 
 .. _MCUBoot:
    https://github.com/JuulLabs-OSS/mcuboot/blob/master/README.md

--- a/boards/arm/nucleo_f446re/doc/index.rst
+++ b/boards/arm/nucleo_f446re/doc/index.rst
@@ -211,16 +211,16 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo F446RE website:
-   http://www.st.com/en/evaluation-tools/nucleo-f446re.html
+   https://www.st.com/en/evaluation-tools/nucleo-f446re.html
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf
 
 .. _STM32F446RE on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f446re.html
+   https://www.st.com/en/microcontrollers/stm32f446re.html
 
 .. _STM32F446 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00135183.pdf
+   https://www.st.com/resource/en/reference_manual/dm00135183.pdf
 
 .. _RS485 CAN Shield:
    https://www.waveshare.com/wiki/RS485_CAN_Shield

--- a/boards/arm/nucleo_f446ze/doc/index.rst
+++ b/boards/arm/nucleo_f446ze/doc/index.rst
@@ -236,13 +236,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo F446ZE website:
-   http://www.st.com/en/evaluation-tools/nucleo-f446ze.html
+   https://www.st.com/en/evaluation-tools/nucleo-f446ze.html
 
 .. _STM32 Nucleo-144 board User Manual:
    https://www.st.com/resource/en/user_manual/um1974-stm32-nucleo144-boards-mb1137-stmicroelectronics.pdf
 
 .. _STM32F446ZE on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f446ze.html
+   https://www.st.com/en/microcontrollers/stm32f446ze.html
 
 .. _STM32F446 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00135183.pdf
+   https://www.st.com/resource/en/reference_manual/dm00135183.pdf

--- a/boards/arm/nucleo_f746zg/doc/index.rst
+++ b/boards/arm/nucleo_f746zg/doc/index.rst
@@ -226,7 +226,7 @@ You can debug an application in the usual way.  Here is an example for the
    https://www.st.com/en/evaluation-tools/nucleo-f746zg.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00244518.pdf
+   https://www.st.com/resource/en/user_manual/dm00244518.pdf
 
 .. _STM32F746ZG on www.st.com:
    https://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32-high-performance-mcus/stm32f7-series/stm32f7x6/stm32f746zg.html

--- a/boards/arm/nucleo_f756zg/doc/index.rst
+++ b/boards/arm/nucleo_f756zg/doc/index.rst
@@ -209,7 +209,7 @@ You can debug an application in the usual way.  Here is an example for the
    https://www.st.com/en/evaluation-tools/nucleo-f756zg.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf
 
 .. _STM32F756ZG on www.st.com:
    https://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32-high-performance-mcus/stm32f7-series/stm32f7x6/stm32f756zg.html

--- a/boards/arm/nucleo_f767zi/doc/index.rst
+++ b/boards/arm/nucleo_f767zi/doc/index.rst
@@ -227,7 +227,7 @@ You can debug an application in the usual way.  Here is an example for the
    https://www.st.com/en/evaluation-tools/nucleo-f767zi.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00244518.pdf
+   https://www.st.com/resource/en/user_manual/dm00244518.pdf
 
 .. _STM32f767zi on www.st.com:
    https://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32-high-performance-mcus/stm32f7-series/stm32f7x&/stm32f767zi.html

--- a/boards/arm/nucleo_g031k8/doc/index.rst
+++ b/boards/arm/nucleo_g031k8/doc/index.rst
@@ -159,7 +159,7 @@ References
 .. target-notes::
 
 .. _Nucleo G031K8 website:
-   http://www.st.com/en/evaluation-tools/nucleo-g031k8.html
+   https://www.st.com/en/evaluation-tools/nucleo-g031k8.html
 
 .. _STM32G0x1 reference manual:
    https://www.st.com/resource/en/reference_manual/rm0444-stm32g0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf

--- a/boards/arm/nucleo_g031k8/support/openocd.cfg
+++ b/boards/arm/nucleo_g031k8/support/openocd.cfg
@@ -1,5 +1,5 @@
 # This is an ST NUCLEO-G031K8 board with single STM32G031K8 chip.
-# http://www.st.com/en/evaluation-tools/nucleo-g031k8.html
+# https://www.st.com/en/evaluation-tools/nucleo-g031k8.html
 
 source [find interface/stlink-dap.cfg]
 

--- a/boards/arm/nucleo_g070rb/doc/index.rst
+++ b/boards/arm/nucleo_g070rb/doc/index.rst
@@ -182,10 +182,10 @@ References
 .. target-notes::
 
 .. _Nucleo G070RB website:
-   http://www.st.com/en/evaluation-tools/nucleo-g070rb.html
+   https://www.st.com/en/evaluation-tools/nucleo-g070rb.html
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00452640.pdf
+   https://www.st.com/resource/en/user_manual/dm00452640.pdf
 
 .. _G070RB on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32g070rb.html
+   https://www.st.com/en/microcontrollers/stm32g070rb.html

--- a/boards/arm/nucleo_g071rb/doc/index.rst
+++ b/boards/arm/nucleo_g071rb/doc/index.rst
@@ -186,13 +186,13 @@ References
 .. target-notes::
 
 .. _Nucleo G071RB website:
-   http://www.st.com/en/evaluation-tools/nucleo-g071rb.html
+   https://www.st.com/en/evaluation-tools/nucleo-g071rb.html
 
 .. _STM32G071 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00371828.pdf
+   https://www.st.com/resource/en/reference_manual/dm00371828.pdf
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00452640.pdf
+   https://www.st.com/resource/en/user_manual/dm00452640.pdf
 
 .. _G071RB on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32g071rb.html
+   https://www.st.com/en/microcontrollers/stm32g071rb.html

--- a/boards/arm/nucleo_g0b1re/doc/index.rst
+++ b/boards/arm/nucleo_g0b1re/doc/index.rst
@@ -195,13 +195,13 @@ References
 .. target-notes::
 
 .. _Nucleo G0B1RE website:
-   http://www.st.com/en/evaluation-tools/nucleo-g0b1re.html
+   https://www.st.com/en/evaluation-tools/nucleo-g0b1re.html
 
 .. _STM32G0B1 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00371828.pdf
+   https://www.st.com/resource/en/reference_manual/dm00371828.pdf
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00452640.pdf
+   https://www.st.com/resource/en/user_manual/dm00452640.pdf
 
 .. _G0B1RE on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32g0b1re.html
+   https://www.st.com/en/microcontrollers/stm32g0b1re.html

--- a/boards/arm/nucleo_g431rb/doc/index.rst
+++ b/boards/arm/nucleo_g431rb/doc/index.rst
@@ -249,13 +249,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo G431RB website:
-   http://www.st.com/en/evaluation-tools/nucleo-g431rb.html
+   https://www.st.com/en/evaluation-tools/nucleo-g431rb.html
 
 .. _STM32G4 Nucleo-64 board User Manual:
    https://www.st.com/resource/en/user_manual/dm00556337.pdf
 
 .. _STM32G431RB on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32g431rb.html
+   https://www.st.com/en/microcontrollers/stm32g431rb.html
 
 .. _STM32G4 reference manual:
    https://www.st.com/resource/en/reference_manual/dm00355726.pdf

--- a/boards/arm/nucleo_g474re/doc/index.rst
+++ b/boards/arm/nucleo_g474re/doc/index.rst
@@ -239,13 +239,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo G474RE website:
-   http://www.st.com/en/evaluation-tools/nucleo-g474re.html
+   https://www.st.com/en/evaluation-tools/nucleo-g474re.html
 
 .. _STM32G4 Nucleo-64 board User Manual:
    https://www.st.com/resource/en/user_manual/dm00556337.pdf
 
 .. _STM32G474RE on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32g474re.html
+   https://www.st.com/en/microcontrollers/stm32g474re.html
 
 .. _STM32G4 reference manual:
    https://www.st.com/resource/en/reference_manual/dm00355726.pdf

--- a/boards/arm/nucleo_h563zi/doc/index.rst
+++ b/boards/arm/nucleo_h563zi/doc/index.rst
@@ -308,7 +308,7 @@ You can debug an application in the usual way.  Here is an example for the
    https://www.st.com/resource/en/user_manual/um3115-stm32h5-nucleo144-board-mb1404-stmicroelectronics.pdf
 
 .. _STM32H563ZI on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32h563zi.html
+   https://www.st.com/en/microcontrollers/stm32h563zi.html
 
 .. _STM32H563 reference manual:
    https://www.st.com/resource/en/reference_manual/rm0481-stm32h563h573-and-stm32h562-armbased-32bit-mcus-stmicroelectronics.pdf

--- a/boards/arm/nucleo_h743zi/doc/index.rst
+++ b/boards/arm/nucleo_h743zi/doc/index.rst
@@ -237,7 +237,7 @@ You can debug an application in the usual way.  Here is an example for the
    https://www.st.com/en/evaluation-tools/nucleo-h743zi.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00244518.pdf
+   https://www.st.com/resource/en/user_manual/dm00244518.pdf
 
 .. _STM32H743ZI on www.st.com:
    https://www.st.com/content/st_com/en/products/microcontrollers-microprocessors/stm32-32-bit-arm-cortex-mcus/stm32-high-performance-mcus/stm32h7-series/stm32h743-753/stm32h743zi.html

--- a/boards/arm/nucleo_h753zi/doc/index.rst
+++ b/boards/arm/nucleo_h753zi/doc/index.rst
@@ -224,7 +224,7 @@ You can debug an application in the usual way.  Here is an example for the
    https://www.st.com/en/evaluation-tools/nucleo-h753zi.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00244518.pdf
+   https://www.st.com/resource/en/user_manual/dm00244518.pdf
 
 .. _STM32H753ZI on www.st.com:
    https://www.st.com/content/st_com/en/products/microcontrollers-microprocessors/stm32-32-bit-arm-cortex-mcus/stm32-high-performance-mcus/stm32h7-series/stm32h743-753/stm32h753zi.html

--- a/boards/arm/nucleo_l011k4/doc/index.rst
+++ b/boards/arm/nucleo_l011k4/doc/index.rst
@@ -158,7 +158,7 @@ References
 .. target-notes::
 
 .. _Nucleo L011K4 website:
-   http://www.st.com/en/evaluation-tools/nucleo-l011k4.html
+   https://www.st.com/en/evaluation-tools/nucleo-l011k4.html
 
 .. _STM32L0x1 reference manual:
    https://www.st.com/resource/en/reference_manual/dm00108282-ultralowpower-stm32l0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf

--- a/boards/arm/nucleo_l011k4/support/openocd.cfg
+++ b/boards/arm/nucleo_l011k4/support/openocd.cfg
@@ -1,5 +1,5 @@
 # This is an ST NUCLEO-L011K4 board with single STM32L011K4 chip.
-# http://www.st.com/en/evaluation-tools/nucleo-l011k4.html
+# https://www.st.com/en/evaluation-tools/nucleo-l011k4.html
 source [find interface/stlink.cfg]
 
 transport select hla_swd

--- a/boards/arm/nucleo_l031k6/doc/index.rst
+++ b/boards/arm/nucleo_l031k6/doc/index.rst
@@ -151,7 +151,7 @@ References
 .. target-notes::
 
 .. _Nucleo L031K6 website:
-   http://www.st.com/en/evaluation-tools/nucleo-l031k6.html
+   https://www.st.com/en/evaluation-tools/nucleo-l031k6.html
 
 .. _STM32L0x1 reference manual:
    https://www.st.com/resource/en/reference_manual/dm00108282-ultralowpower-stm32l0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf

--- a/boards/arm/nucleo_l031k6/support/openocd.cfg
+++ b/boards/arm/nucleo_l031k6/support/openocd.cfg
@@ -1,5 +1,5 @@
 # This is an ST NUCLEO-L031K6 board with single STM32L031K6 chip.
-# http://www.st.com/en/evaluation-tools/nucleo-l031k6.html
+# https://www.st.com/en/evaluation-tools/nucleo-l031k6.html
 source [find interface/stlink.cfg]
 
 transport select hla_swd

--- a/boards/arm/nucleo_l053r8/doc/index.rst
+++ b/boards/arm/nucleo_l053r8/doc/index.rst
@@ -167,10 +167,10 @@ References
 .. target-notes::
 
 .. _Nucleo L053R8 website:
-   http://www.st.com/en/evaluation-tools/nucleo-l053r8.html
+   https://www.st.com/en/evaluation-tools/nucleo-l053r8.html
 
 .. _STM32L0x3 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00095744.pdf
+   https://www.st.com/resource/en/reference_manual/dm00095744.pdf
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf

--- a/boards/arm/nucleo_l053r8/support/openocd.cfg
+++ b/boards/arm/nucleo_l053r8/support/openocd.cfg
@@ -1,5 +1,5 @@
 # This is an ST NUCLEO-L053R8 board with single STM32L053R8 chip.
-# http://www.st.com/en/evaluation-tools/nucleo-l053r8.html
+# https://www.st.com/en/evaluation-tools/nucleo-l053r8.html
 source [find interface/stlink.cfg]
 
 transport select hla_swd

--- a/boards/arm/nucleo_l073rz/doc/index.rst
+++ b/boards/arm/nucleo_l073rz/doc/index.rst
@@ -181,10 +181,10 @@ References
 .. target-notes::
 
 .. _Nucleo L073RZ website:
-   http://www.st.com/en/evaluation-tools/nucleo-l073rz.html
+   https://www.st.com/en/evaluation-tools/nucleo-l073rz.html
 
 .. _STM32L0x3 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00095744.pdf
+   https://www.st.com/resource/en/reference_manual/dm00095744.pdf
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf

--- a/boards/arm/nucleo_l073rz/support/openocd.cfg
+++ b/boards/arm/nucleo_l073rz/support/openocd.cfg
@@ -1,5 +1,5 @@
 # This is an ST NUCLEO-L073RZ board with single STM32L073RZ chip.
-# http://www.st.com/en/evaluation-tools/nucleo-l073rz.html
+# https://www.st.com/en/evaluation-tools/nucleo-l073rz.html
 source [find interface/stlink.cfg]
 
 transport select hla_swd

--- a/boards/arm/nucleo_l432kc/doc/index.rst
+++ b/boards/arm/nucleo_l432kc/doc/index.rst
@@ -217,13 +217,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo L432KC website:
-   http://www.st.com/en/evaluation-tools/nucleo-l432kc.html
+   https://www.st.com/en/evaluation-tools/nucleo-l432kc.html
 
 .. _STM32 Nucleo-32 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00231744.pdf
+   https://www.st.com/resource/en/user_manual/dm00231744.pdf
 
 .. _STM32L432KC on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32l432kc.html
+   https://www.st.com/en/microcontrollers/stm32l432kc.html
 
 .. _STM32L432 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00151940.pdf
+   https://www.st.com/resource/en/reference_manual/dm00151940.pdf

--- a/boards/arm/nucleo_l433rc_p/doc/index.rst
+++ b/boards/arm/nucleo_l433rc_p/doc/index.rst
@@ -222,7 +222,7 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo L433RC-P website:
-   http://www.st.com/en/evaluation-tools/nucleo-l433rc-p.html
+   https://www.st.com/en/evaluation-tools/nucleo-l433rc-p.html
 
 .. _ST Nucleo L433RC-P User Manual:
    https://www.st.com/resource/en/user_manual/dm00387966.pdf

--- a/boards/arm/nucleo_l476rg/doc/index.rst
+++ b/boards/arm/nucleo_l476rg/doc/index.rst
@@ -231,13 +231,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo L476RG website:
-   http://www.st.com/en/evaluation-tools/nucleo-l476rg.html
+   https://www.st.com/en/evaluation-tools/nucleo-l476rg.html
 
 .. _STM32 Nucleo-64 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00105823.pdf
+   https://www.st.com/resource/en/user_manual/dm00105823.pdf
 
 .. _STM32L476RG on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32l476rg.html
+   https://www.st.com/en/microcontrollers/stm32l476rg.html
 
 .. _STM32L476 reference manual:
-   http://www.st.com/resource/en/reference_manual/DM00083560.pdf
+   https://www.st.com/resource/en/reference_manual/DM00083560.pdf

--- a/boards/arm/nucleo_l496zg/doc/index.rst
+++ b/boards/arm/nucleo_l496zg/doc/index.rst
@@ -232,13 +232,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo L496ZG website:
-   http://www.st.com/en/evaluation-tools/nucleo-l496zg.html
+   https://www.st.com/en/evaluation-tools/nucleo-l496zg.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00368330.pdf
+   https://www.st.com/resource/en/user_manual/dm00368330.pdf
 
 .. _STM32L496ZG on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32l496zg.html
+   https://www.st.com/en/microcontrollers/stm32l496zg.html
 
 .. _STM32L496 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00083560.pdf
+   https://www.st.com/resource/en/reference_manual/dm00083560.pdf

--- a/boards/arm/nucleo_l4a6zg/doc/index.rst
+++ b/boards/arm/nucleo_l4a6zg/doc/index.rst
@@ -231,13 +231,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo L4A6ZG website:
-   http://www.st.com/en/evaluation-tools/nucleo-l4a6zg.html
+   https://www.st.com/en/evaluation-tools/nucleo-l4a6zg.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00368330.pdf
+   https://www.st.com/resource/en/user_manual/dm00368330.pdf
 
 .. _STM32L4A6ZG on www.st.com:
-   http://www.st.com/en/microcontrollers-microprocessors/stm32l4a6zg.html
+   https://www.st.com/en/microcontrollers-microprocessors/stm32l4a6zg.html
 
 .. _STM32L4A6 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00083560.pdf
+   https://www.st.com/resource/en/reference_manual/dm00083560.pdf

--- a/boards/arm/nucleo_l4r5zi/doc/index.rst
+++ b/boards/arm/nucleo_l4r5zi/doc/index.rst
@@ -243,16 +243,16 @@ You should see the following message on the console:
    Hello World! arm
 
 .. _Nucleo L4R5ZI website:
-   http://www.st.com/en/evaluation-tools/nucleo-l4r5zi.html
+   https://www.st.com/en/evaluation-tools/nucleo-l4r5zi.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00368330.pdf
+   https://www.st.com/resource/en/user_manual/dm00368330.pdf
 
 .. _STM32L4R5ZI on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32l4r5zi.html
+   https://www.st.com/en/microcontrollers/stm32l4r5zi.html
 
 .. _STM32L4R5 reference manual:
-   http://www.st.com/resource/en/reference_manual/DM00310109.pdf
+   https://www.st.com/resource/en/reference_manual/DM00310109.pdf
 
 .. _STM32 ST-LINK utility:
-   http://www.st.com/content/st_com/en/products/development-tools/software-development-tools/stm32-software-development-tools/stm32-programmers/stsw-link004.html
+   https://www.st.com/content/st_com/en/products/development-tools/software-development-tools/stm32-software-development-tools/stm32-programmers/stsw-link004.html

--- a/boards/arm/nucleo_l552ze_q/doc/nucleol552ze_q.rst
+++ b/boards/arm/nucleo_l552ze_q/doc/nucleol552ze_q.rst
@@ -370,16 +370,16 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Nucleo L552ZE Q website:
-   http://www.st.com/en/evaluation-tools/nucleo-l552ze-q.html
+   https://www.st.com/en/evaluation-tools/nucleo-l552ze-q.html
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00615305.pdf
+   https://www.st.com/resource/en/user_manual/dm00615305.pdf
 
 .. _STM32L552ZE on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32l552ze.html
+   https://www.st.com/en/microcontrollers/stm32l552ze.html
 
 .. _STM32L552 reference manual:
-   http://www.st.com/resource/en/reference_manual/DM00346336.pdf
+   https://www.st.com/resource/en/reference_manual/DM00346336.pdf
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html

--- a/boards/arm/nucleo_u575zi_q/doc/index.rst
+++ b/boards/arm/nucleo_u575zi_q/doc/index.rst
@@ -328,10 +328,10 @@ Note: Check the ``build/tfm`` directory to ensure that the commands required by 
 (which is used for initialization) is available in the PATH.
 
 .. _STM32 Nucleo-144 board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00615305.pdf
+   https://www.st.com/resource/en/user_manual/dm00615305.pdf
 
 .. _STM32U575ZI on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32u575zi.html
+   https://www.st.com/en/microcontrollers/stm32u575zi.html
 
 .. _STM32U575 reference manual:
    https://www.st.com/resource/en/reference_manual/rm0456-stm32u575585-armbased-32bit-mcus-stmicroelectronics.pdf

--- a/boards/arm/olimex_stm32_e407/doc/index.rst
+++ b/boards/arm/olimex_stm32_e407/doc/index.rst
@@ -375,4 +375,4 @@ way.  Here is an example for the :ref:`hello_world` application.
    https://www.olimex.com/Products/ARM/ST/STM32-E407/resources/STM32-E407.pdf
 
 .. _ST STM32F407ZG Datasheet:
-   http://www.st.com/resource/en/reference_manual/dm00031020.pdf
+   https://www.st.com/resource/en/reference_manual/dm00031020.pdf

--- a/boards/arm/olimex_stm32_h407/doc/index.rst
+++ b/boards/arm/olimex_stm32_h407/doc/index.rst
@@ -372,4 +372,4 @@ way.  Here is an example for the :ref:`hello_world` application.
    https://www.olimex.com/Products/ARM/ST/STM32-H407/resources/STM32-H407.pdf
 
 .. _ST STM32F407ZG Datasheet:
-   http://www.st.com/resource/en/reference_manual/dm00031020.pdf
+   https://www.st.com/resource/en/reference_manual/dm00031020.pdf

--- a/boards/arm/olimex_stm32_p405/doc/index.rst
+++ b/boards/arm/olimex_stm32_p405/doc/index.rst
@@ -260,4 +260,4 @@ You can debug an application in the usual way.  Here is an example for the
    https://www.olimex.com/Products/ARM/ST/STM32-P405/resources/STM32-P405_UM.pdf
 
 .. _ST STM32F405RG Datasheet:
-   http://www.st.com/resource/en/reference_manual/dm00031020.pdf
+   https://www.st.com/resource/en/reference_manual/dm00031020.pdf

--- a/boards/arm/olimexino_stm32/doc/index.rst
+++ b/boards/arm/olimexino_stm32/doc/index.rst
@@ -458,7 +458,7 @@ serial adapter is required. This tutorial uses the
    https://www.olimex.com/Products/Duino/STM32/OLIMEXINO-STM32/resources/OLIMEXINO-STM32.pdf
 
 .. _ST STM32F103xB Datasheet:
-   http://www.st.com/resource/en/datasheet/stm32f103tb.pdf
+   https://www.st.com/resource/en/datasheet/stm32f103tb.pdf
 
 .. _stm32flash tool:
    https://sourceforge.net/p/stm32flash/wiki/Home/

--- a/boards/arm/pandora_stm32l475/support/openocd.cfg
+++ b/boards/arm/pandora_stm32l475/support/openocd.cfg
@@ -1,5 +1,5 @@
 # Explicitly for the STM32L475 Pandora board:
-# http://www.st.com/web/en/catalog/tools/PF261635
+# https://www.st.com/web/en/catalog/tools/PF261635
 # but perfectly functional for any other STM32L4 board connected via
 # an stlink-v2-1 interface.
 # This is for STM32L4 boards that are connected via stlink-v2-1.

--- a/boards/arm/sensortile_box/doc/index.rst
+++ b/boards/arm/sensortile_box/doc/index.rst
@@ -197,7 +197,7 @@ References
    https://www.st.com/en/evaluation-tools/steval-mksbox1v1.html
 
 .. _AN2606:
-   http://www.st.com/content/ccc/resource/technical/document/application_note/b9/9b/16/3a/12/1e/40/0c/CD00167594.pdf/files/CD00167594.pdf/jcr:content/translations/en.CD00167594.pdf
+   https://www.st.com/content/ccc/resource/technical/document/application_note/b9/9b/16/3a/12/1e/40/0c/CD00167594.pdf/files/CD00167594.pdf/jcr:content/translations/en.CD00167594.pdf
 
 .. _DFU-UTIL website:
    http://dfu-util.sourceforge.net/

--- a/boards/arm/steval_fcu001v1/doc/index.rst
+++ b/boards/arm/steval_fcu001v1/doc/index.rst
@@ -155,4 +155,4 @@ You can debug an application in the usual way. Here is an example for the
    https://www.st.com/en/microcontrollers-microprocessors/stm32f401cc.html
 
 .. _STM32F401 reference manual:
-    http://www.st.com/resource/en/reference_manual/dm00096844.pdf
+    https://www.st.com/resource/en/reference_manual/dm00096844.pdf

--- a/boards/arm/stm3210c_eval/doc/index.rst
+++ b/boards/arm/stm3210c_eval/doc/index.rst
@@ -159,7 +159,7 @@ References
 .. target-notes::
 
 .. _STM3210C-EVAL website:
-   http://www.st.com/en/evaluation-tools/stm3210c-eval.html
+   https://www.st.com/en/evaluation-tools/stm3210c-eval.html
 
 .. _STM32F107VCT reference manual:
-   http://www.st.com/resource/en/reference_manual/CD00171190.pdf
+   https://www.st.com/resource/en/reference_manual/CD00171190.pdf

--- a/boards/arm/stm32373c_eval/doc/index.rst
+++ b/boards/arm/stm32373c_eval/doc/index.rst
@@ -153,7 +153,7 @@ References
 .. target-notes::
 
 .. _STM32373C-EVAL website:
-   http://www.st.com/en/evaluation-tools/stm32373c-eval.html
+   https://www.st.com/en/evaluation-tools/stm32373c-eval.html
 
 .. _STM32F373VCT6 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00041563.pdf
+   https://www.st.com/resource/en/reference_manual/dm00041563.pdf

--- a/boards/arm/stm32_min_dev/doc/index.rst
+++ b/boards/arm/stm32_min_dev/doc/index.rst
@@ -181,6 +181,6 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _STM32F103x8:
-        http://www.st.com/resource/en/datasheet/stm32f103c8.pdf
+        https://www.st.com/resource/en/datasheet/stm32f103c8.pdf
 .. _EmbedJournal:
         https://embedjournal.com/tag/stm32-min-dev/

--- a/boards/arm/stm32f072_eval/doc/index.rst
+++ b/boards/arm/stm32f072_eval/doc/index.rst
@@ -179,7 +179,7 @@ You can debug an application in the usual way.  Here is an example for the
 
 
 .. _STM32F072VB on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f072vb.html
+   https://www.st.com/en/microcontrollers/stm32f072vb.html
 
 .. _STM32F072 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00031936.pdf
+   https://www.st.com/resource/en/reference_manual/dm00031936.pdf

--- a/boards/arm/stm32f072b_disco/doc/index.rst
+++ b/boards/arm/stm32f072b_disco/doc/index.rst
@@ -203,17 +203,17 @@ References
 .. target-notes::
 
 .. _STM32F072B-DISCO website:
-   http://www.st.com/en/evaluation-tools/32f072bdiscovery.html
+   https://www.st.com/en/evaluation-tools/32f072bdiscovery.html
 
 
 .. _STM32F072B-DISCO board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00099401.pdf
+   https://www.st.com/resource/en/user_manual/dm00099401.pdf
 
 .. _STM32F072RB on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f072rb.html
+   https://www.st.com/en/microcontrollers/stm32f072rb.html
 
 .. _STM32F072xB reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00031936.pdf
+   https://www.st.com/resource/en/reference_manual/dm00031936.pdf
 
 .. _SK Pang CAN breakout board:
    https://www.skpang.co.uk/products/can-bus-can-fd-breakout-board-5v-supply-and-5v-logic

--- a/boards/arm/stm32f0_disco/doc/index.rst
+++ b/boards/arm/stm32f0_disco/doc/index.rst
@@ -134,10 +134,10 @@ References
 .. target-notes::
 
 .. _STM32F0DISCOVERY website:
-   http://www.st.com/en/evaluation-tools/stm32f0discovery.html
+   https://www.st.com/en/evaluation-tools/stm32f0discovery.html
 
 .. _STM32F0x8 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00031936.pdf
+   https://www.st.com/resource/en/reference_manual/dm00031936.pdf
 
 .. _STM32F0DISCOVERY board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00050135.pdf
+   https://www.st.com/resource/en/user_manual/dm00050135.pdf

--- a/boards/arm/stm32f103_mini/doc/index.rst
+++ b/boards/arm/stm32f103_mini/doc/index.rst
@@ -160,7 +160,7 @@ References
 .. target-notes::
 
 .. _STM32F103 reference manual:
-   http://www.st.com/resource/en/reference_manual/cd00171190.pdf
+   https://www.st.com/resource/en/reference_manual/cd00171190.pdf
 
 .. _STM32F103 data sheet:
-   http://www.st.com/resource/en/datasheet/stm32f103rc.pdf
+   https://www.st.com/resource/en/datasheet/stm32f103rc.pdf

--- a/boards/arm/stm32f3_disco/doc/index.rst
+++ b/boards/arm/stm32f3_disco/doc/index.rst
@@ -269,13 +269,13 @@ Again you have to use the adapted command for newer PCB revisions (E and newer):
    :goals: debug
 
 .. _STM32F3DISCOVERY website:
-   http://www.st.com/en/evaluation-tools/stm32f3discovery.html
+   https://www.st.com/en/evaluation-tools/stm32f3discovery.html
 
 .. _STM32F3DISCOVERY board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00063382.pdf
+   https://www.st.com/resource/en/user_manual/dm00063382.pdf
 
 .. _STM32F303VC on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f303vc.html
+   https://www.st.com/en/microcontrollers/stm32f303vc.html
 
 .. _STM32F303xC reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00043574.pdf
+   https://www.st.com/resource/en/reference_manual/dm00043574.pdf

--- a/boards/arm/stm32f3_seco_d23/doc/index.rst
+++ b/boards/arm/stm32f3_seco_d23/doc/index.rst
@@ -236,7 +236,7 @@ You should see the following message on the console:
    https://www.seco.com/Manuals/SBC-D23_Manual.pdf
 
 .. _STM32F302VC on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f302vc.html
+   https://www.st.com/en/microcontrollers/stm32f302vc.html
 
 .. _STM32F302xC reference manual:
    https://www.st.com/resource/en/reference_manual/rm0365-stm32f302xbcde-and-stm32f302x68-advanced-armbased-32bit-mcus-stmicroelectronics.pdf

--- a/boards/arm/stm32f411e_disco/doc/index.rst
+++ b/boards/arm/stm32f411e_disco/doc/index.rst
@@ -176,13 +176,13 @@ References
 .. target-notes::
 
 .. _32F411EDISCOVERY website:
-   http://www.st.com/en/evaluation-tools/32f411ediscovery.html
+   https://www.st.com/en/evaluation-tools/32f411ediscovery.html
 
 .. _32F411EDISCOVERY board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00148985.pdf
+   https://www.st.com/resource/en/user_manual/dm00148985.pdf
 
 .. _STM32F411VE website:
-   http://www.st.com/en/microcontrollers/stm32f411ve.html
+   https://www.st.com/en/microcontrollers/stm32f411ve.html
 
 .. _STM32F411x reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00119316.pdf
+   https://www.st.com/resource/en/reference_manual/dm00119316.pdf

--- a/boards/arm/stm32f412g_disco/doc/index.rst
+++ b/boards/arm/stm32f412g_disco/doc/index.rst
@@ -190,13 +190,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _32F412GDISCOVERY website:
-   http://www.st.com/en/evaluation-tools/32f412gdiscovery.html
+   https://www.st.com/en/evaluation-tools/32f412gdiscovery.html
 
 .. _32F412GDISCOVERY board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00275919.pdf
+   https://www.st.com/resource/en/user_manual/dm00275919.pdf
 
 .. _STM32F412ZG on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f412zg.html
+   https://www.st.com/en/microcontrollers/stm32f412zg.html
 
 .. _STM32F412 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00180369.pdf
+   https://www.st.com/resource/en/reference_manual/dm00180369.pdf

--- a/boards/arm/stm32f429i_disc1/doc/index.rst
+++ b/boards/arm/stm32f429i_disc1/doc/index.rst
@@ -196,13 +196,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _STM32F429I-DISC1 website:
-   http://www.st.com/en/evaluation-tools/32f429idiscovery.html
+   https://www.st.com/en/evaluation-tools/32f429idiscovery.html
 
 .. _STM32F429I-DISC1 board User Manual:
-   http://www.st.com/web/en/resource/technical/document/user_manual/DM00097320.pdf
+   https://www.st.com/web/en/resource/technical/document/user_manual/DM00097320.pdf
 
 .. _STM32F429ZI on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f429-439.html
+   https://www.st.com/en/microcontrollers/stm32f429-439.html
 
 .. _STM32F429 Reference Manual:
-   http://www.st.com/content/ccc/resource/technical/document/reference_manual/3d/6d/5a/66/b4/99/40/d4/DM00031020.pdf/files/DM00031020.pdf/jcr:content/translations/en.DM00031020.pdf
+   https://www.st.com/content/ccc/resource/technical/document/reference_manual/3d/6d/5a/66/b4/99/40/d4/DM00031020.pdf/files/DM00031020.pdf/jcr:content/translations/en.DM00031020.pdf

--- a/boards/arm/stm32f469i_disco/doc/index.rst
+++ b/boards/arm/stm32f469i_disco/doc/index.rst
@@ -196,13 +196,13 @@ You can debug an application in the usual way.  Here is an example for the
 
 
 .. _32F469IDISCOVERY website:
-   http://www.st.com/en/evaluation-tools/32f469idiscovery.html
+   https://www.st.com/en/evaluation-tools/32f469idiscovery.html
 
 .. _32F469IDISCOVERY board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00218846.pdf
+   https://www.st.com/resource/en/user_manual/dm00218846.pdf
 
 .. _STM32F469NI on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f469ni.html
+   https://www.st.com/en/microcontrollers/stm32f469ni.html
 
 .. _STM32F469 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00127514.pdf
+   https://www.st.com/resource/en/reference_manual/dm00127514.pdf

--- a/boards/arm/stm32f4_disco/doc/index.rst
+++ b/boards/arm/stm32f4_disco/doc/index.rst
@@ -199,16 +199,16 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _STM32F4DISCOVERY website:
-   http://www.st.com/en/evaluation-tools/stm32f4discovery.html
+   https://www.st.com/en/evaluation-tools/stm32f4discovery.html
 
 .. _STM32F4DISCOVERY board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00039084.pdf
+   https://www.st.com/resource/en/user_manual/dm00039084.pdf
 
 .. _STM32F407VG on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f407vg.html
+   https://www.st.com/en/microcontrollers/stm32f407vg.html
 
 .. _STM32F407 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00031020.pdf
+   https://www.st.com/resource/en/reference_manual/dm00031020.pdf
 
 .. _SK Pang CAN breakout board:
    https://www.skpang.co.uk/products/can-bus-can-fd-breakout-board-5v-supply-and-3-3v-logic

--- a/boards/arm/stm32f723e_disco/doc/index.rst
+++ b/boards/arm/stm32f723e_disco/doc/index.rst
@@ -180,13 +180,13 @@ You can debug an application in the usual way.  Here is an example for the
 
 
 .. _32F723E-DISCO website:
-   http://www.st.com/en/evaluation-tools/32f723ediscovery.html
+   https://www.st.com/en/evaluation-tools/32f723ediscovery.html
 
 .. _32F723E-DISCO board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00342318.pdf
+   https://www.st.com/resource/en/user_manual/dm00342318.pdf
 
 .. _STM32F723IEK6 on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32f723ie.html
+   https://www.st.com/en/microcontrollers/stm32f723ie.html
 
 .. _STM32F72xxx reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00305990.pdf
+   https://www.st.com/resource/en/reference_manual/dm00305990.pdf

--- a/boards/arm/stm32f746g_disco/doc/index.rst
+++ b/boards/arm/stm32f746g_disco/doc/index.rst
@@ -231,13 +231,13 @@ You can debug an application in the usual way.  Here is an example for the
 
 
 .. _32F746G-DISCO website:
-   http://www.st.com/en/evaluation-tools/32f746gdiscovery.html
+   https://www.st.com/en/evaluation-tools/32f746gdiscovery.html
 
 .. _32F746G-DISCO board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00190424.pdf
+   https://www.st.com/resource/en/user_manual/dm00190424.pdf
 
 .. _STM32F746NGH6 on www.st.com:
-   http://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32-high-performance-mcus/stm32f7-series/stm32f7x6/stm32f746ng.html
+   https://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32-high-performance-mcus/stm32f7-series/stm32f7x6/stm32f746ng.html
 
 .. _STM32F74xxx reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00124865.pdf
+   https://www.st.com/resource/en/reference_manual/dm00124865.pdf

--- a/boards/arm/stm32f7508_dk/doc/index.rst
+++ b/boards/arm/stm32f7508_dk/doc/index.rst
@@ -226,13 +226,13 @@ You can debug an application in the usual way.  Here is an example for the
 
 
 .. _32F7508-DK website:
-   http://www.st.com/en/evaluation-tools/stm32f7508-dk.html
+   https://www.st.com/en/evaluation-tools/stm32f7508-dk.html
 
 .. _32F7508-DK board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00537062-discovery-kit-for-stm32f7-series-with-stm32f750n8-mcu-stmicroelectronics.pdf
+   https://www.st.com/resource/en/user_manual/dm00537062-discovery-kit-for-stm32f7-series-with-stm32f750n8-mcu-stmicroelectronics.pdf
 
 .. _STM32F750x8 on www.st.com:
    https://www.st.com/resource/en/datasheet/stm32f750z8.pdf
 
 .. _STM32F74xxx reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00124865.pdf
+   https://www.st.com/resource/en/reference_manual/dm00124865.pdf

--- a/boards/arm/stm32f769i_disco/doc/index.rst
+++ b/boards/arm/stm32f769i_disco/doc/index.rst
@@ -213,13 +213,13 @@ You can debug an application in the usual way.  Here is an example for the
 
 
 .. _32F769I-DISCO website:
-   http://www.st.com/en/evaluation-tools/32f769idiscovery.html
+   https://www.st.com/en/evaluation-tools/32f769idiscovery.html
 
 .. _32F769I-DISCO board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00276557.pdf
+   https://www.st.com/resource/en/user_manual/dm00276557.pdf
 
 .. _STM32F769NIH6 on www.st.com:
 	https://www.st.com/content/st_com/en/products/microcontrollers/stm32-32-bit-arm-cortex-mcus/stm32-high-performance-mcus/stm32f7-series/stm32f7x9/stm32f769ni.html
 
 .. _STM32F76xxx reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00224583.pdf
+   https://www.st.com/resource/en/reference_manual/dm00224583.pdf

--- a/boards/arm/stm32g071b_disco/doc/index.rst
+++ b/boards/arm/stm32g071b_disco/doc/index.rst
@@ -160,10 +160,10 @@ References
    https://www.st.com/en/evaluation-tools/stm32g071b-disco.html
 
 .. _STM32G071 reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00371828.pdf
+   https://www.st.com/resource/en/reference_manual/dm00371828.pdf
 
 .. _STM32G0 Discovery board User Manual:
    https://www.st.com/resource/en/user_manual/dm00496511.pdf
 
 .. _G071RB on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32g071rb.html
+   https://www.st.com/en/microcontrollers/stm32g071rb.html

--- a/boards/arm/stm32g081b_eval/doc/index.rst
+++ b/boards/arm/stm32g081b_eval/doc/index.rst
@@ -204,4 +204,4 @@ References
    https://www.st.com/resource/en/user_manual/um2403-evaluation-board-with-stm32g081rb-mcu-stmicroelectronics.pdf
 
 .. _G081RB on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32g081rb.html
+   https://www.st.com/en/microcontrollers/stm32g081rb.html

--- a/boards/arm/stm32h747i_disco/doc/index.rst
+++ b/boards/arm/stm32h747i_disco/doc/index.rst
@@ -281,13 +281,13 @@ In order to debug a Zephyr application on Cortex M4 side, you can use
 `STM32CubeIDE`_.
 
 .. _STM32H747I-DISCO website:
-   http://www.st.com/en/evaluation-tools/stm32h747i-disco.html
+   https://www.st.com/en/evaluation-tools/stm32h747i-disco.html
 
 .. _STM32H747XI on www.st.com:
    https://www.st.com/content/st_com/en/products/microcontrollers-microprocessors/stm32-32-bit-arm-cortex-mcus/stm32-high-performance-mcus/stm32h7-series/stm32h747-757/stm32h747xi.html
 
 .. _STM32H747xx reference manual:
-   http://www.st.com/resource/en/reference_manual/dm00176879.pdf
+   https://www.st.com/resource/en/reference_manual/dm00176879.pdf
 
 .. _STM32H747xx datasheet:
    https://www.st.com/resource/en/datasheet/stm32h747xi.pdf

--- a/boards/arm/stm32l476g_disco/doc/index.rst
+++ b/boards/arm/stm32l476g_disco/doc/index.rst
@@ -206,13 +206,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _STM32L476G Discovery website:
-   http://www.st.com/en/evaluation-tools/32l476gdiscovery.html
+   https://www.st.com/en/evaluation-tools/32l476gdiscovery.html
 
 .. _STM32L476G Discovery board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00172179.pdf
+   https://www.st.com/resource/en/user_manual/dm00172179.pdf
 
 .. _STM32L476VG on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32l476vg.html
+   https://www.st.com/en/microcontrollers/stm32l476vg.html
 
 .. _STM32L476 reference manual:
-   http://www.st.com/resource/en/reference_manual/DM00083560.pdf
+   https://www.st.com/resource/en/reference_manual/DM00083560.pdf

--- a/boards/arm/stm32l496g_disco/doc/index.rst
+++ b/boards/arm/stm32l496g_disco/doc/index.rst
@@ -247,13 +247,13 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _STM32L496G Discovery website:
-   http://www.st.com/en/evaluation-tools/32l496gdiscovery.html
+   https://www.st.com/en/evaluation-tools/32l496gdiscovery.html
 
 .. _STM32L496G Discovery board User Manual:
-   http://www.st.com/resource/en/user_manual/dm00353127.pdf
+   https://www.st.com/resource/en/user_manual/dm00353127.pdf
 
 .. _STM32L496AG on www.st.com:
-   http://www.st.com/en/microcontrollers/stm32l496ag.html
+   https://www.st.com/en/microcontrollers/stm32l496ag.html
 
 .. _STM32L496 reference manual:
-   http://www.st.com/resource/en/reference_manual/DM00083560.pdf
+   https://www.st.com/resource/en/reference_manual/DM00083560.pdf

--- a/boards/arm/stm32l562e_dk/doc/index.rst
+++ b/boards/arm/stm32l562e_dk/doc/index.rst
@@ -381,7 +381,7 @@ You can debug an application in the usual way.  Here is an example for the
    https://www.st.com/en/microcontrollers/stm32l562qe.html
 
 .. _STM32L562 reference manual:
-   http://www.st.com/resource/en/reference_manual/DM00346336.pdf
+   https://www.st.com/resource/en/reference_manual/DM00346336.pdf
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html

--- a/boards/shields/x_nucleo_idb05a1/doc/index.rst
+++ b/boards/shields/x_nucleo_idb05a1/doc/index.rst
@@ -95,7 +95,7 @@ References
 .. target-notes::
 
 .. _X-NUCLEO-IDB05A1 website:
-   http://www.st.com/en/ecosystems/x-nucleo-idb05a1.html
+   https://www.st.com/en/ecosystems/x-nucleo-idb05a1.html
 
 .. _X-NUCLEO-IDB05A1 databrief:
    https://www.st.com/resource/en/data_brief/x-nucleo-idb05a1.pdf

--- a/boards/shields/x_nucleo_iks01a1/doc/index.rst
+++ b/boards/shields/x_nucleo_iks01a1/doc/index.rst
@@ -54,7 +54,7 @@ References
 .. target-notes::
 
 .. _X-NUCLEO-IKS01A1 website:
-   http://www.st.com/en/ecosystems/x-nucleo-iks01a1.html
+   https://www.st.com/en/ecosystems/x-nucleo-iks01a1.html
 
 .. _X-NUCLEO-IKS01A1 data sheet:
-   http://www.st.com/resource/en/datasheet/x-nucleo-iks01a1.pdf
+   https://www.st.com/resource/en/datasheet/x-nucleo-iks01a1.pdf

--- a/boards/shields/x_nucleo_iks01a2/doc/index.rst
+++ b/boards/shields/x_nucleo_iks01a2/doc/index.rst
@@ -98,7 +98,7 @@ References
 .. target-notes::
 
 .. _X-NUCLEO-IKS01A2 website:
-   http://www.st.com/en/ecosystems/x-nucleo-iks01a2.html
+   https://www.st.com/en/ecosystems/x-nucleo-iks01a2.html
 
 .. _X-NUCLEO-IKS01A2 databrief:
-   http://www.st.com/resource/en/data_brief/x-nucleo-iks01a2.pdf
+   https://www.st.com/resource/en/data_brief/x-nucleo-iks01a2.pdf

--- a/boards/shields/x_nucleo_iks01a3/doc/index.rst
+++ b/boards/shields/x_nucleo_iks01a3/doc/index.rst
@@ -95,7 +95,7 @@ References
 .. target-notes::
 
 .. _X-NUCLEO-IKS01A3 website:
-   http://www.st.com/en/ecosystems/x-nucleo-iks01a3.html
+   https://www.st.com/en/ecosystems/x-nucleo-iks01a3.html
 
 .. _X-NUCLEO-IKS01A3 user manual:
    https://www.st.com/resource/en/user_manual/dm00601501.pdf

--- a/boards/shields/x_nucleo_iks02a1/doc/index.rst
+++ b/boards/shields/x_nucleo_iks02a1/doc/index.rst
@@ -97,7 +97,7 @@ References
 .. target-notes::
 
 .. _X-NUCLEO-IKS02A1 website:
-   http://www.st.com/en/ecosystems/x-nucleo-iks02a1.html
+   https://www.st.com/en/ecosystems/x-nucleo-iks02a1.html
 
 .. _X-NUCLEO-IKS02A1 user manual:
    https://www.st.com/resource/en/user_manual/DM00651686.pdf

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -28,9 +28,9 @@ LOG_MODULE_REGISTER(VL53L0X, CONFIG_SENSOR_LOG_LEVEL);
 
 /* All the values used in this driver are coming from ST datasheet and examples.
  * It can be found here:
- *   http://www.st.com/en/embedded-software/stsw-img005.html
+ *   https://www.st.com/en/embedded-software/stsw-img005.html
  * There are also examples of use in the L4 cube FW:
- *   http://www.st.com/en/embedded-software/stm32cubel4.html
+ *   https://www.st.com/en/embedded-software/stm32cubel4.html
  */
 #define VL53L0X_INITIAL_ADDR                    0x29
 #define VL53L0X_REG_WHO_AM_I                    0xC0

--- a/samples/sensor/hts221/README.rst
+++ b/samples/sensor/hts221/README.rst
@@ -17,7 +17,7 @@ This sample uses the HTS221 sensor controlled using the I2C interface.
 References
 **********
 
- - HTS211: http://www.st.com/en/mems-and-sensors/hts221.html
+ - HTS211: https://www.st.com/en/mems-and-sensors/hts221.html
 
 Building and Running
 ********************

--- a/samples/sensor/lis2dh/README.rst
+++ b/samples/sensor/lis2dh/README.rst
@@ -20,7 +20,7 @@ References
 **********
 
 For more information about the LIS2DH motion sensor see
-http://www.st.com/en/mems-and-sensors/lis2dh.html.
+https://www.st.com/en/mems-and-sensors/lis2dh.html.
 
 Building and Running
 ********************

--- a/samples/sensor/lps22hb/README.rst
+++ b/samples/sensor/lps22hb/README.rst
@@ -17,7 +17,7 @@ This sample uses the LPS22HB sensor controlled using the I2C interface.
 References
 **********
 
-- LPS22HB: http://www.st.com/en/mems-and-sensors/lps22hb.html
+- LPS22HB: https://www.st.com/en/mems-and-sensors/lps22hb.html
 
 Building and Running
 ********************

--- a/samples/sensor/lps22hh/README.rst
+++ b/samples/sensor/lps22hh/README.rst
@@ -17,7 +17,7 @@ This sample uses the LPS22HH sensor controlled using the I2C interface.
 References
 **********
 
-- LPS22HH: http://www.st.com/en/mems-and-sensors/lps22hh.html
+- LPS22HH: https://www.st.com/en/mems-and-sensors/lps22hh.html
 
 Building and Running
 ********************

--- a/samples/sensor/lps22hh_i3c/README.rst
+++ b/samples/sensor/lps22hh_i3c/README.rst
@@ -18,7 +18,7 @@ STEVALMKI192-V1 connected to the I3C header on :ref:`mimxrt685_evk`.
 References
 **********
 
-- LPS22HH: http://www.st.com/en/mems-and-sensors/lps22hh.html
+- LPS22HH: https://www.st.com/en/mems-and-sensors/lps22hh.html
 
 Building and Running
 ********************

--- a/samples/sensor/lsm303dlhc/README.rst
+++ b/samples/sensor/lsm303dlhc/README.rst
@@ -20,7 +20,7 @@ References
 **********
 
 For more information about the LSM303DLHC eCompass module, see
-http://www.st.com/en/mems-and-sensors/lsm303dlhc.html
+https://www.st.com/en/mems-and-sensors/lsm303dlhc.html
 
 Building and Running
 ********************

--- a/samples/sensor/lsm6dsl/README.rst
+++ b/samples/sensor/lsm6dsl/README.rst
@@ -20,7 +20,7 @@ It has been tested on both :ref:`96b_argonkey` and disco_l475_iot1 board.
 References
 **********
 
-- LSM6DSL http://www.st.com/en/mems-and-sensors/lsm6dsl.html
+- LSM6DSL https://www.st.com/en/mems-and-sensors/lsm6dsl.html
 
 Building and Running
 ********************

--- a/samples/sensor/lsm6dso/README.rst
+++ b/samples/sensor/lsm6dso/README.rst
@@ -18,7 +18,7 @@ It has been tested on the :ref:`stm32l562e_dk_board`.
 References
 **********
 
-- LSM6DSO http://www.st.com/en/mems-and-sensors/lsm6dso.html
+- LSM6DSO https://www.st.com/en/mems-and-sensors/lsm6dso.html
 
 Building and Running
 ********************

--- a/samples/sensor/lsm6dso_i2c_on_i3c/README.rst
+++ b/samples/sensor/lsm6dso_i2c_on_i3c/README.rst
@@ -20,7 +20,7 @@ on :ref:`mimxrt685_evk`.
 References
 **********
 
-- LSM6DSO http://www.st.com/en/mems-and-sensors/lsm6dso.html
+- LSM6DSO https://www.st.com/en/mems-and-sensors/lsm6dso.html
 
 Building and Running
 ********************

--- a/samples/sensor/vl53l0x/README.rst
+++ b/samples/sensor/vl53l0x/README.rst
@@ -18,7 +18,7 @@ This sample uses the VL53L0X sensor controlled using the I2C interface.
 References
 **********
 
- - VL53L0X: http://www.st.com/en/imaging-and-photonics-solutions/vl53l0x.html
+ - VL53L0X: https://www.st.com/en/imaging-and-photonics-solutions/vl53l0x.html
 
 Building and Running
 ********************

--- a/samples/shields/x_nucleo_iks01a1/README.rst
+++ b/samples/shields/x_nucleo_iks01a1/README.rst
@@ -28,7 +28,7 @@ does not yet support sensors multiple instances.
 References
 **********
 
--X-NUCLEO-IKS01A1: http://www.st.com/en/ecosystems/x-nucleo-iks01a1.html
+-X-NUCLEO-IKS01A1: https://www.st.com/en/ecosystems/x-nucleo-iks01a1.html
 
 Building and Running
 ********************

--- a/samples/shields/x_nucleo_iks01a2/sensorhub/README.rst
+++ b/samples/shields/x_nucleo_iks01a2/sensorhub/README.rst
@@ -36,7 +36,7 @@ does not yet support sensors multiple instances.
 References
 **********
 
--X-NUCLEO-IKS01A2: http://www.st.com/en/ecosystems/x-nucleo-iks01a2.html
+-X-NUCLEO-IKS01A2: https://www.st.com/en/ecosystems/x-nucleo-iks01a2.html
 
 Building and Running
 ********************

--- a/samples/shields/x_nucleo_iks01a2/standard/README.rst
+++ b/samples/shields/x_nucleo_iks01a2/standard/README.rst
@@ -32,7 +32,7 @@ does not yet support sensors multiple instances.
 References
 **********
 
--X-NUCLEO-IKS01A2: http://www.st.com/en/ecosystems/x-nucleo-iks01a2.html
+-X-NUCLEO-IKS01A2: https://www.st.com/en/ecosystems/x-nucleo-iks01a2.html
 
 Building and Running
 ********************

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/README.rst
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/README.rst
@@ -46,7 +46,7 @@ as sensors multiple instances are not supported.
 References
 **********
 
-- X-NUCLEO-IKS01A3: http://www.st.com/en/ecosystems/x-nucleo-iks01a3.html
+- X-NUCLEO-IKS01A3: https://www.st.com/en/ecosystems/x-nucleo-iks01a3.html
 
 Building and Running
 ********************

--- a/samples/shields/x_nucleo_iks01a3/standard/README.rst
+++ b/samples/shields/x_nucleo_iks01a3/standard/README.rst
@@ -39,7 +39,7 @@ as sensors multiple instances are not supported.
 References
 **********
 
-- X-NUCLEO-IKS01A3: http://www.st.com/en/ecosystems/x-nucleo-iks01a3.html
+- X-NUCLEO-IKS01A3: https://www.st.com/en/ecosystems/x-nucleo-iks01a3.html
 
 Building and Running
 ********************

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/README.rst
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/README.rst
@@ -41,7 +41,7 @@ as sensors multiple instances are not supported.
 References
 **********
 
-- X-NUCLEO-IKS02A1: http://www.st.com/en/ecosystems/x-nucleo-iks02a1.html
+- X-NUCLEO-IKS02A1: https://www.st.com/en/ecosystems/x-nucleo-iks02a1.html
 
 Building and Running
 ********************

--- a/samples/shields/x_nucleo_iks02a1/standard/README.rst
+++ b/samples/shields/x_nucleo_iks02a1/standard/README.rst
@@ -36,7 +36,7 @@ as sensors multiple instances are not supported.
 References
 **********
 
-- X-NUCLEO-IKS02A1: http://www.st.com/en/ecosystems/x-nucleo-iks02a1.html
+- X-NUCLEO-IKS02A1: https://www.st.com/en/ecosystems/x-nucleo-iks02a1.html
 
 Building and Running
 ********************


### PR DESCRIPTION
While recent browsers seem to transparently try to use https when hitting http://www.st.com/... URLs, they are effectively not working anymore, so use https://www.st.com/... URLs instead. And it's a good practice anyway to promote secure links vs. plain http.

```
curl http://www.st.com/en/evaluation-tools/nucleo-g070rb.html -m 5 -v
*   Trying 104.89.117.48:80...
* Connected to www.st.com (104.89.117.48) port 80 (#0)
> GET /en/evaluation-tools/nucleo-g070rb.html HTTP/1.1
> Host: www.st.com
> User-Agent: curl/8.1.2
> Accept: */*
> 
* Operation timed out after 5002 milliseconds with 0 bytes received
* Closing connection 0
curl: (28) Operation timed out after 5002 milliseconds with 0 bytes received
```