### PR TITLE
Bluetooth: Mesh: make mesh1.1 prov pts tests passable with btp tester

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/shell.rst
+++ b/doc/connectivity/bluetooth/api/mesh/shell.rst
@@ -297,7 +297,7 @@ To allow a device to provision devices over GATT, the :kconfig:option:`CONFIG_BT
 	* ``String``: Unquoted alphanumeric authentication string.
 
 
-``mesh prov static-oob [Val(1-16 hex)]``
+``mesh prov static-oob [Val(1-32 hex)]``
 ----------------------------------------
 
 	Set or clear the static OOB authentication value. The static OOB authentication value must be set before provisioning starts to have any effect. The static OOB value must be same on both participants in the provisioning. To enable this command, the :kconfig:option:`BT_MESH_SHELL_PROV_CTX_INSTANCE` option must be enabled.
@@ -358,7 +358,7 @@ To allow a device to provision devices over GATT, the :kconfig:option:`CONFIG_BT
 ------------------------------------------------
 	From the provisioner device, instruct the unprovisioned device to use static OOB authentication, and use the given static authentication value when provisioning.
 
-	* ``Val`` - Static OOB value. Providing a hex-string shorter than 16 bytes will populate the N most significant bytes of the array and zero-pad the rest.
+	* ``Val`` - Static OOB value. Providing a hex-string shorter than 32 bytes will populate the N most significant bytes of the array and zero-pad the rest.
 
 ``mesh prov auth-method none``
 ------------------------------

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -181,12 +181,6 @@ int bt_mesh_prov_auth(bool is_provisioner, uint8_t method, uint8_t action, uint8
 	uint8_t auth_size = bt_mesh_prov_auth_size_get();
 	int err;
 
-	if (IS_ENABLED(CONFIG_BT_MESH_OOB_AUTH_REQUIRED) &&
-	    (method == AUTH_METHOD_NO_OOB ||
-	    bt_mesh_prov_link.algorithm == BT_MESH_PROV_AUTH_CMAC_AES128_AES_CCM)) {
-		return -EINVAL;
-	}
-
 	switch (method) {
 	case AUTH_METHOD_NO_OOB:
 		if (action || size) {

--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -183,9 +183,14 @@ static void prov_start(const uint8_t *data)
 	}
 
 	if (atomic_test_bit(bt_mesh_prov_link.flags, OOB_STATIC_KEY)) {
-		memcpy(bt_mesh_prov_link.auth + auth_size - bt_mesh_prov->static_val_len,
-			bt_mesh_prov->static_val, bt_mesh_prov->static_val_len);
-		memset(bt_mesh_prov_link.auth, 0, auth_size - bt_mesh_prov->static_val_len);
+
+		uint8_t tail_size = bt_mesh_prov->static_val_len < auth_size
+					    ? auth_size - bt_mesh_prov->static_val_len
+					    : 0;
+
+		memcpy(bt_mesh_prov_link.auth + tail_size, bt_mesh_prov->static_val,
+		       tail_size ? bt_mesh_prov->static_val_len : auth_size);
+		memset(bt_mesh_prov_link.auth, 0, tail_size);
 	}
 }
 

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -611,7 +611,7 @@ static void link_close(bt_mesh_prov_bearer_t bearer)
 	shell_print_ctx("Provisioning link closed on %s", bearer2str(bearer));
 }
 
-static uint8_t static_val[16];
+static uint8_t static_val[32];
 
 struct bt_mesh_prov bt_mesh_shell_prov = {
 	.uuid = dev_uuid,
@@ -645,7 +645,7 @@ static int cmd_static_oob(const struct shell *sh, size_t argc, char *argv[])
 		bt_mesh_shell_prov.static_val_len = 0U;
 	} else {
 		bt_mesh_shell_prov.static_val_len = hex2bin(argv[1], strlen(argv[1]),
-					      static_val, 16);
+					      static_val, 32);
 		if (bt_mesh_shell_prov.static_val_len) {
 			bt_mesh_shell_prov.static_val = static_val;
 		} else {
@@ -886,7 +886,7 @@ static int cmd_auth_method_set_output(const struct shell *sh, size_t argc, char 
 static int cmd_auth_method_set_static(const struct shell *sh, size_t argc, char *argv[])
 {
 	size_t len;
-	uint8_t static_oob_auth[16];
+	uint8_t static_oob_auth[32];
 	int err = 0;
 
 	len = hex2bin(argv[1], strlen(argv[1]), static_oob_auth, sizeof(static_oob_auth));

--- a/tests/bluetooth/tester/src/btp/btp_mesh.h
+++ b/tests/bluetooth/tester/src/btp/btp_mesh.h
@@ -30,9 +30,15 @@ struct btp_mesh_read_supported_commands_rp {
 
 #define BTP_MESH_CONFIG_PROVISIONING		0x02
 
+#if IS_ENABLED(CONFIG_BT_MESH_ECDH_P256_HMAC_SHA256_AES_CCM)
+#define BTP_MESH_PROV_AUTH_MAX_LEN   32
+#else
+#define BTP_MESH_PROV_AUTH_MAX_LEN   16
+#endif
+
 struct btp_mesh_config_provisioning_cmd {
 	uint8_t uuid[16];
-	uint8_t static_auth[16];
+	uint8_t static_auth[BTP_MESH_PROV_AUTH_MAX_LEN];
 	uint8_t out_size;
 	uint16_t out_actions;
 	uint8_t in_size;
@@ -41,7 +47,7 @@ struct btp_mesh_config_provisioning_cmd {
 } __packed;
 struct btp_mesh_config_provisioning_cmd_v2 {
 	uint8_t uuid[16];
-	uint8_t static_auth[16];
+	uint8_t static_auth[BTP_MESH_PROV_AUTH_MAX_LEN];
 	uint8_t out_size;
 	uint16_t out_actions;
 	uint8_t in_size;

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -43,7 +43,7 @@ static uint8_t priv_key[32];
 
 /* Configured provisioning data */
 static uint8_t dev_uuid[16];
-static uint8_t static_auth[16];
+static uint8_t static_auth[BTP_MESH_PROV_AUTH_MAX_LEN];
 
 /* Vendor Model data */
 #define VND_MODEL_ID_1 0x1234


### PR DESCRIPTION
PR adds:
1. Ability to accept and trim static oob value if it is longer than required.(specification requirement) 
2. Support 32 bytes static oob in shell
3. Refactor oob mandating feature to handle this feature independently in provisioner and provisionee.
4. Support 32 bytes static oob value in btp to pass mesh-1.1 pts tests (requires support in auto pts site too)