### PR TITLE
boards: nrf9160dk_nrf52840: Add missing inclusion

### DIFF
--- a/boards/arm/nrf9160dk_nrf52840/board.c
+++ b/boards/arm/nrf9160dk_nrf52840/board.c
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/logging/log.h>
+#include <soc.h>
 #include <hal/nrf_gpio.h>
 
 LOG_MODULE_REGISTER(board_control, CONFIG_BOARD_NRF9160DK_LOG_LEVEL);


### PR DESCRIPTION
This code uses the `NRF_DT_GPIOS_TO_PSEL` macro, so it should include `<soc.h>` explicitly and not rely on the header being included by some other one.

This should fix the build error occurring for `nrf9160dk_nrf52840` in #57086.