### PR TITLE
tests/drivers/flash common: Allow on nrf52_bsim

### DIFF
--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -41,6 +41,7 @@ tests:
       - it8xxx2_evb
       - mimxrt685_evk_cm33
       - mimxrt595_evk_cm33
+      - nrf52_bsim
   drivers.flash.common.tfm_ns:
     build_only: true
     filter: (CONFIG_FLASH_HAS_DRIVER_ENABLED and CONFIG_TRUSTED_EXECUTION_NONSECURE


### PR DESCRIPTION
903a79431aefed48bc1c918a7fca14b7a96444bb
seems to have attempted to limit how many platforms this test runs due to issues in some platforms.
But how it was done (using platform allow apart from integration platform) it prevents it running on other platforms in which it works.
Add the nrf52_bsim target to this allow list so the test can be run on it too.