### PR TITLE
gecko: Fix sdid for xg27 part

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -225,7 +225,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 32f35f1b3763b4d31021c656ff7cd4e7b192a97c
+      revision: 6a4521e5934d2e787f782b9e5370f3206e6cc9d2
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Please see the original slcc sdid value:
https://github.com/SiliconLabs/gecko_sdk/blob/gsdk_4.3/platform/Device/component/efr32bg27c140f768im40.slcc#L70