### PR TITLE
smbus: Detect IRQ and simplify IRQ flags generation

### DIFF
--- a/drivers/smbus/intel_pch_smbus.c
+++ b/drivers/smbus/intel_pch_smbus.c
@@ -1005,10 +1005,10 @@ static void smbus_isr(const struct device *dev)
 
 /* Device macro initialization  / DTS hackery */
 
-#define SMBUS_PCH_IRQ_FLAGS_SENSE0(n) 0
-#define SMBUS_PCH_IRQ_FLAGS_SENSE1(n) DT_INST_IRQ(n, sense)
-#define SMBUS_PCH_IRQ_FLAGS(n) \
-	_CONCAT(SMBUS_PCH_IRQ_FLAGS_SENSE, DT_INST_IRQ_HAS_CELL(n, sense))(n)
+#define SMBUS_PCH_IRQ_FLAGS(n)                                                 \
+	COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, sense),                            \
+		    (DT_INST_IRQ(n, sense)),                                   \
+		    (0))
 
 #define SMBUS_IRQ_CONFIG(n)                                                    \
 	BUILD_ASSERT(IS_ENABLED(CONFIG_DYNAMIC_INTERRUPTS),                    \

--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -57,7 +57,7 @@
 			#size-cells = <0>;
 			vendor-id = <0x8086>;
 			device-id = <0x54a3>;
-			interrupts = <16 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -204,7 +204,7 @@
 			#size-cells = <0>;
 			vendor-id = <0x8086>;
 			device-id = <0x4b23>;
-			interrupts = <16 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";

--- a/dts/x86/intel/raptor_lake.dtsi
+++ b/dts/x86/intel/raptor_lake.dtsi
@@ -56,7 +56,7 @@
 			#size-cells = <0>;
 			vendor-id = <0x8086>;
 			device-id = <0x7a23>;
-			interrupts = <18 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
+			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
 			status = "okay";


### PR DESCRIPTION
Simplify IRQ flags using `COND_CODE_1` and detect IRQ.