### PR TITLE
doc: sphinx.util.progress_message is deprecated

### DIFF
--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -44,7 +44,7 @@ from sphinx.domains import Domain, ObjType
 from sphinx.environment import BuildEnvironment
 from sphinx.errors import ExtensionError
 from sphinx.roles import XRefRole
-from sphinx.util import progress_message
+from sphinx.util.display import progress_message
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import make_refnode
 


### PR DESCRIPTION
As of Sphinx 6.1, sphinx.util.progress_message is deprecated and sphinx.util.display.progress_message should be used instead.
 
See https://www.sphinx-doc.org/en/master/changes.html#id165