### PR TITLE
drivers: clock_control: stm32: add an option to enable CRS for HSI48

### DIFF
--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -61,6 +61,7 @@
 
 &clk_hsi48 {
 	status = "okay";
+	crs-usb-sof;
 };
 
 &pll {

--- a/drivers/clock_control/clock_stm32g0.c
+++ b/drivers/clock_control/clock_stm32g0.c
@@ -9,6 +9,7 @@
 
 #include <soc.h>
 #include <stm32_ll_bus.h>
+#include <stm32_ll_crs.h>
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_utils.h>
 #include <zephyr/drivers/clock_control.h>
@@ -74,4 +75,18 @@ void config_enable_default_clocks(void)
 {
 	/* Enable the power interface clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+
+#if defined(CRS)
+	if (IS_ENABLED(STM32_HSI48_CRS_USB_SOF)) {
+		LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_CRS);
+		/*
+		 * After reset the CRS configuration register
+		 * (CRS_CFGR) value corresponds to an USB SOF
+		 * synchronization.  FIXME: write it anyway.
+		 */
+		LL_CRS_EnableAutoTrimming();
+		LL_CRS_EnableFreqErrorCounter();
+	}
+#endif /* defined(CRS) */
+
 }

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -14,7 +14,7 @@
 		clocks {
 			clk_hsi48: clk-hsi48 {
 				#clock-cells = <0>;
-				compatible = "fixed-clock";
+				compatible = "st,stm32-hsi48-clock";
 				clock-frequency = <DT_FREQ_M(48)>;
 				status = "disabled";
 			};

--- a/dts/bindings/clock/st,stm32-hsi48-clock.yaml
+++ b/dts/bindings/clock/st,stm32-hsi48-clock.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023, Aurelien Jarno
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32 HSI48 Clock
+
+compatible: "st,stm32-hsi48-clock"
+
+include: [fixed-clock.yaml]
+
+properties:
+  crs-usb-sof:
+    type: boolean
+    description: |
+      Clock Recovery System using USB SOF packet reception
+      Set the property to enable clock recovery of the HSI48 oscillator using
+      the USB SOF packet reception as a reference.

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -385,6 +385,10 @@
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi48), fixed_clock, okay)
 #define STM32_HSI48_ENABLED	1
 #define STM32_HSI48_FREQ	DT_PROP(DT_NODELABEL(clk_hsi48), clock_frequency)
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi48), st_stm32_hsi48_clock, okay)
+#define STM32_HSI48_ENABLED	1
+#define STM32_HSI48_FREQ	DT_PROP(DT_NODELABEL(clk_hsi48), clock_frequency)
+#define STM32_HSI48_CRS_USB_SOF	DT_PROP(DT_NODELABEL(clk_hsi48), crs_usb_sof)
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(perck), st_stm32_clock_mux, okay)


### PR DESCRIPTION
for nucleo_stm32g0b1 board.
the HSI48 clock is the clock used by default for the USB controller, however its default tolerance is not enough for the USB specification, leading to some random errors depending on many factors, including the upstream HUB or host.

this commit adds an option in the device tree to enable the STM32 Clock recovery system (CRS) using USB SOF packet reception as a reference, which brings the HSI48 within the required accuracy for USB transfers.