### PR TITLE
drivers: pinctrl: fix multiple issues

### DIFF
--- a/boards/arm/mimxrt1062_fmurt6/mimxrt1062_fmurt6-pinctrl.dtsi
+++ b/boards/arm/mimxrt1062_fmurt6/mimxrt1062_fmurt6-pinctrl.dtsi
@@ -59,20 +59,6 @@
 		};
 	};
 
-	pinmux_sensor: pinmux_sensor {
-		group0	{
-			pinmux = <&iomuxc_gpio_emc_13_gpio4_io13>,
-				<&iomuxc_gpio_emc_09_gpio4_io09>,
-				<&iomuxc_gpio_emc_06_gpio4_io06>,
-				<&iomuxc_gpio_emc_41_gpio3_io27>,
-				<&iomuxc_gpio_ad_b0_00_gpio1_io00>,
-				<&iomuxc_snvs_pmic_on_req_gpio5_io01>;
-			drive-strength = "r0-7";
-			bias-pull-up;
-			slew-rate = "fast";
-		};
-	};
-
 	pinmux_flexcan1: pinmux_flexcan1 {
 		group0 {
 			pinmux = <&iomuxc_gpio_ad_b1_08_flexcan1_tx>,

--- a/boards/arm/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/arm/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -51,8 +51,6 @@
 
 	/* This regulator controls VDD_3V3_SD_CARD onboard supply */
 	reg-3v3-sdcard {
-		pinctrl-0 = <&pinmux_sensor>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-3v3-sdcard";
 		enable-gpios = <&gpio4 13 GPIO_ACTIVE_HIGH>;
@@ -62,8 +60,6 @@
 
 	/* This regulator controls VDD_5V_PERIPH onboard supply */
 	reg-5v-periph {
-		pinctrl-0 = <&pinmux_sensor>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-5v-periph";
 		enable-gpios = <&gpio4 9 GPIO_ACTIVE_LOW>;
@@ -73,8 +69,6 @@
 
 	/* This regulator controls VDD_5V_HIPOWER onboard supply */
 	reg-5v-hipower {
-		pinctrl-0 = <&pinmux_sensor>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-5v-hipower";
 		enable-gpios = <&gpio4 6 GPIO_ACTIVE_LOW>;
@@ -84,8 +78,6 @@
 
 	/* This regulator controls the 3V3_S line, which powers sensors on-board. */
 	reg-3v3-sensor {
-		pinctrl-0 = <&pinmux_sensor>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-3v3-sensor";
 		enable-gpios = <&gpio3 27 GPIO_ACTIVE_HIGH>;
@@ -96,8 +88,6 @@
 
 	/* This regulator controls VDD_3V3_SPEKTRUM onboard supply */
 	reg-3v3-spektrum {
-		pinctrl-0 = <&pinmux_sensor>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-3v3-spektrum";
 		enable-gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
@@ -107,8 +97,6 @@
 
 	/* This regulator controls ETH_VDD_3V3 supply to power up the TJA1103 PHY */
 	reg-eth-power {
-		pinctrl-0 = <&pinmux_sensor>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-eth-power";
 		enable-gpios = <&gpio5 1 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
+++ b/boards/arm/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
@@ -9,24 +9,6 @@
 #include <nxp/nxp_imx/rt/mimxrt1176dvmaa-pinctrl.dtsi>
 
 &pinctrl {
-
-
-	pinmux_regulator: pinmux_regulator {
-		group0	{
-			pinmux = <&iomuxc_gpio_emc_b1_34_gpio_mux2_io02>,
-				<&iomuxc_gpio_emc_b1_37_gpio_mux2_io05>,
-				<&iomuxc_gpio_emc_b1_33_gpio_mux2_io01>,
-				<&iomuxc_gpio_emc_b1_22_gpio_mux1_io22>,
-				<&iomuxc_gpio_emc_b1_14_gpio_mux1_io14>,
-				<&iomuxc_gpio_emc_b1_36_gpio_mux2_io04>,
-				<&iomuxc_gpio_emc_b1_38_gpio_mux2_io06>,
-				<&iomuxc_gpio_emc_b1_01_gpio_mux1_io01>,
-				<&iomuxc_gpio_disp_b2_08_gpio_mux5_io09>;
-			bias-pull-up;
-			slew-rate = "fast";
-		};
-	};
-
 	pinmux_enet: pinmux_enet {
 		group0 {
 			pinmux = <&iomuxc_gpio_disp_b2_09_gpio_mux5_io10>,

--- a/boards/arm/vmu_rt1170/vmu_rt1170.dts
+++ b/boards/arm/vmu_rt1170/vmu_rt1170.dts
@@ -36,8 +36,6 @@
 
 	/* This regulator controls VDD_3V3_SD_CARD onboard supply */
 	reg-3v3-sdcard {
-		pinctrl-0 = <&pinmux_regulator>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-3v3-sdcard";
 		enable-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
@@ -47,8 +45,6 @@
 
 	/* This regulator controls VDD_5V_PERIPH onboard supply */
 	reg-5v-periph {
-		pinctrl-0 = <&pinmux_regulator>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-5v-periph";
 		enable-gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
@@ -58,8 +54,6 @@
 
 	/* This regulator controls VDD_5V_HIPOWER onboard supply */
 	reg-5v-hipower {
-		pinctrl-0 = <&pinmux_regulator>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-5v-hipower";
 		enable-gpios = <&gpio2 5 GPIO_ACTIVE_LOW>;
@@ -69,8 +63,6 @@
 
 	/* This regulator controls the VDD_3V3_SENSORS1 onboard supply. */
 	reg-3v3-sensors-1 {
-		pinctrl-0 = <&pinmux_regulator>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-3v3-sensors-1";
 		enable-gpios = <&gpio2 1 GPIO_ACTIVE_HIGH>;
@@ -81,8 +73,6 @@
 
 	/* This regulator controls the VDD_3V3_SENSORS2 onboard supply. */
 	reg-3v3-sensors-2 {
-		pinctrl-0 = <&pinmux_regulator>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-3v3-sensors-2";
 		enable-gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
@@ -93,8 +83,6 @@
 
 	/* This regulator controls the VDD_3V3_SENSORS3 onboard supply. */
 	reg-3v3-sensors-3 {
-		pinctrl-0 = <&pinmux_regulator>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-3v3-sensors-3";
 		enable-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
@@ -105,8 +93,6 @@
 
 	/* This regulator controls the VDD_3V3_SENSORS4 onboard supply. */
 	reg-3v3-sensors-4 {
-		pinctrl-0 = <&pinmux_regulator>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-3v3-sensors-4";
 		enable-gpios = <&gpio2 4 GPIO_ACTIVE_HIGH>;
@@ -117,8 +103,6 @@
 
 	/* This regulator controls VDD_3V3_SPEKTRUM onboard supply */
 	reg-3v3-spektrum {
-		pinctrl-0 = <&pinmux_regulator>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-3v3-spektrum";
 		enable-gpios = <&gpio2 6 GPIO_ACTIVE_HIGH>;
@@ -128,8 +112,6 @@
 
 	/* This regulator controls ETH_VDD_3V3 supply to power up the TJA1103 PHY */
 	reg-eth-power {
-		pinctrl-0 = <&pinmux_regulator>;
-		pinctrl-names = "default";
 		compatible = "regulator-fixed";
 		regulator-name = "reg-eth-power";
 		enable-gpios = <&gpio5 9 GPIO_ACTIVE_HIGH>;

--- a/dts/bindings/dac/nxp,lpdac.yaml
+++ b/dts/bindings/dac/nxp,lpdac.yaml
@@ -5,7 +5,7 @@ description: NXP MCUX LPDAC
 
 compatible: "nxp,lpdac"
 
-include: dac-controller.yaml
+include: [dac-controller.yaml, pinctrl-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/i2c/sifive,i2c0.yaml
+++ b/dts/bindings/i2c/sifive,i2c0.yaml
@@ -5,7 +5,7 @@ description: SiFive Freedom I2C interface
 
 compatible: "sifive,i2c0"
 
-include: i2c-controller.yaml
+include: [i2c-controller.yaml, pinctrl-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/i2c/telink,b91-i2c.yaml
+++ b/dts/bindings/i2c/telink,b91-i2c.yaml
@@ -3,7 +3,7 @@
 
 description: Telink B91 I2C
 
-include: i2c-controller.yaml
+include: [i2c-controller.yaml, pinctrl-device.yaml]
 
 compatible: "telink,b91-i2c"
 
@@ -12,5 +12,4 @@ properties:
     required: true
 
   pinctrl-0:
-    type: phandles
     required: true

--- a/dts/bindings/pwm/telink,b91-pwm.yaml
+++ b/dts/bindings/pwm/telink,b91-pwm.yaml
@@ -4,14 +4,13 @@
 
 description: Telink B91 PWM
 
-include: [pwm-controller.yaml, base.yaml]
+include: [pwm-controller.yaml, pinctrl-device.yaml, base.yaml]
 
 compatible: "telink,b91-pwm"
 
 properties:
 
   pinctrl-0:
-    type: phandles
     required: true
 
   clock-frequency:

--- a/dts/bindings/serial/quicklogic,usbserialport_s3b.yaml
+++ b/dts/bindings/serial/quicklogic,usbserialport_s3b.yaml
@@ -5,7 +5,7 @@ description: QuickLogic USBserialport_S3B serial interface
 
 compatible: "quicklogic,usbserialport-s3b"
 
-include: uart-controller.yaml
+include: [uart-controller.yaml, pinctrl-device.yaml]
 
 properties:
   reg:

--- a/dts/bindings/serial/telink,b91-uart.yaml
+++ b/dts/bindings/serial/telink,b91-uart.yaml
@@ -5,7 +5,7 @@ description: Telink B91 UART
 
 compatible: "telink,b91-uart"
 
-include: uart-controller.yaml
+include: [uart-controller.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
@@ -15,5 +15,4 @@ properties:
     required: true
 
   pinctrl-0:
-    type: phandles
     required: true

--- a/dts/bindings/spi/telink,b91-spi.yaml
+++ b/dts/bindings/spi/telink,b91-spi.yaml
@@ -3,7 +3,7 @@
 
 description: Telink B91 SPI
 
-include: spi-controller.yaml
+include: [spi-controller.yaml, pinctrl-device.yaml]
 
 compatible: "telink,b91-spi"
 
@@ -19,7 +19,6 @@ properties:
       - "HSPI_MODULE"
 
   pinctrl-0:
-    type: phandles
     required: true
 
   cs0-pin:

--- a/dts/bindings/test/vnd,adc-temp-sensor.yaml
+++ b/dts/bindings/test/vnd,adc-temp-sensor.yaml
@@ -5,7 +5,7 @@ description: Test ADC-based temperature sensor
 
 compatible: "vnd,adc-temp-sensor"
 
-include: [base.yaml, reset-device.yaml]
+include: [base.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   io-channels:
@@ -18,12 +18,3 @@ properties:
 
   clocks:
     required: true
-
-  pinctrl-0:
-    type: phandles
-
-  pinctrl-1:
-    type: phandles
-
-  pinctrl-2:
-    type: phandles

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1551,7 +1551,6 @@ class Node:
             # Allow a few special properties to not be declared in the binding
             if prop_name.endswith("-controller") or \
                prop_name.startswith("#") or \
-               prop_name.startswith("pinctrl-") or \
                prop_name in {
                    "compatible", "status", "ranges", "phandle",
                    "interrupt-parent", "interrupts-extended", "device_type"}:


### PR DESCRIPTION
- Add missing pinctrl-device.yaml includes
- Remove some invalid pinctrl-N entries
- Enforce usage of pinctrl-device.yaml (has always been documented)