### PR TITLE
modules/MCUboot: Fix missing dependency

### DIFF
--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -192,6 +192,7 @@ config MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
 config MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT
 	bool "MCUboot has been configured for DirectXIP with revert"
 	select MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP
+	select MCUBOOT_BOOTLOADER_MODE_HAS_NO_DOWNGRADE
 	select MCUBOOT_BOOTLOADER_NO_DOWNGRADE
 	help
 	  MCUboot expects slot0_partition and slot1_partition to exist in DT.


### PR DESCRIPTION
The CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP has been missing select of CONFIG_MCUBOOT_BOOTLOADER_MODE_HAS_NO_DOWNGRADE.