### PR TITLE
tests: pm: driver_init: use native_posix

### DIFF
--- a/tests/subsys/pm/device_driver_init/src/main.c
+++ b/tests/subsys/pm/device_driver_init/src/main.c
@@ -27,7 +27,7 @@
 	zassert_equal(rc, 0, "Device state retrieval failed"); \
 	zassert_equal(state, value, "Unexpected device state");
 
-ZTEST(device_driver_init, test_demo)
+ZTEST(device_driver_init, test_device_driver_init)
 {
 #if IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)
 	enum pm_device_state state;

--- a/tests/subsys/pm/device_driver_init/testcase.yaml
+++ b/tests/subsys/pm/device_driver_init/testcase.yaml
@@ -1,16 +1,15 @@
+common:
+  platform_allow:
+    - native_posix
+  tags:
+    - pm
 tests:
-  pm.device_driver_init:
-    tags: pm
-    platform_allow: qemu_cortex_m3
+  pm.device_driver_init: {}
   pm.device_driver_init.pm:
-    tags: pm
-    platform_allow: qemu_cortex_m3
     extra_configs:
       - CONFIG_PM_DEVICE=y
       - CONFIG_PM_DEVICE_POWER_DOMAIN=y
   pm.device_driver_init.pm_device_runtime:
-    tags: pm
-    platform_allow: qemu_cortex_m3
     extra_configs:
       - CONFIG_PM_DEVICE=y
       - CONFIG_PM_DEVICE_POWER_DOMAIN=y

--- a/tests/subsys/pm/device_power_domains/src/main.c
+++ b/tests/subsys/pm/device_power_domains/src/main.c
@@ -29,7 +29,7 @@ PM_DEVICE_DT_DEFINE(DT_NODELABEL(test_dev), dev_pm_control);
 DEVICE_DT_DEFINE(DT_NODELABEL(test_dev), dev_init, PM_DEVICE_DT_GET(DT_NODELABEL(test_dev)),
 		 NULL, NULL, POST_KERNEL, 80, NULL);
 
-ZTEST(device_power_domain, test_demo)
+ZTEST(device_power_domain, test_device_power_domain)
 {
 	const struct device *const reg_0 = DEVICE_DT_GET(DT_NODELABEL(test_reg_0));
 	const struct device *const reg_1 = DEVICE_DT_GET(DT_NODELABEL(test_reg_1));

--- a/tests/subsys/pm/device_power_domains/testcase.yaml
+++ b/tests/subsys/pm/device_power_domains/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   pm.power_domain.device:
-    tags: pm
-    platform_allow: qemu_cortex_m3
+    tags:
+      - pm
+    platform_allow:
+      - native_posix


### PR DESCRIPTION
- tests: pm: driver_init: use native_posix for testing
- tests: pm: driver_init: rename testcase, demo is ambigous
