### PR TITLE
Bluetooth: Controller: Fix BIS payload sliding window overrun check

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
@@ -74,7 +74,6 @@ struct lll_sync_iso {
 	struct node_rx_pdu *payload[BT_CTLR_SYNC_ISO_STREAM_MAX]
 				   [PDU_BIG_PAYLOAD_COUNT_MAX];
 	uint8_t payload_count_max;
-	uint8_t payload_head;
 	uint8_t payload_tail;
 
 	uint32_t window_widening_periodic_us;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -454,10 +454,9 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 
 	/* Initialize payload pointers */
 	lll->payload_count_max = PDU_BIG_PAYLOAD_COUNT_MAX;
-	lll->payload_head = 0U;
 	lll->payload_tail = 0U;
 	for (int i = 0; i < CONFIG_BT_CTLR_SYNC_ISO_STREAM_MAX; i++) {
-		for (int j = 0; j < PDU_BIG_PAYLOAD_COUNT_MAX; j++) {
+		for (int j = 0; j < lll->payload_count_max; j++) {
 			lll->payload[i][j] = NULL;
 		}
 	}


### PR DESCRIPTION
Fix BIS implementation for checking overrun of the BIS PDU sliding window buffer overrun.