### PR TITLE
boards: doc: cypress: Update all cypress.com links to use HTTPS

### DIFF
--- a/boards/arm/cy8ckit_062_wifi_bt/doc/index.rst
+++ b/boards/arm/cy8ckit_062_wifi_bt/doc/index.rst
@@ -187,22 +187,22 @@ References
 **********
 
 .. _PSoC 62 MCU SoC Website:
-	http://www.cypress.com/products/32-bit-arm-cortex-m4-psoc-6
+	https://www.cypress.com/products/32-bit-arm-cortex-m4-psoc-6
 
 .. _PSoC 62 MCU Datasheet:
-	http://www.cypress.com/documentation/datasheets/psoc-6-mcu-psoc-62-datasheet-programmable-system-chip-psoc-preliminary
+	https://www.cypress.com/documentation/datasheets/psoc-6-mcu-psoc-62-datasheet-programmable-system-chip-psoc-preliminary
 
 .. _PSoC 62 MCU Architecture Reference Manual:
-	http://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-62-architecture-technical-reference-manual
+	https://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-62-architecture-technical-reference-manual
 
 .. _PSoC 62 MCU Register Reference Manual:
-	http://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-62-register-technical-reference-manual-trm
+	https://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-62-register-technical-reference-manual-trm
 
 .. _CY8CKIT-062-WiFi-BT Website:
-   http://www.cypress.com/documentation/development-kitsboards/psoc-6-wifi-bt-pioneer-kit
+   https://www.cypress.com/documentation/development-kitsboards/psoc-6-wifi-bt-pioneer-kit
 
 .. _CY8CKIT-062-WiFi-BT User Guide:
-   http://www.cypress.com/file/407731/download
+   https://www.cypress.com/file/407731/download
 
 .. _CY8CKIT-062-WiFi-BT Schematics:
-   http://www.cypress.com/file/420846/download
+   https://www.cypress.com/file/420846/download

--- a/boards/arm/cy8cproto_062_4343w/doc/index.rst
+++ b/boards/arm/cy8cproto_062_4343w/doc/index.rst
@@ -160,16 +160,16 @@ Errata
 +------------------------------------------------+----------------------------------------+
 
 .. _PSoC 62 MCU SoC Website:
-    http://www.cypress.com/products/32-bit-arm-cortex-m4-psoc-6
+    https://www.cypress.com/products/32-bit-arm-cortex-m4-psoc-6
 
 .. _PSoC 62 MCU Datasheet:
-    http://www.cypress.com/documentation/datasheets/psoc-6-mcu-psoc-62-datasheet-programmable-system-chip-psoc-preliminary
+    https://www.cypress.com/documentation/datasheets/psoc-6-mcu-psoc-62-datasheet-programmable-system-chip-psoc-preliminary
 
 .. _PSoC 62 MCU Architecture Reference Manual:
-    http://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-62-architecture-technical-reference-manual
+    https://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-62-architecture-technical-reference-manual
 
 .. _PSoC 62 MCU Register Reference Manual:
-    http://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-62-register-technical-reference-manual-trm
+    https://www.cypress.com/documentation/technical-reference-manuals/psoc-6-mcu-psoc-62-register-technical-reference-manual-trm
 
 .. _CY8CPROTO-062-4343W PSoC 6 Wi-Fi BT Website:
     https://www.infineon.com/cms/en/product/evaluation-boards/cy8cproto-062-4343w/

--- a/boards/arm/cy8cproto_063_ble/doc/index.rst
+++ b/boards/arm/cy8cproto_063_ble/doc/index.rst
@@ -121,7 +121,7 @@ References
 **********
 
 .. _PSoC 63 BLE MCU SoC Website:
-    http://www.cypress.com/products/32-bit-arm-cortex-m4-psoc-6
+    https://www.cypress.com/products/32-bit-arm-cortex-m4-psoc-6
 
 .. _PSoC 63 BLE MCU Datasheet:
     https://www.infineon.com/dgdl/Infineon-PSoC_6_MCU_PSoC_63_with_BLE_Datasheet_Programmable_System-on-Chip_(PSoC)-DataSheet-v16_00-EN.pdf?fileId=8ac78c8c7d0d8da4017d0ee4efe46c37&utm_source=cypress&utm_medium=referral&utm_campaign=202110_globe_en_all_integration-files


### PR DESCRIPTION
While recent browsers seem to transparently try to use https when hitting http://www.cypress.com/... URLs, they are effectively not working anymore, so use https://www.cypress.com/... URLs instead. And it's a good practice anyway to promote secure links vs. plain http :)

```
curl http://www.cypress.com/products/32-bit-arm-cortex-m4-psoc-6 -v -m 5
*   Trying [2a02:26f0:2b00:1a::212:b1ac]:80...
* Connected to www.cypress.com (2a02:26f0:2b00:1a::212:b1ac) port 80
  (#0)
> GET /products/32-bit-arm-cortex-m4-psoc-6 HTTP/1.1 Host:
> www.cypress.com User-Agent: curl/8.1.2 Accept: */*
>
* Operation timed out after 5004 milliseconds with 0 bytes received
* Closing connection 0 curl: (28) Operation timed out after 5004 milliseconds with 0 bytes received
```