### PR TITLE
gitlint: exclude long line with co-authored-by

### DIFF
--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -109,7 +109,7 @@ class MaxLineLengthExceptions(LineRule):
     def validate(self, line, _commit):
         max_length = self.options['line-length'].value
         urls = re.findall(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', line)
-        if line.startswith('Signed-off-by'):
+        if line.lower().startswith('signed-off-by') or line.lower().startswith('co-authored-by'):
             return
 
         if urls:


### PR DESCRIPTION
Treat co-authored-by like signed-off-by.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
