### PR TITLE
drivers: sensor: npcx: fix debug message when port B is captured

### DIFF
--- a/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -176,7 +176,7 @@ static inline bool tach_npcx_is_captured(const struct device *dev)
 
 	LOG_DBG("port A is captured %d, port b is captured %d",
 		IS_BIT_SET(inst->TECTRL, NPCX_TECTRL_TAPND),
-		IS_BIT_SET(inst->TECTRL, NPCX_TECTRL_TAPND));
+		IS_BIT_SET(inst->TECTRL, NPCX_TECTRL_TBPND));
 
 	/*
 	 * In mode 5, the flag TAPND or TBPND indicates a input captured on


### PR DESCRIPTION
Fix wrong debug message when port B of tachometer is captured.