### PR TITLE
Bluetooth: controller: Add missing tx_pwr_lvl to lll_conn_iso_stream

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -62,6 +62,10 @@ struct lll_conn_iso_stream {
 	/* Resumption information */
 	uint8_t next_subevent;      /* Next subevent to schedule */
 
+#if defined(CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL)
+	int8_t tx_pwr_lvl;
+#endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
+
 	/* Transmission queue */
 	MEMQ_DECLARE(tx);
 	memq_link_t link_tx;


### PR DESCRIPTION
Added the missing tx_pwr_lvl field to lll_conn_iso_stream when compiled with CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL. This is required for BT_HCI_OP_VS_WRITE_TX_POWER_LEVEL, when e.g. building sample hci_pwr_ctrl.