### PR TITLE
drivers: adc: stm32: reset acquisition time between reads

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -990,6 +990,11 @@ static void adc_context_on_complete(struct adc_context *ctx, int status)
 	ARG_UNUSED(status);
 
 	adc_stm32_disable(adc);
+
+	/* Reset acquisition time used for the sequence */
+	data->acq_time_index = -1;
+
+	/* Reset internal channels */
 	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
 				       LL_ADC_PATH_INTERNAL_NONE);
 
@@ -1119,6 +1124,7 @@ static int adc_stm32_channel_setup(const struct device *dev,
 			 * identical acquisition time.
 			 */
 			if (acq_time_index != data->acq_time_index) {
+				LOG_ERR("Multiple sampling times not supported");
 				return -EINVAL;
 			}
 		}


### PR DESCRIPTION
For all STM32 ADC that use common sampling times, there is a check made to ensure that all channels of a sequence use the same sampling time. The value was not reset between reads, resulting in error if two consecutive sequences used different values.
This commit adds a reset of this value once read is done.