### PR TITLE
doc: board_porting: Move the board extensions section

### DIFF
--- a/boards/index.rst
+++ b/boards/index.rst
@@ -6,8 +6,11 @@ Supported Boards
 Zephyr project developers are continually adding board-specific support as
 documented below.
 
-To add support documentation for a new board, please use the template available
-under :zephyr_file:`doc/templates/board.tmpl`
+If you are looking to add Zephyr support for a new board, please start with the
+:ref:`board_porting_guide`.
+
+When adding support documentation for each board, remember to use the template
+available under :zephyr_file:`doc/templates/board.tmpl`.
 
 
 .. toctree::

--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -242,37 +242,6 @@ followed by trial and error. If you want to understand details, you will need
 to read the rest of the devicetree documentation and the devicetree
 specification.
 
-Board extensions
-****************
-
-Board extensions are board fragments that can be present in a board root
-folder, under ``${BOARD_ROOT}/boards/extensions``. The extension folder must
-follow the naming structure of the original board to extend. The board extension
-directory may contain Kconfig fragments and/or devicetree overlays. Board
-extensions are, by default, automatically loaded and applied on top of board
-files, before anything else. There is no guarantee on which order extensions are
-applied, in case multiple exist. This feature shall be disabled by passing
-``-DBOARD_EXTENSIONS=OFF`` when building.
-
-Board extensions are designed for downstream users, for example,
-``example-application`` or vendor SDKs. In some situations, certain hardware
-description or `choices <devicetree-chosen-nodes>`_ can not be added in the
-upstream Zephyr repository, but they can be in a downstream project, where
-custom bindings or driver classes can also be created. This feature may also be
-useful in development phases, when the board skeleton lives upstream, but other
-features are developed in a downstream module.
-
-Note that board extensions need to follow the
-:ref:`same guidelines <porting-general-recommendations>` as regular boards. For
-example, it is wrong to enable extra peripherals or subsystems in a board
-extension.
-
-.. warning::
-
-   Board extensions are not allowed in any module referenced in Zephyr's
-   ``west.yml`` manifest file. Any board changes are required to be submitted to
-   the main Zephyr repository.
-
 .. _dt_k6x_example:
 
 Example: FRDM-K64F and Hexiwear K64
@@ -810,3 +779,34 @@ There are some extra things you'll need to do:
 
 #. Prepare a pull request adding your board which follows the
    :ref:`contribute_guidelines`.
+
+Board extensions
+****************
+
+Board extensions are designed for downstream users, for example,
+``example-application`` or vendor SDKs. In some situations, certain hardware
+description or `choices <devicetree-chosen-nodes>`_ can not be added in the
+upstream Zephyr repository, but they can be in a downstream project, where
+custom bindings or driver classes can also be created. This feature may also be
+useful in development phases, when the board skeleton lives upstream, but other
+features are developed in a downstream module.
+
+Board extensions are board fragments that can be present in a board root
+folder, under ``${BOARD_ROOT}/boards/extensions``. The extension folder must
+follow the naming structure of the original board to extend. The board extension
+directory may contain Kconfig fragments and/or devicetree overlays. Board
+extensions are, by default, automatically loaded and applied on top of board
+files, before anything else. There is no guarantee on which order extensions are
+applied, in case multiple exist. This feature shall be disabled by passing
+``-DBOARD_EXTENSIONS=OFF`` when building.
+
+Note that board extensions need to follow the
+:ref:`same guidelines <porting-general-recommendations>` as regular boards. For
+example, it is wrong to enable extra peripherals or subsystems in a board
+extension.
+
+.. warning::
+
+   Board extensions are not allowed in any module referenced in Zephyr's
+   ``west.yml`` manifest file. Any board changes are required to be submitted to
+   the main Zephyr repository.

--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -783,21 +783,31 @@ There are some extra things you'll need to do:
 Board extensions
 ****************
 
-Board extensions are designed for downstream users, for example,
+Boards already supported by Zephyr can be extended by downstream users, such as
 ``example-application`` or vendor SDKs. In some situations, certain hardware
-description or `choices <devicetree-chosen-nodes>`_ can not be added in the
+description or :ref:`choices <devicetree-chosen-nodes>` can not be added in the
 upstream Zephyr repository, but they can be in a downstream project, where
 custom bindings or driver classes can also be created. This feature may also be
 useful in development phases, when the board skeleton lives upstream, but other
 features are developed in a downstream module.
 
-Board extensions are board fragments that can be present in a board root
-folder, under ``${BOARD_ROOT}/boards/extensions``. The extension folder must
-follow the naming structure of the original board to extend. The board extension
-directory may contain Kconfig fragments and/or devicetree overlays. Board
-extensions are, by default, automatically loaded and applied on top of board
+Board extensions are board fragments that can be present in an out-of-tree board
+root folder, under ``${BOARD_ROOT}/boards/extensions``. Here is an example
+structure of an extension for the ``plank`` board and its revisions:
+
+.. code-block:: none
+
+   boards/extensions/plank
+   ├── plank.conf                # optional
+   ├── plank_<revision>.conf     # optional
+   ├── plank.overlay             # optional
+   └── plank_<revision>.overlay  # optional
+
+A board extension directory must follow the naming structure of the original
+board it extends. It may contain Kconfig fragments and/or devicetree overlays.
+Extensions are, by default, automatically loaded and applied on top of board
 files, before anything else. There is no guarantee on which order extensions are
-applied, in case multiple exist. This feature shall be disabled by passing
+applied, in case multiple exist. This feature can be disabled by passing
 ``-DBOARD_EXTENSIONS=OFF`` when building.
 
 Note that board extensions need to follow the


### PR DESCRIPTION
It was awkwardly placed in the middle of the "Write your devicetree" section, breaking up the flow of the guide. A more natural placement would be underneath "Contributing your board", considering that this feature deals with boards already submitted to Zephyr.

Let's relocate this part and swap two of its paragraphs in the process, to motivate the feature before describing it. Tweak a few sentences and add a basic example, to fit in with the overall document a little better.