### PR TITLE
drivers/serial: ns16550: Add high speed baud rate support for IT8XXX2

### DIFF
--- a/drivers/serial/Kconfig.it8xxx2
+++ b/drivers/serial/Kconfig.it8xxx2
@@ -4,6 +4,7 @@
 config UART_ITE_IT8XXX2
 	bool "ITE IT8XXX2 UART driver"
 	default y
+	select UART_NS16550_ITE_HIGH_SPEED_BUADRATE
 	depends on DT_HAS_ITE_IT8XXX2_UART_ENABLED
 	help
 	  IT8XXX2 uses shared ns16550.c driver which does not

--- a/drivers/serial/Kconfig.ns16550
+++ b/drivers/serial/Kconfig.ns16550
@@ -77,6 +77,12 @@ config UART_NS16550_TI_K3
 	  Texas Instruments K3 SoCs by enabling a vendor specific extended register
 	  set.
 
+config UART_NS16550_ITE_HIGH_SPEED_BUADRATE
+	bool "IT8XXX2 specific baud rate configuration"
+	help
+	  Enable IT8XXX2 specific baud rate configuration.
+	  This applies to high-speed baud rate configuration.
+
 menu "NS16550 Workarounds"
 
 config UART_NS16550_WA_ISR_REENABLE_INTERRUPT


### PR DESCRIPTION
Add the support of high speed baud rate 230.4k and 460.8k for IT8XXX2 of ITE.