### PR TITLE
drivers: i2c: esp32: check busy line before transfer

### DIFF
--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -560,10 +560,18 @@ static int IRAM_ATTR i2c_esp32_transfer(const struct device *dev, struct i2c_msg
 {
 	struct i2c_esp32_data *data = (struct i2c_esp32_data *const)(dev)->data;
 	struct i2c_msg *current, *next;
+	uint32_t timeout = I2C_TRANSFER_TIMEOUT_MSEC * USEC_PER_MSEC;
 	int ret = 0;
 
 	if (!num_msgs) {
 		return 0;
+	}
+
+	while (i2c_hal_is_bus_busy(&data->hal)) {
+		k_busy_wait(1);
+		if (timeout-- == 0) {
+			return -EBUSY;
+		}
 	}
 
 	/* Check for validity of all messages before transfer */


### PR DESCRIPTION
I2C scan might fail as peripheral is still busy completing last operation. This makes sure transfer functions waits for free access.