### PR TITLE
Bluetooth: Controller: Fix ULL_HIGH ticker operations count

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -278,22 +278,21 @@
 
 #define TICKER_USER_ULL_LOW_OPS  (1 + TICKER_USER_ULL_LOW_VENDOR_OPS + 1)
 
-/* NOTE: When ULL_LOW priority is configured to lower than ULL_HIGH, then extra
- *       ULL_HIGH operations queue elements are required to buffer the
- *       requested ticker operations.
+/* NOTE: Extended Advertising needs one extra ticker operation being enqueued
+ *       for scheduling the auxiliary PDU reception while there can already
+ *       be three other operations being enqueued.
+ *
+ *       This value also covers the case were initiator with 1M and Coded PHY
+ *       scan window is stopping the two scan tickers, stopping one scan stop
+ *       ticker and starting one new ticker for establishing an ACL connection.
  */
-#if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_CTLR_ADV_EXT) && \
-	defined(CONFIG_BT_CTLR_PHY_CODED)
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
 #define TICKER_USER_ULL_HIGH_OPS (4 + TICKER_USER_ULL_HIGH_VENDOR_OPS + \
 				  TICKER_USER_ULL_HIGH_FLASH_OPS + 1)
-#else /* !CONFIG_BT_CENTRAL || !CONFIG_BT_CTLR_ADV_EXT ||
-       * !CONFIG_BT_CTLR_PHY_CODED
-       */
+#else /* !CONFIG_BT_CTLR_ADV_EXT */
 #define TICKER_USER_ULL_HIGH_OPS (3 + TICKER_USER_ULL_HIGH_VENDOR_OPS + \
 				  TICKER_USER_ULL_HIGH_FLASH_OPS + 1)
-#endif /* !CONFIG_BT_CENTRAL || !CONFIG_BT_CTLR_ADV_EXT ||
-	* !CONFIG_BT_CTLR_PHY_CODED
-	*/
+#endif /* !CONFIG_BT_CTLR_ADV_EXT */
 
 #define TICKER_USER_LLL_OPS      (3 + TICKER_USER_LLL_VENDOR_OPS + 1)
 


### PR DESCRIPTION
Fix ULL_HIGH ticker operations count, it is discovered in new BabbleSim test implementations that mesh tests using Extended Advertising and Scanning enqueue upto 4 ticker operations before ULL_LOW ticker_job could process it.