### PR TITLE
drivers: serial: stm32: Make it compatible with runtime PM on console

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -23,6 +23,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 
 #ifdef CONFIG_UART_ASYNC_API
 #include <zephyr/drivers/dma/dma_stm32.h>
@@ -671,6 +672,11 @@ static void uart_stm32_poll_out_visitor(const struct device *dev, void *out, pol
 		 */
 		uart_stm32_pm_policy_state_lock_get(dev);
 
+		/* Resume device if needed before enabling IT */
+		if (pm_device_runtime_is_enabled(dev)) {
+			(void)pm_device_runtime_get(dev);
+		}
+
 		/* Enable TC interrupt so we can release suspend
 		 * constraint when done
 		 */
@@ -1263,6 +1269,11 @@ static void uart_stm32_isr(const struct device *dev)
 		async_evt_tx_done(data);
 
 #ifdef CONFIG_PM
+		/* Device can now be released */
+		if (pm_device_runtime_is_enabled(dev)) {
+			(void)pm_device_runtime_put(dev);
+		}
+
 		uart_stm32_pm_policy_state_lock_put(dev);
 #endif
 	} else if (LL_USART_IsEnabledIT_RXNE(config->usart) &&


### PR DESCRIPTION
Since #53979, runtime PM can be applied on serial device used by console. While it should be transparent on serial driver side as the application (console in this case) is driving the PM runtime requests, on STM32 it requires some modification on serial driver as UART interrupts are generated to handle internal power management house cleaning. When these interrupts are generated, PM runtime should also be driven to ensure clock availability when treating the uart ISR. On STM32, some additional changes are required

Fixes #63367