### PR TITLE
test pwm_loopback: add option to skip PWM inverted polarity test

### DIFF
--- a/tests/drivers/pwm/pwm_loopback/Kconfig
+++ b/tests/drivers/pwm/pwm_loopback/Kconfig
@@ -1,0 +1,9 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config SKIP_PWM_INVERTED_TEST
+	bool "Skip test for PWM inverted polarity"
+	help
+	  Skip test for PWM inverted polarity

--- a/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
+++ b/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
@@ -115,12 +115,16 @@ ZTEST_USER(pwm_loopback, test_pulse_capture)
 
 ZTEST_USER(pwm_loopback, test_pulse_capture_inverted)
 {
+#ifdef CONFIG_SKIP_PWM_INVERTED_TEST
+	ztest_test_skip();
+#else
 	test_capture(TEST_PWM_PERIOD_NSEC, TEST_PWM_PULSE_NSEC,
 		     TEST_PWM_UNIT_NSEC,
 		     PWM_CAPTURE_TYPE_PULSE | PWM_POLARITY_INVERTED);
 	test_capture(TEST_PWM_PERIOD_USEC, TEST_PWM_PULSE_USEC,
 		     TEST_PWM_UNIT_USEC,
 		     PWM_CAPTURE_TYPE_PULSE | PWM_POLARITY_INVERTED);
+#endif
 }
 
 ZTEST_USER(pwm_loopback, test_period_capture)
@@ -135,12 +139,16 @@ ZTEST_USER(pwm_loopback, test_period_capture)
 
 ZTEST_USER(pwm_loopback, test_period_capture_inverted)
 {
+#ifdef CONFIG_SKIP_PWM_INVERTED_TEST
+	ztest_test_skip();
+#else
 	test_capture(TEST_PWM_PERIOD_NSEC, TEST_PWM_PULSE_NSEC,
 		     TEST_PWM_UNIT_NSEC,
 		     PWM_CAPTURE_TYPE_PERIOD | PWM_POLARITY_INVERTED);
 	test_capture(TEST_PWM_PERIOD_USEC, TEST_PWM_PULSE_USEC,
 		     TEST_PWM_UNIT_USEC,
 		     PWM_CAPTURE_TYPE_PERIOD | PWM_POLARITY_INVERTED);
+#endif
 }
 
 ZTEST_USER(pwm_loopback, test_pulse_and_period_capture)


### PR DESCRIPTION
Some drivers/hardware may not support generate active-low pulse, or support but can configure the polarity only once.
Add option to skip that test.