### PR TITLE
Bluetooth: Audio: Add codec_cfg_set_octets_per_frame

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -660,6 +660,19 @@ int bt_audio_codec_cfg_get_chan_allocation_val(const struct bt_audio_codec_cfg *
  */
 int bt_audio_codec_cfg_get_octets_per_frame(const struct bt_audio_codec_cfg *codec_cfg);
 
+/**
+ * @brief Set the octets per codec frame of a codec configuration.
+ *
+ * @param codec_cfg        The codec configuration to set data for.
+ * @param octets_per_frame The octets per codec frame to set.
+ *
+ * @retval The data_len of @p codec_cfg on success
+ * @retval -EINVAL if arguments are invalid
+ * @retval -ENOMEM if the new value could not set or added due to memory
+ */
+int bt_audio_codec_cfg_set_octets_per_frame(struct bt_audio_codec_cfg *codec_cfg,
+					    uint16_t octets_per_frame);
+
 /** @brief Extract number of audio frame blockss in each SDU from BT codec config
  *
  *  The overall SDU size will be octets_per_frame * frame_blocks_per_sdu * number-of-channels.

--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -377,6 +377,18 @@ int bt_audio_codec_cfg_get_octets_per_frame(const struct bt_audio_codec_cfg *cod
 	return sys_get_le16(data);
 }
 
+int bt_audio_codec_cfg_set_octets_per_frame(struct bt_audio_codec_cfg *codec_cfg,
+					    uint16_t octets_per_frame)
+{
+	uint16_t octets_per_frame_le16;
+
+	octets_per_frame_le16 = sys_cpu_to_le16(octets_per_frame);
+
+	return bt_audio_codec_cfg_set_val(codec_cfg, BT_AUDIO_CODEC_CONFIG_LC3_FRAME_LEN,
+					  (uint8_t *)&octets_per_frame_le16,
+					  sizeof(octets_per_frame_le16));
+}
+
 int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg *codec_cfg,
 						bool fallback_to_default)
 {

--- a/tests/bluetooth/audio/codec/src/main.c
+++ b/tests/bluetooth/audio/codec/src/main.c
@@ -109,6 +109,22 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_octets_per_frame)
 	zassert_equal(ret, 80u, "unexpected return value %d", ret);
 }
 
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_set_octets_per_frame)
+{
+	struct bt_bap_lc3_preset preset = BT_BAP_LC3_UNICAST_PRESET_32_2_2(
+		BT_AUDIO_LOCATION_FRONT_LEFT, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	int ret;
+
+	ret = bt_audio_codec_cfg_get_octets_per_frame(&preset.codec_cfg);
+	zassert_equal(ret, 80, "Unexpected return value %d", ret);
+
+	ret = bt_audio_codec_cfg_set_octets_per_frame(&preset.codec_cfg, 120);
+	zassert_true(ret > 0, "Unexpected return value %d", ret);
+
+	ret = bt_audio_codec_cfg_get_octets_per_frame(&preset.codec_cfg);
+	zassert_equal(ret, 120, "Unexpected return value %d", ret);
+}
+
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_frame_blocks_per_sdu)
 {
 	const struct bt_bap_lc3_preset preset =


### PR DESCRIPTION
Add the bt_audio_codec_cfg_set_octets_per_frame function
to set or add the frame blocks per SDU field in the
codec configuration.