### PR TITLE
doc: boards: Fix typo in Arduino Giga R1 note directive

### DIFF
--- a/boards/arm/arduino_giga_r1/doc/index.rst
+++ b/boards/arm/arduino_giga_r1/doc/index.rst
@@ -82,7 +82,7 @@ that run the command:
 
    west blobs fetch hal_infineon
 
-.. note: Only Bluetooth functionality is currently supported.
+.. note:: Only Bluetooth functionality is currently supported.
 
 Resources sharing
 =================


### PR DESCRIPTION
Fix a minor typo causing Sphinx note to not render.

Note now shows correctly as per https://builds.zephyrproject.io/zephyr/pr/63163/docs/boards/arm/arduino_giga_r1/doc/index.html#fetch-binary-blobs