### PR TITLE
usbc: add checks for results of TCPC related functions

### DIFF
--- a/drivers/usb_c/tcpc/ucpd_stm32.c
+++ b/drivers/usb_c/tcpc/ucpd_stm32.c
@@ -1027,21 +1027,21 @@ static int ucpd_transmit_data(const struct device *dev,
 /**
  * @brief Tests if a received Power Delivery message is pending
  *
- * @retval true if message is pending, else false
+ * @retval 0 if there is no pending message
+ * @retval 1 if there is a pending message
  */
-static bool ucpd_is_rx_pending_msg(const struct device *dev,
-				   enum pd_packet_type *type)
+static int ucpd_is_rx_pending_msg(const struct device *dev, enum pd_packet_type *type)
 {
 	struct tcpc_data *data = dev->data;
-	bool ret;
+	bool pending;
 
-	ret = (*(uint32_t *)data->ucpd_rx_buffer > 0);
+	pending = (*(uint32_t *)data->ucpd_rx_buffer > 0);
 
-	if (ret & (type != NULL)) {
+	if (pending & (type != NULL)) {
 		*type = *(uint16_t *)data->ucpd_rx_buffer;
 	}
 
-	return ret;
+	return (pending) ? 1 : 0;
 }
 
 /**

--- a/drivers/usb_c/tcpc/ucpd_stm32.c
+++ b/drivers/usb_c/tcpc/ucpd_stm32.c
@@ -1025,44 +1025,24 @@ static int ucpd_transmit_data(const struct device *dev,
 }
 
 /**
- * @brief Tests if a received Power Delivery message is pending
- *
- * @retval 0 if there is no pending message
- * @retval 1 if there is a pending message
- */
-static int ucpd_is_rx_pending_msg(const struct device *dev, enum pd_packet_type *type)
-{
-	struct tcpc_data *data = dev->data;
-	bool pending;
-
-	pending = (*(uint32_t *)data->ucpd_rx_buffer > 0);
-
-	if (pending & (type != NULL)) {
-		*type = *(uint16_t *)data->ucpd_rx_buffer;
-	}
-
-	return (pending) ? 1 : 0;
-}
-
-/**
  * @brief Retrieves the Power Delivery message from the TCPC
  *
- * @retval number of bytes received
- * @retval -EIO on no message to retrieve
- * @retval -EFAULT on buf being NULL
+ * @retval number of bytes received if msg parameter is provided
+ * @retval 0 if there is a message pending and the msg parameter is NULL
+ * @retval -ENODATA if there is no pending message
  */
-static int ucpd_receive_data(const struct device *dev, struct pd_msg *msg)
+static int ucpd_get_rx_pending_msg(const struct device *dev, struct pd_msg *msg)
 {
 	struct tcpc_data *data = dev->data;
 	int ret = 0;
 
-	if (msg == NULL) {
-		return -EFAULT;
+	/* Make sure we have a message to retrieve */
+	if (*(uint32_t *)data->ucpd_rx_buffer == 0) {
+		return -ENODATA;
 	}
 
-	/* Make sure we have a message to retrieve */
-	if (!ucpd_is_rx_pending_msg(dev, NULL)) {
-		return -EIO;
+	if (msg == NULL) {
+		return 0;
 	}
 
 	msg->type = *(uint16_t *)data->ucpd_rx_buffer;
@@ -1443,8 +1423,7 @@ static const struct tcpc_driver_api driver_api = {
 	.set_alert_handler_cb = ucpd_set_alert_handler_cb,
 	.get_cc = ucpd_get_cc,
 	.set_rx_enable = ucpd_set_rx_enable,
-	.is_rx_pending_msg = ucpd_is_rx_pending_msg,
-	.receive_data = ucpd_receive_data,
+	.get_rx_pending_msg = ucpd_get_rx_pending_msg,
 	.transmit_data = ucpd_transmit_data,
 	.select_rp_value = ucpd_select_rp_value,
 	.get_rp_value = ucpd_get_rp_value,

--- a/drivers/usb_c/tcpc/ucpd_stm32.c
+++ b/drivers/usb_c/tcpc/ucpd_stm32.c
@@ -1366,7 +1366,7 @@ static int ucpd_init(const struct device *dev)
 
 	LOG_DBG("Pinctrl signals configuration");
 	ret = pinctrl_apply_state(config->ucpd_pcfg, PINCTRL_STATE_DEFAULT);
-	if (ret < 0) {
+	if (ret != 0) {
 		LOG_ERR("USB pinctrl setup failed (%d)", ret);
 		return ret;
 	}

--- a/drivers/usb_c/vbus/usbc_vbus_adc.c
+++ b/drivers/usb_c/vbus/usbc_vbus_adc.c
@@ -146,13 +146,12 @@ static int adc_vbus_init(const struct device *dev)
 
 	/* Configure VBUS Measurement enable pin if defined */
 	if (gcp->port) {
-		ret = device_is_ready(gcp->port);
-		if (ret < 0) {
+		if (!device_is_ready(gcp->port)) {
 			LOG_ERR("%s: device not ready", gcp->port->name);
-			return ret;
+			return -EIO;
 		}
 		ret = gpio_pin_configure_dt(gcp, GPIO_OUTPUT_INACTIVE);
-		if (ret < 0) {
+		if (ret != 0) {
 			LOG_ERR("Failed to control feed %s.%u: %d",
 				gcp->port->name, gcp->pin, ret);
 			return ret;
@@ -161,13 +160,12 @@ static int adc_vbus_init(const struct device *dev)
 
 	/* Configure VBUS Discharge pin if defined */
 	if (gcd->port) {
-		ret = device_is_ready(gcd->port);
-		if (ret == false) {
+		if (!device_is_ready(gcd->port)) {
 			LOG_ERR("%s: device not ready", gcd->port->name);
-			return ret;
+			return -EIO;
 		}
 		ret = gpio_pin_configure_dt(gcd, GPIO_OUTPUT_INACTIVE);
-		if (ret < 0) {
+		if (ret != 0) {
 			LOG_ERR("Failed to control feed %s.%u: %d",
 				gcd->port->name, gcd->pin, ret);
 			return ret;
@@ -179,13 +177,13 @@ static int adc_vbus_init(const struct device *dev)
 	data->sequence.buffer_size = sizeof(data->sample);
 
 	ret = adc_channel_setup_dt(&config->adc_channel);
-	if (ret < 0) {
+	if (ret != 0) {
 		LOG_INF("Could not setup channel (%d)\n", ret);
 		return ret;
 	}
 
 	ret = adc_sequence_init_dt(&config->adc_channel, &data->sequence);
-	if (ret < 0) {
+	if (ret != 0) {
 		LOG_INF("Could not init sequence (%d)\n", ret);
 		return ret;
 	}

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -231,6 +231,7 @@ static inline int tcpc_is_cc_only_one_rd(enum tc_cc_voltage_state cc1,
  *
  * @retval 0 on success
  * @retval -EIO on failure
+ * @retval -EAGAIN if initialization should be postponed
  */
 static inline int tcpc_init(const struct device *dev)
 {

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -137,7 +137,7 @@ __subsystem struct tcpc_driver_api {
 	int (*set_roles)(const struct device *dev, enum tc_power_role power_role,
 			enum tc_data_role data_role);
 	int (*receive_data)(const struct device *dev, struct pd_msg *msg);
-	bool (*is_rx_pending_msg)(const struct device *dev, enum pd_packet_type *type);
+	int (*is_rx_pending_msg)(const struct device *dev, enum pd_packet_type *type);
 	int (*set_rx_enable)(const struct device *dev, bool enable);
 	int (*set_cc_polarity)(const struct device *dev, enum tc_cc_polarity polarity);
 	int (*transmit_data)(const struct device *dev, struct pd_msg *msg);
@@ -152,8 +152,8 @@ __subsystem struct tcpc_driver_api {
 	int (*set_debug_accessory)(const struct device *dev, bool enable);
 	int (*set_debug_detach)(const struct device *dev);
 	int (*set_drp_toggle)(const struct device *dev, bool enable);
-	bool (*get_snk_ctrl)(const struct device *dev);
-	bool (*get_src_ctrl)(const struct device *dev);
+	int (*get_snk_ctrl)(const struct device *dev);
+	int (*get_src_ctrl)(const struct device *dev);
 	int (*get_chip_info)(const struct device *dev, struct tcpc_chip_info *chip_info);
 	int (*set_low_power_mode)(const struct device *dev, bool enable);
 	int (*sop_prime_enable)(const struct device *dev, bool enable);
@@ -460,12 +460,12 @@ static inline int tcpc_set_roles(const struct device *dev,
  * @param dev  Runtime device structure
  * @param type  pointer to where message type is written. Can be NULL
  *
- * @retval true if message is pending, else false
+ * @retval 0 if there is no pending message
+ * @retval 1 if there is a pending message
  * @retval -EIO on failure
  * @retval -ENOSYS if not implemented
  */
-static inline bool tcpc_is_rx_pending_msg(const struct device *dev,
-					  enum pd_packet_type *type)
+static inline int tcpc_is_rx_pending_msg(const struct device *dev, enum pd_packet_type *type)
 {
 	const struct tcpc_driver_api *api =
 		(const struct tcpc_driver_api *)dev->api;
@@ -767,7 +767,7 @@ static inline int tcpc_set_drp_toggle(const struct device *dev, bool enable)
  * @retval false if not sinking power
  * @retval -ENOSYS if not implemented
  */
-static inline bool tcpc_get_snk_ctrl(const struct device *dev)
+static inline int tcpc_get_snk_ctrl(const struct device *dev)
 {
 	const struct tcpc_driver_api *api =
 		(const struct tcpc_driver_api *)dev->api;
@@ -788,7 +788,7 @@ static inline bool tcpc_get_snk_ctrl(const struct device *dev)
  * @retval false if not sourcing power
  * @retval -ENOSYS if not implemented
  */
-static inline bool tcpc_get_src_ctrl(const struct device *dev)
+static inline int tcpc_get_src_ctrl(const struct device *dev)
 {
 	const struct tcpc_driver_api *api =
 		(const struct tcpc_driver_api *)dev->api;

--- a/subsys/usb/usb_c/usbc_prl.c
+++ b/subsys/usb/usb_c/usbc_prl.c
@@ -1177,7 +1177,7 @@ static void prl_rx_wait_for_phy_message(const struct device *dev)
 	uint8_t power_role;
 
 	/* Get the message */
-	if (tcpc_receive_data(tcpc, rx_emsg) <= 0) {
+	if (tcpc_is_rx_pending_msg(tcpc, NULL) == 0 || tcpc_receive_data(tcpc, rx_emsg) <= 0) {
 		/* No pending message or problem getting the message */
 		return;
 	}

--- a/subsys/usb/usb_c/usbc_prl.c
+++ b/subsys/usb/usb_c/usbc_prl.c
@@ -1177,7 +1177,7 @@ static void prl_rx_wait_for_phy_message(const struct device *dev)
 	uint8_t power_role;
 
 	/* Get the message */
-	if (tcpc_is_rx_pending_msg(tcpc, NULL) == 0 || tcpc_receive_data(tcpc, rx_emsg) <= 0) {
+	if (tcpc_get_rx_pending_msg(tcpc, rx_emsg) <= 0) {
 		/* No pending message or problem getting the message */
 		return;
 	}

--- a/subsys/usb/usb_c/usbc_prl.c
+++ b/subsys/usb/usb_c/usbc_prl.c
@@ -446,7 +446,7 @@ static void increment_msgid_counter(const struct device *dev)
 /**
  * @brief Get the SOP* header for the current received message
  */
-static uint32_t get_sop_star_header(const struct device *dev)
+static uint16_t get_sop_star_header(const struct device *dev)
 {
 	struct usbc_port_data *data = dev->data;
 	struct protocol_layer_tx_t *prl_tx = data->prl_tx;

--- a/subsys/usb/usb_c/usbc_tc_common.c
+++ b/subsys/usb/usb_c/usbc_tc_common.c
@@ -70,7 +70,14 @@ void tc_run(const struct device *dev, const int32_t dpm_request)
 		}
 
 		/* Sample CC lines */
-		tcpc_get_cc(tcpc, &tc->cc1, &tc->cc2);
+		if (tcpc_get_cc(tcpc, &tc->cc1, &tc->cc2) != 0) {
+			/* If this function fails, it may mean that the TCPC is in sleep mode or
+			 * the communication with TCPC has failed, so we can assume that the CC
+			 * lines are open or existing connection is faulty.
+			 */
+			tc->cc1 = TC_CC_VOLT_OPEN;
+			tc->cc2 = TC_CC_VOLT_OPEN;
+		}
 
 		/* Detect polarity */
 		tc->cc_polarity = (tc->cc1 > tc->cc2) ? TC_POLARITY_CC1 : TC_POLARITY_CC2;

--- a/subsys/usb/usb_c/usbc_tc_common.c
+++ b/subsys/usb/usb_c/usbc_tc_common.c
@@ -214,14 +214,23 @@ static void tc_cc_open_entry(void *obj)
 	const struct device *dev = tc->dev;
 	struct usbc_port_data *data = dev->data;
 	const struct device *tcpc = data->tcpc;
+	int ret;
 
 	tc->cc_voltage = TC_CC_VOLT_OPEN;
 
 	/* Disable VCONN */
-	tcpc_set_vconn(tcpc, false);
+	ret = tcpc_set_vconn(tcpc, false);
+	if (ret != 0 && ret != -ENOSYS) {
+		LOG_ERR("Set vconn failed: %d", ret);
+		return;
+	}
 
 	/* Open CC lines */
-	tcpc_set_cc(tcpc, TC_CC_OPEN);
+	ret = tcpc_set_cc(tcpc, TC_CC_OPEN);
+	if (ret != 0) {
+		LOG_ERR("Set CC lines failed: %d", ret);
+		return;
+	}
 }
 
 /**

--- a/subsys/usb/usb_c/usbc_tc_snk_states.c
+++ b/subsys/usb/usb_c/usbc_tc_snk_states.c
@@ -174,11 +174,17 @@ void tc_attached_snk_entry(void *obj)
 	const struct device *dev = tc->dev;
 	struct usbc_port_data *data = dev->data;
 	const struct device *tcpc = data->tcpc;
+	int ret;
 
 	LOG_INF("Attached.SNK");
 
 	/* Set CC polarity */
-	tcpc_set_cc_polarity(tcpc, tc->cc_polarity);
+	ret = tcpc_set_cc_polarity(tcpc, tc->cc_polarity);
+	if (ret != 0) {
+		LOG_ERR("Couldn't set CC polarity to %d: %d", tc->cc_polarity, ret);
+		tc_set_state(dev, TC_ERROR_RECOVERY_STATE);
+		return;
+	}
 
 	/* Enable PD */
 	tc_pd_enable(dev, true);
@@ -227,6 +233,11 @@ void tc_cc_rd_entry(void *obj)
 	const struct device *dev = tc->dev;
 	struct usbc_port_data *data = dev->data;
 	const struct device *tcpc = data->tcpc;
+	int ret;
 
-	tcpc_set_cc(tcpc, TC_CC_RD);
+	ret = tcpc_set_cc(tcpc, TC_CC_RD);
+	if (ret != 0) {
+		LOG_ERR("Couldn't set CC lines to Rd: %d", ret);
+		tc_set_state(dev, TC_ERROR_RECOVERY_STATE);
+	}
 }

--- a/subsys/usb/usb_c/usbc_tc_src_states.c
+++ b/subsys/usb/usb_c/usbc_tc_src_states.c
@@ -222,6 +222,7 @@ void tc_attached_src_entry(void *obj)
 	const struct device *dev = tc->dev;
 	struct usbc_port_data *data = dev->data;
 	const struct device *tcpc = data->tcpc;
+	int ret;
 
 	LOG_INF("Attached.SRC");
 
@@ -229,7 +230,12 @@ void tc_attached_src_entry(void *obj)
 	tcpc_set_roles(tcpc, TC_ROLE_SOURCE, TC_ROLE_DFP);
 
 	/* Set cc polarity */
-	tcpc_set_cc_polarity(tcpc, tc->cc_polarity);
+	ret = tcpc_set_cc_polarity(tcpc, tc->cc_polarity);
+	if (ret != 0) {
+		LOG_ERR("Couldn't set CC polarity to %d: %d", tc->cc_polarity, ret);
+		tc_set_state(dev, TC_ERROR_RECOVERY_STATE);
+		return;
+	}
 
 	/* Start sourcing VBUS */
 	if (data->policy_cb_src_en(dev, true) == 0) {
@@ -287,6 +293,7 @@ void tc_attached_src_exit(void *obj)
 	const struct device *dev = tc->dev;
 	struct usbc_port_data *data = dev->data;
 	const struct device *tcpc = data->tcpc;
+	int ret;
 
 	__ASSERT(data->policy_cb_src_en != NULL,
 			"policy_cb_src_en must not be NULL");
@@ -298,7 +305,10 @@ void tc_attached_src_exit(void *obj)
 	data->policy_cb_src_en(dev, false);
 
 	/* Stop sourcing VCONN */
-	tcpc_set_vconn(tcpc, false);
+	ret = tcpc_set_vconn(tcpc, false);
+	if (ret != 0 && ret != -ENOSYS) {
+		LOG_ERR("Couldn't disable VCONN source");
+	}
 }
 
 /**
@@ -312,6 +322,7 @@ void tc_cc_rp_entry(void *obj)
 	struct usbc_port_data *data = dev->data;
 	const struct device *tcpc = data->tcpc;
 	enum tc_rp_value rp = TC_RP_USB;
+	int ret;
 
 	/*
 	 * Get initial Rp value from Device Policy Manager or use
@@ -322,8 +333,17 @@ void tc_cc_rp_entry(void *obj)
 	}
 
 	/* Select Rp value */
-	tcpc_select_rp_value(tcpc, rp);
+	ret = tcpc_select_rp_value(tcpc, rp);
+	if (ret != 0 && ret != -ENOTSUP) {
+		LOG_ERR("Couldn't set Rp value to %d: %d", rp, ret);
+		tc_set_state(dev, TC_ERROR_RECOVERY_STATE);
+		return;
+	}
 
 	/* Place Rp on CC lines */
-	tcpc_set_cc(tcpc, TC_CC_RP);
+	ret = tcpc_set_cc(tcpc, TC_CC_RP);
+	if (ret != 0) {
+		LOG_ERR("Couldn't set CC lines to Rp: %d", ret);
+		tc_set_state(dev, TC_ERROR_RECOVERY_STATE);
+	}
 }


### PR DESCRIPTION
This PR adds checks for the failing paths in the USB-C PD stack. It adds option for the tcpc_init function to return error or postpone value. Error causes the type-c layer to be disabled, where postpone value means that the TCPC may need more time (for powering up) and needs more tries.
Other failures in the stack means that there is a communication problem with the TCPC, so the layer is going into error recovery state.