### PR TITLE
Bluetooth: Audio: Add codec_cfg_set_frame_blocks_per_sdu

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -697,6 +697,19 @@ int bt_audio_codec_cfg_set_octets_per_frame(struct bt_audio_codec_cfg *codec_cfg
 int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg *codec_cfg,
 						bool fallback_to_default);
 
+/**
+ * @brief Set the frame blocks per SDU of a codec configuration.
+ *
+ * @param codec_cfg    The codec configuration to set data for.
+ * @param frame_blocks The frame blocks per SDU to set.
+ *
+ * @retval The data_len of @p codec_cfg on success
+ * @retval -EINVAL if arguments are invalid
+ * @retval -ENOMEM if the new value could not set or added due to memory
+ */
+int bt_audio_codec_cfg_set_frame_blocks_per_sdu(struct bt_audio_codec_cfg *codec_cfg,
+						uint8_t frame_blocks);
+
 /** @brief Lookup a specific codec configuration value
  *
  *  @param[in] codec_cfg The codec data to search in.

--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -416,6 +416,13 @@ int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg 
 
 	return data[0];
 }
+
+int bt_audio_codec_cfg_set_frame_blocks_per_sdu(struct bt_audio_codec_cfg *codec_cfg,
+						uint8_t frame_blocks)
+{
+	return bt_audio_codec_cfg_set_val(codec_cfg, BT_AUDIO_CODEC_CONFIG_LC3_FRAME_BLKS_PER_SDU,
+					  &frame_blocks, sizeof(frame_blocks));
+}
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 
 #if CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE > 0 ||                                             \

--- a/tests/bluetooth/audio/codec/src/main.c
+++ b/tests/bluetooth/audio/codec/src/main.c
@@ -136,6 +136,22 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_get_frame_blocks_per_sdu)
 	zassert_equal(ret, 1u, "unexpected return value %d", ret);
 }
 
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_set_frame_blocks_per_sdu)
+{
+	struct bt_bap_lc3_preset preset = BT_BAP_LC3_UNICAST_PRESET_32_2_2(
+		BT_AUDIO_LOCATION_FRONT_LEFT, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	int ret;
+
+	ret = bt_audio_codec_cfg_get_frame_blocks_per_sdu(&preset.codec_cfg, true);
+	zassert_equal(ret, 1, "Unexpected return value %d", ret);
+
+	ret = bt_audio_codec_cfg_set_frame_blocks_per_sdu(&preset.codec_cfg, 2U);
+	zassert_true(ret > 0, "Unexpected return value %d", ret);
+
+	ret = bt_audio_codec_cfg_get_frame_blocks_per_sdu(&preset.codec_cfg, true);
+	zassert_equal(ret, 2, "Unexpected return value %d", ret);
+}
+
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_pref_context)
 {
 	const enum bt_audio_context ctx =


### PR DESCRIPTION
Add the bt_audio_codec_cfg_set_frame_blocks_per_sdu function
to set or add the frame blocks per SDU field in the
codec configuration.
