### PR TITLE
drivers: spi: stm32h7: Use SPI FIFO

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -272,6 +272,48 @@ static int spi_dma_move_buffers(const struct device *dev, size_t len)
 /* Value to shift out when no application data needs transmitting. */
 #define SPI_STM32_TX_NOP 0x00
 
+static void spi_stm32_send_next_frame(SPI_TypeDef *spi,
+		struct spi_stm32_data *data)
+{
+	const uint8_t frame_size = SPI_WORD_SIZE_GET(data->ctx.config->operation);
+	uint32_t tx_frame = SPI_STM32_TX_NOP;
+
+	if (frame_size == 8) {
+		if (spi_context_tx_buf_on(&data->ctx)) {
+			tx_frame = UNALIGNED_GET((uint8_t *)(data->ctx.tx_buf));
+		}
+		LL_SPI_TransmitData8(spi, tx_frame);
+		spi_context_update_tx(&data->ctx, 1, 1);
+	} else {
+		if (spi_context_tx_buf_on(&data->ctx)) {
+			tx_frame = UNALIGNED_GET((uint16_t *)(data->ctx.tx_buf));
+		}
+		LL_SPI_TransmitData16(spi, tx_frame);
+		spi_context_update_tx(&data->ctx, 2, 1);
+	}
+}
+
+static void spi_stm32_read_next_frame(SPI_TypeDef *spi,
+		struct spi_stm32_data *data)
+{
+	const uint8_t frame_size = SPI_WORD_SIZE_GET(data->ctx.config->operation);
+	uint32_t rx_frame = 0;
+
+	if (frame_size == 8) {
+		rx_frame = LL_SPI_ReceiveData8(spi);
+		if (spi_context_rx_buf_on(&data->ctx)) {
+			UNALIGNED_PUT(rx_frame, (uint8_t *)data->ctx.rx_buf);
+		}
+		spi_context_update_rx(&data->ctx, 1, 1);
+	} else {
+		rx_frame = LL_SPI_ReceiveData16(spi);
+		if (spi_context_rx_buf_on(&data->ctx)) {
+			UNALIGNED_PUT(rx_frame, (uint16_t *)data->ctx.rx_buf);
+		}
+		spi_context_update_rx(&data->ctx, 2, 1);
+	}
+}
+
 static bool spi_stm32_transfer_ongoing(struct spi_stm32_data *data)
 {
 	return spi_context_tx_on(&data->ctx) || spi_context_rx_on(&data->ctx);
@@ -299,46 +341,17 @@ static int spi_stm32_get_err(SPI_TypeDef *spi)
 /* Shift a SPI frame as master. */
 static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 {
-	uint16_t tx_frame = SPI_STM32_TX_NOP;
-	uint16_t rx_frame;
-
 	while (!ll_func_tx_is_not_full(spi)) {
 		/* NOP */
 	}
 
-	if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 8) {
-		if (spi_context_tx_buf_on(&data->ctx)) {
-			tx_frame = UNALIGNED_GET((uint8_t *)(data->ctx.tx_buf));
-		}
-		LL_SPI_TransmitData8(spi, tx_frame);
-		/* The update is ignored if TX is off. */
-		spi_context_update_tx(&data->ctx, 1, 1);
-	} else {
-		if (spi_context_tx_buf_on(&data->ctx)) {
-			tx_frame = UNALIGNED_GET((uint16_t *)(data->ctx.tx_buf));
-		}
-		LL_SPI_TransmitData16(spi, tx_frame);
-		/* The update is ignored if TX is off. */
-		spi_context_update_tx(&data->ctx, 2, 1);
-	}
+	spi_stm32_send_next_frame(spi, data);
 
 	while (!ll_func_rx_is_not_empty(spi)) {
 		/* NOP */
 	}
 
-	if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 8) {
-		rx_frame = LL_SPI_ReceiveData8(spi);
-		if (spi_context_rx_buf_on(&data->ctx)) {
-			UNALIGNED_PUT(rx_frame, (uint8_t *)data->ctx.rx_buf);
-		}
-		spi_context_update_rx(&data->ctx, 1, 1);
-	} else {
-		rx_frame = LL_SPI_ReceiveData16(spi);
-		if (spi_context_rx_buf_on(&data->ctx)) {
-			UNALIGNED_PUT(rx_frame, (uint16_t *)data->ctx.rx_buf);
-		}
-		spi_context_update_rx(&data->ctx, 2, 1);
-	}
+	spi_stm32_read_next_frame(spi, data);
 }
 
 /* Shift a SPI frame as slave. */

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -302,7 +302,7 @@ static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 	uint16_t tx_frame = SPI_STM32_TX_NOP;
 	uint16_t rx_frame;
 
-	while (!ll_func_tx_is_empty(spi)) {
+	while (!ll_func_tx_is_not_full(spi)) {
 		/* NOP */
 	}
 
@@ -344,7 +344,7 @@ static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 /* Shift a SPI frame as slave. */
 static void spi_stm32_shift_s(SPI_TypeDef *spi, struct spi_stm32_data *data)
 {
-	if (ll_func_tx_is_empty(spi) && spi_context_tx_on(&data->ctx)) {
+	if (ll_func_tx_is_not_full(spi) && spi_context_tx_on(&data->ctx)) {
 		uint16_t tx_frame;
 
 		if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 8) {

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -306,20 +306,6 @@ static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 		/* NOP */
 	}
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	/* With the STM32MP1, STM32U5 and the STM32H7,
-	 * if the device is the SPI master,
-	 * we need to enable the start of the transfer with
-	 * LL_SPI_StartMasterTransfer(spi)
-	 */
-	if (LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
-		LL_SPI_StartMasterTransfer(spi);
-		while (!LL_SPI_IsActiveMasterTransfer(spi)) {
-			/* NOP */
-		}
-	}
-#endif
-
 	if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 8) {
 		if (spi_context_tx_buf_on(&data->ctx)) {
 			tx_frame = UNALIGNED_GET((uint8_t *)(data->ctx.tx_buf));
@@ -690,6 +676,20 @@ static int transceive(const struct device *dev,
 #endif
 
 	LL_SPI_Enable(spi);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+	/* With the STM32MP1, STM32U5 and the STM32H7,
+	 * if the device is the SPI master,
+	 * we need to enable the start of the transfer with
+	 * LL_SPI_StartMasterTransfer(spi)
+	 */
+	if (LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
+		LL_SPI_StartMasterTransfer(spi);
+		while (!LL_SPI_IsActiveMasterTransfer(spi)) {
+			/* NOP */
+		}
+	}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
 #if CONFIG_SOC_SERIES_STM32H7X
 	/*

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -94,7 +94,7 @@ static inline uint32_t ll_func_spi_dma_busy(SPI_TypeDef *spi)
 }
 #endif /* CONFIG_SPI_STM32_DMA */
 
-static inline uint32_t ll_func_tx_is_empty(SPI_TypeDef *spi)
+static inline uint32_t ll_func_tx_is_not_full(SPI_TypeDef *spi)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	return LL_SPI_IsActiveFlag_TXP(spi);


### PR DESCRIPTION
This is a proposal to support different "packet sizes" in the SPI driver. In this context, a packet size bigger than one allows to write more than one frame to the SPI's TxFIFO (in case it has one) so that delays can be avoided:

 * It allows to remove delays between frames.
 * If interrupts are enabled, the same data will be sent using less interrupts, as each one will send several frames.

To ilustrate the first point, here are some captures of a transmission with the stm32h7 SPI current driver:

![with_gaps](https://github.com/zephyrproject-rtos/zephyr/assets/127399215/fdf9bdd6-7632-4cab-b2b9-d22e2e2864eb)

As you can see above, there are delays between each frame. This can dramatically impair performance when sending large amounts of data.

If a bigger packet size is used for the same transmission, the delays disappear:

![without_gaps](https://github.com/zephyrproject-rtos/zephyr/assets/127399215/34f41597-61c6-4266-8650-7fd98aaa5bbd)

EDIT
------
After the received feedback, this PR will no longer use the FIFO threshold. It now implements the use of the FIFO but without using modifying the FIFO threshold (so it defaults to 1). This still fixes the performance problem described above.

Test plan
=========

Connect an STM32H7 board to the PC with pins D11 and D12 connected.

Open a minicom or equivalent terminal to read the test report.

Execute the following commands:

```
rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_test_packet_sizes.loopback
west flash
```

And verify all tests pass.


EDIT
-------
The tests above are no longer necessary as the use of the FIFO threshold has been discarded. Thus, run the already existing spi loopback tests and verify they pass:

```
rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi tests/drivers/spi/spi_loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames_dma.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma_no_nocache.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames_dma_no_nocache.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_interrupt.loopback
west flash




rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h743zi tests/drivers/spi/spi_loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h743zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h743zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h743zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames_dma.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h743zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_dma_no_nocache.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h743zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_16bits_frames_dma_no_nocache.loopback
west flash

rm -rf ~/zephyrproject/zephyr/build
west build -p auto -b nucleo_h753zi -T tests/drivers/spi/spi_loopback/drivers.spi.stm32_spi_interrupt.loopback
west flash
```

EDIT 2
---------
This PR has also been tested with 2 separated nucleo boards (H743), one acting as SPI master and the other as SPI slave.
