### PR TITLE
Bluetooth: Controller: nRF53: Fix back-to-back PDU chaining

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -394,7 +394,7 @@ static void isr_tx_chain(void *param)
 						 lll->phy_s, lll->phy_flags);
 	} else {
 		radio_isr_set(isr_done, lll_aux);
-		radio_switch_complete_and_disable();
+		radio_switch_complete_and_b2b_tx_disable();
 	}
 
 	radio_pkt_tx_set(pdu);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -367,7 +367,7 @@ static void isr_tx(void *param)
 		switch_radio_complete_and_b2b_tx(lll_sync, lll->phy_s);
 	} else {
 		radio_isr_set(isr_done, lll_sync);
-		radio_switch_complete_and_disable();
+		radio_switch_complete_and_b2b_tx_disable();
 	}
 
 	radio_pkt_tx_set(pdu);


### PR DESCRIPTION
Fix back-to-back PDU chaining using DPPI on nRF53x SoC. Relates to commit b61bd2364c1a ("Bluetooth: Controller: nrf53: Fix back-to-back Tx Rx implementation").