### PR TITLE
Revert "intel_adsp: move memory window setup to PRE_KERNEL_1"

### DIFF
--- a/drivers/console/winstream_console.c
+++ b/drivers/console/winstream_console.c
@@ -62,4 +62,4 @@ static int winstream_console_init(void)
 	return 0;
 }
 
-SYS_INIT(winstream_console_init, PRE_KERNEL_1, CONFIG_CONSOLE_INIT_PRIORITY);
+SYS_INIT(winstream_console_init, EARLY, CONFIG_CONSOLE_INIT_PRIORITY);

--- a/soc/xtensa/intel_adsp/common/mem_window.c
+++ b/soc/xtensa/intel_adsp/common/mem_window.c
@@ -54,9 +54,8 @@ void mem_window_idle_exit(void)
 		.mem_base = DT_REG_ADDR(DT_PHANDLE(MEM_WINDOW_NODE(n), memory)) + WIN_OFFSET(n),   \
 		.initialize = DT_PROP(MEM_WINDOW_NODE(n), initialize),                             \
 	};                                                                                         \
-	DEVICE_DT_DEFINE(MEM_WINDOW_NODE(n), mem_win_init, NULL, NULL,                             \
-			&mem_win_config_##n, PRE_KERNEL_1,                                         \
-			CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+	DEVICE_DT_DEFINE(MEM_WINDOW_NODE(n), mem_win_init, NULL, NULL, &mem_win_config_##n, EARLY, \
+			 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
 
 #if DT_NODE_HAS_STATUS(MEM_WINDOW_NODE(0), okay)
 MEM_WINDOW_DEFINE(0)


### PR DESCRIPTION
This reverts commit 759e07bebe208f4cc1036a7525a80551e16a465c.