### PR TITLE
tests bluetooth mesh: Fixes around asserts 

### DIFF
--- a/tests/bsim/bluetooth/mesh/src/mesh_test.h
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.h
@@ -66,21 +66,40 @@
 		}                                                              \
 	} while (0)
 
-#define ASSERT_TRUE(cond, ...)                                                 \
+#define ASSERT_TRUE(cond)                                                      \
 	do {                                                                   \
 		if (!(cond)) {                                                 \
 			bst_result = Failed;                                   \
 			bs_trace_error_time_line(                              \
-				#cond " is false.", ##__VA_ARGS__);             \
+				#cond " is false.\n");                         \
 		}                                                              \
 	} while (0)
 
-#define ASSERT_FALSE(cond, ...)                                                \
+#define ASSERT_TRUE_MSG(cond, fmt, ...)                                        \
+	do {                                                                   \
+		if (!(cond)) {                                                 \
+			bst_result = Failed;                                   \
+			bs_trace_error_time_line(                              \
+				#cond " is false. " fmt, ##__VA_ARGS__);       \
+		}                                                              \
+	} while (0)
+
+
+#define ASSERT_FALSE(cond)                                                     \
 	do {                                                                   \
 		if (cond) {                                                    \
 			bst_result = Failed;                                   \
 			bs_trace_error_time_line(                              \
-				#cond " is true.", ##__VA_ARGS__);             \
+				#cond " is true.\n");                          \
+		}                                                              \
+	} while (0)
+
+#define ASSERT_FALSE_MSG(cond, fmt, ...)                                       \
+	do {                                                                   \
+		if (cond) {                                                    \
+			bst_result = Failed;                                   \
+			bs_trace_error_time_line(                              \
+				#cond " is true. " fmt, ##__VA_ARGS__);        \
 		}                                                              \
 	} while (0)
 

--- a/tests/bsim/bluetooth/mesh/src/test_advertiser.c
+++ b/tests/bsim/bluetooth/mesh/src/test_advertiser.c
@@ -84,7 +84,7 @@ static void allocate_all_array(struct net_buf **buf, size_t num_buf, uint8_t xmi
 		*buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
 					  xmit, K_NO_WAIT);
 
-		ASSERT_FALSE(!*buf, "Out of buffers");
+		ASSERT_FALSE_MSG(!*buf, "Out of buffers\n");
 		buf++;
 	}
 }
@@ -96,7 +96,7 @@ static void verify_adv_queue_overflow(void)
 	/* Verity Queue overflow */
 	dummy_buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
 				       BT_MESH_TRANSMIT(2, 20), K_NO_WAIT);
-	ASSERT_TRUE(!dummy_buf, "Unexpected extra buffer");
+	ASSERT_TRUE_MSG(!dummy_buf, "Unexpected extra buffer\n");
 }
 
 static bool check_delta_time(uint8_t transmit, uint64_t interval)
@@ -162,7 +162,7 @@ static void realloc_end_cb(int err, void *cb_data)
 	ASSERT_EQUAL(0, err);
 	buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
 			BT_MESH_TRANSMIT(2, 20), K_NO_WAIT);
-	ASSERT_FALSE(!buf, "Out of buffers");
+	ASSERT_FALSE_MSG(!buf, "Out of buffers\n");
 
 	k_sem_give(&observer_sem);
 }
@@ -248,13 +248,13 @@ static void rx_gatt_beacons(void)
 	int err;
 
 	err = bt_le_scan_start(&scan_param, gatt_scan_cb);
-	ASSERT_FALSE(err && err != -EALREADY, "starting scan failed (err %d)", err);
+	ASSERT_FALSE_MSG(err && err != -EALREADY, "Starting scan failed (err %d)\n", err);
 
 	err = k_sem_take(&observer_sem, K_SECONDS(20));
 	ASSERT_OK(err);
 
 	err = bt_le_scan_stop();
-	ASSERT_FALSE(err && err != -EALREADY, "stopping scan failed (err %d)", err);
+	ASSERT_FALSE_MSG(err && err != -EALREADY, "Stopping scan failed (err %d)\n", err);
 }
 
 static void xmit_scan_cb(const bt_addr_le_t *addr, int8_t rssi, uint8_t adv_type,
@@ -294,13 +294,13 @@ static void rx_xmit_adv(void)
 	int err;
 
 	err = bt_le_scan_start(&scan_param, xmit_scan_cb);
-	ASSERT_FALSE(err && err != -EALREADY, "starting scan failed (err %d)", err);
+	ASSERT_FALSE_MSG(err && err != -EALREADY, "Starting scan failed (err %d)\n", err);
 
 	err = k_sem_take(&observer_sem, K_SECONDS(20));
 	ASSERT_OK(err);
 
 	err = bt_le_scan_stop();
-	ASSERT_FALSE(err && err != -EALREADY, "stopping scan failed (err %d)", err);
+	ASSERT_FALSE_MSG(err && err != -EALREADY, "Stopping scan failed (err %d)\n", err);
 }
 
 static void send_order_start_cb(uint16_t duration, int err, void *user_data)
@@ -324,7 +324,7 @@ static void send_order_end_cb(int err, void *user_data)
 	struct net_buf *buf = (struct net_buf *)user_data;
 
 	ASSERT_OK_MSG(err, "Failed adv start cb err (%d)", err);
-	ASSERT_TRUE(!buf->data, "Data not cleared!");
+	ASSERT_TRUE_MSG(!buf->data, "Data not cleared!\n");
 	seq_checker++;
 	LOG_INF("tx end: seq(%d)", seq_checker);
 
@@ -368,7 +368,7 @@ static void receive_order(int expect_adv)
 	int err;
 
 	err = bt_le_scan_start(&scan_param, receive_order_scan_cb);
-	ASSERT_FALSE(err && err != -EALREADY, "starting scan failed (err %d)", err);
+	ASSERT_FALSE_MSG(err && err != -EALREADY, "Starting scan failed (err %d)\n", err);
 
 	previous_checker = 0xff;
 	for (int i = 0; i < expect_adv; i++) {
@@ -377,7 +377,7 @@ static void receive_order(int expect_adv)
 	}
 
 	err = bt_le_scan_stop();
-	ASSERT_FALSE(err && err != -EALREADY, "stopping scan failed (err %d)", err);
+	ASSERT_FALSE_MSG(err && err != -EALREADY, "Stopping scan failed (err %d)\n", err);
 }
 
 static void send_adv_buf(struct net_buf *buf, uint8_t curr, uint8_t prev)
@@ -427,7 +427,7 @@ static void test_tx_cb_single(void)
 
 	buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
 			BT_MESH_TRANSMIT(2, 20), K_NO_WAIT);
-	ASSERT_FALSE(!buf, "Out of buffers");
+	ASSERT_FALSE_MSG(!buf, "Out of buffers\n");
 
 	send_cb.start = single_start_cb;
 	send_cb.end = single_end_cb;
@@ -638,16 +638,16 @@ static void test_tx_random_order(void)
 	previous_checker = 0xff;
 	buf[0] = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
 				    xmit, K_NO_WAIT);
-	ASSERT_FALSE(!buf[0], "Out of buffers");
+	ASSERT_FALSE_MSG(!buf[0], "Out of buffers\n");
 	buf[1] = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
 				    xmit, K_NO_WAIT);
-	ASSERT_FALSE(!buf[1], "Out of buffers");
+	ASSERT_FALSE_MSG(!buf[1], "Out of buffers\n");
 
 	send_adv_buf(buf[0], 0, 0xff);
 
 	buf[2] = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
 				    xmit, K_NO_WAIT);
-	ASSERT_FALSE(!buf[2], "Out of buffers");
+	ASSERT_FALSE_MSG(!buf[2], "Out of buffers\n");
 
 	send_adv_buf(buf[2], 2, 0);
 

--- a/tests/bsim/bluetooth/mesh/src/test_blob.c
+++ b/tests/bsim/bluetooth/mesh/src/test_blob.c
@@ -77,13 +77,13 @@ static int blob_chunk_wr(const struct bt_mesh_blob_io *io,
 			 const struct bt_mesh_blob_chunk *chunk)
 {
 	partial_block += chunk->size;
-	ASSERT_TRUE(partial_block <= block->size, "Received block is too large");
+	ASSERT_TRUE_MSG(partial_block <= block->size, "Received block is too large\n");
 
 
 	if (partial_block == block->size) {
 		partial_block = 0;
-		ASSERT_FALSE(atomic_test_and_set_bit(block_bitfield, block->number),
-			     "Received duplicate block");
+		ASSERT_FALSE_MSG(atomic_test_and_set_bit(block_bitfield, block->number),
+				 "Received duplicate block\n");
 	}
 
 	if (atomic_test_bit(block_bitfield, 0)) {

--- a/tests/bsim/bluetooth/mesh/src/test_blob.c
+++ b/tests/bsim/bluetooth/mesh/src/test_blob.c
@@ -1525,7 +1525,7 @@ static void srv_check_reboot_and_continue(void)
 	ASSERT_EQUAL(0, blob_srv.state.ttl);
 	ASSERT_EQUAL(BLOB_CLI_ADDR, blob_srv.state.cli);
 	ASSERT_EQUAL(1, blob_srv.state.timeout_base);
-	ASSERT_TRUE(BT_MESH_TX_SDU_MAX, blob_srv.state.mtu_size);
+	ASSERT_EQUAL(BT_MESH_RX_SDU_MAX - BT_MESH_MIC_SHORT, blob_srv.state.mtu_size);
 	ASSERT_EQUAL(CONFIG_BT_MESH_BLOB_BLOCK_SIZE_MAX * 2, blob_srv.state.xfer.size);
 	ASSERT_EQUAL(12, blob_srv.state.xfer.block_size_log);
 	ASSERT_EQUAL(1, blob_srv.state.xfer.id);

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -601,8 +601,8 @@ static void test_dist_dfu_slot_create(void)
 	size_t metadata_len = 4;
 	int err, i;
 
-	ASSERT_TRUE(CONFIG_BT_MESH_DFU_SLOT_CNT >= 3,
-		    "CONFIG_BT_MESH_DFU_SLOT_CNT must be at least 3");
+	ASSERT_TRUE_MSG(CONFIG_BT_MESH_DFU_SLOT_CNT >= 3,
+			"CONFIG_BT_MESH_DFU_SLOT_CNT must be at least 3\n");
 
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
 	bt_mesh_device_setup(&prov, &dist_comp);
@@ -613,7 +613,7 @@ static void test_dist_dfu_slot_create(void)
 		metadata[0] = i;
 		slot[i] = slot_reserve_and_set(size, fwid, fwid_len, metadata, metadata_len);
 
-		ASSERT_FALSE(slot[i] == NULL, "Failed to add slot");
+		ASSERT_FALSE_MSG(slot[i] == NULL, "Failed to add slot\n");
 
 		if (i > 0) {
 			/* All but first slot are committed */
@@ -668,8 +668,8 @@ static void test_dist_dfu_slot_create_recover(void)
 	size_t metadata_len = 4;
 	int i, idx;
 
-	ASSERT_TRUE(CONFIG_BT_MESH_DFU_SLOT_CNT >= 3,
-		    "CONFIG_BT_MESH_DFU_SLOT_CNT must be at least 3");
+	ASSERT_TRUE_MSG(CONFIG_BT_MESH_DFU_SLOT_CNT >= 3,
+			"CONFIG_BT_MESH_DFU_SLOT_CNT must be at least 3\n");
 
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
 	bt_mesh_device_setup(&prov, &dist_comp);
@@ -698,8 +698,8 @@ static void check_delete_all(void)
 	const struct bt_mesh_dfu_slot *slot;
 	size_t slot_count;
 
-	ASSERT_TRUE(CONFIG_BT_MESH_DFU_SLOT_CNT >= 3,
-		    "CONFIG_BT_MESH_DFU_SLOT_CNT must be at least 3");
+	ASSERT_TRUE_MSG(CONFIG_BT_MESH_DFU_SLOT_CNT >= 3,
+			"CONFIG_BT_MESH_DFU_SLOT_CNT must be at least 3\n");
 
 	slot_count = bt_mesh_dfu_slot_foreach(NULL, NULL);
 	ASSERT_EQUAL(0, slot_count);
@@ -712,8 +712,8 @@ static void check_delete_all(void)
 
 static void test_dist_dfu_slot_delete_all(void)
 {
-	ASSERT_TRUE(CONFIG_BT_MESH_DFU_SLOT_CNT >= 3,
-		    "CONFIG_BT_MESH_DFU_SLOT_CNT must be at least 3");
+	ASSERT_TRUE_MSG(CONFIG_BT_MESH_DFU_SLOT_CNT >= 3,
+			"CONFIG_BT_MESH_DFU_SLOT_CNT must be at least 3\n");
 
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
 	bt_mesh_device_setup(&prov, &dist_comp);
@@ -763,8 +763,8 @@ static void test_dist_dfu_slot_idempotency(void)
 	size_t fwid_len = 4;
 	struct bt_mesh_dfu_slot *slot;
 
-	ASSERT_TRUE(CONFIG_BT_MESH_DFU_SLOT_CNT >= 1,
-		    "CONFIG_BT_MESH_DFU_SLOT_CNT must be at least 1");
+	ASSERT_TRUE_MSG(CONFIG_BT_MESH_DFU_SLOT_CNT >= 1,
+			"CONFIG_BT_MESH_DFU_SLOT_CNT must be at least 1\n");
 
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
 	bt_mesh_device_setup(&prov, &dist_comp);

--- a/tests/bsim/bluetooth/mesh/src/test_provision.c
+++ b/tests/bsim/bluetooth/mesh/src/test_provision.c
@@ -565,7 +565,7 @@ static void node_configure_and_reset(void)
 					  BT_MESH_MODEL_ID_HEALTH_SRV, &healthpub,
 					  &status));
 	ASSERT_EQUAL(0, status);
-	ASSERT_TRUE(healthpub.addr == BT_MESH_ADDR_UNASSIGNED, "Pub not cleared");
+	ASSERT_TRUE_MSG(healthpub.addr == BT_MESH_ADDR_UNASSIGNED, "Pub not cleared\n");
 
 	/* Set pub and sub to check that they are reset */
 	healthpub.addr = 0xc001;

--- a/tests/bsim/bluetooth/mesh/src/test_replay_cache.c
+++ b/tests/bsim/bluetooth/mesh/src/test_replay_cache.c
@@ -178,7 +178,7 @@ static void test_rx_immediate_replay_attack(void)
 
 	k_sleep(K_SECONDS(6 * TEST_DATA_WAITING_TIME));
 
-	ASSERT_TRUE(rx_cnt == 3, "Device didn't receive expected data");
+	ASSERT_TRUE_MSG(rx_cnt == 3, "Device didn't receive expected data\n");
 
 	PASS();
 }
@@ -235,7 +235,7 @@ static void test_rx_power_replay_attack(void)
 
 	k_sleep(K_SECONDS(6 * TEST_DATA_WAITING_TIME));
 
-	ASSERT_TRUE(rx_cnt == 3, "Device didn't receive expected data");
+	ASSERT_TRUE_MSG(rx_cnt == 3, "Device didn't receive expected data\n");
 
 	PASS();
 }


### PR DESCRIPTION
    tests bluetooth mesh: Fix ASSERT_TRUE/FALSE with messages
    
    The previous ASSERT_TRUE/FALSE macros looked like
    they could take extra printf like parameters but did not
    (those extra arguments were just dropped).
    
    Define 2 new macros that can take those extra parameters
    and fix all uses that intended to print those extra messages.
    
    Also add an extra "\n" as the underlaying print functions
    do not add end of lines on their own.
    
----------

    tests bluetooth mesh: Fix an incorrect assert
    
    This ASSERT_TRUE should have been an assert equal
    (ASSERT_TRUE checks that the first paramters != 0)
    and the condition was not correct.
    Fix it.
    
