### PR TITLE
scripts: domains: More stability improvements

### DIFF
--- a/scripts/pylib/build_helpers/domains.py
+++ b/scripts/pylib/build_helpers/domains.py
@@ -8,6 +8,8 @@ This provides parsing of domains yaml file and creation of objects of the
 Domain class.
 '''
 
+from dataclasses import dataclass
+
 import yaml
 import pykwalify.core
 import logging
@@ -119,24 +121,8 @@ class Domains:
         return self._build_dir
 
 
+@dataclass
 class Domain:
 
-    def __init__(self, name, build_dir):
-        self.name = name
-        self.build_dir = build_dir
-
-    @property
-    def name(self):
-        return self._name
-
-    @name.setter
-    def name(self, value):
-        self._name = value
-
-    @property
-    def build_dir(self):
-        return self._build_dir
-
-    @build_dir.setter
-    def build_dir(self, value):
-        self._build_dir = value
+    name: str
+    build_dir: str

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -151,9 +151,14 @@ def load_domains(path):
     domains_file = Path(path) / 'domains.yaml'
 
     if not domains_file.is_file():
-        return Domains.from_data({'default': 'app',
-                                  'build_dir': path,
-                                  'domains': [{'name': 'app', 'build_dir': path}],
-                                  'flash_order': ['app']})
+        return Domains.from_yaml(f'''\
+default: app
+build_dir: {path}
+domains:
+  - name: app
+    build_dir: {path}
+flash_order:
+  - app
+''')
 
     return Domains.from_file(domains_file)


### PR DESCRIPTION
Fixes #63166

* Catch inconsistent `domains.yaml` contents early
* In the YAML schema, make "domains" a required key
* Remove unnecessary warnings
* Remove support for initializing `Domains` from a dictionary
* Bonus: Convert `Domain` into a dataclass (cosmetic)