### PR TITLE
nrf_hw_models: Update HW models to latest and align with them

### DIFF
--- a/boards/posix/nrf52_bsim/common/bstests_entry.c
+++ b/boards/posix/nrf52_bsim/common/bstests_entry.c
@@ -244,3 +244,28 @@ uint8_t bst_delete(void)
 
 	return bst_result;
 }
+
+#if defined(CONFIG_NATIVE_SIMULATOR_CPU_N)
+#include "bstest_ticker.h"
+
+void bst_ticker_set_period(bs_time_t tick_period)
+{
+	bst_ticker_amp_set_period(CONFIG_NATIVE_SIMULATOR_CPU_N, tick_period);
+}
+
+void bst_ticker_set_next_tick_absolute(bs_time_t time)
+{
+	bst_ticker_amp_set_next_tick_absolutelute(CONFIG_NATIVE_SIMULATOR_CPU_N, time);
+}
+
+void bst_ticker_set_next_tick_delta(bs_time_t time)
+{
+	bst_ticker_amp_set_next_tick_delta(CONFIG_NATIVE_SIMULATOR_CPU_N, time);
+}
+
+void bst_awake_cpu_asap(void)
+{
+	bst_ticker_amp_awake_cpu_asap(CONFIG_NATIVE_SIMULATOR_CPU_N);
+}
+
+#endif /* defined(CONFIG_NATIVE_SIMULATOR_CPU_N) */

--- a/boards/posix/nrf52_bsim/cpu_wait.c
+++ b/boards/posix/nrf52_bsim/cpu_wait.c
@@ -32,7 +32,7 @@ void arch_busy_wait(uint32_t usec_to_wait)
 		 * There may be wakes due to other interrupts or nested calls to
 		 * k_busy_wait in interrupt handlers
 		 */
-		fake_timer_wake_in_time(time_end);
+		nhw_fake_timer_wake_in_time(CONFIG_NATIVE_SIMULATOR_CPU_N, time_end);
 		posix_halt_cpu();
 	}
 }
@@ -58,7 +58,7 @@ void posix_cpu_hold(uint32_t usec_to_waste)
 		 * cpu_hold in interrupt handlers
 		 */
 		time_start = nsi_hws_get_time();
-		fake_timer_wake_in_time(time_start + to_wait);
+		nhw_fake_timer_wake_in_time(CONFIG_NATIVE_SIMULATOR_CPU_N, time_start + to_wait);
 		posix_change_cpu_state_and_wait(true);
 		to_wait -= nsi_hws_get_time() - time_start;
 

--- a/boards/posix/nrf52_bsim/nsi_if.c
+++ b/boards/posix/nrf52_bsim/nsi_if.c
@@ -12,6 +12,7 @@
 #include "bstests.h"
 #include "bs_tracing.h"
 #include "phy_sync_ctrl.h"
+#include "nsi_hw_scheduler.h"
 
 NATIVE_SIMULATOR_IF void nsif_cpu0_pre_cmdline_hooks(void)
 {
@@ -89,9 +90,11 @@ NATIVE_SIMULATOR_IF void nsif_cpu0_irq_raised(void)
 	posix_interrupt_raised();
 }
 
-NATIVE_SIMULATOR_IF void nsif_cpu0_bst_tick(uint64_t time)
+NATIVE_SIMULATOR_IF int nsif_cpu0_test_hook(void *p)
 {
-	bst_tick(time);
+	(void) p;
+	bst_tick(nsi_hws_get_time());
+	return 0;
 }
 
 NATIVE_SIMULATOR_IF void nsif_cpu0_irq_raised_from_sw(void)

--- a/west.yml
+++ b/west.yml
@@ -303,7 +303,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 57b61a9a2da75c860f15ca79522b24d57992df2c
+      revision: f4595802d32d103718bf50b3d390b7a450895843
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 42b7c577714b8f22ce82a901e19c1814af4609a8


### PR DESCRIPTION
* In Zephyr:
  * The HW models now include N fake timers, and N bst timers. The embedded code needs to target the one for its CPU specifically.

* Update the HW models module to f4595802d32d103718bf50b3d390b7a450895843

  Including the following:
  * f459580 TEMP & ECB: Fix INTEN sideeffect prototypes
  * 50c2abe nrfx_common: Fix build error with clang
  * 5f0ae29 FICR: Add nrf53 variants
  * 82ee9bd DPPI: On initialization, set all registers to their reset value
  * 1472c34 NVMC & UICR: Readied for nrf53
  * f425c08 NVMC & UICR: Refactor
  * 3a4cfc2 RADIO: Parametrize ED_RSSIOFFS
  * a20e9fc nrfx_get_irq_number() Add missing CCM peripheral for nrf5340net
  * c199715 DPPI: Bugfix
  * 93806ac Zephyr cmake: Align with nrf53 board rename
  * 51f26a3 VREQCTRL: Add register stub and definitions for nrf53
  * 802e0cf RADIO: Switch to level interrupts, readied for nrf53
  * 49bcea2 Templates: Added shortcut check & event signaling version for s
  * a880cd6 Template: Move static out of signal handler definition
  * 709f82b TEMP: Switched to level interrupts, readied for nrf53
  * 6ef0069 AES_CCM: Switched to level interrupts, readied for nrf53
  * eaa89da RNG: Use common templates
  * 75a6cb4 AAR: Switched to level interrupts, readied for nrf53
  * fbf58f3 AES_ECB: Switched to level interrupts, readied for nrf53
  * d084647 RNG: Bugfix in STOP subscription
  * 8007318 Templates: Added template code for the most common models logic
  * bab6a54 int ctrl: Added new API
  * daaaaa0 config: Fix nrf53 Net core EGU instance HAL mapping
  * 54570a0 nrf5340 RTC int mapping fix
  * 043af26 nrfx_common: Provide nrfx_get_irq_number() for 5340 cores
  * ecd7b9b SWI: Add SWI pseudo peripheral
  * a70c73b CLOCK: Add missing TASK sideeffecting prototypes, and fix typo
  * 56c7581 nrf5340: Split HAL files in net and app sets
  * 3892d3e Add API to get the MCUs/domains names
  * 8f485bc RADIO: Prevent clang build warning
  * 5aac1c2 hal: Build weak version of the HAL for the 53 series also
  * f18422d standalone nrfx_config: Provide needed definitions for nrf53
  * 4015d5a nrfx_glue_bsim: Provide 2 trivial definitions for standalone bu
  * 4af80d5 cmsis stubs: Provide trivial macro to replace ISB
  * b6c2769 cmsis replacements: Fix for other Zephyr bsim targets
  * 8316930 zephyr CMakefile: Set HAL version based on Kconfig
  * 4404106 RNG: Rename functions to match new naming convention
  * a3dbb38 RTC: Rename functions to match new naming convention
  * 886dc73 CLOCK: Rename functions to match new naming convention
  * bcb2b99 EGU: Rename functions to match new naming convention
  * 50af67e TIMER: Rename functions to match new naming convention
  * 8120224 CLOCK/POWER/RESET: Add DPPI connections, generalize to N instan
  * 450337c RTC: Add DPPI connection, nrf53 support and new functionality
  * 2918ce6 DPPI common subscription: Minor API change
  * ec1c2a7 TIMER: Add DPPI connection, nrf53 support and functionality
  * e6f9860 EGU: Add DPPI connection, nrf53 support and generalize
  * c8a4368 bst_ticker: Generalize to N instances
  * 093deee fake timer: Generalize to N instances
  * 302da8d DPPI: Typo fix
  
  ----
  
This is part of the introduction of the nrf53_bsim https://github.com/zephyrproject-rtos/zephyr/pull/63193 , but benefits on its own.
Note: The DNM tag is to ensure @jori-nordic can provide his blessing.