### PR TITLE
mgmt/MCUmgr/mgmt: Support for finding registered command groups

### DIFF
--- a/include/zephyr/mgmt/mcumgr/mgmt/mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/mgmt.h
@@ -123,6 +123,16 @@ void mgmt_unregister_group(struct mgmt_group *group);
  */
 const struct mgmt_handler *mgmt_find_handler(uint16_t group_id, uint16_t command_id);
 
+/**
+ * @brief Finds a registered command group.
+ *
+ * @param group_id	The command group id to find.
+ *
+ * @return	The requested command group on success;
+ *		NULL on failure.
+ */
+const struct mgmt_group *mgmt_find_group(uint16_t group_id);
+
 #if IS_ENABLED(CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL)
 /**
  * @brief		Finds a registered error translation function for converting from SMP

--- a/subsys/mgmt/mcumgr/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/mgmt/src/mgmt.c
@@ -69,6 +69,29 @@ mgmt_find_handler(uint16_t group_id, uint16_t command_id)
 	return &group->mg_handlers[command_id];
 }
 
+const struct mgmt_group *
+mgmt_find_group(uint16_t group_id)
+{
+	struct mgmt_group *group = NULL;
+	sys_snode_t *snp, *sns;
+
+	/*
+	 * Find the group with the specified group id
+	 * from the registered group list, if one exists
+	 * return the matching mgmt group pointer, otherwise return NULL
+	 */
+	SYS_SLIST_FOR_EACH_NODE_SAFE(&mgmt_group_list, snp, sns) {
+		struct mgmt_group *loop_group =
+			CONTAINER_OF(snp, struct mgmt_group, node);
+		if (loop_group->mg_group_id == group_id) {
+			group = loop_group;
+			break;
+		}
+	}
+
+	return group;
+}
+
 #if IS_ENABLED(CONFIG_MCUMGR_SMP_SUPPORT_ORIGINAL_PROTOCOL)
 smp_translate_error_fn mgmt_find_error_translation_function(uint16_t group_id)
 {


### PR DESCRIPTION
This commit adds support for finding registered mcumgr command groups. By default, supported command groups are local to the namespace where they're registered. This api addition allows applications to get reference to these supported command groups to deregister & re-register them. This adds scope for applications to support multiple implementations of a command group alongside the default.

An example use case might be an application where command groups need to target a host and a co-processor, where a target host might need to act as a passthrough for group commands that target a co-processor. The default command group handlers will need to be replaced when targeting the co-processor, and used when targeting the host.