### PR TITLE
native simulator: minor additions

### DIFF
--- a/boards/posix/common/natsim_config.cmake
+++ b/boards/posix/common/natsim_config.cmake
@@ -20,6 +20,7 @@ set(nsi_config_content
   "NSI_EXTRA_LIBS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,RUNNER_LINK_LIBRARIES>,\ >"
   "NSI_PATH:=${NSI_DIR}/"
   "NSI_N_CPUS:=${CONFIG_NATIVE_SIMULATOR_NUMBER_MCUS}"
+  "NSI_LOCALIZE_OPTIONS:=--localize-symbol=CONFIG_*"
 )
 
 string(REPLACE ";" "\n" nsi_config_content "${nsi_config_content}")

--- a/boards/posix/common/natsim_config.cmake
+++ b/boards/posix/common/natsim_config.cmake
@@ -13,7 +13,7 @@ set(nsi_config_content
   "NSI_BUILD_PATH:=${zephyr_build_path}/NSI"
   "NSI_CC:=${CCACHE} ${CMAKE_C_COMPILER}"
   "NSI_OBJCOPY:=${CMAKE_OBJCOPY}"
-  "NSI_EMBEDDED_CPU_SW:=${zephyr_build_path}/${KERNEL_ELF_NAME}"
+  "NSI_EMBEDDED_CPU_SW:=${zephyr_build_path}/${KERNEL_ELF_NAME} ${CONFIG_NATIVE_SIMULATOR_EXTRA_IMAGE_PATHS}"
   "NSI_EXE:=${zephyr_build_path}/${KERNEL_EXE_NAME}"
   "NSI_EXTRA_SRCS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_SOURCES>,\ >"
   "NSI_LINK_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_LINK_OPTIONS>,\ >"

--- a/boards/posix/common/natsim_config.cmake
+++ b/boards/posix/common/natsim_config.cmake
@@ -19,6 +19,7 @@ set(nsi_config_content
   "NSI_LINK_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_LINK_OPTIONS>,\ >"
   "NSI_EXTRA_LIBS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,RUNNER_LINK_LIBRARIES>,\ >"
   "NSI_PATH:=${NSI_DIR}/"
+  "NSI_N_CPUS:=${CONFIG_NATIVE_SIMULATOR_NUMBER_MCUS}"
 )
 
 string(REPLACE ";" "\n" nsi_config_content "${nsi_config_content}")

--- a/soc/posix/inf_clock/Kconfig
+++ b/soc/posix/inf_clock/Kconfig
@@ -11,6 +11,14 @@ config NATIVE_SIMULATOR_CPU_N
 	  This option is only applicable for targets which use the
 	  native simulator as their runner.
 
+config NATIVE_SIMULATOR_NUMBER_MCUS
+	int "Total number of MCUs this target has"
+	range 1 16
+	default 1
+	depends on NATIVE_LIBRARY
+	help
+	  How many AMP MCUs does this target have in total.
+
 config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	int "Which CPU is the primary/preferred"
 	default 0

--- a/soc/posix/inf_clock/Kconfig
+++ b/soc/posix/inf_clock/Kconfig
@@ -10,3 +10,13 @@ config NATIVE_SIMULATOR_CPU_N
 	  Which native simulator embedded CPU number is this image targeting.
 	  This option is only applicable for targets which use the
 	  native simulator as their runner.
+
+config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
+	int "Which CPU is the primary/preferred"
+	default 0
+	depends on NATIVE_LIBRARY
+	help
+	  On a multi MCU device, which MCU is the preferred one.
+	  This MCU will for example have its tests command line parameters presented
+	  without any prefix. Note that an MCU being primary does not imply it will be
+	  the first one to boot.

--- a/soc/posix/inf_clock/Kconfig
+++ b/soc/posix/inf_clock/Kconfig
@@ -28,3 +28,12 @@ config NATIVE_SIMULATOR_PRIMARY_MCU_INDEX
 	  This MCU will for example have its tests command line parameters presented
 	  without any prefix. Note that an MCU being primary does not imply it will be
 	  the first one to boot.
+
+config NATIVE_SIMULATOR_EXTRA_IMAGE_PATHS
+	string "Other cores images to include"
+	depends on NATIVE_LIBRARY
+	help
+	  This option can be used to provide the native simulator with other MCUs/Cores images which have
+	  been produced by either other Zephyr builds or different OS builds.
+	  So you can, for ex., use this application build produce one core image, and at the same time
+	  have it produce the final link with the native simulator runner and the other MCU images.


### PR DESCRIPTION
Four minor additions for the native simulator integration in Zephyr needed to support AMP targets.
(This is part of https://github.com/zephyrproject-rtos/zephyr/pull/63193, but can come on its own to ease review)

    native boards: AMP fix: localize the CONFIG_ symbols
    
    The Zephyr build leaves all kconfig options as absolute symbols
    in the image. This need to be localized, otherwise they will
    appear as duplicates with other Zephyr images.
    
-------

    native SOC: Add option to define how many MCUs a SOC has
    
    Add a new Kconfig option to define how many MCUs a SOC has
    
-----

    native SOC: Add option to select the primary MCU
    
    Add a new kconfig option to select which is the
    preffered embedded MCU.

-----

    native soc: Add option to pass extra images to native simulator build

    Add a new kconfig option to be able to pass extra images to the
    native simulator build.
    So one can, for ex., use one application build to produce one core image,
    and at the same time have it produce the final link with the native
    simulator runner and the other MCU images.