### PR TITLE
MAINTAINERS: Add domains.py under West area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2908,6 +2908,7 @@ West:
     - scripts/west-commands.yml
     - scripts/west_commands/
     - doc/develop/west/
+    - scripts/pylib/build_helpers/domains.py
   labels:
     - "area: West"
 


### PR DESCRIPTION
This small library is shared by both west and twister, where it's used to parse the `domains.yaml` files generated by sysbuild. It also defines the schema that sysbuild itself must adhere to when generating the file.