### PR TITLE
west: runners: Add support for a common --reset argument

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -229,6 +229,9 @@ class RunnerCaps:
       erased by the underlying tool before flashing; UICR on nRF SoCs
       is one example.)
 
+    - reset: whether the runner supports a --reset option, which
+      resets the device after a flash operation is complete.
+
     - tool_opt: whether the runner supports a --tool-opt (-O) option, which
       can be given multiple times and is passed on to the underlying tool
       that the runner wraps.
@@ -240,12 +243,14 @@ class RunnerCaps:
                  dev_id: bool = False,
                  flash_addr: bool = False,
                  erase: bool = False,
+                 reset: bool = False,
                  tool_opt: bool = False,
                  file: bool = False):
         self.commands = commands
         self.dev_id = dev_id
         self.flash_addr = bool(flash_addr)
         self.erase = bool(erase)
+        self.reset = bool(reset)
         self.tool_opt = bool(tool_opt)
         self.file = bool(file)
 
@@ -254,6 +259,7 @@ class RunnerCaps:
                 f'dev_id={self.dev_id}, '
                 f'flash_addr={self.flash_addr}, '
                 f'erase={self.erase}, '
+                f'reset={self.reset}, '
                 f'tool_opt={self.tool_opt}, '
                 f'file={self.file}'
                 ')')
@@ -521,8 +527,15 @@ class ZephyrBinaryRunner(abc.ABC):
 
         parser.add_argument('--erase', '--no-erase', nargs=0,
                             action=_ToggleAction,
-                            help=("mass erase flash before loading, or don't"
+                            help=("mass erase flash before loading, or don't. "
+                                  "Default action depends on each specific runner."
                                   if caps.erase else argparse.SUPPRESS))
+
+        parser.add_argument('--reset', '--no-reset', nargs=0,
+                            action=_ToggleAction,
+                            help=("reset device after flashing, or don't. "
+                                  "Default action depends on each specific runner."
+                                  if caps.reset else argparse.SUPPRESS))
 
         parser.add_argument('-O', '--tool-opt', dest='tool_opt',
                             default=[], action='append',
@@ -552,6 +565,8 @@ class ZephyrBinaryRunner(abc.ABC):
             _missing_cap(cls, '--dt-flash')
         if args.erase and not caps.erase:
             _missing_cap(cls, '--erase')
+        if args.reset and not caps.reset:
+            _missing_cap(cls, '--reset')
         if args.tool_opt and not caps.tool_opt:
             _missing_cap(cls, '--tool-opt')
         if args.file and not caps.file:
@@ -564,6 +579,8 @@ class ZephyrBinaryRunner(abc.ABC):
         ret = cls.do_create(cfg, args)
         if args.erase:
             ret.logger.info('mass erase requested')
+        if args.reset:
+            ret.logger.info('reset after flashing requested')
         return ret
 
     @classmethod

--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -28,7 +28,7 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
     '''Runner front-end base class for nrf tools.'''
 
     def __init__(self, cfg, family, softreset, dev_id, erase=False,
-                 tool_opt=[], force=False, recover=False):
+                 reset=True, tool_opt=[], force=False, recover=False):
         super().__init__(cfg)
         self.hex_ = cfg.hex_file
         if family and not family.endswith('_FAMILY'):
@@ -37,6 +37,7 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
         self.softreset = softreset
         self.dev_id = dev_id
         self.erase = bool(erase)
+        self.reset = bool(reset)
         self.force = force
         self.recover = bool(recover)
 
@@ -47,7 +48,7 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash'}, dev_id=True, erase=True,
-                          tool_opt=True)
+                          reset=True, tool_opt=True)
 
     @classmethod
     def dev_id_help(cls) -> str:
@@ -74,6 +75,8 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
                             help='''erase all user available non-volatile
                             memory and disable read back protection before
                             flashing (erases flash for both cores on nRF53)''')
+
+        parser.set_defaults(reset=True)
 
     def ensure_snr(self):
         if not self.dev_id or "*" in self.dev_id:
@@ -398,7 +401,8 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
         if self.recover:
             self.recover_target()
         self.program_hex()
-        self.reset_target()
+        if self.reset:
+            self.reset_target()
         # All done, now flush any outstanding ops
         self.flush(force=True)
 

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -30,6 +30,7 @@ class NrfJprogBinaryRunner(NrfBinaryRunner):
     def do_create(cls, cfg, args):
         return NrfJprogBinaryRunner(cfg, args.nrf_family, args.softreset,
                                     args.dev_id, erase=args.erase,
+                                    reset=args.reset,
                                     tool_opt=args.tool_opt, force=args.force,
                                     recover=args.recover)
 

--- a/scripts/west_commands/runners/nrfutil.py
+++ b/scripts/west_commands/runners/nrfutil.py
@@ -16,9 +16,9 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
     '''Runner front-end for nrfutil.'''
 
     def __init__(self, cfg, family, softreset, dev_id, erase=False,
-                 tool_opt=[], force=False, recover=False):
+                 reset=True, tool_opt=[], force=False, recover=False):
 
-        super().__init__(cfg, family, softreset, dev_id, erase,
+        super().__init__(cfg, family, softreset, dev_id, erase, reset,
                          tool_opt, force, recover)
         self._ops = []
         self._op_id = 1
@@ -35,6 +35,7 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
     def do_create(cls, cfg, args):
         return NrfUtilBinaryRunner(cfg, args.nrf_family, args.softreset,
                                    args.dev_id, erase=args.erase,
+                                   reset=args.reset,
                                    tool_opt=args.tool_opt, force=args.force,
                                    recover=args.recover)
 

--- a/scripts/west_commands/runners/stm32flash.py
+++ b/scripts/west_commands/runners/stm32flash.py
@@ -37,7 +37,7 @@ class Stm32flashBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash'})
+        return RunnerCaps(commands={'flash'}, reset=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -72,11 +72,10 @@ class Stm32flashBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--serial-mode', default='8e1', required=False,
                             help='serial port mode, default \'8e1\'')
 
-        parser.add_argument('--reset', default=False, required=False, action='store_true',
-                            help='reset device at exit, default False')
-
         parser.add_argument('--verify', default=False, required=False, action='store_true',
                             help='verify writes, default False')
+
+        parser.set_defaults(reset=False)
 
     @classmethod
     def do_create(cls, cfg, args):


### PR DESCRIPTION
Some of the runners in the tree have been adding their own, class-specific versions of a switch to instruct the runner to reset or not the device after flashing.

In order to better support multi-image builds that require more than one flash operation, introduce a new --reset,--no-reset command-line parameter that is part of the RunnerCaps so taht this functionality can be accessed in a standardized manner.

Implementations for the new parameter are provided for the runner classes that were already configurable in this regard.