### PR TITLE
arch: arm: cortex_m: Improve atomic operations support on armv8-m.baseline

### DIFF
--- a/arch/arm/core/cortex_m/Kconfig
+++ b/arch/arm/core/cortex_m/Kconfig
@@ -171,7 +171,7 @@ config CPU_CORTEX_M_HAS_CMSE
 
 config ARMV6_M_ARMV8_M_BASELINE
 	bool
-	select ATOMIC_OPERATIONS_C
+	select ATOMIC_OPERATIONS_C if !ARMV8_M_BASELINE
 	select ISA_THUMB2
 	help
 	  This option signifies the use of an ARMv6-M processor

--- a/include/zephyr/arch/arm/asm_inline_gcc.h
+++ b/include/zephyr/arch/arm/asm_inline_gcc.h
@@ -43,13 +43,17 @@ static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 {
 	unsigned int key;
 
-#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) && !defined(CONFIG_ARMV8_M_BASELINE)
+#if CONFIG_MP_MAX_NUM_CPUS == 1
 	__asm__ volatile("mrs %0, PRIMASK;"
 		"cpsid i"
 		: "=r" (key)
 		:
 		: "memory");
-#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+#else
+#error "Cortex-M0 and Cortex-M0+ require SoC specific support for cross core synchronisation."
+#endif
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE) || defined(CONFIG_ARMV8_M_BASELINE)
 	unsigned int tmp;
 
 	__asm__ volatile(
@@ -83,7 +87,7 @@ static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 
 static ALWAYS_INLINE void arch_irq_unlock(unsigned int key)
 {
-#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) && !defined(CONFIG_ARMV8_M_BASELINE)
 	if (key != 0U) {
 		return;
 	}
@@ -91,7 +95,7 @@ static ALWAYS_INLINE void arch_irq_unlock(unsigned int key)
 		"cpsie i;"
 		"isb"
 		: : : "memory");
-#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE) || defined(CONFIG_ARMV8_M_BASELINE)
 	__asm__ volatile(
 		"msr BASEPRI, %0;"
 		"isb;"


### PR DESCRIPTION
Armv8-m baseline support various instruction carrying exclusive-monitor and
acquire-release semantic. By adding this guard we let armv8-m.baseline
fall-back to arch defined or compiler built-in support for atomic
operations.

This PR also allows for armv8m.baseline cores to rely on BASEPRI based interrupt
masking and share the same code as v7m and v8m.mainline.