### PR TITLE
devicetree: add APIs to get the compat of a node identifier

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -3018,6 +3018,58 @@
 	DT_NODE_HAS_STATUS_INTERNAL(node_id, status)
 
 /**
+ * @brief Get compatible of a node by index.
+ *
+ * The compatible returned can be used directly in other DT macros that requires
+ * `compat` as argument
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     n: node {
+ *             compatible = "vnd,specific-device", "generic-device";
+ *     }
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_COMPAT_BY_IDX(DT_NODELABEL(n), 0) // vnd_specific_device
+ *     DT_COMPAT_BY_IDX(DT_NODELABEL(n), 1) // generic_device
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @param idx the index to get
+ * @return the compat at idx
+ */
+#define DT_COMPAT_BY_IDX(node_id, idx) DT_STRING_TOKEN_BY_IDX(node_id, compatible, idx)
+
+/**
+ * @brief Get the first compatible of a node
+ *
+ * The compatible returned can be used directly in other DT macros that requires
+ * `compat` as argument
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     n: node {
+ *             compatible = "vnd,specific-device", "generic-device";
+ *     }
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     DT_COMPAT(DT_NODELABEL(n)) // vnd_specific_device
+ * @endcode
+ *
+ * @param node_id node identifier
+ * @return the compat of node_id
+ */
+#define DT_COMPAT(node_id) DT_COMPAT_BY_IDX(node_id, 0)
+
+/**
  * @brief Does the devicetree have a status `okay` node with a compatible?
  *
  * Test for whether the devicetree has any nodes with status `okay`

--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -262,6 +262,15 @@ extern "C" {
 #define IS_EQ(a, b) Z_IS_EQ(a, b)
 
 /**
+ * @brief Like <tt>a != b</tt>, but does evaluation and
+ * short-circuiting at C preprocessor time.
+ *
+ * This however only works for integer literal from 0 to 255.
+ *
+ */
+#define IS_NEQ(a, b) IS_EQ(IS_EQ(a, b), 0)
+
+/**
  * @brief Remove empty arguments from list.
  *
  * During macro expansion, `__VA_ARGS__` and other preprocessor

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -410,6 +410,11 @@
 			status = "okay";
 		};
 
+		test_compat: compat {
+			compatible = "zephyr,model1", "gpio", "zephyr,model2";
+			status = "okay";
+		};
+
 		test_intc: interrupt-controller@bbbbcccc  {
 			compatible = "vnd,intc";
 			reg = <0xbbbbcccc 0x1000>;

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -525,6 +525,19 @@ ZTEST(devicetree_api, test_vendor)
 	zassert_true(!strcmp(DT_NODE_VENDOR_OR(TEST_VENDOR, NULL), VND_VENDOR), "");
 }
 
+ZTEST(devicetree_api, test_compat)
+{
+
+	zassert_mem_equal(STRINGIFY(DT_COMPAT(DT_NODELABEL(test_compat))), "zephyr_model1",
+				    sizeof("zephyr_model1"));
+	zassert_mem_equal(STRINGIFY(DT_COMPAT_BY_IDX(DT_NODELABEL(test_compat), 0)),
+				    "zephyr_model1", sizeof("zephyr_model1"));
+	zassert_mem_equal(STRINGIFY(DT_COMPAT_BY_IDX(DT_NODELABEL(test_compat), 1)), "gpio",
+				    sizeof("gpio"));
+	zassert_mem_equal(STRINGIFY(DT_COMPAT_BY_IDX(DT_NODELABEL(test_compat), 2)),
+				    "zephyr_model2", sizeof("zephyr_model2"));
+}
+
 #define VND_MODEL "model1"
 #define ZEP_MODEL "model2"
 

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -86,6 +86,10 @@ ZTEST(util_cxx, test_IS_EQ) {
 	run_IS_EQ();
 }
 
+ZTEST(util_cxx, test_IS_NEQ) {
+	run_IS_NEQ();
+}
+
 ZTEST(util_cxx, test_LIST_DROP_EMPTY) {
 	run_LIST_DROP_EMPTY();
 }
@@ -232,6 +236,10 @@ ZTEST(util_cc, test_IS_EMPTY) {
 
 ZTEST(util_cc, test_IS_EQ) {
 	run_IS_EQ();
+}
+
+ZTEST(util_cc, test_IS_NEQ) {
+	run_IS_NEQ();
 }
 
 ZTEST(util_cc, test_LIST_DROP_EMPTY) {

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -382,6 +382,17 @@ void run_IS_EQ(void)
 	zassert_false(IS_EQ(7, 0), "Unexpected IS_EQ result");
 }
 
+void run_IS_NEQ(void)
+{
+	zassert_false(IS_NEQ(0, 0), "Unexpected IS_NEQ result");
+	zassert_false(IS_NEQ(1, 1), "Unexpected IS_NEQ result");
+	zassert_false(IS_NEQ(7, 7), "Unexpected IS_NEQ result");
+
+	zassert_true(IS_NEQ(0, 1), "Unexpected IS_NEQ result");
+	zassert_true(IS_NEQ(1, 7), "Unexpected IS_NEQ result");
+	zassert_true(IS_NEQ(7, 0), "Unexpected IS_NEQ result");
+}
+
 void run_LIST_DROP_EMPTY(void)
 {
 	/*


### PR DESCRIPTION
Added `IS_NEQ`, `DT_COMPAT` & `DT_COMPAT_AT_IDX`