### PR TITLE
 dts: nxp: Clean up NXP SoC dtsi files

### DIFF
--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu0_r52.dts
@@ -5,7 +5,6 @@
  */
 
 /dts-v1/;
-#include <dt-bindings/clock/nxp_s32z2_clock.h>
 #include <arm/nxp/nxp_s32z27x_rtu0_r52.dtsi>
 #include "s32z270dc2_r52.dtsi"
 

--- a/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
+++ b/boards/arm/s32z270dc2_r52/s32z270dc2_rtu1_r52.dts
@@ -5,7 +5,6 @@
  */
 
 /dts-v1/;
-#include <dt-bindings/clock/nxp_s32z2_clock.h>
 #include <arm/nxp/nxp_s32z27x_rtu1_r52.dtsi>
 #include "s32z270dc2_r52.dtsi"
 

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -7,6 +7,7 @@
 #include <mem.h>
 #include <arm/armv8-r.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/clock/nxp_s32z2_clock.h>
 
 / {
 	cpus {

--- a/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
@@ -17,7 +17,6 @@
 	chosen {
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
-		zephyr,sram = &sram0;
 	};
 
 	cpus {

--- a/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
@@ -17,7 +17,6 @@
 	chosen {
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
-		zephyr,sram = &sram0;
 	};
 
 	cpus {

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -14,12 +14,6 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	chosen {
-		zephyr,console = &uart2;
-		zephyr,shell-uart = &uart2;
-		zephyr,sram = &sram0;
-	};
-
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;


### PR DESCRIPTION
This PR aims to clean up dtsi files for NXP SoCs:
* Move include to the file that actually needs it.
* Remove chosen definitions of undefined labels because they are defined (and assigned to proper chosen properties) on the board level.