### PR TITLE
tests: kernel: timer: jitter_drift: Restore initial alignment to tick

### DIFF
--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -136,6 +136,17 @@ static void do_test_using(void (*sample_collection_fn)(void))
 
 	periodic_idx = 0;
 	k_sem_init(&periodic_sem, 0, 1);
+
+	/* Align to tick boundary. Otherwise the first handler execution
+	 * might turn out to be significantly late and cause the test to
+	 * fail. This can happen if k_timer_start() is called right before
+	 * the upcoming tick boundary and in consequence the tick passes
+	 * between the moment when the kernel decides what tick to use for
+	 * the next timeout and the moment when the system timer actually
+	 * sets up that timeout.
+	 */
+	k_sleep(K_TICKS(1));
+
 	sample_collection_fn();
 	k_sem_take(&periodic_sem, K_FOREVER);
 


### PR DESCRIPTION
This is a follow-up to commit 4cc21e2f4aea2e37f4fea1216fe92ded9ba6d755.

That short sleeping before starting the test was removed together with accuracy improvements (specifically, with moving of the first readout of the cycle counter). Nevertheless, this tick alignment it still needed, as without it in specific conditions the test may undesirably fail.