### PR TITLE
riscv: privileged: custom Interrupt Controller API

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -100,6 +100,17 @@ config RISCV_SOC_HAS_CUSTOM_SYS_IO
 	  the RISC-V SoC needs to do something different and more than reading and
 	  writing the registers.
 
+config RISCV_CUSTOM_INTERRUPT_CONTROLLER
+	bool "Custom interrupt controller"
+	depends on !RISCV_HAS_CLIC && !RISCV_HAS_PLIC
+	help
+	  This option signifies that the RISCV CPU is connected to a custom interrupt
+	  controller.
+
+	  When this option is selected, the architecture interrupt control
+	  functions are mapped to the functions which is to be
+	  implemented by the custom interrupt controller driver.
+
 config RISCV_SOC_CONTEXT_SAVE
 	bool "SOC-based context saving in IRQ handlers"
 	select RISCV_SOC_OFFSETS

--- a/include/zephyr/arch/riscv/irq.h
+++ b/include/zephyr/arch/riscv/irq.h
@@ -29,13 +29,69 @@ extern void arch_irq_enable(unsigned int irq);
 extern void arch_irq_disable(unsigned int irq);
 extern int arch_irq_is_enabled(unsigned int irq);
 
-#if defined(CONFIG_RISCV_HAS_PLIC) || defined(CONFIG_RISCV_HAS_CLIC)
+#if defined(CONFIG_RISCV_HAS_PLIC) || defined(CONFIG_RISCV_HAS_CLIC) || \
+	defined(CONFIG_RISCV_CUSTOM_INTERRUPT_CONTROLLER)
 extern void z_riscv_irq_priority_set(unsigned int irq,
 				     unsigned int prio,
 				     uint32_t flags);
 #else
 #define z_riscv_irq_priority_set(i, p, f) /* Nothing */
 #endif /* CONFIG_RISCV_HAS_PLIC || CONFIG_RISCV_HAS_CLIC */
+
+#if defined(CONFIG_RISCV_CUSTOM_INTERRUPT_CONTROLLER)
+
+/**
+ * @brief Enable an interrupt line for RISC-V custom interrupt controller.
+ *
+ * This routine enables an interrupt line for RISC-V custom interrupt controller.
+ * Should be implemented by custom interrupt controller.
+ *
+ * @param irq IRQ number to enable
+ */
+void z_irq_enable(unsigned int irq);
+
+/**
+ * @brief Disable an interrupt line for RISC-V custom interrupt controller.
+ *
+ * This routine disables an interrupt line for RISC-V custom interrupt controller.
+ * Should be implemented by custom interrupt controller.
+ *
+ * @param irq IRQ number to disable
+ */
+void z_irq_disable(unsigned int irq);
+
+/**
+ * @brief Check if an interrupt line for RISC-V custom interrupt controller is enabled
+ *
+ * This routine checks if an interrupt line for RISC-V custom interrupt
+ * controller is enabled.
+ * Should be implemented by custom interrupt controller.
+ *
+ * @param irq IRQ number to check
+ *
+ * @return 1 - if IRQ is enabled; 0 - otherwise
+ */
+int z_irq_is_enabled(unsigned int irq);
+
+/**
+ * @brief Set priority of a RISC-V custom interrupt controller interrupt line
+ *
+ * This routine set the priority of a RISC-V custom interrupt controller
+ * interrupt line. Should be implemented by custom interrupt controller.
+ *
+ * @param irq IRQ number for which to set priority
+ * @param prio Priority of IRQ to set to
+ * @param flags IRQ flags to additionally configure, if applicable
+ */
+void z_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags);
+
+#define arch_irq_enable(irq) z_irq_enable(irq)
+#define arch_irq_disable(irq) z_irq_disable(irq)
+#define arch_irq_is_enabled(irq) z_irq_is_enabled(irq)
+#define z_riscv_irq_priority_set(irq, prio, flags) \
+	z_irq_priority_set(irq, prio, flags)
+
+#endif /* CONFIG_RISCV_CUSTOM_INTERRUPT_CONTROLLER */
 
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 { \


### PR DESCRIPTION
It looks like the existing path providing IRQ handling functionality for PLIC within the RISC-V Privileged IRQ infrastructure basically fits to any Interrupt Controller which handles 2nd level IRQs, including the custom ones.

This change introduces the extension for RISC-V privileged IRQ infrastructure API to simplify addition of the custom Interrupt Controllers.

The specific Inerrupt Controller implementation is getting connected to the IRQ infrastructure through this API. The related functions are to be implemented by any custom Interrupt Controllers for 2nd level IRQ handling. At the same time no changes for the infrastructure itself is necessary when a new Interrupt Controller is added.