### PR TITLE
dts: bindings: nxp,kinetis-*: do not re-specify pinctrl-0 type

### DIFF
--- a/dts/bindings/i2c/nxp,kinetis-i2c.yaml
+++ b/dts/bindings/i2c/nxp,kinetis-i2c.yaml
@@ -15,5 +15,4 @@ properties:
     required: true
 
   pinctrl-0:
-    type: phandles
     required: true

--- a/dts/bindings/pwm/nxp,kinetis-ftm-pwm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-ftm-pwm.yaml
@@ -12,7 +12,6 @@ properties:
     const: 3
 
   pinctrl-0:
-    type: phandles
     required: true
 
 pwm-cells:

--- a/dts/bindings/pwm/nxp,kinetis-tpm.yaml
+++ b/dts/bindings/pwm/nxp,kinetis-tpm.yaml
@@ -15,7 +15,6 @@ properties:
     required: true
 
   pinctrl-0:
-    type: phandles
     required: true
 
   "#pwm-cells":

--- a/dts/bindings/serial/nxp,kinetis-uart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-uart.yaml
@@ -15,5 +15,4 @@ properties:
     required: true
 
   pinctrl-0:
-    type: phandles
     required: true

--- a/dts/bindings/spi/nxp,kinetis-dspi.yaml
+++ b/dts/bindings/spi/nxp,kinetis-dspi.yaml
@@ -36,7 +36,6 @@ properties:
       select assert. If not set, the minimum supported delay is used.
 
   pinctrl-0:
-    type: phandles
     required: true
 
   nxp,rx-tx-chn-share:


### PR DESCRIPTION
It's already defined in pinctrl-device.yaml.