### PR TITLE
net: ppp: Mark the PPP L2 as non-experimental

### DIFF
--- a/scripts/kconfig/hardened.csv
+++ b/scripts/kconfig/hardened.csv
@@ -100,7 +100,6 @@ NET_CONNECTION_MANAGER,n,experimental
 NET_GPTP,n,experimental
 NET_IPV4_AUTO,n,experimental
 NET_L2_IEEE802154_SECURITY,n,experimental
-NET_L2_PPP,n,experimental
 NET_PROMISCUOUS_MODE,n,experimental
 NET_SOCKETS_CAN,n,experimental
 NET_SOCKETS_ENABLE_DTLS,n,experimental

--- a/subsys/net/l2/ppp/Kconfig
+++ b/subsys/net/l2/ppp/Kconfig
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_L2_PPP
-	bool "Point-to-point (PPP) support [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Point-to-point (PPP) support"
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	help


### PR DESCRIPTION
The experimental status of the PPP L2 is long overdue so it can be removed as the component is working fine.

This was discussed in recent modem tech-talk and the reason for the experimental status was that it was just forgotten there.
