### PR TITLE
boards: mps2_an385: Exclude platform from networking tests

### DIFF
--- a/boards/arm/mps2_an385/mps2_an385.yaml
+++ b/boards/arm/mps2_an385/mps2_an385.yaml
@@ -13,4 +13,6 @@ supported:
   - gpio
 testing:
   default: true
+  ignore_tags:
+    - net
 vendor: arm

--- a/samples/net/sockets/socketpair/sample.yaml
+++ b/samples/net/sockets/socketpair/sample.yaml
@@ -9,6 +9,6 @@ common:
   harness: net
   arch_exclude: posix
   integration_platforms:
-    - mps2_an385
+    - qemu_x86
 tests:
   sample.net.sockets.socketpair: {}


### PR DESCRIPTION
The platform is known for having unstable system timer with networking enabled (see https://github.com/zephyrproject-rtos/zephyr/issues/48608) causing occasional failures of time-sensitive networking testsuties (TLS, now DHCPv6). Instead of excluding the platform on per-test basis, just exclude the platform from networking testing globally.