### PR TITLE
samples: bindesc: doc: Describe sample using zephyr:code-sample

### DIFF
--- a/samples/subsys/bindesc/hello_bindesc/README.rst
+++ b/samples/subsys/bindesc/hello_bindesc/README.rst
@@ -1,12 +1,13 @@
-.. _hello_bindesc-sample:
+.. zephyr:code-sample:: hello-bindesc
+   :name: Binary descriptors "Hello World"
+   :relevant-api: bindesc_define
 
-hello_bindesc Sample Application
-################################
+   Set and access binary descriptors for a basic Zephyr application.
 
 Overview
 ********
 
-A simple sample of binary descriptor definition and usage.
+A simple sample of :ref:`binary descriptor <binary_descriptors>` definition and usage.
 
 Building and Running
 ********************


### PR DESCRIPTION
Missed the chance to review the sample doc in time for this one, sorry @yonsch . 
@nashif would it make sense to add a generic entry for samples to MAINTAINERS file? (implicitly volunteering myself as a maintainer for it).

Describe the code sample using zephyr:code-sample directive to help with making it easier to find from API reference.
Also cross-referenced main bindesc page from the sample.