### PR TITLE
bindesc: Add a few missing pieces

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -193,6 +193,18 @@ Ambiq Platforms:
   labels:
     - "platform: Ambiq"
 
+Binary Descriptors:
+  status: maintained
+  maintainers:
+    - yonsch
+  files:
+    - subsys/bindesc/
+    - include/zephyr/bindesc.h
+    - samples/subsys/bindesc/
+    - scripts/west_commands/bindesc.py
+  labels:
+    - "area: Binary Descriptors"
+
 Bluetooth:
   status: maintained
   maintainers:

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -378,6 +378,10 @@ Libraries / Subsystems
 
   * Added the :ref:`blinfo_api` subsystem.
 
+* Binary descriptors
+
+  * Added the :ref:`binary_descriptors` (``bindesc``) subsystem.
+
 HALs
 ****
 

--- a/samples/subsys/bindesc/hello_bindesc/README.rst
+++ b/samples/subsys/bindesc/hello_bindesc/README.rst
@@ -11,7 +11,7 @@ A simple sample of binary descriptor definition and usage.
 Building and Running
 ********************
 
-Follow these steps to build the `hello_bindesc` sample application:
+Follow these steps to build the ``hello_bindesc`` sample application:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/bindesc/hello_bindesc
@@ -19,8 +19,13 @@ Follow these steps to build the `hello_bindesc` sample application:
    :goals: build
    :compact:
 
-To see all binary descriptors, run:
+To dump all binary descriptors in the image, run:
 
 .. code-block:: bash
 
    west bindesc dump build/zephyr/zephyr.bin
+
+(Note: you can also dump the contents of ``zephyr.elf``, if your build system
+does not produce a ``*.bin`` file, e.g. compiling for ``native_posix``.)
+
+For more details see :ref:`binary_descriptors` and :ref:`west-bindesc`.

--- a/samples/subsys/bindesc/hello_bindesc/README.rst
+++ b/samples/subsys/bindesc/hello_bindesc/README.rst
@@ -1,12 +1,13 @@
-.. _hello_bindesc-sample:
+.. zephyr:code-sample:: hello-bindesc
+   :name: Binary descriptors "Hello World"
+   :relevant-api: bindesc_define
 
-hello_bindesc Sample Application
-################################
+   Set and access binary descriptors for a basic Zephyr application.
 
 Overview
 ********
 
-A simple sample of binary descriptor definition and usage.
+A simple sample of :ref:`binary descriptor <binary_descriptors>` definition and usage.
 
 Building and Running
 ********************

--- a/scripts/west_commands/bindesc.py
+++ b/scripts/west_commands/bindesc.py
@@ -111,7 +111,7 @@ class Bindesc(WestCommand):
                                          help=self.help,
                                          description=self.description)
 
-        subparsers = parser.add_subparsers(help='sub-command to run')
+        subparsers = parser.add_subparsers(help='sub-command to run', required=True)
 
         dump_parser = subparsers.add_parser('dump', help='Dump all binary descriptors in the image')
         dump_parser.add_argument('file', type=str, help='Executable file')


### PR DESCRIPTION
This PR adds a few missing pieces to bindesc:
1. Area in MAINTAINERS.yml
2. Release notes for 3.5
3. Improved documentation for the `hello_bindesc` sample
4. Fixed `west bindesc` crash when no subcommand is given

Fixes: #63221