### PR TITLE
Bluetooth: controller: fix comparison of unsigned int to larger then or equal to 0

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso_types.h
@@ -9,10 +9,17 @@
 #define LL_BIS_ADV_HANDLE_BASE BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE
 #define LL_BIS_ADV_IDX_FROM_HANDLE(conn_handle) \
 	((conn_handle) - (LL_BIS_ADV_HANDLE_BASE))
+/* Conditional compile to prevent coverity issue CWE570, comparison of unsigned int to 0 */
+#if (LL_BIS_ADV_HANDLE_BASE > 0)
 #define IS_ADV_ISO_HANDLE(conn_handle) \
 	(((conn_handle) >= (LL_BIS_ADV_HANDLE_BASE)) && \
 	 ((conn_handle) <= ((LL_BIS_ADV_HANDLE_BASE) + \
 			    (BT_CTLR_ADV_ISO_STREAM_MAX) - 1U)))
+#else
+#define IS_ADV_ISO_HANDLE(conn_handle) \
+	((conn_handle) <= ((LL_BIS_ADV_HANDLE_BASE) + \
+			   (BT_CTLR_ADV_ISO_STREAM_MAX) - 1U))
+#endif /* LL_BIS_ADV_HANDLE_BASE */
 #else
 #define LL_BIS_ADV_IDX_FROM_HANDLE(conn_handle) 0U
 #define IS_ADV_ISO_HANDLE(conn_handle) 0U
@@ -23,10 +30,17 @@
 #define LL_BIS_SYNC_HANDLE_BASE BT_CTLR_SYNC_ISO_STREAM_HANDLE_BASE
 #define LL_BIS_SYNC_IDX_FROM_HANDLE(conn_handle) \
 	((conn_handle) - (LL_BIS_SYNC_HANDLE_BASE))
+/* Conditional compile to prevent coverity issue CWE570, comparison of unsigned int to 0 */
+#if (LL_BIS_SYNC_HANDLE_BASE > 0)
 #define IS_SYNC_ISO_HANDLE(conn_handle) \
 	(((conn_handle) >= (LL_BIS_SYNC_HANDLE_BASE)) && \
 	 ((conn_handle) <= ((LL_BIS_SYNC_HANDLE_BASE) + \
 			    (BT_CTLR_SYNC_ISO_STREAM_MAX) - 1U)))
+#else
+#define IS_SYNC_ISO_HANDLE(conn_handle) \
+	((conn_handle) <= ((LL_BIS_SYNC_HANDLE_BASE) + \
+			   (BT_CTLR_SYNC_ISO_STREAM_MAX) - 1U))
+#endif /* LL_BIS_SYNC_HANDLE_BASE */
 #else
 #define LL_BIS_SYNC_IDX_FROM_HANDLE(conn_handle) 0U
 #define IS_SYNC_ISO_HANDLE(conn_handle) 0U


### PR DESCRIPTION
Bluetooth: controller: fix comparison of unsigned int to larger then 0

Fixes a coverity issue where an unsigned integer is compared to be larger then or equal to 0

fixes #58998 
fixes #58986 
fixes #58985 
fixes #58996 
fixes #58983 
fixes #58979 
fixes #58962