### PR TITLE
Bluetooth: Mesh: DFU and tester fixes

### DIFF
--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -477,7 +477,9 @@ static int handle_upload_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx
 	/* This will be a no-op if the slot state isn't RESERVED, which is
 	 * what we want.
 	 */
-	bt_mesh_dfu_slot_release(srv->upload.slot);
+	if (srv->upload.slot) {
+		bt_mesh_dfu_slot_release(srv->upload.slot);
+	}
 
 #ifdef CONFIG_BT_MESH_DFD_SRV_OOB_UPLOAD
 	srv->upload.is_oob = false;

--- a/tests/bluetooth/tester/src/btp/btp_mesh.h
+++ b/tests/bluetooth/tester/src/btp/btp_mesh.h
@@ -954,6 +954,7 @@ struct btp_mmdl_dfu_firmware_update_rp {
 struct btp_mmdl_blob_srv_recv_cmd {
 	uint64_t id;
 	uint16_t timeout;
+	uint8_t ttl;
 } __packed;
 
 #define BTP_MMDL_BLOB_TRANSFER_START		0x66
@@ -963,6 +964,7 @@ struct btp_mmdl_blob_transfer_start_cmd {
 	uint8_t block_size;
 	uint16_t chunk_size;
 	uint16_t timeout;
+	uint8_t ttl;
 } __packed;
 
 #define BTP_MMDL_BLOB_TRANSFER_CANCEL		0x67

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -4228,6 +4228,10 @@ static uint8_t blob_transfer_start(const void *cmd, uint16_t cmd_len,
 		blob_cli_xfer.inputs.timeout_base = cp->timeout;
 	}
 
+	if (cp->ttl) {
+		blob_cli_xfer.inputs.ttl = cp->ttl;
+	}
+
 	err = bt_mesh_blob_cli_send(&blob_cli, &blob_cli_xfer.inputs,
 				    &blob_cli_xfer.xfer, &dummy_blob_io);
 
@@ -4311,13 +4315,15 @@ static uint8_t blob_srv_recv(const void *cmd, uint16_t cmd_len,
 
 	uint16_t timeout_base;
 	uint64_t id;
+	uint8_t ttl;
 
 	LOG_DBG("");
 
 	id = cp->id;
 	timeout_base = cp->timeout;
+	ttl = cp->ttl;
 
-	err = bt_mesh_blob_srv_recv(srv, id, &dummy_blob_io, BT_MESH_TTL_MAX,
+	err = bt_mesh_blob_srv_recv(srv, id, &dummy_blob_io, ttl,
 				    timeout_base);
 
 	if (err) {

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -1761,7 +1761,12 @@ static uint8_t large_comp_data_get(const void *cmd, uint16_t cmd_len,
 	struct btp_mesh_large_comp_data_get_rp *rp = rsp;
 	int err;
 
-	struct bt_mesh_large_comp_data_rsp comp;
+	NET_BUF_SIMPLE_DEFINE(data, 500);
+	net_buf_simple_init(&data, 0);
+
+	struct bt_mesh_large_comp_data_rsp comp = {
+		.data = &data,
+	};
 
 	err = bt_mesh_large_comp_data_get(sys_le16_to_cpu(cp->net_idx),
 				    sys_le16_to_cpu(cp->addr), cp->page,
@@ -1785,7 +1790,12 @@ static uint8_t models_metadata_get(const void *cmd, uint16_t cmd_len,
 	struct btp_mesh_models_metadata_get_rp *rp = rsp;
 	int err;
 
-	struct bt_mesh_large_comp_data_rsp metadata;
+	NET_BUF_SIMPLE_DEFINE(data, 500);
+	net_buf_simple_init(&data, 0);
+
+	struct bt_mesh_large_comp_data_rsp metadata = {
+		.data = &data,
+	};
 
 	err = bt_mesh_models_metadata_get(sys_le16_to_cpu(cp->net_idx),
 					  sys_le16_to_cpu(cp->addr), cp->page,


### PR DESCRIPTION
1. Fixes for tester:
 - MBT tests need the Transfer TTL IXIT value to be set for tester.
 - Fix for large comp data structure init
2. Fix for mesh DFD server
 - Unreserved slot should be checked before releasing