### PR TITLE
dts: arm: nordic: Add support for ieee802154 in the nRF52820 radio

### DIFF
--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -88,9 +88,15 @@
 			interrupts = <1 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "okay";
 			dfe-supported;
+			ieee802154-supported;
 			ble-2mbps-supported;
 			ble-coded-phy-supported;
 			tx-high-power-supported;
+
+			ieee802154: ieee802154 {
+				compatible = "nordic,nrf-ieee802154";
+				status = "disabled";
+			};
 		};
 
 		uart0: uart@40002000 {


### PR DESCRIPTION
The nRF52820 radio peripheral supports IEEE 802.15.4, add the required property and node to reflect this.

See
https://infocenter.nordicsemi.com/topic/ps_nrf52820/radio.html?cp=5_3_0_5_11