### PR TITLE
arm: stm32: nucleo_g431rb: Enable support for Random Number Generator

### DIFF
--- a/boards/arm/nucleo_g431rb/doc/index.rst
+++ b/boards/arm/nucleo_g431rb/doc/index.rst
@@ -119,6 +119,8 @@ The Zephyr nucleo_g431rb board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| RNG       | on-chip    | rng                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -63,6 +63,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(24)>;
 	status = "okay";
@@ -84,6 +88,12 @@
 	ahb-prescaler = <1>;
 	apb1-prescaler = <1>;
 	apb2-prescaler = <1>;
+};
+
+&rng {
+	clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x04000000>,
+		 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
+	status = "okay";
 };
 
 &usart1 {

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.yaml
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.yaml
@@ -19,5 +19,6 @@ supported:
   - usb device
   - counter
   - spi
+  - rng
   - dac
   - watchdog


### PR DESCRIPTION
The `nucleo_g431rb` board is equipped with STM32G491RE microcontroller, which do have the RNG IP block.

However, by default it is not enabled. To make it working properly, the provided clock needs to fulfill following condition: 
`fRNGCLK < fHCLK/32`, otherwise RNG_SR would set `CEIS` (bit5) and `CECS` (bit1).
When combined with enabled interrupt from RNG, one would experience the interrupt storm.

In this patch the DTS for this board has been adjusted properly, as well as the board description has been updated to reflect RNG support.