### PR TITLE
bluetooth: disable BT_ATT_ENFORCE_FLOW for BlueNRG devices

### DIFF
--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -7,7 +7,7 @@ menu "ATT and GATT Options"
 
 config BT_ATT_ENFORCE_FLOW
 	bool "Enforce strict flow control semantics for incoming PDUs"
-	default y if !(BOARD_QEMU_CORTEX_M3 || BOARD_QEMU_X86 || ARCH_POSIX)
+	default y if !(BOARD_QEMU_CORTEX_M3 || BOARD_QEMU_X86 || ARCH_POSIX || BT_SPI_BLUENRG)
 	help
 	  Enforce flow control rules on incoming PDUs, preventing a peer
 	  from sending new requests until a previous one has been responded


### PR DESCRIPTION
The firmware on these devices seems to have a bug that can cause reordering of received packets. This can lead to new GATT requests being received before the acknowledgement of the previous GATT response, accompanied by log messages like the following:

```
<wrn> bt_att: bt_att_recv: Ignoring unexpected request
```