### PR TITLE
Bluetooth: HCI ISO data packets fragmentation fix

### DIFF
--- a/subsys/bluetooth/Kconfig.iso
+++ b/subsys/bluetooth/Kconfig.iso
@@ -99,6 +99,10 @@ config BT_ISO_TX_MTU
 	range 1 4095
 	help
 	  Maximum MTU for Isochronous channels TX buffers.
+	  This is the actual data payload. It doesn't include the optional
+	  HCI ISO Data packet fields (e.g. `struct bt_hci_iso_ts_data_hdr`).
+	  Set this value to 247 to fit 247 bytes of data within a single
+	  HCI ISO Data packet with a size of 255, without utilizing timestamps.
 
 config BT_ISO_RX_BUF_COUNT
 	int "Number of Isochronous RX buffers"
@@ -113,6 +117,8 @@ config BT_ISO_RX_MTU
 	range 23 4095
 	help
 	  Maximum MTU for Isochronous channels RX buffers.
+	  This is the actual data payload. It doesn't include the optional
+	  HCI ISO Data packet fields (e.g. `struct bt_hci_iso_ts_data_hdr`)
 
 config BT_ISO_ADVANCED
 	bool "Advanced ISO parameters"

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -656,21 +656,6 @@ fail:
 	return err;
 }
 
-static size_t iso_hdr_len(struct net_buf *buf, struct bt_conn *conn)
-{
-#if defined(CONFIG_BT_ISO)
-	if (conn->type == BT_CONN_TYPE_ISO) {
-		if (tx_data(buf)->iso_has_ts) {
-			return BT_HCI_ISO_TS_DATA_HDR_SIZE;
-		} else {
-			return BT_HCI_ISO_DATA_HDR_SIZE;
-		}
-	}
-#endif
-
-	return 0;
-}
-
 static int send_frag(struct bt_conn *conn,
 		     struct net_buf *buf, struct net_buf *frag,
 		     uint8_t flags)
@@ -683,9 +668,7 @@ static int send_frag(struct bt_conn *conn,
 
 	/* Add the data to the buffer */
 	if (frag) {
-		size_t iso_hdr = flags == FRAG_START ? iso_hdr_len(buf, conn) : 0;
-		uint16_t frag_len = MIN(conn_mtu(conn) + iso_hdr,
-					net_buf_tailroom(frag));
+		uint16_t frag_len = MIN(conn_mtu(conn), net_buf_tailroom(frag));
 
 		net_buf_add_mem(frag, buf->data, frag_len);
 		net_buf_pull(buf, frag_len);
@@ -733,11 +716,6 @@ static struct net_buf *create_frag(struct bt_conn *conn, struct net_buf *buf)
 	return frag;
 }
 
-static bool fits_single_ctlr_buf(struct net_buf *buf, struct bt_conn *conn)
-{
-	return buf->len - iso_hdr_len(buf, conn) <= conn_mtu(conn);
-}
-
 static int send_buf(struct bt_conn *conn, struct net_buf *buf)
 {
 	struct net_buf *frag;
@@ -747,7 +725,7 @@ static int send_buf(struct bt_conn *conn, struct net_buf *buf)
 	LOG_DBG("conn %p buf %p len %u", conn, buf, buf->len);
 
 	/* Send directly if the packet fits the ACL MTU */
-	if (fits_single_ctlr_buf(buf, conn) && !tx_data(buf)->is_cont) {
+	if (buf->len <= conn_mtu(conn) && !tx_data(buf)->is_cont) {
 		LOG_DBG("send single");
 		return send_frag(conn, buf, NULL, FRAG_SINGLE);
 	}

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -712,6 +712,7 @@ static struct net_buf *create_frag(struct bt_conn *conn, struct net_buf *buf)
 	/* Fragments never have a TX completion callback */
 	tx_data(frag)->tx = NULL;
 	tx_data(frag)->is_cont = false;
+	tx_data(frag)->iso_has_ts = tx_data(buf)->iso_has_ts;
 
 	return frag;
 }


### PR DESCRIPTION
PR contains three commits:
- 1st commit fixes calculations of HCI ISO Data packet length
- 2nd commit fixes timestamp value for SDUs fragmented to several HCI ISO Data packets
- 3rd commit fixes KConfig descriptions of BT_ISO_TX_MTU and BT_ISO_RX_MTU