### PR TITLE
subsys/dfu/boot: Fix image confirm for Direct XIP

### DIFF
--- a/boards/posix/native_sim/native_sim.dts
+++ b/boards/posix/native_sim/native_sim.dts
@@ -23,6 +23,7 @@
 		zephyr,flash-controller = &flashcontroller0;
 		zephyr,display = &sdl_dc;
 		zephyr,canbus = &can_loopback0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -34,6 +34,9 @@
 #define BOOT_HEADER_MAGIC_V1 0x96f3b83d
 #define BOOT_HEADER_SIZE_V1 32
 
+/* Get active partition. zephyr,code-partition chosen node must be defined */
+#define ACTIVE_SLOT_FLASH_AREA_ID DT_FIXED_PARTITION_ID(DT_CHOSEN(zephyr_code_partition))
+
 /*
  * Raw (on-flash) representation of the v1 image header.
  */
@@ -213,14 +216,18 @@ bool boot_is_img_confirmed(void)
 
 int boot_write_img_confirmed(void)
 {
-	int rc;
+	const struct flash_area *fa;
+	int rc = 0;
 
-	rc = boot_set_confirmed();
-	if (rc) {
+	if (flash_area_open(ACTIVE_SLOT_FLASH_AREA_ID, &fa) != 0) {
 		return -EIO;
 	}
 
-	return 0;
+	rc = boot_set_next(fa, true, true);
+
+	flash_area_close(fa);
+
+	return rc;
 }
 
 int boot_write_img_confirmed_multi(int image_index)


### PR DESCRIPTION
Previously the boot_write_img_confirmed() function used the MCUboot public API function boot_set_confirmed(), but this function is hardcoded to set the confirmed flag of slot 0. This works for MCUboot swap modes but not for Direct XIP, where applications can execute out of secondary slots.

This commit changes boot_write_img_confirmed() to instead use boot_set_next() which sets the confirmed flag for a given flash area and works with Direct XIP.
~To support this, new functions boot_active_slot() and boot_flash_area_id() have been added to get the current active slot and flash area.~