### PR TITLE
soc: nxp_rt11xx: fix missing unique PWM name.

### DIFF
--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -619,7 +619,7 @@
 			reg = <0x40194000 0x4000>;
 			interrupts =  <186 0>;
 
-			flexpwm3_pwm0: pwm0 {
+			flexpwm3_pwm0: flexpwm3_pwm0 {
 				compatible = "nxp,imx-pwm";
 				index = <0>;
 				interrupts = <182 0>;


### PR DESCRIPTION
Found an issue where I forgot to somehow update one of the unique PWM names. This one-liner adds that missing PWM unique device name.


