### PR TITLE
kernel: Use existent macros

### DIFF
--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -101,7 +101,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	 */
 	unsigned int key = arch_irq_lock();
 	struct k_thread *thread = IS_ENABLED(CONFIG_MULTITHREADING) ?
-			k_current_get() : NULL;
+			_current : NULL;
 
 	/* twister looks for the "ZEPHYR FATAL ERROR" string, don't
 	 * change it without also updating twister

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -84,15 +84,6 @@ FUNC_NORETURN void k_fatal_halt(unsigned int reason)
 }
 /* LCOV_EXCL_STOP */
 
-static inline int get_cpu(void)
-{
-#if defined(CONFIG_SMP)
-	return arch_curr_cpu()->id;
-#else
-	return 0;
-#endif
-}
-
 void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 {
 	/* We can't allow this code to be preempted, but don't need to
@@ -107,7 +98,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 	 * change it without also updating twister
 	 */
 	LOG_ERR(">>> ZEPHYR FATAL ERROR %d: %s on CPU %d", reason,
-		reason_to_str(reason), get_cpu());
+		reason_to_str(reason), _current_cpu->id);
 
 	/* FIXME: This doesn't seem to work as expected on all arches.
 	 * Need a reliable way to determine whether the fault happened when

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -785,7 +785,7 @@ void z_object_recycle(const void *obj)
 
 	if (ko != NULL) {
 		(void)memset(ko->perms, 0, sizeof(ko->perms));
-		z_thread_perms_set(ko, k_current_get());
+		z_thread_perms_set(ko, _current);
 		ko->flags |= K_OBJ_FLAG_INITIALIZED;
 	}
 }


### PR DESCRIPTION
- s/k_current_get/_current 
- s/get_cpu/_current_cpu

Running inside kernel we can use _current instead of k_current_get that can lead to additional function call
checks.
