### PR TITLE
tests: error_hook: skip test_catch_fatal_error for Armv8-R

### DIFF
--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -115,14 +115,16 @@ __no_optimization static void trigger_fault_divide_zero(void)
  * For the Cortex-M0, M0+, M23 (CONFIG_ARMV6_M_ARMV8_M_BASELINE)
  * which does not include a divide instruction, the test is skipped,
  * and there will be no hardware exception for that.
+ * For ARMv8-R, divide by zero trapping is not supported in hardware.
  */
 #if (defined(CONFIG_SOC_SERIES_MPS2) && defined(CONFIG_QEMU_TARGET)) || \
 	(defined(CONFIG_SOC_SERIES_MPS3) && defined(CONFIG_QEMU_TARGET)) || \
 	defined(CONFIG_BOARD_QEMU_CORTEX_A53) || defined(CONFIG_SOC_QEMU_ARC) || \
 	defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || \
 	defined(CONFIG_BOARD_QEMU_CORTEX_R5) || \
-	defined(CONFIG_BOARD_FVP_BASER_AEMV8R) || defined(CONFIG_BOARD_FVP_BASE_REVC_2XAEMV8A) || \
-	defined(CONFIG_BOARD_FVP_BASER_AEMV8R_AARCH32) || defined(CONFIG_SOC_NSIM_EM11D)
+	defined(CONFIG_ARMV8_R) || defined(CONFIG_AARCH32_ARMV8_R) || \
+	defined(CONFIG_BOARD_FVP_BASE_REVC_2XAEMV8A) || \
+	defined(CONFIG_SOC_NSIM_EM11D)
 	ztest_test_skip();
 #endif
 }


### PR DESCRIPTION
Skip `test_catch_fatal_error` test case for Armv8-R because divide by zero trapping is not supported on this architecture.

Fixes #63268

```
west twister -p s32z270dc2_rtu0_r52@D --device-testing --device-serial=/dev/ttyUSB0 -T tests/ztest/error_hook/
Renaming output directory to /home/user/zephyrproject/zephyr/twister-out.4
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.4.0-4641-g0d2e235d4d4d
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/user/zephyrproject/zephyr/twister-out/testplan.json

Device testing on:

| Platform              | ID   | Serial device   |
|-----------------------|------|-----------------|
| s32z270dc2_rtu0_r52@D |      | /dev/ttyUSB0    |

INFO    - JOBS: 8
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    2/   2  100%  skipped:    0, failed:    0, error:    0
INFO    - 2 test scenarios (2 test instances) selected, 0 configurations skipped (0 by static filter, 0 at runtime).
INFO    - 2 of 2 test configurations passed (100.00%), 0 failed, 0 errored, 0 skipped with 0 warnings in 38.01 seconds
INFO    - In total 16 test cases were executed, 1 skipped on 1 out of total 623 platforms (0.16%)
INFO    - 2 test configurations executed on platforms, 0 test configurations were only built.

Hardware distribution summary:

| Board                 | ID   |   Counter |
|-----------------------|------|-----------|
| s32z270dc2_rtu0_r52@D |      |         2 |
INFO    - Saving reports...
INFO    - Writing JSON report /home/user/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/user/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/user/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```