### PR TITLE
tests: kernel: syscalls: use default faulty address for s32z270dc2

### DIFF
--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -25,8 +25,6 @@
 #define FAULTY_ADDRESS 0x0FFFFFFF
 #elif defined(CONFIG_BOARD_QEMU_CORTEX_R5)
 #define FAULTY_ADDRESS 0xBFFFFFFF
-#elif defined(CONFIG_SOC_SERIES_S32ZE_R52)
-#define FAULTY_ADDRESS ((uintptr_t)(&_image_ram_end))
 #elif CONFIG_MMU
 /* Just past the zephyr image mapping should be a non-present page */
 #define FAULTY_ADDRESS Z_FREE_VM_START


### PR DESCRIPTION
Before Picolibc was made default, this board needed a custom test faulty address. Now this address does not produce a fault anymore so switch back to the default faulty address.

Fixes #63270

```
west twister -p s32z270dc2_rtu0_r52@D --device-testing --device-serial=/dev/ttyUSB0 -T tests/kernel/mem_protect/syscalls/
Renaming output directory to /home/user/zephyrproject/zephyr/twister-out.11
INFO    - Using Ninja..
INFO    - Zephyr version: zephyr-v3.4.0-4641-g0797603eb0eb
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/user/zephyrproject/zephyr/twister-out/testplan.json

Device testing on:

| Platform              | ID   | Serial device   |
|-----------------------|------|-----------------|
| s32z270dc2_rtu0_r52@D |      | /dev/ttyUSB0    |

INFO    - JOBS: 8
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    1/   1  100%  skipped:    0, failed:    0, error:    0
INFO    - 1 test scenarios (1 test instances) selected, 0 configurations skipped (0 by static filter, 0 at runtime).
INFO    - 1 of 1 test configurations passed (100.00%), 0 failed, 0 errored, 0 skipped with 0 warnings in 44.50 seconds
INFO    - In total 8 test cases were executed, 0 skipped on 1 out of total 623 platforms (0.16%)
INFO    - 1 test configurations executed on platforms, 0 test configurations were only built.

Hardware distribution summary:

| Board                 | ID   |   Counter |
|-----------------------|------|-----------|
| s32z270dc2_rtu0_r52@D |      |         1 |
INFO    - Saving reports...
INFO    - Writing JSON report /home/user/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/user/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/user/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```