### PR TITLE
dts: bindings: serial: nxp,kinetis-lpsci: do not re-specify pinctrl-0

### DIFF
--- a/dts/bindings/serial/nxp,kinetis-lpsci.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpsci.yaml
@@ -12,5 +12,4 @@ properties:
     required: true
 
   pinctrl-0:
-    type: phandles
     required: true


### PR DESCRIPTION
Property type is already defined in pinctrl-device.yaml.