### PR TITLE
modules: Updated Tracerecorder to version 4.8.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -313,7 +313,7 @@ manifest:
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio
-      revision: 7ba53eb1c22d14a49fa51f4b57fc0614a893fdd7
+      revision: 5266c84ec20f447bb1508d487c7f5be223ddc9d1
       groups:
         - debug
     - name: picolibc

--- a/west.yml
+++ b/west.yml
@@ -313,7 +313,7 @@ manifest:
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio
-      revision: 5266c84ec20f447bb1508d487c7f5be223ddc9d1
+      revision: 0fbc5b72aeab8a6434523a3a7bc8111c17f0bc73
       groups:
         - debug
     - name: picolibc


### PR DESCRIPTION
This updates the tracerecorder part of the Percepio module to version 4.8.1.