### PR TITLE
scripts: build: gen_isr_tables: Cleanup access to ".intList"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1239,20 +1239,13 @@ if(CONFIG_GEN_ISR_TABLES)
   # isr_tables.c is generated from ${ZEPHYR_LINK_STAGE_EXECUTABLE} by
   # gen_isr_tables.py
   add_custom_command(
-    OUTPUT isr_tables.c isrList.bin
-    COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
-            $<TARGET_PROPERTY:bintools,elfconvert_flag>
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_intarget>${OUTPUT_FORMAT}
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>binary
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_section_only>.intList
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>$<TARGET_FILE:${ZEPHYR_LINK_STAGE_EXECUTABLE}>
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>isrList.bin
-            $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+    OUTPUT isr_tables.c
     COMMAND ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/build/gen_isr_tables.py
     --output-source isr_tables.c
     --kernel $<TARGET_FILE:${ZEPHYR_LINK_STAGE_EXECUTABLE}>
-    --intlist isrList.bin
+    --intlist-section .intList
+    --intlist-section intList
     $<$<BOOL:${CONFIG_BIG_ENDIAN}>:--big-endian>
     $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--debug>
     ${GEN_ISR_TABLE_EXTRA_ARG}

--- a/scripts/build/gen_isr_tables.py
+++ b/scripts/build/gen_isr_tables.py
@@ -42,7 +42,7 @@ def endian_prefix():
     else:
         return "<"
 
-def read_intlist(intlist_path, syms):
+def read_intlist(elfobj, syms, snames):
     """read a binary file containing the contents of the kernel's .intList
     section. This is an instance of a header created by
     include/zephyr/linker/intlist.ld:
@@ -66,7 +66,7 @@ def read_intlist(intlist_path, syms):
         const void *param;
     };
     """
-
+    intList_sect = None
     intlist = {}
 
     prefix = endian_prefix()
@@ -77,8 +77,16 @@ def read_intlist(intlist_path, syms):
     else:
         intlist_entry_fmt = prefix + "iiII"
 
-    with open(intlist_path, "rb") as fp:
-        intdata = fp.read()
+    for sname in snames:
+        intList_sect = elfobj.get_section_by_name(sname)
+        if intList_sect is not None:
+            debug("Found intlist section: \"{}\"".format(sname))
+            break
+
+    if intList_sect is None:
+        error("Cannot find the intlist section!")
+
+    intdata = intList_sect.data()
 
     header_sz = struct.calcsize(intlist_header_fmt)
     header = struct.unpack_from(intlist_header_fmt, intdata, 0)
@@ -122,8 +130,9 @@ def parse_args():
             help="Generate SW ISR table")
     parser.add_argument("-V", "--vector-table", action="store_true",
             help="Generate vector table")
-    parser.add_argument("-i", "--intlist", required=True,
-            help="Zephyr intlist binary for intList extraction")
+    parser.add_argument("-i", "--intlist-section", action="append", required=True,
+            help="The name of the section to search for the interrupt data. "
+                 "This is accumulative argument. The first section found would be used.")
 
     args = parser.parse_args()
 
@@ -286,6 +295,7 @@ def main():
     with open(args.kernel, "rb") as fp:
         kernel = ELFFile(fp)
         syms = get_symbols(kernel)
+        intlist = read_intlist(kernel, syms, args.intlist_section)
 
     if "CONFIG_MULTI_LEVEL_INTERRUPTS" in syms:
         max_irq_per = syms["CONFIG_MAX_IRQ_PER_AGGREGATOR"]
@@ -313,7 +323,6 @@ def main():
 
                 debug('3rd level offsets: {}'.format(list_3rd_lvl_offsets))
 
-    intlist = read_intlist(args.intlist, syms)
     nvec = intlist["num_vectors"]
     offset = intlist["offset"]
 


### PR DESCRIPTION
This commit removes the needs or generating isrList.bin temporary file. Now gen_isr_tables.py script access the required section directly in elf file, that was accessed by the script anyway.
It simplifies the building removing one step.

This is the part of #60838 PR that should not rise any controversy.
Just simplification of the build process without changing the way the intList section is handled later.