### PR TITLE
Modem pipe avoid inconsequential open close calls

### DIFF
--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -69,6 +69,9 @@ void modem_pipe_init(struct modem_pipe *pipe, void *data, struct modem_pipe_api 
  * @brief Open pipe
  *
  * @param pipe Pipe instance
+ *
+ * @retval 0 if pipe was successfully opened or was already open
+ * @retval -errno code otherwise
  */
 int modem_pipe_open(struct modem_pipe *pipe);
 
@@ -76,6 +79,12 @@ int modem_pipe_open(struct modem_pipe *pipe);
  * @brief Open pipe asynchronously
  *
  * @param pipe Pipe instance
+ *
+ * @note The MODEM_PIPE_EVENT_OPENED event is invoked immediately if pipe is
+ * already opened.
+ *
+ * @retval 0 if pipe open was called successfully or pipe was already open
+ * @retval -errno code otherwise
  */
 int modem_pipe_open_async(struct modem_pipe *pipe);
 
@@ -85,6 +94,9 @@ int modem_pipe_open_async(struct modem_pipe *pipe);
  * @param pipe Pipe instance
  * @param callback Callback called when pipe event occurs
  * @param user_data Free to use user data passed with callback
+ *
+ * @note The MODEM_PIPE_EVENT_RECEIVE_READY event is invoked immediately if pipe has pending
+ * data ready to receive.
  */
 void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback, void *user_data);
 
@@ -127,6 +139,9 @@ void modem_pipe_release(struct modem_pipe *pipe);
  * @brief Close pipe
  *
  * @param pipe Pipe instance
+ *
+ * @retval 0 if pipe open was called closed or pipe was already closed
+ * @retval -errno code otherwise
  */
 int modem_pipe_close(struct modem_pipe *pipe);
 
@@ -134,6 +149,12 @@ int modem_pipe_close(struct modem_pipe *pipe);
  * @brief Close pipe asynchronously
  *
  * @param pipe Pipe instance
+ *
+ * @note The MODEM_PIPE_EVENT_CLOSED event is invoked immediately if pipe is
+ * already closed.
+ *
+ * @retval 0 if pipe close was called successfully or pipe was already closed
+ * @retval -errno code otherwise
  */
 int modem_pipe_close_async(struct modem_pipe *pipe);
 

--- a/tests/subsys/modem/backends/tty/src/main.c
+++ b/tests/subsys/modem/backends/tty/src/main.c
@@ -122,10 +122,10 @@ static void test_modem_backend_tty_teardown(void *f)
 /*************************************************************************************************/
 ZTEST(modem_backend_tty_suite, test_close_open)
 {
-	zassert_true(modem_pipe_close(tty_pipe) == 0, "Failed to close pipe");
-	zassert_true(modem_pipe_close(tty_pipe) == -EALREADY, "Pipe should already be closed");
-	zassert_true(modem_pipe_open(tty_pipe) == 0, "Failed to open pipe");
-	zassert_true(modem_pipe_open(tty_pipe) == -EALREADY, "Pipe should already be open");
+	zassert_ok(modem_pipe_close(tty_pipe), "Failed to close pipe");
+	zassert_ok(modem_pipe_close(tty_pipe), "Pipe should already be closed");
+	zassert_ok(modem_pipe_open(tty_pipe), "Failed to open pipe");
+	zassert_ok(modem_pipe_open(tty_pipe), "Pipe should already be open");
 }
 
 ZTEST(modem_backend_tty_suite, test_receive_ready_event_not_raised)


### PR DESCRIPTION
This PR adds a mechanism to avoid calling open() or close() on pipes which are already opened or closed respectively. This optimization can help simplify backends implementing the modem_pipe API by avoiding duplicated boilerplate code.

The doxygen documentation for the modem_pipe API has also been improved, documenting expected return values and noting the new added behavior of the modem_pipe API