### PR TITLE
net: l2: ppp: Don't attempt reestablish PPP if carrier is down

### DIFF
--- a/include/zephyr/net/ppp.h
+++ b/include/zephyr/net/ppp.h
@@ -483,9 +483,6 @@ struct ppp_context {
 	/** This tells how many network protocols are up */
 	int network_protos_up;
 
-	/** Is network carrier up */
-	uint16_t is_net_carrier_up : 1;
-
 	/** Is PPP ready to receive packets */
 	uint16_t is_ready_to_serve : 1;
 

--- a/subsys/net/l2/ppp/lcp.c
+++ b/subsys/net/l2/ppp/lcp.c
@@ -179,6 +179,10 @@ static void lcp_down(struct ppp_fsm *fsm)
 
 	ppp_link_down(ctx);
 
+	if (!net_if_is_carrier_ok(ctx->iface)) {
+		return;
+	}
+
 	ppp_change_phase(ctx, PPP_ESTABLISH);
 }
 


### PR DESCRIPTION
This PR adds a check to prevent attempting to reestablish the PPP session if the carrier is down. The current behavior is not breaking anything as the PPP FSM attempts a couple of times then gives up,  but it is unnecessary and therefore not desired.

Without the additional check:

carrier on
```
[2023-09-29 11:34:34][0x20005370] phase DEAD (0) => ESTABLISH (1))
[2023-09-29 11:34:37][0x20005370] phase ESTABLISH (1) => AUTH (2))
[2023-09-29 11:34:37][0x20005370] phase AUTH (2) => NETWORK (3))
[2023-09-29 11:34:37][0x20005370] phase NETWORK (3) => RUNNING (4))
```
carrier off
```
[2023-09-29 11:35:04][0x20005370] phase RUNNING (4) => TERMINATE (5))
[2023-09-29 11:35:04][0x20005370] phase TERMINATE (5) => DEAD (0))
[2023-09-29 11:35:04][0x20005370] phase DEAD (0) => ESTABLISH (1))
[2023-09-29 11:35:07][0x20005370] phase ESTABLISH (1) => DEAD (0))
```

With the additional check:

carrier on
```
[0x20005370] phase DEAD (0) => ESTABLISH (1))
[0x20005370] phase ESTABLISH (1) => AUTH (2))
[0x20005370] phase AUTH (2) => NETWORK (3))
[0x20005370] phase NETWORK (3) => RUNNING (4))
```
carrier off
```
[0x20005370] phase RUNNING (4) => TERMINATE (5))
[0x20005370] phase TERMINATE (5) => DEAD (0))
```

This PR also removes an unused flag from the `struct ppp_context` to prevent future confusion :)