### PR TITLE
llvm: Add support for LLVM libc++ C++ Standard Library

### DIFF
--- a/cmake/linker/lld/target.cmake
+++ b/cmake/linker/lld/target.cmake
@@ -110,6 +110,6 @@ endfunction(toolchain_ld_link_elf)
 # Load toolchain_ld-family macros
 include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_base.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_baremetal.cmake)
-include(${ZEPHYR_BASE}/cmake/linker/ld/target_cpp.cmake)
+include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_cpp.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/ld/target_relocation.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/ld/target_configure.cmake)

--- a/cmake/linker/lld/target_cpp.cmake
+++ b/cmake/linker/lld/target_cpp.cmake
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# See root CMakeLists.txt for description and expectations of these macros
+
+macro(toolchain_ld_cpp)
+
+  zephyr_link_libraries(
+    -lc++
+  )
+
+endmacro()

--- a/lib/cpp/Kconfig
+++ b/lib/cpp/Kconfig
@@ -74,6 +74,7 @@ config FULL_LIBCPP_SUPPORTED
 choice LIBCPP_IMPLEMENTATION
 	prompt "C++ Standard Library Implementation"
 	default EXTERNAL_LIBCPP if REQUIRES_FULL_LIBCPP && NATIVE_BUILD
+	default LIBCXX_LIBCPP if REQUIRES_FULL_LIBCPP && "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "llvm"
 	default GLIBCXX_LIBCPP if REQUIRES_FULL_LIBCPP
 	default MINIMAL_LIBCPP
 
@@ -95,6 +96,17 @@ config GLIBCXX_LIBCPP
 	help
 	  Build with GNU C++ Standard Library (libstdc++) provided by the GNU
 	  Compiler Collection (GCC)-based toolchain.
+
+config LIBCXX_LIBCPP
+	bool "LLVM C++ Standard Library"
+	depends on !NATIVE_APPLICATION
+	depends on NEWLIB_LIBC
+	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "llvm"
+	select FULL_LIBCPP_SUPPORTED
+	help
+	  Build with LLVM C++ Standard Library (libc++) provided by LLVM
+	  toolchain. Information about library can be found at
+	  https://libcxx.llvm.org
 
 config ARCMWDT_LIBCPP
 	bool "ARC MWDT C++ Library"


### PR DESCRIPTION
LLVM toolchain provides its own C++ standard library called libc++. This patch adds new LLVM_LIBCXX config which should be used to indicate that libc++ is used.

Information about library can be found at https://libcxx.llvm.org