### PR TITLE
net: icmp: Don't unref net_pkt from the registered handler

### DIFF
--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -491,8 +491,6 @@ static int icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
 
 	net_stats_update_icmp_sent(net_pkt_iface(reply));
 
-	net_pkt_unref(pkt);
-
 	return 0;
 drop:
 	if (reply) {

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -168,8 +168,6 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 
 	net_stats_update_icmp_sent(net_pkt_iface(reply));
 
-	net_pkt_unref(pkt);
-
 	return 0;
 
 drop:

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -356,8 +356,6 @@ static int handle_mld_query(struct net_icmp_ctx *ctx,
 
 	send_mld_report(net_pkt_iface(pkt));
 
-	net_pkt_unref(pkt);
-
 	return 0;
 
 drop:

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1383,7 +1383,6 @@ send_na:
 
 	if (!net_ipv6_send_na(net_pkt_iface(pkt), na_src,
 			      na_dst, tgt, flags)) {
-		net_pkt_unref(pkt);
 		return 0;
 	}
 
@@ -1821,8 +1820,6 @@ static int handle_na_input(struct net_icmp_ctx *ctx,
 	if (!handle_na_neighbor(pkt, na_hdr, tllao_offset)) {
 		goto drop;
 	}
-
-	net_pkt_unref(pkt);
 
 	return 0;
 
@@ -2609,8 +2606,6 @@ static int handle_ra_input(struct net_icmp_ctx *ctx,
 
 	/* Cancel the RS timer on iface */
 	net_if_stop_rs(net_pkt_iface(pkt));
-
-	net_pkt_unref(pkt);
 
 	return 0;
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -4388,7 +4388,6 @@ static int handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 		ping_done(&ping_ctx);
 	}
 
-	net_pkt_unref(pkt);
 	return 0;
 }
 #else
@@ -4463,7 +4462,6 @@ static int handle_ipv4_echo_reply(struct net_icmp_ctx *ctx,
 		ping_done(&ping_ctx);
 	}
 
-	net_pkt_unref(pkt);
 	return 0;
 }
 #else

--- a/tests/net/icmp/src/main.c
+++ b/tests/net/icmp/src/main.c
@@ -449,8 +449,6 @@ static int icmp_handler(struct net_icmp_ctx *ctx,
 	test->req_received = true;
 	k_sem_give(&test->tx_sem);
 
-	net_pkt_unref(pkt);
-
 	return 0;
 }
 

--- a/tests/net/icmpv4/src/main.c
+++ b/tests/net/icmpv4/src/main.c
@@ -131,7 +131,6 @@ static int handle_reply_msg(struct net_icmp_ctx *ctx,
 		return -ENOMSG;
 	}
 
-	net_pkt_unref(pkt);
 	return 0;
 }
 

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -2282,8 +2282,6 @@ static int handle_ipv6_echo_reply(struct net_icmp_ctx *ctx,
 		i++;
 	}
 
-	net_pkt_unref(pkt);
-
 	k_sem_give(&wait_data);
 
 	return NET_OK;


### PR DESCRIPTION
A minor overlook from the recent ICMP rework, the registered handlers should no longer unref the processed packet as it's now the responsibility of the ICMP module.