### PR TITLE
nrf53_bsim: Enable more tests

### DIFF
--- a/tests/drivers/entropy/api/testcase.yaml
+++ b/tests/drivers/entropy/api/testcase.yaml
@@ -5,7 +5,9 @@ tests:
       - drivers
       - entropy
   drivers.entropy.bt_hci:
-    platform_allow: nrf52_bsim
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpunet
     extra_args:
       - DTC_OVERLAY_FILE=./entropy_bt_hci.overlay
       - OVERLAY_CONFIG=./entropy_bt_hci.conf

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -42,6 +42,8 @@ tests:
       - mimxrt685_evk_cm33
       - mimxrt595_evk_cm33
       - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpunet
+      - nrf5340bsim_nrf5340_cpuapp
   drivers.flash.common.tfm_ns:
     build_only: true
     filter: (CONFIG_FLASH_HAS_DRIVER_ENABLED and CONFIG_TRUSTED_EXECUTION_NONSECURE

--- a/tests/drivers/timer/nrf_rtc_timer/testcase.yaml
+++ b/tests/drivers/timer/nrf_rtc_timer/testcase.yaml
@@ -19,5 +19,7 @@ tests:
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
       - nrf52_bsim
+      - nrf5340bsim_nrf5340_cpuapp
+      - nrf5340bsim_nrf5340_cpunet
     integration_platforms:
       - nrf52dk_nrf52832


### PR DESCRIPTION
Enable (platform_allow) the new nrf53_bsim targets for some tests which would be otherwise filtered out, and for which there is a benefit enabling them in this target. 
Both as the drivers work slightly differently in the 52 and 53 targets, and so we test them if the HW models change.