### PR TITLE
samples: net: socket: echo_server: conn mgmt header file missing

### DIFF
--- a/samples/net/sockets/echo_server/src/tunnel.c
+++ b/samples/net/sockets/echo_server/src/tunnel.c
@@ -11,6 +11,7 @@ LOG_MODULE_DECLARE(net_echo_server_sample, LOG_LEVEL_DBG);
 
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/virtual_mgmt.h>
+#include <zephyr/net/conn_mgr_monitor.h>
 
 /* User data for the interface callback */
 struct ud {


### PR DESCRIPTION
The conn_mgr_monitor.h was not included so the compilation gave warning for missing conn_mgr_ignore_iface() function.