### PR TITLE
twister: Fix quarantine performance issue

### DIFF
--- a/scripts/tests/twister/test_quarantine.py
+++ b/scripts/tests/twister/test_quarantine.py
@@ -104,10 +104,9 @@ def test_quarantinedata_post_init():
 
     quarantine_element = QuarantineElement(
         platforms=['dummy platform'],
-        architectures=[]
+        architectures=[],
+        simulations=['dummy simulation', 'another simulation']
     )
-    quarantine_element.scenarios = []
-    quarantine_element.simulations = ['dummy simulation', 'another simulation']
 
     quarantine_data_qlist = [quarantine_element, quarantine_element_dict]
 


### PR DESCRIPTION
When using a quarantine file with more than 512 unique entries, than time of matching quarantine increases significantly. This is because regexp cache size is 512. Add precompiled regexp entries to the quarantine as a fix.

This problem occurred in one of our Downstream tests (when testing new platform there are many entries in the quarantine).
When using regexp cache, calling ` get_matched_quarantine` method takes about 0.00025s, without cache it is 0,008 (30x slower).
So for thousands of test-configurations (e.g. with build_on_all flag enabled in test yaml), the total time is noticeable.