### PR TITLE
samples/gettimeofday: Detect 32-bit timeval.tv_sec

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -58,6 +58,10 @@ else() # Linux.x86_64
     check_set_compiler_property(APPEND PROPERTY fpsse2 "SHELL:-msse2 -mfpmath=sse")
     zephyr_compile_options($<TARGET_PROPERTY:compiler,fpsse2>)
     target_compile_options(native_simulator INTERFACE "$<TARGET_PROPERTY:compiler,fpsse2>")
+
+    # Enable 64-bit time_t and 64-bit off_t in glibc to match other
+    # Zephyr environments.
+    zephyr_compile_definitions(_TIME_BITS=64 _FILE_OFFSET_BITS=64)
   endif ()
 endif()
 

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -301,21 +301,20 @@ static int do_write_unaligned(const struct shell *sh, off_t offset, uint8_t *buf
 	if (!single_page_write) {
 		size_t middle_data_len = aligned_size;
 		off_t middle_page_start = start_page;
-		off_t data_offset = (off_t)buf;
+		char *data = buf;
 
 		/* Write the middle bit if available */
 		if (size_before > 0) {
 			middle_page_start += page_size;
 			middle_data_len -= page_size;
-			data_offset += (page_size - size_before);
+			data += (page_size - size_before);
 		}
 		if (size_after > 0) {
 			middle_data_len -= page_size;
 		}
 		if (middle_data_len > 0) {
 			flash_write(flash_device, middle_page_start,
-					 (const void *)data_offset,
-					 middle_data_len);
+					 data, middle_data_len);
 		}
 
 		/* Write the last page if needed. */

--- a/samples/posix/gettimeofday/src/main.c
+++ b/samples/posix/gettimeofday/src/main.c
@@ -10,10 +10,17 @@
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
+#include <stdint.h>
 
 int main(void)
 {
 	struct timeval tv;
+
+	if (sizeof(tv.tv_sec) < sizeof(uint64_t)) {
+		printf("Error: sizeof(time_t) (%d) is less than 64 bits\n",
+		       (int) sizeof(tv.tv_sec));
+		return 1;
+	}
 
 	while (1) {
 		int res = gettimeofday(&tv, NULL);

--- a/tests/subsys/fs/common/test_fs_basic.c
+++ b/tests/subsys/fs/common/test_fs_basic.c
@@ -162,7 +162,7 @@ static int seek_within_hello(const struct fs_mount_t *mp)
 	zassert_equal(fs_tell(&file), stat.size,
 		      "verify hello read middle tell failed");
 
-	zassert_equal(fs_seek(&file, -stat.size, FS_SEEK_CUR),
+	zassert_equal(fs_seek(&file, -(off_t)stat.size, FS_SEEK_CUR),
 		      0,
 		      "verify hello seek back from cur failed");
 


### PR DESCRIPTION
First, fix the posix arch to make glibc expose 64-bit time_t and off_t types. Then, make sure time_t is never 32-bits on all architectures.