### PR TITLE
usb: device: cdc_acm: fixes for v3.5.0

### DIFF
--- a/doc/connectivity/usb/device/usb_device.rst
+++ b/doc/connectivity/usb/device/usb_device.rst
@@ -82,6 +82,9 @@ But there are two important differences in behavior to a real UART controller:
   initialized and started, until then any data is discarded
 * If device is connected to the host, it still needs an application
   on the host side which requests the data
+* The CDC ACM poll out implementation follows the API and blocks when the TX
+  ring buffer is full only if the hw-flow-control property is enabled and
+  called from a non-ISR context.
 
 The devicetree compatible property for CDC ACM UART is
 :dtcompatible:`zephyr,cdc-acm-uart`.

--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -301,8 +301,10 @@ static void cdc_acm_read_cb(uint8_t ep, int size, void *priv)
 	}
 
 done:
-	usb_transfer(ep, dev_data->rx_buf, sizeof(dev_data->rx_buf),
-		     USB_TRANS_READ, cdc_acm_read_cb, dev_data);
+	if (dev_data->configured) {
+		usb_transfer(ep, dev_data->rx_buf, sizeof(dev_data->rx_buf),
+			     USB_TRANS_READ, cdc_acm_read_cb, dev_data);
+	}
 }
 
 /**
@@ -366,9 +368,9 @@ static void cdc_acm_do_cb(struct cdc_acm_dev_data_t *dev_data,
 	case USB_DC_CONFIGURED:
 		LOG_INF("Device configured");
 		if (!dev_data->configured) {
+			dev_data->configured = true;
 			cdc_acm_read_cb(cfg->endpoint[ACM_OUT_EP_IDX].ep_addr, 0,
 					dev_data);
-			dev_data->configured = true;
 		}
 		if (!dev_data->tx_ready) {
 			dev_data->tx_ready = true;


### PR DESCRIPTION
usb: device: cdc_acm: restart OUT transfer in only configured state

When a usb_transfer is cancelled, the callback is finally invoked.
Silly, there is no transfer status passed, and in the callback we can
only check the size and device status.
Fixes: #63262 

---

usb: device: cdc_acm: block in uart_poll_out() routine

According to the UART API documentation, implementation must block when
the transceiver is full. For CDC ACM UART, TX ringbuffer can be
considered as transceiver buffer/FIFO. Blocking when the USB subsystem
is not ready is considered highly undesirable behavior. Blocking may
also be undesirable when CDC ACM UART is used as a logging backend.

Change the behavior of CDC ACM poll out to:
 - Block if the TX ring buffer is full, hw_flow_control property is
   enabled, and called from a non-ISR context.
 - Do not block if the USB subsystem is not ready, poll out
   implementation is called from an ISR context, or hw_flow_control
   property is disabled.