### PR TITLE
intel_ish: Enable ISH boards for coverage.

### DIFF
--- a/soc/x86/intel_ish/Kconfig
+++ b/soc/x86/intel_ish/Kconfig
@@ -13,3 +13,4 @@ config SOC_FAMILY_INTEL_ISH
 	select CPU_HAS_FPU
 	select INTEL_HAL
 	select HAS_PM
+	select HAS_COVERAGE_SUPPORT


### PR DESCRIPTION
When build ISH project in Chromium repo, the coverage report error:

zmake build --coverage rex-ish
lcov: ERROR: no valid records found in tracefile.

To fix this, enable coverage config to link ISH boards with coverage library.