### PR TITLE
tests bsim: Limit parallel build

### DIFF
--- a/tests/bsim/bluetooth/compile.sh
+++ b/tests/bsim/bluetooth/compile.sh
@@ -18,9 +18,14 @@ mkdir -p ${WORK_DIR}
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
+# Note: We do not parallelize the call into the build of the host, ll and mesh images as those
+# are already building many images in parallel in themselves, and otherwise we would be
+# launching too many parallel builds which can lead to a too high system load.
+# On the other hand the audio compile script, only builds one image. So we parallelize it with
+# the rest to save a couple of seconds.
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio/compile.sh
-run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/host/compile.sh
-run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/ll/compile.sh
-run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/mesh/compile.sh
+${ZEPHYR_BASE}/tests/bsim/bluetooth/host/compile.sh
+${ZEPHYR_BASE}/tests/bsim/bluetooth/ll/compile.sh
+${ZEPHYR_BASE}/tests/bsim/bluetooth/mesh/compile.sh
 
 wait_for_background_jobs


### PR DESCRIPTION
The compile script had been modified
to fully parallelize all images builds
in 1de363d9d5279e2c3d6021fecad41ffca96e09f1

And has been kept building everything in parallel since then. Over time we have seen an increase in the number of hangs for this job in CI.
This is understood as being the result of the number of images having increased, leading to a too high load
on the worker machines which cause them to timeout their connection to the github CI scheduler.

In b83a82882559f0c4a6bc0a64f83be06cdbdf79c1
these jobs priority was lowered to alleviate this issue, but again we see an increased number of CI runner
disconnects.

Let's parallelize this compile jobs a bit less.

With this change, we do not build anymore the sets of host, ll and mesh test images in parallel but sequentially. 
On a local test with a clean ccache this reduces the peak 1 average load from 
~1700 to ~700, and eliminates issues with system unresponsiveness;
while there is no statistically measurable increase in overall build time.
Note that the single audio image is still built in parallel to the other 3 sets, as this was seen to improve total build time by 2 seconds out of 1m51s.

---

Context:
* The rate of this type of hangs is still relatively low: A quick check showed 2 connection losses in the last 150 runs.
* These build and run scripts are meant to go away, as we plan to add support to twister for this type of tests, so this kind of quick solution should be more than good enough as a stop gap.


Fixes: #63371