### PR TITLE
llext: Cleanups noted in initial PR

### DIFF
--- a/arch/arm/core/elf.c
+++ b/arch/arm/core/elf.c
@@ -8,13 +8,13 @@
 #include <zephyr/llext/llext.h>
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_DECLARE(elf);
+LOG_MODULE_REGISTER(elf, CONFIG_LLEXT_LOG_LEVEL);
 
 /**
  * @brief Architecture specific function for relocating partially linked (static) elf
  *
  * Elf files contain a series of relocations described in a section. These relocation
- * instructions are architecture specific and each architecture supporting modules
+ * instructions are architecture specific and each architecture supporting extensions
  * must implement this.
  *
  * The relocation codes for arm are well documented

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -79,7 +79,7 @@ struct llext *llext_by_name(const char *name);
  * Only relocatable ELF files are currently supported (partially linked).
  *
  * @param[in] loader An extension loader that provides input data and context
- * @param[in] name A string identifier for the module
+ * @param[in] name A string identifier for the extension
  * @param[out] ext A pointer to a statically allocated llext struct
  *
  * @retval 0 Success
@@ -143,4 +143,4 @@ void arch_elf_relocate(elf_rel_t *rel, uintptr_t opaddr, uintptr_t opval);
 }
 #endif
 
-#endif /* ZEPHYR_MODULE_H */
+#endif /* ZEPHYR_LLEXT_H */


### PR DESCRIPTION
There were a few small nits that were pointed out in the initial PR. Fixes the LOG_ macro in the arm elf implementation, replaces a few stray mentions of modules in llext.h with extensions.

Fixes review comments in #57086 