### PR TITLE
drivers: systick: Fix Cortex-M systick jumping forward and back again

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -314,9 +314,9 @@ static int sys_clock_driver_init(void)
 {
 
 	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
-	last_load = CYC_PER_TICK - 1;
+	last_load = CYC_PER_TICK;
 	overflow_cyc = 0U;
-	SysTick->LOAD = last_load;
+	SysTick->LOAD = last_load - 1;
 	SysTick->VAL = 0; /* resets timer to last_load */
 	SysTick->CTRL |= (SysTick_CTRL_ENABLE_Msk |
 			  SysTick_CTRL_TICKINT_Msk |

--- a/tests/kernel/timer/timer_monotonic/testcase.yaml
+++ b/tests/kernel/timer/timer_monotonic/testcase.yaml
@@ -15,3 +15,11 @@ tests:
     extra_configs:
       - CONFIG_APIC_TSC_DEADLINE_TIMER=y
       - CONFIG_HPET_TIMER=n
+  kernel.timer.monotonic.icount_off:
+    # Extra test for GH-48608
+    tags:
+      - kernel
+      - timer
+    platform_allow: mps2_an385
+    extra_configs:
+      - CONFIG_QEMU_ICOUNT=n


### PR DESCRIPTION
The timer is started with a value of zero, after one tick it reloads to`last_load - 1`.

Check if the timer value is zero when calculating the elapsed ticks. If `COUNTFLAG` is not set and the value is zero then no ticks have occurred since the timer was started.

Add a test to validate that the issue is fixed (and stays fixed).

Extra context:
I have assumed than once `SysTick->VAL` ticks from 1 down to 0 that `COUNTFLAG` will be set and an ISR triggered.
That is why I chose to put this check in the `else` for when `COUNTFLAG` is not set.
I used `val1` rather than `val2` as `COUNTFLAG` may be set inbetween reading `SysTick->CTRL` and setting `val2`.
The check could instead be `else if (val1 == 0 && val2 == 0) {` which would allow an extra tick to be counted if the timer had reloaded in between setting `val1` and `val2`.

Input/review from anyone more familiar with this Cortex-M3 systick would be appreciated

Fixes: #48608