### PR TITLE
bluetooth: conn: Fix forced pairing request handling

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -813,6 +813,9 @@ int bt_le_set_auto_conn(const bt_addr_le_t *addr,
  *  @note When @kconfig{CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY} is enabled then the
  *        security level will always be level 3.
  *
+ *  @note When @ref BT_SECURITY_FORCE_PAIR within @p sec is enabled then the pairing
+ *        procedure will always be initiated.
+ *
  *  @param conn Connection object.
  *  @param sec Requested security level.
  *

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2306,11 +2306,15 @@ static int start_security(struct bt_conn *conn)
 
 int bt_conn_set_security(struct bt_conn *conn, bt_security_t sec)
 {
+	bool force_pair;
 	int err;
 
 	if (conn->state != BT_CONN_CONNECTED) {
 		return -ENOTCONN;
 	}
+
+	force_pair = sec & BT_SECURITY_FORCE_PAIR;
+	sec &= ~BT_SECURITY_FORCE_PAIR;
 
 	if (IS_ENABLED(CONFIG_BT_SMP_SC_ONLY)) {
 		sec = BT_SECURITY_L4;
@@ -2321,13 +2325,12 @@ int bt_conn_set_security(struct bt_conn *conn, bt_security_t sec)
 	}
 
 	/* nothing to do */
-	if (conn->sec_level >= sec || conn->required_sec_level >= sec) {
+	if (!force_pair && (conn->sec_level >= sec || conn->required_sec_level >= sec)) {
 		return 0;
 	}
 
-	atomic_set_bit_to(conn->flags, BT_CONN_FORCE_PAIR,
-			  sec & BT_SECURITY_FORCE_PAIR);
-	conn->required_sec_level = sec & ~BT_SECURITY_FORCE_PAIR;
+	atomic_set_bit_to(conn->flags, BT_CONN_FORCE_PAIR, force_pair);
+	conn->required_sec_level = sec;
 
 	err = start_security(conn);
 


### PR DESCRIPTION
BT_SECURITY_FORCE_PAIR option gets overridden when CONFIG_BT_SMP_SC_ONLY or CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY is defined. Cache the bit value before overrides.
Add explicit forced pair handling to existing security level check. Functionality did not change as this was done implicitly due to integer comparison for enums.
Add extra clarification to the method doc.
Signed-off-by: Rait Rääk <raitraak@gmail.com>