### PR TITLE
drivers: can: remove unnecessary asserts in timing callbacks

### DIFF
--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -119,12 +119,6 @@ static int can_esp32_twai_set_timing(const struct device *dev, const struct can_
 	uint8_t btr0;
 	uint8_t btr1;
 
-	__ASSERT_NO_MSG(timing->sjw >= 0x1 && timing->sjw <= 0x4);
-	__ASSERT_NO_MSG(timing->prop_seg == 0);
-	__ASSERT_NO_MSG(timing->phase_seg1 >= 0x1 && timing->phase_seg1 <= 0x10);
-	__ASSERT_NO_MSG(timing->phase_seg2 >= 0x1 && timing->phase_seg2 <= 0x8);
-	__ASSERT_NO_MSG(timing->prescaler >= 0x1 && timing->prescaler <= 0x2000);
-
 	if (data->started) {
 		return -EBUSY;
 	}

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -204,12 +204,6 @@ int can_mcan_set_timing(const struct device *dev, const struct can_timing *timin
 		return -EBUSY;
 	}
 
-	__ASSERT_NO_MSG(timing->prop_seg == 0U);
-	__ASSERT_NO_MSG(timing->phase_seg1 <= 0x100 && timing->phase_seg1 > 1U);
-	__ASSERT_NO_MSG(timing->phase_seg2 <= 0x80 && timing->phase_seg2 > 1U);
-	__ASSERT_NO_MSG(timing->prescaler <= 0x200 && timing->prescaler > 0U);
-	__ASSERT_NO_MSG(timing->sjw <= 0x80 && timing->sjw > 0U);
-
 	k_mutex_lock(&data->lock, K_FOREVER);
 
 	nbtp |= FIELD_PREP(CAN_MCAN_NBTP_NSJW, timing->sjw - 1UL) |
@@ -238,12 +232,6 @@ int can_mcan_set_timing_data(const struct device *dev, const struct can_timing *
 	if (data->started) {
 		return -EBUSY;
 	}
-
-	__ASSERT_NO_MSG(timing_data->prop_seg == 0U);
-	__ASSERT_NO_MSG(timing_data->phase_seg1 <= 0x20 && timing_data->phase_seg1 > 0U);
-	__ASSERT_NO_MSG(timing_data->phase_seg2 <= 0x10 && timing_data->phase_seg2 > 0U);
-	__ASSERT_NO_MSG(timing_data->prescaler <= 0x20 && timing_data->prescaler > 0U);
-	__ASSERT_NO_MSG(timing_data->sjw <= 0x10 && timing_data->sjw > 0U);
 
 	k_mutex_lock(&data->lock, K_FOREVER);
 

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -389,17 +389,6 @@ static int mcp2515_set_timing(const struct device *dev,
 	const uint8_t rx0_ctrl = BIT(6) | BIT(5) | BIT(2);
 	const uint8_t rx1_ctrl = BIT(6) | BIT(5);
 
-	__ASSERT(timing->sjw <= 4, "1 <= SJW <= 4");
-	__ASSERT((timing->prop_seg >= 1) && (timing->prop_seg <= 8),
-		 "1 <= PROP <= 8");
-	__ASSERT((timing->phase_seg1 >= 1) && (timing->phase_seg1 <= 8),
-		 "1 <= BS1 <= 8");
-	__ASSERT((timing->phase_seg2 >= 2) && (timing->phase_seg2 <= 8),
-		 "2 <= BS2 <= 8");
-	__ASSERT(timing->prop_seg + timing->phase_seg1 >= timing->phase_seg2,
-		 "PROP + BS1 >= BS2");
-	__ASSERT(timing->phase_seg2 > timing->sjw, "BS2 > SJW");
-
 	config_buf[0] = cnf3;
 	config_buf[1] = cnf2;
 	config_buf[2] = cnf1;

--- a/drivers/can/can_mcp251xfd.c
+++ b/drivers/can/can_mcp251xfd.c
@@ -425,12 +425,6 @@ static int mcp251xfd_set_timing(const struct device *dev, const struct can_timin
 		return -EBUSY;
 	}
 
-	__ASSERT_NO_MSG(timing->prop_seg == 0);
-	__ASSERT_NO_MSG(timing->sjw >= 1 && timing->sjw <= 128);
-	__ASSERT_NO_MSG(timing->phase_seg1 >= 2 && timing->phase_seg1 <= 256);
-	__ASSERT_NO_MSG(timing->phase_seg2 >= 1 && timing->phase_seg2 <= 128);
-	__ASSERT_NO_MSG(timing->prescaler >= 1 && timing->prescaler <= 256);
-
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 
 	reg = mcp251xfd_get_spi_buf_ptr(dev);
@@ -465,12 +459,6 @@ static int mcp251xfd_set_timing_data(const struct device *dev, const struct can_
 	if (dev_data->started) {
 		return -EBUSY;
 	}
-
-	__ASSERT_NO_MSG(timing->prop_seg == 0);
-	__ASSERT_NO_MSG(timing->sjw >= 1 && timing->sjw <= 16);
-	__ASSERT_NO_MSG(timing->phase_seg1 >= 1 && timing->phase_seg1 <= 32);
-	__ASSERT_NO_MSG(timing->phase_seg2 >= 1 && timing->phase_seg2 <= 16);
-	__ASSERT_NO_MSG(timing->prescaler >= 1 && timing->prescaler <= 256);
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -108,12 +108,6 @@ int can_sja1000_set_timing(const struct device *dev, const struct can_timing *ti
 	uint8_t btr0;
 	uint8_t btr1;
 
-	__ASSERT_NO_MSG(timing->sjw >= 1 && timing->sjw <= 4);
-	__ASSERT_NO_MSG(timing->prop_seg == 0);
-	__ASSERT_NO_MSG(timing->phase_seg1 >= 1 && timing->phase_seg1 <= 16);
-	__ASSERT_NO_MSG(timing->phase_seg2 >= 1 && timing->phase_seg2 <= 8);
-	__ASSERT_NO_MSG(timing->prescaler >= 1 && timing->prescaler <= 64);
-
 	if (data->started) {
 		return -EBUSY;
 	}


### PR DESCRIPTION
Remove unnecessary calls to `__ASSERT_NO_MSG()` in CAN controller driver timing setter callbacks. The CAN API functions `can_set_timing()` and `can_set_timing_data()` already provide run-time timing parameter validation.