### PR TITLE
doc: release/migration: 3.5: Add MCUboot, retention, retained memory and some MCUmgr notes

### DIFF
--- a/doc/releases/migration-guide-3.5.rst
+++ b/doc/releases/migration-guide-3.5.rst
@@ -34,6 +34,13 @@ Required changes
   SMP version 2 error code defines for in-tree modules have been updated to
   replace the ``*_RET_RC_*`` parts with ``*_ERR_*``.
 
+* MCUmgr SMP version 2 error translation (to legacy MCUmgr error code) is now
+  handled in function handlers by setting the ``mg_translate_error`` function
+  pointer of :c:struct:`mgmt_group` when registering a group. See
+  :c:type:`smp_translate_error_fn` for function details. Any SMP version 2
+  handlers made for Zephyr 3.4 need to be updated to include these translation
+  functions when the groups are registered.
+
 * ``zephyr,memory-region-mpu`` was renamed ``zephyr,memory-attr`` and its type
   moved from 'enum' to 'int'. To have a seamless conversion this is the
   required change in the DT:

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -249,6 +249,13 @@ Drivers and Sensors
 
   * Added support for Nuvoton NuMaker M46x
 
+* Retained memory
+
+  * Added support for allowing mutex support to be forcibly disabled with
+    :kconfig:option:`CONFIG_RETAINED_MEM_MUTEX_FORCE_DISABLE`.
+
+  * Fixed issue with user mode support not working.
+
 * SDHC
 
 * Sensor

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -332,7 +332,7 @@ Libraries / Subsystems
 
   * MCUmgr SMP version 2 error translation (to legacy MCUmgr error code) is now
     supported in function handlers by setting ``mg_translate_error`` of
-    :c:struct:`mgmt_group` when registering a transport. See
+    :c:struct:`mgmt_group` when registering a group. See
     :c:type:`smp_translate_error_fn` for function details.
 
   * Fixed an issue with MCUmgr img_mgmt group whereby the size of the upload in

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -367,6 +367,15 @@ Libraries / Subsystems
   * Added ``user_data`` as an optional field to :c:struct:`mgmt_handler` when
     :kconfig:option:`CONFIG_MCUMGR_MGMT_HANDLER_USER_DATA` is enabled.
 
+  * Added optional ``force`` parameter to os mgmt reset command, this can be checked in the
+    :c:enum:`MGMT_EVT_OP_OS_MGMT_RESET` notification callback whose data structure is
+    :c:struct:`os_mgmt_reset_data`.
+
+  * Added configurable number of SMP encoding levels via
+    :kconfig:option:`CONFIG_MCUMGR_SMP_CBOR_MIN_ENCODING_LEVELS`, which automatically increments
+    minimum encoding levels for in-tree groups if :kconfig:option:`CONFIG_ZCBOR_CANONICAL` is
+    enabled.
+
 * File systems
 
   * Added support for ext2 file system.

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -403,6 +403,63 @@ MCUboot
     the primary slot with secondary slot contents, without saving the original
     image in primary slot.
 
+  * Fixed issue with serial recovery not showing image details for decrypted images.
+
+  * Fixed issue with serial recovery in single slot mode wrongly iterating over 2 image slots.
+
+  * Fixed an issue with boot_serial repeats not being processed when output was sent, this would
+    lead to a divergence of commands whereby later commands being sent would have the previous
+    command output sent instead.
+
+  * Fixed an issue with the boot_serial zcbor setup encoder function wrongly including the buffer
+    address in the size which caused serial recovery to fail on some platforms.
+
+  * Fixed wrongly building in optimize for debug mode by default, this saves a significant amount
+    of flash space.
+
+  * Fixed issue with serial recovery use of MBEDTLS having undefined operations which led to usage
+    faults when the secondary slot image was encrypted.
+
+  * Added error output when flash device fails to open and asserts are disabled, which will now
+    panic the bootloader.
+
+  * Added currently running slot ID and maximum application size to shared data function
+    definition.
+
+  * Added P384 and SHA384 support to imgtool.
+
+  * Added optional serial recovery image state and image set state commands.
+
+  * Added ``dumpinfo`` command for signed image parsing in imgtool.
+
+  * Added ``getpubhash`` command to dump the sha256 hash of the public key in imgtool.
+
+  * Added support for ``getpub`` to print the output to a file in imgtool.
+
+  * Added support for dumping the raw versions of the public keys in imgtool.
+
+  * Added support for sharing boot information with application via retention subsystem.
+
+  * Added support for serial recovery to read and handle encrypted seondary slot partitions.
+
+  * Removed ECDSA P224 support.
+
+  * Removed custom image list boot serial extension support.
+
+  * Reworked boot serial extensions so that they can be used by modules or from user repositories
+    by switching to iterable sections.
+
+  * Reworked image encryption support for Zephyr, static dummy key files are no longer in the code,
+    a pem file must be supplied to extract the private and public keys. The Kconfig menu has
+    changed to only show a single option for enabling encryption and selecting the key file.
+
+  * Reworked the ECDSA256 TLV curve agnostic and renamed it to ``ECDSA_SIG``.
+
+  * CDDL auto-generated function code has been replaced with zcbor function calls, this now allows
+    the parameters to be supplied in any order.
+
+  * The MCUboot version in this release is version ``2.0.0+0-rc1``.
+
 Storage
 *******
 

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -395,6 +395,9 @@ Libraries / Subsystems
 
   * Added the :ref:`blinfo_api` subsystem.
 
+  * Added support for allowing mutex support to be forcibly disabled with
+    :kconfig:option:`CONFIG_RETENTION_MUTEX_FORCE_DISABLE`.
+
 * Binary descriptors
 
   * Added the :ref:`binary_descriptors` (``bindesc``) subsystem.


### PR DESCRIPTION
    doc: release: 3.5: Add additional retention change note
    
    Adds a note on the change to disable retention system mutex
    support


    doc: release: 3.5: Add retained memory changes
    
    Adds notes on changes to retained memory


    doc: release: 3.5: Add additional MCUmgr changes
    
    Adds some additional notes on changes to MCUmgr in 3.5


    doc: release: 3.5: Add MCUboot release notes
    
    Adds the changes in MCUboot to this release


    doc: migration-guide: 3.5: Add note on SMP version 2 error handlers
    
    Adds a note about required changed for Zephyr 3.4 SMP version 2
    error translation handlers in Zephyr 3.5 (or newer)


    doc: release: 3.5: Correct word in MCUmgr update
    
    Changes wrong word transport to group
