### PR TITLE
samples: tracing: Reenable the percepio test case

### DIFF
--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -66,7 +66,6 @@ tests:
     platform_allow: native_posix
     extra_args: CONF_FILE="prj_native_posix_ctf.conf"
   sample.tracing.percepio:
-    skip: true
     platform_allow: frdm_k64f
     extra_args: CONF_FILE="prj_percepio.conf"
     modules:

--- a/west.yml
+++ b/west.yml
@@ -304,7 +304,7 @@ manifest:
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio
-      revision: 722448367cf6c4b877eb7999c90ee52226379acc
+      revision: 79d586d592fca3e9fecd8886af6acd8c7bb66314
       groups:
         - debug
     - name: picolibc


### PR DESCRIPTION
Update to a fixed percepio tree, which allows the build to pass for valid version numbers with 0 being one of the version number components.

Fixes #63357