### PR TITLE
boards/arm/stm32h735g_disco: Enable L2 Ethernet

### DIFF
--- a/boards/arm/stm32h735g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32h735g_disco/Kconfig.defconfig
@@ -8,6 +8,13 @@ if BOARD_STM32H735G_DISCO
 config BOARD
 	default "stm32h735g_disco"
 
+if NETWORKING
+
+config NET_L2_ETHERNET
+	default y
+
+endif # NETWORKING
+
 config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI


### PR DESCRIPTION
The stm32h735g_disco board support Ethernet but the L2 Ethernet driver was not being enabled.

The L2 Ethernet driver is now enabled along with Networking.