### PR TITLE
boards: nrf5340dk_nrf5340: Add default HW flow control pins to uart1

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -84,10 +84,12 @@
 
 	uart1_default: uart1_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 1)>;
+			psels = <NRF_PSEL(UART_TX, 1, 1)>,
+				<NRF_PSEL(UART_RTS, 0, 11)>;
 		};
 		group2 {
-			psels = <NRF_PSEL(UART_RX, 1, 0)>;
+			psels = <NRF_PSEL(UART_RX, 1, 0)>,
+				<NRF_PSEL(UART_CTS, 0, 10)>;
 			bias-pull-up;
 		};
 	};
@@ -95,7 +97,9 @@
 	uart1_sleep: uart1_sleep {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 1)>,
-				<NRF_PSEL(UART_RX, 1, 0)>;
+				<NRF_PSEL(UART_RX, 1, 0)>,
+				<NRF_PSEL(UART_RTS, 0, 11)>,
+				<NRF_PSEL(UART_CTS, 0, 10)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Add the default HW flow control pins to the uart1 node.