### PR TITLE
intel_adsp: boot_complete must be done PRE_KERNEL_1

### DIFF
--- a/soc/xtensa/intel_adsp/common/boot_complete.c
+++ b/soc/xtensa/intel_adsp/common/boot_complete.c
@@ -29,4 +29,4 @@ int boot_complete(void)
 	return 0;
 }
 
-SYS_INIT(boot_complete, EARLY, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(boot_complete, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);


### PR DESCRIPTION
This reverts commit 759e07bebe208f4cc1036a7525a80551e16a465c.

Zephyr boot fails on Intel Meteor Lake with this patch.

UPDATE: instead of revert, fix suggested by @nashif works:

intel_adsp: boot_complete must be done PRE_KERNEL_1
