### PR TITLE
cmake: stub zephyr_set(... SCOPE ...) function in package helper

### DIFF
--- a/cmake/package_helper.cmake
+++ b/cmake/package_helper.cmake
@@ -111,5 +111,16 @@ if(NOT DEFINED MODULES)
   )
 endif()
 
+# Loading Zephyr CMake extension commands, which allows us to overload Zephyr
+# scoping rules.
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS extensions)
+
+# Zephyr scoping creates custom targets for handling of properties.
+# However, custom targets cannot be used in CMake script mode.
+# Therefore disable zephyr_set(... SCOPE ...) in package helper as it is not needed.
+function(zephyr_set variable)
+  # This silence the error: zephyr_set(...  SCOPE <scope>) doesn't exists.
+endfunction()
+
 string(REPLACE ";" "," MODULES "${MODULES}")
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS zephyr_default:${MODULES})


### PR DESCRIPTION
Fixes: #63011

Custom targets are not available in script mode, which cause snippet loading to fail when using package helper.

Lookup of snippets is supported by package helper, thus allowing twister to filter test cases based on snippets.

However, loading of snippets itself is not supported as snippets make use of Zephyr scoping, which uses custom targets, something that is not available in script mode.

Therefore overload the `zephyr_set()` function, so that CMake package helper can be used together with snippets.