### PR TITLE
drivers: i2s: use new k_mem_slab definition

### DIFF
--- a/drivers/i2s/i2s_handlers.c
+++ b/drivers/i2s/i2s_handlers.c
@@ -33,7 +33,7 @@ static inline int z_vrfy_i2s_configure(const struct device *dev,
 	/* Ensure that the k_mem_slab's slabs are large enough for the
 	 * specified block size
 	 */
-	if (config.block_size > config.mem_slab->block_size) {
+	if (config.block_size > config.mem_slab->info.block_size) {
 		goto out;
 	}
 


### PR DESCRIPTION
Commit 2f003e59e407 ("kernel: Re-factor k_mem_slab definition") moved block_size into from k_mem_slab to k_mem_slab_info without updating i2s handlers. Use the new member to fix build failures.

Fixes: #63363