### PR TITLE
PM: Add testing pm_device_state_str function in device_driver_init testcase.

### DIFF
--- a/tests/subsys/pm/device_driver_init/src/main.c
+++ b/tests/subsys/pm/device_driver_init/src/main.c
@@ -32,23 +32,26 @@ ZTEST(device_driver_init, test_demo)
 #if IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)
 	enum pm_device_state state;
 	int rc;
-
+	state = -1;
+	zassert_equal(strcmp("",  pm_device_state_str(state)), 0, "Invalid device state");
 	/* No device runtime PM, starts on */
 	DEVICE_STATE_IS(DT_NODELABEL(test_reg), PM_DEVICE_STATE_ACTIVE);
 	DEVICE_STATE_IS(DT_NODELABEL(test_reg_chained), PM_DEVICE_STATE_ACTIVE);
 	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg), GPIO_OUTPUT_HIGH);
 	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_chained), GPIO_OUTPUT_HIGH);
-
+	zassert_equal(strcmp("active",  pm_device_state_str(state)), 0, "Invalid device state");
 	/* Device powered, zephyr,pm-device-runtime-auto, starts suspended */
 	DEVICE_STATE_IS(DT_NODELABEL(test_reg_chained_auto), PM_DEVICE_STATE_SUSPENDED);
 	DEVICE_STATE_IS(DT_NODELABEL(test_reg_auto), PM_DEVICE_STATE_SUSPENDED);
 	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_chained_auto), GPIO_OUTPUT_LOW);
 	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_auto), GPIO_OUTPUT_LOW);
+	zassert_equal(strcmp("suspended", pm_device_state_str(state)), 0, "Invalid device state");
 	/* Device not powered, starts off */
 	DEVICE_STATE_IS(DT_NODELABEL(test_reg_auto_chained), PM_DEVICE_STATE_OFF);
 	DEVICE_STATE_IS(DT_NODELABEL(test_reg_auto_chained_auto), PM_DEVICE_STATE_OFF);
 	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_auto_chained), GPIO_DISCONNECTED);
 	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_auto_chained_auto), GPIO_DISCONNECTED);
+	zassert_equal(strcmp("off",  pm_device_state_str(state)), 0, "Invalid device state");
 #else
 	/* Every regulator should be in "active" mode automatically.
 	 * State checking via GPIO as PM API is disabled.


### PR DESCRIPTION
Add calling the pm_device_state_str function to increase code coverage of subsys/pm/device.c file.