### PR TITLE
net: coap: release non-confirmable messages

### DIFF
--- a/tests/net/lib/coap_client/src/main.c
+++ b/tests/net/lib/coap_client/src/main.c
@@ -392,7 +392,5 @@ ZTEST(coap_client, test_unmatching_tokens)
 	k_sleep(K_MSEC(1));
 	k_sleep(K_MSEC(1));
 	clear_socket_events();
-	zassert_equal(last_response_code, COAP_RESPONSE_CODE_NOT_FOUND, "Unexpected response %d",
-		      last_response_code);
-	k_sleep(K_MSEC(1));
+	k_sleep(K_MSEC(1000));
 }


### PR DESCRIPTION
Only confirmable messages need pending tracking. Non-confirmable messages are released after sending.
Match incoming packets with token, not message ID. Ignore responses with non-matching tokens.