### PR TITLE
twister: Fix missing timeout in handler class

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1052,7 +1052,7 @@ class ProjectBuilder(FilterBuilder):
             harness = HarnessImporter.get_harness(instance.testsuite.harness.capitalize())
             harness.configure(instance)
             if isinstance(harness, Pytest):
-                harness.pytest_run(instance.handler.timeout)
+                harness.pytest_run(instance.handler.get_test_timeout())
             else:
                 instance.handler.handle(harness)
 


### PR DESCRIPTION
In PR #62947 a timeout variable was replaced with a method, but this timeout was used in another place to start pytest subprogram. This commit provides a fix.