### PR TITLE
boards/sparc: Update simulator_exec for twister

### DIFF
--- a/boards/sparc/generic_leon3/generic_leon3.yaml
+++ b/boards/sparc/generic_leon3/generic_leon3.yaml
@@ -2,7 +2,7 @@ identifier: generic_leon3
 name: Generic LEON3 system
 type: mcu
 simulation: tsim
-simulation_exec: tsim
+simulation_exec: tsim-leon3
 arch: sparc
 ram: 4096
 flash: 2048

--- a/boards/sparc/generic_leon3/generic_leon3.yaml
+++ b/boards/sparc/generic_leon3/generic_leon3.yaml
@@ -11,4 +11,8 @@ toolchain:
   - xtools
 supported:
   - netif
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
 vendor: gaisler

--- a/boards/sparc/gr716a_mini/gr716a_mini.yaml
+++ b/boards/sparc/gr716a_mini/gr716a_mini.yaml
@@ -9,4 +9,8 @@ toolchain:
   - xtools
 supported:
   - netif
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
 vendor: gaisler

--- a/boards/sparc/gr716a_mini/gr716a_mini.yaml
+++ b/boards/sparc/gr716a_mini/gr716a_mini.yaml
@@ -2,7 +2,7 @@ identifier: gr716a_mini
 name: GR716-MINI Development Board
 type: mcu
 simulation: tsim
-simulation_exec: tsim
+simulation_exec: tsim-leon3
 arch: sparc
 toolchain:
   - zephyr


### PR DESCRIPTION
The tsim simulator executable is named tsim-leon3, tsim-leon4, tsim-gr716, etc. This change is needed so that twister can find the simulator program and do the run step.
