### PR TITLE
Add separate initialization priority to MFD devices

### DIFF
--- a/drivers/mfd/Kconfig.npm1300
+++ b/drivers/mfd/Kconfig.npm1300
@@ -8,3 +8,10 @@ config MFD_NPM1300
 	select I2C
 	help
 	  Enable the Nordic nPM1300 PMIC multi-function device driver
+
+config MFD_NPM1300_INIT_PRIORITY
+	int "nPM1300 MFD initialization priority"
+	default MFD_INIT_PRIORITY
+	depends on MFD_NPM1300
+	help
+	  Multi-function device initialization priority for nPM1300.

--- a/drivers/mfd/Kconfig.npm6001
+++ b/drivers/mfd/Kconfig.npm6001
@@ -8,3 +8,13 @@ config MFD_NPM6001
 	select I2C
 	help
 	  Enable the Nordic nPM6001 PMIC multi-function device driver
+
+if MFD_NPM6001
+
+config MFD_NPM6001_INIT_PRIORITY
+	int "nPM6001 MFD initialization priority"
+	default MFD_INIT_PRIORITY
+	help
+	  Multi-function device initialization priority for nPM6001.
+
+endif # MFD_NPM6001

--- a/drivers/mfd/Kconfig.npm6001
+++ b/drivers/mfd/Kconfig.npm6001
@@ -9,12 +9,9 @@ config MFD_NPM6001
 	help
 	  Enable the Nordic nPM6001 PMIC multi-function device driver
 
-if MFD_NPM6001
-
 config MFD_NPM6001_INIT_PRIORITY
 	int "nPM6001 MFD initialization priority"
 	default MFD_INIT_PRIORITY
+	depends on MFD_NPM6001
 	help
 	  Multi-function device initialization priority for nPM6001.
-
-endif # MFD_NPM6001

--- a/drivers/mfd/mfd_npm1300.c
+++ b/drivers/mfd/mfd_npm1300.c
@@ -288,6 +288,6 @@ int mfd_npm1300_remove_callback(const struct device *dev, struct gpio_callback *
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, mfd_npm1300_init, NULL, &data_##inst, &config##inst,           \
-			      POST_KERNEL, CONFIG_MFD_INIT_PRIORITY, NULL);
+			      POST_KERNEL, CONFIG_MFD_NPM1300_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(MFD_NPM1300_DEFINE)

--- a/drivers/mfd/mfd_npm6001.c
+++ b/drivers/mfd/mfd_npm6001.c
@@ -87,6 +87,6 @@ static int mfd_npm6001_init(const struct device *dev)
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, mfd_npm6001_init, NULL, NULL, &config##inst, POST_KERNEL,      \
-			      CONFIG_MFD_INIT_PRIORITY, NULL);
+			      CONFIG_MFD_NPM6001_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(MFD_NPM6001_DEFINE)


### PR DESCRIPTION
Enables setting the initialization priority of the nPM6001 and nPM1300 independently from the common MFD priority. This is necessary in the case where nPM6001 is powered by a regulator on nPM1300 on the same board.