### PR TITLE
cmake: LLVM LLD minimum version 14.0.0

### DIFF
--- a/cmake/linker/lld/target.cmake
+++ b/cmake/linker/lld/target.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set_property(TARGET linker PROPERTY devices_start_symbol "_device_list_start")
 
-find_package(LlvmLld REQUIRED)
+find_package(LlvmLld 14.0.0 REQUIRED)
 set(CMAKE_LINKER ${LLVMLLD_LINKER})
 
 set_ifndef(LINKERFLAGPREFIX -Wl)


### PR DESCRIPTION
Fixes: #35671

Add minimal version required for LLVM LLD linker.
Linking fails with older LLVM LLD, such as v10.0.0.

LLVM v14.0.0 was released in 2022, and latest LLVM is v17.0.1. Zephyr currently doesn't have a strict minimum version of LLVM specified, but based on LLVM development and known issues on older releases, then a minimum version of v14.0.0 has been chosen in this commit.