### PR TITLE
posix: timer: Fix timer_obj alignment

### DIFF
--- a/lib/posix/timer.c
+++ b/lib/posix/timer.c
@@ -29,7 +29,7 @@ struct timer_obj {
 };
 
 K_MEM_SLAB_DEFINE(posix_timer_slab, sizeof(struct timer_obj),
-		  CONFIG_MAX_TIMER_COUNT, 4);
+		  CONFIG_MAX_TIMER_COUNT, __alignof__(struct timer_obj));
 
 static void zephyr_timer_wrapper(struct k_timer *ztimer)
 {

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -1,9 +1,6 @@
 common:
   filter: not (CONFIG_NATIVE_BUILD and CONFIG_EXTERNAL_LIBC)
-  # FIXME: qemu_leon3 is excluded because of the alignment-related failure
-  #        reported in the GitHub issue zephyrproject-rtos/zephyr#48992.
   platform_exclude:
-    - qemu_leon3
     - native_posix
     - native_posix_64
   tags: posix


### PR DESCRIPTION
This makes sure the heap `posix_timer_slab` provides objects aligned compatible with the type `timer_obj`. It was previously set to align at 4 bytes. One example where this failed was on the SPARC which requires access to `int64_t` to be 8-byte aligned.
    
In particular, `struct timer_obj` contains fields of type `k_timer_t` and `struct _timeout` which can have 64-bit fields.
    
With this commit we now get the information on required alignment for `struct timer_obj` from the compiler by using `__alignof__()`.

Before adding this patch, the run-time consistently got memory address alignment exceptions on qemu_leon3. It was possible to trace these exceptions to the assignment `its->it_interval = timer->interval;` (loading from `timer->interval`) in the file `lib/posix/timer.c`.

I believe this can close #48992 even though the crash signatures look a bit different.