### PR TITLE
tests: kernel: Add qemu_leon3 to no-multithreading tests

### DIFF
--- a/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
+++ b/tests/kernel/mem_heap/mheap_api_concept/testcase.yaml
@@ -24,6 +24,7 @@ tests:
       - qemu_riscv32
       - qemu_riscv32e
       - qemu_riscv64
+      - qemu_leon3
     integration_platforms:
       - qemu_cortex_m3
     extra_configs:

--- a/tests/kernel/mem_slab/mslab_api/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_api/testcase.yaml
@@ -22,6 +22,7 @@ tests:
       - qemu_riscv32
       - qemu_riscv32e
       - qemu_riscv64
+      - qemu_leon3
     integration_platforms:
       - qemu_cortex_m3
       - qemu_arc_hs

--- a/tests/kernel/threads/no-multithreading/testcase.yaml
+++ b/tests/kernel/threads/no-multithreading/testcase.yaml
@@ -22,5 +22,6 @@ tests:
       - qemu_riscv32
       - qemu_riscv32e
       - qemu_riscv64
+      - qemu_leon3
     integration_platforms:
       - qemu_cortex_m0

--- a/tests/kernel/timer/timer_api/testcase.yaml
+++ b/tests/kernel/timer/timer_api/testcase.yaml
@@ -34,6 +34,7 @@ tests:
       - qemu_arc_em
       - qemu_arc_hs
       - qemu_arc_hs6x
+      - qemu_leon3
     integration_platforms:
       - qemu_cortex_m3
       - nsim_em


### PR DESCRIPTION
Add qemu_leon3 target to the tests that list below. These set CONFIG_MULTITHREADING=n.

- tests/kernel/mem_heap/mheap_api_concept
- tests/kernel/mem_slab/mslab_api
- tests/kernel/threads/no-multithreading
- tests/kernel/timer/timer_api