### PR TITLE
tests/logging: Enable tests for SPARC

### DIFF
--- a/tests/subsys/logging/log_switch_format/testcase.yaml
+++ b/tests/subsys/logging/log_switch_format/testcase.yaml
@@ -8,7 +8,6 @@ common:
     - mips
     - nios2
     - posix
-    - sparc
   filter: not CONFIG_64BIT
 tests:
   logging.log_switch_format.deferred:

--- a/tests/subsys/logging/log_syst/testcase.yaml
+++ b/tests/subsys/logging/log_syst/testcase.yaml
@@ -9,7 +9,6 @@ tests:
       - mips
       - nios2
       - posix
-      - sparc
     # "CONFIG_FULL_LIBC_SUPPORTED" filter was applied
     # because of following chain of dependencies:
     # LOG_MIPI_SYST_ENABLE=y --> CONFIG_MIPI_SYST_LIB --> \
@@ -33,7 +32,6 @@ tests:
       - mips
       - nios2
       - posix
-      - sparc
     filter: CONFIG_FULL_LIBC_SUPPORTED
     extra_configs:
       - CONFIG_LOG_MIPI_SYST_ENABLE=n


### PR DESCRIPTION
Enables the tests log_switch_format and log_syst for SPARC.

The following boards have been tested and twister gives PASSED result:
- qemu_leon3
- generic_leon3
- gr716a_mini
