### PR TITLE
tests: posix: Enable pthread_pressure test on SPARC

### DIFF
--- a/tests/posix/pthread_pressure/Kconfig
+++ b/tests/posix/pthread_pressure/Kconfig
@@ -27,6 +27,7 @@ config TEST_DELAY_US
 config TEST_STACK_SIZE
 	int "Size of each thread stack in this test"
 	default 1024 if 64BIT
+	default 1024 if SPARC
 	default 512
 	help
 	  The minimal stack size required to run a minimal thread.

--- a/tests/posix/pthread_pressure/testcase.yaml
+++ b/tests/posix/pthread_pressure/testcase.yaml
@@ -5,8 +5,6 @@ common:
     - posix
   integration_platforms:
     - qemu_riscv64_smp
-  platform_exclude:
-    - qemu_leon3
 tests:
   portability.posix.pthread_pressure:
     extra_configs:


### PR DESCRIPTION
This sets the stack size appropriate for SPARC in the pthread_pressure test, and removes the exclusion for qemu_leon3.

Tested with twister on the board configurations qemu_leon3, gr716a_mini and generic_leon3.