### PR TITLE
tests/mcumgr/smp_version: Enable for SPARC

### DIFF
--- a/subsys/mgmt/mcumgr/grp/os_mgmt/include/os_mgmt_processor.h
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/include/os_mgmt_processor.h
@@ -132,6 +132,8 @@ extern "C" {
 #define PROCESSOR_NAME "riscv"
 #elif defined(CONFIG_XTENSA)
 #define PROCESSOR_NAME "xtensa"
+#elif defined(CONFIG_SPARC)
+#define PROCESSOR_NAME "sparc"
 #endif
 
 #ifndef PROCESSOR_NAME

--- a/tests/subsys/mgmt/mcumgr/smp_version/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/smp_version/testcase.yaml
@@ -11,7 +11,6 @@ tests:
     # FIXME: Exclude systems whereby the processor type is not known and emits a warning
     arch_exclude:
       - nios2
-      - sparc
       - mips
       - posix
     platform_exclude:
@@ -25,7 +24,6 @@ tests:
     # FIXME: Exclude systems whereby the processor type is not known and emits a warning
     arch_exclude:
       - nios2
-      - sparc
       - mips
       - posix
     platform_exclude:


### PR DESCRIPTION
This enables support for running the tests smp.version and smp.version_no_legacy on SPARC.

It has been tested on the following boards with PASSED result.
- qemu_leon3
- generic_leon3
- gr716a_mini
    
