### PR TITLE
drivers: modem: modem_cellular: extend CMUX timeout

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1323,8 +1323,14 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(zephyr_gsm_ppp_init_chat_script_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match),
+			      /* The 300ms delay after sending the AT+CMUX command is required
+			       * for some modems to ensure they get enough time to enter CMUX
+			       * mode before sending the first CMUX command. If this delay is
+			       * too short, modems have been observed to simply deadlock,
+			       * refusing to respond to any CMUX command.
+			       */
 			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT+CMUX=0,0,5,127,10,3,30,10,2",
-							      0));
+							      300));
 
 MODEM_CHAT_SCRIPT_DEFINE(zephyr_gsm_ppp_init_chat_script, zephyr_gsm_ppp_init_chat_script_cmds,
 			 abort_matches, modem_cellular_chat_callback_handler, 10);


### PR DESCRIPTION
This commit adds a timeout of 300ms to the generic (gsm_ppp) init chat script. This delay is required for some modems (discovered on a Telit ME910G1-WW) to allow it to enter CMUX mode. Without this delay, the modem simply refuses to respond to any CMUX commands.

Fixes #63410