### PR TITLE
cmake: Unset CXX compiler so target doesn't use host

### DIFF
--- a/cmake/modules/FindTargetTools.cmake
+++ b/cmake/modules/FindTargetTools.cmake
@@ -92,6 +92,8 @@ endif()
 # re-set it.
 unset(CMAKE_C_COMPILER)
 unset(CMAKE_C_COMPILER CACHE)
+unset(CMAKE_CXX_COMPILER)
+unset(CMAKE_CXX_COMPILER CACHE)
 
 # A toolchain consist of a compiler and a linker.
 # In Zephyr, toolchains require a port under cmake/toolchain/.


### PR DESCRIPTION
CXX compiler is using host compiler when it should find target compiler
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/63771