### PR TITLE
Allow picolibc to be used with third party CPP

### DIFF
--- a/cmake/linker/ld/target_cpp.cmake
+++ b/cmake/linker/ld/target_cpp.cmake
@@ -4,8 +4,10 @@
 
 macro(toolchain_ld_cpp)
 
-  zephyr_link_libraries(
-    -lstdc++
-  )
+  if(NOT CONFIG_EXTERNAL_MODULE_LIBCPP)
+    zephyr_link_libraries(
+      -lstdc++
+    )
+  endif()
 
 endmacro()

--- a/lib/cpp/Kconfig
+++ b/lib/cpp/Kconfig
@@ -107,7 +107,12 @@ config ARCMWDT_LIBCPP
 config EXTERNAL_LIBCPP
 	bool "External C++ standard library"
 	help
-	  Build with an external/user-provided C++ standard library.
+	  Build and link with an external/user-provided C++ standard library.
+
+config EXTERNAL_MODULE_LIBCPP
+	bool "External C++ standard library module"
+	help
+	  Build an external/user-provided C++ standard library.
 
 endchoice # LIBCPP_IMPLEMENTATION
 

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -36,7 +36,7 @@ config PICOLIBC_SUPPORTED
 	bool
 	depends on !NATIVE_APPLICATION
 	depends on ("$(TOOLCHAIN_HAS_PICOLIBC)" = "y") || (NATIVE_LIBRARY)
-	depends on !(CPP && ("$(TOOLCHAIN_HAS_PICOLIBC)" = "y"))
+	depends on !REQUIRES_FULL_LIBCPP || ("$(TOOLCHAIN_HAS_PICOLIBC)" = "y")
 	default y
 	select FULL_LIBC_SUPPORTED
 	help


### PR DESCRIPTION
Picolibc is disabled due to unsatisfied dependencies when trying to use third party minimal implementations of CPP. 

For example the enabling of `CPP` below causes an unsatisfied dependency turning off PICOLIBC
```
CONFIG_PICOLIBC=y
CONFIG_PICOLIBC_USE_MODULE=y
CONFIG_MINIMAL_LIBC=n

CONFIG_CPP=y
CONFIG_STD_CPP20=y

CONFIG_3PP_MINIMAL_CPP_STDLIB=y
```