### PR TITLE
kernel: disable THREAD_USERSPACE_LOCAL_DATA if LIBC_ERRNO

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -201,7 +201,7 @@ config THREAD_CUSTOM_DATA
 config THREAD_USERSPACE_LOCAL_DATA
 	bool
 	depends on USERSPACE
-	default y if ERRNO && !ERRNO_IN_TLS
+	default y if ERRNO && !ERRNO_IN_TLS && !LIBC_ERRNO
 
 config DYNAMIC_THREAD
 	bool "Support for dynamic threads [EXPERIMENTAL]"


### PR DESCRIPTION
Thread userspace local data is to be used with storing errno per thread without thread local storage support. However, if the C library has native errno support, there is no need to enable thread userspace local data to store errno per thread. Therefore, amend the default for CONFIG_THREAD_USERSPACE_LOCAL_DATA so that it is not enabled if the C library has native errno support.