### PR TITLE
dts: bindings: uart-controller: Set default values UART controller

### DIFF
--- a/dts/bindings/serial/uart-controller.yaml
+++ b/dts/bindings/serial/uart-controller.yaml
@@ -11,6 +11,7 @@ properties:
   current-speed:
     type: int
     description: Initial baud rate setting for UART
+    default: 115200
   hw-flow-control:
     type: boolean
     description: Set to enable RTS/CTS flow control at boot time
@@ -19,6 +20,7 @@ properties:
     description: |
       Configures the parity of the adapter. Enumeration id 0 for none, 1 for odd
       and 2 for even parity. Default to none if not specified.
+    default: "none"
     enum:
       - "none"
       - "odd"
@@ -27,6 +29,7 @@ properties:
     type: string
     description: |
       Sets the number of stop bits.
+    default: "1"
     enum:
       - "0_5"
       - "1"
@@ -36,6 +39,7 @@ properties:
     type: int
     description: |
       Sets the number of data bits.
+    default: 8
     enum:
       - 5
       - 6


### PR DESCRIPTION
Add default values for baud rate, data bits, parity and stop bits so drivers can use system wide defaults.