### PR TITLE
dts: bindings: uart-controller: Add detailed flow control options

### DIFF
--- a/dts/bindings/serial/uart-controller.yaml
+++ b/dts/bindings/serial/uart-controller.yaml
@@ -11,6 +11,18 @@ properties:
   current-speed:
     type: int
     description: Initial baud rate setting for UART
+  flow-control:
+    type: string
+    description: |
+      Configures the flow control to be used at boot time. Enumeration id 0 for
+      none, 1 for RTS/CTS, 2 for DTR/DSR and 3 for RS-485. Default to none if
+      not specified.
+    default: "none"
+    enum:
+      - "none"
+      - "rtscts"
+      - "dtrdsr"
+      - "rs485"
   hw-flow-control:
     type: boolean
     description: Set to enable RTS/CTS flow control at boot time


### PR DESCRIPTION
Add options to configure all hardware flow control mechanisms provided by the UART API.

This enables user to configure their desired flow control mechanism via device tree. Like the options for parity and stop bits, this one matches the enum provided by the UART API header `uart_config_flow_control` and can be used in a similar way.

As for the RFC: `hw-flow-control` should be marked as depricated but I'm not sure what the correct way would be to do so