### PR TITLE
bluetooth: mesh: Remove dead code

### DIFF
--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -76,10 +76,8 @@ static int dev_comp_data_get(struct bt_mesh_model *model,
 		page = 2U;
 	} else if (page >= 1U && IS_ENABLED(CONFIG_BT_MESH_COMP_PAGE_1)) {
 		page = 1U;
-	} else if (page != 0U) {
-		LOG_DBG("Composition page %u not available", page);
-		page = 0U;
 	}
+
 	LOG_DBG("Preparing Composition data page %d", page);
 
 	bt_mesh_model_msg_init(&sdu, OP_DEV_COMP_DATA_STATUS);


### PR DESCRIPTION
If uint8_t < 1 then it should be 0. Fixes "dead code" warnings.