### PR TITLE
Bluetooth: Audio: Update return value of {cfg,cap}_get_val 

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -802,10 +802,13 @@ int bt_audio_codec_cfg_set_frame_blocks_per_sdu(struct bt_audio_codec_cfg *codec
  *  @param[in] codec_cfg The codec data to search in.
  *  @param[in] type The type id to look for
  *  @param[out] data Pointer to the data-pointer to update when item is found
- *  @return Length of found @p data or 0 if not found
+ *
+ *  @retval Length of found @p data (may be 0)
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
  */
-uint8_t bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
-				   enum bt_audio_codec_config_type type, const uint8_t **data);
+int bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
+			       enum bt_audio_codec_config_type type, const uint8_t **data);
 
 /**
  * @brief Set or add a specific codec configuration value
@@ -1194,10 +1197,12 @@ int bt_audio_codec_cfg_meta_set_vendor(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  type The type id to look for
  * @param[out] data Pointer to the data-pointer to update when item is found
  *
- * @return Length of found @p data or 0 if not found
+ *  @retval Length of found @p data (may be 0)
+ *  @retval -EINVAL if arguments are invalid
+ *  @retval -ENODATA if not found
  */
-uint8_t bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
-				   enum bt_audio_codec_capability_type type, const uint8_t **data);
+int bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
+			       enum bt_audio_codec_capability_type type, const uint8_t **data);
 
 /**
  * @brief Set or add a specific codec capability value

--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -279,8 +279,8 @@ static void init_net_buf_simple_from_codec_cfg(struct net_buf_simple *buf,
 	buf->len = codec_cfg->data_len;
 }
 
-uint8_t bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
-				   enum bt_audio_codec_config_type type, const uint8_t **data)
+int bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
+			       enum bt_audio_codec_config_type type, const uint8_t **data)
 {
 	struct search_type_param param = {
 		.found = false,
@@ -292,12 +292,12 @@ uint8_t bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
 
 	CHECKIF(codec_cfg == NULL) {
 		LOG_DBG("codec is NULL");
-		return 0;
+		return -EINVAL;
 	}
 
 	CHECKIF(data == NULL) {
 		LOG_DBG("data is NULL");
-		return 0;
+		return -EINVAL;
 	}
 
 	*data = NULL;
@@ -305,12 +305,12 @@ uint8_t bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
 	err = bt_audio_data_parse(codec_cfg->data, codec_cfg->data_len, parse_cb, &param);
 	if (err != 0 && err != -ECANCELED) {
 		LOG_DBG("Could not parse the data: %d", err);
-		return 0;
+		return err;
 	}
 
-	if (param.data == NULL) {
+	if (!param.found) {
 		LOG_DBG("Could not find the type %u", type);
-		return 0;
+		return -ENODATA;
 	}
 
 	return param.data_len;
@@ -591,12 +591,12 @@ static void init_net_buf_simple_from_meta(struct net_buf_simple *buf, uint8_t me
 	buf->len = meta_len;
 }
 
-static int codec_meta_get_val(const uint8_t meta[], size_t meta_len, uint8_t type,
-			      const uint8_t **data)
+static int codec_meta_get_val(const uint8_t meta[], size_t meta_len,
+			      enum bt_audio_metadata_type type, const uint8_t **data)
 {
 	struct search_type_param param = {
 		.found = false,
-		.type = type,
+		.type = (uint8_t)type,
 		.data_len = 0,
 		.data = data,
 	};
@@ -1793,8 +1793,8 @@ static void init_net_buf_simple_from_codec_cap(struct net_buf_simple *buf,
 	buf->len = codec_cap->data_len;
 }
 
-uint8_t bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
-				   enum bt_audio_codec_capability_type type, const uint8_t **data)
+int bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
+			       enum bt_audio_codec_capability_type type, const uint8_t **data)
 {
 	struct search_type_param param = {
 		.found = false,
@@ -1806,12 +1806,12 @@ uint8_t bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
 
 	CHECKIF(codec_cap == NULL) {
 		LOG_DBG("codec_cap is NULL");
-		return 0;
+		return -EINVAL;
 	}
 
 	CHECKIF(data == NULL) {
 		LOG_DBG("data is NULL");
-		return 0;
+		return -EINVAL;
 	}
 
 	*data = NULL;
@@ -1819,12 +1819,12 @@ uint8_t bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
 	err = bt_audio_data_parse(codec_cap->data, codec_cap->data_len, parse_cb, &param);
 	if (err != 0 && err != -ECANCELED) {
 		LOG_DBG("Could not parse the data: %d", err);
-		return 0;
+		return err;
 	}
 
-	if (param.data == NULL) {
+	if (!param.found) {
 		LOG_DBG("Could not find the type %u", type);
-		return 0;
+		return -ENODATA;
 	}
 
 	return param.data_len;

--- a/tests/bluetooth/audio/codec/src/main.c
+++ b/tests/bluetooth/audio/codec/src/main.c
@@ -65,7 +65,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_set_val_new_value)
 	int ret;
 
 	ret = bt_audio_codec_cfg_get_val(&codec_cfg, BT_AUDIO_CODEC_CONFIG_LC3_FREQ, &data);
-	zassert_equal(ret, 0, "Unexpected return value %d", ret);
+	zassert_equal(ret, -ENODATA, "Unexpected return value %d", ret);
 
 	ret = bt_audio_codec_cfg_set_val(&codec_cfg, BT_AUDIO_CODEC_CONFIG_LC3_FREQ,
 					 &new_expected_data, sizeof(new_expected_data));
@@ -95,7 +95,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_unset_val)
 	zassert_true(ret >= 0, "Unexpected return value %d", ret);
 
 	ret = bt_audio_codec_cfg_get_val(&codec_cfg, BT_AUDIO_CODEC_CONFIG_LC3_FREQ, &data);
-	zassert_equal(ret, 0, "Unexpected return value %d", ret);
+	zassert_equal(ret, -ENODATA, "Unexpected return value %d", ret);
 }
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_freq_to_freq_hz)
@@ -925,7 +925,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_set_val_new)
 	int ret;
 
 	ret = bt_audio_codec_cap_get_val(&codec_cap, BT_AUDIO_CODEC_CONFIG_LC3_FREQ, &data);
-	zassert_equal(ret, 0, "Unexpected return value %d", ret);
+	zassert_equal(ret, -ENODATA, "Unexpected return value %d", ret);
 
 	ret = bt_audio_codec_cap_set_val(&codec_cap, BT_AUDIO_CODEC_CONFIG_LC3_FREQ,
 					 &new_expected_data, sizeof(new_expected_data));
@@ -955,7 +955,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_unset_val)
 	zassert_true(ret >= 0, "Unexpected return value %d", ret);
 
 	ret = bt_audio_codec_cap_get_val(&codec_cap, BT_AUDIO_CODEC_CONFIG_LC3_FREQ, &data);
-	zassert_equal(ret, 0, "Unexpected return value %d", ret);
+	zassert_equal(ret, -ENODATA, "Unexpected return value %d", ret);
 }
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_get_freq)


### PR DESCRIPTION
The get_val functions will now return -ENODATA in case that a value isn't found, instead of 0.
    
This makes them more similar to the meta_get_val functions.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/62292