### PR TITLE
drivers: sensor: adxl372: fix define comment

### DIFF
--- a/drivers/sensor/adxl372/adxl372.h
+++ b/drivers/sensor/adxl372/adxl372.h
@@ -373,6 +373,6 @@ int adxl372_trigger_set(const struct device *dev,
 			sensor_trigger_handler_t handler);
 
 int adxl372_init_interrupt(const struct device *dev);
-#endif /* CONFIG_ADT7420_TRIGGER */
+#endif /* CONFIG_ADXL372_TRIGGER */
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ADXL372_ADXL372_H_ */


### PR DESCRIPTION
Replace unrelated part name with the actual driver name in the adxl372.h header file.

Fixes: a3e7cea ("drivers: sensors: adxl372: Add driver for ADXL372 high-g accelerometer")