### PR TITLE
cmake run_native: Fix target dependency

### DIFF
--- a/cmake/emu/native.cmake
+++ b/cmake/emu/native.cmake
@@ -3,7 +3,9 @@
 add_custom_target(run_native
   COMMAND
   ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_EXE_NAME}
-  DEPENDS ${logical_target_for_zephyr_elf}
+  DEPENDS
+    ${logical_target_for_zephyr_elf}
+    $<$<TARGET_EXISTS:native_runner_executable>:native_runner_executable>
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   USES_TERMINAL
   )


### PR DESCRIPTION
The run_native (and therefore run) targets did not depend
on the proper thing for native_simulator based targets

Fix it.

Fixes #63433