### PR TITLE
doc: retained memory/retention: Add note on mutex configuration

### DIFF
--- a/doc/hardware/peripherals/retained_mem.rst
+++ b/doc/hardware/peripherals/retained_mem.rst
@@ -17,6 +17,20 @@ Related configuration options:
 
 * :kconfig:option:`CONFIG_RETAINED_MEM`
 * :kconfig:option:`CONFIG_RETAINED_MEM_INIT_PRIORITY`
+* :kconfig:option:`CONFIG_RETAINED_MEM_MUTEX_FORCE_DISABLE`
+
+Mutex protection
+****************
+
+Mutex protection of retained memory drivers is enabled by default when
+applications are compiled with multithreading support. This means that
+different threads can safely call the retained memory functions without
+clashing with other concurrent thread function usage, but means that retained
+memory functions cannot be used from ISRs. It is possible to disable mutex
+protection globally on all retained memory drivers by enabling
+:kconfig:option:`CONFIG_RETAINED_MEM_MUTEX_FORCE_DISABLE` - users are then
+responsible for ensuring that the function calls do not conflict with each
+other.
 
 API Reference
 *************

--- a/doc/services/retention/index.rst
+++ b/doc/services/retention/index.rst
@@ -121,6 +121,20 @@ When the write function is called, the magic header and checksum (if enabled)
 will be set on the area, and it will be marked as valid from that point
 onwards.
 
+Mutex protection
+****************
+
+Mutex protection of retention areas is enabled by default when applications are
+compiled with multithreading support. This means that different threads can
+safely call the retention functions without clashing with other concurrent
+thread function usage, but means that retention functions cannot be used from
+ISRs. It is possible to disable mutex protection globally on all retention
+areas by enabling :kconfig:option:`CONFIG_RETENTION_MUTEX_FORCE_DISABLE` -
+users are then responsible for ensuring that the function calls do not conflict
+with each other. Note that to use this, retention driver mutex support must
+also be disabled by enabling
+:kconfig:option:`CONFIG_RETAINED_MEM_MUTEX_FORCE_DISABLE`.
+
 .. _boot_mode_api:
 
 Boot mode


### PR DESCRIPTION
    Adds a note on how to configure and what to beware of when
    disabling mutex support in a multithreading application