### PR TITLE
drivers: sensor: adxl372: remove unused function

### DIFF
--- a/drivers/sensor/adxl372/adxl372.h
+++ b/drivers/sensor/adxl372/adxl372.h
@@ -365,9 +365,6 @@ int adxl372_i2c_init(const struct device *dev);
 int adxl372_get_status(const struct device *dev,
 		       uint8_t *status1, uint8_t *status2, uint16_t *fifo_entries);
 
-int adxl372_reg_write_mask(const struct device *dev,
-			   uint8_t reg_addr, uint32_t mask, uint8_t data);
-
 int adxl372_trigger_set(const struct device *dev,
 			const struct sensor_trigger *trig,
 			sensor_trigger_handler_t handler);


### PR DESCRIPTION
After the merge of 9dda350 the `adxl327_reg_write_mask` function is no longer used.