### PR TITLE
include: zephyr: drivers: modify SPI_CONFIG_DT to add CPOL, CPHA, HOLD_CS

### DIFF
--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -1091,8 +1091,6 @@ static struct dsa_api dsa_api_f = {
 #if defined(CONFIG_DSA_SPI)
 #define DSA_SPI_BUS_CONFIGURATION(n)					\
 	.spi = SPI_DT_SPEC_INST_GET(n,					\
-			COND_CODE_1(DT_INST_PROP(n, spi_cpol), (SPI_MODE_CPOL), ()) | \
-			COND_CODE_1(DT_INST_PROP(n, spi_cpha), (SPI_MODE_CPHA), ()) | \
 			SPI_WORD_SET(8),				\
 			0U)
 #else

--- a/drivers/led_strip/ws2812_spi.c
+++ b/drivers/led_strip/ws2812_spi.c
@@ -34,8 +34,6 @@ LOG_MODULE_REGISTER(ws2812_spi);
  *   isn't an EEPROM)
  */
 #define SPI_OPER(idx) (SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | \
-		  COND_CODE_1(DT_INST_PROP(idx, spi_cpol), (SPI_MODE_CPOL), (0)) | \
-		  COND_CODE_1(DT_INST_PROP(idx, spi_cpha), (SPI_MODE_CPHA), (0)) | \
 		  SPI_WORD_SET(SPI_FRAME_BITS))
 
 struct ws2812_spi_cfg {

--- a/dts/bindings/dsa/microchip_dsa.yaml
+++ b/dts/bindings/dsa/microchip_dsa.yaml
@@ -12,16 +12,6 @@ properties:
   dsa-slave-ports:
     type: int
     description: Number of slave ports on the switch
-  spi-cpha:
-    type: boolean
-    description: |
-       Set to indicate phase starts with asserted half-phase (CPHA=1).
-       For this driver using this property requires also using cpol.
-  spi-cpol:
-    type: boolean
-    description: |
-      Set to indicate clock leading edge is falling (CPOL=1).
-      For this driver using this property requires also using cpha.
   reset-gpios:
     type: phandle-array
     description: |

--- a/dts/bindings/led_strip/worldsemi,ws2812-spi.yaml
+++ b/dts/bindings/led_strip/worldsemi,ws2812-spi.yaml
@@ -24,14 +24,6 @@ include: [spi-device.yaml, ws2812.yaml]
 
 properties:
 
-  spi-cpol:
-    type: boolean
-    description: Set SPI clock polarity.
-
-  spi-cpha:
-    type: boolean
-    description: Set SPI clock phase.
-
   spi-one-frame:
     type: int
     required: true

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -40,3 +40,21 @@ properties:
     enum:
       - 0
       - 32768
+  spi-cpol:
+    type: boolean
+    description: |
+      SPI clock polarity which indicates the clock idle state.
+      If it is used, the clock idle state is logic high; otherwise, low.
+  spi-cpha:
+    type: boolean
+    description: |
+      SPI clock phase that indicates on which edge data is sampled.
+      If it is used, data is sampled on the second edge; otherwise, on the first edge.
+  spi-hold-cs:
+    type: boolean
+    description: |
+      In some cases, it is necessary for the master to manage SPI chip select
+      under software control, so that multiple spi transactions can be performed
+      without releasing it. A typical use case is variable length SPI packets
+      where the first spi transaction reads the length and the second spi transaction
+      reads length bytes.

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -332,7 +332,10 @@ struct spi_config {
 		.frequency = DT_PROP(node_id, spi_max_frequency),	\
 		.operation = (operation_) |				\
 			DT_PROP(node_id, duplex) |			\
-			DT_PROP(node_id, frame_format),			\
+			DT_PROP(node_id, frame_format) |			\
+			COND_CODE_1(DT_PROP(node_id, spi_cpol), SPI_MODE_CPOL, (0)) |	\
+			COND_CODE_1(DT_PROP(node_id, spi_cpha), SPI_MODE_CPHA, (0)) |	\
+			COND_CODE_1(DT_PROP(node_id, spi_hold_cs), SPI_HOLD_ON_CS, (0)),	\
 		.slave = DT_REG_ADDR(node_id),				\
 		.cs = SPI_CS_CONTROL_INIT(node_id, delay_),		\
 	}


### PR DESCRIPTION
Expose SPI device hardware characteristics: clock polarity, phase, and ability to control the chip select in application via DeviceTree files.
This allows users to define these SPI hardware characteristics in dts, overlay, etc. files without the need to modify the C code.