### PR TITLE
drivers: i2c: stm32: disable reload mode at the end of a transfer

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -103,6 +103,10 @@ static void stm32_i2c_master_mode_end(const struct device *dev)
 
 	stm32_i2c_disable_transfer_interrupts(dev);
 
+	if (LL_I2C_IsEnabledReloadMode(i2c)) {
+		LL_I2C_DisableReloadMode(i2c);
+	}
+
 #if defined(CONFIG_I2C_TARGET)
 	data->master_active = false;
 	if (!data->slave_attached) {


### PR DESCRIPTION
Fixes an issue that reload mode is not disabled in case of an error.

From this case the driver could not recover because in `msg_init()` no new transfer could be initialized.