### PR TITLE
bluetooth: tester: add support for variable static oob size

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_mesh.h
+++ b/tests/bluetooth/tester/src/btp/btp_mesh.h
@@ -30,15 +30,12 @@ struct btp_mesh_read_supported_commands_rp {
 
 #define BTP_MESH_CONFIG_PROVISIONING		0x02
 
-#if IS_ENABLED(CONFIG_BT_MESH_ECDH_P256_HMAC_SHA256_AES_CCM)
-#define BTP_MESH_PROV_AUTH_MAX_LEN   32
-#else
-#define BTP_MESH_PROV_AUTH_MAX_LEN   16
-#endif
+#define BTP_MESH_PROV_AUTH_MAX_LEN 32
 
 struct btp_mesh_config_provisioning_cmd {
 	uint8_t uuid[16];
 	uint8_t static_auth[BTP_MESH_PROV_AUTH_MAX_LEN];
+	uint8_t static_auth_size;
 	uint8_t out_size;
 	uint16_t out_actions;
 	uint8_t in_size;
@@ -48,6 +45,7 @@ struct btp_mesh_config_provisioning_cmd {
 struct btp_mesh_config_provisioning_cmd_v2 {
 	uint8_t uuid[16];
 	uint8_t static_auth[BTP_MESH_PROV_AUTH_MAX_LEN];
+	uint8_t static_auth_size;
 	uint8_t out_size;
 	uint16_t out_actions;
 	uint8_t in_size;


### PR DESCRIPTION
Adding variable static auth size support to be compatible both mesh 1.0.1 and mesh 1.1