### PR TITLE
bluetooth: mesh: fix static oob auth padding

### DIFF
--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -192,14 +192,16 @@ static void prov_start(const uint8_t *data)
 	}
 
 	if (atomic_test_bit(bt_mesh_prov_link.flags, OOB_STATIC_KEY)) {
+		/* Trim the Auth if it is longer than required length */
+		memcpy(bt_mesh_prov_link.auth, bt_mesh_prov->static_val,
+		       bt_mesh_prov->static_val_len > auth_size ? auth_size
+								: bt_mesh_prov->static_val_len);
 
-		uint8_t tail_size = bt_mesh_prov->static_val_len < auth_size
-					    ? auth_size - bt_mesh_prov->static_val_len
-					    : 0;
-
-		memcpy(bt_mesh_prov_link.auth + tail_size, bt_mesh_prov->static_val,
-		       tail_size ? bt_mesh_prov->static_val_len : auth_size);
-		memset(bt_mesh_prov_link.auth, 0, tail_size);
+		/* Padd with zeros if the Auth is shorter the required length*/
+		if (bt_mesh_prov->static_val_len < auth_size) {
+			memset(bt_mesh_prov_link.auth + bt_mesh_prov->static_val_len, 0,
+			       auth_size - bt_mesh_prov->static_val_len);
+		}
 	}
 }
 

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -751,17 +751,20 @@ int bt_mesh_auth_method_set_output(bt_mesh_output_action_t action, uint8_t size)
 
 int bt_mesh_auth_method_set_static(const uint8_t *static_val, uint8_t size)
 {
-	uint8_t tail_size = size < PROV_AUTH_MAX_LEN ? PROV_AUTH_MAX_LEN - size : 0;
-
 	if (!size || !static_val) {
 		return -EINVAL;
 	}
 
 	prov_set_method(AUTH_METHOD_STATIC, 0, 0);
 
-	memcpy(bt_mesh_prov_link.auth + tail_size, static_val,
-	       tail_size ? size : PROV_AUTH_MAX_LEN);
-	memset(bt_mesh_prov_link.auth, 0, tail_size);
+	/* Trim the Auth if it is longer than required length */
+	memcpy(bt_mesh_prov_link.auth, static_val,
+	       size > PROV_AUTH_MAX_LEN ? PROV_AUTH_MAX_LEN : size);
+
+	/* Padd with zeros if the Auth is shorter the required length*/
+	if (size < PROV_AUTH_MAX_LEN) {
+		memset(bt_mesh_prov_link.auth + size, 0, PROV_AUTH_MAX_LEN - size);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
The remaining bit should be zero if auth is shorter than PROV_AUTH_MAX_LEN and it should be trimmed by removing octets with indexes higher than PROV_AUTH_MAX_LEN.