### PR TITLE
west: runners: nrf: Document why the network core is recovered first

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -227,6 +227,11 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
         else:
             self.logger.info('Recovering and erasing all flash memory.')
 
+        # The network core needs to be recovered first due to the fact that
+        # recovering it erases the flash of *both* cores. Since a recover
+        # operation unlocks the core and then flashes a small image that keeps
+        # the debug access port open, recovering the network core last would
+        # result in that small image being deleted from the app core.
         if self.family == 'NRF53_FAMILY':
             self.exec_op('recover', core='NRFDL_DEVICE_CORE_NETWORK')
 


### PR DESCRIPTION
The network core needs to be recovered first due to the fact that recovering it erases both the network and application cores' flash memory. This means that the little flash image that is programmed during the recover operation would be lost for the app core if we inverted the order.