### PR TITLE
boards: arm: nrf9161dk_nrf9161: Add ext flash support for 0.7.0 version

### DIFF
--- a/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_0_7_0.overlay
+++ b/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_0_7_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf9161dk_nrf9161_common_0_7_0.dtsi"

--- a/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_common_0_7_0.dtsi
+++ b/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_common_0_7_0.dtsi
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi3 {
+	gd25lb256: gd25lb256e3ir@1 {
+		compatible = "jedec,spi-nor";
+		status = "okay";
+		reg = <1>;
+		spi-max-frequency = <60000000>;
+		jedec-id = [c8 67 19];
+		sfdp-bfp = [
+			e5 20 ea ff  ff ff ff 0f  44 eb 08 6b  00 3b 00 bb
+			fe ff ff ff  ff ff 00 ff  ff ff 44 eb  0c 20 0f 52
+			10 d8 00 ff  d5 31 b1 fe  82 e4 14 4c  ec 60 06 33
+			7a 75 7a 75  04 bd d5 5c  29 06 74 00  08 50 00 01
+		];
+		size = <268435456>;
+		has-dpd;
+		t-enter-dpd = <3000>;
+		t-exit-dpd = <30000>;
+	};
+};
+
+/ {
+	aliases {
+		spi-flash0 = &gd25lb256;
+	};
+};

--- a/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_ns_0_7_0.overlay
+++ b/boards/arm/nrf9161dk_nrf9161/nrf9161dk_nrf9161_ns_0_7_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf9161dk_nrf9161_common_0_7_0.dtsi"

--- a/boards/arm/nrf9161dk_nrf9161/revision.cmake
+++ b/boards/arm/nrf9161dk_nrf9161/revision.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+board_check_revision(
+  FORMAT MAJOR.MINOR.PATCH
+  DEFAULT_REVISION 0.9.0
+  VALID_REVISIONS 0.7.0 0.9.0
+)


### PR DESCRIPTION
Add support for external flash on the 0.7.0 DK version.