### PR TITLE
lib: libc: armstdc: add missing retarget of fputc to _stdout_hook

### DIFF
--- a/lib/libc/armstdc/src/libc-hooks.c
+++ b/lib/libc/armstdc/src/libc-hooks.c
@@ -25,3 +25,8 @@ volatile int *__aeabi_errno_addr(void)
 {
 	return &_current->errno_var;
 }
+
+int fputc(int c, FILE *f)
+{
+	return (_stdout_hook)(c);
+}


### PR DESCRIPTION
Fixes #62677 where printf defaults to using armclang's semihosting backed implementation of printf.