### PR TITLE
Bluetooth: Controller: Remove unused terminate_ack

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -291,8 +291,6 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	/* Setup the PRT reload */
 	ull_cp_prt_reload_set(conn, conn_interval_us);
 
-	conn->central.terminate_ack = 0U;
-
 	conn->llcp_terminate.reason_final = 0U;
 	/* NOTE: use allocated link for generating dedicated
 	 * terminate ind rx node

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1044,12 +1044,6 @@ void ull_conn_done(struct node_rx_event_done *done)
 				lll->latency_event = lll->latency;
 			}
 #endif /* CONFIG_BT_PERIPHERAL */
-
-#if defined(CONFIG_BT_CENTRAL)
-		} else if (reason_final) {
-			conn->central.terminate_ack = 1;
-#endif /* CONFIG_BT_CENTRAL */
-
 		}
 
 		/* Reset connection failed to establish countdown */

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -202,7 +202,6 @@ struct ll_conn {
 #if defined(CONFIG_BT_CTLR_CONN_META)
 			uint8_t  is_must_expire:1;
 #endif /* CONFIG_BT_CTLR_CONN_META */
-			uint8_t terminate_ack:1;
 		} central;
 #endif /* CONFIG_BT_CENTRAL */
 	};


### PR DESCRIPTION
Remove the terminate_ack from struct ll_conn since it is not used anywhere, and results in dead code.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/58971