### PR TITLE
kernel: Re-order _static_thread_data initializer to match type

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -707,8 +707,8 @@ struct _static_thread_data {
 	.init_p3 = (void *)p3,                                   \
 	.init_prio = (prio),                                     \
 	.init_options = (options),                               \
-	.init_delay = SYS_TIMEOUT_MS(delay),			 \
 	.init_name = STRINGIFY(tname),                           \
+	.init_delay = SYS_TIMEOUT_MS(delay),			 \
 	}
 
 /*


### PR DESCRIPTION
C++ compilers complain if the order of designated initializers doesn't match the order of the members in the type. Re-order the initializers for the _static_thread_data struct to match the new order of the type.

Closes: #63453