### PR TITLE
usbc: improve stack response time

### DIFF
--- a/include/zephyr/usb_c/usbc.h
+++ b/include/zephyr/usb_c/usbc.h
@@ -351,6 +351,15 @@ int usbc_suspend(const struct device *dev);
 int usbc_request(const struct device *dev, const enum usbc_policy_request_t req);
 
 /**
+ * @internal
+ * @brief Bypass the next USB-C stack sleep and execute one more iteration of the state machines.
+ * Used internally to decrease the response time.
+ *
+ * @param dev Runtime device structure
+ */
+void usbc_bypass_next_sleep(const struct device *dev);
+
+/**
  * @brief Set pointer to Device Policy Manager (DPM) data
  *
  * @param dev Runtime device structure

--- a/subsys/usb/usb_c/usbc_pe_common.c
+++ b/subsys/usb/usb_c/usbc_pe_common.c
@@ -345,6 +345,9 @@ void pe_message_received(const struct device *dev)
 	struct policy_engine *pe = data->pe;
 
 	atomic_set_bit(pe->flags, PE_FLAGS_MSG_RECEIVED);
+
+	/* Allow the PE to be executed once more and respond faster for the received message */
+	usbc_bypass_next_sleep(dev);
 }
 
 /**
@@ -422,6 +425,9 @@ void pe_set_state(const struct device *dev, const enum usbc_pe_state state)
 
 	__ASSERT(state < ARRAY_SIZE(pe_states), "invalid pe_state %d", state);
 	smf_set_state(SMF_CTX(data->pe), &pe_states[state]);
+
+	/* Allow the PE to execute logic from the new state without additional delay */
+	usbc_bypass_next_sleep(dev);
 }
 
 /**

--- a/subsys/usb/usb_c/usbc_stack.c
+++ b/subsys/usb/usb_c/usbc_stack.c
@@ -37,7 +37,12 @@ static ALWAYS_INLINE void usbc_handler(void *port_dev)
 		k_thread_suspend(port->port_thread);
 	}
 
-	k_msleep(CONFIG_USBC_STATE_MACHINE_CYCLE_TIME);
+	/* Check if there wasn't any request to do a one more iteration of USB-C state machines */
+	if (!port->bypass_next_sleep) {
+		k_msleep(CONFIG_USBC_STATE_MACHINE_CYCLE_TIME);
+	} else {
+		port->bypass_next_sleep = false;
+	}
 }
 
 #define USBC_SUBSYS_INIT(inst)                                                                     \
@@ -131,6 +136,13 @@ int usbc_request(const struct device *dev, const enum usbc_policy_request_t req)
 	k_fifo_put(&data->request_fifo, &data->request);
 
 	return 0;
+}
+
+void usbc_bypass_next_sleep(const struct device *dev)
+{
+	struct usbc_port_data *data = dev->data;
+
+	data->bypass_next_sleep = true;
 }
 
 /**

--- a/subsys/usb/usb_c/usbc_stack.h
+++ b/subsys/usb/usb_c/usbc_stack.h
@@ -107,6 +107,9 @@ struct usbc_port_data {
 	/** Device Policy manager Request */
 	struct request_value request;
 
+	/** Bypass next sleep and request one more iteration of the USB-C state machines */
+	bool bypass_next_sleep;
+
 	/* USB-C Callbacks */
 
 	/**

--- a/subsys/usb/usb_c/usbc_tc_snk_states.c
+++ b/subsys/usb/usb_c/usbc_tc_snk_states.c
@@ -79,7 +79,15 @@ static void sink_power_sub_states(const struct device *dev)
  */
 void tc_unattached_snk_entry(void *obj)
 {
+	struct tc_sm_t *tc = (struct tc_sm_t *)obj;
+
 	LOG_INF("Unattached.SNK");
+
+	/*
+	 * Allow the state machine to immediately check the state of CC lines and go into
+	 * Attach.Wait state in case the Rp value is detected on the CC lines
+	 */
+	usbc_bypass_next_sleep(tc->dev);
 }
 
 /**
@@ -109,6 +117,12 @@ void tc_attach_wait_snk_entry(void *obj)
 	LOG_INF("AttachWait.SNK");
 
 	tc->cc_state = TC_CC_NONE;
+
+	/*
+	 * Allow the debounce timers to start immediately without additional delay added
+	 * by going into sleep
+	 */
+	usbc_bypass_next_sleep(tc->dev);
 }
 
 /**
@@ -138,6 +152,11 @@ void tc_attach_wait_snk_run(void *obj)
 	/* Wait for CC debounce */
 	if (usbc_timer_running(&tc->tc_t_cc_debounce) &&
 	    usbc_timer_expired(&tc->tc_t_cc_debounce) == false) {
+		if (CONFIG_USBC_STATE_MACHINE_CYCLE_TIME >= TC_T_CC_DEBOUNCE_MIN_MS) {
+			/* Make sure the debounce time won't be longer than specified */
+			usbc_bypass_next_sleep(tc->dev);
+		}
+
 		return;
 	}
 
@@ -156,6 +175,13 @@ void tc_attach_wait_snk_run(void *obj)
 	if (vbus_present) {
 		tc_set_state(dev, TC_ATTACHED_SNK_STATE);
 	}
+
+	/*
+	 * In case of no VBUS present, this call prevents going into the sleep and allows for
+	 * faster VBUS detection. In case of VBUS present, allows for immediate execution of logic
+	 * from new state.
+	 */
+	usbc_bypass_next_sleep(tc->dev);
 }
 
 void tc_attach_wait_snk_exit(void *obj)


### PR DESCRIPTION
Add internal function that can be used to prevent USB-C thread sleep and makes another one iteration of subsystem machine states. It's used to improve the response time by allowing immediate action in new machine state instead of sleeping and waiting for it.
This allows to have a long USB-C machine state delay set in Kconfig, to preserve power, while maintaining that the contracts can be handled properly.