### PR TITLE
usbc: add support for controlling VBUS by TCPC

### DIFF
--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -154,7 +154,9 @@ __subsystem struct tcpc_driver_api {
 	int (*set_debug_detach)(const struct device *dev);
 	int (*set_drp_toggle)(const struct device *dev, bool enable);
 	int (*get_snk_ctrl)(const struct device *dev);
+	int (*set_snk_ctrl)(const struct device *dev, bool enable);
 	int (*get_src_ctrl)(const struct device *dev);
+	int (*set_src_ctrl)(const struct device *dev, bool enable);
 	int (*get_chip_info)(const struct device *dev, struct tcpc_chip_info *chip_info);
 	int (*set_low_power_mode)(const struct device *dev, bool enable);
 	int (*sop_prime_enable)(const struct device *dev, bool enable);
@@ -757,6 +759,25 @@ static inline int tcpc_get_snk_ctrl(const struct device *dev)
 }
 
 /**
+ * @brief Set the VBUS sinking state of the TCPC
+ *
+ * @param dev Runtime device structure
+ * @param enable True if sinking should be enabled, false if disabled
+ * @retval 0 on success
+ * @retval -ENOSYS if not implemented
+ */
+static inline int tcpc_set_snk_ctrl(const struct device *dev, bool enable)
+{
+	const struct tcpc_driver_api *api = (const struct tcpc_driver_api *)dev->api;
+
+	if (api->set_snk_ctrl == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->set_snk_ctrl(dev, enable);
+}
+
+/**
  * @brief Queries the current sourcing state of the TCPC
  *
  * @param dev Runtime device structure
@@ -775,6 +796,25 @@ static inline int tcpc_get_src_ctrl(const struct device *dev)
 	}
 
 	return api->get_src_ctrl(dev);
+}
+
+/**
+ * @brief Set the VBUS sourcing state of the TCPC
+ *
+ * @param dev Runtime device structure
+ * @param enable True if sourcing should be enabled, false if disabled
+ * @retval 0 on success
+ * @retval -ENOSYS if not implemented
+ */
+static inline int tcpc_set_src_ctrl(const struct device *dev, bool enable)
+{
+	const struct tcpc_driver_api *api = (const struct tcpc_driver_api *)dev->api;
+
+	if (api->set_src_ctrl == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->set_src_ctrl(dev, enable);
 }
 
 /**

--- a/subsys/usb/usb_c/usbc_stack.h
+++ b/subsys/usb/usb_c/usbc_stack.h
@@ -216,4 +216,37 @@ struct usbc_port_data {
 	void *dpm_data;
 };
 
+#ifdef CONFIG_USBC_CSM_SOURCE_ONLY
+/**
+ * @brief Function that enables the source path either using callback or by the TCPC.
+ * If source and sink paths are controlled by the TCPC, this callback doesn't have to be set.
+ *
+ * @param dev USB-C connector device
+ * @param tcpc Type-C Port Controller device
+ * @param en True to enable the sourcing, false to disable
+ * @return int 0 if success, -ENOSYS if both callback and TCPC function are not implemented.
+ *             In case of error, value from any of the functions is returned
+ */
+static inline int usbc_policy_src_en(const struct device *dev, const struct device *tcpc, bool en)
+{
+	struct usbc_port_data *data = dev->data;
+	int ret_cb = -ENOSYS;
+	int ret_tcpc;
+
+	if (data->policy_cb_src_en != NULL) {
+		ret_cb = data->policy_cb_src_en(dev, en);
+		if (ret_cb != 0 && ret_cb != -ENOSYS) {
+			return ret_cb;
+		}
+	}
+
+	ret_tcpc = tcpc_set_src_ctrl(tcpc, en);
+	if (ret_tcpc == -ENOSYS) {
+		return ret_cb;
+	}
+
+	return ret_tcpc;
+}
+#endif
+
 #endif /* ZEPHYR_SUBSYS_USBC_STACK_PRIV_H_ */

--- a/subsys/usb/usb_c/usbc_tc_common.c
+++ b/subsys/usb/usb_c/usbc_tc_common.c
@@ -147,7 +147,7 @@ static int tc_init(const struct device *dev)
 
 #ifdef CONFIG_USBC_CSM_SOURCE_ONLY
 	/* Stop sourcing VBUS by policy callback and/or TCPC */
-	ret = data->policy_cb_src_en(dev, false);
+	ret = usbc_policy_src_en(dev, tcpc, false);
 	if (ret != 0) {
 		LOG_ERR("Couldn't disable vbus sourcing: %d", ret);
 		return ret;

--- a/subsys/usb/usb_c/usbc_tc_src_states.c
+++ b/subsys/usb/usb_c/usbc_tc_src_states.c
@@ -239,7 +239,7 @@ void tc_attached_src_entry(void *obj)
 	}
 
 	/* Start sourcing VBUS */
-	if (data->policy_cb_src_en(dev, true) == 0) {
+	if (usbc_policy_src_en(dev, tcpc, true) == 0) {
 		/* Start sourcing VCONN */
 		if (policy_check(dev, CHECK_VCONN_CONTROL)) {
 			if (tcpc_set_vconn(tcpc, true) == 0) {
@@ -304,14 +304,13 @@ void tc_attached_src_exit(void *obj)
 	const struct device *tcpc = data->tcpc;
 	int ret;
 
-	__ASSERT(data->policy_cb_src_en != NULL,
-			"policy_cb_src_en must not be NULL");
-
 	/* Disable PD */
 	tc_pd_enable(dev, false);
 
 	/* Stop sourcing VBUS */
-	data->policy_cb_src_en(dev, false);
+	if (usbc_policy_src_en(dev, tcpc, false) != 0) {
+		LOG_ERR("Couldn't disable VBUS source");
+	}
 
 	/* Disable the VBUS sourcing by the PPC */
 	if (data->ppc != NULL) {


### PR DESCRIPTION
This PR adds support for enabling the sinking and sourcing by TCPC functions. The example code uses the callback that must be provided by user application to enable the sourcing of VBUS, where if the project uses the TCPC, the VBUS should be controlled by it without requirement for user to provide callback where the TCPC driver is responsible for enabling the paths.