### PR TITLE
sensors: Fix alignment issues

### DIFF
--- a/drivers/sensor/icm42688/icm42688.c
+++ b/drivers/sensor/icm42688/icm42688.c
@@ -251,12 +251,11 @@ int icm42688_init(const struct device *dev)
 	}
 #endif
 
-	memset(&data->cfg, 0, sizeof(struct icm42688_cfg));
 	data->cfg.accel_mode = ICM42688_ACCEL_LN;
-	data->cfg.gyro_mode = ICM42688_GYRO_LN;
 	data->cfg.accel_fs = ICM42688_ACCEL_FS_2G;
-	data->cfg.gyro_fs = ICM42688_GYRO_FS_125;
 	data->cfg.accel_odr = ICM42688_ACCEL_ODR_1000;
+	data->cfg.gyro_mode = ICM42688_GYRO_LN;
+	data->cfg.gyro_fs = ICM42688_GYRO_FS_125;
 	data->cfg.gyro_odr = ICM42688_GYRO_ODR_1000;
 	data->cfg.fifo_en = false;
 

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -801,10 +801,13 @@ struct __attribute__((__packed__)) sensor_data_generic_header {
 	 * The number of channels present in the frame. This will be the true number of elements in
 	 * channel_info and in the q31 values that follow the header.
 	 */
-	size_t num_channels;
+	uint32_t num_channels;
 
 	/* Shift value for all samples in the frame */
 	int8_t shift;
+
+	/* This padding is needed to make sure that the 'channels' field is aligned */
+	int8_t _padding[sizeof(enum sensor_channel) - 1];
 
 	/* Channels present in the frame */
 	enum sensor_channel channels[0];


### PR DESCRIPTION
Add padding to the header and remove unnecessary memset in order to fix alignment faults in cores such as M0 or ones that support CONFIG_TRAP_UNALIGNED_ACCESS

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/62845