### PR TITLE
board: m5stack_core2: Add SD-Card support

### DIFF
--- a/boards/xtensa/m5stack_core2/doc/index.rst
+++ b/boards/xtensa/m5stack_core2/doc/index.rst
@@ -50,37 +50,39 @@ of the M5Stack Core2 board.
 .. _PMU-AXP192: https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/core/AXP192_datasheet_en.pdf
 .. _VIB-1072_RFN01: https://m5stack.oss-cn-shenzhen.aliyuncs.com/resource/docs/datasheet/core/1027RFN01-33d.pdf
 
-+------------------+--------------------------------------------------------------------------+
-| Key Component    | Description                                                              |
-+==================+==========================================================================+
-|| ESP32-D0WDQ6-V2 || This `MPU-ESP32`_ module provides complete Wi-Fi and Bluetooth          |
-|| module          || functionalities and integrates a 16-MB SPI flash.                       |
-+------------------+--------------------------------------------------------------------------+
-|| 32.768 kHz RTC  || External precision 32.768 kHz crystal oscillator serves as a clock with |
-||                 || low-power consumption while the chip is in Deep-sleep mode.             |
-+------------------+--------------------------------------------------------------------------+
-| Status LED       | One user LED connected to the GPIO pin.                                  |
-+------------------+--------------------------------------------------------------------------+
-|| USB Port        || USB interface. Power supply for the board as well as the                |
-||                 || communication interface between a computer and the board.               |
-||                 || Contains: TypeC x 1, GROVE(I2C+I/O+UART) x 1                            |
-+------------------+--------------------------------------------------------------------------+
-| Reset button     | Reset button                                                             |
-+------------------+--------------------------------------------------------------------------+
-| Power Switch     | Power on/off button.                                                     |
-+------------------+--------------------------------------------------------------------------+
-|| LCD screen      || Built-in LCD TFT display \(`LCD-ILI9342C`_, 2", 320x240 px\)            |
-||                 || controlled via SPI interface                                            |
-+------------------+--------------------------------------------------------------------------+
-|| 6-axis IMU      || The `MPU-6886`_ is a 6-axis motion tracker (6DOF IMU) device that       |
-|| MPU6886         || combines a 3-axis gyroscope and a 3-axis accelerometer.                 |
-||                 || For details please refer to :ref:`m5stack_core2_ext`                    |
-+------------------+--------------------------------------------------------------------------+
-|| Built-in        || The `SPM-1423`_ I2S driven microphone.                                  |
-|| microphone      ||                                                                         |
-+------------------+--------------------------------------------------------------------------+
-| Built-in speaker | 1W speaker for audio output via I2S interface.                           |
-+------------------+--------------------------------------------------------------------------+
++------------------+--------------------------------------------------------------------------+------------+
+| Key Component    | Description                                                              | Status     |
++==================+==========================================================================+============+
+|| ESP32-D0WDQ6-V2 || This `MPU-ESP32`_ module provides complete Wi-Fi and Bluetooth          || supported |
+|| module          || functionalities and integrates a 16-MB SPI flash.                       ||           |
++------------------+--------------------------------------------------------------------------+------------+
+|| 32.768 kHz RTC  || External precision 32.768 kHz crystal oscillator serves as a clock with || supported |
+||                 || low-power consumption while the chip is in Deep-sleep mode.             ||           |
++------------------+--------------------------------------------------------------------------+------------+
+| Status LED       | One user LED connected to the GPIO pin.                                  | supported  |
++------------------+--------------------------------------------------------------------------+------------+
+|| USB Port        || USB interface. Power supply for the board as well as the                || supported |
+||                 || communication interface between a computer and the board.               ||           |
+||                 || Contains: TypeC x 1, GROVE(I2C+I/O+UART) x 1                            ||           |
++------------------+--------------------------------------------------------------------------+------------+
+| Reset button     | Reset button                                                             | supported  |
++------------------+--------------------------------------------------------------------------+------------+
+| Power Switch     | Power on/off button.                                                     | supported  |
++------------------+--------------------------------------------------------------------------+------------+
+|| LCD screen      || Built-in LCD TFT display \(`LCD-ILI9342C`_, 2", 320x240 px\)            || supported |
+||                 || controlled via SPI interface                                            ||           |
++------------------+--------------------------------------------------------------------------+------------+
+| SD-Card slot     | SD-Card connection via SPI-mode.                                         | supported  |
++------------------+--------------------------------------------------------------------------+------------+
+|| 6-axis IMU      || The `MPU-6886`_ is a 6-axis motion tracker (6DOF IMU) device that       || todo      |
+|| MPU6886         || combines a 3-axis gyroscope and a 3-axis accelerometer.                 ||           |
+||                 || For details please refer to :ref:`m5stack_core2_ext`                    ||           |
++------------------+--------------------------------------------------------------------------+------------+
+|| Built-in        || The `SPM-1423`_ I2S driven microphone.                                  || todo      |
+|| microphone      ||                                                                         ||           |
++------------------+--------------------------------------------------------------------------+------------+
+| Built-in speaker | 1W speaker for audio output via I2S interface.                           | todo       |
++------------------+--------------------------------------------------------------------------+------------+
 
 Supported Features
 ==================

--- a/boards/xtensa/m5stack_core2/m5stack_core2-pinctrl.dtsi
+++ b/boards/xtensa/m5stack_core2/m5stack_core2-pinctrl.dtsi
@@ -39,23 +39,10 @@
 	spim3_default: spim3_default {
 		group1 {
 			pinmux = <SPIM3_MISO_GPIO38>,
-				 <SPIM3_SCLK_GPIO18>,
-				 <SPIM3_CSEL_GPIO5>;
+				 <SPIM3_SCLK_GPIO18>;
 		};
 		group2 {
 			pinmux = <SPIM3_MOSI_GPIO23>;
-			output-low;
-		};
-	};
-
-	spim2_default: spim2_default {
-		group1 {
-			pinmux = <SPIM2_SCLK_GPIO6>,
-				 <SPIM2_MISO_GPIO7>,
-				 <SPIM2_CSEL_GPIO11>;
-		};
-		group2 {
-			pinmux = <SPIM2_MOSI_GPIO8>;
 			output-low;
 		};
 	};

--- a/boards/xtensa/m5stack_core2/m5stack_core2.dts
+++ b/boards/xtensa/m5stack_core2/m5stack_core2.dts
@@ -182,10 +182,12 @@
 	pinctrl-names = "default";
 	dma-enabled;
 	clock-frequency = <20000000>;
-	cs-gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio0 5 GPIO_ACTIVE_LOW>,
+			   <&gpio0 4 GPIO_ACTIVE_LOW>;
 
 	ili9342c: ili9342c@0 {
 		compatible = "ilitek,ili9342c";
+		status = "okay";
 		spi-max-frequency = <30000000>;
 		reg = <0>;
 		cmd-data-gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
@@ -196,6 +198,18 @@
 		width = <320>;
 		height = <240>;
 		rotation = <0>;
+	};
+
+	sdhc0: sdhc@1 {
+		compatible = "zephyr,sdhc-spi-slot";
+		reg = <1>;
+		status = "okay";
+		spi-max-frequency = <20000000>;
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			status = "okay";
+		};
+
 	};
 };
 


### PR DESCRIPTION
Added support for SD-Card slot of M5Stack-Core2 module.
SPI-mode is beeing used and by default SPI speed is running at 20MHz
to support low-speed cards and for stability reasons.

Signed-off-by: Martin Kiepfer <mrmarteng@teleschirm.org>