### PR TITLE
kernel: mem_manage: un-expose an internal variable and some doxygen fixes

### DIFF
--- a/include/zephyr/kernel/internal/mm.h
+++ b/include/zephyr/kernel/internal/mm.h
@@ -168,10 +168,10 @@ extern "C" {
  * This API is part of infrastructure still under development and may
  * change.
  *
- * @param virt [out] Output virtual address storage location
- * @param phys Physical address base of the memory region
- * @param size Size of the memory region
- * @param flags Caching mode and access flags, see K_MAP_* macros
+ * @param[out] virt Output virtual address storage location
+ * @param[in]  phys Physical address base of the memory region
+ * @param[in]  size Size of the memory region
+ * @param[in]  flags Caching mode and access flags, see K_MAP_* macros
  */
 void z_phys_map(uint8_t **virt_ptr, uintptr_t phys, size_t size,
 		uint32_t flags);

--- a/include/zephyr/kernel/mm.h
+++ b/include/zephyr/kernel/mm.h
@@ -191,11 +191,11 @@ void k_mem_unmap(void *addr, size_t size);
  * The returned region will have both its base address and size aligned
  * to the provided alignment value.
  *
- * @param aligned_addr [out] Aligned address
- * @param aligned_size [out] Aligned region size
- * @param addr Region base address
- * @param size Region size
- * @param align What to align the address and size to
+ * @param[out] aligned_addr Aligned address
+ * @param[out] aligned_size Aligned region size
+ * @param[in]  addr Region base address
+ * @param[in]  size Region size
+ * @param[in]  align What to align the address and size to
  * @retval offset between aligned_addr and addr
  */
 size_t k_mem_region_align(uintptr_t *aligned_addr, size_t *aligned_size,

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -215,9 +215,6 @@ static inline void z_mem_assert_virtual_region(uint8_t *addr, size_t size)
  */
 void z_page_frames_dump(void);
 
-/* Number of free page frames. This information may go stale immediately */
-extern size_t z_free_page_count;
-
 /* Convenience macro for iterating over all page frames */
 #define Z_PAGE_FRAME_FOREACH(_phys, _pageframe) \
 	for (_phys = Z_PHYS_RAM_START, _pageframe = z_page_frames; \

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -381,8 +381,10 @@ static void *virt_region_alloc(size_t size, size_t align)
  */
 static sys_slist_t free_page_frame_list;
 
-/* Number of unused and available free page frames */
-size_t z_free_page_count;
+/* Number of unused and available free page frames.
+ * This information may go stale immediately.
+ */
+static size_t z_free_page_count;
 
 #define PF_ASSERT(pf, expr, fmt, ...) \
 	__ASSERT(expr, "page frame 0x%lx: " fmt, z_page_frame_to_phys(pf), \


### PR DESCRIPTION
* Un-expose an internal variable that is only being used in one file.
* Fixes doxygen stuff in `sys/mem_manage.h` so the API doc is more usable.