### PR TITLE
Bluetooth: Controll: Fix dead code in ll_setup_iso_path

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -491,11 +491,11 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 					  pdu_release, &source_handle);
 
 		if (!err) {
-			if (cis) {
+			if (IS_ENABLED(CONFIG_BT_CTLR_CONN_ISO) && cis != NULL) {
 				cis->hdr.datapath_in = dp;
 			}
 
-			if (adv_stream) {
+			if (IS_ENABLED(CONFIG_BT_CTLR_ADV_ISO) && adv_stream != NULL) {
 				adv_stream->dp = dp;
 			}
 


### PR DESCRIPTION
In ll_setup_iso_path cis is only ever set if CONFIG_BT_CTLR_CONN_ISO is enabled, and similarly adv_stream is only ever set if CONFIG_BT_CTLR_ADV_ISO is enabled.

The two assignments were reported as dead code by Coverity due to this, which has been fixed by guarding the code with the respective Kconfigs.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/58982