### PR TITLE
soc: arm: nxp_lpc: Only clock core from PLL1 when CONFIG_FLASH=n

### DIFF
--- a/boards/arm/lpcxpresso55s16/doc/index.rst
+++ b/boards/arm/lpcxpresso55s16/doc/index.rst
@@ -138,9 +138,11 @@ the functionality of a pin.
 System Clock
 ============
 
-The LPC55S16 SoC is configured to use the internal FRO at 96MHz as a
-source for the system clock. Other sources for the system clock are
-provided in the SOC, depending on your system requirements.
+The LPC55S16 SoC is configured to use PLL1 clocked from the external 24MHz
+crystal, running at 150MHz as a source for the system clock. When the flash
+controller is enabled, the core clock will be reduced to 96MHz. The application
+may reconfigure clocks after initialization, provided that the core clock is
+always set to 96MHz when flash programming operations are performed.
 
 Serial Port
 ===========

--- a/boards/arm/lpcxpresso55s28/doc/index.rst
+++ b/boards/arm/lpcxpresso55s28/doc/index.rst
@@ -125,9 +125,11 @@ the functionality of a pin.
 System Clock
 ============
 
-The LPC55S28 SoC is configured to use the internal FRO at 96MHz as a
-source for the system clock. Other sources for the system clock are
-provided in the SOC, depending on your system requirements.
+The LPC55S28 SoC is configured to use PLL1 clocked from the external 24MHz
+crystal, running at 150MHz as a source for the system clock. When the flash
+controller is enabled, the core clock will be reduced to 96MHz. The application
+may reconfigure clocks after initialization, provided that the core clock is
+always set to 96MHz when flash programming operations are performed.
 
 Serial Port
 ===========

--- a/boards/arm/lpcxpresso55s69/doc/index.rst
+++ b/boards/arm/lpcxpresso55s69/doc/index.rst
@@ -256,9 +256,11 @@ Dual Core samples
 System Clock
 ============
 
-The LPC55S69 SoC is configured to use the internal FRO at 96MHz as a source for
-the system clock. Other sources for the system clock are provided in the SOC,
-depending on your system requirements.
+The LPC55S69 SoC is configured to use PLL1 clocked from the external 24MHz
+crystal, running at 150MHz as a source for the system clock. When the flash
+controller is enabled, the core clock will be reduced to 96MHz. The application
+may reconfigure clocks after initialization, provided that the core clock is
+always set to 96MHz when flash programming operations are performed.
 
 Serial Port
 ===========

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.soc
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.soc
@@ -123,10 +123,12 @@ config INIT_PLL0
 config INIT_PLL1
 	bool "Initialize PLL1"
 	default "y"
-	depends on !SOC_LPC55S06
+	depends on !(SOC_LPC55S06 || FLASH)
 	help
 	  In the LPC55XXX Family, this is currently being used to set the
 	  core clock value at it's highest frequency which clocks at 150MHz.
+	  Note that flash programming operations are limited to 100MHz, and
+	  this PLL should not be used as the core clock in those cases.
 
 config SECOND_CORE_MCUX
 	bool "LPC55xxx's second core"


### PR DESCRIPTION
Do not clock the LPC55xxx cores from PLL1 when CONFIG_FLASH is set. This is required due to the following limitation of the flash controller (documented in the reference manual):

Flash operations (erase, blank check, program) and reading a single word can only be performed for CPU frequencies of up to 100 MHz. These operations cannot be performed for frequencies above 100 MHz.

The PLL1 clock source will result in a core clock of 150MHz, which violates this requirement.

Fixes #62963