### PR TITLE
tests: drivers: flash: remove platform_allow filter

### DIFF
--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -35,15 +35,6 @@ tests:
     integration_platforms:
       - qemu_x86
       - mimxrt1060_evk
-    platform_allow:
-      - qemu_x86
-      - mimxrt1060_evk
-      - it8xxx2_evb
-      - mimxrt685_evk_cm33
-      - mimxrt595_evk_cm33
-      - nrf52_bsim
-      - nrf5340bsim_nrf5340_cpunet
-      - nrf5340bsim_nrf5340_cpuapp
   drivers.flash.common.tfm_ns:
     build_only: true
     filter: (CONFIG_FLASH_HAS_DRIVER_ENABLED and CONFIG_TRUSTED_EXECUTION_NONSECURE


### PR DESCRIPTION
Prior to commit 903a79431, drivers.flash.common.default would have executed on any platform that passed the filter condition. With the addition of the platform_allow filter, this is no longer the case, and is masking issues such as those seen in #62963. Remove the platform_allow filter to return this test to the previous behavior.