### PR TITLE
drivers: can: mcan: Move RF0L and RF1L to line 1

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1511,7 +1511,7 @@ int can_mcan_init(const struct device *dev)
 		return err;
 	}
 
-	reg = CAN_MCAN_ILS_RF0NL | CAN_MCAN_ILS_RF1NL;
+	reg = CAN_MCAN_ILS_RF0NL | CAN_MCAN_ILS_RF1NL | CAN_MCAN_ILS_RF0LL | CAN_MCAN_ILS_RF1LL;
 	err = can_mcan_write_reg(dev, CAN_MCAN_ILS, reg);
 	if (err != 0) {
 		return err;


### PR DESCRIPTION
The code is designed to handle RF0L and RF1L in line 1, but they were being sent to line 0. Becuase they weren't handled, the interrupts would never be handled which locked up the chip.

**Additionally, I'd like some additional guidance on how to backport this to v3.4.**