### PR TITLE
 drivers: eth: gmac: Fix ethernet startup when fixed-link

### DIFF
--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1973,7 +1973,9 @@ static void eth0_iface_init(struct net_if *iface)
 	}
 
 	/* Do not start the interface until PHY link is up */
-	net_if_carrier_off(iface);
+	if (!(dev_data->link_up)) {
+		net_if_carrier_off(iface);
+	}
 
 	init_done = true;
 }


### PR DESCRIPTION
When upgrading to version 3.4, our hardware lost ethernet connectivity. Our hardware assumes a fixed link and does not communicate with the underlying phy via the mdio bus.

I confirmed that the atsame54_xpro board also will lose ethernet functionality when the atsame54_xpro configures the phy to use a fixed link.

The eth_sam_gmac driver changed the initialization behavior to call net_if_carrier_off and notes to wait until phy link is up (via callback.)  However, when in a fixed link configuration, the callback is never called. So the net_if_carrier_on event never occurs.

This patch adds a check to see if link is up already before calling net_if_carrior_off. This check works because in fixed-link mode, link-up is set synchronously during phy driver initialization.

I tested that atsame54_xpro with fixed-link configuration will now work after this patch.