### PR TITLE
kernel: work: check handler when submit to queue

### DIFF
--- a/kernel/work.c
+++ b/kernel/work.c
@@ -370,6 +370,7 @@ int z_work_submit_to_queue(struct k_work_q *queue,
 		  struct k_work *work)
 {
 	__ASSERT_NO_MSG(work != NULL);
+	__ASSERT_NO_MSG(work->handler != NULL);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -875,6 +875,7 @@ static void test_drain_wait_cb(struct k_timer *timer)
 ZTEST(work_1cpu, test_1cpu_drain_wait)
 {
 	struct test_drain_wait_timer *ctx = &test_drain_wait_ctx;
+	struct k_work *wp = &ctx->work;
 	int rc;
 
 	/* Reset state, allow one re-submission, and use the delaying
@@ -882,10 +883,10 @@ ZTEST(work_1cpu, test_1cpu_drain_wait)
 	 */
 	reset_counters();
 	atomic_set(&resubmits_left, 1);
-	k_work_init(&common_work, delay_handler);
+	k_work_init(wp, delay_handler);
 
 	/* Submit to the cooperative queue. */
-	rc = k_work_submit_to_queue(&coophi_queue, &common_work);
+	rc = k_work_submit_to_queue(&coophi_queue, wp);
 	zassert_equal(rc, 1);
 	zassert_equal(coophi_counter(), 0);
 


### PR DESCRIPTION
Assert that the `handler` of a `work` item is not `NULL` when submitting it to the queue. This allows early detection when somewhere is submitting a non-`NULL` `work` with `NULL` `handler` to the work queue (where it happens), rather than right before the `work` item get executed in the queue (when it happens).

Thi makes sure that a work is initialized with `k_work_init` before getting submitted, as mentioned in the `k_work_init` API:

https://github.com/zephyrproject-rtos/zephyr/blob/db8855aaa3f32d3ba1f4e4e9066eb953c4406e25/include/zephyr/kernel.h#L3259-L3273

`k_work_init` will make sure that the work item has a valid handler:

https://github.com/zephyrproject-rtos/zephyr/blob/db8855aaa3f32d3ba1f4e4e9066eb953c4406e25/kernel/work.c#L134-L143

Fixes #63559

___

The first commit led to the discovery of a [hidden bug](https://github.com/zephyrproject-rtos/zephyr/actions/runs/6401145624/job/17375816925?pr=63492) in the workqueue testcase, see: https://github.com/zephyrproject-rtos/zephyr/pull/63492#issuecomment-1746215447. The 2nd commit addresses the bug in the testcase.