### PR TITLE
driver: crypto: SHA: npcx: change to support npcx4

### DIFF
--- a/drivers/crypto/crypto_npcx_sha.c
+++ b/drivers/crypto/crypto_npcx_sha.c
@@ -14,7 +14,7 @@
 LOG_MODULE_REGISTER(sha_npcx, CONFIG_CRYPTO_LOG_LEVEL);
 
 #define NPCX_HASH_CAPS_SUPPORT	(CAP_SEPARATE_IO_BUFS | CAP_SYNC_OPS)
-#define NPCX_SHA256_HANDLE_SIZE 212
+#define NPCX_SHA256_HANDLE_SIZE DT_INST_PROP(0, context_buffer_size)
 #define NPCX_SHA_MAX_SESSION	1
 
 /* The status code returns from Nuvoton Cryptographic Library ROM APIs */

--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -292,6 +292,7 @@
 		sha0: sha@13c {
 			compatible = "nuvoton,npcx-sha";
 			reg = <0x13c 0x3c>;
+			context-buffer-size = <228>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nuvoton/npcx/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9.dtsi
@@ -269,6 +269,7 @@
 		sha0: sha@13c {
 			compatible = "nuvoton,npcx-sha";
 			reg = <0x13c 0x3c>;
+			context-buffer-size = <212>;
 			status = "disabled";
 		};
 	};

--- a/dts/bindings/crypto/nuvoton,npcx-sha.yaml
+++ b/dts/bindings/crypto/nuvoton,npcx-sha.yaml
@@ -10,3 +10,10 @@ include: base.yaml
 properties:
   reg:
     required: true
+
+  context-buffer-size:
+    type: int
+    required: true
+    description: |
+      Size of the pre-allocated buffer for the SHA ROM API to store the
+      intermdiate computation result and final digest.


### PR DESCRIPTION
The pre-alloacted size of the buffer for the SHA ROM API code increases in npcx4 chip. 
This commit adds a new property `context-buffer-size` to sha0 DT node in npcx9 and npcx4 separately.
The driver can pre-allocate buffer with the correct size based on the property.