### PR TITLE
stm32: pm: Enable to driver JTAG port pns to analog when not required

### DIFF
--- a/boards/arm/nucleo_wba52cg/board.cmake
+++ b/boards/arm/nucleo_wba52cg/board.cmake
@@ -1,3 +1,7 @@
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
+set(OPENOCD "/local/mcu/tools/openocd/src/openocd" CACHE FILEPATH "" FORCE)
+set(OPENOCD_DEFAULT_PATH /local/mcu/tools/openocd/tcl)
+
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_wba52cg/support/openocd.cfg
+++ b/boards/arm/nucleo_wba52cg/support/openocd.cfg
@@ -22,5 +22,3 @@ set CLOCK_FREQ 8000
 reset_config srst_only srst_nogate
 
 source [find target/stm32wbax.cfg]
-
-gdb_memory_map disable

--- a/doc/hardware/pinctrl/index.rst
+++ b/doc/hardware/pinctrl/index.rst
@@ -145,9 +145,10 @@ In most situations, the states defined in Devicetree will be the ones used in
 the compiled firmware. However, there are some cases where certain states will
 be conditionally used depending on a compilation flag. A typical case is the
 ``sleep`` state. This state is only used in practice if
-:kconfig:option:`CONFIG_PM_DEVICE` is enabled. If a firmware variant without device
-power management is needed, one should in theory remove the ``sleep`` state from
-Devicetree to not waste ROM space storing such unused state.
+:kconfig:option:`CONFIG_PM` or :kconfig:option:`CONFIG_PM_DEVICE` is enabled.
+If a firmware variant without these power management configurations is needed,
+one should in theory remove the ``sleep`` state from Devicetree to not waste ROM
+space storing such unused state.
 
 States can be skipped by the ``pinctrl`` Devicetree macros if a definition named
 ``PINCTRL_SKIP_{STATE_NAME}`` expanding to ``1`` is present when pin control
@@ -157,8 +158,8 @@ management:
 
 .. code-block:: c
 
-    #ifndef CONFIG_PM_DEVICE
-    /** If device power management is not enabled, "sleep" state will be ignored. */
+    #if !defined(CONFIG_PM) && !defined(CONFIG_PM_DEVICE)
+    /** Out of power management configurations, ignore "sleep" state. */
     #define PINCTRL_SKIP_SLEEP 1
     #endif
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -840,6 +840,17 @@
 				status = "disabled";
 			};
 		};
+
+	};
+
+	swj_port: swj_port {
+		compatible = "swj-connector";
+		pinctrl-0 = <&debug_jtms_swdio_pa13 &debug_jtck_swclk_pa14
+			     &debug_jtdi_pa15 &debug_jtdo_swo_pb3
+			     &debug_jtrst_pb4>;
+		pinctrl-1 = <&analog_pa13 &analog_pa14 &analog_pa15
+			     &analog_pb3 &analog_pb4>;
+		pinctrl-names = "default", "sleep";
 	};
 
 	die_temp: dietemp {

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -462,6 +462,16 @@
 		};
 	};
 
+	swj_port: swj_port {
+		compatible = "swj-connector";
+		pinctrl-0 = <&debug_jtms_swdio_pa13 &debug_jtck_swclk_pa14
+			     &debug_jtdi_pa15 &debug_jtdo_swo_pb3
+			     &debug_jtrst_pb4>;
+		pinctrl-1 = <&analog_pa13 &analog_pa14 &analog_pa15
+			     &analog_pb3 &analog_pb4>;
+		pinctrl-names = "default", "sleep";
+	};
+
 	smbus1: smbus1 {
 		compatible = "st,stm32-smbus";
 		#address-cells = <1>;

--- a/dts/bindings/gpio/swj-connector.yaml
+++ b/dts/bindings/gpio/swj-connector.yaml
@@ -1,0 +1,5 @@
+description: Serial Wire - JTAG Connector
+
+compatible: "swj-connector"
+
+include: pinctrl-device.yaml

--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -76,8 +76,8 @@ struct pinctrl_dev_config {
 
 /** @cond INTERNAL_HIDDEN */
 
-#ifndef CONFIG_PM_DEVICE
-/** If device power management is not enabled, "sleep" state will be ignored. */
+#if !defined(CONFIG_PM) && !defined(CONFIG_PM_DEVICE)
+/** Out of power management configurations, ignore "sleep" state. */
 #define PINCTRL_SKIP_SLEEP 1
 #endif
 

--- a/soc/arm/st_stm32/common/CMakeLists.txt
+++ b/soc/arm/st_stm32/common/CMakeLists.txt
@@ -8,3 +8,7 @@ zephyr_sources_ifdef(CONFIG_STM32_BACKUP_SRAM stm32_backup_sram.c)
 zephyr_linker_sources_ifdef(CONFIG_STM32_BACKUP_SRAM SECTIONS stm32_backup_sram.ld)
 
 zephyr_sources(soc_config.c)
+
+if (NOT CONFIG_DEBUG AND CONFIG_PM)
+  zephyr_sources_ifdef(CONFIG_DT_HAS_SWJ_CONNECTOR_ENABLED pm_debug_swj.c)
+endif()

--- a/soc/arm/st_stm32/common/Kconfig.soc
+++ b/soc/arm/st_stm32/common/Kconfig.soc
@@ -21,6 +21,14 @@ config USE_STM32_ASSERT
 	help
 	  Enable asserts in STM32Cube HAL and LL drivers.
 
+config SWJ_ANALOG_PRIORITY
+	int "SWJ DP port to analog routine initialization priority"
+	default 49
+	help
+	  Initialization priority of the routine within the PRE_KERNEL1 level.
+	  This priority must be greater than GPIO_INIT_PRIORITY and lower than
+	  UART_INIT_PRIORITY.
+
 choice POWER_SUPPLY_CHOICE
 	prompt "STM32 power supply configuration"
 	default POWER_SUPPLY_LDO

--- a/soc/arm/st_stm32/common/pm_debug_swj.c
+++ b/soc/arm/st_stm32/common/pm_debug_swj.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/init.h>
+
+#define SWJ_NODE DT_NODELABEL(swj_port)
+
+PINCTRL_DT_DEFINE(SWJ_NODE);
+
+const struct pinctrl_dev_config *swj_pcfg = PINCTRL_DT_DEV_CONFIG_GET(SWJ_NODE);
+
+/*
+ * Serial Wire / JTAG port pins are enabled as part of SoC default configuration.
+ * When debug access is not needed and in case power consumption performance is
+ * expected, configure matching pins to analog in order to save power.
+ */
+
+static int swj_to_analog(void)
+{
+	int err;
+
+	/* Set Serial Wire / JTAG port pins to analog mode */
+	err = pinctrl_apply_state(swj_pcfg, PINCTRL_STATE_SLEEP);
+	if (err < 0) {
+		__ASSERT(0, "SWJ pinctrl setup failed");
+		return err;
+	}
+
+	return 0;
+}
+
+/* Run this routine as the earliest pin configuration in the target,
+ * to avoid potential conflicts with devices accessing SWJ-DG pins for
+ * their own needs.
+ */
+SYS_INIT(swj_to_analog, PRE_KERNEL_1, CONFIG_SWJ_ANALOG_PRIORITY);

--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 22925907a6faeb601fc9a0d8cbb65c4b26d38043
+      revision: 60c9634f61c697e1c310ec648d33529712806069
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Configuring JTAG port pins in analog when not required (build time) can save few uA.

Requires https://github.com/zephyrproject-rtos/zephyr/pull/64109

Note:
This operation can also be done using pinctrl API, which would allow dynamic handling of the pins (JTAG function are alternate functions which can't be configured using GPIO API)
Main reason to push this PR using GPIO API is that this is my first shot at this. If everyone agrees this is good enough, this is fine with me
