### PR TITLE
Bluetooth: Controller: Make aa in radio_aa_set const

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -382,7 +382,7 @@ void radio_whiten_iv_set(uint32_t iv)
 			    RADIO_PCNF1_WHITEEN_Msk;
 }
 
-void radio_aa_set(uint8_t *aa)
+void radio_aa_set(const uint8_t *aa)
 {
 	NRF_RADIO->TXADDRESS =
 	    (((0UL) << RADIO_TXADDRESS_TXADDRESS_Pos) &

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -70,7 +70,7 @@ int8_t radio_tx_power_max_get(void);
 int8_t radio_tx_power_floor(int8_t power);
 void radio_freq_chan_set(uint32_t chan);
 void radio_whiten_iv_set(uint32_t iv);
-void radio_aa_set(uint8_t *aa);
+void radio_aa_set(const uint8_t *aa);
 void radio_pkt_configure(uint8_t bits_len, uint8_t max_len, uint8_t flags);
 void radio_pkt_rx_set(void *rx_packet);
 void radio_pkt_tx_set(void *tx_packet);

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.c
@@ -684,7 +684,7 @@ void radio_whiten_iv_set(uint32_t iv)
 	GENFSK->WHITEN_SZ_THR |= GENFSK_WHITEN_SZ_THR_WHITEN_SZ_THR(0);
 }
 
-void radio_aa_set(uint8_t *aa)
+void radio_aa_set(const uint8_t *aa)
 {
 	/* Configure Access Address detection using NETWORK ADDRESS 0 */
 	GENFSK->NTW_ADR_0 = *((uint32_t *)aa);

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.h
@@ -20,7 +20,7 @@ void radio_tx_power_set(uint32_t power);
 void radio_tx_power_max_set(void);
 void radio_freq_chan_set(uint32_t chan);
 void radio_whiten_iv_set(uint32_t iv);
-void radio_aa_set(uint8_t *aa);
+void radio_aa_set(const uint8_t *aa);
 void radio_pkt_configure(uint8_t bits_len, uint8_t max_len, uint8_t flags);
 void radio_pkt_rx_set(void *rx_packet);
 void radio_pkt_tx_set(void *tx_packet);


### PR DESCRIPTION
Make the aa argument const to solve a Coverity issue that assumes that any value that is being byteswapped is tainted. Making the argument const should avoid this assumption from Coverity.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/59509