### PR TITLE
Incorrect datatype in lib/os/json.c

### DIFF
--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -667,7 +667,7 @@ static int64_t obj_parse(struct json_obj *obj, const struct json_obj_descr *desc
 	struct json_obj_key_value kv;
 	int64_t decoded_fields = 0;
 	size_t i;
-	int ret;
+	int64_t ret;
 
 	while (!obj_next(obj, &kv)) {
 		if (kv.value.type == JSON_TOK_OBJECT_END) {


### PR DESCRIPTION
Incorrect datatype "int ret" should be changed to "int64_t ret"
See: https://github.com/zephyrproject-rtos/zephyr/issues/61829