### PR TITLE
bluetooth: host: smp: Add runtime check for central-specific path 

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -4706,6 +4706,7 @@ static void bt_smp_encrypt_change(struct bt_l2cap_chan *chan,
 	 */
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 	    IS_ENABLED(CONFIG_BT_PRIVACY) &&
+	    conn->role == BT_HCI_ROLE_CENTRAL &&
 	    !(smp->remote_dist & BT_SMP_DIST_ID_KEY)) {
 		uint8_t smp_err;
 

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/src/bs_bt_utils.c
@@ -88,6 +88,11 @@ DEFINE_FLAG(flag_pairing_complete);
 DEFINE_FLAG(flag_bonded);
 DEFINE_FLAG(flag_not_bonded);
 
+static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
+{
+	FAIL("Pairing failed (unexpected): reason %u\n", reason);
+}
+
 static void pairing_complete(struct bt_conn *conn, bool bonded)
 {
 	SET_FLAG(flag_pairing_complete);
@@ -100,6 +105,7 @@ static void pairing_complete(struct bt_conn *conn, bool bonded)
 }
 
 static struct bt_conn_auth_info_cb bt_conn_auth_info_cb = {
+	.pairing_failed = pairing_failed,
 	.pairing_complete = pairing_complete,
 };
 

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/src/peripheral.c
@@ -33,6 +33,8 @@ void peripheral(void)
 	wait_connected();
 	/* Central should bond here and trigger a disconnect. */
 	wait_disconnected();
+	TAKE_FLAG(flag_pairing_complete);
+	TAKE_FLAG(flag_bonded);
 	unpair(id_a);
 	clear_g_conn();
 
@@ -43,6 +45,8 @@ void peripheral(void)
 	wait_connected();
 	/* Central should bond here and trigger a disconnect. */
 	wait_disconnected();
+	TAKE_FLAG(flag_pairing_complete);
+	TAKE_FLAG(flag_bonded);
 	clear_g_conn();
 
 	printk("== Bonding id b - bond per-connection false ==\n");
@@ -51,6 +55,8 @@ void peripheral(void)
 	wait_connected();
 	/* Central should pair without bond here and trigger a disconnect. */
 	wait_disconnected();
+	TAKE_FLAG(flag_pairing_complete);
+	TAKE_FLAG(flag_not_bonded);
 
 	PASS("PASS\n");
 }


### PR DESCRIPTION
Added run-time BT_CENTRAL role check for the path that was
central specific and did not have such check.

When multi-role BT device tried to pair without bonding (peripheral role)
while already previously bonded with the same device on another
Bluetooth identity, pairing failed.
It executed central-specific code, which should not be executed in case
when the device acts as peripheral (as it is even opt-out from code when
CONFIG_BT_CENTRAL is not enabled).

Also improved/aligned `bondable_per_connection` bsim test to check such case.

CC: @kapi-no @MarekPieta 