### PR TITLE
doc: remove usage and mentions to "numbered steps"

### DIFF
--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -580,29 +580,3 @@ in the Zephyr setup.  Within a tab, you can have most any content *other
 than a heading* (code-blocks, ordered and unordered lists, pictures,
 paragraphs, and such).  You can read more about sphinx-tabs from the
 link above.
-
-Instruction Steps
-*****************
-
-Also introduced in the :ref:`getting_started` is a style that makes it
-easy to create tutorial guides with clearly identified steps. Add
-the ``.. rst-class:: numbered-step`` directive immediately before a
-second-level heading (by project convention, a heading underlined with
-asterisks ``******``, and it will be displayed as a numbered step,
-sequentially numbered within the document.  For example::
-
-   .. rst-class:: numbered-step
-
-   Put your right hand in
-   **********************
-
-.. rst-class:: numbered-step
-
-Put your right hand in
-**********************
-
-See the :zephyr_raw:`doc/develop/getting_started/index.rst` source file and
-compare with the :ref:`getting_started` to see a full example.  As implemented,
-only one set of numbered steps is intended per document.
-
-For instructions on building the documentation, see :ref:`zephyr_doc`.

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -13,8 +13,6 @@ Follow this guide to:
 
 .. _host_setup:
 
-.. rst-class:: numbered-step
-
 Select and Update OS
 ********************
 
@@ -45,8 +43,6 @@ Click the operating system you are using.
       Click *Check for updates* and install any that are available.
 
 .. _install-required-tools:
-
-.. rst-class:: numbered-step
 
 Install dependencies
 ********************
@@ -177,8 +173,6 @@ The current minimum required version for the main dependencies are:
 .. _clone-zephyr:
 .. _install_py_requirements:
 .. _gs_python_deps:
-
-.. rst-class:: numbered-step
 
 Get Zephyr and install Python dependencies
 ******************************************
@@ -476,8 +470,6 @@ additional Python dependencies.
 
                   pip3 install -r %HOMEPATH%\zephyrproject\zephyr\scripts\requirements.txt
 
-.. rst-class:: numbered-step
-
 
 Install Zephyr SDK
 ******************
@@ -643,8 +635,6 @@ that are used to emulate, flash and debug Zephyr applications.
 
 .. _getting_started_run_sample:
 
-.. rst-class:: numbered-step
-
 Build the Blinky Sample
 ***********************
 
@@ -687,8 +677,6 @@ The ``-p always`` option forces a pristine build, and is recommended for new
 users. Users may also use the ``-p auto`` option, which will use
 heuristics to determine if a pristine build is required, such as when building
 another sample.
-
-.. rst-class:: numbered-step
 
 Flash the Sample
 ****************


### PR DESCRIPTION
Many moons ago, the getting started was employing a technique to number headings corresponding to steps

<img width="493" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/128251/75502c11-12c0-4e91-9f9f-45d91c31f21d">

While a "nice to have", this has effectively stopped working with a6d8c232e06a2686d753cc77f9c0a22a88c7690f and I don't think it's worth restoring. 
This PR drops useless calls to `rst-class` directives from the getting started guide and misleading instroctions from the doc guidelines.

It might be worthwhile reintroducing something similar in the future but the added value is probably minimal (or we could use vanilla Sphinx `sectnum`, even if it might prove limited when one wants a mix of number and not-numbered headings in the same doc).