### PR TITLE
obj_parse has wrong return datatype int to int64_t

### DIFF
--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -667,7 +667,7 @@ static int64_t obj_parse(struct json_obj *obj, const struct json_obj_descr *desc
 	struct json_obj_key_value kv;
 	int64_t decoded_fields = 0;
 	size_t i;
-	int ret;
+	int64_t ret;
 
 	while (!obj_next(obj, &kv)) {
 		if (kv.value.type == JSON_TOK_OBJECT_END) {


### PR DESCRIPTION
obj_parse has datatype of int64_t, however the return type is int. This causes issues when there is more than 32 items in the json structs

Signed-off-by: Shahin Haque <ShahinHaque97@outlook.com>