### PR TITLE
boards: Add TF-M support for all nordic NS boards

### DIFF
--- a/boards/arm/bl5340_dvk/Kconfig.defconfig
+++ b/boards/arm/bl5340_dvk/Kconfig.defconfig
@@ -13,21 +13,6 @@ config BOARD
 config I2C
 	default GPIO || DAC
 
-# By default, if we build for a Non-Secure version of the board,
-# enable building with TF-M as the Secure Execution Environment.
-config BUILD_WITH_TFM
-	default y if BOARD_BL5340_DVK_CPUAPP_NS
-
-if BUILD_WITH_TFM
-
-# By default, if we build with TF-M, instruct build system to
-# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
-config TFM_FLASH_MERGED_BINARY
-	bool
-	default y
-
-endif # BUILD_WITH_TFM
-
 # Code Partition:
 #
 # For the secure version of the board the firmware is linked at the beginning

--- a/boards/arm/nrf5340_audio_dk_nrf5340/doc/index.rst
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/doc/index.rst
@@ -53,9 +53,6 @@ The nrf5340_audio_dk_nrf5340_cpuapp build target provides support for the applic
 core on the nRF5340 SoC. The nrf5340_audio_dk_nrf5340_cpunet build target provides
 support for the network core on the nRF5340 SoC.
 
-.. note::
-   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
-
 The `Nordic Semiconductor Infocenter`_ contains the processor's information and
 the datasheet.
 

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common-pinctrl.dtsi
@@ -51,6 +51,28 @@
 		};
 	};
 
+	uart1_default: uart1_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 9)>,
+				<NRF_PSEL(UART_RTS, 1, 11)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 1, 8)>,
+				<NRF_PSEL(UART_CTS, 1, 10)>;
+			bias-pull-up;
+		};
+	};
+
+	uart1_sleep: uart1_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 9)>,
+				<NRF_PSEL(UART_RX, 1, 11)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>,
+				<NRF_PSEL(UART_CTS, 1, 10)>;
+			low-power-enable;
+		};
+	};
+
 	i2c1_default: i2c1_default {
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,

--- a/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/arm/nrf5340_audio_dk_nrf5340/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -141,6 +141,14 @@
 	pinctrl-names = "default", "sleep";
 };
 
+arduino_serial: &uart1 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-1 = <&uart1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
 &i2c1 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";

--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -8,21 +8,6 @@ if  BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 config BOARD
 	default "nrf5340dk_nrf5340_cpuapp" if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 
-# By default, if we build for a Non-Secure version of the board,
-# enable building with TF-M as the Secure Execution Environment.
-config BUILD_WITH_TFM
-	default y if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
-
-if BUILD_WITH_TFM
-
-# By default, if we build with TF-M, instruct build system to
-# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
-config TFM_FLASH_MERGED_BINARY
-	bool
-	default y
-
-endif # BUILD_WITH_TFM
-
 # Code Partition:
 #
 # For the secure version of the board the firmware is linked at the beginning

--- a/boards/arm/nrf9160_innblue21/doc/index.rst
+++ b/boards/arm/nrf9160_innblue21/doc/index.rst
@@ -104,9 +104,6 @@ have to set the IDAU (SPU) configuration to allow Non-Secure access to all
 CPU resources utilized by the Non-Secure application firmware. SPU
 configuration shall take place before jumping to the Non-Secure application.
 
-.. note::
-   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
-
 Building a Secure only application
 ==================================
 

--- a/boards/arm/nrf9160_innblue22/doc/index.rst
+++ b/boards/arm/nrf9160_innblue22/doc/index.rst
@@ -104,9 +104,6 @@ have to set the IDAU (SPU) configuration to allow Non-Secure access to all
 CPU resources utilized by the Non-Secure application firmware. SPU
 configuration shall take place before jumping to the Non-Secure application.
 
-.. note::
-   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
-
 Building a Secure only application
 ==================================
 

--- a/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
@@ -8,21 +8,6 @@ if BOARD_NRF9160DK_NRF9160 || BOARD_NRF9160DK_NRF9160_NS
 config BOARD
 	default "nrf9160dk_nrf9160"
 
-# By default, if we build for a Non-Secure version of the board,
-# enable building with TF-M as the Secure Execution Environment.
-config BUILD_WITH_TFM
-	default y if BOARD_NRF9160DK_NRF9160_NS
-
-if BUILD_WITH_TFM
-
-# By default, if we build with TF-M, instruct build system to
-# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
-config TFM_FLASH_MERGED_BINARY
-	bool
-	default y
-
-endif # BUILD_WITH_TFM
-
 # For the secure version of the board the firmware is linked at the beginning
 # of the flash, or into the code-partition defined in DT if it is intended to
 # be loaded by MCUboot. If the secure firmware is to be combined with a non-

--- a/boards/arm/nrf9161dk_nrf9161/Kconfig.defconfig
+++ b/boards/arm/nrf9161dk_nrf9161/Kconfig.defconfig
@@ -8,21 +8,6 @@ if BOARD_NRF9161DK_NRF9161 || BOARD_NRF9161DK_NRF9161_NS
 config BOARD
 	default "nrf9161dk_nrf9161"
 
-# By default, if we build for a Non-Secure version of the board,
-# enable building with TF-M as the Secure Execution Environment.
-config BUILD_WITH_TFM
-	default y if BOARD_NRF9161DK_NRF9161_NS
-
-if BUILD_WITH_TFM
-
-# By default, if we build with TF-M, instruct build system to
-# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
-config TFM_FLASH_MERGED_BINARY
-	bool
-	default y
-
-endif # BUILD_WITH_TFM
-
 # For the secure version of the board the firmware is linked at the beginning
 # of the flash, or into the code-partition defined in DT if it is intended to
 # be loaded by MCUboot. If the secure firmware is to be combined with a non-

--- a/boards/arm/raytac_mdbt53_db_40_nrf5340/Kconfig.defconfig
+++ b/boards/arm/raytac_mdbt53_db_40_nrf5340/Kconfig.defconfig
@@ -8,21 +8,6 @@ if  BOARD_RAYTAC_MDBT53_DB_40_NRF5340_CPUAPP || BOARD_RAYTAC_MDBT53_DB_40_NRF534
 config BOARD
 	default "raytac_mdbt53_db_40_nrf5340_cpuapp"
 
-# By default, if we build for a Non-Secure version of the board,
-# enable building with TF-M as the Secure Execution Environment.
-config BUILD_WITH_TFM
-	default n if BOARD_RAYTAC_MDBT53_DB_40_NRF5340_CPUAPP_NS
-
-if BUILD_WITH_TFM
-
-# By default, if we build with TF-M, instruct build system to
-# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
-config TFM_FLASH_MERGED_BINARY
-	bool
-	default n
-
-endif # BUILD_WITH_TFM
-
 # Code Partition:
 #
 # For the secure version of the board the firmware is linked at the beginning

--- a/boards/arm/raytac_mdbt53_db_40_nrf5340/doc/index.rst
+++ b/boards/arm/raytac_mdbt53_db_40_nrf5340/doc/index.rst
@@ -24,9 +24,6 @@ The raytac_mdbt53_db_40_nrf5340_cpuapp build target provides support for the app
 core on the nRF5340 SoC. The raytac_mdbt53_db_40_nrf5340_cpuapp build target provides
 support for the network core on the nRF5340 SoC.
 
-.. note::
-   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
-
 nRF5340 SoC provides support for the following devices:
 
 * :abbr:`ADC (Analog to Digital Converter)`

--- a/boards/arm/raytac_mdbt53_db_40_nrf5340/raytac_mdbt53_db_40_nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/raytac_mdbt53_db_40_nrf5340/raytac_mdbt53_db_40_nrf5340_cpuapp_common-pinctrl.dtsi
@@ -41,18 +41,19 @@
 
 	uart1_default: uart1_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 1)>;
-		};
-		group2 {
-			psels = <NRF_PSEL(UART_RX, 1, 0)>;
-			bias-pull-up;
+			psels = <NRF_PSEL(UART_TX, 1, 1)>,
+				<NRF_PSEL(UART_RX, 1, 0)>,
+				<NRF_PSEL(UART_RTS, 1, 14)>,
+				<NRF_PSEL(UART_CTS, 1, 15)>;
 		};
 	};
 
 	uart1_sleep: uart1_sleep {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 1)>,
-				<NRF_PSEL(UART_RX, 1, 0)>;
+				<NRF_PSEL(UART_RX, 1, 0)>,
+				<NRF_PSEL(UART_RTS, 1, 14)>,
+				<NRF_PSEL(UART_CTS, 1, 15)>;
 			low-power-enable;
 		};
 	};

--- a/boards/arm/raytac_mdbt53v_db_40_nrf5340/Kconfig.defconfig
+++ b/boards/arm/raytac_mdbt53v_db_40_nrf5340/Kconfig.defconfig
@@ -7,20 +7,6 @@ if  BOARD_RAYTAC_MDBT53V_DB_40_NRF5340_CPUAPP || BOARD_RAYTAC_MDBT53V_DB_40_NRF5
 
 config BOARD
 	default "raytac_mdbt53v_db_40_nrf5340_cpuapp" if BOARD_RAYTAC_MDBT53V_DB_40_NRF5340_CPUAPP || BOARD_RAYTAC_MDBT53V_DB_40_NRF5340_CPUAPP_NS
-# By default, if we build for a Non-Secure version of the board,
-# enable building with TF-M as the Secure Execution Environment.
-config BUILD_WITH_TFM
-	default n if BOARD_BL5340_DVK_CPUAPP_NS
-
-if BUILD_WITH_TFM
-
-# By default, if we build with TF-M, instruct build system to
-# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
-config TFM_FLASH_MERGED_BINARY
-	bool
-	default n
-
-endif # BUILD_WITH_TFM
 
 # Code Partition:
 #

--- a/boards/arm/raytac_mdbt53v_db_40_nrf5340/doc/index.rst
+++ b/boards/arm/raytac_mdbt53v_db_40_nrf5340/doc/index.rst
@@ -24,9 +24,6 @@ The raytac_mdbt53v_db_40_nrf5340_cpuapp build target provides support for the ap
 core on the nRF5340 SoC. The raytac_mdbt53v_db_40_nrf5340_cpuapp build target provides
 support for the network core on the nRF5340 SoC.
 
-.. note::
-   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
-
 nRF5340 SoC provides support for the following devices:
 
 * :abbr:`ADC (Analog to Digital Converter)`

--- a/boards/arm/raytac_mdbt53v_db_40_nrf5340/raytac_mdbt53v_db_40_nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/raytac_mdbt53v_db_40_nrf5340/raytac_mdbt53v_db_40_nrf5340_cpuapp_common-pinctrl.dtsi
@@ -39,6 +39,25 @@
 		};
 	};
 
+	uart1_default: uart1_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 5)>,
+				<NRF_PSEL(UART_RX, 0, 4)>,
+				<NRF_PSEL(UART_RTS, 1, 2)>,
+				<NRF_PSEL(UART_CTS, 1, 3)>;
+		};
+	};
+
+	uart1_sleep: uart1_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 5)>,
+				<NRF_PSEL(UART_RX, 0, 4)>,
+				<NRF_PSEL(UART_RTS, 1, 2)>,
+				<NRF_PSEL(UART_CTS, 1, 3)>;
+			low-power-enable;
+		};
+	};
+
 	pwm0_default: pwm0_default {
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 0, 28)>;

--- a/boards/arm/raytac_mdbt53v_db_40_nrf5340/raytac_mdbt53v_db_40_nrf5340_cpuapp_common.dts
+++ b/boards/arm/raytac_mdbt53v_db_40_nrf5340/raytac_mdbt53v_db_40_nrf5340_cpuapp_common.dts
@@ -107,6 +107,14 @@
 	pinctrl-names = "default", "sleep";
 };
 
+&uart1 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-1 = <&uart1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
 &pwm0 {
 	status = "okay";
 	pinctrl-0 = <&pwm0_default>;

--- a/boards/arm/raytac_mdbt53v_db_40_nrf5340/raytac_mdbt53v_db_40_nrf5340_cpunet-pinctrl.dtsi
+++ b/boards/arm/raytac_mdbt53v_db_40_nrf5340/raytac_mdbt53v_db_40_nrf5340_cpunet-pinctrl.dtsi
@@ -9,7 +9,7 @@
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 0, 31)>,
 				<NRF_PSEL(UART_RTS, 1, 13)>,
-			    <NRF_PSEL(UART_RX, 1, 11)>,
+				<NRF_PSEL(UART_RX, 1, 11)>,
 				<NRF_PSEL(UART_CTS, 1, 12)>;
 		};
 	};

--- a/boards/arm/sparkfun_thing_plus_nrf9160/doc/index.rst
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/doc/index.rst
@@ -91,9 +91,6 @@ Building an application
 In most cases you'll want to use the ``ns`` target with any of the Zephyr
 or Nordic based examples.
 
-.. note::
-   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
-
 Some of the examples do not use secure mode, so they do not required the ``ns`` suffix.
 A great example of this is the `hello_world` below.
 

--- a/boards/arm/thingy53_nrf5340/doc/index.rst
+++ b/boards/arm/thingy53_nrf5340/doc/index.rst
@@ -22,9 +22,6 @@ The nrf5340dk_nrf5340_cpuapp build target provides support for the application
 core on the nRF5340 SoC. The nrf5340dk_nrf5340_cpunet build target provides
 support for the network core on the nRF5340 SoC.
 
-.. note::
-   Trusted Firmware-M (TF-M) and building the ``ns`` target is not supported for this board.
-
 The `Nordic Semiconductor Infocenter`_ contains the processor's information and
 the datasheet.
 

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -9,9 +9,6 @@ config ZEPHYR_TRUSTED_FIRMWARE_M_MODULE
 
 config TFM_BOARD
 	string
-	default "nordic_nrf/nrf9160dk_nrf9160" if BOARD_NRF9160DK_NRF9160_NS
-	default "nordic_nrf/nrf9161dk_nrf9161" if BOARD_NRF9161DK_NRF9161_NS
-	default "nordic_nrf/nrf5340dk_nrf5340_cpuapp" if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 	default "nxp/lpcxpresso55s69" if BOARD_LPCXPRESSO55S69_CPU0
 	default "arm/mps2/an521" if BOARD_MPS2_AN521_CPU0_NS
 	default "arm/mps3/an547" if BOARD_MPS3_AN547
@@ -21,6 +18,9 @@ config TFM_BOARD
 	default "arm/musca_b1" if BOARD_MUSCA_B1
 	default "arm/musca_s1" if BOARD_MUSCA_S1
 	default "lairdconnectivity/bl5340_dvk_cpuapp" if BOARD_BL5340_DVK_CPUAPP_NS
+	default "${ZEPHYR_BASE}/modules/trusted-firmware-m/nordic_nrf/nrf9160" if SOC_NRF9160
+	default "${ZEPHYR_BASE}/modules/trusted-firmware-m/nordic_nrf/nrf9120" if SOC_NRF9120
+	default "${ZEPHYR_BASE}/modules/trusted-firmware-m/nordic_nrf/nrf5340_cpuapp" if SOC_NRF5340_CPUAPP
 	help
 	  The board name used for building TFM. Building with TFM requires that
 	  TFM has been ported to the given board/SoC.

--- a/modules/trusted-firmware-m/nordic_nrf/CMakeLists.txt
+++ b/modules/trusted-firmware-m/nordic_nrf/CMakeLists.txt
@@ -1,0 +1,67 @@
+#
+# Copyright (c) 2023, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_policy(SET CMP0076 NEW)
+set(CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+set(partition_includes
+    ${Trusted\ Firmware\ M_SOURCE_DIR}/platform/ext/target/nordic_nrf/common/${NRF_SOC_VARIANT}/partition
+    ${CMAKE_BINARY_DIR}/../zephyr/include/generated
+)
+
+set(board_includes
+    ${CMAKE_BINARY_DIR}/../zephyr/misc/generated/syscalls_links/include
+    ${ZEPHYR_BASE}/include
+)
+
+target_include_directories(platform_region_defs
+    INTERFACE
+        ${partition_includes}
+)
+
+
+target_sources(platform_s
+    PRIVATE
+        $<$<BOOL:${TFM_PARTITION_PLATFORM}>:${CMAKE_CURRENT_SOURCE_DIR}/src/tfm_platform_system.c>
+)
+
+target_include_directories(platform_s
+    PUBLIC
+        services/include
+        include
+        ${partition_includes}
+        ${board_includes}
+)
+
+target_include_directories(platform_ns
+    PUBLIC
+        include
+        include/util
+        ${partition_includes}
+        ${board_includes}
+)
+
+if(BL2)
+    target_include_directories(platform_bl2
+        PUBLIC
+            include
+            include/util
+            ${partition_includes}
+            ${board_includes}
+    )
+endif()
+
+if (TFM_PARTITION_PLATFORM)
+install(FILES       include/tfm_ioctl_api.h
+        DESTINATION ${TFM_INSTALL_PATH}/interface/include)
+endif()
+
+#========================= tfm_spm ============================================#
+
+target_sources(tfm_spm
+    PRIVATE
+        src/tfm_hal_platform.c
+)

--- a/modules/trusted-firmware-m/nordic_nrf/include/RTE_Device.h
+++ b/modules/trusted-firmware-m/nordic_nrf/include/RTE_Device.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+#include <autoconf.h>
+
+/* ARRAY_SIZE causes a conflict as it is defined both by TF-M and indirectly by devicetree.h */
+#undef ARRAY_SIZE
+#include <zephyr/devicetree.h>
+
+#define UART_PIN_INIT(node_id, prop, idx) \
+	DT_PROP_BY_IDX(node_id, prop, idx),
+
+/* Configuration settings for Driver_USART0. */
+#if DOMAIN_NS == 1U
+
+#define RTE_USART0 1
+
+#define RTE_USART0_PINS \
+{ \
+	DT_FOREACH_CHILD_VARGS( \
+		DT_PINCTRL_BY_NAME(DT_NODELABEL(uart0), default, 0), \
+		DT_FOREACH_PROP_ELEM, psels, UART_PIN_INIT \
+	) \
+}
+
+#endif
+
+/* Configuration settings for Driver_USART1. */
+#if DT_PINCTRL_HAS_NAME(DT_NODELABEL(uart1), default) && DOMAIN_NS != 1U
+
+#define RTE_USART1 1
+
+#define RTE_USART1_PINS \
+{ \
+	DT_FOREACH_CHILD_VARGS( \
+		DT_PINCTRL_BY_NAME(DT_NODELABEL(uart1), default, 0), \
+		DT_FOREACH_PROP_ELEM, psels, UART_PIN_INIT \
+	) \
+}
+
+#endif
+
+/* Configuration settings for Driver_FLASH0. */
+#define RTE_FLASH0 1
+
+#endif  /* __RTE_DEVICE_H */

--- a/modules/trusted-firmware-m/nordic_nrf/include/device_cfg.h
+++ b/modules/trusted-firmware-m/nordic_nrf/include/device_cfg.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DEVICE_CFG_H__
+#define DEVICE_CFG_H__
+
+#include <autoconf.h>
+
+/* ARRAY_SIZE causes a conflict as it is defined both by TF-M and indirectly by devicetree.h */
+#undef ARRAY_SIZE
+#include <zephyr/devicetree.h>
+
+#if DOMAIN_NS == 1U
+#define TFM_UART uart0
+#endif
+
+#if DOMAIN_NS != 1U
+#define TFM_UART uart1
+#endif
+
+#define DEFAULT_UART_BAUDRATE DT_PROP_OR(DT_NODELABEL(TFM_UART), current_speed, 115200)
+
+#if DT_PROP(DT_NODELABEL(TFM_UART), hw_flow_control)
+#define DEFAULT_UART_CONTROL ARM_USART_FLOW_CONTROL_RTS_CTS
+#else
+#define DEFAULT_UART_CONTROL 0
+#endif
+
+#endif /* DEVICE_CFG_H__ */

--- a/modules/trusted-firmware-m/nordic_nrf/include/tfm_ioctl_api.h
+++ b/modules/trusted-firmware-m/nordic_nrf/include/tfm_ioctl_api.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TFM_IOCTL_API_H__
+#define TFM_IOCTL_API_H__
+
+#include <limits.h>
+#include <stdint.h>
+#include <tfm_api.h>
+#include <tfm_platform_api.h>
+
+/* Include core IOCTL services */
+#include <tfm_ioctl_core_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Board specific IOCTL services can be added here */
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* TFM_IOCTL_API_H__ */

--- a/modules/trusted-firmware-m/nordic_nrf/include/tfm_peripherals_config.h
+++ b/modules/trusted-firmware-m/nordic_nrf/include/tfm_peripherals_config.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TFM_PERIPHERALS_CONFIG_H__
+#define TFM_PERIPHERALS_CONFIG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef SECURE_UART1
+#define TFM_PERIPHERAL_UARTE1_SECURE 1
+#endif
+
+#if TEST_NS_SLIH_IRQ || TEST_NS_FLIH_IRQ
+#define TFM_PERIPHERAL_TIMER0_SECURE 1
+#endif
+
+#ifdef PSA_API_TEST_IPC
+#define TFM_PERIPHERAL_EGU5_SECURE 1
+
+#define TFM_PERIPHERAL_WDT_SECURE 1
+#endif
+
+#if defined(NRF91_SERIES)
+    #include <tfm_peripherals_config_nrf91.h>
+#elif defined(NRF5340_XXAA_APPLICATION)
+    #include <tfm_peripherals_config_nrf5340_application.h>
+#else
+    #error "Unknown device."
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TFM_PERIPHERAL_CONFIG_H__ */

--- a/modules/trusted-firmware-m/nordic_nrf/include/tfm_read_ranges.h
+++ b/modules/trusted-firmware-m/nordic_nrf/include/tfm_read_ranges.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TFM_READ_RANGES_H__
+#define TFM_READ_RANGES_H__
+
+#include <tfm_ioctl_core_api.h>
+
+#include <nrf.h>
+
+#ifdef NRF_FICR_S_BASE
+
+#define FICR_BASE               NRF_FICR_S_BASE
+
+#define FICR_INFO_ADDR          (FICR_BASE + offsetof(NRF_FICR_Type, INFO))
+#define FICR_INFO_SIZE          (sizeof(FICR_INFO_Type))
+
+#if defined(FICR_NFC_TAGHEADER0_MFGID_Msk)
+#define FICR_NFC_ADDR           (FICR_BASE + offsetof(NRF_FICR_Type, NFC))
+#define FICR_NFC_SIZE           (sizeof(FICR_NFC_Type))
+#endif
+
+#if defined(FICR_XOSC32MTRIM_SLOPE_Msk)
+#define FICR_XOSC32MTRIM_ADDR   (FICR_BASE + offsetof(NRF_FICR_Type, XOSC32MTRIM))
+#define FICR_XOSC32MTRIM_SIZE   (sizeof(uint32_t))
+#endif
+
+/* Used by nrf_erratas.h */
+#define FICR_RESTRICTED_ADDR    (FICR_BASE + 0x130)
+#define FICR_RESTRICTED_SIZE    0x8
+
+#if defined(FICR_SIPINFO_PARTNO_PARTNO_Pos)
+#define FICR_SIPINFO_ADDR       (FICR_BASE + offsetof(NRF_FICR_Type, SIPINFO))
+#define FICR_SIPINFO_SIZE       (sizeof(FICR_SIPINFO_Type))
+#endif
+
+#endif /* NRF_FICR_S_BASE */
+
+static const struct tfm_read_service_range ranges[] = {
+#if defined(FICR_INFO_ADDR)
+	{ .start = FICR_INFO_ADDR, .size = FICR_INFO_SIZE },
+#endif
+#if defined(FICR_NFC_ADDR)
+	{ .start = FICR_NFC_ADDR, .size = FICR_NFC_SIZE },
+#endif
+#if defined(FICR_RESTRICTED_ADDR)
+	{ .start = FICR_RESTRICTED_ADDR, .size = FICR_RESTRICTED_SIZE },
+#endif
+#if defined(FICR_XOSC32MTRIM_ADDR)
+	{ .start = FICR_XOSC32MTRIM_ADDR, .size = FICR_XOSC32MTRIM_SIZE },
+#endif
+#if defined(FICR_SIPINFO_ADDR)
+	{ .start = FICR_SIPINFO_ADDR, .size = FICR_SIPINFO_SIZE },
+#endif
+};
+
+#endif /* TFM_READ_RANGES_H__ */

--- a/modules/trusted-firmware-m/nordic_nrf/include/util/array.h
+++ b/modules/trusted-firmware-m/nordic_nrf/include/util/array.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __ARRAY_H__
+#define __ARRAY_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/sys/util.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ARRAY_H__ */

--- a/modules/trusted-firmware-m/nordic_nrf/nrf5340_cpuapp/CMakeLists.txt
+++ b/modules/trusted-firmware-m/nordic_nrf/nrf5340_cpuapp/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2023, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set(NRF_BOARD_SELECTED True)
+set(NRF_SOC_VARIANT nrf5340)
+
+add_subdirectory(${Trusted\ Firmware\ M_SOURCE_DIR}/platform/ext/target/nordic_nrf/common/nrf5340 nrf5340)
+
+add_subdirectory(.. common)

--- a/modules/trusted-firmware-m/nordic_nrf/nrf5340_cpuapp/config.cmake
+++ b/modules/trusted-firmware-m/nordic_nrf/nrf5340_cpuapp/config.cmake
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2023, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set(PLATFORM_PATH platform/ext/target/nordic_nrf/)
+include(${PLATFORM_PATH}/common/nrf5340/config.cmake)

--- a/modules/trusted-firmware-m/nordic_nrf/nrf5340_cpuapp/preload.cmake
+++ b/modules/trusted-firmware-m/nordic_nrf/nrf5340_cpuapp/preload.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+include(platform/ext/target/nordic_nrf/common/nrf5340/preload.cmake)

--- a/modules/trusted-firmware-m/nordic_nrf/nrf9120/CMakeLists.txt
+++ b/modules/trusted-firmware-m/nordic_nrf/nrf9120/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2023, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set(NRF_BOARD_SELECTED True)
+set(NRF_SOC_VARIANT nrf91)
+
+add_subdirectory(${Trusted\ Firmware\ M_SOURCE_DIR}/platform/ext/target/nordic_nrf/common/nrf91 nrf91)
+
+add_subdirectory(.. common)

--- a/modules/trusted-firmware-m/nordic_nrf/nrf9120/config.cmake
+++ b/modules/trusted-firmware-m/nordic_nrf/nrf9120/config.cmake
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2023, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set(PLATFORM_PATH platform/ext/target/nordic_nrf/)
+include(${PLATFORM_PATH}/common/nrf91/config.cmake)

--- a/modules/trusted-firmware-m/nordic_nrf/nrf9120/preload.cmake
+++ b/modules/trusted-firmware-m/nordic_nrf/nrf9120/preload.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+include(platform/ext/target/nordic_nrf/common/nrf9120/preload.cmake)

--- a/modules/trusted-firmware-m/nordic_nrf/nrf9160/CMakeLists.txt
+++ b/modules/trusted-firmware-m/nordic_nrf/nrf9160/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2023, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set(NRF_BOARD_SELECTED True)
+set(NRF_SOC_VARIANT nrf91)
+
+add_subdirectory(${Trusted\ Firmware\ M_SOURCE_DIR}/platform/ext/target/nordic_nrf/common/nrf91 nrf91)
+
+add_subdirectory(.. common)

--- a/modules/trusted-firmware-m/nordic_nrf/nrf9160/config.cmake
+++ b/modules/trusted-firmware-m/nordic_nrf/nrf9160/config.cmake
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2023, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set(PLATFORM_PATH platform/ext/target/nordic_nrf/)
+include(${PLATFORM_PATH}/common/nrf91/config.cmake)

--- a/modules/trusted-firmware-m/nordic_nrf/nrf9160/preload.cmake
+++ b/modules/trusted-firmware-m/nordic_nrf/nrf9160/preload.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023, Nordic Semiconductor ASA.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+include(platform/ext/target/nordic_nrf/common/nrf9160/preload.cmake)

--- a/modules/trusted-firmware-m/nordic_nrf/src/tfm_hal_platform.c
+++ b/modules/trusted-firmware-m/nordic_nrf/src/tfm_hal_platform.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "tfm_hal_defs.h"
+#include "tfm_hal_platform_common.h"
+
+enum tfm_hal_status_t tfm_hal_platform_init(void)
+{
+	return tfm_hal_platform_common_init();
+}

--- a/modules/trusted-firmware-m/nordic_nrf/src/tfm_platform_system.c
+++ b/modules/trusted-firmware-m/nordic_nrf/src/tfm_platform_system.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "platform/include/tfm_platform_system.h"
+#include "cmsis.h"
+#include "tfm_platform_hal_ioctl.h"
+#include "tfm_ioctl_core_api.h"
+
+void tfm_platform_hal_system_reset(void)
+{
+	/* Reset the system */
+	NVIC_SystemReset();
+}
+
+enum tfm_platform_err_t tfm_platform_hal_ioctl(tfm_platform_ioctl_req_t request,
+					       psa_invec  *in_vec,
+					       psa_outvec *out_vec)
+{
+	/* Core IOCTL services */
+	switch (request) {
+	case TFM_PLATFORM_IOCTL_READ_SERVICE:
+		return tfm_platform_hal_read_service(in_vec, out_vec);
+#if defined(GPIO_PIN_CNF_MCUSEL_Msk)
+	case TFM_PLATFORM_IOCTL_GPIO_SERVICE:
+		return tfm_platform_hal_gpio_service(in_vec, out_vec);
+#endif /* defined(GPIO_PIN_CNF_MCUSEL_Msk) */
+
+
+	/* Board specific IOCTL services */
+
+	/* Not a supported IOCTL service.*/
+	default:
+		return TFM_PLATFORM_ERR_NOT_SUPPORTED;
+	}
+}

--- a/soc/arm/nordic_nrf/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/CMakeLists.txt
@@ -21,4 +21,8 @@ if(CONFIG_BUILD_WITH_TFM)
   set_property(TARGET zephyr_property_target
     APPEND PROPERTY TFM_CMAKE_OPTIONS -DHAL_NORDIC_PATH=${ZEPHYR_HAL_NORDIC_MODULE_DIR}
     )
+
+  set_property(TARGET zephyr_property_target
+    APPEND PROPERTY TFM_CMAKE_OPTIONS -DZEPHYR_BASE=${ZEPHYR_BASE}
+    )
 endif()

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -25,6 +25,13 @@ config NRF_SOC_SECURE_SUPPORTED
 	  For non-secure the functions must redirect to secure services exposed
 	  by the secure firmware.
 
+config TFM_LOG_LEVEL_SILENCE
+	default y if !$(dt_nodelabel_has_prop,uart1,pinctrl-names)
+	depends on BUILD_WITH_TFM
+	help
+	  Disable TF-M secure output if the uart1 node has not assigned GPIO
+	  pins using pinctrl.
+
 config NRF_MPU_FLASH_REGION_SIZE
 	hex
 	default 0x1000

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -25,12 +25,28 @@ config NRF_SOC_SECURE_SUPPORTED
 	  For non-secure the functions must redirect to secure services exposed
 	  by the secure firmware.
 
+config BUILD_WITH_TFM
+	default y if TRUSTED_EXECUTION_NONSECURE
+	help
+	  By default, if we build for a Non-Secure version of the board,
+	  enable building with TF-M as the Secure Execution Environment.
+
+if BUILD_WITH_TFM
+
+config TFM_FLASH_MERGED_BINARY
+	default y
+	help
+	  By default, if we build with TF-M, instruct build system to
+	  flash the combined TF-M (Secure) & Zephyr (Non Secure) image
+
 config TFM_LOG_LEVEL_SILENCE
 	default y if !$(dt_nodelabel_has_prop,uart1,pinctrl-names)
-	depends on BUILD_WITH_TFM
 	help
 	  Disable TF-M secure output if the uart1 node has not assigned GPIO
 	  pins using pinctrl.
+
+endif # BUILD_WITH_TFM
+
 
 config NRF_MPU_FLASH_REGION_SIZE
 	hex

--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       groups:
         - crypto
     - name: trusted-firmware-m
-      revision: b168d92c7ed3c77c94d7ce3362bdde5dbffe8424
+      revision: 696b09568c6b30cbcbe5b8764f703c90a48825eb
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Add generic SoC support for the supported nordic SoCs:
- nrf5340
- nrf9160
- nrf9120

Add generic SoC support by taking board specific configurations from
zephyr devicetree and kconfig.
