### PR TITLE
tests: newlib/thread_safety: exclude acrn_ehl_crb from more tests

### DIFF
--- a/tests/lib/newlib/thread_safety/testcase.yaml
+++ b/tests/lib/newlib/thread_safety/testcase.yaml
@@ -31,6 +31,7 @@ tests:
       - userspace
     min_ram: 192
     timeout: 120
+    platform_exclude: acrn_ehl_crb  # See #61129
   libraries.libc.newlib_nano.thread_safety:
     extra_configs:
       - CONFIG_NEWLIB_LIBC_NANO=y


### PR DESCRIPTION
This is currently failing in the weekly run: https://github.com/zephyrproject-rtos/zephyr/runs/17290089874

---

This was already excluded from
libraries.libc.newlib_nano.thread_safety.userspace.stress and it's now failing in libraries.libc.newlib.thread_safety.userspace.stress as well.

The issue is being rootcaused to a toolchain issue but a proper fix has not been identified yet, exclude that test as well in the meantime.

Link: https://github.com/zephyrproject-rtos/zephyr/issues/61129