### PR TITLE
boards: frdm_k64f: Add uart-mcumgr chosen

### DIFF
--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -28,6 +28,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 		zephyr,canbus = &flexcan0;
+		zephyr,uart-mcumgr = &uart0;
 	};
 
 	leds {


### PR DESCRIPTION
Since frdm_k64f is used as example in mcumgr sample with serial transport, make it ready for compilation.

Fixes #63520