### PR TITLE
net: context: set context->local for offloaded iface

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -709,24 +709,19 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			return -EADDRNOTAVAIL;
 		}
 
-		if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
-		    net_if_is_ip_offloaded(iface)) {
-			net_context_set_iface(context, iface);
-
-			return net_offload_bind(iface,
-						context,
-						addr,
-						addrlen);
-		}
-
 		k_mutex_lock(&context->lock, K_FOREVER);
-
-		ret = 0;
 
 		net_context_set_iface(context, iface);
 
 		net_sin6_ptr(&context->local)->sin6_family = AF_INET6;
 		net_sin6_ptr(&context->local)->sin6_addr = ptr;
+
+		if (IS_ENABLED(CONFIG_NET_OFFLOAD) && net_if_is_ip_offloaded(iface)) {
+			k_mutex_unlock(&context->lock);
+			return net_offload_bind(iface, context, addr, addrlen);
+		}
+
+		ret = 0;
 		if (addr6->sin6_port) {
 			ret = check_used_port(context->proto,
 					      addr6->sin6_port,
@@ -811,24 +806,19 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			return -EADDRNOTAVAIL;
 		}
 
-		if (IS_ENABLED(CONFIG_NET_OFFLOAD) &&
-		    net_if_is_ip_offloaded(iface)) {
-			net_context_set_iface(context, iface);
-
-			return net_offload_bind(iface,
-						context,
-						addr,
-						addrlen);
-		}
-
 		k_mutex_lock(&context->lock, K_FOREVER);
-
-		ret = 0;
 
 		net_context_set_iface(context, iface);
 
 		net_sin_ptr(&context->local)->sin_family = AF_INET;
 		net_sin_ptr(&context->local)->sin_addr = ptr;
+
+		if (IS_ENABLED(CONFIG_NET_OFFLOAD) && net_if_is_ip_offloaded(iface)) {
+			k_mutex_unlock(&context->lock);
+			return net_offload_bind(iface, context, addr, addrlen);
+		}
+
+		ret = 0;
 		if (addr4->sin_port) {
 			ret = check_used_port(context->proto,
 					      addr4->sin_port,


### PR DESCRIPTION
Currently, context->local is set to NULL for offloaded iface.

This causes the following data abort in `net conn` shell command:

```
cmd$ net conn
     Context   	Iface  Flags            Local             Remote
[ 1] 0x20011b0c	1      4DU          AF_UNSPEC	                
[ 2] 0x20011ba4	2      4DU          AF_UNSPEC	                
[00:00:15.427,000] <err> os: ***** BUS FAULT *****
[00:00:15.427,000] <err> os:   Precise data bus error
[00:00:15.427,000] <err> os:   BFAR Address: 0x0
[00:00:15.427,000] <err> os: r0/a1:  0x20015224  r1/a2:  0x00000000  r2/a3:  0x00000000
[00:00:15.427,000] <err> os: r3/a4:  0x00000000 r12/ip:  0x00000000 r14/lr:  0x080256b1
[00:00:15.427,000] <err> os:  xpsr:  0x61000000
[00:00:15.427,000] <err> os: s[ 0]:  0x080e7e16  s[ 1]:  0x2003d014  s[ 2]:  0x0000002e  s[ 3]:  0x0808f4ad
[00:00:15.427,000] <err> os: s[ 4]:  0x0000000d  s[ 5]:  0x20010ea8  s[ 6]:  0x00000000  s[ 7]:  0x00000000
[00:00:15.427,000] <err> os: s[ 8]:  0x2003d014  s[ 9]:  0x20011c3c  s[10]:  0x2003d038  s[11]:  0x2003d0a4
[00:00:15.427,000] <err> os: s[12]:  0x080cd914  s[13]:  0x2003d0a8  s[14]:  0x00000001  s[15]:  0x080d23f8
[00:00:15.427,000] <err> os: fpscr:  0x2003d0fc
[00:00:15.427,000] <err> os: Faulting instruction address (r15/pc): 0x080201b6
[00:00:15.427,000] <err> os: >>> ZEPHYR FATAL ERROR 25: Unknown error on CPU 0
[00:00:15.427,000] <err> os: Current thread: 0x2000d340 (shell_uart)
```