### PR TITLE
Bluetooth: Mesh: Don't reset mod pointer in reset callback in RPR server

### DIFF
--- a/subsys/bluetooth/mesh/rpr_srv.c
+++ b/subsys/bluetooth/mesh/rpr_srv.c
@@ -1337,7 +1337,6 @@ static void rpr_srv_reset(struct bt_mesh_model *mod)
 	atomic_clear(srv.flags);
 	srv.link.dev = NULL;
 	srv.scan.dev = NULL;
-	srv.mod = NULL;
 }
 
 const struct bt_mesh_model_cb _bt_mesh_rpr_srv_cb = {


### PR DESCRIPTION
Don't reset values set in init callback as it is called only once by bt_mesh_init call. The reset callback is called on every node reset.

Fixes #63631