### PR TITLE
net: lwm2m: Add Docker based test script

### DIFF
--- a/scripts/net/run-sample-tests.sh
+++ b/scripts/net/run-sample-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
@@ -36,7 +36,7 @@ check_dirs ()
 	    do
 	        local l
 
-	        l="$d/net-tools"
+	        l="$d/tools/net-tools"
 	        if [ -d "$l" ]; then
 		        NET_TOOLS_BASE="$l"
 		        break

--- a/tests/net/lib/lwm2m/interop/README.md
+++ b/tests/net/lib/lwm2m/interop/README.md
@@ -74,7 +74,13 @@ Install with `pip install CoAPthon3`
 
 ```
 twister -p native_posix -vv --enable-slow -T tests/net/lib/lwm2m/interop
-``````
+```
+
+Or use the Docker based testing
+
+```
+./scripts/net/run-sample-tests.sh tests/net/lib/lwm2m/interop
+```
 
 ## Test specification
 

--- a/tests/net/lib/lwm2m/interop/docker-test.sh
+++ b/tests/net/lib/lwm2m/interop/docker-test.sh
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if [ -z "$RUNNING_FROM_MAIN_SCRIPT" ]; then
+    echo "Do not run this script directly!"
+    echo "Run $ZEPHYR_BASE/scripts/net/run-sample-tests.sh instead."
+    exit 1
+fi
+
+IP="--ip=192.0.2.2 --ip6=2001:db8::2"
+FWD="-p 8080:8080 -p 8081:8081 -p 5683:5683/udp"
+
+start_configuration "$IP $FWD" || return $?
+start_docker "/net-tools/start-leshan.sh" || return $?
+
+twister -p native_posix -T ./ --enable-slow -vv
+
+result=$?
+
+stop_docker

--- a/tests/net/lib/lwm2m/interop/pytest/test_lwm2m.py
+++ b/tests/net/lib/lwm2m/interop/pytest/test_lwm2m.py
@@ -112,7 +112,7 @@ def verify_LightweightM2M_1_1_int_107(shell: Shell, leshan: Leshan, endpoint: st
     lines = shell.get_filtered_output(shell.exec_command('lwm2m read 1/0/1 -u32'))
     lifetime = int(lines[0])
     assert lifetime == 120
-    logger.debug(f'sleeping for {lifetime} s')
+    logger.debug(f'Wait for update, max {lifetime} s')
     shell._device.readlines_until(regex='.*net_lwm2m_rd_client: Update Done', timeout=lifetime)
     assert leshan.get(f'/clients/{endpoint}')
 
@@ -123,6 +123,7 @@ def verify_LightweightM2M_1_1_int_108(leshan, endpoint):
 def verify_LightweightM2M_1_1_int_109(shell: Shell, leshan: Leshan, endpoint: str):
     logger.info("LightweightM2M-1.1-int-109 - Behavior in Queue Mode")
     verify_LightweightM2M_1_1_int_107(shell, leshan, endpoint)
+    logger.debug('Wait for Queue RX OFF')
     shell._device.readlines_until(regex='.*Queue mode RX window closed', timeout=120)
     # Restore previous value
     shell.exec_command('lwm2m write 1/0/1 -u32 86400')

--- a/west.yml
+++ b/west.yml
@@ -289,7 +289,7 @@ manifest:
         - debug
       revision: a819419603a2dfcb47f7f39092e1bc112e45d1ef
     - name: net-tools
-      revision: e0828aa9629b533644dc96ff6d1295c939bd713c
+      revision: d68ee9d17648a1bb3729c2023abfcb735dfe92fa
       path: tools/net-tools
       groups:
         - tools


### PR DESCRIPTION
Add Docker based test script for LwM2M interoperability test.

Depends on https://github.com/zephyrproject-rtos/net-tools/pull/65