### PR TITLE
tests: drivers: uart: uart_basic_api: basic_api.wide issue

### DIFF
--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -15,8 +15,6 @@ tests:
     harness: keyboard
     arch_allow: arm
     platform_allow: nucleo_h743zi
-    integration_platforms:
-      - nucleo_h743zi
     extra_args: DTC_OVERLAY_FILE="boards/nucleo_h743zi.overlay"
   drivers.uart.basic_api.poll:
     extra_args: CONF_FILE=prj_poll.conf


### PR DESCRIPTION
The twister test drivers.uart.basic_api.wide
can't work without keyboard
integration_platforms: nucleo_h743zi