### PR TITLE
drivers: i2s: i2s_mcux_sai: fix logging statements for k_mem_slab

### DIFF
--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -660,9 +660,9 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 		LOG_DBG("tx slab free_list = 0x%x",
 			(uint32_t)i2s_cfg->mem_slab->free_list);
 		LOG_DBG("tx slab num_blocks = %d",
-			(uint32_t)i2s_cfg->mem_slab->num_blocks);
+			(uint32_t)i2s_cfg->mem_slab->info.num_blocks);
 		LOG_DBG("tx slab block_size = %d",
-			(uint32_t)i2s_cfg->mem_slab->block_size);
+			(uint32_t)i2s_cfg->mem_slab->info.block_size);
 		LOG_DBG("tx slab buffer = 0x%x",
 			(uint32_t)i2s_cfg->mem_slab->buffer);
 
@@ -693,9 +693,9 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 		LOG_DBG("rx slab free_list = 0x%x",
 			(uint32_t)i2s_cfg->mem_slab->free_list);
 		LOG_DBG("rx slab num_blocks = %d",
-			(uint32_t)i2s_cfg->mem_slab->num_blocks);
+			(uint32_t)i2s_cfg->mem_slab->info.num_blocks);
 		LOG_DBG("rx slab block_size = %d",
-			(uint32_t)i2s_cfg->mem_slab->block_size);
+			(uint32_t)i2s_cfg->mem_slab->info.block_size);
 		LOG_DBG("rx slab buffer = 0x%x",
 			(uint32_t)i2s_cfg->mem_slab->buffer);
 


### PR DESCRIPTION
Since 2f003e59 reworked the structure of k_mem_slab information fields, we need to update the logging statements in the i2s_mcux_sai driver to access these fields correctly.

Fixes #63527