### PR TITLE
Bluetooth: Mesh: fix settings work queue size for rpr

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1718,6 +1718,7 @@ config BT_MESH_SETTINGS_WORKQ_PRIO
 
 config BT_MESH_SETTINGS_WORKQ_STACK_SIZE
 	int "Stack size of the settings workq"
+	default 1200 if BT_MESH_RPR_SRV
 	default 880
 	help
 	  Size of the settings workqueue stack.


### PR DESCRIPTION
If RPR server is used then Mesh settings work queue requires more size during provisioning procedure.

Lack of memory has been figured out during passing PTS tests.
MESH/SR/RPR/LNK/BV-25-C
MESH/SR/RPR/LNK/BI-05-C
caused BT Mesh settings work thread stack memory overflow.
