### PR TITLE
usb: msc: Added check for negative overflow length

### DIFF
--- a/subsys/usb/device/class/msc.c
+++ b/subsys/usb/device/class/msc.c
@@ -818,6 +818,10 @@ static void thread_memory_write_done(void)
 	uint32_t size = defered_wr_sz;
 	size_t overflowed_len = (curr_offset + size) - BLOCK_SIZE;
 
+	if (BLOCK_SIZE > (curr_offset + size)) {
+		overflowed_len = 0;
+	}
+
 	if (overflowed_len > 0) {
 		memmove(page, &page[BLOCK_SIZE], overflowed_len);
 	}


### PR DESCRIPTION
Added a check for when current_offset plus size is less than BLOCK_SIZE.

Fixes: #63330