### PR TITLE
drivers: i2s: i2s_mcux_sai: use clock-mux property to select SAI mux

### DIFF
--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 NXP Semiconductor INC.
+ * Copyright 2021,2023 NXP Semiconductor INC.
  * All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -1235,9 +1235,7 @@ static const struct i2s_driver_api i2s_mcux_driver_api = {
 									\
 	static const struct i2s_mcux_config i2s_##i2s_id##_config = {	\
 		.base = (I2S_Type *)DT_INST_REG_ADDR(i2s_id),		\
-		.clk_src =						\
-			DT_CLOCKS_CELL_BY_IDX(DT_DRV_INST(i2s_id),	\
-				0, bits),				\
+		.clk_src = DT_INST_PROP(i2s_id, clock_mux),		\
 		.clk_pre_div = DT_INST_PROP(i2s_id, pre_div),		\
 		.clk_src_div = DT_INST_PROP(i2s_id, podf),		\
 		.pll_src =						\

--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -272,6 +272,8 @@
 			#pinmux-cells = <2>;
 			reg = <0x401e0000 0x4000>;
 			clocks = <&ccm IMX_CCM_SAI1_CLK 0x7C 18>;
+			/* Source clock from Audio PLL */
+			clock-mux = <2>;
 			/* Audio PLL Output Frequency is determined by:
 			 * (Fref * (DIV_SELECT + NUM/DENOM)) / POST_DIV
 			 * = (24MHz * (32 + 77 / 100)) / 1 = 786.48 MHz
@@ -310,6 +312,8 @@
 			#pinmux-cells = <2>;
 			reg = <0x401e8000 0x4000>;
 			clocks = <&ccm IMX_CCM_SAI3_CLK 0x7C 22>;
+			/* Source clock from Audio PLL */
+			clock-mux = <2>;
 			pre-div = <0>;
 			podf = <63>;
 			pll-clocks = <&anatop 0x70 0xC000 0>,

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NXP
+ * Copyright 2017,2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -937,11 +937,13 @@
 			#pinmux-cells = <2>;
 			reg = <0x40384000 0x4000>;
 			clocks = <&ccm IMX_CCM_SAI1_CLK 0x7C 18>;
+			/* Source clock from Audio PLL */
+			clock-mux = <2>;
 			/* Audio PLL Output Frequency is determined by:
 			 * (Fref * (DIV_SELECT + NUM/DENOM)) / POST_DIV
 			 * = (24MHz * (32 + 77 / 100)) / 1 = 786.48 MHz
 			 */
-		       pll-clocks = <&anatop 0x70 0xC000 0>,
+			pll-clocks = <&anatop 0x70 0xC000 0>,
 				      <&anatop 0x70 0x7F 32>,
 				      <&anatop 0x70 0x180000 1>,
 				      <&anatop 0x80 0x3FFFFFFF 77>,
@@ -975,6 +977,8 @@
 			#pinmux-cells = <2>;
 			reg = <0x40388000 0x4000>;
 			clocks = <&ccm IMX_CCM_SAI2_CLK 0x7C 20>;
+			/* Source clock from Audio PLL */
+			clock-mux = <2>;
 			pre-div = <0>;
 			podf = <63>;
 			pll-clocks = <&anatop 0x70 0xC000 0x0>,
@@ -1000,6 +1004,8 @@
 			#pinmux-cells = <2>;
 			reg = <0x4038C000 0x4000>;
 			clocks = <&ccm IMX_CCM_SAI3_CLK 0x7C 22>;
+			/* Source clock from Audio PLL */
+			clock-mux = <2>;
 			pre-div = <0>;
 			podf = <63>;
 			pll-clocks = <&anatop 0x70 0xC000 0>,

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NXP
+ * Copyright 2021,2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -990,6 +990,8 @@
 			#pinmux-cells = <2>;
 			reg = <0x40404000 0x4000>;
 			clocks = <&ccm IMX_CCM_SAI1_CLK 0x2004 4>;
+			/* Source from audio PLL */
+			clock-mux = <4>;
 			pre-div = <0>;
 			podf = <4>;
 			pll-clocks = <&anatop 0 0 0>,
@@ -1011,6 +1013,8 @@
 			#pinmux-cells = <2>;
 			reg = <0x40408000 0x4000>;
 			clocks = <&ccm IMX_CCM_SAI2_CLK 0x2084 4>;
+			/* Source from audio PLL */
+			clock-mux = <4>;
 			pre-div = <0>;
 			podf = <63>;
 			pll-clocks = <&anatop 0 0 0>,
@@ -1032,6 +1036,8 @@
 			#pinmux-cells = <2>;
 			reg = <0x4040c000 0x4000>;
 			clocks = <&ccm IMX_CCM_SAI3_CLK 0x2104 4>;
+			/* Source from audio PLL */
+			clock-mux = <4>;
 			pre-div = <0>;
 			podf = <63>;
 			pll-clocks = <&anatop 0 0 0>,
@@ -1053,6 +1059,8 @@
 			#pinmux-cells = <2>;
 			reg = <0x40c40000 0x4000>;
 			clocks = <&ccm IMX_CCM_SAI4_CLK 0x2184 6>;
+			/* Source from audio PLL */
+			clock-mux = <6>;
 			pre-div = <0>;
 			podf = <63>;
 			pll-clocks = <&anatop 0 0 0>,

--- a/dts/bindings/i2s/nxp,mcux-i2s.yaml
+++ b/dts/bindings/i2s/nxp,mcux-i2s.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NXP
+# Copyright 2021,2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP mcux SAI-I2S controller
@@ -60,3 +60,8 @@ properties:
   nxp,tx-channel:
     type: int
     description: tx channel the maximum number is SOC dependent
+
+  clock-mux:
+    required: true
+    type: int
+    description: Clock mux source for SAI root clock


### PR DESCRIPTION
Use a new property, "clock-mux" to select the clock mux for the SAI. Previously, the clock mux was being selected using the "bits" specifier of the "clocks" phandle property, which is not the purpose of this specifier. This can be shown by the regression introduced by 5bebbb91, which changed the "bits" field to the clock gate shift (which is the intended meaning).

This incidently worked for the SAI1 and SAI3 peripherals, as the lower 2 bits of the correct clock source selection (0b10) are the same as the new value placed in the "bit" specifier. For SAI2, the clock source was switched to PLL3 PDF0 by this change.

To resolve this, use an explict "clock-mux" property for this selection.

Fixes #63541