### PR TITLE
Move malloc data structures to libc partition

### DIFF
--- a/include/zephyr/sys/libc-hooks.h
+++ b/include/zephyr/sys/libc-hooks.h
@@ -92,9 +92,7 @@ __syscall size_t zephyr_fwrite(const void *ZRESTRICT ptr, size_t size,
 extern struct k_mem_partition z_malloc_partition;
 #endif
 
-#if defined(CONFIG_NEWLIB_LIBC) || (defined(CONFIG_STACK_CANARIES) && \
-			    !defined(CONFIG_STACK_CANARIES_TLS)) || \
-defined(CONFIG_PICOLIBC) || defined(CONFIG_NEED_LIBC_MEM_PARTITION)
+#ifdef CONFIG_NEED_LIBC_MEM_PARTITION
 /* - All newlib globals will be placed into z_libc_partition.
  * - Minimal C library globals, if any, will be placed into
  *   z_libc_partition.

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -975,6 +975,7 @@ menu "Security Options"
 config STACK_CANARIES
 	bool "Compiler stack canaries"
 	depends on ENTROPY_GENERATOR || TEST_RANDOM_GENERATOR
+	select NEED_LIBC_MEM_PARTITION if !STACK_CANARIES_TLS
 	help
 	  This option enables compiler stack canaries.
 

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -74,6 +74,7 @@ config PICOLIBC
 	select COMMON_LIBC_ABORT
 	select THREAD_LOCAL_STORAGE if ARCH_HAS_THREAD_LOCAL_STORAGE && TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
 	select LIBC_ERRNO if THREAD_LOCAL_STORAGE
+	select NEED_LIBC_MEM_PARTITION
 	imply COMMON_LIBC_MALLOC
 	depends on !NATIVE_APPLICATION
 	depends on PICOLIBC_SUPPORTED
@@ -87,6 +88,7 @@ config NEWLIB_LIBC
 	select COMMON_LIBC_ABORT
 	depends on !NATIVE_APPLICATION
 	depends on NEWLIB_LIBC_SUPPORTED
+	select NEED_LIBC_MEM_PARTITION
 	help
 	  Build with newlib library. The newlib library is expected to be
 	  part of the SDK in this case.

--- a/lib/libc/common/Kconfig
+++ b/lib/libc/common/Kconfig
@@ -13,6 +13,7 @@ config COMMON_LIBC_TIME
 
 config COMMON_LIBC_MALLOC
 	bool "Common C library malloc implementation"
+	select NEED_LIBC_MEM_PARTITION if COMMON_LIBC_MALLOC_ARENA_SIZE != 0
 	help
 	  Common implementation of malloc family that uses the kernel heap
 	  API.


### PR DESCRIPTION
Leave the malloc partition so that it only contains the heap itself; this lets the initialization code adjust the address range when configuring the arena at startup.

This could be done differently -- when the malloc arena is allocated at build time as a static array, we could stick
the malloc variables in the same partition and avoid needing the libc partition. That's a bit more complicated as it would require detecting that condition when deciding whether to create a libc partition ...

Closes: #63493 