### PR TITLE
mgmt: mcumgr: transport: dummy: Fix truncating uint16_t

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/smp_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_dummy.c
@@ -65,7 +65,7 @@ static struct net_buf *mcumgr_dummy_process_frag(
 
 static struct net_buf *mcumgr_dummy_process_frag_outgoing(
 	struct mcumgr_serial_rx_ctxt *tx_ctxt,
-	const uint8_t *frag, int frag_len);
+	const uint8_t *frag, uint16_t frag_len);
 
 static int mcumgr_dummy_tx_pkt(const uint8_t *data, int len,
 			       mcumgr_serial_tx_cb cb);
@@ -113,7 +113,7 @@ static void smp_dummy_process_frag(struct uart_mcumgr_rx_buf *rx_buf)
  * used in tests
  */
 static struct net_buf *smp_dummy_process_frag_outgoing(uint8_t *buffer,
-						       uint8_t buffer_size)
+						       uint16_t buffer_size)
 {
 	struct net_buf *nb;
 
@@ -441,7 +441,7 @@ static struct net_buf *mcumgr_dummy_process_frag(
  */
 static struct net_buf *mcumgr_dummy_process_frag_outgoing(
 	struct mcumgr_serial_rx_ctxt *tx_ctxt,
-	const uint8_t *frag, int frag_len)
+	const uint8_t *frag, uint16_t frag_len)
 {
 	struct net_buf *nb;
 	uint16_t crc;


### PR DESCRIPTION
`smp_send_pos` is 16 bits wide but it was being passed as uint8_t, thus truncating. This made it impossible to receive packets larger than 256 bytes.

This caused an issue to us, because we are doing unit tests for our own mcumgr groups with the dummy smp transport and `smp_dummy_get_outgoing` was returning `nullptr` for larger packets.