### PR TITLE
drivers: led: LP5562: Add DTS property for default LED current

### DIFF
--- a/dts/bindings/led/ti,lp5562.yaml
+++ b/dts/bindings/led/ti,lp5562.yaml
@@ -3,3 +3,21 @@ description: TI LP5562 LED
 compatible: "ti,lp5562"
 
 include: i2c-device.yaml
+
+properties:
+  current-red-ua:
+    type: int
+    default: 17500
+    description: LED current in microamps for red channel
+  current-green-ua:
+    type: int
+    default: 17500
+    description: LED current in microamps for green channel
+  current-blue-ua:
+    type: int
+    default: 17500
+    description: LED current in microamps for blue channel
+  current-white-ua:
+    type: int
+    default: 17500
+    description: LED current in microamps for white channel


### PR DESCRIPTION
The LP5562 driver did not have a way to specify the LED current. This adds a DTS property which will apply the specified current per channel when the driver initializes or the default value of 17.5mA if no property is provided.