### PR TITLE
tests: bluetooth: tester: Move bt_mesh_init call to BTP_MESH_INIT cmd

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_mesh.h
+++ b/tests/bluetooth/tester/src/btp/btp_mesh.h
@@ -851,8 +851,6 @@ struct btp_mesh_opcodes_aggregator_init_cmd {
 
 #define BTP_MESH_COMP_CHANGE_PREPARE		0x57
 
-#define BTP_MESH_SET_COMP_ALT			0x58
-
 #define BTP_MESH_RPR_SCAN_START			0x59
 struct btp_rpr_scan_start_cmd {
 	uint16_t dst;

--- a/tests/bluetooth/tester/src/btp/btp_mesh.h
+++ b/tests/bluetooth/tester/src/btp/btp_mesh.h
@@ -79,6 +79,10 @@ struct btp_mesh_provision_node_cmd_v2 {
 } __packed;
 
 #define BTP_MESH_INIT				0x04
+struct btp_mesh_init_cmd {
+	bool comp_alt;
+} __packed;
+
 #define BTP_MESH_RESET				0x05
 #define BTP_MESH_INPUT_NUMBER			0x06
 struct btp_mesh_input_number_cmd {

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -317,8 +317,6 @@ static struct {
 	.dst = BT_MESH_ADDR_UNASSIGNED,
 };
 
-static bool default_comp = true;
-
 static uint8_t supported_commands(const void *cmd, uint16_t cmd_len,
 				  void *rsp, uint16_t *rsp_len)
 {
@@ -1878,47 +1876,6 @@ static uint8_t change_prepare(const void *cmd, uint16_t cmd_len,
 #endif
 
 	return BTP_STATUS_SUCCESS;
-}
-
-#if IS_ENABLED(CONFIG_BT_SETTINGS)
-static int comp_alt_set(const char *name, size_t len_rd,
-		   settings_read_cb read_cb, void *store)
-{
-	ssize_t len;
-	bool alt_comp_value;
-
-	if (len_rd == 0) {
-		LOG_DBG("Default composition");
-	}
-
-	len = read_cb(store, &alt_comp_value, sizeof(alt_comp_value));
-	if (len < 0 || len != len_rd) {
-		LOG_ERR("Failed to read value (err %zd)", len);
-		return len;
-	}
-
-	if (alt_comp_value) {
-		default_comp = false;
-	}
-
-	return 0;
-}
-
-SETTINGS_STATIC_HANDLER_DEFINE(tester_comp_alt, "tester/comp_alt", NULL, comp_alt_set, NULL, NULL);
-#endif
-
-static uint8_t set_comp_alt(const void *cmd, uint16_t cmd_len,
-			    void *rsp, uint16_t *rsp_len)
-{
-#if !IS_ENABLED(CONFIG_BT_SETTINGS)
-	return BTP_STATUS_FAILED;
-#else
-	bool comp_alt_val = true;
-
-	settings_save_one("tester/comp_alt", &comp_alt_val, sizeof(comp_alt_val));
-
-	return BTP_STATUS_SUCCESS;
-#endif
 }
 
 static uint8_t config_krp_get(const void *cmd, uint16_t cmd_len,
@@ -4837,11 +4794,6 @@ static const struct btp_handler handlers[] = {
 		.opcode = BTP_MESH_COMP_CHANGE_PREPARE,
 		.expect_len = 0,
 		.func = change_prepare
-	},
-	{
-		.opcode = BTP_MESH_SET_COMP_ALT,
-		.expect_len = 0,
-		.func = set_comp_alt
 	},
 #if defined(CONFIG_BT_MESH_RPR_CLI)
 	{

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -1233,7 +1233,23 @@ static uint8_t provision_adv(const void *cmd, uint16_t cmd_len,
 static uint8_t init(const void *cmd, uint16_t cmd_len,
 		    void *rsp, uint16_t *rsp_len)
 {
+	const struct btp_mesh_init_cmd *cp = cmd;
 	int err;
+
+	if (!cp->comp_alt) {
+		LOG_WRN("Loading default comp data");
+		err = bt_mesh_init(&prov, &comp);
+	} else {
+		LOG_WRN("Loading alternative comp data");
+#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
+		health_srv.metadata = health_srv_meta_alt;
+#endif
+		err = bt_mesh_init(&prov, &comp_alt);
+	}
+
+	if (err) {
+		return BTP_STATUS_FAILED;
+	}
 
 	LOG_DBG("");
 
@@ -4394,7 +4410,7 @@ static const struct btp_handler handlers[] = {
 	},
 	{
 		.opcode = BTP_MESH_INIT,
-		.expect_len = 0,
+		.expect_len = sizeof(struct btp_mesh_init_cmd),
 		.func = init,
 	},
 	{
@@ -5199,26 +5215,12 @@ BT_MESH_LPN_CB_DEFINE(lpn_cb) = {
 
 uint8_t tester_init_mesh(void)
 {
-	int err;
-
 	if (IS_ENABLED(CONFIG_BT_TESTING)) {
 		bt_test_cb_register(&bt_test_cb);
 	}
 
 	tester_register_command_handlers(BTP_SERVICE_ID_MESH, handlers,
 					 ARRAY_SIZE(handlers));
-	if (default_comp) {
-		err = bt_mesh_init(&prov, &comp);
-	} else {
-#ifdef CONFIG_BT_MESH_LARGE_COMP_DATA_SRV
-		health_srv.metadata = health_srv_meta_alt;
-#endif
-		err = bt_mesh_init(&prov, &comp_alt);
-	}
-
-	if (err) {
-		return BTP_STATUS_FAILED;
-	}
 
 	return BTP_STATUS_SUCCESS;
 }


### PR DESCRIPTION
In some RPR tests we need to pass alternative composition data when
testing CDP128. When bt_mesh_init is called from mesh service
registration callback, we can't pass any arguments. Therefore we need
to move bt_mesh_init call out from mesh service registration to
BTP_MESH_INIT command. BTP_MESH_SET_COMP_ALT can then be removed as
it won't work as it was assumed initially.

Corresponding PR to AutoPTS: https://github.com/auto-pts/auto-pts/pull/1018