### PR TITLE
Bluetooth: Controller: Fix leak in scheduled ticker node

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -2326,43 +2326,46 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 					    uint32_t ticks_elapsed)
 {
 	struct ticker_node *nodes;
-	uint8_t rescheduling = 1U;
-	uint8_t rescheduled = 0U;
+	uint8_t rescheduling;
+	uint8_t rescheduled;
 
 	nodes = &instance->nodes[0];
 
 	/* Do until all pending re-schedules handled */
+	rescheduling = 1U;
+	rescheduled = 0U;
 	while (rescheduling) {
-		uint32_t ticks_to_expire_offset = 0U;
-		uint32_t ticks_start_offset = 0U;
-		uint32_t window_start_ticks = 0U;
-		uint32_t ticks_slot_window = 0U;
-		uint32_t ticks_to_expire = 0U;
+		struct ticker_node *ticker_resched;
+		uint32_t ticks_to_expire_offset;
 		struct ticker_ext  *ext_data;
-		struct ticker_node *ticker;
-		uint8_t ticker_id_head;
+		uint32_t ticks_start_offset;
+		uint32_t window_start_ticks;
+		uint32_t ticks_slot_window;
+		uint8_t ticker_id_resched;
+		uint32_t ticks_to_expire;
 		uint8_t ticker_id_prev;
-		uint8_t ticker_id_iter;
+		uint8_t ticker_id_next;
 		uint32_t ticks_slot;
 
 		rescheduling = 0U;
 
 		/* Find first pending re-schedule */
-		ticker_id_head = instance->ticker_id_head;
-		while (ticker_id_head != TICKER_NULL) {
-			ticker = &nodes[ticker_id_head];
-			if (TICKER_RESCHEDULE_PENDING(ticker)) {
+		ticker_id_resched = instance->ticker_id_head;
+		while (ticker_id_resched != TICKER_NULL) {
+			ticker_resched = &nodes[ticker_id_resched];
+			if (TICKER_RESCHEDULE_PENDING(ticker_resched)) {
 				/* Pending reschedule found */
 				break;
 			}
-			ticker_id_head = ticker->next;
+			ticker_id_resched = ticker_resched->next;
 		}
-		if (ticker_id_head == TICKER_NULL) {
+		if (ticker_id_resched == TICKER_NULL) {
 			/* Done */
 			break;
 		}
 
 		/* Check for intersection with already active node */
+		window_start_ticks = 0U;
 		if (instance->ticks_slot_previous > ticks_elapsed) {
 			/* Active node intersects - window starts after end of
 			 * active slot
@@ -2371,7 +2374,7 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 					     ticks_elapsed;
 		}
 
-		ticker_id_iter = nodes[ticker_id_head].next;
+		ticker_id_next = ticker_resched->next;
 
 		/* If drift was applied to this node, this must be
 		 * taken into consideration. Reduce the window with
@@ -2382,43 +2385,50 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 		 * ticker would have the best possible window to re-schedule in
 		 * and not be restricted to ticks_slot_window - ticks_drift.
 		 */
-		ext_data = ticker->ext_data;
+		ext_data = ticker_resched->ext_data;
 		if (ext_data->ticks_drift < ext_data->ticks_slot_window) {
 			ticks_slot_window = ext_data->ticks_slot_window -
 					    ext_data->ticks_drift;
 		} else {
 			/* Window has been exhausted - we can't reschedule */
-			ticker_id_iter = TICKER_NULL;
+			ticker_id_next = TICKER_NULL;
+
+			/* Assignment will be unused when TICKER_NULL */
+			ticks_slot_window = 0U;
 		}
 
 		/* Use ticker's reserved time ticks_slot, else for unreserved
 		 * tickers use the reschedule margin as ticks_slot.
 		 */
-		if (ticker->ticks_slot) {
-			ticks_slot = ticker->ticks_slot;
+		if (ticker_resched->ticks_slot) {
+			ticks_slot = ticker_resched->ticks_slot;
 		} else {
-			LL_ASSERT(TICKER_HAS_SLOT_WINDOW(ticker));
+			LL_ASSERT(TICKER_HAS_SLOT_WINDOW(ticker_resched));
 
 			ticks_slot = HAL_TICKER_RESCHEDULE_MARGIN;
 		}
 
 		/* Try to find available slot for re-scheduling */
-		while ((ticker_id_iter != TICKER_NULL) &&
+		ticks_to_expire_offset = 0U;
+		ticks_start_offset = 0U;
+		ticks_to_expire = 0U;
+		while ((ticker_id_next != TICKER_NULL) &&
 		       ((ticks_start_offset + ticks_slot) <=
 			ticks_slot_window)) {
-			uint32_t window_end_ticks = 0U;
-			struct ticker_node *node;
+			struct ticker_node *ticker_next;
+			uint32_t window_end_ticks;
 
-			node = &nodes[ticker_id_iter];
-			ticks_to_expire_offset += node->ticks_to_expire;
+			ticker_next = &nodes[ticker_id_next];
+			ticks_to_expire_offset += ticker_next->ticks_to_expire;
 
 			/* Skip other pending re-schedule nodes and
 			 * tickers with no reservation or not periodic
 			 */
-			if (TICKER_RESCHEDULE_PENDING(node) ||
-			    !node->ticks_slot ||
-			    !node->ticks_periodic) {
-				ticker_id_iter = node->next;
+			if (TICKER_RESCHEDULE_PENDING(ticker_next) ||
+			    !ticker_next->ticks_slot ||
+			    !ticker_next->ticks_periodic) {
+				ticker_id_next = ticker_next->next;
+
 				continue;
 			}
 
@@ -2444,7 +2454,7 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 			 */
 			if (window_end_ticks > (ticks_start_offset +
 						ticks_slot)) {
-				if (!ticker->ticks_slot) {
+				if (!ticker_resched->ticks_slot) {
 					/* Place at start of window */
 					ticks_to_expire = window_start_ticks;
 				} else {
@@ -2477,10 +2487,10 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 			 */
 			ticks_start_offset += ticks_to_expire_offset;
 			window_start_ticks  = ticks_start_offset +
-					      node->ticks_slot;
+					      ticker_next->ticks_slot;
 			ticks_to_expire_offset = 0U;
 
-			if (!ticker->ticks_slot) {
+			if (!ticker_resched->ticks_slot) {
 				/* Try at the end of the next node */
 				ticks_to_expire = window_start_ticks;
 			} else {
@@ -2493,56 +2503,61 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 						  ticks_slot;
 			}
 
-			ticker_id_iter = node->next;
+			ticker_id_next = ticker_next->next;
 		}
 
 		ext_data->ticks_drift += ticks_to_expire -
-					 ticker->ticks_to_expire;
-		ticker->ticks_to_expire = ticks_to_expire;
-		ticker_id_iter = nodes[ticker_id_head].next;
-		ticker_id_prev = TICKER_NULL;
+					 ticker_resched->ticks_to_expire;
+		ticker_resched->ticks_to_expire = ticks_to_expire;
 
 		/* Place the ticker node sorted by expiration time and adjust
 		 * delta times
 		 */
-		while (ticker_id_iter != TICKER_NULL) {
-			struct ticker_node *node;
+		ticker_id_next = ticker_resched->next;
+		ticker_id_prev = TICKER_NULL;
+		while (ticker_id_next != TICKER_NULL) {
+			struct ticker_node *ticker_next;
 
-			node = &nodes[ticker_id_iter];
-			if (ticker->ticks_to_expire > node->ticks_to_expire) {
+			ticker_next = &nodes[ticker_id_next];
+			if (ticker_resched->ticks_to_expire >
+			    ticker_next->ticks_to_expire) {
 				/* Node is after this - adjust delta */
-				ticker->ticks_to_expire -=
-					node->ticks_to_expire;
+				ticker_resched->ticks_to_expire -=
+					ticker_next->ticks_to_expire;
 			} else {
 				/* Node is before this one */
-				node->ticks_to_expire -=
-					ticker->ticks_to_expire;
+				ticker_next->ticks_to_expire -=
+					ticker_resched->ticks_to_expire;
 				break;
 			}
-			ticker_id_prev = ticker_id_iter;
-			ticker_id_iter = node->next;
+			ticker_id_prev = ticker_id_next;
+			ticker_id_next = ticker_next->next;
 		}
 
+		/* If the node moved in the list, insert it */
 		if (ticker_id_prev != TICKER_NULL) {
+			LL_ASSERT(instance->ticker_id_head ==
+				  ticker_id_resched);
+
 			/* Node did not become the first - update head and
 			 * insert node after 'previous'
 			 */
-			instance->ticker_id_head = nodes[ticker_id_head].next;
+			instance->ticker_id_head = ticker_resched->next;
 
 			/* Link inserted node */
-			nodes[ticker_id_head].next = nodes[ticker_id_prev].next;
-			nodes[ticker_id_prev].next = ticker_id_head;
+			ticker_resched->next = nodes[ticker_id_prev].next;
+			nodes[ticker_id_prev].next = ticker_id_resched;
 		}
 
 		/* Remove latency added in ticker_worker */
-		ticker->lazy_current--;
+		ticker_resched->lazy_current--;
 
 		/* Prevent repeated re-scheduling */
 		ext_data->reschedule_state =
 			TICKER_RESCHEDULE_STATE_DONE;
 
 #if defined(CONFIG_BT_TICKER_EXT_EXPIRE_INFO)
-		ticker_mark_expire_info_outdated(instance, ticker_id_head);
+		ticker_mark_expire_info_outdated(instance, ticker_id_resched);
 #endif /* CONFIG_BT_TICKER_EXT_EXPIRE_INFO */
 
 		/* Check for other pending re-schedules and set exit flag */

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -2337,6 +2337,7 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 	while (rescheduling) {
 		struct ticker_node *ticker_resched;
 		uint32_t ticks_to_expire_offset;
+		uint8_t ticker_id_resched_prev;
 		struct ticker_ext  *ext_data;
 		uint32_t ticks_start_offset;
 		uint32_t window_start_ticks;
@@ -2350,6 +2351,7 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 		rescheduling = 0U;
 
 		/* Find first pending re-schedule */
+		ticker_id_resched_prev = TICKER_NULL;
 		ticker_id_resched = instance->ticker_id_head;
 		while (ticker_id_resched != TICKER_NULL) {
 			ticker_resched = &nodes[ticker_id_resched];
@@ -2357,6 +2359,8 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 				/* Pending reschedule found */
 				break;
 			}
+
+			ticker_id_resched_prev = ticker_id_resched;
 			ticker_id_resched = ticker_resched->next;
 		}
 		if (ticker_id_resched == TICKER_NULL) {
@@ -2536,13 +2540,15 @@ static uint8_t ticker_job_reschedule_in_window(struct ticker_instance *instance,
 
 		/* If the node moved in the list, insert it */
 		if (ticker_id_prev != TICKER_NULL) {
-			LL_ASSERT(instance->ticker_id_head ==
-				  ticker_id_resched);
-
-			/* Node did not become the first - update head and
-			 * insert node after 'previous'
-			 */
-			instance->ticker_id_head = ticker_resched->next;
+			/* Remove node from its current position in list */
+			if (ticker_id_resched_prev != TICKER_NULL) {
+				/* Node was not at the head of the list */
+				nodes[ticker_id_resched_prev].next =
+					ticker_resched->next;
+			} else {
+				/* Node was at the head, move head forward */
+				instance->ticker_id_head = ticker_resched->next;
+			}
 
 			/* Link inserted node */
 			ticker_resched->next = nodes[ticker_id_prev].next;


### PR DESCRIPTION
Fix leak in scheduled ticker node when rescheduling ticker
nodes.

Applications having active Extended Advertising or Observer
role with the use of ticker reschedule in window feature
would experience assertion check failure due to delayed
radio event preparation or stalled controller with no active
roles.

Fix updating of the ticker linked list when handling
rescheduled tickers.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>

Bug reference: https://devzone.nordicsemi.com/f/nordic-q-a/103127/connectless-cte-tx-rx-problem