### PR TITLE
tests: bluetooth: tester: Fix parameter type in BTP_MESH_INIT cmd

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_mesh.h
+++ b/tests/bluetooth/tester/src/btp/btp_mesh.h
@@ -78,7 +78,7 @@ struct btp_mesh_provision_node_cmd_v2 {
 
 #define BTP_MESH_INIT				0x04
 struct btp_mesh_init_cmd {
-	bool comp_alt;
+	uint8_t comp;
 } __packed;
 
 #define BTP_MESH_RESET				0x05

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -1243,7 +1243,7 @@ static uint8_t init(const void *cmd, uint16_t cmd_len,
 	const struct btp_mesh_init_cmd *cp = cmd;
 	int err;
 
-	if (!cp->comp_alt) {
+	if (cp->comp == 0) {
 		LOG_WRN("Loading default comp data");
 		err = bt_mesh_init(&prov, &comp);
 	} else {


### PR DESCRIPTION
This PR fixes parameter type in BTP_MESH_INIT command allowing to pass integer value instead of boolean.