### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -507,6 +507,8 @@ MCUboot
   * Fixed issue with serial recovery use of MBEDTLS having undefined operations which led to usage
     faults when the secondary slot image was encrypted.
 
+  * Fixed issue with bootutil asserting on maximum alignment in non-swap modes.
+
   * Added error output when flash device fails to open and asserts are disabled, which will now
     panic the bootloader.
 

--- a/west.yml
+++ b/west.yml
@@ -281,7 +281,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 4fe28b3cf6d30c3e57d6a4f7ee3dba8617aa9a0a
+      revision: 13767d0b72eb14ce42eb8aad1e5a133ef66afc54
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  13767d0b72eb14ce42eb8aad1e5a133ef66afc54

Brings following Zephyr relevant fixes:
 - bootutil: Disable MCUBOOT_BOOT_MAX_ALIGN assert for
   non-swap modes

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.