### PR TITLE
drivers/sensor: lis2dw12: add wakeup_duration support

### DIFF
--- a/drivers/sensor/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/lis2dw12/lis2dw12.c
@@ -476,6 +476,14 @@ static int lis2dw12_init(const struct device *dev)
 		return ret;
 	}
 
+#ifdef CONFIG_LIS2DW12_THRESHOLD
+	ret = lis2dw12_wkup_dur_set(ctx, cfg->wakeup_duration);
+	if (ret < 0) {
+		LOG_ERR("wakeup duration config error %d", ret);
+		return ret;
+	}
+#endif /* CONFIG_LIS2DW12_THRESHOLD */
+
 	return 0;
 }
 
@@ -521,6 +529,13 @@ static int lis2dw12_init(const struct device *dev)
 #define LIS2DW12_CONFIG_FREEFALL(inst)
 #endif /* CONFIG_LIS2DW12_FREEFALL */
 
+#ifdef CONFIG_LIS2DW12_THRESHOLD
+#define LIS2DW12_CONFIG_THRESHOLD(inst)					\
+	.wakeup_duration = DT_INST_PROP(inst, wakeup_duration),
+#else
+#define LIS2DW12_CONFIG_THRESHOLD(inst)
+#endif
+
 #ifdef CONFIG_LIS2DW12_TRIGGER
 #define LIS2DW12_CFG_IRQ(inst) \
 	.gpio_int = GPIO_DT_SPEC_INST_GET(inst, irq_gpios),		\
@@ -540,6 +555,7 @@ static int lis2dw12_init(const struct device *dev)
 	.drdy_pulsed = DT_INST_PROP(inst, drdy_pulsed),			\
 	LIS2DW12_CONFIG_TAP(inst)					\
 	LIS2DW12_CONFIG_FREEFALL(inst)					\
+	LIS2DW12_CONFIG_THRESHOLD(inst)					\
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, irq_gpios),		\
 			(LIS2DW12_CFG_IRQ(inst)), ())
 

--- a/drivers/sensor/lis2dw12/lis2dw12.h
+++ b/drivers/sensor/lis2dw12/lis2dw12.h
@@ -96,6 +96,9 @@ struct lis2dw12_device_config {
 	uint8_t freefall_duration;
 	uint8_t freefall_threshold;
 #endif /* CONFIG_LIS2DW12_FREEFALL */
+#ifdef CONFIG_LIS2DW12_THRESHOLD
+	uint8_t wakeup_duration;
+#endif /* CONFIG_LIS2DW12_THRESHOLD */
 #endif /* CONFIG_LIS2DW12_TRIGGER */
 };
 

--- a/dts/bindings/sensor/st,lis2dw12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dw12-common.yaml
@@ -246,3 +246,19 @@ properties:
       - 5
       - 6
       - 7
+
+  wakeup-duration:
+    type: int
+    default: 0
+    description: |
+      The wakeup duration value represented in 1 LSB = 1/ODR.
+      If the accelerometer readings of the all axes are higher
+      than the wakeup threshold value for the wakeup duration long,
+      then a wakeup trigger occurs. This value is 2 bits long in the
+      register.
+
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3


### PR DESCRIPTION
Add wakeup_duration support. (WAKE_DUR in WAKE_UP_DUR).
Value is configurable through DT per instance.