### PR TITLE
scripts: twister: & ci: Fix the failing domains testing

### DIFF
--- a/.github/workflows/pylib_tests.yml
+++ b/.github/workflows/pylib_tests.yml
@@ -1,0 +1,54 @@
+# Copyright (c) 2023 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Misc. Pylib Scripts TestSuite
+
+on:
+  push:
+    branches:
+    - main
+    - v*-branch
+    paths:
+    - 'scripts/pylib/build_helpers/**'
+    - '.github/workflows/pylib_tests.yml'
+  pull_request:
+    branches:
+    - main
+    - v*-branch
+    paths:
+    - 'scripts/pylib/build_helpers/**'
+    - '.github/workflows/pylib_tests.yml'
+
+jobs:
+  pylib-tests:
+    name: Misc. Pylib Unit Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, '3.10']
+        os: [ubuntu-22.04]
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: cache-pip-linux
+      if: startsWith(runner.os, 'Linux')
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}
+    - name: install-packages
+      run: |
+        pip3 install -r scripts/requirements-base.txt -r scripts/requirements-build-test.txt
+    - name: Run pytest for build_helpers
+      env:
+        ZEPHYR_BASE: ./
+        ZEPHYR_TOOLCHAIN_VARIANT: zephyr
+      run: |
+        echo "Run build_helpers tests"
+        PYTHONPATH=./scripts/tests pytest ./scripts/tests/build_helpers

--- a/scripts/pylib/build_helpers/domains.py
+++ b/scripts/pylib/build_helpers/domains.py
@@ -78,7 +78,7 @@ class Domains:
         # Now that self._domains has been initialized, we can leverage
         # the common checks in self.get_domain to verify this.
         self._default_domain = self.get_domain(data['default'])
-        self._flash_order = self.get_domains(data['flash_order'] or [])
+        self._flash_order = self.get_domains(data.get('flash_order', []))
 
     @staticmethod
     def from_file(domains_file):

--- a/scripts/tests/build_helpers/test_domains.py
+++ b/scripts/tests/build_helpers/test_domains.py
@@ -12,7 +12,7 @@ import pytest
 import sys
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
-sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
 
 import domains
 

--- a/scripts/tests/twister/test_domains.py
+++ b/scripts/tests/twister/test_domains.py
@@ -23,21 +23,9 @@ TESTDATA_1 = [
     ('', False, 1, ['domains.yaml file not found: domains.yaml']),
     (
 """
-default: some default
-build_dir: my/dir
-domains:
-- name: some default
-  build_dir: dir/2
-- name: another
-  build_dir: dir/3
-flash_order: I don\'t think this is correct
-""",
-        True, 1, ['ERROR: Malformed yaml in file: domains.yaml']
-    ),
-    (
-"""
 default: None
 build_dir: some/dir
+domains: []
 """,
         True, None, []
     ),
@@ -46,7 +34,7 @@ build_dir: some/dir
 @pytest.mark.parametrize(
     'f_contents, f_exists, exit_code, expected_logs',
     TESTDATA_1,
-    ids=['no file', 'schema error', 'valid']
+    ids=['no file', 'valid']
 )
 def test_from_file(caplog, f_contents, f_exists, exit_code, expected_logs):
     def mock_open(*args, **kwargs):
@@ -71,43 +59,51 @@ def test_from_file(caplog, f_contents, f_exists, exit_code, expected_logs):
 
 
 TESTDATA_2 = [
-    ({'build_dir': None, 'default': None}, True, None, [], None, {}),
     (
-        {
-            'build_dir': os.path.join('build', 'dir'),
-            'domains': [
-                {
-                    'name': 'a domain',
-                    'build_dir': os.path.join('dir', '1')
-                },
-                {
-                    'name': 'default_domain',
-                    'build_dir': os.path.join('dir', '2')
-                }
-            ],
-            'default': 'default_domain',
-            'flash_order': ['default_domain', 'a domain']
-        },
-        False,
-        os.path.join('build', 'dir'),
-        [('default_domain', os.path.join('dir', '2')),
-         ('a domain', os.path.join('dir', '1'))],
-        ('default_domain', os.path.join('dir', '2')),
-        {'a domain': ('a domain', os.path.join('dir', '1')),
-         'default_domain': ('default_domain', os.path.join('dir', '2'))}
+"""
+default: some default
+build_dir: my/dir
+domains:
+- name: some default
+  build_dir: dir/2
+- name: another
+  build_dir: dir/3
+flash_order: I don\'t think this is correct
+""",
+        1, None, None, None, None
+    ),
+    (
+"""
+build_dir: build/dir
+domains:
+- name: a domain
+  build_dir: dir/1
+- name: default_domain
+  build_dir: dir/2
+default: default_domain
+flash_order:
+- default_domain
+- a domain
+""",
+        None,
+        'build/dir',
+        [('default_domain', 'dir/2'), ('a domain', 'dir/1')],
+        ('default_domain', 'dir/2'),
+        {'a domain': ('a domain', 'dir/1'),
+         'default_domain': ('default_domain', 'dir/2')}
     ),
 ]
 
 @pytest.mark.parametrize(
-    'data, expect_warning, expected_build_dir, expected_flash_order,' \
+    'data, exit_code, expected_build_dir, expected_flash_order,' \
     ' expected_default, expected_domains',
     TESTDATA_2,
-    ids=['required only', 'with default domain']
+    ids=['invalid', 'valid']
 )
-def test_from_data(
+def test_from_yaml(
     caplog,
     data,
-    expect_warning,
+    exit_code,
     expected_build_dir,
     expected_flash_order,
     expected_default,
@@ -116,15 +112,13 @@ def test_from_data(
     def mock_domain(name, build_dir, *args, **kwargs):
         return name, build_dir
 
-    warning_log = "no domains defined; this probably won't work"
+    with mock.patch('domains.Domain', side_effect=mock_domain), \
+         pytest.raises(SystemExit) if exit_code else nullcontext() as exit_st:
+        doms = domains.Domains.from_yaml(data)
 
-    with mock.patch('domains.Domain', side_effect=mock_domain):
-        doms = domains.Domains.from_data(data)
-
-    if expect_warning:
-        assert warning_log in caplog.text
-    else:
-        assert warning_log not in caplog.text
+    if exit_code:
+        assert str(exit_st.value) == str(exit_code)
+        return
 
     assert doms.get_default_domain() == expected_default
     assert doms.get_top_build_dir() == expected_build_dir
@@ -139,50 +133,93 @@ TESTDATA_3 = [
     (
         None,
         True,
-        None,
-        [],
         [('some', os.path.join('dir', '2')),
          ('order', os.path.join('dir', '1'))]
     ),
     (
         None,
         False,
-        None,
-        [],
         [('order', os.path.join('dir', '1')),
          ('some', os.path.join('dir', '2'))]
     ),
     (
-        ['some', 'other'],
-        False,
-        1,
-        ['domain other not found, valid domains are: order, some'],
-        [('some', os.path.join('dir', '2')),
-         ('order', os.path.join('dir', '1'))]
-    ),
-    (
         ['some'],
         False,
-        None,
-        [],
         [('some', os.path.join('dir', '2'))]
     ),
 ]
 
 @pytest.mark.parametrize(
-    'names, default_flash_order, exit_code, expected_logs, expected_result',
+    'names, default_flash_order, expected_result',
     TESTDATA_3,
-    ids=['order only', 'no parameters', 'domain not found', 'valid']
+    ids=['order only', 'no parameters', 'valid']
 )
 def test_get_domains(
     caplog,
     names,
     default_flash_order,
+    expected_result
+):
+    doms = domains.Domains(
+"""
+domains:
+- name: dummy
+  build_dir: dummy
+default: dummy
+build_dir: dummy
+"""
+    )
+    doms._flash_order = [
+        ('some', os.path.join('dir', '2')),
+        ('order', os.path.join('dir', '1'))
+    ]
+    doms._domains = {
+        'order': ('order', os.path.join('dir', '1')),
+        'some': ('some', os.path.join('dir', '2'))
+    }
+
+    result = doms.get_domains(names, default_flash_order)
+
+    assert result == expected_result
+
+
+
+TESTDATA_3 = [
+    (
+        'other',
+        1,
+        ['domain "other" not found, valid domains are: order, some'],
+        None
+    ),
+    (
+        'some',
+        None,
+        [],
+        ('some', os.path.join('dir', '2'))
+    ),
+]
+
+@pytest.mark.parametrize(
+    'name, exit_code, expected_logs, expected_result',
+    TESTDATA_3,
+    ids=['domain not found', 'valid']
+)
+def test_get_domain(
+    caplog,
+    name,
     exit_code,
     expected_logs,
     expected_result
 ):
-    doms = domains.Domains({'domains': [], 'default': None})
+    doms = domains.Domains(
+"""
+domains:
+- name: dummy
+  build_dir: dummy
+default: dummy
+build_dir: dummy
+"""
+    )
     doms._flash_order = [
         ('some', os.path.join('dir', '2')),
         ('order', os.path.join('dir', '1'))
@@ -193,7 +230,7 @@ def test_get_domains(
     }
 
     with pytest.raises(SystemExit) if exit_code else nullcontext() as s_exit:
-        result = doms.get_domains(names, default_flash_order)
+        result = doms.get_domain(name)
 
     assert all([log in caplog.text for log in expected_logs])
 


### PR DESCRIPTION
PR #[63195](https://github.com/zephyrproject-rtos/zephyr/pull/63195) has managed to change code under test without triggering checks to verify that the tests still are working.
This PR fixes one small mistake in the domains file (so there are no failing tests after their changes), modifies and fixes tests so 100% coverage is maintained and modifies relevant workflows so we can avoid that situation in the future.