### PR TITLE
drivers: audio: tas6422dac: add TDM support

### DIFF
--- a/dts/bindings/audio/ti,tas6422dac.yaml
+++ b/dts/bindings/audio/ti,tas6422dac.yaml
@@ -10,3 +10,23 @@ include: i2c-device.yaml
 properties:
   mute-gpios:
     type: phandle-array
+
+  tdm-slots:
+    type: string
+    description:
+      TDM slots selection. The default is set to the reset value (slots 1-2)
+    default: "1-2"
+    enum:
+      - "1-2"
+      - "3-4"
+      - "5-6"
+      - "7-8"
+
+  tdm-slot-size:
+    type: string
+    description:
+      TDM slot size. The default is set to the reset value (slot size 24-bit or 32-bit)
+    default: "24-bit or 32-bit"
+    enum:
+      - "24-bit or 32-bit"
+      - "16-bit"


### PR DESCRIPTION
Add new tas6422dac device tree properties:
- tdm-slots to select TDM slots to use
- tdm-slot-size to choose TDM slot size