### PR TITLE
sys/time_units.h: cap z_tmcvt_int_div_xx divisor to 1

### DIFF
--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -154,12 +154,12 @@ static TIME_CONSTEXPR inline int sys_clock_hw_cycles_per_sec(void)
 	 ((uint32_t)((__t) +						\
 		     z_tmcvt_off_div(__from_hz, __to_hz,		\
 				     __round_up, __round_off)) /	\
-	  ((__from_hz) / (__to_hz)))					\
+	  (MAX((__from_hz) / (__to_hz), 1)))				\
 	 :								\
 	 (uint32_t) (((uint64_t) (__t) +				\
 		      z_tmcvt_off_div(__from_hz, __to_hz,		\
 				      __round_up, __round_off)) /	\
-		     ((__from_hz) / (__to_hz)))				\
+		     (MAX((__from_hz) / (__to_hz), 1)))			\
 		)
 
 /* Integer multiplication 32-bit conversion */
@@ -175,7 +175,7 @@ static TIME_CONSTEXPR inline int sys_clock_hw_cycles_per_sec(void)
 #define z_tmcvt_int_div_64(__t, __from_hz, __to_hz, __round_up, __round_off) \
 	((uint64_t) (__t) + z_tmcvt_off_div(__from_hz, __to_hz,		\
 					    __round_up, __round_off)) / \
-	((__from_hz) / (__to_hz))
+	(MAX((__from_hz) / (__to_hz), 1))
 
 /* Integer multiplcation 64-bit conversion */
 #define z_tmcvt_int_mul_64(__t, __from_hz, __to_hz)	\


### PR DESCRIPTION
Tested with:

```
$ export ZEPHYR_TOOLCHAIN_VARIANT=llvm
$ west build -p -b native_posix_64 samples/basic/threads -DCONFIG_SYS_CLOCK_TICKS_PER_SEC=10000
$ west build -p -b native_posix_64 samples/basic/threads -DCONFIG_SYS_CLOCK_TICKS_PER_SEC=10000 -DCONFIG_TIMEOUT_64BIT=n
```

Just to be clear, I'm not too sure about side implications of doing this, in the cases I've bumped into the value is not used and if I read the conditions correctly this should only kick in if `__from_hz > __to_hz`, which implies that that divisor can't be < 1 in any relevant cases, but let me know I'm missing something.

---

The "/ (__from_hz) / (__to_hz)" element of z_tmcvt_int_div_xx often result in a "/ 0" on tickless systems, which results in a compiler warning when using clang even if the value is not used.

Cap the divisor to a minimum of 1 to avoid the warning.

Link: https://github.com/zephyrproject-rtos/zephyr/issues/63564