### PR TITLE
rtio: Remove unused Kconfigs for executors

### DIFF
--- a/subsys/rtio/Kconfig
+++ b/subsys/rtio/Kconfig
@@ -6,21 +6,6 @@ menuconfig RTIO
 
 if RTIO
 
-config RTIO_EXECUTOR_SIMPLE
-	bool "A simple executor for RTIO"
-	default y
-	help
-	  An simple RTIO executor that will execute a queue of requested I/O
-	  operations as if they are a single chain of submission queue entries. This
-	  does not support concurrent chains or submissions.
-
-config RTIO_EXECUTOR_CONCURRENT
-	bool "A low cost concurrent executor for RTIO"
-	default y
-	help
-	  A low memory cost RTIO executor that will execute a queue of requested I/O
-	  with a fixed amount of concurrency using minimal memory overhead.
-
 config RTIO_SUBMIT_SEM
 	bool "Use a semaphore when waiting for completions in rtio_submit"
 	help


### PR DESCRIPTION
There's only one executor now and its always built, no need for these old crufty Kconfigs.