### PR TITLE
doc: Setup Algolia search engine

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,6 +40,11 @@ project = "Zephyr Project"
 copyright = "2015-2023 Zephyr Project members and individual contributors"
 author = "The Zephyr Project Contributors"
 
+# Algolia DocSearch Configuration
+docsearch_app_id = "MG0KSQTIE6"
+docsearch_api_key = "30a946b69d7872b830aa4b80d05c7b2b"
+docsearch_index_name = "zephyrproject"
+
 # parse version from 'VERSION' file
 with open(ZEPHYR_BASE / "VERSION") as f:
     m = re.match(
@@ -89,6 +94,7 @@ extensions = [
     "sphinx_togglebutton",
     "zephyr.external_content",
     "zephyr.domain",
+    "sphinx_docsearch",
 ]
 
 # Only use SVG converter when it is really needed, e.g. LaTeX.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,7 +9,7 @@ pygments>=2.9
 sphinx-notfound-page
 sphinx-copybutton
 sphinx-togglebutton
-
+sphinx-docsearch==0.0.3
 # YAML validation. Used by zephyr_module.
 PyYAML>=5.1
 pykwalify


### PR DESCRIPTION
Zephyr is eligible to use Algolia's Docsearch service for free. This commit enables Algolia search in the simplest way as a proof of concept.

Live website: https://builds.zephyrproject.io/zephyr/pr/63588/docs/
