### PR TITLE
sys/time_units.h: Work around clang div-by-zero warning

### DIFF
--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -70,14 +70,11 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * @brief Get the system timer frequency.
  * @return system timer frequency in Hz
  */
-static TIME_CONSTEXPR inline int sys_clock_hw_cycles_per_sec(void)
-{
 #if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
-	return sys_clock_hw_cycles_per_sec_runtime_get();
+#define sys_clock_hw_cycles_per_sec() sys_clock_hw_cycles_per_sec_runtime_get()
 #else
-	return CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
+#define sys_clock_hw_cycles_per_sec() CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC
 #endif
-}
 
 /** @internal
  * Macro determines if fast conversion algorithm can be used. It checks if

--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -138,6 +138,16 @@ static TIME_CONSTEXPR inline int sys_clock_hw_cycles_per_sec(void)
 	 (__round_up) ? ((__from_hz) / (__to_hz)) - 1 :			\
 	 0)
 
+/* Clang emits a divide-by-zero warning even though the int_div macro
+ * results are only used when the divisor will not be zero. Work
+ * around this by substituting 1 to make the compiler happy.
+ */
+#ifdef __clang__
+#define z_tmcvt_divisor(a, b) ((a) / (b) ?: 1)
+#else
+#define z_tmcvt_divisor(a, b) ((a) / (b))
+#endif
+
 /*
  * Compute the offset needed to round the result correctly when
  * the conversion requires a full mul/div
@@ -154,12 +164,12 @@ static TIME_CONSTEXPR inline int sys_clock_hw_cycles_per_sec(void)
 	 ((uint32_t)((__t) +						\
 		     z_tmcvt_off_div(__from_hz, __to_hz,		\
 				     __round_up, __round_off)) /	\
-	  ((__from_hz) / (__to_hz)))					\
+	  z_tmcvt_divisor(__from_hz, __to_hz))				\
 	 :								\
 	 (uint32_t) (((uint64_t) (__t) +				\
 		      z_tmcvt_off_div(__from_hz, __to_hz,		\
 				      __round_up, __round_off)) /	\
-		     ((__from_hz) / (__to_hz)))				\
+		     z_tmcvt_divisor(__from_hz, __to_hz))		\
 		)
 
 /* Integer multiplication 32-bit conversion */
@@ -173,9 +183,9 @@ static TIME_CONSTEXPR inline int sys_clock_hw_cycles_per_sec(void)
 
 /* Integer division 64-bit conversion */
 #define z_tmcvt_int_div_64(__t, __from_hz, __to_hz, __round_up, __round_off) \
-	((uint64_t) (__t) + z_tmcvt_off_div(__from_hz, __to_hz,		\
-					    __round_up, __round_off)) / \
-	((__from_hz) / (__to_hz))
+	(((uint64_t) (__t) + z_tmcvt_off_div(__from_hz, __to_hz,	\
+					     __round_up, __round_off)) / \
+	z_tmcvt_divisor(__from_hz, __to_hz))
 
 /* Integer multiplcation 64-bit conversion */
 #define z_tmcvt_int_mul_64(__t, __from_hz, __to_hz)	\

--- a/tests/kernel/timer/timer_api/src/timer_convert.c
+++ b/tests/kernel/timer/timer_api/src/timer_convert.c
@@ -33,7 +33,16 @@ struct test_rec {
 			(void *)test_##src##_to_##dst##_##round##prec	\
 	}								\
 
+#ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
+#define TESTVAR(src, dst, round, prec)
+#else
+#define TESTVAR(src, dst, round, prec)					\
+	uint##prec##_t test_##src##_to_##dst##_##round##prec##_val =	\
+		k_##src##_to_##dst##_##round##prec(42);
+#endif
+
 #define TESTFUNC(src, dst, round, prec)					\
+	TESTVAR(src, dst, round, prec)					\
 	static uint##prec##_t test_##src##_to_##dst##_##round##prec(uint##prec##_t t) { \
 		return k_##src##_to_##dst##_##round##prec(t);		\
 	}


### PR DESCRIPTION
clang emits a warning for this code:

  foo.c:1:25: warning: division by zero is undefined [-Wdivision-by-zero]
  int i = (10 > 100 ? (20 / (10 / 100)) : (20 * (100 / 10)));
	                        ^ ~~~~~~~~~~

The warning is generated for code whose value does not affect the expression result, but technically it is still 'undefined behavior'.

Work around this warning by checking for a zero divisor and substituting one to make the compiler happy.

Closes: #63564 