### PR TITLE
drivers: entropy: Several small fixes

### DIFF
--- a/drivers/entropy/entropy_b91_trng.c
+++ b/drivers/entropy/entropy_b91_trng.c
@@ -55,7 +55,7 @@ static int entropy_b91_trng_get_entropy_isr(const struct device *dev,
 	/* No specific handling in case of running from ISR, just call standard API */
 	entropy_b91_trng_get_entropy(dev, buffer, length);
 
-	return 0;
+	return length;
 }
 
 /* Entropy driver APIs structure */

--- a/drivers/entropy/entropy_gecko_se.c
+++ b/drivers/entropy/entropy_gecko_se.c
@@ -40,13 +40,6 @@ static int entropy_gecko_se_get_entropy(const struct device *dev,
 	return err;
 }
 
-static int entropy_gecko_se_get_entropy_isr(const struct device *dev,
-					    uint8_t *buf,
-					    uint16_t len, uint32_t flags)
-{
-	return -ENOTSUP;
-}
-
 static int entropy_gecko_se_init(const struct device *dev)
 {
 	if (sl_se_init()) {
@@ -58,7 +51,6 @@ static int entropy_gecko_se_init(const struct device *dev)
 
 static const struct entropy_driver_api entropy_gecko_se_api_funcs = {
 	.get_entropy = entropy_gecko_se_get_entropy,
-	.get_entropy_isr = entropy_gecko_se_get_entropy_isr
 };
 
 #define GECKO_SE_INIT(n) \

--- a/drivers/entropy/entropy_neorv32_trng.c
+++ b/drivers/entropy/entropy_neorv32_trng.c
@@ -69,7 +69,7 @@ static int neorv32_trng_get_entropy_isr(const struct device *dev, uint8_t *buffe
 		}
 
 		/* No entropy available */
-		return 0;
+		return -ENODATA;
 	}
 
 	err = neorv32_trng_get_entropy(dev, buffer, len);

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -41,6 +41,8 @@ static inline uint32_t _data(Trng * const trng)
 
 static int entropy_sam_wait_ready(Trng * const trng, uint32_t flags)
 {
+	ARG_UNUSED(flags);
+
 	/* According to the reference manual, the generator provides
 	 * one 32-bit random value every 84 peripheral clock cycles.
 	 * MCK may not be smaller than HCLK/4, so it should not take
@@ -55,17 +57,6 @@ static int entropy_sam_wait_ready(Trng * const trng, uint32_t flags)
 	while (!_ready(trng)) {
 		if (timeout-- == 0) {
 			return -ETIMEDOUT;
-		}
-
-		if ((flags & ENTROPY_BUSYWAIT) == 0U) {
-			/* This internal function is used by both get_entropy,
-			 * and get_entropy_isr APIs. The later may call this
-			 * function with the ENTROPY_BUSYWAIT flag set. In
-			 * that case make no assumption that the kernel is
-			 * initialized when the function is called; so, just
-			 * do busy-wait for the random data to be ready.
-			 */
-			k_yield();
 		}
 	}
 

--- a/drivers/entropy/entropy_sam.c
+++ b/drivers/entropy/entropy_sam.c
@@ -39,10 +39,8 @@ static inline uint32_t _data(Trng * const trng)
 #endif
 }
 
-static int entropy_sam_wait_ready(Trng * const trng, uint32_t flags)
+static int entropy_sam_wait_ready(Trng * const trng)
 {
-	ARG_UNUSED(flags);
-
 	/* According to the reference manual, the generator provides
 	 * one 32-bit random value every 84 peripheral clock cycles.
 	 * MCK may not be smaller than HCLK/4, so it should not take
@@ -65,7 +63,7 @@ static int entropy_sam_wait_ready(Trng * const trng, uint32_t flags)
 
 static int entropy_sam_get_entropy_internal(const struct device *dev,
 					    uint8_t *buffer,
-					    uint16_t length, uint32_t flags)
+					    uint16_t length)
 {
 	const struct trng_sam_dev_cfg *config = dev->config;
 	Trng *const trng = config->regs;
@@ -75,7 +73,7 @@ static int entropy_sam_get_entropy_internal(const struct device *dev,
 		uint32_t value;
 		int res;
 
-		res = entropy_sam_wait_ready(trng, flags);
+		res = entropy_sam_wait_ready(trng);
 		if (res < 0) {
 			return res;
 		}
@@ -94,7 +92,7 @@ static int entropy_sam_get_entropy_internal(const struct device *dev,
 static int entropy_sam_get_entropy(const struct device *dev, uint8_t *buffer,
 				   uint16_t length)
 {
-	return entropy_sam_get_entropy_internal(dev, buffer, length, 0);
+	return entropy_sam_get_entropy_internal(dev, buffer, length);
 }
 
 static int entropy_sam_get_entropy_isr(const struct device *dev,
@@ -135,7 +133,7 @@ static int entropy_sam_get_entropy_isr(const struct device *dev,
 		/* Allowed to busy-wait */
 		int ret =
 			entropy_sam_get_entropy_internal(dev,
-				buffer, length, flags);
+				buffer, length);
 
 		if (ret == 0) {
 			/* Data retrieved successfully. */

--- a/drivers/entropy/fake_entropy_native_posix.c
+++ b/drivers/entropy/fake_entropy_native_posix.c
@@ -59,7 +59,9 @@ static int entropy_native_posix_get_entropy_isr(const struct device *dev,
 	 * entropy_native_posix_get_entropy() is also safe for ISRs
 	 * and always produces data.
 	 */
-	return entropy_native_posix_get_entropy(dev, buf, len);
+	entropy_native_posix_get_entropy(dev, buf, len);
+
+	return len;
 }
 
 static int entropy_native_posix_init(const struct device *dev)


### PR DESCRIPTION
- Fix return value in get_entropy_isr callback in some drivers
- Do not call `k_yield` from ISR