### PR TITLE
fuel_gauge: Fix desired current/voltage units

### DIFF
--- a/drivers/fuel_gauge/bq27z746/bq27z746.c
+++ b/drivers/fuel_gauge/bq27z746/bq27z746.c
@@ -175,11 +175,11 @@ static int bq27z746_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		break;
 	case FUEL_GAUGE_CHARGE_VOLTAGE:
 		rc = bq27z746_read16(dev, BQ27Z746_CHARGINGVOLTAGE, &tmp_val);
-		val->chg_voltage = tmp_val;
+		val->chg_voltage = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_CHARGE_CURRENT:
 		rc = bq27z746_read16(dev, BQ27Z746_CHARGINGCURRENT, &tmp_val);
-		val->chg_current = tmp_val;
+		val->chg_current = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_STATUS:
 		rc = bq27z746_read16(dev, BQ27Z746_BATTERYSTATUS, &tmp_val);

--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -127,11 +127,11 @@ static int sbs_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		break;
 	case FUEL_GAUGE_CHARGE_CURRENT:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CHG_CURRENT, &tmp_val);
-		val->chg_current = tmp_val;
+		val->chg_current = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_CHARGE_VOLTAGE:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CHG_VOLTAGE, &tmp_val);
-		val->chg_voltage = tmp_val;
+		val->chg_voltage = tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_STATUS:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_FLAGS, &tmp_val);

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -26,8 +26,6 @@ extern "C" {
 
 #include <zephyr/device.h>
 
-/* Keep these alphabetized wrt property name */
-
 enum fuel_gauge_prop_type {
 	/** Runtime Dynamic Battery Parameters */
 	/**

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -72,9 +72,9 @@ enum fuel_gauge_prop_type {
 	FUEL_GAUGE_VOLTAGE,
 	/** Battery Mode (flags) */
 	FUEL_GAUGE_SBS_MODE,
-	/** Battery desired Max Charging Current (mA) */
+	/** Battery desired Max Charging Current (uA) */
 	FUEL_GAUGE_CHARGE_CURRENT,
-	/** Battery desired Max Charging Voltage (mV) */
+	/** Battery desired Max Charging Voltage (uV) */
 	FUEL_GAUGE_CHARGE_VOLTAGE,
 	/** Alarm, Status and Error codes (flags) */
 	FUEL_GAUGE_STATUS,
@@ -153,9 +153,9 @@ union fuel_gauge_prop_val {
 	/** FUEL_GAUGE_SBS_MODE */
 	uint16_t sbs_mode;
 	/** FUEL_GAUGE_CHARGE_CURRENT */
-	uint16_t chg_current;
+	uint32_t chg_current;
 	/** FUEL_GAUGE_CHARGE_VOLTAGE */
-	uint16_t chg_voltage;
+	uint32_t chg_voltage;
 	/** FUEL_GAUGE_STATUS */
 	uint16_t fg_status;
 	/** FUEL_GAUGE_DESIGN_CAPACITY */

--- a/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
+++ b/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
@@ -139,8 +139,8 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 	zassert_equal(vals[10].voltage, 1000);
 	zassert_equal(vals[11].sbs_at_rate, -2);
 	zassert_equal(vals[12].sbs_at_rate_time_to_empty, 1);
-	zassert_equal(vals[13].chg_voltage, 1);
-	zassert_equal(vals[14].chg_current, 1);
+	zassert_equal(vals[13].chg_voltage, 1000);
+	zassert_equal(vals[14].chg_current, 1000);
 	zassert_equal(vals[15].fg_status, 1);
 	zassert_equal(vals[16].design_cap, 1);
 #else


### PR DESCRIPTION
The desired current/voltage properties make use of milliamps/volts while the present current/voltage properties make use of microamps/volts.

Fix the desired current/voltage properties to be consistent with the present current/voltage properties where they're most likely to be used with.

Added to https://github.com/zephyrproject-rtos/zephyr/issues/61818 API improvements issue. Units should be documents directly in the properties. Relying on documentation isn't great.