### PR TITLE
boards: esp32: Fix documentation spelling

### DIFF
--- a/boards/riscv/esp32c3_devkitm/doc/index.rst
+++ b/boards/riscv/esp32c3_devkitm/doc/index.rst
@@ -122,7 +122,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/riscv/esp32c3_luatos_core/doc/index.rst
+++ b/boards/riscv/esp32c3_luatos_core/doc/index.rst
@@ -140,7 +140,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/riscv/icev_wireless/doc/index.rst
+++ b/boards/riscv/icev_wireless/doc/index.rst
@@ -128,7 +128,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/riscv/stamp_c3/doc/index.rst
+++ b/boards/riscv/stamp_c3/doc/index.rst
@@ -86,7 +86,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/riscv/xiao_esp32c3/doc/index.rst
+++ b/boards/riscv/xiao_esp32c3/doc/index.rst
@@ -110,7 +110,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/esp32_devkitc_wrover/doc/index.rst
+++ b/boards/xtensa/esp32_devkitc_wrover/doc/index.rst
@@ -141,7 +141,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/esp32_ethernet_kit/doc/index.rst
+++ b/boards/xtensa/esp32_ethernet_kit/doc/index.rst
@@ -468,7 +468,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/esp32s2_franzininho/doc/index.rst
+++ b/boards/xtensa/esp32s2_franzininho/doc/index.rst
@@ -84,7 +84,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/esp32s2_saola/doc/index.rst
+++ b/boards/xtensa/esp32s2_saola/doc/index.rst
@@ -118,7 +118,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/esp32s3_devkitm/doc/index.rst
+++ b/boards/xtensa/esp32s3_devkitm/doc/index.rst
@@ -167,7 +167,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/esp32s3_luatos_core/doc/index.rst
+++ b/boards/xtensa/esp32s3_luatos_core/doc/index.rst
@@ -166,7 +166,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/esp_wrover_kit/doc/index.rst
+++ b/boards/xtensa/esp_wrover_kit/doc/index.rst
@@ -533,7 +533,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/heltec_wifi_lora32_v2/doc/index.rst
+++ b/boards/xtensa/heltec_wifi_lora32_v2/doc/index.rst
@@ -72,7 +72,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/m5stickc_plus/doc/index.rst
+++ b/boards/xtensa/m5stickc_plus/doc/index.rst
@@ -117,7 +117,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/odroid_go/doc/index.rst
+++ b/boards/xtensa/odroid_go/doc/index.rst
@@ -128,7 +128,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/olimex_esp32_evb/doc/index.rst
+++ b/boards/xtensa/olimex_esp32_evb/doc/index.rst
@@ -138,7 +138,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/xiao_esp32s3/doc/index.rst
+++ b/boards/xtensa/xiao_esp32s3/doc/index.rst
@@ -126,7 +126,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 

--- a/boards/xtensa/yd_esp32/doc/index.rst
+++ b/boards/xtensa/yd_esp32/doc/index.rst
@@ -147,7 +147,7 @@ Sysbuild
 ========
 
 The sysbuild makes possible to build and flash all necessary images needed to
-bootstrap the board with the EPS32 SoC.
+bootstrap the board with the ESP32 SoC.
 
 To build the sample application using sysbuild use the command:
 


### PR DESCRIPTION
Dear Maintainers,

Unless I am mistaken, this fixes a simple documentation spelling typo on SoC name.

Regards,
Gaël