### PR TITLE
bluetooth: common: Kconfig: Add missing dependency for BT_MONITOR

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -282,6 +282,7 @@ endif # BT_ASSERT
 
 config BT_MONITOR
 	bool
+	select LOG_OUTPUT
 
 choice BT_DEBUG_TYPE
 	prompt "Bluetooth debug type"


### PR DESCRIPTION
This module calls `log_output_*` functions so it should enable the `LOG_OUTPUT` Kconfig option explicitly.

Fixes #63533.