### PR TITLE
boards: arm: nrf52840dongle_nrf52840: Enable console by default

### DIFF
--- a/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/Kconfig.defconfig
@@ -33,6 +33,9 @@ config USB_DEVICE_STACK
 config USB_CDC_ACM
 	default SERIAL
 
+config CONSOLE
+	default y
+
 config UART_CONSOLE
 	default CONSOLE
 


### PR DESCRIPTION
Enables UART output for samples that do not enable `CONFIG_CONSOLE` in their config file.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/63603