### PR TITLE
Bluetooth: BAP: Add PSN debug log support

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -484,6 +484,10 @@ struct bt_bap_stream {
 	/** Stream user data */
 	void *user_data;
 
+#if defined(CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM)
+	uint16_t _prev_seq_num;
+#endif /* CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM */
+
 	/* Internally used list node */
 	sys_snode_t _node;
 };

--- a/subsys/bluetooth/audio/Kconfig.bap
+++ b/subsys/bluetooth/audio/Kconfig.bap
@@ -277,5 +277,14 @@ config BT_BAP_STREAM
 	default y if BT_ASCS || BT_BAP_UNICAST_CLIENT || \
 			BT_BAP_BROADCAST_SOURCE || BT_BAP_BROADCAST_SINK
 
+config BT_BAP_DEBUG_STREAM_SEQ_NUM
+	bool "Bluetooth Audio Stream sequence number debug"
+	depends on BT_BAP_STREAM_LOG_LEVEL >= BT_BAP_STREAM_LOG_LEVEL_WRN
+	default y
+	help
+	  Use this option to enable Bluetooth Audio Stream sequence number debugging logs for
+	  the Bluetooth Audio functionality. This will provide a warning if the application
+	  provides unexpected sequence numbers.
+
 rsource "Kconfig.pacs"
 rsource "Kconfig.ascs"

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -273,6 +273,16 @@ int bt_bap_stream_send(struct bt_bap_stream *stream, struct net_buf *buf,
 		return -EBADMSG;
 	}
 
+#if defined(CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM)
+	if (stream->_prev_seq_num != 0U && seq_num != 0U &&
+	    (stream->_prev_seq_num + 1U) != seq_num) {
+		LOG_WRN("Unexpected seq_num diff between %u and %u for %p", stream->_prev_seq_num,
+			seq_num, stream);
+	}
+
+	stream->_prev_seq_num = seq_num;
+#endif /* CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM */
+
 	/* TODO: Add checks for broadcast sink */
 
 	return bt_iso_chan_send(bt_bap_stream_iso_chan_get(stream),


### PR DESCRIPTION
Add a Kconfig that enables support for logging and debugging invalid sequence numbers.