### PR TITLE
drivers: bluetooth: rpmsg: Send reset only when the Host is included

### DIFF
--- a/drivers/bluetooth/hci/rpmsg.c
+++ b/drivers/bluetooth/hci/rpmsg.c
@@ -339,10 +339,12 @@ static int bt_rpmsg_close(void)
 {
 	int err;
 
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_RESET, NULL, NULL);
-	if (err) {
-		LOG_ERR("Sending reset command failed with: %d", err);
-		return err;
+	if (IS_ENABLED(CONFIG_BT_HCI_HOST)) {
+		err = bt_hci_cmd_send_sync(BT_HCI_OP_RESET, NULL, NULL);
+		if (err) {
+			LOG_ERR("Sending reset command failed with: %d", err);
+			return err;
+		}
 	}
 
 	err = ipc_service_deregister_endpoint(&hci_ept);


### PR DESCRIPTION
The rpmsg_close() call uses the HCI reset command to reset the controller. But when building as controller-only we do not bring in the infrastructure to send HCI commands (nor should we) and rpmsg_close() will not be called anyway.

Fixes #63534.