### PR TITLE
drivers: usb_dc_nrfx: Isochronous endpoint cannot be bulk

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1397,6 +1397,12 @@ int usb_dc_ep_check_cap(const struct usb_dc_ep_cfg_data *const ep_cfg)
 		return -1;
 	}
 
+	if ((ep_cfg->ep_type != USB_DC_EP_ISOCHRONOUS) &&
+	    (NRF_USBD_EPISO_CHECK(ep_cfg->ep_addr))) {
+		LOG_WRN("iso endpoint can only be iso");
+		return -1;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Prevent use of isochronous endpoints as bulk and/or interrupt endpoint. The issue was observed when trying to use 4 CDC ACM instances where the 4th instance would claim the isochronous IN endpoint 0x88 to be bulk. Because the isochronous endpoints cannot respond with handshake packet the iso endpoints cannot be used as bulk or interrupt substitue.

Properly fail endpoint check and therefore make 4 CDC ACM instances not enumerate at all because the hardware has endpoints that only allows up to 3 CDC ACM instances.